### PR TITLE
Don't build twice the sanitizers on Linux

### DIFF
--- a/src/librustc_asan/build.rs
+++ b/src/librustc_asan/build.rs
@@ -18,7 +18,7 @@ use cmake::Config;
 
 fn main() {
     if let Some(llvm_config) = env::var_os("LLVM_CONFIG") {
-        let native = match sanitizer_lib_boilerplate("asan") {
+        let (native, target) = match sanitizer_lib_boilerplate("asan") {
             Ok(native) => native,
             _ => return,
         };
@@ -29,7 +29,7 @@ fn main() {
             .define("COMPILER_RT_BUILD_XRAY", "OFF")
             .define("LLVM_CONFIG_PATH", llvm_config)
             .out_dir(&native.out_dir)
-            .build_target("asan")
+            .build_target(&target)
             .build();
     }
     println!("cargo:rerun-if-env-changed=LLVM_CONFIG");

--- a/src/librustc_lsan/build.rs
+++ b/src/librustc_lsan/build.rs
@@ -18,7 +18,7 @@ use cmake::Config;
 
 fn main() {
     if let Some(llvm_config) = env::var_os("LLVM_CONFIG") {
-        let native = match sanitizer_lib_boilerplate("lsan") {
+        let (native, target) = match sanitizer_lib_boilerplate("lsan") {
             Ok(native) => native,
             _ => return,
         };
@@ -29,7 +29,7 @@ fn main() {
             .define("COMPILER_RT_BUILD_XRAY", "OFF")
             .define("LLVM_CONFIG_PATH", llvm_config)
             .out_dir(&native.out_dir)
-            .build_target("lsan")
+            .build_target(&target)
             .build();
     }
     println!("cargo:rerun-if-env-changed=LLVM_CONFIG");

--- a/src/librustc_msan/build.rs
+++ b/src/librustc_msan/build.rs
@@ -18,7 +18,7 @@ use cmake::Config;
 
 fn main() {
     if let Some(llvm_config) = env::var_os("LLVM_CONFIG") {
-        let native = match sanitizer_lib_boilerplate("msan") {
+        let (native, target) = match sanitizer_lib_boilerplate("msan") {
             Ok(native) => native,
             _ => return,
         };
@@ -29,7 +29,7 @@ fn main() {
             .define("COMPILER_RT_BUILD_XRAY", "OFF")
             .define("LLVM_CONFIG_PATH", llvm_config)
             .out_dir(&native.out_dir)
-            .build_target("msan")
+            .build_target(&target)
             .build();
     }
     println!("cargo:rerun-if-env-changed=LLVM_CONFIG");

--- a/src/librustc_tsan/build.rs
+++ b/src/librustc_tsan/build.rs
@@ -18,7 +18,7 @@ use cmake::Config;
 
 fn main() {
     if let Some(llvm_config) = env::var_os("LLVM_CONFIG") {
-        let native = match sanitizer_lib_boilerplate("tsan") {
+        let (native, target) = match sanitizer_lib_boilerplate("tsan") {
             Ok(native) => native,
             _ => return,
         };
@@ -29,7 +29,7 @@ fn main() {
             .define("COMPILER_RT_BUILD_XRAY", "OFF")
             .define("LLVM_CONFIG_PATH", llvm_config)
             .out_dir(&native.out_dir)
-            .build_target("tsan")
+            .build_target(&target)
             .build();
     }
     println!("cargo:rerun-if-env-changed=LLVM_CONFIG");


### PR DESCRIPTION
This commit is an attempted fix at #50887. It was noticed that on that issue
we're building both x86_64 and i386 versions of libraries, but we only actually
need the x86_64 versions! This hopes that the build race condition exhibited
in #50887 is connected to building both architectures and/or building a lot of
libraries, so this should help us build precisely what we need and no more.