### PR TITLE
[NLL] Use smaller spans for errors involving closure captures

### DIFF
--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -1542,7 +1542,7 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
         if borrow_of_local_data(&borrow.borrowed_place) {
             let err = self.tcx
                 .cannot_borrow_across_generator_yield(
-                    self.retrieve_borrow_span(borrow),
+                    self.retrieve_borrow_spans(borrow).var_or_use(),
                     yield_span,
                     Origin::Mir,
                 );

--- a/src/librustc_mir/util/borrowck_errors.rs
+++ b/src/librustc_mir/util/borrowck_errors.rs
@@ -203,8 +203,15 @@ pub trait BorrowckErrors<'cx>: Sized + Copy {
             desc,
             OGN = o
         );
-        err.span_label(old_loan_span, "first closure is constructed here");
-        err.span_label(new_loan_span, "second closure is constructed here");
+        if old_loan_span == new_loan_span {
+            err.span_label(
+                old_loan_span,
+                "closures are constructed here in different iterations of loop"
+            );
+        } else {
+            err.span_label(old_loan_span, "first closure is constructed here");
+            err.span_label(new_loan_span, "second closure is constructed here");
+        }
         if let Some(old_load_end_span) = old_load_end_span {
             err.span_label(old_load_end_span, "borrow from first closure ends here");
         }

--- a/src/test/ui/borrowck/borrowck-closures-two-mut.stderr
+++ b/src/test/ui/borrowck/borrowck-closures-two-mut.stderr
@@ -77,11 +77,11 @@ error[E0499]: cannot borrow `x` as mutable more than once at a time (Mir)
   --> $DIR/borrowck-closures-two-mut.rs:24:24
    |
 LL |     let c1 = to_fn_mut(|| x = 4);
-   |                        -- - previous borrow occurs due to use of `x` in closure
+   |                        -- - first borrow occurs due to use of `x` in closure
    |                        |
    |                        first mutable borrow occurs here
 LL |     let c2 = to_fn_mut(|| x = 5); //~ ERROR cannot borrow `x` as mutable more than once
-   |                        ^^ - borrow occurs due to use of `x` in closure
+   |                        ^^ - second borrow occurs due to use of `x` in closure
    |                        |
    |                        second mutable borrow occurs here
 LL |     //~| ERROR cannot borrow `x` as mutable more than once
@@ -92,11 +92,11 @@ error[E0499]: cannot borrow `x` as mutable more than once at a time (Mir)
   --> $DIR/borrowck-closures-two-mut.rs:36:24
    |
 LL |     let c1 = to_fn_mut(|| set(&mut x));
-   |                        --          - previous borrow occurs due to use of `x` in closure
+   |                        --          - first borrow occurs due to use of `x` in closure
    |                        |
    |                        first mutable borrow occurs here
 LL |     let c2 = to_fn_mut(|| set(&mut x)); //~ ERROR cannot borrow `x` as mutable more than once
-   |                        ^^          - borrow occurs due to use of `x` in closure
+   |                        ^^          - second borrow occurs due to use of `x` in closure
    |                        |
    |                        second mutable borrow occurs here
 LL |     //~| ERROR cannot borrow `x` as mutable more than once
@@ -107,11 +107,11 @@ error[E0499]: cannot borrow `x` as mutable more than once at a time (Mir)
   --> $DIR/borrowck-closures-two-mut.rs:44:24
    |
 LL |     let c1 = to_fn_mut(|| x = 5);
-   |                        -- - previous borrow occurs due to use of `x` in closure
+   |                        -- - first borrow occurs due to use of `x` in closure
    |                        |
    |                        first mutable borrow occurs here
 LL |     let c2 = to_fn_mut(|| set(&mut x)); //~ ERROR cannot borrow `x` as mutable more than once
-   |                        ^^          - borrow occurs due to use of `x` in closure
+   |                        ^^          - second borrow occurs due to use of `x` in closure
    |                        |
    |                        second mutable borrow occurs here
 LL |     //~| ERROR cannot borrow `x` as mutable more than once
@@ -122,11 +122,11 @@ error[E0499]: cannot borrow `x` as mutable more than once at a time (Mir)
   --> $DIR/borrowck-closures-two-mut.rs:52:24
    |
 LL |     let c1 = to_fn_mut(|| x = 5);
-   |                        -- - previous borrow occurs due to use of `x` in closure
+   |                        -- - first borrow occurs due to use of `x` in closure
    |                        |
    |                        first mutable borrow occurs here
 LL |     let c2 = to_fn_mut(|| { let _y = to_fn_mut(|| set(&mut x)); }); // (nested closure)
-   |                        ^^                                  - borrow occurs due to use of `x` in closure
+   |                        ^^                                  - second borrow occurs due to use of `x` in closure
    |                        |
    |                        second mutable borrow occurs here
 ...
@@ -137,11 +137,11 @@ error[E0499]: cannot borrow `x` as mutable more than once at a time (Mir)
   --> $DIR/borrowck-closures-two-mut.rs:65:24
    |
 LL |     let c1 = to_fn_mut(|| set(&mut *x.f));
-   |                        --           - previous borrow occurs due to use of `x` in closure
+   |                        --           - first borrow occurs due to use of `x` in closure
    |                        |
    |                        first mutable borrow occurs here
 LL |     let c2 = to_fn_mut(|| set(&mut *x.f));
-   |                        ^^           - borrow occurs due to use of `x` in closure
+   |                        ^^           - second borrow occurs due to use of `x` in closure
    |                        |
    |                        second mutable borrow occurs here
 ...

--- a/src/test/ui/borrowck/borrowck-escaping-closure-error-1.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-escaping-closure-error-1.nll.stderr
@@ -1,8 +1,10 @@
 error[E0597]: `books` does not live long enough
-  --> $DIR/borrowck-escaping-closure-error-1.rs:23:11
+  --> $DIR/borrowck-escaping-closure-error-1.rs:23:14
    |
 LL |     spawn(|| books.push(4));
-   |           ^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+   |           -- ^^^^^ borrowed value does not live long enough
+   |           |
+   |           value captured here
 LL |     //~^ ERROR E0373
 LL | }
    | - `books` dropped here while still borrowed

--- a/src/test/ui/borrowck/borrowck-escaping-closure-error-2.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-escaping-closure-error-2.nll.stderr
@@ -1,8 +1,10 @@
 error[E0597]: `books` does not live long enough
-  --> $DIR/borrowck-escaping-closure-error-2.rs:21:14
+  --> $DIR/borrowck-escaping-closure-error-2.rs:21:17
    |
 LL |     Box::new(|| books.push(4))
-   |              ^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+   |              -- ^^^^^ borrowed value does not live long enough
+   |              |
+   |              value captured here
 LL |     //~^ ERROR E0373
 LL | }
    | - `books` dropped here while still borrowed

