### PR TITLE
[DO NOT MERGE] break codegen test

### DIFF
--- a/src/test/codegen/function-arguments.rs
+++ b/src/test/codegen/function-arguments.rs
@@ -126,7 +126,7 @@ pub fn str(_: &[u8]) {
 pub fn trait_borrow(_: &Drop) {
 }
 
-// CHECK: @trait_box({}* noalias nonnull, {}* noalias nonnull readonly)
+// CHECK: @trait_box({}* noalias nonnull, {}* noalias readonly)
 #[no_mangle]
 pub fn trait_box(_: Box<Drop>) {
 }


### PR DESCRIPTION
This is just to see if I can reproduce the problem I noticed in https://github.com/rust-lang/rust/pull/51361 where a codegen test was failing for pre-bors CI did not catch it.