### PR TITLE
 syntax_ext: remove leftover span_err_if_not_stage0 macro.

### DIFF
--- a/src/libsyntax_ext/deriving/default.rs
+++ b/src/libsyntax_ext/deriving/default.rs
@@ -76,8 +76,8 @@ fn default_substructure(cx: &mut ExtCtxt, trait_span: Span, substr: &Substructur
             }
         }
         StaticEnum(..) => {
-            span_err_if_not_stage0!(cx, trait_span, E0665,
-                                    "`Default` cannot be derived for enums, only structs");
+            span_err!(cx, trait_span, E0665,
+                      "`Default` cannot be derived for enums, only structs");
             // let compilation continue
             cx.expr_usize(trait_span, 0)
         }

--- a/src/libsyntax_ext/deriving/mod.rs
+++ b/src/libsyntax_ext/deriving/mod.rs
@@ -19,17 +19,6 @@ use syntax::ptr::P;
 use syntax::symbol::Symbol;
 use syntax_pos::Span;
 
-macro_rules! span_err_if_not_stage0 {
-    ($cx:expr, $sp:expr, $code:ident, $text:tt) => {
-        #[cfg(not(stage0))] {
-            span_err!($cx, $sp, $code, $text)
-        }
-        #[cfg(stage0)] {
-            $cx.span_err($sp, $text)
-        }
-    }
-}
-
 macro path_local($x:ident) {
     generic::ty::Path::new_local(stringify!($x))
 }

