### PR TITLE
Exec gdb/lldb in rust-{gdb/lldb} wrapper scripts

### DIFF
--- a/src/etc/rust-gdb
+++ b/src/etc/rust-gdb
@@ -20,7 +20,7 @@ GDB_PYTHON_MODULE_DIRECTORY="$RUSTC_SYSROOT/lib/rustlib/etc"
 # Set the environment variable `RUST_GDB` to overwrite the call to a
 # different/specific command (defaults to `gdb`).
 RUST_GDB="${RUST_GDB:-gdb}"
-PYTHONPATH="$PYTHONPATH:$GDB_PYTHON_MODULE_DIRECTORY" ${RUST_GDB} \
+PYTHONPATH="$PYTHONPATH:$GDB_PYTHON_MODULE_DIRECTORY" exec ${RUST_GDB} \
   --directory="$GDB_PYTHON_MODULE_DIRECTORY" \
   -iex "add-auto-load-safe-path $GDB_PYTHON_MODULE_DIRECTORY" \
   "$@"

--- a/src/etc/rust-lldb
+++ b/src/etc/rust-lldb
@@ -23,19 +23,16 @@ display the contents of local variables!"
     echo "***"
 fi
 
-# Create a tempfile containing the LLDB script we want to execute on startup
-TMPFILE=`mktemp /tmp/rust-lldb-commands.XXXXXX`
-
-# Make sure to delete the tempfile no matter what
-trap "rm -f $TMPFILE; exit" INT TERM EXIT
-
 # Find out where to look for the pretty printer Python module
 RUSTC_SYSROOT=`rustc --print sysroot`
 
-# Write the LLDB script to the tempfile
-echo "command script import \"$RUSTC_SYSROOT/lib/rustlib/etc/lldb_rust_formatters.py\"" >> $TMPFILE
-echo "type summary add --no-value --python-function lldb_rust_formatters.print_val -x \".*\" --category Rust" >> $TMPFILE
-echo "type category enable Rust" >> $TMPFILE
+# Prepare commands that will be loaded before any file on the command line has been loaded
+script_import="command script import \"$RUSTC_SYSROOT/lib/rustlib/etc/lldb_rust_formatters.py\""
+category_definition="type summary add --no-value --python-function lldb_rust_formatters.print_val -x \".*\" --category Rust"
+category_enable="type category enable Rust"
 
-# Call LLDB with the script added to the argument list
-lldb --source-before-file="$TMPFILE" "$@"
+# Call LLDB with the commands added to the argument list
+lldb --one-line-before-file="$script_import" \
+    --one-line-before-file="$category_definition" \
+    --one-line-before-file="$category_enable" \
+    "$@"

--- a/src/etc/rust-lldb
+++ b/src/etc/rust-lldb
@@ -32,7 +32,7 @@ category_definition="type summary add --no-value --python-function lldb_rust_for
 category_enable="type category enable Rust"
 
 # Call LLDB with the commands added to the argument list
-lldb --one-line-before-file="$script_import" \
+exec lldb --one-line-before-file="$script_import" \
     --one-line-before-file="$category_definition" \
     --one-line-before-file="$category_enable" \
     "$@"


### PR DESCRIPTION
This way, the process we get by executing `rust-gdb` or `rust-lldb` (eventually) is an actual `gdb` or `lldb` process and behaves accordingly. Previously (and at least to me unexpectedly) it was just a script waiting for the debugger to exit. Sending a signal (e.g. SIGINT) to the spawned process did therefore not affect the debugger process (which was just a child of the wrapper script).

In order to work around that we `exec` (according to [this](http://pubs.opengroup.org/onlinepubs/009695399/utilities/exec.html) part of the posix shell) and replace the script process with the debugger in the last line of the script. The lldb script had to be modified to not pass the configuration commands via a script file (which in my opinion is cleaner anyway).
