### PR TITLE
resolve: Functions introducing procedural macros reserve a slot in the macro namespace as well

### DIFF
--- a/src/librustc/ich/impls_syntax.rs
+++ b/src/librustc/ich/impls_syntax.rs
@@ -98,7 +98,8 @@ impl_stable_hash_for!(enum ::syntax::ast::AsmDialect {
 impl_stable_hash_for!(enum ::syntax::ext::base::MacroKind {
     Bang,
     Attr,
-    Derive
+    Derive,
+    ProcMacroStub,
 });
 
 

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -571,6 +571,8 @@ pub enum MacroKind {
     Attr,
     /// A derive attribute macro - #[derive(Foo)]
     Derive,
+    /// A view of a procedural macro from the same crate that defines it.
+    ProcMacroStub,
 }
 
 impl MacroKind {
@@ -579,6 +581,7 @@ impl MacroKind {
             MacroKind::Bang => "macro",
             MacroKind::Attr => "attribute macro",
             MacroKind::Derive => "derive macro",
+            MacroKind::ProcMacroStub => "crate-local procedural macro",
         }
     }
 }

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -232,7 +232,7 @@ pub enum InvocationKind {
 }
 
 impl Invocation {
-    fn span(&self) -> Span {
+    pub fn span(&self) -> Span {
         match self.kind {
             InvocationKind::Bang { span, .. } => span,
             InvocationKind::Attr { attr: Some(ref attr), .. } => attr.span,

--- a/src/libsyntax_ext/proc_macro_registrar.rs
+++ b/src/libsyntax_ext/proc_macro_registrar.rs
@@ -147,11 +147,6 @@ impl<'a> CollectProcMacros<'a> {
                                   "cannot override a built-in #[derive] mode");
         }
 
-        if self.derives.iter().any(|d| d.trait_name == trait_name) {
-            self.handler.span_err(trait_attr.span(),
-                                  "derive mode defined twice in this crate");
-        }
-
         let proc_attrs: Vec<_> = if let Some(attr) = attributes_attr {
             if !attr.check_name("attributes") {
                 self.handler.span_err(attr.span(), "second argument must be `attributes`")

--- a/src/test/compile-fail-fulldeps/proc-macro/define-two.rs
+++ b/src/test/compile-fail-fulldeps/proc-macro/define-two.rs
@@ -21,7 +21,7 @@ pub fn foo(input: TokenStream) -> TokenStream {
     input
 }
 
-#[proc_macro_derive(A)] //~ ERROR: derive mode defined twice in this crate
+#[proc_macro_derive(A)] //~ ERROR the name `A` is defined multiple times
 pub fn bar(input: TokenStream) -> TokenStream {
     input
 }

--- a/src/test/ui-fulldeps/proc-macro/macro-namespace-reserved-2.rs
+++ b/src/test/ui-fulldeps/proc-macro/macro-namespace-reserved-2.rs
@@ -1,0 +1,56 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+
+#![feature(proc_macro)]
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+use proc_macro::*;
+
+#[proc_macro]
+pub fn my_macro(input: TokenStream) -> TokenStream {
+    input
+}
+
+#[proc_macro_attribute]
+pub fn my_macro_attr(input: TokenStream, _: TokenStream) -> TokenStream {
+    input
+}
+
+#[proc_macro_derive(MyTrait)]
+pub fn my_macro_derive(input: TokenStream) -> TokenStream {
+    input
+}
+
+fn check_bang1() {
+    my_macro!(); //~ ERROR can't use a procedural macro from the same crate that defines it
+}
+fn check_bang2() {
+    my_macro_attr!(); //~ ERROR can't use a procedural macro from the same crate that defines it
+}
+fn check_bang3() {
+    MyTrait!(); //~ ERROR can't use a procedural macro from the same crate that defines it
+}
+
+#[my_macro] //~ ERROR can't use a procedural macro from the same crate that defines it
+fn check_attr1() {}
+#[my_macro_attr] //~ ERROR can't use a procedural macro from the same crate that defines it
+fn check_attr2() {}
+#[MyTrait] //~ ERROR can't use a procedural macro from the same crate that defines it
+fn check_attr3() {}
+
+#[derive(my_macro)] //~ ERROR can't use a procedural macro from the same crate that defines it
+struct CheckDerive1;
+#[derive(my_macro_attr)] //~ ERROR can't use a procedural macro from the same crate that defines it
+struct CheckDerive2;
+#[derive(MyTrait)] //~ ERROR can't use a procedural macro from the same crate that defines it
+struct CheckDerive3;

--- a/src/test/ui-fulldeps/proc-macro/macro-namespace-reserved-2.stderr
+++ b/src/test/ui-fulldeps/proc-macro/macro-namespace-reserved-2.stderr
@@ -1,0 +1,56 @@
+error: can't use a procedural macro from the same crate that defines it
+  --> $DIR/macro-namespace-reserved-2.rs:35:5
+   |
+LL |     my_macro!(); //~ ERROR can't use a procedural macro from the same crate that defines it
+   |     ^^^^^^^^^^^^
+
+error: can't use a procedural macro from the same crate that defines it
+  --> $DIR/macro-namespace-reserved-2.rs:38:5
+   |
+LL |     my_macro_attr!(); //~ ERROR can't use a procedural macro from the same crate that defines it
+   |     ^^^^^^^^^^^^^^^^^
+
+error: can't use a procedural macro from the same crate that defines it
+  --> $DIR/macro-namespace-reserved-2.rs:41:5
+   |
+LL |     MyTrait!(); //~ ERROR can't use a procedural macro from the same crate that defines it
+   |     ^^^^^^^^^^^
+
+error: can't use a procedural macro from the same crate that defines it
+  --> $DIR/macro-namespace-reserved-2.rs:44:1
+   |
+LL | #[my_macro] //~ ERROR can't use a procedural macro from the same crate that defines it
+   | ^^^^^^^^^^^
+
+error: can't use a procedural macro from the same crate that defines it
+  --> $DIR/macro-namespace-reserved-2.rs:46:1
+   |
+LL | #[my_macro_attr] //~ ERROR can't use a procedural macro from the same crate that defines it
+   | ^^^^^^^^^^^^^^^^
+
+error: can't use a procedural macro from the same crate that defines it
+  --> $DIR/macro-namespace-reserved-2.rs:48:1
+   |
+LL | #[MyTrait] //~ ERROR can't use a procedural macro from the same crate that defines it
+   | ^^^^^^^^^^
+
+error: can't use a procedural macro from the same crate that defines it
+  --> $DIR/macro-namespace-reserved-2.rs:51:10
+   |
+LL | #[derive(my_macro)] //~ ERROR can't use a procedural macro from the same crate that defines it
+   |          ^^^^^^^^
+
+error: can't use a procedural macro from the same crate that defines it
+  --> $DIR/macro-namespace-reserved-2.rs:53:10
+   |
+LL | #[derive(my_macro_attr)] //~ ERROR can't use a procedural macro from the same crate that defines it
+   |          ^^^^^^^^^^^^^
+
+error: can't use a procedural macro from the same crate that defines it
+  --> $DIR/macro-namespace-reserved-2.rs:55:10
+   |
+LL | #[derive(MyTrait)] //~ ERROR can't use a procedural macro from the same crate that defines it
+   |          ^^^^^^^
+
+error: aborting due to 9 previous errors
+

--- a/src/test/ui-fulldeps/proc-macro/macro-namespace-reserved.rs
+++ b/src/test/ui-fulldeps/proc-macro/macro-namespace-reserved.rs
@@ -1,0 +1,47 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+
+#![feature(proc_macro, decl_macro)]
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+use proc_macro::*;
+
+#[proc_macro]
+pub fn my_macro(input: TokenStream) -> TokenStream {
+    input
+}
+
+#[proc_macro_attribute]
+pub fn my_macro_attr(input: TokenStream, _: TokenStream) -> TokenStream {
+    input
+}
+
+#[proc_macro_derive(MyTrait)]
+pub fn my_macro_derive(input: TokenStream) -> TokenStream {
+    input
+}
+
+macro my_macro() {} //~ ERROR the name `my_macro` is defined multiple times
+macro my_macro_attr() {} //~ ERROR the name `my_macro_attr` is defined multiple times
+macro MyTrait() {} //~ ERROR the name `MyTrait` is defined multiple times
+
+#[proc_macro_derive(SameName)]
+pub fn foo(input: TokenStream) -> TokenStream {
+    input
+}
+
+#[proc_macro]
+pub fn SameName(input: TokenStream) -> TokenStream {
+//~^ ERROR the name `SameName` is defined multiple times
+    input
+}

--- a/src/test/ui-fulldeps/proc-macro/macro-namespace-reserved.stderr
+++ b/src/test/ui-fulldeps/proc-macro/macro-namespace-reserved.stderr
@@ -1,0 +1,47 @@
+error[E0428]: the name `my_macro` is defined multiple times
+  --> $DIR/macro-namespace-reserved.rs:34:1
+   |
+LL | pub fn my_macro(input: TokenStream) -> TokenStream {
+   | -------------------------------------------------- previous definition of the macro `my_macro` here
+...
+LL | macro my_macro() {} //~ ERROR the name `my_macro` is defined multiple times
+   | ^^^^^^^^^^^^^^^^ `my_macro` redefined here
+   |
+   = note: `my_macro` must be defined only once in the macro namespace of this module
+
+error[E0428]: the name `my_macro_attr` is defined multiple times
+  --> $DIR/macro-namespace-reserved.rs:35:1
+   |
+LL | pub fn my_macro_attr(input: TokenStream, _: TokenStream) -> TokenStream {
+   | ----------------------------------------------------------------------- previous definition of the macro `my_macro_attr` here
+...
+LL | macro my_macro_attr() {} //~ ERROR the name `my_macro_attr` is defined multiple times
+   | ^^^^^^^^^^^^^^^^^^^^^ `my_macro_attr` redefined here
+   |
+   = note: `my_macro_attr` must be defined only once in the macro namespace of this module
+
+error[E0428]: the name `MyTrait` is defined multiple times
+  --> $DIR/macro-namespace-reserved.rs:36:1
+   |
+LL | #[proc_macro_derive(MyTrait)]
+   |                     ------- previous definition of the macro `MyTrait` here
+...
+LL | macro MyTrait() {} //~ ERROR the name `MyTrait` is defined multiple times
+   | ^^^^^^^^^^^^^^^ `MyTrait` redefined here
+   |
+   = note: `MyTrait` must be defined only once in the macro namespace of this module
+
+error[E0428]: the name `SameName` is defined multiple times
+  --> $DIR/macro-namespace-reserved.rs:44:1
+   |
+LL | #[proc_macro_derive(SameName)]
+   |                     -------- previous definition of the macro `SameName` here
+...
+LL | pub fn SameName(input: TokenStream) -> TokenStream {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `SameName` redefined here
+   |
+   = note: `SameName` must be defined only once in the macro namespace of this module
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0428`.


### PR DESCRIPTION
Similarly to https://github.com/rust-lang/rust/pull/52234, this gives us symmetry between internal and external views of a crate, but in this case it's always an error to call a procedural macro in the same crate in which it's defined.

Closes https://github.com/rust-lang/rust/issues/52225