### PR TITLE
[experiment] use unreachable_unchecked() everywhere

### DIFF
--- a/src/liballoc/borrow.rs
+++ b/src/liballoc/borrow.rs
@@ -208,7 +208,7 @@ impl<'a, B: ?Sized> Cow<'a, B>
             Borrowed(borrowed) => {
                 *self = Owned(borrowed.to_owned());
                 match *self {
-                    Borrowed(..) => unreachable!(),
+                    Borrowed(..) => unsafe { ::core::hint::unreachable_unchecked() },
                     Owned(ref mut owned) => owned,
                 }
             }

--- a/src/liballoc/collections/btree/map.rs
+++ b/src/liballoc/collections/btree/map.rs
@@ -164,7 +164,7 @@ impl<K: Clone, V: Clone> Clone for BTreeMap<K, V> {
                     {
                         let mut out_node = match out_tree.root.as_mut().force() {
                             Leaf(leaf) => leaf,
-                            Internal(_) => unreachable!(),
+                            Internal(_) => unsafe { ::core::hint::unreachable_unchecked() },
                         };
 
                         let mut in_edge = leaf.first_edge();
@@ -979,7 +979,7 @@ impl<K: Ord, V> BTreeMap<K, V> {
                 // We need to steal.
                 let mut last_kv = match last_edge.left_kv() {
                     Ok(left) => left,
-                    Err(_) => unreachable!(),
+                    Err(_) => unsafe { ::core::hint::unreachable_unchecked() },
                 };
                 last_kv.bulk_steal_left(node::MIN_LEN - right_child_len);
                 last_edge = last_kv.right_edge();
@@ -1057,7 +1057,7 @@ impl<K: Ord, V> BTreeMap<K, V> {
                         break;
                     }
                     _ => {
-                        unreachable!();
+                        unsafe { ::core::hint::unreachable_unchecked() };
                     }
                 }
             }
@@ -2508,7 +2508,7 @@ impl<'a, K: Ord, V> OccupiedEntry<'a, K, V> {
         while cur_node.len() < node::CAPACITY / 2 {
             match handle_underfull_node(cur_node) {
                 AtRoot => break,
-                EmptyParent(_) => unreachable!(),
+                EmptyParent(_) => unsafe { ::core::hint::unreachable_unchecked() },
                 Merged(parent) => {
                     if parent.len() == 0 {
                         // We must be at the root

--- a/src/liballoc/collections/btree/node.rs
+++ b/src/liballoc/collections/btree/node.rs
@@ -1425,7 +1425,7 @@ impl<'a, K, V> Handle<NodeRef<marker::Mut<'a>, K, V, marker::Internal>, marker::
                     move_edges(left, new_left_len + 1, right, 0, count);
                 },
                 (ForceResult::Leaf(_), ForceResult::Leaf(_)) => { }
-                _ => { unreachable!(); }
+                _ => { ::core::hint::unreachable_unchecked(); }
             }
         }
     }
@@ -1486,7 +1486,7 @@ impl<'a, K, V> Handle<NodeRef<marker::Mut<'a>, K, V, marker::Internal>, marker::
                     right.correct_childrens_parent_links(0, new_right_len + 1);
                 },
                 (ForceResult::Leaf(_), ForceResult::Leaf(_)) => { }
-                _ => { unreachable!(); }
+                _ => { ::core::hint::unreachable_unchecked(); }
             }
         }
     }
@@ -1571,7 +1571,7 @@ impl<'a, K, V> Handle<NodeRef<marker::Mut<'a>, K, V, marker::LeafOrInternal>, ma
                     move_edges(left, left_new_len + 1, right, 1, right_new_len);
                 },
                 (ForceResult::Leaf(_), ForceResult::Leaf(_)) => { }
-                _ => { unreachable!(); }
+                _ => { ::core::hint::unreachable_unchecked(); }
             }
         }
     }

--- a/src/liballoc/raw_vec.rs
+++ b/src/liballoc/raw_vec.rs
@@ -421,7 +421,7 @@ impl<T, A: Alloc> RawVec<T, A> {
     pub fn reserve_exact(&mut self, used_cap: usize, needed_extra_cap: usize) {
         match self.reserve_internal(used_cap, needed_extra_cap, Infallible, Exact) {
             Err(CapacityOverflow) => capacity_overflow(),
-            Err(AllocErr) => unreachable!(),
+            Err(AllocErr) => unsafe { ::core::hint::unreachable_unchecked() },
             Ok(()) => { /* yay */ }
          }
      }
@@ -501,7 +501,7 @@ impl<T, A: Alloc> RawVec<T, A> {
     pub fn reserve(&mut self, used_cap: usize, needed_extra_cap: usize) {
         match self.reserve_internal(used_cap, needed_extra_cap, Infallible, Amortized) {
             Err(CapacityOverflow) => capacity_overflow(),
-            Err(AllocErr) => unreachable!(),
+            Err(AllocErr) => unsafe { ::core::hint::unreachable_unchecked() },
             Ok(()) => { /* yay */ }
         }
     }

--- a/src/liballoc/tests/btree/map.rs
+++ b/src/liballoc/tests/btree/map.rs
@@ -368,7 +368,7 @@ fn test_entry() {
 
     // Existing key (insert)
     match map.entry(1) {
-        Vacant(_) => unreachable!(),
+        Vacant(_) => unsafe { ::core::hint::unreachable_unchecked() },
         Occupied(mut view) => {
             assert_eq!(view.get(), &10);
             assert_eq!(view.insert(100), 10);
@@ -380,7 +380,7 @@ fn test_entry() {
 
     // Existing key (update)
     match map.entry(2) {
-        Vacant(_) => unreachable!(),
+        Vacant(_) => unsafe { ::core::hint::unreachable_unchecked() },
         Occupied(mut view) => {
             let v = view.get_mut();
             *v *= 10;
@@ -391,7 +391,7 @@ fn test_entry() {
 
     // Existing key (take)
     match map.entry(3) {
-        Vacant(_) => unreachable!(),
+        Vacant(_) => unsafe { ::core::hint::unreachable_unchecked() },
         Occupied(view) => {
             assert_eq!(view.remove(), 30);
         }
@@ -402,7 +402,7 @@ fn test_entry() {
 
     // Inexistent key (insert)
     match map.entry(10) {
-        Occupied(_) => unreachable!(),
+        Occupied(_) => unsafe { ::core::hint::unreachable_unchecked() },
         Vacant(view) => {
             assert_eq!(*view.insert(1000), 1000);
         }

--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -323,6 +323,7 @@ use ops::{self, Try};
 use usize;
 use intrinsics;
 use mem;
+use super::hint;
 
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::iterator::Iterator;
@@ -1177,7 +1178,7 @@ impl<A, B> ZipImpl<A, B> for Zip<A, B>
         match (self.a.next_back(), self.b.next_back()) {
             (Some(x), Some(y)) => Some((x, y)),
             (None, None) => None,
-            _ => unreachable!(),
+            _ => unsafe { hint::unreachable_unchecked() },
         }
     }
 
@@ -2035,7 +2036,7 @@ impl<I: Iterator> Peekable<I> {
         match self.peeked {
             Some(Some(ref value)) => Some(value),
             Some(None) => None,
-            _ => unreachable!(),
+            _ => unsafe { hint::unreachable_unchecked() },
         }
     }
 }

--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -459,7 +459,7 @@ macro_rules! writeln {
 ///         if 3*i < i { panic!("u32 overflow"); }
 ///         if x < 3*i { return i-1; }
 ///     }
-///     unreachable!();
+///     unreachable!()
 /// }
 /// ```
 #[macro_export]

--- a/src/libcore/num/dec2flt/rawfp.rs
+++ b/src/libcore/num/dec2flt/rawfp.rs
@@ -36,6 +36,7 @@ use num::FpCategory::{Infinite, Zero, Subnormal, Normal, Nan};
 use num::FpCategory;
 use num::dec2flt::num::{self, Big};
 use num::dec2flt::table;
+use super::super::super::hint;
 
 #[derive(Copy, Clone, Debug)]
 pub struct Unpacked {
@@ -298,14 +299,16 @@ pub fn encode_normal<T: RawFloat>(x: Unpacked) -> T {
         "encode_normal: exponent out of range");
     // Leave sign bit at 0 ("+"), our numbers are all positive
     let bits = (k_enc as u64) << T::EXPLICIT_SIG_BITS | sig_enc;
-    T::from_bits(bits.try_into().unwrap_or_else(|_| unreachable!()))
+    T::from_bits(bits.try_into().unwrap_or_else(|_|
+        unsafe { hint::unreachable_unchecked() }))
 }
 
 /// Construct a subnormal. A mantissa of 0 is allowed and constructs zero.
 pub fn encode_subnormal<T: RawFloat>(significand: u64) -> T {
     assert!(significand < T::MIN_SIG, "encode_subnormal: not actually subnormal");
     // Encoded exponent is 0, the sign bit is 0, so we just have to reinterpret the bits.
-    T::from_bits(significand.try_into().unwrap_or_else(|_| unreachable!()))
+    T::from_bits(significand.try_into().unwrap_or_else(|_|
+        unsafe { hint::unreachable_unchecked() }))
 }
 
 /// Approximate a bignum with an Fp. Rounds within 0.5 ULP with half-to-even.

--- a/src/libcore/tests/slice.rs
+++ b/src/libcore/tests/slice.rs
@@ -399,7 +399,7 @@ fn test_iter_ref_consistency() {
         let v : &[T] = &[x, x, x];
         let v_ptrs : [*const T; 3] = match v {
             [ref v1, ref v2, ref v3] => [v1 as *const _, v2 as *const _, v3 as *const _],
-            _ => unreachable!()
+            _ => unsafe { ::core::hint::unreachable_unchecked() }
         };
         let len = v.len();
 
@@ -455,7 +455,7 @@ fn test_iter_ref_consistency() {
         let v_ptrs : [*mut T; 3] = match v {
             [ref v1, ref v2, ref v3] =>
               [v1 as *const _ as *mut _, v2 as *const _ as *mut _, v3 as *const _ as *mut _],
-            _ => unreachable!()
+            _ => unsafe { ::core::hint::unreachable_unchecked() }
         };
         let len = v.len();
 

--- a/src/libpanic_unwind/emcc.rs
+++ b/src/libpanic_unwind/emcc.rs
@@ -46,7 +46,7 @@ pub unsafe fn panic(data: Box<dyn Any + Send>) -> u32 {
     ptr::write(exception, data);
     __cxa_throw(exception as *mut _, ptr::null_mut(), ptr::null_mut());
 
-    unreachable!()
+    unsafe { ::core::hint::unreachable_unchecked() }
 }
 
 #[lang = "eh_personality"]

--- a/src/libproc_macro/quote.rs
+++ b/src/libproc_macro/quote.rs
@@ -128,7 +128,7 @@ pub fn quote(stream: TokenStream) -> TokenStream {
                         lit.set_span((@ quote_span(tt.span())));
                         lit
                     } else {
-                        unreachable!()
+                        unsafe { ::std::hint::unreachable_unchecked() }
                     }
                 }))
             })),))

--- a/src/libproc_macro/rustc.rs
+++ b/src/libproc_macro/rustc.rs
@@ -179,8 +179,10 @@ impl TokenTree {
             }),
 
             DotEq => op!('.', '='),
-            OpenDelim(..) | CloseDelim(..) => unreachable!(),
-            Whitespace | Comment | Shebang(..) | Eof => unreachable!(),
+            OpenDelim(..) | CloseDelim(..) => unsafe { ::std::hint::unreachable_unchecked() },
+            Whitespace | Comment | Shebang(..) | Eof => unsafe {
+                ::std::hint::unreachable_unchecked()
+            },
         }
     }
 
@@ -260,7 +262,7 @@ impl TokenTree {
             '$' => Dollar,
             '?' => Question,
             '\'' => SingleQuote,
-            _ => unreachable!(),
+            _ => unsafe { ::std::hint::unreachable_unchecked() },
         };
 
         let tree = TokenTree::Token(span.0, token);

--- a/src/librustc/hir/def_id.rs
+++ b/src/librustc/hir/def_id.rs
@@ -104,7 +104,7 @@ impl DefIndex {
         match self.0 & 1 {
             0 => DefIndexAddressSpace::Low,
             1 => DefIndexAddressSpace::High,
-            _ => unreachable!()
+            _ => unsafe { ::core::hint::unreachable_unchecked() }
         }
     }
 

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -3786,7 +3786,9 @@ impl<'a> LoweringContext<'a> {
                     (&None, &Some(..), HalfOpen) => "RangeTo",
                     (&Some(..), &Some(..), HalfOpen) => "Range",
                     (&None, &Some(..), Closed) => "RangeToInclusive",
-                    (&Some(..), &Some(..), Closed) => unreachable!(),
+                    (&Some(..), &Some(..), Closed) => unsafe {
+                        ::core::hint::unreachable_unchecked()
+                    },
                     (_, &None, Closed) => self.diagnostic()
                         .span_fatal(e.span, "inclusive range with no end")
                         .raise(),

--- a/src/librustc/hir/print.rs
+++ b/src/librustc/hir/print.rs
@@ -2057,7 +2057,7 @@ impl<'a> State<'a> {
                 self.print_type(&ty)?;
                 self.maybe_print_comment(ty.span.lo())
             }
-            hir::DefaultReturn(..) => unreachable!(),
+            hir::DefaultReturn(..) => unsafe { ::core::hint::unreachable_unchecked() },
         }
     }
 
@@ -2224,7 +2224,7 @@ impl<'a> State<'a> {
         self.ibox(indent_unit)?;
         self.word_space("->")?;
         match decl.output {
-            hir::DefaultReturn(..) => unreachable!(),
+            hir::DefaultReturn(..) => unsafe { ::core::hint::unreachable_unchecked() },
             hir::Return(ref ty) => self.print_type(&ty)?,
         }
         self.end()?;

--- a/src/librustc/infer/error_reporting/mod.rs
+++ b/src/librustc/infer/error_reporting/mod.rs
@@ -198,7 +198,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
             Some(hir_map::NodeItem(it)) => Self::item_scope_tag(&it),
             Some(hir_map::NodeTraitItem(it)) => Self::trait_item_scope_tag(&it),
             Some(hir_map::NodeImplItem(it)) => Self::impl_item_scope_tag(&it),
-            _ => unreachable!()
+            _ => unsafe { ::core::hint::unreachable_unchecked() }
         };
         let (prefix, span) = match *region {
             ty::ReEarlyBound(ref br) => {

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -302,7 +302,7 @@ impl LintStore {
             CheckLintNameResult::NoLint => {
                 Some(struct_err!(sess, E0602, "unknown lint: `{}`", lint_name))
             }
-            CheckLintNameResult::Tool(_) => unreachable!(),
+            CheckLintNameResult::Tool(_) => unsafe { ::core::hint::unreachable_unchecked() },
         };
 
         if let Some(mut db) = db {

--- a/src/librustc/middle/reachable.rs
+++ b/src/librustc/middle/reachable.rs
@@ -374,7 +374,7 @@ impl<'a, 'tcx: 'a> ItemLikeVisitor<'tcx> for CollectPrivateImplItemsVisitor<'a, 
 
                 let trait_def_id = match trait_ref.path.def {
                     Def::Trait(def_id) => def_id,
-                    _ => unreachable!()
+                    _ => unsafe { ::core::hint::unreachable_unchecked() }
                 };
 
                 if !trait_def_id.is_local() {

--- a/src/librustc/mir/tcx.rs
+++ b/src/librustc/mir/tcx.rs
@@ -308,7 +308,7 @@ impl BinOp {
             BinOp::Gt => hir::BinOpKind::Gt,
             BinOp::Le => hir::BinOpKind::Le,
             BinOp::Ge => hir::BinOpKind::Ge,
-            BinOp::Offset => unreachable!()
+            BinOp::Offset => unsafe { ::core::hint::unreachable_unchecked() }
         }
     }
 }

--- a/src/librustc/traits/project.rs
+++ b/src/librustc/traits/project.rs
@@ -171,7 +171,7 @@ impl<'tcx> ProjectionTyCandidateSet<'tcx> {
                 match (current, candidate) {
                     (ParamEnv(..), ParamEnv(..)) => convert_to_ambiguous = (),
                     (ParamEnv(..), _) => return false,
-                    (_, ParamEnv(..)) => { unreachable!(); }
+                    (_, ParamEnv(..)) => { unsafe { ::core::hint::unreachable_unchecked() }; }
                     (_, _) => convert_to_ambiguous = (),
                 }
             }

--- a/src/librustc/ty/query/on_disk_cache.rs
+++ b/src/librustc/ty/query/on_disk_cache.rs
@@ -658,7 +658,7 @@ impl<'a, 'tcx, 'x> SpecializedDecoder<Span> for CacheDecoder<'a, 'tcx, 'x> {
                 }
             }
             _ => {
-                unreachable!()
+                unsafe { ::core::hint::unreachable_unchecked() }
             }
         };
 
@@ -751,7 +751,7 @@ for CacheDecoder<'a, 'tcx, 'x> {
                 Ok(mir::ClearCrossCrate::Set(val))
             }
             _ => {
-                unreachable!()
+                unsafe { ::core::hint::unreachable_unchecked() }
             }
         }
     }

