### PR TITLE
rustc: Tweak expansion of #[proc_macro] for 2018

### DIFF
--- a/src/test/ui-fulldeps/rust-2018/proc-macro-crate-in-paths.rs
+++ b/src/test/ui-fulldeps/rust-2018/proc-macro-crate-in-paths.rs
@@ -1,0 +1,24 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-pass
+
+#![crate_type = "proc-macro"]
+#![deny(rust_2018_compatibility)]
+#![feature(rust_2018_preview)]
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+
+#[proc_macro_derive(Template, attributes(template))]
+pub fn derive_template(input: TokenStream) -> TokenStream {
+    input
+}


### PR DESCRIPTION
The syntactical expansion of `#[proc_macro]` and related attributes currently
contains absolute paths which conflicts with a lint for the 2018 edition,
causing issues like #52214. This commit puts a band-aid on the issue by ensuring
that procedural macros can also migrate to the 2018 edition for now by tweaking
the expansion based on what features are activated. A more long-term solution
would probably tweak the edition hygiene of spans, but this should do the trick
for now.

Closes #52214