### PR TITLE
set emit_debug_gdb_scripts: false for riscv32imac-unknown-none target

### DIFF
--- a/src/librustc_target/spec/riscv32imac_unknown_none_elf.rs
+++ b/src/librustc_target/spec/riscv32imac_unknown_none_elf.rs
@@ -33,6 +33,7 @@ pub fn target() -> TargetResult {
             executables: true,
             panic_strategy: PanicStrategy::Abort,
             relocation_model: "static".to_string(),
+            emit_debug_gdb_scripts: false,
             abi_blacklist: vec![
                 Abi::Cdecl,
                 Abi::Stdcall,


### PR DESCRIPTION
Same as the other embedded targets, see:
https://github.com/rust-lang/rust/pull/49728

This is a temporary workaround for #44993.