### PR TITLE
Use smaller span for adjustments on block expressions

### DIFF
--- a/src/librustc_mir/hair/cx/expr.rs
+++ b/src/librustc_mir/hair/cx/expr.rs
@@ -78,7 +78,7 @@ fn apply_adjustment<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
                                     mut expr: Expr<'tcx>,
                                     adjustment: &Adjustment<'tcx>)
                                     -> Expr<'tcx> {
-    let Expr { temp_lifetime, span, .. } = expr;
+    let Expr { temp_lifetime, mut span, .. } = expr;
     let kind = match adjustment.kind {
         Adjust::ReifyFnPointer => {
             ExprKind::ReifyFnPointer { source: expr.to_ref() }
@@ -96,6 +96,25 @@ fn apply_adjustment<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
             ExprKind::Cast { source: expr.to_ref() }
         }
         Adjust::Deref(None) => {
+            // Adjust the span from the block, to the last expression of the
+            // block. This is a better span when returning a mutable reference
+            // with too short a lifetime. The error message will use the span
+            // from the assignment to the return place, which should only point
+            // at the returned value, not the entire function body.
+            //
+            // fn return_short_lived<'a>(x: &'a mut i32) -> &'static mut i32 {
+            //      x
+            //   // ^ error message points at this expression.
+            // }
+            //
+            // We don't need to do this adjustment in the next match arm since
+            // deref coercions always start with a built-in deref.
+            if let ExprKind::Block { body } = expr.kind {
+                if let Some(ref last_expr) = body.expr {
+                    span = last_expr.span;
+                    expr.span = span;
+                }
+            }
             ExprKind::Deref { arg: expr.to_ref() }
         }
         Adjust::Deref(Some(deref)) => {

--- a/src/librustc_mir/hair/cx/expr.rs
+++ b/src/librustc_mir/hair/cx/expr.rs
@@ -199,6 +199,13 @@ fn apply_adjustment<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
             ExprKind::Use { source: cast_expr.to_ref() }
         }
         Adjust::Unsize => {
+            // See the above comment for Adjust::Deref
+            if let ExprKind::Block { body } = expr.kind {
+                if let Some(ref last_expr) = body.expr {
+                    span = last_expr.span;
+                    expr.span = span;
+                }
+            }
             ExprKind::Unsize { source: expr.to_ref() }
         }
     };

--- a/src/test/ui/issues/issue-17718-const-bad-values.rs
+++ b/src/test/ui/issues/issue-17718-const-bad-values.rs
@@ -15,6 +15,5 @@ static mut S: usize = 3;
 const C2: &'static mut usize = unsafe { &mut S };
 //~^ ERROR: constants cannot refer to statics
 //~| ERROR: references in constants may only refer to immutable values
-//~| ERROR: references in constants may only refer to immutable values
 
 fn main() {}

--- a/src/test/ui/issues/issue-17718-const-bad-values.stderr
+++ b/src/test/ui/issues/issue-17718-const-bad-values.stderr
@@ -16,13 +16,7 @@ error[E0017]: references in constants may only refer to immutable values
 LL | const C2: &'static mut usize = unsafe { &mut S };
    |                                         ^^^^^^ constants require immutable values
 
-error[E0017]: references in constants may only refer to immutable values
-  --> $DIR/issue-17718-const-bad-values.rs:15:32
-   |
-LL | const C2: &'static mut usize = unsafe { &mut S };
-   |                                ^^^^^^^^^^^^^^^^^ constants require immutable values
-
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 
 Some errors occurred: E0013, E0017.
 For more information about an error, try `rustc --explain E0013`.

--- a/src/test/ui/issues/issue-46471-1.stderr
+++ b/src/test/ui/issues/issue-46471-1.stderr
@@ -12,16 +12,13 @@ LL | }
 error[E0597]: `z` does not live long enough (Mir)
   --> $DIR/issue-46471-1.rs:16:9
    |
