### PR TITLE
rustdoc: refactor how passes are structured, and turn intra-doc-link collection into a pass

### DIFF
--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -596,6 +596,8 @@ pub fn run_core(search_paths: SearchPaths,
                 }
             }
 
+            ctxt.sess().abort_if_errors();
+
             (krate, ctxt.renderinfo.into_inner(), passes)
         }), &sess)
     })

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -45,8 +45,9 @@ use std::path::PathBuf;
 
 use visit_ast::RustdocVisitor;
 use clean;
-use clean::{get_path_for_type, Clean, MAX_DEF_ID};
+use clean::{get_path_for_type, Clean, MAX_DEF_ID, AttributesExt};
 use html::render::RenderInfo;
+use passes;
 
 pub use rustc::session::config::{Input, Options, CodegenOptions};
 pub use rustc::session::search_paths::SearchPaths;
@@ -322,7 +323,9 @@ pub fn run_core(search_paths: SearchPaths,
                 error_format: ErrorOutputType,
                 cmd_lints: Vec<(String, lint::Level)>,
                 lint_cap: Option<lint::Level>,
-                describe_lints: bool) -> (clean::Crate, RenderInfo)
+                describe_lints: bool,
+                mut manual_passes: Vec<String>,
+                mut default_passes: passes::DefaultPassOption) -> (clean::Crate, RenderInfo, Vec<String>)
 {
     // Parse, resolve, and typecheck the given crate.
 
@@ -527,13 +530,76 @@ pub fn run_core(search_paths: SearchPaths,
             };
             debug!("crate: {:?}", tcx.hir.krate());
 
-            let krate = {
+            let mut krate = {
                 let mut v = RustdocVisitor::new(&ctxt);
                 v.visit(tcx.hir.krate());
                 v.clean(&ctxt)
             };
 
-            (krate, ctxt.renderinfo.into_inner())
+            fn report_deprecated_attr(name: &str, diag: &errors::Handler) {
+                let mut msg = diag.struct_warn(&format!("the `#![doc({})]` attribute is \
+                                                         considered deprecated", name));
+                msg.warn("please see https://github.com/rust-lang/rust/issues/44136");
+
+                if name == "no_default_passes" {
+                    msg.help("you may want to use `#![doc(document_private_items)]`");
+                }
+
+                msg.emit();
+            }
+
+            // Process all of the crate attributes, extracting plugin metadata along
+            // with the passes which we are supposed to run.
+            for attr in krate.module.as_ref().unwrap().attrs.lists("doc") {
+                let diag = ctxt.sess().diagnostic();
+
+                let name = attr.name().map(|s| s.as_str());
+                let name = name.as_ref().map(|s| &s[..]);
+                if attr.is_word() {
+                    if name == Some("no_default_passes") {
+                        report_deprecated_attr("no_default_passes", diag);
+                        if default_passes == passes::DefaultPassOption::Default {
+                            default_passes = passes::DefaultPassOption::None;
+                        }
+                    }
+                } else if let Some(value) = attr.value_str() {
+                    let sink = match name {
+                        Some("passes") => {
+                            report_deprecated_attr("passes = \"...\"", diag);
+                            &mut manual_passes
+                        },
+                        Some("plugins") => {
+                            report_deprecated_attr("plugins = \"...\"", diag);
+                            eprintln!("WARNING: #![doc(plugins = \"...\")] no longer functions; \
+                                      see CVE-2018-1000622");
+                            continue
+                        },
+                        _ => continue,
+                    };
+                    for p in value.as_str().split_whitespace() {
+                        sink.push(p.to_string());
+                    }
+                }
+
+                if attr.is_word() && name == Some("document_private_items") {
+                    if default_passes == passes::DefaultPassOption::Default {
+                        default_passes = passes::DefaultPassOption::Private;
+                    }
+                }
+            }
+
+            let mut passes: Vec<String> =
+                passes::defaults(default_passes).iter().map(|p| p.to_string()).collect();
+            passes.extend(manual_passes);
+
+            for pass in &passes {
+                // the "unknown pass" error will be reported when late passes are run
+                if let Some(pass) = passes::find_pass(pass).and_then(|p| p.early_fn()) {
+                    krate = pass(krate, &ctxt);
+                }
+            }
+
+            (krate, ctxt.renderinfo.into_inner(), passes)
         }), &sess)
     })
 }

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -26,7 +26,7 @@ use rustc_metadata::creader::CrateLoader;
 use rustc_metadata::cstore::CStore;
 use rustc_target::spec::TargetTriple;
 
-use syntax::ast::{self, Ident, Name, NodeId};
+use syntax::ast::{self, Ident};
 use syntax::codemap;
 use syntax::edition::Edition;
 use syntax::feature_gate::UnstableFeatures;
@@ -58,7 +58,6 @@ pub struct DocContext<'a, 'tcx: 'a, 'rcx: 'a, 'cstore: 'rcx> {
     pub tcx: TyCtxt<'a, 'tcx, 'tcx>,
     pub resolver: &'a RefCell<resolve::Resolver<'rcx, 'cstore>>,
     /// The stack of module NodeIds up till this point
-    pub mod_ids: RefCell<Vec<NodeId>>,
     pub crate_name: Option<String>,
     pub cstore: Rc<CStore>,
     pub populated_all_crate_impls: Cell<bool>,