--- a/src/librustc/ty/query/plumbing.rs
+++ b/src/librustc/ty/query/plumbing.rs
@@ -650,7 +650,7 @@ macro_rules! handle_cycle_error {
     }};
     ([fatal_cycle$(, $modifiers:ident)*][$this:expr]) => {{
         $this.sess.abort_if_errors();
-        unreachable!();
+        unsafe { ::core::hint::unreachable_unchecked() };
     }};
     ([$other:ident$(, $modifiers:ident)*][$($args:tt)*]) => {
         handle_cycle_error!([$($modifiers),*][$($args)*])

--- a/src/librustc/util/bug.rs
+++ b/src/librustc/util/bug.rs
@@ -47,5 +47,5 @@ fn opt_span_bug_fmt<S: Into<MultiSpan>>(
             (None, _) => panic!(msg),
         }
     });
-    unreachable!();
+    unsafe { ::core::hint::unreachable_unchecked() };
 }

--- a/src/librustc_apfloat/ieee.rs
+++ b/src/librustc_apfloat/ieee.rs
@@ -1756,7 +1756,7 @@ impl<S: Semantics> IeeeFloat<S> {
                             1..=7 => Loss::LessThanHalf,
                             8 => Loss::ExactlyHalf,
                             9..=15 => Loss::MoreThanHalf,
-                            _ => unreachable!(),
+                            _ => unsafe { ::std::hint::unreachable_unchecked() },
                         });
                     }
                 }

--- a/src/librustc_apfloat/lib.rs
+++ b/src/librustc_apfloat/lib.rs
@@ -43,7 +43,6 @@
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
       html_root_url = "https://doc.rust-lang.org/nightly/")]
-#![forbid(unsafe_code)]
 
 #![cfg_attr(not(stage0), feature(nll))]
 #![feature(try_from)]

--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -728,7 +728,7 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
         });
         let (move_span, move_note) = match the_move.kind {
             move_data::Declared => {
-                unreachable!();
+                unsafe { ::std::hint::unreachable_unchecked() };
             }
 
             move_data::MoveExpr |

--- a/src/librustc_codegen_llvm/back/lto.rs
+++ b/src/librustc_codegen_llvm/back/lto.rs
@@ -201,7 +201,7 @@ pub(crate) fn run(cgcx: &CodegenContext,
             }
             thin_lto(&diag_handler, modules, upstream_modules, &arr, timeline)
         }
-        Lto::No => unreachable!(),
+        Lto::No => unsafe { ::std::hint::unreachable_unchecked() },
     }
 }
 

--- a/src/librustc_codegen_llvm/intrinsic.rs
+++ b/src/librustc_codegen_llvm/intrinsic.rs
@@ -1289,7 +1289,7 @@ fn generic_simd_intrinsic(
             ty::TyInt(v) => format!("v{}{}i{}", vec_len, p0s, v.bit_width().unwrap()),
             ty::TyUint(v) => format!("v{}{}i{}", vec_len, p0s, v.bit_width().unwrap()),
             ty::TyFloat(v) => format!("v{}{}f{}", vec_len, p0s, v.bit_width()),
-            _ => unreachable!(),
+            _ => unsafe { ::std::hint::unreachable_unchecked() },
         }
     }
 
@@ -1300,7 +1300,7 @@ fn generic_simd_intrinsic(
             ty::TyInt(v) => Type::int_from_ty(cx, v),
             ty::TyUint(v) => Type::uint_from_ty(cx, v),
             ty::TyFloat(v) => Type::float_from_ty(cx, v),
-            _ => unreachable!(),
+            _ => unsafe { ::std::hint::unreachable_unchecked() },
         };
         while no_pointers > 0 {
             elem_ty = elem_ty.ptr_to();
@@ -1365,7 +1365,7 @@ fn generic_simd_intrinsic(
                                  argument `{}`, found `{}` != `*_ {}`",
                          arg_tys[1].simd_type(tcx).sty, arg_tys[1], in_elem, in_ty,
                          arg_tys[1].simd_type(tcx).sty, in_elem);
-                unreachable!();
+                unsafe { ::std::hint::unreachable_unchecked() };
             }
         };
         assert!(pointer_count > 0);
@@ -1462,7 +1462,7 @@ fn generic_simd_intrinsic(
                                  argument `{}`, found `{}` != `*mut {}`",
                          arg_tys[1].simd_type(tcx).sty, arg_tys[1], in_elem, in_ty,
                          arg_tys[1].simd_type(tcx).sty, in_elem);
-                unreachable!();
+                unsafe { ::std::hint::unreachable_unchecked() };
             }
         };
         assert!(pointer_count > 0);

