### PR TITLE
rustc: remove Ty::{is_self, has_self_ty}.

### DIFF
--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -940,6 +940,7 @@ for ty::FloatVid
 
 impl_stable_hash_for!(struct ty::ParamTy {
     idx,
+    def_id,
     name
 });
 

--- a/src/librustc/traits/util.rs
+++ b/src/librustc/traits/util.rs
@@ -213,7 +213,7 @@ impl<'cx, 'gcx, 'tcx> Elaborator<'cx, 'gcx, 'tcx> {
                            },
 
                            Component::Param(p) => {
-                               let ty = tcx.mk_ty_param(p.idx, p.name);
+                               let ty = p.to_ty(tcx);
                                Some(ty::Predicate::TypeOutlives(
                                    ty::Binder::dummy(ty::OutlivesPredicate(ty, r_min))))
                            },

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -76,7 +76,7 @@ use syntax::attr;
 use syntax::source_map::MultiSpan;
 use syntax::edition::Edition;
 use syntax::feature_gate;
-use syntax::symbol::{Symbol, keywords, InternedString};
+use syntax::symbol::Symbol;
 use syntax_pos::Span;
 
 use hir;
@@ -2556,22 +2556,20 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         self.mk_ty(Infer(it))
     }
 
-    pub fn mk_ty_param(self,
-                    index: u32,
-                    name: InternedString) -> Ty<'tcx> {
-        self.mk_ty(Param(ParamTy { idx: index, name: name }))
+    pub fn mk_ty_param(self, def: &ty::GenericParamDef) -> Ty<'tcx> {
+        ParamTy::for_def(def).to_ty(self)
     }
 
-    pub fn mk_self_type(self) -> Ty<'tcx> {
-        self.mk_ty_param(0, keywords::SelfType.name().as_interned_str())
+    pub fn mk_self_type(self, trait_def_id: DefId) -> Ty<'tcx> {
+        ParamTy::for_self(trait_def_id).to_ty(self)
     }
 
-    pub fn mk_param_from_def(self, param: &ty::GenericParamDef) -> Kind<'tcx> {
+    pub fn mk_param(self, param: &ty::GenericParamDef) -> Kind<'tcx> {
         match param.kind {
             GenericParamDefKind::Lifetime => {
                 self.mk_region(ty::ReEarlyBound(param.to_early_bound_region_data())).into()
             }
-            GenericParamDefKind::Type {..} => self.mk_ty_param(param.index, param.name).into(),
+            GenericParamDefKind::Type {..} => self.mk_ty_param(param).into(),
         }
     }
 

--- a/src/librustc/ty/error.rs
+++ b/src/librustc/ty/error.rs
@@ -222,13 +222,7 @@ impl<'a, 'gcx, 'lcx, 'tcx> ty::TyS<'tcx> {
             ty::Infer(ty::FreshIntTy(_)) => "skolemized integral type".to_string(),
             ty::Infer(ty::FreshFloatTy(_)) => "skolemized floating-point type".to_string(),
             ty::Projection(_) => "associated type".to_string(),
-            ty::Param(ref p) => {
-                if p.is_self() {
-                    "Self".to_string()
-                } else {
-                    "type parameter".to_string()
-                }
-            }
+            ty::Param(_) => format!("`{}` parameter", self),
             ty::Anon(..) => "anonymized type".to_string(),
             ty::Error => "type error".to_string(),
         }

--- a/src/librustc/ty/flags.rs
+++ b/src/librustc/ty/flags.rs
@@ -90,13 +90,9 @@ impl FlagComputation {
                 self.add_flags(TypeFlags::HAS_TY_ERR)
             }
 
