### PR TITLE
Remove Travis shutdown debug scripts, and remove CI-specific DNS settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -278,8 +278,6 @@ after_success:
       du . | sort -nr | head -n100
 
 after_failure:
-  # Requested by travis to debug "shutting down NOW" errors
-  - sudo tail -n 500 /var/log/syslog
   - >
       echo "#### Build failed; Disk usage after running script:";
       df -h;

--- a/.travis.yml
+++ b/.travis.yml
@@ -218,10 +218,6 @@ before_install:
       echo '{"ipv6":true,"fixed-cidr-v6":"fd9a:8454:6789:13f7::/64"}' | sudo tee /etc/docker/daemon.json;
       sudo service docker restart;
     fi
-  - date
-  - sudo atq || true
-  - sudo grep -rE 'shutdown|poweroff|halt' /var/spool/cron || true
-  - sudo grep -E 'google-clock-skew|ntpd|startup-script' /var/log/syslog || true
 
 install:
   - case "$TRAVIS_OS_NAME" in

--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -119,10 +119,6 @@ fi
 # goes ahead and sets it for all builders.
 args="$args --privileged"
 
-if [ "$CI" != "" ]; then
-    args="$args --dns 8.8.8.8 --dns 8.8.4.4 --dns 1.1.1.1 --dns 1.0.0.1"
-fi
-
 exec docker \
   run \
   --volume "$root_dir:/checkout:ro" \


### PR DESCRIPTION
Since the cause of the host shutdown (travis-ci/travis-ci#4924) is found, we could revert the shutdown debug attempts to shorten the logs.

Additionally, we're pretty sure a custom DNS (added in  will not help travis-ci/travis-ci#9696, so reverting that part of #51420 to reduce CI-specific settings.

