### PR TITLE
Fix a few regressions from enabling macro modularization

### DIFF
--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -789,7 +789,6 @@ impl<'a, 'b, 'cl> BuildReducedGraphVisitor<'a, 'b, 'cl> {
     fn visit_invoc(&mut self, id: ast::NodeId) -> &'b InvocationData<'b> {
         let mark = id.placeholder_to_mark();
         self.resolver.current_module.unresolved_invocations.borrow_mut().insert(mark);
-        self.resolver.unresolved_invocations_macro_export.insert(mark);
         let invocation = self.resolver.invocations[&mark];
         invocation.module.set(self.resolver.current_module);
         invocation.legacy_scope.set(self.legacy_scope);

--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -196,9 +196,7 @@ impl<'a, 'crateloader: 'a> base::Resolver for Resolver<'a, 'crateloader> {
 
         self.current_module = invocation.module.get();
         self.current_module.unresolved_invocations.borrow_mut().remove(&mark);
-        self.unresolved_invocations_macro_export.remove(&mark);
         self.current_module.unresolved_invocations.borrow_mut().extend(derives);
-        self.unresolved_invocations_macro_export.extend(derives);
         for &derive in derives {
             self.invocations.insert(derive, invocation);
         }

--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -669,7 +669,10 @@ impl<'a, 'cl> Resolver<'a, 'cl> {
                     }
                 }
                 WhereToResolve::BuiltinAttrs => {
-                    if is_builtin_attr_name(ident.name) {
+                    // FIXME: Only built-in attributes are not considered as candidates for
+                    // non-attributes to fight off regressions on stable channel (#53205).
+                    // We need to come up with some more principled approach instead.
+                    if is_attr && is_builtin_attr_name(ident.name) {
                         let binding = (Def::NonMacroAttr(NonMacroAttrKind::Builtin),
                                        ty::Visibility::Public, ident.span, Mark::root())
                                        .to_name_binding(self.arenas);

--- a/src/test/compile-fail-fulldeps/proc-macro/proc-macro-attributes.rs
+++ b/src/test/compile-fail-fulldeps/proc-macro/proc-macro-attributes.rs
@@ -21,7 +21,7 @@ extern crate derive_b;
 #[C] //~ ERROR: The attribute `C` is currently unknown to the compiler
 #[B(D)]
 #[B(E = "foo")]
-#[B arbitrary tokens] //~ expected one of `(` or `=`, found `arbitrary`
+#[B arbitrary tokens] //~ ERROR arbitrary tokens in non-macro attributes are unstable
 struct B;
 
 fn main() {}

--- a/src/test/compile-fail/gated-attr-literals.rs
+++ b/src/test/compile-fail/gated-attr-literals.rs
@@ -11,37 +11,33 @@
 // Check that literals in attributes don't parse without the feature gate.
 
 // gate-test-attr_literals
-// gate-test-custom_attribute
 
-#![feature(rustc_attrs)]
-#![allow(dead_code)]
-#![allow(unused_variables)]
+#![feature(custom_attribute)]
 
-#[fake_attr] //~ ERROR attribute `fake_attr` is currently unknown
-#[fake_attr(100)] //~ ERROR attribute `fake_attr` is currently unknown
+#[fake_attr] // OK
+#[fake_attr(100)]
     //~^ ERROR non-string literals in attributes
-#[fake_attr(1, 2, 3)] //~ ERROR attribute `fake_attr` is currently unknown
+#[fake_attr(1, 2, 3)]
     //~^ ERROR non-string literals in attributes
-#[fake_attr("hello")] //~ ERROR attribute `fake_attr` is currently unknown
+#[fake_attr("hello")]
     //~^ ERROR string literals in top-level positions, are experimental
-#[fake_attr(name = "hello")] //~ ERROR attribute `fake_attr` is currently unknown
-#[fake_attr(1, "hi", key = 12, true, false)] //~ ERROR attribute `fake_attr` is currently unknown
+#[fake_attr(name = "hello")] // OK
+#[fake_attr(1, "hi", key = 12, true, false)]
     //~^ ERROR non-string literals in attributes, or string literals in top-level positions
-#[fake_attr(key = "hello", val = 10)] //~ ERROR attribute `fake_attr` is currently unknown
+#[fake_attr(key = "hello", val = 10)]
     //~^ ERROR non-string literals in attributes
-#[fake_attr(key("hello"), val(10))] //~ ERROR attribute `fake_attr` is currently unknown
+#[fake_attr(key("hello"), val(10))]
     //~^ ERROR non-string literals in attributes, or string literals in top-level positions
-#[fake_attr(enabled = true, disabled = false)] //~ ERROR attribute `fake_attr` is currently unknown
+#[fake_attr(enabled = true, disabled = false)]
     //~^ ERROR non-string literals in attributes
-#[fake_attr(true)] //~ ERROR attribute `fake_attr` is currently unknown
+#[fake_attr(true)]
     //~^ ERROR non-string literals in attributes
-#[fake_attr(pi = 3.14159)] //~ ERROR attribute `fake_attr` is currently unknown
+#[fake_attr(pi = 3.14159)]
     //~^ ERROR non-string literals in attributes
-#[fake_attr(b"hi")] //~ ERROR attribute `fake_attr` is currently unknown
+#[fake_attr(b"hi")]
     //~^ ERROR string literals in top-level positions, are experimental
-#[fake_doc(r"doc")] //~ ERROR attribute `fake_doc` is currently unknown
+#[fake_doc(r"doc")]
     //~^ ERROR string literals in top-level positions, are experimental
 struct Q {  }
 
-#[rustc_error]
 fn main() { }

--- a/src/test/compile-fail/macro-attribute.rs
+++ b/src/test/compile-fail/macro-attribute.rs
@@ -8,5 +8,5 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[doc = $not_there] //~ error: unexpected token: `$`
+#[doc = $not_there] //~ ERROR arbitrary tokens in non-macro attributes are unstable
 fn main() { }

--- a/src/test/run-pass-fulldeps/proc-macro/derive-b.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/derive-b.rs
@@ -11,7 +11,7 @@
 // aux-build:derive-b.rs
 // ignore-stage1
 
-#![feature(proc_macro_path_invoc)]
+#![feature(proc_macro_path_invoc, unrestricted_attribute_tokens)]
 
 extern crate derive_b;
 

--- a/src/test/ui/feature-gate-rustc-attrs-1.rs
+++ b/src/test/ui/feature-gate-rustc-attrs-1.rs
@@ -12,7 +12,7 @@
 
 // Test that `#[rustc_*]` attributes are gated by `rustc_attrs` feature gate.
 
-#[rustc_foo]
-//~^ ERROR unless otherwise specified, attributes with the prefix `rustc_` are reserved for internal compiler diagnostics
+#[rustc_variance] //~ ERROR the `#[rustc_variance]` attribute is just used for rustc unit tests and will never be stable
+#[rustc_error] //~ ERROR the `#[rustc_error]` attribute is just used for rustc unit tests and will never be stable
 
 fn main() {}

--- a/src/test/ui/feature-gate-rustc-attrs-1.stderr
+++ b/src/test/ui/feature-gate-rustc-attrs-1.stderr
@@ -1,0 +1,19 @@
+error[E0658]: the `#[rustc_variance]` attribute is just used for rustc unit tests and will never be stable (see issue #29642)
+  --> $DIR/feature-gate-rustc-attrs-1.rs:15:1
+   |
+LL | #[rustc_variance] //~ ERROR the `#[rustc_variance]` attribute is just used for rustc unit tests and will never be stable
+   | ^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(rustc_attrs)] to the crate attributes to enable
+
+error[E0658]: the `#[rustc_error]` attribute is just used for rustc unit tests and will never be stable (see issue #29642)
+  --> $DIR/feature-gate-rustc-attrs-1.rs:16:1
+   |
+LL | #[rustc_error] //~ ERROR the `#[rustc_error]` attribute is just used for rustc unit tests and will never be stable
+   | ^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(rustc_attrs)] to the crate attributes to enable
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/feature-gate-rustc-attrs.stderr
+++ b/src/test/ui/feature-gate-rustc-attrs.stderr
@@ -1,27 +1,11 @@
-error[E0658]: the `#[rustc_variance]` attribute is just used for rustc unit tests and will never be stable (see issue #29642)
-  --> $DIR/feature-gate-rustc-attrs.rs:15:1
-   |
-LL | #[rustc_variance] //~ ERROR the `#[rustc_variance]` attribute is just used for rustc unit tests and will never be stable
-   | ^^^^^^^^^^^^^^^^^
-   |
-   = help: add #![feature(rustc_attrs)] to the crate attributes to enable
-
-error[E0658]: the `#[rustc_error]` attribute is just used for rustc unit tests and will never be stable (see issue #29642)
-  --> $DIR/feature-gate-rustc-attrs.rs:16:1
-   |
-LL | #[rustc_error] //~ ERROR the `#[rustc_error]` attribute is just used for rustc unit tests and will never be stable
-   | ^^^^^^^^^^^^^^
-   |
-   = help: add #![feature(rustc_attrs)] to the crate attributes to enable
-
 error[E0658]: unless otherwise specified, attributes with the prefix `rustc_` are reserved for internal compiler diagnostics (see issue #29642)
-  --> $DIR/feature-gate-rustc-attrs.rs:17:1
+  --> $DIR/feature-gate-rustc-attrs.rs:15:1
    |
 LL | #[rustc_foo]
    | ^^^^^^^^^^^^
    |
    = help: add #![feature(rustc_attrs)] to the crate attributes to enable
 
-error: aborting due to 3 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/feature-gate-unrestricted-attribute-tokens.rs
+++ b/src/test/ui/feature-gate-unrestricted-attribute-tokens.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,6 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// asterisk is bogus
-#[path*] //~ ERROR arbitrary tokens in non-macro attributes are unstable
-mod m {}
+#![feature(custom_attribute)]
+
+#[my_attr(a b c d)]
+//~^ ERROR expected one of `(`, `)`, `,`, `::`, or `=`, found `b`
+//~| ERROR expected one of `(`, `)`, `,`, `::`, or `=`, found `c`
+//~| ERROR expected one of `(`, `)`, `,`, `::`, or `=`, found `d`
+fn main() {}

--- a/src/test/ui/feature-gate-unrestricted-attribute-tokens.stderr
+++ b/src/test/ui/feature-gate-unrestricted-attribute-tokens.stderr
@@ -1,0 +1,20 @@
+error: expected one of `(`, `)`, `,`, `::`, or `=`, found `b`
+  --> $DIR/feature-gate-unrestricted-attribute-tokens.rs:13:13
+   |
+LL | #[my_attr(a b c d)]
+   |             ^ expected one of `(`, `)`, `,`, `::`, or `=` here
+
+error: expected one of `(`, `)`, `,`, `::`, or `=`, found `c`
+  --> $DIR/feature-gate-unrestricted-attribute-tokens.rs:13:15
+   |
+LL | #[my_attr(a b c d)]
+   |               ^ expected one of `(`, `)`, `,`, `::`, or `=` here
+
+error: expected one of `(`, `)`, `,`, `::`, or `=`, found `d`
+  --> $DIR/feature-gate-unrestricted-attribute-tokens.rs:13:17
+   |
+LL | #[my_attr(a b c d)]
+   |                 ^ expected one of `(`, `)`, `,`, `::`, or `=` here
+
+error: aborting due to 3 previous errors
+

--- a/src/test/ui/imports/local-modularized-tricky-fail-3.rs
+++ b/src/test/ui/imports/local-modularized-tricky-fail-3.rs
@@ -1,0 +1,32 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Crate-local macro expanded `macro_export` macros cannot be accessed with module-relative paths.
+
+#![feature(use_extern_macros)]
+
+macro_rules! define_exported { () => {
+    #[macro_export]
+    macro_rules! exported {
+        () => ()
+    }
+}}
+
+define_exported!();
+
+mod m {
+    use exported;
+    //~^ ERROR macro-expanded `macro_export` macros from the current crate cannot
+}
+
+fn main() {
+    ::exported!();
+    //~^ ERROR macro-expanded `macro_export` macros from the current crate cannot
+}

--- a/src/test/ui/imports/local-modularized-tricky-fail-3.stderr
+++ b/src/test/ui/imports/local-modularized-tricky-fail-3.stderr
@@ -1,0 +1,36 @@
+error: macro-expanded `macro_export` macros from the current crate cannot be referred to by absolute paths
+  --> $DIR/local-modularized-tricky-fail-3.rs:25:9
+   |
+LL |     use exported;
+   |         ^^^^^^^^
+   |
+note: the macro is defined here
+  --> $DIR/local-modularized-tricky-fail-3.rs:17:5
+   |
+LL | /     macro_rules! exported {
+LL | |         () => ()
+LL | |     }
+   | |_____^
+...
+LL |   define_exported!();
+   |   ------------------- in this macro invocation
+
+error: macro-expanded `macro_export` macros from the current crate cannot be referred to by absolute paths
+  --> $DIR/local-modularized-tricky-fail-3.rs:30:5
+   |
+LL |     ::exported!();
+   |     ^^^^^^^^^^
+   |
+note: the macro is defined here
+  --> $DIR/local-modularized-tricky-fail-3.rs:17:5
+   |
+LL | /     macro_rules! exported {
+LL | |         () => ()
+LL | |     }
+   | |_____^
+...
+LL |   define_exported!();
+   |   ------------------- in this macro invocation
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/issue-11692-2.rs
+++ b/src/test/ui/issue-11692-2.rs
@@ -10,5 +10,5 @@
 
 fn main() {
     concat!(test!());
-    //~^ ERROR expected a macro, found built-in attribute
+    //~^ ERROR cannot find macro `test!` in this scope
 }

--- a/src/test/ui/issue-11692-2.stderr
+++ b/src/test/ui/issue-11692-2.stderr
@@ -1,4 +1,4 @@
-error: expected a macro, found built-in attribute
+error: cannot find macro `test!` in this scope
   --> $DIR/issue-11692-2.rs:12:13
    |
 LL |     concat!(test!());

--- a/src/test/ui/macro-path-prelude-fail-3.rs
+++ b/src/test/ui/macro-path-prelude-fail-3.rs
@@ -10,9 +10,9 @@
 
 #![feature(use_extern_macros)]
 
-#[derive(inline)] //~ ERROR expected a macro, found built-in attribute
+#[derive(inline)] //~ ERROR cannot find derive macro `inline` in this scope
 struct S;
 
 fn main() {
-    inline!(); //~ ERROR expected a macro, found built-in attribute
+    inline!(); //~ ERROR cannot find macro `inline!` in this scope
 }

--- a/src/test/ui/macro-path-prelude-fail-3.stderr
+++ b/src/test/ui/macro-path-prelude-fail-3.stderr
@@ -1,14 +1,14 @@
-error: expected a macro, found built-in attribute
+error: cannot find derive macro `inline` in this scope
   --> $DIR/macro-path-prelude-fail-3.rs:13:10
    |
-LL | #[derive(inline)] //~ ERROR expected a macro, found built-in attribute
+LL | #[derive(inline)] //~ ERROR cannot find derive macro `inline` in this scope
    |          ^^^^^^
 
-error: expected a macro, found built-in attribute
+error: cannot find macro `inline!` in this scope
   --> $DIR/macro-path-prelude-fail-3.rs:17:5
    |
-LL |     inline!(); //~ ERROR expected a macro, found built-in attribute
-   |     ^^^^^^
+LL |     inline!(); //~ ERROR cannot find macro `inline!` in this scope
+   |     ^^^^^^ help: you could try the macro: `line`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/macro-path-prelude-shadowing.rs
+++ b/src/test/ui/macro-path-prelude-shadowing.rs
@@ -21,7 +21,9 @@ add_macro_expanded_things_to_macro_prelude!();
 
 mod m1 {
     fn check() {
-        inline!(); //~ ERROR `inline` is ambiguous
+        inline!(); // OK. Theoretically ambiguous, but we do not consider built-in attributes
+                   // as candidates for non-attribute macro invocations to avoid regressions
+                   // on stable channel
     }
 }
 

--- a/src/test/ui/macro-path-prelude-shadowing.stderr
+++ b/src/test/ui/macro-path-prelude-shadowing.stderr
@@ -1,42 +1,21 @@
-error[E0659]: `inline` is ambiguous
-  --> $DIR/macro-path-prelude-shadowing.rs:24:9
-   |
-LL |         inline!(); //~ ERROR `inline` is ambiguous
-   |         ^^^^^^
-   |
-note: `inline` could refer to the name imported here
-  --> $DIR/macro-path-prelude-shadowing.rs:16:5
-   |
-LL |     #[macro_use]
-   |     ^^^^^^^^^^^^
-...
-LL | add_macro_expanded_things_to_macro_prelude!();
-   | ---------------------------------------------- in this macro invocation
-note: `inline` could also refer to the name defined here
-  --> $DIR/macro-path-prelude-shadowing.rs:24:9
-   |
-LL |         inline!(); //~ ERROR `inline` is ambiguous
-   |         ^^^^^^
-   = note: macro-expanded macro imports do not shadow
-
 error[E0659]: `std` is ambiguous
-  --> $DIR/macro-path-prelude-shadowing.rs:37:9
+  --> $DIR/macro-path-prelude-shadowing.rs:39:9
    |
 LL |         std::panic!(); //~ ERROR `std` is ambiguous
    |         ^^^^^^^^^^
    |
 note: `std` could refer to the name imported here
-  --> $DIR/macro-path-prelude-shadowing.rs:35:9
+  --> $DIR/macro-path-prelude-shadowing.rs:37:9
    |
 LL |     use m2::*; // glob-import user-defined `std`
    |         ^^^^^
 note: `std` could also refer to the name defined here
-  --> $DIR/macro-path-prelude-shadowing.rs:37:9
+  --> $DIR/macro-path-prelude-shadowing.rs:39:9
    |
 LL |         std::panic!(); //~ ERROR `std` is ambiguous
    |         ^^^
    = note: consider adding an explicit import of `std` to disambiguate
 
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0659`.


### PR DESCRIPTION
The first commit restores the old behavior for some minor unstable stuff (`rustc_*` and `derive_*` attributes) and adds a new feature gate for arbitrary tokens in non-macro attributes.

The second commit fixes https://github.com/rust-lang/rust/issues/53205

The third commit fixes https://github.com/rust-lang/rust/issues/53144.
Same technique is used as for other things blocking expansion progress - if something causes indeterminacy too often, then prohibit it.
In this case referring to crate-local macro-expanded `#[macro_export]` macros via module-relative paths is prohibited, see comments in code for more details.

cc https://github.com/rust-lang/rust/pull/50911
