### PR TITLE
Update llvm-rebuild-trigger in light of LLVM 7 upgrade

### DIFF
--- a/src/rustllvm/llvm-rebuild-trigger
+++ b/src/rustllvm/llvm-rebuild-trigger
@@ -1,4 +1,4 @@
 # If this file is modified, then llvm will be (optionally) cleaned and then rebuilt.
 # The actual contents of this file do not matter, but to trigger a change on the
 # build bots then the contents should be changed so git updates the mtime.
-2018-05-18
+2018-07-12


### PR DESCRIPTION
Not triggering a LLVM rebuild [since the LLVM 7 upgrade](https://github.com/rust-lang/rust/pull/51966#issuecomment-404624633) causes builds of rustc to fail.

r? @alexcrichton 