### PR TITLE
Various small diagnostic and code clean up

### DIFF
--- a/src/librustc_mir/hair/pattern/check_match.rs
+++ b/src/librustc_mir/hair/pattern/check_match.rs
@@ -540,12 +540,16 @@ fn check_legality_of_move_bindings(cx: &MatchVisitor,
                       "cannot bind by-move into a pattern guard")
                 .span_label(p.span, "moves value into pattern guard")
                 .emit();
-        } else if by_ref_span.is_some() {
-            struct_span_err!(cx.tcx.sess, p.span, E0009,
-                            "cannot bind by-move and by-ref in the same pattern")
-                    .span_label(p.span, "by-move pattern here")
-                    .span_label(by_ref_span.unwrap(), "both by-ref and by-move used")
-                    .emit();
+        } else if let Some(by_ref_span) = by_ref_span {
+            struct_span_err!(
+                cx.tcx.sess,
+                p.span,
+                E0009,
+                "cannot bind by-move and by-ref in the same pattern",
+            )
+            .span_label(p.span, "by-move pattern here")
+            .span_label(by_ref_span, "both by-ref and by-move used")
+            .emit();
         }
     };
 

--- a/src/librustc_save_analysis/span_utils.rs
+++ b/src/librustc_save_analysis/span_utils.rs
@@ -154,8 +154,7 @@ impl<'a> SpanUtils<'a> {
                 let loc = self.sess.source_map().lookup_char_pos(span.lo());
                 span_bug!(
                     span,
-                    "Mis-counted brackets when breaking path? Parsing '{}' \
-                     in {}, line {}",
+                    "Mis-counted brackets when breaking path? Parsing '{}' in {}, line {}",
                     self.snippet(span),
                     loc.file.name,
                     loc.line

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1178,6 +1178,7 @@ fn check_fn<'a, 'gcx, 'tcx>(inherited: &'a Inherited<'a, 'gcx, 'tcx>,
                         }
                     }
                 } else {
+                    let span = fcx.tcx.sess.source_map().def_span(span);
                     fcx.tcx.sess.span_err(span, "function should have one argument");
                 }
             } else {
@@ -1226,6 +1227,7 @@ fn check_fn<'a, 'gcx, 'tcx>(inherited: &'a Inherited<'a, 'gcx, 'tcx>,
                         }
                     }
                 } else {
+                    let span = fcx.tcx.sess.source_map().def_span(span);
                     fcx.tcx.sess.span_err(span, "function should have one argument");
                 }
             } else {

--- a/src/librustc_typeck/check/op.rs
+++ b/src/librustc_typeck/check/op.rs
@@ -256,14 +256,19 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                     let source_map = self.tcx.sess.source_map();
                     match is_assign {
                         IsAssign::Yes => {
-                            let mut err = struct_span_err!(self.tcx.sess, expr.span, E0368,
-                                                "binary assignment operation `{}=` \
-                                                cannot be applied to type `{}`",
-                                                op.node.as_str(),
-                                                lhs_ty);
-                            err.span_label(lhs_expr.span,
-                                    format!("cannot use `{}=` on type `{}`",
-                                    op.node.as_str(), lhs_ty));
+                            let mut err = struct_span_err!(
+                                self.tcx.sess,
+                                expr.span,
+                                E0368,
+                                "binary assignment operation `{}=` cannot be applied to type `{}`",
+                                op.node.as_str(),
+                                lhs_ty,
+                            );
+                            err.span_label(
+                                lhs_expr.span,
+                                format!("cannot use `{}=` on type `{}`",
+                                op.node.as_str(), lhs_ty),
+                            );
                             let mut suggested_deref = false;
                             if let Ref(_, mut rty, _) = lhs_ty.sty {
                                 if {
@@ -280,13 +285,17 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                             rty = rty_inner;
                                         }
                                         let msg = &format!(
-                                                "`{}=` can be used on '{}', you can \
-                                                dereference `{2}`: `*{2}`",
-                                                op.node.as_str(),
-                                                rty,
-                                                lstring
+                                            "`{}=` can be used on '{}', you can dereference `{}`",
+                                            op.node.as_str(),
+                                            rty,
+                                            lstring,
                                         );
-                                        err.help(msg);
+                                        err.span_suggestion_with_applicability(
+                                            lhs_expr.span,
+                                            msg,
+                                            format!("*{}", lstring),
+                                            errors::Applicability::MachineApplicable,
+                                        );
                                         suggested_deref = true;
                                     }
                                 }

--- a/src/test/ui/alloc-error/alloc-error-handler-bad-signature-3.stderr
+++ b/src/test/ui/alloc-error/alloc-error-handler-bad-signature-3.stderr
@@ -1,10 +1,8 @@
 error: function should have one argument
   --> $DIR/alloc-error-handler-bad-signature-3.rs:20:1
    |
-LL | / fn oom() -> ! { //~ ERROR function should have one argument
-LL | |     loop {}
-LL | | }
-   | |_^
+LL | fn oom() -> ! { //~ ERROR function should have one argument
+   | ^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-5239-1.stderr
+++ b/src/test/ui/issues/issue-5239-1.stderr
@@ -5,8 +5,10 @@ LL |     let x = |ref x: isize| { x += 1; };
    |                              -^^^^^
    |                              |
    |                              cannot use `+=` on type `&isize`
+help: `+=` can be used on 'isize', you can dereference `x`
    |
-   = help: `+=` can be used on 'isize', you can dereference `x`: `*x`
+LL |     let x = |ref x: isize| { *x += 1; };
+   |                              ^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/panic-handler/panic-handler-bad-signature-3.stderr
+++ b/src/test/ui/panic-handler/panic-handler-bad-signature-3.stderr
@@ -1,10 +1,8 @@
 error: function should have one argument
   --> $DIR/panic-handler-bad-signature-3.rs:20:1
    |
-LL | / fn panic() -> ! { //~ ERROR function should have one argument
-LL | |     loop {}
-LL | | }
-   | |_^
+LL | fn panic() -> ! { //~ ERROR function should have one argument
+   | ^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 


### PR DESCRIPTION
 - Point at def span on incorrect `panic` or `oom` function
 - Use structured suggestion instead of note for `+=` that can be performed on a dereference of the left binding
 - Small code formatting cleanup