### PR TITLE
document effect of join on memory ordering

### DIFF
--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -1308,13 +1308,17 @@ impl<T> JoinHandle<T> {
         &self.0.thread
     }
 
-    /// Waits for the associated thread to finish.
+    /// Waits for the associated thread to finish. In terms of [atomic memory orderings],
+    /// the completion of the associated thread synchronizes with this function returning.
+    /// In other words, all operations performed by that thread are ordered before all
+    /// operations that happen after `join` returns.
     ///
     /// If the child thread panics, [`Err`] is returned with the parameter given
     /// to [`panic`].
     ///
     /// [`Err`]: ../../std/result/enum.Result.html#variant.Err
     /// [`panic`]: ../../std/macro.panic.html
+    /// [atomic memory orderings]: ../../std/sync/atomic/index.html
     ///
     /// # Panics
     ///

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -1308,9 +1308,11 @@ impl<T> JoinHandle<T> {
         &self.0.thread
     }
 
-    /// Waits for the associated thread to finish. In terms of [atomic memory orderings],
-    /// the completion of the associated thread synchronizes with this function returning.
-    /// In other words, all operations performed by that thread are ordered before all
+    /// Waits for the associated thread to finish.
+    ///
+    /// In terms of [atomic memory orderings],  the completion of the associated
+    /// thread synchronizes with this function returning. In other words, all
+    /// operations performed by that thread are ordered before all
     /// operations that happen after `join` returns.
     ///
     /// If the child thread panics, [`Err`] is returned with the parameter given


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/45467