### PR TITLE
Suggest comma when writing `println!("{}" a);`

### DIFF
--- a/src/libsyntax/tokenstream.rs
+++ b/src/libsyntax/tokenstream.rs
@@ -186,7 +186,7 @@ impl TokenStream {
     /// Given a `TokenStream` with a `Stream` of only two arguments, return a new `TokenStream`
     /// separating the two arguments with a comma for diagnostic suggestions.
     pub(crate) fn add_comma(&self) -> Option<(TokenStream, Span)> {
-        // Used ot suggest if a user writes `println!("{}" a);`
+        // Used to suggest if a user writes `println!("{}" a);`
         if let TokenStreamKind::Stream(ref slice) = self.kind {
             if slice.len() == 2 {
                 let comma_span = match slice[0] {

--- a/src/libsyntax/tokenstream.rs
+++ b/src/libsyntax/tokenstream.rs
@@ -182,6 +182,31 @@ pub struct TokenStream {
     kind: TokenStreamKind,
 }
 
+impl TokenStream {
+    /// Given a `TokenStream` with a `Stream` of only two arguments, return a new `TokenStream`
+    /// separating the two arguments with a comma for diagnostic suggestions.
+    pub(crate) fn add_comma(&self) -> Option<(TokenStream, Span)> {
+        // Used ot suggest if a user writes `println!("{}" a);`
+        if let TokenStreamKind::Stream(ref slice) = self.kind {
+            if slice.len() == 2 {
+                let comma_span = match slice[0] {
+                    TokenStream { kind: TokenStreamKind::Tree(TokenTree::Token(sp, _)) } |
+                    TokenStream { kind: TokenStreamKind::Tree(TokenTree::Delimited(sp, _)) } => {
+                        sp.shrink_to_hi()
+                    }
+                    _ => DUMMY_SP,
+                };
+                let comma = TokenStream {
+                    kind: TokenStreamKind::Tree(TokenTree::Token(comma_span, token::Comma)),
+                };
+                let slice = RcSlice::new(vec![slice[0].clone(), comma, slice[1].clone()]);
+                return Some((TokenStream { kind: TokenStreamKind::Stream(slice) }, comma_span));
+            }
+        }
+        None
+    }
+}
+
 #[derive(Clone, Debug)]
 enum TokenStreamKind {
     Empty,

--- a/src/libsyntax_ext/format.rs
+++ b/src/libsyntax_ext/format.rs
@@ -147,7 +147,7 @@ fn parse_args(ecx: &mut ExtCtxt,
     let mut named = false;
     while p.token != token::Eof {
         if !p.eat(&token::Comma) {
-            ecx.span_err(sp, "expected token: `,`");
+            ecx.span_err(p.span, "expected token: `,`");
             return None;
         }
         if p.token == token::Eof {

--- a/src/test/ui/codemap_tests/bad-format-args.stderr
+++ b/src/test/ui/codemap_tests/bad-format-args.stderr
@@ -7,20 +7,16 @@ LL |     format!(); //~ ERROR requires at least a format string argument
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: expected token: `,`
-  --> $DIR/bad-format-args.rs:13:5
+  --> $DIR/bad-format-args.rs:13:16
    |
 LL |     format!("" 1); //~ ERROR expected token: `,`
-   |     ^^^^^^^^^^^^^^
-   |
-   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+   |                ^
 
 error: expected token: `,`
-  --> $DIR/bad-format-args.rs:14:5
+  --> $DIR/bad-format-args.rs:14:19
    |
 LL |     format!("", 1 1); //~ ERROR expected token: `,`
-   |     ^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+   |                   ^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/macros/missing-comma.rs
+++ b/src/test/ui/macros/missing-comma.rs
@@ -1,0 +1,14 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    println!("{}" a);
+    //~^ ERROR no rules expected the token `a`
+}

--- a/src/test/ui/macros/missing-comma.rs
+++ b/src/test/ui/macros/missing-comma.rs
@@ -8,7 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+macro_rules! foo {
+    ($a:ident, $b:ident) => ()
+}
+
 fn main() {
     println!("{}" a);
-    //~^ ERROR no rules expected the token `a`
+    //~^ ERROR expected token: `,`
+    foo!(a b);
+    //~^ ERROR no rules expected the token `b`
 }

--- a/src/test/ui/macros/missing-comma.stderr
+++ b/src/test/ui/macros/missing-comma.stderr
@@ -1,10 +1,16 @@
-error: no rules expected the token `a`
-  --> $DIR/missing-comma.rs:12:19
+error: expected token: `,`
+  --> $DIR/missing-comma.rs:16:19
    |
 LL |     println!("{}" a);
-   |                  -^
-   |                  |
-   |                  help: missing comma here
+   |                   ^
 
-error: aborting due to previous error
+error: no rules expected the token `b`
+  --> $DIR/missing-comma.rs:18:12
+   |
+LL |     foo!(a b);
+   |           -^
+   |           |
+   |           help: missing comma here
+
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/macros/missing-comma.stderr
+++ b/src/test/ui/macros/missing-comma.stderr
@@ -1,0 +1,10 @@
+error: no rules expected the token `a`
+  --> $DIR/missing-comma.rs:12:19
+   |
+LL |     println!("{}" a);
+   |                  -^
+   |                  |
+   |                  help: missing comma here
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fix #49370.