### PR TITLE
Don't keep the possibly initialized flow around longer than needed

### DIFF
--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -218,7 +218,6 @@ fn do_mir_borrowck<'a, 'gcx, 'tcx>(
         &borrow_set,
     );
     let regioncx = Rc::new(regioncx);
-    let flow_inits = flow_inits; // remove mut
 
     let flow_borrows = FlowAtLocation::new(do_dataflow(
         tcx,
@@ -264,7 +263,6 @@ fn do_mir_borrowck<'a, 'gcx, 'tcx>(
 
     let mut state = Flows::new(
         flow_borrows,
-        flow_inits,
         flow_uninits,
         flow_move_outs,
         flow_ever_inits,


### PR DESCRIPTION
The possibly initialized flow isn't used after liveness is computed, so don't keep it around. Locally this is about a 10% time win for tuple-stress (which is spending a lot of time calculating flows now that it's not spending so much on liveness).

r? @nikomatsakis 