### PR TITLE
docs: Use dollar sign for all bash prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,9 @@ you have a more recent version installed the build system doesn't understand
 then you may need to force rustbuild to use an older version. This can be done
 by manually calling the appropriate vcvars file before running the bootstrap.
 
-```
-CALL "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat"
-python x.py build
+```batch
+> CALL "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat"
+> python x.py build
 ```
 
 #### Specifying an ABI

--- a/src/bootstrap/README.md
+++ b/src/bootstrap/README.md
@@ -8,14 +8,14 @@ system.
 
 The rustbuild build system has a primary entry point, a top level `x.py` script:
 
-```
-python ./x.py build
+```sh
+$ python ./x.py build
 ```
 
 Note that if you're on Unix you should be able to execute the script directly:
 
-```
-./x.py build
+```sh
+$ ./x.py build
 ```
 
 The script accepts commands, flags, and arguments to determine what to do:
@@ -129,18 +129,18 @@ To follow this course of action, first thing you will want to do is to
 install a nightly, presumably using `rustup`. You will then want to
 configure your directory to use this build, like so:
 
-```
+```sh
 # configure to use local rust instead of downloading a beta.
 # `--local-rust-root` is optional here. If elided, we will
 # use whatever rustc we find on your PATH.
-> ./configure --local-rust-root=~/.cargo/ --enable-local-rebuild
+$ ./configure --local-rust-root=~/.cargo/ --enable-local-rebuild
 ```
 
 After that, you can use the `--incremental` flag to actually do
 incremental builds:
 
-```
-> ./x.py build --incremental
+```sh
+$ ./x.py build --incremental
 ```
 
 The `--incremental` flag will store incremental compilation artifacts
@@ -159,7 +159,7 @@ will still be using the local nightly as your bootstrap).
 This build system houses all output under the `build` directory, which looks
 like this:
 
-```
+```sh
 # Root folder of all output. Everything is scoped underneath here
 build/
 

--- a/src/doc/rustc/src/lints/index.md
+++ b/src/doc/rustc/src/lints/index.md
@@ -12,7 +12,7 @@ $ cat main.rs
 fn main() {
     let x = 5;
 }
-> rustc main.rs
+$ rustc main.rs
 warning: unused variable: `x`
  --> main.rs:2:9
   |

--- a/src/doc/rustc/src/lints/levels.md
+++ b/src/doc/rustc/src/lints/levels.md
@@ -45,7 +45,7 @@ pub fn foo() {
 
 This will produce this warning:
 
-```console
+```bash
 $ rustc lib.rs --crate-type=lib
 warning: unused variable: `x`
  --> lib.rs:2:9
@@ -69,7 +69,7 @@ fn main() {
 ```
 
 ```bash
-> rustc main.rs
+$ rustc main.rs
 error: bitshift exceeds the type's number of bits
  --> main.rs:2:13
   |
@@ -129,7 +129,10 @@ warning: missing documentation for a function
   |
 1 | pub fn foo() {}
   | ^^^^^^^^^^^^
-> rustc lib.rs --crate-type=lib -D missing-docs
+```
+
+```bash
+$ rustc lib.rs --crate-type=lib -D missing-docs
 error: missing documentation for crate
  --> lib.rs:1:1
   |
@@ -150,13 +153,13 @@ error: aborting due to 2 previous errors
 You can also pass each flag more than once for changing multiple lints:
 
 ```bash
-rustc lib.rs --crate-type=lib -D missing-docs -D unused-variables
+$ rustc lib.rs --crate-type=lib -D missing-docs -D unused-variables
 ```
 
 And of course, you can mix these four flags together:
 
 ```bash
-rustc lib.rs --crate-type=lib -D missing-docs -A unused-variables
+$ rustc lib.rs --crate-type=lib -D missing-docs -A unused-variables
 ```
 
 ### Via an attribute
@@ -164,7 +167,7 @@ rustc lib.rs --crate-type=lib -D missing-docs -A unused-variables
 You can also modify the lint level with a crate-wide attribute:
 
 ```bash
-> cat lib.rs
+$ cat lib.rs
 #![warn(missing_docs)]
 
 pub fn foo() {}


### PR DESCRIPTION
Making it consistent across the board, as most of them already use `$`.

Also split one continues bash run into two, to make it easier see
different runs: one with warning and another with error.