--- a/src/librustc_codegen_llvm/mir/rvalue.rs
+++ b/src/librustc_codegen_llvm/mir/rvalue.rs
@@ -583,7 +583,7 @@ impl FunctionCx<'a, 'll, 'tcx> {
                 C_bool(bx.cx, match op {
                     mir::BinOp::Ne | mir::BinOp::Lt | mir::BinOp::Gt => false,
                     mir::BinOp::Eq | mir::BinOp::Le | mir::BinOp::Ge => true,
-                    _ => unreachable!()
+                    _ => unsafe { ::std::hint::unreachable_unchecked() }
                 })
             } else if is_float {
                 bx.fcmp(
@@ -669,7 +669,7 @@ impl FunctionCx<'a, 'll, 'tcx> {
                     mir::BinOp::Add => OverflowOp::Add,
                     mir::BinOp::Sub => OverflowOp::Sub,
                     mir::BinOp::Mul => OverflowOp::Mul,
-                    _ => unreachable!()
+                    _ => unsafe { ::std::hint::unreachable_unchecked() }
                 };
                 let intrinsic = get_overflow_intrinsic(oop, bx, input_ty);
                 let res = bx.call(intrinsic, &[lhs, rhs], None);
@@ -753,7 +753,7 @@ fn get_overflow_intrinsic(oop: OverflowOp, bx: &Builder<'_, 'll, '_>, ty: Ty) ->
             TyUint(U64) => "llvm.uadd.with.overflow.i64",
             TyUint(U128) => "llvm.uadd.with.overflow.i128",
 
-            _ => unreachable!(),
+            _ => unsafe { ::std::hint::unreachable_unchecked() },
         },
         OverflowOp::Sub => match new_sty {
             TyInt(I8) => "llvm.ssub.with.overflow.i8",
@@ -768,7 +768,7 @@ fn get_overflow_intrinsic(oop: OverflowOp, bx: &Builder<'_, 'll, '_>, ty: Ty) ->
             TyUint(U64) => "llvm.usub.with.overflow.i64",
             TyUint(U128) => "llvm.usub.with.overflow.i128",
 
-            _ => unreachable!(),
+            _ => unsafe { ::std::hint::unreachable_unchecked() },
         },
         OverflowOp::Mul => match new_sty {
             TyInt(I8) => "llvm.smul.with.overflow.i8",
@@ -783,7 +783,7 @@ fn get_overflow_intrinsic(oop: OverflowOp, bx: &Builder<'_, 'll, '_>, ty: Ty) ->
             TyUint(U64) => "llvm.umul.with.overflow.i64",
             TyUint(U128) => "llvm.umul.with.overflow.i128",
 
-            _ => unreachable!(),
+            _ => unsafe { ::std::hint::unreachable_unchecked() },
         },
     };
 

--- a/src/librustc_data_structures/obligation_forest/mod.rs
+++ b/src/librustc_data_structures/obligation_forest/mod.rs
@@ -515,7 +515,9 @@ impl<O: ForestObligation> ObligationForest<O> {
                     node_rewrites[i] = nodes_len;
                     dead_nodes += 1;
                 }
-                NodeState::OnDfsStack | NodeState::Success => unreachable!()
+                NodeState::OnDfsStack | NodeState::Success => unsafe {
+                    ::core::hint::unreachable_unchecked()
+                }
             }
         }
 
@@ -534,7 +536,7 @@ impl<O: ForestObligation> ObligationForest<O> {
                                  match node.state.get() {
                                      NodeState::Error => None,
                                      NodeState::Done => Some(node.obligation),
-                                     _ => unreachable!()
+                                     _ => unsafe { ::core::hint::unreachable_unchecked() }
                                  }
                              })
             .collect();

--- a/src/librustc_data_structures/small_vec.rs
+++ b/src/librustc_data_structures/small_vec.rs
@@ -95,7 +95,7 @@ impl<A: Array> SmallVec<A> {
                     if let AccumulateVec::Array(array) = array {
                         match self.0 {
                             AccumulateVec::Heap(ref mut vec) => vec.extend(array),
-                            _ => unreachable!()
+                            _ => unsafe { ::core::hint::unreachable_unchecked() }
                         }
                     }
                 }

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -252,7 +252,9 @@ pub fn get_codegen_backend(sess: &Session) -> Box<dyn CodegenBackend> {
 
     #[allow(deprecated)]
     #[no_debug]
-    static mut LOAD: fn() -> Box<dyn CodegenBackend> = || unreachable!();
+    static mut LOAD: fn() -> Box<dyn CodegenBackend> = || unsafe {
+        ::std::hint::unreachable_unchecked()
+    };
 
     INIT.call_once(|| {
         let codegen_name = sess.opts.debugging_opts.codegen_backend.as_ref()

--- a/src/librustc_driver/pretty.rs
+++ b/src/librustc_driver/pretty.rs
@@ -965,7 +965,7 @@ pub fn print_after_parsing(sess: &Session,
             })
             .unwrap()
     } else {
-        unreachable!();
+        unsafe { ::std::hint::unreachable_unchecked() };
     };
 
     write_output(out, ofile);
@@ -1116,7 +1116,7 @@ pub fn print_after_hir_lowering<'tcx, 'a: 'tcx>(sess: &'a Session,
                 })
             }
 
-            _ => unreachable!(),
+            _ => unsafe { ::std::hint::unreachable_unchecked() },
         }
         .unwrap();
 
@@ -1168,13 +1168,13 @@ fn print_with_analysis<'tcx, 'a: 'tcx>(sess: &'a Session,
                     match ppm {
                         PpmMir => write_mir_pretty(tcx, Some(def_id), &mut out),
                         PpmMirCFG => write_mir_graphviz(tcx, Some(def_id), &mut out),
-                        _ => unreachable!(),
+                        _ => unsafe { ::std::hint::unreachable_unchecked() },
                     }?;
                 } else {
                     match ppm {
                         PpmMir => write_mir_pretty(tcx, None, &mut out),
                         PpmMirCFG => write_mir_graphviz(tcx, None, &mut out),
-                        _ => unreachable!(),
+                        _ => unsafe { ::std::hint::unreachable_unchecked() },
                     }?;
                 }
                 Ok(())
@@ -1204,7 +1204,7 @@ fn print_with_analysis<'tcx, 'a: 'tcx>(sess: &'a Session,
                     }
                 }
             }
-            _ => unreachable!(),
+            _ => unsafe { ::std::hint::unreachable_unchecked() },
         }
     }),
                  sess)

--- a/src/librustc_driver/profile/mod.rs
+++ b/src/librustc_driver/profile/mod.rs
@@ -136,8 +136,10 @@ fn profile_queries_thread(r:Receiver<ProfileQueriesMsg>) {
                 profq_msgs.push(msg.clone());
                 // Respond to the message, knowing that we've already handled Halt and Dump, above.
                 match (frame.parse_st.clone(), msg) {
-                    (_,ProfileQueriesMsg::Halt) => unreachable!(),
-                    (_,ProfileQueriesMsg::Dump(_)) => unreachable!(),
+                    (_,ProfileQueriesMsg::Halt) => unsafe { ::std::hint::unreachable_unchecked() },
+                    (_,ProfileQueriesMsg::Dump(_)) => unsafe {
+                        ::std::hint::unreachable_unchecked()
+                    },
 
                     // Parse State: Clear
                     (ParseState::Clear,
@@ -304,10 +306,10 @@ fn profile_queries_thread(r:Receiver<ProfileQueriesMsg>) {
                     },
 
                     (ParseState::HaveTimeBegin(_, _), _) => {
-                        unreachable!()
+                        unsafe { ::std::hint::unreachable_unchecked() }
                     },
                     (ParseState::HaveTaskBegin(_, _), _) => {
-                        unreachable!()
+                        unsafe { ::std::hint::unreachable_unchecked() }
                     },
                 }
 

--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -749,7 +749,7 @@ impl Level {
                     .set_intense(true);
             }
             FailureNote => {}
-            Cancelled => unreachable!(),
+            Cancelled => unsafe { ::std::hint::unreachable_unchecked() },
         }
         spec
     }

--- a/src/librustc_incremental/persist/dirty_clean.rs
+++ b/src/librustc_incremental/persist/dirty_clean.rs
@@ -465,7 +465,7 @@ impl<'a, 'tcx> DirtyCleanVisitor<'a, 'tcx> {
             .map(move |label| {
                 match DepNode::from_label_string(label, def_path_hash) {
                     Ok(dep_node) => dep_node,
-                    Err(()) => unreachable!(),
+                    Err(()) => unsafe { ::std::hint::unreachable_unchecked() },
                 }
             })
     }

--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -872,7 +872,7 @@ impl<'a, 'b: 'a, 'tcx: 'b> IsolatedEncoder<'a, 'b, 'tcx> {
                         None
                     }
                 }
-                ty::AssociatedKind::Existential => unreachable!(),
+                ty::AssociatedKind::Existential => unsafe { ::std::hint::unreachable_unchecked() },
             },
             inherent_impls: LazySeq::empty(),
             variances: if trait_item.kind == ty::AssociatedKind::Method {

--- a/src/librustc_metadata/locator.rs
+++ b/src/librustc_metadata/locator.rs
@@ -426,7 +426,7 @@ impl<'a> Context<'a> {
 
         err.emit();
         self.sess.abort_if_errors();
-        unreachable!();
+        unsafe { ::std::hint::unreachable_unchecked() }
     }
 
     fn find_library_crate(&mut self,

--- a/src/librustc_mir/borrow_check/error_reporting.rs
+++ b/src/librustc_mir/borrow_check/error_reporting.rs
@@ -342,7 +342,9 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
                     Origin::Mir,
                 ),
 
-            (BorrowKind::Shared, _, _, BorrowKind::Shared, _, _) => unreachable!(),
+            (BorrowKind::Shared, _, _, BorrowKind::Shared, _, _) => unsafe {
+                ::core::hint::unreachable_unchecked()
+            },
         };
 
         if issued_spans == borrow_spans {

--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -1342,7 +1342,7 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
                 let af = match *rvalue {
                     Rvalue::Len(..) => ArtificialField::ArrayLength,
                     Rvalue::Discriminant(..) => ArtificialField::Discriminant,
-                    _ => unreachable!(),
+                    _ => unsafe { ::core::hint::unreachable_unchecked() },
                 };
                 self.access_place(
                     context,
@@ -1886,7 +1886,7 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
                 let is_local_mutation_allowed = match borrow_kind {
                     BorrowKind::Unique => LocalMutationIsAllowed::Yes,
                     BorrowKind::Mut { .. } => is_local_mutation_allowed,
-                    BorrowKind::Shared => unreachable!(),
+                    BorrowKind::Shared => unsafe { ::core::hint::unreachable_unchecked() },
                 };
                 match self.is_mutable(place, is_local_mutation_allowed) {
                     Ok(root_place) => {

--- a/src/librustc_mir/borrow_check/move_errors.rs
+++ b/src/librustc_mir/borrow_check/move_errors.rs
@@ -243,7 +243,9 @@ impl<'a, 'gcx, 'tcx> MirBorrowckCtxt<'a, 'gcx, 'tcx> {
                                                 proj.base == Place::Local(Local::new(1))
                                             }
                                             Place::Promoted(_) |
-                                            Place::Local(_) | Place::Static(_) => unreachable!(),
+                                            Place::Local(_) | Place::Static(_) => unsafe {
+                                                ::core::hint::unreachable_unchecked()
+                                            },
                                         }
                                     } =>
                             {

--- a/src/librustc_mir/borrow_check/mutability_errors.rs
+++ b/src/librustc_mir/borrow_check/mutability_errors.rs
@@ -124,7 +124,7 @@ impl<'a, 'gcx, 'tcx> MirBorrowckCtxt<'a, 'gcx, 'tcx> {
                 }
             }
 
-            Place::Promoted(_) => unreachable!(),
+            Place::Promoted(_) => unsafe { ::core::hint::unreachable_unchecked() },
 
             Place::Static(box Static { def_id, ty: _ }) => {
                 if let Place::Static(_) = access_place {
@@ -319,7 +319,9 @@ impl<'a, 'gcx, 'tcx> MirBorrowckCtxt<'a, 'gcx, 'tcx> {
                     })) => suggest_ref_mut(self.tcx, local_decl.source_info.span),
 
                     //
-                    ClearCrossCrate::Set(mir::BindingForm::RefForGuard) => unreachable!(),
+                    ClearCrossCrate::Set(mir::BindingForm::RefForGuard) => unsafe {
+                        ::core::hint::unreachable_unchecked()
+                    },
 
                     ClearCrossCrate::Clear => bug!("saw cleared local state"),
                 };

--- a/src/librustc_mir/borrow_check/nll/invalidation.rs
+++ b/src/librustc_mir/borrow_check/nll/invalidation.rs
@@ -437,7 +437,7 @@ impl<'cg, 'cx, 'tcx, 'gcx> InvalidationGenerator<'cg, 'cx, 'tcx, 'gcx> {
                 let af = match *rvalue {
                     Rvalue::Len(..) => ArtificialField::ArrayLength,
                     Rvalue::Discriminant(..) => ArtificialField::Discriminant,
-                    _ => unreachable!(),
+                    _ => unsafe { ::core::hint::unreachable_unchecked() },
                 };
                 self.access_place(
                     context,

--- a/src/librustc_mir/build/scope.rs
+++ b/src/librustc_mir/build/scope.rs
@@ -943,7 +943,7 @@ fn build_scope_drops<'tcx>(cfg: &mut CFG<'tcx>,
                             kind: StatementKind::StorageDead(index)
                         });
                     }
