### PR TITLE
Lament the invincibility of the Turbofish

### DIFF
--- a/src/test/ui/bastion-of-the-turbofish.rs
+++ b/src/test/ui/bastion-of-the-turbofish.rs
@@ -36,6 +36,10 @@
 // My heart aches in sorrow, for I know I am defeated. Let this be a warning
 // to all those who come after. Here stands the bastion of the Turbofish.
 
+// See https://github.com/rust-lang/rust/pull/53562
+// and https://github.com/rust-lang/rfcs/pull/2527
+// for context.
+
 fn main() {
     let (oh, woe, is, me) = ("the", "Turbofish", "remains", "undefeated");
     let _: (bool, bool) = (oh<woe, is>(me));


### PR DESCRIPTION
Here a test case is added to ensure that any others attempting to drive the Turbofish to extinction have second thoughts. Previously the [entire test suite would succeed](https://github.com/rust-lang/rust/pull/53511) if generic arguments were accepted without disambiguation, making for [confusing and heartbreaking circumstances](https://github.com/rust-lang/rfcs/pull/2527).