### PR TITLE
Enable default inlining in platform intrinsics

### DIFF
--- a/src/etc/platform-intrinsics/generator.py
+++ b/src/etc/platform-intrinsics/generator.py
@@ -806,9 +806,6 @@ class CompilerDefs(object):
 use {{Intrinsic, Type}};
 use IntrinsicDef::Named;
 
-// The default inlining settings trigger a pathological behaviour in
-// LLVM, which causes makes compilation very slow. See #28273.
-#[inline(never)]
 pub fn find(name: &str) -> Option<Intrinsic> {{
     if !name.starts_with("{0}") {{ return None }}
     Some(match &name["{0}".len()..] {{'''.format(platform.platform_prefix())

--- a/src/librustc_platform_intrinsics/aarch64.rs
+++ b/src/librustc_platform_intrinsics/aarch64.rs
@@ -16,9 +16,6 @@
 use {Intrinsic, Type};
 use IntrinsicDef::Named;
 
-// The default inlining settings trigger a pathological behaviour in
-// LLVM, which causes makes compilation very slow. See #28273.
-#[inline(never)]
 pub fn find(name: &str) -> Option<Intrinsic> {
     if !name.starts_with("aarch64_v") { return None }
     Some(match &name["aarch64_v".len()..] {

--- a/src/librustc_platform_intrinsics/arm.rs
+++ b/src/librustc_platform_intrinsics/arm.rs
@@ -16,9 +16,6 @@
 use {Intrinsic, Type};
 use IntrinsicDef::Named;
 
-// The default inlining settings trigger a pathological behaviour in
-// LLVM, which causes makes compilation very slow. See #28273.
-#[inline(never)]
 pub fn find(name: &str) -> Option<Intrinsic> {
     if !name.starts_with("arm_v") { return None }
     Some(match &name["arm_v".len()..] {

--- a/src/librustc_platform_intrinsics/hexagon.rs
+++ b/src/librustc_platform_intrinsics/hexagon.rs
@@ -16,9 +16,6 @@
 use {Intrinsic, Type};
 use IntrinsicDef::Named;
 
-// The default inlining settings trigger a pathological behaviour in
-// LLVM, which causes makes compilation very slow. See #28273.
-#[inline(never)]
 pub fn find(name: &str) -> Option<Intrinsic> {
     if !name.starts_with("Q6_") { return None }
     Some(match &name["Q6_".len()..] {

--- a/src/librustc_platform_intrinsics/nvptx.rs
+++ b/src/librustc_platform_intrinsics/nvptx.rs
@@ -16,9 +16,6 @@
 use {Intrinsic, Type};
 use IntrinsicDef::Named;
 
-// The default inlining settings trigger a pathological behaviour in
-// LLVM, which causes makes compilation very slow. See #28273.
-#[inline(never)]
 pub fn find(name: &str) -> Option<Intrinsic> {
     if !name.starts_with("nvptx") { return None }
     Some(match &name["nvptx".len()..] {

--- a/src/librustc_platform_intrinsics/powerpc.rs
+++ b/src/librustc_platform_intrinsics/powerpc.rs
@@ -16,9 +16,6 @@
 use {Intrinsic, Type};
 use IntrinsicDef::Named;
 
-// The default inlining settings trigger a pathological behaviour in
-// LLVM, which causes makes compilation very slow. See #28273.
-#[inline(never)]
 pub fn find(name: &str) -> Option<Intrinsic> {
     if !name.starts_with("powerpc") { return None }
     Some(match &name["powerpc".len()..] {

--- a/src/librustc_platform_intrinsics/x86.rs
+++ b/src/librustc_platform_intrinsics/x86.rs
@@ -16,9 +16,6 @@
 use {Intrinsic, Type};
 use IntrinsicDef::Named;
 
-// The default inlining settings trigger a pathological behaviour in
-// LLVM, which causes makes compilation very slow. See #28273.
-#[inline(never)]
 pub fn find(name: &str) -> Option<Intrinsic> {
     if !name.starts_with("x86") { return None }
     Some(match &name["x86".len()..] {


### PR DESCRIPTION
Since [#28273](https://github.com/rust-lang/rust/issues/28273) has been fixed for quite some time, it might be a good idea to return to default inlining in platform intrinsics.