### PR TITLE
WIP: Allocator- and fallibility-polymorphic collections

### DIFF
--- a/src/liballoc/abort_adapter.rs
+++ b/src/liballoc/abort_adapter.rs
@@ -54,7 +54,10 @@ unsafe impl<A: Alloc> Alloc for AbortAdapter<A> {
                       ptr: NonNull<u8>,
                       layout: Layout,
                       new_size: usize) -> Result<NonNull<u8>, Self::Err> {
-        self.0.realloc(ptr, layout, new_size).or_else(|_| handle_alloc_error(layout))
+        self.0.realloc(ptr, layout, new_size).or_else(|_| {
+            let layout = Layout::from_size_align_unchecked(new_size, layout.align());
+            handle_alloc_error(layout)
+        })
     }
 
     unsafe fn alloc_zeroed(&mut self, layout: Layout) -> Result<NonNull<u8>, Self::Err> {

--- a/src/liballoc/abort_adapter.rs
+++ b/src/liballoc/abort_adapter.rs
@@ -1,0 +1,115 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![unstable(feature = "allocator_api",
+            reason = "the precise API and guarantees it provides may be tweaked \
+                      slightly, especially to possibly take into account the \
+                      types being stored to make room for a future \
+                      tracing garbage collector",
+            issue = "32838")]
+
+use core::usize;
+use core::ptr::NonNull;
+
+use crate::alloc::*;
+
+/// An allocator adapter that blows up by calling `Alloc::oom` on all errors.
+///
+/// On one hand, concrete allocator implementations should always be written
+/// without panicking on user error and OOM to give users maximum
+/// flexibility. On the other hand, code that depends on allocation succeeding
+/// should depend on `Alloc<Err=!>` to avoid repetitively handling errors from
+/// which it cannot recover.
+///
+/// This adapter bridges the gap, effectively allowing `Alloc<Err=!>` to be
+/// implemented by any allocator.
+#[derive(Copy, Clone, Debug, Default)]
+pub struct AbortAdapter<Alloc>(pub Alloc);
+
+impl<A: AllocHelper> AllocHelper for AbortAdapter<A> {
+    type Err = !;
+}
+
+unsafe impl<A: Alloc> Alloc for AbortAdapter<A> {
+    unsafe fn alloc(&mut self, layout: Layout) -> Result<NonNull<u8>, Self::Err> {
+        self.0.alloc(layout).or_else(|_| handle_alloc_error(layout))
+    }
+
+    unsafe fn dealloc(&mut self, ptr: NonNull<u8>, layout: Layout) {
+        self.0.dealloc(ptr, layout)
+    }
+
+    fn usable_size(&self, layout: &Layout) -> (usize, usize) {
+        self.0.usable_size(layout)
+    }
+
+    unsafe fn realloc(&mut self,
+                      ptr: NonNull<u8>,
+                      layout: Layout,
+                      new_size: usize) -> Result<NonNull<u8>, Self::Err> {
+        self.0.realloc(ptr, layout, new_size).or_else(|_| handle_alloc_error(layout))
+    }
+
+    unsafe fn alloc_zeroed(&mut self, layout: Layout) -> Result<NonNull<u8>, Self::Err> {
+        self.0.alloc_zeroed(layout).or_else(|_| handle_alloc_error(layout))
+    }
+
+    unsafe fn alloc_excess(&mut self, layout: Layout) -> Result<Excess, Self::Err> {
+        self.0.alloc_excess(layout).or_else(|_| handle_alloc_error(layout))
+    }
+
+    unsafe fn grow_in_place(&mut self,
+                            ptr: NonNull<u8>,
+                            layout: Layout,
+                            new_size: usize) -> Result<(), CannotReallocInPlace> {
+        self.0.grow_in_place(ptr, layout, new_size)
+    }
+
+    unsafe fn shrink_in_place(&mut self,
+                              ptr: NonNull<u8>,
+                              layout: Layout,
+                              new_size: usize) -> Result<(), CannotReallocInPlace> {
+        self.0.shrink_in_place(ptr, layout, new_size)
+    }
+
+    fn alloc_one<T>(&mut self) -> Result<NonNull<T>, Self::Err>
+        where Self: Sized
+    {
+        self.0.alloc_one().or_else(|_| handle_alloc_error(Layout::new::<T>()))
+    }
+
+    unsafe fn dealloc_one<T>(&mut self, ptr: NonNull<T>)
+        where Self: Sized
+    {
+        self.0.dealloc_one(ptr)
+    }
+
+    fn alloc_array<T>(&mut self, n: usize) -> Result<NonNull<T>, Self::Err>
+        where Self: Sized
+    {
+        self.0.alloc_array(n).or_else(|_| handle_alloc_error(Layout::new::<T>()))
+    }
+
+    unsafe fn realloc_array<T>(&mut self,
+                               ptr: NonNull<T>,
+                               n_old: usize,
+                               n_new: usize) -> Result<NonNull<T>, Self::Err>
+        where Self: Sized
+    {
+        self.0.realloc_array(ptr, n_old, n_new)
+            .or_else(|_| handle_alloc_error(Layout::new::<T>()))
+    }
+
+    unsafe fn dealloc_array<T>(&mut self, ptr: NonNull<T>, n: usize) -> Result<(), Self::Err>
+        where Self: Sized
+    {
+        self.0.dealloc_array(ptr, n).or_else(|_| handle_alloc_error(Layout::new::<T>()))
+    }
+}

--- a/src/liballoc/alloc.rs
+++ b/src/liballoc/alloc.rs
@@ -122,6 +122,12 @@ pub unsafe fn alloc_zeroed(layout: Layout) -> *mut u8 {
 
 #[cfg(not(test))]
 #[unstable(feature = "allocator_api", issue = "32838")]
+impl AllocHelper for Global {
+    type Err = AllocErr;
+}
+
+#[cfg(not(test))]
+#[unstable(feature = "allocator_api", issue = "32838")]
 unsafe impl Alloc for Global {
     #[inline]
     unsafe fn alloc(&mut self, layout: Layout) -> Result<NonNull<u8>, AllocErr> {

--- a/src/liballoc/alloc.rs
+++ b/src/liballoc/alloc.rs
@@ -177,6 +177,11 @@ unsafe fn exchange_malloc(size: usize, align: usize) -> *mut u8 {
 #[cfg_attr(not(test), lang = "box_free")]
 #[inline]
 pub(crate) unsafe fn box_free<T: ?Sized, A: Alloc>(ptr: Unique<T>, mut a: A) {
+    box_free_worker(ptr, &mut a)
+}
+
+#[inline]
+pub(crate) unsafe fn box_free_worker<T: ?Sized, A: Alloc>(ptr: Unique<T>, a: &mut A) {
     let ptr = ptr.as_ptr();
     let size = size_of_val(&*ptr);
     let align = min_align_of_val(&*ptr);

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -69,6 +69,7 @@ use core::ops::{CoerceUnsized, Deref, DerefMut, Generator, GeneratorState};
 use core::ptr::{self, NonNull, Unique};
 use core::task::{Context, Poll};
 
+use alloc::{Alloc, Global, Layout, handle_alloc_error};
 use raw_vec::RawVec;
 use str::from_boxed_utf8_unchecked;
 
@@ -78,7 +79,7 @@ use str::from_boxed_utf8_unchecked;
 #[lang = "owned_box"]
 #[fundamental]
 #[stable(feature = "rust1", since = "1.0.0")]
-pub struct Box<T: ?Sized>(Unique<T>);
+pub struct Box<T: ?Sized, A: Alloc = Global>(Unique<T>, A);
 
 impl<T> Box<T> {
     /// Allocates memory on the heap and then places `x` into it.
@@ -94,6 +95,37 @@ impl<T> Box<T> {
     #[inline(always)]
     pub fn new(x: T) -> Box<T> {
         box x
+    }
+}
+
+impl<T, A: Alloc> Box<T, A> {
+    /// Allocates memory in the given allocator and then places `x` into it.
+    ///
+    /// This doesn't actually allocate if `T` is zero-sized.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #![feature(allocator_api)]
+    /// use std::alloc::Global;
+    /// let five = Box::new_in(5, Global);
+    /// ```
+    #[unstable(feature = "allocator_api", issue = "32838")]
+    #[inline(always)]
+    pub fn new_in(x: T, a: A) -> Box<T, A> {
+        let mut a = a;
+        let layout = Layout::for_value(&x);
+        let size = layout.size();
+        let ptr = if size == 0 {
+            Unique::empty()
+        } else {
+            unsafe {
+                let ptr = a.alloc(layout).unwrap_or_else(|_| handle_alloc_error(layout));
+                ptr::write(ptr.as_ptr() as *mut T, x);
+                ptr.cast().into()
+            }
+        };
+        Box(ptr, a)
     }
 }
 
@@ -123,7 +155,35 @@ impl<T: ?Sized> Box<T> {
     #[stable(feature = "box_raw", since = "1.4.0")]
     #[inline]
     pub unsafe fn from_raw(raw: *mut T) -> Self {
-        Box(Unique::new_unchecked(raw))
+        Box(Unique::new_unchecked(raw), Global)
+    }
+}
+
+impl<T: ?Sized, A: Alloc> Box<T, A> {
+    /// Constructs a box from a raw pointer in the given allocator.
+    ///
+    /// This is similar to the [`Box::from_raw`] function, but assumes
+    /// the pointer was allocated with the given allocator.
+    ///
+    /// This function is unsafe because improper use may lead to
+    /// memory problems. For example, specifying the wrong allocator
+    /// may corrupt the allocator state.
+    ///
+    /// [`Box::from_raw`]: struct.Box.html#method.from_raw
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #![feature(allocator_api)]
+    /// use std::alloc::Global;
+    /// let x = Box::new_in(5, Global);
+    /// let ptr = Box::into_raw(x);
+    /// let x = unsafe { Box::from_raw_in(ptr, Global) };
+    /// ```
+    #[unstable(feature = "allocator_api", issue = "32838")]
+    #[inline]
+    pub unsafe fn from_raw_in(raw: *mut T, a: A) -> Self {
+        Box(Unique::new_unchecked(raw), a)
     }
 
     /// Consumes the `Box`, returning the wrapped raw pointer.
@@ -148,7 +208,7 @@ impl<T: ?Sized> Box<T> {
     /// ```
     #[stable(feature = "box_raw", since = "1.4.0")]
     #[inline]
-    pub fn into_raw(b: Box<T>) -> *mut T {
+    pub fn into_raw(b: Box<T, A>) -> *mut T {
         Box::into_raw_non_null(b).as_ptr()
     }
 
@@ -180,14 +240,14 @@ impl<T: ?Sized> Box<T> {
     /// ```
     #[unstable(feature = "box_into_raw_non_null", issue = "47336")]
     #[inline]
-    pub fn into_raw_non_null(b: Box<T>) -> NonNull<T> {
+    pub fn into_raw_non_null(b: Box<T, A>) -> NonNull<T> {
         Box::into_unique(b).into()
     }
 
     #[unstable(feature = "ptr_internals", issue = "0", reason = "use into_raw_non_null instead")]
     #[inline]
     #[doc(hidden)]
-    pub fn into_unique(b: Box<T>) -> Unique<T> {
+    pub fn into_unique(b: Box<T, A>) -> Unique<T> {
         let unique = b.0;
         mem::forget(b);
         unique
@@ -234,7 +294,7 @@ impl<T: ?Sized> Box<T> {
     /// ```
     #[stable(feature = "box_leak", since = "1.26.0")]
     #[inline]
-    pub fn leak<'a>(b: Box<T>) -> &'a mut T
+    pub fn leak<'a>(b: Box<T, A>) -> &'a mut T
     where
         T: 'a // Technically not needed, but kept to be explicit.
     {
@@ -243,7 +303,7 @@ impl<T: ?Sized> Box<T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-unsafe impl<#[may_dangle] T: ?Sized> Drop for Box<T> {
+unsafe impl<#[may_dangle] T: ?Sized, A: Alloc> Drop for Box<T, A> {
     fn drop(&mut self) {
         // FIXME: Do nothing, drop is currently performed by compiler.
     }
@@ -257,10 +317,18 @@ impl<T: Default> Default for Box<T> {
     }
 }
 
+#[unstable(feature = "allocator_api", issue = "32838")]
+impl<T: Default, A: Alloc + Default> Default for Box<T, A> {
+    /// Creates a `Box<T, A>`, with the `Default` value for T.
+    default fn default() -> Box<T, A> {
+        Box::new_in(Default::default(), Default::default())
+    }
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T> Default for Box<[T]> {
-    fn default() -> Box<[T]> {
-        Box::<[T; 0]>::new([])
+impl<T, A: Alloc + Default> Default for Box<[T], A> {
+    fn default() -> Box<[T], A> {
+        Box::<[T; 0], A>::new_in([], A::default())
     }
 }
 
@@ -286,6 +354,7 @@ impl<T: Clone> Clone for Box<T> {
     fn clone(&self) -> Box<T> {
         box { (**self).clone() }
     }
+
     /// Copies `source`'s contents into `self` without creating a new allocation.
     ///
     /// # Examples
@@ -304,6 +373,18 @@ impl<T: Clone> Clone for Box<T> {
     }
 }
 
+#[unstable(feature = "allocator_api", issue = "32838")]
+impl<T: Clone, A: Alloc + Clone> Clone for Box<T, A> {
+    #[inline]
+    default fn clone(&self) -> Box<T, A> {
+        Box::new_in((**self).clone(), self.1.clone())
+    }
+
+    #[inline]
+    default fn clone_from(&mut self, source: &Box<T, A>) {
+        (**self).clone_from(&(**source));
+    }
+}
 
 #[stable(feature = "box_slice_clone", since = "1.3.0")]
 impl Clone for Box<str> {
@@ -318,58 +399,58 @@ impl Clone for Box<str> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized + PartialEq> PartialEq for Box<T> {
+impl<T: ?Sized + PartialEq, A: Alloc> PartialEq for Box<T, A> {
     #[inline]
-    fn eq(&self, other: &Box<T>) -> bool {
+    fn eq(&self, other: &Box<T, A>) -> bool {
         PartialEq::eq(&**self, &**other)
     }
     #[inline]
-    fn ne(&self, other: &Box<T>) -> bool {
+    fn ne(&self, other: &Box<T, A>) -> bool {
         PartialEq::ne(&**self, &**other)
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized + PartialOrd> PartialOrd for Box<T> {
+impl<T: ?Sized + PartialOrd, A: Alloc> PartialOrd for Box<T, A> {
     #[inline]
-    fn partial_cmp(&self, other: &Box<T>) -> Option<Ordering> {
+    fn partial_cmp(&self, other: &Box<T, A>) -> Option<Ordering> {
         PartialOrd::partial_cmp(&**self, &**other)
     }
     #[inline]
-    fn lt(&self, other: &Box<T>) -> bool {
+    fn lt(&self, other: &Box<T, A>) -> bool {
         PartialOrd::lt(&**self, &**other)
     }
     #[inline]
-    fn le(&self, other: &Box<T>) -> bool {
+    fn le(&self, other: &Box<T, A>) -> bool {
         PartialOrd::le(&**self, &**other)
     }
     #[inline]
-    fn ge(&self, other: &Box<T>) -> bool {
+    fn ge(&self, other: &Box<T, A>) -> bool {
         PartialOrd::ge(&**self, &**other)
     }
     #[inline]
-    fn gt(&self, other: &Box<T>) -> bool {
+    fn gt(&self, other: &Box<T, A>) -> bool {
         PartialOrd::gt(&**self, &**other)
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized + Ord> Ord for Box<T> {
+impl<T: ?Sized + Ord, A: Alloc> Ord for Box<T, A> {
     #[inline]
-    fn cmp(&self, other: &Box<T>) -> Ordering {
+    fn cmp(&self, other: &Box<T, A>) -> Ordering {
         Ord::cmp(&**self, &**other)
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized + Eq> Eq for Box<T> {}
+impl<T: ?Sized + Eq, A: Alloc> Eq for Box<T, A> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized + Hash> Hash for Box<T> {
+impl<T: ?Sized + Hash, A: Alloc> Hash for Box<T, A> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         (**self).hash(state);
     }
 }
 
 #[stable(feature = "indirect_hasher_impl", since = "1.22.0")]
-impl<T: ?Sized + Hasher> Hasher for Box<T> {
+impl<T: ?Sized + Hasher, A: Alloc> Hasher for Box<T, A> {
     fn finish(&self) -> u64 {
         (**self).finish()
     }
@@ -421,10 +502,18 @@ impl<T> From<T> for Box<T> {
     }
 }
 
+#[unstable(feature = "allocator_api", issue = "32838")]
+impl<T, A: Alloc + Default> From<T> for Box<T, A> {
+    default fn from(t: T) -> Self {
+        Box::new_in(t, A::default())
+    }
+}
+
 #[stable(feature = "box_from_slice", since = "1.17.0")]
-impl<'a, T: Copy> From<&'a [T]> for Box<[T]> {
-    fn from(slice: &'a [T]) -> Box<[T]> {
-        let mut boxed = unsafe { RawVec::with_capacity(slice.len()).into_box() };
+impl<'a, T: Copy, A: Alloc + Default> From<&'a [T]> for Box<[T], A> {
+    fn from(slice: &'a [T]) -> Box<[T], A> {
+        let a = A::default();
+        let mut boxed = unsafe { RawVec::with_capacity_in(slice.len(), a).into_box() };
         boxed.copy_from_slice(slice);
         boxed
     }
@@ -511,21 +600,21 @@ impl Box<dyn Any + Send> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: fmt::Display + ?Sized> fmt::Display for Box<T> {
+impl<T: fmt::Display + ?Sized, A: Alloc> fmt::Display for Box<T, A> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Display::fmt(&**self, f)
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: fmt::Debug + ?Sized> fmt::Debug for Box<T> {
+impl<T: fmt::Debug + ?Sized, A: Alloc> fmt::Debug for Box<T, A> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Debug::fmt(&**self, f)
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized> fmt::Pointer for Box<T> {
+impl<T: ?Sized, A: Alloc> fmt::Pointer for Box<T, A> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // It's not possible to extract the inner Uniq directly from the Box,
         // instead we cast it to a *const which aliases the Unique
@@ -535,7 +624,7 @@ impl<T: ?Sized> fmt::Pointer for Box<T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized> Deref for Box<T> {
+impl<T: ?Sized, A: Alloc> Deref for Box<T, A> {
     type Target = T;
 
     fn deref(&self) -> &T {
@@ -544,14 +633,14 @@ impl<T: ?Sized> Deref for Box<T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized> DerefMut for Box<T> {
+impl<T: ?Sized, A: Alloc> DerefMut for Box<T, A> {
     fn deref_mut(&mut self) -> &mut T {
         &mut **self
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<I: Iterator + ?Sized> Iterator for Box<I> {
+impl<I: Iterator + ?Sized, A: Alloc> Iterator for Box<I, A> {
     type Item = I::Item;
     fn next(&mut self) -> Option<I::Item> {
         (**self).next()
@@ -564,13 +653,13 @@ impl<I: Iterator + ?Sized> Iterator for Box<I> {
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<I: DoubleEndedIterator + ?Sized> DoubleEndedIterator for Box<I> {
+impl<I: DoubleEndedIterator + ?Sized, A: Alloc> DoubleEndedIterator for Box<I, A> {
     fn next_back(&mut self) -> Option<I::Item> {
         (**self).next_back()
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<I: ExactSizeIterator + ?Sized> ExactSizeIterator for Box<I> {
+impl<I: ExactSizeIterator + ?Sized, A: Alloc> ExactSizeIterator for Box<I, A> {
     fn len(&self) -> usize {
         (**self).len()
     }
@@ -580,7 +669,7 @@ impl<I: ExactSizeIterator + ?Sized> ExactSizeIterator for Box<I> {
 }
 
 #[stable(feature = "fused", since = "1.26.0")]
-impl<I: FusedIterator + ?Sized> FusedIterator for Box<I> {}
+impl<I: FusedIterator + ?Sized, A: Alloc> FusedIterator for Box<I, A> {}
 
 
 /// `FnBox` is a version of the `FnOnce` intended for use with boxed
@@ -662,13 +751,13 @@ impl<'a, A, R> FnOnce<A> for Box<dyn FnBox<A, Output = R> + Send + 'a> {
 }
 
 #[unstable(feature = "coerce_unsized", issue = "27732")]
-impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<Box<U>> for Box<T> {}
+impl<T: ?Sized + Unsize<U>, U: ?Sized, A: Alloc> CoerceUnsized<Box<U, A>> for Box<T, A> {}
 
 #[stable(feature = "box_slice_clone", since = "1.3.0")]
-impl<T: Clone> Clone for Box<[T]> {
+impl<T: Clone, A: Alloc + Clone> Clone for Box<[T], A> {
     fn clone(&self) -> Self {
         let mut new = BoxBuilder {
-            data: RawVec::with_capacity(self.len()),
+            data: RawVec::with_capacity_in(self.len(), self.1.clone()),
             len: 0,
         };
 
@@ -686,20 +775,20 @@ impl<T: Clone> Clone for Box<[T]> {
         return unsafe { new.into_box() };
 
         // Helper type for responding to panics correctly.
-        struct BoxBuilder<T> {
-            data: RawVec<T>,
+        struct BoxBuilder<T, A: Alloc> {
+            data: RawVec<T, A>,
             len: usize,
         }
 
-        impl<T> BoxBuilder<T> {
-            unsafe fn into_box(self) -> Box<[T]> {
+        impl<T, A: Alloc> BoxBuilder<T, A> {
+            unsafe fn into_box(self) -> Box<[T], A> {
                 let raw = ptr::read(&self.data);
                 mem::forget(self);
                 raw.into_box()
             }
         }
 
-        impl<T> Drop for BoxBuilder<T> {
+        impl<T, A: Alloc> Drop for BoxBuilder<T, A> {
             fn drop(&mut self) {
                 let mut data = self.data.ptr();
                 let max = unsafe { data.offset(self.len as isize) };
@@ -716,35 +805,35 @@ impl<T: Clone> Clone for Box<[T]> {
 }
 
 #[stable(feature = "box_borrow", since = "1.1.0")]
-impl<T: ?Sized> borrow::Borrow<T> for Box<T> {
+impl<T: ?Sized, A: Alloc> borrow::Borrow<T> for Box<T, A> {
     fn borrow(&self) -> &T {
         &**self
     }
 }
 
 #[stable(feature = "box_borrow", since = "1.1.0")]
-impl<T: ?Sized> borrow::BorrowMut<T> for Box<T> {
+impl<T: ?Sized, A: Alloc> borrow::BorrowMut<T> for Box<T, A> {
     fn borrow_mut(&mut self) -> &mut T {
         &mut **self
     }
 }
 
 #[stable(since = "1.5.0", feature = "smart_ptr_as_ref")]
-impl<T: ?Sized> AsRef<T> for Box<T> {
+impl<T: ?Sized, A: Alloc> AsRef<T> for Box<T, A> {
     fn as_ref(&self) -> &T {
         &**self
     }
 }
 
 #[stable(since = "1.5.0", feature = "smart_ptr_as_ref")]
-impl<T: ?Sized> AsMut<T> for Box<T> {
+impl<T: ?Sized, A: Alloc> AsMut<T> for Box<T, A> {
     fn as_mut(&mut self) -> &mut T {
         &mut **self
     }
 }
 
 #[unstable(feature = "generator_trait", issue = "43122")]
-impl<T> Generator for Box<T>
+impl<T, A: Alloc> Generator for Box<T, A>
     where T: Generator + ?Sized
 {
     type Yield = T::Yield;

--- a/src/liballoc/collections/mod.rs
+++ b/src/liballoc/collections/mod.rs
@@ -56,24 +56,24 @@ use alloc::{AllocErr, LayoutErr};
 /// Augments `AllocErr` with a CapacityOverflow variant.
 #[derive(Clone, PartialEq, Eq, Debug)]
 #[unstable(feature = "try_reserve", reason = "new API", issue="48043")]
-pub enum CollectionAllocErr {
+pub enum CollectionAllocErr<E> {
     /// Error due to the computed capacity exceeding the collection's maximum
     /// (usually `isize::MAX` bytes).
     CapacityOverflow,
     /// Error due to the allocator (see the `AllocErr` type's docs).
-    AllocErr,
+    AllocErr(E),
 }
 
 #[unstable(feature = "try_reserve", reason = "new API", issue="48043")]
-impl From<AllocErr> for CollectionAllocErr {
+impl From<AllocErr> for CollectionAllocErr<AllocErr> {
     #[inline]
     fn from(AllocErr: AllocErr) -> Self {
-        CollectionAllocErr::AllocErr
+        CollectionAllocErr::AllocErr(AllocErr)
     }
 }
 
 #[unstable(feature = "try_reserve", reason = "new API", issue="48043")]
-impl From<LayoutErr> for CollectionAllocErr {
+impl<E> From<LayoutErr> for CollectionAllocErr<E> {
     #[inline]
     fn from(_: LayoutErr) -> Self {
         CollectionAllocErr::CapacityOverflow

--- a/src/liballoc/collections/vec_deque.rs
+++ b/src/liballoc/collections/vec_deque.rs
@@ -30,6 +30,7 @@ use core::slice;
 use core::hash::{Hash, Hasher};
 use core::cmp;
 
+use alloc::AllocErr;
 use collections::CollectionAllocErr;
 use raw_vec::RawVec;
 use vec::Vec;
@@ -558,7 +559,7 @@ impl<T> VecDeque<T> {
             .expect("capacity overflow");
 
         if new_cap > old_cap {
-            self.buf.reserve_exact(used_cap, new_cap - used_cap);
+            let Ok(()) = self.buf.reserve_exact(used_cap, new_cap - used_cap);
             unsafe {
                 self.handle_cap_increase(old_cap);
             }
@@ -602,7 +603,7 @@ impl<T> VecDeque<T> {
     /// # process_data(&[1, 2, 3]).expect("why is the test harness OOMing on 12 bytes?");
     /// ```
     #[unstable(feature = "try_reserve", reason = "new API", issue="48043")]
-    pub fn try_reserve_exact(&mut self, additional: usize) -> Result<(), CollectionAllocErr>  {
+    pub fn try_reserve_exact(&mut self, additional: usize) -> Result<(), CollectionAllocErr<AllocErr>>  {
         self.try_reserve(additional)
     }
 
@@ -640,7 +641,7 @@ impl<T> VecDeque<T> {
     /// # process_data(&[1, 2, 3]).expect("why is the test harness OOMing on 12 bytes?");
     /// ```
     #[unstable(feature = "try_reserve", reason = "new API", issue="48043")]
-    pub fn try_reserve(&mut self, additional: usize) -> Result<(), CollectionAllocErr> {
+    pub fn try_reserve(&mut self, additional: usize) -> Result<(), CollectionAllocErr<AllocErr>> {
         let old_cap = self.cap();
         let used_cap = self.len() + 1;
         let new_cap = used_cap.checked_add(additional)
@@ -757,7 +758,7 @@ impl<T> VecDeque<T> {
                 debug_assert!(self.head < self.tail);
             }
 
-            self.buf.shrink_to_fit(target_cap);
+            let Ok(()) = self.buf.shrink_to_fit(target_cap);
 
             debug_assert!(self.head < self.cap());
             debug_assert!(self.tail < self.cap());
@@ -1877,7 +1878,7 @@ impl<T> VecDeque<T> {
     fn grow_if_necessary(&mut self) {
         if self.is_full() {
             let old_cap = self.cap();
-            self.buf.double();
+            let Ok(()) = self.buf.double();
             unsafe {
                 self.handle_cap_increase(old_cap);
             }
@@ -2528,7 +2529,7 @@ impl<T> From<Vec<T>> for VecDeque<T> {
             if !buf.cap().is_power_of_two() || (buf.cap() < (MINIMUM_CAPACITY + 1)) ||
                (buf.cap() == len) {
                 let cap = cmp::max(buf.cap() + 1, MINIMUM_CAPACITY + 1).next_power_of_two();
-                buf.reserve_exact(len, cap - len);
+                let Ok(()) = buf.reserve_exact(len, cap - len);
             }
 
             VecDeque {

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -123,6 +123,8 @@
 #![feature(inclusive_range_methods)]
 #![feature(rustc_const_unstable)]
 #![feature(const_vec_new)]
+#![feature(never_type)]
+#![feature(crate_in_paths)]
 
 #![cfg_attr(not(test), feature(fn_traits, i128))]
 #![cfg_attr(test, feature(test))]
@@ -144,6 +146,7 @@ mod macros;
 // Heaps provided for low-level allocation strategies
 
 pub mod alloc;
+pub mod abort_adapter;
 
 #[unstable(feature = "futures_api",
            reason = "futures in libcore are unstable",

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -125,6 +125,7 @@
 #![feature(const_vec_new)]
 #![feature(never_type)]
 #![feature(crate_in_paths)]
+#![feature(exhaustive_patterns)]
 
 #![cfg_attr(not(test), feature(fn_traits, i128))]
 #![cfg_attr(test, feature(test))]

--- a/src/liballoc/raw_vec.rs
+++ b/src/liballoc/raw_vec.rs
@@ -693,8 +693,8 @@ impl<T, A: Alloc> RawVec<T, A> {
 
 }
 
-impl<T> RawVec<T, Global> {
-    /// Converts the entire buffer into `Box<[T]>`.
+impl<T, A: Alloc> RawVec<T, A> {
+    /// Converts the entire buffer into `Box<[T], A>`.
     ///
     /// While it is not *strictly* Undefined Behavior to call
     /// this procedure while some of the RawVec is uninitialized,
@@ -702,10 +702,11 @@ impl<T> RawVec<T, Global> {
     ///
     /// Note that this will correctly reconstitute any `cap` changes
     /// that may have been performed. (see description of type for details)
-    pub unsafe fn into_box(self) -> Box<[T]> {
+    pub unsafe fn into_box(self) -> Box<[T], A> {
         // NOTE: not calling `cap()` here, actually using the real `cap` field!
         let slice = slice::from_raw_parts_mut(self.ptr(), self.cap);
-        let output: Box<[T]> = Box::from_raw(slice);
+        let a = ptr::read(&self.a);
+        let output: Box<[T], A> = Box::from_raw_in(slice, a);
         mem::forget(self);
         output
     }

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -687,7 +687,7 @@ impl<T: ?Sized> Rc<T> {
                 value_size);
 
             // Free the allocation without dropping its contents
-            box_free(box_unique);
+            box_free(box_unique, Global);
 
             Rc { ptr: NonNull::new_unchecked(ptr), phantom: PhantomData }
         }

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -13,7 +13,7 @@
 //! Single-threaded reference-counting pointers. 'Rc' stands for 'Reference
 //! Counted'.
 //!
-//! The type [`Rc<T>`][`Rc`] provides shared ownership of a value of type `T`,
+//! The type [`Rc<T, A>`][`Rc`] provides shared ownership of a value of type `T`,
 //! allocated in the heap. Invoking [`clone`][clone] on [`Rc`] produces a new
 //! pointer to the same value in the heap. When the last [`Rc`] pointer to a
 //! given value is destroyed, the pointed-to value is also destroyed.
@@ -41,9 +41,9 @@
 //! [`Rc`] pointers from parent nodes to children, and [`Weak`] pointers from
 //! children back to their parents.
 //!
-//! `Rc<T>` automatically dereferences to `T` (via the [`Deref`] trait),
-//! so you can call `T`'s methods on a value of type [`Rc<T>`][`Rc`]. To avoid name
-//! clashes with `T`'s methods, the methods of [`Rc<T>`][`Rc`] itself are [associated
+//! `Rc<T, A>` automatically dereferences to `T` (via the [`Deref`] trait),
+//! so you can call `T`'s methods on a value of type [`Rc<T, A>`][`Rc`]. To avoid name
+//! clashes with `T`'s methods, the methods of [`Rc<T, A>`][`Rc`] itself are [associated
 //! functions][assoc], called using function-like syntax:
 //!
 //! ```
@@ -53,13 +53,13 @@
 //! Rc::downgrade(&my_rc);
 //! ```
 //!
-//! [`Weak<T>`][`Weak`] does not auto-dereference to `T`, because the value may have
+//! [`Weak<T, A>`][`Weak`] does not auto-dereference to `T`, because the value may have
 //! already been destroyed.
 //!
 //! # Cloning references
 //!
 //! Creating a new reference from an existing reference counted pointer is done using the
-//! `Clone` trait implemented for [`Rc<T>`][`Rc`] and [`Weak<T>`][`Weak`].
+//! `Clone` trait implemented for [`Rc<T, A>`][`Rc`] and [`Weak<T, A>`][`Weak`].
 //!
 //! ```
 //! use std::rc::Rc;
@@ -256,16 +256,18 @@ use core::marker::{Unsize, PhantomData};
 use core::mem::{self, align_of_val, forget, size_of_val};
 use core::ops::Deref;
 use core::ops::CoerceUnsized;
-use core::ptr::{self, NonNull};
+use core::ptr::{self, NonNull, Unique};
 use core::convert::From;
 
-use alloc::{Global, Alloc, Layout, box_free, handle_alloc_error};
+use abort_adapter::AbortAdapter;
+use alloc::{Global, Alloc, Layout, box_free_worker};
 use string::String;
 use vec::Vec;
 
-struct RcBox<T: ?Sized> {
+struct RcBox<T: ?Sized, A: Alloc = AbortAdapter<Global>> {
     strong: Cell<usize>,
     weak: Cell<usize>,
+    alloc: A,
     value: T,
 }
 
@@ -281,18 +283,18 @@ struct RcBox<T: ?Sized> {
 ///
 /// [get_mut]: #method.get_mut
 #[stable(feature = "rust1", since = "1.0.0")]
-pub struct Rc<T: ?Sized> {
-    ptr: NonNull<RcBox<T>>,
+pub struct Rc<T: ?Sized, A: Alloc = AbortAdapter<Global>> {
+    ptr: NonNull<RcBox<T, A>>,
     phantom: PhantomData<T>,
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized> !marker::Send for Rc<T> {}
+impl<T: ?Sized, A: Alloc> !marker::Send for Rc<T, A> {}
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized> !marker::Sync for Rc<T> {}
+impl<T: ?Sized, A: Alloc> !marker::Sync for Rc<T, A> {}
 
 #[unstable(feature = "coerce_unsized", issue = "27732")]
-impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<Rc<U>> for Rc<T> {}
+impl<T: ?Sized + Unsize<U>, U: ?Sized, A: Alloc> CoerceUnsized<Rc<U, A>> for Rc<T, A> {}
 
 impl<T> Rc<T> {
     /// Constructs a new `Rc<T>`.
@@ -304,20 +306,31 @@ impl<T> Rc<T> {
     ///
     /// let five = Rc::new(5);
     /// ```
+    #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn new(value: T) -> Rc<T> {
-        Rc {
-            // there is an implicit weak pointer owned by all the strong
-            // pointers, which ensures that the weak destructor never frees
-            // the allocation while the strong destructor is running, even
-            // if the weak pointer is stored inside the strong one.
-            ptr: Box::into_raw_non_null(box RcBox {
-                strong: Cell::new(1),
-                weak: Cell::new(1),
-                value,
-            }),
-            phantom: PhantomData,
-        }
+        let Ok(a) = Self::new_in(value, Default::default());
+        a
+    }
+}
+
+impl<T, A: Alloc> Rc<T, A> {
+    #[unstable(feature = "allocator_api", issue = "32838")]
+    pub fn new_in(value: T, alloc: A) -> Result<Rc<T, A>, A::Err> {
+        // there is an implicit weak pointer owned by all the strong
+        // pointers, which ensures that the weak destructor never frees
+        // the allocation while the strong destructor is running, even
+        // if the weak pointer is stored inside the strong one.
+        let x: Box<_, A> = Box::new_in(RcBox {
+            strong: Cell::new(1),
+            weak: Cell::new(1),
+            alloc: unsafe { mem::uninitialized() },
+            value,
+        }, alloc)?;
+        let (unique, mut alloc_after) = Box::into_both(x);
+        mem::swap(unsafe { &mut (*unique.as_ptr()).alloc }, &mut alloc_after);
+        mem::forget(alloc_after);
+        Ok(Rc { ptr: NonNull::from(unique), phantom: PhantomData })
     }
 
     /// Returns the contained value, if the `Rc` has exactly one strong reference.
@@ -364,29 +377,6 @@ impl<T> Rc<T> {
 }
 
 impl<T: ?Sized> Rc<T> {
-    /// Consumes the `Rc`, returning the wrapped pointer.
-    ///
-    /// To avoid a memory leak the pointer must be converted back to an `Rc` using
-    /// [`Rc::from_raw`][from_raw].
-    ///
-    /// [from_raw]: struct.Rc.html#method.from_raw
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use std::rc::Rc;
-    ///
-    /// let x = Rc::new(10);
-    /// let x_ptr = Rc::into_raw(x);
-    /// assert_eq!(unsafe { *x_ptr }, 10);
-    /// ```
-    #[stable(feature = "rc_raw", since = "1.17.0")]
-    pub fn into_raw(this: Self) -> *const T {
-        let ptr: *const T = &*this;
-        mem::forget(this);
-        ptr
-    }
-
     /// Constructs an `Rc` from a raw pointer.
     ///
     /// The raw pointer must have been previously returned by a call to a
@@ -417,14 +407,44 @@ impl<T: ?Sized> Rc<T> {
     /// ```
     #[stable(feature = "rc_raw", since = "1.17.0")]
     pub unsafe fn from_raw(ptr: *const T) -> Self {
+        Self::from_raw_in(ptr)
+    }
+}
+
+impl<T: ?Sized, A: Alloc> Rc<T, A> {
+    /// Consumes the `Rc`, returning the wrapped pointer.
+    ///
+    /// To avoid a memory leak the pointer must be converted back to an `Rc` using
+    /// [`Rc::from_raw`][from_raw].
+    ///
+    /// [from_raw]: struct.Rc.html#method.from_raw
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::rc::Rc;
+    ///
+    /// let x = Rc::new(10);
+    /// let x_ptr = Rc::into_raw(x);
+    /// assert_eq!(unsafe { *x_ptr }, 10);
+    /// ```
+    #[stable(feature = "rc_raw", since = "1.17.0")]
+    pub fn into_raw(this: Self) -> *const T {
+        let ptr: *const T = &*this;
+        mem::forget(this);
+        ptr
+    }
+
+    #[unstable(feature = "allocator_api", issue = "32838")]
+    pub unsafe fn from_raw_in(ptr: *const T) -> Self {
         // Align the unsized value to the end of the RcBox.
         // Because it is ?Sized, it will always be the last field in memory.
         let align = align_of_val(&*ptr);
-        let layout = Layout::new::<RcBox<()>>();
+        let layout = Layout::new::<RcBox<(), A>>();
         let offset = (layout.size() + layout.padding_needed_for(align)) as isize;
 
         // Reverse the offset to find the original RcBox.
-        let fake_ptr = ptr as *mut RcBox<T>;
+        let fake_ptr = ptr as *mut RcBox<T, A>;
         let rc_ptr = set_data_ptr(fake_ptr, (ptr as *mut u8).offset(-offset));
 
         Rc {
@@ -447,7 +467,7 @@ impl<T: ?Sized> Rc<T> {
     /// let weak_five = Rc::downgrade(&five);
     /// ```
     #[stable(feature = "rc_weak", since = "1.4.0")]
-    pub fn downgrade(this: &Self) -> Weak<T> {
+    pub fn downgrade(this: &Self) -> Weak<T, A> {
         this.inc_weak();
         Weak { ptr: this.ptr }
     }
@@ -618,7 +638,7 @@ impl<T: Clone> Rc<T> {
     }
 }
 
-impl Rc<dyn Any> {
+impl<A: Alloc> Rc<dyn Any, A> {
     #[inline]
     #[stable(feature = "rc_downcast", since = "1.29.0")]
     /// Attempt to downcast the `Rc<Any>` to a concrete type.
@@ -641,55 +661,86 @@ impl Rc<dyn Any> {
     ///     print_if_string(Rc::new(0i8));
     /// }
     /// ```
-    pub fn downcast<T: Any>(self) -> Result<Rc<T>, Rc<dyn Any>> {
+    pub fn downcast<T: Any>(self) -> Result<Rc<T, A>, Rc<dyn Any, A>> {
         if (*self).is::<T>() {
-            let ptr = self.ptr.cast::<RcBox<T>>();
-            forget(self);
-            Ok(Rc { ptr, phantom: PhantomData })
+            // avoid the pointer arithmetic in from_raw
+            unsafe {
+                let raw: *const RcBox<dyn Any, A> = self.ptr.as_ptr();
+                forget(self);
+                Ok(Rc {
+                    ptr: NonNull::new_unchecked(raw as *const RcBox<T> as *mut _),
+                    phantom: PhantomData,
+                })
+            }
         } else {
             Err(self)
         }
     }
 }
-
 impl<T: ?Sized> Rc<T> {
+    fn from_box(v: Box<T>) -> Self {
+        let Ok(a) = Self::from_box_in(v, Default::default());
+        a
+    }
+}
+
+impl<T: ?Sized, A: Alloc> Rc<T, A> {
     // Allocates an `RcBox<T>` with sufficient space for an unsized value
-    unsafe fn allocate_for_ptr(ptr: *const T) -> *mut RcBox<T> {
+    unsafe fn allocate_for_ptr(ptr: *const T, mut alloc: A) -> Result<*mut RcBox<T, A>, A::Err> {
         // Create a fake RcBox to find allocation size and alignment
-        let fake_ptr = ptr as *mut RcBox<T>;
+        let fake_ptr = ptr as *mut RcBox<T, A>;
 
         let layout = Layout::for_value(&*fake_ptr);
 
-        let mem = Global.alloc(layout)
-            .unwrap_or_else(|_| handle_alloc_error(layout));
+        let mem = alloc.alloc(layout)?;
 
         // Initialize the real RcBox
-        let inner = set_data_ptr(ptr as *mut T, mem.as_ptr() as *mut u8) as *mut RcBox<T>;
+        let inner = set_data_ptr(ptr as *mut T, mem.as_ptr() as *mut u8) as *mut RcBox<T, A>;
 
-        ptr::write(&mut (*inner).strong, Cell::new(1));
-        ptr::write(&mut (*inner).weak, Cell::new(1));
+        ptr::write(inner as *mut RcBox<(), A>, RcBox {
+            strong: Cell::new(1),
+            weak: Cell::new(1),
+            alloc,
+            value: (),
+        });
 
-        inner
+        Ok(inner)
     }
 
-    fn from_box(v: Box<T>) -> Rc<T> {
+    /// `v` must be heap-allocated
+    unsafe fn from_box_raw(box_unique: Unique<T>, alloc: A) -> Result<Rc<T, A>, A::Err> {
+        let bptr = box_unique.as_ptr();
+        let value_size = size_of_val(&*bptr);
+        let ptr = Self::allocate_for_ptr(bptr, alloc)?;
+
+        // Copy value as bytes
+        ptr::copy_nonoverlapping(
+            bptr as *const T as *const u8,
+            &mut (*ptr).value as *mut _ as *mut u8,
+            value_size);
+
+        Ok(Rc { ptr: NonNull::new_unchecked(ptr), phantom: PhantomData })
+    }
+
+    #[unstable(feature = "allocator_api", issue = "32838")]
+    pub fn from_box_in<A2: Alloc>(v: Box<T, A2>, alloc: A) -> Result<Self, A::Err> {
+        let (u, mut a) = Box::into_both(v);
         unsafe {
-            let box_unique = Box::into_unique(v);
-            let bptr = box_unique.as_ptr();
-
-            let value_size = size_of_val(&*bptr);
-            let ptr = Self::allocate_for_ptr(bptr);
-
-            // Copy value as bytes
-            ptr::copy_nonoverlapping(
-                bptr as *const T as *const u8,
-                &mut (*ptr).value as *mut _ as *mut u8,
-                value_size);
-
+            let rc = Self::from_box_raw(u, alloc)?;
             // Free the allocation without dropping its contents
-            box_free(box_unique, Global);
+            box_free_worker(u, &mut a);
+            Ok(rc)
+        }
+    }
 
-            Rc { ptr: NonNull::new_unchecked(ptr), phantom: PhantomData }
+    #[unstable(feature = "allocator_api", issue = "32838")]
+    pub fn from_box_in_same(v: Box<T, A>) -> Result<Self, A::Err> {
+        let (u, a) = Box::into_both(v);
+        unsafe {
+            let rc = Self::from_box_raw(u, a)?;
+            // Free the allocation without dropping its contents
+            box_free_worker(u, &mut (*rc.ptr.as_ptr()).alloc);
+            Ok(rc)
         }
     }
 }
@@ -709,7 +760,7 @@ impl<T> Rc<[T]> {
     // Unsafe because the caller must either take ownership or bind `T: Copy`
     unsafe fn copy_from_slice(v: &[T]) -> Rc<[T]> {
         let v_ptr = v as *const [T];
-        let ptr = Self::allocate_for_ptr(v_ptr);
+        let Ok(ptr) = Self::allocate_for_ptr(v_ptr, Default::default());
 
         ptr::copy_nonoverlapping(
             v.as_ptr(),
@@ -752,7 +803,7 @@ impl<T: Clone> RcFromSlice<T> for Rc<[T]> {
 
         unsafe {
             let v_ptr = v as *const [T];
-            let ptr = Self::allocate_for_ptr(v_ptr);
+            let Ok(ptr) = Self::allocate_for_ptr(v_ptr, Default::default());
 
             let mem = ptr as *mut _ as *mut u8;
             let layout = Layout::for_value(&*ptr);
@@ -788,7 +839,7 @@ impl<T: Copy> RcFromSlice<T> for Rc<[T]> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized> Deref for Rc<T> {
+impl<T: ?Sized, A: Alloc> Deref for Rc<T, A> {
     type Target = T;
 
     #[inline(always)]
@@ -798,7 +849,7 @@ impl<T: ?Sized> Deref for Rc<T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-unsafe impl<#[may_dangle] T: ?Sized> Drop for Rc<T> {
+unsafe impl<#[may_dangle] T: ?Sized, A: Alloc> Drop for Rc<T, A> {
     /// Drops the `Rc`.
     ///
     /// This will decrement the strong reference count. If the strong reference
@@ -1151,12 +1202,12 @@ impl<T> From<Vec<T>> for Rc<[T]> {
 /// [`Option`]: ../../std/option/enum.Option.html
 /// [`None`]: ../../std/option/enum.Option.html#variant.None
 #[stable(feature = "rc_weak", since = "1.4.0")]
-pub struct Weak<T: ?Sized> {
+pub struct Weak<T: ?Sized, A: Alloc = AbortAdapter<Global>> {
     // This is a `NonNull` to allow optimizing the size of this type in enums,
     // but it is not necessarily a valid pointer.
     // `Weak::new` sets this to a dangling pointer so that it doesn’t need
     // to allocate space on the heap.
-    ptr: NonNull<RcBox<T>>,
+    ptr: NonNull<RcBox<T, A>>,
 }
 
 #[stable(feature = "rc_weak", since = "1.4.0")]
@@ -1184,8 +1235,16 @@ impl<T> Weak<T> {
     /// ```
     #[stable(feature = "downgraded_weak", since = "1.10.0")]
     pub fn new() -> Weak<T> {
+        Self::new_in()
+    }
+}
+
+impl<T, A: Alloc> Weak<T, A> {
+    /// The same as `new`, but separate for stability reasons
+    #[unstable(feature = "allocator_api", issue = "32838")]
+    pub fn new_in() -> Weak<T, A> {
         Weak {
-            ptr: NonNull::dangling(),
+            ptr: NonNull::dangling()
         }
     }
 }
@@ -1233,11 +1292,25 @@ impl<T: ?Sized> Weak<T> {
             Some(Rc { ptr: self.ptr, phantom: PhantomData })
         }
     }
+}
+
+impl<T: ?Sized, A: Alloc> Weak<T, A> {
+    /// The same as `upgrade`, but separate for stability reasons
+    #[unstable(feature = "allocator_api", issue = "32838")]
+    pub fn upgrade_in(&self) -> Option<Rc<T, A>> {
+        let inner = self.inner()?;
+        if inner.strong() == 0 {
+            None
+        } else {
+            inner.inc_strong();
+            Some(Rc { ptr: self.ptr, phantom: PhantomData })
+        }
+    }
 
     /// Return `None` when the pointer is dangling and there is no allocated `RcBox`,
     /// i.e. this `Weak` was created by `Weak::new`
     #[inline]
-    fn inner(&self) -> Option<&RcBox<T>> {
+    fn inner(&self) -> Option<&RcBox<T, A>> {
         if is_dangling(self.ptr) {
             None
         } else {
@@ -1247,7 +1320,7 @@ impl<T: ?Sized> Weak<T> {
 }
 
 #[stable(feature = "rc_weak", since = "1.4.0")]
-impl<T: ?Sized> Drop for Weak<T> {
+impl<T: ?Sized, A: Alloc> Drop for Weak<T, A> {
     /// Drops the `Weak` pointer.
     ///
     /// # Examples
@@ -1346,8 +1419,8 @@ impl<T> Default for Weak<T> {
 // clone these much in Rust thanks to ownership and move-semantics.
 
 #[doc(hidden)]
-trait RcBoxPtr<T: ?Sized> {
-    fn inner(&self) -> &RcBox<T>;
+trait RcBoxPtr<T: ?Sized, A: Alloc> {
+    fn inner(&self) -> &RcBox<T, A>;
 
     #[inline]
     fn strong(&self) -> usize {
@@ -1380,18 +1453,18 @@ trait RcBoxPtr<T: ?Sized> {
     }
 }
 
-impl<T: ?Sized> RcBoxPtr<T> for Rc<T> {
+impl<T: ?Sized, A: Alloc> RcBoxPtr<T, A> for Rc<T, A> {
     #[inline(always)]
-    fn inner(&self) -> &RcBox<T> {
+    fn inner(&self) -> &RcBox<T, A> {
         unsafe {
             self.ptr.as_ref()
         }
     }
 }
 
-impl<T: ?Sized> RcBoxPtr<T> for RcBox<T> {
+impl<T: ?Sized, A: Alloc> RcBoxPtr<T, A> for RcBox<T, A> {
     #[inline(always)]
-    fn inner(&self) -> &RcBox<T> {
+    fn inner(&self) -> &RcBox<T, A> {
         self
     }
 }

--- a/src/liballoc/str.rs
+++ b/src/liballoc/str.rs
@@ -47,6 +47,7 @@ use core::ptr;
 use core::iter::FusedIterator;
 use core::unicode::conversions;
 
+use alloc::{Alloc, AllocHelper};
 use borrow::{Borrow, ToOwned};
 use boxed::Box;
 use slice::{SliceConcatExt, SliceIndex};
@@ -605,6 +606,10 @@ impl str {
 /// ```
 #[stable(feature = "str_box_extras", since = "1.20.0")]
 #[inline]
-pub unsafe fn from_boxed_utf8_unchecked(v: Box<[u8]>) -> Box<str> {
-    Box::from_raw(Box::into_raw(v) as *mut str)
+pub unsafe fn from_boxed_utf8_unchecked
+    <A: Alloc + AllocHelper + Clone>
+    (v: Box<[u8], A>) -> Box<str, A>
+{
+    let (u, a) = Box::into_both(v);
+    Box::from_raw_in(u.as_ptr() as *mut str, a)
 }

--- a/src/liballoc/string.rs
+++ b/src/liballoc/string.rs
@@ -66,6 +66,7 @@ use core::ptr;
 use core::str::pattern::Pattern;
 use core::str::lossy;
 
+use alloc::AllocErr;
 use collections::CollectionAllocErr;
 use borrow::{Cow, ToOwned};
 use boxed::Box;
@@ -952,7 +953,7 @@ impl String {
     /// # process_data("rust").expect("why is the test harness OOMing on 4 bytes?");
     /// ```
     #[unstable(feature = "try_reserve", reason = "new API", issue="48043")]
-    pub fn try_reserve(&mut self, additional: usize) -> Result<(), CollectionAllocErr> {
+    pub fn try_reserve(&mut self, additional: usize) -> Result<(), CollectionAllocErr<AllocErr>> {
         self.vec.try_reserve(additional)
     }
 
@@ -990,7 +991,7 @@ impl String {
     /// # process_data("rust").expect("why is the test harness OOMing on 4 bytes?");
     /// ```
     #[unstable(feature = "try_reserve", reason = "new API", issue="48043")]
-    pub fn try_reserve_exact(&mut self, additional: usize) -> Result<(), CollectionAllocErr>  {
+    pub fn try_reserve_exact(&mut self, additional: usize) -> Result<(), CollectionAllocErr<AllocErr>>  {
         self.vec.try_reserve_exact(additional)
     }
 

--- a/src/liballoc/sync.rs
+++ b/src/liballoc/sync.rs
@@ -12,7 +12,7 @@
 
 //! Thread-safe reference-counting pointers.
 //!
-//! See the [`Arc<T>`][arc] documentation for more details.
+//! See the [`Arc<T, A>`][arc] documentation for more details.
 //!
 //! [arc]: struct.Arc.html
 
@@ -26,13 +26,14 @@ use core::intrinsics::abort;
 use core::mem::{self, align_of_val, size_of_val};
 use core::ops::Deref;
 use core::ops::CoerceUnsized;
-use core::ptr::{self, NonNull};
+use core::ptr::{self, NonNull, Unique};
 use core::marker::{Unsize, PhantomData};
 use core::hash::{Hash, Hasher};
 use core::{isize, usize};
 use core::convert::From;
 
-use alloc::{Global, Alloc, Layout, box_free, handle_alloc_error};
+use abort_adapter::AbortAdapter;
+use alloc::{Global, Alloc, Layout, box_free_worker};
 use boxed::Box;
 use rc::is_dangling;
 use string::String;
@@ -47,7 +48,7 @@ const MAX_REFCOUNT: usize = (isize::MAX) as usize;
 /// A thread-safe reference-counting pointer. 'Arc' stands for 'Atomically
 /// Reference Counted'.
 ///
-/// The type `Arc<T>` provides shared ownership of a value of type `T`,
+/// The type `Arc<T, A>` provides shared ownership of a value of type `T`,
 /// allocated in the heap. Invoking [`clone`][clone] on `Arc` produces
 /// a new pointer to the same value in the heap. When the last `Arc`
 /// pointer to a given value is destroyed, the pointed-to value is
@@ -67,21 +68,21 @@ const MAX_REFCOUNT: usize = (isize::MAX) as usize;
 /// are not sharing reference-counted values between threads, consider using
 /// [`Rc<T>`] for lower overhead. [`Rc<T>`] is a safe default, because the
 /// compiler will catch any attempt to send an [`Rc<T>`] between threads.
-/// However, a library might choose `Arc<T>` in order to give library consumers
+/// However, a library might choose `Arc<T, A>` in order to give library consumers
 /// more flexibility.
 ///
-/// `Arc<T>` will implement [`Send`] and [`Sync`] as long as the `T` implements
+/// `Arc<T, A>` will implement [`Send`] and [`Sync`] as long as the `T` implements
 /// [`Send`] and [`Sync`]. Why can't you put a non-thread-safe type `T` in an
-/// `Arc<T>` to make it thread-safe? This may be a bit counter-intuitive at
-/// first: after all, isn't the point of `Arc<T>` thread safety? The key is
-/// this: `Arc<T>` makes it thread safe to have multiple ownership of the same
+/// `Arc<T, A>` to make it thread-safe? This may be a bit counter-intuitive at
+/// first: after all, isn't the point of `Arc<T, A>` thread safety? The key is
+/// this: `Arc<T, A>` makes it thread safe to have multiple ownership of the same
 /// data, but it  doesn't add thread safety to its data. Consider
-/// `Arc<`[`RefCell<T>`]`>`. [`RefCell<T>`] isn't [`Sync`], and if `Arc<T>` was always
+/// `Arc<`[`RefCell<T>`]`>`. [`RefCell<T>`] isn't [`Sync`], and if `Arc<T, A>` was always
 /// [`Send`], `Arc<`[`RefCell<T>`]`>` would be as well. But then we'd have a problem:
 /// [`RefCell<T>`] is not thread safe; it keeps track of the borrowing count using
 /// non-atomic operations.
 ///
-/// In the end, this means that you may need to pair `Arc<T>` with some sort of
+/// In the end, this means that you may need to pair `Arc<T, A>` with some sort of
 /// [`std::sync`] type, usually [`Mutex<T>`][mutex].
 ///
 /// ## Breaking cycles with `Weak`
@@ -99,7 +100,7 @@ const MAX_REFCOUNT: usize = (isize::MAX) as usize;
 /// # Cloning references
 ///
 /// Creating a new reference from an existing reference counted pointer is done using the
-/// `Clone` trait implemented for [`Arc<T>`][arc] and [`Weak<T>`][weak].
+/// `Clone` trait implemented for [`Arc<T, A>`][arc] and [`Weak<T>`][weak].
 ///
 /// ```
 /// use std::sync::Arc;
@@ -116,9 +117,9 @@ const MAX_REFCOUNT: usize = (isize::MAX) as usize;
 ///
 /// ## `Deref` behavior
 ///
-/// `Arc<T>` automatically dereferences to `T` (via the [`Deref`][deref] trait),
-/// so you can call `T`'s methods on a value of type `Arc<T>`. To avoid name
-/// clashes with `T`'s methods, the methods of `Arc<T>` itself are [associated
+/// `Arc<T, A>` automatically dereferences to `T` (via the [`Deref`][deref] trait),
+/// so you can call `T`'s methods on a value of type `Arc<T, A>`. To avoid name
+/// clashes with `T`'s methods, the methods of `Arc<T, A>` itself are [associated
 /// functions][assoc], called using function-like syntax:
 ///
 /// ```
@@ -198,18 +199,18 @@ const MAX_REFCOUNT: usize = (isize::MAX) as usize;
 ///
 /// [rc_examples]: ../../std/rc/index.html#examples
 #[stable(feature = "rust1", since = "1.0.0")]
-pub struct Arc<T: ?Sized> {
-    ptr: NonNull<ArcInner<T>>,
+pub struct Arc<T: ?Sized, A: Alloc = AbortAdapter<Global>> {
+    ptr: NonNull<ArcInner<T, A>>,
     phantom: PhantomData<T>,
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-unsafe impl<T: ?Sized + Sync + Send> Send for Arc<T> {}
+unsafe impl<T: ?Sized + Sync + Send, A: Alloc + Sync + Send> Send for Arc<T, A> {}
 #[stable(feature = "rust1", since = "1.0.0")]
-unsafe impl<T: ?Sized + Sync + Send> Sync for Arc<T> {}
+unsafe impl<T: ?Sized + Sync + Send, A: Alloc + Sync + Send> Sync for Arc<T, A> {}
 
 #[unstable(feature = "coerce_unsized", issue = "27732")]
-impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<Arc<U>> for Arc<T> {}
+impl<T: ?Sized + Unsize<U>, U: ?Sized, A: Alloc> CoerceUnsized<Arc<U, A>> for Arc<T, A> {}
 
 /// `Weak` is a version of [`Arc`] that holds a non-owning reference to the
 /// managed value. The value is accessed by calling [`upgrade`] on the `Weak`
@@ -235,30 +236,30 @@ impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<Arc<U>> for Arc<T> {}
 /// [`Option`]: ../../std/option/enum.Option.html
 /// [`None`]: ../../std/option/enum.Option.html#variant.None
 #[stable(feature = "arc_weak", since = "1.4.0")]
-pub struct Weak<T: ?Sized> {
+pub struct Weak<T: ?Sized, A: Alloc = AbortAdapter<Global>> {
     // This is a `NonNull` to allow optimizing the size of this type in enums,
     // but it is not necessarily a valid pointer.
     // `Weak::new` sets this to a dangling pointer so that it doesn’t need
     // to allocate space on the heap.
-    ptr: NonNull<ArcInner<T>>,
+    ptr: NonNull<ArcInner<T, A>>,
 }
 
 #[stable(feature = "arc_weak", since = "1.4.0")]
-unsafe impl<T: ?Sized + Sync + Send> Send for Weak<T> {}
+unsafe impl<T: ?Sized + Sync + Send, A: Alloc + Sync + Send> Send for Weak<T, A> {}
 #[stable(feature = "arc_weak", since = "1.4.0")]
-unsafe impl<T: ?Sized + Sync + Send> Sync for Weak<T> {}
+unsafe impl<T: ?Sized + Sync + Send, A: Alloc + Sync + Send> Sync for Weak<T, A> {}
 
 #[unstable(feature = "coerce_unsized", issue = "27732")]
-impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<Weak<U>> for Weak<T> {}
+impl<T: ?Sized + Unsize<U>, U: ?Sized, A: Alloc> CoerceUnsized<Weak<U, A>> for Weak<T, A> {}
 
 #[stable(feature = "arc_weak", since = "1.4.0")]
-impl<T: ?Sized + fmt::Debug> fmt::Debug for Weak<T> {
+impl<T: ?Sized + fmt::Debug, A: Alloc> fmt::Debug for Weak<T, A> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "(Weak)")
     }
 }
 
-struct ArcInner<T: ?Sized> {
+struct ArcInner<T: ?Sized, A: Alloc = AbortAdapter<Global>> {
     strong: atomic::AtomicUsize,
 
     // the value usize::MAX acts as a sentinel for temporarily "locking" the
@@ -266,14 +267,16 @@ struct ArcInner<T: ?Sized> {
     // to avoid races in `make_mut` and `get_mut`.
     weak: atomic::AtomicUsize,
 
+    alloc: A,
+
     data: T,
 }
 
-unsafe impl<T: ?Sized + Sync + Send> Send for ArcInner<T> {}
-unsafe impl<T: ?Sized + Sync + Send> Sync for ArcInner<T> {}
+unsafe impl<T: ?Sized + Sync + Send, A: Alloc + Sync + Send> Send for ArcInner<T, A> {}
+unsafe impl<T: ?Sized + Sync + Send, A: Alloc + Sync + Send> Sync for ArcInner<T, A> {}
 
 impl<T> Arc<T> {
-    /// Constructs a new `Arc<T>`.
+    /// Constructs a new `Arc<T, A>`.
     ///
     /// # Examples
     ///
@@ -285,14 +288,26 @@ impl<T> Arc<T> {
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn new(data: T) -> Arc<T> {
+        let Ok(a) = Self::new_in(data, Default::default());
+        a
+    }
+}
+
+impl<T, A: Alloc> Arc<T, A> {
+    #[unstable(feature = "allocator_api", issue = "32838")]
+    pub fn new_in(data: T, alloc: A) -> Result<Arc<T, A>, A::Err> {
         // Start the weak pointer count as 1 which is the weak pointer that's
         // held by all the strong pointers (kinda), see std/rc.rs for more info
-        let x: Box<_> = box ArcInner {
+        let x: Box<_, A> = Box::new_in(ArcInner {
             strong: atomic::AtomicUsize::new(1),
             weak: atomic::AtomicUsize::new(1),
+            alloc: unsafe { mem::uninitialized() },
             data,
-        };
-        Arc { ptr: Box::into_raw_non_null(x), phantom: PhantomData }
+        }, alloc)?;
+        let (unique, mut alloc_after) = Box::into_both(x);
+        mem::swap(unsafe { &mut (*unique.as_ptr()).alloc }, &mut alloc_after);
+        mem::forget(alloc_after);
+        Ok(Arc { ptr: From::from(unique), phantom: PhantomData })
     }
 
     /// Returns the contained value, if the `Arc` has exactly one strong reference.
@@ -339,29 +354,6 @@ impl<T> Arc<T> {
 }
 
 impl<T: ?Sized> Arc<T> {
-    /// Consumes the `Arc`, returning the wrapped pointer.
-    ///
-    /// To avoid a memory leak the pointer must be converted back to an `Arc` using
-    /// [`Arc::from_raw`][from_raw].
-    ///
-    /// [from_raw]: struct.Arc.html#method.from_raw
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use std::sync::Arc;
-    ///
-    /// let x = Arc::new(10);
-    /// let x_ptr = Arc::into_raw(x);
-    /// assert_eq!(unsafe { *x_ptr }, 10);
-    /// ```
-    #[stable(feature = "rc_raw", since = "1.17.0")]
-    pub fn into_raw(this: Self) -> *const T {
-        let ptr: *const T = &*this;
-        mem::forget(this);
-        ptr
-    }
-
     /// Constructs an `Arc` from a raw pointer.
     ///
     /// The raw pointer must have been previously returned by a call to a
@@ -392,14 +384,44 @@ impl<T: ?Sized> Arc<T> {
     /// ```
     #[stable(feature = "rc_raw", since = "1.17.0")]
     pub unsafe fn from_raw(ptr: *const T) -> Self {
+        Self::from_raw_in(ptr)
+    }
+}
+
+impl<T: ?Sized, A: Alloc> Arc<T, A> {
+    /// Consumes the `Arc`, returning the wrapped pointer.
+    ///
+    /// To avoid a memory leak the pointer must be converted back to an `Arc` using
+    /// [`Arc::from_raw`][from_raw].
+    ///
+    /// [from_raw]: struct.Arc.html#method.from_raw
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    ///
+    /// let x = Arc::new(10);
+    /// let x_ptr = Arc::into_raw(x);
+    /// assert_eq!(unsafe { *x_ptr }, 10);
+    /// ```
+    #[stable(feature = "rc_raw", since = "1.17.0")]
+    pub fn into_raw(this: Self) -> *const T {
+        let ptr: *const T = &*this;
+        mem::forget(this);
+        ptr
+    }
+
+    #[unstable(feature = "allocator_api", issue = "32838")]
+    pub unsafe fn from_raw_in(ptr: *const T) -> Self {
         // Align the unsized value to the end of the ArcInner.
         // Because it is ?Sized, it will always be the last field in memory.
         let align = align_of_val(&*ptr);
-        let layout = Layout::new::<ArcInner<()>>();
+        let layout = Layout::new::<ArcInner<(), A>>();
         let offset = (layout.size() + layout.padding_needed_for(align)) as isize;
 
         // Reverse the offset to find the original ArcInner.
-        let fake_ptr = ptr as *mut ArcInner<T>;
+        let fake_ptr = ptr as *mut ArcInner<T, A>;
         let arc_ptr = set_data_ptr(fake_ptr, (ptr as *mut u8).offset(-offset));
 
         Arc {
@@ -422,7 +444,7 @@ impl<T: ?Sized> Arc<T> {
     /// let weak_five = Arc::downgrade(&five);
     /// ```
     #[stable(feature = "arc_weak", since = "1.4.0")]
-    pub fn downgrade(this: &Self) -> Weak<T> {
+    pub fn downgrade(this: &Self) -> Weak<T, A> {
         // This Relaxed is OK because we're checking the value in the CAS
         // below.
         let mut cur = this.inner().weak.load(Relaxed);
@@ -506,7 +528,7 @@ impl<T: ?Sized> Arc<T> {
     }
 
     #[inline]
-    fn inner(&self) -> &ArcInner<T> {
+    fn inner(&self) -> &ArcInner<T, A> {
         // This unsafety is ok because while this arc is alive we're guaranteed
         // that the inner pointer is valid. Furthermore, we know that the
         // `ArcInner` structure itself is `Sync` because the inner data is
@@ -524,7 +546,15 @@ impl<T: ?Sized> Arc<T> {
 
         if self.inner().weak.fetch_sub(1, Release) == 1 {
             atomic::fence(Acquire);
-            Global.dealloc(self.ptr.cast(), Layout::for_value(self.ptr.as_ref()))
+
+            // The logic here is a little tricky because we're using an Alloc
+            // stored in the data to free the container. We first move the Alloc
+            // out of the container and then free the container. The Alloc itself
+            // will be dropped when it goes out of scope in this function.
+
+            let mut alloc = ptr::read(&(*self.ptr.as_ptr()).alloc);
+
+            alloc.dealloc(self.ptr.cast(), Layout::for_value(self.ptr.as_ref()))
         }
     }
 
@@ -551,43 +581,69 @@ impl<T: ?Sized> Arc<T> {
 }
 
 impl<T: ?Sized> Arc<T> {
-    // Allocates an `ArcInner<T>` with sufficient space for an unsized value
-    unsafe fn allocate_for_ptr(ptr: *const T) -> *mut ArcInner<T> {
+    fn from_box(v: Box<T>) -> Arc<T> {
+        let Ok(a) = Self::from_box_in(v, Default::default());
+        a
+    }
+}
+
+impl<T: ?Sized, A: Alloc> Arc<T, A> {
+    // Allocates an `ArcInner<T, A>` with sufficient space for an unsized value
+    unsafe fn allocate_for_ptr(ptr: *const T, mut alloc: A) -> Result<*mut ArcInner<T, A>, A::Err> {
         // Create a fake ArcInner to find allocation size and alignment
-        let fake_ptr = ptr as *mut ArcInner<T>;
+        let fake_ptr = ptr as *mut ArcInner<T, A>;
 
         let layout = Layout::for_value(&*fake_ptr);
 
-        let mem = Global.alloc(layout)
-            .unwrap_or_else(|_| handle_alloc_error(layout));
+        let mem = alloc.alloc(layout)?;
 
         // Initialize the real ArcInner
-        let inner = set_data_ptr(ptr as *mut T, mem.as_ptr() as *mut u8) as *mut ArcInner<T>;
+        let inner = set_data_ptr(ptr as *mut T, mem.as_ptr() as *mut u8) as *mut ArcInner<T, A>;
 
-        ptr::write(&mut (*inner).strong, atomic::AtomicUsize::new(1));
-        ptr::write(&mut (*inner).weak, atomic::AtomicUsize::new(1));
+        ptr::write(inner as *mut ArcInner<(), A>, ArcInner {
+            strong:  atomic::AtomicUsize::new(1),
+            weak: atomic::AtomicUsize::new(1),
+            alloc,
+            data: (),
+        });
 
-        inner
+        Ok(inner)
     }
 
-    fn from_box(v: Box<T>) -> Arc<T> {
+    /// `v` must be heap-allocated
+    unsafe fn from_box_raw(box_unique: Unique<T>, alloc: A) -> Result<Self, A::Err> {
+        let bptr = box_unique.as_ptr();
+        let value_size = size_of_val(&*bptr);
+        let ptr = Self::allocate_for_ptr(bptr, alloc)?;
+
+        // Copy value as bytes
+        ptr::copy_nonoverlapping(
+            bptr as *const T as *const u8,
+            &mut (*ptr).data as *mut _ as *mut u8,
+            value_size);
+
+        Ok(Arc { ptr: NonNull::new_unchecked(ptr), phantom: PhantomData })
+    }
+
+    #[unstable(feature = "allocator_api", issue = "32838")]
+    pub fn from_box_in<A2: Alloc>(v: Box<T, A2>, alloc: A) -> Result<Self, A::Err> {
+        let (u, mut a) = Box::into_both(v);
         unsafe {
-            let box_unique = Box::into_unique(v);
-            let bptr = box_unique.as_ptr();
-
-            let value_size = size_of_val(&*bptr);
-            let ptr = Self::allocate_for_ptr(bptr);
-
-            // Copy value as bytes
-            ptr::copy_nonoverlapping(
-                bptr as *const T as *const u8,
-                &mut (*ptr).data as *mut _ as *mut u8,
-                value_size);
-
+            let arc = Self::from_box_raw(u, alloc)?;
             // Free the allocation without dropping its contents
-            box_free(box_unique, Global);
+            box_free_worker(u, &mut a);
+            Ok(arc)
+        }
+    }
 
-            Arc { ptr: NonNull::new_unchecked(ptr), phantom: PhantomData }
+    #[unstable(feature = "allocator_api", issue = "32838")]
+    pub fn from_box_in_same(v: Box<T, A>) -> Result<Self, A::Err> {
+        let (u, a) = Box::into_both(v);
+        unsafe {
+            let arc = Self::from_box_raw(u, a)?;
+            // Free the allocation without dropping its contents
+            box_free_worker(u, &mut (*arc.ptr.as_ptr()).alloc);
+            Ok(arc)
         }
     }
 }
@@ -602,41 +658,49 @@ unsafe fn set_data_ptr<T: ?Sized, U>(mut ptr: *mut T, data: *mut U) -> *mut T {
 }
 
 impl<T> Arc<[T]> {
-    // Copy elements from slice into newly allocated Arc<[T]>
+    unsafe fn copy_from_slice(v: &[T]) -> Arc<[T]> {
+        let Ok(a) = Self::copy_from_slice_in(v, Default::default());
+        a
+    }
+}
+
+impl<T, A: Alloc> Arc<[T], A> {
+    // Copy elements from slice into newly allocated Arc<[T], A>
     //
     // Unsafe because the caller must either take ownership or bind `T: Copy`
-    unsafe fn copy_from_slice(v: &[T]) -> Arc<[T]> {
+    unsafe fn copy_from_slice_in(v: &[T], alloc: A) -> Result<Arc<[T], A>, A::Err> {
         let v_ptr = v as *const [T];
-        let ptr = Self::allocate_for_ptr(v_ptr);
+        let ptr = Self::allocate_for_ptr(v_ptr, alloc)?;
 
         ptr::copy_nonoverlapping(
             v.as_ptr(),
             &mut (*ptr).data as *mut [T] as *mut T,
             v.len());
 
-        Arc { ptr: NonNull::new_unchecked(ptr), phantom: PhantomData }
+        Ok(Arc { ptr: NonNull::new_unchecked(ptr), phantom: PhantomData })
     }
 }
 
 // Specialization trait used for From<&[T]>
-trait ArcFromSlice<T> {
-    fn from_slice(slice: &[T]) -> Self;
+trait ArcFromSlice<T, A: Alloc>: Sized {
+    fn from_slice(slice: &[T], alloc: A) -> Result<Self, A::Err>;
 }
 
-impl<T: Clone> ArcFromSlice<T> for Arc<[T]> {
+impl<T: Clone, A: Alloc> ArcFromSlice<T, A> for Arc<[T], A> {
     #[inline]
-    default fn from_slice(v: &[T]) -> Self {
+    default fn from_slice(v: &[T], alloc: A) -> Result<Self, A::Err> {
         // Panic guard while cloning T elements.
         // In the event of a panic, elements that have been written
         // into the new ArcInner will be dropped, then the memory freed.
-        struct Guard<T> {
+        struct Guard<'a, T, A: 'a + Alloc> {
             mem: NonNull<u8>,
             elems: *mut T,
             layout: Layout,
             n_elems: usize,
+            alloc: &'a mut A,
         }
 
-        impl<T> Drop for Guard<T> {
+        impl<'a, T, A: 'a + Alloc> Drop for Guard<'a, T, A> {
             fn drop(&mut self) {
                 use core::slice::from_raw_parts_mut;
 
@@ -644,14 +708,14 @@ impl<T: Clone> ArcFromSlice<T> for Arc<[T]> {
                     let slice = from_raw_parts_mut(self.elems, self.n_elems);
                     ptr::drop_in_place(slice);
 
-                    Global.dealloc(self.mem.cast(), self.layout.clone());
+                    self.alloc.dealloc(self.mem.cast(), self.layout.clone());
                 }
             }
         }
 
         unsafe {
             let v_ptr = v as *const [T];
-            let ptr = Self::allocate_for_ptr(v_ptr);
+            let ptr = Self::allocate_for_ptr(v_ptr, alloc)?;
 
             let mem = ptr as *mut _ as *mut u8;
             let layout = Layout::for_value(&*ptr);
@@ -664,6 +728,7 @@ impl<T: Clone> ArcFromSlice<T> for Arc<[T]> {
                 elems: elems,
                 layout: layout,
                 n_elems: 0,
+                alloc: &mut (*ptr).alloc,
             };
 
             for (i, item) in v.iter().enumerate() {
@@ -674,20 +739,20 @@ impl<T: Clone> ArcFromSlice<T> for Arc<[T]> {
             // All clear. Forget the guard so it doesn't free the new ArcInner.
             mem::forget(guard);
 
-            Arc { ptr: NonNull::new_unchecked(ptr), phantom: PhantomData }
+            Ok(Arc { ptr: NonNull::new_unchecked(ptr), phantom: PhantomData })
         }
     }
 }
 
-impl<T: Copy> ArcFromSlice<T> for Arc<[T]> {
+impl<T: Copy, A: Alloc> ArcFromSlice<T, A> for Arc<[T], A> {
     #[inline]
-    fn from_slice(v: &[T]) -> Self {
-        unsafe { Arc::copy_from_slice(v) }
+    fn from_slice(v: &[T], alloc: A) -> Result<Self, A::Err> {
+        unsafe { Arc::copy_from_slice_in(v, alloc) }
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized> Clone for Arc<T> {
+impl<T: ?Sized, A: Alloc> Clone for Arc<T, A> {
     /// Makes a clone of the `Arc` pointer.
     ///
     /// This creates another pointer to the same inner value, increasing the
@@ -703,7 +768,7 @@ impl<T: ?Sized> Clone for Arc<T> {
     /// Arc::clone(&five);
     /// ```
     #[inline]
-    fn clone(&self) -> Arc<T> {
+    fn clone(&self) -> Arc<T, A> {
         // Using a relaxed ordering is alright here, as knowledge of the
         // original reference prevents other threads from erroneously deleting
         // the object.
@@ -737,7 +802,7 @@ impl<T: ?Sized> Clone for Arc<T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized> Deref for Arc<T> {
+impl<T: ?Sized, A: Alloc> Deref for Arc<T, A> {
     type Target = T;
 
     #[inline]
@@ -831,7 +896,7 @@ impl<T: Clone> Arc<T> {
     }
 }
 
-impl<T: ?Sized> Arc<T> {
+impl<T: ?Sized, A: Alloc> Arc<T, A> {
     /// Returns a mutable reference to the inner value, if there are
     /// no other `Arc` or [`Weak`][weak] pointers to the same value.
     ///
@@ -905,7 +970,7 @@ impl<T: ?Sized> Arc<T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-unsafe impl<#[may_dangle] T: ?Sized> Drop for Arc<T> {
+unsafe impl<#[may_dangle] T: ?Sized, A: Alloc> Drop for Arc<T, A> {
     /// Drops the `Arc`.
     ///
     /// This will decrement the strong reference count. If the strong reference
@@ -1032,13 +1097,21 @@ impl<T> Weak<T> {
     /// ```
     #[stable(feature = "downgraded_weak", since = "1.10.0")]
     pub fn new() -> Weak<T> {
+        Weak::new_in()
+    }
+}
+
+impl<T, A: Alloc> Weak<T, A> {
+    /// The same as `new`, but separate for stability reasons
+    #[unstable(feature = "allocator_api", issue = "32838")]
+    pub fn new_in() -> Weak<T, A> {
         Weak {
             ptr: NonNull::dangling(),
         }
     }
 }
 
-impl<T: ?Sized> Weak<T> {
+impl<T: ?Sized, A: Alloc> Weak<T, A> {
     /// Attempts to upgrade the `Weak` pointer to an [`Arc`], extending
     /// the lifetime of the value if successful.
     ///
@@ -1066,7 +1139,7 @@ impl<T: ?Sized> Weak<T> {
     /// assert!(weak_five.upgrade().is_none());
     /// ```
     #[stable(feature = "arc_weak", since = "1.4.0")]
-    pub fn upgrade(&self) -> Option<Arc<T>> {
+    pub fn upgrade(&self) -> Option<Arc<T, A>> {
         // We use a CAS loop to increment the strong count instead of a
         // fetch_add because once the count hits 0 it must never be above 0.
         let inner = self.inner()?;
@@ -1104,7 +1177,7 @@ impl<T: ?Sized> Weak<T> {
     /// Return `None` when the pointer is dangling and there is no allocated `ArcInner`,
     /// i.e. this `Weak` was created by `Weak::new`
     #[inline]
-    fn inner(&self) -> Option<&ArcInner<T>> {
+    fn inner(&self) -> Option<&ArcInner<T, A>> {
         if is_dangling(self.ptr) {
             None
         } else {
@@ -1114,7 +1187,7 @@ impl<T: ?Sized> Weak<T> {
 }
 
 #[stable(feature = "arc_weak", since = "1.4.0")]
-impl<T: ?Sized> Clone for Weak<T> {
+impl<T: ?Sized, A: Alloc> Clone for Weak<T, A> {
     /// Makes a clone of the `Weak` pointer that points to the same value.
     ///
     /// # Examples
@@ -1127,7 +1200,7 @@ impl<T: ?Sized> Clone for Weak<T> {
     /// Weak::clone(&weak_five);
     /// ```
     #[inline]
-    fn clone(&self) -> Weak<T> {
+    fn clone(&self) -> Weak<T, A> {
         let inner = if let Some(inner) = self.inner() {
             inner
         } else {
@@ -1172,7 +1245,7 @@ impl<T> Default for Weak<T> {
 }
 
 #[stable(feature = "arc_weak", since = "1.4.0")]
-impl<T: ?Sized> Drop for Weak<T> {
+impl<T: ?Sized, A: Alloc> Drop for Weak<T, A> {
     /// Drops the `Weak` pointer.
     ///
     /// # Examples
@@ -1215,14 +1288,20 @@ impl<T: ?Sized> Drop for Weak<T> {
         if inner.weak.fetch_sub(1, Release) == 1 {
             atomic::fence(Acquire);
             unsafe {
-                Global.dealloc(self.ptr.cast(), Layout::for_value(self.ptr.as_ref()))
+                // The logic here is a little tricky because we're using an Alloc
+                // stored in the data to free the container. We first move the Alloc
+                // out of the container and then free the container. The Alloc itself
+                // will be dropped when it goes out of scope in this function.
+
+                let mut alloc = ptr::read(&(*self.ptr.as_ptr()).alloc);
+                alloc.dealloc(self.ptr.cast(), Layout::for_value(&*self.ptr.as_ptr()))
             }
         }
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized + PartialEq> PartialEq for Arc<T> {
+impl<T: ?Sized + PartialEq, A: Alloc> PartialEq for Arc<T, A> {
     /// Equality for two `Arc`s.
     ///
     /// Two `Arc`s are equal if their inner values are equal.
@@ -1236,7 +1315,7 @@ impl<T: ?Sized + PartialEq> PartialEq for Arc<T> {
     ///
     /// assert!(five == Arc::new(5));
     /// ```
-    fn eq(&self, other: &Arc<T>) -> bool {
+    fn eq(&self, other: &Arc<T, A>) -> bool {
         *(*self) == *(*other)
     }
 
@@ -1253,12 +1332,12 @@ impl<T: ?Sized + PartialEq> PartialEq for Arc<T> {
     ///
     /// assert!(five != Arc::new(6));
     /// ```
-    fn ne(&self, other: &Arc<T>) -> bool {
+    fn ne(&self, other: &Arc<T, A>) -> bool {
         *(*self) != *(*other)
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized + PartialOrd> PartialOrd for Arc<T> {
+impl<T: ?Sized + PartialOrd, A: Alloc> PartialOrd for Arc<T, A> {
     /// Partial comparison for two `Arc`s.
     ///
     /// The two are compared by calling `partial_cmp()` on their inner values.
@@ -1273,7 +1352,7 @@ impl<T: ?Sized + PartialOrd> PartialOrd for Arc<T> {
     ///
     /// assert_eq!(Some(Ordering::Less), five.partial_cmp(&Arc::new(6)));
     /// ```
-    fn partial_cmp(&self, other: &Arc<T>) -> Option<Ordering> {
+    fn partial_cmp(&self, other: &Arc<T, A>) -> Option<Ordering> {
         (**self).partial_cmp(&**other)
     }
 
@@ -1290,7 +1369,7 @@ impl<T: ?Sized + PartialOrd> PartialOrd for Arc<T> {
     ///
     /// assert!(five < Arc::new(6));
     /// ```
-    fn lt(&self, other: &Arc<T>) -> bool {
+    fn lt(&self, other: &Arc<T, A>) -> bool {
         *(*self) < *(*other)
     }
 
@@ -1307,7 +1386,7 @@ impl<T: ?Sized + PartialOrd> PartialOrd for Arc<T> {
     ///
     /// assert!(five <= Arc::new(5));
     /// ```
-    fn le(&self, other: &Arc<T>) -> bool {
+    fn le(&self, other: &Arc<T, A>) -> bool {
         *(*self) <= *(*other)
     }
 
@@ -1324,7 +1403,7 @@ impl<T: ?Sized + PartialOrd> PartialOrd for Arc<T> {
     ///
     /// assert!(five > Arc::new(4));
     /// ```
-    fn gt(&self, other: &Arc<T>) -> bool {
+    fn gt(&self, other: &Arc<T, A>) -> bool {
         *(*self) > *(*other)
     }
 
@@ -1341,12 +1420,12 @@ impl<T: ?Sized + PartialOrd> PartialOrd for Arc<T> {
     ///
     /// assert!(five >= Arc::new(5));
     /// ```
-    fn ge(&self, other: &Arc<T>) -> bool {
+    fn ge(&self, other: &Arc<T, A>) -> bool {
         *(*self) >= *(*other)
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized + Ord> Ord for Arc<T> {
+impl<T: ?Sized + Ord, A: Alloc> Ord for Arc<T, A> {
     /// Comparison for two `Arc`s.
     ///
     /// The two are compared by calling `cmp()` on their inner values.
@@ -1361,29 +1440,29 @@ impl<T: ?Sized + Ord> Ord for Arc<T> {
     ///
     /// assert_eq!(Ordering::Less, five.cmp(&Arc::new(6)));
     /// ```
-    fn cmp(&self, other: &Arc<T>) -> Ordering {
+    fn cmp(&self, other: &Arc<T, A>) -> Ordering {
         (**self).cmp(&**other)
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized + Eq> Eq for Arc<T> {}
+impl<T: ?Sized + Eq, A: Alloc> Eq for Arc<T, A> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized + fmt::Display> fmt::Display for Arc<T> {
+impl<T: ?Sized + fmt::Display, A: Alloc> fmt::Display for Arc<T, A> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Display::fmt(&**self, f)
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized + fmt::Debug> fmt::Debug for Arc<T> {
+impl<T: ?Sized + fmt::Debug, A: Alloc> fmt::Debug for Arc<T, A> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Debug::fmt(&**self, f)
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized> fmt::Pointer for Arc<T> {
+impl<T: ?Sized, A: Alloc> fmt::Pointer for Arc<T, A> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Pointer::fmt(&(&**self as *const T), f)
     }
@@ -1391,7 +1470,7 @@ impl<T: ?Sized> fmt::Pointer for Arc<T> {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: Default> Default for Arc<T> {
-    /// Creates a new `Arc<T>`, with the `Default` value for `T`.
+    /// Creates a new `Arc<T, A>`, with the `Default` value for `T`.
     ///
     /// # Examples
     ///
@@ -1407,7 +1486,7 @@ impl<T: Default> Default for Arc<T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized + Hash> Hash for Arc<T> {
+impl<T: ?Sized + Hash, A: Alloc> Hash for Arc<T, A> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         (**self).hash(state)
     }
@@ -1424,7 +1503,8 @@ impl<T> From<T> for Arc<T> {
 impl<'a, T: Clone> From<&'a [T]> for Arc<[T]> {
     #[inline]
     fn from(v: &[T]) -> Arc<[T]> {
-        <Self as ArcFromSlice<T>>::from_slice(v)
+        let Ok(a) = <Self as ArcFromSlice<T, _>>::from_slice(v, Default::default());
+        a
     }
 }
 
@@ -1739,7 +1819,7 @@ mod tests {
         assert_eq!(format!("{:?}", a), "5");
     }
 
-    // Make sure deriving works with Arc<T>
+    // Make sure deriving works with Arc<T, A>
     #[derive(Eq, Ord, PartialEq, PartialOrd, Clone, Debug, Default)]
     struct Foo {
         inner: Arc<i32>,
@@ -1925,14 +2005,14 @@ mod tests {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized> borrow::Borrow<T> for Arc<T> {
+impl<T: ?Sized, A: Alloc> borrow::Borrow<T> for Arc<T, A> {
     fn borrow(&self) -> &T {
         &**self
     }
 }
 
 #[stable(since = "1.5.0", feature = "smart_ptr_as_ref")]
-impl<T: ?Sized> AsRef<T> for Arc<T> {
+impl<T: ?Sized, A: Alloc> AsRef<T> for Arc<T, A> {
     fn as_ref(&self) -> &T {
         &**self
     }

--- a/src/liballoc/sync.rs
+++ b/src/liballoc/sync.rs
@@ -585,7 +585,7 @@ impl<T: ?Sized> Arc<T> {
                 value_size);
 
             // Free the allocation without dropping its contents
-            box_free(box_unique);
+            box_free(box_unique, Global);
 
             Arc { ptr: NonNull::new_unchecked(ptr), phantom: PhantomData }
         }

--- a/src/test/mir-opt/validate_2.rs
+++ b/src/test/mir-opt/validate_2.rs
@@ -22,14 +22,14 @@ fn main() {
 // fn main() -> () {
 //     ...
 //     bb1: {
-//         Validate(Acquire, [_2: std::boxed::Box<[i32; 3]>]);
-//         Validate(Release, [_2: std::boxed::Box<[i32; 3]>]);
-//         _1 = move _2 as std::boxed::Box<[i32]> (Unsize);
-//         Validate(Acquire, [_1: std::boxed::Box<[i32]>]);
+//         Validate(Acquire, [_2: std::boxed::Box<[i32; 3], std::alloc::Global>]);
+//         Validate(Release, [_2: std::boxed::Box<[i32; 3], std::alloc::Global>]);
+//         _1 = move _2 as std::boxed::Box<[i32], std::alloc::Global> (Unsize);
+//         Validate(Acquire, [_1: std::boxed::Box<[i32], std::alloc::Global>]);
 //         StorageDead(_2);
 //         StorageDead(_3);
 //         _0 = ();
-//         Validate(Release, [_1: std::boxed::Box<[i32]>]);
+//         Validate(Release, [_1: std::boxed::Box<[i32], std::alloc::Global>]);
 //         drop(_1) -> [return: bb2, unwind: bb3];
 //     }
 //     ...

--- a/src/test/ui/e0119/conflict-with-std.stderr
+++ b/src/test/ui/e0119/conflict-with-std.stderr
@@ -5,8 +5,8 @@ LL | impl AsRef<Q> for Box<Q> { //~ ERROR conflicting implementations
    | ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: conflicting implementation in crate `alloc`:
-           - impl<T> std::convert::AsRef<T> for std::boxed::Box<T>
-             where T: ?Sized;
+           - impl<T, A> std::convert::AsRef<T> for std::boxed::Box<T, A>
+             where A: std::alloc::Alloc, T: ?Sized;
 
 error[E0119]: conflicting implementations of trait `std::convert::From<S>` for type `S`:
   --> $DIR/conflict-with-std.rs:24:1

--- a/src/test/ui/issue-14092.rs
+++ b/src/test/ui/issue-14092.rs
@@ -9,6 +9,6 @@
 // except according to those terms.
 
 fn fn1(0: Box) {}
-        //~^ ERROR wrong number of type arguments: expected 1, found 0 [E0243]
+        //~^ ERROR wrong number of type arguments: expected at least 1, found 0 [E0243]
 
 fn main() {}

--- a/src/test/ui/issue-14092.stderr
+++ b/src/test/ui/issue-14092.stderr
@@ -1,8 +1,8 @@
-error[E0243]: wrong number of type arguments: expected 1, found 0
+error[E0243]: wrong number of type arguments: expected at least 1, found 0
   --> $DIR/issue-14092.rs:11:11
    |
 LL | fn fn1(0: Box) {}
-   |           ^^^ expected 1 type argument
+   |           ^^^ expected at least 1 type argument
 
 error: aborting due to previous error
 

--- a/src/test/ui/issue-41974.stderr
+++ b/src/test/ui/issue-41974.stderr
@@ -1,13 +1,13 @@
-error[E0119]: conflicting implementations of trait `std::ops::Drop` for type `std::boxed::Box<_>`:
+error[E0119]: conflicting implementations of trait `std::ops::Drop` for type `std::boxed::Box<_, _>`:
   --> $DIR/issue-41974.rs:17:1
    |
 LL | impl<T> Drop for T where T: A { //~ ERROR E0119
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: conflicting implementation in crate `alloc`:
-           - impl<T> std::ops::Drop for std::boxed::Box<T>
-             where T: ?Sized;
-   = note: downstream crates may implement trait `A` for type `std::boxed::Box<_>`
+           - impl<T, A> std::ops::Drop for std::boxed::Box<T, A>
+             where A: std::alloc::Alloc, T: ?Sized;
+   = note: downstream crates may implement trait `A` for type `std::boxed::Box<_, _>`
 
 error[E0120]: the Drop trait may only be implemented on structures
   --> $DIR/issue-41974.rs:17:18

--- a/src/test/ui/nll/ty-outlives/projection-no-regions-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-no-regions-closure.stderr
@@ -20,7 +20,7 @@ LL |     with_signature(x, |mut y| Box::new(y.next()))
                '_#1r,
                T,
                i32,
-               extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<(dyn Anything + '_#2r)>
+               extern "rust-call" fn((std::boxed::Box<T, std::alloc::Global>,)) -> std::boxed::Box<(dyn Anything + '_#2r), std::alloc::Global>
            ]
    = note: number of external vids: 3
    = note: where <T as std::iter::Iterator>::Item: '_#2r
@@ -60,7 +60,7 @@ LL |     with_signature(x, |mut y| Box::new(y.next()))
                '_#1r,
                T,
                i32,
-               extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<(dyn Anything + '_#2r)>
+               extern "rust-call" fn((std::boxed::Box<T, std::alloc::Global>,)) -> std::boxed::Box<(dyn Anything + '_#2r), std::alloc::Global>
            ]
    = note: number of external vids: 3
    = note: where <T as std::iter::Iterator>::Item: '_#2r
@@ -92,7 +92,7 @@ LL |     with_signature(x, |mut y| Box::new(y.next()))
                '_#2r,
                T,
                i32,
-               extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<(dyn Anything + '_#3r)>
+               extern "rust-call" fn((std::boxed::Box<T, std::alloc::Global>,)) -> std::boxed::Box<(dyn Anything + '_#3r), std::alloc::Global>
            ]
    = note: number of external vids: 4
    = note: where <T as std::iter::Iterator>::Item: '_#3r
@@ -134,7 +134,7 @@ LL |     with_signature(x, |mut y| Box::new(y.next()))
                '_#2r,
                T,
                i32,
-               extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<(dyn Anything + '_#3r)>
+               extern "rust-call" fn((std::boxed::Box<T, std::alloc::Global>,)) -> std::boxed::Box<(dyn Anything + '_#3r), std::alloc::Global>
            ]
    = note: number of external vids: 4
    = note: where <T as std::iter::Iterator>::Item: '_#3r

--- a/src/test/ui/nll/ty-outlives/ty-param-closure-outlives-from-return-type.stderr
+++ b/src/test/ui/nll/ty-outlives/ty-param-closure-outlives-from-return-type.stderr
@@ -20,7 +20,7 @@ LL |     with_signature(x, |y| y)
                '_#1r,
                T,
                i32,
-               extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<(dyn std::fmt::Debug + '_#2r)>
+               extern "rust-call" fn((std::boxed::Box<T, std::alloc::Global>,)) -> std::boxed::Box<(dyn std::fmt::Debug + '_#2r), std::alloc::Global>
            ]
    = note: number of external vids: 3
    = note: where T: '_#2r


### PR DESCRIPTION
This picks up where https://github.com/rust-lang/rust/pull/50882 will leave off, adding allocator parameters to the other collections. It also adds and associated error type for allocation, so as to enable fallibility-polymorphic code and support the few `impl`s and other functions which require "infallible" allocation.

When done, should convert all the collections for https://github.com/rust-lang/rust/issues/42774

---

Unfortunately, as documented in https://github.com/rust-lang/rust/issues/52396, I had to make an `AllocHelper` trait in order to get my `default impl` to work.

~~Also, `OK(_): Result<T, !>` is no longer deemed and infallible pattern so my `let Ok(..) = ..;` doesn't work. I can switch it to something else, but I'd like to make sure that's intentional first.~~ *edit* fixed with `exhaustive_patterns`.