### PR TITLE
[WIP] Fix evaluation overflow

### DIFF
--- a/src/librustc/traits/structural_impls.rs
+++ b/src/librustc/traits/structural_impls.rs
@@ -175,7 +175,7 @@ impl<'a, 'tcx> Lift<'tcx> for traits::SelectionError<'a> {
             super::ConstEvalFailure(ref err) => tcx.lift(&**err).map(|err| super::ConstEvalFailure(
                 err.into(),
             )),
-            super::Overflow => bug!(), // FIXME: ape ConstEvalFailure?
+            super::Overflow => Some(super::Overflow),
         }
     }
 }


### PR DESCRIPTION
Fixes #52873.

Currently, it fails to evaluate [this code](https://docs.rs/typenum/1.10.0/src/typenum/uint.rs.html#1023-1031). By replacing this line, instead of a bug we get a nice infinite recursion:

```
error[E0275]: overflow evaluating the requirement `_: core::marker::Sized`
  |
  = help: consider adding a `#![recursion_limit="128"]` attribute to your crate
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<_, _>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `private::PrivatePow<uint::UInt<uint::UTerm, bit::B1>, uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`
  = note: required because of the requirements on the impl of `type_operators::Pow<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<uint::UInt<_, _>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>, bit::B0>>` for `uint::UTerm`

error: Could not document `typenum`.
```

So I assume the simplification is failing for some reasons in [predicate_may_hold](https://github.com/rust-lang/rust/blob/master/src/librustdoc/clean/blanket_impl.rs#L106).

cc @eddyb @nikomatsakis 