### PR TITLE
Speed up `SparseBitMatrix` use in `RegionValues`.

### DIFF
--- a/src/librustc_mir/borrow_check/nll/region_infer/values.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/values.rs
@@ -10,7 +10,7 @@
 
 use rustc::mir::{BasicBlock, Location, Mir};
 use rustc::ty::RegionVid;
-use rustc_data_structures::bitvec::{SparseBitMatrix, SparseBitSet};
+use rustc_data_structures::bitvec::{BitVector, SparseBitMatrix};
 use rustc_data_structures::indexed_vec::Idx;
 use rustc_data_structures::indexed_vec::IndexVec;
 use std::fmt::Debug;
@@ -53,6 +53,11 @@ impl RegionValueElements {
             num_universal_regions,
             num_points,
         }
+    }
+
+    /// Total number of element indices that exist.
+    crate fn num_elements(&self) -> usize {
+        self.num_points + self.num_universal_regions
     }
 
     /// Converts an element of a region value into a `RegionElementIndex`.
@@ -186,7 +191,7 @@ impl<N: Idx> RegionValues<N> {
     crate fn new(elements: &Rc<RegionValueElements>) -> Self {
         Self {
             elements: elements.clone(),
-            matrix: SparseBitMatrix::new(),
+            matrix: SparseBitMatrix::new(elements.num_elements()),
         }
     }
 
@@ -217,12 +222,12 @@ impl<N: Idx> RegionValues<N> {
     /// Iterates through each row and the accompanying bit set.
     pub fn iter_enumerated<'a>(
         &'a self
-    ) -> impl Iterator<Item = (N, &'a SparseBitSet<RegionElementIndex>)> + 'a {
+    ) -> impl Iterator<Item = (N, &'a BitVector)> + 'a {
         self.matrix.iter_enumerated()
     }
 
     /// Merge a row, `from`, originating in another `RegionValues` into the `into` row.
-    pub fn merge_into(&mut self, into: N, from: &SparseBitSet<RegionElementIndex>) -> bool {
+    pub fn merge_into(&mut self, into: N, from: &BitVector) -> bool {
         self.matrix.merge_into(into, from)
     }
 


### PR DESCRIPTION
In practice, these matrices range from 10% to 90%+ full once they are
filled in, so the dense representation is better.
    
This reduces the runtime of Check Nll builds of `inflate` by 32%, and
several other benchmarks by 1--5%.
    
It also increases max-rss of `clap-rs` by 30% and a couple of others by
up to 5%, while decreasing max-rss of `coercions` by 14%. I think the
speed-ups justify the max-rss increases.

r? @nikomatsakis 