### PR TITLE
Rustdoc fixes

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -242,6 +242,7 @@
         }
     }
 
+    highlightSourceLines(null);
     window.onhashchange = highlightSourceLines;
 
     // Gets the human-readable string for the virtual-key code of the

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -502,12 +502,17 @@ h4 > code, h3 > code, .invisible > code {
 	margin-left: 33px;
 	margin-top: -13px;
 }
+
 .content .stability::before {
 	content: '˪';
 	font-size: 30px;
 	position: absolute;
 	top: -9px;
 	left: -13px;
+}
+
+#main > .stability {
+	margin-top: 0;
 }
 
 nav {


### PR DESCRIPTION
Fixes #53817.

Fixes rustdoc not scrolling to given lines and invalid unstable display:

<img width="1440" alt="screen shot 2018-08-27 at 23 28 47" src="https://user-images.githubusercontent.com/3050060/44687252-06535e80-aa51-11e8-8512-d7d34d1cb963.png">

r? @QuietMisdreavus 