-                    _ => unreachable!(),
+                    _ => unsafe { ::core::hint::unreachable_unchecked() },
                 }
             }
         }

--- a/src/librustc_mir/transform/add_moves_for_packed_drops.rs
+++ b/src/librustc_mir/transform/add_moves_for_packed_drops.rs
@@ -112,7 +112,7 @@ fn add_move_for_packed_drop<'a, 'tcx>(
     let (location, target, unwind) = match terminator.kind {
         TerminatorKind::Drop { ref location, target, unwind } =>
             (location, target, unwind),
-        _ => unreachable!()
+        _ => unsafe { ::core::hint::unreachable_unchecked() }
     };
 
     let source_info = terminator.source_info;

--- a/src/librustc_mir/transform/simplify.rs
+++ b/src/librustc_mir/transform/simplify.rs
@@ -163,7 +163,7 @@ impl<'a, 'tcx: 'a> CfgSimplifier<'a, 'tcx> {
                 self.collapse_goto_chain(target, changed);
                 *target
             }
-            _ => unreachable!()
+            _ => unsafe { ::core::hint::unreachable_unchecked() }
         };
         self.basic_blocks[*start].terminator = terminator;
 

--- a/src/librustc_plugin/build.rs
+++ b/src/librustc_plugin/build.rs
@@ -61,7 +61,7 @@ pub fn find_plugin_registrar(diagnostic: &errors::Handler,
             }
             e.emit();
             diagnostic.abort_if_errors();
-            unreachable!();
+            unsafe { ::std::hint::unreachable_unchecked() };
         }
     }
 }

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -383,7 +383,7 @@ impl<'a, 'tcx> Visitor<'tcx> for EmbargoVisitor<'a, 'tcx> {
             {
                 module
             } else {
-                unreachable!()
+                unsafe { ::std::hint::unreachable_unchecked() }
             };
             for id in &module.item_ids {
                 self.update(id.id, level);

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -279,7 +279,9 @@ impl<'a, 'cl> Resolver<'a, 'cl> {
                         let crate_root = self.resolve_crate_root(source);
                         let crate_name = match crate_root.kind {
                             ModuleKind::Def(_, name) => name,
-                            ModuleKind::Block(..) => unreachable!(),
+                            ModuleKind::Block(..) => unsafe {
+                                ::std::hint::unreachable_unchecked()
+                            },
                         };
                         // HACK(eddyb) unclear how good this is, but keeping `$crate`
                         // in `source` breaks `src/test/compile-fail/import-crate-var.rs`,
@@ -619,7 +621,9 @@ impl<'a, 'cl> Resolver<'a, 'cl> {
                 self.current_module = module;
             }
 
-            ItemKind::MacroDef(..) | ItemKind::Mac(_) => unreachable!(),
+            ItemKind::MacroDef(..) | ItemKind::Mac(_) => unsafe {
+                ::std::hint::unreachable_unchecked()
+            },
         }
     }
 
@@ -658,7 +662,7 @@ impl<'a, 'cl> Resolver<'a, 'cl> {
             ForeignItemKind::Ty => {
                 (Def::TyForeign(self.definitions.local_def_id(item.id)), TypeNS)
             }
-            ForeignItemKind::Macro(_) => unreachable!(),
+            ForeignItemKind::Macro(_) => unsafe { ::std::hint::unreachable_unchecked() },
         };
         let parent = self.current_module;
         let vis = self.resolve_visibility(&item.vis);

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -1613,7 +1613,7 @@ impl<'a, 'crateloader> Resolver<'a, 'crateloader> {
                 _ => {}
             },
             PathResult::Module(ModuleOrUniformRoot::UniformRoot(_)) |
-            PathResult::Indeterminate => unreachable!(),
+            PathResult::Indeterminate => unsafe { ::std::hint::unreachable_unchecked() },
             PathResult::Failed(span, msg, _) => {
                 error_callback(self, span, ResolutionError::FailedToResolve(&msg));
             }

--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -145,7 +145,7 @@ impl<'a, 'crateloader: 'a> base::Resolver for Resolver<'a, 'crateloader> {
             fn fold_path(&mut self, path: ast::Path) -> ast::Path {
                 match self.fold_qpath(None, path) {
                     (None, path) => path,
-                    _ => unreachable!(),
+                    _ => unsafe { ::std::hint::unreachable_unchecked() },
                 }
             }
 
@@ -168,7 +168,7 @@ impl<'a, 'crateloader: 'a> base::Resolver for Resolver<'a, 'crateloader> {
                             ModuleKind::Def(_, name) => ast::PathSegment::from_ident(
                                 ast::Ident::with_empty_ctxt(name).with_span_pos(span)
                             ),
-                            _ => unreachable!(),
+                            _ => unsafe { ::std::hint::unreachable_unchecked() },
                         });
                         if let Some(qself) = &mut qself {
                             qself.position += 1;
@@ -553,7 +553,7 @@ impl<'a, 'cl> Resolver<'a, 'cl> {
                         }
                     }
                 },
-                PathResult::Module(..) => unreachable!(),
+                PathResult::Module(..) => unsafe { ::std::hint::unreachable_unchecked() },
                 PathResult::Indeterminate if !force => return Err(Determinacy::Undetermined),
                 _ => {
                     self.found_unresolved_macro = true;
@@ -910,7 +910,7 @@ impl<'a, 'cl> Resolver<'a, 'cl> {
                 PathResult::Failed(span, msg, _) => {
                     resolve_error(self, span, ResolutionError::FailedToResolve(&msg));
                 }
-                _ => unreachable!(),
+                _ => unsafe { ::std::hint::unreachable_unchecked() },
             }
         }
 
@@ -1076,7 +1076,10 @@ impl<'a, 'cl> Resolver<'a, 'cl> {
                                                item, hygiene::default_edition()));
         self.macro_map.insert(def_id, ext);
 
-        let def = match item.node { ast::ItemKind::MacroDef(ref def) => def, _ => unreachable!() };
+        let def = match item.node {
+            ast::ItemKind::MacroDef(ref def) => def,
+            _ => unsafe { ::std::hint::unreachable_unchecked() }
+        };
         if def.legacy {
             let ident = ident.modern();
             self.macro_names.insert(ident);

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -289,7 +289,7 @@ impl<'a, 'crateloader> Resolver<'a, 'crateloader> {
             let module = unwrap_or!(single_import.imported_module.get(), return Err(Undetermined));
             let ident = match single_import.subclass {
                 SingleImport { source, .. } => source,
-                _ => unreachable!(),
+                _ => unsafe { ::std::hint::unreachable_unchecked() },
             };
             match self.resolve_ident_in_module(module, ident, ns, false, path_span) {
                 Err(Determined) => continue,
@@ -413,7 +413,7 @@ impl<'a, 'crateloader> Resolver<'a, 'crateloader> {
             // which are not relevant to import resolution.
             GlobImport { is_prelude: true, .. } => {}
             GlobImport { .. } => self.current_module.globs.borrow_mut().push(directive),
-            _ => unreachable!(),
+            _ => unsafe { ::std::hint::unreachable_unchecked() },
         }
     }
 
@@ -753,7 +753,7 @@ impl<'a, 'b:'a, 'c: 'b> ImportResolver<'a, 'b, 'c> {
                 self.resolve_glob_import(directive);
                 return true;
             }
-            _ => unreachable!(),
+            _ => unsafe { ::std::hint::unreachable_unchecked() },
         };
 
         let mut indeterminate = false;
@@ -871,7 +871,7 @@ impl<'a, 'b:'a, 'c: 'b> ImportResolver<'a, 'b, 'c> {
                 }
                 return None;
             }
-            _ => unreachable!(),
+            _ => unsafe { ::std::hint::unreachable_unchecked() },
         };
 
         let mut all_ns_err = true;

--- a/src/librustc_save_analysis/dump_visitor.rs
+++ b/src/librustc_save_analysis/dump_visitor.rs
@@ -511,7 +511,7 @@ impl<'l, 'tcx: 'l, 'll, O: DumpOutput + 'll> DumpVisitor<'l, 'tcx, 'll, O> {
         let (kind, keyword) = match item.node {
             ast::ItemKind::Struct(_, _) => (DefKind::Struct, keywords::Struct),
             ast::ItemKind::Union(_, _) => (DefKind::Union, keywords::Union),
-            _ => unreachable!(),
+            _ => unsafe { ::std::hint::unreachable_unchecked() },
         };
 
         let sub_span = self.span.sub_span_after_keyword(item.span, keyword);

--- a/src/librustc_target/abi/call/mod.rs
+++ b/src/librustc_target/abi/call/mod.rs
@@ -377,7 +377,7 @@ impl<'a, Ty> ArgType<'a, Ty> {
             PassMode::Indirect(ref mut attrs) => {
                 attrs.set(ArgAttribute::ByVal);
             }
-            _ => unreachable!()
+            _ => unsafe { ::std::hint::unreachable_unchecked() }
         }
     }
 

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -383,7 +383,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> dyn AstConv<'gcx, 'tcx>+'o {
             Def::Err => {
                 FatalError.raise();
             }
-            _ => unreachable!(),
+            _ => unsafe { ::std::hint::unreachable_unchecked() },
         }
     }
 
@@ -1386,7 +1386,7 @@ fn split_auto_traits<'a, 'b, 'gcx, 'tcx>(tcx: TyCtxt<'a, 'gcx, 'tcx>,
         if let Def::Trait(trait_did) = tr.trait_ref.path.def {
             trait_did
         } else {
-            unreachable!()
+            unsafe { ::std::hint::unreachable_unchecked() }
         }
     }).collect::<Vec<_>>();
 

--- a/src/librustc_typeck/check/coercion.rs
+++ b/src/librustc_typeck/check/coercion.rs
@@ -1268,7 +1268,7 @@ impl<'a, T> AsCoercionSite for &'a T
 
 impl AsCoercionSite for ! {
     fn as_coercion_site(&self) -> &hir::Expr {
-        unreachable!()
+        unsafe { ::std::hint::unreachable_unchecked() }
     }
 }
 

--- a/src/librustc_typeck/check/compare_method.rs
+++ b/src/librustc_typeck/check/compare_method.rs
@@ -821,7 +821,7 @@ fn compare_synthetic_generics<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                         let impl_m = tcx.hir.impl_item(hir::ImplItemId { node_id: impl_m });
                         let input_tys = match impl_m.node {
                             hir::ImplItemKind::Method(ref sig, _) => &sig.decl.inputs,
-                            _ => unreachable!(),
+                            _ => unsafe { ::std::hint::unreachable_unchecked() },
                         };
                         struct Visitor(Option<Span>, hir::def_id::DefId);
                         impl<'v> hir::intravisit::Visitor<'v> for Visitor {
@@ -881,7 +881,7 @@ fn compare_synthetic_generics<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                         Some(())
                     })();
                 },
