### PR TITLE
Change rustdoc style so fully qualified name does not overlap src link

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -97,7 +97,7 @@ h1, h2, h3:not(.impl):not(.method):not(.type):not(.tymethod):not(.important), h4
 h1.fqn {
 	border-bottom: 1px dashed;
 	margin-top: 0;
-	position: relative;
+	overflow: auto;
 }
 h2, h3:not(.impl):not(.method):not(.type):not(.tymethod), h4:not(.method):not(.type):not(.tymethod):not(.associatedconstant) {
 	border-bottom: 1px solid;
@@ -352,14 +352,11 @@ nav.sub {
 }
 
 .content .out-of-band {
+	float: right;
 	font-size: 23px;
 	margin: 0px;
 	padding: 0px;
-	text-align: right;
-	display: inline-block;
 	font-weight: normal;
-	position: absolute;
-	right: 0;
 }
 
 h3.impl > .out-of-band {


### PR DESCRIPTION
A type's fully qualified name will now wrap once it gets to the
`[-][src]` link aligned against the right edge of the content area.
Previously the two would overlap and the name would only wrap when
hitting the edge of the content area.

Before:
![image](https://user-images.githubusercontent.com/5081378/43676506-cf548758-97c0-11e8-80a0-a812d8ea0eef.png)

After:
![image](https://user-images.githubusercontent.com/5081378/43676509-e78810a6-97c0-11e8-8cd4-b90bd5858a5f.png)