### PR TITLE
Don't reduce E0161 to a warning in NLL migrate mode

### DIFF
--- a/src/librustc_mir/borrow_check/nll/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/mod.rs
@@ -125,7 +125,6 @@ pub(in borrow_check) fn compute_regions<'cx, 'gcx, 'tcx>(
         flow_inits,
         move_data,
         elements,
-        errors_buffer,
     );
 
     if let Some(all_facts) = &mut all_facts {

--- a/src/test/ui/dst/dst-index.nll.stderr
+++ b/src/test/ui/dst/dst-index.nll.stderr
@@ -4,17 +4,17 @@ error[E0161]: cannot move a value of type str: the size of str cannot be statica
 LL |     S[0];
    |     ^^^^
 
-error[E0507]: cannot move out of borrowed content
-  --> $DIR/dst-index.rs:41:5
-   |
-LL |     S[0];
-   |     ^^^^ cannot move out of borrowed content
-
 error[E0161]: cannot move a value of type dyn std::fmt::Debug: the size of dyn std::fmt::Debug cannot be statically determined
   --> $DIR/dst-index.rs:44:5
    |
 LL |     T[0];
    |     ^^^^
+
+error[E0507]: cannot move out of borrowed content
+  --> $DIR/dst-index.rs:41:5
+   |
+LL |     S[0];
+   |     ^^^^ cannot move out of borrowed content
 
 error[E0507]: cannot move out of borrowed content
   --> $DIR/dst-index.rs:44:5

--- a/src/test/ui/dst/dst-rvalue.nll.stderr
+++ b/src/test/ui/dst/dst-rvalue.nll.stderr
@@ -4,17 +4,17 @@ error[E0161]: cannot move a value of type str: the size of str cannot be statica
 LL |     let _x: Box<str> = box *"hello world";
    |                            ^^^^^^^^^^^^^^
 
-error[E0507]: cannot move out of borrowed content
-  --> $DIR/dst-rvalue.rs:16:28
-   |
-LL |     let _x: Box<str> = box *"hello world";
-   |                            ^^^^^^^^^^^^^^ cannot move out of borrowed content
-
 error[E0161]: cannot move a value of type [isize]: the size of [isize] cannot be statically determined
   --> $DIR/dst-rvalue.rs:21:32
    |
 LL |     let _x: Box<[isize]> = box *array;
    |                                ^^^^^^
+
+error[E0507]: cannot move out of borrowed content
+  --> $DIR/dst-rvalue.rs:16:28
+   |
+LL |     let _x: Box<str> = box *"hello world";
+   |                            ^^^^^^^^^^^^^^ cannot move out of borrowed content
 
 error[E0508]: cannot move out of type `[isize]`, a non-copy slice
   --> $DIR/dst-rvalue.rs:21:32

--- a/src/test/ui/error-codes/E0161.ast.stderr
+++ b/src/test/ui/error-codes/E0161.ast.stderr
@@ -1,0 +1,9 @@
+error[E0161]: cannot move a value of type [i32]: the size of [i32] cannot be statically determined
+  --> $DIR/E0161.rs:32:9
+   |
+LL |     box *x; //~ ERROR E0161
+   |         ^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0161`.

--- a/src/test/ui/error-codes/E0161.astul.stderr
+++ b/src/test/ui/error-codes/E0161.astul.stderr
@@ -1,0 +1,9 @@
+error[E0161]: cannot move a value of type [i32]: the size of [i32] cannot be statically determined
+  --> $DIR/E0161.rs:32:5
+   |
+LL |     box *x; //~ ERROR E0161
+   |     ^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0161`.

--- a/src/test/ui/error-codes/E0161.edition.stderr
+++ b/src/test/ui/error-codes/E0161.edition.stderr
@@ -1,0 +1,9 @@
+error[E0161]: cannot move a value of type [i32]: the size of [i32] cannot be statically determined
+  --> $DIR/E0161.rs:32:9
+   |
+LL |     box *x; //~ ERROR E0161
+   |         ^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0161`.

--- a/src/test/ui/error-codes/E0161.editionul.stderr
+++ b/src/test/ui/error-codes/E0161.editionul.stderr
@@ -1,0 +1,9 @@
+error[E0161]: cannot move a value of type [i32]: the size of [i32] cannot be statically determined
+  --> $DIR/E0161.rs:32:5
+   |
+LL |     box *x; //~ ERROR E0161
+   |     ^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0161`.

--- a/src/test/ui/error-codes/E0161.nll.stderr
+++ b/src/test/ui/error-codes/E0161.nll.stderr
@@ -1,0 +1,9 @@
+error[E0161]: cannot move a value of type [i32]: the size of [i32] cannot be statically determined
+  --> $DIR/E0161.rs:32:9
+   |
+LL |     box *x; //~ ERROR E0161
+   |         ^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0161`.

--- a/src/test/ui/error-codes/E0161.nllul.stderr
+++ b/src/test/ui/error-codes/E0161.nllul.stderr
@@ -1,0 +1,9 @@
+error[E0161]: cannot move a value of type [i32]: the size of [i32] cannot be statically determined
+  --> $DIR/E0161.rs:32:5
+   |
+LL |     box *x; //~ ERROR E0161
+   |     ^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0161`.

--- a/src/test/ui/error-codes/E0161.rs
+++ b/src/test/ui/error-codes/E0161.rs
@@ -8,9 +8,28 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-compare-mode-nll
+
+// Check that E0161 is a hard error in all possible configurations that might
+// affect it.
+
+// revisions: ast nll zflags edition astul nllul zflagsul editionul
+//[zflags]compile-flags: -Z borrowck=migrate -Z two-phase-borrows
+//[edition]edition:2018
+//[zflagsul]compile-flags: -Z borrowck=migrate -Z two-phase-borrows
+//[editionul]edition:2018
+
+#![cfg_attr(nll, feature(nll))]
+#![cfg_attr(nllul, feature(nll))]
+#![cfg_attr(astul, feature(unsized_locals))]
+#![cfg_attr(zflagsul, feature(unsized_locals))]
+#![cfg_attr(nllul, feature(unsized_locals))]
+#![cfg_attr(editionul, feature(unsized_locals))]
+
 #![feature(box_syntax)]
 
-fn main() {
-    let _x: Box<str> = box *"hello"; //~ ERROR E0161
-                                     //~^ ERROR E0507
+fn foo(x: Box<[i32]>) {
+    box *x; //~ ERROR E0161
 }
+
+fn main() {}

--- a/src/test/ui/error-codes/E0161.zflags.stderr
+++ b/src/test/ui/error-codes/E0161.zflags.stderr
@@ -1,0 +1,9 @@
+error[E0161]: cannot move a value of type [i32]: the size of [i32] cannot be statically determined
+  --> $DIR/E0161.rs:32:9
+   |
+LL |     box *x; //~ ERROR E0161
+   |         ^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0161`.

--- a/src/test/ui/error-codes/E0161.zflagsul.stderr
+++ b/src/test/ui/error-codes/E0161.zflagsul.stderr
@@ -1,0 +1,9 @@
+error[E0161]: cannot move a value of type [i32]: the size of [i32] cannot be statically determined
+  --> $DIR/E0161.rs:32:5
+   |
+LL |     box *x; //~ ERROR E0161
+   |     ^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0161`.


### PR DESCRIPTION
This error has been on stable for a while, and allowing such code cause the compile to later ICE (since we can't codegen it). Errors `box UNSIZED EXPR` with unsized locals because it's not compatible with the current evaluation order (create the box before evaluating the expressions).

cc #53469 (fixes the ICE in this case)
cc @qnighy 