### PR TITLE
task: remove wrong comments about non-existent LocalWake trait

### DIFF
--- a/src/libcore/task/wake.rs
+++ b/src/libcore/task/wake.rs
@@ -113,8 +113,8 @@ impl LocalWaker {
     /// but you otherwise shouldn't call it directly.
     ///
     /// If you're working with the standard library then it's recommended to
-    /// use the `LocalWaker::from` function instead which works with the safe
-    /// `Rc` type and the safe `LocalWake` trait.
+    /// use the `local_waker_from_nonlocal` or `local_waker` to convert a `Waker`
+    /// into a `LocalWaker`.
     ///
     /// For this function to be used safely, it must be sound to call `inner.wake_local()`
     /// on the current thread.
@@ -197,9 +197,7 @@ impl Drop for LocalWaker {
 /// customization.
 ///
 /// When using `std`, a default implementation of the `UnsafeWake` trait is provided for
-/// `Arc<T>` where `T: Wake` and `Rc<T>` where `T: LocalWake`.
-///
-/// Although the methods on `UnsafeWake` take pointers rather than references,
+/// `Arc<T>` where `T: Wake`.
 pub unsafe trait UnsafeWake: Send + Sync {
     /// Creates a clone of this `UnsafeWake` and stores it behind a `Waker`.
     ///


### PR DESCRIPTION
~~A `LocalWaker` is specifically `!Send `, and the unsafety comment around
`LocalWaker::new` only specifies that it be safe to call `wake_local`.
One could then accidentally promote a `LocalWaker` into a `Waker`, which
is universally `Send`, simply via `Waker::from(local_waker)`. A
`LocalWaker` the was built expecting to not be `Send`, such as using
`Rc`, could be sent to other threads safely.~~

~~Separately, though somewhat related, `Context` holds a `&LocalWaker`
internally, and exposes a `waker() -> &Waker` method. This simply
transmutes the `&LocalWaker` to `&Waker`, which would be unsound, except
that you can't "send" a `&Waker`, you'd need to clone it first. Since
`UnsafeWake::clone_raw` requires that it return a `Waker`, the transmute
is not unsound. The transmuted `LocalWaker` will be promoted to a
`Waker` correctly.~~

~~That would mean that if `UnsafeWake::clone_raw` were to be changed, such
as returning `Self` instead of `Waker`, this would no longer be sound.
Thus, this also adds a comment to `clone_raw` to remember this.~~

r? @cramertj 