### PR TITLE
rustc: Lint against `#[macro_use]` in 2018 idioms

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -322,6 +322,13 @@ declare_lint! {
     "detects proc macro derives using inaccessible names from parent modules"
 }
 
+declare_lint! {
+    pub MACRO_USE_EXTERN_CRATE,
+    Allow,
+    "the `#[macro_use]` attribute is now deprecated in favor of using macros \
+     via the module system"
+}
+
 /// Does nothing as a lint pass, but registers some `Lint`s
 /// which are used by other parts of the compiler.
 #[derive(Copy, Clone)]
@@ -379,6 +386,7 @@ impl LintPass for HardwiredLints {
             INTRA_DOC_LINK_RESOLUTION_FAILURE,
             WHERE_CLAUSES_OBJECT_SAFETY,
             PROC_MACRO_DERIVE_RESOLUTION_FALLBACK,
+            MACRO_USE_EXTERN_CRATE,
         )
     }
 }

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -43,6 +43,7 @@ extern crate syntax_pos;
 use rustc::lint;
 use rustc::lint::{LateContext, LateLintPass, LintPass, LintArray};
 use rustc::lint::builtin::{BARE_TRAIT_OBJECTS, ABSOLUTE_PATHS_NOT_STARTING_WITH_CRATE};
+use rustc::lint::builtin::MACRO_USE_EXTERN_CRATE;
 use rustc::session;
 use rustc::util;
 use rustc::hir;
@@ -179,6 +180,7 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
                     BARE_TRAIT_OBJECTS,
                     UNREACHABLE_PUB,
                     UNUSED_EXTERN_CRATES,
+                    MACRO_USE_EXTERN_CRATE,
                     ELLIPSIS_INCLUSIVE_RANGE_PATTERNS);
 
     // Guidelines for creating a future incompatibility lint:

--- a/src/test/ui/rust-2018/auxiliary/macro-use-warned-against.rs
+++ b/src/test/ui/rust-2018/auxiliary/macro-use-warned-against.rs
@@ -1,0 +1,12 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[macro_export]
+macro_rules! foo { () => () }

--- a/src/test/ui/rust-2018/auxiliary/macro-use-warned-against2.rs
+++ b/src/test/ui/rust-2018/auxiliary/macro-use-warned-against2.rs
@@ -1,0 +1,10 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+

--- a/src/test/ui/rust-2018/macro-use-warned-against.rs
+++ b/src/test/ui/rust-2018/macro-use-warned-against.rs
@@ -1,0 +1,25 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:macro-use-warned-against.rs
+// aux-build:macro-use-warned-against2.rs
+// compile-pass
+
+#![warn(rust_2018_idioms, unused)]
+#![feature(use_extern_macros)]
+
+#[macro_use] //~ WARN should be replaced at use sites with a `use` statement
+extern crate macro_use_warned_against;
+#[macro_use] //~ WARN unused `#[macro_use]`
+extern crate macro_use_warned_against2;
+
+fn main() {
+    foo!();
+}

--- a/src/test/ui/rust-2018/macro-use-warned-against.stderr
+++ b/src/test/ui/rust-2018/macro-use-warned-against.stderr
@@ -1,0 +1,26 @@
+warning: deprecated `#[macro_use]` directive used to import macros should be replaced at use sites with a `use` statement to import the macro instead
+  --> $DIR/macro-use-warned-against.rs:18:1
+   |
+LL | #[macro_use] //~ WARN should be replaced at use sites with a `use` statement
+   | ^^^^^^^^^^^^
+   |
+note: lint level defined here
+  --> $DIR/macro-use-warned-against.rs:15:9
+   |
+LL | #![warn(rust_2018_idioms, unused)]
+   |         ^^^^^^^^^^^^^^^^
+   = note: #[warn(macro_use_extern_crate)] implied by #[warn(rust_2018_idioms)]
+
+warning: unused `#[macro_use]` import
+  --> $DIR/macro-use-warned-against.rs:20:1
+   |
+LL | #[macro_use] //~ WARN unused `#[macro_use]`
+   | ^^^^^^^^^^^^
+   |
+note: lint level defined here
+  --> $DIR/macro-use-warned-against.rs:15:27
+   |
+LL | #![warn(rust_2018_idioms, unused)]
+   |                           ^^^^^^
+   = note: #[warn(unused_imports)] implied by #[warn(unused)]
+


### PR DESCRIPTION
This commit adds a lint to the compiler to warn against the `#[macro_use]`
directive as part of the `rust_2018_idioms` lint. This lint is turned off by
default and is only enabled when the `use_extern_macros` feature is also
enabled.

The lint here isn't fully fleshed out as it's just a simple warning rather than
suggestions of how to actually import the macro, but hopefully it's a good base
to start from!

cc #52043