### PR TITLE
[NLL] Fix some things for bootstrap

### DIFF
--- a/src/libfmt_macros/lib.rs
+++ b/src/libfmt_macros/lib.rs
@@ -168,7 +168,7 @@ impl<'a> Iterator for Parser<'a> {
                     if self.consume('{') {
                         Some(String(self.string(pos + 1)))
                     } else {
-                        let mut arg = self.argument();
+                        let arg = self.argument();
                         if let Some(arg_pos) = self.must_consume('}').map(|end| {
                             (pos + raw + 1, end + raw + 2)
                         }) {

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -2814,7 +2814,7 @@ impl<'a> LoweringContext<'a> {
                 let mut defs = self.expect_full_def_from_use(id);
                 // we want to return *something* from this function, so hang onto the first item
                 // for later
-                let mut ret_def = defs.next().unwrap_or(Def::Err);
+                let ret_def = defs.next().unwrap_or(Def::Err);
 
                 for (def, &new_node_id) in defs.zip([id1, id2].iter()) {
                     let vis = vis.clone();

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -1054,7 +1054,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
             // found arguments is empty (assume the user just wants to ignore args in this case).
             // For example, if `expected_args_length` is 2, suggest `|_, _|`.
             if found_args.is_empty() && is_closure {
-                let mut underscores = "_".repeat(expected_args.len())
+                let underscores = "_".repeat(expected_args.len())
                                       .split("")
                                       .filter(|s| !s.is_empty())
                                       .collect::<Vec<_>>()

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -354,7 +354,7 @@ impl PrintContext {
                 };
                 if has_default {
                     if let Some(substs) = tcx.lift(&substs) {
-                        let mut types = substs.types().rev().skip(child_types);
+                        let types = substs.types().rev().skip(child_types);
                         for ((def_id, has_default), actual) in type_params.zip(types) {
                             if !has_default {
                                 break;

--- a/src/librustc_data_structures/sorted_map.rs
+++ b/src/librustc_data_structures/sorted_map.rs
@@ -56,7 +56,7 @@ impl<K: Ord, V> SortedMap<K, V> {
     pub fn insert(&mut self, key: K, mut value: V) -> Option<V> {
         match self.lookup_index_for(&key) {
             Ok(index) => {
-                let mut slot = unsafe {
+                let slot = unsafe {
                     self.data.get_unchecked_mut(index)
                 };
                 mem::swap(&mut slot.1, &mut value);

--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -146,7 +146,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedResults {
         fn check_must_use(cx: &LateContext, def_id: DefId, sp: Span, describe_path: &str) -> bool {
             for attr in cx.tcx.get_attrs(def_id).iter() {
                 if attr.check_name("must_use") {
-                    let mut msg = format!("unused {}`{}` which must be used",
+                    let msg = format!("unused {}`{}` which must be used",
                                           describe_path, cx.tcx.item_path_str(def_id));
                     let mut err = cx.struct_span_lint(UNUSED_MUST_USE, sp, &msg);
                     // check for #[must_use = "..."]

--- a/src/librustc_mir/borrow_check/nll/constraints/graph.rs
+++ b/src/librustc_mir/borrow_check/nll/constraints/graph.rs
@@ -28,8 +28,8 @@ impl ConstraintGraph {
         let mut next_constraints = IndexVec::from_elem(None, &set.constraints);
 
         for (idx, constraint) in set.constraints.iter_enumerated().rev() {
-            let mut head = &mut first_constraints[constraint.sup];
-            let mut next = &mut next_constraints[idx];
+            let head = &mut first_constraints[constraint.sup];
+            let next = &mut next_constraints[idx];
             debug_assert!(next.is_none());
             *next = *head;
             *head = Some(idx);

--- a/src/librustc_mir/build/matches/test.rs
+++ b/src/librustc_mir/build/matches/test.rs
@@ -259,7 +259,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
             }
 
             TestKind::Eq { value, mut ty } => {
-                let mut val = Operand::Copy(place.clone());
+                let val = Operand::Copy(place.clone());
                 let mut expect = self.literal_operand(test.span, ty, value);
                 // Use PartialEq::eq instead of BinOp::Eq
                 // (the binop can only handle primitives)

--- a/src/librustc_mir/monomorphize/partitioning.rs
+++ b/src/librustc_mir/monomorphize/partitioning.rs
@@ -353,7 +353,7 @@ fn place_root_mono_items<'a, 'tcx, I>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                 Visibility::Hidden
             }
         };
-        let (linkage, mut visibility) = match mono_item.explicit_linkage(tcx) {
+        let (linkage, visibility) = match mono_item.explicit_linkage(tcx) {
             Some(explicit_linkage) => (explicit_linkage, Visibility::Default),
             None => {
                 match mono_item {

--- a/src/librustc_mir/transform/promote_consts.rs
+++ b/src/librustc_mir/transform/promote_consts.rs
@@ -390,7 +390,7 @@ pub fn promote_candidates<'a, 'tcx>(mir: &mut Mir<'tcx>,
             LocalDecl::new_return_place(tcx.types.never, mir.span)
         ).collect();
 
-        let mut promoter = Promoter {
+        let promoter = Promoter {
             promoted: Mir::new(
                 IndexVec::new(),
                 // FIXME: maybe try to filter this to avoid blowing up

--- a/src/librustc_passes/rvalue_promotion.rs
+++ b/src/librustc_passes/rvalue_promotion.rs
@@ -248,7 +248,8 @@ impl<'a, 'tcx> CheckCrateVisitor<'a, 'tcx> {
         let tcx = self.tcx;
         let param_env = self.param_env;
         let region_scope_tree = self.tcx.region_scope_tree(item_def_id);
-        euv::ExprUseVisitor::new(self, tcx, param_env, &region_scope_tree, self.tables, None)
+        let tables = self.tables;
+        euv::ExprUseVisitor::new(self, tcx, param_env, &region_scope_tree, tables, None)
             .consume_body(body);
 
         let body_promotable = self.check_expr(&body.value);

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -865,7 +865,7 @@ impl<'a, 'b:'a> ImportResolver<'a, 'b> {
         // this may resolve to either a value or a type, but for documentation
         // purposes it's good enough to just favor one over the other.
         self.per_ns(|this, ns| if let Some(binding) = result[ns].get().ok() {
-            let mut import = this.import_map.entry(directive.id).or_default();
+            let import = this.import_map.entry(directive.id).or_default();
             import[ns] = Some(PathResolution::new(binding.def()));
         });
 

--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -423,7 +423,7 @@ impl<'l, 'tcx: 'l> SaveContext<'l, 'tcx> {
                             let mut qualname = String::from("<");
                             qualname.push_str(&self.tcx.hir.node_to_pretty_string(ty.id));
 
-                            let mut trait_id = self.tcx.trait_id_of_impl(impl_id);
+                            let trait_id = self.tcx.trait_id_of_impl(impl_id);
                             let mut decl_id = None;
                             let mut docs = String::new();
                             let mut attrs = vec![];

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1172,7 +1172,7 @@ fn resolve(cx: &DocContext, path_str: &str, is_val: bool) -> Result<(Def, Option
 
         // Try looking for methods and associated items
         let mut split = path_str.rsplitn(2, "::");
-        let mut item_name = if let Some(first) = split.next() {
+        let item_name = if let Some(first) = split.next() {
             first
         } else {
             return Err(())


### PR DESCRIPTION
Some changes that are required when bootstrapping rustc with NLL enabled.

* Remove a bunch of unused `mut`s that aren't needed, but the existing lint doesn't catch.
* Rewrite a function call to satisfy NLL borrowck. Note that the borrow is two-phase, but gets activated immediately by an unsizing coercion.

cc #51823