### PR TITLE
improve diagnostics for tests with custom return values

### DIFF
--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -326,7 +326,14 @@ pub fn test_main_static(tests: &[TestDescAndFn]) {
 /// test is considered a failure. By default, invokes `report()`
 /// and checks for a `0` result.
 pub fn assert_test_result<T: Termination>(result: T) {
-    assert_eq!(result.report(), 0);
+    let code = result.report();
+    assert_eq!(
+        code,
+        0,
+        "the test returned a termination value with a non-zero status code ({}) \
+         which indicates a failure",
+        code
+    );
 }
 
 #[derive(Copy, Clone, Debug)]


### PR DESCRIPTION
This is an attempt at getting the ball rolling to improve the diagnostics for test functions that return custom `impl Termination` values (see #52436).

An alternative could be to use `eprintln!`, but including this in the panic message felt nicely consistent with how failing test assertions would be reported.

Let me know what you think!