-                _ => unreachable!(),
+                _ => unsafe { ::std::hint::unreachable_unchecked() },
             }
             err.emit();
             error_found = true;

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1856,7 +1856,7 @@ impl<'a, 'gcx, 'tcx> AstConv<'gcx, 'tcx> for FnCtxt<'a, 'gcx, 'tcx> {
         if let UnpackedKind::Type(ty) = self.var_for_def(span, ty_param_def).unpack() {
             return ty;
         }
-        unreachable!()
+        unsafe { ::std::hint::unreachable_unchecked() }
     }
 
     fn projected_ty_from_poly_trait_ref(&self,
@@ -4981,7 +4981,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
 
                     let has_default = match param.kind {
                         GenericParamDefKind::Type { has_default, .. } => has_default,
-                        _ => unreachable!()
+                        _ => unsafe { ::std::hint::unreachable_unchecked() }
                     };
 
                     if let Some(ast_ty) = types.get(i) {

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -386,7 +386,7 @@ fn check_where_clauses<'a, 'gcx, 'fcx, 'tcx>(
             GenericParamDefKind::Type { has_default, .. } => {
                 has_default && def.index >= generics.parent_count as u32
             }
-            _ => unreachable!()
+            _ => unsafe { ::std::hint::unreachable_unchecked() }
         }
     };
 

--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -162,7 +162,7 @@ impl<'a, 'tcx, 'rcx, 'cstore> AutoTraitFinder<'a, 'tcx, 'rcx, 'cstore> {
                         where_predicates: Vec::new(),
                     }
                 }
-                _ => unreachable!(),
+                _ => unsafe { ::std::hint::unreachable_unchecked() },
             };
             let real_name = name.map(|name| Ident::from_str(&name));
             let ty = self.cx.get_real_ty(def_id, def_ctor, &real_name, &generics);

--- a/src/librustdoc/clean/def_ctor.rs
+++ b/src/librustdoc/clean/def_ctor.rs
@@ -38,7 +38,7 @@ where F: Fn(& dyn Fn(DefId) -> Def) -> Vec<Item> {
                 ty::TyStr => Def::PrimTy(hir::TyStr),
                 ty::TyBool => Def::PrimTy(hir::TyBool),
                 ty::TyChar => Def::PrimTy(hir::TyChar),
-                _ => unreachable!(),
+                _ => unsafe { ::std::hint::unreachable_unchecked() },
             }
         }),
         _ => {

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -399,7 +399,7 @@ pub fn build_impl(cx: &DocContext, did: DefId, ret: &mut Vec<clean::Item>) {
     let trait_ = associated_trait.clean(cx).map(|bound| {
         match bound {
             clean::GenericBound::TraitBound(polyt, _) => polyt.trait_,
-            clean::GenericBound::Outlives(..) => unreachable!(),
+            clean::GenericBound::Outlives(..) => unsafe { ::std::hint::unreachable_unchecked() },
         }
     });
     if trait_.def_id() == tcx.lang_items().deref_trait() {
@@ -494,7 +494,7 @@ fn build_macro(cx: &DocContext, did: DefId, name: ast::Name) -> Option<clean::Ma
         let tts: Vec<_> = def.stream().into_trees().collect();
         tts.chunks(4).map(|arm| arm[0].span()).collect()
     } else {
-        unreachable!()
+        unsafe { ::std::hint::unreachable_unchecked() }
     };
 
     let source = format!("macro_rules! {} {{\n{}}}",

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -174,14 +174,14 @@ impl<'a, 'tcx, 'rcx, 'cstore> Clean<Crate> for visit_ast::RustdocVisitor<'a, 'tc
                     }
                 }
             }
-            _ => unreachable!(),
+            _ => unsafe { ::std::hint::unreachable_unchecked() },
         }
 
         let ExternalCrate { name, src, primitives, keywords, .. } = LOCAL_CRATE.clean(cx);
         {
             let m = match module.inner {
                 ModuleItem(ref mut m) => m,
-                _ => unreachable!(),
+                _ => unsafe { ::std::hint::unreachable_unchecked() },
             };
             m.items.extend(primitives.iter().map(|&(def_id, prim, ref attrs)| {
                 Item {
@@ -1500,7 +1500,9 @@ impl Clean<Generics> for hir::Generics {
             .map(|param| {
                 let param: GenericParamDef = param.clean(cx);
                 match param.kind {
-                    GenericParamDefKind::Lifetime => unreachable!(),
+                    GenericParamDefKind::Lifetime => unsafe {
+                        ::std::hint::unreachable_unchecked()
+                    },
                     GenericParamDefKind::Type { did, ref bounds, .. } => {
                         cx.impl_trait_bounds.borrow_mut().insert(did, bounds.clone());
                     }
@@ -1985,7 +1987,7 @@ impl<'tcx> Clean<Item> for ty::AssociatedItem {
                                 BorrowedRef{ref mut type_, ..} => {
                                     **type_ = Generic(String::from("Self"))
                                 }
-                                _ => unreachable!(),
+                                _ => unsafe { ::std::hint::unreachable_unchecked() },
                             }
                         }
                     }

--- a/src/librustdoc/fold.rs
+++ b/src/librustdoc/fold.rs
@@ -34,7 +34,7 @@ pub trait DocFolder : Sized {
     /// don't override!
     fn fold_inner_recur(&mut self, inner: ItemEnum) -> ItemEnum {
         match inner {
-            StrippedItem(..) => unreachable!(),
+            StrippedItem(..) => unsafe { ::std::hint::unreachable_unchecked() },
             ModuleItem(i) => {
                 ModuleItem(self.fold_mod(i))
             },

--- a/src/librustdoc/html/escape.rs
+++ b/src/librustdoc/html/escape.rs
@@ -36,7 +36,7 @@ impl<'a> fmt::Display for Escape<'a> {
                         '&' => "&amp;",
                         '\'' => "&#39;",
                         '"' => "&quot;",
-                        _ => unreachable!()
+                        _ => unsafe { ::std::hint::unreachable_unchecked() }
                     };
                     fmt.write_str(s)?;
                     last = i + 1;

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -761,7 +761,7 @@ fn fmt_impl(i: &clean::Impl,
                     fmt::Display::fmt(&last.name, f)?;
                     fmt::Display::fmt(&last.args, f)?;
                 }
-                _ => unreachable!(),
+                _ => unsafe { ::std::hint::unreachable_unchecked() },
             }
         }
         write!(f, " for ")?;

--- a/src/librustdoc/html/item_type.rs
+++ b/src/librustdoc/html/item_type.rs
@@ -88,7 +88,7 @@ impl<'a> From<&'a clean::Item> for ItemType {
             clean::AssociatedTypeItem(..)  => ItemType::AssociatedType,
             clean::ForeignTypeItem         => ItemType::ForeignType,
             clean::KeywordItem(..)         => ItemType::Keyword,
-            clean::StrippedItem(..)        => unreachable!(),
+            clean::StrippedItem(..)        => unsafe { ::std::hint::unreachable_unchecked() },
         }
     }
 }

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1437,7 +1437,7 @@ impl DocFolder for Cache {
                         }
                     }
                 } else {
-                    unreachable!()
+                    unsafe { ::std::hint::unreachable_unchecked() }
                 };
                 for did in dids {
                     self.impls.entry(did).or_insert(vec![]).push(Impl {
@@ -1910,7 +1910,7 @@ impl Context {
                 let m = match item.inner {
                     clean::StrippedItem(box clean::ModuleItem(m)) |
                     clean::ModuleItem(m) => m,
-                    _ => unreachable!()
+                    _ => unsafe { ::std::hint::unreachable_unchecked() }
                 };
 
                 // Render sidebar-items.js used throughout this module.
@@ -2117,7 +2117,7 @@ impl<'a> fmt::Display for Item<'a> {
             clean::ExistentialItem(..) => write!(fmt, "Existential Type ")?,
             _ => {
                 // We don't generate pages for any other type.
-                unreachable!();
+                unsafe { ::std::hint::unreachable_unchecked() };
             }
         }
         if !self.item.is_primitive() && !self.item.is_keyword() {
@@ -2154,7 +2154,7 @@ impl<'a> fmt::Display for Item<'a> {
             clean::ExistentialItem(ref e, _) => item_existential(fmt, self.cx, self.item, e),
             _ => {
                 // We don't generate pages for any other type.
-                unreachable!();
+                unsafe { ::std::hint::unreachable_unchecked() };
             }
         }
     }
@@ -3289,7 +3289,7 @@ fn item_enum(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
                             }
                         }
                     }
-                    _ => unreachable!()
+                    _ => unsafe { ::std::hint::unreachable_unchecked() }
                 }
                 write!(w, ",\n")?;
             }
@@ -3486,7 +3486,7 @@ fn render_struct(w: &mut fmt::Formatter, it: &clean::Item,
                     clean::StructFieldItem(ref ty) => {
                         write!(w, "{}{}", VisSpace(&field.visibility), *ty)?
                     }
-                    _ => unreachable!()
+                    _ => unsafe { ::std::hint::unreachable_unchecked() }
                 }
             }
             write!(w, ")")?;

--- a/src/librustdoc/passes/collapse_docs.rs
+++ b/src/librustdoc/passes/collapse_docs.rs
@@ -76,7 +76,7 @@ fn collapse(doc_strings: &mut Vec<DocFragment>) {
                             doc_string.push_str(frag.as_str());
                             *span = span.to(frag.span());
                         }
-                    _ => unreachable!(),
+                    _ => unsafe { ::std::hint::unreachable_unchecked() },
                 }
                 last_frag = Some(curr_frag);
             }

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -1731,7 +1731,7 @@ impl<T: Iterator<Item=char>> Parser<T> {
                         return Ok(res);
                     },
                     Some(c) => res.push(c),
-                    None => unreachable!()
+                    None => unsafe { ::std::hint::unreachable_unchecked() }
                 }
             }
         }

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -801,7 +801,7 @@ impl<K, V, S> HashMap<K, V, S>
     pub fn reserve(&mut self, additional: usize) {
         match self.reserve_internal(additional, Infallible) {
             Err(CollectionAllocErr::CapacityOverflow) => panic!("capacity overflow"),
-            Err(CollectionAllocErr::AllocErr) => unreachable!(),
+            Err(CollectionAllocErr::AllocErr) => unsafe { ::core::hint::unreachable_unchecked() },
             Ok(()) => { /* yay */ }
         }
     }
@@ -996,7 +996,7 @@ impl<K, V, S> HashMap<K, V, S>
                 elem.insert(v);
                 None
             }
-            None => unreachable!(),
+            None => unsafe { ::core::hint::unreachable_unchecked() },
         }
     }
 
