### PR TITLE
Run the error index tool against the sysroot libdir

### DIFF
--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -275,7 +275,7 @@ pub fn prepare_tool_cargo(
 
 macro_rules! tool {
     ($($name:ident, $path:expr, $tool_name:expr, $mode:expr $(,llvm_tools = $llvm:expr)*;)+) => {
-        #[derive(Copy, Clone)]
+        #[derive(Copy, PartialEq, Eq, Clone)]
         pub enum Tool {
             $(
                 $name,
@@ -640,7 +640,7 @@ impl<'a> Builder<'a> {
     fn prepare_tool_cmd(&self, compiler: Compiler, tool: Tool, cmd: &mut Command) {
         let host = &compiler.host;
         let mut lib_paths: Vec<PathBuf> = vec![
-            if compiler.stage == 0 {
+            if compiler.stage == 0 && tool != Tool::ErrorIndex {
                 self.build.rustc_snapshot_libdir()
             } else {
                 PathBuf::from(&self.sysroot_libdir(compiler, compiler.host))


### PR DESCRIPTION
Previously when building the error index tool in stage 0 we would
attempt to use stage 0 libraries, but because it depends on rustdoc,
those don't exist: rustdoc is built against stage 1 libraries.

This patch aligns those two and passes the stage 1 libdir to the error
index.

@GuillaumeGomez discovered that this hasn't worked (presumably for a long time now, but not sure).

r? @alexcrichton 