### PR TITLE
Warn if the user tries to use GATs

### DIFF
--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -1920,6 +1920,11 @@ pub fn get_features(span_handler: &Handler, krate_attrs: &[ast::Attribute],
         err.emit();
     }
 
+    // Some features are known to be incomplete and using them is likely to have
+    // unanticipated results, such as compiler crashes. We warn the user about these
+    // to alert them.
+    let incomplete_features = ["generic_associated_types"];
+
     let mut features = Features::new();
     let mut edition_enabled_features = FxHashMap();
 
@@ -1954,6 +1959,16 @@ pub fn get_features(span_handler: &Handler, krate_attrs: &[ast::Attribute],
                           "malformed feature, expected just one word");
                 continue
             };
+
+            if incomplete_features.iter().any(|f| *f == name.as_str()) {
+                span_handler.struct_span_warn(
+                    mi.span,
+                    &format!(
+                        "the feature `{}` is incomplete and may cause the compiler to crash",
+                        name
+                    )
+                ).emit();
+            }
 
             if let Some(edition) = ALL_EDITIONS.iter().find(|e| name == e.feature_name()) {
                 if *edition <= crate_edition {

--- a/src/test/ui/rfc1598-generic-associated-types/collections.rs
+++ b/src/test/ui/rfc1598-generic-associated-types/collections.rs
@@ -9,10 +9,11 @@
 // except according to those terms.
 
 #![feature(generic_associated_types)]
+//~^ WARNING the feature `generic_associated_types` is incomplete
 #![feature(associated_type_defaults)]
 
-//FIXME(#44265): "lifetime parameters are not allowed on this type" errors will be addressed in a
-//follow-up PR
+// FIXME(#44265): "lifetime parameters are not allowed on this type" errors will be addressed in a
+// follow-up PR.
 
 // A Collection trait and collection families. Based on
 // http://smallcultfollowing.com/babysteps/blog/2016/11/03/

--- a/src/test/ui/rfc1598-generic-associated-types/collections.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/collections.stderr
@@ -1,29 +1,35 @@
+warning: the feature `generic_associated_types` is incomplete and may cause the compiler to crash
+  --> $DIR/collections.rs:11:12
+   |
+LL | #![feature(generic_associated_types)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^
+
 error[E0109]: type parameters are not allowed on this type
-  --> $DIR/collections.rs:65:90
+  --> $DIR/collections.rs:66:90
    |
 LL | fn floatify<C>(ints: &C) -> <<C as Collection<i32>>::Family as CollectionFamily>::Member<f32>
    |                                                                                          ^^^ type parameter not allowed
 
 error[E0109]: type parameters are not allowed on this type
-  --> $DIR/collections.rs:77:69
+  --> $DIR/collections.rs:78:69
    |
 LL | fn floatify_sibling<C>(ints: &C) -> <C as Collection<i32>>::Sibling<f32>
    |                                                                     ^^^ type parameter not allowed
 
 error[E0109]: type parameters are not allowed on this type
-  --> $DIR/collections.rs:26:71
+  --> $DIR/collections.rs:27:71
    |
 LL |         <<Self as Collection<T>>::Family as CollectionFamily>::Member<U>;
    |                                                                       ^ type parameter not allowed
 
 error[E0110]: lifetime parameters are not allowed on this type
-  --> $DIR/collections.rs:33:50
+  --> $DIR/collections.rs:34:50
    |
 LL |     fn iterate<'iter>(&'iter self) -> Self::Iter<'iter>;
    |                                                  ^^^^^ lifetime parameter not allowed
 
 error[E0110]: lifetime parameters are not allowed on this type
-  --> $DIR/collections.rs:59:50
+  --> $DIR/collections.rs:60:50
    |
 LL |     fn iterate<'iter>(&'iter self) -> Self::Iter<'iter> {
    |                                                  ^^^^^ lifetime parameter not allowed

--- a/src/test/ui/rfc1598-generic-associated-types/construct_with_other_type.rs
+++ b/src/test/ui/rfc1598-generic-associated-types/construct_with_other_type.rs
@@ -9,11 +9,12 @@
 // except according to those terms.
 
 #![feature(generic_associated_types)]
+//~^ WARNING the feature `generic_associated_types` is incomplete
 
 use std::ops::Deref;
 
