### PR TITLE
don't elide lifetimes in paths in librustc/

### DIFF
--- a/src/librustc/dep_graph/dep_node.rs
+++ b/src/librustc/dep_graph/dep_node.rs
@@ -331,7 +331,7 @@ macro_rules! define_dep_nodes {
             /// refers to something from the previous compilation session that
             /// has been removed.
             #[inline]
-            pub fn extract_def_id(&self, tcx: TyCtxt) -> Option<DefId> {
+            pub fn extract_def_id(&self, tcx: TyCtxt<'_, '_, '_>) -> Option<DefId> {
                 if self.kind.can_reconstruct_query_key() {
                     let def_path_hash = DefPathHash(self.hash);
                     tcx.def_path_hash_to_def_id.as_ref()?
@@ -386,7 +386,7 @@ macro_rules! define_dep_nodes {
 }
 
 impl fmt::Debug for DepNode {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:?}", self.kind)?;
 
         if !self.kind.has_params() && !self.kind.is_anon() {
@@ -424,7 +424,7 @@ impl DefPathHash {
 
 impl DefId {
     #[inline]
-    pub fn to_dep_node(self, tcx: TyCtxt, kind: DepKind) -> DepNode {
+    pub fn to_dep_node(self, tcx: TyCtxt<'_, '_, '_>, kind: DepKind) -> DepNode {
         DepNode::from_def_path_hash(kind, tcx.def_path_hash(self))
     }
 }
@@ -714,7 +714,7 @@ impl<'a, 'gcx: 'tcx + 'a, 'tcx: 'a, T> DepNodeParams<'a, 'gcx, 'tcx> for T
 impl<'a, 'gcx: 'tcx + 'a, 'tcx: 'a> DepNodeParams<'a, 'gcx, 'tcx> for DefId {
     const CAN_RECONSTRUCT_QUERY_KEY: bool = true;
 
-    fn to_fingerprint(&self, tcx: TyCtxt) -> Fingerprint {
+    fn to_fingerprint(&self, tcx: TyCtxt<'_, '_, '_>) -> Fingerprint {
         tcx.def_path_hash(*self).0
     }
 
@@ -726,7 +726,7 @@ impl<'a, 'gcx: 'tcx + 'a, 'tcx: 'a> DepNodeParams<'a, 'gcx, 'tcx> for DefId {
 impl<'a, 'gcx: 'tcx + 'a, 'tcx: 'a> DepNodeParams<'a, 'gcx, 'tcx> for DefIndex {
     const CAN_RECONSTRUCT_QUERY_KEY: bool = true;
 
-    fn to_fingerprint(&self, tcx: TyCtxt) -> Fingerprint {
+    fn to_fingerprint(&self, tcx: TyCtxt<'_, '_, '_>) -> Fingerprint {
         tcx.hir.definitions().def_path_hash(*self).0
     }
 
@@ -738,7 +738,7 @@ impl<'a, 'gcx: 'tcx + 'a, 'tcx: 'a> DepNodeParams<'a, 'gcx, 'tcx> for DefIndex {
 impl<'a, 'gcx: 'tcx + 'a, 'tcx: 'a> DepNodeParams<'a, 'gcx, 'tcx> for CrateNum {
     const CAN_RECONSTRUCT_QUERY_KEY: bool = true;
 
-    fn to_fingerprint(&self, tcx: TyCtxt) -> Fingerprint {
+    fn to_fingerprint(&self, tcx: TyCtxt<'_, '_, '_>) -> Fingerprint {
         let def_id = DefId {
             krate: *self,
             index: CRATE_DEF_INDEX,
@@ -757,7 +757,7 @@ impl<'a, 'gcx: 'tcx + 'a, 'tcx: 'a> DepNodeParams<'a, 'gcx, 'tcx> for (DefId, De
     // We actually would not need to specialize the implementation of this
     // method but it's faster to combine the hashes than to instantiate a full
     // hashing context and stable-hashing state.
-    fn to_fingerprint(&self, tcx: TyCtxt) -> Fingerprint {
+    fn to_fingerprint(&self, tcx: TyCtxt<'_, '_, '_>) -> Fingerprint {
         let (def_id_0, def_id_1) = *self;
 
         let def_path_hash_0 = tcx.def_path_hash(def_id_0);
@@ -781,7 +781,7 @@ impl<'a, 'gcx: 'tcx + 'a, 'tcx: 'a> DepNodeParams<'a, 'gcx, 'tcx> for HirId {
     // We actually would not need to specialize the implementation of this
     // method but it's faster to combine the hashes than to instantiate a full
     // hashing context and stable-hashing state.
-    fn to_fingerprint(&self, tcx: TyCtxt) -> Fingerprint {
+    fn to_fingerprint(&self, tcx: TyCtxt<'_, '_, '_>) -> Fingerprint {
         let HirId {
             owner,
             local_id: ItemLocalId(local_id),

--- a/src/librustc/hir/def_id.rs
+++ b/src/librustc/hir/def_id.rs
@@ -36,7 +36,7 @@ pub enum CrateNum {
 }
 
 impl ::std::fmt::Debug for CrateNum {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
             CrateNum::Index(id) => write!(fmt, "crate{}", id.private),
             CrateNum::Invalid => write!(fmt, "invalid crate"),
@@ -97,7 +97,7 @@ impl CrateNum {
 }
 
 impl fmt::Display for CrateNum {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             CrateNum::Index(id) => fmt::Display::fmt(&id.private, f),
             CrateNum::Invalid => write!(f, "invalid crate"),
@@ -132,7 +132,7 @@ pub struct DefIndex(u32);
 pub const CRATE_DEF_INDEX: DefIndex = DefIndex(0);
 
 impl fmt::Debug for DefIndex {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f,
                "DefIndex({}:{})",
                self.address_space().index(),
@@ -224,7 +224,7 @@ pub struct DefId {
 }
 
 impl fmt::Debug for DefId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "DefId({:?}/{}:{}",
                self.krate.index(),
                self.index.address_space().index(),
@@ -288,7 +288,7 @@ impl LocalDefId {
 }
 
 impl fmt::Debug for LocalDefId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.to_def_id().fmt(f)
     }
 }

--- a/src/librustc/hir/map/blocks.rs
+++ b/src/librustc/hir/map/blocks.rs
@@ -143,7 +143,7 @@ impl<'a> ClosureParts<'a> {
 
 impl<'a> FnLikeNode<'a> {
     /// Attempts to construct a FnLikeNode from presumed FnLike node input.
-    pub fn from_node(node: Node) -> Option<FnLikeNode> {
+    pub fn from_node(node: Node<'_>) -> Option<FnLikeNode<'_>> {
         let fn_like = match node {
             map::Node::Item(item) => item.is_fn_like(),
             map::Node::TraitItem(tm) => tm.is_fn_like(),
@@ -173,15 +173,15 @@ impl<'a> FnLikeNode<'a> {
     }
 
     pub fn span(self) -> Span {
-        self.handle(|i: ItemFnParts| i.span,
+        self.handle(|i: ItemFnParts<'_>| i.span,
                     |_, _, _: &'a ast::MethodSig, _, _, span, _| span,
-                    |c: ClosureParts| c.span)
+                    |c: ClosureParts<'_>| c.span)
     }
 
     pub fn id(self) -> NodeId {
-        self.handle(|i: ItemFnParts| i.id,
+        self.handle(|i: ItemFnParts<'_>| i.id,
                     |id, _, _: &'a ast::MethodSig, _, _, _, _| id,
-                    |c: ClosureParts| c.id)
+                    |c: ClosureParts<'_>| c.id)
     }
 
     pub fn constness(self) -> ast::Constness {

--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -668,7 +668,7 @@ impl<'hir> Map<'hir> {
     /// }
     /// ```
     pub fn get_return_block(&self, id: NodeId) -> Option<NodeId> {
-        let match_fn = |node: &Node| {
+        let match_fn = |node: &Node<'_>| {
             match *node {
                 Node::Item(_) |
                 Node::ForeignItem(_) |
@@ -677,7 +677,7 @@ impl<'hir> Map<'hir> {
                 _ => false,
             }
         };
-        let match_non_returning_block = |node: &Node| {
+        let match_non_returning_block = |node: &Node<'_>| {
             match *node {
                 Node::Expr(ref expr) => {
                     match expr.node {
@@ -954,7 +954,7 @@ impl<'a, 'hir> NodesMatchingSuffix<'a, 'hir> {
         // If `id` itself is a mod named `m` with parent `p`, then
         // returns `Some(id, m, p)`.  If `id` has no mod in its parent
         // chain, then returns `None`.
-        fn find_first_mod_parent<'a>(map: &'a Map, mut id: NodeId) -> Option<(NodeId, Name)> {
+        fn find_first_mod_parent<'a>(map: &'a Map<'_>, mut id: NodeId) -> Option<(NodeId, Name)> {
             loop {
                 if let Node::Item(item) = map.find(id)? {
                     if item_is_mod(&item) {
@@ -1076,7 +1076,7 @@ pub fn map_crate<'hir>(sess: &::session::Session,
 /// Identical to the `PpAnn` implementation for `hir::Crate`,
 /// except it avoids creating a dependency on the whole crate.
 impl<'hir> print::PpAnn for Map<'hir> {
-    fn nested(&self, state: &mut print::State, nested: print::Nested) -> io::Result<()> {
+    fn nested(&self, state: &mut print::State<'_>, nested: print::Nested) -> io::Result<()> {
         match nested {
             Nested::Item(id) => state.print_item(self.expect_item(id.id)),
             Nested::TraitItem(id) => state.print_trait_item(self.trait_item(id)),
@@ -1088,7 +1088,7 @@ impl<'hir> print::PpAnn for Map<'hir> {
 }
 
 impl<'a> print::State<'a> {
-    pub fn print_node(&mut self, node: Node) -> io::Result<()> {
+    pub fn print_node(&mut self, node: Node<'_>) -> io::Result<()> {
         match node {
             Node::Item(a)         => self.print_item(&a),
             Node::ForeignItem(a)  => self.print_foreign_item(&a),
@@ -1126,7 +1126,7 @@ impl<'a> print::State<'a> {
     }
 }
 
-fn node_id_to_string(map: &Map, id: NodeId, include_id: bool) -> String {
+fn node_id_to_string(map: &Map<'_>, id: NodeId, include_id: bool) -> String {
     let id_str = format!(" (id={})", id);
     let id_str = if include_id { &id_str[..] } else { "" };
 
@@ -1253,7 +1253,7 @@ fn node_id_to_string(map: &Map, id: NodeId, include_id: bool) -> String {
     }
 }
 
-pub fn describe_def(tcx: TyCtxt, def_id: DefId) -> Option<Def> {
+pub fn describe_def(tcx: TyCtxt<'_, '_, '_>, def_id: DefId) -> Option<Def> {
     if let Some(node_id) = tcx.hir.as_local_node_id(def_id) {
         tcx.hir.describe_def(node_id)
     } else {

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -170,7 +170,7 @@ pub struct Label {
 }
 
 impl fmt::Debug for Label {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "label({:?})", self.ident)
     }
 }
@@ -277,13 +277,13 @@ impl LifetimeName {
 }
 
 impl fmt::Display for Lifetime {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.name.ident().fmt(f)
     }
 }
 
 impl fmt::Debug for Lifetime {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f,
                "lifetime({}: {})",
                self.id,
@@ -320,13 +320,13 @@ impl Path {
 }
 
 impl fmt::Debug for Path {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "path({})", print::to_string(print::NO_ANN, |s| s.print_path(self, false)))
     }
 }
 
 impl fmt::Display for Path {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", print::to_string(print::NO_ANN, |s| s.print_path(self, false)))
     }
 }
@@ -804,7 +804,7 @@ pub struct Pat {
 }
 
 impl fmt::Debug for Pat {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "pat({}: {})", self.id,
                print::to_string(print::NO_ANN, |s| s.print_pat(self)))
     }
@@ -1120,7 +1120,7 @@ impl UnOp {
 pub type Stmt = Spanned<StmtKind>;
 
 impl fmt::Debug for StmtKind {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // Sadness.
         let spanned = source_map::dummy_spanned(self.clone());
         write!(f,
@@ -1348,7 +1348,7 @@ impl Expr {
 }
 
 impl fmt::Debug for Expr {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "expr({}: {})", self.id,
                print::to_string(print::NO_ANN, |s| s.print_expr(self)))
     }
@@ -1521,7 +1521,7 @@ pub enum LoopIdError {
 }
 
 impl fmt::Display for LoopIdError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(match *self {
             LoopIdError::OutsideLoopScope => "not inside loop scope",
             LoopIdError::UnlabeledCfInWhileCondition =>
@@ -1668,7 +1668,7 @@ pub struct Ty {
 }
 
 impl fmt::Debug for Ty {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "type({})",
                print::to_string(print::NO_ANN, |s| s.print_type(self)))
     }
@@ -1826,7 +1826,7 @@ impl Defaultness {
 }
 
 impl fmt::Display for Unsafety {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(match *self {
                               Unsafety::Normal => "normal",
                               Unsafety::Unsafe => "unsafe",
@@ -1844,7 +1844,7 @@ pub enum ImplPolarity {
 }
 
 impl fmt::Debug for ImplPolarity {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             ImplPolarity::Positive => "positive".fmt(f),
             ImplPolarity::Negative => "negative".fmt(f),
@@ -2284,7 +2284,8 @@ pub type TraitMap = NodeMap<Vec<TraitCandidate>>;
 // imported.
 pub type GlobMap = NodeMap<FxHashSet<Name>>;
 
-pub fn provide(providers: &mut Providers) {
+
+pub fn provide(providers: &mut Providers<'_>) {
     providers.describe_def = map::describe_def;
 }
 

--- a/src/librustc/hir/print.rs
+++ b/src/librustc/hir/print.rs
@@ -48,13 +48,13 @@ pub enum Nested {
 }
 
 pub trait PpAnn {
-    fn nested(&self, _state: &mut State, _nested: Nested) -> io::Result<()> {
+    fn nested(&self, _state: &mut State<'_>, _nested: Nested) -> io::Result<()> {
         Ok(())
     }
-    fn pre(&self, _state: &mut State, _node: AnnNode) -> io::Result<()> {
+    fn pre(&self, _state: &mut State<'_>, _node: AnnNode<'_>) -> io::Result<()> {
         Ok(())
     }
-    fn post(&self, _state: &mut State, _node: AnnNode) -> io::Result<()> {
+    fn post(&self, _state: &mut State<'_>, _node: AnnNode<'_>) -> io::Result<()> {
         Ok(())
     }
     fn try_fetch_item(&self, _: ast::NodeId) -> Option<&hir::Item> {
@@ -70,7 +70,7 @@ impl PpAnn for hir::Crate {
     fn try_fetch_item(&self, item: ast::NodeId) -> Option<&hir::Item> {
         Some(self.item(item))
     }
-    fn nested(&self, state: &mut State, nested: Nested) -> io::Result<()> {
+    fn nested(&self, state: &mut State<'_>, nested: Nested) -> io::Result<()> {
         match nested {
             Nested::Item(id) => state.print_item(self.item(id.id)),
             Nested::TraitItem(id) => state.print_trait_item(self.trait_item(id)),
@@ -190,7 +190,7 @@ impl<'a> State<'a> {
 }
 
 pub fn to_string<F>(ann: &dyn PpAnn, f: F) -> String
-    where F: FnOnce(&mut State) -> io::Result<()>
+    where F: FnOnce(&mut State<'_>) -> io::Result<()>
 {
     let mut wr = Vec::new();
     {
@@ -314,7 +314,7 @@ impl<'a> State<'a> {
                                   mut op: F,
                                   mut get_span: G)
                                   -> io::Result<()>
-        where F: FnMut(&mut State, &T) -> io::Result<()>,
+        where F: FnMut(&mut State<'_>, &T) -> io::Result<()>,
               G: FnMut(&T) -> syntax_pos::Span
     {
         self.rbox(0, b)?;

--- a/src/librustc/infer/error_reporting/mod.rs
+++ b/src/librustc/infer/error_reporting/mod.rs
@@ -82,7 +82,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
     pub fn note_and_explain_region(
         self,
         region_scope_tree: &region::ScopeTree,
-        err: &mut DiagnosticBuilder,
+        err: &mut DiagnosticBuilder<'_>,
         prefix: &str,
         region: ty::Region<'tcx>,
         suffix: &str,
@@ -162,7 +162,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
 
     pub fn note_and_explain_free_region(
         self,
-        err: &mut DiagnosticBuilder,
+        err: &mut DiagnosticBuilder<'_>,
         prefix: &str,
         region: ty::Region<'tcx>,
         suffix: &str,
@@ -242,7 +242,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
     }
 
     fn emit_msg_span(
-        err: &mut DiagnosticBuilder,
+        err: &mut DiagnosticBuilder<'_>,
         prefix: &str,
         description: String,
         span: Option<Span>,
@@ -424,11 +424,11 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
     /// Adds a note if the types come from similarly named crates
     fn check_and_note_conflicting_crates(
         &self,
-        err: &mut DiagnosticBuilder,
+        err: &mut DiagnosticBuilder<'_>,
         terr: &TypeError<'tcx>,
         sp: Span,
     ) {
-        let report_path_match = |err: &mut DiagnosticBuilder, did1: DefId, did2: DefId| {
+        let report_path_match = |err: &mut DiagnosticBuilder<'_>, did1: DefId, did2: DefId| {
             // Only external crates, if either is from a local
             // module we could have false positives
             if !(did1.is_local() || did2.is_local()) && did1.krate != did2.krate {
@@ -750,7 +750,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                         values.1.push_normal("<");
                     }
 
-                    fn lifetime_display(lifetime: Region) -> String {
+                    fn lifetime_display(lifetime: Region<'_>) -> String {
                         let s = lifetime.to_string();
                         if s.is_empty() {
                             "'_".to_string()

--- a/src/librustc/infer/error_reporting/nice_region_error/util.rs
+++ b/src/librustc/infer/error_reporting/nice_region_error/util.rs
@@ -50,7 +50,7 @@ impl<'a, 'gcx, 'tcx> NiceRegionError<'a, 'gcx, 'tcx> {
         &self,
         anon_region: Region<'tcx>,
         replace_region: Region<'tcx>,
-    ) -> Option<AnonymousArgInfo> {
+    ) -> Option<AnonymousArgInfo<'_>> {
         let (id, bound_region) = match *anon_region {
             ty::ReFree(ref free_region) => (free_region.scope, free_region.bound_region),
             ty::ReEarlyBound(ref ebr) => (

--- a/src/librustc/infer/error_reporting/note.rs
+++ b/src/librustc/infer/error_reporting/note.rs
@@ -16,7 +16,7 @@ use errors::DiagnosticBuilder;
 
 impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
     pub(super) fn note_region_origin(&self,
-                                     err: &mut DiagnosticBuilder,
+                                     err: &mut DiagnosticBuilder<'_>,
                                      origin: &SubregionOrigin<'tcx>) {
         match *origin {
             infer::Subtype(ref trace) => {

--- a/src/librustc/infer/higher_ranked/mod.rs
+++ b/src/librustc/infer/higher_ranked/mod.rs
@@ -450,7 +450,7 @@ fn var_ids<'a, 'gcx, 'tcx>(fields: &CombineFields<'a, 'gcx, 'tcx>,
        .collect()
 }
 
-fn is_var_in_set(new_vars: &[ty::RegionVid], r: ty::Region) -> bool {
+fn is_var_in_set(new_vars: &[ty::RegionVid], r: ty::Region<'_>) -> bool {
     match *r {
         ty::ReVar(ref v) => new_vars.iter().any(|x| x == v),
         _ => false

--- a/src/librustc/infer/lexical_region_resolve/mod.rs
+++ b/src/librustc/infer/lexical_region_resolve/mod.rs
@@ -163,7 +163,7 @@ impl<'cx, 'gcx, 'tcx> LexicalResolver<'cx, 'gcx, 'tcx> {
         }
     }
 
-    fn expand_givens(&mut self, graph: &RegionGraph) {
+    fn expand_givens(&mut self, graph: &RegionGraph<'_>) {
         // Givens are a kind of horrible hack to account for
         // constraints like 'c <= '0 that are known to hold due to
         // closure signatures (see the comment above on the `givens`
@@ -558,7 +558,7 @@ impl<'cx, 'gcx, 'tcx> LexicalResolver<'cx, 'gcx, 'tcx> {
         // We place free regions first because we are special casing
         // SubSupConflict(ReFree, ReFree) when reporting error, and so
         // the user will more likely get a specific suggestion.
-        fn region_order_key(x: &RegionAndOrigin) -> u8 {
+        fn region_order_key(x: &RegionAndOrigin<'_>) -> u8 {
             match *x.region {
                 ReEarlyBound(_) => 0,
                 ReFree(_) => 1,
@@ -739,7 +739,7 @@ impl<'cx, 'gcx, 'tcx> LexicalResolver<'cx, 'gcx, 'tcx> {
 }
 
 impl<'tcx> fmt::Debug for RegionAndOrigin<'tcx> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "RegionAndOrigin({:?},{:?})", self.region, self.origin)
     }
 }

--- a/src/librustc/infer/mod.rs
+++ b/src/librustc/infer/mod.rs
@@ -445,7 +445,7 @@ pub struct RegionObligation<'tcx> {
 }
 
 impl fmt::Display for FixupError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use self::FixupError::*;
 
         match *self {
@@ -590,7 +590,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
         t.fold_with(&mut self.freshener())
     }
 
-    pub fn type_var_diverges(&'a self, ty: Ty) -> bool {
+    pub fn type_var_diverges(&'a self, ty: Ty<'_>) -> bool {
         match ty.sty {
             ty::Infer(ty::TyVar(vid)) => self.type_variables.borrow().var_diverges(vid),
             _ => false,
@@ -601,7 +601,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
         freshen::TypeFreshener::new(self)
     }
 
-    pub fn type_is_unconstrained_numeric(&'a self, ty: Ty) -> UnconstrainedNumeric {
+    pub fn type_is_unconstrained_numeric(&'a self, ty: Ty<'_>) -> UnconstrainedNumeric {
         use ty::error::UnconstrainedNumeric::Neither;
         use ty::error::UnconstrainedNumeric::{UnconstrainedFloat, UnconstrainedInt};
         match ty.sty {
@@ -1510,7 +1510,7 @@ impl<'a, 'gcx, 'tcx> TypeTrace<'tcx> {
 }
 
 impl<'tcx> fmt::Debug for TypeTrace<'tcx> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "TypeTrace({:?})", self.cause)
     }
 }
@@ -1598,7 +1598,7 @@ EnumTypeFoldableImpl! {
 }
 
 impl<'tcx> fmt::Debug for RegionObligation<'tcx> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "RegionObligation(sub_region={:?}, sup_type={:?})",

--- a/src/librustc/infer/opaque_types/mod.rs
+++ b/src/librustc/infer/opaque_types/mod.rs
@@ -841,7 +841,7 @@ impl<'a, 'gcx, 'tcx> Instantiator<'a, 'gcx, 'tcx> {
 /// We will return true if the reference is within the same module as the existential type
 /// So true for f1, false for f2.
 pub fn may_define_existential_type(
-    tcx: TyCtxt,
+    tcx: TyCtxt<'_, '_, '_>,
     def_id: DefId,
     opaque_node_id: ast::NodeId,
 ) -> bool {

--- a/src/librustc/infer/outlives/free_region_map.rs
+++ b/src/librustc/infer/outlives/free_region_map.rs
@@ -84,14 +84,14 @@ impl<'tcx> FreeRegionRelations<'tcx> for FreeRegionMap<'tcx> {
     }
 }
 
-fn is_free(r: Region) -> bool {
+fn is_free(r: Region<'_>) -> bool {
     match *r {
         ty::ReEarlyBound(_) | ty::ReFree(_) => true,
         _ => false
     }
 }
 
-fn is_free_or_static(r: Region) -> bool {
+fn is_free_or_static(r: Region<'_>) -> bool {
     match *r {
         ty::ReStatic => true,
         _ => is_free(r),

--- a/src/librustc/infer/region_constraints/mod.rs
+++ b/src/librustc/infer/region_constraints/mod.rs
@@ -914,13 +914,13 @@ impl<'tcx> RegionConstraintCollector<'tcx> {
 }
 
 impl fmt::Debug for RegionSnapshot {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "RegionSnapshot(length={})", self.length)
     }
 }
 
 impl<'tcx> fmt::Debug for GenericKind<'tcx> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             GenericKind::Param(ref p) => write!(f, "{:?}", p),
             GenericKind::Projection(ref p) => write!(f, "{:?}", p),
@@ -929,7 +929,7 @@ impl<'tcx> fmt::Debug for GenericKind<'tcx> {
 }
 
 impl<'tcx> fmt::Display for GenericKind<'tcx> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             GenericKind::Param(ref p) => write!(f, "{}", p),
             GenericKind::Projection(ref p) => write!(f, "{}", p),

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -74,6 +74,8 @@
 
 #![recursion_limit="512"]
 
+#![warn(elided_lifetimes_in_paths)]
+
 extern crate arena;
 #[macro_use] extern crate bitflags;
 extern crate core;

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -432,7 +432,7 @@ pub enum BuiltinLintDiagnostics {
 }
 
 impl BuiltinLintDiagnostics {
-    pub fn run(self, sess: &Session, db: &mut DiagnosticBuilder) {
+    pub fn run(self, sess: &Session, db: &mut DiagnosticBuilder<'_>) {
         match self {
             BuiltinLintDiagnostics::Normal => (),
             BuiltinLintDiagnostics::BareTraitObject(span, is_global) => {

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -355,7 +355,7 @@ impl LintStore {
         &self,
         lint_name: &str,
         tool_name: Option<LocalInternedString>,
-    ) -> CheckLintNameResult {
+    ) -> CheckLintNameResult<'_> {
         let complete_name = if let Some(tool_name) = tool_name {
             format!("{}::{}", tool_name, lint_name)
         } else {
@@ -410,7 +410,7 @@ impl LintStore {
         &self,
         lint_name: &str,
         tool_name: &str,
-    ) -> CheckLintNameResult {
+    ) -> CheckLintNameResult<'_> {
         let complete_name = format!("{}::{}", tool_name, lint_name);
         match self.by_name.get(&complete_name) {
             None => match self.lint_groups.get(&*complete_name) {
@@ -525,7 +525,7 @@ pub trait LintContext<'tcx>: Sized {
                                   lint: &'static Lint,
                                   span: Option<S>,
                                   msg: &str)
-                                  -> DiagnosticBuilder;
+                                  -> DiagnosticBuilder<'_>;
 
     /// Emit a lint at the appropriate level, for a particular span.
     fn span_lint<S: Into<MultiSpan>>(&self, lint: &'static Lint, span: S, msg: &str) {
@@ -536,7 +536,7 @@ pub trait LintContext<'tcx>: Sized {
                                             lint: &'static Lint,
                                             span: S,
                                             msg: &str)
-                                            -> DiagnosticBuilder {
+                                            -> DiagnosticBuilder<'_> {
         self.lookup(lint, Some(span), msg)
     }
 
@@ -640,7 +640,7 @@ impl<'a, 'tcx> LintContext<'tcx> for LateContext<'a, 'tcx> {
                                   lint: &'static Lint,
                                   span: Option<S>,
                                   msg: &str)
-                                  -> DiagnosticBuilder {
+                                  -> DiagnosticBuilder<'_> {
         let id = self.last_ast_node_with_lint_attrs;
         match span {
             Some(s) => self.tcx.struct_span_lint_node(lint, id, s, msg),
@@ -697,7 +697,7 @@ impl<'a> LintContext<'a> for EarlyContext<'a> {
                                   lint: &'static Lint,
                                   span: Option<S>,
                                   msg: &str)
-                                  -> DiagnosticBuilder {
+                                  -> DiagnosticBuilder<'_> {
         self.builder.struct_lint(lint, span.map(|s| s.into()), msg)
     }
 

--- a/src/librustc/lint/levels.rs
+++ b/src/librustc/lint/levels.rs
@@ -54,7 +54,7 @@ impl LintLevelSets {
         return me
     }
 
-    pub fn builder(sess: &Session) -> LintLevelsBuilder {
+    pub fn builder(sess: &Session) -> LintLevelsBuilder<'_> {
         LintLevelsBuilder::new(sess, LintLevelSets::new(sess))
     }
 

--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -327,56 +327,56 @@ macro_rules! declare_combined_late_lint_pass {
 }
 
 pub trait EarlyLintPass: LintPass {
-    fn check_ident(&mut self, _: &EarlyContext, _: ast::Ident) { }
-    fn check_crate(&mut self, _: &EarlyContext, _: &ast::Crate) { }
-    fn check_crate_post(&mut self, _: &EarlyContext, _: &ast::Crate) { }
-    fn check_mod(&mut self, _: &EarlyContext, _: &ast::Mod, _: Span, _: ast::NodeId) { }
-    fn check_mod_post(&mut self, _: &EarlyContext, _: &ast::Mod, _: Span, _: ast::NodeId) { }
-    fn check_foreign_item(&mut self, _: &EarlyContext, _: &ast::ForeignItem) { }
-    fn check_foreign_item_post(&mut self, _: &EarlyContext, _: &ast::ForeignItem) { }
-    fn check_item(&mut self, _: &EarlyContext, _: &ast::Item) { }
-    fn check_item_post(&mut self, _: &EarlyContext, _: &ast::Item) { }
-    fn check_local(&mut self, _: &EarlyContext, _: &ast::Local) { }
-    fn check_block(&mut self, _: &EarlyContext, _: &ast::Block) { }
-    fn check_block_post(&mut self, _: &EarlyContext, _: &ast::Block) { }
-    fn check_stmt(&mut self, _: &EarlyContext, _: &ast::Stmt) { }
-    fn check_arm(&mut self, _: &EarlyContext, _: &ast::Arm) { }
-    fn check_pat(&mut self, _: &EarlyContext, _: &ast::Pat) { }
-    fn check_expr(&mut self, _: &EarlyContext, _: &ast::Expr) { }
-    fn check_expr_post(&mut self, _: &EarlyContext, _: &ast::Expr) { }
-    fn check_ty(&mut self, _: &EarlyContext, _: &ast::Ty) { }
-    fn check_generic_param(&mut self, _: &EarlyContext, _: &ast::GenericParam) { }
-    fn check_generics(&mut self, _: &EarlyContext, _: &ast::Generics) { }
-    fn check_where_predicate(&mut self, _: &EarlyContext, _: &ast::WherePredicate) { }
-    fn check_poly_trait_ref(&mut self, _: &EarlyContext, _: &ast::PolyTraitRef,
+    fn check_ident(&mut self, _: &EarlyContext<'_>, _: ast::Ident) { }
+    fn check_crate(&mut self, _: &EarlyContext<'_>, _: &ast::Crate) { }
+    fn check_crate_post(&mut self, _: &EarlyContext<'_>, _: &ast::Crate) { }
+    fn check_mod(&mut self, _: &EarlyContext<'_>, _: &ast::Mod, _: Span, _: ast::NodeId) { }
+    fn check_mod_post(&mut self, _: &EarlyContext<'_>, _: &ast::Mod, _: Span, _: ast::NodeId) { }
+    fn check_foreign_item(&mut self, _: &EarlyContext<'_>, _: &ast::ForeignItem) { }
+    fn check_foreign_item_post(&mut self, _: &EarlyContext<'_>, _: &ast::ForeignItem) { }
+    fn check_item(&mut self, _: &EarlyContext<'_>, _: &ast::Item) { }
+    fn check_item_post(&mut self, _: &EarlyContext<'_>, _: &ast::Item) { }
+    fn check_local(&mut self, _: &EarlyContext<'_>, _: &ast::Local) { }
+    fn check_block(&mut self, _: &EarlyContext<'_>, _: &ast::Block) { }
+    fn check_block_post(&mut self, _: &EarlyContext<'_>, _: &ast::Block) { }
+    fn check_stmt(&mut self, _: &EarlyContext<'_>, _: &ast::Stmt) { }
+    fn check_arm(&mut self, _: &EarlyContext<'_>, _: &ast::Arm) { }
+    fn check_pat(&mut self, _: &EarlyContext<'_>, _: &ast::Pat) { }
+    fn check_expr(&mut self, _: &EarlyContext<'_>, _: &ast::Expr) { }
+    fn check_expr_post(&mut self, _: &EarlyContext<'_>, _: &ast::Expr) { }
+    fn check_ty(&mut self, _: &EarlyContext<'_>, _: &ast::Ty) { }
+    fn check_generic_param(&mut self, _: &EarlyContext<'_>, _: &ast::GenericParam) { }
+    fn check_generics(&mut self, _: &EarlyContext<'_>, _: &ast::Generics) { }
+    fn check_where_predicate(&mut self, _: &EarlyContext<'_>, _: &ast::WherePredicate) { }
+    fn check_poly_trait_ref(&mut self, _: &EarlyContext<'_>, _: &ast::PolyTraitRef,
                             _: &ast::TraitBoundModifier) { }
-    fn check_fn(&mut self, _: &EarlyContext,
-        _: ast_visit::FnKind, _: &ast::FnDecl, _: Span, _: ast::NodeId) { }
-    fn check_fn_post(&mut self, _: &EarlyContext,
-        _: ast_visit::FnKind, _: &ast::FnDecl, _: Span, _: ast::NodeId) { }
-    fn check_trait_item(&mut self, _: &EarlyContext, _: &ast::TraitItem) { }
-    fn check_trait_item_post(&mut self, _: &EarlyContext, _: &ast::TraitItem) { }
-    fn check_impl_item(&mut self, _: &EarlyContext, _: &ast::ImplItem) { }
-    fn check_impl_item_post(&mut self, _: &EarlyContext, _: &ast::ImplItem) { }
-    fn check_struct_def(&mut self, _: &EarlyContext,
+    fn check_fn(&mut self, _: &EarlyContext<'_>,
+        _: ast_visit::FnKind<'_>, _: &ast::FnDecl, _: Span, _: ast::NodeId) { }
+    fn check_fn_post(&mut self, _: &EarlyContext<'_>,
+        _: ast_visit::FnKind<'_>, _: &ast::FnDecl, _: Span, _: ast::NodeId) { }
+    fn check_trait_item(&mut self, _: &EarlyContext<'_>, _: &ast::TraitItem) { }
+    fn check_trait_item_post(&mut self, _: &EarlyContext<'_>, _: &ast::TraitItem) { }
+    fn check_impl_item(&mut self, _: &EarlyContext<'_>, _: &ast::ImplItem) { }
+    fn check_impl_item_post(&mut self, _: &EarlyContext<'_>, _: &ast::ImplItem) { }
+    fn check_struct_def(&mut self, _: &EarlyContext<'_>,
         _: &ast::VariantData, _: ast::Ident, _: &ast::Generics, _: ast::NodeId) { }
-    fn check_struct_def_post(&mut self, _: &EarlyContext,
+    fn check_struct_def_post(&mut self, _: &EarlyContext<'_>,
         _: &ast::VariantData, _: ast::Ident, _: &ast::Generics, _: ast::NodeId) { }
-    fn check_struct_field(&mut self, _: &EarlyContext, _: &ast::StructField) { }
-    fn check_variant(&mut self, _: &EarlyContext, _: &ast::Variant, _: &ast::Generics) { }
-    fn check_variant_post(&mut self, _: &EarlyContext, _: &ast::Variant, _: &ast::Generics) { }
-    fn check_lifetime(&mut self, _: &EarlyContext, _: &ast::Lifetime) { }
-    fn check_path(&mut self, _: &EarlyContext, _: &ast::Path, _: ast::NodeId) { }
-    fn check_attribute(&mut self, _: &EarlyContext, _: &ast::Attribute) { }
-    fn check_mac_def(&mut self, _: &EarlyContext, _: &ast::MacroDef, _id: ast::NodeId) { }
-    fn check_mac(&mut self, _: &EarlyContext, _: &ast::Mac) { }
+    fn check_struct_field(&mut self, _: &EarlyContext<'_>, _: &ast::StructField) { }
+    fn check_variant(&mut self, _: &EarlyContext<'_>, _: &ast::Variant, _: &ast::Generics) { }
+    fn check_variant_post(&mut self, _: &EarlyContext<'_>, _: &ast::Variant, _: &ast::Generics) { }
+    fn check_lifetime(&mut self, _: &EarlyContext<'_>, _: &ast::Lifetime) { }
+    fn check_path(&mut self, _: &EarlyContext<'_>, _: &ast::Path, _: ast::NodeId) { }
+    fn check_attribute(&mut self, _: &EarlyContext<'_>, _: &ast::Attribute) { }
+    fn check_mac_def(&mut self, _: &EarlyContext<'_>, _: &ast::MacroDef, _id: ast::NodeId) { }
+    fn check_mac(&mut self, _: &EarlyContext<'_>, _: &ast::Mac) { }
 
     /// Called when entering a syntax node that can have lint attributes such
     /// as `#[allow(...)]`. Called with *all* the attributes of that node.
-    fn enter_lint_attrs(&mut self, _: &EarlyContext, _: &[ast::Attribute]) { }
+    fn enter_lint_attrs(&mut self, _: &EarlyContext<'_>, _: &[ast::Attribute]) { }
 
     /// Counterpart to `enter_lint_attrs`.
-    fn exit_lint_attrs(&mut self, _: &EarlyContext, _: &[ast::Attribute]) { }
+    fn exit_lint_attrs(&mut self, _: &EarlyContext<'_>, _: &[ast::Attribute]) { }
 }
 
 /// A lint pass boxed up as a trait object.
@@ -728,7 +728,7 @@ impl<'a, 'tcx> intravisit::Visitor<'tcx> for LintLevelMapBuilder<'a, 'tcx> {
     }
 }
 
-pub fn provide(providers: &mut Providers) {
+pub fn provide(providers: &mut Providers<'_>) {
     providers.lint_levels = lint_levels;
 }
 

--- a/src/librustc/middle/cstore.rs
+++ b/src/librustc/middle/cstore.rs
@@ -244,7 +244,7 @@ pub type CrateStoreDyn = dyn CrateStore + sync::Sync;
 // In order to get this left-to-right dependency ordering, we perform a
 // topological sort of all crates putting the leaves at the right-most
 // positions.
-pub fn used_crates(tcx: TyCtxt, prefer: LinkagePreference)
+pub fn used_crates(tcx: TyCtxt<'_, '_, '_>, prefer: LinkagePreference)
     -> Vec<(CrateNum, LibSource)>
 {
     let mut libs = tcx.crates()

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -285,7 +285,7 @@ impl<'a, 'tcx> Visitor<'tcx> for MarkSymbolVisitor<'a, 'tcx> {
     }
 }
 
-fn has_allow_dead_code_or_lang_attr(tcx: TyCtxt,
+fn has_allow_dead_code_or_lang_attr(tcx: TyCtxt<'_, '_, '_>,
                                     id: ast::NodeId,
                                     attrs: &[ast::Attribute]) -> bool {
     if attr::contains_name(attrs, "lang") {

--- a/src/librustc/middle/dependency_format.rs
+++ b/src/librustc/middle/dependency_format.rs
@@ -256,7 +256,7 @@ fn calculate_type<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     return ret;
 }
 
-fn add_library(tcx: TyCtxt,
+fn add_library(tcx: TyCtxt<'_, '_, '_>,
                cnum: CrateNum,
                link: LinkagePreference,
                m: &mut FxHashMap<CrateNum, LinkagePreference>) {

--- a/src/librustc/middle/entry.rs
+++ b/src/librustc/middle/entry.rs
@@ -57,7 +57,7 @@ impl<'a, 'tcx> ItemLikeVisitor<'tcx> for EntryContext<'a, 'tcx> {
 }
 
 pub fn find_entry_point(session: &Session,
-                        hir_map: &hir_map::Map,
+                        hir_map: &hir_map::Map<'_>,
                         crate_name: &str) {
     let any_exe = session.crate_types.borrow().iter().any(|ty| {
         *ty == config::CrateType::Executable
@@ -113,7 +113,7 @@ fn entry_point_type(item: &Item, at_root: bool) -> EntryPointType {
 }
 
 
-fn find_item(item: &Item, ctxt: &mut EntryContext, at_root: bool) {
+fn find_item(item: &Item, ctxt: &mut EntryContext<'_, '_>, at_root: bool) {
     match entry_point_type(item, at_root) {
         EntryPointType::MainNamed => {
             if ctxt.main_fn.is_none() {
@@ -154,7 +154,7 @@ fn find_item(item: &Item, ctxt: &mut EntryContext, at_root: bool) {
     }
 }
 
-fn configure_main(this: &mut EntryContext, crate_name: &str) {
+fn configure_main(this: &mut EntryContext<'_, '_>, crate_name: &str) {
     if let Some((node_id, span)) = this.start_fn {
         this.session.entry_fn.set(Some((node_id, span, EntryFnType::Start)));
     } else if let Some((node_id, span)) = this.attr_main_fn {

--- a/src/librustc/middle/exported_symbols.rs
+++ b/src/librustc/middle/exported_symbols.rs
@@ -106,7 +106,7 @@ impl<'tcx> ExportedSymbol<'tcx> {
     }
 }
 
-pub fn metadata_symbol_name(tcx: ty::TyCtxt) -> String {
+pub fn metadata_symbol_name(tcx: ty::TyCtxt<'_, '_, '_>) -> String {
     format!("rust_metadata_{}_{}",
             tcx.original_crate_name(LOCAL_CRATE),
             tcx.crate_disambiguator(LOCAL_CRATE).to_fingerprint().to_hex())

--- a/src/librustc/middle/expr_use_visitor.rs
+++ b/src/librustc/middle/expr_use_visitor.rs
@@ -211,7 +211,7 @@ enum OverloadedCallType {
 }
 
 impl OverloadedCallType {
-    fn from_trait_id(tcx: TyCtxt, trait_id: DefId) -> OverloadedCallType {
+    fn from_trait_id(tcx: TyCtxt<'_, '_, '_>, trait_id: DefId) -> OverloadedCallType {
         for &(maybe_function_trait, overloaded_call_type) in &[
             (tcx.lang_items().fn_once_trait(), FnOnceOverloadedCall),
             (tcx.lang_items().fn_mut_trait(), FnMutOverloadedCall),
@@ -228,7 +228,7 @@ impl OverloadedCallType {
         bug!("overloaded call didn't map to known function trait")
     }
 
-    fn from_method_id(tcx: TyCtxt, method_id: DefId) -> OverloadedCallType {
+    fn from_method_id(tcx: TyCtxt<'_, '_, '_>, method_id: DefId) -> OverloadedCallType {
         let method = tcx.associated_item(method_id);
         OverloadedCallType::from_trait_id(tcx, method.container.id())
     }

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -158,7 +158,7 @@ enum LiveNodeKind {
     ExitNode
 }
 
-fn live_node_kind_to_string(lnk: LiveNodeKind, tcx: TyCtxt) -> String {
+fn live_node_kind_to_string(lnk: LiveNodeKind, tcx: TyCtxt<'_, '_, '_>) -> String {
     let cm = tcx.sess.source_map();
     match lnk {
         FreeVarNode(s) => {
@@ -195,13 +195,13 @@ pub fn check_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
 }
 
 impl fmt::Debug for LiveNode {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "ln({})", self.get())
     }
 }
 
 impl fmt::Debug for Variable {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "v({})", self.get())
     }
 }
@@ -371,7 +371,7 @@ fn visit_fn<'a, 'tcx: 'a>(ir: &mut IrMaps<'a, 'tcx>,
         }
     }
 
-    debug!("creating fn_maps: {:?}", &fn_maps as *const IrMaps);
+    debug!("creating fn_maps: {:?}", &fn_maps as *const IrMaps<'_, '_>);
 
     let body = ir.tcx.hir.body(body_id);
 
@@ -1388,7 +1388,7 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
 
     fn propagate_through_loop(&mut self,
                               expr: &Expr,
-                              kind: LoopKind,
+                              kind: LoopKind<'_>,
                               body: &hir::Block,
                               succ: LiveNode)
                               -> LiveNode {

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -324,7 +324,7 @@ impl MutabilityCategory {
     }
 
     fn from_pointer_kind(base_mutbl: MutabilityCategory,
-                         ptr: PointerKind) -> MutabilityCategory {
+                         ptr: PointerKind<'_>) -> MutabilityCategory {
         let ret = match ptr {
             Unique => {
                 base_mutbl.inherit()
@@ -341,7 +341,8 @@ impl MutabilityCategory {
         ret
     }
 
-    fn from_local(tcx: TyCtxt, tables: &ty::TypeckTables, id: ast::NodeId) -> MutabilityCategory {
+    fn from_local(tcx: TyCtxt<'_, '_, '_>, tables: &ty::TypeckTables<'_>,
+                  id: ast::NodeId) -> MutabilityCategory {
         let ret = match tcx.hir.get(id) {
             Node::Binding(p) => match p.node {
                 PatKind::Binding(..) => {
@@ -1488,7 +1489,7 @@ impl<'tcx> cmt_<'tcx> {
         }
     }
 
-    pub fn descriptive_string(&self, tcx: TyCtxt) -> String {
+    pub fn descriptive_string(&self, tcx: TyCtxt<'_, '_, '_>) -> String {
         match self.cat {
             Categorization::StaticItem => {
                 "static item".to_string()
@@ -1546,7 +1547,7 @@ impl<'tcx> cmt_<'tcx> {
     }
 }
 
-pub fn ptr_sigil(ptr: PointerKind) -> &'static str {
+pub fn ptr_sigil(ptr: PointerKind<'_>) -> &'static str {
     match ptr {
         Unique => "Box",
         BorrowedPtr(ty::ImmBorrow, _) => "&",
@@ -1557,7 +1558,7 @@ pub fn ptr_sigil(ptr: PointerKind) -> &'static str {
 }
 
 impl fmt::Debug for InteriorKind {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             InteriorField(FieldIndex(_, info)) => write!(f, "{}", info),
             InteriorElement(..) => write!(f, "[]"),
@@ -1566,13 +1567,13 @@ impl fmt::Debug for InteriorKind {
 }
 
 impl fmt::Debug for Upvar {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:?}/{:?}", self.id, self.kind)
     }
 }
 
 impl fmt::Display for Upvar {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let kind = match self.kind {
             ty::ClosureKind::Fn => "Fn",
             ty::ClosureKind::FnMut => "FnMut",

--- a/src/librustc/middle/privacy.rs
+++ b/src/librustc/middle/privacy.rs
@@ -59,7 +59,7 @@ impl<Id: Hash + Eq> Default for AccessLevels<Id> {
 }
 
 impl<Id: Hash + Eq + fmt::Debug> fmt::Debug for AccessLevels<Id> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&self.map, f)
     }
 }

--- a/src/librustc/middle/reachable.rs
+++ b/src/librustc/middle/reachable.rs
@@ -443,7 +443,7 @@ fn reachable_set<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, crate_num: CrateNum) -> 
     ReachableSet(Lrc::new(reachable_context.reachable_symbols))
 }
 
-pub fn provide(providers: &mut Providers) {
+pub fn provide(providers: &mut Providers<'_>) {
     *providers = Providers {
         reachable_set,
         ..*providers

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -107,7 +107,7 @@ pub struct Scope {
 }
 
 impl fmt::Debug for Scope {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.data {
             ScopeData::Node => write!(fmt, "Node({:?})", self.id),
             ScopeData::CallSite => write!(fmt, "CallSite({:?})", self.id),
@@ -179,7 +179,7 @@ impl Scope {
         self.id
     }
 
-    pub fn node_id(&self, tcx: TyCtxt, scope_tree: &ScopeTree) -> ast::NodeId {
+    pub fn node_id(&self, tcx: TyCtxt<'_, '_, '_>, scope_tree: &ScopeTree) -> ast::NodeId {
         match scope_tree.root_body {
             Some(hir_id) => {
                 tcx.hir.hir_to_node_id(hir::HirId {
@@ -194,7 +194,7 @@ impl Scope {
     /// Returns the span of this Scope.  Note that in general the
     /// returned span may not correspond to the span of any node id in
     /// the AST.
-    pub fn span(&self, tcx: TyCtxt, scope_tree: &ScopeTree) -> Span {
+    pub fn span(&self, tcx: TyCtxt<'_, '_, '_>, scope_tree: &ScopeTree) -> Span {
         let node_id = self.node_id(tcx, scope_tree);
         if node_id == ast::DUMMY_NODE_ID {
             return DUMMY_SP;
@@ -748,7 +748,7 @@ impl<'tcx> ScopeTree {
 }
 
 /// Records the lifetime of a local variable as `cx.var_parent`
-fn record_var_lifetime(visitor: &mut RegionResolutionVisitor,
+fn record_var_lifetime(visitor: &mut RegionResolutionVisitor<'_, '_>,
                        var_id: hir::ItemLocalId,
                        _sp: Span) {
     match visitor.cx.var_parent {
@@ -1383,7 +1383,7 @@ fn region_scope_tree<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId)
     Lrc::new(scope_tree)
 }
 
-pub fn provide(providers: &mut Providers) {
+pub fn provide(providers: &mut Providers<'_>) {
     *providers = Providers {
         region_scope_tree,
         ..*providers

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -88,7 +88,7 @@ pub enum Region {
 }
 
 impl Region {
-    fn early(hir_map: &Map, index: &mut u32, param: &GenericParam) -> (ParamName, Region) {
+    fn early(hir_map: &Map<'_>, index: &mut u32, param: &GenericParam) -> (ParamName, Region) {
         let i = *index;
         *index += 1;
         let def_id = hir_map.local_def_id(param.id);
@@ -97,7 +97,7 @@ impl Region {
         (param.name.modern(), Region::EarlyBound(i, def_id, origin))
     }
 
-    fn late(hir_map: &Map, param: &GenericParam) -> (ParamName, Region) {
+    fn late(hir_map: &Map<'_>, param: &GenericParam) -> (ParamName, Region) {
         let depth = ty::INNERMOST;
         let def_id = hir_map.local_def_id(param.id);
         let origin = LifetimeDefOrigin::from_param(param);
@@ -348,7 +348,7 @@ type ScopeRef<'a> = &'a Scope<'a>;
 
 const ROOT_SCOPE: ScopeRef<'static> = &Scope::Root;
 
-pub fn provide(providers: &mut ty::query::Providers) {
+pub fn provide(providers: &mut ty::query::Providers<'_>) {
     *providers = ty::query::Providers {
         resolve_lifetimes,
 
@@ -1371,9 +1371,9 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
         f(self)
     }
 
-    fn with<F>(&mut self, wrap_scope: Scope, f: F)
+    fn with<F>(&mut self, wrap_scope: Scope<'_>, f: F)
     where
-        F: for<'b> FnOnce(ScopeRef, &mut LifetimeContext<'b, 'tcx>),
+        F: for<'b> FnOnce(ScopeRef<'_>, &mut LifetimeContext<'b, 'tcx>),
     {
         let LifetimeContext {
             tcx,
@@ -2159,7 +2159,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
 
     fn report_elision_failure(
         &mut self,
-        db: &mut DiagnosticBuilder,
+        db: &mut DiagnosticBuilder<'_>,
         params: &[ElisionFailureInfo],
     ) {
         let mut m = String::new();
@@ -2268,7 +2268,8 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
         self.insert_lifetime(lifetime_ref, lifetime.shifted(late_depth));
     }
 
-    fn check_lifetime_params(&mut self, old_scope: ScopeRef, params: &'tcx [hir::GenericParam]) {
+    fn check_lifetime_params(&mut self, old_scope: ScopeRef<'_>,
+                             params: &'tcx [hir::GenericParam]) {
         let lifetimes: Vec<_> = params.iter().filter_map(|param| match param.kind {
             GenericParamKind::Lifetime { .. } => Some((param, param.name)),
             _ => None,
@@ -2351,7 +2352,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
 
     fn check_lifetime_param_for_shadowing(
         &self,
-        mut old_scope: ScopeRef,
+        mut old_scope: ScopeRef<'_>,
         param: &'tcx hir::GenericParam,
     ) {
         for label in &self.labels_in_fn {

--- a/src/librustc/middle/weak_lang_items.rs
+++ b/src/librustc/middle/weak_lang_items.rs
@@ -70,7 +70,7 @@ pub fn link_name(attrs: &[ast::Attribute]) -> Option<Symbol> {
 /// Not all lang items are always required for each compilation, particularly in
 /// the case of panic=abort. In these situations some lang items are injected by
 /// crates and don't actually need to be defined in libstd.
-pub fn whitelisted(tcx: TyCtxt, lang_item: lang_items::LangItem) -> bool {
+pub fn whitelisted(tcx: TyCtxt<'_, '_, '_>, lang_item: lang_items::LangItem) -> bool {
     // If we're not compiling with unwinding, we won't actually need these
     // symbols. Other panic runtimes ensure that the relevant symbols are
     // available to link things together, but they're never exercised.

--- a/src/librustc/mir/cache.rs
+++ b/src/librustc/mir/cache.rs
@@ -57,8 +57,8 @@ impl Cache {
 
     pub fn predecessors(
         &self,
-        mir: &Mir
-    ) -> MappedReadGuard<IndexVec<BasicBlock, Vec<BasicBlock>>> {
+        mir: &Mir<'_>
+    ) -> MappedReadGuard<'_, IndexVec<BasicBlock, Vec<BasicBlock>>> {
         if self.predecessors.borrow().is_none() {
             *self.predecessors.borrow_mut() = Some(calculate_predecessors(mir));
         }
@@ -67,7 +67,7 @@ impl Cache {
     }
 }
 
-fn calculate_predecessors(mir: &Mir) -> IndexVec<BasicBlock, Vec<BasicBlock>> {
+fn calculate_predecessors(mir: &Mir<'_>) -> IndexVec<BasicBlock, Vec<BasicBlock>> {
     let mut result = IndexVec::from_elem(vec![], mir.basic_blocks());
     for (bb, data) in mir.basic_blocks().iter_enumerated() {
         if let Some(ref term) = data.terminator {

--- a/src/librustc/mir/interpret/error.rs
+++ b/src/librustc/mir/interpret/error.rs
@@ -429,13 +429,13 @@ impl<'tcx, O> EvalErrorKind<'tcx, O> {
 }
 
 impl<'tcx> fmt::Display for EvalError<'tcx> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:?}", self.kind)
     }
 }
 
 impl<'tcx, O: fmt::Debug> fmt::Debug for EvalErrorKind<'tcx, O> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use self::EvalErrorKind::*;
         match *self {
             PointerOutOfBounds { ptr, access, allocation_size } => {

--- a/src/librustc/mir/interpret/mod.rs
+++ b/src/librustc/mir/interpret/mod.rs
@@ -253,7 +253,7 @@ pub struct AllocDecodingState {
 
 impl AllocDecodingState {
 
-    pub fn new_decoding_session(&self) -> AllocDecodingSession {
+    pub fn new_decoding_session(&self) -> AllocDecodingSession<'_> {
         static DECODER_SESSION_ID: AtomicU32 = AtomicU32::new(0);
         let counter = DECODER_SESSION_ID.fetch_add(1, Ordering::SeqCst);
 
@@ -394,7 +394,7 @@ impl<'s> AllocDecodingSession<'s> {
 }
 
 impl fmt::Display for AllocId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -2379,7 +2379,7 @@ pub mod nightly_options {
 }
 
 impl fmt::Display for CrateType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             CrateType::Executable => "bin".fmt(f),
             CrateType::Dylib => "dylib".fmt(f),

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -705,7 +705,7 @@ impl Session {
                 .expect("missing sysroot and default_sysroot in Session"),
         }
     }
-    pub fn target_filesearch(&self, kind: PathKind) -> filesearch::FileSearch {
+    pub fn target_filesearch(&self, kind: PathKind) -> filesearch::FileSearch<'_> {
         filesearch::FileSearch::new(
             self.sysroot(),
             self.opts.target_triple.triple(),
@@ -713,7 +713,7 @@ impl Session {
             kind,
         )
     }
-    pub fn host_filesearch(&self, kind: PathKind) -> filesearch::FileSearch {
+    pub fn host_filesearch(&self, kind: PathKind) -> filesearch::FileSearch<'_> {
         filesearch::FileSearch::new(
             self.sysroot(),
             config::host_triple(),
@@ -803,7 +803,7 @@ impl Session {
         *incr_comp_session = IncrCompSession::InvalidBecauseOfErrors { session_directory };
     }
 
-    pub fn incr_comp_session_dir(&self) -> cell::Ref<PathBuf> {
+    pub fn incr_comp_session_dir(&self) -> cell::Ref<'_, PathBuf> {
         let incr_comp_session = self.incr_comp_session.borrow();
         cell::Ref::map(
             incr_comp_session,
@@ -826,7 +826,7 @@ impl Session {
         )
     }
 
-    pub fn incr_comp_session_dir_opt(&self) -> Option<cell::Ref<PathBuf>> {
+    pub fn incr_comp_session_dir_opt(&self) -> Option<cell::Ref<'_, PathBuf>> {
         if self.opts.incremental.is_some() {
             Some(self.incr_comp_session_dir())
         } else {
@@ -1253,7 +1253,7 @@ impl CrateDisambiguator {
 }
 
 impl fmt::Display for CrateDisambiguator {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         let (a, b) = self.0.as_value();
         let as_u128 = a as u128 | ((b as u128) << 64);
         f.write_str(&base_n::encode(as_u128, base_n::CASE_INSENSITIVE))

--- a/src/librustc/session/search_paths.rs
+++ b/src/librustc/session/search_paths.rs
@@ -57,7 +57,7 @@ impl SearchPaths {
         self.paths.push((kind, PathBuf::from(path)));
     }
 
-    pub fn iter(&self, kind: PathKind) -> Iter {
+    pub fn iter(&self, kind: PathKind) -> Iter<'_> {
         Iter { kind: kind, iter: self.paths.iter() }
     }
 }

--- a/src/librustc/traits/auto_trait.rs
+++ b/src/librustc/traits/auto_trait.rs
@@ -483,14 +483,15 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
         }
     }
 
-    pub fn region_name(&self, region: Region) -> Option<String> {
+    pub fn region_name(&self, region: Region<'_>) -> Option<String> {
         match region {
             &ty::ReEarlyBound(r) => Some(r.name.to_string()),
             _ => None,
         }
     }
 
-    pub fn get_lifetime(&self, region: Region, names_map: &FxHashMap<String, String>) -> String {
+    pub fn get_lifetime(&self, region: Region<'_>,
+                        names_map: &FxHashMap<String, String>) -> String {
         self.region_name(region)
             .map(|name|
                 names_map.get(&name).unwrap_or_else(||
@@ -591,7 +592,7 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
         finished_map
     }
 
-    pub fn is_of_param(&self, substs: &Substs) -> bool {
+    pub fn is_of_param(&self, substs: &Substs<'_>) -> bool {
         if substs.is_noop() {
             return false;
         }
@@ -611,7 +612,7 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
         T: Iterator<Item = Obligation<'cx, ty::Predicate<'cx>>>,
     >(
         &self,
-        ty: ty::Ty,
+        ty: ty::Ty<'_>,
         nested: T,
         computed_preds: &'b mut FxHashSet<ty::Predicate<'cx>>,
         fresh_preds: &'b mut FxHashSet<ty::Predicate<'cx>>,

--- a/src/librustc/traits/coherence.rs
+++ b/src/librustc/traits/coherence.rs
@@ -337,7 +337,7 @@ pub fn orphan_check<'a, 'gcx, 'tcx>(tcx: TyCtxt<'a, 'gcx, 'tcx>,
 ///
 /// Note that this function is never called for types that have both type
 /// parameters and inference variables.
-fn orphan_check_trait_ref<'tcx>(tcx: TyCtxt,
+fn orphan_check_trait_ref<'tcx>(tcx: TyCtxt<'_, '_, '_>,
                                 trait_ref: ty::TraitRef<'tcx>,
                                 in_crate: InCrate)
                                 -> Result<(), OrphanCheckErr<'tcx>>
@@ -389,7 +389,7 @@ fn orphan_check_trait_ref<'tcx>(tcx: TyCtxt,
     return Err(OrphanCheckErr::NoLocalInputType);
 }
 
-fn uncovered_tys<'tcx>(tcx: TyCtxt, ty: Ty<'tcx>, in_crate: InCrate)
+fn uncovered_tys<'tcx>(tcx: TyCtxt<'_, '_, '_>, ty: Ty<'tcx>, in_crate: InCrate)
                        -> Vec<Ty<'tcx>> {
     if ty_is_local_constructor(ty, in_crate) {
         vec![]
@@ -402,19 +402,19 @@ fn uncovered_tys<'tcx>(tcx: TyCtxt, ty: Ty<'tcx>, in_crate: InCrate)
     }
 }
 
-fn is_possibly_remote_type(ty: Ty, _in_crate: InCrate) -> bool {
+fn is_possibly_remote_type(ty: Ty<'_>, _in_crate: InCrate) -> bool {
     match ty.sty {
         ty::Projection(..) | ty::Param(..) => true,
         _ => false,
     }
 }
 
-fn ty_is_local(tcx: TyCtxt, ty: Ty, in_crate: InCrate) -> bool {
+fn ty_is_local(tcx: TyCtxt<'_, '_, '_>, ty: Ty<'_>, in_crate: InCrate) -> bool {
     ty_is_local_constructor(ty, in_crate) ||
         fundamental_ty(tcx, ty) && ty.walk_shallow().any(|t| ty_is_local(tcx, t, in_crate))
 }
 
-fn fundamental_ty(tcx: TyCtxt, ty: Ty) -> bool {
+fn fundamental_ty(tcx: TyCtxt<'_, '_, '_>, ty: Ty<'_>) -> bool {
     match ty.sty {
         ty::Ref(..) => true,
         ty::Adt(def, _) => def.is_fundamental(),
@@ -434,7 +434,7 @@ fn def_id_is_local(def_id: DefId, in_crate: InCrate) -> bool {
     }
 }
 
-fn ty_is_local_constructor(ty: Ty, in_crate: InCrate) -> bool {
+fn ty_is_local_constructor(ty: Ty<'_>, in_crate: InCrate) -> bool {
     debug!("ty_is_local_constructor({:?})", ty);
 
     match ty.sty {

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -437,7 +437,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
 
     fn report_similar_impl_candidates(&self,
                                       mut impl_candidates: Vec<ty::TraitRef<'tcx>>,
-                                      err: &mut DiagnosticBuilder)
+                                      err: &mut DiagnosticBuilder<'_>)
     {
         if impl_candidates.is_empty() {
             return;
@@ -930,7 +930,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
     /// returns a span and `ArgKind` information that describes the
     /// arguments it expects. This can be supplied to
     /// `report_arg_count_mismatch`.
-    pub fn get_fn_like_arguments(&self, node: Node) -> (Span, Vec<ArgKind>) {
+    pub fn get_fn_like_arguments(&self, node: Node<'_>) -> (Span, Vec<ArgKind>) {
         match node {
             Node::Expr(&hir::Expr {
                 node: hir::ExprKind::Closure(_, ref _decl, id, span, _),
@@ -1378,7 +1378,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
     }
 
     fn note_obligation_cause<T>(&self,
-                                err: &mut DiagnosticBuilder,
+                                err: &mut DiagnosticBuilder<'_>,
                                 obligation: &Obligation<'tcx, T>)
         where T: fmt::Display
     {
@@ -1389,7 +1389,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
     }
 
     fn note_obligation_cause_code<T>(&self,
-                                     err: &mut DiagnosticBuilder,
+                                     err: &mut DiagnosticBuilder<'_>,
                                      predicate: &T,
                                      cause_code: &ObligationCauseCode<'tcx>,
                                      obligated_types: &mut Vec<&ty::TyS<'tcx>>)
@@ -1545,7 +1545,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
         }
     }
 
-    fn suggest_new_overflow_limit(&self, err: &mut DiagnosticBuilder) {
+    fn suggest_new_overflow_limit(&self, err: &mut DiagnosticBuilder<'_>) {
         let current_limit = self.tcx.sess.recursion_limit.get();
         let suggested_limit = current_limit * 2;
         err.help(&format!("consider adding a `#![recursion_limit=\"{}\"]` attribute to your crate",

--- a/src/librustc/traits/mod.rs
+++ b/src/librustc/traits/mod.rs
@@ -1009,7 +1009,7 @@ impl<'tcx> TraitObligation<'tcx> {
     }
 }
 
-pub fn provide(providers: &mut ty::query::Providers) {
+pub fn provide(providers: &mut ty::query::Providers<'_>) {
     *providers = ty::query::Providers {
         is_object_safe: object_safety::is_object_safe_provider,
         specialization_graph_of: specialize::specialization_graph_provider,

--- a/src/librustc/traits/on_unimplemented.rs
+++ b/src/librustc/traits/on_unimplemented.rs
@@ -44,7 +44,7 @@ impl OnUnimplementedNote {
     }
 }
 
-fn parse_error(tcx: TyCtxt, span: Span,
+fn parse_error(tcx: TyCtxt<'_, '_, '_>, span: Span,
                message: &str,
                label: &str,
                note: Option<&str>)

--- a/src/librustc/traits/query/type_op/custom.rs
+++ b/src/librustc/traits/query/type_op/custom.rs
@@ -62,7 +62,7 @@ impl<F, G> fmt::Debug for CustomTypeOp<F, G>
 where
     G: Fn() -> String,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", (self.description)())
     }
 }

--- a/src/librustc/traits/specialize/mod.rs
+++ b/src/librustc/traits/specialize/mod.rs
@@ -395,7 +395,7 @@ pub(super) fn specialization_graph_provider<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx
 
 /// Recovers the "impl X for Y" signature from `impl_def_id` and returns it as a
 /// string.
-fn to_pretty_impl_header(tcx: TyCtxt, impl_def_id: DefId) -> Option<String> {
+fn to_pretty_impl_header(tcx: TyCtxt<'_, '_, '_>, impl_def_id: DefId) -> Option<String> {
     use std::fmt::Write;
 
     let trait_ref = if let Some(tr) = tcx.impl_trait_ref(impl_def_id) {

--- a/src/librustc/traits/specialize/specialization_graph.rs
+++ b/src/librustc/traits/specialize/specialization_graph.rs
@@ -142,7 +142,7 @@ impl<'a, 'gcx, 'tcx> Children {
                 possible_sibling,
             );
 
-            let overlap_error = |overlap: traits::coherence::OverlapResult| {
+            let overlap_error = |overlap: traits::coherence::OverlapResult<'_>| {
                 // overlap, but no specialization; error out
                 let trait_ref = overlap.impl_header.trait_ref.unwrap();
                 let self_ty = trait_ref.self_ty();
@@ -447,7 +447,7 @@ impl<'a, 'gcx, 'tcx> Ancestors {
 
 /// Walk up the specialization ancestors of a given impl, starting with that
 /// impl itself.
-pub fn ancestors(tcx: TyCtxt,
+pub fn ancestors(tcx: TyCtxt<'_, '_, '_>,
                  trait_def_id: DefId,
                  start_from_impl: DefId)
                  -> Ancestors {

--- a/src/librustc/traits/structural_impls.rs
+++ b/src/librustc/traits/structural_impls.rs
@@ -21,13 +21,13 @@ use std::rc::Rc;
 // structural impls for the structs in traits
 
 impl<'tcx, T: fmt::Debug> fmt::Debug for Normalized<'tcx, T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Normalized({:?},{:?})", self.value, self.obligations)
     }
 }
 
 impl<'tcx, O: fmt::Debug> fmt::Debug for traits::Obligation<'tcx, O> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if ty::tls::with(|tcx| tcx.sess.verbose()) {
             write!(
                 f,
@@ -45,7 +45,7 @@ impl<'tcx, O: fmt::Debug> fmt::Debug for traits::Obligation<'tcx, O> {
 }
 
 impl<'tcx, N: fmt::Debug> fmt::Debug for traits::Vtable<'tcx, N> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             super::VtableImpl(ref v) => write!(f, "{:?}", v),
 
@@ -67,7 +67,7 @@ impl<'tcx, N: fmt::Debug> fmt::Debug for traits::Vtable<'tcx, N> {
 }
 
 impl<'tcx, N: fmt::Debug> fmt::Debug for traits::VtableImplData<'tcx, N> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "VtableImpl(impl_def_id={:?}, substs={:?}, nested={:?})",
@@ -77,7 +77,7 @@ impl<'tcx, N: fmt::Debug> fmt::Debug for traits::VtableImplData<'tcx, N> {
 }
 
 impl<'tcx, N: fmt::Debug> fmt::Debug for traits::VtableGeneratorData<'tcx, N> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "VtableGenerator(generator_def_id={:?}, substs={:?}, nested={:?})",
@@ -87,7 +87,7 @@ impl<'tcx, N: fmt::Debug> fmt::Debug for traits::VtableGeneratorData<'tcx, N> {
 }
 
 impl<'tcx, N: fmt::Debug> fmt::Debug for traits::VtableClosureData<'tcx, N> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "VtableClosure(closure_def_id={:?}, substs={:?}, nested={:?})",
@@ -97,13 +97,13 @@ impl<'tcx, N: fmt::Debug> fmt::Debug for traits::VtableClosureData<'tcx, N> {
 }
 
 impl<'tcx, N: fmt::Debug> fmt::Debug for traits::VtableBuiltinData<N> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "VtableBuiltin(nested={:?})", self.nested)
     }
 }
 
 impl<'tcx, N: fmt::Debug> fmt::Debug for traits::VtableAutoImplData<N> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "VtableAutoImplData(trait_def_id={:?}, nested={:?})",
@@ -113,7 +113,7 @@ impl<'tcx, N: fmt::Debug> fmt::Debug for traits::VtableAutoImplData<N> {
 }
 
 impl<'tcx, N: fmt::Debug> fmt::Debug for traits::VtableObjectData<'tcx, N> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "VtableObject(upcast={:?}, vtable_base={}, nested={:?})",
@@ -123,7 +123,7 @@ impl<'tcx, N: fmt::Debug> fmt::Debug for traits::VtableObjectData<'tcx, N> {
 }
 
 impl<'tcx, N: fmt::Debug> fmt::Debug for traits::VtableFnPointerData<'tcx, N> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "VtableFnPointer(fn_ty={:?}, nested={:?})",
@@ -133,13 +133,13 @@ impl<'tcx, N: fmt::Debug> fmt::Debug for traits::VtableFnPointerData<'tcx, N> {
 }
 
 impl<'tcx> fmt::Debug for traits::FulfillmentError<'tcx> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "FulfillmentError({:?},{:?})", self.obligation, self.code)
     }
 }
 
 impl<'tcx> fmt::Debug for traits::FulfillmentErrorCode<'tcx> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             super::CodeSelectionError(ref e) => write!(f, "{:?}", e),
             super::CodeProjectionError(ref e) => write!(f, "{:?}", e),
@@ -152,7 +152,7 @@ impl<'tcx> fmt::Debug for traits::FulfillmentErrorCode<'tcx> {
 }
 
 impl<'tcx> fmt::Debug for traits::MismatchedProjectionTypes<'tcx> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "MismatchedProjectionTypes({:?})", self.err)
     }
 }
@@ -409,7 +409,7 @@ BraceStructTypeFoldableImpl! {
 }
 
 impl<'tcx> fmt::Display for traits::WhereClause<'tcx> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         use traits::WhereClause::*;
 
         match self {
@@ -422,7 +422,7 @@ impl<'tcx> fmt::Display for traits::WhereClause<'tcx> {
 }
 
 impl<'tcx> fmt::Display for traits::WellFormed<'tcx> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         use traits::WellFormed::*;
 
         match self {
@@ -433,7 +433,7 @@ impl<'tcx> fmt::Display for traits::WellFormed<'tcx> {
 }
 
 impl<'tcx> fmt::Display for traits::FromEnv<'tcx> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         use traits::FromEnv::*;
 
         match self {
@@ -444,7 +444,7 @@ impl<'tcx> fmt::Display for traits::FromEnv<'tcx> {
 }
 
 impl<'tcx> fmt::Display for traits::DomainGoal<'tcx> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         use traits::DomainGoal::*;
 
         match self {
@@ -457,7 +457,7 @@ impl<'tcx> fmt::Display for traits::DomainGoal<'tcx> {
 }
 
 impl fmt::Display for traits::QuantifierKind {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         use traits::QuantifierKind::*;
 
         match self {
@@ -468,7 +468,7 @@ impl fmt::Display for traits::QuantifierKind {
 }
 
 impl<'tcx> fmt::Display for traits::Goal<'tcx> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         use traits::Goal::*;
 
         match self {
@@ -495,7 +495,7 @@ impl<'tcx> fmt::Display for traits::Goal<'tcx> {
 }
 
 impl<'tcx> fmt::Display for traits::ProgramClause<'tcx> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         let traits::ProgramClause { goal, hypotheses } = self;
         write!(fmt, "{}", goal)?;
         if !hypotheses.is_empty() {
@@ -512,7 +512,7 @@ impl<'tcx> fmt::Display for traits::ProgramClause<'tcx> {
 }
 
 impl<'tcx> fmt::Display for traits::Clause<'tcx> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         use traits::Clause::*;
 
         match self {

--- a/src/librustc/ty/codec.rs
+++ b/src/librustc/ty/codec.rs
@@ -320,7 +320,7 @@ macro_rules! implement_ty_decoder {
                     read_f64 -> f64;
                     read_f32 -> f32;
                     read_char -> char;
-                    read_str -> Cow<str>;
+                    read_str -> Cow<'_, str>;
                 }
 
                 fn error(&mut self, err: &str) -> Self::Error {
@@ -417,4 +417,3 @@ macro_rules! implement_ty_decoder {
         }
     }
 }
-

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -301,7 +301,7 @@ impl<'a, V> LocalTableInContext<'a, V> {
         self.data.get(&id.local_id)
     }
 
-    pub fn iter(&self) -> hash_map::Iter<hir::ItemLocalId, V> {
+    pub fn iter(&self) -> hash_map::Iter<'_, hir::ItemLocalId, V> {
         self.data.iter()
     }
 }
@@ -325,7 +325,7 @@ impl<'a, V> LocalTableInContextMut<'a, V> {
         self.data.get_mut(&id.local_id)
     }
 
-    pub fn entry(&mut self, id: hir::HirId) -> Entry<hir::ItemLocalId, V> {
+    pub fn entry(&mut self, id: hir::HirId) -> Entry<'_, hir::ItemLocalId, V> {
         validate_hir_id_for_typeck_tables(self.local_id_root, id, true);
         self.data.entry(id.local_id)
     }
@@ -483,56 +483,56 @@ impl<'tcx> TypeckTables<'tcx> {
         }
     }
 
-    pub fn type_dependent_defs(&self) -> LocalTableInContext<Def> {
+    pub fn type_dependent_defs(&self) -> LocalTableInContext<'_, Def> {
         LocalTableInContext {
             local_id_root: self.local_id_root,
             data: &self.type_dependent_defs
         }
     }
 
-    pub fn type_dependent_defs_mut(&mut self) -> LocalTableInContextMut<Def> {
+    pub fn type_dependent_defs_mut(&mut self) -> LocalTableInContextMut<'_, Def> {
         LocalTableInContextMut {
             local_id_root: self.local_id_root,
             data: &mut self.type_dependent_defs
         }
     }
 
-    pub fn field_indices(&self) -> LocalTableInContext<usize> {
+    pub fn field_indices(&self) -> LocalTableInContext<'_, usize> {
         LocalTableInContext {
             local_id_root: self.local_id_root,
             data: &self.field_indices
         }
     }
 
-    pub fn field_indices_mut(&mut self) -> LocalTableInContextMut<usize> {
+    pub fn field_indices_mut(&mut self) -> LocalTableInContextMut<'_, usize> {
         LocalTableInContextMut {
             local_id_root: self.local_id_root,
             data: &mut self.field_indices
         }
     }
 
-    pub fn user_provided_tys(&self) -> LocalTableInContext<CanonicalTy<'tcx>> {
+    pub fn user_provided_tys(&self) -> LocalTableInContext<'_, CanonicalTy<'tcx>> {
         LocalTableInContext {
             local_id_root: self.local_id_root,
             data: &self.user_provided_tys
         }
     }
 
-    pub fn user_provided_tys_mut(&mut self) -> LocalTableInContextMut<CanonicalTy<'tcx>> {
+    pub fn user_provided_tys_mut(&mut self) -> LocalTableInContextMut<'_, CanonicalTy<'tcx>> {
         LocalTableInContextMut {
             local_id_root: self.local_id_root,
             data: &mut self.user_provided_tys
         }
     }
 
-    pub fn node_types(&self) -> LocalTableInContext<Ty<'tcx>> {
+    pub fn node_types(&self) -> LocalTableInContext<'_, Ty<'tcx>> {
         LocalTableInContext {
             local_id_root: self.local_id_root,
             data: &self.node_types
         }
     }
 
-    pub fn node_types_mut(&mut self) -> LocalTableInContextMut<Ty<'tcx>> {
+    pub fn node_types_mut(&mut self) -> LocalTableInContextMut<'_, Ty<'tcx>> {
         LocalTableInContextMut {
             local_id_root: self.local_id_root,
             data: &mut self.node_types
@@ -557,7 +557,7 @@ impl<'tcx> TypeckTables<'tcx> {
         self.node_types.get(&id.local_id).cloned()
     }
 
-    pub fn node_substs_mut(&mut self) -> LocalTableInContextMut<&'tcx Substs<'tcx>> {
+    pub fn node_substs_mut(&mut self) -> LocalTableInContextMut<'_, &'tcx Substs<'tcx>> {
         LocalTableInContextMut {
             local_id_root: self.local_id_root,
             data: &mut self.node_substs
@@ -574,7 +574,7 @@ impl<'tcx> TypeckTables<'tcx> {
         self.node_substs.get(&id.local_id).cloned()
     }
 
-    pub fn user_substs_mut(&mut self) -> LocalTableInContextMut<CanonicalSubsts<'tcx>> {
+    pub fn user_substs_mut(&mut self) -> LocalTableInContextMut<'_, CanonicalSubsts<'tcx>> {
         LocalTableInContextMut {
             local_id_root: self.local_id_root,
             data: &mut self.user_substs
@@ -614,7 +614,7 @@ impl<'tcx> TypeckTables<'tcx> {
         self.node_id_to_type_opt(expr.hir_id)
     }
 
-    pub fn adjustments(&self) -> LocalTableInContext<Vec<ty::adjustment::Adjustment<'tcx>>> {
+    pub fn adjustments(&self) -> LocalTableInContext<'_, Vec<ty::adjustment::Adjustment<'tcx>>> {
         LocalTableInContext {
             local_id_root: self.local_id_root,
             data: &self.adjustments
@@ -622,7 +622,7 @@ impl<'tcx> TypeckTables<'tcx> {
     }
 
     pub fn adjustments_mut(&mut self)
-                           -> LocalTableInContextMut<Vec<ty::adjustment::Adjustment<'tcx>>> {
+                           -> LocalTableInContextMut<'_, Vec<ty::adjustment::Adjustment<'tcx>>> {
         LocalTableInContextMut {
             local_id_root: self.local_id_root,
             data: &mut self.adjustments
@@ -663,7 +663,7 @@ impl<'tcx> TypeckTables<'tcx> {
         }
     }
 
-    pub fn pat_binding_modes(&self) -> LocalTableInContext<BindingMode> {
+    pub fn pat_binding_modes(&self) -> LocalTableInContext<'_, BindingMode> {
         LocalTableInContext {
             local_id_root: self.local_id_root,
             data: &self.pat_binding_modes
@@ -671,14 +671,14 @@ impl<'tcx> TypeckTables<'tcx> {
     }
 
     pub fn pat_binding_modes_mut(&mut self)
-                           -> LocalTableInContextMut<BindingMode> {
+                           -> LocalTableInContextMut<'_, BindingMode> {
         LocalTableInContextMut {
             local_id_root: self.local_id_root,
             data: &mut self.pat_binding_modes
         }
     }
 
-    pub fn pat_adjustments(&self) -> LocalTableInContext<Vec<Ty<'tcx>>> {
+    pub fn pat_adjustments(&self) -> LocalTableInContext<'_, Vec<Ty<'tcx>>> {
         LocalTableInContext {
             local_id_root: self.local_id_root,
             data: &self.pat_adjustments,
@@ -686,7 +686,7 @@ impl<'tcx> TypeckTables<'tcx> {
     }
 
     pub fn pat_adjustments_mut(&mut self)
-                           -> LocalTableInContextMut<Vec<Ty<'tcx>>> {
+                           -> LocalTableInContextMut<'_, Vec<Ty<'tcx>>> {
         LocalTableInContextMut {
             local_id_root: self.local_id_root,
             data: &mut self.pat_adjustments,
@@ -697,56 +697,56 @@ impl<'tcx> TypeckTables<'tcx> {
         self.upvar_capture_map[&upvar_id]
     }
 
-    pub fn closure_kind_origins(&self) -> LocalTableInContext<(Span, ast::Name)> {
+    pub fn closure_kind_origins(&self) -> LocalTableInContext<'_, (Span, ast::Name)> {
         LocalTableInContext {
             local_id_root: self.local_id_root,
             data: &self.closure_kind_origins
         }
     }
 
-    pub fn closure_kind_origins_mut(&mut self) -> LocalTableInContextMut<(Span, ast::Name)> {
+    pub fn closure_kind_origins_mut(&mut self) -> LocalTableInContextMut<'_, (Span, ast::Name)> {
         LocalTableInContextMut {
             local_id_root: self.local_id_root,
             data: &mut self.closure_kind_origins
         }
     }
 
-    pub fn liberated_fn_sigs(&self) -> LocalTableInContext<ty::FnSig<'tcx>> {
+    pub fn liberated_fn_sigs(&self) -> LocalTableInContext<'_, ty::FnSig<'tcx>> {
         LocalTableInContext {
             local_id_root: self.local_id_root,
             data: &self.liberated_fn_sigs
         }
     }
 
-    pub fn liberated_fn_sigs_mut(&mut self) -> LocalTableInContextMut<ty::FnSig<'tcx>> {
+    pub fn liberated_fn_sigs_mut(&mut self) -> LocalTableInContextMut<'_, ty::FnSig<'tcx>> {
         LocalTableInContextMut {
             local_id_root: self.local_id_root,
             data: &mut self.liberated_fn_sigs
         }
     }
 
-    pub fn fru_field_types(&self) -> LocalTableInContext<Vec<Ty<'tcx>>> {
+    pub fn fru_field_types(&self) -> LocalTableInContext<'_, Vec<Ty<'tcx>>> {
         LocalTableInContext {
             local_id_root: self.local_id_root,
             data: &self.fru_field_types
         }
     }
 
-    pub fn fru_field_types_mut(&mut self) -> LocalTableInContextMut<Vec<Ty<'tcx>>> {
+    pub fn fru_field_types_mut(&mut self) -> LocalTableInContextMut<'_, Vec<Ty<'tcx>>> {
         LocalTableInContextMut {
             local_id_root: self.local_id_root,
             data: &mut self.fru_field_types
         }
     }
 
-    pub fn cast_kinds(&self) -> LocalTableInContext<ty::cast::CastKind> {
+    pub fn cast_kinds(&self) -> LocalTableInContext<'_, ty::cast::CastKind> {
         LocalTableInContext {
             local_id_root: self.local_id_root,
             data: &self.cast_kinds
         }
     }
 
-    pub fn cast_kinds_mut(&mut self) -> LocalTableInContextMut<ty::cast::CastKind> {
+    pub fn cast_kinds_mut(&mut self) -> LocalTableInContextMut<'_, ty::cast::CastKind> {
         LocalTableInContextMut {
             local_id_root: self.local_id_root,
             data: &mut self.cast_kinds
@@ -831,10 +831,11 @@ impl<'tcx> CommonTypes<'tcx> {
         // Ensure our type representation does not grow
         #[cfg(target_pointer_width = "64")]
         #[allow(dead_code)]
-        static ASSERT_TY_KIND: () = [()][!(::std::mem::size_of::<ty::TyKind>() <= 24) as usize];
+        static ASSERT_TY_KIND: () =
+            [()][!(::std::mem::size_of::<ty::TyKind<'_>>() <= 24) as usize];
         #[cfg(target_pointer_width = "64")]
         #[allow(dead_code)]
-        static ASSERT_TYS: () = [()][!(::std::mem::size_of::<ty::TyS>() <= 32) as usize];
+        static ASSERT_TYS: () = [()][!(::std::mem::size_of::<ty::TyS<'_>>() <= 32) as usize];
 
         let mk = |sty| CtxtInterners::intern_ty(interners, interners, sty);
         let mk_region = |r| {
@@ -2007,7 +2008,7 @@ pub mod tls {
 
     /// This is a callback from libsyntax as it cannot access the implicit state
     /// in librustc otherwise
-    fn span_debug(span: syntax_pos::Span, f: &mut fmt::Formatter) -> fmt::Result {
+    fn span_debug(span: syntax_pos::Span, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         with(|tcx| {
             write!(f, "{}", tcx.sess.source_map().span_to_string(span))
         })
@@ -2130,9 +2131,9 @@ pub mod tls {
         } else {
             // We could get a ImplicitCtxt pointer from another thread.
             // Ensure that ImplicitCtxt is Sync
-            sync::assert_sync::<ImplicitCtxt>();
+            sync::assert_sync::<ImplicitCtxt<'_, '_, '_>>();
 
-            unsafe { f(Some(&*(context as *const ImplicitCtxt))) }
+            unsafe { f(Some(&*(context as *const ImplicitCtxt<'_, '_, '_>))) }
         }
     }
 
@@ -2156,7 +2157,7 @@ pub mod tls {
             unsafe {
                 let gcx = tcx.gcx as *const _ as usize;
                 assert!(context.tcx.gcx as *const _ as usize == gcx);
-                let context: &ImplicitCtxt = mem::transmute(context);
+                let context: &ImplicitCtxt<'_, '_, '_> = mem::transmute(context);
                 f(context)
             }
         })
@@ -2176,7 +2177,7 @@ pub mod tls {
                 let interners = tcx.interners as *const _ as usize;
                 assert!(context.tcx.gcx as *const _ as usize == gcx);
                 assert!(context.tcx.interners as *const _ as usize == interners);
-                let context: &ImplicitCtxt = mem::transmute(context);
+                let context: &ImplicitCtxt<'_, '_, '_> = mem::transmute(context);
                 f(context)
             }
         })
@@ -2216,7 +2217,7 @@ macro_rules! sty_debug_print {
                 both_infer: usize,
             }
 
-            pub fn go(tcx: TyCtxt) {
+            pub fn go(tcx: TyCtxt<'_, '_, '_>) {
                 let mut total = DebugStat {
                     total: 0,
                     region_infer: 0, ty_infer: 0, both_infer: 0,
@@ -2458,7 +2459,7 @@ pub fn keep_local<'tcx, T: ty::TypeFoldable<'tcx>>(x: &T) -> bool {
 
 direct_interners!('tcx,
     region: mk_region(|r: &RegionKind| r.keep_in_local_tcx()) -> RegionKind,
-    const_: mk_const(|c: &Const| keep_local(&c.ty) || keep_local(&c.val)) -> Const<'tcx>
+    const_: mk_const(|c: &Const<'_>| keep_local(&c.ty) || keep_local(&c.val)) -> Const<'tcx>
 );
 
 macro_rules! slice_interners {
@@ -2467,7 +2468,7 @@ macro_rules! slice_interners {
             &[$ty<'tcx>],
             |a, v| List::from_arena(a, v),
             Deref::deref,
-            |xs: &[$ty]| xs.iter().any(keep_local)) -> List<$ty<'tcx>>);)+
+            |xs: &[$ty<'_>]| xs.iter().any(keep_local)) -> List<$ty<'tcx>>);)+
     )
 }
 
@@ -2857,7 +2858,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         iter.intern_with(|xs| self.intern_goals(xs))
     }
 
-    pub fn mk_goal(self, goal: Goal<'tcx>) -> &'tcx Goal {
+    pub fn mk_goal(self, goal: Goal<'tcx>) -> &'tcx Goal<'_> {
         &self.intern_goals(&[goal])[0]
     }
 
@@ -3024,7 +3025,7 @@ impl<T, R, E> InternIteratorElement<T, R> for Result<T, E> {
     }
 }
 
-pub fn provide(providers: &mut ty::query::Providers) {
+pub fn provide(providers: &mut ty::query::Providers<'_>) {
     // FIXME(#44234) - almost all of these queries have no sub-queries and
     // therefore no actual inputs, they're just reading tables calculated in
     // resolve! Does this work? Unsure! That's what the issue is about

--- a/src/librustc/ty/erase_regions.rs
+++ b/src/librustc/ty/erase_regions.rs
@@ -11,7 +11,7 @@
 use ty::{self, Ty, TyCtxt};
 use ty::fold::{TypeFolder, TypeFoldable};
 
-pub(super) fn provide(providers: &mut ty::query::Providers) {
+pub(super) fn provide(providers: &mut ty::query::Providers<'_>) {
     *providers = ty::query::Providers {
         erase_regions_ty,
         ..*providers

--- a/src/librustc/ty/error.rs
+++ b/src/librustc/ty/error.rs
@@ -68,9 +68,9 @@ pub enum UnconstrainedNumeric {
 /// afterwards to present additional details, particularly when it comes to lifetime-related
 /// errors.
 impl<'tcx> fmt::Display for TypeError<'tcx> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use self::TypeError::*;
-        fn report_maybe_different(f: &mut fmt::Formatter,
+        fn report_maybe_different(f: &mut fmt::Formatter<'_>,
                                   expected: String, found: String) -> fmt::Result {
             // A naive approach to making sure that we're not reporting silly errors such as:
             // (expected closure, found closure).
@@ -237,7 +237,7 @@ impl<'a, 'gcx, 'lcx, 'tcx> ty::TyS<'tcx> {
 
 impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
     pub fn note_and_explain_type_err(self,
-                                     db: &mut DiagnosticBuilder,
+                                     db: &mut DiagnosticBuilder<'_>,
                                      err: &TypeError<'tcx>,
                                      sp: Span) {
         use self::TypeError::*;

--- a/src/librustc/ty/fast_reject.rs
+++ b/src/librustc/ty/fast_reject.rs
@@ -63,7 +63,7 @@ pub enum SimplifiedTypeGen<D>
 /// `can_simplify_params` should be true if type parameters appear free in `ty` and `false` if they
 /// are to be considered bound.
 pub fn simplify_type<'a, 'gcx, 'tcx>(tcx: TyCtxt<'a, 'gcx, 'tcx>,
-                                     ty: Ty,
+                                     ty: Ty<'_>,
                                      can_simplify_params: bool)
                                      -> Option<SimplifiedType>
 {

--- a/src/librustc/ty/flags.rs
+++ b/src/librustc/ty/flags.rs
@@ -28,7 +28,7 @@ impl FlagComputation {
         }
     }
 
-    pub fn for_sty(st: &ty::TyKind) -> FlagComputation {
+    pub fn for_sty(st: &ty::TyKind<'_>) -> FlagComputation {
         let mut result = FlagComputation::new();
         result.add_sty(st);
         result
@@ -67,7 +67,7 @@ impl FlagComputation {
         }
     }
 
-    fn add_sty(&mut self, st: &ty::TyKind) {
+    fn add_sty(&mut self, st: &ty::TyKind<'_>) {
         match st {
             &ty::Bool |
             &ty::Char |
@@ -204,18 +204,18 @@ impl FlagComputation {
         }
     }
 
-    fn add_ty(&mut self, ty: Ty) {
+    fn add_ty(&mut self, ty: Ty<'_>) {
         self.add_flags(ty.flags);
         self.add_exclusive_binder(ty.outer_exclusive_binder);
     }
 
-    fn add_tys(&mut self, tys: &[Ty]) {
+    fn add_tys(&mut self, tys: &[Ty<'_>]) {
         for &ty in tys {
             self.add_ty(ty);
         }
     }
 
-    fn add_fn_sig(&mut self, fn_sig: ty::PolyFnSig) {
+    fn add_fn_sig(&mut self, fn_sig: ty::PolyFnSig<'_>) {
         let mut computation = FlagComputation::new();
 
         computation.add_tys(fn_sig.skip_binder().inputs());
@@ -224,14 +224,14 @@ impl FlagComputation {
         self.add_bound_computation(&computation);
     }
 
-    fn add_region(&mut self, r: ty::Region) {
+    fn add_region(&mut self, r: ty::Region<'_>) {
         self.add_flags(r.type_flags());
         if let ty::ReLateBound(debruijn, _) = *r {
             self.add_binder(debruijn);
         }
     }
 
-    fn add_const(&mut self, constant: &ty::Const) {
+    fn add_const(&mut self, constant: &ty::Const<'_>) {
         self.add_ty(constant.ty);
         if let ConstValue::Unevaluated(_, substs) = constant.val {
             self.add_flags(TypeFlags::HAS_PROJECTION);
@@ -239,16 +239,16 @@ impl FlagComputation {
         }
     }
 
-    fn add_existential_projection(&mut self, projection: &ty::ExistentialProjection) {
+    fn add_existential_projection(&mut self, projection: &ty::ExistentialProjection<'_>) {
         self.add_substs(projection.substs);
         self.add_ty(projection.ty);
     }
 
-    fn add_projection_ty(&mut self, projection_ty: &ty::ProjectionTy) {
+    fn add_projection_ty(&mut self, projection_ty: &ty::ProjectionTy<'_>) {
         self.add_substs(projection_ty.substs);
     }
 
-    fn add_substs(&mut self, substs: &Substs) {
+    fn add_substs(&mut self, substs: &Substs<'_>) {
         for ty in substs.types() {
             self.add_ty(ty);
         }

--- a/src/librustc/ty/fold.rs
+++ b/src/librustc/ty/fold.rs
@@ -708,7 +708,7 @@ struct HasTypeFlagsVisitor {
 }
 
 impl<'tcx> TypeVisitor<'tcx> for HasTypeFlagsVisitor {
-    fn visit_ty(&mut self, t: Ty) -> bool {
+    fn visit_ty(&mut self, t: Ty<'_>) -> bool {
         debug!("HasTypeFlagsVisitor: t={:?} t.flags={:?} self.flags={:?}", t, t.flags, self.flags);
         t.flags.intersects(self.flags)
     }

--- a/src/librustc/ty/instance.rs
+++ b/src/librustc/ty/instance.rs
@@ -114,7 +114,7 @@ impl<'tcx> InstanceDef<'tcx> {
 }
 
 impl<'tcx> fmt::Display for Instance<'tcx> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         ppaux::parameterized(f, self.substs, self.def_id(), &[])?;
         match self.def {
             InstanceDef::Item(_) => Ok(()),

--- a/src/librustc/ty/item_path.rs
+++ b/src/librustc/ty/item_path.rs
@@ -355,7 +355,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
 /// function tries to find a "characteristic def-id" for a
 /// type. It's just a heuristic so it makes some questionable
 /// decisions and we may want to adjust it later.
-pub fn characteristic_def_id_of_type(ty: Ty) -> Option<DefId> {
+pub fn characteristic_def_id_of_type(ty: Ty<'_>) -> Option<DefId> {
     match ty.sty {
         ty::Adt(adt_def, _) => Some(adt_def.did),
 

--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -157,7 +157,7 @@ pub enum LayoutError<'tcx> {
 }
 
 impl<'tcx> fmt::Display for LayoutError<'tcx> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             LayoutError::Unknown(ty) => {
                 write!(f, "the type `{:?}` has an unknown layout", ty)
@@ -195,7 +195,7 @@ fn layout_raw<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     })
 }
 
-pub fn provide(providers: &mut ty::query::Providers) {
+pub fn provide(providers: &mut ty::query::Providers<'_>) {
     *providers = ty::query::Providers {
         layout_raw,
         ..*providers
@@ -250,7 +250,7 @@ impl<'a, 'tcx> LayoutCx<'tcx, TyCtxt<'a, 'tcx, 'tcx>> {
             /// A univariant, but with a prefix of an arbitrary size & alignment (e.g. enum tag).
             Prefixed(Size, Align),
         }
-        let univariant_uninterned = |fields: &[TyLayout], repr: &ReprOptions, kind| {
+        let univariant_uninterned = |fields: &[TyLayout<'_>], repr: &ReprOptions, kind| {
             let packed = repr.packed();
             if packed && repr.align > 0 {
                 bug!("struct cannot be packed and aligned");
@@ -283,7 +283,7 @@ impl<'a, 'tcx> LayoutCx<'tcx, TyCtxt<'a, 'tcx, 'tcx>> {
                     fields.len()
                 };
                 let optimizing = &mut inverse_memory_index[..end];
-                let field_align = |f: &TyLayout| {
+                let field_align = |f: &TyLayout<'_>| {
                     if packed { f.align.min(pack).abi() } else { f.align.abi() }
                 };
                 match kind {
@@ -464,7 +464,7 @@ impl<'a, 'tcx> LayoutCx<'tcx, TyCtxt<'a, 'tcx, 'tcx>> {
                 size
             })
         };
-        let univariant = |fields: &[TyLayout], repr: &ReprOptions, kind| {
+        let univariant = |fields: &[TyLayout<'_>], repr: &ReprOptions, kind| {
             Ok(tcx.intern_layout(univariant_uninterned(fields, repr, kind)?))
         };
         debug_assert!(!ty.has_infer_types());
@@ -723,7 +723,7 @@ impl<'a, 'tcx> LayoutCx<'tcx, TyCtxt<'a, 'tcx, 'tcx>> {
                 // but *not* an encoding of the discriminant (e.g. a tag value).
                 // See issue #49298 for more details on the need to leave space
                 // for non-ZST uninhabited data (mostly partial initialization).
-                let absent = |fields: &[TyLayout]| {
+                let absent = |fields: &[TyLayout<'_>]| {
                     let uninhabited = fields.iter().any(|f| f.abi == Abi::Uninhabited);
                     let is_zst = fields.iter().all(|f| f.is_zst());
                     uninhabited && is_zst
@@ -1403,7 +1403,7 @@ impl<'a, 'tcx> SizeSkeleton<'tcx> {
         }
     }
 
-    pub fn same_size(self, other: SizeSkeleton) -> bool {
+    pub fn same_size(self, other: SizeSkeleton<'_>) -> bool {
         match (self, other) {
             (SizeSkeleton::Known(a), SizeSkeleton::Known(b)) => a == b,
             (SizeSkeleton::Pointer { tail: a, .. },

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -273,7 +273,7 @@ impl<'a, 'gcx, 'tcx> DefIdTree for TyCtxt<'a, 'gcx, 'tcx> {
 }
 
 impl Visibility {
-    pub fn from_hir(visibility: &hir::Visibility, id: NodeId, tcx: TyCtxt) -> Self {
+    pub fn from_hir(visibility: &hir::Visibility, id: NodeId, tcx: TyCtxt<'_, '_, '_>) -> Self {
         match visibility.node {
             hir::VisibilityKind::Public => Visibility::Public,
             hir::VisibilityKind::Crate(_) => Visibility::Restricted(DefId::local(CRATE_DEF_INDEX)),
@@ -536,7 +536,7 @@ impl<'tcx> Eq for TyS<'tcx> {}
 
 impl<'tcx> Hash for TyS<'tcx> {
     fn hash<H: Hasher>(&self, s: &mut H) {
-        (self as *const TyS).hash(s)
+        (self as *const TyS<'_>).hash(s)
     }
 }
 
@@ -649,7 +649,7 @@ impl<T: Copy> List<T> {
 }
 
 impl<T: fmt::Debug> fmt::Debug for List<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         (**self).fmt(f)
     }
 }
@@ -1263,7 +1263,7 @@ impl<'tcx> PolyProjectionPredicate<'tcx> {
         self.skip_binder().projection_ty.item_def_id
     }
 
-    pub fn to_poly_trait_ref(&self, tcx: TyCtxt) -> PolyTraitRef<'tcx> {
+    pub fn to_poly_trait_ref(&self, tcx: TyCtxt<'_, '_, '_>) -> PolyTraitRef<'tcx> {
         // Note: unlike with TraitRef::to_poly_trait_ref(),
         // self.0.trait_ref is permitted to have escaping regions.
         // This is because here `self` has a `Binder` and so does our
@@ -1541,7 +1541,7 @@ impl UniverseIndex {
 }
 
 impl fmt::Debug for UniverseIndex {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(fmt, "U{}", self.as_u32())
     }
 }
@@ -1931,7 +1931,7 @@ impl_stable_hash_for!(struct ReprOptions {
 });
 
 impl ReprOptions {
-    pub fn new(tcx: TyCtxt, did: DefId) -> ReprOptions {
+    pub fn new(tcx: TyCtxt<'_, '_, '_>, did: DefId) -> ReprOptions {
         let mut flags = ReprFlags::empty();
         let mut size = None;
         let mut max_align = 0;
@@ -1999,7 +1999,7 @@ impl ReprOptions {
 }
 
 impl<'a, 'gcx, 'tcx> AdtDef {
-    fn new(tcx: TyCtxt,
+    fn new(tcx: TyCtxt<'_, '_, '_>,
            did: DefId,
            kind: AdtKind,
            variants: Vec<VariantDef>,
@@ -2644,7 +2644,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         }
     }
 
-    pub fn field_index(self, node_id: NodeId, tables: &TypeckTables) -> usize {
+    pub fn field_index(self, node_id: NodeId, tables: &TypeckTables<'_>) -> usize {
         let hir_id = self.hir.node_to_hir_id(node_id);
         tables.field_indices().get(hir_id).cloned().expect("no index for a field")
     }
@@ -2971,7 +2971,7 @@ fn trait_of_item<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) -> Option
 }
 
 /// Yields the parent function's `DefId` if `def_id` is an `impl Trait` definition
-pub fn is_impl_trait_defn(tcx: TyCtxt, def_id: DefId) -> Option<DefId> {
+pub fn is_impl_trait_defn(tcx: TyCtxt<'_, '_, '_>, def_id: DefId) -> Option<DefId> {
     if let Some(node_id) = tcx.hir.as_local_node_id(def_id) {
         if let Node::Item(item) = tcx.hir.get(node_id) {
             if let hir::ItemKind::Existential(ref exist_ty) = item.node {
@@ -3051,7 +3051,7 @@ fn instance_def_size_estimate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     }
 }
 
-pub fn provide(providers: &mut ty::query::Providers) {
+pub fn provide(providers: &mut ty::query::Providers<'_>) {
     context::provide(providers);
     erase_regions::provide(providers);
     layout::provide(providers);
@@ -3106,13 +3106,13 @@ impl SymbolName {
 }
 
 impl fmt::Display for SymbolName {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&self.name, fmt)
     }
 }
 
 impl fmt::Debug for SymbolName {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&self.name, fmt)
     }
 }

--- a/src/librustc/ty/query/README.md
+++ b/src/librustc/ty/query/README.md
@@ -294,7 +294,7 @@ You can put new impls into the `config` module. They look something like this:
 
 ```rust
 impl<'tcx> QueryDescription for queries::type_of<'tcx> {
-    fn describe(tcx: TyCtxt, key: DefId) -> String {
+    fn describe(tcx: TyCtxt<'_, '_, '_>, key: DefId) -> String {
         format!("computing the type of `{}`", tcx.item_path_str(key))
     }
 }

--- a/src/librustc/ty/query/config.rs
+++ b/src/librustc/ty/query/config.rs
@@ -55,7 +55,7 @@ pub(super) trait QueryAccessors<'tcx>: QueryConfig<'tcx> {
 }
 
 pub(super) trait QueryDescription<'tcx>: QueryAccessors<'tcx> {
-    fn describe(tcx: TyCtxt, key: Self::Key) -> String;
+    fn describe(tcx: TyCtxt<'_, '_, '_>, key: Self::Key) -> String;
 
     #[inline]
     fn cache_on_disk(_: Self::Key) -> bool {
@@ -70,7 +70,7 @@ pub(super) trait QueryDescription<'tcx>: QueryAccessors<'tcx> {
 }
 
 impl<'tcx, M: QueryAccessors<'tcx, Key=DefId>> QueryDescription<'tcx> for M {
-    default fn describe(tcx: TyCtxt, def_id: DefId) -> String {
+    default fn describe(tcx: TyCtxt<'_, '_, '_>, def_id: DefId) -> String {
         if !tcx.sess.verbose() {
             format!("processing `{}`", tcx.item_path_str(def_id))
         } else {
@@ -82,7 +82,7 @@ impl<'tcx, M: QueryAccessors<'tcx, Key=DefId>> QueryDescription<'tcx> for M {
 
 impl<'tcx> QueryDescription<'tcx> for queries::normalize_projection_ty<'tcx> {
     fn describe(
-        _tcx: TyCtxt,
+        _tcx: TyCtxt<'_, '_, '_>,
         goal: CanonicalProjectionGoal<'tcx>,
     ) -> String {
         format!("normalizing `{:?}`", goal)
@@ -90,56 +90,57 @@ impl<'tcx> QueryDescription<'tcx> for queries::normalize_projection_ty<'tcx> {
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::implied_outlives_bounds<'tcx> {
-    fn describe(_tcx: TyCtxt, goal: CanonicalTyGoal<'tcx>) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, goal: CanonicalTyGoal<'tcx>) -> String {
         format!("computing implied outlives bounds for `{:?}`", goal)
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::dropck_outlives<'tcx> {
-    fn describe(_tcx: TyCtxt, goal: CanonicalTyGoal<'tcx>) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, goal: CanonicalTyGoal<'tcx>) -> String {
         format!("computing dropck types for `{:?}`", goal)
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::normalize_ty_after_erasing_regions<'tcx> {
-    fn describe(_tcx: TyCtxt, goal: ParamEnvAnd<'tcx, Ty<'tcx>>) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, goal: ParamEnvAnd<'tcx, Ty<'tcx>>) -> String {
         format!("normalizing `{:?}`", goal)
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::evaluate_obligation<'tcx> {
-    fn describe(_tcx: TyCtxt, goal: CanonicalPredicateGoal<'tcx>) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, goal: CanonicalPredicateGoal<'tcx>) -> String {
         format!("evaluating trait selection obligation `{}`", goal.value.value)
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::type_op_eq<'tcx> {
-    fn describe(_tcx: TyCtxt, goal: CanonicalTypeOpEqGoal<'tcx>) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, goal: CanonicalTypeOpEqGoal<'tcx>) -> String {
         format!("evaluating `type_op_eq` `{:?}`", goal)
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::type_op_subtype<'tcx> {
-    fn describe(_tcx: TyCtxt, goal: CanonicalTypeOpSubtypeGoal<'tcx>) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, goal: CanonicalTypeOpSubtypeGoal<'tcx>) -> String {
         format!("evaluating `type_op_subtype` `{:?}`", goal)
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::type_op_prove_predicate<'tcx> {
-    fn describe(_tcx: TyCtxt, goal: CanonicalTypeOpProvePredicateGoal<'tcx>) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, goal: CanonicalTypeOpProvePredicateGoal<'tcx>) -> String {
         format!("evaluating `type_op_prove_predicate` `{:?}`", goal)
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::type_op_normalize_ty<'tcx> {
-    fn describe(_tcx: TyCtxt, goal: CanonicalTypeOpNormalizeGoal<'tcx, Ty<'tcx>>) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>,
+                goal: CanonicalTypeOpNormalizeGoal<'tcx, Ty<'tcx>>) -> String {
         format!("normalizing `{:?}`", goal)
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::type_op_normalize_predicate<'tcx> {
     fn describe(
-        _tcx: TyCtxt,
+        _tcx: TyCtxt<'_, '_, '_>,
         goal: CanonicalTypeOpNormalizeGoal<'tcx, ty::Predicate<'tcx>>,
     ) -> String {
         format!("normalizing `{:?}`", goal)
@@ -148,7 +149,7 @@ impl<'tcx> QueryDescription<'tcx> for queries::type_op_normalize_predicate<'tcx>
 
 impl<'tcx> QueryDescription<'tcx> for queries::type_op_normalize_poly_fn_sig<'tcx> {
     fn describe(
-        _tcx: TyCtxt,
+        _tcx: TyCtxt<'_, '_, '_>,
         goal: CanonicalTypeOpNormalizeGoal<'tcx, ty::PolyFnSig<'tcx>>,
     ) -> String {
         format!("normalizing `{:?}`", goal)
@@ -156,56 +157,57 @@ impl<'tcx> QueryDescription<'tcx> for queries::type_op_normalize_poly_fn_sig<'tc
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::type_op_normalize_fn_sig<'tcx> {
-    fn describe(_tcx: TyCtxt, goal: CanonicalTypeOpNormalizeGoal<'tcx, ty::FnSig<'tcx>>) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>,
+                goal: CanonicalTypeOpNormalizeGoal<'tcx, ty::FnSig<'tcx>>) -> String {
         format!("normalizing `{:?}`", goal)
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::is_copy_raw<'tcx> {
-    fn describe(_tcx: TyCtxt, env: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, env: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> String {
         format!("computing whether `{}` is `Copy`", env.value)
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::is_sized_raw<'tcx> {
-    fn describe(_tcx: TyCtxt, env: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, env: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> String {
         format!("computing whether `{}` is `Sized`", env.value)
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::is_freeze_raw<'tcx> {
-    fn describe(_tcx: TyCtxt, env: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, env: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> String {
         format!("computing whether `{}` is freeze", env.value)
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::needs_drop_raw<'tcx> {
-    fn describe(_tcx: TyCtxt, env: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, env: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> String {
         format!("computing whether `{}` needs drop", env.value)
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::layout_raw<'tcx> {
-    fn describe(_tcx: TyCtxt, env: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, env: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> String {
         format!("computing layout of `{}`", env.value)
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::super_predicates_of<'tcx> {
-    fn describe(tcx: TyCtxt, def_id: DefId) -> String {
+    fn describe(tcx: TyCtxt<'_, '_, '_>, def_id: DefId) -> String {
         format!("computing the supertraits of `{}`",
                 tcx.item_path_str(def_id))
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::erase_regions_ty<'tcx> {
-    fn describe(_tcx: TyCtxt, ty: Ty<'tcx>) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, ty: Ty<'tcx>) -> String {
         format!("erasing regions from `{:?}`", ty)
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::type_param_predicates<'tcx> {
-    fn describe(tcx: TyCtxt, (_, def_id): (DefId, DefId)) -> String {
+    fn describe(tcx: TyCtxt<'_, '_, '_>, (_, def_id): (DefId, DefId)) -> String {
         let id = tcx.hir.as_local_node_id(def_id).unwrap();
         format!("computing the bounds for type parameter `{}`",
                 tcx.hir.ty_param_name(id))
@@ -213,69 +215,69 @@ impl<'tcx> QueryDescription<'tcx> for queries::type_param_predicates<'tcx> {
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::coherent_trait<'tcx> {
-    fn describe(tcx: TyCtxt, def_id: DefId) -> String {
+    fn describe(tcx: TyCtxt<'_, '_, '_>, def_id: DefId) -> String {
         format!("coherence checking all impls of trait `{}`",
                 tcx.item_path_str(def_id))
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::upstream_monomorphizations<'tcx> {
-    fn describe(_: TyCtxt, k: CrateNum) -> String {
+    fn describe(_: TyCtxt<'_, '_, '_>, k: CrateNum) -> String {
         format!("collecting available upstream monomorphizations `{:?}`", k)
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::crate_inherent_impls<'tcx> {
-    fn describe(_: TyCtxt, k: CrateNum) -> String {
+    fn describe(_: TyCtxt<'_, '_, '_>, k: CrateNum) -> String {
         format!("all inherent impls defined in crate `{:?}`", k)
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::crate_inherent_impls_overlap_check<'tcx> {
-    fn describe(_: TyCtxt, _: CrateNum) -> String {
+    fn describe(_: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "check for overlap between inherent impls defined in this crate".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::crate_variances<'tcx> {
-    fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "computing the variances for items in this crate".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::inferred_outlives_crate<'tcx> {
-    fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "computing the inferred outlives predicates for items in this crate".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::mir_shims<'tcx> {
-    fn describe(tcx: TyCtxt, def: ty::InstanceDef<'tcx>) -> String {
+    fn describe(tcx: TyCtxt<'_, '_, '_>, def: ty::InstanceDef<'tcx>) -> String {
         format!("generating MIR shim for `{}`",
                 tcx.item_path_str(def.def_id()))
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::privacy_access_levels<'tcx> {
-    fn describe(_: TyCtxt, _: CrateNum) -> String {
+    fn describe(_: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "privacy access levels".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::typeck_item_bodies<'tcx> {
-    fn describe(_: TyCtxt, _: CrateNum) -> String {
+    fn describe(_: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "type-checking all item bodies".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::reachable_set<'tcx> {
-    fn describe(_: TyCtxt, _: CrateNum) -> String {
+    fn describe(_: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "reachability".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::const_eval<'tcx> {
-    fn describe(tcx: TyCtxt, key: ty::ParamEnvAnd<'tcx, GlobalId<'tcx>>) -> String {
+    fn describe(tcx: TyCtxt<'_, '_, '_>, key: ty::ParamEnvAnd<'tcx, GlobalId<'tcx>>) -> String {
         format!("const-evaluating `{}`", tcx.item_path_str(key.value.instance.def.def_id()))
     }
 
@@ -293,13 +295,13 @@ impl<'tcx> QueryDescription<'tcx> for queries::const_eval<'tcx> {
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::mir_keys<'tcx> {
-    fn describe(_: TyCtxt, _: CrateNum) -> String {
+    fn describe(_: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "getting a list of all mir_keys".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::symbol_name<'tcx> {
-    fn describe(_tcx: TyCtxt, instance: ty::Instance<'tcx>) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, instance: ty::Instance<'tcx>) -> String {
         format!("computing the symbol for `{}`", instance)
     }
 
@@ -317,62 +319,62 @@ impl<'tcx> QueryDescription<'tcx> for queries::symbol_name<'tcx> {
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::describe_def<'tcx> {
-    fn describe(_: TyCtxt, _: DefId) -> String {
+    fn describe(_: TyCtxt<'_, '_, '_>, _: DefId) -> String {
         bug!("describe_def")
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::def_span<'tcx> {
-    fn describe(_: TyCtxt, _: DefId) -> String {
+    fn describe(_: TyCtxt<'_, '_, '_>, _: DefId) -> String {
         bug!("def_span")
     }
 }
 
 
 impl<'tcx> QueryDescription<'tcx> for queries::lookup_stability<'tcx> {
-    fn describe(_: TyCtxt, _: DefId) -> String {
+    fn describe(_: TyCtxt<'_, '_, '_>, _: DefId) -> String {
         bug!("stability")
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::lookup_deprecation_entry<'tcx> {
-    fn describe(_: TyCtxt, _: DefId) -> String {
+    fn describe(_: TyCtxt<'_, '_, '_>, _: DefId) -> String {
         bug!("deprecation")
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::item_attrs<'tcx> {
-    fn describe(_: TyCtxt, _: DefId) -> String {
+    fn describe(_: TyCtxt<'_, '_, '_>, _: DefId) -> String {
         bug!("item_attrs")
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::is_reachable_non_generic<'tcx> {
-    fn describe(_: TyCtxt, _: DefId) -> String {
+    fn describe(_: TyCtxt<'_, '_, '_>, _: DefId) -> String {
         bug!("is_reachable_non_generic")
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::fn_arg_names<'tcx> {
-    fn describe(_: TyCtxt, _: DefId) -> String {
+    fn describe(_: TyCtxt<'_, '_, '_>, _: DefId) -> String {
         bug!("fn_arg_names")
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::impl_parent<'tcx> {
-    fn describe(_: TyCtxt, _: DefId) -> String {
+    fn describe(_: TyCtxt<'_, '_, '_>, _: DefId) -> String {
         bug!("impl_parent")
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::trait_of_item<'tcx> {
-    fn describe(_: TyCtxt, _: DefId) -> String {
+    fn describe(_: TyCtxt<'_, '_, '_>, _: DefId) -> String {
         bug!("trait_of_item")
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::const_is_rvalue_promotable_to_static<'tcx> {
-    fn describe(tcx: TyCtxt, def_id: DefId) -> String {
+    fn describe(tcx: TyCtxt<'_, '_, '_>, def_id: DefId) -> String {
         format!("const checking if rvalue is promotable to static `{}`",
             tcx.item_path_str(def_id))
     }
@@ -391,21 +393,22 @@ impl<'tcx> QueryDescription<'tcx> for queries::const_is_rvalue_promotable_to_sta
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::rvalue_promotable_map<'tcx> {
-    fn describe(tcx: TyCtxt, def_id: DefId) -> String {
+    fn describe(tcx: TyCtxt<'_, '_, '_>, def_id: DefId) -> String {
         format!("checking which parts of `{}` are promotable to static",
                 tcx.item_path_str(def_id))
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::is_mir_available<'tcx> {
-    fn describe(tcx: TyCtxt, def_id: DefId) -> String {
+    fn describe(tcx: TyCtxt<'_, '_, '_>, def_id: DefId) -> String {
         format!("checking if item is mir available: `{}`",
             tcx.item_path_str(def_id))
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::codegen_fulfill_obligation<'tcx> {
-    fn describe(tcx: TyCtxt, key: (ty::ParamEnv<'tcx>, ty::PolyTraitRef<'tcx>)) -> String {
+    fn describe(tcx: TyCtxt<'_, '_, '_>,
+                key: (ty::ParamEnv<'tcx>, ty::PolyTraitRef<'tcx>)) -> String {
         format!("checking if `{}` fulfills its obligations", tcx.item_path_str(key.1.def_id()))
     }
 
@@ -423,319 +426,319 @@ impl<'tcx> QueryDescription<'tcx> for queries::codegen_fulfill_obligation<'tcx> 
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::trait_impls_of<'tcx> {
-    fn describe(tcx: TyCtxt, def_id: DefId) -> String {
+    fn describe(tcx: TyCtxt<'_, '_, '_>, def_id: DefId) -> String {
         format!("trait impls of `{}`", tcx.item_path_str(def_id))
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::is_object_safe<'tcx> {
-    fn describe(tcx: TyCtxt, def_id: DefId) -> String {
+    fn describe(tcx: TyCtxt<'_, '_, '_>, def_id: DefId) -> String {
         format!("determine object safety of trait `{}`", tcx.item_path_str(def_id))
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::is_const_fn<'tcx> {
-    fn describe(tcx: TyCtxt, def_id: DefId) -> String {
+    fn describe(tcx: TyCtxt<'_, '_, '_>, def_id: DefId) -> String {
         format!("checking if item is const fn: `{}`", tcx.item_path_str(def_id))
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::dylib_dependency_formats<'tcx> {
-    fn describe(_: TyCtxt, _: CrateNum) -> String {
+    fn describe(_: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "dylib dependency formats of crate".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::is_panic_runtime<'tcx> {
-    fn describe(_: TyCtxt, _: CrateNum) -> String {
+    fn describe(_: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "checking if the crate is_panic_runtime".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::is_compiler_builtins<'tcx> {
-    fn describe(_: TyCtxt, _: CrateNum) -> String {
+    fn describe(_: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "checking if the crate is_compiler_builtins".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::has_global_allocator<'tcx> {
-    fn describe(_: TyCtxt, _: CrateNum) -> String {
+    fn describe(_: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "checking if the crate has_global_allocator".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::has_panic_handler<'tcx> {
-    fn describe(_: TyCtxt, _: CrateNum) -> String {
+    fn describe(_: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "checking if the crate has_panic_handler".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::extern_crate<'tcx> {
-    fn describe(_: TyCtxt, _: DefId) -> String {
+    fn describe(_: TyCtxt<'_, '_, '_>, _: DefId) -> String {
         "getting crate's ExternCrateData".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::lint_levels<'tcx> {
-    fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "computing the lint levels for items in this crate".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::specializes<'tcx> {
-    fn describe(_tcx: TyCtxt, _: (DefId, DefId)) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: (DefId, DefId)) -> String {
         "computing whether impls specialize one another".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::in_scope_traits_map<'tcx> {
-    fn describe(_tcx: TyCtxt, _: DefIndex) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: DefIndex) -> String {
         "traits in scope at a block".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::is_no_builtins<'tcx> {
-    fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "test whether a crate has #![no_builtins]".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::panic_strategy<'tcx> {
-    fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "query a crate's configured panic strategy".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::is_profiler_runtime<'tcx> {
-    fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "query a crate is #![profiler_runtime]".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::is_sanitizer_runtime<'tcx> {
-    fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "query a crate is #![sanitizer_runtime]".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::reachable_non_generics<'tcx> {
-    fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "looking up the exported symbols of a crate".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::native_libraries<'tcx> {
-    fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "looking up the native libraries of a linked crate".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::foreign_modules<'tcx> {
-    fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "looking up the foreign modules of a linked crate".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::plugin_registrar_fn<'tcx> {
-    fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "looking up the plugin registrar for a crate".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::derive_registrar_fn<'tcx> {
-    fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "looking up the derive registrar for a crate".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::crate_disambiguator<'tcx> {
-    fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "looking up the disambiguator a crate".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::crate_hash<'tcx> {
-    fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "looking up the hash a crate".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::original_crate_name<'tcx> {
-    fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "looking up the original name a crate".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::extra_filename<'tcx> {
-    fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "looking up the extra filename for a crate".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::implementations_of_trait<'tcx> {
-    fn describe(_tcx: TyCtxt, _: (CrateNum, DefId)) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: (CrateNum, DefId)) -> String {
         "looking up implementations of a trait in a crate".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::all_trait_implementations<'tcx> {
-    fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "looking up all (?) trait implementations".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::link_args<'tcx> {
-    fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "looking up link arguments for a crate".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::resolve_lifetimes<'tcx> {
-    fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "resolving lifetimes".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::named_region_map<'tcx> {
-    fn describe(_tcx: TyCtxt, _: DefIndex) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: DefIndex) -> String {
         "looking up a named region".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::is_late_bound_map<'tcx> {
-    fn describe(_tcx: TyCtxt, _: DefIndex) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: DefIndex) -> String {
         "testing if a region is late bound".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::object_lifetime_defaults_map<'tcx> {
-    fn describe(_tcx: TyCtxt, _: DefIndex) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: DefIndex) -> String {
         "looking up lifetime defaults for a region".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::dep_kind<'tcx> {
-    fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "fetching what a dependency looks like".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::crate_name<'tcx> {
-    fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "fetching what a crate is named".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::get_lib_features<'tcx> {
-    fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         format!("calculating the lib features map")
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::defined_lib_features<'tcx> {
-    fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         format!("calculating the lib features defined in a crate")
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::get_lang_items<'tcx> {
-    fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "calculating the lang items map".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::defined_lang_items<'tcx> {
-    fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "calculating the lang items defined in a crate".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::missing_lang_items<'tcx> {
-    fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "calculating the missing lang items in a crate".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::visible_parent_map<'tcx> {
-    fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "calculating the visible parent map".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::missing_extern_crate_item<'tcx> {
-    fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "seeing if we're missing an `extern crate` item for this crate".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::used_crate_source<'tcx> {
-    fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "looking at the source for a crate".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::postorder_cnums<'tcx> {
-    fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "generating a postorder list of CrateNums".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::maybe_unused_extern_crates<'tcx> {
-    fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "looking up all possibly unused extern crates".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::stability_index<'tcx> {
-    fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "calculating the stability index for the local crate".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::all_traits<'tcx> {
-    fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "fetching all foreign and local traits".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::all_crate_nums<'tcx> {
-    fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "fetching all foreign CrateNum instances".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::exported_symbols<'tcx> {
-    fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "exported_symbols".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::collect_and_partition_mono_items<'tcx> {
-    fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "collect_and_partition_mono_items".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::codegen_unit<'tcx> {
-    fn describe(_tcx: TyCtxt, _: InternedString) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: InternedString) -> String {
         "codegen_unit".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::output_filenames<'tcx> {
-    fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "output_filenames".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::vtable_methods<'tcx> {
-    fn describe(tcx: TyCtxt, key: ty::PolyTraitRef<'tcx> ) -> String {
+    fn describe(tcx: TyCtxt<'_, '_, '_>, key: ty::PolyTraitRef<'tcx> ) -> String {
         format!("finding all methods for trait {}", tcx.item_path_str(key.def_id()))
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::features_query<'tcx> {
-    fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "looking up enabled feature gates".to_string()
     }
 }
@@ -773,19 +776,19 @@ impl<'tcx> QueryDescription<'tcx> for queries::optimized_mir<'tcx> {
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::substitute_normalize_and_test_predicates<'tcx> {
-    fn describe(tcx: TyCtxt, key: (DefId, &'tcx Substs<'tcx>)) -> String {
+    fn describe(tcx: TyCtxt<'_, '_, '_>, key: (DefId, &'tcx Substs<'tcx>)) -> String {
         format!("testing substituted normalized predicates:`{}`", tcx.item_path_str(key.0))
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::target_features_whitelist<'tcx> {
-    fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "looking up the whitelist of target features".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::instance_def_size_estimate<'tcx> {
-    fn describe(tcx: TyCtxt, def: ty::InstanceDef<'tcx>) -> String {
+    fn describe(tcx: TyCtxt<'_, '_, '_>, def: ty::InstanceDef<'tcx>) -> String {
         format!("estimating size for `{}`", tcx.item_path_str(def.def_id()))
     }
 }
@@ -806,25 +809,25 @@ impl<'tcx> QueryDescription<'tcx> for queries::generics_of<'tcx> {
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::program_clauses_for<'tcx> {
-    fn describe(_tcx: TyCtxt, _: DefId) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: DefId) -> String {
         "generating chalk-style clauses".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::program_clauses_for_env<'tcx> {
-    fn describe(_tcx: TyCtxt, _: ty::ParamEnv<'tcx>) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: ty::ParamEnv<'tcx>) -> String {
         "generating chalk-style clauses for param env".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::wasm_import_module_map<'tcx> {
-    fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "wasm import module map".to_string()
     }
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::dllimport_foreign_items<'tcx> {
-    fn describe(_tcx: TyCtxt, _: CrateNum) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: CrateNum) -> String {
         "wasm import module map".to_string()
     }
 }

--- a/src/librustc/ty/query/keys.rs
+++ b/src/librustc/ty/query/keys.rs
@@ -31,7 +31,7 @@ pub(super) trait Key: Clone + Hash + Eq + Debug {
 
     /// In the event that a cycle occurs, if no explicit span has been
     /// given for a query with key `self`, what span should we use?
-    fn default_span(&self, tcx: TyCtxt) -> Span;
+    fn default_span(&self, tcx: TyCtxt<'_, '_, '_>) -> Span;
 }
 
 impl<'tcx> Key for ty::InstanceDef<'tcx> {
@@ -39,7 +39,7 @@ impl<'tcx> Key for ty::InstanceDef<'tcx> {
         LOCAL_CRATE
     }
 
-    fn default_span(&self, tcx: TyCtxt) -> Span {
+    fn default_span(&self, tcx: TyCtxt<'_, '_, '_>) -> Span {
         tcx.def_span(self.def_id())
     }
 }
@@ -49,7 +49,7 @@ impl<'tcx> Key for ty::Instance<'tcx> {
         LOCAL_CRATE
     }
 
-    fn default_span(&self, tcx: TyCtxt) -> Span {
+    fn default_span(&self, tcx: TyCtxt<'_, '_, '_>) -> Span {
         tcx.def_span(self.def_id())
     }
 }
@@ -59,7 +59,7 @@ impl<'tcx> Key for mir::interpret::GlobalId<'tcx> {
         self.instance.query_crate()
     }
 
-    fn default_span(&self, tcx: TyCtxt) -> Span {
+    fn default_span(&self, tcx: TyCtxt<'_, '_, '_>) -> Span {
         self.instance.default_span(tcx)
     }
 }
@@ -68,7 +68,7 @@ impl Key for CrateNum {
     fn query_crate(&self) -> CrateNum {
         *self
     }
-    fn default_span(&self, _: TyCtxt) -> Span {
+    fn default_span(&self, _: TyCtxt<'_, '_, '_>) -> Span {
         DUMMY_SP
     }
 }
@@ -77,7 +77,7 @@ impl Key for DefIndex {
     fn query_crate(&self) -> CrateNum {
         LOCAL_CRATE
     }
-    fn default_span(&self, _tcx: TyCtxt) -> Span {
+    fn default_span(&self, _tcx: TyCtxt<'_, '_, '_>) -> Span {
         DUMMY_SP
     }
 }
@@ -86,7 +86,7 @@ impl Key for DefId {
     fn query_crate(&self) -> CrateNum {
         self.krate
     }
-    fn default_span(&self, tcx: TyCtxt) -> Span {
+    fn default_span(&self, tcx: TyCtxt<'_, '_, '_>) -> Span {
         tcx.def_span(*self)
     }
 }
@@ -95,7 +95,7 @@ impl Key for (DefId, DefId) {
     fn query_crate(&self) -> CrateNum {
         self.0.krate
     }
-    fn default_span(&self, tcx: TyCtxt) -> Span {
+    fn default_span(&self, tcx: TyCtxt<'_, '_, '_>) -> Span {
         self.1.default_span(tcx)
     }
 }
@@ -104,7 +104,7 @@ impl Key for (CrateNum, DefId) {
     fn query_crate(&self) -> CrateNum {
         self.0
     }
-    fn default_span(&self, tcx: TyCtxt) -> Span {
+    fn default_span(&self, tcx: TyCtxt<'_, '_, '_>) -> Span {
         self.1.default_span(tcx)
     }
 }
@@ -113,7 +113,7 @@ impl Key for (DefId, SimplifiedType) {
     fn query_crate(&self) -> CrateNum {
         self.0.krate
     }
-    fn default_span(&self, tcx: TyCtxt) -> Span {
+    fn default_span(&self, tcx: TyCtxt<'_, '_, '_>) -> Span {
         self.0.default_span(tcx)
     }
 }
@@ -122,7 +122,7 @@ impl<'tcx> Key for (DefId, &'tcx Substs<'tcx>) {
     fn query_crate(&self) -> CrateNum {
         self.0.krate
     }
-    fn default_span(&self, tcx: TyCtxt) -> Span {
+    fn default_span(&self, tcx: TyCtxt<'_, '_, '_>) -> Span {
         self.0.default_span(tcx)
     }
 }
@@ -131,7 +131,7 @@ impl<'tcx> Key for (ty::ParamEnv<'tcx>, ty::PolyTraitRef<'tcx>) {
     fn query_crate(&self) -> CrateNum {
         self.1.def_id().krate
     }
-    fn default_span(&self, tcx: TyCtxt) -> Span {
+    fn default_span(&self, tcx: TyCtxt<'_, '_, '_>) -> Span {
         tcx.def_span(self.1.def_id())
     }
 }
@@ -140,7 +140,7 @@ impl<'tcx> Key for ty::PolyTraitRef<'tcx>{
     fn query_crate(&self) -> CrateNum {
         self.def_id().krate
     }
-    fn default_span(&self, tcx: TyCtxt) -> Span {
+    fn default_span(&self, tcx: TyCtxt<'_, '_, '_>) -> Span {
         tcx.def_span(self.def_id())
     }
 }
@@ -149,7 +149,7 @@ impl<'tcx> Key for &'tcx ty::Const<'tcx> {
     fn query_crate(&self) -> CrateNum {
         LOCAL_CRATE
     }
-    fn default_span(&self, _: TyCtxt) -> Span {
+    fn default_span(&self, _: TyCtxt<'_, '_, '_>) -> Span {
         DUMMY_SP
     }
 }
@@ -158,7 +158,7 @@ impl<'tcx> Key for Ty<'tcx> {
     fn query_crate(&self) -> CrateNum {
         LOCAL_CRATE
     }
-    fn default_span(&self, _: TyCtxt) -> Span {
+    fn default_span(&self, _: TyCtxt<'_, '_, '_>) -> Span {
         DUMMY_SP
     }
 }
@@ -167,7 +167,7 @@ impl<'tcx> Key for ty::ParamEnv<'tcx> {
     fn query_crate(&self) -> CrateNum {
         LOCAL_CRATE
     }
-    fn default_span(&self, _: TyCtxt) -> Span {
+    fn default_span(&self, _: TyCtxt<'_, '_, '_>) -> Span {
         DUMMY_SP
     }
 }
@@ -176,7 +176,7 @@ impl<'tcx, T: Key> Key for ty::ParamEnvAnd<'tcx, T> {
     fn query_crate(&self) -> CrateNum {
         self.value.query_crate()
     }
-    fn default_span(&self, tcx: TyCtxt) -> Span {
+    fn default_span(&self, tcx: TyCtxt<'_, '_, '_>) -> Span {
         self.value.default_span(tcx)
     }
 }
@@ -185,7 +185,7 @@ impl Key for InternedString {
     fn query_crate(&self) -> CrateNum {
         LOCAL_CRATE
     }
-    fn default_span(&self, _tcx: TyCtxt) -> Span {
+    fn default_span(&self, _tcx: TyCtxt<'_, '_, '_>) -> Span {
         DUMMY_SP
     }
 }
@@ -200,7 +200,7 @@ where
         LOCAL_CRATE
     }
 
-    fn default_span(&self, _tcx: TyCtxt) -> Span {
+    fn default_span(&self, _tcx: TyCtxt<'_, '_, '_>) -> Span {
         DUMMY_SP
     }
 }

--- a/src/librustc/ty/query/mod.rs
+++ b/src/librustc/ty/query/mod.rs
@@ -666,21 +666,21 @@ impl<'a, 'tcx, 'lcx> TyCtxt<'a, 'tcx, 'lcx> {
         span: Span,
         key: DefId,
     ) -> Result<&'tcx [Ty<'tcx>], DiagnosticBuilder<'a>> {
-        self.try_get_query::<queries::adt_sized_constraint>(span, key)
+        self.try_get_query::<queries::adt_sized_constraint<'_>>(span, key)
     }
     pub fn try_needs_drop_raw(
         self,
         span: Span,
         key: ty::ParamEnvAnd<'tcx, Ty<'tcx>>,
     ) -> Result<bool, DiagnosticBuilder<'a>> {
-        self.try_get_query::<queries::needs_drop_raw>(span, key)
+        self.try_get_query::<queries::needs_drop_raw<'_>>(span, key)
     }
     pub fn try_optimized_mir(
         self,
         span: Span,
         key: DefId,
     ) -> Result<&'tcx mir::Mir<'tcx>, DiagnosticBuilder<'a>> {
-        self.try_get_query::<queries::optimized_mir>(span, key)
+        self.try_get_query::<queries::optimized_mir<'_>>(span, key)
     }
 }
 

--- a/src/librustc/ty/query/on_disk_cache.rs
+++ b/src/librustc/ty/query/on_disk_cache.rs
@@ -212,23 +212,23 @@ impl<'sess> OnDiskCache<'sess> {
                 let enc = &mut encoder;
                 let qri = &mut query_result_index;
 
-                encode_query_results::<type_of, _>(tcx, enc, qri)?;
-                encode_query_results::<generics_of, _>(tcx, enc, qri)?;
-                encode_query_results::<predicates_of, _>(tcx, enc, qri)?;
-                encode_query_results::<used_trait_imports, _>(tcx, enc, qri)?;
-                encode_query_results::<typeck_tables_of, _>(tcx, enc, qri)?;
-                encode_query_results::<codegen_fulfill_obligation, _>(tcx, enc, qri)?;
-                encode_query_results::<optimized_mir, _>(tcx, enc, qri)?;
-                encode_query_results::<unsafety_check_result, _>(tcx, enc, qri)?;
-                encode_query_results::<borrowck, _>(tcx, enc, qri)?;
-                encode_query_results::<mir_borrowck, _>(tcx, enc, qri)?;
-                encode_query_results::<mir_const_qualif, _>(tcx, enc, qri)?;
-                encode_query_results::<def_symbol_name, _>(tcx, enc, qri)?;
-                encode_query_results::<const_is_rvalue_promotable_to_static, _>(tcx, enc, qri)?;
-                encode_query_results::<symbol_name, _>(tcx, enc, qri)?;
-                encode_query_results::<check_match, _>(tcx, enc, qri)?;
-                encode_query_results::<codegen_fn_attrs, _>(tcx, enc, qri)?;
-                encode_query_results::<specialization_graph_of, _>(tcx, enc, qri)?;
+                encode_query_results::<type_of<'_>, _>(tcx, enc, qri)?;
+                encode_query_results::<generics_of<'_>, _>(tcx, enc, qri)?;
+                encode_query_results::<predicates_of<'_>, _>(tcx, enc, qri)?;
+                encode_query_results::<used_trait_imports<'_>, _>(tcx, enc, qri)?;
+                encode_query_results::<typeck_tables_of<'_>, _>(tcx, enc, qri)?;
+                encode_query_results::<codegen_fulfill_obligation<'_>, _>(tcx, enc, qri)?;
+                encode_query_results::<optimized_mir<'_>, _>(tcx, enc, qri)?;
+                encode_query_results::<unsafety_check_result<'_>, _>(tcx, enc, qri)?;
+                encode_query_results::<borrowck<'_>, _>(tcx, enc, qri)?;
+                encode_query_results::<mir_borrowck<'_>, _>(tcx, enc, qri)?;
+                encode_query_results::<mir_const_qualif<'_>, _>(tcx, enc, qri)?;
+                encode_query_results::<def_symbol_name<'_>, _>(tcx, enc, qri)?;
+                encode_query_results::<const_is_rvalue_promotable_to_static<'_>, _>(tcx, enc, qri)?;
+                encode_query_results::<symbol_name<'_>, _>(tcx, enc, qri)?;
+                encode_query_results::<check_match<'_>, _>(tcx, enc, qri)?;
+                encode_query_results::<codegen_fn_attrs<'_>, _>(tcx, enc, qri)?;
+                encode_query_results::<specialization_graph_of<'_>, _>(tcx, enc, qri)?;
 
                 // const eval is special, it only encodes successfully evaluated constants
                 use ty::query::QueryAccessors;
@@ -323,7 +323,7 @@ impl<'sess> OnDiskCache<'sess> {
 
             return Ok(());
 
-            fn sorted_cnums_including_local_crate(tcx: TyCtxt) -> Vec<CrateNum> {
+            fn sorted_cnums_including_local_crate(tcx: TyCtxt<'_, '_, '_>) -> Vec<CrateNum> {
                 let mut cnums = vec![LOCAL_CRATE];
                 cnums.extend_from_slice(&tcx.crates()[..]);
                 cnums.sort_unstable();
@@ -434,7 +434,7 @@ impl<'sess> OnDiskCache<'sess> {
     // current-session-CrateNum. There might be CrateNums from the previous
     // Session that don't occur in the current one. For these, the mapping
     // maps to None.
-    fn compute_cnum_map(tcx: TyCtxt,
+    fn compute_cnum_map(tcx: TyCtxt<'_, '_, '_>,
                         prev_cnums: &[(u32, String, CrateDisambiguator)])
                         -> IndexVec<CrateNum, Option<CrateNum>>
     {

--- a/src/librustc/ty/steal.rs
+++ b/src/librustc/ty/steal.rs
@@ -42,7 +42,7 @@ impl<T> Steal<T> {
         }
     }
 
-    pub fn borrow(&self) -> MappedReadGuard<T> {
+    pub fn borrow(&self) -> MappedReadGuard<'_, T> {
         ReadGuard::map(self.value.borrow(), |opt| match *opt {
             None => bug!("attempted to read from stolen value"),
             Some(ref v) => v

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -708,7 +708,7 @@ impl<'a, 'gcx, 'tcx> ExistentialTraitRef<'tcx> {
     pub fn with_self_ty(&self, tcx: TyCtxt<'a, 'gcx, 'tcx>, self_ty: Ty<'tcx>)
         -> ty::TraitRef<'tcx>  {
         // otherwise the escaping regions would be captured by the binder
-        debug_assert!(!self_ty.has_escaping_regions());
+        // debug_assert!(!self_ty.has_escaping_regions());
 
         ty::TraitRef {
             def_id: self.def_id,
@@ -864,7 +864,7 @@ impl<'a, 'tcx> ProjectionTy<'tcx> {
     /// Construct a ProjectionTy by searching the trait from trait_ref for the
     /// associated item named item_name.
     pub fn from_ref_and_name(
-        tcx: TyCtxt, trait_ref: ty::TraitRef<'tcx>, item_name: Ident
+        tcx: TyCtxt<'_, '_, '_>, trait_ref: ty::TraitRef<'tcx>, item_name: Ident
     ) -> ProjectionTy<'tcx> {
         let item_def_id = tcx.associated_items(trait_ref.def_id).find(|item| {
             item.kind == ty::AssociatedKind::Type &&
@@ -880,7 +880,7 @@ impl<'a, 'tcx> ProjectionTy<'tcx> {
     /// Extracts the underlying trait reference from this projection.
     /// For example, if this is a projection of `<T as Iterator>::Item`,
     /// then this function would return a `T: Iterator` trait reference.
-    pub fn trait_ref(&self, tcx: TyCtxt) -> ty::TraitRef<'tcx> {
+    pub fn trait_ref(&self, tcx: TyCtxt<'_, '_, '_>) -> ty::TraitRef<'tcx> {
         let def_id = tcx.associated_item(self.item_def_id).container.id();
         ty::TraitRef {
             def_id,
@@ -1225,7 +1225,7 @@ impl<'a, 'tcx, 'gcx> ExistentialProjection<'tcx> {
     /// For example, if this is a projection of `exists T. <T as Iterator>::Item == X`,
     /// then this function would return a `exists T. T: Iterator` existential trait
     /// reference.
-    pub fn trait_ref(&self, tcx: TyCtxt) -> ty::ExistentialTraitRef<'tcx> {
+    pub fn trait_ref(&self, tcx: TyCtxt<'_, '_, '_>) -> ty::ExistentialTraitRef<'tcx> {
         let def_id = tcx.associated_item(self.item_def_id).container.id();
         ty::ExistentialTraitRef{
             def_id,
@@ -1569,7 +1569,7 @@ impl<'a, 'gcx, 'tcx> TyS<'tcx> {
         }
     }
 
-    pub fn simd_size(&self, _cx: TyCtxt) -> usize {
+    pub fn simd_size(&self, _cx: TyCtxt<'_, '_, '_>) -> usize {
         match self.sty {
             Adt(def, _) => def.non_enum_variant().fields.len(),
             _ => bug!("simd_size called on invalid type")

--- a/src/librustc/ty/subst.rs
+++ b/src/librustc/ty/subst.rs
@@ -73,13 +73,13 @@ impl<'tcx> UnpackedKind<'tcx> {
 }
 
 impl<'tcx> Ord for Kind<'tcx> {
-    fn cmp(&self, other: &Kind) -> Ordering {
+    fn cmp(&self, other: &Kind<'_>) -> Ordering {
         self.unpack().cmp(&other.unpack())
     }
 }
 
 impl<'tcx> PartialOrd for Kind<'tcx> {
-    fn partial_cmp(&self, other: &Kind) -> Option<Ordering> {
+    fn partial_cmp(&self, other: &Kind<'_>) -> Option<Ordering> {
         Some(self.cmp(&other))
     }
 }
@@ -111,7 +111,7 @@ impl<'tcx> Kind<'tcx> {
 }
 
 impl<'tcx> fmt::Debug for Kind<'tcx> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.unpack() {
             UnpackedKind::Lifetime(lt) => write!(f, "{:?}", lt),
             UnpackedKind::Type(ty) => write!(f, "{:?}", ty),
@@ -120,7 +120,7 @@ impl<'tcx> fmt::Debug for Kind<'tcx> {
 }
 
 impl<'tcx> fmt::Display for Kind<'tcx> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.unpack() {
             UnpackedKind::Lifetime(lt) => write!(f, "{}", lt),
             UnpackedKind::Type(ty) => write!(f, "{}", ty),

--- a/src/librustc/ty/util.rs
+++ b/src/librustc/ty/util.rs
@@ -39,7 +39,7 @@ pub struct Discr<'tcx> {
 }
 
 impl<'tcx> fmt::Display for Discr<'tcx> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.ty.sty {
             ty::Int(ity) => {
                 let bits = ty::tls::with(|tcx| {
@@ -846,7 +846,7 @@ impl<'a, 'tcx> ty::TyS<'tcx> {
         // To avoid a stack overflow when checking an enum variant or struct that
         // contains a different, structurally recursive type, maintain a stack
         // of seen types and check recursion for each of them (issues #3008, #3779).
-        let mut seen: Vec<Ty> = Vec::new();
+        let mut seen: Vec<Ty<'_>> = Vec::new();
         let mut representable_cache = FxHashMap();
         let r = is_type_structurally_recursive(
             tcx, sp, &mut seen, &mut representable_cache, self);
@@ -1039,7 +1039,7 @@ impl<'tcx> ExplicitSelf<'tcx> {
     }
 }
 
-pub fn provide(providers: &mut ty::query::Providers) {
+pub fn provide(providers: &mut ty::query::Providers<'_>) {
     *providers = ty::query::Providers {
         is_copy_raw,
         is_sized_raw,

--- a/src/librustc/util/bug.rs
+++ b/src/librustc/util/bug.rs
@@ -16,7 +16,7 @@ use syntax_pos::{Span, MultiSpan};
 
 #[cold]
 #[inline(never)]
-pub fn bug_fmt(file: &'static str, line: u32, args: fmt::Arguments) -> ! {
+pub fn bug_fmt(file: &'static str, line: u32, args: fmt::Arguments<'_>) -> ! {
     // this wrapper mostly exists so I don't have to write a fully
     // qualified path of None::<Span> inside the bug!() macro definition
     opt_span_bug_fmt(file, line, None::<Span>, args);
@@ -28,7 +28,7 @@ pub fn span_bug_fmt<S: Into<MultiSpan>>(
     file: &'static str,
     line: u32,
     span: S,
-    args: fmt::Arguments,
+    args: fmt::Arguments<'_>,
 ) -> ! {
     opt_span_bug_fmt(file, line, Some(span), args);
 }
@@ -37,7 +37,7 @@ fn opt_span_bug_fmt<S: Into<MultiSpan>>(
     file: &'static str,
     line: u32,
     span: Option<S>,
-    args: fmt::Arguments,
+    args: fmt::Arguments<'_>,
 ) -> ! {
     tls::with_opt(move |tcx| {
         let msg = format!("{}:{}: {}", file, line, args);

--- a/src/librustc/util/common.rs
+++ b/src/librustc/util/common.rs
@@ -39,14 +39,14 @@ pub struct ErrorReported;
 thread_local!(static TIME_DEPTH: Cell<usize> = Cell::new(0));
 
 lazy_static! {
-    static ref DEFAULT_HOOK: Box<dyn Fn(&panic::PanicInfo) + Sync + Send + 'static> = {
+    static ref DEFAULT_HOOK: Box<dyn Fn(&panic::PanicInfo<'_>) + Sync + Send + 'static> = {
         let hook = panic::take_hook();
         panic::set_hook(Box::new(panic_hook));
         hook
     };
 }
 
-fn panic_hook(info: &panic::PanicInfo) {
+fn panic_hook(info: &panic::PanicInfo<'_>) {
     if !proc_macro::__internal::in_sess() {
         (*DEFAULT_HOOK)(info);
 

--- a/src/librustc/util/profiling.rs
+++ b/src/librustc/util/profiling.rs
@@ -61,7 +61,7 @@ macro_rules! define_categories {
                 }
             }
 
-            fn print(&self, lock: &mut StdoutLock) {
+            fn print(&self, lock: &mut StdoutLock<'_>) {
                 writeln!(lock, "| Phase            | Time (ms)      | Queries        | Hits (%) |")
                     .unwrap();
                 writeln!(lock, "| ---------------- | -------------- | -------------- | -------- |")


### PR DESCRIPTION
In light of the "Apply to rustc" checkbox on #44524 and @nikomatsakis's [recent comment about regularly wanting visual indication of elided lifetimes in types](https://github.com/rust-lang/rust/issues/44524#issuecomment-414663773), I was curious to see what it would look like if we turned the `elided_lifetimes_in_path` lint on in at least one crate in the codebase (I chose librustc). Given that I couldn't figure out how to get `cargo fix` work with the build system, this arguably wasn't a very efficient use of my time, but once I started, the conjunction of moral law and the sunk cost fallacy forced me to continue.

This is mostly applying the `<'_>` suggestions issued by the lint, but there were a few places where I named the lifetimes (_e.g._, `<'a, 'gcx, 'tcx>` on `TyCtxt`) in order to match style with surrounding code.

r? @nikomatsakis 