@@ -3469,7 +3469,7 @@ mod test_map {
 
         // Existing key (insert)
         match map.entry(1) {
-            Vacant(_) => unreachable!(),
+            Vacant(_) => unsafe { ::core::hint::unreachable_unchecked() },
             Occupied(mut view) => {
                 assert_eq!(view.get(), &10);
                 assert_eq!(view.insert(100), 10);
@@ -3481,7 +3481,7 @@ mod test_map {
 
         // Existing key (update)
         match map.entry(2) {
-            Vacant(_) => unreachable!(),
+            Vacant(_) => unsafe { ::core::hint::unreachable_unchecked() },
             Occupied(mut view) => {
                 let v = view.get_mut();
                 let new_v = (*v) * 10;
@@ -3493,7 +3493,7 @@ mod test_map {
 
         // Existing key (take)
         match map.entry(3) {
-            Vacant(_) => unreachable!(),
+            Vacant(_) => unsafe { ::core::hint::unreachable_unchecked() },
             Occupied(view) => {
                 assert_eq!(view.remove(), 30);
             }
@@ -3504,7 +3504,7 @@ mod test_map {
 
         // Inexistent key (insert)
         match map.entry(10) {
-            Occupied(_) => unreachable!(),
+            Occupied(_) => unsafe { ::core::hint::unreachable_unchecked() },
             Vacant(view) => {
                 assert_eq!(*view.insert(1000), 1000);
             }

--- a/src/libstd/collections/hash/table.rs
+++ b/src/libstd/collections/hash/table.rs
@@ -717,7 +717,7 @@ impl<K, V> RawTable<K, V> {
     unsafe fn new_uninitialized(capacity: usize) -> RawTable<K, V> {
         match Self::new_uninitialized_internal(capacity, Infallible) {
             Err(CollectionAllocErr::CapacityOverflow) => panic!("capacity overflow"),
-            Err(CollectionAllocErr::AllocErr) => unreachable!(),
+            Err(CollectionAllocErr::AllocErr) => ::core::hint::unreachable_unchecked(),
             Ok(table) => { table }
         }
     }
@@ -758,7 +758,7 @@ impl<K, V> RawTable<K, V> {
     pub fn new(capacity: usize) -> RawTable<K, V> {
         match Self::new_internal(capacity, Infallible) {
             Err(CollectionAllocErr::CapacityOverflow) => panic!("capacity overflow"),
-            Err(CollectionAllocErr::AllocErr) => unreachable!(),
+            Err(CollectionAllocErr::AllocErr) => unsafe { ::core::hint::unreachable_unchecked() },
             Ok(table) => { table }
         }
     }

--- a/src/libstd/io/error.rs
+++ b/src/libstd/io/error.rs
@@ -212,7 +212,7 @@ impl ErrorKind {
             ErrorKind::Interrupted => "operation interrupted",
             ErrorKind::Other => "other os error",
             ErrorKind::UnexpectedEof => "unexpected end of file",
-            ErrorKind::__Nonexhaustive => unreachable!()
+            ErrorKind::__Nonexhaustive => unsafe { ::core::hint::unreachable_unchecked() }
         }
     }
 }

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -291,7 +291,7 @@ macro_rules! select {
         }
         let ret = sel.wait();
         $( if ret == $rx.id() { let $name = $rx.$meth(); $code } else )+
-        { unreachable!() }
+        { unsafe { ::std::hint::unreachable_unchecked() } }
     })
 }
 

--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -408,7 +408,7 @@ enum State {
 ///         assert_eq!(Prefix::Disk(b'C'), prefix_component.kind());
 ///         assert_eq!(OsStr::new("c:"), prefix_component.as_os_str());
 ///     }
-///     _ => unsafe { ::core::hint::unreachable_unchecked() },
+///     _ => unreachable!(),
 /// }
 /// # }
 /// ```

--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -408,7 +408,7 @@ enum State {
 ///         assert_eq!(Prefix::Disk(b'C'), prefix_component.kind());
 ///         assert_eq!(OsStr::new("c:"), prefix_component.as_os_str());
 ///     }
-///     _ => unreachable!(),
+///     _ => unsafe { ::core::hint::unreachable_unchecked() },
 /// }
 /// # }
 /// ```
@@ -953,7 +953,7 @@ impl<'a> Iterator for Components<'a> {
                 State::Body => {
                     self.front = State::Done;
                 }
-                State::Done => unreachable!(),
+                State::Done => unsafe { ::core::hint::unreachable_unchecked() },
             }
         }
         None
@@ -1000,7 +1000,7 @@ impl<'a> DoubleEndedIterator for Components<'a> {
                     self.back = State::Done;
                     return None;
                 }
-                State::Done => unreachable!(),
+                State::Done => unsafe { ::core::hint::unreachable_unchecked() },
             }
         }
         None

--- a/src/libstd/sync/mpsc/mod.rs
+++ b/src/libstd/sync/mpsc/mod.rs
@@ -848,7 +848,7 @@ impl<T> Sender<T> {
             }
             Flavor::Stream(ref p) => return p.send(t).map_err(SendError),
             Flavor::Shared(ref p) => return p.send(t).map_err(SendError),
-            Flavor::Sync(..) => unreachable!(),
+            Flavor::Sync(..) => unsafe { ::core::hint::unreachable_unchecked() },
         };
 
         unsafe {
@@ -895,7 +895,7 @@ impl<T> Clone for Sender<T> {
                 p.clone_chan();
                 return Sender::new(Flavor::Shared(p.clone()));
             }
-            Flavor::Sync(..) => unreachable!(),
+            Flavor::Sync(..) => unsafe { ::core::hint::unreachable_unchecked() },
         };
 
         unsafe {
@@ -913,7 +913,7 @@ impl<T> Drop for Sender<T> {
             Flavor::Oneshot(ref p) => p.drop_chan(),
             Flavor::Stream(ref p) => p.drop_chan(),
             Flavor::Shared(ref p) => p.drop_chan(),
-            Flavor::Sync(..) => unreachable!(),
+            Flavor::Sync(..) => unsafe { ::core::hint::unreachable_unchecked() },
         }
     }
 }
@@ -1203,7 +1203,7 @@ impl<T> Receiver<T> {
                         Ok(t) => return Ok(t),
                         Err(oneshot::Disconnected) => return Err(RecvError),
                         Err(oneshot::Upgraded(rx)) => rx,
-                        Err(oneshot::Empty) => unreachable!(),
+                        Err(oneshot::Empty) => unsafe { ::core::hint::unreachable_unchecked() },
                     }
                 }
                 Flavor::Stream(ref p) => {
@@ -1211,14 +1211,14 @@ impl<T> Receiver<T> {
                         Ok(t) => return Ok(t),
                         Err(stream::Disconnected) => return Err(RecvError),
                         Err(stream::Upgraded(rx)) => rx,
-                        Err(stream::Empty) => unreachable!(),
+                        Err(stream::Empty) => unsafe { ::core::hint::unreachable_unchecked() },
                     }
                 }
                 Flavor::Shared(ref p) => {
                     match p.recv(None) {
                         Ok(t) => return Ok(t),
                         Err(shared::Disconnected) => return Err(RecvError),
-                        Err(shared::Empty) => unreachable!(),
+                        Err(shared::Empty) => unsafe { ::core::hint::unreachable_unchecked() },
                     }
                 }
                 Flavor::Sync(ref p) => return p.recv(None).map_err(|_| RecvError),

--- a/src/libstd/sync/mpsc/oneshot.rs
+++ b/src/libstd/sync/mpsc/oneshot.rs
@@ -121,7 +121,7 @@ impl<T> Packet<T> {
                 }
 
                 // Not possible, these are one-use channels
-                DATA => unreachable!(),
+                DATA => ::core::hint::unreachable_unchecked(),
 
                 // There is a thread waiting on the other end. We leave the 'DATA'
                 // state inside so it'll pick it up on the other end.
@@ -187,7 +187,7 @@ impl<T> Packet<T> {
                     self.state.compare_and_swap(DATA, EMPTY, Ordering::SeqCst);
                     match (&mut *self.data.get()).take() {
                         Some(data) => Ok(data),
-                        None => unreachable!(),
+                        None => ::core::hint::unreachable_unchecked(),
                     }
                 }
 
@@ -209,7 +209,7 @@ impl<T> Packet<T> {
 
                 // We are the sole receiver; there cannot be a blocking
                 // receiver already.
-                _ => unreachable!()
+                _ => ::core::hint::unreachable_unchecked()
             }
         }
     }
@@ -266,7 +266,7 @@ impl<T> Packet<T> {
             DATA => unsafe { (&mut *self.data.get()).take().unwrap(); },
 
             // We're the only ones that can block on this port
-            _ => unreachable!()
+            _ => unsafe { ::core::hint::unreachable_unchecked() }
         }
     }
 
@@ -295,7 +295,7 @@ impl<T> Packet<T> {
                         up => { ptr::write(self.upgrade.get(), up); Ok(true) }
                     }
                 }
-                _ => unreachable!(), // we're the "one blocker"
+                _ => ::core::hint::unreachable_unchecked(), // we're the "one blocker"
             }
         }
     }
@@ -334,7 +334,7 @@ impl<T> Packet<T> {
                         }
                     }
                 }
-                _ => unreachable!(), // we're the "one blocker"
+                _ => ::core::hint::unreachable_unchecked(), // we're the "one blocker"
             }
         }
     }
@@ -359,7 +359,7 @@ impl<T> Packet<T> {
         // Now that we've got ownership of our state, figure out what to do
         // about it.
         match state {
-            EMPTY => unreachable!(),
+            EMPTY => unsafe { ::core::hint::unreachable_unchecked() },
             // our thread used for select was stolen
             DATA => Ok(true),
 

--- a/src/libstd/sync/mpsc/select.rs
+++ b/src/libstd/sync/mpsc/select.rs
@@ -367,6 +367,7 @@ impl<'rx, T:Send+'rx> fmt::Debug for Handle<'rx, T> {
 #[allow(unused_imports)]
 #[cfg(all(test, not(target_os = "emscripten")))]
 mod tests {
+    use core;
     use thread;
     use sync::mpsc::*;
 
@@ -383,7 +384,7 @@ mod tests {
             }
             let ret = sel.wait();
             $( if ret == $rx.id() { let $name = $rx.$meth(); $code } else )+
-            { unreachable!() }
+            { unsafe { ::core::hint::unreachable_unchecked() } }
         })
     }
 

--- a/src/libstd/sync/mpsc/shared.rs
+++ b/src/libstd/sync/mpsc/shared.rs
@@ -334,7 +334,7 @@ impl<T> Packet<T> {
                             mpsc::Data(t) => Ok(t),
                             mpsc::Empty => Err(Disconnected),
                             // with no senders, an inconsistency is impossible.
-                            mpsc::Inconsistent => unreachable!(),
+                            mpsc::Inconsistent => unsafe { ::core::hint::unreachable_unchecked() },
                         }
                     }
                 }

--- a/src/libstd/sync/mpsc/spsc_queue.rs
+++ b/src/libstd/sync/mpsc/spsc_queue.rs
@@ -276,14 +276,14 @@ mod tests {
                 Some(vec) => {
                     assert_eq!(&*vec, &[1]);
                 },
-                None => unreachable!()
+                None => ::core::hint::unreachable_unchecked()
             }
 
             match queue.pop() {
                 Some(vec) => {
                     assert_eq!(&*vec, &[1]);
                 },
-                None => unreachable!()
+                None => ::core::hint::unreachable_unchecked()
             }
         }
     }