-LL |       let y = {
-   |  _____________-
-LL | |         let mut z = 0;
-LL | |         &mut z
-   | |         ^^^^^^ borrowed value does not live long enough
-LL | |     };
-   | |     -
-   | |     |
-   | |_____`z` dropped here while still borrowed
-   |       borrow later used here
+LL |         &mut z
+   |         ^^^^^^
+   |         |
+   |         borrowed value does not live long enough
+   |         borrow later used here
+LL |     };
+   |     - `z` dropped here while still borrowed
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/match/match-ref-mut-invariance.nll.stderr
+++ b/src/test/ui/match/match-ref-mut-invariance.nll.stderr
@@ -5,17 +5,14 @@ LL |         match self.0 { ref mut x => x } //~ ERROR mismatched types
    |                                     ^
 
 error: unsatisfied lifetime constraints
-  --> $DIR/match-ref-mut-invariance.rs:19:49
+  --> $DIR/match-ref-mut-invariance.rs:20:9
    |
-LL |   impl<'b> S<'b> {
-   |        -- lifetime `'b` defined here
-LL |       fn bar<'a>(&'a mut self) -> &'a mut &'a i32 {
-   |  ____________--___________________________________^
-   | |            |
-   | |            lifetime `'a` defined here
-LL | |         match self.0 { ref mut x => x } //~ ERROR mismatched types
-LL | |     }
-   | |_____^ returning this value requires that `'a` must outlive `'b`
+LL | impl<'b> S<'b> {
+   |      -- lifetime `'b` defined here
+LL |     fn bar<'a>(&'a mut self) -> &'a mut &'a i32 {
+   |            -- lifetime `'a` defined here
+LL |         match self.0 { ref mut x => x } //~ ERROR mismatched types
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ returning this value requires that `'a` must outlive `'b`
 
 error: aborting due to previous error
 

--- a/src/test/ui/match/match-ref-mut-let-invariance.nll.stderr
+++ b/src/test/ui/match/match-ref-mut-let-invariance.nll.stderr
@@ -5,18 +5,15 @@ LL |         x //~ ERROR mismatched types
    |         ^
 
 error: unsatisfied lifetime constraints
-  --> $DIR/match-ref-mut-let-invariance.rs:19:49
+  --> $DIR/match-ref-mut-let-invariance.rs:21:9
    |
-LL |   impl<'b> S<'b> {
-   |        -- lifetime `'b` defined here
-LL |       fn bar<'a>(&'a mut self) -> &'a mut &'a i32 {
-   |  ____________--___________________________________^
-   | |            |
-   | |            lifetime `'a` defined here
-LL | |         let ref mut x = self.0;
-LL | |         x //~ ERROR mismatched types
-LL | |     }
-   | |_____^ returning this value requires that `'a` must outlive `'b`
+LL | impl<'b> S<'b> {
+   |      -- lifetime `'b` defined here
+LL |     fn bar<'a>(&'a mut self) -> &'a mut &'a i32 {
+   |            -- lifetime `'a` defined here
+LL |         let ref mut x = self.0;
+LL |         x //~ ERROR mismatched types
+   |         ^ returning this value requires that `'a` must outlive `'b`
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/mir_check_cast_unsize.rs
+++ b/src/test/ui/nll/mir_check_cast_unsize.rs
@@ -15,9 +15,9 @@
 use std::fmt::Debug;
 
 fn bar<'a>(x: &'a u32) -> &'static dyn Debug {
-    //~^ ERROR unsatisfied lifetime constraints
     x
-    //~^ WARNING not reporting region error due to nll
+    //~^ ERROR unsatisfied lifetime constraints
+    //~| WARNING not reporting region error due to nll
 }
 
 fn main() {}

--- a/src/test/ui/nll/mir_check_cast_unsize.stderr
+++ b/src/test/ui/nll/mir_check_cast_unsize.stderr
@@ -1,21 +1,16 @@
 warning: not reporting region error due to nll
