### PR TITLE
make pretty source comparison check be fatal (fixes #52255)

### DIFF
--- a/src/test/pretty/cast-lt.pp
+++ b/src/test/pretty/cast-lt.pp
@@ -3,7 +3,7 @@
 #[prelude_import]
 use std::prelude::v1::*;
 #[macro_use]
-extern crate std as std;
+extern crate std;
 // Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
@@ -21,4 +21,3 @@ extern crate std as std;
 macro_rules! negative(( $ e : expr ) => { $ e < 0 });
 
 fn main() { (1 as i32) < 0; }
-

--- a/src/test/pretty/cast-lt.rs
+++ b/src/test/pretty/cast-lt.rs
@@ -19,4 +19,3 @@ macro_rules! negative {
 fn main() {
       negative!(1 as i32);
 }
-

--- a/src/test/pretty/issue-4264.pp
+++ b/src/test/pretty/issue-4264.pp
@@ -1,7 +1,7 @@
 #[prelude_import]
 use std::prelude::v1::*;
 #[macro_use]
-extern crate std as std;
+extern crate std;
 // Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -519,9 +519,8 @@ impl<'test> TestCx<'test> {
 
     fn compare_source(&self, expected: &str, actual: &str) {
         if expected != actual {
-            self.error("pretty-printed source does not match expected source");
-            println!(
-                "\n\
+            self.fatal(&format!(
+                "pretty-printed source does not match expected source\n\
                  expected:\n\
                  ------------------------------------------\n\
                  {}\n\
@@ -531,7 +530,7 @@ impl<'test> TestCx<'test> {
                  {}\n\
                  ------------------------------------------\n\
                  \n",
-                expected, actual
+                expected, actual)
             );
         }
     }


### PR DESCRIPTION
This is not ready for merging because it reveals (at least) two regressions in the pretty suite. Should I attempt to fix those in this PR also?