### PR TITLE
restore the page title after escaping out of a search

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -52,6 +52,8 @@
 
     var themesWidth = null;
 
+    var titleBeforeSearch = document.title;
+
     if (!String.prototype.startsWith) {
         String.prototype.startsWith = function(searchString, position) {
             position = position || 0;
@@ -267,6 +269,7 @@
             ev.preventDefault();
             addClass(search, "hidden");
             removeClass(document.getElementById("main"), "hidden");
+            document.title = titleBeforeSearch;
         }
         defocusSearchBar();
     }


### PR DESCRIPTION
Currently if I start a search in the docs, but then hit ESC, the "Results for..." title is still there in my browser tab. This is a simple attempt to fix that. I see that there's a separate `var previousTitle = document.title` thing happening in `startSearch()`, but as far as I can tell that's only related to the back stack? I'd also appreciate feedback on the right place to declare the `titleBeforeSearch` variable.

Testing-wise, I've confirmed by hand that the tab title restores correctly after building with `./x.py doc --stage 1 src/libstd`, but nothing more involved than that. What else should I test?