### PR TITLE
Deny bare trait objects in src/librustc_codegen_utils

### DIFF
--- a/src/librustc_codegen_utils/lib.rs
+++ b/src/librustc_codegen_utils/lib.rs
@@ -20,6 +20,7 @@
 #![feature(box_syntax)]
 #![feature(custom_attribute)]
 #![allow(unused_attributes)]
+#![deny(bare_trait_objects)]
 #![feature(quote)]
 #![feature(rustc_diagnostic_macros)]
 


### PR DESCRIPTION
Enforce `#![deny(bare_trait_objects)]` in `src/librustc_codegen_utils`.