### PR TITLE
Fix of bug introduced by #53762 (tool_lints)

### DIFF
--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -319,7 +319,15 @@ impl LintStore {
             CheckLintNameResult::NoLint => {
                 Some(struct_err!(sess, E0602, "unknown lint: `{}`", lint_name))
             }
-            CheckLintNameResult::Tool(_) => unreachable!(),
+            CheckLintNameResult::Tool(result) => match result {
+                Err((Some(_), new_name)) => Some(sess.struct_warn(&format!(
+                    "lint name `{}` is deprcated \
+                     and does not have an effect anymore. \
+                     Use: {}",
+                    lint_name, new_name
+                ))),
+                _ => None,
+            },
         };
 
         if let Some(mut db) = db {

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -321,7 +321,7 @@ impl LintStore {
             }
             CheckLintNameResult::Tool(result) => match result {
                 Err((Some(_), new_name)) => Some(sess.struct_warn(&format!(
-                    "lint name `{}` is deprcated \
+                    "lint name `{}` is deprecated \
                      and does not have an effect anymore. \
                      Use: {}",
                     lint_name, new_name

--- a/src/test/ui-fulldeps/lint_tool_cmdline_allow.rs
+++ b/src/test/ui-fulldeps/lint_tool_cmdline_allow.rs
@@ -1,0 +1,23 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// run-pass
+// aux-build:lint_tool_test.rs
+// ignore-stage1
+// compile-flags: -A test-lint
+
+#![feature(plugin)]
+#![warn(unused)]
+#![plugin(lint_tool_test)]
+
+fn lintme() { }
+
+pub fn main() {
+}

--- a/src/test/ui-fulldeps/lint_tool_cmdline_allow.stderr
+++ b/src/test/ui-fulldeps/lint_tool_cmdline_allow.stderr
@@ -1,0 +1,25 @@
+warning: lint name `test_lint` is deprcated and does not have an effect anymore. Use: clippy::test_lint
+   |
+   = note: requested on the command line with `-A test_lint`
+
+warning: item is named 'lintme'
+  --> $DIR/lint_tool_cmdline_allow.rs:20:1
+   |
+LL | fn lintme() { }
+   | ^^^^^^^^^^^^^^^
+   |
+   = note: #[warn(clippy::test_lint)] on by default
+
+warning: function is never used: `lintme`
+  --> $DIR/lint_tool_cmdline_allow.rs:20:1
+   |
+LL | fn lintme() { }
+   | ^^^^^^^^^^^
+   |
+note: lint level defined here
+  --> $DIR/lint_tool_cmdline_allow.rs:17:9
+   |
+LL | #![warn(unused)]
+   |         ^^^^^^
+   = note: #[warn(dead_code)] implied by #[warn(unused)]
+

--- a/src/test/ui-fulldeps/lint_tool_cmdline_allow.stderr
+++ b/src/test/ui-fulldeps/lint_tool_cmdline_allow.stderr
@@ -1,4 +1,4 @@
-warning: lint name `test_lint` is deprcated and does not have an effect anymore. Use: clippy::test_lint
+warning: lint name `test_lint` is deprecated and does not have an effect anymore. Use: clippy::test_lint
    |
    = note: requested on the command line with `-A test_lint`
 


### PR DESCRIPTION
Before implementing backwards compat for tool lints, the `Tool` case when parsing cmdline lints was unreachable. This changed with #53762.

This fix is needed for rls test-pass. (@nrc)

r? @Manishearth 