### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/src/librustc_borrowck/borrowck/unused.rs
+++ b/src/librustc_borrowck/borrowck/unused.rs
@@ -13,6 +13,7 @@ use rustc::hir::{self, HirId};
 use rustc::lint::builtin::UNUSED_MUT;
 use rustc::ty;
 use rustc::util::nodemap::{FxHashMap, FxHashSet};
+use errors::Applicability;
 use std::slice;
 use syntax::ptr::P;
 
@@ -83,7 +84,11 @@ impl<'a, 'tcx> UnusedMutCx<'a, 'tcx> {
                                      hir_id,
                                      span,
                                      "variable does not need to be mutable")
-                .span_suggestion_short(mut_span, "remove this `mut`", "".to_owned())
+                .span_suggestion_short_with_applicability(
+                    mut_span,
+                    "remove this `mut`",
+                    "".to_owned(),
+                    Applicability::MachineApplicable)
                 .emit();
         }
     }

--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -24,7 +24,7 @@ use rustc::mir::{Terminator, TerminatorKind};
 use rustc::ty::query::Providers;
 use rustc::ty::{self, ParamEnv, TyCtxt, Ty};
 
-use rustc_errors::{Diagnostic, DiagnosticBuilder, Level};
+use rustc_errors::{Applicability, Diagnostic, DiagnosticBuilder, Level};
 use rustc_data_structures::graph::dominators::Dominators;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_data_structures::indexed_set::IdxSetBuf;
@@ -324,7 +324,11 @@ fn do_mir_borrowck<'a, 'gcx, 'tcx>(
                 span,
                 "variable does not need to be mutable",
             );
-            err.span_suggestion_short(mut_span, "remove this `mut`", "".to_owned());
+            err.span_suggestion_short_with_applicability(
+                mut_span,
+                "remove this `mut`",
+                "".to_owned(),
+                Applicability::MachineApplicable);
 
             err.buffer(&mut mbcx.errors_buffer);
         }

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -24,7 +24,7 @@ use util::nodemap::FxHashSet;
 
 use syntax::ast;
 use syntax::util::lev_distance::find_best_match_for_name;
-use errors::DiagnosticBuilder;
+use errors::{Applicability, DiagnosticBuilder};
 use syntax_pos::{Span, FileName};
 
 
@@ -406,11 +406,12 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 }
                 if static_sources.len() == 1 {
                     if let Some(expr) = rcvr_expr {
-                        err.span_suggestion(expr.span.to(span),
+                        err.span_suggestion_with_applicability(expr.span.to(span),
                                             "use associated function syntax instead",
                                             format!("{}::{}",
                                                     self.ty_to_string(actual),
-                                                    item_name));
+                                                    item_name),
+                                            Applicability::MachineApplicable);
                     } else {
                         err.help(&format!("try with `{}::{}`",
                                           self.ty_to_string(actual), item_name));

--- a/src/librustc_typeck/check_unused.rs
+++ b/src/librustc_typeck/check_unused.rs
@@ -11,6 +11,7 @@
 use lint;
 use rustc::ty::TyCtxt;
 
+use errors::Applicability;
 use syntax::ast;
 use syntax_pos::Span;
 
@@ -138,7 +139,11 @@ fn unused_crates_lint<'tcx>(tcx: TyCtxt<'_, 'tcx, 'tcx>) {
             let id = tcx.hir.hir_to_node_id(hir_id);
             let msg = "unused extern crate";
             tcx.struct_span_lint_node(lint, id, span, msg)
-                .span_suggestion_short(span, "remove it", "".to_string())
+                .span_suggestion_short_with_applicability(
+                    span,
+                    "remove it",
+                    "".to_string(),
+                    Applicability::MachineApplicable)
                 .emit();
             continue;
         }

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -52,6 +52,8 @@
 
     var themesWidth = null;
 
+    var titleBeforeSearch = document.title;
+
     if (!String.prototype.startsWith) {
         String.prototype.startsWith = function(searchString, position) {
             position = position || 0;
@@ -267,6 +269,7 @@
             ev.preventDefault();
             addClass(search, "hidden");
             removeClass(document.getElementById("main"), "hidden");
+            document.title = titleBeforeSearch;
         }
         defocusSearchBar();
     }

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -273,7 +273,8 @@ impl Builder {
         self.clippy_version = self.version("clippy", "x86_64-unknown-linux-gnu");
         self.rustfmt_version = self.version("rustfmt", "x86_64-unknown-linux-gnu");
         self.llvm_tools_version = self.version("llvm-tools", "x86_64-unknown-linux-gnu");
-        self.lldb_version = self.version("lldb", "x86_64-unknown-linux-gnu");
+        // lldb is only built for macOS.
+        self.lldb_version = self.version("lldb", "x86_64-apple-darwin");
 
         self.rust_git_commit_hash = self.git_commit_hash("rust", "x86_64-unknown-linux-gnu");
         self.cargo_git_commit_hash = self.git_commit_hash("cargo", "x86_64-unknown-linux-gnu");


### PR DESCRIPTION
Successful merges:

 - #53405 (restore the page title after escaping out of a search)
 - #53418 (Mark some suggestions as MachineApplicable)
 - #53452 (Change target triple used to check for lldb in build-manifest)

Failed merges:

 - #53472 (Use FxHash{Map,Set} instead of the default Hash{Map,Set} everywhere in rustc.)
 - #53479 (Don't emit "unused extern crate" warnings for `extern crate foo as _;`)

r? @ghost