### PR TITLE
Add timeout to use of `curl` in bootstrap.py.

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -88,7 +88,10 @@ def _download(path, url, probably_big, verbose, exception):
             option = "-#"
         else:
             option = "-s"
-        run(["curl", option, "--retry", "3", "-Sf", "-o", path, url],
+        run(["curl", option,
+             "-y", "30", "-Y", "10",    # timeout if speed is < 10 bytes/sec for > 30 seconds
+             "--connect-timeout", "30", # timeout if cannot connect within 30 seconds
+             "--retry", "3", "-Sf", "-o", path, url],
             verbose=verbose,
             exception=exception)
 


### PR DESCRIPTION
Recently we've seen a lot of "30 minutes no output" spurious errors while downloading the bootstrap compiler. This added several timeout options so if the "30 minutes no output" errors were caused by connection or transfer issue, we could fail quicker for curl to retry.