### PR TITLE
A few cleanups for rustc_target

### DIFF
--- a/src/librustc_target/abi/call/mips64.rs
+++ b/src/librustc_target/abi/call/mips64.rs
@@ -145,7 +145,7 @@ fn classify_arg_ty<'a, Ty, C>(cx: C, arg: &mut ArgType<'a, Ty>)
     // Extract first 8 chunks as the prefix
     let rest_size = size - Size::from_bytes(8) * prefix_index as u64;
     arg.cast_to(CastTarget {
-        prefix: prefix,
+        prefix,
         prefix_chunk: Size::from_bytes(8),
         rest: Uniform { unit: Reg::i64(), total: rest_size }
     });

--- a/src/librustc_target/abi/call/mod.rs
+++ b/src/librustc_target/abi/call/mod.rs
@@ -90,7 +90,7 @@ impl ArgAttributes {
     }
 
     pub fn set(&mut self, attr: ArgAttribute) -> &mut Self {
-        self.regular = self.regular | attr;
+        self.regular |= attr;
         self
     }
 
@@ -229,7 +229,7 @@ impl CastTarget {
 
     pub fn align<C: HasDataLayout>(&self, cx: C) -> Align {
         self.prefix.iter()
-            .filter_map(|x| x.map(|kind| Reg { kind: kind, size: self.prefix_chunk }.align(cx)))
+            .filter_map(|x| x.map(|kind| Reg { kind, size: self.prefix_chunk }.align(cx)))
             .fold(cx.data_layout().aggregate_align.max(self.rest.align(cx)),
                 |acc, align| acc.max(align))
     }

--- a/src/librustc_target/abi/call/x86_64.rs
+++ b/src/librustc_target/abi/call/x86_64.rs
@@ -199,10 +199,8 @@ pub fn compute_abi_info<'a, Ty, C>(cx: C, fty: &mut FnType<'a, Ty>)
                         _ => {}
                     }
                 }
-                if arg.layout.is_aggregate() {
-                    if int_regs < needed_int || sse_regs < needed_sse {
-                        cls_or_mem = Err(Memory);
-                    }
+                if arg.layout.is_aggregate() && (int_regs < needed_int || sse_regs < needed_sse) {
+                    cls_or_mem = Err(Memory);
                 }
             }
         }

