### PR TITLE
Rollup of 11 pull requests

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -308,7 +308,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "chalk-engine"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "chalk-macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1897,7 +1897,7 @@ dependencies = [
  "backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "chalk-engine 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chalk-engine 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fmt_macros 0.0.0",
  "graphviz 0.0.0",
@@ -2408,7 +2408,7 @@ name = "rustc_traits"
 version = "0.0.0"
 dependencies = [
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "chalk-engine 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chalk-engine 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "graphviz 0.0.0",
  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc 0.0.0",
@@ -3135,7 +3135,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cargo_metadata 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d6809b327f87369e6f3651efd2c5a96c49847a3ed2559477ecba79014751ee1"
 "checksum cc 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "2119ea4867bd2b8ed3aecab467709720b2d55b1bcfe09f772fd68066eaf15275"
 "checksum cfg-if 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "efe5c877e17a9c717a0bf3613b2709f723202c4e4675cc8f12926ded29bcb17e"
-"checksum chalk-engine 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a146c19172c7eea48ea55a7123ac95da786639bc665097f1e14034ee5f1d8699"
+"checksum chalk-engine 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "25ce2f28f55ed544a2a3756b7acf41dd7d6f27acffb2086439950925506af7d0"
 "checksum chalk-macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "295635afd6853aa9f20baeb7f0204862440c0fe994c5a253d5f479dac41d047e"
 "checksum chrono 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6962c635d530328acc53ac6a955e83093fedc91c5809dfac1fa60fa470830a37"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"

--- a/src/doc/unstable-book/src/language-features/crate-in-paths.md
+++ b/src/doc/unstable-book/src/language-features/crate-in-paths.md
@@ -9,10 +9,6 @@ The tracking issue for this feature is: [#44660]
 The `crate_in_paths` feature allows to explicitly refer to the crate root in absolute paths
 using keyword `crate`.
 
-`crate` can be used *only* in absolute paths, i.e. either in `::crate::a::b::c` form or in `use`
-items where the starting `::` is added implicitly.  
-Paths like `crate::a::b::c` are not accepted currently.
-
 This feature is required in `feature(extern_absolute_paths)` mode to refer to any absolute path
 in the local crate (absolute paths refer to extern crates by default in that mode), but can be
 used without `feature(extern_absolute_paths)` as well.
@@ -39,15 +35,14 @@ mod n
     use crate as root;
     pub fn check() {
         assert_eq!(f(), 1);
-        // `::` is required in non-import paths
-        assert_eq!(::crate::m::g(), 2);
+        assert_eq!(crate::m::g(), 2);
         assert_eq!(root::m::h(), 3);
     }
 }
 
 fn main() {
     assert_eq!(f(), 1);
-    assert_eq!(::crate::m::g(), 2);
+    assert_eq!(crate::m::g(), 2);
     assert_eq!(root::m::h(), 3);
     n::check();
 }

--- a/src/doc/unstable-book/src/language-features/extern-absolute-paths.md
+++ b/src/doc/unstable-book/src/language-features/extern-absolute-paths.md
@@ -12,7 +12,7 @@ The `extern_absolute_paths` feature enables mode allowing to refer to names from
 `::my_crate::a::b` will resolve to path `a::b` in crate `my_crate`.
 
 `feature(crate_in_paths)` can be used in `feature(extern_absolute_paths)` mode for referring
-to absolute paths in the local crate (`::crate::a::b`).
+to absolute paths in the local crate (`crate::a::b`).
 
 `feature(extern_in_paths)` provides the same effect by using keyword `extern` to refer to
 paths from other crates (`extern::my_crate::a::b`).

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -1891,7 +1891,7 @@ $EndFeature, "
         /// ```
         /// #![feature(int_to_from_bytes)]
         ///
-        /// let bytes = 0x12345678i32.to_be_bytes();
+        /// let bytes = 0x12_34_56_78_i32.to_be_bytes();
         /// assert_eq!(bytes, [0x12, 0x34, 0x56, 0x78]);
         /// ```
         #[unstable(feature = "int_to_from_bytes", issue = "52963")]
@@ -1908,7 +1908,7 @@ $EndFeature, "
         /// ```
         /// #![feature(int_to_from_bytes)]
         ///
-        /// let bytes = 0x12345678i32.to_le_bytes();
+        /// let bytes =  0x12_34_56_78_i32.to_le_bytes();
         /// assert_eq!(bytes, [0x78, 0x56, 0x34, 0x12]);
         /// ```
         #[unstable(feature = "int_to_from_bytes", issue = "52963")]
@@ -3576,7 +3576,7 @@ $EndFeature, "
         /// ```
         /// #![feature(int_to_from_bytes)]
         ///
-        /// let bytes = 0x12345678i32.to_be_bytes();
+        /// let bytes =  0x12_34_56_78_i32.to_be_bytes();
         /// assert_eq!(bytes, [0x12, 0x34, 0x56, 0x78]);
         /// ```
         #[unstable(feature = "int_to_from_bytes", issue = "52963")]
@@ -3593,7 +3593,7 @@ $EndFeature, "
         /// ```
         /// #![feature(int_to_from_bytes)]
         ///
-        /// let bytes = 0x12345678i32.to_le_bytes();
+        /// let bytes =  0x12_34_56_78_i32.to_le_bytes();
         /// assert_eq!(bytes, [0x78, 0x56, 0x34, 0x12]);
         /// ```
         #[unstable(feature = "int_to_from_bytes", issue = "52963")]

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -3568,47 +3568,119 @@ $EndFeature, "
             }
         }
 
-        /// Return the memory representation of this integer as a byte array.
-        ///
-        /// The target platform’s native endianness is used.
-        /// Portable code likely wants to use this after [`to_be`] or [`to_le`].
-        ///
-        /// [`to_be`]: #method.to_be
-        /// [`to_le`]: #method.to_le
+        /// Return the memory representation of this integer as a byte array in
+        /// big-endian (network) byte order.
         ///
         /// # Examples
         ///
         /// ```
         /// #![feature(int_to_from_bytes)]
         ///
-        /// let bytes = 0x1234_5678_u32.to_be().to_bytes();
+        /// let bytes = 0x12345678i32.to_be_bytes();
         /// assert_eq!(bytes, [0x12, 0x34, 0x56, 0x78]);
         /// ```
         #[unstable(feature = "int_to_from_bytes", issue = "52963")]
         #[inline]
