### PR TITLE
Track whether module declarations are inline (fixes #12590)

### DIFF
--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1841,6 +1841,8 @@ pub struct Mod {
     /// to the last token in the external file.
     pub inner: Span,
     pub items: Vec<P<Item>>,
+    /// For `mod foo;` inline is false, for `mod foo { .. }` it is true.
+    pub inline: bool,
 }
 
 /// Foreign module declaration.

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -1101,6 +1101,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
             ast::ItemKind::Mod(ast::Mod {
                 inner: inner_span,
                 items,
+                inline: true
             })
         )
     }

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -290,6 +290,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                 krate.module = ast::Mod {
                     inner: orig_mod_span,
                     items: vec![],
+                    inline: true,
                 };
             },
             _ => unreachable!(),

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -1036,10 +1036,11 @@ pub fn noop_fold_fn_header<T: Folder>(mut header: FnHeader, folder: &mut T) -> F
     header
 }
 
-pub fn noop_fold_mod<T: Folder>(Mod {inner, items}: Mod, folder: &mut T) -> Mod {
+pub fn noop_fold_mod<T: Folder>(Mod {inner, items, inline}: Mod, folder: &mut T) -> Mod {
     Mod {
         inner: folder.new_span(inner),
         items: items.move_flat_map(|x| folder.fold_item(x)),
+        inline: inline,
     }
 }
 
@@ -1069,6 +1070,7 @@ pub fn noop_fold_crate<T: Folder>(Crate {module, attrs, span}: Crate,
         None => (ast::Mod {
             inner: span,
             items: vec![],
+            inline: true,
         }, vec![], span)
     };
 

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -6288,10 +6288,9 @@ impl<'a> Parser<'a> {
                 // This mod is in an external file. Let's go get it!
                 let ModulePathSuccess { path, directory_ownership, warn } =
                     self.submod_path(id, &outer_attrs, id_span)?;
-                let (mut module, mut attrs) =
+                let (module, mut attrs) =
                     self.eval_src_mod(path, directory_ownership, id.to_string(), id_span)?;
                 // Record that we fetched the mod from an external file
-                module.inline = false;
                 if warn {
                     let attr = Attribute {
                         id: attr::mk_attr_id(),
@@ -6530,7 +6529,8 @@ impl<'a> Parser<'a> {
         p0.cfg_mods = self.cfg_mods;
         let mod_inner_lo = p0.span;
         let mod_attrs = p0.parse_inner_attributes()?;
-        let m0 = p0.parse_mod_items(&token::Eof, mod_inner_lo)?;
+        let mut m0 = p0.parse_mod_items(&token::Eof, mod_inner_lo)?;
+        m0.inline = false;
         self.sess.included_mod_stack.borrow_mut().pop();
         Ok((m0, mod_attrs))
     }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -6252,6 +6252,7 @@ impl<'a> Parser<'a> {
         Ok(ast::Mod {
             inner: inner_lo.to(hi),
             items,
+            inline: true
         })
     }
 
@@ -6287,8 +6288,10 @@ impl<'a> Parser<'a> {
                 // This mod is in an external file. Let's go get it!
                 let ModulePathSuccess { path, directory_ownership, warn } =
                     self.submod_path(id, &outer_attrs, id_span)?;
-                let (module, mut attrs) =
+                let (mut module, mut attrs) =
                     self.eval_src_mod(path, directory_ownership, id.to_string(), id_span)?;
+                // Record that we fetched the mod from an external file
+                module.inline = false;
                 if warn {
                     let attr = Attribute {
                         id: attr::mk_attr_id(),
@@ -6301,9 +6304,13 @@ impl<'a> Parser<'a> {
                     attr::mark_known(&attr);
                     attrs.push(attr);
                 }
-                Ok((id, module, Some(attrs)))
+                Ok((id, ItemKind::Mod(module), Some(attrs)))
             } else {
-                let placeholder = ast::Mod { inner: syntax_pos::DUMMY_SP, items: Vec::new() };
+                let placeholder = ast::Mod {
+                    inner: syntax_pos::DUMMY_SP,
+                    items: Vec::new(),
+                    inline: false
+                };
                 Ok((id, ItemKind::Mod(placeholder), None))
             }
         } else {
@@ -6503,7 +6510,7 @@ impl<'a> Parser<'a> {
                     directory_ownership: DirectoryOwnership,
                     name: String,
                     id_sp: Span)
-                    -> PResult<'a, (ast::ItemKind, Vec<Attribute> )> {
+                    -> PResult<'a, (ast::Mod, Vec<Attribute> )> {
         let mut included_mod_stack = self.sess.included_mod_stack.borrow_mut();
         if let Some(i) = included_mod_stack.iter().position(|p| *p == path) {
             let mut err = String::from("circular modules: ");
@@ -6525,7 +6532,7 @@ impl<'a> Parser<'a> {
         let mod_attrs = p0.parse_inner_attributes()?;
         let m0 = p0.parse_mod_items(&token::Eof, mod_inner_lo)?;
         self.sess.included_mod_stack.borrow_mut().pop();
-        Ok((ast::ItemKind::Mod(m0), mod_attrs))
+        Ok((m0, mod_attrs))
     }
 
     /// Parse a function declaration from a foreign module

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -61,6 +61,7 @@ pub struct State<'a> {
     cur_cmnt: usize,
     boxes: Vec<pp::Breaks>,
     ann: &'a (dyn PpAnn+'a),
+    is_expanded: bool
 }
 
 fn rust_printer<'a>(writer: Box<dyn Write+'a>, ann: &'a dyn PpAnn) -> State<'a> {
@@ -72,6 +73,7 @@ fn rust_printer<'a>(writer: Box<dyn Write+'a>, ann: &'a dyn PpAnn) -> State<'a> 
         cur_cmnt: 0,
         boxes: Vec::new(),
         ann,
+        is_expanded: false
     }
 }
 
@@ -133,14 +135,17 @@ impl<'a> State<'a> {
             // If the code is post expansion, don't use the table of
             // literals, since it doesn't correspond with the literals
             // in the AST anymore.
-            if is_expanded { None } else { Some(lits) })
+            if is_expanded { None } else { Some(lits) },
+            is_expanded
+        )
     }
 
     pub fn new(cm: &'a SourceMap,
                out: Box<dyn Write+'a>,
                ann: &'a dyn PpAnn,
                comments: Option<Vec<comments::Comment>>,
-               literals: Option<Vec<comments::Literal>>) -> State<'a> {
+               literals: Option<Vec<comments::Literal>>,
+               is_expanded: bool) -> State<'a> {
         State {
             s: pp::mk_printer(out, DEFAULT_COLUMNS),
             cm: Some(cm),
@@ -149,6 +154,7 @@ impl<'a> State<'a> {
             cur_cmnt: 0,
             boxes: Vec::new(),
             ann,
+            is_expanded: is_expanded
         }
     }
 }