-//FIXME(#44265): "lifetime parameters are not allowed on this type" errors will be addressed in a
-//follow-up PR
+// FIXME(#44265): "lifetime parameters are not allowed on this type" errors will be addressed in a
+// follow-up PR.
 
 trait Foo {
     type Bar<'a, 'b>;

--- a/src/test/ui/rfc1598-generic-associated-types/construct_with_other_type.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/construct_with_other_type.stderr
@@ -1,17 +1,23 @@
+warning: the feature `generic_associated_types` is incomplete and may cause the compiler to crash
+  --> $DIR/construct_with_other_type.rs:11:12
+   |
+LL | #![feature(generic_associated_types)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^
+
 error[E0110]: lifetime parameters are not allowed on this type
-  --> $DIR/construct_with_other_type.rs:26:46
+  --> $DIR/construct_with_other_type.rs:27:46
    |
 LL |     type Baa<'a>: Deref<Target = <Self::Quux<'a> as Foo>::Bar<'a, 'static>>;
    |                                              ^^ lifetime parameter not allowed
 
 error[E0110]: lifetime parameters are not allowed on this type
-  --> $DIR/construct_with_other_type.rs:26:63
+  --> $DIR/construct_with_other_type.rs:27:63
    |
 LL |     type Baa<'a>: Deref<Target = <Self::Quux<'a> as Foo>::Bar<'a, 'static>>;
    |                                                               ^^ lifetime parameter not allowed
 
 error[E0110]: lifetime parameters are not allowed on this type
-  --> $DIR/construct_with_other_type.rs:34:40
+  --> $DIR/construct_with_other_type.rs:35:40
    |
 LL |     type Baa<'a> = &'a <T as Foo>::Bar<'a, 'static>;
    |                                        ^^ lifetime parameter not allowed

--- a/src/test/ui/rfc1598-generic-associated-types/empty_generics.rs
+++ b/src/test/ui/rfc1598-generic-associated-types/empty_generics.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![feature(generic_associated_types)]
+//~^ WARNING the feature `generic_associated_types` is incomplete
 
 trait Foo {
     type Bar<,>;

--- a/src/test/ui/rfc1598-generic-associated-types/empty_generics.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/empty_generics.stderr
@@ -1,8 +1,14 @@
 error: expected one of `>`, identifier, or lifetime, found `,`
-  --> $DIR/empty_generics.rs:14:14
+  --> $DIR/empty_generics.rs:15:14
    |
 LL |     type Bar<,>;
    |              ^ expected one of `>`, identifier, or lifetime here
+
+warning: the feature `generic_associated_types` is incomplete and may cause the compiler to crash
+  --> $DIR/empty_generics.rs:11:12
+   |
+LL | #![feature(generic_associated_types)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/rfc1598-generic-associated-types/gat-incomplete-warning.rs
+++ b/src/test/ui/rfc1598-generic-associated-types/gat-incomplete-warning.rs
@@ -1,0 +1,16 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// run-pass
+
+#![feature(generic_associated_types)]
+//~^ WARNING the feature `generic_associated_types` is incomplete
+
+fn main() {}

--- a/src/test/ui/rfc1598-generic-associated-types/gat-incomplete-warning.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/gat-incomplete-warning.stderr
@@ -1,0 +1,6 @@
+warning: the feature `generic_associated_types` is incomplete and may cause the compiler to crash
+  --> $DIR/gat-incomplete-warning.rs:13:12
+   |
+LL | #![feature(generic_associated_types)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^
+

--- a/src/test/ui/rfc1598-generic-associated-types/generic-associated-types-where.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/generic-associated-types-where.stderr
@@ -1,0 +1,6 @@
+warning: the feature `generic_associated_types` is incomplete and may cause the compiler to crash
+  --> $DIR/generic-associated-types-where.rs:11:12
+   |
+LL | #![feature(generic_associated_types)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^
+

--- a/src/test/ui/rfc1598-generic-associated-types/generic_associated_type_undeclared_lifetimes.rs
+++ b/src/test/ui/rfc1598-generic-associated-types/generic_associated_type_undeclared_lifetimes.rs
@@ -9,11 +9,12 @@
 // except according to those terms.
 
 #![feature(generic_associated_types)]
+//~^ WARNING the feature `generic_associated_types` is incomplete
 
 use std::ops::Deref;
 
-//FIXME(#44265): "lifetime parameters are not allowed on this type" errors will be addressed in a
-//follow-up PR
+// FIXME(#44265): "lifetime parameters are not allowed on this type" errors will be addressed in a
+// follow-up PR.
 
 trait Iterable {
     type Item<'a>;

--- a/src/test/ui/rfc1598-generic-associated-types/generic_associated_type_undeclared_lifetimes.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/generic_associated_type_undeclared_lifetimes.stderr
@@ -1,29 +1,35 @@
+warning: the feature `generic_associated_types` is incomplete and may cause the compiler to crash
+  --> $DIR/generic_associated_type_undeclared_lifetimes.rs:11:12
+   |
+LL | #![feature(generic_associated_types)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^
+
 error[E0261]: use of undeclared lifetime name `'b`
-  --> $DIR/generic_associated_type_undeclared_lifetimes.rs:22:37
+  --> $DIR/generic_associated_type_undeclared_lifetimes.rs:23:37
    |
 LL |         + Deref<Target = Self::Item<'b>>;
    |                                     ^^ undeclared lifetime
 
 error[E0261]: use of undeclared lifetime name `'undeclared`
-  --> $DIR/generic_associated_type_undeclared_lifetimes.rs:26:41
+  --> $DIR/generic_associated_type_undeclared_lifetimes.rs:27:41
    |
 LL |     fn iter<'a>(&'a self) -> Self::Iter<'undeclared>;
    |                                         ^^^^^^^^^^^ undeclared lifetime
 
 error[E0110]: lifetime parameters are not allowed on this type
-  --> $DIR/generic_associated_type_undeclared_lifetimes.rs:20:47
+  --> $DIR/generic_associated_type_undeclared_lifetimes.rs:21:47
    |
 LL |     type Iter<'a>: Iterator<Item = Self::Item<'a>>
    |                                               ^^ lifetime parameter not allowed
 
 error[E0110]: lifetime parameters are not allowed on this type
-  --> $DIR/generic_associated_type_undeclared_lifetimes.rs:22:37
+  --> $DIR/generic_associated_type_undeclared_lifetimes.rs:23:37
    |
 LL |         + Deref<Target = Self::Item<'b>>;
    |                                     ^^ lifetime parameter not allowed
 
 error[E0110]: lifetime parameters are not allowed on this type
-  --> $DIR/generic_associated_type_undeclared_lifetimes.rs:26:41
+  --> $DIR/generic_associated_type_undeclared_lifetimes.rs:27:41
    |
 LL |     fn iter<'a>(&'a self) -> Self::Iter<'undeclared>;
    |                                         ^^^^^^^^^^^ lifetime parameter not allowed

--- a/src/test/ui/rfc1598-generic-associated-types/iterable.rs
+++ b/src/test/ui/rfc1598-generic-associated-types/iterable.rs
@@ -9,11 +9,12 @@
 // except according to those terms.
 
 #![feature(generic_associated_types)]
+//~^ WARNING the feature `generic_associated_types` is incomplete
 
 use std::ops::Deref;
 
-//FIXME(#44265): "lifetime parameters are not allowed on this type" errors will be addressed in a
-//follow-up PR
+// FIXME(#44265): "lifetime parameters are not allowed on this type" errors will be addressed in a
+// follow-up PR.
 
 trait Iterable {
     type Item<'a>;

--- a/src/test/ui/rfc1598-generic-associated-types/iterable.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/iterable.stderr
@@ -1,35 +1,41 @@
+warning: the feature `generic_associated_types` is incomplete and may cause the compiler to crash
+  --> $DIR/iterable.rs:11:12
+   |
+LL | #![feature(generic_associated_types)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^
+
 error[E0110]: lifetime parameters are not allowed on this type
-  --> $DIR/iterable.rs:20:47
+  --> $DIR/iterable.rs:21:47
    |
 LL |     type Iter<'a>: Iterator<Item = Self::Item<'a>>;
    |                                               ^^ lifetime parameter not allowed
 
 error[E0110]: lifetime parameters are not allowed on this type
-  --> $DIR/iterable.rs:49:53
+  --> $DIR/iterable.rs:50:53
    |
 LL | fn make_iter<'a, I: Iterable>(it: &'a I) -> I::Iter<'a> {
    |                                                     ^^ lifetime parameter not allowed
 
 error[E0110]: lifetime parameters are not allowed on this type
-  --> $DIR/iterable.rs:54:60
+  --> $DIR/iterable.rs:55:60
    |
 LL | fn get_first<'a, I: Iterable>(it: &'a I) -> Option<I::Item<'a>> {
    |                                                            ^^ lifetime parameter not allowed
 
 error[E0110]: lifetime parameters are not allowed on this type
