### PR TITLE
Don't collect() when size_hint is useless

### DIFF
--- a/src/librustc/infer/outlives/obligations.rs
+++ b/src/librustc/infer/outlives/obligations.rs
@@ -151,12 +151,14 @@ impl<'cx, 'gcx, 'tcx> InferCtxt<'cx, 'gcx, 'tcx> {
         debug!("process_registered_region_obligations()");
 
         // pull out the region obligations with the given `body_id` (leaving the rest)
-        let my_region_obligations = {
+        let mut my_region_obligations = Vec::with_capacity(self.region_obligations.borrow().len());
+        {
             let mut r_o = self.region_obligations.borrow_mut();
-            let my_r_o = r_o.drain_filter(|(ro_body_id, _)| *ro_body_id == body_id)
-                            .map(|(_, obligation)| obligation).collect::<Vec<_>>();
-            my_r_o
-        };
+            my_region_obligations.extend(
+                r_o.drain_filter(|(ro_body_id, _)| *ro_body_id == body_id)
+                   .map(|(_, obligation)| obligation)
+            );
+        }
 
         let outlives = &mut TypeOutlives::new(
             self,

--- a/src/librustc_data_structures/small_vec.rs
+++ b/src/librustc_data_structures/small_vec.rs
@@ -210,7 +210,12 @@ impl<A> Decodable for SmallVec<A>
           A::Element: Decodable {
     fn decode<D: Decoder>(d: &mut D) -> Result<SmallVec<A>, D::Error> {
         d.read_seq(|d, len| {
-            (0..len).map(|i| d.read_seq_elt(i, |d| Decodable::decode(d))).collect()
+            let mut vec = SmallVec::with_capacity(len);
+            // FIXME(#48994) - could just be collected into a Result<SmallVec, D::Error>
+            for i in 0..len {
+                vec.push(d.read_seq_elt(i, |d| Decodable::decode(d))?);
+            }
+            Ok(vec)
         })
     }
 }

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -501,7 +501,11 @@ impl Pat {
             PatKind::Slice(pats, None, _) if pats.len() == 1 =>
                 pats[0].to_ty().map(TyKind::Slice)?,
             PatKind::Tuple(pats, None) => {
-                let tys = pats.iter().map(|pat| pat.to_ty()).collect::<Option<Vec<_>>>()?;
+                let mut tys = Vec::with_capacity(pats.len());
+                // FIXME(#48994) - could just be collected into an Option<Vec>
+                for pat in pats {
+                    tys.push(pat.to_ty()?);
+                }
                 TyKind::Tup(tys)
             }
             _ => return None,


### PR DESCRIPTION
This adjusts PRs #52738 and #52697 by falling back to calculating capacity and extending or pushing in a loop where `collect()` can't be trusted to calculate the right capacity.

It is a performance win.