### PR TITLE
NLL: sort diagnostics by span

### DIFF
--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -331,9 +331,7 @@ fn do_mir_borrowck<'a, 'gcx, 'tcx>(
     }
 
     if mbcx.errors_buffer.len() > 0 {
-        mbcx.errors_buffer.sort_by(|diag1, diag2| {
-            diag1.span.primary_span().cmp(&diag2.span.primary_span())
-        });
+        mbcx.errors_buffer.sort_by_key(|diag| diag.span.primary_span());
 
         if tcx.migrate_borrowck() {
             match tcx.borrowck(def_id).signalled_any_error {

--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -331,6 +331,10 @@ fn do_mir_borrowck<'a, 'gcx, 'tcx>(
     }
 
     if mbcx.errors_buffer.len() > 0 {
+        mbcx.errors_buffer.sort_by(|diag1, diag2| {
+            diag1.span.primary_span().cmp(&diag2.span.primary_span())
+        });
+
         if tcx.migrate_borrowck() {
             match tcx.borrowck(def_id).signalled_any_error {
                 SignalledError::NoErrorsSeen => {

--- a/src/test/ui/borrowck/issue-41962.stderr
+++ b/src/test/ui/borrowck/issue-41962.stderr
@@ -17,6 +17,25 @@ LL |         if let Some(thing) = maybe {
    = note: move occurs because the value has type `std::vec::Vec<bool>`, which does not implement the `Copy` trait
 
 error[E0382]: use of moved value: `maybe` (Mir)
+  --> $DIR/issue-41962.rs:17:16
+   |
+LL |         if let Some(thing) = maybe {
+   |                ^^^^^-----^
+   |                |    |
+   |                |    value moved here
+   |                value used here after move
+   |
+   = note: move occurs because value has type `std::vec::Vec<bool>`, which does not implement the `Copy` trait
+
+error[E0382]: use of moved value (Mir)
+  --> $DIR/issue-41962.rs:17:21
+   |
+LL |         if let Some(thing) = maybe {
+   |                     ^^^^^ value moved here in previous iteration of loop
+   |
+   = note: move occurs because value has type `std::vec::Vec<bool>`, which does not implement the `Copy` trait
+
+error[E0382]: use of moved value: `maybe` (Mir)
   --> $DIR/issue-41962.rs:17:30
    |
 LL |         if let Some(thing) = maybe {
@@ -33,25 +52,6 @@ LL |         if let Some(thing) = maybe {
    |                     -----    ^^^^^ value borrowed here after move
    |                     |
    |                     value moved here
-   |
-   = note: move occurs because value has type `std::vec::Vec<bool>`, which does not implement the `Copy` trait
-
-error[E0382]: use of moved value: `maybe` (Mir)
-  --> $DIR/issue-41962.rs:17:16
-   |
-LL |         if let Some(thing) = maybe {
-   |                ^^^^^-----^
-   |                |    |
-   |                |    value moved here
-   |                value used here after move
-   |
-   = note: move occurs because value has type `std::vec::Vec<bool>`, which does not implement the `Copy` trait
-
-error[E0382]: use of moved value (Mir)
-  --> $DIR/issue-41962.rs:17:21
-   |
-LL |         if let Some(thing) = maybe {
-   |                     ^^^^^ value moved here in previous iteration of loop
    |
    = note: move occurs because value has type `std::vec::Vec<bool>`, which does not implement the `Copy` trait
 

--- a/src/test/ui/borrowck/two-phase-multi-mut.stderr
+++ b/src/test/ui/borrowck/two-phase-multi-mut.stderr
@@ -1,14 +1,4 @@
 error[E0499]: cannot borrow `foo` as mutable more than once at a time
-  --> $DIR/two-phase-multi-mut.rs:23:16
-   |
-LL |     foo.method(&mut foo);
-   |     -----------^^^^^^^^-
-   |     |          |
-   |     |          second mutable borrow occurs here
-   |     first mutable borrow occurs here
-   |     borrow later used here
-
-error[E0499]: cannot borrow `foo` as mutable more than once at a time
   --> $DIR/two-phase-multi-mut.rs:23:5
    |
 LL |     foo.method(&mut foo);
@@ -16,6 +6,16 @@ LL |     foo.method(&mut foo);
    |     |          |
    |     |          first mutable borrow occurs here
    |     second mutable borrow occurs here
+   |     borrow later used here
+
+error[E0499]: cannot borrow `foo` as mutable more than once at a time
+  --> $DIR/two-phase-multi-mut.rs:23:16
+   |
+LL |     foo.method(&mut foo);
+   |     -----------^^^^^^^^-
+   |     |          |
+   |     |          second mutable borrow occurs here
+   |     first mutable borrow occurs here
    |     borrow later used here
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/hygiene/fields-move.nll.stderr
+++ b/src/test/ui/hygiene/fields-move.nll.stderr
@@ -1,15 +1,4 @@
 error[E0382]: use of moved value: `foo.x`
-  --> $DIR/fields-move.rs:38:42
-   |
-LL |    $foo.x
-   |    ------ value moved here
-...
-LL |     assert_two_copies(copy_modern!(foo), foo.x); //~ ERROR use of moved value: `foo.x`
-   |                                          ^^^^^ value used here after move
-   |
-   = note: move occurs because `foo.x` has type `NonCopy`, which does not implement the `Copy` trait
-
-error[E0382]: use of moved value: `foo.x`
   --> $DIR/fields-move.rs:28:9
    |
 LL |    $foo.x
@@ -22,6 +11,17 @@ LL |     assert_two_copies(copy_modern!(foo), foo.x); //~ ERROR use of moved val
    |                                          ----- value moved here
 LL |     assert_two_copies(copy_legacy!(foo), foo.x); //~ ERROR use of moved value: `foo.x`
    |                       ----------------- in this macro invocation
+   |
+   = note: move occurs because `foo.x` has type `NonCopy`, which does not implement the `Copy` trait
+
+error[E0382]: use of moved value: `foo.x`
+  --> $DIR/fields-move.rs:38:42
+   |
+LL |    $foo.x
+   |    ------ value moved here
+...
+LL |     assert_two_copies(copy_modern!(foo), foo.x); //~ ERROR use of moved value: `foo.x`
+   |                                          ^^^^^ value used here after move
    |
    = note: move occurs because `foo.x` has type `NonCopy`, which does not implement the `Copy` trait
 

--- a/src/test/ui/issue-27592.nll.stderr
+++ b/src/test/ui/issue-27592.nll.stderr
@@ -1,18 +1,18 @@
 error[E0597]: borrowed value does not live long enough
-  --> $DIR/issue-27592.rs:26:33
-   |
-LL |     write(|| format_args!("{}", String::from("Hello world")));
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^- temporary value only lives until here
-   |                                 |
-   |                                 temporary value does not live long enough
-
-error[E0597]: borrowed value does not live long enough
   --> $DIR/issue-27592.rs:26:27
    |
 LL |     write(|| format_args!("{}", String::from("Hello world")));
    |                           ^^^^                             - temporary value only lives until here
    |                           |
    |                           temporary value does not live long enough
+
+error[E0597]: borrowed value does not live long enough
+  --> $DIR/issue-27592.rs:26:33
+   |
+LL |     write(|| format_args!("{}", String::from("Hello world")));
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^- temporary value only lives until here
+   |                                 |
+   |                                 temporary value does not live long enough
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/nll/closure-requirements/escape-argument-callee.stderr
+++ b/src/test/ui/nll/closure-requirements/escape-argument-callee.stderr
@@ -4,15 +4,6 @@ warning: not reporting region error due to nll
 LL |         let mut closure = expect_sig(|p, y| *p = y);
    |                                                  ^
 
-error: unsatisfied lifetime constraints
-  --> $DIR/escape-argument-callee.rs:36:45
-   |
-LL |         let mut closure = expect_sig(|p, y| *p = y);
-   |                                       -  -  ^^^^^^ requires that `'1` must outlive `'2`
-   |                                       |  |
-   |                                       |  has type `&'1 i32`
-   |                                       has type `&mut &'2 i32`
-
 note: No external requirements
   --> $DIR/escape-argument-callee.rs:36:38
    |
@@ -23,6 +14,15 @@ LL |         let mut closure = expect_sig(|p, y| *p = y);
                i16,
                for<'r, 's, 't0> extern "rust-call" fn((&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0:0), 'r)) mut &ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0:0), 's)) i32, &ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0:0), 't0)) i32))
            ]
+
+error: unsatisfied lifetime constraints
+  --> $DIR/escape-argument-callee.rs:36:45
+   |
+LL |         let mut closure = expect_sig(|p, y| *p = y);
+   |                                       -  -  ^^^^^^ requires that `'1` must outlive `'2`
+   |                                       |  |
+   |                                       |  has type `&'1 i32`
+   |                                       has type `&mut &'2 i32`
 
 note: No external requirements
   --> $DIR/escape-argument-callee.rs:30:1

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-fail-no-postdom.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-fail-no-postdom.stderr
@@ -4,17 +4,6 @@ warning: not reporting region error due to nll
 LL |             let p = x.get();
    |                     ^^^^^^^
 
-error: unsatisfied lifetime constraints
-  --> $DIR/propagate-approximated-fail-no-postdom.rs:57:13
-   |
-LL |         |_outlives1, _outlives2, _outlives3, x, y| {
-   |          ----------              ---------- has type `std::cell::Cell<&'2 &u32>`
-   |          |
-   |          has type `std::cell::Cell<&&'1 u32>`
-...
-LL |             demand_y(x, y, p) //~ ERROR
-   |             ^^^^^^^^^^^^^^^^^ argument requires that `'1` must outlive `'2`
-
 note: No external requirements
   --> $DIR/propagate-approximated-fail-no-postdom.rs:53:9
    |
@@ -30,6 +19,17 @@ LL | |         },
                i16,
                for<'r, 's> extern "rust-call" fn((std::cell::Cell<&'_#1r &ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0:0), 'r)) u32>, std::cell::Cell<&'_#2r &ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0:0), 'r)) u32>, std::cell::Cell<&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0:0), 's)) &'_#3r u32>, std::cell::Cell<&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0:0), 'r)) u32>, std::cell::Cell<&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0:0), 's)) u32>))
            ]
+
+error: unsatisfied lifetime constraints
+  --> $DIR/propagate-approximated-fail-no-postdom.rs:57:13
+   |
+LL |         |_outlives1, _outlives2, _outlives3, x, y| {
+   |          ----------              ---------- has type `std::cell::Cell<&'2 &u32>`
+   |          |
+   |          has type `std::cell::Cell<&&'1 u32>`
+...
+LL |             demand_y(x, y, p) //~ ERROR
+   |             ^^^^^^^^^^^^^^^^^ argument requires that `'1` must outlive `'2`
 
 note: No external requirements
   --> $DIR/propagate-approximated-fail-no-postdom.rs:48:1

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
@@ -4,17 +4,6 @@ warning: not reporting region error due to nll
 LL |     foo(cell, |cell_a, cell_x| {
    |     ^^^
 
-error: borrowed data escapes outside of closure
-  --> $DIR/propagate-approximated-shorter-to-static-comparing-against-free.rs:33:9
-   |
-LL |     foo(cell, |cell_a, cell_x| {
-   |                ------  ------ `cell_x` is a reference that is only valid in the closure body
-   |                |
-   |                `cell_a` is declared here, outside of the closure body
-LL |         //~^ WARNING not reporting region error due to nll
-LL |         cell_a.set(cell_x.get()); // forces 'x: 'a, error in closure
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^ `cell_x` escapes the closure body here
-
 note: No external requirements
   --> $DIR/propagate-approximated-shorter-to-static-comparing-against-free.rs:31:15
    |
@@ -30,6 +19,17 @@ LL | |     })
                i32,
                for<'r> extern "rust-call" fn((std::cell::Cell<&'_#1r u32>, std::cell::Cell<&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0:0), 'r)) u32>))
            ]
+
+error: borrowed data escapes outside of closure
+  --> $DIR/propagate-approximated-shorter-to-static-comparing-against-free.rs:33:9
+   |
+LL |     foo(cell, |cell_a, cell_x| {
+   |                ------  ------ `cell_x` is a reference that is only valid in the closure body
+   |                |
+   |                `cell_a` is declared here, outside of the closure body
+LL |         //~^ WARNING not reporting region error due to nll
+LL |         cell_a.set(cell_x.get()); // forces 'x: 'a, error in closure
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^ `cell_x` escapes the closure body here
 
 note: No external requirements
   --> $DIR/propagate-approximated-shorter-to-static-comparing-against-free.rs:28:1

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-no-bound.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-no-bound.stderr
@@ -23,19 +23,6 @@ LL | |     });
    = note: number of external vids: 4
    = note: where '_#1r: '_#0r
 
-error: borrowed data escapes outside of function
-  --> $DIR/propagate-approximated-shorter-to-static-no-bound.rs:45:5
-   |
-LL |   fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
-   |                     ------ `cell_a` is a reference that is only valid in the function body
-LL | /     establish_relationships(&cell_a, &cell_b, |_outlives, x, y| {
-LL | |         //~^ ERROR
-LL | |
-LL | |         // Only works if 'x: 'y:
-LL | |         demand_y(x, y, x.get()) //~ WARNING not reporting region error due to nll
-LL | |     });
-   | |______^ `cell_a` escapes the function body here
-
 note: No external requirements
   --> $DIR/propagate-approximated-shorter-to-static-no-bound.rs:44:1
    |
@@ -49,6 +36,19 @@ LL | | }
    | |_^
    |
    = note: defining type: DefId(0/0:6 ~ propagate_approximated_shorter_to_static_no_bound[317d]::supply[0]) with substs []
+
+error: borrowed data escapes outside of function
+  --> $DIR/propagate-approximated-shorter-to-static-no-bound.rs:45:5
+   |
+LL |   fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
+   |                     ------ `cell_a` is a reference that is only valid in the function body
+LL | /     establish_relationships(&cell_a, &cell_b, |_outlives, x, y| {
+LL | |         //~^ ERROR
+LL | |
+LL | |         // Only works if 'x: 'y:
+LL | |         demand_y(x, y, x.get()) //~ WARNING not reporting region error due to nll
+LL | |     });
+   | |______^ `cell_a` escapes the function body here
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-wrong-bound.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-wrong-bound.stderr
@@ -23,19 +23,6 @@ LL | |     });
    = note: number of external vids: 5
    = note: where '_#1r: '_#0r
 
