### PR TITLE
52985 diagnostics no concrete type behind existential type

### DIFF
--- a/src/librustc/traits/query/normalize.rs
+++ b/src/librustc/traits/query/normalize.rs
@@ -12,15 +12,15 @@
 //! which folds deeply, invoking the underlying
 //! `normalize_projection_ty` query when it encounters projections.
 
-use infer::{InferCtxt, InferOk};
 use infer::at::At;
-use mir::interpret::{GlobalId, ConstValue};
+use infer::{InferCtxt, InferOk};
+use mir::interpret::{ConstValue, GlobalId};
 use rustc_data_structures::small_vec::SmallVec;
-use traits::{Obligation, ObligationCause, PredicateObligation, Reveal};
 use traits::project::Normalized;
-use ty::{self, Ty, TyCtxt};
+use traits::{Obligation, ObligationCause, PredicateObligation, Reveal};
 use ty::fold::{TypeFoldable, TypeFolder};
 use ty::subst::{Subst, Substs};
+use ty::{self, Ty, TyCtxt};
 
 use super::NoSolution;
 
@@ -121,9 +121,14 @@ impl<'cx, 'gcx, 'tcx> TypeFolder<'gcx, 'tcx> for QueryNormalizer<'cx, 'gcx, 'tcx
                         let concrete_ty = generic_ty.subst(self.tcx(), substs);
                         self.anon_depth += 1;
                         if concrete_ty == ty {
-                            bug!("infinite recursion generic_ty: {:#?}, substs: {:#?}, \
-                                  concrete_ty: {:#?}, ty: {:#?}", generic_ty, substs, concrete_ty,
-                                  ty);
+                            bug!(
+                                "infinite recursion generic_ty: {:#?}, substs: {:#?}, \
+                                 concrete_ty: {:#?}, ty: {:#?}",
+                                generic_ty,
+                                substs,
+                                concrete_ty,
+                                ty
+                            );
                         }
                         let folded_ty = self.fold_ty(concrete_ty);
                         self.anon_depth -= 1;
@@ -149,8 +154,8 @@ impl<'cx, 'gcx, 'tcx> TypeFolder<'gcx, 'tcx> for QueryNormalizer<'cx, 'gcx, 'tcx
                 let gcx = self.infcx.tcx.global_tcx();
 
                 let mut orig_values = SmallVec::new();
-                let c_data =
-                    self.infcx.canonicalize_query(&self.param_env.and(*data), &mut orig_values);
+                let c_data = self.infcx
+                    .canonicalize_query(&self.param_env.and(*data), &mut orig_values);
                 debug!("QueryNormalizer: c_data = {:#?}", c_data);
                 debug!("QueryNormalizer: orig_values = {:#?}", orig_values);
                 match gcx.normalize_projection_ty(c_data) {

--- a/src/librustc/traits/query/normalize.rs
+++ b/src/librustc/traits/query/normalize.rs
@@ -12,15 +12,15 @@
 //! which folds deeply, invoking the underlying
 //! `normalize_projection_ty` query when it encounters projections.
 
-use infer::at::At;
 use infer::{InferCtxt, InferOk};
-use mir::interpret::{ConstValue, GlobalId};
+use infer::at::At;
+use mir::interpret::{GlobalId, ConstValue};
 use rustc_data_structures::small_vec::SmallVec;
-use traits::project::Normalized;
 use traits::{Obligation, ObligationCause, PredicateObligation, Reveal};
+use traits::project::Normalized;
+use ty::{self, Ty, TyCtxt};
 use ty::fold::{TypeFoldable, TypeFolder};
 use ty::subst::{Subst, Substs};
-use ty::{self, Ty, TyCtxt};
 
 use super::NoSolution;
 
@@ -121,36 +121,9 @@ impl<'cx, 'gcx, 'tcx> TypeFolder<'gcx, 'tcx> for QueryNormalizer<'cx, 'gcx, 'tcx
                         let concrete_ty = generic_ty.subst(self.tcx(), substs);
                         self.anon_depth += 1;
                         if concrete_ty == ty {
-                            // The type in question can only be inferred in terms of itself. This
-                            // is likely a user code issue, not a compiler issue. Thus, we will
-                            // induce a cycle error by calling the parent query again on the type.
-                            //
-                            // FIXME: Perhaps a better solution would be to have fold_ty()
-                            // itself be a query. Then, a type fold cycle would be detected
-                            // and reported more naturally as part of the query system, rather
-                            // than forcing it here.
-                            //
-                            // FIXME: Need a better span than just one pointing to the type def.
-                            // Should point to a defining use of the type that results in this
-                            // un-normalizable state.
-                            if let Some(param_env_lifted) =
-                                self.tcx().lift_to_global(&self.param_env)
-                            {
-                                if let Some(ty_lifted) = self.tcx().lift_to_global(&concrete_ty) {
-                                    let span = self.tcx().def_span(def_id);
-                                    self.tcx()
-                                        .global_tcx()
-                                        .at(span)
-                                        .normalize_ty_after_erasing_regions(
-                                            param_env_lifted.and(ty_lifted),
-                                        );
-                                    self.tcx().sess.abort_if_errors();
-                                }
-                            }
-                            // If a cycle error can't be emitted, indicate a NoSolution error
-                            // and let the caller handle it.
-                            self.error = true;
-                            return concrete_ty;
+                            bug!("infinite recursion generic_ty: {:#?}, substs: {:#?}, \
+                                  concrete_ty: {:#?}, ty: {:#?}", generic_ty, substs, concrete_ty,
+                                  ty);
                         }
                         let folded_ty = self.fold_ty(concrete_ty);
                         self.anon_depth -= 1;
@@ -176,8 +149,8 @@ impl<'cx, 'gcx, 'tcx> TypeFolder<'gcx, 'tcx> for QueryNormalizer<'cx, 'gcx, 'tcx
                 let gcx = self.infcx.tcx.global_tcx();
 
                 let mut orig_values = SmallVec::new();
-                let c_data = self.infcx
-                    .canonicalize_query(&self.param_env.and(*data), &mut orig_values);
+                let c_data =
+                    self.infcx.canonicalize_query(&self.param_env.and(*data), &mut orig_values);
                 debug!("QueryNormalizer: c_data = {:#?}", c_data);
                 debug!("QueryNormalizer: orig_values = {:#?}", orig_values);
                 match gcx.normalize_projection_ty(c_data) {

--- a/src/librustc_typeck/check/writeback.rs
+++ b/src/librustc_typeck/check/writeback.rs
@@ -492,6 +492,14 @@ impl<'cx, 'gcx, 'tcx> WritebackCx<'cx, 'gcx, 'tcx> {
                 })
             };
 
