### PR TITLE
docs: minor stylistic changes to str/string docs

### DIFF
--- a/src/liballoc/str.rs
+++ b/src/liballoc/str.rs
@@ -513,7 +513,7 @@ impl str {
         unsafe { String::from_utf8_unchecked(slice.into_vec()) }
     }
 
-    /// Create a [`String`] by repeating a string `n` times.
+    /// Creates a new [`String`] by repeating a string `n` times.
     ///
     /// [`String`]: string/struct.String.html
     ///

--- a/src/liballoc/string.rs
+++ b/src/liballoc/string.rs
@@ -752,7 +752,7 @@ impl String {
         self.vec
     }
 
-    /// Extracts a string slice containing the entire string.
+    /// Extracts a string slice containing the entire `String`.
     ///
     /// # Examples
     ///
@@ -1454,8 +1454,8 @@ impl String {
         self.vec.clear()
     }
 
-    /// Creates a draining iterator that removes the specified range in the string
-    /// and yields the removed chars.
+    /// Creates a draining iterator that removes the specified range in the `String`
+    /// and yields the removed `chars`.
     ///
     /// Note: The element range is removed even if the iterator is not
     /// consumed until the end.


### PR DESCRIPTION
std::string::String.repeat(): slightly rephrase to be more in-line with other descriptions.

add ticks around a few keywords in other descriptions.