### PR TITLE
Deny bare trait objects in src/librustc_codegen_llvm

### DIFF
--- a/src/librustc_codegen_llvm/back/archive.rs
+++ b/src/librustc_codegen_llvm/back/archive.rs
@@ -48,7 +48,7 @@ enum Addition {
     },
     Archive {
         archive: ArchiveRO,
-        skip: Box<FnMut(&str) -> bool>,
+        skip: Box<dyn FnMut(&str) -> bool>,
     },
 }
 

--- a/src/librustc_codegen_llvm/back/link.rs
+++ b/src/librustc_codegen_llvm/back/link.rs
@@ -251,7 +251,7 @@ fn filename_for_metadata(sess: &Session, crate_name: &str, outputs: &OutputFilen
 
 pub(crate) fn each_linked_rlib(sess: &Session,
                                info: &CrateInfo,
-                               f: &mut FnMut(CrateNum, &Path)) -> Result<(), String> {
+                               f: &mut dyn FnMut(CrateNum, &Path)) -> Result<(), String> {
     let crates = info.used_crates_static.iter();
     let fmts = sess.dependency_formats.borrow();
     let fmts = fmts.get(&config::CrateTypeExecutable)
@@ -984,7 +984,7 @@ fn exec_linker(sess: &Session, cmd: &mut Command, out_filename: &Path, tmpdir: &
     }
 }
 
-fn link_args(cmd: &mut Linker,
+fn link_args(cmd: &mut dyn Linker,
              sess: &Session,
              crate_type: config::CrateType,
              tmpdir: &Path,
@@ -1195,7 +1195,7 @@ fn link_args(cmd: &mut Linker,
 // Also note that the native libraries linked here are only the ones located
 // in the current crate. Upstream crates with native library dependencies
 // may have their native library pulled in above.
-fn add_local_native_libraries(cmd: &mut Linker,
+fn add_local_native_libraries(cmd: &mut dyn Linker,
                               sess: &Session,
                               codegen_results: &CodegenResults) {
     sess.target_filesearch(PathKind::All).for_each_lib_search_path(|path, k| {
@@ -1226,7 +1226,7 @@ fn add_local_native_libraries(cmd: &mut Linker,
 // Rust crates are not considered at all when creating an rlib output. All
 // dependencies will be linked when producing the final output (instead of
 // the intermediate rlib version)
-fn add_upstream_rust_crates(cmd: &mut Linker,
+fn add_upstream_rust_crates(cmd: &mut dyn Linker,
                             sess: &Session,
                             codegen_results: &CodegenResults,
                             crate_type: config::CrateType,
@@ -1350,7 +1350,7 @@ fn add_upstream_rust_crates(cmd: &mut Linker,
     // it's packed in a .rlib, it contains stuff that are not objects that will
     // make the linker error. So we must remove those bits from the .rlib before
     // linking it.
-    fn link_sanitizer_runtime(cmd: &mut Linker,
+    fn link_sanitizer_runtime(cmd: &mut dyn Linker,
                               sess: &Session,
                               codegen_results: &CodegenResults,
                               tmpdir: &Path,
@@ -1419,7 +1419,7 @@ fn add_upstream_rust_crates(cmd: &mut Linker,
     // (aka we're making an executable), we can just pass the rlib blindly to
     // the linker (fast) because it's fine if it's not actually included as
     // we're at the end of the dependency chain.
-    fn add_static_crate(cmd: &mut Linker,
+    fn add_static_crate(cmd: &mut dyn Linker,
                         sess: &Session,
                         codegen_results: &CodegenResults,
                         tmpdir: &Path,
@@ -1524,7 +1524,7 @@ fn add_upstream_rust_crates(cmd: &mut Linker,
     }
 
     // Same thing as above, but for dynamic crates instead of static crates.
-    fn add_dynamic_crate(cmd: &mut Linker, sess: &Session, cratepath: &Path) {
+    fn add_dynamic_crate(cmd: &mut dyn Linker, sess: &Session, cratepath: &Path) {
         // If we're performing LTO, then it should have been previously required
         // that all upstream rust dependencies were available in an rlib format.
         assert!(!is_full_lto_enabled(sess));
@@ -1559,7 +1559,7 @@ fn add_upstream_rust_crates(cmd: &mut Linker,
 // generic function calls a native function, then the generic function must
 // be instantiated in the target crate, meaning that the native symbol must
 // also be resolved in the target crate.
-fn add_upstream_native_libraries(cmd: &mut Linker,
+fn add_upstream_native_libraries(cmd: &mut dyn Linker,
                                  sess: &Session,
                                  codegen_results: &CodegenResults,
                                  crate_type: config::CrateType) {

--- a/src/librustc_codegen_llvm/back/linker.rs
+++ b/src/librustc_codegen_llvm/back/linker.rs
@@ -44,7 +44,7 @@ impl LinkerInfo {
 
     pub fn to_linker<'a>(&'a self,
                          cmd: Command,
-                         sess: &'a Session) -> Box<Linker+'a> {
+                         sess: &'a Session) -> Box<dyn Linker+'a> {
         match sess.linker_flavor() {
             LinkerFlavor::Lld(LldFlavor::Link) |
             LinkerFlavor::Msvc => {
@@ -52,14 +52,14 @@ impl LinkerInfo {
                     cmd,
                     sess,
                     info: self
-                }) as Box<Linker>
+                }) as Box<dyn Linker>
             }
             LinkerFlavor::Em =>  {
                 Box::new(EmLinker {
                     cmd,
                     sess,
                     info: self
-                }) as Box<Linker>
+                }) as Box<dyn Linker>
             }
             LinkerFlavor::Gcc =>  {
                 Box::new(GccLinker {
@@ -68,7 +68,7 @@ impl LinkerInfo {
                     info: self,
                     hinted_static: false,
                     is_ld: false,
-                }) as Box<Linker>
+                }) as Box<dyn Linker>
             }
 
             LinkerFlavor::Lld(LldFlavor::Ld) |
@@ -80,14 +80,14 @@ impl LinkerInfo {
                     info: self,
                     hinted_static: false,
                     is_ld: true,
-                }) as Box<Linker>
+                }) as Box<dyn Linker>
             }
 
             LinkerFlavor::Lld(LldFlavor::Wasm) => {
                 Box::new(WasmLd {
                     cmd,
                     sess,
-                }) as Box<Linker>
+                }) as Box<dyn Linker>
             }
         }
     }

--- a/src/librustc_codegen_llvm/back/rpath.rs
+++ b/src/librustc_codegen_llvm/back/rpath.rs
@@ -22,7 +22,7 @@ pub struct RPathConfig<'a> {
     pub is_like_osx: bool,
     pub has_rpath: bool,
     pub linker_is_gnu: bool,
-    pub get_install_prefix_lib_path: &'a mut FnMut() -> PathBuf,
+    pub get_install_prefix_lib_path: &'a mut dyn FnMut() -> PathBuf,
 }
 
 pub fn get_rpath_flags(config: &mut RPathConfig) -> Vec<String> {

--- a/src/librustc_codegen_llvm/base.rs
+++ b/src/librustc_codegen_llvm/base.rs
@@ -717,7 +717,7 @@ pub fn iter_globals(llmod: llvm::ModuleRef) -> ValueIter {
 }
 
 pub fn codegen_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
-                             rx: mpsc::Receiver<Box<Any + Send>>)
+                             rx: mpsc::Receiver<Box<dyn Any + Send>>)
                              -> OngoingCodegen {
 
     check_for_rustc_errors_attr(tcx);

--- a/src/librustc_codegen_llvm/intrinsic.rs
+++ b/src/librustc_codegen_llvm/intrinsic.rs
@@ -916,7 +916,7 @@ fn gen_fn<'a, 'tcx>(cx: &CodegenCx<'a, 'tcx>,
                     name: &str,
                     inputs: Vec<Ty<'tcx>>,
                     output: Ty<'tcx>,
-                    codegen: &mut for<'b> FnMut(Builder<'b, 'tcx>))
+                    codegen: &mut dyn for<'b> FnMut(Builder<'b, 'tcx>))
                     -> ValueRef {
     let rust_fn_ty = cx.tcx.mk_fn_ptr(ty::Binder::bind(cx.tcx.mk_fn_sig(
         inputs.into_iter(),
@@ -936,7 +936,7 @@ fn gen_fn<'a, 'tcx>(cx: &CodegenCx<'a, 'tcx>,
 //
 // This function is only generated once and is then cached.
 fn get_rust_try_fn<'a, 'tcx>(cx: &CodegenCx<'a, 'tcx>,
-                             codegen: &mut for<'b> FnMut(Builder<'b, 'tcx>))
+                             codegen: &mut dyn for<'b> FnMut(Builder<'b, 'tcx>))
                              -> ValueRef {
     if let Some(llfn) = cx.rust_try_fn.get() {
         return llfn;


### PR DESCRIPTION
Enforce `#![deny(bare_trait_objects)]` in `src/librustc_codegen_llvm`.