### PR TITLE
Fix #[linkage] propagation though generic functions

### DIFF
--- a/src/librustc_codegen_llvm/consts.rs
+++ b/src/librustc_codegen_llvm/consts.rs
@@ -119,6 +119,8 @@ pub fn get_static(cx: &CodegenCx, def_id: DefId) -> ValueRef {
     let ty = instance.ty(cx.tcx);
     let sym = cx.tcx.symbol_name(instance).as_str();
 
+    debug!("get_static: sym={} instance={:?}", sym, instance);
+
     let g = if let Some(id) = cx.tcx.hir.as_local_node_id(def_id) {
 
         let llty = cx.layout_of(ty).llvm_type(cx);
@@ -145,6 +147,8 @@ pub fn get_static(cx: &CodegenCx, def_id: DefId) -> ValueRef {
                 ref attrs, span, node: hir::ForeignItemKind::Static(..), ..
             }) => {
                 let g = if let Some(linkage) = cx.tcx.codegen_fn_attrs(def_id).linkage {
+                    debug!("get_static: sym={} linkage={:?}", sym, linkage);
+
                     // If this is a static with a linkage specified, then we need to handle
                     // it a little specially. The typesystem prevents things like &T and
                     // extern "C" fn() from being non-null, so we can't just declare a
@@ -188,6 +192,8 @@ pub fn get_static(cx: &CodegenCx, def_id: DefId) -> ValueRef {
             item => bug!("get_static: expected static, found {:?}", item)
         };
 
+        debug!("get_static: sym={} attrs={:?}", sym, attrs);
+
         for attr in attrs {
             if attr.check_name("thread_local") {
                 llvm::set_thread_local_mode(g, cx.tls_model);
@@ -197,19 +203,60 @@ pub fn get_static(cx: &CodegenCx, def_id: DefId) -> ValueRef {
         g
     } else {
         // FIXME(nagisa): perhaps the map of externs could be offloaded to llvm somehow?
-        // FIXME(nagisa): investigate whether it can be changed into define_global
-        let g = declare::declare_global(cx, &sym, cx.layout_of(ty).llvm_type(cx));
+        debug!("get_static: sym={} item_attr={:?}", sym, cx.tcx.item_attrs(def_id));
+
+        let codegen_fn_attrs = cx.tcx.codegen_fn_attrs(def_id);
+        let llty = cx.layout_of(ty).llvm_type(cx);
+        let g = if let Some(linkage) = codegen_fn_attrs.linkage {
+            debug!("get_static: sym={} linkage={:?}", sym, linkage);
+
+            // If this is a static with a linkage specified, then we need to handle
+            // it a little specially. The typesystem prevents things like &T and
+            // extern "C" fn() from being non-null, so we can't just declare a
+            // static and call it a day. Some linkages (like weak) will make it such
+            // that the static actually has a null value.
+            let llty2 = match ty.sty {
+                ty::TyRawPtr(ref mt) => cx.layout_of(mt.ty).llvm_type(cx),
+                _ => {
+                    bug!("must have type `*const T` or `*mut T`")
+                }
+            };
+            unsafe {
+                // Declare a symbol `foo` with the desired linkage.
+                let g1 = declare::declare_global(cx, &sym, llty2);
+                llvm::LLVMRustSetLinkage(g1, base::linkage_to_llvm(linkage));
+
+                // Declare an internal global `extern_with_linkage_foo` which
+                // is initialized with the address of `foo`.  If `foo` is
+                // discarded during linking (for example, if `foo` has weak
+                // linkage and there are no definitions), then
+                // `extern_with_linkage_foo` will instead be initialized to
+                // zero.
+                let mut real_name = "_rust_extern_with_linkage_".to_string();
+                real_name.push_str(&sym);
+                let g2 = declare::define_global(cx, &real_name, llty).unwrap_or_else(||{
+                    bug!("symbol `{}` is already defined", &sym)
+                });
+                llvm::LLVMRustSetLinkage(g2, llvm::Linkage::InternalLinkage);
+                llvm::LLVMSetInitializer(g2, g1);
+                g2
+            }
+        } else {
+            // Generate an external declaration.
+            // FIXME(nagisa): investigate whether it can be changed into define_global
+            declare::declare_global(cx, &sym, llty)
+        };
+
         // Thread-local statics in some other crate need to *always* be linked
         // against in a thread-local fashion, so we need to be sure to apply the
         // thread-local attribute locally if it was present remotely. If we
         // don't do this then linker errors can be generated where the linker
         // complains that one object files has a thread local version of the
         // symbol and another one doesn't.
-        for attr in cx.tcx.get_attrs(def_id).iter() {
-            if attr.check_name("thread_local") {
-                llvm::set_thread_local_mode(g, cx.tls_model);
-            }
+        if codegen_fn_attrs.flags.contains(CodegenFnAttrFlags::THREAD_LOCAL) {
+            llvm::set_thread_local_mode(g, cx.tls_model);
         }
+
         if cx.use_dll_storage_attrs && !cx.tcx.is_foreign_item(def_id) {
             // This item is external but not foreign, i.e. it originates from an external Rust
             // crate. Since we don't know whether this crate will be linked dynamically or

--- a/src/test/run-pass/issue-18804/auxiliary/lib.rs
+++ b/src/test/run-pass/issue-18804/auxiliary/lib.rs
@@ -1,0 +1,20 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type = "rlib"]
+#![feature(linkage)]
+
+pub fn foo<T>() -> *const() {
+    extern {
+        #[linkage = "extern_weak"]
+        static FOO: *const();
+    }
+    unsafe { FOO }
+}

--- a/src/test/run-pass/issue-18804/auxiliary/lib.rs
+++ b/src/test/run-pass/issue-18804/auxiliary/lib.rs
@@ -8,9 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-asmjs no weak symbol support
-// ignore-emscripten no weak symbol support
-
 #![crate_type = "rlib"]
 #![feature(linkage)]
 

--- a/src/test/run-pass/issue-18804/auxiliary/lib.rs
+++ b/src/test/run-pass/issue-18804/auxiliary/lib.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-asmjs no weak symbol support
+// ignore-emscripten no weak symbol support
+
 #![crate_type = "rlib"]
 #![feature(linkage)]
 

--- a/src/test/run-pass/issue-18804/main.rs
+++ b/src/test/run-pass/issue-18804/main.rs
@@ -1,0 +1,20 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test for issue #18804, #[linkage] does not propagate thorugh generic
+// functions. Failure results in a linker error.
+
+// aux-build:lib.rs
+
+extern crate lib;
+
+fn main() {
+    lib::foo::<i32>();
+}

--- a/src/test/run-pass/issue-18804/main.rs
+++ b/src/test/run-pass/issue-18804/main.rs
@@ -11,6 +11,9 @@
 // Test for issue #18804, #[linkage] does not propagate thorugh generic
 // functions. Failure results in a linker error.
 
+// ignore-asmjs no weak symbol support
+// ignore-emscripten no weak symbol support
+
 // aux-build:lib.rs
 
 extern crate lib;


### PR DESCRIPTION
Fixes #18804

In the non-local branch of `get_static` (where the fix was implemented) `span_fatal` had to be replaced with `bug!` as we have no span in that case.