-            &ty::Param(ref p) => {
+            &ty::Param(_) => {
                 self.add_flags(TypeFlags::HAS_FREE_LOCAL_NAMES);
-                if p.is_self() {
-                    self.add_flags(TypeFlags::HAS_SELF);
-                } else {
-                    self.add_flags(TypeFlags::HAS_PARAMS);
-                }
+                self.add_flags(TypeFlags::HAS_PARAMS);
             }
 
             &ty::Generator(_, ref substs, _) => {

--- a/src/librustc/ty/fold.rs
+++ b/src/librustc/ty/fold.rs
@@ -93,9 +93,6 @@ pub trait TypeFoldable<'tcx>: fmt::Debug + Clone {
     fn has_param_types(&self) -> bool {
         self.has_type_flags(TypeFlags::HAS_PARAMS)
     }
-    fn has_self_ty(&self) -> bool {
-        self.has_type_flags(TypeFlags::HAS_SELF)
-    }
     fn has_infer_types(&self) -> bool {
         self.has_type_flags(TypeFlags::HAS_TY_INFER)
     }

--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -1130,7 +1130,6 @@ impl<'a, 'tcx> LayoutCx<'tcx, TyCtxt<'a, 'tcx, 'tcx>> {
         if
             !self.tcx.sess.opts.debugging_opts.print_type_sizes ||
             layout.ty.has_param_types() ||
-            layout.ty.has_self_ty() ||
             !self.param_env.caller_bounds.is_empty()
         {
             return;
@@ -1300,7 +1299,7 @@ impl<'a, 'tcx> SizeSkeleton<'tcx> {
                 let tail = tcx.struct_tail(pointee);
                 match tail.sty {
                     ty::Param(_) | ty::Projection(_) => {
-                        debug_assert!(tail.has_param_types() || tail.has_self_ty());
+                        debug_assert!(tail.has_param_types());
                         Ok(SizeSkeleton::Pointer {
                             non_zero,
                             tail: tcx.erase_regions(&tail)

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -423,57 +423,54 @@ pub struct CReaderCacheKey {
 bitflags! {
     pub struct TypeFlags: u32 {
         const HAS_PARAMS         = 1 << 0;
-        const HAS_SELF           = 1 << 1;
-        const HAS_TY_INFER       = 1 << 2;
-        const HAS_RE_INFER       = 1 << 3;
-        const HAS_RE_SKOL        = 1 << 4;
+        const HAS_TY_INFER       = 1 << 1;
+        const HAS_RE_INFER       = 1 << 2;
+        const HAS_RE_SKOL        = 1 << 3;
 
         /// Does this have any `ReEarlyBound` regions? Used to
         /// determine whether substitition is required, since those
         /// represent regions that are bound in a `ty::Generics` and
         /// hence may be substituted.
-        const HAS_RE_EARLY_BOUND = 1 << 5;
+        const HAS_RE_EARLY_BOUND = 1 << 4;
 
         /// Does this have any region that "appears free" in the type?
         /// Basically anything but `ReLateBound` and `ReErased`.
-        const HAS_FREE_REGIONS   = 1 << 6;
+        const HAS_FREE_REGIONS   = 1 << 5;
 
         /// Is an error type reachable?
-        const HAS_TY_ERR         = 1 << 7;
-        const HAS_PROJECTION     = 1 << 8;
+        const HAS_TY_ERR         = 1 << 6;
+        const HAS_PROJECTION     = 1 << 7;
 
         // FIXME: Rename this to the actual property since it's used for generators too
-        const HAS_TY_CLOSURE     = 1 << 9;
+        const HAS_TY_CLOSURE     = 1 << 8;
 
         // true if there are "names" of types and regions and so forth
         // that are local to a particular fn
-        const HAS_FREE_LOCAL_NAMES    = 1 << 10;
+        const HAS_FREE_LOCAL_NAMES    = 1 << 9;
 
         // Present if the type belongs in a local type context.
         // Only set for Infer other than Fresh.
-        const KEEP_IN_LOCAL_TCX  = 1 << 11;
+        const KEEP_IN_LOCAL_TCX  = 1 << 10;
 
         // Is there a projection that does not involve a bound region?
         // Currently we can't normalize projections w/ bound regions.
-        const HAS_NORMALIZABLE_PROJECTION = 1 << 12;
+        const HAS_NORMALIZABLE_PROJECTION = 1 << 11;
 
         // Set if this includes a "canonical" type or region var --
         // ought to be true only for the results of canonicalization.
-        const HAS_CANONICAL_VARS = 1 << 13;
+        const HAS_CANONICAL_VARS = 1 << 12;
 
         /// Does this have any `ReLateBound` regions? Used to check
         /// if a global bound is safe to evaluate.
-        const HAS_RE_LATE_BOUND = 1 << 14;
+        const HAS_RE_LATE_BOUND = 1 << 13;
 
         const NEEDS_SUBST        = TypeFlags::HAS_PARAMS.bits |
-                                   TypeFlags::HAS_SELF.bits |
                                    TypeFlags::HAS_RE_EARLY_BOUND.bits;
 
         // Flags representing the nominal content of a type,
         // computed by FlagsComputation. If you add a new nominal
         // flag, it should be added here too.
         const NOMINAL_FLAGS     = TypeFlags::HAS_PARAMS.bits |
-                                  TypeFlags::HAS_SELF.bits |
                                   TypeFlags::HAS_TY_INFER.bits |
                                   TypeFlags::HAS_RE_INFER.bits |
                                   TypeFlags::HAS_RE_SKOL.bits |
@@ -1632,7 +1629,6 @@ impl<'tcx> ParamEnv<'tcx> {
                 if value.has_skol()
                     || value.needs_infer()
                     || value.has_param_types()
-                    || value.has_self_ty()
                 {
                     ParamEnvAnd {
                         param_env: self,

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -963,24 +963,25 @@ impl<'tcx> PolyFnSig<'tcx> {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, RustcEncodable, RustcDecodable)]
 pub struct ParamTy {
     pub idx: u32,
+    pub def_id: DefId,
     pub name: InternedString,
 }
 
-impl<'a, 'gcx, 'tcx> ParamTy {
-    pub fn new(index: u32, name: InternedString) -> ParamTy {
-        ParamTy { idx: index, name: name }
+impl ParamTy {
+    pub fn new(idx: u32, def_id: DefId, name: ast::Name) -> ParamTy {
+        ParamTy { idx, def_id, name: name.as_interned_str() }
     }
 
-    pub fn for_self() -> ParamTy {
-        ParamTy::new(0, keywords::SelfType.name().as_interned_str())
+    pub fn for_self(trait_def_id: DefId) -> ParamTy {
+        ParamTy::new(0, trait_def_id, keywords::SelfType.name())
     }
 
     pub fn for_def(def: &ty::GenericParamDef) -> ParamTy {
-        ParamTy::new(def.index, def.name)
+        ParamTy { idx: def.index, def_id: def.def_id, name: def.name }
     }
 
-    pub fn to_ty(self, tcx: TyCtxt<'a, 'gcx, 'tcx>) -> Ty<'tcx> {
-        tcx.mk_ty_param(self.idx, self.name)
+    pub fn to_ty(self, tcx: TyCtxt<'_, '_, 'tcx>) -> Ty<'tcx> {
+        tcx.mk_ty(ty::Param(self))
     }
 }
 

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -982,17 +982,6 @@ impl<'a, 'gcx, 'tcx> ParamTy {
     pub fn to_ty(self, tcx: TyCtxt<'a, 'gcx, 'tcx>) -> Ty<'tcx> {
         tcx.mk_ty_param(self.idx, self.name)
     }
-
-    pub fn is_self(&self) -> bool {
-        // FIXME(#50125): Ignoring `Self` with `idx != 0` might lead to weird behavior elsewhere,
-        // but this should only be possible when using `-Z continue-parse-after-error` like
-        // `compile-fail/issue-36638.rs`.
-        if self.name == keywords::SelfType.name().as_str() && self.idx == 0 {
-            true
-        } else {
-            false
-        }
-    }
 }
 
 /// A [De Bruijn index][dbi] is a standard means of representing
@@ -1515,13 +1504,6 @@ impl<'a, 'gcx, 'tcx> TyS<'tcx> {
     pub fn is_param(&self, index: u32) -> bool {
         match self.sty {
             ty::Param(ref data) => data.idx == index,
-            _ => false,
-        }
-    }
-
-    pub fn is_self(&self) -> bool {
-        match self.sty {
-            Param(ref p) => p.is_self(),
             _ => false,
         }
     }

--- a/src/librustc/ty/subst.rs
+++ b/src/librustc/ty/subst.rs
@@ -185,9 +185,7 @@ impl<'a, 'gcx, 'tcx> Substs<'tcx> {
     /// Creates a Substs that maps each generic parameter to itself.
     pub fn identity_for_item(tcx: TyCtxt<'a, 'gcx, 'tcx>, def_id: DefId)
                              -> &'tcx Substs<'tcx> {
-        Substs::for_item(tcx, def_id, |param, _| {
-            tcx.mk_param_from_def(param)
-        })
+        Substs::for_item(tcx, def_id, |param, _| tcx.mk_param(param))
     }
 
     /// Creates a Substs for generic parameter definitions,

--- a/src/librustc_driver/test.rs
+++ b/src/librustc_driver/test.rs
@@ -312,8 +312,9 @@ impl<'a, 'gcx, 'tcx> Env<'a, 'gcx, 'tcx> {
     }
 
     pub fn t_param(&self, index: u32) -> Ty<'tcx> {
+        let def_id = self.infcx.tcx.hir.local_def_id(ast::CRATE_NODE_ID);
         let name = format!("T{}", index);
-        self.infcx.tcx.mk_ty_param(index, Symbol::intern(&name).as_interned_str())
+        ty::ParamTy::new(index, def_id, Symbol::intern(&name)).to_ty(self.infcx.tcx)
     }
 
     pub fn re_early_bound(&self, index: u32, name: &'static str) -> ty::Region<'tcx> {

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1076,7 +1076,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnconditionalRecursion {
                 // A trait method, from any number of possible sources.
                 // Attempt to select a concrete impl before checking.
                 ty::TraitContainer(trait_def_id) => {
-                    let trait_self_ty = tcx.mk_self_type();
+                    let trait_self_ty = tcx.mk_self_type(trait_def_id);
                     let trait_ref = ty::TraitRef::from_method(tcx, trait_def_id, callee_substs);
                     let trait_ref = ty::Binder::bind(trait_ref);
                     let span = tcx.hir.span(expr_id);

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1076,6 +1076,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnconditionalRecursion {
                 // A trait method, from any number of possible sources.
                 // Attempt to select a concrete impl before checking.
                 ty::TraitContainer(trait_def_id) => {
+                    let trait_self_ty = tcx.mk_self_type();
                     let trait_ref = ty::TraitRef::from_method(tcx, trait_def_id, callee_substs);
                     let trait_ref = ty::Binder::bind(trait_ref);
                     let span = tcx.hir.span(expr_id);
@@ -1091,7 +1092,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnconditionalRecursion {
                             // If `T` is `Self`, then this call is inside
                             // a default method definition.
                             Ok(Some(traits::VtableParam(_))) => {
-                                let on_self = trait_ref.self_ty().is_self();
+                                let on_self = trait_ref.self_ty() == trait_self_ty;
                                 // We can only be recurring in a default
                                 // method if we're being called literally
                                 // on the `Self` type.

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -597,7 +597,9 @@ impl<'o, 'gcx: 'tcx, 'tcx> dyn AstConv<'gcx, 'tcx>+'o {
         let default_needs_object_self = |param: &ty::GenericParamDef| {
             if let GenericParamDefKind::Type { has_default, .. } = param.kind {
                 if is_object && has_default {
-                    if tcx.at(span).type_of(param.def_id).has_self_ty() {
+                    let trait_self_ty = tcx.mk_self_type();
+                    let default = tcx.at(span).type_of(param.def_id);
+                    if default.walk().any(|ty| ty == trait_self_ty) {
                         // There is no suitable inference default for a type parameter
                         // that references self, in an object type.
                         return true;

--- a/src/librustc_typeck/check/compare_method.rs
+++ b/src/librustc_typeck/check/compare_method.rs
@@ -512,7 +512,7 @@ fn compare_self_type<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     let self_string = |method: &ty::AssociatedItem| {
         let untransformed_self_ty = match method.container {
             ty::ImplContainer(_) => impl_trait_ref.self_ty(),
-            ty::TraitContainer(_) => tcx.mk_self_type()
+            ty::TraitContainer(def_id) => tcx.mk_self_type(def_id),
         };
         let self_arg_ty = *tcx.fn_sig(method.def_id).input(0).skip_binder();
         let param_env = ty::ParamEnv::reveal_all();

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -183,7 +183,7 @@ fn check_associated_item<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         let item = fcx.tcx.associated_item(fcx.tcx.hir.local_def_id(item_id));
 
         let (mut implied_bounds, self_ty) = match item.container {
-            ty::TraitContainer(_) => (vec![], fcx.tcx.mk_self_type()),
+            ty::TraitContainer(def_id) => (vec![], fcx.tcx.mk_self_type(def_id)),
             ty::ImplContainer(def_id) => (fcx.impl_implied_bounds(def_id, span),
                                             fcx.tcx.type_of(def_id))
         };
@@ -431,7 +431,7 @@ fn check_where_clauses<'a, 'gcx, 'fcx, 'tcx>(
         match param.kind {
             GenericParamDefKind::Lifetime => {
                 // All regions are identity.
-                fcx.tcx.mk_param_from_def(param)
+                fcx.tcx.mk_param(param)
             }
             GenericParamDefKind::Type {..} => {
                 // If the param has a default,

--- a/src/librustc_typeck/check/writeback.rs
+++ b/src/librustc_typeck/check/writeback.rs
@@ -433,9 +433,7 @@ impl<'cx, 'gcx, 'tcx> WritebackCx<'cx, 'gcx, 'tcx> {
                                     if subst == ty {
                                         // found it in the substitution list, replace with the
                                         // parameter from the existential type
-                                        return self.tcx()
-                                            .global_tcx()
-                                            .mk_ty_param(param.index, param.name);
+                                        return self.tcx().global_tcx().mk_ty_param(param);
                                     }
                                 }
                             }

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -979,13 +979,6 @@ fn generics_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) -> &'tcx ty
                     synthetic,
                     ..
                 } => {
-                    if param.name.ident().name == keywords::SelfType.name() {
-                        span_bug!(
-                            param.span,
-                            "`Self` should not be the name of a regular parameter"
-                        );
-                    }
-
                     if !allow_defaults && default.is_some() {
                         if !tcx.features().default_type_parameter_fallback {
                             tcx.lint_node(

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -249,7 +249,7 @@ fn type_param_predicates<'a, 'tcx>(
     let param_owner_def_id = tcx.hir.local_def_id(param_owner);
     let generics = tcx.generics_of(param_owner_def_id);
     let index = generics.param_def_id_to_index[&def_id];
-    let ty = tcx.mk_ty_param(index, tcx.hir.ty_param_name(param_id).as_interned_str());
+    let ty = ty::ParamTy::new(index, def_id, tcx.hir.ty_param_name(param_id)).to_ty(tcx);
 
     // Don't look for bounds where the type parameter isn't in scope.
     let parent = if item_def_id == param_owner_def_id {
@@ -683,7 +683,7 @@ fn super_predicates_of<'a, 'tcx>(
     let icx = ItemCtxt::new(tcx, trait_def_id);
 
     // Convert the bounds that follow the colon, e.g. `Bar+Zed` in `trait Foo : Bar+Zed`.
-    let self_param_ty = tcx.mk_self_type();
+    let self_param_ty = tcx.mk_self_type(trait_def_id);
     let superbounds1 = compute_bounds(&icx, self_param_ty, bounds, SizedByDefault::No, item.span);
 
     let superbounds1 = superbounds1.predicates(tcx, self_param_ty);
@@ -1773,8 +1773,9 @@ fn explicit_predicates_of<'a, 'tcx>(
     for param in &ast_generics.params {
         match param.kind {
             GenericParamKind::Type { .. } => {
-                let name = param.name.ident().as_interned_str();
-                let param_ty = ty::ParamTy::new(index, name).to_ty(tcx);
+                let def_id = tcx.hir.local_def_id(param.id);
+                let name = param.name.ident().name;
+                let param_ty = ty::ParamTy::new(index, def_id, name).to_ty(tcx);
                 index += 1;
 
                 let sized = SizedByDefault::Yes;

--- a/src/librustc_typeck/outlives/implicit_infer.rs
+++ b/src/librustc_typeck/outlives/implicit_infer.rs
@@ -187,7 +187,7 @@ fn insert_required_predicates_to_be_wf<'tcx>(
                 // let _: () = substs.region_at(0);
                 check_explicit_predicates(
                     tcx,
-                    &def.did,
+                    def.did,
                     substs,
                     required_predicates,
                     explicit_map,
@@ -210,7 +210,7 @@ fn insert_required_predicates_to_be_wf<'tcx>(
                 if let Some(ex_trait_ref) = obj.principal() {
                     check_explicit_predicates(
                         tcx,
-                        &ex_trait_ref.skip_binder().def_id,
+                        ex_trait_ref.skip_binder().def_id,
                         ex_trait_ref.with_self_ty(tcx, ty).skip_binder().substs,
                         required_predicates,
                         explicit_map,
@@ -225,7 +225,7 @@ fn insert_required_predicates_to_be_wf<'tcx>(
                 debug!("Projection");
                 check_explicit_predicates(
                     tcx,
-                    &tcx.associated_item(obj.item_def_id).container.id(),
+                    tcx.associated_item(obj.item_def_id).container.id(),
                     obj.substs,
                     required_predicates,
                     explicit_map,
@@ -255,20 +255,20 @@ fn insert_required_predicates_to_be_wf<'tcx>(
 /// applying the substitution as above.
 pub fn check_explicit_predicates<'tcx>(
     tcx: TyCtxt<'_, 'tcx, 'tcx>,
-    def_id: &DefId,
+    def_id: DefId,
     substs: &[Kind<'tcx>],
     required_predicates: &mut RequiredPredicates<'tcx>,
     explicit_map: &mut ExplicitPredicatesMap<'tcx>,
     ignore_self_ty: bool,
 ) {
-    debug!("def_id = {:?}", &def_id);
-    debug!("substs = {:?}", &substs);
+    debug!("def_id = {:?}", def_id);
+    debug!("substs = {:?}", substs);
     debug!("explicit_map =  {:?}", explicit_map);
     debug!("required_predicates = {:?}", required_predicates);
-    let explicit_predicates = explicit_map.explicit_predicates_of(tcx, *def_id);
+    let explicit_predicates = explicit_map.explicit_predicates_of(tcx, def_id);
 
     let ignore_self_ty = if ignore_self_ty {
-        Some(tcx.mk_self_type())
+        Some(tcx.mk_self_type(def_id))
     } else {
         None
     };

--- a/src/librustc_typeck/outlives/implicit_infer.rs
+++ b/src/librustc_typeck/outlives/implicit_infer.rs
@@ -267,6 +267,11 @@ pub fn check_explicit_predicates<'tcx>(
     debug!("required_predicates = {:?}", required_predicates);
     let explicit_predicates = explicit_map.explicit_predicates_of(tcx, *def_id);
 
+    let ignore_self_ty = if ignore_self_ty {
+        Some(tcx.mk_self_type())
+    } else {
+        None
+    };
     for outlives_predicate in explicit_predicates.iter() {
         debug!("outlives_predicate = {:?}", &outlives_predicate);
 
@@ -297,7 +302,7 @@ pub fn check_explicit_predicates<'tcx>(
         // to apply the substs, and not filter this predicate, we might then falsely
         // conclude that e.g. `X: 'x` was a reasonable inferred requirement.
         if let UnpackedKind::Type(ty) = outlives_predicate.0.unpack() {
-            if ty.is_self() && ignore_self_ty {
+            if Some(ty) == ignore_self_ty {
                 debug!("skipping self ty = {:?}", &ty);
                 continue;
             }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1971,10 +1971,8 @@ impl<'tcx> Clean<Item> for ty::AssociatedItem {
 
                 if self.method_has_self_argument {
                     let self_ty = match self.container {
-                        ty::ImplContainer(def_id) => {
-                            cx.tcx.type_of(def_id)
-                        }
-                        ty::TraitContainer(_) => cx.tcx.mk_self_type()
+                        ty::ImplContainer(def_id) => cx.tcx.type_of(def_id),
+                        ty::TraitContainer(def_id) => cx.tcx.mk_self_type(def_id),
                     };
                     let self_arg_ty = *sig.input(0).skip_binder();
                     if self_arg_ty == self_ty {

--- a/src/librustdoc/clean/simplify.rs
+++ b/src/librustdoc/clean/simplify.rs
@@ -156,10 +156,11 @@ fn trait_is_same_or_supertrait(cx: &DocContext, child: DefId,
     if child == trait_ {
         return true
     }
+    let trait_self_ty = cx.tcx.mk_self_type();
     let predicates = cx.tcx.super_predicates_of(child).predicates;
     predicates.iter().filter_map(|pred| {
         if let ty::Predicate::Trait(ref pred) = *pred {
-            if pred.skip_binder().trait_ref.self_ty().is_self() {
+            if pred.skip_binder().trait_ref.self_ty() == trait_self_ty {
                 Some(pred.def_id())
             } else {
                 None

--- a/src/librustdoc/clean/simplify.rs
+++ b/src/librustdoc/clean/simplify.rs
@@ -156,7 +156,7 @@ fn trait_is_same_or_supertrait(cx: &DocContext, child: DefId,
     if child == trait_ {
         return true
     }
-    let trait_self_ty = cx.tcx.mk_self_type();
+    let trait_self_ty = cx.tcx.mk_self_type(child);
     let predicates = cx.tcx.super_predicates_of(child).predicates;
     predicates.iter().filter_map(|pred| {
         if let ty::Predicate::Trait(ref pred) = *pred {

--- a/src/test/ui/associated-types/associated-types-issue-20346.stderr
+++ b/src/test/ui/associated-types/associated-types-issue-20346.stderr
@@ -2,7 +2,7 @@ error[E0271]: type mismatch resolving `<Adapter<I> as Iterator>::Item == std::op
   --> $DIR/associated-types-issue-20346.rs:44:5
    |
 LL |     is_iterator_of::<Option<T>, _>(&adapter); //~ ERROR type mismatch
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected type parameter, found enum `std::option::Option`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `T` parameter, found enum `std::option::Option`
    |
    = note: expected type `T`
               found type `std::option::Option<T>`

--- a/src/test/ui/compare-method/reordered-type-param.stderr
+++ b/src/test/ui/compare-method/reordered-type-param.stderr
@@ -5,7 +5,7 @@ LL |   fn b<C:Clone,D>(&self, x: C) -> C;
    |                             - type in trait
 ...
 LL |   fn b<F:Clone,G>(&self, _x: G) -> G { panic!() } //~ ERROR method `b` has an incompatible type
-   |                              ^ expected type parameter, found a different type parameter
+   |                              ^ expected `F` parameter, found `G` parameter
    |
    = note: expected type `fn(&E, F) -> F`
               found type `fn(&E, G) -> G`

--- a/src/test/ui/impl-trait/impl-generic-mismatch-ab.stderr
+++ b/src/test/ui/impl-trait/impl-generic-mismatch-ab.stderr
@@ -5,7 +5,7 @@ LL |     fn foo<A: Debug>(&self, a: &A, b: &impl Debug);
    |                                -- type in trait
 ...
 LL |     fn foo<B: Debug>(&self, a: &impl Debug, b: &B) { }
-   |                                ^^^^^^^^^^^ expected type parameter, found a different type parameter
+   |                                ^^^^^^^^^^^ expected `B` parameter, found `impl Debug` parameter
    |
    = note: expected type `fn(&(), &B, &impl Debug)`
               found type `fn(&(), &impl Debug, &B)`

--- a/src/test/ui/impl-trait/must_outlive_least_region_or_bound.nll.stderr
+++ b/src/test/ui/impl-trait/must_outlive_least_region_or_bound.nll.stderr
@@ -62,10 +62,11 @@ LL |     move |_| println!("{}", y)
 error[E0310]: the parameter type `T` may not live long enough
   --> $DIR/must_outlive_least_region_or_bound.rs:34:5
    |
+LL | fn ty_param_wont_outlive_static<T:Debug>(x: T) -> impl Debug + 'static {
+   |                                 -- help: consider adding an explicit lifetime bound `T: 'static`...
+LL |     //~^ ERROR the parameter type `T` may not live long enough
 LL |     x
    |     ^
-   |
-   = help: consider adding an explicit lifetime bound `T: 'static`...
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/impl-trait/type_parameters_captured.nll.stderr
+++ b/src/test/ui/impl-trait/type_parameters_captured.nll.stderr
@@ -7,10 +7,11 @@ LL | fn foo<T>(x: T) -> impl Any + 'static {
 error[E0310]: the parameter type `T` may not live long enough
   --> $DIR/type_parameters_captured.rs:19:5
    |
+LL | fn foo<T>(x: T) -> impl Any + 'static {
+   |        - help: consider adding an explicit lifetime bound `T: 'static`...
+LL |     //~^ ERROR the parameter type `T` may not live long enough
 LL |     x
    |     ^
-   |
-   = help: consider adding an explicit lifetime bound `T: 'static`...
 
 error: aborting due to previous error
 

--- a/src/test/ui/impl-trait/universal-mismatched-type.stderr
+++ b/src/test/ui/impl-trait/universal-mismatched-type.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn foo(x: impl Debug) -> String {
    |                          ------ expected `std::string::String` because of return type
 LL |     x //~ ERROR mismatched types
-   |     ^ expected struct `std::string::String`, found type parameter
+   |     ^ expected struct `std::string::String`, found `impl Debug` parameter
    |
    = note: expected type `std::string::String`
               found type `impl Debug`

--- a/src/test/ui/impl-trait/universal-two-impl-traits.stderr
+++ b/src/test/ui/impl-trait/universal-two-impl-traits.stderr
@@ -2,10 +2,10 @@ error[E0308]: mismatched types
   --> $DIR/universal-two-impl-traits.rs:15:9
    |
 LL |     a = y; //~ ERROR mismatched
-   |         ^ expected type parameter, found a different type parameter
+   |         ^ expected `impl Debug` parameter, found a different `impl Debug` parameter
    |
-   = note: expected type `impl Debug` (type parameter)
-              found type `impl Debug` (type parameter)
+   = note: expected type `impl Debug` (`impl Debug` parameter)
+              found type `impl Debug` (`impl Debug` parameter)
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-13853.stderr
+++ b/src/test/ui/issues/issue-13853.stderr
@@ -5,7 +5,7 @@ LL |     fn nodes<'a, I: Iterator<Item=&'a N>>(&self) -> I
    |                                                     - expected `I` because of return type
 ...
 LL |         self.iter() //~ ERROR mismatched types
-   |         ^^^^^^^^^^^ expected type parameter, found struct `std::slice::Iter`
+   |         ^^^^^^^^^^^ expected `I` parameter, found struct `std::slice::Iter`
    |
    = note: expected type `I`
               found type `std::slice::Iter<'_, N>`

--- a/src/test/ui/issues/issue-20225.stderr
+++ b/src/test/ui/issues/issue-20225.stderr
@@ -2,7 +2,7 @@ error[E0053]: method `call` has an incompatible type for trait
   --> $DIR/issue-20225.rs:16:3
    |
 LL |   extern "rust-call" fn call(&self, (_,): (T,)) {}
-   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected reference, found type parameter
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected reference, found `T` parameter
    |
    = note: expected type `extern "rust-call" fn(&Foo, (&'a T,))`
               found type `extern "rust-call" fn(&Foo, (T,))`
@@ -11,7 +11,7 @@ error[E0053]: method `call_mut` has an incompatible type for trait
   --> $DIR/issue-20225.rs:22:3
    |
 LL |   extern "rust-call" fn call_mut(&mut self, (_,): (T,)) {}
-   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected reference, found type parameter
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected reference, found `T` parameter
    |
    = note: expected type `extern "rust-call" fn(&mut Foo, (&'a T,))`
               found type `extern "rust-call" fn(&mut Foo, (T,))`
@@ -20,7 +20,7 @@ error[E0053]: method `call_once` has an incompatible type for trait
   --> $DIR/issue-20225.rs:30:3
    |
 LL |   extern "rust-call" fn call_once(self, (_,): (T,)) {}
-   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected reference, found type parameter
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected reference, found `T` parameter
    |
    = note: expected type `extern "rust-call" fn(Foo, (&'a T,))`
               found type `extern "rust-call" fn(Foo, (T,))`

--- a/src/test/ui/issues/issue-24204.stderr
+++ b/src/test/ui/issues/issue-24204.stderr
@@ -2,7 +2,7 @@ error[E0271]: type mismatch resolving `<<T as Trait>::A as MultiDispatch<i32>>::
   --> $DIR/issue-24204.rs:24:1
    |
 LL | fn test<T: Trait<B=i32>>(b: i32) -> T where T::A: MultiDispatch<i32> { T::new(b) }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected associated type, found type parameter
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected associated type, found `T` parameter
    |
    = note: expected type `<<T as Trait>::A as MultiDispatch<i32>>::O`
               found type `T`

--- a/src/test/ui/issues/issue-2951.rs
+++ b/src/test/ui/issues/issue-2951.rs
@@ -14,7 +14,7 @@ fn foo<T, U>(x: T, y: U) {
     //~^  ERROR mismatched types
     //~| expected type `T`
     //~| found type `U`
-    //~| expected type parameter, found a different type parameter
+    //~| expected `T` parameter, found `U` parameter
 }
 
 fn main() {

--- a/src/test/ui/issues/issue-2951.stderr
+++ b/src/test/ui/issues/issue-2951.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-2951.rs:13:10
    |
 LL |     xx = y;
-   |          ^ expected type parameter, found a different type parameter
+   |          ^ expected `T` parameter, found `U` parameter
    |
    = note: expected type `T`
               found type `U`

--- a/src/test/ui/mismatched_types/issue-35030.stderr
+++ b/src/test/ui/mismatched_types/issue-35030.stderr
@@ -2,9 +2,9 @@ error[E0308]: mismatched types
   --> $DIR/issue-35030.rs:19:14
    |
 LL |         Some(true) //~ ERROR mismatched types
-   |              ^^^^ expected type parameter, found bool
+   |              ^^^^ expected `bool` parameter, found bool
    |
-   = note: expected type `bool` (type parameter)
+   = note: expected type `bool` (`bool` parameter)
               found type `bool` (bool)
 
 error: aborting due to previous error

--- a/src/test/ui/nll/closure-requirements/propagate-from-trait-match.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-from-trait-match.stderr
@@ -46,6 +46,9 @@ LL | | }
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/propagate-from-trait-match.rs:42:36
    |
+LL |   fn supply<'a, T>(value: T)
+   |                 - help: consider adding an explicit lifetime bound `T: ReEarlyBound(0, 'a)`...
+...
 LL |       establish_relationships(value, |value| {
    |  ____________________________________^
 LL | |         //~^ ERROR the parameter type `T` may not live long enough
@@ -55,8 +58,6 @@ LL | |         // This function call requires that
 LL | |         //~^ WARNING not reporting region error due to nll
 LL | |     });
    | |_____^
-   |
-   = help: consider adding an explicit lifetime bound `T: ReEarlyBound(0, 'a)`...
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/ty-outlives/impl-trait-outlives.stderr
+++ b/src/test/ui/nll/ty-outlives/impl-trait-outlives.stderr
@@ -13,18 +13,20 @@ LL | fn wrong_region<'a, 'b, T>(x: Box<T>) -> impl Debug + 'a
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/impl-trait-outlives.rs:22:5
    |
+LL | fn no_region<'a, T>(x: Box<T>) -> impl Debug + 'a
+   |                  - help: consider adding an explicit lifetime bound `T: ReEarlyBound(0, 'a)`...
+...
 LL |     x
    |     ^
-   |
-   = help: consider adding an explicit lifetime bound `T: ReEarlyBound(0, 'a)`...
 
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/impl-trait-outlives.rs:38:5
    |
+LL | fn wrong_region<'a, 'b, T>(x: Box<T>) -> impl Debug + 'a
+   |                         - help: consider adding an explicit lifetime bound `T: ReEarlyBound(0, 'a)`...
+...
 LL |     x
    |     ^
-   |
-   = help: consider adding an explicit lifetime bound `T: ReEarlyBound(0, 'a)`...
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/nll/ty-outlives/projection-implied-bounds.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-implied-bounds.stderr
@@ -7,10 +7,10 @@ LL |     twice(value, |value_ref, item| invoke2(value_ref, item));
 error[E0310]: the parameter type `T` may not live long enough
   --> $DIR/projection-implied-bounds.rs:45:18
    |
+LL | fn generic2<T: Iterator>(value: T) {
+   |             -- help: consider adding an explicit lifetime bound `T: 'static`...
 LL |     twice(value, |value_ref, item| invoke2(value_ref, item));
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: consider adding an explicit lifetime bound `T: 'static`...
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/ty-outlives/projection-one-region-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-one-region-closure.stderr
@@ -65,8 +65,10 @@ error[E0309]: the parameter type `T` may not live long enough
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: consider adding an explicit lifetime bound `T: ReFree(DefId(0/0:8 ~ projection_one_region_closure[317d]::no_relationships_late[0]), BrNamed(crate0:DefIndex(1:16), 'a))`...
    |
-   = help: consider adding an explicit lifetime bound `T: ReFree(DefId(0/0:8 ~ projection_one_region_closure[317d]::no_relationships_late[0]), BrNamed(crate0:DefIndex(1:16), 'a))`...
+LL | fn no_relationships_late<'a, 'b, T: ReFree(DefId(0/0:8 ~ projection_one_region_closure[317d]::no_relationships_late[0]), BrNamed(crate0:DefIndex(1:16), 'a))>(cell: Cell<&'a ()>, t: T)
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 note: External requirements
   --> $DIR/projection-one-region-closure.rs:67:29
@@ -117,10 +119,11 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/projection-one-region-closure.rs:67:29
    |
+LL | fn no_relationships_early<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
+   |                                   - help: consider adding an explicit lifetime bound `T: ReEarlyBound(0, 'a)`...
+...
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: consider adding an explicit lifetime bound `T: ReEarlyBound(0, 'a)`...
 
 note: External requirements
   --> $DIR/projection-one-region-closure.rs:89:29
@@ -171,10 +174,11 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/projection-one-region-closure.rs:89:29
    |
+LL | fn projection_outlives<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
+   |                                - help: consider adding an explicit lifetime bound `T: ReEarlyBound(0, 'a)`...
+...
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: consider adding an explicit lifetime bound `T: ReEarlyBound(0, 'a)`...
 
 note: External requirements
   --> $DIR/projection-one-region-closure.rs:102:29

--- a/src/test/ui/nll/ty-outlives/ty-param-closure-approximate-lower-bound.stderr
+++ b/src/test/ui/nll/ty-outlives/ty-param-closure-approximate-lower-bound.stderr
@@ -80,8 +80,10 @@ error[E0309]: the parameter type `T` may not live long enough
    |
 LL |     twice(cell, value, |a, b| invoke(a, b));
    |                        ^^^^^^^^^^^^^^^^^^^
+help: consider adding an explicit lifetime bound `T: ReFree(DefId(0/0:6 ~ ty_param_closure_approximate_lower_bound[317d]::generic_fail[0]), BrNamed(crate0:DefIndex(1:15), 'a))`...
    |
-   = help: consider adding an explicit lifetime bound `T: ReFree(DefId(0/0:6 ~ ty_param_closure_approximate_lower_bound[317d]::generic_fail[0]), BrNamed(crate0:DefIndex(1:15), 'a))`...
+LL | fn generic_fail<'a, T: ReFree(DefId(0/0:6 ~ ty_param_closure_approximate_lower_bound[317d]::generic_fail[0]), BrNamed(crate0:DefIndex(1:15), 'a))>(cell: Cell<&'a ()>, value: T) {
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/ty-outlives/ty-param-closure-outlives-from-return-type.stderr
+++ b/src/test/ui/nll/ty-outlives/ty-param-closure-outlives-from-return-type.stderr
@@ -45,18 +45,20 @@ LL | | }
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/ty-param-closure-outlives-from-return-type.rs:36:23
    |
+LL | fn no_region<'a, T>(x: Box<T>) -> Box<dyn Debug + 'a>
+   |                  - help: consider adding an explicit lifetime bound `T: ReEarlyBound(0, 'a)`...
+...
 LL |     with_signature(x, |y| y)
    |                       ^^^^^
-   |
-   = help: consider adding an explicit lifetime bound `T: ReEarlyBound(0, 'a)`...
 
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/ty-param-closure-outlives-from-return-type.rs:52:5
    |
+LL | fn wrong_region<'a, 'b, T>(x: Box<T>) -> Box<Debug + 'a>
+   |                         - help: consider adding an explicit lifetime bound `T: ReEarlyBound(0, 'a)`...
+...
 LL |     x
    |     ^
-   |
-   = help: consider adding an explicit lifetime bound `T: ReEarlyBound(0, 'a)`...
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/nll/ty-outlives/ty-param-closure-outlives-from-where-clause.stderr
+++ b/src/test/ui/nll/ty-outlives/ty-param-closure-outlives-from-where-clause.stderr
@@ -59,8 +59,10 @@ LL | |         // See `correct_region`, which explains the point of this
 LL | |         //~^ WARNING not reporting region error due to nll
 LL | |     })
    | |_____^
+help: consider adding an explicit lifetime bound `T: ReFree(DefId(0/0:6 ~ ty_param_closure_outlives_from_where_clause[317d]::no_region[0]), BrNamed(crate0:DefIndex(1:14), 'a))`...
    |
-   = help: consider adding an explicit lifetime bound `T: ReFree(DefId(0/0:6 ~ ty_param_closure_outlives_from_where_clause[317d]::no_region[0]), BrNamed(crate0:DefIndex(1:14), 'a))`...
+LL | fn no_region<'a, T: ReFree(DefId(0/0:6 ~ ty_param_closure_outlives_from_where_clause[317d]::no_region[0]), BrNamed(crate0:DefIndex(1:14), 'a))>(a: Cell<&'a ()>, b: T) {
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 note: External requirements
   --> $DIR/ty-param-closure-outlives-from-where-clause.rs:54:26
@@ -150,8 +152,10 @@ LL | |         require(&x, &y)
 LL | |         //~^ WARNING not reporting region error due to nll
 LL | |     })
    | |_____^
+help: consider adding an explicit lifetime bound `T: ReFree(DefId(0/0:8 ~ ty_param_closure_outlives_from_where_clause[317d]::wrong_region[0]), BrNamed(crate0:DefIndex(1:20), 'a))`...
    |
-   = help: consider adding an explicit lifetime bound `T: ReFree(DefId(0/0:8 ~ ty_param_closure_outlives_from_where_clause[317d]::wrong_region[0]), BrNamed(crate0:DefIndex(1:20), 'a))`...
+LL | fn wrong_region<'a, 'b, T: ReFree(DefId(0/0:8 ~ ty_param_closure_outlives_from_where_clause[317d]::wrong_region[0]), BrNamed(crate0:DefIndex(1:20), 'a))>(a: Cell<&'a ()>, b: T)
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 note: External requirements
   --> $DIR/ty-param-closure-outlives-from-where-clause.rs:89:26

--- a/src/test/ui/nll/ty-outlives/ty-param-fn-body-nll-feature.stderr
+++ b/src/test/ui/nll/ty-outlives/ty-param-fn-body-nll-feature.stderr
@@ -1,10 +1,10 @@
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/ty-param-fn-body-nll-feature.rs:30:5
    |
+LL | fn region_static<'a, T>(cell: Cell<&'a usize>, t: T) {
+   |                      - help: consider adding an explicit lifetime bound `T: 'a`...
 LL |     outlives(cell, t)
    |     ^^^^^^^^^^^^^^^^^
-   |
-   = help: consider adding an explicit lifetime bound `T: 'a`...
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/ty-outlives/ty-param-fn-body.stderr
+++ b/src/test/ui/nll/ty-outlives/ty-param-fn-body.stderr
@@ -7,10 +7,10 @@ LL |     outlives(cell, t)
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/ty-param-fn-body.rs:29:5
    |
+LL | fn region_static<'a, T>(cell: Cell<&'a usize>, t: T) {
+   |                      - help: consider adding an explicit lifetime bound `T: 'a`...
 LL |     outlives(cell, t)
    |     ^^^^^^^^^^^^^^^^^
-   |
-   = help: consider adding an explicit lifetime bound `T: 'a`...
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/ty-outlives/ty-param-fn.stderr
+++ b/src/test/ui/nll/ty-outlives/ty-param-fn.stderr
@@ -13,18 +13,20 @@ LL |     x
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/ty-param-fn.rs:21:5
    |
+LL | fn no_region<'a, T>(x: Box<T>) -> Box<Debug + 'a>
+   |                  - help: consider adding an explicit lifetime bound `T: 'a`...
+...
 LL |     x
    |     ^
-   |
-   = help: consider adding an explicit lifetime bound `T: 'a`...
 
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/ty-param-fn.rs:37:5
    |
+LL | fn wrong_region<'a, 'b, T>(x: Box<T>) -> Box<Debug + 'a>
+   |                         - help: consider adding an explicit lifetime bound `T: 'a`...
+...
 LL |     x
    |     ^
-   |
-   = help: consider adding an explicit lifetime bound `T: 'a`...
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/regions/regions-close-object-into-object-4.nll.stderr
+++ b/src/test/ui/regions/regions-close-object-into-object-4.nll.stderr
@@ -42,18 +42,18 @@ LL | | }
 error[E0310]: the parameter type `U` may not live long enough
   --> $DIR/regions-close-object-into-object-4.rs:20:5
    |
+LL | fn i<'a, T, U>(v: Box<A<U>+'a>) -> Box<X+'static> {
+   |             - help: consider adding an explicit lifetime bound `U: 'static`...
 LL |     box B(&*v) as Box<X> //~ ERROR cannot infer
    |     ^^^^^^^^^^
-   |
-   = help: consider adding an explicit lifetime bound `U: 'static`...
 
 error[E0310]: the parameter type `U` may not live long enough
   --> $DIR/regions-close-object-into-object-4.rs:20:9
    |
+LL | fn i<'a, T, U>(v: Box<A<U>+'a>) -> Box<X+'static> {
+   |             - help: consider adding an explicit lifetime bound `U: 'static`...
 LL |     box B(&*v) as Box<X> //~ ERROR cannot infer
    |         ^^^^^^
-   |
-   = help: consider adding an explicit lifetime bound `U: 'static`...
 
 error[E0597]: `*v` does not live long enough
   --> $DIR/regions-close-object-into-object-4.rs:20:11

--- a/src/test/ui/regions/regions-close-object-into-object-5.nll.stderr
+++ b/src/test/ui/regions/regions-close-object-into-object-5.nll.stderr
@@ -31,18 +31,20 @@ LL |     box B(&*v) as Box<X>
 error[E0310]: the parameter type `T` may not live long enough
   --> $DIR/regions-close-object-into-object-5.rs:27:5
    |
+LL | fn f<'a, T, U>(v: Box<A<T>+'static>) -> Box<X+'static> {
+   |          - help: consider adding an explicit lifetime bound `T: 'static`...
+LL |     // oh dear!
 LL |     box B(&*v) as Box<X>
    |     ^^^^^^^^^^
-   |
-   = help: consider adding an explicit lifetime bound `T: 'static`...
 
 error[E0310]: the parameter type `T` may not live long enough
   --> $DIR/regions-close-object-into-object-5.rs:27:9
    |
+LL | fn f<'a, T, U>(v: Box<A<T>+'static>) -> Box<X+'static> {
+   |          - help: consider adding an explicit lifetime bound `T: 'static`...
+LL |     // oh dear!
 LL |     box B(&*v) as Box<X>
    |         ^^^^^^
-   |
-   = help: consider adding an explicit lifetime bound `T: 'static`...
 
 error[E0597]: `*v` does not live long enough
   --> $DIR/regions-close-object-into-object-5.rs:27:11

--- a/src/test/ui/regions/regions-close-over-type-parameter-1.nll.stderr
+++ b/src/test/ui/regions/regions-close-over-type-parameter-1.nll.stderr
@@ -25,18 +25,18 @@ LL |     box v as Box<SomeTrait+'b>
 error[E0310]: the parameter type `A` may not live long enough
   --> $DIR/regions-close-over-type-parameter-1.rs:20:5
    |
+LL | fn make_object1<A:SomeTrait>(v: A) -> Box<SomeTrait+'static> {
+   |                 -- help: consider adding an explicit lifetime bound `A: 'static`...
 LL |     box v as Box<SomeTrait+'static>
    |     ^^^^^
-   |
-   = help: consider adding an explicit lifetime bound `A: 'static`...
 
 error[E0309]: the parameter type `A` may not live long enough
   --> $DIR/regions-close-over-type-parameter-1.rs:30:5
    |
+LL | fn make_object3<'a,'b,A:SomeTrait+'a>(v: A) -> Box<SomeTrait+'b> {
+   |                       -- help: consider adding an explicit lifetime bound `A: 'b`...
 LL |     box v as Box<SomeTrait+'b>
    |     ^^^^^
-   |
-   = help: consider adding an explicit lifetime bound `A: 'b`...
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/regions/regions-close-over-type-parameter-multiple.nll.stderr
+++ b/src/test/ui/regions/regions-close-over-type-parameter-multiple.nll.stderr
@@ -7,10 +7,11 @@ LL |     box v as Box<SomeTrait+'a> //~ ERROR cannot infer an appropriate lifeti
 error[E0309]: the parameter type `A` may not live long enough
   --> $DIR/regions-close-over-type-parameter-multiple.rs:30:5
    |
+LL | fn make_object_bad<'a,'b,'c,A:SomeTrait+'a+'b>(v: A) -> Box<SomeTrait+'c> {
+   |                             -- help: consider adding an explicit lifetime bound `A: 'c`...
+LL |     // A outlives 'a AND 'b...but not 'c.
 LL |     box v as Box<SomeTrait+'a> //~ ERROR cannot infer an appropriate lifetime
    |     ^^^^^
-   |
-   = help: consider adding an explicit lifetime bound `A: 'c`...
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-close-param-into-object.nll.stderr
+++ b/src/test/ui/regions/regions-close-param-into-object.nll.stderr
@@ -25,34 +25,38 @@ LL |     Box::new(v) //~ ERROR parameter type `T` may not live long enough
 error[E0310]: the parameter type `T` may not live long enough
   --> $DIR/regions-close-param-into-object.rs:16:5
    |
+LL | fn p1<T>(v: T) -> Box<X+'static>
+   |       - help: consider adding an explicit lifetime bound `T: 'static`...
+...
 LL |     Box::new(v) //~ ERROR parameter type `T` may not live long enough
    |     ^^^^^^^^^^^
-   |
-   = help: consider adding an explicit lifetime bound `T: 'static`...
 
 error[E0310]: the parameter type `T` may not live long enough
   --> $DIR/regions-close-param-into-object.rs:22:5
    |
+LL | fn p2<T>(v: Box<T>) -> Box<X+'static>
+   |       - help: consider adding an explicit lifetime bound `T: 'static`...
+...
 LL |     Box::new(v) //~ ERROR parameter type `T` may not live long enough
    |     ^^^^^^^^^^^
-   |
-   = help: consider adding an explicit lifetime bound `T: 'static`...
 
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/regions-close-param-into-object.rs:28:5
    |
+LL | fn p3<'a,T>(v: T) -> Box<X+'a>
+   |          - help: consider adding an explicit lifetime bound `T: 'a`...
+...
 LL |     Box::new(v) //~ ERROR parameter type `T` may not live long enough
    |     ^^^^^^^^^^^
-   |
-   = help: consider adding an explicit lifetime bound `T: 'a`...
 
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/regions-close-param-into-object.rs:34:5
    |
+LL | fn p4<'a,T>(v: Box<T>) -> Box<X+'a>
+   |          - help: consider adding an explicit lifetime bound `T: 'a`...
+...
 LL |     Box::new(v) //~ ERROR parameter type `T` may not live long enough
    |     ^^^^^^^^^^^
-   |
-   = help: consider adding an explicit lifetime bound `T: 'a`...
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/regions/regions-infer-bound-from-trait.nll.stderr
+++ b/src/test/ui/regions/regions-infer-bound-from-trait.nll.stderr
@@ -13,18 +13,18 @@ LL |     check_bound(x, a) //~ ERROR parameter type `A` may not live long enough
 error[E0309]: the parameter type `A` may not live long enough
   --> $DIR/regions-infer-bound-from-trait.rs:43:5
    |
+LL | fn bar1<'a,A>(x: Inv<'a>, a: A) {
+   |            - help: consider adding an explicit lifetime bound `A: 'a`...
 LL |     check_bound(x, a) //~ ERROR parameter type `A` may not live long enough
    |     ^^^^^^^^^^^^^^^^^
-   |
-   = help: consider adding an explicit lifetime bound `A: 'a`...
 
 error[E0309]: the parameter type `A` may not live long enough
   --> $DIR/regions-infer-bound-from-trait.rs:47:5
    |
+LL | fn bar2<'a,'b,A:Is<'b>>(x: Inv<'a>, y: Inv<'b>, a: A) {
+   |               -- help: consider adding an explicit lifetime bound `A: 'a`...
 LL |     check_bound(x, a) //~ ERROR parameter type `A` may not live long enough
    |     ^^^^^^^^^^^^^^^^^
-   |
-   = help: consider adding an explicit lifetime bound `A: 'a`...
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/structs/struct-path-self-type-mismatch.stderr
+++ b/src/test/ui/structs/struct-path-self-type-mismatch.stderr
@@ -8,7 +8,7 @@ error[E0308]: mismatched types
   --> $DIR/struct-path-self-type-mismatch.rs:25:20
    |
 LL |             inner: u
-   |                    ^ expected type parameter, found a different type parameter
+   |                    ^ expected `T` parameter, found `U` parameter
    |
    = note: expected type `T`
               found type `U`
@@ -23,7 +23,7 @@ LL | |         //~^ ERROR mismatched types
 LL | |             inner: u
 LL | |             //~^ ERROR mismatched types
 LL | |         }
-   | |_________^ expected type parameter, found a different type parameter
+   | |_________^ expected `U` parameter, found `T` parameter
    |
    = note: expected type `Foo<U>`
               found type `Foo<T>`

--- a/src/test/ui/structs/struct-path-self.rs
+++ b/src/test/ui/structs/struct-path-self.rs
@@ -13,13 +13,13 @@ struct S;
 trait Tr {
     fn f() {
         let s = Self {};
-        //~^ ERROR expected struct, variant or union type, found Self
+        //~^ ERROR expected struct, variant or union type, found `Self` parameter
         let z = Self::<u8> {};
-        //~^ ERROR expected struct, variant or union type, found Self
+        //~^ ERROR expected struct, variant or union type, found `Self` parameter
         //~| ERROR type parameters are not allowed on this type
         match s {
             Self { .. } => {}
-            //~^ ERROR expected struct, variant or union type, found Self
+            //~^ ERROR expected struct, variant or union type, found `Self` parameter
         }
     }
 }

--- a/src/test/ui/structs/struct-path-self.stderr
+++ b/src/test/ui/structs/struct-path-self.stderr
@@ -1,4 +1,4 @@
-error[E0071]: expected struct, variant or union type, found Self
+error[E0071]: expected struct, variant or union type, found `Self` parameter
   --> $DIR/struct-path-self.rs:15:17
    |
 LL |         let s = Self {};
@@ -10,13 +10,13 @@ error[E0109]: type parameters are not allowed on this type
 LL |         let z = Self::<u8> {};
    |                        ^^ type parameter not allowed
 
-error[E0071]: expected struct, variant or union type, found Self
+error[E0071]: expected struct, variant or union type, found `Self` parameter
   --> $DIR/struct-path-self.rs:17:17
    |
 LL |         let z = Self::<u8> {};
    |                 ^^^^^^^^^^ not a struct
 
-error[E0071]: expected struct, variant or union type, found Self
+error[E0071]: expected struct, variant or union type, found `Self` parameter
   --> $DIR/struct-path-self.rs:21:13
    |
 LL |             Self { .. } => {}

--- a/src/test/ui/type/type-parameter-names.rs
+++ b/src/test/ui/type/type-parameter-names.rs
@@ -16,7 +16,7 @@ fn foo<Foo, Bar>(x: Foo) -> Bar {
 //~^ ERROR mismatched types
 //~| expected type `Bar`
 //~| found type `Foo`
-//~| expected type parameter, found a different type parameter
+//~| expected `Bar` parameter, found `Foo` parameter
 }
 
 fn main() {}

--- a/src/test/ui/type/type-parameter-names.stderr
+++ b/src/test/ui/type/type-parameter-names.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn foo<Foo, Bar>(x: Foo) -> Bar {
    |                             --- expected `Bar` because of return type
 LL |     x
-   |     ^ expected type parameter, found a different type parameter
+   |     ^ expected `Bar` parameter, found `Foo` parameter
    |
    = note: expected type `Bar`
               found type `Foo`

--- a/src/test/ui/type/type-params-in-different-spaces-1.rs
+++ b/src/test/ui/type/type-params-in-different-spaces-1.rs
@@ -15,7 +15,7 @@ trait BrokenAdd: Copy + Add<Output=Self> {
         *self + rhs //~  ERROR mismatched types
                     //~| expected type `Self`
                     //~| found type `T`
-                    //~| expected Self, found type parameter
+                    //~| expected `Self` parameter, found `T` parameter
     }
 }
 

--- a/src/test/ui/type/type-params-in-different-spaces-1.stderr
+++ b/src/test/ui/type/type-params-in-different-spaces-1.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/type-params-in-different-spaces-1.rs:15:17
    |
 LL |         *self + rhs //~  ERROR mismatched types
-   |                 ^^^ expected Self, found type parameter
+   |                 ^^^ expected `Self` parameter, found `T` parameter
    |
    = note: expected type `Self`
               found type `T`

--- a/src/test/ui/type/type-params-in-different-spaces-3.stderr
+++ b/src/test/ui/type/type-params-in-different-spaces-3.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL |     fn test<X>(u: X) -> Self {
    |                         ---- expected `Self` because of return type
 LL |         u   //~ ERROR mismatched types
-   |         ^ expected Self, found type parameter
+   |         ^ expected `Self` parameter, found `X` parameter
    |
    = note: expected type `Self`
               found type `X`


### PR DESCRIPTION
Fixes #50125 by replacing special-casing of `Self` (and the gensym hack) with getting the type for the `Self` parameter from the trait, and comparing types with that, instead.

**NOTE**: this is part of #53661, split out to independently check performance impact.