### PR TITLE
[experimental] Don't partition generic and non-generic code into different CGUs during incr. comp.

### DIFF
--- a/src/test/codegen-units/partitioning/extern-generic.rs
+++ b/src/test/codegen-units/partitioning/extern-generic.rs
@@ -58,5 +58,5 @@ mod mod3 {
 
 // Make sure the two generic functions from the extern crate get instantiated
 // once for the current crate
-//~ MONO_ITEM fn cgu_generic_function::foo[0]<&str> @@ cgu_generic_function.volatile[External]
-//~ MONO_ITEM fn cgu_generic_function::bar[0]<&str> @@ cgu_generic_function.volatile[External]
+//~ MONO_ITEM fn cgu_generic_function::foo[0]<&str> @@ cgu_generic_function[External]
+//~ MONO_ITEM fn cgu_generic_function::bar[0]<&str> @@ cgu_generic_function[External]

--- a/src/test/codegen-units/partitioning/local-generic.rs
+++ b/src/test/codegen-units/partitioning/local-generic.rs
@@ -16,10 +16,10 @@
 #![allow(dead_code)]
 #![crate_type="lib"]
 
-//~ MONO_ITEM fn local_generic::generic[0]<u32> @@ local_generic.volatile[External]
-//~ MONO_ITEM fn local_generic::generic[0]<u64> @@ local_generic.volatile[External]
-//~ MONO_ITEM fn local_generic::generic[0]<char> @@ local_generic.volatile[External]
-//~ MONO_ITEM fn local_generic::generic[0]<&str> @@ local_generic.volatile[External]
+//~ MONO_ITEM fn local_generic::generic[0]<u32> @@ local_generic[External]
+//~ MONO_ITEM fn local_generic::generic[0]<u64> @@ local_generic[External]
+//~ MONO_ITEM fn local_generic::generic[0]<char> @@ local_generic[External]
+//~ MONO_ITEM fn local_generic::generic[0]<&str> @@ local_generic[External]
 pub fn generic<T>(x: T) -> T { x }
 
 //~ MONO_ITEM fn local_generic::user[0] @@ local_generic[Internal]

--- a/src/test/codegen-units/partitioning/shared-generics.rs
+++ b/src/test/codegen-units/partitioning/shared-generics.rs
@@ -19,7 +19,7 @@ extern crate shared_generics_aux;
 //~ MONO_ITEM fn shared_generics::foo[0]
 pub fn foo() {
 
-    //~ MONO_ITEM fn shared_generics_aux::generic_fn[0]<u16> @@ shared_generics_aux.volatile[External]
+    //~ MONO_ITEM fn shared_generics_aux::generic_fn[0]<u16> @@ shared_generics_aux[External]
     let _ = shared_generics_aux::generic_fn(0u16, 1u16);
 
     // This should not generate a monomorphization because it's already

--- a/src/test/codegen-units/partitioning/vtable-through-const.rs
+++ b/src/test/codegen-units/partitioning/vtable-through-const.rs
@@ -78,20 +78,20 @@ fn start(_: isize, _: *const *const u8) -> isize {
     // Since Trait1::do_something() is instantiated via its default implementation,
     // it is considered a generic and is instantiated here only because it is
     // referenced in this module.
-    //~ MONO_ITEM fn vtable_through_const::mod1[0]::Trait1[0]::do_something_else[0]<u32> @@ vtable_through_const-mod1.volatile[External]
+    //~ MONO_ITEM fn vtable_through_const::mod1[0]::Trait1[0]::do_something_else[0]<u32> @@ vtable_through_const-mod1[External]
 
     // Although it is never used, Trait1::do_something_else() has to be
     // instantiated locally here too, otherwise the <&u32 as &Trait1> vtable
     // could not be fully constructed.
-    //~ MONO_ITEM fn vtable_through_const::mod1[0]::Trait1[0]::do_something[0]<u32> @@ vtable_through_const-mod1.volatile[External]
+    //~ MONO_ITEM fn vtable_through_const::mod1[0]::Trait1[0]::do_something[0]<u32> @@ vtable_through_const-mod1[External]
     mod1::TRAIT1_REF.do_something();
 
     // Same as above
-    //~ MONO_ITEM fn vtable_through_const::mod1[0]::{{impl}}[1]::do_something[0]<u8> @@ vtable_through_const-mod1.volatile[External]
-    //~ MONO_ITEM fn vtable_through_const::mod1[0]::{{impl}}[1]::do_something_else[0]<u8> @@ vtable_through_const-mod1.volatile[External]
+    //~ MONO_ITEM fn vtable_through_const::mod1[0]::{{impl}}[1]::do_something[0]<u8> @@ vtable_through_const-mod1[External]
+    //~ MONO_ITEM fn vtable_through_const::mod1[0]::{{impl}}[1]::do_something_else[0]<u8> @@ vtable_through_const-mod1[External]
     mod1::TRAIT1_GEN_REF.do_something(0u8);
 
-    //~ MONO_ITEM fn vtable_through_const::mod1[0]::id[0]<char> @@ vtable_through_const-mod1.volatile[External]
+    //~ MONO_ITEM fn vtable_through_const::mod1[0]::id[0]<char> @@ vtable_through_const-mod1[External]
     mod1::ID_CHAR('x');
 
     0


### PR DESCRIPTION
At the moment we are splitting generic and non-generic code into different CGUs when partitioning the crate during incremental compilation. The reasoning behind this is that generic code might change more often than non-generic code. That reasoning was never properly validated though. Since it's simple to just not split things, let's give it a try and see how it performs.