### PR TITLE
Don't match on region kinds when reporting NLL errors

### DIFF
--- a/src/test/ui/borrowck/borrowck-escaping-closure-error-1.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-escaping-closure-error-1.nll.stderr
@@ -5,7 +5,7 @@ LL |     spawn(|| books.push(4));
    |           ^^^^^^^^^^^^^^^^ borrowed value does not live long enough
 LL |     //~^ ERROR E0373
 LL | }
-   | - borrowed value only lives until here
+   | - `books` dropped here while still borrowed
    |
    = note: borrowed value must be valid for the static lifetime...
 

--- a/src/test/ui/borrowck/borrowck-escaping-closure-error-2.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-escaping-closure-error-2.nll.stderr
@@ -5,7 +5,7 @@ LL |     Box::new(|| books.push(4))
    |              ^^^^^^^^^^^^^^^^ borrowed value does not live long enough
 LL |     //~^ ERROR E0373
 LL | }
-   | - borrowed value only lives until here
+   | - `books` dropped here while still borrowed
    |
 note: borrowed value must be valid for the lifetime 'a as defined on the function body at 19:8...
   --> $DIR/borrowck-escaping-closure-error-2.rs:19:8

--- a/src/test/ui/dropck/dropck-eyepatch-extern-crate.nll.stderr
+++ b/src/test/ui/dropck/dropck-eyepatch-extern-crate.nll.stderr
@@ -7,7 +7,7 @@ LL |     dt = Dt("dt", &c_shortest);
 LL | }
    | -
    | |
-   | borrowed value only lives until here
+   | `c_shortest` dropped here while still borrowed
    | borrow later used here, when `dt` is dropped
    |
    = note: values in a scope are dropped in the opposite order they are defined

--- a/src/test/ui/dropck/dropck-eyepatch-reorder.nll.stderr
+++ b/src/test/ui/dropck/dropck-eyepatch-reorder.nll.stderr
@@ -7,7 +7,7 @@ LL |     dt = Dt("dt", &c_shortest);
 LL | }
    | -
    | |
-   | borrowed value only lives until here
+   | `c_shortest` dropped here while still borrowed
    | borrow later used here, when `dt` is dropped
    |
    = note: values in a scope are dropped in the opposite order they are defined

--- a/src/test/ui/dropck/dropck-eyepatch.nll.stderr
+++ b/src/test/ui/dropck/dropck-eyepatch.nll.stderr
@@ -7,7 +7,7 @@ LL |     dt = Dt("dt", &c_shortest);
 LL | }
    | -
    | |
-   | borrowed value only lives until here
+   | `c_shortest` dropped here while still borrowed
    | borrow later used here, when `dt` is dropped
    |
    = note: values in a scope are dropped in the opposite order they are defined

--- a/src/test/ui/error-codes/E0597.nll.stderr
+++ b/src/test/ui/error-codes/E0597.nll.stderr
@@ -7,7 +7,7 @@ LL |     //~^ `y` does not live long enough [E0597]
 LL | }
    | -
    | |
-   | borrowed value only lives until here
+   | `y` dropped here while still borrowed
    | borrow later used here, when `x` is dropped
    |
    = note: values in a scope are dropped in the opposite order they are defined

--- a/src/test/ui/generator/borrowing.nll.stderr
+++ b/src/test/ui/generator/borrowing.nll.stderr
@@ -5,7 +5,7 @@ LL |         unsafe { (|| yield &a).resume() }
    |                  ^^^^^^^^^^^^^ borrowed value does not live long enough
 LL |         //~^ ERROR: `a` does not live long enough
 LL |     };
-   |     - borrowed value only lives until here
+   |     - `a` dropped here while still borrowed
 
 error[E0597]: `a` does not live long enough
   --> $DIR/borrowing.rs:24:9
@@ -16,7 +16,7 @@ LL | |             //~^ ERROR: `a` does not live long enough
 LL | |         }
    | |_________^ borrowed value does not live long enough
 LL |       };
-   |       - borrowed value only lives until here
+   |       - `a` dropped here while still borrowed
 LL |   }
    |   - borrow later used here, when `_b` is dropped
 

--- a/src/test/ui/generator/dropck.nll.stderr
+++ b/src/test/ui/generator/dropck.nll.stderr
@@ -7,7 +7,7 @@ LL |     let ref_ = Box::leak(Box::new(Some(cell.borrow_mut())));
 LL | }
    | -
    | |
-   | borrowed value only lives until here
+   | `*cell` dropped here while still borrowed
    | borrow later used here, when `gen` is dropped
    |
    = note: values in a scope are dropped in the opposite order they are defined
@@ -26,7 +26,7 @@ LL | |     };
 LL |   }
    |   -
    |   |
-   |   borrowed value only lives until here
+   |   `ref_` dropped here while still borrowed
    |   borrow later used here, when `gen` is dropped
    |
    = note: values in a scope are dropped in the opposite order they are defined

--- a/src/test/ui/generator/ref-escapes-but-not-over-yield.nll.stderr
+++ b/src/test/ui/generator/ref-escapes-but-not-over-yield.nll.stderr
@@ -5,7 +5,7 @@ LL |         a = &b;
    |             ^^ borrowed value does not live long enough
 LL |         //~^ ERROR `b` does not live long enough
 LL |     };
-   |     - borrowed value only lives until here
+   |     - `b` dropped here while still borrowed
 
 error: aborting due to previous error
 

--- a/src/test/ui/issue-12470.nll.stderr
+++ b/src/test/ui/issue-12470.nll.stderr
@@ -5,7 +5,7 @@ LL |     let bb: &B = &*b;    //~ ERROR does not live long enough
    |                  ^^^ borrowed value does not live long enough
 LL |     make_a(bb)
 LL | }
-   | - borrowed value only lives until here
+   | - `*b` dropped here while still borrowed
    |
 note: borrowed value must be valid for the lifetime 'a as defined on the function body at 36:16...
   --> $DIR/issue-12470.rs:36:16

