### PR TITLE
Generalize `async_idents` to all new keywords

### DIFF
--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -1046,7 +1046,7 @@ impl<'a> ast_visit::Visitor<'a> for EarlyContext<'a> {
         self.check_id(id);
     }
 
-    fn visit_mac(&mut self, mac: &'ast ast::Mac) {
+    fn visit_mac(&mut self, mac: &'a ast::Mac) {
         run_lints!(self, check_mac, mac);
     }
 }

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -110,7 +110,7 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
     }
 
     add_pre_expansion_builtin!(sess,
-        Async2018,
+        KeywordIdents,
     );
 
     add_early_builtin!(sess,
@@ -240,7 +240,7 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
             edition: Some(Edition::Edition2018),
         },
         FutureIncompatibleInfo {
-            id: LintId::of(ASYNC_IDENTS),
+            id: LintId::of(KEYWORD_IDENTS),
             reference: "issue #49716 <https://github.com/rust-lang/rust/issues/49716>",
             edition: Some(Edition::Edition2018),
         },
@@ -349,6 +349,7 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
     store.register_renamed("bare_trait_object", "bare_trait_objects");
     store.register_renamed("unstable_name_collision", "unstable_name_collisions");
     store.register_renamed("unused_doc_comment", "unused_doc_comments");
+    store.register_renamed("async_idents", "keyword_idents");
     store.register_removed("unknown_features", "replaced by an error");
     store.register_removed("unsigned_negation", "replaced by negate_unsigned feature gate");
     store.register_removed("negate_unsigned", "cast a signed value instead");

--- a/src/test/ui/editions/auxiliary/edition-kw-macro-2015.rs
+++ b/src/test/ui/editions/auxiliary/edition-kw-macro-2015.rs
@@ -10,7 +10,7 @@
 
 // edition:2015
 
-#![allow(async_idents)]
+#![allow(keyword_idents)]
 
 #[macro_export]
 macro_rules! produces_async {

--- a/src/test/ui/editions/edition-keywords-2015-2015-expansion.rs
+++ b/src/test/ui/editions/edition-keywords-2015-2015-expansion.rs
@@ -12,7 +12,7 @@
 // aux-build:edition-kw-macro-2015.rs
 // compile-pass
 
-#![allow(async_idents)]
+#![allow(keyword_idents)]
 
 #[macro_use]
 extern crate edition_kw_macro_2015;

--- a/src/test/ui/editions/edition-keywords-2018-2015-expansion.rs
+++ b/src/test/ui/editions/edition-keywords-2018-2015-expansion.rs
@@ -12,7 +12,7 @@
 // aux-build:edition-kw-macro-2015.rs
 // compile-pass
 
-#![allow(async_idents)]
+#![allow(keyword_idents)]
 
 #[macro_use]
 extern crate edition_kw_macro_2015;

--- a/src/test/ui/rust-2018/async-ident-allowed.stderr
+++ b/src/test/ui/rust-2018/async-ident-allowed.stderr
@@ -9,7 +9,7 @@ note: lint level defined here
    |
 LL | #![deny(rust_2018_compatibility)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^
-   = note: #[deny(async_idents)] implied by #[deny(rust_2018_compatibility)]
+   = note: #[deny(keyword_idents)] implied by #[deny(rust_2018_compatibility)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 

--- a/src/test/ui/rust-2018/async-ident.fixed
+++ b/src/test/ui/rust-2018/async-ident.fixed
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 #![allow(dead_code, unused_variables, non_camel_case_types, non_upper_case_globals)]
-#![deny(async_idents)]
+#![deny(keyword_idents)]
 
 // edition:2015
 // run-rustfix

--- a/src/test/ui/rust-2018/async-ident.rs
+++ b/src/test/ui/rust-2018/async-ident.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 #![allow(dead_code, unused_variables, non_camel_case_types, non_upper_case_globals)]
-#![deny(async_idents)]
+#![deny(keyword_idents)]
 
 // edition:2015
 // run-rustfix

--- a/src/test/ui/rust-2018/async-ident.stderr
+++ b/src/test/ui/rust-2018/async-ident.stderr
@@ -7,8 +7,8 @@ LL | fn async() {} //~ ERROR async
 note: lint level defined here
   --> $DIR/async-ident.rs:12:9
    |
-LL | #![deny(async_idents)]
-   |         ^^^^^^^^^^^^
+LL | #![deny(keyword_idents)]
+   |         ^^^^^^^^^^^^^^
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 

--- a/src/test/ui/rust-2018/try-ident.fixed
+++ b/src/test/ui/rust-2018/try-ident.fixed
@@ -8,31 +8,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// edition:2018
+// run-rustfix
+// compile-pass
 
-#![allow(keyword_idents)]
+#![warn(rust_2018_compatibility)]
 
-#[macro_export]
-macro_rules! produces_async {
-    () => (pub fn async() {})
+fn main() {
+    r#try();
 }
 
-#[macro_export]
-macro_rules! produces_async_raw {
-    () => (pub fn r#async() {})
-}
-
-#[macro_export]
-macro_rules! consumes_async {
-    (async) => (1)
-}
-
-#[macro_export]
-macro_rules! consumes_async_raw {
-    (r#async) => (1)
-}
-
-#[macro_export]
-macro_rules! passes_ident {
-    ($i: ident) => ($i)
+fn r#try() {
 }

--- a/src/test/ui/rust-2018/try-ident.rs
+++ b/src/test/ui/rust-2018/try-ident.rs
@@ -8,31 +8,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// edition:2018
+// run-rustfix
+// compile-pass
 
-#![allow(keyword_idents)]
+#![warn(rust_2018_compatibility)]
 
-#[macro_export]
-macro_rules! produces_async {
-    () => (pub fn async() {})
+fn main() {
+    try();
 }
 
-#[macro_export]
-macro_rules! produces_async_raw {
-    () => (pub fn r#async() {})
-}
-
-#[macro_export]
-macro_rules! consumes_async {
-    (async) => (1)
-}
-
-#[macro_export]
-macro_rules! consumes_async_raw {
-    (r#async) => (1)
-}
-
-#[macro_export]
-macro_rules! passes_ident {
-    ($i: ident) => ($i)
+fn try() {
 }

--- a/src/test/ui/rust-2018/try-ident.stderr
+++ b/src/test/ui/rust-2018/try-ident.stderr
@@ -1,0 +1,24 @@
+warning: `try` is a keyword in the 2018 edition
+  --> $DIR/try-ident.rs:17:5
+   |
+LL |     try();
+   |     ^^^ help: you can use a raw identifier to stay compatible: `r#try`
+   |
+note: lint level defined here
+  --> $DIR/try-ident.rs:14:9
+   |
+LL | #![warn(rust_2018_compatibility)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^
+   = note: #[warn(keyword_idents)] implied by #[warn(rust_2018_compatibility)]
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
+
+warning: `try` is a keyword in the 2018 edition
+  --> $DIR/try-ident.rs:20:4
+   |
+LL | fn try() {
+   |    ^^^ help: you can use a raw identifier to stay compatible: `r#try`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
+


### PR DESCRIPTION
This commit generalizes the existing `async_idents` lint to easily encompass
other identifiers that will be keywords in future editions. The new lint is
called `keyword_idents` and the old `async_idents` lint is registered as renamed
to this new lint.

As a proof of concept the `try` keyword was added to this list as it looks to be
listed as a keyword in the 2018 edition only. The `await` keyword was not added
as it's not listed as a keyword yet.

Closes #53077