-  --> $DIR/iterable.rs:23:41
+  --> $DIR/iterable.rs:24:41
    |
 LL |     fn iter<'a>(&'a self) -> Self::Iter<'a>;
    |                                         ^^ lifetime parameter not allowed
 
 error[E0110]: lifetime parameters are not allowed on this type
-  --> $DIR/iterable.rs:32:41
+  --> $DIR/iterable.rs:33:41
    |
 LL |     fn iter<'a>(&'a self) -> Self::Iter<'a> {
    |                                         ^^ lifetime parameter not allowed
 
 error[E0110]: lifetime parameters are not allowed on this type
-  --> $DIR/iterable.rs:43:41
+  --> $DIR/iterable.rs:44:41
    |
 LL |     fn iter<'a>(&'a self) -> Self::Iter<'a> {
    |                                         ^^ lifetime parameter not allowed

--- a/src/test/ui/rfc1598-generic-associated-types/parameter_number_and_kind.rs
+++ b/src/test/ui/rfc1598-generic-associated-types/parameter_number_and_kind.rs
@@ -9,12 +9,13 @@
 // except according to those terms.
 
 #![feature(generic_associated_types)]
+//~^ WARNING the feature `generic_associated_types` is incomplete
 #![feature(associated_type_defaults)]
 
