### PR TITLE
miri loop detector hashing

### DIFF
--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -239,6 +239,7 @@ impl<'mir, 'tcx> interpret::Machine<'mir, 'tcx> for CompileTimeEvaluator {
     type MemoryKinds = !;
 
     const MUT_STATIC_KIND: Option<!> = None; // no mutating of statics allowed
+    const DETECT_LOOPS: bool = true;
 
     fn find_fn<'a>(
         ecx: &mut EvalContext<'a, 'mir, 'tcx, Self>,

--- a/src/librustc_mir/interpret/machine.rs
+++ b/src/librustc_mir/interpret/machine.rs
@@ -12,28 +12,28 @@
 //! This separation exists to ensure that no fancy miri features like
 //! interpreting common C functions leak into CTFE.
 
-use std::hash::Hash;
-
 use rustc::hir::def_id::DefId;
-use rustc::ich::StableHashingContext;
 use rustc::mir::interpret::{Allocation, EvalResult, Scalar};
 use rustc::mir;
 use rustc::ty::{self, layout::TyLayout, query::TyCtxtAt};
-use rustc_data_structures::stable_hasher::HashStable;
 
 use super::{EvalContext, PlaceTy, OpTy};
 
 /// Methods of this trait signifies a point where CTFE evaluation would fail
 /// and some use case dependent behaviour can instead be applied
-pub trait Machine<'mir, 'tcx>: Clone + Eq + Hash + for<'a> HashStable<StableHashingContext<'a>> {
+pub trait Machine<'mir, 'tcx>: Clone + Eq {
     /// Additional data that can be accessed via the Memory
-    type MemoryData: Clone + Eq + Hash + for<'a> HashStable<StableHashingContext<'a>>;
+    type MemoryData: Clone + Eq;
 
     /// Additional memory kinds a machine wishes to distinguish from the builtin ones
-    type MemoryKinds: ::std::fmt::Debug + Copy + Clone + Eq + Hash;
+    type MemoryKinds: ::std::fmt::Debug + Copy + Clone + Eq;
 
     /// The memory kind to use for mutated statics -- or None if those are not supported.
     const MUT_STATIC_KIND: Option<Self::MemoryKinds>;
+
+    /// Whether to attempt to detect infinite loops (any kind of infinite
+    /// execution, really).
+    const DETECT_LOOPS: bool;
 
     /// Entry point to all function calls.
     ///

--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -13,6 +13,7 @@
 //! All high-level functions to write to memory work on places as destinations.
 
 use std::convert::TryFrom;
+use std::mem;
 
 use rustc::ich::StableHashingContext;
 use rustc::mir;
@@ -57,11 +58,13 @@ pub enum Place<Id=AllocId> {
     },
 }
 
+// Can't use the macro here because that does not support named enum fields.
 impl<'a> HashStable<StableHashingContext<'a>> for Place {
     fn hash_stable<W: StableHasherResult>(
         &self, hcx: &mut StableHashingContext<'a>,
-        hasher: &mut StableHasher<W>) {
-
+        hasher: &mut StableHasher<W>)
+    {
+        mem::discriminant(self).hash_stable(hcx, hasher);
         match self {
             Place::Ptr(mem_place) => mem_place.hash_stable(hcx, hasher),
 

--- a/src/librustc_mir/interpret/step.rs
+++ b/src/librustc_mir/interpret/step.rs
@@ -65,6 +65,10 @@ impl<'a, 'mir, 'tcx, M: Machine<'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> {
             }
         }
 
+        if !M::DETECT_LOOPS {
+            return Ok(());
+        }
+
         if self.loop_detector.is_empty() {
             // First run of the loop detector
 
@@ -75,7 +79,6 @@ impl<'a, 'mir, 'tcx, M: Machine<'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> {
 
         self.loop_detector.observe_and_analyze(
             &self.tcx,
-            &self.machine,
             &self.memory,
             &self.stack[..],
         )


### PR DESCRIPTION
* fix enum hashing to also consider discriminant
* do not hash extra machine state
* standalone miri is not interested in loop detection, so let it opt-out

In the future I think we want to move the hashing logic out of the miri engine, this is CTFE-only.

r? @oli-obk 