### PR TITLE
Duration div mul extras

### DIFF
--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -517,16 +517,16 @@ impl Mul<f64> for Duration {
 
     fn mul(self, rhs: f64) -> Duration {
         const NPS: f64 = NANOS_PER_SEC as f64;
-        if rhs.is_sign_negative() {
-            panic!("duration can not be multiplied by negative float");
-        }
         let nanos_f64 = rhs * (NPS * (self.secs as f64) + (self.nanos as f64));
         if !nanos_f64.is_finite() {
             panic!("got non-finite value when multiplying duration by float");
         }
         if nanos_f64 > MAX_NANOS_F64 {
             panic!("overflow when multiplying duration by float");
-        };
+        }
+        if nanos_f64 < 0.0 {
+            panic!("underflow when multiplying duration by float");
+        }
         let nanos_u128 = nanos_f64 as u128;
         Duration {
             secs: (nanos_u128 / (NANOS_PER_SEC as u128)) as u64,
@@ -541,16 +541,16 @@ impl Mul<Duration> for f64 {
 
     fn mul(self, rhs: Duration) -> Duration {
         const NPS: f64 = NANOS_PER_SEC as f64;
-        if self.is_sign_negative() {
-            panic!("duration can not be multiplied by negative float");
-        }
         let nanos_f64 = self * (NPS * (rhs.secs as f64) + (rhs.nanos as f64));
         if !nanos_f64.is_finite() {
             panic!("got non-finite value when multiplying float by duration");
         }
         if nanos_f64 > MAX_NANOS_F64 {
             panic!("overflow when multiplying float by duration");
-        };
+        }
+        if nanos_f64 < 0.0 {
+            panic!("underflow when multiplying float by duration");
+        }
         let nanos_u128 = nanos_f64 as u128;
         Duration {
             secs: (nanos_u128 / (NANOS_PER_SEC as u128)) as u64,
@@ -588,16 +588,16 @@ impl Div<f64> for Duration {
 
     fn div(self, rhs: f64) -> Duration {
         const NPS: f64 = NANOS_PER_SEC as f64;
-        if rhs.is_sign_negative() {
-            panic!("duration can not be divided by negative float");
-        }
         let nanos_f64 = (NPS * (self.secs as f64) + (self.nanos as f64)) / rhs;
         if !nanos_f64.is_finite() {
             panic!("got non-finite value when dividing duration by float");
         }
         if nanos_f64 > MAX_NANOS_F64 {
             panic!("overflow when dividing duration by float");
-        };
+        }
+        if nanos_f64 < 0.0 {
+            panic!("underflow when multiplying duration by float");
+        }
         let nanos_u128 = nanos_f64 as u128;
         Duration {
             secs: (nanos_u128 / (NANOS_PER_SEC as u128)) as u64,

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -21,10 +21,9 @@
 //! assert_eq!(Duration::new(5, 0), Duration::from_secs(5));
 //! ```
 
-use fmt;
+use {fmt, u64};
 use iter::Sum;
 use ops::{Add, Sub, Mul, Div, AddAssign, SubAssign, MulAssign, DivAssign};
-use {u64, u128};
 
 const NANOS_PER_SEC: u32 = 1_000_000_000;
 const NANOS_PER_MILLI: u32 = 1_000_000;
@@ -517,22 +516,20 @@ impl Mul<f64> for Duration {
 
     fn mul(self, rhs: f64) -> Duration {
         const NPS: f64 = NANOS_PER_SEC as f64;
+        if rhs.is_sign_negative() {
+            panic!("duration can not be multiplied by negative float");
+        }
         let nanos_f64 = rhs * (NPS * (self.secs as f64) + (self.nanos as f64));
         if !nanos_f64.is_finite() {
             panic!("got non-finite value when multiplying duration by float");
         }
-        if nanos_f64 > (u128::MAX as f64) {
+        if nanos_f64 > ((u64::MAX as u128)*(NANOS_PER_SEC as u128)) as f64 {
             panic!("overflow when multiplying duration by float");
         };
         let nanos_u128 = nanos_f64 as u128;
-        let secs = nanos_u128 / (NANOS_PER_SEC as u128);
-        let nanos = nanos_u128 % (NANOS_PER_SEC as u128);
-        if secs > (u64::MAX as u128) {
-            panic!("overflow when multiplying duration by float");
-        }
         Duration {
-            secs: secs as u64,
-            nanos: nanos as u32,
+            secs: (nanos_u128 / (NANOS_PER_SEC as u128)) as u64,
+            nanos: (nanos_u128 % (NANOS_PER_SEC as u128)) as u32,
         }
     }
 }
@@ -543,22 +540,20 @@ impl Mul<Duration> for f64 {
 
     fn mul(self, rhs: Duration) -> Duration {
         const NPS: f64 = NANOS_PER_SEC as f64;
+        if self.is_sign_negative() {
+            panic!("duration can not be multiplied by negative float");
+        }
         let nanos_f64 = self * (NPS * (rhs.secs as f64) + (rhs.nanos as f64));
         if !nanos_f64.is_finite() {
             panic!("got non-finite value when multiplying float by duration");
         }
-        if nanos_f64 > (u128::MAX as f64) {
+        if nanos_f64 > ((u64::MAX as u128)*(NANOS_PER_SEC as u128)) as f64 {
             panic!("overflow when multiplying float by duration");
         };
         let nanos_u128 = nanos_f64 as u128;
-        let secs = nanos_u128 / (NANOS_PER_SEC as u128);
-        let nanos = nanos_u128 % (NANOS_PER_SEC as u128);
-        if secs > (u64::MAX as u128) {
-            panic!("overflow when multiplying float by duration");
-        }
         Duration {
-            secs: secs as u64,
-            nanos: nanos as u32,
+            secs: (nanos_u128 / (NANOS_PER_SEC as u128)) as u64,
+            nanos: (nanos_u128 % (NANOS_PER_SEC as u128)) as u32,
         }
     }
 }
@@ -592,22 +587,20 @@ impl Div<f64> for Duration {
 
     fn div(self, rhs: f64) -> Duration {
         const NPS: f64 = NANOS_PER_SEC as f64;
+        if rhs.is_sign_negative() {
+            panic!("duration can not be divided by negative float");
+        }
         let nanos_f64 = (NPS * (self.secs as f64) + (self.nanos as f64)) / rhs;
         if !nanos_f64.is_finite() {
             panic!("got non-finite value when dividing duration by float");
         }
-        if nanos_f64 > (u128::MAX as f64) {
+        if nanos_f64 > ((u64::MAX as u128)*(NANOS_PER_SEC as u128)) as f64 {
             panic!("overflow when dividing duration by float");
         };
         let nanos_u128 = nanos_f64 as u128;
-        let secs = nanos_u128 / (NANOS_PER_SEC as u128);
-        let nanos = nanos_u128 % (NANOS_PER_SEC as u128);
-        if secs > (u64::MAX as u128) {
-            panic!("overflow when dividing duration by float");
-        }
         Duration {
-            secs: secs as u64,
-            nanos: nanos as u32,
+            secs: (nanos_u128 / (NANOS_PER_SEC as u128)) as u64,
+            nanos: (nanos_u128 % (NANOS_PER_SEC as u128)) as u32,
         }
     }
 }

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -30,6 +30,7 @@ const NANOS_PER_MILLI: u32 = 1_000_000;
 const NANOS_PER_MICRO: u32 = 1_000;
 const MILLIS_PER_SEC: u64 = 1_000;
 const MICROS_PER_SEC: u64 = 1_000_000;
+const MAX_NANOS_F64: f64 = ((u64::MAX as u128)*(NANOS_PER_SEC as u128)) as f64;
 
 /// A `Duration` type to represent a span of time, typically used for system
 /// timeouts.
@@ -523,7 +524,7 @@ impl Mul<f64> for Duration {
         if !nanos_f64.is_finite() {
             panic!("got non-finite value when multiplying duration by float");
         }
-        if nanos_f64 > ((u64::MAX as u128)*(NANOS_PER_SEC as u128)) as f64 {
+        if nanos_f64 > MAX_NANOS_F64 {
             panic!("overflow when multiplying duration by float");
         };
         let nanos_u128 = nanos_f64 as u128;
@@ -547,7 +548,7 @@ impl Mul<Duration> for f64 {
         if !nanos_f64.is_finite() {
             panic!("got non-finite value when multiplying float by duration");
         }
-        if nanos_f64 > ((u64::MAX as u128)*(NANOS_PER_SEC as u128)) as f64 {
+        if nanos_f64 > MAX_NANOS_F64 {
             panic!("overflow when multiplying float by duration");
         };
         let nanos_u128 = nanos_f64 as u128;
@@ -594,7 +595,7 @@ impl Div<f64> for Duration {
         if !nanos_f64.is_finite() {
             panic!("got non-finite value when dividing duration by float");
         }
-        if nanos_f64 > ((u64::MAX as u128)*(NANOS_PER_SEC as u128)) as f64 {
+        if nanos_f64 > MAX_NANOS_F64 {
             panic!("overflow when dividing duration by float");
         };
         let nanos_u128 = nanos_f64 as u128;

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -507,7 +507,7 @@ impl Mul<Duration> for u32 {
     type Output = Duration;
 
     fn mul(self, rhs: Duration) -> Duration {
-        rhs.checked_mul(self).expect("overflow when multiplying scalar by duration")
+        rhs * self
     }
 }
 
@@ -540,22 +540,7 @@ impl Mul<Duration> for f64 {
     type Output = Duration;
 
     fn mul(self, rhs: Duration) -> Duration {
-        const NPS: f64 = NANOS_PER_SEC as f64;
-        let nanos_f64 = self * (NPS * (rhs.secs as f64) + (rhs.nanos as f64));
-        if !nanos_f64.is_finite() {
-            panic!("got non-finite value when multiplying float by duration");
-        }
-        if nanos_f64 > MAX_NANOS_F64 {
-            panic!("overflow when multiplying float by duration");
-        }
-        if nanos_f64 < 0.0 {
-            panic!("underflow when multiplying float by duration");
-        }
-        let nanos_u128 = nanos_f64 as u128;
-        Duration {
-            secs: (nanos_u128 / (NANOS_PER_SEC as u128)) as u64,
-            nanos: (nanos_u128 % (NANOS_PER_SEC as u128)) as u32,
-        }
+        rhs * self
     }
 }
 

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -464,6 +464,8 @@ impl Duration {
     ///
     /// # Examples
     /// ```
+    /// use std::time::Duration;
+    ///
     /// let dur = Duration::new(2, 700_000_000);
     /// assert_eq!(dur.mul_f64(3.14), Duration::new(8, 478_000_000));
     /// assert_eq!(dur.mul_f64(3.14e5), Duration::new(847_800, 0));
@@ -495,6 +497,8 @@ impl Duration {
     ///
     /// # Examples
     /// ```
+    /// use std::time::Duration;
+    ///
     /// let dur = Duration::new(2, 700_000_000);
     /// assert_eq!(dur.div_f64(3.14), Duration::new(0, 859_872_611));
     /// // note that truncation is used, not rounding
@@ -527,6 +531,8 @@ impl Duration {
     ///
     /// # Examples
     /// ```
+    /// use std::time::Duration;
+    ///
     /// let dur1 = Duration::new(2, 700_000_000);
     /// let dur2 = Duration::new(5, 400_000_000);
     /// assert_eq!(dur1.div_duration(dur2), 0.5);

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -464,6 +464,7 @@ impl Duration {
     ///
     /// # Examples
     /// ```
+    /// #![feature(exact_chunks)]
     /// use std::time::Duration;
     ///
     /// let dur = Duration::new(2, 700_000_000);
@@ -497,6 +498,7 @@ impl Duration {
     ///
     /// # Examples
     /// ```
+    /// #![feature(exact_chunks)]
     /// use std::time::Duration;
     ///
     /// let dur = Duration::new(2, 700_000_000);
@@ -531,6 +533,7 @@ impl Duration {
     ///
     /// # Examples
     /// ```
+    /// #![feature(exact_chunks)]
     /// use std::time::Duration;
     ///
     /// let dur1 = Duration::new(2, 700_000_000);
@@ -595,7 +598,7 @@ impl Mul<Duration> for u32 {
     type Output = Duration;
 
     fn mul(self, rhs: Duration) -> Duration {
-        rhs.checked_mul(self).expect("overflow when multiplying scalar by duration")
+        rhs * self
     }
 }
 

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -30,7 +30,7 @@ const NANOS_PER_MILLI: u32 = 1_000_000;
 const NANOS_PER_MICRO: u32 = 1_000;
 const MILLIS_PER_SEC: u64 = 1_000;
 const MICROS_PER_SEC: u64 = 1_000_000;
-const MAX_NANOS_F64: f64 = ((u64::MAX as u128 + 1)*(NANOS_PER_SEC as u128) - 1) as f64;
+const MAX_NANOS_F64: f64 = ((u64::MAX as u128 + 1)*(NANOS_PER_SEC as u128)) as f64;
 
 /// A `Duration` type to represent a span of time, typically used for system
 /// timeouts.
@@ -472,7 +472,7 @@ impl Duration {
     /// let dur = Duration::new(2, 700_000_000);
     /// assert_eq!(dur.as_float_secs(), 2.7);
     /// ```
-    #[unstable(feature = "duration_float", issue = "0")]
+    #[unstable(feature = "duration_float", issue = "54361")]
     #[inline]
     pub fn as_float_secs(&self) -> f64 {
         (self.secs as f64) + (self.nanos as f64) / (NANOS_PER_SEC as f64)
@@ -491,14 +491,14 @@ impl Duration {
     /// let dur = Duration::from_float_secs(2.7);
     /// assert_eq!(dur, Duration::new(2, 700_000_000));
     /// ```
-    #[unstable(feature = "duration_float", issue = "0")]
+    #[unstable(feature = "duration_float", issue = "54361")]
     #[inline]
     pub fn from_float_secs(secs: f64) -> Duration {
         let nanos =  secs * (NANOS_PER_SEC as f64);
         if !nanos.is_finite() {
             panic!("got non-finite value when converting float to duration");
         }
-        if nanos > MAX_NANOS_F64 {
+        if nanos >= MAX_NANOS_F64 {
             panic!("overflow when converting float to duration");
         }
         if nanos < 0.0 {
@@ -525,7 +525,7 @@ impl Duration {
     /// assert_eq!(dur.mul_f64(3.14), Duration::new(8, 478_000_000));
     /// assert_eq!(dur.mul_f64(3.14e5), Duration::new(847_800, 0));
     /// ```
-    #[unstable(feature = "duration_float", issue = "0")]
+    #[unstable(feature = "duration_float", issue = "54361")]
     #[inline]
     pub fn mul_f64(self, rhs: f64) -> Duration {
         Duration::from_float_secs(rhs * self.as_float_secs())
@@ -546,7 +546,7 @@ impl Duration {
     /// // note that truncation is used, not rounding
     /// assert_eq!(dur.div_f64(3.14e5), Duration::new(0, 8_598));
     /// ```
-    #[unstable(feature = "duration_float", issue = "0")]
+    #[unstable(feature = "duration_float", issue = "54361")]
     #[inline]
     pub fn div_f64(self, rhs: f64) -> Duration {
         Duration::from_float_secs(self.as_float_secs() / rhs)
@@ -563,7 +563,7 @@ impl Duration {
     /// let dur2 = Duration::new(5, 400_000_000);
     /// assert_eq!(dur1.div_duration(dur2), 0.5);
     /// ```
-    #[unstable(feature = "duration_float", issue = "0")]
+    #[unstable(feature = "duration_float", issue = "54361")]
     #[inline]
     pub fn div_duration(self, rhs: Duration) -> f64 {
         self.as_float_secs() / rhs.as_float_secs()
@@ -611,7 +611,7 @@ impl Mul<u32> for Duration {
     }
 }
 
-#[stable(feature = "symmetric_u32_duration_mul", since = "1.30.0")]
+#[stable(feature = "symmetric_u32_duration_mul", since = "1.31.0")]
 impl Mul<Duration> for u32 {
     type Output = Duration;
 

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -502,7 +502,7 @@ impl Mul<u32> for Duration {
     }
 }
 
-#[stable(feature = "duration_mul_div_extras", since = "1.29.0")]
+#[stable(feature = "duration_mul_div_extras", since = "1.30.0")]
 impl Mul<Duration> for u32 {
     type Output = Duration;
 
@@ -511,7 +511,7 @@ impl Mul<Duration> for u32 {
     }
 }
 
-#[stable(feature = "duration_mul_div_extras", since = "1.29.0")]
+#[stable(feature = "duration_mul_div_extras", since = "1.30.0")]
 impl Mul<f64> for Duration {
     type Output = Duration;
 
@@ -535,7 +535,7 @@ impl Mul<f64> for Duration {
     }
 }
 
-#[stable(feature = "duration_mul_div_extras", since = "1.29.0")]
+#[stable(feature = "duration_mul_div_extras", since = "1.30.0")]
 impl Mul<Duration> for f64 {
     type Output = Duration;
 
@@ -551,7 +551,7 @@ impl MulAssign<u32> for Duration {
     }
 }
 
-#[stable(feature = "duration_mul_div_extras", since = "1.29.0")]
+#[stable(feature = "duration_mul_div_extras", since = "1.30.0")]
 impl MulAssign<f64> for Duration {
     fn mul_assign(&mut self, rhs: f64) {
         *self = *self * rhs;
@@ -567,7 +567,7 @@ impl Div<u32> for Duration {
     }
 }
 
-#[stable(feature = "duration_mul_div_extras", since = "1.29.0")]
+#[stable(feature = "duration_mul_div_extras", since = "1.30.0")]
 impl Div<f64> for Duration {
     type Output = Duration;
 
@@ -591,7 +591,7 @@ impl Div<f64> for Duration {
     }
 }
 
-#[stable(feature = "duration_mul_div_extras", since = "1.29.0")]
+#[stable(feature = "duration_mul_div_extras", since = "1.30.0")]
 impl Div<Duration> for Duration {
     type Output = f64;
 
@@ -610,7 +610,7 @@ impl DivAssign<u32> for Duration {
     }
 }
 
-#[stable(feature = "duration_mul_div_extras", since = "1.29.0")]
+#[stable(feature = "duration_mul_div_extras", since = "1.30.0")]
 impl DivAssign<f64> for Duration {
     fn div_assign(&mut self, rhs: f64) {
         *self = *self / rhs;

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -616,7 +616,6 @@ impl DivAssign<u32> for Duration {
     }
 }
 
-
 macro_rules! sum_durations {
     ($iter:expr) => {{
         let mut total_secs: u64 = 0;

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -459,7 +459,7 @@ impl Duration {
             None
         }
     }
-    
+
     /// Returns the number of seconds contained by this `Duration` as `f64`.
     ///
     /// The returned value does include the fractional (nanosecond) part of the duration.
@@ -497,7 +497,7 @@ impl Duration {
             nanos: (nanos % (NANOS_PER_SEC as u128)) as u32,
         }
     }
-    
+
     /// Multiply `Duration` by `f64`.
     ///
     /// # Examples

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -480,6 +480,9 @@ impl Duration {
 
     /// Creates a new `Duration` from the specified number of seconds.
     ///
+    /// # Panics
+    /// This constructor will panic if `secs` is not finite, negative or overflows `Duration`.
+    ///
     /// # Examples
     /// ```
     /// #![feature(duration_float)]
@@ -510,6 +513,9 @@ impl Duration {
 
     /// Multiply `Duration` by `f64`.
     ///
+    /// # Panics
+    /// This method will panic if result is not finite, negative or overflows `Duration`.
+    ///
     /// # Examples
     /// ```
     /// #![feature(duration_float)]
@@ -526,6 +532,9 @@ impl Duration {
     }
 
     /// Divide `Duration` by `f64`.
+    ///
+    /// # Panics
+    /// This method will panic if result is not finite, negative or overflows `Duration`.
     ///
     /// # Examples
     /// ```

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -589,7 +589,7 @@ impl Mul<Duration> for u32 {
     type Output = Duration;
 
     fn mul(self, rhs: Duration) -> Duration {
-        rhs * self
+        rhs.checked_mul(self).expect("overflow when multiplying scalar by duration")
     }
 }
 

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -464,7 +464,7 @@ impl Duration {
     ///
     /// # Examples
     /// ```
-    /// #![feature(exact_chunks)]
+    /// #![feature(duration_float_ops)]
     /// use std::time::Duration;
     ///
     /// let dur = Duration::new(2, 700_000_000);
@@ -498,7 +498,7 @@ impl Duration {
     ///
     /// # Examples
     /// ```
-    /// #![feature(exact_chunks)]
+    /// #![feature(duration_float_ops)]
     /// use std::time::Duration;
     ///
     /// let dur = Duration::new(2, 700_000_000);
@@ -533,7 +533,7 @@ impl Duration {
     ///
     /// # Examples
     /// ```
-    /// #![feature(exact_chunks)]
+    /// #![feature(duration_float_ops)]
     /// use std::time::Duration;
     ///
     /// let dur1 = Duration::new(2, 700_000_000);

--- a/src/libstd/time.rs
+++ b/src/libstd/time.rs
@@ -590,4 +590,30 @@ mod tests {
         let hundred_twenty_years = thirty_years * 4;
         assert!(a < hundred_twenty_years);
     }
+
+    #[test]
+    fn duration_float_ops() {
+        let dur = Duration::new(2, 700_000_000);
+
+        let dur2 = 3.14*dur;
+        assert_eq!(dur2, dur*3.14);
+        assert_eq!(dur2.as_secs(), 8);
+        assert_eq!(dur2.subsec_nanos(), 478_000_000);
+
+        let dur3 = 3.14e5*dur;
+        assert_eq!(dur3, dur*3.14e5);
+        assert_eq!(dur3.as_secs(), 847_800);
+        assert_eq!(dur3.subsec_nanos(), 0);
+
+        let dur4 = dur/3.14;
+        assert_eq!(dur4.as_secs(), 0);
+        assert_eq!(dur4.subsec_nanos(), 859_872_611);
+
+        let dur5 = dur/3.14e5;
+        assert_eq!(dur5.as_secs(), 0);
+        // we are using truncation and not rounding
+        assert_eq!(dur5.subsec_nanos(), 8598);
+
+        assert_eq!(dur/Duration::new(5, 400_000_000), 0.5);
+    }
 }

--- a/src/libstd/time.rs
+++ b/src/libstd/time.rs
@@ -590,30 +590,4 @@ mod tests {
         let hundred_twenty_years = thirty_years * 4;
         assert!(a < hundred_twenty_years);
     }
-
-    #[test]
-    fn duration_float_ops() {
-        let dur = Duration::new(2, 700_000_000);
-
-        let dur2 = 3.14*dur;
-        assert_eq!(dur2, dur*3.14);
-        assert_eq!(dur2.as_secs(), 8);
-        assert_eq!(dur2.subsec_nanos(), 478_000_000);
-
-        let dur3 = 3.14e5*dur;
-        assert_eq!(dur3, dur*3.14e5);
-        assert_eq!(dur3.as_secs(), 847_800);
-        assert_eq!(dur3.subsec_nanos(), 0);
-
-        let dur4 = dur/3.14;
-        assert_eq!(dur4.as_secs(), 0);
-        assert_eq!(dur4.subsec_nanos(), 859_872_611);
-
-        let dur5 = dur/3.14e5;
-        assert_eq!(dur5.as_secs(), 0);
-        // we are using truncation and not rounding
-        assert_eq!(dur5.subsec_nanos(), 8598);
-
-        assert_eq!(dur/Duration::new(5, 400_000_000), 0.5);
-    }
 }


### PR DESCRIPTION
Successor of #52556.

This PR adds the following `impl`s:
- `impl Mul<Duration> for u32` (to allow `10*SECOND` in addition to `SECOND*10`)
- `impl Mul<f64> for Duration` (to allow `2.5*SECOND` vs `2*SECOND + 500*MILLISECOND`)
- `impl Mul<Duration> for f64`
- `impl MulAssign<f64> for Duration`
- `impl Div<f64> for Duration`
- `impl DivAssign<f64> for Duration`
- `impl Div<Duration> for Duration` (`Output = f64`, can be useful e.g. for `duration/MINUTE`)

`f64` is chosen over `f32` to minimize rounding errors. (52 bits fraction precision vs `Duration`'s ~94 bit)