### PR TITLE
Only run the sparc-abi test on sparc

### DIFF
--- a/src/test/codegen/sparc-struct-abi.rs
+++ b/src/test/codegen/sparc-struct-abi.rs
@@ -11,6 +11,7 @@
 // Checks that we correctly codegen extern "C" functions returning structs.
 // See issue #52638.
 
+// only-sparc64
 // compile-flags: -O --target=sparc64-unknown-linux-gnu --crate-type=rlib
 #![feature(no_core, lang_items)]
 #![no_core]


### PR DESCRIPTION
It is not required for LLVM to have SPARC target support, so it is
necessary to only run this test when LLVM does support SPARC. Sadly, it
isn’t possible to specify exactly this constraint. Instead, we specify
that this test should run on SPARC host only (it surely is sane
assumption to make that compiler running on a SPARC can generate
SPARC, right?)

Since you cannot specify multiple `only-*` to have it run on both 32-bit
and 64-bit SPARC we pick 64-bit SPARC, because it is exactly what is
being tested by this test.

Fixes #52881