### PR TITLE
Force-inline `shallow_resolve` at its hottest call site.

### DIFF
--- a/src/librustc/infer/mod.rs
+++ b/src/librustc/infer/mod.rs
@@ -1116,7 +1116,11 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
         self.resolve_type_vars_if_possible(t).to_string()
     }
 
-    pub fn shallow_resolve(&self, typ: Ty<'tcx>) -> Ty<'tcx> {
+    // We have this force-inlined variant of shallow_resolve() for the one
+    // callsite that is extremely hot. All other callsites use the normal
+    // variant.
+    #[inline(always)]
+    pub fn inlined_shallow_resolve(&self, typ: Ty<'tcx>) -> Ty<'tcx> {
         match typ.sty {
             ty::TyInfer(ty::TyVar(v)) => {
                 // Not entirely obvious: if `typ` is a type variable,
@@ -1155,6 +1159,10 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                 typ
             }
         }
+    }
+
+    pub fn shallow_resolve(&self, typ: Ty<'tcx>) -> Ty<'tcx> {
+        self.inlined_shallow_resolve(typ)
     }
 
     pub fn resolve_type_vars_if_possible<T>(&self, value: &T) -> T

--- a/src/librustc/traits/fulfill.rs
+++ b/src/librustc/traits/fulfill.rs
@@ -269,7 +269,8 @@ impl<'a, 'b, 'gcx, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'b, 'gcx, 
         // doing more work yet
         if !pending_obligation.stalled_on.is_empty() {
             if pending_obligation.stalled_on.iter().all(|&ty| {
-                let resolved_ty = self.selcx.infcx().shallow_resolve(&ty);
+                // Use the force-inlined variant of shallow_resolve() because this code is hot.
+                let resolved_ty = self.selcx.infcx().inlined_shallow_resolve(&ty);
                 resolved_ty == ty // nothing changed here
             }) {
                 debug!("process_predicate: pending obligation {:?} still stalled on {:?}",


### PR DESCRIPTION
It's a ~1% win on `keccak` and `inflate`.