### PR TITLE
Add rust-gdbgui script.

### DIFF
--- a/src/etc/rust-gdbgui
+++ b/src/etc/rust-gdbgui
@@ -20,8 +20,8 @@ gdbgui - https://gdbgui.com - is a graphical front-end to GDB
 that runs in a browser. This script invokes gdbgui with the Rust
 pretty printers loaded.
 
-Simple usage  : rust-gdbgui target\debug\myprog
-With arguments: rust-gdbgui 'target\debug\myprog arg1 arg2...'
+Simple usage  : rust-gdbgui target/debug/myprog
+With arguments: rust-gdbgui 'target/debug/myprog arg1 arg2...'
   (note the quotes)
 
 
@@ -32,7 +32,7 @@ in its options make sure to disable the 'Add breakpoint to main after
 loading executable' setting to avoid a 'File not found: main' warning
 on startup.
 
-Instead, type 'main' into the file browser and you should get
+Instead, type 'main' into gdbgui's file browser and you should get
 auto-completion on the filename. Just pick 'main.rs', add a breakpoint
 by clicking in the line number gutter, and type 'r' or hit the Restart
 icon to start your program running.

--- a/src/etc/rust-gdbgui
+++ b/src/etc/rust-gdbgui
@@ -1,0 +1,65 @@
+#!/bin/sh
+# Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution and at
+# http://rust-lang.org/COPYRIGHT.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+# Exit if anything fails
+set -e
+
+if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ] || [ "$1" = "--help" ]; then
+    echo "
+rust-gdbgui
+===========
+gdbgui - https://gdbgui.com - is a graphical front-end to GDB
+that runs in a browser. This script invokes gdbgui with the Rust
+pretty printers loaded.
+
+Simple usage  : rust-gdbgui target\debug\myprog
+With arguments: rust-gdbgui 'target\debug\myprog arg1 arg2...'
+  (note the quotes)
+
+
+Hints
+=====
+gdbgui won't be able to find the rust 'main' method automatically, so
+in its options make sure to disable the 'Add breakpoint to main after
+loading executable' setting to avoid a 'File not found: main' warning
+on startup.
+
+Instead, type 'main' into the file browser and you should get
+auto-completion on the filename. Just pick 'main.rs', add a breakpoint
+by clicking in the line number gutter, and type 'r' or hit the Restart
+icon to start your program running.
+"
+    exit 0
+fi
+
+# Find out where the pretty printer Python module is
+RUSTC_SYSROOT=`rustc --print=sysroot`
+GDB_PYTHON_MODULE_DIRECTORY="$RUSTC_SYSROOT/lib/rustlib/etc"
+
+# Set the environment variable `RUST_GDB` to overwrite the call to a
+# different/specific command (defaults to `gdb`).
+RUST_GDB="${RUST_GDB:-gdb}"
+
+# Set the environment variable `RUST_GDBGUI` to overwrite the call to a
+# different/specific command (defaults to `gdbgui`).
+RUST_GDBGUI="${RUST_GDBGUI:-gdbgui}"
+
+# These arguments get passed through to GDB and make it load the
+# Rust pretty printers.
+GDB_ARGS="--directory=\"$GDB_PYTHON_MODULE_DIRECTORY\" -iex \"add-auto-load-safe-path $GDB_PYTHON_MODULE_DIRECTORY\""
+
+# Finally we execute gdbgui.
+PYTHONPATH="$PYTHONPATH:$GDB_PYTHON_MODULE_DIRECTORY" \
+  exec ${RUST_GDBGUI} \
+  --gdb ${RUST_GDB} \
+  --gdb-args "${GDB_ARGS}" \
+  "${@}"
+


### PR DESCRIPTION
This script invokes the [gdbgui](https://gdbgui.com/) graphical GDB front-end with the Rust pretty printers loaded. The script does not install gdbgui, that must be done manually.

As an escapee from Visual Studio it is nice to have a point-and-click debugger. This script invokes `gdbgui` similarly to the way that `rust-gdb` invokes `gdb` - I copied that script as a starting point.

Because it is a wrapper around a wrapper you don't have as much flexibility in passing arguments to GDB and I could not find a way to eliminate the single quotes you have to use when you want to pass arguments to your program (`gdbgui` supposedly supports an `--args` option which I think should allow this, but I couldn't get it to work, my shell-fu is weak). Still, I find this very usable for debugging programs, and it is a lot more approachable than gdb in the terminal.