### PR TITLE
Deny bare trait objects in librustc_driver

### DIFF
--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -100,7 +100,7 @@ pub fn spawn_thread_pool<F: FnOnce(config::Options) -> R + sync::Send, R: sync::
             // the thread local rustc uses. syntax_globals and syntax_pos_globals are
             // captured and set on the new threads. ty::tls::with_thread_locals sets up
             // thread local callbacks from libsyntax
-            let main_handler = move |worker: &mut FnMut()| {
+            let main_handler = move |worker: &mut dyn FnMut()| {
                 syntax::GLOBALS.set(syntax_globals, || {
                     syntax_pos::GLOBALS.set(syntax_pos_globals, || {
                         ty::tls::with_thread_locals(|| {

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -118,7 +118,7 @@ pub fn spawn_thread_pool<F: FnOnce(config::Options) -> R + sync::Send, R: sync::
 }
 
 pub fn compile_input(
-    codegen_backend: Box<CodegenBackend>,
+    codegen_backend: Box<dyn CodegenBackend>,
     sess: &Session,
     cstore: &CStore,
     input_path: &Option<PathBuf>,
@@ -399,10 +399,10 @@ pub struct CompileController<'a> {
 
     /// Allows overriding default rustc query providers,
     /// after `default_provide` has installed them.
-    pub provide: Box<Fn(&mut ty::query::Providers) + 'a>,
+    pub provide: Box<dyn Fn(&mut ty::query::Providers) + 'a>,
     /// Same as `provide`, but only for non-local crates,
     /// applied after `default_provide_extern`.
-    pub provide_extern: Box<Fn(&mut ty::query::Providers) + 'a>,
+    pub provide_extern: Box<dyn Fn(&mut ty::query::Providers) + 'a>,
 }
 
 impl<'a> CompileController<'a> {
@@ -471,10 +471,10 @@ impl<'a> ::CompilerCalls<'a> for CompileController<'a> {
     }
     fn late_callback(
         &mut self,
-        codegen_backend: &::CodegenBackend,
+        codegen_backend: &dyn (::CodegenBackend),
         matches: &::getopts::Matches,
         sess: &Session,
-        cstore: &::CrateStore,
+        cstore: &dyn (::CrateStore),
         input: &Input,
         odir: &Option<PathBuf>,
         ofile: &Option<PathBuf>,
@@ -496,7 +496,7 @@ pub struct PhaseController<'a> {
     // If true then the compiler will try to run the callback even if the phase
     // ends with an error. Note that this is not always possible.
     pub run_callback_on_error: bool,
-    pub callback: Box<Fn(&mut CompileState) + 'a>,
+    pub callback: Box<dyn Fn(&mut CompileState) + 'a>,
 }
 
 impl<'a> PhaseController<'a> {
@@ -1175,7 +1175,7 @@ pub fn default_provide_extern(providers: &mut ty::query::Providers) {
 /// miscellaneous analysis passes on the crate. Return various
 /// structures carrying the results of the analysis.
 pub fn phase_3_run_analysis_passes<'tcx, F, R>(
-    codegen_backend: &CodegenBackend,
+    codegen_backend: &dyn CodegenBackend,
     control: &CompileController,
     sess: &'tcx Session,
     cstore: &'tcx CrateStoreDyn,
@@ -1191,7 +1191,7 @@ where
     F: for<'a> FnOnce(
         TyCtxt<'a, 'tcx, 'tcx>,
         ty::CrateAnalysis,
-        mpsc::Receiver<Box<Any + Send>>,
+        mpsc::Receiver<Box<dyn Any + Send>>,
         CompileResult,
     ) -> R,
 {
@@ -1324,10 +1324,10 @@ where
 /// Run the codegen backend, after which the AST and analysis can
 /// be discarded.
 pub fn phase_4_codegen<'a, 'tcx>(
-    codegen_backend: &CodegenBackend,
+    codegen_backend: &dyn CodegenBackend,
     tcx: TyCtxt<'a, 'tcx, 'tcx>,
-    rx: mpsc::Receiver<Box<Any + Send>>,
-) -> Box<Any> {
+    rx: mpsc::Receiver<Box<dyn Any + Send>>,
+) -> Box<dyn Any> {
     time(tcx.sess, "resolving dependency formats", || {
         ::rustc::middle::dependency_format::calculate(tcx)
     });

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -14,6 +14,8 @@
 //!
 //! This API is completely unstable and subject to change.
 
+#![deny(bare_trait_objects)]
+
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
       html_root_url = "https://doc.rust-lang.org/nightly/")]
@@ -131,7 +133,7 @@ pub mod target_features {
     /// features is available on the target machine, by querying LLVM.
     pub fn add_configuration(cfg: &mut ast::CrateConfig,
                              sess: &Session,
-                             codegen_backend: &CodegenBackend) {
+                             codegen_backend: &dyn CodegenBackend) {
         let tf = Symbol::intern("target_feature");
 
         for feat in codegen_backend.target_features(sess) {
@@ -202,7 +204,7 @@ pub fn run<F>(run_compiler: F) -> isize
     0
 }
 
-fn load_backend_from_dylib(path: &Path) -> fn() -> Box<CodegenBackend> {
+fn load_backend_from_dylib(path: &Path) -> fn() -> Box<dyn CodegenBackend> {
     // Note that we're specifically using `open_global_now` here rather than
     // `open`, namely we want the behavior on Unix of RTLD_GLOBAL and RTLD_NOW,
     // where NOW means "bind everything right now" because we don't want
@@ -235,12 +237,12 @@ fn load_backend_from_dylib(path: &Path) -> fn() -> Box<CodegenBackend> {
     }
 }
 
-pub fn get_codegen_backend(sess: &Session) -> Box<CodegenBackend> {
+pub fn get_codegen_backend(sess: &Session) -> Box<dyn CodegenBackend> {
     static INIT: Once = ONCE_INIT;
 
     #[allow(deprecated)]
     #[no_debug]
-    static mut LOAD: fn() -> Box<CodegenBackend> = || unreachable!();
+    static mut LOAD: fn() -> Box<dyn CodegenBackend> = || unreachable!();
 
     INIT.call_once(|| {
         let codegen_name = sess.opts.debugging_opts.codegen_backend.as_ref()
@@ -264,7 +266,7 @@ pub fn get_codegen_backend(sess: &Session) -> Box<CodegenBackend> {
     backend
 }
 
-fn get_codegen_sysroot(backend_name: &str) -> fn() -> Box<CodegenBackend> {
+fn get_codegen_sysroot(backend_name: &str) -> fn() -> Box<dyn CodegenBackend> {
     // For now we only allow this function to be called once as it'll dlopen a
     // few things, which seems to work best if we only do that once. In
     // general this assertion never trips due to the once guard in `get_codegen_backend`,
@@ -454,9 +456,9 @@ fn get_codegen_sysroot(backend_name: &str) -> fn() -> Box<CodegenBackend> {
 // See comments on CompilerCalls below for details about the callbacks argument.
 // The FileLoader provides a way to load files from sources other than the file system.
 pub fn run_compiler<'a>(args: &[String],
-                        callbacks: Box<CompilerCalls<'a> + sync::Send + 'a>,
-                        file_loader: Option<Box<FileLoader + Send + Sync + 'static>>,
-                        emitter_dest: Option<Box<Write + Send>>)
+                        callbacks: Box<dyn CompilerCalls<'a> + sync::Send + 'a>,
+                        file_loader: Option<Box<dyn FileLoader + Send + Sync + 'static>>,
+                        emitter_dest: Option<Box<dyn Write + Send>>)
                         -> (CompileResult, Option<Session>)
 {
     syntax::with_globals(|| {
@@ -478,9 +480,9 @@ fn run_compiler_with_pool<'a>(
     matches: getopts::Matches,
     sopts: config::Options,
     cfg: ast::CrateConfig,
-    mut callbacks: Box<CompilerCalls<'a> + sync::Send + 'a>,
-    file_loader: Option<Box<FileLoader + Send + Sync + 'static>>,
-    emitter_dest: Option<Box<Write + Send>>
+    mut callbacks: Box<dyn CompilerCalls<'a> + sync::Send + 'a>,
+    file_loader: Option<Box<dyn FileLoader + Send + Sync + 'static>>,
+    emitter_dest: Option<Box<dyn Write + Send>>
 ) -> (CompileResult, Option<Session>) {
     macro_rules! do_or_return {($expr: expr, $sess: expr) => {
         match $expr {
@@ -662,10 +664,10 @@ pub trait CompilerCalls<'a> {
     /// be called just before actual compilation starts (and before build_controller
     /// is called), after all arguments etc. have been completely handled.
     fn late_callback(&mut self,
-                     _: &CodegenBackend,
+                     _: &dyn CodegenBackend,
                      _: &getopts::Matches,
                      _: &Session,
-                     _: &CrateStore,
+                     _: &dyn CrateStore,
                      _: &Input,
                      _: &Option<PathBuf>,
                      _: &Option<PathBuf>)
@@ -870,10 +872,10 @@ impl<'a> CompilerCalls<'a> for RustcDefaultCalls {
     }
 
     fn late_callback(&mut self,
-                     codegen_backend: &CodegenBackend,
+                     codegen_backend: &dyn CodegenBackend,
                      matches: &getopts::Matches,
                      sess: &Session,
-                     cstore: &CrateStore,
+                     cstore: &dyn CrateStore,
                      input: &Input,
                      odir: &Option<PathBuf>,
                      ofile: &Option<PathBuf>)
@@ -979,7 +981,7 @@ pub fn enable_save_analysis(control: &mut CompileController) {
 
 impl RustcDefaultCalls {
     pub fn list_metadata(sess: &Session,
-                         cstore: &CrateStore,
+                         cstore: &dyn CrateStore,
                          matches: &getopts::Matches,
                          input: &Input)
                          -> Compilation {
@@ -1007,7 +1009,7 @@ impl RustcDefaultCalls {
     }
 
 
-    fn print_crate_info(codegen_backend: &CodegenBackend,
+    fn print_crate_info(codegen_backend: &dyn CodegenBackend,
                         sess: &Session,
                         input: Option<&Input>,
                         odir: &Option<PathBuf>,
@@ -1486,7 +1488,7 @@ fn parse_crate_attrs<'a>(sess: &'a Session, input: &Input) -> PResult<'a, Vec<as
 /// Runs `f` in a suitable thread for running `rustc`; returns a
 /// `Result` with either the return value of `f` or -- if a panic
 /// occurs -- the panic value.
-pub fn in_rustc_thread<F, R>(f: F) -> Result<R, Box<Any + Send>>
+pub fn in_rustc_thread<F, R>(f: F) -> Result<R, Box<dyn Any + Send>>
     where F: FnOnce() -> R + Send + 'static,
           R: Send + 'static,
 {

--- a/src/librustc_driver/test.rs
+++ b/src/librustc_driver/test.rs
@@ -88,13 +88,13 @@ impl Emitter for ExpectErrorEmitter {
     }
 }
 
-fn errors(msgs: &[&str]) -> (Box<Emitter + sync::Send>, usize) {
+fn errors(msgs: &[&str]) -> (Box<dyn Emitter + sync::Send>, usize) {
     let v = msgs.iter().map(|m| m.to_string()).collect();
-    (box ExpectErrorEmitter { messages: v } as Box<Emitter + sync::Send>, msgs.len())
+    (box ExpectErrorEmitter { messages: v } as Box<dyn Emitter + sync::Send>, msgs.len())
 }
 
 fn test_env<F>(source_string: &str,
-               args: (Box<Emitter + sync::Send>, usize),
+               args: (Box<dyn Emitter + sync::Send>, usize),
                body: F)
     where F: FnOnce(Env)
 {
@@ -112,7 +112,7 @@ fn test_env<F>(source_string: &str,
 fn test_env_with_pool<F>(
     options: config::Options,
     source_string: &str,
-    (emitter, expected_err_count): (Box<Emitter + sync::Send>, usize),
+    (emitter, expected_err_count): (Box<dyn Emitter + sync::Send>, usize),
     body: F
 )
     where F: FnOnce(Env)


### PR DESCRIPTION
Enforce `#![deny(bare_trait_objects)]` in `src/librustc_driver`.