### PR TITLE
Non-naive implementation of `VecDeque.append`

### DIFF
--- a/src/liballoc/Cargo.toml
+++ b/src/liballoc/Cargo.toml
@@ -23,3 +23,8 @@ path = "../liballoc/tests/lib.rs"
 [[bench]]
 name = "collectionsbenches"
 path = "../liballoc/benches/lib.rs"
+
+[[bench]]
+name = "vec_deque_append_bench"
+path = "../liballoc/benches/vec_deque_append.rs"
+harness = false

--- a/src/liballoc/benches/vec_deque_append.rs
+++ b/src/liballoc/benches/vec_deque_append.rs
@@ -1,0 +1,48 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(duration_as_u128)]
+use std::{collections::VecDeque, time::Instant};
+
+const VECDEQUE_LEN: i32 = 100000;
+const WARMUP_N: usize = 100;
+const BENCH_N: usize = 1000;
+
+fn main() {
+    let a: VecDeque<i32> = (0..VECDEQUE_LEN).collect();
+    let b: VecDeque<i32> = (0..VECDEQUE_LEN).collect();
+
+    for _ in 0..WARMUP_N {
+        let mut c = a.clone();
+        let mut d = b.clone();
+        c.append(&mut d);
+    }
+
+    let mut durations = Vec::with_capacity(BENCH_N);
+
+    for _ in 0..BENCH_N {
+        let mut c = a.clone();
+        let mut d = b.clone();
+        let before = Instant::now();
+        c.append(&mut d);
+        let after = Instant::now();
+        durations.push(after.duration_since(before));
+    }
+
+    let l = durations.len();
+    durations.sort();
+
+    assert!(BENCH_N % 2 == 0);
+    let median = (durations[(l / 2) - 1] + durations[l / 2]) / 2;
+    println!(
+        "\ncustom-bench vec_deque_append {:?} ns/iter\n",
+        median.as_nanos()
+    );
+}