--- a/src/test/ui/issue-13497-2.nll.stderr
+++ b/src/test/ui/issue-13497-2.nll.stderr
@@ -1,0 +1,18 @@
+error[E0597]: `rawLines` does not live long enough
+  --> $DIR/issue-13497-2.rs:13:5
+   |
+LL |     rawLines //~ ERROR `rawLines` does not live long enough
+   |     ^^^^^^^^ borrowed value does not live long enough
+LL |         .iter().map(|l| l.trim()).collect()
+LL | }
+   | - `rawLines` dropped here while still borrowed
+   |
+note: borrowed value must be valid for the lifetime 'a as defined on the function body at 11:24...
+  --> $DIR/issue-13497-2.rs:11:24
+   |
+LL | fn read_lines_borrowed<'a>() -> Vec<&'a str> {
+   |                        ^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/issue-17954.ast.nll.stderr
+++ b/src/test/ui/issue-17954.ast.nll.stderr
@@ -5,7 +5,7 @@ LL |     let a = &FOO;
    |             ^^^^ borrowed value does not live long enough
 ...
 LL | }
-   | - borrowed value only lives until here
+   | - `FOO` dropped here while still borrowed
    |
    = note: borrowed value must be valid for the static lifetime...
 

--- a/src/test/ui/issue-17954.mir.stderr
+++ b/src/test/ui/issue-17954.mir.stderr
@@ -5,7 +5,7 @@ LL |     let a = &FOO;
    |             ^^^^ borrowed value does not live long enough
 ...
 LL | }
-   | - borrowed value only lives until here
+   | - `FOO` dropped here while still borrowed
    |
    = note: borrowed value must be valid for the static lifetime...
 

--- a/src/test/ui/issue-17954.rs
+++ b/src/test/ui/issue-17954.rs
@@ -29,5 +29,5 @@ fn main() {
         println!("{}", a);
     });
 }
-//[mir]~^ borrowed value only lives until here
+//[mir]~^ `FOO` dropped here while still borrowed
 //[ast]~^^ temporary value only lives until here

--- a/src/test/ui/issue-18118.nll.stderr
+++ b/src/test/ui/issue-18118.nll.stderr
@@ -57,7 +57,7 @@ LL |         &p //~ ERROR `p` does not live long enough
    |         ^^ borrowed value does not live long enough
 LL |         //~^ ERROR let bindings in constants are unstable
 LL |     };
-   |     - borrowed value only lives until here
+   |     - `p` dropped here while still borrowed
    |
    = note: borrowed value must be valid for the static lifetime...
 

--- a/src/test/ui/issue-30438-c.nll.stderr
+++ b/src/test/ui/issue-30438-c.nll.stderr
@@ -5,7 +5,7 @@ LL |     &x
    |     ^^ borrowed value does not live long enough
 LL |     //~^ ERROR: `x` does not live long enough
 LL | }
-   | - borrowed value only lives until here
+   | - `x` dropped here while still borrowed
    |
 note: borrowed value must be valid for the lifetime 'y as defined on the function body at 17:10...
   --> $DIR/issue-30438-c.rs:17:10

--- a/src/test/ui/issue-4335.nll.stderr
+++ b/src/test/ui/issue-4335.nll.stderr
@@ -11,7 +11,7 @@ LL |     id(Box::new(|| *v))
    |                 ^^^^^ borrowed value does not live long enough
 ...
 LL | }
-   | - borrowed value only lives until here
+   | - `v` dropped here while still borrowed
    |
 note: borrowed value must be valid for the lifetime 'r as defined on the function body at 15:6...
   --> $DIR/issue-4335.rs:15:6

--- a/src/test/ui/issue-46036.stderr
+++ b/src/test/ui/issue-46036.stderr
@@ -5,7 +5,7 @@ LL |     let foo = Foo { x: &a }; //~ ERROR E0597
    |                        ^^ borrowed value does not live long enough
 LL |     loop { }
 LL | }
-   | - borrowed value only lives until here
+   | - `a` dropped here while still borrowed
    |
    = note: borrowed value must be valid for the static lifetime...
 

--- a/src/test/ui/issue-46471-1.stderr
+++ b/src/test/ui/issue-46471-1.stderr
@@ -20,7 +20,7 @@ LL | |         &mut z
 LL | |     };
    | |     -
    | |     |
-   | |_____borrowed value only lives until here
+   | |_____`z` dropped here while still borrowed
    |       borrow later used here
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/issue-46471.stderr
+++ b/src/test/ui/issue-46471.stderr
@@ -16,7 +16,7 @@ LL |     &x
    |     ^^ borrowed value does not live long enough
 ...
 LL | }
-   | - borrowed value only lives until here
+   | - `x` dropped here while still borrowed
    |
    = note: borrowed value must be valid for the static lifetime...
 

--- a/src/test/ui/issue-52126-assign-op-invariance.nll.stderr
+++ b/src/test/ui/issue-52126-assign-op-invariance.nll.stderr
@@ -8,7 +8,7 @@ LL |         println!("accumulator before add_assign {:?}", acc.map);
    |                                                        ------- borrow later used here
 ...
 LL |     }
-   |     - borrowed value only lives until here
+   |     - `line` dropped here while still borrowed
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/borrowed-local-error.stderr
+++ b/src/test/ui/nll/borrowed-local-error.stderr
@@ -10,7 +10,7 @@ LL | |         //~^ ERROR `v` does not live long enough [E0597]
 LL | |     });
    | |_____-- borrow later used here
    |       |
-   |       borrowed value only lives until here
+   |       `v` dropped here while still borrowed
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/borrowed-universal-error-2.stderr
+++ b/src/test/ui/nll/borrowed-universal-error-2.stderr
@@ -5,7 +5,7 @@ LL |     &v
    |     ^^ borrowed value does not live long enough
 LL |     //~^ ERROR `v` does not live long enough [E0597]
 LL | }