-error: borrowed data escapes outside of function
-  --> $DIR/propagate-approximated-shorter-to-static-wrong-bound.rs:48:5
-   |
-LL |   fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
-   |                     ------ `cell_a` is a reference that is only valid in the function body
-LL | /     establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y| {
-LL | |         //~^ ERROR
-LL | |         // Only works if 'x: 'y:
-LL | |         demand_y(x, y, x.get())
-LL | |         //~^ WARNING not reporting region error due to nll
-LL | |     });
-   | |______^ `cell_a` escapes the function body here
-
 note: No external requirements
   --> $DIR/propagate-approximated-shorter-to-static-wrong-bound.rs:47:1
    |
@@ -49,6 +36,19 @@ LL | | }
    | |_^
    |
    = note: defining type: DefId(0/0:6 ~ propagate_approximated_shorter_to_static_wrong_bound[317d]::supply[0]) with substs []
+
+error: borrowed data escapes outside of function
+  --> $DIR/propagate-approximated-shorter-to-static-wrong-bound.rs:48:5
+   |
+LL |   fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
+   |                     ------ `cell_a` is a reference that is only valid in the function body
+LL | /     establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y| {
+LL | |         //~^ ERROR
+LL | |         // Only works if 'x: 'y:
+LL | |         demand_y(x, y, x.get())
+LL | |         //~^ WARNING not reporting region error due to nll
+LL | |     });
+   | |______^ `cell_a` escapes the function body here
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-no-bounds.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-no-bounds.stderr
@@ -4,17 +4,6 @@ warning: not reporting region error due to nll
 LL |         demand_y(x, y, x.get())
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
-error: unsatisfied lifetime constraints
-  --> $DIR/propagate-fail-to-approximate-longer-no-bounds.rs:47:9
-   |
-LL |     establish_relationships(&cell_a, &cell_b, |_outlives, x, y| {
-   |                                                ---------  - has type `&std::cell::Cell<&'1 u32>`
-   |                                                |
-   |                                                has type `&std::cell::Cell<&'2 &u32>`
-LL |         // Only works if 'x: 'y:
-LL |         demand_y(x, y, x.get())
-   |         ^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'1` must outlive `'2`
-
 note: No external requirements
   --> $DIR/propagate-fail-to-approximate-longer-no-bounds.rs:45:47
    |
@@ -31,6 +20,17 @@ LL | |     });
                i16,
                for<'r, 's, 't0, 't1, 't2> extern "rust-call" fn((&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0:0), 'r)) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0:0), 's)) &'_#1r u32>, &ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0:0), 't0)) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0:0), 't1)) u32>, &ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0:0), 't2)) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0:0), 's)) u32>))
            ]
+
+error: unsatisfied lifetime constraints
+  --> $DIR/propagate-fail-to-approximate-longer-no-bounds.rs:47:9
+   |
+LL |     establish_relationships(&cell_a, &cell_b, |_outlives, x, y| {
+   |                                                ---------  - has type `&std::cell::Cell<&'1 u32>`
+   |                                                |
+   |                                                has type `&std::cell::Cell<&'2 &u32>`
+LL |         // Only works if 'x: 'y:
+LL |         demand_y(x, y, x.get())
+   |         ^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'1` must outlive `'2`
 
 note: No external requirements
   --> $DIR/propagate-fail-to-approximate-longer-no-bounds.rs:44:1

--- a/src/test/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-wrong-bounds.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-wrong-bounds.stderr
@@ -4,17 +4,6 @@ warning: not reporting region error due to nll
 LL |         demand_y(x, y, x.get())
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
-error: unsatisfied lifetime constraints
-  --> $DIR/propagate-fail-to-approximate-longer-wrong-bounds.rs:51:9
-   |
-LL |     establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y| {
-   |                                                ----------  ---------- has type `&std::cell::Cell<&'2 &u32>`
-   |                                                |
-   |                                                has type `&std::cell::Cell<&'1 &u32>`
-LL |         // Only works if 'x: 'y:
-LL |         demand_y(x, y, x.get())
-   |         ^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'1` must outlive `'2`
-
 note: No external requirements
   --> $DIR/propagate-fail-to-approximate-longer-wrong-bounds.rs:49:47
    |
@@ -31,6 +20,17 @@ LL | |     });
                i16,
                for<'r, 's, 't0, 't1, 't2, 't3> extern "rust-call" fn((&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0:0), 'r)) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0:0), 's)) &'_#1r u32>, &ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0:0), 't0)) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0:0), 't1)) &'_#2r u32>, &ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0:0), 't2)) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0:0), 's)) u32>, &ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0:0), 't3)) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0:0), 't1)) u32>))
            ]
+
+error: unsatisfied lifetime constraints
+  --> $DIR/propagate-fail-to-approximate-longer-wrong-bounds.rs:51:9
+   |
+LL |     establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y| {
+   |                                                ----------  ---------- has type `&std::cell::Cell<&'2 &u32>`
+   |                                                |
+   |                                                has type `&std::cell::Cell<&'1 &u32>`
+LL |         // Only works if 'x: 'y:
+LL |         demand_y(x, y, x.get())
+   |         ^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'1` must outlive `'2`
 
 note: No external requirements
   --> $DIR/propagate-fail-to-approximate-longer-wrong-bounds.rs:48:1

--- a/src/test/ui/nll/closure-requirements/propagate-from-trait-match.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-from-trait-match.stderr
@@ -26,21 +26,6 @@ LL | |     });
    = note: number of external vids: 3
    = note: where T: '_#1r
 
-error[E0309]: the parameter type `T` may not live long enough
-  --> $DIR/propagate-from-trait-match.rs:42:36
-   |
-LL |       establish_relationships(value, |value| {
-   |  ____________________________________^
-LL | |         //~^ ERROR the parameter type `T` may not live long enough
-LL | |
-LL | |         // This function call requires that
-...  |
-LL | |         //~^ WARNING not reporting region error due to nll
-LL | |     });
-   | |_____^
-   |
-   = help: consider adding an explicit lifetime bound `T: ReEarlyBound(0, 'a)`...
-
 note: No external requirements
   --> $DIR/propagate-from-trait-match.rs:38:1
    |
@@ -57,6 +42,21 @@ LL | | }
                '_#1r,
                T
            ]
+
+error[E0309]: the parameter type `T` may not live long enough
+  --> $DIR/propagate-from-trait-match.rs:42:36
+   |
+LL |       establish_relationships(value, |value| {
+   |  ____________________________________^
+LL | |         //~^ ERROR the parameter type `T` may not live long enough
+LL | |
+LL | |         // This function call requires that
+...  |
+LL | |         //~^ WARNING not reporting region error due to nll
+LL | |     });
+   | |_____^
+   |
+   = help: consider adding an explicit lifetime bound `T: ReEarlyBound(0, 'a)`...
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/closure-requirements/return-wrong-bound-region.stderr
+++ b/src/test/ui/nll/closure-requirements/return-wrong-bound-region.stderr
@@ -4,15 +4,6 @@ warning: not reporting region error due to nll
 LL |     expect_sig(|a, b| b); // ought to return `a`
    |                       ^
 
-error: unsatisfied lifetime constraints
-  --> $DIR/return-wrong-bound-region.rs:21:23
-   |
-LL |     expect_sig(|a, b| b); // ought to return `a`
-   |                 -  -  ^ closure was supposed to return data with lifetime `'1` but it is returning data with lifetime `'2`
-   |                 |  |
-   |                 |  has type `&'1 i32`
-   |                 has type `&'2 i32`
-
 note: No external requirements
   --> $DIR/return-wrong-bound-region.rs:21:16
    |
@@ -23,6 +14,15 @@ LL |     expect_sig(|a, b| b); // ought to return `a`
                i16,
                for<'r, 's> extern "rust-call" fn((&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0:0), 'r)) i32, &ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0:0), 's)) i32)) -> &ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0:0), 'r)) i32
            ]