-//FIXME(#44265): "lifetime parameters are not allowed on this type" errors will be addressed in a
-//follow-up PR
+// FIXME(#44265): "lifetime parameters are not allowed on this type" errors will be addressed in a
+// follow-up PR.
 
-//FIXME(#44265): Update expected errors once E110 is resolved, now does not get past `trait Foo`
+// FIXME(#44265): Update expected errors once E110 is resolved, now does not get past `trait Foo`.
 
 trait Foo {
     type A<'a>;

--- a/src/test/ui/rfc1598-generic-associated-types/parameter_number_and_kind.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/parameter_number_and_kind.stderr
@@ -1,29 +1,35 @@
+warning: the feature `generic_associated_types` is incomplete and may cause the compiler to crash
+  --> $DIR/parameter_number_and_kind.rs:11:12
+   |
+LL | #![feature(generic_associated_types)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^
+
 error[E0110]: lifetime parameters are not allowed on this type
-  --> $DIR/parameter_number_and_kind.rs:26:27
+  --> $DIR/parameter_number_and_kind.rs:27:27
    |
 LL |     type FOk<T> = Self::E<'static, T>;
    |                           ^^^^^^^ lifetime parameter not allowed
 
 error[E0109]: type parameters are not allowed on this type
-  --> $DIR/parameter_number_and_kind.rs:26:36
+  --> $DIR/parameter_number_and_kind.rs:27:36
    |
 LL |     type FOk<T> = Self::E<'static, T>;
    |                                    ^ type parameter not allowed
 
 error[E0110]: lifetime parameters are not allowed on this type
-  --> $DIR/parameter_number_and_kind.rs:29:26
+  --> $DIR/parameter_number_and_kind.rs:30:26
    |
 LL |     type FErr1 = Self::E<'static, 'static>; // Error
    |                          ^^^^^^^ lifetime parameter not allowed
 
 error[E0110]: lifetime parameters are not allowed on this type
-  --> $DIR/parameter_number_and_kind.rs:31:29
+  --> $DIR/parameter_number_and_kind.rs:32:29
    |
 LL |     type FErr2<T> = Self::E<'static, T, u32>; // Error
    |                             ^^^^^^^ lifetime parameter not allowed
 
 error[E0109]: type parameters are not allowed on this type
-  --> $DIR/parameter_number_and_kind.rs:31:38
+  --> $DIR/parameter_number_and_kind.rs:32:38
    |
 LL |     type FErr2<T> = Self::E<'static, T, u32>; // Error
    |                                      ^ type parameter not allowed

--- a/src/test/ui/rfc1598-generic-associated-types/pointer_family.rs
+++ b/src/test/ui/rfc1598-generic-associated-types/pointer_family.rs
@@ -9,8 +9,9 @@
 // except according to those terms.
 
 #![feature(generic_associated_types)]
+//~^ WARNING the feature `generic_associated_types` is incomplete
 
-//FIXME(#44265): "type parameter not allowed" errors will be addressed in a follow-up PR
+// FIXME(#44265): "type parameter not allowed" errors will be addressed in a follow-up PR.
 
 use std::rc::Rc;
 use std::sync::Arc;

--- a/src/test/ui/rfc1598-generic-associated-types/pointer_family.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/pointer_family.stderr
@@ -1,23 +1,29 @@
+warning: the feature `generic_associated_types` is incomplete and may cause the compiler to crash
+  --> $DIR/pointer_family.rs:11:12
+   |
+LL | #![feature(generic_associated_types)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^
+
 error[E0109]: type parameters are not allowed on this type
-  --> $DIR/pointer_family.rs:46:21
+  --> $DIR/pointer_family.rs:47:21
    |
 LL |     bar: P::Pointer<String>,
    |                     ^^^^^^ type parameter not allowed
 
 error[E0109]: type parameters are not allowed on this type
-  --> $DIR/pointer_family.rs:21:42
+  --> $DIR/pointer_family.rs:22:42
    |
 LL |     fn new<T>(value: T) -> Self::Pointer<T>;
    |                                          ^ type parameter not allowed
 
 error[E0109]: type parameters are not allowed on this type
-  --> $DIR/pointer_family.rs:29:42
+  --> $DIR/pointer_family.rs:30:42
    |
 LL |     fn new<T>(value: T) -> Self::Pointer<T> {
    |                                          ^ type parameter not allowed
 
 error[E0109]: type parameters are not allowed on this type
-  --> $DIR/pointer_family.rs:39:42
+  --> $DIR/pointer_family.rs:40:42
    |
 LL |     fn new<T>(value: T) -> Self::Pointer<T> {
    |                                          ^ type parameter not allowed

--- a/src/test/ui/rfc1598-generic-associated-types/shadowing.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/shadowing.stderr
@@ -1,0 +1,6 @@
+warning: the feature `generic_associated_types` is incomplete and may cause the compiler to crash
+  --> $DIR/shadowing.rs:11:12
+   |
+LL | #![feature(generic_associated_types)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^
+

--- a/src/test/ui/rfc1598-generic-associated-types/streaming_iterator.rs
+++ b/src/test/ui/rfc1598-generic-associated-types/streaming_iterator.rs
@@ -9,8 +9,9 @@
 // except according to those terms.
 
 #![feature(generic_associated_types)]
+//~^ WARNING the feature `generic_associated_types` is incomplete
 
-//FIXME(#44265): "lifetime parameter not allowed on this type" errors will be addressed in a
+// FIXME(#44265): "lifetime parameter not allowed on this type" errors will be addressed in a
 // follow-up PR
 
 use std::fmt::Display;

--- a/src/test/ui/rfc1598-generic-associated-types/streaming_iterator.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/streaming_iterator.stderr
@@ -1,29 +1,35 @@
+warning: the feature `generic_associated_types` is incomplete and may cause the compiler to crash
+  --> $DIR/streaming_iterator.rs:11:12
+   |
+LL | #![feature(generic_associated_types)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^
+
 error[E0110]: lifetime parameters are not allowed on this type
-  --> $DIR/streaming_iterator.rs:27:41
+  --> $DIR/streaming_iterator.rs:28:41
    |
 LL |     bar: <T as StreamingIterator>::Item<'static>,
    |                                         ^^^^^^^ lifetime parameter not allowed
 
 error[E0110]: lifetime parameters are not allowed on this type
-  --> $DIR/streaming_iterator.rs:35:64
+  --> $DIR/streaming_iterator.rs:36:64
    |
 LL | fn foo<T>(iter: T) where T: StreamingIterator, for<'a> T::Item<'a>: Display { /* ... */ }
    |                                                                ^^ lifetime parameter not allowed
 
 error[E0110]: lifetime parameters are not allowed on this type
-  --> $DIR/streaming_iterator.rs:21:48
+  --> $DIR/streaming_iterator.rs:22:48
    |
 LL |     fn next<'a>(&'a self) -> Option<Self::Item<'a>>;
    |                                                ^^ lifetime parameter not allowed
 
 error[E0110]: lifetime parameters are not allowed on this type
-  --> $DIR/streaming_iterator.rs:47:37
+  --> $DIR/streaming_iterator.rs:48:37
    |
 LL |     type Item<'a> = (usize, I::Item<'a>);
    |                                     ^^ lifetime parameter not allowed
 
 error[E0110]: lifetime parameters are not allowed on this type
-  --> $DIR/streaming_iterator.rs:49:48
+  --> $DIR/streaming_iterator.rs:50:48
    |
 LL |     fn next<'a>(&'a self) -> Option<Self::Item<'a>> {
    |                                                ^^ lifetime parameter not allowed


### PR DESCRIPTION
GATs are currently broken, but still accessible behind a feature gate. This leads to people attempting to use them and then immediately encountering ICEs (or other broken behaviour). Here, we emit a warning if the user tries to use any feature associated with GATs, hopefully making it obvious that ICEs and the like are expected. For the meantime, this seems better than continually getting reported errors (for example: [here](https://github.com/rust-lang/rust/issues?q=is%3Aissue+gat+is%3Aclosed) and [here](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aissue+generic_associated_types+is%3Aclosed)).