### PR TITLE
[beta] const eval perf regression fix

### DIFF
--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1631,7 +1631,12 @@ fn validate_const<'a, 'tcx>(
 
 fn check_const(cx: &LateContext, body_id: hir::BodyId, what: &str) {
     let def_id = cx.tcx.hir.body_owner_def_id(body_id);
-    let param_env = cx.tcx.param_env(def_id);
+    let is_static = cx.tcx.is_static(def_id).is_some();
+    let param_env = if is_static {
+        ty::ParamEnv::reveal_all()
+    } else {
+        cx.tcx.param_env(def_id)
+    };
     let cid = ::rustc::mir::interpret::GlobalId {
         instance: ty::Instance::mono(cx.tcx, def_id),
         promoted: None
@@ -1639,8 +1644,8 @@ fn check_const(cx: &LateContext, body_id: hir::BodyId, what: &str) {
     match cx.tcx.const_eval(param_env.and(cid)) {
         Ok(val) => validate_const(cx.tcx, val, param_env, cid, what),
         Err(err) => {
-            // errors for statics are already reported directly in the query
-            if cx.tcx.is_static(def_id).is_none() {
+            // errors for statics are already reported directly in the query, avoid duplicates
+            if !is_static {
                 let span = cx.tcx.def_span(def_id);
                 err.report_as_lint(
                     cx.tcx.at(span),

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1633,6 +1633,7 @@ fn check_const(cx: &LateContext, body_id: hir::BodyId, what: &str) {
     let def_id = cx.tcx.hir.body_owner_def_id(body_id);
     let is_static = cx.tcx.is_static(def_id).is_some();
     let param_env = if is_static {
+        // Use the same param_env as `codegen_static_initializer`, to reuse the cache.
         ty::ParamEnv::reveal_all()
     } else {
         cx.tcx.param_env(def_id)

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -214,10 +214,10 @@ impl<'a, 'mir, 'tcx, M> InfiniteLoopDetector<'a, 'mir, 'tcx, M>
         stack: &Vec<Frame<'mir, 'tcx>>,
         memory: &Memory<'a, 'mir, 'tcx, M>,
     ) -> EvalResult<'tcx, ()> {
-        let snapshot = (machine, stack, memory);
-
         let mut fx = FxHasher::default();
-        snapshot.hash(&mut fx);
+        // don't hash the memory, that takes too much time, just compare when you hit a collision
+        // should be rare enough
+        (machine, stack).hash(&mut fx);
         let hash = fx.finish();
 
         if self.hashes.insert(hash) {


### PR DESCRIPTION
backports #52925 (for https://github.com/rust-lang/rust/issues/52849)

and additionally skips hashing on every evaluation step

