### PR TITLE
WIP: Suggest method names when mistyping trait methods

### DIFF
--- a/src/librustc_typeck/check/method/mod.rs
+++ b/src/librustc_typeck/check/method/mod.rs
@@ -56,6 +56,7 @@ pub struct MethodCallee<'tcx> {
     pub sig: ty::FnSig<'tcx>,
 }
 
+#[derive(Debug)]
 pub enum MethodError<'tcx> {
     // Did not find an applicable method, but we did find various near-misses that may work.
     NoMatch(NoMatchData<'tcx>),
@@ -77,6 +78,7 @@ pub enum MethodError<'tcx> {
 
 // Contains a list of static methods that may apply, a list of unsatisfied trait predicates which
 // could lead to matches if satisfied, and a list of not-in-scope traits which may work.
+#[derive(Debug)]
 pub struct NoMatchData<'tcx> {
     pub static_candidates: Vec<CandidateSource>,
     pub unsatisfied_predicates: Vec<TraitRef<'tcx>>,

--- a/src/test/ui/impl-trait/method-suggestion-impl-trait.rs
+++ b/src/test/ui/impl-trait/method-suggestion-impl-trait.rs
@@ -1,0 +1,22 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait A {
+    fn method(&self) {}
+}
+
+struct B;
+
+impl A for B {}
+
+fn main() {
+    let b = B{};
+    b.methodd();
+}

--- a/src/test/ui/impl-trait/method-suggestion-impl-trait.stderr
+++ b/src/test/ui/impl-trait/method-suggestion-impl-trait.stderr
@@ -1,0 +1,14 @@
+error[E0599]: no method named `methodd` found for type `B` in the current scope
+  --> $DIR/method-suggestion-impl-trait.rs:21:7
+   |
+LL | struct B;
+   | --------- method `methodd` not found for this
+...
+LL |     b.methodd();
+   |       ^^^^^^^
+   |
+   = help: did you mean `method`?
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0599`.


### PR DESCRIPTION
Typeck will only suggest inherent candidates when a method is mistyped.
With this change we also take into account extension candidates that are
specified in traits.

Consider the following program:

```rust
trait MyTrait {
    fn hello(&self);
}

struct MyStruct;

impl MyStruct {
    fn bye(&self) {
    }
}

impl MyTrait for MyStruct {
    fn hello(&self) {
    }
}
```

If we currently mistype a method defined in the struct impl:

```
error[E0599]: no method named `byee` found for type `MyStruct` in the current scope
  --> hello-world.rs:19:7
   |
5  | struct MyStruct;
   | ---------------- method `byee` not found for this
...
19 |     a.byee();
   |       ^^^^
   |
   = help: did you mean `bye`?

error: aborting due to previous error

For more information about this error, try `rustc --explain E0599`.
```

However, the behavior is not consistent if we mistype a method defined in a trait that this struct implements:

```
error[E0599]: no method named `helloo` found for type `MyStruct` in the current scope
  --> hello-world.rs:19:7
   |
5  | struct MyStruct;
   | ---------------- method `helloo` not found for this
...
19 |     a.helloo();
   |       ^^^^^^

error: aborting due to previous error

For more information about this error, try `rustc --explain E0599`.
```

As you can see, in this example, no suggestion is provided. After this patch is applied, we get:

```
error[E0599]: no method named `helloo` found for type `MyStruct` in the current scope
  --> hello-world.rs:19:7
   |
5  | struct MyStruct;
   | ---------------- method `helloo` not found for this
...
19 |     a.helloo();
   |       ^^^^^^
   |
   = help: did you mean `hello`?

error: aborting due to previous error

For more information about this error, try `rustc --explain E0599`.
```

This PR fixes this small issue. However, I'm not completely sure I'm doing it in the best possible way, since calling to `assemble_extension_candidates_for_all_traits` could be considered excessive in this case?

I couldn't see a better way by using `assemble_extension_candidates_for_traits_in_scope` with the `ast::NodeId`, but didn't know what explicit `ast::NodeId` to use in order to only assemble the candidates for traits in scope for that specific node.