### PR TITLE
Expend syntax::with_globals coverage and allow nested calls

### DIFF
--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -100,10 +100,20 @@ impl Globals {
 pub fn with_globals<F, R>(f: F) -> R
     where F: FnOnce() -> R
 {
-    let globals = Globals::new();
-    GLOBALS.set(&globals, || {
-        syntax_pos::GLOBALS.set(&globals.syntax_pos_globals, f)
-    })
+    if GLOBALS.is_set() {
+        if syntax_pos::GLOBALS.is_set() {
+            f()
+        } else {
+            GLOBALS.with(|globals| {
+                syntax_pos::GLOBALS.set(&globals.syntax_pos_globals, f)
+            })
+        }
+    } else {
+        let globals = Globals::new();
+        GLOBALS.set(&globals, || {
+            syntax_pos::GLOBALS.set(&globals.syntax_pos_globals, f)
+        })
+    }
 }
 
 scoped_thread_local!(pub static GLOBALS: Globals);


### PR DESCRIPTION
#53448 (and proberly #53469) is partialy fixed in the sense the error messages, if any, will be shown as

```rust
error: internal compiler error: broken MIR in DefId(0/0:7 ~ hrtb_fn_parameters[317d]::main[0]) (_7 = &mut (*_2)): bad assignment (&mut dyn std::ops::FnMut(()) = &mut dyn std::ops::FnMut(<() as Lt<'_>>::T)): NoSolution
  --> F:\work\rust\rust_git\rust\src/test\run-pass\hrtb-fn-parameters.rs:23:5
   |
23 |     f(v);
   |     ^
```

rather than "cannot access a scoped thread local variable without calling `set` first".

# Problem analysis

`run_compiler` function is wrapped by a `syntax::with_globals` call to ensure it have access to `syntax::GLOBALS`. However, as we have code after running `run_compile` requires to emit errors, when it needs to show the position of the error, it will `panic` as `syntax::GLOBALS` is unavailable.

This pull request fixed this by introducing a new call to `syntax::with_globals` in `run`. So code in `run` will use bigger `syntax::with_globals` coverage than other calls to `run_compiler`. 

It also makes calling `syntax::with_globals` when it is already called in the outside code uses the already initialized globals, rather than creating new instances.

Although this does not actually fix #53448 nor #53469, it will make similar errors never hide the useful error message any more, and so will help diagnosis simular situations easier.

----

My very first pull request on the compiler ever. Please advise me if I did anything wrong.
