### PR TITLE
Do not check outlives when explicit bound contains escaping regions

### DIFF
--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -753,7 +753,8 @@ impl<T> Binder<T> {
     pub fn dummy<'tcx>(value: T) -> Binder<T>
         where T: TypeFoldable<'tcx>
     {
-        debug_assert!(!value.has_escaping_regions());
+        debug_assert!(!value.has_escaping_regions(),
+            "Value has unexpected escaping regions: {:?}", value);
         Binder(value)
     }
 

--- a/src/librustc/ty/wf.rs
+++ b/src/librustc/ty/wf.rs
@@ -487,7 +487,7 @@ impl<'a, 'gcx, 'tcx> WfPredicates<'a, 'gcx, 'tcx> {
         // Note: in fact we only permit builtin traits, not `Bar<'d>`, I
         // am looking forward to the future here.
 
-        if !data.has_escaping_regions() {
+        if !data.has_escaping_regions() && !region.has_escaping_regions() {
             let implicit_bounds =
                 object_region_bounds(self.infcx.tcx, data);
 
@@ -495,6 +495,8 @@ impl<'a, 'gcx, 'tcx> WfPredicates<'a, 'gcx, 'tcx> {
 
             for implicit_bound in implicit_bounds {
                 let cause = self.cause(traits::ObjectTypeBound(ty, explicit_bound));
+                debug!("Testing implicit bound {:?} with explicit bound {:?}, cause {:?}",
+                    implicit_bound, explicit_bound, cause);
                 let outlives = ty::Binder::dummy(
                     ty::OutlivesPredicate(explicit_bound, implicit_bound));
                 self.out.push(traits::Obligation::new(cause,

--- a/src/test/run-pass/issue-53548.rs
+++ b/src/test/run-pass/issue-53548.rs
@@ -1,0 +1,40 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Regression test for #53548: having a 'static bound on a trait
+// made it impossible to keep a trait object to it across an
+// await point inside a closure
+
+#![feature(arbitrary_self_types, async_await, await_macro, futures_api, pin)]
+
+use std::future::Future;
+use std::mem::PinMut;
+use std::task::{Poll, Context};
+
+// A trait with 'static bound
+trait Trait: 'static {}
+
+// Anything we can give to await!()
+struct DummyFut();
+impl Future for DummyFut {
+    type Output = ();
+    fn poll(self: PinMut<Self>, _ctx: &mut Context) -> Poll<()> {
+        Poll::Pending
+    }
+}
+
+// The actual reproducer, requires that Trait is 'static and a trait
+// object to it is captured in a closure for successful reproduction.
+async fn foo(b: Box<Trait + 'static>) -> () {
+    let _bar = move || { b; () };
+    await!(DummyFut())
+}
+
+pub fn main() {}


### PR DESCRIPTION
This makes the code similar to the handling of `ty::Ref` in
`src/librustc/ty/wf.rs`, except checking for non-escaping-regions
somewhere down the call chain instead of at the root.

Fixes #53548

Note: I have literally 0 confidence that this fix is actually correct, as I don't really understand all the surrounding code. However, it appears to break no test, and to pass the added test, equivalent to the one in #53548. Maybe the root cause of the issue is somewhere else, though.

Hope this helps! :)