### PR TITLE
rustc_target: separate out an individual alignment quantity type from Align.

### DIFF
--- a/src/librustc/mir/interpret/allocation.rs
+++ b/src/librustc/mir/interpret/allocation.rs
@@ -12,7 +12,7 @@
 
 use super::{Pointer, EvalResult, AllocId};
 
-use ty::layout::{Size, Align, AbiAndPrefAlign};
+use ty::layout::{Size, Align};
 use syntax::ast::Mutability;
 use std::iter;
 use mir;
@@ -40,7 +40,7 @@ pub struct Allocation<Tag=(),Extra=()> {
     /// Denotes undefined memory. Reading from undefined memory is forbidden in miri
     pub undef_mask: UndefMask,
     /// The alignment of the allocation to detect unaligned reads.
-    pub align: AbiAndPrefAlign,
+    pub align: Align,
     /// Whether the allocation is mutable.
     /// Also used by codegen to determine if a static should be put into mutable memory,
     /// which happens for `static mut` and `static` with interior mutability.
@@ -90,7 +90,7 @@ impl AllocationExtra<()> for () {}
 
 impl<Tag, Extra: Default> Allocation<Tag, Extra> {
     /// Creates a read-only allocation initialized by the given bytes
-    pub fn from_bytes(slice: &[u8], align: AbiAndPrefAlign) -> Self {
+    pub fn from_bytes(slice: &[u8], align: Align) -> Self {
         let mut undef_mask = UndefMask::new(Size::ZERO);
         undef_mask.grow(Size::from_bytes(slice.len() as u64), true);
         Self {
@@ -104,10 +104,10 @@ impl<Tag, Extra: Default> Allocation<Tag, Extra> {
     }
 
     pub fn from_byte_aligned_bytes(slice: &[u8]) -> Self {
-        Allocation::from_bytes(slice, AbiAndPrefAlign::new(Align::from_bytes(1).unwrap()))
+        Allocation::from_bytes(slice, Align::from_bytes(1).unwrap())
     }
 
-    pub fn undef(size: Size, align: AbiAndPrefAlign) -> Self {
+    pub fn undef(size: Size, align: Align) -> Self {
         assert_eq!(size.bytes() as usize as u64, size.bytes());
         Allocation {
             bytes: vec![0; size.bytes() as usize],

--- a/src/librustc/mir/interpret/allocation.rs
+++ b/src/librustc/mir/interpret/allocation.rs
@@ -12,7 +12,7 @@
 
 use super::{Pointer, EvalResult, AllocId};
 
-use ty::layout::{Size, Align};
+use ty::layout::{Size, AbiAndPrefAlign};
 use syntax::ast::Mutability;
 use std::iter;
 use mir;
@@ -40,7 +40,7 @@ pub struct Allocation<Tag=(),Extra=()> {
     /// Denotes undefined memory. Reading from undefined memory is forbidden in miri
     pub undef_mask: UndefMask,
     /// The alignment of the allocation to detect unaligned reads.
-    pub align: Align,
+    pub align: AbiAndPrefAlign,
     /// Whether the allocation is mutable.
     /// Also used by codegen to determine if a static should be put into mutable memory,
     /// which happens for `static mut` and `static` with interior mutability.
@@ -90,7 +90,7 @@ impl AllocationExtra<()> for () {}
 
 impl<Tag, Extra: Default> Allocation<Tag, Extra> {
     /// Creates a read-only allocation initialized by the given bytes
-    pub fn from_bytes(slice: &[u8], align: Align) -> Self {
+    pub fn from_bytes(slice: &[u8], align: AbiAndPrefAlign) -> Self {
         let mut undef_mask = UndefMask::new(Size::ZERO);
         undef_mask.grow(Size::from_bytes(slice.len() as u64), true);
         Self {
@@ -104,10 +104,10 @@ impl<Tag, Extra: Default> Allocation<Tag, Extra> {
     }
 
     pub fn from_byte_aligned_bytes(slice: &[u8]) -> Self {
-        Allocation::from_bytes(slice, Align::from_bytes(1, 1).unwrap())
+        Allocation::from_bytes(slice, AbiAndPrefAlign::from_bytes(1, 1).unwrap())
     }
 
-    pub fn undef(size: Size, align: Align) -> Self {
+    pub fn undef(size: Size, align: AbiAndPrefAlign) -> Self {
         assert_eq!(size.bytes() as usize as u64, size.bytes());
         Allocation {
             bytes: vec![0; size.bytes() as usize],

--- a/src/librustc/mir/interpret/allocation.rs
+++ b/src/librustc/mir/interpret/allocation.rs
@@ -12,7 +12,7 @@
 
 use super::{Pointer, EvalResult, AllocId};
 
-use ty::layout::{Size, AbiAndPrefAlign};
+use ty::layout::{Size, Align, AbiAndPrefAlign};
 use syntax::ast::Mutability;
 use std::iter;
 use mir;
@@ -104,7 +104,7 @@ impl<Tag, Extra: Default> Allocation<Tag, Extra> {
     }
 
     pub fn from_byte_aligned_bytes(slice: &[u8]) -> Self {
-        Allocation::from_bytes(slice, AbiAndPrefAlign::from_bytes(1, 1).unwrap())
+        Allocation::from_bytes(slice, AbiAndPrefAlign::new(Align::from_bytes(1).unwrap()))
     }
 
     pub fn undef(size: Size, align: AbiAndPrefAlign) -> Self {

--- a/src/librustc/mir/interpret/error.rs
+++ b/src/librustc/mir/interpret/error.rs
@@ -13,7 +13,7 @@ use std::{fmt, env};
 use hir::map::definitions::DefPathData;
 use mir;
 use ty::{self, Ty, layout};
-use ty::layout::{Size, AbiAndPrefAlign, LayoutError};
+use ty::layout::{Size, Align, LayoutError};
 use rustc_target::spec::abi::Abi;
 
 use super::{RawConst, Pointer, InboundsCheck, ScalarMaybeUndef};
@@ -301,8 +301,8 @@ pub enum EvalErrorKind<'tcx, O> {
     TlsOutOfBounds,
     AbiViolation(String),
     AlignmentCheckFailed {
-        required: AbiAndPrefAlign,
-        has: AbiAndPrefAlign,
+        required: Align,
+        has: Align,
     },
     ValidationFailure(String),
     CalledClosureAsFunction,
@@ -315,7 +315,7 @@ pub enum EvalErrorKind<'tcx, O> {
     DeallocatedWrongMemoryKind(String, String),
     ReallocateNonBasePtr,
     DeallocateNonBasePtr,
-    IncorrectAllocationInformation(Size, Size, AbiAndPrefAlign, AbiAndPrefAlign),
+    IncorrectAllocationInformation(Size, Size, Align, Align),
     Layout(layout::LayoutError<'tcx>),
     HeapAllocZeroBytes,
     HeapAllocNonPowerOfTwoAlignment(u64),
@@ -527,7 +527,7 @@ impl<'tcx, O: fmt::Debug> fmt::Debug for EvalErrorKind<'tcx, O> {
                 write!(f, "tried to interpret an invalid 32-bit value as a char: {}", c),
             AlignmentCheckFailed { required, has } =>
                write!(f, "tried to access memory with alignment {}, but alignment {} is required",
-                      has.abi.bytes(), required.abi.bytes()),
+                      has.bytes(), required.bytes()),
             TypeNotPrimitive(ty) =>
                 write!(f, "expected primitive type, got {}", ty),
             Layout(ref err) =>
@@ -539,7 +539,7 @@ impl<'tcx, O: fmt::Debug> fmt::Debug for EvalErrorKind<'tcx, O> {
             IncorrectAllocationInformation(size, size2, align, align2) =>
                 write!(f, "incorrect alloc info: expected size {} and align {}, \
                            got size {} and align {}",
-                    size.bytes(), align.abi.bytes(), size2.bytes(), align2.abi.bytes()),
+                    size.bytes(), align.bytes(), size2.bytes(), align2.bytes()),
             Panic { ref msg, line, col, ref file } =>
                 write!(f, "the evaluated program panicked at '{}', {}:{}:{}", msg, file, line, col),
             InvalidDiscriminant(val) =>

--- a/src/librustc/mir/interpret/error.rs
+++ b/src/librustc/mir/interpret/error.rs
@@ -527,7 +527,7 @@ impl<'tcx, O: fmt::Debug> fmt::Debug for EvalErrorKind<'tcx, O> {
                 write!(f, "tried to interpret an invalid 32-bit value as a char: {}", c),
             AlignmentCheckFailed { required, has } =>
                write!(f, "tried to access memory with alignment {}, but alignment {} is required",
-                      has.abi(), required.abi()),
+                      has.abi.bytes(), required.abi.bytes()),
             TypeNotPrimitive(ty) =>
                 write!(f, "expected primitive type, got {}", ty),
             Layout(ref err) =>
@@ -537,8 +537,9 @@ impl<'tcx, O: fmt::Debug> fmt::Debug for EvalErrorKind<'tcx, O> {
             MachineError(ref inner) =>
                 write!(f, "{}", inner),
             IncorrectAllocationInformation(size, size2, align, align2) =>
-                write!(f, "incorrect alloc info: expected size {} and align {}, got size {} and \
-                       align {}", size.bytes(), align.abi(), size2.bytes(), align2.abi()),
+                write!(f, "incorrect alloc info: expected size {} and align {}, \
+                           got size {} and align {}",
+                    size.bytes(), align.abi.bytes(), size2.bytes(), align2.abi.bytes()),
             Panic { ref msg, line, col, ref file } =>
                 write!(f, "the evaluated program panicked at '{}', {}:{}:{}", msg, file, line, col),
             InvalidDiscriminant(val) =>

--- a/src/librustc/mir/interpret/error.rs
+++ b/src/librustc/mir/interpret/error.rs
@@ -13,7 +13,7 @@ use std::{fmt, env};
 use hir::map::definitions::DefPathData;
 use mir;
 use ty::{self, Ty, layout};
-use ty::layout::{Size, Align, LayoutError};
+use ty::layout::{Size, AbiAndPrefAlign, LayoutError};
 use rustc_target::spec::abi::Abi;
 
 use super::{RawConst, Pointer, InboundsCheck, ScalarMaybeUndef};
@@ -301,8 +301,8 @@ pub enum EvalErrorKind<'tcx, O> {
     TlsOutOfBounds,
     AbiViolation(String),
     AlignmentCheckFailed {
-        required: Align,
-        has: Align,
+        required: AbiAndPrefAlign,
+        has: AbiAndPrefAlign,
     },
     ValidationFailure(String),
     CalledClosureAsFunction,
@@ -315,7 +315,7 @@ pub enum EvalErrorKind<'tcx, O> {
     DeallocatedWrongMemoryKind(String, String),
     ReallocateNonBasePtr,
     DeallocateNonBasePtr,
-    IncorrectAllocationInformation(Size, Size, Align, Align),
+    IncorrectAllocationInformation(Size, Size, AbiAndPrefAlign, AbiAndPrefAlign),
     Layout(layout::LayoutError<'tcx>),
     HeapAllocZeroBytes,
     HeapAllocNonPowerOfTwoAlignment(u64),

--- a/src/librustc/session/code_stats.rs
+++ b/src/librustc/session/code_stats.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use rustc_target::abi::{AbiAndPrefAlign, Size};
+use rustc_target::abi::{Align, Size};
 use rustc_data_structures::fx::{FxHashSet};
 use std::cmp::{self, Ordering};
 
@@ -63,7 +63,7 @@ impl CodeStats {
     pub fn record_type_size<S: ToString>(&mut self,
                                          kind: DataTypeKind,
                                          type_desc: S,
-                                         align: AbiAndPrefAlign,
+                                         align: Align,
                                          overall_size: Size,
                                          packed: bool,
                                          opt_discr_size: Option<Size>,
@@ -71,7 +71,7 @@ impl CodeStats {
         let info = TypeSizeInfo {
             kind,
             type_description: type_desc.to_string(),
-            align: align.abi.bytes(),
+            align: align.bytes(),
             overall_size: overall_size.bytes(),
             packed: packed,
             opt_discr_size: opt_discr_size.map(|s| s.bytes()),

--- a/src/librustc/session/code_stats.rs
+++ b/src/librustc/session/code_stats.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use rustc_target::abi::{Align, Size};
+use rustc_target::abi::{AbiAndPrefAlign, Size};
 use rustc_data_structures::fx::{FxHashSet};
 use std::cmp::{self, Ordering};
 
@@ -63,7 +63,7 @@ impl CodeStats {
     pub fn record_type_size<S: ToString>(&mut self,
                                          kind: DataTypeKind,
                                          type_desc: S,
-                                         align: Align,
+                                         align: AbiAndPrefAlign,
                                          overall_size: Size,
                                          packed: bool,
                                          opt_discr_size: Option<Size>,

--- a/src/librustc/session/code_stats.rs
+++ b/src/librustc/session/code_stats.rs
@@ -71,7 +71,7 @@ impl CodeStats {
         let info = TypeSizeInfo {
             kind,
             type_description: type_desc.to_string(),
-            align: align.abi(),
+            align: align.abi.bytes(),
             overall_size: overall_size.bytes(),
             packed: packed,
             opt_discr_size: opt_discr_size.map(|s| s.bytes()),

--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -248,7 +248,7 @@ impl<'a, 'tcx> LayoutCx<'tcx, TyCtxt<'a, 'tcx, 'tcx>> {
             /// A univariant, the last field of which may be coerced to unsized.
             MaybeUnsized,
             /// A univariant, but with a prefix of an arbitrary size & alignment (e.g. enum tag).
-            Prefixed(Size, Align),
+            Prefixed(Size, AbiAndPrefAlign),
         }
 
         let univariant_uninterned = |fields: &[TyLayout<'_>], repr: &ReprOptions, kind| {
@@ -259,7 +259,7 @@ impl<'a, 'tcx> LayoutCx<'tcx, TyCtxt<'a, 'tcx, 'tcx>> {
 
             let pack = {
                 let pack = repr.pack as u64;
-                Align::from_bytes(pack, pack).unwrap()
+                AbiAndPrefAlign::from_bytes(pack, pack).unwrap()
             };
 
             let mut align = if packed {
@@ -352,7 +352,7 @@ impl<'a, 'tcx> LayoutCx<'tcx, TyCtxt<'a, 'tcx, 'tcx>> {
 
             if repr.align > 0 {
                 let repr_align = repr.align as u64;
-                align = align.max(Align::from_bytes(repr_align, repr_align).unwrap());
+                align = align.max(AbiAndPrefAlign::from_bytes(repr_align, repr_align).unwrap());
                 debug!("univariant repr_align: {:?}", repr_align);
             }
 
@@ -682,7 +682,7 @@ impl<'a, 'tcx> LayoutCx<'tcx, TyCtxt<'a, 'tcx, 'tcx>> {
 
                     let pack = {
                         let pack = def.repr.pack as u64;
-                        Align::from_bytes(pack, pack).unwrap()
+                        AbiAndPrefAlign::from_bytes(pack, pack).unwrap()
                     };
 
                     let mut align = if packed {
@@ -694,7 +694,7 @@ impl<'a, 'tcx> LayoutCx<'tcx, TyCtxt<'a, 'tcx, 'tcx>> {
                     if def.repr.align > 0 {
                         let repr_align = def.repr.align as u64;
                         align = align.max(
-                            Align::from_bytes(repr_align, repr_align).unwrap());
+                            AbiAndPrefAlign::from_bytes(repr_align, repr_align).unwrap());
                     }
 
                     let optimize = !def.repr.inhibit_union_abi_opt();
@@ -964,7 +964,7 @@ impl<'a, 'tcx> LayoutCx<'tcx, TyCtxt<'a, 'tcx, 'tcx>> {
                 let mut size = Size::ZERO;
 
                 // We're interested in the smallest alignment, so start large.
-                let mut start_align = Align::from_bytes(256, 256).unwrap();
+                let mut start_align = AbiAndPrefAlign::from_bytes(256, 256).unwrap();
                 assert_eq!(Integer::for_abi_align(dl, start_align), None);
 
                 // repr(C) on an enum tells us to make a (tag, union) layout,
@@ -1994,7 +1994,7 @@ impl_stable_hash_for!(enum ::ty::layout::Primitive {
     Pointer
 });
 
-impl<'gcx> HashStable<StableHashingContext<'gcx>> for Align {
+impl<'gcx> HashStable<StableHashingContext<'gcx>> for AbiAndPrefAlign {
     fn hash_stable<W: StableHasherResult>(&self,
                                           hcx: &mut StableHashingContext<'gcx>,
                                           hasher: &mut StableHasher<W>) {

--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -226,9 +226,10 @@ impl<'a, 'tcx> LayoutCx<'tcx, TyCtxt<'a, 'tcx, 'tcx>> {
             tcx.intern_layout(LayoutDetails::scalar(self, scalar_unit(value)))
         };
         let scalar_pair = |a: Scalar, b: Scalar| {
-            let align = a.value.align(dl).max(b.value.align(dl)).max(dl.aggregate_align);
-            let b_offset = a.value.size(dl).abi_align(b.value.align(dl));
-            let size = (b_offset + b.value.size(dl)).abi_align(align);
+            let b_align = b.value.align(dl);
+            let align = a.value.align(dl).max(b_align).max(dl.aggregate_align);
+            let b_offset = a.value.size(dl).align_to(b_align.abi);
+            let size = (b_offset + b.value.size(dl)).align_to(align.abi);
             LayoutDetails {
                 variants: Variants::Single { index: VariantIdx::new(0) },
                 fields: FieldPlacement::Arbitrary {
@@ -248,7 +249,7 @@ impl<'a, 'tcx> LayoutCx<'tcx, TyCtxt<'a, 'tcx, 'tcx>> {
             /// A univariant, the last field of which may be coerced to unsized.
             MaybeUnsized,
             /// A univariant, but with a prefix of an arbitrary size & alignment (e.g. enum tag).
-            Prefixed(Size, AbiAndPrefAlign),
+            Prefixed(Size, Align),
         }
 
         let univariant_uninterned = |fields: &[TyLayout<'_>], repr: &ReprOptions, kind| {
@@ -257,10 +258,7 @@ impl<'a, 'tcx> LayoutCx<'tcx, TyCtxt<'a, 'tcx, 'tcx>> {
                 bug!("struct cannot be packed and aligned");
             }
 
-            let pack = {
-                let pack = repr.pack as u64;
-                AbiAndPrefAlign::new(Align::from_bytes(pack).unwrap())
-            };
+            let pack = Align::from_bytes(repr.pack as u64).unwrap();
 
             let mut align = if packed {
                 dl.i8_align
@@ -274,7 +272,7 @@ impl<'a, 'tcx> LayoutCx<'tcx, TyCtxt<'a, 'tcx, 'tcx>> {
 
             let mut optimize = !repr.inhibit_struct_field_reordering_opt();
             if let StructKind::Prefixed(_, align) = kind {
-                optimize &= align.abi.bytes() == 1;
+                optimize &= align.bytes() == 1;
             }
 
             if optimize {
@@ -285,7 +283,7 @@ impl<'a, 'tcx> LayoutCx<'tcx, TyCtxt<'a, 'tcx, 'tcx>> {
                 };
                 let optimizing = &mut inverse_memory_index[..end];
                 let field_align = |f: &TyLayout<'_>| {
-                    if packed { f.align.min(pack).abi } else { f.align.abi }
+                    if packed { f.align.abi.min(pack) } else { f.align.abi }
                 };
                 match kind {
                     StructKind::AlwaysSized |
@@ -312,13 +310,13 @@ impl<'a, 'tcx> LayoutCx<'tcx, TyCtxt<'a, 'tcx, 'tcx>> {
             let mut offset = Size::ZERO;
 
             if let StructKind::Prefixed(prefix_size, prefix_align) = kind {
-                if packed {
-                    let prefix_align = prefix_align.min(pack);
-                    align = align.max(prefix_align);
+                let prefix_align = if packed {
+                    prefix_align.min(pack)
                 } else {
-                    align = align.max(prefix_align);
-                }
-                offset = prefix_size.abi_align(prefix_align);
+                    prefix_align
+                };
+                align = align.max(AbiAndPrefAlign::new(prefix_align));
+                offset = prefix_size.align_to(prefix_align);
             }
 
             for &i in &inverse_memory_index {
@@ -333,15 +331,13 @@ impl<'a, 'tcx> LayoutCx<'tcx, TyCtxt<'a, 'tcx, 'tcx>> {
                 }
 
                 // Invariant: offset < dl.obj_size_bound() <= 1<<61
-                if packed {
-                    let field_pack = field.align.min(pack);
-                    offset = offset.abi_align(field_pack);
-                    align = align.max(field_pack);
-                }
-                else {
-                    offset = offset.abi_align(field.align);
-                    align = align.max(field.align);
-                }
+                let field_align = if packed {
+                    field.align.min(AbiAndPrefAlign::new(pack))
+                } else {
+                    field.align
+                };
+                offset = offset.align_to(field_align.abi);
+                align = align.max(field_align);
 
                 debug!("univariant offset: {:?} field: {:#?}", offset, field);
                 offsets[i as usize] = offset;
@@ -377,7 +373,7 @@ impl<'a, 'tcx> LayoutCx<'tcx, TyCtxt<'a, 'tcx, 'tcx>> {
                 memory_index = inverse_memory_index;
             }
 
-            let size = min_size.abi_align(align);
+            let size = min_size.align_to(align.abi);
             let mut abi = Abi::Aggregate { sized };
 
             // Unpack newtype ABIs and find scalar pairs.
@@ -648,7 +644,7 @@ impl<'a, 'tcx> LayoutCx<'tcx, TyCtxt<'a, 'tcx, 'tcx>> {
                 let size = element.size.checked_mul(count, dl)
                     .ok_or(LayoutError::SizeOverflow(ty))?;
                 let align = dl.vector_align(size);
-                let size = size.abi_align(align);
+                let size = size.align_to(align.abi);
 
                 tcx.intern_layout(LayoutDetails {
                     variants: Variants::Single { index: VariantIdx::new(0) },
@@ -680,10 +676,7 @@ impl<'a, 'tcx> LayoutCx<'tcx, TyCtxt<'a, 'tcx, 'tcx>> {
                         bug!("Union cannot be packed and aligned");
                     }
 
-                    let pack = {
-                        let pack = def.repr.pack as u64;
-                        AbiAndPrefAlign::new(Align::from_bytes(pack).unwrap())
-                    };
+                    let pack = Align::from_bytes(def.repr.pack as u64).unwrap();
 
                     let mut align = if packed {
                         dl.i8_align
@@ -704,12 +697,12 @@ impl<'a, 'tcx> LayoutCx<'tcx, TyCtxt<'a, 'tcx, 'tcx>> {
                     for field in &variants[index] {
                         assert!(!field.is_unsized());
 
-                        if packed {
-                            let field_pack = field.align.min(pack);
-                            align = align.max(field_pack);
+                        let field_align = if packed {
+                            field.align.min(AbiAndPrefAlign::new(pack))
                         } else {
-                            align = align.max(field.align);
-                        }
+                            field.align
+                        };
+                        align = align.max(field_align);
 
                         // If all non-ZST fields have the same ABI, forward this ABI
                         if optimize && !field.is_zst() {
@@ -749,7 +742,7 @@ impl<'a, 'tcx> LayoutCx<'tcx, TyCtxt<'a, 'tcx, 'tcx>> {
                         fields: FieldPlacement::Union(variants[index].len()),
                         abi,
                         align,
-                        size: size.abi_align(align)
+                        size: size.align_to(align.abi)
                     }));
                 }
 
@@ -964,19 +957,19 @@ impl<'a, 'tcx> LayoutCx<'tcx, TyCtxt<'a, 'tcx, 'tcx>> {
                 let mut size = Size::ZERO;
 
                 // We're interested in the smallest alignment, so start large.
-                let mut start_align = AbiAndPrefAlign::new(Align::from_bytes(256).unwrap());
-                assert_eq!(Integer::for_abi_align(dl, start_align), None);
+                let mut start_align = Align::from_bytes(256).unwrap();
+                assert_eq!(Integer::for_align(dl, start_align), None);
 
                 // repr(C) on an enum tells us to make a (tag, union) layout,
                 // so we need to grow the prefix alignment to be at least
                 // the alignment of the union. (This value is used both for
                 // determining the alignment of the overall enum, and the
                 // determining the alignment of the payload after the tag.)
-                let mut prefix_align = min_ity.align(dl);
+                let mut prefix_align = min_ity.align(dl).abi;
                 if def.repr.c() {
                     for fields in &variants {
                         for field in fields {
-                            prefix_align = prefix_align.max(field.align);
+                            prefix_align = prefix_align.max(field.align.abi);
                         }
                     }
                 }
@@ -990,7 +983,7 @@ impl<'a, 'tcx> LayoutCx<'tcx, TyCtxt<'a, 'tcx, 'tcx>> {
                     // to make room for a larger discriminant.
                     for field in st.fields.index_by_increasing_offset().map(|j| field_layouts[j]) {
                         if !field.is_zst() || field.align.abi.bytes() != 1 {
-                            start_align = start_align.min(field.align);
+                            start_align = start_align.min(field.align.abi);
                             break;
                         }
                     }
@@ -1000,7 +993,7 @@ impl<'a, 'tcx> LayoutCx<'tcx, TyCtxt<'a, 'tcx, 'tcx>> {
                 }).collect::<Result<IndexVec<VariantIdx, _>, _>>()?;
 
                 // Align the maximum variant size to the largest alignment.
-                size = size.abi_align(align);
+                size = size.align_to(align.abi);
 
                 if size.bytes() >= dl.obj_size_bound() {
                     return Err(LayoutError::SizeOverflow(ty));
@@ -1036,7 +1029,7 @@ impl<'a, 'tcx> LayoutCx<'tcx, TyCtxt<'a, 'tcx, 'tcx>> {
                 let mut ity = if def.repr.c() || def.repr.int.is_some() {
                     min_ity
                 } else {
-                    Integer::for_abi_align(dl, start_align).unwrap_or(min_ity)
+                    Integer::for_align(dl, start_align).unwrap_or(min_ity)
                 };
 
                 // If the alignment is not larger than the chosen discriminant size,
@@ -1204,7 +1197,7 @@ impl<'a, 'tcx> LayoutCx<'tcx, TyCtxt<'a, 'tcx, 'tcx>> {
             let type_desc = format!("{:?}", layout.ty);
             self.tcx.sess.code_stats.borrow_mut().record_type_size(kind,
                                                                    type_desc,
-                                                                   layout.align,
+                                                                   layout.align.abi,
                                                                    layout.size,
                                                                    packed,
                                                                    opt_discr_size,
@@ -1823,7 +1816,9 @@ impl<'a, 'tcx> LayoutCx<'tcx, TyCtxt<'a, 'tcx, 'tcx>> {
             Abi::ScalarPair(ref a, ref b) => {
                 // HACK(nox): We iter on `b` and then `a` because `max_by_key`
                 // returns the last maximum.
-                let niche = iter::once((b, a.value.size(self).abi_align(b.value.align(self))))
+                let niche = iter::once(
+                    (b, a.value.size(self).align_to(b.value.align(self).abi))
+                )
                     .chain(iter::once((a, Size::ZERO)))
                     .filter_map(|(scalar, offset)| scalar_niche(scalar, offset))
                     .max_by_key(|niche| niche.available);

--- a/src/librustc_codegen_llvm/abi.rs
+++ b/src/librustc_codegen_llvm/abi.rs
@@ -73,7 +73,7 @@ impl ArgAttributesExt for ArgAttributes {
             if let Some(align) = self.pointee_align {
                 llvm::LLVMRustAddAlignmentAttr(llfn,
                                                idx.as_uint(),
-                                               align.abi() as u32);
+                                               align.abi.bytes() as u32);
             }
             regular.for_each_kind(|attr| attr.apply_llfn(idx, llfn));
         }
@@ -98,7 +98,7 @@ impl ArgAttributesExt for ArgAttributes {
             if let Some(align) = self.pointee_align {
                 llvm::LLVMRustAddAlignmentCallSiteAttr(callsite,
                                                        idx.as_uint(),
-                                                       align.abi() as u32);
+                                                       align.abi.bytes() as u32);
             }
             regular.for_each_kind(|attr| attr.apply_callsite(idx, callsite));
         }

--- a/src/librustc_codegen_llvm/builder.rs
+++ b/src/librustc_codegen_llvm/builder.rs
@@ -475,7 +475,7 @@ impl BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
                 llvm::LLVMBuildAlloca(self.llbuilder, ty,
                                       name.as_ptr())
             };
-            llvm::LLVMSetAlignment(alloca, align.abi() as c_uint);
+            llvm::LLVMSetAlignment(alloca, align.abi.bytes() as c_uint);
             alloca
         }
     }
@@ -494,7 +494,7 @@ impl BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
                 llvm::LLVMBuildArrayAlloca(self.llbuilder, ty, len,
                                            name.as_ptr())
             };
-            llvm::LLVMSetAlignment(alloca, align.abi() as c_uint);
+            llvm::LLVMSetAlignment(alloca, align.abi.bytes() as c_uint);
             alloca
         }
     }
@@ -503,7 +503,7 @@ impl BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
         self.count_insn("load");
         unsafe {
             let load = llvm::LLVMBuildLoad(self.llbuilder, ptr, noname());
-            llvm::LLVMSetAlignment(load, align.abi() as c_uint);
+            llvm::LLVMSetAlignment(load, align.abi.bytes() as c_uint);
             load
         }
     }
@@ -658,7 +658,7 @@ impl BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
             let align = if flags.contains(MemFlags::UNALIGNED) {
                 1
             } else {
-                align.abi() as c_uint
+                align.abi.bytes() as c_uint
             };
             llvm::LLVMSetAlignment(store, align);
             if flags.contains(MemFlags::VOLATILE) {
@@ -893,8 +893,8 @@ impl BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
         let dst = self.pointercast(dst, self.cx().type_i8p());
         let src = self.pointercast(src, self.cx().type_i8p());
         unsafe {
-            llvm::LLVMRustBuildMemCpy(self.llbuilder, dst, dst_align.abi() as c_uint,
-                                      src, src_align.abi() as c_uint, size, is_volatile);
+            llvm::LLVMRustBuildMemCpy(self.llbuilder, dst, dst_align.abi.bytes() as c_uint,
+                                      src, src_align.abi.bytes() as c_uint, size, is_volatile);
         }
     }
 
@@ -913,8 +913,8 @@ impl BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
         let dst = self.pointercast(dst, self.cx().type_i8p());
         let src = self.pointercast(src, self.cx().type_i8p());
         unsafe {
-            llvm::LLVMRustBuildMemMove(self.llbuilder, dst, dst_align.abi() as c_uint,
-                                      src, src_align.abi() as c_uint, size, is_volatile);
+            llvm::LLVMRustBuildMemMove(self.llbuilder, dst, dst_align.abi.bytes() as c_uint,
+                                      src, src_align.abi.bytes() as c_uint, size, is_volatile);
         }
     }
 
@@ -930,7 +930,7 @@ impl BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
         let intrinsic_key = format!("llvm.memset.p0i8.i{}", ptr_width);
         let llintrinsicfn = self.cx().get_intrinsic(&intrinsic_key);
         let ptr = self.pointercast(ptr, self.cx().type_i8p());
-        let align = self.cx().const_u32(align.abi() as u32);
+        let align = self.cx().const_u32(align.abi.bytes() as u32);
         let volatile = self.cx().const_bool(flags.contains(MemFlags::VOLATILE));
         self.call(llintrinsicfn, &[ptr, fill_byte, size, align, volatile], None);
     }

--- a/src/librustc_codegen_llvm/common.rs
+++ b/src/librustc_codegen_llvm/common.rs
@@ -357,7 +357,7 @@ impl ConstMethods<'tcx> for CodegenCx<'ll, 'tcx> {
         offset: Size,
     ) -> PlaceRef<'tcx, &'ll Value> {
         let init = const_alloc_to_llvm(self, alloc);
-        let base_addr = self.static_addr_of(init, layout.align, None);
+        let base_addr = self.static_addr_of(init, layout.align.abi, None);
 
         let llval = unsafe { llvm::LLVMConstInBoundsGEP(
             self.static_bitcast(base_addr, self.type_i8p()),

--- a/src/librustc_codegen_llvm/debuginfo/metadata.rs
+++ b/src/librustc_codegen_llvm/debuginfo/metadata.rs
@@ -35,7 +35,7 @@ use rustc_data_structures::fingerprint::Fingerprint;
 use rustc::ty::Instance;
 use common::CodegenCx;
 use rustc::ty::{self, AdtKind, ParamEnv, Ty, TyCtxt};
-use rustc::ty::layout::{self, AbiAndPrefAlign, HasDataLayout, Integer, IntegerExt, LayoutOf,
+use rustc::ty::layout::{self, Align, HasDataLayout, Integer, IntegerExt, LayoutOf,
                         PrimitiveExt, Size, TyLayout};
 use rustc::session::config;
 use rustc::util::nodemap::FxHashMap;
@@ -323,7 +323,7 @@ fn fixed_vec_metadata(
         llvm::LLVMRustDIBuilderCreateArrayType(
             DIB(cx),
             size.bits(),
-            align.abi.bits() as u32,
+            align.bits() as u32,
             element_type_metadata,
             subscripts)
     };
@@ -465,7 +465,7 @@ fn trait_pointer_metadata(
                 syntax_pos::DUMMY_SP),
             offset: layout.fields.offset(0),
             size: data_ptr_field.size,
-            align: data_ptr_field.align,
+            align: data_ptr_field.align.abi,
             flags: DIFlags::FlagArtificial,
             discriminant: None,
         },
@@ -474,7 +474,7 @@ fn trait_pointer_metadata(
             type_metadata: type_metadata(cx, vtable_field.ty, syntax_pos::DUMMY_SP),
             offset: layout.fields.offset(1),
             size: vtable_field.size,
-            align: vtable_field.align,
+            align: vtable_field.align.abi,
             flags: DIFlags::FlagArtificial,
             discriminant: None,
         },
@@ -787,7 +787,7 @@ fn basic_type_metadata(cx: &CodegenCx<'ll, 'tcx>, t: Ty<'tcx>) -> &'ll DIType {
             DIB(cx),
             name.as_ptr(),
             size.bits(),
-            align.abi.bits() as u32,
+            align.bits() as u32,
             encoding)
     };
 
@@ -818,7 +818,7 @@ fn pointer_type_metadata(
             DIB(cx),
             pointee_type_metadata,
             pointer_size.bits(),
-            pointer_align.abi.bits() as u32,
+            pointer_align.bits() as u32,
             name.as_ptr())
     }
 }
@@ -923,7 +923,7 @@ struct MemberDescription<'ll> {
     type_metadata: &'ll DIType,
     offset: Size,
     size: Size,
-    align: AbiAndPrefAlign,
+    align: Align,
     flags: DIFlags,
     discriminant: Option<u64>,
 }
@@ -990,7 +990,7 @@ impl<'tcx> StructMemberDescriptionFactory<'tcx> {
                 type_metadata: type_metadata(cx, field.ty, self.span),
                 offset: layout.fields.offset(i),
                 size: field.size,
-                align: field.align,
+                align: field.align.abi,
                 flags: DIFlags::FlagZero,
                 discriminant: None,
             }
@@ -1113,7 +1113,7 @@ impl<'tcx> UnionMemberDescriptionFactory<'tcx> {
                 type_metadata: type_metadata(cx, field.ty, self.span),
                 offset: Size::ZERO,
                 size: field.size,
-                align: field.align,
+                align: field.align.abi,
                 flags: DIFlags::FlagZero,
                 discriminant: None,
             }
@@ -1226,7 +1226,7 @@ impl EnumMemberDescriptionFactory<'ll, 'tcx> {
                         type_metadata: variant_type_metadata,
                         offset: Size::ZERO,
                         size: self.layout.size,
-                        align: self.layout.align,
+                        align: self.layout.align.abi,
                         flags: DIFlags::FlagZero,
                         discriminant: None,
                     }
@@ -1265,7 +1265,7 @@ impl EnumMemberDescriptionFactory<'ll, 'tcx> {
                         type_metadata: variant_type_metadata,
                         offset: Size::ZERO,
                         size: self.layout.size,
-                        align: self.layout.align,
+                        align: self.layout.align.abi,
                         flags: DIFlags::FlagZero,
                         discriminant: Some(self.layout.ty.ty_adt_def().unwrap()
                                            .discriminant_for_variant(cx.tcx, i)
@@ -1334,7 +1334,7 @@ impl EnumMemberDescriptionFactory<'ll, 'tcx> {
                             type_metadata: variant_type_metadata,
                             offset: Size::ZERO,
                             size: variant.size,
-                            align: variant.align,
+                            align: variant.align.abi,
                             flags: DIFlags::FlagZero,
                             discriminant: None,
                         }
@@ -1372,7 +1372,7 @@ impl EnumMemberDescriptionFactory<'ll, 'tcx> {
                             type_metadata: variant_type_metadata,
                             offset: Size::ZERO,
                             size: self.layout.size,
-                            align: self.layout.align,
+                            align: self.layout.align.abi,
                             flags: DIFlags::FlagZero,
                             discriminant: niche_value,
                         }
@@ -1675,7 +1675,7 @@ fn prepare_enum_metadata(
                     file_metadata,
                     UNKNOWN_LINE_NUMBER,
                     size.bits(),
-                    align.abi.bits() as u32,
+                    align.bits() as u32,
                     layout.fields.offset(0).bits(),
                     DIFlags::FlagArtificial,
                     discr_metadata))
@@ -1803,7 +1803,7 @@ fn set_members_of_composite_type(cx: &CodegenCx<'ll, '_>,
                     unknown_file_metadata(cx),
                     UNKNOWN_LINE_NUMBER,
                     member_description.size.bits(),
-                    member_description.align.abi.bits() as u32,
+                    member_description.align.bits() as u32,
                     member_description.offset.bits(),
                     match member_description.discriminant {
                         None => None,
@@ -1851,7 +1851,7 @@ fn create_struct_stub(
             unknown_file_metadata(cx),
             UNKNOWN_LINE_NUMBER,
             struct_size.bits(),
-            struct_align.abi.bits() as u32,
+            struct_align.bits() as u32,
             DIFlags::FlagZero,
             None,
             empty_array,
@@ -1889,7 +1889,7 @@ fn create_union_stub(
             unknown_file_metadata(cx),
             UNKNOWN_LINE_NUMBER,
             union_size.bits(),
-            union_align.abi.bits() as u32,
+            union_align.bits() as u32,
             DIFlags::FlagZero,
             Some(empty_array),
             0, // RuntimeLang
@@ -1958,7 +1958,7 @@ pub fn create_global_var_metadata(
                                                     is_local_to_unit,
                                                     global,
                                                     None,
-                                                    global_align.abi.bytes() as u32,
+                                                    global_align.bytes() as u32,
         );
     }
 }

--- a/src/librustc_codegen_llvm/debuginfo/metadata.rs
+++ b/src/librustc_codegen_llvm/debuginfo/metadata.rs
@@ -323,7 +323,7 @@ fn fixed_vec_metadata(
         llvm::LLVMRustDIBuilderCreateArrayType(
             DIB(cx),
             size.bits(),
-            align.abi_bits() as u32,
+            align.abi.bits() as u32,
             element_type_metadata,
             subscripts)
     };
@@ -787,7 +787,7 @@ fn basic_type_metadata(cx: &CodegenCx<'ll, 'tcx>, t: Ty<'tcx>) -> &'ll DIType {
             DIB(cx),
             name.as_ptr(),
             size.bits(),
-            align.abi_bits() as u32,
+            align.abi.bits() as u32,
             encoding)
     };
 
@@ -818,7 +818,7 @@ fn pointer_type_metadata(
             DIB(cx),
             pointee_type_metadata,
             pointer_size.bits(),
-            pointer_align.abi_bits() as u32,
+            pointer_align.abi.bits() as u32,
             name.as_ptr())
     }
 }
@@ -1563,7 +1563,7 @@ fn prepare_enum_metadata(
                         file_metadata,
                         UNKNOWN_LINE_NUMBER,
                         discriminant_size.bits(),
-                        discriminant_align.abi_bits() as u32,
+                        discriminant_align.abi.bits() as u32,
                         create_DIArray(DIB(cx), &enumerators_metadata),
                         discriminant_base_type_metadata, true)
                 };
@@ -1607,7 +1607,7 @@ fn prepare_enum_metadata(
                 file_metadata,
                 UNKNOWN_LINE_NUMBER,
                 layout.size.bits(),
-                layout.align.abi_bits() as u32,
+                layout.align.abi.bits() as u32,
                 DIFlags::FlagZero,
                 None,
                 0, // RuntimeLang
@@ -1655,7 +1655,7 @@ fn prepare_enum_metadata(
                     file_metadata,
                     UNKNOWN_LINE_NUMBER,
                     size.bits(),
-                    align.abi_bits() as u32,
+                    align.abi.bits() as u32,
                     layout.fields.offset(0).bits(),
                     DIFlags::FlagArtificial,
                     discr_metadata))
@@ -1675,7 +1675,7 @@ fn prepare_enum_metadata(
                     file_metadata,
                     UNKNOWN_LINE_NUMBER,
                     size.bits(),
-                    align.abi_bits() as u32,
+                    align.abi.bits() as u32,
                     layout.fields.offset(0).bits(),
                     DIFlags::FlagArtificial,
                     discr_metadata))
@@ -1692,7 +1692,7 @@ fn prepare_enum_metadata(
             file_metadata,
             UNKNOWN_LINE_NUMBER,
             layout.size.bits(),
-            layout.align.abi_bits() as u32,
+            layout.align.abi.bits() as u32,
             DIFlags::FlagZero,
             discriminator_metadata,
             empty_array,
@@ -1709,7 +1709,7 @@ fn prepare_enum_metadata(
             file_metadata,
             UNKNOWN_LINE_NUMBER,
             layout.size.bits(),
-            layout.align.abi_bits() as u32,
+            layout.align.abi.bits() as u32,
             DIFlags::FlagZero,
             None,
             type_array,
@@ -1803,7 +1803,7 @@ fn set_members_of_composite_type(cx: &CodegenCx<'ll, '_>,
                     unknown_file_metadata(cx),
                     UNKNOWN_LINE_NUMBER,
                     member_description.size.bits(),
-                    member_description.align.abi_bits() as u32,
+                    member_description.align.abi.bits() as u32,
                     member_description.offset.bits(),
                     match member_description.discriminant {
                         None => None,
@@ -1851,7 +1851,7 @@ fn create_struct_stub(
             unknown_file_metadata(cx),
             UNKNOWN_LINE_NUMBER,
             struct_size.bits(),
-            struct_align.abi_bits() as u32,
+            struct_align.abi.bits() as u32,
             DIFlags::FlagZero,
             None,
             empty_array,
@@ -1889,7 +1889,7 @@ fn create_union_stub(
             unknown_file_metadata(cx),
             UNKNOWN_LINE_NUMBER,
             union_size.bits(),
-            union_align.abi_bits() as u32,
+            union_align.abi.bits() as u32,
             DIFlags::FlagZero,
             Some(empty_array),
             0, // RuntimeLang
@@ -1958,7 +1958,7 @@ pub fn create_global_var_metadata(
                                                     is_local_to_unit,
                                                     global,
                                                     None,
-                                                    global_align.abi() as u32,
+                                                    global_align.abi.bytes() as u32,
         );
     }
 }
@@ -1996,7 +1996,7 @@ pub fn create_vtable_metadata(
             unknown_file_metadata(cx),
             UNKNOWN_LINE_NUMBER,
             Size::ZERO.bits(),
-            cx.tcx.data_layout.pointer_align.abi_bits() as u32,
+            cx.tcx.data_layout.pointer_align.abi.bits() as u32,
             DIFlags::FlagArtificial,
             None,
             empty_array,

--- a/src/librustc_codegen_llvm/debuginfo/mod.rs
+++ b/src/librustc_codegen_llvm/debuginfo/mod.rs
@@ -201,7 +201,7 @@ impl DebugInfoBuilderMethods<'tcx> for Builder<'a, 'll, 'tcx> {
                         cx.sess().opts.optimize != config::OptLevel::No,
                         DIFlags::FlagZero,
                         argument_index,
-                        align.abi() as u32,
+                        align.abi.bytes() as u32,
                     )
                 };
                 source_loc::set_debug_location(self,

--- a/src/librustc_codegen_llvm/debuginfo/mod.rs
+++ b/src/librustc_codegen_llvm/debuginfo/mod.rs
@@ -201,7 +201,7 @@ impl DebugInfoBuilderMethods<'tcx> for Builder<'a, 'll, 'tcx> {
                         cx.sess().opts.optimize != config::OptLevel::No,
                         DIFlags::FlagZero,
                         argument_index,
-                        align.abi.bytes() as u32,
+                        align.bytes() as u32,
                     )
                 };
                 source_loc::set_debug_location(self,

--- a/src/librustc_codegen_llvm/intrinsic.rs
+++ b/src/librustc_codegen_llvm/intrinsic.rs
@@ -158,7 +158,7 @@ impl IntrinsicCallMethods<'tcx> for Builder<'a, 'll, 'tcx> {
             }
             "min_align_of" => {
                 let tp_ty = substs.type_at(0);
-                self.cx().const_usize(self.cx().align_of(tp_ty).abi())
+                self.cx().const_usize(self.cx().align_of(tp_ty).abi.bytes())
             }
             "min_align_of_val" => {
                 let tp_ty = substs.type_at(0);
@@ -167,12 +167,12 @@ impl IntrinsicCallMethods<'tcx> for Builder<'a, 'll, 'tcx> {
                         glue::size_and_align_of_dst(self, tp_ty, Some(meta));
                     llalign
                 } else {
-                    self.cx().const_usize(self.cx().align_of(tp_ty).abi())
+                    self.cx().const_usize(self.cx().align_of(tp_ty).abi.bytes())
                 }
             }
             "pref_align_of" => {
                 let tp_ty = substs.type_at(0);
-                self.cx().const_usize(self.cx().align_of(tp_ty).pref())
+                self.cx().const_usize(self.cx().align_of(tp_ty).pref.bytes())
             }
             "type_name" => {
                 let tp_ty = substs.type_at(0);
@@ -261,7 +261,7 @@ impl IntrinsicCallMethods<'tcx> for Builder<'a, 'll, 'tcx> {
                 let align = if name == "unaligned_volatile_load" {
                     1
                 } else {
-                    self.cx().align_of(tp_ty).abi() as u32
+                    self.cx().align_of(tp_ty).abi.bytes() as u32
                 };
                 unsafe {
                     llvm::LLVMSetAlignment(load, align);
@@ -1436,7 +1436,7 @@ fn generic_simd_intrinsic(
 
         // Alignment of T, must be a constant integer value:
         let alignment_ty = bx.cx().type_i32();
-        let alignment = bx.cx().const_i32(bx.cx().align_of(in_elem).abi() as i32);
+        let alignment = bx.cx().const_i32(bx.cx().align_of(in_elem).abi.bytes() as i32);
 
         // Truncate the mask vector to a vector of i1s:
         let (mask, mask_ty) = {
@@ -1536,7 +1536,7 @@ fn generic_simd_intrinsic(
 
         // Alignment of T, must be a constant integer value:
         let alignment_ty = bx.cx().type_i32();
-        let alignment = bx.cx().const_i32(bx.cx().align_of(in_elem).abi() as i32);
+        let alignment = bx.cx().const_i32(bx.cx().align_of(in_elem).abi.bytes() as i32);
 
         // Truncate the mask vector to a vector of i1s:
         let (mask, mask_ty) = {

--- a/src/librustc_codegen_llvm/type_of.rs
+++ b/src/librustc_codegen_llvm/type_of.rs
@@ -12,7 +12,7 @@ use abi::{FnType, FnTypeExt};
 use common::*;
 use rustc::hir;
 use rustc::ty::{self, Ty, TypeFoldable};
-use rustc::ty::layout::{self, Align, LayoutOf, Size, TyLayout};
+use rustc::ty::layout::{self, AbiAndPrefAlign, LayoutOf, Size, TyLayout};
 use rustc_target::abi::FloatTy;
 use rustc_mir::monomorphize::item::DefPathBasedNames;
 use type_::Type;
@@ -80,7 +80,7 @@ fn uncached_llvm_type<'a, 'tcx>(cx: &CodegenCx<'a, 'tcx>,
 
     match layout.fields {
         layout::FieldPlacement::Union(_) => {
-            let fill = cx.type_padding_filler( layout.size, layout.align);
+            let fill = cx.type_padding_filler(layout.size, layout.align);
             let packed = false;
             match name {
                 None => {
@@ -165,7 +165,7 @@ fn struct_llfields<'a, 'tcx>(cx: &CodegenCx<'a, 'tcx>,
 }
 
 impl<'a, 'tcx> CodegenCx<'a, 'tcx> {
-    pub fn align_of(&self, ty: Ty<'tcx>) -> Align {
+    pub fn align_of(&self, ty: Ty<'tcx>) -> AbiAndPrefAlign {
         self.layout_of(ty).align
     }
 
@@ -173,8 +173,9 @@ impl<'a, 'tcx> CodegenCx<'a, 'tcx> {
         self.layout_of(ty).size
     }
 
-    pub fn size_and_align_of(&self, ty: Ty<'tcx>) -> (Size, Align) {
-        self.layout_of(ty).size_and_align()
+    pub fn size_and_align_of(&self, ty: Ty<'tcx>) -> (Size, AbiAndPrefAlign) {
+        let layout = self.layout_of(ty);
+        (layout.size, layout.align)
     }
 }
 
@@ -196,7 +197,7 @@ pub enum PointerKind {
 #[derive(Copy, Clone)]
 pub struct PointeeInfo {
     pub size: Size,
-    pub align: Align,
+    pub align: AbiAndPrefAlign,
     pub safe: Option<PointerKind>,
 }
 

--- a/src/librustc_codegen_llvm/type_of.rs
+++ b/src/librustc_codegen_llvm/type_of.rs
@@ -125,14 +125,14 @@ fn struct_llfields<'a, 'tcx>(cx: &CodegenCx<'a, 'tcx>,
     for i in layout.fields.index_by_increasing_offset() {
         let target_offset = layout.fields.offset(i as usize);
         let field = layout.field(cx, i);
-        let effective_field_align = layout.align
-            .min(field.align)
-            .restrict_for_offset(target_offset);
-        packed |= effective_field_align.abi() < field.align.abi();
+        let effective_field_align = AbiAndPrefAlign::new(layout.align.abi
+            .min(field.align.abi)
+            .restrict_for_offset(target_offset));
+        packed |= effective_field_align.abi < field.align.abi;
 
         debug!("struct_llfields: {}: {:?} offset: {:?} target_offset: {:?} \
                 effective_field_align: {}",
-               i, field, offset, target_offset, effective_field_align.abi());
+               i, field, offset, target_offset, effective_field_align.abi.bytes());
         assert!(target_offset >= offset);
         let padding = target_offset - offset;
         let padding_align = prev_effective_align.min(effective_field_align);

--- a/src/librustc_codegen_ssa/base.rs
+++ b/src/librustc_codegen_ssa/base.rs
@@ -31,7 +31,7 @@ use rustc::middle::lang_items::StartFnLangItem;
 use rustc::middle::weak_lang_items;
 use rustc::mir::mono::{Stats, CodegenUnitNameBuilder};
 use rustc::ty::{self, Ty, TyCtxt};
-use rustc::ty::layout::{self, Align, TyLayout, LayoutOf, VariantIdx, HasTyCtxt};
+use rustc::ty::layout::{self, AbiAndPrefAlign, TyLayout, LayoutOf, VariantIdx, HasTyCtxt};
 use rustc::ty::query::Providers;
 use rustc::middle::cstore::{self, LinkagePreference};
 use rustc::util::common::{time, print_time_passes_entry};
@@ -410,9 +410,9 @@ pub fn to_immediate_scalar<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>>(
 pub fn memcpy_ty<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>>(
     bx: &mut Bx,
     dst: Bx::Value,
-    dst_align: Align,
+    dst_align: AbiAndPrefAlign,
     src: Bx::Value,
-    src_align: Align,
+    src_align: AbiAndPrefAlign,
     layout: TyLayout<'tcx>,
     flags: MemFlags,
 ) {

--- a/src/librustc_codegen_ssa/base.rs
+++ b/src/librustc_codegen_ssa/base.rs
@@ -31,7 +31,7 @@ use rustc::middle::lang_items::StartFnLangItem;
 use rustc::middle::weak_lang_items;
 use rustc::mir::mono::{Stats, CodegenUnitNameBuilder};
 use rustc::ty::{self, Ty, TyCtxt};
-use rustc::ty::layout::{self, AbiAndPrefAlign, TyLayout, LayoutOf, VariantIdx, HasTyCtxt};
+use rustc::ty::layout::{self, Align, TyLayout, LayoutOf, VariantIdx, HasTyCtxt};
 use rustc::ty::query::Providers;
 use rustc::middle::cstore::{self, LinkagePreference};
 use rustc::util::common::{time, print_time_passes_entry};
@@ -410,9 +410,9 @@ pub fn to_immediate_scalar<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>>(
 pub fn memcpy_ty<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>>(
     bx: &mut Bx,
     dst: Bx::Value,
-    dst_align: AbiAndPrefAlign,
+    dst_align: Align,
     src: Bx::Value,
-    src_align: AbiAndPrefAlign,
+    src_align: Align,
     layout: TyLayout<'tcx>,
     flags: MemFlags,
 ) {

--- a/src/librustc_codegen_ssa/glue.rs
+++ b/src/librustc_codegen_ssa/glue.rs
@@ -25,14 +25,12 @@ pub fn size_and_align_of_dst<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>>(
     t: Ty<'tcx>,
     info: Option<Bx::Value>
 ) -> (Bx::Value, Bx::Value) {
-    debug!("calculate size of DST: {}; with lost info: {:?}",
-           t, info);
-    if bx.cx().type_is_sized(t) {
-        let (size, align) = bx.cx().layout_of(t).size_and_align();
-        debug!("size_and_align_of_dst t={} info={:?} size: {:?} align: {:?}",
-               t, info, size, align);
-        let size = bx.cx().const_usize(size.bytes());
-        let align = bx.cx().const_usize(align.abi());
+    let layout = bx.cx().layout_of(t);
+    debug!("size_and_align_of_dst(ty={}, info={:?}): layout: {:?}",
+           t, info, layout);
+    if !layout.is_unsized() {
+        let size = bx.cx().const_usize(layout.size.bytes());
+        let align = bx.cx().const_usize(layout.align.abi());
         return (size, align);
     }
     match t.sty {
@@ -42,19 +40,17 @@ pub fn size_and_align_of_dst<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>>(
             (meth::SIZE.get_usize(bx, vtable), meth::ALIGN.get_usize(bx, vtable))
         }
         ty::Slice(_) | ty::Str => {
-            let unit = t.sequence_element_type(bx.tcx());
+            let unit = layout.field(bx.cx(), 0);
             // The info in this case is the length of the str, so the size is that
             // times the unit size.
-            let (size, align) = bx.cx().layout_of(unit).size_and_align();
-            (bx.mul(info.unwrap(), bx.cx().const_usize(size.bytes())),
-             bx.cx().const_usize(align.abi()))
+            (bx.mul(info.unwrap(), bx.cx().const_usize(unit.size.bytes())),
+             bx.cx().const_usize(unit.align.abi()))
         }
         _ => {
             // First get the size of all statically known fields.
             // Don't use size_of because it also rounds up to alignment, which we
             // want to avoid, as the unsized field's alignment could be smaller.
             assert!(!t.is_simd());
-            let layout = bx.cx().layout_of(t);
             debug!("DST {} layout: {:?}", t, layout);
 
             let i = layout.fields.count() - 1;

--- a/src/librustc_codegen_ssa/glue.rs
+++ b/src/librustc_codegen_ssa/glue.rs
@@ -30,7 +30,7 @@ pub fn size_and_align_of_dst<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>>(
            t, info, layout);
     if !layout.is_unsized() {
         let size = bx.cx().const_usize(layout.size.bytes());
-        let align = bx.cx().const_usize(layout.align.abi());
+        let align = bx.cx().const_usize(layout.align.abi.bytes());
         return (size, align);
     }
     match t.sty {
@@ -44,7 +44,7 @@ pub fn size_and_align_of_dst<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>>(
             // The info in this case is the length of the str, so the size is that
             // times the unit size.
             (bx.mul(info.unwrap(), bx.cx().const_usize(unit.size.bytes())),
-             bx.cx().const_usize(unit.align.abi()))
+             bx.cx().const_usize(unit.align.abi.bytes()))
         }
         _ => {
             // First get the size of all statically known fields.
@@ -55,7 +55,7 @@ pub fn size_and_align_of_dst<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>>(
 
             let i = layout.fields.count() - 1;
             let sized_size = layout.fields.offset(i).bytes();
-            let sized_align = layout.align.abi();
+            let sized_align = layout.align.abi.bytes();
             debug!("DST {} statically sized prefix size: {} align: {}",
                    t, sized_size, sized_align);
             let sized_size = bx.cx().const_usize(sized_size);

--- a/src/librustc_codegen_ssa/meth.rs
+++ b/src/librustc_codegen_ssa/meth.rs
@@ -100,15 +100,15 @@ pub fn get_vtable<'tcx, Cx: CodegenMethods<'tcx>>(
         })
     });
 
-    let (size, align) = cx.layout_of(ty).size_and_align();
+    let layout = cx.layout_of(ty);
     // /////////////////////////////////////////////////////////////////////////////////////////////
     // If you touch this code, be sure to also make the corresponding changes to
     // `get_vtable` in rust_mir/interpret/traits.rs
     // /////////////////////////////////////////////////////////////////////////////////////////////
     let components: Vec<_> = [
         cx.get_fn(monomorphize::resolve_drop_in_place(cx.tcx(), ty)),
-        cx.const_usize(size.bytes()),
-        cx.const_usize(align.abi())
+        cx.const_usize(layout.size.bytes()),
+        cx.const_usize(layout.align.abi())
     ].iter().cloned().chain(methods).collect();
 
     let vtable_const = cx.const_struct(&components, false);

--- a/src/librustc_codegen_ssa/meth.rs
+++ b/src/librustc_codegen_ssa/meth.rs
@@ -41,7 +41,7 @@ impl<'a, 'tcx: 'a> VirtualIndex {
             llvtable,
             bx.cx().type_ptr_to(bx.cx().fn_ptr_backend_type(fn_ty))
         );
-        let ptr_align = bx.tcx().data_layout.pointer_align;
+        let ptr_align = bx.tcx().data_layout.pointer_align.abi;
         let gep = bx.inbounds_gep(llvtable, &[bx.cx().const_usize(self.0)]);
         let ptr = bx.load(gep, ptr_align);
         bx.nonnull_metadata(ptr);
@@ -59,7 +59,7 @@ impl<'a, 'tcx: 'a> VirtualIndex {
         debug!("get_int({:?}, {:?})", llvtable, self);
 
         let llvtable = bx.pointercast(llvtable, bx.cx().type_ptr_to(bx.cx().type_isize()));
-        let usize_align = bx.tcx().data_layout.pointer_align;
+        let usize_align = bx.tcx().data_layout.pointer_align.abi;
         let gep = bx.inbounds_gep(llvtable, &[bx.cx().const_usize(self.0)]);
         let ptr = bx.load(gep, usize_align);
         // Vtable loads are invariant
@@ -112,7 +112,7 @@ pub fn get_vtable<'tcx, Cx: CodegenMethods<'tcx>>(
     ].iter().cloned().chain(methods).collect();
 
     let vtable_const = cx.const_struct(&components, false);
-    let align = cx.data_layout().pointer_align;
+    let align = cx.data_layout().pointer_align.abi;
     let vtable = cx.static_addr_of(vtable_const, align, Some("vtable"));
 
     cx.create_vtable_metadata(ty, vtable);

--- a/src/librustc_codegen_ssa/meth.rs
+++ b/src/librustc_codegen_ssa/meth.rs
@@ -108,7 +108,7 @@ pub fn get_vtable<'tcx, Cx: CodegenMethods<'tcx>>(
     let components: Vec<_> = [
         cx.get_fn(monomorphize::resolve_drop_in_place(cx.tcx(), ty)),
         cx.const_usize(layout.size.bytes()),
-        cx.const_usize(layout.align.abi())
+        cx.const_usize(layout.align.abi.bytes())
     ].iter().cloned().chain(methods).collect();
 
     let vtable_const = cx.const_struct(&components, false);

--- a/src/librustc_codegen_ssa/mir/block.rs
+++ b/src/librustc_codegen_ssa/mir/block.rs
@@ -280,7 +280,7 @@ impl<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                                 scratch.llval
                             }
                             Ref(llval, _, align) => {
-                                assert_eq!(align.abi, op.layout.align.abi,
+                                assert_eq!(align, op.layout.align.abi,
                                            "return place is unaligned!");
                                 llval
                             }
@@ -288,7 +288,7 @@ impl<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                         let addr = bx.pointercast(llslot, bx.cx().type_ptr_to(
                             bx.cx().cast_backend_type(&cast_ty)
                         ));
-                        bx.load(addr, self.fn_ty.ret.layout.align)
+                        bx.load(addr, self.fn_ty.ret.layout.align.abi)
                     }
                 };
                 bx.ret(llval);
@@ -386,9 +386,9 @@ impl<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 let filename = bx.cx().const_str_slice(filename);
                 let line = bx.cx().const_u32(loc.line as u32);
                 let col = bx.cx().const_u32(loc.col.to_usize() as u32 + 1);
-                let align = tcx.data_layout.aggregate_align
-                    .max(tcx.data_layout.i32_align)
-                    .max(tcx.data_layout.pointer_align);
+                let align = tcx.data_layout.aggregate_align.abi
+                    .max(tcx.data_layout.i32_align.abi)
+                    .max(tcx.data_layout.pointer_align.abi);
 
                 // Put together the arguments to the panic entry point.
                 let (lang_item, args) = match *msg {
@@ -522,9 +522,9 @@ impl<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                     let filename = bx.cx().const_str_slice(filename);
                     let line = bx.cx().const_u32(loc.line as u32);
                     let col = bx.cx().const_u32(loc.col.to_usize() as u32 + 1);
-                    let align = tcx.data_layout.aggregate_align
-                        .max(tcx.data_layout.i32_align)
-                        .max(tcx.data_layout.pointer_align);
+                    let align = tcx.data_layout.aggregate_align.abi
+                        .max(tcx.data_layout.i32_align.abi)
+                        .max(tcx.data_layout.pointer_align.abi);
 
                     let str = format!(
                         "Attempted to instantiate uninhabited type {} using mem::{}",
@@ -800,12 +800,12 @@ impl<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                         (scratch.llval, scratch.align, true)
                     }
                     _ => {
-                        (op.immediate_or_packed_pair(bx), arg.layout.align, false)
+                        (op.immediate_or_packed_pair(bx), arg.layout.align.abi, false)
                     }
                 }
             }
             Ref(llval, _, align) => {
-                if arg.is_indirect() && align.abi < arg.layout.align.abi {
+                if arg.is_indirect() && align < arg.layout.align.abi {
                     // `foo(packed.large_field)`. We can't pass the (unaligned) field directly. I
                     // think that ATM (Rust 1.16) we only pass temporaries, but we shouldn't
                     // have scary latent bugs around.
@@ -826,7 +826,7 @@ impl<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 let addr = bx.pointercast(llval, bx.cx().type_ptr_to(
                     bx.cx().cast_backend_type(&ty))
                 );
-                llval = bx.load(addr, align.min(arg.layout.align));
+                llval = bx.load(addr, align.min(arg.layout.align.abi));
             } else {
                 // We can't use `PlaceRef::load` here because the argument
                 // may have a type we don't treat as immediate, but the ABI
@@ -1006,7 +1006,7 @@ impl<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             self.codegen_place(bx, dest)
         };
         if fn_ret.is_indirect() {
-            if dest.align.abi < dest.layout.align.abi {
+            if dest.align < dest.layout.align.abi {
                 // Currently, MIR code generation does not create calls
                 // that store directly to fields of packed structs (in
                 // fact, the calls it creates write only to temps),
@@ -1062,7 +1062,7 @@ impl<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         let src = self.codegen_operand(bx, src);
         let llty = bx.cx().backend_type(src.layout);
         let cast_ptr = bx.pointercast(dst.llval, bx.cx().type_ptr_to(llty));
-        let align = src.layout.align.min(dst.layout.align);
+        let align = src.layout.align.abi.min(dst.align);
         src.val.store(bx, PlaceRef::new_sized(cast_ptr, src.layout, align));
     }
 

--- a/src/librustc_codegen_ssa/mir/block.rs
+++ b/src/librustc_codegen_ssa/mir/block.rs
@@ -280,7 +280,7 @@ impl<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                                 scratch.llval
                             }
                             Ref(llval, _, align) => {
-                                assert_eq!(align.abi(), op.layout.align.abi(),
+                                assert_eq!(align.abi, op.layout.align.abi,
                                            "return place is unaligned!");
                                 llval
                             }
@@ -805,7 +805,7 @@ impl<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 }
             }
             Ref(llval, _, align) => {
-                if arg.is_indirect() && align.abi() < arg.layout.align.abi() {
+                if arg.is_indirect() && align.abi < arg.layout.align.abi {
                     // `foo(packed.large_field)`. We can't pass the (unaligned) field directly. I
                     // think that ATM (Rust 1.16) we only pass temporaries, but we shouldn't
                     // have scary latent bugs around.
@@ -1006,7 +1006,7 @@ impl<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             self.codegen_place(bx, dest)
         };
         if fn_ret.is_indirect() {
-            if dest.align.abi() < dest.layout.align.abi() {
+            if dest.align.abi < dest.layout.align.abi {
                 // Currently, MIR code generation does not create calls
                 // that store directly to fields of packed structs (in
                 // fact, the calls it creates write only to temps),

--- a/src/librustc_codegen_ssa/mir/mod.rs
+++ b/src/librustc_codegen_ssa/mir/mod.rs
@@ -304,7 +304,7 @@ pub fn codegen_mir<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>>(
                 if local == mir::RETURN_PLACE && fx.fn_ty.ret.is_indirect() {
                     debug!("alloc: {:?} (return place) -> place", local);
                     let llretptr = fx.cx.get_param(llfn, 0);
-                    LocalRef::Place(PlaceRef::new_sized(llretptr, layout, layout.align))
+                    LocalRef::Place(PlaceRef::new_sized(llretptr, layout, layout.align.abi))
                 } else if memory_locals.contains(local) {
                     debug!("alloc: {:?} -> place", local);
                     if layout.is_unsized() {
@@ -555,7 +555,7 @@ fn arg_local_refs<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>>(
             let llarg = bx.cx().get_param(bx.llfn(), llarg_idx as c_uint);
             bx.set_value_name(llarg, &name);
             llarg_idx += 1;
-            PlaceRef::new_sized(llarg, arg.layout, arg.layout.align)
+            PlaceRef::new_sized(llarg, arg.layout, arg.layout.align.abi)
         } else if arg.is_unsized_indirect() {
             // As the storage for the indirect argument lives during
             // the whole function call, we just copy the fat pointer.

--- a/src/librustc_codegen_ssa/mir/operand.rs
+++ b/src/librustc_codegen_ssa/mir/operand.rs
@@ -11,7 +11,7 @@
 use rustc::mir::interpret::{ConstValue, ErrorHandled};
 use rustc::mir;
 use rustc::ty;
-use rustc::ty::layout::{self, AbiAndPrefAlign, LayoutOf, TyLayout};
+use rustc::ty::layout::{self, Align, AbiAndPrefAlign, LayoutOf, TyLayout};
 
 use base;
 use MemFlags;
@@ -348,8 +348,8 @@ impl<'a, 'tcx: 'a, V: CodegenObject> OperandValue<V> {
             };
 
         // FIXME: choose an appropriate alignment, or use dynamic align somehow
-        let max_align = AbiAndPrefAlign::from_bits(128, 128).unwrap();
-        let min_align = AbiAndPrefAlign::from_bits(8, 8).unwrap();
+        let max_align = AbiAndPrefAlign::new(Align::from_bits(128).unwrap());
+        let min_align = AbiAndPrefAlign::new(Align::from_bits(8).unwrap());
 
         // Allocate an appropriate region on the stack, and copy the value into it
         let (llsize, _) = glue::size_and_align_of_dst(bx, unsized_ty, Some(llextra));

--- a/src/librustc_codegen_ssa/mir/operand.rs
+++ b/src/librustc_codegen_ssa/mir/operand.rs
@@ -11,7 +11,7 @@
 use rustc::mir::interpret::{ConstValue, ErrorHandled};
 use rustc::mir;
 use rustc::ty;
-use rustc::ty::layout::{self, Align, LayoutOf, TyLayout};
+use rustc::ty::layout::{self, AbiAndPrefAlign, LayoutOf, TyLayout};
 
 use base;
 use MemFlags;
@@ -33,7 +33,7 @@ pub enum OperandValue<V> {
     /// to be valid for the operand's lifetime.
     /// The second value, if any, is the extra data (vtable or length)
     /// which indicates that it refers to an unsized rvalue.
-    Ref(V, Option<V>, Align),
+    Ref(V, Option<V>, AbiAndPrefAlign),
     /// A single LLVM value.
     Immediate(V),
     /// A pair of immediate LLVM values. Used by fat pointers too.
@@ -348,8 +348,8 @@ impl<'a, 'tcx: 'a, V: CodegenObject> OperandValue<V> {
             };
 
         // FIXME: choose an appropriate alignment, or use dynamic align somehow
-        let max_align = Align::from_bits(128, 128).unwrap();
-        let min_align = Align::from_bits(8, 8).unwrap();
+        let max_align = AbiAndPrefAlign::from_bits(128, 128).unwrap();
+        let min_align = AbiAndPrefAlign::from_bits(8, 8).unwrap();
 
         // Allocate an appropriate region on the stack, and copy the value into it
         let (llsize, _) = glue::size_and_align_of_dst(bx, unsized_ty, Some(llextra));

--- a/src/librustc_codegen_ssa/mir/place.rs
+++ b/src/librustc_codegen_ssa/mir/place.rs
@@ -101,7 +101,7 @@ impl<'a, 'tcx: 'a, V: CodegenObject> PlaceRef<'tcx, V> {
     ) -> Self {
         let field = self.layout.field(bx.cx(), ix);
         let offset = self.layout.fields.offset(ix);
-        let effective_field_align = self.align.restrict_for_offset(offset);
+        let effective_field_align = self.align.abi.restrict_for_offset(offset);
 
         let mut simple = || {
             // Unions and newtypes only use an offset of 0.
@@ -123,7 +123,7 @@ impl<'a, 'tcx: 'a, V: CodegenObject> PlaceRef<'tcx, V> {
                     None
                 },
                 layout: field,
-                align: effective_field_align,
+                align: AbiAndPrefAlign::new(effective_field_align),
             }
         };
 
@@ -143,7 +143,7 @@ impl<'a, 'tcx: 'a, V: CodegenObject> PlaceRef<'tcx, V> {
                 if def.repr.packed() {
                     // FIXME(eddyb) generalize the adjustment when we
                     // start supporting packing to larger alignments.
-                    assert_eq!(self.layout.align.abi(), 1);
+                    assert_eq!(self.layout.align.abi.bytes(), 1);
                     return simple();
                 }
             }
@@ -197,7 +197,7 @@ impl<'a, 'tcx: 'a, V: CodegenObject> PlaceRef<'tcx, V> {
             llval: bx.pointercast(byte_ptr, bx.cx().type_ptr_to(ll_fty)),
             llextra: self.llextra,
             layout: field,
-            align: effective_field_align,
+            align: AbiAndPrefAlign::new(effective_field_align),
         }
     }
 

--- a/src/librustc_codegen_ssa/mir/rvalue.rs
+++ b/src/librustc_codegen_ssa/mir/rvalue.rs
@@ -496,10 +496,10 @@ impl<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             }
 
             mir::Rvalue::NullaryOp(mir::NullOp::Box, content_ty) => {
-                let content_ty: Ty<'tcx> = self.monomorphize(&content_ty);
-                let (size, align) = bx.cx().layout_of(content_ty).size_and_align();
-                let llsize = bx.cx().const_usize(size.bytes());
-                let llalign = bx.cx().const_usize(align.abi());
+                let content_ty = self.monomorphize(&content_ty);
+                let content_layout = bx.cx().layout_of(content_ty);
+                let llsize = bx.cx().const_usize(content_layout.size.bytes());
+                let llalign = bx.cx().const_usize(content_layout.align.abi());
                 let box_layout = bx.cx().layout_of(bx.tcx().mk_box(content_ty));
                 let llty_ptr = bx.cx().backend_type(box_layout);
 

--- a/src/librustc_codegen_ssa/mir/rvalue.rs
+++ b/src/librustc_codegen_ssa/mir/rvalue.rs
@@ -499,7 +499,7 @@ impl<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 let content_ty = self.monomorphize(&content_ty);
                 let content_layout = bx.cx().layout_of(content_ty);
                 let llsize = bx.cx().const_usize(content_layout.size.bytes());
-                let llalign = bx.cx().const_usize(content_layout.align.abi());
+                let llalign = bx.cx().const_usize(content_layout.align.abi.bytes());
                 let box_layout = bx.cx().layout_of(bx.tcx().mk_box(content_ty));
                 let llty_ptr = bx.cx().backend_type(box_layout);
 

--- a/src/librustc_codegen_ssa/traits/builder.rs
+++ b/src/librustc_codegen_ssa/traits/builder.rs
@@ -17,7 +17,7 @@ use super::HasCodegen;
 use common::{AtomicOrdering, AtomicRmwBinOp, IntPredicate, RealPredicate, SynchronizationScope};
 use mir::operand::OperandRef;
 use mir::place::PlaceRef;
-use rustc::ty::layout::{AbiAndPrefAlign, Size};
+use rustc::ty::layout::{Align, Size};
 use std::ffi::CStr;
 use MemFlags;
 
@@ -97,18 +97,17 @@ pub trait BuilderMethods<'a, 'tcx: 'a>:
     fn fneg(&mut self, v: Self::Value) -> Self::Value;
     fn not(&mut self, v: Self::Value) -> Self::Value;
 
-    fn alloca(&mut self, ty: Self::Type, name: &str, align: AbiAndPrefAlign) -> Self::Value;
-    fn dynamic_alloca(&mut self, ty: Self::Type, name: &str, align: AbiAndPrefAlign)
-        -> Self::Value;
+    fn alloca(&mut self, ty: Self::Type, name: &str, align: Align) -> Self::Value;
+    fn dynamic_alloca(&mut self, ty: Self::Type, name: &str, align: Align) -> Self::Value;
     fn array_alloca(
         &mut self,
         ty: Self::Type,
         len: Self::Value,
         name: &str,
-        align: AbiAndPrefAlign,
+        align: Align,
     ) -> Self::Value;
 
-    fn load(&mut self, ptr: Self::Value, align: AbiAndPrefAlign) -> Self::Value;
+    fn load(&mut self, ptr: Self::Value, align: Align) -> Self::Value;
     fn volatile_load(&mut self, ptr: Self::Value) -> Self::Value;
     fn atomic_load(&mut self, ptr: Self::Value, order: AtomicOrdering, size: Size) -> Self::Value;
     fn load_operand(&mut self, place: PlaceRef<'tcx, Self::Value>)
@@ -117,12 +116,12 @@ pub trait BuilderMethods<'a, 'tcx: 'a>:
     fn range_metadata(&mut self, load: Self::Value, range: Range<u128>);
     fn nonnull_metadata(&mut self, load: Self::Value);
 
-    fn store(&mut self, val: Self::Value, ptr: Self::Value, align: AbiAndPrefAlign) -> Self::Value;
+    fn store(&mut self, val: Self::Value, ptr: Self::Value, align: Align) -> Self::Value;
     fn store_with_flags(
         &mut self,
         val: Self::Value,
         ptr: Self::Value,
-        align: AbiAndPrefAlign,
+        align: Align,
         flags: MemFlags,
     ) -> Self::Value;
     fn atomic_store(
@@ -175,18 +174,18 @@ pub trait BuilderMethods<'a, 'tcx: 'a>:
     fn memcpy(
         &mut self,
         dst: Self::Value,
-        dst_align: AbiAndPrefAlign,
+        dst_align: Align,
         src: Self::Value,
-        src_align: AbiAndPrefAlign,
+        src_align: Align,
         size: Self::Value,
         flags: MemFlags,
     );
     fn memmove(
         &mut self,
         dst: Self::Value,
-        dst_align: AbiAndPrefAlign,
+        dst_align: Align,
         src: Self::Value,
-        src_align: AbiAndPrefAlign,
+        src_align: Align,
         size: Self::Value,
         flags: MemFlags,
     );
@@ -195,7 +194,7 @@ pub trait BuilderMethods<'a, 'tcx: 'a>:
         ptr: Self::Value,
         fill_byte: Self::Value,
         size: Self::Value,
-        align: AbiAndPrefAlign,
+        align: Align,
         flags: MemFlags,
     );
 

--- a/src/librustc_codegen_ssa/traits/builder.rs
+++ b/src/librustc_codegen_ssa/traits/builder.rs
@@ -15,10 +15,10 @@ use super::intrinsic::IntrinsicCallMethods;
 use super::type_::ArgTypeMethods;
 use super::HasCodegen;
 use common::{AtomicOrdering, AtomicRmwBinOp, IntPredicate, RealPredicate, SynchronizationScope};
-use std::ffi::CStr;
 use mir::operand::OperandRef;
 use mir::place::PlaceRef;
-use rustc::ty::layout::{Align, Size};
+use rustc::ty::layout::{AbiAndPrefAlign, Size};
+use std::ffi::CStr;
 use MemFlags;
 
 use std::borrow::Cow;
@@ -97,17 +97,18 @@ pub trait BuilderMethods<'a, 'tcx: 'a>:
     fn fneg(&mut self, v: Self::Value) -> Self::Value;
     fn not(&mut self, v: Self::Value) -> Self::Value;
 
-    fn alloca(&mut self, ty: Self::Type, name: &str, align: Align) -> Self::Value;
-    fn dynamic_alloca(&mut self, ty: Self::Type, name: &str, align: Align) -> Self::Value;
+    fn alloca(&mut self, ty: Self::Type, name: &str, align: AbiAndPrefAlign) -> Self::Value;
+    fn dynamic_alloca(&mut self, ty: Self::Type, name: &str, align: AbiAndPrefAlign)
+        -> Self::Value;
     fn array_alloca(
         &mut self,
         ty: Self::Type,
         len: Self::Value,
         name: &str,
-        align: Align,
+        align: AbiAndPrefAlign,
     ) -> Self::Value;
 
-    fn load(&mut self, ptr: Self::Value, align: Align) -> Self::Value;
+    fn load(&mut self, ptr: Self::Value, align: AbiAndPrefAlign) -> Self::Value;
     fn volatile_load(&mut self, ptr: Self::Value) -> Self::Value;
     fn atomic_load(&mut self, ptr: Self::Value, order: AtomicOrdering, size: Size) -> Self::Value;
     fn load_operand(&mut self, place: PlaceRef<'tcx, Self::Value>)
@@ -116,12 +117,12 @@ pub trait BuilderMethods<'a, 'tcx: 'a>:
     fn range_metadata(&mut self, load: Self::Value, range: Range<u128>);
     fn nonnull_metadata(&mut self, load: Self::Value);
 
-    fn store(&mut self, val: Self::Value, ptr: Self::Value, align: Align) -> Self::Value;
+    fn store(&mut self, val: Self::Value, ptr: Self::Value, align: AbiAndPrefAlign) -> Self::Value;
     fn store_with_flags(
         &mut self,
         val: Self::Value,
         ptr: Self::Value,
-        align: Align,
+        align: AbiAndPrefAlign,
         flags: MemFlags,
     ) -> Self::Value;
     fn atomic_store(
@@ -174,18 +175,18 @@ pub trait BuilderMethods<'a, 'tcx: 'a>:
     fn memcpy(
         &mut self,
         dst: Self::Value,
-        dst_align: Align,
+        dst_align: AbiAndPrefAlign,
         src: Self::Value,
-        src_align: Align,
+        src_align: AbiAndPrefAlign,
         size: Self::Value,
         flags: MemFlags,
     );
     fn memmove(
         &mut self,
         dst: Self::Value,
-        dst_align: Align,
+        dst_align: AbiAndPrefAlign,
         src: Self::Value,
-        src_align: Align,
+        src_align: AbiAndPrefAlign,
         size: Self::Value,
         flags: MemFlags,
     );
@@ -194,7 +195,7 @@ pub trait BuilderMethods<'a, 'tcx: 'a>:
         ptr: Self::Value,
         fill_byte: Self::Value,
         size: Self::Value,
-        align: Align,
+        align: AbiAndPrefAlign,
         flags: MemFlags,
     );
 

--- a/src/librustc_codegen_ssa/traits/statics.rs
+++ b/src/librustc_codegen_ssa/traits/statics.rs
@@ -10,13 +10,23 @@
 
 use super::Backend;
 use rustc::hir::def_id::DefId;
-use rustc::ty::layout::Align;
+use rustc::ty::layout::AbiAndPrefAlign;
 
 pub trait StaticMethods<'tcx>: Backend<'tcx> {
     fn static_ptrcast(&self, val: Self::Value, ty: Self::Type) -> Self::Value;
     fn static_bitcast(&self, val: Self::Value, ty: Self::Type) -> Self::Value;
-    fn static_addr_of_mut(&self, cv: Self::Value, align: Align, kind: Option<&str>) -> Self::Value;
-    fn static_addr_of(&self, cv: Self::Value, align: Align, kind: Option<&str>) -> Self::Value;
+    fn static_addr_of_mut(
+        &self,
+        cv: Self::Value,
+        align: AbiAndPrefAlign,
+        kind: Option<&str>,
+    ) -> Self::Value;
+    fn static_addr_of(
+        &self,
+        cv: Self::Value,
+        align: AbiAndPrefAlign,
+        kind: Option<&str>,
+    ) -> Self::Value;
     fn get_static(&self, def_id: DefId) -> Self::Value;
     fn codegen_static(&self, def_id: DefId, is_mutable: bool);
     unsafe fn static_replace_all_uses(&self, old_g: Self::Value, new_g: Self::Value);

--- a/src/librustc_codegen_ssa/traits/statics.rs
+++ b/src/librustc_codegen_ssa/traits/statics.rs
@@ -10,23 +10,13 @@
 
 use super::Backend;
 use rustc::hir::def_id::DefId;
-use rustc::ty::layout::AbiAndPrefAlign;
+use rustc::ty::layout::Align;
 
 pub trait StaticMethods<'tcx>: Backend<'tcx> {
     fn static_ptrcast(&self, val: Self::Value, ty: Self::Type) -> Self::Value;
     fn static_bitcast(&self, val: Self::Value, ty: Self::Type) -> Self::Value;
-    fn static_addr_of_mut(
-        &self,
-        cv: Self::Value,
-        align: AbiAndPrefAlign,
-        kind: Option<&str>,
-    ) -> Self::Value;
-    fn static_addr_of(
-        &self,
-        cv: Self::Value,
-        align: AbiAndPrefAlign,
-        kind: Option<&str>,
-    ) -> Self::Value;
+    fn static_addr_of_mut(&self, cv: Self::Value, align: Align, kind: Option<&str>) -> Self::Value;
+    fn static_addr_of(&self, cv: Self::Value, align: Align, kind: Option<&str>) -> Self::Value;
     fn get_static(&self, def_id: DefId) -> Self::Value;
     fn codegen_static(&self, def_id: DefId, is_mutable: bool);
     unsafe fn static_replace_all_uses(&self, old_g: Self::Value, new_g: Self::Value);

--- a/src/librustc_codegen_ssa/traits/type_.rs
+++ b/src/librustc_codegen_ssa/traits/type_.rs
@@ -13,7 +13,7 @@ use super::Backend;
 use super::HasCodegen;
 use common::{self, TypeKind};
 use mir::place::PlaceRef;
-use rustc::ty::layout::{self, Align, Size, TyLayout};
+use rustc::ty::layout::{self, AbiAndPrefAlign, Size, TyLayout};
 use rustc::ty::{self, Ty};
 use rustc::util::nodemap::FxHashMap;
 use rustc_target::abi::call::{ArgType, CastTarget, FnType, Reg};
@@ -120,7 +120,7 @@ pub trait DerivedTypeMethods<'tcx>: BaseTypeMethods<'tcx> + MiscMethods<'tcx> {
         }
     }
 
-    fn type_pointee_for_abi_align(&self, align: Align) -> Self::Type {
+    fn type_pointee_for_abi_align(&self, align: AbiAndPrefAlign) -> Self::Type {
         // FIXME(eddyb) We could find a better approximation if ity.align < align.
         let ity = layout::Integer::approximate_abi_align(self, align);
         self.type_from_integer(ity)
@@ -128,7 +128,7 @@ pub trait DerivedTypeMethods<'tcx>: BaseTypeMethods<'tcx> + MiscMethods<'tcx> {
 
     /// Return a LLVM type that has at most the required alignment,
     /// and exactly the required size, as a best-effort padding array.
-    fn type_padding_filler(&self, size: Size, align: Align) -> Self::Type {
+    fn type_padding_filler(&self, size: Size, align: AbiAndPrefAlign) -> Self::Type {
         let unit = layout::Integer::approximate_abi_align(self, align);
         let size = size.bytes();
         let unit_size = unit.size().bytes();

--- a/src/librustc_codegen_ssa/traits/type_.rs
+++ b/src/librustc_codegen_ssa/traits/type_.rs
@@ -13,7 +13,7 @@ use super::Backend;
 use super::HasCodegen;
 use common::{self, TypeKind};
 use mir::place::PlaceRef;
-use rustc::ty::layout::{self, AbiAndPrefAlign, Size, TyLayout};
+use rustc::ty::layout::{self, Align, Size, TyLayout};
 use rustc::ty::{self, Ty};
 use rustc::util::nodemap::FxHashMap;
 use rustc_target::abi::call::{ArgType, CastTarget, FnType, Reg};
@@ -120,16 +120,16 @@ pub trait DerivedTypeMethods<'tcx>: BaseTypeMethods<'tcx> + MiscMethods<'tcx> {
         }
     }
 
-    fn type_pointee_for_abi_align(&self, align: AbiAndPrefAlign) -> Self::Type {
+    fn type_pointee_for_align(&self, align: Align) -> Self::Type {
         // FIXME(eddyb) We could find a better approximation if ity.align < align.
-        let ity = layout::Integer::approximate_abi_align(self, align);
+        let ity = layout::Integer::approximate_align(self, align);
         self.type_from_integer(ity)
     }
 
     /// Return a LLVM type that has at most the required alignment,
     /// and exactly the required size, as a best-effort padding array.
-    fn type_padding_filler(&self, size: Size, align: AbiAndPrefAlign) -> Self::Type {
-        let unit = layout::Integer::approximate_abi_align(self, align);
+    fn type_padding_filler(&self, size: Size, align: Align) -> Self::Type {
+        let unit = layout::Integer::approximate_align(self, align);
         let size = size.bytes();
         let unit_size = unit.size().bytes();
         assert_eq!(size % unit_size, 0);

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -129,7 +129,7 @@ pub fn op_to_const<'tcx>(
             assert!(meta.is_none());
             let ptr = ptr.to_ptr()?;
             let alloc = ecx.memory.get(ptr.alloc_id)?;
-            assert!(alloc.align.abi() >= align.abi());
+            assert!(alloc.align.abi >= align.abi);
             assert!(alloc.bytes.len() as u64 - ptr.offset.bytes() >= op.layout.size.bytes());
             let mut alloc = alloc.clone();
             alloc.align = align;

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -129,7 +129,7 @@ pub fn op_to_const<'tcx>(
             assert!(meta.is_none());
             let ptr = ptr.to_ptr()?;
             let alloc = ecx.memory.get(ptr.alloc_id)?;
-            assert!(alloc.align.abi >= align.abi);
+            assert!(alloc.align >= align);
             assert!(alloc.bytes.len() as u64 - ptr.offset.bytes() >= op.layout.size.bytes());
             let mut alloc = alloc.clone();
             alloc.align = align;

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -636,7 +636,7 @@ impl<'a, 'mir, 'tcx: 'mir, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tc
                         let (ptr, align) = mplace.to_scalar_ptr_align();
                         match ptr {
                             Scalar::Ptr(ptr) => {
-                                write!(msg, " by align({}) ref:", align.abi()).unwrap();
+                                write!(msg, " by align({}) ref:", align.abi.bytes()).unwrap();
                                 allocs.push(ptr.alloc_id);
                             }
                             ptr => write!(msg, " by integral ref: {:?}", ptr).unwrap(),
@@ -665,7 +665,7 @@ impl<'a, 'mir, 'tcx: 'mir, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tc
             Place::Ptr(mplace) => {
                 match mplace.ptr {
                     Scalar::Ptr(ptr) => {
-                        trace!("by align({}) ref:", mplace.align.abi());
+                        trace!("by align({}) ref:", mplace.align.abi.bytes());
                         self.memory.dump_alloc(ptr.alloc_id);
                     }
                     ptr => trace!(" integral by ref: {:?}", ptr),

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -16,7 +16,7 @@ use rustc::hir::def_id::DefId;
 use rustc::hir::def::Def;
 use rustc::mir;
 use rustc::ty::layout::{
-    self, Size, AbiAndPrefAlign, HasDataLayout, LayoutOf, TyLayout
+    self, Size, Align, HasDataLayout, LayoutOf, TyLayout
 };
 use rustc::ty::subst::{Subst, Substs};
 use rustc::ty::{self, Ty, TyCtxt, TypeFoldable};
@@ -314,9 +314,9 @@ impl<'a, 'mir, 'tcx: 'mir, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tc
         &self,
         metadata: Option<Scalar<M::PointerTag>>,
         layout: TyLayout<'tcx>,
-    ) -> EvalResult<'tcx, Option<(Size, AbiAndPrefAlign)>> {
+    ) -> EvalResult<'tcx, Option<(Size, Align)>> {
         if !layout.is_unsized() {
-            return Ok(Some((layout.size, layout.align)));
+            return Ok(Some((layout.size, layout.align.abi)));
         }
         match layout.ty.sty {
             ty::Adt(..) | ty::Tuple(..) => {
@@ -328,7 +328,7 @@ impl<'a, 'mir, 'tcx: 'mir, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tc
                 trace!("DST layout: {:?}", layout);
 
                 let sized_size = layout.fields.offset(layout.fields.count() - 1);
-                let sized_align = layout.align;
+                let sized_align = layout.align.abi;
                 trace!(
                     "DST {} statically sized prefix size: {:?} align: {:?}",
                     layout.ty,
@@ -381,7 +381,7 @@ impl<'a, 'mir, 'tcx: 'mir, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tc
                 //
                 //   `(size + (align-1)) & -align`
 
-                Ok(Some((size.abi_align(align), align)))
+                Ok(Some((size.align_to(align), align)))
             }
             ty::Dynamic(..) => {
                 let vtable = metadata.expect("dyn trait fat ptr must have vtable").to_ptr()?;
@@ -392,7 +392,7 @@ impl<'a, 'mir, 'tcx: 'mir, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tc
             ty::Slice(_) | ty::Str => {
                 let len = metadata.expect("slice fat ptr must have vtable").to_usize(self)?;
                 let elem = layout.field(self, 0)?;
-                Ok(Some((elem.size * len, elem.align)))
+                Ok(Some((elem.size * len, elem.align.abi)))
             }
 
             ty::Foreign(_) => {
@@ -406,7 +406,7 @@ impl<'a, 'mir, 'tcx: 'mir, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tc
     pub fn size_and_align_of_mplace(
         &self,
         mplace: MPlaceTy<'tcx, M::PointerTag>
-    ) -> EvalResult<'tcx, Option<(Size, AbiAndPrefAlign)>> {
+    ) -> EvalResult<'tcx, Option<(Size, Align)>> {
         self.size_and_align_of(mplace.meta, mplace.layout)
     }
 
@@ -636,7 +636,7 @@ impl<'a, 'mir, 'tcx: 'mir, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tc
                         let (ptr, align) = mplace.to_scalar_ptr_align();
                         match ptr {
                             Scalar::Ptr(ptr) => {
-                                write!(msg, " by align({}) ref:", align.abi.bytes()).unwrap();
+                                write!(msg, " by align({}) ref:", align.bytes()).unwrap();
                                 allocs.push(ptr.alloc_id);
                             }
                             ptr => write!(msg, " by integral ref: {:?}", ptr).unwrap(),
@@ -665,7 +665,7 @@ impl<'a, 'mir, 'tcx: 'mir, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tc
             Place::Ptr(mplace) => {
                 match mplace.ptr {
                     Scalar::Ptr(ptr) => {
-                        trace!("by align({}) ref:", mplace.align.abi.bytes());
+                        trace!("by align({}) ref:", mplace.align.bytes());
                         self.memory.dump_alloc(ptr.alloc_id);
                     }
                     ptr => trace!(" integral by ref: {:?}", ptr),

--- a/src/librustc_mir/interpret/intrinsics.rs
+++ b/src/librustc_mir/interpret/intrinsics.rs
@@ -60,7 +60,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
         match intrinsic_name {
             "min_align_of" => {
                 let elem_ty = substs.type_at(0);
-                let elem_align = self.layout_of(elem_ty)?.align.abi();
+                let elem_align = self.layout_of(elem_ty)?.align.abi.bytes();
                 let align_val = Scalar::from_uint(elem_align, dest.layout.size);
                 self.write_scalar(align_val, dest)?;
             }

--- a/src/librustc_mir/interpret/memory.rs
+++ b/src/librustc_mir/interpret/memory.rs
@@ -21,7 +21,7 @@ use std::ptr;
 use std::borrow::Cow;
 
 use rustc::ty::{self, Instance, ParamEnv, query::TyCtxtAt};
-use rustc::ty::layout::{self, AbiAndPrefAlign, TargetDataLayout, Size, HasDataLayout};
+use rustc::ty::layout::{self, Align, AbiAndPrefAlign, TargetDataLayout, Size, HasDataLayout};
 pub use rustc::mir::interpret::{truncate, write_target_uint, read_target_uint};
 use rustc_data_structures::fx::{FxHashSet, FxHashMap};
 
@@ -268,18 +268,18 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> Memory<'a, 'mir, 'tcx, M> {
             }
         };
         // Check alignment
-        if alloc_align.abi() < required_align.abi() {
+        if alloc_align.abi < required_align.abi {
             return err!(AlignmentCheckFailed {
                 has: alloc_align,
                 required: required_align,
             });
         }
-        if offset % required_align.abi() == 0 {
+        if offset % required_align.abi.bytes() == 0 {
             Ok(())
         } else {
-            let has = offset % required_align.abi();
+            let has = offset % required_align.abi.bytes();
             err!(AlignmentCheckFailed {
-                has: AbiAndPrefAlign::from_bytes(has, has).unwrap(),
+                has: AbiAndPrefAlign::new(Align::from_bytes(has).unwrap()),
                 required: required_align,
             })
         }
@@ -450,7 +450,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> Memory<'a, 'mir, 'tcx, M> {
         // Could also be a fn ptr or extern static
         match self.tcx.alloc_map.lock().get(id) {
             Some(AllocType::Function(..)) => {
-                (Size::ZERO, AbiAndPrefAlign::from_bytes(1, 1).unwrap())
+                (Size::ZERO, AbiAndPrefAlign::new(Align::from_bytes(1).unwrap()))
             }
             Some(AllocType::Static(did)) => {
                 // The only way `get` couldn't have worked here is if this is an extern static
@@ -523,7 +523,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> Memory<'a, 'mir, 'tcx, M> {
             "{}({} bytes, alignment {}){}",
             msg,
             alloc.bytes.len(),
-            alloc.align.abi(),
+            alloc.align.abi.bytes(),
             extra
         );
 
@@ -865,7 +865,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> Memory<'a, 'mir, 'tcx, M> {
         allow_ptr_and_undef: bool,
     ) -> EvalResult<'tcx> {
         // Empty accesses don't need to be valid pointers, but they should still be non-NULL
-        let align = AbiAndPrefAlign::from_bytes(1, 1).unwrap();
+        let align = AbiAndPrefAlign::new(Align::from_bytes(1).unwrap());
         if size.bytes() == 0 {
             self.check_align(ptr, align)?;
             return Ok(());
@@ -883,7 +883,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> Memory<'a, 'mir, 'tcx, M> {
 
     pub fn read_bytes(&self, ptr: Scalar<M::PointerTag>, size: Size) -> EvalResult<'tcx, &[u8]> {
         // Empty accesses don't need to be valid pointers, but they should still be non-NULL
-        let align = AbiAndPrefAlign::from_bytes(1, 1).unwrap();
+        let align = AbiAndPrefAlign::new(Align::from_bytes(1).unwrap());
         if size.bytes() == 0 {
             self.check_align(ptr, align)?;
             return Ok(&[]);
@@ -893,7 +893,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> Memory<'a, 'mir, 'tcx, M> {
 
     pub fn write_bytes(&mut self, ptr: Scalar<M::PointerTag>, src: &[u8]) -> EvalResult<'tcx> {
         // Empty accesses don't need to be valid pointers, but they should still be non-NULL
-        let align = AbiAndPrefAlign::from_bytes(1, 1).unwrap();
+        let align = AbiAndPrefAlign::new(Align::from_bytes(1).unwrap());
         if src.is_empty() {
             self.check_align(ptr, align)?;
             return Ok(());
@@ -910,7 +910,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> Memory<'a, 'mir, 'tcx, M> {
         count: Size
     ) -> EvalResult<'tcx> {
         // Empty accesses don't need to be valid pointers, but they should still be non-NULL
-        let align = AbiAndPrefAlign::from_bytes(1, 1).unwrap();
+        let align = AbiAndPrefAlign::new(Align::from_bytes(1).unwrap());
         if count.bytes() == 0 {
             self.check_align(ptr, align)?;
             return Ok(());

--- a/src/librustc_mir/interpret/operand.rs
+++ b/src/librustc_mir/interpret/operand.rs
@@ -285,7 +285,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
                 let (a, b) = (&a.value, &b.value);
                 let (a_size, b_size) = (a.size(self), b.size(self));
                 let a_ptr = ptr;
-                let b_offset = a_size.abi_align(b.align(self));
+                let b_offset = a_size.align_to(b.align(self).abi);
                 assert!(b_offset.bytes() > 0); // we later use the offset to test which field to use
                 let b_ptr = ptr.offset(b_offset, self)?.into();
                 let a_val = self.memory.read_scalar(a_ptr, ptr_align, a_size)?;

--- a/src/librustc_mir/interpret/snapshot.rs
+++ b/src/librustc_mir/interpret/snapshot.rs
@@ -16,7 +16,7 @@ use rustc::mir::interpret::{
 };
 
 use rustc::ty::{self, TyCtxt};
-use rustc::ty::layout::AbiAndPrefAlign;
+use rustc::ty::layout::Align;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_data_structures::indexed_vec::IndexVec;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
@@ -276,7 +276,7 @@ struct AllocationSnapshot<'a> {
     bytes: &'a [u8],
     relocations: Relocations<(), AllocIdSnapshot<'a>>,
     undef_mask: &'a UndefMask,
-    align: &'a AbiAndPrefAlign,
+    align: &'a Align,
     mutability: &'a Mutability,
 }
 

--- a/src/librustc_mir/interpret/snapshot.rs
+++ b/src/librustc_mir/interpret/snapshot.rs
@@ -16,7 +16,7 @@ use rustc::mir::interpret::{
 };
 
 use rustc::ty::{self, TyCtxt};
-use rustc::ty::layout::Align;
+use rustc::ty::layout::AbiAndPrefAlign;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_data_structures::indexed_vec::IndexVec;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
@@ -276,7 +276,7 @@ struct AllocationSnapshot<'a> {
     bytes: &'a [u8],
     relocations: Relocations<(), AllocIdSnapshot<'a>>,
     undef_mask: &'a UndefMask,
-    align: &'a Align,
+    align: &'a AbiAndPrefAlign,
     mutability: &'a Mutability,
 }
 

--- a/src/librustc_mir/interpret/terminator.rs
+++ b/src/librustc_mir/interpret/terminator.rs
@@ -401,7 +401,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
             // cannot use the shim here, because that will only result in infinite recursion
             ty::InstanceDef::Virtual(_, idx) => {
                 let ptr_size = self.pointer_size();
-                let ptr_align = self.tcx.data_layout.pointer_align;
+                let ptr_align = self.tcx.data_layout.pointer_align.abi;
                 let ptr = self.deref_operand(args[0])?;
                 let vtable = ptr.vtable()?;
                 let fn_ptr = self.memory.read_ptr_sized(

--- a/src/librustc_mir/interpret/traits.rs
+++ b/src/librustc_mir/interpret/traits.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use rustc::ty::{self, Ty};
-use rustc::ty::layout::{Size, Align, AbiAndPrefAlign, LayoutOf};
+use rustc::ty::layout::{Size, Align, LayoutOf};
 use rustc::mir::interpret::{Scalar, Pointer, EvalResult, PointerArithmetic};
 
 use super::{EvalContext, Machine, MemoryKind};
@@ -45,7 +45,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
         let align = layout.align.abi.bytes();
 
         let ptr_size = self.pointer_size();
-        let ptr_align = self.tcx.data_layout.pointer_align;
+        let ptr_align = self.tcx.data_layout.pointer_align.abi;
         // /////////////////////////////////////////////////////////////////////////////////////////
         // If you touch this code, be sure to also make the corresponding changes to
         // `get_vtable` in rust_codegen_llvm/meth.rs
@@ -87,7 +87,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
         vtable: Pointer<M::PointerTag>,
     ) -> EvalResult<'tcx, (ty::Instance<'tcx>, ty::Ty<'tcx>)> {
         // we don't care about the pointee type, we just want a pointer
-        let pointer_align = self.tcx.data_layout.pointer_align;
+        let pointer_align = self.tcx.data_layout.pointer_align.abi;
         let drop_fn = self.memory.read_ptr_sized(vtable, pointer_align)?.to_ptr()?;
         let drop_instance = self.memory.get_fn(drop_fn)?;
         trace!("Found drop fn: {:?}", drop_instance);
@@ -101,15 +101,15 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
     pub fn read_size_and_align_from_vtable(
         &self,
         vtable: Pointer<M::PointerTag>,
-    ) -> EvalResult<'tcx, (Size, AbiAndPrefAlign)> {
+    ) -> EvalResult<'tcx, (Size, Align)> {
         let pointer_size = self.pointer_size();
-        let pointer_align = self.tcx.data_layout.pointer_align;
+        let pointer_align = self.tcx.data_layout.pointer_align.abi;
         let size = self.memory.read_ptr_sized(vtable.offset(pointer_size, self)?,pointer_align)?
             .to_bits(pointer_size)? as u64;
         let align = self.memory.read_ptr_sized(
             vtable.offset(pointer_size * 2, self)?,
             pointer_align
         )?.to_bits(pointer_size)? as u64;
-        Ok((Size::from_bytes(size), AbiAndPrefAlign::new(Align::from_bytes(align).unwrap())))
+        Ok((Size::from_bytes(size), Align::from_bytes(align).unwrap()))
     }
 }

--- a/src/librustc_mir/interpret/traits.rs
+++ b/src/librustc_mir/interpret/traits.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use rustc::ty::{self, Ty};
-use rustc::ty::layout::{Size, AbiAndPrefAlign, LayoutOf};
+use rustc::ty::layout::{Size, Align, AbiAndPrefAlign, LayoutOf};
 use rustc::mir::interpret::{Scalar, Pointer, EvalResult, PointerArithmetic};
 
 use super::{EvalContext, Machine, MemoryKind};
@@ -42,7 +42,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
         let layout = self.layout_of(ty)?;
         assert!(!layout.is_unsized(), "can't create a vtable for an unsized type");
         let size = layout.size.bytes();
-        let align = layout.align.abi();
+        let align = layout.align.abi.bytes();
 
         let ptr_size = self.pointer_size();
         let ptr_align = self.tcx.data_layout.pointer_align;
@@ -110,6 +110,6 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
             vtable.offset(pointer_size * 2, self)?,
             pointer_align
         )?.to_bits(pointer_size)? as u64;
-        Ok((Size::from_bytes(size), AbiAndPrefAlign::from_bytes(align, align).unwrap()))
+        Ok((Size::from_bytes(size), AbiAndPrefAlign::new(Align::from_bytes(align).unwrap())))
     }
 }

--- a/src/librustc_mir/interpret/traits.rs
+++ b/src/librustc_mir/interpret/traits.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use rustc::ty::{self, Ty};
-use rustc::ty::layout::{Size, Align, LayoutOf};
+use rustc::ty::layout::{Size, AbiAndPrefAlign, LayoutOf};
 use rustc::mir::interpret::{Scalar, Pointer, EvalResult, PointerArithmetic};
 
 use super::{EvalContext, Machine, MemoryKind};
@@ -101,7 +101,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
     pub fn read_size_and_align_from_vtable(
         &self,
         vtable: Pointer<M::PointerTag>,
-    ) -> EvalResult<'tcx, (Size, Align)> {
+    ) -> EvalResult<'tcx, (Size, AbiAndPrefAlign)> {
         let pointer_size = self.pointer_size();
         let pointer_align = self.tcx.data_layout.pointer_align;
         let size = self.memory.read_ptr_sized(vtable.offset(pointer_size, self)?,pointer_align)?
@@ -110,6 +110,6 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
             vtable.offset(pointer_size * 2, self)?,
             pointer_align
         )?.to_bits(pointer_size)? as u64;
-        Ok((Size::from_bytes(size), Align::from_bytes(align, align).unwrap()))
+        Ok((Size::from_bytes(size), AbiAndPrefAlign::from_bytes(align, align).unwrap()))
     }
 }

--- a/src/librustc_mir/interpret/validity.rs
+++ b/src/librustc_mir/interpret/validity.rs
@@ -13,7 +13,7 @@ use std::hash::Hash;
 use std::ops::RangeInclusive;
 
 use syntax_pos::symbol::Symbol;
-use rustc::ty::layout::{self, Size, Align, TyLayout, LayoutOf, VariantIdx};
+use rustc::ty::layout::{self, Size, AbiAndPrefAlign, TyLayout, LayoutOf, VariantIdx};
 use rustc::ty;
 use rustc_data_structures::fx::FxHashSet;
 use rustc::mir::interpret::{
@@ -355,7 +355,7 @@ impl<'rt, 'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>>
                     // for the purpose of validity, consider foreign types to have
                     // alignment and size determined by the layout (size will be 0,
                     // alignment should take attributes into account).
-                    .unwrap_or_else(|| layout.size_and_align());
+                    .unwrap_or_else(|| (layout.size, layout.align));
                 match self.ecx.memory.check_align(ptr, align) {
                     Ok(_) => {},
                     Err(err) => {
@@ -463,7 +463,7 @@ impl<'rt, 'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>>
                     // for function pointers.
                     let non_null =
                         self.ecx.memory.check_align(
-                            Scalar::Ptr(ptr), Align::from_bytes(1, 1).unwrap()
+                            Scalar::Ptr(ptr), AbiAndPrefAlign::from_bytes(1, 1).unwrap()
                         ).is_ok() ||
                         self.ecx.memory.get_fn(ptr).is_ok();
                     if !non_null {

--- a/src/librustc_mir/interpret/validity.rs
+++ b/src/librustc_mir/interpret/validity.rs
@@ -13,7 +13,7 @@ use std::hash::Hash;
 use std::ops::RangeInclusive;
 
 use syntax_pos::symbol::Symbol;
-use rustc::ty::layout::{self, Size, Align, AbiAndPrefAlign, TyLayout, LayoutOf, VariantIdx};
+use rustc::ty::layout::{self, Size, Align, TyLayout, LayoutOf, VariantIdx};
 use rustc::ty;
 use rustc_data_structures::fx::FxHashSet;
 use rustc::mir::interpret::{
@@ -355,7 +355,7 @@ impl<'rt, 'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>>
                     // for the purpose of validity, consider foreign types to have
                     // alignment and size determined by the layout (size will be 0,
                     // alignment should take attributes into account).
-                    .unwrap_or_else(|| (layout.size, layout.align));
+                    .unwrap_or_else(|| (layout.size, layout.align.abi));
                 match self.ecx.memory.check_align(ptr, align) {
                     Ok(_) => {},
                     Err(err) => {
@@ -463,7 +463,7 @@ impl<'rt, 'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>>
                     // for function pointers.
                     let non_null =
                         self.ecx.memory.check_align(
-                            Scalar::Ptr(ptr), AbiAndPrefAlign::new(Align::from_bytes(1).unwrap())
+                            Scalar::Ptr(ptr), Align::from_bytes(1).unwrap()
                         ).is_ok() ||
                         self.ecx.memory.get_fn(ptr).is_ok();
                     if !non_null {

--- a/src/librustc_mir/interpret/validity.rs
+++ b/src/librustc_mir/interpret/validity.rs
@@ -13,7 +13,7 @@ use std::hash::Hash;
 use std::ops::RangeInclusive;
 
 use syntax_pos::symbol::Symbol;
-use rustc::ty::layout::{self, Size, AbiAndPrefAlign, TyLayout, LayoutOf, VariantIdx};
+use rustc::ty::layout::{self, Size, Align, AbiAndPrefAlign, TyLayout, LayoutOf, VariantIdx};
 use rustc::ty;
 use rustc_data_structures::fx::FxHashSet;
 use rustc::mir::interpret::{
@@ -463,7 +463,7 @@ impl<'rt, 'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>>
                     // for function pointers.
                     let non_null =
                         self.ecx.memory.check_align(
-                            Scalar::Ptr(ptr), AbiAndPrefAlign::from_bytes(1, 1).unwrap()
+                            Scalar::Ptr(ptr), AbiAndPrefAlign::new(Align::from_bytes(1).unwrap())
                         ).is_ok() ||
                         self.ecx.memory.get_fn(ptr).is_ok();
                     if !non_null {

--- a/src/librustc_mir/util/alignment.rs
+++ b/src/librustc_mir/util/alignment.rs
@@ -30,7 +30,7 @@ pub fn is_disaligned<'a, 'tcx, L>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 
     let ty = place.ty(local_decls, tcx).to_ty(tcx);
     match tcx.layout_raw(param_env.and(ty)) {
-        Ok(layout) if layout.align.abi() == 1 => {
+        Ok(layout) if layout.align.abi.bytes() == 1 => {
             // if the alignment is 1, the type can't be further
             // disaligned.
             debug!("is_disaligned({:?}) - align = 1", place);

--- a/src/librustc_target/abi/call/arm.rs
+++ b/src/librustc_target/abi/call/arm.rs
@@ -93,7 +93,7 @@ fn classify_arg_ty<'a, Ty, C>(cx: &C, arg: &mut ArgType<'a, Ty>, vfp: bool)
         }
     }
 
-    let align = arg.layout.align.abi();
+    let align = arg.layout.align.abi.bytes();
     let total = arg.layout.size;
     arg.cast_to(Uniform {
         unit: if align <= 4 { Reg::i32() } else { Reg::i64() },

--- a/src/librustc_target/abi/call/mips.rs
+++ b/src/librustc_target/abi/call/mips.rs
@@ -27,21 +27,21 @@ fn classify_arg_ty<'a, Ty, C>(cx: &C, arg: &mut ArgType<Ty>, offset: &mut Size)
 {
     let dl = cx.data_layout();
     let size = arg.layout.size;
-    let align = arg.layout.align.max(dl.i32_align).min(dl.i64_align);
+    let align = arg.layout.align.max(dl.i32_align).min(dl.i64_align).abi;
 
     if arg.layout.is_aggregate() {
         arg.cast_to(Uniform {
             unit: Reg::i32(),
             total: size
         });
-        if !offset.is_abi_aligned(align) {
+        if !offset.is_aligned(align) {
             arg.pad_with(Reg::i32());
         }
     } else {
         arg.extend_integer_width_to(32);
     }
 
-    *offset = offset.abi_align(align) + size.abi_align(align);
+    *offset = offset.align_to(align) + size.align_to(align);
 }
 
 pub fn compute_abi_info<'a, Ty, C>(cx: &C, fty: &mut FnType<Ty>)

--- a/src/librustc_target/abi/call/mips64.rs
+++ b/src/librustc_target/abi/call/mips64.rs
@@ -118,9 +118,9 @@ fn classify_arg_ty<'a, Ty, C>(cx: &C, arg: &mut ArgType<'a, Ty>)
                 // We only care about aligned doubles
                 if let abi::Abi::Scalar(ref scalar) = field.abi {
                     if let abi::Float(abi::FloatTy::F64) = scalar.value {
-                        if offset.is_abi_aligned(dl.f64_align) {
+                        if offset.is_aligned(dl.f64_align.abi) {
                             // Insert enough integers to cover [last_offset, offset)
-                            assert!(last_offset.is_abi_aligned(dl.f64_align));
+                            assert!(last_offset.is_aligned(dl.f64_align.abi));
                             for _ in 0..((offset - last_offset).bits() / 64)
                                 .min((prefix.len() - prefix_index) as u64) {
 

--- a/src/librustc_target/abi/call/mod.rs
+++ b/src/librustc_target/abi/call/mod.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use abi::{self, Abi, AbiAndPrefAlign, FieldPlacement, Size};
+use abi::{self, Abi, Align, FieldPlacement, Size};
 use abi::{HasDataLayout, LayoutOf, TyLayout, TyLayoutMethods};
 use spec::HasTargetSpec;
 
@@ -80,7 +80,7 @@ mod attr_impl {
 pub struct ArgAttributes {
     pub regular: ArgAttribute,
     pub pointee_size: Size,
-    pub pointee_align: Option<AbiAndPrefAlign>
+    pub pointee_align: Option<Align>
 }
 
 impl ArgAttributes {
@@ -137,28 +137,28 @@ impl Reg {
 }
 
 impl Reg {
-    pub fn align<C: HasDataLayout>(&self, cx: &C) -> AbiAndPrefAlign {
+    pub fn align<C: HasDataLayout>(&self, cx: &C) -> Align {
         let dl = cx.data_layout();
         match self.kind {
             RegKind::Integer => {
                 match self.size.bits() {
-                    1 => dl.i1_align,
-                    2..=8 => dl.i8_align,
-                    9..=16 => dl.i16_align,
-                    17..=32 => dl.i32_align,
-                    33..=64 => dl.i64_align,
-                    65..=128 => dl.i128_align,
+                    1 => dl.i1_align.abi,
+                    2..=8 => dl.i8_align.abi,
+                    9..=16 => dl.i16_align.abi,
+                    17..=32 => dl.i32_align.abi,
+                    33..=64 => dl.i64_align.abi,
+                    65..=128 => dl.i128_align.abi,
                     _ => panic!("unsupported integer: {:?}", self)
                 }
             }
             RegKind::Float => {
                 match self.size.bits() {
-                    32 => dl.f32_align,
-                    64 => dl.f64_align,
+                    32 => dl.f32_align.abi,
+                    64 => dl.f64_align.abi,
                     _ => panic!("unsupported float: {:?}", self)
                 }
             }
-            RegKind::Vector => dl.vector_align(self.size)
+            RegKind::Vector => dl.vector_align(self.size).abi,
         }
     }
 }
@@ -188,7 +188,7 @@ impl From<Reg> for Uniform {
 }
 
 impl Uniform {
-    pub fn align<C: HasDataLayout>(&self, cx: &C) -> AbiAndPrefAlign {
+    pub fn align<C: HasDataLayout>(&self, cx: &C) -> Align {
         self.unit.align(cx)
     }
 }
@@ -227,13 +227,13 @@ impl CastTarget {
 
     pub fn size<C: HasDataLayout>(&self, cx: &C) -> Size {
         (self.prefix_chunk * self.prefix.iter().filter(|x| x.is_some()).count() as u64)
-             .abi_align(self.rest.align(cx)) + self.rest.total
+             .align_to(self.rest.align(cx)) + self.rest.total
     }
 
-    pub fn align<C: HasDataLayout>(&self, cx: &C) -> AbiAndPrefAlign {
+    pub fn align<C: HasDataLayout>(&self, cx: &C) -> Align {
         self.prefix.iter()
             .filter_map(|x| x.map(|kind| Reg { kind, size: self.prefix_chunk }.align(cx)))
-            .fold(cx.data_layout().aggregate_align.max(self.rest.align(cx)),
+            .fold(cx.data_layout().aggregate_align.abi.max(self.rest.align(cx)),
                 |acc, align| acc.max(align))
     }
 }
@@ -369,7 +369,7 @@ impl<'a, Ty> ArgType<'a, Ty> {
         attrs.pointee_size = self.layout.size;
         // FIXME(eddyb) We should be doing this, but at least on
         // i686-pc-windows-msvc, it results in wrong stack offsets.
-        // attrs.pointee_align = Some(self.layout.align);
+        // attrs.pointee_align = Some(self.layout.align.abi);
 
         let extra_attrs = if self.layout.is_unsized() {
             Some(ArgAttributes::new())

--- a/src/librustc_target/abi/call/mod.rs
+++ b/src/librustc_target/abi/call/mod.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use abi::{self, Abi, Align, FieldPlacement, Size};
+use abi::{self, Abi, AbiAndPrefAlign, FieldPlacement, Size};
 use abi::{HasDataLayout, LayoutOf, TyLayout, TyLayoutMethods};
 use spec::HasTargetSpec;
 
@@ -80,7 +80,7 @@ mod attr_impl {
 pub struct ArgAttributes {
     pub regular: ArgAttribute,
     pub pointee_size: Size,
-    pub pointee_align: Option<Align>
+    pub pointee_align: Option<AbiAndPrefAlign>
 }
 
 impl ArgAttributes {
@@ -137,7 +137,7 @@ impl Reg {
 }
 
 impl Reg {
-    pub fn align<C: HasDataLayout>(&self, cx: &C) -> Align {
+    pub fn align<C: HasDataLayout>(&self, cx: &C) -> AbiAndPrefAlign {
         let dl = cx.data_layout();
         match self.kind {
             RegKind::Integer => {
@@ -188,7 +188,7 @@ impl From<Reg> for Uniform {
 }
 
 impl Uniform {
-    pub fn align<C: HasDataLayout>(&self, cx: &C) -> Align {
+    pub fn align<C: HasDataLayout>(&self, cx: &C) -> AbiAndPrefAlign {
         self.unit.align(cx)
     }
 }
@@ -230,7 +230,7 @@ impl CastTarget {
              .abi_align(self.rest.align(cx)) + self.rest.total
     }
 
-    pub fn align<C: HasDataLayout>(&self, cx: &C) -> Align {
+    pub fn align<C: HasDataLayout>(&self, cx: &C) -> AbiAndPrefAlign {
         self.prefix.iter()
             .filter_map(|x| x.map(|kind| Reg { kind, size: self.prefix_chunk }.align(cx)))
             .fold(cx.data_layout().aggregate_align.max(self.rest.align(cx)),

--- a/src/librustc_target/abi/call/powerpc.rs
+++ b/src/librustc_target/abi/call/powerpc.rs
@@ -27,21 +27,21 @@ fn classify_arg_ty<'a, Ty, C>(cx: &C, arg: &mut ArgType<Ty>, offset: &mut Size)
 {
     let dl = cx.data_layout();
     let size = arg.layout.size;
-    let align = arg.layout.align.max(dl.i32_align).min(dl.i64_align);
+    let align = arg.layout.align.max(dl.i32_align).min(dl.i64_align).abi;
 
     if arg.layout.is_aggregate() {
         arg.cast_to(Uniform {
             unit: Reg::i32(),
             total: size
         });
-        if !offset.is_abi_aligned(align) {
+        if !offset.is_aligned(align) {
             arg.pad_with(Reg::i32());
         }
     } else {
         arg.extend_integer_width_to(32);
     }
 
-    *offset = offset.abi_align(align) + size.abi_align(align);
+    *offset = offset.align_to(align) + size.align_to(align);
 }
 
 pub fn compute_abi_info<'a, Ty, C>(cx: &C, fty: &mut FnType<Ty>)

--- a/src/librustc_target/abi/call/powerpc64.rs
+++ b/src/librustc_target/abi/call/powerpc64.rs
@@ -13,7 +13,7 @@
 // need to be fixed when PowerPC vector support is added.
 
 use abi::call::{FnType, ArgType, Reg, RegKind, Uniform};
-use abi::{AbiAndPrefAlign, Endian, HasDataLayout, LayoutOf, TyLayout, TyLayoutMethods};
+use abi::{Endian, HasDataLayout, LayoutOf, TyLayout, TyLayoutMethods};
 use spec::HasTargetSpec;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -120,8 +120,8 @@ fn classify_arg_ty<'a, Ty, C>(cx: &C, arg: &mut ArgType<'a, Ty>, abi: ABI)
     } else {
         // Aggregates larger than a doubleword should be padded
         // at the tail to fill out a whole number of doublewords.
-        let align = AbiAndPrefAlign::from_bits(64, 64).unwrap();
-        (Reg::i64(), size.abi_align(align))
+        let reg_i64 = Reg::i64();
+        (reg_i64, size.abi_align(reg_i64.align(cx)))
     };
 
     arg.cast_to(Uniform {

--- a/src/librustc_target/abi/call/powerpc64.rs
+++ b/src/librustc_target/abi/call/powerpc64.rs
@@ -121,7 +121,7 @@ fn classify_arg_ty<'a, Ty, C>(cx: &C, arg: &mut ArgType<'a, Ty>, abi: ABI)
         // Aggregates larger than a doubleword should be padded
         // at the tail to fill out a whole number of doublewords.
         let reg_i64 = Reg::i64();
-        (reg_i64, size.abi_align(reg_i64.align(cx)))
+        (reg_i64, size.align_to(reg_i64.align(cx)))
     };
 
     arg.cast_to(Uniform {

--- a/src/librustc_target/abi/call/powerpc64.rs
+++ b/src/librustc_target/abi/call/powerpc64.rs
@@ -13,7 +13,7 @@
 // need to be fixed when PowerPC vector support is added.
 
 use abi::call::{FnType, ArgType, Reg, RegKind, Uniform};
-use abi::{Align, Endian, HasDataLayout, LayoutOf, TyLayout, TyLayoutMethods};
+use abi::{AbiAndPrefAlign, Endian, HasDataLayout, LayoutOf, TyLayout, TyLayoutMethods};
 use spec::HasTargetSpec;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -120,7 +120,7 @@ fn classify_arg_ty<'a, Ty, C>(cx: &C, arg: &mut ArgType<'a, Ty>, abi: ABI)
     } else {
         // Aggregates larger than a doubleword should be padded
         // at the tail to fill out a whole number of doublewords.
-        let align = Align::from_bits(64, 64).unwrap();
+        let align = AbiAndPrefAlign::from_bits(64, 64).unwrap();
         (Reg::i64(), size.abi_align(align))
     };
 

--- a/src/librustc_target/abi/call/sparc.rs
+++ b/src/librustc_target/abi/call/sparc.rs
@@ -27,21 +27,21 @@ fn classify_arg_ty<'a, Ty, C>(cx: &C, arg: &mut ArgType<Ty>, offset: &mut Size)
 {
     let dl = cx.data_layout();
     let size = arg.layout.size;
-    let align = arg.layout.align.max(dl.i32_align).min(dl.i64_align);
+    let align = arg.layout.align.max(dl.i32_align).min(dl.i64_align).abi;
 
     if arg.layout.is_aggregate() {
         arg.cast_to(Uniform {
             unit: Reg::i32(),
             total: size
         });
-        if !offset.is_abi_aligned(align) {
+        if !offset.is_aligned(align) {
             arg.pad_with(Reg::i32());
         }
     } else {
         arg.extend_integer_width_to(32);
     }
 
-    *offset = offset.abi_align(align) + size.abi_align(align);
+    *offset = offset.align_to(align) + size.align_to(align);
 }
 
 pub fn compute_abi_info<'a, Ty, C>(cx: &C, fty: &mut FnType<Ty>)

--- a/src/librustc_target/abi/call/x86_64.rs
+++ b/src/librustc_target/abi/call/x86_64.rs
@@ -41,7 +41,7 @@ fn classify_arg<'a, Ty, C>(cx: &C, arg: &ArgType<'a, Ty>)
         where Ty: TyLayoutMethods<'a, C> + Copy,
             C: LayoutOf<Ty = Ty, TyLayout = TyLayout<'a, Ty>> + HasDataLayout
     {
-        if !off.is_abi_aligned(layout.align) {
+        if !off.is_aligned(layout.align.abi) {
             if !layout.is_zst() {
                 return Err(Memory);
             }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1779,7 +1779,7 @@ fn check_transparent<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, sp: Span, def_id: De
         // We are currently checking the type this field came from, so it must be local
         let span = tcx.hir.span_if_local(field.did).unwrap();
         let zst = layout.map(|layout| layout.is_zst()).unwrap_or(false);
-        let align1 = layout.map(|layout| layout.align.abi() == 1).unwrap_or(false);
+        let align1 = layout.map(|layout| layout.align.abi.bytes() == 1).unwrap_or(false);
         (span, zst, align1)
     });
 


### PR DESCRIPTION
Before this PR, `rustc_target::abi::Align` combined "power-of-two alignment quantity" semantics, with a distinction between ABI (required) and preferred alignment (by having two quantities).

After this PR, `Align` is only *one* such quantity, and a new `AbiAndPrefAlign` type is introduced to hold the pair of ABI and preferred `Align` quantities.

`Align` is used everywhere one quantity is necessary/sufficient, simplifying some of the code in codegen/miri, while `AbiAndPrefAlign` only in layout computation (to propagate preferred alignment).

r? @oli-obk cc @nagisa @RalfJung @nikomatsakis 