--- a/src/test/ui/error-codes/E0504.nll.stderr
+++ b/src/test/ui/error-codes/E0504.nll.stderr
@@ -1,17 +1,16 @@
 error[E0505]: cannot move out of `fancy_num` because it is borrowed
   --> $DIR/E0504.rs:19:13
    |
-LL |       let fancy_ref = &fancy_num;
-   |                       ---------- borrow of `fancy_num` occurs here
+LL |     let fancy_ref = &fancy_num;
+   |                     ---------- borrow of `fancy_num` occurs here
 LL | 
-LL |       let x = move || {
-   |  _____________^
-LL | |         println!("child function: {}", fancy_num.num); //~ ERROR E0504
-LL | |     };
-   | |_____^ move out of `fancy_num` occurs here
+LL |     let x = move || {
+   |             ^^^^^^^ move out of `fancy_num` occurs here
+LL |         println!("child function: {}", fancy_num.num); //~ ERROR E0504
+   |                                        --------- move occurs due to use in closure
 ...
-LL |       println!("main function: {}", fancy_ref.num);
-   |                                     ------------- borrow later used here
+LL |     println!("main function: {}", fancy_ref.num);
+   |                                   ------------- borrow later used here
 
 error: aborting due to previous error
 

--- a/src/test/ui/issue-11192.nll.stderr
+++ b/src/test/ui/issue-11192.nll.stderr
@@ -5,7 +5,7 @@ LL |     let mut test = |foo: &Foo| {
    |                    ----------- mutable borrow occurs here
 LL |         println!("access {}", foo.x);
 LL |         ptr = box Foo { x: ptr.x + 1 };
-   |         --- previous borrow occurs due to use of `ptr` in closure
+   |         --- first borrow occurs due to use of `ptr` in closure
 ...
 LL |     test(&*ptr);
    |     -----^^^^^-

--- a/src/test/ui/issue-11873.nll.stderr
+++ b/src/test/ui/issue-11873.nll.stderr
@@ -2,7 +2,9 @@ error[E0505]: cannot move out of `v` because it is borrowed
   --> $DIR/issue-11873.rs:14:14
    |
 LL |     let mut f = || v.push(2);
-   |                 ------------ borrow of `v` occurs here
+   |                 -- - borrow occurs due to use in closure
+   |                 |
+   |                 borrow of `v` occurs here
 LL |     let _w = v; //~ ERROR: cannot move out of `v`
    |              ^ move out of `v` occurs here
 LL | 

--- a/src/test/ui/issue-18783.nll.stderr
+++ b/src/test/ui/issue-18783.nll.stderr
@@ -2,11 +2,11 @@ error[E0499]: cannot borrow `y` as mutable more than once at a time
   --> $DIR/issue-18783.rs:17:21
    |
 LL |     c.push(Box::new(|| y = 0));
-   |                     -- - previous borrow occurs due to use of `y` in closure
+   |                     -- - first borrow occurs due to use of `y` in closure
    |                     |
    |                     first mutable borrow occurs here
 LL |     c.push(Box::new(|| y = 0));
-   |                     ^^ - borrow occurs due to use of `y` in closure
+   |                     ^^ - second borrow occurs due to use of `y` in closure
    |                     |
    |                     second mutable borrow occurs here
 LL | //~^ ERROR cannot borrow `y` as mutable more than once at a time
@@ -17,11 +17,11 @@ error[E0499]: cannot borrow `y` as mutable more than once at a time
   --> $DIR/issue-18783.rs:26:29
    |
 LL |     Push::push(&c, Box::new(|| y = 0));
-   |                             -- - previous borrow occurs due to use of `y` in closure
+   |                             -- - first borrow occurs due to use of `y` in closure
    |                             |
    |                             first mutable borrow occurs here
 LL |     Push::push(&c, Box::new(|| y = 0));
-   |                             ^^ - borrow occurs due to use of `y` in closure
+   |                             ^^ - second borrow occurs due to use of `y` in closure
    |                             |
    |                             second mutable borrow occurs here
 LL | //~^ ERROR cannot borrow `y` as mutable more than once at a time

--- a/src/test/ui/issue-24357.nll.stderr
+++ b/src/test/ui/issue-24357.nll.stderr
@@ -2,7 +2,9 @@ error[E0382]: use of moved value: `x`
   --> $DIR/issue-24357.rs:16:12
    |
 LL |    let f = move || { let y = x; };
-   |            ---------------------- value moved here
+   |            -------           - variable moved due to use in closure
+   |            |
+   |            value moved into closure here
 LL |    //~^ NOTE value moved (into closure) here
 LL |    let z = x;
    |            ^ value used here after move

--- a/src/test/ui/issue-27282-move-match-input-into-guard.stderr
+++ b/src/test/ui/issue-27282-move-match-input-into-guard.stderr
@@ -1,11 +1,13 @@
 error[E0505]: cannot move out of `b` because it is borrowed
-  --> $DIR/issue-27282-move-match-input-into-guard.rs:26:16
+  --> $DIR/issue-27282-move-match-input-into-guard.rs:26:17
    |
 LL |     match b {
    |           - borrow of `b` occurs here
 LL |         &mut false => {},
 LL |         _ if { (|| { let bar = b; *bar = false; })();
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ move out of `b` occurs here
+   |                 ^^             - move occurs due to use in closure
+   |                 |
+   |                 move out of `b` occurs here
 ...
 LL |         &mut true => { println!("You might think we should get here"); },
    |         --------- borrow later used here
@@ -14,7 +16,9 @@ error[E0382]: use of moved value: `*b`
   --> $DIR/issue-27282-move-match-input-into-guard.rs:29:14
    |
 LL |         _ if { (|| { let bar = b; *bar = false; })();
-   |                ----------------------------------- value moved here
+   |                 --             - variable moved due to use in closure
+   |                 |
+   |                 value moved into closure here
 ...
 LL |         &mut true => { println!("You might think we should get here"); },
    |              ^^^^ value used here after move

--- a/src/test/ui/issue-27282-mutate-before-diverging-arm-1.stderr
+++ b/src/test/ui/issue-27282-mutate-before-diverging-arm-1.stderr
@@ -5,7 +5,7 @@ LL |     match x {
    |           - borrow occurs here
 ...
 LL |             (|| { *x = None; drop(force_fn_once); })();
-   |              ^^    - borrow occurs due to use of `x` in closure
+   |              ^^    - second borrow occurs due to use of `x` in closure
    |              |
    |              closure construction occurs here
 ...

--- a/src/test/ui/issue-27282-mutate-before-diverging-arm-2.stderr
+++ b/src/test/ui/issue-27282-mutate-before-diverging-arm-2.stderr
@@ -5,7 +5,7 @@ LL |     match x {
    |           - borrow occurs here
 ...
 LL |                 (|| { *x = None; drop(force_fn_once); })();
-   |                  ^^    - borrow occurs due to use of `x` in closure
+   |                  ^^    - second borrow occurs due to use of `x` in closure
    |                  |
    |                  closure construction occurs here
 ...

--- a/src/test/ui/issue-4335.nll.stderr
+++ b/src/test/ui/issue-4335.nll.stderr
@@ -5,10 +5,12 @@ LL |     id(Box::new(|| *v))
    |                    ^^ cannot move out of captured variable in an `FnMut` closure
 
 error[E0597]: `v` does not live long enough
-  --> $DIR/issue-4335.rs:16:17
+  --> $DIR/issue-4335.rs:16:21
    |
 LL |     id(Box::new(|| *v))
-   |                 ^^^^^ borrowed value does not live long enough
+   |                 --  ^ borrowed value does not live long enough
+   |                 |
+   |                 value captured here
 ...
 LL | }
    | - `v` dropped here while still borrowed

--- a/src/test/ui/issue-6801.nll.stderr
+++ b/src/test/ui/issue-6801.nll.stderr
@@ -2,7 +2,9 @@ error[E0505]: cannot move out of `x` because it is borrowed
   --> $DIR/issue-6801.rs:29:13
    |
 LL |       let sq =  || { *x * *x };
-   |                 -------------- borrow of `x` occurs here
+   |                 --    - borrow occurs due to use in closure
+   |                 |
+   |                 borrow of `x` occurs here
 LL | 
 LL |       twice(x); //~ ERROR: cannot move out of
    |             ^ move out of `x` occurs here

--- a/src/test/ui/nll/closure-access-spans.rs
+++ b/src/test/ui/nll/closure-access-spans.rs
@@ -1,0 +1,68 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// check that accesses due to a closure capture give a special note
+
+#![feature(nll)]
+
+fn closure_imm_capture_conflict(mut x: i32) {
+    let r = &mut x;
+    || x; //~ ERROR
+    r.use_mut();
+}
+
+fn closure_mut_capture_conflict(mut x: i32) {
+    let r = &mut x;
+    || x = 2; //~ ERROR
+    r.use_mut();
+}
+
+fn closure_unique_capture_conflict(mut x: &mut i32) {
+    let r = &mut x;
+    || *x = 2; //~ ERROR
+    r.use_mut();
+}
+
+fn closure_copy_capture_conflict(mut x: i32) {
+    let r = &mut x;
+    move || x; //~ ERROR
+    r.use_ref();
+}
+
+fn closure_move_capture_conflict(mut x: String) {
+    let r = &x;
+    || x; //~ ERROR
+    r.use_ref();
+}
+
+fn closure_imm_capture_moved(mut x: String) {
+    let r = x;
+    || x.len(); //~ ERROR
+}
+
+fn closure_mut_capture_moved(mut x: String) {
+    let r = x;
+    || x = String::new(); //~ ERROR
+}
+
+fn closure_unique_capture_moved(x: &mut String) {
+    let r = x;
+    || *x = String::new(); //~ ERROR
+}
+
+fn closure_move_capture_moved(x: &mut String) {
+    let r = x;
+    || x; //~ ERROR
+}
+
+fn main() {}
+
+trait Fake { fn use_mut(&mut self) { } fn use_ref(&self) { }  }
+impl<T> Fake for T { }

--- a/src/test/ui/nll/closure-access-spans.stderr
+++ b/src/test/ui/nll/closure-access-spans.stderr
@@ -1,0 +1,110 @@
+error[E0502]: cannot borrow `x` as immutable because it is also borrowed as mutable
+  --> $DIR/closure-access-spans.rs:17:5
+   |
+LL |     let r = &mut x;
+   |             ------ mutable borrow occurs here
+LL |     || x; //~ ERROR
+   |     ^^ - second borrow occurs due to use of `x` in closure
+   |     |
+   |     immutable borrow occurs here
+LL |     r.use_mut();
+   |     - borrow later used here
+
+error[E0499]: cannot borrow `x` as mutable more than once at a time
+  --> $DIR/closure-access-spans.rs:23:5
+   |
+LL |     let r = &mut x;
+   |             ------ first mutable borrow occurs here
+LL |     || x = 2; //~ ERROR
+   |     ^^ - second borrow occurs due to use of `x` in closure
+   |     |
+   |     second mutable borrow occurs here
+LL |     r.use_mut();
+   |     - borrow later used here
+
+error[E0500]: closure requires unique access to `x` but it is already borrowed
+  --> $DIR/closure-access-spans.rs:29:5
+   |
+LL |     let r = &mut x;
+   |             ------ borrow occurs here
+LL |     || *x = 2; //~ ERROR
+   |     ^^  - second borrow occurs due to use of `x` in closure
+   |     |
+   |     closure construction occurs here
+LL |     r.use_mut();
+   |     - borrow later used here
+
+error[E0503]: cannot use `x` because it was mutably borrowed
+  --> $DIR/closure-access-spans.rs:35:13
+   |
+LL |     let r = &mut x;
+   |             ------ borrow of `x` occurs here
+LL |     move || x; //~ ERROR
+   |             ^ use of borrowed `x`
+LL |     r.use_ref();
+   |     - borrow later used here
+
+error[E0505]: cannot move out of `x` because it is borrowed
+  --> $DIR/closure-access-spans.rs:41:5
+   |
+LL |     let r = &x;
+   |             -- borrow of `x` occurs here
+LL |     || x; //~ ERROR
+   |     ^^ - move occurs due to use in closure
+   |     |
+   |     move out of `x` occurs here
+LL |     r.use_ref();
+   |     - borrow later used here
+
+error[E0382]: borrow of moved value: `x`
+  --> $DIR/closure-access-spans.rs:47:5
+   |
+LL |     let r = x;
+   |             - value moved here
+LL |     || x.len(); //~ ERROR
+   |     ^^ - borrow occurs due to use in closure
+   |     |
+   |     value borrowed here after move
+   |
+   = note: move occurs because `x` has type `std::string::String`, which does not implement the `Copy` trait
+
+error[E0382]: borrow of moved value: `x`
+  --> $DIR/closure-access-spans.rs:52:5
+   |
+LL |     let r = x;
+   |             - value moved here
+LL |     || x = String::new(); //~ ERROR
+   |     ^^ - borrow occurs due to use in closure
+   |     |
+   |     value borrowed here after move
+   |
+   = note: move occurs because `x` has type `std::string::String`, which does not implement the `Copy` trait
+
+error[E0382]: borrow of moved value: `x`
+  --> $DIR/closure-access-spans.rs:57:5
+   |
+LL |     let r = x;
+   |             - value moved here
+LL |     || *x = String::new(); //~ ERROR
+   |     ^^  - borrow occurs due to use in closure
+   |     |
+   |     value borrowed here after move
+   |
+   = note: move occurs because `x` has type `&mut std::string::String`, which does not implement the `Copy` trait
+
+error[E0382]: use of moved value: `x`
+  --> $DIR/closure-access-spans.rs:62:5
+   |
+LL |     let r = x;
+   |             - value moved here
+LL |     || x; //~ ERROR
+   |     ^^ - use occurs due to use in closure
+   |     |
+   |     value used here after move
+   |
+   = note: move occurs because `x` has type `&mut std::string::String`, which does not implement the `Copy` trait
+
+error: aborting due to 9 previous errors
+
+Some errors occurred: E0382, E0499, E0500, E0502, E0503, E0505.
+For more information about an error, try `rustc --explain E0382`.

--- a/src/test/ui/nll/closure-borrow-spans.rs
+++ b/src/test/ui/nll/closure-borrow-spans.rs
@@ -1,0 +1,112 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// check that existing borrows due to a closure capture give a special note
+
+#![feature(nll)]
+
+fn move_while_borrowed(x: String) {
+    let f = || x.len();
+    let y = x; //~ ERROR
+    f.use_ref();
+}
+
+fn borrow_mut_while_borrowed(mut x: i32) {
+    let f = || x;
+    let y = &mut x; //~ ERROR
+    f.use_ref();
+}
+
+fn drop_while_borrowed() {
+    let f;
+    {
+        let x = 1;
+        f = || x; //~ ERROR
+    }
+    f.use_ref();
+}
+
+fn assign_while_borrowed(mut x: i32) {
+    let f = || x;
+    x = 1; //~ ERROR
+    f.use_ref();
+}
+
+fn copy_while_borrowed_mut(mut x: i32) {
+    let f = || x = 0;
+    let y = x; //~ ERROR
+    f.use_ref();
+}
+
+fn borrow_while_borrowed_mut(mut x: i32) {
+    let f = || x = 0;
+    let y = &x; //~ ERROR
+    f.use_ref();
+}
+
+fn borrow_mut_while_borrowed_mut(mut x: i32) {
+    let f = || x = 0;
+    let y = &mut x; //~ ERROR
+    f.use_ref();
+}
+
+fn drop_while_borrowed_mut() {
+    let f;
+    {
+        let mut x = 1;
+        f = || x = 0; //~ ERROR
+    }
+    f.use_ref();
+}
+
+fn assign_while_borrowed_mut(mut x: i32) {
+    let f = || x = 0;
+    x = 1; //~ ERROR
+    f.use_ref();
+}
+
+fn copy_while_borrowed_unique(x: &mut i32) {
+    let f = || *x = 0;
+    let y = x; //~ ERROR
+    f.use_ref();
+}
+
+fn borrow_while_borrowed_unique(x: &mut i32) {
+    let f = || *x = 0;
+    let y = &x; //~ ERROR
+    f.use_ref();
+}
+
+fn borrow_mut_while_borrowed_unique(mut x: &mut i32) {
+    let f = || *x = 0;
+    let y = &mut x; //~ ERROR
+    f.use_ref();
+}
+
+fn drop_while_borrowed_unique() {
+    let mut z = 1;
+    let f;
+    {
+        let x = &mut z;
+        f = || *x = 0; //~ ERROR
+    }
+    f.use_ref();
+}
+
+fn assign_while_borrowed_unique(x: &mut i32) {
+    let f = || *x = 0;
+    *x = 1; //~ ERROR
+    f.use_ref();
+}
+
+fn main() {}
+
+trait Fake { fn use_mut(&mut self) { } fn use_ref(&self) { }  }
+impl<T> Fake for T { }

--- a/src/test/ui/nll/closure-borrow-spans.stderr
+++ b/src/test/ui/nll/closure-borrow-spans.stderr
@@ -1,0 +1,172 @@
+error[E0505]: cannot move out of `x` because it is borrowed
+  --> $DIR/closure-borrow-spans.rs:17:13
+   |
+LL |     let f = || x.len();
+   |             -- - borrow occurs due to use in closure
+   |             |
+   |             borrow of `x` occurs here
+LL |     let y = x; //~ ERROR
+   |             ^ move out of `x` occurs here
+LL |     f.use_ref();
+   |     - borrow later used here
+
+error[E0502]: cannot borrow `x` as mutable because it is also borrowed as immutable
+  --> $DIR/closure-borrow-spans.rs:23:13
+   |
+LL |     let f = || x;
+   |             -- - first borrow occurs due to use of `x` in closure
+   |             |
+   |             immutable borrow occurs here
+LL |     let y = &mut x; //~ ERROR
+   |             ^^^^^^ mutable borrow occurs here
+LL |     f.use_ref();
+   |     - borrow later used here
+
+error[E0597]: `x` does not live long enough
+  --> $DIR/closure-borrow-spans.rs:31:16
+   |
+LL |         f = || x; //~ ERROR
+   |             -- ^ borrowed value does not live long enough
+   |             |
+   |             value captured here
+LL |     }
+   |     - `x` dropped here while still borrowed
+LL |     f.use_ref();
+   |     - borrow later used here
+
+error[E0506]: cannot assign to `x` because it is borrowed
+  --> $DIR/closure-borrow-spans.rs:38:5
+   |
+LL |     let f = || x;
+   |             -- - borrow occurs due to use in closure
+   |             |
+   |             borrow of `x` occurs here
+LL |     x = 1; //~ ERROR
+   |     ^^^^^ assignment to borrowed `x` occurs here
+LL |     f.use_ref();
+   |     - borrow later used here
+
+error[E0503]: cannot use `x` because it was mutably borrowed
+  --> $DIR/closure-borrow-spans.rs:44:13
+   |
+LL |     let f = || x = 0;
+   |             -- - borrow occurs due to use of `x` in closure
+   |             |
+   |             borrow of `x` occurs here
+LL |     let y = x; //~ ERROR
+   |             ^ use of borrowed `x`
+LL |     f.use_ref();
+   |     - borrow later used here
+
+error[E0502]: cannot borrow `x` as immutable because it is also borrowed as mutable
+  --> $DIR/closure-borrow-spans.rs:50:13
+   |
+LL |     let f = || x = 0;
+   |             -- - first borrow occurs due to use of `x` in closure
+   |             |
+   |             mutable borrow occurs here
+LL |     let y = &x; //~ ERROR
+   |             ^^ immutable borrow occurs here
+LL |     f.use_ref();
+   |     - borrow later used here
+
+error[E0499]: cannot borrow `x` as mutable more than once at a time
+  --> $DIR/closure-borrow-spans.rs:56:13
+   |
+LL |     let f = || x = 0;
+   |             -- - first borrow occurs due to use of `x` in closure
+   |             |
+   |             first mutable borrow occurs here
+LL |     let y = &mut x; //~ ERROR
+   |             ^^^^^^ second mutable borrow occurs here
+LL |     f.use_ref();
+   |     - borrow later used here
+
+error[E0597]: `x` does not live long enough
+  --> $DIR/closure-borrow-spans.rs:64:16
+   |
+LL |         f = || x = 0; //~ ERROR
+   |             -- ^ borrowed value does not live long enough
+   |             |
+   |             value captured here
+LL |     }
+   |     - `x` dropped here while still borrowed
+LL |     f.use_ref();
+   |     - borrow later used here
+
+error[E0506]: cannot assign to `x` because it is borrowed
+  --> $DIR/closure-borrow-spans.rs:71:5
+   |
+LL |     let f = || x = 0;
+   |             -- - borrow occurs due to use in closure
+   |             |
+   |             borrow of `x` occurs here
+LL |     x = 1; //~ ERROR
+   |     ^^^^^ assignment to borrowed `x` occurs here
+LL |     f.use_ref();
+   |     - borrow later used here
+
+error[E0505]: cannot move out of `x` because it is borrowed
+  --> $DIR/closure-borrow-spans.rs:77:13
+   |
+LL |     let f = || *x = 0;
+   |             --  - borrow occurs due to use in closure
+   |             |
+   |             borrow of `x` occurs here
+LL |     let y = x; //~ ERROR
+   |             ^ move out of `x` occurs here
+LL |     f.use_ref();
+   |     - borrow later used here
+
+error[E0501]: cannot borrow `x` as immutable because previous closure requires unique access
+  --> $DIR/closure-borrow-spans.rs:83:13
+   |
+LL |     let f = || *x = 0;
+   |             --  - first borrow occurs due to use of `x` in closure
+   |             |
+   |             closure construction occurs here
+LL |     let y = &x; //~ ERROR
+   |             ^^ borrow occurs here
+LL |     f.use_ref();
+   |     - borrow later used here
+
+error[E0501]: cannot borrow `x` as mutable because previous closure requires unique access
+  --> $DIR/closure-borrow-spans.rs:89:13
+   |
+LL |     let f = || *x = 0;
+   |             --  - first borrow occurs due to use of `x` in closure
+   |             |
+   |             closure construction occurs here
+LL |     let y = &mut x; //~ ERROR
+   |             ^^^^^^ borrow occurs here
+LL |     f.use_ref();
+   |     - borrow later used here
+
+error[E0597]: `x` does not live long enough
+  --> $DIR/closure-borrow-spans.rs:98:17
+   |
+LL |         f = || *x = 0; //~ ERROR
+   |             --  ^ borrowed value does not live long enough
+   |             |
+   |             value captured here
+LL |     }
+   |     - `x` dropped here while still borrowed
+LL |     f.use_ref();
+   |     - borrow later used here
+
+error[E0506]: cannot assign to `*x` because it is borrowed
+  --> $DIR/closure-borrow-spans.rs:105:5
+   |
+LL |     let f = || *x = 0;
+   |             --  - borrow occurs due to use in closure
+   |             |
+   |             borrow of `*x` occurs here
+LL |     *x = 1; //~ ERROR
+   |     ^^^^^^ assignment to borrowed `*x` occurs here
+LL |     f.use_ref();
+   |     - borrow later used here
+
+error: aborting due to 14 previous errors
+
+Some errors occurred: E0499, E0501, E0502, E0503, E0505, E0506, E0597.
+For more information about an error, try `rustc --explain E0499`.

--- a/src/test/ui/nll/closure-captures.rs
+++ b/src/test/ui/nll/closure-captures.rs
@@ -13,7 +13,7 @@
 #![allow(unused)]
 #![feature(nll)]
 
-// Should have one error per assigment
+// Should have one error per assignment
 
 fn one_closure(x: i32) {
     ||

--- a/src/test/ui/nll/closure-move-spans.rs
+++ b/src/test/ui/nll/closure-move-spans.rs
@@ -1,0 +1,33 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// check that moves due to a closure capture give a special note
+
+#![feature(nll)]
+
+fn move_after_move(x: String) {
+    || x;
+    let y = x; //~ ERROR
+}
+
+fn borrow_after_move(x: String) {
+    || x;
+    let y = &x; //~ ERROR
+}
+
+fn borrow_mut_after_move(mut x: String) {
+    || x;
+    let y = &mut x; //~ ERROR
+}
+
+fn fn_ref<F: Fn()>(f: F) -> F { f }
+fn fn_mut<F: FnMut()>(f: F) -> F { f }
+
+fn main() {}

--- a/src/test/ui/nll/closure-move-spans.stderr
+++ b/src/test/ui/nll/closure-move-spans.stderr
@@ -1,0 +1,39 @@
+error[E0382]: use of moved value: `x`
+  --> $DIR/closure-move-spans.rs:17:13
+   |
+LL |     || x;
+   |     -- - variable moved due to use in closure
+   |     |
+   |     value moved into closure here
+LL |     let y = x; //~ ERROR
+   |             ^ value used here after move
+   |
+   = note: move occurs because `x` has type `std::string::String`, which does not implement the `Copy` trait
+
+error[E0382]: borrow of moved value: `x`
+  --> $DIR/closure-move-spans.rs:22:13
+   |
+LL |     || x;
+   |     -- - variable moved due to use in closure
+   |     |
+   |     value moved into closure here
+LL |     let y = &x; //~ ERROR
+   |             ^^ value borrowed here after move
+   |
+   = note: move occurs because `x` has type `std::string::String`, which does not implement the `Copy` trait
+
+error[E0382]: borrow of moved value: `x`
+  --> $DIR/closure-move-spans.rs:27:13
+   |
+LL |     || x;
+   |     -- - variable moved due to use in closure
+   |     |
+   |     value moved into closure here
+LL |     let y = &mut x; //~ ERROR
+   |             ^^^^^^ value borrowed here after move
+   |
+   = note: move occurs because `x` has type `std::string::String`, which does not implement the `Copy` trait
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0382`.

--- a/src/test/ui/nll/closure-requirements/escape-upvar-nested.rs
+++ b/src/test/ui/nll/closure-requirements/escape-upvar-nested.rs
@@ -27,8 +27,8 @@ fn test() {
     {
         let y = 22;
 
-        let mut closure = || { //~ ERROR `y` does not live long enough [E0597]
-            let mut closure1 = || p = &y;
+        let mut closure = || {
+            let mut closure1 = || p = &y; //~ ERROR `y` does not live long enough [E0597]
             closure1();
         };
 

--- a/src/test/ui/nll/closure-requirements/escape-upvar-nested.stderr
+++ b/src/test/ui/nll/closure-requirements/escape-upvar-nested.stderr
@@ -1,7 +1,7 @@
 note: External requirements
   --> $DIR/escape-upvar-nested.rs:31:32
    |
-LL |             let mut closure1 = || p = &y;
+LL |             let mut closure1 = || p = &y; //~ ERROR `y` does not live long enough [E0597]
    |                                ^^^^^^^^^
    |
    = note: defining type: DefId(0/1:10 ~ escape_upvar_nested[317d]::test[0]::{{closure}}[0]::{{closure}}[0]) with closure substs [
@@ -16,9 +16,9 @@ LL |             let mut closure1 = || p = &y;
 note: External requirements
   --> $DIR/escape-upvar-nested.rs:30:27
    |
-LL |           let mut closure = || { //~ ERROR `y` does not live long enough [E0597]
+LL |           let mut closure = || {
    |  ___________________________^
-LL | |             let mut closure1 = || p = &y;
+LL | |             let mut closure1 = || p = &y; //~ ERROR `y` does not live long enough [E0597]
 LL | |             closure1();
 LL | |         };
    | |_________^
@@ -47,20 +47,18 @@ LL | | }
    = note: defining type: DefId(0/0:3 ~ escape_upvar_nested[317d]::test[0]) with substs []
 
 error[E0597]: `y` does not live long enough
-  --> $DIR/escape-upvar-nested.rs:30:27
+  --> $DIR/escape-upvar-nested.rs:31:40
    |
-LL |           let mut closure = || { //~ ERROR `y` does not live long enough [E0597]
-   |  ___________________________^
-LL | |             let mut closure1 = || p = &y;
-LL | |             closure1();
-LL | |         };
-   | |_________^ borrowed value does not live long enough
+LL |         let mut closure = || {
+   |                           -- value captured here
+LL |             let mut closure1 = || p = &y; //~ ERROR `y` does not live long enough [E0597]
+   |                                        ^ borrowed value does not live long enough
 ...
-LL |       }
-   |       - `y` dropped here while still borrowed
+LL |     }
+   |     - `y` dropped here while still borrowed
 LL | 
-LL |       deref(p);
-   |             - borrow later used here
+LL |     deref(p);
+   |           - borrow later used here
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/closure-requirements/escape-upvar-ref.stderr
+++ b/src/test/ui/nll/closure-requirements/escape-upvar-ref.stderr
@@ -28,10 +28,12 @@ LL | | }
    = note: defining type: DefId(0/0:3 ~ escape_upvar_ref[317d]::test[0]) with substs []
 
 error[E0597]: `y` does not live long enough
-  --> $DIR/escape-upvar-ref.rs:33:27
+  --> $DIR/escape-upvar-ref.rs:33:35
    |
 LL |         let mut closure = || p = &y;
-   |                           ^^^^^^^^^ borrowed value does not live long enough
+   |                           --      ^ borrowed value does not live long enough
+   |                           |
+   |                           value captured here
 ...
 LL |     }
    |     - `y` dropped here while still borrowed

--- a/src/test/ui/nll/closure-use-spans.rs
+++ b/src/test/ui/nll/closure-use-spans.rs
@@ -1,0 +1,33 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// check that liveness due to a closure capture gives a special note
+
+#![feature(nll)]
+
+fn use_as_borrow_capture(mut x: i32) {
+    let y = &x;
+    x = 0; //~ ERROR
+    || *y;
+}
+
+fn use_as_borrow_mut_capture(mut x: i32) {
+    let y = &mut x;
+    x = 0; //~ ERROR
+    || *y = 1;
+}
+
+fn use_as_move_capture(mut x: i32) {
+    let y = &x;
+    x = 0; //~ ERROR
+    move || *y;
+}
+
+fn main() {}

--- a/src/test/ui/nll/closure-use-spans.stderr
+++ b/src/test/ui/nll/closure-use-spans.stderr
@@ -1,0 +1,33 @@
+error[E0506]: cannot assign to `x` because it is borrowed
+  --> $DIR/closure-use-spans.rs:17:5
+   |
+LL |     let y = &x;
+   |             -- borrow of `x` occurs here
+LL |     x = 0; //~ ERROR
+   |     ^^^^^ assignment to borrowed `x` occurs here
+LL |     || *y;
+   |         - borrow later captured here by closure
+
+error[E0506]: cannot assign to `x` because it is borrowed
+  --> $DIR/closure-use-spans.rs:23:5
+   |
+LL |     let y = &mut x;
+   |             ------ borrow of `x` occurs here
+LL |     x = 0; //~ ERROR
+   |     ^^^^^ assignment to borrowed `x` occurs here
+LL |     || *y = 1;
+   |         - borrow later captured here by closure
+
+error[E0506]: cannot assign to `x` because it is borrowed
+  --> $DIR/closure-use-spans.rs:29:5
+   |
+LL |     let y = &x;
+   |             -- borrow of `x` occurs here
+LL |     x = 0; //~ ERROR
+   |     ^^^^^ assignment to borrowed `x` occurs here
+LL |     move || *y;
+   |              - borrow later captured here by closure
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0506`.

--- a/src/test/ui/nll/closures-in-loops.rs
+++ b/src/test/ui/nll/closures-in-loops.rs
@@ -1,0 +1,36 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test messages where a closure capture conflicts with itself because it's in
+// a loop.
+
+#![feature(nll)]
+
+fn repreated_move(x: String) {
+    for i in 0..10 {
+        || x; //~ ERROR
+    }
+}
+
+fn repreated_mut_borrow(mut x: String) {
+    let mut v = Vec::new();
+    for i in 0..10 {
+        v.push(|| x = String::new()); //~ ERROR
+    }
+}
+
+fn repreated_unique_borrow(x: &mut String) {
+    let mut v = Vec::new();
+    for i in 0..10 {
+        v.push(|| *x = String::new()); //~ ERROR
+    }
+}
+
+fn main() {}

--- a/src/test/ui/nll/closures-in-loops.stderr
+++ b/src/test/ui/nll/closures-in-loops.stderr
@@ -1,0 +1,30 @@
+error[E0382]: use of moved value: `x`
+  --> $DIR/closures-in-loops.rs:18:9
+   |
+LL |         || x; //~ ERROR
+   |         ^^ - use occurs due to use in closure
+   |         |
+   |         value moved into closure here in previous iteration of loop
+   |
+   = note: move occurs because `x` has type `std::string::String`, which does not implement the `Copy` trait
+
+error[E0499]: cannot borrow `x` as mutable more than once at a time
+  --> $DIR/closures-in-loops.rs:25:16
+   |
+LL |         v.push(|| x = String::new()); //~ ERROR
+   |                ^^ - borrows occur due to use of `x` in closure
+   |                |
+   |                mutable borrow starts here in previous iteration of loop
+
+error[E0524]: two closures require unique access to `x` at the same time
+  --> $DIR/closures-in-loops.rs:32:16
+   |
+LL |         v.push(|| *x = String::new()); //~ ERROR
+   |                ^^  - borrows occur due to use of `x` in closure
+   |                |
+   |                closures are constructed here in different iterations of loop
+
+error: aborting due to 3 previous errors
+
+Some errors occurred: E0382, E0499, E0524.
+For more information about an error, try `rustc --explain E0382`.

--- a/src/test/ui/nll/issue-51268.stderr
+++ b/src/test/ui/nll/issue-51268.stderr
@@ -8,7 +8,7 @@ LL |            self.thing.bar(|| {
    | ||
 LL | ||         //~^ ERROR cannot borrow `self.thing` as mutable because it is also borrowed as immutable [E0502]
 LL | ||             &self.number;
-   | ||              ---- previous borrow occurs due to use of `self` in closure
+   | ||              ---- first borrow occurs due to use of `self` in closure
 LL | ||         });
    | ||          ^
    | ||__________|

--- a/src/test/ui/region-borrow-params-issue-29793-small.nll.stderr
+++ b/src/test/ui/region-borrow-params-issue-29793-small.nll.stderr
@@ -1,44 +1,54 @@
 error[E0597]: `x` does not live long enough
-  --> $DIR/region-borrow-params-issue-29793-small.rs:19:17
+  --> $DIR/region-borrow-params-issue-29793-small.rs:19:34
    |
 LL |         let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+   |                 ---------        ^ borrowed value does not live long enough
+   |                 |
+   |                 value captured here
 ...
 LL |     };
    |      - `x` dropped here while still borrowed
 
 error[E0597]: `y` does not live long enough
-  --> $DIR/region-borrow-params-issue-29793-small.rs:19:17
+  --> $DIR/region-borrow-params-issue-29793-small.rs:19:45
    |
 LL |         let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+   |                 ---------                   ^ borrowed value does not live long enough
+   |                 |
+   |                 value captured here
 ...
 LL |     };
    |      - `y` dropped here while still borrowed
 
 error[E0597]: `x` does not live long enough
-  --> $DIR/region-borrow-params-issue-29793-small.rs:34:17
+  --> $DIR/region-borrow-params-issue-29793-small.rs:34:34
    |
 LL |         let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+   |                 ---------        ^ borrowed value does not live long enough
+   |                 |
+   |                 value captured here
 ...
 LL |     };
    |      - `x` dropped here while still borrowed
 
 error[E0597]: `y` does not live long enough
-  --> $DIR/region-borrow-params-issue-29793-small.rs:34:17
+  --> $DIR/region-borrow-params-issue-29793-small.rs:34:45
    |
 LL |         let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+   |                 ---------                   ^ borrowed value does not live long enough
+   |                 |
+   |                 value captured here
 ...
 LL |     };
    |      - `y` dropped here while still borrowed
 
 error[E0597]: `x` does not live long enough
