### PR TITLE
sparc ABI issue - structure returning from function is returned in 64bit registers (with tests)

### DIFF
--- a/src/librustc_target/abi/call/sparc64.rs
+++ b/src/librustc_target/abi/call/sparc64.rs
@@ -57,16 +57,7 @@ fn classify_ret_ty<'a, Ty, C>(cx: C, ret: &mut ArgType<'a, Ty>)
     let size = ret.layout.size;
     let bits = size.bits();
     if bits <= 256 {
-        let unit = if bits <= 8 {
-            Reg::i8()
-        } else if bits <= 16 {
-            Reg::i16()
-        } else if bits <= 32 {
-            Reg::i32()
-        } else {
-            Reg::i64()
-        };
-
+        let unit = Reg::i64();
         ret.cast_to(Uniform {
             unit,
             total: size

--- a/src/test/codegen/sparc-struct-abi.rs
+++ b/src/test/codegen/sparc-struct-abi.rs
@@ -1,0 +1,36 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+//
+// Checks that we correctly codegen extern "C" functions returning structs.
+// See issue #52638.
+
+// compile-flags: -O --target=sparc64-unknown-linux-gnu --crate-type=rlib
+#![feature(no_core, lang_items)]
+#![no_core]
+
+#[lang="sized"]
+trait Sized { }
+#[lang="freeze"]
+trait Freeze { }
+#[lang="copy"]
+trait Copy { }
+
+#[repr(C)]
+pub struct Bool {
+    b: bool,
+}
+
+// CHECK: define i64 @structbool()
+// CHECK-NEXT: start:
+// CHECK-NEXT: ret i64 72057594037927936
+#[no_mangle]
+pub extern "C" fn structbool() -> Bool {
+    Bool { b: true }
+}


### PR DESCRIPTION
Fixes #52638

Supersedes #52730

cc @psumbera 