### PR TITLE
Reduce number of syscalls in `rand`

### DIFF
--- a/src/libstd/sys/unix/rand.rs
+++ b/src/libstd/sys/unix/rand.rs
@@ -61,6 +61,7 @@ mod imp {
                     continue;
                 } else if err == libc::ENOSYS {
                     GETRANDOM_UNAVAILABLE.store(true, Ordering::Relaxed);
+                    return false;
                 } else if err == libc::EAGAIN {
                     return false;
                 } else {


### PR DESCRIPTION
This skips the initial zero-length `getrandom` call and
directly hands the user buffer to the operating system, saving one
`getrandom` syscall.