@@ -88,7 +87,6 @@ pub struct DocContext<'a, 'tcx: 'a, 'rcx: 'a, 'cstore: 'rcx> {
     pub all_fake_def_ids: RefCell<FxHashSet<DefId>>,
     /// Maps (type_id, trait_id) -> auto trait impl
     pub generated_synthetics: RefCell<FxHashSet<(DefId, DefId)>>,
-    pub current_item_name: RefCell<Option<Name>>,
     pub all_traits: Vec<DefId>,
 }
 
@@ -325,7 +323,8 @@ pub fn run_core(search_paths: SearchPaths,
                 lint_cap: Option<lint::Level>,
                 describe_lints: bool,
                 mut manual_passes: Vec<String>,
-                mut default_passes: passes::DefaultPassOption) -> (clean::Crate, RenderInfo, Vec<String>)
+                mut default_passes: passes::DefaultPassOption)
+    -> (clean::Crate, RenderInfo, Vec<String>)
 {
     // Parse, resolve, and typecheck the given crate.
 
@@ -520,12 +519,10 @@ pub fn run_core(search_paths: SearchPaths,
                 ty_substs: Default::default(),
                 lt_substs: Default::default(),
                 impl_trait_bounds: Default::default(),
-                mod_ids: Default::default(),
                 send_trait: send_trait,
                 fake_def_ids: RefCell::new(FxHashMap()),
                 all_fake_def_ids: RefCell::new(FxHashSet()),
                 generated_synthetics: RefCell::new(FxHashSet()),
-                current_item_name: RefCell::new(None),
                 all_traits: tcx.all_traits(LOCAL_CRATE).to_vec(),
             };
             debug!("crate: {:?}", tcx.hir.krate());

--- a/src/librustdoc/passes/collapse_docs.rs
+++ b/src/librustdoc/passes/collapse_docs.rs
@@ -11,7 +11,12 @@
 use clean::{self, DocFragment, Item};
 use fold;
 use fold::DocFolder;
+use passes::Pass;
 use std::mem::replace;
+
+pub const COLLAPSE_DOCS: Pass =
+    Pass::late("collapse-docs", collapse_docs,
+        "concatenates all document attributes into one document attribute");
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 enum DocFragmentKind {

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -379,8 +379,6 @@ impl<'a, 'tcx, 'rcx, 'cstore> DocFolder for LinkCollector<'a, 'tcx, 'rcx, 'cstor
             }
         }
 
