### PR TITLE
Deny bare trait objects in librustc_target and libtest

### DIFF
--- a/src/librustc_target/lib.rs
+++ b/src/librustc_target/lib.rs
@@ -21,6 +21,8 @@
 //! one that doesn't; the one that doesn't might get decent parallel
 //! build speedups.
 
+#![deny(bare_trait_objects)]
+
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
       html_root_url = "https://doc.rust-lang.org/nightly/")]

--- a/src/librustc_target/spec/mod.rs
+++ b/src/librustc_target/spec/mod.rs
@@ -229,7 +229,7 @@ macro_rules! supported_targets {
             }
         }
 
-        pub fn get_targets() -> Box<Iterator<Item=String>> {
+        pub fn get_targets() -> Box<dyn Iterator<Item=String>> {
             Box::new(TARGETS.iter().filter_map(|t| -> Option<String> {
                 load_specific(t)
                     .and(Ok(t.to_string()))


### PR DESCRIPTION
Enforce `#![deny(bare_trait_objects)]` in `src/librustc_target` and `src/libtest`.