### PR TITLE
Bump bootstrap compiler

### DIFF
--- a/src/stage0.txt
+++ b/src/stage0.txt
@@ -12,7 +12,7 @@
 # source tarball for a stable release you'll likely see `1.x.0` for rustc and
 # `0.x.0` for Cargo where they were released on `date`.
 
-date: 2018-07-13
+date: 2018-07-27
 rustc: beta
 cargo: beta
 


### PR DESCRIPTION
This PR bumps the bootstrap compiler to the latest beta, `beta-2017-07-27`. That should be the latest beta with relevant changes (the only nominated PR at the moment is a docs change).

r? @Mark-Simulacrum 