### PR TITLE
Speed up leb128 write functions, add benchmarks

### DIFF
--- a/src/libserialize/leb128.rs
+++ b/src/libserialize/leb128.rs
@@ -8,11 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[inline]
-pub fn write_to_vec(vec: &mut Vec<u8>, byte: u8) {
-    vec.push(byte);
-}
-
 #[cfg(target_pointer_width = "32")]
 const USIZE_LEB128_SIZE: usize = 5;
 #[cfg(target_pointer_width = "64")]
@@ -30,19 +25,18 @@ macro_rules! impl_write_unsigned_leb128 {
     ($fn_name:ident, $int_ty:ident) => (
         #[inline]
         pub fn $fn_name(out: &mut Vec<u8>, mut value: $int_ty) {
-            for _ in 0 .. leb128_size!($int_ty) {
-                let mut byte = (value & 0x7F) as u8;
-                value >>= 7;
-                if value != 0 {
+            out.extend((0..leb128_size!($int_ty)).scan(value, |state, _| {
+                let mut byte = (*state & 0x7F) as u8;
+                *state >>= 7;
+                if *state != 0 {
                     byte |= 0x80;
+                    Some(byte)
+                } else {
+                    value = byte as $int_ty;
+                    None
                 }
-
-                write_to_vec(out, byte);
-
-                if value == 0 {
-                    break;
-                }
-            }
+            }));
+            out.push(value as u8);
         }
     )
 }
@@ -52,7 +46,6 @@ impl_write_unsigned_leb128!(write_u32_leb128, u32);
 impl_write_unsigned_leb128!(write_u64_leb128, u64);
 impl_write_unsigned_leb128!(write_u128_leb128, u128);
 impl_write_unsigned_leb128!(write_usize_leb128, usize);
-
 
 macro_rules! impl_read_unsigned_leb128 {
     ($fn_name:ident, $int_ty:ident) => (
@@ -88,8 +81,6 @@ impl_read_unsigned_leb128!(read_u64_leb128, u64);
 impl_read_unsigned_leb128!(read_u128_leb128, u128);
 impl_read_unsigned_leb128!(read_usize_leb128, usize);
 
-
-
 #[inline]
 /// encodes an integer using signed leb128 encoding and stores
 /// the result using a callback function.
@@ -97,29 +88,22 @@ impl_read_unsigned_leb128!(read_usize_leb128, usize);
 /// The callback `write` is called once for each position
 /// that is to be written to with the byte to be encoded
 /// at that position.
-pub fn write_signed_leb128_to<W>(mut value: i128, mut write: W)
-    where W: FnMut(u8)
-{
-    loop {
-        let mut byte = (value as u8) & 0x7f;
-        value >>= 7;
-        let more = !((((value == 0) && ((byte & 0x40) == 0)) ||
-                      ((value == -1) && ((byte & 0x40) != 0))));
+pub fn write_signed_leb128(out: &mut Vec<u8>, mut value: i128) {
+    out.extend((0..).scan(value, |state, _| {
+        let mut byte = (*state as u8) & 0x7f;
+        *state >>= 7;
+        let more = !((((*state ==  0) && ((byte & 0x40) == 0)) ||
+                      ((*state == -1) && ((byte & 0x40) != 0))));
 
         if more {
             byte |= 0x80; // Mark this byte to show that more bytes will follow.
+            Some(byte)
+        } else {
+            value = byte as i128;
+            None
         }
-
-        write(byte);
-
-        if !more {
-            break;
-        }
-    }
-}
-
-pub fn write_signed_leb128(out: &mut Vec<u8>, value: i128) {
-    write_signed_leb128_to(value, |v| write_to_vec(out, v))
+    }));
+    out.push(value as u8);
 }
 
 #[inline]
@@ -148,46 +132,72 @@ pub fn read_signed_leb128(data: &[u8], start_position: usize) -> (i128, usize) {
     (result, position - start_position)
 }
 
-macro_rules! impl_test_unsigned_leb128 {
-    ($test_name:ident, $write_fn_name:ident, $read_fn_name:ident, $int_ty:ident) => (
-        #[test]
-        fn $test_name() {
-            let mut stream = Vec::new();
+#[cfg(test)]
+mod tests {
+    extern crate test;
+    use self::test::Bencher;
+    use super::*;
 
-            for x in 0..62 {
-                $write_fn_name(&mut stream, (3u64 << x) as $int_ty);
-            }
+    macro_rules! impl_test_unsigned_leb128 {
+        ($test_name:ident, $write_fn_name:ident, $read_fn_name:ident, $int_ty:ident) => (
+            #[test]
+            fn $test_name() {
+                let mut stream = Vec::new();
 
-            let mut position = 0;
-            for x in 0..62 {
-                let expected = (3u64 << x) as $int_ty;
-                let (actual, bytes_read) = $read_fn_name(&stream[position ..]);
-                assert_eq!(expected, actual);
-                position += bytes_read;
+                for x in 0..62 {
+                    $write_fn_name(&mut stream, (3u64 << x) as $int_ty);
+                }
+
+                let mut position = 0;
+                for x in 0..62 {
+                    let expected = (3u64 << x) as $int_ty;
+                    let (actual, bytes_read) = $read_fn_name(&stream[position ..]);
+                    assert_eq!(expected, actual);
+                    position += bytes_read;
+                }
+                assert_eq!(stream.len(), position);
             }
-            assert_eq!(stream.len(), position);
+        )
+    }
+
+    impl_test_unsigned_leb128!(test_u16_leb128, write_u16_leb128, read_u16_leb128, u16);
+    impl_test_unsigned_leb128!(test_u32_leb128, write_u32_leb128, read_u32_leb128, u32);
+    impl_test_unsigned_leb128!(test_u64_leb128, write_u64_leb128, read_u64_leb128, u64);
+    impl_test_unsigned_leb128!(test_u128_leb128, write_u128_leb128, read_u128_leb128, u128);
+    impl_test_unsigned_leb128!(test_usize_leb128, write_usize_leb128, read_usize_leb128, usize);
+
+    #[test]
+    fn test_signed_leb128() {
+        let values: Vec<_> = (-500..500).map(|i| i * 0x12345789ABCDEF).collect();
+        let mut stream = Vec::new();
+        for &x in &values {
+            write_signed_leb128(&mut stream, x);
         }
-    )
-}
-
-impl_test_unsigned_leb128!(test_u16_leb128, write_u16_leb128, read_u16_leb128, u16);
-impl_test_unsigned_leb128!(test_u32_leb128, write_u32_leb128, read_u32_leb128, u32);
-impl_test_unsigned_leb128!(test_u64_leb128, write_u64_leb128, read_u64_leb128, u64);
-impl_test_unsigned_leb128!(test_u128_leb128, write_u128_leb128, read_u128_leb128, u128);
-impl_test_unsigned_leb128!(test_usize_leb128, write_usize_leb128, read_usize_leb128, usize);
-
-#[test]
-fn test_signed_leb128() {
-    let values: Vec<_> = (-500..500).map(|i| i * 0x12345789ABCDEF).collect();
-    let mut stream = Vec::new();
-    for &x in &values {
-        write_signed_leb128(&mut stream, x);
+        let mut pos = 0;
+        for &x in &values {
+            let (value, bytes_read) = read_signed_leb128(&mut stream, pos);
+            pos += bytes_read;
+            assert_eq!(x, value);
+        }
+        assert_eq!(pos, stream.len());
     }
-    let mut pos = 0;
-    for &x in &values {
-        let (value, bytes_read) = read_signed_leb128(&mut stream, pos);
-        pos += bytes_read;
-        assert_eq!(x, value);
+
+    macro_rules! impl_bench_leb128_write {
+        ($bench_name:ident, $write_fn_name:ident, $int_ty:ident) => (
+            #[bench]
+            fn $bench_name(b: &mut Bencher) {
+                b.iter(|| {
+                    let mut stream = Vec::new();
+                    for i in 0..1000 { $write_fn_name(&mut stream, i as $int_ty) }
+                })
+            }
+        )
     }
-    assert_eq!(pos, stream.len());
+
+    impl_bench_leb128_write!(bench_write_u16, write_u16_leb128, u16);
+    impl_bench_leb128_write!(bench_write_u32, write_u32_leb128, u32);
+    impl_bench_leb128_write!(bench_write_u64, write_u64_leb128, u64);
+    impl_bench_leb128_write!(bench_write_u128, write_u128_leb128, u128);
+    impl_bench_leb128_write!(bench_write_usize, write_usize_leb128, usize);
+    impl_bench_leb128_write!(bench_write_i128, write_signed_leb128, i128);
 }


### PR DESCRIPTION
According to a few benchmarks I added for `leb128`, using a `scan`+`extend` combo instead of a push loop can improve the performance of write functions by **13-33%**:

before:
```
test leb128::tests::bench_write_u128  ... bench:       4,795 ns/iter (+/- 151)
test leb128::tests::bench_write_u16   ... bench:       4,795 ns/iter (+/- 122)
test leb128::tests::bench_write_u32   ... bench:       5,000 ns/iter (+/- 534)
test leb128::tests::bench_write_u64   ... bench:       5,013 ns/iter (+/- 235)
test leb128::tests::bench_write_usize ... bench:       5,011 ns/iter (+/- 119)
test leb128::tests::bench_write_i128  ... bench:       6,734 ns/iter (+/- 404)
```
after:
```
test leb128::tests::bench_write_u128  ... bench:       4,185 ns/iter (+/- 136)
test leb128::tests::bench_write_u16   ... bench:       3,697 ns/iter (+/- 516)
test leb128::tests::bench_write_u32   ... bench:       3,348 ns/iter (+/- 147)
test leb128::tests::bench_write_u64   ... bench:       3,367 ns/iter (+/- 180)
test leb128::tests::bench_write_usize ... bench:       3,381 ns/iter (+/- 393)
test leb128::tests::bench_write_i128  ... bench:       4,375 ns/iter (+/- 143)
```