+            if let ty::Anon(defin_ty_def_id, _substs) = definition_ty.sty {
+                if def_id == defin_ty_def_id {
+                  // Concrete type resolved to the existential type itself
+                  // Force a cycle error
+                  self.tcx().at(span).type_of(defin_ty_def_id);
+                }
+            }
+
             let old = self.tables.concrete_existential_types.insert(def_id, definition_ty);
             if let Some(old) = old {
                 if old != definition_ty {

--- a/src/test/ui/existential_types/nested_existential_types.rs
+++ b/src/test/ui/existential_types/nested_existential_types.rs
@@ -1,0 +1,31 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(existential_type)]
+// compile-pass
+mod my_mod {
+  use std::fmt::Debug;
+
+  pub existential type Foo: Debug;
+  pub existential type Foot: Debug;
+
+  pub fn get_foo() -> Foo {
+      5i32
+  }
+
+  pub fn get_foot() -> Foot {
+      get_foo()
+  }
+}
+
+fn main() {
+    let _: my_mod::Foot = my_mod::get_foot();
+}
+

--- a/src/test/ui/existential_types/no_inferrable_concrete_type.stderr
+++ b/src/test/ui/existential_types/no_inferrable_concrete_type.stderr
@@ -1,10 +1,15 @@
-error[E0391]: cycle detected when normalizing `ParamEnvAnd { param_env: ParamEnv { caller_bounds: [], reveal: All }, value: Foo }`
+error[E0391]: cycle detected when processing `Foo`
   --> $DIR/no_inferrable_concrete_type.rs:16:1
    |
 LL | existential type Foo: Copy; //~ cycle detected
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: ...which again requires normalizing `ParamEnvAnd { param_env: ParamEnv { caller_bounds: [], reveal: All }, value: Foo }`, completing the cycle
+note: ...which requires processing `bar`...
+  --> $DIR/no_inferrable_concrete_type.rs:19:23
+   |
+LL | fn bar(x: Foo) -> Foo { x }
+   |                       ^^^^^
+   = note: ...which again requires processing `Foo`, completing the cycle
 
 error: aborting due to previous error
 


### PR DESCRIPTION
@oli-obk FYI. See below for new cycle error generated.

```rust
error[E0391]: cycle detected when processing `Foo`
 --> /dev/staging/existential_type_no_concrete_type_nouse_potential.rs:3:1
  |
3 | existential type Foo: Copy;
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
note: ...which requires processing `bar`...
 --> /dev/staging/existential_type_no_concrete_type_nouse_potential.rs:6:23
  |
6 |   fn bar(x: Foo) -> Foo { 
  |  _______________________^
7 | |     x
8 | | }
  | |_^
  = note: ...which again requires processing `Foo`, completing the cycle

error: aborting due to previous error

For more information about this error, try `rustc --explain E0391`.
```
