### PR TITLE
wasm: Remove --strip-debug argument to LLD

### DIFF
--- a/src/librustc_codegen_llvm/back/linker.rs
+++ b/src/librustc_codegen_llvm/back/linker.rs
@@ -1006,18 +1006,6 @@ impl<'a> Linker for WasmLd<'a> {
             OptLevel::Size => "-O2",
             OptLevel::SizeMin => "-O2"
         });
-        match self.sess.opts.optimize {
-            OptLevel::No => (),
-            OptLevel::Less |
-            OptLevel::Default |
-            OptLevel::Aggressive |
-            OptLevel::Size |
-            OptLevel::SizeMin => {
-                // LLD generates incorrect debugging information when
-                // optimization is applied: strip debug sections.
-                self.cmd.arg("--strip-debug");
-            }
-        }
     }
 
     fn pgo_gen(&mut self) {


### PR DESCRIPTION
Originally added in #52887 this commit disables passing `--strip-debug` to LLD
when optimized. This bring back the original bug of emitting broken debuginfo
but currently it *also* strips the `name` section which makes it very difficult
to inspect the final binary. A real fix is happening at
https://reviews.llvm.org/D50729 and we can reevaluate once we've updated LLD to
have that commit.