### PR TITLE
Cross reference io::copy and fs::copy in docs.

### DIFF
--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -1566,6 +1566,12 @@ pub fn rename<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> io::Result<()> 
 /// On success, the total number of bytes copied is returned and it is equal to
 /// the length of the `to` file as reported by `metadata`.
 ///
+/// If you’re wanting to copy the contents of one file to another and you’re
+/// working with [`File`]s, see the [`io::copy`] function.
+///
+/// [`io::copy`]: ../io/fn.copy.html
+/// [`File`]: ./struct.File.html
+///
 /// # Platform-specific behavior
 ///
 /// This function currently corresponds to the `open` function in Unix

--- a/src/libstd/io/util.rs
+++ b/src/libstd/io/util.rs
@@ -23,6 +23,11 @@ use mem;
 /// On success, the total number of bytes that were copied from
 /// `reader` to `writer` is returned.
 ///
+/// If you’re wanting to copy the contents of one file to another and you’re
+/// working with filesystem paths, see the [`fs::copy`] function.
+///
+/// [`fs::copy`]: ../fs/fn.copy.html
+///
 /// # Errors
 ///
 /// This function will return an error immediately if any call to `read` or


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/52524.