### PR TITLE
Suggest valid crate type if invalid crate type is found

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -422,6 +422,7 @@ pub enum BuiltinLintDiagnostics {
     ProcMacroDeriveResolutionFallback(Span),
     MacroExpandedMacroExportsAccessedByAbsolutePaths(Span),
     ElidedLifetimesInPaths(usize, Span, bool, Span, String),
+    UnknownCrateTypes(Span, String, String),
 }
 
 impl BuiltinLintDiagnostics {
@@ -498,6 +499,14 @@ impl BuiltinLintDiagnostics {
                     &format!("indicate the anonymous lifetime{}", if n >= 2 { "s" } else { "" }),
                     suggestion,
                     Applicability::MachineApplicable
+                );
+            }
+            BuiltinLintDiagnostics::UnknownCrateTypes(span, note, sugg) => {
+                db.span_suggestion_with_applicability(
+                    span,
+                    &note,
+                    sugg,
+                    Applicability::MaybeIncorrect
                 );
             }
         }

--- a/src/test/ui/invalid/invalid-crate-type.rs
+++ b/src/test/ui/invalid/invalid-crate-type.rs
@@ -11,6 +11,48 @@
 // regression test for issue 11256
 #![crate_type="foo"]    //~ ERROR invalid `crate_type` value
 
+// Tests for suggestions (#53958)
+
+#![crate_type="statoclib"]
+//~^ ERROR invalid `crate_type` value
+//~| HELP did you mean
+//~| SUGGESTION staticlib
+
+#![crate_type="procmacro"]
+//~^ ERROR invalid `crate_type` value
+//~| HELP did you mean
+//~| SUGGESTION proc-macro
+
+#![crate_type="static-lib"]
+//~^ ERROR invalid `crate_type` value
+//~| HELP did you mean
+//~| SUGGESTION staticlib
+
+#![crate_type="drylib"]
+//~^ ERROR invalid `crate_type` value
+//~| HELP did you mean
+//~| SUGGESTION dylib
+
+#![crate_type="dlib"]
+//~^ ERROR invalid `crate_type` value
+//~| HELP did you mean
+//~| SUGGESTION rlib
+
+#![crate_type="lob"]
+//~^ ERROR invalid `crate_type` value
+//~| HELP did you mean
+//~| SUGGESTION lib
+
+#![crate_type="bon"]
+//~^ ERROR invalid `crate_type` value
+//~| HELP did you mean
+//~| SUGGESTION bin
+
+#![crate_type="cdalib"]
+//~^ ERROR invalid `crate_type` value
+//~| HELP did you mean
+//~| SUGGESTION cdylib
+
 fn main() {
     return
 }

--- a/src/test/ui/invalid/invalid-crate-type.stderr
+++ b/src/test/ui/invalid/invalid-crate-type.stderr
@@ -1,10 +1,58 @@
 error: invalid `crate_type` value
-  --> $DIR/invalid-crate-type.rs:12:1
+  --> $DIR/invalid-crate-type.rs:12:15
    |
 LL | #![crate_type="foo"]    //~ ERROR invalid `crate_type` value
-   | ^^^^^^^^^^^^^^^^^^^^
+   |               ^^^^^
    |
    = note: #[deny(unknown_crate_types)] on by default
 
-error: aborting due to previous error
+error: invalid `crate_type` value
+  --> $DIR/invalid-crate-type.rs:16:15
+   |
+LL | #![crate_type="statoclib"]
+   |               ^^^^^^^^^^^ help: did you mean: `"staticlib"`
+
+error: invalid `crate_type` value
+  --> $DIR/invalid-crate-type.rs:21:15
+   |
+LL | #![crate_type="procmacro"]
+   |               ^^^^^^^^^^^ help: did you mean: `"proc-macro"`
+
+error: invalid `crate_type` value
+  --> $DIR/invalid-crate-type.rs:26:15
+   |
+LL | #![crate_type="static-lib"]
+   |               ^^^^^^^^^^^^ help: did you mean: `"staticlib"`
+
+error: invalid `crate_type` value
+  --> $DIR/invalid-crate-type.rs:31:15
+   |
+LL | #![crate_type="drylib"]
+   |               ^^^^^^^^ help: did you mean: `"dylib"`
+
+error: invalid `crate_type` value
+  --> $DIR/invalid-crate-type.rs:36:15
+   |
+LL | #![crate_type="dlib"]
+   |               ^^^^^^ help: did you mean: `"rlib"`
+
+error: invalid `crate_type` value
+  --> $DIR/invalid-crate-type.rs:41:15
+   |
+LL | #![crate_type="lob"]
+   |               ^^^^^ help: did you mean: `"lib"`
+
+error: invalid `crate_type` value
+  --> $DIR/invalid-crate-type.rs:46:15
+   |
+LL | #![crate_type="bon"]
+   |               ^^^^^ help: did you mean: `"bin"`
+
+error: invalid `crate_type` value
+  --> $DIR/invalid-crate-type.rs:51:15
+   |
+LL | #![crate_type="cdalib"]
+   |               ^^^^^^^^ help: did you mean: `"cdylib"`
+
+error: aborting due to 9 previous errors
 


### PR DESCRIPTION
This adds a suggestion to the `invalid_crate_types` lint.

The suggestion is based on the Levenshtein distance to existing crate
types. If no suggestion is found it will show the lint without any
suggestions.

Closes #53958 