### PR TITLE
[WIP]  rustc_typeck: ensure type alias bounds are implied by the type being well-formed.

### DIFF
--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -135,7 +135,8 @@ pub fn check_item_well_formed<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: Def
             let generics = tcx.generics_of(def_id);
             let used_params = super::check_params_are_used(tcx, &generics, item_ty);
             for_item(tcx, item).with_fcx(|fcx, _this| {
-                let item_ty = fcx.normalize_associated_types_in(item.span, &item_ty);
+                // HACK(eddyb) Commented out to not require trait bounds for projections.
+                // let item_ty = fcx.normalize_associated_types_in(item.span, &item_ty);
 
                 // Check the user-declared bounds, assuming the type is WF.
                 // This ensures that by checking the WF of the aliased type, where
@@ -172,7 +173,8 @@ pub fn check_item_well_formed<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: Def
                     }));
                 }
 
-                vec![item_ty]
+                // HACK(eddyb) Commented out to not require trait bounds for projections.
+                vec![/*item_ty*/]
             });
         }
         hir::ItemKind::Struct(ref struct_def, ref ast_generics) => {

--- a/src/test/incremental/hashes/type_defs.rs
+++ b/src/test/incremental/hashes/type_defs.rs
@@ -132,12 +132,12 @@ type ChangeNestedTupleField = (i32, (i64, i8));
 
 // Add type param --------------------------------------------------------------
 #[cfg(cfail1)]
-type AddTypeParam<T1> = (T1, T1);
+type AddTypeParam<T1> = (T1, Option<T1>);
 
 #[cfg(not(cfail1))]
 #[rustc_clean(cfg="cfail2", except="Hir,HirBody")]
 #[rustc_clean(cfg="cfail3")]
-type AddTypeParam<T1, T2> = (T1, T2);
+type AddTypeParam<T1, T2> = (T1, Option<T2>);
 
 
 
@@ -148,18 +148,18 @@ type AddTypeParamBound<T1> = (T1, u32);
 #[cfg(not(cfail1))]
 #[rustc_clean(cfg="cfail2", except="Hir,HirBody")]
 #[rustc_clean(cfg="cfail3")]
-type AddTypeParamBound<T1: Clone> = (T1, u32);
+type AddTypeParamBound<T1: std::any::Any> = (T1, u32);
 
 
 
 // Add type param bound in where clause ----------------------------------------
 #[cfg(cfail1)]
-type AddTypeParamBoundWhereClause<T1> where T1: Clone = (T1, u32);
+type AddTypeParamBoundWhereClause<T1> where T1: Sized = (T1, u32);
 
 #[cfg(not(cfail1))]
 #[rustc_clean(cfg="cfail2", except="Hir,HirBody")]
 #[rustc_clean(cfg="cfail3")]
-type AddTypeParamBoundWhereClause<T1> where T1: Clone+Copy = (T1, u32);
+type AddTypeParamBoundWhereClause<T1> where T1: Sized+std::any::Any = (T1, u32);
 
 
 
@@ -203,7 +203,9 @@ where 'b: 'a,
 
 // Change Trait Bound Indirectly -----------------------------------------------
 trait ReferencedTrait1 {}
+impl<T> ReferencedTrait1 for T {}
 trait ReferencedTrait2 {}
+impl<T> ReferencedTrait2 for T {}
 
 mod change_trait_bound_indirectly {
     #[cfg(cfail1)]

--- a/src/test/run-pass/attr-on-generic-formals.rs
+++ b/src/test/run-pass/attr-on-generic-formals.rs
@@ -30,7 +30,7 @@ trait TrLt<#[rustc_lt_trait] 'c> { fn foo(&self, _: &'c [u32]) -> &'c u32; }
 trait TrTy<#[rustc_ty_trait] K> { fn foo(&self, _: K); }
 
 type TyLt<#[rustc_lt_type] 'd> = &'d u32;
-type TyTy<#[rustc_ty_type] L> = (L, );
+type TyTy<#[rustc_ty_type] L> = Option<L>;
 
 impl<#[rustc_lt_inherent] 'e> StLt<'e> { }
 impl<#[rustc_ty_inherent] M> StTy<M> { }

--- a/src/test/run-pass/type-param.rs
+++ b/src/test/run-pass/type-param.rs
@@ -12,6 +12,6 @@
 
 // pretty-expanded FIXME #23616
 
-type lteq<T> = extern fn(T) -> bool;
+type lteq<T: ?Sized> = extern fn(T) -> bool;
 
 pub fn main() { }

--- a/src/test/ui/consts/const-eval/pub_const_err.stderr
+++ b/src/test/ui/consts/const-eval/pub_const_err.stderr
@@ -1,10 +1,8 @@
-warning: this constant cannot be used
-  --> $DIR/pub_const_err.rs:16:1
+warning: attempt to subtract with overflow
+  --> $DIR/pub_const_err.rs:19:22
    |
-LL | pub const Z: u32 = 0 - 1;
-   | ^^^^^^^^^^^^^^^^^^^-----^
-   |                    |
-   |                    attempt to subtract with overflow
+LL | pub type Foo = [i32; 0 - 1];
+   |                      ^^^^^
    |
 note: lint level defined here
   --> $DIR/pub_const_err.rs:12:9
@@ -12,11 +10,13 @@ note: lint level defined here
 LL | #![warn(const_err)]
    |         ^^^^^^^^^
 
-warning: attempt to subtract with overflow
-  --> $DIR/pub_const_err.rs:19:22
+warning: this constant cannot be used
+  --> $DIR/pub_const_err.rs:16:1
    |
-LL | pub type Foo = [i32; 0 - 1];
-   |                      ^^^^^
+LL | pub const Z: u32 = 0 - 1;
+   | ^^^^^^^^^^^^^^^^^^^-----^
+   |                    |
+   |                    attempt to subtract with overflow
 
 warning: this array length cannot be used
   --> $DIR/pub_const_err.rs:19:22

--- a/src/test/ui/consts/const-eval/pub_const_err.stderr
+++ b/src/test/ui/consts/const-eval/pub_const_err.stderr
@@ -1,15 +1,3 @@
-warning: attempt to subtract with overflow
-  --> $DIR/pub_const_err.rs:19:22
-   |
-LL | pub type Foo = [i32; 0 - 1];
-   |                      ^^^^^
-   |
-note: lint level defined here
-  --> $DIR/pub_const_err.rs:12:9
-   |
-LL | #![warn(const_err)]
-   |         ^^^^^^^^^
-
 warning: this constant cannot be used
   --> $DIR/pub_const_err.rs:16:1
    |
@@ -17,6 +5,18 @@ LL | pub const Z: u32 = 0 - 1;
    | ^^^^^^^^^^^^^^^^^^^-----^
    |                    |
    |                    attempt to subtract with overflow
+   |
+note: lint level defined here
+  --> $DIR/pub_const_err.rs:12:9
+   |
+LL | #![warn(const_err)]
+   |         ^^^^^^^^^
+
+warning: attempt to subtract with overflow
+  --> $DIR/pub_const_err.rs:19:22
+   |
+LL | pub type Foo = [i32; 0 - 1];
+   |                      ^^^^^
 
 warning: this array length cannot be used
   --> $DIR/pub_const_err.rs:19:22

--- a/src/test/ui/consts/const-eval/pub_const_err_bin.stderr
+++ b/src/test/ui/consts/const-eval/pub_const_err_bin.stderr
@@ -1,15 +1,3 @@
-warning: attempt to subtract with overflow
-  --> $DIR/pub_const_err_bin.rs:17:22
-   |
-LL | pub type Foo = [i32; 0 - 1];
-   |                      ^^^^^
-   |
-note: lint level defined here
-  --> $DIR/pub_const_err_bin.rs:12:9
-   |
-LL | #![warn(const_err)]
-   |         ^^^^^^^^^
-
 warning: this constant cannot be used
   --> $DIR/pub_const_err_bin.rs:14:1
    |
@@ -17,6 +5,18 @@ LL | pub const Z: u32 = 0 - 1;
    | ^^^^^^^^^^^^^^^^^^^-----^
    |                    |
    |                    attempt to subtract with overflow
+   |
+note: lint level defined here
+  --> $DIR/pub_const_err_bin.rs:12:9
+   |
+LL | #![warn(const_err)]
+   |         ^^^^^^^^^
+
+warning: attempt to subtract with overflow
+  --> $DIR/pub_const_err_bin.rs:17:22
+   |
+LL | pub type Foo = [i32; 0 - 1];
+   |                      ^^^^^
 
 warning: this array length cannot be used
   --> $DIR/pub_const_err_bin.rs:17:22

--- a/src/test/ui/consts/const-eval/pub_const_err_bin.stderr
+++ b/src/test/ui/consts/const-eval/pub_const_err_bin.stderr
@@ -1,10 +1,8 @@
-warning: this constant cannot be used
-  --> $DIR/pub_const_err_bin.rs:14:1
+warning: attempt to subtract with overflow
+  --> $DIR/pub_const_err_bin.rs:17:22
    |
-LL | pub const Z: u32 = 0 - 1;
-   | ^^^^^^^^^^^^^^^^^^^-----^
-   |                    |
-   |                    attempt to subtract with overflow
+LL | pub type Foo = [i32; 0 - 1];
+   |                      ^^^^^
    |
 note: lint level defined here
   --> $DIR/pub_const_err_bin.rs:12:9
@@ -12,11 +10,13 @@ note: lint level defined here
 LL | #![warn(const_err)]
    |         ^^^^^^^^^
 
-warning: attempt to subtract with overflow
-  --> $DIR/pub_const_err_bin.rs:17:22
+warning: this constant cannot be used
+  --> $DIR/pub_const_err_bin.rs:14:1
    |
-LL | pub type Foo = [i32; 0 - 1];
-   |                      ^^^^^
+LL | pub const Z: u32 = 0 - 1;
+   | ^^^^^^^^^^^^^^^^^^^-----^
+   |                    |
+   |                    attempt to subtract with overflow
 
 warning: this array length cannot be used
   --> $DIR/pub_const_err_bin.rs:17:22

--- a/src/test/ui/dst/dst-bad-assign-3.rs
+++ b/src/test/ui/dst/dst-bad-assign-3.rs
@@ -12,7 +12,7 @@
 
 #![feature(unsized_tuple_coercion)]
 
-type Fat<T> = (isize, &'static str, T);
+type Fat<T: ?Sized> = (isize, &'static str, T);
 
 #[derive(PartialEq,Eq)]
 struct Bar;

--- a/src/test/ui/feature-gates/feature-gate-trivial_bounds.rs
+++ b/src/test/ui/feature-gates/feature-gate-trivial_bounds.rs
@@ -25,7 +25,7 @@ trait T where i32: Foo {} //~ ERROR
 
 union U where i32: Foo { f: i32 } //~ ERROR
 
-type Y where i32: Foo = (); // OK - bound is ignored
+type Y where i32: Foo = (); //~ ERROR
 
 impl Foo for () where i32: Foo { //~ ERROR
     fn test(&self) {

--- a/src/test/ui/feature-gates/feature-gate-trivial_bounds.stderr
+++ b/src/test/ui/feature-gates/feature-gate-trivial_bounds.stderr
@@ -35,6 +35,15 @@ LL | union U where i32: Foo { f: i32 } //~ ERROR
    = help: add #![feature(trivial_bounds)] to the crate attributes to enable
 
 error[E0277]: the trait bound `i32: Foo` is not satisfied
+  --> $DIR/feature-gate-trivial_bounds.rs:28:1
+   |
+LL | type Y where i32: Foo = (); //~ ERROR
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `i32`
+   |
+   = help: see issue #48214
+   = help: add #![feature(trivial_bounds)] to the crate attributes to enable
+
+error[E0277]: the trait bound `i32: Foo` is not satisfied
   --> $DIR/feature-gate-trivial_bounds.rs:30:1
    |
 LL | / impl Foo for () where i32: Foo { //~ ERROR
@@ -125,6 +134,6 @@ LL | | }
    = help: see issue #48214
    = help: add #![feature(trivial_bounds)] to the crate attributes to enable
 
-error: aborting due to 11 previous errors
+error: aborting due to 12 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/generic/generic-param-attrs.rs
+++ b/src/test/ui/generic/generic-param-attrs.rs
@@ -28,7 +28,7 @@ enum EnTy<#[rustc_ty_enum] J> { A(J), B }
 trait TrLt<#[rustc_lt_trait] 'c> { fn foo(&self, _: &'c [u32]) -> &'c u32; }
 trait TrTy<#[rustc_ty_trait] K> { fn foo(&self, _: K); }
 type TyLt<#[rustc_lt_type] 'd> = &'d u32;
-type TyTy<#[rustc_ty_type] L> = (L, );
+type TyTy<#[rustc_ty_type] L> = Option<L>;
 
 impl<#[rustc_lt_inherent] 'e> StLt<'e> { }
 impl<#[rustc_ty_inherent] M> StTy<M> { }

--- a/src/test/ui/issues/issue-47715.rs
+++ b/src/test/ui/issues/issue-47715.rs
@@ -31,7 +31,7 @@ union Union<T: Iterable<Item = impl Foo> + Copy> {
     x: T,
 }
 
-type Type<T: Iterable<Item = impl Foo>> = T;
+type Type<T: Iterable<Item = impl Foo>> = Container<T>;
 //~^ ERROR `impl Trait` not allowed
 
 fn main() {

--- a/src/test/ui/issues/issue-47715.stderr
+++ b/src/test/ui/issues/issue-47715.stderr
@@ -19,7 +19,7 @@ LL | union Union<T: Iterable<Item = impl Foo> + Copy> {
 error[E0562]: `impl Trait` not allowed outside of function and inherent method return types
   --> $DIR/issue-47715.rs:34:30
    |
-LL | type Type<T: Iterable<Item = impl Foo>> = T;
+LL | type Type<T: Iterable<Item = impl Foo>> = Container<T>;
    |                              ^^^^^^^^
 
 error: aborting due to 4 previous errors

--- a/src/test/ui/issues/issue-6936.rs
+++ b/src/test/ui/issues/issue-6936.rs
@@ -31,7 +31,7 @@ mod t4 {
 }
 
 mod t5 {
-    type Bar<T> = T;
+    type Bar<T: ?Sized> = T;
     mod Bar {} //~ ERROR the name `Bar` is defined multiple times
 }
 

--- a/src/test/ui/issues/issue-6936.stderr
+++ b/src/test/ui/issues/issue-6936.stderr
@@ -31,8 +31,8 @@ LL |     enum Foo {} //~ ERROR the name `Foo` is defined multiple times
 error[E0428]: the name `Bar` is defined multiple times
   --> $DIR/issue-6936.rs:35:5
    |
-LL |     type Bar<T> = T;
-   |     ---------------- previous definition of the type `Bar` here
+LL |     type Bar<T: ?Sized> = T;
+   |     ------------------------ previous definition of the type `Bar` here
 LL |     mod Bar {} //~ ERROR the name `Bar` is defined multiple times
    |     ^^^^^^^ `Bar` redefined here
    |

--- a/src/test/ui/privacy/private-in-public-warn.rs
+++ b/src/test/ui/privacy/private-in-public-warn.rs
@@ -57,8 +57,11 @@ mod traits {
     pub struct Pub<T>(T);
     pub trait PubTr {}
 
-    pub type Alias<T: PrivTr> = T; //~ ERROR private trait `traits::PrivTr` in public interface
-    //~| WARNING hard error
+    pub struct Struct<T: PrivTr>(T);
+        //~^ ERROR private trait `traits::PrivTr` in public interface
+    pub type Alias<T: PrivTr> = Struct<T>;
+        //~^ ERROR private trait `traits::PrivTr` in public interface
+        //~| WARNING hard error
     pub trait Tr1: PrivTr {} //~ ERROR private trait `traits::PrivTr` in public interface
     //~^ WARNING hard error
     pub trait Tr2<T: PrivTr> {} //~ ERROR private trait `traits::PrivTr` in public interface
@@ -81,7 +84,9 @@ mod traits_where {
     pub struct Pub<T>(T);
     pub trait PubTr {}
 
-    pub type Alias<T> where T: PrivTr = T;
+    pub struct Struct<T>(T) where T: PrivTr;
+        //~^ ERROR private trait `traits_where::PrivTr` in public interface
+    pub type Alias<T> where T: PrivTr = Struct<T>;
         //~^ ERROR private trait `traits_where::PrivTr` in public interface
         //~| WARNING hard error
     pub trait Tr2<T> where T: PrivTr {}
@@ -273,7 +278,7 @@ mod aliases_priv {
 
 mod aliases_params {
     struct Priv;
-    type PrivAliasGeneric<T = Priv> = T;
+    type PrivAliasGeneric<T = Priv> = Option<T>;
     type Result<T> = ::std::result::Result<T, Priv>;
 
     pub fn f1(arg: PrivAliasGeneric<u8>) {} // OK, not an error

--- a/src/test/ui/privacy/private-in-public-warn.stderr
+++ b/src/test/ui/privacy/private-in-public-warn.stderr
@@ -102,17 +102,23 @@ LL |     struct Priv;
 LL |         type Alias = Priv; //~ ERROR private type `types::Priv` in public interface
    |         ^^^^^^^^^^^^^^^^^^ can't leak private type
 
-error: private trait `traits::PrivTr` in public interface (error E0445)
+error[E0445]: private trait `traits::PrivTr` in public interface
   --> $DIR/private-in-public-warn.rs:60:5
    |
-LL |     pub type Alias<T: PrivTr> = T; //~ ERROR private trait `traits::PrivTr` in public interface
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     pub struct Struct<T: PrivTr>(T);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private trait
+
+error: private trait `traits::PrivTr` in public interface (error E0445)
+  --> $DIR/private-in-public-warn.rs:62:5
+   |
+LL |     pub type Alias<T: PrivTr> = Struct<T>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: private trait `traits::PrivTr` in public interface (error E0445)
-  --> $DIR/private-in-public-warn.rs:62:5
+  --> $DIR/private-in-public-warn.rs:65:5
    |
 LL |     pub trait Tr1: PrivTr {} //~ ERROR private trait `traits::PrivTr` in public interface
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -121,7 +127,7 @@ LL |     pub trait Tr1: PrivTr {} //~ ERROR private trait `traits::PrivTr` in pu
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: private trait `traits::PrivTr` in public interface (error E0445)
-  --> $DIR/private-in-public-warn.rs:64:5
+  --> $DIR/private-in-public-warn.rs:67:5
    |
 LL |     pub trait Tr2<T: PrivTr> {} //~ ERROR private trait `traits::PrivTr` in public interface
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -130,7 +136,7 @@ LL |     pub trait Tr2<T: PrivTr> {} //~ ERROR private trait `traits::PrivTr` in
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: private trait `traits::PrivTr` in public interface (error E0445)
-  --> $DIR/private-in-public-warn.rs:66:5
+  --> $DIR/private-in-public-warn.rs:69:5
    |
 LL | /     pub trait Tr3 {
 LL | |         //~^ ERROR private trait `traits::PrivTr` in public interface
@@ -145,7 +151,7 @@ LL | |     }
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: private trait `traits::PrivTr` in public interface (error E0445)
-  --> $DIR/private-in-public-warn.rs:70:9
+  --> $DIR/private-in-public-warn.rs:73:9
    |
 LL |         fn f<T: PrivTr>(arg: T) {} //~ ERROR private trait `traits::PrivTr` in public interface
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -154,7 +160,7 @@ LL |         fn f<T: PrivTr>(arg: T) {} //~ ERROR private trait `traits::PrivTr`
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: private trait `traits::PrivTr` in public interface (error E0445)
-  --> $DIR/private-in-public-warn.rs:73:5
+  --> $DIR/private-in-public-warn.rs:76:5
    |
 LL |     impl<T: PrivTr> Pub<T> {} //~ ERROR private trait `traits::PrivTr` in public interface
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -163,7 +169,7 @@ LL |     impl<T: PrivTr> Pub<T> {} //~ ERROR private trait `traits::PrivTr` in p
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: private trait `traits::PrivTr` in public interface (error E0445)
-  --> $DIR/private-in-public-warn.rs:75:5
+  --> $DIR/private-in-public-warn.rs:78:5
    |
 LL |     impl<T: PrivTr> PubTr for Pub<T> {} //~ ERROR private trait `traits::PrivTr` in public interface
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -171,17 +177,23 @@ LL |     impl<T: PrivTr> PubTr for Pub<T> {} //~ ERROR private trait `traits::Pr
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
-error: private trait `traits_where::PrivTr` in public interface (error E0445)
-  --> $DIR/private-in-public-warn.rs:84:5
+error[E0445]: private trait `traits_where::PrivTr` in public interface
+  --> $DIR/private-in-public-warn.rs:87:5
    |
-LL |     pub type Alias<T> where T: PrivTr = T;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     pub struct Struct<T>(T) where T: PrivTr;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private trait
+
+error: private trait `traits_where::PrivTr` in public interface (error E0445)
+  --> $DIR/private-in-public-warn.rs:89:5
+   |
+LL |     pub type Alias<T> where T: PrivTr = Struct<T>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: private trait `traits_where::PrivTr` in public interface (error E0445)
-  --> $DIR/private-in-public-warn.rs:87:5
+  --> $DIR/private-in-public-warn.rs:92:5
    |
 LL |     pub trait Tr2<T> where T: PrivTr {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -190,7 +202,7 @@ LL |     pub trait Tr2<T> where T: PrivTr {}
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: private trait `traits_where::PrivTr` in public interface (error E0445)
-  --> $DIR/private-in-public-warn.rs:91:9
+  --> $DIR/private-in-public-warn.rs:96:9
    |
 LL |         fn f<T>(arg: T) where T: PrivTr {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -199,7 +211,7 @@ LL |         fn f<T>(arg: T) where T: PrivTr {}
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: private trait `traits_where::PrivTr` in public interface (error E0445)
-  --> $DIR/private-in-public-warn.rs:95:5
+  --> $DIR/private-in-public-warn.rs:100:5
    |
 LL |     impl<T> Pub<T> where T: PrivTr {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -208,7 +220,7 @@ LL |     impl<T> Pub<T> where T: PrivTr {}
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: private trait `traits_where::PrivTr` in public interface (error E0445)
-  --> $DIR/private-in-public-warn.rs:98:5
+  --> $DIR/private-in-public-warn.rs:103:5
    |
 LL |     impl<T> PubTr for Pub<T> where T: PrivTr {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -217,7 +229,7 @@ LL |     impl<T> PubTr for Pub<T> where T: PrivTr {}
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: private trait `generics::PrivTr<generics::Pub>` in public interface (error E0445)
-  --> $DIR/private-in-public-warn.rs:109:5
+  --> $DIR/private-in-public-warn.rs:114:5
    |
 LL |     pub trait Tr1: PrivTr<Pub> {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -226,7 +238,7 @@ LL |     pub trait Tr1: PrivTr<Pub> {}
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: private type `generics::Priv` in public interface (error E0446)
-  --> $DIR/private-in-public-warn.rs:112:5
+  --> $DIR/private-in-public-warn.rs:117:5
    |
 LL |     pub trait Tr2: PubTr<Priv> {} //~ ERROR private type `generics::Priv` in public interface
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -235,7 +247,7 @@ LL |     pub trait Tr2: PubTr<Priv> {} //~ ERROR private type `generics::Priv` i
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: private type `generics::Priv` in public interface (error E0446)
-  --> $DIR/private-in-public-warn.rs:114:5
+  --> $DIR/private-in-public-warn.rs:119:5
    |
 LL |     pub trait Tr3: PubTr<[Priv; 1]> {} //~ ERROR private type `generics::Priv` in public interface
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -244,7 +256,7 @@ LL |     pub trait Tr3: PubTr<[Priv; 1]> {} //~ ERROR private type `generics::Pr
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: private type `generics::Priv` in public interface (error E0446)
-  --> $DIR/private-in-public-warn.rs:116:5
+  --> $DIR/private-in-public-warn.rs:121:5
    |
 LL |     pub trait Tr4: PubTr<Pub<Priv>> {} //~ ERROR private type `generics::Priv` in public interface
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -253,7 +265,7 @@ LL |     pub trait Tr4: PubTr<Pub<Priv>> {} //~ ERROR private type `generics::Pr
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error[E0446]: private type `impls::Priv` in public interface
-  --> $DIR/private-in-public-warn.rs:143:9
+  --> $DIR/private-in-public-warn.rs:148:9
    |
 LL |     struct Priv;
    |     - `impls::Priv` declared as private
@@ -262,7 +274,7 @@ LL |         type Alias = Priv; //~ ERROR private type `impls::Priv` in public i
    |         ^^^^^^^^^^^^^^^^^^ can't leak private type
 
 error: private type `aliases_pub::Priv` in public interface (error E0446)
-  --> $DIR/private-in-public-warn.rs:214:9
+  --> $DIR/private-in-public-warn.rs:219:9
    |
 LL |         pub fn f(arg: Priv) {} //~ ERROR private type `aliases_pub::Priv` in public interface
    |         ^^^^^^^^^^^^^^^^^^^^^^
@@ -271,7 +283,7 @@ LL |         pub fn f(arg: Priv) {} //~ ERROR private type `aliases_pub::Priv` i
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error[E0446]: private type `aliases_pub::Priv` in public interface
-  --> $DIR/private-in-public-warn.rs:218:9
+  --> $DIR/private-in-public-warn.rs:223:9
    |
 LL |     struct Priv;
    |     - `aliases_pub::Priv` declared as private
@@ -280,7 +292,7 @@ LL |         type Check = Priv; //~ ERROR private type `aliases_pub::Priv` in pu
    |         ^^^^^^^^^^^^^^^^^^ can't leak private type
 
 error[E0446]: private type `aliases_pub::Priv` in public interface
-  --> $DIR/private-in-public-warn.rs:221:9
+  --> $DIR/private-in-public-warn.rs:226:9
    |
 LL |     struct Priv;
    |     - `aliases_pub::Priv` declared as private
@@ -289,7 +301,7 @@ LL |         type Check = Priv; //~ ERROR private type `aliases_pub::Priv` in pu
    |         ^^^^^^^^^^^^^^^^^^ can't leak private type
 
 error[E0446]: private type `aliases_pub::Priv` in public interface
-  --> $DIR/private-in-public-warn.rs:224:9
+  --> $DIR/private-in-public-warn.rs:229:9
    |
 LL |     struct Priv;
    |     - `aliases_pub::Priv` declared as private
@@ -298,7 +310,7 @@ LL |         type Check = Priv; //~ ERROR private type `aliases_pub::Priv` in pu
    |         ^^^^^^^^^^^^^^^^^^ can't leak private type
 
 error: private trait `aliases_priv::PrivTr1` in public interface (error E0445)
-  --> $DIR/private-in-public-warn.rs:248:5
+  --> $DIR/private-in-public-warn.rs:253:5
    |
 LL |     pub trait Tr1: PrivUseAliasTr {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -307,7 +319,7 @@ LL |     pub trait Tr1: PrivUseAliasTr {}
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: private type `aliases_priv::Priv2` in public interface (error E0446)
-  --> $DIR/private-in-public-warn.rs:251:5
+  --> $DIR/private-in-public-warn.rs:256:5
    |
 LL |     pub trait Tr2: PrivUseAliasTr<PrivAlias> {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -316,7 +328,7 @@ LL |     pub trait Tr2: PrivUseAliasTr<PrivAlias> {}
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: private trait `aliases_priv::PrivTr1<aliases_priv::Priv2>` in public interface (error E0445)
-  --> $DIR/private-in-public-warn.rs:251:5
+  --> $DIR/private-in-public-warn.rs:256:5
    |
 LL |     pub trait Tr2: PrivUseAliasTr<PrivAlias> {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -324,6 +336,7 @@ LL |     pub trait Tr2: PrivUseAliasTr<PrivAlias> {}
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
-error: aborting due to 35 previous errors
+error: aborting due to 37 previous errors
 
-For more information about this error, try `rustc --explain E0446`.
+Some errors occurred: E0445, E0446.
+For more information about an error, try `rustc --explain E0445`.

--- a/src/test/ui/privacy/private-in-public.rs
+++ b/src/test/ui/privacy/private-in-public.rs
@@ -147,7 +147,7 @@ mod aliases_priv {
 
 mod aliases_params {
     struct Priv;
-    type PrivAliasGeneric<T = Priv> = T;
+    type PrivAliasGeneric<T = Priv> = Option<T>;
     type Result<T> = ::std::result::Result<T, Priv>;
 
     pub fn f2(arg: PrivAliasGeneric) {}

--- a/src/test/ui/regions/regions-outlives-projection-hrtype.rs
+++ b/src/test/ui/regions/regions-outlives-projection-hrtype.rs
@@ -24,7 +24,8 @@ trait TheTrait {
 
 fn wf<T>() { }
 
-type FnType<T> = for<'r> fn(&'r T);
+#[allow(type_alias_bounds)]
+type FnType<T: ?Sized> = for<'r> fn(&'r T);
 
 fn foo<'a,'b,T>()
     where FnType<T>: TheTrait

--- a/src/test/ui/regions/regions-outlives-projection-hrtype.stderr
+++ b/src/test/ui/regions/regions-outlives-projection-hrtype.stderr
@@ -1,5 +1,5 @@
 error: compilation successful
-  --> $DIR/regions-outlives-projection-hrtype.rs:36:1
+  --> $DIR/regions-outlives-projection-hrtype.rs:37:1
    |
 LL | fn main() { } //~ ERROR compilation successful
    | ^^^^^^^^^^^^^

--- a/src/test/ui/run-pass/binding/expr-match-generic.rs
+++ b/src/test/ui/run-pass/binding/expr-match-generic.rs
@@ -11,7 +11,8 @@
 // run-pass
 #![allow(non_camel_case_types)]
 
-type compare<T> = extern "Rust" fn(T, T) -> bool;
+#[allow(type_alias_bounds)]
+type compare<T: ?Sized> = extern "Rust" fn(T, T) -> bool;
 
 fn test_generic<T:Clone>(expected: T, eq: compare<T>) {
   let actual: T = match true { true => { expected.clone() }, _ => panic!("wat") };

--- a/src/test/ui/run-pass/issues/issue-14933.rs
+++ b/src/test/ui/run-pass/issues/issue-14933.rs
@@ -11,6 +11,7 @@
 // run-pass
 // pretty-expanded FIXME #23616
 
-pub type BigRat<T = isize> = T;
+#[allow(type_alias_bounds)]
+pub type BigRat<T: ?Sized = isize> = T;
 
 fn main() {}

--- a/src/test/ui/run-pass/issues/issue-19404.rs
+++ b/src/test/ui/run-pass/issues/issue-19404.rs
@@ -12,7 +12,8 @@
 use std::any::TypeId;
 use std::rc::Rc;
 
-type Fp<T> = Rc<T>;
+#[allow(type_alias_bounds)]
+type Fp<T: ?Sized> = Rc<T>;
 
 struct Engine;
 

--- a/src/test/ui/run-pass/issues/issue-20616.rs
+++ b/src/test/ui/run-pass/issues/issue-20616.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // run-pass
-type MyType<'a, T> = &'a T;
+type MyType<'a, T> = &'a Option<T>;
 
 // combine lifetime bounds and type arguments in usual way
 type TypeA<'a> = MyType<'a, ()>;
@@ -28,18 +28,18 @@ type TypeD = TypeA<'static>;
 type TypeE = TypeA<'static,>;
 
 // normal type argument
-type TypeF<T> = Box<T>;
+type TypeF<T> = Option<T>;
 
 // type argument with trailing comma
-type TypeG<T> = Box<T,>;
+type TypeG<T> = Option<T,>;
 
 // trailing comma on lifetime defs
 type TypeH<'a,> = &'a ();
 
 // trailing comma on type argument
-type TypeI<T,> = T;
+type TypeI<T,> = Option<T>;
 
-static STATIC: () = ();
+static STATIC: Option<()> = Some(());
 
 fn main() {
 

--- a/src/test/ui/run-pass/issues/issue-22356.rs
+++ b/src/test/ui/run-pass/issues/issue-22356.rs
@@ -35,7 +35,8 @@ impl<D: Device, T> BufferHandle<D, T> {
     }
 }
 
-pub type RawBufferHandle<D: Device> = Handle<<D as Device>::Buffer, String>;
+#[allow(type_alias_bounds)]
+pub type RawBufferHandle<D: ?Sized + Device> = Handle<<D as Device>::Buffer, String>;
 
 pub trait Device {
     type Buffer;

--- a/src/test/ui/run-pass/issues/issue-22471.rs
+++ b/src/test/ui/run-pass/issues/issue-22471.rs
@@ -9,8 +9,10 @@
 // except according to those terms.
 
 // run-pass
-#![allow(type_alias_bounds)]
 
-type Foo<T> where T: Copy = Box<T>;
+struct NeedsCopy<T: Copy>(T);
+
+#[allow(type_alias_bounds)]
+type Foo<T> where T: Copy = NeedsCopy<T>;
 
 fn main(){}

--- a/src/test/ui/run-pass/issues/issue-36278-prefix-nesting.rs
+++ b/src/test/ui/run-pass/issues/issue-36278-prefix-nesting.rs
@@ -17,7 +17,8 @@ use std::mem;
 const SZ: usize = 100;
 struct P<T: ?Sized>([u8; SZ], T);
 
-type Ack<T> = P<P<T>>;
+#[allow(type_alias_bounds)]
+type Ack<T: ?Sized> = P<P<T>>;
 
 fn main() {
     let size_of_sized; let size_of_unsized;

--- a/src/test/ui/run-pass/specialization/specialization-projection-alias.rs
+++ b/src/test/ui/run-pass/specialization/specialization-projection-alias.rs
@@ -19,7 +19,8 @@ trait Id_ {
     type Out;
 }
 
-type Id<T> = <T as Id_>::Out;
+#[allow(type_alias_bounds)]
+type Id<T: ?Sized> = <T as Id_>::Out;
 
 impl<T> Id_ for T {
     default type Out = T;

--- a/src/test/ui/trivial-bounds/trivial-bounds-inconsistent.rs
+++ b/src/test/ui/trivial-bounds/trivial-bounds-inconsistent.rs
@@ -29,7 +29,7 @@ trait T where i32: Foo {}
 
 union U where i32: Foo { f: i32 }
 
-type Y where i32: Foo = ();
+type Y where i32: Foo = S;
 
 impl Foo for () where i32: Foo {
     fn test(&self) {

--- a/src/test/ui/trivial-bounds/trivial-bounds-inconsistent.stderr
+++ b/src/test/ui/trivial-bounds/trivial-bounds-inconsistent.stderr
@@ -27,7 +27,7 @@ LL | union U where i32: Foo { f: i32 }
 warning: where clauses are not enforced in type aliases
   --> $DIR/trivial-bounds-inconsistent.rs:32:14
    |
-LL | type Y where i32: Foo = ();
+LL | type Y where i32: Foo = S;
    |              ^^^^^^^^
    |
    = note: #[warn(type_alias_bounds)] on by default
@@ -36,8 +36,8 @@ LL | type Y where i32: Foo = ();
 warning: Trait bound i32: Foo does not depend on any type or lifetime parameters
   --> $DIR/trivial-bounds-inconsistent.rs:32:1
    |
-LL | type Y where i32: Foo = ();
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | type Y where i32: Foo = S;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: Trait bound i32: Foo does not depend on any type or lifetime parameters
   --> $DIR/trivial-bounds-inconsistent.rs:34:1

--- a/src/test/ui/type/type-alias-bounds-err.rs
+++ b/src/test/ui/type/type-alias-bounds-err.rs
@@ -1,0 +1,29 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(dead_code)]
+
+// This test contains examples originally in `type-alias-bounds.rs`,
+// that now produce errors instead of being silently accepted.
+
+type SVec<T: Send+Send> = Vec<T>;
+//~^ ERROR `T` cannot be sent between threads safely
+type S2Vec<T> where T: Send = Vec<T>;
+//~^ ERROR `T` cannot be sent between threads safely
+
+trait Bound { type Assoc; }
+type T4<U> = <U as Bound>::Assoc;
+//~^ ERROR the trait bound `U: Bound` is not satisfied
+//~| ERROR the size for values of type `U` cannot be known at compilation time
+
+type T6<U: Bound> = ::std::vec::Vec<U>;
+//~^ ERROR the trait bound `U: Bound` is not satisfied
+
+fn main() {}

--- a/src/test/ui/type/type-alias-bounds-err.rs
+++ b/src/test/ui/type/type-alias-bounds-err.rs
@@ -19,9 +19,6 @@ type S2Vec<T> where T: Send = Vec<T>;
 //~^ ERROR `T` cannot be sent between threads safely
 
 trait Bound { type Assoc; }
-type T4<U> = <U as Bound>::Assoc;
-//~^ ERROR the trait bound `U: Bound` is not satisfied
-//~| ERROR the size for values of type `U` cannot be known at compilation time
 
 type T6<U: Bound> = ::std::vec::Vec<U>;
 //~^ ERROR the trait bound `U: Bound` is not satisfied

--- a/src/test/ui/type/type-alias-bounds-err.stderr
+++ b/src/test/ui/type/type-alias-bounds-err.stderr
@@ -1,0 +1,47 @@
+error[E0277]: `T` cannot be sent between threads safely
+  --> $DIR/type-alias-bounds-err.rs:16:1
+   |
+LL | type SVec<T: Send+Send> = Vec<T>;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `T` cannot be sent between threads safely
+   |
+   = help: the trait `std::marker::Send` is not implemented for `T`
+   = help: consider adding a `where T: std::marker::Send` bound
+
+error[E0277]: `T` cannot be sent between threads safely
+  --> $DIR/type-alias-bounds-err.rs:18:1
+   |
+LL | type S2Vec<T> where T: Send = Vec<T>;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `T` cannot be sent between threads safely
+   |
+   = help: the trait `std::marker::Send` is not implemented for `T`
+   = help: consider adding a `where T: std::marker::Send` bound
+
+error[E0277]: the trait bound `U: Bound` is not satisfied
+  --> $DIR/type-alias-bounds-err.rs:22:1
+   |
+LL | type T4<U> = <U as Bound>::Assoc;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Bound` is not implemented for `U`
+   |
+   = help: consider adding a `where U: Bound` bound
+
+error[E0277]: the size for values of type `U` cannot be known at compilation time
+  --> $DIR/type-alias-bounds-err.rs:22:1
+   |
+LL | type T4<U> = <U as Bound>::Assoc;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `std::marker::Sized` is not implemented for `U`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
+   = help: consider adding a `where U: std::marker::Sized` bound
+
+error[E0277]: the trait bound `U: Bound` is not satisfied
+  --> $DIR/type-alias-bounds-err.rs:26:1
+   |
+LL | type T6<U: Bound> = ::std::vec::Vec<U>;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Bound` is not implemented for `U`
+   |
+   = help: consider adding a `where U: Bound` bound
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/type/type-alias-bounds-err.stderr
+++ b/src/test/ui/type/type-alias-bounds-err.stderr
@@ -17,31 +17,13 @@ LL | type S2Vec<T> where T: Send = Vec<T>;
    = help: consider adding a `where T: std::marker::Send` bound
 
 error[E0277]: the trait bound `U: Bound` is not satisfied
-  --> $DIR/type-alias-bounds-err.rs:22:1
-   |
-LL | type T4<U> = <U as Bound>::Assoc;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Bound` is not implemented for `U`
-   |
-   = help: consider adding a `where U: Bound` bound
-
-error[E0277]: the size for values of type `U` cannot be known at compilation time
-  --> $DIR/type-alias-bounds-err.rs:22:1
-   |
-LL | type T4<U> = <U as Bound>::Assoc;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `std::marker::Sized` is not implemented for `U`
-   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
-   = help: consider adding a `where U: std::marker::Sized` bound
-
-error[E0277]: the trait bound `U: Bound` is not satisfied
-  --> $DIR/type-alias-bounds-err.rs:26:1
+  --> $DIR/type-alias-bounds-err.rs:23:1
    |
 LL | type T6<U: Bound> = ::std::vec::Vec<U>;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Bound` is not implemented for `U`
    |
    = help: consider adding a `where U: Bound` bound
 
-error: aborting due to 5 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/type/type-alias-bounds.rs
+++ b/src/test/ui/type/type-alias-bounds.rs
@@ -15,9 +15,8 @@
 
 use std::rc::Rc;
 
-type SVec<T: Send+Send> = Vec<T>;
-//~^ WARN bounds on generic parameters are not enforced in type aliases [type_alias_bounds]
-type S2Vec<T> where T: Send = Vec<T>;
+type SVec<T: /*Send+Send*/> = Vec<T>; // NOTE(eddyb) moved to `type-alias-bounds-err.rs`
+type S2Vec<T> where T: /*Send*/ = Vec<T>; // NOTE(eddyb) moved to `type-alias-bounds-err.rs`
 //~^ WARN where clauses are not enforced in type aliases [type_alias_bounds]
 type VVec<'b, 'a: 'b+'b> = (&'b u32, Vec<&'a i32>);
 //~^ WARN bounds on generic parameters are not enforced in type aliases [type_alias_bounds]
@@ -54,16 +53,16 @@ type MySendable<T> = Sendable<T>; // no error here!
 
 // However, bounds *are* taken into account when accessing associated types
 trait Bound { type Assoc; }
-type T1<U: Bound> = U::Assoc; //~ WARN not enforced in type aliases
-type T2<U> where U: Bound = U::Assoc;  //~ WARN not enforced in type aliases
+type T1<U: Bound + ?Sized> = U::Assoc; //~ WARN not enforced in type aliases
+type T2<U> where U: Bound + ?Sized = U::Assoc;  //~ WARN not enforced in type aliases
 
 // This errors
 // type T3<U> = U::Assoc;
 // Do this instead
-type T4<U> = <U as Bound>::Assoc;
+// type T4<U: ?Sized> = <U as Bound>::Assoc; // NOTE(eddyb) moved to `type-alias-bounds-err.rs`
 
 // Make sure the help about associatd types is not shown incorrectly
-type T5<U: Bound> = <U as Bound>::Assoc;  //~ WARN not enforced in type aliases
-type T6<U: Bound> = ::std::vec::Vec<U>;  //~ WARN not enforced in type aliases
+type T5<U: Bound + ?Sized> = <U as Bound>::Assoc;  //~ WARN not enforced in type aliases
+// type T6<U: Bound> = ::std::vec::Vec<U>; // NOTE(eddyb) moved to `type-alias-bounds-err.rs`
 
 fn main() {}

--- a/src/test/ui/type/type-alias-bounds.rs
+++ b/src/test/ui/type/type-alias-bounds.rs
@@ -59,7 +59,7 @@ type T2<U> where U: Bound + ?Sized = U::Assoc;  //~ WARN not enforced in type al
 // This errors
 // type T3<U> = U::Assoc;
 // Do this instead
-// type T4<U: ?Sized> = <U as Bound>::Assoc; // NOTE(eddyb) moved to `type-alias-bounds-err.rs`
+type T4<U> = <U as Bound>::Assoc;
 
 // Make sure the help about associatd types is not shown incorrectly
 type T5<U: Bound + ?Sized> = <U as Bound>::Assoc;  //~ WARN not enforced in type aliases

--- a/src/test/ui/type/type-alias-bounds.stderr
+++ b/src/test/ui/type/type-alias-bounds.stderr
@@ -1,22 +1,14 @@
-warning: bounds on generic parameters are not enforced in type aliases
-  --> $DIR/type-alias-bounds.rs:18:14
+warning: where clauses are not enforced in type aliases
+  --> $DIR/type-alias-bounds.rs:19:21
    |
-LL | type SVec<T: Send+Send> = Vec<T>;
-   |              ^^^^ ^^^^
+LL | type S2Vec<T> where T: /*Send*/ = Vec<T>; // NOTE(eddyb) moved to `type-alias-bounds-err.rs`
+   |                     ^^
    |
    = note: #[warn(type_alias_bounds)] on by default
-   = help: the bound will not be checked when the type alias is used, and should be removed
-
-warning: where clauses are not enforced in type aliases
-  --> $DIR/type-alias-bounds.rs:20:21
-   |
-LL | type S2Vec<T> where T: Send = Vec<T>;
-   |                     ^^^^^^^
-   |
    = help: the clause will not be checked when the type alias is used, and should be removed
 
 warning: bounds on generic parameters are not enforced in type aliases
-  --> $DIR/type-alias-bounds.rs:22:19
+  --> $DIR/type-alias-bounds.rs:21:19
    |
 LL | type VVec<'b, 'a: 'b+'b> = (&'b u32, Vec<&'a i32>);
    |                   ^^ ^^
@@ -24,7 +16,7 @@ LL | type VVec<'b, 'a: 'b+'b> = (&'b u32, Vec<&'a i32>);
    = help: the bound will not be checked when the type alias is used, and should be removed
 
 warning: bounds on generic parameters are not enforced in type aliases
-  --> $DIR/type-alias-bounds.rs:24:18
+  --> $DIR/type-alias-bounds.rs:23:18
    |
 LL | type WVec<'b, T: 'b+'b> = (&'b u32, Vec<T>);
    |                  ^^ ^^
@@ -32,7 +24,7 @@ LL | type WVec<'b, T: 'b+'b> = (&'b u32, Vec<T>);
    = help: the bound will not be checked when the type alias is used, and should be removed
 
 warning: where clauses are not enforced in type aliases
-  --> $DIR/type-alias-bounds.rs:26:25
+  --> $DIR/type-alias-bounds.rs:25:25
    |
 LL | type W2Vec<'b, T> where T: 'b, T: 'b = (&'b u32, Vec<T>);
    |                         ^^^^^  ^^^^^
@@ -40,44 +32,44 @@ LL | type W2Vec<'b, T> where T: 'b, T: 'b = (&'b u32, Vec<T>);
    = help: the clause will not be checked when the type alias is used, and should be removed
 
 warning: bounds on generic parameters are not enforced in type aliases
-  --> $DIR/type-alias-bounds.rs:57:12
+  --> $DIR/type-alias-bounds.rs:56:12
    |
-LL | type T1<U: Bound> = U::Assoc; //~ WARN not enforced in type aliases
-   |            ^^^^^
+LL | type T1<U: Bound + ?Sized> = U::Assoc; //~ WARN not enforced in type aliases
+   |            ^^^^^   ^^^^^^
    |
    = help: the bound will not be checked when the type alias is used, and should be removed
 help: use fully disambiguated paths (i.e., `<T as Trait>::Assoc`) to refer to associated types in type aliases
-  --> $DIR/type-alias-bounds.rs:57:21
+  --> $DIR/type-alias-bounds.rs:56:30
    |
-LL | type T1<U: Bound> = U::Assoc; //~ WARN not enforced in type aliases
-   |                     ^^^^^^^^
+LL | type T1<U: Bound + ?Sized> = U::Assoc; //~ WARN not enforced in type aliases
+   |                              ^^^^^^^^
 
 warning: where clauses are not enforced in type aliases
-  --> $DIR/type-alias-bounds.rs:58:18
+  --> $DIR/type-alias-bounds.rs:57:18
    |
-LL | type T2<U> where U: Bound = U::Assoc;  //~ WARN not enforced in type aliases
-   |                  ^^^^^^^^
+LL | type T2<U> where U: Bound + ?Sized = U::Assoc;  //~ WARN not enforced in type aliases
+   |                  ^^^^^^^^^^^^^^^^^
    |
    = help: the clause will not be checked when the type alias is used, and should be removed
 help: use fully disambiguated paths (i.e., `<T as Trait>::Assoc`) to refer to associated types in type aliases
-  --> $DIR/type-alias-bounds.rs:58:29
+  --> $DIR/type-alias-bounds.rs:57:38
    |
-LL | type T2<U> where U: Bound = U::Assoc;  //~ WARN not enforced in type aliases
-   |                             ^^^^^^^^
+LL | type T2<U> where U: Bound + ?Sized = U::Assoc;  //~ WARN not enforced in type aliases
+   |                                      ^^^^^^^^
 
 warning: bounds on generic parameters are not enforced in type aliases
-  --> $DIR/type-alias-bounds.rs:66:12
+  --> $DIR/type-alias-bounds.rs:57:29
    |
-LL | type T5<U: Bound> = <U as Bound>::Assoc;  //~ WARN not enforced in type aliases
-   |            ^^^^^
+LL | type T2<U> where U: Bound + ?Sized = U::Assoc;  //~ WARN not enforced in type aliases
+   |                             ^^^^^^
    |
    = help: the bound will not be checked when the type alias is used, and should be removed
 
 warning: bounds on generic parameters are not enforced in type aliases
-  --> $DIR/type-alias-bounds.rs:67:12
+  --> $DIR/type-alias-bounds.rs:65:12
    |
-LL | type T6<U: Bound> = ::std::vec::Vec<U>;  //~ WARN not enforced in type aliases
-   |            ^^^^^
+LL | type T5<U: Bound + ?Sized> = <U as Bound>::Assoc;  //~ WARN not enforced in type aliases
+   |            ^^^^^   ^^^^^^
    |
    = help: the bound will not be checked when the type alias is used, and should be removed
 


### PR DESCRIPTION
**NOTE**: this is mainly for crater, we'll only emit hard errors on Rust 2018.
This is the second half to a plan outlined in comment on #49441 (see #54033 for the first half).

Fixes #21903 (by disallowing currently unenforceable bounds instead of enforcing them).

This PR includes two hacks: first to not check (usually implied) `T: Sized` bounds, as they're a common source of breakage and would probably be too annoying in practice, and a second to remove some overlap with #54033, so adding missing bounds is *not* required to test this PR.
A decision should be made about the former hack, while the latter is only a temporary convenience.

r? @nikomatsakis 