-  --> $DIR/region-borrow-params-issue-29793-small.rs:65:17
+  --> $DIR/region-borrow-params-issue-29793-small.rs:65:34
    |
 LL |         let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+   |                 ---------        ^ borrowed value does not live long enough
+   |                 |
+   |                 value captured here
 ...
 LL |     };
    |     - `x` dropped here while still borrowed
@@ -50,10 +60,12 @@ LL |     fn g<'a>(x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
    |          ^^
 
 error[E0597]: `y` does not live long enough
-  --> $DIR/region-borrow-params-issue-29793-small.rs:65:17
+  --> $DIR/region-borrow-params-issue-29793-small.rs:65:45
    |
 LL |         let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+   |                 ---------                   ^ borrowed value does not live long enough
+   |                 |
+   |                 value captured here
 ...
 LL |     };
    |     - `y` dropped here while still borrowed
@@ -65,10 +77,12 @@ LL |     fn g<'a>(x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
    |          ^^
 
 error[E0597]: `x` does not live long enough
-  --> $DIR/region-borrow-params-issue-29793-small.rs:76:17
+  --> $DIR/region-borrow-params-issue-29793-small.rs:76:34
    |
 LL |         let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+   |                 ---------        ^ borrowed value does not live long enough
+   |                 |
+   |                 value captured here
 ...
 LL |     };
    |     - `x` dropped here while still borrowed
