### PR TITLE
Account for --remap-path-prefix in save-analysis

### DIFF
--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -125,7 +125,7 @@ impl<'l, 'tcx: 'l> SaveContext<'l, 'tcx> {
             result.push(ExternalCrateData {
                 // FIXME: change file_name field to PathBuf in rls-data
                 // https://github.com/nrc/rls-data/issues/7
-                file_name: SpanUtils::make_path_string(&lo_loc.file.name),
+                file_name: self.span_utils.make_path_string(&lo_loc.file.name),
                 num: n.as_u32(),
                 id: GlobalCrateId {
                     name: self.tcx.crate_name(n).to_string(),

--- a/src/librustc_save_analysis/span_utils.rs
+++ b/src/librustc_save_analysis/span_utils.rs
@@ -13,7 +13,6 @@ use rustc::session::Session;
 use generated_code;
 
 use std::cell::Cell;
-use std::env;
 
 use syntax::parse::lexer::{self, StringReader};
 use syntax::parse::token::{self, Token};
@@ -36,11 +35,10 @@ impl<'a> SpanUtils<'a> {
         }
     }
 
-    pub fn make_path_string(path: &FileName) -> String {
+    pub fn make_path_string(&self, path: &FileName) -> String {
         match *path {
             FileName::Real(ref path) if !path.is_absolute() =>
-                env::current_dir()
-                    .unwrap()
+                self.sess.working_dir.0
                     .join(&path)
                     .display()
                     .to_string(),


### PR DESCRIPTION
Fixes #52549.

Didn't add a test since save-analysis is still unstable, only tested this locally. Should I add a test for that? If so, is run-make-fulldeps an appropriate format?

Session is already created with remapped working directory, so use that instead of the actual cwd.
This was the only place affected, since the rest of the paths in save-analysis are directly derived from files in spans from `sess.codemap()`, which already creates remapped ones.

r? @nrc