### PR TITLE
Introduce the `Result::into_inner` method

### DIFF
--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -1002,6 +1002,34 @@ impl<T, E> Result<Option<T>, E> {
     }
 }
 
+impl<T> Result<T, T> {
+    /// Extract the value of a [`Result`] where the [`Err`] and [`Ok`] types are the same.
+    ///
+    /// This function does not panic in any way, the [`Result`] type is always either an [`Ok`]
+    /// or an [`Err`]. If the types of the variants are the same, it is possible to extract a value
+    /// either from one or the other variant.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(result_into_inner)]
+    ///
+    /// let x: Result<i32, i32> = Ok(16);
+    /// assert_eq!(x.into_inner(), 16);
+    ///
+    /// let x: Result<i32, i32> = Err(42);
+    /// assert_eq!(x.into_inner(), 42);
+    /// ```
+    #[unstable(feature = "result_into_inner", issue = "0")]
+    #[inline]
+    pub fn into_inner(self) -> T {
+        match self {
+            Ok(value) => value,
+            Err(value) => value,
+        }
+    }
+}
+
 // This is a separate function to reduce the code size of the methods
 #[inline(never)]
 #[cold]


### PR DESCRIPTION
This method extract the value of either the `Ok` or the `Err` `Result` variant in the case where the variant types are the same.

```rust
// It is too boring to write this
let x = match Ok(16) {
    Ok(x) => x,
    Err(x) => x,
};

// this is much more convenient to write that
let x: Result<i32, i32> = Ok(16);
assert_eq!(x.into_inner(), 16);

let x: Result<i32, i32> = Err(42);
assert_eq!(x.into_inner(), 42);
```

It is inspired by the [`Either::into_inner` method](https://docs.rs/either/1.5.0/either/enum.Either.html#method.into_inner).

I found use cases, in particular when using [`slice::binary_search` like functions](https://doc.rust-lang.org/std/primitive.slice.html#method.binary_search) which returns `Result<usize, usize>`. Note that it is always possible to apply logic on one or the other variant like so:

```rust
let res: Result<usize, usize> = unimplemented!();

// this maps the `Ok` part
let x = res.map(|i| i + 1).into_inner();

// this maps the `Err` part
let x = res.map_err(|i| i - 2).into_inner();

// returns a &usize
let x = res.as_ref().into_inner();
```
