### PR TITLE
Enable macros to pass $:literal to another macro

### DIFF
--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -302,6 +302,10 @@ impl Token {
             BinOp(Minus) => true,
             Ident(ident, false) if ident.name == keywords::True.name() => true,
             Ident(ident, false) if ident.name == keywords::False.name() => true,
+            Interpolated(ref nt) => match nt.0 {
+                NtLiteral(..) => true,
+                _             => false,
+            },
             _            => false,
         }
     }

--- a/src/test/run-pass/issue-52169.rs
+++ b/src/test/run-pass/issue-52169.rs
@@ -1,0 +1,24 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(macro_literal_matcher)]
+
+macro_rules! a {
+    ($i:literal) => { "right" };
+    ($i:tt) => { "wrong" };
+}
+
+macro_rules! b {
+    ($i:literal) => { a!($i) };
+}
+
+fn main() {
+    assert_eq!(b!(0), "right");
+}


### PR DESCRIPTION
Fixes #52169.