### PR TITLE
unsized ManuallyDrop

### DIFF
--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -1024,9 +1024,6 @@ impl<T: ?Sized> DerefMut for ManuallyDrop<T> {
     }
 }
 
-#[unstable(feature = "coerce_unsized", issue = "27732")]
-impl<T: CoerceUnsized<U>, U> CoerceUnsized<ManuallyDrop<U>> for ManuallyDrop<T> {}
-
 /// A pinned reference.
 ///
 /// A pinned reference is a lot like a mutable reference, except that it is not

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -956,6 +956,7 @@ pub fn discriminant<T>(v: &T) -> Discriminant<T> {
 #[stable(feature = "manually_drop", since = "1.20.0")]
 #[lang = "manually_drop"]
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
 pub struct ManuallyDrop<T: ?Sized> {
     value: T,
 }

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -956,7 +956,7 @@ pub fn discriminant<T>(v: &T) -> Discriminant<T> {
 #[stable(feature = "manually_drop", since = "1.20.0")]
 #[lang = "manually_drop"]
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct ManuallyDrop<T> {
+pub struct ManuallyDrop<T: ?Sized> {
     value: T,
 }
 
@@ -990,7 +990,9 @@ impl<T> ManuallyDrop<T> {
     pub fn into_inner(slot: ManuallyDrop<T>) -> T {
         slot.value
     }
+}
 
+impl<T: ?Sized> ManuallyDrop<T> {
     /// Manually drops the contained value.
     ///
     /// # Safety
@@ -1006,7 +1008,7 @@ impl<T> ManuallyDrop<T> {
 }
 
 #[stable(feature = "manually_drop", since = "1.20.0")]
-impl<T> Deref for ManuallyDrop<T> {
+impl<T: ?Sized> Deref for ManuallyDrop<T> {
     type Target = T;
     #[inline]
     fn deref(&self) -> &Self::Target {
@@ -1015,12 +1017,15 @@ impl<T> Deref for ManuallyDrop<T> {
 }
 
 #[stable(feature = "manually_drop", since = "1.20.0")]
-impl<T> DerefMut for ManuallyDrop<T> {
+impl<T: ?Sized> DerefMut for ManuallyDrop<T> {
     #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.value
     }
 }
+
+#[unstable(feature = "coerce_unsized", issue = "27732")]
+impl<T: CoerceUnsized<U>, U> CoerceUnsized<ManuallyDrop<U>> for ManuallyDrop<T> {}
 
 /// A pinned reference.
 ///

--- a/src/libcore/tests/manually_drop.rs
+++ b/src/libcore/tests/manually_drop.rs
@@ -21,4 +21,8 @@ fn smoke() {
 
     let x = ManuallyDrop::new(TypeWithDrop);
     drop(x);
+
+    // also test unsizing
+    let x : Box<ManuallyDrop<[TypeWithDrop]>> = Box::new(ManuallyDrop::new([TypeWithDrop]));
+    drop(x);
 }

--- a/src/libcore/tests/manually_drop.rs
+++ b/src/libcore/tests/manually_drop.rs
@@ -23,6 +23,7 @@ fn smoke() {
     drop(x);
 
     // also test unsizing
-    let x : Box<ManuallyDrop<[TypeWithDrop]>> = Box::new(ManuallyDrop::new([TypeWithDrop]));
+    let x : Box<ManuallyDrop<[TypeWithDrop]>> =
+        Box::new(ManuallyDrop::new([TypeWithDrop, TypeWithDrop]));
     drop(x);
 }


### PR DESCRIPTION
I think this matches what @eddyb had in https://github.com/rust-lang/rust/pull/52711 originally.

~~However, I have never added a `CoerceUnsized` before so I am not sure if I did this right. I copied the `unstable` attribute on the `impl` from elsewhere, but AFAIK it is useless because `impl`'s are insta-stable... so shouldn't this rather say "stable since 1.30"?~~

This is insta-stable and hence requires FCP, at least.

Fixes https://github.com/rust-lang/rust/issues/47034