### PR TITLE
[beta] Rollup backports

### DIFF
--- a/src/librustc_codegen_llvm/mir/mod.rs
+++ b/src/librustc_codegen_llvm/mir/mod.rs
@@ -572,6 +572,25 @@ fn arg_local_refs<'a, 'tcx>(bx: &Builder<'a, 'tcx>,
             };
             let upvar_tys = upvar_substs.upvar_tys(def_id, tcx);
 
+            // Store the pointer to closure data in an alloca for debuginfo
+            // because that's what the llvm.dbg.declare intrinsic expects.
+
+            // FIXME(eddyb) this shouldn't be necessary but SROA seems to
+            // mishandle DW_OP_plus not preceded by DW_OP_deref, i.e. it
+            // doesn't actually strip the offset when splitting the closure
+            // environment into its components so it ends up out of bounds.
+            // (cuviper) It seems to be fine without the alloca on LLVM 6 and later.
+            let env_alloca = !env_ref && unsafe { llvm::LLVMRustVersionMajor() < 6 };
+            let env_ptr = if env_alloca {
+                let scratch = PlaceRef::alloca(bx,
+                    bx.cx.layout_of(tcx.mk_mut_ptr(arg.layout.ty)),
+                    "__debuginfo_env_ptr");
+                bx.store(place.llval, scratch.llval, scratch.align);
+                scratch.llval
+            } else {
+                place.llval
+            };
+
             for (i, (decl, ty)) in mir.upvar_decls.iter().zip(upvar_tys).enumerate() {
                 let byte_offset_of_var_in_env = closure_layout.fields.offset(i).bytes();
 
@@ -583,7 +602,10 @@ fn arg_local_refs<'a, 'tcx>(bx: &Builder<'a, 'tcx>,
                 };
 
                 // The environment and the capture can each be indirect.
-                let mut ops = if env_ref { &ops[..] } else { &ops[1..] };
+
+                // FIXME(eddyb) see above why we sometimes have to keep
+                // a pointer in an alloca for debuginfo atm.
+                let mut ops = if env_ref || env_alloca { &ops[..] } else { &ops[1..] };
 
                 let ty = if let (true, &ty::TyRef(_, ty, _)) = (decl.by_ref, &ty.sty) {
                     ty
@@ -593,7 +615,7 @@ fn arg_local_refs<'a, 'tcx>(bx: &Builder<'a, 'tcx>,
                 };
 
                 let variable_access = VariableAccess::IndirectVariable {
-                    alloca: place.llval,
+                    alloca: env_ptr,
                     address_operations: &ops
                 };
                 declare_local(

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -284,7 +284,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnsafeCode {
 declare_lint! {
     pub MISSING_DOCS,
     Allow,
-    "detects missing documentation for public members"
+    "detects missing documentation for public members",
+    report_in_external_macro: true
 }
 
 pub struct MissingDoc {

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -203,6 +203,8 @@ impl<'a> Resolver<'a> {
             };
             match self.resolve_ident_in_module(module, ident, ns, false, path_span) {
                 Err(Determined) => continue,
+                Ok(binding)
+                    if !self.is_accessible_from(binding.vis, single_import.parent) => continue,
                 Ok(_) | Err(Undetermined) => return Err(Undetermined),
             }
         }
@@ -255,8 +257,11 @@ impl<'a> Resolver<'a> {
                 module, ident, ns, false, false, path_span,
             );
             self.current_module = orig_current_module;
+
             match result {
                 Err(Determined) => continue,
+                Ok(binding)
+                    if !self.is_accessible_from(binding.vis, glob_import.parent) => continue,
                 Ok(_) | Err(Undetermined) => return Err(Undetermined),
             }
         }

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -1861,10 +1861,15 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                     "existential types are unstable"
                 );
             }
-
-            ast::ImplItemKind::Type(_) if !ii.generics.params.is_empty() => {
-                gate_feature_post!(&self, generic_associated_types, ii.span,
-                                   "generic associated types are unstable");
+            ast::ImplItemKind::Type(_) => {
+                if !ii.generics.params.is_empty() {
+                    gate_feature_post!(&self, generic_associated_types, ii.span,
+                                       "generic associated types are unstable");
+                }
+                if !ii.generics.where_clause.predicates.is_empty() {
+                    gate_feature_post!(&self, generic_associated_types, ii.span,
+                                       "where clauses on associated types are unstable");
+                }
             }
             _ => {}
         }

--- a/src/test/ui-fulldeps/proc-macro/generate-mod.rs
+++ b/src/test/ui-fulldeps/proc-macro/generate-mod.rs
@@ -31,6 +31,14 @@ struct S;
                                      //~| WARN this was previously accepted
 struct Z;
 
+fn inner_block() {
+    #[derive(generate_mod::CheckDerive)] //~ WARN cannot find type `FromOutside` in this scope
+                                        //~| WARN cannot find type `OuterDerive` in this scope
+                                        //~| WARN this was previously accepted
+                                        //~| WARN this was previously accepted
+    struct InnerZ;
+}
+
 #[derive(generate_mod::CheckDeriveLint)] // OK, lint is suppressed
 struct W;
 

--- a/src/test/ui-fulldeps/proc-macro/generate-mod.stderr
+++ b/src/test/ui-fulldeps/proc-macro/generate-mod.stderr
@@ -41,6 +41,24 @@ LL | #[derive(generate_mod::CheckDerive)] //~ WARN cannot find type `FromOutside
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #50504 <https://github.com/rust-lang/rust/issues/50504>
 
+warning: cannot find type `FromOutside` in this scope
+  --> $DIR/generate-mod.rs:35:14
+   |
+LL |     #[derive(generate_mod::CheckDerive)] //~ WARN cannot find type `FromOutside` in this scope
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^ names from parent modules are not accessible without an explicit import
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #50504 <https://github.com/rust-lang/rust/issues/50504>
+
+warning: cannot find type `OuterDerive` in this scope
+  --> $DIR/generate-mod.rs:35:14
+   |
+LL |     #[derive(generate_mod::CheckDerive)] //~ WARN cannot find type `FromOutside` in this scope
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^ names from parent modules are not accessible without an explicit import
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #50504 <https://github.com/rust-lang/rust/issues/50504>
+
 error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0412`.

--- a/src/test/ui/feature-gate-generic_associated_types.rs
+++ b/src/test/ui/feature-gate-generic_associated_types.rs
@@ -19,6 +19,7 @@ trait PointerFamily<U> {
 }
 
 struct Foo;
+
 impl PointerFamily<u32> for Foo {
     type Pointer<usize> = Box<usize>;
     //~^ ERROR generic associated types are unstable
@@ -31,5 +32,9 @@ trait Bar {
     //~^ ERROR where clauses on associated types are unstable
 }
 
+impl Bar for Foo {
+    type Assoc where Self: Sized = Foo;
+    //~^ ERROR where clauses on associated types are unstable
+}
 
 fn main() {}

--- a/src/test/ui/feature-gate-generic_associated_types.stderr
+++ b/src/test/ui/feature-gate-generic_associated_types.stderr
@@ -23,7 +23,7 @@ LL |     type Pointer2<T>: Deref<Target = T> where T: Clone, U: Clone;
    = help: add #![feature(generic_associated_types)] to the crate attributes to enable
 
 error[E0658]: generic associated types are unstable (see issue #44265)
-  --> $DIR/feature-gate-generic_associated_types.rs:23:5
+  --> $DIR/feature-gate-generic_associated_types.rs:24:5
    |
 LL |     type Pointer<usize> = Box<usize>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -31,7 +31,7 @@ LL |     type Pointer<usize> = Box<usize>;
    = help: add #![feature(generic_associated_types)] to the crate attributes to enable
 
 error[E0658]: generic associated types are unstable (see issue #44265)
-  --> $DIR/feature-gate-generic_associated_types.rs:25:5
+  --> $DIR/feature-gate-generic_associated_types.rs:26:5
    |
 LL |     type Pointer2<u32> = Box<u32>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -39,13 +39,21 @@ LL |     type Pointer2<u32> = Box<u32>;
    = help: add #![feature(generic_associated_types)] to the crate attributes to enable
 
 error[E0658]: where clauses on associated types are unstable (see issue #44265)
-  --> $DIR/feature-gate-generic_associated_types.rs:30:5
+  --> $DIR/feature-gate-generic_associated_types.rs:31:5
    |
 LL |     type Assoc where Self: Sized;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add #![feature(generic_associated_types)] to the crate attributes to enable
 
-error: aborting due to 6 previous errors
+error[E0658]: where clauses on associated types are unstable (see issue #44265)
+  --> $DIR/feature-gate-generic_associated_types.rs:36:5
+   |
+LL |     type Assoc where Self: Sized = Foo;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(generic_associated_types)] to the crate attributes to enable
+
+error: aborting due to 7 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/imports/issue-53140.rs
+++ b/src/test/ui/imports/issue-53140.rs
@@ -1,0 +1,21 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-pass
+
+mod m {
+    pub struct S(u8);
+
+    use S as Z;
+}
+
+use m::*;
+
+fn main() {}

--- a/src/test/ui/lint/lints-in-foreign-macros.rs
+++ b/src/test/ui/lint/lints-in-foreign-macros.rs
@@ -11,7 +11,7 @@
 // aux-build:lints-in-foreign-macros.rs
 // compile-pass
 
-#![warn(unused_imports)]
+#![warn(unused_imports)] //~ missing documentation for crate [missing_docs]
 #![warn(missing_docs)]
 
 #[macro_use]
@@ -25,6 +25,7 @@ mod a { foo!(); }
 mod b { bar!(); }
 mod c { baz!(use std::string::ToString;); } //~ WARN: unused import
 mod d { baz2!(use std::string::ToString;); } //~ WARN: unused import
-mod e { baz!(pub fn undocumented() {}); }//~ WARN: missing documentation for a function
+baz!(pub fn undocumented() {}); //~ WARN: missing documentation for a function
+baz2!(pub fn undocumented2() {}); //~ WARN: missing documentation for a function
 
 fn main() {}

--- a/src/test/ui/lint/lints-in-foreign-macros.rs
+++ b/src/test/ui/lint/lints-in-foreign-macros.rs
@@ -12,6 +12,7 @@
 // compile-pass
 
 #![warn(unused_imports)]
+#![warn(missing_docs)] //~ WARN: missing documentation for crate [missing_docs]
 
 #[macro_use]
 extern crate lints_in_foreign_macros;

--- a/src/test/ui/lint/lints-in-foreign-macros.rs
+++ b/src/test/ui/lint/lints-in-foreign-macros.rs
@@ -12,7 +12,7 @@
 // compile-pass
 
 #![warn(unused_imports)]
-#![warn(missing_docs)] //~ WARN: missing documentation for crate [missing_docs]
+#![warn(missing_docs)]
 
 #[macro_use]
 extern crate lints_in_foreign_macros;
@@ -25,5 +25,6 @@ mod a { foo!(); }
 mod b { bar!(); }
 mod c { baz!(use std::string::ToString;); } //~ WARN: unused import
 mod d { baz2!(use std::string::ToString;); } //~ WARN: unused import
+mod e { baz!(pub fn undocumented() {}); }//~ WARN: missing documentation for a function
 
 fn main() {}

--- a/src/test/ui/lint/lints-in-foreign-macros.stderr
+++ b/src/test/ui/lint/lints-in-foreign-macros.stderr
@@ -10,7 +10,7 @@ LL | mod a { foo!(); }
 note: lint level defined here
   --> $DIR/lints-in-foreign-macros.rs:14:9
    |
-LL | #![warn(unused_imports)]
+LL | #![warn(unused_imports)] //~ missing documentation for crate [missing_docs]
    |         ^^^^^^^^^^^^^^
 
 warning: unused import: `std::string::ToString`
@@ -28,13 +28,13 @@ LL | mod d { baz2!(use std::string::ToString;); } //~ WARN: unused import
 warning: missing documentation for crate
   --> $DIR/lints-in-foreign-macros.rs:14:1
    |
-LL | / #![warn(unused_imports)]
+LL | / #![warn(unused_imports)] //~ missing documentation for crate [missing_docs]
 LL | | #![warn(missing_docs)]
 LL | |
 LL | | #[macro_use]
 ...  |
 LL | |
-LL | | fn main() {} //~ WARN: missing documentation for crate [missing_docs]
+LL | | fn main() {}
    | |____________^
    |
 note: lint level defined here
@@ -42,4 +42,16 @@ note: lint level defined here
    |
 LL | #![warn(missing_docs)]
    |         ^^^^^^^^^^^^
+
+warning: missing documentation for a function
+  --> $DIR/lints-in-foreign-macros.rs:28:6
+   |
+LL | baz!(pub fn undocumented() {}); //~ WARN: missing documentation for a function
+   |      ^^^^^^^^^^^^^^^^^^^^^
+
+warning: missing documentation for a function
+  --> $DIR/lints-in-foreign-macros.rs:29:7
+   |
+LL | baz2!(pub fn undocumented2() {}); //~ WARN: missing documentation for a function
+   |       ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/test/ui/lint/lints-in-foreign-macros.stderr
+++ b/src/test/ui/lint/lints-in-foreign-macros.stderr
@@ -29,17 +29,17 @@ warning: missing documentation for crate
   --> $DIR/lints-in-foreign-macros.rs:14:1
    |
 LL | / #![warn(unused_imports)]
-LL | | #![warn(missing_docs)] //~ WARN: missing documentation for crate [missing_docs]
+LL | | #![warn(missing_docs)]
 LL | |
 LL | | #[macro_use]
 ...  |
 LL | |
-LL | | fn main() {}
+LL | | fn main() {} //~ WARN: missing documentation for crate [missing_docs]
    | |____________^
    |
 note: lint level defined here
   --> $DIR/lints-in-foreign-macros.rs:15:9
    |
-LL | #![warn(missing_docs)] //~ WARN: missing documentation for crate [missing_docs]
+LL | #![warn(missing_docs)]
    |         ^^^^^^^^^^^^
 

--- a/src/test/ui/lint/lints-in-foreign-macros.stderr
+++ b/src/test/ui/lint/lints-in-foreign-macros.stderr
@@ -1,5 +1,5 @@
 warning: unused import: `std::string::ToString`
-  --> $DIR/lints-in-foreign-macros.rs:20:16
+  --> $DIR/lints-in-foreign-macros.rs:21:16
    |
 LL |     () => {use std::string::ToString;} //~ WARN: unused import
    |                ^^^^^^^^^^^^^^^^^^^^^
@@ -14,14 +14,32 @@ LL | #![warn(unused_imports)]
    |         ^^^^^^^^^^^^^^
 
 warning: unused import: `std::string::ToString`
-  --> $DIR/lints-in-foreign-macros.rs:25:18
+  --> $DIR/lints-in-foreign-macros.rs:26:18
    |
 LL | mod c { baz!(use std::string::ToString;); } //~ WARN: unused import
    |                  ^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused import: `std::string::ToString`
-  --> $DIR/lints-in-foreign-macros.rs:26:19
+  --> $DIR/lints-in-foreign-macros.rs:27:19
    |
 LL | mod d { baz2!(use std::string::ToString;); } //~ WARN: unused import
    |                   ^^^^^^^^^^^^^^^^^^^^^
+
+warning: missing documentation for crate
+  --> $DIR/lints-in-foreign-macros.rs:14:1
+   |
+LL | / #![warn(unused_imports)]
+LL | | #![warn(missing_docs)] //~ WARN: missing documentation for crate [missing_docs]
+LL | |
+LL | | #[macro_use]
+...  |
+LL | |
+LL | | fn main() {}
+   | |____________^
+   |
+note: lint level defined here
+  --> $DIR/lints-in-foreign-macros.rs:15:9
+   |
+LL | #![warn(missing_docs)] //~ WARN: missing documentation for crate [missing_docs]
+   |         ^^^^^^^^^^^^
 


### PR DESCRIPTION
Merged and approved:

* #53559: add macro check for lint
* #53509: resolve: Reject some inaccessible candidates sooner during import resolution
* #53239: rustc_codegen_llvm: Restore the closure env alloca hack for LLVM 5.
* #53235: Feature gate where clauses on associated type impls
* #53516: resolve: Continue search in outer scopes after applying derive resolution fallback

r? @ghost