+
+error: unsatisfied lifetime constraints
+  --> $DIR/return-wrong-bound-region.rs:21:23
+   |
+LL |     expect_sig(|a, b| b); // ought to return `a`
+   |                 -  -  ^ closure was supposed to return data with lifetime `'1` but it is returning data with lifetime `'2`
+   |                 |  |
+   |                 |  has type `&'1 i32`
+   |                 has type `&'2 i32`
 
 note: No external requirements
   --> $DIR/return-wrong-bound-region.rs:20:1

--- a/src/test/ui/nll/ty-outlives/projection-no-regions-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-no-regions-closure.stderr
@@ -25,14 +25,6 @@ LL |     with_signature(x, |mut y| Box::new(y.next()))
    = note: number of external vids: 4
    = note: where <T as std::iter::Iterator>::Item: '_#2r
 
-error[E0309]: the associated type `<T as std::iter::Iterator>::Item` may not live long enough
-  --> $DIR/projection-no-regions-closure.rs:35:23
-   |
-LL |     with_signature(x, |mut y| Box::new(y.next()))
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: consider adding an explicit lifetime bound `<T as std::iter::Iterator>::Item: ReEarlyBound(0, 'a)`...
-
 note: No external requirements
   --> $DIR/projection-no-regions-closure.rs:31:1
    |
