### PR TITLE
ARM: expose `rclass` and `dsp` target features

### DIFF
--- a/src/librustc_codegen_llvm/llvm_util.rs
+++ b/src/librustc_codegen_llvm/llvm_util.rs
@@ -85,6 +85,8 @@ unsafe fn configure_llvm(sess: &Session) {
 
 const ARM_WHITELIST: &[(&str, Option<&str>)] = &[
     ("mclass", Some("arm_target_feature")),
+    ("rclass", Some("arm_target_feature")),
+    ("dsp", Some("arm_target_feature")),
     ("neon", Some("arm_target_feature")),
     ("v7", Some("arm_target_feature")),
     ("vfp2", Some("arm_target_feature")),


### PR DESCRIPTION
- `dsp`: the subtarget supports the DSP (saturating arith. and such)
         instructions
- `rclass`: target is a Cortex-R

Both features are useful to support ARM MCUs on `coresimd`.

Note: Cortex-R52 is the first Armv8-R with `neon` support.

r? @alexcrichton 
cc @japaric 


