### PR TITLE
Fix camel case type warning for types with trailing underscores

### DIFF
--- a/src/librustc_lint/nonstandard_style.rs
+++ b/src/librustc_lint/nonstandard_style.rs
@@ -59,10 +59,10 @@ impl NonCamelCaseTypes {
 
         fn is_camel_case(name: ast::Name) -> bool {
             let name = name.as_str();
+            let name = name.trim_matches('_');
             if name.is_empty() {
                 return true;
             }
-            let name = name.trim_matches('_');
 
             // start with a non-lowercase letter rather than non-uppercase
             // ones (some scripts don't have a concept of upper/lowercase)

--- a/src/test/ui/lint/issue-54099-camel-case-underscore-types.rs
+++ b/src/test/ui/lint/issue-54099-camel-case-underscore-types.rs
@@ -1,0 +1,14 @@
+// compile-pass
+
+#![forbid(non_camel_case_types)]
+#![allow(dead_code)]
+
+// None of the following types should generate a warning
+struct _X {}
+struct __X {}
+struct __ {}
+struct X_ {}
+struct X__ {}
+struct X___ {}
+
+fn main() { }

--- a/src/test/ui/lint/lint-non-camel-case-types.rs
+++ b/src/test/ui/lint/lint-non-camel-case-types.rs
@@ -43,8 +43,6 @@ struct foo7 {
     bar: isize,
 }
 
-type __ = isize; //~ ERROR type `__` should have a camel case name such as `CamelCase`
-
 struct X86_64;
 
 struct X86__64; //~ ERROR type `X86__64` should have a camel case name such as `X86_64`

--- a/src/test/ui/lint/lint-non-camel-case-types.stderr
+++ b/src/test/ui/lint/lint-non-camel-case-types.stderr
@@ -60,29 +60,23 @@ error: type parameter `ty` should have a camel case name such as `Ty`
 LL | fn f<ty>(_: ty) {} //~ ERROR type parameter `ty` should have a camel case name such as `Ty`
    |      ^^
 
-error: type `__` should have a camel case name such as `CamelCase`
-  --> $DIR/lint-non-camel-case-types.rs:46:1
-   |
-LL | type __ = isize; //~ ERROR type `__` should have a camel case name such as `CamelCase`
-   | ^^^^^^^^^^^^^^^^
-
 error: type `X86__64` should have a camel case name such as `X86_64`
-  --> $DIR/lint-non-camel-case-types.rs:50:1
+  --> $DIR/lint-non-camel-case-types.rs:48:1
    |
 LL | struct X86__64; //~ ERROR type `X86__64` should have a camel case name such as `X86_64`
    | ^^^^^^^^^^^^^^^
 
 error: type `Abc_123` should have a camel case name such as `Abc123`
-  --> $DIR/lint-non-camel-case-types.rs:52:1
+  --> $DIR/lint-non-camel-case-types.rs:50:1
    |
 LL | struct Abc_123; //~ ERROR type `Abc_123` should have a camel case name such as `Abc123`
    | ^^^^^^^^^^^^^^^
 
 error: type `A1_b2_c3` should have a camel case name such as `A1B2C3`
-  --> $DIR/lint-non-camel-case-types.rs:54:1
+  --> $DIR/lint-non-camel-case-types.rs:52:1
    |
 LL | struct A1_b2_c3; //~ ERROR type `A1_b2_c3` should have a camel case name such as `A1B2C3`
    | ^^^^^^^^^^^^^^^^
 
-error: aborting due to 12 previous errors
+error: aborting due to 11 previous errors
 


### PR DESCRIPTION
Fixes #54099 