### PR TITLE
rustc: Suggest removing `extern crate` in 2018

### DIFF
--- a/src/librustc_typeck/check_unused.rs
+++ b/src/librustc_typeck/check_unused.rs
@@ -176,7 +176,12 @@ fn unused_crates_lint<'tcx>(tcx: TyCtxt<'_, 'tcx, 'tcx>) {
         };
         let replacement = visibility_qualified(&item.vis, &base_replacement);
         tcx.struct_span_lint_node(lint, id, extern_crate.span, msg)
-            .span_suggestion_short(extern_crate.span, &help, replacement)
+            .span_suggestion_short_with_applicability(
+                extern_crate.span,
+                &help,
+                replacement,
+                Applicability::MachineApplicable,
+            )
             .emit();
     }
 }

--- a/src/test/ui/rust-2018/auxiliary/remove-extern-crate.rs
+++ b/src/test/ui/rust-2018/auxiliary/remove-extern-crate.rs
@@ -1,0 +1,19 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[macro_export]
+macro_rules! foo {
+    () => ()
+}
+
+#[macro_export]
+macro_rules! bar {
+    () => ()
+}

--- a/src/test/ui/rust-2018/remove-extern-crate.fixed
+++ b/src/test/ui/rust-2018/remove-extern-crate.fixed
@@ -1,0 +1,39 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// run-rustfix
+// edition:2018
+// compile-pass
+// aux-build:remove-extern-crate.rs
+
+#![warn(rust_2018_idioms)]
+
+
+use core as another_name;
+use remove_extern_crate;
+#[macro_use]
+extern crate remove_extern_crate as something_else;
+
+fn main() {
+    another_name::mem::drop(3);
+    another::foo();
+    remove_extern_crate::foo!();
+    bar!();
+}
+
+mod another {
+    use core;
+    use remove_extern_crate;
+
+    pub fn foo() {
+        core::mem::drop(4);
+        remove_extern_crate::foo!();
+    }
+}

--- a/src/test/ui/rust-2018/remove-extern-crate.rs
+++ b/src/test/ui/rust-2018/remove-extern-crate.rs
@@ -1,0 +1,39 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// run-rustfix
+// edition:2018
+// compile-pass
+// aux-build:remove-extern-crate.rs
+
+#![warn(rust_2018_idioms)]
+
+extern crate core;
+extern crate core as another_name;
+use remove_extern_crate;
+#[macro_use]
+extern crate remove_extern_crate as something_else;
+
+fn main() {
+    another_name::mem::drop(3);
+    another::foo();
+    remove_extern_crate::foo!();
+    bar!();
+}
+
+mod another {
+    extern crate core;
+    use remove_extern_crate;
+
+    pub fn foo() {
+        core::mem::drop(4);
+        remove_extern_crate::foo!();
+    }
+}

--- a/src/test/ui/rust-2018/remove-extern-crate.stderr
+++ b/src/test/ui/rust-2018/remove-extern-crate.stderr
@@ -1,0 +1,25 @@
+warning: unused extern crate
+  --> $DIR/remove-extern-crate.rs:18:1
+   |
+LL | extern crate core;
+   | ^^^^^^^^^^^^^^^^^^ help: remove it
+   |
+note: lint level defined here
+  --> $DIR/remove-extern-crate.rs:16:9
+   |
+LL | #![warn(rust_2018_idioms)]
+   |         ^^^^^^^^^^^^^^^^
+   = note: #[warn(unused_extern_crates)] implied by #[warn(rust_2018_idioms)]
+
+warning: `extern crate` is not idiomatic in the new edition
+  --> $DIR/remove-extern-crate.rs:19:1
+   |
+LL | extern crate core as another_name;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: convert it to a `use`
+
+warning: `extern crate` is not idiomatic in the new edition
+  --> $DIR/remove-extern-crate.rs:32:5
+   |
+LL |     extern crate core;
+   |     ^^^^^^^^^^^^^^^^^^ help: convert it to a `use`
+


### PR DESCRIPTION
This commit updates the `unused_extern_crates` lint to make automatic
suggestions about removing `extern crate` annotations in the 2018 edition. This
ended up being a little easier than originally though due to what's likely been
fixed issues in the resolver!

Closes #52829