@@ -49,6 +41,14 @@ LL | | }
                '_#1r,
                T
            ]
+
+error[E0309]: the associated type `<T as std::iter::Iterator>::Item` may not live long enough
+  --> $DIR/projection-no-regions-closure.rs:35:23
+   |
+LL |     with_signature(x, |mut y| Box::new(y.next()))
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider adding an explicit lifetime bound `<T as std::iter::Iterator>::Item: ReEarlyBound(0, 'a)`...
 
 note: External requirements
   --> $DIR/projection-no-regions-closure.rs:45:23
@@ -97,14 +97,6 @@ LL |     with_signature(x, |mut y| Box::new(y.next()))
    = note: number of external vids: 5
    = note: where <T as std::iter::Iterator>::Item: '_#3r
 
-error[E0309]: the associated type `<T as std::iter::Iterator>::Item` may not live long enough
-  --> $DIR/projection-no-regions-closure.rs:53:23
-   |
-LL |     with_signature(x, |mut y| Box::new(y.next()))
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: consider adding an explicit lifetime bound `<T as std::iter::Iterator>::Item: ReEarlyBound(0, 'a)`...
-
 note: No external requirements
   --> $DIR/projection-no-regions-closure.rs:49:1
    |
@@ -122,6 +114,14 @@ LL | | }
                '_#2r,
                T
            ]
+
+error[E0309]: the associated type `<T as std::iter::Iterator>::Item` may not live long enough
+  --> $DIR/projection-no-regions-closure.rs:53:23
+   |
+LL |     with_signature(x, |mut y| Box::new(y.next()))
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider adding an explicit lifetime bound `<T as std::iter::Iterator>::Item: ReEarlyBound(0, 'a)`...
 
 note: External requirements
   --> $DIR/projection-no-regions-closure.rs:64:23

--- a/src/test/ui/nll/ty-outlives/projection-one-region-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-one-region-closure.stderr
@@ -32,20 +32,6 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    = note: where T: '_#2r
    = note: where '_#1r: '_#2r
 
