### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -92,7 +92,7 @@ impl<T: ?Sized> !Send for *mut T { }
 #[stable(feature = "rust1", since = "1.0.0")]
 #[lang = "sized"]
 #[rustc_on_unimplemented(
-    message="the size for value values of type `{Self}` cannot be known at compilation time",
+    message="the size for values of type `{Self}` cannot be known at compilation time",
     label="doesn't have a size known at compile-time",
     note="to learn more, visit <https://doc.rust-lang.org/book/second-edition/\
           ch19-04-advanced-types.html#dynamically-sized-types--sized>",

--- a/src/libcore/panic.rs
+++ b/src/libcore/panic.rs
@@ -30,7 +30,11 @@ use fmt;
 /// use std::panic;
 ///
 /// panic::set_hook(Box::new(|panic_info| {
-///     println!("panic occurred: {:?}", panic_info.payload().downcast_ref::<&str>().unwrap());
+///     if let Some(s) = panic_info.payload().downcast_ref::<&str>() {
+///         println!("panic occurred: {:?}", s);
+///     } else {
+///         println!("panic occurred");
+///     }
 /// }));
 ///
 /// panic!("Normal panic");

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -1541,9 +1541,9 @@ impl<T> [T] {
     /// let src = [1, 2, 3, 4];
     /// let mut dst = [0, 0];
     ///
-    /// // Note: the slices must be the same length, so you can slice the source
-    /// // or the destination to be the same size. Here we slice the source, four elements,
-    /// // to two, the same size as the destination slice. It *will* panic if we don't do this.
+    /// // Because the slices have to be the same length,
+    /// // we slice the source slice from four elements
+    /// // to two. It will panic if we don't do this.
     /// dst.clone_from_slice(&src[2..]);
     ///
     /// assert_eq!(src, [1, 2, 3, 4]);
@@ -1610,9 +1610,9 @@ impl<T> [T] {
     /// let src = [1, 2, 3, 4];
     /// let mut dst = [0, 0];
     ///
-    /// // Note: the slices must be the same length, so you can slice the source
-    /// // or the destination to be the same size. Here we slice the source, four elements,
-    /// // to two, the same size as the destination slice. It *will* panic if we don't do this.
+    /// // Because the slices have to be the same length,
+    /// // we slice the source slice from four elements
+    /// // to two. It will panic if we don't do this.
     /// dst.copy_from_slice(&src[2..]);
     ///
     /// assert_eq!(src, [1, 2, 3, 4]);

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -1541,10 +1541,9 @@ impl<T> [T] {
     /// let src = [1, 2, 3, 4];
     /// let mut dst = [0, 0];
     ///
-    /// // Note: the slices must be the same length, so
-    /// // you can slice the source to be the same size.
-    /// // Here we slice the source, four elements, to two, the same size
-    /// // as the destination slice. It *will* panic if we don't do this.
+    /// // Note: the slices must be the same length, so you can slice the 
+    /// // source to be the same size. Here we slice the source, four elements,
+    /// // to two, the same size as the destination slice. It *will* panic if we don't do this.
     /// dst.clone_from_slice(&src[2..]);
     ///
     /// assert_eq!(src, [1, 2, 3, 4]);
@@ -1611,10 +1610,9 @@ impl<T> [T] {
     /// let src = [1, 2, 3, 4];
     /// let mut dst = [0, 0];
     ///
-    /// // Note: the slices must be the same length, so
-    /// // you can slice the source to be the same size.
-    /// // Here we slice the source, four elements, to two, the same size
-    /// // as the destination slice. It *will* panic if we don't do this.
+    /// // Note: the slices must be the same length, so you can slice the 
+    /// // source to be the same size. Here we slice the source, four elements,
+    /// // to two, the same size as the destination slice. It *will* panic if we don't do this.
     /// dst.copy_from_slice(&src[2..]);
     ///
     /// assert_eq!(src, [1, 2, 3, 4]);

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -1541,7 +1541,7 @@ impl<T> [T] {
     /// let src = [1, 2, 3, 4];
     /// let mut dst = [0, 0];
     ///
-    /// // Note: the slices must be the same length, so you can slice the 
+    /// // Note: the slices must be the same length, so you can slice the
     /// // source to be the same size. Here we slice the source, four elements,
     /// // to two, the same size as the destination slice. It *will* panic if we don't do this.
     /// dst.clone_from_slice(&src[2..]);
@@ -1610,7 +1610,7 @@ impl<T> [T] {
     /// let src = [1, 2, 3, 4];
     /// let mut dst = [0, 0];
     ///
-    /// // Note: the slices must be the same length, so you can slice the 
+    /// // Note: the slices must be the same length, so you can slice the
     /// // source to be the same size. Here we slice the source, four elements,
     /// // to two, the same size as the destination slice. It *will* panic if we don't do this.
     /// dst.copy_from_slice(&src[2..]);

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -1541,6 +1541,10 @@ impl<T> [T] {
     /// let src = [1, 2, 3, 4];
     /// let mut dst = [0, 0];
     ///
+    /// // Note: the slices must be the same length, so
+    /// // you can slice the source to be the same size.
+    /// // Here we slice the source, four elements, to two, the same size
+    /// // as the destination slice. It *will* panic if we don't do this.
     /// dst.clone_from_slice(&src[2..]);
     ///
     /// assert_eq!(src, [1, 2, 3, 4]);
@@ -1607,6 +1611,10 @@ impl<T> [T] {
     /// let src = [1, 2, 3, 4];
     /// let mut dst = [0, 0];
     ///
+    /// // Note: the slices must be the same length, so
+    /// // you can slice the source to be the same size.
+    /// // Here we slice the source, four elements, to two, the same size
+    /// // as the destination slice. It *will* panic if we don't do this.
     /// dst.copy_from_slice(&src[2..]);
     ///
     /// assert_eq!(src, [1, 2, 3, 4]);

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -1541,8 +1541,8 @@ impl<T> [T] {
     /// let src = [1, 2, 3, 4];
     /// let mut dst = [0, 0];
     ///
-    /// // Note: the slices must be the same length, so you can slice the
-    /// // source to be the same size. Here we slice the source, four elements,
+    /// // Note: the slices must be the same length, so you can slice the source
+    /// // or the destination to be the same size. Here we slice the source, four elements,
     /// // to two, the same size as the destination slice. It *will* panic if we don't do this.
     /// dst.clone_from_slice(&src[2..]);
     ///
@@ -1610,8 +1610,8 @@ impl<T> [T] {
     /// let src = [1, 2, 3, 4];
     /// let mut dst = [0, 0];
     ///
-    /// // Note: the slices must be the same length, so you can slice the
-    /// // source to be the same size. Here we slice the source, four elements,
+    /// // Note: the slices must be the same length, so you can slice the source
+    /// // or the destination to be the same size. Here we slice the source, four elements,
     /// // to two, the same size as the destination slice. It *will* panic if we don't do this.
     /// dst.copy_from_slice(&src[2..]);
     ///

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -1256,7 +1256,7 @@ let map = HashMap::new();
 ```
 
 Please verify you didn't misspell the type/module's name or that you didn't
-forgot to import it:
+forget to import it:
 
 
 ```

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -193,6 +193,17 @@ pub fn run_core(search_paths: SearchPaths,
     let intra_link_resolution_failure_name = lint::builtin::INTRA_DOC_LINK_RESOLUTION_FAILURE.name;
     let warnings_lint_name = lint::builtin::WARNINGS.name;
     let missing_docs = rustc_lint::builtin::MISSING_DOCS.name;
+
+    // In addition to those specific lints, we also need to whitelist those given through
+    // command line, otherwise they'll get ignored and we don't want that.
+    let mut whitelisted_lints = vec![warnings_lint_name.to_owned(),
+                                     intra_link_resolution_failure_name.to_owned(),
+                                     missing_docs.to_owned()];
+
+    for (lint, _) in &cmd_lints {
+        whitelisted_lints.push(lint.clone());
+    }
+
     let lints = lint::builtin::HardwiredLints.get_lints()
                     .into_iter()
                     .chain(rustc_lint::SoftLints.get_lints().into_iter())
@@ -248,9 +259,7 @@ pub fn run_core(search_paths: SearchPaths,
                                      .filter_map(|lint| {
                                          // We don't want to whitelist *all* lints so let's
                                          // ignore those ones.
-                                         if lint.name == warnings_lint_name ||
-                                            lint.name == intra_link_resolution_failure_name ||
-                                            lint.name == missing_docs {
+                                         if whitelisted_lints.iter().any(|l| &lint.name == l) {
                                              None
                                          } else {
                                              Some(lint)

--- a/src/test/compile-fail/associated-types-unsized.rs
+++ b/src/test/compile-fail/associated-types-unsized.rs
@@ -14,7 +14,7 @@ trait Get {
 }
 
 fn foo<T:Get>(t: T) {
-    let x = t.get(); //~ ERROR the size for value values of type
+    let x = t.get(); //~ ERROR the size for values of type
 }
 
 fn main() {

--- a/src/test/compile-fail/bad-sized.rs
+++ b/src/test/compile-fail/bad-sized.rs
@@ -13,6 +13,6 @@ trait Trait {}
 pub fn main() {
     let x: Vec<Trait + Sized> = Vec::new();
     //~^ ERROR only auto traits can be used as additional traits in a trait object
-    //~| ERROR the size for value values of type
-    //~| ERROR the size for value values of type
+    //~| ERROR the size for values of type
+    //~| ERROR the size for values of type
 }

--- a/src/test/compile-fail/dst-bad-assign-2.rs
+++ b/src/test/compile-fail/dst-bad-assign-2.rs
@@ -43,6 +43,6 @@ pub fn main() {
     let f5: &mut Fat<ToBar> = &mut Fat { f1: 5, f2: "some str", ptr: Bar1 {f :42} };
     let z: Box<ToBar> = Box::new(Bar1 {f: 36});
     f5.ptr = *z;
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 
 }

--- a/src/test/compile-fail/dst-bad-assign-3.rs
+++ b/src/test/compile-fail/dst-bad-assign-3.rs
@@ -45,5 +45,5 @@ pub fn main() {
     //~| expected type `dyn ToBar`
     //~| found type `Bar1`
     //~| expected trait ToBar, found struct `Bar1`
-    //~| ERROR the size for value values of type
+    //~| ERROR the size for values of type
 }

--- a/src/test/compile-fail/dst-bad-assign.rs
+++ b/src/test/compile-fail/dst-bad-assign.rs
@@ -47,5 +47,5 @@ pub fn main() {
     //~| expected type `dyn ToBar`
     //~| found type `Bar1`
     //~| expected trait ToBar, found struct `Bar1`
-    //~| ERROR the size for value values of type
+    //~| ERROR the size for values of type
 }

--- a/src/test/compile-fail/dst-bad-deep-2.rs
+++ b/src/test/compile-fail/dst-bad-deep-2.rs
@@ -19,5 +19,5 @@ pub fn main() {
     let f: ([isize; 3],) = ([5, 6, 7],);
     let g: &([isize],) = &f;
     let h: &(([isize],),) = &(*g,);
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 }

--- a/src/test/compile-fail/dst-bad-deep.rs
+++ b/src/test/compile-fail/dst-bad-deep.rs
@@ -21,5 +21,5 @@ pub fn main() {
     let f: Fat<[isize; 3]> = Fat { ptr: [5, 6, 7] };
     let g: &Fat<[isize]> = &f;
     let h: &Fat<Fat<[isize]>> = &Fat { ptr: *g };
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 }

--- a/src/test/compile-fail/dst-object-from-unsized-type.rs
+++ b/src/test/compile-fail/dst-object-from-unsized-type.rs
@@ -16,22 +16,22 @@ impl Foo for [u8] {}
 
 fn test1<T: ?Sized + Foo>(t: &T) {
     let u: &Foo = t;
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 }
 
 fn test2<T: ?Sized + Foo>(t: &T) {
     let v: &Foo = t as &Foo;
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 }
 
 fn test3() {
     let _: &[&Foo] = &["hi"];
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 }
 
 fn test4(x: &[u8]) {
     let _: &Foo = x as &Foo;
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 }
 
 fn main() { }

--- a/src/test/compile-fail/dst-sized-trait-param.rs
+++ b/src/test/compile-fail/dst-sized-trait-param.rs
@@ -15,9 +15,9 @@
 trait Foo<T> : Sized { fn take(self, x: &T) { } } // Note: T is sized
 
 impl Foo<[isize]> for usize { }
-//~^ ERROR the size for value values of type
+//~^ ERROR the size for values of type
 
 impl Foo<isize> for [usize] { }
-//~^ ERROR the size for value values of type
+//~^ ERROR the size for values of type
 
 pub fn main() { }

--- a/src/test/compile-fail/extern-types-unsized.rs
+++ b/src/test/compile-fail/extern-types-unsized.rs
@@ -30,14 +30,14 @@ fn assert_sized<T>() { }
 
 fn main() {
     assert_sized::<A>();
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 
     assert_sized::<Foo>();
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 
     assert_sized::<Bar<A>>();
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 
     assert_sized::<Bar<Bar<A>>>();
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 }

--- a/src/test/compile-fail/issue-14366.rs
+++ b/src/test/compile-fail/issue-14366.rs
@@ -10,5 +10,5 @@
 
 fn main() {
     let _x = "test" as &::std::any::Any;
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 }

--- a/src/test/compile-fail/issue-15756.rs
+++ b/src/test/compile-fail/issue-15756.rs
@@ -15,7 +15,7 @@ fn dft_iter<'a, T>(arg1: Chunks<'a,T>, arg2: ChunksMut<'a,T>)
 {
     for
     &mut something
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
     in arg2
     {
     }

--- a/src/test/compile-fail/issue-17651.rs
+++ b/src/test/compile-fail/issue-17651.rs
@@ -13,5 +13,5 @@
 
 fn main() {
     (|| Box::new(*(&[0][..])))();
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 }

--- a/src/test/compile-fail/issue-18107.rs
+++ b/src/test/compile-fail/issue-18107.rs
@@ -12,7 +12,7 @@ pub trait AbstractRenderer {}
 
 fn _create_render(_: &()) ->
     AbstractRenderer
-//~^ ERROR the size for value values of type
+//~^ ERROR the size for values of type
 {
     match 0 {
         _ => unimplemented!()

--- a/src/test/compile-fail/issue-18919.rs
+++ b/src/test/compile-fail/issue-18919.rs
@@ -11,7 +11,7 @@
 type FuncType<'f> = Fn(&isize) -> isize + 'f;
 
 fn ho_func(f: Option<FuncType>) {
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 }
 
 fn main() {}

--- a/src/test/compile-fail/issue-20005.rs
+++ b/src/test/compile-fail/issue-20005.rs
@@ -15,7 +15,7 @@ trait From<Src> {
 }
 
 trait To {
-    fn to<Dst>(  //~ ERROR the size for value values of type
+    fn to<Dst>(  //~ ERROR the size for values of type
         self
     ) -> <Dst as From<Self>>::Result where Dst: From<Self> {
         From::from(self)

--- a/src/test/compile-fail/issue-20433.rs
+++ b/src/test/compile-fail/issue-20433.rs
@@ -14,5 +14,5 @@ struct The;
 
 impl The {
     fn iceman(c: Vec<[i32]>) {}
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 }

--- a/src/test/compile-fail/issue-20605.rs
+++ b/src/test/compile-fail/issue-20605.rs
@@ -10,7 +10,7 @@
 
 fn changer<'a>(mut things: Box<Iterator<Item=&'a mut u8>>) {
     for item in *things { *item = 0 }
-//~^ ERROR the size for value values of type
+//~^ ERROR the size for values of type
 }
 
 fn main() {}

--- a/src/test/compile-fail/issue-22874.rs
+++ b/src/test/compile-fail/issue-22874.rs
@@ -10,7 +10,7 @@
 
 struct Table {
     rows: [[String]],
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 }
 
 fn f(table: &Table) -> &[String] {

--- a/src/test/compile-fail/issue-23281.rs
+++ b/src/test/compile-fail/issue-23281.rs
@@ -14,7 +14,7 @@ pub struct Struct;
 
 impl Struct {
     pub fn function(funs: Vec<Fn() -> ()>) {}
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 }
 
 fn main() {}

--- a/src/test/compile-fail/issue-24446.rs
+++ b/src/test/compile-fail/issue-24446.rs
@@ -11,7 +11,7 @@
 fn main() {
     static foo: Fn() -> u32 = || -> u32 {
         //~^ ERROR mismatched types
-        //~| ERROR the size for value values of type
+        //~| ERROR the size for values of type
         0
     };
 }

--- a/src/test/compile-fail/issue-27060-2.rs
+++ b/src/test/compile-fail/issue-27060-2.rs
@@ -10,7 +10,7 @@
 
 #[repr(packed)]
 pub struct Bad<T: ?Sized> {
-    data: T, //~ ERROR the size for value values of type
+    data: T, //~ ERROR the size for values of type
 }
 
 fn main() {}

--- a/src/test/compile-fail/issue-27078.rs
+++ b/src/test/compile-fail/issue-27078.rs
@@ -13,7 +13,7 @@
 trait Foo {
     const BAR: i32;
     fn foo(self) -> &'static i32 {
-        //~^ ERROR the size for value values of type
+        //~^ ERROR the size for values of type
         &<Self>::BAR
     }
 }

--- a/src/test/compile-fail/issue-35988.rs
+++ b/src/test/compile-fail/issue-35988.rs
@@ -10,7 +10,7 @@
 
 enum E {
     V([Box<E>]),
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 }
 
 fn main() {}

--- a/src/test/compile-fail/issue-38954.rs
+++ b/src/test/compile-fail/issue-38954.rs
@@ -9,6 +9,6 @@
 // except according to those terms.
 
 fn _test(ref _p: str) {}
-//~^ ERROR the size for value values of type
+//~^ ERROR the size for values of type
 
 fn main() { }

--- a/src/test/compile-fail/issue-41229-ref-str.rs
+++ b/src/test/compile-fail/issue-41229-ref-str.rs
@@ -9,6 +9,6 @@
 // except according to those terms.
 
 pub fn example(ref s: str) {}
-//~^ ERROR the size for value values of type
+//~^ ERROR the size for values of type
 
 fn main() {}

--- a/src/test/compile-fail/issue-42312.rs
+++ b/src/test/compile-fail/issue-42312.rs
@@ -12,10 +12,10 @@ use std::ops::Deref;
 
 pub trait Foo {
     fn baz(_: Self::Target) where Self: Deref {}
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 }
 
 pub fn f(_: ToString) {}
-//~^ ERROR the size for value values of type
+//~^ ERROR the size for values of type
 
 fn main() { }

--- a/src/test/compile-fail/issue-5883.rs
+++ b/src/test/compile-fail/issue-5883.rs
@@ -15,8 +15,8 @@ struct Struct {
 }
 
 fn new_struct(r: A+'static)
-    -> Struct { //~^ ERROR the size for value values of type
-    //~^ ERROR the size for value values of type
+    -> Struct { //~^ ERROR the size for values of type
+    //~^ ERROR the size for values of type
     Struct { r: r }
 }
 

--- a/src/test/compile-fail/range-1.rs
+++ b/src/test/compile-fail/range-1.rs
@@ -22,5 +22,5 @@ pub fn main() {
     // Unsized type.
     let arr: &[_] = &[1, 2, 3];
     let range = *arr..;
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 }

--- a/src/test/compile-fail/str-mut-idx.rs
+++ b/src/test/compile-fail/str-mut-idx.rs
@@ -12,8 +12,8 @@ fn bot<T>() -> T { loop {} }
 
 fn mutate(s: &mut str) {
     s[1..2] = bot();
-    //~^ ERROR the size for value values of type
-    //~| ERROR the size for value values of type
+    //~^ ERROR the size for values of type
+    //~| ERROR the size for values of type
     s[1usize] = bot();
     //~^ ERROR the type `str` cannot be mutably indexed by `usize`
 }

--- a/src/test/compile-fail/substs-ppaux.rs
+++ b/src/test/compile-fail/substs-ppaux.rs
@@ -56,6 +56,6 @@ fn foo<'z>() where &'z (): Sized {
     //[normal]~| found type `fn() {foo::<'static>}`
 
     <str as Foo<u8>>::bar;
-    //[verbose]~^ ERROR the size for value values of type
-    //[normal]~^^ ERROR the size for value values of type
+    //[verbose]~^ ERROR the size for values of type
+    //[normal]~^^ ERROR the size for values of type
 }

--- a/src/test/compile-fail/trait-bounds-not-on-bare-trait.rs
+++ b/src/test/compile-fail/trait-bounds-not-on-bare-trait.rs
@@ -15,7 +15,7 @@ trait Foo {
 // This should emit the less confusing error, not the more confusing one.
 
 fn foo(_x: Foo + Send) {
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 }
 
 fn main() { }

--- a/src/test/compile-fail/union/union-unsized.rs
+++ b/src/test/compile-fail/union/union-unsized.rs
@@ -12,7 +12,7 @@
 
 union U {
     a: str,
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 
     b: u8,
 }
@@ -20,7 +20,7 @@ union U {
 union W {
     a: u8,
     b: str,
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 }
 
 fn main() {}

--- a/src/test/compile-fail/unsized-bare-typaram.rs
+++ b/src/test/compile-fail/unsized-bare-typaram.rs
@@ -10,5 +10,5 @@
 
 fn bar<T: Sized>() { }
 fn foo<T: ?Sized>() { bar::<T>() }
-//~^ ERROR the size for value values of type
+//~^ ERROR the size for values of type
 fn main() { }

--- a/src/test/compile-fail/unsized-enum.rs
+++ b/src/test/compile-fail/unsized-enum.rs
@@ -15,7 +15,7 @@ fn not_sized<T: ?Sized>() { }
 enum Foo<U> { FooSome(U), FooNone }
 fn foo1<T>() { not_sized::<Foo<T>>() } // Hunky dory.
 fn foo2<T: ?Sized>() { not_sized::<Foo<T>>() }
-//~^ ERROR the size for value values of type
+//~^ ERROR the size for values of type
 //
 // Not OK: `T` is not sized.
 

--- a/src/test/compile-fail/unsized-inherent-impl-self-type.rs
+++ b/src/test/compile-fail/unsized-inherent-impl-self-type.rs
@@ -15,7 +15,7 @@
 struct S5<Y>(Y);
 
 impl<X: ?Sized> S5<X> {
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 }
 
 fn main() { }

--- a/src/test/compile-fail/unsized-struct.rs
+++ b/src/test/compile-fail/unsized-struct.rs
@@ -15,14 +15,14 @@ fn not_sized<T: ?Sized>() { }
 struct Foo<T> { data: T }
 fn foo1<T>() { not_sized::<Foo<T>>() } // Hunky dory.
 fn foo2<T: ?Sized>() { not_sized::<Foo<T>>() }
-//~^ ERROR the size for value values of type
+//~^ ERROR the size for values of type
 //
 // Not OK: `T` is not sized.
 
 struct Bar<T: ?Sized> { data: T }
 fn bar1<T: ?Sized>() { not_sized::<Bar<T>>() }
 fn bar2<T: ?Sized>() { is_sized::<Bar<T>>() }
-//~^ ERROR the size for value values of type
+//~^ ERROR the size for values of type
 //
 // Not OK: `Bar<T>` is not sized, but it should be.
 

--- a/src/test/compile-fail/unsized-trait-impl-self-type.rs
+++ b/src/test/compile-fail/unsized-trait-impl-self-type.rs
@@ -18,7 +18,7 @@ trait T3<Z: ?Sized> {
 struct S5<Y>(Y);
 
 impl<X: ?Sized> T3<X> for S5<X> {
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 }
 
 fn main() { }

--- a/src/test/compile-fail/unsized-trait-impl-trait-arg.rs
+++ b/src/test/compile-fail/unsized-trait-impl-trait-arg.rs
@@ -16,7 +16,7 @@ trait T2<Z> {
 }
 struct S4<Y: ?Sized>(Box<Y>);
 impl<X: ?Sized> T2<X> for S4<X> {
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 }
 
 fn main() { }

--- a/src/test/compile-fail/unsized3.rs
+++ b/src/test/compile-fail/unsized3.rs
@@ -15,7 +15,7 @@ use std::marker;
 // Unbounded.
 fn f1<X: ?Sized>(x: &X) {
     f2::<X>(x);
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 }
 fn f2<X>(x: &X) {
 }
@@ -26,7 +26,7 @@ trait T {
 }
 fn f3<X: ?Sized + T>(x: &X) {
     f4::<X>(x);
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 }
 fn f4<X: T>(x: &X) {
 }
@@ -41,20 +41,20 @@ struct S<X: ?Sized> {
 
 fn f8<X: ?Sized>(x1: &S<X>, x2: &S<X>) {
     f5(x1);
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
     f6(x2); // ok
 }
 
 // Test some tuples.
 fn f9<X: ?Sized>(x1: Box<S<X>>) {
     f5(&(*x1, 34));
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 }
 
 fn f10<X: ?Sized>(x1: Box<S<X>>) {
     f5(&(32, *x1));
-    //~^ ERROR the size for value values of type
-    //~| ERROR the size for value values of type
+    //~^ ERROR the size for values of type
+    //~| ERROR the size for values of type
 }
 
 pub fn main() {

--- a/src/test/compile-fail/unsized5.rs
+++ b/src/test/compile-fail/unsized5.rs
@@ -12,32 +12,32 @@
 
 struct S1<X: ?Sized> {
     f1: X,
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
     f2: isize,
 }
 struct S2<X: ?Sized> {
     f: isize,
     g: X,
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
     h: isize,
 }
 struct S3 {
     f: str,
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
     g: [usize]
 }
 struct S4 {
     f: [u8],
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
     g: usize
 }
 enum E<X: ?Sized> {
     V1(X, isize),
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 }
 enum F<X: ?Sized> {
     V2{f1: X, f: isize},
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 }
 
 pub fn main() {

--- a/src/test/compile-fail/unsized6.rs
+++ b/src/test/compile-fail/unsized6.rs
@@ -15,40 +15,40 @@ trait T {}
 fn f1<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized>(x: &X) {
     let _: W; // <-- this is OK, no bindings created, no initializer.
     let _: (isize, (X, isize));
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
     let y: Y;
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
     let y: (isize, (Z, usize));
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 }
 fn f2<X: ?Sized, Y: ?Sized>(x: &X) {
     let y: X;
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
     let y: (isize, (Y, isize));
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 }
 
 fn f3<X: ?Sized>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
     let y: X = *x1;
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
     let y = *x2;
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
     let (y, z) = (*x3, 4);
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 }
 fn f4<X: ?Sized + T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
     let y: X = *x1;
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
     let y = *x2;
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
     let (y, z) = (*x3, 4);
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 }
 
 fn g1<X: ?Sized>(x: X) {}
-//~^ ERROR the size for value values of type
+//~^ ERROR the size for values of type
 fn g2<X: ?Sized + T>(x: X) {}
-//~^ ERROR the size for value values of type
+//~^ ERROR the size for values of type
 
 pub fn main() {
 }

--- a/src/test/compile-fail/unsized7.rs
+++ b/src/test/compile-fail/unsized7.rs
@@ -20,7 +20,7 @@ trait T1<Z: T> {
 
 struct S3<Y: ?Sized>(Box<Y>);
 impl<X: ?Sized + T> T1<X> for S3<X> {
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 }
 
 fn main() { }

--- a/src/test/ui/const-unsized.rs
+++ b/src/test/ui/const-unsized.rs
@@ -11,16 +11,16 @@
 use std::fmt::Debug;
 
 const CONST_0: Debug+Sync = *(&0 as &(Debug+Sync));
-//~^ ERROR the size for value values of type
+//~^ ERROR the size for values of type
 
 const CONST_FOO: str = *"foo";
-//~^ ERROR the size for value values of type
+//~^ ERROR the size for values of type
 
 static STATIC_1: Debug+Sync = *(&1 as &(Debug+Sync));
-//~^ ERROR the size for value values of type
+//~^ ERROR the size for values of type
 
 static STATIC_BAR: str = *"bar";
-//~^ ERROR the size for value values of type
+//~^ ERROR the size for values of type
 
 fn main() {
     println!("{:?} {:?} {:?} {:?}", &CONST_0, &CONST_FOO, &STATIC_1, &STATIC_BAR);

--- a/src/test/ui/const-unsized.stderr
+++ b/src/test/ui/const-unsized.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the size for value values of type `(dyn std::fmt::Debug + std::marker::Sync + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `(dyn std::fmt::Debug + std::marker::Sync + 'static)` cannot be known at compilation time
   --> $DIR/const-unsized.rs:13:29
    |
 LL | const CONST_0: Debug+Sync = *(&0 as &(Debug+Sync));
@@ -8,7 +8,7 @@ LL | const CONST_0: Debug+Sync = *(&0 as &(Debug+Sync));
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: constant expressions must have a statically known size
 
-error[E0277]: the size for value values of type `str` cannot be known at compilation time
+error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/const-unsized.rs:16:24
    |
 LL | const CONST_FOO: str = *"foo";
@@ -18,7 +18,7 @@ LL | const CONST_FOO: str = *"foo";
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: constant expressions must have a statically known size
 
-error[E0277]: the size for value values of type `(dyn std::fmt::Debug + std::marker::Sync + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `(dyn std::fmt::Debug + std::marker::Sync + 'static)` cannot be known at compilation time
   --> $DIR/const-unsized.rs:19:31
    |
 LL | static STATIC_1: Debug+Sync = *(&1 as &(Debug+Sync));
@@ -28,7 +28,7 @@ LL | static STATIC_1: Debug+Sync = *(&1 as &(Debug+Sync));
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: constant expressions must have a statically known size
 
-error[E0277]: the size for value values of type `str` cannot be known at compilation time
+error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/const-unsized.rs:22:26
    |
 LL | static STATIC_BAR: str = *"bar";

--- a/src/test/ui/error-codes/E0277.rs
+++ b/src/test/ui/error-codes/E0277.rs
@@ -21,7 +21,7 @@ fn some_func<T: Foo>(foo: T) {
 }
 
 fn f(p: Path) { }
-//~^ ERROR the size for value values of type
+//~^ ERROR the size for values of type
 
 fn main() {
     some_func(5i32);

--- a/src/test/ui/error-codes/E0277.stderr
+++ b/src/test/ui/error-codes/E0277.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the size for value values of type `[u8]` cannot be known at compilation time
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> $DIR/E0277.rs:23:6
    |
 LL | fn f(p: Path) { }

--- a/src/test/ui/feature-gate-trivial_bounds.stderr
+++ b/src/test/ui/feature-gate-trivial_bounds.stderr
@@ -87,7 +87,7 @@ LL | | }
    = help: see issue #48214
    = help: add #![feature(trivial_bounds)] to the crate attributes to enable
 
-error[E0277]: the size for value values of type `str` cannot be known at compilation time
+error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/feature-gate-trivial_bounds.rs:62:1
    |
 LL | struct TwoStrs(str, str) where str: Sized; //~ ERROR
@@ -98,7 +98,7 @@ LL | struct TwoStrs(str, str) where str: Sized; //~ ERROR
    = help: see issue #48214
    = help: add #![feature(trivial_bounds)] to the crate attributes to enable
 
-error[E0277]: the size for value values of type `(dyn A + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `(dyn A + 'static)` cannot be known at compilation time
   --> $DIR/feature-gate-trivial_bounds.rs:65:1
    |
 LL | / fn unsized_local() where Dst<A>: Sized { //~ ERROR
@@ -112,7 +112,7 @@ LL | | }
    = help: see issue #48214
    = help: add #![feature(trivial_bounds)] to the crate attributes to enable
 
-error[E0277]: the size for value values of type `str` cannot be known at compilation time
+error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/feature-gate-trivial_bounds.rs:69:1
    |
 LL | / fn return_str() -> str where str: Sized { //~ ERROR

--- a/src/test/ui/generator/sized-yield.rs
+++ b/src/test/ui/generator/sized-yield.rs
@@ -15,9 +15,9 @@ use std::ops::Generator;
 fn main() {
    let s = String::from("foo");
    let mut gen = move || {
-   //~^ ERROR the size for value values of type
+   //~^ ERROR the size for values of type
        yield s[..];
    };
    unsafe { gen.resume(); }
-   //~^ ERROR the size for value values of type
+   //~^ ERROR the size for values of type
 }

--- a/src/test/ui/generator/sized-yield.stderr
+++ b/src/test/ui/generator/sized-yield.stderr
@@ -1,9 +1,9 @@
-error[E0277]: the size for value values of type `str` cannot be known at compilation time
+error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/sized-yield.rs:17:26
    |
 LL |      let mut gen = move || {
    |  __________________________^
-LL | |    //~^ ERROR the size for value values of type
+LL | |    //~^ ERROR the size for values of type
 LL | |        yield s[..];
 LL | |    };
    | |____^ doesn't have a size known at compile-time
@@ -12,7 +12,7 @@ LL | |    };
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: the yield type of a generator must have a statically known size
 
-error[E0277]: the size for value values of type `str` cannot be known at compilation time
+error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/sized-yield.rs:21:17
    |
 LL |    unsafe { gen.resume(); }

--- a/src/test/ui/mismatched_types/cast-rfc0401.rs
+++ b/src/test/ui/mismatched_types/cast-rfc0401.rs
@@ -60,7 +60,7 @@ fn main()
 
     let _ = 42usize as *const [u8]; //~ ERROR is invalid
     let _ = v as *const [u8]; //~ ERROR cannot cast
-    let _ = fat_v as *const Foo; //~ ERROR the size for value values of type
+    let _ = fat_v as *const Foo; //~ ERROR the size for values of type
     let _ = foo as *const str; //~ ERROR is invalid
     let _ = foo as *mut str; //~ ERROR is invalid
     let _ = main as *mut str; //~ ERROR is invalid
@@ -69,7 +69,7 @@ fn main()
     let _ = fat_sv as usize; //~ ERROR is invalid
 
     let a : *const str = "hello";
-    let _ = a as *const Foo; //~ ERROR the size for value values of type
+    let _ = a as *const Foo; //~ ERROR the size for values of type
 
     // check no error cascade
     let _ = main.f as *const u32; //~ ERROR no field

--- a/src/test/ui/mismatched_types/cast-rfc0401.stderr
+++ b/src/test/ui/mismatched_types/cast-rfc0401.stderr
@@ -216,20 +216,20 @@ LL |     let _ = cf as *const Bar; //~ ERROR is invalid
    |
    = note: vtable kinds may not match
 
-error[E0277]: the size for value values of type `[u8]` cannot be known at compilation time
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> $DIR/cast-rfc0401.rs:63:13
    |
-LL |     let _ = fat_v as *const Foo; //~ ERROR the size for value values of type
+LL |     let _ = fat_v as *const Foo; //~ ERROR the size for values of type
    |             ^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `[u8]`
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: required for the cast to the object type `dyn Foo`
 
-error[E0277]: the size for value values of type `str` cannot be known at compilation time
+error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/cast-rfc0401.rs:72:13
    |
-LL |     let _ = a as *const Foo; //~ ERROR the size for value values of type
+LL |     let _ = a as *const Foo; //~ ERROR the size for values of type
    |             ^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `str`

--- a/src/test/ui/resolve/issue-5035-2.rs
+++ b/src/test/ui/resolve/issue-5035-2.rs
@@ -12,6 +12,6 @@ trait I {}
 type K = I+'static;
 
 fn foo(_x: K) {}
-//~^ ERROR the size for value values of type
+//~^ ERROR the size for values of type
 
 fn main() {}

--- a/src/test/ui/resolve/issue-5035-2.stderr
+++ b/src/test/ui/resolve/issue-5035-2.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the size for value values of type `(dyn I + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `(dyn I + 'static)` cannot be known at compilation time
   --> $DIR/issue-5035-2.rs:14:8
    |
 LL | fn foo(_x: K) {}

--- a/src/test/ui/suggestions/str-array-assignment.rs
+++ b/src/test/ui/suggestions/str-array-assignment.rs
@@ -15,7 +15,7 @@ fn main() {
   let u: &str = if true { s[..2] } else { s };
   //~^ ERROR mismatched types
   let v = s[..2];
-  //~^ ERROR the size for value values of type
+  //~^ ERROR the size for values of type
   let w: &str = s[..2];
   //~^ ERROR mismatched types
 }

--- a/src/test/ui/suggestions/str-array-assignment.stderr
+++ b/src/test/ui/suggestions/str-array-assignment.stderr
@@ -19,7 +19,7 @@ LL |   let u: &str = if true { s[..2] } else { s };
    = note: expected type `&str`
               found type `str`
 
-error[E0277]: the size for value values of type `str` cannot be known at compilation time
+error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/str-array-assignment.rs:17:7
    |
 LL |   let v = s[..2];

--- a/src/test/ui/trait-suggest-where-clause.rs
+++ b/src/test/ui/trait-suggest-where-clause.rs
@@ -15,10 +15,10 @@ struct Misc<T:?Sized>(T);
 fn check<T: Iterator, U: ?Sized>() {
     // suggest a where-clause, if needed
     mem::size_of::<U>();
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 
     mem::size_of::<Misc<U>>();
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 
     // ... even if T occurs as a type parameter
 
@@ -36,10 +36,10 @@ fn check<T: Iterator, U: ?Sized>() {
     // ... and also not if the error is not related to the type
 
     mem::size_of::<[T]>();
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 
     mem::size_of::<[&U]>();
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 }
 
 fn main() {

--- a/src/test/ui/trait-suggest-where-clause.stderr
+++ b/src/test/ui/trait-suggest-where-clause.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the size for value values of type `U` cannot be known at compilation time
+error[E0277]: the size for values of type `U` cannot be known at compilation time
   --> $DIR/trait-suggest-where-clause.rs:17:5
    |
 LL |     mem::size_of::<U>();
@@ -9,7 +9,7 @@ LL |     mem::size_of::<U>();
    = help: consider adding a `where U: std::marker::Sized` bound
    = note: required by `std::mem::size_of`
 
-error[E0277]: the size for value values of type `U` cannot be known at compilation time
+error[E0277]: the size for values of type `U` cannot be known at compilation time
   --> $DIR/trait-suggest-where-clause.rs:20:5
    |
 LL |     mem::size_of::<Misc<U>>();
@@ -47,7 +47,7 @@ LL |     <Misc<_> as From<T>>::from;
    |
    = note: required by `std::convert::From::from`
 
-error[E0277]: the size for value values of type `[T]` cannot be known at compilation time
+error[E0277]: the size for values of type `[T]` cannot be known at compilation time
   --> $DIR/trait-suggest-where-clause.rs:38:5
    |
 LL |     mem::size_of::<[T]>();
@@ -57,7 +57,7 @@ LL |     mem::size_of::<[T]>();
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: required by `std::mem::size_of`
 
-error[E0277]: the size for value values of type `[&U]` cannot be known at compilation time
+error[E0277]: the size for values of type `[&U]` cannot be known at compilation time
   --> $DIR/trait-suggest-where-clause.rs:41:5
    |
 LL |     mem::size_of::<[&U]>();

--- a/src/test/ui/trivial-bounds-leak.stderr
+++ b/src/test/ui/trivial-bounds-leak.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the size for value values of type `str` cannot be known at compilation time
+error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/trivial-bounds-leak.rs:22:25
    |
 LL | fn cant_return_str() -> str { //~ ERROR

--- a/src/test/ui/union/union-sized-field.rs
+++ b/src/test/ui/union/union-sized-field.rs
@@ -12,18 +12,18 @@
 
 union Foo<T: ?Sized> {
     value: T,
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 }
 
 struct Foo2<T: ?Sized> {
     value: T,
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
     t: u32,
 }
 
 enum Foo3<T: ?Sized> {
     Value(T),
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 }
 
 fn main() {}

--- a/src/test/ui/union/union-sized-field.stderr
+++ b/src/test/ui/union/union-sized-field.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the size for value values of type `T` cannot be known at compilation time
+error[E0277]: the size for values of type `T` cannot be known at compilation time
   --> $DIR/union-sized-field.rs:14:5
    |
 LL |     value: T,
@@ -9,7 +9,7 @@ LL |     value: T,
    = help: consider adding a `where T: std::marker::Sized` bound
    = note: no field of a union may have a dynamically sized type
 
-error[E0277]: the size for value values of type `T` cannot be known at compilation time
+error[E0277]: the size for values of type `T` cannot be known at compilation time
   --> $DIR/union-sized-field.rs:19:5
    |
 LL |     value: T,
@@ -20,7 +20,7 @@ LL |     value: T,
    = help: consider adding a `where T: std::marker::Sized` bound
    = note: only the last field of a struct may have a dynamically sized type
 
-error[E0277]: the size for value values of type `T` cannot be known at compilation time
+error[E0277]: the size for values of type `T` cannot be known at compilation time
   --> $DIR/union-sized-field.rs:25:11
    |
 LL |     Value(T),

--- a/src/test/ui/unsized-enum2.rs
+++ b/src/test/ui/unsized-enum2.rs
@@ -31,53 +31,53 @@ struct Path4(PathHelper4);
 enum E<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized> {
     // parameter
     VA(W),
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
     VB{x: X},
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
     VC(isize, Y),
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
     VD{u: isize, x: Z},
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 
     // slice / str
     VE([u8]),
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
     VF{x: str},
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
     VG(isize, [f32]),
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
     VH{u: isize, x: [u32]},
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 
     // unsized struct
     VI(Path1),
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
     VJ{x: Path2},
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
     VK(isize, Path3),
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
     VL{u: isize, x: Path4},
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 
     // plain trait
     VM(Foo),
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
     VN{x: Bar},
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
     VO(isize, FooBar),
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
     VP{u: isize, x: BarFoo},
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 
     // projected
     VQ(<&'static [i8] as Deref>::Target),
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
     VR{x: <&'static [char] as Deref>::Target},
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
     VS(isize, <&'static [f64] as Deref>::Target),
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
     VT{u: isize, x: <&'static [i32] as Deref>::Target},
-    //~^ ERROR the size for value values of type
+    //~^ ERROR the size for values of type
 }
 
 

--- a/src/test/ui/unsized-enum2.stderr
+++ b/src/test/ui/unsized-enum2.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the size for value values of type `W` cannot be known at compilation time
+error[E0277]: the size for values of type `W` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:33:8
    |
 LL |     VA(W),
@@ -9,7 +9,7 @@ LL |     VA(W),
    = help: consider adding a `where W: std::marker::Sized` bound
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: the size for value values of type `X` cannot be known at compilation time
+error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:35:8
    |
 LL |     VB{x: X},
@@ -20,7 +20,7 @@ LL |     VB{x: X},
    = help: consider adding a `where X: std::marker::Sized` bound
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: the size for value values of type `Y` cannot be known at compilation time
+error[E0277]: the size for values of type `Y` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:37:15
    |
 LL |     VC(isize, Y),
@@ -31,7 +31,7 @@ LL |     VC(isize, Y),
    = help: consider adding a `where Y: std::marker::Sized` bound
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: the size for value values of type `Z` cannot be known at compilation time
+error[E0277]: the size for values of type `Z` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:39:18
    |
 LL |     VD{u: isize, x: Z},
@@ -42,7 +42,7 @@ LL |     VD{u: isize, x: Z},
    = help: consider adding a `where Z: std::marker::Sized` bound
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: the size for value values of type `[u8]` cannot be known at compilation time
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:43:8
    |
 LL |     VE([u8]),
@@ -52,7 +52,7 @@ LL |     VE([u8]),
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: the size for value values of type `str` cannot be known at compilation time
+error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:45:8
    |
 LL |     VF{x: str},
@@ -62,7 +62,7 @@ LL |     VF{x: str},
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: the size for value values of type `[f32]` cannot be known at compilation time
+error[E0277]: the size for values of type `[f32]` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:47:15
    |
 LL |     VG(isize, [f32]),
@@ -72,7 +72,7 @@ LL |     VG(isize, [f32]),
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: the size for value values of type `[u32]` cannot be known at compilation time
+error[E0277]: the size for values of type `[u32]` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:49:18
    |
 LL |     VH{u: isize, x: [u32]},
@@ -82,7 +82,7 @@ LL |     VH{u: isize, x: [u32]},
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: the size for value values of type `(dyn Foo + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `(dyn Foo + 'static)` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:63:8
    |
 LL |     VM(Foo),
@@ -92,7 +92,7 @@ LL |     VM(Foo),
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: the size for value values of type `(dyn Bar + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `(dyn Bar + 'static)` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:65:8
    |
 LL |     VN{x: Bar},
@@ -102,7 +102,7 @@ LL |     VN{x: Bar},
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: the size for value values of type `(dyn FooBar + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `(dyn FooBar + 'static)` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:67:15
    |
 LL |     VO(isize, FooBar),
@@ -112,7 +112,7 @@ LL |     VO(isize, FooBar),
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: the size for value values of type `(dyn BarFoo + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `(dyn BarFoo + 'static)` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:69:18
    |
 LL |     VP{u: isize, x: BarFoo},
@@ -122,7 +122,7 @@ LL |     VP{u: isize, x: BarFoo},
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: the size for value values of type `[i8]` cannot be known at compilation time
+error[E0277]: the size for values of type `[i8]` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:73:8
    |
 LL |     VQ(<&'static [i8] as Deref>::Target),
@@ -132,7 +132,7 @@ LL |     VQ(<&'static [i8] as Deref>::Target),
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: the size for value values of type `[char]` cannot be known at compilation time
+error[E0277]: the size for values of type `[char]` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:75:8
    |
 LL |     VR{x: <&'static [char] as Deref>::Target},
@@ -142,7 +142,7 @@ LL |     VR{x: <&'static [char] as Deref>::Target},
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: the size for value values of type `[f64]` cannot be known at compilation time
+error[E0277]: the size for values of type `[f64]` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:77:15
    |
 LL |     VS(isize, <&'static [f64] as Deref>::Target),
@@ -152,7 +152,7 @@ LL |     VS(isize, <&'static [f64] as Deref>::Target),
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: the size for value values of type `[i32]` cannot be known at compilation time
+error[E0277]: the size for values of type `[i32]` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:79:18
    |
 LL |     VT{u: isize, x: <&'static [i32] as Deref>::Target},
@@ -162,7 +162,7 @@ LL |     VT{u: isize, x: <&'static [i32] as Deref>::Target},
    = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized>
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: the size for value values of type `(dyn PathHelper1 + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `(dyn PathHelper1 + 'static)` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:53:8
    |
 LL |     VI(Path1),
@@ -173,7 +173,7 @@ LL |     VI(Path1),
    = note: required because it appears within the type `Path1`
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: the size for value values of type `(dyn PathHelper2 + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `(dyn PathHelper2 + 'static)` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:55:8
    |
 LL |     VJ{x: Path2},
@@ -184,7 +184,7 @@ LL |     VJ{x: Path2},
    = note: required because it appears within the type `Path2`
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: the size for value values of type `(dyn PathHelper3 + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `(dyn PathHelper3 + 'static)` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:57:15
    |
 LL |     VK(isize, Path3),
@@ -195,7 +195,7 @@ LL |     VK(isize, Path3),
    = note: required because it appears within the type `Path3`
    = note: no field of an enum variant may have a dynamically sized type
 
-error[E0277]: the size for value values of type `(dyn PathHelper4 + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `(dyn PathHelper4 + 'static)` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:59:18
    |
 LL |     VL{u: isize, x: Path4},


### PR DESCRIPTION
Successful merges:

 - #51701 (Better docs for copy_from_slice & clone_from_slice)
 - #52231 (Fix typo in error message E0277)
 - #52233 (Improve lint handling in rustdoc)
 - #52238 (Avoid unwrapping in PanicInfo doc example.)
 - #52241 (Fix typo in E0433 docs)

Failed merges:


r? @ghost