### PR TITLE
rustc: Fix a suggestion for the `proc_macro` feature

### DIFF
--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -4521,7 +4521,7 @@ impl<'a> Resolver<'a> {
                     attr::mark_known(attr);
 
                     let msg = "attribute procedural macros are experimental";
-                    let feature = "proc_macro";
+                    let feature = "use_extern_macros";
 
                     feature_err(&self.session.parse_sess, feature,
                                 attr.span, GateIssue::Language, msg)


### PR DESCRIPTION
This feature is stable, we shouldn't suggest it any more! Instead suggest the
real feature, `use_extern_macros`.