### PR TITLE
cleanup: Remove `Def::GlobalAsm`

### DIFF
--- a/src/librustc/hir/def.rs
+++ b/src/librustc/hir/def.rs
@@ -70,8 +70,6 @@ pub enum Def {
     Macro(DefId, MacroKind),
     NonMacroAttr, // e.g. `#[inline]` or `#[rustfmt::skip]`
 
-    GlobalAsm(DefId),
-
     // Both namespaces
     Err,
 }
@@ -251,8 +249,7 @@ impl Def {
             Def::AssociatedTy(id) | Def::TyParam(id) | Def::Struct(id) | Def::StructCtor(id, ..) |
             Def::Union(id) | Def::Trait(id) | Def::Method(id) | Def::Const(id) |
             Def::AssociatedConst(id) | Def::Macro(id, ..) |
-            Def::Existential(id) | Def::AssociatedExistential(id) |
-            Def::GlobalAsm(id) | Def::TyForeign(id) => {
+            Def::Existential(id) | Def::AssociatedExistential(id) | Def::TyForeign(id) => {
                 id
             }
 
@@ -302,7 +299,6 @@ impl Def {
             Def::Label(..) => "label",
             Def::SelfTy(..) => "self type",
             Def::Macro(.., macro_kind) => macro_kind.descr(),
-            Def::GlobalAsm(..) => "global asm",
             Def::ToolMod => "tool module",
             Def::NonMacroAttr => "non-macro attribute",
             Def::Err => "unresolved item",

--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -432,7 +432,6 @@ impl<'hir> Map<'hir> {
                     ItemKind::Const(..) => Some(Def::Const(def_id())),
                     ItemKind::Fn(..) => Some(Def::Fn(def_id())),
                     ItemKind::Mod(..) => Some(Def::Mod(def_id())),
-                    ItemKind::GlobalAsm(..) => Some(Def::GlobalAsm(def_id())),
                     ItemKind::Existential(..) => Some(Def::Existential(def_id())),
                     ItemKind::Ty(..) => Some(Def::TyAlias(def_id())),
                     ItemKind::Enum(..) => Some(Def::Enum(def_id())),
@@ -445,6 +444,7 @@ impl<'hir> Map<'hir> {
                     ItemKind::ExternCrate(_) |
                     ItemKind::Use(..) |
                     ItemKind::ForeignMod(..) |
+                    ItemKind::GlobalAsm(..) |
                     ItemKind::Impl(..) => None,
                 }
             }

--- a/src/librustc/ich/impls_hir.rs
+++ b/src/librustc/ich/impls_hir.rs
@@ -1015,7 +1015,6 @@ impl_stable_hash_for!(enum hir::def::Def {
     Upvar(def_id, index, expr_id),
     Label(node_id),
     Macro(def_id, macro_kind),
-    GlobalAsm(def_id),
     ToolMod,
     NonMacroAttr,
     Err

--- a/src/librustc_metadata/decoder.rs
+++ b/src/librustc_metadata/decoder.rs
@@ -427,10 +427,10 @@ impl<'tcx> EntryKind<'tcx> {
             EntryKind::Trait(_) => Def::Trait(did),
             EntryKind::Enum(..) => Def::Enum(did),
             EntryKind::MacroDef(_) => Def::Macro(did, MacroKind::Bang),
-            EntryKind::GlobalAsm => Def::GlobalAsm(did),
             EntryKind::ForeignType => Def::TyForeign(did),
 
             EntryKind::ForeignMod |
+            EntryKind::GlobalAsm |
             EntryKind::Impl(_) |
             EntryKind::Field |
             EntryKind::Generator(_) |

--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -810,7 +810,6 @@ impl<'l, 'tcx: 'l> SaveContext<'l, 'tcx> {
             HirDef::SelfTy(..) |
             HirDef::Label(..) |
             HirDef::Macro(..) |
-            HirDef::GlobalAsm(..) |
             HirDef::ToolMod |
             HirDef::NonMacroAttr |
             HirDef::Err => None,


### PR DESCRIPTION
Global asm is not something that needs to have a `Def` or `DefId`.