### PR TITLE
Lint uncallable function

### DIFF
--- a/src/libstd/sys/cloudabi/shims/fs.rs
+++ b/src/libstd/sys/cloudabi/shims/fs.rs
@@ -251,6 +251,9 @@ pub fn rename(_old: &Path, _new: &Path) -> io::Result<()> {
     unsupported()
 }
 
+// `FilePermissions` is uninhabited in CloudABI, so this function is
+// uncallable (but necessary for the public interface).
+#[allow(unreachable_code)]
 pub fn set_perm(_p: &Path, perm: FilePermissions) -> io::Result<()> {
     match perm.0 {}
 }

--- a/src/libstd/sys/cloudabi/shims/pipe.rs
+++ b/src/libstd/sys/cloudabi/shims/pipe.rs
@@ -17,6 +17,9 @@ impl AnonPipe {
     }
 }
 
+// `AnonPipe` is uninhabited in CloudABI, so this function is
+// uncallable (but necessary for the public interface).
+#[allow(unreachable_code)]
 pub fn read2(p1: AnonPipe, _v1: &mut Vec<u8>, _p2: AnonPipe, _v2: &mut Vec<u8>) -> io::Result<()> {
     match p1.0 {}
 }

--- a/src/libstd/sys/sgx/fs.rs
+++ b/src/libstd/sys/sgx/fs.rs
@@ -253,6 +253,9 @@ pub fn rename(_old: &Path, _new: &Path) -> io::Result<()> {
     unsupported()
 }
 
+// `FilePermissions` is uninhabited in SGX, so this function is
+// uncallable (but necessary for the public interface).
+#[allow(unreachable_code)]
 pub fn set_perm(_p: &Path, perm: FilePermissions) -> io::Result<()> {
     match perm.0 {}
 }

--- a/src/libstd/sys/sgx/pipe.rs
+++ b/src/libstd/sys/sgx/pipe.rs
@@ -17,6 +17,9 @@ impl AnonPipe {
     }
 }
 
+// `AnonPipe` is uninhabited in SGX, so this function is
+// uncallable (but necessary for the public interface).
+#[allow(unreachable_code)]
 pub fn read2(p1: AnonPipe,
              _v1: &mut Vec<u8>,
              _p2: AnonPipe,

--- a/src/libstd/sys/wasm/fs.rs
+++ b/src/libstd/sys/wasm/fs.rs
@@ -253,6 +253,9 @@ pub fn rename(_old: &Path, _new: &Path) -> io::Result<()> {
     unsupported()
 }
 
+// `FilePermissions` is uninhabited in WASM, so this function is
+// uncallable (but necessary for the public interface).
+#[allow(unreachable_code)]
 pub fn set_perm(_p: &Path, perm: FilePermissions) -> io::Result<()> {
     match perm.0 {}
 }

--- a/src/libstd/sys/wasm/pipe.rs
+++ b/src/libstd/sys/wasm/pipe.rs
@@ -17,6 +17,9 @@ impl AnonPipe {
     }
 }
 
