### PR TITLE
Apply some fixes to cross-language LTO (especially when targeting MSVC)

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -2006,13 +2006,6 @@ pub fn build_session_options_and_crate_config(
         (&None, &None) => None,
     }.map(|m| PathBuf::from(m));
 
-    if cg.lto != Lto::No && incremental.is_some() {
-        early_error(
-            error_format,
-            "can't perform LTO when compiling incrementally",
-        );
-    }
-
     if debugging_opts.profile && incremental.is_some() {
         early_error(
             error_format,

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -831,7 +831,7 @@ macro_rules! options {
         pub const parse_lto: Option<&'static str> =
             Some("one of `thin`, `fat`, or omitted");
         pub const parse_cross_lang_lto: Option<&'static str> =
-            Some("either a boolean (`yes`, `no`, `on`, `off`, etc), `no-link`, \
+            Some("either a boolean (`yes`, `no`, `on`, `off`, etc), \
                   or the path to the linker plugin");
     }
 

--- a/src/librustc_codegen_llvm/back/link.rs
+++ b/src/librustc_codegen_llvm/back/link.rs
@@ -563,7 +563,7 @@ fn link_staticlib(sess: &Session,
         });
         ab.add_rlib(path,
                     &name.as_str(),
-                    is_full_lto_enabled(sess) &&
+                    are_upstream_rust_objects_already_included(sess) &&
                         !ignored_for_lto(sess, &codegen_results.crate_info, cnum),
                     skip_object_files).unwrap();
 
@@ -1446,7 +1446,7 @@ fn add_upstream_rust_crates(cmd: &mut dyn Linker,
             lib.kind == NativeLibraryKind::NativeStatic && !relevant_lib(sess, lib)
         });
 
-        if (!is_full_lto_enabled(sess) ||
+        if (!are_upstream_rust_objects_already_included(sess) ||
             ignored_for_lto(sess, &codegen_results.crate_info, cnum)) &&
            crate_type != config::CrateType::Dylib &&
            !skip_native {
@@ -1500,7 +1500,7 @@ fn add_upstream_rust_crates(cmd: &mut dyn Linker,
                 // file, then we don't need the object file as it's part of the
                 // LTO module. Note that `#![no_builtins]` is excluded from LTO,
                 // though, so we let that object file slide.
-                let skip_because_lto = is_full_lto_enabled(sess) &&
+                let skip_because_lto = are_upstream_rust_objects_already_included(sess) &&
                     is_rust_object &&
                     (sess.target.target.options.no_builtins ||
                      !codegen_results.crate_info.is_no_builtins.contains(&cnum));
@@ -1537,7 +1537,7 @@ fn add_upstream_rust_crates(cmd: &mut dyn Linker,
     fn add_dynamic_crate(cmd: &mut dyn Linker, sess: &Session, cratepath: &Path) {
         // If we're performing LTO, then it should have been previously required
         // that all upstream rust dependencies were available in an rlib format.
-        assert!(!is_full_lto_enabled(sess));
+        assert!(!are_upstream_rust_objects_already_included(sess));
 
         // Just need to tell the linker about where the library lives and
         // what its name is
@@ -1623,7 +1623,7 @@ fn relevant_lib(sess: &Session, lib: &NativeLibrary) -> bool {
     }
 }
 
-fn is_full_lto_enabled(sess: &Session) -> bool {
+fn are_upstream_rust_objects_already_included(sess: &Session) -> bool {
     match sess.lto() {
         Lto::Yes |
         Lto::Fat => true,

--- a/src/librustc_codegen_llvm/back/link.rs
+++ b/src/librustc_codegen_llvm/back/link.rs
@@ -1626,8 +1626,12 @@ fn relevant_lib(sess: &Session, lib: &NativeLibrary) -> bool {
 fn is_full_lto_enabled(sess: &Session) -> bool {
     match sess.lto() {
         Lto::Yes |
-        Lto::Thin |
         Lto::Fat => true,
+        Lto::Thin => {
+            // If we defer LTO to the linker, we haven't run LTO ourselves, so
+            // any upstream object files have not been copied yet.
+            !sess.opts.debugging_opts.cross_lang_lto.enabled()
+        }
         Lto::No |
         Lto::ThinLocal => false,
     }

--- a/src/librustc_codegen_llvm/back/lto.rs
+++ b/src/librustc_codegen_llvm/back/lto.rs
@@ -195,6 +195,10 @@ pub(crate) fn run(cgcx: &CodegenContext,
         }
         Lto::Thin |
         Lto::ThinLocal => {
+            if cgcx.opts.debugging_opts.cross_lang_lto.enabled() {
+                unreachable!("We should never reach this case if the LTO step \
+                              is deferred to the linker");
+            }
             thin_lto(&diag_handler, modules, upstream_modules, &arr, timeline)
         }
         Lto::No => unreachable!(),

--- a/src/librustc_codegen_llvm/back/write.rs
+++ b/src/librustc_codegen_llvm/back/write.rs
@@ -2385,7 +2385,7 @@ fn msvc_imps_needed(tcx: TyCtxt) -> bool {
               tcx.sess.opts.cg.prefer_dynamic));
 
     tcx.sess.target.target.options.is_like_msvc &&
-        tcx.sess.crate_types.borrow().iter().any(|ct| *ct == config::CrateTypeRlib) &&
+        tcx.sess.crate_types.borrow().iter().any(|ct| *ct == config::CrateType::Rlib) &&
     // ThinLTO can't handle this workaround in all cases, so we don't
     // emit the `__imp_` symbols. Instead we make them unnecessary by disallowing
     // dynamic linking when cross-language LTO is enabled.

--- a/src/librustc_codegen_llvm/back/write.rs
+++ b/src/librustc_codegen_llvm/back/write.rs
@@ -552,7 +552,8 @@ unsafe fn optimize(cgcx: &CodegenContext,
                 llvm::LLVMRustAddAnalysisPasses(tm, fpm, llmod);
                 llvm::LLVMRustAddAnalysisPasses(tm, mpm, llmod);
                 let opt_level = config.opt_level.unwrap_or(llvm::CodeGenOptLevel::None);
-                let prepare_for_thin_lto = cgcx.lto == Lto::Thin || cgcx.lto == Lto::ThinLocal;
+                let prepare_for_thin_lto = cgcx.lto == Lto::Thin || cgcx.lto == Lto::ThinLocal ||
+                    (cgcx.lto != Lto::Fat && cgcx.opts.debugging_opts.cross_lang_lto.enabled());
                 have_name_anon_globals_pass = have_name_anon_globals_pass || prepare_for_thin_lto;
                 if using_thin_buffers && !prepare_for_thin_lto {
                     assert!(addpass("name-anon-globals"));

--- a/src/librustc_codegen_llvm/back/write.rs
+++ b/src/librustc_codegen_llvm/back/write.rs
@@ -1351,6 +1351,8 @@ fn execute_work_item(cgcx: &CodegenContext,
         unsafe {
             optimize(cgcx, &diag_handler, &module, config, timeline)?;
 
+            let linker_does_lto = cgcx.opts.debugging_opts.cross_lang_lto.enabled();
+
             // After we've done the initial round of optimizations we need to
             // decide whether to synchronously codegen this module or ship it
             // back to the coordinator thread for further LTO processing (which
@@ -1360,6 +1362,11 @@ fn execute_work_item(cgcx: &CodegenContext,
             // codegenning...
             let needs_lto = match cgcx.lto {
                 Lto::No => false,
+
+                // If the linker does LTO, we don't have to do it. Note that we
+                // keep doing full LTO, if it is requested, as not to break the
+                // assumption that the output will be a single module.
+                Lto::Thin | Lto::ThinLocal if linker_does_lto => false,
 
                 // Here we've got a full crate graph LTO requested. We ignore
                 // this, however, if the crate type is only an rlib as there's
@@ -1390,11 +1397,6 @@ fn execute_work_item(cgcx: &CodegenContext,
             // Metadata modules never participate in LTO regardless of the lto
             // settings.
             let needs_lto = needs_lto && module.kind != ModuleKind::Metadata;
-
-            // Don't run LTO passes when cross-lang LTO is enabled. The linker
-            // will do that for us in this case.
-            let needs_lto = needs_lto &&
-                !cgcx.opts.debugging_opts.cross_lang_lto.enabled();
 
             if needs_lto {
                 Ok(WorkItemResult::NeedsLTO(module))
@@ -2375,8 +2377,18 @@ pub(crate) fn submit_codegened_module_to_llvm(tcx: TyCtxt,
 }
 
 fn msvc_imps_needed(tcx: TyCtxt) -> bool {
+    // This should never be true (because it's not supported). If it is true,
+    // something is wrong with commandline arg validation.
+    assert!(!(tcx.sess.opts.debugging_opts.cross_lang_lto.enabled() &&
+              tcx.sess.target.target.options.is_like_msvc &&
+              tcx.sess.opts.cg.prefer_dynamic));
+
     tcx.sess.target.target.options.is_like_msvc &&
-        tcx.sess.crate_types.borrow().iter().any(|ct| *ct == config::CrateType::Rlib)
+        tcx.sess.crate_types.borrow().iter().any(|ct| *ct == config::CrateTypeRlib) &&
+    // ThinLTO can't handle this workaround in all cases, so we don't
+    // emit the `__imp_` symbols. Instead we make them unnecessary by disallowing
+    // dynamic linking when cross-language LTO is enabled.
+    !tcx.sess.opts.debugging_opts.cross_lang_lto.enabled()
 }
 
 // Create a `__imp_<symbol> = &symbol` global for every public static `symbol`.

--- a/src/librustc_codegen_llvm/base.rs
+++ b/src/librustc_codegen_llvm/base.rs
@@ -596,6 +596,7 @@ fn maybe_create_entry_wrapper(cx: &CodegenCx) {
 
         // `main` should respect same config for frame pointer elimination as rest of code
         attributes::set_frame_pointer_elimination(cx, llfn);
+        attributes::apply_target_cpu_attr(cx, llfn);
 
         let bx = Builder::new_block(cx, llfn, "top");
 

--- a/src/librustc_codegen_llvm/context.rs
+++ b/src/librustc_codegen_llvm/context.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use attributes;
 use common;
 use llvm;
 use rustc::dep_graph::DepGraphSafe;
@@ -381,6 +382,7 @@ impl<'b, 'tcx> CodegenCx<'b, 'tcx> {
                 declare::declare_cfn(self, name, fty)
             }
         };
+        attributes::apply_target_cpu_attr(self, llfn);
         self.eh_personality.set(Some(llfn));
         llfn
     }
@@ -412,6 +414,7 @@ impl<'b, 'tcx> CodegenCx<'b, 'tcx> {
 
         let llfn = declare::declare_fn(self, "rust_eh_unwind_resume", ty);
         attributes::unwind(llfn, true);
+        attributes::apply_target_cpu_attr(self, llfn);
         unwresume.set(Some(llfn));
         llfn
     }

--- a/src/test/codegen/no-dllimport-w-cross-lang-lto.rs
+++ b/src/test/codegen/no-dllimport-w-cross-lang-lto.rs
@@ -1,0 +1,23 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This test makes sure that functions get annotated with the proper
+// "target-cpu" attribute in LLVM.
+
+// no-prefer-dynamic
+// only-msvc
+// compile-flags: -C no-prepopulate-passes -Z cross-lang-lto
+
+#![crate_type = "rlib"]
+
+// CHECK-NOT: @{{.*}}__imp_{{.*}}GLOBAL{{.*}} = global i8*
+
+pub static GLOBAL: u32 = 0;
+pub static mut GLOBAL2: u32 = 0;

--- a/src/test/codegen/no-dllimport-w-cross-lang-lto.rs
+++ b/src/test/codegen/no-dllimport-w-cross-lang-lto.rs
@@ -13,7 +13,7 @@
 
 // no-prefer-dynamic
 // only-msvc
-// compile-flags: -C no-prepopulate-passes -Z cross-lang-lto
+// compile-flags: -Z cross-lang-lto
 
 #![crate_type = "rlib"]
 

--- a/src/test/codegen/target-cpu-on-functions.rs
+++ b/src/test/codegen/target-cpu-on-functions.rs
@@ -13,7 +13,6 @@
 
 // no-prefer-dynamic
 // ignore-tidy-linelength
-// only-x86_64
 // compile-flags: -C no-prepopulate-passes -C panic=abort -Z cross-lang-lto -Cpasses=name-anon-globals
 
 #![crate_type = "staticlib"]
@@ -27,4 +26,4 @@ pub extern fn exported() {
 // CHECK-LABEL: define {{.*}} @_ZN23target_cpu_on_functions12not_exported{{.*}}() {{.*}} #0
 fn not_exported() {}
 
-// CHECK: attributes #0 = {{.*}} "target-cpu"="x86-64"
+// CHECK: attributes #0 = {{.*}} "target-cpu"="{{.*}}"

--- a/src/test/codegen/target-cpu-on-functions.rs
+++ b/src/test/codegen/target-cpu-on-functions.rs
@@ -1,0 +1,28 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This test makes sure that functions get annotated with the proper
+// "target-cpu" attribute in LLVM.
+
+// only-x86_64
+// compile-flags: -C no-prepopulate-passes -C panic=abort
+
+#![crate_type = "staticlib"]
+
+// CHECK-LABEL: define {{.*}} @exported() {{.*}} #0
+#[no_mangle]
+pub extern fn exported() {
+    not_exported();
+}
+
+// CHECK-LABEL: define {{.*}} @_ZN23target_cpu_on_functions12not_exported{{.*}}() {{.*}} #0
+fn not_exported() {}
+
+// CHECK: attributes #0 = {{.*}} "target-cpu"="x86-64"

--- a/src/test/codegen/target-cpu-on-functions.rs
+++ b/src/test/codegen/target-cpu-on-functions.rs
@@ -11,8 +11,10 @@
 // This test makes sure that functions get annotated with the proper
 // "target-cpu" attribute in LLVM.
 
+// no-prefer-dynamic
+// ignore-tidy-linelength
 // only-x86_64
-// compile-flags: -C no-prepopulate-passes -C panic=abort
+// compile-flags: -C no-prepopulate-passes -C panic=abort -Z cross-lang-lto -Cpasses=name-anon-globals
 
 #![crate_type = "staticlib"]
 

--- a/src/test/run-make-fulldeps/cross-lang-lto-upstream-rlibs/Makefile
+++ b/src/test/run-make-fulldeps/cross-lang-lto-upstream-rlibs/Makefile
@@ -11,7 +11,7 @@ all: staticlib.rs upstream.rs
 	$(RUSTC) staticlib.rs -Z cross-lang-lto -Ccodegen-units=1 -L. -o $(TMPDIR)/staticlib.a
 	(cd $(TMPDIR); llvm-ar x ./staticlib.a)
 	# Make sure the upstream object file was included
-	ls upstream.*.rcgu.o
+	ls $(TMPDIR)/upstream.*.rcgu.o
 
 	# Cleanup
 	rm $(TMPDIR)/*
@@ -20,4 +20,4 @@ all: staticlib.rs upstream.rs
 	$(RUSTC) upstream.rs -Z cross-lang-lto -Ccodegen-units=1 -Clto=thin
 	$(RUSTC) staticlib.rs -Z cross-lang-lto -Ccodegen-units=1 -Clto=thin -L. -o $(TMPDIR)/staticlib.a
 	(cd $(TMPDIR); llvm-ar x ./staticlib.a)
-	ls upstream.*.rcgu.o
+	ls $(TMPDIR)/upstream.*.rcgu.o

--- a/src/test/run-make-fulldeps/cross-lang-lto-upstream-rlibs/Makefile
+++ b/src/test/run-make-fulldeps/cross-lang-lto-upstream-rlibs/Makefile
@@ -1,0 +1,23 @@
+
+-include ../tools.mk
+
+# This test makes sure that we don't loose upstream object files when compiling
+# staticlibs with -Zcross-lang-lto
+
+all: staticlib.rs upstream.rs
+	$(RUSTC) upstream.rs -Z cross-lang-lto -Ccodegen-units=1
+
+	# Check No LTO
+	$(RUSTC) staticlib.rs -Z cross-lang-lto -Ccodegen-units=1 -L. -o $(TMPDIR)/staticlib.a
+	(cd $(TMPDIR); llvm-ar x ./staticlib.a)
+	# Make sure the upstream object file was included
+	ls upstream.*.rcgu.o
+
+	# Cleanup
+	rm $(TMPDIR)/*
+
+	# Check ThinLTO
+	$(RUSTC) upstream.rs -Z cross-lang-lto -Ccodegen-units=1 -Clto=thin
+	$(RUSTC) staticlib.rs -Z cross-lang-lto -Ccodegen-units=1 -Clto=thin -L. -o $(TMPDIR)/staticlib.a
+	(cd $(TMPDIR); llvm-ar x ./staticlib.a)
+	ls upstream.*.rcgu.o

--- a/src/test/run-make-fulldeps/cross-lang-lto-upstream-rlibs/staticlib.rs
+++ b/src/test/run-make-fulldeps/cross-lang-lto-upstream-rlibs/staticlib.rs
@@ -1,0 +1,18 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type="staticlib"]
+
+extern crate upstream;
+
+#[no_mangle]
+pub extern fn bar() {
+    upstream::foo();
+}

--- a/src/test/run-make-fulldeps/cross-lang-lto-upstream-rlibs/upstream.rs
+++ b/src/test/run-make-fulldeps/cross-lang-lto-upstream-rlibs/upstream.rs
@@ -1,0 +1,13 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type = "rlib"]
+
+pub fn foo() {}

--- a/src/test/run-make-fulldeps/cross-lang-lto/Makefile
+++ b/src/test/run-make-fulldeps/cross-lang-lto/Makefile
@@ -1,4 +1,3 @@
-# ignore-msvc
 
 -include ../tools.mk
 


### PR DESCRIPTION
This PR contains a few fixes that were needed in order to get Firefox compiling with Rust/C++ cross-language ThinLTO on Windows. The commits are self-contained and should be self-explanatory. 

r? @alexcrichton 