### PR TITLE
rustdoc: rework how default passes are chosen

### DIFF
--- a/src/librustdoc/passes/mod.rs
+++ b/src/librustdoc/passes/mod.rs
@@ -63,6 +63,33 @@ pub const DEFAULT_PASSES: &'static [&'static str] = &[
     "propagate-doc-cfg",
 ];
 
+pub const DEFAULT_PRIVATE_PASSES: &'static [&'static str] = &[
+    "strip-priv-imports",
+    "collapse-docs",
+    "unindent-comments",
+    "propagate-doc-cfg",
+];
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum DefaultPassOption {
+    Default,
+    Private,
+    None,
+}
+
+pub fn defaults(default_set: DefaultPassOption) -> &'static [&'static str] {
+    match default_set {
+        DefaultPassOption::Default => {
+            DEFAULT_PASSES
+        },
+        DefaultPassOption::Private => {
+            DEFAULT_PRIVATE_PASSES
+        },
+        DefaultPassOption::None => {
+            &[]
+        },
+    }
+}
 
 struct Stripper<'a> {
     retained: &'a mut DefIdSet,


### PR DESCRIPTION
This is a refactor that changes how we select default passes, and changes the set of passes used for `--document-private-items`. It's groundwork for a bigger refactor i want to do.

The major changes:

* There are now two sets of "default passes": one set for "no flags given" and one for "document private items".
* These sets can be selected by a new `DefaultPassOption` enum, which is selected from based on the presence of `--no-defaults` or `--document-private-items` CLI flags, or their associated crate attributes.
* When printing the list of passes, we also print the list of passes for `--document-private-items` in addition to the "default defaults".
* I added `propagate-doc-cfg` and `strip-priv-imports` to the "document private items" set. The former is to ensure items are properly tagged with the full set of cfg flags even when "document private items" is active. The latter is based on feedback and personal experience navigating the `rustc` docs, which use that flag. `strip-priv-imports` only removes non-pub `use` statements, so it should be harmless from a documentation standpoint to remove those items from "private items" documentation.