### PR TITLE
rustc: Register crates under their real names

### DIFF
--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -188,13 +188,12 @@ impl<'a> CrateLoader<'a> {
     fn register_crate(&mut self,
                       root: &Option<CratePaths>,
                       ident: Symbol,
-                      name: Symbol,
                       span: Span,
                       lib: Library,
                       dep_kind: DepKind)
                       -> (CrateNum, Lrc<cstore::CrateMetadata>) {
-        info!("register crate `extern crate {} as {}`", name, ident);
         let crate_root = lib.metadata.get_root();
+        info!("register crate `extern crate {} as {}`", crate_root.name, ident);
         self.verify_no_symbol_conflicts(span, &crate_root);
 
         // Claim this crate number and cache it
@@ -233,7 +232,7 @@ impl<'a> CrateLoader<'a> {
             .collect();
 
         let cmeta = cstore::CrateMetadata {
-            name,
+            name: crate_root.name,
             extern_crate: Lock::new(None),
             def_path_table: Lrc::new(def_path_table),
             trait_impls,
@@ -328,7 +327,7 @@ impl<'a> CrateLoader<'a> {
                 (cnum, data)
             }
             LoadResult::Loaded(library) => {
-                self.register_crate(root, ident, name, span, library, dep_kind)
+                self.register_crate(root, ident, span, library, dep_kind)
             }
         }
     }

--- a/src/test/run-make-fulldeps/extern-flag-rename-transitive/Makefile
+++ b/src/test/run-make-fulldeps/extern-flag-rename-transitive/Makefile
@@ -1,0 +1,7 @@
+-include ../tools.mk
+
+all:
+	$(RUSTC) foo.rs
+	$(RUSTC) bar.rs
+	$(RUSTC) baz.rs --extern a=$(TMPDIR)/libfoo.rlib
+

--- a/src/test/run-make-fulldeps/extern-flag-rename-transitive/bar.rs
+++ b/src/test/run-make-fulldeps/extern-flag-rename-transitive/bar.rs
@@ -1,0 +1,13 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type = "rlib"]
+
+extern crate foo;

--- a/src/test/run-make-fulldeps/extern-flag-rename-transitive/baz.rs
+++ b/src/test/run-make-fulldeps/extern-flag-rename-transitive/baz.rs
@@ -1,0 +1,14 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type = "rlib"]
+
+extern crate a;
+extern crate bar;

--- a/src/test/run-make-fulldeps/extern-flag-rename-transitive/foo.rs
+++ b/src/test/run-make-fulldeps/extern-flag-rename-transitive/foo.rs
@@ -1,0 +1,11 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type = "rlib"]


### PR DESCRIPTION
Whenever we register a crate into the crate store, make sure to use the real
name mentioned in the metadata instead of the name mentioned in the `extern
crate` statement, as the statement can be wrong!

Closes #51796