### PR TITLE
rustc_resolve: inject `uniform_paths` canaries regardless of the feature-gate, on Rust 2018.

### DIFF
--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -199,22 +199,6 @@ impl<'a, 'cl> Resolver<'a, 'cl> {
         if emit_uniform_paths_canary {
             let source = prefix_start.unwrap();
 
-            // HACK(eddyb) For `use x::{self, ...};`, use the ID of the
-            // `self` nested import for the canary. This allows the
-            // ambiguity reporting scope to ignore false positives
-            // in the same way it does for `use x;` (by comparing IDs).
-            let mut canary_id = id;
-            if let ast::UseTreeKind::Nested(ref items) = use_tree.kind {
-                for &(ref use_tree, id) in items {
-                    if let ast::UseTreeKind::Simple(..) = use_tree.kind {
-                        if use_tree.ident().name == keywords::SelfValue.name() {
-                            canary_id = id;
-                            break;
-                        }
-                    }
-                }
-            }
-
             // Helper closure to emit a canary with the given base path.
             let emit = |this: &mut Self, base: Option<Ident>| {
                 let subclass = SingleImport {
@@ -234,7 +218,7 @@ impl<'a, 'cl> Resolver<'a, 'cl> {
                     base.into_iter().collect(),
                     subclass.clone(),
                     source.span,
-                    canary_id,
+                    id,
                     root_use_tree.span,
                     root_id,
                     ty::Visibility::Invisible,

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -194,7 +194,7 @@ impl<'a, 'cl> Resolver<'a, 'cl> {
         // ergonomically unacceptable.
         let emit_uniform_paths_canary =
             !uniform_paths_canary_emitted &&
-            uniform_paths &&
+            self.session.rust_2018() &&
             starts_with_non_keyword;
         if emit_uniform_paths_canary {
             let source = prefix_start.unwrap();

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -705,6 +705,7 @@ impl<'a, 'b:'a, 'c: 'b> ImportResolver<'a, 'b, 'c> {
             }
         }
 
+        let uniform_paths_feature = self.session.features_untracked().uniform_paths;
         for ((span, _), (name, results)) in uniform_paths_canaries {
             self.per_ns(|this, ns| {
                 let results = &results[ns];
@@ -736,15 +737,24 @@ impl<'a, 'b:'a, 'c: 'b> ImportResolver<'a, 'b, 'c> {
                         suggestion_choices.push_str(" or ");
                     }
                     write!(suggestion_choices, "`self::{}`", name);
-                    err.span_label(span,
-                        format!("can refer to `self::{}`", name));
+                    if uniform_paths_feature {
+                        err.span_label(span,
+                            format!("can refer to `self::{}`", name));
+                    } else {
+                        err.span_label(span,
+                            format!("may refer to `self::{}` in the future", name));
+                    }
                 }
                 for &span in &results.block_scopes {
                     err.span_label(span,
                         format!("shadowed by block-scoped `{}`", name));
                 }
                 err.help(&format!("write {} explicitly instead", suggestion_choices));
-                err.note("relative `use` paths enabled by `#![feature(uniform_paths)]`");
+                if uniform_paths_feature {
+                    err.note("relative `use` paths enabled by `#![feature(uniform_paths)]`");
+                } else {
+                    err.note("in the future, `#![feature(uniform_paths)]` may become the default");
+                }
                 err.emit();
             });
         }
@@ -930,11 +940,15 @@ impl<'a, 'b:'a, 'c: 'b> ImportResolver<'a, 'b, 'c> {
             _ => unreachable!(),
         };
 
+        // Do not record uses from canaries, to avoid interfering with other
+        // diagnostics or suggestions that rely on some items not being used.
+        let record_used = !directive.is_uniform_paths_canary;
+
         let mut all_ns_err = true;
         self.per_ns(|this, ns| if !type_ns_only || ns == TypeNS {
             if let Ok(binding) = result[ns].get() {
                 all_ns_err = false;
-                if this.record_use(ident, ns, binding) {
+                if record_used && this.record_use(ident, ns, binding) {
                     if let ModuleOrUniformRoot::Module(module) = module {
                         this.resolution(module, ident, ns).borrow_mut().binding =
                             Some(this.dummy_binding);
@@ -946,7 +960,7 @@ impl<'a, 'b:'a, 'c: 'b> ImportResolver<'a, 'b, 'c> {
         if all_ns_err {
             let mut all_ns_failed = true;
             self.per_ns(|this, ns| if !type_ns_only || ns == TypeNS {
-                match this.resolve_ident_in_module(module, ident, ns, true, span) {
+                match this.resolve_ident_in_module(module, ident, ns, record_used, span) {
                     Ok(_) => all_ns_failed = false,
                     _ => {}
                 }

--- a/src/test/ui/rust-2018/uniform-paths-forward-compat/ambiguity-macros-nested.rs
+++ b/src/test/ui/rust-2018/uniform-paths-forward-compat/ambiguity-macros-nested.rs
@@ -1,0 +1,29 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// edition:2018
+
+// This test is similar to `ambiguity-macros.rs`, but nested in a module.
+
+mod foo {
+    pub use std::io;
+    //~^ ERROR `std` import is ambiguous
+
+    macro_rules! m {
+        () => {
+            mod std {
+                pub struct io;
+            }
+        }
+    }
+    m!();
+}
+
+fn main() {}

--- a/src/test/ui/rust-2018/uniform-paths-forward-compat/ambiguity-macros-nested.stderr
+++ b/src/test/ui/rust-2018/uniform-paths-forward-compat/ambiguity-macros-nested.stderr
@@ -1,0 +1,16 @@
+error: `std` import is ambiguous
+  --> $DIR/ambiguity-macros-nested.rs:16:13
+   |
+LL |       pub use std::io;
+   |               ^^^ can refer to external crate `::std`
+...
+LL | /             mod std {
+LL | |                 pub struct io;
+LL | |             }
+   | |_____________- may refer to `self::std` in the future
+   |
+   = help: write `::std` or `self::std` explicitly instead
+   = note: in the future, `#![feature(uniform_paths)]` may become the default
+
+error: aborting due to previous error
+

--- a/src/test/ui/rust-2018/uniform-paths-forward-compat/ambiguity-macros.rs
+++ b/src/test/ui/rust-2018/uniform-paths-forward-compat/ambiguity-macros.rs
@@ -1,0 +1,27 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// edition:2018
+
+// This test is similar to `ambiguity.rs`, but with macros defining local items.
+
+use std::io;
+//~^ ERROR `std` import is ambiguous
+
+macro_rules! m {
+    () => {
+        mod std {
+            pub struct io;
+        }
+    }
+}
+m!();
+
+fn main() {}

--- a/src/test/ui/rust-2018/uniform-paths-forward-compat/ambiguity-macros.stderr
+++ b/src/test/ui/rust-2018/uniform-paths-forward-compat/ambiguity-macros.stderr
@@ -1,0 +1,16 @@
+error: `std` import is ambiguous
+  --> $DIR/ambiguity-macros.rs:15:5
+   |
+LL |   use std::io;
+   |       ^^^ can refer to external crate `::std`
+...
+LL | /         mod std {
+LL | |             pub struct io;
+LL | |         }
+   | |_________- may refer to `self::std` in the future
+   |
+   = help: write `::std` or `self::std` explicitly instead
+   = note: in the future, `#![feature(uniform_paths)]` may become the default
+
+error: aborting due to previous error
+

--- a/src/test/ui/rust-2018/uniform-paths-forward-compat/ambiguity-nested.rs
+++ b/src/test/ui/rust-2018/uniform-paths-forward-compat/ambiguity-nested.rs
@@ -1,0 +1,24 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// edition:2018
+
+// This test is similar to `ambiguity.rs`, but nested in a module.
+
+mod foo {
+    pub use std::io;
+    //~^ ERROR `std` import is ambiguous
+
+    mod std {
+        pub struct io;
+    }
+}
+
+fn main() {}

--- a/src/test/ui/rust-2018/uniform-paths-forward-compat/ambiguity-nested.stderr
+++ b/src/test/ui/rust-2018/uniform-paths-forward-compat/ambiguity-nested.stderr
@@ -1,0 +1,16 @@
+error: `std` import is ambiguous
+  --> $DIR/ambiguity-nested.rs:16:13
+   |
+LL |       pub use std::io;
+   |               ^^^ can refer to external crate `::std`
+...
+LL | /     mod std {
+LL | |         pub struct io;
+LL | |     }
+   | |_____- may refer to `self::std` in the future
+   |
+   = help: write `::std` or `self::std` explicitly instead
+   = note: in the future, `#![feature(uniform_paths)]` may become the default
+
+error: aborting due to previous error
+

--- a/src/test/ui/rust-2018/uniform-paths-forward-compat/ambiguity.rs
+++ b/src/test/ui/rust-2018/uniform-paths-forward-compat/ambiguity.rs
@@ -1,0 +1,20 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// edition:2018
+
+use std::io;
+//~^ ERROR `std` import is ambiguous
+
+mod std {
+    pub struct io;
+}
+
+fn main() {}

--- a/src/test/ui/rust-2018/uniform-paths-forward-compat/ambiguity.stderr
+++ b/src/test/ui/rust-2018/uniform-paths-forward-compat/ambiguity.stderr
@@ -1,0 +1,16 @@
+error: `std` import is ambiguous
+  --> $DIR/ambiguity.rs:13:5
+   |
+LL |   use std::io;
+   |       ^^^ can refer to external crate `::std`
+...
+LL | / mod std {
+LL | |     pub struct io;
+LL | | }
+   | |_- may refer to `self::std` in the future
+   |
+   = help: write `::std` or `self::std` explicitly instead
+   = note: in the future, `#![feature(uniform_paths)]` may become the default
+
+error: aborting due to previous error
+

--- a/src/test/ui/rust-2018/uniform-paths-forward-compat/block-scoped-shadow.rs
+++ b/src/test/ui/rust-2018/uniform-paths-forward-compat/block-scoped-shadow.rs
@@ -1,0 +1,21 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// edition:2018
+
+struct std;
+
+fn main() {
+    fn std() {}
+    enum std {}
+    use std as foo;
+    //~^ ERROR `std` import is ambiguous
+    //~| ERROR `std` import is ambiguous
+}

--- a/src/test/ui/rust-2018/uniform-paths-forward-compat/block-scoped-shadow.stderr
+++ b/src/test/ui/rust-2018/uniform-paths-forward-compat/block-scoped-shadow.stderr
@@ -1,0 +1,31 @@
+error: `std` import is ambiguous
+  --> $DIR/block-scoped-shadow.rs:18:9
+   |
+LL | struct std;
+   | ----------- may refer to `self::std` in the future
+...
+LL |     enum std {}
+   |     ----------- shadowed by block-scoped `std`
+LL |     use std as foo;
+   |         ^^^ can refer to external crate `::std`
+   |
+   = help: write `::std` or `self::std` explicitly instead
+   = note: in the future, `#![feature(uniform_paths)]` may become the default
+
+error: `std` import is ambiguous
+  --> $DIR/block-scoped-shadow.rs:18:9
+   |
+LL | struct std;
+   | ----------- may refer to `self::std` in the future
+...
+LL |     fn std() {}
+   |     ----------- shadowed by block-scoped `std`
+LL |     enum std {}
+LL |     use std as foo;
+   |         ^^^
+   |
+   = help: write `self::std` explicitly instead
+   = note: in the future, `#![feature(uniform_paths)]` may become the default
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/rust-2018/uniform-paths-forward-compat/redundant.rs
+++ b/src/test/ui/rust-2018/uniform-paths-forward-compat/redundant.rs
@@ -8,11 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// run-pass
 // edition:2018
 
-#![feature(uniform_paths)]
-
 use std;
+use std::io;
 
 mod foo {
     pub use std as my_std;
@@ -23,6 +23,7 @@ mod bar {
 }
 
 fn main() {
+    io::stdout();
     self::std::io::stdout();
     foo::my_std::io::stdout();
     bar::std::io::stdout();

--- a/src/test/ui/rust-2018/uniform-paths/redundant.rs
+++ b/src/test/ui/rust-2018/uniform-paths/redundant.rs
@@ -1,0 +1,32 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// run-pass
+// edition:2018
+
+#![feature(uniform_paths)]
+
+use std;
+use std::io;
+
+mod foo {
+    pub use std as my_std;
+}
+
+mod bar {
+    pub use std::{self};
+}
+
+fn main() {
+    io::stdout();
+    self::std::io::stdout();
+    foo::my_std::io::stdout();
+    bar::std::io::stdout();
+}


### PR DESCRIPTION
This PR is an attempt at future-proofing "anchored paths" by emitting the same ambiguity errors that `#![feature(uniform_paths)]` would, with slightly changed phrasing (see added UI tests).

Also, on top of #54005, this PR allows this as well:
```rust
use crate_name;
use crate_name::foo;
```
In that any ambiguity between an extern crate and an import *of that same crate* is ignored.

r? @petrochenkov cc @aturon @Centril @joshtriplett 