### PR TITLE
rustc: Tweak visibility of some lang items 

### DIFF
--- a/src/librustc_allocator/expand.rs
+++ b/src/librustc_allocator/expand.rs
@@ -13,7 +13,7 @@ use rustc_errors;
 use syntax::{
     ast::{
         self, Arg, Attribute, Crate, Expr, FnHeader, Generics, Ident, Item, ItemKind,
-        LitKind, Mac, Mod, Mutability, StrStyle, Ty, TyKind, Unsafety, VisibilityKind,
+        Mac, Mod, Mutability, Ty, TyKind, Unsafety, VisibilityKind,
     },
     attr,
     codemap::{
@@ -236,17 +236,12 @@ impl<'a> AllocFnFactory<'a> {
     }
 
     fn attrs(&self) -> Vec<Attribute> {
-        let key = Symbol::intern("linkage");
-        let value = LitKind::Str(Symbol::intern("external"), StrStyle::Cooked);
-        let linkage = self.cx.meta_name_value(self.span, key, value);
-
         let no_mangle = Symbol::intern("no_mangle");
         let no_mangle = self.cx.meta_word(self.span, no_mangle);
 
         let special = Symbol::intern("rustc_std_internal_symbol");
         let special = self.cx.meta_word(self.span, special);
         vec![
-            self.cx.attribute(self.span, linkage),
             self.cx.attribute(self.span, no_mangle),
             self.cx.attribute(self.span, special),
         ]

--- a/src/librustc_codegen_llvm/allocator.rs
+++ b/src/librustc_codegen_llvm/allocator.rs
@@ -67,14 +67,15 @@ pub(crate) unsafe fn codegen(tcx: TyCtxt, mods: &ModuleLlvm, kind: AllocatorKind
         if tcx.sess.target.target.options.default_hidden_visibility {
             llvm::LLVMRustSetVisibility(llfn, llvm::Visibility::Hidden);
         }
-       if tcx.sess.target.target.options.requires_uwtable {
-           attributes::emit_uwtable(llfn, true);
-       }
+        if tcx.sess.target.target.options.requires_uwtable {
+            attributes::emit_uwtable(llfn, true);
+        }
 
         let callee = CString::new(kind.fn_name(method.name)).unwrap();
         let callee = llvm::LLVMRustGetOrInsertFunction(llmod,
                                                        callee.as_ptr(),
                                                        ty);
+        llvm::LLVMRustSetVisibility(callee, llvm::Visibility::Hidden);
 
         let llbb = llvm::LLVMAppendBasicBlockInContext(llcx,
                                                        llfn,

--- a/src/test/run-make/wasm-symbols-not-exported/Makefile
+++ b/src/test/run-make/wasm-symbols-not-exported/Makefile
@@ -1,0 +1,16 @@
+-include ../../run-make-fulldeps/tools.mk
+
+ifeq ($(TARGET),wasm32-unknown-unknown)
+all:
+	$(RUSTC) foo.rs --target wasm32-unknown-unknown
+	$(NODE) verify-exported-symbols.js $(TMPDIR)/foo.wasm
+	$(RUSTC) foo.rs --target wasm32-unknown-unknown -O
+	$(NODE) verify-exported-symbols.js $(TMPDIR)/foo.wasm
+	$(RUSTC) bar.rs --target wasm32-unknown-unknown
+	$(NODE) verify-exported-symbols.js $(TMPDIR)/bar.wasm
+	$(RUSTC) bar.rs --target wasm32-unknown-unknown -O
+	$(NODE) verify-exported-symbols.js $(TMPDIR)/bar.wasm
+else
+all:
+endif
+

--- a/src/test/run-make/wasm-symbols-not-exported/bar.rs
+++ b/src/test/run-make/wasm-symbols-not-exported/bar.rs
@@ -1,0 +1,45 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(panic_implementation, alloc_error_handler)]
+#![crate_type = "cdylib"]
+#![no_std]
+
+use core::alloc::*;
+
+struct B;
+
+unsafe impl GlobalAlloc for B {
+    unsafe fn alloc(&self, x: Layout) -> *mut u8 {
+        1 as *mut u8
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, x: Layout) {
+    }
+}
+
+#[global_allocator]
+static A: B = B;
+
+#[no_mangle]
+pub extern fn foo(a: u32) -> u32 {
+    assert_eq!(a, 3);
+    a * 2
+}
+
+#[alloc_error_handler]
+fn a(_: core::alloc::Layout) -> ! {
+    loop {}
+}
+
+#[panic_implementation]
+fn b(_: &core::panic::PanicInfo) -> ! {
+    loop {}
+}

--- a/src/test/run-make/wasm-symbols-not-exported/foo.rs
+++ b/src/test/run-make/wasm-symbols-not-exported/foo.rs
@@ -1,0 +1,17 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type = "cdylib"]
+
+#[no_mangle]
+pub extern fn foo() {
+    println!("foo");
+    panic!("test");
+}

--- a/src/test/run-make/wasm-symbols-not-exported/verify-exported-symbols.js
+++ b/src/test/run-make/wasm-symbols-not-exported/verify-exported-symbols.js
@@ -1,0 +1,31 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+const fs = require('fs');
+const process = require('process');
+const assert = require('assert');
+const buffer = fs.readFileSync(process.argv[2]);
+
+let m = new WebAssembly.Module(buffer);
+let list = WebAssembly.Module.exports(m);
+console.log('exports', list);
+
+let bad = false;
+for (let i = 0; i < list.length; i++) {
+  const e = list[i];
+  if (e.name == "foo" || e.kind != "function")
+    continue;
+
+  console.log('unexpected exported symbol:', e.name);
+  bad = true;
+}
+
+if (bad)
+  process.exit(1);


### PR DESCRIPTION
This commit tweaks the linker-level visibility of some lang items that rustc
uses and defines. Notably this means that `#[panic_implementation]` and
`#[alloc_error_handler]` functions are never marked as `internal`. It's up to
the linker to eliminate these, not rustc.

Additionally `#[global_allocator]` generated symbols are no longer forced to
`Default` visibility (fully exported), but rather they're relaxed to `Hidden`
visibility). This symbols are *not* needed across DLL boundaries, only as a
local implementation detail of the compiler-injected allocator symbols, so
`Hidden` should suffice.

Closes #51342
Closes #52795