-   | - borrowed value only lives until here
+   | - `v` dropped here while still borrowed
    |
 note: borrowed value must be valid for the lifetime 'a as defined on the function body at 14:8...
   --> $DIR/borrowed-universal-error-2.rs:14:8

--- a/src/test/ui/nll/capture-ref-in-struct.stderr
+++ b/src/test/ui/nll/capture-ref-in-struct.stderr
@@ -5,7 +5,7 @@ LL |             y: &y,
    |                ^^ borrowed value does not live long enough
 ...
 LL |     }
-   |     - borrowed value only lives until here
+   |     - `y` dropped here while still borrowed
 LL | 
 LL |     deref(p);
    |           - borrow later used here

--- a/src/test/ui/nll/closure-requirements/escape-argument.stderr
+++ b/src/test/ui/nll/closure-requirements/escape-argument.stderr
@@ -30,7 +30,7 @@ LL |         closure(&mut p, &y);
    |                         ^^ borrowed value does not live long enough
 LL |         //~^ ERROR `y` does not live long enough [E0597]
 LL |     }
-   |     - borrowed value only lives until here
+   |     - `y` dropped here while still borrowed
 LL | 
 LL |     deref(p);
    |           - borrow later used here

--- a/src/test/ui/nll/closure-requirements/escape-upvar-nested.stderr
+++ b/src/test/ui/nll/closure-requirements/escape-upvar-nested.stderr
@@ -57,7 +57,7 @@ LL | |         };
    | |_________^ borrowed value does not live long enough
 ...
 LL |       }
-   |       - borrowed value only lives until here
+   |       - `y` dropped here while still borrowed
 LL | 
 LL |       deref(p);
    |             - borrow later used here

--- a/src/test/ui/nll/closure-requirements/escape-upvar-ref.stderr
+++ b/src/test/ui/nll/closure-requirements/escape-upvar-ref.stderr
@@ -34,7 +34,7 @@ LL |         let mut closure = || p = &y;
    |                           ^^^^^^^^^ borrowed value does not live long enough
 ...
 LL |     }
-   |     - borrowed value only lives until here
+   |     - `y` dropped here while still borrowed
 LL | 
 LL |     deref(p);
    |           - borrow later used here

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
@@ -82,7 +82,7 @@ LL |     let cell = Cell::new(&a);
    |                          ^^ borrowed value does not live long enough
 ...
 LL | }
-   | - borrowed value only lives until here
+   | - `a` dropped here while still borrowed
    |
    = note: borrowed value must be valid for the static lifetime...
 

--- a/src/test/ui/nll/issue-31567.stderr
+++ b/src/test/ui/nll/issue-31567.stderr
@@ -5,7 +5,7 @@ LL |     let s_inner: &'a S = &*v.0; //~ ERROR `*v.0` does not live long enough
    |                          ^^^^^ borrowed value does not live long enough
 LL |     &s_inner.0
 LL | }
-   | - borrowed value only lives until here
+   | - `*v.0` dropped here while still borrowed
    |
 note: borrowed value must be valid for the lifetime 'a as defined on the function body at 21:17...
   --> $DIR/issue-31567.rs:21:17

--- a/src/test/ui/nll/issue-47470.stderr
+++ b/src/test/ui/nll/issue-47470.stderr
@@ -4,7 +4,7 @@ error[E0597]: `local` does not live long enough
 LL |         &local //~ ERROR `local` does not live long enough
    |         ^^^^^^ borrowed value does not live long enough
 LL |     }
-   |     - borrowed value only lives until here
+   |     - `local` dropped here while still borrowed
    |
 note: borrowed value must be valid for the lifetime 'a as defined on the impl at 23:6...
   --> $DIR/issue-47470.rs:23:6

--- a/src/test/ui/region-borrow-params-issue-29793-small.nll.stderr
+++ b/src/test/ui/region-borrow-params-issue-29793-small.nll.stderr
@@ -5,7 +5,7 @@ LL |         let f = |t: bool| if t { x } else { y }; // (separate errors for `x
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
 ...
 LL |     };
-   |      - borrowed value only lives until here
+   |      - `x` dropped here while still borrowed
 
 error[E0597]: `y` does not live long enough
   --> $DIR/region-borrow-params-issue-29793-small.rs:19:17
@@ -14,7 +14,7 @@ LL |         let f = |t: bool| if t { x } else { y }; // (separate errors for `x
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
 ...
 LL |     };
-   |      - borrowed value only lives until here
+   |      - `y` dropped here while still borrowed
 
 error[E0597]: `x` does not live long enough
   --> $DIR/region-borrow-params-issue-29793-small.rs:34:17
@@ -23,7 +23,7 @@ LL |         let f = |t: bool| if t { x } else { y }; // (separate errors for `x
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
 ...
 LL |     };
-   |      - borrowed value only lives until here
+   |      - `x` dropped here while still borrowed
 
 error[E0597]: `y` does not live long enough
   --> $DIR/region-borrow-params-issue-29793-small.rs:34:17
@@ -32,7 +32,7 @@ LL |         let f = |t: bool| if t { x } else { y }; // (separate errors for `x
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
 ...
 LL |     };
-   |      - borrowed value only lives until here
+   |      - `y` dropped here while still borrowed
 
 error[E0597]: `x` does not live long enough
   --> $DIR/region-borrow-params-issue-29793-small.rs:65:17
@@ -41,7 +41,7 @@ LL |         let f = |t: bool| if t { x } else { y }; // (separate errors for `x
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
 ...
 LL |     };
-   |     - borrowed value only lives until here
+   |     - `x` dropped here while still borrowed
    |
 note: borrowed value must be valid for the lifetime 'a as defined on the function body at 64:10...
   --> $DIR/region-borrow-params-issue-29793-small.rs:64:10
