### PR TITLE
Rollup of 12 pull requests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -56,3 +56,11 @@
 [submodule "src/libbacktrace"]
 	path = src/libbacktrace
 	url = https://github.com/rust-lang-nursery/libbacktrace
+[submodule "src/lldb"]
+	path = src/lldb
+	url = https://github.com/rust-lang-nursery/lldb/
+	branch = rust-release-70
+[submodule "src/clang"]
+	path = src/clang
+	url = https://github.com/rust-lang-nursery/clang/
+	branch = master

--- a/config.toml.example
+++ b/config.toml.example
@@ -354,6 +354,10 @@
 # sysroot.
 #llvm-tools = false
 
+# Indicates whether LLDB will be made available in the sysroot.
+# This is only built if LLVM is also being built.
+#lldb = false
+
 # Whether to deny warnings in crates
 #deny-warnings = true
 

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -2338,6 +2338,7 @@ dependencies = [
  "rustc 0.0.0",
  "rustc_data_structures 0.0.0",
  "rustc_errors 0.0.0",
+ "rustc_metadata 0.0.0",
  "syntax 0.0.0",
  "syntax_pos 0.0.0",
 ]

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -2115,6 +2115,7 @@ dependencies = [
  "rustc 0.0.0",
  "rustc_data_structures 0.0.0",
  "rustc_incremental 0.0.0",
+ "rustc_metadata 0.0.0",
  "rustc_mir 0.0.0",
  "rustc_target 0.0.0",
  "syntax 0.0.0",

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1011,7 +1011,7 @@ name = "installer"
 version = "0.0.0"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -461,6 +461,7 @@ impl<'a> Builder<'a> {
                 dist::Rustfmt,
                 dist::Clippy,
                 dist::LlvmTools,
+                dist::Lldb,
                 dist::Extended,
                 dist::HashSign
             ),

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -777,7 +777,7 @@ impl<'a> Builder<'a> {
         // compiler, but for tools we just use the precompiled libraries that
         // we've downloaded
         let use_snapshot = mode == Mode::ToolBootstrap;
-        assert!(!use_snapshot || stage == 0);
+        assert!(!use_snapshot || stage == 0 || self.local_rebuild);
 
         let maybe_sysroot = self.sysroot(compiler);
         let sysroot = if use_snapshot {

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -87,6 +87,7 @@ pub struct Config {
     pub llvm_link_jobs: Option<u32>,
 
     pub lld_enabled: bool,
+    pub lldb_enabled: bool,
     pub llvm_tools_enabled: bool,
 
     // rust codegen options
@@ -310,6 +311,7 @@ struct Rust {
     codegen_backends_dir: Option<String>,
     wasm_syscall: Option<bool>,
     lld: Option<bool>,
+    lldb: Option<bool>,
     llvm_tools: Option<bool>,
     deny_warnings: Option<bool>,
     backtrace_on_ice: Option<bool>,
@@ -538,6 +540,7 @@ impl Config {
             }
             set(&mut config.wasm_syscall, rust.wasm_syscall);
             set(&mut config.lld_enabled, rust.lld);
+            set(&mut config.lldb_enabled, rust.lldb);
             set(&mut config.llvm_tools_enabled, rust.llvm_tools);
             config.rustc_parallel_queries = rust.experimental_parallel_queries.unwrap_or(false);
             config.rustc_default_linker = rust.default_linker.clone();

--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -335,6 +335,7 @@ for key in known_args:
     elif option.name == 'full-tools':
         set('rust.codegen-backends', ['llvm', 'emscripten'])
         set('rust.lld', True)
+        set('rust.lldb', True)
         set('rust.llvm-tools', True)
         set('build.extended', True)
     elif option.name == 'option-checking':

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -1992,9 +1992,10 @@ impl Step for Lldb {
     fn run(self, builder: &Builder) -> Option<PathBuf> {
         let target = self.target;
 
-        // Do nothing if lldb was not built.  This is difficult to
-        // determine in should_run because the target is not available
-        // at that point.
+        if builder.config.dry_run {
+            return None;
+        }
+
         let bindir = builder
             .llvm_out(target)
             .join("bin");

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -47,6 +47,8 @@ pub fn pkgname(builder: &Builder, component: &str) -> String {
         format!("{}-{}", component, builder.rustfmt_package_vers())
     } else if component == "llvm-tools" {
         format!("{}-{}", component, builder.llvm_tools_package_vers())
+    } else if component == "lldb" {
+        format!("{}-{}", component, builder.lldb_package_vers())
     } else {
         assert!(component.starts_with("rust"));
         format!("{}-{}", component, builder.rust_package_vers())
@@ -1396,6 +1398,7 @@ impl Step for Extended {
         let rls_installer = builder.ensure(Rls { stage, target });
         let llvm_tools_installer = builder.ensure(LlvmTools { stage, target });
         let clippy_installer = builder.ensure(Clippy { stage, target });
+        let lldb_installer = builder.ensure(Lldb { target });
         let mingw_installer = builder.ensure(Mingw { host: target });
         let analysis_installer = builder.ensure(Analysis {
             compiler: builder.compiler(stage, self.host),
@@ -1435,6 +1438,7 @@ impl Step for Extended {
         tarballs.extend(clippy_installer.clone());
         tarballs.extend(rustfmt_installer.clone());
         tarballs.extend(llvm_tools_installer.clone());
+        tarballs.extend(lldb_installer.clone());
         tarballs.push(analysis_installer);
         tarballs.push(std_installer);
         if builder.config.docs {
@@ -1869,6 +1873,7 @@ impl Step for HashSign {
         cmd.arg(builder.package_vers(&builder.release_num("clippy")));
         cmd.arg(builder.package_vers(&builder.release_num("rustfmt")));
         cmd.arg(builder.llvm_tools_package_vers());
+        cmd.arg(builder.lldb_package_vers());
         cmd.arg(addr);
 
         builder.create_dir(&distdir(builder));
@@ -1957,6 +1962,115 @@ impl Step for LlvmTools {
             .arg(format!("--package-name={}-{}", name, target))
             .arg("--legacy-manifest-dirs=rustlib,cargo")
             .arg("--component-name=llvm-tools-preview");
+
+
+        builder.run(&mut cmd);
+        Some(distdir(builder).join(format!("{}-{}.tar.gz", name, target)))
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct Lldb {
+    pub target: Interned<String>,
+}
+
+impl Step for Lldb {
+    type Output = Option<PathBuf>;
+    const ONLY_HOSTS: bool = true;
+    const DEFAULT: bool = true;
+
+    fn should_run(run: ShouldRun) -> ShouldRun {
+        run.path("src/lldb")
+    }
+
+    fn make_run(run: RunConfig) {
+        run.builder.ensure(Lldb {
+            target: run.target,
+        });
+    }
+
+    fn run(self, builder: &Builder) -> Option<PathBuf> {
+        let target = self.target;
+
+        builder.info(&format!("Dist Lldb ({})", target));
+        let src = builder.src.join("src/lldb");
+        let name = pkgname(builder, "lldb");
+
+        let tmp = tmpdir(builder);
+        let image = tmp.join("lldb-image");
+        drop(fs::remove_dir_all(&image));
+
+        // Prepare the image directory
+        let bindir = builder
+            .llvm_out(target)
+            .join("bin");
+        let dst = image.join("bin");
+        t!(fs::create_dir_all(&dst));
+        for program in &["lldb", "lldb-argdumper", "lldb-mi", "lldb-server"] {
+            let exe = bindir.join(exe(program, &target));
+            builder.install(&exe, &dst, 0o755);
+        }
+
+        // The libraries.
+        let libdir = builder.llvm_out(target).join("lib");
+        let dst = image.join("lib");
+        t!(fs::create_dir_all(&dst));
+        for entry in t!(fs::read_dir(&libdir)) {
+            // let entry = t!(entry);
+            let entry = entry.unwrap();
+            if let Ok(name) = entry.file_name().into_string() {
+                if name.starts_with("liblldb.") && !name.ends_with(".a") {
+                    if t!(entry.file_type()).is_symlink() {
+                        builder.copy_to_folder(&entry.path(), &dst);
+                    } else {
+                       builder.install(&entry.path(), &dst, 0o755);
+                    }
+                }
+            }
+        }
+
+        // The lldb scripts might be installed in lib/python$version
+        // or in lib64/python$version.  If lib64 exists, use it;
+        // otherwise lib.
+        let libdir = builder.llvm_out(target).join("lib64");
+        let (libdir, libdir_name) = if libdir.exists() {
+            (libdir, "lib64")
+        } else {
+            (builder.llvm_out(target).join("lib"), "lib")
+        };
+        for entry in t!(fs::read_dir(&libdir)) {
+            let entry = t!(entry);
+            if let Ok(name) = entry.file_name().into_string() {
+                if name.starts_with("python") {
+                    let dst = image.join(libdir_name)
+                        .join(entry.file_name());
+                    t!(fs::create_dir_all(&dst));
+                    builder.cp_r(&entry.path(), &dst);
+                    break;
+                }
+            }
+        }
+
+        // Prepare the overlay
+        let overlay = tmp.join("lldb-overlay");
+        drop(fs::remove_dir_all(&overlay));
+        builder.create_dir(&overlay);
+        builder.install(&src.join("LICENSE.TXT"), &overlay, 0o644);
+        builder.create(&overlay.join("version"), &builder.lldb_vers());
+
+        // Generate the installer tarball
+        let mut cmd = rust_installer(builder);
+        cmd.arg("generate")
+            .arg("--product-name=Rust")
+            .arg("--rel-manifest-dir=rustlib")
+            .arg("--success-message=lldb-installed.")
+            .arg("--image-dir").arg(&image)
+            .arg("--work-dir").arg(&tmpdir(builder))
+            .arg("--output-dir").arg(&distdir(builder))
+            .arg("--non-installed-overlay").arg(&overlay)
+            .arg(format!("--package-name={}-{}", name, target))
+            .arg("--legacy-manifest-dirs=rustlib,cargo")
+            .arg("--component-name=lldb-preview");
 
 
         builder.run(&mut cmd);

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -1992,6 +1992,17 @@ impl Step for Lldb {
     fn run(self, builder: &Builder) -> Option<PathBuf> {
         let target = self.target;
 
+        // Do nothing if lldb was not built.  This is difficult to
+        // determine in should_run because the target is not available
+        // at that point.
+        let bindir = builder
+            .llvm_out(target)
+            .join("bin");
+        let lldb_exe = bindir.join(exe("lldb", &target));
+        if !lldb_exe.exists() {
+            return None;
+        }
+
         builder.info(&format!("Dist Lldb ({})", target));
         let src = builder.src.join("src/lldb");
         let name = pkgname(builder, "lldb");
@@ -2001,9 +2012,6 @@ impl Step for Lldb {
         drop(fs::remove_dir_all(&image));
 
         // Prepare the image directory
-        let bindir = builder
-            .llvm_out(target)
-            .join("bin");
         let dst = image.join("bin");
         t!(fs::create_dir_all(&dst));
         for program in &["lldb", "lldb-argdumper", "lldb-mi", "lldb-server"] {

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -149,7 +149,6 @@ impl Step for Llvm {
            .define("WITH_POLLY", "OFF")
            .define("LLVM_ENABLE_TERMINFO", "OFF")
            .define("LLVM_ENABLE_LIBEDIT", "OFF")
-           .define("LLVM_ENABLE_LIBXML2", "OFF")
            .define("LLVM_PARALLEL_COMPILE_JOBS", builder.jobs().to_string())
            .define("LLVM_TARGET_ARCH", target.split('-').next().unwrap())
            .define("LLVM_DEFAULT_TARGET_TRIPLE", target);
@@ -163,6 +162,14 @@ impl Step for Llvm {
         cfg.define("LLVM_OCAML_INSTALL_PATH",
             env::var_os("LLVM_OCAML_INSTALL_PATH").unwrap_or_else(|| "usr/lib/ocaml".into()));
 
+        // Build clang and lldb if asked, or if doing a macOS nightly
+        // build.  LLVM_ENABLE_PROJECTS allows them to be checked out
+        // parallel to src/llvm, and makes conditionally building them
+        // simpler.
+        let want_lldb = builder.config.lldb_enabled ||
+            (target.contains("apple-darwin") &&
+             builder.config.channel == "nightly");
+
         // This setting makes the LLVM tools link to the dynamic LLVM library,
         // which saves both memory during parallel links and overall disk space
         // for the tools.  We don't distribute any of those tools, so this is
@@ -170,12 +177,13 @@ impl Step for Llvm {
         //
         // If we are shipping llvm tools then we statically link them LLVM
         if (target.contains("linux-gnu") || target.contains("apple-darwin")) &&
-            !builder.config.llvm_tools_enabled {
+            !builder.config.llvm_tools_enabled &&
+            !want_lldb {
                 cfg.define("LLVM_LINK_LLVM_DYLIB", "ON");
         }
 
         // For distribution we want the LLVM tools to be *statically* linked to libstdc++
-        if builder.config.llvm_tools_enabled {
+        if builder.config.llvm_tools_enabled || want_lldb {
             if !target.contains("windows") {
                 if target.contains("apple") {
                     cfg.define("CMAKE_EXE_LINKER_FLAGS", "-static-libstdc++");
@@ -194,6 +202,12 @@ impl Step for Llvm {
 
         if target.starts_with("i686") {
             cfg.define("LLVM_BUILD_32_BITS", "ON");
+        }
+
+        if want_lldb {
+            cfg.define("LLVM_ENABLE_PROJECTS", "clang;lldb");
+        } else {
+            cfg.define("LLVM_ENABLE_LIBXML2", "OFF");
         }
 
         if let Some(num_linkers) = builder.config.llvm_link_jobs {

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -1267,8 +1267,7 @@ impl<A, V: FromIterator<A>> FromIterator<Option<A>> for Option<V> {
                 if self.found_none {
                     (0, Some(0))
                 } else {
-                    let (_, upper) = self.iter.size_hint();
-                    (0, upper)
+                    self.iter.size_hint()
                 }
             }
         }

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -1176,9 +1176,13 @@ impl<A, E, V: FromIterator<A>> FromIterator<Result<A, E>> for Result<V, E> {
                 }
             }
 
+            #[inline]
             fn size_hint(&self) -> (usize, Option<usize>) {
-                let (_min, max) = self.iter.size_hint();
-                (0, max)
+                if self.err.is_some() {
+                    (0, Some(0))
+                } else {
+                    self.iter.size_hint()
+                }
             }
         }
 

--- a/src/librustc/hir/def.rs
+++ b/src/librustc/hir/def.rs
@@ -68,8 +68,6 @@ pub enum Def {
     // Macro namespace
     Macro(DefId, MacroKind),
 
-    GlobalAsm(DefId),
-
     // Both namespaces
     Err,
 }
@@ -249,8 +247,7 @@ impl Def {
             Def::AssociatedTy(id) | Def::TyParam(id) | Def::Struct(id) | Def::StructCtor(id, ..) |
             Def::Union(id) | Def::Trait(id) | Def::Method(id) | Def::Const(id) |
             Def::AssociatedConst(id) | Def::Macro(id, ..) |
-            Def::Existential(id) | Def::AssociatedExistential(id) |
-            Def::GlobalAsm(id) | Def::TyForeign(id) => {
+            Def::Existential(id) | Def::AssociatedExistential(id) | Def::TyForeign(id) => {
                 id
             }
 
@@ -298,7 +295,6 @@ impl Def {
             Def::Label(..) => "label",
             Def::SelfTy(..) => "self type",
             Def::Macro(.., macro_kind) => macro_kind.descr(),
-            Def::GlobalAsm(..) => "global asm",
             Def::Err => "unresolved item",
         }
     }

--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -432,7 +432,6 @@ impl<'hir> Map<'hir> {
                     ItemKind::Const(..) => Some(Def::Const(def_id())),
                     ItemKind::Fn(..) => Some(Def::Fn(def_id())),
                     ItemKind::Mod(..) => Some(Def::Mod(def_id())),
-                    ItemKind::GlobalAsm(..) => Some(Def::GlobalAsm(def_id())),
                     ItemKind::Existential(..) => Some(Def::Existential(def_id())),
                     ItemKind::Ty(..) => Some(Def::TyAlias(def_id())),
                     ItemKind::Enum(..) => Some(Def::Enum(def_id())),
@@ -445,6 +444,7 @@ impl<'hir> Map<'hir> {
                     ItemKind::ExternCrate(_) |
                     ItemKind::Use(..) |
                     ItemKind::ForeignMod(..) |
+                    ItemKind::GlobalAsm(..) |
                     ItemKind::Impl(..) => None,
                 }
             }

--- a/src/librustc/ich/impls_hir.rs
+++ b/src/librustc/ich/impls_hir.rs
@@ -1015,7 +1015,6 @@ impl_stable_hash_for!(enum hir::def::Def {
     Upvar(def_id, index, expr_id),
     Label(node_id),
     Macro(def_id, macro_kind),
-    GlobalAsm(def_id),
     Err
 });
 

--- a/src/librustc/middle/cstore.rs
+++ b/src/librustc/middle/cstore.rs
@@ -25,7 +25,7 @@
 use hir::def;
 use hir::def_id::{CrateNum, DefId, LOCAL_CRATE};
 use hir::map as hir_map;
-use hir::map::definitions::{Definitions, DefKey, DefPathTable};
+use hir::map::definitions::{DefKey, DefPathTable};
 use hir::svh::Svh;
 use ty::{self, TyCtxt};
 use session::{Session, CrateDisambiguator};
@@ -258,26 +258,6 @@ pub trait CrateStore {
 }
 
 pub type CrateStoreDyn = dyn CrateStore + sync::Sync;
-
-pub trait CrateLoader {
-    fn process_extern_crate(&mut self, item: &ast::Item, defs: &Definitions) -> CrateNum;
-
-    fn process_path_extern(
-        &mut self,
-        name: Symbol,
-        span: Span,
-    ) -> CrateNum;
-
-    fn process_use_extern(
-        &mut self,
-        name: Symbol,
-        span: Span,
-        id: ast::NodeId,
-        defs: &Definitions,
-    ) -> CrateNum;
-
-    fn postprocess(&mut self, krate: &ast::Crate);
-}
 
 // This method is used when generating the command line to pass through to
 // system linker. The linker expects undefined symbols on the left of the

--- a/src/librustc/middle/cstore.rs
+++ b/src/librustc/middle/cstore.rs
@@ -231,7 +231,6 @@ pub trait CrateStore {
     fn def_path_table(&self, cnum: CrateNum) -> Lrc<DefPathTable>;
 
     // "queries" used in resolve that aren't tracked for incremental compilation
-    fn visibility_untracked(&self, def: DefId) -> ty::Visibility;
     fn export_macros_untracked(&self, cnum: CrateNum);
     fn dep_kind_untracked(&self, cnum: CrateNum) -> DepKind;
     fn crate_name_untracked(&self, cnum: CrateNum) -> Symbol;

--- a/src/librustc/middle/cstore.rs
+++ b/src/librustc/middle/cstore.rs
@@ -260,33 +260,6 @@ pub trait CrateStore {
 
 pub type CrateStoreDyn = dyn CrateStore + sync::Sync;
 
-// FIXME: find a better place for this?
-pub fn validate_crate_name(sess: Option<&Session>, s: &str, sp: Option<Span>) {
-    let mut err_count = 0;
-    {
-        let mut say = |s: &str| {
-            match (sp, sess) {
-                (_, None) => bug!("{}", s),
-                (Some(sp), Some(sess)) => sess.span_err(sp, s),
-                (None, Some(sess)) => sess.err(s),
-            }
-            err_count += 1;
-        };
-        if s.is_empty() {
-            say("crate name must not be empty");
-        }
-        for c in s.chars() {
-            if c.is_alphanumeric() { continue }
-            if c == '_'  { continue }
-            say(&format!("invalid character `{}` in crate name: `{}`", c, s));
-        }
-    }
-
-    if err_count > 0 {
-        sess.unwrap().abort_if_errors();
-    }
-}
-
 /// A dummy crate store that does not support any non-local crates,
 /// for test purposes.
 pub struct DummyCrateStore;

--- a/src/librustc/middle/cstore.rs
+++ b/src/librustc/middle/cstore.rs
@@ -22,7 +22,6 @@
 //! are *mostly* used as a part of that interface, but these should
 //! probably get a better home if someone can find one.
 
-use hir::def;
 use hir::def_id::{CrateNum, DefId, LOCAL_CRATE};
 use hir::map as hir_map;
 use hir::map::definitions::{DefKey, DefPathTable};
@@ -34,8 +33,6 @@ use session::search_paths::PathKind;
 use std::any::Any;
 use std::path::{Path, PathBuf};
 use syntax::ast;
-use syntax::edition::Edition;
-use syntax::ext::base::SyntaxExtension;
 use syntax::symbol::Symbol;
 use syntax_pos::Span;
 use rustc_target::spec::Target;
@@ -140,11 +137,6 @@ pub struct ForeignModule {
     pub def_id: DefId,
 }
 
-pub enum LoadedMacro {
-    MacroDef(ast::Item),
-    ProcMacro(Lrc<SyntaxExtension>),
-}
-
 #[derive(Copy, Clone, Debug)]
 pub struct ExternCrate {
     pub src: ExternCrateSource,
@@ -221,9 +213,6 @@ pub trait MetadataLoader {
 pub trait CrateStore {
     fn crate_data_as_rc_any(&self, krate: CrateNum) -> Lrc<dyn Any>;
 
-    // access to the metadata loader
-    fn metadata_loader(&self) -> &dyn MetadataLoader;
-
     // resolve
     fn def_key(&self, def: DefId) -> DefKey;
     fn def_path(&self, def: DefId) -> hir_map::DefPath;
@@ -231,18 +220,11 @@ pub trait CrateStore {
     fn def_path_table(&self, cnum: CrateNum) -> Lrc<DefPathTable>;
 
     // "queries" used in resolve that aren't tracked for incremental compilation
-    fn export_macros_untracked(&self, cnum: CrateNum);
-    fn dep_kind_untracked(&self, cnum: CrateNum) -> DepKind;
     fn crate_name_untracked(&self, cnum: CrateNum) -> Symbol;
     fn crate_disambiguator_untracked(&self, cnum: CrateNum) -> CrateDisambiguator;
     fn crate_hash_untracked(&self, cnum: CrateNum) -> Svh;
-    fn crate_edition_untracked(&self, cnum: CrateNum) -> Edition;
-    fn struct_field_names_untracked(&self, def: DefId) -> Vec<ast::Name>;
-    fn item_children_untracked(&self, did: DefId, sess: &Session) -> Vec<def::Export>;
-    fn load_macro_untracked(&self, did: DefId, sess: &Session) -> LoadedMacro;
     fn extern_mod_stmt_cnum_untracked(&self, emod_id: ast::NodeId) -> Option<CrateNum>;
     fn item_generics_cloned_untracked(&self, def: DefId, sess: &Session) -> ty::Generics;
-    fn associated_item_cloned_untracked(&self, def: DefId) -> ty::AssociatedItem;
     fn postorder_cnums_untracked(&self) -> Vec<CrateNum>;
 
     // This is basically a 1-based range of ints, which is a little

--- a/src/librustc/middle/cstore.rs
+++ b/src/librustc/middle/cstore.rs
@@ -260,69 +260,6 @@ pub trait CrateStore {
 
 pub type CrateStoreDyn = dyn CrateStore + sync::Sync;
 
-/// A dummy crate store that does not support any non-local crates,
-/// for test purposes.
-pub struct DummyCrateStore;
-
-#[allow(unused_variables)]
-impl CrateStore for DummyCrateStore {
-    fn crate_data_as_rc_any(&self, krate: CrateNum) -> Lrc<dyn Any>
-        { bug!("crate_data_as_rc_any") }
-    // item info
-    fn visibility_untracked(&self, def: DefId) -> ty::Visibility { bug!("visibility") }
-    fn item_generics_cloned_untracked(&self, def: DefId, sess: &Session) -> ty::Generics
-        { bug!("item_generics_cloned") }
-
-    // trait/impl-item info
-    fn associated_item_cloned_untracked(&self, def: DefId) -> ty::AssociatedItem
-        { bug!("associated_item_cloned") }
-
-    // crate metadata
-    fn dep_kind_untracked(&self, cnum: CrateNum) -> DepKind { bug!("is_explicitly_linked") }
-    fn export_macros_untracked(&self, cnum: CrateNum) { bug!("export_macros") }
-    fn crate_name_untracked(&self, cnum: CrateNum) -> Symbol { bug!("crate_name") }
-    fn crate_disambiguator_untracked(&self, cnum: CrateNum) -> CrateDisambiguator {
-        bug!("crate_disambiguator")
-    }
-    fn crate_hash_untracked(&self, cnum: CrateNum) -> Svh { bug!("crate_hash") }
-    fn crate_edition_untracked(&self, cnum: CrateNum) -> Edition { bug!("crate_edition_untracked") }
-
-    // resolve
-    fn def_key(&self, def: DefId) -> DefKey { bug!("def_key") }
-    fn def_path(&self, def: DefId) -> hir_map::DefPath {
-        bug!("relative_def_path")
-    }
-    fn def_path_hash(&self, def: DefId) -> hir_map::DefPathHash {
-        bug!("def_path_hash")
-    }
-    fn def_path_table(&self, cnum: CrateNum) -> Lrc<DefPathTable> {
-        bug!("def_path_table")
-    }
-    fn struct_field_names_untracked(&self, def: DefId) -> Vec<ast::Name> {
-        bug!("struct_field_names")
-    }
-    fn item_children_untracked(&self, did: DefId, sess: &Session) -> Vec<def::Export> {
-        bug!("item_children")
-    }
-    fn load_macro_untracked(&self, did: DefId, sess: &Session) -> LoadedMacro { bug!("load_macro") }
-
-    fn crates_untracked(&self) -> Vec<CrateNum> { vec![] }
-
-    // utility functions
-    fn extern_mod_stmt_cnum_untracked(&self, emod_id: ast::NodeId) -> Option<CrateNum> { None }
-    fn encode_metadata<'a, 'tcx>(&self,
-                                 tcx: TyCtxt<'a, 'tcx, 'tcx>,
-                                 link_meta: &LinkMeta)
-                                 -> EncodedMetadata {
-        bug!("encode_metadata")
-    }
-    fn metadata_encoding_version(&self) -> &[u8] { bug!("metadata_encoding_version") }
-    fn postorder_cnums_untracked(&self) -> Vec<CrateNum> { bug!("postorder_cnums_untracked") }
-
-    // access to the metadata loader
-    fn metadata_loader(&self) -> &dyn MetadataLoader { bug!("metadata_loader") }
-}
-
 pub trait CrateLoader {
     fn process_extern_crate(&mut self, item: &ast::Item, defs: &Definitions) -> CrateNum;
 

--- a/src/librustc_codegen_llvm/back/linker.rs
+++ b/src/librustc_codegen_llvm/back/linker.rs
@@ -1006,6 +1006,18 @@ impl<'a> Linker for WasmLd<'a> {
             OptLevel::Size => "-O2",
             OptLevel::SizeMin => "-O2"
         });
+        match self.sess.opts.optimize {
+            OptLevel::No => (),
+            OptLevel::Less |
+            OptLevel::Default |
+            OptLevel::Aggressive |
+            OptLevel::Size |
+            OptLevel::SizeMin => {
+                // LLD generates incorrect debugging information when
+                // optimization is applied: strip debug sections.
+                self.cmd.arg("--strip-debug");
+            }
+        }
     }
 
     fn pgo_gen(&mut self) {

--- a/src/librustc_codegen_utils/Cargo.toml
+++ b/src/librustc_codegen_utils/Cargo.toml
@@ -20,3 +20,4 @@ rustc_target = { path = "../librustc_target" }
 rustc_data_structures = { path = "../librustc_data_structures" }
 rustc_mir = { path = "../librustc_mir" }
 rustc_incremental = { path = "../librustc_incremental" }
+rustc_metadata = { path = "../librustc_metadata" }

--- a/src/librustc_codegen_utils/lib.rs
+++ b/src/librustc_codegen_utils/lib.rs
@@ -37,6 +37,7 @@ extern crate rustc_incremental;
 extern crate syntax;
 extern crate syntax_pos;
 #[macro_use] extern crate rustc_data_structures;
+extern crate rustc_metadata;
 
 use rustc::ty::TyCtxt;
 

--- a/src/librustc_codegen_utils/link.rs
+++ b/src/librustc_codegen_utils/link.rs
@@ -10,11 +10,12 @@
 
 use rustc::session::config::{self, OutputFilenames, Input, OutputType};
 use rustc::session::Session;
-use rustc::middle::cstore::{self, LinkMeta};
+use rustc::middle::cstore::LinkMeta;
 use rustc::hir::svh::Svh;
 use std::path::{Path, PathBuf};
 use syntax::{ast, attr};
 use syntax_pos::Span;
+use rustc_metadata::creader;
 
 pub fn out_filename(sess: &Session,
                 crate_type: config::CrateType,
@@ -61,7 +62,7 @@ pub fn find_crate_name(sess: Option<&Session>,
                        attrs: &[ast::Attribute],
                        input: &Input) -> String {
     let validate = |s: String, span: Option<Span>| {
-        cstore::validate_crate_name(sess, &s, span);
+        creader::validate_crate_name(sess, &s, span);
         s
     };
 

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -676,7 +676,7 @@ pub trait CompilerCalls<'a> {
                      _: &dyn CodegenBackend,
                      _: &getopts::Matches,
                      _: &Session,
-                     _: &dyn CrateStore,
+                     _: &CStore,
                      _: &Input,
                      _: &Option<PathBuf>,
                      _: &Option<PathBuf>)
@@ -884,7 +884,7 @@ impl<'a> CompilerCalls<'a> for RustcDefaultCalls {
                      codegen_backend: &dyn CodegenBackend,
                      matches: &getopts::Matches,
                      sess: &Session,
-                     cstore: &dyn CrateStore,
+                     cstore: &CStore,
                      input: &Input,
                      odir: &Option<PathBuf>,
                      ofile: &Option<PathBuf>)
@@ -990,7 +990,7 @@ pub fn enable_save_analysis(control: &mut CompileController) {
 
 impl RustcDefaultCalls {
     pub fn list_metadata(sess: &Session,
-                         cstore: &dyn CrateStore,
+                         cstore: &CStore,
                          matches: &getopts::Matches,
                          input: &Input)
                          -> Compilation {

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -78,7 +78,6 @@ use rustc::session::filesearch;
 use rustc::session::{early_error, early_warn};
 use rustc::lint::Lint;
 use rustc::lint;
-use rustc::middle::cstore::CrateStore;
 use rustc_metadata::locator;
 use rustc_metadata::cstore::CStore;
 use rustc_metadata::dynamic_lib::DynamicLibrary;
@@ -1002,7 +1001,7 @@ impl RustcDefaultCalls {
                     let mut v = Vec::new();
                     locator::list_file_metadata(&sess.target.target,
                                                 path,
-                                                cstore.metadata_loader(),
+                                                &*cstore.metadata_loader,
                                                 &mut v)
                             .unwrap();
                     println!("{}", String::from_utf8(v).unwrap());

--- a/src/librustc_driver/pretty.rs
+++ b/src/librustc_driver/pretty.rs
@@ -20,11 +20,11 @@ use {abort_on_err, driver};
 use rustc::ty::{self, TyCtxt, Resolutions, AllArenas};
 use rustc::cfg;
 use rustc::cfg::graphviz::LabelledCFG;
-use rustc::middle::cstore::CrateStoreDyn;
 use rustc::session::Session;
 use rustc::session::config::{Input, OutputFilenames};
 use rustc_borrowck as borrowck;
 use rustc_borrowck::graphviz as borrowck_dot;
+use rustc_metadata::cstore::CStore;
 
 use rustc_mir::util::{write_mir_pretty, write_mir_graphviz};
 
@@ -199,7 +199,7 @@ impl PpSourceMode {
     }
     fn call_with_pp_support_hir<'tcx, A, F>(&self,
                                                sess: &'tcx Session,
-                                               cstore: &'tcx CrateStoreDyn,
+                                               cstore: &'tcx CStore,
                                                hir_map: &hir_map::Map<'tcx>,
                                                analysis: &ty::CrateAnalysis,
                                                resolutions: &Resolutions,
@@ -918,7 +918,7 @@ pub fn print_after_parsing(sess: &Session,
 }
 
 pub fn print_after_hir_lowering<'tcx, 'a: 'tcx>(sess: &'a Session,
-                                                cstore: &'tcx CrateStoreDyn,
+                                                cstore: &'tcx CStore,
                                                 hir_map: &hir_map::Map<'tcx>,
                                                 analysis: &ty::CrateAnalysis,
                                                 resolutions: &Resolutions,
@@ -1074,7 +1074,7 @@ pub fn print_after_hir_lowering<'tcx, 'a: 'tcx>(sess: &'a Session,
 // with a different callback than the standard driver, so that isn't easy.
 // Instead, we call that function ourselves.
 fn print_with_analysis<'tcx, 'a: 'tcx>(sess: &'a Session,
-                                       cstore: &'a CrateStoreDyn,
+                                       cstore: &'a CStore,
                                        hir_map: &hir_map::Map<'tcx>,
                                        analysis: &ty::CrateAnalysis,
                                        resolutions: &Resolutions,

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1632,6 +1632,7 @@ fn check_const(cx: &LateContext, body_id: hir::BodyId, what: &str) {
     let def_id = cx.tcx.hir.body_owner_def_id(body_id);
     let is_static = cx.tcx.is_static(def_id).is_some();
     let param_env = if is_static {
+        // Use the same param_env as `codegen_static_initializer`, to reuse the cache.
         ty::ParamEnv::reveal_all()
     } else {
         cx.tcx.param_env(def_id)

--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -24,7 +24,6 @@ use rustc::session::{Session, CrateDisambiguator};
 use rustc::session::config::{Sanitizer, self};
 use rustc_target::spec::{PanicStrategy, TargetTriple};
 use rustc::session::search_paths::PathKind;
-use rustc::middle;
 use rustc::middle::cstore::{ExternCrate, ExternCrateSource};
 use rustc::util::common::record_time;
 use rustc::util::nodemap::FxHashSet;
@@ -1056,8 +1055,8 @@ impl<'a> CrateLoader<'a> {
     }
 }
 
-impl<'a> middle::cstore::CrateLoader for CrateLoader<'a> {
-    fn postprocess(&mut self, krate: &ast::Crate) {
+impl<'a> CrateLoader<'a> {
+    pub fn postprocess(&mut self, krate: &ast::Crate) {
         // inject the sanitizer runtime before the allocator runtime because all
         // sanitizers force the use of the `alloc_system` allocator
         self.inject_sanitizer_runtime();
@@ -1070,7 +1069,9 @@ impl<'a> middle::cstore::CrateLoader for CrateLoader<'a> {
         }
     }
 
-    fn process_extern_crate(&mut self, item: &ast::Item, definitions: &Definitions) -> CrateNum {
+    pub fn process_extern_crate(
+        &mut self, item: &ast::Item, definitions: &Definitions,
+    ) -> CrateNum {
         match item.node {
             ast::ItemKind::ExternCrate(orig_name) => {
                 debug!("resolving extern crate stmt. ident: {} orig_name: {:?}",
@@ -1113,7 +1114,7 @@ impl<'a> middle::cstore::CrateLoader for CrateLoader<'a> {
         }
     }
 
-    fn process_path_extern(
+    pub fn process_path_extern(
         &mut self,
         name: Symbol,
         span: Span,
@@ -1137,7 +1138,7 @@ impl<'a> middle::cstore::CrateLoader for CrateLoader<'a> {
         cnum
     }
 
-    fn process_use_extern(
+    pub fn process_use_extern(
         &mut self,
         name: Symbol,
         span: Span,

--- a/src/librustc_metadata/cstore.rs
+++ b/src/librustc_metadata/cstore.rs
@@ -93,6 +93,11 @@ pub struct CStore {
     pub metadata_loader: Box<dyn MetadataLoader + Sync>,
 }
 
+pub enum LoadedMacro {
+    MacroDef(ast::Item),
+    ProcMacro(Lrc<SyntaxExtension>),
+}
+
 impl CStore {
     pub fn new(metadata_loader: Box<dyn MetadataLoader + Sync>) -> CStore {
         CStore {

--- a/src/librustc_metadata/cstore_impl.rs
+++ b/src/librustc_metadata/cstore_impl.rs
@@ -420,10 +420,6 @@ impl CrateStore for cstore::CStore {
         &*self.metadata_loader
     }
 
-    fn visibility_untracked(&self, def: DefId) -> ty::Visibility {
-        self.get_crate_data(def.krate).get_visibility(def.index)
-    }
-
     fn item_generics_cloned_untracked(&self, def: DefId, sess: &Session) -> ty::Generics {
         self.get_crate_data(def.krate).get_generics(def.index, sess)
     }

--- a/src/librustc_metadata/cstore_impl.rs
+++ b/src/librustc_metadata/cstore_impl.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use cstore;
+use cstore::{self, LoadedMacro};
 use encoder;
 use link_args;
 use native_libs;
@@ -17,8 +17,8 @@ use schema;
 
 use rustc::ty::query::QueryConfig;
 use rustc::middle::cstore::{CrateStore, DepKind,
-                            MetadataLoader, LinkMeta,
-                            LoadedMacro, EncodedMetadata, NativeLibraryKind};
+                            LinkMeta,
+                            EncodedMetadata, NativeLibraryKind};
 use rustc::middle::exported_symbols::ExportedSymbol;
 use rustc::middle::stability::DeprecationEntry;
 use rustc::hir::def;
@@ -411,32 +411,8 @@ pub fn provide<'tcx>(providers: &mut Providers<'tcx>) {
     };
 }
 
-impl CrateStore for cstore::CStore {
-    fn crate_data_as_rc_any(&self, krate: CrateNum) -> Lrc<dyn Any> {
-        self.get_crate_data(krate)
-    }
-
-    fn metadata_loader(&self) -> &dyn MetadataLoader {
-        &*self.metadata_loader
-    }
-
-    fn item_generics_cloned_untracked(&self, def: DefId, sess: &Session) -> ty::Generics {
-        self.get_crate_data(def.krate).get_generics(def.index, sess)
-    }
-
-    fn associated_item_cloned_untracked(&self, def: DefId) -> ty::AssociatedItem
-    {
-        self.get_crate_data(def.krate).get_associated_item(def.index)
-    }
-
-    fn dep_kind_untracked(&self, cnum: CrateNum) -> DepKind
-    {
-        let data = self.get_crate_data(cnum);
-        let r = *data.dep_kind.lock();
-        r
-    }
-
-    fn export_macros_untracked(&self, cnum: CrateNum) {
+impl cstore::CStore {
+    pub fn export_macros_untracked(&self, cnum: CrateNum) {
         let data = self.get_crate_data(cnum);
         let mut dep_kind = data.dep_kind.lock();
         if *dep_kind == DepKind::UnexportedMacrosOnly {
@@ -444,69 +420,28 @@ impl CrateStore for cstore::CStore {
         }
     }
 
-    fn crate_name_untracked(&self, cnum: CrateNum) -> Symbol
-    {
-        self.get_crate_data(cnum).name
+    pub fn dep_kind_untracked(&self, cnum: CrateNum) -> DepKind {
+        let data = self.get_crate_data(cnum);
+        let r = *data.dep_kind.lock();
+        r
     }
 
-    fn crate_disambiguator_untracked(&self, cnum: CrateNum) -> CrateDisambiguator
-    {
-        self.get_crate_data(cnum).root.disambiguator
-    }
-
-    fn crate_hash_untracked(&self, cnum: CrateNum) -> hir::svh::Svh
-    {
-        self.get_crate_data(cnum).root.hash
-    }
-
-    fn crate_edition_untracked(&self, cnum: CrateNum) -> Edition
-    {
+    pub fn crate_edition_untracked(&self, cnum: CrateNum) -> Edition {
         self.get_crate_data(cnum).root.edition
     }
 
-    /// Returns the `DefKey` for a given `DefId`. This indicates the
-    /// parent `DefId` as well as some idea of what kind of data the
-    /// `DefId` refers to.
-    fn def_key(&self, def: DefId) -> DefKey {
-        // Note: loading the def-key (or def-path) for a def-id is not
-        // a *read* of its metadata. This is because the def-id is
-        // really just an interned shorthand for a def-path, which is the
-        // canonical name for an item.
-        //
-        // self.dep_graph.read(DepNode::MetaData(def));
-        self.get_crate_data(def.krate).def_key(def.index)
-    }
-
-    fn def_path(&self, def: DefId) -> DefPath {
-        // See `Note` above in `def_key()` for why this read is
-        // commented out:
-        //
-        // self.dep_graph.read(DepNode::MetaData(def));
-        self.get_crate_data(def.krate).def_path(def.index)
-    }
-
-    fn def_path_hash(&self, def: DefId) -> DefPathHash {
-        self.get_crate_data(def.krate).def_path_hash(def.index)
-    }
-
-    fn def_path_table(&self, cnum: CrateNum) -> Lrc<DefPathTable> {
-        self.get_crate_data(cnum).def_path_table.clone()
-    }
-
-    fn struct_field_names_untracked(&self, def: DefId) -> Vec<ast::Name>
-    {
+    pub fn struct_field_names_untracked(&self, def: DefId) -> Vec<ast::Name> {
         self.get_crate_data(def.krate).get_struct_field_names(def.index)
     }
 
-    fn item_children_untracked(&self, def_id: DefId, sess: &Session) -> Vec<def::Export>
-    {
+    pub fn item_children_untracked(&self, def_id: DefId, sess: &Session) -> Vec<def::Export> {
         let mut result = vec![];
         self.get_crate_data(def_id.krate)
             .each_child_of_item(def_id.index, |child| result.push(child), sess);
         result
     }
 
-    fn load_macro_untracked(&self, id: DefId, sess: &Session) -> LoadedMacro {
+    pub fn load_macro_untracked(&self, id: DefId, sess: &Session) -> LoadedMacro {
         let data = self.get_crate_data(id.krate);
         if let Some(ref proc_macros) = data.proc_macros {
             return LoadedMacro::ProcMacro(proc_macros[id.index.to_proc_macro_index()].1.clone());
@@ -553,6 +488,64 @@ impl CrateStore for cstore::CStore {
             vis: codemap::respan(local_span.shrink_to_lo(), ast::VisibilityKind::Inherited),
             tokens: None,
         })
+    }
+
+    pub fn associated_item_cloned_untracked(&self, def: DefId) -> ty::AssociatedItem {
+        self.get_crate_data(def.krate).get_associated_item(def.index)
+    }
+}
+
+impl CrateStore for cstore::CStore {
+    fn crate_data_as_rc_any(&self, krate: CrateNum) -> Lrc<dyn Any> {
+        self.get_crate_data(krate)
+    }
+
+    fn item_generics_cloned_untracked(&self, def: DefId, sess: &Session) -> ty::Generics {
+        self.get_crate_data(def.krate).get_generics(def.index, sess)
+    }
+
+    fn crate_name_untracked(&self, cnum: CrateNum) -> Symbol
+    {
+        self.get_crate_data(cnum).name
+    }
+
+    fn crate_disambiguator_untracked(&self, cnum: CrateNum) -> CrateDisambiguator
+    {
+        self.get_crate_data(cnum).root.disambiguator
+    }
+
+    fn crate_hash_untracked(&self, cnum: CrateNum) -> hir::svh::Svh
+    {
+        self.get_crate_data(cnum).root.hash
+    }
+
+    /// Returns the `DefKey` for a given `DefId`. This indicates the
+    /// parent `DefId` as well as some idea of what kind of data the
+    /// `DefId` refers to.
+    fn def_key(&self, def: DefId) -> DefKey {
+        // Note: loading the def-key (or def-path) for a def-id is not
+        // a *read* of its metadata. This is because the def-id is
+        // really just an interned shorthand for a def-path, which is the
+        // canonical name for an item.
+        //
+        // self.dep_graph.read(DepNode::MetaData(def));
+        self.get_crate_data(def.krate).def_key(def.index)
+    }
+
+    fn def_path(&self, def: DefId) -> DefPath {
+        // See `Note` above in `def_key()` for why this read is
+        // commented out:
+        //
+        // self.dep_graph.read(DepNode::MetaData(def));
+        self.get_crate_data(def.krate).def_path(def.index)
+    }
+
+    fn def_path_hash(&self, def: DefId) -> DefPathHash {
+        self.get_crate_data(def.krate).def_path_hash(def.index)
+    }
+
+    fn def_path_table(&self, cnum: CrateNum) -> Lrc<DefPathTable> {
+        self.get_crate_data(cnum).def_path_table.clone()
     }
 
     fn crates_untracked(&self) -> Vec<CrateNum>

--- a/src/librustc_metadata/decoder.rs
+++ b/src/librustc_metadata/decoder.rs
@@ -427,10 +427,10 @@ impl<'tcx> EntryKind<'tcx> {
             EntryKind::Trait(_) => Def::Trait(did),
             EntryKind::Enum(..) => Def::Enum(did),
             EntryKind::MacroDef(_) => Def::Macro(did, MacroKind::Bang),
-            EntryKind::GlobalAsm => Def::GlobalAsm(did),
             EntryKind::ForeignType => Def::TyForeign(did),
 
             EntryKind::ForeignMod |
+            EntryKind::GlobalAsm |
             EntryKind::Impl(_) |
             EntryKind::Field |
             EntryKind::Generator(_) |

--- a/src/librustc_resolve/Cargo.toml
+++ b/src/librustc_resolve/Cargo.toml
@@ -17,3 +17,4 @@ arena = { path = "../libarena" }
 rustc_errors = { path = "../librustc_errors" }
 syntax_pos = { path = "../libsyntax_pos" }
 rustc_data_structures = { path = "../librustc_data_structures" }
+rustc_metadata = { path = "../librustc_metadata" }

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -21,11 +21,11 @@ use {PerNS, Resolver, ResolverArenas};
 use Namespace::{self, TypeNS, ValueNS, MacroNS};
 use {resolve_error, resolve_struct_error, ResolutionError};
 
-use rustc::middle::cstore::LoadedMacro;
 use rustc::hir::def::*;
 use rustc::hir::def_id::{BUILTIN_MACROS_CRATE, CRATE_DEF_INDEX, LOCAL_CRATE, DefId};
 use rustc::ty;
 use rustc::middle::cstore::CrateStore;
+use rustc_metadata::cstore::LoadedMacro;
 
 use std::cell::Cell;
 use rustc_data_structures::sync::Lrc;

--- a/src/librustc_resolve/check_unused.rs
+++ b/src/librustc_resolve/check_unused.rs
@@ -31,8 +31,8 @@ use syntax::visit::{self, Visitor};
 use syntax_pos::{Span, MultiSpan, DUMMY_SP};
 
 
-struct UnusedImportCheckVisitor<'a, 'b: 'a> {
-    resolver: &'a mut Resolver<'b>,
+struct UnusedImportCheckVisitor<'a, 'b: 'a, 'd: 'b> {
+    resolver: &'a mut Resolver<'b, 'd>,
     /// All the (so far) unused imports, grouped path list
     unused_imports: NodeMap<NodeMap<Span>>,
     base_id: ast::NodeId,
@@ -40,21 +40,21 @@ struct UnusedImportCheckVisitor<'a, 'b: 'a> {
 }
 
 // Deref and DerefMut impls allow treating UnusedImportCheckVisitor as Resolver.
-impl<'a, 'b> Deref for UnusedImportCheckVisitor<'a, 'b> {
-    type Target = Resolver<'b>;
+impl<'a, 'b, 'd> Deref for UnusedImportCheckVisitor<'a, 'b, 'd> {
+    type Target = Resolver<'b, 'd>;
 
-    fn deref<'c>(&'c self) -> &'c Resolver<'b> {
+    fn deref<'c>(&'c self) -> &'c Resolver<'b, 'd> {
         &*self.resolver
     }
 }
 
-impl<'a, 'b> DerefMut for UnusedImportCheckVisitor<'a, 'b> {
-    fn deref_mut<'c>(&'c mut self) -> &'c mut Resolver<'b> {
+impl<'a, 'b, 'd> DerefMut for UnusedImportCheckVisitor<'a, 'b, 'd> {
+    fn deref_mut<'c>(&'c mut self) -> &'c mut Resolver<'b, 'd> {
         &mut *self.resolver
     }
 }
 
-impl<'a, 'b> UnusedImportCheckVisitor<'a, 'b> {
+impl<'a, 'b, 'd> UnusedImportCheckVisitor<'a, 'b, 'd> {
     // We have information about whether `use` (import) directives are actually
     // used now. If an import is not used at all, we signal a lint error.
     fn check_import(&mut self, item_id: ast::NodeId, id: ast::NodeId, span: Span) {
@@ -77,7 +77,7 @@ impl<'a, 'b> UnusedImportCheckVisitor<'a, 'b> {
     }
 }
 
-impl<'a, 'b> Visitor<'a> for UnusedImportCheckVisitor<'a, 'b> {
+impl<'a, 'b, 'cl> Visitor<'a> for UnusedImportCheckVisitor<'a, 'b, 'cl> {
     fn visit_item(&mut self, item: &'a ast::Item) {
         self.item_span = item.span;
 

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -200,15 +200,10 @@ fn resolve_struct_error<'sess, 'a>(resolver: &'sess Resolver,
                         err.span_label(typaram_span, "type variable from outer function");
                     }
                 },
-                Def::Mod(..) | Def::Struct(..) | Def::Union(..) | Def::Enum(..) | Def::Variant(..) |
-                Def::Trait(..) | Def::TyAlias(..) | Def::TyForeign(..) | Def::TraitAlias(..) |
-                Def::AssociatedTy(..) | Def::PrimTy(..) | Def::Fn(..) | Def::Const(..) |
-                Def::Static(..) | Def::StructCtor(..) | Def::VariantCtor(..) | Def::Method(..) |
-                Def::AssociatedConst(..) | Def::Local(..) | Def::Upvar(..) | Def::Label(..) |
-                Def::Existential(..) | Def::AssociatedExistential(..) |
-                Def::Macro(..) | Def::GlobalAsm(..) | Def::Err =>
+                _ => {
                     bug!("TypeParametersFromOuterFunction should only be used with Def::SelfTy or \
                          Def::TyParam")
+                }
             }
 
             // Try to retrieve the span of the function signature and generate a new message with

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -25,7 +25,6 @@ use rustc::hir::def_id::{CRATE_DEF_INDEX, DefId};
 use rustc::hir::def::*;
 use rustc::session::DiagnosticMessageId;
 use rustc::util::nodemap::{FxHashMap, FxHashSet};
-use rustc::middle::cstore::CrateStore;
 
 use syntax::ast::{Ident, Name, NodeId, CRATE_NODE_ID};
 use syntax::ext::base::Determinacy::{self, Determined, Undetermined};

--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -810,7 +810,6 @@ impl<'l, 'tcx: 'l> SaveContext<'l, 'tcx> {
             HirDef::SelfTy(..) |
             HirDef::Label(..) |
             HirDef::Macro(..) |
-            HirDef::GlobalAsm(..) |
             HirDef::Err => None,
         }
     }

--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -13,6 +13,7 @@ use rustc::traits::{self, auto_trait as auto};
 use rustc::ty::{self, ToPredicate, TypeFoldable};
 use rustc::ty::subst::Subst;
 use rustc::infer::InferOk;
+use rustc::middle::cstore::CrateStore;
 use std::fmt::Debug;
 use syntax_pos::DUMMY_SP;
 
@@ -20,13 +21,13 @@ use core::DocAccessLevels;
 
 use super::*;
 
-pub struct AutoTraitFinder<'a, 'tcx: 'a, 'rcx: 'a> {
-    pub cx: &'a core::DocContext<'a, 'tcx, 'rcx>,
+pub struct AutoTraitFinder<'a, 'tcx: 'a, 'rcx: 'a, 'cstore: 'rcx> {
+    pub cx: &'a core::DocContext<'a, 'tcx, 'rcx, 'cstore>,
     pub f: auto::AutoTraitFinder<'a, 'tcx>,
 }
 
-impl<'a, 'tcx, 'rcx> AutoTraitFinder<'a, 'tcx, 'rcx> {
-    pub fn new(cx: &'a core::DocContext<'a, 'tcx, 'rcx>) -> Self {
+impl<'a, 'tcx, 'rcx, 'cstore> AutoTraitFinder<'a, 'tcx, 'rcx, 'cstore> {
+    pub fn new(cx: &'a core::DocContext<'a, 'tcx, 'rcx, 'cstore>) -> Self {
         let f = auto::AutoTraitFinder::new(&cx.tcx);
 
         AutoTraitFinder { cx, f }

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -19,7 +19,7 @@ use syntax_pos::Span;
 use rustc::hir;
 use rustc::hir::def::{Def, CtorKind};
 use rustc::hir::def_id::DefId;
-use rustc::middle::cstore::LoadedMacro;
+use rustc::middle::cstore::{CrateStore, LoadedMacro};
 use rustc::ty;
 use rustc::util::nodemap::FxHashSet;
 

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -19,7 +19,7 @@ use syntax_pos::Span;
 use rustc::hir;
 use rustc::hir::def::{Def, CtorKind};
 use rustc::hir::def_id::DefId;
-use rustc::middle::cstore::{CrateStore, LoadedMacro};
+use rustc_metadata::cstore::LoadedMacro;
 use rustc::ty;
 use rustc::util::nodemap::FxHashSet;
 

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -145,7 +145,7 @@ pub struct Crate {
     pub masked_crates: FxHashSet<CrateNum>,
 }
 
-impl<'a, 'tcx, 'rcx> Clean<Crate> for visit_ast::RustdocVisitor<'a, 'tcx, 'rcx> {
+impl<'a, 'tcx, 'rcx, 'cstore> Clean<Crate> for visit_ast::RustdocVisitor<'a, 'tcx, 'rcx, 'cstore> {
     fn clean(&self, cx: &DocContext) -> Crate {
         use ::visit_lib::LibEmbargoVisitor;
 

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -13,7 +13,6 @@ use rustc_driver::{self, driver, target_features, abort_on_err};
 use rustc::session::{self, config};
 use rustc::hir::def_id::{DefId, CrateNum, LOCAL_CRATE};
 use rustc::hir::def::Def;
-use rustc::middle::cstore::CrateStore;
 use rustc::middle::privacy::AccessLevels;
 use rustc::ty::{self, TyCtxt, AllArenas};
 use rustc::hir::map as hir_map;
@@ -49,13 +48,13 @@ pub use rustc::session::search_paths::SearchPaths;
 
 pub type ExternalPaths = FxHashMap<DefId, (Vec<String>, clean::TypeKind)>;
 
-pub struct DocContext<'a, 'tcx: 'a, 'rcx: 'a> {
+pub struct DocContext<'a, 'tcx: 'a, 'rcx: 'a, 'cstore: 'rcx> {
     pub tcx: TyCtxt<'a, 'tcx, 'tcx>,
-    pub resolver: &'a RefCell<resolve::Resolver<'rcx>>,
+    pub resolver: &'a RefCell<resolve::Resolver<'rcx, 'cstore>>,
     /// The stack of module NodeIds up till this point
     pub mod_ids: RefCell<Vec<NodeId>>,
     pub crate_name: Option<String>,
-    pub cstore: Rc<dyn CrateStore>,
+    pub cstore: Rc<CStore>,
     pub populated_all_crate_impls: Cell<bool>,
     // Note that external items for which `doc(hidden)` applies to are shown as
     // non-reachable while local items aren't. This is because we're reusing
@@ -87,7 +86,7 @@ pub struct DocContext<'a, 'tcx: 'a, 'rcx: 'a> {
     pub all_traits: Vec<DefId>,
 }
 
-impl<'a, 'tcx, 'rcx> DocContext<'a, 'tcx, 'rcx> {
+impl<'a, 'tcx, 'rcx, 'cstore> DocContext<'a, 'tcx, 'rcx, 'cstore> {
     pub fn sess(&self) -> &session::Session {
         &self.tcx.sess
     }

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -38,10 +38,10 @@ use doctree::*;
 // also, is there some reason that this doesn't use the 'visit'
 // framework from syntax?
 
-pub struct RustdocVisitor<'a, 'tcx: 'a, 'rcx: 'a> {
+pub struct RustdocVisitor<'a, 'tcx: 'a, 'rcx: 'a, 'cstore: 'rcx> {
     pub module: Module,
     pub attrs: hir::HirVec<ast::Attribute>,
-    pub cx: &'a core::DocContext<'a, 'tcx, 'rcx>,
+    pub cx: &'a core::DocContext<'a, 'tcx, 'rcx, 'cstore>,
     view_item_stack: FxHashSet<ast::NodeId>,
     inlining: bool,
     /// Is the current module and all of its parents public?
@@ -49,8 +49,10 @@ pub struct RustdocVisitor<'a, 'tcx: 'a, 'rcx: 'a> {
     exact_paths: Option<FxHashMap<DefId, Vec<String>>>,
 }
 
-impl<'a, 'tcx, 'rcx> RustdocVisitor<'a, 'tcx, 'rcx> {
-    pub fn new(cx: &'a core::DocContext<'a, 'tcx, 'rcx>) -> RustdocVisitor<'a, 'tcx, 'rcx> {
+impl<'a, 'tcx, 'rcx, 'cstore> RustdocVisitor<'a, 'tcx, 'rcx, 'cstore> {
+    pub fn new(
+        cx: &'a core::DocContext<'a, 'tcx, 'rcx, 'cstore>
+    ) -> RustdocVisitor<'a, 'tcx, 'rcx, 'cstore> {
         // If the root is re-exported, terminate all recursion.
         let mut stack = FxHashSet();
         stack.insert(ast::CRATE_NODE_ID);

--- a/src/librustdoc/visit_lib.rs
+++ b/src/librustdoc/visit_lib.rs
@@ -22,8 +22,8 @@ use clean::{AttributesExt, NestedAttributesExt};
 
 /// Similar to `librustc_privacy::EmbargoVisitor`, but also takes
 /// specific rustdoc annotations into account (i.e. `doc(hidden)`)
-pub struct LibEmbargoVisitor<'a, 'tcx: 'a, 'rcx: 'a> {
-    cx: &'a ::core::DocContext<'a, 'tcx, 'rcx>,
+pub struct LibEmbargoVisitor<'a, 'tcx: 'a, 'rcx: 'a, 'cstore: 'rcx> {
+    cx: &'a ::core::DocContext<'a, 'tcx, 'rcx, 'cstore>,
     // Accessibility levels for reachable nodes
     access_levels: RefMut<'a, AccessLevels<DefId>>,
     // Previous accessibility level, None means unreachable
@@ -32,8 +32,10 @@ pub struct LibEmbargoVisitor<'a, 'tcx: 'a, 'rcx: 'a> {
     visited_mods: FxHashSet<DefId>,
 }
 
-impl<'a, 'tcx, 'rcx> LibEmbargoVisitor<'a, 'tcx, 'rcx> {
-    pub fn new(cx: &'a ::core::DocContext<'a, 'tcx, 'rcx>) -> LibEmbargoVisitor<'a, 'tcx, 'rcx> {
+impl<'a, 'tcx, 'rcx, 'cstore> LibEmbargoVisitor<'a, 'tcx, 'rcx, 'cstore> {
+    pub fn new(
+        cx: &'a ::core::DocContext<'a, 'tcx, 'rcx, 'cstore>
+    ) -> LibEmbargoVisitor<'a, 'tcx, 'rcx, 'cstore> {
         LibEmbargoVisitor {
             cx,
             access_levels: cx.access_levels.borrow_mut(),

--- a/src/test/run-pass-fulldeps/compiler-calls.rs
+++ b/src/test/run-pass-fulldeps/compiler-calls.rs
@@ -21,12 +21,13 @@ extern crate rustc_driver;
 extern crate rustc_codegen_utils;
 extern crate syntax;
 extern crate rustc_errors as errors;
+extern crate rustc_metadata;
 
-use rustc::middle::cstore::CrateStore;
 use rustc::session::Session;
 use rustc::session::config::{self, Input};
 use rustc_driver::{driver, CompilerCalls, Compilation};
 use rustc_codegen_utils::codegen_backend::CodegenBackend;
+use rustc_metadata::cstore::CStore;
 use syntax::ast;
 
 use std::path::PathBuf;
@@ -51,7 +52,7 @@ impl<'a> CompilerCalls<'a> for TestCalls<'a> {
                      _: &CodegenBackend,
                      _: &getopts::Matches,
                      _: &Session,
-                     _: &CrateStore,
+                     _: &CStore,
                      _: &Input,
                      _: &Option<PathBuf>,
                      _: &Option<PathBuf>)

--- a/src/test/ui/borrowck/mut-borrow-outside-loop.nll.stderr
+++ b/src/test/ui/borrowck/mut-borrow-outside-loop.nll.stderr
@@ -17,7 +17,7 @@ LL |         let inner_second = &mut inner_void; //~ ERROR cannot borrow
    |                            ^^^^^^^^^^^^^^^ second mutable borrow occurs here
 LL |         inner_second.use_mut();
 LL |         inner_first.use_mut();
-   |         ----------- borrow later used here
+   |         ----------- borrow used here in later iteration of loop
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/generator/dropck.nll.stderr
+++ b/src/test/ui/generator/dropck.nll.stderr
@@ -9,8 +9,6 @@ LL | }
    | |
    | `*cell` dropped here while still borrowed
    | borrow later used here, when `gen` is dropped
-   |
-   = note: values in a scope are dropped in the opposite order they are defined
 
 error[E0597]: `ref_` does not live long enough
   --> $DIR/dropck.rs:22:11

--- a/src/test/ui/impl-trait/static-return-lifetime-infered.nll.stderr
+++ b/src/test/ui/impl-trait/static-return-lifetime-infered.nll.stderr
@@ -21,6 +21,8 @@ LL |         self.x.iter().map(|a| a.0)
 error: unsatisfied lifetime constraints
   --> $DIR/static-return-lifetime-infered.rs:21:9
    |
+LL |     fn iter_values<'a>(&'a self) -> impl Iterator<Item=u32> {
+   |                    -- lifetime `'a` defined here
 LL |         self.x.iter().map(|a| a.0)
    |         ^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
 

--- a/src/test/ui/issue-10291.nll.stderr
+++ b/src/test/ui/issue-10291.nll.stderr
@@ -7,6 +7,8 @@ LL |         x //~ ERROR E0312
 error: unsatisfied lifetime constraints
   --> $DIR/issue-10291.rs:12:5
    |
+LL | fn test<'x>(x: &'x isize) {
+   |         -- lifetime `'x` defined here
 LL |     drop::<Box<for<'z> FnMut(&'z isize) -> &'z isize>>(Box::new(|z| {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'x` must outlive `'static`
 

--- a/src/test/ui/issue-45696-long-live-borrows-in-boxes.rs
+++ b/src/test/ui/issue-45696-long-live-borrows-in-boxes.rs
@@ -1,0 +1,103 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// rust-lang/rust#45696: This test is checking that we can return
+// mutable borrows owned by boxes even when the boxes are dropped.
+//
+// We will explicitly test AST-borrowck, NLL, and migration modes;
+// thus we will also skip the automated compare-mode=nll.
+
+// revisions: ast nll migrate
+// ignore-compare-mode-nll
+
+#![cfg_attr(nll, feature(nll))]
+//[migrate]compile-flags: -Z borrowck=migrate -Z two-phase-borrows
+
+// run-pass
+
+type Boxed<'a, 'b> = Box<(&'a mut u32, &'b mut u32)>;
+
+fn return_borrow_from_dropped_box<'a>(x: Boxed<'a, '_>) -> &'a mut u32 {
+    &mut *x.0
+}
+
+fn return_borrow_from_dropped_tupled_box<'a>(x: (Boxed<'a, '_>, &mut u32)) -> &'a mut u32 {
+    &mut *(x.0).0
+}
+
+fn basic_tests() {
+    let mut x = 2;
+    let mut y = 3;
+    let mut z = 4;
+    *return_borrow_from_dropped_box(Box::new((&mut x, &mut y))) += 10;
+    assert_eq!((x, y, z), (12, 3, 4));
+    *return_borrow_from_dropped_tupled_box((Box::new((&mut x, &mut y)), &mut z)) += 10;
+    assert_eq!((x, y, z), (22, 3, 4));
+}
+
+// These scribbling tests have been transcribed from
+// issue-45696-scribble-on-boxed-borrow.rs
+//
+// In the context of that file, these tests are meant to show cases
+// that should be *accepted* by the compiler, so here we are actually
+// checking that the code we get when they are compiled matches our
+// expectations.
+
+struct Scribble<'a>(&'a mut u32);
+
+impl<'a> Drop for Scribble<'a> { fn drop(&mut self) { *self.0 = 42; } }
+
+// this is okay, in both AST-borrowck and NLL: The `Scribble` here *has*
+// to strictly outlive `'a`
+fn borrowed_scribble<'a>(s: &'a mut Scribble) -> &'a mut u32 {
+    &mut *s.0
+}
+
+// this, by analogy to previous case, is also okay.
+fn boxed_borrowed_scribble<'a>(s: Box<&'a mut Scribble>) -> &'a mut u32 {
+    &mut *(*s).0
+}
+
+// this, by analogy to previous case, is also okay.
+fn boxed_boxed_borrowed_scribble<'a>(s: Box<Box<&'a mut Scribble>>) -> &'a mut u32 {
+    &mut *(**s).0
+}
+
+fn scribbling_tests() {
+    let mut x = 1;
+    {
+        let mut long_lived = Scribble(&mut x);
+        *borrowed_scribble(&mut long_lived) += 10;
+        assert_eq!(*long_lived.0, 11);
+        // (Scribble dtor runs here, after `&mut`-borrow above ends)
+    }
+    assert_eq!(x, 42);
+    x = 1;
+    {
+        let mut long_lived = Scribble(&mut x);
+        *boxed_borrowed_scribble(Box::new(&mut long_lived)) += 10;
+        assert_eq!(*long_lived.0, 11);
+        // (Scribble dtor runs here, after `&mut`-borrow above ends)
+    }
+    assert_eq!(x, 42);
+    x = 1;
+    {
+        let mut long_lived = Scribble(&mut x);
+        *boxed_boxed_borrowed_scribble(Box::new(Box::new(&mut long_lived))) += 10;
+        assert_eq!(*long_lived.0, 11);
+        // (Scribble dtor runs here, after `&mut`-borrow above ends)
+    }
+    assert_eq!(x, 42);
+}
+
+fn main() {
+    basic_tests();
+    scribbling_tests();
+}

--- a/src/test/ui/issue-45696-no-variant-box-recur.rs
+++ b/src/test/ui/issue-45696-no-variant-box-recur.rs
@@ -1,0 +1,66 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// rust-lang/rust#45696: This test checks the compiler won't infinite
+// loop when you declare a variable of type `struct A(Box<A>, ...);`
+// (which is impossible to construct but *is* possible to declare; see
+// also issues #4287, #44933, and #52852).
+//
+// We will explicitly test AST-borrowck, NLL, and migration modes;
+// thus we will also skip the automated compare-mode=nll.
+
+// revisions: ast nll migrate
+// ignore-compare-mode-nll
+
+#![cfg_attr(nll, feature(nll))]
+//[migrate]compile-flags: -Z borrowck=migrate -Z two-phase-borrows
+
+// run-pass
+
+// This test has structs and functions that are by definiton unusable
+// all over the place, so just go ahead and allow dead_code
+#![allow(dead_code)]
+
+// direct regular recursion with indirect ownership via box
+struct C { field: Box<C> }
+
+// direct non-regular recursion with indirect ownership via box
+struct D { field: Box<(D, D)> }
+
+// indirect regular recursion with indirect ownership via box.
+struct E { field: F }
+struct F { field: Box<E> }
+
+// indirect non-regular recursion with indirect ownership via box.
+struct G { field: (F, F) }
+struct H { field: Box<E> }
+
+// These enums are cases that are not currently hit by the
+// `visit_terminator_drop` recursion down a type's structural
+// definition.
+//
+// But it seems prudent to include them in this test as variants on
+// the above, in that they are similarly non-constructable data types
+// with destructors that would diverge.
+enum I { One(Box<I>) }
+enum J { One(Box<J>), Two(Box<J>) }
+
+fn impossible_to_call_c(_c: C) { }
+fn impossible_to_call_d(_d: D) { }
+fn impossible_to_call_e(_e: E) { }
+fn impossible_to_call_f(_f: F) { }
+fn impossible_to_call_g(_g: G) { }
+fn impossible_to_call_h(_h: H) { }
+fn impossible_to_call_i(_i: I) { }
+fn impossible_to_call_j(_j: J) { }
+
+fn main() {
+
+}

--- a/src/test/ui/issue-45696-no-variant-box-recur.rs
+++ b/src/test/ui/issue-45696-no-variant-box-recur.rs
@@ -39,8 +39,8 @@ struct E { field: F }
 struct F { field: Box<E> }
 
 // indirect non-regular recursion with indirect ownership via box.
-struct G { field: (F, F) }
-struct H { field: Box<E> }
+struct G { field: (H, H) }
+struct H { field: Box<G> }
 
 // These enums are cases that are not currently hit by the
 // `visit_terminator_drop` recursion down a type's structural

--- a/src/test/ui/issue-45696-scribble-on-boxed-borrow.ast.stderr
+++ b/src/test/ui/issue-45696-scribble-on-boxed-borrow.ast.stderr
@@ -1,0 +1,14 @@
+error: compilation successful
+  --> $DIR/issue-45696-scribble-on-boxed-borrow.rs:89:1
+   |
+LL | / fn main() { //[ast]~ ERROR compilation successful
+LL | |      //[migrate]~^ ERROR compilation successful
+LL | |     let mut x = 1;
+LL | |     {
+...  |
+LL | |     *boxed_boxed_scribbled(Box::new(Box::new(Scribble(&mut x)))) += 10;
+LL | | }
+   | |_^
+
+error: aborting due to previous error
+

--- a/src/test/ui/issue-45696-scribble-on-boxed-borrow.migrate.stderr
+++ b/src/test/ui/issue-45696-scribble-on-boxed-borrow.migrate.stderr
@@ -1,0 +1,69 @@
+warning[E0597]: `*s.0` does not live long enough
+  --> $DIR/issue-45696-scribble-on-boxed-borrow.rs:63:5
+   |
+LL |     &mut *s.0 //[nll]~ ERROR `*s.0` does not live long enough [E0597]
+   |     ^^^^^^^^^ borrowed value does not live long enough
+...
+LL | }
+   | - `*s.0` dropped here while still borrowed
+   |
+note: borrowed value must be valid for the lifetime 'a as defined on the function body at 62:14...
+  --> $DIR/issue-45696-scribble-on-boxed-borrow.rs:62:14
+   |
+LL | fn scribbled<'a>(s: Scribble<'a>) -> &'a mut u32 {
+   |              ^^
+   = warning: This error has been downgraded to a warning for backwards compatibility with previous releases.
+           It represents potential unsoundness in your code.
+           This warning will become a hard error in the future.
+
+warning[E0597]: `*s.0` does not live long enough
+  --> $DIR/issue-45696-scribble-on-boxed-borrow.rs:73:5
+   |
+LL |     &mut *(*s).0 //[nll]~ ERROR `*s.0` does not live long enough [E0597]
+   |     ^^^^^^^^^^^^ borrowed value does not live long enough
+...
+LL | }
+   | - `*s.0` dropped here while still borrowed
+   |
+note: borrowed value must be valid for the lifetime 'a as defined on the function body at 72:20...
+  --> $DIR/issue-45696-scribble-on-boxed-borrow.rs:72:20
+   |
+LL | fn boxed_scribbled<'a>(s: Box<Scribble<'a>>) -> &'a mut u32 {
+   |                    ^^
+   = warning: This error has been downgraded to a warning for backwards compatibility with previous releases.
+           It represents potential unsoundness in your code.
+           This warning will become a hard error in the future.
+
+warning[E0597]: `*s.0` does not live long enough
+  --> $DIR/issue-45696-scribble-on-boxed-borrow.rs:83:5
+   |
+LL |     &mut *(**s).0 //[nll]~ ERROR `*s.0` does not live long enough [E0597]
+   |     ^^^^^^^^^^^^^ borrowed value does not live long enough
+...
+LL | }
+   | - `*s.0` dropped here while still borrowed
+   |
+note: borrowed value must be valid for the lifetime 'a as defined on the function body at 82:26...
+  --> $DIR/issue-45696-scribble-on-boxed-borrow.rs:82:26
+   |
+LL | fn boxed_boxed_scribbled<'a>(s: Box<Box<Scribble<'a>>>) -> &'a mut u32 {
+   |                          ^^
+   = warning: This error has been downgraded to a warning for backwards compatibility with previous releases.
+           It represents potential unsoundness in your code.
+           This warning will become a hard error in the future.
+
+error: compilation successful
+  --> $DIR/issue-45696-scribble-on-boxed-borrow.rs:89:1
+   |
+LL | / fn main() { //[ast]~ ERROR compilation successful
+LL | |      //[migrate]~^ ERROR compilation successful
+LL | |     let mut x = 1;
+LL | |     {
+...  |
+LL | |     *boxed_boxed_scribbled(Box::new(Box::new(Scribble(&mut x)))) += 10;
+LL | | }
+   | |_^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/issue-45696-scribble-on-boxed-borrow.nll.stderr
+++ b/src/test/ui/issue-45696-scribble-on-boxed-borrow.nll.stderr
@@ -1,0 +1,48 @@
+error[E0597]: `*s.0` does not live long enough
+  --> $DIR/issue-45696-scribble-on-boxed-borrow.rs:63:5
+   |
+LL |     &mut *s.0 //[nll]~ ERROR `*s.0` does not live long enough [E0597]
+   |     ^^^^^^^^^ borrowed value does not live long enough
+...
+LL | }
+   | - `*s.0` dropped here while still borrowed
+   |
+note: borrowed value must be valid for the lifetime 'a as defined on the function body at 62:14...
+  --> $DIR/issue-45696-scribble-on-boxed-borrow.rs:62:14
+   |
+LL | fn scribbled<'a>(s: Scribble<'a>) -> &'a mut u32 {
+   |              ^^
+
+error[E0597]: `*s.0` does not live long enough
+  --> $DIR/issue-45696-scribble-on-boxed-borrow.rs:73:5
+   |
+LL |     &mut *(*s).0 //[nll]~ ERROR `*s.0` does not live long enough [E0597]
+   |     ^^^^^^^^^^^^ borrowed value does not live long enough
+...
+LL | }
+   | - `*s.0` dropped here while still borrowed
+   |
+note: borrowed value must be valid for the lifetime 'a as defined on the function body at 72:20...
+  --> $DIR/issue-45696-scribble-on-boxed-borrow.rs:72:20
+   |
+LL | fn boxed_scribbled<'a>(s: Box<Scribble<'a>>) -> &'a mut u32 {
+   |                    ^^
+
+error[E0597]: `*s.0` does not live long enough
+  --> $DIR/issue-45696-scribble-on-boxed-borrow.rs:83:5
+   |
+LL |     &mut *(**s).0 //[nll]~ ERROR `*s.0` does not live long enough [E0597]
+   |     ^^^^^^^^^^^^^ borrowed value does not live long enough
+...
+LL | }
+   | - `*s.0` dropped here while still borrowed
+   |
+note: borrowed value must be valid for the lifetime 'a as defined on the function body at 82:26...
+  --> $DIR/issue-45696-scribble-on-boxed-borrow.rs:82:26
+   |
+LL | fn boxed_boxed_scribbled<'a>(s: Box<Box<Scribble<'a>>>) -> &'a mut u32 {
+   |                          ^^
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/issue-45696-scribble-on-boxed-borrow.rs
+++ b/src/test/ui/issue-45696-scribble-on-boxed-borrow.rs
@@ -1,0 +1,110 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// rust-lang/rust#45696: This test is checking that we *cannot* return
+// mutable borrows that would be scribbled over by destructors before
+// the return occurs.
+//
+// We will explicitly test AST-borrowck, NLL, and migration modes;
+// thus we will also skip the automated compare-mode=nll.
+
+// revisions: ast nll migrate
+// ignore-compare-mode-nll
+
+// This test is going to pass in the ast and migrate revisions,
+// because the AST-borrowck accepted this code in the past (see notes
+// below). So we use `#[rustc_error]` to keep the outcome as an error
+// in all scenarios, and rely on the stderr files to show what the
+// actual behavior is. (See rust-lang/rust#49855.)
+#![feature(rustc_attrs)]
+
+#![cfg_attr(nll, feature(nll))]
+//[migrate]compile-flags: -Z borrowck=migrate -Z two-phase-borrows
+
+struct Scribble<'a>(&'a mut u32);
+
+impl<'a> Drop for Scribble<'a> { fn drop(&mut self) { *self.0 = 42; } }
+
+// this is okay, in both AST-borrowck and NLL: The `Scribble` here *has*
+// to strictly outlive `'a`
+fn borrowed_scribble<'a>(s: &'a mut Scribble) -> &'a mut u32 {
+    &mut *s.0
+}
+
+// this, by analogy to previous case, is also okay.
+fn boxed_borrowed_scribble<'a>(s: Box<&'a mut Scribble>) -> &'a mut u32 {
+    &mut *(*s).0
+}
+
+// this, by analogy to previous case, is also okay.
+fn boxed_boxed_borrowed_scribble<'a>(s: Box<Box<&'a mut Scribble>>) -> &'a mut u32 {
+    &mut *(**s).0
+}
+
+// this is not okay: in between the time that we take the mutable
+// borrow and the caller receives it as a return value, the drop of
+// `s` will scribble on it, violating our aliasing guarantees.
+//
+// * (Maybe in the future the two-phase borrows system will be
+//   extended to support this case. But for now, it is an error in
+//   NLL, even with two-phase borrows.)
+//
+// In any case, the AST-borrowck was not smart enough to know that
+// this should be an error. (Which is perhaps the essence of why
+// rust-lang/rust#45696 arose in the first place.)
+fn scribbled<'a>(s: Scribble<'a>) -> &'a mut u32 {
+    &mut *s.0 //[nll]~ ERROR `*s.0` does not live long enough [E0597]
+    //[migrate]~^ WARNING `*s.0` does not live long enough [E0597]
+    //[migrate]~| WARNING This error has been downgraded to a warning for backwards compatibility
+}
+
+// This, by analogy to previous case, is *also* not okay.
+//
+// (But again, AST-borrowck was not smart enogh to know that this
+// should be an error.)
+fn boxed_scribbled<'a>(s: Box<Scribble<'a>>) -> &'a mut u32 {
+    &mut *(*s).0 //[nll]~ ERROR `*s.0` does not live long enough [E0597]
+    //[migrate]~^ WARNING `*s.0` does not live long enough [E0597]
+    //[migrate]~| WARNING This error has been downgraded to a warning for backwards compatibility
+}
+
+// This, by analogy to previous case, is *also* not okay.
+//
+// (But again, AST-borrowck was not smart enogh to know that this
+// should be an error.)
+fn boxed_boxed_scribbled<'a>(s: Box<Box<Scribble<'a>>>) -> &'a mut u32 {
+    &mut *(**s).0 //[nll]~ ERROR `*s.0` does not live long enough [E0597]
+    //[migrate]~^ WARNING `*s.0` does not live long enough [E0597]
+    //[migrate]~| WARNING This error has been downgraded to a warning for backwards compatibility
+}
+
+#[rustc_error]
+fn main() { //[ast]~ ERROR compilation successful
+     //[migrate]~^ ERROR compilation successful
+    let mut x = 1;
+    {
+        let mut long_lived = Scribble(&mut x);
+        *borrowed_scribble(&mut long_lived) += 10;
+        // (Scribble dtor runs here, after `&mut`-borrow above ends)
+    }
+    {
+        let mut long_lived = Scribble(&mut x);
+        *boxed_borrowed_scribble(Box::new(&mut long_lived)) += 10;
+        // (Scribble dtor runs here, after `&mut`-borrow above ends)
+    }
+    {
+        let mut long_lived = Scribble(&mut x);
+        *boxed_boxed_borrowed_scribble(Box::new(Box::new(&mut long_lived))) += 10;
+        // (Scribble dtor runs here, after `&mut`-borrow above ends)
+    }
+    *scribbled(Scribble(&mut x)) += 10;
+    *boxed_scribbled(Box::new(Scribble(&mut x))) += 10;
+    *boxed_boxed_scribbled(Box::new(Box::new(Scribble(&mut x)))) += 10;
+}

--- a/src/test/ui/issue-52126-assign-op-invariance.nll.stderr
+++ b/src/test/ui/issue-52126-assign-op-invariance.nll.stderr
@@ -5,7 +5,7 @@ LL |         let v: Vec<&str> = line.split_whitespace().collect();
    |                            ^^^^ borrowed value does not live long enough
 LL |         //~^ ERROR `line` does not live long enough
 LL |         println!("accumulator before add_assign {:?}", acc.map);
-   |                                                        ------- borrow later used here
+   |                                                        ------- borrow used here in later iteration of loop
 ...
 LL |     }
    |     - `line` dropped here while still borrowed

--- a/src/test/ui/issue-52213.nll.stderr
+++ b/src/test/ui/issue-52213.nll.stderr
@@ -7,6 +7,11 @@ LL |     match (&t,) { //~ ERROR cannot infer an appropriate lifetime
 error: unsatisfied lifetime constraints
   --> $DIR/issue-52213.rs:13:11
    |
+LL | fn transmute_lifetime<'a, 'b, T>(t: &'a (T,)) -> &'b T {
+   |                       --  -- lifetime `'b` defined here
+   |                       |
+   |                       lifetime `'a` defined here
+LL |     match (&t,) { //~ ERROR cannot infer an appropriate lifetime
 LL |         ((u,),) => u,
    |           ^ requires that `'a` must outlive `'b`
 

--- a/src/test/ui/nll/closure-requirements/region-lbr-named-does-not-outlive-static.stderr
+++ b/src/test/ui/nll/closure-requirements/region-lbr-named-does-not-outlive-static.stderr
@@ -7,6 +7,8 @@ LL |     &*x
 error: unsatisfied lifetime constraints
   --> $DIR/region-lbr-named-does-not-outlive-static.rs:19:5
    |
+LL | fn foo<'a>(x: &'a u32) -> &'static u32 {
+   |        -- lifetime `'a` defined here
 LL |     &*x
    |     ^^^ requires that `'a` must outlive `'static`
 

--- a/src/test/ui/nll/mir_check_cast_closure.stderr
+++ b/src/test/ui/nll/mir_check_cast_closure.stderr
@@ -7,6 +7,10 @@ LL |     g
 error: unsatisfied lifetime constraints
   --> $DIR/mir_check_cast_closure.rs:16:28
    |
+LL | fn bar<'a, 'b>() -> fn(&'a u32, &'b u32) -> &'a u32 {
+   |        --  -- lifetime `'b` defined here
+   |        |
+   |        lifetime `'a` defined here
 LL |     let g: fn(_, _) -> _ = |_x, y| y;
    |                            ^^^^^^^^^ cast requires that `'b` must outlive `'a`
 

--- a/src/test/ui/nll/mir_check_cast_unsize.stderr
+++ b/src/test/ui/nll/mir_check_cast_unsize.stderr
@@ -8,7 +8,9 @@ error: unsatisfied lifetime constraints
   --> $DIR/mir_check_cast_unsize.rs:17:46
    |
 LL |   fn bar<'a>(x: &'a u32) -> &'static dyn Debug {
-   |  ______________________________________________^
+   |  ________--____________________________________^
+   | |        |
+   | |        lifetime `'a` defined here
 LL | |     //~^ ERROR unsatisfied lifetime constraints
 LL | |     x
 LL | |     //~^ WARNING not reporting region error due to nll

--- a/src/test/ui/nll/ty-outlives/projection-one-region-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-one-region-closure.stderr
@@ -52,6 +52,11 @@ LL | | }
 error: unsatisfied lifetime constraints
   --> $DIR/projection-one-region-closure.rs:55:5
    |
+LL | fn no_relationships_late<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
+   |                          --  -- lifetime `'b` defined here
+   |                          |
+   |                          lifetime `'a` defined here
+...
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'b` must outlive `'a`
 
@@ -101,6 +106,11 @@ LL | | }
 error: unsatisfied lifetime constraints
   --> $DIR/projection-one-region-closure.rs:67:5
    |
+LL | fn no_relationships_early<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
+   |                           --  -- lifetime `'b` defined here
+   |                           |
+   |                           lifetime `'a` defined here
+...
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'b` must outlive `'a`
 
@@ -150,6 +160,11 @@ LL | | }
 error: unsatisfied lifetime constraints
   --> $DIR/projection-one-region-closure.rs:89:5
    |
+LL | fn projection_outlives<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
+   |                        --  -- lifetime `'b` defined here
+   |                        |
+   |                        lifetime `'a` defined here
+...
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'b` must outlive `'a`
 

--- a/src/test/ui/nll/ty-outlives/projection-one-region-trait-bound-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-one-region-trait-bound-closure.stderr
@@ -51,6 +51,11 @@ LL | | }
 error: unsatisfied lifetime constraints
   --> $DIR/projection-one-region-trait-bound-closure.rs:47:5
    |
+LL | fn no_relationships_late<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
+   |                          --  -- lifetime `'b` defined here
+   |                          |
+   |                          lifetime `'a` defined here
+...
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'b` must outlive `'a`
 
@@ -91,6 +96,11 @@ LL | | }
 error: unsatisfied lifetime constraints
   --> $DIR/projection-one-region-trait-bound-closure.rs:58:5
    |
+LL | fn no_relationships_early<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
+   |                           --  -- lifetime `'b` defined here
+   |                           |
+   |                           lifetime `'a` defined here
+...
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'b` must outlive `'a`
 
@@ -131,6 +141,11 @@ LL | | }
 error: unsatisfied lifetime constraints
   --> $DIR/projection-one-region-trait-bound-closure.rs:79:5
    |
+LL | fn projection_outlives<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
+   |                        --  -- lifetime `'b` defined here
+   |                        |
+   |                        lifetime `'a` defined here
+...
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'b` must outlive `'a`
 

--- a/src/test/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.stderr
@@ -259,6 +259,11 @@ LL | | }
 error: unsatisfied lifetime constraints
   --> $DIR/projection-two-region-trait-bound-closure.rs:108:5
    |
+LL | fn two_regions<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
+   |                --  -- lifetime `'b` defined here
+   |                |
+   |                lifetime `'a` defined here
+...
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'b` must outlive `'a`
 

--- a/src/test/ui/rfc-2005-default-binding-mode/borrowck-issue-49631.nll.stderr
+++ b/src/test/ui/rfc-2005-default-binding-mode/borrowck-issue-49631.nll.stderr
@@ -7,7 +7,7 @@ LL |         foo.mutate();
    |         ^^^^^^^^^^^^ mutable borrow occurs here
 LL |         //~^ ERROR cannot borrow `foo` as mutable
 LL |         println!("foo={:?}", *string);
-   |                              ------- borrow later used here
+   |                              ------- borrow used here in later iteration of loop
 
 error: aborting due to previous error
 

--- a/src/test/ui/span/dropck-object-cycle.nll.stderr
+++ b/src/test/ui/span/dropck-object-cycle.nll.stderr
@@ -9,8 +9,6 @@ LL | }
    | |
    | `*m` dropped here while still borrowed
    | borrow later used here, when `m` is dropped
-   |
-   = note: values in a scope are dropped in the opposite order they are defined
 
 error: aborting due to previous error
 

--- a/src/test/ui/span/regions-escape-loop-via-variable.nll.stderr
+++ b/src/test/ui/span/regions-escape-loop-via-variable.nll.stderr
@@ -2,7 +2,7 @@ error[E0597]: `x` does not live long enough
   --> $DIR/regions-escape-loop-via-variable.rs:21:13
    |
 LL |         let x = 1 + *p;
-   |                     -- borrow later used here
+   |                     -- borrow used here in later iteration of loop
 LL |         p = &x;
    |             ^^ borrowed value does not live long enough
 LL |     }

--- a/src/test/ui/span/regions-escape-loop-via-vec.nll.stderr
+++ b/src/test/ui/span/regions-escape-loop-via-vec.nll.stderr
@@ -7,7 +7,7 @@ LL |     while x < 10 { //~ ERROR cannot use `x` because it was mutably borrowed
    |           ^ use of borrowed `x`
 LL |         let mut z = x; //~ ERROR cannot use `x` because it was mutably borrowed
 LL |         _y.push(&mut z);
-   |         -- borrow later used here
+   |         -- borrow used here in later iteration of loop
 
 error[E0503]: cannot use `x` because it was mutably borrowed
   --> $DIR/regions-escape-loop-via-vec.rs:16:21
@@ -18,7 +18,7 @@ LL |     while x < 10 { //~ ERROR cannot use `x` because it was mutably borrowed
 LL |         let mut z = x; //~ ERROR cannot use `x` because it was mutably borrowed
    |                     ^ use of borrowed `x`
 LL |         _y.push(&mut z);
-   |         -- borrow later used here
+   |         -- borrow used here in later iteration of loop
 
 error[E0597]: `z` does not live long enough
   --> $DIR/regions-escape-loop-via-vec.rs:17:17
@@ -26,7 +26,7 @@ error[E0597]: `z` does not live long enough
 LL |         _y.push(&mut z);
    |         --      ^^^^^^ borrowed value does not live long enough
    |         |
-   |         borrow later used here
+   |         borrow used here in later iteration of loop
 ...
 LL |     }
    |     - `z` dropped here while still borrowed
@@ -38,7 +38,7 @@ LL |     let mut _y = vec![&mut x];
    |                       ------ borrow of `x` occurs here
 ...
 LL |         _y.push(&mut z);
-   |         -- borrow later used here
+   |         -- borrow used here in later iteration of loop
 LL |         //~^ ERROR `z` does not live long enough
 LL |         x += 1; //~ ERROR cannot assign
    |         ^^^^^^ use of borrowed `x`

--- a/src/tools/tidy/src/lib.rs
+++ b/src/tools/tidy/src/lib.rs
@@ -56,8 +56,10 @@ pub mod libcoretest;
 
 fn filter_dirs(path: &Path) -> bool {
     let skip = [
+        "src/clang",
         "src/dlmalloc",
         "src/jemalloc",
+        "src/lldb",
         "src/llvm",
         "src/llvm-emscripten",
         "src/libbacktrace",


### PR DESCRIPTION
Successful merges:

 - #52716 (Add lldb to the build)
 - #52782 ([NLL] Dangly paths for box)
 - #52886 (cleanup: Remove `Def::GlobalAsm`)
 - #52887 (Disable debug sections when optimization flags is set for LLD.)
 - #52910 (Calculate capacity when collecting into Option and Result)
 - #52925 (check_const: use the same ParamEnv as codegen for statics)
 - #52927 (Crate store cleanup)
 - #52940 (Align 6-week cycle check with beta promotion instead of stable release.)
 - #52948 (NLL: Better Diagnostic When "Later" means "A Future Loop Iteration")
 - #52952 (Update LLVM submodule)
 - #52969 (rustbuild: fix local_rebuild)
 - #52973 (NLL mentions lifetimes that are not included in printed span(s).)

Failed merges:


r? @ghost