### PR TITLE
Address two regressions

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -331,6 +331,13 @@ declare_lint! {
      via the module system"
 }
 
+declare_lint! {
+    pub MACRO_EXPANDED_MACRO_EXPORTS_ACCESSED_BY_ABSOLUTE_PATHS,
+    Deny,
+    "macro-expanded `macro_export` macros from the current crate \
+     cannot be referred to by absolute paths"
+}
+
 /// Some lints that are buffered from `libsyntax`. See `syntax::early_buffered_lints`.
 pub mod parser {
     declare_lint! {
@@ -398,6 +405,7 @@ impl LintPass for HardwiredLints {
             WHERE_CLAUSES_OBJECT_SAFETY,
             PROC_MACRO_DERIVE_RESOLUTION_FALLBACK,
             MACRO_USE_EXTERN_CRATE,
+            MACRO_EXPANDED_MACRO_EXPORTS_ACCESSED_BY_ABSOLUTE_PATHS,
             parser::QUESTION_MARK_MACRO_SEP,
         )
     }
@@ -412,6 +420,7 @@ pub enum BuiltinLintDiagnostics {
     AbsPathWithModule(Span),
     DuplicatedMacroExports(ast::Ident, Span, Span),
     ProcMacroDeriveResolutionFallback(Span),
+    MacroExpandedMacroExportsAccessedByAbsolutePaths(Span),
     ElidedLifetimesInPaths(usize, Span, bool, Span, String),
 }
 
@@ -452,6 +461,9 @@ impl BuiltinLintDiagnostics {
             BuiltinLintDiagnostics::ProcMacroDeriveResolutionFallback(span) => {
                 db.span_label(span, "names from parent modules are not \
                                      accessible without an explicit import");
+            }
+            BuiltinLintDiagnostics::MacroExpandedMacroExportsAccessedByAbsolutePaths(span_def) => {
+                db.span_note(span_def, "the macro is defined here");
             }
             BuiltinLintDiagnostics::ElidedLifetimesInPaths(
                 n, path_span, incl_angl_brckt, insertion_span, anon_lts

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -334,7 +334,12 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
             id: LintId::of(QUESTION_MARK_MACRO_SEP),
             reference: "issue #48075 <https://github.com/rust-lang/rust/issues/48075>",
             edition: Some(Edition::Edition2018),
-        }
+        },
+        FutureIncompatibleInfo {
+            id: LintId::of(MACRO_EXPANDED_MACRO_EXPORTS_ACCESSED_BY_ABSOLUTE_PATHS),
+            reference: "issue #52234 <https://github.com/rust-lang/rust/issues/52234>",
+            edition: None,
+        },
         ]);
 
     // Register renamed and removed lints

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -4477,9 +4477,12 @@ impl<'a, 'crateloader: 'a> Resolver<'a, 'crateloader> {
         for &(span_use, span_def) in &self.macro_expanded_macro_export_errors {
             let msg = "macro-expanded `macro_export` macros from the current crate \
                        cannot be referred to by absolute paths";
-            self.session.struct_span_err(span_use, msg)
-                        .span_note(span_def, "the macro is defined here")
-                        .emit();
+            self.session.buffer_lint_with_diagnostic(
+                lint::builtin::MACRO_EXPANDED_MACRO_EXPORTS_ACCESSED_BY_ABSOLUTE_PATHS,
+                CRATE_NODE_ID, span_use, msg,
+                lint::builtin::BuiltinLintDiagnostics::
+                    MacroExpandedMacroExportsAccessedByAbsolutePaths(span_def),
+            );
         }
 
         for &AmbiguityError { span, name, b1, b2, lexical } in &self.ambiguity_errors {

--- a/src/libsyntax_pos/hygiene.rs
+++ b/src/libsyntax_pos/hygiene.rs
@@ -108,14 +108,7 @@ impl Mark {
 
     #[inline]
     pub fn set_expn_info(self, info: ExpnInfo) {
-        HygieneData::with(|data| {
-            let old_info = &mut data.marks[self.0 as usize].expn_info;
-            if let Some(old_info) = old_info {
-                panic!("expansion info is reset for the mark {}\nold: {:#?}\nnew: {:#?}",
-                       self.0, old_info, info);
-            }
-            *old_info = Some(info);
-        })
+        HygieneData::with(|data| data.marks[self.0 as usize].expn_info = Some(info))
     }
 
     #[inline]

--- a/src/test/ui/hygiene/expansion-info-reset.rs
+++ b/src/test/ui/hygiene/expansion-info-reset.rs
@@ -1,0 +1,17 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// FIXME: Investigate why expansion info for a single expansion id is reset from
+// `MacroBang(format_args)` to `MacroAttribute(derive(Clone))` (issue #52363).
+
+fn main() {
+    format_args!({ #[derive(Clone)] struct S; });
+    //~^ ERROR format argument must be a string literal
+}

--- a/src/test/ui/hygiene/expansion-info-reset.stderr
+++ b/src/test/ui/hygiene/expansion-info-reset.stderr
@@ -1,0 +1,12 @@
+error: format argument must be a string literal
+  --> $DIR/expansion-info-reset.rs:15:18
+   |
+LL |     format_args!({ #[derive(Clone)] struct S; });
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: you might be missing a string literal to format with
+   |
+LL |     format_args!("{}", { #[derive(Clone)] struct S; });
+   |                  ^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/imports/local-modularized-tricky-fail-3.rs
+++ b/src/test/ui/imports/local-modularized-tricky-fail-3.rs
@@ -22,9 +22,11 @@ define_exported!();
 mod m {
     use exported;
     //~^ ERROR macro-expanded `macro_export` macros from the current crate cannot
+    //~| WARN this was previously accepted
 }
 
 fn main() {
     ::exported!();
     //~^ ERROR macro-expanded `macro_export` macros from the current crate cannot
+    //~| WARN this was previously accepted
 }

--- a/src/test/ui/imports/local-modularized-tricky-fail-3.stderr
+++ b/src/test/ui/imports/local-modularized-tricky-fail-3.stderr
@@ -4,6 +4,9 @@ error: macro-expanded `macro_export` macros from the current crate cannot be ref
 LL |     use exported;
    |         ^^^^^^^^
    |
+   = note: #[deny(macro_expanded_macro_exports_accessed_by_absolute_paths)] on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #52234 <https://github.com/rust-lang/rust/issues/52234>
 note: the macro is defined here
   --> $DIR/local-modularized-tricky-fail-3.rs:15:5
    |
@@ -16,11 +19,13 @@ LL |   define_exported!();
    |   ------------------- in this macro invocation
 
 error: macro-expanded `macro_export` macros from the current crate cannot be referred to by absolute paths
-  --> $DIR/local-modularized-tricky-fail-3.rs:28:5
+  --> $DIR/local-modularized-tricky-fail-3.rs:29:5
    |
 LL |     ::exported!();
    |     ^^^^^^^^^^
    |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #52234 <https://github.com/rust-lang/rust/issues/52234>
 note: the macro is defined here
   --> $DIR/local-modularized-tricky-fail-3.rs:15:5
    |


### PR DESCRIPTION
Remove assert checking that expansion data is immutable until I have time to investigate why it's firing, cc https://github.com/rust-lang/rust/issues/52363
Turn the error for module-relative access to macro-expanded `macro_export` macros into a deprecation lint, closes https://github.com/rust-lang/rust/issues/53495