-error[E0309]: the parameter type `T` may not live long enough
-  --> $DIR/projection-one-region-closure.rs:55:29
-   |
-LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: consider adding an explicit lifetime bound `T: ReFree(DefId(0/0:8 ~ projection_one_region_closure[317d]::no_relationships_late[0]), BrNamed(crate0:DefIndex(1:16), 'a))`...
-
-error: unsatisfied lifetime constraints
-  --> $DIR/projection-one-region-closure.rs:55:5
-   |
-LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'b` must outlive `'a`
-
 note: No external requirements
   --> $DIR/projection-one-region-closure.rs:51:1
    |
@@ -63,6 +49,20 @@ LL | | }
                T
            ]
 
+error: unsatisfied lifetime constraints
+  --> $DIR/projection-one-region-closure.rs:55:5
+   |
+LL |     with_signature(cell, t, |cell, t| require(cell, t));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'b` must outlive `'a`
+
+error[E0309]: the parameter type `T` may not live long enough
+  --> $DIR/projection-one-region-closure.rs:55:29
+   |
+LL |     with_signature(cell, t, |cell, t| require(cell, t));
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider adding an explicit lifetime bound `T: ReFree(DefId(0/0:8 ~ projection_one_region_closure[317d]::no_relationships_late[0]), BrNamed(crate0:DefIndex(1:16), 'a))`...
+
 note: External requirements
   --> $DIR/projection-one-region-closure.rs:67:29
    |
@@ -79,20 +79,6 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    = note: number of external vids: 5
    = note: where T: '_#3r
    = note: where '_#2r: '_#3r
-
-error[E0309]: the parameter type `T` may not live long enough
-  --> $DIR/projection-one-region-closure.rs:67:29
-   |
-LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: consider adding an explicit lifetime bound `T: ReEarlyBound(0, 'a)`...
-
-error: unsatisfied lifetime constraints
-  --> $DIR/projection-one-region-closure.rs:67:5
-   |
-LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'b` must outlive `'a`
 
 note: No external requirements
   --> $DIR/projection-one-region-closure.rs:62:1
@@ -112,6 +98,20 @@ LL | | }
                T
            ]
 
+error: unsatisfied lifetime constraints
+  --> $DIR/projection-one-region-closure.rs:67:5
+   |
+LL |     with_signature(cell, t, |cell, t| require(cell, t));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'b` must outlive `'a`
+
+error[E0309]: the parameter type `T` may not live long enough
+  --> $DIR/projection-one-region-closure.rs:67:29
+   |
+LL |     with_signature(cell, t, |cell, t| require(cell, t));
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider adding an explicit lifetime bound `T: ReEarlyBound(0, 'a)`...
+
 note: External requirements
   --> $DIR/projection-one-region-closure.rs:89:29
    |
@@ -128,20 +128,6 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    = note: number of external vids: 5
    = note: where T: '_#3r
    = note: where '_#2r: '_#3r
-
-error[E0309]: the parameter type `T` may not live long enough
-  --> $DIR/projection-one-region-closure.rs:89:29
-   |
-LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: consider adding an explicit lifetime bound `T: ReEarlyBound(0, 'a)`...
-
-error: unsatisfied lifetime constraints
-  --> $DIR/projection-one-region-closure.rs:89:5
-   |
-LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'b` must outlive `'a`
 
 note: No external requirements
   --> $DIR/projection-one-region-closure.rs:74:1
@@ -160,6 +146,20 @@ LL | | }
                '_#2r,
                T
            ]
+
+error: unsatisfied lifetime constraints
+  --> $DIR/projection-one-region-closure.rs:89:5
+   |
+LL |     with_signature(cell, t, |cell, t| require(cell, t));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'b` must outlive `'a`
+
+error[E0309]: the parameter type `T` may not live long enough
+  --> $DIR/projection-one-region-closure.rs:89:29
+   |
+LL |     with_signature(cell, t, |cell, t| require(cell, t));
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider adding an explicit lifetime bound `T: ReEarlyBound(0, 'a)`...
 
 note: External requirements
   --> $DIR/projection-one-region-closure.rs:102:29

--- a/src/test/ui/nll/ty-outlives/projection-one-region-trait-bound-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-one-region-trait-bound-closure.stderr
@@ -31,12 +31,6 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    = note: number of external vids: 5
    = note: where '_#1r: '_#2r
 
-error: unsatisfied lifetime constraints
-  --> $DIR/projection-one-region-trait-bound-closure.rs:47:5
-   |
-LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'b` must outlive `'a`
-
 note: No external requirements
   --> $DIR/projection-one-region-trait-bound-closure.rs:43:1
    |
@@ -54,6 +48,12 @@ LL | | }
                T
            ]
 
+error: unsatisfied lifetime constraints
+  --> $DIR/projection-one-region-trait-bound-closure.rs:47:5
+   |
+LL |     with_signature(cell, t, |cell, t| require(cell, t));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'b` must outlive `'a`
+
 note: External requirements
   --> $DIR/projection-one-region-trait-bound-closure.rs:58:29
    |
@@ -69,12 +69,6 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
            ]
    = note: number of external vids: 5
    = note: where '_#2r: '_#3r
-
-error: unsatisfied lifetime constraints
-  --> $DIR/projection-one-region-trait-bound-closure.rs:58:5
-   |
-LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'b` must outlive `'a`
 
 note: No external requirements
   --> $DIR/projection-one-region-trait-bound-closure.rs:53:1
@@ -94,6 +88,12 @@ LL | | }
                T
            ]
 
+error: unsatisfied lifetime constraints
+  --> $DIR/projection-one-region-trait-bound-closure.rs:58:5
+   |
+LL |     with_signature(cell, t, |cell, t| require(cell, t));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'b` must outlive `'a`
+
 note: External requirements
   --> $DIR/projection-one-region-trait-bound-closure.rs:79:29
    |
@@ -109,12 +109,6 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
            ]
    = note: number of external vids: 5
    = note: where '_#2r: '_#3r
-
-error: unsatisfied lifetime constraints
-  --> $DIR/projection-one-region-trait-bound-closure.rs:79:5
-   |
-LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'b` must outlive `'a`
 
 note: No external requirements
   --> $DIR/projection-one-region-trait-bound-closure.rs:64:1
@@ -133,6 +127,12 @@ LL | | }
                '_#2r,
                T
            ]
+
+error: unsatisfied lifetime constraints
+  --> $DIR/projection-one-region-trait-bound-closure.rs:79:5
+   |
+LL |     with_signature(cell, t, |cell, t| require(cell, t));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'b` must outlive `'a`
 
 note: External requirements
   --> $DIR/projection-one-region-trait-bound-closure.rs:90:29

