### PR TITLE
Revert "Stabilize to_bytes and from_bytes for integers."

### DIFF
--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -1903,10 +1903,12 @@ $EndFeature, "
         /// # Examples
         ///
         /// ```
+        /// #![feature(int_to_from_bytes)]
+        ///
         /// let bytes = i32::min_value().to_be().to_bytes();
         /// assert_eq!(bytes, [0x80, 0, 0, 0]);
         /// ```
-        #[stable(feature = "int_to_from_bytes", since = "1.29.0")]
+        #[unstable(feature = "int_to_from_bytes", issue = "49792")]
         #[inline]
         pub fn to_bytes(self) -> [u8; mem::size_of::<Self>()] {
             unsafe { mem::transmute(self) }
@@ -1923,10 +1925,12 @@ $EndFeature, "
         /// # Examples
         ///
         /// ```
+        /// #![feature(int_to_from_bytes)]
+        ///
         /// let int = i32::from_be(i32::from_bytes([0x80, 0, 0, 0]));
         /// assert_eq!(int, i32::min_value());
         /// ```
-        #[stable(feature = "int_to_from_bytes", since = "1.29.0")]
+        #[unstable(feature = "int_to_from_bytes", issue = "49792")]
         #[inline]
         pub fn from_bytes(bytes: [u8; mem::size_of::<Self>()]) -> Self {
             unsafe { mem::transmute(bytes) }
@@ -3508,10 +3512,12 @@ $EndFeature, "
         /// # Examples
         ///
         /// ```
+        /// #![feature(int_to_from_bytes)]
+        ///
         /// let bytes = 0x1234_5678_u32.to_be().to_bytes();
         /// assert_eq!(bytes, [0x12, 0x34, 0x56, 0x78]);
         /// ```
-        #[stable(feature = "int_to_from_bytes", since = "1.29.0")]
+        #[unstable(feature = "int_to_from_bytes", issue = "49792")]
         #[inline]
         pub fn to_bytes(self) -> [u8; mem::size_of::<Self>()] {
             unsafe { mem::transmute(self) }
@@ -3528,10 +3534,12 @@ $EndFeature, "
         /// # Examples
         ///
         /// ```
+        /// #![feature(int_to_from_bytes)]
+        ///
         /// let int = u32::from_be(u32::from_bytes([0x12, 0x34, 0x56, 0x78]));
         /// assert_eq!(int, 0x1234_5678_u32);
         /// ```
-        #[stable(feature = "int_to_from_bytes", since = "1.29.0")]
+        #[unstable(feature = "int_to_from_bytes", issue = "49792")]
         #[inline]
         pub fn from_bytes(bytes: [u8; mem::size_of::<Self>()]) -> Self {
             unsafe { mem::transmute(bytes) }


### PR DESCRIPTION
This reverts commit c8f9b84b393915a48253e3edc862c15a9b7152a7 / PR https://github.com/rust-lang/rust/pull/51835, and reopens the tracking issue https://github.com/rust-lang/rust/issues/49792.

These methods were stabilized in Rust 1.29, which is still in Nightly as of this writing. So my understanding is that it is still time to change our minds. Given the ongoing discussion in https://github.com/rust-lang/rust/pull/51919 about possibly renaming these APIs and since 1.29 goes to beta soon, I’d like to revert this stabilization for now until a decision is made in that PR. It’s possible that a decision will be made in time for 1.29, but there is no urgency. At most I expect this functionality to make it into 1.30.