### PR TITLE
Make LocalWaker::new a const fn

### DIFF
--- a/src/libcore/task/wake.rs
+++ b/src/libcore/task/wake.rs
@@ -119,7 +119,7 @@ impl LocalWaker {
     /// For this function to be used safely, it must be sound to call `inner.wake_local()`
     /// on the current thread.
     #[inline]
-    pub unsafe fn new(inner: NonNull<dyn UnsafeWake>) -> Self {
+    pub const unsafe fn new(inner: NonNull<dyn UnsafeWake>) -> Self {
         LocalWaker { inner }
     }
 


### PR DESCRIPTION
This is mostly not that useful, except for `futures-test` where we want to have statics available for the more trivial test wakers for better ergonomics.

r? @cramertj 