@@ -56,7 +56,7 @@ LL |         let f = |t: bool| if t { x } else { y }; // (separate errors for `x
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
 ...
 LL |     };
-   |     - borrowed value only lives until here
+   |     - `y` dropped here while still borrowed
    |
 note: borrowed value must be valid for the lifetime 'a as defined on the function body at 64:10...
   --> $DIR/region-borrow-params-issue-29793-small.rs:64:10
@@ -71,7 +71,7 @@ LL |         let f = |t: bool| if t { x } else { y }; // (separate errors for `x
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
 ...
 LL |     };
-   |     - borrowed value only lives until here
+   |     - `x` dropped here while still borrowed
    |
 note: borrowed value must be valid for the lifetime 'a as defined on the function body at 75:10...
   --> $DIR/region-borrow-params-issue-29793-small.rs:75:10
@@ -86,7 +86,7 @@ LL |         let f = |t: bool| if t { x } else { y }; // (separate errors for `x
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
 ...
 LL |     };
-   |     - borrowed value only lives until here
+   |     - `y` dropped here while still borrowed
    |
 note: borrowed value must be valid for the lifetime 'a as defined on the function body at 75:10...
   --> $DIR/region-borrow-params-issue-29793-small.rs:75:10
@@ -101,7 +101,7 @@ LL |             let f = |t: bool| if t { x } else { y }; // (separate errors fo
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
 ...
 LL |         }
-   |         - borrowed value only lives until here
+   |         - `x` dropped here while still borrowed
    |
 note: borrowed value must be valid for the lifetime 'a as defined on the method body at 99:14...
   --> $DIR/region-borrow-params-issue-29793-small.rs:99:14
@@ -116,7 +116,7 @@ LL |             let f = |t: bool| if t { x } else { y }; // (separate errors fo
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
 ...
 LL |         }
-   |         - borrowed value only lives until here
+   |         - `y` dropped here while still borrowed
    |
 note: borrowed value must be valid for the lifetime 'a as defined on the method body at 99:14...
   --> $DIR/region-borrow-params-issue-29793-small.rs:99:14
@@ -131,7 +131,7 @@ LL |             let f = |t: bool| if t { x } else { y }; // (separate errors fo
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
 ...
 LL |         }
-   |         - borrowed value only lives until here
+   |         - `x` dropped here while still borrowed
    |
 note: borrowed value must be valid for the lifetime 'a as defined on the method body at 113:14...
   --> $DIR/region-borrow-params-issue-29793-small.rs:113:14
@@ -146,7 +146,7 @@ LL |             let f = |t: bool| if t { x } else { y }; // (separate errors fo
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
 ...
 LL |         }
-   |         - borrowed value only lives until here
+   |         - `y` dropped here while still borrowed
    |
 note: borrowed value must be valid for the lifetime 'a as defined on the method body at 113:14...
   --> $DIR/region-borrow-params-issue-29793-small.rs:113:14
@@ -161,7 +161,7 @@ LL |             let f = |t: bool| if t { x } else { y }; // (separate errors fo
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
 ...
 LL |         }
-   |         - borrowed value only lives until here
+   |         - `x` dropped here while still borrowed
    |
 note: borrowed value must be valid for the lifetime 'a as defined on the method body at 141:14...
   --> $DIR/region-borrow-params-issue-29793-small.rs:141:14
@@ -176,7 +176,7 @@ LL |             let f = |t: bool| if t { x } else { y }; // (separate errors fo
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
 ...
 LL |         }
-   |         - borrowed value only lives until here
+   |         - `y` dropped here while still borrowed
    |
 note: borrowed value must be valid for the lifetime 'a as defined on the method body at 141:14...
   --> $DIR/region-borrow-params-issue-29793-small.rs:141:14
@@ -191,7 +191,7 @@ LL |             let f = |t: bool| if t { x } else { y }; // (separate errors fo
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
 ...
 LL |         }
-   |         - borrowed value only lives until here
+   |         - `x` dropped here while still borrowed
    |
 note: borrowed value must be valid for the lifetime 'a as defined on the method body at 156:14...
   --> $DIR/region-borrow-params-issue-29793-small.rs:156:14
@@ -206,7 +206,7 @@ LL |             let f = |t: bool| if t { x } else { y }; // (separate errors fo
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
 ...
 LL |         }
-   |         - borrowed value only lives until here
+   |         - `y` dropped here while still borrowed
    |
 note: borrowed value must be valid for the lifetime 'a as defined on the method body at 156:14...
   --> $DIR/region-borrow-params-issue-29793-small.rs:156:14
@@ -221,7 +221,7 @@ LL |             let f = |t: bool| if t { x } else { y }; // (separate errors fo
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
 ...
 LL |         }
-   |         - borrowed value only lives until here
+   |         - `x` dropped here while still borrowed
    |
 note: borrowed value must be valid for the lifetime 'a as defined on the method body at 184:14...
   --> $DIR/region-borrow-params-issue-29793-small.rs:184:14
@@ -236,7 +236,7 @@ LL |             let f = |t: bool| if t { x } else { y }; // (separate errors fo
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
 ...
 LL |         }
-   |         - borrowed value only lives until here
+   |         - `y` dropped here while still borrowed
    |
 note: borrowed value must be valid for the lifetime 'a as defined on the method body at 184:14...
   --> $DIR/region-borrow-params-issue-29793-small.rs:184:14
@@ -251,7 +251,7 @@ LL |             let f = |t: bool| if t { x } else { y }; // (separate errors fo
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
 ...
 LL |         }
-   |         - borrowed value only lives until here
+   |         - `x` dropped here while still borrowed
    |
 note: borrowed value must be valid for the lifetime 'a as defined on the method body at 198:14...
   --> $DIR/region-borrow-params-issue-29793-small.rs:198:14
@@ -266,7 +266,7 @@ LL |             let f = |t: bool| if t { x } else { y }; // (separate errors fo
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
 ...
 LL |         }
