### PR TITLE
NLL migration in the 2018 edition needs two-phase borrows too!

### DIFF
--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -1395,10 +1395,18 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
     }
 
     /// If true, we should enable two-phase borrows checks. This is
-    /// done with either `-Ztwo-phase-borrows` or with
-    /// `#![feature(nll)]`.
+    /// done with either: `-Ztwo-phase-borrows`, `#![feature(nll)]`,
+    /// or by opting into an edition after 2015.
     pub fn two_phase_borrows(self) -> bool {
-        self.features().nll || self.sess.opts.debugging_opts.two_phase_borrows
+        if self.features().nll || self.sess.opts.debugging_opts.two_phase_borrows {
+            return true;
+        }
+
+        match self.sess.edition() {
+            Edition::Edition2015 => false,
+            Edition::Edition2018 => true,
+            _ => true,
+        }
     }
 
     /// What mode(s) of borrowck should we run? AST? MIR? both?

--- a/src/test/ui/borrowck/issue-52967-edition-2018-needs-two-phase-borrows.rs
+++ b/src/test/ui/borrowck/issue-52967-edition-2018-needs-two-phase-borrows.rs
@@ -1,0 +1,32 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This is a regression test for #52967, where we discovered that in
+// the initial deployment of NLL for the 2018 edition, I forgot to
+// turn on two-phase-borrows in addition to `-Z borrowck=migrate`.
+
+// revisions: ast zflags edition
+//[zflags]compile-flags: -Z borrowck=migrate -Z two-phase-borrows
+//[edition]compile-flags: --edition 2018
+
+// run-pass
+
+fn the_bug() {
+    let mut stuff = ("left", "right");
+    match stuff {
+        (ref mut left, _) if *left == "left" => { *left = "new left"; }
+        _ => {}
+    }
+    assert_eq!(stuff, ("new left", "right"));
+}
+
+fn main() {
+    the_bug();
+}


### PR DESCRIPTION
NLL migration in the 2018 edition needs two-phase borrows too!

Fix #52967.