### PR TITLE
pretty print BTreeSet

### DIFF
--- a/src/etc/debugger_pretty_printers_common.py
+++ b/src/etc/debugger_pretty_printers_common.py
@@ -48,6 +48,7 @@ TYPE_KIND_FIXED_SIZE_VEC    = 16
 TYPE_KIND_REGULAR_UNION     = 17
 TYPE_KIND_OS_STRING         = 18
 TYPE_KIND_STD_VECDEQUE      = 19
+TYPE_KIND_STD_BTREESET      = 20
 
 ENCODED_ENUM_PREFIX = "RUST$ENCODED$ENUM$"
 ENUM_DISR_FIELD_NAME = "RUST$ENUM$DISR"
@@ -70,6 +71,9 @@ STD_VECDEQUE_FIELD_NAME_BUF = "buf"
 STD_VECDEQUE_FIELD_NAMES = [STD_VECDEQUE_FIELD_NAME_TAIL,
                             STD_VECDEQUE_FIELD_NAME_HEAD,
                             STD_VECDEQUE_FIELD_NAME_BUF]
+
+# std::collections::BTreeSet<> related constants
+STD_BTREESET_FIELD_NAMES = ["map"]
 
 # std::String related constants
 STD_STRING_FIELD_NAMES = ["vec"]
@@ -174,6 +178,11 @@ class Type(object):
         if (unqualified_type_name.startswith("VecDeque<") and
             self.__conforms_to_field_layout(STD_VECDEQUE_FIELD_NAMES)):
             return TYPE_KIND_STD_VECDEQUE
+
+        # STD COLLECTION BTREESET
+        if (unqualified_type_name.startswith("BTreeSet<") and
+                self.__conforms_to_field_layout(STD_BTREESET_FIELD_NAMES)):
+            return TYPE_KIND_STD_BTREESET
 
         # STD STRING
         if (unqualified_type_name.startswith("String") and
@@ -356,6 +365,19 @@ def extract_tail_head_ptr_and_cap_from_std_vecdeque(vec_val):
     data_ptr = unique_ptr_val.get_child_at_index(0)
     assert data_ptr.type.get_dwarf_type_kind() == DWARF_TYPE_CODE_PTR
     return (tail, head, data_ptr, capacity)
+
+
+def extract_length_and_ptr_from_std_btreeset(vec_val):
+    assert vec_val.type.get_type_kind() == TYPE_KIND_STD_BTREESET
+    map = vec_val.get_child_at_index(0)
+    root = map.get_child_at_index(0)
+    length = map.get_child_at_index(1).as_integer()
+    node = root.get_child_at_index(0)
+    ptr = node.get_child_at_index(0)
+    unique_ptr_val = ptr.get_child_at_index(0)
+    data_ptr = unique_ptr_val.get_child_at_index(0)
+    assert data_ptr.type.get_dwarf_type_kind() == DWARF_TYPE_CODE_PTR
+    return (length, data_ptr)
 
 
 def extract_length_and_ptr_from_slice(slice_val):

--- a/src/etc/gdb_rust_pretty_printing.py
+++ b/src/etc/gdb_rust_pretty_printing.py
@@ -308,13 +308,13 @@ class RustStdBTreeSetPrinter(object):
 
     @staticmethod
     def display_hint():
-        return "map"
+        return "array"
 
     def to_string(self):
         (length, data_ptr) = \
             rustpp.extract_length_and_ptr_from_std_btreeset(self.__val)
         return (self.__val.type.get_unqualified_type_name() +
-                (" with %i elements" % length))
+                ("(len: %i)" % length))
 
     def children(self):
         (length, data_ptr) = \
@@ -322,7 +322,6 @@ class RustStdBTreeSetPrinter(object):
         val = GdbValue(data_ptr.get_wrapped_value().dereference()).get_child_at_index(3)
         gdb_ptr = val.get_wrapped_value()
         for index in xrange(length):
-            yield (str(index), str(index))
             yield (str(index), gdb_ptr[index])
 
 

--- a/src/etc/gdb_rust_pretty_printing.py
+++ b/src/etc/gdb_rust_pretty_printing.py
@@ -319,7 +319,7 @@ class RustStdBTreeSetPrinter(object):
     def children(self):
         (length, data_ptr) = \
             rustpp.extract_length_and_ptr_from_std_btreeset(self.__val)
