### PR TITLE
rustc: Remove a workaround in ThinLTO fixed upstream

### DIFF
--- a/src/librustc_codegen_llvm/back/lto.rs
+++ b/src/librustc_codegen_llvm/back/lto.rs
@@ -759,20 +759,6 @@ impl ThinModule {
         cgcx.save_temp_bitcode(&module, "thin-lto-after-pm");
         timeline.record("thin-done");
 
-        // FIXME: this is a hack around a bug in LLVM right now. Discovered in
-        // #46910 it was found out that on 32-bit MSVC LLVM will hit a codegen
-        // error if there's an available_externally function in the LLVM module.
-        // Typically we don't actually use these functions but ThinLTO makes
-        // heavy use of them when inlining across modules.
-        //
-        // Tracked upstream at https://bugs.llvm.org/show_bug.cgi?id=35736 this
-        // function call (and its definition on the C++ side of things)
-        // shouldn't be necessary eventually and we can safetly delete these few
-        // lines.
-        llvm::LLVMRustThinLTORemoveAvailableExternally(llmod);
-        cgcx.save_temp_bitcode(&module, "thin-lto-after-rm-ae");
-        timeline.record("no-ae");
-
         Ok(module)
     }
 }

--- a/src/librustc_llvm/ffi.rs
+++ b/src/librustc_llvm/ffi.rs
@@ -1791,7 +1791,6 @@ extern "C" {
                                            CU1: *mut *mut c_void,
                                            CU2: *mut *mut c_void);
     pub fn LLVMRustThinLTOPatchDICompileUnit(M: ModuleRef, CU: *mut c_void);
-    pub fn LLVMRustThinLTORemoveAvailableExternally(M: ModuleRef);
 
     pub fn LLVMRustLinkerNew(M: ModuleRef) -> LinkerRef;
     pub fn LLVMRustLinkerAdd(linker: LinkerRef,

--- a/src/rustllvm/PassWrapper.cpp
+++ b/src/rustllvm/PassWrapper.cpp
@@ -1228,15 +1228,6 @@ LLVMRustThinLTOPatchDICompileUnit(LLVMModuleRef Mod, DICompileUnit *Unit) {
   MD->addOperand(Unit);
 }
 
-extern "C" void
-LLVMRustThinLTORemoveAvailableExternally(LLVMModuleRef Mod) {
-  Module *M = unwrap(Mod);
-  for (Function &F : M->functions()) {
-    if (F.hasAvailableExternallyLinkage())
-      F.deleteBody();
-  }
-}
-
 #else
 
 extern "C" bool
@@ -1325,11 +1316,6 @@ LLVMRustThinLTOGetDICompileUnit(LLVMModuleRef Mod,
 
 extern "C" void
 LLVMRustThinLTOPatchDICompileUnit(LLVMModuleRef Mod) {
-  report_fatal_error("ThinLTO not available");
-}
-
-extern "C" void
-LLVMRustThinLTORemoveAvailableExternally(LLVMModuleRef Mod) {
   report_fatal_error("ThinLTO not available");
 }
 


### PR DESCRIPTION
This commit removes a hack in our ThinLTO passes which removes available
externally functions manually. The [upstream bug][1] has long since been fixed,
so we should be able to rely on LLVM natively for this now!

[1]: https://bugs.llvm.org/show_bug.cgi?id=35736