### PR TITLE
Another SmallVec.extend optimization

### DIFF
--- a/src/librustc_data_structures/small_vec.rs
+++ b/src/librustc_data_structures/small_vec.rs
@@ -169,18 +169,11 @@ impl<A: Array> FromIterator<A::Element> for SmallVec<A> {
 
 impl<A: Array> Extend<A::Element> for SmallVec<A> {
     fn extend<I: IntoIterator<Item=A::Element>>(&mut self, iter: I) {
-        if self.is_array() {
-            let iter = iter.into_iter();
-            self.reserve(iter.size_hint().0);
-
-            for el in iter {
-                self.push(el);
-            }
-        } else {
-            match self.0 {
-                AccumulateVec::Heap(ref mut vec) => vec.extend(iter),
-                _ => unreachable!()
-            }
+        let iter = iter.into_iter();
+        self.reserve(iter.size_hint().0);
+        match self.0 {
+            AccumulateVec::Heap(ref mut vec) => vec.extend(iter),
+            _ => iter.for_each(|el| self.push(el))
         }
     }
 }


### PR DESCRIPTION
This improves SmallVec.extend even more over #52859 while making the code easier to read.

Before

```
test small_vec::tests::fill_small_vec_1_10_with_cap  ... bench:          31 ns/iter (+/- 5)
test small_vec::tests::fill_small_vec_1_10_wo_cap    ... bench:          70 ns/iter (+/- 4)
test small_vec::tests::fill_small_vec_1_50_with_cap  ... bench:          36 ns/iter (+/- 3)
test small_vec::tests::fill_small_vec_1_50_wo_cap    ... bench:         256 ns/iter (+/- 17)
test small_vec::tests::fill_small_vec_32_10_with_cap ... bench:          31 ns/iter (+/- 5)
test small_vec::tests::fill_small_vec_32_10_wo_cap   ... bench:          26 ns/iter (+/- 1)
test small_vec::tests::fill_small_vec_32_50_with_cap ... bench:          49 ns/iter (+/- 4)
test small_vec::tests::fill_small_vec_32_50_wo_cap   ... bench:         219 ns/iter (+/- 11)
test small_vec::tests::fill_small_vec_8_10_with_cap  ... bench:          32 ns/iter (+/- 2)
test small_vec::tests::fill_small_vec_8_10_wo_cap    ... bench:          61 ns/iter (+/- 12)
test small_vec::tests::fill_small_vec_8_50_with_cap  ... bench:          37 ns/iter (+/- 3)
test small_vec::tests::fill_small_vec_8_50_wo_cap    ... bench:         210 ns/iter (+/- 10)
```

After:

```
test small_vec::tests::fill_small_vec_1_10_wo_cap    ... bench:          31 ns/iter (+/- 3)
test small_vec::tests::fill_small_vec_1_50_with_cap  ... bench:          39 ns/iter (+/- 4)
test small_vec::tests::fill_small_vec_1_50_wo_cap    ... bench:          35 ns/iter (+/- 4)
test small_vec::tests::fill_small_vec_32_10_with_cap ... bench:          37 ns/iter (+/- 3)
test small_vec::tests::fill_small_vec_32_10_wo_cap   ... bench:          32 ns/iter (+/- 2)
test small_vec::tests::fill_small_vec_32_50_with_cap ... bench:          52 ns/iter (+/- 4)
test small_vec::tests::fill_small_vec_32_50_wo_cap   ... bench:          46 ns/iter (+/- 0)
test small_vec::tests::fill_small_vec_8_10_with_cap  ... bench:          35 ns/iter (+/- 4)
test small_vec::tests::fill_small_vec_8_10_wo_cap    ... bench:          31 ns/iter (+/- 0)
test small_vec::tests::fill_small_vec_8_50_with_cap  ... bench:          40 ns/iter (+/- 15)
test small_vec::tests::fill_small_vec_8_50_wo_cap    ... bench:          36 ns/iter (+/- 2)
```