### PR TITLE
Fix ICE when using a pointer cast as array size

### DIFF
--- a/src/librustc/ty/relate.rs
+++ b/src/librustc/ty/relate.rs
@@ -20,6 +20,7 @@ use ty::{self, Ty, TyCtxt, TypeFoldable};
 use ty::error::{ExpectedFound, TypeError};
 use mir::interpret::GlobalId;
 use util::common::ErrorReported;
+use syntax_pos::DUMMY_SP;
 use std::rc::Rc;
 use std::iter;
 use rustc_target::spec::abi;
@@ -503,7 +504,11 @@ pub fn super_relate_tys<'a, 'gcx, 'tcx, R>(relation: &mut R,
                             "array length could not be evaluated");
                         Err(ErrorReported)
                     }
-                    _ => bug!("arrays should not have {:?} as length", x)
+                    _ => {
+                        tcx.sess.delay_span_bug(DUMMY_SP,
+                            &format!("arrays should not have {:?} as length", x));
+                        Err(ErrorReported)
+                    }
                 }
             };
             match (to_u64(sz_a), to_u64(sz_b)) {

--- a/src/test/ui/issue-52023-array-size-pointer-cast.rs
+++ b/src/test/ui/issue-52023-array-size-pointer-cast.rs
@@ -1,0 +1,13 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let _ = [0; (&0 as *const i32) as usize]; //~ ERROR raw pointers cannot be cast
+}

--- a/src/test/ui/issue-52023-array-size-pointer-cast.stderr
+++ b/src/test/ui/issue-52023-array-size-pointer-cast.stderr
@@ -1,0 +1,9 @@
+error[E0018]: raw pointers cannot be cast to integers in constants
+  --> $DIR/issue-52023-array-size-pointer-cast.rs:12:17
+   |
+LL |     let _ = [0; (&0 as *const i32) as usize]; //~ ERROR raw pointers cannot be cast
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0018`.


### PR DESCRIPTION
Fixes #52023. I'm not sure if the comment https://github.com/rust-lang/rust/issues/52023#issuecomment-402402392 suggested we also emit `E0080`, but just emitting `E0018` seems reasonable for now.

r? @oli-obk 