--- a/src/liballoc/collections/vec_deque.rs
+++ b/src/liballoc/collections/vec_deque.rs
@@ -208,11 +208,14 @@ impl<T> VecDeque<T> {
         let head = self.head;
         let tail = self.tail;
         let buf = self.buffer_as_mut_slice();
-        if head == tail {
+        if head != tail {
+            // In buf, head..tail contains the VecDeque and tail..head is unused.
+            // So calling `ring_slices` with tail and head swapped returns unused slices.
+            RingSlices::ring_slices(buf, tail, head)
+        } else {
+            // Swapping doesn't help when head == tail.
             let (before, after) = buf.split_at_mut(head);
             (after, before)
-        } else {
-            RingSlices::ring_slices(buf, tail, head)
         }
     }
 

--- a/src/liballoc/collections/vec_deque.rs
+++ b/src/liballoc/collections/vec_deque.rs
@@ -1882,18 +1882,18 @@ impl<T> VecDeque<T> {
             // Values are not copied one by one but as slices in `copy_whole_slice`.
             // What slices are used depends on various properties of src and dst.
             // There are 6 cases in total:
-            //     1. `src` and `dst` are contiguous
-            //     2. `src` is contiguous and `dst` is discontiguous
-            //     3. `src` is discontiguous and `dst` is contiguous
-            //     4. `src` and `dst` are discontiguous
+            //     1. `src` is contiguous and fits in dst_high
+            //     2. `src` is contiguous and does not fit in dst_high
+            //     3. `src` is discontiguous and fits in dst_high
+            //     4. `src` is discontiguous and does not fit in dst_high
             //        + src_high is smaller than dst_high
-            //     5. `src` and `dst` are discontiguous
+            //     5. `src` is discontiguous and does not fit in dst_high
             //        + dst_high is smaller than src_high
-            //     6. `src` and `dst` are discontiguous
+            //     6. `src` is discontiguous and does not fit in dst_high
             //        + dst_high is the same size as src_high
             let src_contiguous = src_low.is_empty();
-            let dst_contiguous = dst_high.len() >= src_total;
-            match (src_contiguous, dst_contiguous) {
+            let dst_high_fits_src = dst_high.len() >= src_total;
+            match (src_contiguous, dst_high_fits_src) {
                 (true, true) => {
                     // 1.
                     // other [. . . o o o . . . . . .]

--- a/src/liballoc/collections/vec_deque.rs
+++ b/src/liballoc/collections/vec_deque.rs
@@ -1859,7 +1859,7 @@ impl<T> VecDeque<T> {
         // Guarantees there is space in `self` for `other`.
         self.reserve(src_total);
 
-        let new_head = {
+        self.head = {
             let original_head = self.head;
 
             // The goal is to copy all values from `other` into `self`. To avoid any
@@ -1988,12 +1988,8 @@ impl<T> VecDeque<T> {
             }
         };
 
-        // Up until this point we are in a bad state as some values
-        // exist in both `self` and `other`. To preserve panic safety
-        // it is important we clear the old values from `other`...
-        other.clear();
-        // and that we update `head` as the last step, making the values accessible in `self`.
-        self.head = new_head;
+        // Some values now exist in both `other` and `self` but are made inaccessible in `other`.
+        other.tail = other.head;
     }
 
     /// Retains only the elements specified by the predicate.

--- a/src/liballoc/tests/vec_deque.rs
+++ b/src/liballoc/tests/vec_deque.rs
@@ -929,6 +929,60 @@ fn test_append() {
 }
 
 #[test]
+fn test_append_advanced() {
+    fn check(
+        a_push_back: usize,
+        a_pop_back: usize,
+        b_push_back: usize,
+        b_pop_back: usize,
+        a_push_front: usize,
+        a_pop_front: usize,
+        b_push_front: usize,
+        b_pop_front: usize
+    ) {
+        let mut taken = 0;
+        let mut a = VecDeque::new();
+        let mut b = VecDeque::new();
+        for n in (taken..).take(a_push_back) {
+            a.push_back(n);
+        }
+        taken += a_push_back;
+        for n in (taken..).take(a_push_front) {
+            a.push_front(n);
+        }
+        taken += a_push_front;
+        for n in (taken..).take(b_push_back) {
+            b.push_back(n);
+        }
+        taken += b_push_back;
+        for n in (taken..).take(b_push_front) {
+            b.push_front(n);
+        }
+
+        a.drain(..a_pop_back);
+        a.drain(a_pop_front..);
+        b.drain(..b_pop_back);
+        b.drain(b_pop_front..);
+        let checked = a.iter().chain(b.iter()).map(|&x| x).collect::<Vec<usize>>();
+        a.append(&mut b);
+        assert_eq!(a, checked);
+        assert!(b.is_empty());
+    }
+    for a_push in 0..17 {
+        for a_pop in 0..a_push {
+            for b_push in 0..17 {
+                for b_pop in 0..b_push {
+                    check(a_push, a_pop, b_push, b_pop, 0, 0, 0, 0);
+                    check(a_push, a_pop, b_push, b_pop, a_push, 0, 0, 0);
+                    check(a_push, a_pop, b_push, b_pop, 0, 0, b_push, 0);
+                    check(0, 0, 0, 0, a_push, a_pop, b_push, b_pop);
+                }
+            }
+        }
+    }
+}
+
+#[test]
 fn test_retain() {
     let mut buf = VecDeque::new();
     buf.extend(1..5);

--- a/src/liballoc/tests/vec_deque.rs
+++ b/src/liballoc/tests/vec_deque.rs
@@ -1004,6 +1004,31 @@ fn test_append_permutations() {
     }
 }
 
+struct DropCounter<'a> {
+    count: &'a mut u32,
+}
+
+impl<'a> Drop for DropCounter<'a> {
+    fn drop(&mut self) {
+        *self.count += 1;
+    }
+}
+
+#[test]
+fn test_append_double_drop() {
+    let (mut count_a, mut count_b) = (0, 0);
+    {
+        let mut a = VecDeque::new();
+        let mut b = VecDeque::new();
+        a.push_back(DropCounter { count: &mut count_a });
+        b.push_back(DropCounter { count: &mut count_b });
+
+        a.append(&mut b);
+    }
+    assert_eq!(count_a, 1);
+    assert_eq!(count_b, 1);
+}
+
 #[test]
 fn test_retain() {
     let mut buf = VecDeque::new();


### PR DESCRIPTION
Replaces the old, simple implementation with a more manual (and **unsafe** 😱) one. I've added 1 more test and verified that it covers all 6 code paths in the function.

This new implementation was about 60% faster than the old naive one when I tried benchmarking it.