### PR TITLE
Two small improvements

### DIFF
--- a/src/librustc_apfloat/ieee.rs
+++ b/src/librustc_apfloat/ieee.rs
@@ -2306,24 +2306,14 @@ mod sig {
 
     /// One, not zero, based LSB. That is, returns 0 for a zeroed significand.
     pub(super) fn olsb(limbs: &[Limb]) -> usize {
-        for (i, &limb) in limbs.iter().enumerate() {
-            if limb != 0 {
-                return i * LIMB_BITS + limb.trailing_zeros() as usize + 1;
-            }
-        }
-
-        0
+        limbs.iter().enumerate().find(|(_, &limb)| limb != 0).map_or(0,
+            |(i, limb)| i * LIMB_BITS + limb.trailing_zeros() as usize + 1)
     }
 
     /// One, not zero, based MSB. That is, returns 0 for a zeroed significand.
     pub(super) fn omsb(limbs: &[Limb]) -> usize {
-        for (i, &limb) in limbs.iter().enumerate().rev() {
-            if limb != 0 {
-                return (i + 1) * LIMB_BITS - limb.leading_zeros() as usize;
-            }
-        }
-
-        0
+        limbs.iter().enumerate().rfind(|(_, &limb)| limb != 0).map_or(0,
+            |(i, limb)| (i + 1) * LIMB_BITS - limb.leading_zeros() as usize)
     }
 
     /// Comparison (unsigned) of two significands.

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -1387,10 +1387,9 @@ impl Stack {
 
     // Used by Parser to test whether the top-most element is an index.
     fn last_is_index(&self) -> bool {
-        if let Some(InternalIndex(_)) = self.stack.last() {
-            true
-        } else {
-            false
+        match self.stack.last() {
+            Some(InternalIndex(_)) => true,
+            _ => false,
         }
     }
 


### PR DESCRIPTION
In `librustc_apfloat/ieee.rs`, use the iterator.[r]find methods to simplify the code. In `libserialize/json.rs`, make use of the fact that `Vec.last` on an empty `Vec` returns `None` to simplify the code to a single match.