### PR TITLE
Don't silently ignore invalid data in target spec

### DIFF
--- a/src/test/run-make-fulldeps/target-specs/my-x86_64-unknown-linux-gnu-platform.json
+++ b/src/test/run-make-fulldeps/target-specs/my-x86_64-unknown-linux-gnu-platform.json
@@ -1,5 +1,5 @@
 {
-    "pre-link-args": ["-m64"],
+    "pre-link-args": {"gcc": ["-m64"]},
     "data-layout": "e-m:e-i64:64-f80:128-n8:16:32:64-S128",
     "linker-flavor": "gcc",
     "llvm-target": "x86_64-unknown-linux-gnu",


### PR DESCRIPTION
This is technically a breaking change, but only because invalid data was previously silently being ignored.