### PR TITLE
[beta] Rollup backports

### DIFF
--- a/src/librustc/lint/levels.rs
+++ b/src/librustc/lint/levels.rs
@@ -118,6 +118,11 @@ impl LintLevelSets {
         // Ensure that we never exceed the `--cap-lints` argument.
         level = cmp::min(level, self.lint_cap);
 
+        if let Some(driver_level) = sess.driver_lint_caps.get(&LintId::of(lint)) {
+            // Ensure that we never exceed driver level.
+            level = cmp::min(*driver_level, level);
+        }
+
         return (level, src)
     }
 

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -1342,7 +1342,7 @@ impl<'a, 'gcx, 'tcx> MemCategorizationContext<'a, 'gcx, 'tcx> {
                 ref ty => span_bug!(pat.span, "tuple pattern unexpected type {:?}", ty),
             };
             for (i, subpat) in subpats.iter().enumerate_and_adjust(expected_len, ddpos) {
-                let subpat_ty = self.pat_ty_unadjusted(&subpat)?; // see (*2)
+                let subpat_ty = self.pat_ty_adjusted(&subpat)?; // see (*2)
                 let interior = InteriorField(FieldIndex(i, Name::intern(&i.to_string())));
                 let subcmt = Rc::new(self.cat_imm_interior(pat, cmt.clone(), subpat_ty, interior));
                 self.cat_pattern_(subcmt, &subpat, op)?;

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -22,7 +22,7 @@ use middle::dependency_format;
 use session::search_paths::PathKind;
 use session::config::{OutputType};
 use ty::tls;
-use util::nodemap::{FxHashSet};
+use util::nodemap::{FxHashMap, FxHashSet};
 use util::common::{duration_to_secs_str, ErrorReported};
 use util::common::ProfileQueriesMsg;
 
@@ -160,6 +160,9 @@ pub struct Session {
 
     /// Metadata about the allocators for the current crate being compiled
     pub has_global_allocator: Once<bool>,
+
+    /// Cap lint level specified by a driver specifically.
+    pub driver_lint_caps: FxHashMap<lint::LintId, lint::Level>,
 }
 
 pub struct PerfStats {
@@ -1164,6 +1167,7 @@ pub fn build_session_(
             (*GLOBAL_JOBSERVER).clone()
         },
         has_global_allocator: Once::new(),
+        driver_lint_caps: FxHashMap(),
     };
 
     sess

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -283,7 +283,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnsafeCode {
 }
 
 declare_lint! {
-    MISSING_DOCS,
+    pub MISSING_DOCS,
     Allow,
     "detects missing documentation for public members"
 }

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -51,7 +51,7 @@ use lint::LintId;
 use lint::FutureIncompatibleInfo;
 
 mod bad_style;
-mod builtin;
+pub mod builtin;
 mod types;
 mod unused;
 

--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -105,7 +105,10 @@ use rustc::hir::{self, PatKind};
 
 // a variation on try that just returns unit
 macro_rules! ignore_err {
-    ($e:expr) => (match $e { Ok(e) => e, Err(_) => return () })
+    ($e:expr) => (match $e { Ok(e) => e, Err(_) => {
+        debug!("ignoring mem-categorization error!");
+        return ()
+    }})
 }
 
 ///////////////////////////////////////////////////////////////////////////
@@ -1034,7 +1037,7 @@ impl<'a, 'gcx, 'tcx> RegionCtxt<'a, 'gcx, 'tcx> {
         debug!("link_pattern(discr_cmt={:?}, root_pat={:?})",
                discr_cmt,
                root_pat);
-        let _ = self.with_mc(|mc| {
+        ignore_err!(self.with_mc(|mc| {
             mc.cat_pattern(discr_cmt, root_pat, |sub_cmt, sub_pat| {
                 match sub_pat.node {
                     // `ref x` pattern
@@ -1049,7 +1052,7 @@ impl<'a, 'gcx, 'tcx> RegionCtxt<'a, 'gcx, 'tcx> {
                     _ => {}
                 }
             })
-        });
+        }));
     }
 
     /// Link lifetime of borrowed pointer resulting from autoref to lifetimes in the value being

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -241,6 +241,8 @@ pub fn run_core(search_paths: SearchPaths,
                                      .into_iter()
                                      .chain(rustc_lint::SoftLints.get_lints().into_iter())
                                      .filter_map(|lint| {
+                                         // We don't want to whitelist *all* lints so let's
+                                         // ignore those ones.
                                          if lint.name == warnings_lint_name ||
                                             lint.name == intra_link_resolution_failure_name ||
                                             lint.name == missing_docs {

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -235,6 +235,14 @@ pub fn run_core(search_paths: SearchPaths,
         let mut sess = session::build_session_(
             sessopts, cpath, diagnostic_handler, codemap,
         );
+
+        let shutdown_lints = [lint::builtin::UNUSED_IMPORTS,
+                              lint::builtin::UNUSED_EXTERN_CRATES];
+
+        for l in &shutdown_lints {
+            sess.driver_lint_caps.insert(lint::LintId::of(l), lint::Allow);
+        }
+
         let codegen_backend = rustc_driver::get_codegen_backend(&sess);
         let cstore = Rc::new(CStore::new(codegen_backend.metadata_loader()));
         rustc_lint::register_builtins(&mut sess.lint_store.borrow_mut(), Some(&sess));
@@ -299,7 +307,6 @@ pub fn run_core(search_paths: SearchPaths,
                                                             &sess);
 
         let resolver = RefCell::new(resolver);
-
         abort_on_err(driver::phase_3_run_analysis_passes(&*codegen_backend,
                                                         control,
                                                         &sess,

--- a/src/test/compile-fail/issue-52213.rs
+++ b/src/test/compile-fail/issue-52213.rs
@@ -1,0 +1,24 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn transmute_lifetime<'a, 'b, T>(t: &'a (T,)) -> &'b T {
+    match (&t,) { //~ ERROR cannot infer an appropriate lifetime
+        ((u,),) => u,
+    }
+}
+
+fn main() {
+    let x = {
+        let y = Box::new((42,));
+        transmute_lifetime(&y)
+    };
+
+    println!("{}", x);
+}

--- a/src/test/rustdoc-ui/unused.rs
+++ b/src/test/rustdoc-ui/unused.rs
@@ -1,0 +1,24 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-pass
+
+// This test purpose is to check that unused_imports lint isn't fired
+// by rustdoc. Why would it? Because when rustdoc is running, it uses
+// "everybody-loops" which replaces parts of code with "loop {}" to get
+// huge performance improvements.
+
+#![deny(unused_imports)]
+
+use std::fs::File;
+
+pub fn f() {
+    let _: File;
+}


### PR DESCRIPTION
Merged and approved:

* #51956: Fix rustdoc run failures by shutting down definitely some lints
* #52232: use the adjusted type for cat_pattern in tuple patterns 

Closes #52311
Closes #52313

r? @ghost