### PR TITLE
Don't count MIR locals as borrowed after StorageDead when finding locals live across a yield terminator

### DIFF
--- a/src/librustc_mir/transform/generator.rs
+++ b/src/librustc_mir/transform/generator.rs
@@ -433,7 +433,8 @@ fn locals_live_across_suspend_points<'a, 'tcx,>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                 // The `liveness` variable contains the liveness of MIR locals ignoring borrows.
                 // This is correct for movable generators since borrows cannot live across
                 // suspension points. However for immovable generators we need to account for
-                // borrows, so we conseratively assume that all borrowed locals live forever.
+                // borrows, so we conseratively assume that all borrowed locals are live until
+                // we find a StorageDead statement referencing the locals.
                 // To do this we just union our `liveness` result with `borrowed_locals`, which
                 // contains all the locals which has been borrowed before this suspension point.
                 // If a borrow is converted to a raw reference, we must also assume that it lives

--- a/src/test/run-pass/generator/yield-in-initializer.rs
+++ b/src/test/run-pass/generator/yield-in-initializer.rs
@@ -1,0 +1,25 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(generators)]
+
+fn main() {
+    static || {
+        loop {
+            // Test that `opt` is not live across the yield, even when borrowed in a loop
+            // See https://github.com/rust-lang/rust/issues/52792
+            let opt = {
+                yield;
+                true
+            };
+            &opt;
+        }
+    };
+}


### PR DESCRIPTION
This should fix https://github.com/rust-lang/rust/issues/52792.

r? @eddyb