### PR TITLE
Warn about metadata loader errors

### DIFF
--- a/src/librustc_metadata/locator.rs
+++ b/src/librustc_metadata/locator.rs
@@ -617,7 +617,7 @@ impl<'a> Context<'a> {
                         }
                     }
                     Err(err) => {
-                        info!("no metadata found: {}", err);
+                        warn!("no metadata found: {}", err);
                         continue;
                     }
                 };


### PR DESCRIPTION
Output when writing corrupting to libcore.rlib

```
warning: no metadata found: failed to read rlib metadata in '/Users/bjorn/Documents/rust_fork/build/x86_64-apple-darwin/stage1-std/x86_64-apple-darwin/release/deps/libcore-857d662d379c5d0c.rlib': File too small to be an archive

error[E0463]: can't find crate for `core`

error: aborting due to previous error
```

Fixes #53381