### PR TITLE
[beta] Rollup backports

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -3,26 +3,26 @@ Version 1.28.0 (2018-08-02)
 
 Language
 --------
-- [Stabilised the `#[repr(transparent)]` attribute.][51562] This attribute
+- [The `#[repr(transparent)]` attribute is now stable.][51562] This attribute
   allows a Rust newtype wrapper (`struct NewType<T>(T);`) to be represented as
   the inner type across Foreign Function Interface (FFI) boundaries.
 - [The keywords `pure`, `sizeof`, `alignof`, and `offsetof` have been unreserved
   and can now be used as identifiers.][51196]
-- [Stabilised the `GlobalAlloc` trait and `#[global_allocator]`
-  attribute.][51241] This will allow users to specify a global allocator for
+- [The `GlobalAlloc` trait and `#[global_allocator]` attribute are now
+  stable.][51241] This will allow users to specify a global allocator for
   their program.
 - [Unit test functions marked with the `#[test]` attribute can now return
   `Result<(), E: Debug>` in addition to `()`.][51298]
-- [Stabilised a `lifetime` specifier to `macro_rules!` allowing macros to easily
-  target lifetimes.][50385]
+- [The `lifetime` specifier for `macro_rules!` is now stable.][50385] This
+  allows macros to easily target lifetimes.
 
 Compiler
 --------
-- [Stabilised the `s` and `z` optimisation levels.][50265] These optimisations
+- [The `s` and `z` optimisation levels are now stable.][50265] These optimisations
   prioritise making smaller binary sizes. `z` is the same as `s` with the
   exception that it does not vectorise loops, which typically results in an even
   smaller binary.
-- [Stabilised the short error format.][49546] Specified with
+- [The short error format is now stable.][49546] Specified with
   `--error-format=short` this option will provide a more compressed output of
   rust error messages.
 - [Added a lint warning when you have duplicated `macro_export`s.][50143]
@@ -77,9 +77,9 @@ Cargo
 
 Misc
 ----
-- [Stabilised the `suggestion_applicability` field in the json output.][50486]
-  This will allow dev tools to check whether a code suggestion would apply
-  to them.
+- [The `suggestion_applicability` field in `rustc`'s json output is now
+  stable.][50486] This will allow dev tools to check whether a code suggestion
+  would apply to them.
 
 Compatibility Notes
 -------------------
@@ -329,7 +329,7 @@ Language
 - [Closures now implement `Copy` and/or `Clone` if all captured variables
   implement either or both traits.][49299]
 - [The inclusive range syntax e.g. `for x in 0..=10` is now stable.][47813]
-- [Stablise `'_`. The underscore lifetime can be used anywhere where a
+- [The `'_` lifetime is now stable. The underscore lifetime can be used anywhere where a
   lifetime can be elided.][49458]
 - [`impl Trait` is now stable allowing you to have abstract types in returns
    or in function parameters.][49255] e.g. `fn foo() -> impl Iterator<Item=u8>` or
@@ -530,7 +530,7 @@ Version 1.25.0 (2018-03-29)
 
 Language
 --------
-- [Stabilised `#[repr(align(x))]`.][47006] [RFC 1358]
+- [The `#[repr(align(x))]` attribute is now stable.][47006] [RFC 1358]
 - [You can now use nested groups of imports.][47948]
   e.g. `use std::{fs::File, io::Read, path::{Path, PathBuf}};`
 - [You can now have `|` at the start of a match arm.][47947] e.g.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -42,6 +42,8 @@ Libraries
   for `Cow<CStr>`, `From<OsString>, From<OsStr>, From<&OsString>` for
   `Cow<OsStr>`, `From<&PathBuf>` for `Cow<Path>`, and `From<Cow<Path>>`
   for `PathBuf`.][50170]
+- [Implemented `Shl` and `Shr` for `Wrapping<u128>`
+  and `Wrapping<i128>`.][50465]
 - [`DirEntry::metadata` now uses `fstatat` instead of `lstat` when
   possible.][51050] This can provide up to a 40% speed increase.
 - [Improved error messages when using `format!`.][50610]
