### PR TITLE
[beta] Don't sanity check function pointers in vtables

### DIFF
--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -1621,25 +1621,11 @@ impl<'a, 'tcx, C> TyLayoutMethods<'tcx, C> for Ty<'tcx>
                 match tcx.struct_tail(pointee).sty {
                     ty::TySlice(_) |
                     ty::TyStr => tcx.types.usize,
-                    ty::TyDynamic(data, _) => {
-                        let trait_def_id = data.principal().unwrap().def_id();
-                        let num_fns: u64 = crate::traits::supertrait_def_ids(tcx, trait_def_id)
-                            .map(|trait_def_id| {
-                                tcx.associated_items(trait_def_id)
-                                    .filter(|item| item.kind == ty::AssociatedKind::Method)
-                                    .count() as u64
-                            })
-                            .sum();
+                    ty::TyDynamic(_, _) => {
                         tcx.mk_imm_ref(
                             tcx.types.re_static,
-                            tcx.mk_array(tcx.types.usize, 3 + num_fns),
-                        )
-                        /* FIXME use actual fn pointers
-                        tcx.mk_tup(&[
                             tcx.mk_array(tcx.types.usize, 3),
-                            tcx.mk_array(Option<fn()>),
-                        ])
-                        */
+                        )
                     }
                     _ => bug!("TyLayout::field_type({:?}): not applicable", this)
                 }

--- a/src/test/codegen/function-arguments.rs
+++ b/src/test/codegen/function-arguments.rs
@@ -120,13 +120,13 @@ pub fn unsafe_slice(_: &[UnsafeInner]) {
 pub fn str(_: &[u8]) {
 }
 
-// CHECK: @trait_borrow({}* nonnull %arg0.0, [4 x [[USIZE]]]* noalias readonly dereferenceable({{.*}}) %arg0.1)
+// CHECK: @trait_borrow({}* nonnull %arg0.0, [3 x [[USIZE]]]* noalias readonly dereferenceable({{.*}}) %arg0.1)
 // FIXME #25759 This should also have `nocapture`
 #[no_mangle]
 pub fn trait_borrow(_: &Drop) {
 }
 
-// CHECK: @trait_box({}* noalias nonnull, [4 x [[USIZE]]]* noalias readonly dereferenceable({{.*}}))
+// CHECK: @trait_box({}* noalias nonnull, [3 x [[USIZE]]]* noalias readonly dereferenceable({{.*}}))
 #[no_mangle]
 pub fn trait_box(_: Box<Drop>) {
 }

--- a/src/test/ui/consts/const-eval/issue-53401.rs
+++ b/src/test/ui/consts/const-eval/issue-53401.rs
@@ -1,0 +1,21 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-pass
+
+pub const STATIC_TRAIT: &Test = &();
+
+fn main() {}
+
+pub trait Test {
+    fn test() where Self: Sized {}
+}
+
+impl Test for () {}


### PR DESCRIPTION
cc https://github.com/rust-lang/rust/issues/53401

There's no beta nomination because the full fix (https://github.com/rust-lang/rust/pull/53424) is not backportable