-   |         - borrowed value only lives until here
+   |         - `y` dropped here while still borrowed
    |
 note: borrowed value must be valid for the lifetime 'a as defined on the method body at 198:14...
   --> $DIR/region-borrow-params-issue-29793-small.rs:198:14

--- a/src/test/ui/regions-nested-fns-2.nll.stderr
+++ b/src/test/ui/regions-nested-fns-2.nll.stderr
@@ -7,7 +7,7 @@ LL | |             if false { &y } else { z }
 LL | |         });
    | |_________^ borrowed value does not live long enough
 LL |   }
-   |   - borrowed value only lives until here
+   |   - `y` dropped here while still borrowed
    |
    = note: borrowed value must be valid for the static lifetime...
 

--- a/src/test/ui/span/destructor-restrictions.nll.stderr
+++ b/src/test/ui/span/destructor-restrictions.nll.stderr
@@ -4,7 +4,7 @@ error[E0597]: `*a` does not live long enough
 LL |         *a.borrow() + 1
    |          ^ borrowed value does not live long enough
 LL |     }; //~^ ERROR `*a` does not live long enough
-   |     - borrowed value only lives until here
+   |     - `*a` dropped here while still borrowed
 
 error: aborting due to previous error
 

--- a/src/test/ui/span/dropck-object-cycle.nll.stderr
+++ b/src/test/ui/span/dropck-object-cycle.nll.stderr
@@ -7,7 +7,7 @@ LL |     assert_eq!(object_invoke1(&*m), (4,5));
 LL | }
    | -
    | |
-   | borrowed value only lives until here
+   | `*m` dropped here while still borrowed
    | borrow later used here, when `m` is dropped
    |
    = note: values in a scope are dropped in the opposite order they are defined

--- a/src/test/ui/span/dropck_arr_cycle_checked.nll.stderr
+++ b/src/test/ui/span/dropck_arr_cycle_checked.nll.stderr
@@ -7,7 +7,7 @@ LL |     b1.a[1].v.set(Some(&b3));
 LL | }
    | -
    | |
-   | borrowed value only lives until here
+   | `b3` dropped here while still borrowed
    | borrow later used here, when `b1` is dropped
 
 error[E0597]: `b2` does not live long enough
@@ -19,7 +19,7 @@ LL |     b1.a[0].v.set(Some(&b2));
 LL | }
    | -
    | |
-   | borrowed value only lives until here
+   | `b2` dropped here while still borrowed
    | borrow later used here, when `b1` is dropped
 
 error[E0597]: `b1` does not live long enough
@@ -31,7 +31,7 @@ LL |     b3.a[0].v.set(Some(&b1));
 LL | }
    | -
    | |
-   | borrowed value only lives until here
+   | `b1` dropped here while still borrowed
    | borrow later used here, when `b1` is dropped
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/span/dropck_direct_cycle_with_drop.nll.stderr
+++ b/src/test/ui/span/dropck_direct_cycle_with_drop.nll.stderr
@@ -7,7 +7,7 @@ LL |     d1.p.set(Some(&d2));
 LL | }
    | -
    | |
-   | borrowed value only lives until here
+   | `d2` dropped here while still borrowed
    | borrow later used here, when `d1` is dropped
    |
    = note: values in a scope are dropped in the opposite order they are defined
@@ -21,7 +21,7 @@ LL |     //~^ ERROR `d1` does not live long enough
 LL | }
    | -
    | |
-   | borrowed value only lives until here
+   | `d1` dropped here while still borrowed
    | borrow later used here, when `d1` is dropped
    |
    = note: values in a scope are dropped in the opposite order they are defined

--- a/src/test/ui/span/dropck_misc_variants.nll.stderr
+++ b/src/test/ui/span/dropck_misc_variants.nll.stderr
@@ -6,7 +6,7 @@ LL |     _w = Wrap::<&[&str]>(NoisyDrop(&bomb));
 LL | }
    | -
    | |
-   | borrowed value only lives until here
+   | `bomb` dropped here while still borrowed
    | borrow later used here, when `_w` is dropped
    |
    = note: values in a scope are dropped in the opposite order they are defined
@@ -20,7 +20,7 @@ LL |         let u = NoisyDrop(&v);
 LL | }
    | -
    | |
-   | borrowed value only lives until here
+   | `v` dropped here while still borrowed
    | borrow later used here, when `_w` is dropped
    |
    = note: values in a scope are dropped in the opposite order they are defined

--- a/src/test/ui/span/dropck_vec_cycle_checked.nll.stderr
+++ b/src/test/ui/span/dropck_vec_cycle_checked.nll.stderr
@@ -7,7 +7,7 @@ LL |     c1.v[1].v.set(Some(&c3));
 LL | }
    | -
    | |
-   | borrowed value only lives until here
+   | `c3` dropped here while still borrowed
    | borrow later used here, when `c1` is dropped
 
 error[E0597]: `c2` does not live long enough
@@ -19,7 +19,7 @@ LL |     c1.v[0].v.set(Some(&c2));
 LL | }
    | -
    | |
-   | borrowed value only lives until here
+   | `c2` dropped here while still borrowed
    | borrow later used here, when `c1` is dropped
 
 error[E0597]: `c1` does not live long enough
@@ -31,7 +31,7 @@ LL |     c3.v[0].v.set(Some(&c1));
 LL | }
    | -
    | |
-   | borrowed value only lives until here
+   | `c1` dropped here while still borrowed
    | borrow later used here, when `c1` is dropped
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/span/issue-11925.nll.stderr
+++ b/src/test/ui/span/issue-11925.nll.stderr
@@ -4,7 +4,7 @@ error[E0597]: `x` does not live long enough
 LL |         let f = to_fn_once(move|| &x); //~ ERROR does not live long enough
    |                                   ^-
    |                                   ||
