### PR TITLE
Fix the stable release of os_str_str_ref_eq

### DIFF
--- a/src/libstd/ffi/os_str.rs
+++ b/src/libstd/ffi/os_str.rs
@@ -420,14 +420,14 @@ impl PartialEq<OsString> for str {
     }
 }
 
-#[stable(feature = "os_str_str_ref_eq", since = "1.28.0")]
+#[stable(feature = "os_str_str_ref_eq", since = "1.29.0")]
 impl<'a> PartialEq<&'a str> for OsString {
     fn eq(&self, other: &&'a str) -> bool {
         **self == **other
     }
 }
 
-#[stable(feature = "os_str_str_ref_eq", since = "1.28.0")]
+#[stable(feature = "os_str_str_ref_eq", since = "1.29.0")]
 impl<'a> PartialEq<OsString> for &'a str {
     fn eq(&self, other: &OsString) -> bool {
         **other == **self


### PR DESCRIPTION
This was added and stabilized in commit 02503029b83a, but while that
claimed to be for 1.28.0, it didn't actually make it until 1.29.0.

Fixes #54195.