### PR TITLE
CTFE: use binary_op to compare integer with match disriminant

### DIFF
--- a/src/test/ui/const-eval/match-test-ptr-null.rs
+++ b/src/test/ui/const-eval/match-test-ptr-null.rs
@@ -1,0 +1,12 @@
+fn main() {
+    // Make sure match uses the usual pointer comparison code path -- i.e., it should complain
+    // that pointer comparison is disallowed, not that parts of a pointer are accessed as raw
+    // bytes.
+    let _: [u8; 0] = [4; { //~ ERROR could not evaluate repeat length
+        match &1 as *const i32 as usize { //~ ERROR raw pointers cannot be cast to integers
+            0 => 42, //~ ERROR constant contains unimplemented expression type
+            //~^ NOTE "pointer arithmetic or comparison" needs an rfc before being allowed
+            n => n,
+        }
+    }];
+}

--- a/src/test/ui/const-eval/match-test-ptr-null.rs
+++ b/src/test/ui/const-eval/match-test-ptr-null.rs
@@ -1,3 +1,13 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
 fn main() {
     // Make sure match uses the usual pointer comparison code path -- i.e., it should complain
     // that pointer comparison is disallowed, not that parts of a pointer are accessed as raw

--- a/src/test/ui/const-eval/match-test-ptr-null.stderr
+++ b/src/test/ui/const-eval/match-test-ptr-null.stderr
@@ -1,17 +1,17 @@
 error[E0018]: raw pointers cannot be cast to integers in constants
-  --> $DIR/match-test-ptr-null.rs:6:15
+  --> $DIR/match-test-ptr-null.rs:16:15
    |
 LL |         match &1 as *const i32 as usize { //~ ERROR raw pointers cannot be cast to integers
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0019]: constant contains unimplemented expression type
-  --> $DIR/match-test-ptr-null.rs:7:13
+  --> $DIR/match-test-ptr-null.rs:17:13
    |
 LL |             0 => 42, //~ ERROR constant contains unimplemented expression type
    |             ^
 
 error[E0080]: could not evaluate repeat length
-  --> $DIR/match-test-ptr-null.rs:5:26
+  --> $DIR/match-test-ptr-null.rs:15:26
    |
 LL |       let _: [u8; 0] = [4; { //~ ERROR could not evaluate repeat length
    |  __________________________^

--- a/src/test/ui/const-eval/match-test-ptr-null.stderr
+++ b/src/test/ui/const-eval/match-test-ptr-null.stderr
@@ -1,0 +1,30 @@
+error[E0018]: raw pointers cannot be cast to integers in constants
+  --> $DIR/match-test-ptr-null.rs:6:15
+   |
+LL |         match &1 as *const i32 as usize { //~ ERROR raw pointers cannot be cast to integers
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0019]: constant contains unimplemented expression type
+  --> $DIR/match-test-ptr-null.rs:7:13
+   |
+LL |             0 => 42, //~ ERROR constant contains unimplemented expression type
+   |             ^
+
+error[E0080]: could not evaluate repeat length
+  --> $DIR/match-test-ptr-null.rs:5:26
+   |
+LL |       let _: [u8; 0] = [4; { //~ ERROR could not evaluate repeat length
+   |  __________________________^
+LL | |         match &1 as *const i32 as usize { //~ ERROR raw pointers cannot be cast to integers
+LL | |             0 => 42, //~ ERROR constant contains unimplemented expression type
+   | |             - "pointer arithmetic or comparison" needs an rfc before being allowed inside constants
+LL | |             //~^ NOTE "pointer arithmetic or comparison" needs an rfc before being allowed
+LL | |             n => n,
+LL | |         }
+LL | |     }];
+   | |_____^
+
+error: aborting due to 3 previous errors
+
+Some errors occurred: E0018, E0019, E0080.
+For more information about an error, try `rustc --explain E0018`.


### PR DESCRIPTION
This is needed to unblock https://github.com/solson/miri/pull/401: There is code in the Windows initialization functions that uses `match` to test whether a pointer is NULL.

I will add a testcase in miri; I was not sure where to add a testcase in Rust itself.

r? @oli-obk 