-        val = GdbValue(data_ptr.get_wrapped_value().dereference()).get_child_at_index(0)
+        val = GdbValue(data_ptr.get_wrapped_value().dereference()).get_child_at_index(3)
         gdb_ptr = val.get_wrapped_value()
         for index in xrange(length):
             yield (str(index), str(index))

--- a/src/etc/gdb_rust_pretty_printing.py
+++ b/src/etc/gdb_rust_pretty_printing.py
@@ -127,6 +127,9 @@ def rust_pretty_printer_lookup_function(gdb_val):
     if type_kind == rustpp.TYPE_KIND_STD_VECDEQUE:
         return RustStdVecDequePrinter(val)
 
+    if type_kind == rustpp.TYPE_KIND_STD_BTREESET:
+        return RustStdBTreeSetPrinter(val)
+
     if type_kind == rustpp.TYPE_KIND_STD_STRING:
         return RustStdStringPrinter(val)
 
@@ -297,6 +300,30 @@ class RustStdVecDequePrinter(object):
         gdb_ptr = data_ptr.get_wrapped_value()
         for index in xrange(tail, head):
             yield (str(index), (gdb_ptr + index).dereference())
+
+
+class RustStdBTreeSetPrinter(object):
+    def __init__(self, val):
+        self.__val = val
+
+    @staticmethod
+    def display_hint():
+        return "map"
+
+    def to_string(self):
+        (length, data_ptr) = \
+            rustpp.extract_length_and_ptr_from_std_btreeset(self.__val)
+        return (self.__val.type.get_unqualified_type_name() +
+                (" with %i elements" % length))
+
+    def children(self):
+        (length, data_ptr) = \
+            rustpp.extract_length_and_ptr_from_std_btreeset(self.__val)
+        val = GdbValue(data_ptr.get_wrapped_value().dereference()).get_child_at_index(0)
+        gdb_ptr = val.get_wrapped_value()
+        for index in xrange(length):
+            yield (str(index), str(index))
+            yield (str(index), gdb_ptr[index])
 
 
 class RustStdStringPrinter(object):

--- a/src/test/debuginfo/pretty-std-collections.rs
+++ b/src/test/debuginfo/pretty-std-collections.rs
@@ -20,7 +20,7 @@
 // gdb-command: run
 
 // gdb-command: print btree_set
-// gdb-check:$1 = BTreeSet<i32> with 3 elements = {[0] = 3, [1] = 5, [2] = 7}
+// gdb-check:$1 = BTreeSet<i32>(len: 3) = {3, 5, 7}
 
 // gdb-command: print vec_deque
 // gdb-check:$2 = VecDeque<i32>(len: 3, cap: 8) = {5, 3, 7}

--- a/src/test/debuginfo/pretty-std-collections.rs
+++ b/src/test/debuginfo/pretty-std-collections.rs
@@ -1,0 +1,50 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-windows failing on win32 bot
+// ignore-freebsd: gdb package too new
+// ignore-android: FIXME(#10381)
+// compile-flags:-g
+// min-gdb-version 7.7
+// min-lldb-version: 310
+
+// === GDB TESTS ===================================================================================
+
+// gdb-command: run
+
+// gdb-command: print btree_set
+// gdb-check:$1 = BTreeSet<i32> with 3 elements = {[0] = 3, [1] = 5, [2] = 7}
+
+// gdb-command: print vec_deque
+// gdb-check:$2 = VecDeque<i32>(len: 3, cap: 8) = {5, 3, 7}
+
+#![allow(unused_variables)]
+use std::collections::BTreeSet;
+use std::collections::VecDeque;
+
+
+fn main() {
+
+    // BTreeSet
+    let mut btree_set = BTreeSet::new();
+    btree_set.insert(5);
+    btree_set.insert(3);
+    btree_set.insert(7);
+
+    // VecDeque
+    let mut vec_deque = VecDeque::new();
+    vec_deque.push_back(5);
+    vec_deque.push_back(3);
+    vec_deque.push_back(7);
+
+    zzz(); // #break
+}
+
+fn zzz() { () }


### PR DESCRIPTION
I want pretty printing for BTreeSet.
```rust
use std::collections::*;

fn main() {
  let mut s = BTreeSet::new();
  s.insert(5);
  s.insert(3);
  s.insert(7);
  s.remove(&3);
  println!("{:?}", s);
}
```

```
(gdb) b 9
(gdb) p s
$1 = BTreeSet<i32> with 2 elements = {[0] = 5, [1] = 7}
```
This is analogy of pretty printing for C++ std::set.
