### PR TITLE
Have rust-lldb look for the rust-enabled lldb

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -2056,7 +2056,8 @@ impl Step for Lldb {
         drop(fs::remove_dir_all(&image));
 
         // Prepare the image directory
-        let dst = image.join("bin");
+        let root = image.join("lib/rustlib").join(&*target);
+        let dst = root.join("bin");
         t!(fs::create_dir_all(&dst));
         for program in &["lldb", "lldb-argdumper", "lldb-mi", "lldb-server"] {
             let exe = bindir.join(exe(program, &target));
@@ -2065,7 +2066,7 @@ impl Step for Lldb {
 
         // The libraries.
         let libdir = builder.llvm_out(target).join("lib");
-        let dst = image.join("lib");
+        let dst = root.join("lib");
         t!(fs::create_dir_all(&dst));
         for entry in t!(fs::read_dir(&libdir)) {
             let entry = entry.unwrap();
@@ -2093,7 +2094,7 @@ impl Step for Lldb {
             let entry = t!(entry);
             if let Ok(name) = entry.file_name().into_string() {
                 if name.starts_with("python") {
-                    let dst = image.join(libdir_name)
+                    let dst = root.join(libdir_name)
                         .join(entry.file_name());
                     t!(fs::create_dir_all(&dst));
                     builder.cp_r(&entry.path(), &dst);

--- a/src/etc/rust-lldb
+++ b/src/etc/rust-lldb
@@ -12,19 +12,27 @@
 # Exit if anything fails
 set -e
 
-LLDB_VERSION=`lldb --version 2>/dev/null | head -1 | cut -d. -f1`
+# Find out where to look for the pretty printer Python module
+RUSTC_SYSROOT=`rustc --print sysroot`
 
-if [ "$LLDB_VERSION" = "lldb-350" ]
-then
-    echo "***"
+# Find the host triple so we can find lldb in rustlib.
+host=`rustc -vV | sed -n -e 's/^host: //p'`
+
+lldb=lldb
+if [ -f "$RUSTC_SYSROOT/lib/rustlib/$host/bin/lldb" ]; then
+    lldb="$RUSTC_SYSROOT/lib/rustlib/$host/bin/lldb"
+else
+    LLDB_VERSION=`"$lldb" --version 2>/dev/null | head -1 | cut -d. -f1`
+
+    if [ "$LLDB_VERSION" = "lldb-350" ]
+    then
+        echo "***"
 	echo \
 "WARNING: This version of LLDB has known issues with Rust and cannot \
 display the contents of local variables!"
-    echo "***"
+        echo "***"
+    fi
 fi
-
-# Find out where to look for the pretty printer Python module
-RUSTC_SYSROOT=`rustc --print sysroot`
 
 # Prepare commands that will be loaded before any file on the command line has been loaded
 script_import="command script import \"$RUSTC_SYSROOT/lib/rustlib/etc/lldb_rust_formatters.py\""
@@ -32,7 +40,7 @@ category_definition="type summary add --no-value --python-function lldb_rust_for
 category_enable="type category enable Rust"
 
 # Call LLDB with the commands added to the argument list
-exec lldb --one-line-before-file="$script_import" \
+exec "$lldb" --one-line-before-file="$script_import" \
     --one-line-before-file="$category_definition" \
     --one-line-before-file="$category_enable" \
     "$@"


### PR DESCRIPTION
We're shipping a rust-enabled lldb, but the "lldb" executable is not
installed into the "bin" directory by rustup.  See the discussion in
https://github.com/rust-lang-nursery/rustup.rs/pull/1492 for
background on this decision.  There, we agreed to have rust-lldb
prefer the rust-enabled lldb if it is installed.  This patch changes
rust-lldb to look in the sysroot and use the lldb found there, if any.

See issue #48168