### PR TITLE
Don't display default generic parameters in diagnostics that compare types

### DIFF
--- a/src/librustc/infer/error_reporting/mod.rs
+++ b/src/librustc/infer/error_reporting/mod.rs
@@ -60,13 +60,13 @@ use super::{InferCtxt, RegionVariableOrigin, SubregionOrigin, TypeTrace, ValuePa
 use super::region_constraints::GenericKind;
 use super::lexical_region_resolve::RegionResolutionError;
 
-use std::fmt;
+use std::{cmp, fmt};
 use hir;
 use hir::map as hir_map;
 use hir::def_id::DefId;
 use middle::region;
 use traits::{ObligationCause, ObligationCauseCode};
-use ty::{self, Region, Ty, TyCtxt, TypeFoldable, TypeVariants};
+use ty::{self, subst::Subst, Region, Ty, TyCtxt, TypeFoldable, TypeVariants};
 use ty::error::TypeError;
 use syntax::ast::DUMMY_NODE_ID;
 use syntax_pos::{Pos, Span};
@@ -672,6 +672,43 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
         }
     }
 
+    /// For generic types with parameters with defaults, remove the parameters corresponding to
+    /// the defaults. This repeats a lot of the logic found in `PrintContext::parameterized`.
+    fn strip_generic_default_params(
+        &self,
+        def_id: DefId,
+        substs: &ty::subst::Substs<'tcx>
+    ) -> &'tcx ty::subst::Substs<'tcx> {
+        let generics = self.tcx.generics_of(def_id);
+        let mut num_supplied_defaults = 0;
+        let mut type_params = generics.params.iter().rev().filter_map(|param| match param.kind {
+            ty::GenericParamDefKind::Lifetime => None,
+            ty::GenericParamDefKind::Type { has_default, .. } => {
+                Some((param.def_id, has_default))
+            }
+        }).peekable();
+        let has_default = {
+            let has_default = type_params.peek().map(|(_, has_default)| has_default);
+            *has_default.unwrap_or(&false)
+        };
+        if has_default {
+            let types = substs.types().rev();
+            for ((def_id, has_default), actual) in type_params.zip(types) {
+                if !has_default {
+                    break;
+                }
+                if self.tcx.type_of(def_id).subst(self.tcx, substs) != actual {
+                    break;
+                }
+                num_supplied_defaults += 1;
+            }
+        }
+        let len = generics.params.len();
+        let mut generics = generics.clone();
+        generics.params.truncate(len - num_supplied_defaults);
+        substs.truncate_to(self.tcx, &generics)
+    }
+
     /// Compare two given types, eliding parts that are the same between them and highlighting
     /// relevant differences, and return two representation of those types for highlighted printing.
     fn cmp(&self, t1: Ty<'tcx>, t2: Ty<'tcx>) -> (DiagnosticStyledString, DiagnosticStyledString) {
@@ -713,6 +750,8 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
 
         match (&t1.sty, &t2.sty) {
             (&ty::TyAdt(def1, sub1), &ty::TyAdt(def2, sub2)) => {
+                let sub_no_defaults_1 = self.strip_generic_default_params(def1.did, sub1);
+                let sub_no_defaults_2 = self.strip_generic_default_params(def2.did, sub2);
                 let mut values = (DiagnosticStyledString::new(), DiagnosticStyledString::new());
                 let path1 = self.tcx.item_path_str(def1.did.clone());
                 let path2 = self.tcx.item_path_str(def2.did.clone());
@@ -728,8 +767,19 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                     values.0.push_normal(path1);
                     values.1.push_normal(path2);
 
+                    // Avoid printing out default generic parameters that are common to both
+                    // types.
+                    let len1 = sub_no_defaults_1.len();
+                    let len2 = sub_no_defaults_2.len();
+                    let common_len = cmp::min(len1, len2);
+                    let remainder1: Vec<_> = sub1.types().skip(common_len).collect();
+                    let remainder2: Vec<_> = sub2.types().skip(common_len).collect();
+                    let common_default_params =
+                        remainder1.iter().rev().zip(remainder2.iter().rev())
+                                               .filter(|(a, b)| a == b).count();
+                    let len = sub1.len() - common_default_params;
+
                     // Only draw `<...>` if there're lifetime/type arguments.
-                    let len = sub1.len();
                     if len > 0 {
                         values.0.push_normal("<");
                         values.1.push_normal("<");
@@ -774,7 +824,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                     //         ^ elided type as this type argument was the same in both sides
                     let type_arguments = sub1.types().zip(sub2.types());
                     let regions_len = sub1.regions().collect::<Vec<_>>().len();
-                    for (i, (ta1, ta2)) in type_arguments.enumerate() {
+                    for (i, (ta1, ta2)) in type_arguments.take(len).enumerate() {
                         let i = i + regions_len;
                         if ta1 == ta2 {
                             values.0.push_normal("_");
@@ -804,7 +854,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                         &mut values.0,
                         &mut values.1,
                         path1.clone(),
-                        sub1,
+                        sub_no_defaults_1,
                         path2.clone(),
                         &t2,
                     ).is_some()
@@ -816,8 +866,14 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                     //     Bar<Qux>
                     //     Foo<Bar<Qux>>
                     //         ------- this type argument is exactly the same as the other type
-                    if self.cmp_type_arg(&mut values.1, &mut values.0, path2, sub2, path1, &t1)
-                        .is_some()
+                    if self.cmp_type_arg(
+                        &mut values.1,
+                        &mut values.0,
+                        path2,
+                        sub_no_defaults_2,
+                        path1,
+                        &t1,
+                    ).is_some()
                     {
                         return values;
                     }

--- a/src/test/ui/type-mismatch.rs
+++ b/src/test/ui/type-mismatch.rs
@@ -1,0 +1,86 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait Qux {}
+struct A;
+struct B;
+impl Qux for A {}
+impl Qux for B {}
+
+struct Foo<T, U: Qux = A, V: Qux = B>(T, U, V);
+
+struct foo;
+struct bar;
+
+fn want<T>(t: T) {}
+
+fn have_usize(f: usize) {
+    want::<foo>(f); //~ ERROR mismatched types
+    want::<bar>(f); //~ ERROR mismatched types
+    want::<Foo<usize>>(f); //~ ERROR mismatched types
+    want::<Foo<usize, B>>(f); //~ ERROR mismatched types
+    want::<Foo<foo>>(f); //~ ERROR mismatched types
+    want::<Foo<foo, B>>(f); //~ ERROR mismatched types
+    want::<Foo<bar>>(f); //~ ERROR mismatched types
+    want::<Foo<bar, B>>(f); //~ ERROR mismatched types
+}
+
+fn have_foo(f: foo) {
+    want::<usize>(f); //~ ERROR mismatched types
+    want::<bar>(f); //~ ERROR mismatched types
+    want::<Foo<usize>>(f); //~ ERROR mismatched types
+    want::<Foo<usize, B>>(f); //~ ERROR mismatched types
+    want::<Foo<foo>>(f); //~ ERROR mismatched types
+    want::<Foo<foo, B>>(f); //~ ERROR mismatched types
+    want::<Foo<bar>>(f); //~ ERROR mismatched types
+    want::<Foo<bar, B>>(f); //~ ERROR mismatched types
+}
+
+fn have_foo_foo(f: Foo<foo>) {
+    want::<usize>(f); //~ ERROR mismatched types
+    want::<foo>(f); //~ ERROR mismatched types
+    want::<bar>(f); //~ ERROR mismatched types
+    want::<Foo<usize>>(f); //~ ERROR mismatched types
+    want::<Foo<usize, B>>(f); //~ ERROR mismatched types
+    want::<Foo<foo, B>>(f); //~ ERROR mismatched types
+    want::<Foo<bar>>(f); //~ ERROR mismatched types
+    want::<Foo<bar, B>>(f); //~ ERROR mismatched types
+    want::<&Foo<foo>>(f); //~ ERROR mismatched types
+    want::<&Foo<foo, B>>(f); //~ ERROR mismatched types
+}
+
+fn have_foo_foo_b(f: Foo<foo, B>) {
+    want::<usize>(f); //~ ERROR mismatched types
+    want::<foo>(f); //~ ERROR mismatched types
+    want::<bar>(f); //~ ERROR mismatched types
+    want::<Foo<usize>>(f); //~ ERROR mismatched types
+    want::<Foo<usize, B>>(f); //~ ERROR mismatched types
+    want::<Foo<foo>>(f); //~ ERROR mismatched types
+    want::<Foo<bar>>(f); //~ ERROR mismatched types
+    want::<Foo<bar, B>>(f); //~ ERROR mismatched types
+    want::<&Foo<foo>>(f); //~ ERROR mismatched types
+    want::<&Foo<foo, B>>(f); //~ ERROR mismatched types
+}
+
+fn have_foo_foo_b_a(f: Foo<foo, B, A>) {
+    want::<usize>(f); //~ ERROR mismatched types
+    want::<foo>(f); //~ ERROR mismatched types
+    want::<bar>(f); //~ ERROR mismatched types
+    want::<Foo<usize>>(f); //~ ERROR mismatched types
+    want::<Foo<usize, B>>(f); //~ ERROR mismatched types
+    want::<Foo<foo>>(f); //~ ERROR mismatched types
+    want::<Foo<foo, B>>(f); //~ ERROR mismatched types
+    want::<Foo<bar>>(f); //~ ERROR mismatched types
+    want::<Foo<bar, B>>(f); //~ ERROR mismatched types
+    want::<&Foo<foo>>(f); //~ ERROR mismatched types
+    want::<&Foo<foo, B>>(f); //~ ERROR mismatched types
+}
+
+fn main() {}

--- a/src/test/ui/type-mismatch.stderr
+++ b/src/test/ui/type-mismatch.stderr
@@ -1,0 +1,432 @@
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:25:17
+   |
+LL |     want::<foo>(f); //~ ERROR mismatched types
+   |                 ^ expected struct `foo`, found usize
+   |
+   = note: expected type `foo`
+              found type `usize`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:26:17
+   |
+LL |     want::<bar>(f); //~ ERROR mismatched types
+   |                 ^ expected struct `bar`, found usize
+   |
+   = note: expected type `bar`
+              found type `usize`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:27:24
+   |
+LL |     want::<Foo<usize>>(f); //~ ERROR mismatched types
+   |                        ^ expected struct `Foo`, found usize
+   |
+   = note: expected type `Foo<usize>`
+              found type `usize`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:28:27
+   |
+LL |     want::<Foo<usize, B>>(f); //~ ERROR mismatched types
+   |                           ^ expected struct `Foo`, found usize
+   |
+   = note: expected type `Foo<usize, B>`
+              found type `usize`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:29:22
+   |
+LL |     want::<Foo<foo>>(f); //~ ERROR mismatched types
+   |                      ^ expected struct `Foo`, found usize
+   |
+   = note: expected type `Foo<foo>`
+              found type `usize`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:30:25
+   |
+LL |     want::<Foo<foo, B>>(f); //~ ERROR mismatched types
+   |                         ^ expected struct `Foo`, found usize
+   |
+   = note: expected type `Foo<foo, B>`
+              found type `usize`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:31:22
+   |
+LL |     want::<Foo<bar>>(f); //~ ERROR mismatched types
+   |                      ^ expected struct `Foo`, found usize
+   |
+   = note: expected type `Foo<bar>`
+              found type `usize`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:32:25
+   |
+LL |     want::<Foo<bar, B>>(f); //~ ERROR mismatched types
+   |                         ^ expected struct `Foo`, found usize
+   |
+   = note: expected type `Foo<bar, B>`
+              found type `usize`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:36:19
+   |
+LL |     want::<usize>(f); //~ ERROR mismatched types
+   |                   ^ expected usize, found struct `foo`
+   |
+   = note: expected type `usize`
+              found type `foo`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:37:17
+   |
+LL |     want::<bar>(f); //~ ERROR mismatched types
+   |                 ^ expected struct `bar`, found struct `foo`
+   |
+   = note: expected type `bar`
+              found type `foo`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:38:24
+   |
+LL |     want::<Foo<usize>>(f); //~ ERROR mismatched types
+   |                        ^ expected struct `Foo`, found struct `foo`
+   |
+   = note: expected type `Foo<usize>`
+              found type `foo`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:39:27
+   |
+LL |     want::<Foo<usize, B>>(f); //~ ERROR mismatched types
+   |                           ^ expected struct `Foo`, found struct `foo`
+   |
+   = note: expected type `Foo<usize, B>`
+              found type `foo`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:40:22
+   |
+LL |     want::<Foo<foo>>(f); //~ ERROR mismatched types
+   |                      ^ expected struct `Foo`, found struct `foo`
+   |
+   = note: expected type `Foo<foo, A, B>`
+              found type `foo`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:41:25
+   |
+LL |     want::<Foo<foo, B>>(f); //~ ERROR mismatched types
+   |                         ^ expected struct `Foo`, found struct `foo`
+   |
+   = note: expected type `Foo<foo, B, B>`
+              found type `foo`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:42:22
+   |
+LL |     want::<Foo<bar>>(f); //~ ERROR mismatched types
+   |                      ^ expected struct `Foo`, found struct `foo`
+   |
+   = note: expected type `Foo<bar>`
+              found type `foo`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:43:25
+   |
+LL |     want::<Foo<bar, B>>(f); //~ ERROR mismatched types
+   |                         ^ expected struct `Foo`, found struct `foo`
+   |
+   = note: expected type `Foo<bar, B>`
+              found type `foo`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:47:19
+   |
+LL |     want::<usize>(f); //~ ERROR mismatched types
+   |                   ^ expected usize, found struct `Foo`
+   |
+   = note: expected type `usize`
+              found type `Foo<foo>`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:48:17
+   |
+LL |     want::<foo>(f); //~ ERROR mismatched types
+   |                 ^ expected struct `foo`, found struct `Foo`
+   |
+   = note: expected type `foo`
+              found type `Foo<foo, A, B>`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:49:17
+   |
+LL |     want::<bar>(f); //~ ERROR mismatched types
+   |                 ^ expected struct `bar`, found struct `Foo`
+   |
+   = note: expected type `bar`
+              found type `Foo<foo>`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:50:24
+   |
+LL |     want::<Foo<usize>>(f); //~ ERROR mismatched types
+   |                        ^ expected usize, found struct `foo`
+   |
+   = note: expected type `Foo<usize, _, _>`
+              found type `Foo<foo, _, _>`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:51:27
+   |
+LL |     want::<Foo<usize, B>>(f); //~ ERROR mismatched types
+   |                           ^ expected usize, found struct `foo`
+   |
+   = note: expected type `Foo<usize, B, _>`
+              found type `Foo<foo, A, _>`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:52:25
+   |
+LL |     want::<Foo<foo, B>>(f); //~ ERROR mismatched types
+   |                         ^ expected struct `B`, found struct `A`
+   |
+   = note: expected type `Foo<_, B, _>`
+              found type `Foo<_, A, _>`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:53:22
+   |
+LL |     want::<Foo<bar>>(f); //~ ERROR mismatched types
+   |                      ^ expected struct `bar`, found struct `foo`
+   |
+   = note: expected type `Foo<bar, _, _>`
+              found type `Foo<foo, _, _>`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:54:25
+   |
+LL |     want::<Foo<bar, B>>(f); //~ ERROR mismatched types
+   |                         ^ expected struct `bar`, found struct `foo`
+   |
+   = note: expected type `Foo<bar, B, _>`
+              found type `Foo<foo, A, _>`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:55:23
+   |
+LL |     want::<&Foo<foo>>(f); //~ ERROR mismatched types
+   |                       ^
+   |                       |
+   |                       expected &Foo<foo>, found struct `Foo`
+   |                       help: consider borrowing here: `&f`
+   |
+   = note: expected type `&Foo<foo>`
+              found type `Foo<foo>`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:56:26
+   |
+LL |     want::<&Foo<foo, B>>(f); //~ ERROR mismatched types
+   |                          ^ expected reference, found struct `Foo`
+   |
+   = note: expected type `&Foo<foo, B>`
+              found type `Foo<foo>`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:60:19
+   |
+LL |     want::<usize>(f); //~ ERROR mismatched types
+   |                   ^ expected usize, found struct `Foo`
+   |
+   = note: expected type `usize`
+              found type `Foo<foo, B>`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:61:17
+   |
+LL |     want::<foo>(f); //~ ERROR mismatched types
+   |                 ^ expected struct `foo`, found struct `Foo`
+   |
+   = note: expected type `foo`
+              found type `Foo<foo, B, B>`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:62:17
+   |
+LL |     want::<bar>(f); //~ ERROR mismatched types
+   |                 ^ expected struct `bar`, found struct `Foo`
+   |
+   = note: expected type `bar`
+              found type `Foo<foo, B>`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:63:24
+   |
+LL |     want::<Foo<usize>>(f); //~ ERROR mismatched types
+   |                        ^ expected usize, found struct `foo`
+   |
+   = note: expected type `Foo<usize, A, _>`
+              found type `Foo<foo, B, _>`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:64:27
+   |
+LL |     want::<Foo<usize, B>>(f); //~ ERROR mismatched types
+   |                           ^ expected usize, found struct `foo`
+   |
+   = note: expected type `Foo<usize, _, _>`
+              found type `Foo<foo, _, _>`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:65:22
+   |
+LL |     want::<Foo<foo>>(f); //~ ERROR mismatched types
+   |                      ^ expected struct `A`, found struct `B`
+   |
+   = note: expected type `Foo<_, A, _>`
+              found type `Foo<_, B, _>`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:66:22
+   |
+LL |     want::<Foo<bar>>(f); //~ ERROR mismatched types
+   |                      ^ expected struct `bar`, found struct `foo`
+   |
+   = note: expected type `Foo<bar, A, _>`
+              found type `Foo<foo, B, _>`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:67:25
+   |
+LL |     want::<Foo<bar, B>>(f); //~ ERROR mismatched types
+   |                         ^ expected struct `bar`, found struct `foo`
+   |
+   = note: expected type `Foo<bar, _, _>`
+              found type `Foo<foo, _, _>`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:68:23
+   |
+LL |     want::<&Foo<foo>>(f); //~ ERROR mismatched types
+   |                       ^ expected &Foo<foo>, found struct `Foo`
+   |
+   = note: expected type `&Foo<foo>`
+              found type `Foo<foo, B>`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:69:26
+   |
+LL |     want::<&Foo<foo, B>>(f); //~ ERROR mismatched types
+   |                          ^
+   |                          |
+   |                          expected reference, found struct `Foo`
+   |                          help: consider borrowing here: `&f`
+   |
+   = note: expected type `&Foo<foo, B>`
+              found type `Foo<foo, B>`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:73:19
+   |
+LL |     want::<usize>(f); //~ ERROR mismatched types
+   |                   ^ expected usize, found struct `Foo`
+   |
+   = note: expected type `usize`
+              found type `Foo<foo, B, A>`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:74:17
+   |
+LL |     want::<foo>(f); //~ ERROR mismatched types
+   |                 ^ expected struct `foo`, found struct `Foo`
+   |
+   = note: expected type `foo`
+              found type `Foo<foo, B, A>`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:75:17
+   |
+LL |     want::<bar>(f); //~ ERROR mismatched types
+   |                 ^ expected struct `bar`, found struct `Foo`
+   |
+   = note: expected type `bar`
+              found type `Foo<foo, B, A>`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:76:24
+   |
+LL |     want::<Foo<usize>>(f); //~ ERROR mismatched types
+   |                        ^ expected usize, found struct `foo`
+   |
+   = note: expected type `Foo<usize, A, B>`
+              found type `Foo<foo, B, A>`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:77:27
+   |
+LL |     want::<Foo<usize, B>>(f); //~ ERROR mismatched types
+   |                           ^ expected usize, found struct `foo`
+   |
+   = note: expected type `Foo<usize, _, B>`
+              found type `Foo<foo, _, A>`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:78:22
+   |
+LL |     want::<Foo<foo>>(f); //~ ERROR mismatched types
+   |                      ^ expected struct `A`, found struct `B`
+   |
+   = note: expected type `Foo<_, A, B>`
+              found type `Foo<_, B, A>`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:79:25
+   |
+LL |     want::<Foo<foo, B>>(f); //~ ERROR mismatched types
+   |                         ^ expected struct `B`, found struct `A`
+   |
+   = note: expected type `Foo<_, _, B>`
+              found type `Foo<_, _, A>`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:80:22
+   |
+LL |     want::<Foo<bar>>(f); //~ ERROR mismatched types
+   |                      ^ expected struct `bar`, found struct `foo`
+   |
+   = note: expected type `Foo<bar, A, B>`
+              found type `Foo<foo, B, A>`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:81:25
+   |
+LL |     want::<Foo<bar, B>>(f); //~ ERROR mismatched types
+   |                         ^ expected struct `bar`, found struct `foo`
+   |
+   = note: expected type `Foo<bar, _, B>`
+              found type `Foo<foo, _, A>`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:82:23
+   |
+LL |     want::<&Foo<foo>>(f); //~ ERROR mismatched types
+   |                       ^ expected &Foo<foo>, found struct `Foo`
+   |
+   = note: expected type `&Foo<foo>`
+              found type `Foo<foo, B, A>`
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch.rs:83:26
+   |
+LL |     want::<&Foo<foo, B>>(f); //~ ERROR mismatched types
+   |                          ^ expected reference, found struct `Foo`
+   |
+   = note: expected type `&Foo<foo, B>`
+              found type `Foo<foo, B, A>`
+
+error: aborting due to 47 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/type-mismatch.stderr
+++ b/src/test/ui/type-mismatch.stderr
@@ -112,7 +112,7 @@ error[E0308]: mismatched types
 LL |     want::<Foo<foo>>(f); //~ ERROR mismatched types
    |                      ^ expected struct `Foo`, found struct `foo`
    |
-   = note: expected type `Foo<foo, A, B>`
+   = note: expected type `Foo<foo>`
               found type `foo`
 
 error[E0308]: mismatched types
@@ -121,7 +121,7 @@ error[E0308]: mismatched types
 LL |     want::<Foo<foo, B>>(f); //~ ERROR mismatched types
    |                         ^ expected struct `Foo`, found struct `foo`
    |
-   = note: expected type `Foo<foo, B, B>`
+   = note: expected type `Foo<foo, B>`
               found type `foo`
 
 error[E0308]: mismatched types
@@ -158,7 +158,7 @@ LL |     want::<foo>(f); //~ ERROR mismatched types
    |                 ^ expected struct `foo`, found struct `Foo`
    |
    = note: expected type `foo`
-              found type `Foo<foo, A, B>`
+              found type `Foo<foo>`
 
 error[E0308]: mismatched types
   --> $DIR/type-mismatch.rs:49:17
@@ -175,8 +175,8 @@ error[E0308]: mismatched types
 LL |     want::<Foo<usize>>(f); //~ ERROR mismatched types
    |                        ^ expected usize, found struct `foo`
    |
-   = note: expected type `Foo<usize, _, _>`
-              found type `Foo<foo, _, _>`
+   = note: expected type `Foo<usize>`
+              found type `Foo<foo>`
 
 error[E0308]: mismatched types
   --> $DIR/type-mismatch.rs:51:27
@@ -184,8 +184,8 @@ error[E0308]: mismatched types
 LL |     want::<Foo<usize, B>>(f); //~ ERROR mismatched types
    |                           ^ expected usize, found struct `foo`
    |
-   = note: expected type `Foo<usize, B, _>`
-              found type `Foo<foo, A, _>`
+   = note: expected type `Foo<usize, B>`
+              found type `Foo<foo, A>`
 
 error[E0308]: mismatched types
   --> $DIR/type-mismatch.rs:52:25
@@ -193,8 +193,8 @@ error[E0308]: mismatched types
 LL |     want::<Foo<foo, B>>(f); //~ ERROR mismatched types
    |                         ^ expected struct `B`, found struct `A`
    |
-   = note: expected type `Foo<_, B, _>`
-              found type `Foo<_, A, _>`
+   = note: expected type `Foo<_, B>`
+              found type `Foo<_, A>`
 
 error[E0308]: mismatched types
   --> $DIR/type-mismatch.rs:53:22
@@ -202,8 +202,8 @@ error[E0308]: mismatched types
 LL |     want::<Foo<bar>>(f); //~ ERROR mismatched types
    |                      ^ expected struct `bar`, found struct `foo`
    |
-   = note: expected type `Foo<bar, _, _>`
-              found type `Foo<foo, _, _>`
+   = note: expected type `Foo<bar>`
+              found type `Foo<foo>`
 
 error[E0308]: mismatched types
   --> $DIR/type-mismatch.rs:54:25
@@ -211,8 +211,8 @@ error[E0308]: mismatched types
 LL |     want::<Foo<bar, B>>(f); //~ ERROR mismatched types
    |                         ^ expected struct `bar`, found struct `foo`
    |
-   = note: expected type `Foo<bar, B, _>`
-              found type `Foo<foo, A, _>`
+   = note: expected type `Foo<bar, B>`
+              found type `Foo<foo, A>`
 
 error[E0308]: mismatched types
   --> $DIR/type-mismatch.rs:55:23
@@ -251,7 +251,7 @@ LL |     want::<foo>(f); //~ ERROR mismatched types
    |                 ^ expected struct `foo`, found struct `Foo`
    |
    = note: expected type `foo`
-              found type `Foo<foo, B, B>`
+              found type `Foo<foo, B>`
 
 error[E0308]: mismatched types
   --> $DIR/type-mismatch.rs:62:17
@@ -268,8 +268,8 @@ error[E0308]: mismatched types
 LL |     want::<Foo<usize>>(f); //~ ERROR mismatched types
    |                        ^ expected usize, found struct `foo`
    |
-   = note: expected type `Foo<usize, A, _>`
-              found type `Foo<foo, B, _>`
+   = note: expected type `Foo<usize, A>`
+              found type `Foo<foo, B>`
 
 error[E0308]: mismatched types
   --> $DIR/type-mismatch.rs:64:27
@@ -277,8 +277,8 @@ error[E0308]: mismatched types
 LL |     want::<Foo<usize, B>>(f); //~ ERROR mismatched types
    |                           ^ expected usize, found struct `foo`
    |
-   = note: expected type `Foo<usize, _, _>`
-              found type `Foo<foo, _, _>`
+   = note: expected type `Foo<usize, _>`
+              found type `Foo<foo, _>`
 
 error[E0308]: mismatched types
   --> $DIR/type-mismatch.rs:65:22
@@ -286,8 +286,8 @@ error[E0308]: mismatched types
 LL |     want::<Foo<foo>>(f); //~ ERROR mismatched types
    |                      ^ expected struct `A`, found struct `B`
    |
-   = note: expected type `Foo<_, A, _>`
-              found type `Foo<_, B, _>`
+   = note: expected type `Foo<_, A>`
+              found type `Foo<_, B>`
 
 error[E0308]: mismatched types
   --> $DIR/type-mismatch.rs:66:22
@@ -295,8 +295,8 @@ error[E0308]: mismatched types
 LL |     want::<Foo<bar>>(f); //~ ERROR mismatched types
    |                      ^ expected struct `bar`, found struct `foo`
    |
-   = note: expected type `Foo<bar, A, _>`
-              found type `Foo<foo, B, _>`
+   = note: expected type `Foo<bar, A>`
+              found type `Foo<foo, B>`
 
 error[E0308]: mismatched types
   --> $DIR/type-mismatch.rs:67:25
@@ -304,8 +304,8 @@ error[E0308]: mismatched types
 LL |     want::<Foo<bar, B>>(f); //~ ERROR mismatched types
    |                         ^ expected struct `bar`, found struct `foo`
    |
-   = note: expected type `Foo<bar, _, _>`
-              found type `Foo<foo, _, _>`
+   = note: expected type `Foo<bar, _>`
+              found type `Foo<foo, _>`
 
 error[E0308]: mismatched types
   --> $DIR/type-mismatch.rs:68:23


### PR DESCRIPTION
In errors like:
```
   expected type: `RawVec<foo, Global>`
      found type: `foo`
```

`RawVec` being defined as `RawVec<T, A: Alloc = Global>`, the error is better written as
```
   expected type: `RawVec<foo>`
      found type: `foo`
```

In fact, that is already what happens when `foo` is not an ADT, because in that case, the diagnostic handler doesn't try to highlight something, and just uses the `Display` trait instead of its own logic.

e.g.
```
   expected type: `RawVec<usize>`
      found type: `usize`
```