@@ -80,10 +94,12 @@ LL |     fn g<'a>(x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
    |          ^^
 
 error[E0597]: `y` does not live long enough
-  --> $DIR/region-borrow-params-issue-29793-small.rs:76:17
+  --> $DIR/region-borrow-params-issue-29793-small.rs:76:45
    |
 LL |         let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+   |                 ---------                   ^ borrowed value does not live long enough
+   |                 |
+   |                 value captured here
 ...
 LL |     };
    |     - `y` dropped here while still borrowed
@@ -95,10 +111,12 @@ LL |     fn g<'a>(x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
    |          ^^
 
 error[E0597]: `x` does not live long enough
-  --> $DIR/region-borrow-params-issue-29793-small.rs:100:21
+  --> $DIR/region-borrow-params-issue-29793-small.rs:100:38
    |
 LL |             let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+   |                     ---------        ^ borrowed value does not live long enough
+   |                     |
+   |                     value captured here
 ...
 LL |         }
    |         - `x` dropped here while still borrowed
@@ -110,10 +128,12 @@ LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
    |              ^^
 
 error[E0597]: `y` does not live long enough
-  --> $DIR/region-borrow-params-issue-29793-small.rs:100:21
+  --> $DIR/region-borrow-params-issue-29793-small.rs:100:49
    |
 LL |             let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+   |                     ---------                   ^ borrowed value does not live long enough
