### PR TITLE
Make entire row of doc search results clickable

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -615,6 +615,11 @@ a {
 .content .search-results td:first-child a {
 	padding-right: 10px;
 }
+.content .search-results td:first-child a:after {
+    clear: both;
+    content: "";
+    display: block;
+}
 .content .search-results td:first-child a span {
 	float: left;
 }


### PR DESCRIPTION
By adding empty `after` content that clears and is `display: block`.
Technique found here: https://stackoverflow.com/a/7817313/51683

Now any part of a documentation search result that is highlighted when
you hover over it should also be clickable.

NOTE: THE BELOW IMAGES ARE GIFS BUT I DIDN'T MAKE THEM LOOP, OPEN IN A NEW TAB TO SEE THEM SORRY SORRY

Here's what happens before this change: my mouse cursor is in the middle of the table cell, and the row is highlighted which makes it look like clicking should have an effect, but clicking doesn't do anything:

![rustdoc-clicky-clicky-before](https://user-images.githubusercontent.com/193874/43668604-d1e63392-974b-11e8-99f5-e7e11c9056e8.gif)

After this change, clicking in the middle of the cell works!

![rustdoc-clicky-clicky-after](https://user-images.githubusercontent.com/193874/43668616-e522fa08-974b-11e8-8409-3826d586d1f7.gif)

It even works nicely when the type is really long and wraps! (I created the type artificially because I couldn't find a long enough one in the wild)

![rustdoc-clicky-clicky-after-long](https://user-images.githubusercontent.com/193874/43668639-f962a75c-974b-11e8-9218-70bf068387a3.gif)
