### PR TITLE
[Do not merge] Allow generic parameters to be specified in expressions without `::`

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1714,11 +1714,10 @@ impl<'a> Parser<'a> {
         } else if self.eat_keyword(keywords::Const) {
             Mutability::Immutable
         } else {
-            let span = self.prev_span;
-            self.span_err(span,
-                          "expected mut or const in raw pointer type (use \
-                           `*mut T` or `*const T` as appropriate)");
-            Mutability::Immutable
+            let mut err = self.fatal("expected mut or const in raw pointer type (use \
+            `*mut T` or `*const T` as appropriate)");
+            err.span_label(self.prev_span, "expected mut or const");
+            return Err(err);
         };
         let t = self.parse_ty_no_plus()?;
         Ok(MutTy { ty: t, mutbl: mutbl })
@@ -2022,20 +2021,26 @@ impl<'a> Parser<'a> {
                           -> PResult<'a, PathSegment> {
         let ident = self.parse_path_segment_ident()?;
 
-        let is_args_start = |token: &token::Token| match *token {
-            token::Lt | token::BinOp(token::Shl) | token::OpenDelim(token::Paren) => true,
+        let is_args_start = |token: &token::Token, include_paren: bool| match *token {
+            token::Lt | token::BinOp(token::Shl) => true,
+            token::OpenDelim(token::Paren) => include_paren,
             _ => false,
         };
-        let check_args_start = |this: &mut Self| {
-            this.expected_tokens.extend_from_slice(
-                &[TokenType::Token(token::Lt), TokenType::Token(token::OpenDelim(token::Paren))]
-            );
-            is_args_start(&this.token)
+        let check_args_start = |this: &mut Self, include_paren: bool| {
+            this.expected_tokens.push(TokenType::Token(token::Lt));
+            if include_paren {
+                this.expected_tokens.push(TokenType::Token(token::OpenDelim(token::Paren)));
+            }
+            is_args_start(&this.token, include_paren)
         };
 
-        Ok(if style == PathStyle::Type && check_args_start(self) ||
+        let expr_without_disambig = style == PathStyle::Expr && check_args_start(self, false);
+        let parser_snapshot_before_generics = self.clone();
+
+        Ok(if style == PathStyle::Type && check_args_start(self, true) ||
               style != PathStyle::Mod && self.check(&token::ModSep)
-                                      && self.look_ahead(1, |t| is_args_start(t)) {
+                                      && self.look_ahead(1, |t| is_args_start(t, true))
+                                      || expr_without_disambig {
             // Generic arguments are found - `<`, `(`, `::<` or `::(`.
             let lo = self.span;
             if self.eat(&token::ModSep) && style == PathStyle::Type && enable_warning {
@@ -2045,10 +2050,26 @@ impl<'a> Parser<'a> {
 
             let args = if self.eat_lt() {
                 // `<'a, T, A = U>`
-                let (args, bindings) = self.parse_generic_args()?;
-                self.expect_gt()?;
-                let span = lo.to(self.prev_span);
-                AngleBracketedArgs { args, bindings, span }.into()
+                let args: PResult<_> = do catch {
+                    let (args, bindings) = self.parse_generic_args()?;
+                    self.expect_gt()?;
+                    let span = lo.to(self.prev_span);
+                    AngleBracketedArgs { args, bindings, span }
+                };
+
+                match args {
+                    Err(mut err) => {
+                        if expr_without_disambig {
+                            err.cancel();
+                            mem::replace(self, parser_snapshot_before_generics);
+                            return Ok(PathSegment::from_ident(ident));
+                        }
+                        return Err(err);
+                    }
+                    _ => {
+                        args?.into()
+                    }
+                }
             } else {
                 // `(T, U) -> R`
                 self.bump(); // `(`

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2039,6 +2039,14 @@ impl<'a> Parser<'a> {
         Ok(if style == PathStyle::Type && check_args_start(self, true)
             || style != PathStyle::Mod && self.check(&token::ModSep)
                                        && self.look_ahead(1, |t| is_args_start(t, true))
+                                       && {
+                if style == PathStyle::Expr {
+                    // Simulate every occurrence of `::<>` actually being `<>`.
+                    self.eat(&token::ModSep);
+                    parser_snapshot_before_generics = Some(self.clone());
+                }
+                true
+            }
             || style == PathStyle::Expr && check_args_start(self, false) && {
                 // Check for generic arguments in an expression without a disambiguating `::`.
                 // We have to save a snapshot, because it could end up being an expression

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -167,7 +167,7 @@ pub enum Token {
     Comma,
     Semi,
     Colon,
-    ModSep,
+    ModSep, // `::`
     RArrow,
     LArrow,
     FatArrow,

--- a/src/test/parse-fail/pat-ranges-2.rs
+++ b/src/test/parse-fail/pat-ranges-2.rs
@@ -11,5 +11,5 @@
 // Parsing of range patterns
 
 fn main() {
-    let 10 ..= makropulos!() = 12; //~ error: expected one of `::`, `:`, `;`, or `=`, found `!`
+    let 10 ..= makropulos!() = 12; //~ error: expected one of `::`, `:`, `;`, `<`, or `=`, found `!`
 }

--- a/src/test/parse-fail/require-parens-for-chained-comparison.rs
+++ b/src/test/parse-fail/require-parens-for-chained-comparison.rs
@@ -18,9 +18,4 @@ fn main() {
 
     false == 0 < 2;
     //~^ ERROR: chained comparison operators require parentheses
-
-    f<X>();
-    //~^ ERROR: chained comparison operators require parentheses
-    //~| HELP: use `::<...>` instead of `<...>`
-    //~| HELP: or use `(...)`
 }

--- a/src/test/ui/did_you_mean/issue-40396.rs
+++ b/src/test/ui/did_you_mean/issue-40396.rs
@@ -9,16 +9,16 @@
 // except according to those terms.
 
 fn foo() {
-    println!("{:?}", (0..13).collect<Vec<i32>>()); //~ ERROR chained comparison
+    println!("{:?}", (0..13).collect<Vec<i32>>()); // ok
 }
 
 fn bar() {
-    println!("{:?}", Vec<i32>::new()); //~ ERROR chained comparison
+    println!("{:?}", Vec<i32>::new()); // ok
 }
 
 fn qux() {
-    println!("{:?}", (0..13).collect<Vec<i32>()); //~ ERROR chained comparison
-    //~^ ERROR chained comparison
+    println!("{:?}", (0..13).collect<Vec<i32>()); //~ ERROR expected function, found struct `Vec`
+    //~^ ERROR attempted to take value of method `collect`
 }
 
 fn main() {}

--- a/src/test/ui/did_you_mean/issue-40396.stderr
+++ b/src/test/ui/did_you_mean/issue-40396.stderr
@@ -1,38 +1,18 @@
-error: chained comparison operators require parentheses
-  --> $DIR/issue-40396.rs:12:37
+error[E0423]: expected function, found struct `Vec`
+  --> $DIR/issue-40396.rs:20:38
    |
-LL |     println!("{:?}", (0..13).collect<Vec<i32>>()); //~ ERROR chained comparison
-   |                                     ^^^^^^^^
-   |
-   = help: use `::<...>` instead of `<...>` if you meant to specify type arguments
-   = help: or use `(...)` if you meant to specify fn arguments
+LL |     println!("{:?}", (0..13).collect<Vec<i32>()); //~ ERROR expected function, found struct `Vec`
+   |                                      ^^^^^^^^ did you mean `Vec { /* fields */ }`?
 
-error: chained comparison operators require parentheses
-  --> $DIR/issue-40396.rs:16:25
+error[E0615]: attempted to take value of method `collect` on type `std::ops::Range<{integer}>`
+  --> $DIR/issue-40396.rs:20:30
    |
-LL |     println!("{:?}", Vec<i32>::new()); //~ ERROR chained comparison
-   |                         ^^^^^^^
+LL |     println!("{:?}", (0..13).collect<Vec<i32>()); //~ ERROR expected function, found struct `Vec`
+   |                              ^^^^^^^
    |
-   = help: use `::<...>` instead of `<...>` if you meant to specify type arguments
-   = help: or use `(...)` if you meant to specify fn arguments
+   = help: maybe a `()` to call it is missing?
 
-error: chained comparison operators require parentheses
-  --> $DIR/issue-40396.rs:20:37
-   |
-LL |     println!("{:?}", (0..13).collect<Vec<i32>()); //~ ERROR chained comparison
-   |                                     ^^^^^^^^
-   |
-   = help: use `::<...>` instead of `<...>` if you meant to specify type arguments
-   = help: or use `(...)` if you meant to specify fn arguments
+error: aborting due to 2 previous errors
 
-error: chained comparison operators require parentheses
-  --> $DIR/issue-40396.rs:20:41
-   |
-LL |     println!("{:?}", (0..13).collect<Vec<i32>()); //~ ERROR chained comparison
-   |                                         ^^^^^^
-   |
-   = help: use `::<...>` instead of `<...>` if you meant to specify type arguments
-   = help: or use `(...)` if you meant to specify fn arguments
-
-error: aborting due to 4 previous errors
-
+Some errors occurred: E0423, E0615.
+For more information about an error, try `rustc --explain E0423`.

--- a/src/test/ui/issues/issue-6596-2.stderr
+++ b/src/test/ui/issues/issue-6596-2.stderr
@@ -7,11 +7,11 @@ LL |         { $inp $nonexistent }
 LL |     g!(foo);
    |     -------- in this macro invocation
 
-error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `nonexistent`
+error: expected one of `!`, `.`, `::`, `;`, `<`, `?`, `{`, `}`, or an operator, found `nonexistent`
   --> $DIR/issue-6596-2.rs:15:16
    |
 LL |         { $inp $nonexistent }
-   |                ^^^^^^^^^^^^ expected one of 8 possible tokens here
+   |                ^^^^^^^^^^^^ expected one of 9 possible tokens here
 ...
 LL |     g!(foo);
    |     -------- in this macro invocation

--- a/src/test/ui/macro_backtrace/main.stderr
+++ b/src/test/ui/macro_backtrace/main.stderr
@@ -1,21 +1,21 @@
-error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `error`
+error: expected one of `!`, `.`, `::`, `;`, `<`, `?`, `{`, `}`, or an operator, found `error`
   --> $DIR/main.rs:19:20
    |
 LL | / macro_rules! pong {
 LL | |     () => { syntax error };
-   | |                    ^^^^^ expected one of 8 possible tokens here
+   | |                    ^^^^^ expected one of 9 possible tokens here
 LL | | }
    | |_- in this expansion of `pong!`
 ...
 LL |       pong!();
    |       -------- in this macro invocation
 
-error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `error`
+error: expected one of `!`, `.`, `::`, `;`, `<`, `?`, `{`, `}`, or an operator, found `error`
   --> $DIR/main.rs:19:20
    |
 LL | / macro_rules! pong {
 LL | |     () => { syntax error };
-   | |                    ^^^^^ expected one of 8 possible tokens here
+   | |                    ^^^^^ expected one of 9 possible tokens here
 LL | | }
    | |_- in this expansion of `pong!`
 ...
@@ -30,12 +30,12 @@ LL |   (  ) => { pong ! (  ) ; }
    |   |         in this macro invocation
    |   in this expansion of `ping!`
 
-error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `error`
+error: expected one of `!`, `.`, `::`, `;`, `<`, `?`, `{`, `}`, or an operator, found `error`
   --> $DIR/main.rs:19:20
    |
 LL | / macro_rules! pong {
 LL | |     () => { syntax error };
-   | |                    ^^^^^ expected one of 8 possible tokens here
+   | |                    ^^^^^ expected one of 9 possible tokens here
 LL | | }
    | |_- in this expansion of `pong!` (#5)
 ...

--- a/src/test/ui/raw/raw-literal-keywords.stderr
+++ b/src/test/ui/raw/raw-literal-keywords.stderr
@@ -1,20 +1,20 @@
-error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `true`
+error: expected one of `!`, `.`, `::`, `;`, `<`, `?`, `{`, `}`, or an operator, found `true`
   --> $DIR/raw-literal-keywords.rs:16:10
    |
 LL |     r#if true { } //~ ERROR found `true`
-   |          ^^^^ expected one of 8 possible tokens here
+   |          ^^^^ expected one of 9 possible tokens here
 
-error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `Test`
+error: expected one of `!`, `.`, `::`, `;`, `<`, `?`, `{`, `}`, or an operator, found `Test`
   --> $DIR/raw-literal-keywords.rs:20:14
    |
 LL |     r#struct Test; //~ ERROR found `Test`
-   |              ^^^^ expected one of 8 possible tokens here
+   |              ^^^^ expected one of 9 possible tokens here
 
-error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `Test`
+error: expected one of `!`, `.`, `::`, `;`, `<`, `?`, `{`, `}`, or an operator, found `Test`
   --> $DIR/raw-literal-keywords.rs:24:13
    |
 LL |     r#union Test; //~ ERROR found `Test`
-   |             ^^^^ expected one of 8 possible tokens here
+   |             ^^^^ expected one of 9 possible tokens here
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
Note: this PR is an experiment in making the `::` generics disambiguation in expressions optional. It is not intended to be merged. Any serious consideration of such a change would be subject to the full RFC process.

---

I was almost ready to move on, then I realised I had made a silly mistake in the last experiment. I wanted to just see whether this small optimisation made a difference or not.

(I closed the old branch on https://github.com/rust-lang/rust/pull/53074, so I had to open a new PR.)

r? @varkor (not sure if this works, to avoid pinging anyone unnecessarily)