### PR TITLE
1.27 actually added the `armv5te-unknown-linux-musleabi` target

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -216,7 +216,7 @@ Language
 
 Compiler
 --------
-- [Added the `armv5te-unknown-linux-musl` target.][50423]
+- [Added the `armv5te-unknown-linux-musleabi` target.][50423]
 
 Libraries
 ---------


### PR DESCRIPTION
The PR title says `armv5te-unknown-linux-musl`, but it looks like the final code merge renamed the target to `armv5te-unknown-linux-musleabi`. `rustup` reports this as correct as well.

The [Rust Platform Support](https://forge.rust-lang.org/platform-support.html) page needs this added as well, but I'm not certain what codebase that is generated from.