### PR TITLE
[beta] Rollup backports

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -777,7 +777,7 @@ impl<'a> Builder<'a> {
         // compiler, but for tools we just use the precompiled libraries that
         // we've downloaded
         let use_snapshot = mode == Mode::ToolBootstrap;
-        assert!(!use_snapshot || stage == 0);
+        assert!(!use_snapshot || stage == 0 || self.local_rebuild);
 
         let maybe_sysroot = self.sysroot(compiler);
         let sysroot = if use_snapshot {

--- a/src/libstd/build.rs
+++ b/src/libstd/build.rs
@@ -104,7 +104,8 @@ fn build_libbacktrace(target: &str) -> Result<(), ()> {
     } else {
         build.file("../libbacktrace/elf.c");
 
-        if target.contains("64") {
+        let pointer_width = env::var("CARGO_CFG_TARGET_POINTER_WIDTH").unwrap();
+        if pointer_width == "64" {
             build.define("BACKTRACE_ELF_SIZE", "64");
         } else {
             build.define("BACKTRACE_ELF_SIZE", "32");

--- a/src/libsyntax_pos/hygiene.rs
+++ b/src/libsyntax_pos/hygiene.rs
@@ -108,14 +108,7 @@ impl Mark {
 
     #[inline]
     pub fn set_expn_info(self, info: ExpnInfo) {
-        HygieneData::with(|data| {
-            let old_info = &mut data.marks[self.0 as usize].expn_info;
-            if let Some(old_info) = old_info {
-                panic!("expansion info is reset for the mark {}\nold: {:#?}\nnew: {:#?}",
-                       self.0, old_info, info);
-            }
-            *old_info = Some(info);
-        })
+        HygieneData::with(|data| data.marks[self.0 as usize].expn_info = Some(info))
     }
 
     #[inline]

--- a/src/test/ui/hygiene/expansion-info-reset.rs
+++ b/src/test/ui/hygiene/expansion-info-reset.rs
@@ -1,0 +1,17 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// FIXME: Investigate why expansion info for a single expansion id is reset from
+// `MacroBang(format_args)` to `MacroAttribute(derive(Clone))` (issue #52363).
+
+fn main() {
+    format_args!({ #[derive(Clone)] struct S; });
+    //~^ ERROR format argument must be a string literal
+}

--- a/src/test/ui/hygiene/expansion-info-reset.stderr
+++ b/src/test/ui/hygiene/expansion-info-reset.stderr
@@ -1,0 +1,12 @@
+error: format argument must be a string literal
+  --> $DIR/expansion-info-reset.rs:15:18
+   |
+LL |     format_args!({ #[derive(Clone)] struct S; });
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: you might be missing a string literal to format with
+   |
+LL |     format_args!("{}", { #[derive(Clone)] struct S; });
+   |                  ^^^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Merged and approved:

* #53653: Address two regressions
* #53377: std: Use target_pointer_width for BACKTRACE_ELF_SIZE
* #52969: rustbuild: fix local_rebuild

r? @ghost