### PR TITLE
#[feature(uniform_paths)]: allow `use x::y;` to resolve through `self::x`, not just `::x`.

### DIFF
--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -865,7 +865,7 @@ where
 
     krate = time(sess, "crate injection", || {
         let alt_std_name = sess.opts.alt_std_name.as_ref().map(|s| &**s);
-        syntax::std_inject::maybe_inject_crates_ref(krate, alt_std_name)
+        syntax::std_inject::maybe_inject_crates_ref(krate, alt_std_name, sess.edition())
     });
 
     let mut addl_plugins = Some(addl_plugins);

--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -1139,32 +1139,4 @@ impl<'a> CrateLoader<'a> {
 
         cnum
     }
-
-    pub fn process_use_extern(
-        &mut self,
-        name: Symbol,
-        span: Span,
-        id: ast::NodeId,
-        definitions: &Definitions,
-    ) -> CrateNum {
-        let cnum = self.resolve_crate(
-            &None, name, name, None, None, span, PathKind::Crate, DepKind::Explicit
-        ).0;
-
-        let def_id = definitions.opt_local_def_id(id).unwrap();
-        let path_len = definitions.def_path(def_id.index).data.len();
-
-        self.update_extern_crate(
-            cnum,
-            ExternCrate {
-                src: ExternCrateSource::Use,
-                span,
-                path_len,
-                direct: true,
-            },
-            &mut FxHashSet(),
-        );
-
-        cnum
-    }
 }

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -101,7 +101,7 @@ impl Path {
     // or starts with something like `self`/`super`/`$crate`/etc.
     pub fn make_root(&self) -> Option<PathSegment> {
         if let Some(ident) = self.segments.get(0).map(|seg| seg.ident) {
-            if ident.is_path_segment_keyword() && ident.name != keywords::Crate.name() {
+            if ident.is_path_segment_keyword() {
                 return None;
             }
         }

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -507,6 +507,9 @@ declare_features! (
 
     // Support for arbitrary delimited token streams in non-macro attributes.
     (active, unrestricted_attribute_tokens, "1.30.0", Some(44690), None),
+
+    // Allows `use x::y;` to resolve through `self::x`, not just `::x`.
+    (active, uniform_paths, "1.30.0", Some(53130), None),
 );
 
 declare_features! (

--- a/src/test/compile-fail/dollar-crate-is-keyword.rs
+++ b/src/test/compile-fail/dollar-crate-is-keyword.rs
@@ -10,7 +10,11 @@
 
 macro_rules! m {
     () => {
-        struct $crate {} //~ ERROR expected identifier, found reserved identifier `$crate`
+        // Avoid having more than one `$crate`-named item in the same module,
+        // as even though they error, they still parse as `$crate` and conflict.
+        mod foo {
+            struct $crate {} //~ ERROR expected identifier, found reserved identifier `$crate`
+        }
 
         use $crate; // OK
                     //~^ WARN `$crate` may not be imported

--- a/src/test/compile-fail/import-crate-var.rs
+++ b/src/test/compile-fail/import-crate-var.rs
@@ -9,15 +9,14 @@
 // except according to those terms.
 
 // aux-build:import_crate_var.rs
-// error-pattern: `$crate` may not be imported
-// error-pattern: `use $crate;` was erroneously allowed and will become a hard error
-// error-pattern: compilation successful
 
 #![feature(rustc_attrs)]
 
 #[macro_use] extern crate import_crate_var;
 
 #[rustc_error]
-fn main() {
+fn main() { //~ ERROR compilation successful
     m!();
+    //~^ WARN `$crate` may not be imported
+    //~| NOTE `use $crate;` was erroneously allowed and will become a hard error
 }

--- a/src/test/compile-fail/rfc-2126-extern-absolute-paths/single-segment.rs
+++ b/src/test/compile-fail/rfc-2126-extern-absolute-paths/single-segment.rs
@@ -11,10 +11,8 @@
 // aux-build:xcrate.rs
 // edition:2018
 
-use crate; //~ ERROR unresolved import `crate`
-           //~^ NOTE crate root imports need to be explicitly named: `use crate as name;`
-use *; //~ ERROR unresolved import `*`
-       //~^ NOTE cannot glob-import all possible crates
+use crate; //~ ERROR crate root imports need to be explicitly named: `use crate as name;`
+use *; //~ ERROR cannot glob-import all possible crates
 
 fn main() {
     let s = ::xcrate; //~ ERROR expected value, found module `xcrate`

--- a/src/test/pretty/cast-lt.pp
+++ b/src/test/pretty/cast-lt.pp
@@ -1,7 +1,7 @@
 #![feature(prelude_import)]
 #![no_std]
 #[prelude_import]
-use std::prelude::v1::*;
+use ::std::prelude::v1::*;
 #[macro_use]
 extern crate std;
 // Copyright 2017 The Rust Project Developers. See the COPYRIGHT

--- a/src/test/pretty/issue-4264.pp
+++ b/src/test/pretty/issue-4264.pp
@@ -1,5 +1,5 @@
 #[prelude_import]
-use std::prelude::v1::*;
+use ::std::prelude::v1::*;
 #[macro_use]
 extern crate std;
 // Copyright 2014 The Rust Project Developers. See the COPYRIGHT

--- a/src/test/run-pass/issue-52140/auxiliary/some_crate.rs
+++ b/src/test/run-pass/issue-52140/auxiliary/some_crate.rs
@@ -1,4 +1,4 @@
-// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,8 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(extern_in_paths)]
+#![crate_type = "lib"]
 
-fn main() {
-    let extern = 0; //~ ERROR cannot find unit struct/variant or constant `extern` in this scope
+pub fn hello() {
+    println!("Hello, world!");
 }

--- a/src/test/run-pass/issue-52140/main.rs
+++ b/src/test/run-pass/issue-52140/main.rs
@@ -1,4 +1,4 @@
-// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,15 +8,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// aux-build:xcrate.rs
+// aux-build:some_crate.rs
+// edition:2018
 
-#![feature(extern_in_paths)]
-
-use extern; //~ ERROR unresolved import `extern`
-            //~^ NOTE no `extern` in the root
-use extern::*; //~ ERROR cannot glob-import all possible crates
+mod foo {
+    pub use some_crate;
+}
 
 fn main() {
-    let s = extern::xcrate; //~ ERROR expected value, found module `extern::xcrate`
-                            //~^ NOTE not a value
+    ::some_crate::hello();
+    foo::some_crate::hello();
 }

--- a/src/test/run-pass/issue-52141/auxiliary/some_crate.rs
+++ b/src/test/run-pass/issue-52141/auxiliary/some_crate.rs
@@ -1,4 +1,4 @@
-// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,8 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(extern_in_paths)]
+#![crate_type = "lib"]
 
-fn main() {
-    let extern = 0; //~ ERROR cannot find unit struct/variant or constant `extern` in this scope
+pub fn hello() {
+    println!("Hello, world!");
 }

--- a/src/test/run-pass/issue-52141/main.rs
+++ b/src/test/run-pass/issue-52141/main.rs
@@ -1,4 +1,4 @@
-// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,15 +8,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// aux-build:xcrate.rs
+// aux-build:some_crate.rs
+// edition:2018
 
-#![feature(extern_in_paths)]
+use some_crate as some_name;
 
-use extern; //~ ERROR unresolved import `extern`
-            //~^ NOTE no `extern` in the root
-use extern::*; //~ ERROR cannot glob-import all possible crates
+mod foo {
+    pub use crate::some_name::*;
+}
 
 fn main() {
-    let s = extern::xcrate; //~ ERROR expected value, found module `extern::xcrate`
-                            //~^ NOTE not a value
+    ::some_crate::hello();
+    some_name::hello();
+    foo::hello();
 }

--- a/src/test/run-pass/issue-52705/auxiliary/png.rs
+++ b/src/test/run-pass/issue-52705/auxiliary/png.rs
@@ -1,4 +1,4 @@
-// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(extern_in_paths)]
+#![crate_type = "lib"]
 
-fn main() {
-    let extern = 0; //~ ERROR cannot find unit struct/variant or constant `extern` in this scope
-}
+pub struct DecodingError;

--- a/src/test/run-pass/issue-52705/main.rs
+++ b/src/test/run-pass/issue-52705/main.rs
@@ -1,4 +1,4 @@
-// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,15 +8,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// aux-build:xcrate.rs
+// aux-build:png.rs
+// edition:2018
 
-#![feature(extern_in_paths)]
+mod png {
+    use png as png_ext;
 
-use extern; //~ ERROR unresolved import `extern`
-            //~^ NOTE no `extern` in the root
-use extern::*; //~ ERROR cannot glob-import all possible crates
+    fn foo() -> png_ext::DecodingError { unimplemented!() }
+}
 
 fn main() {
-    let s = extern::xcrate; //~ ERROR expected value, found module `extern::xcrate`
-                            //~^ NOTE not a value
+    println!("Hello, world!");
 }

--- a/src/test/run-pass/uniform-paths/basic-nested.rs
+++ b/src/test/run-pass/uniform-paths/basic-nested.rs
@@ -1,0 +1,52 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// edition:2018
+
+#![feature(uniform_paths)]
+
+// This test is similar to `basic.rs`, but nested in modules.
+
+mod foo {
+    // Test that ambiguity errors are not emitted between `self::test` and
+    // `::test`, assuming the latter (crate) is not in `extern_prelude`.
+    mod test {
+        pub struct Foo(pub ());
+    }
+    pub use test::Foo;
+
+    // Test that qualified paths can refer to both the external crate and local item.
+    mod std {
+        pub struct io(pub ());
+    }
+    pub use ::std::io as std_io;
+    pub use self::std::io as local_io;
+}
+
+// Test that we can refer to the external crate unqualified
+// (when there isn't a local item with the same name).
+use std::io;
+
+mod bar {
+    // Also test the unqualified external crate import in a nested module,
+    // to show that the above import doesn't resolve through a local `std`
+    // item, e.g. the automatically injected `extern crate std;`, which in
+    // the Rust 2018 should no longer be visible through `crate::std`.
+    pub use std::io;
+}
+
+
+fn main() {
+    foo::Foo(());
+    foo::std_io::stdout();
+    foo::local_io(());
+    io::stdout();
+    bar::io::stdout();
+}

--- a/src/test/run-pass/uniform-paths/basic.rs
+++ b/src/test/run-pass/uniform-paths/basic.rs
@@ -1,0 +1,33 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// edition:2018
+
+#![feature(uniform_paths)]
+
+// Test that ambiguity errors are not emitted between `self::test` and
+// `::test`, assuming the latter (crate) is not in `extern_prelude`.
+mod test {
+    pub struct Foo(pub ());
+}
+use test::Foo;
+
+// Test that qualified paths can refer to both the external crate and local item.
+mod std {
+    pub struct io(pub ());
+}
+use ::std::io as std_io;
+use self::std::io as local_io;
+
+fn main() {
+    Foo(());
+    std_io::stdout();
+    local_io(());
+}

--- a/src/test/run-pass/uniform-paths/macros-nested.rs
+++ b/src/test/run-pass/uniform-paths/macros-nested.rs
@@ -1,0 +1,62 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// edition:2018
+
+#![feature(uniform_paths)]
+
+// This test is similar to `macros.rs`, but nested in modules.
+
+mod foo {
+    // Test that ambiguity errors are not emitted between `self::test` and
+    // `::test`, assuming the latter (crate) is not in `extern_prelude`.
+    macro_rules! m1 {
+        () => {
+            mod test {
+                pub struct Foo(pub ());
+            }
+        }
+    }
+    pub use test::Foo;
+    m1!();
+
+    // Test that qualified paths can refer to both the external crate and local item.
+    macro_rules! m2 {
+        () => {
+            mod std {
+                pub struct io(pub ());
+            }
+        }
+    }
+    pub use ::std::io as std_io;
+    pub use self::std::io as local_io;
+    m2!();
+}
+
+// Test that we can refer to the external crate unqualified
+// (when there isn't a local item with the same name).
+use std::io;
+
+mod bar {
+    // Also test the unqualified external crate import in a nested module,
+    // to show that the above import doesn't resolve through a local `std`
+    // item, e.g. the automatically injected `extern crate std;`, which in
+    // the Rust 2018 should no longer be visible through `crate::std`.
+    pub use std::io;
+}
+
+
+fn main() {
+    foo::Foo(());
+    foo::std_io::stdout();
+    foo::local_io(());
+    io::stdout();
+    bar::io::stdout();
+}

--- a/src/test/run-pass/uniform-paths/macros.rs
+++ b/src/test/run-pass/uniform-paths/macros.rs
@@ -1,0 +1,45 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// edition:2018
+
+#![feature(uniform_paths)]
+
+// This test is similar to `basic.rs`, but with macros defining local items.
+
+// Test that ambiguity errors are not emitted between `self::test` and
+// `::test`, assuming the latter (crate) is not in `extern_prelude`.
+macro_rules! m1 {
+    () => {
+        mod test {
+            pub struct Foo(pub ());
+        }
+    }
+}
+use test::Foo;
+m1!();
+
+// Test that qualified paths can refer to both the external crate and local item.
+macro_rules! m2 {
+    () => {
+        mod std {
+            pub struct io(pub ());
+        }
+    }
+}
+use ::std::io as std_io;
+use self::std::io as local_io;
+m2!();
+
+fn main() {
+    Foo(());
+    std_io::stdout();
+    local_io(());
+}

--- a/src/test/run-pass/uniform-paths/same-crate.rs
+++ b/src/test/run-pass/uniform-paths/same-crate.rs
@@ -1,0 +1,109 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// edition:2018
+
+#![feature(uniform_paths)]
+
+pub const A: usize = 0;
+
+pub mod foo {
+    pub const B: usize = 1;
+
+    pub mod bar {
+        pub const C: usize = 2;
+
+        pub enum E {
+            V1(usize),
+            V2(String),
+        }
+
+        pub fn test() -> String {
+            format!("{} {} {}", crate::A, crate::foo::B, C)
+        }
+
+        pub fn test_use() -> String {
+            use crate::A;
+            use crate::foo::B;
+
+            format!("{} {} {}", A, B, C)
+        }
+
+        pub fn test_enum() -> String {
+            use E::*;
+            match E::V1(10) {
+                V1(i) => { format!("V1: {}", i) }
+                V2(s) => { format!("V2: {}", s) }
+            }
+        }
+    }
+
+    pub fn test() -> String {
+        format!("{} {} {}", crate::A, B, bar::C)
+    }
+
+    pub fn test_use() -> String {
+        use crate::A;
+        use bar::C;
+
+        format!("{} {} {}", A, B, C)
+    }
+
+    pub fn test_enum() -> String {
+        use bar::E::*;
+        match bar::E::V1(10) {
+            V1(i) => { format!("V1: {}", i) }
+            V2(s) => { format!("V2: {}", s) }
+        }
+    }
+}
+
+pub fn test() -> String {
+    format!("{} {} {}", A, foo::B, foo::bar::C)
+}
+
+pub fn test_use() -> String {
+    use foo::B;
+    use foo::bar::C;
+
+    format!("{} {} {}", A, B, C)
+}
+
+pub fn test_enum() -> String {
+    use foo::bar::E::*;
+    match foo::bar::E::V1(10) {
+        V1(i) => { format!("V1: {}", i) }
+        V2(s) => { format!("V2: {}", s) }
+    }
+}
+
+fn main() {
+    let output = [
+        test(),
+        foo::test(),
+        foo::bar::test(),
+        test_use(),
+        foo::test_use(),
+        foo::bar::test_use(),
+        test_enum(),
+        foo::test_enum(),
+        foo::bar::test_enum(),
+    ].join("\n");
+    assert_eq!(output, "\
+0 1 2
+0 1 2
+0 1 2
+0 1 2
+0 1 2
+0 1 2
+V1: 10
+V1: 10
+V1: 10");
+}

--- a/src/test/ui/feature-gate-uniform-paths.rs
+++ b/src/test/ui/feature-gate-uniform-paths.rs
@@ -1,0 +1,22 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub mod foo {
+    pub use bar::Bar;
+    //~^ ERROR unresolved import `bar`
+
+    pub mod bar {
+        pub struct Bar;
+    }
+}
+
+fn main() {
+    let _ = foo::Bar;
+}

--- a/src/test/ui/feature-gate-uniform-paths.stderr
+++ b/src/test/ui/feature-gate-uniform-paths.stderr
@@ -1,0 +1,9 @@
+error[E0432]: unresolved import `bar`
+  --> $DIR/feature-gate-uniform-paths.rs:12:13
+   |
+LL |     pub use bar::Bar;
+   |             ^^^ Did you mean `self::bar`?
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0432`.

--- a/src/test/ui/rust-2018/uniform-paths/ambiguity-macros-nested.rs
+++ b/src/test/ui/rust-2018/uniform-paths/ambiguity-macros-nested.rs
@@ -1,0 +1,31 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// edition:2018
+
+#![feature(uniform_paths)]
+
+// This test is similar to `ambiguity-macros.rs`, but nested in a module.
+
+mod foo {
+    pub use std::io;
+    //~^ ERROR import from `std` is ambiguous
+
+    macro_rules! m {
+        () => {
+            mod std {
+                pub struct io;
+            }
+        }
+    }
+    m!();
+}
+
+fn main() {}

--- a/src/test/ui/rust-2018/uniform-paths/ambiguity-macros-nested.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/ambiguity-macros-nested.stderr
@@ -1,0 +1,16 @@
+error: import from `std` is ambiguous
+  --> $DIR/ambiguity-macros-nested.rs:18:13
+   |
+LL |       pub use std::io;
+   |               ^^^ could refer to external crate `::std`
+...
+LL | /             mod std {
+LL | |                 pub struct io;
+LL | |             }
+   | |_____________- could also refer to `self::std`
+   |
+   = help: write `::std` or `self::std` explicitly instead
+   = note: relative `use` paths enabled by `#![feature(uniform_paths)]`
+
+error: aborting due to previous error
+

--- a/src/test/ui/rust-2018/uniform-paths/ambiguity-macros.rs
+++ b/src/test/ui/rust-2018/uniform-paths/ambiguity-macros.rs
@@ -1,0 +1,29 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// edition:2018
+
+#![feature(uniform_paths)]
+
+// This test is similar to `ambiguity.rs`, but with macros defining local items.
+
+use std::io;
+//~^ ERROR import from `std` is ambiguous
+
+macro_rules! m {
+    () => {
+        mod std {
+            pub struct io;
+        }
+    }
+}
+m!();
+
+fn main() {}

--- a/src/test/ui/rust-2018/uniform-paths/ambiguity-macros.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/ambiguity-macros.stderr
@@ -1,0 +1,16 @@
+error: import from `std` is ambiguous
+  --> $DIR/ambiguity-macros.rs:17:5
+   |
+LL |   use std::io;
+   |       ^^^ could refer to external crate `::std`
+...
+LL | /         mod std {
+LL | |             pub struct io;
+LL | |         }
+   | |_________- could also refer to `self::std`
+   |
+   = help: write `::std` or `self::std` explicitly instead
+   = note: relative `use` paths enabled by `#![feature(uniform_paths)]`
+
+error: aborting due to previous error
+

--- a/src/test/ui/rust-2018/uniform-paths/ambiguity-nested.rs
+++ b/src/test/ui/rust-2018/uniform-paths/ambiguity-nested.rs
@@ -1,0 +1,26 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// edition:2018
+
+#![feature(uniform_paths)]
+
+// This test is similar to `ambiguity.rs`, but nested in a module.
+
+mod foo {
+    pub use std::io;
+    //~^ ERROR import from `std` is ambiguous
+
+    mod std {
+        pub struct io;
+    }
+}
+
+fn main() {}

--- a/src/test/ui/rust-2018/uniform-paths/ambiguity-nested.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/ambiguity-nested.stderr
@@ -1,0 +1,16 @@
+error: import from `std` is ambiguous
+  --> $DIR/ambiguity-nested.rs:18:13
+   |
+LL |       pub use std::io;
+   |               ^^^ could refer to external crate `::std`
+...
+LL | /     mod std {
+LL | |         pub struct io;
+LL | |     }
+   | |_____- could also refer to `self::std`
+   |
+   = help: write `::std` or `self::std` explicitly instead
+   = note: relative `use` paths enabled by `#![feature(uniform_paths)]`
+
+error: aborting due to previous error
+

--- a/src/test/ui/rust-2018/uniform-paths/ambiguity.rs
+++ b/src/test/ui/rust-2018/uniform-paths/ambiguity.rs
@@ -1,0 +1,22 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// edition:2018
+
+#![feature(uniform_paths)]
+
+use std::io;
+//~^ ERROR import from `std` is ambiguous
+
+mod std {
+    pub struct io;
+}
+
+fn main() {}

--- a/src/test/ui/rust-2018/uniform-paths/ambiguity.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/ambiguity.stderr
@@ -1,0 +1,16 @@
+error: import from `std` is ambiguous
+  --> $DIR/ambiguity.rs:15:5
+   |
+LL |   use std::io;
+   |       ^^^ could refer to external crate `::std`
+...
+LL | / mod std {
+LL | |     pub struct io;
+LL | | }
+   | |_- could also refer to `self::std`
+   |
+   = help: write `::std` or `self::std` explicitly instead
+   = note: relative `use` paths enabled by `#![feature(uniform_paths)]`
+
+error: aborting due to previous error
+

--- a/src/test/ui/rust-2018/uniform-paths/block-scoped-shadow.rs
+++ b/src/test/ui/rust-2018/uniform-paths/block-scoped-shadow.rs
@@ -1,0 +1,23 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// edition:2018
+
+#![feature(uniform_paths)]
+
+enum Foo { A, B }
+
+fn main() {
+    enum Foo {}
+    use Foo::*;
+    //~^ ERROR import from `Foo` is ambiguous
+
+    let _ = (A, B);
+}

--- a/src/test/ui/rust-2018/uniform-paths/block-scoped-shadow.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/block-scoped-shadow.stderr
@@ -1,0 +1,13 @@
+error: import from `Foo` is ambiguous
+  --> $DIR/block-scoped-shadow.rs:19:9
+   |
+LL |     enum Foo {}
+   |     ----------- shadowed by block-scoped `Foo`
+LL |     use Foo::*;
+   |         ^^^
+   |
+   = help: write `::Foo` or `self::Foo` explicitly instead
+   = note: relative `use` paths enabled by `#![feature(uniform_paths)]`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
_Branch originally by @cramertj, based on @petrochenkov's [description on the internals forum](https://internals.rust-lang.org/t/relative-paths-in-rust-2018/7883/30?u=petrochenkov)._
_(note, however, that the approach has significantly changed since)_

Implements `#[feature(uniform_paths)]` from #53130, by treating unqualified `use` paths as maybe-relative. That is, `use x::y;`, where `x` is a plain identifier (not a keyword), is no longer the same as `use ::x::y;`, and before picking an external crate named `x`, it first looks for an item named `x` in the same module (i.e. `self::x`) and prefers that local item instead.

Such a "maybe-relative" `x` can only resolve to an external crate if it's listed in "`extern_prelude`" (i.e. `core` / `std` and all the crates passed to `--extern`; the latter includes Cargo dependencies) - this is the same condition as being able to refer to the external crate from an unqualified, non-`use` path.
All other crates must be explicitly imported with an absolute path, e.g. `use ::x::y;`

To detect an ambiguity between the external crate and the local item with the same name, a "canary" import (e.g. `use self::x as _;`), tagged with the `is_uniform_paths_canary` flag, is injected. As the initial implementation is not sophisticated enough to handle all possible ways in which `self::x` could appear (e.g. from macro expansion), this also guards against accidentally picking the external crate, when it might actually get "shadowed" later.
Also, more canaries are injected for each block scope around the `use`, as `self::x` cannot resolve to any items named `x` in those scopes, but non-`use` paths can, and that could be confusing or even backwards-incompatible.

Errors are emitted only if the main "canary" import succeeds while an external crate exists (or if any of the block-scoped ones succeed at all), and ambiguities have custom error reporting, e.g.:
```rust
#![feature(uniform_paths)]
pub mod foo {
    use std::io;
    pub mod std { pub mod io {} }
}
```
```rust
error: import from `std` is ambiguous
 --> test.rs:3:9
  |
3 |     use std::io;
  |         ^^^ could refer to external crate `::std`
4 |     pub mod std { pub mod io {} }
  |     ----------------------------- could also refer to `self::std`
  |
  = help: write `::std` or `self::std` explicitly instead
  = note: relative `use` paths enabled by `#![feature(uniform_paths)]`
```
Another example, this time with a block-scoped item shadowing a module-scoped one:
```rust
#![feature(uniform_paths)]
enum Foo { A, B }
fn main() {
    enum Foo {}
    use Foo::*;
}
```
```rust
error: import from `Foo` is ambiguous
 --> test.rs:5:9
  |
4 |     enum Foo {}
  |     ----------- shadowed by block-scoped `Foo`
5 |     use Foo::*;
  |         ^^^
  |
  = help: write `::Foo` or `self::Foo` explicitly instead
  = note: relative `use` paths enabled by `#![feature(uniform_paths)]`
```

Additionally, this PR, because replacing "the `finalize_import` hack" was a blocker:
* fixes #52140
* fixes #52141
* fixes #52705

cc @aturon @joshtriplett 