### PR TITLE
Suggest comma when missing in macro call

### DIFF
--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -181,7 +181,7 @@ fn generic_extension<'cx>(cx: &'cx mut ExtCtxt,
         for lhs in lhses { // try each arm's matchers
             let lhs_tt = match *lhs {
                 quoted::TokenTree::Delimited(_, ref delim) => &delim.tts[..],
-                _ => cx.span_bug(sp, "malformed macro lhs")
+                _ => continue,
             };
             match TokenTree::parse(cx, lhs_tt, arg.clone()) {
                 Success(_) => {
@@ -191,7 +191,7 @@ fn generic_extension<'cx>(cx: &'cx mut ExtCtxt,
                         err.span_suggestion_short(
                             comma_span,
                             "missing comma here",
-                            ",".to_string(),
+                            ", ".to_string(),
                         );
                     }
                 }

--- a/src/test/ui/macros/missing-comma.rs
+++ b/src/test/ui/macros/missing-comma.rs
@@ -9,7 +9,11 @@
 // except according to those terms.
 
 macro_rules! foo {
-    ($a:ident, $b:ident) => ()
+    ($a:ident) => ();
+    ($a:ident, $b:ident) => ();
+    ($a:ident, $b:ident, $c:ident) => ();
+    ($a:ident, $b:ident, $c:ident, $d:ident) => ();
+    ($a:ident, $b:ident, $c:ident, $d:ident, $e:ident) => ();
 }
 
 fn main() {
@@ -17,4 +21,10 @@ fn main() {
     //~^ ERROR expected token: `,`
     foo!(a b);
     //~^ ERROR no rules expected the token `b`
+    foo!(a, b, c, d e);
+    //~^ ERROR no rules expected the token `e`
+    foo!(a, b, c d, e);
+    //~^ ERROR no rules expected the token `d`
+    foo!(a, b, c d e);
+    //~^ ERROR no rules expected the token `d`
 }

--- a/src/test/ui/macros/missing-comma.stderr
+++ b/src/test/ui/macros/missing-comma.stderr
@@ -1,16 +1,38 @@
 error: expected token: `,`
-  --> $DIR/missing-comma.rs:16:19
+  --> $DIR/missing-comma.rs:20:19
    |
 LL |     println!("{}" a);
    |                   ^
 
 error: no rules expected the token `b`
-  --> $DIR/missing-comma.rs:18:12
+  --> $DIR/missing-comma.rs:22:12
    |
 LL |     foo!(a b);
    |           -^
    |           |
    |           help: missing comma here
 
-error: aborting due to 2 previous errors
+error: no rules expected the token `e`
+  --> $DIR/missing-comma.rs:24:21
+   |
+LL |     foo!(a, b, c, d e);
+   |                    -^
+   |                    |
+   |                    help: missing comma here
+
+error: no rules expected the token `d`
+  --> $DIR/missing-comma.rs:26:18
+   |
+LL |     foo!(a, b, c d, e);
+   |                 -^
+   |                 |
+   |                 help: missing comma here
+
+error: no rules expected the token `d`
+  --> $DIR/missing-comma.rs:28:18
+   |
+LL |     foo!(a, b, c d e);
+   |                  ^
+
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
When missing a comma in a macro call, suggest it, regardless of
position. When a macro call doesn't match any of the patterns, check
if the call's token stream could be missing a comma between two idents,
and if so, create a new token stream containing the comma and try to
match against the macro patterns. If successful, emit the suggestion.

This works on arbitrary macros, with no need of special support from
the macro writers.

```
error: no rules expected the token `d`
  --> $DIR/missing-comma.rs:26:18
   |
LL |     foo!(a, b, c d, e);
   |                 -^
   |                 |
   |                 help: missing comma here
```
Follow up to #52397.