### PR TITLE
Backwards compatibility for tool/clippy lints

### DIFF
--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -417,7 +417,7 @@ impl LintStore {
                             new_name.to_string(),
                         )));
                     }
-                    CheckLintNameResult::Tool(Ok(&ids.0))
+                    CheckLintNameResult::Tool(Err((Some(&ids.0), complete_name)))
                 }
             },
             Some(&Id(ref id)) => {

--- a/src/librustc/lint/levels.rs
+++ b/src/librustc/lint/levels.rs
@@ -280,25 +280,27 @@ impl<'a> LintLevelsBuilder<'a> {
                                 let (lvl, src) =
                                     self.sets
                                         .get_lint_level(lint, self.cur, Some(&specs), &sess);
+                                let msg = format!(
+                                    "lint name `{}` is deprecated \
+                                     and may not have an effect in the future \
+                                     Also `cfg_attr(cargo-clippy)` won't be necessary anymore",
+                                    name
+                                );
                                 let mut err = lint::struct_lint_level(
                                     self.sess,
                                     lint,
                                     lvl,
                                     src,
                                     Some(li.span.into()),
-                                    &format!(
-                                        "lint name `{}` is deprecated \
-                                         and may not have an effect in the future",
-                                        name
-                                    ),
+                                    &msg,
                                 );
                                 err.span_suggestion_with_applicability(
                                     li.span,
                                     "change it to",
                                     new_lint_name.to_string(),
                                     Applicability::MachineApplicable,
-                                );
-                                err.emit();
+                                ).emit();
+
                                 let src = LintSource::Node(Symbol::intern(&new_lint_name), li.span);
                                 for id in ids {
                                     specs.insert(*id, (level, src));

--- a/src/librustc/lint/levels.rs
+++ b/src/librustc/lint/levels.rs
@@ -282,7 +282,7 @@ impl<'a> LintLevelsBuilder<'a> {
                                         .get_lint_level(lint, self.cur, Some(&specs), &sess);
                                 let msg = format!(
                                     "lint name `{}` is deprecated \
-                                     and may not have an effect in the future \
+                                     and may not have an effect in the future. \
                                      Also `cfg_attr(cargo-clippy)` won't be necessary anymore",
                                     name
                                 );

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -924,8 +924,8 @@ where
             ls.register_late_pass(Some(sess), true, pass);
         }
 
-        for (name, to) in lint_groups {
-            ls.register_group(Some(sess), true, name, to);
+        for (name, (to, deprecated_name)) in lint_groups {
+            ls.register_group(Some(sess), true, name, deprecated_name, to);
         }
 
         *sess.plugin_llvm_passes.borrow_mut() = llvm_passes;

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -105,7 +105,7 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
 
     macro_rules! add_lint_group {
         ($sess:ident, $name:expr, $($lint:ident),*) => (
-            store.register_group($sess, false, $name, vec![$(LintId::of($lint)),*]);
+            store.register_group($sess, false, $name, None, vec![$(LintId::of($lint)),*]);
             )
     }
 

--- a/src/librustc_plugin/registry.rs
+++ b/src/librustc_plugin/registry.rs
@@ -53,7 +53,7 @@ pub struct Registry<'a> {
     pub late_lint_passes: Vec<LateLintPassObject>,
 
     #[doc(hidden)]
-    pub lint_groups: FxHashMap<&'static str, Vec<LintId>>,
+    pub lint_groups: FxHashMap<&'static str, (Vec<LintId>, Option<&'static str>)>,
 
     #[doc(hidden)]
     pub llvm_passes: Vec<String>,
@@ -170,8 +170,15 @@ impl<'a> Registry<'a> {
         self.late_lint_passes.push(lint_pass);
     }
     /// Register a lint group.
-    pub fn register_lint_group(&mut self, name: &'static str, to: Vec<&'static Lint>) {
-        self.lint_groups.insert(name, to.into_iter().map(|x| LintId::of(x)).collect());
+    pub fn register_lint_group(
+        &mut self,
+        name: &'static str,
+        deprecated_name: Option<&'static str>,
+        to: Vec<&'static Lint>
+    ) {
+        self.lint_groups.insert(name,
+                                (to.into_iter().map(|x| LintId::of(x)).collect(),
+                                 deprecated_name));
     }
 
     /// Register an LLVM pass.

--- a/src/test/compile-fail-fulldeps/auxiliary/lint_group_plugin_test.rs
+++ b/src/test/compile-fail-fulldeps/auxiliary/lint_group_plugin_test.rs
@@ -49,5 +49,5 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
 #[plugin_registrar]
 pub fn plugin_registrar(reg: &mut Registry) {
     reg.register_late_lint_pass(box Pass);
-    reg.register_lint_group("lint_me", vec![TEST_LINT, PLEASE_LINT]);
+    reg.register_lint_group("lint_me", None, vec![TEST_LINT, PLEASE_LINT]);
 }

--- a/src/test/ui-fulldeps/auxiliary/lint_group_plugin_test.rs
+++ b/src/test/ui-fulldeps/auxiliary/lint_group_plugin_test.rs
@@ -49,5 +49,5 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
 #[plugin_registrar]
 pub fn plugin_registrar(reg: &mut Registry) {
     reg.register_late_lint_pass(box Pass);
-    reg.register_lint_group("lint_me", vec![TEST_LINT, PLEASE_LINT]);
+    reg.register_lint_group("lint_me", None, vec![TEST_LINT, PLEASE_LINT]);
 }

--- a/src/test/ui-fulldeps/auxiliary/lint_tool_test.rs
+++ b/src/test/ui-fulldeps/auxiliary/lint_tool_test.rs
@@ -25,12 +25,13 @@ use rustc::lint::{EarlyContext, LintContext, LintPass, EarlyLintPass,
 use rustc_plugin::Registry;
 use syntax::ast;
 declare_tool_lint!(pub clippy::TEST_LINT, Warn, "Warn about stuff");
+declare_tool_lint!(pub clippy::TEST_GROUP, Warn, "Warn about other stuff");
 
 struct Pass;
 
 impl LintPass for Pass {
     fn get_lints(&self) -> LintArray {
-        lint_array!(TEST_LINT)
+        lint_array!(TEST_LINT, TEST_GROUP)
     }
 }
 
@@ -39,10 +40,14 @@ impl EarlyLintPass for Pass {
         if it.ident.name == "lintme" {
             cx.span_lint(TEST_LINT, it.span, "item is named 'lintme'");
         }
+        if it.ident.name == "lintmetoo" {
+            cx.span_lint(TEST_GROUP, it.span, "item is named 'lintmetoo'");
+        }
     }
 }
 
 #[plugin_registrar]
 pub fn plugin_registrar(reg: &mut Registry) {
     reg.register_early_lint_pass(box Pass);
+    reg.register_lint_group("clippy::group", Some("clippy_group"), vec![TEST_LINT, TEST_GROUP]);
 }

--- a/src/test/ui-fulldeps/lint_tool_test.rs
+++ b/src/test/ui-fulldeps/lint_tool_test.rs
@@ -8,17 +8,29 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// run-pass
 // aux-build:lint_tool_test.rs
 // ignore-stage1
 #![feature(plugin)]
 #![feature(tool_lints)]
 #![plugin(lint_tool_test)]
 #![allow(dead_code)]
+#![deny(clippy_group)]
+//~^ WARNING lint name `clippy_group` is deprecated and may not have an effect in the future
 
-fn lintme() { } //~ WARNING item is named 'lintme'
+fn lintme() { } //~ ERROR item is named 'lintme'
+
+#[allow(clippy::group)]
+fn lintmetoo() {}
 
 #[allow(clippy::test_lint)]
 pub fn main() {
     fn lintme() { }
+    fn lintmetoo() { } //~ ERROR item is named 'lintmetoo'
+}
+
+#[allow(test_group)]
+//~^ WARNING lint name `test_group` is deprecated and may not have an effect in the future
+#[deny(this_lint_does_not_exist)] //~ WARNING unknown lint: `this_lint_does_not_exist`
+fn hello() {
+    fn lintmetoo() { }
 }

--- a/src/test/ui-fulldeps/lint_tool_test.rs
+++ b/src/test/ui-fulldeps/lint_tool_test.rs
@@ -10,13 +10,16 @@
 
 // aux-build:lint_tool_test.rs
 // ignore-stage1
+// compile-flags: --cfg foo
 #![feature(plugin)]
 #![feature(tool_lints)]
 #![plugin(lint_tool_test)]
 #![allow(dead_code)]
+#![cfg_attr(foo, warn(test_lint))]
+//~^ WARNING lint name `test_lint` is deprecated and may not have an effect in the future
+//~^^ WARNING lint name `test_lint` is deprecated and may not have an effect in the future
 #![deny(clippy_group)]
 //~^ WARNING lint name `clippy_group` is deprecated and may not have an effect in the future
-//~^^ WARNING lint name `clippy_group` is deprecated and may not have an effect in the future
 
 fn lintme() { } //~ ERROR item is named 'lintme'
 

--- a/src/test/ui-fulldeps/lint_tool_test.rs
+++ b/src/test/ui-fulldeps/lint_tool_test.rs
@@ -16,6 +16,7 @@
 #![allow(dead_code)]
 #![deny(clippy_group)]
 //~^ WARNING lint name `clippy_group` is deprecated and may not have an effect in the future
+//~^^ WARNING lint name `clippy_group` is deprecated and may not have an effect in the future
 
 fn lintme() { } //~ ERROR item is named 'lintme'
 

--- a/src/test/ui-fulldeps/lint_tool_test.stderr
+++ b/src/test/ui-fulldeps/lint_tool_test.stderr
@@ -1,52 +1,58 @@
-warning: lint name `clippy_group` is deprecated and may not have an effect in the future Also `cfg_attr(cargo-clippy)` won't be necessary anymore
-  --> $DIR/lint_tool_test.rs:17:9
+warning: lint name `test_lint` is deprecated and may not have an effect in the future. Also `cfg_attr(cargo-clippy)` won't be necessary anymore
+  --> $DIR/lint_tool_test.rs:18:23
    |
-LL | #![deny(clippy_group)]
-   |         ^^^^^^^^^^^^ help: change it to: `clippy::group`
+LL | #![cfg_attr(foo, warn(test_lint))]
+   |                       ^^^^^^^^^ help: change it to: `clippy::test_lint`
    |
    = note: #[warn(renamed_and_removed_lints)] on by default
 
-warning: lint name `test_group` is deprecated and may not have an effect in the future Also `cfg_attr(cargo-clippy)` won't be necessary anymore
-  --> $DIR/lint_tool_test.rs:32:9
+warning: lint name `clippy_group` is deprecated and may not have an effect in the future. Also `cfg_attr(cargo-clippy)` won't be necessary anymore
+  --> $DIR/lint_tool_test.rs:21:9
+   |
+LL | #![deny(clippy_group)]
+   |         ^^^^^^^^^^^^ help: change it to: `clippy::group`
+
+warning: lint name `test_group` is deprecated and may not have an effect in the future. Also `cfg_attr(cargo-clippy)` won't be necessary anymore
+  --> $DIR/lint_tool_test.rs:35:9
    |
 LL | #[allow(test_group)]
    |         ^^^^^^^^^^ help: change it to: `clippy::test_group`
 
 warning: unknown lint: `this_lint_does_not_exist`
-  --> $DIR/lint_tool_test.rs:34:8
+  --> $DIR/lint_tool_test.rs:37:8
    |
 LL | #[deny(this_lint_does_not_exist)] //~ WARNING unknown lint: `this_lint_does_not_exist`
    |        ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: #[warn(unknown_lints)] on by default
 
-warning: lint name `clippy_group` is deprecated and may not have an effect in the future Also `cfg_attr(cargo-clippy)` won't be necessary anymore
-  --> $DIR/lint_tool_test.rs:17:9
+warning: lint name `test_lint` is deprecated and may not have an effect in the future. Also `cfg_attr(cargo-clippy)` won't be necessary anymore
+  --> $DIR/lint_tool_test.rs:18:23
    |
-LL | #![deny(clippy_group)]
-   |         ^^^^^^^^^^^^ help: change it to: `clippy::group`
+LL | #![cfg_attr(foo, warn(test_lint))]
+   |                       ^^^^^^^^^ help: change it to: `clippy::test_lint`
 
 error: item is named 'lintme'
-  --> $DIR/lint_tool_test.rs:21:1
+  --> $DIR/lint_tool_test.rs:24:1
    |
 LL | fn lintme() { } //~ ERROR item is named 'lintme'
    | ^^^^^^^^^^^^^^^
    |
 note: lint level defined here
-  --> $DIR/lint_tool_test.rs:17:9
+  --> $DIR/lint_tool_test.rs:21:9
    |
 LL | #![deny(clippy_group)]
    |         ^^^^^^^^^^^^
    = note: #[deny(clippy::test_lint)] implied by #[deny(clippy::group)]
 
 error: item is named 'lintmetoo'
-  --> $DIR/lint_tool_test.rs:29:5
+  --> $DIR/lint_tool_test.rs:32:5
    |
 LL |     fn lintmetoo() { } //~ ERROR item is named 'lintmetoo'
    |     ^^^^^^^^^^^^^^^^^^
    |
 note: lint level defined here
-  --> $DIR/lint_tool_test.rs:17:9
+  --> $DIR/lint_tool_test.rs:21:9
    |
 LL | #![deny(clippy_group)]
    |         ^^^^^^^^^^^^

--- a/src/test/ui-fulldeps/lint_tool_test.stderr
+++ b/src/test/ui-fulldeps/lint_tool_test.stderr
@@ -1,8 +1,56 @@
-warning: item is named 'lintme'
-  --> $DIR/lint_tool_test.rs:19:1
+warning: lint name `clippy_group` is deprecated and may not have an effect in the future
+  --> $DIR/lint_tool_test.rs:17:9
    |
-LL | fn lintme() { } //~ WARNING item is named 'lintme'
+LL | #![deny(clippy_group)]
+   |         ^^^^^^^^^^^^ help: change it to: `clippy::group`
+   |
+   = note: #[warn(renamed_and_removed_lints)] on by default
+
+warning: lint name `test_group` is deprecated and may not have an effect in the future
+  --> $DIR/lint_tool_test.rs:31:9
+   |
+LL | #[allow(test_group)]
+   |         ^^^^^^^^^^ help: change it to: `clippy::test_group`
+
+warning: unknown lint: `this_lint_does_not_exist`
+  --> $DIR/lint_tool_test.rs:33:8
+   |
+LL | #[deny(this_lint_does_not_exist)] //~ WARNING unknown lint: `this_lint_does_not_exist`
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: #[warn(unknown_lints)] on by default
+
+warning: lint name `clippy_group` is deprecated and may not have an effect in the future
+  --> $DIR/lint_tool_test.rs:17:9
+   |
+LL | #![deny(clippy_group)]
+   |         ^^^^^^^^^^^^ help: change it to: `clippy::group`
+
+error: item is named 'lintme'
+  --> $DIR/lint_tool_test.rs:20:1
+   |
+LL | fn lintme() { } //~ ERROR item is named 'lintme'
    | ^^^^^^^^^^^^^^^
    |
-   = note: #[warn(clippy::test_lint)] on by default
+note: lint level defined here
+  --> $DIR/lint_tool_test.rs:17:9
+   |
+LL | #![deny(clippy_group)]
+   |         ^^^^^^^^^^^^
+   = note: #[deny(clippy::test_lint)] implied by #[deny(clippy::group)]
+
+error: item is named 'lintmetoo'
+  --> $DIR/lint_tool_test.rs:28:5
+   |
+LL |     fn lintmetoo() { } //~ ERROR item is named 'lintmetoo'
+   |     ^^^^^^^^^^^^^^^^^^
+   |
+note: lint level defined here
+  --> $DIR/lint_tool_test.rs:17:9
+   |
+LL | #![deny(clippy_group)]
+   |         ^^^^^^^^^^^^
+   = note: #[deny(clippy::test_group)] implied by #[deny(clippy::group)]
+
+error: aborting due to 2 previous errors
 

--- a/src/test/ui-fulldeps/lint_tool_test.stderr
+++ b/src/test/ui-fulldeps/lint_tool_test.stderr
@@ -1,4 +1,4 @@
-warning: lint name `clippy_group` is deprecated and may not have an effect in the future
+warning: lint name `clippy_group` is deprecated and may not have an effect in the future Also `cfg_attr(cargo-clippy)` won't be necessary anymore
   --> $DIR/lint_tool_test.rs:17:9
    |
 LL | #![deny(clippy_group)]
@@ -6,28 +6,28 @@ LL | #![deny(clippy_group)]
    |
    = note: #[warn(renamed_and_removed_lints)] on by default
 
-warning: lint name `test_group` is deprecated and may not have an effect in the future
-  --> $DIR/lint_tool_test.rs:31:9
+warning: lint name `test_group` is deprecated and may not have an effect in the future Also `cfg_attr(cargo-clippy)` won't be necessary anymore
+  --> $DIR/lint_tool_test.rs:32:9
    |
 LL | #[allow(test_group)]
    |         ^^^^^^^^^^ help: change it to: `clippy::test_group`
 
 warning: unknown lint: `this_lint_does_not_exist`
-  --> $DIR/lint_tool_test.rs:33:8
+  --> $DIR/lint_tool_test.rs:34:8
    |
 LL | #[deny(this_lint_does_not_exist)] //~ WARNING unknown lint: `this_lint_does_not_exist`
    |        ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: #[warn(unknown_lints)] on by default
 
-warning: lint name `clippy_group` is deprecated and may not have an effect in the future
+warning: lint name `clippy_group` is deprecated and may not have an effect in the future Also `cfg_attr(cargo-clippy)` won't be necessary anymore
   --> $DIR/lint_tool_test.rs:17:9
    |
 LL | #![deny(clippy_group)]
    |         ^^^^^^^^^^^^ help: change it to: `clippy::group`
 
 error: item is named 'lintme'
-  --> $DIR/lint_tool_test.rs:20:1
+  --> $DIR/lint_tool_test.rs:21:1
    |
 LL | fn lintme() { } //~ ERROR item is named 'lintme'
    | ^^^^^^^^^^^^^^^
@@ -40,7 +40,7 @@ LL | #![deny(clippy_group)]
    = note: #[deny(clippy::test_lint)] implied by #[deny(clippy::group)]
 
 error: item is named 'lintmetoo'
-  --> $DIR/lint_tool_test.rs:28:5
+  --> $DIR/lint_tool_test.rs:29:5
    |
 LL |     fn lintmetoo() { } //~ ERROR item is named 'lintmetoo'
    |     ^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
cc #44690 
cc https://github.com/rust-lang-nursery/rust-clippy/pull/2977#issuecomment-409706557

This is the next step towards `tool_lints`.

This makes Clippy lints still work without scoping, but will warn and suggest the new scoped name. This warning will only appear if the code is checked with Clippy itself.

There is still an issue with using the old lint name in inner attributes. For inner attributes the warning gets emitted twice. I'm currently not really sure why this happens, but will try to fix this ASAP.

r? @Manishearth 