### PR TITLE
allow compiletest to pass down `--extern` flags

### DIFF
--- a/src/test/run-make-fulldeps/use-suggestions-rust-2018/Makefile
+++ b/src/test/run-make-fulldeps/use-suggestions-rust-2018/Makefile
@@ -1,7 +1,0 @@
--include ../tools.mk
-
-all:
-	$(RUSTC) ep-nested-lib.rs
-
-	$(RUSTC) use-suggestions.rs --edition=2018 --extern ep_nested_lib=$(TMPDIR)/libep_nested_lib.rlib 2>&1 | $(CGREP) "use ep_nested_lib::foo::bar::Baz"
-

--- a/src/test/ui/auxiliary/baz.rs
+++ b/src/test/ui/auxiliary/baz.rs
@@ -1,0 +1,13 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type="lib"]
+
+pub struct Yellow;

--- a/src/test/ui/issue-53737.rs
+++ b/src/test/ui/issue-53737.rs
@@ -1,0 +1,19 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-crate:myfoo=baz.rs
+// edition:2018
+
+
+use myfoo::Yellow;
+
+fn main() {
+    let x = Yellow{};
+}

--- a/src/test/ui/rust-2018/auxiliary/ep-nested-lib.rs
+++ b/src/test/ui/rust-2018/auxiliary/ep-nested-lib.rs
@@ -8,6 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn main() {
-    let x = Baz{};
+#![crate_type = "rlib"]
+
+pub mod foo {
+    pub mod bar {
+        pub struct Bazz;
+    }
 }

--- a/src/test/ui/rust-2018/use-suggestions-extern-prelude.rs
+++ b/src/test/ui/rust-2018/use-suggestions-extern-prelude.rs
@@ -8,10 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![crate_type = "rlib"]
+// edition:2018
+// aux-crate:netted=ep-nested-lib.rs
 
-pub mod foo {
-    pub mod bar {
-        pub struct Baz;
-    }
+fn main() {
+    let _x = Bazz{};
+    //~^ ERROR cannot find struct, variant or union type `Bazz` in this scope
 }

--- a/src/test/ui/rust-2018/use-suggestions-extern-prelude.stderr
+++ b/src/test/ui/rust-2018/use-suggestions-extern-prelude.stderr
@@ -1,0 +1,13 @@
+error[E0422]: cannot find struct, variant or union type `Bazz` in this scope
+  --> $DIR/use-suggestions-extern-prelude.rs:15:14
+   |
+LL |     let _x = Bazz{};
+   |              ^^^^ not found in this scope
+help: possible candidate is found in another module, you can import it into scope
+   |
+LL | use netted::foo::bar::Bazz;
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0422`.

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -838,8 +838,8 @@ fn test_parse_name_value_directive() {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct KeyValue {
-    key: String,
-    value: String,
+    pub key: String,
+    pub value: String,
 }
 
 #[test]

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -815,6 +815,29 @@ fn test_parse_name_value_directive() {
     assert_eq!(None, internal_parse_name_value_directive("faux-build:foo.rs", "aux-build"));
 }
 
+#[derive(Debug, PartialEq)]
+struct KeyValue {
+    key: String,
+    value: String,
+}
+
+#[test]
+fn test_parse_name_kv_directive() {
+    let value = internal_parse_name_kv_directive("crate-aux-build:baz=foo.rs", "crate-aux-build");
+    assert_eq!(Some(KeyValue{key:"baz".to_owned(), value:"foo.rs".to_owned()}), value);
+}
+
+fn internal_parse_name_kv_directive(line: &str, directive: &str) -> Option<KeyValue> {
+    if let Some(value) = internal_parse_name_value_directive(line, directive) {
+        let parts = value.split("=").collect::<Vec<&str>>();
+        if parts.len() == 2 {
+            let (k,v) = (parts[0], parts[1]);
+            return Some(KeyValue{key:k.to_string(),value:v.to_string()});
+        }
+    }
+    None
+}
+
 fn internal_parse_name_value_directive(line: &str, directive: &str) -> Option<String> {
     let colon = directive.len();
     if line.starts_with(directive) && line.as_bytes().get(colon) == Some(&b':') {

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -811,8 +811,8 @@ pub fn lldb_version_to_int(version_string: &str) -> isize {
 
 #[test]
 fn test_parse_name_value_directive() {
-    let sample_directive = "aux-build:foo.rs";
-    assert_eq!(Some("foo.rs".to_owned()), internal_parse_name_value_directive(&sample_directive, "aux-build"))
+    assert_eq!(Some("foo.rs".to_owned()), internal_parse_name_value_directive("aux-build:foo.rs", "aux-build"));
+    assert_eq!(None, internal_parse_name_value_directive("faux-build:foo.rs", "aux-build"));
 }
 
 fn internal_parse_name_value_directive(line: &str, directive: &str) -> Option<String> {

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -772,14 +772,7 @@ impl Config {
     }
 
     pub fn parse_name_value_directive(&self, line: &str, directive: &str) -> Option<String> {
-        let colon = directive.len();
-        if line.starts_with(directive) && line.as_bytes().get(colon) == Some(&b':') {
-            let value = line[(colon + 1)..].to_owned();
-            debug!("{}: {}", directive, value);
-            Some(expand_variables(value, self))
-        } else {
-            None
-        }
+        internal_parse_name_value_directive(self, line, directive)
     }
 
     pub fn find_rust_src_root(&self) -> Option<PathBuf> {
@@ -814,6 +807,17 @@ pub fn lldb_version_to_int(version_string: &str) -> isize {
         version_string
     );
     version_string.parse().expect(&error_string)
+}
+
+fn internal_parse_name_value_directive(config: &Config, line: &str, directive: &str) -> Option<String> {
+    let colon = directive.len();
+    if line.starts_with(directive) && line.as_bytes().get(colon) == Some(&b':') {
+        let value = line[(colon + 1)..].to_owned();
+        debug!("{}: {}", directive, value);
+        Some(expand_variables(value, config))
+    } else {
+        None
+    }
 }
 
 fn expand_variables(mut value: String, config: &Config) -> String {

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -832,7 +832,8 @@ pub fn lldb_version_to_int(version_string: &str) -> isize {
 
 #[test]
 fn test_parse_name_value_directive() {
-    assert_eq!(Some("foo.rs".to_owned()), internal_parse_name_value_directive("aux-build:foo.rs", "aux-build"));
+    assert_eq!(Some("foo.rs".to_owned()),
+               internal_parse_name_value_directive("aux-build:foo.rs", "aux-build"));
     assert_eq!(None, internal_parse_name_value_directive("faux-build:foo.rs", "aux-build"));
 }
 

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -772,7 +772,7 @@ impl Config {
     }
 
     pub fn parse_name_value_directive(&self, line: &str, directive: &str) -> Option<String> {
-        internal_parse_name_value_directive(self, line, directive)
+        internal_parse_name_value_directive(line, directive).map(|v| expand_variables(v, self))
     }
 
     pub fn find_rust_src_root(&self) -> Option<PathBuf> {
@@ -809,12 +809,18 @@ pub fn lldb_version_to_int(version_string: &str) -> isize {
     version_string.parse().expect(&error_string)
 }
 
-fn internal_parse_name_value_directive(config: &Config, line: &str, directive: &str) -> Option<String> {
+#[test]
+fn test_parse_name_value_directive() {
+    let sample_directive = "aux-build:foo.rs";
+    assert_eq!(Some("foo.rs".to_owned()), internal_parse_name_value_directive(&sample_directive, "aux-build"))
+}
+
+fn internal_parse_name_value_directive(line: &str, directive: &str) -> Option<String> {
     let colon = directive.len();
     if line.starts_with(directive) && line.as_bytes().get(colon) == Some(&b':') {
         let value = line[(colon + 1)..].to_owned();
         debug!("{}: {}", directive, value);
-        Some(expand_variables(value, config))
+        Some(value)
     } else {
         None
     }

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1574,7 +1574,10 @@ impl<'test> TestCx<'test> {
 
         for aux_crate in &self.props.aux_crates {
             rustc.arg("--extern");
-            rustc.arg(format!("{}={}/lib{}", aux_crate.key, aux_dir.display(), &aux_crate.value.replace(".rs", ".so").replace("-","_")));
+            rustc.arg(format!("{}={}/lib{}",
+                              aux_crate.key,
+                              aux_dir.display(),
+                              &aux_crate.value.replace(".rs", ".so").replace("-","_")));
         }
 
         self.compose_and_run(

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1571,6 +1571,11 @@ impl<'test> TestCx<'test> {
         }
 
         rustc.envs(self.props.rustc_env.clone());
+
+        for aux_crate in &self.props.aux_crates {
+            rustc.arg(format!("--extern {}={}", aux_crate.key, aux_crate.value));
+        }
+
         self.compose_and_run(
             rustc,
             self.config.compile_lib_path.to_str().unwrap(),

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1573,7 +1573,8 @@ impl<'test> TestCx<'test> {
         rustc.envs(self.props.rustc_env.clone());
 
         for aux_crate in &self.props.aux_crates {
-            rustc.arg(format!("--extern {}={}", aux_crate.key, aux_crate.value));
+            rustc.arg("--extern");
+            rustc.arg(format!("{}={}/lib{}", aux_crate.key, aux_dir.display(), &aux_crate.value.replace(".rs", ".so").replace("-","_")));
         }
 
         self.compose_and_run(

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1566,6 +1566,10 @@ impl<'test> TestCx<'test> {
             build_auxiliary(self, rel_ab, &aux_dir);
         }
 
+        for rel_ab in &self.props.aux_crates {
+            build_auxiliary(self, &rel_ab.value, &aux_dir);
+        }
+
         rustc.envs(self.props.rustc_env.clone());
         self.compose_and_run(
             rustc,

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -36,6 +36,7 @@ use std::io::{self, BufReader};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, ExitStatus, Output, Stdio};
 use std::str;
+use std::env::consts::DLL_EXTENSION;
 
 use extract_gdb_version;
 use is_android_gdb_target;
@@ -1577,7 +1578,9 @@ impl<'test> TestCx<'test> {
             rustc.arg(format!("{}={}/lib{}",
                               aux_crate.key,
                               aux_dir.display(),
-                              &aux_crate.value.replace(".rs", ".so").replace("-","_")));
+                              aux_crate.value.replace(".rs", &format!(".{}", DLL_EXTENSION))
+                              .replace("-","_")
+                              ));
         }
 
         self.compose_and_run(


### PR DESCRIPTION
When cargo exposes a crate to rustc, it uses `--extern`, with the potential for crate name aliasing. This PR adds this support to compiletest via a `aux-crate:foo=baz.rs` header, where it exposes the crate `baz` under a `foo` alias.

This is specially useful for testing the new Rust 2018 edition module behaviors, since crates listed via `--extern` appear in the prelude.

Additionally, this also adds some tests to the existing compiletest parsing code.

Fixes #53737