### PR TITLE
rustc: Continue to tweak "std internal symbols"

### DIFF
--- a/src/liballoc_jemalloc/lib.rs
+++ b/src/liballoc_jemalloc/lib.rs
@@ -89,16 +89,16 @@ mod contents {
     // linkage directives are provided as part of the current compiler allocator
     // ABI
 
-    #[no_mangle]
     #[rustc_std_internal_symbol]
+    #[cfg_attr(stage0, no_mangle)]
     pub unsafe extern fn __rde_alloc(size: usize, align: usize) -> *mut u8 {
         let flags = align_to_flags(align, size);
         let ptr = mallocx(size as size_t, flags) as *mut u8;
         ptr
     }
 
-    #[no_mangle]
     #[rustc_std_internal_symbol]
+    #[cfg_attr(stage0, no_mangle)]
     pub unsafe extern fn __rde_dealloc(ptr: *mut u8,
                                        size: usize,
                                        align: usize) {
@@ -106,8 +106,8 @@ mod contents {
         sdallocx(ptr as *mut c_void, size, flags);
     }
 
-    #[no_mangle]
     #[rustc_std_internal_symbol]
+    #[cfg_attr(stage0, no_mangle)]
     pub unsafe extern fn __rde_realloc(ptr: *mut u8,
                                        _old_size: usize,
                                        align: usize,
@@ -117,8 +117,8 @@ mod contents {
         ptr
     }
 
-    #[no_mangle]
     #[rustc_std_internal_symbol]
+    #[cfg_attr(stage0, no_mangle)]
     pub unsafe extern fn __rde_alloc_zeroed(size: usize, align: usize) -> *mut u8 {
         let ptr = if align <= MIN_ALIGN && align <= size {
             calloc(size as size_t, 1) as *mut u8

--- a/src/libpanic_abort/lib.rs
+++ b/src/libpanic_abort/lib.rs
@@ -31,7 +31,7 @@
 
 // Rust's "try" function, but if we're aborting on panics we just call the
 // function as there's nothing else we need to do here.
-#[no_mangle]
+#[cfg_attr(stage0, no_mangle)]
 #[rustc_std_internal_symbol]
 pub unsafe extern fn __rust_maybe_catch_panic(f: fn(*mut u8),
                                               data: *mut u8,
@@ -51,7 +51,7 @@ pub unsafe extern fn __rust_maybe_catch_panic(f: fn(*mut u8),
 // which would break compat with XP. For now just use `intrinsics::abort` which
 // will kill us with an illegal instruction, which will do a good enough job for
 // now hopefully.
-#[no_mangle]
+#[cfg_attr(stage0, no_mangle)]
 #[rustc_std_internal_symbol]
 pub unsafe extern fn __rust_start_panic(_payload: usize) -> u32 {
     abort();

--- a/src/librustc/ich/impls_hir.rs
+++ b/src/librustc/ich/impls_hir.rs
@@ -1136,6 +1136,7 @@ impl_stable_hash_for!(struct hir::CodegenFnAttrs {
     flags,
     inline,
     export_name,
+    link_name,
     target_features,
     linkage,
     link_section,

--- a/src/librustc/middle/reachable.rs
+++ b/src/librustc/middle/reachable.rs
@@ -231,8 +231,11 @@ impl<'a, 'tcx> ReachableContext<'a, 'tcx> {
                     false
                 };
                 let def_id = self.tcx.hir.local_def_id(item.id);
-                let is_extern = self.tcx.codegen_fn_attrs(def_id).contains_extern_indicator();
-                if reachable || is_extern {
+                let codegen_attrs = self.tcx.codegen_fn_attrs(def_id);
+                let is_extern = codegen_attrs.contains_extern_indicator();
+                let std_internal = codegen_attrs.flags.contains(
+                    CodegenFnAttrFlags::RUSTC_STD_INTERNAL_SYMBOL);
+                if reachable || is_extern || std_internal {
                     self.reachable_symbols.insert(search_item);
                 }
             }

--- a/src/librustc_allocator/expand.rs
+++ b/src/librustc_allocator/expand.rs
@@ -236,15 +236,9 @@ impl<'a> AllocFnFactory<'a> {
     }
 
     fn attrs(&self) -> Vec<Attribute> {
-        let no_mangle = Symbol::intern("no_mangle");
-        let no_mangle = self.cx.meta_word(self.span, no_mangle);
-
         let special = Symbol::intern("rustc_std_internal_symbol");
         let special = self.cx.meta_word(self.span, special);
-        vec![
-            self.cx.attribute(self.span, no_mangle),
-            self.cx.attribute(self.span, special),
-        ]
+        vec![self.cx.attribute(self.span, special)]
     }
 
     fn arg_ty(

--- a/src/librustc_mir/monomorphize/collector.rs
+++ b/src/librustc_mir/monomorphize/collector.rs
@@ -1023,7 +1023,6 @@ impl<'b, 'a, 'v> RootCollector<'b, 'a, 'v> {
             MonoItemCollectionMode::Lazy => {
                 self.entry_fn == Some(def_id) ||
                 self.tcx.is_reachable_non_generic(def_id) ||
-                self.tcx.is_weak_lang_item(def_id) ||
                 self.tcx.codegen_fn_attrs(def_id).flags.contains(
                     CodegenFnAttrFlags::RUSTC_STD_INTERNAL_SYMBOL)
             }

--- a/src/librustc_mir/monomorphize/partitioning.rs
+++ b/src/librustc_mir/monomorphize/partitioning.rs
@@ -516,10 +516,8 @@ fn mono_item_visibility(
         //   visibility below. Like the weak lang items, though, we can't let
         //   LLVM internalize them as this decision is left up to the linker to
         //   omit them, so prevent them from being internalized.
-        let codegen_fn_attrs = tcx.codegen_fn_attrs(def_id);
-        let std_internal_symbol = codegen_fn_attrs.flags
-            .contains(CodegenFnAttrFlags::RUSTC_STD_INTERNAL_SYMBOL);
-        if tcx.is_weak_lang_item(def_id) || std_internal_symbol {
+        let attrs = tcx.codegen_fn_attrs(def_id);
+        if attrs.flags.contains(CodegenFnAttrFlags::RUSTC_STD_INTERNAL_SYMBOL) {
             *can_be_internalized = false;
         }
 

--- a/src/libstd/alloc.rs
+++ b/src/libstd/alloc.rs
@@ -150,23 +150,23 @@ pub mod __default_lib_allocator {
     // linkage directives are provided as part of the current compiler allocator
     // ABI
 
-    #[no_mangle]
     #[rustc_std_internal_symbol]
+    #[cfg_attr(stage0, no_mangle)]
     pub unsafe extern fn __rdl_alloc(size: usize, align: usize) -> *mut u8 {
         let layout = Layout::from_size_align_unchecked(size, align);
         System.alloc(layout)
     }
 
-    #[no_mangle]
     #[rustc_std_internal_symbol]
+    #[cfg_attr(stage0, no_mangle)]
     pub unsafe extern fn __rdl_dealloc(ptr: *mut u8,
                                        size: usize,
                                        align: usize) {
         System.dealloc(ptr, Layout::from_size_align_unchecked(size, align))
     }
 
-    #[no_mangle]
     #[rustc_std_internal_symbol]
+    #[cfg_attr(stage0, no_mangle)]
     pub unsafe extern fn __rdl_realloc(ptr: *mut u8,
                                        old_size: usize,
                                        align: usize,
@@ -175,8 +175,8 @@ pub mod __default_lib_allocator {
         System.realloc(ptr, old_layout, new_size)
     }
 
-    #[no_mangle]
     #[rustc_std_internal_symbol]
+    #[cfg_attr(stage0, no_mangle)]
     pub unsafe extern fn __rdl_alloc_zeroed(size: usize, align: usize) -> *mut u8 {
         let layout = Layout::from_size_align_unchecked(size, align);
         System.alloc_zeroed(layout)

--- a/src/test/run-make/wasm-symbols-not-imported/Makefile
+++ b/src/test/run-make/wasm-symbols-not-imported/Makefile
@@ -1,0 +1,16 @@
+-include ../../run-make-fulldeps/tools.mk
+
+ifeq ($(TARGET),wasm32-unknown-unknown)
+all:
+	$(RUSTC) foo.rs --target wasm32-unknown-unknown
+	$(NODE) verify-no-imports.js $(TMPDIR)/foo.wasm
+	$(RUSTC) foo.rs --target wasm32-unknown-unknown -C lto
+	$(NODE) verify-no-imports.js $(TMPDIR)/foo.wasm
+	$(RUSTC) foo.rs --target wasm32-unknown-unknown -O
+	$(NODE) verify-no-imports.js $(TMPDIR)/foo.wasm
+	$(RUSTC) foo.rs --target wasm32-unknown-unknown -O -C lto
+	$(NODE) verify-no-imports.js $(TMPDIR)/foo.wasm
+else
+all:
+endif
+

--- a/src/test/run-make/wasm-symbols-not-imported/foo.rs
+++ b/src/test/run-make/wasm-symbols-not-imported/foo.rs
@@ -1,0 +1,26 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type = "cdylib"]
+
+#![feature(panic_implementation)]
+#![no_std]
+
+use core::panic::PanicInfo;
+
+#[no_mangle]
+pub extern fn foo() {
+    panic!()
+}
+
+#[panic_implementation]
+fn panic(_info: &PanicInfo) -> ! {
+    loop {}
+}

--- a/src/test/run-make/wasm-symbols-not-imported/verify-no-imports.js
+++ b/src/test/run-make/wasm-symbols-not-imported/verify-no-imports.js
@@ -1,0 +1,20 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+const fs = require('fs');
+const process = require('process');
+const assert = require('assert');
+const buffer = fs.readFileSync(process.argv[2]);
+
+let m = new WebAssembly.Module(buffer);
+let list = WebAssembly.Module.imports(m);
+console.log('imports', list);
+if (list.length !== 0)
+  throw new Error("there are some imports");

--- a/src/test/ui/panic-handler/panic-handler-std.stderr
+++ b/src/test/ui/panic-handler/panic-handler-std.stderr
@@ -8,6 +8,12 @@ LL | | }
    |
    = note: first defined in crate `std`.
 
-error: aborting due to previous error
+error: argument should be `&PanicInfo`
+  --> $DIR/panic-handler-std.rs:18:16
+   |
+LL | fn panic(info: PanicInfo) -> ! {
+   |                ^^^^^^^^^
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0152`.


### PR DESCRIPTION
In investigating [an issue][1] with `panic_implementation` defined in an
executable that's optimized I once again got to rethinking a bit about the
`rustc_std_internal_symbol` attribute as well as weak lang items. We've sort of
been non-stop tweaking these items ever since their inception, and this
continues to the trend.

The crux of the bug was that in the reachability we have a [different branch][2]
for non-library builds which meant that weak lang items (and std internal
symbols) weren't considered reachable, causing them to get eliminiated by
ThinLTO passes. The fix was to basically tweak that branch to consider these
symbols to ensure that they're propagated all the way to the linker.

Along the way I've attempted to erode the distinction between std internal
symbols and weak lang items by having weak lang items automatically configure
fields of `CodegenFnAttrs`. That way most code no longer even considers weak
lang items and they're simply considered normal functions with attributes about
the ABI.

In the end this fixes the final comment of #51342

[1]: https://github.com/rust-lang/rust/issues/51342#issuecomment-414368019
[2]: https://github.com/rust-lang/rust/blob/35bf1ae25799a4e62131159f052e0a3cbd27c960/src/librustc/middle/reachable.rs#L225-L238