### PR TITLE
[RISCV] Use lld as the default linker; Enable C extension; Add riscv32imc-unknown-none-elf target

### DIFF
--- a/src/ci/docker/dist-various-1/Dockerfile
+++ b/src/ci/docker/dist-various-1/Dockerfile
@@ -102,6 +102,7 @@ ENV TARGETS=$TARGETS,thumbv6m-none-eabi
 ENV TARGETS=$TARGETS,thumbv7m-none-eabi
 ENV TARGETS=$TARGETS,thumbv7em-none-eabi
 ENV TARGETS=$TARGETS,thumbv7em-none-eabihf
+ENV TARGETS=$TARGETS,riscv32imc-unknown-none-elf
 ENV TARGETS=$TARGETS,riscv32imac-unknown-none-elf
 ENV TARGETS=$TARGETS,armebv7r-none-eabi
 ENV TARGETS=$TARGETS,armebv7r-none-eabihf

--- a/src/librustc_target/spec/mod.rs
+++ b/src/librustc_target/spec/mod.rs
@@ -74,6 +74,7 @@ mod thumb_base;
 mod l4re_base;
 mod fuchsia_base;
 mod redox_base;
+mod riscv_base;
 
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Hash,
          RustcEncodable, RustcDecodable)]
@@ -406,6 +407,7 @@ supported_targets! {
     ("aarch64-unknown-hermit", aarch64_unknown_hermit),
     ("x86_64-unknown-hermit", x86_64_unknown_hermit),
 
+    ("riscv32imc-unknown-none-elf", riscv32imc_unknown_none_elf),
     ("riscv32imac-unknown-none-elf", riscv32imac_unknown_none_elf),
 
     ("aarch64-unknown-none", aarch64_unknown_none),

--- a/src/librustc_target/spec/riscv32imac_unknown_none_elf.rs
+++ b/src/librustc_target/spec/riscv32imac_unknown_none_elf.rs
@@ -8,7 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use spec::{LinkerFlavor, PanicStrategy, Target, TargetOptions, TargetResult};
+use spec::{LinkerFlavor, LldFlavor, PanicStrategy,
+           Target, TargetOptions, TargetResult};
 use spec::abi::{Abi};
 
 pub fn target() -> TargetResult {
@@ -22,10 +23,10 @@ pub fn target() -> TargetResult {
         target_env: String::new(),
         target_vendor: "unknown".to_string(),
         arch: "riscv32".to_string(),
-        linker_flavor: LinkerFlavor::Ld,
+        linker_flavor: LinkerFlavor::Lld(LldFlavor::Ld),
 
         options: TargetOptions {
-            linker: Some("riscv32-unknown-elf-ld".to_string()),
+            linker: Some("rust-lld".to_string()),
             cpu: "generic-rv32".to_string(),
             max_atomic_width: Some(32),
             atomic_cas: false, // incomplete +a extension

--- a/src/librustc_target/spec/riscv32imac_unknown_none_elf.rs
+++ b/src/librustc_target/spec/riscv32imac_unknown_none_elf.rs
@@ -30,7 +30,7 @@ pub fn target() -> TargetResult {
             cpu: "generic-rv32".to_string(),
             max_atomic_width: Some(32),
             atomic_cas: false, // incomplete +a extension
-            features: "+m,+a".to_string(), // disable +c extension
+            features: "+m,+a,+c".to_string(),
             executables: true,
             panic_strategy: PanicStrategy::Abort,
             relocation_model: "static".to_string(),

--- a/src/librustc_target/spec/riscv32imc_unknown_none_elf.rs
+++ b/src/librustc_target/spec/riscv32imc_unknown_none_elf.rs
@@ -27,7 +27,8 @@ pub fn target() -> TargetResult {
         options: TargetOptions {
             linker: Some("rust-lld".to_string()),
             cpu: "generic-rv32".to_string(),
-            max_atomic_width: Some(32),
+            // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86005
+            max_atomic_width: None, //Some(32),
             atomic_cas: false,
             features: "+m,+c".to_string(),
             executables: true,

--- a/src/librustc_target/spec/riscv32imc_unknown_none_elf.rs
+++ b/src/librustc_target/spec/riscv32imc_unknown_none_elf.rs
@@ -28,8 +28,8 @@ pub fn target() -> TargetResult {
             linker: Some("rust-lld".to_string()),
             cpu: "generic-rv32".to_string(),
             max_atomic_width: Some(32),
-            atomic_cas: false, // incomplete +a extension
-            features: "+m,+a,+c".to_string(),
+            atomic_cas: false,
+            features: "+m,+c".to_string(),
             executables: true,
             panic_strategy: PanicStrategy::Abort,
             relocation_model: "static".to_string(),

--- a/src/librustc_target/spec/riscv_base.rs
+++ b/src/librustc_target/spec/riscv_base.rs
@@ -1,0 +1,30 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use spec::abi::Abi;
+
+// All the calling conventions trigger an assertion(Unsupported calling
+// convention) in llvm on RISCV
+pub fn abi_blacklist() -> Vec<Abi> {
+    vec![
+        Abi::Cdecl,
+        Abi::Stdcall,
+        Abi::Fastcall,
+        Abi::Vectorcall,
+        Abi::Thiscall,
+        Abi::Aapcs,
+        Abi::Win64,
+        Abi::SysV64,
+        Abi::PtxKernel,
+        Abi::Msp430Interrupt,
+        Abi::X86Interrupt,
+        Abi::AmdGpuKernel,
+    ]
+}

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -92,6 +92,7 @@ static TARGETS: &'static [&'static str] = &[
     "powerpc64-unknown-linux-gnu",
     "powerpc64le-unknown-linux-gnu",
     "powerpc64le-unknown-linux-musl",
+    "riscv32imc-unknown-none-elf",
     "riscv32imac-unknown-none-elf",
     "s390x-unknown-linux-gnu",
     "sparc-unknown-linux-gnu",


### PR DESCRIPTION
The riscv32imc-unknown-none-elf target is intended for soft cores.

The riscv32imc target is supported by the following popular soft cores:

picorv32: https://github.com/cliffordwolf/picorv32
vexriscv: https://github.com/SpinalHDL/VexRiscv
pulp riscy: https://github.com/pulp-platform/riscv
pulp zero-riscy: https://github.com/pulp-platform/zero-riscy