### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -231,10 +231,9 @@
         }
 
         var elem = document.getElementById(hash);
-        if (elem && isHidden(elem.offsetParent)) {
+        if (elem && elem.offsetParent && isHidden(elem.offsetParent)) {
             var h3 = elem.parentNode.previousSibling;
-
-            if (h3.tagName !== 'H3') {
+            if (h3 && h3.tagName !== 'H3') {
                 h3 = h3.previousSibling; // skip div.docblock
             }
 

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -224,14 +224,9 @@
         }
     }
 
-    function expandSection() {
-        var hash = getPageId();
-        if (hash === null) {
-            return;
-        }
-
-        var elem = document.getElementById(hash);
-        if (elem && elem.offsetParent && isHidden(elem.offsetParent)) {
+    function expandSection(id) {
+        var elem = document.getElementById(id);
+        if (elem && isHidden(elem)) {
             var h3 = elem.parentNode.previousSibling;
             if (h3 && h3.tagName !== 'H3') {
                 h3 = h3.previousSibling; // skip div.docblock
@@ -247,13 +242,7 @@
         }
     }
 
-    function onHashChange(ev) {
-        highlightSourceLines(ev);
-        expandSection();
-    }
-
-    highlightSourceLines(null);
-    window.onhashchange = onHashChange;
+    window.onhashchange = highlightSourceLines;
 
     // Gets the human-readable string for the virtual-key code of the
     // given KeyboardEvent, ev.
@@ -346,6 +335,15 @@
         }
     }
 
+    function findParentElement(elem, tagName) {
+        do {
+            if (elem && elem.tagName === tagName) {
+                return elem;
+            }
+        } while (elem = elem.parentNode);
+        return null;
+    }
+
     document.onkeypress = handleShortcut;
     document.onkeydown = handleShortcut;
     document.onclick = function(ev) {
@@ -383,6 +381,13 @@
         } else if (!hasClass(document.getElementById("help"), "hidden")) {
             addClass(document.getElementById("help"), "hidden");
             removeClass(document.body, "blur");
+        } else {
+            // Making a collapsed element visible on onhashchange seems
+            // too late
+            var a = findParentElement(ev.target, 'A');
+            if (a && a.hash) {
+                expandSection(a.hash.replace(/^#/, ''));
+            }
         }
     };
 
@@ -2242,7 +2247,7 @@
     autoCollapse(getPageId(), getCurrentValue("rustdoc-collapse") === "true");
 
     if (window.location.hash && window.location.hash.length > 0) {
-        expandSection();
+        expandSection(window.location.hash.replace(/^#/, ''));
     }
 }());
 

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -223,8 +223,38 @@
             }
         }
     }
+
+    function expandSection() {
+        var hash = getPageId();
+        if (hash === null) {
+            return;
+        }
+
+        var elem = document.getElementById(hash);
+        if (elem && isHidden(elem.offsetParent)) {
+            var h3 = elem.parentNode.previousSibling;
+
+            if (h3.tagName !== 'H3') {
+                h3 = h3.previousSibling; // skip div.docblock
+            }
+
+            if (h3) {
+                var collapses = h3.getElementsByClassName("collapse-toggle");
+                if (collapses.length > 0) {
+                    // The element is not visible, we need to make it appear!
+                    collapseDocs(collapses[0], "show");
+                }
+            }
+        }
+    }
+
+    function onHashChange(ev) {
+        highlightSourceLines(ev);
+        expandSection();
+    }
+
     highlightSourceLines(null);
-    window.onhashchange = highlightSourceLines;
+    window.onhashchange = onHashChange;
 
     // Gets the human-readable string for the virtual-key code of the
     // given KeyboardEvent, ev.
@@ -2213,21 +2243,7 @@
     autoCollapse(getPageId(), getCurrentValue("rustdoc-collapse") === "true");
 
     if (window.location.hash && window.location.hash.length > 0) {
-        var hash = getPageId();
-        if (hash !== null) {
-            var elem = document.getElementById(hash);
-            if (elem && elem.offsetParent === null) {
-                if (elem.parentNode && elem.parentNode.previousSibling) {
-                    var collapses = elem.parentNode
-                                        .previousSibling
-                                        .getElementsByClassName("collapse-toggle");
-                    if (collapses.length > 0) {
-                        // The element is not visible, we need to make it appear!
-                        collapseDocs(collapses[0], "show");
-                    }
-                }
-            }
-        }
+        expandSection();
     }
 }());
 

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -500,6 +500,19 @@ h4 > code, h3 > code, .invisible > code {
 	font-size: 90%;
 }
 
