### PR TITLE
Updated core/macros.rs to note it works in a no_std environment.

### DIFF
--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -349,19 +349,24 @@ macro_rules! try {
 /// write!(&mut v, "s = {:?}", s).unwrap(); // uses io::Write::write_fmt
 /// assert_eq!(v, b"s = \"abc 123\"");
 /// ```
+///
 /// Note : This macro can be used in no_std setups as well
-/// In a no_std setup you are responsible for the 
+/// In a no_std setup you are responsible for the
 /// implementation details of the components.
+///
 /// ```
 ///  # extern crate core;
 ///  use core::fmt::Write;
+///
 ///  struct Example{
 ///  }
+///
 ///  impl Write for Example{
 ///      fn write_str(&mut self, _s: &str) -> core::fmt::Result {
 ///           unimplemented!();
 ///      }
 ///  }
+///
 ///  let mut m = Example{};
 ///  write!(&mut m, "Hello World").expect("Not written");
 /// ```

--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -355,20 +355,19 @@ macro_rules! try {
 /// implementation details of the components.
 ///
 /// ```no_run
-///  # extern crate core;
-///  use core::fmt::Write;
+/// # extern crate core;
+/// use core::fmt::Write;
 ///
-///  struct Example{
-///  }
+/// struct Example;
 ///
-///  impl Write for Example{
-///      fn write_str(&mut self, _s: &str) -> core::fmt::Result {
-///           unimplemented!();
-///      }
-///  }
+/// impl Write for Example {
+///     fn write_str(&mut self, _s: &str) -> core::fmt::Result {
+///          unimplemented!();
+///     }
+/// }
 ///
-///  let mut m = Example{};
-///  write!(&mut m, "Hello World").expect("Not written");
+/// let mut m = Example{};
+/// write!(&mut m, "Hello World").expect("Not written");
 /// ```
 #[macro_export]
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -349,6 +349,34 @@ macro_rules! try {
 /// write!(&mut v, "s = {:?}", s).unwrap(); // uses io::Write::write_fmt
 /// assert_eq!(v, b"s = \"abc 123\"");
 /// ```
+
+/// /// Note : This macro can be used in no_std setups as well
+/// /// In a no_std setup you are responsible for the 
+/// /// implementation details of the components.
+
+/// ```rust
+///  extern crate core;
+///  use core::fmt::Write;
+
+///  #[derive(Debug)]
+///  struct Greetings<'a>{
+///      message : &'a str,
+///  }
+
+
+///  impl<'a> Write for Greetings<'a>{
+///      fn write_str(&mut self, _s: &str) -> core::fmt::Result {
+///           unimplemented!();
+///      }
+///  }
+
+///  fn main(){
+///      let mut m = Greetings{message: ""};
+///      write!(&mut m, "Hello World").expect("Not written");
+///  }
+/// ```
+
+
 #[macro_export]
 #[stable(feature = "rust1", since = "1.0.0")]
 macro_rules! write {

--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -349,34 +349,22 @@ macro_rules! try {
 /// write!(&mut v, "s = {:?}", s).unwrap(); // uses io::Write::write_fmt
 /// assert_eq!(v, b"s = \"abc 123\"");
 /// ```
-
-/// /// Note : This macro can be used in no_std setups as well
-/// /// In a no_std setup you are responsible for the 
-/// /// implementation details of the components.
-
-/// ```rust
-///  extern crate core;
+/// Note : This macro can be used in no_std setups as well
+/// In a no_std setup you are responsible for the 
+/// implementation details of the components.
+/// ```
+///  # extern crate core;
 ///  use core::fmt::Write;
-
-///  #[derive(Debug)]
-///  struct Greetings<'a>{
-///      message : &'a str,
+///  struct Example{
 ///  }
-
-
-///  impl<'a> Write for Greetings<'a>{
+///  impl Write for Example{
 ///      fn write_str(&mut self, _s: &str) -> core::fmt::Result {
 ///           unimplemented!();
 ///      }
 ///  }
-
-///  fn main(){
-///      let mut m = Greetings{message: ""};
-///      write!(&mut m, "Hello World").expect("Not written");
-///  }
+///  let mut m = Example{};
+///  write!(&mut m, "Hello World").expect("Not written");
 /// ```
-
-
 #[macro_export]
 #[stable(feature = "rust1", since = "1.0.0")]
 macro_rules! write {

--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -350,7 +350,7 @@ macro_rules! try {
 /// assert_eq!(v, b"s = \"abc 123\"");
 /// ```
 ///
-/// Note: This macro can be used in no_std setups as well
+/// Note: This macro can be used in `no_std` setups as well
 /// In a `no_std` setup you are responsible for the
 /// implementation details of the components.
 ///

--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -350,8 +350,8 @@ macro_rules! try {
 /// assert_eq!(v, b"s = \"abc 123\"");
 /// ```
 ///
-/// Note : This macro can be used in no_std setups as well
-/// In a no_std setup you are responsible for the
+/// Note: This macro can be used in no_std setups as well
+/// In a `no_std` setup you are responsible for the
 /// implementation details of the components.
 ///
 /// ```no_run

--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -354,7 +354,7 @@ macro_rules! try {
 /// In a no_std setup you are responsible for the
 /// implementation details of the components.
 ///
-/// ```
+/// ```no_run
 ///  # extern crate core;
 ///  use core::fmt::Write;
 ///


### PR DESCRIPTION
Fixes #45797 
This PR updates the documentation of `write!` to note it works in a `no_std` environment, and adds an
example to showcase this. In a `no_std` environment, the author of the code is responsible for the
implementation of the `Write` trait. This example will work out of the box with `no_std`, but the
implementation of `Write` is expected to be provided by the user.

r? @steveklabnik 