### PR TITLE
Time units

### DIFF
--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -122,6 +122,7 @@
 #![feature(const_slice_len)]
 #![feature(const_str_as_bytes)]
 #![feature(const_str_len)]
+#![feature(time_units)]
 
 #[prelude_import]
 #[allow(unused)]

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -514,7 +514,7 @@ impl Mul<u32> for Duration {
     }
 }
 
-#[stable(feature = "time_units", since = "1.29.0")]
+#[stable(feature = "u32_duration_mul", since = "1.29.0")]
 impl Mul<Duration> for u32 {
     type Output = Duration;
 

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -44,15 +44,6 @@ const MS: Duration = Duration::from_millis(1);
 /// 1 second `Duration`
 #[unstable(feature = "time_units", issue = "0")]
 const S: Duration = Duration::from_secs(1);
-/// 1 minute `Duration`
-#[unstable(feature = "time_units", issue = "0")]
-const M: Duration = Duration::from_secs(60);
-/// 1 hour `Duration`
-#[unstable(feature = "time_units", issue = "0")]
-const H: Duration = Duration::from_secs(60*60);
-/// 1 day `Duration`
-#[unstable(feature = "time_units", issue = "0")]
-const D: Duration = Duration::from_secs(24*60*60);
 
 /// A `Duration` type to represent a span of time, typically used for system
 /// timeouts.
@@ -524,7 +515,6 @@ impl Mul<u32> for Duration {
     }
 }
 
-#[unstable(feature = "time_units", issue = "0")]
 impl Mul<Duration> for u32 {
     type Output = Duration;
 

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -31,6 +31,29 @@ const NANOS_PER_MICRO: u32 = 1_000;
 const MILLIS_PER_SEC: u64 = 1_000;
 const MICROS_PER_SEC: u64 = 1_000_000;
 
+/// 1 nanosecond `Duration`
+#[unstable(feature = "time_units", issue = "0")]
+const NS: Duration = Duration::from_nanos(1);
+/// 1 microsecond `Duration`
+#[unstable(feature = "time_units", issue = "0")]
+const US: Duration = Duration::from_micros(1);
+#[unstable(feature = "time_units", issue = "0")]
+/// 1 millisecond `Duration`
+#[unstable(feature = "time_units", issue = "0")]
+const MS: Duration = Duration::from_millis(1);
+/// 1 second `Duration`
+#[unstable(feature = "time_units", issue = "0")]
+const S: Duration = Duration::from_secs(1);
+/// 1 minute `Duration`
+#[unstable(feature = "time_units", issue = "0")]
+const M: Duration = Duration::from_secs(60);
+/// 1 hour `Duration`
+#[unstable(feature = "time_units", issue = "0")]
+const H: Duration = Duration::from_secs(60*60);
+/// 1 day `Duration`
+#[unstable(feature = "time_units", issue = "0")]
+const D: Duration = Duration::from_secs(24*60*60);
+
 /// A `Duration` type to represent a span of time, typically used for system
 /// timeouts.
 ///
@@ -498,6 +521,15 @@ impl Mul<u32> for Duration {
 
     fn mul(self, rhs: u32) -> Duration {
         self.checked_mul(rhs).expect("overflow when multiplying duration by scalar")
+    }
+}
+
+#[unstable(feature = "time_units", issue = "0")]
+impl Mul<Duration> for u32 {
+    type Output = Duration;
+
+    fn mul(self, rhs: Duration) -> Duration {
+        rhs.checked_mul(self).expect("overflow when multiplying scalar by duration")
     }
 }
 

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -37,7 +37,6 @@ const NS: Duration = Duration::from_nanos(1);
 /// 1 microsecond `Duration`
 #[unstable(feature = "time_units", issue = "0")]
 const US: Duration = Duration::from_micros(1);
-#[unstable(feature = "time_units", issue = "0")]
 /// 1 millisecond `Duration`
 #[unstable(feature = "time_units", issue = "0")]
 const MS: Duration = Duration::from_millis(1);

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -514,6 +514,7 @@ impl Mul<u32> for Duration {
     }
 }
 
