### PR TITLE
Tweak the raw_identifiers lints in 2018

### DIFF
--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1830,12 +1830,16 @@ impl Async2018 {
             span,
             "`async` is a keyword in the 2018 edition",
         );
-        lint.span_suggestion_with_applicability(
-            span,
-            "you can use a raw identifier to stay compatible",
-            "r#async".to_string(),
-            Applicability::MachineApplicable,
-        );
+
+        // Don't suggest about raw identifiers if the feature isn't active
+        if cx.sess.features_untracked().raw_identifiers {
+            lint.span_suggestion_with_applicability(
+                span,
+                "you can use a raw identifier to stay compatible",
+                "r#async".to_string(),
+                Applicability::MachineApplicable,
+            );
+        }
         lint.emit()
     }
 }

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -409,7 +409,7 @@ declare_features! (
     (active, underscore_imports, "1.26.0", Some(48216), None),
 
     // Allows keywords to be escaped for use as identifiers
-    (active, raw_identifiers, "1.26.0", Some(48589), None),
+    (active, raw_identifiers, "1.26.0", Some(48589), Some(Edition::Edition2018)),
 
     // Allows macro invocations in `extern {}` blocks
     (active, macros_in_extern, "1.27.0", Some(49476), None),

--- a/src/test/ui/rust-2018/async-ident-allowed.rs
+++ b/src/test/ui/rust-2018/async-ident-allowed.rs
@@ -1,0 +1,21 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: --edition 2015
+
+#![deny(rust_2018_compatibility)]
+
+// Don't make a suggestion for a raw identifer replacement unless raw
+// identifiers are enabled.
+
+fn main() {
+    let async = 3; //~ ERROR: is a keyword
+    //~^ WARN previously accepted
+}

--- a/src/test/ui/rust-2018/async-ident-allowed.stderr
+++ b/src/test/ui/rust-2018/async-ident-allowed.stderr
@@ -1,0 +1,17 @@
+error: `async` is a keyword in the 2018 edition
+  --> $DIR/async-ident-allowed.rs:19:9
+   |
+LL |     let async = 3; //~ ERROR: is a keyword
+   |         ^^^^^
+   |
+note: lint level defined here
+  --> $DIR/async-ident-allowed.rs:13:9
+   |
+LL | #![deny(rust_2018_compatibility)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^
+   = note: #[deny(async_idents)] implied by #[deny(rust_2018_compatibility)]
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
+
+error: aborting due to previous error
+


### PR DESCRIPTION
* Enable the `raw_identifiers` feature automatically in the 2018 preview
* Only emit lint warnings if the `raw_identifiers` feature is activated

cc rust-lang/cargo#5783