### PR TITLE
Add crate build test for `thumb*` targets. [IRR-2018-embedded]

### DIFF
--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -983,7 +983,7 @@ impl Step for Compiletest {
         }
 
         if builder.no_std(target) == Some(true) {
-            // for no_std run-make (e.g. thumb*), 
+            // for no_std run-make (e.g. thumb*),
             // we need a host compiler which is called by cargo.
             builder.ensure(compile::Std { compiler, target: compiler.host });
         }

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -975,9 +975,19 @@ impl Step for Compiletest {
             builder.ensure(compile::Rustc { compiler, target });
         }
 
-        if builder.no_std(target) != Some(true) {
+        if builder.no_std(target) == Some(true) {
+            // the `test` doesn't compile for no-std targets
+            builder.ensure(compile::Std { compiler, target });
+        } else {
             builder.ensure(compile::Test { compiler, target });
         }
+
+        if builder.no_std(target) == Some(true) {
+            // for no_std run-make (e.g. thumb*), 
+            // we need a host compiler which is called by cargo.
+            builder.ensure(compile::Std { compiler, target: compiler.host });
+        }
+
         builder.ensure(native::TestHelpers { target });
         builder.ensure(RemoteCopyLibs { compiler, target });
 

--- a/src/test/run-make/git_clone_sha1.sh
+++ b/src/test/run-make/git_clone_sha1.sh
@@ -1,5 +1,15 @@
 #!/bin/bash -x
 
+# Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution and at
+# http://rust-lang.org/COPYRIGHT.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
 # Usage: $0 project_name url sha1
 # Get the crate with the specified sha1.
 #

--- a/src/test/run-make/git_clone_sha1.sh
+++ b/src/test/run-make/git_clone_sha1.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -x
+
+# Usage: $0 project_name url sha1
+# Get the crate with the specified sha1.
+#
+# all arguments are required.
+#
+# See below link for git usage:
+# https://stackoverflow.com/questions/3489173/how-to-clone-git-repository-with-specific-revision-changeset/14091182#14091182
+
+# Mandatory arguments:
+PROJECT_NAME=$1
+URL=$2
+SHA1=$3
+
+function err_exit() {
+    echo "ERROR:" $*
+    exit 1
+}
+
+git clone $URL $PROJECT_NAME || err_exit
+cd $PROJECT_NAME || err_exit
+git reset --hard $SHA1 || err_exit

--- a/src/test/run-make/git_clone_sha1.sh
+++ b/src/test/run-make/git_clone_sha1.sh
@@ -6,7 +6,7 @@
 # all arguments are required.
 #
 # See below link for git usage:
-# https://stackoverflow.com/questions/3489173/how-to-clone-git-repository-with-specific-revision-changeset/14091182#14091182
+# https://stackoverflow.com/questions/3489173#14091182
 
 # Mandatory arguments:
 PROJECT_NAME=$1

--- a/src/test/run-make/thumb-none-cortex-m/Makefile
+++ b/src/test/run-make/thumb-none-cortex-m/Makefile
@@ -1,20 +1,28 @@
-# Don't use the definitions
-#-include ../../run-make-fulldeps/tools.mk
+-include ../../run-make-fulldeps/tools.mk
+
+# How to run this
+# $ ./x.py dist --target x86_64-unknown-linux-gnu,thumbv7m-none-eabi --exclude src/doc
+# $ ./x.py test --target thumbv7m-none-eabi src/test/run-make
 
 ifeq ($(TARGET),thumbv7m-none-eabi)
 
 #TMP_DIR := $(shell mktemp -d)
 TMP_DIR := /tmp/safe_place
 CRATE := cortex-m
-LD_LIBRARY_PATH=/home/sekineh/rustme9/build/x86_64-unknown-linux-gnu/stage2/lib/rustlib/thumbv7m-none-eabi/lib
+RUSTC := $(RUSTC_ORIGINAL)
+LD_LIBRARY_PATH := $(HOST_RPATH_DIR)
+HOST := x86_64-unknown-linux-gnu
 
 all:
+	# Workaround for error[E0463]: can't find crate for `core`
+	-ln -sv $(SRC)/build/tmp/dist/rust-std-*-$(TARGET)/rust-std-$(TARGET)/lib/rustlib/$(TARGET)/lib/*.rlib $(SRC)/build/x86_64-unknown-linux-gnu/stage2/lib/rustlib/$(TARGET)/lib/
+	# Workaround for error[E0463]: can't find crate for `std`
+	-ln -sv $(SRC)/build/tmp/dist/rust-std-*-$(HOST)/rust-std-$(HOST)/lib/rustlib/$(HOST)/lib/*.rlib $(SRC)/build/x86_64-unknown-linux-gnu/stage2/lib/rustlib/$(HOST)/lib/
 	env > env.txt
 	mkdir -p $(TMP_DIR)
 	-cd $(TMP_DIR) && rm -rf $(CRATE)
 	cd $(TMP_DIR) && $(CARGO) clone $(CRATE) --vers 0.5.0
-	pwd
-	cd $(TMP_DIR) && cd $(CRATE) && env RUST_LOG=debug $(CARGO) build -j 1 --target $(TARGET) -vv 2>&1 | tee cargo-fail-vv-9.2.log
+	cd $(TMP_DIR) && cd $(CRATE) && $(CARGO) build -j 1 --target $(TARGET) -v
 else
 
 all:

--- a/src/test/run-make/thumb-none-cortex-m/Makefile
+++ b/src/test/run-make/thumb-none-cortex-m/Makefile
@@ -13,16 +13,17 @@
 # See https://stackoverflow.com/questions/7656425/makefile-ifeq-logical-or
 ifneq (,$(filter $(TARGET),thumbv6m-none-eabi thumbv7em-none-eabi thumbv7em-none-eabihf thumbv7m-none-eabi))
 
+# For cargo setting
+RUSTC := $(RUSTC_ORIGINAL)
+LD_LIBRARY_PATH := $(HOST_RPATH_DIR)
 # We need to be outside of 'src' dir in order to run cargo
 WORK_DIR := $(TMPDIR)
+
 HERE := $(shell pwd)
 
 CRATE := cortex-m
 CRATE_URL := https://github.com/rust-embedded/cortex-m
 CRATE_SHA1 := a448e9156e2cb1e556e5441fd65426952ef4b927 # 0.5.0
-
-RUSTC := $(RUSTC_ORIGINAL)
-LD_LIBRARY_PATH := $(HOST_RPATH_DIR)
 
 all:
 	env

--- a/src/test/run-make/thumb-none-cortex-m/Makefile
+++ b/src/test/run-make/thumb-none-cortex-m/Makefile
@@ -13,7 +13,7 @@ all:
 	-cd $(TMP_DIR) && rm -rf $(CRATE)
 	cd $(TMP_DIR) && $(CARGO) clone $(CRATE) --vers 0.5.0
 	pwd
-	cd $(TMP_DIR) && cd $(CRATE) && $(CARGO) build --target $(TARGET) -vv
+	cd $(TMP_DIR) && cd $(CRATE) && $(CARGO) build --target $(TARGET) -vv 2>&1 | tee cargo-fail-vv-9.2.log
 else
 
 all:

--- a/src/test/run-make/thumb-none-cortex-m/Makefile
+++ b/src/test/run-make/thumb-none-cortex-m/Makefile
@@ -11,13 +11,8 @@ TMP_DIR := /tmp/safe_place
 CRATE := cortex-m
 RUSTC := $(RUSTC_ORIGINAL)
 LD_LIBRARY_PATH := $(HOST_RPATH_DIR)
-HOST := x86_64-unknown-linux-gnu
 
 all:
-	# Workaround for error[E0463]: can't find crate for `core`
-	-ln -sv $(SRC)/build/tmp/dist/rust-std-*-$(TARGET)/rust-std-$(TARGET)/lib/rustlib/$(TARGET)/lib/*.rlib $(SRC)/build/x86_64-unknown-linux-gnu/stage2/lib/rustlib/$(TARGET)/lib/
-	# Workaround for error[E0463]: can't find crate for `std`
-	-ln -sv $(SRC)/build/tmp/dist/rust-std-*-$(HOST)/rust-std-$(HOST)/lib/rustlib/$(HOST)/lib/*.rlib $(SRC)/build/x86_64-unknown-linux-gnu/stage2/lib/rustlib/$(HOST)/lib/
 	env > env.txt
 	mkdir -p $(TMP_DIR)
 	-cd $(TMP_DIR) && rm -rf $(CRATE)

--- a/src/test/run-make/thumb-none-cortex-m/Makefile
+++ b/src/test/run-make/thumb-none-cortex-m/Makefile
@@ -14,7 +14,7 @@
 ifneq (,$(filter $(TARGET),thumbv6m-none-eabi thumbv7em-none-eabi thumbv7em-none-eabihf thumbv7m-none-eabi))
 
 # We need to be outside of 'src' dir in order to run cargo
-WORK_DIR := $(RUST_TEST_TMPDIR)/run-make/$(TARGET)
+WORK_DIR := $(TMPDIR)
 HERE := $(shell pwd)
 
 CRATE := cortex-m

--- a/src/test/run-make/thumb-none-cortex-m/Makefile
+++ b/src/test/run-make/thumb-none-cortex-m/Makefile
@@ -6,6 +6,7 @@ ifeq ($(TARGET),thumbv7m-none-eabi)
 #TMP_DIR := $(shell mktemp -d)
 TMP_DIR := /tmp/safe_place
 CRATE := cortex-m
+LD_LIBRARY_PATH=/home/sekineh/rustme9/build/x86_64-unknown-linux-gnu/stage2/lib/rustlib/thumbv7m-none-eabi/lib
 
 all:
 	env > env.txt
@@ -13,7 +14,7 @@ all:
 	-cd $(TMP_DIR) && rm -rf $(CRATE)
 	cd $(TMP_DIR) && $(CARGO) clone $(CRATE) --vers 0.5.0
 	pwd
-	cd $(TMP_DIR) && cd $(CRATE) && $(CARGO) build --target $(TARGET) -vv 2>&1 | tee cargo-fail-vv-9.2.log
+	cd $(TMP_DIR) && cd $(CRATE) && env RUST_LOG=debug $(CARGO) build -j 1 --target $(TARGET) -vv 2>&1 | tee cargo-fail-vv-9.2.log
 else
 
 all:

--- a/src/test/run-make/thumb-none-cortex-m/Makefile
+++ b/src/test/run-make/thumb-none-cortex-m/Makefile
@@ -13,7 +13,7 @@ all:
 	-cd $(TMP_DIR) && rm -rf $(CRATE)
 	cd $(TMP_DIR) && $(CARGO) clone $(CRATE) --vers 0.5.0
 	pwd
-	cd $(TMP_DIR) && cd $(CRATE) && $(CARGO) build --target $(TARGET)
+	cd $(TMP_DIR) && cd $(CRATE) && $(CARGO) build --target $(TARGET) -vv
 else
 
 all:

--- a/src/test/run-make/thumb-none-cortex-m/Makefile
+++ b/src/test/run-make/thumb-none-cortex-m/Makefile
@@ -1,9 +1,17 @@
 -include ../../run-make-fulldeps/tools.mk
 
 # How to run this
-# $ ./x.py test --target thumbv7m-none-eabi src/test/run-make
+# $ ./x.py clean
+# $ ./x.py test --target thumbv6m-none-eabi,thumbv7m-none-eabi src/test/run-make
 
-ifeq ($(TARGET),thumbv7m-none-eabi)
+# Supported targets:
+# - thumbv6m-none-eabi (Bare Cortex-M0, M0+, M1)
+# - thumbv7em-none-eabi (Bare Cortex-M4, M7)
+# - thumbv7em-none-eabihf (Bare Cortex-M4F, M7F, FPU, hardfloat)
+# - thumbv7m-none-eabi (Bare Cortex-M3)
+
+# See https://stackoverflow.com/questions/7656425/makefile-ifeq-logical-or
+ifneq (,$(filter $(TARGET),thumbv6m-none-eabi thumbv7em-none-eabi thumbv7em-none-eabihf thumbv7m-none-eabi))
 
 # We need to be outside of 'src' dir in order to run cargo
 WORK_DIR := $(RUST_TEST_TMPDIR)/run-make/$(TARGET)

--- a/src/test/run-make/thumb-none-cortex-m/Makefile
+++ b/src/test/run-make/thumb-none-cortex-m/Makefile
@@ -15,9 +15,11 @@ ifneq (,$(filter $(TARGET),thumbv6m-none-eabi thumbv7em-none-eabi thumbv7em-none
 
 # We need to be outside of 'src' dir in order to run cargo
 WORK_DIR := $(RUST_TEST_TMPDIR)/run-make/$(TARGET)
+HERE := $(shell pwd)
 
 CRATE := cortex-m
-CRATE_VER := 0.5.0
+CRATE_URL := https://github.com/rust-embedded/cortex-m
+CRATE_SHA1 := a448e9156e2cb1e556e5441fd65426952ef4b927 # 0.5.0
 
 RUSTC := $(RUSTC_ORIGINAL)
 LD_LIBRARY_PATH := $(HOST_RPATH_DIR)
@@ -26,7 +28,7 @@ all:
 	env
 	mkdir -p $(WORK_DIR)
 	-cd $(WORK_DIR) && rm -rf $(CRATE)
-	cd $(WORK_DIR) && $(CARGO) clone $(CRATE) --vers $(CRATE_VER)
+	cd $(WORK_DIR) && bash -x $(HERE)/../git_clone_sha1.sh $(CRATE) $(CRATE_URL) $(CRATE_SHA1)
 	cd $(WORK_DIR) && cd $(CRATE) && $(CARGO) build --target $(TARGET) -v
 else
 

--- a/src/test/run-make/thumb-none-cortex-m/Makefile
+++ b/src/test/run-make/thumb-none-cortex-m/Makefile
@@ -27,7 +27,7 @@ all:
 	mkdir -p $(WORK_DIR)
 	-cd $(WORK_DIR) && rm -rf $(CRATE)
 	cd $(WORK_DIR) && $(CARGO) clone $(CRATE) --vers $(CRATE_VER)
-	cd $(WORK_DIR) && cd $(CRATE) && $(CARGO) build -j 1 --target $(TARGET) -v
+	cd $(WORK_DIR) && cd $(CRATE) && $(CARGO) build --target $(TARGET) -v
 else
 
 all:

--- a/src/test/run-make/thumb-none-cortex-m/Makefile
+++ b/src/test/run-make/thumb-none-cortex-m/Makefile
@@ -1,0 +1,21 @@
+# Don't use the definitions
+#-include ../../run-make-fulldeps/tools.mk
+
+ifeq ($(TARGET),thumbv7m-none-eabi)
+
+#TMP_DIR := $(shell mktemp -d)
+TMP_DIR := /tmp/safe_place
+CRATE := cortex-m
+
+all:
+	env > env.txt
+	mkdir -p $(TMP_DIR)
+	-cd $(TMP_DIR) && rm -rf $(CRATE)
+	cd $(TMP_DIR) && $(CARGO) clone $(CRATE) --vers 0.5.0
+	pwd
+	cd $(TMP_DIR) && cd $(CRATE) && $(CARGO) build --target $(TARGET)
+else
+
+all:
+
+endif

--- a/src/test/run-make/thumb-none-cortex-m/Makefile
+++ b/src/test/run-make/thumb-none-cortex-m/Makefile
@@ -1,23 +1,25 @@
 -include ../../run-make-fulldeps/tools.mk
 
 # How to run this
-# $ ./x.py dist --target x86_64-unknown-linux-gnu,thumbv7m-none-eabi --exclude src/doc
 # $ ./x.py test --target thumbv7m-none-eabi src/test/run-make
 
 ifeq ($(TARGET),thumbv7m-none-eabi)
 
-#TMP_DIR := $(shell mktemp -d)
-TMP_DIR := /tmp/safe_place
+# We need to be outside of 'src' dir in order to run cargo
+WORK_DIR := $(RUST_TEST_TMPDIR)/run-make/$(TARGET)
+
 CRATE := cortex-m
+CRATE_VER := 0.5.0
+
 RUSTC := $(RUSTC_ORIGINAL)
 LD_LIBRARY_PATH := $(HOST_RPATH_DIR)
 
 all:
-	env > env.txt
-	mkdir -p $(TMP_DIR)
-	-cd $(TMP_DIR) && rm -rf $(CRATE)
-	cd $(TMP_DIR) && $(CARGO) clone $(CRATE) --vers 0.5.0
-	cd $(TMP_DIR) && cd $(CRATE) && $(CARGO) build -j 1 --target $(TARGET) -v
+	env
+	mkdir -p $(WORK_DIR)
+	-cd $(WORK_DIR) && rm -rf $(CRATE)
+	cd $(WORK_DIR) && $(CARGO) clone $(CRATE) --vers $(CRATE_VER)
+	cd $(WORK_DIR) && cd $(CRATE) && $(CARGO) build -j 1 --target $(TARGET) -v
 else
 
 all:


### PR DESCRIPTION
## Summary

This PR adds `run-make` test that compiles `cortex-m` crate for all supported `thumb*-none-*` targets using `cargo` and stage2 `rustc`.

- Supported `thumb*-none-*` targets:
  - thumbv6m-none-eabi (Bare Cortex-M0, M0+, M1)
  - thumbv7em-none-eabi (Bare Cortex-M4, M7)
  - thumbv7em-none-eabihf (Bare Cortex-M4F, M7F, FPU, hardfloat)
  - thumbv7m-none-eabi (Bare Cortex-M3)

## How to run & Example output
I tested locally and all targets succeeded like below:
```
./x.py clean
./x.py test --target thumbv6m-none-eabi,thumbv7em-none-eabi,thumbv7em-none-eabihf,thumbv7m-none-eabi src/test/run-make
```
```
Check compiletest suite=run-make mode=run-make (x86_64-unknown-linux-gnu -> thumbv6m-none-eabi)

running 5 tests
.....
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

## How to re-run

Remove `stamp` file for the test run.
```
rm build/x86_64-unknown-linux-gnu/test/run-make/thumb-none-cortex-m/stamp  
```
Then run `test`
```
./x.py test --target thumbv6m-none-eabi,thumbv7em-none-eabi,thumbv7em-none-eabihf,thumbv7m-none-eabi src/test/run-make
(snip)
running 5 tests
iiii.
test result: ok. 1 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out
```

## Artifacts

You can examine the artifacts under the directory below: 
```
sekineh@sekineh-VirtualBox:~/rustme10$ ls -l build/x86_64-unknown-linux-gnu/test/run-make/thumb-none-cortex-m/thumb-none-cortex-m/
total 4
drwxrwxr-x 7 sekineh sekineh 4096  8月 14 22:40 cortex-m
```
where `build/x86_64-unknown-linux-gnu/test/run-make/thumb-none-cortex-m/thumb-none-cortex-m/` is came from TMPDIR variable.

## Other notes

For `test.rs` modification, I used the same logic as:
- https://github.com/rust-lang/rust/blame/d8b3c830fbcdd14d085209a8dcc3399151f3286a/src/bootstrap/dist.rs#L652-L657
```
            if builder.no_std(target) == Some(true) {
                // the `test` doesn't compile for no-std targets
                builder.ensure(compile::Std { compiler, target });
            } else {
                builder.ensure(compile::Test { compiler, target });
            }
```
It is a useful snippet when adding `no_std` support to `src/bootstrap` code.

CC @kennytm @jamesmunns @nerdyvaishali