### PR TITLE
Try to guess a smarter initial capacity in Vec::from_iter

### DIFF
--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -1861,36 +1861,17 @@ impl<T, I> SpecExtend<T, I> for Vec<T>
             if let Some(x) = iterator.next() { x }
             else { return Vec::new() };
         let (lower, upper) = iterator.size_hint();
-        let upper = upper.unwrap_or(lower);
-        let mut vector =
-            if lower >= upper / 2 {
-                // This branch covers three main cases:
-                // - There was no upper bound, so we just use the lower.
-                // - The hint turned out to be exact, so we use it.
-                // - Picking the upper won't waste more that the doubling
-                //   strategy might anyway, so go directly there.
-                Vec::with_capacity(upper.saturating_add(1))
-            } else {
-                // Try to start near the geometric mean of the range.  That's
-                // never all that high -- even 0B..1GB will only allocate 32kB --
-                // but it's much more useful than the lower bound, especially
-                // for iterator adapters like filter that have lower == 0.
-                let mut v = Vec::new();
-                let mag_diff = lower.leading_zeros() - upper.leading_zeros();
-                let guess = upper >> (mag_diff / 2);
-                match v.try_reserve(guess.saturating_add(1)) {
-                    Ok(_) => v,
-                    Err(_) => Vec::with_capacity(lower.saturating_add(1)),
-                }
-            };
+        let guess = if let Some(upper) = upper {
+            lower.saturating_mul(2).min(upper)
+        } else {
+            lower
+        };
+        let mut vector = Vec::with_capacity(guess.saturating_add(1));
         unsafe {
             ptr::write(vector.get_unchecked_mut(0), element);
             vector.set_len(1);
         }
         <Vec<T> as SpecExtend<T, I>>::spec_extend(&mut vector, iterator);
-        if vector.len() < vector.capacity() / 2 {
-            vector.shrink_to_fit();
-        }
         vector
     }
 


### PR DESCRIPTION
> Another possibility is collect could look at the upper bound and be smarter about what capacity to use?  ~ https://github.com/rust-lang/rust/issues/45840#issuecomment-342949609

This is obviously good for hints like `(60, Some(61))` where today we allocate space for 60, then double it should the additional element show up, and it'd be much better to just always allocate 61.

More nuanced are hints like `(0, Some(150))`, where today the code uses just the `0`, and thus starts at a capacity of `1`, but with this change will start at `10` instead.

This can undeniably increase memory pressure over where it is today, so I expect at least some controversy :slightly_smiling_face:  It does use `try_reserve` for the allocation that's more than the lower bound, and thus shouldn't introduce new aborts, at least.  And the starting point grows by the root, keeping things fairly contained: even with an hint of `(0, Some(1_000_000_000))` it'll only start at `30_517`.

cc @ljedrz 
cc https://github.com/rust-lang/rust/issues/48994