-   |                                   |borrowed value only lives until here
+   |                                   |`x` dropped here while still borrowed
    |                                   borrowed value does not live long enough
 
 error: aborting due to previous error

--- a/src/test/ui/span/issue-23338-locals-die-before-temps-of-body.nll.stderr
+++ b/src/test/ui/span/issue-23338-locals-die-before-temps-of-body.nll.stderr
@@ -4,7 +4,7 @@ error[E0597]: `y` does not live long enough
 LL |     y.borrow().clone()
    |     ^ borrowed value does not live long enough
 LL | }
-   | - borrowed value only lives until here
+   | - `y` dropped here while still borrowed
 
 error[E0597]: `y` does not live long enough
   --> $DIR/issue-23338-locals-die-before-temps-of-body.rs:27:9
@@ -12,7 +12,7 @@ error[E0597]: `y` does not live long enough
 LL |         y.borrow().clone()
    |         ^ borrowed value does not live long enough
 LL |     };
-   |     - borrowed value only lives until here
+   |     - `y` dropped here while still borrowed
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/span/issue-24805-dropck-child-has-items-via-parent.nll.stderr
+++ b/src/test/ui/span/issue-24805-dropck-child-has-items-via-parent.nll.stderr
@@ -7,7 +7,7 @@ LL |     _d = D_Child(&d1);
 LL | }
    | -
    | |
-   | borrowed value only lives until here
+   | `d1` dropped here while still borrowed
    | borrow later used here, when `_d` is dropped
    |
    = note: values in a scope are dropped in the opposite order they are defined

--- a/src/test/ui/span/issue-24805-dropck-trait-has-items.nll.stderr
+++ b/src/test/ui/span/issue-24805-dropck-trait-has-items.nll.stderr
@@ -6,7 +6,7 @@ LL |     _d = D_HasSelfMethod(&d1);
 LL | }
    | -
    | |
-   | borrowed value only lives until here
+   | `d1` dropped here while still borrowed
    | borrow later used here, when `_d` is dropped
    |
    = note: values in a scope are dropped in the opposite order they are defined
@@ -19,7 +19,7 @@ LL |     _d = D_HasMethodWithSelfArg(&d1);
 LL | }
    | -
    | |
-   | borrowed value only lives until here
+   | `d1` dropped here while still borrowed
    | borrow later used here, when `_d` is dropped
    |
    = note: values in a scope are dropped in the opposite order they are defined
@@ -32,7 +32,7 @@ LL |     _d = D_HasType(&d1);
 LL | }
    | -
    | |
-   | borrowed value only lives until here
+   | `d1` dropped here while still borrowed
    | borrow later used here, when `_d` is dropped
    |
    = note: values in a scope are dropped in the opposite order they are defined

--- a/src/test/ui/span/issue-24895-copy-clone-dropck.nll.stderr
+++ b/src/test/ui/span/issue-24895-copy-clone-dropck.nll.stderr
@@ -6,7 +6,7 @@ LL |     d2 = D(S(&d1, "inner"), "d2");
 LL | }
    | -
    | |
-   | borrowed value only lives until here
+   | `d1` dropped here while still borrowed
    | borrow later used here, when `d2` is dropped
    |
    = note: values in a scope are dropped in the opposite order they are defined

--- a/src/test/ui/span/issue-25199.nll.stderr
+++ b/src/test/ui/span/issue-25199.nll.stderr
@@ -7,7 +7,7 @@ LL |     let test = Test{test: &container};
 LL | }
    | -
    | |
-   | borrowed value only lives until here
+   | `container` dropped here while still borrowed
    | borrow later used here, when `container` is dropped
 
 error: aborting due to previous error

--- a/src/test/ui/span/issue-26656.nll.stderr
+++ b/src/test/ui/span/issue-26656.nll.stderr
@@ -6,7 +6,7 @@ LL |     zook.button = B::BigRedButton(&ticking);
 LL | }
    | -
    | |
-   | borrowed value only lives until here
+   | `ticking` dropped here while still borrowed
    | borrow later used here, when `zook` is dropped
    |
    = note: values in a scope are dropped in the opposite order they are defined

--- a/src/test/ui/span/issue-29106.nll.stderr
+++ b/src/test/ui/span/issue-29106.nll.stderr
@@ -6,7 +6,7 @@ LL |         y = Arc::new(Foo(&x));
 LL |     }
    |     -
    |     |
-   |     borrowed value only lives until here
+   |     `x` dropped here while still borrowed
    |     borrow later used here, when `y` is dropped
 
 error[E0597]: `x` does not live long enough
@@ -17,7 +17,7 @@ LL |         y = Rc::new(Foo(&x));
 LL |     }
    |     -
    |     |
-   |     borrowed value only lives until here
+   |     `x` dropped here while still borrowed
    |     borrow later used here, when `y` is dropped
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/span/issue-36537.nll.stderr
+++ b/src/test/ui/span/issue-36537.nll.stderr
@@ -5,7 +5,7 @@ LL |         p = &a;
    |         ^^^^^^ borrowed value does not live long enough
 ...
 LL |     }
-   |     - borrowed value only lives until here
+   |     - `a` dropped here while still borrowed
 LL |     p.use_ref();
    |     - borrow later used here
 

--- a/src/test/ui/span/issue-40157.nll.stderr
+++ b/src/test/ui/span/issue-40157.nll.stderr
@@ -4,7 +4,7 @@ error[E0597]: `foo` does not live long enough
 LL |     {println!("{:?}", match { let foo = vec![1, 2]; foo.get(1) } { x => x });}
    |                       ------------------------------^^^--------------------
    |                       |                             |          |
-   |                       |                             |          borrowed value only lives until here
+   |                       |                             |          `foo` dropped here while still borrowed
    |                       |                             borrowed value does not live long enough
    |                       borrow later used here
 

