### PR TITLE
Deny bare trait objects in src/librustc_errors

### DIFF
--- a/src/librustc_errors/diagnostic.rs
+++ b/src/librustc_errors/diagnostic.rs
@@ -121,7 +121,7 @@ impl Diagnostic {
     }
 
     pub fn note_expected_found(&mut self,
-                               label: &fmt::Display,
+                               label: &dyn fmt::Display,
                                expected: DiagnosticStyledString,
                                found: DiagnosticStyledString)
                                -> &mut Self
@@ -130,11 +130,11 @@ impl Diagnostic {
     }
 
     pub fn note_expected_found_extra(&mut self,
-                                     label: &fmt::Display,
+                                     label: &dyn fmt::Display,
                                      expected: DiagnosticStyledString,
                                      found: DiagnosticStyledString,
-                                     expected_extra: &fmt::Display,
-                                     found_extra: &fmt::Display)
+                                     expected_extra: &dyn fmt::Display,
+                                     found_extra: &dyn fmt::Display)
                                      -> &mut Self
     {
         let mut msg: Vec<_> = vec![(format!("expected {} `", label), Style::NoStyle)];

--- a/src/librustc_errors/diagnostic_builder.rs
+++ b/src/librustc_errors/diagnostic_builder.rs
@@ -148,17 +148,17 @@ impl<'a> DiagnosticBuilder<'a> {
     }
 
     forward!(pub fn note_expected_found(&mut self,
-                                        label: &fmt::Display,
+                                        label: &dyn fmt::Display,
                                         expected: DiagnosticStyledString,
                                         found: DiagnosticStyledString)
                                         -> &mut Self);
 
     forward!(pub fn note_expected_found_extra(&mut self,
-                                              label: &fmt::Display,
+                                              label: &dyn fmt::Display,
                                               expected: DiagnosticStyledString,
                                               found: DiagnosticStyledString,
-                                              expected_extra: &fmt::Display,
-                                              found_extra: &fmt::Display)
+                                              expected_extra: &dyn fmt::Display,
+                                              found_extra: &dyn fmt::Display)
                                               -> &mut Self);
 
     forward!(pub fn note(&mut self, msg: &str) -> &mut Self);

--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -148,7 +148,7 @@ impl EmitterWriter {
         }
     }
 
-    pub fn new(dst: Box<Write + Send>,
+    pub fn new(dst: Box<dyn Write + Send>,
                code_map: Option<Lrc<CodeMapperDyn>>,
                short_message: bool,
                teach: bool)
@@ -1469,13 +1469,13 @@ fn emit_to_destination(rendered_buffer: &Vec<Vec<StyledString>>,
 pub enum Destination {
     Terminal(StandardStream),
     Buffered(BufferWriter),
-    Raw(Box<Write + Send>),
+    Raw(Box<dyn Write + Send>),
 }
 
 pub enum WritableDst<'a> {
     Terminal(&'a mut StandardStream),
     Buffered(&'a mut BufferWriter, Buffer),
-    Raw(&'a mut Box<Write + Send>),
+    Raw(&'a mut Box<dyn Write + Send>),
 }
 
 impl Destination {

--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![deny(bare_trait_objects)]
+
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
       html_root_url = "https://doc.rust-lang.org/nightly/")]
@@ -110,7 +112,7 @@ pub struct SubstitutionPart {
     pub snippet: String,
 }
 
-pub type CodeMapperDyn = CodeMapper + sync::Send + sync::Sync;
+pub type CodeMapperDyn = dyn CodeMapper + sync::Send + sync::Sync;
 
 pub trait CodeMapper {
     fn lookup_char_pos(&self, pos: BytePos) -> Loc;
@@ -270,7 +272,7 @@ pub struct Handler {
     pub flags: HandlerFlags,
 
     err_count: AtomicUsize,
-    emitter: Lock<Box<Emitter + sync::Send>>,
+    emitter: Lock<Box<dyn Emitter + sync::Send>>,
     continue_after_error: LockCell<bool>,
     delayed_span_bug: Lock<Option<Diagnostic>>,
 
@@ -326,7 +328,7 @@ impl Handler {
 
     pub fn with_emitter(can_emit_warnings: bool,
                         treat_err_as_bug: bool,
-                        e: Box<Emitter + sync::Send>)
+                        e: Box<dyn Emitter + sync::Send>)
                         -> Handler {
         Handler::with_emitter_and_flags(
             e,
@@ -337,7 +339,8 @@ impl Handler {
             })
     }
 
-    pub fn with_emitter_and_flags(e: Box<Emitter + sync::Send>, flags: HandlerFlags) -> Handler {
+    pub fn with_emitter_and_flags(e: Box<dyn Emitter + sync::Send>, flags: HandlerFlags) -> Handler
+    {
         Handler {
             flags,
             err_count: AtomicUsize::new(0),

--- a/src/librustc_errors/lock.rs
+++ b/src/librustc_errors/lock.rs
@@ -23,7 +23,7 @@ use std::any::Any;
 
 #[cfg(windows)]
 #[allow(bad_style)]
-pub fn acquire_global_lock(name: &str) -> Box<Any> {
+pub fn acquire_global_lock(name: &str) -> Box<dyn Any> {
     use std::ffi::CString;
     use std::io;
 
@@ -110,6 +110,6 @@ pub fn acquire_global_lock(name: &str) -> Box<Any> {
 }
 
 #[cfg(unix)]
-pub fn acquire_global_lock(_name: &str) -> Box<Any> {
+pub fn acquire_global_lock(_name: &str) -> Box<dyn Any> {
     Box::new(())
 }


### PR DESCRIPTION
Enforce `#![deny(bare_trait_objects)]` in `src/librustc_errors`.