### PR TITLE
use structured suggestion for "missing mut" label

### DIFF
--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -45,7 +45,7 @@ use rustc_data_structures::sync::Lrc;
 use std::hash::{Hash, Hasher};
 use syntax::ast;
 use syntax_pos::{MultiSpan, Span};
-use errors::{DiagnosticBuilder, DiagnosticId};
+use errors::{Applicability, DiagnosticBuilder, DiagnosticId};
 
 use rustc::hir;
 use rustc::hir::intravisit::{self, Visitor};
@@ -1299,9 +1299,11 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
                         snippet
                     );
                 } else {
-                    db.span_label(
+                    db.span_suggestion_with_applicability(
                         let_span,
-                        format!("consider changing this to `mut {}`", snippet),
+                        "make this binding mutable",
+                        format!("mut {}", snippet),
+                        Applicability::MachineApplicable,
                     );
                 }
             }

--- a/src/librustc_mir/borrow_check/error_reporting.rs
+++ b/src/librustc_mir/borrow_check/error_reporting.rs
@@ -17,7 +17,7 @@ use rustc::mir::{ProjectionElem, Rvalue, Statement, StatementKind};
 use rustc::ty;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_data_structures::sync::Lrc;
-use rustc_errors::DiagnosticBuilder;
+use rustc_errors::{Applicability, DiagnosticBuilder};
 use syntax_pos::Span;
 
 use super::borrow_set::BorrowData;
