### PR TITLE
`ui`ify run-pass

### DIFF
--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -755,10 +755,11 @@ default_test_with_compare_mode!(Ui {
     compare_mode: "nll"
 });
 
-default_test!(RunPass {
+default_test_with_compare_mode!(RunPass {
     path: "src/test/run-pass",
     mode: "run-pass",
-    suite: "run-pass"
+    suite: "run-pass",
+    compare_mode: "nll"
 });
 
 default_test!(CompileFail {

--- a/src/test/run-pass-fulldeps/ast_stmt_expr_attr.rs
+++ b/src/test/run-pass-fulldeps/ast_stmt_expr_attr.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_imports)]
 // ignore-cross-compile
 
 #![feature(rustc_private)]

--- a/src/test/run-pass-fulldeps/custom-derive-partial-eq.stderr
+++ b/src/test/run-pass-fulldeps/custom-derive-partial-eq.stderr
@@ -1,0 +1,6 @@
+warning: `#[derive]` for custom traits is deprecated and will be removed in the future. Prefer using procedural macro custom derive.
+  --> $DIR/custom-derive-partial-eq.rs:17:10
+   |
+LL | #[derive(CustomPartialEq)] // Check that this is not a stability error.
+   |          ^^^^^^^^^^^^^^^
+

--- a/src/test/run-pass-fulldeps/derive-no-std-not-supported.rs
+++ b/src/test/run-pass-fulldeps/derive-no-std-not-supported.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 #![feature(rustc_private)]
 #![no_std]
 

--- a/src/test/run-pass-fulldeps/deriving-encodable-decodable-box.rs
+++ b/src/test/run-pass-fulldeps/deriving-encodable-decodable-box.rs
@@ -14,11 +14,12 @@
 #![feature(rustc_private)]
 
 extern crate serialize;
+use serialize as rustc_serialize;
 
 use serialize::{Encodable, Decodable};
 use serialize::json;
 
-#[derive(Encodable, Decodable)]
+#[derive(RustcEncodable, RustcDecodable)]
 struct A {
     foo: Box<[bool]>,
 }

--- a/src/test/run-pass-fulldeps/deriving-encodable-decodable-box.rs
+++ b/src/test/run-pass-fulldeps/deriving-encodable-decodable-box.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_imports)]
 
 #![feature(box_syntax)]
 #![feature(rustc_private)]

--- a/src/test/run-pass-fulldeps/deriving-encodable-decodable-cell-refcell.rs
+++ b/src/test/run-pass-fulldeps/deriving-encodable-decodable-cell-refcell.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_imports)]
 // This briefly tests the capability of `Cell` and `RefCell` to implement the
 // `Encodable` and `Decodable` traits via `#[derive(Encodable, Decodable)]`
 

--- a/src/test/run-pass-fulldeps/deriving-encodable-decodable-cell-refcell.rs
+++ b/src/test/run-pass-fulldeps/deriving-encodable-decodable-cell-refcell.rs
@@ -16,17 +16,18 @@
 #![feature(rustc_private)]
 
 extern crate serialize;
+use serialize as rustc_serialize;
 
 use std::cell::{Cell, RefCell};
 use serialize::{Encodable, Decodable};
 use serialize::json;
 
-#[derive(Encodable, Decodable)]
+#[derive(RustcEncodable, RustcDecodable)]
 struct A {
     baz: isize
 }
 
-#[derive(Encodable, Decodable)]
+#[derive(RustcEncodable, RustcDecodable)]
 struct B {
     foo: Cell<bool>,
     bar: RefCell<A>,

--- a/src/test/run-pass-fulldeps/deriving-global.rs
+++ b/src/test/run-pass-fulldeps/deriving-global.rs
@@ -11,6 +11,7 @@
 #![feature(rustc_private)]
 
 extern crate serialize;
+use serialize as rustc_serialize;
 
 mod submod {
     // if any of these are implemented without global calls for any
@@ -20,21 +21,21 @@ mod submod {
                Hash,
                Clone,
                Debug,
-               Encodable, Decodable)]
+               RustcEncodable, RustcDecodable)]
     enum A { A1(usize), A2(isize) }
 
     #[derive(PartialEq, PartialOrd, Eq, Ord,
                Hash,
                Clone,
                Debug,
-               Encodable, Decodable)]
+               RustcEncodable, RustcDecodable)]
     struct B { x: usize, y: isize }
 
     #[derive(PartialEq, PartialOrd, Eq, Ord,
                Hash,
                Clone,
                Debug,
-               Encodable, Decodable)]
+               RustcEncodable, RustcDecodable)]
     struct C(usize, isize);
 
 }

--- a/src/test/run-pass-fulldeps/deriving-hygiene.rs
+++ b/src/test/run-pass-fulldeps/deriving-hygiene.rs
@@ -11,6 +11,7 @@
 #![allow(non_upper_case_globals)]
 #![feature(rustc_private)]
 extern crate serialize;
+use serialize as rustc_serialize;
 
 pub const other: u8 = 1;
 pub const f: u8 = 1;
@@ -19,7 +20,7 @@ pub const s: u8 = 1;
 pub const state: u8 = 1;
 pub const cmp: u8 = 1;
 
-#[derive(Ord,Eq,PartialOrd,PartialEq,Debug,Decodable,Encodable,Hash)]
+#[derive(Ord,Eq,PartialOrd,PartialEq,Debug,RustcDecodable,RustcEncodable,Hash)]
 struct Foo {}
 
 fn main() {

--- a/src/test/run-pass-fulldeps/deriving-hygiene.rs
+++ b/src/test/run-pass-fulldeps/deriving-hygiene.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_upper_case_globals)]
 #![feature(rustc_private)]
 extern crate serialize;
 

--- a/src/test/run-pass-fulldeps/dropck_tarena_sound_drop.rs
+++ b/src/test/run-pass-fulldeps/dropck_tarena_sound_drop.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_lints)]
 // Check that an arena (TypedArena) can carry elements whose drop
 // methods might access borrowed data, as long as the borrowed data
 // has lifetime that strictly outlives the arena itself.

--- a/src/test/run-pass-fulldeps/issue-11881.rs
+++ b/src/test/run-pass-fulldeps/issue-11881.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_must_use)]
+#![allow(dead_code)]
+#![allow(unused_imports)]
 
 #![feature(rustc_private)]
 

--- a/src/test/run-pass-fulldeps/issue-11881.rs
+++ b/src/test/run-pass-fulldeps/issue-11881.rs
@@ -15,6 +15,7 @@
 #![feature(rustc_private)]
 
 extern crate serialize;
+use serialize as rustc_serialize;
 
 use std::io::Cursor;
 use std::io::prelude::*;
@@ -25,12 +26,12 @@ use serialize::{Encodable, Encoder};
 use serialize::json;
 use serialize::opaque;
 
-#[derive(Encodable)]
+#[derive(RustcEncodable)]
 struct Foo {
     baz: bool,
 }
 
-#[derive(Encodable)]
+#[derive(RustcEncodable)]
 struct Bar {
     froboz: usize,
 }

--- a/src/test/run-pass-fulldeps/issue-14021.rs
+++ b/src/test/run-pass-fulldeps/issue-14021.rs
@@ -13,11 +13,12 @@
 #![feature(rustc_private)]
 
 extern crate serialize;
+extern crate serialize as rustc_serialize;
 
 use serialize::{Encodable, Decodable};
 use serialize::json;
 
-#[derive(Encodable, Decodable, PartialEq, Debug)]
+#[derive(RustcEncodable, RustcDecodable, PartialEq, Debug)]
 struct UnitLikeStruct;
 
 pub fn main() {

--- a/src/test/run-pass-fulldeps/issue-14021.rs
+++ b/src/test/run-pass-fulldeps/issue-14021.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_mut)]
+#![allow(unused_imports)]
 #![feature(rustc_private)]
 
 extern crate serialize;

--- a/src/test/run-pass-fulldeps/issue-15149.rs
+++ b/src/test/run-pass-fulldeps/issue-15149.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_variables)]
 // no-prefer-dynamic
 // ignore-cross-compile
 

--- a/src/test/run-pass-fulldeps/issue-15924.rs
+++ b/src/test/run-pass-fulldeps/issue-15924.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_imports)]
+#![allow(unused_must_use)]
 // pretty-expanded FIXME #23616
 
 #![feature(rustc_private)]

