### PR TITLE
Enable run-pass/sepcomp-lib-lto.rs on Android

### DIFF
--- a/src/test/run-pass/sepcomp-lib-lto.rs
+++ b/src/test/run-pass/sepcomp-lib-lto.rs
@@ -14,7 +14,6 @@
 // aux-build:sepcomp_lib.rs
 // compile-flags: -C lto -g
 // no-prefer-dynamic
-// ignore-android FIXME #18800
 
 extern crate sepcomp_lib;
 use sepcomp_lib::a::one;


### PR DESCRIPTION
#18800 is fixed, so it should be safe to restore this test.