### PR TITLE
App-lint-cability

### DIFF
--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -22,6 +22,7 @@ use std::cmp;
 use std::{i8, i16, i32, i64, u8, u16, u32, u64, f32, f64};
 
 use syntax::{ast, attr};
+use syntax::errors::Applicability;
 use rustc_target::spec::abi::Abi;
 use syntax_pos::Span;
 use syntax::codemap;
@@ -143,9 +144,12 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TypeLimits {
                                                              OVERFLOWING_LITERALS,
                                                              parent_expr.span,
                                                              "only u8 can be cast into char");
-                                        err.span_suggestion(parent_expr.span,
-                                                            &"use a char literal instead",
-                                                            format!("'\\u{{{:X}}}'", lit_val));
+                                        err.span_suggestion_with_applicability(
+                                            parent_expr.span,
+                                            &"use a char literal instead",
+                                            format!("'\\u{{{:X}}}'", lit_val),
+                                            Applicability::MachineApplicable
+                                        );
                                         err.emit();
                                         return
                                     }
@@ -398,10 +402,11 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TypeLimits {
             {
                 if let Some(pos) = repr_str.chars().position(|c| c == 'i' || c == 'u') {
                     let (sans_suffix, _) = repr_str.split_at(pos);
-                    err.span_suggestion(
+                    err.span_suggestion_with_applicability(
                         expr.span,
                         &format!("consider using `{}` instead", sugg_ty),
                         format!("{}{}", sans_suffix, sugg_ty),
+                        Applicability::MachineApplicable
                     );
                 } else {
                     err.help(&format!("consider using `{}` instead", sugg_ty));

--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -17,6 +17,7 @@ use lint::{LintPass, EarlyLintPass, LateLintPass};
 
 use syntax::ast;
 use syntax::attr;
+use syntax::errors::Applicability;
 use syntax::feature_gate::{BUILTIN_ATTRIBUTES, AttributeType};
 use syntax::print::pprust;
 use syntax::symbol::keywords;
@@ -303,9 +304,12 @@ impl UnusedParens {
                             _ => false,
                         }
                     }).to_owned();
-                err.span_suggestion_short(value.span,
-                                          "remove these parentheses",
-                                          parens_removed);
+                err.span_suggestion_short_with_applicability(
+                    value.span,
+                    "remove these parentheses",
+                    parens_removed,
+                    Applicability::MachineApplicable
+                );
                 err.emit();
             }
         }

--- a/src/test/ui/lint/unused_parens_json_suggestion.stderr
+++ b/src/test/ui/lint/unused_parens_json_suggestion.stderr
@@ -82,7 +82,7 @@
           ],
           "label": null,
           "suggested_replacement": "1 / (2 + 3)",
-          "suggestion_applicability": "Unspecified",
+          "suggestion_applicability": "MachineApplicable",
           "expansion": null
         }
       ],


### PR DESCRIPTION
@eminence recently pointed out (rust-lang/cargo#5846) that it's
surprising that `cargo fix` (now shipping with Cargo itself!) doesn't
fix very common lint warnings, which is as good of a reminder as any
that we should finish #50723.

(Previously, we did this on the librustc and libsyntax crates in #50724. I filed cmr/this-week-in-rust#685 in hopes of recruiting new contributors to do the rest.)

r? @estebank 