### PR TITLE
Feature gate where clauses on associated type impls

### DIFF
--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -1869,10 +1869,15 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                     "existential types are unstable"
                 );
             }
-
-            ast::ImplItemKind::Type(_) if !ii.generics.params.is_empty() => {
-                gate_feature_post!(&self, generic_associated_types, ii.span,
-                                   "generic associated types are unstable");
+            ast::ImplItemKind::Type(_) => {
+                if !ii.generics.params.is_empty() {
+                    gate_feature_post!(&self, generic_associated_types, ii.span,
+                                       "generic associated types are unstable");
+                }
+                if !ii.generics.where_clause.predicates.is_empty() {
+                    gate_feature_post!(&self, generic_associated_types, ii.span,
+                                       "where clauses on associated types are unstable");
+                }
             }
             _ => {}
         }

--- a/src/test/ui/feature-gates/feature-gate-generic_associated_types.rs
+++ b/src/test/ui/feature-gates/feature-gate-generic_associated_types.rs
@@ -19,6 +19,7 @@ trait PointerFamily<U> {
 }
 
 struct Foo;
+
 impl PointerFamily<u32> for Foo {
     type Pointer<usize> = Box<usize>;
     //~^ ERROR generic associated types are unstable
@@ -31,5 +32,9 @@ trait Bar {
     //~^ ERROR where clauses on associated types are unstable
 }
 
+impl Bar for Foo {
+    type Assoc where Self: Sized = Foo;
+    //~^ ERROR where clauses on associated types are unstable
+}
 
 fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-generic_associated_types.stderr
+++ b/src/test/ui/feature-gates/feature-gate-generic_associated_types.stderr
@@ -23,7 +23,7 @@ LL |     type Pointer2<T>: Deref<Target = T> where T: Clone, U: Clone;
    = help: add #![feature(generic_associated_types)] to the crate attributes to enable
 
 error[E0658]: generic associated types are unstable (see issue #44265)
-  --> $DIR/feature-gate-generic_associated_types.rs:23:5
+  --> $DIR/feature-gate-generic_associated_types.rs:24:5
    |
 LL |     type Pointer<usize> = Box<usize>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -31,7 +31,7 @@ LL |     type Pointer<usize> = Box<usize>;
    = help: add #![feature(generic_associated_types)] to the crate attributes to enable
 
 error[E0658]: generic associated types are unstable (see issue #44265)
-  --> $DIR/feature-gate-generic_associated_types.rs:25:5
+  --> $DIR/feature-gate-generic_associated_types.rs:26:5
    |
 LL |     type Pointer2<u32> = Box<u32>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -39,13 +39,21 @@ LL |     type Pointer2<u32> = Box<u32>;
    = help: add #![feature(generic_associated_types)] to the crate attributes to enable
 
 error[E0658]: where clauses on associated types are unstable (see issue #44265)
-  --> $DIR/feature-gate-generic_associated_types.rs:30:5
+  --> $DIR/feature-gate-generic_associated_types.rs:31:5
    |
 LL |     type Assoc where Self: Sized;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add #![feature(generic_associated_types)] to the crate attributes to enable
 
-error: aborting due to 6 previous errors
+error[E0658]: where clauses on associated types are unstable (see issue #44265)
+  --> $DIR/feature-gate-generic_associated_types.rs:36:5
+   |
+LL |     type Assoc where Self: Sized = Foo;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(generic_associated_types)] to the crate attributes to enable
+
+error: aborting due to 7 previous errors
 
 For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
Fixes #52913. This doesn't address the core problem, which is tracked by https://github.com/rust-lang/rust/issues/47206. However, it fixes the stable-to-stable regression: you now have to enable `#![feature(generic_associated_types)]` to trigger the weird behaviour.