### PR TITLE
[beta] Rollup backports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,6 @@ matrix:
         CI_JOB_NAME=dist-x86_64-apple-alt
       os: osx
       osx_image: xcode9.3-moar
-      if: branch = auto
 
     # macOS builders. These are placed near the beginning because they are very
     # slow to run.
@@ -57,7 +56,6 @@ matrix:
         CI_JOB_NAME=x86_64-apple
       os: osx
       osx_image: xcode9.3-moar
-      if: branch = auto
 
     - env: >
         RUST_CHECK_TARGET=check
@@ -71,7 +69,6 @@ matrix:
         CI_JOB_NAME=i686-apple
       os: osx
       osx_image: xcode9.3-moar
-      if: branch = auto
 
     # OSX builders producing releases. These do not run the full test suite and
     # just produce a bunch of artifacts.
@@ -91,7 +88,6 @@ matrix:
         CI_JOB_NAME=dist-i686-apple
       os: osx
       osx_image: xcode9.3-moar
-      if: branch = auto
 
     - env: >
         RUST_CHECK_TARGET=dist
@@ -105,7 +101,6 @@ matrix:
         CI_JOB_NAME=dist-x86_64-apple
       os: osx
       osx_image: xcode9.3-moar
-      if: branch = auto
 
     # Linux builders, remaining docker images
     - env: IMAGE=arm-android

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -52,6 +52,16 @@ Stabilized APIs
 ---------------
 - [`Iterator::step_by`]
 - [`Path::ancestors`]
+- [`SystemTime::UNIX_EPOCH`]
+- [`alloc::GlobalAlloc`]
+- [`alloc::Layout`]
+- [`alloc::LayoutErr`]
+- [`alloc::System`]
+- [`alloc::alloc`]
+- [`alloc::alloc_zeroed`]
+- [`alloc::dealloc`]
+- [`alloc::realloc`]
+- [`alloc::handle_alloc_error`]
 - [`btree_map::Entry::or_default`]
 - [`fmt::Alignment`]
 - [`hash_map::Entry::or_default`]
@@ -122,6 +132,16 @@ Compatibility Notes
 [cargo/5584]: https://github.com/rust-lang/cargo/pull/5584/
 [`Iterator::step_by`]: https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.step_by
 [`Path::ancestors`]: https://doc.rust-lang.org/std/path/struct.Path.html#method.ancestors
+[`SystemTime::UNIX_EPOCH`]: https://doc.rust-lang.org/std/time/struct.SystemTime.html#associatedconstant.UNIX_EPOCH
+[`alloc::GlobalAlloc`]: https://doc.rust-lang.org/std/alloc/trait.GlobalAlloc.html
+[`alloc::Layout`]: https://doc.rust-lang.org/std/alloc/struct.Layout.html
+[`alloc::LayoutErr`]: https://doc.rust-lang.org/std/alloc/struct.LayoutErr.html
+[`alloc::System`]: https://doc.rust-lang.org/std/alloc/struct.System.html
+[`alloc::alloc`]: https://doc.rust-lang.org/std/alloc/fn.alloc.html
+[`alloc::alloc_zeroed`]: https://doc.rust-lang.org/std/alloc/fn.alloc_zeroed.html
+[`alloc::dealloc`]: https://doc.rust-lang.org/std/alloc/fn.dealloc.html
+[`alloc::realloc`]: https://doc.rust-lang.org/std/alloc/fn.realloc.html
+[`alloc::handle_alloc_error`]: https://doc.rust-lang.org/std/alloc/fn.handle_alloc_error.html
 [`btree_map::Entry::or_default`]: https://doc.rust-lang.org/std/collections/btree_map/enum.Entry.html#method.or_default
 [`fmt::Alignment`]: https://doc.rust-lang.org/std/fmt/enum.Alignment.html
 [`hash_map::Entry::or_default`]: https://doc.rust-lang.org/std/collections/btree_map/enum.Entry.html#method.or_default
