### PR TITLE
Add target thumbv7a-pc-windows-msvc

### DIFF
--- a/src/libpanic_unwind/seh.rs
+++ b/src/libpanic_unwind/seh.rs
@@ -119,7 +119,9 @@ mod imp {
     }
 }
 
-#[cfg(target_arch = "x86_64")]
+// TODO: this needs to be validated when WinEH for ARM is implemented in LLVM
+// It looks like ARM and ARM64 use the same _TypeInfo semantics as x64
+#[cfg(any(target_arch = "x86_64", target_arch = "arm"))]
 #[macro_use]
 mod imp {
     pub type ptr_t = u32;

--- a/src/libpanic_unwind/seh.rs
+++ b/src/libpanic_unwind/seh.rs
@@ -119,8 +119,6 @@ mod imp {
     }
 }
 
-// TODO: this needs to be validated when WinEH for ARM is implemented in LLVM
-// It looks like ARM and ARM64 use the same _TypeInfo semantics as x64
 #[cfg(any(target_arch = "x86_64", target_arch = "arm"))]
 #[macro_use]
 mod imp {

--- a/src/librustc_target/spec/mod.rs
+++ b/src/librustc_target/spec/mod.rs
@@ -386,6 +386,7 @@ supported_targets! {
     ("x86_64-pc-windows-msvc", x86_64_pc_windows_msvc),
     ("i686-pc-windows-msvc", i686_pc_windows_msvc),
     ("i586-pc-windows-msvc", i586_pc_windows_msvc),
+    ("thumbv7a-pc-windows-msvc", thumbv7a_pc_windows_msvc),
 
     ("asmjs-unknown-emscripten", asmjs_unknown_emscripten),
     ("wasm32-unknown-emscripten", wasm32_unknown_emscripten),

--- a/src/librustc_target/spec/thumbv7a_pc_windows_msvc.rs
+++ b/src/librustc_target/spec/thumbv7a_pc_windows_msvc.rs
@@ -1,4 +1,4 @@
-// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -12,21 +12,6 @@ use spec::{LinkerFlavor, Target, TargetOptions, TargetResult, PanicStrategy};
 
 pub fn target() -> TargetResult {
     let mut base = super::windows_msvc_base::opts();
-
-    base.pre_link_args.get_mut(&LinkerFlavor::Msvc).unwrap().push(
-        "/LIBPATH:C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Enterprise\\VC\\Tools\\MSVC\\14.11.25503\\lib\\arm".to_string());
-
-    base.pre_link_args.get_mut(&LinkerFlavor::Msvc).unwrap().push(
-        "/LIBPATH:C:\\Program Files (x86)\\Windows Kits\\10\\lib\\10.0.17134.0\\ucrt\\arm".to_string());
-
-    base.pre_link_args.get_mut(&LinkerFlavor::Msvc).unwrap().push(
-        "/LIBPATH:C:\\Program Files (x86)\\Windows Kits\\10\\lib\\10.0.17134.0\\um\\arm".to_string());
-
-    base.pre_link_args.get_mut(&LinkerFlavor::Msvc).unwrap().push(
-        "/MACHINE:ARM".to_string());
-
-    base.pre_link_args.get_mut(&LinkerFlavor::Msvc).unwrap().push(
-        "/INCREMENTAL:NO".to_string());
 
     // Prevent error LNK2013: BRANCH24(T) fixup overflow
     base.pre_link_args.get_mut(&LinkerFlavor::Msvc).unwrap().push(
@@ -47,7 +32,7 @@ pub fn target() -> TargetResult {
         linker_flavor: LinkerFlavor::Msvc,
 
         options: TargetOptions {
-            features: "+v7,+thumb-mode,+vfp3,+d16,+thumb2,+neon".to_string(),
+            features: "+vfp3,+neon".to_string(),
             cpu: "generic".to_string(),
             max_atomic_width: Some(64),
             abi_blacklist: super::arm_base::abi_blacklist(),

--- a/src/librustc_target/spec/thumbv7a_pc_windows_msvc.rs
+++ b/src/librustc_target/spec/thumbv7a_pc_windows_msvc.rs
@@ -14,9 +14,17 @@ pub fn target() -> TargetResult {
     let mut base = super::windows_msvc_base::opts();
 
     // Prevent error LNK2013: BRANCH24(T) fixup overflow
+    // The LBR optimization tries to eliminate branch islands,
+    // but if the displacement is larger than can fit
+    // in the instruction, this error will occur. The linker
+    // should be smart enough to insert branch islands only
+    // where necessary, but this is not the observed behavior.
+    // Disabling the LBR optimization works around the issue.
     base.pre_link_args.get_mut(&LinkerFlavor::Msvc).unwrap().push(
         "/OPT:NOLBR".to_string());
 
+    // FIXME(jordanrh): use PanicStrategy::Unwind when SEH is
+    // implemented for windows/arm in LLVM
     base.panic_strategy = PanicStrategy::Abort;
 
     Ok(Target {

--- a/src/librustc_target/spec/thumbv7a_pc_windows_msvc.rs
+++ b/src/librustc_target/spec/thumbv7a_pc_windows_msvc.rs
@@ -1,0 +1,57 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use spec::{LinkerFlavor, Target, TargetOptions, TargetResult, PanicStrategy};
+
+pub fn target() -> TargetResult {
+    let mut base = super::windows_msvc_base::opts();
+
+    base.pre_link_args.get_mut(&LinkerFlavor::Msvc).unwrap().push(
+        "/LIBPATH:C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Enterprise\\VC\\Tools\\MSVC\\14.11.25503\\lib\\arm".to_string());
+
+    base.pre_link_args.get_mut(&LinkerFlavor::Msvc).unwrap().push(
+        "/LIBPATH:C:\\Program Files (x86)\\Windows Kits\\10\\lib\\10.0.17134.0\\ucrt\\arm".to_string());
+
+    base.pre_link_args.get_mut(&LinkerFlavor::Msvc).unwrap().push(
+        "/LIBPATH:C:\\Program Files (x86)\\Windows Kits\\10\\lib\\10.0.17134.0\\um\\arm".to_string());
+
+    base.pre_link_args.get_mut(&LinkerFlavor::Msvc).unwrap().push(
+        "/MACHINE:ARM".to_string());
+
+    base.pre_link_args.get_mut(&LinkerFlavor::Msvc).unwrap().push(
+        "/INCREMENTAL:NO".to_string());
+
+    // Prevent error LNK2013: BRANCH24(T) fixup overflow
+    base.pre_link_args.get_mut(&LinkerFlavor::Msvc).unwrap().push(
+        "/OPT:NOLBR".to_string());
+
+    base.panic_strategy = PanicStrategy::Abort;
+
+    Ok(Target {
+        llvm_target: "thumbv7a-pc-windows-msvc".to_string(),
+        target_endian: "little".to_string(),
+        target_pointer_width: "32".to_string(),
+        target_c_int_width: "32".to_string(),
+        data_layout: "e-m:w-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64".to_string(),
+        arch: "arm".to_string(),
+        target_os: "windows".to_string(),
+        target_env: "msvc".to_string(),
+        target_vendor: "pc".to_string(),
+        linker_flavor: LinkerFlavor::Msvc,
+
+        options: TargetOptions {
+            features: "+v7,+thumb-mode,+vfp3,+d16,+thumb2,+neon".to_string(),
+            cpu: "generic".to_string(),
+            max_atomic_width: Some(64),
+            abi_blacklist: super::arm_base::abi_blacklist(),
+            .. base
+        }
+    })
+}

--- a/src/libstd/sys/windows/backtrace/mod.rs
+++ b/src/libstd/sys/windows/backtrace/mod.rs
@@ -248,6 +248,17 @@ impl StackFrame for c::STACKFRAME_EX {
         c::IMAGE_FILE_MACHINE_AMD64
     }
 
+    #[cfg(target_arch = "arm")]
+    fn init(&mut self, ctx: &c::CONTEXT) -> c::DWORD {
+        self.AddrPC.Offset = ctx.Pc as u64;
+        self.AddrPC.Mode = c::ADDRESS_MODE::AddrModeFlat;
+        self.AddrStack.Offset = ctx.Sp as u64;
+        self.AddrStack.Mode = c::ADDRESS_MODE::AddrModeFlat;
+        self.AddrFrame.Offset = ctx.R11 as u64;
+        self.AddrFrame.Mode = c::ADDRESS_MODE::AddrModeFlat;
+        c::IMAGE_FILE_MACHINE_ARMNT
+    }
+
     #[cfg(target_arch = "aarch64")]
     fn init(&mut self, ctx: &c::CONTEXT) -> c::DWORD {
         self.AddrPC.Offset = ctx.Pc as u64;
@@ -289,6 +300,17 @@ impl StackFrame for c::STACKFRAME64 {
         self.AddrFrame.Offset = ctx.Rbp as u64;
         self.AddrFrame.Mode = c::ADDRESS_MODE::AddrModeFlat;
         c::IMAGE_FILE_MACHINE_AMD64
+    }
+
+    #[cfg(target_arch = "arm")]
+    fn init(&mut self, ctx: &c::CONTEXT) -> c::DWORD {
+        self.AddrPC.Offset = ctx.Pc as u64;
+        self.AddrPC.Mode = c::ADDRESS_MODE::AddrModeFlat;
+        self.AddrStack.Offset = ctx.Sp as u64;
+        self.AddrStack.Mode = c::ADDRESS_MODE::AddrModeFlat;
+        self.AddrFrame.Offset = ctx.R11 as u64;
+        self.AddrFrame.Mode = c::ADDRESS_MODE::AddrModeFlat;
+        c::IMAGE_FILE_MACHINE_ARMNT
     }
 
     #[cfg(target_arch = "aarch64")]

--- a/src/libstd/sys/windows/c.rs
+++ b/src/libstd/sys/windows/c.rs
@@ -114,6 +114,11 @@ pub const SECURITY_SQOS_PRESENT: DWORD = 0x00100000;
 
 pub const FIONBIO: c_ulong = 0x8004667e;
 
+#[cfg(target_arch = "arm")]
+const ARM_MAX_BREAKPOINTS: usize = 8;
+#[cfg(target_arch = "arm")]
+const ARM_MAX_WATCHPOINTS: usize = 1;
+
 #[repr(C)]
 #[derive(Copy)]
 pub struct WIN32_FIND_DATAW {
@@ -283,6 +288,9 @@ pub const IMAGE_FILE_MACHINE_AMD64: DWORD = 0x8664;
 #[cfg(target_arch = "aarch64")]
 #[cfg(feature = "backtrace")]
 pub const IMAGE_FILE_MACHINE_ARM64: DWORD = 0xAA64;
+#[cfg(target_arch = "arm")]
+#[cfg(feature = "backtrace")]
+pub const IMAGE_FILE_MACHINE_ARMNT: DWORD = 0x01c4;
 
 pub const EXCEPTION_CONTINUE_SEARCH: LONG = 0;
 pub const EXCEPTION_STACK_OVERFLOW: DWORD = 0xc00000fd;
@@ -789,12 +797,43 @@ pub struct FLOATING_SAVE_AREA {
     _Dummy: [u8; 512] // FIXME: Fill this out
 }
 
+#[cfg(target_arch = "arm")]
+#[repr(C)]
+pub struct CONTEXT {
+    pub ContextFlags: ULONG,
+    pub R0: ULONG,
+    pub R1: ULONG,
+    pub R2: ULONG,
+    pub R3: ULONG,
+    pub R4: ULONG,
+    pub R5: ULONG,
+    pub R6: ULONG,
+    pub R7: ULONG,
+    pub R8: ULONG,
+    pub R9: ULONG,
+    pub R10: ULONG,
+    pub R11: ULONG,
+    pub R12: ULONG,
+    pub Sp: ULONG,
+    pub Lr: ULONG,
+    pub Pc: ULONG,
+    pub Cpsr: ULONG,
+    pub Fpscr: ULONG,
+    pub Padding: ULONG,
+    pub D: [u64; 32],
+    pub Bvr: [ULONG; ARM_MAX_BREAKPOINTS],
+    pub Bcr: [ULONG; ARM_MAX_BREAKPOINTS],
+    pub Wvr: [ULONG; ARM_MAX_WATCHPOINTS],
+    pub Wcr: [ULONG; ARM_MAX_WATCHPOINTS],
+    pub Padding2: [ULONG; 2]
+}
+
 // FIXME(#43348): This structure is used for backtrace only, and a fake
 // definition is provided here only to allow rustdoc to pass type-check. This
 // will not appear in the final documentation. This should be also defined for
 // other architectures supported by Windows such as ARM, and for historical
 // interest, maybe MIPS and PowerPC as well.
-#[cfg(all(rustdoc, not(any(target_arch = "x86_64", target_arch = "x86", target_arch = "aarch64"))))]
+#[cfg(all(rustdoc, not(any(target_arch = "x86_64", target_arch = "x86", target_arch = "aarch64", target_arch = "arm"))))]
 pub enum CONTEXT {}
 
 #[cfg(target_arch = "aarch64")]

--- a/src/libstd/sys/windows/c.rs
+++ b/src/libstd/sys/windows/c.rs
@@ -833,7 +833,8 @@ pub struct CONTEXT {
 // will not appear in the final documentation. This should be also defined for
 // other architectures supported by Windows such as ARM, and for historical
 // interest, maybe MIPS and PowerPC as well.
-#[cfg(all(rustdoc, not(any(target_arch = "x86_64", target_arch = "x86", target_arch = "aarch64", target_arch = "arm"))))]
+#[cfg(all(rustdoc, not(any(target_arch = "x86_64", target_arch = "x86",
+      target_arch = "aarch64", target_arch = "arm"))))]
 pub enum CONTEXT {}
 
 #[cfg(target_arch = "aarch64")]


### PR DESCRIPTION
This is an early draft of support for Windows/ARM. To test it,

1. Install Visual Studio 2017 and Windows SDK version 17134.
1. Obtain alexcrichton/xz2-rs#35, rust-lang-nursery/compiler-builtins#256, and the fix for [LLVM Bug 38620](https://bugs.llvm.org/show_bug.cgi?id=38620).
2. Open a command prompt and run
```
set CC_thumbv7a-pc-windows-msvc=C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Tools\MSVC\14.11.25503\bin\HostX64\arm\CL.exe
set CFLAGS_thumbv7a-pc-windows-msvc=/D_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE=1 /nologo
c:\python27\python.exe x.py build --host x86_64-pc-windows-msvc --build x86_64-pc-windows-msvc --target thumbv7a-pc-windows-msvc
```

It will build the stage 2 compiler, but fail building stage 2 test. To build an executable targeting windows/arm,
1. Copy `build\x86_64-pc-windows-msvc\stage0\bin\cargo.exe` to `build\x86_64-pc-windows-msvc\stage2\bin`
2. Open a command prompt and run
```
"C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
set PATH=build\x86_64-pc-windows-msvc\stage2\bin;%PATH%
cargo new hello
cd hello
cargo build --target thumbv7a-pc-windows-msvc –release
```

Copy target\thumbv7a-pc-windows-msvc\release\hello.exe to your platform and run.

There are a number of open issues that I'm hoping to get help with:

 - Error when compiling the `test` crate: `error: cannot link together two panic runtimes: panic_abort and panic_unwind`
 - Warnings when building the compiler_builtins crate: `warning: cl : Command line warning D9002 : ignoring unknown option '-fvisibility=hidden'`. It looks like the build system is passing GCC-style flags to MSVC.
 - How to specify the LIBPATH entries for ARM. Right now they are hardcoded as absolute paths in the target spec.

This pull request depends on
 - alexcrichton/xz2-rs#35 - update vcxproj to Visual Studio 2017
 - rust-lang-nursery/compiler-builtins#256 - fix compile errors when building for windows/arm
 - [Bug 38620 - ARM: Incorrect COFF relocation type for thumb bl instruction](https://bugs.llvm.org/show_bug.cgi?id=38620)

This PR updates #52659
