### PR TITLE
librustc benchmarks: more changes towards fixing build failure of dispatch.rs and pattern.rs

### DIFF
--- a/src/librustc/benches/dispatch.rs
+++ b/src/librustc/benches/dispatch.rs
@@ -8,7 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use test::Bencher;
+#![cfg(test)]
+ #![feature(test)] 
+extern crate test;
+use self::test::Bencher;
 
 // Static/dynamic method dispatch
 
@@ -29,7 +32,7 @@ impl Trait for Struct {
 #[bench]
 fn trait_vtable_method_call(b: &mut Bencher) {
     let s = Struct { field: 10 };
-    let t = &s as &Trait;
+    let t = &s as &dyn Trait;
     b.iter(|| {
         t.method()
     });

--- a/src/librustc/benches/pattern.rs
+++ b/src/librustc/benches/pattern.rs
@@ -8,7 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use test::Bencher;
+#![cfg(test)]
+#![feature(test)]
+#![feature(slice_patterns)]
+extern crate test;
+use self::test::Bencher;
 
 // Overhead of various match forms
 


### PR DESCRIPTION
There's another failure left
````
error[E0658]: syntax for subslices in slice patterns is not yet stabilized (see issue #23121)
  --> librustc/benches/pattern.rs:35:20
   |
35 |             [1,2,3,..] => 10,
   |                    ^^
   |
   = help: add #![feature(slice_patterns)] to the crate attributes to enable
````
but I don't understand why it's there since the crate attr is there.