### PR TITLE
Forget Waker when cloning LocalWaker

### DIFF
--- a/src/libcore/task/wake.rs
+++ b/src/libcore/task/wake.rs
@@ -12,7 +12,7 @@
             reason = "futures in libcore are unstable",
             issue = "50547")]
 
-use fmt;
+use {fmt, mem};
 use marker::Unpin;
 use ptr::NonNull;
 
@@ -166,9 +166,10 @@ impl From<LocalWaker> for Waker {
 impl Clone for LocalWaker {
     #[inline]
     fn clone(&self) -> Self {
-        unsafe {
-            LocalWaker { inner: self.inner.as_ref().clone_raw().inner }
-        }
+        let waker = unsafe { self.inner.as_ref().clone_raw() };
+        let inner = waker.inner;
+        mem::forget(waker);
+        LocalWaker { inner }
     }
 }
 


### PR DESCRIPTION
Since NonNull is Copy the inner field of the cloned Waker was copied for
use in the new LocalWaker, however this left Waker to be dropped. Which
means that when cloning LocalWaker would also erroneously call drop_raw.

This change forgets the Waker, rather then dropping it, leaving the
inner field to be used by the returned LocalWaker.

Closes #52629.