### PR TITLE
Don't accept non-string literals for the format string in writeln

### DIFF
--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -396,6 +396,7 @@ macro_rules! write {
 /// ```
 #[macro_export]
 #[stable(feature = "rust1", since = "1.0.0")]
+#[allow_internal_unstable]
 macro_rules! writeln {
     ($dst:expr) => (
         write!($dst, "\n")
@@ -403,11 +404,8 @@ macro_rules! writeln {
     ($dst:expr,) => (
         writeln!($dst)
     );
-    ($dst:expr, $fmt:expr) => (
-        write!($dst, concat!($fmt, "\n"))
-    );
-    ($dst:expr, $fmt:expr, $($arg:tt)*) => (
-        write!($dst, concat!($fmt, "\n"), $($arg)*)
+    ($dst:expr, $($arg:tt)*) => (
+        $dst.write_fmt(format_args_nl!($($arg)*))
     );
 }
 

--- a/src/test/ui/macros/issue-30143.rs
+++ b/src/test/ui/macros/issue-30143.rs
@@ -1,0 +1,21 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::fmt::Write;
+
+fn main() {
+    println!(0);
+    //~^ ERROR format argument must be a string literal
+    eprintln!('a');
+    //~^ ERROR format argument must be a string literal
+    let mut s = String::new();
+    writeln!(s, true).unwrap();
+    //~^ ERROR format argument must be a string literal
+}

--- a/src/test/ui/macros/issue-30143.stderr
+++ b/src/test/ui/macros/issue-30143.stderr
@@ -1,0 +1,32 @@
+error: format argument must be a string literal
+  --> $DIR/issue-30143.rs:14:14
+   |
+LL |     println!(0);
+   |              ^
+help: you might be missing a string literal to format with
+   |
+LL |     println!("{}", 0);
+   |              ^^^^^
+
+error: format argument must be a string literal
+  --> $DIR/issue-30143.rs:16:15
+   |
+LL |     eprintln!('a');
+   |               ^^^
+help: you might be missing a string literal to format with
+   |
+LL |     eprintln!("{}", 'a');
+   |               ^^^^^
+
+error: format argument must be a string literal
+  --> $DIR/issue-30143.rs:19:17
+   |
+LL |     writeln!(s, true).unwrap();
+   |                 ^^^^
+help: you might be missing a string literal to format with
+   |
+LL |     writeln!(s, "{}", true).unwrap();
+   |                 ^^^^^
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
This is to improve diagnostics.

`println` and `eprintln` were already fixed by #52394.

Fixes #30143