### PR TITLE
Addressed #51602

### DIFF
--- a/src/test/ui/issue-51602.rs
+++ b/src/test/ui/issue-51602.rs
@@ -1,0 +1,15 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main(){
+    if i in 1..10 {
+        break;
+    }
+}

--- a/src/test/ui/issue-51602.stderr
+++ b/src/test/ui/issue-51602.stderr
@@ -1,0 +1,10 @@
+error: expected `{`, found `in`
+  --> $DIR/issue-51602.rs:12:10
+   |
+LL |     if i in 1..10 {
+   |     --   ^^ expected `{`
+   |     |
+   |     this `if` statement has a condition, but no block
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fixed #51602 
r? @estebank 

here I have addressed the case where `in` was not expected right after `if` block. Speaking of `type ascription` I am not sure if this the best approach which I have implemented. Plus I think one more test case can be added to test `type-ascription` case, though I don't have any at this point of time. I will ping you again if all existing testcases pass.