### PR TITLE
Fix links in rustdoc book.

### DIFF
--- a/src/doc/rustdoc/src/passes.md
+++ b/src/doc/rustdoc/src/passes.md
@@ -5,8 +5,8 @@ Rustdoc has a concept called "passes". These are transformations that
 
 In addition to the passes below, check out the docs for these flags:
 
-* [`--passes`](command-line-arguments.html#--passes-add-more-rustdoc-passes)
-* [`--no-defaults`](command-line-arguments.html#--no-defaults-dont-run-default-passes)
+* [`--passes`](command-line-arguments.html#a--passes-add-more-rustdoc-passes)
+* [`--no-defaults`](command-line-arguments.html#a--no-defaults-dont-run-default-passes)
 
 ## Default passes
 


### PR DESCRIPTION
Due to a change in how mdbook generates section anchors, headers
with non-alphabetic characters now start with "a".