### PR TITLE
Reexport CheckLintNameResult

### DIFF
--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -53,7 +53,7 @@ use ty::query::Providers;
 use util::nodemap::NodeMap;
 
 pub use lint::context::{LateContext, EarlyContext, LintContext, LintStore,
-                        check_crate, check_ast_crate,
+                        check_crate, check_ast_crate, CheckLintNameResult,
                         FutureIncompatibleInfo, BufferedEarlyLint};
 
 /// Specification of a single lint.


### PR DESCRIPTION
Make the enum `CheckLintNameResult` public, so that lint tools (aka Clippy) can use it together with [`LintStore::check_lint_name`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc/lint/struct.LintStore.html#method.check_lint_name), to handle the case that a scoped `tool_lint` doesn't exist in the tool.

This is currently not handled by the compiler:
https://github.com/rust-lang/rust/blob/595345419d12c3ea860151df52f78744a31bafff/src/librustc/lint/levels.rs#L309-L314

Needed for rust-lang-nursery/rust-clippy#3161

r? @Manishearth