### PR TITLE
[NLL] Returns are interesting for free regions

### DIFF
--- a/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/mod.rs
@@ -453,7 +453,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                 diag.span_label(span, format!(
                     "{} was supposed to return data with lifetime `{}` but it is returning \
                     data with lifetime `{}`",
-                    mir_def_name, fr_name, outlived_fr_name,
+                    mir_def_name, outlived_fr_name, fr_name
                 ));
             },
             _ => {

--- a/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/mod.rs
@@ -42,7 +42,7 @@ impl fmt::Display for ConstraintCategory {
         // Must end with a space. Allows for empty names to be provided.
         match self {
             ConstraintCategory::Assignment => write!(f, "assignment "),
-            ConstraintCategory::Return => write!(f, "return "),
+            ConstraintCategory::Return => write!(f, "returning this value "),
             ConstraintCategory::Cast => write!(f, "cast "),
             ConstraintCategory::CallArgument => write!(f, "argument "),
             _ => write!(f, ""),

--- a/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/mod.rs
@@ -14,7 +14,7 @@ use rustc::hir::def_id::DefId;
 use rustc::infer::error_reporting::nice_region_error::NiceRegionError;
 use rustc::infer::InferCtxt;
 use rustc::mir::{self, Location, Mir, Place, Rvalue, StatementKind, TerminatorKind};
-use rustc::ty::RegionVid;
+use rustc::ty::{TyCtxt, RegionVid};
 use rustc_data_structures::indexed_vec::IndexVec;
 use rustc_errors::Diagnostic;
 use std::collections::VecDeque;
@@ -67,6 +67,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
     fn best_blame_constraint(
         &self,
         mir: &Mir<'tcx>,
+        tcx: TyCtxt<'_, '_, 'tcx>,
         from_region: RegionVid,
         target_test: impl Fn(RegionVid) -> bool,
     ) -> (ConstraintCategory, Span, RegionVid) {
@@ -92,7 +93,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         // Classify each of the constraints along the path.
         let mut categorized_path: Vec<(ConstraintCategory, Span)> = path
             .iter()
-            .map(|&index| self.classify_constraint(index, mir))
+            .map(|&index| self.classify_constraint(index, mir, tcx))
             .collect();
         debug!(
             "best_blame_constraint: categorized_path={:#?}",
@@ -231,6 +232,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         &self,
         index: ConstraintIndex,
         mir: &Mir<'tcx>,
+        tcx: TyCtxt<'_, '_, 'tcx>,
     ) -> (ConstraintCategory, Span) {
         let constraint = self.constraints[index];
         debug!("classify_constraint: constraint={:?}", constraint);
@@ -254,7 +256,34 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                 debug!("classify_constraint: terminator.kind={:?}", terminator.kind);
                 match terminator.kind {
                     TerminatorKind::DropAndReplace { .. } => ConstraintCategory::Assignment,
-                    TerminatorKind::Call { .. } => ConstraintCategory::CallArgument,
+                    // Classify calls differently depending on whether or not
+                    // the sub region appears in the destination type (so the
+                    // sup region is in the return type). If the return type
+                    // contains the sub-region, then this is either an
+                    // assignment or a return, depending on whether we are
+                    // writing to the RETURN_PLACE or not.
+                    //
+                    // The idea here is that the region is being propagated
+                    // from an input into the output place, so it's a kind of
+                    // assignment. Otherwise, if the sub-region only appears in
+                    // the argument types, then use the CallArgument
+                    // classification.
+                    TerminatorKind::Call { destination: Some((ref place, _)), .. } => {
+                        if tcx.any_free_region_meets(
+                            &place.ty(mir, tcx).to_ty(tcx),
+                            |region| self.to_region_vid(region) == constraint.sub,
+                        ) {
+                            match place {
+                                Place::Local(mir::RETURN_PLACE) => ConstraintCategory::Return,
+                                _ => ConstraintCategory::Assignment,
+                            }
+                        } else {
+                            ConstraintCategory::CallArgument
+                        }
+                    }
+                    TerminatorKind::Call { destination: None, .. } => {
+                        ConstraintCategory::CallArgument
+                    }
                     _ => ConstraintCategory::Other,
                 }
             } else {
@@ -304,7 +333,12 @@ impl<'tcx> RegionInferenceContext<'tcx> {
     ) {
         debug!("report_error(fr={:?}, outlived_fr={:?})", fr, outlived_fr);
 
-        let (category, span, _) = self.best_blame_constraint(mir, fr, |r| r == outlived_fr);
+        let (category, span, _) = self.best_blame_constraint(
+            mir,
+            infcx.tcx,
+            fr,
+            |r| r == outlived_fr
+        );
 
         // Check if we can use one of the "nice region errors".
         if let (Some(f), Some(o)) = (self.to_error_region(fr), self.to_error_region(outlived_fr)) {
@@ -446,10 +480,11 @@ impl<'tcx> RegionInferenceContext<'tcx> {
     crate fn find_outlives_blame_span(
         &self,
         mir: &Mir<'tcx>,
+        tcx: TyCtxt<'_, '_, 'tcx>,
         fr1: RegionVid,
         fr2: RegionVid,
     ) -> Span {
-        let (_, span, _) = self.best_blame_constraint(mir, fr1, |r| r == fr2);
+        let (_, span, _) = self.best_blame_constraint(mir, tcx, fr1, |r| r == fr2);
         span
     }
 }

--- a/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/mod.rs
@@ -124,13 +124,15 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             let constraint = &self.constraints[path[i]];
 
             let constraint_sup_scc = self.constraint_sccs.scc(constraint.sup);
-            if constraint_sup_scc == target_scc {
-                return false;
-            }
 
             match categorized_path[i].0 {
                 ConstraintCategory::Boring => false,
-                _ => true,
+                ConstraintCategory::Other => {
+                    // other isn't interesting when the two lifetimes
+                    // are unified.
+                    constraint_sup_scc != self.constraint_sccs.scc(constraint.sub)
+                }
+                _ => constraint_sup_scc != target_scc,
             }
         });
         if let Some(i) = best_choice {

--- a/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/region_name.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/region_name.rs
@@ -587,7 +587,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             infcx.extract_type_name(&return_ty)
         });
 
-                let mir_node_id = tcx.hir.as_local_node_id(mir_def_id).expect("non-local mir");
+        let mir_node_id = tcx.hir.as_local_node_id(mir_def_id).expect("non-local mir");
 
         let (return_span, mir_description) = if let hir::ExprKind::Closure(_, _, _, span, gen_move)
             = tcx.hir.expect_expr(mir_node_id).node

--- a/src/librustc_mir/borrow_check/nll/region_infer/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/mod.rs
@@ -1040,7 +1040,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                 longer_fr, shorter_fr,
             );
 
-            let blame_span = self.find_outlives_blame_span(mir, longer_fr, shorter_fr);
+            let blame_span = self.find_outlives_blame_span(mir, infcx.tcx, longer_fr, shorter_fr);
 
             if let Some(propagated_outlives_requirements) = propagated_outlives_requirements {
                 // Shrink `fr` until we find a non-local region (if we do).
@@ -1128,7 +1128,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         };
 
         // Find the code to blame for the fact that `longer_fr` outlives `error_fr`.
-        let span = self.find_outlives_blame_span(mir, longer_fr, error_region);
+        let span = self.find_outlives_blame_span(mir, infcx.tcx, longer_fr, error_region);
 
         // Obviously, this error message is far from satisfactory.
         // At present, though, it only appears in unit tests --

--- a/src/test/ui/associated-types/cache/project-fn-ret-contravariant.krisskross.nll.stderr
+++ b/src/test/ui/associated-types/cache/project-fn-ret-contravariant.krisskross.nll.stderr
@@ -18,7 +18,7 @@ LL | fn transmute<'a,'b>(x: &'a u32, y: &'b u32) -> (&'a u32, &'b u32) {
    |              |
    |              lifetime `'a` defined here
 LL |    let a = bar(foo, y);
-   |            ^^^^^^^^^^^ argument requires that `'b` must outlive `'a`
+   |            ^^^^^^^^^^^ assignment requires that `'b` must outlive `'a`
 
 error: unsatisfied lifetime constraints
   --> $DIR/project-fn-ret-contravariant.rs:54:12
@@ -29,7 +29,7 @@ LL | fn transmute<'a,'b>(x: &'a u32, y: &'b u32) -> (&'a u32, &'b u32) {
    |              lifetime `'a` defined here
 LL |    let a = bar(foo, y);
 LL |    let b = bar(foo, x);
-   |            ^^^^^^^^^^^ argument requires that `'a` must outlive `'b`
+   |            ^^^^^^^^^^^ assignment requires that `'a` must outlive `'b`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/associated-types/cache/project-fn-ret-contravariant.transmute.nll.stderr
+++ b/src/test/ui/associated-types/cache/project-fn-ret-contravariant.transmute.nll.stderr
@@ -4,13 +4,13 @@ warning: not reporting region error due to nll
 LL |    bar(foo, x) //[transmute]~ ERROR E0495
    |        ^^^
 
-error: borrowed data escapes outside of function
+error: unsatisfied lifetime constraints
   --> $DIR/project-fn-ret-contravariant.rs:48:4
    |
 LL | fn baz<'a,'b>(x: &'a u32) -> &'static u32 {
-   |               - `x` is a reference that is only valid in the function body
+   |        -- lifetime `'a` defined here
 LL |    bar(foo, x) //[transmute]~ ERROR E0495
-   |    ^^^^^^^^^^^ `x` escapes the function body here
+   |    ^^^^^^^^^^^ returning this value requires that `'a` must outlive `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/associated-types/cache/project-fn-ret-invariant.krisskross.nll.stderr
+++ b/src/test/ui/associated-types/cache/project-fn-ret-invariant.krisskross.nll.stderr
@@ -18,7 +18,7 @@ LL | fn transmute<'a,'b>(x: Type<'a>, y: Type<'b>) -> (Type<'a>, Type<'b>) {
    |              |
    |              lifetime `'a` defined here
 LL |    let a = bar(foo, y); //[krisskross]~ ERROR E0623
-   |            ^^^^^^^^^^^ argument requires that `'b` must outlive `'a`
+   |            ^^^^^^^^^^^ assignment requires that `'b` must outlive `'a`
 
 error: unsatisfied lifetime constraints
   --> $DIR/project-fn-ret-invariant.rs:64:12
@@ -29,7 +29,7 @@ LL | fn transmute<'a,'b>(x: Type<'a>, y: Type<'b>) -> (Type<'a>, Type<'b>) {
    |              lifetime `'a` defined here
 LL |    let a = bar(foo, y); //[krisskross]~ ERROR E0623
 LL |    let b = bar(foo, x);
-   |            ^^^^^^^^^^^ argument requires that `'a` must outlive `'b`
+   |            ^^^^^^^^^^^ assignment requires that `'a` must outlive `'b`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/associated-types/cache/project-fn-ret-invariant.transmute.nll.stderr
+++ b/src/test/ui/associated-types/cache/project-fn-ret-invariant.transmute.nll.stderr
@@ -4,14 +4,14 @@ warning: not reporting region error due to nll
 LL |    bar(foo, x) //[transmute]~ ERROR E0495
    |        ^^^
 
-error: borrowed data escapes outside of function
+error: unsatisfied lifetime constraints
   --> $DIR/project-fn-ret-invariant.rs:58:4
    |
 LL | fn baz<'a,'b>(x: Type<'a>) -> Type<'static> {
-   |               - `x` is a reference that is only valid in the function body
+   |        -- lifetime `'a` defined here
 ...
 LL |    bar(foo, x) //[transmute]~ ERROR E0495
-   |    ^^^^^^^^^^^ `x` escapes the function body here
+   |    ^^^^^^^^^^^ returning this value requires that `'a` must outlive `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-describe-lvalue.ast.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-describe-lvalue.ast.nll.stderr
@@ -35,7 +35,7 @@ LL | |                    //[mir]~^ ERROR cannot borrow `x` as mutable more than
 LL | |                    *y = 1;
 LL | |                    drop(y);
 LL | |                 }
-   | |_________________^ requires that `'1` must outlive `'2`
+   | |_________________^ returning this value requires that `'1` must outlive `'2`
    |
    = note: closure implements `FnMut`, so references to captured variables can't escape the closure
 

--- a/src/test/ui/borrowck/borrowck-describe-lvalue.mir.stderr
+++ b/src/test/ui/borrowck/borrowck-describe-lvalue.mir.stderr
@@ -35,7 +35,7 @@ LL | |                    //[mir]~^ ERROR cannot borrow `x` as mutable more than
 LL | |                    *y = 1;
 LL | |                    drop(y);
 LL | |                 }
-   | |_________________^ requires that `'1` must outlive `'2`
+   | |_________________^ returning this value requires that `'1` must outlive `'2`
    |
    = note: closure implements `FnMut`, so references to captured variables can't escape the closure
 

--- a/src/test/ui/borrowck/borrowck-reborrow-from-shorter-lived-andmut.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-reborrow-from-shorter-lived-andmut.nll.stderr
@@ -5,14 +5,14 @@ LL |     S { pointer: &mut *p.pointer }
    |                  ^^^^^^^^^^^^^^^
 
 error: unsatisfied lifetime constraints
-  --> $DIR/borrowck-reborrow-from-shorter-lived-andmut.rs:19:18
+  --> $DIR/borrowck-reborrow-from-shorter-lived-andmut.rs:19:5
    |
 LL | fn copy_borrowed_ptr<'a,'b>(p: &'a mut S<'b>) -> S<'b> {
    |                      -- -- lifetime `'b` defined here
    |                      |
    |                      lifetime `'a` defined here
 LL |     S { pointer: &mut *p.pointer }
-   |                  ^^^^^^^^^^^^^^^ requires that `'a` must outlive `'b`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0621-does-not-trigger-for-closures.nll.stderr
+++ b/src/test/ui/error-codes/E0621-does-not-trigger-for-closures.nll.stderr
@@ -5,10 +5,10 @@ LL |     invoke(&x, |a, b| if a > b { a } else { b }); //~ ERROR E0495
    |     ^^^^^^
 
 error: unsatisfied lifetime constraints
-  --> $DIR/E0621-does-not-trigger-for-closures.rs:25:26
+  --> $DIR/E0621-does-not-trigger-for-closures.rs:25:45
    |
 LL |     invoke(&x, |a, b| if a > b { a } else { b }); //~ ERROR E0495
-   |                    --    ^^^^^ requires that `'1` must outlive `'2`
+   |                    --                       ^ returning this value requires that `'1` must outlive `'2`
    |                    ||
    |                    |return type of closure is &'2 i32
    |                    has type `&'1 i32`

--- a/src/test/ui/impl-trait/must_outlive_least_region_or_bound.nll.stderr
+++ b/src/test/ui/impl-trait/must_outlive_least_region_or_bound.nll.stderr
@@ -40,13 +40,13 @@ error: unsatisfied lifetime constraints
   --> $DIR/must_outlive_least_region_or_bound.rs:16:44
    |
 LL | fn explicit<'a>(x: &'a i32) -> impl Copy { x }
-   |             -- lifetime `'a` defined here  ^ return requires that `'a` must outlive `'static`
+   |             -- lifetime `'a` defined here  ^ returning this value requires that `'a` must outlive `'static`
 
 error: unsatisfied lifetime constraints
   --> $DIR/must_outlive_least_region_or_bound.rs:22:69
    |
 LL | fn with_bound<'a>(x: &'a i32) -> impl LifetimeTrait<'a> + 'static { x }
-   |               -- lifetime `'a` defined here                         ^ return requires that `'a` must outlive `'static`
+   |               -- lifetime `'a` defined here                         ^ returning this value requires that `'a` must outlive `'static`
 
 error: unsatisfied lifetime constraints
   --> $DIR/must_outlive_least_region_or_bound.rs:29:5
@@ -57,7 +57,7 @@ LL | fn move_lifetime_into_fn<'a, 'b>(x: &'a u32, y: &'b u32) -> impl Fn(&'a u32
    |                          lifetime `'a` defined here
 LL |     //~^ ERROR lifetime mismatch
 LL |     move |_| println!("{}", y)
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ function was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
 
 error[E0310]: the parameter type `T` may not live long enough
   --> $DIR/must_outlive_least_region_or_bound.rs:34:5

--- a/src/test/ui/in-band-lifetimes/mismatched.nll.stderr
+++ b/src/test/ui/in-band-lifetimes/mismatched.nll.stderr
@@ -22,7 +22,7 @@ error: unsatisfied lifetime constraints
   --> $DIR/mismatched.rs:16:46
    |
 LL | fn foo2(x: &'a u32, y: &'b u32) -> &'a u32 { y } //~ ERROR lifetime mismatch
-   |             --          --                   ^ function was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
+   |             --          --                   ^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
    |             |           |
    |             |           lifetime `'b` defined here
    |             lifetime `'a` defined here

--- a/src/test/ui/issues/issue-14285.nll.stderr
+++ b/src/test/ui/issues/issue-14285.nll.stderr
@@ -5,12 +5,12 @@ LL |     B(a)    //~ ERROR 22:5: 22:9: explicit lifetime required in the type of
    |       ^
 
 error[E0621]: explicit lifetime required in the type of `a`
-  --> $DIR/issue-14285.rs:22:7
+  --> $DIR/issue-14285.rs:22:5
    |
 LL | fn foo<'a>(a: &Foo) -> B<'a> {
    |               ---- help: add explicit lifetime `'a` to the type of `a`: `&'a (dyn Foo + 'a)`
 LL |     B(a)    //~ ERROR 22:5: 22:9: explicit lifetime required in the type of `a` [E0621]
-   |       ^ lifetime `'a` required
+   |     ^^^^ lifetime `'a` required
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-15034.nll.stderr
+++ b/src/test/ui/issues/issue-15034.nll.stderr
@@ -5,12 +5,12 @@ LL |         Parser { lexer: lexer }
    |         ^^^^^^
 
 error[E0621]: explicit lifetime required in the type of `lexer`
-  --> $DIR/issue-15034.rs:27:25
+  --> $DIR/issue-15034.rs:27:9
    |
 LL |     pub fn new(lexer: &'a mut Lexer) -> Parser<'a> {
    |                       ------------- help: add explicit lifetime `'a` to the type of `lexer`: `&'a mut Lexer<'a>`
 LL |         Parser { lexer: lexer }
-   |                         ^^^^^ lifetime `'a` required
+   |         ^^^^^^^^^^^^^^^^^^^^^^^ lifetime `'a` required
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-3154.nll.stderr
+++ b/src/test/ui/issues/issue-3154.nll.stderr
@@ -11,12 +11,12 @@ LL |     thing{ x: x } //~ ERROR 16:5: 16:18: explicit lifetime required in the 
    |     ^^^^^
 
 error[E0621]: explicit lifetime required in the type of `x`
-  --> $DIR/issue-3154.rs:16:15
+  --> $DIR/issue-3154.rs:16:5
    |
 LL | fn thing<'a,Q>(x: &Q) -> thing<'a,Q> {
    |                   -- help: add explicit lifetime `'a` to the type of `x`: `&'a Q`
 LL |     thing{ x: x } //~ ERROR 16:5: 16:18: explicit lifetime required in the type of `x` [E0621]
-   |               ^ lifetime `'a` required
+   |     ^^^^^^^^^^^^^ lifetime `'a` required
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-40510-1.nll.stderr
+++ b/src/test/ui/issues/issue-40510-1.nll.stderr
@@ -7,7 +7,7 @@ LL |     || {
    |     |return type of closure is &'2 mut std::boxed::Box<()>
    |     lifetime `'1` represents this closure's body
 LL |         &mut x
-   |         ^^^^^^ return requires that `'1` must outlive `'2`
+   |         ^^^^^^ returning this value requires that `'1` must outlive `'2`
    |
    = note: closure implements `FnMut`, so references to captured variables can't escape the closure
 

--- a/src/test/ui/issues/issue-40510-3.nll.stderr
+++ b/src/test/ui/issues/issue-40510-3.nll.stderr
@@ -9,7 +9,7 @@ LL |       || {
 LL | /         || {
 LL | |             x.push(())
 LL | |         }
-   | |_________^ requires that `'1` must outlive `'2`
+   | |_________^ returning this value requires that `'1` must outlive `'2`
    |
    = note: closure implements `FnMut`, so references to captured variables can't escape the closure
 

--- a/src/test/ui/issues/issue-49824.nll.stderr
+++ b/src/test/ui/issues/issue-49824.nll.stderr
@@ -9,7 +9,7 @@ LL |       || {
 LL | /         || {
 LL | |             let _y = &mut x;
 LL | |         }
-   | |_________^ requires that `'1` must outlive `'2`
+   | |_________^ returning this value requires that `'1` must outlive `'2`
    |
    = note: closure implements `FnMut`, so references to captured variables can't escape the closure
 

--- a/src/test/ui/issues/issue-52213.nll.stderr
+++ b/src/test/ui/issues/issue-52213.nll.stderr
@@ -5,7 +5,7 @@ LL |     match (&t,) { //~ ERROR cannot infer an appropriate lifetime
    |           ^^^^^
 
 error: unsatisfied lifetime constraints
-  --> $DIR/issue-52213.rs:13:11
+  --> $DIR/issue-52213.rs:13:20
    |
 LL | fn transmute_lifetime<'a, 'b, T>(t: &'a (T,)) -> &'b T {
    |                       --  -- lifetime `'b` defined here
@@ -13,7 +13,7 @@ LL | fn transmute_lifetime<'a, 'b, T>(t: &'a (T,)) -> &'b T {
    |                       lifetime `'a` defined here
 LL |     match (&t,) { //~ ERROR cannot infer an appropriate lifetime
 LL |         ((u,),) => u,
-   |           ^ requires that `'a` must outlive `'b`
+   |                    ^ returning this value requires that `'a` must outlive `'b`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-52533-1.nll.stderr
+++ b/src/test/ui/issues/issue-52533-1.nll.stderr
@@ -8,7 +8,7 @@ error: unsatisfied lifetime constraints
   --> $DIR/issue-52533-1.rs:19:18
    |
 LL |     gimme(|x, y| y)
-   |            -  -  ^ closure was supposed to return data with lifetime `'1` but it is returning data with lifetime `'2`
+   |            -  -  ^ closure was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |            |  |
    |            |  has type `&Foo<'_, '1, u32>`
    |            has type `&Foo<'_, '2, u32>`

--- a/src/test/ui/issues/issue-52533.nll.stderr
+++ b/src/test/ui/issues/issue-52533.nll.stderr
@@ -8,7 +8,7 @@ error: unsatisfied lifetime constraints
   --> $DIR/issue-52533.rs:15:16
    |
 LL |     foo(|a, b| b)
-   |          -  -  ^ closure was supposed to return data with lifetime `'1` but it is returning data with lifetime `'2`
+   |          -  -  ^ closure was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |          |  |
    |          |  has type `&'1 u32`
    |          has type `&'2 u32`

--- a/src/test/ui/lifetimes/lifetime-errors/42701_one_named_and_one_anonymous.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/42701_one_named_and_one_anonymous.nll.stderr
@@ -5,17 +5,13 @@ LL |         &*x //~ ERROR explicit lifetime
    |         ^^^
 
 error[E0621]: explicit lifetime required in the type of `x`
-  --> $DIR/42701_one_named_and_one_anonymous.rs:16:5
+  --> $DIR/42701_one_named_and_one_anonymous.rs:20:9
    |
-LL |   fn foo2<'a>(a: &'a Foo, x: &i32) -> &'a i32 {
-   |                              ---- help: add explicit lifetime `'a` to the type of `x`: `&'a i32`
-LL | /     if true {
-LL | |         let p: &i32 = &a.field;
-LL | |         &*p
-LL | |     } else {
-LL | |         &*x //~ ERROR explicit lifetime
-LL | |     }
-   | |_____^ lifetime `'a` required
+LL | fn foo2<'a>(a: &'a Foo, x: &i32) -> &'a i32 {
+   |                            ---- help: add explicit lifetime `'a` to the type of `x`: `&'a i32`
+...
+LL |         &*x //~ ERROR explicit lifetime
+   |         ^^^ lifetime `'a` required
 
 error: aborting due to previous error
 

--- a/src/test/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-early-bound-in-struct.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-early-bound-in-struct.nll.stderr
@@ -5,12 +5,13 @@ LL |                     other //~ ERROR explicit lifetime
    |                     ^^^^^
 
 error[E0621]: explicit lifetime required in the type of `other`
-  --> $DIR/ex1-return-one-existing-name-early-bound-in-struct.rs:18:15
+  --> $DIR/ex1-return-one-existing-name-early-bound-in-struct.rs:21:21
    |
 LL |     fn bar(&self, other: Foo) -> Foo<'a> {
    |                          --- help: add explicit lifetime `'a` to the type of `other`: `Foo<'a>`
-LL |         match *self {
-   |               ^^^^^ lifetime `'a` required
+...
+LL |                     other //~ ERROR explicit lifetime
+   |                     ^^^^^ lifetime `'a` required
 
 error: aborting due to previous error
 

--- a/src/test/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-if-else-2.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-if-else-2.nll.stderr
@@ -5,12 +5,12 @@ LL |     if x > y { x } else { y } //~ ERROR explicit lifetime
    |                ^
 
 error[E0621]: explicit lifetime required in the type of `x`
-  --> $DIR/ex1-return-one-existing-name-if-else-2.rs:12:8
+  --> $DIR/ex1-return-one-existing-name-if-else-2.rs:12:16
    |
 LL | fn foo<'a>(x: &i32, y: &'a i32) -> &'a i32 {
    |               ---- help: add explicit lifetime `'a` to the type of `x`: `&'a i32`
 LL |     if x > y { x } else { y } //~ ERROR explicit lifetime
-   |        ^^^^^ lifetime `'a` required
+   |                ^ lifetime `'a` required
 
 error: aborting due to previous error
 

--- a/src/test/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-if-else-3.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-if-else-3.nll.stderr
@@ -5,12 +5,12 @@ LL |     if x > y { x } else { y } //~ ERROR explicit lifetime
    |                           ^
 
 error[E0621]: explicit lifetime required in parameter type
-  --> $DIR/ex1-return-one-existing-name-if-else-3.rs:11:16
+  --> $DIR/ex1-return-one-existing-name-if-else-3.rs:12:27
    |
 LL | fn foo<'a>((x, y): (&'a i32, &i32)) -> &'a i32 {
-   |                ^   --------------- help: add explicit lifetime `'a` to type: `(&'a i32, &'a i32)`
-   |                |
-   |                lifetime `'a` required
+   |                    --------------- help: add explicit lifetime `'a` to type: `(&'a i32, &'a i32)`
+LL |     if x > y { x } else { y } //~ ERROR explicit lifetime
+   |                           ^ lifetime `'a` required
 
 error: aborting due to previous error
 

--- a/src/test/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-if-else-using-impl-2.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-if-else-using-impl-2.nll.stderr
@@ -5,12 +5,12 @@ LL |    if x > y { x } else { y } //~ ERROR explicit lifetime
    |               ^
 
 error[E0621]: explicit lifetime required in the type of `x`
-  --> $DIR/ex1-return-one-existing-name-if-else-using-impl-2.rs:14:7
+  --> $DIR/ex1-return-one-existing-name-if-else-using-impl-2.rs:14:15
    |
 LL | fn foo<'a>(x: &i32, y: &'a i32) -> &'a i32 {
    |               ---- help: add explicit lifetime `'a` to the type of `x`: `&'a i32`
 LL |    if x > y { x } else { y } //~ ERROR explicit lifetime
-   |       ^^^^^ lifetime `'a` required
+   |               ^ lifetime `'a` required
 
 error: aborting due to previous error
 

--- a/src/test/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-if-else-using-impl-3.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-if-else-using-impl-3.nll.stderr
@@ -5,13 +5,13 @@ LL |     if true { &self.field } else { x } //~ ERROR explicit lifetime
    |                                    ^
 
 error[E0621]: explicit lifetime required in the type of `x`
-  --> $DIR/ex1-return-one-existing-name-if-else-using-impl-3.rs:18:5
+  --> $DIR/ex1-return-one-existing-name-if-else-using-impl-3.rs:18:36
    |
 LL |   fn foo<'a>(&'a self, x: &i32) -> &i32 {
    |                           ---- help: add explicit lifetime `'a` to the type of `x`: `&'a i32`
 LL | 
 LL |     if true { &self.field } else { x } //~ ERROR explicit lifetime
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ lifetime `'a` required
+   |                                    ^ lifetime `'a` required
 
 error: aborting due to previous error
 

--- a/src/test/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-if-else-using-impl.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-if-else-using-impl.nll.stderr
@@ -5,7 +5,7 @@ LL |         if x > y { x } else { y } //~ ERROR lifetime mismatch
    |                    ^
 
 error: unsatisfied lifetime constraints
-  --> $DIR/ex1-return-one-existing-name-if-else-using-impl.rs:21:12
+  --> $DIR/ex1-return-one-existing-name-if-else-using-impl.rs:21:20
    |
 LL |     fn foo<'a>(x: &i32, y: &'a i32) -> &'a i32 {
    |            --     - let's call the lifetime of this reference `'1`
@@ -13,7 +13,7 @@ LL |     fn foo<'a>(x: &i32, y: &'a i32) -> &'a i32 {
    |            lifetime `'a` defined here
 LL | 
 LL |         if x > y { x } else { y } //~ ERROR lifetime mismatch
-   |            ^^^^^ requires that `'1` must outlive `'a`
+   |                    ^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'1`
 
 error: aborting due to previous error
 

--- a/src/test/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-if-else.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-if-else.nll.stderr
@@ -5,12 +5,12 @@ LL |     if x > y { x } else { y } //~ ERROR explicit lifetime
    |                           ^
 
 error[E0621]: explicit lifetime required in the type of `y`
-  --> $DIR/ex1-return-one-existing-name-if-else.rs:12:8
+  --> $DIR/ex1-return-one-existing-name-if-else.rs:12:27
    |
 LL | fn foo<'a>(x: &'a i32, y: &i32) -> &'a i32 {
    |                           ---- help: add explicit lifetime `'a` to the type of `y`: `&'a i32`
 LL |     if x > y { x } else { y } //~ ERROR explicit lifetime
-   |        ^^^^^ lifetime `'a` required
+   |                           ^ lifetime `'a` required
 
 error: aborting due to previous error
 

--- a/src/test/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-return-type-is-anon.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-return-type-is-anon.nll.stderr
@@ -13,7 +13,7 @@ LL |   fn foo<'a>(&self, x: &'a i32) -> &i32 {
    |          lifetime `'a` defined here
 LL | 
 LL |     x //~ ERROR lifetime mismatch
-   |     ^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'1`
+   |     ^ function was supposed to return data with lifetime `'1` but it is returning data with lifetime `'a`
 
 error: aborting due to previous error
 

--- a/src/test/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-self-is-anon.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-self-is-anon.nll.stderr
@@ -5,7 +5,7 @@ LL |         if true { x } else { self } //~ ERROR lifetime mismatch
    |                              ^^^^
 
 error: unsatisfied lifetime constraints
-  --> $DIR/ex1-return-one-existing-name-self-is-anon.rs:18:9
+  --> $DIR/ex1-return-one-existing-name-self-is-anon.rs:18:30
    |
 LL |     fn foo<'a>(&self, x: &'a Foo) -> &'a Foo {
    |            --  - let's call the lifetime of this reference `'1`
@@ -13,7 +13,7 @@ LL |     fn foo<'a>(&self, x: &'a Foo) -> &'a Foo {
    |            lifetime `'a` defined here
 LL | 
 LL |         if true { x } else { self } //~ ERROR lifetime mismatch
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'1` must outlive `'a`
+   |                              ^^^^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'1`
 
 error: aborting due to previous error
 

--- a/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-return-type-is-anon.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-return-type-is-anon.nll.stderr
@@ -12,7 +12,7 @@ LL |   fn foo<'a>(&self, x: &i32) -> &i32 {
    |              |
    |              let's call the lifetime of this reference `'2`
 LL |     x //~ ERROR lifetime mismatch
-   |     ^ function was supposed to return data with lifetime `'1` but it is returning data with lifetime `'2`
+   |     ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: aborting due to previous error
 

--- a/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-self-is-anon.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-self-is-anon.nll.stderr
@@ -5,14 +5,14 @@ LL |         if true { x } else { self } //~ ERROR lifetime mismatch
    |                   ^
 
 error: unsatisfied lifetime constraints
-  --> $DIR/ex3-both-anon-regions-self-is-anon.rs:17:9
+  --> $DIR/ex3-both-anon-regions-self-is-anon.rs:17:19
    |
 LL |     fn foo<'a>(&self, x: &Foo) -> &Foo {
    |                -         - let's call the lifetime of this reference `'1`
    |                |
    |                let's call the lifetime of this reference `'2`
 LL |         if true { x } else { self } //~ ERROR lifetime mismatch
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'1` must outlive `'2`
+   |                   ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: aborting due to previous error
 

--- a/src/test/ui/lub-if.nll.stderr
+++ b/src/test/ui/lub-if.nll.stderr
@@ -11,20 +11,22 @@ LL |         s  //~ ERROR E0312
    |         ^
 
 error: unsatisfied lifetime constraints
-  --> $DIR/lub-if.rs:34:8
+  --> $DIR/lub-if.rs:38:9
    |
 LL | pub fn opt_str2<'a>(maybestr: &'a Option<String>) -> &'static str {
    |                 -- lifetime `'a` defined here
-LL |     if maybestr.is_none() {
-   |        ^^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
+...
+LL |         s  //~ ERROR E0312
+   |         ^ returning this value requires that `'a` must outlive `'static`
 
 error: unsatisfied lifetime constraints
-  --> $DIR/lub-if.rs:43:8
+  --> $DIR/lub-if.rs:45:9
    |
 LL | pub fn opt_str3<'a>(maybestr: &'a Option<String>) -> &'static str {
    |                 -- lifetime `'a` defined here
-LL |     if maybestr.is_some() {
-   |        ^^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
+...
+LL |         s  //~ ERROR E0312
+   |         ^ returning this value requires that `'a` must outlive `'static`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/lub-match.nll.stderr
+++ b/src/test/ui/lub-match.nll.stderr
@@ -11,20 +11,22 @@ LL |             s //~ ERROR E0312
    |             ^
 
 error: unsatisfied lifetime constraints
-  --> $DIR/lub-match.rs:36:11
+  --> $DIR/lub-match.rs:40:13
    |
 LL | pub fn opt_str2<'a>(maybestr: &'a Option<String>) -> &'static str {
    |                 -- lifetime `'a` defined here
-LL |     match *maybestr {
-   |           ^^^^^^^^^ requires that `'a` must outlive `'static`
+...
+LL |             s //~ ERROR E0312
+   |             ^ returning this value requires that `'a` must outlive `'static`
 
 error: unsatisfied lifetime constraints
-  --> $DIR/lub-match.rs:46:11
+  --> $DIR/lub-match.rs:49:13
    |
 LL | pub fn opt_str3<'a>(maybestr: &'a Option<String>) -> &'static str {
    |                 -- lifetime `'a` defined here
-LL |     match *maybestr {
-   |           ^^^^^^^^^ requires that `'a` must outlive `'static`
+...
+LL |             s //~ ERROR E0312
+   |             ^ returning this value requires that `'a` must outlive `'static`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/match/match-ref-mut-invariance.nll.stderr
+++ b/src/test/ui/match/match-ref-mut-invariance.nll.stderr
@@ -15,7 +15,7 @@ LL |       fn bar<'a>(&'a mut self) -> &'a mut &'a i32 {
    | |            lifetime `'a` defined here
 LL | |         match self.0 { ref mut x => x } //~ ERROR mismatched types
 LL | |     }
-   | |_____^ requires that `'a` must outlive `'b`
+   | |_____^ returning this value requires that `'a` must outlive `'b`
 
 error: aborting due to previous error
 

--- a/src/test/ui/match/match-ref-mut-let-invariance.nll.stderr
+++ b/src/test/ui/match/match-ref-mut-let-invariance.nll.stderr
@@ -16,7 +16,7 @@ LL |       fn bar<'a>(&'a mut self) -> &'a mut &'a i32 {
 LL | |         let ref mut x = self.0;
 LL | |         x //~ ERROR mismatched types
 LL | |     }
-   | |_____^ requires that `'a` must outlive `'b`
+   | |_____^ returning this value requires that `'a` must outlive `'b`
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/closure-requirements/region-lbr-named-does-not-outlive-static.stderr
+++ b/src/test/ui/nll/closure-requirements/region-lbr-named-does-not-outlive-static.stderr
@@ -10,7 +10,7 @@ error: unsatisfied lifetime constraints
 LL | fn foo<'a>(x: &'a u32) -> &'static u32 {
    |        -- lifetime `'a` defined here
 LL |     &*x
-   |     ^^^ requires that `'a` must outlive `'static`
+   |     ^^^ returning this value requires that `'a` must outlive `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/closure-requirements/region-lbr1-does-not-outlive-ebr2.stderr
+++ b/src/test/ui/nll/closure-requirements/region-lbr1-does-not-outlive-ebr2.stderr
@@ -12,7 +12,7 @@ LL | fn foo<'a, 'b>(x: &'a u32, y: &'b u32) -> &'b u32 {
    |        |
    |        lifetime `'a` defined here
 LL |     &*x
-   |     ^^^ requires that `'a` must outlive `'b`
+   |     ^^^ function was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/closure-requirements/return-wrong-bound-region.stderr
+++ b/src/test/ui/nll/closure-requirements/return-wrong-bound-region.stderr
@@ -19,7 +19,7 @@ error: unsatisfied lifetime constraints
   --> $DIR/return-wrong-bound-region.rs:21:23
    |
 LL |     expect_sig(|a, b| b); // ought to return `a`
-   |                 -  -  ^ closure was supposed to return data with lifetime `'1` but it is returning data with lifetime `'2`
+   |                 -  -  ^ closure was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |                 |  |
    |                 |  has type `&'1 i32`
    |                 has type `&'2 i32`

--- a/src/test/ui/nll/issue-48238.stderr
+++ b/src/test/ui/nll/issue-48238.stderr
@@ -2,7 +2,7 @@ error: unsatisfied lifetime constraints
   --> $DIR/issue-48238.rs:21:13
    |
 LL |     move || use_val(&orig); //~ ERROR
-   |     ------- ^^^^^^^^^^^^^^ argument requires that `'1` must outlive `'2`
+   |     ------- ^^^^^^^^^^^^^^ returning this value requires that `'1` must outlive `'2`
    |     |     |
    |     |     return type of closure is &'2 u8
    |     lifetime `'1` represents this closure's body

--- a/src/test/ui/nll/mir_check_cast_closure.rs
+++ b/src/test/ui/nll/mir_check_cast_closure.rs
@@ -14,9 +14,9 @@
 
 fn bar<'a, 'b>() -> fn(&'a u32, &'b u32) -> &'a u32 {
     let g: fn(_, _) -> _ = |_x, y| y;
-    //~^ ERROR unsatisfied lifetime constraints
     g
     //~^ WARNING not reporting region error due to nll
+    //~^^ ERROR unsatisfied lifetime constraints
 }
 
 fn main() {}

--- a/src/test/ui/nll/mir_check_cast_closure.stderr
+++ b/src/test/ui/nll/mir_check_cast_closure.stderr
@@ -1,18 +1,19 @@
 warning: not reporting region error due to nll
-  --> $DIR/mir_check_cast_closure.rs:18:5
+  --> $DIR/mir_check_cast_closure.rs:17:5
    |
 LL |     g
    |     ^
 
 error: unsatisfied lifetime constraints
-  --> $DIR/mir_check_cast_closure.rs:16:28
+  --> $DIR/mir_check_cast_closure.rs:17:5
    |
 LL | fn bar<'a, 'b>() -> fn(&'a u32, &'b u32) -> &'a u32 {
    |        --  -- lifetime `'b` defined here
    |        |
    |        lifetime `'a` defined here
 LL |     let g: fn(_, _) -> _ = |_x, y| y;
-   |                            ^^^^^^^^^ cast requires that `'b` must outlive `'a`
+LL |     g
+   |     ^ returning this value requires that `'b` must outlive `'a`
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/mir_check_cast_reify.stderr
+++ b/src/test/ui/nll/mir_check_cast_reify.stderr
@@ -4,14 +4,14 @@ warning: not reporting region error due to nll
 LL |     let f: fn(_) -> _ = foo;
    |                         ^^^
 
-error: borrowed data escapes outside of function
+error: unsatisfied lifetime constraints
   --> $DIR/mir_check_cast_reify.rs:48:5
    |
 LL | fn bar<'a>(x: &'a u32) -> &'static u32 {
-   |            - `x` is a reference that is only valid in the function body
+   |        -- lifetime `'a` defined here
 ...
 LL |     f(x)
-   |     ^^^^ `x` escapes the function body here
+   |     ^^^^ returning this value requires that `'a` must outlive `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/mir_check_cast_unsafe_fn.stderr
+++ b/src/test/ui/nll/mir_check_cast_unsafe_fn.stderr
@@ -4,14 +4,14 @@ warning: not reporting region error due to nll
 LL |     let g: unsafe fn(_) -> _ = f;
    |                                ^
 
-error: borrowed data escapes outside of function
+error: unsatisfied lifetime constraints
   --> $DIR/mir_check_cast_unsafe_fn.rs:20:14
    |
 LL | fn bar<'a>(input: &'a u32, f: fn(&'a u32) -> &'a u32) -> &'static u32 {
-   |            ----- `input` is a reference that is only valid in the function body
+   |        -- lifetime `'a` defined here
 ...
 LL |     unsafe { g(input) }
-   |              ^^^^^^^^ `input` escapes the function body here
+   |              ^^^^^^^^ returning this value requires that `'a` must outlive `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/mir_check_cast_unsize.stderr
+++ b/src/test/ui/nll/mir_check_cast_unsize.stderr
@@ -15,7 +15,7 @@ LL | |     //~^ ERROR unsatisfied lifetime constraints
 LL | |     x
 LL | |     //~^ WARNING not reporting region error due to nll
 LL | | }
-   | |_^ return requires that `'a` must outlive `'static`
+   | |_^ returning this value requires that `'a` must outlive `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/object-lifetime/object-lifetime-default-elision.nll.stderr
+++ b/src/test/ui/object-lifetime/object-lifetime-default-elision.nll.stderr
@@ -18,7 +18,7 @@ LL | |     // for<'a,'b,'c>fn(&'a (SomeTrait+'c)) -> &'b (SomeTrait+'a)
 ...  |
 LL | |         //~| ERROR cannot infer
 LL | | }
-   | |_^ return requires that `'a` must outlive `'b`
+   | |_^ returning this value requires that `'a` must outlive `'b`
 
 error: aborting due to previous error
 

--- a/src/test/ui/object-lifetime/object-lifetime-default-mybox.nll.stderr
+++ b/src/test/ui/object-lifetime/object-lifetime-default-mybox.nll.stderr
@@ -19,7 +19,7 @@ LL | fn load1<'a,'b>(a: &'a MyBox<SomeTrait>,
    |          lifetime `'a` defined here
 ...
 LL |     a //~ ERROR lifetime mismatch
-   |     ^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
+   |     ^ function was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
 
 error: borrowed data escapes outside of function
   --> $DIR/object-lifetime-default-mybox.rs:41:5

--- a/src/test/ui/regions/region-object-lifetime-2.nll.stderr
+++ b/src/test/ui/regions/region-object-lifetime-2.nll.stderr
@@ -4,13 +4,15 @@ warning: not reporting region error due to nll
 LL |     x.borrowed() //~ ERROR cannot infer
    |       ^^^^^^^^
 
-error: borrowed data escapes outside of function
+error: unsatisfied lifetime constraints
   --> $DIR/region-object-lifetime-2.rs:20:5
    |
 LL | fn borrowed_receiver_different_lifetimes<'a,'b>(x: &'a Foo) -> &'b () {
-   |                                                 - `x` is a reference that is only valid in the function body
+   |                                          -- -- lifetime `'b` defined here
+   |                                          |
+   |                                          lifetime `'a` defined here
 LL |     x.borrowed() //~ ERROR cannot infer
-   |     ^^^^^^^^^^^^ `x` escapes the function body here
+   |     ^^^^^^^^^^^^ returning this value requires that `'a` must outlive `'b`
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/region-object-lifetime-in-coercion.nll.stderr
+++ b/src/test/ui/regions/region-object-lifetime-in-coercion.nll.stderr
@@ -67,7 +67,7 @@ LL |   fn d<'a,'b>(v: &'a [u8]) -> Box<Foo+'b> {
 LL | |     Box::new(v)
 LL | |         //~^ ERROR cannot infer an appropriate lifetime due to conflicting
 LL | | }
-   | |_^ return requires that `'a` must outlive `'b`
+   | |_^ returning this value requires that `'a` must outlive `'b`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/regions/regions-bounds.nll.stderr
+++ b/src/test/ui/regions/regions-bounds.nll.stderr
@@ -18,7 +18,7 @@ LL | fn a_fn1<'a,'b>(e: an_enum<'a>) -> an_enum<'b> {
    |          |
    |          lifetime `'a` defined here
 LL |     return e; //~ ERROR mismatched types
-   |            ^ return requires that `'a` must outlive `'b`
+   |            ^ returning this value requires that `'a` must outlive `'b`
 
 error: unsatisfied lifetime constraints
   --> $DIR/regions-bounds.rs:23:12
@@ -28,7 +28,7 @@ LL | fn a_fn3<'a,'b>(e: a_class<'a>) -> a_class<'b> {
    |          |
    |          lifetime `'a` defined here
 LL |     return e; //~ ERROR mismatched types
-   |            ^ return requires that `'a` must outlive `'b`
+   |            ^ returning this value requires that `'a` must outlive `'b`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/regions/regions-close-object-into-object-2.nll.stderr
+++ b/src/test/ui/regions/regions-close-object-into-object-2.nll.stderr
@@ -13,7 +13,7 @@ LL |   fn g<'a, T: 'static>(v: Box<A<T>+'a>) -> Box<X+'static> {
    | |      lifetime `'a` defined here
 LL | |     box B(&*v) as Box<X> //~ ERROR cannot infer
 LL | | }
-   | |_^ return requires that `'a` must outlive `'static`
+   | |_^ returning this value requires that `'a` must outlive `'static`
 
 error[E0597]: `*v` does not live long enough
   --> $DIR/regions-close-object-into-object-2.rs:20:11

--- a/src/test/ui/regions/regions-close-object-into-object-4.nll.stderr
+++ b/src/test/ui/regions/regions-close-object-into-object-4.nll.stderr
@@ -37,7 +37,7 @@ LL |   fn i<'a, T, U>(v: Box<A<U>+'a>) -> Box<X+'static> {
    | |      lifetime `'a` defined here
 LL | |     box B(&*v) as Box<X> //~ ERROR cannot infer
 LL | | }
-   | |_^ return requires that `'a` must outlive `'static`
+   | |_^ returning this value requires that `'a` must outlive `'static`
 
 error[E0310]: the parameter type `U` may not live long enough
   --> $DIR/regions-close-object-into-object-4.rs:20:5

--- a/src/test/ui/regions/regions-creating-enums3.nll.stderr
+++ b/src/test/ui/regions/regions-creating-enums3.nll.stderr
@@ -5,14 +5,14 @@ LL |     ast::add(x, y) //~ ERROR 17:5: 17:19: lifetime mismatch [E0623]
    |     ^^^^^^^^
 
 error: unsatisfied lifetime constraints
-  --> $DIR/regions-creating-enums3.rs:17:14
+  --> $DIR/regions-creating-enums3.rs:17:5
    |
 LL | fn mk_add_bad1<'a,'b>(x: &'a ast<'a>, y: &'b ast<'b>) -> ast<'a> {
    |                -- -- lifetime `'b` defined here
    |                |
    |                lifetime `'a` defined here
 LL |     ast::add(x, y) //~ ERROR 17:5: 17:19: lifetime mismatch [E0623]
-   |              ^ requires that `'b` must outlive `'a`
+   |     ^^^^^^^^^^^^^^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-creating-enums4.nll.stderr
+++ b/src/test/ui/regions/regions-creating-enums4.nll.stderr
@@ -5,14 +5,14 @@ LL |     ast::add(x, y) //~ ERROR cannot infer
    |     ^^^^^^^^
 
 error: unsatisfied lifetime constraints
-  --> $DIR/regions-creating-enums4.rs:17:14
+  --> $DIR/regions-creating-enums4.rs:17:5
    |
 LL | fn mk_add_bad2<'a,'b>(x: &'a ast<'a>, y: &'a ast<'a>, z: &ast) -> ast<'b> {
    |                -- -- lifetime `'b` defined here
    |                |
    |                lifetime `'a` defined here
 LL |     ast::add(x, y) //~ ERROR cannot infer
-   |              ^ requires that `'a` must outlive `'b`
+   |     ^^^^^^^^^^^^^^ returning this value requires that `'a` must outlive `'b`
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-early-bound-error-method.nll.stderr
+++ b/src/test/ui/regions/regions-early-bound-error-method.nll.stderr
@@ -12,7 +12,7 @@ LL | impl<'a> Box<'a> {
 LL |     fn or<'b,G:GetRef<'b>>(&self, g2: G) -> &'a isize {
    |           -- lifetime `'b` defined here
 LL |         g2.get()
-   |         ^^^^^^^^ argument requires that `'b` must outlive `'a`
+   |         ^^^^^^^^ returning this value requires that `'b` must outlive `'a`
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-early-bound-error.nll.stderr
+++ b/src/test/ui/regions/regions-early-bound-error.nll.stderr
@@ -12,7 +12,7 @@ LL | fn get<'a,'b,G:GetRef<'a, isize>>(g1: G, b: &'b isize) -> &'b isize {
    |        |
    |        lifetime `'a` defined here
 LL |     g1.get()
-   |     ^^^^^^^^ argument requires that `'a` must outlive `'b`
+   |     ^^^^^^^^ function was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-escape-method.nll.stderr
+++ b/src/test/ui/regions/regions-escape-method.nll.stderr
@@ -8,7 +8,7 @@ error: unsatisfied lifetime constraints
   --> $DIR/regions-escape-method.rs:25:13
    |
 LL |     s.f(|p| p) //~ ERROR cannot infer
-   |          -- ^ return requires that `'1` must outlive `'2`
+   |          -- ^ returning this value requires that `'1` must outlive `'2`
    |          ||
    |          |return type of closure is &'2 i32
    |          has type `&'1 i32`

--- a/src/test/ui/regions/regions-escape-via-trait-or-not.nll.stderr
+++ b/src/test/ui/regions/regions-escape-via-trait-or-not.nll.stderr
@@ -8,7 +8,7 @@ error: unsatisfied lifetime constraints
   --> $DIR/regions-escape-via-trait-or-not.rs:28:14
    |
 LL |     with(|o| o) //~ ERROR cannot infer
-   |           -- ^ return requires that `'1` must outlive `'2`
+   |           -- ^ returning this value requires that `'1` must outlive `'2`
    |           ||
    |           |return type of closure is &'2 isize
    |           has type `&'1 isize`

--- a/src/test/ui/regions/regions-free-region-ordering-callee.nll.stderr
+++ b/src/test/ui/regions/regions-free-region-ordering-callee.nll.stderr
@@ -19,7 +19,7 @@ LL | fn ordering2<'a, 'b>(x: &'a &'b usize, y: &'a usize) -> &'b usize {
    |              lifetime `'a` defined here
 LL |     // However, it is not safe to assume that 'b <= 'a
 LL |     &*y //~ ERROR 23:5: 23:8: lifetime mismatch [E0623]
-   |     ^^^ requires that `'a` must outlive `'b`
+   |     ^^^ function was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
 
 error: unsatisfied lifetime constraints
   --> $DIR/regions-free-region-ordering-callee.rs:28:24

--- a/src/test/ui/regions/regions-free-region-ordering-incorrect.nll.stderr
+++ b/src/test/ui/regions/regions-free-region-ordering-incorrect.nll.stderr
@@ -15,7 +15,7 @@ LL | /     match self.next {
 LL | |       Some(ref next) => next.get(),
 LL | |       None => &self.val //~ ERROR cannot infer
 LL | |     }
-   | |_____^ requires that `'a` must outlive `'b`
+   | |_____^ returning this value requires that `'a` must outlive `'b`
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-glb-free-free.nll.stderr
+++ b/src/test/ui/regions/regions-glb-free-free.nll.stderr
@@ -5,13 +5,17 @@ LL |             Flag { //~ ERROR 25:13: 30:14: explicit lifetime required in th
    |             ^^^^
 
 error[E0621]: explicit lifetime required in the type of `s`
-  --> $DIR/regions-glb-free-free.rs:26:23
+  --> $DIR/regions-glb-free-free.rs:25:13
    |
-LL |         pub fn set_desc(self, s: &str) -> Flag<'a> {
-   |                                  ---- help: add explicit lifetime `'a` to the type of `s`: `&'a str`
-LL |             Flag { //~ ERROR 25:13: 30:14: explicit lifetime required in the type of `s` [E0621]
-LL |                 name: self.name,
-   |                       ^^^^^^^^^ lifetime `'a` required
+LL |           pub fn set_desc(self, s: &str) -> Flag<'a> {
+   |                                    ---- help: add explicit lifetime `'a` to the type of `s`: `&'a str`
+LL | /             Flag { //~ ERROR 25:13: 30:14: explicit lifetime required in the type of `s` [E0621]
+LL | |                 name: self.name,
+LL | |                 desc: s,
+LL | |                 max_count: self.max_count,
+LL | |                 value: self.value
+LL | |             }
+   | |_____________^ lifetime `'a` required
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-infer-call-3.nll.stderr
+++ b/src/test/ui/regions/regions-infer-call-3.nll.stderr
@@ -4,13 +4,14 @@ warning: not reporting region error due to nll
 LL |     let z = with(|y| { select(x, y) });
    |                        ^^^^^^^^^^^^
 
-error: borrowed data escapes outside of closure
+error: unsatisfied lifetime constraints
   --> $DIR/regions-infer-call-3.rs:18:24
    |
 LL |     let z = with(|y| { select(x, y) });
-   |                   -    ^^^^^^^^^^^^ `y` escapes the closure body here
-   |                   |
-   |                   `y` is a reference that is only valid in the closure body
+   |                   --   ^^^^^^^^^^^^ returning this value requires that `'1` must outlive `'2`
+   |                   ||
+   |                   |return type of closure is &'2 isize
+   |                   has type `&'1 isize`
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-infer-invariance-due-to-decl.nll.stderr
+++ b/src/test/ui/regions/regions-infer-invariance-due-to-decl.nll.stderr
@@ -10,7 +10,7 @@ error: unsatisfied lifetime constraints
 LL | fn to_longer_lifetime<'r>(b_isize: invariant<'r>) -> invariant<'static> {
    |                       -- lifetime `'r` defined here
 LL |     b_isize //~ ERROR mismatched types
-   |     ^^^^^^^ return requires that `'r` must outlive `'static`
+   |     ^^^^^^^ returning this value requires that `'r` must outlive `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-infer-invariance-due-to-mutability-3.nll.stderr
+++ b/src/test/ui/regions/regions-infer-invariance-due-to-mutability-3.nll.stderr
@@ -10,7 +10,7 @@ error: unsatisfied lifetime constraints
 LL | fn to_longer_lifetime<'r>(b_isize: invariant<'r>) -> invariant<'static> {
    |                       -- lifetime `'r` defined here
 LL |     b_isize //~ ERROR mismatched types
-   |     ^^^^^^^ return requires that `'r` must outlive `'static`
+   |     ^^^^^^^ returning this value requires that `'r` must outlive `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-infer-invariance-due-to-mutability-4.nll.stderr
+++ b/src/test/ui/regions/regions-infer-invariance-due-to-mutability-4.nll.stderr
@@ -10,7 +10,7 @@ error: unsatisfied lifetime constraints
 LL | fn to_longer_lifetime<'r>(b_isize: Invariant<'r>) -> Invariant<'static> {
    |                       -- lifetime `'r` defined here
 LL |     b_isize //~ ERROR mismatched types
-   |     ^^^^^^^ return requires that `'r` must outlive `'static`
+   |     ^^^^^^^ returning this value requires that `'r` must outlive `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-infer-not-param.nll.stderr
+++ b/src/test/ui/regions/regions-infer-not-param.nll.stderr
@@ -14,7 +14,7 @@ error: unsatisfied lifetime constraints
   --> $DIR/regions-infer-not-param.rs:25:54
    |
 LL | fn take_direct<'a,'b>(p: direct<'a>) -> direct<'b> { p } //~ ERROR mismatched types
-   |                -- -- lifetime `'b` defined here      ^ return requires that `'a` must outlive `'b`
+   |                -- -- lifetime `'b` defined here      ^ returning this value requires that `'a` must outlive `'b`
    |                |
    |                lifetime `'a` defined here
 
@@ -22,7 +22,7 @@ error: unsatisfied lifetime constraints
   --> $DIR/regions-infer-not-param.rs:29:63
    |
 LL | fn take_indirect2<'a,'b>(p: indirect2<'a>) -> indirect2<'b> { p } //~ ERROR mismatched types
-   |                   -- -- lifetime `'b` defined here            ^ function was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
+   |                   -- -- lifetime `'b` defined here            ^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
    |                   |
    |                   lifetime `'a` defined here
 
@@ -30,7 +30,7 @@ error: unsatisfied lifetime constraints
   --> $DIR/regions-infer-not-param.rs:29:63
    |
 LL | fn take_indirect2<'a,'b>(p: indirect2<'a>) -> indirect2<'b> { p } //~ ERROR mismatched types
-   |                   -- -- lifetime `'b` defined here            ^ return requires that `'a` must outlive `'b`
+   |                   -- -- lifetime `'b` defined here            ^ returning this value requires that `'a` must outlive `'b`
    |                   |
    |                   lifetime `'a` defined here
 

--- a/src/test/ui/regions/regions-reborrow-from-shorter-mut-ref-mut-ref.nll.stderr
+++ b/src/test/ui/regions/regions-reborrow-from-shorter-mut-ref-mut-ref.nll.stderr
@@ -14,7 +14,7 @@ LL |   fn copy_borrowed_ptr<'a, 'b, 'c>(p: &'a mut &'b mut &'c mut isize) -> &'b
    | |                      lifetime `'a` defined here
 LL | |     &mut ***p //~ ERROR 14:5: 14:14: lifetime mismatch [E0623]
 LL | | }
-   | |_^ requires that `'a` must outlive `'b`
+   | |_^ function was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-reborrow-from-shorter-mut-ref.nll.stderr
+++ b/src/test/ui/regions/regions-reborrow-from-shorter-mut-ref.nll.stderr
@@ -14,7 +14,7 @@ LL |   fn copy_borrowed_ptr<'a, 'b>(p: &'a mut &'b mut isize) -> &'b mut isize {
    | |                      lifetime `'a` defined here
 LL | |     &mut **p //~ ERROR 16:5: 16:13: lifetime mismatch [E0623]
 LL | | }
-   | |_^ requires that `'a` must outlive `'b`
+   | |_^ function was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-ret-borrowed-1.nll.stderr
+++ b/src/test/ui/regions/regions-ret-borrowed-1.nll.stderr
@@ -8,7 +8,7 @@ error: unsatisfied lifetime constraints
   --> $DIR/regions-ret-borrowed-1.rs:20:14
    |
 LL |     with(|o| o)
-   |           -- ^ return requires that `'1` must outlive `'2`
+   |           -- ^ returning this value requires that `'1` must outlive `'2`
    |           ||
    |           |return type of closure is &'2 isize
    |           has type `&'1 isize`

--- a/src/test/ui/regions/regions-ret-borrowed.nll.stderr
+++ b/src/test/ui/regions/regions-ret-borrowed.nll.stderr
@@ -8,7 +8,7 @@ error: unsatisfied lifetime constraints
   --> $DIR/regions-ret-borrowed.rs:23:14
    |
 LL |     with(|o| o)
-   |           -- ^ return requires that `'1` must outlive `'2`
+   |           -- ^ returning this value requires that `'1` must outlive `'2`
    |           ||
    |           |return type of closure is &'2 isize
    |           has type `&'1 isize`

--- a/src/test/ui/regions/regions-return-ref-to-upvar-issue-17403.nll.stderr
+++ b/src/test/ui/regions/regions-return-ref-to-upvar-issue-17403.nll.stderr
@@ -8,7 +8,7 @@ error: unsatisfied lifetime constraints
   --> $DIR/regions-return-ref-to-upvar-issue-17403.rs:17:24
    |
 LL |         let mut f = || &mut x; //~ ERROR cannot infer
-   |                     -- ^^^^^^ return requires that `'1` must outlive `'2`
+   |                     -- ^^^^^^ returning this value requires that `'1` must outlive `'2`
    |                     ||
    |                     |return type of closure is &'2 mut i32
    |                     lifetime `'1` represents this closure's body

--- a/src/test/ui/regions/regions-static-bound.ll.nll.stderr
+++ b/src/test/ui/regions/regions-static-bound.ll.nll.stderr
@@ -22,7 +22,7 @@ error: unsatisfied lifetime constraints
 LL | fn static_id_wrong_way<'a>(t: &'a ()) -> &'static () where 'static: 'a {
    |                        -- lifetime `'a` defined here
 LL |     t //[ll]~ ERROR E0312
-   |     ^ return requires that `'a` must outlive `'static`
+   |     ^ returning this value requires that `'a` must outlive `'static`
 
 error[E0621]: explicit lifetime required in the type of `u`
   --> $DIR/regions-static-bound.rs:25:5

--- a/src/test/ui/regions/regions-static-bound.nll.stderr
+++ b/src/test/ui/regions/regions-static-bound.nll.stderr
@@ -22,7 +22,7 @@ error: unsatisfied lifetime constraints
 LL | fn static_id_wrong_way<'a>(t: &'a ()) -> &'static () where 'static: 'a {
    |                        -- lifetime `'a` defined here
 LL |     t //[ll]~ ERROR E0312
-   |     ^ return requires that `'a` must outlive `'static`
+   |     ^ returning this value requires that `'a` must outlive `'static`
 
 error[E0621]: explicit lifetime required in the type of `u`
   --> $DIR/regions-static-bound.rs:25:5

--- a/src/test/ui/regions/regions-trait-object-subtyping.nll.stderr
+++ b/src/test/ui/regions/regions-trait-object-subtyping.nll.stderr
@@ -22,7 +22,7 @@ LL | |     // Without knowing 'a:'b, we can't coerce
 LL | |     x //~ ERROR lifetime bound not satisfied
 LL | |      //~^ ERROR cannot infer an appropriate lifetime
 LL | | }
-   | |_^ return requires that `'a` must outlive `'b`
+   | |_^ returning this value requires that `'a` must outlive `'b`
 
 error: unsatisfied lifetime constraints
   --> $DIR/regions-trait-object-subtyping.rs:32:5
@@ -33,7 +33,7 @@ LL | fn foo4<'a:'b,'b>(x: Wrapper<&'a mut Dummy>) -> Wrapper<&'b mut Dummy> {
    |         lifetime `'a` defined here
 LL |     // We can't coerce because it is packed in `Wrapper`
 LL |     x //~ ERROR mismatched types
-   |     ^ return requires that `'b` must outlive `'a`
+   |     ^ returning this value requires that `'b` must outlive `'a`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/underscore-lifetime/dyn-trait-underscore.nll.stderr
+++ b/src/test/ui/underscore-lifetime/dyn-trait-underscore.nll.stderr
@@ -32,7 +32,7 @@ LL |   fn a<T>(items: &[T]) -> Box<dyn Iterator<Item=&T>> {
 LL | |     //                      ^^^^^^^^^^^^^^^^^^^^^ bound *here* defaults to `'static`
 LL | |     Box::new(items.iter()) //~ ERROR cannot infer an appropriate lifetime
 LL | | }
-   | |_^ return requires that `'1` must outlive `'static`
+   | |_^ returning this value requires that `'1` must outlive `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/variance/variance-btree-invariant-types.nll.stderr
+++ b/src/test/ui/variance/variance-btree-invariant-types.nll.stderr
@@ -76,7 +76,7 @@ error: unsatisfied lifetime constraints
 LL | fn iter_cov_key<'a, 'new>(v: IterMut<'a, &'static (), ()>) -> IterMut<'a, &'new (), ()> {
    |                     ---- lifetime `'new` defined here
 LL |     v //~ ERROR mismatched types
-   |     ^ return requires that `'new` must outlive `'static`
+   |     ^ returning this value requires that `'new` must outlive `'static`
 
 error: unsatisfied lifetime constraints
   --> $DIR/variance-btree-invariant-types.rs:19:5
@@ -84,7 +84,7 @@ error: unsatisfied lifetime constraints
 LL | fn iter_cov_val<'a, 'new>(v: IterMut<'a, (), &'static ()>) -> IterMut<'a, (), &'new ()> {
    |                     ---- lifetime `'new` defined here
 LL |     v //~ ERROR mismatched types
-   |     ^ return requires that `'new` must outlive `'static`
+   |     ^ returning this value requires that `'new` must outlive `'static`
 
 error: unsatisfied lifetime constraints
   --> $DIR/variance-btree-invariant-types.rs:22:5
@@ -92,7 +92,7 @@ error: unsatisfied lifetime constraints
 LL | fn iter_contra_key<'a, 'new>(v: IterMut<'a, &'new (), ()>) -> IterMut<'a, &'static (), ()> {
    |                        ---- lifetime `'new` defined here
 LL |     v //~ ERROR mismatched types
-   |     ^ return requires that `'new` must outlive `'static`
+   |     ^ returning this value requires that `'new` must outlive `'static`
 
 error: unsatisfied lifetime constraints
   --> $DIR/variance-btree-invariant-types.rs:25:5
@@ -100,7 +100,7 @@ error: unsatisfied lifetime constraints
 LL | fn iter_contra_val<'a, 'new>(v: IterMut<'a, (), &'new ()>) -> IterMut<'a, (), &'static ()> {
    |                        ---- lifetime `'new` defined here
 LL |     v //~ ERROR mismatched types
-   |     ^ return requires that `'new` must outlive `'static`
+   |     ^ returning this value requires that `'new` must outlive `'static`
 
 error: unsatisfied lifetime constraints
   --> $DIR/variance-btree-invariant-types.rs:30:5
@@ -109,7 +109,7 @@ LL | fn occ_cov_key<'a, 'new>(v: OccupiedEntry<'a, &'static (), ()>)
    |                    ---- lifetime `'new` defined here
 LL |                          -> OccupiedEntry<'a, &'new (), ()> {
 LL |     v //~ ERROR mismatched types
-   |     ^ return requires that `'new` must outlive `'static`
+   |     ^ returning this value requires that `'new` must outlive `'static`
 
 error: unsatisfied lifetime constraints
   --> $DIR/variance-btree-invariant-types.rs:34:5
@@ -118,7 +118,7 @@ LL | fn occ_cov_val<'a, 'new>(v: OccupiedEntry<'a, (), &'static ()>)
    |                    ---- lifetime `'new` defined here
 LL |                          -> OccupiedEntry<'a, (), &'new ()> {
 LL |     v //~ ERROR mismatched types
-   |     ^ return requires that `'new` must outlive `'static`
+   |     ^ returning this value requires that `'new` must outlive `'static`
 
 error: unsatisfied lifetime constraints
   --> $DIR/variance-btree-invariant-types.rs:38:5
@@ -127,7 +127,7 @@ LL | fn occ_contra_key<'a, 'new>(v: OccupiedEntry<'a, &'new (), ()>)
    |                       ---- lifetime `'new` defined here
 LL |                             -> OccupiedEntry<'a, &'static (), ()> {
 LL |     v //~ ERROR mismatched types
-   |     ^ return requires that `'new` must outlive `'static`
+   |     ^ returning this value requires that `'new` must outlive `'static`
 
 error: unsatisfied lifetime constraints
   --> $DIR/variance-btree-invariant-types.rs:42:5
@@ -136,7 +136,7 @@ LL | fn occ_contra_val<'a, 'new>(v: OccupiedEntry<'a, (), &'new ()>)
    |                       ---- lifetime `'new` defined here
 LL |                             -> OccupiedEntry<'a, (), &'static ()> {
 LL |     v //~ ERROR mismatched types
-   |     ^ return requires that `'new` must outlive `'static`
+   |     ^ returning this value requires that `'new` must outlive `'static`
 
 error: unsatisfied lifetime constraints
   --> $DIR/variance-btree-invariant-types.rs:47:5
@@ -145,7 +145,7 @@ LL | fn vac_cov_key<'a, 'new>(v: VacantEntry<'a, &'static (), ()>)
    |                    ---- lifetime `'new` defined here
 LL |                          -> VacantEntry<'a, &'new (), ()> {
 LL |     v //~ ERROR mismatched types
-   |     ^ return requires that `'new` must outlive `'static`
+   |     ^ returning this value requires that `'new` must outlive `'static`
 
 error: unsatisfied lifetime constraints
   --> $DIR/variance-btree-invariant-types.rs:51:5
@@ -154,7 +154,7 @@ LL | fn vac_cov_val<'a, 'new>(v: VacantEntry<'a, (), &'static ()>)
    |                    ---- lifetime `'new` defined here
 LL |                          -> VacantEntry<'a, (), &'new ()> {
 LL |     v //~ ERROR mismatched types
-   |     ^ return requires that `'new` must outlive `'static`
+   |     ^ returning this value requires that `'new` must outlive `'static`
 
 error: unsatisfied lifetime constraints
   --> $DIR/variance-btree-invariant-types.rs:55:5
@@ -163,7 +163,7 @@ LL | fn vac_contra_key<'a, 'new>(v: VacantEntry<'a, &'new (), ()>)
    |                       ---- lifetime `'new` defined here
 LL |                             -> VacantEntry<'a, &'static (), ()> {
 LL |     v //~ ERROR mismatched types
-   |     ^ return requires that `'new` must outlive `'static`
+   |     ^ returning this value requires that `'new` must outlive `'static`
 
 error: unsatisfied lifetime constraints
   --> $DIR/variance-btree-invariant-types.rs:59:5
@@ -172,7 +172,7 @@ LL | fn vac_contra_val<'a, 'new>(v: VacantEntry<'a, (), &'new ()>)
    |                       ---- lifetime `'new` defined here
 LL |                             -> VacantEntry<'a, (), &'static ()> {
 LL |     v //~ ERROR mismatched types
-   |     ^ return requires that `'new` must outlive `'static`
+   |     ^ returning this value requires that `'new` must outlive `'static`
 
 error: aborting due to 12 previous errors
 

--- a/src/test/ui/variance/variance-use-contravariant-struct-1.nll.stderr
+++ b/src/test/ui/variance/variance-use-contravariant-struct-1.nll.stderr
@@ -13,7 +13,7 @@ LL | fn foo<'min,'max>(v: SomeStruct<&'max ()>)
    |        lifetime `'min` defined here
 ...
 LL |     v //~ ERROR mismatched types
-   |     ^ return requires that `'min` must outlive `'max`
+   |     ^ returning this value requires that `'min` must outlive `'max`
 
 error: aborting due to previous error
 

--- a/src/test/ui/variance/variance-use-covariant-struct-1.nll.stderr
+++ b/src/test/ui/variance/variance-use-covariant-struct-1.nll.stderr
@@ -13,7 +13,7 @@ LL | fn foo<'min,'max>(v: SomeStruct<&'min ()>)
    |        lifetime `'min` defined here
 ...
 LL |     v //~ ERROR mismatched types
-   |     ^ return requires that `'min` must outlive `'max`
+   |     ^ returning this value requires that `'min` must outlive `'max`
 
 error: aborting due to previous error
 

--- a/src/test/ui/variance/variance-use-invariant-struct-1.nll.stderr
+++ b/src/test/ui/variance/variance-use-invariant-struct-1.nll.stderr
@@ -19,7 +19,7 @@ LL | fn foo<'min,'max>(v: SomeStruct<&'max ()>)
    |        lifetime `'min` defined here
 ...
 LL |     v //~ ERROR mismatched types
-   |     ^ return requires that `'min` must outlive `'max`
+   |     ^ returning this value requires that `'min` must outlive `'max`
 
 error: unsatisfied lifetime constraints
   --> $DIR/variance-use-invariant-struct-1.rs:29:5
@@ -30,7 +30,7 @@ LL | fn bar<'min,'max>(v: SomeStruct<&'min ()>)
    |        lifetime `'min` defined here
 ...
 LL |     v //~ ERROR mismatched types
-   |     ^ return requires that `'min` must outlive `'max`
+   |     ^ returning this value requires that `'min` must outlive `'max`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/wf/wf-static-method.nll.stderr
+++ b/src/test/ui/wf/wf-static-method.nll.stderr
@@ -37,7 +37,7 @@ LL | impl<'a, 'b> Foo<'a, 'b, Evil<'a, 'b>> for () {
    |      lifetime `'a` defined here
 ...
 LL |         u //~ ERROR E0312
-   |         ^ return requires that `'b` must outlive `'a`
+   |         ^ returning this value requires that `'b` must outlive `'a`
 
 error: unsatisfied lifetime constraints
   --> $DIR/wf-static-method.rs:43:9
@@ -48,7 +48,7 @@ LL | impl<'a, 'b> Evil<'a, 'b> {
    |      lifetime `'a` defined here
 LL |     fn inherent_evil(u: &'b u32) -> &'a u32 {
 LL |         u //~ ERROR E0312
-   |         ^ return requires that `'b` must outlive `'a`
+   |         ^ returning this value requires that `'b` must outlive `'a`
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Based on #53088 - creating now to get feedback.

Closes #51175

* Make assigning to the return type interesting.
* Use "returning this value" instead of "return" in error messages.
* Prefer one of the explanations that we have a name for to a generic interesting cause in some cases.
* Treat causes that involve the destination of a call like assignments.
