### PR TITLE
Add unaligned volatile intrinsics

### DIFF
--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -1085,6 +1085,15 @@ extern "rust-intrinsic" {
     /// [`std::ptr::write_volatile`](../../std/ptr/fn.write_volatile.html).
     pub fn volatile_store<T>(dst: *mut T, val: T);
 
+    /// Perform a volatile load from the `src` pointer
+    /// The pointer is not required to be aligned.
+    #[cfg(not(stage0))]
+    pub fn unaligned_volatile_load<T>(src: *const T) -> T;
+    /// Perform a volatile store to the `dst` pointer.
+    /// The pointer is not required to be aligned.
+    #[cfg(not(stage0))]
+    pub fn unaligned_volatile_store<T>(dst: *mut T, val: T);
+
     /// Returns the square root of an `f32`
     pub fn sqrtf32(x: f32) -> f32;
     /// Returns the square root of an `f64`

--- a/src/librustc_codegen_llvm/mir/operand.rs
+++ b/src/librustc_codegen_llvm/mir/operand.rs
@@ -286,6 +286,10 @@ impl<'a, 'tcx> OperandValue {
         self.store_with_flags(bx, dest, MemFlags::VOLATILE);
     }
 
+    pub fn unaligned_volatile_store(self, bx: &Builder<'a, 'tcx>, dest: PlaceRef<'tcx>) {
+        self.store_with_flags(bx, dest, MemFlags::VOLATILE | MemFlags::UNALIGNED);
+    }
+
     pub fn nontemporal_store(self, bx: &Builder<'a, 'tcx>, dest: PlaceRef<'tcx>) {
         self.store_with_flags(bx, dest, MemFlags::NONTEMPORAL);
     }

--- a/src/librustc_typeck/check/intrinsic.rs
+++ b/src/librustc_typeck/check/intrinsic.rs
@@ -270,9 +270,9 @@ pub fn check_intrinsic_type<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
             "roundf32"     => (0, vec![ tcx.types.f32 ], tcx.types.f32),
             "roundf64"     => (0, vec![ tcx.types.f64 ], tcx.types.f64),
 
-            "volatile_load" =>
+            "volatile_load" | "unaligned_volatile_load" =>
                 (1, vec![ tcx.mk_imm_ptr(param(0)) ], param(0)),
-            "volatile_store" =>
+            "volatile_store" | "unaligned_volatile_store" =>
                 (1, vec![ tcx.mk_mut_ptr(param(0)), param(0) ], tcx.mk_nil()),
 
             "ctpop" | "ctlz" | "ctlz_nonzero" | "cttz" | "cttz_nonzero" |

--- a/src/test/run-make-fulldeps/volatile-intrinsics/main.rs
+++ b/src/test/run-make-fulldeps/volatile-intrinsics/main.rs
@@ -10,17 +10,24 @@
 
 #![feature(core_intrinsics, volatile)]
 
-use std::intrinsics::{volatile_load, volatile_store};
+use std::intrinsics::{
+    unaligned_volatile_load, unaligned_volatile_store, volatile_load, volatile_store,
+};
 use std::ptr::{read_volatile, write_volatile};
 
 pub fn main() {
     unsafe {
-        let mut i : isize = 1;
+        let mut i: isize = 1;
         volatile_store(&mut i, 2);
         assert_eq!(volatile_load(&i), 2);
     }
     unsafe {
-        let mut i : isize = 1;
+        let mut i: isize = 1;
+        unaligned_volatile_store(&mut i, 2);
+        assert_eq!(unaligned_volatile_load(&i), 2);
+    }
+    unsafe {
+        let mut i: isize = 1;
         write_volatile(&mut i, 2);
         assert_eq!(read_volatile(&i), 2);
     }


### PR DESCRIPTION
Surprisingly enough, it turns out that unaligned volatile loads are actually useful for certain (very niche) types of lock-free code. I included unaligned volatile stores for completeness, but I currently do not know of any use cases for them.

These are only exposed as intrinsics for now. If they turn out to be useful in practice, we can work towards stabilizing them.

r? @alexcrichton 