### PR TITLE
Export WASM table by default

### DIFF
--- a/src/librustc_codegen_llvm/back/linker.rs
+++ b/src/librustc_codegen_llvm/back/linker.rs
@@ -1079,6 +1079,9 @@ impl<'a> Linker for WasmLd<'a> {
         // For now we just never have an entry symbol
         self.cmd.arg("--no-entry");
 
+        // Make the default table accessible
+        self.cmd.arg("--export-table");
+
         let mut cmd = Command::new("");
         ::std::mem::swap(&mut cmd, &mut self.cmd);
         cmd


### PR DESCRIPTION
This allows loading a rust-generated `.wasm` binary in a host and using the exported table much like the `memory` export.