### PR TITLE
Remove `ty_to_def_id`

### DIFF
--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -469,13 +469,9 @@ impl<'a, 'tcx> DeadVisitor<'a, 'tcx> {
 
     fn should_warn_about_field(&mut self, field: &hir::StructField) -> bool {
         let field_type = self.tcx.type_of(self.tcx.hir.local_def_id(field.id));
-        let is_marker_field = match field_type.ty_to_def_id() {
-            Some(def_id) => self.tcx.lang_items().items().iter().any(|item| *item == Some(def_id)),
-            _ => false
-        };
         !field.is_positional()
             && !self.symbol_is_live(field.id, None)
-            && !is_marker_field
+            && !field_type.is_phantom_data()
             && !has_allow_dead_code_or_lang_attr(self.tcx, field.id, &field.attrs)
     }
 

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -1767,17 +1767,6 @@ impl<'a, 'gcx, 'tcx> TyS<'tcx> {
         }
     }
 
-    pub fn ty_to_def_id(&self) -> Option<DefId> {
-        match self.sty {
-            TyDynamic(ref tt, ..) => tt.principal().map(|p| p.def_id()),
-            TyAdt(def, _) => Some(def.did),
-            TyForeign(did) => Some(did),
-            TyClosure(id, _) => Some(id),
-            TyFnDef(id, _) => Some(id),
-            _ => None,
-        }
-    }
-
     pub fn ty_adt_def(&self) -> Option<&'tcx AdtDef> {
         match self.sty {
             TyAdt(adt, _) => Some(adt),

--- a/src/librustc_codegen_llvm/back/write.rs
+++ b/src/librustc_codegen_llvm/back/write.rs
@@ -399,6 +399,9 @@ impl CodegenContext {
 }
 
 struct DiagnosticHandlers<'a> {
+    #[allow(dead_code)]
+    // This value is not actually dead, llcx has pointers to it and needs these pointers to be alive
+    // until Drop is executed on this object
     inner: Box<(&'a CodegenContext, &'a Handler)>,
     llcx: ContextRef,
 }

--- a/src/librustc_codegen_llvm/back/write.rs
+++ b/src/librustc_codegen_llvm/back/write.rs
@@ -399,10 +399,7 @@ impl CodegenContext {
 }
 
 struct DiagnosticHandlers<'a> {
-    #[allow(dead_code)]
-    // This value is not actually dead, llcx has pointers to it and needs these pointers to be alive
-    // until Drop is executed on this object
-    inner: Box<(&'a CodegenContext, &'a Handler)>,
+    data: *mut (&'a CodegenContext, &'a Handler),
     llcx: ContextRef,
 }
 
@@ -410,24 +407,22 @@ impl<'a> DiagnosticHandlers<'a> {
     fn new(cgcx: &'a CodegenContext,
            handler: &'a Handler,
            llcx: ContextRef) -> DiagnosticHandlers<'a> {
-        let data = Box::new((cgcx, handler));
+        let data = Box::into_raw(Box::new((cgcx, handler)));
         unsafe {
-            let arg = &*data as &(_, _) as *const _ as *mut _;
-            llvm::LLVMRustSetInlineAsmDiagnosticHandler(llcx, inline_asm_handler, arg);
-            llvm::LLVMContextSetDiagnosticHandler(llcx, diagnostic_handler, arg);
+            llvm::LLVMRustSetInlineAsmDiagnosticHandler(llcx, inline_asm_handler, data as *mut _);
+            llvm::LLVMContextSetDiagnosticHandler(llcx, diagnostic_handler, data as *mut _);
         }
-        DiagnosticHandlers {
-            inner: data,
-            llcx: llcx,
-        }
+        DiagnosticHandlers { data, llcx }
     }
 }
 
 impl<'a> Drop for DiagnosticHandlers<'a> {
     fn drop(&mut self) {
+        use std::ptr::null_mut;
         unsafe {
-            llvm::LLVMRustSetInlineAsmDiagnosticHandler(self.llcx, inline_asm_handler, 0 as *mut _);
-            llvm::LLVMContextSetDiagnosticHandler(self.llcx, diagnostic_handler, 0 as *mut _);
+            llvm::LLVMRustSetInlineAsmDiagnosticHandler(self.llcx, inline_asm_handler, null_mut());
+            llvm::LLVMContextSetDiagnosticHandler(self.llcx, diagnostic_handler, null_mut());
+            drop(Box::from_raw(self.data));
         }
     }
 }

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -591,8 +591,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MissingDebugImplementations {
         if self.impling_types.is_none() {
             let mut impls = NodeSet();
             cx.tcx.for_each_impl(debug, |d| {
-                if let Some(ty_def) = cx.tcx.type_of(d).ty_to_def_id() {
-                    if let Some(node_id) = cx.tcx.hir.as_local_node_id(ty_def) {
+                if let Some(ty_def) = cx.tcx.type_of(d).ty_adt_def() {
+                    if let Some(node_id) = cx.tcx.hir.as_local_node_id(ty_def.did) {
                         impls.insert(node_id);
                     }
                 }


### PR DESCRIPTION
fixes https://github.com/rust-lang/rust/issues/52341

The uses were mostly convenience and generally "too powerful" (would also have worked for types that weren't interesting at the use site)

r? @eddyb 