### PR TITLE
rustc: Trim down the `rust_2018_idioms` lint group

### DIFF
--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -45,7 +45,6 @@ use rustc::lint::{LateContext, LateLintPass, LintPass, LintArray};
 use rustc::lint::builtin::{
     BARE_TRAIT_OBJECTS,
     ABSOLUTE_PATHS_NOT_STARTING_WITH_CRATE,
-    MACRO_USE_EXTERN_CRATE,
     ELIDED_LIFETIMES_IN_PATHS,
     parser::QUESTION_MARK_MACRO_SEP
 };
@@ -195,11 +194,18 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
     add_lint_group!(sess,
                     "rust_2018_idioms",
                     BARE_TRAIT_OBJECTS,
-                    UNREACHABLE_PUB,
                     UNUSED_EXTERN_CRATES,
-                    MACRO_USE_EXTERN_CRATE,
-                    ELIDED_LIFETIMES_IN_PATHS,
-                    ELLIPSIS_INCLUSIVE_RANGE_PATTERNS);
+                    ELLIPSIS_INCLUSIVE_RANGE_PATTERNS,
+                    ELIDED_LIFETIMES_IN_PATHS
+
+                    // FIXME(#52665, #47816) not always applicable and not all
+                    // macros are ready for this yet.
+                    // UNREACHABLE_PUB,
+
+                    // FIXME macro crates are not up for this yet, too much
+                    // breakage is seen if we try to encourage this lint.
+                    // MACRO_USE_EXTERN_CRATE,
+                    );
 
     // Guidelines for creating a future incompatibility lint:
     //

--- a/src/test/ui/rust-2018/macro-use-warned-against.rs
+++ b/src/test/ui/rust-2018/macro-use-warned-against.rs
@@ -12,7 +12,7 @@
 // aux-build:macro-use-warned-against2.rs
 // compile-pass
 
-#![warn(rust_2018_idioms, unused)]
+#![warn(macro_use_extern_crate, unused)]
 #![feature(use_extern_macros)]
 
 #[macro_use] //~ WARN should be replaced at use sites with a `use` statement

--- a/src/test/ui/rust-2018/macro-use-warned-against.stderr
+++ b/src/test/ui/rust-2018/macro-use-warned-against.stderr
@@ -7,9 +7,8 @@ LL | #[macro_use] //~ WARN should be replaced at use sites with a `use` statemen
 note: lint level defined here
   --> $DIR/macro-use-warned-against.rs:15:9
    |
-LL | #![warn(rust_2018_idioms, unused)]
-   |         ^^^^^^^^^^^^^^^^
-   = note: #[warn(macro_use_extern_crate)] implied by #[warn(rust_2018_idioms)]
+LL | #![warn(macro_use_extern_crate, unused)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused `#[macro_use]` import
   --> $DIR/macro-use-warned-against.rs:20:1
@@ -18,9 +17,9 @@ LL | #[macro_use] //~ WARN unused `#[macro_use]`
    | ^^^^^^^^^^^^
    |
 note: lint level defined here
-  --> $DIR/macro-use-warned-against.rs:15:27
+  --> $DIR/macro-use-warned-against.rs:15:33
    |
-LL | #![warn(rust_2018_idioms, unused)]
-   |                           ^^^^^^
+LL | #![warn(macro_use_extern_crate, unused)]
+   |                                 ^^^^^^
    = note: #[warn(unused_imports)] implied by #[warn(unused)]
 


### PR DESCRIPTION
These migration lints aren't all up to par in terms of a good migration
experience. Some, like `unreachable_pub`, hit bugs like #52665 and unprepared
macros to be handled enough of the time. Others like linting against
`#[macro_use]` are swimming upstream in an ecosystem that's not quite ready (and
slightly buggy pending a few current PRs).

The general idea is that we will continue to recommend the `rust_2018_idioms`
lint group as part of the transition guide (as an optional step) but we'll be
much more selective about which lints make it into this group. Only those with a
strong track record of not causing too much churn will make the cut.

cc #52679