### PR TITLE
Fix docker/run.sh script when run locally

### DIFF
--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -99,7 +99,7 @@ objdir=$root_dir/obj
 
 mkdir -p $HOME/.cargo
 mkdir -p $objdir/tmp
-mkdir $objdir/cores
+mkdir -p $objdir/cores
 
 args=
 if [ "$SCCACHE_BUCKET" != "" ]; then


### PR DESCRIPTION
Switch a `mkdir $foo` to `mkdir -p $foo` to handle the case that this script is
being run locally and has previously executed.