### PR TITLE
rustc: Verify #[proc_macro] is only a word

### DIFF
--- a/src/libsyntax_ext/proc_macro_registrar.rs
+++ b/src/libsyntax_ext/proc_macro_registrar.rs
@@ -200,8 +200,8 @@ impl<'a> CollectProcMacros<'a> {
     }
 
     fn collect_attr_proc_macro(&mut self, item: &'a ast::Item, attr: &'a ast::Attribute) {
-        if let Some(_) = attr.meta_item_list() {
-            self.handler.span_err(attr.span, "`#[proc_macro_attribute]` attribute
+        if !attr.is_word() {
+            self.handler.span_err(attr.span, "`#[proc_macro_attribute]` attribute \
                 does not take any arguments");
             return;
         }
@@ -223,8 +223,8 @@ impl<'a> CollectProcMacros<'a> {
     }
 
     fn collect_bang_proc_macro(&mut self, item: &'a ast::Item, attr: &'a ast::Attribute) {
-        if let Some(_) = attr.meta_item_list() {
-            self.handler.span_err(attr.span, "`#[proc_macro]` attribute
+        if !attr.is_word() {
+            self.handler.span_err(attr.span, "`#[proc_macro]` attribute \
                 does not take any arguments");
             return;
         }

--- a/src/test/ui-fulldeps/proc-macro/invalid-attributes.rs
+++ b/src/test/ui-fulldeps/proc-macro/invalid-attributes.rs
@@ -1,0 +1,36 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+#![feature(proc_macro)]
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+
+#[proc_macro = "test"] //~ ERROR: does not take any arguments
+pub fn a(a: TokenStream) -> TokenStream { a }
+
+#[proc_macro()] //~ ERROR: does not take any arguments
+pub fn c(a: TokenStream) -> TokenStream { a }
+
+#[proc_macro(x)] //~ ERROR: does not take any arguments
+pub fn d(a: TokenStream) -> TokenStream { a }
+
+#[proc_macro_attribute = "test"] //~ ERROR: does not take any arguments
+pub fn e(_: TokenStream, a: TokenStream) -> TokenStream { a }
+
+#[proc_macro_attribute()] //~ ERROR: does not take any arguments
+pub fn g(_: TokenStream, a: TokenStream) -> TokenStream { a }
+
+#[proc_macro_attribute(x)] //~ ERROR: does not take any arguments
+pub fn h(_: TokenStream, a: TokenStream) -> TokenStream { a }

--- a/src/test/ui-fulldeps/proc-macro/invalid-attributes.stderr
+++ b/src/test/ui-fulldeps/proc-macro/invalid-attributes.stderr
@@ -1,0 +1,38 @@
+error: `#[proc_macro]` attribute does not take any arguments
+  --> $DIR/invalid-attributes.rs:20:1
+   |
+LL | #[proc_macro = "test"] //~ ERROR: does not take any arguments
+   | ^^^^^^^^^^^^^^^^^^^^^^
+
+error: `#[proc_macro]` attribute does not take any arguments
+  --> $DIR/invalid-attributes.rs:23:1
+   |
+LL | #[proc_macro()] //~ ERROR: does not take any arguments
+   | ^^^^^^^^^^^^^^^
+
+error: `#[proc_macro]` attribute does not take any arguments
+  --> $DIR/invalid-attributes.rs:26:1
+   |
+LL | #[proc_macro(x)] //~ ERROR: does not take any arguments
+   | ^^^^^^^^^^^^^^^^
+
+error: `#[proc_macro_attribute]` attribute does not take any arguments
+  --> $DIR/invalid-attributes.rs:29:1
+   |
+LL | #[proc_macro_attribute = "test"] //~ ERROR: does not take any arguments
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `#[proc_macro_attribute]` attribute does not take any arguments
+  --> $DIR/invalid-attributes.rs:32:1
+   |
+LL | #[proc_macro_attribute()] //~ ERROR: does not take any arguments
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `#[proc_macro_attribute]` attribute does not take any arguments
+  --> $DIR/invalid-attributes.rs:35:1
+   |
+LL | #[proc_macro_attribute(x)] //~ ERROR: does not take any arguments
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 6 previous errors
+


### PR DESCRIPTION
... and perform the same verification for #[proc_macro_attribute], currently
neither of these attributes take any arguments.

Closes #52273