### PR TITLE
Add target for Little-endian ARM Cortex-R4F/R5F MCUs

### DIFF
--- a/src/ci/docker/disabled/dist-armv7r-none-eabihf/Dockerfile
+++ b/src/ci/docker/disabled/dist-armv7r-none-eabihf/Dockerfile
@@ -13,21 +13,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   xz-utils \
   bzip2 \
   libssl-dev \
-  pkg-config
+  pkg-config \
+  gcc-arm-none-eabi
 
 
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
-# GNU Arm Embedded Toolchain 7-2018-q2-update (June 27,2018)
-ENV BASE_URL=https://developer.arm.com/-/media/Files/downloads/gnu-rm/
-RUN curl -L $BASE_URL/7-2018q2/gcc-arm-none-eabi-7-2018-q2-update-linux.tar.bz2 | tar -xj
-ENV PATH=$PATH:/gcc-arm-none-eabi-7-2018-q2-update/bin
-
 ENV TARGET=armv7r-none-eabihf
-
-ENV CC_armv7r_none_eabihf=arm-none-eabi-gcc \
-    CFLAGS_armv7r_none_eabihf="-march=armv7-r"
 
 ENV RUST_CONFIGURE_ARGS --disable-docs
 

--- a/src/ci/docker/disabled/dist-armv7r-none-eabihf/Dockerfile
+++ b/src/ci/docker/disabled/dist-armv7r-none-eabihf/Dockerfile
@@ -1,0 +1,34 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  g++ \
+  make \
+  file \
+  curl \
+  ca-certificates \
+  python2.7 \
+  git \
+  cmake \
+  sudo \
+  xz-utils \
+  bzip2 \
+  libssl-dev \
+  pkg-config
+
+
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
+
+# GNU Arm Embedded Toolchain 7-2018-q2-update (June 27,2018)
+ENV BASE_URL=https://developer.arm.com/-/media/Files/downloads/gnu-rm/
+RUN curl -L $BASE_URL/7-2018q2/gcc-arm-none-eabi-7-2018-q2-update-linux.tar.bz2 | tar -xj
+ENV PATH=$PATH:/gcc-arm-none-eabi-7-2018-q2-update/bin
+
+ENV TARGET=armv7r-none-eabihf
+
+ENV CC_armv7r_none_eabihf=arm-none-eabi-gcc \
+    CFLAGS_armv7r_none_eabihf="-march=armv7-r"
+
+ENV RUST_CONFIGURE_ARGS --disable-docs
+
+ENV SCRIPT python2.7 ../x.py dist --target $TARGET

--- a/src/librustc_target/spec/armv7r_none_eabihf.rs
+++ b/src/librustc_target/spec/armv7r_none_eabihf.rs
@@ -11,7 +11,7 @@
 // Targets the Little-endian Cortex-R4F/R5F processor (ARMv7-R)
 
 use std::default::Default;
-use spec::{LinkerFlavor, PanicStrategy, Target, TargetOptions, TargetResult};
+use spec::{LinkerFlavor, LldFlavor, PanicStrategy, Target, TargetOptions, TargetResult};
 
 pub fn target() -> TargetResult {
     Ok(Target {
@@ -24,9 +24,10 @@ pub fn target() -> TargetResult {
         target_os: "none".to_string(),
         target_env: "".to_string(),
         target_vendor: "".to_string(),
-        linker_flavor: LinkerFlavor::Gcc,
+        linker_flavor: LinkerFlavor::Lld(LldFlavor::Ld),
 
         options: TargetOptions {
+            linker: Some("rust-lld".to_string()),
             executables: true,
             relocation_model: "static".to_string(),
             panic_strategy: PanicStrategy::Abort,

--- a/src/librustc_target/spec/armv7r_none_eabihf.rs
+++ b/src/librustc_target/spec/armv7r_none_eabihf.rs
@@ -1,0 +1,40 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Targets the Little-endian Cortex-R4F/R5F processor (ARMv7-R)
+
+use std::default::Default;
+use spec::{LinkerFlavor, PanicStrategy, Target, TargetOptions, TargetResult};
+
+pub fn target() -> TargetResult {
+    Ok(Target {
+        llvm_target: "armv7r-none-eabihf".to_string(),
+        target_endian: "little".to_string(),
+        target_pointer_width: "32".to_string(),
+        target_c_int_width: "32".to_string(),
+        data_layout: "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64".to_string(),
+        arch: "arm".to_string(),
+        target_os: "none".to_string(),
+        target_env: "".to_string(),
+        target_vendor: "".to_string(),
+        linker_flavor: LinkerFlavor::Gcc,
+
+        options: TargetOptions {
+            executables: true,
+            relocation_model: "static".to_string(),
+            panic_strategy: PanicStrategy::Abort,
+            features: "+vfp3,+d16,+fp-only-sp".to_string(),
+            max_atomic_width: Some(32),
+            abi_blacklist: super::arm_base::abi_blacklist(),
+            emit_debug_gdb_scripts: false,
+            .. Default::default()
+        },
+    })
+}

--- a/src/librustc_target/spec/mod.rs
+++ b/src/librustc_target/spec/mod.rs
@@ -371,6 +371,7 @@ supported_targets! {
     ("armv7s-apple-ios", armv7s_apple_ios),
 
     ("armebv7r-none-eabihf", armebv7r_none_eabihf),
+    ("armv7r-none-eabihf", armv7r_none_eabihf),
 
     ("x86_64-sun-solaris", x86_64_sun_solaris),
     ("sparcv9-sun-solaris", sparcv9_sun_solaris),

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -64,6 +64,7 @@ static TARGETS: &'static [&'static str] = &[
     "armv7-unknown-linux-gnueabihf",
     "armv7-unknown-linux-musleabihf",
     "armebv7r-none-eabihf",
+    "armv7r-none-eabihf",
     "armv7s-apple-ios",
     "asmjs-unknown-emscripten",
     "i386-apple-ios",


### PR DESCRIPTION
Similar to `armebv7r-none-eabihf`, but for Little-endian MCUs.

As example: TI RM4x/RM5x are Little-endian Cortex-R4F/R5F MCUs.

CI/Dockerfile is intentionally in the disabled folder.

r? @parched 
r? @alexcrichton 
cc @japaric 