### PR TITLE
Implemented map_or_else for Result<T, E>

### DIFF
--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -470,7 +470,7 @@ impl<T, E> Result<T, E> {
         }
     }
 
-    /// Maps a `Result<T, E>` to `T` by applying a function to a
+    /// Maps a `Result<T, E>` to `U` by applying a function to a
     /// contained [`Ok`] value, or a fallback function to a
     /// contained [`Err`] value.
     ///

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -470,6 +470,35 @@ impl<T, E> Result<T, E> {
         }
     }
 
+    /// Maps a `Result<T, E>` to `T` by applying a function to a
+    /// contained [`Ok`] value, or a fallback function to a
+    /// contained [`Err`] value.
+    ///
+    /// This function can be used to unpack a successful result
+    /// while handling an error.
+    ///
+    /// [`Ok`]: enum.Result.html#variant.Ok
+    /// [`Err`]: enum.Result.html#variant.Err
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// let k = 21;
+    ///
+    /// let x = Ok("foo");
+    /// assert_eq!(x.map_or_else(|e| k * 2, |v| v.len()), 3);
+    ///
+    /// let x = Err("bar");
+    /// assert_eq!(x.map_or_else(|e| k * 2, |v| v.len()), 42);
+    /// ```
+    #[inline]
+    #[stable(feature = "rust1", since = "1.30.0")]
+    pub fn map_or_else<U, M: FnOnce(T) -> U, F: FnOnce(E) -> U>(self, fallback: F, map: M) -> U {
+        self.map(map).unwrap_or_else(fallback)
+    }
+
     /// Maps a `Result<T, E>` to `Result<T, F>` by applying a function to a
     /// contained [`Err`] value, leaving an [`Ok`] value untouched.
     ///

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -494,7 +494,7 @@ impl<T, E> Result<T, E> {
     /// assert_eq!(x.map_or_else(|e| k * 2, |v| v.len()), 42);
     /// ```
     #[inline]
-    #[stable(feature = "rust1", since = "1.30.0")]
+    #[stable(feature = "result_map_or_else", since = "1.30.0")]
     pub fn map_or_else<U, M: FnOnce(T) -> U, F: FnOnce(E) -> U>(self, fallback: F, map: M) -> U {
         self.map(map).unwrap_or_else(fallback)
     }

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -487,10 +487,10 @@ impl<T, E> Result<T, E> {
     /// ```
     /// let k = 21;
     ///
-    /// let x = Ok("foo");
+    /// let x : Result<_, &str> = Ok("foo");
     /// assert_eq!(x.map_or_else(|e| k * 2, |v| v.len()), 3);
     ///
-    /// let x = Err("bar");
+    /// let x : Result<&str, _> = Err("bar");
     /// assert_eq!(x.map_or_else(|e| k * 2, |v| v.len()), 42);
     /// ```
     #[inline]

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -485,6 +485,7 @@ impl<T, E> Result<T, E> {
     /// Basic usage:
     ///
     /// ```
+    /// #![feature(result_map_or_else)]
     /// let k = 21;
     ///
     /// let x : Result<_, &str> = Ok("foo");

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -494,7 +494,7 @@ impl<T, E> Result<T, E> {
     /// assert_eq!(x.map_or_else(|e| k * 2, |v| v.len()), 42);
     /// ```
     #[inline]
-    #[stable(feature = "result_map_or_else", since = "1.30.0")]
+    #[unstable(feature = "result_map_or_else", issue = "53268")]
     pub fn map_or_else<U, M: FnOnce(T) -> U, F: FnOnce(E) -> U>(self, fallback: F, map: M) -> U {
         self.map(map).unwrap_or_else(fallback)
     }


### PR DESCRIPTION
Fulfills #53268
The example is ripped from `Option::map_or_else`, with the types corrected.