### PR TITLE
libtest terse format: show how far in we are

### DIFF
--- a/src/libtest/formatters/terse.rs
+++ b/src/libtest/formatters/terse.rs
@@ -34,7 +34,7 @@ impl<T: Write> TerseFormatter<T> {
             max_name_len,
             is_multithreaded,
             test_count: 0,
-            total_test_count: 0,
+            total_test_count: 0, // initialized later, when write_run_start is called
         }
     }
 

--- a/src/libtest/formatters/terse.rs
+++ b/src/libtest/formatters/terse.rs
@@ -18,6 +18,7 @@ pub(crate) struct TerseFormatter<T> {
     max_name_len: usize,
 
     test_count: usize,
+    total_test_count: usize,
 }
 
 impl<T: Write> TerseFormatter<T> {
@@ -33,6 +34,7 @@ impl<T: Write> TerseFormatter<T> {
             max_name_len,
             is_multithreaded,
             test_count: 0,
+            total_test_count: 0,
         }
     }
 
@@ -66,7 +68,8 @@ impl<T: Write> TerseFormatter<T> {
             // we insert a new line every 100 dots in order to flush the
             // screen when dealing with line-buffered output (e.g. piping to
             // `stamp` in the rust CI).
-            self.write_plain("\n")?;
+            let out = format!(" {}/{}\n", self.test_count+1, self.total_test_count);
+            self.write_plain(&out)?;
         }
 
         self.test_count += 1;
@@ -160,6 +163,7 @@ impl<T: Write> TerseFormatter<T> {
 
 impl<T: Write> OutputFormatter for TerseFormatter<T> {
     fn write_run_start(&mut self, test_count: usize) -> io::Result<()> {
+        self.total_test_count = test_count;
         let noun = if test_count != 1 { "tests" } else { "test" };
         self.write_plain(&format!("\nrunning {} {}\n", test_count, noun))
     }


### PR DESCRIPTION
So for example `./x.py test src/libcore` looks like
```
running 881 tests
.................................................................................................... 100/881
.................................................................................................... 200/881
.................................................................................................... 300/881
.............................................................i.i.................................... 400/881
.................................................................................................... 500/881
.................................................................................................... 600/881
.................................................................................................... 700/881
.................................................................................................... 800/881
.................................................................................
test result: ok. 879 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out
```
When I am waiting for 3500 ui tests to complete, I am often missing some sense of how far in these 3500 it is.

Getting the total count in `write_run_start` is a bit hacky; I did that to not change the "public interface" of the formatters. I can also give them an extra argument in their constructor so that they know from the beginning how many tests there will be. Would you prefer that? (I think I would, but I wanted to get feedback first.)