### PR TITLE
Rewrite docs for pointer methods

### DIFF
--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -976,19 +976,15 @@ extern "rust-intrinsic" {
     ///
     /// Behavior is undefined if any of the following conditions are violated:
     ///
+    /// * `src` must be [valid] for reads of `count * size_of::<T>()` bytes.
+    ///
+    /// * `dst` must be [valid] for writes of `count * size_of::<T>()` bytes.
+    ///
     /// * Both `src` and `dst` must be properly aligned.
     ///
-    /// * `src.offset(i)` must be [valid] for all `i` in `0..count`. In other
-    ///   words, the region of memory which begins at `src` and has a length of
-    ///   `count * size_of::<T>()` bytes must belong to a single, live
-    ///   allocation.
-    ///
-    /// * `dst.offset(i)` must be [valid] for all `i` in `0..count`. In other
-    ///   words, the region of memory which begins at `dst` and has a length of
-    ///   `count * size_of::<T>()` bytes must belong to a single, live
-    ///   allocation.
-    ///
-    /// * The two regions of memory must *not* overlap.
+    /// * The region of memory beginning at `src` with a size of `count *
+    ///   size_of::<T>()` bytes must *not* overlap with the region of memory
+    ///   beginning at `dst` with the same size.
     ///
     /// Like [`read`], `copy` creates a bitwise copy of `T`, regardless of
     /// whether `T` is [`Copy`].  If `T` is not [`Copy`], using both the values
@@ -1064,17 +1060,11 @@ extern "rust-intrinsic" {
     ///
     /// Behavior is undefined if any of the following conditions are violated:
     ///
+    /// * `src` must be [valid] for reads of `count * size_of::<T>()` bytes.
+    ///
+    /// * `dst` must be [valid] for writes of `count * size_of::<T>()` bytes.
+    ///
     /// * Both `src` and `dst` must be properly aligned.
-    ///
-    /// * `src.offset(i)` must be [valid] for all `i` in `0..count`. In other
-    ///   words, the region of memory which begins at `src` and has a length of
-    ///   `count * size_of::<T>()` bytes must belong to a single, live
-    ///   allocation.
-    ///
-    /// * `dst.offset(i)` must be [valid] for all `i` in `0..count`. In other
-    ///   words, the region of memory which begins at `dst` and has a length of
-    ///   `count * size_of::<T>()` bytes must belong to a single, live
-    ///   allocation.
     ///
     /// Like [`read`], `copy` creates a bitwise copy of `T`, regardless of
     /// whether `T` is [`Copy`].  If `T` is not [`Copy`], using both the values
@@ -1116,12 +1106,9 @@ extern "rust-intrinsic" {
     ///
     /// Behavior is undefined if any of the following conditions are violated:
     ///
-    /// * `dst` must be properly aligned.
+    /// * `dst` must be [valid] for writes of `count * size_of::<T>()` bytes.
     ///
-    /// * `dst.offset(i)` must be [valid] for all `i` in `0..count`. In other
-    ///   words, the region of memory which begins at `dst` and has a length of
-    ///   `count * size_of::<T>()` bytes must belong to a single, live
-    ///   allocation.
+    /// * `dst` must be properly aligned.
     ///
     /// Additionally, the caller must ensure that writing `count *
     /// size_of::<T>()` bytes to the given region of memory results in a valid

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -980,11 +980,11 @@ extern "rust-intrinsic" {
     ///
     /// * Both `src` and `dst` must be properly aligned.
     ///
-    /// * `src.offset(count)` must be [valid]. In other words, the region of
+    /// * `src.offset(count-1)` must be [valid]. In other words, the region of
     ///   memory which begins at `src` and has a length of `count *
     ///   size_of::<T>()` bytes must belong to a single, live allocation.
     ///
-    /// * `dst.offset(count)` must be [valid]. In other words, the region of
+    /// * `dst.offset(count-1)` must be [valid]. In other words, the region of
     ///   memory which begins at `dst` and has a length of `count *
     ///   size_of::<T>()` bytes must belong to a single, live allocation.
     ///
@@ -1068,11 +1068,11 @@ extern "rust-intrinsic" {
     ///
     /// * Both `src` and `dst` must be properly aligned.
     ///
-    /// * `src.offset(count)` must be [valid]. In other words, the region of
+    /// * `src.offset(count-1)` must be [valid]. In other words, the region of
     ///   memory which begins at `src` and has a length of `count *
     ///   size_of::<T>()` bytes must belong to a single, live allocation.
     ///
-    /// * `dst.offset(count)` must be [valid]. In other words, the region of
+    /// * `dst.offset(count-1)` must be [valid]. In other words, the region of
     ///   memory which begins at `dst` and has a length of `count *
     ///   size_of::<T>()` bytes must belong to a single, live allocation.
     ///
@@ -1118,7 +1118,7 @@ extern "rust-intrinsic" {
     ///
     /// * `dst` must be [valid].
     ///
-    /// * `dst.offset(count)` must be [valid]. In other words, the region of
+    /// * `dst.offset(count-1)` must be [valid]. In other words, the region of
     ///   memory which begins at `dst` and has a length of `count *
     ///   size_of::<T>()` bytes must belong to a single, live allocation.
     ///

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -1149,7 +1149,7 @@ extern "rust-intrinsic" {
     /// Creating an invalid value:
     ///
     /// ```no_run
-    /// use std::{mem, ptr};
+    /// use std::ptr;
     ///
     /// let mut v = Box::new(0i32);
     ///

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -976,17 +976,17 @@ extern "rust-intrinsic" {
     ///
     /// Behavior is undefined if any of the following conditions are violated:
     ///
-    /// * Both `src` and `dst` must be [valid].
-    ///
     /// * Both `src` and `dst` must be properly aligned.
     ///
-    /// * `src.offset(count-1)` must be [valid]. In other words, the region of
-    ///   memory which begins at `src` and has a length of `count *
-    ///   size_of::<T>()` bytes must belong to a single, live allocation.
+    /// * `src.offset(i)` must be [valid] for all `i` in `0..count`. In other
+    ///   words, the region of memory which begins at `src` and has a length of
+    ///   `count * size_of::<T>()` bytes must belong to a single, live
+    ///   allocation.
     ///
-    /// * `dst.offset(count-1)` must be [valid]. In other words, the region of
-    ///   memory which begins at `dst` and has a length of `count *
-    ///   size_of::<T>()` bytes must belong to a single, live allocation.
+    /// * `dst.offset(i)` must be [valid] for all `i` in `0..count`. In other
+    ///   words, the region of memory which begins at `dst` and has a length of
+    ///   `count * size_of::<T>()` bytes must belong to a single, live
+    ///   allocation.
     ///
     /// * The two regions of memory must *not* overlap.
     ///
@@ -1064,17 +1064,17 @@ extern "rust-intrinsic" {
     ///
     /// Behavior is undefined if any of the following conditions are violated:
     ///
-    /// * Both `src` and `dst` must be [valid].
-    ///
     /// * Both `src` and `dst` must be properly aligned.
     ///
-    /// * `src.offset(count-1)` must be [valid]. In other words, the region of
-    ///   memory which begins at `src` and has a length of `count *
-    ///   size_of::<T>()` bytes must belong to a single, live allocation.
+    /// * `src.offset(i)` must be [valid] for all `i` in `0..count`. In other
+    ///   words, the region of memory which begins at `src` and has a length of
+    ///   `count * size_of::<T>()` bytes must belong to a single, live
+    ///   allocation.
     ///
-    /// * `dst.offset(count-1)` must be [valid]. In other words, the region of
-    ///   memory which begins at `dst` and has a length of `count *
-    ///   size_of::<T>()` bytes must belong to a single, live allocation.
+    /// * `dst.offset(i)` must be [valid] for all `i` in `0..count`. In other
+    ///   words, the region of memory which begins at `dst` and has a length of
+    ///   `count * size_of::<T>()` bytes must belong to a single, live
+    ///   allocation.
     ///
     /// Like [`read`], `copy` creates a bitwise copy of `T`, regardless of
     /// whether `T` is [`Copy`].  If `T` is not [`Copy`], using both the values
@@ -1116,13 +1116,12 @@ extern "rust-intrinsic" {
     ///
     /// Behavior is undefined if any of the following conditions are violated:
     ///
-    /// * `dst` must be [valid].
-    ///
-    /// * `dst.offset(count-1)` must be [valid]. In other words, the region of
-    ///   memory which begins at `dst` and has a length of `count *
-    ///   size_of::<T>()` bytes must belong to a single, live allocation.
-    ///
     /// * `dst` must be properly aligned.
+    ///
+    /// * `dst.offset(i)` must be [valid] for all `i` in `0..count`. In other
+    ///   words, the region of memory which begins at `dst` and has a length of
+    ///   `count * size_of::<T>()` bytes must belong to a single, live
+    ///   allocation.
     ///
     /// Additionally, the caller must ensure that writing `count *
     /// size_of::<T>()` bytes to the given region of memory results in a valid

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -1017,13 +1017,13 @@ extern "rust-intrinsic" {
     ///     unsafe {
     ///         // The call to offset is always safe because `Vec` will never
     ///         // allocate more than `isize::MAX` bytes.
-    ///         let dst = dst.as_mut_ptr().offset(dst_len as isize);
-    ///         let src = src.as_ptr();
+    ///         let dst_ptr = dst.as_mut_ptr().offset(dst_len as isize);
+    ///         let src_ptr = src.as_ptr();
     ///
     ///         // The two regions cannot overlap becuase mutable references do
     ///         // not alias, and two different vectors cannot own the same
     ///         // memory.
-    ///         ptr::copy_nonoverlapping(src, dst, src_len);
+    ///         ptr::copy_nonoverlapping(src_ptr, dst_ptr, src_len);
     ///
     ///         // Truncate `src` without dropping its contents. This cannot panic,
     ///         // so double-drops cannot happen.
@@ -1145,7 +1145,7 @@ extern "rust-intrinsic" {
     /// Creating an invalid value:
     ///
     /// ```
-    /// use std::ptr;
+    /// use std::{mem, ptr};
     ///
     /// let mut v = Box::new(0i32);
     ///

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -991,8 +991,8 @@ extern "rust-intrinsic" {
     /// in the region beginning at `*src` and the region beginning at `*dst` can
     /// [violate memory safety][read-ownership].
     ///
-    /// These restrictions apply even if the effectively copied size (`count *
-    /// size_of::<T>()`) is `0`.
+    /// Note that even if the effectively copied size (`count * size_of::<T>()`) is
+    /// `0`, the pointers must be non-NULL and properly aligned.
     ///
     /// [`Copy`]: ../marker/trait.Copy.html
     /// [`read`]: ../ptr/fn.read.html
@@ -1074,8 +1074,8 @@ extern "rust-intrinsic" {
     /// in the region beginning at `*src` and the region beginning at `*dst` can
     /// [violate memory safety][read-ownership].
     ///
-    /// These restrictions apply even if the effectively copied size (`count *
-    /// size_of::<T>()`) is `0`.
+    /// Note that even if the effectively copied size (`count * size_of::<T>()`) is
+    /// `0`, the pointers must be non-NULL and properly aligned.
     ///
     /// [`Copy`]: ../marker/trait.Copy.html
     /// [`read`]: ../ptr/fn.read.html
@@ -1121,8 +1121,8 @@ extern "rust-intrinsic" {
     /// value of `T`. Creating an invalid value of `T` can result in undefined
     /// behavior.
     ///
-    /// These restrictions apply even if the effectively written size (`count *
-    /// size_of::<T>()`) is `0`.
+    /// Note that even if the effectively copied size (`count * size_of::<T>()`) is
+    /// `0`, the pointer must be non-NULL and properly aligned.
     ///
     /// [valid]: ../ptr/index.html#safety
     ///

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -1117,10 +1117,10 @@ extern "rust-intrinsic" {
     ///
     /// * `dst` must be properly aligned.
     ///
-    /// Additionally, the caller must ensure that writing `count *
+    /// Additionally, the caller should ensure that writing `count *
     /// size_of::<T>()` bytes to the given region of memory results in a valid
-    /// value of `T`. Creating an invalid value of `T` can result in undefined
-    /// behavior.
+    /// value of `T`. Using a region of memory typed as a `T` that contains an
+    /// invalid value of `T` is undefined behavior.
     ///
     /// Note that even if the effectively copied size (`count * size_of::<T>()`) is
     /// `0`, the pointer must be non-NULL and properly aligned.

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -1159,7 +1159,7 @@ extern "rust-intrinsic" {
     /// // At this point, using or dropping `v` results in undefined behavior.
     /// // drop(v); // ERROR
     ///
-    /// // Even leaking `v` "uses" it, and henc eis undefined behavior.
+    /// // Even leaking `v` "uses" it, and hence is undefined behavior.
     /// // mem::forget(v); // ERROR
     ///
     /// unsafe {

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -1162,6 +1162,10 @@ extern "rust-intrinsic" {
     /// // Even leaking `v` "uses" it, and hence is undefined behavior.
     /// // mem::forget(v); // ERROR
     ///
+    /// // In fact, `v` is invalid according to basic type layout invariants, so *any*
+    /// // operation touching it is undefined behavior.
+    /// // let v2 = v; // ERROR
+    ///
     /// unsafe {
     ///     // Let us instead put in a valid value
     ///     ptr::write(&mut v as *mut Box<i32>, Box::new(42i32));

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -1118,7 +1118,7 @@ extern "rust-intrinsic" {
     ///
     /// * `dst` must be properly aligned.
     ///
-    /// Additionally, the caller should ensure that writing `count *
+    /// Additionally, the caller must ensure that writing `count *
     /// size_of::<T>()` bytes to the given region of memory results in a valid
     /// value of `T`. Using a region of memory typed as a `T` that contains an
     /// invalid value of `T` is undefined behavior.
@@ -1153,7 +1153,7 @@ extern "rust-intrinsic" {
     /// unsafe {
     ///     // Leaks the previously held value by overwriting the `Box<T>` with
     ///     // a null pointer.
-    ///     ptr::write_bytes(&mut v, 0, 1);
+    ///     ptr::write_bytes(&mut v as *mut Box<i32>, 0, 1);
     /// }
     ///
     /// // At this point, using or dropping `v` results in undefined behavior.
@@ -1164,7 +1164,7 @@ extern "rust-intrinsic" {
     ///
     /// unsafe {
     ///     // Let us instead put in a valid value
-    ///     ptr::write(&mut v, Box::new(42i32));
+    ///     ptr::write(&mut v as *mut Box<i32>, Box::new(42i32));
     /// }
     ///
     /// // Now the box is fine

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -986,10 +986,13 @@ extern "rust-intrinsic" {
     ///   size_of::<T>()` bytes must *not* overlap with the region of memory
     ///   beginning at `dst` with the same size.
     ///
-    /// Like [`read`], `copy` creates a bitwise copy of `T`, regardless of
-    /// whether `T` is [`Copy`].  If `T` is not [`Copy`], using both the values
+    /// Like [`read`], `copy_nonoverlapping` creates a bitwise copy of `T`, regardless of
+    /// whether `T` is [`Copy`].  If `T` is not [`Copy`], using *both* the values
     /// in the region beginning at `*src` and the region beginning at `*dst` can
     /// [violate memory safety][read-ownership].
+    ///
+    /// These restrictions apply even if the effectively copied size (`count *
+    /// size_of::<T>()`) is `0`.
     ///
     /// [`Copy`]: ../marker/trait.Copy.html
     /// [`read`]: ../ptr/fn.read.html
@@ -1071,6 +1074,9 @@ extern "rust-intrinsic" {
     /// in the region beginning at `*src` and the region beginning at `*dst` can
     /// [violate memory safety][read-ownership].
     ///
+    /// These restrictions apply even if the effectively copied size (`count *
+    /// size_of::<T>()`) is `0`.
+    ///
     /// [`Copy`]: ../marker/trait.Copy.html
     /// [`read`]: ../ptr/fn.read.html
     /// [read-ownership]: ../ptr/fn.read.html#ownership-of-the-returned-value
@@ -1114,6 +1120,9 @@ extern "rust-intrinsic" {
     /// size_of::<T>()` bytes to the given region of memory results in a valid
     /// value of `T`. Creating an invalid value of `T` can result in undefined
     /// behavior.
+    ///
+    /// These restrictions apply even if the effectively written size (`count *
+    /// size_of::<T>()`) is `0`.
     ///
     /// [valid]: ../ptr/index.html#safety
     ///
@@ -1164,7 +1173,7 @@ extern "rust-intrinsic" {
     /// `min_align_of::<T>()`
     ///
     /// The volatile parameter is set to `true`, so it will not be optimized out
-    /// unless size is equal to zero..
+    /// unless size is equal to zero.
     pub fn volatile_copy_memory<T>(dst: *mut T, src: *const T, count: usize);
     /// Equivalent to the appropriate `llvm.memset.p0i8.*` intrinsic, with a
     /// size of `count` * `size_of::<T>()` and an alignment of

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -1146,7 +1146,7 @@ extern "rust-intrinsic" {
     /// Creating an invalid value:
     ///
     /// ```
-    /// use std::{mem, ptr};
+    /// use std::ptr;
     ///
     /// let mut v = Box::new(0i32);
     ///
@@ -1162,8 +1162,10 @@ extern "rust-intrinsic" {
     /// // Even leaking `v` "uses" it, and henc eis undefined behavior.
     /// // mem::forget(v); // ERROR
     ///
-    /// // Let us instead put in a valid value
-    /// ptr::write(&mut v, Box::new(42i32);
+    /// unsafe {
+    ///     // Let us instead put in a valid value
+    ///     ptr::write(&mut v, Box::new(42i32));
+    /// }
     ///
     /// // Now the box is fine
     /// assert_eq!(*v, 42);

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -1024,10 +1024,9 @@ extern "rust-intrinsic" {
     ///         // not alias, and two different vectors cannot own the same
     ///         // memory.
     ///         ptr::copy_nonoverlapping(src, dst, src_len);
-    ///     }
     ///
-    ///     unsafe {
-    ///         // Truncate `src` without dropping its contents.
+    ///         // Truncate `src` without dropping its contents. This cannot panic,
+    ///         // so double-drops cannot happen.
     ///         src.set_len(0);
     ///
     ///         // Notify `dst` that it now holds the contents of `src`.
@@ -1054,7 +1053,9 @@ extern "rust-intrinsic" {
     /// If the source and destination will *never* overlap,
     /// [`copy_nonoverlapping`] can be used instead.
     ///
-    /// `copy` is semantically equivalent to C's [`memmove`].
+    /// `copy` is semantically equivalent to C's [`memmove`].  Copying takes place as
+    /// if the bytes were copied from `src` to a temporary array and then copied from
+    /// the array to `dst`-
     ///
     /// [`copy_nonoverlapping`]: ./fn.copy_nonoverlapping.html
     /// [`memmove`]: https://www.gnu.org/software/libc/manual/html_node/Copying-Strings-and-Arrays.html#index-memmove
@@ -1143,7 +1144,7 @@ extern "rust-intrinsic" {
     ///
     /// Creating an invalid value:
     ///
-    /// ```no_run
+    /// ```
     /// use std::ptr;
     ///
     /// let mut v = Box::new(0i32);
@@ -1155,7 +1156,10 @@ extern "rust-intrinsic" {
     /// }
     ///
     /// // At this point, using or dropping `v` results in undefined behavior.
-    /// // v = Box::new(0i32); // ERROR
+    /// // drop(v); // ERROR
+    ///
+    /// // Leaking it does not invoke drop and is fine:
+    /// mem::forget(v)
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn write_bytes<T>(dst: *mut T, val: u8, count: usize);

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -226,12 +226,28 @@ pub unsafe fn swap<T>(x: *mut T, y: *mut T) {
     mem::forget(tmp);
 }
 
-/// Swaps a sequence of values at two mutable locations of the same type.
+/// Swaps `count * size_of::<T>()` bytes between the two regions of memory
+/// beginning at `x` and `y`. The two regions must *not* overlap.
 ///
 /// # Safety
 ///
-/// The two arguments must each point to the beginning of `count` locations
-/// of valid memory, and the two memory ranges must not overlap.
+/// Behavior is undefined if any of the following conditions are violated:
+///
+/// * Both `x` and `y` must be [valid].
+///
+/// * Both `x` and `y` must be properly aligned.
+///
+/// * `x.offset(count)` must be [valid]. In other words, the region of memory
+///   which begins at `x` and has a length of `count * size_of::<T>()` bytes
+///   must belong to a single, live allocation.
+///
+/// * `y.offset(count)` must be [valid]. In other words, the region of memory
+///   which begins at `y` and has a length of `count * size_of::<T>()` bytes
+///   must belong to a single, live allocation.
+///
+/// * The two regions of memory must *not* overlap.
+///
+/// [valid]: ../ptr/index.html#safety
 ///
 /// # Examples
 ///

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -25,10 +25,10 @@
 //!   freed).
 //! * The pointer satisfies [LLVM's pointer aliasing rules].
 //!
-//! Valid pointers are not necessarily properly aligned. However, except for
-//! [`read_unaligned`] and [`write_unaligned`], most functions require their
-//! arguments to be aligned. Any alignment requirements will be explicitly
-//! stated in the function's documentation.
+//! Valid pointers are not necessarily properly aligned. However, most functions
+//! require their arguments to be properly aligned, and will explicitly state
+//! this requirement in the `Safety` section. Notable exceptions to this are
+//! [`read_unaligned`] and [`write_unaligned`].
 //!
 //! [LLVM's pointer aliasing rules]: https://llvm.org/docs/LangRef.html#pointer-aliasing-rules
 //! [`read_unaligned`]: ./fn.read_unaligned.html

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -240,17 +240,15 @@ pub unsafe fn swap<T>(x: *mut T, y: *mut T) {
 ///
 /// Behavior is undefined if any of the following conditions are violated:
 ///
-/// * Both `x` and `y` must be [valid].
-///
 /// * Both `x` and `y` must be properly aligned.
 ///
-/// * `x.offset(count-1)` must be [valid]. In other words, the region of memory
-///   which begins at `x` and has a length of `count * size_of::<T>()` bytes
-///   must belong to a single, live allocation.
+/// * `x.offset(i)` must be [valid] for all `i` in `0..count`. In other words,
+///   the region of memory which begins at `x` and has a length of `count *
+///   size_of::<T>()` bytes must belong to a single, live allocation.
 ///
-/// * `y.offset(count-1)` must be [valid]. In other words, the region of memory
-///   which begins at `y` and has a length of `count * size_of::<T>()` bytes
-///   must belong to a single, live allocation.
+/// * `y.offset(i)` must be [valid] for all `i` in `0..count`. In other words,
+///   the region of memory which begins at `y` and has a length of `count *
+///   size_of::<T>()` bytes must belong to a single, live allocation.
 ///
 /// * The two regions of memory must *not* overlap.
 ///

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -50,7 +50,7 @@
 //! [aliasing]: ../../nomicon/aliasing.html
 //! [book]: ../../book/second-edition/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer
 //! [ub]: ../../reference/behavior-considered-undefined.html
-//! [`copy`]: ./fn.copy.html
+//! [`copy`]: ../../std/ptr/fn.copy.html
 //! [`read_unaligned`]: ./fn.read_unaligned.html
 //! [`write_unaligned`]: ./fn.write_unaligned.html
 

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -237,11 +237,11 @@ pub unsafe fn swap<T>(x: *mut T, y: *mut T) {
 ///
 /// * Both `x` and `y` must be properly aligned.
 ///
-/// * `x.offset(count)` must be [valid]. In other words, the region of memory
+/// * `x.offset(count-1)` must be [valid]. In other words, the region of memory
 ///   which begins at `x` and has a length of `count * size_of::<T>()` bytes
 ///   must belong to a single, live allocation.
 ///
-/// * `y.offset(count)` must be [valid]. In other words, the region of memory
+/// * `y.offset(count-1)` must be [valid]. In other words, the region of memory
 ///   which begins at `y` and has a length of `count * size_of::<T>()` bytes
 ///   must belong to a single, live allocation.
 ///

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -17,20 +17,27 @@
 //! # Safety
 //!
 //! Many functions in this module take raw pointers as arguments and dereference
-//! them. For this to be safe, these pointers must be valid. A valid pointer
-//! is one that satisfies **all** of the following conditions:
+//! them. For this to be safe, these pointers must be valid. However, because
+//! rust does not yet have a formal memory model, determining whether an
+//! arbitrary pointer is a valid one can be tricky. One thing is certain:
+//! creating a raw pointer from a reference (e.g. `&x as *const _`) *always*
+//! results in a valid pointer. By exploiting this—and by taking care when
+//! using [pointer arithmetic]—users can be confident in the correctness of
+//! their unsafe code.
 //!
-//! * The pointer is not null.
-//! * The pointer is not dangling (it does not point to memory which has been
-//!   freed).
-//! * The pointer satisfies [LLVM's pointer aliasing rules].
+//! For more information on dereferencing raw pointers, see the both the [book]
+//! and the section in the reference devoted to [undefined behavior][ub].
+//!
+//! ## Alignment
 //!
 //! Valid pointers are not necessarily properly aligned. However, most functions
 //! require their arguments to be properly aligned, and will explicitly state
 //! this requirement in the `Safety` section. Notable exceptions to this are
 //! [`read_unaligned`] and [`write_unaligned`].
 //!
-//! [LLVM's pointer aliasing rules]: https://llvm.org/docs/LangRef.html#pointer-aliasing-rules
+//! [ub]: ../../reference/behavior-considered-undefined.html
+//! [book]: ../../book/second-edition/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer
+//! [pointer arithmetic]: ../../std/primitive.pointer.html#method.offset
 //! [`read_unaligned`]: ./fn.read_unaligned.html
 //! [`write_unaligned`]: ./fn.write_unaligned.html
 

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -42,10 +42,9 @@
 //!
 //! * The result of casting a reference to a pointer is valid for as long as the
 //!   underlying object is live.
-//! * All pointers to types with a [size of zero][zst] are valid for all
-//!   operations of size zero.
-//! * A [null] pointer is *never* valid, except when it points to a zero-sized
-//!   type.
+//! * A [null] pointer is *never* valid.
+//! * All pointers (except for the null pointer) are valid for all operations of
+//!   [size zero][zst].
 //!
 //! These axioms, along with careful use of [`offset`] for pointer arithmentic,
 //! are enough to correctly implement many useful things in unsafe code. Still,

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -748,8 +748,8 @@ pub unsafe fn write<T>(dst: *mut T, src: T) {
 ///     // Take a reference to a 32-bit integer which is not aligned.
 ///     let unaligned = &mut x.unaligned as *mut u32;
 ///
-///     // Dereferencing normally will emit an unaligned store instruction,
-///     // causing undefined behavior.
+///     // Dereferencing normally will emit an aligned store instruction,
+///     // causing undefined behavior because the pointer is not aligned.
 ///     // *unaligned = v; // ERROR
 ///
 ///     // Instead, use `write_unaligned` to write improperly aligned values.

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -16,18 +16,23 @@
 //!
 //! # Safety
 //!
-//! Most functions in this module [dereference raw pointers].
-//!
-//! In order for a pointer dereference to be safe, the pointer must be "valid".
-//! A valid pointer is one that satisfies **all** of the following conditions:
+//! Many functions in this module take raw pointers as arguments and dereference
+//! them. For this to be safe, these pointers must be valid. A valid pointer
+//! is one that satisfies **all** of the following conditions:
 //!
 //! * The pointer is not null.
 //! * The pointer is not dangling (it does not point to memory which has been
 //!   freed).
 //! * The pointer satisfies [LLVM's pointer aliasing rules].
 //!
-//! [dereference raw pointers]: https://doc.rust-lang.org/book/second-edition/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer
+//! Valid pointers are not necessarily properly aligned. However, except for
+//! [`read_unaligned`] and [`write_unaligned`], most functions require their
+//! arguments to be aligned. Any alignment requirements will be explicitly
+//! stated in the function's documentation.
+//!
 //! [LLVM's pointer aliasing rules]: https://llvm.org/docs/LangRef.html#pointer-aliasing-rules
+//! [`read_unaligned`]: ./fn.read_unaligned.html
+//! [`write_unaligned`]: ./fn.write_unaligned.html
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
@@ -667,6 +672,7 @@ pub unsafe fn write<T>(dst: *mut T, src: T) {
 ///
 /// // Accessing unaligned values directly is safe.
 /// assert!(x.unaligned == v);
+/// ```
 #[inline]
 #[stable(feature = "ptr_unaligned", since = "1.17.0")]
 pub unsafe fn write_unaligned<T>(dst: *mut T, src: T) {

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -1401,29 +1401,9 @@ impl<T: ?Sized> *const T {
     /// Reads the value from `self` without moving it. This leaves the
     /// memory in `self` unchanged.
     ///
-    /// # Safety
+    /// See [`ptr::read`] for safety concerns and examples.
     ///
-    /// Beyond accepting a raw pointer, this is unsafe because it semantically
-    /// moves the value out of `self` without preventing further usage of `self`.
-    /// If `T` is not `Copy`, then care must be taken to ensure that the value at
-    /// `self` is not used before the data is overwritten again (e.g. with `write`,
-    /// `write_bytes`, or `copy`). Note that `*self = foo` counts as a use
-    /// because it will attempt to drop the value previously at `*self`.
-    ///
-    /// The pointer must be aligned; use `read_unaligned` if that is not the case.
-    ///
-    /// # Examples
-    ///
-    /// Basic usage:
-    ///
-    /// ```
-    /// let x = 12;
-    /// let y = &x as *const i32;
-    ///
-    /// unsafe {
-    ///     assert_eq!(y.read(), 12);
-    /// }
-    /// ```
+    /// [`ptr::read`]: ./ptr/fn.read.html
     #[stable(feature = "pointer_methods", since = "1.26.0")]
     #[inline]
     pub unsafe fn read(self) -> T
@@ -1439,47 +1419,9 @@ impl<T: ?Sized> *const T {
     /// to not be elided or reordered by the compiler across other volatile
     /// operations.
     ///
-    /// # Notes
+    /// See [`ptr::read_volatile`] for safety concerns and examples.
     ///
-    /// Rust does not currently have a rigorously and formally defined memory model,
-    /// so the precise semantics of what "volatile" means here is subject to change
-    /// over time. That being said, the semantics will almost always end up pretty
-    /// similar to [C11's definition of volatile][c11].
-    ///
-    /// The compiler shouldn't change the relative order or number of volatile
-    /// memory operations. However, volatile memory operations on zero-sized types
-    /// (e.g. if a zero-sized type is passed to `read_volatile`) are no-ops
-    /// and may be ignored.
-    ///
-    /// [c11]: http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1570.pdf
-    ///
-    /// # Safety
-    ///
-    /// Beyond accepting a raw pointer, this is unsafe because it semantically
-    /// moves the value out of `self` without preventing further usage of `self`.
-    /// If `T` is not `Copy`, then care must be taken to ensure that the value at
-    /// `self` is not used before the data is overwritten again (e.g. with `write`,
-    /// `write_bytes`, or `copy`). Note that `*self = foo` counts as a use
-    /// because it will attempt to drop the value previously at `*self`.
-    ///
-    /// Just like in C, whether an operation is volatile has no bearing whatsoever
-    /// on questions involving concurrent access from multiple threads. Volatile
-    /// accesses behave exactly like non-atomic accesses in that regard. In particular,
-    /// a race between a `read_volatile` and any write operation to the same location
-    /// is undefined behavior.
-    ///
-    /// # Examples
-    ///
-    /// Basic usage:
-    ///
-    /// ```
-    /// let x = 12;
-    /// let y = &x as *const i32;
-    ///
-    /// unsafe {
-    ///     assert_eq!(y.read_volatile(), 12);
-    /// }
-    /// ```
+    /// [`ptr::read_volatile`]: ./ptr/fn.read_volatile.html
     #[stable(feature = "pointer_methods", since = "1.26.0")]
     #[inline]
     pub unsafe fn read_volatile(self) -> T
@@ -1493,27 +1435,9 @@ impl<T: ?Sized> *const T {
     ///
     /// Unlike `read`, the pointer may be unaligned.
     ///
-    /// # Safety
+    /// See [`ptr::read_unaligned`] for safety concerns and examples.
     ///
-    /// Beyond accepting a raw pointer, this is unsafe because it semantically
-    /// moves the value out of `self` without preventing further usage of `self`.
-    /// If `T` is not `Copy`, then care must be taken to ensure that the value at
-    /// `self` is not used before the data is overwritten again (e.g. with `write`,
-    /// `write_bytes`, or `copy`). Note that `*self = foo` counts as a use
-    /// because it will attempt to drop the value previously at `*self`.
-    ///
-    /// # Examples
-    ///
-    /// Basic usage:
-    ///
-    /// ```
-    /// let x = 12;
-    /// let y = &x as *const i32;
-    ///
-    /// unsafe {
-    ///     assert_eq!(y.read_unaligned(), 12);
-    /// }
-    /// ```
+    /// [`ptr::read_unaligned`]: ./ptr/fn.read_unaligned.html
     #[stable(feature = "pointer_methods", since = "1.26.0")]
     #[inline]
     pub unsafe fn read_unaligned(self) -> T
@@ -1525,30 +1449,11 @@ impl<T: ?Sized> *const T {
     /// Copies `count * size_of<T>` bytes from `self` to `dest`. The source
     /// and destination may overlap.
     ///
-    /// NOTE: this has the *same* argument order as `ptr::copy`.
+    /// NOTE: this has the *same* argument order as [`ptr::copy`].
     ///
-    /// This is semantically equivalent to C's `memmove`.
+    /// See [`ptr::copy`] for safety concerns and examples.
     ///
-    /// # Safety
-    ///
-    /// Care must be taken with the ownership of `self` and `dest`.
-    /// This method semantically moves the values of `self` into `dest`.
-    /// However it does not drop the contents of `dest`, or prevent the contents
-    /// of `self` from being dropped or used.
-    ///
-    /// # Examples
-    ///
-    /// Efficiently create a Rust vector from an unsafe buffer:
-    ///
-    /// ```
-    /// # #[allow(dead_code)]
-    /// unsafe fn from_buf_raw<T: Copy>(ptr: *const T, elts: usize) -> Vec<T> {
-    ///     let mut dst = Vec::with_capacity(elts);
-    ///     dst.set_len(elts);
-    ///     ptr.copy_to(dst.as_mut_ptr(), elts);
-    ///     dst
-    /// }
-    /// ```
+    /// [`ptr::copy`]: ./ptr/fn.copy.html
     #[stable(feature = "pointer_methods", since = "1.26.0")]
     #[inline]
     pub unsafe fn copy_to(self, dest: *mut T, count: usize)
@@ -1560,32 +1465,11 @@ impl<T: ?Sized> *const T {
     /// Copies `count * size_of<T>` bytes from `self` to `dest`. The source
     /// and destination may *not* overlap.
     ///
-    /// NOTE: this has the *same* argument order as `ptr::copy_nonoverlapping`.
+    /// NOTE: this has the *same* argument order as [`ptr::copy_nonoverlapping`].
     ///
-    /// `copy_nonoverlapping` is semantically equivalent to C's `memcpy`.
+    /// See [`ptr::copy_nonoverlapping`] for safety concerns and examples.
     ///
-    /// # Safety
-    ///
-    /// Beyond requiring that the program must be allowed to access both regions
-    /// of memory, it is Undefined Behavior for source and destination to
-    /// overlap. Care must also be taken with the ownership of `self` and
-    /// `self`. This method semantically moves the values of `self` into `dest`.
-    /// However it does not drop the contents of `dest`, or prevent the contents
-    /// of `self` from being dropped or used.
-    ///
-    /// # Examples
-    ///
-    /// Efficiently create a Rust vector from an unsafe buffer:
-    ///
-    /// ```
-    /// # #[allow(dead_code)]
-    /// unsafe fn from_buf_raw<T: Copy>(ptr: *const T, elts: usize) -> Vec<T> {
-    ///     let mut dst = Vec::with_capacity(elts);
-    ///     dst.set_len(elts);
-    ///     ptr.copy_to_nonoverlapping(dst.as_mut_ptr(), elts);
-    ///     dst
-    /// }
-    /// ```
+    /// [`ptr::copy_nonoverlapping`]: ./ptr/fn.copy_nonoverlapping.html
     #[stable(feature = "pointer_methods", since = "1.26.0")]
     #[inline]
     pub unsafe fn copy_to_nonoverlapping(self, dest: *mut T, count: usize)
@@ -2155,29 +2039,9 @@ impl<T: ?Sized> *mut T {
     /// Reads the value from `self` without moving it. This leaves the
     /// memory in `self` unchanged.
     ///
-    /// # Safety
+    /// See [`ptr::read`] for safety concerns and examples.
     ///
-    /// Beyond accepting a raw pointer, this is unsafe because it semantically
-    /// moves the value out of `self` without preventing further usage of `self`.
-    /// If `T` is not `Copy`, then care must be taken to ensure that the value at
-    /// `self` is not used before the data is overwritten again (e.g. with `write`,
-    /// `write_bytes`, or `copy`). Note that `*self = foo` counts as a use
-    /// because it will attempt to drop the value previously at `*self`.
-    ///
-    /// The pointer must be aligned; use `read_unaligned` if that is not the case.
-    ///
-    /// # Examples
-    ///
-    /// Basic usage:
-    ///
-    /// ```
-    /// let x = 12;
-    /// let y = &x as *const i32;
-    ///
-    /// unsafe {
-    ///     assert_eq!(y.read(), 12);
-    /// }
-    /// ```
+    /// [`ptr::read`]: ./ptr/fn.read.html
     #[stable(feature = "pointer_methods", since = "1.26.0")]
     #[inline]
     pub unsafe fn read(self) -> T
@@ -2193,47 +2057,9 @@ impl<T: ?Sized> *mut T {
     /// to not be elided or reordered by the compiler across other volatile
     /// operations.
     ///
-    /// # Notes
+    /// See [`ptr::read_volatile`] for safety concerns and examples.
     ///
-    /// Rust does not currently have a rigorously and formally defined memory model,
-    /// so the precise semantics of what "volatile" means here is subject to change
-    /// over time. That being said, the semantics will almost always end up pretty
-    /// similar to [C11's definition of volatile][c11].
-    ///
-    /// The compiler shouldn't change the relative order or number of volatile
-    /// memory operations. However, volatile memory operations on zero-sized types
-    /// (e.g. if a zero-sized type is passed to `read_volatile`) are no-ops
-    /// and may be ignored.
-    ///
-    /// [c11]: http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1570.pdf
-    ///
-    /// # Safety
-    ///
-    /// Beyond accepting a raw pointer, this is unsafe because it semantically
-    /// moves the value out of `self` without preventing further usage of `self`.
-    /// If `T` is not `Copy`, then care must be taken to ensure that the value at
-    /// `self` is not used before the data is overwritten again (e.g. with `write`,
-    /// `write_bytes`, or `copy`). Note that `*self = foo` counts as a use
-    /// because it will attempt to drop the value previously at `*self`.
-    ///
-    /// Just like in C, whether an operation is volatile has no bearing whatsoever
-    /// on questions involving concurrent access from multiple threads. Volatile
-    /// accesses behave exactly like non-atomic accesses in that regard. In particular,
-    /// a race between a `read_volatile` and any write operation to the same location
-    /// is undefined behavior.
-    ///
-    /// # Examples
-    ///
-    /// Basic usage:
-    ///
-    /// ```
-    /// let x = 12;
-    /// let y = &x as *const i32;
-    ///
-    /// unsafe {
-    ///     assert_eq!(y.read_volatile(), 12);
-    /// }
-    /// ```
+    /// [`ptr::read_volatile`]: ./ptr/fn.read_volatile.html
     #[stable(feature = "pointer_methods", since = "1.26.0")]
     #[inline]
     pub unsafe fn read_volatile(self) -> T
@@ -2247,27 +2073,9 @@ impl<T: ?Sized> *mut T {
     ///
     /// Unlike `read`, the pointer may be unaligned.
     ///
-    /// # Safety
+    /// See [`ptr::read_unaligned`] for safety concerns and examples.
     ///
-    /// Beyond accepting a raw pointer, this is unsafe because it semantically
-    /// moves the value out of `self` without preventing further usage of `self`.
-    /// If `T` is not `Copy`, then care must be taken to ensure that the value at
-    /// `self` is not used before the data is overwritten again (e.g. with `write`,
-    /// `write_bytes`, or `copy`). Note that `*self = foo` counts as a use
-    /// because it will attempt to drop the value previously at `*self`.
-    ///
-    /// # Examples
-    ///
-    /// Basic usage:
-    ///
-    /// ```
-    /// let x = 12;
-    /// let y = &x as *const i32;
-    ///
-    /// unsafe {
-    ///     assert_eq!(y.read_unaligned(), 12);
-    /// }
-    /// ```
+    /// [`ptr::read_unaligned`]: ./ptr/fn.read_unaligned.html
     #[stable(feature = "pointer_methods", since = "1.26.0")]
     #[inline]
     pub unsafe fn read_unaligned(self) -> T
@@ -2279,30 +2087,11 @@ impl<T: ?Sized> *mut T {
     /// Copies `count * size_of<T>` bytes from `self` to `dest`. The source
     /// and destination may overlap.
     ///
-    /// NOTE: this has the *same* argument order as `ptr::copy`.
+    /// NOTE: this has the *same* argument order as [`ptr::copy`].
     ///
-    /// This is semantically equivalent to C's `memmove`.
+    /// See [`ptr::copy`] for safety concerns and examples.
     ///
-    /// # Safety
-    ///
-    /// Care must be taken with the ownership of `self` and `dest`.
-    /// This method semantically moves the values of `self` into `dest`.
-    /// However it does not drop the contents of `self`, or prevent the contents
-    /// of `dest` from being dropped or used.
-    ///
-    /// # Examples
-    ///
-    /// Efficiently create a Rust vector from an unsafe buffer:
-    ///
-    /// ```
-    /// # #[allow(dead_code)]
-    /// unsafe fn from_buf_raw<T: Copy>(ptr: *const T, elts: usize) -> Vec<T> {
-    ///     let mut dst = Vec::with_capacity(elts);
-    ///     dst.set_len(elts);
-    ///     ptr.copy_to(dst.as_mut_ptr(), elts);
-    ///     dst
-    /// }
-    /// ```
+    /// [`ptr::copy`]: ./ptr/fn.copy.html
     #[stable(feature = "pointer_methods", since = "1.26.0")]
     #[inline]
     pub unsafe fn copy_to(self, dest: *mut T, count: usize)
@@ -2314,32 +2103,11 @@ impl<T: ?Sized> *mut T {
     /// Copies `count * size_of<T>` bytes from `self` to `dest`. The source
     /// and destination may *not* overlap.
     ///
-    /// NOTE: this has the *same* argument order as `ptr::copy_nonoverlapping`.
+    /// NOTE: this has the *same* argument order as [`ptr::copy_nonoverlapping`].
     ///
-    /// `copy_nonoverlapping` is semantically equivalent to C's `memcpy`.
+    /// See [`ptr::copy_nonoverlapping`] for safety concerns and examples.
     ///
-    /// # Safety
-    ///
-    /// Beyond requiring that the program must be allowed to access both regions
-    /// of memory, it is Undefined Behavior for source and destination to
-    /// overlap. Care must also be taken with the ownership of `self` and
-    /// `self`. This method semantically moves the values of `self` into `dest`.
-    /// However it does not drop the contents of `dest`, or prevent the contents
-    /// of `self` from being dropped or used.
-    ///
-    /// # Examples
-    ///
-    /// Efficiently create a Rust vector from an unsafe buffer:
-    ///
-    /// ```
-    /// # #[allow(dead_code)]
-    /// unsafe fn from_buf_raw<T: Copy>(ptr: *const T, elts: usize) -> Vec<T> {
-    ///     let mut dst = Vec::with_capacity(elts);
-    ///     dst.set_len(elts);
-    ///     ptr.copy_to_nonoverlapping(dst.as_mut_ptr(), elts);
-    ///     dst
-    /// }
-    /// ```
+    /// [`ptr::copy_nonoverlapping`]: ./ptr/fn.copy_nonoverlapping.html
     #[stable(feature = "pointer_methods", since = "1.26.0")]
     #[inline]
     pub unsafe fn copy_to_nonoverlapping(self, dest: *mut T, count: usize)
@@ -2351,30 +2119,11 @@ impl<T: ?Sized> *mut T {
     /// Copies `count * size_of<T>` bytes from `src` to `self`. The source
     /// and destination may overlap.
     ///
-    /// NOTE: this has the *opposite* argument order of `ptr::copy`.
+    /// NOTE: this has the *opposite* argument order of [`ptr::copy`].
     ///
-    /// This is semantically equivalent to C's `memmove`.
+    /// See [`ptr::copy`] for safety concerns and examples.
     ///
-    /// # Safety
-    ///
-    /// Care must be taken with the ownership of `src` and `self`.
-    /// This method semantically moves the values of `src` into `self`.
-    /// However it does not drop the contents of `self`, or prevent the contents
-    /// of `src` from being dropped or used.
-    ///
-    /// # Examples
-    ///
-    /// Efficiently create a Rust vector from an unsafe buffer:
-    ///
-    /// ```
-    /// # #[allow(dead_code)]
-    /// unsafe fn from_buf_raw<T: Copy>(ptr: *const T, elts: usize) -> Vec<T> {
-    ///     let mut dst: Vec<T> = Vec::with_capacity(elts);
-    ///     dst.set_len(elts);
-    ///     dst.as_mut_ptr().copy_from(ptr, elts);
-    ///     dst
-    /// }
-    /// ```
+    /// [`ptr::copy`]: ./ptr/fn.copy.html
     #[stable(feature = "pointer_methods", since = "1.26.0")]
     #[inline]
     pub unsafe fn copy_from(self, src: *const T, count: usize)
@@ -2386,32 +2135,11 @@ impl<T: ?Sized> *mut T {
     /// Copies `count * size_of<T>` bytes from `src` to `self`. The source
     /// and destination may *not* overlap.
     ///
-    /// NOTE: this has the *opposite* argument order of `ptr::copy_nonoverlapping`.
+    /// NOTE: this has the *opposite* argument order of [`ptr::copy_nonoverlapping`].
     ///
-    /// `copy_nonoverlapping` is semantically equivalent to C's `memcpy`.
+    /// See [`ptr::copy_nonoverlapping`] for safety concerns and examples.
     ///
-    /// # Safety
-    ///
-    /// Beyond requiring that the program must be allowed to access both regions
-    /// of memory, it is Undefined Behavior for source and destination to
-    /// overlap. Care must also be taken with the ownership of `src` and
-    /// `self`. This method semantically moves the values of `src` into `self`.
-    /// However it does not drop the contents of `self`, or prevent the contents
-    /// of `src` from being dropped or used.
-    ///
-    /// # Examples
-    ///
-    /// Efficiently create a Rust vector from an unsafe buffer:
-    ///
-    /// ```
-    /// # #[allow(dead_code)]
-    /// unsafe fn from_buf_raw<T: Copy>(ptr: *const T, elts: usize) -> Vec<T> {
-    ///     let mut dst: Vec<T> = Vec::with_capacity(elts);
-    ///     dst.set_len(elts);
-    ///     dst.as_mut_ptr().copy_from_nonoverlapping(ptr, elts);
-    ///     dst
-    /// }
-    /// ```
+    /// [`ptr::copy_nonoverlapping`]: ./ptr/fn.copy_nonoverlapping.html
     #[stable(feature = "pointer_methods", since = "1.26.0")]
     #[inline]
     pub unsafe fn copy_from_nonoverlapping(self, src: *const T, count: usize)
@@ -2422,21 +2150,9 @@ impl<T: ?Sized> *mut T {
 
     /// Executes the destructor (if any) of the pointed-to value.
     ///
-    /// This has two use cases:
+    /// See [`ptr::drop_in_place`] for safety concerns and examples.
     ///
-    /// * It is *required* to use `drop_in_place` to drop unsized types like
-    ///   trait objects, because they can't be read out onto the stack and
-    ///   dropped normally.
-    ///
-    /// * It is friendlier to the optimizer to do this over `ptr::read` when
-    ///   dropping manually allocated memory (e.g. when writing Box/Rc/Vec),
-    ///   as the compiler doesn't need to prove that it's sound to elide the
-    ///   copy.
-    ///
-    /// # Safety
-    ///
-    /// This has all the same safety problems as `ptr::read` with respect to
-    /// invalid pointers, types, and double drops.
+    /// [`ptr::drop_in_place`]: ./ptr/fn.drop_in_place.html
     #[stable(feature = "pointer_methods", since = "1.26.0")]
     #[inline]
     pub unsafe fn drop_in_place(self) {
@@ -2446,36 +2162,9 @@ impl<T: ?Sized> *mut T {
     /// Overwrites a memory location with the given value without reading or
     /// dropping the old value.
     ///
-    /// # Safety
+    /// See [`ptr::write`] for safety concerns and examples.
     ///
-    /// This operation is marked unsafe because it writes through a raw pointer.
-    ///
-    /// It does not drop the contents of `self`. This is safe, but it could leak
-    /// allocations or resources, so care must be taken not to overwrite an object
-    /// that should be dropped.
-    ///
-    /// Additionally, it does not drop `val`. Semantically, `val` is moved into the
-    /// location pointed to by `self`.
-    ///
-    /// This is appropriate for initializing uninitialized memory, or overwriting
-    /// memory that has previously been `read` from.
-    ///
-    /// The pointer must be aligned; use `write_unaligned` if that is not the case.
-    ///
-    /// # Examples
-    ///
-    /// Basic usage:
-    ///
-    /// ```
-    /// let mut x = 0;
-    /// let y = &mut x as *mut i32;
-    /// let z = 12;
-    ///
-    /// unsafe {
-    ///     y.write(z);
-    ///     assert_eq!(y.read(), 12);
-    /// }
-    /// ```
+    /// [`ptr::write`]: ./ptr/fn.write.html
     #[stable(feature = "pointer_methods", since = "1.26.0")]
     #[inline]
     pub unsafe fn write(self, val: T)
@@ -2487,16 +2176,9 @@ impl<T: ?Sized> *mut T {
     /// Invokes memset on the specified pointer, setting `count * size_of::<T>()`
     /// bytes of memory starting at `self` to `val`.
     ///
-    /// # Examples
+    /// See [`ptr::write_bytes`] for safety concerns and examples.
     ///
-    /// ```
-    /// let mut vec = vec![0; 4];
-    /// unsafe {
-    ///     let vec_ptr = vec.as_mut_ptr();
-    ///     vec_ptr.write_bytes(b'a', 2);
-    /// }
-    /// assert_eq!(vec, [b'a', b'a', 0, 0]);
-    /// ```
+    /// [`ptr::write_bytes`]: ./ptr/fn.write_bytes.html
     #[stable(feature = "pointer_methods", since = "1.26.0")]
     #[inline]
     pub unsafe fn write_bytes(self, val: u8, count: usize)
@@ -2512,51 +2194,9 @@ impl<T: ?Sized> *mut T {
     /// to not be elided or reordered by the compiler across other volatile
     /// operations.
     ///
-    /// # Notes
+    /// See [`ptr::write_volatile`] for safety concerns and examples.
     ///
-    /// Rust does not currently have a rigorously and formally defined memory model,
-    /// so the precise semantics of what "volatile" means here is subject to change
-    /// over time. That being said, the semantics will almost always end up pretty
-    /// similar to [C11's definition of volatile][c11].
-    ///
-    /// The compiler shouldn't change the relative order or number of volatile
-    /// memory operations. However, volatile memory operations on zero-sized types
-    /// (e.g. if a zero-sized type is passed to `write_volatile`) are no-ops
-    /// and may be ignored.
-    ///
-    /// [c11]: http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1570.pdf
-    ///
-    /// # Safety
-    ///
-    /// This operation is marked unsafe because it accepts a raw pointer.
-    ///
-    /// It does not drop the contents of `self`. This is safe, but it could leak
-    /// allocations or resources, so care must be taken not to overwrite an object
-    /// that should be dropped.
-    ///
-    /// This is appropriate for initializing uninitialized memory, or overwriting
-    /// memory that has previously been `read` from.
-    ///
-    /// Just like in C, whether an operation is volatile has no bearing whatsoever
-    /// on questions involving concurrent access from multiple threads. Volatile
-    /// accesses behave exactly like non-atomic accesses in that regard. In particular,
-    /// a race between a `write_volatile` and any other operation (reading or writing)
-    /// on the same location is undefined behavior.
-    ///
-    /// # Examples
-    ///
-    /// Basic usage:
-    ///
-    /// ```
-    /// let mut x = 0;
-    /// let y = &mut x as *mut i32;
-    /// let z = 12;
-    ///
-    /// unsafe {
-    ///     y.write_volatile(z);
-    ///     assert_eq!(y.read_volatile(), 12);
-    /// }
-    /// ```
+    /// [`ptr::write_volatile`]: ./ptr/fn.write_volatile.html
     #[stable(feature = "pointer_methods", since = "1.26.0")]
     #[inline]
     pub unsafe fn write_volatile(self, val: T)
@@ -2570,34 +2210,9 @@ impl<T: ?Sized> *mut T {
     ///
     /// Unlike `write`, the pointer may be unaligned.
     ///
-    /// # Safety
+    /// See [`ptr::write_unaligned`] for safety concerns and examples.
     ///
-    /// This operation is marked unsafe because it writes through a raw pointer.
-    ///
-    /// It does not drop the contents of `self`. This is safe, but it could leak
-    /// allocations or resources, so care must be taken not to overwrite an object
-    /// that should be dropped.
-    ///
-    /// Additionally, it does not drop `self`. Semantically, `self` is moved into the
-    /// location pointed to by `val`.
-    ///
-    /// This is appropriate for initializing uninitialized memory, or overwriting
-    /// memory that has previously been `read` from.
-    ///
-    /// # Examples
-    ///
-    /// Basic usage:
-    ///
-    /// ```
-    /// let mut x = 0;
-    /// let y = &mut x as *mut i32;
-    /// let z = 12;
-    ///
-    /// unsafe {
-    ///     y.write_unaligned(z);
-    ///     assert_eq!(y.read_unaligned(), 12);
-    /// }
-    /// ```
+    /// [`ptr::write_unaligned`]: ./ptr/fn.write_unaligned.html
     #[stable(feature = "pointer_methods", since = "1.26.0")]
     #[inline]
     pub unsafe fn write_unaligned(self, val: T)
@@ -2609,10 +2224,9 @@ impl<T: ?Sized> *mut T {
     /// Replaces the value at `self` with `src`, returning the old
     /// value, without dropping either.
     ///
-    /// # Safety
+    /// See [`ptr::replace`] for safety concerns and examples.
     ///
-    /// This is only unsafe because it accepts a raw pointer.
-    /// Otherwise, this operation is identical to `mem::replace`.
+    /// [`ptr::replace`]: ./ptr/fn.replace.html
     #[stable(feature = "pointer_methods", since = "1.26.0")]
     #[inline]
     pub unsafe fn replace(self, src: T) -> T
@@ -2625,12 +2239,9 @@ impl<T: ?Sized> *mut T {
     /// deinitializing either. They may overlap, unlike `mem::swap` which is
     /// otherwise equivalent.
     ///
-    /// # Safety
+    /// See [`ptr::swap`] for safety concerns and examples.
     ///
-    /// This function copies the memory through the raw pointers passed to it
-    /// as arguments.
-    ///
-    /// Ensure that these pointers are valid before calling `swap`.
+    /// [`ptr::swap`]: ./ptr/fn.swap.html
     #[stable(feature = "pointer_methods", since = "1.26.0")]
     #[inline]
     pub unsafe fn swap(self, with: *mut T)

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -407,6 +407,7 @@ pub unsafe fn replace<T>(dest: *mut T, mut src: T) -> T {
 ///     // this point, `s` must no longer be used, as the underlying memory has
 ///     // been freed.
 ///     s2 = String::default();
+///     assert_eq!(s2, "");
 ///
 ///     // Assigning to `s` would cause the old value to be dropped again,
 ///     // resulting in undefined behavior.

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -24,8 +24,8 @@
 //! to access only a single value, in which case the documentation omits the size
 //! and implicitly assumes it to be `size_of::<T>()` bytes.
 //!
-//! While we can't yet define whether an arbitrary pointer is valid, there
-//! are a few rules regarding validity:
+//! The precise rules for validity are not determined yet.  The guarantees that are
+//! provided at this point are very minimal:
 //!
 //! * A [null] pointer is *never* valid, not even for accesses of [size zero][zst].
 //! * All pointers (except for the null pointer) are valid for all operations of
@@ -35,9 +35,8 @@
 //!   access the same memory.
 //!
 //! These axioms, along with careful use of [`offset`] for pointer arithmentic,
-//! are enough to correctly implement many useful things in unsafe code. Still,
-//! unsafe code should be carefully examined since some of the finer
-//! details—notably the [aliasing] rules—are not yet settled. For more
+//! are enough to correctly implement many useful things in unsafe code. Stronger guarantees
+//! will be provided eventually, as the [aliasing] rules are being determined. For more
 //! information, see the [book] as well as the section in the reference devoted
 //! to [undefined behavior][ub].
 //!

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -774,8 +774,8 @@ pub unsafe fn write_unaligned<T>(dst: *mut T, src: T) {
 /// to not be elided or reordered by the compiler across other volatile
 /// operations.
 ///
-/// Memory read with `read_volatile` should almost always be written to using
-/// [`write_volatile`].
+/// Memory accessed with `read_volatile` or [`write_volatile`] should not be
+/// accessed with non-volatile operations.
 ///
 /// [`write_volatile`]: ./fn.write_volatile.html
 ///
@@ -844,8 +844,8 @@ pub unsafe fn read_volatile<T>(src: *const T) -> T {
 /// to not be elided or reordered by the compiler across other volatile
 /// operations.
 ///
-/// Memory written with `write_volatile` should almost always be read from using
-/// [`read_volatile`].
+/// Memory accessed with [`read_volatile`] or `write_volatile` should not be
+/// accessed with non-volatile operations.
 ///
 /// `write_volatile` does not drop the contents of `dst`. This is safe, but it
 /// could leak allocations or resources, so care should be taken not to overwrite

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -40,7 +40,7 @@
 //!
 //! ## Alignment
 //!
-//! Valid pointers as defined above are not necessarily properly aligned (where
+//! Valid raw pointers as defined above are not necessarily properly aligned (where
 //! "proper" alignment is defind by the pointee type, i.e., `*const T` must be
 //! aligned to `mem::align_of::<T>()`). However, most functions require their
 //! arguments to be properly aligned, and will explicitly state

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -236,7 +236,7 @@ pub const fn null_mut<T>() -> *mut T { 0 as *mut T }
 ///
 /// * The two pointed-to values may overlap. If the values do overlap, then the
 ///   overlapping region of memory from `x` will be used. This is demonstrated
-///   in the examples below.
+///   in the second example below.
 ///
 /// [`mem::swap`]: ../mem/fn.swap.html
 ///
@@ -261,8 +261,8 @@ pub const fn null_mut<T>() -> *mut T { 0 as *mut T }
 ///
 /// let mut array = [0, 1, 2, 3];
 ///
-/// let x = array[0..].as_mut_ptr() as *mut [u32; 2];
-/// let y = array[2..].as_mut_ptr() as *mut [u32; 2];
+/// let x = array[0..].as_mut_ptr() as *mut [u32; 2]; // this is `array[0..2]`
+/// let y = array[2..].as_mut_ptr() as *mut [u32; 2]; // this is `array[2..4]`
 ///
 /// unsafe {
 ///     ptr::swap(x, y);
@@ -277,11 +277,16 @@ pub const fn null_mut<T>() -> *mut T { 0 as *mut T }
 ///
 /// let mut array = [0, 1, 2, 3];
 ///
-/// let x = array[0..].as_mut_ptr() as *mut [u32; 3];
-/// let y = array[1..].as_mut_ptr() as *mut [u32; 3];
+/// let x = array[0..].as_mut_ptr() as *mut [u32; 3]; // this is `array[0..3]`
+/// let y = array[1..].as_mut_ptr() as *mut [u32; 3]; // this is `array[1..4]`
 ///
 /// unsafe {
 ///     ptr::swap(x, y);
+///     // The indices `1..3` of the slice overlap between `x` and `y`.
+///     // Reasonable results would be for to them be `[2, 3]`, so that indices `0..3` are
+///     // `[1, 2, 3]` (matching `y` before the `swap`); or for them to be `[0, 1]`
+///     // so that indices `1..4` are `[0, 1, 2]` (matching `x` before the `swap`).
+///     // This implementation is defined to make the latter choice.
 ///     assert_eq!([1, 0, 1, 2], array);
 /// }
 /// ```

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -28,6 +28,12 @@
 //! * A [null] pointer is *never* valid, not even for accesses of [size zero][zst].
 //! * All pointers (except for the null pointer) are valid for all operations of
 //!   [size zero][zst].
+//! * All accesses performed by functions in this module are *non-atomic* in the sense
+//!   of [atomic operations] used to synchronize between threads. This means it is
+//!   undefined behavior to perform two concurrent accesses to the same location from different
+//!   threads unless both accesses only read from memory. Notice that this explicitly
+//!   includes [`read_volatile`] and [`write_volatile`]: Volatile accesses cannot
+//!   be used for inter-thread synchronization.
 //! * The result of casting a reference to a pointer is valid for as long as the
 //!   underlying object is live and no reference (just raw pointers) is used to
 //!   access the same memory.
@@ -56,10 +62,13 @@
 //! [ub]: ../../reference/behavior-considered-undefined.html
 //! [null]: ./fn.null.html
 //! [zst]: ../../nomicon/exotic-sizes.html#zero-sized-types-zsts
+//! [atomic operations]: ../../std/sync/atomic/index.html
 //! [`copy`]: ../../std/ptr/fn.copy.html
 //! [`offset`]: ../../std/primitive.pointer.html#method.offset
 //! [`read_unaligned`]: ./fn.read_unaligned.html
 //! [`write_unaligned`]: ./fn.write_unaligned.html
+//! [`read_volatile`]: ./fn.read_volatile.html
+//! [`write_volatile`]: ./fn.write_volatile.html
 //! [`NonNull::dangling`]: ./struct.NonNull.html#method.dangling
 
 #![stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -114,7 +114,7 @@ pub use intrinsics::write_bytes;
 /// again. [`write`] can be used to overwrite data without causing it to be
 /// dropped.
 ///
-/// These restrictions apply even if `T` has size `0`.
+/// Note that even if `T` has size `0`, the pointer must be non-NULL and properly aligned.
 ///
 /// [valid]: ../ptr/index.html#safety
 /// [`Copy`]: ../marker/trait.Copy.html
@@ -205,7 +205,7 @@ pub const fn null_mut<T>() -> *mut T { 0 as *mut T }
 ///
 /// * Both `x` and `y` must be properly aligned.
 ///
-/// These restrictions apply even if `T` has size `0`.
+/// Note that even if `T` has size `0`, the pointers must be non-NULL and properly aligned.
 ///
 /// [valid]: ../ptr/index.html#safety
 ///
@@ -274,7 +274,7 @@ pub unsafe fn swap<T>(x: *mut T, y: *mut T) {
 ///   size_of::<T>()` bytes must *not* overlap with the region of memory
 ///   beginning at `y` with the same size.
 ///
-/// These restrictions apply even if `T` has size `0`.
+/// Note that even if `T` has size `0`, the pointers must be non-NULL and properly aligned.
 ///
 /// [valid]: ../ptr/index.html#safety
 ///
@@ -387,7 +387,7 @@ unsafe fn swap_nonoverlapping_bytes(x: *mut u8, y: *mut u8, len: usize) {
 ///
 /// * `dest` must be properly aligned.
 ///
-/// These restrictions apply even if `T` has size `0`.
+/// Note that even if `T` has size `0`, the pointer must be non-NULL and properly aligned.
 ///
 /// [valid]: ../ptr/index.html#safety
 ///
@@ -426,7 +426,7 @@ pub unsafe fn replace<T>(dest: *mut T, mut src: T) -> T {
 /// * `src` must be properly aligned. Use [`read_unaligned`] if this is not the
 ///   case.
 ///
-/// These restrictions apply even if `T` has size `0`.
+/// Note that even if `T` has size `0`, the pointer must be non-NULL and properly aligned.
 ///
 /// ## Ownership of the Returned Value
 ///
@@ -542,7 +542,7 @@ pub unsafe fn read<T>(src: *const T) -> T {
 /// whether `T` is [`Copy`].  If `T` is not [`Copy`], using both the returned
 /// value and the value at `*src` can [violate memory safety][read-ownership].
 ///
-/// These restrictions apply even if `T` has size `0`.
+/// Note that even if `T` has size `0`, the pointer must be non-NULL and properly aligned.
 ///
 /// [`Copy`]: ../marker/trait.Copy.html
 /// [`read`]: ./fn.read.html
@@ -620,7 +620,7 @@ pub unsafe fn read_unaligned<T>(src: *const T) -> T {
 /// * `dst` must be properly aligned. Use [`write_unaligned`] if this is not the
 ///   case.
 ///
-/// These restrictions apply even if `T` has size `0`.
+/// Note that even if `T` has size `0`, the pointer must be non-NULL and properly aligned.
 ///
 /// [valid]: ../ptr/index.html#safety
 /// [`write_unaligned`]: ./fn.write_unaligned.html
@@ -693,7 +693,7 @@ pub unsafe fn write<T>(dst: *mut T, src: T) {
 ///
 /// * `dst` must be [valid] for writes.
 ///
-/// These restrictions apply even if `T` has size `0`.
+/// Note that even if `T` has size `0`, the pointer must be non-NULL and properly aligned.
 ///
 /// [valid]: ../ptr/index.html#safety
 ///
@@ -778,7 +778,7 @@ pub unsafe fn write_unaligned<T>(dst: *mut T, src: T) {
 /// However, storing non-[`Copy`] types in volatile memory is almost certainly
 /// incorrect.
 ///
-/// These restrictions apply even if `T` has size `0`.
+/// Note that even if `T` has size `0`, the pointer must be non-NULL and properly aligned.
 ///
 /// [valid]: ../ptr/index.html#safety
 /// [`Copy`]: ../marker/trait.Copy.html
@@ -849,7 +849,7 @@ pub unsafe fn read_volatile<T>(src: *const T) -> T {
 ///
 /// * `dst` must be properly aligned.
 ///
-/// These restrictions apply even if `T` has size `0`.
+/// Note that even if `T` has size `0`, the pointer must be non-NULL and properly aligned.
 ///
 /// [valid]: ../ptr/index.html#safety
 ///

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -10,9 +10,24 @@
 
 // FIXME: talk about offset, copy_memory, copy_nonoverlapping_memory
 
-//! Raw, unsafe pointers, `*const T`, and `*mut T`.
+//! Manually manage memory through raw pointers.
 //!
 //! *[See also the pointer primitive types](../../std/primitive.pointer.html).*
+//!
+//! # Safety
+//!
+//! Most functions in this module [dereference raw pointers].
+//!
+//! In order for a pointer dereference to be safe, the pointer must be "valid".
+//! A valid pointer is one that satisfies **all** of the following conditions:
+//!
+//! * The pointer is not null.
+//! * The pointer is not dangling (it does not point to memory which has been
+//!   freed).
+//! * The pointer satisfies [LLVM's pointer aliasing rules].
+//!
+//! [dereference raw pointers]: https://doc.rust-lang.org/book/second-edition/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer
+//! [LLVM's pointer aliasing rules]: https://llvm.org/docs/LangRef.html#pointer-aliasing-rules
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
@@ -38,21 +53,63 @@ pub use intrinsics::write_bytes;
 
 /// Executes the destructor (if any) of the pointed-to value.
 ///
-/// This has two use cases:
+/// This is semantically equivalent to calling [`ptr::read`] and discarding
+/// the result, but has the following advantages:
 ///
 /// * It is *required* to use `drop_in_place` to drop unsized types like
 ///   trait objects, because they can't be read out onto the stack and
 ///   dropped normally.
 ///
-/// * It is friendlier to the optimizer to do this over `ptr::read` when
+/// * It is friendlier to the optimizer to do this over [`ptr::read`] when
 ///   dropping manually allocated memory (e.g. when writing Box/Rc/Vec),
 ///   as the compiler doesn't need to prove that it's sound to elide the
 ///   copy.
 ///
+/// [`ptr::read`]: ../ptr/fn.read.html
+///
 /// # Safety
 ///
-/// This has all the same safety problems as `ptr::read` with respect to
-/// invalid pointers, types, and double drops.
+/// Behavior is undefined if any of the following conditions are violated:
+///
+/// * `to_drop` must be [valid].
+///
+/// * `to_drop` must be properly aligned.
+///
+/// Additionally, if `T` is not [`Copy`], using the pointed-to value after
+/// calling `drop_in_place` can cause undefined behavior. Note that `*to_drop =
+/// foo` counts as a use because it will cause the the value to be dropped
+/// again. [`write`] can be used to overwrite data without causing it to be
+/// dropped.
+///
+/// [valid]: ../ptr/index.html#safety
+/// [`Copy`]: ../marker/trait.Copy.html
+/// [`write`]: ../ptr/fn.write.html
+///
+/// # Examples
+///
+/// Manually remove the last item from a vector:
+///
+/// ```
+/// use std::ptr;
+/// use std::rc::Rc;
+///
+/// let last = Rc::new(1);
+/// let weak = Rc::downgrade(&last);
+///
+/// let mut v = vec![Rc::new(0), last];
+///
+/// unsafe {
+///     // Without a call `drop_in_place`, the last item would never be dropped,
+///     // and the memory it manages would be leaked.
+///     ptr::drop_in_place(&mut v[1]);
+///     v.set_len(1);
+/// }
+///
+/// assert_eq!(v, &[0.into()]);
+///
+/// // Ensure that the last item was dropped.
+/// assert!(weak.upgrade().is_none());
+/// ```
 #[stable(feature = "drop_in_place", since = "1.8.0")]
 #[lang = "drop_in_place"]
 #[allow(unconditional_recursion)]
@@ -93,17 +150,27 @@ pub const fn null_mut<T>() -> *mut T { 0 as *mut T }
 /// Swaps the values at two mutable locations of the same type, without
 /// deinitializing either.
 ///
-/// The values pointed at by `x` and `y` may overlap, unlike `mem::swap` which
-/// is otherwise equivalent. If the values do overlap, then the overlapping
-/// region of memory from `x` will be used. This is demonstrated in the
-/// examples section below.
+/// But for the following two exceptions, this function is semantically
+/// equivalent to [`mem::swap`]:
+///
+/// * It operates on raw pointers instead of references. When references are
+///   available, [`mem::swap`] should be preferred.
+///
+/// * The two pointed-to values may overlap. If the values do overlap, then the
+///   overlapping region of memory from `x` will be used. This is demonstrated
+///   in the examples below.
+///
+/// [`mem::swap`]: ../mem/fn.swap.html
 ///
 /// # Safety
 ///
-/// This function copies the memory through the raw pointers passed to it
-/// as arguments.
+/// Behavior is undefined if any of the following conditions are violated:
 ///
-/// Ensure that these pointers are valid before calling `swap`.
+/// * Both `x` and `y` must be [valid].
+///
+/// * Both `x` and `y` must be properly aligned.
+///
+/// [valid]: ../ptr/index.html#safety
 ///
 /// # Examples
 ///
@@ -256,10 +323,38 @@ unsafe fn swap_nonoverlapping_bytes(x: *mut u8, y: *mut u8, len: usize) {
 ///
 /// Neither value is dropped.
 ///
+/// This function is semantically equivalent to [`mem::replace`] except that it
+/// operates on raw pointers instead of references. When references are
+/// available, [`mem::replace`] should be preferred.
+///
+/// [`mem::replace`]: ../mem/fn.replace.html
+///
 /// # Safety
 ///
-/// This is only unsafe because it accepts a raw pointer.
-/// Otherwise, this operation is identical to `mem::replace`.
+/// Behavior is undefined if any of the following conditions are violated:
+///
+/// * `dest` must be [valid].
+///
+/// * `dest` must be properly aligned.
+///
+/// [valid]: ../ptr/index.html#safety
+///
+/// # Examples
+///
+/// ```
+/// use std::ptr;
+///
+/// let mut rust = vec!['b', 'u', 's', 't'];
+///
+/// // `mem::replace` would have the same effect without requiring the unsafe
+/// // block.
+/// let b = unsafe {
+///     ptr::replace(&mut rust[0], 'r')
+/// };
+///
+/// assert_eq!(b, 'b');
+/// assert_eq!(rust, &['r', 'u', 's', 't']);
+/// ```
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub unsafe fn replace<T>(dest: *mut T, mut src: T) -> T {
@@ -272,14 +367,52 @@ pub unsafe fn replace<T>(dest: *mut T, mut src: T) -> T {
 ///
 /// # Safety
 ///
-/// Beyond accepting a raw pointer, this is unsafe because it semantically
-/// moves the value out of `src` without preventing further usage of `src`.
-/// If `T` is not `Copy`, then care must be taken to ensure that the value at
-/// `src` is not used before the data is overwritten again (e.g. with `write`,
-/// `write_bytes`, or `copy`). Note that `*src = foo` counts as a use
-/// because it will attempt to drop the value previously at `*src`.
+/// Behavior is undefined if any of the following conditions are violated:
 ///
-/// The pointer must be aligned; use `read_unaligned` if that is not the case.
+/// * `src` must be [valid].
+///
+/// * `src` must be properly aligned. Use [`read_unaligned`] if this is not the
+///   case.
+///
+/// ## Ownership of the Returned Value
+///
+/// `read` creates a bitwise copy of `T`, regardless of whether `T` is [`Copy`].
+/// If `T` is not [`Copy`], using both the returned value and the value at
+/// `*src` can violate memory safety.  Note that assigning to `src` counts as a
+/// use because it will attempt to drop the value at `*src`.
+///
+/// [`write`] can be used to overwrite data without causing it to be dropped.
+///
+/// [valid]: ../ptr/index.html#safety
+/// [`Copy`]: ../marker/trait.Copy.html
+/// [`read_unaligned`]: ./fn.read_unaligned.html
+/// [`write`]: ./fn.write.html
+///
+/// ```
+/// use std::ptr;
+///
+/// let mut s = String::new("foo");
+/// unsafe {
+///     // `s2` now points to the same underlying memory as `s1`.
+///     let mut s2 = ptr::read(&s);
+///
+///     assert_eq!(s2, "foo");
+///
+///     // Assigning to `s2` causes its original value to be dropped. Beyond
+///     // this point, `s` must no longer be used, as the underlying memory has
+///     // been freed.
+///     s2 = String::default();
+///
+///     // Assigning to `s` would cause the old value to be dropped again,
+///     // resulting in undefined behavior.
+///     // s = String::new("bar"); // ERROR
+///
+///     // `ptr::write` can be used to overwrite a value without dropping it.
+///     ptr::write(&s, String::new("bar"));
+/// }
+///
+/// assert_eq!(s, "bar");
+/// ```
 ///
 /// # Examples
 ///
@@ -293,6 +426,44 @@ pub unsafe fn replace<T>(dest: *mut T, mut src: T) -> T {
 ///     assert_eq!(std::ptr::read(y), 12);
 /// }
 /// ```
+///
+/// Manually implement [`mem::swap`]:
+///
+/// ```
+/// use std::ptr;
+///
+/// fn swap<T>(a: &mut T, b: &mut T) {
+///     unsafe {
+///         // Create a bitwise copy of the value at `a` in `tmp`.
+///         let tmp = ptr::read(a);
+///
+///         // Exiting at this point (either by explicitly returning or by
+///         // calling a function which panics) would cause the value in `tmp` to
+///         // be dropped while the same value is still referenced by `a`. This
+///         // could trigger undefined behavior if `T` is not `Copy`.
+///
+///         // Create a bitwise copy of the value at `b` in `a`.
+///         // This is safe because mutable references cannot alias.
+///         ptr::copy_nonoverlapping(b, a, 1);
+///
+///         // As above, exiting here could trigger undefined behavior because
+///         // the same value is referenced by `a` and `b`.
+///
+///         // Move `tmp` into `b`.
+///         ptr::write(b, tmp);
+///     }
+/// }
+///
+/// let mut foo = "foo".to_owned();
+/// let mut bar = "bar".to_owned();
+///
+/// swap(&mut foo, &mut bar);
+///
+/// assert_eq!(foo, "bar");
+/// assert_eq!(bar, "foo");
+/// ```
+///
+/// [`mem::swap`]: ../mem/fn.swap.html
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub unsafe fn read<T>(src: *const T) -> T {
@@ -304,28 +475,59 @@ pub unsafe fn read<T>(src: *const T) -> T {
 /// Reads the value from `src` without moving it. This leaves the
 /// memory in `src` unchanged.
 ///
-/// Unlike `read`, the pointer may be unaligned.
+/// Unlike [`read`], `read_unaligned` works with unaligned pointers.
 ///
 /// # Safety
 ///
-/// Beyond accepting a raw pointer, this is unsafe because it semantically
-/// moves the value out of `src` without preventing further usage of `src`.
-/// If `T` is not `Copy`, then care must be taken to ensure that the value at
-/// `src` is not used before the data is overwritten again (e.g. with `write`,
-/// `write_bytes`, or `copy`). Note that `*src = foo` counts as a use
-/// because it will attempt to drop the value previously at `*src`.
+/// Behavior is undefined if any of the following conditions are violated:
+///
+/// * `src` must be [valid].
+///
+/// Like [`read`], `read_unaligned` creates a bitwise copy of `T`, regardless of
+/// whether `T` is [`Copy`].  If `T` is not [`Copy`], using both the returned
+/// value and the value at `*src` can [violate memory safety][read-ownership].
+///
+/// [`Copy`]: ../marker/trait.Copy.html
+/// [`read`]: ./fn.read.html
+/// [`write_unaligned`]: ./fn.write_unaligned.html
+/// [read-ownership]: ./fn.read.html#ownership-of-the-returned-value
+/// [valid]: ../ptr/index.html#safety
 ///
 /// # Examples
 ///
-/// Basic usage:
+/// Access members of a packed struct by reference:
 ///
 /// ```
-/// let x = 12;
-/// let y = &x as *const i32;
+/// use std::ptr;
 ///
-/// unsafe {
-///     assert_eq!(std::ptr::read_unaligned(y), 12);
+/// #[repr(packed, C)]
+/// #[derive(Default)]
+/// struct Packed {
+///     _padding: u8,
+///     unaligned: u32,
 /// }
+///
+/// let x = Packed {
+///     _padding: 0x00,
+///     unaligned: 0x01020304,
+/// };
+///
+/// let v = unsafe {
+///     // Take a reference to a 32-bit integer which is not aligned.
+///     let unaligned = &x.unaligned;
+///
+///     // Dereferencing normally will emit an unaligned load instruction,
+///     // causing undefined behavior.
+///     // let v = *unaligned; // ERROR
+///
+///     // Instead, use `read_unaligned` to read improperly aligned values.
+///     let v = ptr::read_unaligned(unaligned);
+///
+///     v
+/// };
+///
+/// // Accessing unaligned values directly is safe.
+/// assert!(x.unaligned == v);
 /// ```
 #[inline]
 #[stable(feature = "ptr_unaligned", since = "1.17.0")]
@@ -340,11 +542,7 @@ pub unsafe fn read_unaligned<T>(src: *const T) -> T {
 /// Overwrites a memory location with the given value without reading or
 /// dropping the old value.
 ///
-/// # Safety
-///
-/// This operation is marked unsafe because it accepts a raw pointer.
-///
-/// It does not drop the contents of `dst`. This is safe, but it could leak
+/// `write` does not drop the contents of `dst`. This is safe, but it could leak
 /// allocations or resources, so care must be taken not to overwrite an object
 /// that should be dropped.
 ///
@@ -352,9 +550,21 @@ pub unsafe fn read_unaligned<T>(src: *const T) -> T {
 /// location pointed to by `dst`.
 ///
 /// This is appropriate for initializing uninitialized memory, or overwriting
-/// memory that has previously been `read` from.
+/// memory that has previously been [`read`] from.
 ///
-/// The pointer must be aligned; use `write_unaligned` if that is not the case.
+/// [`read`]: ./fn.read.html
+///
+/// # Safety
+///
+/// Behavior is undefined if any of the following conditions are violated:
+///
+/// * `dst` must be [valid].
+///
+/// * `dst` must be properly aligned. Use [`write_unaligned`] if this is not the
+///   case.
+///
+/// [valid]: ../ptr/index.html#safety
+/// [`write_unaligned`]: ./fn.write_unaligned.html
 ///
 /// # Examples
 ///
@@ -370,6 +580,30 @@ pub unsafe fn read_unaligned<T>(src: *const T) -> T {
 ///     assert_eq!(std::ptr::read(y), 12);
 /// }
 /// ```
+///
+/// Manually implement [`mem::swap`]:
+///
+/// ```
+/// use std::ptr;
+///
+/// fn swap<T>(a: &mut T, b: &mut T) {
+///     unsafe {
+///         let tmp = ptr::read(a);
+///         ptr::copy_nonoverlapping(b, a, 1);
+///         ptr::write(b, tmp);
+///     }
+/// }
+///
+/// let mut foo = "foo".to_owned();
+/// let mut bar = "bar".to_owned();
+///
+/// swap(&mut foo, &mut bar);
+///
+/// assert_eq!(foo, "bar");
+/// assert_eq!(bar, "foo");
+/// ```
+///
+/// [`mem::swap`]: ../mem/fn.swap.html
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub unsafe fn write<T>(dst: *mut T, src: T) {
@@ -379,36 +613,60 @@ pub unsafe fn write<T>(dst: *mut T, src: T) {
 /// Overwrites a memory location with the given value without reading or
 /// dropping the old value.
 ///
-/// Unlike `write`, the pointer may be unaligned.
+/// Unlike [`write`], the pointer may be unaligned.
 ///
-/// # Safety
-///
-/// This operation is marked unsafe because it accepts a raw pointer.
-///
-/// It does not drop the contents of `dst`. This is safe, but it could leak
-/// allocations or resources, so care must be taken not to overwrite an object
-/// that should be dropped.
+/// `write_unaligned` does not drop the contents of `dst`. This is safe, but it
+/// could leak allocations or resources, so care must be taken not to overwrite
+/// an object that should be dropped.
 ///
 /// Additionally, it does not drop `src`. Semantically, `src` is moved into the
 /// location pointed to by `dst`.
 ///
 /// This is appropriate for initializing uninitialized memory, or overwriting
-/// memory that has previously been `read` from.
+/// memory that has previously been read with [`read_unaligned`].
+///
+/// [`write`]: ./fn.write.html
+/// [`read_unaligned`]: ./fn.read_unaligned.html
+///
+/// # Safety
+///
+/// Behavior is undefined if any of the following conditions are violated:
+///
+/// * `dst` must be [valid].
+///
+/// [valid]: ../ptr/index.html#safety
 ///
 /// # Examples
 ///
-/// Basic usage:
+/// Access fields in a packed struct:
 ///
 /// ```
-/// let mut x = 0;
-/// let y = &mut x as *mut i32;
-/// let z = 12;
+/// use std::{mem, ptr};
+///
+/// #[repr(packed, C)]
+/// #[derive(Default)]
+/// struct Packed {
+///     _padding: u8,
+///     unaligned: u32,
+/// }
+///
+/// let v = 0x01020304;
+/// let mut x: Packed = unsafe { mem::zeroed() };
 ///
 /// unsafe {
-///     std::ptr::write_unaligned(y, z);
-///     assert_eq!(std::ptr::read_unaligned(y), 12);
+///     // Take a reference to a 32-bit integer which is not aligned.
+///     let unaligned = &mut x.unaligned;
+///
+///     // Dereferencing normally will emit an unaligned store instruction,
+///     // causing undefined behavior.
+///     // *unaligned = v; // ERROR
+///
+///     // Instead, use `write_unaligned` to write improperly aligned values.
+///     ptr::write_unaligned(unaligned, v);
 /// }
-/// ```
+///
+/// // Accessing unaligned values directly is safe.
+/// assert!(x.unaligned == v);
 #[inline]
 #[stable(feature = "ptr_unaligned", since = "1.17.0")]
 pub unsafe fn write_unaligned<T>(dst: *mut T, src: T) {
@@ -424,6 +682,11 @@ pub unsafe fn write_unaligned<T>(dst: *mut T, src: T) {
 /// Volatile operations are intended to act on I/O memory, and are guaranteed
 /// to not be elided or reordered by the compiler across other volatile
 /// operations.
+///
+/// Memory read with `read_volatile` should almost always be written to using
+/// [`write_volatile`].
+///
+/// [`write_volatile`]: ./fn.write_volatile.html
 ///
 /// # Notes
 ///
@@ -441,12 +704,21 @@ pub unsafe fn write_unaligned<T>(dst: *mut T, src: T) {
 ///
 /// # Safety
 ///
-/// Beyond accepting a raw pointer, this is unsafe because it semantically
-/// moves the value out of `src` without preventing further usage of `src`.
-/// If `T` is not `Copy`, then care must be taken to ensure that the value at
-/// `src` is not used before the data is overwritten again (e.g. with `write`,
-/// `write_bytes`, or `copy`). Note that `*src = foo` counts as a use
-/// because it will attempt to drop the value previously at `*src`.
+/// Behavior is undefined if any of the following conditions are violated:
+///
+/// * `src` must be [valid].
+///
+/// * `src` must be properly aligned.
+///
+/// Like [`read`], `read_unaligned` creates a bitwise copy of `T`, regardless of
+/// whether `T` is [`Copy`].  If `T` is not [`Copy`], using both the returned
+/// value and the value at `*src` can [violate memory safety][read-ownership].
+/// However, storing non-[`Copy`] types in volatile memory is almost certainly
+/// incorrect.
+///
+/// [valid]: ../ptr/index.html#safety
+/// [`Copy`]: ../marker/trait.Copy.html
+/// [`read`]: ./fn.read.html
 ///
 /// Just like in C, whether an operation is volatile has no bearing whatsoever
 /// on questions involving concurrent access from multiple threads. Volatile
@@ -479,6 +751,18 @@ pub unsafe fn read_volatile<T>(src: *const T) -> T {
 /// to not be elided or reordered by the compiler across other volatile
 /// operations.
 ///
+/// Memory written with `write_volatile` should almost always be read from using
+/// [`read_volatile`].
+///
+/// `write_volatile` does not drop the contents of `dst`. This is safe, but it
+/// could leak allocations or resources, so care must be taken not to overwrite
+/// an object that should be dropped.
+///
+/// Additionally, it does not drop `src`. Semantically, `src` is moved into the
+/// location pointed to by `dst`.
+///
+/// [`read_volatile`]: ./fn.read_volatile.html
+///
 /// # Notes
 ///
 /// Rust does not currently have a rigorously and formally defined memory model,
@@ -495,14 +779,13 @@ pub unsafe fn read_volatile<T>(src: *const T) -> T {
 ///
 /// # Safety
 ///
-/// This operation is marked unsafe because it accepts a raw pointer.
+/// Behavior is undefined if any of the following conditions are violated:
 ///
-/// It does not drop the contents of `dst`. This is safe, but it could leak
-/// allocations or resources, so care must be taken not to overwrite an object
-/// that should be dropped.
+/// * `dst` must be [valid].
 ///
-/// This is appropriate for initializing uninitialized memory, or overwriting
-/// memory that has previously been `read` from.
+/// * `dst` must be properly aligned.
+///
+/// [valid]: ../ptr/index.html#safety
 ///
 /// Just like in C, whether an operation is volatile has no bearing whatsoever
 /// on questions involving concurrent access from multiple threads. Volatile

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -472,47 +472,6 @@ pub unsafe fn replace<T>(dst: *mut T, mut src: T) -> T {
 ///
 /// Note that even if `T` has size `0`, the pointer must be non-NULL and properly aligned.
 ///
-/// ## Ownership of the Returned Value
-///
-/// `read` creates a bitwise copy of `T`, regardless of whether `T` is [`Copy`].
-/// If `T` is not [`Copy`], using both the returned value and the value at
-/// `*src` can violate memory safety.  Note that assigning to `src` counts as a
-/// use because it will attempt to drop the value at `*src`.
-///
-/// [`write`] can be used to overwrite data without causing it to be dropped.
-///
-/// [valid]: ../ptr/index.html#safety
-/// [`Copy`]: ../marker/trait.Copy.html
-/// [`read_unaligned`]: ./fn.read_unaligned.html
-/// [`write`]: ./fn.write.html
-///
-/// ```
-/// use std::ptr;
-///
-/// let mut s = String::from("foo");
-/// unsafe {
-///     // `s2` now points to the same underlying memory as `s`.
-///     let mut s2: String = ptr::read(&s);
-///
-///     assert_eq!(s2, "foo");
-///
-///     // Assigning to `s2` causes its original value to be dropped. Beyond
-///     // this point, `s` must no longer be used, as the underlying memory has
-///     // been freed.
-///     s2 = String::default();
-///     assert_eq!(s2, "");
-///
-///     // Assigning to `s` would cause the old value to be dropped again,
-///     // resulting in undefined behavior.
-///     // s = String::from("bar"); // ERROR
-///
-///     // `ptr::write` can be used to overwrite a value without dropping it.
-///     ptr::write(&mut s, String::from("bar"));
-/// }
-///
-/// assert_eq!(s, "bar");
-/// ```
-///
 /// # Examples
 ///
 /// Basic usage:
@@ -565,7 +524,47 @@ pub unsafe fn replace<T>(dst: *mut T, mut src: T) -> T {
 /// assert_eq!(bar, "foo");
 /// ```
 ///
+/// ## Ownership of the Returned Value
+///
+/// `read` creates a bitwise copy of `T`, regardless of whether `T` is [`Copy`].
+/// If `T` is not [`Copy`], using both the returned value and the value at
+/// `*src` can violate memory safety.  Note that assigning to `*src` counts as a
+/// use because it will attempt to drop the value at `*src`.
+///
+/// [`write`] can be used to overwrite data without causing it to be dropped.
+///
+/// ```
+/// use std::ptr;
+///
+/// let mut s = String::from("foo");
+/// unsafe {
+///     // `s2` now points to the same underlying memory as `s`.
+///     let mut s2: String = ptr::read(&s);
+///
+///     assert_eq!(s2, "foo");
+///
+///     // Assigning to `s2` causes its original value to be dropped. Beyond
+///     // this point, `s` must no longer be used, as the underlying memory has
+///     // been freed.
+///     s2 = String::default();
+///     assert_eq!(s2, "");
+///
+///     // Assigning to `s` would cause the old value to be dropped again,
+///     // resulting in undefined behavior.
+///     // s = String::from("bar"); // ERROR
+///
+///     // `ptr::write` can be used to overwrite a value without dropping it.
+///     ptr::write(&mut s, String::from("bar"));
+/// }
+///
+/// assert_eq!(s, "bar");
+/// ```
+///
 /// [`mem::swap`]: ../mem/fn.swap.html
+/// [valid]: ../ptr/index.html#safety
+/// [`Copy`]: ../marker/trait.Copy.html
+/// [`read_unaligned`]: ./fn.read_unaligned.html
+/// [`write`]: ./fn.write.html
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub unsafe fn read<T>(src: *const T) -> T {

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -19,25 +19,38 @@
 //! Many functions in this module take raw pointers as arguments and dereference
 //! them. For this to be safe, these pointers must be valid. However, because
 //! rust does not yet have a formal memory model, determining whether an
-//! arbitrary pointer is a valid one can be tricky. One thing is certain:
-//! creating a raw pointer from a reference (e.g. `&x as *const _`) *always*
-//! results in a valid pointer. By exploiting this—and by taking care when
-//! using [pointer arithmetic]—users can be confident in the correctness of
-//! their unsafe code.
+//! arbitrary pointer is valid for a given operation can be tricky.
 //!
-//! For more information on dereferencing raw pointers, see the both the [book]
-//! and the section in the reference devoted to [undefined behavior][ub].
+//! There are two types of operations on memory, reads and writes. It is
+//! possible for a `*mut` to be valid for one operation and not the other. Since
+//! a `*const` can only be read and not written, it has no such ambiguity. For
+//! example, a `*mut` is not valid for writes if a a reference exists which
+//! [refers to the same memory][aliasing]. Therefore, each function in this
+//! module will document which operations must be valid on any `*mut` arguments.
+//!
+//! Additionally, some functions (e.g. [`copy`]) take a single pointer but
+//! operate on many values. In this case, the function will state the size of
+//! the operation for which the pointer must be valid. For example,
+//! `copy::<T>(&src, &mut dst, 3)` requires `dst` to be valid for writes of
+//! `size_of::<T>() * 3` bytes. When the documentation requires that a pointer
+//! be valid for an operation but omits the size of that operation, the size is
+//! implied to be `size_of::<T>()` bytes.
+//!
+//! For more information on the safety implications of dereferencing raw
+//! pointers, see the both the [book] and the section in the reference devoted
+//! to [undefined behavior][ub].
 //!
 //! ## Alignment
 //!
 //! Valid pointers are not necessarily properly aligned. However, most functions
 //! require their arguments to be properly aligned, and will explicitly state
-//! this requirement in the `Safety` section. Notable exceptions to this are
+//! this requirement in their documentation. Notable exceptions to this are
 //! [`read_unaligned`] and [`write_unaligned`].
 //!
-//! [ub]: ../../reference/behavior-considered-undefined.html
+//! [aliasing]: ../../nomicon/aliasing.html
 //! [book]: ../../book/second-edition/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer
-//! [pointer arithmetic]: ../../std/primitive.pointer.html#method.offset
+//! [ub]: ../../reference/behavior-considered-undefined.html
+//! [`copy`]: ./fn.copy.html
 //! [`read_unaligned`]: ./fn.read_unaligned.html
 //! [`write_unaligned`]: ./fn.write_unaligned.html
 
@@ -83,7 +96,7 @@ pub use intrinsics::write_bytes;
 ///
 /// Behavior is undefined if any of the following conditions are violated:
 ///
-/// * `to_drop` must be [valid].
+/// * `to_drop` must be [valid] for reads.
 ///
 /// * `to_drop` must be properly aligned.
 ///
@@ -178,7 +191,7 @@ pub const fn null_mut<T>() -> *mut T { 0 as *mut T }
 ///
 /// Behavior is undefined if any of the following conditions are violated:
 ///
-/// * Both `x` and `y` must be [valid].
+/// * Both `x` and `y` must be [valid] for reads and writes.
 ///
 /// * Both `x` and `y` must be properly aligned.
 ///
@@ -240,17 +253,14 @@ pub unsafe fn swap<T>(x: *mut T, y: *mut T) {
 ///
 /// Behavior is undefined if any of the following conditions are violated:
 ///
+/// * Both `x` and `y` must be [valid] for reads and writes of `count *
+///   size_of::<T>()` bytes.
+///
 /// * Both `x` and `y` must be properly aligned.
 ///
-/// * `x.offset(i)` must be [valid] for all `i` in `0..count`. In other words,
-///   the region of memory which begins at `x` and has a length of `count *
-///   size_of::<T>()` bytes must belong to a single, live allocation.
-///
-/// * `y.offset(i)` must be [valid] for all `i` in `0..count`. In other words,
-///   the region of memory which begins at `y` and has a length of `count *
-///   size_of::<T>()` bytes must belong to a single, live allocation.
-///
-/// * The two regions of memory must *not* overlap.
+/// * The region of memory beginning at `x` with a size of `count *
+///   size_of::<T>()` bytes must *not* overlap with the region of memory
+///   beginning at `y` with the same size.
 ///
 /// [valid]: ../ptr/index.html#safety
 ///
@@ -359,7 +369,7 @@ unsafe fn swap_nonoverlapping_bytes(x: *mut u8, y: *mut u8, len: usize) {
 ///
 /// Behavior is undefined if any of the following conditions are violated:
 ///
-/// * `dest` must be [valid].
+/// * `dest` must be [valid] for writes.
 ///
 /// * `dest` must be properly aligned.
 ///
@@ -395,7 +405,7 @@ pub unsafe fn replace<T>(dest: *mut T, mut src: T) -> T {
 ///
 /// Behavior is undefined if any of the following conditions are violated:
 ///
-/// * `src` must be [valid].
+/// * `src` must be [valid] for reads.
 ///
 /// * `src` must be properly aligned. Use [`read_unaligned`] if this is not the
 ///   case.
@@ -508,7 +518,7 @@ pub unsafe fn read<T>(src: *const T) -> T {
 ///
 /// Behavior is undefined if any of the following conditions are violated:
 ///
-/// * `src` must be [valid].
+/// * `src` must be [valid] for reads.
 ///
 /// Like [`read`], `read_unaligned` creates a bitwise copy of `T`, regardless of
 /// whether `T` is [`Copy`].  If `T` is not [`Copy`], using both the returned
@@ -585,7 +595,7 @@ pub unsafe fn read_unaligned<T>(src: *const T) -> T {
 ///
 /// Behavior is undefined if any of the following conditions are violated:
 ///
-/// * `dst` must be [valid].
+/// * `dst` must be [valid] for writes.
 ///
 /// * `dst` must be properly aligned. Use [`write_unaligned`] if this is not the
 ///   case.
@@ -659,7 +669,7 @@ pub unsafe fn write<T>(dst: *mut T, src: T) {
 ///
 /// Behavior is undefined if any of the following conditions are violated:
 ///
-/// * `dst` must be [valid].
+/// * `dst` must be [valid] for writes.
 ///
 /// [valid]: ../ptr/index.html#safety
 ///
@@ -734,7 +744,7 @@ pub unsafe fn write_unaligned<T>(dst: *mut T, src: T) {
 ///
 /// Behavior is undefined if any of the following conditions are violated:
 ///
-/// * `src` must be [valid].
+/// * `src` must be [valid] for reads.
 ///
 /// * `src` must be properly aligned.
 ///
@@ -809,7 +819,7 @@ pub unsafe fn read_volatile<T>(src: *const T) -> T {
 ///
 /// Behavior is undefined if any of the following conditions are violated:
 ///
-/// * `dst` must be [valid].
+/// * `dst` must be [valid] for writes.
 ///
 /// * `dst` must be properly aligned.
 ///

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -396,7 +396,7 @@ pub unsafe fn replace<T>(dest: *mut T, mut src: T) -> T {
 /// ```
 /// use std::ptr;
 ///
-/// let mut s = String::new("foo");
+/// let mut s = String::from("foo");
 /// unsafe {
 ///     // `s2` now points to the same underlying memory as `s1`.
 ///     let mut s2 = ptr::read(&s);
@@ -410,10 +410,10 @@ pub unsafe fn replace<T>(dest: *mut T, mut src: T) -> T {
 ///
 ///     // Assigning to `s` would cause the old value to be dropped again,
 ///     // resulting in undefined behavior.
-///     // s = String::new("bar"); // ERROR
+///     // s = String::from("bar"); // ERROR
 ///
 ///     // `ptr::write` can be used to overwrite a value without dropping it.
-///     ptr::write(&s, String::new("bar"));
+///     ptr::write(&mut s, String::from("bar"));
 /// }
 ///
 /// assert_eq!(s, "bar");

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -274,7 +274,8 @@ pub unsafe fn swap<T>(x: *mut T, y: *mut T) {
 ///   size_of::<T>()` bytes must *not* overlap with the region of memory
 ///   beginning at `y` with the same size.
 ///
-/// Note that even if `T` has size `0`, the pointers must be non-NULL and properly aligned.
+/// Note that even if the effectively copied size (`count * size_of::<T>()`) is `0`,
+/// the pointers must be non-NULL and properly aligned.
 ///
 /// [valid]: ../ptr/index.html#safety
 ///
@@ -369,7 +370,7 @@ unsafe fn swap_nonoverlapping_bytes(x: *mut u8, y: *mut u8, len: usize) {
     }
 }
 
-/// Moves `src` into the pointed `dest`, returning the previous `dest` value.
+/// Moves `src` into the pointed `dst`, returning the previous `dst` value.
 ///
 /// Neither value is dropped.
 ///
@@ -383,9 +384,9 @@ unsafe fn swap_nonoverlapping_bytes(x: *mut u8, y: *mut u8, len: usize) {
 ///
 /// Behavior is undefined if any of the following conditions are violated:
 ///
-/// * `dest` must be [valid] for writes.
+/// * `dst` must be [valid] for writes.
 ///
-/// * `dest` must be properly aligned.
+/// * `dst` must be properly aligned.
 ///
 /// Note that even if `T` has size `0`, the pointer must be non-NULL and properly aligned.
 ///
@@ -409,8 +410,8 @@ unsafe fn swap_nonoverlapping_bytes(x: *mut u8, y: *mut u8, len: usize) {
 /// ```
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
-pub unsafe fn replace<T>(dest: *mut T, mut src: T) -> T {
-    mem::swap(&mut *dest, &mut src); // cannot overlap
+pub unsafe fn replace<T>(dst: *mut T, mut src: T) -> T {
+    mem::swap(&mut *dst, &mut src); // cannot overlap
     src
 }
 
@@ -447,8 +448,8 @@ pub unsafe fn replace<T>(dest: *mut T, mut src: T) -> T {
 ///
 /// let mut s = String::from("foo");
 /// unsafe {
-///     // `s2` now points to the same underlying memory as `s1`.
-///     let mut s2 = ptr::read(&s);
+///     // `s2` now points to the same underlying memory as `s`.
+///     let mut s2: String = ptr::read(&s);
 ///
 ///     assert_eq!(s2, "foo");
 ///
@@ -558,7 +559,6 @@ pub unsafe fn read<T>(src: *const T) -> T {
 /// use std::ptr;
 ///
 /// #[repr(packed, C)]
-/// #[derive(Default)]
 /// struct Packed {
 ///     _padding: u8,
 ///     unaligned: u32,
@@ -570,10 +570,11 @@ pub unsafe fn read<T>(src: *const T) -> T {
 /// };
 ///
 /// let v = unsafe {
-///     // Take a reference to a 32-bit integer which is not aligned.
-///     let unaligned = &x.unaligned;
+///     // Take the address of a 32-bit integer which is not aligned.
+///     // This must be done as a raw pointer; unaligned references are invalid.
+///     let unaligned = &x.unaligned as *const u32;
 ///
-///     // Dereferencing normally will emit an unaligned load instruction,
+///     // Dereferencing normally will emit an aligned load instruction,
 ///     // causing undefined behavior.
 ///     // let v = *unaligned; // ERROR
 ///

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -136,12 +136,14 @@ pub use intrinsics::write_bytes;
 /// let mut v = vec![Rc::new(0), last];
 ///
 /// unsafe {
+///     // Get a raw pointer to the last element in `v`.
+///     let ptr = &mut v[1] as *mut _;
 ///     // Shorten `v` to prevent the last item from being dropped.  We do that first,
 ///     // to prevent issues if the `drop_in_place` below panics.
 ///     v.set_len(1);
 ///     // Without a call `drop_in_place`, the last item would never be dropped,
 ///     // and the memory it manages would be leaked.
-///     ptr::drop_in_place(&mut v[1]);
+///     ptr::drop_in_place(ptr);
 /// }
 ///
 /// assert_eq!(v, &[0.into()]);

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// FIXME: talk about offset, copy_memory, copy_nonoverlapping_memory
-
 //! Manually manage memory through raw pointers.
 //!
 //! *[See also the pointer primitive types](../../std/primitive.pointer.html).*
@@ -42,8 +40,10 @@
 //!
 //! ## Alignment
 //!
-//! Valid pointers are not necessarily properly aligned. However, most functions
-//! require their arguments to be properly aligned, and will explicitly state
+//! Valid pointers as defined above are not necessarily properly aligned (where
+//! "proper" alignment is defind by the pointee type, i.e., `*const T` must be
+//! aligned to `mem::align_of::<T>()`). However, most functions require their
+//! arguments to be properly aligned, and will explicitly state
 //! this requirement in their documentation. Notable exceptions to this are
 //! [`read_unaligned`] and [`write_unaligned`].
 //!
@@ -136,11 +136,12 @@ pub use intrinsics::write_bytes;
 /// let mut v = vec![Rc::new(0), last];
 ///
 /// unsafe {
+///     // Shorten `v` to prevent the last item from being dropped.  We do that first,
+///     // to prevent issues if the `drop_in_place` below panics.
+///     v.set_len(1);
 ///     // Without a call `drop_in_place`, the last item would never be dropped,
 ///     // and the memory it manages would be leaked.
 ///     ptr::drop_in_place(&mut v[1]);
-///     // Shorten `v` to prevent the last item from being dropped.
-///     v.set_len(1);
 /// }
 ///
 /// assert_eq!(v, &[0.into()]);
@@ -745,7 +746,7 @@ pub unsafe fn write<T>(dst: *mut T, src: T) {
 ///
 /// unsafe {
 ///     // Take a reference to a 32-bit integer which is not aligned.
-///     let unaligned = &mut x.unaligned;
+///     let unaligned = &mut x.unaligned as *mut u32;
 ///
 ///     // Dereferencing normally will emit an unaligned store instruction,
 ///     // causing undefined behavior.

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -149,7 +149,8 @@ pub use intrinsics::write_bytes;
 /// assert!(weak.upgrade().is_none());
 /// ```
 ///
-/// Drops a potentially unaligned value by copying it to aligned memory first:
+/// Unaligned values cannot be dropped in place, they must be copied to an aligned
+/// location first:
 /// ```
 /// use std::ptr;
 /// use std::mem;
@@ -158,7 +159,7 @@ pub use intrinsics::write_bytes;
 ///     let mut copy: T = mem::uninitialized();
 ///     let copy = &mut copy as *mut T;
 ///     ptr::copy(to_drop, copy, 1);
-///     ptr::drop_in_place(copy);
+///     drop(copy);
 /// }
 ///
 /// #[repr(packed, C)]

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -157,8 +157,7 @@ pub use intrinsics::write_bytes;
 ///
 /// unsafe fn drop_after_copy<T>(to_drop: *mut T) {
 ///     let mut copy: T = mem::uninitialized();
-///     let copy = &mut copy as *mut T;
-///     ptr::copy(to_drop, copy, 1);
+///     ptr::copy(to_drop, &mut copy, 1);
 ///     drop(copy);
 /// }
 ///

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -47,7 +47,7 @@
 //! ## Alignment
 //!
 //! Valid raw pointers as defined above are not necessarily properly aligned (where
-//! "proper" alignment is defind by the pointee type, i.e., `*const T` must be
+//! "proper" alignment is defined by the pointee type, i.e., `*const T` must be
 //! aligned to `mem::align_of::<T>()`). However, most functions require their
 //! arguments to be properly aligned, and will explicitly state
 //! this requirement in their documentation. Notable exceptions to this are


### PR DESCRIPTION
This takes over https://github.com/rust-lang/rust/pull/51016 by @ecstatic-morse. They did most of the work, I just did some editing.

However, I realized one problem: This updates the docs for the "free functions" in `core::ptr`, but it does not update the copies of these docs for the inherent methods of the `*const T` and `*mut T` types. These getting out-of-sync is certainly bad, but I also don't feel like copying all this stuff around. Instead, we should remove this redundancy. Any good ideas?