### PR TITLE
Warn that `#![feature(rust_2018_preview)]` is implied when the edition is set to Rust 2018.

### DIFF
--- a/src/test/run-pass/macro-at-most-once-rep.rs
+++ b/src/test/run-pass/macro-at-most-once-rep.rs
@@ -18,7 +18,7 @@
 //
 // This test focuses on non-error cases and making sure the correct number of repetitions happen.
 
-// compile-flags: --edition=2018
+// edition:2018
 
 #![feature(macro_at_most_once_rep)]
 

--- a/src/test/rustdoc/async-fn.rs
+++ b/src/test/rustdoc/async-fn.rs
@@ -13,7 +13,7 @@
 
 // FIXME: once `--edition` is stable in rustdoc, remove that `compile-flags` directive
 
-#![feature(rust_2018_preview, async_await, futures_api)]
+#![feature(async_await, futures_api)]
 
 // @has async_fn/struct.S.html
 // @has - '//code' 'pub async fn f()'

--- a/src/test/ui-fulldeps/rust-2018/suggestions-not-always-applicable.fixed
+++ b/src/test/ui-fulldeps/rust-2018/suggestions-not-always-applicable.fixed
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // aux-build:suggestions-not-always-applicable.rs
-// compile-flags: --edition 2015
+// edition:2015
 // run-rustfix
 // rustfix-only-machine-applicable
 // compile-pass

--- a/src/test/ui-fulldeps/rust-2018/suggestions-not-always-applicable.rs
+++ b/src/test/ui-fulldeps/rust-2018/suggestions-not-always-applicable.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // aux-build:suggestions-not-always-applicable.rs
-// compile-flags: --edition 2015
+// edition:2015
 // run-rustfix
 // rustfix-only-machine-applicable
 // compile-pass

--- a/src/test/ui-fulldeps/unnecessary-extern-crate.rs
+++ b/src/test/ui-fulldeps/unnecessary-extern-crate.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: --edition 2018
+// edition:2018
 
 #![deny(unused_extern_crates)]
 #![feature(alloc, test, libc)]

--- a/src/test/ui/E0705.rs
+++ b/src/test/ui/E0705.rs
@@ -10,9 +10,9 @@
 
 // compile-pass
 
-#![feature(rust_2018_preview)]
 #![feature(raw_identifiers)]
 //~^ WARN the feature `raw_identifiers` is included in the Rust 2018 edition