@@ -70,7 +72,7 @@ Stabilized APIs
 Cargo
 -----
 - [Cargo will now no longer allow you to publish crates with build scripts that
-  modify the `src` directory.][5584] The `src` directory in a crate should be
+  modify the `src` directory.][cargo/5584] The `src` directory in a crate should be
   considered to be immutable.
 
 Misc
@@ -103,6 +105,7 @@ Compatibility Notes
 [50265]: https://github.com/rust-lang/rust/pull/50265/
 [50364]: https://github.com/rust-lang/rust/pull/50364/
 [50385]: https://github.com/rust-lang/rust/pull/50385/
+[50465]: https://github.com/rust-lang/rust/pull/50465/
 [50486]: https://github.com/rust-lang/rust/pull/50486/
 [50554]: https://github.com/rust-lang/rust/pull/50554/
 [50610]: https://github.com/rust-lang/rust/pull/50610/
@@ -115,7 +118,7 @@ Compatibility Notes
 [51298]: https://github.com/rust-lang/rust/pull/51298/
 [51306]: https://github.com/rust-lang/rust/pull/51306/
 [51562]: https://github.com/rust-lang/rust/pull/51562/
-[5584]: https://github.com/rust-lang/cargo/pull/5584/
+[cargo/5584]: https://github.com/rust-lang/cargo/pull/5584/
 [`Iterator::step_by`]: https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.step_by
 [`Path::ancestors`]: https://doc.rust-lang.org/std/path/struct.Path.html#method.ancestors
 [`btree_map::Entry::or_default`]: https://doc.rust-lang.org/std/collections/btree_map/enum.Entry.html#method.or_default

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,141 @@
+Version 1.28.0 (2018-08-02)
+===========================
+
+Language
+--------
+- [Stabilised the `#[repr(transparent)]` attribute.][51562] This attribute
+  allows a Rust newtype wrapper (`struct NewType<T>(T);`) to be represented as
+  the inner type across Foreign Function Interface (FFI) boundaries.
+- [The keywords `pure`, `sizeof`, `alignof`, and `offsetof` have been unreserved
+  and can now be used as identifiers.][51196]
+- [Stabilised the `GlobalAlloc` trait and `#[global_allocator]`
+  attribute.][51241] This will allow users to specify a global allocator for
+  their program.
+- [Unit test functions marked with the `#[test]` attribute can now return
+  `Result<(), E: Debug>` in addition to `()`.][51298]
+- [Stabilised a `lifetime` specifier to `macro_rules!` allowing macros to easily
+  target lifetimes.][50385]
+
+Compiler
+--------
+- [Stabilised the `s` and `z` optimisation levels.][50265] These optimisations
+  prioritise making smaller binary sizes. `z` is the same as `s` with the
+  exception that it does not vectorise loops, which typically results in an even
+  smaller binary.
+- [Stabilised the short error format.][49546] Specified with
+  `--error-format=short` this option will provide a more compressed output of
+  rust error messages.
+- [Added a lint warning when you have duplicated `macro_export`s.][50143]
+- [Reduced the number of allocations in the macro parser.][50855] This can
+  improve compile times of macro heavy crates on average by 5%.
+
+Libraries
+---------
+- [Implemented `Default` for `&mut str`.][51306]
+- [Implemented `From<bool>` for all integer and unsigned number types.][50554]
+- [Implemented `Extend` for `()`.][50234]
+- [The `Debug` implementation of `time::Duration` should now be more easily
+  human readable.][50364] Previously a `Duration` of one second would printed as
+  `Duration { secs: 1, nanos: 0 }` will now be printed as `1s`.
+- [Implemented `From<&String>` for `Cow<str>`, `From<&Vec<T>>` for `Cow<[T]>`,
+  `From<Cow<CStr>>` for `CString`, `From<CString>, From<CStr>, From<&CString>`
+  for `Cow<CStr>`, `From<OsString>, From<OsStr>, From<&OsString>` for
+  `Cow<OsStr>`, `From<&PathBuf>` for `Cow<Path>`, and `From<Cow<Path>>`
+  for `PathBuf`.][50170]
+- [`DirEntry::metadata` now uses `fstatat` instead of `lstat` when
+  possible.][51050] This can provide up to a 40% speed increase.
+- [Improved error messages when using `format!`.][50610]
+
+Stabilized APIs
+---------------
+- [`Iterator::step_by`]
+- [`Path::ancestors`]
+- [`btree_map::Entry::or_default`]
+- [`fmt::Alignment`]
+- [`hash_map::Entry::or_default`]
+- [`iter::repeat_with`]
+- [`num::NonZeroU128`]
+- [`num::NonZeroU16`]
+- [`num::NonZeroU32`]
+- [`num::NonZeroU64`]
+- [`num::NonZeroU8`]
+- [`ops::RangeBounds`]
+- [`slice::SliceIndex`]
+- [`slice::from_mut`]
+- [`slice::from_ref`]
+- [`{Any + Send + Sync}::downcast_mut`]
+- [`{Any + Send + Sync}::downcast_ref`]
+- [`{Any + Send + Sync}::is`]
+
+Cargo
+-----
+- [Cargo will now no longer allow you to publish crates with build scripts that
+  modify the `src` directory.][5584] The `src` directory in a crate should be
+  considered to be immutable.
+
+Misc
+----
+- [Stabilised the `suggestion_applicability` field in the json output.][50486]
+  This will allow dev tools to check whether a code suggestion would apply
+  to them.
+
+Compatibility Notes
+-------------------
+- [Rust will no longer consider trait objects with duplicated constraints to
+  have implementations.][51276] For example the below code will now fail
+  to compile.
+  ```rust
+  trait Trait {}
+
+  impl Trait + Send {
+      fn test(&self) { println!("one"); } //~ ERROR duplicate definitions with name `test`
+  }
+
+  impl Trait + Send + Send {
+      fn test(&self) { println!("two"); }
+  }
+  ```
+
+[49546]: https://github.com/rust-lang/rust/pull/49546/
+[50143]: https://github.com/rust-lang/rust/pull/50143/
+[50170]: https://github.com/rust-lang/rust/pull/50170/
+[50234]: https://github.com/rust-lang/rust/pull/50234/
+[50265]: https://github.com/rust-lang/rust/pull/50265/
+[50364]: https://github.com/rust-lang/rust/pull/50364/
+[50385]: https://github.com/rust-lang/rust/pull/50385/
+[50486]: https://github.com/rust-lang/rust/pull/50486/
+[50554]: https://github.com/rust-lang/rust/pull/50554/
+[50610]: https://github.com/rust-lang/rust/pull/50610/
+[50855]: https://github.com/rust-lang/rust/pull/50855/
+[51050]: https://github.com/rust-lang/rust/pull/51050/
+[51196]: https://github.com/rust-lang/rust/pull/51196/
+[51200]: https://github.com/rust-lang/rust/pull/51200/
+[51241]: https://github.com/rust-lang/rust/pull/51241/
+[51276]: https://github.com/rust-lang/rust/pull/51276/
+[51298]: https://github.com/rust-lang/rust/pull/51298/
+[51306]: https://github.com/rust-lang/rust/pull/51306/
+[51562]: https://github.com/rust-lang/rust/pull/51562/
+[5584]: https://github.com/rust-lang/cargo/pull/5584/
+[`Iterator::step_by`]: https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.step_by
+[`Path::ancestors`]: https://doc.rust-lang.org/std/path/struct.Path.html#method.ancestors
+[`btree_map::Entry::or_default`]: https://doc.rust-lang.org/std/collections/btree_map/enum.Entry.html#method.or_default
+[`fmt::Alignment`]: https://doc.rust-lang.org/std/fmt/enum.Alignment.html
+[`hash_map::Entry::or_default`]: https://doc.rust-lang.org/std/collections/btree_map/enum.Entry.html#method.or_default
+[`iter::repeat_with`]: https://doc.rust-lang.org/std/iter/fn.repeat_with.html
+[`num::NonZeroU128`]: https://doc.rust-lang.org/std/num/struct.NonZeroU128.html
+[`num::NonZeroU16`]: https://doc.rust-lang.org/std/num/struct.NonZeroU16.html
+[`num::NonZeroU32`]: https://doc.rust-lang.org/std/num/struct.NonZeroU32.html
+[`num::NonZeroU64`]: https://doc.rust-lang.org/std/num/struct.NonZeroU64.html
+[`num::NonZeroU8`]: https://doc.rust-lang.org/std/num/struct.NonZeroU8.html
+[`ops::RangeBounds`]: https://doc.rust-lang.org/std/ops/trait.RangeBounds.html
+[`slice::SliceIndex`]: https://doc.rust-lang.org/std/slice/trait.SliceIndex.html
+[`slice::from_mut`]: https://doc.rust-lang.org/std/slice/fn.from_mut.html
+[`slice::from_ref`]: https://doc.rust-lang.org/std/slice/fn.from_ref.html
+[`{Any + Send + Sync}::downcast_mut`]: https://doc.rust-lang.org/std/any/trait.Any.html#method.downcast_mut-2
+[`{Any + Send + Sync}::downcast_ref`]: https://doc.rust-lang.org/std/any/trait.Any.html#method.downcast_ref-2
+[`{Any + Send + Sync}::is`]: https://doc.rust-lang.org/std/any/trait.Any.html#method.is-2
+
+
 Version 1.27.0 (2018-06-21)
 ==========================
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -36,7 +36,7 @@ Libraries
 - [Implemented `Extend` for `()`.][50234]
 - [The `Debug` implementation of `time::Duration` should now be more easily
   human readable.][50364] Previously a `Duration` of one second would printed as