+   |                     |
+   |                     value captured here
 ...
 LL |         }
    |         - `y` dropped here while still borrowed
@@ -125,10 +145,12 @@ LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
    |              ^^
 
 error[E0597]: `x` does not live long enough
-  --> $DIR/region-borrow-params-issue-29793-small.rs:114:21
+  --> $DIR/region-borrow-params-issue-29793-small.rs:114:38
    |
 LL |             let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+   |                     ---------        ^ borrowed value does not live long enough
+   |                     |
+   |                     value captured here
 ...
 LL |         }
    |         - `x` dropped here while still borrowed
@@ -140,10 +162,12 @@ LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
    |              ^^
 
 error[E0597]: `y` does not live long enough
-  --> $DIR/region-borrow-params-issue-29793-small.rs:114:21
+  --> $DIR/region-borrow-params-issue-29793-small.rs:114:49
    |
 LL |             let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+   |                     ---------                   ^ borrowed value does not live long enough
+   |                     |
+   |                     value captured here
 ...
 LL |         }
    |         - `y` dropped here while still borrowed
@@ -155,10 +179,12 @@ LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
    |              ^^
 
 error[E0597]: `x` does not live long enough
-  --> $DIR/region-borrow-params-issue-29793-small.rs:142:21
+  --> $DIR/region-borrow-params-issue-29793-small.rs:142:38
    |
 LL |             let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+   |                     ---------        ^ borrowed value does not live long enough
