### PR TITLE
librustc_lint: In recursion warning, change 'recurring' to 'recursing'

### DIFF
--- a/src/doc/rustc/src/lints/listing/warn-by-default.md
+++ b/src/doc/rustc/src/lints/listing/warn-by-default.md
@@ -603,11 +603,11 @@ fn foo() {
 This will produce:
 
 ```text
-warning: function cannot return without recurring
+warning: function cannot return without recursing
  --> src/main.rs:1:1
   |
 1 | fn foo() {
-  | ^^^^^^^^ cannot return without recurring
+  | ^^^^^^^^ cannot return without recursing
 2 |     foo();
   |     ----- recursive call site
   |

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -901,7 +901,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnconditionalRecursion {
         // considers this to be an error for two reasons, (a) it is
         // easier to implement, and (b) it seems rare to actually want
         // to have behaviour like the above, rather than
-        // e.g. accidentally recurring after an assert.
+        // e.g. accidentally recursing after an assert.
 
         let cfg = cfg::CFG::new(cx.tcx, &body);
 
@@ -961,8 +961,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnconditionalRecursion {
             let sp = cx.tcx.sess.codemap().def_span(sp);
             let mut db = cx.struct_span_lint(UNCONDITIONAL_RECURSION,
                                              sp,
-                                             "function cannot return without recurring");
-            db.span_label(sp, "cannot return without recurring");
+                                             "function cannot return without recursing");
+            db.span_label(sp, "cannot return without recursing");
             // offer some help to the programmer.
             for call in &self_call_spans {
                 db.span_label(*call, "recursive call site");
@@ -1090,7 +1090,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnconditionalRecursion {
                             // a default method definition.
                             Ok(Some(traits::VtableParam(_))) => {
                                 let on_self = trait_ref.self_ty().is_self();
-                                // We can only be recurring in a default
+                                // We can only be recursing in a default
                                 // method if we're being called literally
                                 // on the `Self` type.
                                 on_self && callee_id == method.def_id

--- a/src/test/ui/issues/issue-8727.rs
+++ b/src/test/ui/issues/issue-8727.rs
@@ -15,7 +15,7 @@ fn generic<T>() {
     generic::<Option<T>>();
 }
 //~^^^ ERROR reached the recursion limit while instantiating `generic::<std::option::Option<
-//~| WARN function cannot return without recurring
+//~| WARN function cannot return without recursing
 
 
 

--- a/src/test/ui/issues/issue-8727.stderr
+++ b/src/test/ui/issues/issue-8727.stderr
@@ -1,8 +1,8 @@
-warning: function cannot return without recurring
+warning: function cannot return without recursing
   --> $DIR/issue-8727.rs:14:1
    |
 LL | fn generic<T>() {
-   | ^^^^^^^^^^^^^^^ cannot return without recurring
+   | ^^^^^^^^^^^^^^^ cannot return without recursing
 LL |     generic::<Option<T>>();
    |     ---------------------- recursive call site
    |

--- a/src/test/ui/lint/lint-unconditional-recursion.rs
+++ b/src/test/ui/lint/lint-unconditional-recursion.rs
@@ -11,7 +11,7 @@
 #![deny(unconditional_recursion)]
 
 #![allow(dead_code)]
-fn foo() { //~ ERROR function cannot return without recurring
+fn foo() { //~ ERROR function cannot return without recursing
     foo();
 }
 
@@ -21,7 +21,7 @@ fn bar() {
     }
 }
 
-fn baz() { //~ ERROR function cannot return without recurring
+fn baz() { //~ ERROR function cannot return without recursing
     if true {
         baz()
     } else {
@@ -33,7 +33,7 @@ fn qux() {
     loop {}
 }
 
-fn quz() -> bool { //~ ERROR function cannot return without recurring
+fn quz() -> bool { //~ ERROR function cannot return without recursing
     if true {
         while quz() {}
         true
@@ -44,13 +44,13 @@ fn quz() -> bool { //~ ERROR function cannot return without recurring
 
 // Trait method calls.
 trait Foo {
-    fn bar(&self) { //~ ERROR function cannot return without recurring
+    fn bar(&self) { //~ ERROR function cannot return without recursing
         self.bar()
     }
 }
 
 impl Foo for Box<Foo+'static> {
-    fn bar(&self) { //~ ERROR function cannot return without recurring
+    fn bar(&self) { //~ ERROR function cannot return without recursing
         loop {
             self.bar()
         }
@@ -59,7 +59,7 @@ impl Foo for Box<Foo+'static> {
 
 // Trait method call with integer fallback after method resolution.
 impl Foo for i32 {
-    fn bar(&self) { //~ ERROR function cannot return without recurring
+    fn bar(&self) { //~ ERROR function cannot return without recursing
         0.bar()
     }
 }
@@ -72,13 +72,13 @@ impl Foo for u32 {
 
 // Trait method calls via paths.
 trait Foo2 {
-    fn bar(&self) { //~ ERROR function cannot return without recurring
+    fn bar(&self) { //~ ERROR function cannot return without recursing
         Foo2::bar(self)
     }
 }
 
 impl Foo2 for Box<Foo2+'static> {
-    fn bar(&self) { //~ ERROR function cannot return without recurring
+    fn bar(&self) { //~ ERROR function cannot return without recursing
         loop {
             Foo2::bar(self)
         }
@@ -88,19 +88,19 @@ impl Foo2 for Box<Foo2+'static> {
 struct Baz;
 impl Baz {
     // Inherent method call.
-    fn qux(&self) { //~ ERROR function cannot return without recurring
+    fn qux(&self) { //~ ERROR function cannot return without recursing
         self.qux();
     }
 
     // Inherent method call via path.
-    fn as_ref(&self) -> &Self { //~ ERROR function cannot return without recurring
+    fn as_ref(&self) -> &Self { //~ ERROR function cannot return without recursing
         Baz::as_ref(self)
     }
 }
 
 // Trait method calls to impls via paths.
 impl Default for Baz {
-    fn default() -> Baz { //~ ERROR function cannot return without recurring
+    fn default() -> Baz { //~ ERROR function cannot return without recursing
         let x = Default::default();
         x
     }
@@ -109,14 +109,14 @@ impl Default for Baz {
 // Overloaded operators.
 impl std::ops::Deref for Baz {
     type Target = ();
-    fn deref(&self) -> &() { //~ ERROR function cannot return without recurring
+    fn deref(&self) -> &() { //~ ERROR function cannot return without recursing
         &**self
     }
 }
 
 impl std::ops::Index<usize> for Baz {
     type Output = Baz;
-    fn index(&self, x: usize) -> &Baz { //~ ERROR function cannot return without recurring
+    fn index(&self, x: usize) -> &Baz { //~ ERROR function cannot return without recursing
         &self[x]
     }
 }
@@ -125,7 +125,7 @@ impl std::ops::Index<usize> for Baz {
 struct Quux;
 impl std::ops::Deref for Quux {
     type Target = Baz;
-    fn deref(&self) -> &Baz { //~ ERROR function cannot return without recurring
+    fn deref(&self) -> &Baz { //~ ERROR function cannot return without recursing
         self.as_ref()
     }
 }

--- a/src/test/ui/lint/lint-unconditional-recursion.stderr
+++ b/src/test/ui/lint/lint-unconditional-recursion.stderr
@@ -1,8 +1,8 @@
-error: function cannot return without recurring
+error: function cannot return without recursing
   --> $DIR/lint-unconditional-recursion.rs:14:1
    |
-LL | fn foo() { //~ ERROR function cannot return without recurring
-   | ^^^^^^^^ cannot return without recurring
+LL | fn foo() { //~ ERROR function cannot return without recursing
+   | ^^^^^^^^ cannot return without recursing
 LL |     foo();
    |     ----- recursive call site
    |
@@ -13,11 +13,11 @@ LL | #![deny(unconditional_recursion)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^
    = help: a `loop` may express intention better if this is on purpose
 
-error: function cannot return without recurring
+error: function cannot return without recursing
   --> $DIR/lint-unconditional-recursion.rs:24:1
    |
-LL | fn baz() { //~ ERROR function cannot return without recurring
-   | ^^^^^^^^ cannot return without recurring
+LL | fn baz() { //~ ERROR function cannot return without recursing
+   | ^^^^^^^^ cannot return without recursing
 LL |     if true {
 LL |         baz()
    |         ----- recursive call site
@@ -27,11 +27,11 @@ LL |         baz()
    |
    = help: a `loop` may express intention better if this is on purpose
 
-error: function cannot return without recurring
+error: function cannot return without recursing
   --> $DIR/lint-unconditional-recursion.rs:36:1
    |
-LL | fn quz() -> bool { //~ ERROR function cannot return without recurring
-   | ^^^^^^^^^^^^^^^^ cannot return without recurring
+LL | fn quz() -> bool { //~ ERROR function cannot return without recursing
+   | ^^^^^^^^^^^^^^^^ cannot return without recursing
 LL |     if true {
 LL |         while quz() {}
    |               ----- recursive call site
@@ -41,113 +41,113 @@ LL |         loop { quz(); }
    |
    = help: a `loop` may express intention better if this is on purpose
 
-error: function cannot return without recurring
+error: function cannot return without recursing
   --> $DIR/lint-unconditional-recursion.rs:47:5
    |
-LL |     fn bar(&self) { //~ ERROR function cannot return without recurring
-   |     ^^^^^^^^^^^^^ cannot return without recurring
+LL |     fn bar(&self) { //~ ERROR function cannot return without recursing
+   |     ^^^^^^^^^^^^^ cannot return without recursing
 LL |         self.bar()
    |         ---------- recursive call site
    |
    = help: a `loop` may express intention better if this is on purpose
 
-error: function cannot return without recurring
+error: function cannot return without recursing
   --> $DIR/lint-unconditional-recursion.rs:53:5
    |
-LL |     fn bar(&self) { //~ ERROR function cannot return without recurring
-   |     ^^^^^^^^^^^^^ cannot return without recurring
+LL |     fn bar(&self) { //~ ERROR function cannot return without recursing
+   |     ^^^^^^^^^^^^^ cannot return without recursing
 LL |         loop {
 LL |             self.bar()
    |             ---------- recursive call site
    |
    = help: a `loop` may express intention better if this is on purpose
 
-error: function cannot return without recurring
+error: function cannot return without recursing
   --> $DIR/lint-unconditional-recursion.rs:62:5
    |
-LL |     fn bar(&self) { //~ ERROR function cannot return without recurring
-   |     ^^^^^^^^^^^^^ cannot return without recurring
+LL |     fn bar(&self) { //~ ERROR function cannot return without recursing
+   |     ^^^^^^^^^^^^^ cannot return without recursing
 LL |         0.bar()
    |         ------- recursive call site
    |
    = help: a `loop` may express intention better if this is on purpose
 
-error: function cannot return without recurring
+error: function cannot return without recursing
   --> $DIR/lint-unconditional-recursion.rs:75:5
    |
-LL |     fn bar(&self) { //~ ERROR function cannot return without recurring
-   |     ^^^^^^^^^^^^^ cannot return without recurring
+LL |     fn bar(&self) { //~ ERROR function cannot return without recursing
+   |     ^^^^^^^^^^^^^ cannot return without recursing
 LL |         Foo2::bar(self)
    |         --------------- recursive call site
    |
    = help: a `loop` may express intention better if this is on purpose
 
-error: function cannot return without recurring
+error: function cannot return without recursing
   --> $DIR/lint-unconditional-recursion.rs:81:5
    |
-LL |     fn bar(&self) { //~ ERROR function cannot return without recurring
-   |     ^^^^^^^^^^^^^ cannot return without recurring
+LL |     fn bar(&self) { //~ ERROR function cannot return without recursing
+   |     ^^^^^^^^^^^^^ cannot return without recursing
 LL |         loop {
 LL |             Foo2::bar(self)
    |             --------------- recursive call site
    |
    = help: a `loop` may express intention better if this is on purpose
 
-error: function cannot return without recurring
+error: function cannot return without recursing
   --> $DIR/lint-unconditional-recursion.rs:91:5
    |
-LL |     fn qux(&self) { //~ ERROR function cannot return without recurring
-   |     ^^^^^^^^^^^^^ cannot return without recurring
+LL |     fn qux(&self) { //~ ERROR function cannot return without recursing
+   |     ^^^^^^^^^^^^^ cannot return without recursing
 LL |         self.qux();
    |         ---------- recursive call site
    |
    = help: a `loop` may express intention better if this is on purpose
 
-error: function cannot return without recurring
+error: function cannot return without recursing
   --> $DIR/lint-unconditional-recursion.rs:96:5
    |
-LL |     fn as_ref(&self) -> &Self { //~ ERROR function cannot return without recurring
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ cannot return without recurring
+LL |     fn as_ref(&self) -> &Self { //~ ERROR function cannot return without recursing
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ cannot return without recursing
 LL |         Baz::as_ref(self)
    |         ----------------- recursive call site
    |
    = help: a `loop` may express intention better if this is on purpose
 
-error: function cannot return without recurring
+error: function cannot return without recursing
   --> $DIR/lint-unconditional-recursion.rs:103:5
    |
-LL |     fn default() -> Baz { //~ ERROR function cannot return without recurring
-   |     ^^^^^^^^^^^^^^^^^^^ cannot return without recurring
+LL |     fn default() -> Baz { //~ ERROR function cannot return without recursing
+   |     ^^^^^^^^^^^^^^^^^^^ cannot return without recursing
 LL |         let x = Default::default();
    |                 ------------------ recursive call site
    |
    = help: a `loop` may express intention better if this is on purpose
 
-error: function cannot return without recurring
+error: function cannot return without recursing
   --> $DIR/lint-unconditional-recursion.rs:112:5
    |
-LL |     fn deref(&self) -> &() { //~ ERROR function cannot return without recurring
-   |     ^^^^^^^^^^^^^^^^^^^^^^ cannot return without recurring
+LL |     fn deref(&self) -> &() { //~ ERROR function cannot return without recursing
+   |     ^^^^^^^^^^^^^^^^^^^^^^ cannot return without recursing
 LL |         &**self
    |          ------ recursive call site
    |
    = help: a `loop` may express intention better if this is on purpose
 
-error: function cannot return without recurring
+error: function cannot return without recursing
   --> $DIR/lint-unconditional-recursion.rs:119:5
    |
-LL |     fn index(&self, x: usize) -> &Baz { //~ ERROR function cannot return without recurring
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot return without recurring
+LL |     fn index(&self, x: usize) -> &Baz { //~ ERROR function cannot return without recursing
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot return without recursing
 LL |         &self[x]
    |          ------- recursive call site
    |
    = help: a `loop` may express intention better if this is on purpose
 
-error: function cannot return without recurring
+error: function cannot return without recursing
   --> $DIR/lint-unconditional-recursion.rs:128:5
    |
-LL |     fn deref(&self) -> &Baz { //~ ERROR function cannot return without recurring
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ cannot return without recurring
+LL |     fn deref(&self) -> &Baz { //~ ERROR function cannot return without recursing
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ cannot return without recursing
 LL |         self.as_ref()
    |         ---- recursive call site
    |


### PR DESCRIPTION
The existing wording seems incorrect.

Aside: This warning, 'function cannot return without recursing' is not perfectly clear - it implies that the function _can_ return, it's just got to recurse. But really the fn cannot return period. Clearer wording: 'function recurses infinitely; it cannot return'; or 'function is infinitely self-recursive; it cannot return, and this is probably an error'. I like that.