--- a/src/libstd/sync/mpsc/stream.rs
+++ b/src/libstd/sync/mpsc/stream.rs
@@ -360,7 +360,7 @@ impl<T> Packet<T> {
             Some(&mut GoUp(..)) => {
                 match self.recv(None) {
                     Err(Upgraded(port)) => Err(port),
-                    _ => unreachable!(),
+                    _ => unsafe { ::core::hint::unreachable_unchecked() },
                 }
             }
             Some(..) => Ok(true),
@@ -389,7 +389,7 @@ impl<T> Packet<T> {
                     Some(&mut GoUp(..)) => {
                         match self.queue.pop() {
                             Some(GoUp(port)) => SelUpgraded(token, port),
-                            _ => unreachable!(),
+                            _ => unsafe { ::core::hint::unreachable_unchecked() },
                         }
                     }
                     Some(..) => SelCanceled,
@@ -481,7 +481,7 @@ impl<T> Packet<T> {
                 Some(&mut GoUp(..)) => {
                     match self.queue.pop() {
                         Some(GoUp(port)) => Err(port),
-                        _ => unreachable!(),
+                        _ => unsafe { ::core::hint::unreachable_unchecked() },
                     }
                 }
                 _ => Ok(true),

--- a/src/libstd/sync/mpsc/sync.rs
+++ b/src/libstd/sync/mpsc/sync.rs
@@ -123,7 +123,7 @@ fn wait<'a, 'b, T>(lock: &'a Mutex<State<T>>,
     let (wait_token, signal_token) = blocking::tokens();
     match mem::replace(&mut guard.blocker, f(signal_token)) {
         NoneBlocked => {}
-        _ => unreachable!(),
+        _ => unsafe { ::core::hint::unreachable_unchecked() },
     }
     drop(guard);         // unlock
     wait_token.wait();   // block
@@ -140,7 +140,7 @@ fn wait_timeout_receiver<'a, 'b, T>(lock: &'a Mutex<State<T>>,
     let (wait_token, signal_token) = blocking::tokens();
     match mem::replace(&mut guard.blocker, BlockedReceiver(signal_token)) {
         NoneBlocked => {}
-        _ => unreachable!(),
+        _ => unsafe { ::core::hint::unreachable_unchecked() },
     }
     drop(guard);         // unlock
     *success = wait_token.wait_max_until(deadline);   // block
@@ -248,7 +248,7 @@ impl<T> Packet<T> {
             // transfer the data unless there's a receiver waiting.
             match mem::replace(&mut guard.blocker, NoneBlocked) {
                 NoneBlocked => Err(super::TrySendError::Full(t)),
-                BlockedSender(..) => unreachable!(),
+                BlockedSender(..) => unsafe { ::core::hint::unreachable_unchecked() },
                 BlockedReceiver(token) => {
                     guard.buf.enqueue(t);
                     wakeup(token, guard);
@@ -264,7 +264,7 @@ impl<T> Packet<T> {
             match mem::replace(&mut guard.blocker, NoneBlocked) {
                 BlockedReceiver(token) => wakeup(token, guard),
                 NoneBlocked => {}
-                BlockedSender(..) => unreachable!(),
+                BlockedSender(..) => unsafe { ::core::hint::unreachable_unchecked() },
             }
             Ok(())
         }
@@ -335,7 +335,7 @@ impl<T> Packet<T> {
         let pending_sender2 = if guard.cap == 0 && !waited {
             match mem::replace(&mut guard.blocker, NoneBlocked) {
                 NoneBlocked => None,
-                BlockedReceiver(..) => unreachable!(),
+                BlockedReceiver(..) => unsafe { ::core::hint::unreachable_unchecked() },
                 BlockedSender(token) => {
                     guard.canceled.take();
                     Some(token)
@@ -377,7 +377,7 @@ impl<T> Packet<T> {
         guard.disconnected = true;
         match mem::replace(&mut guard.blocker, NoneBlocked) {
             NoneBlocked => {}
-            BlockedSender(..) => unreachable!(),
+            BlockedSender(..) => unsafe { ::core::hint::unreachable_unchecked() },
             BlockedReceiver(token) => wakeup(token, guard),
         }
     }
@@ -409,7 +409,7 @@ impl<T> Packet<T> {
                 *guard.canceled.take().unwrap() = true;
                 Some(token)
             }
-            BlockedReceiver(..) => unreachable!(),
+            BlockedReceiver(..) => unsafe { ::core::hint::unreachable_unchecked() },
         };
         mem::drop(guard);
 
@@ -437,8 +437,8 @@ impl<T> Packet<T> {
         } else {
             match mem::replace(&mut guard.blocker, BlockedReceiver(token)) {
                 NoneBlocked => {}
-                BlockedSender(..) => unreachable!(),
-                BlockedReceiver(..) => unreachable!(),
+                BlockedSender(..) => unsafe { ::core::hint::unreachable_unchecked() },
+                BlockedReceiver(..) => unsafe { ::core::hint::unreachable_unchecked() },
             }
             Installed
         }

--- a/src/libstd/sync/rwlock.rs
+++ b/src/libstd/sync/rwlock.rs
@@ -224,7 +224,7 @@ impl<T: ?Sized> RwLock<T> {
     ///
     /// match lock.try_read() {
     ///     Ok(n) => assert_eq!(*n, 1),
-    ///     Err(_) => unreachable!(),
+    ///     Err(_) => unsafe { ::core::hint::unreachable_unchecked() },
     /// };
     /// ```
     #[inline]

--- a/src/libstd/sync/rwlock.rs
+++ b/src/libstd/sync/rwlock.rs
@@ -224,7 +224,7 @@ impl<T: ?Sized> RwLock<T> {
     ///
     /// match lock.try_read() {
     ///     Ok(n) => assert_eq!(*n, 1),
-    ///     Err(_) => unsafe { ::core::hint::unreachable_unchecked() },
+    ///     Err(_) => unreachable!(),
     /// };
     /// ```
     #[inline]

--- a/src/libstd/sys/redox/os.rs
+++ b/src/libstd/sys/redox/os.rs
@@ -204,7 +204,7 @@ pub fn home_dir() -> Option<PathBuf> {
 
 pub fn exit(code: i32) -> ! {
     let _ = syscall::exit(code as usize);
-    unreachable!();
+    unsafe { ::core::hint::unreachable_unchecked() };
 }
 
 pub fn getpid() -> u32 {

--- a/src/libstd/sys/redox/syscall/call.rs
+++ b/src/libstd/sys/redox/syscall/call.rs
@@ -18,7 +18,7 @@ use core::{mem, ptr};
 // Signal restorer
 extern "C" fn restorer() -> ! {
     sigreturn().unwrap();
-    unreachable!();
+    unsafe { ::core::hint::unreachable_unchecked() };
 }
 
 /// Set the end of the process's heap

--- a/src/libstd/sys/unix/fs.rs
+++ b/src/libstd/sys/unix/fs.rs
@@ -504,7 +504,7 @@ impl File {
                 },
                 OPEN_CLOEXEC_SUPPORTED => need_to_set = false,
                 OPEN_CLOEXEC_NOTSUPPORTED => need_to_set = true,
-                _ => unreachable!(),
+                _ => unsafe { ::core::hint::unreachable_unchecked() },
             }
             if need_to_set {
                 fd.set_cloexec()?;

--- a/src/libstd/sys_common/poison.rs
+++ b/src/libstd/sys_common/poison.rs
@@ -82,7 +82,7 @@ pub struct Guard {
 /// }).join();
 ///
 /// match mutex.lock() {
-///     Ok(_) => unsafe { ::core::hint::unreachable_unchecked() },
+///     Ok(_) => unreachable!(),
 ///     Err(p_err) => {
 ///         let data = p_err.get_ref();
 ///         println!("recovered: {}", data);

--- a/src/libstd/sys_common/poison.rs
+++ b/src/libstd/sys_common/poison.rs
@@ -82,7 +82,7 @@ pub struct Guard {
 /// }).join();
 ///
 /// match mutex.lock() {
-///     Ok(_) => unreachable!(),
+///     Ok(_) => unsafe { ::core::hint::unreachable_unchecked() },
 ///     Err(p_err) => {
 ///         let data = p_err.get_ref();
 ///         println!("recovered: {}", data);

--- a/src/libsyntax/attr/builtin.rs
+++ b/src/libsyntax/attr/builtin.rs
@@ -392,7 +392,7 @@ fn find_stability_generic<'a, I>(diagnostic: &Handler,
                         }
                     }
                 }
-                _ => unreachable!()
+                _ => unsafe { ::core::hint::unreachable_unchecked() }
             }
         } else {
             span_err!(diagnostic, attr.span(), E0548, "incorrect stability attribute type");

--- a/src/libsyntax/diagnostics/plugin.rs
+++ b/src/libsyntax/diagnostics/plugin.rs
@@ -45,7 +45,7 @@ pub fn expand_diagnostic_used<'cx>(ecx: &'cx mut ExtCtxt,
                                    -> Box<dyn MacResult+'cx> {
     let code = match (token_tree.len(), token_tree.get(0)) {
         (1, Some(&TokenTree::Token(_, token::Ident(code, _)))) => code,
-        _ => unreachable!()
+        _ => unsafe { ::core::hint::unreachable_unchecked() }
     };
 
     ecx.parse_sess.registered_diagnostics.with_lock(|diagnostics| {
@@ -90,7 +90,7 @@ pub fn expand_register_diagnostic<'cx>(ecx: &'cx mut ExtCtxt,
             Some(&TokenTree::Token(_, token::Literal(token::StrRaw(description, _), None)))) => {
             (code, Some(description))
         }
-        _ => unreachable!()
+        _ => unsafe { ::core::hint::unreachable_unchecked() }
     };
 
     // Check that the description starts and ends with a newline and doesn't
@@ -154,7 +154,7 @@ pub fn expand_build_diagnostic_array<'cx>(ecx: &'cx mut ExtCtxt,
             // DIAGNOSTICS ident.
             &TokenTree::Token(_, token::Ident(ref name, _))
         ) => (*&crate_name, name),
-        _ => unreachable!()
+        _ => unsafe { ::core::hint::unreachable_unchecked() }
     };
 
     // Output error metadata to `tmp/extended-errors/<target arch>/<crate name>.json`

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -302,7 +302,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                     items: vec![],
                 };
             },
-            _ => unreachable!(),
+            _ => unsafe { ::core::hint::unreachable_unchecked() },
         };
         self.cx.trace_macros_diag();
         krate
@@ -414,7 +414,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                         .expect_from_annotatables(::std::iter::once(item_with_markers));
                     self.collect_invocations(fragment, derives)
                 } else {
-                    unreachable!()
+                    unsafe { ::core::hint::unreachable_unchecked() }
                 }
             } else {
                 self.collect_invocations(invoc.fragment_kind.dummy(invoc.span()).unwrap(), &[])
@@ -554,7 +554,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                          -> Option<AstFragment> {
         let (attr, item) = match invoc.kind {
             InvocationKind::Attr { attr, item, .. } => (attr?, item),
-            _ => unreachable!(),
+            _ => unsafe { ::core::hint::unreachable_unchecked() },
         };
 
         if let NonMacroAttr { mark_used: false } = *ext {} else {
@@ -718,7 +718,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
         let (mark, kind) = (invoc.expansion_data.mark, invoc.fragment_kind);
         let (mac, ident, span) = match invoc.kind {
             InvocationKind::Bang { mac, ident, span } => (mac, ident, span),
-            _ => unreachable!(),
+            _ => unsafe { ::core::hint::unreachable_unchecked() },
         };
         let path = &mac.node.path;
 
@@ -908,7 +908,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                            -> Option<AstFragment> {
         let (path, item) = match invoc.kind {
             InvocationKind::Derive { path, item } => (path, item),
-            _ => unreachable!(),
+            _ => unsafe { ::core::hint::unreachable_unchecked() },
         };
         if !item.derive_allowed() {
             return None;
@@ -1250,7 +1250,7 @@ impl<'a, 'b> Folder for InvocationCollector<'a, 'b> {
 
         pat.and_then(|pat| match pat.node {
             PatKind::Mac(mac) => self.collect_bang(mac, pat.span, AstFragmentKind::Pat).make_pat(),
-            _ => unreachable!(),
+            _ => unsafe { ::core::hint::unreachable_unchecked() },
         })
     }
 
@@ -1333,7 +1333,7 @@ impl<'a, 'b> Folder for InvocationCollector<'a, 'b> {
                             span: item.span,
                         }).make_items()
                     }
-                    _ => unreachable!(),
+                    _ => unsafe { ::core::hint::unreachable_unchecked() },
                 })
             }
             ast::ItemKind::Mod(ast::Mod { inner, .. }) => {
@@ -1481,7 +1481,7 @@ impl<'a, 'b> Folder for InvocationCollector<'a, 'b> {
 
         match ty.node {
             ast::TyKind::Mac(mac) => self.collect_bang(mac, ty.span, AstFragmentKind::Ty).make_ty(),
-            _ => unreachable!(),
+            _ => unsafe { ::core::hint::unreachable_unchecked() },
         }
     }
 

--- a/src/libsyntax/ext/placeholders.rs
+++ b/src/libsyntax/ext/placeholders.rs
@@ -100,7 +100,7 @@ impl<'a, 'b> PlaceholderExpander<'a, 'b> {
             for derive in derives {
                 match self.remove(NodeId::placeholder_from_mark(derive)) {
                     AstFragment::Items(derived_items) => items.extend(derived_items),
-                    _ => unreachable!(),
+                    _ => unsafe { ::core::hint::unreachable_unchecked() },
                 }
             }
             fragment = AstFragment::Items(items);

--- a/src/libsyntax/ext/tt/macro_parser.rs
+++ b/src/libsyntax/ext/tt/macro_parser.rs
@@ -752,7 +752,7 @@ pub fn parse(
                 item.idx += 1;
                 item.match_cur += 1;
             } else {
-                unreachable!()
+                unsafe { ::core::hint::unreachable_unchecked() }
             }
             cur_items.push(item);
         }

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -218,7 +218,7 @@ pub fn compile(sess: &ParseSess, features: &Features, def: &ast::Item, edition: 
     // Parse the macro_rules! invocation
     let body = match def.node {
         ast::ItemKind::MacroDef(ref body) => body,
-        _ => unreachable!(),
+        _ => unsafe { ::core::hint::unreachable_unchecked() },
     };
 
     // The pattern that macro_rules matches.

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -1389,7 +1389,8 @@ impl<'a> StringReader<'a> {
                     Some('\'') => self.scan_byte(),
                     Some('"') => self.scan_byte_string(),
                     Some('r') => self.scan_raw_byte_string(),
-                    _ => unreachable!(),  // Should have been a token::Ident above.
+                    // Should have been a token::Ident above.
+                    _ => unsafe { ::core::hint::unreachable_unchecked() },
                 };
                 let suffix = self.scan_optional_raw_name();
                 Ok(token::Literal(lit, suffix))

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -630,7 +630,7 @@ impl<'a> Parser<'a> {
     crate fn unexpected<T>(&mut self) -> PResult<'a, T> {
         match self.expect_one_of(&[], &[]) {
             Err(e) => Err(e),
-            Ok(_) => unreachable!(),
+            Ok(_) => unsafe { ::core::hint::unreachable_unchecked() },
         }
     }
 
@@ -2203,7 +2203,7 @@ impl<'a> Parser<'a> {
         };
         let delimited = match self.parse_token_tree() {
             TokenTree::Delimited(_, delimited) => delimited,
-            _ => unreachable!(),
+            _ => unsafe { ::core::hint::unreachable_unchecked() },
         };
         let delim = match delim {
             token::Paren => MacDelimiter::Parenthesis,
@@ -2743,7 +2743,7 @@ impl<'a> Parser<'a> {
                 self.bump();
                 let name = match self.token {
                     token::Ident(ident, _) => ident,
-                    _ => unreachable!()
+                    _ => unsafe { ::core::hint::unreachable_unchecked() }
                 };
                 let mut err = self.fatal(&format!("unknown macro variable `{}`", name));
                 err.span_label(self.span, "unknown macro variable");
@@ -2779,7 +2779,7 @@ impl<'a> Parser<'a> {
                     tts: frame.tree_cursor.original_stream().into(),
                 })
             },
-            token::CloseDelim(_) | token::Eof => unreachable!(),
+            token::CloseDelim(_) | token::Eof => unsafe { ::core::hint::unreachable_unchecked() },
             _ => {
                 let (token, span) = (mem::replace(&mut self.token, token::Whitespace), self.span);
                 self.bump();
@@ -4454,7 +4454,7 @@ impl<'a> Parser<'a> {
                 let tokens = if self.check(&token::OpenDelim(token::Brace)) {
                     match self.parse_token_tree() {
                         TokenTree::Delimited(_, ref delimited) => delimited.stream(),
-                        _ => unreachable!(),
+                        _ => unsafe { ::core::hint::unreachable_unchecked() },
                     }
                 } else if self.check(&token::OpenDelim(token::Paren)) {
                     let args = self.parse_token_tree();
@@ -4462,7 +4462,7 @@ impl<'a> Parser<'a> {
                         self.parse_token_tree()
                     } else {
                         self.unexpected()?;
-                        unreachable!()
+                        unsafe { ::core::hint::unreachable_unchecked() }
                     };
                     TokenStream::concat(vec![
                         args.into(),
@@ -4471,7 +4471,7 @@ impl<'a> Parser<'a> {
                     ])
                 } else {
                     self.unexpected()?;
-                    unreachable!()
+                    unsafe { ::core::hint::unreachable_unchecked() }
                 };
 
                 (ident, ast::MacroDef { tokens: tokens.into(), legacy: false })
@@ -5298,7 +5298,7 @@ impl<'a> Parser<'a> {
             // Preserve hygienic context.
             token::Ident(ident, _) =>
                 { let span = this.span; this.bump(); Ident::new(ident.name, span) }
-            _ => unreachable!()
+            _ => unsafe { ::core::hint::unreachable_unchecked() }
         };
         let isolated_self = |this: &mut Self, n| {
             this.look_ahead(n, |t| t.is_keyword(keywords::SelfValue)) &&

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -2804,7 +2804,7 @@ impl<'a> State<'a> {
                 self.print_type(ty)?;
                 self.maybe_print_comment(ty.span.lo())
             }
-            ast::FunctionRetTy::Default(..) => unreachable!(),
+            ast::FunctionRetTy::Default(..) => unsafe { ::core::hint::unreachable_unchecked() },
         }
     }
 
@@ -3048,7 +3048,7 @@ impl<'a> State<'a> {
         self.ibox(INDENT_UNIT)?;
         self.word_space("->")?;
         match decl.output {
-            ast::FunctionRetTy::Default(..) => unreachable!(),
+            ast::FunctionRetTy::Default(..) => unsafe { ::core::hint::unreachable_unchecked() },
             ast::FunctionRetTy::Ty(ref ty) =>
                 self.print_type(ty)?
         }

--- a/src/libsyntax/tokenstream.rs
+++ b/src/libsyntax/tokenstream.rs
@@ -337,7 +337,7 @@ impl TokenStream {
         match self.kind {
             TokenStreamKind::Tree(tree) => (tree, false),
             TokenStreamKind::JointTree(tree) => (tree, true),
-            _ => unreachable!(),
+            _ => unsafe { ::core::hint::unreachable_unchecked() },
         }
     }
 
@@ -349,7 +349,7 @@ impl TokenStream {
             result.push(match stream.kind {
                 TokenStreamKind::Tree(tree) => f(i, tree).into(),
                 TokenStreamKind::JointTree(tree) => f(i, tree).joint(),
-                _ => unreachable!()
+                _ => unsafe { ::core::hint::unreachable_unchecked() }
             });
             i += 1;
         }
@@ -363,7 +363,7 @@ impl TokenStream {
             result.push(match stream.kind {
                 TokenStreamKind::Tree(tree) => f(tree).into(),
                 TokenStreamKind::JointTree(tree) => f(tree).joint(),
-                _ => unreachable!()
+                _ => unsafe { ::core::hint::unreachable_unchecked() }
             });
         }
         TokenStream::concat(result)
@@ -507,7 +507,7 @@ impl Iterator for Cursor {
     fn next(&mut self) -> Option<TokenTree> {
         self.next_as_stream().map(|stream| match stream.kind {
             TokenStreamKind::Tree(tree) | TokenStreamKind::JointTree(tree) => tree,
-            _ => unreachable!()
+            _ => unsafe { ::core::hint::unreachable_unchecked() }
         })
     }
 }

--- a/src/libsyntax_ext/deriving/debug.rs
+++ b/src/libsyntax_ext/deriving/debug.rs
@@ -122,7 +122,7 @@ fn show_substructure(cx: &mut ExtCtxt, span: Span, substr: &Substructure) -> P<E
             }
             stmts
         }
-        _ => unreachable!(),
+        _ => unsafe { ::std::hint::unreachable_unchecked() },
     };
 
     let expr = cx.expr_method_call(span, builder_expr, Ident::from_str("finish"), vec![]);

--- a/src/libsyntax_ext/deriving/generic/mod.rs
+++ b/src/libsyntax_ext/deriving/generic/mod.rs
@@ -465,7 +465,7 @@ impl<'a> TraitDef<'a> {
                             return;
                         }
                     }
-                    _ => unreachable!(),
+                    _ => unsafe { ::std::hint::unreachable_unchecked() },
                 };
                 // Keep the lint attributes of the previous item to control how the
                 // generated implementations are linted

--- a/src/libsyntax_pos/lib.rs
+++ b/src/libsyntax_pos/lib.rs
@@ -860,7 +860,7 @@ impl Encodable for FileMap {
                         1 => for diff in diff_iter { (diff.0 as u8).encode(s)? },
                         2 => for diff in diff_iter { (diff.0 as u16).encode(s)? },
                         4 => for diff in diff_iter { diff.0.encode(s)? },
-                        _ => unreachable!()
+                        _ => unsafe { ::std::hint::unreachable_unchecked() }
                     }
                 }
 
@@ -908,7 +908,7 @@ impl Decodable for FileMap {
                             1 => d.read_u8()? as u32,
                             2 => d.read_u16()? as u32,
                             4 => d.read_u32()?,
-                            _ => unreachable!()
+                            _ => unsafe { ::std::hint::unreachable_unchecked() }
                         };
 
                         line_start = line_start + BytePos(diff);

--- a/src/libterm/terminfo/parm.rs
+++ b/src/libterm/terminfo/parm.rs
@@ -166,7 +166,7 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables) -> Result<Vec<
                                     '>' => x > y,
                                     'A' => x > 0 && y > 0,
                                     'O' => x > 0 || y > 0,
-                                    _ => unreachable!(),
+                                    _ => unsafe { ::std::hint::unreachable_unchecked() },
                                 } {
                                     1
                                 } else {
@@ -186,7 +186,7 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables) -> Result<Vec<
                                     '!' if x > 0 => 0,
                                     '!' => 1,
                                     '~' => !x,
-                                    _ => unreachable!(),
+                                    _ => unsafe { ::std::hint::unreachable_unchecked() },
                                 }))
                             }
                             Some(_) => return Err(format!("non-numbers on stack with {}", cur)),