--- a/src/test/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.stderr
@@ -38,14 +38,6 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    = note: number of external vids: 6
    = note: where <T as Anything<ReClosureBound('_#1r), ReClosureBound('_#2r)>>::AssocType: '_#3r
 
-error[E0309]: the associated type `<T as Anything<'_#6r, '_#7r>>::AssocType` may not live long enough
-  --> $DIR/projection-two-region-trait-bound-closure.rs:48:29
-   |
-LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: consider adding an explicit lifetime bound `<T as Anything<'_#6r, '_#7r>>::AssocType: ReFree(DefId(0/0:8 ~ projection_two_region_trait_bound_closure[317d]::no_relationships_late[0]), BrNamed(crate0:DefIndex(1:18), 'a))`...
-
 note: No external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:44:1
    |
@@ -64,6 +56,14 @@ LL | | }
                T
            ]
 
+error[E0309]: the associated type `<T as Anything<'_#6r, '_#7r>>::AssocType` may not live long enough
+  --> $DIR/projection-two-region-trait-bound-closure.rs:48:29
+   |
+LL |     with_signature(cell, t, |cell, t| require(cell, t));
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider adding an explicit lifetime bound `<T as Anything<'_#6r, '_#7r>>::AssocType: ReFree(DefId(0/0:8 ~ projection_two_region_trait_bound_closure[317d]::no_relationships_late[0]), BrNamed(crate0:DefIndex(1:18), 'a))`...
+
 note: External requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:59:29
    |
@@ -80,14 +80,6 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
            ]
    = note: number of external vids: 6
    = note: where <T as Anything<ReClosureBound('_#2r), ReClosureBound('_#3r)>>::AssocType: '_#4r
-
-error[E0309]: the associated type `<T as Anything<'_#7r, '_#8r>>::AssocType` may not live long enough
-  --> $DIR/projection-two-region-trait-bound-closure.rs:59:29
-   |
-LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: consider adding an explicit lifetime bound `<T as Anything<'_#7r, '_#8r>>::AssocType: ReEarlyBound(0, 'a)`...
 
 note: No external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:54:1
@@ -108,6 +100,14 @@ LL | | }
                T
            ]
 
+error[E0309]: the associated type `<T as Anything<'_#7r, '_#8r>>::AssocType` may not live long enough
+  --> $DIR/projection-two-region-trait-bound-closure.rs:59:29
+   |
+LL |     with_signature(cell, t, |cell, t| require(cell, t));
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider adding an explicit lifetime bound `<T as Anything<'_#7r, '_#8r>>::AssocType: ReEarlyBound(0, 'a)`...
+
 note: External requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:80:29
    |
@@ -124,14 +124,6 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
            ]
    = note: number of external vids: 6
    = note: where <T as Anything<ReClosureBound('_#2r), ReClosureBound('_#3r)>>::AssocType: '_#4r
-
-error[E0309]: the associated type `<T as Anything<'_#7r, '_#8r>>::AssocType` may not live long enough
-  --> $DIR/projection-two-region-trait-bound-closure.rs:80:29
-   |
-LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: consider adding an explicit lifetime bound `<T as Anything<'_#7r, '_#8r>>::AssocType: ReEarlyBound(0, 'a)`...
 
 note: No external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:65:1
@@ -151,6 +143,14 @@ LL | | }
                '_#3r,
                T
            ]
+
+error[E0309]: the associated type `<T as Anything<'_#7r, '_#8r>>::AssocType` may not live long enough
+  --> $DIR/projection-two-region-trait-bound-closure.rs:80:29
+   |
+LL |     with_signature(cell, t, |cell, t| require(cell, t));
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider adding an explicit lifetime bound `<T as Anything<'_#7r, '_#8r>>::AssocType: ReEarlyBound(0, 'a)`...
 
 note: External requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:91:29
@@ -239,12 +239,6 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    = note: number of external vids: 5
    = note: where <T as Anything<ReClosureBound('_#1r), ReClosureBound('_#1r)>>::AssocType: '_#2r
 
-error: unsatisfied lifetime constraints
-  --> $DIR/projection-two-region-trait-bound-closure.rs:108:5
-   |
-LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'b` must outlive `'a`
-
 note: No external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:104:1
    |
@@ -261,6 +255,12 @@ LL | | }
                '_#1r,
                T
            ]
+
+error: unsatisfied lifetime constraints
+  --> $DIR/projection-two-region-trait-bound-closure.rs:108:5
+   |
+LL |     with_signature(cell, t, |cell, t| require(cell, t));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'b` must outlive `'a`
 
 note: External requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:119:29

--- a/src/test/ui/nll/ty-outlives/ty-param-closure-approximate-lower-bound.stderr
+++ b/src/test/ui/nll/ty-outlives/ty-param-closure-approximate-lower-bound.stderr
@@ -60,14 +60,6 @@ LL |     twice(cell, value, |a, b| invoke(a, b));
    = note: number of external vids: 4
    = note: where T: '_#1r
 
-error[E0309]: the parameter type `T` may not live long enough
-  --> $DIR/ty-param-closure-approximate-lower-bound.rs:42:24
-   |
-LL |     twice(cell, value, |a, b| invoke(a, b));
-   |                        ^^^^^^^^^^^^^^^^^^^
-   |
-   = help: consider adding an explicit lifetime bound `T: ReFree(DefId(0/0:6 ~ ty_param_closure_approximate_lower_bound[317d]::generic_fail[0]), BrNamed(crate0:DefIndex(1:15), 'a))`...
-
 note: No external requirements
   --> $DIR/ty-param-closure-approximate-lower-bound.rs:41:1
    |
@@ -82,6 +74,14 @@ LL | | }
    = note: defining type: DefId(0/0:6 ~ ty_param_closure_approximate_lower_bound[317d]::generic_fail[0]) with substs [
                T
            ]
+
+error[E0309]: the parameter type `T` may not live long enough
+  --> $DIR/ty-param-closure-approximate-lower-bound.rs:42:24
+   |
+LL |     twice(cell, value, |a, b| invoke(a, b));
+   |                        ^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider adding an explicit lifetime bound `T: ReFree(DefId(0/0:6 ~ ty_param_closure_approximate_lower_bound[317d]::generic_fail[0]), BrNamed(crate0:DefIndex(1:15), 'a))`...
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/ty-outlives/ty-param-closure-outlives-from-return-type.stderr
+++ b/src/test/ui/nll/ty-outlives/ty-param-closure-outlives-from-return-type.stderr
@@ -25,14 +25,6 @@ LL |     with_signature(x, |y| y)
    = note: number of external vids: 4
    = note: where T: '_#2r
 
-error[E0309]: the parameter type `T` may not live long enough
-  --> $DIR/ty-param-closure-outlives-from-return-type.rs:36:23
-   |
-LL |     with_signature(x, |y| y)
-   |                       ^^^^^
-   |
-   = help: consider adding an explicit lifetime bound `T: ReEarlyBound(0, 'a)`...
-
 note: No external requirements
   --> $DIR/ty-param-closure-outlives-from-return-type.rs:25:1
    |
