### PR TITLE
bench: libcore: fix build failure of any.rs benchmark (use "dyn Any")

### DIFF
--- a/src/libcore/benches/any.rs
+++ b/src/libcore/benches/any.rs
@@ -15,7 +15,7 @@ use test::{Bencher, black_box};
 fn bench_downcast_ref(b: &mut Bencher) {
     b.iter(|| {
         let mut x = 0;
-        let mut y = &mut x as &mut Any;
+        let mut y = &mut x as &mut dyn Any;
         black_box(&mut y);
         black_box(y.downcast_ref::<isize>() == Some(&0));
     });


### PR DESCRIPTION
fixes
````
error: trait objects without an explicit `dyn` are deprecated
  --> libcore/../libcore/benches/any.rs:18:36
   |
18 |         let mut y = &mut x as &mut Any;
   |                                    ^^^ help: use `dyn`: `dyn Any`
   |
   = note: requested on the command line with `-D bare-trait-objects`
````