### PR TITLE
[WIP] rustc_typeck: check well-formedness of type aliases.

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -250,7 +250,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "chalk-engine"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "chalk-macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -638,6 +638,14 @@ dependencies = [
 [[package]]
 name = "ena"
 version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ena"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1856,7 +1864,7 @@ dependencies = [
  "backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "chalk-engine 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chalk-engine 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fmt_macros 0.0.0",
  "graphviz 0.0.0",
@@ -2122,7 +2130,7 @@ name = "rustc_data_structures"
 version = "0.0.0"
 dependencies = [
  "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "ena 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ena 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot_core 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2383,7 +2391,7 @@ name = "rustc_traits"
 version = "0.0.0"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "chalk-engine 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chalk-engine 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "graphviz 0.0.0",
  "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc 0.0.0",
@@ -3126,7 +3134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cargo_metadata 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d6809b327f87369e6f3651efd2c5a96c49847a3ed2559477ecba79014751ee1"
 "checksum cc 1.0.22 (registry+https://github.com/rust-lang/crates.io-index)" = "4a6007c146fdd28d4512a794b07ffe9d8e89e6bf86e2e0c4ddff2e1fb54a0007"
 "checksum cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4e7bb64a8ebb0d856483e1e682ea3422f883c5f5615a90d51a2c82fe87fdd3"
-"checksum chalk-engine 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "25ce2f28f55ed544a2a3756b7acf41dd7d6f27acffb2086439950925506af7d0"
+"checksum chalk-engine 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "217042da49c0c0655bbc4aa9f9bed20c7a599429faddc9b2ef3bd09a2769d3ef"
 "checksum chalk-macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "295635afd6853aa9f20baeb7f0204862440c0fe994c5a253d5f479dac41d047e"
 "checksum chrono 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6962c635d530328acc53ac6a955e83093fedc91c5809dfac1fa60fa470830a37"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
@@ -3156,6 +3164,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum elasticlunr-rs 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4837d77a1e157489a3933b743fd774ae75074e0e390b2b7f071530048a0d87ee"
+"checksum ena 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "25b4e5febb25f08c49f1b07dc33a182729a6b21edfb562b5aef95f78e0dbe5bb"
 "checksum ena 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "88dc8393b3c7352f94092497f6b52019643e493b6b890eb417cdb7c46117e621"
 "checksum env_logger 0.5.12 (registry+https://github.com/rust-lang/crates.io-index)" = "f4d7e69c283751083d53d01eac767407343b8b69c4bd70058e08adc2637cb257"
 "checksum environment 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1f4b14e20978669064c33b4c1e0fb4083412e40fe56cbea2eae80fd7591503ee"

--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -304,6 +304,11 @@ fn main() {
     {
         cmd.arg("-Dwarnings");
         cmd.arg("-Dbare_trait_objects");
+        if !(stage == "0" || target.is_none() && version.is_none()) {
+            // HACK(eddyb) allow bootstrapping while we're testing with
+            // the lint on `deny` by default. Remove before merging.
+            cmd.arg("-Atype_alias_missing_bounds");
+        }
     }
 
     if verbose > 1 {

--- a/src/libgraphviz/lib.rs
+++ b/src/libgraphviz/lib.rs
@@ -574,8 +574,10 @@ impl<'a> LabelText<'a> {
     }
 }
 
-pub type Nodes<'a,N> = Cow<'a,[N]>;
-pub type Edges<'a,E> = Cow<'a,[E]>;
+#[allow(type_alias_bounds)]
+pub type Nodes<'a,N: Clone> = Cow<'a,[N]>;
+#[allow(type_alias_bounds)]
+pub type Edges<'a,E: Clone> = Cow<'a,[E]>;
 
 // (The type parameters in GraphWalk should be associated items,
 // when/if Rust supports such.)

--- a/src/librustc/infer/canonical/mod.rs
+++ b/src/librustc/infer/canonical/mod.rs
@@ -128,10 +128,12 @@ pub struct QueryResult<'tcx, R> {
     pub value: R,
 }
 
-pub type Canonicalized<'gcx, V> = Canonical<'gcx, <V as Lift<'gcx>>::Lifted>;
+#[allow(type_alias_bounds)]
+pub type Canonicalized<'gcx, V: Lift<'gcx>> = Canonical<'gcx, V::Lifted>;
 
-pub type CanonicalizedQueryResult<'gcx, T> =
-    Lrc<Canonical<'gcx, QueryResult<'gcx, <T as Lift<'gcx>>::Lifted>>>;
+#[allow(type_alias_bounds)]
+pub type CanonicalizedQueryResult<'gcx, T: Lift<'gcx>> =
+    Lrc<Canonical<'gcx, QueryResult<'gcx, T::Lifted>>>;
 
 /// Indicates whether or not we were able to prove the query to be
 /// true.

--- a/src/librustc/infer/mod.rs
+++ b/src/librustc/infer/mod.rs
@@ -1424,8 +1424,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
     /// new obligations that must further be processed.
     pub fn partially_normalize_associated_types_in<T>(
         &self,
-        span: Span,
-        body_id: ast::NodeId,
+        cause: ObligationCause<'tcx>,
         param_env: ty::ParamEnv<'tcx>,
         value: &T,
     ) -> InferOk<'tcx, T>
@@ -1434,7 +1433,6 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
     {
         debug!("partially_normalize_associated_types_in(value={:?})", value);
         let mut selcx = traits::SelectionContext::new(self);
-        let cause = ObligationCause::misc(span, body_id);
         let traits::Normalized { value, obligations } =
             traits::normalize(&mut selcx, param_env, cause, value);
         debug!(

--- a/src/librustc/infer/outlives/env.rs
+++ b/src/librustc/infer/outlives/env.rs
@@ -10,11 +10,8 @@
 
 use infer::{GenericKind, InferCtxt};
 use infer::outlives::free_region_map::FreeRegionMap;
-use traits::query::outlives_bounds::{self, OutlivesBound};
+use traits::{self, query::outlives_bounds::{self, OutlivesBound}};
 use ty::{self, Ty};
-
-use syntax::ast;
-use syntax_pos::Span;
 
 /// The `OutlivesEnvironment` collects information about what outlives
 /// what in a given type-checking setting. For example, if we have a
@@ -136,15 +133,14 @@ impl<'a, 'gcx: 'tcx, 'tcx: 'a> OutlivesEnvironment<'tcx> {
         &mut self,
         infcx: &InferCtxt<'a, 'gcx, 'tcx>,
         fn_sig_tys: &[Ty<'tcx>],
-        body_id: ast::NodeId,
-        span: Span,
+        cause: &traits::ObligationCause<'tcx>,
     ) {
         debug!("add_implied_bounds()");
 
         for &ty in fn_sig_tys {
             let ty = infcx.resolve_type_vars_if_possible(&ty);
             debug!("add_implied_bounds: ty = {}", ty);
-            let implied_bounds = infcx.implied_outlives_bounds(self.param_env, body_id, ty, span);
+            let implied_bounds = infcx.implied_outlives_bounds(self.param_env, cause, ty);
             self.add_outlives_bounds(Some(infcx), implied_bounds)
         }
     }

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -338,6 +338,12 @@ declare_lint! {
      cannot be referred to by absolute paths"
 }
 
+declare_lint! {
+    pub TYPE_ALIAS_MISSING_BOUNDS,
+    Deny,
+    "type aliases missing bounds required by the type being aliased, are now deprecated"
+}
+
 /// Some lints that are buffered from `libsyntax`. See `syntax::early_buffered_lints`.
 pub mod parser {
     declare_lint! {
@@ -406,6 +412,7 @@ impl LintPass for HardwiredLints {
             PROC_MACRO_DERIVE_RESOLUTION_FALLBACK,
             MACRO_USE_EXTERN_CRATE,
             MACRO_EXPANDED_MACRO_EXPORTS_ACCESSED_BY_ABSOLUTE_PATHS,
+            TYPE_ALIAS_MISSING_BOUNDS,
             parser::QUESTION_MARK_MACRO_SEP,
         )
     }

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -584,6 +584,14 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
             ObligationCauseCode::ImplDerivedObligation(data) => {
                 self.get_lint_from_cause_code(&data.parent_code)
             }
+            &ObligationCauseCode::TypeAliasMissingBound(id) => {
+                if self.tcx.sess.rust_2018() {
+                    // Error since Rust 2018.
+                    None
+                } else {
+                    Some((::lint::builtin::TYPE_ALIAS_MISSING_BOUNDS, id))
+                }
+            }
             _ => None,
         }
     }
@@ -1610,6 +1618,12 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                     err.help("add #![feature(trivial_bounds)] to the \
                               crate attributes to enable",
                     );
+                }
+            }
+            ObligationCauseCode::TypeAliasMissingBound(_) => {
+                err.help("missing bounds in type aliases were previously allowed");
+                if !self.tcx.sess.rust_2018() {
+                    err.help("this is a hard error in Rust 2018");
                 }
             }
         }