+#![feature(rust_2018_preview)]
 
 fn main() {
     let foo = 0;

--- a/src/test/ui/E0705.stderr
+++ b/src/test/ui/E0705.stderr
@@ -1,5 +1,5 @@
 warning[E0705]: the feature `raw_identifiers` is included in the Rust 2018 edition
-  --> $DIR/E0705.rs:14:12
+  --> $DIR/E0705.rs:13:12
    |
 LL | #![feature(raw_identifiers)]
    |            ^^^^^^^^^^^^^^^

--- a/src/test/ui/borrowck/borrowck-feature-nll-overrides-migrate.rs
+++ b/src/test/ui/borrowck/borrowck-feature-nll-overrides-migrate.rs
@@ -20,7 +20,7 @@
 
 // revisions: zflag edition
 // [zflag]compile-flags: -Z borrowck=migrate
-// [edition]compile-flags: --edition 2018
+// [edition]edition:2018
 
 #![feature(nll)]
 

--- a/src/test/ui/borrowck/borrowck-migrate-to-nll.rs
+++ b/src/test/ui/borrowck/borrowck-migrate-to-nll.rs
@@ -23,7 +23,7 @@
 
 // revisions: zflag edition
 //[zflag]compile-flags: -Z borrowck=migrate
-//[edition]compile-flags: --edition 2018
+//[edition]edition:2018
 //[zflag] run-pass
 //[edition] run-pass
 

--- a/src/test/ui/borrowck/issue-52967-edition-2018-needs-two-phase-borrows.rs
+++ b/src/test/ui/borrowck/issue-52967-edition-2018-needs-two-phase-borrows.rs
@@ -14,7 +14,7 @@
 
 // revisions: ast zflags edition
 //[zflags]compile-flags: -Z borrowck=migrate -Z two-phase-borrows
-//[edition]compile-flags: --edition 2018
+//[edition]edition:2018
 
 // run-pass
 

--- a/src/test/ui/editions/edition-extern-crate-allowed.rs
+++ b/src/test/ui/editions/edition-extern-crate-allowed.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // aux-build:edition-extern-crate-allowed.rs
-// compile-flags: --edition 2015
+// edition:2015
 // compile-pass
 
 #![warn(rust_2018_idioms)]

--- a/src/test/ui/editions/edition-feature-redundant.rs
+++ b/src/test/ui/editions/edition-feature-redundant.rs
@@ -8,8 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// edition:2018
 // compile-pass
 
 #![feature(rust_2018_preview)]
+//~^ WARN the feature `rust_2018_preview` is included in the Rust 2018 edition
 
 fn main() {}

--- a/src/test/ui/editions/edition-feature-redundant.stderr
+++ b/src/test/ui/editions/edition-feature-redundant.stderr
@@ -1,0 +1,6 @@
+warning[E0705]: the feature `rust_2018_preview` is included in the Rust 2018 edition
+  --> $DIR/edition-feature-redundant.rs:14:12
+   |
+LL | #![feature(rust_2018_preview)]
+   |            ^^^^^^^^^^^^^^^^^
+

--- a/src/test/ui/in-band-lifetimes/elided-lifetimes.fixed
+++ b/src/test/ui/in-band-lifetimes/elided-lifetimes.fixed
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // run-rustfix
-// compile-flags: --edition 2018
+// edition:2018
 
 #![allow(unused)]
 #![deny(elided_lifetimes_in_paths)]

--- a/src/test/ui/in-band-lifetimes/elided-lifetimes.rs
+++ b/src/test/ui/in-band-lifetimes/elided-lifetimes.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // run-rustfix
-// compile-flags: --edition 2018
+// edition:2018
 
 #![allow(unused)]
 #![deny(elided_lifetimes_in_paths)]

--- a/src/test/ui/macros/macro-at-most-once-rep-2015-ques-rep-feature-flag.rs
+++ b/src/test/ui/macros/macro-at-most-once-rep-2015-ques-rep-feature-flag.rs
@@ -12,7 +12,7 @@
 // with the feature flag.
 
 // gate-test-macro_at_most_once_rep
-// compile-flags: --edition=2015
+// edition:2015
 
 #![feature(macro_at_most_once_rep)]
 

--- a/src/test/ui/macros/macro-at-most-once-rep-2015-ques-rep.rs
+++ b/src/test/ui/macros/macro-at-most-once-rep-2015-ques-rep.rs
@@ -10,7 +10,7 @@
 
 // Test behavior of `?` macro _kleene op_ under the 2015 edition. Namely, it doesn't exist.
 
-// compile-flags: --edition=2015
+// edition:2015
 
 macro_rules! bar {
     ($(a)?) => {} //~ERROR expected `*` or `+`

--- a/src/test/ui/macros/macro-at-most-once-rep-2015-ques-sep.rs
+++ b/src/test/ui/macros/macro-at-most-once-rep-2015-ques-sep.rs
@@ -11,7 +11,7 @@
 // Test behavior of `?` macro _separator_ under the 2015 edition. Namely, `?` can be used as a
 // separator, but you get a migration warning for the edition.
 
-// compile-flags: --edition=2015
+// edition:2015
 // compile-pass
 
 #![warn(rust_2018_compatibility)]

--- a/src/test/ui/macros/macro-at-most-once-rep-2018-feature-gate.rs
+++ b/src/test/ui/macros/macro-at-most-once-rep-2018-feature-gate.rs
@@ -11,7 +11,7 @@
 // Feature gate test for macro_at_most_once_rep under 2018 edition.
 
 // gate-test-macro_at_most_once_rep
-// compile-flags: --edition=2018
+// edition:2018
 
 macro_rules! foo {
     ($(a)?) => {}

--- a/src/test/ui/macros/macro-at-most-once-rep-2018.rs
+++ b/src/test/ui/macros/macro-at-most-once-rep-2018.rs
@@ -10,7 +10,7 @@
 
 // Tests that `?` is a Kleene op and not a macro separator in the 2018 edition.
 
-// compile-flags: --edition=2018
+// edition:2018
 
 #![feature(macro_at_most_once_rep)]
 

--- a/src/test/ui/removing-extern-crate.fixed
+++ b/src/test/ui/removing-extern-crate.fixed
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: --edition 2018
+// edition:2018
 // aux-build:removing-extern-crate.rs
 // run-rustfix
 // compile-pass

--- a/src/test/ui/removing-extern-crate.rs
+++ b/src/test/ui/removing-extern-crate.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: --edition 2018
+// edition:2018
 // aux-build:removing-extern-crate.rs
 // run-rustfix
 // compile-pass

--- a/src/test/ui/rust-2018/async-ident-allowed.rs
+++ b/src/test/ui/rust-2018/async-ident-allowed.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: --edition 2015
+// edition:2015
 
 #![deny(rust_2018_compatibility)]
 

--- a/src/test/ui/rust-2018/extern-crate-idiomatic-in-2018.fixed
+++ b/src/test/ui/rust-2018/extern-crate-idiomatic-in-2018.fixed
@@ -10,7 +10,7 @@
 
 // aux-build:edition-lint-paths.rs
 // run-rustfix
-// compile-flags:--edition 2018
+// edition:2018
 
 // The "normal case". Ideally we would remove the `extern crate` here,
 // but we don't.

--- a/src/test/ui/rust-2018/extern-crate-idiomatic-in-2018.fixed
+++ b/src/test/ui/rust-2018/extern-crate-idiomatic-in-2018.fixed
@@ -15,7 +15,6 @@
 // The "normal case". Ideally we would remove the `extern crate` here,
 // but we don't.
 
-#![feature(rust_2018_preview)]
 #![deny(rust_2018_idioms)]
 #![allow(dead_code)]
 

--- a/src/test/ui/rust-2018/extern-crate-idiomatic-in-2018.rs
+++ b/src/test/ui/rust-2018/extern-crate-idiomatic-in-2018.rs
@@ -10,7 +10,7 @@
 
 // aux-build:edition-lint-paths.rs
 // run-rustfix
-// compile-flags:--edition 2018
+// edition:2018
 
 // The "normal case". Ideally we would remove the `extern crate` here,
 // but we don't.

--- a/src/test/ui/rust-2018/extern-crate-idiomatic-in-2018.rs
+++ b/src/test/ui/rust-2018/extern-crate-idiomatic-in-2018.rs
@@ -15,7 +15,6 @@
 // The "normal case". Ideally we would remove the `extern crate` here,
 // but we don't.
 
-#![feature(rust_2018_preview)]
 #![deny(rust_2018_idioms)]
 #![allow(dead_code)]
 

--- a/src/test/ui/rust-2018/extern-crate-idiomatic-in-2018.stderr
+++ b/src/test/ui/rust-2018/extern-crate-idiomatic-in-2018.stderr
@@ -1,18 +1,18 @@
 error: unused extern crate
-  --> $DIR/extern-crate-idiomatic-in-2018.rs:22:1
+  --> $DIR/extern-crate-idiomatic-in-2018.rs:21:1
    |
 LL | extern crate edition_lint_paths;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove it
    |
 note: lint level defined here
-  --> $DIR/extern-crate-idiomatic-in-2018.rs:19:9
+  --> $DIR/extern-crate-idiomatic-in-2018.rs:18:9
    |
 LL | #![deny(rust_2018_idioms)]
    |         ^^^^^^^^^^^^^^^^
    = note: #[deny(unused_extern_crates)] implied by #[deny(rust_2018_idioms)]
 
 error: `extern crate` is not idiomatic in the new edition
-  --> $DIR/extern-crate-idiomatic-in-2018.rs:25:1
+  --> $DIR/extern-crate-idiomatic-in-2018.rs:24:1
    |
 LL | extern crate edition_lint_paths as bar;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: convert it to a `use`

--- a/src/test/ui/rust-2018/issue-52202-use-suggestions.rs
+++ b/src/test/ui/rust-2018/issue-52202-use-suggestions.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: --edition 2018
+// edition:2018
 
 // The local `use` suggestion should start with `crate::` (but the
 // standard-library suggestions should not, obviously).


### PR DESCRIPTION
cc @varkor @petrochenkov @joshtriplett 