### PR TITLE
[NLL] Use span of the closure args in free region errors

### DIFF
--- a/src/test/ui/error-codes/E0621-does-not-trigger-for-closures.nll.stderr
+++ b/src/test/ui/error-codes/E0621-does-not-trigger-for-closures.nll.stderr
@@ -8,10 +8,10 @@ error: unsatisfied lifetime constraints
   --> $DIR/E0621-does-not-trigger-for-closures.rs:25:26
    |
 LL |     invoke(&x, |a, b| if a > b { a } else { b }); //~ ERROR E0495
-   |                ------    ^^^^^ requires that `'1` must outlive `'2`
-   |                |   |
-   |                |   has type `&'1 i32`
-   |                lifetime `'2` appears in return type
+   |                    --    ^^^^^ requires that `'1` must outlive `'2`
+   |                    ||
+   |                    |return type of closure is &'2 i32
+   |                    has type `&'1 i32`
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0621-does-not-trigger-for-closures.nll.stderr
+++ b/src/test/ui/error-codes/E0621-does-not-trigger-for-closures.nll.stderr
@@ -8,9 +8,8 @@ error: unsatisfied lifetime constraints
   --> $DIR/E0621-does-not-trigger-for-closures.rs:25:26
    |
 LL |     invoke(&x, |a, b| if a > b { a } else { b }); //~ ERROR E0495
-   |                ----------^^^^^-----------------
-   |                |   |     |
-   |                |   |     requires that `'1` must outlive `'2`
+   |                ------    ^^^^^ requires that `'1` must outlive `'2`
+   |                |   |
    |                |   has type `&'1 i32`
    |                lifetime `'2` appears in return type
 

