### PR TITLE
Remove super old comment on function that parses items

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -6842,8 +6842,6 @@ impl<'a> Parser<'a> {
     }
 
     /// Parse one of the items allowed by the flags.
-    /// NB: this function no longer parses the items inside an
-    /// extern crate.
     fn parse_item_implementation(
         &mut self,
         attrs: Vec<Attribute>,


### PR DESCRIPTION
This comment was added more than 5 years ago in ab03c1e4221. As far as anyone reading this comment today needs to know, the function has never parsed items from inside an extern crate.