### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -99,7 +99,7 @@ objdir=$root_dir/obj
 
 mkdir -p $HOME/.cargo
 mkdir -p $objdir/tmp
-mkdir $objdir/cores
+mkdir -p $objdir/cores
 
 args=
 if [ "$SCCACHE_BUCKET" != "" ]; then

--- a/src/libcore/slice/rotate.rs
+++ b/src/libcore/slice/rotate.rs
@@ -48,7 +48,6 @@ impl<T> RawArray<T> {
 /// # Safety
 ///
 /// The specified range must be valid for reading and writing.
-/// The type `T` must have non-zero size.
 ///
 /// # Algorithm
 ///
@@ -73,6 +72,7 @@ pub unsafe fn ptr_rotate<T>(mut left: usize, mid: *mut T, mut right: usize) {
     loop {
         let delta = cmp::min(left, right);
         if delta <= RawArray::<T>::cap() {
+            // We will always hit this immediately for ZST.
             break;
         }
 

--- a/src/librustc/hir/map/blocks.rs
+++ b/src/librustc/hir/map/blocks.rs
@@ -51,6 +51,12 @@ impl MaybeFnLike for ast::Item {
     }
 }
 
+impl MaybeFnLike for ast::ImplItem {
+    fn is_fn_like(&self) -> bool {
+        match self.node { ast::ImplItemKind::Method(..) => true, _ => false, }
+    }
+}
+
 impl MaybeFnLike for ast::TraitItem {
     fn is_fn_like(&self) -> bool {
         match self.node {
@@ -141,7 +147,7 @@ impl<'a> FnLikeNode<'a> {
         let fn_like = match node {
             map::NodeItem(item) => item.is_fn_like(),
             map::NodeTraitItem(tm) => tm.is_fn_like(),
-            map::NodeImplItem(_) => true,
+            map::NodeImplItem(it) => it.is_fn_like(),
             map::NodeExpr(e) => e.is_fn_like(),
             _ => false
         };

--- a/src/librustc_codegen_llvm/back/lto.rs
+++ b/src/librustc_codegen_llvm/back/lto.rs
@@ -759,20 +759,6 @@ impl ThinModule {
         cgcx.save_temp_bitcode(&module, "thin-lto-after-pm");
         timeline.record("thin-done");
 
-        // FIXME: this is a hack around a bug in LLVM right now. Discovered in
-        // #46910 it was found out that on 32-bit MSVC LLVM will hit a codegen
-        // error if there's an available_externally function in the LLVM module.
-        // Typically we don't actually use these functions but ThinLTO makes
-        // heavy use of them when inlining across modules.
-        //
-        // Tracked upstream at https://bugs.llvm.org/show_bug.cgi?id=35736 this
-        // function call (and its definition on the C++ side of things)
-        // shouldn't be necessary eventually and we can safetly delete these few
-        // lines.
-        llvm::LLVMRustThinLTORemoveAvailableExternally(llmod);
-        cgcx.save_temp_bitcode(&module, "thin-lto-after-rm-ae");
-        timeline.record("no-ae");
-
         Ok(module)
     }
 }

--- a/src/librustc_codegen_llvm/builder.rs
+++ b/src/librustc_codegen_llvm/builder.rs
@@ -13,7 +13,7 @@
 use llvm;
 use llvm::{AtomicRmwBinOp, AtomicOrdering, SynchronizationScope, AsmDialect};
 use llvm::{Opcode, IntPredicate, RealPredicate, False, OperandBundleDef};
-use llvm::{ValueRef, BasicBlockRef, BuilderRef, ModuleRef};
+use llvm::{ValueRef, BasicBlockRef, BuilderRef};
 use common::*;
 use type_::Type;
 use value::Value;
@@ -1154,23 +1154,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         self.count_insn("ptrdiff");
         unsafe {
             llvm::LLVMBuildPtrDiff(self.llbuilder, lhs, rhs, noname())
-        }
-    }
-
-    pub fn trap(&self) {
-        unsafe {
-            let bb: BasicBlockRef = llvm::LLVMGetInsertBlock(self.llbuilder);
-            let fn_: ValueRef = llvm::LLVMGetBasicBlockParent(bb);
-            let m: ModuleRef = llvm::LLVMGetGlobalParent(fn_);
-            let p = "llvm.trap\0".as_ptr();
-            let t: ValueRef = llvm::LLVMGetNamedFunction(m, p as *const _);
-            assert!((t as isize != 0));
-            let args: &[ValueRef] = &[];
-            self.count_insn("trap");
-            llvm::LLVMRustBuildCall(self.llbuilder, t,
-                                    args.as_ptr(), args.len() as c_uint,
-                                    ptr::null_mut(),
-                                    noname());
         }
     }
 

--- a/src/librustc_llvm/ffi.rs
+++ b/src/librustc_llvm/ffi.rs
@@ -1791,7 +1791,6 @@ extern "C" {
                                            CU1: *mut *mut c_void,
                                            CU2: *mut *mut c_void);
     pub fn LLVMRustThinLTOPatchDICompileUnit(M: ModuleRef, CU: *mut c_void);
-    pub fn LLVMRustThinLTORemoveAvailableExternally(M: ModuleRef);
 
     pub fn LLVMRustLinkerNew(M: ModuleRef) -> LinkerRef;
     pub fn LLVMRustLinkerAdd(linker: LinkerRef,

--- a/src/rustllvm/PassWrapper.cpp
+++ b/src/rustllvm/PassWrapper.cpp
@@ -1228,15 +1228,6 @@ LLVMRustThinLTOPatchDICompileUnit(LLVMModuleRef Mod, DICompileUnit *Unit) {
   MD->addOperand(Unit);
 }
 
-extern "C" void
-LLVMRustThinLTORemoveAvailableExternally(LLVMModuleRef Mod) {
-  Module *M = unwrap(Mod);
-  for (Function &F : M->functions()) {
-    if (F.hasAvailableExternallyLinkage())
-      F.deleteBody();
-  }
-}
-
 #else
 
 extern "C" bool
@@ -1325,11 +1316,6 @@ LLVMRustThinLTOGetDICompileUnit(LLVMModuleRef Mod,
 
 extern "C" void
 LLVMRustThinLTOPatchDICompileUnit(LLVMModuleRef Mod) {
-  report_fatal_error("ThinLTO not available");
-}
-
-extern "C" void
-LLVMRustThinLTORemoveAvailableExternally(LLVMModuleRef Mod) {
   report_fatal_error("ThinLTO not available");
 }
 

--- a/src/test/run-pass-fulldeps/proc-macro/auxiliary/derive-two-attrs.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/auxiliary/derive-two-attrs.rs
@@ -1,0 +1,22 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+
+use proc_macro::*;
+
+#[proc_macro_derive(A, attributes(b))]
+pub fn foo(_x: TokenStream) -> TokenStream {
+    TokenStream::new()
+}

--- a/src/test/run-pass-fulldeps/proc-macro/derive-two-attrs.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/derive-two-attrs.rs
@@ -1,0 +1,24 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:derive-two-attrs.rs
+
+#![feature(use_extern_macros)]
+
+extern crate derive_two_attrs as foo;
+
+use foo::A;
+
+#[derive(A)]
+#[b]
+#[b]
+struct B;
+
+fn main() {}

--- a/src/test/run-pass/const-block.rs
+++ b/src/test/run-pass/const-block.rs
@@ -39,13 +39,6 @@ static BLOCK_FN: fn(usize) -> usize = { foo::<usize> };
 
 static BLOCK_ENUM_CONSTRUCTOR: fn(usize) -> Option<usize> = { Some };
 
-// FIXME #13972
-// static BLOCK_UNSAFE_SAFE_PTR: &'static isize = unsafe { &*(0xdeadbeef as *const isize) };
-// static BLOCK_UNSAFE_SAFE_PTR_2: &'static isize = unsafe {
-//     const X: *const isize = 0xdeadbeef as *const isize;
-//     &*X
-// };
-
 pub fn main() {
     assert_eq!(BLOCK_INTEGRAL, 1);
     assert_eq!(BLOCK_EXPLICIT_UNIT, ());
@@ -58,7 +51,4 @@ pub fn main() {
     assert_eq!(BLOCK_FN_INFERRED(300), 300);
     assert_eq!(BLOCK_FN(300), 300);
     assert_eq!(BLOCK_ENUM_CONSTRUCTOR(200), Some(200));
-    // FIXME #13972
-    // assert_eq!(BLOCK_UNSAFE_SAFE_PTR as *const isize as usize, 0xdeadbeef);
-    // assert_eq!(BLOCK_UNSAFE_SAFE_PTR_2 as *const isize as usize, 0xdeadbeef);
 }

--- a/src/test/run-pass/sepcomp-lib-lto.rs
+++ b/src/test/run-pass/sepcomp-lib-lto.rs
@@ -14,7 +14,6 @@
 // aux-build:sepcomp_lib.rs
 // compile-flags: -C lto -g
 // no-prefer-dynamic
-// ignore-android FIXME #18800
 
 extern crate sepcomp_lib;
 use sepcomp_lib::a::one;


### PR DESCRIPTION
Successful merges:

 - #52502 (fix unsafety: don't call ptr_rotate for ZST)
 - #52505 (rustc: Remove a workaround in ThinLTO fixed upstream)
 - #52526 (Enable run-pass/sepcomp-lib-lto.rs on Android)
 - #52527 (Remove duplicate E0396 tests)
 - #52539 (rustc: Fix two custom attributes with custom derive)
 - #52540 (Fix docker/run.sh script when run locally)
 - #52573 (Cleanups)

Failed merges:


r? @ghost