### PR TITLE
Regression test for rust-lang/rust#53675.

### DIFF
--- a/src/test/ui/issues/issue-53675-a-test-called-panic.rs
+++ b/src/test/ui/issues/issue-53675-a-test-called-panic.rs
@@ -1,0 +1,36 @@
+// rust-lang/rust#53675: At one point the compiler errored when a test
+// named `panic` used the `assert!` macro in expression position.
+
+// compile-pass
+// compile-flags: --test
+
+mod in_expression_position {
+    #[test]
+    fn panic() {
+        assert!(true)
+    }
+}
+
+mod in_statement_position {
+    #[test]
+    fn panic() {
+        assert!(true);
+    }
+}
+
+mod what_if_we_use_panic_directly_in_expr {
+    #[test]
+    #[should_panic]
+    fn panic() {
+        panic!("in expr")
+    }
+}
+
+
+mod what_if_we_use_panic_directly_in_stmt {
+    #[test]
+    #[should_panic]
+    fn panic() {
+        panic!("in stmt");
+    }
+}


### PR DESCRIPTION
(Includes a couple variations on the theme. I confirmed that the ones
in `in_expression_position` and `what_if_we_use_panic_directly_in_expr`
both failed back on "rustc 1.30.0-nightly (0f063aef6 2018-09-03)".)

Fix #53675 