--- a/src/test/run-pass-fulldeps/issue-18763-quote-token-tree.rs
+++ b/src/test/run-pass-fulldeps/issue-18763-quote-token-tree.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
+#![allow(unused_imports)]
 // ignore-cross-compile
 #![feature(quote, rustc_private)]
 

--- a/src/test/run-pass-fulldeps/issue-24972.rs
+++ b/src/test/run-pass-fulldeps/issue-24972.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 #![feature(rustc_private)]
 
 extern crate serialize;

--- a/src/test/run-pass-fulldeps/issue-2804.rs
+++ b/src/test/run-pass-fulldeps/issue-2804.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
+#![allow(dead_code)]
 #![feature(rustc_private)]
 
 extern crate serialize;

--- a/src/test/run-pass-fulldeps/issue-4016.rs
+++ b/src/test/run-pass-fulldeps/issue-4016.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 
 #![feature(rustc_private)]
 

--- a/src/test/run-pass-fulldeps/issue-40663.rs
+++ b/src/test/run-pass-fulldeps/issue-40663.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 // aux-build:custom_derive_plugin.rs
 // ignore-stage1
 

--- a/src/test/run-pass-fulldeps/macro-crate-multi-decorator-literals.rs
+++ b/src/test/run-pass-fulldeps/macro-crate-multi-decorator-literals.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(plugin_as_library)]
+#![allow(unused_imports)]
 // aux-build:macro_crate_test.rs
 // ignore-stage1
 

--- a/src/test/run-pass-fulldeps/macro-crate-multi-decorator.rs
+++ b/src/test/run-pass-fulldeps/macro-crate-multi-decorator.rs
@@ -8,6 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(plugin_as_library)]
+#![allow(dead_code)]
+#![allow(unused_variables)]
+#![allow(unused_imports)]
 // aux-build:macro_crate_test.rs
 // ignore-stage1
 

--- a/src/test/run-pass-fulldeps/macro-crate.rs
+++ b/src/test/run-pass-fulldeps/macro-crate.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(plugin_as_library)]
+#![allow(dead_code)]
 // aux-build:macro_crate_test.rs
 // ignore-stage1
 

--- a/src/test/run-pass-fulldeps/macro-quote-cond.rs
+++ b/src/test/run-pass-fulldeps/macro-quote-cond.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_parens)]
 // aux-build:cond_plugin.rs
 // ignore-stage1
 

--- a/src/test/run-pass-fulldeps/proc-macro/call-site.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/call-site.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_variables)]
+#![allow(unused_imports)]
 // aux-build:call-site.rs
 // ignore-stage1
 

--- a/src/test/run-pass-fulldeps/proc-macro/derive-attr-cfg.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/derive-attr-cfg.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 // aux-build:derive-attr-cfg.rs
 // ignore-stage1
 

--- a/src/test/run-pass-fulldeps/proc-macro/derive-same-struct.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/derive-same-struct.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(path_statements)]
+#![allow(dead_code)]
 // aux-build:derive-same-struct.rs
 // ignore-stage1
 

--- a/src/test/run-pass-fulldeps/proc-macro/derive-same-struct.stdout
+++ b/src/test/run-pass-fulldeps/proc-macro/derive-same-struct.stdout
@@ -1,0 +1,1 @@
+input1: "struct A;"

--- a/src/test/run-pass-fulldeps/proc-macro/derive-two-attrs.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/derive-two-attrs.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 // aux-build:derive-two-attrs.rs
 
 extern crate derive_two_attrs as foo;

--- a/src/test/run-pass-fulldeps/proc-macro/derive-union.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/derive-union.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_variables)]
 // aux-build:derive-union.rs
 // ignore-stage1
 

--- a/src/test/run-pass-fulldeps/proc-macro/empty-crate.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/empty-crate.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_imports)]
 // aux-build:empty-crate.rs
 // ignore-stage1
 

--- a/src/test/run-pass-fulldeps/proc-macro/hygiene_example.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/hygiene_example.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_macros)]
 // aux-build:hygiene_example_codegen.rs
 // aux-build:hygiene_example.rs
 // ignore-stage1

--- a/src/test/run-pass-fulldeps/proc-macro/issue-39889.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/issue-39889.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 // aux-build:issue-39889.rs
 // ignore-stage1
 

--- a/src/test/run-pass-fulldeps/proc-macro/issue-50061.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/issue-50061.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(path_statements)]
 // aux-build:issue-50061.rs
 // ignore-stage1
 

--- a/src/test/run-pass-fulldeps/proc-macro/lifetimes.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/lifetimes.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_variables)]
 // aux-build:lifetimes.rs
 // ignore-stage1
 

--- a/src/test/run-pass-fulldeps/proc-macro/load-two.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/load-two.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(path_statements)]
+#![allow(dead_code)]
 // aux-build:derive-atob.rs
 // aux-build:derive-ctod.rs
 // ignore-stage1

--- a/src/test/run-pass-fulldeps/proc-macro/smoke.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/smoke.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_must_use)]
+#![allow(path_statements)]
 // aux-build:derive-a.rs
 // ignore-stage1
 

--- a/src/test/run-pass-fulldeps/proc-macro/struct-field-macro.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/struct-field-macro.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 // aux-build:derive-nothing.rs
 // ignore-stage1
 

--- a/src/test/run-pass-fulldeps/qquote.rs
+++ b/src/test/run-pass-fulldeps/qquote.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_imports)]
 // ignore-cross-compile
 
 #![feature(quote, rustc_private)]

--- a/src/test/run-pass-fulldeps/quote-tokens.rs
+++ b/src/test/run-pass-fulldeps/quote-tokens.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
+#![allow(unused_variables)]
+#![allow(unused_imports)]
 // ignore-cross-compile
 #![feature(quote, rustc_private)]
 

--- a/src/test/run-pass-fulldeps/quote-unused-sp-no-warning.rs
+++ b/src/test/run-pass-fulldeps/quote-unused-sp-no-warning.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 // ignore-cross-compile
 #![feature(quote, rustc_private)]
 #![deny(unused_variables)]

--- a/src/test/run-pass-fulldeps/regions-mock-tcx.rs
+++ b/src/test/run-pass-fulldeps/regions-mock-tcx.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
+#![allow(unused_imports)]
 
 // Test a sample usage pattern for regions. Makes use of the
 // following features:

--- a/src/test/run-pass-fulldeps/rename-directory.rs
+++ b/src/test/run-pass-fulldeps/rename-directory.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_must_use)]
+#![allow(unused_imports)]
 // This test can't be a unit test in std,
 // because it needs TempDir, which is in extra
 

--- a/src/test/run-pass/abort-on-c-abi.rs
+++ b/src/test/run-pass/abort-on-c-abi.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_must_use)]
 // Since we mark some ABIs as "nounwind" to LLVM, we must make sure that
 // we never unwind through them.
 

--- a/src/test/run-pass/alias-uninit-value.rs
+++ b/src/test/run-pass/alias-uninit-value.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
+#![allow(dead_code)]
+
 
 
 // Regression test for issue #374

--- a/src/test/run-pass/align-with-extern-c-fn.rs
+++ b/src/test/run-pass/align-with-extern-c-fn.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(stable_features)]
+#![allow(unused_variables)]
+
 // #45662
 
 #![feature(repr_align)]

--- a/src/test/run-pass/alignment-gep-tup-like-1.rs
+++ b/src/test/run-pass/alignment-gep-tup-like-1.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
+#![allow(dead_code)]
+
 #![feature(box_syntax)]
 
 struct pair<A,B> {

--- a/src/test/run-pass/alloca-from-derived-tydesc.rs
+++ b/src/test/run-pass/alloca-from-derived-tydesc.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
+#![allow(dead_code)]
+
 
 // pretty-expanded FIXME #23616
 

--- a/src/test/run-pass/allocator-alloc-one.rs
+++ b/src/test/run-pass/allocator-alloc-one.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(stable_features)]
+
 #![feature(allocator_api, nonnull)]
 
 use std::alloc::{Alloc, Global, Layout, handle_alloc_error};

--- a/src/test/run-pass/asm-in-moved.rs
+++ b/src/test/run-pass/asm-in-moved.rs
@@ -12,6 +12,7 @@
 //[mir]compile-flags: -Z borrowck=mir
 
 #![feature(asm)]
+#![allow(dead_code)]
 
 use std::cell::Cell;
 

--- a/src/test/run-pass/atomic-access-bool.rs
+++ b/src/test/run-pass/atomic-access-bool.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(stable_features)]
 #![feature(atomic_access)]
 use std::sync::atomic::{AtomicBool, ATOMIC_BOOL_INIT};
 use std::sync::atomic::Ordering::*;

