### PR TITLE
rustc_resolve: don't treat uniform_paths canaries as ambiguities unless they resolve to distinct Def's.

### DIFF
--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -735,6 +735,12 @@ impl<'a, 'b:'a, 'c: 'b> ImportResolver<'a, 'b, 'c> {
                 None
             };
 
+            // Currently imports can't resolve in non-module scopes,
+            // we only have canaries in them for future-proofing.
+            if external_crate.is_none() && results.module_scope.is_none() {
+                return;
+            }
+
             let result_filter = |result: &&NameBinding| {
                 // Ignore canaries that resolve to an import of the same crate.
                 // That is, we allow `use crate_name; use crate_name::foo;`.

--- a/src/test/ui/run-pass/uniform-paths/basic-nested.rs
+++ b/src/test/ui/run-pass/uniform-paths/basic-nested.rs
@@ -59,4 +59,12 @@ fn main() {
     bar::io::stdout();
     bar::std();
     bar::std!();
+
+    {
+        // Test that having `io` in a module scope and a non-module
+        // scope is allowed, when both resolve to the same definition.
+        use std::io;
+        use io::stdout;
+        stdout();
+    }
 }

--- a/src/test/ui/run-pass/uniform-paths/basic.rs
+++ b/src/test/ui/run-pass/uniform-paths/basic.rs
@@ -33,4 +33,12 @@ fn main() {
     Foo(());
     std_io::stdout();
     local_io(());
+
+    {
+        // Test that having `std_io` in a module scope and a non-module
+        // scope is allowed, when both resolve to the same definition.
+        use std::io as std_io;
+        use std_io::stdout;
+        stdout();
+    }
 }


### PR DESCRIPTION
In particular, this allows this pattern that @cramertj mentioned in https://github.com/rust-lang/rust/issues/53130#issuecomment-420848814: 
```rust
use log::{debug, log};
fn main() {
    use log::{debug, log};
    debug!(...);
}
```
The canaries for the inner `use log::...;`, *in the macro namespace*, see the `log` macro imported at the module scope, and the (same) `log` macro, imported in the block scope inside `main`.

Previously, these two possible (macro namspace) `log` resolutions would be considered ambiguous (from a forwards-compat standpoint, where we might make imports aware of block scopes).

With this PR, such a case is allowed *if and only if* all the possible resolutions refer to the same definition (more specifically, because the *same* `log` macro is being imported twice).
This condition subsumes previous (weaker) checks like #54005 and the second commit of #54011.

Only the last commit is the main change, the other two are cleanups.

r? @petrochenkov cc @Centril @joshtriplett 