### PR TITLE
Simplify 2 functions in rustc_mir/dataflow

### DIFF
--- a/src/librustc_mir/dataflow/graphviz.rs
+++ b/src/librustc_mir/dataflow/graphviz.rs
@@ -73,8 +73,8 @@ pub type Node = BasicBlock;
 pub struct Edge { source: BasicBlock, index: usize }
 
 fn outgoing(mir: &Mir, bb: BasicBlock) -> Vec<Edge> {
-    mir[bb].terminator().successors().enumerate()
-        .map(|(index, _)| Edge { source: bb, index: index}).collect()
+    (0..mir[bb].terminator().successors().count())
+        .map(|index| Edge { source: bb, index: index}).collect()
 }
 
 impl<'a, 'tcx, MWF, P> dot::Labeller<'a> for Graph<'a, 'tcx, MWF, P>

--- a/src/librustc_mir/dataflow/mod.rs
+++ b/src/librustc_mir/dataflow/mod.rs
@@ -441,11 +441,6 @@ pub struct DataflowState<O: BitDenotation>
 }
 
 impl<O: BitDenotation> DataflowState<O> {
-    pub fn each_bit<F>(&self, words: &IdxSet<O::Idx>, f: F) where F: FnMut(O::Idx)
-    {
-        words.iter().for_each(f)
-    }
-
     pub(crate) fn interpret_set<'c, P>(&self,
                                        o: &'c O,
                                        words: &IdxSet<O::Idx>,
@@ -453,11 +448,7 @@ impl<O: BitDenotation> DataflowState<O> {
                                        -> Vec<DebugFormatted>
         where P: Fn(&O, O::Idx) -> DebugFormatted
     {
-        let mut v = Vec::new();
-        self.each_bit(words, |i| {
-            v.push(render_idx(o, i));
-        });
-        v
+        words.iter().map(|i| render_idx(o, i)).collect()
     }
 }
 


### PR DESCRIPTION
- `graphviz::outgoing`: the `enumerate` only provides indices; use a range instead
- `DataflowState::interpret_set`: change a push loop to an iterator and remove the `each_bit` helper function