### PR TITLE
[beta] Rollup backports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ matrix:
         CI_JOB_NAME=dist-x86_64-apple-alt
       os: osx
       osx_image: xcode9.3-moar
+      if: branch = auto
 
     # macOS builders. These are placed near the beginning because they are very
     # slow to run.
@@ -56,6 +57,7 @@ matrix:
         CI_JOB_NAME=x86_64-apple
       os: osx
       osx_image: xcode9.3-moar
+      if: branch = auto
 
     - env: >
         RUST_CHECK_TARGET=check
@@ -69,6 +71,7 @@ matrix:
         CI_JOB_NAME=i686-apple
       os: osx
       osx_image: xcode9.3-moar
+      if: branch = auto
 
     # OSX builders producing releases. These do not run the full test suite and
     # just produce a bunch of artifacts.
@@ -88,6 +91,7 @@ matrix:
         CI_JOB_NAME=dist-i686-apple
       os: osx
       osx_image: xcode9.3-moar
+      if: branch = auto
 
     - env: >
         RUST_CHECK_TARGET=dist
@@ -101,6 +105,7 @@ matrix:
         CI_JOB_NAME=dist-x86_64-apple
       os: osx
       osx_image: xcode9.3-moar
+      if: branch = auto
 
     # Linux builders, remaining docker images
     - env: IMAGE=arm-android

--- a/src/test/ui/issue-52126-assign-op-invariance.nll.stderr
+++ b/src/test/ui/issue-52126-assign-op-invariance.nll.stderr
@@ -1,0 +1,15 @@
+error[E0597]: `line` does not live long enough
+  --> $DIR/issue-52126-assign-op-invariance.rs:44:28
+   |
+LL |         let v: Vec<&str> = line.split_whitespace().collect();
+   |                            ^^^^ borrowed value does not live long enough
+LL |         //~^ ERROR `line` does not live long enough
+LL |         println!("accumulator before add_assign {:?}", acc.map);
+   |                                                        ------- borrow later used here
+...
+LL |     }
+   |     - borrowed value only lives until here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/issue-52126-assign-op-invariance.rs
+++ b/src/test/ui/issue-52126-assign-op-invariance.rs
@@ -1,0 +1,59 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Issue 52126: With respect to variance, the assign-op's like += were
+// accidentally lumped together with other binary op's. In both cases
+// we were coercing the LHS of the op to the expected supertype.
+//
+// The problem is that since the LHS of += is modified, we need the
+// parameter to be invariant with respect to the overall type, not
+// covariant.
+
+use std::collections::HashMap;
+use std::ops::AddAssign;
+
+pub fn main() {
+    panics();
+}
+
+pub struct Counter<'l> {
+    map: HashMap<&'l str, usize>,
+}
+
+impl<'l> AddAssign for Counter<'l>
+{
+    fn add_assign(&mut self, rhs: Counter<'l>) {
+        rhs.map.into_iter().for_each(|(key, val)| {
+            let count = self.map.entry(key).or_insert(0);
+            *count += val;
+        });
+    }
+}
+
+/// often times crashes, if not prints invalid strings
+pub fn panics() {
+    let mut acc = Counter{map: HashMap::new()};
+    for line in vec!["123456789".to_string(), "12345678".to_string()] {
+        let v: Vec<&str> = line.split_whitespace().collect();
+        //~^ ERROR `line` does not live long enough
+        println!("accumulator before add_assign {:?}", acc.map);
+        let mut map = HashMap::new();
+        for str_ref in v {
+            let e = map.entry(str_ref);
+            println!("entry: {:?}", e);
+            let count = e.or_insert(0);
+            *count += 1;
+        }
+        let cnt2 = Counter{map};
+        acc += cnt2;
+        println!("accumulator after add_assign {:?}", acc.map);
+        // line gets dropped here but references are kept in acc.map
+    }
+}

--- a/src/test/ui/issue-52126-assign-op-invariance.stderr
+++ b/src/test/ui/issue-52126-assign-op-invariance.stderr
@@ -1,0 +1,14 @@
+error[E0597]: `line` does not live long enough
+  --> $DIR/issue-52126-assign-op-invariance.rs:44:28
+   |
+LL |         let v: Vec<&str> = line.split_whitespace().collect();
+   |                            ^^^^ borrowed value does not live long enough
+...
+LL |     }
+   |     - `line` dropped here while still borrowed
+LL | }
+   | - borrowed value needs to live until here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/nll/constant.rs
+++ b/src/test/ui/nll/constant.rs
@@ -11,7 +11,7 @@
 // Test that MIR borrowck and NLL analysis can handle constants of
 // arbitrary types without ICEs.
 
-// compile-flags:-Zborrowck=mir -Zverbose
+// compile-flags:-Zborrowck=mir
 // compile-pass
 
 const HI: &str = "hi";


### PR DESCRIPTION
Merged and approved:

* #52564: LHS of assign op is invariant

This PR also reverts commit 3fd32219b2a4cd377126bab2e30cd4595bf42290, which is not needed anymore. cc @kennytm 

r? @ghost