--- a/src/test/ui/span/issue28498-reject-ex1.nll.stderr
+++ b/src/test/ui/span/issue28498-reject-ex1.nll.stderr
@@ -7,7 +7,7 @@ LL |     foo.data[0].1.set(Some(&foo.data[1]));
 LL | }
    | -
    | |
-   | borrowed value only lives until here
+   | `foo.data` dropped here while still borrowed
    | borrow later used here, when `foo` is dropped
    |
    = note: values in a scope are dropped in the opposite order they are defined

--- a/src/test/ui/span/issue28498-reject-lifetime-param.nll.stderr
+++ b/src/test/ui/span/issue28498-reject-lifetime-param.nll.stderr
@@ -7,7 +7,7 @@ LL |     foo1 = Foo(1, &first_dropped);
 LL | }
    | -
    | |
-   | borrowed value only lives until here
+   | `first_dropped` dropped here while still borrowed
    | borrow later used here, when `foo1` is dropped
    |
    = note: values in a scope are dropped in the opposite order they are defined

--- a/src/test/ui/span/issue28498-reject-passed-to-fn.nll.stderr
+++ b/src/test/ui/span/issue28498-reject-passed-to-fn.nll.stderr
@@ -7,7 +7,7 @@ LL |     foo1 = Foo(1, &first_dropped, Box::new(callback));
 LL | }
    | -
    | |
-   | borrowed value only lives until here
+   | `first_dropped` dropped here while still borrowed
    | borrow later used here, when `foo1` is dropped
    |
    = note: values in a scope are dropped in the opposite order they are defined

--- a/src/test/ui/span/issue28498-reject-trait-bound.nll.stderr
+++ b/src/test/ui/span/issue28498-reject-trait-bound.nll.stderr
@@ -7,7 +7,7 @@ LL |     foo1 = Foo(1, &first_dropped);
 LL | }
    | -
    | |
-   | borrowed value only lives until here
+   | `first_dropped` dropped here while still borrowed
    | borrow later used here, when `foo1` is dropped
    |
    = note: values in a scope are dropped in the opposite order they are defined

--- a/src/test/ui/span/mut-ptr-cant-outlive-ref.nll.stderr
+++ b/src/test/ui/span/mut-ptr-cant-outlive-ref.nll.stderr
@@ -4,7 +4,7 @@ error[E0597]: `b` does not live long enough
 LL |         p = &*b;
    |               ^ borrowed value does not live long enough
 LL |     }
-   |     - borrowed value only lives until here
+   |     - `b` dropped here while still borrowed
 LL |     //~^^ ERROR `b` does not live long enough
 LL |     p.use_ref();
    |     - borrow later used here

--- a/src/test/ui/span/range-2.nll.stderr
+++ b/src/test/ui/span/range-2.nll.stderr
@@ -4,7 +4,7 @@ error[E0597]: `b` does not live long enough
 LL |         &a..&b
    |             ^^ borrowed value does not live long enough
 LL |     };
-   |     - borrowed value only lives until here
+   |     - `b` dropped here while still borrowed
 ...
 LL |     r.use_ref();
    |     - borrow later used here
@@ -15,7 +15,7 @@ error[E0597]: `a` does not live long enough
 LL |         &a..&b
    |         ^^ borrowed value does not live long enough
 LL |     };
-   |     - borrowed value only lives until here
+   |     - `a` dropped here while still borrowed
 ...
 LL |     r.use_ref();
    |     - borrow later used here

--- a/src/test/ui/span/regionck-unboxed-closure-lifetimes.nll.stderr
+++ b/src/test/ui/span/regionck-unboxed-closure-lifetimes.nll.stderr
@@ -5,7 +5,7 @@ LL |         let c_ref = &c;
    |                     ^^ borrowed value does not live long enough
 ...
 LL |     }
-   |     - borrowed value only lives until here
+   |     - `c` dropped here while still borrowed
 LL |     f.use_mut();
    |     - borrow later used here
 

--- a/src/test/ui/span/regions-close-over-type-parameter-2.nll.stderr
+++ b/src/test/ui/span/regions-close-over-type-parameter-2.nll.stderr
@@ -10,7 +10,7 @@ LL | |         repeater3(tmp1)
 LL | |     };
    | |     -
    | |     |
-   | |_____borrowed value only lives until here
+   | |_____`tmp0` dropped here while still borrowed
    |       borrow later used here
 
 error: aborting due to previous error

--- a/src/test/ui/span/regions-escape-loop-via-variable.nll.stderr
+++ b/src/test/ui/span/regions-escape-loop-via-variable.nll.stderr
@@ -6,7 +6,7 @@ LL |         let x = 1 + *p;
 LL |         p = &x;
    |             ^^ borrowed value does not live long enough
 LL |     }
-   |     - borrowed value only lives until here
+   |     - `x` dropped here while still borrowed
 
 error: aborting due to previous error
 

--- a/src/test/ui/span/regions-escape-loop-via-vec.nll.stderr
+++ b/src/test/ui/span/regions-escape-loop-via-vec.nll.stderr
@@ -41,7 +41,7 @@ LL |         _y.push(&mut z);
    |         borrow later used here
 ...
 LL |     }
-   |     - borrowed value only lives until here
+   |     - `z` dropped here while still borrowed
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/span/regions-infer-borrow-scope-within-loop.nll.stderr
+++ b/src/test/ui/span/regions-infer-borrow-scope-within-loop.nll.stderr
@@ -5,7 +5,7 @@ LL |         y = borrow(&*x);
    |                    ^^^ borrowed value does not live long enough
 ...
 LL |     }
-   |     - borrowed value only lives until here
+   |     - `*x` dropped here while still borrowed
 LL |     assert!(*y != 0);
    |             -- borrow later used here
 

--- a/src/test/ui/span/send-is-not-static-ensures-scoping.nll.stderr
+++ b/src/test/ui/span/send-is-not-static-ensures-scoping.nll.stderr
@@ -8,7 +8,7 @@ LL | |             //~^ ERROR `y` does not live long enough
 LL | |         })
    | |_________^ borrowed value does not live long enough
 LL |       };