+#[unstable(feature = "time_units", issue = "0")]
 impl Mul<Duration> for u32 {
     type Output = Duration;
 

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -33,16 +33,19 @@ const MICROS_PER_SEC: u64 = 1_000_000;
 
 /// 1 nanosecond `Duration`
 #[unstable(feature = "time_units", issue = "0")]
-pub const NS: Duration = Duration::from_nanos(1);
+pub const NANOSECOND: Duration = Duration::from_nanos(1);
 /// 1 microsecond `Duration`
 #[unstable(feature = "time_units", issue = "0")]
-pub const US: Duration = Duration::from_micros(1);
+pub const MICROSECOND: Duration = Duration::from_micros(1);
 /// 1 millisecond `Duration`
 #[unstable(feature = "time_units", issue = "0")]
-pub const MS: Duration = Duration::from_millis(1);
+pub const MILLISECOND: Duration = Duration::from_millis(1);
 /// 1 second `Duration`
 #[unstable(feature = "time_units", issue = "0")]
-pub const S: Duration = Duration::from_secs(1);
+pub const SECOND: Duration = Duration::from_secs(1);
+/// 1 minute `Duration`
+#[unstable(feature = "time_units", issue = "0")]
+pub const MINUTE: Duration = Duration::from_secs(60);
 
 /// A `Duration` type to represent a span of time, typically used for system
 /// timeouts.

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -31,18 +31,34 @@ const NANOS_PER_MICRO: u32 = 1_000;
 const MILLIS_PER_SEC: u64 = 1_000;
 const MICROS_PER_SEC: u64 = 1_000_000;
 
-/// 1 nanosecond `Duration`
+/// 1 nanosecond `Duration`.
 #[unstable(feature = "time_units", issue = "0")]
 pub const NANOSECOND: Duration = Duration { secs: 0, nanos: 1 };
-/// 1 microsecond `Duration`
+/// 1 microsecond `Duration`.
 #[unstable(feature = "time_units", issue = "0")]
 pub const MICROSECOND: Duration = Duration { secs: 0, nanos: NANOS_PER_MICRO };
-/// 1 millisecond `Duration`
+/// 1 millisecond `Duration`.
 #[unstable(feature = "time_units", issue = "0")]
 pub const MILLISECOND: Duration = Duration { secs: 0, nanos: NANOS_PER_MILLI };
-/// 1 second `Duration`
+/// 1 second `Duration`.
 #[unstable(feature = "time_units", issue = "0")]
 pub const SECOND: Duration = Duration { secs: 1, nanos: 0 };
+/// 1 minute `Duration` (60 seconds).
+///
+/// Note that it's different from UTC minute, which can be 59-61 seconds long.
+#[unstable(feature = "time_units", issue = "0")]
+pub const MINUTE: Duration = Duration { secs: 60, nanos: 0 };
+/// 1 hour `Duration` (60*60 = 3 600 seconds).
+///
+/// Note that it's different from UTC hour, which can be 3559-3661 seconds long.
+#[unstable(feature = "time_units", issue = "0")]
+pub const HOUR: Duration = Duration { secs: 3_600, nanos: 0 };
+/// 1 day `Duration` (24*60*60 = 86 400 seconds).
+///
+/// Note that it's different from UTC day, length of which can vary from plus
+/// minus second (leap seconds) and up to plus minus an hour (Daylight Save Time).
+#[unstable(feature = "time_units", issue = "0")]
+pub const DAY: Duration = Duration { secs: 86_400, nanos: 0 };
 
 /// A `Duration` type to represent a span of time, typically used for system
 /// timeouts.

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -43,9 +43,6 @@ pub const MILLISECOND: Duration = Duration::from_millis(1);
 /// 1 second `Duration`
 #[unstable(feature = "time_units", issue = "0")]
 pub const SECOND: Duration = Duration::from_secs(1);
-/// 1 minute `Duration`
-#[unstable(feature = "time_units", issue = "0")]
-pub const MINUTE: Duration = Duration::from_secs(60);
 
 /// A `Duration` type to represent a span of time, typically used for system
 /// timeouts.
@@ -517,7 +514,7 @@ impl Mul<u32> for Duration {
     }
 }
 