--- a/src/test/run-pass/atomic-compare_exchange.rs
+++ b/src/test/run-pass/atomic-compare_exchange.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(stable_features)]
+
 #![feature(extended_compare_and_swap)]
 use std::sync::atomic::{AtomicIsize, ATOMIC_ISIZE_INIT};
 use std::sync::atomic::Ordering::*;

--- a/src/test/run-pass/atomic-print.rs
+++ b/src/test/run-pass/atomic-print.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_must_use)]
+#![allow(deprecated)]
 // ignore-cloudabi no process support
 // ignore-emscripten no threads support
 

--- a/src/test/run-pass/attr-before-view-item.rs
+++ b/src/test/run-pass/attr-before-view-item.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_attributes)]
+
 // pretty-expanded FIXME #23616
 
 #![feature(custom_attribute, test)]

--- a/src/test/run-pass/attr-before-view-item2.rs
+++ b/src/test/run-pass/attr-before-view-item2.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_attributes)]
+
 // pretty-expanded FIXME #23616
 
 #![feature(custom_attribute, test)]

--- a/src/test/run-pass/attr-mix-new.rs
+++ b/src/test/run-pass/attr-mix-new.rs
@@ -7,6 +7,10 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+
+#![allow(unused_attributes)]
+#![allow(unknown_lints)]
+
 // pretty-expanded FIXME #23616
 
 #![allow(unused_attribute)]

--- a/src/test/run-pass/attr-on-generic-formals.rs
+++ b/src/test/run-pass/attr-on-generic-formals.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_attributes)]
+
 // This test ensures we can attach attributes to the formals in all
 // places where generic parameter lists occur, assuming appropriate
 // feature gates are enabled.

--- a/src/test/run-pass/augmented-assignments.rs
+++ b/src/test/run-pass/augmented-assignments.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_imports)]
 #![deny(unused_assignments)]
 
 use std::mem;

--- a/src/test/run-pass/auto-instantiate.rs
+++ b/src/test/run-pass/auto-instantiate.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 #[derive(Debug)]
 struct Pair<T, U> { a: T, b: U }
 struct Triple { x: isize, y: isize, z: isize }

--- a/src/test/run-pass/auto-is-contextual.rs
+++ b/src/test/run-pass/auto-is-contextual.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(path_statements)]
+#![allow(dead_code)]
 macro_rules! auto {
     () => (struct S;)
 }

--- a/src/test/run-pass/binops.rs
+++ b/src/test/run-pass/binops.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
 // Binop corner cases
 
 fn test_nil() {

--- a/src/test/run-pass/blind-item-local-shadow.rs
+++ b/src/test/run-pass/blind-item-local-shadow.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
+#![allow(unused_imports)]
 mod bar {
     pub fn foo() -> bool { true }
 }

--- a/src/test/run-pass/block-arg-call-as.rs
+++ b/src/test/run-pass/block-arg-call-as.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_snake_case)]
 
 fn asBlock<F>(f: F) -> usize where F: FnOnce() -> usize {
    return f();

--- a/src/test/run-pass/block-expr-precedence.rs
+++ b/src/test/run-pass/block-expr-precedence.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_must_use)]
+#![allow(unused_parens)]
 // This test has some extra semis in it that the pretty-printer won't
 // reproduce so we don't want to automatically reformat it
 

--- a/src/test/run-pass/builtin-clone-unwind.rs
+++ b/src/test/run-pass/builtin-clone-unwind.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_variables)]
+#![allow(unused_imports)]
 // ignore-wasm32-bare compiled with panic=abort by default
 
 // Test that builtin implementations of `Clone` cleanup everything

--- a/src/test/run-pass/builtin-superkinds-in-metadata.rs
+++ b/src/test/run-pass/builtin-superkinds-in-metadata.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_imports)]
 
 // aux-build:trait_superkinds_in_metadata.rs
 

--- a/src/test/run-pass/builtin-superkinds-phantom-typaram.rs
+++ b/src/test/run-pass/builtin-superkinds-phantom-typaram.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 // Tests that even when a type parameter doesn't implement a required
 // super-builtin-kind of a trait, if the type parameter is never used,
 // the type can implement the trait anyway.

--- a/src/test/run-pass/cast.rs
+++ b/src/test/run-pass/cast.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_assignments)]
+#![allow(unused_variables)]
 
 pub fn main() {
     let i: isize = 'Q' as isize;

--- a/src/test/run-pass/cell-does-not-clone.rs
+++ b/src/test/run-pass/cell-does-not-clone.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 
 use std::cell::Cell;
 

--- a/src/test/run-pass/check-static-recursion-foreign.rs
+++ b/src/test/run-pass/check-static-recursion-foreign.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 // Static recursion check shouldn't fail when given a foreign item (#18279)
 
 // aux-build:check_static_recursion_foreign_helper.rs

--- a/src/test/run-pass/cleanup-arm-conditional.rs
+++ b/src/test/run-pass/cleanup-arm-conditional.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(stable_features)]
+#![allow(unused_imports)]
 // Test that cleanup scope for temporaries created in a match
 // arm is confined to the match arm itself.
 

--- a/src/test/run-pass/cleanup-rvalue-for-scope.rs
+++ b/src/test/run-pass/cleanup-rvalue-for-scope.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_snake_case)]
+#![allow(dead_code)]
+#![allow(unused_variables)]
 // Test that the lifetime of rvalues in for loops is extended
 // to the for loop itself.
 

--- a/src/test/run-pass/cleanup-rvalue-scopes.rs
+++ b/src/test/run-pass/cleanup-rvalue-scopes.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_snake_case)]
+#![allow(unused_variables)]
 // Test that destructors for rvalue temporaries run either at end of
 // statement or end of block, as appropriate given the temporary
 // lifetime rules.

--- a/src/test/run-pass/cleanup-rvalue-temp-during-incomplete-alloc.rs
+++ b/src/test/run-pass/cleanup-rvalue-temp-during-incomplete-alloc.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_must_use)]
+#![allow(dead_code)]
+#![allow(unused_variables)]
 // Test cleanup of rvalue temporary that occurs while `box` construction
 // is in progress. This scenario revealed a rather terrible bug.  The
 // ingredients are:

--- a/src/test/run-pass/clone-with-exterior.rs
+++ b/src/test/run-pass/clone-with-exterior.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_must_use)]
 // ignore-emscripten no threads support
 
 #![feature(box_syntax)]

--- a/src/test/run-pass/close-over-big-then-small-data.rs
+++ b/src/test/run-pass/close-over-big-then-small-data.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 // If we use GEPi rather than GEP_tup_like when
 // storing closure data (as we used to do), the u64 would
 // overwrite the u16.

--- a/src/test/run-pass/collections-const-new.rs
+++ b/src/test/run-pass/collections-const-new.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 // Test several functions can be used for constants
 // 1. Vec::new()
 // 2. String::new()

--- a/src/test/run-pass/command-before-exec.rs
+++ b/src/test/run-pass/command-before-exec.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(stable_features)]
 // ignore-windows - this is a unix-specific test
 // ignore-cloudabi no processes
 // ignore-emscripten no processes

--- a/src/test/run-pass/command-exec.rs
+++ b/src/test/run-pass/command-exec.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(stable_features)]
 // ignore-windows - this is a unix-specific test
 // ignore-pretty issue #37199
 // ignore-cloudabi no processes

--- a/src/test/run-pass/complex.rs
+++ b/src/test/run-pass/complex.rs
@@ -8,6 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unconditional_recursion)]
+#![allow(non_camel_case_types)]
+#![allow(dead_code)]
+#![allow(unused_mut)]
 
 
 

--- a/src/test/run-pass/core-run-destroy.rs
+++ b/src/test/run-pass/core-run-destroy.rs
@@ -8,6 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_must_use)]
+#![allow(stable_features)]
+#![allow(deprecated)]
+#![allow(unused_imports)]
 // compile-flags:--test
 // ignore-cloudabi no processes
 // ignore-emscripten no processes

--- a/src/test/run-pass/crt-static-off-works.rs
+++ b/src/test/run-pass/crt-static-off-works.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(stable_features)]
 // compile-flags:-C target-feature=-crt-static -Z unstable-options
 // ignore-musl - requires changing the linker which is hard
 

--- a/src/test/run-pass/crt-static-on-works.rs
+++ b/src/test/run-pass/crt-static-on-works.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(stable_features)]
 // compile-flags:-C target-feature=+crt-static -Z unstable-options
 
 #![feature(cfg_target_feature)]

