### PR TITLE
Add compile time checks for unchecked_shl/shr

### DIFF
--- a/src/librustc_mir/interpret/intrinsics.rs
+++ b/src/librustc_mir/interpret/intrinsics.rs
@@ -126,23 +126,22 @@ impl<'a, 'mir, 'tcx, M: Machine<'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> {
                 }
             }
             "unchecked_shl" | "unchecked_shr" => {
-                let bits = dest.layout.size.bytes() as u128 * 8;
                 let l = self.read_value(args[0])?;
                 let r = self.read_value(args[1])?;
-                let r_ty = substs.type_at(0);
-                let r_layout_of = self.layout_of(r_ty)?;
-                let r_val =  r.to_scalar()?.to_bits(r_layout_of.size)?;
-                if r_val >= bits {
-                    return err!(Intrinsic(
-                        format!("Overflowing shift by {} in {}", r_val, intrinsic_name),
-                    ));
-                }
                 let bin_op = match intrinsic_name {
                     "unchecked_shl" => BinOp::Shl,
                     "unchecked_shr" => BinOp::Shr,
                     _ => bug!("Already checked for int ops")
                 };
-                self.binop_ignore_overflow(bin_op, l, r, dest)?;
+                let (val, overflowed) = self.binary_op_val(bin_op, l, r)?;
+                if overflowed {
+                    let layout = self.layout_of(substs.type_at(0))?;
+                    let r_val =  r.to_scalar()?.to_bits(layout.size)?;
+                    return err!(Intrinsic(
+                        format!("Overflowing shift by {} in {}", r_val, intrinsic_name),
+                    ));
+                }
+                self.write_scalar(val, dest)?;
             }
             "transmute" => {
                 // Go through an allocation, to make sure the completely different layouts

--- a/src/test/ui/consts/const-int-unchecked.rs
+++ b/src/test/ui/consts/const-int-unchecked.rs
@@ -1,0 +1,21 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(core_intrinsics)]
+
+use std::intrinsics;
+
+const SHR: u8 = unsafe { intrinsics::unchecked_shr(5_u8, 8) };
+//^~ ERROR: Overflowing shift by 8 in unchecked_shr
+const SHL: u8 = unsafe { intrinsics::unchecked_shl(5_u8, 8) };
+//^~ ERROR: Overflowing shift by 8 in unchecked_shl
+
+fn main() {
+}

--- a/src/test/ui/consts/const-int-unchecked.stderr
+++ b/src/test/ui/consts/const-int-unchecked.stderr
@@ -1,0 +1,20 @@
+error: this constant cannot be used
+  --> $DIR/const-int-unchecked.rs:15:1
+   |
+LL | const SHR: u8 = unsafe { intrinsics::unchecked_shr(5_u8, 8) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^----------------------------------^^^
+   |                          |
+   |                          Overflowing shift by 8 in unchecked_shr
+   |
+   = note: #[deny(const_err)] on by default
+
+error: this constant cannot be used
+  --> $DIR/const-int-unchecked.rs:17:1
+   |
+LL | const SHL: u8 = unsafe { intrinsics::unchecked_shl(5_u8, 8) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^----------------------------------^^^
+   |                          |
+   |                          Overflowing shift by 8 in unchecked_shl
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
r? @RalfJung 

cc @oli-obk 

#53697 broke miri's test suite as described in [this comment](https://github.com/rust-lang/rust/pull/53697#issuecomment-419034668). This PR adds test for the `unchecked_shr/shl` for the intrinsics.