+.content .stability {
+	position: relative;
+	margin-left: 33px;
+	margin-top: -13px;
+}
+.content .stability::before {
+	content: '˪';
+	font-size: 30px;
+	position: absolute;
+	top: -9px;
+	left: -13px;
+}
+
 nav {
 	border-bottom: 1px solid;
 	padding-bottom: 10px;

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -545,10 +545,8 @@ a {
 	left: -5px;
 }
 .small-section-header > .anchor {
-	left: -20px;
-}
-.small-section-header > .anchor:not(.field) {
 	left: -28px;
+	padding-right: 10px; /* avoid gap that causes hover to disappear */
 }
 .anchor:before {
 	content: '\2002\00a7\2002';
@@ -745,6 +743,7 @@ a.test-arrow:hover{
 .section-header:hover a:before {
 	position: absolute;
 	left: -25px;
+	padding-right: 10px; /* avoid gap that causes hover to disappear */
 	content: '\2002\00a7\2002';
 }
 

--- a/src/libstd/keyword_docs.rs
+++ b/src/libstd/keyword_docs.rs
@@ -56,3 +56,24 @@ mod fn_keyword { }
 ///
 /// [book]: https://doc.rust-lang.org/book/second-edition/ch03-01-variables-and-mutability.html
 mod let_keyword { }
+
+#[doc(keyword = "struct")]
+//
+/// The `struct` keyword.
+///
+/// The `struct` keyword is used to define a struct type.
+///
+/// Example:
+///
+/// ```
+/// struct Foo {
+///     field1: u32,
+///     field2: String,
+/// }
+/// ```
+///
+/// There are different kinds of structs. For more information, take a look at the
+/// [Rust Book][book].
+///
+/// [book]: https://doc.rust-lang.org/book/second-edition/ch05-01-defining-structs.html
+mod struct_keyword { }

--- a/src/libtest/formatters/terse.rs
+++ b/src/libtest/formatters/terse.rs
@@ -34,7 +34,7 @@ impl<T: Write> TerseFormatter<T> {
             max_name_len,
             is_multithreaded,
             test_count: 0,
-            total_test_count: 0,
+            total_test_count: 0, // initialized later, when write_run_start is called
         }
     }
 

--- a/src/libtest/formatters/terse.rs
+++ b/src/libtest/formatters/terse.rs
@@ -18,6 +18,7 @@ pub(crate) struct TerseFormatter<T> {
     max_name_len: usize,
 
     test_count: usize,
+    total_test_count: usize,
 }
 
 impl<T: Write> TerseFormatter<T> {
@@ -33,6 +34,7 @@ impl<T: Write> TerseFormatter<T> {
             max_name_len,
             is_multithreaded,
             test_count: 0,
+            total_test_count: 0,
         }
     }
 
@@ -66,7 +68,8 @@ impl<T: Write> TerseFormatter<T> {
             // we insert a new line every 100 dots in order to flush the
             // screen when dealing with line-buffered output (e.g. piping to
             // `stamp` in the rust CI).
-            self.write_plain("\n")?;
+            let out = format!(" {}/{}\n", self.test_count+1, self.total_test_count);
+            self.write_plain(&out)?;
         }
 
         self.test_count += 1;
@@ -160,6 +163,7 @@ impl<T: Write> TerseFormatter<T> {
 
 impl<T: Write> OutputFormatter for TerseFormatter<T> {
     fn write_run_start(&mut self, test_count: usize) -> io::Result<()> {
+        self.total_test_count = test_count;
         let noun = if test_count != 1 { "tests" } else { "test" };
         self.write_plain(&format!("\nrunning {} {}\n", test_count, noun))
     }


### PR DESCRIPTION
Successful merges:

 - #53043 (Improve unstable message display)
 - #53428 (libtest terse format: show how far in we are)
 - #53626 (Automatically expand a section even after page load)
 - #53651 (Add struct keyword doc)
 - #53706 (rustdoc: Fix gap on section anchor symbol when hovering.)

Failed merges:

 - #53472 (Use FxHash{Map,Set} instead of the default Hash{Map,Set} everywhere in rustc.)

r? @ghost