### PR TITLE
Make left column of rustdoc search results narrower

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -610,7 +610,7 @@ a {
 
 .content .search-results td:first-child {
 	padding-right: 0;
-	width: 75%;
+	width: 50%;
 }
 .content .search-results td:first-child a {
 	padding-right: 10px;


### PR DESCRIPTION
To make more room for the description of the item

The description often has useful text that helps disambiguate between search results, but very little of it is shown.

As a side effect, this breaks the alignment between the search results and the "In Return Types" tab, which tends to line up above the description-- up until I started investigating this, I thought "In Names"/"In Parameters"/"In Return Types" were column headers and I just never saw search results that had info for the "In Parameters" middle column! Now, with the two columns of search results each taking up about a half, they look more like tabs than column headers.

Types that are long still wrap and look good-- I made some artificially long types in the following screenshots.

Before screenshot:

<img width="1258" alt="screen shot 2018-08-03 at 8 32 35 pm" src="https://user-images.githubusercontent.com/193874/43670805-56e3b3b4-975e-11e8-9296-600837d03de2.png">


After screenshot:
 

<img width="1239" alt="screen shot 2018-08-03 at 8 31 17 pm" src="https://user-images.githubusercontent.com/193874/43670810-6591f9ac-975e-11e8-9e12-4ea9ab1e5806.png">
