### PR TITLE
resolve:  Support custom attributes when macro modularization is enabled

### DIFF
--- a/src/librustc/hir/def.rs
+++ b/src/librustc/hir/def.rs
@@ -29,6 +29,18 @@ pub enum CtorKind {
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub enum NonMacroAttrKind {
+    /// Single-segment attribute defined by the language (`#[inline]`)
+    Builtin,
+    /// Multi-segment custom attribute living in a "tool module" (`#[rustfmt::skip]`).
+    Tool,
+    /// Single-segment custom attribute registered by a derive macro (`#[serde(default)]`).
+    DeriveHelper,
+    /// Single-segment custom attribute not registered in any way (`#[my_attr]`).
+    Custom,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
 pub enum Def {
     // Type namespace
     Mod(DefId),
@@ -68,7 +80,7 @@ pub enum Def {
 
     // Macro namespace
     Macro(DefId, MacroKind),
-    NonMacroAttr, // e.g. `#[inline]` or `#[rustfmt::skip]`
+    NonMacroAttr(NonMacroAttrKind), // e.g. `#[inline]` or `#[rustfmt::skip]`
 
     GlobalAsm(DefId),
 
@@ -242,6 +254,17 @@ impl CtorKind {
     }
 }
 
+impl NonMacroAttrKind {
+    fn descr(self) -> &'static str {
+        match self {
+            NonMacroAttrKind::Builtin => "built-in attribute",
+            NonMacroAttrKind::Tool => "tool attribute",
+            NonMacroAttrKind::DeriveHelper => "derive helper attribute",
+            NonMacroAttrKind::Custom => "custom attribute",
+        }
+    }
+}
+
 impl Def {
     pub fn def_id(&self) -> DefId {
         match *self {
@@ -262,7 +285,7 @@ impl Def {
             Def::PrimTy(..) |
             Def::SelfTy(..) |
             Def::ToolMod |
-            Def::NonMacroAttr |
+            Def::NonMacroAttr(..) |
             Def::Err => {
                 bug!("attempted .def_id() on invalid def: {:?}", self)
             }
@@ -304,7 +327,7 @@ impl Def {
             Def::Macro(.., macro_kind) => macro_kind.descr(),
             Def::GlobalAsm(..) => "global asm",
             Def::ToolMod => "tool module",
-            Def::NonMacroAttr => "non-macro attribute",
+            Def::NonMacroAttr(attr_kind) => attr_kind.descr(),
             Def::Err => "unresolved item",
         }
     }

--- a/src/librustc/ich/impls_hir.rs
+++ b/src/librustc/ich/impls_hir.rs
@@ -988,6 +988,13 @@ impl_stable_hash_for!(enum hir::def::CtorKind {
     Fictive
 });
 
+impl_stable_hash_for!(enum hir::def::NonMacroAttrKind {
+    Builtin,
+    Tool,
+    DeriveHelper,
+    Custom,
+});
+
 impl_stable_hash_for!(enum hir::def::Def {
     Mod(def_id),
     Struct(def_id),
@@ -1017,7 +1024,7 @@ impl_stable_hash_for!(enum hir::def::Def {
     Macro(def_id, macro_kind),
     GlobalAsm(def_id),
     ToolMod,
-    NonMacroAttr,
+    NonMacroAttr(attr_kind),
     Err
 });
 

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -630,8 +630,8 @@ impl<'a, 'cl> Resolver<'a, 'cl> {
     pub fn get_macro(&mut self, def: Def) -> Lrc<SyntaxExtension> {
         let def_id = match def {
             Def::Macro(def_id, ..) => def_id,
-            Def::NonMacroAttr => return Lrc::new(SyntaxExtension::NonMacroAttr),
-            _ => panic!("Expected Def::Macro(..) or Def::NonMacroAttr"),
+            Def::NonMacroAttr(..) => return Lrc::new(SyntaxExtension::NonMacroAttr),
+            _ => panic!("expected `Def::Macro` or `Def::NonMacroAttr`"),
         };
         if let Some(ext) = self.macro_map.get(&def_id) {
             return ext.clone();

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -630,7 +630,9 @@ impl<'a, 'cl> Resolver<'a, 'cl> {
     pub fn get_macro(&mut self, def: Def) -> Lrc<SyntaxExtension> {
         let def_id = match def {
             Def::Macro(def_id, ..) => def_id,
-            Def::NonMacroAttr(..) => return Lrc::new(SyntaxExtension::NonMacroAttr),
+            Def::NonMacroAttr(attr_kind) => return Lrc::new(SyntaxExtension::NonMacroAttr {
+                mark_used: attr_kind == NonMacroAttrKind::Tool,
+            }),
             _ => panic!("expected `Def::Macro` or `Def::NonMacroAttr`"),
         };
         if let Some(ext) = self.macro_map.get(&def_id) {

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -3514,7 +3514,8 @@ impl<'a, 'crateloader: 'a> Resolver<'a, 'crateloader> {
                     if let Some(next_module) = binding.module() {
                         module = Some(next_module);
                     } else if def == Def::ToolMod && i + 1 != path.len() {
-                        return PathResult::NonModule(PathResolution::new(Def::NonMacroAttr))
+                        let def = Def::NonMacroAttr(NonMacroAttrKind::Tool);
+                        return PathResult::NonModule(PathResolution::new(def));
                     } else if def == Def::Err {
                         return PathResult::NonModule(err_path_resolution());
                     } else if opt_ns.is_some() && (is_last || maybe_assoc) {

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -3485,8 +3485,9 @@ impl<'a, 'crateloader: 'a> Resolver<'a, 'crateloader> {
             let binding = if let Some(module) = module {
                 self.resolve_ident_in_module(module, ident, ns, record_used, path_span)
             } else if opt_ns == Some(MacroNS) {
-                self.resolve_lexical_macro_path_segment(ident, ns, record_used, path_span)
-                    .map(MacroBinding::binding)
+                assert!(ns == TypeNS);
+                self.resolve_lexical_macro_path_segment(ident, ns, record_used, record_used,
+                                                        false, path_span).map(MacroBinding::binding)
             } else {
                 let record_used_id =
                     if record_used { crate_lint.node_id().or(Some(CRATE_NODE_ID)) } else { None };
@@ -4549,6 +4550,8 @@ impl<'a, 'crateloader: 'a> Resolver<'a, 'crateloader> {
             let result = self.resolve_lexical_macro_path_segment(ident,
                                                                  MacroNS,
                                                                  false,
+                                                                 false,
+                                                                 true,
                                                                  attr.path.span);
             if let Ok(binding) = result {
                 if let SyntaxExtension::AttrProcMacro(..) = *binding.binding().get_macro(self) {

--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -812,7 +812,7 @@ impl<'l, 'tcx: 'l> SaveContext<'l, 'tcx> {
             HirDef::Macro(..) |
             HirDef::GlobalAsm(..) |
             HirDef::ToolMod |
-            HirDef::NonMacroAttr |
+            HirDef::NonMacroAttr(..) |
             HirDef::Err => None,
         }
     }

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -589,7 +589,7 @@ impl MacroKind {
 /// An enum representing the different kinds of syntax extensions.
 pub enum SyntaxExtension {
     /// A trivial "extension" that does nothing, only keeps the attribute and marks it as known.
-    NonMacroAttr,
+    NonMacroAttr { mark_used: bool },
 
     /// A syntax extension that is attached to an item and creates new items
     /// based upon it.
@@ -670,7 +670,7 @@ impl SyntaxExtension {
             SyntaxExtension::IdentTT(..) |
             SyntaxExtension::ProcMacro { .. } =>
                 MacroKind::Bang,
-            SyntaxExtension::NonMacroAttr |
+            SyntaxExtension::NonMacroAttr { .. } |
             SyntaxExtension::MultiDecorator(..) |
             SyntaxExtension::MultiModifier(..) |
             SyntaxExtension::AttrProcMacro(..) =>
@@ -700,7 +700,7 @@ impl SyntaxExtension {
             SyntaxExtension::AttrProcMacro(.., edition) |
             SyntaxExtension::ProcMacroDerive(.., edition) => edition,
             // Unstable legacy stuff
-            SyntaxExtension::NonMacroAttr |
+            SyntaxExtension::NonMacroAttr { .. } |
             SyntaxExtension::IdentTT(..) |
             SyntaxExtension::MultiDecorator(..) |
             SyntaxExtension::MultiModifier(..) |
@@ -737,6 +737,12 @@ pub trait Resolver {
 pub enum Determinacy {
     Determined,
     Undetermined,
+}
+
+impl Determinacy {
+    pub fn determined(determined: bool) -> Determinacy {
+        if determined { Determinacy::Determined } else { Determinacy::Undetermined }
+    }
 }
 
 pub struct DummyResolver;

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -726,7 +726,7 @@ pub trait Resolver {
     fn find_legacy_attr_invoc(&mut self, attrs: &mut Vec<Attribute>, allow_derive: bool)
                               -> Option<Attribute>;
 
-    fn resolve_invoc(&mut self, invoc: &mut Invocation, scope: Mark, force: bool)
+    fn resolve_invoc(&mut self, invoc: &Invocation, scope: Mark, force: bool)
                      -> Result<Option<Lrc<SyntaxExtension>>, Determinacy>;
     fn resolve_macro(&mut self, scope: Mark, path: &ast::Path, kind: MacroKind, force: bool)
                      -> Result<Lrc<SyntaxExtension>, Determinacy>;
@@ -754,7 +754,7 @@ impl Resolver for DummyResolver {
     fn resolve_imports(&mut self) {}
     fn find_legacy_attr_invoc(&mut self, _attrs: &mut Vec<Attribute>, _allow_derive: bool)
                               -> Option<Attribute> { None }
-    fn resolve_invoc(&mut self, _invoc: &mut Invocation, _scope: Mark, _force: bool)
+    fn resolve_invoc(&mut self, _invoc: &Invocation, _scope: Mark, _force: bool)
                      -> Result<Option<Lrc<SyntaxExtension>>, Determinacy> {
         Err(Determinacy::Determined)
     }

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -252,13 +252,6 @@ impl Invocation {
             InvocationKind::Derive { ref path, .. } => path.span,
         }
     }
-
-    pub fn attr_id(&self) -> Option<ast::AttrId> {
-        match self.kind {
-            InvocationKind::Attr { attr: Some(ref attr), .. } => Some(attr.id),
-            _ => None,
-        }
-    }
 }
 
 pub struct MacroExpander<'a, 'b:'a> {
@@ -338,7 +331,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
         let mut undetermined_invocations = Vec::new();
         let (mut progress, mut force) = (false, !self.monotonic);
         loop {
-            let mut invoc = if let Some(invoc) = invocations.pop() {
+            let invoc = if let Some(invoc) = invocations.pop() {
                 invoc
             } else {
                 self.resolve_imports();
@@ -350,20 +343,10 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
 
             let scope =
                 if self.monotonic { invoc.expansion_data.mark } else { orig_expansion_data.mark };
-            let attr_id_before = invoc.attr_id();
-            let ext = match self.cx.resolver.resolve_invoc(&mut invoc, scope, force) {
+            let ext = match self.cx.resolver.resolve_invoc(&invoc, scope, force) {
                 Ok(ext) => Some(ext),
                 Err(Determinacy::Determined) => None,
                 Err(Determinacy::Undetermined) => {
-                    // Sometimes attributes which we thought were invocations
-                    // end up being custom attributes for custom derives. If
-                    // that's the case our `invoc` will have changed out from
-                    // under us. If this is the case we're making progress so we
-                    // want to flag it as such, and we test this by looking if
-                    // the `attr_id()` method has been changing over time.
-                    if invoc.attr_id() != attr_id_before {
-                        progress = true;
-                    }
                     undetermined_invocations.push(invoc);
                     continue
                 }

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -83,10 +83,14 @@ macro_rules! declare_features {
             }
 
             pub fn use_extern_macros(&self) -> bool {
-                // The `decl_macro`, `tool_attributes` and `custom_attributes`
-                // features imply `use_extern_macros`.
+                // A number of "advanced" macro features enable
+                // macro modularization (`use_extern_macros`) implicitly.
                 self.use_extern_macros || self.decl_macro ||
-                self.tool_attributes || self.custom_attribute
+                self.tool_attributes || self.custom_attribute ||
+                self.macros_in_extern || self.proc_macro_path_invoc ||
+                self.proc_macro_mod || self.proc_macro_expr ||
+                self.proc_macro_non_items || self.proc_macro_gen ||
+                self.stmt_expr_attributes
             }
         }
     };
@@ -700,7 +704,7 @@ pub fn is_builtin_attr_name(name: ast::Name) -> bool {
 }
 
 pub fn is_builtin_attr(attr: &ast::Attribute) -> bool {
-    BUILTIN_ATTRIBUTES.iter().any(|&(builtin_name, _, _)| attr.check_name(builtin_name)) ||
+    BUILTIN_ATTRIBUTES.iter().any(|&(builtin_name, _, _)| attr.path == builtin_name) ||
     attr.name().as_str().starts_with("rustc_")
 }
 

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -1354,13 +1354,6 @@ pub const EXPLAIN_UNSIZED_TUPLE_COERCION: &'static str =
 pub const EXPLAIN_MACRO_AT_MOST_ONCE_REP: &'static str =
     "using the `?` macro Kleene operator for \"at most one\" repetition is unstable";
 
-pub const EXPLAIN_MACROS_IN_EXTERN: &'static str =
-    "macro invocations in `extern {}` blocks are experimental.";
-
-// mention proc-macros when enabled
-pub const EXPLAIN_PROC_MACROS_IN_EXTERN: &'static str =
-    "macro and proc-macro invocations in `extern {}` blocks are experimental.";
-
 struct PostExpansionVisitor<'a> {
     context: &'a Context<'a>,
 }
@@ -1969,7 +1962,6 @@ pub fn get_features(span_handler: &Handler, krate_attrs: &[ast::Attribute],
                     ).emit();
                 } else {
                     set(&mut features, mi.span);
-                    feature_checker.collect(&features, mi.span);
                     features.declared_lang_features.push((name, mi.span, None));
                 }
                 continue

--- a/src/test/compile-fail-fulldeps/proc-macro/attr-invalid-exprs.rs
+++ b/src/test/compile-fail-fulldeps/proc-macro/attr-invalid-exprs.rs
@@ -13,7 +13,7 @@
 
 //! Attributes producing expressions in invalid locations
 
-#![feature(use_extern_macros, stmt_expr_attributes, proc_macro_expr)]
+#![feature(stmt_expr_attributes, proc_macro_expr)]
 
 extern crate attr_stmt_expr;
 use attr_stmt_expr::{duplicate, no_output};

--- a/src/test/compile-fail-fulldeps/proc-macro/attr-stmt-expr.rs
+++ b/src/test/compile-fail-fulldeps/proc-macro/attr-stmt-expr.rs
@@ -11,7 +11,7 @@
 // aux-build:attr-stmt-expr.rs
 // ignore-stage1
 
-#![feature(use_extern_macros, proc_macro_expr)]
+#![feature(proc_macro_expr)]
 
 extern crate attr_stmt_expr;
 use attr_stmt_expr::{expect_let, expect_print_stmt, expect_expr, expect_print_expr};

--- a/src/test/compile-fail-fulldeps/proc-macro/issue-41211.rs
+++ b/src/test/compile-fail-fulldeps/proc-macro/issue-41211.rs
@@ -15,7 +15,7 @@
 
 #![feature(use_extern_macros)]
 #![emit_unchanged]
-//~^ ERROR: cannot find attribute macro `emit_unchanged` in this scope
+//~^ ERROR attribute `emit_unchanged` is currently unknown to the compiler
 extern crate issue_41211;
 use issue_41211::emit_unchanged;
 

--- a/src/test/compile-fail-fulldeps/proc-macro/issue-50493.rs
+++ b/src/test/compile-fail-fulldeps/proc-macro/issue-50493.rs
@@ -11,8 +11,6 @@
 // aux-build:issue_50493.rs
 // ignore-stage1
 
-#![feature(proc_macro)]
-
 #[macro_use]
 extern crate issue_50493;
 

--- a/src/test/compile-fail-fulldeps/proc-macro/lints_in_proc_macros.rs
+++ b/src/test/compile-fail-fulldeps/proc-macro/lints_in_proc_macros.rs
@@ -11,7 +11,7 @@
 // aux-build:bang_proc_macro2.rs
 // ignore-stage1
 
-#![feature(use_extern_macros, proc_macro_non_items)]
+#![feature(proc_macro_non_items)]
 #![allow(unused_macros)]
 
 extern crate bang_proc_macro2;

--- a/src/test/compile-fail-fulldeps/proc-macro/macros-in-extern.rs
+++ b/src/test/compile-fail-fulldeps/proc-macro/macros-in-extern.rs
@@ -26,13 +26,13 @@ fn main() {
 #[link(name = "rust_test_helpers", kind = "static")]
 extern {
     #[no_output]
-    //~^ ERROR macro and proc-macro invocations in `extern {}` blocks are experimental.
+    //~^ ERROR macro invocations in `extern {}` blocks are experimental
     fn some_definitely_unknown_symbol_which_should_be_removed();
 
     #[nop_attr]
-    //~^ ERROR macro and proc-macro invocations in `extern {}` blocks are experimental.
+    //~^ ERROR macro invocations in `extern {}` blocks are experimental
     fn rust_get_test_int() -> isize;
 
     emit_input!(fn rust_dbg_extern_identity_u32(arg: u32) -> u32;);
-    //~^ ERROR macro and proc-macro invocations in `extern {}` blocks are experimental.
+    //~^ ERROR macro invocations in `extern {}` blocks are experimental
 }

--- a/src/test/compile-fail-fulldeps/proc-macro/proc-macro-custom-attr-mutex.rs
+++ b/src/test/compile-fail-fulldeps/proc-macro/proc-macro-custom-attr-mutex.rs
@@ -11,7 +11,7 @@
 // aux-build:attr_proc_macro.rs
 // ignore-tidy-linelength
 
-#![feature(use_extern_macros, custom_attribute)]
+#![feature(custom_attribute)]
 //~^ ERROR Cannot use `#![feature(use_extern_macros)]` and `#![feature(custom_attribute)] at the same time
 
 extern crate attr_proc_macro;

--- a/src/test/compile-fail-fulldeps/proc-macro/proc-macro-gates.rs
+++ b/src/test/compile-fail-fulldeps/proc-macro/proc-macro-gates.rs
@@ -16,7 +16,7 @@
 // gate-test-proc_macro_mod
 // gate-test-proc_macro_gen
 
-#![feature(use_extern_macros, stmt_expr_attributes)]
+#![feature(stmt_expr_attributes)]
 
 extern crate proc_macro_gates as foo;
 

--- a/src/test/compile-fail-fulldeps/proc-macro/proc-macro-gates2.rs
+++ b/src/test/compile-fail-fulldeps/proc-macro/proc-macro-gates2.rs
@@ -10,7 +10,7 @@
 
 // aux-build:proc-macro-gates.rs
 
-#![feature(use_extern_macros, stmt_expr_attributes)]
+#![feature(stmt_expr_attributes)]
 
 extern crate proc_macro_gates as foo;
 

--- a/src/test/compile-fail/macro-with-seps-err-msg.rs
+++ b/src/test/compile-fail/macro-with-seps-err-msg.rs
@@ -10,10 +10,6 @@
 
 // gate-test-use_extern_macros
 
-#![feature(proc_macro_path_invoc)]
-
 fn main() {
     globnar::brotz!(); //~ ERROR non-ident macro paths are experimental
-    #[derive(foo::Bar)] struct T; //~ ERROR non-ident macro paths are experimental
-    ::foo!(); //~ ERROR non-ident macro paths are experimental
 }

--- a/src/test/compile-fail/macros-in-extern.rs
+++ b/src/test/compile-fail/macros-in-extern.rs
@@ -34,9 +34,9 @@ fn main() {
 #[link(name = "rust_test_helpers", kind = "static")]
 extern {
     returns_isize!(rust_get_test_int);
-    //~^ ERROR macro invocations in `extern {}` blocks are experimental.
+    //~^ ERROR macro invocations in `extern {}` blocks are experimental
     takes_u32_returns_u32!(rust_dbg_extern_identity_u32);
-    //~^ ERROR macro invocations in `extern {}` blocks are experimental.
+    //~^ ERROR macro invocations in `extern {}` blocks are experimental
     emits_nothing!();
-    //~^ ERROR macro invocations in `extern {}` blocks are experimental.
+    //~^ ERROR macro invocations in `extern {}` blocks are experimental
 }

--- a/src/test/compile-fail/stmt_expr_attrs_no_feature.rs
+++ b/src/test/compile-fail/stmt_expr_attrs_no_feature.rs
@@ -20,7 +20,7 @@ fn main() {
     #[attr]
     fn a() {}
 
-    #[attr]
+    #[attr] //~ ERROR attributes on expressions are experimental
     {
 
     }

--- a/src/test/compile-fail/unknown-tool-name.rs
+++ b/src/test/compile-fail/unknown-tool-name.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(use_extern_macros, proc_macro_path_invoc)]
+#![feature(proc_macro_path_invoc)]
 
 #[foo::bar] //~ ERROR failed to resolve. Use of undeclared type or module `foo`
 fn main() {}

--- a/src/test/pretty/attr-literals.rs
+++ b/src/test/pretty/attr-literals.rs
@@ -18,6 +18,6 @@ fn main() {
     #[align = 8]
     fn f() { }
 
-    #[vec(1, 2, 3)]
+    #[vector(1, 2, 3)]
     fn g() { }
 }

--- a/src/test/run-pass-fulldeps/auxiliary/cond_plugin.rs
+++ b/src/test/run-pass-fulldeps/auxiliary/cond_plugin.rs
@@ -11,7 +11,7 @@
 // no-prefer-dynamic
 
 #![crate_type = "proc-macro"]
-#![feature(proc_macro, proc_macro_non_items)]
+#![feature(proc_macro_non_items)]
 
 extern crate proc_macro;
 

--- a/src/test/run-pass-fulldeps/auxiliary/hello_macro.rs
+++ b/src/test/run-pass-fulldeps/auxiliary/hello_macro.rs
@@ -11,7 +11,7 @@
 // no-prefer-dynamic
 
 #![crate_type = "proc-macro"]
-#![feature(use_extern_macros, proc_macro_non_items, proc_macro_quote)]
+#![feature(proc_macro_non_items, proc_macro_quote)]
 
 extern crate proc_macro;
 

--- a/src/test/run-pass-fulldeps/auxiliary/proc_macro_def.rs
+++ b/src/test/run-pass-fulldeps/auxiliary/proc_macro_def.rs
@@ -11,7 +11,7 @@
 // no-prefer-dynamic
 
 #![crate_type = "proc-macro"]
-#![feature(proc_macro, proc_macro_non_items)]
+#![feature(proc_macro_non_items)]
 
 extern crate proc_macro;
 

--- a/src/test/run-pass-fulldeps/macro-quote-cond.rs
+++ b/src/test/run-pass-fulldeps/macro-quote-cond.rs
@@ -11,7 +11,7 @@
 // aux-build:cond_plugin.rs
 // ignore-stage1
 
-#![feature(use_extern_macros, proc_macro_non_items)]
+#![feature(proc_macro_non_items)]
 
 extern crate cond_plugin;
 

--- a/src/test/run-pass-fulldeps/macro-quote-test.rs
+++ b/src/test/run-pass-fulldeps/macro-quote-test.rs
@@ -13,7 +13,7 @@
 // aux-build:hello_macro.rs
 // ignore-stage1
 
-#![feature(use_extern_macros, proc_macro_non_items, proc_macro_gen)]
+#![feature(proc_macro_non_items, proc_macro_gen)]
 
 extern crate hello_macro;
 

--- a/src/test/run-pass-fulldeps/proc-macro/attr-stmt-expr.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/attr-stmt-expr.rs
@@ -11,7 +11,7 @@
 // aux-build:attr-stmt-expr.rs
 // ignore-stage1
 
-#![feature(use_extern_macros, stmt_expr_attributes, proc_macro_expr)]
+#![feature(stmt_expr_attributes, proc_macro_expr)]
 
 extern crate attr_stmt_expr;
 use attr_stmt_expr::{expect_let, expect_print_stmt, expect_expr, expect_print_expr,

--- a/src/test/run-pass-fulldeps/proc-macro/auxiliary/count_compound_ops.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/auxiliary/count_compound_ops.rs
@@ -10,7 +10,7 @@
 
 // no-prefer-dynamic
 
-#![feature(proc_macro_non_items, proc_macro_quote, use_extern_macros)]
+#![feature(proc_macro_non_items, proc_macro_quote)]
 #![crate_type = "proc-macro"]
 
 extern crate proc_macro;

--- a/src/test/run-pass-fulldeps/proc-macro/auxiliary/hygiene_example_codegen.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/auxiliary/hygiene_example_codegen.rs
@@ -10,7 +10,7 @@
 
 // no-prefer-dynamic
 
-#![feature(use_extern_macros, proc_macro_quote, proc_macro_non_items)]
+#![feature(proc_macro_quote, proc_macro_non_items)]
 #![crate_type = "proc-macro"]
 
 extern crate proc_macro as proc_macro_renamed; // This does not break `quote!`

--- a/src/test/run-pass-fulldeps/proc-macro/bang-macro.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/bang-macro.rs
@@ -11,7 +11,7 @@
 // aux-build:bang-macro.rs
 // ignore-stage1
 
-#![feature(use_extern_macros, proc_macro_non_items)]
+#![feature(proc_macro_non_items)]
 
 extern crate bang_macro;
 use bang_macro::rewrite;

--- a/src/test/run-pass-fulldeps/proc-macro/call-site.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/call-site.rs
@@ -11,7 +11,7 @@
 // aux-build:call-site.rs
 // ignore-stage1
 
-#![feature(proc_macro_non_items, use_extern_macros)]
+#![feature(proc_macro_non_items)]
 
 extern crate call_site;
 use call_site::*;

--- a/src/test/run-pass-fulldeps/proc-macro/count_compound_ops.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/count_compound_ops.rs
@@ -11,7 +11,7 @@
 // aux-build:count_compound_ops.rs
 // ignore-stage1
 
-#![feature(use_extern_macros, proc_macro_non_items)]
+#![feature(proc_macro_non_items)]
 
 extern crate count_compound_ops;
 use count_compound_ops::count_compound_ops;

--- a/src/test/run-pass-fulldeps/proc-macro/derive-b.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/derive-b.rs
@@ -11,7 +11,7 @@
 // aux-build:derive-b.rs
 // ignore-stage1
 
-#![feature(use_extern_macros, proc_macro_path_invoc)]
+#![feature(proc_macro_path_invoc)]
 
 extern crate derive_b;
 

--- a/src/test/run-pass-fulldeps/proc-macro/hygiene_example.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/hygiene_example.rs
@@ -12,7 +12,7 @@
 // aux-build:hygiene_example.rs
 // ignore-stage1
 
-#![feature(use_extern_macros, proc_macro_non_items)]
+#![feature(proc_macro_non_items)]
 
 extern crate hygiene_example;
 use hygiene_example::hello;

--- a/src/test/run-pass-fulldeps/proc-macro/macros-in-extern.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/macros-in-extern.rs
@@ -12,7 +12,7 @@
 // ignore-stage1
 // ignore-wasm32
 
-#![feature(use_extern_macros, macros_in_extern)]
+#![feature(macros_in_extern)]
 
 extern crate test_macros;
 

--- a/src/test/run-pass-fulldeps/proc_macro.rs
+++ b/src/test/run-pass-fulldeps/proc_macro.rs
@@ -12,7 +12,7 @@
 // ignore-stage1
 // ignore-cross-compile
 
-#![feature(use_extern_macros, proc_macro_non_items)]
+#![feature(proc_macro_non_items)]
 
 extern crate proc_macro_def;
 

--- a/src/test/ui-fulldeps/auxiliary/attr_proc_macro.rs
+++ b/src/test/ui-fulldeps/auxiliary/attr_proc_macro.rs
@@ -10,7 +10,7 @@
 
 // force-host
 // no-prefer-dynamic
-#![feature(proc_macro)]
+
 #![crate_type = "proc-macro"]
 
 extern crate proc_macro;

--- a/src/test/ui-fulldeps/auxiliary/bang_proc_macro.rs
+++ b/src/test/ui-fulldeps/auxiliary/bang_proc_macro.rs
@@ -10,7 +10,7 @@
 
 // force-host
 // no-prefer-dynamic
-#![feature(proc_macro)]
+
 #![crate_type = "proc-macro"]
 
 extern crate proc_macro;

--- a/src/test/ui-fulldeps/auxiliary/lifetimes.rs
+++ b/src/test/ui-fulldeps/auxiliary/lifetimes.rs
@@ -10,7 +10,6 @@
 
 // no-prefer-dynamic
 
-#![feature(proc_macro)]
 #![crate_type = "proc-macro"]
 
 extern crate proc_macro;

--- a/src/test/ui-fulldeps/lifetimes.rs
+++ b/src/test/ui-fulldeps/lifetimes.rs
@@ -10,7 +10,7 @@
 
 // aux-build:lifetimes.rs
 
-#![feature(use_extern_macros, proc_macro_non_items)]
+#![feature(proc_macro_non_items)]
 
 extern crate lifetimes;
 

--- a/src/test/ui-fulldeps/proc-macro/auxiliary/generate-mod.rs
+++ b/src/test/ui-fulldeps/proc-macro/auxiliary/generate-mod.rs
@@ -11,7 +11,6 @@
 // run-pass
 // no-prefer-dynamic
 
-#![feature(proc_macro)]
 #![crate_type = "proc-macro"]
 
 extern crate proc_macro;

--- a/src/test/ui-fulldeps/proc-macro/generate-mod.rs
+++ b/src/test/ui-fulldeps/proc-macro/generate-mod.rs
@@ -12,7 +12,7 @@
 
 // aux-build:generate-mod.rs
 
-#![feature(use_extern_macros, proc_macro_gen, proc_macro_path_invoc)]
+#![feature(proc_macro_gen, proc_macro_path_invoc)]
 
 extern crate generate_mod;
 

--- a/src/test/ui-fulldeps/proc-macro/invalid-attributes.rs
+++ b/src/test/ui-fulldeps/proc-macro/invalid-attributes.rs
@@ -11,7 +11,6 @@
 // no-prefer-dynamic
 
 #![crate_type = "proc-macro"]
-#![feature(proc_macro)]
 
 extern crate proc_macro;
 

--- a/src/test/ui-fulldeps/proc-macro/invalid-attributes.stderr
+++ b/src/test/ui-fulldeps/proc-macro/invalid-attributes.stderr
@@ -1,35 +1,35 @@
 error: `#[proc_macro]` attribute does not take any arguments
-  --> $DIR/invalid-attributes.rs:20:1
+  --> $DIR/invalid-attributes.rs:19:1
    |
 LL | #[proc_macro = "test"] //~ ERROR: does not take any arguments
    | ^^^^^^^^^^^^^^^^^^^^^^
 
 error: `#[proc_macro]` attribute does not take any arguments
-  --> $DIR/invalid-attributes.rs:23:1
+  --> $DIR/invalid-attributes.rs:22:1
    |
 LL | #[proc_macro()] //~ ERROR: does not take any arguments
    | ^^^^^^^^^^^^^^^
 
 error: `#[proc_macro]` attribute does not take any arguments
-  --> $DIR/invalid-attributes.rs:26:1
+  --> $DIR/invalid-attributes.rs:25:1
    |
 LL | #[proc_macro(x)] //~ ERROR: does not take any arguments
    | ^^^^^^^^^^^^^^^^
 
 error: `#[proc_macro_attribute]` attribute does not take any arguments
-  --> $DIR/invalid-attributes.rs:29:1
+  --> $DIR/invalid-attributes.rs:28:1
    |
 LL | #[proc_macro_attribute = "test"] //~ ERROR: does not take any arguments
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `#[proc_macro_attribute]` attribute does not take any arguments
-  --> $DIR/invalid-attributes.rs:32:1
+  --> $DIR/invalid-attributes.rs:31:1
    |
 LL | #[proc_macro_attribute()] //~ ERROR: does not take any arguments
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `#[proc_macro_attribute]` attribute does not take any arguments
-  --> $DIR/invalid-attributes.rs:35:1
+  --> $DIR/invalid-attributes.rs:34:1
    |
 LL | #[proc_macro_attribute(x)] //~ ERROR: does not take any arguments
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui-fulldeps/proc-macro/macro-namespace-reserved.rs
+++ b/src/test/ui-fulldeps/proc-macro/macro-namespace-reserved.rs
@@ -10,7 +10,7 @@
 
 // no-prefer-dynamic
 
-#![feature(proc_macro, decl_macro)]
+#![feature(decl_macro)]
 #![crate_type = "proc-macro"]
 
 extern crate proc_macro;

--- a/src/test/ui-fulldeps/proc-macro/non-root.rs
+++ b/src/test/ui-fulldeps/proc-macro/non-root.rs
@@ -10,7 +10,6 @@
 
 // no-prefer-dynamic
 
-#![feature(proc_macro)]
 #![crate_type = "proc-macro"]
 
 extern crate proc_macro;

--- a/src/test/ui-fulldeps/proc-macro/non-root.stderr
+++ b/src/test/ui-fulldeps/proc-macro/non-root.stderr
@@ -1,5 +1,5 @@
 error: functions tagged with `#[proc_macro]` must currently reside in the root of the crate
-  --> $DIR/non-root.rs:21:5
+  --> $DIR/non-root.rs:20:5
    |
 LL |     pub fn foo(arg: TokenStream) -> TokenStream { arg }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui-fulldeps/proc-macro/three-equals.rs
+++ b/src/test/ui-fulldeps/proc-macro/three-equals.rs
@@ -11,7 +11,7 @@
 // aux-build:three-equals.rs
 // ignore-stage1
 
-#![feature(use_extern_macros, proc_macro_non_items)]
+#![feature(proc_macro_non_items)]
 
 extern crate three_equals;
 

--- a/src/test/ui-fulldeps/resolve-error.rs
+++ b/src/test/ui-fulldeps/resolve-error.rs
@@ -13,7 +13,7 @@
 // aux-build:attr_proc_macro.rs
 // aux-build:bang_proc_macro.rs
 
-#![feature(use_extern_macros)]
+#![feature(custom_attribute)]
 
 #[macro_use]
 extern crate derive_foo;
@@ -37,12 +37,10 @@ macro_rules! attr_proc_mac {
 //~^ ERROR cannot find
 struct Foo;
 
-#[attr_proc_macra]
-//~^ ERROR cannot find
+#[attr_proc_macra] // OK, interpreted as a custom attribute
 struct Bar;
 
-#[FooWithLongNan]
-//~^ ERROR cannot find
+#[FooWithLongNan]  // OK, interpreted as a custom attribute
 struct Asdf;
 
 #[derive(Dlone)]

--- a/src/test/ui-fulldeps/resolve-error.stderr
+++ b/src/test/ui-fulldeps/resolve-error.stderr
@@ -4,59 +4,47 @@ error: cannot find derive macro `FooWithLongNan` in this scope
 LL | #[derive(FooWithLongNan)]
    |          ^^^^^^^^^^^^^^ help: try: `FooWithLongName`
 
-error: cannot find attribute macro `attr_proc_macra` in this scope
-  --> $DIR/resolve-error.rs:40:3
-   |
-LL | #[attr_proc_macra]
-   |   ^^^^^^^^^^^^^^^ help: try: `attr_proc_macro`
-
-error: cannot find attribute macro `FooWithLongNan` in this scope
-  --> $DIR/resolve-error.rs:44:3
-   |
-LL | #[FooWithLongNan]
-   |   ^^^^^^^^^^^^^^
-
 error: cannot find derive macro `Dlone` in this scope
-  --> $DIR/resolve-error.rs:48:10
+  --> $DIR/resolve-error.rs:46:10
    |
 LL | #[derive(Dlone)]
    |          ^^^^^ help: try: `Clone`
 
 error: cannot find derive macro `Dlona` in this scope
-  --> $DIR/resolve-error.rs:52:10
+  --> $DIR/resolve-error.rs:50:10
    |
 LL | #[derive(Dlona)]
    |          ^^^^^ help: try: `Clona`
 
 error: cannot find derive macro `attr_proc_macra` in this scope
-  --> $DIR/resolve-error.rs:56:10
+  --> $DIR/resolve-error.rs:54:10
    |
 LL | #[derive(attr_proc_macra)]
    |          ^^^^^^^^^^^^^^^
 
 error: cannot find macro `FooWithLongNama!` in this scope
-  --> $DIR/resolve-error.rs:61:5
+  --> $DIR/resolve-error.rs:59:5
    |
 LL |     FooWithLongNama!();
    |     ^^^^^^^^^^^^^^^ help: you could try the macro: `FooWithLongNam`
 
 error: cannot find macro `attr_proc_macra!` in this scope
-  --> $DIR/resolve-error.rs:64:5
+  --> $DIR/resolve-error.rs:62:5
    |
 LL |     attr_proc_macra!();
    |     ^^^^^^^^^^^^^^^ help: you could try the macro: `attr_proc_mac`
 
 error: cannot find macro `Dlona!` in this scope
-  --> $DIR/resolve-error.rs:67:5
+  --> $DIR/resolve-error.rs:65:5
    |
 LL |     Dlona!();
    |     ^^^^^
 
 error: cannot find macro `bang_proc_macrp!` in this scope
-  --> $DIR/resolve-error.rs:70:5
+  --> $DIR/resolve-error.rs:68:5
    |
 LL |     bang_proc_macrp!();
    |     ^^^^^^^^^^^^^^^ help: you could try the macro: `bang_proc_macro`
 
-error: aborting due to 10 previous errors
+error: aborting due to 8 previous errors
 

--- a/src/test/ui/custom-attribute-multisegment.rs
+++ b/src/test/ui/custom-attribute-multisegment.rs
@@ -1,4 +1,4 @@
-// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,18 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// aux-build:attr_proc_macro.rs
-// ignore-tidy-linelength
+// Unresolved multi-segment attributes are not treated as custom.
 
-#![feature(custom_attribute)]
-//~^ ERROR Cannot use `#![feature(use_extern_macros)]` and `#![feature(custom_attribute)] at the same time
+#![feature(custom_attribute, proc_macro_path_invoc)]
 
-extern crate attr_proc_macro;
-use attr_proc_macro::attr_proc_macro;
+mod existent {}
 
-#[attr_proc_macro]
-fn foo() {}
-
-fn main() {
-    foo();
-}
+#[existent::nonexistent] //~ ERROR failed to resolve. Could not find `nonexistent` in `existent`
+fn main() {}

--- a/src/test/ui/custom-attribute-multisegment.stderr
+++ b/src/test/ui/custom-attribute-multisegment.stderr
@@ -1,0 +1,9 @@
+error[E0433]: failed to resolve. Could not find `nonexistent` in `existent`
+  --> $DIR/custom-attribute-multisegment.rs:17:13
+   |
+LL | #[existent::nonexistent] //~ ERROR failed to resolve. Could not find `nonexistent` in `existent`
+   |             ^^^^^^^^^^^ Could not find `nonexistent` in `existent`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0433`.

--- a/src/test/ui/feature-gate-macros_in_extern.rs
+++ b/src/test/ui/feature-gate-macros_in_extern.rs
@@ -27,9 +27,9 @@ macro_rules! emits_nothing(
 #[link(name = "rust_test_helpers", kind = "static")]
 extern {
     returns_isize!(rust_get_test_int);
-    //~^ ERROR macro invocations in `extern {}` blocks are experimental.
+    //~^ ERROR macro invocations in `extern {}` blocks are experimental
     takes_u32_returns_u32!(rust_dbg_extern_identity_u32);
-    //~^ ERROR macro invocations in `extern {}` blocks are experimental.
+    //~^ ERROR macro invocations in `extern {}` blocks are experimental
     emits_nothing!();
-    //~^ ERROR macro invocations in `extern {}` blocks are experimental.
+    //~^ ERROR macro invocations in `extern {}` blocks are experimental
 }

--- a/src/test/ui/feature-gate-macros_in_extern.stderr
+++ b/src/test/ui/feature-gate-macros_in_extern.stderr
@@ -1,4 +1,4 @@
-error[E0658]: macro and proc-macro invocations in `extern {}` blocks are experimental. (see issue #49476)
+error[E0658]: macro invocations in `extern {}` blocks are experimental (see issue #49476)
   --> $DIR/feature-gate-macros_in_extern.rs:29:5
    |
 LL |     returns_isize!(rust_get_test_int);
@@ -6,7 +6,7 @@ LL |     returns_isize!(rust_get_test_int);
    |
    = help: add #![feature(macros_in_extern)] to the crate attributes to enable
 
-error[E0658]: macro and proc-macro invocations in `extern {}` blocks are experimental. (see issue #49476)
+error[E0658]: macro invocations in `extern {}` blocks are experimental (see issue #49476)
   --> $DIR/feature-gate-macros_in_extern.rs:31:5
    |
 LL |     takes_u32_returns_u32!(rust_dbg_extern_identity_u32);
@@ -14,7 +14,7 @@ LL |     takes_u32_returns_u32!(rust_dbg_extern_identity_u32);
    |
    = help: add #![feature(macros_in_extern)] to the crate attributes to enable
 
-error[E0658]: macro and proc-macro invocations in `extern {}` blocks are experimental. (see issue #49476)
+error[E0658]: macro invocations in `extern {}` blocks are experimental (see issue #49476)
   --> $DIR/feature-gate-macros_in_extern.rs:33:5
    |
 LL |     emits_nothing!();

--- a/src/test/ui/imports/macros.rs
+++ b/src/test/ui/imports/macros.rs
@@ -10,7 +10,7 @@
 
 // aux-build:two_macros.rs
 
-#![feature(item_like_imports, use_extern_macros)]
+#![feature(use_extern_macros)]
 
 extern crate two_macros; // two identity macros `m` and `n`
 

--- a/src/test/ui/issue-11692-2.rs
+++ b/src/test/ui/issue-11692-2.rs
@@ -10,5 +10,5 @@
 
 fn main() {
     concat!(test!());
-    //~^ ERROR expected a macro, found non-macro attribute
+    //~^ ERROR expected a macro, found built-in attribute
 }

--- a/src/test/ui/issue-11692-2.stderr
+++ b/src/test/ui/issue-11692-2.stderr
@@ -1,4 +1,4 @@
-error: expected a macro, found non-macro attribute
+error: expected a macro, found built-in attribute
   --> $DIR/issue-11692-2.rs:12:13
    |
 LL |     concat!(test!());

--- a/src/test/ui/macro-path-prelude-fail-3.rs
+++ b/src/test/ui/macro-path-prelude-fail-3.rs
@@ -10,9 +10,9 @@
 
 #![feature(use_extern_macros)]
 
-#[derive(inline)] //~ ERROR expected a macro, found non-macro attribute
+#[derive(inline)] //~ ERROR expected a macro, found built-in attribute
 struct S;
 
 fn main() {
-    inline!(); //~ ERROR expected a macro, found non-macro attribute
+    inline!(); //~ ERROR expected a macro, found built-in attribute
 }

--- a/src/test/ui/macro-path-prelude-fail-3.stderr
+++ b/src/test/ui/macro-path-prelude-fail-3.stderr
@@ -1,13 +1,13 @@
-error: expected a macro, found non-macro attribute
+error: expected a macro, found built-in attribute
   --> $DIR/macro-path-prelude-fail-3.rs:13:10
    |
-LL | #[derive(inline)] //~ ERROR expected a macro, found non-macro attribute
+LL | #[derive(inline)] //~ ERROR expected a macro, found built-in attribute
    |          ^^^^^^
 
-error: expected a macro, found non-macro attribute
+error: expected a macro, found built-in attribute
   --> $DIR/macro-path-prelude-fail-3.rs:17:5
    |
-LL |     inline!(); //~ ERROR expected a macro, found non-macro attribute
+LL |     inline!(); //~ ERROR expected a macro, found built-in attribute
    |     ^^^^^^
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/tool-attributes-disabled-2.rs
+++ b/src/test/ui/tool-attributes-disabled-2.rs
@@ -11,9 +11,5 @@
 // If macro modularization (`use_extern_macros`) is not enabled,
 // then tool attributes are treated as custom attributes.
 
-// compile-pass
-
-#![feature(custom_attribute)]
-
-#[rustfmt::bar]
+#[rustfmt::bar] //~ ERROR attribute `rustfmt::bar` is currently unknown to the compiler
 fn main() {}

--- a/src/test/ui/tool-attributes-disabled-2.stderr
+++ b/src/test/ui/tool-attributes-disabled-2.stderr
@@ -1,0 +1,11 @@
+error[E0658]: The attribute `rustfmt::bar` is currently unknown to the compiler and may have meaning added to it in the future (see issue #29642)
+  --> $DIR/tool-attributes-disabled-2.rs:14:1
+   |
+LL | #[rustfmt::bar] //~ ERROR attribute `rustfmt::bar` is currently unknown to the compiler
+   | ^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/tool-attributes-misplaced-1.rs
+++ b/src/test/ui/tool-attributes-misplaced-1.rs
@@ -11,7 +11,7 @@
 #![feature(tool_attributes)]
 
 type A = rustfmt; //~ ERROR expected type, found tool module `rustfmt`
-type B = rustfmt::skip; //~ ERROR expected type, found non-macro attribute `rustfmt::skip`
+type B = rustfmt::skip; //~ ERROR expected type, found tool attribute `rustfmt::skip`
 
 #[derive(rustfmt)] //~ ERROR cannot find derive macro `rustfmt` in this scope
 struct S;
@@ -24,5 +24,5 @@ fn main() {
     rustfmt; //~ ERROR expected value, found tool module `rustfmt`
     rustfmt!(); //~ ERROR cannot find macro `rustfmt!` in this scope
 
-    rustfmt::skip; //~ ERROR expected value, found non-macro attribute `rustfmt::skip`
+    rustfmt::skip; //~ ERROR expected value, found tool attribute `rustfmt::skip`
 }

--- a/src/test/ui/tool-attributes-misplaced-1.rs
+++ b/src/test/ui/tool-attributes-misplaced-1.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(tool_attributes)]
+#![feature(tool_attributes, custom_attribute)]
 
 type A = rustfmt; //~ ERROR expected type, found tool module `rustfmt`
 type B = rustfmt::skip; //~ ERROR expected type, found tool attribute `rustfmt::skip`
@@ -16,7 +16,7 @@ type B = rustfmt::skip; //~ ERROR expected type, found tool attribute `rustfmt::
 #[derive(rustfmt)] //~ ERROR cannot find derive macro `rustfmt` in this scope
 struct S;
 
-#[rustfmt] //~ ERROR cannot find attribute macro `rustfmt` in this scope
+#[rustfmt] // OK, interpreted as a custom attribute
 fn check() {}
 
 #[rustfmt::skip] // OK

--- a/src/test/ui/tool-attributes-misplaced-1.stderr
+++ b/src/test/ui/tool-attributes-misplaced-1.stderr
@@ -4,12 +4,6 @@ error: cannot find derive macro `rustfmt` in this scope
 LL | #[derive(rustfmt)] //~ ERROR cannot find derive macro `rustfmt` in this scope
    |          ^^^^^^^
 
-error: cannot find attribute macro `rustfmt` in this scope
-  --> $DIR/tool-attributes-misplaced-1.rs:19:3
-   |
-LL | #[rustfmt] //~ ERROR cannot find attribute macro `rustfmt` in this scope
-   |   ^^^^^^^
-
 error: cannot find macro `rustfmt!` in this scope
   --> $DIR/tool-attributes-misplaced-1.rs:25:5
    |
@@ -40,7 +34,7 @@ error[E0423]: expected value, found tool attribute `rustfmt::skip`
 LL |     rustfmt::skip; //~ ERROR expected value, found tool attribute `rustfmt::skip`
    |     ^^^^^^^^^^^^^ not a value
 
-error: aborting due to 7 previous errors
+error: aborting due to 6 previous errors
 
 Some errors occurred: E0423, E0573.
 For more information about an error, try `rustc --explain E0423`.

--- a/src/test/ui/tool-attributes-misplaced-1.stderr
+++ b/src/test/ui/tool-attributes-misplaced-1.stderr
@@ -22,10 +22,10 @@ error[E0573]: expected type, found tool module `rustfmt`
 LL | type A = rustfmt; //~ ERROR expected type, found tool module `rustfmt`
    |          ^^^^^^^ not a type
 
-error[E0573]: expected type, found non-macro attribute `rustfmt::skip`
+error[E0573]: expected type, found tool attribute `rustfmt::skip`
   --> $DIR/tool-attributes-misplaced-1.rs:14:10
    |
-LL | type B = rustfmt::skip; //~ ERROR expected type, found non-macro attribute `rustfmt::skip`
+LL | type B = rustfmt::skip; //~ ERROR expected type, found tool attribute `rustfmt::skip`
    |          ^^^^^^^^^^^^^ not a type
 
 error[E0423]: expected value, found tool module `rustfmt`
@@ -34,10 +34,10 @@ error[E0423]: expected value, found tool module `rustfmt`
 LL |     rustfmt; //~ ERROR expected value, found tool module `rustfmt`
    |     ^^^^^^^ not a value
 
-error[E0423]: expected value, found non-macro attribute `rustfmt::skip`
+error[E0423]: expected value, found tool attribute `rustfmt::skip`
   --> $DIR/tool-attributes-misplaced-1.rs:27:5
    |
-LL |     rustfmt::skip; //~ ERROR expected value, found non-macro attribute `rustfmt::skip`
+LL |     rustfmt::skip; //~ ERROR expected value, found tool attribute `rustfmt::skip`
    |     ^^^^^^^^^^^^^ not a value
 
 error: aborting due to 7 previous errors

--- a/src/test/ui/tool-attributes-misplaced-2.rs
+++ b/src/test/ui/tool-attributes-misplaced-2.rs
@@ -10,9 +10,9 @@
 
 #![feature(tool_attributes)]
 
-#[derive(rustfmt::skip)] //~ ERROR expected a macro, found non-macro attribute
+#[derive(rustfmt::skip)] //~ ERROR expected a macro, found tool attribute
 struct S;
 
 fn main() {
-    rustfmt::skip!(); //~ ERROR expected a macro, found non-macro attribute
+    rustfmt::skip!(); //~ ERROR expected a macro, found tool attribute
 }

--- a/src/test/ui/tool-attributes-misplaced-2.stderr
+++ b/src/test/ui/tool-attributes-misplaced-2.stderr
@@ -1,13 +1,13 @@
-error: expected a macro, found non-macro attribute
+error: expected a macro, found tool attribute
   --> $DIR/tool-attributes-misplaced-2.rs:13:10
    |
-LL | #[derive(rustfmt::skip)] //~ ERROR expected a macro, found non-macro attribute
+LL | #[derive(rustfmt::skip)] //~ ERROR expected a macro, found tool attribute
    |          ^^^^^^^^^^^^^
 
-error: expected a macro, found non-macro attribute
+error: expected a macro, found tool attribute
   --> $DIR/tool-attributes-misplaced-2.rs:17:5
    |
-LL |     rustfmt::skip!(); //~ ERROR expected a macro, found non-macro attribute
+LL |     rustfmt::skip!(); //~ ERROR expected a macro, found tool attribute
    |     ^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors


### PR DESCRIPTION
Basically, if resolution of a single-segment attribute is a determined error, then we interpret it as a custom attribute.

Since custom attributes are integrated into general macro resolution, `feature(custom_attribute)` now requires and implicitly enables macro modularization (`feature(use_extern_macros)`).
Actually, a few other "advanced" macro features now implicitly enable macro modularization too (and one bug was found and fixed in process of enabling it).

The first two commits are preliminary cleanups/refactorings.