### PR TITLE
A few cleanups

### DIFF
--- a/src/libfmt_macros/lib.rs
+++ b/src/libfmt_macros/lib.rs
@@ -411,7 +411,7 @@ impl<'a> Parser<'a> {
 
         // fill character
         if let Some(&(_, c)) = self.cur.peek() {
-            match self.cur.clone().skip(1).next() {
+            match self.cur.clone().nth(1) {
                 Some((_, '>')) | Some((_, '<')) | Some((_, '^')) => {
                     spec.fill = Some(c);
                     self.cur.next();
@@ -504,13 +504,11 @@ impl<'a> Parser<'a> {
             if word.is_empty() {
                 self.cur = tmp;
                 CountImplied
+            } else if self.consume('$') {
+                CountIsName(word)
             } else {
-                if self.consume('$') {
-                    CountIsName(word)
-                } else {
-                    self.cur = tmp;
-                    CountImplied
-                }
+                self.cur = tmp;
+                CountImplied
             }
         }
     }

--- a/src/libgraphviz/lib.rs
+++ b/src/libgraphviz/lib.rs
@@ -420,7 +420,8 @@ impl<'a> Id<'a> {
         if !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_' ) {
             return Err(());
         }
-        return Ok(Id { name: name });
+
+        Ok(Id { name })
     }
 
     pub fn as_slice(&'a self) -> &'a str {
@@ -533,10 +534,10 @@ impl<'a> LabelText<'a> {
     /// Renders text as string suitable for a label in a .dot file.
     /// This includes quotes or suitable delimiters.
     pub fn to_dot_string(&self) -> String {
-        match self {
-            &LabelStr(ref s) => format!("\"{}\"", s.escape_default()),
-            &EscStr(ref s) => format!("\"{}\"", LabelText::escape_str(&s)),
-            &HtmlStr(ref s) => format!("<{}>", s),
+        match *self {
+            LabelStr(ref s) => format!("\"{}\"", s.escape_default()),
+            EscStr(ref s) => format!("\"{}\"", LabelText::escape_str(&s)),
+            HtmlStr(ref s) => format!("<{}>", s),
         }
     }
 

--- a/src/librustc_target/spec/mod.rs
+++ b/src/librustc_target/spec/mod.rs
@@ -764,14 +764,10 @@ impl Target {
         // the JSON parser is not updated to match the structs.
 
         let get_req_field = |name: &str| {
-            match obj.find(name)
-                     .map(|s| s.as_string())
-                     .and_then(|os| os.map(|s| s.to_string())) {
-                Some(val) => Ok(val),
-                None => {
-                    return Err(format!("Field {} in target specification is required", name))
-                }
-            }
+            obj.find(name)
+               .map(|s| s.as_string())
+               .and_then(|os| os.map(|s| s.to_string()))
+               .ok_or_else(|| format!("Field {} in target specification is required", name))
         };
 
         let get_opt_field = |name: &str, default: &str| {

--- a/src/libserialize/hex.rs
+++ b/src/libserialize/hex.rs
@@ -22,7 +22,7 @@ pub trait ToHex {
     fn to_hex(&self) -> String;
 }
 
-const CHARS: &'static [u8] = b"0123456789abcdef";
+const CHARS: &[u8] = b"0123456789abcdef";
 
 impl ToHex for [u8] {
     /// Turn a vector of `u8` bytes into a hexadecimal string.

--- a/src/libserialize/leb128.rs
+++ b/src/libserialize/leb128.rs
@@ -103,8 +103,8 @@ pub fn write_signed_leb128_to<W>(mut value: i128, mut write: W)
     loop {
         let mut byte = (value as u8) & 0x7f;
         value >>= 7;
-        let more = !((((value == 0) && ((byte & 0x40) == 0)) ||
-                      ((value == -1) && ((byte & 0x40) != 0))));
+        let more = !(((value == 0) && ((byte & 0x40) == 0)) ||
+                     ((value == -1) && ((byte & 0x40) != 0)));
 
         if more {
             byte |= 0x80; // Mark this byte to show that more bytes will follow.

--- a/src/libterm/terminfo/mod.rs
+++ b/src/libterm/terminfo/mod.rs
@@ -60,8 +60,8 @@ impl error::Error for Error {
 
     fn cause(&self) -> Option<&dyn error::Error> {
         use self::Error::*;
-        match self {
-            &IoError(ref e) => Some(e),
+        match *self {
+            IoError(ref e) => Some(e),
             _ => None,
         }
     }
@@ -70,10 +70,10 @@ impl error::Error for Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use self::Error::*;
-        match self {
-            &TermUnset => Ok(()),
-            &MalformedTerminfo(ref e) => e.fmt(f),
-            &IoError(ref e) => e.fmt(f),
+        match *self {
+            TermUnset => Ok(()),
+            MalformedTerminfo(ref e) => e.fmt(f),
+            IoError(ref e) => e.fmt(f),
         }
     }
 }
@@ -109,9 +109,9 @@ impl TermInfo {
     }
     // Keep the metadata small
     fn _from_path(path: &Path) -> Result<TermInfo, Error> {
-        let file = File::open(path).map_err(|e| Error::IoError(e))?;
+        let file = File::open(path).map_err(Error::IoError)?;
         let mut reader = BufReader::new(file);
-        parse(&mut reader, false).map_err(|e| Error::MalformedTerminfo(e))
+        parse(&mut reader, false).map_err(Error::MalformedTerminfo)
     }
 }
 

--- a/src/libterm/terminfo/parm.rs
+++ b/src/libterm/terminfo/parm.rs
@@ -12,8 +12,6 @@
 
 use self::Param::*;
 use self::States::*;
-use self::FormatState::*;
-use self::FormatOp::*;
 
 use std::iter::repeat;
 
@@ -36,9 +34,9 @@ enum States {
 
 #[derive(Copy, PartialEq, Clone)]
 enum FormatState {
-    FormatStateFlags,
-    FormatStateWidth,
-    FormatStatePrecision,
+    Flags,
+    Width,
+    Precision,
 }
 
 /// Types of parameters a capability can use
@@ -210,22 +208,22 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables) -> Result<Vec<
                         if let Some(arg) = stack.pop() {
                             let flags = Flags::new();
                             let res = format(arg, FormatOp::from_char(cur), flags)?;
-                            output.extend(res.iter().map(|x| *x));
+                            output.extend(res.iter().cloned());
                         } else {
                             return Err("stack is empty".to_string());
                         }
                     }
                     ':' | '#' | ' ' | '.' | '0'..='9' => {
                         let mut flags = Flags::new();
-                        let mut fstate = FormatStateFlags;
+                        let mut fstate = FormatState::Flags;
                         match cur {
                             ':' => (),
                             '#' => flags.alternate = true,
                             ' ' => flags.space = true,
-                            '.' => fstate = FormatStatePrecision,
+                            '.' => fstate = FormatState::Precision,
                             '0'..='9' => {
                                 flags.width = cur as usize - '0' as usize;
-                                fstate = FormatStateWidth;
+                                fstate = FormatState::Width;
                             }
                             _ => unreachable!(),
                         }
@@ -318,43 +316,43 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables) -> Result<Vec<
                     (_, 'd') | (_, 'o') | (_, 'x') | (_, 'X') | (_, 's') => {
                         if let Some(arg) = stack.pop() {
                             let res = format(arg, FormatOp::from_char(cur), *flags)?;
-                            output.extend(res.iter().map(|x| *x));
+                            output.extend(res.iter().cloned());
                             // will cause state to go to Nothing
                             old_state = FormatPattern(*flags, *fstate);
                         } else {
                             return Err("stack is empty".to_string());
                         }
                     }
-                    (FormatStateFlags, '#') => {
+                    (FormatState::Flags, '#') => {
                         flags.alternate = true;
                     }
-                    (FormatStateFlags, '-') => {
+                    (FormatState::Flags, '-') => {
                         flags.left = true;
                     }
-                    (FormatStateFlags, '+') => {
+                    (FormatState::Flags, '+') => {
                         flags.sign = true;
                     }
-                    (FormatStateFlags, ' ') => {
+                    (FormatState::Flags, ' ') => {
                         flags.space = true;
                     }
-                    (FormatStateFlags, '0'..='9') => {
+                    (FormatState::Flags, '0'..='9') => {
                         flags.width = cur as usize - '0' as usize;
-                        *fstate = FormatStateWidth;
+                        *fstate = FormatState::Width;
                     }
-                    (FormatStateFlags, '.') => {
-                        *fstate = FormatStatePrecision;
+                    (FormatState::Flags, '.') => {
+                        *fstate = FormatState::Precision;
                     }
-                    (FormatStateWidth, '0'..='9') => {
+                    (FormatState::Width, '0'..='9') => {
                         let old = flags.width;
                         flags.width = flags.width * 10 + (cur as usize - '0' as usize);
                         if flags.width < old {
                             return Err("format width overflow".to_string());
                         }
                     }
-                    (FormatStateWidth, '.') => {
-                        *fstate = FormatStatePrecision;
+                    (FormatState::Width, '.') => {
+                        *fstate = FormatState::Precision;
                     }
-                    (FormatStatePrecision, '0'..='9') => {
+                    (FormatState::Precision, '0'..='9') => {
                         let old = flags.precision;
                         flags.precision = flags.precision * 10 + (cur as usize - '0' as usize);
                         if flags.precision < old {
@@ -437,31 +435,31 @@ impl Flags {
 
 #[derive(Copy, Clone)]
 enum FormatOp {
-    FormatDigit,
-    FormatOctal,
-    FormatHex,
-    FormatHEX,
-    FormatString,
+    Digit,
+    Octal,
+    LowerHex,
+    UpperHex,
+    String,
 }
 
 impl FormatOp {
     fn from_char(c: char) -> FormatOp {
         match c {
-            'd' => FormatDigit,
-            'o' => FormatOctal,
-            'x' => FormatHex,
-            'X' => FormatHEX,
-            's' => FormatString,
+            'd' => FormatOp::Digit,
+            'o' => FormatOp::Octal,
+            'x' => FormatOp::LowerHex,
+            'X' => FormatOp::UpperHex,
+            's' => FormatOp::String,
             _ => panic!("bad FormatOp char"),
         }
     }
     fn to_char(self) -> char {
         match self {
-            FormatDigit => 'd',
-            FormatOctal => 'o',
-            FormatHex => 'x',
-            FormatHEX => 'X',
-            FormatString => 's',
+            FormatOp::Digit => 'd',
+            FormatOp::Octal => 'o',
+            FormatOp::LowerHex => 'x',
+            FormatOp::UpperHex => 'X',
+            FormatOp::String => 's',
         }
     }
 }
@@ -470,7 +468,7 @@ fn format(val: Param, op: FormatOp, flags: Flags) -> Result<Vec<u8>, String> {
     let mut s = match val {
         Number(d) => {
             match op {
-                FormatDigit => {
+                FormatOp::Digit => {
                     if flags.sign {
                         format!("{:+01$}", d, flags.precision)
                     } else if d < 0 {
@@ -482,7 +480,7 @@ fn format(val: Param, op: FormatOp, flags: Flags) -> Result<Vec<u8>, String> {
                         format!("{:01$}", d, flags.precision)
                     }
                 }
-                FormatOctal => {
+                FormatOp::Octal => {
                     if flags.alternate {
                         // Leading octal zero counts against precision.
                         format!("0{:01$o}", d, flags.precision.saturating_sub(1))
@@ -490,27 +488,27 @@ fn format(val: Param, op: FormatOp, flags: Flags) -> Result<Vec<u8>, String> {
                         format!("{:01$o}", d, flags.precision)
                     }
                 }
-                FormatHex => {
+                FormatOp::LowerHex => {
                     if flags.alternate && d != 0 {
                         format!("0x{:01$x}", d, flags.precision)
                     } else {
                         format!("{:01$x}", d, flags.precision)
                     }
                 }
-                FormatHEX => {
+                FormatOp::UpperHex => {
                     if flags.alternate && d != 0 {
                         format!("0X{:01$X}", d, flags.precision)
                     } else {
                         format!("{:01$X}", d, flags.precision)
                     }
                 }
-                FormatString => return Err("non-number on stack with %s".to_string()),
+                FormatOp::String => return Err("non-number on stack with %s".to_string()),
             }
             .into_bytes()
         }
         Words(s) => {
             match op {
-                FormatString => {
+                FormatOp::String => {
                     let mut s = s.into_bytes();
                     if flags.precision > 0 && flags.precision < s.len() {
                         s.truncate(flags.precision);

--- a/src/libterm/win.rs
+++ b/src/libterm/win.rs
@@ -198,11 +198,11 @@ impl<T: Write + Send + 'static> Terminal for WinConsole<T> {
         Ok(true)
     }
 
-    fn get_ref<'a>(&'a self) -> &'a T {
+    fn get_ref(&self) -> &T {
         &self.buf
     }
 
-    fn get_mut<'a>(&'a mut self) -> &'a mut T {
+    fn get_mut(&mut self) -> &mut T {
         &mut self.buf
     }
 


### PR DESCRIPTION
- change `skip(1).next()` to `nth(1)`
- collapse some `if-else` expressions
- remove a few explicit `return`s
- remove an unnecessary field name
- dereference once instead of matching on multiple references
- prefer `iter().enumerate()` to indexing with `for`
- remove some unnecessary lifetime annotations
- use `writeln!()` instead of `write!()`+`\n`
- remove redundant parentheses
- shorten some enum variant names
- a few other cleanups suggested by `clippy`