### PR TITLE
stabilize lint handling in rustdoc

### DIFF
--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -309,19 +309,19 @@ pub fn opts() -> Vec<RustcOptGroup> {
                        "disable-minification",
                        "Disable minification applied on JS files")
         }),
-        unstable("warn", |o| {
+        stable("warn", |o| {
             o.optmulti("W", "warn", "Set lint warnings", "OPT")
         }),
-        unstable("allow", |o| {
+        stable("allow", |o| {
             o.optmulti("A", "allow", "Set lint allowed", "OPT")
         }),
-        unstable("deny", |o| {
+        stable("deny", |o| {
             o.optmulti("D", "deny", "Set lint denied", "OPT")
         }),
-        unstable("forbid", |o| {
+        stable("forbid", |o| {
             o.optmulti("F", "forbid", "Set lint forbidden", "OPT")
         }),
-        unstable("cap-lints", |o| {
+        stable("cap-lints", |o| {
             o.optmulti(
                 "",
                 "cap-lints",


### PR DESCRIPTION
When https://github.com/rust-lang/rust/pull/51732 added CLI flags to manipulate lints in rustdoc, they were added as unstable flags. This made sense as they were new additions, but since they mirrored the flags that rustc has, it's worth considering them to not need an unstable period.

Stabilizing them also provides the opportunity for a critical fix: allowing Cargo to pass `--cap-lints allow` when documenting dependencies, the same as when it compiles them.

r? @rust-lang/rustdoc 