### PR TITLE
Don't format!() string literals

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -94,7 +94,7 @@ impl Step for Docs {
 
         builder.info(&format!("Dist docs ({})", host));
         if !builder.config.docs {
-            builder.info(&format!("\tskipping - docs disabled"));
+            builder.info("\tskipping - docs disabled");
             return distdir(builder).join(format!("{}-{}.tar.gz", name, host));
         }
 
@@ -156,7 +156,7 @@ impl Step for RustcDocs {
 
         builder.info(&format!("Dist compiler docs ({})", host));
         if !builder.config.compiler_docs {
-            builder.info(&format!("\tskipping - compiler docs disabled"));
+            builder.info("\tskipping - compiler docs disabled");
             return distdir(builder).join(format!("{}-{}.tar.gz", name, host));
         }
 
@@ -639,7 +639,7 @@ impl Step for Std {
         // The only true set of target libraries came from the build triple, so
         // let's reduce redundant work by only producing archives from that host.
         if compiler.host != builder.config.build {
-            builder.info(&format!("\tskipping, not a build host"));
+            builder.info("\tskipping, not a build host");
             return distdir(builder).join(format!("{}-{}.tar.gz", name, target));
         }
 
@@ -715,11 +715,11 @@ impl Step for Analysis {
         let compiler = self.compiler;
         let target = self.target;
         assert!(builder.config.extended);
-        builder.info(&format!("Dist analysis"));
+        builder.info("Dist analysis");
         let name = pkgname(builder, "rust-analysis");
 
         if &compiler.host != builder.config.build {
-            builder.info(&format!("\tskipping, not a build host"));
+            builder.info("\tskipping, not a build host");
             return distdir(builder).join(format!("{}-{}.tar.gz", name, target));
         }
 
@@ -824,7 +824,7 @@ impl Step for Src {
 
     /// Creates the `rust-src` installer component
     fn run(self, builder: &Builder) -> PathBuf {
-        builder.info(&format!("Dist src"));
+        builder.info("Dist src");
 
         let name = pkgname(builder, "rust-src");
         let image = tmpdir(builder).join(format!("{}-image", name));
@@ -918,7 +918,7 @@ impl Step for PlainSourceTarball {
 
     /// Creates the plain source tarball
     fn run(self, builder: &Builder) -> PathBuf {
-        builder.info(&format!("Create plain source tarball"));
+        builder.info("Create plain source tarball");
 
         // Make sure that the root folder of tarball has the correct name
         let plain_name = format!("{}-src", pkgname(builder, "rustc"));
@@ -998,7 +998,7 @@ impl Step for PlainSourceTarball {
         if let Some(dir) = tarball.parent() {
             builder.create_dir(&dir);
         }
-        builder.info(&format!("running installer"));
+        builder.info("running installer");
         let mut cmd = rust_installer(builder);
         cmd.arg("tarball")
            .arg("--input").arg(&plain_name)

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -686,7 +686,7 @@ impl Step for Rustc {
         };
 
         if !builder.config.compiler_docs {
-            builder.info(&format!("\tskipping - compiler/librustdoc docs disabled"));
+            builder.info("\tskipping - compiler/librustdoc docs disabled");
             return;
         }
 
@@ -788,7 +788,7 @@ impl Step for Rustdoc {
         };
 
         if !builder.config.compiler_docs {
-            builder.info(&format!("\tskipping - compiler/librustdoc docs disabled"));
+            builder.info("\tskipping - compiler/librustdoc docs disabled");
             return;
         }
 

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -474,7 +474,7 @@ impl Step for TestHelpers {
         }
 
         let _folder = builder.fold_output(|| "build_test_helpers");
-        builder.info(&format!("Building test helpers"));
+        builder.info("Building test helpers");
         t!(fs::create_dir_all(&dst));
         let mut cfg = cc::Build::new();
 

--- a/src/librustc/hir/check_attr.rs
+++ b/src/librustc/hir/check_attr.rs
@@ -248,8 +248,8 @@ impl<'a, 'tcx> CheckAttrVisitor<'a, 'tcx> {
                     self.emit_repr_error(
                         attr.span,
                         stmt.span,
-                        &format!("attribute should not be applied to a statement"),
-                        &format!("not a struct, enum or union"),
+                        "attribute should not be applied to a statement",
+                        "not a struct, enum or union",
                     );
                 }
             }
@@ -269,8 +269,8 @@ impl<'a, 'tcx> CheckAttrVisitor<'a, 'tcx> {
                 self.emit_repr_error(
                     attr.span,
                     expr.span,
-                    &format!("attribute should not be applied to an expression"),
-                    &format!("not defining a struct, enum or union"),
+                    "attribute should not be applied to an expression",
+                    "not defining a struct, enum or union",
                 );
             }
         }

--- a/src/librustc/infer/error_reporting/need_type_info.rs
+++ b/src/librustc/infer/error_reporting/need_type_info.rs
@@ -137,7 +137,8 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
             //          ^ consider giving this closure parameter a type
             // ```
             labels.clear();
-            labels.push((pattern.span, format!("consider giving this closure parameter a type")));
+            labels.push(
+                (pattern.span, "consider giving this closure parameter a type".to_string()));
         } else if let Some(pattern) = local_visitor.found_local_pattern {
             if let Some(simple_ident) = pattern.simple_ident() {
                 match pattern.span.compiler_desugaring_kind() {
@@ -150,7 +151,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                     _ => {}
                 }
             } else {
-                labels.push((pattern.span, format!("consider giving the pattern a type")));
+                labels.push((pattern.span, "consider giving the pattern a type".to_string()));
             }
         }
 

--- a/src/librustc/infer/error_reporting/nice_region_error/different_lifetimes.rs
+++ b/src/librustc/infer/error_reporting/nice_region_error/different_lifetimes.rs
@@ -99,13 +99,13 @@ impl<'a, 'gcx, 'tcx> NiceRegionError<'a, 'gcx, 'tcx> {
         let span_label_var1 = if let Some(simple_ident) = anon_arg_sup.pat.simple_ident() {
             format!(" from `{}`", simple_ident)
         } else {
-            format!("")
+            String::new()
         };
 
         let span_label_var2 = if let Some(simple_ident) = anon_arg_sub.pat.simple_ident() {
             format!(" into `{}`", simple_ident)
         } else {
-            format!("")
+            String::new()
         };
 
 
@@ -113,16 +113,12 @@ impl<'a, 'gcx, 'tcx> NiceRegionError<'a, 'gcx, 'tcx> {
             (None, None) => {
                 let (main_label_1, span_label_1) = if ty_sup.id == ty_sub.id {
                     (
-                        format!("this type is declared with multiple lifetimes..."),
-                        format!(
-                            "...but data{} flows{} here",
-                            format!(" with one lifetime"),
-                            format!(" into the other")
-                        ),
+                        "this type is declared with multiple lifetimes...".to_string(),
+                        "...but data with one lifetime flows into the other here".to_string()
                     )
                 } else {
                     (
-                        format!("these two types are declared with different lifetimes..."),
+                        "these two types are declared with different lifetimes...".to_string(),
                         format!(
                             "...but data{} flows{} here",
                             span_label_var1,
@@ -136,19 +132,17 @@ impl<'a, 'gcx, 'tcx> NiceRegionError<'a, 'gcx, 'tcx> {
             (Some(ret_span), _) => (
                 ty_sub.span,
                 ret_span,
-                format!(
-                    "this parameter and the return type are declared \
-                     with different lifetimes...",
-                ),
+                "this parameter and the return type are declared \
+                 with different lifetimes...".to_string()
+                ,
                 format!("...but data{} is returned here", span_label_var1),
             ),
             (_, Some(ret_span)) => (
                 ty_sup.span,
                 ret_span,
-                format!(
-                    "this parameter and the return type are declared \
-                     with different lifetimes...",
-                ),
+                "this parameter and the return type are declared \
+                 with different lifetimes...".to_string()
+                ,
                 format!("...but data{} is returned here", span_label_var1),
             ),
         };
@@ -156,7 +150,7 @@ impl<'a, 'gcx, 'tcx> NiceRegionError<'a, 'gcx, 'tcx> {
 
         struct_span_err!(self.tcx.sess, span, E0623, "lifetime mismatch")
             .span_label(span_1, main_label)
-            .span_label(span_2, format!(""))
+            .span_label(span_2, String::new())
             .span_label(span, span_label)
             .emit();
         return Some(ErrorReported);

--- a/src/librustc/infer/lexical_region_resolve/graphviz.rs
+++ b/src/librustc/infer/lexical_region_resolve/graphviz.rs
@@ -204,7 +204,7 @@ impl<'a, 'gcx, 'tcx> dot::Labeller<'a> for ConstraintGraph<'a, 'gcx, 'tcx> {
         match *e {
             Edge::Constraint(ref c) =>
                 dot::LabelText::label(format!("{:?}", self.map.get(c).unwrap())),
-            Edge::EnclScope(..) => dot::LabelText::label(format!("(enclosed)")),
+            Edge::EnclScope(..) => dot::LabelText::label("(enclosed)".to_string()),
         }
     }
 }
@@ -273,7 +273,7 @@ fn dump_region_data_to<'a, 'gcx, 'tcx>(region_rels: &RegionRelations<'a, 'gcx, '
     debug!("dump_region_data map (len: {}) path: {}",
            map.len(),
            path);
-    let g = ConstraintGraph::new(format!("region_data"), region_rels, map);
+    let g = ConstraintGraph::new("region_data".to_string(), region_rels, map);
     debug!("dump_region_data calling render");
     let mut v = Vec::new();
     dot::render(&g, &mut v).unwrap();

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -424,7 +424,7 @@ impl BuiltinLintDiagnostics {
                     Ok(ref s) if is_global => (format!("dyn ({})", s),
                                                Applicability::MachineApplicable),
                     Ok(s) => (format!("dyn {}", s), Applicability::MachineApplicable),
-                    Err(_) => (format!("dyn <type>"), Applicability::HasPlaceholders)
+                    Err(_) => ("dyn <type>".to_string(), Applicability::HasPlaceholders)
                 };
                 db.span_suggestion_with_applicability(span, "use `dyn`", sugg, app);
             }
@@ -441,7 +441,7 @@ impl BuiltinLintDiagnostics {
 
                         (format!("crate{}{}", opt_colon, s), Applicability::MachineApplicable)
                     }
-                    Err(_) => (format!("crate::<path>"), Applicability::HasPlaceholders)
+                    Err(_) => ("crate::<path>".to_string(), Applicability::HasPlaceholders)
                 };
                 db.span_suggestion_with_applicability(span, "use `crate`", sugg, app);
             }

--- a/src/librustc/middle/intrinsicck.rs
+++ b/src/librustc/middle/intrinsicck.rs
@@ -107,7 +107,7 @@ impl<'a, 'tcx> ExprVisitor<'a, 'tcx> {
                 }
                 Err(LayoutError::Unknown(bad)) => {
                     if bad == ty {
-                        format!("this type's size can vary")
+                        "this type's size can vary".to_string()
                     } else {
                         format!("size can vary because of {}", bad)
                     }

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -1512,15 +1512,15 @@ impl<'tcx> cmt_<'tcx> {
                     None => {
                         match pk {
                             Unique => {
-                                format!("`Box` content")
+                                "`Box` content".to_string()
                             }
                             UnsafePtr(..) => {
-                                format!("dereference of raw pointer")
+                                "dereference of raw pointer".to_string()
                             }
                             BorrowedPtr(..) => {
                                 match self.note {
-                                    NoteIndex => format!("indexed content"),
-                                    _ => format!("borrowed content"),
+                                    NoteIndex => "indexed content".to_string(),
+                                    _ => "borrowed content".to_string(),
                                 }
                             }
                         }

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -2665,7 +2665,7 @@ pub fn report_missing_lifetime_specifiers(
     let msg = if count > 1 {
         format!("expected {} lifetime parameters", count)
     } else {
-        format!("expected lifetime parameter")
+        "expected lifetime parameter".to_string()
     };
 
     err.span_label(span, msg);

--- a/src/librustc/traits/specialize/mod.rs
+++ b/src/librustc/traits/specialize/mod.rs
@@ -364,7 +364,7 @@ pub(super) fn specialization_graph_provider<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx
                 match tcx.span_of_impl(overlap.with_impl) {
                     Ok(span) => {
                         err.span_label(tcx.sess.codemap().def_span(span),
-                                       format!("first implementation here"));
+                                       "first implementation here".to_string());
                         err.span_label(impl_span,
                                        format!("conflicting implementation{}",
                                                 overlap.self_desc

--- a/src/librustc/ty/error.rs
+++ b/src/librustc/ty/error.rs
@@ -204,7 +204,7 @@ impl<'a, 'gcx, 'lcx, 'tcx> ty::TyS<'tcx> {
                     format!("&{}", tymut_string)
                 }
             }
-            ty::TyFnDef(..) => format!("fn item"),
+            ty::TyFnDef(..) => "fn item".to_string(),
             ty::TyFnPtr(_) => "fn pointer".to_string(),
             ty::TyDynamic(ref inner, ..) => {
                 inner.principal().map_or_else(|| "trait".to_string(),

--- a/src/librustc/ty/query/config.rs
+++ b/src/librustc/ty/query/config.rs
@@ -237,19 +237,19 @@ impl<'tcx> QueryDescription<'tcx> for queries::crate_inherent_impls<'tcx> {
 
 impl<'tcx> QueryDescription<'tcx> for queries::crate_inherent_impls_overlap_check<'tcx> {
     fn describe(_: TyCtxt, _: CrateNum) -> String {
-        format!("check for overlap between inherent impls defined in this crate")
+        "check for overlap between inherent impls defined in this crate".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::crate_variances<'tcx> {
     fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
-        format!("computing the variances for items in this crate")
+        "computing the variances for items in this crate".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::inferred_outlives_crate<'tcx> {
     fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
-        format!("computing the inferred outlives predicates for items in this crate")
+        "computing the inferred outlives predicates for items in this crate".to_string()
     }
 }
 
@@ -262,19 +262,19 @@ impl<'tcx> QueryDescription<'tcx> for queries::mir_shims<'tcx> {
 
 impl<'tcx> QueryDescription<'tcx> for queries::privacy_access_levels<'tcx> {
     fn describe(_: TyCtxt, _: CrateNum) -> String {
-        format!("privacy access levels")
+        "privacy access levels".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::typeck_item_bodies<'tcx> {
     fn describe(_: TyCtxt, _: CrateNum) -> String {
-        format!("type-checking all item bodies")
+        "type-checking all item bodies".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::reachable_set<'tcx> {
     fn describe(_: TyCtxt, _: CrateNum) -> String {
-        format!("reachability")
+        "reachability".to_string()
     }
 }
 
@@ -298,7 +298,7 @@ impl<'tcx> QueryDescription<'tcx> for queries::const_eval<'tcx> {
 
 impl<'tcx> QueryDescription<'tcx> for queries::mir_keys<'tcx> {
     fn describe(_: TyCtxt, _: CrateNum) -> String {
-        format!("getting a list of all mir_keys")
+        "getting a list of all mir_keys".to_string()
     }
 }
 
@@ -476,247 +476,247 @@ impl<'tcx> QueryDescription<'tcx> for queries::extern_crate<'tcx> {
 
 impl<'tcx> QueryDescription<'tcx> for queries::lint_levels<'tcx> {
     fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
-        format!("computing the lint levels for items in this crate")
+        "computing the lint levels for items in this crate".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::specializes<'tcx> {
     fn describe(_tcx: TyCtxt, _: (DefId, DefId)) -> String {
-        format!("computing whether impls specialize one another")
+        "computing whether impls specialize one another".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::in_scope_traits_map<'tcx> {
     fn describe(_tcx: TyCtxt, _: DefIndex) -> String {
-        format!("traits in scope at a block")
+        "traits in scope at a block".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::is_no_builtins<'tcx> {
     fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
-        format!("test whether a crate has #![no_builtins]")
+        "test whether a crate has #![no_builtins]".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::panic_strategy<'tcx> {
     fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
-        format!("query a crate's configured panic strategy")
+        "query a crate's configured panic strategy".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::is_profiler_runtime<'tcx> {
     fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
-        format!("query a crate is #![profiler_runtime]")
+        "query a crate is #![profiler_runtime]".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::is_sanitizer_runtime<'tcx> {
     fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
-        format!("query a crate is #![sanitizer_runtime]")
+        "query a crate is #![sanitizer_runtime]".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::reachable_non_generics<'tcx> {
     fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
-        format!("looking up the exported symbols of a crate")
+        "looking up the exported symbols of a crate".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::native_libraries<'tcx> {
     fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
-        format!("looking up the native libraries of a linked crate")
+        "looking up the native libraries of a linked crate".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::foreign_modules<'tcx> {
     fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
-        format!("looking up the foreign modules of a linked crate")
+        "looking up the foreign modules of a linked crate".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::plugin_registrar_fn<'tcx> {
     fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
-        format!("looking up the plugin registrar for a crate")
+        "looking up the plugin registrar for a crate".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::derive_registrar_fn<'tcx> {
     fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
-        format!("looking up the derive registrar for a crate")
+        "looking up the derive registrar for a crate".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::crate_disambiguator<'tcx> {
     fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
-        format!("looking up the disambiguator a crate")
+        "looking up the disambiguator a crate".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::crate_hash<'tcx> {
     fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
-        format!("looking up the hash a crate")
+        "looking up the hash a crate".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::original_crate_name<'tcx> {
     fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
-        format!("looking up the original name a crate")
+        "looking up the original name a crate".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::extra_filename<'tcx> {
     fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
-        format!("looking up the extra filename for a crate")
+        "looking up the extra filename for a crate".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::implementations_of_trait<'tcx> {
     fn describe(_tcx: TyCtxt, _: (CrateNum, DefId)) -> String {
-        format!("looking up implementations of a trait in a crate")
+        "looking up implementations of a trait in a crate".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::all_trait_implementations<'tcx> {
     fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
-        format!("looking up all (?) trait implementations")
+        "looking up all (?) trait implementations".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::link_args<'tcx> {
     fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
-        format!("looking up link arguments for a crate")
+        "looking up link arguments for a crate".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::resolve_lifetimes<'tcx> {
     fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
-        format!("resolving lifetimes")
+        "resolving lifetimes".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::named_region_map<'tcx> {
     fn describe(_tcx: TyCtxt, _: DefIndex) -> String {
-        format!("looking up a named region")
+        "looking up a named region".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::is_late_bound_map<'tcx> {
     fn describe(_tcx: TyCtxt, _: DefIndex) -> String {
-        format!("testing if a region is late bound")
+        "testing if a region is late bound".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::object_lifetime_defaults_map<'tcx> {
     fn describe(_tcx: TyCtxt, _: DefIndex) -> String {
-        format!("looking up lifetime defaults for a region")
+        "looking up lifetime defaults for a region".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::dep_kind<'tcx> {
     fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
-        format!("fetching what a dependency looks like")
+        "fetching what a dependency looks like".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::crate_name<'tcx> {
     fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
-        format!("fetching what a crate is named")
+        "fetching what a crate is named".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::get_lang_items<'tcx> {
     fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
-        format!("calculating the lang items map")
+        "calculating the lang items map".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::defined_lang_items<'tcx> {
     fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
-        format!("calculating the lang items defined in a crate")
+        "calculating the lang items defined in a crate".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::missing_lang_items<'tcx> {
     fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
-        format!("calculating the missing lang items in a crate")
+        "calculating the missing lang items in a crate".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::visible_parent_map<'tcx> {
     fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
-        format!("calculating the visible parent map")
+        "calculating the visible parent map".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::missing_extern_crate_item<'tcx> {
     fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
-        format!("seeing if we're missing an `extern crate` item for this crate")
+        "seeing if we're missing an `extern crate` item for this crate".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::used_crate_source<'tcx> {
     fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
-        format!("looking at the source for a crate")
+        "looking at the source for a crate".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::postorder_cnums<'tcx> {
     fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
-        format!("generating a postorder list of CrateNums")
+        "generating a postorder list of CrateNums".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::maybe_unused_extern_crates<'tcx> {
     fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
-        format!("looking up all possibly unused extern crates")
+        "looking up all possibly unused extern crates".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::stability_index<'tcx> {
     fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
-        format!("calculating the stability index for the local crate")
+        "calculating the stability index for the local crate".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::all_traits<'tcx> {
     fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
-        format!("fetching all foreign and local traits")
+        "fetching all foreign and local traits".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::all_crate_nums<'tcx> {
     fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
-        format!("fetching all foreign CrateNum instances")
+        "fetching all foreign CrateNum instances".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::exported_symbols<'tcx> {
     fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
-        format!("exported_symbols")
+        "exported_symbols".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::collect_and_partition_mono_items<'tcx> {
     fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
-        format!("collect_and_partition_mono_items")
+        "collect_and_partition_mono_items".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::codegen_unit<'tcx> {
     fn describe(_tcx: TyCtxt, _: InternedString) -> String {
-        format!("codegen_unit")
+        "codegen_unit".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::compile_codegen_unit<'tcx> {
     fn describe(_tcx: TyCtxt, _: InternedString) -> String {
-        format!("compile_codegen_unit")
+        "compile_codegen_unit".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::output_filenames<'tcx> {
     fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
-        format!("output_filenames")
+        "output_filenames".to_string()
     }
 }
 
@@ -728,7 +728,7 @@ impl<'tcx> QueryDescription<'tcx> for queries::vtable_methods<'tcx> {
 
 impl<'tcx> QueryDescription<'tcx> for queries::features_query<'tcx> {
     fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
-        format!("looking up enabled feature gates")
+        "looking up enabled feature gates".to_string()
     }
 }
 
@@ -772,7 +772,7 @@ impl<'tcx> QueryDescription<'tcx> for queries::substitute_normalize_and_test_pre
 
 impl<'tcx> QueryDescription<'tcx> for queries::target_features_whitelist<'tcx> {
     fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
-        format!("looking up the whitelist of target features")
+        "looking up the whitelist of target features".to_string()
     }
 }
 
@@ -799,25 +799,25 @@ impl<'tcx> QueryDescription<'tcx> for queries::generics_of<'tcx> {
 
 impl<'tcx> QueryDescription<'tcx> for queries::program_clauses_for<'tcx> {
     fn describe(_tcx: TyCtxt, _: DefId) -> String {
-        format!("generating chalk-style clauses")
+        "generating chalk-style clauses".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::program_clauses_for_env<'tcx> {
     fn describe(_tcx: TyCtxt, _: ty::ParamEnv<'tcx>) -> String {
-        format!("generating chalk-style clauses for param env")
+        "generating chalk-style clauses for param env".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::wasm_import_module_map<'tcx> {
     fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
-        format!("wasm import module map")
+        "wasm import module map".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::dllimport_foreign_items<'tcx> {
     fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
-        format!("wasm import module map")
+        "wasm import module map".to_string()
     }
 }
 

--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -1314,7 +1314,7 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
         let suggestion =
             match self.tcx.sess.codemap().span_to_snippet(err.span) {
                 Ok(string) => format!("move {}", string),
-                Err(_) => format!("move |<args>| <body>")
+                Err(_) => "move |<args>| <body>".to_string()
             };
 
         self.cannot_capture_in_long_lived_closure(err.span,

--- a/src/librustc_codegen_llvm/back/bytecode.rs
+++ b/src/librustc_codegen_llvm/back/bytecode.rs
@@ -108,37 +108,37 @@ pub struct DecodedBytecode<'a> {
 impl<'a> DecodedBytecode<'a> {
     pub fn new(data: &'a [u8]) -> Result<DecodedBytecode<'a>, String> {
         if !data.starts_with(RLIB_BYTECODE_OBJECT_MAGIC) {
-            return Err(format!("magic bytecode prefix not found"))
+            return Err("magic bytecode prefix not found".to_string())
         }
         let data = &data[RLIB_BYTECODE_OBJECT_MAGIC.len()..];
         if !data.starts_with(&[RLIB_BYTECODE_OBJECT_VERSION, 0, 0, 0]) {
-            return Err(format!("wrong version prefix found in bytecode"))
+            return Err("wrong version prefix found in bytecode".to_string())
         }
         let data = &data[4..];
         if data.len() < 4 {
-            return Err(format!("bytecode corrupted"))
+            return Err("bytecode corrupted".to_string())
         }
         let identifier_len = unsafe {
             u32::from_le(ptr::read_unaligned(data.as_ptr() as *const u32)) as usize
         };
         let data = &data[4..];
         if data.len() < identifier_len {
-            return Err(format!("bytecode corrupted"))
+            return Err("bytecode corrupted".to_string())
         }
         let identifier = match str::from_utf8(&data[..identifier_len]) {
             Ok(s) => s,
-            Err(_) => return Err(format!("bytecode corrupted"))
+            Err(_) => return Err("bytecode corrupted".to_string())
         };
         let data = &data[identifier_len..];
         if data.len() < 8 {
-            return Err(format!("bytecode corrupted"))
+            return Err("bytecode corrupted".to_string())
         }
         let bytecode_len = unsafe {
             u64::from_le(ptr::read_unaligned(data.as_ptr() as *const u64)) as usize
         };
         let data = &data[8..];
         if data.len() < bytecode_len {
-            return Err(format!("bytecode corrupted"))
+            return Err("bytecode corrupted".to_string())
         }
         let encoded_bytecode = &data[..bytecode_len];
 

--- a/src/librustc_codegen_llvm/back/link.rs
+++ b/src/librustc_codegen_llvm/back/link.rs
@@ -260,14 +260,14 @@ pub(crate) fn each_linked_rlib(sess: &Session,
                    .or_else(|| fmts.get(&config::CrateTypeProcMacro));
     let fmts = match fmts {
         Some(f) => f,
-        None => return Err(format!("could not find formats for rlibs"))
+        None => return Err("could not find formats for rlibs".to_string())
     };
     for &(cnum, ref path) in crates {
         match fmts.get(cnum.as_usize() - 1) {
             Some(&Linkage::NotLinked) |
             Some(&Linkage::IncludedFromDylib) => continue,
             Some(_) => {}
-            None => return Err(format!("could not find formats for rlibs"))
+            None => return Err("could not find formats for rlibs".to_string())
         }
         let name = &info.crate_name[&cnum];
         let path = match *path {

--- a/src/librustc_codegen_llvm/back/linker.rs
+++ b/src/librustc_codegen_llvm/back/linker.rs
@@ -206,7 +206,7 @@ impl<'a> GccLinker<'a> {
         match self.sess.opts.cg.lto {
             config::Lto::Thin |
             config::Lto::ThinLocal => {
-                self.linker_arg(&format!("-plugin-opt=thin"));
+                self.linker_arg("-plugin-opt=thin");
             }
             config::Lto::Fat |
             config::Lto::Yes |

--- a/src/librustc_codegen_llvm/back/lto.rs
+++ b/src/librustc_codegen_llvm/back/lto.rs
@@ -421,7 +421,7 @@ fn thin_lto(diag_handler: &Handler,
             symbol_white_list.len() as u32,
         );
         if data.is_null() {
-            let msg = format!("failed to prepare thin LTO context");
+            let msg = "failed to prepare thin LTO context".to_string();
             return Err(write::llvm_err(&diag_handler, msg))
         }
         let data = ThinData(data);
@@ -647,7 +647,7 @@ impl ThinModule {
             self.shared.module_names[self.idx].as_ptr(),
         );
         if llmod.is_null() {
-            let msg = format!("failed to parse bitcode for thin LTO module");
+            let msg = "failed to parse bitcode for thin LTO module".to_string();
             return Err(write::llvm_err(&diag_handler, msg));
         }
         let module = ModuleCodegen {
@@ -670,7 +670,7 @@ impl ThinModule {
         let mut cu2 = ptr::null_mut();
         llvm::LLVMRustThinLTOGetDICompileUnit(llmod, &mut cu1, &mut cu2);
         if !cu2.is_null() {
-            let msg = format!("multiple source DICompileUnits found");
+            let msg = "multiple source DICompileUnits found".to_string();
             return Err(write::llvm_err(&diag_handler, msg))
         }
 
@@ -691,25 +691,25 @@ impl ThinModule {
         // You can find some more comments about these functions in the LLVM
         // bindings we've got (currently `PassWrapper.cpp`)
         if !llvm::LLVMRustPrepareThinLTORename(self.shared.data.0, llmod) {
-            let msg = format!("failed to prepare thin LTO module");
+            let msg = "failed to prepare thin LTO module".to_string();
             return Err(write::llvm_err(&diag_handler, msg))
         }
         cgcx.save_temp_bitcode(&module, "thin-lto-after-rename");
         timeline.record("rename");
         if !llvm::LLVMRustPrepareThinLTOResolveWeak(self.shared.data.0, llmod) {
-            let msg = format!("failed to prepare thin LTO module");
+            let msg = "failed to prepare thin LTO module".to_string();
             return Err(write::llvm_err(&diag_handler, msg))
         }
         cgcx.save_temp_bitcode(&module, "thin-lto-after-resolve");
         timeline.record("resolve");
         if !llvm::LLVMRustPrepareThinLTOInternalize(self.shared.data.0, llmod) {
-            let msg = format!("failed to prepare thin LTO module");
+            let msg = "failed to prepare thin LTO module".to_string();
             return Err(write::llvm_err(&diag_handler, msg))
         }
         cgcx.save_temp_bitcode(&module, "thin-lto-after-internalize");
         timeline.record("internalize");
         if !llvm::LLVMRustPrepareThinLTOImport(self.shared.data.0, llmod) {
-            let msg = format!("failed to prepare thin LTO module");
+            let msg = "failed to prepare thin LTO module".to_string();
             return Err(write::llvm_err(&diag_handler, msg))
         }
         cgcx.save_temp_bitcode(&module, "thin-lto-after-import");

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -1176,7 +1176,7 @@ fn usage(verbose: bool, include_unstable_options: bool) {
     for option in groups.iter().filter(|x| include_unstable_options || x.is_stable()) {
         (option.apply)(&mut options);
     }
-    let message = format!("Usage: rustc [OPTIONS] INPUT");
+    let message = "Usage: rustc [OPTIONS] INPUT".to_string();
     let nightly_help = if nightly_options::is_nightly_build() {
         "\n    -Z help             Print internal options for debugging rustc"
     } else {

--- a/src/librustc_driver/profile/trace.rs
+++ b/src/librustc_driver/profile/trace.rs
@@ -62,7 +62,7 @@ pub fn html_of_effect(eff: &Effect) -> (String, String) {
     match *eff {
         Effect::TimeBegin(ref msg) => {
             (msg.clone(),
-             format!("time-begin"))
+             "time-begin".to_string())
         },
         Effect::TaskBegin(ref key) => {
             let cons = cons_of_key(key);
@@ -91,20 +91,20 @@ fn html_of_duration(_start: &Instant, dur: &Duration) -> (String, String) {
 
 fn html_of_fraction(frac: f64) -> (String, String) {
     let css = {
-        if       frac > 0.50  { format!("frac-50") }
-        else if  frac > 0.40  { format!("frac-40") }
-        else if  frac > 0.30  { format!("frac-30") }
-        else if  frac > 0.20  { format!("frac-20") }
-        else if  frac > 0.10  { format!("frac-10") }
-        else if  frac > 0.05  { format!("frac-05") }
-        else if  frac > 0.02  { format!("frac-02") }
-        else if  frac > 0.01  { format!("frac-01") }
-        else if  frac > 0.001 { format!("frac-001") }
-        else                  { format!("frac-0") }
+        if       frac > 0.50  { "frac-50".to_string() }
+        else if  frac > 0.40  { "frac-40".to_string() }
+        else if  frac > 0.30  { "frac-30".to_string() }
+        else if  frac > 0.20  { "frac-20".to_string() }
+        else if  frac > 0.10  { "frac-10".to_string() }
+        else if  frac > 0.05  { "frac-05".to_string() }
+        else if  frac > 0.02  { "frac-02".to_string() }
+        else if  frac > 0.01  { "frac-01".to_string() }
+        else if  frac > 0.001 { "frac-001".to_string() }
+        else                  { "frac-0".to_string() }
     };
     let percent = frac * 100.0;
     if percent > 0.1 { (format!("{:.1}%", percent), css) }
-    else { (format!("< 0.1%", ), css) }
+    else { ("< 0.1%".to_string(), css) }
 }
 
 fn total_duration(traces: &Vec<Rec>) -> Duration {

--- a/src/librustc_incremental/assert_dep_graph.rs
+++ b/src/librustc_incremental/assert_dep_graph.rs
@@ -229,7 +229,7 @@ fn check_paths<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 }
 
 fn dump_graph(tcx: TyCtxt) {
-    let path: String = env::var("RUST_DEP_GRAPH").unwrap_or_else(|_| format!("dep_graph"));
+    let path: String = env::var("RUST_DEP_GRAPH").unwrap_or_else(|_| "dep_graph".to_string());
     let query = tcx.dep_graph.query();
 
     let nodes = match env::var("RUST_DEP_GRAPH_FILTER") {

--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -802,7 +802,7 @@ impl<'a> CrateLoader<'a> {
                                            name));
                 }
             } else {
-                self.sess.err(&format!("Must link std to be compiled with `-Z sanitizer`"));
+                self.sess.err("Must link std to be compiled with `-Z sanitizer`");
             }
         }
     }

--- a/src/librustc_mir/borrow_check/mutability_errors.rs
+++ b/src/librustc_mir/borrow_check/mutability_errors.rs
@@ -85,7 +85,7 @@ impl<'a, 'gcx, 'tcx> MirBorrowckCtxt<'a, 'gcx, 'tcx> {
                     reason = if self.is_upvar(access_place) {
                         ", as it is a captured variable in a `Fn` closure".to_string()
                     } else {
-                        format!(", as `Fn` closures cannot mutate their captured variables")
+                        ", as `Fn` closures cannot mutate their captured variables".to_string()
                     }
                 } else if {
                     if let Place::Local(local) = *base {
@@ -100,7 +100,7 @@ impl<'a, 'gcx, 'tcx> MirBorrowckCtxt<'a, 'gcx, 'tcx> {
                     }
                 } {
                     item_msg = format!("`{}`", access_place_desc.unwrap());
-                    reason = format!(", as it is immutable for the pattern guard");
+                    reason = ", as it is immutable for the pattern guard".to_string();
                 } else {
                     let pointer_type =
                         if base.ty(self.mir, self.tcx).to_ty(self.tcx).is_region_ptr() {

--- a/src/librustc_mir/borrow_check/nll/explain_borrow/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/explain_borrow/mod.rs
@@ -65,7 +65,7 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
             Some(Cause::LiveVar(_local, location)) => {
                 err.span_label(
                     mir.source_info(location).span,
-                    format!("borrow later used here"),
+                    "borrow later used here".to_string(),
                 );
             }
 

--- a/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/mod.rs
@@ -401,7 +401,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
     ) {
         let mut diag = infcx.tcx.sess.struct_span_err(
             span,
-            &format!("unsatisfied lifetime constraints"), // FIXME
+            "unsatisfied lifetime constraints", // FIXME
         );
 
         let counter = &mut 1;

--- a/src/librustc_mir/borrow_check/nll/region_infer/graphviz.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/graphviz.rs
@@ -50,7 +50,7 @@ impl<'a, 'this, 'tcx> dot::Labeller<'this> for RawConstraints<'a, 'tcx> {
     type Edge = OutlivesConstraint;
 
     fn graph_id(&'this self) -> dot::Id<'this> {
-        dot::Id::new(format!("RegionInferenceContext")).unwrap()
+        dot::Id::new("RegionInferenceContext".to_string()).unwrap()
     }
     fn node_id(&'this self, n: &RegionVid) -> dot::Id<'this> {
         dot::Id::new(format!("r{}", n.index())).unwrap()
@@ -100,7 +100,7 @@ impl<'a, 'this, 'tcx> dot::Labeller<'this> for SccConstraints<'a, 'tcx> {
     type Edge = (ConstraintSccIndex, ConstraintSccIndex);
 
     fn graph_id(&'this self) -> dot::Id<'this> {
-        dot::Id::new(format!("RegionInferenceContext")).unwrap()
+        dot::Id::new("RegionInferenceContext".to_string()).unwrap()
     }
     fn node_id(&'this self, n: &ConstraintSccIndex) -> dot::Id<'this> {
         dot::Id::new(format!("r{}", n.index())).unwrap()

--- a/src/librustc_mir/borrow_check/nll/region_infer/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/mod.rs
@@ -1080,7 +1080,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         let mut diag = infcx
             .tcx
             .sess
-            .struct_span_err(span, &format!("higher-ranked subtype error"));
+            .struct_span_err(span, "higher-ranked subtype error");
         diag.emit();
     }
 }

--- a/src/librustc_mir/borrow_check/nll/type_check/input_output.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/input_output.rs
@@ -137,7 +137,7 @@ impl<'a, 'gcx, 'tcx> TypeChecker<'a, 'gcx, 'tcx> {
                             obligations: obligations.into_vec(),
                         })
                     },
-                    || format!("input_output"),
+                    || "input_output".to_string(),
                 ),
             ).unwrap_or_else(|terr| {
                 span_mirbug!(
@@ -166,7 +166,7 @@ impl<'a, 'gcx, 'tcx> TypeChecker<'a, 'gcx, 'tcx> {
                             obligations: vec![],
                         })
                     },
-                    || format!("anon_type_map"),
+                    || "anon_type_map".to_string(),
                 ),
             ).unwrap();
         }

--- a/src/librustc_mir/interpret/memory.rs
+++ b/src/librustc_mir/interpret/memory.rs
@@ -680,7 +680,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'mir, 'tcx>> Memory<'a, 'mir, 'tcx, M> {
                         (dest.offset <= src.offset && dest.offset + size > src.offset)
                     {
                         return err!(Intrinsic(
-                            format!("copy_nonoverlapping called on overlapping ranges"),
+                            "copy_nonoverlapping called on overlapping ranges".to_string(),
                         ));
                     }
                 }

--- a/src/librustc_mir/transform/check_unsafety.rs
+++ b/src/librustc_mir/transform/check_unsafety.rs
@@ -387,11 +387,11 @@ fn unsafe_derive_on_repr_packed<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: D
     // FIXME: when we make this a hard error, this should have its
     // own error code.
     let message = if tcx.generics_of(def_id).own_counts().types != 0 {
-        format!("#[derive] can't be used on a #[repr(packed)] struct with \
-                 type parameters (error E0133)")
+        "#[derive] can't be used on a #[repr(packed)] struct with \
+         type parameters (error E0133)".to_string()
     } else {
-        format!("#[derive] can't be used on a #[repr(packed)] struct that \
-                 does not derive Copy (error E0133)")
+        "#[derive] can't be used on a #[repr(packed)] struct that \
+         does not derive Copy (error E0133)".to_string()
     };
     tcx.lint_node(SAFE_PACKED_BORROWS,
                   lint_node_id,

--- a/src/librustc_mir/util/pretty.rs
+++ b/src/librustc_mir/util/pretty.rs
@@ -181,10 +181,10 @@ fn dump_path(
     };
 
     let pass_num = if tcx.sess.opts.debugging_opts.dump_mir_exclude_pass_number {
-        format!("")
+        String::new()
     } else {
         match pass_num {
-            None => format!(".-------"),
+            None => ".-------".to_string(),
             Some(pass_num) => format!(".{}", pass_num),
         }
     };
@@ -398,7 +398,7 @@ impl<'cx, 'gcx, 'tcx> Visitor<'tcx> for ExtraComments<'cx, 'gcx, 'tcx> {
     fn visit_constant(&mut self, constant: &Constant<'tcx>, location: Location) {
         self.super_constant(constant, location);
         let Constant { span, ty, literal } = constant;
-        self.push(&format!("mir::Constant"));
+        self.push("mir::Constant");
         self.push(&format!("+ span: {:?}", span));
         self.push(&format!("+ ty: {:?}", ty));
         self.push(&format!("+ literal: {:?}", literal));
@@ -407,7 +407,7 @@ impl<'cx, 'gcx, 'tcx> Visitor<'tcx> for ExtraComments<'cx, 'gcx, 'tcx> {
     fn visit_const(&mut self, constant: &&'tcx ty::Const<'tcx>, _: Location) {
         self.super_const(constant);
         let ty::Const { ty, val, .. } = constant;
-        self.push(&format!("ty::Const"));
+        self.push("ty::Const");
         self.push(&format!("+ ty: {:?}", ty));
         self.push(&format!("+ val: {:?}", val));
     }
@@ -417,13 +417,13 @@ impl<'cx, 'gcx, 'tcx> Visitor<'tcx> for ExtraComments<'cx, 'gcx, 'tcx> {
         match rvalue {
             Rvalue::Aggregate(kind, _) => match **kind {
                 AggregateKind::Closure(def_id, substs) => {
-                    self.push(&format!("closure"));
+                    self.push("closure");
                     self.push(&format!("+ def_id: {:?}", def_id));
                     self.push(&format!("+ substs: {:#?}", substs));
                 }
 
                 AggregateKind::Generator(def_id, substs, movability) => {
-                    self.push(&format!("generator"));
+                    self.push("generator");
                     self.push(&format!("+ def_id: {:?}", def_id));
                     self.push(&format!("+ substs: {:#?}", substs));
                     self.push(&format!("+ movability: {:?}", movability));

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -397,7 +397,8 @@ fn resolve_struct_error<'sess, 'a>(resolver: &'sess Resolver,
             let mut err = struct_span_err!(resolver.session, span, E0128,
                                            "type parameters with a default cannot use \
                                             forward declared identifiers");
-            err.span_label(span, format!("defaulted type parameters cannot be forward declared"));
+            err.span_label(
+                span, "defaulted type parameters cannot be forward declared".to_string());
             err
         }
     }
@@ -2890,16 +2891,16 @@ impl<'a> Resolver<'a> {
                 let item_str = path[path.len() - 1];
                 let item_span = path[path.len() - 1].span;
                 let (mod_prefix, mod_str) = if path.len() == 1 {
-                    (format!(""), format!("this scope"))
+                    (String::new(), "this scope".to_string())
                 } else if path.len() == 2 && path[0].name == keywords::CrateRoot.name() {
-                    (format!(""), format!("the crate root"))
+                    (String::new(), "the crate root".to_string())
                 } else {
                     let mod_path = &path[..path.len() - 1];
                     let mod_prefix = match this.resolve_path(mod_path, Some(TypeNS),
                                                              false, span, CrateLint::No) {
                         PathResult::Module(module) => module.def(),
                         _ => None,
-                    }.map_or(format!(""), |def| format!("{} ", def.kind_name()));
+                    }.map_or(String::new(), |def| format!("{} ", def.kind_name()));
                     (mod_prefix, format!("`{}`", names_to_string(mod_path)))
                 };
                 (format!("cannot find {} `{}` in {}{}", expected, item_str, mod_prefix, mod_str),
@@ -3457,7 +3458,7 @@ impl<'a> Resolver<'a> {
                     path[0].name != keywords::CrateRoot.name() ||
                name == keywords::Crate.name() && path.len() == 1 {
                 let name_str = if name == keywords::CrateRoot.name() {
-                    format!("crate root")
+                    "crate root".to_string()
                 } else {
                     format!("`{}`", name)
                 };

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1298,7 +1298,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> dyn AstConv<'gcx, 'tcx>+'o {
         for br in late_bound_in_ret.difference(&late_bound_in_args) {
             let lifetime_name = match *br {
                 ty::BrNamed(_, name) => format!("lifetime `{}`,", name),
-                ty::BrAnon(_) | ty::BrFresh(_) | ty::BrEnv => format!("an anonymous lifetime"),
+                ty::BrAnon(_) | ty::BrFresh(_) | ty::BrEnv => "an anonymous lifetime".to_string(),
             };
             let mut err = struct_span_err!(tcx.sess,
                                            decl.output.span(),

--- a/src/librustc_typeck/check/compare_method.rs
+++ b/src/librustc_typeck/check/compare_method.rs
@@ -322,7 +322,7 @@ fn compare_predicate_entailment<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 
             infcx.note_type_err(&mut diag,
                                 &cause,
-                                trait_err_span.map(|sp| (sp, format!("type in trait"))),
+                                trait_err_span.map(|sp| (sp, "type in trait".to_string())),
                                 Some(infer::ValuePairs::Types(ExpectedFound {
                                     expected: trait_fty,
                                     found: impl_fty,
@@ -622,7 +622,7 @@ fn compare_number_of_generics<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                 &if num_impl_m_type_params != 1 {
                                     format!("{} type parameters", num_impl_m_type_params)
                                 } else {
-                                    format!("1 type parameter")
+                                    "1 type parameter".to_string()
                                 },
                                 suffix.as_ref().map(|s| &s[..]).unwrap_or("")));
 
@@ -964,7 +964,7 @@ pub fn compare_const_impl<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 
             infcx.note_type_err(&mut diag,
                                 &cause,
-                                trait_c_span.map(|span| (span, format!("type in trait"))),
+                                trait_c_span.map(|span| (span, "type in trait".to_string())),
                                 Some(infer::ValuePairs::Types(ExpectedFound {
                                     expected: trait_ty,
                                     found: impl_ty,

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -343,7 +343,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                 lint::builtin::TYVAR_BEHIND_RAW_POINTER,
                                 scope_expr_id,
                                 span,
-                                &format!("type annotations needed"));
+                                "type annotations needed");
                         }
                     } else {
                         let t = self.structurally_resolved_type(span, final_ty);

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -113,7 +113,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                         let impl_ty = self.impl_self_ty(span, impl_did).ty;
 
                         let insertion = match self.tcx.impl_trait_ref(impl_did) {
-                            None => format!(""),
+                            None => String::new(),
                             Some(trait_ref) => {
                                 format!(" of the trait `{}`",
                                         self.tcx.item_path_str(trait_ref.def_id))

--- a/src/librustc_typeck/check/op.rs
+++ b/src/librustc_typeck/check/op.rs
@@ -490,7 +490,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                                     operator `{}`", op.as_str()));
                     match actual.sty {
                         TyUint(_) if op == hir::UnNeg => {
-                            err.note(&format!("unsigned values cannot be negated"));
+                            err.note("unsigned values cannot be negated");
                         },
                         TyStr | TyNever | TyChar | TyTuple(_) | TyArray(_,_) => {},
                         TyRef(_, ref lty, _) if lty.sty == TyStr => {},

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -191,9 +191,9 @@ fn check_main_fn_ty<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                         hir::ItemKind::Fn(.., ref generics, _) => {
                             let mut error = false;
                             if !generics.params.is_empty() {
-                                let msg = format!("`main` function is not allowed to have generic \
-                                                   parameters");
-                                let label = format!("`main` cannot have generic parameters");
+                                let msg = "`main` function is not allowed to have generic \
+                                           parameters".to_string();
+                                let label = "`main` cannot have generic parameters".to_string();
                                 struct_span_err!(tcx.sess, generics.span, E0131, "{}", msg)
                                     .span_label(generics.span, label)
                                     .emit();

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -2566,7 +2566,7 @@ fn short_stability(item: &clean::Item, cx: &Context, show_reason: bool) -> Vec<S
                                    text));
                 }
             } else {
-                stability.push(format!("<div class='stab unstable'>Experimental</div>"))
+                stability.push("<div class='stab unstable'>Experimental</div>".to_string())
             }
         };
     } else if let Some(depr) = item.deprecation.as_ref() {

--- a/src/libstd/sys/wasm/os.rs
+++ b/src/libstd/sys/wasm/os.rs
@@ -21,7 +21,7 @@ pub fn errno() -> i32 {
 }
 
 pub fn error_string(_errno: i32) -> String {
-    format!("operation successful")
+    "operation successful".to_string()
 }
 
 pub fn getcwd() -> io::Result<PathBuf> {

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -558,7 +558,7 @@ pub fn parse_opts(args: &[String]) -> Option<OptRes> {
 
     let test_threads = match matches.opt_str("test-threads") {
         Some(n_str) => match n_str.parse::<usize>() {
-            Ok(0) => return Some(Err(format!("argument for --test-threads must not be 0"))),
+            Ok(0) => return Some(Err("argument for --test-threads must not be 0".to_string())),
             Ok(n) => Some(n),
             Err(e) => {
                 return Some(Err(format!(


### PR DESCRIPTION
Prefer `to_string()` to `format!()` take 2, this time targetting string literals. In some cases (`&format!("...")` -> `"..."`) also removes allocations. Occurences of `format!("")` are changed to `String::new()`.