### PR TITLE
Specify reentrancy gurantees of `Once::call_once`

### DIFF
--- a/src/libstd/sync/once.rs
+++ b/src/libstd/sync/once.rs
@@ -178,7 +178,7 @@ impl Once {
     /// happens-before relation between the closure and code executing after the
     /// return).
     ///
-    /// If the given closure recusively invokes `call_once` on the same `Once` 
+    /// If the given closure recusively invokes `call_once` on the same `Once`
     /// instance the exact behavior is not specified, allowed outcomes are
     /// a panic or a deadlock.
     ///

--- a/src/libstd/sync/once.rs
+++ b/src/libstd/sync/once.rs
@@ -178,6 +178,10 @@ impl Once {
     /// happens-before relation between the closure and code executing after the
     /// return).
     ///
+    /// If the given closure recusively invokes `call_once` on the same `Once` 
+    /// instance the exact behavior is not specified, allowed outcomes are
+    /// a panic or a deadlock.
+    ///
     /// # Examples
     ///
     /// ```


### PR DESCRIPTION
I don't think the docs are clear about what happens in the following code

```rust
static INIT: Once = ONCE_INIT;

INIT.call_once(|| INIT.call_once(|| println!("huh?")));
```

[Playground](https://play.rust-lang.org/?gist=15dde1f68a6ede263c7250c36977eade&version=stable&mode=debug&edition=2015)

Let's "specify" the behavior to make it clear that the current behavior (deadlock I think?) is not a strict guarantee.