### PR TITLE
avoid tainting the local tree with non-intentional submodule changes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,6 +8,7 @@
 [submodule "src/rust-installer"]
 	path = src/tools/rust-installer
 	url = https://github.com/rust-lang/rust-installer.git
+	ignore = dirty
 [submodule "src/liblibc"]
 	path = src/liblibc
 	url = https://github.com/rust-lang/libc.git


### PR DESCRIPTION
So you do a rust checkout, run a build and suddenly you end up with "rust-installer" marked as if you went there and made changes.

I've tried to find where those extra files are being created under `tests/` to no avail, which brought me down to this question:

- Wouldn't it made sense to ignore local changes and always pull from the upstream repo if we actually want those changes there? Am I missing something? :smiley: