### PR TITLE
fix ptr_rotate comments

### DIFF
--- a/src/libcore/slice/rotate.rs
+++ b/src/libcore/slice/rotate.rs
@@ -48,7 +48,6 @@ impl<T> RawArray<T> {
 /// # Safety
 ///
 /// The specified range must be valid for reading and writing.
-/// The type `T` must have non-zero size.
 ///
 /// # Algorithm
 ///
@@ -73,6 +72,7 @@ pub unsafe fn ptr_rotate<T>(mut left: usize, mid: *mut T, mut right: usize) {
     loop {
         let delta = cmp::min(left, right);
         if delta <= RawArray::<T>::cap() {
+            // We will always hit this immediately for ZST.
             break;
         }
 


### PR DESCRIPTION
`rotate::ptr_rotate` has a comment saying
```
/// # Safety
///
/// The specified range must be valid for reading and writing.
/// The type `T` must have non-zero size.
```
So we better make sure we don't call it on ZST...

Cc @scottmcm (author of https://github.com/rust-lang/rust/pull/41670)