+   |                     |
+   |                     value captured here
 ...
 LL |         }
    |         - `x` dropped here while still borrowed
@@ -170,10 +196,12 @@ LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
    |              ^^
 
 error[E0597]: `y` does not live long enough
-  --> $DIR/region-borrow-params-issue-29793-small.rs:142:21
+  --> $DIR/region-borrow-params-issue-29793-small.rs:142:49
    |
 LL |             let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+   |                     ---------                   ^ borrowed value does not live long enough
+   |                     |
+   |                     value captured here
 ...
 LL |         }
    |         - `y` dropped here while still borrowed
@@ -185,10 +213,12 @@ LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
    |              ^^
 
 error[E0597]: `x` does not live long enough
-  --> $DIR/region-borrow-params-issue-29793-small.rs:157:21
+  --> $DIR/region-borrow-params-issue-29793-small.rs:157:38
    |
 LL |             let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+   |                     ---------        ^ borrowed value does not live long enough
+   |                     |
+   |                     value captured here
 ...
 LL |         }
    |         - `x` dropped here while still borrowed
@@ -200,10 +230,12 @@ LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
    |              ^^
 
 error[E0597]: `y` does not live long enough
-  --> $DIR/region-borrow-params-issue-29793-small.rs:157:21
+  --> $DIR/region-borrow-params-issue-29793-small.rs:157:49
    |
 LL |             let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+   |                     ---------                   ^ borrowed value does not live long enough
