### PR TITLE
rustc_resolve: crates only exist in the type namespace.

### DIFF
--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -194,13 +194,14 @@ impl<'a, 'crateloader> Resolver<'a, 'crateloader> {
                     }
 
                     // Fall back to resolving to an external crate.
-                    if !self.extern_prelude.contains(&ident.name) {
+                    if !(ns == TypeNS && self.extern_prelude.contains(&ident.name)) {
                         // ... unless the crate name is not in the `extern_prelude`.
                         return binding;
                     }
                 }
 
                 let crate_root = if
+                    ns == TypeNS &&
                     root != keywords::Extern.name() &&
                     (
                         ident.name == keywords::Crate.name() ||
@@ -208,7 +209,7 @@ impl<'a, 'crateloader> Resolver<'a, 'crateloader> {
                     )
                 {
                     self.resolve_crate_root(ident)
-                } else if !ident.is_path_segment_keyword() {
+                } else if ns == TypeNS && !ident.is_path_segment_keyword() {
                     let crate_id =
                         self.crate_loader.process_path_extern(ident.name, ident.span);
                     self.get_module(DefId { krate: crate_id, index: CRATE_DEF_INDEX })

--- a/src/test/run-pass/issue-53333.rs
+++ b/src/test/run-pass/issue-53333.rs
@@ -1,0 +1,17 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// edition:2018
+
+fn main() {
+    use std;
+    let std = "std";
+    println!("{}", std);
+}


### PR DESCRIPTION
Fixes #53333 by resolving `::crate_name` in `TypeNS` alone, which was overlooked in #52923 and didn't break tests, since having `use crate_name;` and a `crate_name` value in the same scope is rare.