### PR TITLE
Disable debug sections when optimization flags is set for LLD.

### DIFF
--- a/src/librustc_codegen_llvm/back/linker.rs
+++ b/src/librustc_codegen_llvm/back/linker.rs
@@ -1006,6 +1006,18 @@ impl<'a> Linker for WasmLd<'a> {
             OptLevel::Size => "-O2",
             OptLevel::SizeMin => "-O2"
         });
+        match self.sess.opts.optimize {
+            OptLevel::No => (),
+            OptLevel::Less |
+            OptLevel::Default |
+            OptLevel::Aggressive |
+            OptLevel::Size |
+            OptLevel::SizeMin => {
+                // LLD generates incorrect debugging information when
+                // optimization is applied: strip debug sections.
+                self.cmd.arg("--strip-debug");
+            }
+        }
     }
 
     fn pgo_gen(&mut self) {


### PR DESCRIPTION
Currently LLD does not error when optimization is set and debugging information sections are present. (See discussion at https://reviews.llvm.org/D47901)

Using `--strip-debug` along with the `-O` option.