### PR TITLE
Don't emit "unused extern crate" warnings for `extern crate foo as _;`

### DIFF
--- a/src/test/ui/rfc-2166-underscore-imports/basic.rs
+++ b/src/test/ui/rfc-2166-underscore-imports/basic.rs
@@ -30,7 +30,7 @@ mod m {
 mod unused {
     use m::Tr1 as _; //~ WARN unused import
     use S as _; //~ WARN unused import
-    extern crate core as _; //~ WARN unused extern crate
+    extern crate core as _; // OK
 }
 
 mod outer {

--- a/src/test/ui/rfc-2166-underscore-imports/basic.stderr
+++ b/src/test/ui/rfc-2166-underscore-imports/basic.stderr
@@ -16,15 +16,3 @@ warning: unused import: `S as _`
 LL |     use S as _; //~ WARN unused import
    |         ^^^^^^
 
-warning: unused extern crate
-  --> $DIR/basic.rs:33:5
-   |
-LL |     extern crate core as _; //~ WARN unused extern crate
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ help: remove it
-   |
-note: lint level defined here
-  --> $DIR/basic.rs:14:25
-   |
-LL | #![warn(unused_imports, unused_extern_crates)]
-   |                         ^^^^^^^^^^^^^^^^^^^^
-


### PR DESCRIPTION
When importing a crate and renaming it to an underscore-prefixed name,
suppress "unused extern crate" warnings (but not idiom lints).