### PR TITLE
Do not attempt to recompile codegen backend(s) with --keep-stage

### DIFF
--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -660,6 +660,16 @@ impl Step for CodegenBackend {
 
         builder.ensure(Rustc { compiler, target });
 
+        if let Some(keep_stage) = builder.config.keep_stage {
+            if keep_stage <= compiler.stage {
+                println!("Warning: Using a potentially old codegen backend. \
+                    This may not behave well.");
+                // Codegen backends are linked separately from this step today, so we don't do
+                // anything here.
+                return;
+            }
+        }
+
         if builder.force_use_stage1(compiler, target) {
             builder.ensure(CodegenBackend {
                 compiler: builder.compiler(1, builder.config.build),

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -67,16 +67,14 @@ impl Step for Std {
         let target = self.target;
         let compiler = self.compiler;
 
-        if let Some(keep_stage) = builder.config.keep_stage {
-            if keep_stage <= compiler.stage {
-                println!("Warning: Using a potentially old libstd. This may not behave well.");
-                builder.ensure(StdLink {
-                    compiler: compiler,
-                    target_compiler: compiler,
-                    target,
-                });
-                return;
-            }
+        if builder.config.keep_stage.contains(&compiler.stage) {
+            builder.info("Warning: Using a potentially old libstd. This may not behave well.");
+            builder.ensure(StdLink {
+                compiler: compiler,
+                target_compiler: compiler,
+                target,
+            });
+            return;
         }
 
         builder.ensure(StartupObjects { compiler, target });
@@ -362,19 +360,17 @@ impl Step for Test {
         let target = self.target;
         let compiler = self.compiler;
 
-        if let Some(keep_stage) = builder.config.keep_stage {
-            if keep_stage <= compiler.stage {
-                println!("Warning: Using a potentially old libtest. This may not behave well.");
-                builder.ensure(TestLink {
-                    compiler: compiler,
-                    target_compiler: compiler,
-                    target,
-                });
-                return;
-            }
-        }
-
         builder.ensure(Std { compiler, target });
+
+        if builder.config.keep_stage.contains(&compiler.stage) {
+            builder.info("Warning: Using a potentially old libtest. This may not behave well.");
+            builder.ensure(TestLink {
+                compiler: compiler,
+                target_compiler: compiler,
+                target,
+            });
+            return;
+        }
 
         if builder.force_use_stage1(compiler, target) {
             builder.ensure(Test {
@@ -490,19 +486,17 @@ impl Step for Rustc {
         let compiler = self.compiler;
         let target = self.target;
 
-        if let Some(keep_stage) = builder.config.keep_stage {
-            if keep_stage <= compiler.stage {
-                println!("Warning: Using a potentially old librustc. This may not behave well.");
-                builder.ensure(RustcLink {
-                    compiler: compiler,
-                    target_compiler: compiler,
-                    target,
-                });
-                return;
-            }
-        }
-
         builder.ensure(Test { compiler, target });
+
+        if builder.config.keep_stage.contains(&compiler.stage) {
+            builder.info("Warning: Using a potentially old librustc. This may not behave well.");
+            builder.ensure(RustcLink {
+                compiler: compiler,
+                target_compiler: compiler,
+                target,
+            });
+            return;
+        }
 
         if builder.force_use_stage1(compiler, target) {
             builder.ensure(Rustc {
@@ -660,14 +654,12 @@ impl Step for CodegenBackend {
 
         builder.ensure(Rustc { compiler, target });
 
-        if let Some(keep_stage) = builder.config.keep_stage {
-            if keep_stage <= compiler.stage {
-                println!("Warning: Using a potentially old codegen backend. \
-                    This may not behave well.");
-                // Codegen backends are linked separately from this step today, so we don't do
-                // anything here.
-                return;
-            }
+        if builder.config.keep_stage.contains(&compiler.stage) {
+            builder.info("Warning: Using a potentially old codegen backend. \
+                This may not behave well.");
+            // Codegen backends are linked separately from this step today, so we don't do
+            // anything here.
+            return;
         }
 
         if builder.force_use_stage1(compiler, target) {

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -63,7 +63,7 @@ pub struct Config {
 
     pub on_fail: Option<String>,
     pub stage: Option<u32>,
-    pub keep_stage: Option<u32>,
+    pub keep_stage: Vec<u32>,
     pub src: PathBuf,
     pub jobs: Option<u32>,
     pub cmd: Subcommand,

--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -31,7 +31,7 @@ pub struct Flags {
     pub verbose: usize, // number of -v args; each extra -v after the first is passed to Cargo
     pub on_fail: Option<String>,
     pub stage: Option<u32>,
-    pub keep_stage: Option<u32>,
+    pub keep_stage: Vec<u32>,
 
     pub host: Vec<Interned<String>>,
     pub target: Vec<Interned<String>>,
@@ -122,7 +122,7 @@ To learn more about a subcommand, run `./x.py <subcommand> -h`"
         opts.optopt("", "on-fail", "command to run on failure", "CMD");
         opts.optflag("", "dry-run", "dry run; don't build anything");
         opts.optopt("", "stage", "stage to build", "N");
-        opts.optopt("", "keep-stage", "stage to keep without recompiling", "N");
+        opts.optmulti("", "keep-stage", "stage(s) to keep without recompiling", "N");
         opts.optopt("", "src", "path to the root of the rust checkout", "DIR");
         opts.optopt("j", "jobs", "number of jobs to run in parallel", "JOBS");
         opts.optflag("h", "help", "print this help message");
@@ -402,7 +402,9 @@ Arguments:
             dry_run: matches.opt_present("dry-run"),
             on_fail: matches.opt_str("on-fail"),
             rustc_error_format: matches.opt_str("error-format"),
-            keep_stage: matches.opt_str("keep-stage").map(|j| j.parse().unwrap()),
+            keep_stage: matches.opt_strs("keep-stage")
+                .into_iter().map(|j| j.parse().unwrap())
+                .collect(),
             host: split(matches.opt_strs("host"))
                 .into_iter()
                 .map(|x| INTERNER.intern_string(x))


### PR DESCRIPTION
Previously we'd attempt to recompile them and that would fail since
we've essentially not built the entire compiler yet, or we're faking
that fact. This commit should make us ignore the codegen backend build
as well.

Unlike the other compile steps, there is no CodegenBackendLink step that
we run here, because that is done later as a part of assembling the
final compiler and as an explicit function call.

r? @alexcrichton

I think this may fix or at least assist with #52174.

cc @RalfJung @tinco -- if you can test this patch locally that'd be
amazing; I don't want to recompile for the next couple hours to test it
locally. I don't think it can make the situation worse, and in fact, if
I've interpreted the cause of the failure correctly then this will fix
your problem.