@@ -690,9 +690,11 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
         if let Some(decl) = local_decl {
             if let Some(name) = decl.name {
                 if decl.can_be_made_mutable() {
-                    err.span_label(
+                    err.span_suggestion_with_applicability(
                         decl.source_info.span,
-                        format!("consider changing this to `mut {}`", name),
+                        "make this binding mutable",
+                        format!("mut {}", name),
+                        Applicability::MachineApplicable,
                     );
                 }
             }

--- a/src/test/ui/E0596.ast.stderr
+++ b/src/test/ui/E0596.ast.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow immutable local variable `x` as mutable
   --> $DIR/E0596.rs:16:18
    |
 LL |     let x = 1;
-   |         - consider changing this to `mut x`
+   |         - help: make this binding mutable: `mut x`
 LL |     let y = &mut x; //[ast]~ ERROR [E0596]
    |                  ^ cannot borrow mutably
 

--- a/src/test/ui/asm/asm-out-assign-imm.nll.stderr
+++ b/src/test/ui/asm/asm-out-assign-imm.nll.stderr
@@ -2,7 +2,7 @@ error[E0384]: cannot assign twice to immutable variable `x`
   --> $DIR/asm-out-assign-imm.rs:34:9
    |
 LL |     let x: isize;
-   |         - consider changing this to `mut x`
+   |         - help: make this binding mutable: `mut x`
 LL |     x = 1;
    |     ----- first assignment to `x`
 ...

--- a/src/test/ui/assign-imm-local-twice.ast.nll.stderr
+++ b/src/test/ui/assign-imm-local-twice.ast.nll.stderr
@@ -1,9 +1,9 @@
 error[E0384]: cannot assign twice to immutable variable `v`
-  --> $DIR/assign-imm-local-twice.rs:20:5
+  --> $DIR/assign-imm-local-twice.rs:21:5
    |
 LL |     let v: isize;
-   |         - consider changing this to `mut v`
-LL |     //[mir]~^ NOTE consider changing this to `mut v`
+   |         - help: make this binding mutable: `mut v`
+...
 LL |     v = 1; //[ast]~ NOTE first assignment
    |     ----- first assignment to `v`
 ...

--- a/src/test/ui/assign-imm-local-twice.ast.stderr
+++ b/src/test/ui/assign-imm-local-twice.ast.stderr
@@ -1,5 +1,5 @@
 error[E0384]: cannot assign twice to immutable variable `v`
-  --> $DIR/assign-imm-local-twice.rs:20:5
+  --> $DIR/assign-imm-local-twice.rs:21:5
    |
 LL |     v = 1; //[ast]~ NOTE first assignment
    |     ----- first assignment to `v`

--- a/src/test/ui/assign-imm-local-twice.mir.stderr
+++ b/src/test/ui/assign-imm-local-twice.mir.stderr
@@ -1,9 +1,9 @@
 error[E0384]: cannot assign twice to immutable variable `v`
-  --> $DIR/assign-imm-local-twice.rs:20:5
+  --> $DIR/assign-imm-local-twice.rs:21:5
    |
 LL |     let v: isize;
-   |         - consider changing this to `mut v`
-LL |     //[mir]~^ NOTE consider changing this to `mut v`
+   |         - help: make this binding mutable: `mut v`
+...
 LL |     v = 1; //[ast]~ NOTE first assignment
    |     ----- first assignment to `v`
 ...

--- a/src/test/ui/assign-imm-local-twice.rs
+++ b/src/test/ui/assign-imm-local-twice.rs
@@ -13,7 +13,8 @@
 
 fn test() {
     let v: isize;
-    //[mir]~^ NOTE consider changing this to `mut v`
+    //[mir]~^ HELP make this binding mutable
+    //[mir]~| SUGGESTION mut v
     v = 1; //[ast]~ NOTE first assignment
            //[mir]~^ NOTE first assignment
     println!("v={}", v);

--- a/src/test/ui/augmented-assignments.nll.stderr
+++ b/src/test/ui/augmented-assignments.nll.stderr
@@ -15,11 +15,11 @@ LL | |     x;  //~ value moved here
    |       borrow later used here
 
 error[E0596]: cannot borrow `y` as mutable, as it is not declared as mutable
-  --> $DIR/augmented-assignments.rs:30:5
+  --> $DIR/augmented-assignments.rs:31:5
    |
 LL |     let y = Int(2);
    |         - help: consider changing this to be mutable: `mut y`
-LL |     //~^ consider changing this to `mut y`
+...
 LL |     y   //~ error: cannot borrow immutable local variable `y` as mutable
    |     ^ cannot borrow as mutable
 

--- a/src/test/ui/augmented-assignments.rs
+++ b/src/test/ui/augmented-assignments.rs
@@ -26,7 +26,8 @@ fn main() {
     x;  //~ value moved here
 
     let y = Int(2);
-    //~^ consider changing this to `mut y`
+    //~^ HELP make this binding mutable
+    //~| SUGGESTION mut y
     y   //~ error: cannot borrow immutable local variable `y` as mutable
         //~| cannot borrow
     +=

--- a/src/test/ui/augmented-assignments.stderr
+++ b/src/test/ui/augmented-assignments.stderr
@@ -1,9 +1,9 @@
 error[E0596]: cannot borrow immutable local variable `y` as mutable
-  --> $DIR/augmented-assignments.rs:30:5
+  --> $DIR/augmented-assignments.rs:31:5
    |
 LL |     let y = Int(2);
-   |         - consider changing this to `mut y`
-LL |     //~^ consider changing this to `mut y`
+   |         - help: make this binding mutable: `mut y`
+...
 LL |     y   //~ error: cannot borrow immutable local variable `y` as mutable
    |     ^ cannot borrow mutably
 

--- a/src/test/ui/borrowck/borrowck-access-permissions.ast.stderr
+++ b/src/test/ui/borrowck/borrowck-access-permissions.ast.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow immutable local variable `x` as mutable
   --> $DIR/borrowck-access-permissions.rs:22:24
    |
 LL |     let x = 1;
-   |         - consider changing this to `mut x`
+   |         - help: make this binding mutable: `mut x`
 ...
 LL |         let _y1 = &mut x; //[ast]~ ERROR [E0596]
    |                        ^ cannot borrow mutably
@@ -17,7 +17,7 @@ error[E0596]: cannot borrow immutable `Box` content `*box_x` as mutable
   --> $DIR/borrowck-access-permissions.rs:37:24
    |
 LL |         let box_x = Box::new(1);
-   |             ----- consider changing this to `mut box_x`
+   |             ----- help: make this binding mutable: `mut box_x`
 ...
 LL |         let _y1 = &mut *box_x; //[ast]~ ERROR [E0596]
    |                        ^^^^^^ cannot borrow as mutable

--- a/src/test/ui/borrowck/borrowck-argument.stderr
+++ b/src/test/ui/borrowck/borrowck-argument.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow immutable argument `arg` as mutable
   --> $DIR/borrowck-argument.rs:20:5
    |
 LL | fn func(arg: S) {
-   |         --- consider changing this to `mut arg`
+   |         --- help: make this binding mutable: `mut arg`
 LL |     arg.mutate(); //~ ERROR: cannot borrow immutable argument
    |     ^^^ cannot borrow mutably
 
@@ -10,7 +10,7 @@ error[E0596]: cannot borrow immutable argument `arg` as mutable
   --> $DIR/borrowck-argument.rs:25:9
    |
 LL |     fn method(&self, arg: S) {
-   |                      --- consider changing this to `mut arg`
+   |                      --- help: make this binding mutable: `mut arg`
 LL |         arg.mutate(); //~ ERROR: cannot borrow immutable argument
    |         ^^^ cannot borrow mutably
 
@@ -18,7 +18,7 @@ error[E0596]: cannot borrow immutable argument `arg` as mutable
   --> $DIR/borrowck-argument.rs:31:9
    |
 LL |     fn default(&self, arg: S) {
-   |                       --- consider changing this to `mut arg`
+   |                       --- help: make this binding mutable: `mut arg`
 LL |         arg.mutate(); //~ ERROR: cannot borrow immutable argument
    |         ^^^ cannot borrow mutably
 
@@ -28,7 +28,7 @@ error[E0596]: cannot borrow immutable argument `arg` as mutable
 LL |     (|arg: S| { arg.mutate() })(s); //~ ERROR: cannot borrow immutable argument
    |       ---       ^^^ cannot borrow mutably
    |       |
-   |       consider changing this to `mut arg`
+   |       help: make this binding mutable: `mut arg`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/borrowck/borrowck-asm.ast.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-asm.ast.nll.stderr
@@ -28,7 +28,7 @@ LL |         let x = 3;
    |             -
    |             |
    |             first assignment to `x`
-   |             consider changing this to `mut x`
+   |             help: make this binding mutable: `mut x`
 LL |         unsafe {
 LL |             asm!("nop" : "=r"(x));  //[ast]~ ERROR cannot assign twice
    |             ^^^^^^^^^^^^^^^^^^^^^^ cannot assign twice to immutable variable
@@ -40,7 +40,7 @@ LL |         let x = 3;
    |             -
    |             |
    |             first assignment to `x`
-   |             consider changing this to `mut x`
+   |             help: make this binding mutable: `mut x`
 LL |         unsafe {
 LL |             asm!("nop" : "+r"(x));  //[ast]~ ERROR cannot assign twice
    |             ^^^^^^^^^^^^^^^^^^^^^^ cannot assign twice to immutable variable

--- a/src/test/ui/borrowck/borrowck-asm.mir.stderr
+++ b/src/test/ui/borrowck/borrowck-asm.mir.stderr
@@ -28,7 +28,7 @@ LL |         let x = 3;
    |             -
    |             |
    |             first assignment to `x`
-   |             consider changing this to `mut x`
+   |             help: make this binding mutable: `mut x`
 LL |         unsafe {
 LL |             asm!("nop" : "=r"(x));  //[ast]~ ERROR cannot assign twice
    |             ^^^^^^^^^^^^^^^^^^^^^^ cannot assign twice to immutable variable
@@ -40,7 +40,7 @@ LL |         let x = 3;
    |             -
    |             |
    |             first assignment to `x`
-   |             consider changing this to `mut x`
+   |             help: make this binding mutable: `mut x`
 LL |         unsafe {
 LL |             asm!("nop" : "+r"(x));  //[ast]~ ERROR cannot assign twice
    |             ^^^^^^^^^^^^^^^^^^^^^^ cannot assign twice to immutable variable

--- a/src/test/ui/borrowck/borrowck-auto-mut-ref-to-immut-var.stderr
+++ b/src/test/ui/borrowck/borrowck-auto-mut-ref-to-immut-var.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow immutable local variable `x` as mutable
   --> $DIR/borrowck-auto-mut-ref-to-immut-var.rs:25:5
    |
 LL |     let x = Foo { x: 3 };
-   |         - consider changing this to `mut x`
+   |         - help: make this binding mutable: `mut x`
 LL |     x.printme();    //~ ERROR cannot borrow
    |     ^ cannot borrow mutably
 

--- a/src/test/ui/borrowck/borrowck-borrow-from-owned-ptr.stderr
+++ b/src/test/ui/borrowck/borrowck-borrow-from-owned-ptr.stderr
@@ -147,7 +147,7 @@ error[E0596]: cannot borrow field `foo.bar1` of immutable binding as mutable
   --> $DIR/borrowck-borrow-from-owned-ptr.rs:132:21
    |
 LL |     let foo = make_foo();
-   |         --- consider changing this to `mut foo`
+   |         --- help: make this binding mutable: `mut foo`
 LL |     let bar1 = &mut foo.bar1; //~ ERROR cannot borrow
    |                     ^^^^^^^^ cannot mutably borrow field of immutable binding
 

--- a/src/test/ui/borrowck/borrowck-borrow-from-stack-variable.stderr
+++ b/src/test/ui/borrowck/borrowck-borrow-from-stack-variable.stderr
@@ -114,7 +114,7 @@ error[E0596]: cannot borrow field `foo.bar1` of immutable binding as mutable
   --> $DIR/borrowck-borrow-from-stack-variable.rs:130:21
    |
 LL |     let foo = make_foo();
-   |         --- consider changing this to `mut foo`
+   |         --- help: make this binding mutable: `mut foo`
 LL |     let bar1 = &mut foo.bar1; //~ ERROR cannot borrow
    |                     ^^^^^^^^ cannot mutably borrow field of immutable binding
 

--- a/src/test/ui/borrowck/borrowck-borrow-immut-deref-of-box-as-mut.stderr
+++ b/src/test/ui/borrowck/borrowck-borrow-immut-deref-of-box-as-mut.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow immutable `Box` content `*a` as mutable
   --> $DIR/borrowck-borrow-immut-deref-of-box-as-mut.rs:22:5
    |
 LL |     let a: Box<_> = box A;
-   |         - consider changing this to `mut a`
+   |         - help: make this binding mutable: `mut a`
 LL |     a.foo();
    |     ^ cannot borrow as mutable
 

--- a/src/test/ui/borrowck/borrowck-match-binding-is-assignment.ast.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-match-binding-is-assignment.ast.nll.stderr
@@ -5,7 +5,7 @@ LL |         x => {
    |         -
    |         |
    |         first assignment to `x`
-   |         consider changing this to `mut x`
+   |         help: make this binding mutable: `mut x`
 LL |             x += 1; //[ast]~ ERROR cannot assign twice to immutable variable `x`
    |             ^^^^^^ cannot assign twice to immutable variable
 
@@ -16,7 +16,7 @@ LL |         E::Foo(x) => {
    |                -
    |                |
    |                first assignment to `x`
-   |                consider changing this to `mut x`
+   |                help: make this binding mutable: `mut x`
 LL |             x += 1; //[ast]~ ERROR cannot assign twice to immutable variable `x`
    |             ^^^^^^ cannot assign twice to immutable variable
 
@@ -27,7 +27,7 @@ LL |         S { bar: x } => {
    |                  -
    |                  |
    |                  first assignment to `x`
-   |                  consider changing this to `mut x`
+   |                  help: make this binding mutable: `mut x`
 LL |             x += 1; //[ast]~ ERROR cannot assign twice to immutable variable `x`
    |             ^^^^^^ cannot assign twice to immutable variable
 
@@ -38,7 +38,7 @@ LL |         (x,) => {
    |          -
    |          |
    |          first assignment to `x`
-   |          consider changing this to `mut x`
+   |          help: make this binding mutable: `mut x`
 LL |             x += 1; //[ast]~ ERROR cannot assign twice to immutable variable `x`
    |             ^^^^^^ cannot assign twice to immutable variable
 
@@ -49,7 +49,7 @@ LL |         [x,_,_] => {
    |          -
    |          |
    |          first assignment to `x`
-   |          consider changing this to `mut x`
+   |          help: make this binding mutable: `mut x`
 LL |             x += 1; //[ast]~ ERROR cannot assign twice to immutable variable `x`
    |             ^^^^^^ cannot assign twice to immutable variable
 

--- a/src/test/ui/borrowck/borrowck-match-binding-is-assignment.mir.stderr
+++ b/src/test/ui/borrowck/borrowck-match-binding-is-assignment.mir.stderr
@@ -5,7 +5,7 @@ LL |         x => {
    |         -
    |         |
    |         first assignment to `x`
-   |         consider changing this to `mut x`
+   |         help: make this binding mutable: `mut x`
 LL |             x += 1; //[ast]~ ERROR cannot assign twice to immutable variable `x`
    |             ^^^^^^ cannot assign twice to immutable variable
 
@@ -16,7 +16,7 @@ LL |         E::Foo(x) => {
    |                -
    |                |
    |                first assignment to `x`
-   |                consider changing this to `mut x`
+   |                help: make this binding mutable: `mut x`
 LL |             x += 1; //[ast]~ ERROR cannot assign twice to immutable variable `x`
    |             ^^^^^^ cannot assign twice to immutable variable
 
@@ -27,7 +27,7 @@ LL |         S { bar: x } => {
    |                  -
    |                  |
    |                  first assignment to `x`
-   |                  consider changing this to `mut x`
+   |                  help: make this binding mutable: `mut x`
 LL |             x += 1; //[ast]~ ERROR cannot assign twice to immutable variable `x`
    |             ^^^^^^ cannot assign twice to immutable variable
 
@@ -38,7 +38,7 @@ LL |         (x,) => {
    |          -
    |          |
    |          first assignment to `x`
-   |          consider changing this to `mut x`
+   |          help: make this binding mutable: `mut x`
 LL |             x += 1; //[ast]~ ERROR cannot assign twice to immutable variable `x`
    |             ^^^^^^ cannot assign twice to immutable variable
 
@@ -49,7 +49,7 @@ LL |         [x,_,_] => {
    |          -
    |          |
    |          first assignment to `x`
-   |          consider changing this to `mut x`
+   |          help: make this binding mutable: `mut x`
 LL |             x += 1; //[ast]~ ERROR cannot assign twice to immutable variable `x`
    |             ^^^^^^ cannot assign twice to immutable variable
 

--- a/src/test/ui/borrowck/borrowck-mut-addr-of-imm-var.stderr
+++ b/src/test/ui/borrowck/borrowck-mut-addr-of-imm-var.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow immutable local variable `x` as mutable
   --> $DIR/borrowck-mut-addr-of-imm-var.rs:13:30
    |
 LL |     let x: isize = 3;
-   |         - consider changing this to `mut x`
+   |         - help: make this binding mutable: `mut x`
 LL |     let y: &mut isize = &mut x; //~ ERROR cannot borrow
    |                              ^ cannot borrow mutably
 

--- a/src/test/ui/borrowck/borrowck-mut-slice-of-imm-vec.stderr
+++ b/src/test/ui/borrowck/borrowck-mut-slice-of-imm-vec.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow immutable local variable `v` as mutable
   --> $DIR/borrowck-mut-slice-of-imm-vec.rs:17:16
    |
 LL |     let v = vec![1, 2, 3];
-   |         - consider changing this to `mut v`
+   |         - help: make this binding mutable: `mut v`
 LL |     write(&mut v); //~ ERROR cannot borrow
    |                ^ cannot borrow mutably
 

--- a/src/test/ui/borrowck/borrowck-overloaded-call.stderr
+++ b/src/test/ui/borrowck/borrowck-overloaded-call.stderr
@@ -12,7 +12,7 @@ error[E0596]: cannot borrow immutable local variable `s` as mutable
   --> $DIR/borrowck-overloaded-call.rs:77:5
    |
 LL |     let s = SFnMut {
-   |         - consider changing this to `mut s`
+   |         - help: make this binding mutable: `mut s`
 ...
 LL |     s(3);   //~ ERROR cannot borrow immutable local variable `s` as mutable
    |     ^ cannot borrow mutably

--- a/src/test/ui/borrowck/borrowck-ref-mut-of-imm.stderr
+++ b/src/test/ui/borrowck/borrowck-ref-mut-of-imm.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow field `(x as std::prelude::v1::Some).0` of immutable
   --> $DIR/borrowck-ref-mut-of-imm.rs:14:12
    |
 LL | fn destructure(x: Option<isize>) -> isize {
-   |                - consider changing this to `mut x`
+   |                - help: make this binding mutable: `mut x`
 ...
 LL |       Some(ref mut v) => *v //~ ERROR cannot borrow
    |            ^^^^^^^^^ cannot mutably borrow field of immutable binding

--- a/src/test/ui/borrowck/borrowck-unboxed-closures.stderr
+++ b/src/test/ui/borrowck/borrowck-unboxed-closures.stderr
@@ -12,7 +12,7 @@ error[E0596]: cannot borrow immutable argument `f` as mutable
   --> $DIR/borrowck-unboxed-closures.rs:17:5
    |
 LL | fn b<F:FnMut(isize, isize) -> isize>(f: F) {
-   |                                      - consider changing this to `mut f`
+   |                                      - help: make this binding mutable: `mut f`
 LL |     f(1, 2);    //~ ERROR cannot borrow immutable argument
    |     ^ cannot borrow mutably
 

--- a/src/test/ui/borrowck/immutable-arg.stderr
+++ b/src/test/ui/borrowck/immutable-arg.stderr
@@ -10,7 +10,7 @@ error[E0384]: cannot assign to immutable argument `_x` (Mir)
   --> $DIR/immutable-arg.rs:14:5
    |
 LL | fn foo(_x: u32) {
-   |        -- consider changing this to `mut _x`
+   |        -- help: make this binding mutable: `mut _x`
 LL |     _x = 4;
    |     ^^^^^^ cannot assign to immutable argument
 

--- a/src/test/ui/borrowck/mutability-errors.stderr
+++ b/src/test/ui/borrowck/mutability-errors.stderr
@@ -230,7 +230,7 @@ error[E0596]: cannot borrow immutable argument `x` as mutable
   --> $DIR/mutability-errors.rs:64:10
    |
 LL | fn imm_local(x: (i32,)) {
-   |              - consider changing this to `mut x`
+   |              - help: make this binding mutable: `mut x`
 LL |     &mut x; //~ ERROR
    |          ^ cannot borrow mutably
 
@@ -238,7 +238,7 @@ error[E0596]: cannot borrow field `x.0` of immutable binding as mutable
   --> $DIR/mutability-errors.rs:65:10
    |
 LL | fn imm_local(x: (i32,)) {
-   |              - consider changing this to `mut x`
+   |              - help: make this binding mutable: `mut x`
 LL |     &mut x; //~ ERROR
 LL |     &mut x.0; //~ ERROR
    |          ^^^ cannot mutably borrow field of immutable binding
@@ -247,7 +247,7 @@ error[E0595]: closure cannot assign to immutable argument `x`
   --> $DIR/mutability-errors.rs:69:5
    |
 LL | fn imm_capture(x: (i32,)) {
-   |                - consider changing this to `mut x`
+   |                - help: make this binding mutable: `mut x`
 LL |     || { //~ ERROR
    |     ^^ cannot borrow mutably
 

--- a/src/test/ui/borrowck/reassignment_immutable_fields.stderr
+++ b/src/test/ui/borrowck/reassignment_immutable_fields.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to field `x.0` of immutable binding
   --> $DIR/reassignment_immutable_fields.rs:17:5
    |
 LL |     let x: (u32, u32);
-   |         - consider changing this to `mut x`
+   |         - help: make this binding mutable: `mut x`
 LL |     x.0 = 1; //~ ERROR
    |     ^^^^^^^ cannot mutably borrow field of immutable binding
 
@@ -10,7 +10,7 @@ error[E0594]: cannot assign to field `x.1` of immutable binding
   --> $DIR/reassignment_immutable_fields.rs:18:5
    |
 LL |     let x: (u32, u32);
-   |         - consider changing this to `mut x`
+   |         - help: make this binding mutable: `mut x`
 LL |     x.0 = 1; //~ ERROR
 LL |     x.1 = 22; //~ ERROR
    |     ^^^^^^^^ cannot mutably borrow field of immutable binding
@@ -31,7 +31,7 @@ error[E0594]: cannot assign to field `x.0` of immutable binding
   --> $DIR/reassignment_immutable_fields.rs:25:5
    |
 LL |     let x: (u32, u32);
-   |         - consider changing this to `mut x`
+   |         - help: make this binding mutable: `mut x`
 LL |     x.0 = 1; //~ ERROR
    |     ^^^^^^^ cannot mutably borrow field of immutable binding
 
@@ -39,7 +39,7 @@ error[E0594]: cannot assign to field `x.1` of immutable binding
   --> $DIR/reassignment_immutable_fields.rs:26:5
    |
 LL |     let x: (u32, u32);
-   |         - consider changing this to `mut x`
+   |         - help: make this binding mutable: `mut x`
 LL |     x.0 = 1; //~ ERROR
 LL |     x.1 = 22; //~ ERROR
    |     ^^^^^^^^ cannot mutably borrow field of immutable binding

--- a/src/test/ui/borrowck/reassignment_immutable_fields_overlapping.stderr
+++ b/src/test/ui/borrowck/reassignment_immutable_fields_overlapping.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to field `x.a` of immutable binding
   --> $DIR/reassignment_immutable_fields_overlapping.rs:22:5
    |
 LL |     let x: Foo;
-   |         - consider changing this to `mut x`
+   |         - help: make this binding mutable: `mut x`
 LL |     x.a = 1;  //~ ERROR
    |     ^^^^^^^ cannot mutably borrow field of immutable binding
 
@@ -10,7 +10,7 @@ error[E0594]: cannot assign to field `x.b` of immutable binding
   --> $DIR/reassignment_immutable_fields_overlapping.rs:23:5
    |
 LL |     let x: Foo;
-   |         - consider changing this to `mut x`
+   |         - help: make this binding mutable: `mut x`
 LL |     x.a = 1;  //~ ERROR
 LL |     x.b = 22; //~ ERROR
    |     ^^^^^^^^ cannot mutably borrow field of immutable binding

--- a/src/test/ui/borrowck/reassignment_immutable_fields_twice.stderr
+++ b/src/test/ui/borrowck/reassignment_immutable_fields_twice.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to field `x.0` of immutable binding
   --> $DIR/reassignment_immutable_fields_twice.rs:17:5
    |
 LL |     let x: (u32, u32);
-   |         - consider changing this to `mut x`
+   |         - help: make this binding mutable: `mut x`
 LL |     x = (22, 44);
 LL |     x.0 = 1; //~ ERROR
    |     ^^^^^^^ cannot mutably borrow field of immutable binding
@@ -11,7 +11,7 @@ error[E0594]: cannot assign to field `x.0` of immutable binding
   --> $DIR/reassignment_immutable_fields_twice.rs:22:5
    |
 LL |     let x: (u32, u32);
-   |         - consider changing this to `mut x`
+   |         - help: make this binding mutable: `mut x`
 LL |     x.0 = 1; //~ ERROR
    |     ^^^^^^^ cannot mutably borrow field of immutable binding
 
@@ -19,7 +19,7 @@ error[E0594]: cannot assign to field `x.0` of immutable binding
   --> $DIR/reassignment_immutable_fields_twice.rs:23:5
    |
 LL |     let x: (u32, u32);
-   |         - consider changing this to `mut x`
+   |         - help: make this binding mutable: `mut x`
 LL |     x.0 = 1; //~ ERROR
 LL |     x.0 = 22; //~ ERROR
    |     ^^^^^^^^ cannot mutably borrow field of immutable binding
@@ -28,7 +28,7 @@ error[E0594]: cannot assign to field `x.1` of immutable binding
   --> $DIR/reassignment_immutable_fields_twice.rs:24:5
    |
 LL |     let x: (u32, u32);
-   |         - consider changing this to `mut x`
+   |         - help: make this binding mutable: `mut x`
 ...
 LL |     x.1 = 44; //~ ERROR
    |     ^^^^^^^^ cannot mutably borrow field of immutable binding

--- a/src/test/ui/codemap_tests/huge_multispan_highlight.stderr
+++ b/src/test/ui/codemap_tests/huge_multispan_highlight.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow immutable local variable `x` as mutable
   --> $DIR/huge_multispan_highlight.rs:100:18
    |
 LL |     let x = "foo";
-   |         - consider changing this to `mut x`
+   |         - help: make this binding mutable: `mut x`
 ...
 LL |     let y = &mut x; //~ ERROR cannot borrow
    |                  ^ cannot borrow mutably

--- a/src/test/ui/command-line-diagnostics.nll.stderr
+++ b/src/test/ui/command-line-diagnostics.nll.stderr
@@ -5,7 +5,7 @@ LL |     let x = 42;
    |         -
    |         |
    |         first assignment to `x`
-   |         consider changing this to `mut x`
+   |         help: make this binding mutable: `mut x`
 LL |     x = 43;
    |     ^^^^^^ cannot assign twice to immutable variable
 

--- a/src/test/ui/did_you_mean/issue-35937.stderr
+++ b/src/test/ui/did_you_mean/issue-35937.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow field `f.v` of immutable binding as mutable
   --> $DIR/issue-35937.rs:17:5
    |
 LL |     let f = Foo { v: Vec::new() };
-   |         - consider changing this to `mut f`
+   |         - help: make this binding mutable: `mut f`
 LL |     f.v.push("cat".to_string()); //~ ERROR cannot borrow
    |     ^^^ cannot mutably borrow field of immutable binding
 
@@ -10,7 +10,7 @@ error[E0594]: cannot assign to field `s.x` of immutable binding
   --> $DIR/issue-35937.rs:26:5
    |
 LL |     let s = S { x: 42 };
-   |         - consider changing this to `mut s`
+   |         - help: make this binding mutable: `mut s`
 LL |     s.x += 1; //~ ERROR cannot assign
    |     ^^^^^^^^ cannot mutably borrow field of immutable binding
 
@@ -18,7 +18,7 @@ error[E0594]: cannot assign to field `s.x` of immutable binding
   --> $DIR/issue-35937.rs:30:5
    |
 LL | fn bar(s: S) {
-   |        - consider changing this to `mut s`
+   |        - help: make this binding mutable: `mut s`
 LL |     s.x += 1; //~ ERROR cannot assign
    |     ^^^^^^^^ cannot mutably borrow field of immutable binding
 

--- a/src/test/ui/did_you_mean/issue-39544.stderr
+++ b/src/test/ui/did_you_mean/issue-39544.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow field `z.x` of immutable binding as mutable
   --> $DIR/issue-39544.rs:21:18
    |
 LL |     let z = Z { x: X::Y };
-   |         - consider changing this to `mut z`
+   |         - help: make this binding mutable: `mut z`
 LL |     let _ = &mut z.x; //~ ERROR cannot borrow
    |                  ^^^ cannot mutably borrow field of immutable binding
 
@@ -77,7 +77,7 @@ error[E0596]: cannot borrow field `z.x` of immutable binding as mutable
   --> $DIR/issue-39544.rs:51:18
    |
 LL | pub fn with_arg(z: Z, w: &Z) {
-   |                 - consider changing this to `mut z`
+   |                 - help: make this binding mutable: `mut z`
 LL |     let _ = &mut z.x; //~ ERROR cannot borrow
    |                  ^^^ cannot mutably borrow field of immutable binding
 

--- a/src/test/ui/immut-function-arguments.ast.stderr
+++ b/src/test/ui/immut-function-arguments.ast.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to immutable `Box` content `*y`
   --> $DIR/immut-function-arguments.rs:15:5
    |
 LL | fn f(y: Box<isize>) {
-   |      - consider changing this to `mut y`
+   |      - help: make this binding mutable: `mut y`
 LL |     *y = 5; //[ast]~ ERROR cannot assign
    |     ^^^^^^ cannot borrow as mutable
 
@@ -12,7 +12,7 @@ error[E0594]: cannot assign to immutable `Box` content `*q`
 LL |     let _frob = |q: Box<isize>| { *q = 2; }; //[ast]~ ERROR cannot assign
    |                  -                ^^^^^^ cannot borrow as mutable
    |                  |
-   |                  consider changing this to `mut q`
+   |                  help: make this binding mutable: `mut q`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-36400.stderr
+++ b/src/test/ui/issues/issue-36400.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow immutable `Box` content `*x` as mutable
   --> $DIR/issue-36400.rs:15:12
    |
 LL |     let x = Box::new(3);
-   |         - consider changing this to `mut x`
+   |         - help: make this binding mutable: `mut x`
 LL |     f(&mut *x); //~ ERROR cannot borrow immutable
    |            ^^ cannot borrow as mutable
 

--- a/src/test/ui/issues/issue-45199.ast.nll.stderr
+++ b/src/test/ui/issues/issue-45199.ast.nll.stderr
@@ -1,9 +1,9 @@
 error[E0384]: cannot assign twice to immutable variable `b`
-  --> $DIR/issue-45199.rs:19:5
+  --> $DIR/issue-45199.rs:20:5
    |
 LL |     let b: Box<isize>;
-   |         - consider changing this to `mut b`
-LL |     //[mir]~^ NOTE consider changing this to `mut b`
+   |         - help: make this binding mutable: `mut b`
+...
 LL |     b = Box::new(1);    //[ast]~ NOTE first assignment
    |     - first assignment to `b`
 LL |                         //[mir]~^ NOTE first assignment
@@ -11,23 +11,23 @@ LL |     b = Box::new(2);    //[ast]~ ERROR cannot assign twice to immutable var
    |     ^ cannot assign twice to immutable variable
 
 error[E0384]: cannot assign twice to immutable variable `b`
-  --> $DIR/issue-45199.rs:29:5
+  --> $DIR/issue-45199.rs:31:5
    |
 LL |     let b = Box::new(1);    //[ast]~ NOTE first assignment
    |         -
    |         |
    |         first assignment to `b`
-   |         consider changing this to `mut b`
+   |         help: make this binding mutable: `mut b`
 ...
 LL |     b = Box::new(2);        //[ast]~ ERROR cannot assign twice to immutable variable
    |     ^ cannot assign twice to immutable variable
 
 error[E0384]: cannot assign to immutable argument `b`
-  --> $DIR/issue-45199.rs:37:5
+  --> $DIR/issue-45199.rs:40:5
    |
 LL | fn test_args(b: Box<i32>) {  //[ast]~ NOTE first assignment
-   |              - consider changing this to `mut b`
-LL |                                 //[mir]~^ NOTE consider changing this to `mut b`
+   |              - help: make this binding mutable: `mut b`
+...
 LL |     b = Box::new(2);            //[ast]~ ERROR cannot assign twice to immutable variable
    |     ^ cannot assign to immutable argument
 

--- a/src/test/ui/issues/issue-45199.ast.stderr
+++ b/src/test/ui/issues/issue-45199.ast.stderr
@@ -1,5 +1,5 @@
 error[E0384]: cannot assign twice to immutable variable `b`
-  --> $DIR/issue-45199.rs:19:5
+  --> $DIR/issue-45199.rs:20:5
    |
 LL |     b = Box::new(1);    //[ast]~ NOTE first assignment
    |     --------------- first assignment to `b`
@@ -8,7 +8,7 @@ LL |     b = Box::new(2);    //[ast]~ ERROR cannot assign twice to immutable var
    |     ^^^^^^^^^^^^^^^ cannot assign twice to immutable variable
 
 error[E0384]: cannot assign twice to immutable variable `b`
-  --> $DIR/issue-45199.rs:29:5
+  --> $DIR/issue-45199.rs:31:5
    |
 LL |     let b = Box::new(1);    //[ast]~ NOTE first assignment
    |         - first assignment to `b`
@@ -17,11 +17,11 @@ LL |     b = Box::new(2);        //[ast]~ ERROR cannot assign twice to immutable
    |     ^^^^^^^^^^^^^^^ cannot assign twice to immutable variable
 
 error[E0384]: cannot assign twice to immutable variable `b`
-  --> $DIR/issue-45199.rs:37:5
+  --> $DIR/issue-45199.rs:40:5
    |
 LL | fn test_args(b: Box<i32>) {  //[ast]~ NOTE first assignment
    |              - first assignment to `b`
-LL |                                 //[mir]~^ NOTE consider changing this to `mut b`
+...
 LL |     b = Box::new(2);            //[ast]~ ERROR cannot assign twice to immutable variable
    |     ^^^^^^^^^^^^^^^ cannot assign twice to immutable variable
 

--- a/src/test/ui/issues/issue-45199.mir.stderr
+++ b/src/test/ui/issues/issue-45199.mir.stderr
@@ -1,9 +1,9 @@
 error[E0384]: cannot assign twice to immutable variable `b`
-  --> $DIR/issue-45199.rs:19:5
+  --> $DIR/issue-45199.rs:20:5
    |
 LL |     let b: Box<isize>;
-   |         - consider changing this to `mut b`
-LL |     //[mir]~^ NOTE consider changing this to `mut b`
+   |         - help: make this binding mutable: `mut b`
+...
 LL |     b = Box::new(1);    //[ast]~ NOTE first assignment
    |     - first assignment to `b`
 LL |                         //[mir]~^ NOTE first assignment
@@ -11,23 +11,23 @@ LL |     b = Box::new(2);    //[ast]~ ERROR cannot assign twice to immutable var
    |     ^ cannot assign twice to immutable variable
 
 error[E0384]: cannot assign twice to immutable variable `b`
-  --> $DIR/issue-45199.rs:29:5
+  --> $DIR/issue-45199.rs:31:5
    |
 LL |     let b = Box::new(1);    //[ast]~ NOTE first assignment
    |         -
    |         |
    |         first assignment to `b`
-   |         consider changing this to `mut b`
+   |         help: make this binding mutable: `mut b`
 ...
 LL |     b = Box::new(2);        //[ast]~ ERROR cannot assign twice to immutable variable
    |     ^ cannot assign twice to immutable variable
 
 error[E0384]: cannot assign to immutable argument `b`
-  --> $DIR/issue-45199.rs:37:5
+  --> $DIR/issue-45199.rs:40:5
    |
 LL | fn test_args(b: Box<i32>) {  //[ast]~ NOTE first assignment
-   |              - consider changing this to `mut b`
-LL |                                 //[mir]~^ NOTE consider changing this to `mut b`
+   |              - help: make this binding mutable: `mut b`
+...
 LL |     b = Box::new(2);            //[ast]~ ERROR cannot assign twice to immutable variable
    |     ^ cannot assign to immutable argument
 

--- a/src/test/ui/issues/issue-45199.rs
+++ b/src/test/ui/issues/issue-45199.rs
@@ -13,7 +13,8 @@
 
 fn test_drop_replace() {
     let b: Box<isize>;
-    //[mir]~^ NOTE consider changing this to `mut b`
+    //[mir]~^ HELP make this binding mutable
+    //[mir]~| SUGGESTION mut b
     b = Box::new(1);    //[ast]~ NOTE first assignment
                         //[mir]~^ NOTE first assignment
     b = Box::new(2);    //[ast]~ ERROR cannot assign twice to immutable variable
@@ -25,7 +26,8 @@ fn test_drop_replace() {
 fn test_call() {
     let b = Box::new(1);    //[ast]~ NOTE first assignment
                             //[mir]~^ NOTE first assignment
-                            //[mir]~| NOTE consider changing this to `mut b`
+                            //[mir]~| HELP make this binding mutable
+                            //[mir]~| SUGGESTION mut b
     b = Box::new(2);        //[ast]~ ERROR cannot assign twice to immutable variable
                             //[mir]~^ ERROR cannot assign twice to immutable variable `b`
                             //[ast]~| NOTE cannot assign twice to immutable
@@ -33,7 +35,8 @@ fn test_call() {
 }
 
 fn test_args(b: Box<i32>) {  //[ast]~ NOTE first assignment
-                                //[mir]~^ NOTE consider changing this to `mut b`
+                                //[mir]~^ HELP make this binding mutable
+                                //[mir]~| SUGGESTION mut b
     b = Box::new(2);            //[ast]~ ERROR cannot assign twice to immutable variable
                                 //[mir]~^ ERROR cannot assign to immutable argument `b`
                                 //[ast]~| NOTE cannot assign twice to immutable

--- a/src/test/ui/issues/issue-5500-1.ast.stderr
+++ b/src/test/ui/issues/issue-5500-1.ast.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to field `_iter.node` of immutable binding
   --> $DIR/issue-5500-1.rs:22:5
    |
 LL |       let _iter = TrieMapIterator{node: &a};
-   |           ----- consider changing this to `mut _iter`
+   |           ----- help: make this binding mutable: `mut _iter`
 LL | /     _iter.node = & //[ast]~ ERROR cannot assign to field `_iter.node` of immutable binding
 LL | |                    //[mir]~^ ERROR cannot assign to field `_iter.node` of immutable binding (Ast)
 LL | |                    // MIR doesn't generate an error because the code isn't reachable. This is OK

--- a/src/test/ui/issues/issue-5500-1.mir.stderr
+++ b/src/test/ui/issues/issue-5500-1.mir.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to field `_iter.node` of immutable binding (Ast)
   --> $DIR/issue-5500-1.rs:22:5
    |
 LL |       let _iter = TrieMapIterator{node: &a};
-   |           ----- consider changing this to `mut _iter`
+   |           ----- help: make this binding mutable: `mut _iter`
 LL | /     _iter.node = & //[ast]~ ERROR cannot assign to field `_iter.node` of immutable binding
 LL | |                    //[mir]~^ ERROR cannot assign to field `_iter.node` of immutable binding (Ast)
 LL | |                    // MIR doesn't generate an error because the code isn't reachable. This is OK

--- a/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-one-is-struct-2.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-one-is-struct-2.nll.stderr
@@ -12,7 +12,7 @@ error[E0384]: cannot assign to immutable argument `y`
   --> $DIR/ex3-both-anon-regions-one-is-struct-2.rs:14:5
    |
 LL | fn foo(mut x: Ref, y: &u32) {
-   |                    - consider changing this to `mut y`
+   |                    - help: make this binding mutable: `mut y`
 LL |     y = x.b; //~ ERROR lifetime mismatch
    |     ^^^^^^^ cannot assign to immutable argument
 

--- a/src/test/ui/lifetimes/lifetime-errors/liveness-assign-imm-local-notes.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/liveness-assign-imm-local-notes.stderr
@@ -33,7 +33,7 @@ error[E0384]: cannot assign twice to immutable variable `x` (Mir)
   --> $DIR/liveness-assign-imm-local-notes.rs:23:9
    |
 LL |     let x;
-   |         - consider changing this to `mut x`
+   |         - help: make this binding mutable: `mut x`
 ...
 LL |         x = 2;
    |         ----- first assignment to `x`
@@ -44,7 +44,7 @@ error[E0384]: cannot assign twice to immutable variable `x` (Mir)
   --> $DIR/liveness-assign-imm-local-notes.rs:35:13
    |
 LL |         let x;
-   |             - consider changing this to `mut x`
+   |             - help: make this binding mutable: `mut x`
 ...
 LL |             x = 2;
    |             ----- first assignment to `x`
@@ -55,7 +55,7 @@ error[E0384]: cannot assign twice to immutable variable `x` (Mir)
   --> $DIR/liveness-assign-imm-local-notes.rs:45:13
    |
 LL |     let x;
-   |         - consider changing this to `mut x`
+   |         - help: make this binding mutable: `mut x`
 ...
 LL |             x = 1;      //~ ERROR (Ast) [E0384]
    |             ^^^^^ cannot assign twice to immutable variable
@@ -64,7 +64,7 @@ error[E0384]: cannot assign twice to immutable variable `x` (Mir)
   --> $DIR/liveness-assign-imm-local-notes.rs:48:13
    |
 LL |     let x;
-   |         - consider changing this to `mut x`
+   |         - help: make this binding mutable: `mut x`
 ...
 LL |             x = 1;      //~ ERROR (Ast) [E0384]
    |             ----- first assignment to `x`

--- a/src/test/ui/liveness/liveness-assign/liveness-assign-imm-local-in-loop.ast.nll.stderr
+++ b/src/test/ui/liveness/liveness-assign/liveness-assign-imm-local-in-loop.ast.nll.stderr
@@ -1,8 +1,8 @@
 error[E0384]: cannot assign twice to immutable variable `v`
-  --> $DIR/liveness-assign-imm-local-in-loop.rs:18:9
+  --> $DIR/liveness-assign-imm-local-in-loop.rs:19:9
    |
 LL |     let v: isize;
-   |         - consider changing this to `mut v`
+   |         - help: make this binding mutable: `mut v`
 ...
 LL |         v = 1; //[ast]~ ERROR cannot assign twice to immutable variable
    |         ^^^^^ cannot assign twice to immutable variable

--- a/src/test/ui/liveness/liveness-assign/liveness-assign-imm-local-in-loop.ast.stderr
+++ b/src/test/ui/liveness/liveness-assign/liveness-assign-imm-local-in-loop.ast.stderr
@@ -1,5 +1,5 @@
 error[E0384]: cannot assign twice to immutable variable `v`
-  --> $DIR/liveness-assign-imm-local-in-loop.rs:18:9
+  --> $DIR/liveness-assign-imm-local-in-loop.rs:19:9
    |
 LL |         v = 1; //[ast]~ ERROR cannot assign twice to immutable variable
    |         ^^^^^ cannot assign twice to immutable variable

--- a/src/test/ui/liveness/liveness-assign/liveness-assign-imm-local-in-loop.mir.stderr
+++ b/src/test/ui/liveness/liveness-assign/liveness-assign-imm-local-in-loop.mir.stderr
@@ -1,8 +1,8 @@
 error[E0384]: cannot assign twice to immutable variable `v`
-  --> $DIR/liveness-assign-imm-local-in-loop.rs:18:9
+  --> $DIR/liveness-assign-imm-local-in-loop.rs:19:9
    |
 LL |     let v: isize;
-   |         - consider changing this to `mut v`
+   |         - help: make this binding mutable: `mut v`
 ...
 LL |         v = 1; //[ast]~ ERROR cannot assign twice to immutable variable
    |         ^^^^^ cannot assign twice to immutable variable

--- a/src/test/ui/liveness/liveness-assign/liveness-assign-imm-local-in-loop.rs
+++ b/src/test/ui/liveness/liveness-assign/liveness-assign-imm-local-in-loop.rs
@@ -13,7 +13,8 @@
 
 fn test() {
     let v: isize;
-    //[mir]~^ NOTE consider changing this to `mut v`
+    //[mir]~^ HELP make this binding mutable
+    //[mir]~| SUGGESTION mut v
     loop {
         v = 1; //[ast]~ ERROR cannot assign twice to immutable variable
                //[mir]~^ ERROR cannot assign twice to immutable variable `v`

--- a/src/test/ui/liveness/liveness-assign/liveness-assign-imm-local-in-op-eq.ast.nll.stderr
+++ b/src/test/ui/liveness/liveness-assign/liveness-assign-imm-local-in-op-eq.ast.nll.stderr
@@ -1,9 +1,9 @@
 error[E0384]: cannot assign twice to immutable variable `v`
-  --> $DIR/liveness-assign-imm-local-in-op-eq.rs:19:5
+  --> $DIR/liveness-assign-imm-local-in-op-eq.rs:20:5
    |
 LL |     let v: isize;
-   |         - consider changing this to `mut v`
-LL |     //[mir]~^ NOTE consider changing this to `mut v`
+   |         - help: make this binding mutable: `mut v`
+...
 LL |     v = 2;  //[ast]~ NOTE first assignment
    |     ----- first assignment to `v`
 LL |             //[mir]~^ NOTE first assignment

--- a/src/test/ui/liveness/liveness-assign/liveness-assign-imm-local-in-op-eq.ast.stderr
+++ b/src/test/ui/liveness/liveness-assign/liveness-assign-imm-local-in-op-eq.ast.stderr
@@ -1,5 +1,5 @@
 error[E0384]: cannot assign twice to immutable variable `v`
-  --> $DIR/liveness-assign-imm-local-in-op-eq.rs:19:5
+  --> $DIR/liveness-assign-imm-local-in-op-eq.rs:20:5
    |
 LL |     v = 2;  //[ast]~ NOTE first assignment
    |     ----- first assignment to `v`

--- a/src/test/ui/liveness/liveness-assign/liveness-assign-imm-local-in-op-eq.mir.stderr
+++ b/src/test/ui/liveness/liveness-assign/liveness-assign-imm-local-in-op-eq.mir.stderr
@@ -1,9 +1,9 @@
 error[E0384]: cannot assign twice to immutable variable `v`
-  --> $DIR/liveness-assign-imm-local-in-op-eq.rs:19:5
+  --> $DIR/liveness-assign-imm-local-in-op-eq.rs:20:5
    |
 LL |     let v: isize;
-   |         - consider changing this to `mut v`
-LL |     //[mir]~^ NOTE consider changing this to `mut v`
+   |         - help: make this binding mutable: `mut v`
+...
 LL |     v = 2;  //[ast]~ NOTE first assignment
    |     ----- first assignment to `v`
 LL |             //[mir]~^ NOTE first assignment

--- a/src/test/ui/liveness/liveness-assign/liveness-assign-imm-local-in-op-eq.rs
+++ b/src/test/ui/liveness/liveness-assign/liveness-assign-imm-local-in-op-eq.rs
@@ -13,7 +13,8 @@
 
 fn test() {
     let v: isize;
-    //[mir]~^ NOTE consider changing this to `mut v`
+    //[mir]~^ HELP make this binding mutable
+    //[mir]~| SUGGESTION mut v
     v = 2;  //[ast]~ NOTE first assignment
             //[mir]~^ NOTE first assignment
     v += 1; //[ast]~ ERROR cannot assign twice to immutable variable

--- a/src/test/ui/liveness/liveness-assign/liveness-assign-imm-local-with-drop.ast.nll.stderr
+++ b/src/test/ui/liveness/liveness-assign/liveness-assign-imm-local-with-drop.ast.nll.stderr
@@ -1,11 +1,11 @@
 error[E0384]: cannot assign twice to immutable variable `b`
-  --> $DIR/liveness-assign-imm-local-with-drop.rs:19:5
+  --> $DIR/liveness-assign-imm-local-with-drop.rs:20:5
    |
 LL |     let b = Box::new(1); //[ast]~ NOTE first assignment
    |         -
    |         |
    |         first assignment to `b`
-   |         consider changing this to `mut b`
+   |         help: make this binding mutable: `mut b`
 ...
 LL |     b = Box::new(2); //[ast]~ ERROR cannot assign twice to immutable variable
    |     ^ cannot assign twice to immutable variable

--- a/src/test/ui/liveness/liveness-assign/liveness-assign-imm-local-with-drop.ast.stderr
+++ b/src/test/ui/liveness/liveness-assign/liveness-assign-imm-local-with-drop.ast.stderr
@@ -1,5 +1,5 @@
 error[E0384]: cannot assign twice to immutable variable `b`
-  --> $DIR/liveness-assign-imm-local-with-drop.rs:19:5
+  --> $DIR/liveness-assign-imm-local-with-drop.rs:20:5
    |
 LL |     let b = Box::new(1); //[ast]~ NOTE first assignment
    |         - first assignment to `b`

--- a/src/test/ui/liveness/liveness-assign/liveness-assign-imm-local-with-drop.mir.stderr
+++ b/src/test/ui/liveness/liveness-assign/liveness-assign-imm-local-with-drop.mir.stderr
@@ -1,11 +1,11 @@
 error[E0384]: cannot assign twice to immutable variable `b`
-  --> $DIR/liveness-assign-imm-local-with-drop.rs:19:5
+  --> $DIR/liveness-assign-imm-local-with-drop.rs:20:5
    |
 LL |     let b = Box::new(1); //[ast]~ NOTE first assignment
    |         -
    |         |
    |         first assignment to `b`
-   |         consider changing this to `mut b`
+   |         help: make this binding mutable: `mut b`
 ...
 LL |     b = Box::new(2); //[ast]~ ERROR cannot assign twice to immutable variable
    |     ^ cannot assign twice to immutable variable

--- a/src/test/ui/liveness/liveness-assign/liveness-assign-imm-local-with-drop.rs
+++ b/src/test/ui/liveness/liveness-assign/liveness-assign-imm-local-with-drop.rs
@@ -14,7 +14,8 @@
 fn test() {
     let b = Box::new(1); //[ast]~ NOTE first assignment
                          //[mir]~^ NOTE first assignment
-                         //[mir]~| NOTE consider changing this to `mut b`
+                         //[mir]~| HELP make this binding mutable
+                         //[mir]~| SUGGESTION mut b
     drop(b);
     b = Box::new(2); //[ast]~ ERROR cannot assign twice to immutable variable
                      //[mir]~^ ERROR cannot assign twice to immutable variable `b`

--- a/src/test/ui/liveness/liveness-assign/liveness-assign-imm-local-with-init.ast.nll.stderr
+++ b/src/test/ui/liveness/liveness-assign/liveness-assign-imm-local-with-init.ast.nll.stderr
@@ -1,11 +1,11 @@
 error[E0384]: cannot assign twice to immutable variable `v`
-  --> $DIR/liveness-assign-imm-local-with-init.rs:19:5
+  --> $DIR/liveness-assign-imm-local-with-init.rs:20:5
    |
 LL |     let v: isize = 1; //[ast]~ NOTE first assignment
    |         -
    |         |
    |         first assignment to `v`
-   |         consider changing this to `mut v`
+   |         help: make this binding mutable: `mut v`
 ...
 LL |     v = 2; //[ast]~ ERROR cannot assign twice to immutable variable
    |     ^^^^^ cannot assign twice to immutable variable

--- a/src/test/ui/liveness/liveness-assign/liveness-assign-imm-local-with-init.ast.stderr
+++ b/src/test/ui/liveness/liveness-assign/liveness-assign-imm-local-with-init.ast.stderr
@@ -1,5 +1,5 @@
 error[E0384]: cannot assign twice to immutable variable `v`
-  --> $DIR/liveness-assign-imm-local-with-init.rs:19:5
+  --> $DIR/liveness-assign-imm-local-with-init.rs:20:5
    |
 LL |     let v: isize = 1; //[ast]~ NOTE first assignment
    |         - first assignment to `v`

--- a/src/test/ui/liveness/liveness-assign/liveness-assign-imm-local-with-init.mir.stderr
+++ b/src/test/ui/liveness/liveness-assign/liveness-assign-imm-local-with-init.mir.stderr
@@ -1,11 +1,11 @@
 error[E0384]: cannot assign twice to immutable variable `v`
-  --> $DIR/liveness-assign-imm-local-with-init.rs:19:5
+  --> $DIR/liveness-assign-imm-local-with-init.rs:20:5
    |
 LL |     let v: isize = 1; //[ast]~ NOTE first assignment
    |         -
    |         |
    |         first assignment to `v`
-   |         consider changing this to `mut v`
+   |         help: make this binding mutable: `mut v`
 ...
 LL |     v = 2; //[ast]~ ERROR cannot assign twice to immutable variable
    |     ^^^^^ cannot assign twice to immutable variable

--- a/src/test/ui/liveness/liveness-assign/liveness-assign-imm-local-with-init.rs
+++ b/src/test/ui/liveness/liveness-assign/liveness-assign-imm-local-with-init.rs
@@ -14,7 +14,8 @@
 fn test() {
     let v: isize = 1; //[ast]~ NOTE first assignment
                       //[mir]~^ NOTE first assignment
-                      //[mir]~| NOTE consider changing this to `mut v`
+                      //[mir]~| HELP make this binding mutable
+                      //[mir]~| SUGGESTION mut v
     v.clone();
     v = 2; //[ast]~ ERROR cannot assign twice to immutable variable
            //[mir]~^ ERROR cannot assign twice to immutable variable `v`

--- a/src/test/ui/macros/span-covering-argument-1.stderr
+++ b/src/test/ui/macros/span-covering-argument-1.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow immutable local variable `foo` as mutable
   --> $DIR/span-covering-argument-1.rs:15:19
    |
 LL |             let $s = 0;
-   |                 -- consider changing this to `mut $s`
+   |                 -- help: make this binding mutable: `mut $s`
 LL |             *&mut $s = 0;
    |                   ^^ cannot borrow mutably
 ...

--- a/src/test/ui/mut/mut-pattern-internal-mutability.ast.nll.stderr
+++ b/src/test/ui/mut/mut-pattern-internal-mutability.ast.nll.stderr
@@ -5,7 +5,7 @@ LL |     let &mut x = foo;
    |              -
    |              |
    |              first assignment to `x`
-   |              consider changing this to `mut x`
+   |              help: make this binding mutable: `mut x`
 LL |     x += 1; //[ast]~ ERROR cannot assign twice to immutable variable
    |     ^^^^^^ cannot assign twice to immutable variable
 

--- a/src/test/ui/mut/mut-pattern-internal-mutability.mir.stderr
+++ b/src/test/ui/mut/mut-pattern-internal-mutability.mir.stderr
@@ -5,7 +5,7 @@ LL |     let &mut x = foo;
    |              -
    |              |
    |              first assignment to `x`
-   |              consider changing this to `mut x`
+   |              help: make this binding mutable: `mut x`
 LL |     x += 1; //[ast]~ ERROR cannot assign twice to immutable variable
    |     ^^^^^^ cannot assign twice to immutable variable
 

--- a/src/test/ui/mut/mut-suggestion.nll.stderr
+++ b/src/test/ui/mut/mut-suggestion.nll.stderr
@@ -1,18 +1,18 @@
 error[E0596]: cannot borrow `arg` as mutable, as it is not declared as mutable
-  --> $DIR/mut-suggestion.rs:21:5
+  --> $DIR/mut-suggestion.rs:22:5
    |
 LL | fn func(arg: S) {
    |         --- help: consider changing this to be mutable: `mut arg`
-LL |     //~^ consider changing this to `mut arg`
+...
 LL |     arg.mutate();
    |     ^^^ cannot borrow as mutable
 
 error[E0596]: cannot borrow `local` as mutable, as it is not declared as mutable
-  --> $DIR/mut-suggestion.rs:29:5
+  --> $DIR/mut-suggestion.rs:31:5
    |
 LL |     let local = S;
    |         ----- help: consider changing this to be mutable: `mut local`
-LL |     //~^ consider changing this to `mut local`
+...
 LL |     local.mutate();
    |     ^^^^^ cannot borrow as mutable
 

--- a/src/test/ui/mut/mut-suggestion.rs
+++ b/src/test/ui/mut/mut-suggestion.rs
@@ -17,7 +17,8 @@ impl S {
 }
 
 fn func(arg: S) {
-    //~^ consider changing this to `mut arg`
+    //~^ HELP make this binding mutable
+    //~| SUGGESTION mut arg
     arg.mutate();
     //~^ ERROR cannot borrow immutable argument
     //~| cannot borrow mutably
@@ -25,7 +26,8 @@ fn func(arg: S) {
 
 fn main() {
     let local = S;
-    //~^ consider changing this to `mut local`
+    //~^ HELP make this binding mutable
+    //~| SUGGESTION mut local
     local.mutate();
     //~^ ERROR cannot borrow immutable local variable
     //~| cannot borrow mutably

--- a/src/test/ui/mut/mut-suggestion.stderr
+++ b/src/test/ui/mut/mut-suggestion.stderr
@@ -1,18 +1,18 @@
 error[E0596]: cannot borrow immutable argument `arg` as mutable
-  --> $DIR/mut-suggestion.rs:21:5
+  --> $DIR/mut-suggestion.rs:22:5
    |
 LL | fn func(arg: S) {
-   |         --- consider changing this to `mut arg`
-LL |     //~^ consider changing this to `mut arg`
+   |         --- help: make this binding mutable: `mut arg`
+...
 LL |     arg.mutate();
    |     ^^^ cannot borrow mutably
 
 error[E0596]: cannot borrow immutable local variable `local` as mutable
-  --> $DIR/mut-suggestion.rs:29:5
+  --> $DIR/mut-suggestion.rs:31:5
    |
 LL |     let local = S;
-   |         ----- consider changing this to `mut local`
-LL |     //~^ consider changing this to `mut local`
+   |         ----- help: make this binding mutable: `mut local`
+...
 LL |     local.mutate();
    |     ^^^^^ cannot borrow mutably
 

--- a/src/test/ui/mut/mutable-class-fields.ast.stderr
+++ b/src/test/ui/mut/mutable-class-fields.ast.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to field `nyan.how_hungry` of immutable binding
   --> $DIR/mutable-class-fields.rs:28:3
    |
 LL |   let nyan : cat = cat(52, 99);
-   |       ---- consider changing this to `mut nyan`
+   |       ---- help: make this binding mutable: `mut nyan`
 LL |   nyan.how_hungry = 0; //[ast]~ ERROR cannot assign
    |   ^^^^^^^^^^^^^^^^^^^ cannot mutably borrow field of immutable binding
 

--- a/src/test/ui/span/borrowck-borrow-overloaded-auto-deref-mut.stderr
+++ b/src/test/ui/span/borrowck-borrow-overloaded-auto-deref-mut.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow immutable argument `x` as mutable
   --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:63:24
    |
 LL | fn deref_mut_field1(x: Own<Point>) {
-   |                     - consider changing this to `mut x`
+   |                     - help: make this binding mutable: `mut x`
 LL |     let __isize = &mut x.y; //~ ERROR cannot borrow
    |                        ^ cannot borrow mutably
 
@@ -28,7 +28,7 @@ error[E0596]: cannot borrow immutable argument `x` as mutable
   --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:98:5
    |
 LL | fn assign_field1<'a>(x: Own<Point>) {
-   |                      - consider changing this to `mut x`
+   |                      - help: make this binding mutable: `mut x`
 LL |     x.y = 3; //~ ERROR cannot borrow
    |     ^ cannot borrow mutably
 
@@ -54,7 +54,7 @@ error[E0596]: cannot borrow immutable argument `x` as mutable
   --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:119:5
    |
 LL | fn deref_mut_method1(x: Own<Point>) {
-   |                      - consider changing this to `mut x`
+   |                      - help: make this binding mutable: `mut x`
 LL |     x.set(0, 0); //~ ERROR cannot borrow
    |     ^ cannot borrow mutably
 
@@ -70,7 +70,7 @@ error[E0596]: cannot borrow immutable argument `x` as mutable
   --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:139:6
    |
 LL | fn assign_method1<'a>(x: Own<Point>) {
-   |                       - consider changing this to `mut x`
+   |                       - help: make this binding mutable: `mut x`
 LL |     *x.y_mut() = 3; //~ ERROR cannot borrow
    |      ^ cannot borrow mutably
 

--- a/src/test/ui/span/borrowck-borrow-overloaded-deref-mut.stderr
+++ b/src/test/ui/span/borrowck-borrow-overloaded-deref-mut.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow immutable argument `x` as mutable
   --> $DIR/borrowck-borrow-overloaded-deref-mut.rs:39:25
    |
 LL | fn deref_mut1(x: Own<isize>) {
-   |               - consider changing this to `mut x`
+   |               - help: make this binding mutable: `mut x`
 LL |     let __isize = &mut *x; //~ ERROR cannot borrow
    |                         ^ cannot borrow mutably
 
@@ -18,7 +18,7 @@ error[E0596]: cannot borrow immutable argument `x` as mutable
   --> $DIR/borrowck-borrow-overloaded-deref-mut.rs:59:6
    |
 LL | fn assign1<'a>(x: Own<isize>) {
-   |                - consider changing this to `mut x`
+   |                - help: make this binding mutable: `mut x`
 LL |     *x = 3; //~ ERROR cannot borrow
    |      ^ cannot borrow mutably
 

--- a/src/test/ui/span/borrowck-object-mutability.stderr
+++ b/src/test/ui/span/borrowck-object-mutability.stderr
@@ -11,7 +11,7 @@ error[E0596]: cannot borrow immutable `Box` content `*x` as mutable
   --> $DIR/borrowck-object-mutability.rs:29:5
    |
 LL | fn owned_receiver(x: Box<Foo>) {
-   |                   - consider changing this to `mut x`
+   |                   - help: make this binding mutable: `mut x`
 LL |     x.borrowed();
 LL |     x.borrowed_mut(); //~ ERROR cannot borrow
    |     ^ cannot borrow as mutable

--- a/src/test/ui/unboxed-closures/unboxed-closure-immutable-capture.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-immutable-capture.stderr
@@ -2,7 +2,7 @@ error[E0595]: closure cannot assign to immutable local variable `x`
   --> $DIR/unboxed-closure-immutable-capture.rs:23:5
    |
 LL |     let x = 0;
-   |         - consider changing this to `mut x`
+   |         - help: make this binding mutable: `mut x`
 ...
 LL |     || x = 1; //~ ERROR cannot assign
    |     ^^ cannot borrow mutably
@@ -11,7 +11,7 @@ error[E0595]: closure cannot assign to immutable local variable `x`
   --> $DIR/unboxed-closure-immutable-capture.rs:25:5
    |
 LL |     let x = 0;
-   |         - consider changing this to `mut x`
+   |         - help: make this binding mutable: `mut x`
 ...
 LL |     || set(&mut x); //~ ERROR cannot assign
    |     ^^ cannot borrow mutably
@@ -20,7 +20,7 @@ error[E0595]: closure cannot assign to immutable local variable `x`
   --> $DIR/unboxed-closure-immutable-capture.rs:26:5
    |
 LL |     let x = 0;
-   |         - consider changing this to `mut x`
+   |         - help: make this binding mutable: `mut x`
 ...
 LL |     || x = 1; //~ ERROR cannot assign
    |     ^^ cannot borrow mutably
@@ -29,7 +29,7 @@ error[E0595]: closure cannot assign to immutable local variable `x`
   --> $DIR/unboxed-closure-immutable-capture.rs:28:5
    |
 LL |     let x = 0;
-   |         - consider changing this to `mut x`
+   |         - help: make this binding mutable: `mut x`
 ...
 LL |     || set(&mut x); //~ ERROR cannot assign
    |     ^^ cannot borrow mutably

--- a/src/test/ui/unboxed-closures/unboxed-closures-infer-fnmut-calling-fnmut-no-mut.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-infer-fnmut-calling-fnmut-no-mut.stderr
@@ -2,7 +2,7 @@ error[E0595]: closure cannot assign to immutable local variable `tick1`
   --> $DIR/unboxed-closures-infer-fnmut-calling-fnmut-no-mut.rs:26:17
    |
 LL |     let tick1 = || {
-   |         ----- consider changing this to `mut tick1`
+   |         ----- help: make this binding mutable: `mut tick1`
 ...
 LL |     let tick2 = || { //~ ERROR closure cannot assign to immutable local variable `tick1`
    |                 ^^ cannot borrow mutably
@@ -11,7 +11,7 @@ error[E0596]: cannot borrow immutable local variable `tick2` as mutable
   --> $DIR/unboxed-closures-infer-fnmut-calling-fnmut-no-mut.rs:30:5
    |
 LL |     let tick2 = || { //~ ERROR closure cannot assign to immutable local variable `tick1`
-   |         ----- consider changing this to `mut tick2`
+   |         ----- help: make this binding mutable: `mut tick2`
 ...
 LL |     tick2(); //~ ERROR cannot borrow
    |     ^^^^^ cannot borrow mutably

--- a/src/test/ui/unboxed-closures/unboxed-closures-infer-fnmut-missing-mut.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-infer-fnmut-missing-mut.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow immutable local variable `tick` as mutable
   --> $DIR/unboxed-closures-infer-fnmut-missing-mut.rs:17:5
    |
 LL |     let tick = || counter += 1;
-   |         ---- consider changing this to `mut tick`
+   |         ---- help: make this binding mutable: `mut tick`
 LL |     tick(); //~ ERROR cannot borrow immutable local variable `tick` as mutable
    |     ^^^^ cannot borrow mutably
 

--- a/src/test/ui/unboxed-closures/unboxed-closures-infer-fnmut-move-missing-mut.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-infer-fnmut-move-missing-mut.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow immutable local variable `tick` as mutable
   --> $DIR/unboxed-closures-infer-fnmut-move-missing-mut.rs:17:5
    |
 LL |     let tick = move || counter += 1;
-   |         ---- consider changing this to `mut tick`
+   |         ---- help: make this binding mutable: `mut tick`
 LL |     tick(); //~ ERROR cannot borrow immutable local variable `tick` as mutable
    |     ^^^^ cannot borrow mutably
 

--- a/src/test/ui/unboxed-closures/unboxed-closures-mutate-upvar.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-mutate-upvar.stderr
@@ -2,7 +2,7 @@ error[E0595]: closure cannot assign to immutable local variable `n`
   --> $DIR/unboxed-closures-mutate-upvar.rs:24:27
    |
 LL |     let n = 0;
-   |         - consider changing this to `mut n`
+   |         - help: make this binding mutable: `mut n`
 LL |     let mut f = to_fn_mut(|| { //~ ERROR closure cannot assign
    |                           ^^ cannot borrow mutably
 

--- a/src/test/ui/writing-to-immutable-vec.stderr
+++ b/src/test/ui/writing-to-immutable-vec.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow immutable local variable `v` as mutable
   --> $DIR/writing-to-immutable-vec.rs:14:5
    |
 LL |     let v: Vec<isize> = vec![1, 2, 3];
-   |         - consider changing this to `mut v`
+   |         - help: make this binding mutable: `mut v`
 LL |     v[1] = 4; //~ ERROR cannot borrow immutable local variable `v` as mutable
    |     ^ cannot borrow mutably
 


### PR DESCRIPTION
Fixes #54133 for both NLL and non-NLL.

r? @estebank 

I'm not super happy with the existing wording here, since it's now a suggestion. I wonder if the message would work better as something like "help: make binding mutable: `mut foo`"?

Also, are the `HELP` and `SUGGESTION` comments necessary?