### PR TITLE
impl PartialEq+Eq for BuildHasherDefault

### DIFF
--- a/src/libcore/hash/mod.rs
+++ b/src/libcore/hash/mod.rs
@@ -542,6 +542,16 @@ impl<H> Default for BuildHasherDefault<H> {
     }
 }
 
+#[stable(since = "1.29.0", feature = "build_hasher_eq")]
+impl<H> PartialEq for BuildHasherDefault<H> {
+    fn eq(&self, _other: &BuildHasherDefault<H>) -> bool {
+        true
+    }
+}
+
+#[stable(since = "1.29.0", feature = "build_hasher_eq")]
+impl<H> Eq for BuildHasherDefault<H> {}
+
 //////////////////////////////////////////////////////////////////////////////
 
 mod impls {


### PR DESCRIPTION
`BuildHasherDefault`is only one way of implementing `BuildHasher`. Clearly, every `BuildHasherDefault` for the same type `H` is identical, since it just uses `Default<H>` to construct `H`. In general, this is not true for every `BuildHasher`, so I think it is helpful to implement `PartialEq` and `Eq`.