+// `AnonPipe` is uninhabited in WASM, so this function is
+// uncallable (but necessary for the public interface).
+#[allow(unreachable_code)]
 pub fn read2(p1: AnonPipe,
              _v1: &mut Vec<u8>,
              _p2: AnonPipe,

--- a/src/test/run-pass/drop/drop-uninhabited-enum.rs
+++ b/src/test/run-pass/drop/drop-uninhabited-enum.rs
@@ -1,14 +1,16 @@
 // run-pass
 #![allow(dead_code)]
 #![allow(unused_variables)]
-// pretty-expanded FIXME #23616
+#![allow(unreachable_code)]
 
-enum Foo { }
+enum Foo {}
 
 impl Drop for Foo {
     fn drop(&mut self) { }
 }
 
-fn foo(x: Foo) { }
+fn foo() {
+    let _x: Foo = unimplemented!();
+}
 
 fn main() { }

--- a/src/test/run-pass/issues/issue-3037.rs
+++ b/src/test/run-pass/issues/issue-3037.rs
@@ -1,16 +1,16 @@
 // run-pass
 #![allow(dead_code)]
+#![allow(unused_variables)]
 // pretty-expanded FIXME #23616
-#![allow(non_camel_case_types)]
 
-enum what { }
+enum Void {}
 
-fn what_to_string(x: what) -> String
-{
-    match x {
-    }
+fn void() -> Void {
+    unimplemented!()
 }
 
-pub fn main()
-{
+fn void_to_string() -> String {
+    match void() {}
 }
+
+pub fn main() {}

--- a/src/test/run-pass/issues/issue-46855.stderr
+++ b/src/test/run-pass/issues/issue-46855.stderr
@@ -1,0 +1,18 @@
+warning: functions with parameters of uninhabited types are uncallable
+  --> $DIR/issue-46855.rs:15:1
+   |
+LL | fn foo(xs: [(Never, u32); 1]) -> u32 { xs[0].1 }
+   | ^^^^^^^--^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |        |
+   |        this parameter has an uninhabited type
+   |
+   = note: #[warn(unreachable_code)] on by default
+
+warning: functions with parameters of uninhabited types are uncallable
+  --> $DIR/issue-46855.rs:17:1
+   |
+LL | fn bar([(_, x)]: [(Never, u32); 1]) -> u32 { x }
+   | ^^^^^^^--------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |        |
+   |        this parameter has an uninhabited type
+

--- a/src/test/run-pass/issues/issue-50731.rs
+++ b/src/test/run-pass/issues/issue-50731.rs
@@ -1,6 +1,9 @@
 // run-pass
 enum Void {}
+
+#[allow(unreachable_code)]
 fn foo(_: Result<(Void, u32), (Void, String)>) {}
+
 fn main() {
     let _: fn(_) = foo;
 }

--- a/src/test/run-pass/never-type-rvalues.rs
+++ b/src/test/run-pass/never-type-rvalues.rs
@@ -2,6 +2,7 @@
 #![allow(dead_code)]
 #![allow(path_statements)]
 #![allow(unreachable_patterns)]
+#![allow(unreachable_code)]
 
 fn never_direct(x: !) {
     x;

--- a/src/test/ui/match/match-no-arms-unreachable-after.rs
+++ b/src/test/ui/match/match-no-arms-unreachable-after.rs
@@ -3,10 +3,13 @@
 
 enum Void { }
 
-fn foo(v: Void) {
-    match v { }
+fn bar() -> Void {
+    unreachable!()
+}
+
+fn foo() {
+    match bar() { }
     let x = 2; //~ ERROR unreachable
 }
 
-fn main() {
-}
+fn main() {}

--- a/src/test/ui/match/match-no-arms-unreachable-after.stderr
+++ b/src/test/ui/match/match-no-arms-unreachable-after.stderr
@@ -1,5 +1,5 @@
 error: unreachable statement
-  --> $DIR/match-no-arms-unreachable-after.rs:8:5
+  --> $DIR/match-no-arms-unreachable-after.rs:12:5
    |
 LL |     let x = 2; //~ ERROR unreachable
    |     ^^^^^^^^^^

--- a/src/test/ui/reachable/expr_call.rs
+++ b/src/test/ui/reachable/expr_call.rs
@@ -4,9 +4,9 @@
 #![allow(dead_code)]
 #![deny(unreachable_code)]
 
-fn foo(x: !, y: usize) { }
+fn foo(x: (), y: usize) {}
 
-fn bar(x: !) { }
+fn bar(x: ()) {}
 
 fn a() {
     // the `22` is unreachable:

--- a/src/test/ui/uninhabited/uninhabited-function-parameter-warning.rs
+++ b/src/test/ui/uninhabited/uninhabited-function-parameter-warning.rs
@@ -1,0 +1,17 @@
+#![deny(unreachable_code)]
+
+enum Void {}
+
+fn foo(a: (), b: Void) { //~ ERROR functions with parameters of uninhabited types are uncallable
+    a
+}
+
+trait Foo {
+    fn foo(a: Self);
+}
+
+impl Foo for Void {
+    fn foo(a: Void) {} // ok
+}
+
+fn main() {}

--- a/src/test/ui/uninhabited/uninhabited-function-parameter-warning.rs
+++ b/src/test/ui/uninhabited/uninhabited-function-parameter-warning.rs
@@ -2,9 +2,29 @@
 
 enum Void {}
 
+mod hide {
+    pub struct PrivatelyUninhabited(::Void);
+
+    pub struct PubliclyUninhabited(pub ::Void);
+}
+
+// Check that functions with (publicly) uninhabited parameters trigger a lint.
+
 fn foo(a: (), b: Void) { //~ ERROR functions with parameters of uninhabited types are uncallable
     a
 }
+
+fn bar(a: (), b: hide::PrivatelyUninhabited) { // ok
+    a
+}
+
+fn baz(a: (), b: hide::PubliclyUninhabited) {
+    //~^ ERROR functions with parameters of uninhabited types are uncallable
+    a
+}
+
+// Check that trait methods with uninhabited parameters do not trigger a lint
+// (at least for now).
 
 trait Foo {
     fn foo(a: Self);

--- a/src/test/ui/uninhabited/uninhabited-function-parameter-warning.rs
+++ b/src/test/ui/uninhabited/uninhabited-function-parameter-warning.rs
@@ -8,10 +8,14 @@ fn foo(a: (), b: Void) { //~ ERROR functions with parameters of uninhabited type
 
 trait Foo {
     fn foo(a: Self);
+
+    fn bar(b: Void);
 }
 
 impl Foo for Void {
     fn foo(a: Void) {} // ok
+
+    fn bar(b: Void) {} // ok
 }
 
 fn main() {}

--- a/src/test/ui/uninhabited/uninhabited-function-parameter-warning.stderr
+++ b/src/test/ui/uninhabited/uninhabited-function-parameter-warning.stderr
@@ -1,5 +1,5 @@
 error: functions with parameters of uninhabited types are uncallable
-  --> $DIR/uninhabited-function-parameter-warning.rs:5:1
+  --> $DIR/uninhabited-function-parameter-warning.rs:13:1
    |
 LL |   fn foo(a: (), b: Void) { //~ ERROR functions with parameters of uninhabited types are uncallable
    |   ^             - this parameter has an uninhabited type
@@ -15,5 +15,17 @@ note: lint level defined here
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
 
-error: aborting due to previous error
+error: functions with parameters of uninhabited types are uncallable
+  --> $DIR/uninhabited-function-parameter-warning.rs:21:1
+   |
+LL |   fn baz(a: (), b: hide::PubliclyUninhabited) {
+   |   ^             - this parameter has an uninhabited type
+   |  _|
+   | |
+LL | |     //~^ ERROR functions with parameters of uninhabited types are uncallable
+LL | |     a
+LL | | }
+   | |_^
+
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/uninhabited/uninhabited-function-parameter-warning.stderr
+++ b/src/test/ui/uninhabited/uninhabited-function-parameter-warning.stderr
@@ -1,0 +1,19 @@
+error: functions with parameters of uninhabited types are uncallable
+  --> $DIR/uninhabited-function-parameter-warning.rs:5:1
+   |
+LL |   fn foo(a: (), b: Void) { //~ ERROR functions with parameters of uninhabited types are uncallable
+   |   ^             - this parameter has an uninhabited type
+   |  _|
+   | |
+LL | |     a
+LL | | }
+   | |_^
+   |
+note: lint level defined here
+  --> $DIR/uninhabited-function-parameter-warning.rs:1:9
+   |
+LL | #![deny(unreachable_code)]
+   |         ^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/unreachable/unwarned-match-on-never.rs
+++ b/src/test/ui/unreachable/unwarned-match-on-never.rs
@@ -1,13 +1,17 @@
+#![feature(never_type)]
+
 #![deny(unreachable_code)]
 #![allow(dead_code)]
 
-#![feature(never_type)]
+fn never() -> ! {
+    unimplemented!()
+}
 
-fn foo(x: !) -> bool {
+fn foo() -> bool {
     // Explicit matches on the never type are unwarned.
-    match x {}
+    match never() {}
     // But matches in unreachable code are warned.
-    match x {} //~ ERROR unreachable expression
+    match never() {} //~ ERROR unreachable expression
 }
 
 fn bar() {

--- a/src/test/ui/unreachable/unwarned-match-on-never.stderr
+++ b/src/test/ui/unreachable/unwarned-match-on-never.stderr
@@ -1,23 +1,23 @@
 error: unreachable expression
-  --> $DIR/unwarned-match-on-never.rs:10:5
+  --> $DIR/unwarned-match-on-never.rs:14:5
    |
-LL |     match x {} //~ ERROR unreachable expression
-   |     ^^^^^^^^^^
+LL |     match never() {} //~ ERROR unreachable expression
+   |     ^^^^^^^^^^^^^^^^
    |
 note: lint level defined here
-  --> $DIR/unwarned-match-on-never.rs:1:9
+  --> $DIR/unwarned-match-on-never.rs:3:9
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
 
 error: unreachable arm
-  --> $DIR/unwarned-match-on-never.rs:15:15
+  --> $DIR/unwarned-match-on-never.rs:19:15
    |
 LL |         () => () //~ ERROR unreachable arm
    |               ^^
 
 error: unreachable expression
-  --> $DIR/unwarned-match-on-never.rs:21:5
+  --> $DIR/unwarned-match-on-never.rs:25:5
    |
 LL | /     match () { //~ ERROR unreachable expression
 LL | |         () => (),


### PR DESCRIPTION
Functions with parameters whose types are uninhabited now fall under the `unreachable_code` lint, unless they're part of a trait implementation, as these are currently necessary.

r? @nikomatsakis 