-  `Duration { secs: 1, nanos: 0 }` will now be printed as `1s`.
+  `Duration { secs: 1, nanos: 0 }` and will now be printed as `1s`.
 - [Implemented `From<&String>` for `Cow<str>`, `From<&Vec<T>>` for `Cow<[T]>`,
   `From<Cow<CStr>>` for `CString`, `From<CString>, From<CStr>, From<&CString>`
   for `Cow<CStr>`, `From<OsString>, From<OsStr>, From<&OsString>` for

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -140,6 +140,29 @@ Compatibility Notes
 [`{Any + Send + Sync}::downcast_ref`]: https://doc.rust-lang.org/std/any/trait.Any.html#method.downcast_ref-2
 [`{Any + Send + Sync}::is`]: https://doc.rust-lang.org/std/any/trait.Any.html#method.is-2
 
+Version 1.27.1 (2018-07-10)
+===========================
+
+Security Notes
+--------------
+
+- rustdoc would execute plugins in the /tmp/rustdoc/plugins directory
+  when running, which enabled executing code as some other user on a
+  given machine. This release fixes that vulnerability; you can read
+  more about this on the [blog][rustdoc-sec]. The associated CVE is [CVE-2018-1000622].
+
+  Thank you to Red Hat for responsibily disclosing this vulnerability to us.
+
+Compatibility Notes
+-------------------
+
+- The borrow checker was fixed to avoid an additional potential unsoundness when using
+  match ergonomics: [#51415][51415], [#49534][49534].
+
+[51415]: https://github.com/rust-lang/rust/issues/51415
+[49534]: https://github.com/rust-lang/rust/issues/49534
+[rustdoc-sec]: https://blog.rust-lang.org/2018/07/06/security-advisory-for-rustdoc.html
+[CVE-2018-1000622]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=%20CVE-2018-1000622
 
 Version 1.27.0 (2018-06-21)
 ==========================

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -56,6 +56,7 @@ Stabilized APIs
 - [`fmt::Alignment`]
 - [`hash_map::Entry::or_default`]
 - [`iter::repeat_with`]
+- [`num::NonZeroUsize`]
 - [`num::NonZeroU128`]
 - [`num::NonZeroU16`]
 - [`num::NonZeroU32`]
@@ -125,6 +126,7 @@ Compatibility Notes
 [`fmt::Alignment`]: https://doc.rust-lang.org/std/fmt/enum.Alignment.html
 [`hash_map::Entry::or_default`]: https://doc.rust-lang.org/std/collections/btree_map/enum.Entry.html#method.or_default
 [`iter::repeat_with`]: https://doc.rust-lang.org/std/iter/fn.repeat_with.html
+[`num::NonZeroUsize`]: https://doc.rust-lang.org/std/num/struct.NonZeroUsize.html
 [`num::NonZeroU128`]: https://doc.rust-lang.org/std/num/struct.NonZeroU128.html
 [`num::NonZeroU16`]: https://doc.rust-lang.org/std/num/struct.NonZeroU16.html
 [`num::NonZeroU32`]: https://doc.rust-lang.org/std/num/struct.NonZeroU32.html

--- a/src/libcore/iter/iterator.rs
+++ b/src/libcore/iter/iterator.rs
@@ -271,8 +271,29 @@ pub trait Iterator {
     /// Creates an iterator starting at the same point, but stepping by
     /// the given amount at each iteration.
     ///
-    /// Note that it will always return the first element of the iterator,
+    /// Note 1: The first element of the iterator will always be returned,
     /// regardless of the step given.
+    ///
+    /// Note 2: The time at which ignored elements are pulled is not fixed.
+    /// `StepBy` behaves like the sequence `next(), nth(step-1), nth(step-1), …`,
+    /// but is also free to behave like the sequence
+    /// `advance_n_and_return_first(step), advance_n_and_return_first(step), …`
+    /// Which way is used may change for some iterators for performance reasons.
+    /// The second way will advance the iterator earlier and may consume more items.
+    ///
+    /// `advance_n_and_return_first` is the equivalent of:
+    /// ```
+    /// fn advance_n_and_return_first<I>(iter: &mut I, total_step: usize) -> Option<I::Item>
+    /// where
+    ///     I: Iterator,
+    /// {
+    ///     let next = iter.next();
+    ///     if total_step > 1 {
+    ///         iter.nth(total_step-2);
+    ///     }
+    ///     next
+    /// }
+    /// ```
     ///
     /// # Panics
     ///

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -159,7 +159,7 @@ pub fn opts() -> Vec<RustcOptGroup> {
             o.optmulti("", "extern", "pass an --extern to rustc", "NAME=PATH")
         }),
         stable("plugin-path", |o| {
-            o.optmulti("", "plugin-path", "directory to load plugins from", "DIR")
+            o.optmulti("", "plugin-path", "removed", "DIR")
         }),
         stable("C", |o| {
             o.optmulti("C", "codegen", "pass a codegen option to rustc", "OPT[=VALUE]")
@@ -172,7 +172,7 @@ pub fn opts() -> Vec<RustcOptGroup> {
                        "PASSES")
         }),
         stable("plugins", |o| {
-            o.optmulti("", "plugins", "space separated list of plugins to also load",
+            o.optmulti("", "plugins", "removed",
                        "PLUGINS")
         }),
         stable("no-default", |o| {
@@ -710,9 +710,16 @@ where R: 'static + Send,
             }
         }
 
+        if !plugins.is_empty() {
+            eprintln!("WARNING: --plugins no longer functions; see CVE-2018-1000622");
+        }
+
+        if !plugin_path.is_none() {
+            eprintln!("WARNING: --plugin-path no longer functions; see CVE-2018-1000622");
+        }
+
         // Load all plugins/passes into a PluginManager
-        let path = plugin_path.unwrap_or("/tmp/rustdoc/plugins".to_string());
-        let mut pm = plugins::PluginManager::new(PathBuf::from(path));
+        let mut pm = plugins::PluginManager::new();
         for pass in &passes {
             let plugin = match passes::PASSES.iter()
                                              .position(|&(p, ..)| {
@@ -725,10 +732,6 @@ where R: 'static + Send,
                 },
             };
             pm.add_plugin(plugin);
-        }
-        info!("loading plugins...");
-        for pname in plugins {
-            pm.load_plugin(pname);
         }
 
         // Run everything!
@@ -745,8 +748,6 @@ fn check_deprecated_options(matches: &getopts::Matches, diag: &errors::Handler) 
     let deprecated_flags = [
        "input-format",
        "output-format",
-       "plugin-path",
-       "plugins",
        "no-defaults",
        "passes",
     ];

--- a/src/librustdoc/plugins.rs
+++ b/src/librustdoc/plugins.rs
@@ -12,47 +12,20 @@
 
 use clean;
 
-use std::mem;
-use std::string::String;
-use std::path::PathBuf;
-
-use rustc_metadata::dynamic_lib as dl;
-
 pub type PluginResult = clean::Crate;
 pub type PluginCallback = fn (clean::Crate) -> PluginResult;
 
 /// Manages loading and running of plugins
 pub struct PluginManager {
-    dylibs: Vec<dl::DynamicLibrary> ,
     callbacks: Vec<PluginCallback> ,
-    /// The directory plugins will be loaded from
-    pub prefix: PathBuf,
 }
 
 impl PluginManager {
     /// Create a new plugin manager
-    pub fn new(prefix: PathBuf) -> PluginManager {
+    pub fn new() -> PluginManager {
         PluginManager {
-            dylibs: Vec::new(),
             callbacks: Vec::new(),
-            prefix,
         }
-    }
-
-    /// Load a plugin with the given name.
-    ///
-    /// Turns `name` into the proper dynamic library filename for the given
-    /// platform. On windows, it turns into name.dll, on macOS, name.dylib, and
-    /// elsewhere, libname.so.
-    pub fn load_plugin(&mut self, name: String) {
-        let x = self.prefix.join(libname(name));
-        let lib_result = dl::DynamicLibrary::open(Some(&x));
-        let lib = lib_result.unwrap();
-        unsafe {
-            let plugin = lib.symbol("rustdoc_plugin_entrypoint").unwrap();
-            self.callbacks.push(mem::transmute::<*mut u8,PluginCallback>(plugin));
-        }
-        self.dylibs.push(lib);
     }
 
     /// Load a normal Rust function as a plugin.
@@ -69,24 +42,4 @@ impl PluginManager {
         }
         krate
     }
-}
-
-#[cfg(target_os = "windows")]
-fn libname(mut n: String) -> String {
-    n.push_str(".dll");
-    n
-}
-
-#[cfg(target_os="macos")]
-fn libname(mut n: String) -> String {
-    n.push_str(".dylib");
-    n
-}
-
-#[cfg(all(not(target_os="windows"), not(target_os="macos")))]
-fn libname(n: String) -> String {
-    let mut i = String::from("lib");
-    i.push_str(&n);
-    i.push_str(".so");
-    i
 }

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -365,11 +365,6 @@ impl<'a, 'tcx, 'rcx> RustdocVisitor<'a, 'tcx, 'rcx> {
                 });
                 true
             }
-            hir_map::NodeStructCtor(_) if !glob => {
-                // struct constructors always show up alongside their struct definitions, we've
-                // already processed that so just discard this
-                true
-            }
             _ => false,
         };
         self.view_item_stack.remove(&def_node_id);