@@ -49,6 +41,14 @@ LL | | }
                '_#1r,
                T
            ]
+
+error[E0309]: the parameter type `T` may not live long enough
+  --> $DIR/ty-param-closure-outlives-from-return-type.rs:36:23
+   |
+LL |     with_signature(x, |y| y)
+   |                       ^^^^^
+   |
+   = help: consider adding an explicit lifetime bound `T: ReEarlyBound(0, 'a)`...
 
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/ty-param-closure-outlives-from-return-type.rs:52:5

--- a/src/test/ui/nll/ty-outlives/ty-param-closure-outlives-from-where-clause.stderr
+++ b/src/test/ui/nll/ty-outlives/ty-param-closure-outlives-from-where-clause.stderr
@@ -31,21 +31,6 @@ LL | |     })
    = note: number of external vids: 4
    = note: where T: '_#1r
 
-error[E0309]: the parameter type `T` may not live long enough
-  --> $DIR/ty-param-closure-outlives-from-where-clause.rs:37:26
-   |
-LL |       with_signature(a, b, |x, y| {
-   |  __________________________^
-LL | |         //~^ ERROR the parameter type `T` may not live long enough
-LL | |         //
-LL | |         // See `correct_region`, which explains the point of this
-...  |
-LL | |         //~^ WARNING not reporting region error due to nll
-LL | |     })
-   | |_____^
-   |
-   = help: consider adding an explicit lifetime bound `T: ReFree(DefId(0/0:6 ~ ty_param_closure_outlives_from_where_clause[317d]::no_region[0]), BrNamed(crate0:DefIndex(1:14), 'a))`...
-
 note: No external requirements
   --> $DIR/ty-param-closure-outlives-from-where-clause.rs:36:1
    |
@@ -61,6 +46,21 @@ LL | | }
    = note: defining type: DefId(0/0:6 ~ ty_param_closure_outlives_from_where_clause[317d]::no_region[0]) with substs [
                T
            ]
+
+error[E0309]: the parameter type `T` may not live long enough
+  --> $DIR/ty-param-closure-outlives-from-where-clause.rs:37:26
+   |
+LL |       with_signature(a, b, |x, y| {
+   |  __________________________^
+LL | |         //~^ ERROR the parameter type `T` may not live long enough
+LL | |         //
+LL | |         // See `correct_region`, which explains the point of this
+...  |
+LL | |         //~^ WARNING not reporting region error due to nll
+LL | |     })
+   | |_____^
+   |
+   = help: consider adding an explicit lifetime bound `T: ReFree(DefId(0/0:6 ~ ty_param_closure_outlives_from_where_clause[317d]::no_region[0]), BrNamed(crate0:DefIndex(1:14), 'a))`...
 
 note: External requirements
   --> $DIR/ty-param-closure-outlives-from-where-clause.rs:54:26
@@ -122,20 +122,6 @@ LL | |     })
    = note: number of external vids: 5
    = note: where T: '_#2r
 
-error[E0309]: the parameter type `T` may not live long enough
-  --> $DIR/ty-param-closure-outlives-from-where-clause.rs:75:26
-   |
-LL |       with_signature(a, b, |x, y| {
-   |  __________________________^
-LL | |         //~^ ERROR the parameter type `T` may not live long enough
-LL | |         // See `correct_region`
-LL | |         require(&x, &y)
-LL | |         //~^ WARNING not reporting region error due to nll
-LL | |     })
-   | |_____^
-   |
-   = help: consider adding an explicit lifetime bound `T: ReFree(DefId(0/0:8 ~ ty_param_closure_outlives_from_where_clause[317d]::wrong_region[0]), BrNamed(crate0:DefIndex(1:20), 'a))`...
-
 note: No external requirements
   --> $DIR/ty-param-closure-outlives-from-where-clause.rs:71:1
    |
@@ -152,6 +138,20 @@ LL | | }
                '_#1r,
                T
            ]
+
+error[E0309]: the parameter type `T` may not live long enough
+  --> $DIR/ty-param-closure-outlives-from-where-clause.rs:75:26
+   |
+LL |       with_signature(a, b, |x, y| {
+   |  __________________________^
+LL | |         //~^ ERROR the parameter type `T` may not live long enough
+LL | |         // See `correct_region`
+LL | |         require(&x, &y)
+LL | |         //~^ WARNING not reporting region error due to nll
+LL | |     })
+   | |_____^
+   |
+   = help: consider adding an explicit lifetime bound `T: ReFree(DefId(0/0:8 ~ ty_param_closure_outlives_from_where_clause[317d]::wrong_region[0]), BrNamed(crate0:DefIndex(1:20), 'a))`...
 
 note: External requirements
   --> $DIR/ty-param-closure-outlives-from-where-clause.rs:89:26

--- a/src/test/ui/span/dropck_arr_cycle_checked.nll.stderr
+++ b/src/test/ui/span/dropck_arr_cycle_checked.nll.stderr
@@ -1,15 +1,3 @@
-error[E0597]: `b3` does not live long enough
-  --> $DIR/dropck_arr_cycle_checked.rs:105:24
-   |
-LL |     b1.a[1].v.set(Some(&b3));
-   |                        ^^^ borrowed value does not live long enough
-...
-LL | }
-   | -
-   | |
-   | `b3` dropped here while still borrowed
-   | borrow later used here, when `b1` is dropped
-
 error[E0597]: `b2` does not live long enough
   --> $DIR/dropck_arr_cycle_checked.rs:103:24
    |
@@ -20,6 +8,18 @@ LL | }
    | -
    | |
    | `b2` dropped here while still borrowed
+   | borrow later used here, when `b1` is dropped
+
+error[E0597]: `b3` does not live long enough
+  --> $DIR/dropck_arr_cycle_checked.rs:105:24
+   |
+LL |     b1.a[1].v.set(Some(&b3));
+   |                        ^^^ borrowed value does not live long enough
+...
+LL | }
+   | -
+   | |
+   | `b3` dropped here while still borrowed
    | borrow later used here, when `b1` is dropped
 
 error[E0597]: `b1` does not live long enough

