### PR TITLE
dead-code lint: say "constructed" for structs

### DIFF
--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -554,12 +554,16 @@ impl<'a, 'tcx> Visitor<'tcx> for DeadVisitor<'a, 'tcx> {
                 hir::ItemKind::Impl(..) => self.tcx.sess.codemap().def_span(item.span),
                 _ => item.span,
             };
+            let participle = match item.node {
+                hir::ItemKind::Struct(..) => "constructed", // Issue #52325
+                _ => "used"
+            };
             self.warn_dead_code(
                 item.id,
                 span,
                 item.name,
                 item.node.descriptive_variant(),
-                "used",
+                participle,
             );
         } else {
             // Only continue if we didn't warn

--- a/src/test/compile-fail/lint-dead-code-1.rs
+++ b/src/test/compile-fail/lint-dead-code-1.rs
@@ -19,7 +19,7 @@
 pub use foo2::Bar2;
 
 mod foo {
-    pub struct Bar; //~ ERROR: struct is never used
+    pub struct Bar; //~ ERROR: struct is never constructed
 }
 
 mod foo2 {
@@ -42,7 +42,7 @@ const CONST_USED_IN_ENUM_DISCRIMINANT: isize = 11;
 
 pub type typ = *const UsedStruct4;
 pub struct PubStruct;
-struct PrivStruct; //~ ERROR: struct is never used
+struct PrivStruct; //~ ERROR: struct is never constructed
 struct UsedStruct1 {
     #[allow(dead_code)]
     x: isize

--- a/src/test/compile-fail/lint-dead-code-3.rs
+++ b/src/test/compile-fail/lint-dead-code-3.rs
@@ -20,7 +20,7 @@ extern {
     pub fn extern_foo();
 }
 
-struct Foo; //~ ERROR: struct is never used
+struct Foo; //~ ERROR: struct is never constructed
 impl Foo {
     fn foo(&self) { //~ ERROR: method is never used
         bar()

--- a/src/test/ui/span/macro-span-replacement.rs
+++ b/src/test/ui/span/macro-span-replacement.rs
@@ -14,7 +14,7 @@
 
 macro_rules! m {
     ($a:tt $b:tt) => {
-        $b $a; //~ WARN struct is never used
+        $b $a; //~ WARN struct is never constructed
     }
 }
 

--- a/src/test/ui/span/macro-span-replacement.stderr
+++ b/src/test/ui/span/macro-span-replacement.stderr
@@ -1,7 +1,7 @@
-warning: struct is never used: `S`
+warning: struct is never constructed: `S`
   --> $DIR/macro-span-replacement.rs:17:14
    |
-LL |         $b $a; //~ WARN struct is never used
+LL |         $b $a; //~ WARN struct is never constructed
    |              ^
 ...
 LL |     m!(S struct);

--- a/src/test/ui/span/unused-warning-point-at-signature.rs
+++ b/src/test/ui/span/unused-warning-point-at-signature.rs
@@ -19,7 +19,7 @@ enum Enum { //~ WARN enum is never used
     D,
 }
 
-struct Struct { //~ WARN struct is never used
+struct Struct { //~ WARN struct is never constructed
     a: usize,
     b: usize,
     c: usize,

--- a/src/test/ui/span/unused-warning-point-at-signature.stderr
+++ b/src/test/ui/span/unused-warning-point-at-signature.stderr
@@ -11,10 +11,10 @@ LL | #![warn(unused)]
    |         ^^^^^^
    = note: #[warn(dead_code)] implied by #[warn(unused)]
 
-warning: struct is never used: `Struct`
+warning: struct is never constructed: `Struct`
   --> $DIR/unused-warning-point-at-signature.rs:22:1
    |
-LL | struct Struct { //~ WARN struct is never used
+LL | struct Struct { //~ WARN struct is never constructed
    | ^^^^^^^^^^^^^
 
 warning: function is never used: `func`


### PR DESCRIPTION
Respectively.

This is a sequel to November 2017's #46103 / 1a9dc2e9. It had been
reported (more than once—at least #19140, #44083, and #44565) that the
"never used" language was confusing for enum variants that were "used"
as match patterns, so the wording was changed to say never "constructed"
specifically for enum variants. More recently, the same issue was raised
for structs (#52325). It seems consistent to say "constructed" here,
too, for the same reasons.

~~While we're here, we can also use more specific word "called" for unused
functions and methods. (We declined to do this in #46103, but the
rationale given in the commit message doesn't actually make sense.)~~

This resolves #52325.