### PR TITLE
A few cleanups and minor improvements to rustc_passes

### DIFF
--- a/src/librustc_passes/ast_validation.rs
+++ b/src/librustc_passes/ast_validation.rs
@@ -98,14 +98,11 @@ impl<'a> AstValidator<'a> {
     }
 
     fn check_trait_fn_not_const(&self, constness: Spanned<Constness>) {
-        match constness.node {
-            Constness::Const => {
-                struct_span_err!(self.session, constness.span, E0379,
-                                 "trait fns cannot be declared const")
-                    .span_label(constness.span, "trait fns cannot be const")
-                    .emit();
-            }
-            _ => {}
+        if constness.node == Constness::Const {
+            struct_span_err!(self.session, constness.span, E0379,
+                             "trait fns cannot be declared const")
+                .span_label(constness.span, "trait fns cannot be const")
+                .emit();
         }
     }
 
@@ -113,7 +110,7 @@ impl<'a> AstValidator<'a> {
         for bound in bounds {
             if let GenericBound::Trait(ref poly, TraitBoundModifier::Maybe) = *bound {
                 let mut err = self.err_handler().struct_span_err(poly.span,
-                                    &format!("`?Trait` is not permitted in {}", where_));
+                    &format!("`?Trait` is not permitted in {}", where_));
                 if is_trait {
                     err.note(&format!("traits are `?{}` by default", poly.trait_ref.path));
                 }
@@ -152,16 +149,16 @@ impl<'a> AstValidator<'a> {
         // Check only lifetime parameters are present and that the lifetime
         // parameters that are present have no bounds.
         let non_lt_param_spans: Vec<_> = params.iter().filter_map(|param| match param.kind {
-                GenericParamKind::Lifetime { .. } => {
-                    if !param.bounds.is_empty() {
-                        let spans: Vec<_> = param.bounds.iter().map(|b| b.span()).collect();
-                        self.err_handler()
-                            .span_err(spans, "lifetime bounds cannot be used in this context");
-                    }
-                    None
+            GenericParamKind::Lifetime { .. } => {
+                if !param.bounds.is_empty() {
+                    let spans: Vec<_> = param.bounds.iter().map(|b| b.span()).collect();
+                    self.err_handler()
+                        .span_err(spans, "lifetime bounds cannot be used in this context");
                 }
-                _ => Some(param.ident.span),
-            }).collect();
+                None
+            }
+            _ => Some(param.ident.span),
+        }).collect();
         if !non_lt_param_spans.is_empty() {
             self.err_handler().span_err(non_lt_param_spans,
                 "only lifetime parameters can be used in this context");
@@ -387,7 +384,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                     self.err_handler().span_err(item.span,
                                                 "tuple and unit unions are not permitted");
                 }
-                if vdata.fields().len() == 0 {
+                if vdata.fields().is_empty() {
                     self.err_handler().span_err(item.span,
                                                 "unions cannot have zero fields");
                 }
@@ -414,14 +411,11 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
     }
 
     fn visit_vis(&mut self, vis: &'a Visibility) {
-        match vis.node {
-            VisibilityKind::Restricted { ref path, .. } => {
-                path.segments.iter().find(|segment| segment.args.is_some()).map(|segment| {
-                    self.err_handler().span_err(segment.args.as_ref().unwrap().span(),
-                                                "generic arguments in visibility path");
-                });
-            }
-            _ => {}
+        if let VisibilityKind::Restricted { ref path, .. } = vis.node {
+            path.segments.iter().find(|segment| segment.args.is_some()).map(|segment| {
+                self.err_handler().span_err(segment.args.as_ref().unwrap().span(),
+                                            "generic arguments in visibility path");
+            });
         }
 
         visit::walk_vis(self, vis)
@@ -591,8 +585,7 @@ impl<'a> Visitor<'a> for ImplTraitProjectionVisitor<'a> {
             TyKind::ImplTrait(..) => {
                 if self.is_banned {
                     struct_span_err!(self.session, t.span, E0667,
-                                 "`impl Trait` is not allowed in path parameters")
-                        .emit();
+                        "`impl Trait` is not allowed in path parameters").emit();
                 }
             }
             TyKind::Path(ref qself, ref path) => {
@@ -616,7 +609,7 @@ impl<'a> Visitor<'a> for ImplTraitProjectionVisitor<'a> {
 
                 for (i, segment) in path.segments.iter().enumerate() {
                     // Allow `impl Trait` iff we're on the final path segment
-                    if i == (path.segments.len() - 1) {
+                    if i == path.segments.len() - 1 {
                         visit::walk_path_segment(self, path.span, segment);
                     } else {
                         self.with_ban(|this|

--- a/src/librustc_passes/hir_stats.rs
+++ b/src/librustc_passes/hir_stats.rs
@@ -61,10 +61,8 @@ pub fn print_ast_stats<'v>(krate: &'v ast::Crate, title: &str) {
 impl<'k> StatCollector<'k> {
 
     fn record<T>(&mut self, label: &'static str, id: Id, node: &T) {
-        if id != Id::None {
-            if !self.seen.insert(id) {
-                return
-            }
+        if id != Id::None && !self.seen.insert(id) {
+            return
         }
 
         let entry = self.data.entry(label).or_insert(NodeData {
@@ -135,40 +133,46 @@ impl<'v> hir_visit::Visitor<'v> for StatCollector<'v> {
         hir_visit::walk_item(self, i)
     }
 
-    ///////////////////////////////////////////////////////////////////////////
-
     fn visit_mod(&mut self, m: &'v hir::Mod, _s: Span, n: NodeId) {
         self.record("Mod", Id::None, m);
         hir_visit::walk_mod(self, m, n)
     }
+
     fn visit_foreign_item(&mut self, i: &'v hir::ForeignItem) {
         self.record("ForeignItem", Id::Node(i.id), i);
         hir_visit::walk_foreign_item(self, i)
     }
+
     fn visit_local(&mut self, l: &'v hir::Local) {
         self.record("Local", Id::Node(l.id), l);
         hir_visit::walk_local(self, l)
     }
+
     fn visit_block(&mut self, b: &'v hir::Block) {
         self.record("Block", Id::Node(b.id), b);
         hir_visit::walk_block(self, b)
     }
+
     fn visit_stmt(&mut self, s: &'v hir::Stmt) {
         self.record("Stmt", Id::Node(s.node.id()), s);
         hir_visit::walk_stmt(self, s)
     }
+
     fn visit_arm(&mut self, a: &'v hir::Arm) {
         self.record("Arm", Id::None, a);
         hir_visit::walk_arm(self, a)
     }
+
     fn visit_pat(&mut self, p: &'v hir::Pat) {
         self.record("Pat", Id::Node(p.id), p);
         hir_visit::walk_pat(self, p)
     }
+
     fn visit_decl(&mut self, d: &'v hir::Decl) {
         self.record("Decl", Id::None, d);
         hir_visit::walk_decl(self, d)
     }
+
     fn visit_expr(&mut self, ex: &'v hir::Expr) {
         self.record("Expr", Id::Node(ex.id), ex);
         hir_visit::walk_expr(self, ex)
@@ -198,6 +202,7 @@ impl<'v> hir_visit::Visitor<'v> for StatCollector<'v> {
         self.record("TraitItem", Id::Node(ti.id), ti);
         hir_visit::walk_trait_item(self, ti)
     }
+
     fn visit_impl_item(&mut self, ii: &'v hir::ImplItem) {
         self.record("ImplItem", Id::Node(ii.id), ii);
         hir_visit::walk_impl_item(self, ii)
@@ -220,31 +225,38 @@ impl<'v> hir_visit::Visitor<'v> for StatCollector<'v> {
         self.record("Variant", Id::None, v);
         hir_visit::walk_variant(self, v, g, item_id)
     }
+
     fn visit_lifetime(&mut self, lifetime: &'v hir::Lifetime) {
         self.record("Lifetime", Id::Node(lifetime.id), lifetime);
         hir_visit::walk_lifetime(self, lifetime)
     }
+
     fn visit_qpath(&mut self, qpath: &'v hir::QPath, id: hir::HirId, span: Span) {
         self.record("QPath", Id::None, qpath);
         hir_visit::walk_qpath(self, qpath, id, span)
     }
+
     fn visit_path(&mut self, path: &'v hir::Path, _id: hir::HirId) {
         self.record("Path", Id::None, path);
         hir_visit::walk_path(self, path)
     }
+
     fn visit_path_segment(&mut self,
                           path_span: Span,
                           path_segment: &'v hir::PathSegment) {
         self.record("PathSegment", Id::None, path_segment);
         hir_visit::walk_path_segment(self, path_span, path_segment)
     }
+
     fn visit_assoc_type_binding(&mut self, type_binding: &'v hir::TypeBinding) {
         self.record("TypeBinding", Id::Node(type_binding.id), type_binding);
         hir_visit::walk_assoc_type_binding(self, type_binding)
     }
+
     fn visit_attribute(&mut self, attr: &'v ast::Attribute) {
         self.record("Attribute", Id::Attr(attr.id), attr);
     }
+
     fn visit_macro_def(&mut self, macro_def: &'v hir::MacroDef) {
         self.record("MacroDef", Id::Node(macro_def.id), macro_def);
         hir_visit::walk_macro_def(self, macro_def)

--- a/src/librustc_passes/mir_stats.rs
+++ b/src/librustc_passes/mir_stats.rs
@@ -65,15 +65,12 @@ impl<'a, 'tcx> mir_visit::Visitor<'tcx> for StatCollector<'a, 'tcx> {
         self.super_mir(mir);
     }
 
-    fn visit_basic_block_data(&mut self,
-                              block: BasicBlock,
-                              data: &BasicBlockData<'tcx>) {
+    fn visit_basic_block_data(&mut self, block: BasicBlock, data: &BasicBlockData<'tcx>) {
         self.record("BasicBlockData", data);
         self.super_basic_block_data(block, data);
     }
 
-    fn visit_source_scope_data(&mut self,
-                                   scope_data: &SourceScopeData) {
+    fn visit_source_scope_data(&mut self, scope_data: &SourceScopeData) {
         self.record("SourceScopeData", scope_data);
         self.super_source_scope_data(scope_data);
     }
@@ -130,9 +127,7 @@ impl<'a, 'tcx> mir_visit::Visitor<'tcx> for StatCollector<'a, 'tcx> {
         self.super_terminator_kind(block, kind, location);
     }
 
-    fn visit_assert_message(&mut self,
-                            msg: &AssertMessage<'tcx>,
-                            location: Location) {
+    fn visit_assert_message(&mut self, msg: &AssertMessage<'tcx>, location: Location) {
         self.record("AssertMessage", msg);
         self.record(match *msg {
             EvalErrorKind::BoundsCheck { .. } => "AssertMessage::BoundsCheck",
@@ -151,9 +146,7 @@ impl<'a, 'tcx> mir_visit::Visitor<'tcx> for StatCollector<'a, 'tcx> {
         self.super_assert_message(msg, location);
     }
 
-    fn visit_rvalue(&mut self,
-                    rvalue: &Rvalue<'tcx>,
-                    location: Location) {
+    fn visit_rvalue(&mut self, rvalue: &Rvalue<'tcx>, location: Location) {
         self.record("Rvalue", rvalue);
         let rvalue_kind = match *rvalue {
             Rvalue::Use(..) => "Rvalue::Use",
@@ -184,9 +177,7 @@ impl<'a, 'tcx> mir_visit::Visitor<'tcx> for StatCollector<'a, 'tcx> {
         self.super_rvalue(rvalue, location);
     }
 
-    fn visit_operand(&mut self,
-                     operand: &Operand<'tcx>,
-                     location: Location) {
+    fn visit_operand(&mut self, operand: &Operand<'tcx>, location: Location) {
         self.record("Operand", operand);
         self.record(match *operand {
             Operand::Copy(..) => "Operand::Copy",
@@ -234,42 +225,32 @@ impl<'a, 'tcx> mir_visit::Visitor<'tcx> for StatCollector<'a, 'tcx> {
         self.super_projection_elem(place, context, location);
     }
 
-    fn visit_constant(&mut self,
-                      constant: &Constant<'tcx>,
-                      location: Location) {
+    fn visit_constant(&mut self, constant: &Constant<'tcx>, location: Location) {
         self.record("Constant", constant);
         self.super_constant(constant, location);
     }
 
-    fn visit_source_info(&mut self,
-                         source_info: &SourceInfo) {
+    fn visit_source_info(&mut self, source_info: &SourceInfo) {
         self.record("SourceInfo", source_info);
         self.super_source_info(source_info);
     }
 
-    fn visit_closure_substs(&mut self,
-                            substs: &ClosureSubsts<'tcx>,
-                            _: Location) {
+    fn visit_closure_substs(&mut self, substs: &ClosureSubsts<'tcx>, _: Location) {
         self.record("ClosureSubsts", substs);
         self.super_closure_substs(substs);
     }
 
-    fn visit_const(&mut self,
-                   constant: &&'tcx ty::Const<'tcx>,
-                   _: Location) {
+    fn visit_const(&mut self, constant: &&'tcx ty::Const<'tcx>, _: Location) {
         self.record("Const", constant);
         self.super_const(constant);
     }
 
-    fn visit_local_decl(&mut self,
-                        local: Local,
-                        local_decl: &LocalDecl<'tcx>) {
+    fn visit_local_decl(&mut self, local: Local, local_decl: &LocalDecl<'tcx>) {
         self.record("LocalDecl", local_decl);
         self.super_local_decl(local, local_decl);
     }
 
-    fn visit_source_scope(&mut self,
-                              scope: &SourceScope) {
+    fn visit_source_scope(&mut self, scope: &SourceScope) {
         self.record("VisiblityScope", scope);
         self.super_source_scope(scope);
     }


### PR DESCRIPTION
- prefer `if let` to `match` when only one branch matters
- prefer equality checks to pattern matching
- prefer `is_empty` to `len() == 0`
- collapse a couple of `if` expressions
- rename `label` to `destination` when destructuring `hir::ExprKind::Continue`
- `derive Copy` for `Promotability`
- `impl BitAndAssign` for `Promotability`
- a few formatting fixes
- a few other minor cleanups