### PR TITLE
Don't panic on std::env::vars() when env is null.

### DIFF
--- a/src/libstd/sys/unix/os.rs
+++ b/src/libstd/sys/unix/os.rs
@@ -414,12 +414,8 @@ pub fn env() -> Env {
     unsafe {
         let _guard = ENV_LOCK.lock();
         let mut environ = *environ();
-        if environ == ptr::null() {
-            panic!("os::env() failure getting env string from OS: {}",
-                   io::Error::last_os_error());
-        }
         let mut result = Vec::new();
-        while *environ != ptr::null() {
+        while environ != ptr::null() && *environ != ptr::null() {
             if let Some(key_value) = parse(CStr::from_ptr(*environ).to_bytes()) {
                 result.push(key_value);
             }

--- a/src/test/run-pass/env-null-vars.rs
+++ b/src/test/run-pass/env-null-vars.rs
@@ -1,0 +1,29 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-windows
+// ignore-wasm32-bare no libc to test ffi with
+
+// issue-53200
+
+#![feature(libc)]
+extern crate libc;
+
+use std::env;
+
+// FIXME: more platforms?
+#[cfg(target_os = "linux")]
+fn main() {
+    unsafe { libc::clearenv(); }
+    assert_eq!(env::vars().count(), 0);
+}
+
+#[cfg(not(target_os = "linux"))]
+fn main() {}


### PR DESCRIPTION
Fixes #53200.

Reviewer(s):  
* Do I need to do any `#[cfg()]` here?
* Is this use of libc ok for a dev-dependency?