### PR TITLE
beta: only true stage0 needs feature(global_allocator)

### DIFF
--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -331,9 +331,7 @@
 // `force_alloc_system` is *only* intended as a workaround for local rebuilds
 // with a rustc without jemalloc.
 // FIXME(#44236) shouldn't need MSVC logic
-#![cfg_attr(all(not(target_env = "msvc"),
-                any(all(stage0, not(test)), feature = "force_alloc_system")),
-            feature(global_allocator))]
+#![cfg_attr(all(not(target_env = "msvc"), stage0, not(test)), feature(global_allocator))]
 #[cfg(all(not(target_env = "msvc"),
           any(all(stage0, not(test)), feature = "force_alloc_system")))]
 #[global_allocator]


### PR DESCRIPTION
We use `#[global_allocator]` for `stage0` builds of libstd, and also
with `feature = "force_alloc_system"` that's set for a local rebuild,
where the bootstrap compiler is the same version and otherwise uses the
`--cfg stage1`.

We only need the unstable `feature(global_allocator)` for a true `stage0`
being 1.27.  For rebuilds with 1.28, that feature is stable and causes a
denied warning if it's enabled, so we should avoid it.