### PR TITLE
propagate build.python into cmake

### DIFF
--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -239,6 +239,10 @@ impl Step for Llvm {
             cfg.define("LLVM_NATIVE_BUILD", builder.llvm_out(builder.config.build).join("build"));
         }
 
+        if let Some(ref python) = builder.config.python {
+            cfg.define("PYTHON_EXECUTABLE", python);
+        }
+
         configure_cmake(builder, target, &mut cfg, false);
 
         // FIXME: we don't actually need to build all LLVM tools and all LLVM


### PR DESCRIPTION
If a suitable value of Python is not on `PATH`, one can still invoke x.py
manually, which propagates `BOOTSTRAP_PYTHON` into the bootstrap
environment.  But building LLVM will abort with error messages about not
being able to find Python, and instructions to set `PYTHON_EXECUTABLE`,
because nothing is done with `BOOTSTRAP_PYTHON` when invoking cmake.
Setting `build.python` in config.toml had no effect in this scenario,
either

To fix this, let's provide `PYTHON_EXECUTABLE` when invoking cmake; for
the "normal" case of Python in `PATH`, this doesn't alter any behavior.
For more unusual cases, however, this ensures cmake finds Python
properly.  (This change also ensures there are no differences between
what bootstrap is using, and what cmake uses, which may be useful for
consistency's sake.)