### PR TITLE
Update compatibility note for 1.28.0 to be correct

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -94,9 +94,9 @@ Misc
 
 Compatibility Notes
 -------------------
-- [Rust will no longer consider trait objects with duplicated constraints to
-  have implementations.][51276] For example the below code will now fail
-  to compile.
+- [Rust will consider trait objects with duplicated constraints to be the same
+  type as without the duplicated constraint.][51276] For example the below code will
+  now fail to compile.
   ```rust
   trait Trait {}
 


### PR DESCRIPTION
You can still put implementations on `dyn Trait + Send + Send`, but it'd be the same as putting them on `dyn Trait + Send`. This is why the error is that there are duplicate definitions in the example.