### PR TITLE
rustc_resolve: don't record uniform_paths canaries as reexports.

### DIFF
--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -1155,7 +1155,15 @@ impl<'a, 'b:'a, 'c: 'b> ImportResolver<'a, 'b, 'c> {
                 None => continue,
             };
 
-            if binding.is_import() || binding.is_macro_def() {
+            // Don't reexport `uniform_path` canaries.
+            let non_canary_import = match binding.kind {
+                NameBindingKind::Import { directive, .. } => {
+                    !directive.is_uniform_paths_canary
+                }
+                _ => false,
+            };
+
+            if non_canary_import || binding.is_macro_def() {
                 let def = binding.def();
                 if def != Def::Err {
                     if !def.def_id().is_local() {

--- a/src/test/run-pass/uniform-paths/auxiliary/issue-53691.rs
+++ b/src/test/run-pass/uniform-paths/auxiliary/issue-53691.rs
@@ -1,0 +1,19 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// edition:2018
+
+#![feature(uniform_paths)]
+
+mod m { pub fn f() {} }
+mod n { pub fn g() {} }
+
+pub use m::f;
+pub use n::g;

--- a/src/test/run-pass/uniform-paths/issue-53691.rs
+++ b/src/test/run-pass/uniform-paths/issue-53691.rs
@@ -1,0 +1,18 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:issue-53691.rs
+
+extern crate issue_53691;
+
+fn main() {
+    issue_53691::f();
+    issue_53691::g();
+}


### PR DESCRIPTION
Fixes #53691, fixes #53484.