-        cx.sess().abort_if_errors();
-
         if item.is_mod() && !item.attrs.inner_docs {
             self.mod_ids.push(item_node_id.unwrap());
         }

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -1,0 +1,598 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use clean::*;
+
+use rustc::lint as lint;
+use rustc::hir;
+use rustc::hir::def::Def;
+use rustc::ty;
+use syntax;
+use syntax::ast::{self, Ident, NodeId};
+use syntax::feature_gate::UnstableFeatures;
+use syntax::symbol::Symbol;
+use syntax_pos::{self, DUMMY_SP};
+
+use std::ops::Range;
+
+use core::DocContext;
+use fold::DocFolder;
+use html::markdown::markdown_links;
+use passes::Pass;
+
+pub const COLLECT_INTRA_DOC_LINKS: Pass =
+    Pass::early("collect-intra-doc-links", collect_intra_doc_links,
+                "reads a crate's documentation to resolve intra-doc-links");
+
+pub fn collect_intra_doc_links(krate: Crate, cx: &DocContext) -> Crate {
+    if !UnstableFeatures::from_environment().is_nightly_build() {
+        krate
+    } else {
+        let mut coll = LinkCollector::new(cx);
+
+        coll.fold_crate(krate)
+    }
+}
+
+#[derive(Debug)]
+enum PathKind {
+    /// can be either value or type, not a macro
+    Unknown,
+    /// macro
+    Macro,
+    /// values, functions, consts, statics, everything in the value namespace
+    Value,
+    /// types, traits, everything in the type namespace
+    Type,
+}
+
+struct LinkCollector<'a, 'tcx: 'a, 'rcx: 'a, 'cstore: 'rcx> {
+    cx: &'a DocContext<'a, 'tcx, 'rcx, 'cstore>,
+    mod_ids: Vec<NodeId>,
+}
+
+impl<'a, 'tcx, 'rcx, 'cstore> LinkCollector<'a, 'tcx, 'rcx, 'cstore> {
+    fn new(cx: &'a DocContext<'a, 'tcx, 'rcx, 'cstore>) -> Self {
+        LinkCollector {
+            cx,
+            mod_ids: Vec::new(),
+        }
+    }
+
+    /// Resolve a given string as a path, along with whether or not it is
+    /// in the value namespace. Also returns an optional URL fragment in the case
+    /// of variants and methods
+    fn resolve(&self, path_str: &str, is_val: bool, current_item: &Option<String>)
+        -> Result<(Def, Option<String>), ()>
+    {
+        let cx = self.cx;
+
+        // In case we're in a module, try to resolve the relative
+        // path
+        if let Some(id) = self.mod_ids.last() {
+            let result = cx.resolver.borrow_mut()
+                                    .with_scope(*id,
+                |resolver| {
+                    resolver.resolve_str_path_error(DUMMY_SP,
+                                                    &path_str, is_val)
+            });
+
+            if let Ok(result) = result {
+                // In case this is a trait item, skip the
+                // early return and try looking for the trait
+                let value = match result.def {
+                    Def::Method(_) | Def::AssociatedConst(_) => true,
+                    Def::AssociatedTy(_) => false,
+                    Def::Variant(_) => return handle_variant(cx, result.def),
+                    // not a trait item, just return what we found
+                    _ => return Ok((result.def, None))
+                };
+
+                if value != is_val {
+                    return Err(())
+                }
+            } else if let Some(prim) = is_primitive(path_str, is_val) {
+                return Ok((prim, Some(path_str.to_owned())))
+            } else {
+                // If resolution failed, it may still be a method
+                // because methods are not handled by the resolver
+                // If so, bail when we're not looking for a value
+                if !is_val {
+                    return Err(())
+                }
+            }
+
+            // Try looking for methods and associated items
+            let mut split = path_str.rsplitn(2, "::");
+            let item_name = if let Some(first) = split.next() {
+                first
+            } else {
+                return Err(())
+            };
+
+            let mut path = if let Some(second) = split.next() {
+                second.to_owned()
+            } else {
+                return Err(())
+            };
+
+            if path == "self" || path == "Self" {
+                if let Some(name) = current_item.as_ref() {
+                    path = name.clone();
+                }
+            }
+
+            let ty = cx.resolver.borrow_mut()
+                                .with_scope(*id,
+                |resolver| {
+                    resolver.resolve_str_path_error(DUMMY_SP, &path, false)
+            })?;
+            match ty.def {
+                Def::Struct(did) | Def::Union(did) | Def::Enum(did) | Def::TyAlias(did) => {
+                    let item = cx.tcx.inherent_impls(did)
+                                     .iter()
+                                     .flat_map(|imp| cx.tcx.associated_items(*imp))
+                                     .find(|item| item.ident.name == item_name);
+                    if let Some(item) = item {
+                        let out = match item.kind {
+                            ty::AssociatedKind::Method if is_val => "method",
+                            ty::AssociatedKind::Const if is_val => "associatedconstant",
+                            _ => return Err(())
+                        };
+                        Ok((ty.def, Some(format!("{}.{}", out, item_name))))
+                    } else {
+                        match cx.tcx.type_of(did).sty {
+                            ty::TyAdt(def, _) => {
+                                if let Some(item) = if def.is_enum() {
+                                    def.all_fields().find(|item| item.ident.name == item_name)
+                                } else {
+                                    def.non_enum_variant()
+                                       .fields
+                                       .iter()
+                                       .find(|item| item.ident.name == item_name)
+                                } {
+                                    Ok((ty.def,
+                                        Some(format!("{}.{}",
+                                                     if def.is_enum() {
+                                                         "variant"
+                                                     } else {
+                                                         "structfield"
+                                                     },
+                                                     item.ident))))
+                                } else {
+                                    Err(())
+                                }
+                            }
+                            _ => Err(()),
+                        }
+                    }
+                }
+                Def::Trait(did) => {
+                    let item = cx.tcx.associated_item_def_ids(did).iter()
+                                 .map(|item| cx.tcx.associated_item(*item))
+                                 .find(|item| item.ident.name == item_name);
+                    if let Some(item) = item {
+                        let kind = match item.kind {
+                            ty::AssociatedKind::Const if is_val => "associatedconstant",
+                            ty::AssociatedKind::Type if !is_val => "associatedtype",
+                            ty::AssociatedKind::Method if is_val => {
+                                if item.defaultness.has_value() {
+                                    "method"
+                                } else {
+                                    "tymethod"
+                                }
+                            }
+                            _ => return Err(())
+                        };
+
+                        Ok((ty.def, Some(format!("{}.{}", kind, item_name))))
+                    } else {
+                        Err(())
+                    }
+                }
+                _ => Err(())
+            }
+        } else {
+            Err(())
+        }
+    }
+}
+
+impl<'a, 'tcx, 'rcx, 'cstore> DocFolder for LinkCollector<'a, 'tcx, 'rcx, 'cstore> {
+    fn fold_item(&mut self, mut item: Item) -> Option<Item> {
+        let item_node_id = if item.is_mod() {
+            if let Some(id) = self.cx.tcx.hir.as_local_node_id(item.def_id) {
+                Some(id)
+            } else {
+                debug!("attempting to fold on a non-local item: {:?}", item);
+                return self.fold_item_recur(item);
+            }
+        } else {
+            None
+        };
+
+        let current_item = match item.inner {
+            ModuleItem(..) => {
+                if item.attrs.inner_docs {
+                    if item_node_id.unwrap() != NodeId::new(0) {
+                        item.name.clone()
+                    } else {
+                        None
+                    }
+                } else {
+                    match self.mod_ids.last() {
+                        Some(parent) if *parent != NodeId::new(0) => {
+                            //FIXME: can we pull the parent module's name from elsewhere?
+                            Some(self.cx.tcx.hir.name(*parent).to_string())
+                        }
+                        _ => None,
+                    }
+                }
+            }
+            ImplItem(Impl { ref for_, .. }) => {
+                for_.def_id().map(|did| self.cx.tcx.item_name(did).to_string())
+            }
+            ExternCrateItem(ref name, ..) => Some(name.clone()),
+            ImportItem(Import::Simple(ref name, ..)) => Some(name.clone()),
+            MacroItem(..) => None,
+            _ => item.name.clone(),
+        };
+
+        if item.is_mod() && item.attrs.inner_docs {
+            self.mod_ids.push(item_node_id.unwrap());
+        }
+
+        let cx = self.cx;
+        let dox = item.attrs.collapsed_doc_value().unwrap_or_else(String::new);
+
+        for (ori_link, link_range) in markdown_links(&dox) {
+            // bail early for real links
+            if ori_link.contains('/') {
+                continue;
+            }
+            let link = ori_link.replace("`", "");
+            let (def, fragment) = {
+                let mut kind = PathKind::Unknown;
+                let path_str = if let Some(prefix) =
+                    ["struct@", "enum@", "type@",
+                     "trait@", "union@"].iter()
+                                      .find(|p| link.starts_with(**p)) {
+                    kind = PathKind::Type;
+                    link.trim_left_matches(prefix)
+                } else if let Some(prefix) =
+                    ["const@", "static@",
+                     "value@", "function@", "mod@",
+                     "fn@", "module@", "method@"]
+                        .iter().find(|p| link.starts_with(**p)) {
+                    kind = PathKind::Value;
+                    link.trim_left_matches(prefix)
+                } else if link.ends_with("()") {
+                    kind = PathKind::Value;
+                    link.trim_right_matches("()")
+                } else if link.starts_with("macro@") {
+                    kind = PathKind::Macro;
+                    link.trim_left_matches("macro@")
+                } else if link.ends_with('!') {
+                    kind = PathKind::Macro;
+                    link.trim_right_matches('!')
+                } else {
+                    &link[..]
+                }.trim();
+
+                if path_str.contains(|ch: char| !(ch.is_alphanumeric() ||
+                                                  ch == ':' || ch == '_')) {
+                    continue;
+                }
+
+                match kind {
+                    PathKind::Value => {
+                        if let Ok(def) = self.resolve(path_str, true, &current_item) {
+                            def
+                        } else {
+                            resolution_failure(cx, &item.attrs, path_str, &dox, link_range);
+                            // this could just be a normal link or a broken link
+                            // we could potentially check if something is
+                            // "intra-doc-link-like" and warn in that case
+                            continue;
+                        }
+                    }
+                    PathKind::Type => {
+                        if let Ok(def) = self.resolve(path_str, false, &current_item) {
+                            def
+                        } else {
+                            resolution_failure(cx, &item.attrs, path_str, &dox, link_range);
+                            // this could just be a normal link
+                            continue;
+                        }
+                    }
+                    PathKind::Unknown => {
+                        // try everything!
+                        if let Some(macro_def) = macro_resolve(cx, path_str) {
+                            if let Ok(type_def) = self.resolve(path_str, false, &current_item) {
+                                let (type_kind, article, type_disambig)
+                                    = type_ns_kind(type_def.0, path_str);
+                                ambiguity_error(cx, &item.attrs, path_str,
+                                                article, type_kind, &type_disambig,
+                                                "a", "macro", &format!("macro@{}", path_str));
+                                continue;
+                            } else if let Ok(value_def) = self.resolve(path_str,
+                                                                       true,
+                                                                       &current_item) {
+                                let (value_kind, value_disambig)
+                                    = value_ns_kind(value_def.0, path_str)
+                                        .expect("struct and mod cases should have been \
+                                                 caught in previous branch");
+                                ambiguity_error(cx, &item.attrs, path_str,
+                                                "a", value_kind, &value_disambig,
+                                                "a", "macro", &format!("macro@{}", path_str));
+                            }
+                            (macro_def, None)
+                        } else if let Ok(type_def) = self.resolve(path_str, false, &current_item) {
+                            // It is imperative we search for not-a-value first
+                            // Otherwise we will find struct ctors for when we are looking
+                            // for structs, and the link won't work.
+                            // if there is something in both namespaces
+                            if let Ok(value_def) = self.resolve(path_str, true, &current_item) {
+                                let kind = value_ns_kind(value_def.0, path_str);
+                                if let Some((value_kind, value_disambig)) = kind {
+                                    let (type_kind, article, type_disambig)
+                                        = type_ns_kind(type_def.0, path_str);
+                                    ambiguity_error(cx, &item.attrs, path_str,
+                                                    article, type_kind, &type_disambig,
+                                                    "a", value_kind, &value_disambig);
+                                    continue;
+                                }
+                            }
+                            type_def
+                        } else if let Ok(value_def) = self.resolve(path_str, true, &current_item) {
+                            value_def
+                        } else {
+                            resolution_failure(cx, &item.attrs, path_str, &dox, link_range);
+                            // this could just be a normal link
+                            continue;
+                        }
+                    }
+                    PathKind::Macro => {
+                        if let Some(def) = macro_resolve(cx, path_str) {
+                            (def, None)
+                        } else {
+                            resolution_failure(cx, &item.attrs, path_str, &dox, link_range);
+                            continue
+                        }
+                    }
+                }
+            };
+
+            if let Def::PrimTy(_) = def {
+                item.attrs.links.push((ori_link, None, fragment));
+            } else {
+                let id = register_def(cx, def);
+                item.attrs.links.push((ori_link, Some(id), fragment));
+            }
+        }
+
+        cx.sess().abort_if_errors();
+
+        if item.is_mod() && !item.attrs.inner_docs {
+            self.mod_ids.push(item_node_id.unwrap());
+        }
+
+        if item.is_mod() {
+            let ret = self.fold_item_recur(item);
+
+            self.mod_ids.pop();
+
+            ret
+        } else {
+            self.fold_item_recur(item)
+        }
+    }
+}
+
+/// Resolve a string as a macro
+fn macro_resolve(cx: &DocContext, path_str: &str) -> Option<Def> {
+    use syntax::ext::base::{MacroKind, SyntaxExtension};
+    use syntax::ext::hygiene::Mark;
+    let segment = ast::PathSegment::from_ident(Ident::from_str(path_str));
+    let path = ast::Path { segments: vec![segment], span: DUMMY_SP };
+    let mut resolver = cx.resolver.borrow_mut();
+    let mark = Mark::root();
+    let res = resolver
+        .resolve_macro_to_def_inner(mark, &path, MacroKind::Bang, false);
+    if let Ok(def) = res {
+        if let SyntaxExtension::DeclMacro { .. } = *resolver.get_macro(def) {
+            return Some(def);
+        }
+    }
+    if let Some(def) = resolver.all_macros.get(&Symbol::intern(path_str)) {
+        return Some(*def);
+    }
+    None
+}
+
+fn span_of_attrs(attrs: &Attributes) -> syntax_pos::Span {
+    if attrs.doc_strings.is_empty() {
+        return DUMMY_SP;
+    }
+    let start = attrs.doc_strings[0].span();
+    let end = attrs.doc_strings.last().expect("No doc strings provided").span();
+    start.to(end)
+}
+
+fn resolution_failure(
+    cx: &DocContext,
+    attrs: &Attributes,
+    path_str: &str,
+    dox: &str,
+    link_range: Option<Range<usize>>,
+) {
+    let sp = span_of_attrs(attrs);
+    let msg = format!("`[{}]` cannot be resolved, ignoring it...", path_str);
+
+    let code_dox = sp.to_src(cx);
+
+    let doc_comment_padding = 3;
+    let mut diag = if let Some(link_range) = link_range {
+        // blah blah blah\nblah\nblah [blah] blah blah\nblah blah
+        //                       ^    ~~~~~~
+        //                       |    link_range
+        //                       last_new_line_offset
+
+        let mut diag;
+        if dox.lines().count() == code_dox.lines().count() {
+            let line_offset = dox[..link_range.start].lines().count();
+            // The span starts in the `///`, so we don't have to account for the leading whitespace
+            let code_dox_len = if line_offset <= 1 {
+                doc_comment_padding
+            } else {
+                // The first `///`
+                doc_comment_padding +
+                    // Each subsequent leading whitespace and `///`
+                    code_dox.lines().skip(1).take(line_offset - 1).fold(0, |sum, line| {
+                        sum + doc_comment_padding + line.len() - line.trim().len()
+                    })
+            };
+
+            // Extract the specific span
+            let sp = sp.from_inner_byte_pos(
+                link_range.start + code_dox_len,
+                link_range.end + code_dox_len,
+            );
+
+            diag = cx.tcx.struct_span_lint_node(lint::builtin::INTRA_DOC_LINK_RESOLUTION_FAILURE,
+                                                NodeId::new(0),
+                                                sp,
+                                                &msg);
+            diag.span_label(sp, "cannot be resolved, ignoring");
+        } else {
+            diag = cx.tcx.struct_span_lint_node(lint::builtin::INTRA_DOC_LINK_RESOLUTION_FAILURE,
+                                                NodeId::new(0),
+                                                sp,
+                                                &msg);
+
+            let last_new_line_offset = dox[..link_range.start].rfind('\n').map_or(0, |n| n + 1);
+            let line = dox[last_new_line_offset..].lines().next().unwrap_or("");
+
+            // Print the line containing the `link_range` and manually mark it with '^'s
+            diag.note(&format!(
+                "the link appears in this line:\n\n{line}\n\
+                 {indicator: <before$}{indicator:^<found$}",
+                line=line,
+                indicator="",
+                before=link_range.start - last_new_line_offset,
+                found=link_range.len(),
+            ));
+        }
+        diag
+    } else {
+        cx.tcx.struct_span_lint_node(lint::builtin::INTRA_DOC_LINK_RESOLUTION_FAILURE,
+                                     NodeId::new(0),
+                                     sp,
+                                     &msg)
+    };
+    diag.help("to escape `[` and `]` characters, just add '\\' before them like \
+               `\\[` or `\\]`");
+    diag.emit();
+}
+
+fn ambiguity_error(cx: &DocContext, attrs: &Attributes,
+                   path_str: &str,
+                   article1: &str, kind1: &str, disambig1: &str,
+                   article2: &str, kind2: &str, disambig2: &str) {
+    let sp = span_of_attrs(attrs);
+    cx.sess()
+      .struct_span_warn(sp,
+                        &format!("`{}` is both {} {} and {} {}",
+                                 path_str, article1, kind1,
+                                 article2, kind2))
+      .help(&format!("try `{}` if you want to select the {}, \
+                      or `{}` if you want to \
+                      select the {}",
+                      disambig1, kind1, disambig2,
+                      kind2))
+      .emit();
+}
+
+/// Given a def, returns its name and disambiguator
+/// for a value namespace
+///
+/// Returns None for things which cannot be ambiguous since
+/// they exist in both namespaces (structs and modules)
+fn value_ns_kind(def: Def, path_str: &str) -> Option<(&'static str, String)> {
+    match def {
+        // structs, variants, and mods exist in both namespaces. skip them
+        Def::StructCtor(..) | Def::Mod(..) | Def::Variant(..) | Def::VariantCtor(..) => None,
+        Def::Fn(..)
+            => Some(("function", format!("{}()", path_str))),
+        Def::Method(..)
+            => Some(("method", format!("{}()", path_str))),
+        Def::Const(..)
+            => Some(("const", format!("const@{}", path_str))),
+        Def::Static(..)
+            => Some(("static", format!("static@{}", path_str))),
+        _ => Some(("value", format!("value@{}", path_str))),
+    }
+}
+
+/// Given a def, returns its name, the article to be used, and a disambiguator
+/// for the type namespace
+fn type_ns_kind(def: Def, path_str: &str) -> (&'static str, &'static str, String) {
+    let (kind, article) = match def {
+        // we can still have non-tuple structs
+        Def::Struct(..) => ("struct", "a"),
+        Def::Enum(..) => ("enum", "an"),
+        Def::Trait(..) => ("trait", "a"),
+        Def::Union(..) => ("union", "a"),
+        _ => ("type", "a"),
+    };
+    (kind, article, format!("{}@{}", kind, path_str))
+}
+
+/// Given an enum variant's def, return the def of its enum and the associated fragment
+fn handle_variant(cx: &DocContext, def: Def) -> Result<(Def, Option<String>), ()> {
+    use rustc::ty::DefIdTree;
+
+    let parent = if let Some(parent) = cx.tcx.parent(def.def_id()) {
+        parent
+    } else {
+        return Err(())
+    };
+    let parent_def = Def::Enum(parent);
+    let variant = cx.tcx.expect_variant_def(def);
+    Ok((parent_def, Some(format!("{}.v", variant.name))))
+}
+
+const PRIMITIVES: &[(&str, Def)] = &[
+    ("u8",    Def::PrimTy(hir::PrimTy::TyUint(syntax::ast::UintTy::U8))),
+    ("u16",   Def::PrimTy(hir::PrimTy::TyUint(syntax::ast::UintTy::U16))),
+    ("u32",   Def::PrimTy(hir::PrimTy::TyUint(syntax::ast::UintTy::U32))),
+    ("u64",   Def::PrimTy(hir::PrimTy::TyUint(syntax::ast::UintTy::U64))),
+    ("u128",  Def::PrimTy(hir::PrimTy::TyUint(syntax::ast::UintTy::U128))),
+    ("usize", Def::PrimTy(hir::PrimTy::TyUint(syntax::ast::UintTy::Usize))),
+    ("i8",    Def::PrimTy(hir::PrimTy::TyInt(syntax::ast::IntTy::I8))),
+    ("i16",   Def::PrimTy(hir::PrimTy::TyInt(syntax::ast::IntTy::I16))),
+    ("i32",   Def::PrimTy(hir::PrimTy::TyInt(syntax::ast::IntTy::I32))),
+    ("i64",   Def::PrimTy(hir::PrimTy::TyInt(syntax::ast::IntTy::I64))),
+    ("i128",  Def::PrimTy(hir::PrimTy::TyInt(syntax::ast::IntTy::I128))),
+    ("isize", Def::PrimTy(hir::PrimTy::TyInt(syntax::ast::IntTy::Isize))),
+    ("f32",   Def::PrimTy(hir::PrimTy::TyFloat(syntax::ast::FloatTy::F32))),
+    ("f64",   Def::PrimTy(hir::PrimTy::TyFloat(syntax::ast::FloatTy::F64))),
+    ("str",   Def::PrimTy(hir::PrimTy::TyStr)),
+    ("bool",  Def::PrimTy(hir::PrimTy::TyBool)),
+    ("char",  Def::PrimTy(hir::PrimTy::TyChar)),
+];
+
+fn is_primitive(path_str: &str, is_val: bool) -> Option<Def> {
+    if is_val {
+        None
+    } else {
+        PRIMITIVES.iter().find(|x| x.0 == path_str).map(|x| x.1)
+    }
+}

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -239,7 +239,8 @@ impl<'a, 'tcx, 'rcx, 'cstore> DocFolder for LinkCollector<'a, 'tcx, 'rcx, 'cstor
             ImplItem(Impl { ref for_, .. }) => {
                 for_.def_id().map(|did| self.cx.tcx.item_name(did).to_string())
             }
