### PR TITLE
Pass edition flags to compiler from rustdoc as expected

### DIFF
--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -37,7 +37,7 @@ use syntax::codemap::CodeMap;
 use syntax::edition::Edition;
 use syntax::feature_gate::UnstableFeatures;
 use syntax::with_globals;
-use syntax_pos::{BytePos, DUMMY_SP, Pos, Span, FileName};
+use syntax_pos::{BytePos, DUMMY_SP, Pos, Span, FileName, hygiene};
 use errors;
 use errors::emitter::ColorConfig;
 
@@ -561,6 +561,7 @@ impl Collector {
                     rustc_driver::in_rustc_thread(move || with_globals(move || {
                         io::set_panic(panic);
                         io::set_print(print);
+                        hygiene::set_default_edition(edition);
                         run_test(&test,
                                  &cratename,
                                  &filename,

--- a/src/test/rustdoc/edition-flag.rs
+++ b/src/test/rustdoc/edition-flag.rs
@@ -1,0 +1,24 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags:--test -Z unstable-options
+// edition:2018
+
+#![feature(async_await)]
+
+/// ```rust
+/// #![feature(async_await)]
+/// fn main() {
+///     let _ = async { };
+/// }
+/// ```
+fn main() {
+    let _ = async { };
+}


### PR DESCRIPTION
Fixes #52357.

r? @QuietMisdreavus 