### PR TITLE
rustc_resolve: overhaul `#![feature(uniform_paths)]` error reporting.

### DIFF
--- a/src/test/run-pass/uniform-paths/basic-nested.rs
+++ b/src/test/run-pass/uniform-paths/basic-nested.rs
@@ -10,7 +10,7 @@
 
 // edition:2018
 
-#![feature(uniform_paths)]
+#![feature(decl_macro, uniform_paths)]
 
 // This test is similar to `basic.rs`, but nested in modules.
 
@@ -40,6 +40,11 @@ mod bar {
     // item, e.g. the automatically injected `extern crate std;`, which in
     // the Rust 2018 should no longer be visible through `crate::std`.
     pub use std::io;
+
+    // Also test that items named `std` in other namespaces don't
+    // cause ambiguity errors for the import from `std` above.
+    pub fn std() {}
+    pub macro std() {}
 }
 
 
@@ -49,4 +54,6 @@ fn main() {
     foo::local_io(());
     io::stdout();
     bar::io::stdout();
+    bar::std();
+    bar::std!();
 }

--- a/src/test/ui/rust-2018/uniform-paths/ambiguity-macros-nested.rs
+++ b/src/test/ui/rust-2018/uniform-paths/ambiguity-macros-nested.rs
@@ -16,7 +16,7 @@
 
 mod foo {
     pub use std::io;
-    //~^ ERROR import from `std` is ambiguous
+    //~^ ERROR `std` import is ambiguous
 
     macro_rules! m {
         () => {

--- a/src/test/ui/rust-2018/uniform-paths/ambiguity-macros-nested.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/ambiguity-macros-nested.stderr
@@ -1,13 +1,13 @@
-error: import from `std` is ambiguous
+error: `std` import is ambiguous
   --> $DIR/ambiguity-macros-nested.rs:18:13
    |
 LL |       pub use std::io;
-   |               ^^^ could refer to external crate `::std`
+   |               ^^^ can refer to external crate `::std`
 ...
 LL | /             mod std {
 LL | |                 pub struct io;
 LL | |             }
-   | |_____________- could also refer to `self::std`
+   | |_____________- can refer to `self::std`
    |
    = help: write `::std` or `self::std` explicitly instead
    = note: relative `use` paths enabled by `#![feature(uniform_paths)]`

--- a/src/test/ui/rust-2018/uniform-paths/ambiguity-macros.rs
+++ b/src/test/ui/rust-2018/uniform-paths/ambiguity-macros.rs
@@ -15,7 +15,7 @@
 // This test is similar to `ambiguity.rs`, but with macros defining local items.
 
 use std::io;
-//~^ ERROR import from `std` is ambiguous
+//~^ ERROR `std` import is ambiguous
 
 macro_rules! m {
     () => {

--- a/src/test/ui/rust-2018/uniform-paths/ambiguity-macros.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/ambiguity-macros.stderr
@@ -1,13 +1,13 @@
-error: import from `std` is ambiguous
+error: `std` import is ambiguous
   --> $DIR/ambiguity-macros.rs:17:5
    |
 LL |   use std::io;
-   |       ^^^ could refer to external crate `::std`
+   |       ^^^ can refer to external crate `::std`
 ...
 LL | /         mod std {
 LL | |             pub struct io;
 LL | |         }
-   | |_________- could also refer to `self::std`
+   | |_________- can refer to `self::std`
    |
    = help: write `::std` or `self::std` explicitly instead
    = note: relative `use` paths enabled by `#![feature(uniform_paths)]`

--- a/src/test/ui/rust-2018/uniform-paths/ambiguity-nested.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/ambiguity-nested.stderr
@@ -1,13 +1,13 @@
-error: import from `std` is ambiguous
+error: `std` import is ambiguous
   --> $DIR/ambiguity-nested.rs:18:13
    |
 LL |       pub use std::io;
-   |               ^^^ could refer to external crate `::std`
+   |               ^^^ can refer to external crate `::std`
 ...
 LL | /     mod std {
 LL | |         pub struct io;
 LL | |     }
-   | |_____- could also refer to `self::std`
+   | |_____- can refer to `self::std`
    |
    = help: write `::std` or `self::std` explicitly instead
    = note: relative `use` paths enabled by `#![feature(uniform_paths)]`

--- a/src/test/ui/rust-2018/uniform-paths/ambiguity.rs
+++ b/src/test/ui/rust-2018/uniform-paths/ambiguity.rs
@@ -13,7 +13,7 @@
 #![feature(uniform_paths)]
 
 use std::io;
-//~^ ERROR import from `std` is ambiguous
+//~^ ERROR `std` import is ambiguous
 
 mod std {
     pub struct io;

--- a/src/test/ui/rust-2018/uniform-paths/ambiguity.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/ambiguity.stderr
@@ -1,13 +1,13 @@
-error: import from `std` is ambiguous
+error: `std` import is ambiguous
   --> $DIR/ambiguity.rs:15:5
    |
 LL |   use std::io;
-   |       ^^^ could refer to external crate `::std`
+   |       ^^^ can refer to external crate `::std`
 ...
 LL | / mod std {
 LL | |     pub struct io;
 LL | | }
-   | |_- could also refer to `self::std`
+   | |_- can refer to `self::std`
    |
    = help: write `::std` or `self::std` explicitly instead
    = note: relative `use` paths enabled by `#![feature(uniform_paths)]`

--- a/src/test/ui/rust-2018/uniform-paths/block-scoped-shadow.rs
+++ b/src/test/ui/rust-2018/uniform-paths/block-scoped-shadow.rs
@@ -14,10 +14,18 @@
 
 enum Foo { A, B }
 
+struct std;
+
 fn main() {
     enum Foo {}
     use Foo::*;
-    //~^ ERROR import from `Foo` is ambiguous
+    //~^ ERROR `Foo` import is ambiguous
 
     let _ = (A, B);
+
+    fn std() {}
+    enum std {}
+    use std as foo;
+    //~^ ERROR `std` import is ambiguous
+    //~| ERROR `std` import is ambiguous
 }

--- a/src/test/ui/rust-2018/uniform-paths/block-scoped-shadow.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/block-scoped-shadow.stderr
@@ -1,13 +1,45 @@
-error: import from `Foo` is ambiguous
-  --> $DIR/block-scoped-shadow.rs:19:9
+error: `Foo` import is ambiguous
+  --> $DIR/block-scoped-shadow.rs:21:9
    |
+LL | enum Foo { A, B }
+   | ----------------- can refer to `self::Foo`
+...
 LL |     enum Foo {}
    |     ----------- shadowed by block-scoped `Foo`
 LL |     use Foo::*;
    |         ^^^
    |
-   = help: write `::Foo` or `self::Foo` explicitly instead
+   = help: write `self::Foo` explicitly instead
    = note: relative `use` paths enabled by `#![feature(uniform_paths)]`
 
-error: aborting due to previous error
+error: `std` import is ambiguous
+  --> $DIR/block-scoped-shadow.rs:28:9
+   |
+LL | struct std;
+   | ----------- can refer to `self::std`
+...
+LL |     enum std {}
+   |     ----------- shadowed by block-scoped `std`
+LL |     use std as foo;
+   |         ^^^ can refer to external crate `::std`
+   |
+   = help: write `::std` or `self::std` explicitly instead
+   = note: relative `use` paths enabled by `#![feature(uniform_paths)]`
+
+error: `std` import is ambiguous
+  --> $DIR/block-scoped-shadow.rs:28:9
+   |
+LL | struct std;
+   | ----------- can refer to `self::std`
+...
+LL |     fn std() {}
+   |     ----------- shadowed by block-scoped `std`
+LL |     enum std {}
+LL |     use std as foo;
+   |         ^^^
+   |
+   = help: write `self::std` explicitly instead
+   = note: relative `use` paths enabled by `#![feature(uniform_paths)]`
+
+error: aborting due to 3 previous errors
 

--- a/src/test/ui/rust-2018/uniform-paths/redundant.rs
+++ b/src/test/ui/rust-2018/uniform-paths/redundant.rs
@@ -12,15 +12,6 @@
 
 #![feature(uniform_paths)]
 
-// This test is similar to `ambiguity.rs`, but nested in a module.
-
-mod foo {
-    pub use std::io;
-    //~^ ERROR `std` import is ambiguous
-
-    mod std {
-        pub struct io;
-    }
-}
+use std;
 
 fn main() {}

--- a/src/test/ui/rust-2018/uniform-paths/redundant.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/redundant.stderr
@@ -1,0 +1,14 @@
+error: `std` import is redundant
+  --> $DIR/redundant.rs:15:5
+   |
+LL | use std;
+   |     ^^^
+   |     |
+   |     refers to external crate `::std`
+   |     defines `self::std`, shadowing itself
+   |
+   = help: remove or write `::std` explicitly instead
+   = note: relative `use` paths enabled by `#![feature(uniform_paths)]`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fixes #53408 by only considering external crates to conflict within their (type/module) namespace, *not* with the value or macro namespaces, and also by adding a special-cased error for redundant `use crate_name;` imports (without actually allowing them).
Also, all canaries for a given import are grouped into one diagnostic per namespace, in order to make block-scoped ambiguities clearer.
See changed/added tests for more details.

r? @petrochenkov cc @aturon @joshtriplett 