@@ -1261,7 +1267,8 @@ impl<'a> State<'a> {
                 self.head(&visibility_qualified(&item.vis, "mod"))?;
                 self.print_ident(item.ident)?;
 
-                if _mod.inline {
+                if _mod.inline || self.is_expanded {
+                    println!("Going to print inline anyway");
                     self.nbsp()?;
                     self.bopen()?;
                     self.print_mod(_mod, &item.attrs)?;

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1260,10 +1260,16 @@ impl<'a> State<'a> {
             ast::ItemKind::Mod(ref _mod) => {
                 self.head(&visibility_qualified(&item.vis, "mod"))?;
                 self.print_ident(item.ident)?;
-                self.nbsp()?;
-                self.bopen()?;
-                self.print_mod(_mod, &item.attrs)?;
-                self.bclose(item.span)?;
+
+                if _mod.inline {
+                    self.nbsp()?;
+                    self.bopen()?;
+                    self.print_mod(_mod, &item.attrs)?;
+                    self.bclose(item.span)?;
+                } else {
+                    self.s.word(";")?;
+                }
+
             }
             ast::ItemKind::ForeignMod(ref nmod) => {
                 self.head("extern")?;

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1268,13 +1268,14 @@ impl<'a> State<'a> {
                 self.print_ident(item.ident)?;
 
                 if _mod.inline || self.is_expanded {
-                    println!("Going to print inline anyway");
                     self.nbsp()?;
                     self.bopen()?;
                     self.print_mod(_mod, &item.attrs)?;
                     self.bclose(item.span)?;
                 } else {
                     self.s.word(";")?;
+                    self.end()?; // end inner head-block
+                    self.end()?; // end outer head-block
                 }
 
             }

--- a/src/libsyntax/test.rs
+++ b/src/libsyntax/test.rs
@@ -238,9 +238,9 @@ fn mk_reexport_mod(cx: &mut TestCtxt,
     })).collect();
 
     let reexport_mod = ast::Mod {
+        inline: true,
         inner: DUMMY_SP,
         items,
-        inline: true,
     };
 
     let sym = Ident::with_empty_ctxt(Symbol::gensym("__test_reexports"));
@@ -393,59 +393,6 @@ fn mk_main(cx: &mut TestCtxt) -> P<ast::Item> {
         tokens: None,
     })
 
-    let testmod = ast::Mod {
-        inner: DUMMY_SP,
-        items: vec![import, mainfn, tests],
-        inline: true,
-    };
-    let item_ = ast::ItemKind::Mod(testmod);
-    let mod_ident = Ident::with_empty_ctxt(Symbol::gensym("__test"));
-
-    let mut expander = cx.ext_cx.monotonic_expander();
-    let item = expander.fold_item(P(ast::Item {
-        id: ast::DUMMY_NODE_ID,
-        ident: mod_ident,
-        attrs: vec![],
-        node: item_,
-        vis: dummy_spanned(ast::VisibilityKind::Public),
-        span: DUMMY_SP,
-        tokens: None,
-    })).pop().unwrap();
-    let reexport = cx.reexport_test_harness_main.map(|s| {
-        // building `use __test::main as <ident>;`
-        let rename = Ident::with_empty_ctxt(s);
-
-        let use_path = ast::UseTree {
-            span: DUMMY_SP,
-            prefix: path_node(vec![mod_ident, Ident::from_str("main")]),
-            kind: ast::UseTreeKind::Simple(Some(rename), ast::DUMMY_NODE_ID, ast::DUMMY_NODE_ID),
-        };
-
-        expander.fold_item(P(ast::Item {
-            id: ast::DUMMY_NODE_ID,
-            ident: keywords::Invalid.ident(),
-            attrs: vec![],
-            node: ast::ItemKind::Use(P(use_path)),
-            vis: dummy_spanned(ast::VisibilityKind::Inherited),
-            span: DUMMY_SP,
-            tokens: None,
-        })).pop().unwrap()
-    });
-
-    debug!("Synthetic test module:\n{}\n", pprust::item_to_string(&item));
-
-    (item, reexport)
-}
-
-fn nospan<T>(t: T) -> codemap::Spanned<T> {
-    codemap::Spanned { node: t, span: DUMMY_SP }
-}
-
-fn path_node(ids: Vec<Ident>) -> ast::Path {
-    ast::Path {
-        span: DUMMY_SP,
-        segments: ids.into_iter().map(|id| ast::PathSegment::from_ident(id)).collect(),
-    }
 }
 
 fn path_name_i(idents: &[Ident]) -> String {

--- a/src/test/pretty/issue_12590_a.rs
+++ b/src/test/pretty/issue_12590_a.rs
@@ -1,0 +1,17 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// pp-exact
+
+// The next line should not be expanded
+
+mod issue_12590_b;
+
+fn main() { }

--- a/src/test/pretty/issue_12590_b.rs
+++ b/src/test/pretty/issue_12590_b.rs
@@ -1,0 +1,14 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Second part of two file test
+fn b() { }
+
+fn main() { }

--- a/src/test/pretty/issue_12590_c.pp
+++ b/src/test/pretty/issue_12590_c.pp
@@ -1,7 +1,7 @@
 #![feature(prelude_import)]
 #![no_std]
 #[prelude_import]
-use std::prelude::v1::*;
+use ::std::prelude::v1::*;
 #[macro_use]
 extern crate std;
 // Copyright 2012 The Rust Project Developers. See the COPYRIGHT

--- a/src/test/pretty/issue_12590_c.pp
+++ b/src/test/pretty/issue_12590_c.pp
@@ -1,0 +1,24 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// pp-exact:issue_12590_c.pp
+// pretty-mode:expanded
+
+// The next line should be expanded
+
+mod issue_12590_b {
+
+
+  fn b() { }
+
+  fn main() { }
+}
+
+fn main() { }

--- a/src/test/pretty/issue_12590_c.pp
+++ b/src/test/pretty/issue_12590_c.pp
@@ -1,3 +1,9 @@
+#![feature(prelude_import)]
+#![no_std]
+#[prelude_import]
+use std::prelude::v1::*;
+#[macro_use]
+extern crate std;
 // Copyright 2012 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
@@ -8,17 +14,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pp-exact:issue_12590_c.pp
+// pretty-compare-only
 // pretty-mode:expanded
+// pp-exact:issue_12590_c.pp
 
 // The next line should be expanded
 
 mod issue_12590_b {
 
-
-  fn b() { }
-
-  fn main() { }
+    fn b() { }
+    fn main() { }
 }
-
 fn main() { }

--- a/src/test/pretty/issue_12590_c.rs
+++ b/src/test/pretty/issue_12590_c.rs
@@ -1,0 +1,18 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// pp-exact:issue_12590_c.pp
+// pretty-mode:expanded
+
+// The next line should be expanded
+
+mod issue_12590_b;
+
+fn main() { }

--- a/src/test/pretty/issue_12590_c.rs
+++ b/src/test/pretty/issue_12590_c.rs
@@ -8,8 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pp-exact:issue_12590_c.pp
+// pretty-compare-only
 // pretty-mode:expanded
+// pp-exact:issue_12590_c.pp
 
 // The next line should be expanded
 

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -521,11 +521,16 @@ impl<'test> TestCx<'test> {
             .args(&self.props.compile_flags)
             .envs(self.props.exec_env.clone());
 
+        let src_to_read = match read_from {
+            ReadFrom::Stdin => Some(src),
+            ReadFrom::Path => None
+        };
+
         self.compose_and_run(
             rustc,
             self.config.compile_lib_path.to_str().unwrap(),
             Some(aux_dir.to_str().unwrap()),
-            Some(src),
+            src_to_read,
         )
     }
 


### PR DESCRIPTION
To track whether module declarations are inline I added a field `inline: bool` to `ast::Mod`. The main use case is for pretty to know whether it should render the items associated with the module, but perhaps there are use cases for this information to not be forgotten in the AST.