### PR TITLE
Allow clippy to be installed with make install

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -459,6 +459,7 @@ impl<'a> Builder<'a> {
                 dist::Cargo,
                 dist::Rls,
                 dist::Rustfmt,
+                dist::Clippy,
                 dist::LlvmTools,
                 dist::Extended,
                 dist::HashSign
@@ -469,6 +470,7 @@ impl<'a> Builder<'a> {
                 install::Cargo,
                 install::Rls,
                 install::Rustfmt,
+                install::Clippy,
                 install::Analysis,
                 install::Src,
                 install::Rustc


### PR DESCRIPTION
After #51122 clippy is available as a component but doesn't install when building from source.

This PR allows to install clippy with extended tools.