@@ -416,6 +411,13 @@ impl<'a, 'tcx, 'rcx> RustdocVisitor<'a, 'tcx, 'rcx> {
             hir::ItemUse(_, hir::UseKind::ListStem) => {}
             hir::ItemUse(ref path, kind) => {
                 let is_glob = kind == hir::UseKind::Glob;
+
+                // struct and variant constructors always show up alongside their definitions, we've
+                // already processed them so just discard these.
+                match path.def {
+                    Def::StructCtor(..) | Def::VariantCtor(..) => return,
+                    _ => {}
+                }
 
                 // If there was a private module in the current path then don't bother inlining
                 // anything as it will probably be stripped anyway.

--- a/src/test/rustdoc/constructor-imports.rs
+++ b/src/test/rustdoc/constructor-imports.rs
@@ -1,0 +1,25 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_name = "foo"]
+
+pub mod a {
+    pub struct Foo;
+    pub enum Bar {
+        Baz,
+    }
+}
+
+// @count 'foo/index.html' '//*[code="pub use a::Foo;"]' 1
+#[doc(no_inline)]
+pub use a::Foo;
+// @count 'foo/index.html' '//*[code="pub use a::Bar::Baz;"]' 1
+#[doc(no_inline)]
+pub use a::Bar::Baz;


### PR DESCRIPTION
Merged and approved:

* #51722: Updated RELEASES for 1.28.0 
* #52193: step_by: leave time of item skip unspecified 
* #52194: Remove rustdoc's plugins feature
* #52196: rustdoc: Hide struct and enum variant constructor imports
* #52310: Backport 1.27.1 release notes to master

r? @ghost