### PR TITLE
Include inline attribute in rendered docs

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -3403,13 +3403,14 @@ fn render_attribute(attr: &ast::MetaItem) -> Option<String> {
 
 const ATTRIBUTE_WHITELIST: &'static [&'static str] = &[
     "export_name",
+    "inline",
     "lang",
     "link_section",
     "must_use",
     "no_mangle",
     "repr",
     "unsafe_destructor_blind_to_params",
-    "non_exhaustive"
+    "non_exhaustive",
 ];
 
 fn render_attributes(w: &mut fmt::Formatter, it: &clean::Item) -> fmt::Result {


### PR DESCRIPTION
Fixes #52182.

Screenshot:

<img width="1440" alt="screen shot 2018-09-06 at 23 27 30" src="https://user-images.githubusercontent.com/3050060/45186089-9d2bd200-b22c-11e8-9db9-70d0d9bca3f6.png">

r? @QuietMisdreavus 