### PR TITLE
rustdoc: don't panic when the cross-re-export handler sees a proc-macro

### DIFF
--- a/src/test/rustdoc/doc-proc-macro.rs
+++ b/src/test/rustdoc/doc-proc-macro.rs
@@ -1,0 +1,18 @@
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Issue #52129: ICE when trying to document the `quote` proc-macro from proc_macro
+
+// As of this writing, we don't currently attempt to document proc-macros. However, we shouldn't
+// crash when we try.
+
+extern crate proc_macro;
+
+pub use proc_macro::*;


### PR DESCRIPTION
When i moved the macro cross-re-export inlining code into `clean::inline`, i thought that if a macro had a `Def` that said it was a bang macro, it wouldn't be a proc macro. I thought wrong. Turns out, the `quote!()` in `libproc_macro` is actually a proc-macro, and when the `quote!()` macro is re-exported, this proc-macro is accessed in its place. This causes any `proc_macro::*` glob re-export to pull in this proc-macro, causing the assertion i added to fire, leading to an ICE. This replaces that with an Option that ignores proc-macros for the time being.

Fixes https://github.com/rust-lang/rust/issues/52129