-            ExternCrateItem(ref name, ..) => Some(name.clone()),
+            // we don't display docs on `extern crate` items anyway, so don't process them
+            ExternCrateItem(..) => return self.fold_item_recur(item),
             ImportItem(Import::Simple(ref name, ..)) => Some(name.clone()),
             MacroItem(..) => None,
             _ => item.name.clone(),

--- a/src/librustdoc/passes/mod.rs
+++ b/src/librustdoc/passes/mod.rs
@@ -40,6 +40,9 @@ pub use self::unindent_comments::UNINDENT_COMMENTS;
 mod propagate_doc_cfg;
 pub use self::propagate_doc_cfg::PROPAGATE_DOC_CFG;
 
+mod collect_intra_doc_links;
+pub use self::collect_intra_doc_links::COLLECT_INTRA_DOC_LINKS;
+
 /// Represents a single pass.
 #[derive(Copy, Clone)]
 pub enum Pass {
@@ -128,12 +131,14 @@ pub const PASSES: &'static [Pass] = &[
     STRIP_PRIVATE,
     STRIP_PRIV_IMPORTS,
     PROPAGATE_DOC_CFG,
+    COLLECT_INTRA_DOC_LINKS,
 ];
 
 /// The list of passes run by default.
 pub const DEFAULT_PASSES: &'static [&'static str] = &[
     "strip-hidden",
     "strip-private",
+    "collect-intra-doc-links",
     "collapse-docs",
     "unindent-comments",
     "propagate-doc-cfg",
@@ -142,6 +147,7 @@ pub const DEFAULT_PASSES: &'static [&'static str] = &[
 /// The list of default passes run with `--document-private-items` is passed to rustdoc.
 pub const DEFAULT_PRIVATE_PASSES: &'static [&'static str] = &[
     "strip-priv-imports",
+    "collect-intra-doc-links",
     "collapse-docs",
     "unindent-comments",
     "propagate-doc-cfg",

--- a/src/librustdoc/passes/propagate_doc_cfg.rs
+++ b/src/librustdoc/passes/propagate_doc_cfg.rs
@@ -13,6 +13,11 @@ use std::sync::Arc;
 use clean::{Crate, Item};
 use clean::cfg::Cfg;
 use fold::DocFolder;
+use passes::Pass;
+
+pub const PROPAGATE_DOC_CFG: Pass =
+    Pass::late("propagate-doc-cfg", propagate_doc_cfg,
+        "propagates `#[doc(cfg(...))]` to child items");
 
 pub fn propagate_doc_cfg(cr: Crate) -> Crate {
     CfgPropagator { parent_cfg: None }.fold_crate(cr)

--- a/src/librustdoc/passes/strip_hidden.rs
+++ b/src/librustdoc/passes/strip_hidden.rs
@@ -16,7 +16,11 @@ use clean::Item;
 use fold;
 use fold::DocFolder;
 use fold::StripItem;
-use passes::ImplStripper;
+use passes::{ImplStripper, Pass};
+
+pub const STRIP_HIDDEN: Pass =
+    Pass::late("strip-hidden", strip_hidden,
+               "strips all doc(hidden) items from the output");
 
 /// Strip items marked `#[doc(hidden)]`
 pub fn strip_hidden(krate: clean::Crate) -> clean::Crate {

--- a/src/librustdoc/passes/strip_hidden.rs
+++ b/src/librustdoc/passes/strip_hidden.rs
@@ -13,17 +13,18 @@ use std::mem;
 
 use clean::{self, AttributesExt, NestedAttributesExt};
 use clean::Item;
+use core::DocContext;
 use fold;
 use fold::DocFolder;
 use fold::StripItem;
 use passes::{ImplStripper, Pass};
 
 pub const STRIP_HIDDEN: Pass =
-    Pass::late("strip-hidden", strip_hidden,
-               "strips all doc(hidden) items from the output");
+    Pass::early("strip-hidden", strip_hidden,
+                "strips all doc(hidden) items from the output");
 
 /// Strip items marked `#[doc(hidden)]`
-pub fn strip_hidden(krate: clean::Crate) -> clean::Crate {
+pub fn strip_hidden(krate: clean::Crate, _: &DocContext) -> clean::Crate {
     let mut retained = DefIdSet();
 
     // strip all #[doc(hidden)] items

--- a/src/librustdoc/passes/strip_priv_imports.rs
+++ b/src/librustdoc/passes/strip_priv_imports.rs
@@ -9,12 +9,13 @@
 // except according to those terms.
 
 use clean;
+use core::DocContext;
 use fold::DocFolder;
 use passes::{ImportStripper, Pass};
 
-pub const STRIP_PRIV_IMPORTS: Pass = Pass::late("strip-priv-imports", strip_priv_imports,
+pub const STRIP_PRIV_IMPORTS: Pass = Pass::early("strip-priv-imports", strip_priv_imports,
      "strips all private import statements (`use`, `extern crate`) from a crate");
 
-pub fn strip_priv_imports(krate: clean::Crate)  -> clean::Crate {
+pub fn strip_priv_imports(krate: clean::Crate, _: &DocContext)  -> clean::Crate {
     ImportStripper.fold_crate(krate)
 }

--- a/src/librustdoc/passes/strip_priv_imports.rs
+++ b/src/librustdoc/passes/strip_priv_imports.rs
@@ -10,7 +10,10 @@
 
 use clean;
 use fold::DocFolder;
-use passes::ImportStripper;
+use passes::{ImportStripper, Pass};
+
+pub const STRIP_PRIV_IMPORTS: Pass = Pass::late("strip-priv-imports", strip_priv_imports,
+     "strips all private import statements (`use`, `extern crate`) from a crate");
 
 pub fn strip_priv_imports(krate: clean::Crate)  -> clean::Crate {
     ImportStripper.fold_crate(krate)

--- a/src/librustdoc/passes/strip_private.rs
+++ b/src/librustdoc/passes/strip_private.rs
@@ -12,7 +12,12 @@ use rustc::util::nodemap::DefIdSet;
 
 use clean;
 use fold::DocFolder;
-use passes::{ImplStripper, ImportStripper, Stripper};
+use passes::{ImplStripper, ImportStripper, Stripper, Pass};
+
+pub const STRIP_PRIVATE: Pass =
+    Pass::late("strip-private", strip_private,
+        "strips all private items from a crate which cannot be seen externally, \
+         implies strip-priv-imports");
 
 /// Strip private items from the point of view of a crate or externally from a
 /// crate, specified by the `xcrate` flag.

--- a/src/librustdoc/passes/strip_private.rs
+++ b/src/librustdoc/passes/strip_private.rs
@@ -11,17 +11,18 @@
 use rustc::util::nodemap::DefIdSet;
 
 use clean;
+use core::DocContext;
 use fold::DocFolder;
 use passes::{ImplStripper, ImportStripper, Stripper, Pass};
 
 pub const STRIP_PRIVATE: Pass =
-    Pass::late("strip-private", strip_private,
+    Pass::early("strip-private", strip_private,
         "strips all private items from a crate which cannot be seen externally, \
          implies strip-priv-imports");
 
 /// Strip private items from the point of view of a crate or externally from a
 /// crate, specified by the `xcrate` flag.
-pub fn strip_private(mut krate: clean::Crate) -> clean::Crate {
+pub fn strip_private(mut krate: clean::Crate, _: &DocContext) -> clean::Crate {
     // This stripper collects all *retained* nodes.
     let mut retained = DefIdSet();
     let access_levels = krate.access_levels.clone();

--- a/src/librustdoc/passes/unindent_comments.rs
+++ b/src/librustdoc/passes/unindent_comments.rs
@@ -14,6 +14,11 @@ use std::usize;
 
 use clean::{self, DocFragment, Item};
 use fold::{self, DocFolder};
+use passes::Pass;
+
+pub const UNINDENT_COMMENTS: Pass =
+    Pass::late("unindent-comments", unindent_comments,
+        "removes excess indentation on comments in order for markdown to like it");
 
 pub fn unindent_comments(krate: clean::Crate) -> clean::Crate {
     CommentCleaner.fold_crate(krate)

--- a/src/test/run-make-fulldeps/exit-code/lint-failure.rs
+++ b/src/test/run-make-fulldeps/exit-code/lint-failure.rs
@@ -11,6 +11,6 @@
 #![deny(intra_doc_link_resolution_failure)]
 
 /// [intradoc::failure]
-fn main() {
+pub fn main() {
     println!("Hello, world!");
 }

--- a/src/test/rustdoc/auxiliary/intra-link-extern-crate.rs
+++ b/src/test/rustdoc/auxiliary/intra-link-extern-crate.rs
@@ -1,0 +1,13 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_name="inner"]
+
+//! ooh, i'm a rebel just for [kicks]

--- a/src/test/rustdoc/intra-link-extern-crate.rs
+++ b/src/test/rustdoc/intra-link-extern-crate.rs
@@ -1,0 +1,19 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:intra-link-extern-crate.rs
+
+// When loading `extern crate` statements, we would pull in their docs at the same time, even
+// though they would never actually get displayed. This tripped intra-doc-link resolution failures,
+// for items that aren't under our control, and not actually getting documented!
+
+#![deny(intra_doc_link_resolution_failure)]
+
+extern crate inner;

--- a/src/test/rustdoc/intra-link-private.rs
+++ b/src/test/rustdoc/intra-link-private.rs
@@ -1,0 +1,18 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Rustdoc would previously report resolution failures on items that weren't in the public docs.
+// These failures were legitimate, but not truly relevant - the docs in question couldn't be
+// checked for accuracy anyway.
+
+#![deny(intra_doc_link_resolution_failure)]
+
+/// ooh, i'm a [rebel] just for kicks
+struct SomeStruct;


### PR DESCRIPTION
This builds on https://github.com/rust-lang/rust/pull/52751 and should not be merged until that finally finishes the bors queue

Part 2 of my passes refactor. This introduces the concept of an "early pass", which is run right before exiting the compiler context. This is important for passes that may want to ask the compiler about things. For example, i took out the intra-doc-link collection and turned it into a early pass. I also made the `strip-hidden`, `strip-private` and `strip-priv-imports` passes occur as early passes, so that intra-doc-link collection wouldn't run on docs that weren't getting printed.

Fixes https://github.com/rust-lang/rust/issues/51684, technically https://github.com/rust-lang/rust/issues/51468 too but that version of `h2` hits a legit intra-link error after that `>_>`

r? @rust-lang/rustdoc 