### PR TITLE
Remove unnecessary local in await! generator

### DIFF
--- a/src/libstd/future.rs
+++ b/src/libstd/future.rs
@@ -108,9 +108,9 @@ where
 
 #[unstable(feature = "gen_future", issue = "50547")]
 /// Polls a future in the current thread-local task context.
-pub fn poll_in_task_cx<F>(f: &mut PinMut<F>) -> Poll<F::Output>
+pub fn poll_in_task_cx<F>(f: PinMut<F>) -> Poll<F::Output>
 where
     F: Future
 {
-    get_task_cx(|cx| f.reborrow().poll(cx))
+    get_task_cx(|cx| f.poll(cx))
 }


### PR DESCRIPTION
This makes `async { await!(future::ready(())) }` 4 bytes instead of 16. [Playground example](http://play.rust-lang.org/?gist=54c075599b9ff390fe505c75d6b98feb&version=nightly&mode=debug&edition=2018)