### PR TITLE
Building librustc_codegen_llvm in a separate directory

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -2184,30 +2184,10 @@ dependencies = [
 name = "rustc_codegen_llvm"
 version = "0.0.0"
 dependencies = [
- "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "flate2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "jobserver 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc 0.0.0",
  "rustc-demangle 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_allocator 0.0.0",
- "rustc_apfloat 0.0.0",
- "rustc_codegen_utils 0.0.0",
- "rustc_data_structures 0.0.0",
- "rustc_errors 0.0.0",
- "rustc_incremental 0.0.0",
  "rustc_llvm 0.0.0",
- "rustc_mir 0.0.0",
- "rustc_platform_intrinsics 0.0.0",
- "rustc_target 0.0.0",
- "serialize 0.0.0",
- "syntax 0.0.0",
- "syntax_pos 0.0.0",
- "tempfile 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -137,8 +137,10 @@ impl Step for CodegenBackend {
         let target = self.target;
         let backend = self.backend;
 
+        let out_dir = builder.cargo_out(compiler, Mode::Codegen, target);
+        builder.clear_if_dirty(&out_dir, &librustc_stamp(builder, compiler, target));
+
         let mut cargo = builder.cargo(compiler, Mode::Codegen, target, "check");
-        let features = builder.rustc_features().to_string();
         cargo.arg("--manifest-path").arg(builder.src.join("src/librustc_codegen_llvm/Cargo.toml"));
         rustc_cargo_env(builder, &mut cargo);
 
@@ -146,7 +148,7 @@ impl Step for CodegenBackend {
 
         let _folder = builder.fold_output(|| format!("stage{}-rustc_codegen_llvm", compiler.stage));
         run_cargo(builder,
-                  cargo.arg("--features").arg(features),
+                  &mut cargo,
                   &codegen_backend_stamp(builder, compiler, target, backend),
                   true);
     }

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -670,16 +670,17 @@ impl Step for CodegenBackend {
             return;
         }
 
+        let out_dir = builder.cargo_out(compiler, Mode::Codegen, target);
+        builder.clear_if_dirty(&out_dir, &librustc_stamp(builder, compiler, target));
+
         let mut cargo = builder.cargo(compiler, Mode::Codegen, target, "build");
-        let mut features = builder.rustc_features().to_string();
         cargo.arg("--manifest-path")
             .arg(builder.src.join("src/librustc_codegen_llvm/Cargo.toml"));
         rustc_cargo_env(builder, &mut cargo);
 
-        features += &build_codegen_backend(&builder, &mut cargo, &compiler, target, backend);
+        let features = build_codegen_backend(&builder, &mut cargo, &compiler, target, backend);
 
-        let tmp_stamp = builder.cargo_out(compiler, Mode::Codegen, target)
-            .join(".tmp.stamp");
+        let tmp_stamp = out_dir.join(".tmp.stamp");
 
         let _folder = builder.fold_output(|| format!("stage{}-rustc_codegen_llvm", compiler.stage));
         let files = run_cargo(builder,

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -555,8 +555,8 @@ impl Build {
         let suffix = match mode {
             Mode::Std => "-std",
             Mode::Test => "-test",
-            Mode::Codegen => "-rustc",
             Mode::Rustc => "-rustc",
+            Mode::Codegen => "-codegen",
             Mode::ToolBootstrap => "-bootstrap-tools",
             Mode::ToolStd => "-tools",
             Mode::ToolRustc => "-tools",

--- a/src/librustc_codegen_llvm/Cargo.toml
+++ b/src/librustc_codegen_llvm/Cargo.toml
@@ -10,39 +10,12 @@ crate-type = ["dylib"]
 test = false
 
 [dependencies]
-bitflags = "1.0.1"
 cc = "1.0.1"
-flate2 = "1.0"
-jobserver = "0.1.5"
-libc = "0.2"
-log = "0.4"
 num_cpus = "1.0"
-rustc = { path = "../librustc" }
 rustc-demangle = "0.1.4"
-rustc_allocator = { path = "../librustc_allocator" }
-rustc_apfloat = { path = "../librustc_apfloat" }
-rustc_target = { path = "../librustc_target" }
-rustc_data_structures = { path = "../librustc_data_structures" }
-rustc_errors = { path = "../librustc_errors" }
-rustc_incremental = { path = "../librustc_incremental" }
 rustc_llvm = { path = "../librustc_llvm" }
-rustc_platform_intrinsics = { path = "../librustc_platform_intrinsics" }
-rustc_codegen_utils = { path = "../librustc_codegen_utils" }
-rustc_mir = { path = "../librustc_mir" }
-serialize = { path = "../libserialize" }
-syntax = { path = "../libsyntax" }
-syntax_pos = { path = "../libsyntax_pos" }
-tempfile = "3.0"
-
-# not actually used but needed to make sure we enable the same feature set as
-# winapi used in librustc
-env_logger = { version = "0.5", default-features = false }
 
 [features]
-# Used to communicate the feature to `rustc_target` in the same manner that the
-# `rustc` driver script communicate this.
-jemalloc = ["rustc_target/jemalloc"]
-
 # This is used to convince Cargo to separately cache builds of `rustc_codegen_llvm`
 # when this option is enabled or not. That way we can build two, cache two
 # artifacts, and have nice speedy rebuilds.


### PR DESCRIPTION
This allows clearing it out and building it separately from the
compiler. Since it's essentially a different and separate crate this
makes sense to do, each cargo invocation should generally happen in its
own directory.

r? @alexcrichton 