### PR TITLE
Add the -Zcrate-attr=foo unstable rustc option

### DIFF
--- a/src/librustc/ich/impls_syntax.rs
+++ b/src/librustc/ich/impls_syntax.rs
@@ -423,6 +423,7 @@ impl_stable_hash_for!(enum ::syntax_pos::FileName {
     Anon,
     MacroExpansion,
     ProcMacroSourceCode,
+    CliCrateAttr,
     CfgSpec,
     Custom(s)
 });

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -1369,6 +1369,8 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
           "don't run LLVM in parallel (while keeping codegen-units and ThinLTO)"),
     no_leak_check: bool = (false, parse_bool, [UNTRACKED],
         "disables the 'leak check' for subtyping; unsound, but useful for tests"),
+    crate_attr: Vec<String> = (Vec::new(), parse_string_push, [TRACKED],
+        "inject the given attribute in the crate"),
 }
 
 pub fn default_lib_output() -> CrateType {

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -798,7 +798,7 @@ where
 pub fn phase_2_configure_and_expand_inner<'a, F>(
     sess: &'a Session,
     cstore: &'a CStore,
-    krate: ast::Crate,
+    mut krate: ast::Crate,
     registry: Option<Registry>,
     crate_name: &str,
     addl_plugins: Option<Vec<String>>,
@@ -810,6 +810,10 @@ pub fn phase_2_configure_and_expand_inner<'a, F>(
 where
     F: FnOnce(&ast::Crate) -> CompileResult,
 {
+    krate = time(sess, "attributes injection", || {
+        syntax::attr::inject(krate, &sess.parse_sess, &sess.opts.debugging_opts.crate_attr)
+    });
+
     let (mut krate, features) = syntax::config::features(
         krate,
         &sess.parse_sess,

--- a/src/libsyntax_pos/lib.rs
+++ b/src/libsyntax_pos/lib.rs
@@ -100,6 +100,8 @@ pub enum FileName {
     ProcMacroSourceCode,
     /// Strings provided as --cfg [cfgspec] stored in a crate_cfg
     CfgSpec,
+    /// Strings provided as crate attributes in the CLI
+    CliCrateAttr,
     /// Custom sources for explicit parser calls from plugins and drivers
     Custom(String),
 }
@@ -115,6 +117,7 @@ impl std::fmt::Display for FileName {
             Anon => write!(fmt, "<anon>"),
             ProcMacroSourceCode => write!(fmt, "<proc-macro source code>"),
             CfgSpec => write!(fmt, "cfgspec"),
+            CliCrateAttr => write!(fmt, "<crate attribute>"),
             Custom(ref s) => write!(fmt, "<{}>", s),
         }
     }
@@ -137,6 +140,7 @@ impl FileName {
             MacroExpansion |
             ProcMacroSourceCode |
             CfgSpec |
+            CliCrateAttr |
             Custom(_) |
             QuoteExpansion => false,
         }
@@ -150,6 +154,7 @@ impl FileName {
             MacroExpansion |
             ProcMacroSourceCode |
             CfgSpec |
+            CliCrateAttr |
             Custom(_) |
             QuoteExpansion => false,
             Macros(_) => true,

--- a/src/test/run-pass/z-crate-attr.rs
+++ b/src/test/run-pass/z-crate-attr.rs
@@ -1,0 +1,21 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This test checks if an unstable feature is enabled with the -Zcrate-attr=feature(foo) flag. If
+// the exact feature used here is causing problems feel free to replace it with another
+// perma-unstable feature.
+
+// compile-flags: -Zcrate-attr=feature(abi_unadjusted)
+
+#![allow(dead_code)]
+
+extern "unadjusted" fn foo() {}
+
+fn main() {}


### PR DESCRIPTION
This PR adds a new unstable option to `rustc`: `-Zcrate-attr=foo`. The option can be used to inject crate-level attributes from the CLI, and it's meant to be used by tools like Crater that needs to add their own attributes to a crate without changing the source code.

The exact reason I need this is to implement "edition runs" in Crater: we need to add the preview feature flag to every crate, and editing the crates' source code on the fly might produce unexpected results, while a compiler flag is more reliable.

cc https://github.com/rust-lang-nursery/crater/issues/282 @Mark-Simulacrum 