### PR TITLE
use `NonZeroU32` in `newtype_index!`macro, change syntax

### DIFF
--- a/src/librustc/dep_graph/graph.rs
+++ b/src/librustc/dep_graph/graph.rs
@@ -39,7 +39,9 @@ pub struct DepGraph {
     fingerprints: Lrc<Lock<IndexVec<DepNodeIndex, Fingerprint>>>
 }
 
-newtype_index!(DepNodeIndex);
+newtype_index! {
+    pub struct DepNodeIndex { .. }
+}
 
 impl DepNodeIndex {
     const INVALID: DepNodeIndex = DepNodeIndex(::std::u32::MAX);

--- a/src/librustc/dep_graph/graph.rs
+++ b/src/librustc/dep_graph/graph.rs
@@ -44,9 +44,7 @@ newtype_index! {
 }
 
 impl DepNodeIndex {
-    const INVALID: DepNodeIndex = unsafe {
-        DepNodeIndex::from_u32_unchecked(::std::u32::MAX)
-    };
+    const INVALID: DepNodeIndex = DepNodeIndex::MAX;
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]

--- a/src/librustc/dep_graph/graph.rs
+++ b/src/librustc/dep_graph/graph.rs
@@ -44,7 +44,7 @@ newtype_index! {
 }
 
 impl DepNodeIndex {
-    const INVALID: DepNodeIndex = DepNodeIndex(::std::u32::MAX);
+    const INVALID: DepNodeIndex = DepNodeIndex { private: ::std::u32::MAX };
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
@@ -1127,14 +1127,14 @@ impl DepNodeColorMap {
         match self.values[index] {
             COMPRESSED_NONE => None,
             COMPRESSED_RED => Some(DepNodeColor::Red),
-            value => Some(DepNodeColor::Green(DepNodeIndex(value - COMPRESSED_FIRST_GREEN)))
+            value => Some(DepNodeColor::Green(DepNodeIndex { private: value - COMPRESSED_FIRST_GREEN })),
         }
     }
 
     fn insert(&mut self, index: SerializedDepNodeIndex, color: DepNodeColor) {
         self.values[index] = match color {
             DepNodeColor::Red => COMPRESSED_RED,
-            DepNodeColor::Green(index) => index.0 + COMPRESSED_FIRST_GREEN,
+            DepNodeColor::Green(index) => index.private + COMPRESSED_FIRST_GREEN,
         }
     }
 }

--- a/src/librustc/dep_graph/graph.rs
+++ b/src/librustc/dep_graph/graph.rs
@@ -44,7 +44,9 @@ newtype_index! {
 }
 
 impl DepNodeIndex {
-    const INVALID: DepNodeIndex = DepNodeIndex { private: ::std::u32::MAX };
+    const INVALID: DepNodeIndex = unsafe {
+        DepNodeIndex::from_u32_unchecked(::std::u32::MAX)
+    };
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
@@ -1127,14 +1129,16 @@ impl DepNodeColorMap {
         match self.values[index] {
             COMPRESSED_NONE => None,
             COMPRESSED_RED => Some(DepNodeColor::Red),
-            value => Some(DepNodeColor::Green(DepNodeIndex { private: value - COMPRESSED_FIRST_GREEN })),
+            value => Some(DepNodeColor::Green(DepNodeIndex::from_u32(
+                value - COMPRESSED_FIRST_GREEN
+            )))
         }
     }
 
     fn insert(&mut self, index: SerializedDepNodeIndex, color: DepNodeColor) {
         self.values[index] = match color {
             DepNodeColor::Red => COMPRESSED_RED,
-            DepNodeColor::Green(index) => index.private + COMPRESSED_FIRST_GREEN,
+            DepNodeColor::Green(index) => index.as_u32() + COMPRESSED_FIRST_GREEN,
         }
     }
 }

--- a/src/librustc/dep_graph/serialized.rs
+++ b/src/librustc/dep_graph/serialized.rs
@@ -14,7 +14,9 @@ use dep_graph::DepNode;
 use ich::Fingerprint;
 use rustc_data_structures::indexed_vec::{IndexVec, Idx};
 
-newtype_index!(SerializedDepNodeIndex);
+newtype_index! {
+    pub struct SerializedDepNodeIndex { .. }
+}
 
 /// Data for use when recompiling the **current crate**.
 #[derive(Debug, RustcEncodable, RustcDecodable)]

--- a/src/librustc/hir/def_id.rs
+++ b/src/librustc/hir/def_id.rs
@@ -41,19 +41,7 @@ newtype_index! {
 impl CrateNum {
     pub fn new(x: usize) -> CrateNum {
         assert!(x < (u32::MAX as usize));
-        CrateNum { private: x as u32 }
-    }
-
-    pub fn from_u32(x: u32) -> CrateNum {
-        CrateNum { private: x }
-    }
-
-    pub fn as_usize(&self) -> usize {
-        self.private as usize
-    }
-
-    pub fn as_u32(&self) -> u32 {
-        u32::from(*self)
+        CrateNum::from_u32(x as u32)
     }
 
     pub fn as_def_id(&self) -> DefId { DefId { krate: *self, index: CRATE_DEF_INDEX } }
@@ -61,7 +49,7 @@ impl CrateNum {
 
 impl fmt::Display for CrateNum {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Display::fmt(&self.private, f)
+        fmt::Display::fmt(&self.as_u32(), f)
     }
 }
 

--- a/src/librustc/hir/def_id.rs
+++ b/src/librustc/hir/def_id.rs
@@ -41,15 +41,15 @@ newtype_index! {
 impl CrateNum {
     pub fn new(x: usize) -> CrateNum {
         assert!(x < (u32::MAX as usize));
-        CrateNum(x as u32)
+        CrateNum { private: x as u32 }
     }
 
     pub fn from_u32(x: u32) -> CrateNum {
-        CrateNum(x)
+        CrateNum { private: x }
     }
 
     pub fn as_usize(&self) -> usize {
-        self.0 as usize
+        self.private as usize
     }
 
     pub fn as_u32(&self) -> u32 {
@@ -61,7 +61,7 @@ impl CrateNum {
 
 impl fmt::Display for CrateNum {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Display::fmt(&self.0, f)
+        fmt::Display::fmt(&self.private, f)
     }
 }
 

--- a/src/librustc/hir/def_id.rs
+++ b/src/librustc/hir/def_id.rs
@@ -27,21 +27,20 @@ newtype_index! {
         /// Virtual crate for builtin macros
         // FIXME(jseyfried): this is also used for custom derives until proc-macro crates get
         // `CrateNum`s.
-        const BUILTIN_MACROS_CRATE = u32::MAX,
+        const BUILTIN_MACROS_CRATE = CrateNum::MAX_AS_U32,
 
         /// A CrateNum value that indicates that something is wrong.
-        const INVALID_CRATE = u32::MAX - 1,
+        const INVALID_CRATE = CrateNum::MAX_AS_U32 - 1,
 
         /// A special CrateNum that we use for the tcx.rcache when decoding from
         /// the incr. comp. cache.
-        const RESERVED_FOR_INCR_COMP_CACHE = u32::MAX - 2,
+        const RESERVED_FOR_INCR_COMP_CACHE = CrateNum::MAX_AS_U32 - 2,
     }
 }
 
 impl CrateNum {
     pub fn new(x: usize) -> CrateNum {
-        assert!(x < (u32::MAX as usize));
-        CrateNum::from_u32(x as u32)
+        CrateNum::from_usize(x)
     }
 
     pub fn as_def_id(&self) -> DefId { DefId { krate: *self, index: CRATE_DEF_INDEX } }

--- a/src/librustc/hir/def_id.rs
+++ b/src/librustc/hir/def_id.rs
@@ -53,7 +53,7 @@ impl CrateNum {
     }
 
     pub fn as_u32(&self) -> u32 {
-        self.0
+        u32::from(*self)
     }
 
     pub fn as_def_id(&self) -> DefId { DefId { krate: *self, index: CRATE_DEF_INDEX } }

--- a/src/librustc/hir/def_id.rs
+++ b/src/librustc/hir/def_id.rs
@@ -15,8 +15,8 @@ use serialize;
 use std::fmt;
 use std::u32;
 
-newtype_index!(CrateNum
-    {
+newtype_index! {
+    pub struct CrateNum {
         ENCODABLE = custom
         DEBUG_FORMAT = "crate{}",
 
@@ -35,7 +35,8 @@ newtype_index!(CrateNum
         /// A special CrateNum that we use for the tcx.rcache when decoding from
         /// the incr. comp. cache.
         const RESERVED_FOR_INCR_COMP_CACHE = u32::MAX - 2,
-    });
+    }
+}
 
 impl CrateNum {
     pub fn new(x: usize) -> CrateNum {

--- a/src/librustc/ich/impls_mir.rs
+++ b/src/librustc/ich/impls_mir.rs
@@ -102,7 +102,6 @@ impl<'a> HashStable<StableHashingContext<'a>> for mir::Local {
     fn hash_stable<W: StableHasherResult>(&self,
                                           hcx: &mut StableHashingContext<'a>,
                                           hasher: &mut StableHasher<W>) {
-        use rustc_data_structures::indexed_vec::Idx;
         self.index().hash_stable(hcx, hasher);
     }
 }
@@ -112,7 +111,6 @@ impl<'a> HashStable<StableHashingContext<'a>> for mir::BasicBlock {
     fn hash_stable<W: StableHasherResult>(&self,
                                           hcx: &mut StableHashingContext<'a>,
                                           hasher: &mut StableHasher<W>) {
-        use rustc_data_structures::indexed_vec::Idx;
         self.index().hash_stable(hcx, hasher);
     }
 }
@@ -122,7 +120,6 @@ impl<'a> HashStable<StableHashingContext<'a>> for mir::Field {
     fn hash_stable<W: StableHasherResult>(&self,
                                           hcx: &mut StableHashingContext<'a>,
                                           hasher: &mut StableHasher<W>) {
-        use rustc_data_structures::indexed_vec::Idx;
         self.index().hash_stable(hcx, hasher);
     }
 }
@@ -133,7 +130,6 @@ for mir::SourceScope {
     fn hash_stable<W: StableHasherResult>(&self,
                                           hcx: &mut StableHashingContext<'a>,
                                           hasher: &mut StableHasher<W>) {
-        use rustc_data_structures::indexed_vec::Idx;
         self.index().hash_stable(hcx, hasher);
     }
 }
@@ -143,7 +139,6 @@ impl<'a> HashStable<StableHashingContext<'a>> for mir::Promoted {
     fn hash_stable<W: StableHasherResult>(&self,
                                           hcx: &mut StableHashingContext<'a>,
                                           hasher: &mut StableHasher<W>) {
-        use rustc_data_structures::indexed_vec::Idx;
         self.index().hash_stable(hcx, hasher);
     }
 }

--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -143,7 +143,6 @@ impl<'a> HashStable<StableHashingContext<'a>> for ty::RegionVid {
     fn hash_stable<W: StableHasherResult>(&self,
                                           hcx: &mut StableHashingContext<'a>,
                                           hasher: &mut StableHasher<W>) {
-        use rustc_data_structures::indexed_vec::Idx;
         self.index().hash_stable(hcx, hasher);
     }
 }
@@ -153,7 +152,6 @@ impl<'gcx> HashStable<StableHashingContext<'gcx>> for ty::CanonicalVar {
     fn hash_stable<W: StableHasherResult>(&self,
                                           hcx: &mut StableHashingContext<'gcx>,
                                           hasher: &mut StableHasher<W>) {
-        use rustc_data_structures::indexed_vec::Idx;
         self.index().hash_stable(hcx, hasher);
     }
 }
@@ -774,7 +772,6 @@ impl_stable_hash_for!(enum ty::cast::CastKind {
     FnPtrAddrCast
 });
 
-impl_stable_hash_for!(tuple_struct ::middle::region::FirstStatementIndex { idx });
 impl_stable_hash_for!(struct ::middle::region::Scope { id, code });
 
 impl<'a> ToStableHashKey<StableHashingContext<'a>> for region::Scope {

--- a/src/librustc/infer/error_reporting/mod.rs
+++ b/src/librustc/infer/error_reporting/mod.rs
@@ -73,8 +73,6 @@ use syntax::ast::DUMMY_NODE_ID;
 use syntax_pos::{Pos, Span};
 use errors::{Applicability, DiagnosticBuilder, DiagnosticStyledString};
 
-use rustc_data_structures::indexed_vec::Idx;
-
 mod note;
 
 mod need_type_info;

--- a/src/librustc/infer/region_constraints/mod.rs
+++ b/src/librustc/infer/region_constraints/mod.rs
@@ -16,7 +16,7 @@ use self::CombineMapType::*;
 use super::{MiscVariable, RegionVariableOrigin, SubregionOrigin};
 use super::unify_key;
 
-use rustc_data_structures::indexed_vec::{IndexVec, Idx};
+use rustc_data_structures::indexed_vec::IndexVec;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_data_structures::unify as ut;
 use ty::{self, Ty, TyCtxt};

--- a/src/librustc/infer/unify_key.rs
+++ b/src/librustc/infer/unify_key.rs
@@ -49,8 +49,8 @@ impl UnifyValue for RegionVidKey {
 
 impl UnifyKey for ty::RegionVid {
     type Value = RegionVidKey;
-    fn index(&self) -> u32 { self.0 }
-    fn from_index(i: u32) -> ty::RegionVid { ty::RegionVid(i) }
+    fn index(&self) -> u32 { u32::from(*self) }
+    fn from_index(i: u32) -> ty::RegionVid { ty::RegionVid::from(i) }
     fn tag() -> &'static str { "RegionVid" }
 }
 

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -159,11 +159,12 @@ pub struct BlockRemainder {
     pub first_statement_index: FirstStatementIndex,
 }
 
-newtype_index!(FirstStatementIndex
-    {
+newtype_index! {
+    pub struct FirstStatementIndex {
         pub idx
         MAX = SCOPE_DATA_REMAINDER_MAX
-    });
+    }
+}
 
 impl From<ScopeData> for Scope {
     #[inline]

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -161,10 +161,11 @@ pub struct BlockRemainder {
 
 newtype_index! {
     pub struct FirstStatementIndex {
-        pub idx
         MAX = SCOPE_DATA_REMAINDER_MAX
     }
 }
+
+impl_stable_hash_for!(tuple_struct ::middle::region::FirstStatementIndex { idx });
 
 impl From<ScopeData> for Scope {
     #[inline]

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -165,7 +165,7 @@ newtype_index! {
     }
 }
 
-impl_stable_hash_for!(tuple_struct ::middle::region::FirstStatementIndex { idx });
+impl_stable_hash_for!(struct ::middle::region::FirstStatementIndex { private });
 
 impl From<ScopeData> for Scope {
     #[inline]

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -131,9 +131,6 @@ pub struct Mir<'tcx> {
     cache: cache::Cache,
 }
 
-/// where execution begins
-pub const START_BLOCK: BasicBlock = BasicBlock { private: 0 };
-
 impl<'tcx> Mir<'tcx> {
     pub fn new(
         basic_blocks: IndexVec<BasicBlock, BasicBlockData<'tcx>>,
@@ -239,7 +236,7 @@ impl<'tcx> Mir<'tcx> {
 
     #[inline]
     pub fn local_kind(&self, local: Local) -> LocalKind {
-        let index = local.private as usize;
+        let index = local.as_usize();
         if index == 0 {
             debug_assert!(
                 self.local_decls[local].mutability == Mutability::Mut,
@@ -855,7 +852,8 @@ pub struct UpvarDecl {
 
 newtype_index! {
     pub struct BasicBlock {
-        DEBUG_FORMAT = "bb{}"
+        DEBUG_FORMAT = "bb{}",
+        const START_BLOCK = 0,
     }
 }
 

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -523,11 +523,12 @@ impl BorrowKind {
 ///////////////////////////////////////////////////////////////////////////
 // Variables and temps
 
-newtype_index!(Local
-    {
+newtype_index! {
+    pub struct Local {
         DEBUG_FORMAT = "_{}",
         const RETURN_PLACE = 0,
-    });
+    }
+}
 
 /// Classifies locals into categories. See `Mir::local_kind`.
 #[derive(PartialEq, Eq, Debug)]
@@ -852,7 +853,11 @@ pub struct UpvarDecl {
 ///////////////////////////////////////////////////////////////////////////
 // BasicBlock
 
-newtype_index!(BasicBlock { DEBUG_FORMAT = "bb{}" });
+newtype_index! {
+    pub struct BasicBlock {
+        DEBUG_FORMAT = "bb{}"
+    }
+}
 
 impl BasicBlock {
     pub fn start_location(self) -> Location {
@@ -1822,7 +1827,11 @@ pub type PlaceProjection<'tcx> = Projection<'tcx, Place<'tcx>, Local, Ty<'tcx>>;
 /// and the index is a local.
 pub type PlaceElem<'tcx> = ProjectionElem<'tcx, Local, Ty<'tcx>>;
 
-newtype_index!(Field { DEBUG_FORMAT = "field[{}]" });
+newtype_index! {
+    pub struct Field {
+        DEBUG_FORMAT = "field[{}]"
+    }
+}
 
 impl<'tcx> Place<'tcx> {
     pub fn field(self, f: Field, ty: Ty<'tcx>) -> Place<'tcx> {
@@ -1895,11 +1904,12 @@ impl<'tcx> Debug for Place<'tcx> {
 ///////////////////////////////////////////////////////////////////////////
 // Scopes
 
-newtype_index!(SourceScope
-    {
+newtype_index! {
+    pub struct SourceScope {
         DEBUG_FORMAT = "scope[{}]",
         const OUTERMOST_SOURCE_SCOPE = 0,
-    });
+    }
+}
 
 #[derive(Clone, Debug, RustcEncodable, RustcDecodable)]
 pub struct SourceScopeData {
@@ -2271,7 +2281,11 @@ pub struct Constant<'tcx> {
     pub literal: &'tcx ty::Const<'tcx>,
 }
 
-newtype_index!(Promoted { DEBUG_FORMAT = "promoted[{}]" });
+newtype_index! {
+    pub struct Promoted {
+        DEBUG_FORMAT = "promoted[{}]"
+    }
+}
 
 impl<'tcx> Debug for Constant<'tcx> {
     fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -132,7 +132,7 @@ pub struct Mir<'tcx> {
 }
 
 /// where execution begins
-pub const START_BLOCK: BasicBlock = BasicBlock(0);
+pub const START_BLOCK: BasicBlock = BasicBlock { private: 0 };
 
 impl<'tcx> Mir<'tcx> {
     pub fn new(
@@ -239,7 +239,7 @@ impl<'tcx> Mir<'tcx> {
 
     #[inline]
     pub fn local_kind(&self, local: Local) -> LocalKind {
-        let index = local.0 as usize;
+        let index = local.private as usize;
         if index == 0 {
             debug_assert!(
                 self.local_decls[local].mutability == Mutability::Mut,

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -1274,9 +1274,7 @@ impl DebruijnIndex {
     /// you would need to shift the index for `'a` into 1 new binder.
     #[must_use]
     pub fn shifted_in(self, amount: u32) -> DebruijnIndex {
-        unsafe {
-            DebruijnIndex::from_u32_unchecked(self.as_u32() + amount)
-        }
+        DebruijnIndex::from_u32(self.as_u32() + amount)
     }
 
     /// Update this index in place by shifting it "in" through
@@ -1289,9 +1287,7 @@ impl DebruijnIndex {
     /// `amount` number of new binders.
     #[must_use]
     pub fn shifted_out(self, amount: u32) -> DebruijnIndex {
-        unsafe {
-            DebruijnIndex::from_u32_unchecked(self.as_u32() - amount)
-        }
+        DebruijnIndex::from_u32(self.as_u32() - amount)
     }
 
     /// Update in place by shifting out from `amount` binders.

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -1034,11 +1034,12 @@ impl<'a, 'gcx, 'tcx> ParamTy {
 /// is the outer fn.
 ///
 /// [dbi]: http://en.wikipedia.org/wiki/De_Bruijn_index
-newtype_index!(DebruijnIndex
-    {
+newtype_index! {
+    pub struct DebruijnIndex {
         DEBUG_FORMAT = "DebruijnIndex({})",
         const INNERMOST = 0,
-    });
+    }
+}
 
 pub type Region<'tcx> = &'tcx RegionKind;
 
@@ -1176,11 +1177,12 @@ pub struct FloatVid {
     pub index: u32,
 }
 
-newtype_index!(RegionVid
-    {
+newtype_index! {
+    pub struct RegionVid {
         pub idx
         DEBUG_FORMAT = custom,
-    });
+    }
+}
 
 impl Atom for RegionVid {
     fn index(self) -> usize {
@@ -1217,7 +1219,9 @@ pub enum InferTy {
     CanonicalTy(CanonicalVar),
 }
 
-newtype_index!(CanonicalVar);
+newtype_index! {
+    pub struct CanonicalVar { .. }
+}
 
 /// A `ProjectionPredicate` for an `ExistentialTraitRef`.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, RustcEncodable, RustcDecodable)]

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -1273,7 +1273,7 @@ impl DebruijnIndex {
     ///
     /// you would need to shift the index for `'a` into 1 new binder.
     #[must_use]
-    pub const fn shifted_in(self, amount: u32) -> DebruijnIndex {
+    pub fn shifted_in(self, amount: u32) -> DebruijnIndex {
         unsafe {
             DebruijnIndex::from_u32_unchecked(self.as_u32() + amount)
         }
@@ -1288,7 +1288,7 @@ impl DebruijnIndex {
     /// Returns the resulting index when this value is moved out from
     /// `amount` number of new binders.
     #[must_use]
-    pub const fn shifted_out(self, amount: u32) -> DebruijnIndex {
+    pub fn shifted_out(self, amount: u32) -> DebruijnIndex {
         unsafe {
             DebruijnIndex::from_u32_unchecked(self.as_u32() - amount)
         }

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -1274,7 +1274,7 @@ impl DebruijnIndex {
     /// you would need to shift the index for `'a` into 1 new binder.
     #[must_use]
     pub const fn shifted_in(self, amount: u32) -> DebruijnIndex {
-        DebruijnIndex(self.0 + amount)
+        DebruijnIndex { private: self.private + amount }
     }
 
     /// Update this index in place by shifting it "in" through
@@ -1287,7 +1287,7 @@ impl DebruijnIndex {
     /// `amount` number of new binders.
     #[must_use]
     pub const fn shifted_out(self, amount: u32) -> DebruijnIndex {
-        DebruijnIndex(self.0 - amount)
+        DebruijnIndex { private: self.private - amount }
     }
 
     /// Update in place by shifting out from `amount` binders.
@@ -1316,11 +1316,11 @@ impl DebruijnIndex {
     /// bound by one of the binders we are shifting out of, that is an
     /// error (and should fail an assertion failure).
     pub fn shifted_out_to_binder(self, to_binder: DebruijnIndex) -> Self {
-        self.shifted_out((to_binder.0 - INNERMOST.0) as u32)
+        self.shifted_out((to_binder.private - INNERMOST.private) as u32)
     }
 }
 
-impl_stable_hash_for!(tuple_struct DebruijnIndex { index });
+impl_stable_hash_for!(struct DebruijnIndex { private });
 
 /// Region utilities
 impl RegionKind {

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -1179,7 +1179,6 @@ pub struct FloatVid {
 
 newtype_index! {
     pub struct RegionVid {
-        pub idx
         DEBUG_FORMAT = custom,
     }
 }
@@ -1187,18 +1186,6 @@ newtype_index! {
 impl Atom for RegionVid {
     fn index(self) -> usize {
         Idx::index(self)
-    }
-}
-
-impl From<usize> for RegionVid {
-    fn from(i: usize) -> RegionVid {
-        RegionVid::new(i)
-    }
-}
-
-impl From<RegionVid> for usize {
-    fn from(vid: RegionVid) -> usize {
-        Idx::index(vid)
     }
 }
 

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -1274,7 +1274,9 @@ impl DebruijnIndex {
     /// you would need to shift the index for `'a` into 1 new binder.
     #[must_use]
     pub const fn shifted_in(self, amount: u32) -> DebruijnIndex {
-        DebruijnIndex { private: self.private + amount }
+        unsafe {
+            DebruijnIndex::from_u32_unchecked(self.as_u32() + amount)
+        }
     }
 
     /// Update this index in place by shifting it "in" through
@@ -1287,7 +1289,9 @@ impl DebruijnIndex {
     /// `amount` number of new binders.
     #[must_use]
     pub const fn shifted_out(self, amount: u32) -> DebruijnIndex {
-        DebruijnIndex { private: self.private - amount }
+        unsafe {
+            DebruijnIndex::from_u32_unchecked(self.as_u32() - amount)
+        }
     }
 
     /// Update in place by shifting out from `amount` binders.
@@ -1316,7 +1320,7 @@ impl DebruijnIndex {
     /// bound by one of the binders we are shifting out of, that is an
     /// error (and should fail an assertion failure).
     pub fn shifted_out_to_binder(self, to_binder: DebruijnIndex) -> Self {
-        self.shifted_out((to_binder.private - INNERMOST.private) as u32)
+        self.shifted_out(to_binder.as_u32() - INNERMOST.as_u32())
     }
 }
 

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -26,7 +26,6 @@ use std::cell::Cell;
 use std::fmt;
 use std::usize;
 
-use rustc_data_structures::indexed_vec::Idx;
 use rustc_target::spec::abi::Abi;
 use syntax::ast::CRATE_NODE_ID;
 use syntax::symbol::{Symbol, InternedString};

--- a/src/librustc_codegen_llvm/mir/mod.rs
+++ b/src/librustc_codegen_llvm/mir/mod.rs
@@ -32,7 +32,7 @@ use syntax::symbol::keywords;
 use std::iter;
 
 use rustc_data_structures::bitvec::BitArray;
-use rustc_data_structures::indexed_vec::{IndexVec, Idx};
+use rustc_data_structures::indexed_vec::IndexVec;
 
 pub use self::constant::codegen_static_initializer;
 

--- a/src/librustc_codegen_llvm/mir/operand.rs
+++ b/src/librustc_codegen_llvm/mir/operand.rs
@@ -13,7 +13,6 @@ use rustc::mir;
 use rustc::mir::interpret::{ConstValue, ScalarMaybeUndef};
 use rustc::ty;
 use rustc::ty::layout::{self, Align, LayoutOf, TyLayout};
-use rustc_data_structures::indexed_vec::Idx;
 use rustc_data_structures::sync::Lrc;
 
 use base;

--- a/src/librustc_codegen_llvm/mir/place.rs
+++ b/src/librustc_codegen_llvm/mir/place.rs
@@ -13,7 +13,6 @@ use rustc::ty::{self, Ty};
 use rustc::ty::layout::{self, Align, TyLayout, LayoutOf, Size};
 use rustc::mir;
 use rustc::mir::tcx::PlaceTy;
-use rustc_data_structures::indexed_vec::Idx;
 use base;
 use builder::Builder;
 use common::{CodegenCx, C_undef, C_usize, C_u8, C_u32, C_uint, C_null, C_uint_big};

--- a/src/librustc_data_structures/indexed_vec.rs
+++ b/src/librustc_data_structures/indexed_vec.rs
@@ -72,7 +72,7 @@ macro_rules! newtype_index {
         newtype_index!(
             // Leave out derives marker so we can use its absence to ensure it comes first
             @type         [$name]
-            @max          [::std::u32::MAX]
+            @max          [::std::u32::MAX - 1]
             @vis          [$v]
             @debug_format ["{}"]);
     );
@@ -82,7 +82,7 @@ macro_rules! newtype_index {
         newtype_index!(
             // Leave out derives marker so we can use its absence to ensure it comes first
             @type         [$name]
-            @max          [::std::u32::MAX]
+            @max          [::std::u32::MAX - 1]
             @vis          [$v]
             @debug_format ["{}"]
                           $($tokens)+);
@@ -102,9 +102,13 @@ macro_rules! newtype_index {
         }
 
         impl $type {
+            $v const MAX_AS_U32: u32 = $max;
+
+            $v const MAX: $type = unsafe { $type::from_u32_unchecked($max) };
+
             #[inline]
             $v fn from_usize(value: usize) -> Self {
-                assert!(value < ($max as usize));
+                assert!(value <= ($max as usize));
                 unsafe {
                     $type::from_u32_unchecked(value as u32)
                 }
@@ -112,7 +116,7 @@ macro_rules! newtype_index {
 
             #[inline]
             $v fn from_u32(value: u32) -> Self {
-                assert!(value < $max);
+                assert!(value <= $max);
                 unsafe {
                     $type::from_u32_unchecked(value)
                 }
@@ -138,7 +142,7 @@ macro_rules! newtype_index {
             /// Extract value of this index as a u32.
             #[inline]
             $v const fn as_usize(self) -> usize {
-                self.private as usize
+                self.as_u32() as usize
             }
         }
 

--- a/src/librustc_data_structures/indexed_vec.rs
+++ b/src/librustc_data_structures/indexed_vec.rs
@@ -155,6 +155,7 @@ macro_rules! newtype_index {
         }
 
         impl ::std::iter::Step for $type {
+            #[inline]
             fn steps_between(start: &Self, end: &Self) -> Option<usize> {
                 <usize as ::std::iter::Step>::steps_between(
                     &Idx::index(*start),
@@ -162,46 +163,55 @@ macro_rules! newtype_index {
                 )
             }
 
+            #[inline]
             fn replace_one(&mut self) -> Self {
                 ::std::mem::replace(self, Self::new(1))
             }
 
+            #[inline]
             fn replace_zero(&mut self) -> Self {
                 ::std::mem::replace(self, Self::new(0))
             }
 
+            #[inline]
             fn add_one(&self) -> Self {
                 Self::new(Idx::index(*self) + 1)
             }
 
+            #[inline]
             fn sub_one(&self) -> Self {
                 Self::new(Idx::index(*self) - 1)
             }
 
+            #[inline]
             fn add_usize(&self, u: usize) -> Option<Self> {
                 Idx::index(*self).checked_add(u).map(Self::new)
             }
         }
 
         impl From<$type> for u32 {
+            #[inline]
             fn from(v: $type) -> u32 {
                 v.as_u32()
             }
         }
 
         impl From<$type> for usize {
+            #[inline]
             fn from(v: $type) -> usize {
                 v.as_usize()
             }
         }
 
         impl From<usize> for $type {
+            #[inline]
             fn from(value: usize) -> Self {
                 $type::from_usize(value)
             }
         }
 
         impl From<u32> for $type {
+            #[inline]
             fn from(value: u32) -> Self {
                 $type::from_u32(value)
             }

--- a/src/librustc_data_structures/indexed_vec.rs
+++ b/src/librustc_data_structures/indexed_vec.rs
@@ -98,7 +98,7 @@ macro_rules! newtype_index {
      @debug_format [$debug_format:tt]) => (
         #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, $($derives),*)]
         $v struct $type {
-            private: ::std::num::NonZeroU32
+            private: u32
         }
 
         impl $type {
@@ -142,7 +142,7 @@ macro_rules! newtype_index {
 
             #[inline]
             $v const unsafe fn from_u32_unchecked(value: u32) -> Self {
-                $type { private: ::std::num::NonZeroU32::new_unchecked(value + 1) }
+                $type { private: value }
             }
 
             /// Extract value of this index as an integer.
@@ -153,13 +153,13 @@ macro_rules! newtype_index {
 
             /// Extract value of this index as a usize.
             #[inline]
-            $v fn as_u32(self) -> u32 {
-                self.private.get() - 1
+            $v const fn as_u32(self) -> u32 {
+                self.private
             }
 
             /// Extract value of this index as a u32.
             #[inline]
-            $v fn as_usize(self) -> usize {
+            $v const fn as_usize(self) -> usize {
                 self.as_u32() as usize
             }
         }

--- a/src/librustc_data_structures/indexed_vec.rs
+++ b/src/librustc_data_structures/indexed_vec.rs
@@ -97,7 +97,9 @@ macro_rules! newtype_index {
      @vis          [$v:vis]
      @debug_format [$debug_format:tt]) => (
         #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, $($derives),*)]
-        $v struct $type(u32);
+        $v struct $type {
+            private: u32
+        }
 
         impl $type {
             /// Extract value of this index as an integer.
@@ -111,12 +113,12 @@ macro_rules! newtype_index {
             #[inline]
             fn new(value: usize) -> Self {
                 assert!(value < ($max) as usize);
-                $type(value as u32)
+                $type { private: value as u32 }
             }
 
             #[inline]
             fn index(self) -> usize {
-                self.0 as usize
+                self.private as usize
             }
         }
 
@@ -151,13 +153,13 @@ macro_rules! newtype_index {
 
         impl From<$type> for u32 {
             fn from(v: $type) -> u32 {
-                v.0
+                v.private
             }
         }
 
         impl From<$type> for usize {
             fn from(v: $type) -> usize {
-                v.0 as usize
+                v.private as usize
             }
         }
 
@@ -193,7 +195,7 @@ macro_rules! newtype_index {
      @debug_format [$debug_format:tt]) => (
         impl ::std::fmt::Debug for $type {
             fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-                write!(fmt, $debug_format, self.0)
+                write!(fmt, $debug_format, self.private)
             }
         }
     );
@@ -376,7 +378,7 @@ macro_rules! newtype_index {
                    const $name:ident = $constant:expr,
                    $($tokens:tt)*) => (
         $(#[doc = $doc])*
-        pub const $name: $type = $type($constant);
+        pub const $name: $type = $type { private: $constant  };
         newtype_index!(
             @derives      [$($derives,)*]
             @type         [$type]

--- a/src/librustc_data_structures/indexed_vec.rs
+++ b/src/librustc_data_structures/indexed_vec.rs
@@ -48,6 +48,13 @@ impl Idx for u32 {
     fn index(self) -> usize { self as usize }
 }
 
+/// Creates a struct type `S` that can be used as an index with
+/// `IndexVec` and so on.  This struct can be constructed via `S::new`
+/// (given a `usize`) and converted to a usize with the `index()`
+/// method (from the `Idx` trait). Internally, the index uses a u32,
+/// so the index must not exceed `u32::MAX`. You can also customize
+/// things like the `Debug` impl, what traits are derived, and so
+/// forth.
 #[macro_export]
 macro_rules! newtype_index {
     // ---- public rules ----

--- a/src/librustc_data_structures/indexed_vec.rs
+++ b/src/librustc_data_structures/indexed_vec.rs
@@ -136,7 +136,7 @@ macro_rules! newtype_index {
                 ];
 
                 unsafe {
-                    $type::from_u32_unchecked(value)
+                    $type { private: value }
                 }
             }
 
@@ -153,13 +153,13 @@ macro_rules! newtype_index {
 
             /// Extract value of this index as a usize.
             #[inline]
-            $v const fn as_u32(self) -> u32 {
+            $v fn as_u32(self) -> u32 {
                 self.private
             }
 
             /// Extract value of this index as a u32.
             #[inline]
-            $v const fn as_usize(self) -> usize {
+            $v fn as_usize(self) -> usize {
                 self.as_u32() as usize
             }
         }

--- a/src/librustc_data_structures/indexed_vec.rs
+++ b/src/librustc_data_structures/indexed_vec.rs
@@ -98,7 +98,7 @@ macro_rules! newtype_index {
      @debug_format [$debug_format:tt]) => (
         #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, $($derives),*)]
         $v struct $type {
-            private: u32
+            private: ::std::num::NonZeroU32
         }
 
         impl $type {
@@ -124,7 +124,7 @@ macro_rules! newtype_index {
 
             #[inline]
             $v const unsafe fn from_u32_unchecked(value: u32) -> Self {
-                $type { private: value }
+                $type { private: ::std::num::NonZeroU32::new_unchecked(value + 1) }
             }
 
             /// Extract value of this index as an integer.
@@ -135,13 +135,13 @@ macro_rules! newtype_index {
 
             /// Extract value of this index as a usize.
             #[inline]
-            $v const fn as_u32(self) -> u32 {
-                self.private
+            $v fn as_u32(self) -> u32 {
+                self.private.get() - 1
             }
 
             /// Extract value of this index as a u32.
             #[inline]
-            $v const fn as_usize(self) -> usize {
+            $v fn as_usize(self) -> usize {
                 self.as_u32() as usize
             }
         }

--- a/src/librustc_data_structures/indexed_vec.rs
+++ b/src/librustc_data_structures/indexed_vec.rs
@@ -53,20 +53,22 @@ macro_rules! newtype_index {
     // ---- public rules ----
 
     // Use default constants
-    ($name:ident) => (
+    ($v:vis struct $name:ident { .. }) => (
         newtype_index!(
             // Leave out derives marker so we can use its absence to ensure it comes first
             @type         [$name]
             @max          [::std::u32::MAX]
+            @vis          [$v]
             @debug_format ["{}"]);
     );
 
     // Define any constants
-    ($name:ident { $($tokens:tt)+ }) => (
+    ($v:vis struct $name:ident { $($tokens:tt)+ }) => (
         newtype_index!(
             // Leave out derives marker so we can use its absence to ensure it comes first
             @type         [$name]
             @max          [::std::u32::MAX]
+            @vis          [$v]
             @debug_format ["{}"]
                           $($tokens)+);
     );
@@ -78,9 +80,10 @@ macro_rules! newtype_index {
      @pub          [$($pub:tt)*]
      @type         [$type:ident]
      @max          [$max:expr]
+     @vis          [$v:vis]
      @debug_format [$debug_format:tt]) => (
         #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, $($derives),*)]
-        pub struct $type($($pub)* u32);
+        $v struct $type($($pub)* u32);
 
         impl Idx for $type {
             #[inline]
@@ -170,6 +173,7 @@ macro_rules! newtype_index {
     // Handle the case where someone wants to make the internal field public
     (@type         [$type:ident]
      @max          [$max:expr]
+     @vis          [$v:vis]
      @debug_format [$debug_format:tt]
                    pub idx
                    $($tokens:tt)*) => (
@@ -177,6 +181,7 @@ macro_rules! newtype_index {
             @pub          [pub]
             @type         [$type]
             @max          [$max]
+            @vis          [$v]
             @debug_format [$debug_format]
                           $($tokens)*);
     );
@@ -184,12 +189,14 @@ macro_rules! newtype_index {
     // The default case is that the internal field is private
     (@type         [$type:ident]
      @max          [$max:expr]
+     @vis          [$v:vis]
      @debug_format [$debug_format:tt]
                    $($tokens:tt)*) => (
         newtype_index!(
             @pub          []
             @type         [$type]
             @max          [$max]
+            @vis          [$v]
             @debug_format [$debug_format]
                           $($tokens)*);
     );
@@ -198,6 +205,7 @@ macro_rules! newtype_index {
     (@pub          [$($pub:tt)*]
      @type         [$type:ident]
      @max          [$max:expr]
+     @vis          [$v:vis]
      @debug_format [$debug_format:tt]
                    derive [$($derives:ident),*]
                    $($tokens:tt)*) => (
@@ -205,6 +213,7 @@ macro_rules! newtype_index {
             @pub          [$($pub)*]
             @type         [$type]
             @max          [$max]
+            @vis          [$v]
             @debug_format [$debug_format]
                           derive [$($derives,)*]
                           $($tokens)*);
@@ -215,6 +224,7 @@ macro_rules! newtype_index {
     (@pub          [$($pub:tt)*]
      @type         [$type:ident]
      @max          [$max:expr]
+     @vis          [$v:vis]
      @debug_format [$debug_format:tt]
                    derive [$($derives:ident,)+]
                    ENCODABLE = custom
@@ -224,6 +234,7 @@ macro_rules! newtype_index {
             @pub          [$($pub)*]
             @type         [$type]
             @max          [$max]
+            @vis          [$v]
             @debug_format [$debug_format]
                           $($tokens)*);
     );
@@ -233,6 +244,7 @@ macro_rules! newtype_index {
     (@pub          [$($pub:tt)*]
      @type         [$type:ident]
      @max          [$max:expr]
+     @vis          [$v:vis]
      @debug_format [$debug_format:tt]
                    derive [$($derives:ident,)+]
                    $($tokens:tt)*) => (
@@ -241,6 +253,7 @@ macro_rules! newtype_index {
             @pub          [$($pub)*]
             @type         [$type]
             @max          [$max]
+            @vis          [$v]
             @debug_format [$debug_format]
                           $($tokens)*);
     );
@@ -250,6 +263,7 @@ macro_rules! newtype_index {
     (@pub          [$($pub:tt)*]
      @type         [$type:ident]
      @max          [$max:expr]
+     @vis          [$v:vis]
      @debug_format [$debug_format:tt]
                    ENCODABLE = custom
                    $($tokens:tt)*) => (
@@ -258,6 +272,7 @@ macro_rules! newtype_index {
             @pub          [$($pub)*]
             @type         [$type]
             @max          [$max]
+            @vis          [$v]
             @debug_format [$debug_format]
                           $($tokens)*);
     );
@@ -266,6 +281,7 @@ macro_rules! newtype_index {
     (@pub          [$($pub:tt)*]
      @type         [$type:ident]
      @max          [$max:expr]
+     @vis          [$v:vis]
      @debug_format [$debug_format:tt]
                    $($tokens:tt)*) => (
         newtype_index!(
@@ -273,6 +289,7 @@ macro_rules! newtype_index {
             @pub          [$($pub)*]
             @type         [$type]
             @max          [$max]
+            @vis          [$v]
             @debug_format [$debug_format]
                           $($tokens)*);
     );
@@ -282,6 +299,7 @@ macro_rules! newtype_index {
      @pub          [$($pub:tt)*]
      @type         [$type:ident]
      @max          [$max:expr]
+     @vis          [$v:vis]
      @debug_format [$debug_format:tt]
                    $name:ident = $constant:expr) => (
         newtype_index!(
@@ -289,6 +307,7 @@ macro_rules! newtype_index {
             @pub          [$($pub)*]
             @type         [$type]
             @max          [$max]
+            @vis          [$v]
             @debug_format [$debug_format]
                           $name = $constant,);
     );
@@ -298,6 +317,7 @@ macro_rules! newtype_index {
      @pub          [$($pub:tt)*]
      @type         [$type:ident]
      @max          [$_max:expr]
+     @vis          [$v:vis]
      @debug_format [$debug_format:tt]
                    $(#[doc = $doc:expr])*
                    const $name:ident = $constant:expr) => (
@@ -306,6 +326,7 @@ macro_rules! newtype_index {
             @pub          [$($pub)*]
             @type         [$type]
             @max          [$max]
+            @vis          [$v]
             @debug_format [$debug_format]
                           $(#[doc = $doc])* const $name = $constant,);
     );
@@ -315,6 +336,7 @@ macro_rules! newtype_index {
      @pub          [$($pub:tt)*]
      @type         [$type:ident]
      @max          [$_max:expr]
+     @vis          [$v:vis]
      @debug_format [$debug_format:tt]
                    MAX = $max:expr,
                    $($tokens:tt)*) => (
@@ -323,6 +345,7 @@ macro_rules! newtype_index {
             @pub          [$($pub)*]
             @type         [$type]
             @max          [$max]
+            @vis          [$v]
             @debug_format [$debug_format]
                           $($tokens)*);
     );
@@ -332,6 +355,7 @@ macro_rules! newtype_index {
      @pub          [$($pub:tt)*]
      @type         [$type:ident]
      @max          [$max:expr]
+     @vis          [$v:vis]
      @debug_format [$_debug_format:tt]
                    DEBUG_FORMAT = $debug_format:tt,
                    $($tokens:tt)*) => (
@@ -340,6 +364,7 @@ macro_rules! newtype_index {
             @pub          [$($pub)*]
             @type         [$type]
             @max          [$max]
+            @vis          [$v]
             @debug_format [$debug_format]
                           $($tokens)*);
     );
@@ -349,6 +374,7 @@ macro_rules! newtype_index {
      @pub          [$($pub:tt)*]
      @type         [$type:ident]
      @max          [$max:expr]
+     @vis          [$v:vis]
      @debug_format [$debug_format:tt]
                    $(#[doc = $doc:expr])*
                    const $name:ident = $constant:expr,
@@ -360,6 +386,7 @@ macro_rules! newtype_index {
             @pub          [$($pub)*]
             @type         [$type]
             @max          [$max]
+            @vis          [$v]
             @debug_format [$debug_format]
                           $($tokens)*);
     );

--- a/src/librustc_data_structures/stable_hasher.rs
+++ b/src/librustc_data_structures/stable_hasher.rs
@@ -217,6 +217,14 @@ impl_stable_hash_via_hash!(i128);
 impl_stable_hash_via_hash!(char);
 impl_stable_hash_via_hash!(());
 
+impl<CTX> HashStable<CTX> for ::std::num::NonZeroU32 {
+    fn hash_stable<W: StableHasherResult>(&self,
+                                          ctx: &mut CTX,
+                                          hasher: &mut StableHasher<W>) {
+        self.get().hash_stable(ctx, hasher)
+    }
+}
+
 impl<CTX> HashStable<CTX> for f32 {
     fn hash_stable<W: StableHasherResult>(&self,
                                           ctx: &mut CTX,

--- a/src/librustc_driver/test.rs
+++ b/src/librustc_driver/test.rs
@@ -183,8 +183,13 @@ fn test_env_with_pool<F>(
     });
 }
 
-const D1: ty::DebruijnIndex = ty::INNERMOST;
-const D2: ty::DebruijnIndex = D1.shifted_in(1);
+fn d1() -> ty::DebruijnIndex {
+    ty::INNERMOST
+}
+
+fn d2() -> ty::DebruijnIndex {
+    d1().shifted_in(1)
+}
 
 impl<'a, 'gcx, 'tcx> Env<'a, 'gcx, 'tcx> {
     pub fn tcx(&self) -> TyCtxt<'a, 'gcx, 'tcx> {
@@ -337,7 +342,7 @@ impl<'a, 'gcx, 'tcx> Env<'a, 'gcx, 'tcx> {
     }
 
     pub fn t_rptr_late_bound(&self, id: u32) -> Ty<'tcx> {
-        let r = self.re_late_bound_with_debruijn(id, D1);
+        let r = self.re_late_bound_with_debruijn(id, d1());
         self.infcx.tcx.mk_imm_ref(r, self.tcx().types.isize)
     }
 
@@ -494,7 +499,7 @@ fn subst_ty_renumber_bound() {
 
         // t_expected = fn(&'a isize)
         let t_expected = {
-            let t_ptr_bound2 = env.t_rptr_late_bound_with_debruijn(1, D2);
+            let t_ptr_bound2 = env.t_rptr_late_bound_with_debruijn(1, d2());
             env.t_fn(&[t_ptr_bound2], env.t_nil())
         };
 
@@ -531,7 +536,7 @@ fn subst_ty_renumber_some_bounds() {
         //
         // but not that the Debruijn index is different in the different cases.
         let t_expected = {
-            let t_rptr_bound2 = env.t_rptr_late_bound_with_debruijn(1, D2);
+            let t_rptr_bound2 = env.t_rptr_late_bound_with_debruijn(1, d2());
             env.t_pair(t_rptr_bound1, env.t_fn(&[t_rptr_bound2], env.t_nil()))
         };
 
@@ -559,10 +564,10 @@ fn escaping() {
         let t_rptr_free1 = env.t_rptr_free(1);
         assert!(!t_rptr_free1.has_escaping_regions());
 
-        let t_rptr_bound1 = env.t_rptr_late_bound_with_debruijn(1, D1);
+        let t_rptr_bound1 = env.t_rptr_late_bound_with_debruijn(1, d1());
         assert!(t_rptr_bound1.has_escaping_regions());
 
-        let t_rptr_bound2 = env.t_rptr_late_bound_with_debruijn(1, D2);
+        let t_rptr_bound2 = env.t_rptr_late_bound_with_debruijn(1, d2());
         assert!(t_rptr_bound2.has_escaping_regions());
 
         // t_fn = fn(A)
@@ -578,7 +583,7 @@ fn escaping() {
 #[test]
 fn subst_region_renumber_region() {
     test_env(EMPTY_SOURCE_STR, errors(&[]), |env| {
-        let re_bound1 = env.re_late_bound_with_debruijn(1, D1);
+        let re_bound1 = env.re_late_bound_with_debruijn(1, d1());
 
         // type t_source<'a> = fn(&'a isize)
         let t_source = {
@@ -593,7 +598,7 @@ fn subst_region_renumber_region() {
         //
         // but not that the Debruijn index is different in the different cases.
         let t_expected = {
-            let t_rptr_bound2 = env.t_rptr_late_bound_with_debruijn(1, D2);
+            let t_rptr_bound2 = env.t_rptr_late_bound_with_debruijn(1, d2());
             env.t_fn(&[t_rptr_bound2], env.t_nil())
         };
 

--- a/src/librustc_mir/borrow_check/error_reporting.rs
+++ b/src/librustc_mir/borrow_check/error_reporting.rs
@@ -16,7 +16,6 @@ use rustc::mir::{LocalDecl, LocalKind, Location, Operand, Place};
 use rustc::mir::{ProjectionElem, Rvalue, Statement, StatementKind};
 use rustc::ty;
 use rustc_data_structures::fx::FxHashSet;
-use rustc_data_structures::indexed_vec::Idx;
 use rustc_data_structures::sync::Lrc;
 use rustc_errors::DiagnosticBuilder;
 use syntax_pos::Span;

--- a/src/librustc_mir/borrow_check/location.rs
+++ b/src/librustc_mir/borrow_check/location.rs
@@ -27,7 +27,11 @@ crate struct LocationTable {
     statements_before_block: IndexVec<BasicBlock, usize>,
 }
 
-newtype_index!(LocationIndex { DEBUG_FORMAT = "LocationIndex({})" });
+newtype_index! {
+    pub struct LocationIndex {
+        DEBUG_FORMAT = "LocationIndex({})"
+    }
+}
 
 #[derive(Copy, Clone, Debug)]
 crate enum RichLocation {

--- a/src/librustc_mir/borrow_check/move_errors.rs
+++ b/src/librustc_mir/borrow_check/move_errors.rs
@@ -12,7 +12,6 @@ use core::unicode::property::Pattern_White_Space;
 use rustc::mir::*;
 use rustc::ty;
 use rustc_errors::DiagnosticBuilder;
-use rustc_data_structures::indexed_vec::Idx;
 use syntax_pos::Span;
 
 use borrow_check::MirBorrowckCtxt;

--- a/src/librustc_mir/borrow_check/nll/constraints/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/constraints/mod.rs
@@ -98,6 +98,14 @@ impl fmt::Debug for OutlivesConstraint {
     }
 }
 
-newtype_index!(ConstraintIndex { DEBUG_FORMAT = "ConstraintIndex({})" });
+newtype_index! {
+    pub struct ConstraintIndex {
+        DEBUG_FORMAT = "ConstraintIndex({})"
+    }
+}
 
-newtype_index!(ConstraintSccIndex { DEBUG_FORMAT = "ConstraintSccIndex({})" });
+newtype_index! {
+    pub struct ConstraintSccIndex {
+        DEBUG_FORMAT = "ConstraintSccIndex({})"
+    }
+}

--- a/src/librustc_mir/borrow_check/nll/facts.rs
+++ b/src/librustc_mir/borrow_check/nll/facts.rs
@@ -100,18 +100,6 @@ impl Atom for LocationIndex {
     }
 }
 
-impl From<usize> for LocationIndex {
-    fn from(i: usize) -> LocationIndex {
-        LocationIndex::new(i)
-    }
-}
-
-impl From<LocationIndex> for usize {
-    fn from(vid: LocationIndex) -> usize {
-        Idx::index(vid)
-    }
-}
-
 struct FactWriter<'w> {
     location_table: &'w LocationTable,
     dir: &'w Path,

--- a/src/librustc_mir/borrow_check/nll/region_infer/graphviz.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/graphviz.rs
@@ -15,7 +15,6 @@
 use super::*;
 use borrow_check::nll::constraints::OutlivesConstraint;
 use dot::{self, IntoCow};
-use rustc_data_structures::indexed_vec::Idx;
 use std::borrow::Cow;
 use std::io::{self, Write};
 

--- a/src/librustc_mir/borrow_check/nll/region_infer/values.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/values.rs
@@ -123,13 +123,17 @@ impl RegionValueElements {
 
 /// A single integer representing a `Location` in the MIR control-flow
 /// graph. Constructed efficiently from `RegionValueElements`.
-newtype_index!(PointIndex { DEBUG_FORMAT = "PointIndex({})" });
+newtype_index! {
+    pub struct PointIndex { DEBUG_FORMAT = "PointIndex({})" }
+}
 
 /// A single integer representing a (non-zero) `UniverseIndex`.
 /// Computed just by subtracting one from `UniverseIndex`; this is
 /// because the `0` value for `UniverseIndex` represents the root
 /// universe, and we don't need/want a bit for that one.
-newtype_index!(PlaceholderIndex { DEBUG_FORMAT = "PlaceholderIndex({})" });
+newtype_index! {
+    pub struct PlaceholderIndex { DEBUG_FORMAT = "PlaceholderIndex({})" }
+}
 
 /// An individual element in a region value -- the value of a
 /// particular region variable consists of a set of these elements.

--- a/src/librustc_mir/borrow_check/nll/type_check/liveness/liveness_map.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/liveness/liveness_map.rs
@@ -97,6 +97,6 @@ impl NllLivenessMap {
 /// compute liveness information. For many locals, we are able to
 /// skip liveness information: for example, those variables whose
 /// types contain no regions.
-newtype_index!(
-    LiveVar
-);
+newtype_index! {
+    pub struct LiveVar { .. }
+}

--- a/src/librustc_mir/borrow_check/nll/type_check/liveness/local_use_map.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/liveness/local_use_map.rs
@@ -48,7 +48,9 @@ struct Appearance {
     next: Option<AppearanceIndex>,
 }
 
-newtype_index!(AppearanceIndex);
+newtype_index! {
+    pub struct AppearanceIndex { .. }
+}
 
 impl vll::LinkElem for Appearance {
     type LinkIndex = AppearanceIndex;

--- a/src/librustc_mir/borrow_check/nll/type_check/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/mod.rs
@@ -42,7 +42,6 @@ use syntax_pos::{Span, DUMMY_SP};
 use transform::{MirPass, MirSource};
 
 use rustc_data_structures::fx::FxHashSet;
-use rustc_data_structures::indexed_vec::Idx;
 
 macro_rules! span_mirbug {
     ($context:expr, $elem:expr, $($message:tt)*) => ({

--- a/src/librustc_mir/borrow_check/nll/type_check/relate_tys.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/relate_tys.rs
@@ -20,7 +20,7 @@ use rustc::ty::relate::{self, Relate, RelateResult, TypeRelation};
 use rustc::ty::subst::Kind;
 use rustc::ty::{self, CanonicalTy, CanonicalVar, RegionVid, Ty, TyCtxt};
 use rustc_data_structures::fx::FxHashMap;
-use rustc_data_structures::indexed_vec::{Idx, IndexVec};
+use rustc_data_structures::indexed_vec::IndexVec;
 use std::mem;
 
 pub(super) fn sub_types<'tcx>(

--- a/src/librustc_mir/build/mod.rs
+++ b/src/librustc_mir/build/mod.rs
@@ -402,7 +402,9 @@ struct CFG<'tcx> {
     basic_blocks: IndexVec<BasicBlock, BasicBlockData<'tcx>>,
 }
 
-newtype_index!(ScopeId);
+newtype_index! {
+    pub struct ScopeId { .. }
+}
 
 ///////////////////////////////////////////////////////////////////////////
 /// The `BlockAnd` "monad" packages up the new basic block along with a

--- a/src/librustc_mir/build/scope.rs
+++ b/src/librustc_mir/build/scope.rs
@@ -95,7 +95,6 @@ use rustc::hir;
 use rustc::hir::def_id::LOCAL_CRATE;
 use rustc::mir::*;
 use syntax_pos::{Span};
-use rustc_data_structures::indexed_vec::Idx;
 use rustc_data_structures::fx::FxHashMap;
 
 #[derive(Debug)]

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -19,7 +19,7 @@ use rustc::mir;
 use rustc::ty::{self, TyCtxt, Instance, query::TyCtxtAt};
 use rustc::ty::layout::{LayoutOf, TyLayout};
 use rustc::ty::subst::Subst;
-use rustc_data_structures::indexed_vec::{IndexVec, Idx};
+use rustc_data_structures::indexed_vec::IndexVec;
 
 use syntax::ast::Mutability;
 use syntax::source_map::Span;

--- a/src/librustc_mir/dataflow/at_location.rs
+++ b/src/librustc_mir/dataflow/at_location.rs
@@ -13,7 +13,6 @@
 
 use rustc::mir::{BasicBlock, Location};
 use rustc_data_structures::indexed_set::{HybridIdxSet, IdxSet, Iter};
-use rustc_data_structures::indexed_vec::Idx;
 
 use dataflow::{BitDenotation, BlockSets, DataflowResults};
 use dataflow::move_paths::{HasMoveData, MovePathIndex};

--- a/src/librustc_mir/dataflow/graphviz.rs
+++ b/src/librustc_mir/dataflow/graphviz.rs
@@ -13,7 +13,6 @@
 use syntax::ast::NodeId;
 use rustc::mir::{BasicBlock, Mir};
 use rustc_data_structures::bitslice::bits_to_string;
-use rustc_data_structures::indexed_vec::Idx;
 
 use dot;
 use dot::IntoCow;

--- a/src/librustc_mir/interpret/operand.rs
+++ b/src/librustc_mir/interpret/operand.rs
@@ -16,7 +16,7 @@ use std::convert::TryInto;
 
 use rustc::{mir, ty};
 use rustc::ty::layout::{self, Size, LayoutOf, TyLayout, HasDataLayout, IntegerExt};
-use rustc_data_structures::indexed_vec::Idx;
+
 use rustc::mir::interpret::{
     GlobalId, AllocId,
     ConstValue, Pointer, Scalar, ScalarMaybeUndef,

--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -18,7 +18,6 @@ use rustc::ich::StableHashingContext;
 use rustc::mir;
 use rustc::ty::{self, Ty};
 use rustc::ty::layout::{self, Size, Align, LayoutOf, TyLayout, HasDataLayout};
-use rustc_data_structures::indexed_vec::Idx;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher, StableHasherResult};
 
 use rustc::mir::interpret::{

--- a/src/librustc_mir/lib.rs
+++ b/src/librustc_mir/lib.rs
@@ -24,6 +24,7 @@ Rust MIR: a lowered representation of Rust. Also: an experiment!
 #![feature(box_syntax)]
 #![feature(crate_visibility_modifier)]
 #![feature(core_intrinsics)]
+#![feature(const_fn)]
 #![feature(decl_macro)]
 #![cfg_attr(stage0, feature(macro_vis_matcher))]
 #![feature(exhaustive_patterns)]

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -26,7 +26,7 @@ use interpret::{self, Value, OpTy, MemoryKind};
 use transform::{MirPass, MirSource};
 use syntax::source_map::{Span, DUMMY_SP};
 use rustc::ty::subst::Substs;
-use rustc_data_structures::indexed_vec::{IndexVec, Idx};
+use rustc_data_structures::indexed_vec::IndexVec;
 use rustc::ty::ParamEnv;
 use rustc::ty::layout::{
     LayoutOf, TyLayout, LayoutError,
@@ -133,7 +133,6 @@ impl<'b, 'a, 'tcx:'b> ConstPropagator<'b, 'a, 'tcx> {
         self.ecx.tcx.span = source_info.span;
         let lint_root = match self.mir.source_scope_local_data {
             ClearCrossCrate::Set(ref ivs) => {
-                use rustc_data_structures::indexed_vec::Idx;
                 //FIXME(#51314): remove this check
                 if source_info.scope.index() >= ivs.len() {
                     return None;

--- a/src/librustc_mir/transform/elaborate_drops.rs
+++ b/src/librustc_mir/transform/elaborate_drops.rs
@@ -19,7 +19,6 @@ use rustc::ty::{self, TyCtxt};
 use rustc::mir::*;
 use rustc::util::nodemap::FxHashMap;
 use rustc_data_structures::indexed_set::IdxSet;
-use rustc_data_structures::indexed_vec::Idx;
 use transform::{MirPass, MirSource};
 use util::patch::MirPatch;
 use util::elaborate_drops::{DropFlagState, Unwind, elaborate_drop};

--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -16,7 +16,7 @@
 
 use rustc_data_structures::bitvec::BitArray;
 use rustc_data_structures::indexed_set::IdxSet;
-use rustc_data_structures::indexed_vec::{IndexVec, Idx};
+use rustc_data_structures::indexed_vec::IndexVec;
 use rustc_data_structures::fx::FxHashSet;
 use rustc::hir;
 use rustc::hir::def_id::DefId;

--- a/src/librustc_mir/transform/rustc_peek.rs
+++ b/src/librustc_mir/transform/rustc_peek.rs
@@ -15,7 +15,6 @@ use syntax_pos::Span;
 use rustc::ty::{self, TyCtxt};
 use rustc::mir::{self, Mir, Location};
 use rustc_data_structures::indexed_set::IdxSet;
-use rustc_data_structures::indexed_vec::Idx;
 use transform::{MirPass, MirSource};
 
 use dataflow::{do_dataflow, DebugFormatted};

--- a/src/librustc_mir/util/graphviz.rs
+++ b/src/librustc_mir/util/graphviz.rs
@@ -15,8 +15,6 @@ use rustc::ty::TyCtxt;
 use std::fmt::Debug;
 use std::io::{self, Write};
 
-use rustc_data_structures::indexed_vec::Idx;
-
 use super::pretty::dump_mir_def_ids;
 
 /// Write a graphviz DOT graph of a list of MIRs.

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -25,10 +25,11 @@ use rustc::ty::{self, Ty, TyCtxt, ToPredicate, TypeFoldable};
 use rustc::ty::{GenericParamDef, GenericParamDefKind};
 use rustc::ty::wf::object_region_bounds;
 use rustc_target::spec::abi;
+use std::collections::BTreeSet;
 use std::slice;
 use require_c_abi_if_variadic;
 use util::common::ErrorReported;
-use util::nodemap::{FxHashSet, FxHashMap};
+use util::nodemap::FxHashMap;
 use errors::{FatalError, DiagnosticId};
 use lint;
 
@@ -996,7 +997,9 @@ impl<'o, 'gcx: 'tcx, 'tcx> dyn AstConv<'gcx, 'tcx>+'o {
             return tcx.types.err;
         }
 
-        let mut associated_types = FxHashSet::default();
+        // use a btreeset to keep output in a more consistent order
+        let mut associated_types = BTreeSet::default();
+
         for tr in traits::supertraits(tcx, principal) {
             associated_types.extend(tcx.associated_items(tr.def_id())
                 .filter(|item| item.kind == ty::AssociatedKind::Type)

--- a/src/libserialize/serialize.rs
+++ b/src/libserialize/serialize.rs
@@ -361,6 +361,18 @@ impl Decodable for u32 {
     }
 }
 
+impl Encodable for ::std::num::NonZeroU32 {
+    fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
+        s.emit_u32(self.get())
+    }
+}
+
+impl Decodable for ::std::num::NonZeroU32 {
+    fn decode<D: Decoder>(d: &mut D) -> Result<Self, D::Error> {
+        d.read_u32().map(|d| ::std::num::NonZeroU32::new(d).unwrap())
+    }
+}
+
 impl Encodable for u64 {
     fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
         s.emit_u64(*self)
@@ -895,3 +907,4 @@ impl<T: UseSpecializedDecodable> Decodable for T {
 impl<'a, T: ?Sized + Encodable> UseSpecializedEncodable for &'a T {}
 impl<T: ?Sized + Encodable> UseSpecializedEncodable for Box<T> {}
 impl<T: Decodable> UseSpecializedDecodable for Box<T> {}
+


### PR DESCRIPTION
Various improvements to the `newtype_index!` macro:

- Use `NonZeroU32` so that `Option<T>` is cheap
- More ergonomic helper method, no need to import `Idx` trait all the time
- Improve syntax to use `struct` keyword so that ripgrep works to find type def'n

Fixes https://github.com/rust-lang/rust/issues/50337

I'm curious to see if this passes tests =)

r? @oli-obk (picked because of reviewer suggestions...)