-   |       - borrowed value only lives until here
+   |       - `y` dropped here while still borrowed
 LL | 
 LL |       bad.join();
    |       --- borrow later used here
@@ -20,7 +20,7 @@ LL |         let y = &x;
    |                 ^^ borrowed value does not live long enough
 ...
 LL |     };
-   |     - borrowed value only lives until here
+   |     - `x` dropped here while still borrowed
 LL | 
 LL |     bad.join();
    |     --- borrow later used here

--- a/src/test/ui/span/send-is-not-static-std-sync-2.nll.stderr
+++ b/src/test/ui/span/send-is-not-static-std-sync-2.nll.stderr
@@ -4,7 +4,7 @@ error[E0597]: `x` does not live long enough
 LL |         Mutex::new(&x)
    |                    ^^ borrowed value does not live long enough
 LL |     };
-   |     - borrowed value only lives until here
+   |     - `x` dropped here while still borrowed
 ...
 LL |     let _dangling = *lock.lock().unwrap();
    |                      ---- borrow later used here
@@ -15,7 +15,7 @@ error[E0597]: `x` does not live long enough
 LL |         RwLock::new(&x)
    |                     ^^ borrowed value does not live long enough
 LL |     };
-   |     - borrowed value only lives until here
+   |     - `x` dropped here while still borrowed
 LL |     //~^^ ERROR `x` does not live long enough
 LL |     let _dangling = *lock.read().unwrap();
    |                      ---- borrow later used here
@@ -30,7 +30,7 @@ LL |         let _ = tx.send(&x);
    |                         ^^ borrowed value does not live long enough
 LL |         (tx, rx)
 LL |     };
-   |     - borrowed value only lives until here
+   |     - `x` dropped here while still borrowed
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/span/send-is-not-static-std-sync.nll.stderr
+++ b/src/test/ui/span/send-is-not-static-std-sync.nll.stderr
@@ -15,7 +15,7 @@ error[E0597]: `z` does not live long enough
 LL |         *lock.lock().unwrap() = &z;
    |                                 ^^ borrowed value does not live long enough
 LL |     }
-   |     - borrowed value only lives until here
+   |     - `z` dropped here while still borrowed
 LL |     //~^^ ERROR `z` does not live long enough
 LL |     lock.use_ref(); // (Mutex is #[may_dangle] so its dtor does not use `z` => needs explicit use)
    |     ---- borrow later used here
@@ -37,7 +37,7 @@ error[E0597]: `z` does not live long enough
 LL |         *lock.write().unwrap() = &z;
    |                                  ^^ borrowed value does not live long enough
 LL |     }
-   |     - borrowed value only lives until here
+   |     - `z` dropped here while still borrowed
 LL |     //~^^ ERROR `z` does not live long enough
 LL |     lock.use_ref(); // (RwLock is #[may_dangle] so its dtor does not use `z` => needs explicit use)
    |     ---- borrow later used here
@@ -59,7 +59,7 @@ error[E0597]: `z` does not live long enough
 LL |         tx.send(&z).unwrap();
    |                 ^^ borrowed value does not live long enough
 LL |     }
-   |     - borrowed value only lives until here
+   |     - `z` dropped here while still borrowed
 ...
 LL | }
    | - borrow later used here, when `tx` is dropped

--- a/src/test/ui/span/vec-must-not-hide-type-from-dropck.nll.stderr
+++ b/src/test/ui/span/vec-must-not-hide-type-from-dropck.nll.stderr
@@ -7,7 +7,7 @@ LL |     c1.v[0].v.set(Some(&c2));
 LL | }
    | -
    | |
-   | borrowed value only lives until here
+   | `c2` dropped here while still borrowed
    | borrow later used here, when `c1` is dropped
 
 error[E0597]: `c1` does not live long enough
@@ -19,7 +19,7 @@ LL |     //~^ ERROR `c1` does not live long enough
 LL | }
    | -
    | |
-   | borrowed value only lives until here
+   | `c1` dropped here while still borrowed
    | borrow later used here, when `c1` is dropped
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/span/vec_refs_data_with_early_death.nll.stderr
+++ b/src/test/ui/span/vec_refs_data_with_early_death.nll.stderr
@@ -7,7 +7,7 @@ LL |     v.push(&y);
 LL | }
    | -
    | |
-   | borrowed value only lives until here
+   | `y` dropped here while still borrowed
    | borrow later used here, when `v` is dropped
    |
    = note: values in a scope are dropped in the opposite order they are defined
@@ -21,7 +21,7 @@ LL |     v.push(&x);
 LL | }
    | -
    | |
-   | borrowed value only lives until here
+   | `x` dropped here while still borrowed
    | borrow later used here, when `v` is dropped
    |
    = note: values in a scope are dropped in the opposite order they are defined

--- a/src/test/ui/span/wf-method-late-bound-regions.nll.stderr
+++ b/src/test/ui/span/wf-method-late-bound-regions.nll.stderr
@@ -4,7 +4,7 @@ error[E0597]: `pointer` does not live long enough
 LL |         f2.xmute(&pointer)
    |                  ^^^^^^^^ borrowed value does not live long enough
 LL |     };
-   |     - borrowed value only lives until here
+   |     - `pointer` dropped here while still borrowed
 LL |     //~^^ ERROR `pointer` does not live long enough
 LL |     println!("{}", dangling);
    |                    -------- borrow later used here


### PR DESCRIPTION
First half (by number of tests affected) of the changes to "does not live long enough".

Now that lexical MIR borrowck is gone, region kinds are always ReVar, so matching on them to change errors does nothing.

Changes "borrowed value only lives until here" to "`x` is dropped here while still borrowed".

r? @pnkfelix  cc @nikomatsakis 