### PR TITLE
Doc total order requirement of sort(_unstable)_by

### DIFF
--- a/src/liballoc/slice.rs
+++ b/src/liballoc/slice.rs
@@ -211,6 +211,13 @@ impl<T> [T] {
     ///
     /// This sort is stable (i.e. does not reorder equal elements) and `O(n log n)` worst-case.
     ///
+    /// The comparator function must define a total ordering for the elements in the slice. If
+    /// the ordering is not total, the order of the elements is unspecified. An order is a
+    /// total order if it is (for all a, b and c):
+    ///
+    /// * total and antisymmetric: exactly one of a < b, a == b or a > b is true; and
+    /// * transitive, a < b and b < c implies a < c. The same must hold for both == and >.
+    ///
     /// When applicable, unstable sorting is preferred because it is generally faster than stable
     /// sorting and it doesn't allocate auxiliary memory.
     /// See [`sort_unstable_by`](#method.sort_unstable_by).

--- a/src/liballoc/slice.rs
+++ b/src/liballoc/slice.rs
@@ -218,7 +218,7 @@ impl<T> [T] {
     /// * total and antisymmetric: exactly one of a < b, a == b or a > b is true; and
     /// * transitive, a < b and b < c implies a < c. The same must hold for both == and >.
     ///
-    /// For example, while `f64` doesn't implement `Ord` because `NaN != NaN`, we can use
+    /// For example, while [`f64`] doesn't implement [`Ord`] because `NaN != NaN`, we can use
     /// `partial_cmp` as our sort function when we know the slice doesn't contain a `NaN`.
     ///
     /// ```

--- a/src/liballoc/slice.rs
+++ b/src/liballoc/slice.rs
@@ -242,6 +242,12 @@ impl<T> [T] {
     /// // reverse sorting
     /// v.sort_by(|a, b| b.cmp(a));
     /// assert!(v == [5, 4, 3, 2, 1]);
+    ///
+    /// // While f64 doesn't implement Ord because NaN != NaN, we can use
+    /// // partial_cmp here because we know none of the elements are NaN.
+    /// let mut floats = [5f64, 4.0, 1.0, 3.0, 2.0];
+    /// floats.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    /// assert_eq!(floats, [1.0, 2.0, 3.0, 4.0, 5.0]);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]

--- a/src/liballoc/slice.rs
+++ b/src/liballoc/slice.rs
@@ -218,6 +218,15 @@ impl<T> [T] {
     /// * total and antisymmetric: exactly one of a < b, a == b or a > b is true; and
     /// * transitive, a < b and b < c implies a < c. The same must hold for both == and >.
     ///
+    /// For example, while `f64` doesn't implement `Ord` because `NaN != NaN`, we can use
+    /// `partial_cmp` as our sort function when we know the slice doesn't contain a `NaN`.
+    ///
+    /// ```
+    /// let mut floats = [5f64, 4.0, 1.0, 3.0, 2.0];
+    /// floats.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    /// assert_eq!(floats, [1.0, 2.0, 3.0, 4.0, 5.0]);
+    /// ```
+    ///
     /// When applicable, unstable sorting is preferred because it is generally faster than stable
     /// sorting and it doesn't allocate auxiliary memory.
     /// See [`sort_unstable_by`](#method.sort_unstable_by).
@@ -242,12 +251,6 @@ impl<T> [T] {
     /// // reverse sorting
     /// v.sort_by(|a, b| b.cmp(a));
     /// assert!(v == [5, 4, 3, 2, 1]);
-    ///
-    /// // While f64 doesn't implement Ord because NaN != NaN, we can use
-    /// // partial_cmp here because we know none of the elements are NaN.
-    /// let mut floats = [5f64, 4.0, 1.0, 3.0, 2.0];
-    /// floats.sort_by(|a, b| a.partial_cmp(b).unwrap());
-    /// assert_eq!(floats, [1.0, 2.0, 3.0, 4.0, 5.0]);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -1339,6 +1339,13 @@ impl<T> [T] {
     /// This sort is unstable (i.e. may reorder equal elements), in-place (i.e. does not allocate),
     /// and `O(n log n)` worst-case.
     ///
+    /// The comparator function must define a total ordering for the elements in the slice. If
+    /// the ordering is not total, the order of the elements is unspecified. An order is a
+    /// total order if it is (for all a, b and c):
+    ///
+    /// * total and antisymmetric: exactly one of a < b, a == b or a > b is true; and
+    /// * transitive, a < b and b < c implies a < c. The same must hold for both == and >.
+    ///
     /// # Current implementation
     ///
     /// The current algorithm is based on [pattern-defeating quicksort][pdqsort] by Orson Peters,

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -1346,7 +1346,7 @@ impl<T> [T] {
     /// * total and antisymmetric: exactly one of a < b, a == b or a > b is true; and
     /// * transitive, a < b and b < c implies a < c. The same must hold for both == and >.
     ///
-    /// For example, while `f64` doesn't implement `Ord` because `NaN != NaN`, we can use
+    /// For example, while [`f64`] doesn't implement [`Ord`] because `NaN != NaN`, we can use
     /// `partial_cmp` as our sort function when we know the slice doesn't contain a `NaN`.
     ///
     /// ```

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -1367,6 +1367,12 @@ impl<T> [T] {
     /// // reverse sorting
     /// v.sort_unstable_by(|a, b| b.cmp(a));
     /// assert!(v == [5, 4, 3, 2, 1]);
+    ///
+    /// // While f64 doesn't implement Ord because NaN != NaN, we can use
+    /// // partial_cmp here because we know none of the elements are NaN.
+    /// let mut floats = [5f64, 4.0, 1.0, 3.0, 2.0];
+    /// floats.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap());
+    /// assert_eq!(floats, [1.0, 2.0, 3.0, 4.0, 5.0]);
     /// ```
     ///
     /// [pdqsort]: https://github.com/orlp/pdqsort

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -1346,6 +1346,15 @@ impl<T> [T] {
     /// * total and antisymmetric: exactly one of a < b, a == b or a > b is true; and
     /// * transitive, a < b and b < c implies a < c. The same must hold for both == and >.
     ///
+    /// For example, while `f64` doesn't implement `Ord` because `NaN != NaN`, we can use
+    /// `partial_cmp` as our sort function when we know the slice doesn't contain a `NaN`.
+    ///
+    /// ```
+    /// let mut floats = [5f64, 4.0, 1.0, 3.0, 2.0];
+    /// floats.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    /// assert_eq!(floats, [1.0, 2.0, 3.0, 4.0, 5.0]);
+    /// ```
+    ///
     /// # Current implementation
     ///
     /// The current algorithm is based on [pattern-defeating quicksort][pdqsort] by Orson Peters,
@@ -1367,12 +1376,6 @@ impl<T> [T] {
     /// // reverse sorting
     /// v.sort_unstable_by(|a, b| b.cmp(a));
     /// assert!(v == [5, 4, 3, 2, 1]);
-    ///
-    /// // While f64 doesn't implement Ord because NaN != NaN, we can use
-    /// // partial_cmp here because we know none of the elements are NaN.
-    /// let mut floats = [5f64, 4.0, 1.0, 3.0, 2.0];
-    /// floats.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap());
-    /// assert_eq!(floats, [1.0, 2.0, 3.0, 4.0, 5.0]);
     /// ```
     ///
     /// [pdqsort]: https://github.com/orlp/pdqsort


### PR DESCRIPTION
I took the definition of what a total order is from the Ord trait
docs. I specifically put "elements of the slice" because if you
have a slice of f64s, but know none are NaN, then sorting by
partial ord is total in this case. I'm not sure if I should give
such an example in the docs or not.

r? @GuillaumeGomez 