### PR TITLE
Reexport tests without polluting namespaces

### DIFF
--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -1376,7 +1376,7 @@ impl<'a, 'b> Folder for InvocationCollector<'a, 'b> {
             // #[test] fn foo() {}
             // becomes:
             // #[test] pub fn foo_gensym(){}
-            // #[allow(dead_code)]
+            // #[allow(unused)]
             // use foo_gensym as foo;
             ast::ItemKind::Fn(..) if self.cx.ecfg.should_test => {
                 if self.tests_nameable && item.attrs.iter().any(|attr| is_test_or_bench(attr)) {
@@ -1398,12 +1398,12 @@ impl<'a, 'b> Folder for InvocationCollector<'a, 'b> {
                         self.cx.path(item.ident.span,
                             vec![keywords::SelfValue.ident(), item.ident]));
 
-                    // #[allow(dead_code)] because the test function probably isn't being referenced
+                    // #[allow(unused)] because the test function probably isn't being referenced
                     use_item = use_item.map(|mut ui| {
                         ui.attrs.push(
                             self.cx.attribute(DUMMY_SP, attr::mk_list_item(DUMMY_SP,
                                 Ident::from_str("allow"), vec![
-                                    attr::mk_nested_word_item(Ident::from_str("dead_code"))
+                                    attr::mk_nested_word_item(Ident::from_str("unused"))
                                 ]
                             ))
                         );

--- a/src/test/run-pass/issue-52557.rs
+++ b/src/test/run-pass/issue-52557.rs
@@ -22,12 +22,17 @@ mod a {
 
 mod b {
     #[test]
-    fn foo() {}
+    fn foo() {
+        local_name(); // ensure the local name still works
+    }
+
+    #[test]
+    fn local_name() {}
 }
 
 use a::*;
 use b::*;
 
-fn conflict() {
+pub fn conflict() {
     let _: bool = foo();
 }

--- a/src/test/run-pass/issue-52557.rs
+++ b/src/test/run-pass/issue-52557.rs
@@ -1,0 +1,33 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This test checks for namespace pollution by private tests.
+// Tests used to marked as public causing name conflicts with normal
+// functions only in test builds.
+
+// compile-flags: --test
+
+mod a {
+    pub fn foo() -> bool {
+        true
+    }
+}
+
+mod b {
+    #[test]
+    fn foo() {}
+}
+
+use a::*;
+use b::*;
+
+fn conflict() {
+    let _: bool = foo();
+}


### PR DESCRIPTION
This should fix issue #52557.

Basically now we gensym a new name for the test function and reexport that.
That way the test function's reexport name can't conflict because it was impossible for the test author to write it down.
We then use a `use` statement to expose the original name using the original visibility.