### PR TITLE
Fix usage of `wasm_target_feature`

### DIFF
--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1925,6 +1925,7 @@ fn from_target_feature(
                 Some("mmx_target_feature") => rust_features.mmx_target_feature,
                 Some("sse4a_target_feature") => rust_features.sse4a_target_feature,
                 Some("tbm_target_feature") => rust_features.tbm_target_feature,
+                Some("wasm_target_feature") => rust_features.wasm_target_feature,
                 Some(name) => bug!("unknown target feature gate {}", name),
                 None => true,
             };


### PR DESCRIPTION
Currently usage results in:

```
error: internal compiler error: librustc_typeck/collect.rs:1928: unknown target feature gate wasm_target_feature

thread 'main' panicked at 'Box<Any>', librustc_errors/lib.rs:579:9
note: Run with `RUST_BACKTRACE=1` for a backtrace.
error: aborting due to previous error


note: the compiler unexpectedly panicked. this is a bug.

note: we would appreciate a bug report: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md#bug-reports

note: rustc 1.30.0-nightly (d5a448b3f 2018-08-13) running on x86_64-unknown-linux-gnu

note: compiler flags: -C debuginfo=2 -C linker=/tmp/lld-shim -C incremental --crate-type lib

note: some of the compiler flags provided by cargo are hidden

error: Could not compile `coresimd`.

To learn more, run the command again with --verbose.
```

and hopefully this should fix the ICE!