-        pub fn to_bytes(self) -> [u8; mem::size_of::<Self>()] {
-            unsafe { mem::transmute(self) }
+        pub fn to_be_bytes(self) -> [u8; mem::size_of::<Self>()] {
+            self.to_be().to_ne_bytes()
         }
 
-        /// Create an integer value from its memory representation as a byte array.
-        ///
-        /// The target platform’s native endianness is used.
-        /// Portable code likely wants to use [`to_be`] or [`to_le`] after this.
-        ///
-        /// [`to_be`]: #method.to_be
-        /// [`to_le`]: #method.to_le
+        /// Return the memory representation of this integer as a byte array in
+        /// little-endian byte order.
         ///
         /// # Examples
         ///
         /// ```
         /// #![feature(int_to_from_bytes)]
         ///
-        /// let int = u32::from_be(u32::from_bytes([0x12, 0x34, 0x56, 0x78]));
-        /// assert_eq!(int, 0x1234_5678_u32);
+        /// let bytes = 0x12345678i32.to_le_bytes();
+        /// assert_eq!(bytes, [0x78, 0x56, 0x34, 0x12]);
         /// ```
         #[unstable(feature = "int_to_from_bytes", issue = "52963")]
         #[inline]
-        pub fn from_bytes(bytes: [u8; mem::size_of::<Self>()]) -> Self {
+        pub fn to_le_bytes(self) -> [u8; mem::size_of::<Self>()] {
+            self.to_le().to_ne_bytes()
+        }
+
+        /// Return the memory representation of this integer as a byte array in
+        /// native byte order.
+        ///
+        /// As the target platform's native endianness is used, portable code
+        /// should use [`to_be_bytes`] or [`to_le_bytes`], as appropriate,
+        /// instead.
+        ///
+        /// [`to_be_bytes`]: #method.to_be_bytes
+        /// [`to_le_bytes`]: #method.to_le_bytes
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(int_to_from_bytes)]
+        ///
+        /// let bytes = i32::min_value().to_be().to_ne_bytes();
+        /// assert_eq!(bytes, [0x80, 0, 0, 0]);
+        /// ```
+        #[unstable(feature = "int_to_from_bytes", issue = "52963")]
+        #[inline]
+        pub fn to_ne_bytes(self) -> [u8; mem::size_of::<Self>()] {
+            unsafe { mem::transmute(self) }
+        }
+
+        /// Create an integer value from its representation as a byte array in
+        /// big endian.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(int_to_from_bytes)]
+        ///
+        /// let int = i32::from_be_bytes([0x12, 0x34, 0x56, 0x78]);
+        /// assert_eq!(int, 0x12_34_56_78);
+        /// ```
+        #[unstable(feature = "int_to_from_bytes", issue = "52963")]
+        #[inline]
+        pub fn from_be_bytes(bytes: [u8; mem::size_of::<Self>()]) -> Self {
+            Self::from_be(Self::from_ne_bytes(bytes))
+        }
+
+        /// Create an integer value from its representation as a byte array in
+        /// little endian.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(int_to_from_bytes)]
+        ///
+        /// let int = i32::from_le_bytes([0x12, 0x34, 0x56, 0x78]);
+        /// assert_eq!(int, 0x78_56_34_12);
+        /// ```
+        #[unstable(feature = "int_to_from_bytes", issue = "52963")]
+        #[inline]
+        pub fn from_le_bytes(bytes: [u8; mem::size_of::<Self>()]) -> Self {
+            Self::from_le(Self::from_ne_bytes(bytes))
+        }
+
+        /// Create an integer value from its memory representation as a byte
+        /// array in native endianness.
+        ///
+        /// As the target platform's native endianness is used, portable code
+        /// likely wants to use [`from_be_bytes`] or [`from_le_bytes`], as
+        /// appropriate instead.
+        ///
+        /// [`from_be_bytes`]: #method.from_be_bytes
+        /// [`from_le_bytes`]: #method.from_le_bytes
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(int_to_from_bytes)]
+        ///
+        /// let int = i32::from_be(i32::from_ne_bytes([0x80, 0, 0, 0]));
+        /// assert_eq!(int, i32::min_value());
+        /// ```
+        #[unstable(feature = "int_to_from_bytes", issue = "52963")]
+        #[inline]
+        pub fn from_ne_bytes(bytes: [u8; mem::size_of::<Self>()]) -> Self {
             unsafe { mem::transmute(bytes) }
         }
     }

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -1891,7 +1891,7 @@ $EndFeature, "
         /// ```
         /// #![feature(int_to_from_bytes)]
         ///
-        /// let bytes = 0x12345678i32.to_be_bytes();
+        /// let bytes = 0x12_34_56_78_i32.to_be_bytes();
         /// assert_eq!(bytes, [0x12, 0x34, 0x56, 0x78]);
         /// ```
         #[unstable(feature = "int_to_from_bytes", issue = "52963")]
@@ -1908,7 +1908,7 @@ $EndFeature, "
         /// ```
         /// #![feature(int_to_from_bytes)]
         ///
-        /// let bytes = 0x12345678i32.to_le_bytes();
+        /// let bytes =  0x12_34_56_78_i32.to_le_bytes();
         /// assert_eq!(bytes, [0x78, 0x56, 0x34, 0x12]);
         /// ```
         #[unstable(feature = "int_to_from_bytes", issue = "52963")]
@@ -3568,47 +3568,119 @@ $EndFeature, "
             }
         }
 
-        /// Return the memory representation of this integer as a byte array.
-        ///
-        /// The target platform’s native endianness is used.
-        /// Portable code likely wants to use this after [`to_be`] or [`to_le`].
-        ///
-        /// [`to_be`]: #method.to_be
-        /// [`to_le`]: #method.to_le
+        /// Return the memory representation of this integer as a byte array in
+        /// big-endian (network) byte order.
         ///
         /// # Examples
         ///
         /// ```
         /// #![feature(int_to_from_bytes)]
         ///
-        /// let bytes = 0x1234_5678_u32.to_be().to_bytes();
+        /// let bytes =  0x12_34_56_78_i32.to_be_bytes();
         /// assert_eq!(bytes, [0x12, 0x34, 0x56, 0x78]);
         /// ```
         #[unstable(feature = "int_to_from_bytes", issue = "52963")]
         #[inline]
-        pub fn to_bytes(self) -> [u8; mem::size_of::<Self>()] {
-            unsafe { mem::transmute(self) }
+        pub fn to_be_bytes(self) -> [u8; mem::size_of::<Self>()] {
+            self.to_be().to_ne_bytes()
         }
 
-        /// Create an integer value from its memory representation as a byte array.
-        ///
-        /// The target platform’s native endianness is used.
-        /// Portable code likely wants to use [`to_be`] or [`to_le`] after this.
-        ///
-        /// [`to_be`]: #method.to_be
-        /// [`to_le`]: #method.to_le
+        /// Return the memory representation of this integer as a byte array in
+        /// little-endian byte order.
         ///
         /// # Examples
         ///
         /// ```
         /// #![feature(int_to_from_bytes)]
         ///
-        /// let int = u32::from_be(u32::from_bytes([0x12, 0x34, 0x56, 0x78]));
-        /// assert_eq!(int, 0x1234_5678_u32);
+        /// let bytes =  0x12_34_56_78_i32.to_le_bytes();
+        /// assert_eq!(bytes, [0x78, 0x56, 0x34, 0x12]);
         /// ```
         #[unstable(feature = "int_to_from_bytes", issue = "52963")]
         #[inline]
-        pub fn from_bytes(bytes: [u8; mem::size_of::<Self>()]) -> Self {
+        pub fn to_le_bytes(self) -> [u8; mem::size_of::<Self>()] {
+            self.to_le().to_ne_bytes()
+        }
+
+        /// Return the memory representation of this integer as a byte array in
+        /// native byte order.
+        ///
+        /// As the target platform's native endianness is used, portable code
+        /// should use [`to_be_bytes`] or [`to_le_bytes`], as appropriate,
+        /// instead.
+        ///
+        /// [`to_be_bytes`]: #method.to_be_bytes
+        /// [`to_le_bytes`]: #method.to_le_bytes
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(int_to_from_bytes)]
+        ///
+        /// let bytes = i32::min_value().to_be().to_ne_bytes();
+        /// assert_eq!(bytes, [0x80, 0, 0, 0]);
+        /// ```
+        #[unstable(feature = "int_to_from_bytes", issue = "52963")]
+        #[inline]
+        pub fn to_ne_bytes(self) -> [u8; mem::size_of::<Self>()] {
+            unsafe { mem::transmute(self) }
+        }
+
+        /// Create an integer value from its representation as a byte array in
+        /// big endian.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(int_to_from_bytes)]
+        ///
+        /// let int = i32::from_be_bytes([0x12, 0x34, 0x56, 0x78]);
+        /// assert_eq!(int, 0x12_34_56_78);
+        /// ```
+        #[unstable(feature = "int_to_from_bytes", issue = "52963")]
+        #[inline]
+        pub fn from_be_bytes(bytes: [u8; mem::size_of::<Self>()]) -> Self {
+            Self::from_be(Self::from_ne_bytes(bytes))
+        }
+
+        /// Create an integer value from its representation as a byte array in
+        /// little endian.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(int_to_from_bytes)]
+        ///
+        /// let int = i32::from_le_bytes([0x12, 0x34, 0x56, 0x78]);
+        /// assert_eq!(int, 0x78_56_34_12);
+        /// ```
+        #[unstable(feature = "int_to_from_bytes", issue = "52963")]
+        #[inline]
+        pub fn from_le_bytes(bytes: [u8; mem::size_of::<Self>()]) -> Self {
+            Self::from_le(Self::from_ne_bytes(bytes))
+        }
+
+        /// Create an integer value from its memory representation as a byte
+        /// array in native endianness.
+        ///
+        /// As the target platform's native endianness is used, portable code
+        /// likely wants to use [`from_be_bytes`] or [`from_le_bytes`], as
+        /// appropriate instead.
+        ///
+        /// [`from_be_bytes`]: #method.from_be_bytes
+        /// [`from_le_bytes`]: #method.from_le_bytes
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(int_to_from_bytes)]
+        ///
+        /// let int = i32::from_be(i32::from_ne_bytes([0x80, 0, 0, 0]));
+        /// assert_eq!(int, i32::min_value());
+        /// ```
+        #[unstable(feature = "int_to_from_bytes", issue = "52963")]
+        #[inline]
+        pub fn from_ne_bytes(bytes: [u8; mem::size_of::<Self>()]) -> Self {
             unsafe { mem::transmute(bytes) }
         }
     }

