### PR TITLE
Omit the vendor component in Fuchsia triple

### DIFF
--- a/src/ci/docker/dist-various-2/Dockerfile
+++ b/src/ci/docker/dist-various-2/Dockerfile
@@ -34,12 +34,12 @@ COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
 ENV \
-    AR_x86_64_unknown_fuchsia=x86_64-unknown-fuchsia-ar \
-    CC_x86_64_unknown_fuchsia=x86_64-unknown-fuchsia-clang \
-    CXX_x86_64_unknown_fuchsia=x86_64-unknown-fuchsia-clang++ \
-    AR_aarch64_unknown_fuchsia=aarch64-unknown-fuchsia-ar \
-    CC_aarch64_unknown_fuchsia=aarch64-unknown-fuchsia-clang \
-    CXX_aarch64_unknown_fuchsia=aarch64-unknown-fuchsia-clang++ \
+    AR_x86_64_fuchsia=x86_64-fuchsia-ar \
+    CC_x86_64_fuchsia=x86_64-fuchsia-clang \
+    CXX_x86_64_fuchsia=x86_64-fuchsia-clang++ \
+    AR_aarch64_fuchsia=aarch64-fuchsia-ar \
+    CC_aarch64_fuchsia=aarch64-fuchsia-clang \
+    CXX_aarch64_fuchsia=aarch64-fuchsia-clang++ \
     AR_sparcv9_sun_solaris=sparcv9-sun-solaris2.10-ar \
     CC_sparcv9_sun_solaris=sparcv9-sun-solaris2.10-gcc \
     CXX_sparcv9_sun_solaris=sparcv9-sun-solaris2.10-g++ \
@@ -47,8 +47,8 @@ ENV \
     CC_x86_64_sun_solaris=x86_64-sun-solaris2.10-gcc \
     CXX_x86_64_sun_solaris=x86_64-sun-solaris2.10-g++
 
-ENV TARGETS=x86_64-unknown-fuchsia
-ENV TARGETS=$TARGETS,aarch64-unknown-fuchsia
+ENV TARGETS=x86_64-fuchsia
+ENV TARGETS=$TARGETS,aarch64-fuchsia
 ENV TARGETS=$TARGETS,sparcv9-sun-solaris
 ENV TARGETS=$TARGETS,wasm32-unknown-unknown
 ENV TARGETS=$TARGETS,x86_64-sun-solaris

