### PR TITLE
Add inline annotations on Vec's Deref and DerefMut

### DIFF
--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -1734,6 +1734,7 @@ where
 impl<T> ops::Deref for Vec<T> {
     type Target = [T];
 
+    #[inline]
     fn deref(&self) -> &[T] {
         unsafe {
             let p = self.buf.ptr();
@@ -1745,6 +1746,7 @@ impl<T> ops::Deref for Vec<T> {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T> ops::DerefMut for Vec<T> {
+    #[inline]
     fn deref_mut(&mut self) -> &mut [T] {
         unsafe {
             let ptr = self.buf.ptr();


### PR DESCRIPTION
While doing profiling on https://github.com/BurntSushi/aho-corasick I noticed that `Vec::deref_mut` would show up as a hot function despite the fact that it should be a no-op that should be trivially inlined. (as the layout of `Vec<T>` is that of `&[T]` + a capacity after).

I'd expect that the method(s) would usually be inlined despite the lack of an inline in most cases but for the crate in question I observed a 1.2x speedup if I replaced the deref with `::std::mem::transmute_copy` so there was definitely a noticeable performance regression.

Also, I recognize that it is likely that, were I to use different version of rustc, then the problem could go away. But the fact remains that (evidently) some versions of rustc misses this optimization and maybe an inline annotation can help to avoid this.