+   |                     |
+   |                     value captured here
 ...
 LL |         }
    |         - `y` dropped here while still borrowed
@@ -215,10 +247,12 @@ LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
    |              ^^
 
 error[E0597]: `x` does not live long enough
-  --> $DIR/region-borrow-params-issue-29793-small.rs:185:21
+  --> $DIR/region-borrow-params-issue-29793-small.rs:185:38
    |
 LL |             let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+   |                     ---------        ^ borrowed value does not live long enough
+   |                     |
+   |                     value captured here
 ...
 LL |         }
    |         - `x` dropped here while still borrowed
@@ -230,10 +264,12 @@ LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
    |              ^^
 
 error[E0597]: `y` does not live long enough
-  --> $DIR/region-borrow-params-issue-29793-small.rs:185:21
+  --> $DIR/region-borrow-params-issue-29793-small.rs:185:49
    |
 LL |             let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+   |                     ---------                   ^ borrowed value does not live long enough
+   |                     |
+   |                     value captured here
 ...
 LL |         }
    |         - `y` dropped here while still borrowed
@@ -245,10 +281,12 @@ LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
    |              ^^
 
 error[E0597]: `x` does not live long enough
-  --> $DIR/region-borrow-params-issue-29793-small.rs:199:21
+  --> $DIR/region-borrow-params-issue-29793-small.rs:199:38
    |
 LL |             let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+   |                     ---------        ^ borrowed value does not live long enough
