### PR TITLE
resolve: Recover from indeterminate macro resolutions more agressively

### DIFF
--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -611,6 +611,7 @@ impl<'a, 'cl> Resolver<'a, 'cl> {
                     );
                     self.current_module = orig_current_module;
                     binding.map(|binding| (binding, FromPrelude(false)))
+                        .map_err(|d| Determinacy::determined(d == Determinacy::Determined || force))
                 }
                 WhereToResolve::MacroPrelude => {
                     match self.macro_prelude.get(&ident.name).cloned() {
@@ -756,7 +757,7 @@ impl<'a, 'cl> Resolver<'a, 'cl> {
                 Err(Determinacy::Determined) => {
                     continue_search!();
                 }
-                Err(Determinacy::Undetermined) => return Err(Determinacy::determined(force)),
+                Err(Determinacy::Undetermined) => return Err(Determinacy::Undetermined),
             }
         }
 

--- a/src/test/ui-fulldeps/proc-macro/auxiliary/issue-53481.rs
+++ b/src/test/ui-fulldeps/proc-macro/auxiliary/issue-53481.rs
@@ -1,0 +1,22 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+
+use proc_macro::*;
+
+#[proc_macro_derive(MyTrait, attributes(my_attr))]
+pub fn foo(_: TokenStream) -> TokenStream {
+    TokenStream::new()
+}

--- a/src/test/ui-fulldeps/proc-macro/issue-53481.rs
+++ b/src/test/ui-fulldeps/proc-macro/issue-53481.rs
@@ -1,0 +1,32 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-pass
+// aux-build:issue-53481.rs
+
+#[macro_use]
+extern crate issue_53481;
+
+mod m1 {
+    use m2::MyTrait;
+
+    #[derive(MyTrait)]
+    struct A {}
+}
+
+mod m2 {
+    pub type MyTrait = u8;
+
+    #[derive(MyTrait)]
+    #[my_attr]
+    struct B {}
+}
+
+fn main() {}


### PR DESCRIPTION
If we are in "forced resolution" mode and in-module resolution is indeterminate, don't give up and continue searching in outer scopes.

Fixes https://github.com/rust-lang/rust/issues/53481