### PR TITLE
rustdoc: Remove generated blanket impls from trait pages

### DIFF
--- a/src/test/rustdoc/auxiliary/issue-53689.rs
+++ b/src/test/rustdoc/auxiliary/issue-53689.rs
@@ -1,0 +1,11 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub struct MyStruct;

--- a/src/test/rustdoc/issue-53689.rs
+++ b/src/test/rustdoc/issue-53689.rs
@@ -1,0 +1,26 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:issue-53689.rs
+
+#![crate_name = "foo"]
+
+extern crate issue_53689;
+
+// @has foo/trait.MyTrait.html
+// @!has - 'MyStruct'
+// @count - '//*[code="impl<T> MyTrait for T"]' 1
+pub trait MyTrait {}
+
+impl<T> MyTrait for T {}
+
+mod a {
+    pub use issue_53689::MyStruct;
+}


### PR DESCRIPTION
#53801 only deduped the generated blanket impls but they shouldn't be displayed at all because the original blanket impl is already in the "Implementors" section. This also removes the impls from the sidebar.

Fixes #53689 

r? @QuietMisdreavus