### PR TITLE
Implement Unpin for Box, Rc, and Arc

### DIFF
--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -749,6 +749,9 @@ impl<T: ?Sized> AsMut<T> for Box<T> {
     }
 }
 
+#[unstable(feature = "pin", issue = "49150")]
+impl<T: ?Sized> Unpin for Box<T> { }
+
 #[unstable(feature = "generator_trait", issue = "43122")]
 impl<T> Generator for Box<T>
     where T: Generator + ?Sized

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -751,7 +751,7 @@ impl<T: ?Sized> AsMut<T> for Box<T> {
 
 /* Nota bene
  *
- *  We could have chosen not to add this impl, and instead have written a 
+ *  We could have chosen not to add this impl, and instead have written a
  *  function of Pin<Box<T>> to Pin<T>. Such a function would not be sound,
  *  because Box<T> implements Unpin even when T does not, as a result of
  *  this impl.
@@ -762,7 +762,7 @@ impl<T: ?Sized> AsMut<T> for Box<T> {
  *        standard library pointer types support projecting through a pin
  *        (Box<T> is the only pointer type in std for which this would be
  *        safe.)
- *      - It is in practive very useful to have Box<T> be unconditionally
+ *      - It is in practice very useful to have Box<T> be unconditionally
  *        Unpin because of trait objects, for which the structural auto
  *        trait functionality does not apply (e.g. Box<dyn Foo> would
  *        otherwise not be Unpin).

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -749,6 +749,28 @@ impl<T: ?Sized> AsMut<T> for Box<T> {
     }
 }
 
+/* Nota bene
+ *
+ *  We could have chosen not to add this impl, and instead have written a 
+ *  function of Pin<Box<T>> to Pin<T>. Such a function would not be sound,
+ *  because Box<T> implements Unpin even when T does not, as a result of
+ *  this impl.
+ *
+ *  We chose this API instead of the alternative for a few reasons:
+ *      - Logically, it is helpful to understand pinning in regard to the
+ *        memory region being pointed to. For this reason none of the
+ *        standard library pointer types support projecting through a pin
+ *        (Box<T> is the only pointer type in std for which this would be
+ *        safe.)
+ *      - It is in practive very useful to have Box<T> be unconditionally
+ *        Unpin because of trait objects, for which the structural auto
+ *        trait functionality does not apply (e.g. Box<dyn Foo> would
+ *        otherwise not be Unpin).
+ *
+ *  Another type with the same semantics as Box but only a conditional
+ *  implementation of `Unpin` (where `T: Unpin`) would be valid/safe, and
+ *  could have a method to project a Pin<T> from it.
+ */
 #[unstable(feature = "pin", issue = "49150")]
 impl<T: ?Sized> Unpin for Box<T> { }
 

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -1832,4 +1832,4 @@ impl<T: ?Sized> AsRef<T> for Rc<T> {
 }
 
 #[unstable(feature = "pin", issue = "49150")]
-impl<T: ?Sized> Unpin for Box<T> { }
+impl<T: ?Sized> Unpin for Rc<T> { }

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -252,7 +252,7 @@ use core::fmt;
 use core::hash::{Hash, Hasher};
 use core::intrinsics::abort;
 use core::marker;
-use core::marker::{Unsize, PhantomData};
+use core::marker::{Unpin, Unsize, PhantomData};
 use core::mem::{self, align_of_val, forget, size_of_val};
 use core::ops::Deref;
 use core::ops::CoerceUnsized;
@@ -1830,3 +1830,6 @@ impl<T: ?Sized> AsRef<T> for Rc<T> {
         &**self
     }
 }
+
+#[unstable(feature = "pin", issue = "49150")]
+impl<T: ?Sized> Unpin for Box<T> { }

--- a/src/liballoc/sync.rs
+++ b/src/liballoc/sync.rs
@@ -27,7 +27,7 @@ use core::mem::{self, align_of_val, size_of_val};
 use core::ops::Deref;
 use core::ops::CoerceUnsized;
 use core::ptr::{self, NonNull};
-use core::marker::{Unsize, PhantomData};
+use core::marker::{Unpin, Unsize, PhantomData};
 use core::hash::{Hash, Hasher};
 use core::{isize, usize};
 use core::convert::From;
@@ -1942,3 +1942,6 @@ impl<T: ?Sized> AsRef<T> for Arc<T> {
         &**self
     }
 }
+
+#[unstable(feature = "pin", issue = "49150")]
+impl<T: ?Sized> Unpin for Arc<T> { }


### PR DESCRIPTION
Per the discussion in #49150, these should implement `Unpin` even if what they point to does not.