### PR TITLE
enable jemalloc assertions when configured to do so

### DIFF
--- a/src/liballoc_jemalloc/build.rs
+++ b/src/liballoc_jemalloc/build.rs
@@ -105,11 +105,10 @@ fn main() {
         cmd.arg("--with-jemalloc-prefix=je_");
     }
 
-    // FIXME: building with jemalloc assertions is currently broken.
-    // See <https://github.com/rust-lang/rust/issues/44152>.
-    //if cfg!(feature = "debug") {
-    //    cmd.arg("--enable-debug");
-    //}
+    if cfg!(feature = "debug") {
+        // Enable jemalloc assertions.
+        cmd.arg("--enable-debug");
+    }
 
     cmd.arg(format!("--host={}", build_helper::gnu_target(&target)));
     cmd.arg(format!("--build={}", build_helper::gnu_target(&host)));


### PR DESCRIPTION
This is essentially a re-submission of the functional part of https://github.com/rust-lang/rust/pull/43648. I was unable to reproduce the issue I had back then, maybe something changed somewhere to no longer trigger the assertion.

Fixes https://github.com/rust-lang/rust/issues/44152