### PR TITLE
[nll] add regression test for issue #27868

### DIFF
--- a/src/test/ui/nll/issue-27868.rs
+++ b/src/test/ui/nll/issue-27868.rs
@@ -1,0 +1,40 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Regression test for issue #27868
+
+#![feature(nll)]
+
+use std::ops::AddAssign;
+
+struct MyVec<T>(Vec<T>);
+
+impl <T> Drop for MyVec<T> {
+    fn drop(&mut self) {
+        println!("Being dropped.");
+    }
+}
+
+impl<T> AddAssign<T> for MyVec<T> {
+    fn add_assign(&mut self, _elem: T) {
+        println!("In add_assign.");
+    }
+}
+
+fn main() {
+    let mut vec = MyVec(vec![0]);
+    let mut vecvec = vec![vec];
+
+    vecvec[0] += {
+        vecvec = vec![];
+        //~^ ERROR cannot assign to `vecvec` because it is borrowed [E0506]
+        0
+    };
+}

--- a/src/test/ui/nll/issue-27868.stderr
+++ b/src/test/ui/nll/issue-27868.stderr
@@ -1,0 +1,18 @@
+error[E0506]: cannot assign to `vecvec` because it is borrowed
+  --> $DIR/issue-27868.rs:36:9
+   |
+LL |       vecvec[0] += {
+   |       ------
+   |       |
+   |  _____borrow of `vecvec` occurs here
+   | |
+LL | |         vecvec = vec![];
+   | |         ^^^^^^ assignment to borrowed `vecvec` occurs here
+LL | |         //~^ ERROR cannot assign to `vecvec` because it is borrowed [E0506]
+LL | |         0
+LL | |     };
+   | |_____- borrow later used here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0506`.


### PR DESCRIPTION
Adds a test for #27868 ``Inconsistent evaluation order for assignment operations``

apart of #47366 ``tracking issue for bugs fixed by the MIR borrow checker or NLL``

r? @nikomatsakis
