### PR TITLE
Delete unused code in rustdoc

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -425,9 +425,6 @@ impl Item {
     pub fn is_enum(&self) -> bool {
         self.type_() == ItemType::Enum
     }
-    pub fn is_fn(&self) -> bool {
-        self.type_() == ItemType::Function
-    }
     pub fn is_associated_type(&self) -> bool {
         self.type_() == ItemType::AssociatedType
     }
@@ -2188,10 +2185,6 @@ pub struct FnDecl {
 }
 
 impl FnDecl {
-    pub fn has_self(&self) -> bool {
-        self.inputs.values.len() > 0 && self.inputs.values[0].name == "self"
-    }
-
     pub fn self_type(&self) -> Option<SelfTy> {
         self.inputs.values.get(0).and_then(|v| v.to_self())
     }
@@ -3547,21 +3540,6 @@ pub struct Path {
 }
 
 impl Path {
-    pub fn singleton(name: String) -> Path {
-        Path {
-            global: false,
-            def: Def::Err,
-            segments: vec![PathSegment {
-                name,
-                args: GenericArgs::AngleBracketed {
-                    lifetimes: Vec::new(),
-                    types: Vec::new(),
-                    bindings: Vec::new(),
-                }
-            }]
-        }
-    }
-
     pub fn last_name(&self) -> &str {
         self.segments.last().unwrap().name.as_str()
     }

--- a/src/librustdoc/doctree.rs
+++ b/src/librustdoc/doctree.rs
@@ -11,7 +11,6 @@
 //! This module is used to store stuff from Rust's AST in a more convenient
 //! manner (and with prettier names) before cleaning.
 pub use self::StructType::*;
-pub use self::TypeBound::*;
 
 use syntax::ast;
 use syntax::ast::{Name, NodeId};
@@ -89,11 +88,6 @@ pub enum StructType {
     Tuple,
     /// A unit struct
     Unit,
-}
-
-pub enum TypeBound {
-    RegionBound,
-    TraitBound(hir::TraitRef)
 }
 
 pub struct Struct {

--- a/src/librustdoc/fold.rs
+++ b/src/librustdoc/fold.rs
@@ -12,19 +12,13 @@ use std::mem;
 
 use clean::*;
 
-pub enum FoldItem {
-    Retain(Item),
-    Strip(Item),
-    Erase,
-}
+pub struct StripItem(pub Item);
 
-impl FoldItem {
-    pub fn fold(self) -> Option<Item> {
-        match self {
-            FoldItem::Erase => None,
-            FoldItem::Retain(i) => Some(i),
-            FoldItem::Strip(item@ Item { inner: StrippedItem(..), .. } ) => Some(item),
-            FoldItem::Strip(mut i) => {
+impl StripItem {
+    pub fn strip(self) -> Option<Item> {
+        match self.0 {
+            Item { inner: StrippedItem(..), .. } => Some(self.0),
+            mut i => {
                 i.inner = StrippedItem(box i.inner);
                 Some(i)
             }

--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -60,20 +60,6 @@ pub fn render_with_highlighting(src: &str, class: Option<&str>, id: Option<&str>
     String::from_utf8_lossy(&out[..]).into_owned()
 }
 
-/// Highlights `src`, returning the HTML output. Returns only the inner html to
-/// be inserted into an element. C.f., `render_with_highlighting` which includes
-/// an enclosing `<pre>` block.
-pub fn render_inner_with_highlighting(src: &str) -> io::Result<String> {
-    let sess = parse::ParseSess::new(FilePathMapping::empty());
-    let fm = sess.codemap().new_filemap(FileName::Custom("stdin".to_string()), src.to_string());
-
-    let mut out = Vec::new();
-    let mut classifier = Classifier::new(lexer::StringReader::new(&sess, fm, None), sess.codemap());
-    classifier.write_source(&mut out)?;
-
-    Ok(String::from_utf8_lossy(&out).into_owned())
-}
-
 /// Processes a program (nested in the internal `lexer`), classifying strings of
 /// text by highlighting category (`Class`). Calls out to a `Writer` to write
 /// each span of text in sequence.

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -25,6 +25,7 @@
 #![feature(vec_remove_item)]
 #![feature(entry_and_modify)]
 #![feature(ptr_offset_from)]
+#![feature(crate_visibility_modifier)]
 
 #![recursion_limit="256"]
 
@@ -72,28 +73,28 @@ use rustc_target::spec::TargetTriple;
 use rustc::session::config::get_cmd_lint_options;
 
 #[macro_use]
-pub mod externalfiles;
+mod externalfiles;
 
-pub mod clean;
-pub mod core;
-pub mod doctree;
-pub mod fold;
+mod clean;
+mod core;
+mod doctree;
+mod fold;
 pub mod html {
-    pub mod highlight;
-    pub mod escape;
-    pub mod item_type;
-    pub mod format;
-    pub mod layout;
+    crate mod highlight;
+    crate mod escape;
+    crate mod item_type;
+    crate mod format;
+    crate mod layout;
     pub mod markdown;
-    pub mod render;
-    pub mod toc;
+    crate mod render;
+    crate mod toc;
 }
-pub mod markdown;
-pub mod passes;
-pub mod visit_ast;
-pub mod visit_lib;
-pub mod test;
-pub mod theme;
+mod markdown;
+mod passes;
+mod visit_ast;
+mod visit_lib;
+mod test;
+mod theme;
 
 use clean::AttributesExt;
 
@@ -140,7 +141,7 @@ fn unstable<F>(name: &'static str, f: F) -> RustcOptGroup
     RustcOptGroup::unstable(name, f)
 }
 
-pub fn opts() -> Vec<RustcOptGroup> {
+fn opts() -> Vec<RustcOptGroup> {
     vec![
         stable("h", |o| o.optflag("h", "help", "show this help message")),
         stable("V", |o| o.optflag("V", "version", "print rustdoc's version")),
@@ -334,7 +335,7 @@ pub fn opts() -> Vec<RustcOptGroup> {
     ]
 }
 
-pub fn usage(argv0: &str) {
+fn usage(argv0: &str) {
     let mut options = getopts::Options::new();
     for option in opts() {
         (option.apply)(&mut options);
@@ -342,7 +343,7 @@ pub fn usage(argv0: &str) {
     println!("{}", options.usage(&format!("{} [options] <input>", argv0)));
 }
 
-pub fn main_args(args: &[String]) -> isize {
+fn main_args(args: &[String]) -> isize {
     let mut options = getopts::Options::new();
     for option in opts() {
         (option.apply)(&mut options);

--- a/src/librustdoc/passes/strip_hidden.rs
+++ b/src/librustdoc/passes/strip_hidden.rs
@@ -15,7 +15,7 @@ use clean::{self, AttributesExt, NestedAttributesExt};
 use clean::Item;
 use fold;
 use fold::DocFolder;
-use fold::FoldItem::Strip;
+use fold::StripItem;
 use passes::ImplStripper;
 
 /// Strip items marked `#[doc(hidden)]`
@@ -49,7 +49,7 @@ impl<'a> fold::DocFolder for Stripper<'a> {
                     // strip things like impl methods but when doing so
                     // we must not add any items to the `retained` set.
                     let old = mem::replace(&mut self.update_retained, false);
-                    let ret = Strip(self.fold_item_recur(i).unwrap()).fold();
+                    let ret = StripItem(self.fold_item_recur(i).unwrap()).strip();
                     self.update_retained = old;
                     return ret;
                 }


### PR DESCRIPTION
Also hid the unused crate exports of rustdoc. This is technically a breaking change but we don't even ship librustdoc in the sysroot so I don't expect breakage.