### PR TITLE
Remove obsolete armv5te vars from the dist-various-1 Dockerfile

### DIFF
--- a/src/ci/docker/dist-various-1/Dockerfile
+++ b/src/ci/docker/dist-various-1/Dockerfile
@@ -98,16 +98,10 @@ ENV TARGETS=$TARGETS,thumbv7m-none-eabi
 ENV TARGETS=$TARGETS,thumbv7em-none-eabi
 ENV TARGETS=$TARGETS,thumbv7em-none-eabihf
 
-# FIXME: remove armv5te vars after https://github.com/alexcrichton/cc-rs/issues/271
-#        get fixed and cc update
 ENV CC_mipsel_unknown_linux_musl=mipsel-openwrt-linux-gcc \
     CC_mips_unknown_linux_musl=mips-openwrt-linux-gcc \
     CC_sparc64_unknown_linux_gnu=sparc64-linux-gnu-gcc \
-    CC_x86_64_unknown_redox=x86_64-unknown-redox-gcc \
-    CC_armv5te_unknown_linux_gnueabi=arm-linux-gnueabi-gcc \
-    CFLAGS_armv5te_unknown_linux_gnueabi="-march=armv5te -marm -mfloat-abi=soft" \
-    CC_armv5te_unknown_linux_musleabi=arm-linux-gnueabi-gcc \
-    CFLAGS_armv5te_unknown_linux_musleabi="-march=armv5te -marm -mfloat-abi=soft"
+    CC_x86_64_unknown_redox=x86_64-unknown-redox-gcc
 
 ENV RUST_CONFIGURE_ARGS \
       --musl-root-armv5te=/musl-armv5te \


### PR DESCRIPTION
The [related cc issue](https://github.com/alexcrichton/cc-rs/issues/271) is closed and its changes are in force.