### PR TITLE
Revert #52212 (revert set opt-level = 3)

### DIFF
--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -40,6 +40,13 @@ members = [
   "tools/rls/test_data/workspace_symbol",
 ]
 
+# Curiously, LLVM 7.0 will segfault if compiled with opt-level=3
+# See issue https://github.com/rust-lang/rust/issues/52378
+[profile.release]
+opt-level = 2
+[profile.bench]
+opt-level = 2
+
 # These options are controlled from our rustc wrapper script, so turn them off
 # here and have them controlled elsewhere.
 [profile.dev]


### PR DESCRIPTION
Setting -O3 causes LLVM to spuriously segfault at least on Linux. This PR reverts to -O2.

cc #52378