--- a/src/librustc/Cargo.toml
+++ b/src/librustc/Cargo.toml
@@ -31,7 +31,7 @@ syntax_pos = { path = "../libsyntax_pos" }
 backtrace = "0.3.3"
 parking_lot = "0.5.5"
 byteorder = { version = "1.1", features = ["i128"]}
-chalk-engine = { version = "0.6.0", default-features=false }
+chalk-engine = { version = "0.7.0", default-features=false }
 rustc_fs_util = { path = "../librustc_fs_util" }
 
 # Note that these dependencies are a lie, they're just here to get linkage to

--- a/src/librustc/traits/util.rs
+++ b/src/librustc/traits/util.rs
@@ -239,6 +239,10 @@ impl<'cx, 'gcx, 'tcx> Elaborator<'cx, 'gcx, 'tcx> {
 impl<'cx, 'gcx, 'tcx> Iterator for Elaborator<'cx, 'gcx, 'tcx> {
     type Item = ty::Predicate<'tcx>;
 
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.stack.len(), None)
+    }
+
     fn next(&mut self) -> Option<ty::Predicate<'tcx>> {
         // Extract next item from top-most stack frame, if any.
         let next_predicate = match self.stack.pop() {

--- a/src/librustc_codegen_llvm/back/linker.rs
+++ b/src/librustc_codegen_llvm/back/linker.rs
@@ -1006,18 +1006,6 @@ impl<'a> Linker for WasmLd<'a> {
             OptLevel::Size => "-O2",
             OptLevel::SizeMin => "-O2"
         });
-        match self.sess.opts.optimize {
-            OptLevel::No => (),
-            OptLevel::Less |
-            OptLevel::Default |
-            OptLevel::Aggressive |
-            OptLevel::Size |
-            OptLevel::SizeMin => {
-                // LLD generates incorrect debugging information when
-                // optimization is applied: strip debug sections.
-                self.cmd.arg("--strip-debug");
-            }
-        }
     }
 
     fn pgo_gen(&mut self) {

--- a/src/librustc_traits/Cargo.toml
+++ b/src/librustc_traits/Cargo.toml
@@ -16,4 +16,4 @@ rustc = { path = "../librustc" }
 rustc_data_structures = { path = "../librustc_data_structures" }
 syntax = { path = "../libsyntax" }
 syntax_pos = { path = "../libsyntax_pos" }
-chalk-engine = { version = "0.6.0", default-features=false }
+chalk-engine = { version = "0.7.0", default-features=false }

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1925,6 +1925,7 @@ fn from_target_feature(
                 Some("mmx_target_feature") => rust_features.mmx_target_feature,
                 Some("sse4a_target_feature") => rust_features.sse4a_target_feature,
                 Some("tbm_target_feature") => rust_features.tbm_target_feature,
+                Some("wasm_target_feature") => rust_features.wasm_target_feature,
                 Some(name) => bug!("unknown target feature gate {}", name),
                 None => true,
             };

--- a/src/test/debuginfo/pretty-std-collections.rs
+++ b/src/test/debuginfo/pretty-std-collections.rs
@@ -22,11 +22,15 @@
 // gdb-command: print btree_set
 // gdb-check:$1 = BTreeSet<i32>(len: 3) = {3, 5, 7}
 
+// gdb-command: print btree_map
+// gdb-check:$2 = BTreeMap<i32, i32>(len: 3) = {[3] = 3, [5] = 7, [7] = 4}
+
 // gdb-command: print vec_deque
-// gdb-check:$2 = VecDeque<i32>(len: 3, cap: 8) = {5, 3, 7}
+// gdb-check:$3 = VecDeque<i32>(len: 3, cap: 8) = {5, 3, 7}
 
 #![allow(unused_variables)]
 use std::collections::BTreeSet;
+use std::collections::BTreeMap;
 use std::collections::VecDeque;
 
 
@@ -37,6 +41,12 @@ fn main() {
     btree_set.insert(5);
     btree_set.insert(3);
     btree_set.insert(7);
+
+    // BTreeMap
+    let mut btree_map = BTreeMap::new();
+    btree_map.insert(5, 7);
+    btree_map.insert(3, 3);
+    btree_map.insert(7, 4);
 
     // VecDeque
     let mut vec_deque = VecDeque::new();

--- a/src/test/run-pass/macro-at-most-once-rep.rs
+++ b/src/test/run-pass/macro-at-most-once-rep.rs
@@ -18,7 +18,7 @@
 //
 // This test focuses on non-error cases and making sure the correct number of repetitions happen.
 
-// compile-flags: --edition=2018
+// edition:2018
 
 #![feature(macro_at_most_once_rep)]
 

--- a/src/test/run-pass/rfc-2126-crate-paths/crate-path-absolute.rs
+++ b/src/test/run-pass/rfc-2126-crate-paths/crate-path-absolute.rs
@@ -28,14 +28,14 @@ mod n
     use crate as root;
     pub fn check() {
         assert_eq!(f(), 1);
-        assert_eq!(::crate::m::g(), 2);
+        assert_eq!(crate::m::g(), 2);
         assert_eq!(root::m::h(), 3);
     }
 }
 
 fn main() {
     assert_eq!(f(), 1);
-    assert_eq!(::crate::m::g(), 2);
+    assert_eq!(crate::m::g(), 2);
     assert_eq!(root::m::h(), 3);
     n::check();
 }

--- a/src/test/run-pass/rfc-2126-crate-paths/crate-path-visibility-ambiguity.rs
+++ b/src/test/run-pass/rfc-2126-crate-paths/crate-path-visibility-ambiguity.rs
@@ -14,8 +14,9 @@
 mod m {
     pub struct Z;
     pub struct S1(crate (::m::Z)); // OK
-    pub struct S2(::crate ::m::Z); // OK
+    pub struct S2((crate ::m::Z)); // OK
     pub struct S3(crate ::m::Z); // OK
+    pub struct S4(crate crate::m::Z); // OK
 }
 
 fn main() {

--- a/src/test/rustdoc/async-fn.rs
+++ b/src/test/rustdoc/async-fn.rs
@@ -13,7 +13,7 @@
 
 // FIXME: once `--edition` is stable in rustdoc, remove that `compile-flags` directive
 
-#![feature(rust_2018_preview, async_await, futures_api)]
+#![feature(async_await, futures_api)]
 
 // @has async_fn/struct.S.html
 // @has - '//code' 'pub async fn f()'

--- a/src/test/ui-fulldeps/rust-2018/suggestions-not-always-applicable.fixed
+++ b/src/test/ui-fulldeps/rust-2018/suggestions-not-always-applicable.fixed
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // aux-build:suggestions-not-always-applicable.rs
-// compile-flags: --edition 2015
+// edition:2015
 // run-rustfix
 // rustfix-only-machine-applicable
 // compile-pass

--- a/src/test/ui-fulldeps/rust-2018/suggestions-not-always-applicable.rs
+++ b/src/test/ui-fulldeps/rust-2018/suggestions-not-always-applicable.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // aux-build:suggestions-not-always-applicable.rs
-// compile-flags: --edition 2015
+// edition:2015
 // run-rustfix
 // rustfix-only-machine-applicable
 // compile-pass

--- a/src/test/ui-fulldeps/unnecessary-extern-crate.rs
+++ b/src/test/ui-fulldeps/unnecessary-extern-crate.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: --edition 2018
+// edition:2018
 
 #![deny(unused_extern_crates)]
 #![feature(alloc, test, libc)]

--- a/src/test/ui/E0705.rs
+++ b/src/test/ui/E0705.rs
@@ -10,9 +10,9 @@
 
 // compile-pass
 
-#![feature(rust_2018_preview)]
 #![feature(raw_identifiers)]
 //~^ WARN the feature `raw_identifiers` is included in the Rust 2018 edition
+#![feature(rust_2018_preview)]
 
 fn main() {
     let foo = 0;

--- a/src/test/ui/E0705.stderr
+++ b/src/test/ui/E0705.stderr
@@ -1,5 +1,5 @@
 warning[E0705]: the feature `raw_identifiers` is included in the Rust 2018 edition
-  --> $DIR/E0705.rs:14:12
+  --> $DIR/E0705.rs:13:12
    |
 LL | #![feature(raw_identifiers)]
    |            ^^^^^^^^^^^^^^^

--- a/src/test/ui/borrowck/borrowck-closures-two-mut-fail.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-closures-two-mut-fail.nll.stderr
@@ -2,76 +2,73 @@ error[E0499]: cannot borrow `x` as mutable more than once at a time
   --> $DIR/borrowck-closures-two-mut-fail.rs:26:24
    |
 LL |     let c1 = to_fn_mut(|| x = 4);
-   |                        -- - previous borrow occurs due to use of `x` in closure
+   |                        -- - first borrow occurs due to use of `x` in closure
    |                        |
    |                        first mutable borrow occurs here
 LL |     let c2 = to_fn_mut(|| x = 5); //~ ERROR cannot borrow `x` as mutable more than once
-   |                        ^^ - borrow occurs due to use of `x` in closure
+   |                        ^^ - second borrow occurs due to use of `x` in closure
    |                        |
    |                        second mutable borrow occurs here
 LL |     c1;
-LL | }
-   | - first borrow ends here
+   |     -- borrow later used here
 
 error[E0499]: cannot borrow `x` as mutable more than once at a time
   --> $DIR/borrowck-closures-two-mut-fail.rs:37:24
    |
 LL |     let c1 = to_fn_mut(|| set(&mut x));
-   |                        --          - previous borrow occurs due to use of `x` in closure
+   |                        --          - first borrow occurs due to use of `x` in closure
    |                        |
    |                        first mutable borrow occurs here
 LL |     let c2 = to_fn_mut(|| set(&mut x)); //~ ERROR cannot borrow `x` as mutable more than once
-   |                        ^^          - borrow occurs due to use of `x` in closure
+   |                        ^^          - second borrow occurs due to use of `x` in closure
    |                        |
    |                        second mutable borrow occurs here
 LL |     c1;
-LL | }
-   | - first borrow ends here
+   |     -- borrow later used here
 
 error[E0499]: cannot borrow `x` as mutable more than once at a time
   --> $DIR/borrowck-closures-two-mut-fail.rs:44:24
    |
 LL |     let c1 = to_fn_mut(|| x = 5);
-   |                        -- - previous borrow occurs due to use of `x` in closure
+   |                        -- - first borrow occurs due to use of `x` in closure
    |                        |
    |                        first mutable borrow occurs here
 LL |     let c2 = to_fn_mut(|| set(&mut x)); //~ ERROR cannot borrow `x` as mutable more than once
-   |                        ^^          - borrow occurs due to use of `x` in closure
+   |                        ^^          - second borrow occurs due to use of `x` in closure
    |                        |
    |                        second mutable borrow occurs here
 LL |     c1;
-LL | }
-   | - first borrow ends here
+   |     -- borrow later used here
 
 error[E0499]: cannot borrow `x` as mutable more than once at a time
   --> $DIR/borrowck-closures-two-mut-fail.rs:51:24
    |
 LL |     let c1 = to_fn_mut(|| x = 5);