--- a/src/test/run-pass/default-method-simple.rs
+++ b/src/test/run-pass/default-method-simple.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 
 trait Foo {
     fn f(&self) {

--- a/src/test/run-pass/defaults-well-formedness.rs
+++ b/src/test/run-pass/defaults-well-formedness.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 trait Trait<T> {}
 struct Foo<U, V=i32>(U, V) where U: Trait<V>;
 

--- a/src/test/run-pass/discriminant_value.rs
+++ b/src/test/run-pass/discriminant_value.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(stable_features)]
 #![feature(core, core_intrinsics)]
 
 extern crate core;

--- a/src/test/run-pass/diverging-fallback-control-flow.rs
+++ b/src/test/run-pass/diverging-fallback-control-flow.rs
@@ -8,6 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
+#![allow(unused_assignments)]
+#![allow(unused_variables)]
+#![allow(unreachable_code)]
 // Test various cases where we permit an unconstrained variable
 // to fallback based on control-flow.
 //

--- a/src/test/run-pass/diverging-fallback-method-chain.rs
+++ b/src/test/run-pass/diverging-fallback-method-chain.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_imports)]
 // Test a regression found when building compiler. The `produce()`
 // error type `T` winds up getting unified with result of `x.parse()`;
 // the type of the closure given to `unwrap_or_else` needs to be

--- a/src/test/run-pass/double-ref.rs
+++ b/src/test/run-pass/double-ref.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 // pretty-expanded FIXME #23616
 
 fn check_expr() {

--- a/src/test/run-pass/early-ret-binop-add.rs
+++ b/src/test/run-pass/early-ret-binop-add.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
+#![allow(unreachable_code)]
 // pretty-expanded FIXME #23616
 
 use std::ops::Add;

--- a/src/test/run-pass/early-vtbl-resolution.rs
+++ b/src/test/run-pass/early-vtbl-resolution.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
+#![allow(dead_code)]
 // pretty-expanded FIXME #23616
 
 trait thing<A> {

--- a/src/test/run-pass/edition-keywords-2015-2015.rs
+++ b/src/test/run-pass/edition-keywords-2015-2015.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_mut)]
+#![allow(unused_assignments)]
+#![allow(unused_variables)]
 // edition:2015
 // aux-build:edition-kw-macro-2015.rs
 

--- a/src/test/run-pass/edition-keywords-2015-2018.rs
+++ b/src/test/run-pass/edition-keywords-2015-2018.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_mut)]
+#![allow(unused_assignments)]
+#![allow(unused_variables)]
 // edition:2015
 // aux-build:edition-kw-macro-2018.rs
 

--- a/src/test/run-pass/edition-keywords-2018-2015.rs
+++ b/src/test/run-pass/edition-keywords-2018-2015.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_assignments)]
 // edition:2018
 // aux-build:edition-kw-macro-2015.rs
 

--- a/src/test/run-pass/edition-keywords-2018-2018.rs
+++ b/src/test/run-pass/edition-keywords-2018-2018.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_assignments)]
 // edition:2018
 // aux-build:edition-kw-macro-2018.rs
 

--- a/src/test/run-pass/empty-allocation-rvalue-non-null.rs
+++ b/src/test/run-pass/empty-allocation-rvalue-non-null.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_variables)]
 // pretty-expanded FIXME #23616
 
 pub fn main() {

--- a/src/test/run-pass/env-home-dir.rs
+++ b/src/test/run-pass/env-home-dir.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_variables)]
+#![allow(deprecated)]
 // ignore-cloudabi no environment variables present
 // ignore-emscripten env vars don't work?
 

--- a/src/test/run-pass/env-null-vars.rs
+++ b/src/test/run-pass/env-null-vars.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_imports)]
+
 // ignore-windows
 // ignore-wasm32-bare no libc to test ffi with
 

--- a/src/test/run-pass/epoch-gate-feature.rs
+++ b/src/test/run-pass/epoch-gate-feature.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
+#![allow(unused_variables)]
 // Checks if the correct registers are being used to pass arguments
 // when the sysv64 ABI is specified.
 

--- a/src/test/run-pass/estr-uniq.rs
+++ b/src/test/run-pass/estr-uniq.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_assignments)]
+#![allow(unknown_lints)]
 
 #![allow(dead_assignment)]
 

--- a/src/test/run-pass/existential_type.rs
+++ b/src/test/run-pass/existential_type.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
+#![allow(unused_assignments)]
+#![allow(unused_variables)]
 #![feature(existential_type)]
 
 fn main() {

--- a/src/test/run-pass/explicit-i-suffix.rs
+++ b/src/test/run-pass/explicit-i-suffix.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_must_use)]
 // pretty-expanded FIXME #23616
 
 pub fn main() {

--- a/src/test/run-pass/export-glob-imports-target.rs
+++ b/src/test/run-pass/export-glob-imports-target.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_upper_case_globals)]
+#![allow(dead_code)]
 // Test that a glob-export functions as an import
 // when referenced within its own local scope.
 

--- a/src/test/run-pass/expr-block.rs
+++ b/src/test/run-pass/expr-block.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 
 
 

--- a/src/test/run-pass/expr-empty-ret.rs
+++ b/src/test/run-pass/expr-empty-ret.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 // Issue #521
 
 // pretty-expanded FIXME #23616

--- a/src/test/run-pass/exterior.rs
+++ b/src/test/run-pass/exterior.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 
 
 use std::cell::Cell;

--- a/src/test/run-pass/fixup-deref-mut.rs
+++ b/src/test/run-pass/fixup-deref-mut.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 // pretty-expanded FIXME #23616
 
 use std::ops::{Deref, DerefMut};

--- a/src/test/run-pass/format-hygiene.rs
+++ b/src/test/run-pass/format-hygiene.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_upper_case_globals)]
 pub const arg0: u8 = 1;
 
 pub fn main() {

--- a/src/test/run-pass/fsu-moves-and-copies.rs
+++ b/src/test/run-pass/fsu-moves-and-copies.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
+#![allow(stable_features)]
 // Issue 4691: Ensure that functional-struct-updates operates
 // correctly and moves rather than copy when appropriate.
 

--- a/src/test/run-pass/guards-not-exhaustive.rs
+++ b/src/test/run-pass/guards-not-exhaustive.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_snake_case)]
 
 #[derive(Copy, Clone)]
 enum Q { R(Option<usize>) }

--- a/src/test/run-pass/guards.rs
+++ b/src/test/run-pass/guards.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_shorthand_field_patterns)]
 
 #[derive(Copy, Clone)]
 struct Pair { x: isize, y: isize }

