### PR TITLE
Deny bare trait objects in src/librustc_save_analysis

### DIFF
--- a/src/librustc_save_analysis/json_dumper.rs
+++ b/src/librustc_save_analysis/json_dumper.rs
@@ -46,7 +46,7 @@ impl<'b, W: Write> DumpOutput for WriteOutput<'b, W> {
 }
 
 pub struct CallbackOutput<'b> {
-    callback: &'b mut FnMut(&Analysis),
+    callback: &'b mut dyn FnMut(&Analysis),
 }
 
 impl<'b> DumpOutput for CallbackOutput<'b> {
@@ -67,7 +67,7 @@ impl<'b, W: Write> JsonDumper<WriteOutput<'b, W>> {
 
 impl<'b> JsonDumper<CallbackOutput<'b>> {
     pub fn with_callback(
-        callback: &'b mut FnMut(&Analysis),
+        callback: &'b mut dyn FnMut(&Analysis),
         config: Config,
     ) -> JsonDumper<CallbackOutput<'b>> {
         JsonDumper {

--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -13,6 +13,7 @@
        html_root_url = "https://doc.rust-lang.org/nightly/")]
 #![feature(custom_attribute)]
 #![allow(unused_attributes)]
+#![deny(bare_trait_objects)]
 
 #![recursion_limit="256"]
 
@@ -1088,7 +1089,7 @@ impl<'a> SaveHandler for DumpHandler<'a> {
 
 /// Call a callback with the results of save-analysis.
 pub struct CallbackHandler<'b> {
-    pub callback: &'b mut FnMut(&rls_data::Analysis),
+    pub callback: &'b mut dyn FnMut(&rls_data::Analysis),
 }
 
 impl<'b> SaveHandler for CallbackHandler<'b> {


### PR DESCRIPTION
Enforce `#![deny(bare_trait_objects)]` in `src/librustc_save_analysis`.