### PR TITLE
check_const: use the same ParamEnv as codegen for statics

### DIFF
--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1632,6 +1632,7 @@ fn check_const(cx: &LateContext, body_id: hir::BodyId, what: &str) {
     let def_id = cx.tcx.hir.body_owner_def_id(body_id);
     let is_static = cx.tcx.is_static(def_id).is_some();
     let param_env = if is_static {
+        // Use the same param_env as `codegen_static_initializer`, to reuse the cache.
         ty::ParamEnv::reveal_all()
     } else {
         cx.tcx.param_env(def_id)


### PR DESCRIPTION
Fixes at least part of https://github.com/rust-lang/rust/issues/52849 (my CTFE-stress benchmark). Note that I do not know what I am doing here, this is just based on hints from @oli-obk.

r? @oli-obk 