### PR TITLE
Tidy: ignore non-Markdown files when linting for the Unstable Book

### DIFF
--- a/src/tools/tidy/src/unstable_book.rs
+++ b/src/tools/tidy/src/unstable_book.rs
@@ -60,6 +60,7 @@ pub fn collect_unstable_book_section_file_names(dir: &path::Path) -> BTreeSet<St
         .map(|entry| entry.expect("could not read directory entry"))
         .filter(dir_entry_is_file)
         .map(|entry| entry.file_name().into_string().unwrap())
+        .filter(|n| n.ends_with(".md"))
         .map(|n| n.trim_right_matches(".md").to_owned())
         .collect()
 }


### PR DESCRIPTION
Previously, any file would be assumed a `.md`, which is annoying when files like `.DS_STORE` slip in and then cause tidy errors.