### PR TITLE
Re-enable drop-locations debuginfo tests.

### DIFF
--- a/src/test/debuginfo/drop-locations.rs
+++ b/src/test/debuginfo/drop-locations.rs
@@ -10,13 +10,11 @@
 
 // ignore-windows
 // ignore-android
-// ignore-test // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 // min-lldb-version: 310
 
 #![allow(unused)]
 
-// compile-flags:-g -O -C no-prepopulate-passes
-// -O -C no-prepopulate-passes added to work around https://bugs.llvm.org/show_bug.cgi?id=32123
+// compile-flags:-g
 
 // This test checks that drop glue code gets attributed to scope's closing brace,
 // and function epilogues - to function's closing brace.
@@ -90,4 +88,5 @@ fn foo() {
 
 } // #loc4
 
+#[inline(never)]
 fn zzz() {()}


### PR DESCRIPTION
The `-O -C no-prepopulate-passes` workaround doesn't seem to be needed anymore, so it works again for my version of GDB. Let's see what CI says.

