### PR TITLE
Stabilize euclidean modulo methods

### DIFF
--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -824,7 +824,7 @@ assert_eq!(5", stringify!($SelfT), ".checked_mod_euc(2), Some(1));
 assert_eq!(5", stringify!($SelfT), ".checked_mod_euc(0), None);
 assert_eq!(", stringify!($SelfT), "::MIN.checked_mod_euc(-1), None);
 ```"),
-            #[stable(feature = "euclidean_division", since = "1.29.0")]
+            #[stable(feature = "euclidean_modulo", since = "1.29.0")]
             #[inline]
             pub fn checked_mod_euc(self, rhs: Self) -> Option<Self> {
                 if rhs == 0 || (self == Self::min_value() && rhs == -1) {
@@ -1244,7 +1244,7 @@ Basic usage:
 assert_eq!(100", stringify!($SelfT), ".wrapping_mod_euc(10), 0);
 assert_eq!((-128i8).wrapping_mod_euc(-1), 0);
 ```"),
-            #[stable(feature = "euclidean_division", since = "1.29.0")]
+            #[stable(feature = "euclidean_modulo", since = "1.29.0")]
             #[inline]
             pub fn wrapping_mod_euc(self, rhs: Self) -> Self {
                 self.overflowing_mod_euc(rhs).0
@@ -1603,7 +1603,7 @@ use std::", stringify!($SelfT), ";
 assert_eq!(5", stringify!($SelfT), ".overflowing_mod_euc(2), (1, false));
 assert_eq!(", stringify!($SelfT), "::MIN.overflowing_mod_euc(-1), (0, true));
 ```"),
-            #[stable(feature = "euclidean_division", since = "1.29.0")]
+            #[stable(feature = "euclidean_modulo", since = "1.29.0")]
             #[inline]
             pub fn overflowing_mod_euc(self, rhs: Self) -> (Self, bool) {
                 if self == Self::min_value() && rhs == -1 {
@@ -1870,7 +1870,7 @@ assert_eq!((-a).mod_euc(b), 1);
 assert_eq!(a.mod_euc(-b), 3);
 assert_eq!((-a).mod_euc(-b), 1);
 ```"),
-            #[stable(feature = "euclidean_division", since = "1.29.0")]
+            #[stable(feature = "euclidean_modulo", since = "1.29.0")]
             #[inline]
             #[rustc_inherit_overflow_checks]
             pub fn mod_euc(self, rhs: Self) -> Self {

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -2712,7 +2712,7 @@ Basic usage:
 assert_eq!(5", stringify!($SelfT), ".checked_mod_euc(2), Some(1));
 assert_eq!(5", stringify!($SelfT), ".checked_mod_euc(0), None);
 ```"),
-            #[stable(feature = "euclidean_division", since = "1.29.0")]
+            #[stable(feature = "euclidean_modulo", since = "1.29.0")]
             #[inline]
             pub fn checked_mod_euc(self, rhs: Self) -> Option<Self> {
                 if rhs == 0 {
@@ -3062,7 +3062,7 @@ Basic usage:
 #![feature(euclidean_division)]
 assert_eq!(100", stringify!($SelfT), ".wrapping_mod_euc(10), 0);
 ```"),
-            #[stable(feature = "euclidean_division", since = "1.29.0")]
+            #[stable(feature = "euclidean_modulo", since = "1.29.0")]
             #[inline]
             pub fn wrapping_mod_euc(self, rhs: Self) -> Self {
                 self % rhs
@@ -3574,7 +3574,7 @@ Basic usage:
 #![feature(euclidean_division)]
 assert_eq!(7", stringify!($SelfT), ".mod_euc(4), 3); // or any other integer type
 ```"),
-            #[stable(feature = "euclidean_division", since = "1.29.0")]
+            #[stable(feature = "euclidean_modulo", since = "1.29.0")]
             #[inline]
             #[rustc_inherit_overflow_checks]
             pub fn mod_euc(self, rhs: Self) -> Self {

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -3376,7 +3376,7 @@ Basic usage
 assert_eq!(5", stringify!($SelfT), ".overflowing_mod_euc(2), (1, false));
 ```"),
             #[inline]
-            #[stable(feature = "euclidean_division", since = "1.29.0")]
+            #[stable(feature = "euclidean_modulo", since = "1.29.0")]
             pub fn overflowing_mod_euc(self, rhs: Self) -> (Self, bool) {
                 (self % rhs, false)
             }

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -824,7 +824,7 @@ assert_eq!(5", stringify!($SelfT), ".checked_mod_euc(2), Some(1));
 assert_eq!(5", stringify!($SelfT), ".checked_mod_euc(0), None);
 assert_eq!(", stringify!($SelfT), "::MIN.checked_mod_euc(-1), None);
 ```"),
-            #[unstable(feature = "euclidean_division", issue = "49048")]
+            #[stable(feature = "euclidean_division", since = "1.29.0")]
             #[inline]
             pub fn checked_mod_euc(self, rhs: Self) -> Option<Self> {
                 if rhs == 0 || (self == Self::min_value() && rhs == -1) {
@@ -1244,7 +1244,7 @@ Basic usage:
 assert_eq!(100", stringify!($SelfT), ".wrapping_mod_euc(10), 0);
 assert_eq!((-128i8).wrapping_mod_euc(-1), 0);
 ```"),
-            #[unstable(feature = "euclidean_division", issue = "49048")]
+            #[stable(feature = "euclidean_division", since = "1.29.0")]
             #[inline]
             pub fn wrapping_mod_euc(self, rhs: Self) -> Self {
                 self.overflowing_mod_euc(rhs).0
@@ -1603,7 +1603,7 @@ use std::", stringify!($SelfT), ";
 assert_eq!(5", stringify!($SelfT), ".overflowing_mod_euc(2), (1, false));
 assert_eq!(", stringify!($SelfT), "::MIN.overflowing_mod_euc(-1), (0, true));
 ```"),
-            #[unstable(feature = "euclidean_division", issue = "49048")]
+            #[stable(feature = "euclidean_division", since = "1.29.0")]
             #[inline]
             pub fn overflowing_mod_euc(self, rhs: Self) -> (Self, bool) {
                 if self == Self::min_value() && rhs == -1 {
@@ -1870,7 +1870,7 @@ assert_eq!((-a).mod_euc(b), 1);
 assert_eq!(a.mod_euc(-b), 3);
 assert_eq!((-a).mod_euc(-b), 1);
 ```"),
-            #[unstable(feature = "euclidean_division", issue = "49048")]
+            #[stable(feature = "euclidean_division", since = "1.29.0")]
             #[inline]
             #[rustc_inherit_overflow_checks]
             pub fn mod_euc(self, rhs: Self) -> Self {
@@ -2712,7 +2712,7 @@ Basic usage:
 assert_eq!(5", stringify!($SelfT), ".checked_mod_euc(2), Some(1));
 assert_eq!(5", stringify!($SelfT), ".checked_mod_euc(0), None);
 ```"),
-            #[unstable(feature = "euclidean_division", issue = "49048")]
+            #[stable(feature = "euclidean_division", since = "1.29.0")]
             #[inline]
             pub fn checked_mod_euc(self, rhs: Self) -> Option<Self> {
                 if rhs == 0 {
@@ -3062,7 +3062,7 @@ Basic usage:
 #![feature(euclidean_division)]
 assert_eq!(100", stringify!($SelfT), ".wrapping_mod_euc(10), 0);
 ```"),
-            #[unstable(feature = "euclidean_division", issue = "49048")]
+            #[stable(feature = "euclidean_division", since = "1.29.0")]
             #[inline]
             pub fn wrapping_mod_euc(self, rhs: Self) -> Self {
                 self % rhs
@@ -3376,7 +3376,7 @@ Basic usage
 assert_eq!(5", stringify!($SelfT), ".overflowing_mod_euc(2), (1, false));
 ```"),
             #[inline]
-            #[unstable(feature = "euclidean_division", issue = "49048")]
+            #[stable(feature = "euclidean_division", since = "1.29.0")]
             pub fn overflowing_mod_euc(self, rhs: Self) -> (Self, bool) {
                 (self % rhs, false)
             }
@@ -3574,7 +3574,7 @@ Basic usage:
 #![feature(euclidean_division)]
 assert_eq!(7", stringify!($SelfT), ".mod_euc(4), 3); // or any other integer type
 ```"),
-            #[unstable(feature = "euclidean_division", issue = "49048")]
+            #[stable(feature = "euclidean_division", since = "1.29.0")]
             #[inline]
             #[rustc_inherit_overflow_checks]
             pub fn mod_euc(self, rhs: Self) -> Self {

--- a/src/libstd/f32.rs
+++ b/src/libstd/f32.rs
@@ -268,7 +268,7 @@ impl f32 {
     /// assert_eq!((-a).mod_euc(-b), 1.0);
     /// ```
     #[inline]
-    #[unstable(feature = "euclidean_division", issue = "49048")]
+    #[stable(feature = "euclidean_division", since = "1.29.0")]
     pub fn mod_euc(self, rhs: f32) -> f32 {
         let r = self % rhs;
         if r < 0.0 {

--- a/src/libstd/f32.rs
+++ b/src/libstd/f32.rs
@@ -268,7 +268,7 @@ impl f32 {
     /// assert_eq!((-a).mod_euc(-b), 1.0);
     /// ```
     #[inline]
-    #[stable(feature = "euclidean_division", since = "1.29.0")]
+    #[stable(feature = "euclidean_modulo", since = "1.29.0")]
     pub fn mod_euc(self, rhs: f32) -> f32 {
         let r = self % rhs;
         if r < 0.0 {

--- a/src/libstd/f64.rs
+++ b/src/libstd/f64.rs
@@ -244,7 +244,7 @@ impl f64 {
     /// assert_eq!((-a).mod_euc(-b), 1.0);
     /// ```
     #[inline]
-    #[stable(feature = "euclidean_division", since = "1.29.0")]
+    #[stable(feature = "euclidean_modulo", since = "1.29.0")]
     pub fn mod_euc(self, rhs: f64) -> f64 {
         let r = self % rhs;
         if r < 0.0 {

--- a/src/libstd/f64.rs
+++ b/src/libstd/f64.rs
@@ -244,7 +244,7 @@ impl f64 {
     /// assert_eq!((-a).mod_euc(-b), 1.0);
     /// ```
     #[inline]
-    #[unstable(feature = "euclidean_division", issue = "49048")]
+    #[stable(feature = "euclidean_division", since = "1.29.0")]
     pub fn mod_euc(self, rhs: f64) -> f64 {
         let r = self % rhs;
         if r < 0.0 {


### PR DESCRIPTION
This PR stabilizes the `mod_euc` method on numbers.

In the RFC, the feature for `mod_euc` is `euclidean_modulo`. However, it has been implemented as `euclidean_division`. Should I also stabilize the div methods, or change `mod_euc`'s feature name to `euclidean_modulo`?

Closes #49048