### PR TITLE
[NLL] Don't make "fake" match variables mutable

### DIFF
--- a/src/librustc_mir/build/matches/mod.rs
+++ b/src/librustc_mir/build/matches/mod.rs
@@ -1213,11 +1213,17 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
         let locals = if has_guard.0 && tcx.all_pat_vars_are_implicit_refs_within_guards() {
             let mut vals_for_guard = Vec::with_capacity(num_patterns);
             for _ in 0..num_patterns {
-                let val_for_guard_idx =  self.local_decls.push(local.clone());
+                let val_for_guard_idx = self.local_decls.push(LocalDecl {
+                    // This variable isn't mutated but has a name, so has to be
+                    // immutable to avoid the unused mut lint.
+                    mutability: Mutability::Not,
+                    ..local.clone()
+                });
                 vals_for_guard.push(val_for_guard_idx);
             }
             let ref_for_guard = self.local_decls.push(LocalDecl::<'tcx> {
-                mutability,
+                // See previous comment.
+                mutability: Mutability::Not,
                 ty: tcx.mk_imm_ref(tcx.types.re_empty, var_ty),
                 name: Some(name),
                 source_info,

--- a/src/test/ui/nll/extra-unused-mut.rs
+++ b/src/test/ui/nll/extra-unused-mut.rs
@@ -55,10 +55,19 @@ fn parse_dot_or_call_expr_with(mut attrs: Vec<u32>) {
     );
 }
 
+// Found when trying to bootstrap rustc
+fn if_guard(x: Result<i32, i32>) {
+    match x {
+        Ok(mut r) | Err(mut r) if true => r = 1,
+        _ => (),
+    }
+}
+
 fn main() {
     ref_argument(0);
     mutable_upvar();
     generator_mutable_upvar();
     ref_closure_argument();
     parse_dot_or_call_expr_with(Vec::new());
+    if_guard(Ok(0));
 }


### PR DESCRIPTION
These variables can't be mutated by the user, but since they have names the unused-mut lint thinks that it should check them.