### PR TITLE
Fix ICE when rustdoc encounters certain usages of HRTBs

### DIFF
--- a/src/librustc/traits/auto_trait.rs
+++ b/src/librustc/traits/auto_trait.rs
@@ -358,7 +358,8 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
                 &Err(SelectionError::Unimplemented) => {
                     if self.is_of_param(pred.skip_binder().trait_ref.substs) {
                         already_visited.remove(&pred);
-                        self.add_user_pred(&mut user_computed_preds, ty::Predicate::Trait(pred.clone()));
+                        self.add_user_pred(&mut user_computed_preds,
+                                           ty::Predicate::Trait(pred.clone()));
                         predicates.push_back(pred);
                     } else {
                         debug!(
@@ -416,7 +417,8 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
     // under which a type implements an auto trait. A trait predicate involving
     // a HRTB means that the type needs to work with any choice of lifetime,
     // not just one specific lifetime (e.g. 'static).
-    fn add_user_pred<'c>(&self, user_computed_preds: &mut FxHashSet<ty::Predicate<'c>>, new_pred: ty::Predicate<'c>) {
+    fn add_user_pred<'c>(&self, user_computed_preds: &mut FxHashSet<ty::Predicate<'c>>,
+                         new_pred: ty::Predicate<'c>) {
         let mut should_add_new = true;
         user_computed_preds.retain(|&old_pred| {
             match (&new_pred, old_pred) {
@@ -430,11 +432,17 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
                             return true
                         }
 
-                        for (new_region, old_region) in new_substs.regions().zip(old_substs.regions()) {
+                        for (new_region, old_region) in new_substs
+                            .regions()
+                            .zip(old_substs.regions()) {
+
                             match (new_region, old_region) {
                                 // If both predicates have an 'ReLateBound' (a HRTB) in the
                                 // same spot, we do nothing
-                                (ty::RegionKind::ReLateBound(_, _), ty::RegionKind::ReLateBound(_, _)) => {},
+                                (
+                                    ty::RegionKind::ReLateBound(_, _),
+                                    ty::RegionKind::ReLateBound(_, _)
+                                ) => {},
 
                                 (ty::RegionKind::ReLateBound(_, _), _) => {
                                     // The new predicate has a HRTB in a spot where the old

--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -642,8 +642,8 @@ impl<'a, 'tcx, 'rcx> AutoTraitFinder<'a, 'tcx, 'rcx> {
                                 name: name.to_string(),
                                 kind: GenericParamDefKind::Lifetime,
                             })
-                        }
-                        &ty::ReVar(_) | &ty::ReEarlyBound(_) => None,
+                        },
+                        &ty::ReVar(_) | &ty::ReEarlyBound(_) | &ty::ReStatic => None,
                         _ => panic!("Unexpected region type {:?}", r),
                     }
                 })

--- a/src/test/rustdoc/issue-51236.rs
+++ b/src/test/rustdoc/issue-51236.rs
@@ -1,0 +1,24 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::marker::PhantomData;
+
+pub mod traits {
+    pub trait Owned<'a> {
+        type Reader;
+    }
+}
+
+// @has issue_51236/struct.Owned.html
+// @has - '//*[@id="synthetic-implementations-list"]/*[@class="impl"]//*/code' "impl<T> Send for \
+// Owned<T> where <T as Owned<'static>>::Reader: Send"
+pub struct Owned<T> where T: for<'a> ::traits::Owned<'a> {
+    marker: PhantomData<<T as ::traits::Owned<'static>>::Reader>,
+}

--- a/src/test/rustdoc/synthetic_auto/static-region.rs
+++ b/src/test/rustdoc/synthetic_auto/static-region.rs
@@ -1,0 +1,20 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub trait OwnedTrait<'a> {
+    type Reader;
+}
+
+// @has static_region/struct.Owned.html
+// @has - '//*[@id="synthetic-implementations-list"]/*[@class="impl"]//*/code' "impl<T> Send for \
+// Owned<T> where <T as OwnedTrait<'static>>::Reader: Send"
+pub struct Owned<T> where T: OwnedTrait<'static> {
+    marker: <T as OwnedTrait<'static>>::Reader,
+}


### PR DESCRIPTION
Fixes #51236

Under certain circumstances, `AutoTraitFinder` could end up computing a `ParamEnv` involving two trait predicates that differed only in the region parameters involved. One of these parameters would be a HRTB, while the other would be a normal region parameter.

When this `ParamEnv` was later passed to `SelectionContext`, an `Ambiguity` error would occur, since the erased versions of these predicates would be identical. To solve the issue, we de-duplicate our list of predicates as we build it up. Whenever we encounter two predicates that differ only in their assignment of region parameters (a HRTB vs a normal lifetime parameter), we pick the HRTB. This corresponds to selecting a 'stricter' bound to display in the generated documentation: we're requiring that a particular type works for all possible lifetime parameters if it's going to implement a particular auto trait.