### PR TITLE
Disable landing pads within compiler crates

### DIFF
--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -582,6 +582,7 @@ pub fn rustc_cargo_env(builder: &Builder, cargo: &mut Command) {
     if builder.config.rustc_parallel_queries {
         cargo.env("RUSTC_PARALLEL_QUERIES", "1");
     }
+    cargo.env("RUSTC_NO_LANDING_PADS", "1");
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]


### PR DESCRIPTION
Generally speaking if the compiler panics we just need to emit the ICE
message, there's no particular need to run drop.

Instead of compiling the world with -Cpanic=abort however we use
-Zno-landing-pads to remain compatible with -Cpanic=unwind crates (e.g.,
proc macros) which want to be linked with unwinding because they use
panics for error handling. It's unclear whether this is simply a
limitation of the panic implementation strategy.

This nets wins of 3-6% on most benchmarks.