--- a/src/ci/docker/dist-various-2/build-fuchsia-toolchain.sh
+++ b/src/ci/docker/dist-various-2/build-fuchsia-toolchain.sh
@@ -39,7 +39,7 @@ build() {
   esac
 
   hide_output make -j$(getconf _NPROCESSORS_ONLN) $tgt
-  dst=/usr/local/${arch}-unknown-fuchsia
+  dst=/usr/local/${arch}-fuchsia
   mkdir -p $dst
   cp -a build-${tgt}/sysroot/include $dst/
   cp -a build-${tgt}/sysroot/lib $dst/
@@ -55,11 +55,11 @@ rm -rf zircon
 
 for arch in x86_64 aarch64; do
   for tool in clang clang++; do
-    cat >/usr/local/bin/${arch}-unknown-fuchsia-${tool} <<EOF
+    cat >/usr/local/bin/${arch}-fuchsia-${tool} <<EOF
 #!/bin/sh
-${tool} --target=${arch}-unknown-fuchsia --sysroot=/usr/local/${arch}-unknown-fuchsia "\$@"
+${tool} --target=${arch}-fuchsia --sysroot=/usr/local/${arch}-fuchsia "\$@"
 EOF
-    chmod +x /usr/local/bin/${arch}-unknown-fuchsia-${tool}
+    chmod +x /usr/local/bin/${arch}-fuchsia-${tool}
   done
-  ln -s /usr/local/bin/llvm-ar /usr/local/bin/${arch}-unknown-fuchsia-ar
+  ln -s /usr/local/bin/llvm-ar /usr/local/bin/${arch}-fuchsia-ar
 done

--- a/src/librustc_target/spec/aarch64_fuchsia.rs
+++ b/src/librustc_target/spec/aarch64_fuchsia.rs
@@ -15,7 +15,7 @@ pub fn target() -> TargetResult {
     base.max_atomic_width = Some(128);
 
     Ok(Target {
-        llvm_target: "aarch64-unknown-fuchsia".to_string(),
+        llvm_target: "aarch64-fuchsia".to_string(),
         target_endian: "little".to_string(),
         target_pointer_width: "64".to_string(),
         target_c_int_width: "32".to_string(),
@@ -23,7 +23,7 @@ pub fn target() -> TargetResult {
         arch: "aarch64".to_string(),
         target_os: "fuchsia".to_string(),
         target_env: "".to_string(),
-        target_vendor: "unknown".to_string(),
+        target_vendor: "".to_string(),
         linker_flavor: LinkerFlavor::Gcc,
         options: TargetOptions {
             abi_blacklist: super::arm_base::abi_blacklist(),

--- a/src/librustc_target/spec/fuchsia_base.rs
+++ b/src/librustc_target/spec/fuchsia_base.rs
@@ -33,7 +33,7 @@ pub fn opts() -> TargetOptions {
         executables: true,
         target_family: Some("unix".to_string()),
         linker_is_gnu: true,
-        has_rpath: true,
+        has_rpath: false,
         pre_link_args: args,
         position_independent_executables: true,
         has_elf_tls: true,

--- a/src/librustc_target/spec/mod.rs
+++ b/src/librustc_target/spec/mod.rs
@@ -332,8 +332,8 @@ supported_targets! {
     ("x86_64-apple-darwin", x86_64_apple_darwin),
     ("i686-apple-darwin", i686_apple_darwin),
 
-    ("aarch64-unknown-fuchsia", aarch64_unknown_fuchsia),
-    ("x86_64-unknown-fuchsia", x86_64_unknown_fuchsia),
+    ("aarch64-fuchsia", aarch64_fuchsia),
+    ("x86_64-fuchsia", x86_64_fuchsia),
 
     ("x86_64-unknown-l4re-uclibc", x86_64_unknown_l4re_uclibc),
 

--- a/src/librustc_target/spec/x86_64_fuchsia.rs
+++ b/src/librustc_target/spec/x86_64_fuchsia.rs
@@ -18,7 +18,7 @@ pub fn target() -> TargetResult {
     base.stack_probes = true;
 
     Ok(Target {
-        llvm_target: "x86_64-unknown-fuchsia".to_string(),
+        llvm_target: "x86_64-fuchsia".to_string(),
         target_endian: "little".to_string(),
         target_pointer_width: "64".to_string(),
         target_c_int_width: "32".to_string(),
@@ -26,7 +26,7 @@ pub fn target() -> TargetResult {
         arch: "x86_64".to_string(),
         target_os: "fuchsia".to_string(),
         target_env: "".to_string(),
-        target_vendor: "unknown".to_string(),
+        target_vendor: "".to_string(),
         linker_flavor: LinkerFlavor::Gcc,
         options: base,
     })

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -46,9 +46,9 @@ static HOSTS: &'static [&'static str] = &[
 
 static TARGETS: &'static [&'static str] = &[
     "aarch64-apple-ios",
+    "aarch64-fuchsia",
     "aarch64-linux-android",
     "aarch64-unknown-cloudabi",
-    "aarch64-unknown-fuchsia",
     "aarch64-unknown-linux-gnu",
     "aarch64-unknown-linux-musl",
     "arm-linux-androideabi",
@@ -101,6 +101,7 @@ static TARGETS: &'static [&'static str] = &[
     "wasm32-unknown-unknown",
     "x86_64-apple-darwin",
     "x86_64-apple-ios",
+    "x86_64-fuchsia",
     "x86_64-linux-android",
     "x86_64-pc-windows-gnu",
     "x86_64-pc-windows-msvc",
@@ -108,7 +109,6 @@ static TARGETS: &'static [&'static str] = &[
     "x86_64-sun-solaris",
     "x86_64-unknown-cloudabi",
     "x86_64-unknown-freebsd",
-    "x86_64-unknown-fuchsia",
     "x86_64-unknown-linux-gnu",
     "x86_64-unknown-linux-gnux32",
     "x86_64-unknown-linux-musl",


### PR DESCRIPTION
Previously, using unknown as the vendor value would lead to the same
result, but with the multiarch runtimes support in Clang, the target is
now used to locate the runtime libraries and so the format is important.
The denormalized format with omitted vendor component is the format we
use with Clang and should be using for Rust as well.