### PR TITLE
remove references to AUTHORS.txt file

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -10,8 +10,8 @@ Copyrights in the Rust project are retained by their contributors. No
 copyright assignment is required to contribute to the Rust project.
 
 Some files include explicit copyright notices and/or license notices.
-For full authorship information, see AUTHORS.txt and the version control
-history.
+For full authorship information, see the version control history or
+https://thanks.rust-lang.org
 
 Except as otherwise noted (below and/or in individual files), Rust is
 licensed under the Apache License, Version 2.0 <LICENSE-APACHE> or

--- a/src/doc/man/rustdoc.1
+++ b/src/doc/man/rustdoc.1
@@ -119,7 +119,7 @@ See <\fBhttps://github.com/rust\-lang/rust/issues\fR>
 for issues.
 
 .SH "AUTHOR"
-See \fIAUTHORS.txt\fR in the Rust source distribution.
+See the version control history or <\fBhttps://thanks.rust\-lang.org\fR>
 
 .SH "COPYRIGHT"
 This work is dual\[hy]licensed under Apache\ 2.0 and MIT terms.


### PR DESCRIPTION
Rust does not ship an AUTHORS.txt file anymore.