--- a/src/librustc_target/abi/mod.rs
+++ b/src/librustc_target/abi/mod.rs
@@ -93,17 +93,17 @@ impl TargetDataLayout {
         let mut dl = TargetDataLayout::default();
         let mut i128_align_src = 64;
         for spec in target.data_layout.split('-') {
-            match &spec.split(':').collect::<Vec<_>>()[..] {
-                &["e"] => dl.endian = Endian::Little,
-                &["E"] => dl.endian = Endian::Big,
-                &["a", ref a..] => dl.aggregate_align = align(a, "a")?,
-                &["f32", ref a..] => dl.f32_align = align(a, "f32")?,
-                &["f64", ref a..] => dl.f64_align = align(a, "f64")?,
-                &[p @ "p", s, ref a..] | &[p @ "p0", s, ref a..] => {
+            match spec.split(':').collect::<Vec<_>>()[..] {
+                ["e"] => dl.endian = Endian::Little,
+                ["E"] => dl.endian = Endian::Big,
+                ["a", ref a..] => dl.aggregate_align = align(a, "a")?,
+                ["f32", ref a..] => dl.f32_align = align(a, "f32")?,
+                ["f64", ref a..] => dl.f64_align = align(a, "f64")?,
+                [p @ "p", s, ref a..] | [p @ "p0", s, ref a..] => {
                     dl.pointer_size = size(s, p)?;
                     dl.pointer_align = align(a, p)?;
                 }
-                &[s, ref a..] if s.starts_with("i") => {
+                [s, ref a..] if s.starts_with("i") => {
                     let bits = match s[1..].parse::<u64>() {
                         Ok(bits) => bits,
                         Err(_) => {
@@ -127,7 +127,7 @@ impl TargetDataLayout {
                         dl.i128_align = a;
                     }
                 }
-                &[s, ref a..] if s.starts_with("v") => {
+                [s, ref a..] if s.starts_with("v") => {
                     let v_size = size(&s[1..], "v")?;
                     let a = align(a, s)?;
                     if let Some(v) = dl.vector_align.iter_mut().find(|v| v.0 == v_size) {
@@ -429,8 +429,8 @@ pub enum Integer {
 }
 
 impl Integer {
-    pub fn size(&self) -> Size {
-        match *self {
+    pub fn size(self) -> Size {
+        match self {
             I8 => Size::from_bytes(1),
             I16 => Size::from_bytes(2),
             I32 => Size::from_bytes(4),
@@ -439,10 +439,10 @@ impl Integer {
         }
     }
 
-    pub fn align<C: HasDataLayout>(&self, cx: C) -> Align {
+    pub fn align<C: HasDataLayout>(self, cx: C) -> Align {
         let dl = cx.data_layout();
 
-        match *self {
+        match self {
             I8 => dl.i8_align,
             I16 => dl.i16_align,
             I32 => dl.i32_align,
@@ -522,15 +522,15 @@ impl fmt::Display for FloatTy {
 }
 
 impl FloatTy {
-    pub fn ty_to_string(&self) -> &'static str {
-        match *self {
+    pub fn ty_to_string(self) -> &'static str {
+        match self {
             FloatTy::F32 => "f32",
             FloatTy::F64 => "f64",
         }
     }
 
-    pub fn bit_width(&self) -> usize {
-        match *self {
+    pub fn bit_width(self) -> usize {
+        match self {
             FloatTy::F32 => 32,
             FloatTy::F64 => 64,
         }

--- a/src/librustc_target/spec/abi.rs
+++ b/src/librustc_target/spec/abi.rs
@@ -51,7 +51,7 @@ pub struct AbiData {
 }
 
 #[allow(non_upper_case_globals)]
-const AbiDatas: &'static [AbiData] = &[
+const AbiDatas: &[AbiData] = &[
     // Platform-specific ABIs
     AbiData {abi: Abi::Cdecl, name: "cdecl", generic: false },
     AbiData {abi: Abi::Stdcall, name: "stdcall", generic: false },
@@ -87,20 +87,20 @@ pub fn all_names() -> Vec<&'static str> {
 
 impl Abi {
     #[inline]
-    pub fn index(&self) -> usize {
-        *self as usize
+    pub fn index(self) -> usize {
+        self as usize
     }
 
     #[inline]
-    pub fn data(&self) -> &'static AbiData {
+    pub fn data(self) -> &'static AbiData {
         &AbiDatas[self.index()]
     }
 
-    pub fn name(&self) -> &'static str {
+    pub fn name(self) -> &'static str {
         self.data().name
     }
 
-    pub fn generic(&self) -> bool {
+    pub fn generic(self) -> bool {
         self.data().generic
     }
 }

--- a/src/librustc_target/spec/apple_base.rs
+++ b/src/librustc_target/spec/apple_base.rs
@@ -26,7 +26,7 @@ pub fn opts() -> TargetOptions {
     // TLS is flagged as enabled if it looks to be supported.
     let deployment_target = env::var("MACOSX_DEPLOYMENT_TARGET").ok();
     let version = deployment_target.as_ref().and_then(|s| {
-        let mut i = s.splitn(2, ".");
+        let mut i = s.splitn(2, '.');
         i.next().and_then(|a| i.next().map(|b| (a, b)))
     }).and_then(|(a, b)| {
         a.parse::<u32>().and_then(|a| b.parse::<u32>().map(|b| (a, b))).ok()

--- a/src/librustc_target/spec/apple_ios_base.rs
+++ b/src/librustc_target/spec/apple_ios_base.rs
@@ -25,13 +25,13 @@ pub enum Arch {
 }
 
 impl Arch {
-    pub fn to_string(&self) -> &'static str {
+    pub fn to_string(self) -> &'static str {
         match self {
-            &Armv7 => "armv7",
-            &Armv7s => "armv7s",
-            &Arm64 => "arm64",
-            &I386 => "i386",
-            &X86_64 => "x86_64"
+            Armv7 => "armv7",
+            Armv7s => "armv7s",
+            Arm64 => "arm64",
+            I386 => "i386",
+            X86_64 => "x86_64"
         }
     }
 }


### PR DESCRIPTION
- remove redundant struct field names
- shorten a self-assignment
- prefer `unwrap_or_else` in case of function calls
- collapse an `if`
- collapse a double `map()`
- match on dereferenced objects
- consume `self` if it implements `Copy`