### PR TITLE
Canonicalize style of a few doc comments

### DIFF
--- a/src/libcore/num/flt2dec/strategy/dragon.rs
+++ b/src/libcore/num/flt2dec/strategy/dragon.rs
@@ -8,12 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-/*!
-Almost direct (but slightly optimized) Rust translation of Figure 3 of \[1\].
-
-\[1\] Burger, R. G. and Dybvig, R. K. 1996. Printing floating-point numbers
-    quickly and accurately. SIGPLAN Not. 31, 5 (May. 1996), 108-116.
-*/
+//! Almost direct (but slightly optimized) Rust translation of Figure 3 of "Burger, R. G. and
+//! Dybvig, R. K. 1996. Printing floating-point numbers quickly and accurately. SIGPLAN Not. 31, 5
+//! (May. 1996), 108-116."
 
 use cmp::Ordering;
 

--- a/src/libcore/num/flt2dec/strategy/grisu.rs
+++ b/src/libcore/num/flt2dec/strategy/grisu.rs
@@ -8,13 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-/*!
-Rust adaptation of Grisu3 algorithm described in \[1\]. It uses about
-1KB of precomputed table, and in turn, it's very quick for most inputs.
-
-\[1\] Florian Loitsch. 2010. Printing floating-point numbers quickly and
-    accurately with integers. SIGPLAN Not. 45, 6 (June 2010), 233-243.
-*/
+//! Rust adaptation of the Grisu3 algorithm. It uses about 1KB of precomputed table, and in turn,
+//! it's very quick for most inputs.
+//! 
+//! The Grisu3 algorithm is described in "Florian Loitsch. 2010. Printing floating-point numbers
+//! quickly and accurately with integers. SIGPLAN Not. 45, 6 (June 2010), 233-243."
 
 use num::diy_float::Fp;
 use num::flt2dec::{Decoded, MAX_SIG_DIGITS, round_up};


### PR DESCRIPTION
Originally, I noticed these because they used to warn; the warning was fixed, but the comments were in the unidiomatic style, so I re-did them and changed the flow slightly too.