-   |                        -- - previous borrow occurs due to use of `x` in closure
+   |                        -- - first borrow occurs due to use of `x` in closure
    |                        |
    |                        first mutable borrow occurs here
 LL |     let c2 = to_fn_mut(|| { let _y = to_fn_mut(|| set(&mut x)); }); // (nested closure)
-   |                        ^^                                  - borrow occurs due to use of `x` in closure
+   |                        ^^                                  - second borrow occurs due to use of `x` in closure
    |                        |
    |                        second mutable borrow occurs here
-...
-LL | }
-   | - first borrow ends here
+LL |     //~^ ERROR cannot borrow `x` as mutable more than once
+LL |     c1;
+   |     -- borrow later used here
 
 error[E0499]: cannot borrow `x` as mutable more than once at a time
   --> $DIR/borrowck-closures-two-mut-fail.rs:63:24
    |
 LL |     let c1 = to_fn_mut(|| set(&mut *x.f));
-   |                        --           - previous borrow occurs due to use of `x` in closure
+   |                        --           - first borrow occurs due to use of `x` in closure
    |                        |
    |                        first mutable borrow occurs here
 LL |     let c2 = to_fn_mut(|| set(&mut *x.f));
-   |                        ^^           - borrow occurs due to use of `x` in closure
+   |                        ^^           - second borrow occurs due to use of `x` in closure
    |                        |
    |                        second mutable borrow occurs here
-...
-LL | }
-   | - first borrow ends here
+LL |     //~^ ERROR cannot borrow `x` as mutable more than once
+LL |     c1;
+   |     -- borrow later used here
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/borrowck/borrowck-closures-two-mut-fail.rs
+++ b/src/test/ui/borrowck/borrowck-closures-two-mut-fail.rs
@@ -8,15 +8,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-compare-mode-nll
-
 // Tests that two closures cannot simultaneously have mutable
 // access to the variable, whether that mutable access be used
 // for direct assignment or for taking mutable ref. Issue #6801.
 
-// ignore-compare-mode-nll
-
 #![feature(box_syntax)]
+
+
+
+
 
 fn to_fn_mut<F: FnMut()>(f: F) -> F { f }
 