--- a/src/test/run-pass/hashmap-memory.rs
+++ b/src/test/run-pass/hashmap-memory.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
+#![allow(dead_code)]
+#![allow(unused_mut)]
 // ignore-emscripten No support for threads
 
 /**

--- a/src/test/run-pass/html-literals.rs
+++ b/src/test/run-pass/html-literals.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
 // A test of the macro system. Can we do HTML literals?
 
 /*

--- a/src/test/run-pass/if-ret.rs
+++ b/src/test/run-pass/if-ret.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_parens)]
 // pretty-expanded FIXME #23616
 
 fn foo() { if (return) { } }

--- a/src/test/run-pass/ignore-all-the-things.rs
+++ b/src/test/run-pass/ignore-all-the-things.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_shorthand_field_patterns)]
+#![allow(dead_code)]
+#![allow(unused_variables)]
 // pretty-expanded FIXME #23616
 
 #![feature(slice_patterns)]

--- a/src/test/run-pass/infer-fn-tail-expr.rs
+++ b/src/test/run-pass/infer-fn-tail-expr.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 // issue #680
 
 

--- a/src/test/run-pass/init-large-type.rs
+++ b/src/test/run-pass/init-large-type.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_must_use)]
 // Makes sure that zero-initializing large types is reasonably fast,
 // Doing it incorrectly causes massive slowdown in LLVM during
 // optimisation.

--- a/src/test/run-pass/init-res-into-things.rs
+++ b/src/test/run-pass/init-res-into-things.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
+#![allow(dead_code)]
 #![feature(box_syntax)]
 
 use std::cell::Cell;

--- a/src/test/run-pass/instantiable.rs
+++ b/src/test/run-pass/instantiable.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
+#![allow(dead_code)]
 // pretty-expanded FIXME #23616
 
 use std::ptr;

--- a/src/test/run-pass/invalid_const_promotion.rs
+++ b/src/test/run-pass/invalid_const_promotion.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_mut)]
 // ignore-wasm32
 // ignore-emscripten
 

--- a/src/test/run-pass/issue-53728.rs
+++ b/src/test/run-pass/issue-53728.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 #[repr(u16)]
 enum DeviceKind {
     Nil = 0,

--- a/src/test/run-pass/item-attributes.rs
+++ b/src/test/run-pass/item-attributes.rs
@@ -8,6 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
+#![allow(non_upper_case_globals)]
+#![allow(unused_attributes)]
+#![allow(dead_code)]
+#![allow(unknown_lints)]
 // These are attributes of the implicit crate. Really this just needs to parse
 // for completeness since .rs files linked from .rc files support this
 // notation to specify their module's attributes

--- a/src/test/run-pass/item-name-overload.rs
+++ b/src/test/run-pass/item-name-overload.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 
 
 

--- a/src/test/run-pass/keyword-changes-2012-07-31.rs
+++ b/src/test/run-pass/keyword-changes-2012-07-31.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 // return -> return
 // mod -> module
 // match -> match

--- a/src/test/run-pass/kindck-implicit-close-over-mut-var.rs
+++ b/src/test/run-pass/kindck-implicit-close-over-mut-var.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_must_use)]
+#![allow(dead_code)]
 use std::thread;
 
 fn user(_i: isize) {}

--- a/src/test/run-pass/lambda-infer-unresolved.rs
+++ b/src/test/run-pass/lambda-infer-unresolved.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_mut)]
 // This should typecheck even though the type of e is not fully
 // resolved when we finish typechecking the ||.
 

--- a/src/test/run-pass/large-records.rs
+++ b/src/test/run-pass/large-records.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 
 
 

--- a/src/test/run-pass/last-use-in-block.rs
+++ b/src/test/run-pass/last-use-in-block.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
+#![allow(unused_parens)]
 // Issue #1818
 
 

--- a/src/test/run-pass/last-use-in-cap-clause.rs
+++ b/src/test/run-pass/last-use-in-cap-clause.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 // Make sure #1399 stays fixed
 
 struct A { a: Box<isize> }

--- a/src/test/run-pass/last-use-is-capture.rs
+++ b/src/test/run-pass/last-use-is-capture.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 // Make sure #1399 stays fixed
 
 #![feature(box_syntax)]

--- a/src/test/run-pass/lazy-init.rs
+++ b/src/test/run-pass/lazy-init.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_mut)]
 
 
 fn foo(x: isize) { println!("{}", x); }

--- a/src/test/run-pass/lib-defaults.rs
+++ b/src/test/run-pass/lib-defaults.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// dont-check-compiler-stderr (rust-lang/rust#54222)
+
 // ignore-wasm32-bare no libc to test ffi with
 
 // compile-flags: -lrust_test_helpers

--- a/src/test/run-pass/link-section.rs
+++ b/src/test/run-pass/link-section.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_upper_case_globals)]
 #[cfg(not(target_os = "macos"))]
 #[link_section=".moretext"]
 fn i_live_in_more_text() -> &'static str {

--- a/src/test/run-pass/lint-non-camel-case-types-non-uppercase-statics-unicode.rs
+++ b/src/test/run-pass/lint-non-camel-case-types-non-uppercase-statics-unicode.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 //
+#![allow(dead_code)]
 
 
 #![forbid(non_camel_case_types)]

--- a/src/test/run-pass/lint-non-camel-case-with-trailing-underscores.rs
+++ b/src/test/run-pass/lint-non-camel-case-with-trailing-underscores.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 // This is ok because we often use the trailing underscore to mean 'prime'
 
 // pretty-expanded FIXME #23616

--- a/src/test/run-pass/list.rs
+++ b/src/test/run-pass/list.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
 // pretty-expanded FIXME #23616
 
 #![feature(box_syntax)]

--- a/src/test/run-pass/liveness-assign-imm-local-after-ret.rs
+++ b/src/test/run-pass/liveness-assign-imm-local-after-ret.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unreachable_code)]
 // pretty-expanded FIXME #23616
 
 #![allow(dead_code)]

--- a/src/test/run-pass/log-knows-the-names-of-variants-in-std.rs
+++ b/src/test/run-pass/log-knows-the-names-of-variants-in-std.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
+#![allow(dead_code)]
 #[derive(Clone, Debug)]
 enum foo {
   a(usize),

--- a/src/test/run-pass/log-knows-the-names-of-variants.rs
+++ b/src/test/run-pass/log-knows-the-names-of-variants.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
+#![allow(dead_code)]
 #[derive(Debug)]
 enum foo {
   a(usize),

--- a/src/test/run-pass/max-min-classes.rs
+++ b/src/test/run-pass/max-min-classes.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_snake_case)]
 trait Product {
     fn product(&self) -> isize;
 }

--- a/src/test/run-pass/mid-path-type-params.rs
+++ b/src/test/run-pass/mid-path-type-params.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 // pretty-expanded FIXME #23616
 
 struct S<T> {

--- a/src/test/run-pass/monad.rs
+++ b/src/test/run-pass/monad.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
 
 
 

--- a/src/test/run-pass/monomorphize-abi-alignment.rs
+++ b/src/test/run-pass/monomorphize-abi-alignment.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_upper_case_globals)]
 /*!
  * On x86_64-linux-gnu and possibly other platforms, structs get 8-byte "preferred" alignment,
  * but their "ABI" alignment (i.e., what actually matters for data layout) is the largest alignment

--- a/src/test/run-pass/multiple-reprs.rs
+++ b/src/test/run-pass/multiple-reprs.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 
 use std::mem::{size_of, align_of};
 use std::os::raw::c_int;

--- a/src/test/run-pass/mutual-recursion-group.rs
+++ b/src/test/run-pass/mutual-recursion-group.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
+#![allow(dead_code)]
 
 // pretty-expanded FIXME #23616
 

--- a/src/test/run-pass/nested-class.rs
+++ b/src/test/run-pass/nested-class.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
 
 pub fn main() {
     struct b {

--- a/src/test/run-pass/never-result.rs
+++ b/src/test/run-pass/never-result.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_variables)]
+#![allow(unreachable_code)]
 // Test that we can extract a ! through pattern matching then use it as several different types.
 
 #![feature(never_type)]

--- a/src/test/run-pass/newlambdas-ret-infer.rs
+++ b/src/test/run-pass/newlambdas-ret-infer.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 // Test that the lambda kind is inferred correctly as a return
 // expression
 

--- a/src/test/run-pass/newlambdas-ret-infer2.rs
+++ b/src/test/run-pass/newlambdas-ret-infer2.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 // Test that the lambda kind is inferred correctly as a return
 // expression
 

--- a/src/test/run-pass/newtype-polymorphic.rs
+++ b/src/test/run-pass/newtype-polymorphic.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
 
 
 #[derive(Clone)]

--- a/src/test/run-pass/newtype.rs
+++ b/src/test/run-pass/newtype.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
 #[derive(Copy, Clone)]
 struct mytype(Mytype);
 

--- a/src/test/run-pass/nil-decl-in-foreign.rs
+++ b/src/test/run-pass/nil-decl-in-foreign.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(improper_ctypes)]
+#![allow(dead_code)]
 // Issue #901
 // pretty-expanded FIXME #23616
 

--- a/src/test/run-pass/no-core-1.rs
+++ b/src/test/run-pass/no-core-1.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(stable_features)]
 #![feature(no_core, core)]
 #![no_core]
 

--- a/src/test/run-pass/nullable-pointer-size.rs
+++ b/src/test/run-pass/nullable-pointer-size.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 
 use std::mem;
 

--- a/src/test/run-pass/operator-overloading.rs
+++ b/src/test/run-pass/operator-overloading.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_variables)]
 use std::cmp;
 use std::ops;
 

--- a/src/test/run-pass/optimization-fuel-0.stdout
+++ b/src/test/run-pass/optimization-fuel-0.stdout
@@ -1,0 +1,1 @@
+optimization-fuel-exhausted: Reorder fields of "S1"

--- a/src/test/run-pass/optimization-fuel-1.stdout
+++ b/src/test/run-pass/optimization-fuel-1.stdout
@@ -1,0 +1,1 @@
+optimization-fuel-exhausted: Reorder fields of "S2"

--- a/src/test/run-pass/option-unwrap.rs
+++ b/src/test/run-pass/option-unwrap.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
 use std::cell::Cell;
 
 struct dtor<'a> {

--- a/src/test/run-pass/out-of-stack.rs
+++ b/src/test/run-pass/out-of-stack.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_must_use)]
+#![allow(unconditional_recursion)]
 // ignore-android: FIXME (#20004)
 // ignore-musl
 // ignore-cloudabi no processes

--- a/src/test/run-pass/output-slot-variants.rs
+++ b/src/test/run-pass/output-slot-variants.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
+#![allow(unused_assignments)]
+#![allow(unknown_lints)]
 // pretty-expanded FIXME #23616
 
 #![allow(dead_assignment)]

--- a/src/test/run-pass/over-constrained-vregs.rs
+++ b/src/test/run-pass/over-constrained-vregs.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_must_use)]
 // Regression test for issue #152.
 pub fn main() {
     let mut b: usize = 1_usize;

--- a/src/test/run-pass/parse-panic.rs
+++ b/src/test/run-pass/parse-panic.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 #![allow(unreachable_code)]
 
 fn dont_call_me() { panic!(); println!("{}", 1); }

--- a/src/test/run-pass/paths-containing-nul.rs
+++ b/src/test/run-pass/paths-containing-nul.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(deprecated)]
 // ignore-cloudabi no files or I/O
 // ignore-wasm32-bare no files or I/O
 

--- a/src/test/run-pass/project-cache-issue-37154.rs
+++ b/src/test/run-pass/project-cache-issue-37154.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 // Regression test for #37154: the problem here was that the cache
 // results in a false error because it was caching skolemized results
 // even after those skolemized regions had been popped.

--- a/src/test/run-pass/project-defer-unification.rs
+++ b/src/test/run-pass/project-defer-unification.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
+#![allow(unused_variables)]
+#![allow(unreachable_code)]
 // A regression test extracted from image-0.3.11. The point of
 // failure was in `index_colors` below.
 

--- a/src/test/run-pass/project-defer-unification.rs
+++ b/src/test/run-pass/project-defer-unification.rs
@@ -95,6 +95,10 @@ pub fn index_colors<Pix>(image: &ImageBuffer<Pix, Vec<u8>>)
                          -> ImageBuffer<Luma<u8>, Vec<u8>>
 where Pix: Pixel<Subpixel=u8> + 'static,
 {
+    // When NLL-enabled, `let mut` below is deemed unnecessary (due to
+    // the remaining code being unreachable); so ignore that lint.
+    #![allow(unused_mut)]
+
     let mut indices: ImageBuffer<_,Vec<_>> = loop { };
     for (pixel, idx) in image.pixels().zip(indices.pixels_mut()) {
         // failured occurred here ^^ because we were requiring that we

--- a/src/test/run-pass/ptr-coercion.rs
+++ b/src/test/run-pass/ptr-coercion.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_variables)]
 // Test coercions between pointers which don't do anything fancy like unsizing.
 
 // pretty-expanded FIXME #23616

--- a/src/test/run-pass/pure-sum.rs
+++ b/src/test/run-pass/pure-sum.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 // Check that functions can modify local state.
 
 // pretty-expanded FIXME #23616

--- a/src/test/run-pass/range-type-infer.rs
+++ b/src/test/run-pass/range-type-infer.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_must_use)]
 // Make sure the type inference for the new range expression work as
 // good as the old one. Check out issue #21672, #21595 and #21649 for
 // more details.

--- a/src/test/run-pass/range.rs
+++ b/src/test/run-pass/range.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_comparisons)]
+#![allow(dead_code)]
+#![allow(unused_mut)]
 // Test range syntax.
 
 

--- a/src/test/run-pass/range_inclusive_gate.rs
+++ b/src/test/run-pass/range_inclusive_gate.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_comparisons)]
 // Test that you only need the syntax gate if you don't mention the structs.
 // (Obsoleted since both features are stabilized)
 

--- a/src/test/run-pass/rcvr-borrowed-to-region.rs
+++ b/src/test/run-pass/rcvr-borrowed-to-region.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
 #![feature(box_syntax)]
 
 trait get {

--- a/src/test/run-pass/readalias.rs
+++ b/src/test/run-pass/readalias.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 
 
 

--- a/src/test/run-pass/resolve-issue-2428.rs
+++ b/src/test/run-pass/resolve-issue-2428.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
+#![allow(non_upper_case_globals)]
 
 const foo: isize = 4 >> 1;
 enum bs { thing = foo }

--- a/src/test/run-pass/resource-assign-is-not-copy.rs
+++ b/src/test/run-pass/resource-assign-is-not-copy.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
 use std::cell::Cell;
 
 #[derive(Debug)]

--- a/src/test/run-pass/resource-destruct.rs
+++ b/src/test/run-pass/resource-destruct.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
 use std::cell::Cell;
 
 struct shrinky_pointer<'a> {

--- a/src/test/run-pass/ret-none.rs
+++ b/src/test/run-pass/ret-none.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
+#![allow(dead_code)]
 
 
 // pretty-expanded FIXME #23616

--- a/src/test/run-pass/rustc-rust-log.rs
+++ b/src/test/run-pass/rustc-rust-log.rs
@@ -8,6 +8,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// This test is just checking that we won't ICE if logging is turned
+// on; don't bother trying to compare that (copious) output. (Note
+// also that this test potentially silly, since we do not build+test
+// debug versions of rustc as part of our continuous integration
+// process...)
+//
+// dont-check-compiler-stdout
+// dont-check-compiler-stderr
+
 // rustc-env:RUST_LOG=debug
 
 fn main() {}

--- a/src/test/run-pass/segfault-no-out-of-stack.rs
+++ b/src/test/run-pass/segfault-no-out-of-stack.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_imports)]
 // ignore-cloudabi can't run commands
 // ignore-emscripten can't run commands
 

--- a/src/test/run-pass/semistatement-in-lambda.rs
+++ b/src/test/run-pass/semistatement-in-lambda.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_must_use)]
 
 pub fn main() {
     // Test that lambdas behave as unary expressions with block-like expressions

--- a/src/test/run-pass/shadow.rs
+++ b/src/test/run-pass/shadow.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
+#![allow(dead_code)]
 fn foo(c: Vec<isize> ) {
     let a: isize = 5;
     let mut b: Vec<isize> = Vec::new();

--- a/src/test/run-pass/shadowed-use-visibility.rs
+++ b/src/test/run-pass/shadowed-use-visibility.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_imports)]
 mod foo {
     pub fn f() {}
 

--- a/src/test/run-pass/sigpipe-should-be-ignored.rs
+++ b/src/test/run-pass/sigpipe-should-be-ignored.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_must_use)]
 // Be sure that when a SIGPIPE would have been received that the entire process
 // doesn't die in a ball of fire, but rather it's gracefully handled.
 

--- a/src/test/run-pass/simple-infer.rs
+++ b/src/test/run-pass/simple-infer.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_mut)]
 
 
 pub fn main() { let mut n; n = 1; println!("{}", n); }

--- a/src/test/run-pass/simple_global_asm.rs
+++ b/src/test/run-pass/simple_global_asm.rs
@@ -10,6 +10,7 @@
 
 #![feature(global_asm)]
 #![feature(naked_functions)]
+#![allow(dead_code)]
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 global_asm!(r#"

--- a/src/test/run-pass/size-and-align.rs
+++ b/src/test/run-pass/size-and-align.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
 enum clam<T> { a(T, isize), b, }
 
 fn uhoh<T>(v: Vec<clam<T>> ) {

--- a/src/test/run-pass/sized-borrowed-pointer.rs
+++ b/src/test/run-pass/sized-borrowed-pointer.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 // Possibly-dynamic size of typaram should be cleared at pointer boundary.
 
 // pretty-expanded FIXME #23616

--- a/src/test/run-pass/sized-owned-pointer.rs
+++ b/src/test/run-pass/sized-owned-pointer.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 // Possibly-dynamic size of typaram should be cleared at pointer boundary.
 
 

--- a/src/test/run-pass/snake-case-no-lowercase-equivalent.rs
+++ b/src/test/run-pass/snake-case-no-lowercase-equivalent.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 // pretty-expanded FIXME #23616
 
 #![feature(non_ascii_idents)]

--- a/src/test/run-pass/sse2.rs
+++ b/src/test/run-pass/sse2.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(stable_features)]
 // min-llvm-version 6.0
 // ^ needs MCSubtargetInfo::checkFeatures()
 // ignore-cloudabi no std::env

--- a/src/test/run-pass/structured-compare.rs
+++ b/src/test/run-pass/structured-compare.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
 
 
 #[derive(Copy, Clone, Debug)]

--- a/src/test/run-pass/super-fast-paren-parsing.rs
+++ b/src/test/run-pass/super-fast-paren-parsing.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_upper_case_globals)]
+#![allow(dead_code)]
 // exec-env:RUST_MIN_STACK=16000000
 // rustc-env:RUST_MIN_STACK=16000000
 //

--- a/src/test/run-pass/super.rs
+++ b/src/test/run-pass/super.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 // pretty-expanded FIXME #23616
 
 pub mod a {

--- a/src/test/run-pass/swap-overlapping.rs
+++ b/src/test/run-pass/swap-overlapping.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 // Issue #5041 - avoid overlapping memcpy when src and dest of a swap are the same
 
 // pretty-expanded FIXME #23616

--- a/src/test/run-pass/trivial-message.rs
+++ b/src/test/run-pass/trivial-message.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_must_use)]
 /*
   This is about the simplest program that can successfully send a
   message.

--- a/src/test/run-pass/try-block.rs
+++ b/src/test/run-pass/try-block.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
+#![allow(dead_code)]
 // compile-flags: --edition 2018
 
 #![feature(try_blocks)]

--- a/src/test/run-pass/try-is-identifier-edition2015.rs
+++ b/src/test/run-pass/try-is-identifier-edition2015.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
 // compile-flags: --edition 2015
 
 fn main() {

--- a/src/test/run-pass/try-operator-hygiene.rs
+++ b/src/test/run-pass/try-operator-hygiene.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_upper_case_globals)]
+#![allow(dead_code)]
 // `expr?` expands to:
 //
 // match expr {

--- a/src/test/run-pass/try-operator.rs
+++ b/src/test/run-pass/try-operator.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 // ignore-cloudabi no std::fs
 
 use std::fs::File;

--- a/src/test/run-pass/try-wait.rs
+++ b/src/test/run-pass/try-wait.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(stable_features)]
 // ignore-cloudabi no processes
 // ignore-emscripten no processes
 

--- a/src/test/run-pass/tup.rs
+++ b/src/test/run-pass/tup.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
 
 type point = (isize, isize);
 

--- a/src/test/run-pass/tydesc-name.rs
+++ b/src/test/run-pass/tydesc-name.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 
 #![feature(core_intrinsics)]
 

--- a/src/test/run-pass/type-ascription.rs
+++ b/src/test/run-pass/type-ascription.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
+#![allow(unused_variables)]
 // Type ascription doesn't lead to unsoundness
 
 #![feature(type_ascription)]

--- a/src/test/run-pass/type-in-nested-module.rs
+++ b/src/test/run-pass/type-in-nested-module.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
+#![allow(dead_code)]
 
 
 // pretty-expanded FIXME #23616

--- a/src/test/run-pass/type-infer-generalize-ty-var.rs
+++ b/src/test/run-pass/type-infer-generalize-ty-var.rs
@@ -8,6 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_upper_case_globals)]
+#![allow(dead_code)]
+#![allow(unused_assignments)]
+#![allow(unused_variables)]
 // Test a scenario where we generate a constraint like `?1 <: &?2`.
 // In such a case, it is important that we instantiate `?1` with `&?3`
 // where `?3 <: ?2`, and not with `&?2`. This is a regression test for

--- a/src/test/run-pass/type-param-constraints.rs
+++ b/src/test/run-pass/type-param-constraints.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
+#![allow(dead_code)]
 // pretty-expanded FIXME #23616
 
 #![feature(box_syntax)]

--- a/src/test/run-pass/type-param.rs
+++ b/src/test/run-pass/type-param.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
+#![allow(dead_code)]
 
 
 // pretty-expanded FIXME #23616

--- a/src/test/run-pass/type-params-in-for-each.rs
+++ b/src/test/run-pass/type-params-in-for-each.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 
 // pretty-expanded FIXME #23616
 

--- a/src/test/run-pass/type-ptr.rs
+++ b/src/test/run-pass/type-ptr.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 // pretty-expanded FIXME #23616
 
 fn f(a: *const isize) -> *const isize { return a; }

--- a/src/test/run-pass/type-sizes.rs
+++ b/src/test/run-pass/type-sizes.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
+#![allow(dead_code)]
 #![feature(never_type)]
 
 use std::mem::size_of;

--- a/src/test/run-pass/typeck_type_placeholder_1.rs
+++ b/src/test/run-pass/typeck_type_placeholder_1.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 // This test checks that the `_` type placeholder works
 // correctly for enabling type inference.
 

--- a/src/test/run-pass/typeclasses-eq-example-static.rs
+++ b/src/test/run-pass/typeclasses-eq-example-static.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(dead_code)]
 #![feature(box_syntax)]
 
 // Example from lkuper's intern talk, August 2012 -- now with static

--- a/src/test/run-pass/typeclasses-eq-example.rs
+++ b/src/test/run-pass/typeclasses-eq-example.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(dead_code)]
 #![feature(box_syntax)]
 
 // Example from lkuper's intern talk, August 2012.

--- a/src/test/run-pass/typeid-intrinsic.rs
+++ b/src/test/run-pass/typeid-intrinsic.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(deprecated)]
 // aux-build:typeid-intrinsic-aux1.rs
 // aux-build:typeid-intrinsic-aux2.rs
 

--- a/src/test/run-pass/typestate-cfg-nesting.rs
+++ b/src/test/run-pass/typestate-cfg-nesting.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
+#![allow(unused_assignments)]
+#![allow(unknown_lints)]
 // pretty-expanded FIXME #23616
 
 #![allow(dead_assignment)]

--- a/src/test/run-pass/underscore-lifetimes.rs
+++ b/src/test/run-pass/underscore-lifetimes.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 struct Foo<'a>(&'a u8);
 
 fn foo(x: &u8) -> Foo<'_> {

--- a/src/test/run-pass/unit.rs
+++ b/src/test/run-pass/unit.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_assignments)]
+#![allow(unknown_lints)]
 // pretty-expanded FIXME #23616
 
 #![allow(unused_variables)]

--- a/src/test/run-pass/unreachable-code-1.rs
+++ b/src/test/run-pass/unreachable-code-1.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_must_use)]
+#![allow(unreachable_code)]
 
 #![allow(unused_variables)]
 #![allow(dead_code)]

--- a/src/test/run-pass/unreachable-code.rs
+++ b/src/test/run-pass/unreachable-code.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_must_use)]
+#![allow(dead_code)]
 
 #![allow(path_statements)]
 #![allow(unreachable_code)]

--- a/src/test/run-pass/unsafe-fn-called-from-unsafe-blk.rs
+++ b/src/test/run-pass/unsafe-fn-called-from-unsafe-blk.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 //
 // See also: compile-fail/unsafe-fn-called-from-safe.rs
 

--- a/src/test/run-pass/unsafe-fn-called-from-unsafe-fn.rs
+++ b/src/test/run-pass/unsafe-fn-called-from-unsafe-fn.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 //
 // See also: compile-fail/unsafe-fn-called-from-safe.rs
 

--- a/src/test/run-pass/unsized.rs
+++ b/src/test/run-pass/unsized.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(type_alias_bounds)]
+#![allow(dead_code)]
 // Test syntax checks for `?Sized` syntax.
 
 use std::marker::PhantomData;

--- a/src/test/run-pass/unsized2.rs
+++ b/src/test/run-pass/unsized2.rs
@@ -8,6 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unconditional_recursion)]
+#![allow(dead_code)]
+#![allow(unused_variables)]
+#![allow(unused_imports)]
 #![feature(box_syntax)]
 
 // Test sized-ness checking in substitution.

--- a/src/test/run-pass/unwind-resource.rs
+++ b/src/test/run-pass/unwind-resource.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
 // ignore-emscripten no threads support
 
 use std::sync::mpsc::{channel, Sender};

--- a/src/test/run-pass/use-keyword-2.rs
+++ b/src/test/run-pass/use-keyword-2.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_variables)]
 pub struct A;
 
 mod test {

--- a/src/test/run-pass/use-mod.rs
+++ b/src/test/run-pass/use-mod.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_imports)]
 // pretty-expanded FIXME #23616
 
 pub use foo::bar::{self, First};

--- a/src/test/run-pass/use.rs
+++ b/src/test/run-pass/use.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(stable_features)]
 // pretty-expanded FIXME #23616
 
 #![allow(unused_imports)]

--- a/src/test/run-pass/utf8_idents.rs
+++ b/src/test/run-pass/utf8_idents.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 //
+#![allow(non_snake_case)]
 
 #![feature(non_ascii_idents)]
 

--- a/src/test/run-pass/variant-attributes.rs
+++ b/src/test/run-pass/variant-attributes.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_attributes)]
+#![allow(non_camel_case_types)]
+#![allow(dead_code)]
 // pp-exact - Make sure we actually print the attributes
 // pretty-expanded FIXME #23616
 

--- a/src/test/run-pass/volatile-fat-ptr.rs
+++ b/src/test/run-pass/volatile-fat-ptr.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(stable_features)]
 #![feature(volatile)]
 use std::ptr::{read_volatile, write_volatile};
 

--- a/src/test/run-pass/warn-ctypes-inhibit.rs
+++ b/src/test/run-pass/warn-ctypes-inhibit.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 // compile-flags:-D improper-ctypes
 
 // pretty-expanded FIXME #23616

--- a/src/test/run-pass/weird-exprs.rs
+++ b/src/test/run-pass/weird-exprs.rs
@@ -8,6 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
+#![allow(dead_code)]
+#![allow(unreachable_code)]
+#![allow(unused_parens)]
 // compile-flags: -Z borrowck=compare
 
 #![recursion_limit = "128"]

--- a/src/test/run-pass/wf-bound-region-in-object-type.rs
+++ b/src/test/run-pass/wf-bound-region-in-object-type.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
+#![allow(unused_variables)]
 // Test that the `wf` checker properly handles bound regions in object
 // types. Compiling this code used to trigger an ICE.
 

--- a/src/test/run-pass/writealias.rs
+++ b/src/test/run-pass/writealias.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
 
 use std::sync::Mutex;
 

--- a/src/test/run-pass/wrong-hashset-issue-42918.rs
+++ b/src/test/run-pass/wrong-hashset-issue-42918.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 //
+#![allow(dead_code)]
 // compile-flags: -O
 
 use std::collections::HashSet;

--- a/src/test/run-pass/x86stdcall2.rs
+++ b/src/test/run-pass/x86stdcall2.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
 pub type HANDLE = usize;
 pub type DWORD = u32;
 pub type SIZE_T = u32;

--- a/src/test/run-pass/yield.rs
+++ b/src/test/run-pass/yield.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_must_use)]
+#![allow(unused_mut)]
 // ignore-emscripten no threads support
 
 use std::thread;

--- a/src/test/run-pass/yield1.rs
+++ b/src/test/run-pass/yield1.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_must_use)]
+#![allow(unused_mut)]
 // ignore-emscripten no threads support
 
 use std::thread;

--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -21,6 +21,7 @@ pub enum Mode {
     CompileFail,
     ParseFail,
     RunFail,
+    /// This now behaves like a `ui` test that has an implict `// run-pass`.
     RunPass,
     RunPassValgrind,
     Pretty,

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -199,6 +199,10 @@ pub struct TestProps {
     pub force_host: bool,
     // Check stdout for error-pattern output as well as stderr
     pub check_stdout: bool,
+    // For UI tests, allows compiler to generate arbitrary output to stdout
+    pub dont_check_compiler_stdout: bool,
+    // For UI tests, allows compiler to generate arbitrary output to stderr
+    pub dont_check_compiler_stderr: bool,
     // Don't force a --crate-type=dylib flag on the command line
     pub no_prefer_dynamic: bool,
     // Run --pretty expanded when running pretty printing tests
@@ -249,6 +253,8 @@ impl TestProps {
             build_aux_docs: false,
             force_host: false,
             check_stdout: false,
+            dont_check_compiler_stdout: false,
+            dont_check_compiler_stderr: false,
             no_prefer_dynamic: false,
             pretty_expanded: false,
             pretty_mode: "normal".to_string(),
@@ -325,6 +331,14 @@ impl TestProps {
 
             if !self.check_stdout {
                 self.check_stdout = config.parse_check_stdout(ln);
+            }
+
+            if !self.dont_check_compiler_stdout {
+                self.dont_check_compiler_stdout = config.parse_dont_check_compiler_stdout(ln);
+            }
+
+            if !self.dont_check_compiler_stderr {
+                self.dont_check_compiler_stderr = config.parse_dont_check_compiler_stderr(ln);
             }
 
             if !self.no_prefer_dynamic {
@@ -508,6 +522,14 @@ impl Config {
 
     fn parse_check_stdout(&self, line: &str) -> bool {
         self.parse_name_directive(line, "check-stdout")
+    }
+
+    fn parse_dont_check_compiler_stdout(&self, line: &str) -> bool {
+        self.parse_name_directive(line, "dont-check-compiler-stdout")
+    }
+
+    fn parse_dont_check_compiler_stderr(&self, line: &str) -> bool {
+        self.parse_name_directive(line, "dont-check-compiler-stderr")
     }
 
     fn parse_no_prefer_dynamic(&self, line: &str) -> bool {

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -274,6 +274,18 @@ impl<'test> TestCx<'test> {
             ParseFail | CompileFail => false,
             RunPass => true,
             Ui => self.props.compile_pass,
+            Incremental => {
+                let revision = self.revision
+                    .expect("incremental tests require a list of revisions");
+                if revision.starts_with("rpass") || revision.starts_with("rfail") {
+                    true
+                } else if revision.starts_with("cfail") {
+                    // FIXME: would be nice if incremental revs could start with "cpass"
+                    self.props.compile_pass
+                } else {
+                    panic!("revision name must begin with rpass, rfail, or cfail");
+                }
+            }
             mode => panic!("unimplemented for mode {:?}", mode),
         }
     }

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -271,7 +271,7 @@ impl<'test> TestCx<'test> {
 
     fn should_compile_successfully(&self) -> bool {
         match self.config.mode {
-            ParseFail | CompileFail => false,
+            ParseFail | CompileFail => self.props.compile_pass,
             RunPass => true,
             Ui => self.props.compile_pass,
             Incremental => {

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -262,11 +262,12 @@ impl<'test> TestCx<'test> {
     }
 
     fn should_run_successfully(&self) -> bool {
-        match self.config.mode {
-            RunPass => !self.props.skip_codegen,
+        let run_pass = match self.config.mode {
+            RunPass => true,
             Ui => self.props.run_pass,
             _ => unimplemented!(),
-        }
+        };
+        return run_pass && !self.props.skip_codegen;
     }
 
     fn should_compile_successfully(&self) -> bool {

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2654,8 +2654,12 @@ impl<'test> TestCx<'test> {
         let normalized_stderr = self.normalize_output(&stderr, &self.props.normalize_stderr);
 
         let mut errors = 0;
-        errors += self.compare_output("stdout", &normalized_stdout, &expected_stdout);
-        errors += self.compare_output("stderr", &normalized_stderr, &expected_stderr);
+        if !self.props.dont_check_compiler_stdout {
+            errors += self.compare_output("stdout", &normalized_stdout, &expected_stdout);
+        }
+        if !self.props.dont_check_compiler_stderr {
+            errors += self.compare_output("stderr", &normalized_stderr, &expected_stderr);
+        }
 
         let modes_to_prune = vec![CompareMode::Nll];
         self.prune_duplicate_outputs(&modes_to_prune);

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -271,7 +271,7 @@ impl<'test> TestCx<'test> {
 
     fn should_compile_successfully(&self) -> bool {
         match self.config.mode {
-            CompileFail => false,
+            ParseFail | CompileFail => false,
             RunPass => true,
             Ui => self.props.compile_pass,
             mode => panic!("unimplemented for mode {:?}", mode),

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -263,7 +263,7 @@ impl<'test> TestCx<'test> {
 
     fn should_run_successfully(&self) -> bool {
         match self.config.mode {
-            RunPass => true,
+            RunPass => !self.props.skip_codegen,
             Ui => self.props.run_pass,
             _ => unimplemented!(),
         }


### PR DESCRIPTION
This addresses the remainder of #53764 by first converting `src/test/run-pass` into another `ui`-style test suite, and then turning on `compare-mode=nll` for that new suite.

After this lands, we can address #54047 for the short term by moving all the `src/test/ui/run-pass` tests back to `src/test/run-pass`.

(Longer term, the compiler team's current (hypothetical sketch of a) plan (see [1][], [2][]) is unify all the tests by embedding these meta-properties like "// run-pass` into their headers explicitly and dropping the significance of their location on the file system.)

[1]: https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/subject/weekly.20meeting.202018-09-13/near/133889370
[2]: https://github.com/rust-lang/rust/issues/54047#issuecomment-421030356