@@ -3162,7 +3182,7 @@ Stabilized APIs
 * [`UnixDatagram::shutdown`](http://doc.rust-lang.org/std/os/unix/net/struct.UnixDatagram.html#method.shutdown)
 * RawFd impls for `UnixDatagram`
 * `{BTree,Hash}Map::values_mut`
-* [`<[_]>::binary_search_by_key`](http://doc.rust-lang.org/beta/std/primitive.slice.html#method.binary_search_by_key)
+* [`<[_]>::binary_search_by_key`](http://doc.rust-lang.org/std/primitive.slice.html#method.binary_search_by_key)
 
 Libraries
 ---------
@@ -4080,7 +4100,7 @@ Compatibility Notes
 [1.6bh]: https://github.com/rust-lang/rust/pull/29811
 [1.6c]: https://github.com/rust-lang/cargo/pull/2192
 [1.6cc]: https://github.com/rust-lang/cargo/pull/2131
-[1.6co]: http://doc.rust-lang.org/beta/core/index.html
+[1.6co]: http://doc.rust-lang.org/core/index.html
 [1.6dv]: https://github.com/rust-lang/rust/pull/30000
 [1.6f]: https://github.com/rust-lang/rust/pull/29129
 [1.6m]: https://github.com/rust-lang/rust/pull/29828

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -1483,10 +1483,12 @@ fn parse_crate_attrs<'a>(sess: &'a Session, input: &Input) -> PResult<'a, Vec<as
     }
 }
 