@@ -227,7 +227,7 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables) -> Result<Vec<
                                 flags.width = cur as usize - '0' as usize;
                                 fstate = FormatStateWidth;
                             }
-                            _ => unreachable!(),
+                            _ => unsafe { ::std::hint::unreachable_unchecked() },
                         }
                         state = FormatPattern(flags, fstate);
                     }

--- a/src/libterm/win.rs
+++ b/src/libterm/win.rs
@@ -65,7 +65,7 @@ fn color_to_bits(color: color::Color) -> u16 {
         color::MAGENTA => 0x1 | 0x4,
         color::CYAN => 0x1 | 0x2,
         color::WHITE => 0x1 | 0x2 | 0x4,
-        _ => unreachable!(),
+        _ => unsafe { ::std::hint::unreachable_unchecked() },
     };
 
     if color >= 8 {
@@ -85,7 +85,7 @@ fn bits_to_color(bits: u16) -> color::Color {
         0x5 => color::MAGENTA,
         0x3 => color::CYAN,
         0x7 => color::WHITE,
-        _ => unreachable!(),
+        _ => unsafe { ::std::hint::unreachable_unchecked() },
     };
 
     color | (bits & 0x8) // copy the hi-intensity bit


### PR DESCRIPTION
This is an experimental commit designed to measure if changing `unreachable!()` to its faster unsafe counterpart can result in measurable performance gains (see #52945).

We don't want to perform this change everywhere, only consider it in hot spots under infallible conditions. With any luck a perf run could point us into the right direction; this approach has worked with `assert!` (#53025).

cc @dtolnay 