### PR TITLE
Deny bare trait objects in src/librustc

### DIFF
--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -82,9 +82,9 @@ pub struct LoweringContext<'a> {
     // Use to assign ids to hir nodes that do not directly correspond to an ast node
     sess: &'a Session,
 
-    cstore: &'a CrateStore,
+    cstore: &'a dyn CrateStore,
 
-    resolver: &'a mut Resolver,
+    resolver: &'a mut dyn Resolver,
 
     /// The items being lowered are collected here.
     items: BTreeMap<NodeId, hir::Item>,
@@ -199,10 +199,10 @@ impl<'a> ImplTraitContext<'a> {
 
 pub fn lower_crate(
     sess: &Session,
-    cstore: &CrateStore,
+    cstore: &dyn CrateStore,
     dep_graph: &DepGraph,
     krate: &Crate,
-    resolver: &mut Resolver,
+    resolver: &mut dyn Resolver,
 ) -> hir::Crate {
     // We're constructing the HIR here; we don't care what we will
     // read, since we haven't even constructed the *input* to

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -36,6 +36,8 @@
 //!
 //! This API is completely unstable and subject to change.
 
+#![deny(bare_trait_objects)]
+
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
        html_root_url = "https://doc.rust-lang.org/nightly/")]

--- a/src/librustc/middle/cstore.rs
+++ b/src/librustc/middle/cstore.rs
@@ -257,7 +257,7 @@ pub trait CrateStore {
     fn metadata_encoding_version(&self) -> &[u8];
 }
 
-pub type CrateStoreDyn = CrateStore + sync::Sync;
+pub type CrateStoreDyn = dyn CrateStore + sync::Sync;
 
 // FIXME: find a better place for this?
 pub fn validate_crate_name(sess: Option<&Session>, s: &str, sp: Option<Span>) {


### PR DESCRIPTION
Enforce `#![deny(bare_trait_objects)]` in `src/librustc`.