### PR TITLE
resolve: Future proof derive helper attributes

### DIFF
--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -398,12 +398,12 @@ impl<'a, 'tcx, 'rcx, 'cstore> DocFolder for LinkCollector<'a, 'tcx, 'rcx, 'cstor
 /// Resolve a string as a macro
 fn macro_resolve(cx: &DocContext, path_str: &str) -> Option<Def> {
     use syntax::ext::base::{MacroKind, SyntaxExtension};
-    use syntax::ext::hygiene::Mark;
     let segment = ast::PathSegment::from_ident(Ident::from_str(path_str));
     let path = ast::Path { segments: vec![segment], span: DUMMY_SP };
     let mut resolver = cx.resolver.borrow_mut();
-    let mark = Mark::root();
-    if let Ok(def) = resolver.resolve_macro_to_def_inner(&path, MacroKind::Bang, mark, &[], false) {
+    let parent_scope = resolver.dummy_parent_scope();
+    if let Ok(def) = resolver.resolve_macro_to_def_inner(&path, MacroKind::Bang,
+                                                         &parent_scope, false) {
         if let SyntaxExtension::DeclMacro { .. } = *resolver.get_macro(def) {
             return Some(def);
         }

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -730,7 +730,7 @@ pub trait Resolver {
     fn resolve_macro_invocation(&mut self, invoc: &Invocation, invoc_id: Mark, force: bool)
                                 -> Result<Option<Lrc<SyntaxExtension>>, Determinacy>;
     fn resolve_macro_path(&mut self, path: &ast::Path, kind: MacroKind, invoc_id: Mark,
-                          derives_in_scope: &[ast::Path], force: bool)
+                          derives_in_scope: Vec<ast::Path>, force: bool)
                           -> Result<Lrc<SyntaxExtension>, Determinacy>;
 
     fn check_unused_macros(&self);
@@ -768,7 +768,7 @@ impl Resolver for DummyResolver {
         Err(Determinacy::Determined)
     }
     fn resolve_macro_path(&mut self, _path: &ast::Path, _kind: MacroKind, _invoc_id: Mark,
-                          _derives_in_scope: &[ast::Path], _force: bool)
+                          _derives_in_scope: Vec<ast::Path>, _force: bool)
                           -> Result<Lrc<SyntaxExtension>, Determinacy> {
         Err(Determinacy::Determined)
     }

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -384,7 +384,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                         let mark = Mark::fresh(self.cx.current_expansion.mark);
                         derives.push(mark);
                         let item = match self.cx.resolver.resolve_macro_path(
-                                path, MacroKind::Derive, Mark::root(), &[], false) {
+                                path, MacroKind::Derive, Mark::root(), Vec::new(), false) {
                             Ok(ext) => match *ext {
                                 BuiltinDerive(..) => item_with_markers.clone(),
                                 _ => item.clone(),

--- a/src/test/ui-fulldeps/proc-macro/auxiliary/derive-helper-shadowing.rs
+++ b/src/test/ui-fulldeps/proc-macro/auxiliary/derive-helper-shadowing.rs
@@ -1,0 +1,16 @@
+// no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+use proc_macro::*;
+
+#[proc_macro_attribute]
+pub fn my_attr(_: TokenStream, input: TokenStream) -> TokenStream {
+    input
+}
+
+#[proc_macro_derive(MyTrait, attributes(my_attr))]
+pub fn derive(input: TokenStream) -> TokenStream {
+    TokenStream::new()
+}

--- a/src/test/ui-fulldeps/proc-macro/auxiliary/issue-53481.rs
+++ b/src/test/ui-fulldeps/proc-macro/auxiliary/issue-53481.rs
@@ -1,0 +1,12 @@
+// no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+
+use proc_macro::*;
+
+#[proc_macro_derive(MyTrait, attributes(my_attr))]
+pub fn foo(_: TokenStream) -> TokenStream {
+    TokenStream::new()
+}

--- a/src/test/ui-fulldeps/proc-macro/derive-helper-shadowing.rs
+++ b/src/test/ui-fulldeps/proc-macro/derive-helper-shadowing.rs
@@ -1,0 +1,10 @@
+// aux-build:derive-helper-shadowing.rs
+
+extern crate derive_helper_shadowing;
+use derive_helper_shadowing::*;
+
+#[derive(MyTrait)]
+#[my_attr] //~ ERROR `my_attr` is ambiguous
+struct S;
+
+fn main() {}

--- a/src/test/ui-fulldeps/proc-macro/derive-helper-shadowing.stderr
+++ b/src/test/ui-fulldeps/proc-macro/derive-helper-shadowing.stderr
@@ -1,0 +1,21 @@
+error[E0659]: `my_attr` is ambiguous
+  --> $DIR/derive-helper-shadowing.rs:7:3
+   |
+LL | #[my_attr] //~ ERROR `my_attr` is ambiguous
+   |   ^^^^^^^ ambiguous name
+   |
+note: `my_attr` could refer to the name imported here
+  --> $DIR/derive-helper-shadowing.rs:4:5
+   |
+LL | use derive_helper_shadowing::*;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: `my_attr` could also refer to the name defined here
+  --> $DIR/derive-helper-shadowing.rs:6:10
+   |
+LL | #[derive(MyTrait)]
+   |          ^^^^^^^
+   = note: consider adding an explicit import of `my_attr` to disambiguate
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0659`.

--- a/src/test/ui-fulldeps/proc-macro/issue-53481.rs
+++ b/src/test/ui-fulldeps/proc-macro/issue-53481.rs
@@ -1,0 +1,22 @@
+// compile-pass
+// aux-build:issue-53481.rs
+
+#[macro_use]
+extern crate issue_53481;
+
+mod m1 {
+    use m2::MyTrait;
+
+    #[derive(MyTrait)]
+    struct A {}
+}
+
+mod m2 {
+    pub type MyTrait = u8;
+
+    #[derive(MyTrait)]
+    #[my_attr]
+    struct B {}
+}
+
+fn main() {}


### PR DESCRIPTION
Derive helpers no longer require going through recovery mode (fixes https://github.com/rust-lang/rust/issues/53481).
They also report an error if they are ambiguous with any other macro in scope, so we can resolve the question about their exact priority sometime later (cc https://github.com/rust-lang/rust/issues/52226).