-/// Runs `f` in a suitable thread for running `rustc`; returns a
-/// `Result` with either the return value of `f` or -- if a panic
-/// occurs -- the panic value.
-pub fn in_rustc_thread<F, R>(f: F) -> Result<R, Box<Any + Send>>
+/// Runs `f` in a suitable thread for running `rustc`; returns a `Result` with either the return
+/// value of `f` or -- if a panic occurs -- the panic value.
+///
+/// This version applies the given name to the thread. This is used by rustdoc to ensure consistent
+/// doctest output across platforms and executions.
+pub fn in_named_rustc_thread<F, R>(name: String, f: F) -> Result<R, Box<Any + Send>>
     where F: FnOnce() -> R + Send + 'static,
           R: Send + 'static,
 {
@@ -1530,7 +1532,7 @@ pub fn in_rustc_thread<F, R>(f: F) -> Result<R, Box<Any + Send>>
 
     // The or condition is added from backward compatibility.
     if spawn_thread || env::var_os("RUST_MIN_STACK").is_some() {
-        let mut cfg = thread::Builder::new().name("rustc".to_string());
+        let mut cfg = thread::Builder::new().name(name);
 
         // FIXME: Hacks on hacks. If the env is trying to override the stack size
         // then *don't* set it explicitly.
@@ -1544,6 +1546,16 @@ pub fn in_rustc_thread<F, R>(f: F) -> Result<R, Box<Any + Send>>
         let f = panic::AssertUnwindSafe(f);
         panic::catch_unwind(f)
     }
+}
+
+/// Runs `f` in a suitable thread for running `rustc`; returns a
+/// `Result` with either the return value of `f` or -- if a panic
+/// occurs -- the panic value.
+pub fn in_rustc_thread<F, R>(f: F) -> Result<R, Box<dyn Any + Send>>
+    where F: FnOnce() -> R + Send + 'static,
+          R: Send + 'static,
+{
+    in_named_rustc_thread("rustc".to_string(), f)
 }
 
 /// Get a list of extra command-line flags provided by the user, as strings.

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -548,7 +548,7 @@ impl Collector {
         debug!("Creating test {}: {}", name, test);
         self.tests.push(testing::TestDescAndFn {
             desc: testing::TestDesc {
-                name: testing::DynTestName(name),
+                name: testing::DynTestName(name.clone()),
                 ignore: should_ignore,
                 // compiler failures are test failures
                 should_panic: testing::ShouldPanic::No,
@@ -558,7 +558,7 @@ impl Collector {
                 let panic = io::set_panic(None);
                 let print = io::set_print(None);
                 match {
-                    rustc_driver::in_rustc_thread(move || with_globals(move || {
+                    rustc_driver::in_named_rustc_thread(name, move || with_globals(move || {
                         io::set_panic(panic);
                         io::set_print(print);
                         run_test(&test,

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -331,9 +331,7 @@
 // `force_alloc_system` is *only* intended as a workaround for local rebuilds
 // with a rustc without jemalloc.
 // FIXME(#44236) shouldn't need MSVC logic
-#![cfg_attr(all(not(target_env = "msvc"),
-                any(all(stage0, not(test)), feature = "force_alloc_system")),
-            feature(global_allocator))]
+#![cfg_attr(all(not(target_env = "msvc"), stage0, not(test)), feature(global_allocator))]
 #[cfg(all(not(target_env = "msvc"),
           any(all(stage0, not(test)), feature = "force_alloc_system")))]
 #[global_allocator]

--- a/src/test/rustdoc-ui/failed-doctest-output.rs
+++ b/src/test/rustdoc-ui/failed-doctest-output.rs
@@ -1,0 +1,19 @@
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Issue #51162: A failed doctest was not printing its stdout/stderr
+
+// compile-flags:--test
+// disable-ui-testing-normalization
+
+/// ```
+/// panic!("oh no");
+/// ```
+pub struct SomeStruct;

--- a/src/test/rustdoc-ui/failed-doctest-output.rs
+++ b/src/test/rustdoc-ui/failed-doctest-output.rs
@@ -9,15 +9,19 @@
 // except according to those terms.
 
 // Issue #51162: A failed doctest was not printing its stdout/stderr
+// FIXME: if/when the output of the test harness can be tested on its own, this test should be
+// adapted to use that, and that normalize line can go away
 
 // compile-flags:--test
-// disable-ui-testing-normalization
+// normalize-stdout-test: "src/test/rustdoc-ui" -> "$$DIR"
 
+// doctest fails at runtime
 /// ```
 /// panic!("oh no");
 /// ```
 pub struct SomeStruct;
 
+// doctest fails at compile time
 /// ```
 /// no
 /// ```

--- a/src/test/rustdoc-ui/failed-doctest-output.rs
+++ b/src/test/rustdoc-ui/failed-doctest-output.rs
@@ -14,6 +14,7 @@
 
 // compile-flags:--test
 // normalize-stdout-test: "src/test/rustdoc-ui" -> "$$DIR"
+// failure-status: 101
 
 // doctest fails at runtime
 /// ```

--- a/src/test/rustdoc-ui/failed-doctest-output.rs
+++ b/src/test/rustdoc-ui/failed-doctest-output.rs
@@ -17,3 +17,8 @@
 /// panic!("oh no");
 /// ```
 pub struct SomeStruct;
+
+/// ```
+/// no
+/// ```
+pub struct OtherStruct;

--- a/src/test/rustdoc-ui/failed-doctest-output.stdout
+++ b/src/test/rustdoc-ui/failed-doctest-output.stdout
@@ -1,32 +1,32 @@
 
 running 2 tests
-test src/test/rustdoc-ui/failed-doctest-output.rs - OtherStruct (line 21) ... FAILED
-test src/test/rustdoc-ui/failed-doctest-output.rs - SomeStruct (line 16) ... FAILED
+test $DIR/failed-doctest-output.rs - OtherStruct (line 21) ... FAILED
+test $DIR/failed-doctest-output.rs - SomeStruct (line 16) ... FAILED
 
 failures:
 
----- src/test/rustdoc-ui/failed-doctest-output.rs - OtherStruct (line 21) stdout ----
+---- $DIR/failed-doctest-output.rs - OtherStruct (line 21) stdout ----
 error[E0425]: cannot find value `no` in this scope
- --> src/test/rustdoc-ui/failed-doctest-output.rs:22:1
+ --> $DIR/failed-doctest-output.rs:22:1
   |
 3 | no
   | ^^ not found in this scope
 
-thread 'src/test/rustdoc-ui/failed-doctest-output.rs - OtherStruct (line 21)' panicked at 'couldn't compile the test', librustdoc/test.rs:332:13
+thread '$DIR/failed-doctest-output.rs - OtherStruct (line 21)' panicked at 'couldn't compile the test', librustdoc/test.rs:332:13
 note: Run with `RUST_BACKTRACE=1` for a backtrace.
 
----- src/test/rustdoc-ui/failed-doctest-output.rs - SomeStruct (line 16) stdout ----
-thread 'src/test/rustdoc-ui/failed-doctest-output.rs - SomeStruct (line 16)' panicked at 'test executable failed:
+---- $DIR/failed-doctest-output.rs - SomeStruct (line 16) stdout ----
+thread '$DIR/failed-doctest-output.rs - SomeStruct (line 16)' panicked at 'test executable failed:
 
-thread 'main' panicked at 'oh no', src/test/rustdoc-ui/failed-doctest-output.rs:3:1
+thread 'main' panicked at 'oh no', $DIR/failed-doctest-output.rs:3:1
 note: Run with `RUST_BACKTRACE=1` for a backtrace.
 
 ', librustdoc/test.rs:367:17
 
 
 failures:
-    src/test/rustdoc-ui/failed-doctest-output.rs - OtherStruct (line 21)
-    src/test/rustdoc-ui/failed-doctest-output.rs - SomeStruct (line 16)
+    $DIR/failed-doctest-output.rs - OtherStruct (line 21)
+    $DIR/failed-doctest-output.rs - SomeStruct (line 16)
 
 test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out
 

--- a/src/test/rustdoc-ui/failed-doctest-output.stdout
+++ b/src/test/rustdoc-ui/failed-doctest-output.stdout
@@ -1,22 +1,22 @@
 
 running 2 tests
-test $DIR/failed-doctest-output.rs - OtherStruct (line 21) ... FAILED
-test $DIR/failed-doctest-output.rs - SomeStruct (line 16) ... FAILED
+test $DIR/failed-doctest-output.rs - OtherStruct (line 25) ... FAILED
+test $DIR/failed-doctest-output.rs - SomeStruct (line 19) ... FAILED
 
 failures:
 
----- $DIR/failed-doctest-output.rs - OtherStruct (line 21) stdout ----
+---- $DIR/failed-doctest-output.rs - OtherStruct (line 25) stdout ----
 error[E0425]: cannot find value `no` in this scope
- --> $DIR/failed-doctest-output.rs:22:1
+ --> $DIR/failed-doctest-output.rs:26:1
   |
 3 | no
   | ^^ not found in this scope
 
-thread '$DIR/failed-doctest-output.rs - OtherStruct (line 21)' panicked at 'couldn't compile the test', librustdoc/test.rs:332:13
+thread '$DIR/failed-doctest-output.rs - OtherStruct (line 25)' panicked at 'couldn't compile the test', librustdoc/test.rs:332:13
 note: Run with `RUST_BACKTRACE=1` for a backtrace.
 
----- $DIR/failed-doctest-output.rs - SomeStruct (line 16) stdout ----
-thread '$DIR/failed-doctest-output.rs - SomeStruct (line 16)' panicked at 'test executable failed:
+---- $DIR/failed-doctest-output.rs - SomeStruct (line 19) stdout ----
+thread '$DIR/failed-doctest-output.rs - SomeStruct (line 19)' panicked at 'test executable failed:
 
 thread 'main' panicked at 'oh no', $DIR/failed-doctest-output.rs:3:1
 note: Run with `RUST_BACKTRACE=1` for a backtrace.
@@ -25,8 +25,8 @@ note: Run with `RUST_BACKTRACE=1` for a backtrace.
 
 
 failures:
-    $DIR/failed-doctest-output.rs - OtherStruct (line 21)
-    $DIR/failed-doctest-output.rs - SomeStruct (line 16)
+    $DIR/failed-doctest-output.rs - OtherStruct (line 25)
+    $DIR/failed-doctest-output.rs - SomeStruct (line 19)
 
 test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out
 

--- a/src/test/rustdoc-ui/failed-doctest-output.stdout
+++ b/src/test/rustdoc-ui/failed-doctest-output.stdout
@@ -1,8 +1,19 @@
 
-running 1 test
+running 2 tests
+test src/test/rustdoc-ui/failed-doctest-output.rs - OtherStruct (line 21) ... FAILED
 test src/test/rustdoc-ui/failed-doctest-output.rs - SomeStruct (line 16) ... FAILED
 
 failures:
+
+---- src/test/rustdoc-ui/failed-doctest-output.rs - OtherStruct (line 21) stdout ----
+error[E0425]: cannot find value `no` in this scope
+ --> src/test/rustdoc-ui/failed-doctest-output.rs:22:1
+  |
+3 | no
+  | ^^ not found in this scope
+
+thread 'src/test/rustdoc-ui/failed-doctest-output.rs - OtherStruct (line 21)' panicked at 'couldn't compile the test', librustdoc/test.rs:332:13
+note: Run with `RUST_BACKTRACE=1` for a backtrace.
 
 ---- src/test/rustdoc-ui/failed-doctest-output.rs - SomeStruct (line 16) stdout ----
 thread 'src/test/rustdoc-ui/failed-doctest-output.rs - SomeStruct (line 16)' panicked at 'test executable failed:
@@ -11,11 +22,11 @@ thread 'main' panicked at 'oh no', src/test/rustdoc-ui/failed-doctest-output.rs:
 note: Run with `RUST_BACKTRACE=1` for a backtrace.
 
 ', librustdoc/test.rs:367:17
-note: Run with `RUST_BACKTRACE=1` for a backtrace.
 
 
 failures:
+    src/test/rustdoc-ui/failed-doctest-output.rs - OtherStruct (line 21)
     src/test/rustdoc-ui/failed-doctest-output.rs - SomeStruct (line 16)
 
-test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
+test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out
 

--- a/src/test/rustdoc-ui/failed-doctest-output.stdout
+++ b/src/test/rustdoc-ui/failed-doctest-output.stdout
@@ -12,7 +12,7 @@ error[E0425]: cannot find value `no` in this scope
 3 | no
   | ^^ not found in this scope
 
-thread '$DIR/failed-doctest-output.rs - OtherStruct (line 26)' panicked at 'couldn't compile the test', librustdoc/test.rs:332:13
+thread '$DIR/failed-doctest-output.rs - OtherStruct (line 26)' panicked at 'couldn't compile the test', librustdoc/test.rs:330:13
 note: Run with `RUST_BACKTRACE=1` for a backtrace.
 
 ---- $DIR/failed-doctest-output.rs - SomeStruct (line 20) stdout ----
@@ -21,7 +21,7 @@ thread '$DIR/failed-doctest-output.rs - SomeStruct (line 20)' panicked at 'test 
 thread 'main' panicked at 'oh no', $DIR/failed-doctest-output.rs:3:1
 note: Run with `RUST_BACKTRACE=1` for a backtrace.
 
-', librustdoc/test.rs:367:17
+', librustdoc/test.rs:365:17
 
 
 failures:

--- a/src/test/rustdoc-ui/failed-doctest-output.stdout
+++ b/src/test/rustdoc-ui/failed-doctest-output.stdout
@@ -1,22 +1,22 @@
 
 running 2 tests
-test $DIR/failed-doctest-output.rs - OtherStruct (line 25) ... FAILED
-test $DIR/failed-doctest-output.rs - SomeStruct (line 19) ... FAILED
+test $DIR/failed-doctest-output.rs - OtherStruct (line 26) ... FAILED
+test $DIR/failed-doctest-output.rs - SomeStruct (line 20) ... FAILED
 
 failures:
 
----- $DIR/failed-doctest-output.rs - OtherStruct (line 25) stdout ----
+---- $DIR/failed-doctest-output.rs - OtherStruct (line 26) stdout ----
 error[E0425]: cannot find value `no` in this scope
- --> $DIR/failed-doctest-output.rs:26:1
+ --> $DIR/failed-doctest-output.rs:27:1
   |
 3 | no
   | ^^ not found in this scope
 
-thread '$DIR/failed-doctest-output.rs - OtherStruct (line 25)' panicked at 'couldn't compile the test', librustdoc/test.rs:332:13
+thread '$DIR/failed-doctest-output.rs - OtherStruct (line 26)' panicked at 'couldn't compile the test', librustdoc/test.rs:332:13
 note: Run with `RUST_BACKTRACE=1` for a backtrace.
 
----- $DIR/failed-doctest-output.rs - SomeStruct (line 19) stdout ----
-thread '$DIR/failed-doctest-output.rs - SomeStruct (line 19)' panicked at 'test executable failed:
+---- $DIR/failed-doctest-output.rs - SomeStruct (line 20) stdout ----
+thread '$DIR/failed-doctest-output.rs - SomeStruct (line 20)' panicked at 'test executable failed:
 
 thread 'main' panicked at 'oh no', $DIR/failed-doctest-output.rs:3:1
 note: Run with `RUST_BACKTRACE=1` for a backtrace.
@@ -25,8 +25,8 @@ note: Run with `RUST_BACKTRACE=1` for a backtrace.
 
 
 failures:
-    $DIR/failed-doctest-output.rs - OtherStruct (line 25)
-    $DIR/failed-doctest-output.rs - SomeStruct (line 19)
+    $DIR/failed-doctest-output.rs - OtherStruct (line 26)
+    $DIR/failed-doctest-output.rs - SomeStruct (line 20)
 
 test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out
 

--- a/src/test/rustdoc-ui/failed-doctest-output.stdout
+++ b/src/test/rustdoc-ui/failed-doctest-output.stdout
@@ -1,0 +1,21 @@
+
+running 1 test
+test src/test/rustdoc-ui/failed-doctest-output.rs - SomeStruct (line 16) ... FAILED
+
+failures:
+
+---- src/test/rustdoc-ui/failed-doctest-output.rs - SomeStruct (line 16) stdout ----
+thread 'src/test/rustdoc-ui/failed-doctest-output.rs - SomeStruct (line 16)' panicked at 'test executable failed:
+
+thread 'main' panicked at 'oh no', src/test/rustdoc-ui/failed-doctest-output.rs:3:1
+note: Run with `RUST_BACKTRACE=1` for a backtrace.
+
+', librustdoc/test.rs:367:17
+note: Run with `RUST_BACKTRACE=1` for a backtrace.
+
+
+failures:
+    src/test/rustdoc-ui/failed-doctest-output.rs - SomeStruct (line 16)
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
+

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -396,6 +396,13 @@ impl TestProps {
             }
         });
 
+        if self.failure_status == -1 {
+            self.failure_status = match config.mode {
+                Mode::RunFail => 101,
+                _ => 1,
+            };
+        }
+
         for key in &["RUST_TEST_NOCAPTURE", "RUST_TEST_THREADS"] {
             if let Ok(val) = env::var(key) {
                 if self.exec_env.iter().find(|&&(ref x, _)| x == key).is_none() {

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -15,7 +15,7 @@ use std::io::BufReader;
 use std::path::{Path, PathBuf};
 
 use common;
-use common::Config;
+use common::{Config, Mode};
 use util;
 
 use extract_gdb_version;


### PR DESCRIPTION
Merged and approved:

* #52677: Release notes: add some missing 1.28 libs stabilization
* #52181: rustdoc: set panic output before starting compiler thread pool
* #52709: beta: only true stage0 needs feature(global_allocator)


r? @ghost