-  --> $DIR/mir_check_cast_unsize.rs:19:5
+  --> $DIR/mir_check_cast_unsize.rs:18:5
    |
 LL |     x
    |     ^
 
 error: unsatisfied lifetime constraints
-  --> $DIR/mir_check_cast_unsize.rs:17:46
+  --> $DIR/mir_check_cast_unsize.rs:18:5
    |
-LL |   fn bar<'a>(x: &'a u32) -> &'static dyn Debug {
-   |  ________--____________________________________^
-   | |        |
-   | |        lifetime `'a` defined here
-LL | |     //~^ ERROR unsatisfied lifetime constraints
-LL | |     x
-LL | |     //~^ WARNING not reporting region error due to nll
-LL | | }
-   | |_^ returning this value requires that `'a` must outlive `'static`
+LL | fn bar<'a>(x: &'a u32) -> &'static dyn Debug {
+   |        -- lifetime `'a` defined here
+LL |     x
+   |     ^ returning this value requires that `'a` must outlive `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/object-lifetime/object-lifetime-default-elision.nll.stderr
+++ b/src/test/ui/object-lifetime/object-lifetime-default-elision.nll.stderr
@@ -5,20 +5,15 @@ LL |     ss
    |     ^^
 
 error: unsatisfied lifetime constraints
-  --> $DIR/object-lifetime-default-elision.rs:64:53
+  --> $DIR/object-lifetime-default-elision.rs:81:5
    |
-LL |   fn load3<'a,'b>(ss: &'a SomeTrait) -> &'b SomeTrait {
-   |  __________--_--______________________________________^
-   | |          |  |
-   | |          |  lifetime `'b` defined here
-   | |          lifetime `'a` defined here
-LL | |     // Under old rules, the fully elaborated types of input/output were:
-LL | |     //
-LL | |     // for<'a,'b,'c>fn(&'a (SomeTrait+'c)) -> &'b (SomeTrait+'a)
-...  |
-LL | |         //~| ERROR cannot infer
-LL | | }
-   | |_^ returning this value requires that `'a` must outlive `'b`
+LL | fn load3<'a,'b>(ss: &'a SomeTrait) -> &'b SomeTrait {
+   |          -- -- lifetime `'b` defined here
+   |          |
+   |          lifetime `'a` defined here
+...
+LL |     ss
+   |     ^^ returning this value requires that `'a` must outlive `'b`
 
 error: aborting due to previous error
 

--- a/src/test/ui/object-lifetime/object-lifetime-default-from-box-error.nll.stderr
+++ b/src/test/ui/object-lifetime/object-lifetime-default-from-box-error.nll.stderr
@@ -11,18 +11,13 @@ LL |     ss.r = b; //~ ERROR 41:12: 41:13: explicit lifetime required in the typ
    |            ^
 
 error[E0621]: explicit lifetime required in the type of `ss`
-  --> $DIR/object-lifetime-default-from-box-error.rs:24:48
+  --> $DIR/object-lifetime-default-from-box-error.rs:28:5
    |
-LL |   fn load(ss: &mut SomeStruct) -> Box<SomeTrait> {
-   |  _____________---------------____________________^
-   | |             |
-   | |             help: add explicit lifetime `'static` to the type of `ss`: `&mut SomeStruct<'static>`
-LL | |     // `Box<SomeTrait>` defaults to a `'static` bound, so this return
-LL | |     // is illegal.
-LL | |
-LL | |     ss.r //~ ERROR explicit lifetime required in the type of `ss` [E0621]
-LL | | }
-   | |_^ lifetime `'static` required
+LL | fn load(ss: &mut SomeStruct) -> Box<SomeTrait> {
+   |             --------------- help: add explicit lifetime `'static` to the type of `ss`: `&mut SomeStruct<'static>`
+...
+LL |     ss.r //~ ERROR explicit lifetime required in the type of `ss` [E0621]
+   |     ^^^^ lifetime `'static` required
 
 error[E0507]: cannot move out of borrowed content
   --> $DIR/object-lifetime-default-from-box-error.rs:28:5

--- a/src/test/ui/regions/region-object-lifetime-in-coercion.nll.stderr
+++ b/src/test/ui/regions/region-object-lifetime-in-coercion.nll.stderr
@@ -31,43 +31,31 @@ LL |     let x: Box<Foo + 'static> = Box::new(v);
    |                                 ^^^^^^^^^^^ lifetime `'static` required
 
 error[E0621]: explicit lifetime required in the type of `v`
-  --> $DIR/region-object-lifetime-in-coercion.rs:23:38
+  --> $DIR/region-object-lifetime-in-coercion.rs:24:5
    |
-LL |   fn b(v: &[u8]) -> Box<Foo + 'static> {
-   |  _________-----________________________^
-   | |         |
-   | |         help: add explicit lifetime `'static` to the type of `v`: `&'static [u8]`
-LL | |     Box::new(v)
-LL | |         //~^ ERROR explicit lifetime required in the type of `v` [E0621]
-LL | | }
-   | |_^ lifetime `'static` required
+LL | fn b(v: &[u8]) -> Box<Foo + 'static> {
+   |         ----- help: add explicit lifetime `'static` to the type of `v`: `&'static [u8]`
+LL |     Box::new(v)
+   |     ^^^^^^^^^^^ lifetime `'static` required
 
 error[E0621]: explicit lifetime required in the type of `v`
-  --> $DIR/region-object-lifetime-in-coercion.rs:28:28
+  --> $DIR/region-object-lifetime-in-coercion.rs:31:5
    |
-LL |   fn c(v: &[u8]) -> Box<Foo> {
-   |  _________-----______________^
-   | |         |
-   | |         help: add explicit lifetime `'static` to the type of `v`: `&'static [u8]`
-LL | |     // same as previous case due to RFC 599
-LL | |
-LL | |     Box::new(v)
-LL | |         //~^ ERROR explicit lifetime required in the type of `v` [E0621]
-LL | | }
-   | |_^ lifetime `'static` required
+LL | fn c(v: &[u8]) -> Box<Foo> {
+   |         ----- help: add explicit lifetime `'static` to the type of `v`: `&'static [u8]`
+...
+LL |     Box::new(v)
+   |     ^^^^^^^^^^^ lifetime `'static` required
 
 error: unsatisfied lifetime constraints
-  --> $DIR/region-object-lifetime-in-coercion.rs:35:41
+  --> $DIR/region-object-lifetime-in-coercion.rs:36:5
    |
-LL |   fn d<'a,'b>(v: &'a [u8]) -> Box<Foo+'b> {
-   |  ______--_--______________________________^
-   | |      |  |
-   | |      |  lifetime `'b` defined here
-   | |      lifetime `'a` defined here
-LL | |     Box::new(v)
-LL | |         //~^ ERROR cannot infer an appropriate lifetime due to conflicting
-LL | | }
-   | |_^ returning this value requires that `'a` must outlive `'b`
+LL | fn d<'a,'b>(v: &'a [u8]) -> Box<Foo+'b> {
+   |      -- -- lifetime `'b` defined here
+   |      |
+   |      lifetime `'a` defined here
+LL |     Box::new(v)
+   |     ^^^^^^^^^^^ returning this value requires that `'a` must outlive `'b`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/regions/regions-close-object-into-object-2.nll.stderr
+++ b/src/test/ui/regions/regions-close-object-into-object-2.nll.stderr
@@ -5,15 +5,12 @@ LL |     box B(&*v) as Box<X> //~ ERROR cannot infer
    |           ^^^
 
 error: unsatisfied lifetime constraints
-  --> $DIR/regions-close-object-into-object-2.rs:19:57
+  --> $DIR/regions-close-object-into-object-2.rs:20:5
    |
-LL |   fn g<'a, T: 'static>(v: Box<A<T>+'a>) -> Box<X+'static> {
-   |  ______--_________________________________________________^
-   | |      |
-   | |      lifetime `'a` defined here
-LL | |     box B(&*v) as Box<X> //~ ERROR cannot infer
-LL | | }
-   | |_^ returning this value requires that `'a` must outlive `'static`
+LL | fn g<'a, T: 'static>(v: Box<A<T>+'a>) -> Box<X+'static> {
+   |      -- lifetime `'a` defined here
+LL |     box B(&*v) as Box<X> //~ ERROR cannot infer
+   |     ^^^^^^^^^^^^^^^^^^^^ returning this value requires that `'a` must outlive `'static`
 
 error[E0597]: `*v` does not live long enough
   --> $DIR/regions-close-object-into-object-2.rs:20:11

--- a/src/test/ui/regions/regions-close-object-into-object-4.nll.stderr
+++ b/src/test/ui/regions/regions-close-object-into-object-4.nll.stderr
@@ -28,17 +28,6 @@ warning: not reporting region error due to nll
 LL |     box B(&*v) as Box<X> //~ ERROR cannot infer
    |     ^^^^^^^^^^
 
-error: unsatisfied lifetime constraints
-  --> $DIR/regions-close-object-into-object-4.rs:19:51
-   |
-LL |   fn i<'a, T, U>(v: Box<A<U>+'a>) -> Box<X+'static> {
-   |  ______--___________________________________________^
-   | |      |
-   | |      lifetime `'a` defined here
-LL | |     box B(&*v) as Box<X> //~ ERROR cannot infer
-LL | | }
-   | |_^ returning this value requires that `'a` must outlive `'static`
-
 error[E0310]: the parameter type `U` may not live long enough
   --> $DIR/regions-close-object-into-object-4.rs:20:5
    |
@@ -46,6 +35,14 @@ LL |     box B(&*v) as Box<X> //~ ERROR cannot infer
    |     ^^^^^^^^^^
    |
    = help: consider adding an explicit lifetime bound `U: 'static`...
+
+error: unsatisfied lifetime constraints
+  --> $DIR/regions-close-object-into-object-4.rs:20:5
+   |
+LL | fn i<'a, T, U>(v: Box<A<U>+'a>) -> Box<X+'static> {
+   |      -- lifetime `'a` defined here
+LL |     box B(&*v) as Box<X> //~ ERROR cannot infer
+   |     ^^^^^^^^^^^^^^^^^^^^ returning this value requires that `'a` must outlive `'static`
 
 error[E0310]: the parameter type `U` may not live long enough
   --> $DIR/regions-close-object-into-object-4.rs:20:9

--- a/src/test/ui/regions/regions-proc-bound-capture.nll.stderr
+++ b/src/test/ui/regions/regions-proc-bound-capture.nll.stderr
@@ -5,16 +5,13 @@ LL |     Box::new(move|| { *x }) //~ ERROR explicit lifetime required in the typ
    |              ^^^^^^^^^^^^^
 
 error[E0621]: explicit lifetime required in the type of `x`
-  --> $DIR/regions-proc-bound-capture.rs:17:62
+  --> $DIR/regions-proc-bound-capture.rs:19:5
    |
-LL |   fn static_proc(x: &isize) -> Box<FnMut()->(isize) + 'static> {
-   |  ___________________------_____________________________________^
-   | |                   |
-   | |                   help: add explicit lifetime `'static` to the type of `x`: `&'static isize`
-LL | |     // This is illegal, because the region bound on `proc` is 'static.
-LL | |     Box::new(move|| { *x }) //~ ERROR explicit lifetime required in the type of `x` [E0621]
-LL | | }
-   | |_^ lifetime `'static` required
+LL | fn static_proc(x: &isize) -> Box<FnMut()->(isize) + 'static> {
+   |                   ------ help: add explicit lifetime `'static` to the type of `x`: `&'static isize`
+LL |     // This is illegal, because the region bound on `proc` is 'static.
+LL |     Box::new(move|| { *x }) //~ ERROR explicit lifetime required in the type of `x` [E0621]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ lifetime `'static` required
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-reborrow-from-shorter-mut-ref-mut-ref.nll.stderr
+++ b/src/test/ui/regions/regions-reborrow-from-shorter-mut-ref-mut-ref.nll.stderr
@@ -5,16 +5,14 @@ LL |     &mut ***p //~ ERROR 14:5: 14:14: lifetime mismatch [E0623]
    |     ^^^^^^^^^
 
 error: unsatisfied lifetime constraints
-  --> $DIR/regions-reborrow-from-shorter-mut-ref-mut-ref.rs:13:85
+  --> $DIR/regions-reborrow-from-shorter-mut-ref-mut-ref.rs:14:5
    |
-LL |   fn copy_borrowed_ptr<'a, 'b, 'c>(p: &'a mut &'b mut &'c mut isize) -> &'b mut isize {
-   |  ______________________--__--_________________________________________________________^
-   | |                      |   |
-   | |                      |   lifetime `'b` defined here
-   | |                      lifetime `'a` defined here
-LL | |     &mut ***p //~ ERROR 14:5: 14:14: lifetime mismatch [E0623]
-LL | | }
-   | |_^ function was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
+LL | fn copy_borrowed_ptr<'a, 'b, 'c>(p: &'a mut &'b mut &'c mut isize) -> &'b mut isize {
+   |                      --  -- lifetime `'b` defined here
+   |                      |
+   |                      lifetime `'a` defined here
+LL |     &mut ***p //~ ERROR 14:5: 14:14: lifetime mismatch [E0623]
+   |     ^^^^^^^^^ function was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-reborrow-from-shorter-mut-ref.nll.stderr
+++ b/src/test/ui/regions/regions-reborrow-from-shorter-mut-ref.nll.stderr
@@ -5,16 +5,14 @@ LL |     &mut **p //~ ERROR 16:5: 16:13: lifetime mismatch [E0623]
    |     ^^^^^^^^
 
 error: unsatisfied lifetime constraints
-  --> $DIR/regions-reborrow-from-shorter-mut-ref.rs:15:73
+  --> $DIR/regions-reborrow-from-shorter-mut-ref.rs:16:5
    |
-LL |   fn copy_borrowed_ptr<'a, 'b>(p: &'a mut &'b mut isize) -> &'b mut isize {
-   |  ______________________--__--_____________________________________________^
-   | |                      |   |
-   | |                      |   lifetime `'b` defined here
-   | |                      lifetime `'a` defined here
-LL | |     &mut **p //~ ERROR 16:5: 16:13: lifetime mismatch [E0623]
-LL | | }
-   | |_^ function was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
+LL | fn copy_borrowed_ptr<'a, 'b>(p: &'a mut &'b mut isize) -> &'b mut isize {
+   |                      --  -- lifetime `'b` defined here
+   |                      |
+   |                      lifetime `'a` defined here
+LL |     &mut **p //~ ERROR 16:5: 16:13: lifetime mismatch [E0623]
+   |     ^^^^^^^^ function was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-trait-object-subtyping.nll.stderr
+++ b/src/test/ui/regions/regions-trait-object-subtyping.nll.stderr
@@ -11,18 +11,15 @@ LL |     x //~ ERROR mismatched types
    |     ^
 
 error: unsatisfied lifetime constraints
-  --> $DIR/regions-trait-object-subtyping.rs:23:51
+  --> $DIR/regions-trait-object-subtyping.rs:25:5
    |
-LL |   fn foo3<'a,'b>(x: &'a mut Dummy) -> &'b mut Dummy {
-   |  _________--_--_____________________________________^
-   | |         |  |
-   | |         |  lifetime `'b` defined here
-   | |         lifetime `'a` defined here
-LL | |     // Without knowing 'a:'b, we can't coerce
-LL | |     x //~ ERROR lifetime bound not satisfied
-LL | |      //~^ ERROR cannot infer an appropriate lifetime
-LL | | }
-   | |_^ returning this value requires that `'a` must outlive `'b`
+LL | fn foo3<'a,'b>(x: &'a mut Dummy) -> &'b mut Dummy {
+   |         -- -- lifetime `'b` defined here
+   |         |
+   |         lifetime `'a` defined here
+LL |     // Without knowing 'a:'b, we can't coerce
+LL |     x //~ ERROR lifetime bound not satisfied
+   |     ^ returning this value requires that `'a` must outlive `'b`
 
 error: unsatisfied lifetime constraints
   --> $DIR/regions-trait-object-subtyping.rs:32:5

--- a/src/test/ui/span/regions-close-over-type-parameter-2.nll.stderr
+++ b/src/test/ui/span/regions-close-over-type-parameter-2.nll.stderr
@@ -1,17 +1,12 @@
 error[E0597]: `tmp0` does not live long enough
   --> $DIR/regions-close-over-type-parameter-2.rs:33:20
    |
-LL |       let _ = {
-   |  _____________-
-LL | |         let tmp0 = 3;
-LL | |         let tmp1 = &tmp0;
-   | |                    ^^^^^ borrowed value does not live long enough
-LL | |         repeater3(tmp1)
-LL | |     };
-   | |     -
-   | |     |
-   | |_____`tmp0` dropped here while still borrowed
-   |       borrow later used here
+LL |         let tmp1 = &tmp0;
+   |                    ^^^^^ borrowed value does not live long enough
+LL |         repeater3(tmp1)
+   |         --------------- borrow later used here
+LL |     };
+   |     - `tmp0` dropped here while still borrowed
 
 error: aborting due to previous error
 

--- a/src/test/ui/underscore-lifetime/dyn-trait-underscore.nll.stderr
+++ b/src/test/ui/underscore-lifetime/dyn-trait-underscore.nll.stderr
@@ -23,16 +23,13 @@ LL |     Box::new(items.iter()) //~ ERROR cannot infer an appropriate lifetime
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: unsatisfied lifetime constraints
-  --> $DIR/dyn-trait-underscore.rs:16:52
+  --> $DIR/dyn-trait-underscore.rs:18:5
    |
-LL |   fn a<T>(items: &[T]) -> Box<dyn Iterator<Item=&T>> {
-   |  ________________-___________________________________^
-   | |                |
-   | |                let's call the lifetime of this reference `'1`
-LL | |     //                      ^^^^^^^^^^^^^^^^^^^^^ bound *here* defaults to `'static`
-LL | |     Box::new(items.iter()) //~ ERROR cannot infer an appropriate lifetime
-LL | | }
-   | |_^ returning this value requires that `'1` must outlive `'static`
+LL | fn a<T>(items: &[T]) -> Box<dyn Iterator<Item=&T>> {
+   |                - let's call the lifetime of this reference `'1`
+LL |     //                      ^^^^^^^^^^^^^^^^^^^^^ bound *here* defaults to `'static`
+LL |     Box::new(items.iter()) //~ ERROR cannot infer an appropriate lifetime
+   |     ^^^^^^^^^^^^^^^^^^^^^^ returning this value requires that `'1` must outlive `'static`
 
 error: aborting due to previous error
 


### PR DESCRIPTION
When returning a mutable reference don't use the entire body of the function as the span for the adjustments at the end.

The error [in this case](https://github.com/rust-lang/rust/compare/master...matthewjasper:hair-spans?expand=1#diff-ecef8b1f15622fb48a803c9b61605c78) is worse, but neither error message is really what we want. I have some ideas on how to get a better error message that will have to wait for a future PR.