### PR TITLE
Add lint message for unexpected `and/or` in if statement

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4768,16 +4768,37 @@ impl<'a> Parser<'a> {
                     if self.eat(&token::Semi) {
                         stmt_span = stmt_span.with_hi(self.prev_span.hi());
                     }
-                    let sugg = pprust::to_string(|s| {
-                        use print::pprust::{PrintState, INDENT_UNIT};
-                        s.ibox(INDENT_UNIT)?;
-                        s.bopen()?;
-                        s.print_stmt(&stmt)?;
-                        s.bclose_maybe_open(stmt.span, INDENT_UNIT, false)
-                    });
+
+                    let (msg, sugg) = match self.sess.source_map()
+                                         .span_to_snippet(stmt_span)
+                                         .as_ref()
+                                         .map(|s| s.as_str()) {
+                        Ok("and") => {
+                            (
+                                "try replacing this with",
+                                "&&".to_string(),
+                            )
+                        },
+                        Ok("or") => {
+                            (
+                                "try replacing this with",
+                                "||".to_string(),
+                            )
+                        },
+                        _ => (
+                            "try placing this code inside a block",
+                            pprust::to_string(|s| {
+                                use print::pprust::{PrintState, INDENT_UNIT};
+                                s.ibox(INDENT_UNIT)?;
+                                s.bopen()?;
+                                s.print_stmt(&stmt)?;
+                                s.bclose_maybe_open(stmt.span, INDENT_UNIT, false)
+                            }),
+                        ),
+                    };
                     e.span_suggestion_with_applicability(
                         stmt_span,
-                        "try placing this code inside a block",
+                        msg,
                         sugg,
                         // speculative, has been misleading in the past (closed Issue #46836)
                         Applicability::MaybeIncorrect

--- a/src/test/ui/if/if-with-and.rs
+++ b/src/test/ui/if/if-with-and.rs
@@ -1,0 +1,17 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let x = 1;
+    let y = 2;
+    if x == 1 and y == 2 {}
+    //~^ NOTE this `if` statement has a condition, but no block
+}
+//~^ ERROR expected `{`, found `}`

--- a/src/test/ui/if/if-with-and.stderr
+++ b/src/test/ui/if/if-with-and.stderr
@@ -1,0 +1,10 @@
+error: expected `{`, found `and`
+  --> $DIR/if-with-and.rs:14:15
+   |
+LL |     if x == 1 and y == 2 {}
+   |     --        ^^^ help: try replacing this with: `&&`
+   |     |
+   |     this `if` statement has a condition, but no block
+
+error: aborting due to previous error
+

--- a/src/test/ui/if/if-with-or.rs
+++ b/src/test/ui/if/if-with-or.rs
@@ -1,0 +1,17 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let x = 1;
+    let y = 2;
+    if x == 1 or y == 2 {}
+    //~^ NOTE this `if` statement has a condition, but no block
+}
+//~^ ERROR expected `{`, found `}`

--- a/src/test/ui/if/if-with-or.stderr
+++ b/src/test/ui/if/if-with-or.stderr
@@ -1,0 +1,10 @@
+error: expected `{`, found `or`
+  --> $DIR/if-with-or.rs:14:15
+   |
+LL |     if x == 1 or y == 2 {}
+   |     --        ^^ help: try replacing this with: `||`
+   |     |
+   |     this `if` statement has a condition, but no block
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Closes https://github.com/rust-lang/rust/issues/54109
r? @estebank 