--- a/src/librustc/traits/fulfill.rs
+++ b/src/librustc/traits/fulfill.rs
@@ -440,8 +440,8 @@ impl<'a, 'b, 'gcx, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'b, 'gcx, 
             ty::Predicate::WellFormed(ty) => {
                 match ty::wf::obligations(self.selcx.infcx(),
                                           obligation.param_env,
-                                          obligation.cause.body_id,
-                                          ty, obligation.cause.span) {
+                                          &obligation.cause,
+                                          ty) {
                     None => {
                         pending_obligation.stalled_on = vec![ty];
                         ProcessResult::Unchanged

--- a/src/librustc/traits/mod.rs
+++ b/src/librustc/traits/mod.rs
@@ -700,7 +700,7 @@ pub fn normalize_param_env_or_error<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         ) {
             Ok(predicates) => predicates,
             Err(errors) => {
-                infcx.report_fulfillment_errors(&errors, None, false);
+                infcx.report_fulfillment_errors(&errors, false);
                 // An unnormalized env is better than nothing.
                 return elaborated_env;
             }

--- a/src/librustc/traits/mod.rs
+++ b/src/librustc/traits/mod.rs
@@ -251,6 +251,10 @@ pub enum ObligationCauseCode<'tcx> {
 
     /// #[feature(trivial_bounds)] is not enabled
     TrivialBound,
+
+    /// `type` alias is missing bounds required by the type being aliased
+    /// (lint in Rust 2015, error since Rust 2018).
+    TypeAliasMissingBound(ast::NodeId),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/src/librustc/traits/select.rs
+++ b/src/librustc/traits/select.rs
@@ -682,8 +682,8 @@ impl<'cx, 'gcx, 'tcx> SelectionContext<'cx, 'gcx, 'tcx> {
             ty::Predicate::WellFormed(ty) => {
                 match ty::wf::obligations(self.infcx,
                                           obligation.param_env,
-                                          obligation.cause.body_id,
-                                          ty, obligation.cause.span) {
+                                          &obligation.cause,
+                                          ty) {
                     Some(obligations) =>
                         self.evaluate_predicates_recursively(previous_stack, obligations.iter()),
                     None =>

--- a/src/librustc/traits/structural_impls.rs
+++ b/src/librustc/traits/structural_impls.rs
@@ -238,6 +238,9 @@ impl<'a, 'tcx> Lift<'tcx> for traits::ObligationCauseCode<'a> {
             super::MethodReceiver => Some(super::MethodReceiver),
             super::BlockTailExpression(id) => Some(super::BlockTailExpression(id)),
             super::TrivialBound => Some(super::TrivialBound),
+            super::ObligationCauseCode::TypeAliasMissingBound(id) => {
+                Some(super::ObligationCauseCode::TypeAliasMissingBound(id))
+            }
         }
     }
 }

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -2824,7 +2824,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
                                                     hir_id: HirId,
                                                     span: S,
                                                     msg: &str)
-        -> DiagnosticBuilder<'tcx>
+        -> DiagnosticBuilder<'gcx>
     {
         let node_id = self.hir.hir_to_node_id(hir_id);
         let (level, src) = self.lint_level_at_node(lint, node_id);
@@ -2836,14 +2836,14 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
                                                      id: NodeId,
                                                      span: S,
                                                      msg: &str)
-        -> DiagnosticBuilder<'tcx>
+        -> DiagnosticBuilder<'gcx>
     {
         let (level, src) = self.lint_level_at_node(lint, id);
         lint::struct_lint_level(self.sess, lint, level, src, Some(span.into()), msg)
     }
 
     pub fn struct_lint_node(self, lint: &'static Lint, id: NodeId, msg: &str)
-        -> DiagnosticBuilder<'tcx>
+        -> DiagnosticBuilder<'gcx>
     {
         let (level, src) = self.lint_level_at_node(lint, id);
         lint::struct_lint_level(self.sess, lint, level, src, None, msg)

--- a/src/librustc/ty/util.rs
+++ b/src/librustc/ty/util.rs
@@ -217,7 +217,7 @@ impl<'tcx> ty::ParamEnv<'tcx> {
                             infringing.push(field);
                         }
                         Err(errors) => {
-                            infcx.report_fulfillment_errors(&errors, None, false);
+                            infcx.report_fulfillment_errors(&errors, false);
                         }
                     };
                 }

--- a/src/librustc/ty/wf.rs
+++ b/src/librustc/ty/wf.rs
@@ -140,6 +140,15 @@ enum Elaborate {
 
 impl<'a, 'gcx, 'tcx> WfPredicates<'a, 'gcx, 'tcx> {
     fn cause(&mut self, code: traits::ObligationCauseCode<'tcx>) -> traits::ObligationCause<'tcx> {
+        let code = match self.parent_cause.code {
+            traits::ObligationCauseCode::TypeAliasMissingBound(_) => {
+                // FIXME(eddyb) We're not chaining obligation causes here,
+                // so in the case of cause codes that turn errors into lints,
+                // we have to replace our cause `code` with the parent one.
+                self.parent_cause.code.clone()
+            }
+            _ => code,
+        };
         traits::ObligationCause::new(self.parent_cause.span, self.parent_cause.body_id, code)
     }
 

--- a/src/librustc_data_structures/Cargo.toml
+++ b/src/librustc_data_structures/Cargo.toml
@@ -9,7 +9,7 @@ path = "lib.rs"
 crate-type = ["dylib"]
 
 [dependencies]
-ena = "0.9.3"
+ena = "0.10.1"
 log = "0.4"
 rustc_cratesio_shim = { path = "../librustc_cratesio_shim" }
 serialize = { path = "../libserialize" }

--- a/src/librustc_data_structures/indexed_vec.rs
+++ b/src/librustc_data_structures/indexed_vec.rs
@@ -486,7 +486,8 @@ impl<I: Idx, T: fmt::Debug> fmt::Debug for IndexVec<I, T> {
     }
 }
 
-pub type Enumerated<I, J> = iter::Map<iter::Enumerate<J>, IntoIdx<I>>;
+#[allow(type_alias_bounds)]
+pub type Enumerated<I: Idx, J> = iter::Map<iter::Enumerate<J>, IntoIdx<I>>;
 
 impl<I: Idx, T> IndexVec<I, T> {
     #[inline]

--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -1258,7 +1258,7 @@ impl MirPass for QualifyAndPromoteConstants {
                                               tcx.require_lang_item(lang_items::SyncTraitLangItem),
                                               cause);
                 if let Err(err) = fulfillment_cx.select_all_or_error(&infcx) {
-                    infcx.report_fulfillment_errors(&err, None, false);
+                    infcx.report_fulfillment_errors(&err, false);
                 }
             });
         }

--- a/src/librustc_mir/util/liveness.rs
+++ b/src/librustc_mir/util/liveness.rs
@@ -46,7 +46,8 @@ use std::path::{Path, PathBuf};
 use transform::MirSource;
 use util::pretty::{dump_enabled, write_basic_block, write_mir_intro};
 
-pub type LiveVarSet<V> = IdxSet<V>;
+#[allow(type_alias_bounds)]
+pub type LiveVarSet<V: Idx> = IdxSet<V>;
 
 /// This gives the result of the liveness analysis at the boundary of
 /// basic blocks.

--- a/src/librustc_traits/implied_outlives_bounds.rs
+++ b/src/librustc_traits/implied_outlives_bounds.rs
@@ -22,7 +22,7 @@ use rustc::ty::query::Providers;
 use rustc::ty::wf;
 use syntax::ast::DUMMY_NODE_ID;
 use syntax::source_map::DUMMY_SP;
-use rustc::traits::FulfillmentContext;
+use rustc::traits::{self, FulfillmentContext};
 
 use rustc_data_structures::sync::Lrc;
 
@@ -73,8 +73,8 @@ fn compute_implied_outlives_bounds<'tcx>(
         // than the ultimate set. (Note: normally there won't be
         // unresolved inference variables here anyway, but there might be
         // during typeck under some circumstances.)
-        let obligations =
-            wf::obligations(infcx, param_env, DUMMY_NODE_ID, ty, DUMMY_SP).unwrap_or(vec![]);
+        let cause = traits::ObligationCause::new(DUMMY_SP, DUMMY_NODE_ID, traits::MiscObligation);
+        let obligations = wf::obligations(infcx, param_env, &cause, ty).unwrap_or(vec![]);
 
         // NB: All of these predicates *ought* to be easily proven
         // true. In fact, their correctness is (mostly) implied by

--- a/src/librustc_typeck/check/closure.rs
+++ b/src/librustc_typeck/check/closure.rs
@@ -17,7 +17,7 @@ use rustc::hir::def_id::DefId;
 use rustc::infer::{InferOk, InferResult};
 use rustc::infer::LateBoundRegionConversionTime;
 use rustc::infer::type_variable::TypeVariableOrigin;
-use rustc::traits::error_reporting::ArgKind;
+use rustc::traits::{self, error_reporting::ArgKind};
 use rustc::ty::{self, ToPolyTraitRef, Ty, GenericParamDefKind};
 use rustc::ty::fold::TypeFoldable;
 use rustc::ty::subst::Substs;
@@ -667,8 +667,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         let liberated_sig = self.tcx()
             .liberate_late_bound_regions(expr_def_id, &bound_sig);
         let liberated_sig = self.inh.normalize_associated_types_in(
-            body.value.span,
-            body.value.id,
+            traits::ObligationCause::misc(body.value.span, body.value.id),
             self.param_env,
             &liberated_sig,
         );

--- a/src/librustc_typeck/check/dropck.rs
+++ b/src/librustc_typeck/check/dropck.rs
@@ -112,7 +112,7 @@ fn ensure_drop_params_and_item_params_correspond<'a, 'tcx>(
 
         if let Err(ref errors) = fulfillment_cx.select_all_or_error(&infcx) {
             // this could be reached when we get lazy normalization
-            infcx.report_fulfillment_errors(errors, None, false);
+            infcx.report_fulfillment_errors(errors, false);
             return Err(ErrorReported);
         }
 

--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -88,6 +88,7 @@ use middle::mem_categorization as mc;
 use middle::mem_categorization::Categorization;
 use middle::region;
 use rustc::hir::def_id::DefId;
+use rustc::traits;
 use rustc::ty::subst::Substs;
 use rustc::ty::{self, Ty};
 use rustc::infer;
@@ -139,6 +140,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
     pub fn regionck_item(&self,
                          item_id: ast::NodeId,
                          span: Span,
+                         code: traits::ObligationCauseCode<'tcx>,
                          wf_tys: &[Ty<'tcx>]) {
         debug!("regionck_item(item.id={:?}, wf_tys={:?})", item_id, wf_tys);
         let subject = self.tcx.hir.local_def_id(item_id);
@@ -147,7 +149,8 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                       item_id,
                                       Subject(subject),
                                       self.param_env);
-        rcx.outlives_environment.add_implied_bounds(self, wf_tys, item_id, span);
+        let cause = traits::ObligationCause::new(span, item_id, code);
+        rcx.outlives_environment.add_implied_bounds(self, wf_tys, &cause);
         rcx.visit_region_obligations(item_id);
         rcx.resolve_regions_and_report_errors();
     }
@@ -331,8 +334,8 @@ impl<'a, 'gcx, 'tcx> RegionCtxt<'a, 'gcx, 'tcx> {
         self.outlives_environment.add_implied_bounds(
             self.fcx,
             &fn_sig_tys[..],
-            body_id.node_id,
-            span);
+            &traits::ObligationCause::misc(span, body_id.node_id),
+        );
         self.link_fn_args(region::Scope::Node(body.value.hir_id.local_id), &body.arguments);
         self.visit_body(body);
         self.visit_region_obligations(body_id.node_id);

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -136,6 +136,22 @@ pub fn check_item_well_formed<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: Def
                 vec![] // no implied bounds in a static/const
             });
         }
+        hir::ItemKind::Ty(ref hir_ty, _) => {
+            let code = ObligationCauseCode::TypeAliasMissingBound(item.id);
+            for_item(tcx, item).with_cause_code(code.clone()).with_fcx(|fcx, _this| {
+                let cause = traits::ObligationCause::new(hir_ty.span, fcx.body_id, code.clone());
+
+                let def_id = fcx.tcx.hir.local_def_id(item.id);
+                let ty = fcx.tcx.type_of(def_id);
+                let item_ty = fcx.inh.normalize_associated_types_in(cause, fcx.param_env, &ty);
+
+                fcx.register_wf_obligation(item_ty, hir_ty.span, code.clone());
+
+                check_where_clauses(tcx, fcx, item.span, def_id, None, code);
+
+                vec![item_ty]
+            });
+        }
         hir::ItemKind::Struct(ref struct_def, ref ast_generics) => {
             check_type_defn(tcx, item, false, |fcx| {
                 vec![fcx.non_enum_variant(struct_def)]

--- a/src/librustc_typeck/check/writeback.rs
+++ b/src/librustc_typeck/check/writeback.rs
@@ -17,6 +17,7 @@ use rustc::hir;
 use rustc::hir::def_id::{DefId, DefIndex};
 use rustc::hir::intravisit::{self, NestedVisitorMap, Visitor};
 use rustc::infer::InferCtxt;
+use rustc::traits;
 use rustc::ty::adjustment::{Adjust, Adjustment};
 use rustc::ty::fold::{BottomUpFolder, TypeFoldable, TypeFolder};
 use rustc::ty::subst::UnpackedKind;
@@ -738,8 +739,13 @@ impl<'cx, 'gcx, 'tcx> Resolver<'cx, 'gcx, 'tcx> {
 
     fn report_error(&self, t: Ty<'tcx>) {
         if !self.tcx.sess.has_errors() {
-            self.infcx
-                .need_type_info_err(Some(self.body.id()), self.span.to_span(&self.tcx), t)
+            self.infcx.need_type_info_err(
+                &traits::ObligationCause::misc(
+                    self.span.to_span(&self.tcx),
+                    self.body.id().node_id,
+                ),
+                t,
+            )
                 .emit();
         }
     }

--- a/src/librustc_typeck/coherence/builtin.rs
+++ b/src/librustc_typeck/coherence/builtin.rs
@@ -386,7 +386,7 @@ pub fn coerce_unsized_info<'a, 'gcx>(gcx: TyCtxt<'a, 'gcx, 'gcx>,
 
         // Check that all transitive obligations are satisfied.
         if let Err(errors) = fulfill_cx.select_all_or_error(&infcx) {
-            infcx.report_fulfillment_errors(&errors, None, false);
+            infcx.report_fulfillment_errors(&errors, false);
         }
 
         // Finally, resolve all regions.

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -172,7 +172,7 @@ fn require_same_types<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         match fulfill_cx.select_all_or_error(infcx) {
             Ok(()) => true,
             Err(errors) => {
-                infcx.report_fulfillment_errors(&errors, None, false);
+                infcx.report_fulfillment_errors(&errors, false);
                 false
             }
         }

--- a/src/test/rustdoc/assoc-item-cast.rs
+++ b/src/test/rustdoc/assoc-item-cast.rs
@@ -22,5 +22,5 @@ pub trait AsExpression<T> {
 }
 
 // @has foo/type.AsExprOf.html
-// @has - '//*[@class="rust typedef"]' 'type AsExprOf<Item, Type> = <Item as AsExpression<Type>>::Expression;'
-pub type AsExprOf<Item, Type> = <Item as AsExpression<Type>>::Expression;
+// @has - '//*[@class="rust typedef"]' 'type AsExprOf<Item: AsExpression<Type>, Type> = <Item as AsExpression<Type>>::Expression;'
+pub type AsExprOf<Item: AsExpression<Type>, Type> = <Item as AsExpression<Type>>::Expression;

--- a/src/test/rustdoc/const-evalutation-ice.rs
+++ b/src/test/rustdoc/const-evalutation-ice.rs
@@ -17,4 +17,5 @@ pub struct S {
     s: Cell<usize>
 }
 
+#[allow(type_alias_missing_bounds)] // HACK(eddyb) remove before merge
 pub type _S = [usize; 0 - (mem::size_of::<S>() != 4) as usize];

--- a/src/test/ui/consts/const-eval/pub_const_err-warn.rs
+++ b/src/test/ui/consts/const-eval/pub_const_err-warn.rs
@@ -1,4 +1,4 @@
-// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,17 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// aux-build:issue_3907.rs
-extern crate issue_3907;
+// compile-pass
+#![warn(const_err)]
 
-type Foo = issue_3907::Foo+'static;
-//~^ ERROR E0038
+#![crate_type = "lib"]
 
-struct S {
-    name: isize
-}
-
-fn bar(_x: Foo) {}
-//~^ ERROR E0038
-
-fn main() {}
+pub const Z: u32 = 0 - 1;
+//~^ WARN this constant cannot be used

--- a/src/test/ui/consts/const-eval/pub_const_err-warn.stderr
+++ b/src/test/ui/consts/const-eval/pub_const_err-warn.stderr
@@ -1,0 +1,14 @@
+warning: this constant cannot be used
+  --> $DIR/pub_const_err-warn.rs:16:1
+   |
+LL | pub const Z: u32 = 0 - 1;
+   | ^^^^^^^^^^^^^^^^^^^-----^
+   |                    |
+   |                    attempt to subtract with overflow
+   |
+note: lint level defined here
+  --> $DIR/pub_const_err-warn.rs:12:9
+   |
+LL | #![warn(const_err)]
+   |         ^^^^^^^^^
+

--- a/src/test/ui/consts/const-eval/pub_const_err.rs
+++ b/src/test/ui/consts/const-eval/pub_const_err.rs
@@ -8,14 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-pass
-#![warn(const_err)]
-
 #![crate_type = "lib"]
 
-pub const Z: u32 = 0 - 1;
-//~^ WARN this constant cannot be used
-
 pub type Foo = [i32; 0 - 1];
-//~^ WARN attempt to subtract with overflow
-//~| WARN this array length cannot be used
+//~^ ERROR could not evaluate constant expression
+//~| attempt to subtract with overflow

--- a/src/test/ui/consts/const-eval/pub_const_err.stderr
+++ b/src/test/ui/consts/const-eval/pub_const_err.stderr
@@ -1,26 +1,22 @@
-warning: this constant cannot be used
-  --> $DIR/pub_const_err.rs:16:1
-   |
-LL | pub const Z: u32 = 0 - 1;
-   | ^^^^^^^^^^^^^^^^^^^-----^
-   |                    |
-   |                    attempt to subtract with overflow
-   |
-note: lint level defined here
-  --> $DIR/pub_const_err.rs:12:9
-   |
-LL | #![warn(const_err)]
-   |         ^^^^^^^^^
-
-warning: attempt to subtract with overflow
-  --> $DIR/pub_const_err.rs:19:22
+error: attempt to subtract with overflow
+  --> $DIR/pub_const_err.rs:13:22
    |
 LL | pub type Foo = [i32; 0 - 1];
    |                      ^^^^^
+   |
+   = note: #[deny(const_err)] on by default
 
-warning: this array length cannot be used
-  --> $DIR/pub_const_err.rs:19:22
+error: could not evaluate constant expression
+  --> $DIR/pub_const_err.rs:13:16
    |
 LL | pub type Foo = [i32; 0 - 1];
-   |                      ^^^^^ attempt to subtract with overflow
+   |                ^^^^^^-----^
+   |                      |
+   |                      attempt to subtract with overflow
+   |
+   = note: #[deny(type_alias_missing_bounds)] on by default
+   = help: missing bounds in type aliases were previously allowed
+   = help: this is a hard error in Rust 2018
+
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/consts/const-eval/pub_const_err_bin-warn.rs
+++ b/src/test/ui/consts/const-eval/pub_const_err_bin-warn.rs
@@ -1,4 +1,4 @@
-// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,17 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// aux-build:issue_3907.rs
-extern crate issue_3907;
+// compile-pass
+#![warn(const_err)]
 
-type Foo = issue_3907::Foo+'static;
-//~^ ERROR E0038
-
-struct S {
-    name: isize
-}
-
-fn bar(_x: Foo) {}
-//~^ ERROR E0038
+pub const Z: u32 = 0 - 1;
+//~^ WARN this constant cannot be used
 
 fn main() {}

--- a/src/test/ui/consts/const-eval/pub_const_err_bin-warn.stderr
+++ b/src/test/ui/consts/const-eval/pub_const_err_bin-warn.stderr
@@ -1,0 +1,14 @@
+warning: this constant cannot be used
+  --> $DIR/pub_const_err_bin-warn.rs:14:1
+   |
+LL | pub const Z: u32 = 0 - 1;
+   | ^^^^^^^^^^^^^^^^^^^-----^
+   |                    |
+   |                    attempt to subtract with overflow
+   |
+note: lint level defined here
+  --> $DIR/pub_const_err_bin-warn.rs:12:9
+   |
+LL | #![warn(const_err)]
+   |         ^^^^^^^^^
+

--- a/src/test/ui/consts/const-eval/pub_const_err_bin.rs
+++ b/src/test/ui/consts/const-eval/pub_const_err_bin.rs
@@ -8,14 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-pass
-#![warn(const_err)]
-
-pub const Z: u32 = 0 - 1;
-//~^ WARN this constant cannot be used
-
 pub type Foo = [i32; 0 - 1];
-//~^ WARN attempt to subtract with overflow
-//~| WARN this array length cannot be used
+//~^ ERROR could not evaluate constant expression
+//~| attempt to subtract with overflow
 
 fn main() {}

--- a/src/test/ui/consts/const-eval/pub_const_err_bin.stderr
+++ b/src/test/ui/consts/const-eval/pub_const_err_bin.stderr
@@ -1,26 +1,22 @@
-warning: this constant cannot be used
-  --> $DIR/pub_const_err_bin.rs:14:1
-   |
-LL | pub const Z: u32 = 0 - 1;
-   | ^^^^^^^^^^^^^^^^^^^-----^
-   |                    |
-   |                    attempt to subtract with overflow
-   |
-note: lint level defined here
-  --> $DIR/pub_const_err_bin.rs:12:9
-   |
-LL | #![warn(const_err)]
-   |         ^^^^^^^^^
-
-warning: attempt to subtract with overflow
-  --> $DIR/pub_const_err_bin.rs:17:22
+error: attempt to subtract with overflow
+  --> $DIR/pub_const_err_bin.rs:11:22
    |
 LL | pub type Foo = [i32; 0 - 1];
    |                      ^^^^^
+   |
+   = note: #[deny(const_err)] on by default
 
-warning: this array length cannot be used
-  --> $DIR/pub_const_err_bin.rs:17:22
+error: could not evaluate constant expression
+  --> $DIR/pub_const_err_bin.rs:11:16
    |
 LL | pub type Foo = [i32; 0 - 1];
-   |                      ^^^^^ attempt to subtract with overflow
+   |                ^^^^^^-----^
+   |                      |
+   |                      attempt to subtract with overflow
+   |
+   = note: #[deny(type_alias_missing_bounds)] on by default
+   = help: missing bounds in type aliases were previously allowed
+   = help: this is a hard error in Rust 2018
+
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/feature-gates/feature-gate-trivial_bounds.rs
+++ b/src/test/ui/feature-gates/feature-gate-trivial_bounds.rs
@@ -25,7 +25,7 @@ trait T where i32: Foo {} //~ ERROR
 
 union U where i32: Foo { f: i32 } //~ ERROR
 
-type Y where i32: Foo = (); // OK - bound is ignored
+type Y where i32: Foo = (); //~ ERROR
 
 impl Foo for () where i32: Foo { //~ ERROR
     fn test(&self) {

--- a/src/test/ui/feature-gates/feature-gate-trivial_bounds.stderr
+++ b/src/test/ui/feature-gates/feature-gate-trivial_bounds.stderr
@@ -35,6 +35,15 @@ LL | union U where i32: Foo { f: i32 } //~ ERROR
    = help: add #![feature(trivial_bounds)] to the crate attributes to enable
 
 error[E0277]: the trait bound `i32: Foo` is not satisfied
+  --> $DIR/feature-gate-trivial_bounds.rs:28:1
+   |
+LL | type Y where i32: Foo = (); //~ ERROR
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `i32`
+   |
+   = help: see issue #48214
+   = help: add #![feature(trivial_bounds)] to the crate attributes to enable
+
+error[E0277]: the trait bound `i32: Foo` is not satisfied
   --> $DIR/feature-gate-trivial_bounds.rs:30:1
    |
 LL | / impl Foo for () where i32: Foo { //~ ERROR
@@ -125,6 +134,6 @@ LL | | }
    = help: see issue #48214
    = help: add #![feature(trivial_bounds)] to the crate attributes to enable
 
-error: aborting due to 11 previous errors
+error: aborting due to 12 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/hygiene/assoc_ty_bindings.rs
+++ b/src/test/ui/hygiene/assoc_ty_bindings.rs
@@ -15,10 +15,10 @@
 
 trait Base {
     type AssocTy;
-    fn f();
+    fn f(&self);
 }
 trait Derived: Base {
-    fn g();
+    fn g(&self);
 }
 
 macro mac() {
@@ -27,12 +27,12 @@ macro mac() {
 
     impl Base for u8 {
         type AssocTy = u8;
-        fn f() {
+        fn f(&self) {
             let _: Self::AssocTy;
         }
     }
     impl Derived for u8 {
-        fn g() {
+        fn g(&self) {
             let _: Self::AssocTy;
         }
     }

--- a/src/test/ui/issues/issue-23046.rs
+++ b/src/test/ui/issues/issue-23046.rs
@@ -24,7 +24,7 @@ pub fn let_<'var, VAR, F: for<'v> Fn(Expr<'v, VAR>) -> Expr<'v, VAR>>
 }
 
 fn main() {
-    let ex = |x| { //~ ERROR type annotations needed
+    let ex = |x| {
         let_(add(x,x), |y| {
-            let_(add(x, x), |x|x)})};
+            let_(add(x, x), |x|x)})}; //~ ERROR type annotations needed
 }

--- a/src/test/ui/issues/issue-23046.stderr
+++ b/src/test/ui/issues/issue-23046.stderr
@@ -1,8 +1,8 @@
 error[E0282]: type annotations needed
-  --> $DIR/issue-23046.rs:27:15
+  --> $DIR/issue-23046.rs:29:30
    |
-LL |     let ex = |x| { //~ ERROR type annotations needed
-   |               ^ consider giving this closure parameter a type
+LL |             let_(add(x, x), |x|x)})}; //~ ERROR type annotations needed
+   |                              ^ consider giving this closure parameter a type
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-enum-not-wf.rs
+++ b/src/test/ui/regions/regions-enum-not-wf.rs
@@ -22,7 +22,7 @@ where T: 'a
 {
   type Out = ();
 }
-type RequireOutlives<'a, T> = <T as Dummy<'a>>::Out;
+type RequireOutlives<'a, T> = <T as Dummy<'a>>::Out; //~ ERROR the parameter type `T` may not live long enough
 
 enum Ref1<'a, T> {
     Ref1Variant1(RequireOutlives<'a, T>) //~ ERROR the parameter type `T` may not live long enough

--- a/src/test/ui/regions/regions-enum-not-wf.stderr
+++ b/src/test/ui/regions/regions-enum-not-wf.stderr
@@ -1,4 +1,18 @@
 error[E0309]: the parameter type `T` may not live long enough
+  --> $DIR/regions-enum-not-wf.rs:25:31
+   |
+LL | type RequireOutlives<'a, T> = <T as Dummy<'a>>::Out; //~ ERROR the parameter type `T` may not live long enough
+   |                          -    ^^^^^^^^^^^^^^^^^^^^^
+   |                          |
+   |                          help: consider adding an explicit lifetime bound `T: 'a`...
+   |
+note: ...so that the type `T` will meet its required lifetime bounds
+  --> $DIR/regions-enum-not-wf.rs:25:31
+   |
+LL | type RequireOutlives<'a, T> = <T as Dummy<'a>>::Out; //~ ERROR the parameter type `T` may not live long enough
+   |                               ^^^^^^^^^^^^^^^^^^^^^
+
+error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/regions-enum-not-wf.rs:28:18
    |
 LL | enum Ref1<'a, T> {
@@ -62,6 +76,6 @@ note: ...so that the type `T` will meet its required lifetime bounds
 LL |     RefDoubleVariant1(&'a RequireOutlives<'b, T>)
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 4 previous errors
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0309`.

--- a/src/test/ui/resolve/issue-3907-2.stderr
+++ b/src/test/ui/resolve/issue-3907-2.stderr
@@ -1,11 +1,21 @@
 error[E0038]: the trait `issue_3907::Foo` cannot be made into an object
-  --> $DIR/issue-3907-2.rs:20:1
+  --> $DIR/issue-3907-2.rs:14:12
+   |
+LL | type Foo = issue_3907::Foo+'static;
+   |            ^^^^^^^^^^^^^^^^^^^^^^^ the trait `issue_3907::Foo` cannot be made into an object
+   |
+   = note: method `bar` has no receiver
+   = help: missing bounds in type aliases were previously allowed
+   = help: this is a hard error in Rust 2018
+
+error[E0038]: the trait `issue_3907::Foo` cannot be made into an object
+  --> $DIR/issue-3907-2.rs:21:1
    |
 LL | fn bar(_x: Foo) {}
    | ^^^^^^^^^^^^^^^ the trait `issue_3907::Foo` cannot be made into an object
    |
    = note: method `bar` has no receiver
 
-error: aborting due to previous error
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0038`.

--- a/src/test/ui/rfc-2093-infer-outlives/regions-enum-not-wf.rs
+++ b/src/test/ui/rfc-2093-infer-outlives/regions-enum-not-wf.rs
@@ -22,7 +22,7 @@ where T: 'a
 {
   type Out = ();
 }
-type RequireOutlives<'a, T> = <T as Dummy<'a>>::Out;
+type RequireOutlives<'a, T> = <T as Dummy<'a>>::Out; //~ ERROR the parameter type `T` may not live long enough
 
 enum Ref1<'a, T> {
     Ref1Variant1(RequireOutlives<'a, T>) //~ ERROR the parameter type `T` may not live long enough

--- a/src/test/ui/rfc-2093-infer-outlives/regions-enum-not-wf.stderr
+++ b/src/test/ui/rfc-2093-infer-outlives/regions-enum-not-wf.stderr
@@ -1,4 +1,18 @@
 error[E0309]: the parameter type `T` may not live long enough
+  --> $DIR/regions-enum-not-wf.rs:25:31
+   |
+LL | type RequireOutlives<'a, T> = <T as Dummy<'a>>::Out; //~ ERROR the parameter type `T` may not live long enough
+   |                          -    ^^^^^^^^^^^^^^^^^^^^^
+   |                          |
+   |                          help: consider adding an explicit lifetime bound `T: 'a`...
+   |
+note: ...so that the type `T` will meet its required lifetime bounds
+  --> $DIR/regions-enum-not-wf.rs:25:31
+   |
+LL | type RequireOutlives<'a, T> = <T as Dummy<'a>>::Out; //~ ERROR the parameter type `T` may not live long enough
+   |                               ^^^^^^^^^^^^^^^^^^^^^
+
+error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/regions-enum-not-wf.rs:28:18
    |
 LL | enum Ref1<'a, T> {
@@ -62,6 +76,6 @@ note: ...so that the type `T` will meet its required lifetime bounds
 LL |     RefDoubleVariant1(&'a RequireOutlives<'b, T>)
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 4 previous errors
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0309`.

--- a/src/test/ui/structs/struct-path-alias-bounds.rs
+++ b/src/test/ui/structs/struct-path-alias-bounds.rs
@@ -14,8 +14,8 @@ struct S<T: Clone> { a: T }
 
 struct NoClone;
 type A = S<NoClone>;
+//~^ ERROR the trait bound `NoClone: std::clone::Clone` is not satisfied
 
 fn main() {
     let s = A { a: NoClone };
-    //~^ ERROR the trait bound `NoClone: std::clone::Clone` is not satisfied
 }

--- a/src/test/ui/structs/struct-path-alias-bounds.stderr
+++ b/src/test/ui/structs/struct-path-alias-bounds.stderr
@@ -1,15 +1,12 @@
-error[E0277]: the trait bound `NoClone: std::clone::Clone` is not satisfied
-  --> $DIR/struct-path-alias-bounds.rs:19:13
+error: the trait bound `NoClone: std::clone::Clone` is not satisfied
+  --> $DIR/struct-path-alias-bounds.rs:16:10
    |
-LL |     let s = A { a: NoClone };
-   |             ^ the trait `std::clone::Clone` is not implemented for `NoClone`
+LL | type A = S<NoClone>;
+   |          ^^^^^^^^^^ the trait `std::clone::Clone` is not implemented for `NoClone`
    |
-note: required by `S`
-  --> $DIR/struct-path-alias-bounds.rs:13:1
-   |
-LL | struct S<T: Clone> { a: T }
-   | ^^^^^^^^^^^^^^^^^^
+   = note: #[deny(type_alias_missing_bounds)] on by default
+   = help: missing bounds in type aliases were previously allowed
+   = help: this is a hard error in Rust 2018
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/type/issue-51626.rs
+++ b/src/test/ui/type/issue-51626.rs
@@ -1,4 +1,4 @@
-// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,17 +8,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// aux-build:issue_3907.rs
-extern crate issue_3907;
+pub trait Trait {}
 
-type Foo = issue_3907::Foo+'static;
-//~^ ERROR E0038
+pub struct Foo<T: Trait>(T);
 
-struct S {
-    name: isize
-}
+pub struct Qux;
 
-fn bar(_x: Foo) {}
-//~^ ERROR E0038
+pub type Bar<T = Qux> = Foo<T>;
+//~^ ERROR the trait bound `T: Trait` is not satisfied
+
+pub type Baz<T: Trait = Qux> = Foo<T>;
+//~^ ERROR the trait bound `Qux: Trait` is not satisfied
 
 fn main() {}

--- a/src/test/ui/type/issue-51626.stderr
+++ b/src/test/ui/type/issue-51626.stderr
@@ -1,0 +1,22 @@
+error: the trait bound `T: Trait` is not satisfied
+  --> $DIR/issue-51626.rs:17:25
+   |
+LL | pub type Bar<T = Qux> = Foo<T>;
+   |                         ^^^^^^ the trait `Trait` is not implemented for `T`
+   |
+   = note: #[deny(type_alias_missing_bounds)] on by default
+   = help: consider adding a `where T: Trait` bound
+   = help: missing bounds in type aliases were previously allowed
+   = help: this is a hard error in Rust 2018
+
+error: the trait bound `Qux: Trait` is not satisfied
+  --> $DIR/issue-51626.rs:20:1
+   |
+LL | pub type Baz<T: Trait = Qux> = Foo<T>;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `Qux`
+   |
+   = help: missing bounds in type aliases were previously allowed
+   = help: this is a hard error in Rust 2018
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/type/type-alias-bounds-err.rs
+++ b/src/test/ui/type/type-alias-bounds-err.rs
@@ -1,0 +1,25 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(dead_code)]
+
+// This test contains examples originally in `type-alias-bounds.rs`,
+// that now produce errors instead of being silently accepted.
+
+// Bounds are not checked either, i.e. the definition is not necessarily well-formed
+struct Sendable<T: Send>(T);
+type MySendable<T> = Sendable<T>;
+//~^ ERROR `T` cannot be sent between threads safely
+
+trait Bound { type Assoc; }
+type T4<U> = <U as Bound>::Assoc;
+//~^ ERROR the trait bound `U: Bound` is not satisfied
+
+fn main() {}

--- a/src/test/ui/type/type-alias-bounds-err.stderr
+++ b/src/test/ui/type/type-alias-bounds-err.stderr
@@ -1,0 +1,24 @@
+error: `T` cannot be sent between threads safely
+  --> $DIR/type-alias-bounds-err.rs:18:22
+   |
+LL | type MySendable<T> = Sendable<T>;
+   |                      ^^^^^^^^^^^ `T` cannot be sent between threads safely
+   |
+   = note: #[deny(type_alias_missing_bounds)] on by default
+   = help: the trait `std::marker::Send` is not implemented for `T`
+   = help: consider adding a `where T: std::marker::Send` bound
+   = help: missing bounds in type aliases were previously allowed
+   = help: this is a hard error in Rust 2018
+
+error: the trait bound `U: Bound` is not satisfied
+  --> $DIR/type-alias-bounds-err.rs:22:14
+   |
+LL | type T4<U> = <U as Bound>::Assoc;
+   |              ^^^^^^^^^^^^^^^^^^^ the trait `Bound` is not implemented for `U`
+   |
+   = help: consider adding a `where U: Bound` bound
+   = help: missing bounds in type aliases were previously allowed
+   = help: this is a hard error in Rust 2018
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/type/type-alias-bounds.rs
+++ b/src/test/ui/type/type-alias-bounds.rs
@@ -49,8 +49,8 @@ fn foo<'a>(y: &'a i32) {
 }
 
 // Bounds are not checked either, i.e. the definition is not necessarily well-formed
-struct Sendable<T: Send>(T);
-type MySendable<T> = Sendable<T>; // no error here!
+// struct Sendable<T: Send>(T); // NOTE(eddyb) moved to `type-alias-bounds-err.rs`
+// type MySendable<T> = Sendable<T>; // no error here!
 
 // However, bounds *are* taken into account when accessing associated types
 trait Bound { type Assoc; }
@@ -60,7 +60,7 @@ type T2<U> where U: Bound = U::Assoc;  //~ WARN not enforced in type aliases
 // This errors
 // type T3<U> = U::Assoc;
 // Do this instead
-type T4<U> = <U as Bound>::Assoc;
+// type T4<U> = <U as Bound>::Assoc; // NOTE(eddyb) moved to `type-alias-bounds-err.rs`
 
 // Make sure the help about associatd types is not shown incorrectly
 type T5<U: Bound> = <U as Bound>::Assoc;  //~ WARN not enforced in type aliases


### PR DESCRIPTION
Enforce that for type aliases (`type Foo<T: Trait> = Bar<T>;`), all the bounds required by the type being aliased (`Bar<T>`) are satisfied (e.g. by `T: Trait`).

On Rust 2015, this is reported as a lint, but on Rust 2018 it's a hard error.
(see https://github.com/rust-lang/rust/issues/49441#issuecomment-421136550 for more details on the decision taken)

**NOTE**: this is only the first half, we also need to check declared bounds assuming the RHS type is WF (to ensure the type alias is fully equivalent to its RHS type, everywhere it's used).
**EDIT**: second half is up at #54090.

Fixes #44075, fixes #51626.

r? @nikomatsakis 