### PR TITLE
tidy: Stop requiring a license header

### DIFF
--- a/src/tools/tidy/src/style.rs
+++ b/src/tools/tidy/src/style.rs
@@ -17,7 +17,6 @@
 //! * No trailing whitespace
 //! * No CR characters
 //! * No `TODO` or `XXX` directives
-//! * A valid license header is at the top
 //! * No unexplained ` ```ignore ` or ` ```rust,ignore ` doc tests
 //!
 //! A number of these checks can be opted-out of with various directives like
@@ -28,16 +27,6 @@ use std::io::prelude::*;
 use std::path::Path;
 
 const COLS: usize = 100;
-const LICENSE: &'static str = "\
-Copyright <year> The Rust Project Developers. See the COPYRIGHT
-file at the top-level directory of this distribution and at
-http://rust-lang.org/COPYRIGHT.
-
-Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-<LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-option. This file may not be copied, modified, or distributed
-except according to those terms.";
 
 const UNEXPLAINED_IGNORE_DOCTEST_INFO: &str = r#"unexplained "```ignore" doctest; try one:
 
@@ -168,52 +157,10 @@ pub fn check(path: &Path, bad: &mut bool) {
                 trailing_new_lines = 0;
             }
         }
-        if !licenseck(file, &contents) {
-            tidy_error!(bad, "{}: incorrect license", file.display());
-        }
         match trailing_new_lines {
             0 => tidy_error!(bad, "{}: missing trailing newline", file.display()),
             1 | 2 => {}
             n => tidy_error!(bad, "{}: too many trailing newlines ({})", file.display(), n),
         };
     })
-}
-
-fn licenseck(file: &Path, contents: &str) -> bool {
-    if contents.contains("ignore-license") {
-        return true
-    }
-    let exceptions = [
-        "libstd/sync/mpsc/mpsc_queue.rs",
-        "libstd/sync/mpsc/spsc_queue.rs",
-    ];
-    if exceptions.iter().any(|f| file.ends_with(f)) {
-        return true
-    }
-
-    // Skip the BOM if it's there
-    let bom = "\u{feff}";
-    let contents = if contents.starts_with(bom) {&contents[3..]} else {contents};
-
-    // See if the license shows up in the first 100 lines
-    let lines = contents.lines().take(100).collect::<Vec<_>>();
-    lines.windows(LICENSE.lines().count()).any(|window| {
-        let offset = if window.iter().all(|w| w.starts_with("//")) {
-            2
-        } else if window.iter().all(|w| w.starts_with('#')) {
-            1
-        } else if window.iter().all(|w| w.starts_with(" *")) {
-            2
-        } else {
-            return false
-        };
-        window.iter().map(|a| a[offset..].trim())
-              .zip(LICENSE.lines()).all(|(a, b)| {
-            a == b || match b.find("<year>") {
-                Some(i) => a.starts_with(&b[..i]) && a.ends_with(&b[i+6..]),
-                None => false,
-            }
-        })
-    })
-
 }


### PR DESCRIPTION
Previously approved in rust-lang/rust#43498 ; update tidy to match.