### PR TITLE
[beta] Disable lints in rustdoc

### DIFF
--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -214,7 +214,7 @@ pub fn run_core(search_paths: SearchPaths,
         } else {
             vec![]
         },
-        lint_cap: Some(lint::Forbid),
+        lint_cap: Some(lint::Allow),
         cg,
         externs,
         target_triple: triple.unwrap_or(host_triple),

--- a/src/test/rustdoc-ui/deny-intra-link-resolution-failure.rs
+++ b/src/test/rustdoc-ui/deny-intra-link-resolution-failure.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-test
+
 #![deny(intra_doc_link_resolution_failure)]
 
 /// [v2] //~ ERROR

--- a/src/test/rustdoc-ui/intra-links-warning.rs
+++ b/src/test/rustdoc-ui/intra-links-warning.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-test
+
 // compile-pass
 
        //! Test with [Foo::baz], [Bar::foo], ...


### PR DESCRIPTION
The lint handling in rustdoc 1.28 is still incomplete so I think it would be best to disable it for the stable release. The main thing that's missing is that cargo doesn't cap lints for dependencies. This was fixed in master by #52354 and rust-lang/cargo#5765 but they haven't been backported. Additionally rustdoc is still emitting lints that are not on its whitelist https://github.com/rust-lang/rust/issues/51661#issuecomment-406800119.

cc. @rust-lang/rustdoc 