### PR TITLE
Add `PartialOrd` and `Ord` implementation for `std::net::SocketAddr` 

### DIFF
--- a/src/libstd/net/addr.rs
+++ b/src/libstd/net/addr.rs
@@ -45,7 +45,7 @@ use slice;
 /// assert_eq!(socket.port(), 8080);
 /// assert_eq!(socket.is_ipv4(), true);
 /// ```
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub enum SocketAddr {
     /// An IPv4 socket address.
@@ -81,7 +81,7 @@ pub enum SocketAddr {
 /// assert_eq!(socket.ip(), &Ipv4Addr::new(127, 0, 0, 1));
 /// assert_eq!(socket.port(), 8080);
 /// ```
-#[derive(Copy)]
+#[derive(Copy, PartialOrd, Ord)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct SocketAddrV4 { inner: c::sockaddr_in }
 
@@ -111,7 +111,7 @@ pub struct SocketAddrV4 { inner: c::sockaddr_in }
 /// assert_eq!(socket.ip(), &Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1));
 /// assert_eq!(socket.port(), 8080);
 /// ```
-#[derive(Copy)]
+#[derive(Copy, PartialOrd, Ord)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct SocketAddrV6 { inner: c::sockaddr_in6 }
 

--- a/src/libstd/sys/redox/net/netc.rs
+++ b/src/libstd/sys/redox/net/netc.rs
@@ -17,27 +17,27 @@ pub type sa_family_t = u16;
 pub const AF_INET: sa_family_t = 2;
 pub const AF_INET6: sa_family_t = 23;
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialOrd, Ord)]
 #[repr(C)]
 pub struct in_addr {
     pub s_addr: in_addr_t,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialOrd, Ord)]
 #[repr(align(4))]
 #[repr(C)]
 pub struct in6_addr {
     pub s6_addr: [u8; 16],
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialOrd, Ord)]
 #[repr(C)]
 pub struct sockaddr {
     pub sa_family: sa_family_t,
     pub sa_data: [u8; 14],
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialOrd, Ord)]
 #[repr(C)]
 pub struct sockaddr_in {
     pub sin_family: sa_family_t,
@@ -46,7 +46,7 @@ pub struct sockaddr_in {
     pub sin_zero: [u8; 8],
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialOrd, Ord)]
 #[repr(C)]
 pub struct sockaddr_in6 {
     pub sin6_family: sa_family_t,


### PR DESCRIPTION
Fixes #53710 continuation of #53788 