### PR TITLE
driver: set the syntax edition in phase 1

### DIFF
--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -57,7 +57,7 @@ use syntax::ext::base::ExtCtxt;
 use syntax::fold::Folder;
 use syntax::parse::{self, PResult};
 use syntax::util::node_count::NodeCounter;
-use syntax_pos::FileName;
+use syntax_pos::{FileName, hygiene};
 use syntax_ext;
 
 use derive_registrar;
@@ -670,6 +670,7 @@ pub fn phase_1_parse_input<'a>(
 ) -> PResult<'a, ast::Crate> {
     sess.diagnostic()
         .set_continue_after_error(control.continue_parse_after_error);
+    hygiene::set_default_edition(sess.edition());
 
     if sess.profile_queries() {
         profile::begin(sess);

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -109,7 +109,7 @@ use syntax::ast;
 use syntax::codemap::{CodeMap, FileLoader, RealFileLoader};
 use syntax::feature_gate::{GatedCfg, UnstableFeatures};
 use syntax::parse::{self, PResult};
-use syntax_pos::{hygiene, DUMMY_SP, MultiSpan, FileName};
+use syntax_pos::{DUMMY_SP, MultiSpan, FileName};
 
 #[cfg(test)]
 mod test;
@@ -477,7 +477,6 @@ pub fn run_compiler<'a>(args: &[String],
         };
 
         let (sopts, cfg) = config::build_session_options_and_crate_config(&matches);
-        hygiene::set_default_edition(sopts.edition);
 
         driver::spawn_thread_pool(sopts, |sopts| {
             run_compiler_with_pool(matches, sopts, cfg, callbacks, file_loader, emitter_dest)

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -37,7 +37,7 @@ use syntax::codemap::CodeMap;
 use syntax::edition::Edition;
 use syntax::feature_gate::UnstableFeatures;
 use syntax::with_globals;
-use syntax_pos::{BytePos, DUMMY_SP, Pos, Span, FileName, hygiene};
+use syntax_pos::{BytePos, DUMMY_SP, Pos, Span, FileName};
 use errors;
 use errors::emitter::ColorConfig;
 
@@ -562,7 +562,6 @@ impl Collector {
                     rustc_driver::in_named_rustc_thread(name, move || with_globals(move || {
                         io::set_panic(panic);
                         io::set_print(print);
-                        hygiene::set_default_edition(edition);
                         run_test(&test,
                                  &cratename,
                                  &filename,

--- a/src/test/rustdoc/async-fn.rs
+++ b/src/test/rustdoc/async-fn.rs
@@ -1,0 +1,24 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// edition:2018
+// compile-flags:-Z unstable-options
+
+// FIXME: once `--edition` is stable in rustdoc, remove that `compile-flags` directive
+
+#![feature(rust_2018_preview, async_await, futures_api)]
+
+// @has async_fn/struct.S.html
+// @has - '//code' 'pub async fn f()'
+pub struct S;
+
+impl S {
+    pub async fn f() {}
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/53203

It seems the way libsyntax handles the desired edition is to use a global, set via `syntax_pos::hygiene::set_default_edition`. Right now, this is set in the driver in `run_compiler`, which is the entry point for running the compiler all the way through to emitting files. Since rustdoc doesn't use this function, it wasn't properly setting this global. (When initially setting up editions in rustdoc, i'd assumed that setting `sessopts.edition` would have done this... `>_>`) This was "fixed" for doctests in https://github.com/rust-lang/rust/pull/52385, but rather than patching in a call to `set_default_edition` in all the places rustdoc sets up the compiler, i've instead moved the call in the driver to be farther in the process. This means that any use of `phase_1_parse_input` with the right session options will have the edition properly set without having to also remember to set libsyntax up separately.

r? @rust-lang/compiler 