### PR TITLE
Improve unstable message display

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -500,6 +500,19 @@ h4 > code, h3 > code, .invisible > code {
 	font-size: 90%;
 }
 
+.content .stability {
+	position: relative;
+	margin-left: 33px;
+	margin-top: -13px;
+}
+.content .stability::before {
+	content: '˪';
+	font-size: 30px;
+	position: absolute;
+	top: -9px;
+	left: -13px;
+}
+
 nav {
 	border-bottom: 1px solid;
 	padding-bottom: 10px;


### PR DESCRIPTION
Fixes #51387.
Reopening of #51563.

New display:

<img width="1440" alt="screen shot 2018-08-04 at 00 01 39" src="https://user-images.githubusercontent.com/3050060/43667793-dc14f708-9779-11e8-9808-f3ff126fc213.png">

r? @QuietMisdreavus