### PR TITLE
[experimental] Perform cross-lang-lto for librustc_codegen_llvm.

### DIFF
--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -687,6 +687,7 @@ impl Step for CodegenBackend {
 
         if builder.config.llvm_thin_lto {
             cargo_tails_args.push("--".to_string());
+            cargo_tails_args.push("-Zcross-lang-lto".to_string());
 
             let num_jobs = builder.jobs();
 


### PR DESCRIPTION
This is a follow-up to https://github.com/rust-lang/rust/pull/53245 in order to gauge the impact of cross-language LTO on `rustc`.