+   |                     |
+   |                     value captured here
 ...
 LL |         }
    |         - `x` dropped here while still borrowed
@@ -260,10 +298,12 @@ LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
    |              ^^
 
 error[E0597]: `y` does not live long enough
-  --> $DIR/region-borrow-params-issue-29793-small.rs:199:21
+  --> $DIR/region-borrow-params-issue-29793-small.rs:199:49
    |
 LL |             let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+   |                     ---------                   ^ borrowed value does not live long enough
+   |                     |
+   |                     value captured here
 ...
 LL |         }
    |         - `y` dropped here while still borrowed

--- a/src/test/ui/regions-nested-fns-2.nll.stderr
+++ b/src/test/ui/regions-nested-fns-2.nll.stderr
@@ -1,13 +1,14 @@
 error[E0597]: `y` does not live long enough
-  --> $DIR/regions-nested-fns-2.rs:16:9
+  --> $DIR/regions-nested-fns-2.rs:18:25
    |
-LL | /         |z| {
-LL | |             //~^ ERROR E0373
-LL | |             if false { &y } else { z }
-LL | |         });
-   | |_________^ borrowed value does not live long enough
-LL |   }
-   |   - `y` dropped here while still borrowed
+LL |         |z| {
+   |         --- value captured here
+LL |             //~^ ERROR E0373
+LL |             if false { &y } else { z }
+   |                         ^ borrowed value does not live long enough
+LL |         });
+LL | }
+   | - `y` dropped here while still borrowed
    |
    = note: borrowed value must be valid for the static lifetime...
 

--- a/src/test/ui/span/borrowck-call-is-borrow-issue-12224.nll.stderr
+++ b/src/test/ui/span/borrowck-call-is-borrow-issue-12224.nll.stderr
@@ -8,7 +8,7 @@ LL |       f(Box::new(|| {
    | |
 LL | |     //~^ ERROR: cannot borrow `f` as mutable more than once
 LL | |         f((Box::new(|| {})))
-   | |         - borrow occurs due to use of `f` in closure
+   | |         - second borrow occurs due to use of `f` in closure
 LL | |     }));
    | |_______- borrow later used here
 
@@ -37,18 +37,17 @@ LL |         foo(f);
 error[E0505]: cannot move out of `f` because it is borrowed
   --> $DIR/borrowck-call-is-borrow-issue-12224.rs:65:16
    |
-LL |        f(Box::new(|a| {
-   |   _____-__________^
-   |  |     |
-   |  |_____borrow of `f` occurs here
-   | ||
-LL | ||         foo(f);
-LL | ||         //~^ ERROR cannot move `f` into closure because it is borrowed
-LL | ||         //~| ERROR cannot move out of captured outer variable in an `FnMut` closure
-LL | ||     }), 3);
-   | ||_____^____- borrow later used here
-   |  |_____|
-   |        move out of `f` occurs here
+LL |       f(Box::new(|a| {
+   |       -          ^^^ move out of `f` occurs here
+   |       |
+   |  _____borrow of `f` occurs here
+   | |
+LL | |         foo(f);
+   | |             - move occurs due to use in closure
+LL | |         //~^ ERROR cannot move `f` into closure because it is borrowed
+LL | |         //~| ERROR cannot move out of captured outer variable in an `FnMut` closure
+LL | |     }), 3);
+   | |__________- borrow later used here
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/span/send-is-not-static-ensures-scoping.nll.stderr
+++ b/src/test/ui/span/send-is-not-static-ensures-scoping.nll.stderr
@@ -11,19 +11,18 @@ LL |     bad.join();
    |     --- borrow later used here
 
 error[E0597]: `y` does not live long enough
-  --> $DIR/send-is-not-static-ensures-scoping.rs:29:16
+  --> $DIR/send-is-not-static-ensures-scoping.rs:30:22
    |
-LL |           scoped(|| {
-   |  ________________^
-LL | |             let _z = y;
-LL | |             //~^ ERROR `y` does not live long enough
-LL | |         })
-   | |_________^ borrowed value does not live long enough
-LL |       };
-   |       - `y` dropped here while still borrowed
+LL |         scoped(|| {
+   |                -- value captured here
+LL |             let _z = y;
+   |                      ^ borrowed value does not live long enough
+...
+LL |     };
+   |     - `y` dropped here while still borrowed
 LL | 
-LL |       bad.join();
-   |       --- borrow later used here
+LL |     bad.join();
+   |     --- borrow later used here
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Closes #51170
Closes #46599

Error messages involving closures now point to the captured variable/closure args.

r? @pnkfelix 