### PR TITLE
Prefer sort_unstable*() over sort*()

### DIFF
--- a/src/librustc_mir/borrow_check/nll/region_infer/dump_mir.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/dump_mir.rs
@@ -77,7 +77,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         }
 
         let mut constraints: Vec<_> = self.constraints.iter().collect();
-        constraints.sort();
+        constraints.sort_unstable();
         for constraint in &constraints {
             let OutlivesConstraint {
                 sup,

--- a/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/mod.rs
@@ -227,7 +227,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         debug!("report_error: categorized_path={:?}", categorized_path);
 
         // Find what appears to be the most interesting path to report to the user.
-        categorized_path.sort_by(|p0, p1| p0.0.cmp(&p1.0));
+        categorized_path.sort_unstable_by(|p0, p1| p0.0.cmp(&p1.0));
         debug!("report_error: sorted_path={:?}", categorized_path);
 
         // Get a span

--- a/src/librustc_mir/borrow_check/nll/region_infer/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/mod.rs
@@ -418,7 +418,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
 
         debug!("propagate_constraints: constraints={:#?}", {
             let mut constraints: Vec<_> = self.constraints.iter().collect();
-            constraints.sort();
+            constraints.sort_unstable();
             constraints
         });
 


### PR DESCRIPTION
Since `sort_unstable` is considered typically faster than the regular `sort` ([benchmarks](https://github.com/rust-lang/rust/pull/40601#issue-111299559)), it might be a good idea to check for potential wins in the compiler.