--- a/src/test/ui/span/dropck_vec_cycle_checked.nll.stderr
+++ b/src/test/ui/span/dropck_vec_cycle_checked.nll.stderr
@@ -1,15 +1,3 @@
-error[E0597]: `c3` does not live long enough
-  --> $DIR/dropck_vec_cycle_checked.rs:115:24
-   |
-LL |     c1.v[1].v.set(Some(&c3));
-   |                        ^^^ borrowed value does not live long enough
-...
-LL | }
-   | -
-   | |
-   | `c3` dropped here while still borrowed
-   | borrow later used here, when `c1` is dropped
-
 error[E0597]: `c2` does not live long enough
   --> $DIR/dropck_vec_cycle_checked.rs:113:24
    |
@@ -20,6 +8,18 @@ LL | }
    | -
    | |
    | `c2` dropped here while still borrowed
+   | borrow later used here, when `c1` is dropped
+
+error[E0597]: `c3` does not live long enough
+  --> $DIR/dropck_vec_cycle_checked.rs:115:24
+   |
+LL |     c1.v[1].v.set(Some(&c3));
+   |                        ^^^ borrowed value does not live long enough
+...
+LL | }
+   | -
+   | |
+   | `c3` dropped here while still borrowed
    | borrow later used here, when `c1` is dropped
 
 error[E0597]: `c1` does not live long enough

--- a/src/test/ui/span/range-2.nll.stderr
+++ b/src/test/ui/span/range-2.nll.stderr
@@ -1,14 +1,3 @@
-error[E0597]: `b` does not live long enough
-  --> $DIR/range-2.rs:17:13
-   |
-LL |         &a..&b
-   |             ^^ borrowed value does not live long enough
-LL |     };
-   |     - `b` dropped here while still borrowed
-...
-LL |     r.use_ref();
-   |     - borrow later used here
-
 error[E0597]: `a` does not live long enough
   --> $DIR/range-2.rs:17:9
    |
@@ -16,6 +5,17 @@ LL |         &a..&b
    |         ^^ borrowed value does not live long enough
 LL |     };
    |     - `a` dropped here while still borrowed
+...
+LL |     r.use_ref();
+   |     - borrow later used here
+
+error[E0597]: `b` does not live long enough
+  --> $DIR/range-2.rs:17:13
+   |
+LL |         &a..&b
+   |             ^^ borrowed value does not live long enough
+LL |     };
+   |     - `b` dropped here while still borrowed
 ...
 LL |     r.use_ref();
    |     - borrow later used here

--- a/src/test/ui/span/regions-escape-loop-via-vec.nll.stderr
+++ b/src/test/ui/span/regions-escape-loop-via-vec.nll.stderr
@@ -20,6 +20,17 @@ LL |         let mut z = x; //~ ERROR cannot use `x` because it was mutably borr
 LL |         _y.push(&mut z);
    |         -- borrow later used here
 
+error[E0597]: `z` does not live long enough
+  --> $DIR/regions-escape-loop-via-vec.rs:17:17
+   |
+LL |         _y.push(&mut z);
+   |         --      ^^^^^^ borrowed value does not live long enough
+   |         |
+   |         borrow later used here
+...
+LL |     }
+   |     - `z` dropped here while still borrowed
+
 error[E0503]: cannot use `x` because it was mutably borrowed
   --> $DIR/regions-escape-loop-via-vec.rs:19:9
    |
@@ -31,17 +42,6 @@ LL |         _y.push(&mut z);
 LL |         //~^ ERROR `z` does not live long enough
 LL |         x += 1; //~ ERROR cannot assign
    |         ^^^^^^ use of borrowed `x`
-
-error[E0597]: `z` does not live long enough
-  --> $DIR/regions-escape-loop-via-vec.rs:17:17
-   |
-LL |         _y.push(&mut z);
-   |         --      ^^^^^^ borrowed value does not live long enough
-   |         |
-   |         borrow later used here
-...
-LL |     }
-   |     - `z` dropped here while still borrowed
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/span/send-is-not-static-ensures-scoping.nll.stderr
+++ b/src/test/ui/span/send-is-not-static-ensures-scoping.nll.stderr
@@ -1,3 +1,15 @@
+error[E0597]: `x` does not live long enough
+  --> $DIR/send-is-not-static-ensures-scoping.rs:26:17
+   |
+LL |         let y = &x;
+   |                 ^^ borrowed value does not live long enough
+...
+LL |     };
+   |     - `x` dropped here while still borrowed
+LL | 
+LL |     bad.join();
+   |     --- borrow later used here
+
 error[E0597]: `y` does not live long enough
   --> $DIR/send-is-not-static-ensures-scoping.rs:29:16
    |
@@ -12,18 +24,6 @@ LL |       };
 LL | 
 LL |       bad.join();
    |       --- borrow later used here
-
-error[E0597]: `x` does not live long enough
-  --> $DIR/send-is-not-static-ensures-scoping.rs:26:17
-   |
-LL |         let y = &x;
-   |                 ^^ borrowed value does not live long enough
-...
-LL |     };
-   |     - `x` dropped here while still borrowed
-LL | 
-LL |     bad.join();
-   |     --- borrow later used here
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/span/vec_refs_data_with_early_death.nll.stderr
+++ b/src/test/ui/span/vec_refs_data_with_early_death.nll.stderr
@@ -1,17 +1,3 @@
-error[E0597]: `y` does not live long enough
-  --> $DIR/vec_refs_data_with_early_death.rs:29:12
-   |
-LL |     v.push(&y);
-   |            ^^ borrowed value does not live long enough
-...
-LL | }
-   | -
-   | |
-   | `y` dropped here while still borrowed
-   | borrow later used here, when `v` is dropped
-   |
-   = note: values in a scope are dropped in the opposite order they are defined
-
 error[E0597]: `x` does not live long enough
   --> $DIR/vec_refs_data_with_early_death.rs:27:12
    |
@@ -22,6 +8,20 @@ LL | }
    | -
    | |
    | `x` dropped here while still borrowed
+   | borrow later used here, when `v` is dropped
+   |
+   = note: values in a scope are dropped in the opposite order they are defined
+
+error[E0597]: `y` does not live long enough
+  --> $DIR/vec_refs_data_with_early_death.rs:29:12
+   |
+LL |     v.push(&y);
+   |            ^^ borrowed value does not live long enough
+...
+LL | }
+   | -
+   | |
+   | `y` dropped here while still borrowed
    | borrow later used here, when `v` is dropped
    |
    = note: values in a scope are dropped in the opposite order they are defined


### PR DESCRIPTION
Sorting the output diagnostics by span is a long planned revision to the NLL diagnostics that we hope will yield a less surprising user experience in some case.

Once we got them buffered, it was trivial to implement. (The hard part is skimming the resulting changes to the diagnostics to make sure nothing broke... Note that I largely rubber-stamped the `#[rustc_regions]` output change.)

Fix #51167 