### PR TITLE
Reoptimize VecDeque::append

### DIFF
--- a/src/liballoc/collections/vec_deque.rs
+++ b/src/liballoc/collections/vec_deque.rs
@@ -1024,7 +1024,7 @@ impl<T> VecDeque<T> {
             iter: Iter {
                 tail: drain_tail,
                 head: drain_head,
-                ring: unsafe { self.buffer_as_mut_slice() },
+                ring: unsafe { self.buffer_as_slice() },
             },
         }
     }
@@ -2593,8 +2593,8 @@ impl<T> From<VecDeque<T>> for Vec<T> {
                         let mut right_offset = 0;
                         for i in left_edge..right_edge {
                             right_offset = (i - left_edge) % (cap - right_edge);
-                            let src: isize = (right_edge + right_offset) as isize;
-                            ptr::swap(buf.add(i), buf.offset(src));
+                            let src = right_edge + right_offset;
+                            ptr::swap(buf.add(i), buf.add(src));
                         }
                         let n_ops = right_edge - left_edge;
                         left_edge += n_ops;

--- a/src/liballoc/collections/vec_deque.rs
+++ b/src/liballoc/collections/vec_deque.rs
@@ -1870,7 +1870,8 @@ impl<T> VecDeque<T> {
                 self.copy_slice(src_high);
             }
 
-            // Some values now exist in both `other` and `self` but are made inaccessible in `other`.
+            // Some values now exist in both `other` and `self` but are made inaccessible
+            // in`other`.
             other.tail = other.head;
         }
     }

--- a/src/liballoc/collections/vec_deque.rs
+++ b/src/liballoc/collections/vec_deque.rs
@@ -19,6 +19,7 @@
 
 use core::cmp::Ordering;
 use core::fmt;
+use core::isize;
 use core::iter::{repeat, FromIterator, FusedIterator};
 use core::mem;
 use core::ops::Bound::{Excluded, Included, Unbounded};
@@ -210,6 +211,9 @@ impl<T> VecDeque<T> {
     /// If so, this function never panics.
     #[inline]
     unsafe fn copy_slice(&mut self, src: &[T]) {
+        /// This is guaranteed by `RawVec`.
+        debug_assert!(self.capacity() <= isize::MAX as usize);
+
         let expected_new_len = self.len() + src.len();
         debug_assert!(self.capacity() >= expected_new_len);
 


### PR DESCRIPTION
~Unfortunately, I don't know if these changes fix the unsoundness mentioned in #53529, so it is stil a WIP.
This is also completely untested.
The VecDeque code contains other unsound code: one example : [reading unitialized memory](https://play.rust-lang.org/?gist=6ff47551769af61fd8adc45c44010887&version=nightly&mode=release&edition=2015) (detected by MIRI), so I think this code will need a bigger refactor to make it clearer and safer.~

Note: this is based on #53571.
r? @SimonSapin 
Cc: #53529 #52553 @YorickPeterse @jonas-schievink @Pazzaz @shepmaster.