### PR TITLE
rustc: Fix two custom attributes with custom derive

### DIFF
--- a/src/test/run-pass-fulldeps/proc-macro/auxiliary/derive-two-attrs.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/auxiliary/derive-two-attrs.rs
@@ -1,0 +1,22 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+
+use proc_macro::*;
+
+#[proc_macro_derive(A, attributes(b))]
+pub fn foo(_x: TokenStream) -> TokenStream {
+    TokenStream::new()
+}

--- a/src/test/run-pass-fulldeps/proc-macro/derive-two-attrs.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/derive-two-attrs.rs
@@ -1,0 +1,24 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:derive-two-attrs.rs
+
+#![feature(use_extern_macros)]
+
+extern crate derive_two_attrs as foo;
+
+use foo::A;
+
+#[derive(A)]
+#[b]
+#[b]
+struct B;
+
+fn main() {}


### PR DESCRIPTION
This commit fixes an issue where multiple custom attributes could not be fed
into a custom derive in some situations with the `use_extern_macros` feature
enabled. The problem was that the macro expander didn't consider that it was
making progress when we were deducing that attributes should be lumped in with
custom derive invocations.

The fix applied here was to track in the expander if our attribute is changing
(getting stashed away elsewhere and replaced with a new invocation). If it is
swapped then it's considered progress, otherwise behavior should remain the
same.

Closes #52525