--- a/src/test/ui/E0660.rs
+++ b/src/test/ui/E0660.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-stage1
-
 #![feature(asm)]
 
 fn main() {

--- a/src/test/ui/E0660.stderr
+++ b/src/test/ui/E0660.stderr
@@ -1,11 +1,11 @@
 error[E0660]: malformed inline assembly
-  --> $DIR/E0660.rs:17:5
+  --> $DIR/E0660.rs:15:5
    |
 LL |     asm!("nop" "nop");
    |     ^^^^^^^^^^^^^^^^^^
 
 error[E0660]: malformed inline assembly
-  --> $DIR/E0660.rs:19:5
+  --> $DIR/E0660.rs:17:5
    |
 LL |     asm!("nop" "nop" : "=r"(a));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/E0661.rs
+++ b/src/test/ui/E0661.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-stage1
-
 #![feature(asm)]
 
 fn main() {

--- a/src/test/ui/E0661.stderr
+++ b/src/test/ui/E0661.stderr
@@ -1,5 +1,5 @@
 error[E0661]: output operand constraint lacks '=' or '+'
-  --> $DIR/E0661.rs:17:18
+  --> $DIR/E0661.rs:15:18
    |
 LL |     asm!("nop" : "r"(a));
    |                  ^^^

--- a/src/test/ui/E0662.rs
+++ b/src/test/ui/E0662.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-stage1
-
 #![feature(asm)]
 
 fn main() {

--- a/src/test/ui/E0662.stderr
+++ b/src/test/ui/E0662.stderr
@@ -1,5 +1,5 @@
 error[E0662]: input operand constraint contains '='
-  --> $DIR/E0662.rs:18:12
+  --> $DIR/E0662.rs:16:12
    |
 LL |          : "=test"("a") //~ ERROR E0662
    |            ^^^^^^^

--- a/src/test/ui/E0663.rs
+++ b/src/test/ui/E0663.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-stage1
-
 #![feature(asm)]
 
 fn main() {

--- a/src/test/ui/E0663.stderr
+++ b/src/test/ui/E0663.stderr
@@ -1,5 +1,5 @@
 error[E0663]: input operand constraint contains '+'
-  --> $DIR/E0663.rs:18:12
+  --> $DIR/E0663.rs:16:12
    |
 LL |          : "+test"("a") //~ ERROR E0663
    |            ^^^^^^^

--- a/src/test/ui/E0664.rs
+++ b/src/test/ui/E0664.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-stage1
-
 #![feature(asm)]
 
 fn main() {

--- a/src/test/ui/E0664.stderr
+++ b/src/test/ui/E0664.stderr
@@ -1,5 +1,5 @@
 error[E0664]: clobber should not be surrounded by braces
-  --> $DIR/E0664.rs:19:12
+  --> $DIR/E0664.rs:17:12
    |
 LL |          : "{eax}" //~ ERROR E0664
    |            ^^^^^^^

--- a/src/test/ui/E0665.rs
+++ b/src/test/ui/E0665.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-stage1
-
 #[derive(Default)] //~ ERROR E0665
 enum Food {
     Sweet,

--- a/src/test/ui/E0665.stderr
+++ b/src/test/ui/E0665.stderr
@@ -1,5 +1,5 @@
 error[E0665]: `Default` cannot be derived for enums, only structs
-  --> $DIR/E0665.rs:13:10
+  --> $DIR/E0665.rs:11:10
    |
 LL | #[derive(Default)] //~ ERROR E0665
    |          ^^^^^^^

--- a/src/test/ui/macros/macros-nonfatal-errors.rs
+++ b/src/test/ui/macros/macros-nonfatal-errors.rs
@@ -10,7 +10,6 @@
 
 // normalize-stderr-test: "The system cannot find the file specified\." -> "No such file or directory"
 // ignore-tidy-linelength
-// ignore-stage1
 
 // test that errors in a (selection) of macros don't kill compilation
 // immediately, so that we get more errors listed at a time.

--- a/src/test/ui/macros/macros-nonfatal-errors.stderr
+++ b/src/test/ui/macros/macros-nonfatal-errors.stderr
@@ -1,47 +1,47 @@
 error[E0665]: `Default` cannot be derived for enums, only structs
-  --> $DIR/macros-nonfatal-errors.rs:21:10
+  --> $DIR/macros-nonfatal-errors.rs:20:10
    |
 LL | #[derive(Default)] //~ ERROR
    |          ^^^^^^^
 
 error: inline assembly must be a string literal
-  --> $DIR/macros-nonfatal-errors.rs:25:10
+  --> $DIR/macros-nonfatal-errors.rs:24:10
    |
 LL |     asm!(invalid); //~ ERROR
    |          ^^^^^^^
 
 error: concat_idents! requires ident args.
-  --> $DIR/macros-nonfatal-errors.rs:27:5
+  --> $DIR/macros-nonfatal-errors.rs:26:5
    |
 LL |     concat_idents!("not", "idents"); //~ ERROR
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: argument must be a string literal
-  --> $DIR/macros-nonfatal-errors.rs:29:17
+  --> $DIR/macros-nonfatal-errors.rs:28:17
    |
 LL |     option_env!(invalid); //~ ERROR
    |                 ^^^^^^^
 
 error: expected string literal
-  --> $DIR/macros-nonfatal-errors.rs:30:10
+  --> $DIR/macros-nonfatal-errors.rs:29:10
    |
 LL |     env!(invalid); //~ ERROR
    |          ^^^^^^^
 
 error: expected string literal
-  --> $DIR/macros-nonfatal-errors.rs:31:10
+  --> $DIR/macros-nonfatal-errors.rs:30:10
    |
 LL |     env!(foo, abr, baz); //~ ERROR
    |          ^^^
 
 error: environment variable `RUST_HOPEFULLY_THIS_DOESNT_EXIST` not defined
-  --> $DIR/macros-nonfatal-errors.rs:32:5
+  --> $DIR/macros-nonfatal-errors.rs:31:5
    |
 LL |     env!("RUST_HOPEFULLY_THIS_DOESNT_EXIST"); //~ ERROR
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0658]: non-ident macro paths are experimental (see issue #35896)
-  --> $DIR/macros-nonfatal-errors.rs:34:5
+  --> $DIR/macros-nonfatal-errors.rs:33:5
    |
 LL |     foo::blah!(); //~ ERROR
    |     ^^^^^^^^^
@@ -49,7 +49,7 @@ LL |     foo::blah!(); //~ ERROR
    = help: add #![feature(use_extern_macros)] to the crate attributes to enable
 
 error: format argument must be a string literal
-  --> $DIR/macros-nonfatal-errors.rs:36:13
+  --> $DIR/macros-nonfatal-errors.rs:35:13
    |
 LL |     format!(invalid); //~ ERROR
    |             ^^^^^^^
@@ -59,37 +59,37 @@ LL |     format!("{}", invalid); //~ ERROR
    |             ^^^^^
 
 error: argument must be a string literal
-  --> $DIR/macros-nonfatal-errors.rs:38:14
+  --> $DIR/macros-nonfatal-errors.rs:37:14
    |
 LL |     include!(invalid); //~ ERROR
    |              ^^^^^^^
 
 error: argument must be a string literal
-  --> $DIR/macros-nonfatal-errors.rs:40:18
+  --> $DIR/macros-nonfatal-errors.rs:39:18
    |
 LL |     include_str!(invalid); //~ ERROR
    |                  ^^^^^^^
 
 error: couldn't read $DIR/i'd be quite surprised if a file with this name existed: No such file or directory (os error 2)
-  --> $DIR/macros-nonfatal-errors.rs:41:5
+  --> $DIR/macros-nonfatal-errors.rs:40:5
    |
 LL |     include_str!("i'd be quite surprised if a file with this name existed"); //~ ERROR
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: argument must be a string literal
-  --> $DIR/macros-nonfatal-errors.rs:42:20
+  --> $DIR/macros-nonfatal-errors.rs:41:20
    |
 LL |     include_bytes!(invalid); //~ ERROR
    |                    ^^^^^^^
 
 error: couldn't read $DIR/i'd be quite surprised if a file with this name existed: No such file or directory (os error 2)
-  --> $DIR/macros-nonfatal-errors.rs:43:5
+  --> $DIR/macros-nonfatal-errors.rs:42:5
    |
 LL |     include_bytes!("i'd be quite surprised if a file with this name existed"); //~ ERROR
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: trace_macros! accepts only `true` or `false`
-  --> $DIR/macros-nonfatal-errors.rs:45:5
+  --> $DIR/macros-nonfatal-errors.rs:44:5
    |
 LL |     trace_macros!(invalid); //~ ERROR
    |     ^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
I believe this is the right fix for #53380, although I'm not sure what happened.
My guess is this copy of the macro was accidentally missed when others were removed?

cc @matthewjasper @varkor (please do not put this in a rollup, in case it fails)