--- a/src/test/ui/issue-40510-1.nll.stderr
+++ b/src/test/ui/issue-40510-1.nll.stderr
@@ -3,9 +3,9 @@ error: unsatisfied lifetime constraints
    |
 LL |     || {
    |     --
-   |     |
+   |     ||
+   |     |return type of closure is &'2 mut std::boxed::Box<()>
    |     lifetime `'1` represents this closure's body
-   |     lifetime `'2` appears in return type
 LL |         &mut x
    |         ^^^^^^ return requires that `'1` must outlive `'2`
    |

--- a/src/test/ui/issue-40510-1.nll.stderr
+++ b/src/test/ui/issue-40510-1.nll.stderr
@@ -1,17 +1,15 @@
 error: unsatisfied lifetime constraints
   --> $DIR/issue-40510-1.rs:18:9
    |
-LL |        || {
-   |   _____-
-   |  |_____|
-   | ||
-LL | ||         &mut x
-   | ||         ^^^^^^ return requires that `'1` must outlive `'2`
-LL | ||     };
-   | ||     -
-   | ||_____|
-   | |______lifetime `'1` represents the closure body
-   |        lifetime `'2` appears in return type
+LL |     || {
+   |     --
+   |     |
+   |     lifetime `'1` represents this closure's body
+   |     lifetime `'2` appears in return type
+LL |         &mut x
+   |         ^^^^^^ return requires that `'1` must outlive `'2`
+   |
+   = note: closure implements `FnMut`, so references to captured variables can't escape the closure
 
 error: aborting due to previous error
 

--- a/src/test/ui/issue-40510-3.nll.stderr
+++ b/src/test/ui/issue-40510-3.nll.stderr
@@ -1,20 +1,17 @@
 error: unsatisfied lifetime constraints
   --> $DIR/issue-40510-3.rs:18:9
    |
-LL |         || {
-   |    _____-
-   |   |_____|
-   |  ||
-LL |  ||         || {
-   |  ||_________^
-LL | |||             x.push(())
-LL | |||         }
-   | |||_________^ requires that `'1` must outlive `'2`
-LL |  ||     };
-   |  ||     -
-   |  ||_____|
-   |  |______lifetime `'1` represents the closure body
-   |         lifetime `'2` appears in return type
+LL |       || {
+   |       --
+   |       |
+   |       lifetime `'1` represents this closure's body
+   |       lifetime `'2` appears in return type
+LL | /         || {
+LL | |             x.push(())
+LL | |         }
+   | |_________^ requires that `'1` must outlive `'2`
+   |
+   = note: closure implements `FnMut`, so references to captured variables can't escape the closure
 
 error: aborting due to previous error
 

--- a/src/test/ui/issue-40510-3.nll.stderr
+++ b/src/test/ui/issue-40510-3.nll.stderr
@@ -3,9 +3,9 @@ error: unsatisfied lifetime constraints
    |
 LL |       || {
    |       --
-   |       |
+   |       ||
+   |       |return type of closure is [closure@$DIR/issue-40510-3.rs:18:9: 20:10 x:&'2 mut std::vec::Vec<()>]
    |       lifetime `'1` represents this closure's body
-   |       lifetime `'2` appears in return type
 LL | /         || {
 LL | |             x.push(())
 LL | |         }

--- a/src/test/ui/issue-49824.nll.stderr
+++ b/src/test/ui/issue-49824.nll.stderr
@@ -3,9 +3,9 @@ error: unsatisfied lifetime constraints
    |
 LL |       || {
    |       --
-   |       |
+   |       ||
+   |       |return type of closure is [closure@$DIR/issue-49824.rs:22:9: 24:10 x:&'2 mut i32]
    |       lifetime `'1` represents this closure's body
-   |       lifetime `'2` appears in return type
 LL | /         || {
 LL | |             let _y = &mut x;
 LL | |         }

--- a/src/test/ui/issue-49824.nll.stderr
+++ b/src/test/ui/issue-49824.nll.stderr
@@ -1,20 +1,17 @@
 error: unsatisfied lifetime constraints
   --> $DIR/issue-49824.rs:22:9
    |
-LL |         || {
-   |    _____-
-   |   |_____|
-   |  ||
-LL |  ||         || {
-   |  ||_________^
-LL | |||             let _y = &mut x;
-LL | |||         }
-   | |||_________^ requires that `'1` must outlive `'2`
-LL |  ||     };
-   |  ||     -
-   |  ||_____|
-   |  |______lifetime `'1` represents the closure body
-   |         lifetime `'2` appears in return type
+LL |       || {
+   |       --
+   |       |
+   |       lifetime `'1` represents this closure's body
+   |       lifetime `'2` appears in return type
+LL | /         || {
+LL | |             let _y = &mut x;
+LL | |         }
+   | |_________^ requires that `'1` must outlive `'2`
+   |
+   = note: closure implements `FnMut`, so references to captured variables can't escape the closure
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/issue-48238.stderr
+++ b/src/test/ui/nll/issue-48238.stderr
@@ -2,11 +2,12 @@ error: unsatisfied lifetime constraints
   --> $DIR/issue-48238.rs:21:13
    |
 LL |     move || use_val(&orig); //~ ERROR
-   |     --------^^^^^^^^^^^^^^
-   |     |       |
-   |     |       argument requires that `'1` must outlive `'2`
-   |     lifetime `'1` represents the closure body
+   |     ------- ^^^^^^^^^^^^^^ argument requires that `'1` must outlive `'2`
+   |     |
+   |     lifetime `'1` represents this closure's body
    |     lifetime `'2` appears in return type
+   |
+   = note: closure implements `Fn`, so references to captured variables can't escape the closure
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/issue-48238.stderr
+++ b/src/test/ui/nll/issue-48238.stderr
@@ -3,9 +3,9 @@ error: unsatisfied lifetime constraints
    |
 LL |     move || use_val(&orig); //~ ERROR
    |     ------- ^^^^^^^^^^^^^^ argument requires that `'1` must outlive `'2`
-   |     |
+   |     |     |
+   |     |     return type of closure is &'2 u8
    |     lifetime `'1` represents this closure's body
-   |     lifetime `'2` appears in return type
    |
    = note: closure implements `Fn`, so references to captured variables can't escape the closure
 


### PR DESCRIPTION
Also adds a note when one of the free regions is BrEnv.
In a future PR I'll change these messages to say "return requires", which should improve them a bit more.

r? @nikomatsakis 