@@ -24,6 +24,7 @@ fn a() {
     let mut x = 3;
     let c1 = to_fn_mut(|| x = 4);
     let c2 = to_fn_mut(|| x = 5); //~ ERROR cannot borrow `x` as mutable more than once
+    c1;
 }
 
 fn set(x: &mut isize) {
@@ -34,12 +35,14 @@ fn b() {
     let mut x = 3;
     let c1 = to_fn_mut(|| set(&mut x));
     let c2 = to_fn_mut(|| set(&mut x)); //~ ERROR cannot borrow `x` as mutable more than once
+    c1;
 }
 
 fn c() {
     let mut x = 3;
     let c1 = to_fn_mut(|| x = 5);
     let c2 = to_fn_mut(|| set(&mut x)); //~ ERROR cannot borrow `x` as mutable more than once
+    c1;
 }
 
 fn d() {
@@ -47,6 +50,7 @@ fn d() {
     let c1 = to_fn_mut(|| x = 5);
     let c2 = to_fn_mut(|| { let _y = to_fn_mut(|| set(&mut x)); }); // (nested closure)
     //~^ ERROR cannot borrow `x` as mutable more than once
+    c1;
 }
 
 fn g() {
@@ -58,6 +62,7 @@ fn g() {
     let c1 = to_fn_mut(|| set(&mut *x.f));
     let c2 = to_fn_mut(|| set(&mut *x.f));
     //~^ ERROR cannot borrow `x` as mutable more than once
+    c1;
 }
 
 fn main() {

--- a/src/test/ui/borrowck/borrowck-closures-unique.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-closures-unique.nll.stderr
@@ -1,0 +1,54 @@
+error[E0500]: closure requires unique access to `x` but it is already borrowed
+  --> $DIR/borrowck-closures-unique.rs:36:14
+   |
+LL |     let c1 = || get(x);
+   |              --     - first borrow occurs due to use of `x` in closure
+   |              |
+   |              borrow occurs here
+LL |     let c2 = || set(x); //~ ERROR closure requires unique access to `x`
+   |              ^^     - second borrow occurs due to use of `x` in closure
+   |              |
+   |              closure construction occurs here
+LL |     c1;
+   |     -- borrow later used here
+
+error[E0500]: closure requires unique access to `x` but it is already borrowed
+  --> $DIR/borrowck-closures-unique.rs:42:14
+   |
+LL |     let c1 = || get(x);
+   |              --     - first borrow occurs due to use of `x` in closure
+   |              |
+   |              borrow occurs here
+LL |     let c2 = || { get(x); set(x); }; //~ ERROR closure requires unique access to `x`
+   |              ^^       - second borrow occurs due to use of `x` in closure
+   |              |
+   |              closure construction occurs here
+LL |     c1;
+   |     -- borrow later used here
+
+error[E0524]: two closures require unique access to `x` at the same time
+  --> $DIR/borrowck-closures-unique.rs:48:14
+   |
+LL |     let c1 = || set(x);
+   |              --     - first borrow occurs due to use of `x` in closure
+   |              |
+   |              first closure is constructed here
+LL |     let c2 = || set(x); //~ ERROR two closures require unique access to `x` at the same time
+   |              ^^     - second borrow occurs due to use of `x` in closure
+   |              |
+   |              second closure is constructed here
+LL |     c1;
+   |     -- borrow later used here
+
+error[E0594]: cannot assign to `x`, as it is not declared as mutable
+  --> $DIR/borrowck-closures-unique.rs:57:38
+   |
+LL | fn e(x: &'static mut isize) {
+   |      - help: consider changing this to be mutable: `mut x`
+LL |     let c1 = |y: &'static mut isize| x = y; //~ ERROR closure cannot assign to immutable argument
+   |                                      ^^^^^ cannot assign
+
+error: aborting due to 4 previous errors
+
+Some errors occurred: E0500, E0524, E0594.
+For more information about an error, try `rustc --explain E0500`.

--- a/src/test/ui/borrowck/borrowck-closures-unique.rs
+++ b/src/test/ui/borrowck/borrowck-closures-unique.rs
@@ -8,13 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-compare-mode-nll
-
 // Tests that a closure which requires mutable access to the referent
 // of an `&mut` requires a "unique" borrow -- that is, the variable to
 // be borrowed (here, `x`) will not be borrowed *mutably*, but
 //  may be *immutable*, but we cannot allow
 // multiple borrows.
+
+
 
 fn get(x: &isize) -> isize {
     *x
@@ -27,25 +27,40 @@ fn set(x: &mut isize) -> isize {
 fn a(x: &mut isize) {
     let c1 = || get(x);
     let c2 = || get(x);
+    c1();
+    c2();
 }
 
 fn b(x: &mut isize) {
     let c1 = || get(x);
     let c2 = || set(x); //~ ERROR closure requires unique access to `x`
+    c1;
 }
 
 fn c(x: &mut isize) {
     let c1 = || get(x);
     let c2 = || { get(x); set(x); }; //~ ERROR closure requires unique access to `x`
+    c1;
 }
 
 fn d(x: &mut isize) {
     let c1 = || set(x);
     let c2 = || set(x); //~ ERROR two closures require unique access to `x` at the same time
+    c1;
 }
 
-fn e(x: &mut isize) {
+// This test was originally encoded in the form shown as `fn f` below.
+// However, since MIR-borrowck and thus NLL takes more control-flow information
+// into account, it was necessary to change the test in order to witness the
+// same (expected) error under both AST-borrowck and NLL.
+fn e(x: &'static mut isize) {
+    let c1 = |y: &'static mut isize| x = y; //~ ERROR closure cannot assign to immutable argument
+    c1;
+}
+
+fn f(x: &'static mut isize) {
     let c1 = || x = panic!(); //~ ERROR closure cannot assign to immutable argument
+    c1;
 }
 
 fn main() {

--- a/src/test/ui/borrowck/borrowck-closures-unique.stderr
+++ b/src/test/ui/borrowck/borrowck-closures-unique.stderr
@@ -1,5 +1,5 @@
 error[E0500]: closure requires unique access to `x` but it is already borrowed
-  --> $DIR/borrowck-closures-unique.rs:34:14
+  --> $DIR/borrowck-closures-unique.rs:36:14
    |
 LL |     let c1 = || get(x);
    |              --     - previous borrow occurs due to use of `x` in closure
@@ -9,11 +9,12 @@ LL |     let c2 = || set(x); //~ ERROR closure requires unique access to `x`
    |              ^^     - borrow occurs due to use of `x` in closure
    |              |
    |              closure construction occurs here
+LL |     c1;
 LL | }
    | - borrow ends here
 
 error[E0500]: closure requires unique access to `x` but it is already borrowed
-  --> $DIR/borrowck-closures-unique.rs:39:14
+  --> $DIR/borrowck-closures-unique.rs:42:14
    |
 LL |     let c1 = || get(x);
    |              --     - previous borrow occurs due to use of `x` in closure
@@ -23,11 +24,12 @@ LL |     let c2 = || { get(x); set(x); }; //~ ERROR closure requires unique acce
    |              ^^       - borrow occurs due to use of `x` in closure
    |              |
    |              closure construction occurs here
+LL |     c1;
 LL | }
    | - borrow ends here
 
 error[E0524]: two closures require unique access to `x` at the same time
-  --> $DIR/borrowck-closures-unique.rs:44:14
+  --> $DIR/borrowck-closures-unique.rs:48:14
    |
 LL |     let c1 = || set(x);
    |              --     - previous borrow occurs due to use of `x` in closure
@@ -37,11 +39,22 @@ LL |     let c2 = || set(x); //~ ERROR two closures require unique access to `x`
    |              ^^     - borrow occurs due to use of `x` in closure
    |              |
    |              second closure is constructed here
+LL |     c1;
 LL | }
    | - borrow from first closure ends here
 
 error[E0595]: closure cannot assign to immutable argument `x`
-  --> $DIR/borrowck-closures-unique.rs:48:14
+  --> $DIR/borrowck-closures-unique.rs:57:14
+   |
+LL |     let c1 = |y: &'static mut isize| x = y; //~ ERROR closure cannot assign to immutable argument
+   |              ^^^^^^^^^^^^^^^^^^^^^^^ cannot borrow mutably
+help: consider removing the `&mut`, as it is an immutable binding to a mutable reference
+   |
+LL |     x //~ ERROR closure cannot assign to immutable argument
+   |     ^
+
+error[E0595]: closure cannot assign to immutable argument `x`
+  --> $DIR/borrowck-closures-unique.rs:62:14
    |
 LL |     let c1 = || x = panic!(); //~ ERROR closure cannot assign to immutable argument
    |              ^^ cannot borrow mutably
@@ -50,7 +63,7 @@ help: consider removing the `&mut`, as it is an immutable binding to a mutable r
 LL |     x //~ ERROR closure cannot assign to immutable argument
    |     ^
 
-error: aborting due to 4 previous errors
+error: aborting due to 5 previous errors
 
 Some errors occurred: E0500, E0524, E0595.
 For more information about an error, try `rustc --explain E0500`.

--- a/src/test/ui/borrowck/borrowck-feature-nll-overrides-migrate.rs
+++ b/src/test/ui/borrowck/borrowck-feature-nll-overrides-migrate.rs
@@ -20,7 +20,7 @@
 
 // revisions: zflag edition
 // [zflag]compile-flags: -Z borrowck=migrate
-// [edition]compile-flags: --edition 2018
+// [edition]edition:2018
 
 #![feature(nll)]
 

--- a/src/test/ui/borrowck/borrowck-migrate-to-nll.rs
+++ b/src/test/ui/borrowck/borrowck-migrate-to-nll.rs
@@ -23,7 +23,7 @@
 
 // revisions: zflag edition
 //[zflag]compile-flags: -Z borrowck=migrate
-//[edition]compile-flags: --edition 2018
+//[edition]edition:2018
 //[zflag] run-pass
 //[edition] run-pass
 

--- a/src/test/ui/borrowck/issue-52967-edition-2018-needs-two-phase-borrows.rs
+++ b/src/test/ui/borrowck/issue-52967-edition-2018-needs-two-phase-borrows.rs
@@ -14,7 +14,7 @@
 
 // revisions: ast zflags edition
 //[zflags]compile-flags: -Z borrowck=migrate -Z two-phase-borrows
-//[edition]compile-flags: --edition 2018
+//[edition]edition:2018
 
 // run-pass
 

--- a/src/test/ui/editions/edition-extern-crate-allowed.rs
+++ b/src/test/ui/editions/edition-extern-crate-allowed.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // aux-build:edition-extern-crate-allowed.rs
-// compile-flags: --edition 2015
+// edition:2015
 // compile-pass
 
 #![warn(rust_2018_idioms)]

--- a/src/test/ui/editions/edition-feature-ok.rs
+++ b/src/test/ui/editions/edition-feature-ok.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags:--edition 2018
 // compile-pass
 
 #![feature(rust_2018_preview)]

--- a/src/test/ui/editions/edition-feature-redundant.rs
+++ b/src/test/ui/editions/edition-feature-redundant.rs
@@ -8,8 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// edition:2018
 // compile-pass
 
 #![feature(rust_2018_preview)]
+//~^ WARN the feature `rust_2018_preview` is included in the Rust 2018 edition
 
 fn main() {}

--- a/src/test/ui/editions/edition-feature-redundant.rs
+++ b/src/test/ui/editions/edition-feature-redundant.rs
@@ -9,19 +9,9 @@
 // except according to those terms.
 
 // edition:2018
-// aux-build:removing-extern-crate.rs
-// run-rustfix
 // compile-pass
 
-#![warn(rust_2018_idioms)]
-#![allow(unused_imports)]
-
-extern crate std as foo;
-extern crate core;
-
-mod another {
-    extern crate std as foo;
-    extern crate std;
-}
+#![feature(rust_2018_preview)]
+//~^ WARN the feature `rust_2018_preview` is included in the Rust 2018 edition
 
 fn main() {}

--- a/src/test/ui/editions/edition-feature-redundant.stderr
+++ b/src/test/ui/editions/edition-feature-redundant.stderr
@@ -1,0 +1,6 @@
+warning[E0705]: the feature `rust_2018_preview` is included in the Rust 2018 edition
+  --> $DIR/edition-feature-redundant.rs:14:12
+   |
+LL | #![feature(rust_2018_preview)]
+   |            ^^^^^^^^^^^^^^^^^
+

--- a/src/test/ui/feature-gates/feature-gate-crate_in_paths.rs
+++ b/src/test/ui/feature-gates/feature-gate-crate_in_paths.rs
@@ -11,5 +11,5 @@
 struct S;
 
 fn main() {
-    let _ = ::crate::S; //~ ERROR `crate` in paths is experimental
+    let _ = crate::S; //~ ERROR `crate` in paths is experimental
 }

--- a/src/test/ui/feature-gates/feature-gate-crate_in_paths.stderr
+++ b/src/test/ui/feature-gates/feature-gate-crate_in_paths.stderr
@@ -1,8 +1,8 @@
 error[E0658]: `crate` in paths is experimental (see issue #45477)
-  --> $DIR/feature-gate-crate_in_paths.rs:14:15
+  --> $DIR/feature-gate-crate_in_paths.rs:14:13
    |
-LL |     let _ = ::crate::S; //~ ERROR `crate` in paths is experimental
-   |               ^^^^^
+LL |     let _ = crate::S; //~ ERROR `crate` in paths is experimental
+   |             ^^^^^
    |
    = help: add #![feature(crate_in_paths)] to the crate attributes to enable
 

--- a/src/test/ui/hashmap-lifetimes.nll.stderr
+++ b/src/test/ui/hashmap-lifetimes.nll.stderr
@@ -4,10 +4,9 @@ error[E0502]: cannot borrow `my_stuff` as mutable because it is also borrowed as
 LL |     let mut it = my_stuff.iter();
    |                  -------- immutable borrow occurs here
 LL |     my_stuff.insert(1, 43); //~ ERROR cannot borrow
-   |     ^^^^^^^^ mutable borrow occurs here
+   |     ^^^^^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
 LL |     it;
-LL | }
-   | - immutable borrow ends here
+   |     -- borrow later used here
 
 error: aborting due to previous error
 

--- a/src/test/ui/hashmap-lifetimes.rs
+++ b/src/test/ui/hashmap-lifetimes.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-compare-mode-nll
+
 
 fn main() {
     let mut my_stuff = std::collections::HashMap::new();
@@ -16,4 +16,5 @@ fn main() {
 
     let mut it = my_stuff.iter();
     my_stuff.insert(1, 43); //~ ERROR cannot borrow
+    it;
 }

--- a/src/test/ui/in-band-lifetimes/elided-lifetimes.fixed
+++ b/src/test/ui/in-band-lifetimes/elided-lifetimes.fixed
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // run-rustfix
-// compile-flags: --edition 2018
+// edition:2018
 
 #![allow(unused)]
 #![deny(elided_lifetimes_in_paths)]

--- a/src/test/ui/in-band-lifetimes/elided-lifetimes.rs
+++ b/src/test/ui/in-band-lifetimes/elided-lifetimes.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // run-rustfix
-// compile-flags: --edition 2018
+// edition:2018
 
 #![allow(unused)]
 #![deny(elided_lifetimes_in_paths)]

--- a/src/test/ui/issues/issue-53348.rs
+++ b/src/test/ui/issues/issue-53348.rs
@@ -1,0 +1,26 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let mut v = vec!["hello", "this", "is", "a", "test"];
+
+    let v2 = Vec::new();
+
+    v.into_iter().map(|s|s.to_owned()).collect::<Vec<_>>();
+
+    let mut a = String::new();
+    for i in v {
+        a = *i.to_string();
+        //~^ ERROR mismatched types
+        //~| NOTE expected struct `std::string::String`, found str
+        //~| NOTE expected type
+        v2.push(a);
+    }
+}

--- a/src/test/ui/issues/issue-53348.stderr
+++ b/src/test/ui/issues/issue-53348.stderr
@@ -1,0 +1,12 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-53348.rs:20:13
+   |
+LL |         a = *i.to_string();
+   |             ^^^^^^^^^^^^^^ expected struct `std::string::String`, found str
+   |
+   = note: expected type `std::string::String`
+              found type `str`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/macros/macro-at-most-once-rep-2015-ques-rep-feature-flag.rs
+++ b/src/test/ui/macros/macro-at-most-once-rep-2015-ques-rep-feature-flag.rs
@@ -12,7 +12,7 @@
 // with the feature flag.
 
 // gate-test-macro_at_most_once_rep
-// compile-flags: --edition=2015
+// edition:2015
 
 #![feature(macro_at_most_once_rep)]
 

--- a/src/test/ui/macros/macro-at-most-once-rep-2015-ques-rep.rs
+++ b/src/test/ui/macros/macro-at-most-once-rep-2015-ques-rep.rs
@@ -10,7 +10,7 @@
 
 // Test behavior of `?` macro _kleene op_ under the 2015 edition. Namely, it doesn't exist.
 
-// compile-flags: --edition=2015
+// edition:2015
 
 macro_rules! bar {
     ($(a)?) => {} //~ERROR expected `*` or `+`

--- a/src/test/ui/macros/macro-at-most-once-rep-2015-ques-sep.rs
+++ b/src/test/ui/macros/macro-at-most-once-rep-2015-ques-sep.rs
@@ -11,7 +11,7 @@
 // Test behavior of `?` macro _separator_ under the 2015 edition. Namely, `?` can be used as a
 // separator, but you get a migration warning for the edition.
 
-// compile-flags: --edition=2015
+// edition:2015
 // compile-pass
 
 #![warn(rust_2018_compatibility)]

--- a/src/test/ui/macros/macro-at-most-once-rep-2018-feature-gate.rs
+++ b/src/test/ui/macros/macro-at-most-once-rep-2018-feature-gate.rs
@@ -11,7 +11,7 @@
 // Feature gate test for macro_at_most_once_rep under 2018 edition.
 
 // gate-test-macro_at_most_once_rep
-// compile-flags: --edition=2018
+// edition:2018
 
 macro_rules! foo {
     ($(a)?) => {}

--- a/src/test/ui/macros/macro-at-most-once-rep-2018.rs
+++ b/src/test/ui/macros/macro-at-most-once-rep-2018.rs
@@ -10,7 +10,7 @@
 
 // Tests that `?` is a Kleene op and not a macro separator in the 2018 edition.
 
-// compile-flags: --edition=2018
+// edition:2018
 
 #![feature(macro_at_most_once_rep)]
 

--- a/src/test/ui/nll/issue-27868.rs
+++ b/src/test/ui/nll/issue-27868.rs
@@ -1,0 +1,40 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Regression test for issue #27868
+
+#![feature(nll)]
+
+use std::ops::AddAssign;
+
+struct MyVec<T>(Vec<T>);
+
+impl <T> Drop for MyVec<T> {
+    fn drop(&mut self) {
+        println!("Being dropped.");
+    }
+}
+
+impl<T> AddAssign<T> for MyVec<T> {
+    fn add_assign(&mut self, _elem: T) {
+        println!("In add_assign.");
+    }
+}
+
+fn main() {
+    let mut vec = MyVec(vec![0]);
+    let mut vecvec = vec![vec];
+
+    vecvec[0] += {
+        vecvec = vec![];
+        //~^ ERROR cannot assign to `vecvec` because it is borrowed [E0506]
+        0
+    };
+}

--- a/src/test/ui/nll/issue-27868.stderr
+++ b/src/test/ui/nll/issue-27868.stderr
@@ -1,0 +1,18 @@
+error[E0506]: cannot assign to `vecvec` because it is borrowed
+  --> $DIR/issue-27868.rs:36:9
+   |
+LL |       vecvec[0] += {
+   |       ------
+   |       |
+   |  _____borrow of `vecvec` occurs here
+   | |
+LL | |         vecvec = vec![];
+   | |         ^^^^^^ assignment to borrowed `vecvec` occurs here
+LL | |         //~^ ERROR cannot assign to `vecvec` because it is borrowed [E0506]
+LL | |         0
+LL | |     };
+   | |_____- borrow later used here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0506`.

--- a/src/test/ui/nll/issue-30104.rs
+++ b/src/test/ui/nll/issue-30104.rs
@@ -1,0 +1,52 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Regression test for #30104
+
+// compile-pass
+
+#![feature(nll)]
+
+use std::ops::{Deref, DerefMut};
+
+fn box_two_field(v: &mut Box<(i32, i32)>) {
+    let _a = &mut v.0;
+    let _b = &mut v.1;
+}
+
+fn box_destructure(v: &mut Box<(i32, i32)>) {
+    let (ref mut _head, ref mut _tail) = **v;
+}
+
+struct Wrap<T>(T);
+
+impl<T> Deref for Wrap<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for Wrap<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.0
+    }
+}
+
+fn smart_two_field(v: &mut Wrap<(i32, i32)>) {
+    let _a = &mut v.0;
+    let _b = &mut v.1;
+}
+
+fn smart_destructure(v: &mut Wrap<(i32, i32)>) {
+    let (ref mut _head, ref mut _tail) = **v;
+}
+
+fn main() {}

--- a/src/test/ui/nll/issue-48697.rs
+++ b/src/test/ui/nll/issue-48697.rs
@@ -1,0 +1,24 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Regression test for #48697
+
+// compile-pass
+
+#![feature(nll)]
+
+fn foo(x: &i32) -> &i32 {
+    let z = 4;
+    let f = &|y| y;
+    let k = f(&z);
+    f(x)
+}
+
+fn main() {}

--- a/src/test/ui/removing-extern-crate.fixed
+++ b/src/test/ui/removing-extern-crate.fixed
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: --edition 2018
+// edition:2018
 // aux-build:removing-extern-crate.rs
 // run-rustfix
 // compile-pass

--- a/src/test/ui/removing-extern-crate.rs
+++ b/src/test/ui/removing-extern-crate.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: --edition 2018
+// edition:2018
 // aux-build:removing-extern-crate.rs
 // run-rustfix
 // compile-pass

--- a/src/test/ui/rfc-2126-crate-paths/crate-path-non-absolute.rs
+++ b/src/test/ui/rfc-2126-crate-paths/crate-path-non-absolute.rs
@@ -15,6 +15,7 @@ struct S;
 pub mod m {
     fn f() {
         let s = ::m::crate::S; //~ ERROR failed to resolve
+        let s1 = ::crate::S; //~ ERROR failed to resolve
         let s2 = crate::S; // no error
     }
 }

--- a/src/test/ui/rfc-2126-crate-paths/crate-path-non-absolute.stderr
+++ b/src/test/ui/rfc-2126-crate-paths/crate-path-non-absolute.stderr
@@ -1,9 +1,15 @@
-error[E0433]: failed to resolve. Could not find `crate` in `m`
+error[E0433]: failed to resolve. `crate` in paths can only be used in start position
   --> $DIR/crate-path-non-absolute.rs:17:22
    |
 LL |         let s = ::m::crate::S; //~ ERROR failed to resolve
-   |                      ^^^^^ Could not find `crate` in `m`
+   |                      ^^^^^ `crate` in paths can only be used in start position
 
-error: aborting due to previous error
+error[E0433]: failed to resolve. global paths cannot start with `crate`
+  --> $DIR/crate-path-non-absolute.rs:18:20
+   |
+LL |         let s1 = ::crate::S; //~ ERROR failed to resolve
+   |                    ^^^^^ global paths cannot start with `crate`
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0433`.

--- a/src/test/ui/rfc-2126-crate-paths/keyword-crate-as-identifier.rs
+++ b/src/test/ui/rfc-2126-crate-paths/keyword-crate-as-identifier.rs
@@ -11,5 +11,6 @@
 #![feature(crate_in_paths)]
 
 fn main() {
-    let crate = 0; //~ ERROR failed to resolve. `crate` in paths can only be used in start position
+    let crate = 0;
+    //~^ ERROR expected unit struct/variant or constant, found module `crate`
 }

--- a/src/test/ui/rfc-2126-crate-paths/keyword-crate-as-identifier.stderr
+++ b/src/test/ui/rfc-2126-crate-paths/keyword-crate-as-identifier.stderr
@@ -1,9 +1,9 @@
-error[E0433]: failed to resolve. `crate` in paths can only be used in start position
+error[E0532]: expected unit struct/variant or constant, found module `crate`
   --> $DIR/keyword-crate-as-identifier.rs:14:9
    |
-LL |     let crate = 0; //~ ERROR failed to resolve. `crate` in paths can only be used in start position
-   |         ^^^^^ `crate` in paths can only be used in start position
+LL |     let crate = 0;
+   |         ^^^^^ not a unit struct/variant or constant
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0433`.
+For more information about this error, try `rustc --explain E0532`.

--- a/src/test/ui/rust-2018/async-ident-allowed.rs
+++ b/src/test/ui/rust-2018/async-ident-allowed.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: --edition 2015
+// edition:2015
 
 #![deny(rust_2018_compatibility)]
 

--- a/src/test/ui/rust-2018/edition-lint-paths.fixed
+++ b/src/test/ui/rust-2018/edition-lint-paths.fixed
@@ -68,7 +68,7 @@ fn main() {
     //~^ ERROR absolute
     //~| WARN this was previously accepted
     let x = bar::Bar;
-    let x = ::crate::bar::Bar;
+    let x = crate::bar::Bar;
     let x = self::bar::Bar;
     foo::test();
 

--- a/src/test/ui/rust-2018/edition-lint-paths.rs
+++ b/src/test/ui/rust-2018/edition-lint-paths.rs
@@ -68,7 +68,7 @@ fn main() {
     //~^ ERROR absolute
     //~| WARN this was previously accepted
     let x = bar::Bar;
-    let x = ::crate::bar::Bar;
+    let x = crate::bar::Bar;
     let x = self::bar::Bar;
     foo::test();
 

--- a/src/test/ui/rust-2018/extern-crate-idiomatic-in-2018.fixed
+++ b/src/test/ui/rust-2018/extern-crate-idiomatic-in-2018.fixed
@@ -10,12 +10,11 @@
 
 // aux-build:edition-lint-paths.rs
 // run-rustfix
-// compile-flags:--edition 2018
+// edition:2018
 
 // The "normal case". Ideally we would remove the `extern crate` here,
 // but we don't.
 
-#![feature(rust_2018_preview)]
 #![deny(rust_2018_idioms)]
 #![allow(dead_code)]
 

--- a/src/test/ui/rust-2018/extern-crate-idiomatic-in-2018.fixed
+++ b/src/test/ui/rust-2018/extern-crate-idiomatic-in-2018.fixed
@@ -10,7 +10,7 @@
 
 // aux-build:edition-lint-paths.rs
 // run-rustfix
-// compile-flags:--edition 2018
+// edition:2018
 
 // The "normal case". Ideally we would remove the `extern crate` here,
 // but we don't.

--- a/src/test/ui/rust-2018/extern-crate-idiomatic-in-2018.fixed
+++ b/src/test/ui/rust-2018/extern-crate-idiomatic-in-2018.fixed
@@ -15,7 +15,6 @@
 // The "normal case". Ideally we would remove the `extern crate` here,
 // but we don't.
 
-#![feature(rust_2018_preview)]
 #![deny(rust_2018_idioms)]
 #![allow(dead_code)]
 

--- a/src/test/ui/rust-2018/extern-crate-idiomatic-in-2018.rs
+++ b/src/test/ui/rust-2018/extern-crate-idiomatic-in-2018.rs
@@ -10,12 +10,11 @@
 
 // aux-build:edition-lint-paths.rs
 // run-rustfix
-// compile-flags:--edition 2018
+// edition:2018
 
 // The "normal case". Ideally we would remove the `extern crate` here,
 // but we don't.
 
-#![feature(rust_2018_preview)]
 #![deny(rust_2018_idioms)]
 #![allow(dead_code)]
 

--- a/src/test/ui/rust-2018/extern-crate-idiomatic-in-2018.rs
+++ b/src/test/ui/rust-2018/extern-crate-idiomatic-in-2018.rs
@@ -10,7 +10,7 @@
 
 // aux-build:edition-lint-paths.rs
 // run-rustfix
-// compile-flags:--edition 2018
+// edition:2018
 
 // The "normal case". Ideally we would remove the `extern crate` here,
 // but we don't.

--- a/src/test/ui/rust-2018/extern-crate-idiomatic-in-2018.rs
+++ b/src/test/ui/rust-2018/extern-crate-idiomatic-in-2018.rs
@@ -15,7 +15,6 @@
 // The "normal case". Ideally we would remove the `extern crate` here,
 // but we don't.
 
-#![feature(rust_2018_preview)]
 #![deny(rust_2018_idioms)]
 #![allow(dead_code)]
 

--- a/src/test/ui/rust-2018/extern-crate-idiomatic-in-2018.stderr
+++ b/src/test/ui/rust-2018/extern-crate-idiomatic-in-2018.stderr
@@ -1,18 +1,18 @@
 error: unused extern crate
-  --> $DIR/extern-crate-idiomatic-in-2018.rs:22:1
+  --> $DIR/extern-crate-idiomatic-in-2018.rs:21:1
    |
 LL | extern crate edition_lint_paths;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove it
    |
 note: lint level defined here
-  --> $DIR/extern-crate-idiomatic-in-2018.rs:19:9
+  --> $DIR/extern-crate-idiomatic-in-2018.rs:18:9
    |
 LL | #![deny(rust_2018_idioms)]
    |         ^^^^^^^^^^^^^^^^
    = note: #[deny(unused_extern_crates)] implied by #[deny(rust_2018_idioms)]
 
 error: `extern crate` is not idiomatic in the new edition
-  --> $DIR/extern-crate-idiomatic-in-2018.rs:25:1
+  --> $DIR/extern-crate-idiomatic-in-2018.rs:24:1
    |
 LL | extern crate edition_lint_paths as bar;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: convert it to a `use`

--- a/src/test/ui/rust-2018/issue-52202-use-suggestions.rs
+++ b/src/test/ui/rust-2018/issue-52202-use-suggestions.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: --edition 2018
+// edition:2018
 
 // The local `use` suggestion should start with `crate::` (but the
 // standard-library suggestions should not, obviously).

--- a/src/test/ui/unboxed-closures/unboxed-closure-region.nll.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-region.nll.stderr
@@ -4,12 +4,11 @@ error[E0597]: `x` does not live long enough
 LL |         || x //~ ERROR `x` does not live long enough
    |         -- ^ borrowed value does not live long enough
    |         |
-   |         capture occurs here
+   |         value captured here
 LL |     };
-   |     - borrowed value only lives until here
+   |     - `x` dropped here while still borrowed
 LL |     _f;
-LL | }
-   | - borrowed value needs to live until here
+   |     -- borrow later used here
 
 error: aborting due to previous error
 

--- a/src/test/ui/unboxed-closures/unboxed-closure-region.rs
+++ b/src/test/ui/unboxed-closures/unboxed-closure-region.rs
@@ -8,13 +8,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-compare-mode-nll
-
 // Test that an unboxed closure that captures a free variable by
 // reference cannot escape the region of that variable.
+
+
 fn main() {
     let _f = {
         let x = 0;
         || x //~ ERROR `x` does not live long enough
     };
+    _f;
 }

--- a/src/test/ui/unboxed-closures/unboxed-closures-borrow-conflict.nll.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-borrow-conflict.nll.stderr
@@ -1,0 +1,15 @@
+error[E0503]: cannot use `x` because it was mutably borrowed
+  --> $DIR/unboxed-closures-borrow-conflict.rs:19:14
+   |
+LL |     let f = || x += 1;
+   |             -- - borrow occurs due to use of `x` in closure
+   |             |
+   |             borrow of `x` occurs here
+LL |     let _y = x; //~ ERROR cannot use `x` because it was mutably borrowed
+   |              ^ use of borrowed `x`
+LL |     f;
+   |     - borrow later used here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0503`.

--- a/src/test/ui/unboxed-closures/unboxed-closures-borrow-conflict.rs
+++ b/src/test/ui/unboxed-closures/unboxed-closures-borrow-conflict.rs
@@ -8,13 +8,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-compare-mode-nll
-
 // Test that an unboxed closure that mutates a free variable will
 // cause borrow conflicts.
+
+
 
 fn main() {
     let mut x = 0;
     let f = || x += 1;
     let _y = x; //~ ERROR cannot use `x` because it was mutably borrowed
+    f;
 }


### PR DESCRIPTION
Successful merges:

 - #52858 (Implement Iterator::size_hint for Elaborator.)
 - #53321 (Fix usage of `wasm_target_feature`)
 - #53326 ([nll] add regression test for issue #27868)
 - #53347 (rustc_resolve: don't allow paths starting with `::crate`.)
 - #53349 ([nll] add tests for #48697 and #30104)
 - #53357 (Pretty print btreemap for GDB)
 - #53358 (`{to,from}_{ne,le,be}_bytes` for unsigned integer types)
 - #53406 (Do not suggest conversion method that is already there)
 - #53407 (make more ported compile fail tests more robust w.r.t. NLL)
 - #53413 (Warn that `#![feature(rust_2018_preview)]` is implied when the edition is set to Rust 2018.)
 - #53434 (wasm: Remove --strip-debug argument to LLD)

Failed merges:


r? @ghost