-#[unstable(feature = "time_units", issue = "0")]
+#[stable(feature = "time_units", since = "1.29.0")]
 impl Mul<Duration> for u32 {
     type Output = Duration;
 

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -33,16 +33,16 @@ const MICROS_PER_SEC: u64 = 1_000_000;
 
 /// 1 nanosecond `Duration`
 #[unstable(feature = "time_units", issue = "0")]
-const NS: Duration = Duration::from_nanos(1);
+pub const NS: Duration = Duration::from_nanos(1);
 /// 1 microsecond `Duration`
 #[unstable(feature = "time_units", issue = "0")]
-const US: Duration = Duration::from_micros(1);
+pub const US: Duration = Duration::from_micros(1);
 /// 1 millisecond `Duration`
 #[unstable(feature = "time_units", issue = "0")]
-const MS: Duration = Duration::from_millis(1);
+pub const MS: Duration = Duration::from_millis(1);
 /// 1 second `Duration`
 #[unstable(feature = "time_units", issue = "0")]
-const S: Duration = Duration::from_secs(1);
+pub const S: Duration = Duration::from_secs(1);
 
 /// A `Duration` type to represent a span of time, typically used for system
 /// timeouts.

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -33,16 +33,16 @@ const MICROS_PER_SEC: u64 = 1_000_000;
 
 /// 1 nanosecond `Duration`
 #[unstable(feature = "time_units", issue = "0")]
-pub const NANOSECOND: Duration = Duration::from_nanos(1);
+pub const NANOSECOND: Duration = Duration { secs: 0, nanos: 1 };
 /// 1 microsecond `Duration`
 #[unstable(feature = "time_units", issue = "0")]
-pub const MICROSECOND: Duration = Duration::from_micros(1);
+pub const MICROSECOND: Duration = Duration { secs: 0, nanos: NANOS_PER_MICRO };
 /// 1 millisecond `Duration`
 #[unstable(feature = "time_units", issue = "0")]
-pub const MILLISECOND: Duration = Duration::from_millis(1);
+pub const MILLISECOND: Duration = Duration { secs: 0, nanos: NANOS_PER_MILLI };
 /// 1 second `Duration`
 #[unstable(feature = "time_units", issue = "0")]
-pub const SECOND: Duration = Duration::from_secs(1);
+pub const SECOND: Duration = Duration { secs: 1, nanos: 0 };
 
 /// A `Duration` type to represent a span of time, typically used for system
 /// timeouts.

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -324,6 +324,7 @@
 #![feature(float_internals)]
 #![feature(panic_info_message)]
 #![feature(panic_implementation)]
+#![feature(time_units)]
 
 #![default_lib_allocator]
 

--- a/src/libstd/time.rs
+++ b/src/libstd/time.rs
@@ -31,7 +31,7 @@ use sys_common::FromInner;
 #[stable(feature = "time", since = "1.3.0")]
 pub use core::time::Duration;
 #[unstable(feature = "time_units", issue = "0")]
-pub use core::time::{NANOSECOND, MICROSECOND, MILLISECOND, SECOND, MINUTE};
+pub use core::time::{NANOSECOND, MICROSECOND, MILLISECOND, SECOND};
 
 /// A measurement of a monotonically nondecreasing clock.
 /// Opaque and useful only with `Duration`.

--- a/src/libstd/time.rs
+++ b/src/libstd/time.rs
@@ -30,6 +30,7 @@ use sys_common::FromInner;
 
 #[stable(feature = "time", since = "1.3.0")]
 pub use core::time::Duration;
+pub use core::time::{NS, US, MS, S, M, H, D};
 
 /// A measurement of a monotonically nondecreasing clock.
 /// Opaque and useful only with `Duration`.

--- a/src/libstd/time.rs
+++ b/src/libstd/time.rs
@@ -31,7 +31,7 @@ use sys_common::FromInner;
 #[stable(feature = "time", since = "1.3.0")]
 pub use core::time::Duration;
 #[unstable(feature = "time_units", issue = "0")]
-pub use core::time::{NS, US, MS, S};
+pub use core::time::{NANOSECOND, MICROSECOND, MILLISECOND, SECOND, MINUTE};
 
 /// A measurement of a monotonically nondecreasing clock.
 /// Opaque and useful only with `Duration`.

--- a/src/libstd/time.rs
+++ b/src/libstd/time.rs
@@ -30,6 +30,7 @@ use sys_common::FromInner;
 
 #[stable(feature = "time", since = "1.3.0")]
 pub use core::time::Duration;
+#[unstable(feature = "time_units", issue = "0")]
 pub use core::time::{NS, US, MS, S, M, H, D};
 
 /// A measurement of a monotonically nondecreasing clock.

--- a/src/libstd/time.rs
+++ b/src/libstd/time.rs
@@ -31,7 +31,7 @@ use sys_common::FromInner;
 #[stable(feature = "time", since = "1.3.0")]
 pub use core::time::Duration;
 #[unstable(feature = "time_units", issue = "0")]
-pub use core::time::{NS, US, MS, S, M, H, D};
+pub use core::time::{NS, US, MS, S};
 
 /// A measurement of a monotonically nondecreasing clock.
 /// Opaque and useful only with `Duration`.

--- a/src/libstd/time.rs
+++ b/src/libstd/time.rs
@@ -31,7 +31,9 @@ use sys_common::FromInner;
 #[stable(feature = "time", since = "1.3.0")]
 pub use core::time::Duration;
 #[unstable(feature = "time_units", issue = "0")]
-pub use core::time::{NANOSECOND, MICROSECOND, MILLISECOND, SECOND};
+pub use core::time::{
+    NANOSECOND, MICROSECOND, MILLISECOND, SECOND, MINUTE, HOUR, DAY,
+};
 
 /// A measurement of a monotonically nondecreasing clock.
 /// Opaque and useful only with `Duration`.


### PR DESCRIPTION
This PR adds `NANOSECOND`, `MICROSECOND`, `MILLISECOND`, `SECOND` constants to time module for both `std` and `core`. Instead of `sleep(Duration::from_millis(10))` it will allow us to write:
```rust
use std::time::MILLISECOND as MS;

sleep(10*MS);
```

As was discussed in #51610 adding constants for common durations will make creation of `Duration` significantly more ergonomic. This PR is a draft which can be changed upon discussion. Small explanation of the choice made in this PR:

- Why `NANOSECOND` and not `NS`? While I think the latter is usually more ergonomic, abbreviation [confuses](https://github.com/rust-lang/rust/pull/52556#issuecomment-406576852) error messages and can be ambiguous in some situations. Full names can be shortened via aliasing as was shown in the example earlier. Additionally this naming will be similar to the other languages (in particular to [Go](https://golang.org/pkg/time/#Duration) and [C++](https://en.cppreference.com/w/cpp/header/chrono#Convenience_Typedefs)).
- Why not use a separate module `time::units`? I think that a separate module will be redundant, currently `time` module has only one constant `UNIX_EPOCH`, thus they will not be lost in the documentation, and it will help with teaching existence of those constants.
- Why implement `Mul<Duration> for u32`? This will allow us to write `thread::sleep(10*M + 20*S)` instead of less pleasant `thread::sleep(M*10 + S*20)`. Ideally I would like to have a way to describe commutative property of multiplication in this case to the type system, but oh well...
- Why no `MINUTE`, `HOUR` and `DAY`? While as units accepted for use with the SI they are strictly defined in number of seconds, there is caveats to those units if UTC is considered, e.g. hour can be 3,599–3,601 seconds long, depending on conditions. Thus to avoid confusion some argue its probably better to be conservative and not include them. (see #47097 for more context) Though we probably could use prefixes like `SI_` or `STD_` for those units to highlight the difference from UTC units. **UPD: they are included back**. Final decision can be made on feature stabilization.
- No RFC? I think this change is too small for a separate RFC. Although it could be useful to link this PR on reddit and internals forum.

UPD: PR was updated based on replies.
UPD2: It looks like the prevalent opinion is that custom suffixes will be a better solution, i.e. an ability to write something like this:
```Rust
use std::time::literals::{s, ms};
sleep(1s + 1ms);
```
So even if this feature will get merged, it will probably will not be stabilized and removed at some point.