### PR TITLE
A few cleanups and minor improvements to save_analysis

### DIFF
--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -101,7 +101,7 @@ impl<'l, 'tcx: 'l> SaveContext<'l, 'tcx> {
         let end = cm.lookup_char_pos(span.hi());
 
         SpanData {
-            file_name: start.file.name.clone().to_string().into(),
+            file_name: start.file.name.to_string().into(),
             byte_start: span.lo().0,
             byte_end: span.hi().0,
             line_start: Row::new_one_indexed(start.line as u32),
@@ -113,7 +113,7 @@ impl<'l, 'tcx: 'l> SaveContext<'l, 'tcx> {
 
     // List external crates used by the current crate.
     pub fn get_external_crates(&self) -> Vec<ExternalCrateData> {
-        let mut result = Vec::new();
+        let mut result = Vec::with_capacity(self.tcx.crates().len());
 
         for &n in self.tcx.crates().iter() {
             let span = match *self.tcx.extern_crate(n.as_def_id()) {
@@ -321,7 +321,7 @@ impl<'l, 'tcx: 'l> SaveContext<'l, 'tcx> {
                     decl_id: None,
                     docs: self.docs_for_attrs(&item.attrs),
                     sig: sig::item_signature(item, self),
-                    attributes: lower_attributes(item.attrs.to_owned(), self),
+                    attributes: lower_attributes(item.attrs.clone(), self),
                 }))
             }
             ast::ItemKind::Impl(.., ref trait_ref, ref typ, ref impls) => {

--- a/src/librustc_save_analysis/sig.rs
+++ b/src/librustc_save_analysis/sig.rs
@@ -435,7 +435,7 @@ impl Sig for ast::Item {
                     },
                 ];
                 text.push_str(&name);
-                // Could be either `mod foo;` or `mod foo { ... }`, but we'll just puck one.
+                // Could be either `mod foo;` or `mod foo { ... }`, but we'll just pick one.
                 text.push(';');
 
                 Ok(Signature {
@@ -630,7 +630,7 @@ impl Sig for ast::Generics {
 
         let mut text = "<".to_owned();
 
-        let mut defs = vec![];
+        let mut defs = Vec::with_capacity(self.params.len());
         for param in &self.params {
             let mut param_text = param.ident.to_string();
             defs.push(SigElement {

--- a/src/librustc_save_analysis/span_utils.rs
+++ b/src/librustc_save_analysis/span_utils.rs
@@ -263,11 +263,8 @@ impl<'a> SpanUtils<'a> {
     /// such as references to macro internal variables.
     pub fn filter_generated(&self, sub_span: Option<Span>, parent: Span) -> bool {
         if !generated_code(parent) {
-            if sub_span.is_none() {
-                // Edge case - this occurs on generated code with incorrect expansion info.
-                return true;
-            }
-            return false;
+            // Edge case - this occurs on generated code with incorrect expansion info.
+            return sub_span.is_none()
         }
         // If sub_span is none, filter out generated code.
         let sub_span = match sub_span {


### PR DESCRIPTION
- calculate the capacity of some `Vec`s
- change`to_owned()` to `clone()` for the purposes of `lower_attributes`
- remove a superfluous `clone()`
- prefer `to_owned()` to `to_string()`
- a few other minor improvements