### PR TITLE
Remove obsolete flags in the i586_musl Dockerfile

### DIFF
--- a/src/ci/docker/dist-i586-gnu-i586-i686-musl/Dockerfile
+++ b/src/ci/docker/dist-i586-gnu-i586-i686-musl/Dockerfile
@@ -42,9 +42,7 @@ ENV RUST_CONFIGURE_ARGS \
 # See: https://github.com/rust-lang/rust/issues/34978
 ENV CFLAGS_i686_unknown_linux_musl=-Wa,-mrelax-relocations=no
 ENV CFLAGS_i586_unknown_linux_gnu=-Wa,-mrelax-relocations=no
-# FIXME remove -Wl,-melf_i386 after cc is updated to include
-#       https://github.com/alexcrichton/cc-rs/pull/281
-ENV CFLAGS_i586_unknown_linux_musl="-Wa,-mrelax-relocations=no -Wl,-melf_i386"
+ENV CFLAGS_i586_unknown_linux_musl=-Wa,-mrelax-relocations=no
 
 ENV TARGETS=i586-unknown-linux-gnu,i686-unknown-linux-musl
 


### PR DESCRIPTION
Resolves an [outdated FIXME](https://github.com/rust-lang/rust/blob/ab8b961677ac5c74762dcea955aa0ff4d7fe4915/src/ci/docker/dist-i586-gnu-i586-i686-musl/Dockerfile#L45) in the Dockerfile for dist-i586-gnu-i586-i686-musl.