### PR TITLE
[NLL] Suggest let binding 

### DIFF
--- a/src/test/ui/borrowck/borrowck-borrowed-uniq-rvalue-2.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-borrowed-uniq-rvalue-2.nll.stderr
@@ -8,6 +8,7 @@ LL |     let x = defer(&vec!["Goodbye", "world!"]);
 LL |     x.x[0];
    |     ------ borrow later used here
    |
+   = note: consider using a `let` binding to create a longer lived value
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/borrowck/borrowck-borrowed-uniq-rvalue.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-borrowed-uniq-rvalue.nll.stderr
@@ -8,6 +8,8 @@ LL |     buggy_map.insert(42, &*Box::new(1)); //~ ERROR borrowed value does not 
 ...
 LL |     buggy_map.insert(43, &*tmp);
    |     --------- borrow later used here
+   |
+   = note: consider using a `let` binding to create a longer lived value
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-36082.ast.nll.stderr
+++ b/src/test/ui/issues/issue-36082.ast.nll.stderr
@@ -8,6 +8,8 @@ LL |     let val: &_ = x.borrow().0;
 ...
 LL |     println!("{}", val);
    |                    --- borrow later used here
+   |
+   = note: consider using a `let` binding to create a longer lived value
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-36082.mir.stderr
+++ b/src/test/ui/issues/issue-36082.mir.stderr
@@ -8,6 +8,8 @@ LL |     let val: &_ = x.borrow().0;
 ...
 LL |     println!("{}", val);
    |                    --- borrow later used here
+   |
+   = note: consider using a `let` binding to create a longer lived value
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-36082.rs
+++ b/src/test/ui/issues/issue-36082.rs
@@ -28,6 +28,7 @@ fn main() {
     //[mir]~^^^^^ ERROR borrowed value does not live long enough [E0597]
     //[mir]~| NOTE temporary value does not live long enough
     //[mir]~| NOTE temporary value only lives until here
+    //[mir]~| NOTE consider using a `let` binding to create a longer lived value
     println!("{}", val);
     //[mir]~^ borrow later used here
 }

--- a/src/test/ui/lifetimes/borrowck-let-suggestion.nll.stderr
+++ b/src/test/ui/lifetimes/borrowck-let-suggestion.nll.stderr
@@ -9,6 +9,7 @@ LL |     //~^ ERROR borrowed value does not live long enough
 LL |     x.use_mut();
    |     - borrow later used here
    |
+   = note: consider using a `let` binding to create a longer lived value
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/nll/borrowed-temporary-error.stderr
+++ b/src/test/ui/nll/borrowed-temporary-error.stderr
@@ -8,6 +8,8 @@ LL |     });
    |       - temporary value only lives until here
 LL |     println!("{:?}", x);
    |                      - borrow later used here
+   |
+   = note: consider using a `let` binding to create a longer lived value
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-var-type-out-of-scope.nll.stderr
+++ b/src/test/ui/regions/regions-var-type-out-of-scope.nll.stderr
@@ -8,6 +8,7 @@ LL |         x = &id(3); //~ ERROR borrowed value does not live long enough
 LL |         assert_eq!(*x, 3);
    |         ------------------ borrow later used here
    |
+   = note: consider using a `let` binding to create a longer lived value
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/span/borrowck-let-suggestion-suffixes.nll.stderr
+++ b/src/test/ui/span/borrowck-let-suggestion-suffixes.nll.stderr
@@ -8,6 +8,8 @@ LL |     v3.push(&id('x'));           // statement 6
 ...
 LL |     (v1, v2, v3, /* v4 is above. */ v5).use_ref();
    |              -- borrow later used here
+   |
+   = note: consider using a `let` binding to create a longer lived value
 
 error[E0597]: borrowed value does not live long enough
   --> $DIR/borrowck-let-suggestion-suffixes.rs:38:18
@@ -19,6 +21,8 @@ LL |         v4.push(&id('y'));
 ...
 LL |         v4.use_ref();
    |         -- borrow later used here
+   |
+   = note: consider using a `let` binding to create a longer lived value
 
 error[E0597]: borrowed value does not live long enough
   --> $DIR/borrowck-let-suggestion-suffixes.rs:49:14
@@ -30,6 +34,8 @@ LL |     v5.push(&id('z'));
 ...
 LL |     (v1, v2, v3, /* v4 is above. */ v5).use_ref();
    |                                     -- borrow later used here
+   |
+   = note: consider using a `let` binding to create a longer lived value
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/span/borrowck-ref-into-rvalue.nll.stderr
+++ b/src/test/ui/span/borrowck-ref-into-rvalue.nll.stderr
@@ -8,6 +8,8 @@ LL |     }
    |     - temporary value only lives until here
 LL |     println!("{}", *msg);
    |                    ---- borrow later used here
+   |
+   = note: consider using a `let` binding to create a longer lived value
 
 error: aborting due to previous error
 

--- a/src/test/ui/span/issue-15480.nll.stderr
+++ b/src/test/ui/span/issue-15480.nll.stderr
@@ -8,6 +8,8 @@ LL |     ];
 ...
 LL |     for &&x in &v {
    |                -- borrow later used here
+   |
+   = note: consider using a `let` binding to create a longer lived value
 
 error: aborting due to previous error
 

--- a/src/test/ui/span/regions-close-over-borrowed-ref-in-obj.nll.stderr
+++ b/src/test/ui/span/regions-close-over-borrowed-ref-in-obj.nll.stderr
@@ -8,6 +8,8 @@ LL |     }
    |     - temporary value only lives until here
 LL | }
    | - borrow later used here, when `blah` is dropped
+   |
+   = note: consider using a `let` binding to create a longer lived value
 
 error: aborting due to previous error
 

--- a/src/test/ui/span/slice-borrow.nll.stderr
+++ b/src/test/ui/span/slice-borrow.nll.stderr
@@ -9,6 +9,7 @@ LL |     }
 LL |     y.use_ref();
    |     - borrow later used here
    |
+   = note: consider using a `let` binding to create a longer lived value
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to previous error


### PR DESCRIPTION
Closes #49821

Also adds an alternative to `explain_why_borrow_contains_point` that allows changing error messages based on the reason that will be given. This will also be useful for #51026, #51169 and maybe further changes to does not live long enough messages.
