### PR TITLE
Remove usages of span_suggestion without Applicability

### DIFF
--- a/src/librustc/infer/error_reporting/nice_region_error/named_anon_conflict.rs
+++ b/src/librustc/infer/error_reporting/nice_region_error/named_anon_conflict.rs
@@ -13,6 +13,7 @@
 use infer::error_reporting::nice_region_error::NiceRegionError;
 use ty;
 use util::common::ErrorReported;
+use errors::Applicability;
 
 impl<'a, 'gcx, 'tcx> NiceRegionError<'a, 'gcx, 'tcx> {
     /// When given a `ConcreteFailure` for a function with arguments containing a named region and
@@ -111,10 +112,11 @@ impl<'a, 'gcx, 'tcx> NiceRegionError<'a, 'gcx, 'tcx> {
             E0621,
             "explicit lifetime required in {}",
             error_var
-        ).span_suggestion(
+        ).span_suggestion_with_applicability(
             new_ty_span,
             &format!("add explicit lifetime `{}` to {}", named, span_label_var),
-            new_ty.to_string()
+            new_ty.to_string(),
+            Applicability::Unspecified,
         )
             .span_label(span, format!("lifetime `{}` required", named))
             .emit();

--- a/src/librustc/infer/error_reporting/nice_region_error/named_anon_conflict.rs
+++ b/src/librustc/infer/error_reporting/nice_region_error/named_anon_conflict.rs
@@ -118,8 +118,8 @@ impl<'a, 'gcx, 'tcx> NiceRegionError<'a, 'gcx, 'tcx> {
             new_ty.to_string(),
             Applicability::Unspecified,
         )
-            .span_label(span, format!("lifetime `{}` required", named))
-            .emit();
+        .span_label(span, format!("lifetime `{}` required", named))
+        .emit();
         return Some(ErrorReported);
     }
 

--- a/src/librustc/infer/error_reporting/nice_region_error/static_impl_trait.rs
+++ b/src/librustc/infer/error_reporting/nice_region_error/static_impl_trait.rs
@@ -14,6 +14,7 @@ use infer::error_reporting::nice_region_error::NiceRegionError;
 use infer::lexical_region_resolve::RegionResolutionError;
 use ty::{BoundRegion, FreeRegion, RegionKind};
 use util::common::ErrorReported;
+use errors::Applicability;
 
 impl<'a, 'gcx, 'tcx> NiceRegionError<'a, 'gcx, 'tcx> {
     /// Print the error message for lifetime errors when the return type is a static impl Trait.
@@ -61,7 +62,7 @@ impl<'a, 'gcx, 'tcx> NiceRegionError<'a, 'gcx, 'tcx> {
                             _ => "'_".to_owned(),
                         };
                         if let Ok(snippet) = self.tcx.sess.source_map().span_to_snippet(return_sp) {
-                            err.span_suggestion(
+                            err.span_suggestion_with_applicability(
                                 return_sp,
                                 &format!(
                                     "you can add a constraint to the return type to make it last \
@@ -69,6 +70,7 @@ impl<'a, 'gcx, 'tcx> NiceRegionError<'a, 'gcx, 'tcx> {
                                     lifetime,
                                 ),
                                 format!("{} + {}", snippet, lifetime_name),
+                                Applicability::Unspecified,
                             );
                         }
                         err.emit();

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -432,8 +432,12 @@ impl Session {
                 }
                 DiagnosticBuilderMethod::SpanSuggestion(suggestion) => {
                     let span = span_maybe.expect("span_suggestion_* needs a span");
-                    diag_builder.span_suggestion_with_applicability(span, message, suggestion,
-                                                                    Applicability::Unspecified);
+                    diag_builder.span_suggestion_with_applicability(
+                                                                    span,
+                                                                    message,
+                                                                    suggestion,
+                                                                    Applicability::Unspecified,
+                                                                    );
                 }
             }
         }

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -28,7 +28,7 @@ use rustc_data_structures::base_n;
 use rustc_data_structures::sync::{self, Lrc, Lock, LockCell, OneThread, Once, RwLock};
 
 use syntax::ast::NodeId;
-use errors::{self, DiagnosticBuilder, DiagnosticId};
+use errors::{self, DiagnosticBuilder, DiagnosticId, Applicability};
 use errors::emitter::{Emitter, EmitterWriter};
 use syntax::edition::Edition;
 use syntax::json::JsonEmitter;
@@ -431,8 +431,9 @@ impl Session {
                     diag_builder.span_note(span, message);
                 }
                 DiagnosticBuilderMethod::SpanSuggestion(suggestion) => {
-                    let span = span_maybe.expect("span_suggestion needs a span");
-                    diag_builder.span_suggestion(span, message, suggestion);
+                    let span = span_maybe.expect("span_suggestion_* needs a span");
+                    diag_builder.span_suggestion_with_applicability(span, message, suggestion,
+                                                                    Applicability::Unspecified);
                 }
             }
         }

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -433,11 +433,11 @@ impl Session {
                 DiagnosticBuilderMethod::SpanSuggestion(suggestion) => {
                     let span = span_maybe.expect("span_suggestion_* needs a span");
                     diag_builder.span_suggestion_with_applicability(
-                                                                    span,
-                                                                    message,
-                                                                    suggestion,
-                                                                    Applicability::Unspecified,
-                                                                    );
+                        span,
+                        message,
+                        suggestion,
+                        Applicability::Unspecified,
+                    );
                 }
             }
         }

--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -1250,6 +1250,11 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
                                 let_span,
                                 "use a mutable reference instead",
                                 replace_str,
+                                // I believe this can be machine applicable,
+                                // but if there are multiple attempted uses of an immutable
+                                // reference, I don't know how rustfix handles it, it might
+                                // attempt fixing them multiple times.
+                                //                              @estebank
                                 Applicability::Unspecified,
                             );
                         }
@@ -1308,7 +1313,7 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
                         "consider removing the `&mut`, as it is an \
                         immutable binding to a mutable reference",
                         snippet,
-                        Applicability::Unspecified,
+                        Applicability::MachineApplicable,
                     );
                 } else {
                     db.span_suggestion_with_applicability(
@@ -1345,7 +1350,7 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
                                                    use the `move` keyword",
                                                    cmt_path_or_string),
                                          suggestion,
-                                         Applicability::Unspecified,
+                                         Applicability::MachineApplicable,
             )
             .emit();
         self.signal_error();

--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -868,19 +868,19 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
                                             db.note(fn_closure_msg);
                                         } else {
                                             db.span_suggestion_with_applicability(
-                                                                                  sp,
-                                                                                  msg,
-                                                                                  suggestion,
-                                                                                  Applicability::Unspecified,
-                                                                                  );
+                                                                      sp,
+                                                                      msg,
+                                                                      suggestion,
+                                                                      Applicability::Unspecified,
+                                                                      );
                                         }
                                     } else {
                                         db.span_suggestion_with_applicability(
-                                                                              sp,
-                                                                              msg,
-                                                                              suggestion,
-                                                                              Applicability::Unspecified,
-                                                                              );
+                                                                      sp,
+                                                                      msg,
+                                                                      suggestion,
+                                                                      Applicability::Unspecified,
+                                                                      );
                                     }
                                 }
                                 _ => {

--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -868,19 +868,19 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
                                             db.note(fn_closure_msg);
                                         } else {
                                             db.span_suggestion_with_applicability(
-                                                                      sp,
-                                                                      msg,
-                                                                      suggestion,
-                                                                      Applicability::Unspecified,
-                                                                      );
+                                                sp,
+                                                msg,
+                                                suggestion,
+                                                Applicability::Unspecified,
+                                            );
                                         }
                                     } else {
                                         db.span_suggestion_with_applicability(
-                                                                      sp,
-                                                                      msg,
-                                                                      suggestion,
-                                                                      Applicability::Unspecified,
-                                                                      );
+                                            sp,
+                                            msg,
+                                            suggestion,
+                                            Applicability::Unspecified,
+                                        );
                                     }
                                 }
                                 _ => {
@@ -1344,13 +1344,13 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
                                                   capture_span,
                                                   Origin::Ast)
             .span_suggestion_with_applicability(
-                                         err.span,
-                                         &format!("to force the closure to take ownership of {} \
-                                                   (and any other referenced variables), \
-                                                   use the `move` keyword",
-                                                   cmt_path_or_string),
-                                         suggestion,
-                                         Applicability::MachineApplicable,
+                 err.span,
+                 &format!("to force the closure to take ownership of {} \
+                           (and any other referenced variables), \
+                           use the `move` keyword",
+                           cmt_path_or_string),
+                 suggestion,
+                 Applicability::MachineApplicable,
             )
             .emit();
         self.signal_error();

--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -45,7 +45,7 @@ use rustc_data_structures::sync::Lrc;
 use std::hash::{Hash, Hasher};
 use syntax::ast;
 use syntax_pos::{MultiSpan, Span};
-use errors::{Applicability, DiagnosticBuilder, DiagnosticId, Applicability};
+use errors::{Applicability, DiagnosticBuilder, DiagnosticId};
 
 use rustc::hir;
 use rustc::hir::intravisit::{self, Visitor};

--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -868,11 +868,19 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
                                             db.note(fn_closure_msg);
                                         } else {
                                             db.span_suggestion_with_applicability(
-                                                sp, msg, suggestion, Applicability::Unspecified);
+                                                                                  sp,
+                                                                                  msg,
+                                                                                  suggestion,
+                                                                                  Applicability::Unspecified,
+                                                                                  );
                                         }
                                     } else {
                                         db.span_suggestion_with_applicability(
-                                                sp, msg, suggestion, Applicability::Unspecified);
+                                                                              sp,
+                                                                              msg,
+                                                                              suggestion,
+                                                                              Applicability::Unspecified,
+                                                                              );
                                     }
                                 }
                                 _ => {
@@ -1330,13 +1338,14 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
                                                   &cmt_path_or_string,
                                                   capture_span,
                                                   Origin::Ast)
-            .span_suggestion_with_applicability(err.span,
-                             &format!("to force the closure to take ownership of {} \
-                                       (and any other referenced variables), \
-                                       use the `move` keyword",
-                                       cmt_path_or_string),
-                             suggestion,
-                             Applicability::Unspecified,
+            .span_suggestion_with_applicability(
+                                         err.span,
+                                         &format!("to force the closure to take ownership of {} \
+                                                   (and any other referenced variables), \
+                                                   use the `move` keyword",
+                                                   cmt_path_or_string),
+                                         suggestion,
+                                         Applicability::Unspecified,
             )
             .emit();
         self.signal_error();

--- a/src/librustc_errors/diagnostic.rs
+++ b/src/librustc_errors/diagnostic.rs
@@ -232,6 +232,7 @@ impl Diagnostic {
     /// inline it will only show the text message and not the text.
     ///
     /// See `CodeSuggestion` for more information.
+    #[deprecated(note = "Use `span_suggestion_short_with_applicability`")]
     pub fn span_suggestion_short(&mut self, sp: Span, msg: &str, suggestion: String) -> &mut Self {
         self.suggestions.push(CodeSuggestion {
             substitutions: vec![Substitution {
@@ -263,6 +264,7 @@ impl Diagnostic {
     /// * may contain a name of a function, variable or type, but not whole expressions
     ///
     /// See `CodeSuggestion` for more information.
+    #[deprecated(note = "Use `span_suggestion_with_applicability`")]
     pub fn span_suggestion(&mut self, sp: Span, msg: &str, suggestion: String) -> &mut Self {
         self.suggestions.push(CodeSuggestion {
             substitutions: vec![Substitution {
@@ -298,6 +300,7 @@ impl Diagnostic {
         self
     }
 
+    #[deprecated(note = "Use `multipart_suggestion_with_applicability`")]
     pub fn multipart_suggestion(
         &mut self,
         msg: &str,
@@ -311,6 +314,7 @@ impl Diagnostic {
     }
 
     /// Prints out a message with multiple suggested edits of the code.
+    #[deprecated(note = "Use `span_suggestions_with_applicability`")]
     pub fn span_suggestions(&mut self, sp: Span, msg: &str, suggestions: Vec<String>) -> &mut Self {
         self.suggestions.push(CodeSuggestion {
             substitutions: suggestions.into_iter().map(|snippet| Substitution {

--- a/src/librustc_errors/diagnostic.rs
+++ b/src/librustc_errors/diagnostic.rs
@@ -278,10 +278,11 @@ impl Diagnostic {
         self
     }
 
-    pub fn multipart_suggestion(
+    pub fn multipart_suggestion_with_applicability(
         &mut self,
         msg: &str,
         suggestion: Vec<(Span, String)>,
+        applicability: Applicability,
     ) -> &mut Self {
         self.suggestions.push(CodeSuggestion {
             substitutions: vec![Substitution {
@@ -292,9 +293,21 @@ impl Diagnostic {
             }],
             msg: msg.to_owned(),
             show_code_when_inline: true,
-            applicability: Applicability::Unspecified,
+            applicability,
         });
         self
+    }
+
+    pub fn multipart_suggestion(
+        &mut self,
+        msg: &str,
+        suggestion: Vec<(Span, String)>,
+    ) -> &mut Self {
+        self.multipart_suggestion_with_applicability(
+                                                     msg, 
+                                                     suggestion,
+                                                     Applicability::Unspecified
+                                                    )
     }
 
     /// Prints out a message with multiple suggested edits of the code.

--- a/src/librustc_errors/diagnostic.rs
+++ b/src/librustc_errors/diagnostic.rs
@@ -307,9 +307,9 @@ impl Diagnostic {
         suggestion: Vec<(Span, String)>,
     ) -> &mut Self {
         self.multipart_suggestion_with_applicability(
-                                                 msg,
-                                                 suggestion,
-                                                 Applicability::Unspecified,
+            msg,
+            suggestion,
+            Applicability::Unspecified,
         )
     }
 

--- a/src/librustc_errors/diagnostic.rs
+++ b/src/librustc_errors/diagnostic.rs
@@ -307,10 +307,10 @@ impl Diagnostic {
         suggestion: Vec<(Span, String)>,
     ) -> &mut Self {
         self.multipart_suggestion_with_applicability(
-                                                     msg,
-                                                     suggestion,
-                                                     Applicability::Unspecified
-                                                    )
+                                                 msg,
+                                                 suggestion,
+                                                 Applicability::Unspecified,
+        )
     }
 
     /// Prints out a message with multiple suggested edits of the code.

--- a/src/librustc_errors/diagnostic.rs
+++ b/src/librustc_errors/diagnostic.rs
@@ -307,7 +307,7 @@ impl Diagnostic {
         suggestion: Vec<(Span, String)>,
     ) -> &mut Self {
         self.multipart_suggestion_with_applicability(
-                                                     msg, 
+                                                     msg,
                                                      suggestion,
                                                      Applicability::Unspecified
                                                     )

--- a/src/librustc_errors/diagnostic_builder.rs
+++ b/src/librustc_errors/diagnostic_builder.rs
@@ -39,7 +39,7 @@ pub struct DiagnosticBuilder<'a> {
 /// it easy to declare such methods on the builder.
 macro_rules! forward {
     // Forward pattern for &self -> &Self
-    (pub fn $n:ident(&self, $($name:ident: $ty:ty),*) -> &Self) => {
+    (pub fn $n:ident(&self, $($name:ident: $ty:ty,)*) -> &Self) => {
         pub fn $n(&self, $($name: $ty),*) -> &Self {
             #[allow(deprecated)]
             self.diagnostic.$n($($name),*);
@@ -48,7 +48,7 @@ macro_rules! forward {
     };
 
     // Forward pattern for &mut self -> &mut Self
-    (pub fn $n:ident(&mut self, $($name:ident: $ty:ty),*) -> &mut Self) => {
+    (pub fn $n:ident(&mut self, $($name:ident: $ty:ty,)*) -> &mut Self) => {
         pub fn $n(&mut self, $($name: $ty),*) -> &mut Self {
             #[allow(deprecated)]
             self.diagnostic.$n($($name),*);
@@ -58,8 +58,8 @@ macro_rules! forward {
 
     // Forward pattern for &mut self -> &mut Self, with S: Into<MultiSpan>
     // type parameter. No obvious way to make this more generic.
-    (pub fn $n:ident<S: Into<MultiSpan>>(&mut self, $($name:ident: $ty:ty),*) -> &mut Self) => {
-        pub fn $n<S: Into<MultiSpan>>(&mut self, $($name: $ty),*) -> &mut Self {
+    (pub fn $n:ident<S: Into<MultiSpan>>(&mut self, $($name:ident: $ty:ty,)*) -> &mut Self) => {
+        pub fn $n<S: Into<MultiSpan>>(&mut self, $($name: $ty,)*) -> &mut Self {
             #[allow(deprecated)]
             self.diagnostic.$n($($name),*);
             self
@@ -147,64 +147,64 @@ impl<'a> DiagnosticBuilder<'a> {
     forward!(pub fn note_expected_found(&mut self,
                                         label: &dyn fmt::Display,
                                         expected: DiagnosticStyledString,
-                                        found: DiagnosticStyledString)
-                                        -> &mut Self);
+                                        found: DiagnosticStyledString,
+                                        ) -> &mut Self);
 
     forward!(pub fn note_expected_found_extra(&mut self,
                                               label: &dyn fmt::Display,
                                               expected: DiagnosticStyledString,
                                               found: DiagnosticStyledString,
                                               expected_extra: &dyn fmt::Display,
-                                              found_extra: &dyn fmt::Display)
-                                              -> &mut Self);
+                                              found_extra: &dyn fmt::Display,
+                                              ) -> &mut Self);
 
-    forward!(pub fn note(&mut self, msg: &str) -> &mut Self);
+    forward!(pub fn note(&mut self, msg: &str,) -> &mut Self);
     forward!(pub fn span_note<S: Into<MultiSpan>>(&mut self,
                                                   sp: S,
-                                                  msg: &str)
-                                                  -> &mut Self);
-    forward!(pub fn warn(&mut self, msg: &str) -> &mut Self);
-    forward!(pub fn span_warn<S: Into<MultiSpan>>(&mut self, sp: S, msg: &str) -> &mut Self);
-    forward!(pub fn help(&mut self , msg: &str) -> &mut Self);
+                                                  msg: &str,
+                                                  ) -> &mut Self);
+    forward!(pub fn warn(&mut self, msg: &str,) -> &mut Self);
+    forward!(pub fn span_warn<S: Into<MultiSpan>>(&mut self, sp: S, msg: &str,) -> &mut Self);
+    forward!(pub fn help(&mut self , msg: &str,) -> &mut Self);
     forward!(pub fn span_help<S: Into<MultiSpan>>(&mut self,
                                                   sp: S,
-                                                  msg: &str)
-                                                  -> &mut Self);
+                                                  msg: &str,
+                                                  ) -> &mut Self);
 
     #[deprecated(note = "Use `span_suggestion_short_with_applicability`")]
     forward!(pub fn span_suggestion_short(
                                       &mut self,
                                       sp: Span,
                                       msg: &str,
-                                          suggestion: String)
-                                          -> &mut Self);
+                                      suggestion: String,
+                                      ) -> &mut Self);
 
     #[deprecated(note = "Use `multipart_suggestion_with_applicability`")]
     forward!(pub fn multipart_suggestion(
         &mut self,
         msg: &str,
-        suggestion: Vec<(Span, String)>
+        suggestion: Vec<(Span, String)>,
     ) -> &mut Self);
 
     #[deprecated(note = "Use `span_suggestion_with_applicability`")]
     forward!(pub fn span_suggestion(&mut self,
                                     sp: Span,
                                     msg: &str,
-                                    suggestion: String)
-                                    -> &mut Self);
+                                    suggestion: String,
+                                    ) -> &mut Self);
 
     #[deprecated(note = "Use `span_suggestions_with_applicability`")]
     forward!(pub fn span_suggestions(&mut self,
                                      sp: Span,
                                      msg: &str,
-                                     suggestions: Vec<String>)
-                                     -> &mut Self);
+                                     suggestions: Vec<String>,
+                                     ) -> &mut Self);
 
     pub fn multipart_suggestion_with_applicability(&mut self,
                                               msg: &str,
                                               suggestion: Vec<(Span, String)>,
-                                              applicability: Applicability)
-                                              -> &mut Self {
+                                              applicability: Applicability,
+                                              ) -> &mut Self {
         if !self.allow_suggestions {
             return self
         }
@@ -269,8 +269,8 @@ impl<'a> DiagnosticBuilder<'a> {
         );
         self
     }
-    forward!(pub fn set_span<S: Into<MultiSpan>>(&mut self, sp: S) -> &mut Self);
-    forward!(pub fn code(&mut self, s: DiagnosticId) -> &mut Self);
+    forward!(pub fn set_span<S: Into<MultiSpan>>(&mut self, sp: S,) -> &mut Self);
+    forward!(pub fn code(&mut self, s: DiagnosticId,) -> &mut Self);
 
     pub fn allow_suggestions(&mut self, allow: bool) -> &mut Self {
         self.allow_suggestions = allow;

--- a/src/librustc_errors/diagnostic_builder.rs
+++ b/src/librustc_errors/diagnostic_builder.rs
@@ -41,6 +41,7 @@ macro_rules! forward {
     // Forward pattern for &self -> &Self
     (pub fn $n:ident(&self, $($name:ident: $ty:ty),*) -> &Self) => {
         pub fn $n(&self, $($name: $ty),*) -> &Self {
+            #[allow(deprecated)]
             self.diagnostic.$n($($name),*);
             self
         }
@@ -49,6 +50,7 @@ macro_rules! forward {
     // Forward pattern for &mut self -> &mut Self
     (pub fn $n:ident(&mut self, $($name:ident: $ty:ty),*) -> &mut Self) => {
         pub fn $n(&mut self, $($name: $ty),*) -> &mut Self {
+            #[allow(deprecated)]
             self.diagnostic.$n($($name),*);
             self
         }
@@ -58,6 +60,7 @@ macro_rules! forward {
     // type parameter. No obvious way to make this more generic.
     (pub fn $n:ident<S: Into<MultiSpan>>(&mut self, $($name:ident: $ty:ty),*) -> &mut Self) => {
         pub fn $n<S: Into<MultiSpan>>(&mut self, $($name: $ty),*) -> &mut Self {
+            #[allow(deprecated)]
             self.diagnostic.$n($($name),*);
             self
         }
@@ -167,21 +170,29 @@ impl<'a> DiagnosticBuilder<'a> {
                                                   sp: S,
                                                   msg: &str)
                                                   -> &mut Self);
+
+    #[deprecated(note = "Use `span_suggestion_short_with_applicability`")]
     forward!(pub fn span_suggestion_short(&mut self,
                                           sp: Span,
                                           msg: &str,
                                           suggestion: String)
                                           -> &mut Self);
+
+    #[deprecated(note = "Use `multipart_suggestion_with_applicability`")]
     forward!(pub fn multipart_suggestion(
         &mut self,
         msg: &str,
         suggestion: Vec<(Span, String)>
     ) -> &mut Self);
+
+    #[deprecated(note = "Use `span_suggestion_with_applicability`")]
     forward!(pub fn span_suggestion(&mut self,
                                     sp: Span,
                                     msg: &str,
                                     suggestion: String)
                                     -> &mut Self);
+
+    #[deprecated(note = "Use `span_suggestions_with_applicability`")]
     forward!(pub fn span_suggestions(&mut self,
                                      sp: Span,
                                      msg: &str,

--- a/src/librustc_errors/diagnostic_builder.rs
+++ b/src/librustc_errors/diagnostic_builder.rs
@@ -39,7 +39,7 @@ pub struct DiagnosticBuilder<'a> {
 /// it easy to declare such methods on the builder.
 macro_rules! forward {
     // Forward pattern for &self -> &Self
-    (pub fn $n:ident(&self, $($name:ident: $ty:ty,)*) -> &Self) => {
+    (pub fn $n:ident(&self, $($name:ident: $ty:ty),* $(,)*) -> &Self) => {
         pub fn $n(&self, $($name: $ty),*) -> &Self {
             #[allow(deprecated)]
             self.diagnostic.$n($($name),*);
@@ -48,7 +48,7 @@ macro_rules! forward {
     };
 
     // Forward pattern for &mut self -> &mut Self
-    (pub fn $n:ident(&mut self, $($name:ident: $ty:ty,)*) -> &mut Self) => {
+    (pub fn $n:ident(&mut self, $($name:ident: $ty:ty),* $(,)*) -> &mut Self) => {
         pub fn $n(&mut self, $($name: $ty),*) -> &mut Self {
             #[allow(deprecated)]
             self.diagnostic.$n($($name),*);
@@ -58,8 +58,11 @@ macro_rules! forward {
 
     // Forward pattern for &mut self -> &mut Self, with S: Into<MultiSpan>
     // type parameter. No obvious way to make this more generic.
-    (pub fn $n:ident<S: Into<MultiSpan>>(&mut self, $($name:ident: $ty:ty,)*) -> &mut Self) => {
-        pub fn $n<S: Into<MultiSpan>>(&mut self, $($name: $ty,)*) -> &mut Self {
+    (pub fn $n:ident<S: Into<MultiSpan>>(
+                    &mut self,
+                    $($name:ident: $ty:ty),*
+                    $(,)*) -> &mut Self) => {
+        pub fn $n<S: Into<MultiSpan>>(&mut self, $($name: $ty),*) -> &mut Self {
             #[allow(deprecated)]
             self.diagnostic.$n($($name),*);
             self
@@ -158,14 +161,14 @@ impl<'a> DiagnosticBuilder<'a> {
                                               found_extra: &dyn fmt::Display,
                                               ) -> &mut Self);
 
-    forward!(pub fn note(&mut self, msg: &str,) -> &mut Self);
+    forward!(pub fn note(&mut self, msg: &str) -> &mut Self);
     forward!(pub fn span_note<S: Into<MultiSpan>>(&mut self,
                                                   sp: S,
                                                   msg: &str,
                                                   ) -> &mut Self);
-    forward!(pub fn warn(&mut self, msg: &str,) -> &mut Self);
-    forward!(pub fn span_warn<S: Into<MultiSpan>>(&mut self, sp: S, msg: &str,) -> &mut Self);
-    forward!(pub fn help(&mut self , msg: &str,) -> &mut Self);
+    forward!(pub fn warn(&mut self, msg: &str) -> &mut Self);
+    forward!(pub fn span_warn<S: Into<MultiSpan>>(&mut self, sp: S, msg: &str) -> &mut Self);
+    forward!(pub fn help(&mut self , msg: &str) -> &mut Self);
     forward!(pub fn span_help<S: Into<MultiSpan>>(&mut self,
                                                   sp: S,
                                                   msg: &str,
@@ -269,8 +272,8 @@ impl<'a> DiagnosticBuilder<'a> {
         );
         self
     }
-    forward!(pub fn set_span<S: Into<MultiSpan>>(&mut self, sp: S,) -> &mut Self);
-    forward!(pub fn code(&mut self, s: DiagnosticId,) -> &mut Self);
+    forward!(pub fn set_span<S: Into<MultiSpan>>(&mut self, sp: S) -> &mut Self);
+    forward!(pub fn code(&mut self, s: DiagnosticId) -> &mut Self);
 
     pub fn allow_suggestions(&mut self, allow: bool) -> &mut Self {
         self.allow_suggestions = allow;

--- a/src/librustc_errors/diagnostic_builder.rs
+++ b/src/librustc_errors/diagnostic_builder.rs
@@ -187,6 +187,23 @@ impl<'a> DiagnosticBuilder<'a> {
                                      msg: &str,
                                      suggestions: Vec<String>)
                                      -> &mut Self);
+
+    pub fn multipart_suggestion_with_applicability(&mut self,
+                                              msg: &str,
+                                              suggestion: Vec<(Span, String)>,
+                                              applicability: Applicability)
+                                              -> &mut Self {
+        if !self.allow_suggestions {
+            return self
+        }
+        self.diagnostic.multipart_suggestion_with_applicability(
+            msg,
+            suggestion,
+            applicability,
+        );
+        self
+    }
+
     pub fn span_suggestion_with_applicability(&mut self,
                                               sp: Span,
                                               msg: &str,

--- a/src/librustc_errors/diagnostic_builder.rs
+++ b/src/librustc_errors/diagnostic_builder.rs
@@ -172,9 +172,10 @@ impl<'a> DiagnosticBuilder<'a> {
                                                   -> &mut Self);
 
     #[deprecated(note = "Use `span_suggestion_short_with_applicability`")]
-    forward!(pub fn span_suggestion_short(&mut self,
-                                          sp: Span,
-                                          msg: &str,
+    forward!(pub fn span_suggestion_short(
+                                      &mut self,
+                                      sp: Span,
+                                      msg: &str,
                                           suggestion: String)
                                           -> &mut Self);
 

--- a/src/librustc_mir/borrow_check/move_errors.rs
+++ b/src/librustc_mir/borrow_check/move_errors.rs
@@ -426,7 +426,7 @@ impl<'a, 'gcx, 'tcx> MirBorrowckCtxt<'a, 'gcx, 'tcx> {
                 span,
                 &format!("consider removing the `{}`", to_remove),
                 suggestion,
-                Applicability::Unspecified,
+                Applicability::MachineApplicable,
             );
         }
     }

--- a/src/librustc_mir/borrow_check/move_errors.rs
+++ b/src/librustc_mir/borrow_check/move_errors.rs
@@ -11,7 +11,7 @@
 use core::unicode::property::Pattern_White_Space;
 use rustc::mir::*;
 use rustc::ty;
-use rustc_errors::DiagnosticBuilder;
+use rustc_errors::{DiagnosticBuilder,Applicability};
 use syntax_pos::Span;
 
 use borrow_check::MirBorrowckCtxt;
@@ -350,16 +350,18 @@ impl<'a, 'gcx, 'tcx> MirBorrowckCtxt<'a, 'gcx, 'tcx> {
                     // expressions `a[b]`, which roughly desugar to
                     // `*Index::index(&a, b)` or
                     // `*IndexMut::index_mut(&mut a, b)`.
-                    err.span_suggestion(
+                    err.span_suggestion_with_applicability(
                         span,
                         "consider removing the `*`",
                         snippet[1..].to_owned(),
+                        Applicability::Unspecified,
                     );
                 } else {
-                    err.span_suggestion(
+                    err.span_suggestion_with_applicability(
                         span,
                         "consider borrowing here",
                         format!("&{}", snippet),
+                        Applicability::Unspecified,
                     );
                 }
 
@@ -420,10 +422,11 @@ impl<'a, 'gcx, 'tcx> MirBorrowckCtxt<'a, 'gcx, 'tcx> {
         suggestions.sort_unstable_by_key(|&(span, _, _)| span);
         suggestions.dedup_by_key(|&mut (span, _, _)| span);
         for (span, to_remove, suggestion) in suggestions {
-            err.span_suggestion(
+            err.span_suggestion_with_applicability(
                 span,
                 &format!("consider removing the `{}`", to_remove),
-                suggestion
+                suggestion,
+                Applicability::Unspecified,
             );
         }
     }

--- a/src/librustc_mir/borrow_check/mutability_errors.rs
+++ b/src/librustc_mir/borrow_check/mutability_errors.rs
@@ -232,7 +232,7 @@ impl<'a, 'gcx, 'tcx> MirBorrowckCtxt<'a, 'gcx, 'tcx> {
                     local_decl.source_info.span,
                     "consider changing this to be mutable",
                     format!("mut {}", local_decl.name.unwrap()),
-                    Applicability::Unspecified,
+                    Applicability::MachineApplicable,
                 );
             }
 
@@ -263,7 +263,7 @@ impl<'a, 'gcx, 'tcx> MirBorrowckCtxt<'a, 'gcx, 'tcx> {
                             upvar_ident.span,
                             "consider changing this to be mutable",
                             format!("mut {}", upvar_ident.name),
-                            Applicability::Unspecified,
+                            Applicability::MachineApplicable,
                         );
                     }
                 }
@@ -358,7 +358,7 @@ impl<'a, 'gcx, 'tcx> MirBorrowckCtxt<'a, 'gcx, 'tcx> {
                         err_help_span,
                         &format!("consider changing this to be a mutable {}", pointer_desc),
                         suggested_code,
-                        Applicability::Unspecified,
+                        Applicability::MachineApplicable,
                     );
                 }
 

--- a/src/librustc_mir/borrow_check/mutability_errors.rs
+++ b/src/librustc_mir/borrow_check/mutability_errors.rs
@@ -22,6 +22,7 @@ use borrow_check::MirBorrowckCtxt;
 use util::borrowck_errors::{BorrowckErrors, Origin};
 use util::collect_writes::FindAssignments;
 use util::suggest_ref_mut;
+use rustc_errors::Applicability;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub(super) enum AccessKind {
@@ -227,10 +228,11 @@ impl<'a, 'gcx, 'tcx> MirBorrowckCtxt<'a, 'gcx, 'tcx> {
                 assert_eq!(local_decl.mutability, Mutability::Not);
 
                 err.span_label(span, format!("cannot {ACT}", ACT = act));
-                err.span_suggestion(
+                err.span_suggestion_with_applicability(
                     local_decl.source_info.span,
                     "consider changing this to be mutable",
                     format!("mut {}", local_decl.name.unwrap()),
+                    Applicability::Unspecified,
                 );
             }
 
@@ -257,10 +259,11 @@ impl<'a, 'gcx, 'tcx> MirBorrowckCtxt<'a, 'gcx, 'tcx> {
                         _,
                     ) = pat.node
                     {
-                        err.span_suggestion(
+                        err.span_suggestion_with_applicability(
                             upvar_ident.span,
                             "consider changing this to be mutable",
                             format!("mut {}", upvar_ident.name),
+                            Applicability::Unspecified,
                         );
                     }
                 }
@@ -351,10 +354,11 @@ impl<'a, 'gcx, 'tcx> MirBorrowckCtxt<'a, 'gcx, 'tcx> {
                 };
 
                 if let Some((err_help_span, suggested_code)) = suggestion {
-                    err.span_suggestion(
+                    err.span_suggestion_with_applicability(
                         err_help_span,
                         &format!("consider changing this to be a mutable {}", pointer_desc),
                         suggested_code,
+                        Applicability::Unspecified,
                     );
                 }
 

--- a/src/librustc_passes/ast_validation.rs
+++ b/src/librustc_passes/ast_validation.rs
@@ -182,8 +182,9 @@ impl<'a> AstValidator<'a> {
             );
 
             if let Ok(snippet) = self.session.source_map().span_to_snippet(span) {
-                err.span_suggestion(
+                err.span_suggestion_with_applicability(
                     span, "consider adding parentheses", format!("({})", snippet),
+                    Applicability::Unspecified,
                 );
             }
 

--- a/src/librustc_passes/ast_validation.rs
+++ b/src/librustc_passes/ast_validation.rs
@@ -184,7 +184,7 @@ impl<'a> AstValidator<'a> {
             if let Ok(snippet) = self.session.source_map().span_to_snippet(span) {
                 err.span_suggestion_with_applicability(
                     span, "consider adding parentheses", format!("({})", snippet),
-                    Applicability::Unspecified,
+                    Applicability::MachineApplicable,
                 );
             }
 

--- a/src/librustc_passes/loops.rs
+++ b/src/librustc_passes/loops.rs
@@ -141,7 +141,8 @@ impl<'a, 'hir> Visitor<'hir> for CheckLoopVisitor<'a, 'hir> {
                                 .span_label(e.span,
                                             "can only break with a value inside \
                                             `loop` or breakable block")
-                                .span_suggestion_with_applicability(e.span,
+                                .span_suggestion_with_applicability(
+                                                 e.span,
                                                  &format!("instead, use `break` on its own \
                                                            without a value inside this `{}` loop",
                                                           kind.name()),

--- a/src/librustc_passes/loops.rs
+++ b/src/librustc_passes/loops.rs
@@ -142,12 +142,14 @@ impl<'a, 'hir> Visitor<'hir> for CheckLoopVisitor<'a, 'hir> {
                                             "can only break with a value inside \
                                             `loop` or breakable block")
                                 .span_suggestion_with_applicability(
-                                                 e.span,
-                                                 &format!("instead, use `break` on its own \
-                                                           without a value inside this `{}` loop",
-                                                          kind.name()),
-                                                 "break".to_string(),
-                                                 Applicability::MaybeIncorrect,
+                                    e.span,
+                                    &format!(
+                                        "instead, use `break` on its own \
+                                        without a value inside this `{}` loop",
+                                        kind.name()
+                                    ),
+                                    "break".to_string(),
+                                    Applicability::MaybeIncorrect,
                                 )
                                 .emit();
                         }

--- a/src/librustc_passes/loops.rs
+++ b/src/librustc_passes/loops.rs
@@ -16,6 +16,7 @@ use rustc::hir::intravisit::{self, Visitor, NestedVisitorMap};
 use rustc::hir::{self, Node, Destination};
 use syntax::ast;
 use syntax_pos::Span;
+use errors::Applicability;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 enum LoopKind {
@@ -140,11 +141,13 @@ impl<'a, 'hir> Visitor<'hir> for CheckLoopVisitor<'a, 'hir> {
                                 .span_label(e.span,
                                             "can only break with a value inside \
                                             `loop` or breakable block")
-                                .span_suggestion(e.span,
+                                .span_suggestion_with_applicability(e.span,
                                                  &format!("instead, use `break` on its own \
                                                            without a value inside this `{}` loop",
                                                           kind.name()),
-                                                 "break".to_string())
+                                                 "break".to_string(),
+                                                 Applicability::Unspecified,
+                                )
                                 .emit();
                         }
                     }

--- a/src/librustc_passes/loops.rs
+++ b/src/librustc_passes/loops.rs
@@ -147,7 +147,7 @@ impl<'a, 'hir> Visitor<'hir> for CheckLoopVisitor<'a, 'hir> {
                                                            without a value inside this `{}` loop",
                                                           kind.name()),
                                                  "break".to_string(),
-                                                 Applicability::Unspecified,
+                                                 Applicability::MaybeIncorrect,
                                 )
                                 .emit();
                         }

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -3303,7 +3303,7 @@ impl<'a, 'crateloader: 'a> Resolver<'a, 'crateloader> {
                                                       sp,
                                                       "did you mean to use `;` here instead?",
                                                       ";".to_string(),
-                                                      Applicability::Unspecified,
+                                                      Applicability::MaybeIncorrect,
                                                       );
                         }
                         break;

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -3299,7 +3299,8 @@ impl<'a, 'crateloader: 'a> Resolver<'a, 'crateloader> {
                         err.span_label(base_span,
                                        "expecting a type here because of type ascription");
                         if line_sp != line_base_sp {
-                            err.span_suggestion_short_with_applicability(sp,
+                            err.span_suggestion_short_with_applicability(
+                                                      sp,
                                                       "did you mean to use `;` here instead?",
                                                       ";".to_string(),
                                                       Applicability::Unspecified,

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -3300,11 +3300,11 @@ impl<'a, 'crateloader: 'a> Resolver<'a, 'crateloader> {
                                        "expecting a type here because of type ascription");
                         if line_sp != line_base_sp {
                             err.span_suggestion_short_with_applicability(
-                                                      sp,
-                                                      "did you mean to use `;` here instead?",
-                                                      ";".to_string(),
-                                                      Applicability::MaybeIncorrect,
-                                                      );
+                                sp,
+                                "did you mean to use `;` here instead?",
+                                ";".to_string(),
+                                Applicability::MaybeIncorrect,
+                            );
                         }
                         break;
                     } else if snippet.trim().len() != 0  {
@@ -4829,8 +4829,12 @@ fn show_candidates(err: &mut DiagnosticBuilder,
             *candidate = format!("use {};\n{}", candidate, additional_newline);
         }
 
-        err.span_suggestions_with_applicability(span, &msg, path_strings,
-                                                Applicability::Unspecified);
+        err.span_suggestions_with_applicability(
+            span,
+            &msg,
+            path_strings,
+            Applicability::Unspecified,
+        );
     } else {
         let mut msg = msg;
         msg.push(':');

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -3299,9 +3299,11 @@ impl<'a, 'crateloader: 'a> Resolver<'a, 'crateloader> {
                         err.span_label(base_span,
                                        "expecting a type here because of type ascription");
                         if line_sp != line_base_sp {
-                            err.span_suggestion_short(sp,
+                            err.span_suggestion_short_with_applicability(sp,
                                                       "did you mean to use `;` here instead?",
-                                                      ";".to_string());
+                                                      ";".to_string(),
+                                                      Applicability::Unspecified,
+                                                      );
                         }
                         break;
                     } else if snippet.trim().len() != 0  {
@@ -4826,7 +4828,8 @@ fn show_candidates(err: &mut DiagnosticBuilder,
             *candidate = format!("use {};\n{}", candidate, additional_newline);
         }
 
-        err.span_suggestions(span, &msg, path_strings);
+        err.span_suggestions_with_applicability(span, &msg, path_strings,
+                                                Applicability::Unspecified);
     } else {
         let mut msg = msg;
         msg.push(':');

--- a/src/librustc_typeck/check/cast.rs
+++ b/src/librustc_typeck/check/cast.rs
@@ -299,11 +299,12 @@ impl<'a, 'gcx, 'tcx> CastCheck<'tcx> {
                 err.note("The type information given here is insufficient to check whether \
                           the pointer cast is valid");
                 if unknown_cast_to {
-                    err.span_suggestion_short_with_applicability(self.cast_span,
-                                              "consider giving more type information",
-                                              String::new(),
-                                              Applicability::Unspecified,
-                                              );
+                    err.span_suggestion_short_with_applicability(
+                        self.cast_span,
+                        "consider giving more type information",
+                        String::new(),
+                        Applicability::Unspecified,
+                    );
                 }
                 err.emit();
             }
@@ -329,11 +330,12 @@ impl<'a, 'gcx, 'tcx> CastCheck<'tcx> {
                 if self.cast_ty.is_trait() {
                     match fcx.tcx.sess.source_map().span_to_snippet(self.cast_span) {
                         Ok(s) => {
-                            err.span_suggestion_with_applicability(self.cast_span,
-                                                "try casting to a reference instead",
-                                                format!("&{}{}", mtstr, s),
-                                                Applicability::MachineApplicable,
-                                                );
+                            err.span_suggestion_with_applicability(
+                                self.cast_span,
+                                "try casting to a reference instead",
+                                format!("&{}{}", mtstr, s),
+                                Applicability::MachineApplicable,
+                            );
                         }
                         Err(_) => {
                             span_help!(err, self.cast_span, "did you mean `&{}{}`?", mtstr, tstr)
@@ -350,11 +352,12 @@ impl<'a, 'gcx, 'tcx> CastCheck<'tcx> {
             ty::Adt(def, ..) if def.is_box() => {
                 match fcx.tcx.sess.source_map().span_to_snippet(self.cast_span) {
                     Ok(s) => {
-                        err.span_suggestion_with_applicability(self.cast_span,
-                                            "try casting to a `Box` instead",
-                                            format!("Box<{}>", s),
-                                            Applicability::MachineApplicable,
-                                            );
+                        err.span_suggestion_with_applicability(
+                            self.cast_span,
+                            "try casting to a `Box` instead",
+                            format!("Box<{}>", s),
+                            Applicability::MachineApplicable,
+                        );
                     }
                     Err(_) => span_help!(err, self.cast_span, "did you mean `Box<{}>`?", tstr),
                 }

--- a/src/librustc_typeck/check/cast.rs
+++ b/src/librustc_typeck/check/cast.rs
@@ -332,7 +332,7 @@ impl<'a, 'gcx, 'tcx> CastCheck<'tcx> {
                             err.span_suggestion_with_applicability(self.cast_span,
                                                 "try casting to a reference instead",
                                                 format!("&{}{}", mtstr, s),
-                                                Applicability::Unspecified,
+                                                Applicability::MachineApplicable,
                                                 );
                         }
                         Err(_) => {
@@ -353,7 +353,7 @@ impl<'a, 'gcx, 'tcx> CastCheck<'tcx> {
                         err.span_suggestion_with_applicability(self.cast_span,
                                             "try casting to a `Box` instead",
                                             format!("Box<{}>", s),
-                                            Applicability::Unspecified,
+                                            Applicability::MachineApplicable,
                                             );
                     }
                     Err(_) => span_help!(err, self.cast_span, "did you mean `Box<{}>`?", tstr),

--- a/src/librustc_typeck/check/cast.rs
+++ b/src/librustc_typeck/check/cast.rs
@@ -40,7 +40,7 @@
 
 use super::FnCtxt;
 
-use errors::DiagnosticBuilder;
+use errors::{DiagnosticBuilder,Applicability};
 use hir::def_id::DefId;
 use lint;
 use rustc::hir;
@@ -299,9 +299,11 @@ impl<'a, 'gcx, 'tcx> CastCheck<'tcx> {
                 err.note("The type information given here is insufficient to check whether \
                           the pointer cast is valid");
                 if unknown_cast_to {
-                    err.span_suggestion_short(self.cast_span,
+                    err.span_suggestion_short_with_applicability(self.cast_span,
                                               "consider giving more type information",
-                                              String::new());
+                                              String::new(),
+                                              Applicability::Unspecified,
+                                              );
                 }
                 err.emit();
             }
@@ -327,9 +329,11 @@ impl<'a, 'gcx, 'tcx> CastCheck<'tcx> {
                 if self.cast_ty.is_trait() {
                     match fcx.tcx.sess.source_map().span_to_snippet(self.cast_span) {
                         Ok(s) => {
-                            err.span_suggestion(self.cast_span,
+                            err.span_suggestion_with_applicability(self.cast_span,
                                                 "try casting to a reference instead",
-                                                format!("&{}{}", mtstr, s));
+                                                format!("&{}{}", mtstr, s),
+                                                Applicability::Unspecified,
+                                                );
                         }
                         Err(_) => {
                             span_help!(err, self.cast_span, "did you mean `&{}{}`?", mtstr, tstr)
@@ -346,9 +350,11 @@ impl<'a, 'gcx, 'tcx> CastCheck<'tcx> {
             ty::Adt(def, ..) if def.is_box() => {
                 match fcx.tcx.sess.source_map().span_to_snippet(self.cast_span) {
                     Ok(s) => {
-                        err.span_suggestion(self.cast_span,
+                        err.span_suggestion_with_applicability(self.cast_span,
                                             "try casting to a `Box` instead",
-                                            format!("Box<{}>", s));
+                                            format!("Box<{}>", s),
+                                            Applicability::Unspecified,
+                                            );
                     }
                     Err(_) => span_help!(err, self.cast_span, "did you mean `Box<{}>`?", tstr),
                 }

--- a/src/librustc_typeck/check/compare_method.rs
+++ b/src/librustc_typeck/check/compare_method.rs
@@ -801,7 +801,7 @@ fn compare_synthetic_generics<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                             .span_to_snippet(trait_m.generics.span)
                             .ok()?;
 
-                        err.multipart_suggestion(
+                        err.multipart_suggestion_with_applicability(
                             "try changing the `impl Trait` argument to a generic parameter",
                             vec![
                                 // replace `impl Trait` with `T`
@@ -811,6 +811,7 @@ fn compare_synthetic_generics<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                 // of the generics, but it works for the common case
                                 (generics_span, new_generics),
                             ],
+                            Applicability::Unspecified,
                         );
                         Some(())
                     })();
@@ -872,7 +873,7 @@ fn compare_synthetic_generics<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                             .span_to_snippet(bounds)
                             .ok()?;
 
-                        err.multipart_suggestion(
+                        err.multipart_suggestion_with_applicability(
                             "try removing the generic parameter and using `impl Trait` instead",
                             vec![
                                 // delete generic parameters
@@ -880,6 +881,7 @@ fn compare_synthetic_generics<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                 // replace param usage with `impl Trait`
                                 (span, format!("impl {}", bounds)),
                             ],
+                            Applicability::Unspecified,
                         );
                         Some(())
                     })();

--- a/src/librustc_typeck/check/compare_method.rs
+++ b/src/librustc_typeck/check/compare_method.rs
@@ -16,6 +16,7 @@ use rustc::traits::{self, ObligationCause, ObligationCauseCode, Reveal};
 use rustc::ty::error::{ExpectedFound, TypeError};
 use rustc::ty::subst::{Subst, Substs};
 use rustc::util::common::ErrorReported;
+use errors::Applicability;
 
 use syntax_pos::Span;
 
@@ -321,10 +322,11 @@ fn compare_predicate_entailment<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                 if let Some(trait_err_span) = trait_err_span {
                     if let Ok(trait_err_str) = tcx.sess.source_map().
                                                span_to_snippet(trait_err_span) {
-                        diag.span_suggestion(
+                        diag.span_suggestion_with_applicability(
                             impl_err_span,
                             "consider change the type to match the mutability in trait",
                             format!("{}", trait_err_str),
+                            Applicability::Unspecified,
                         );
                     }
                 }

--- a/src/librustc_typeck/check/compare_method.rs
+++ b/src/librustc_typeck/check/compare_method.rs
@@ -326,7 +326,7 @@ fn compare_predicate_entailment<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                             impl_err_span,
                             "consider change the type to match the mutability in trait",
                             format!("{}", trait_err_str),
-                            Applicability::Unspecified,
+                            Applicability::MachineApplicable,
                         );
                     }
                 }
@@ -811,7 +811,7 @@ fn compare_synthetic_generics<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                 // of the generics, but it works for the common case
                                 (generics_span, new_generics),
                             ],
-                            Applicability::Unspecified,
+                            Applicability::MaybeIncorrect,
                         );
                         Some(())
                     })();
@@ -881,7 +881,7 @@ fn compare_synthetic_generics<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                 // replace param usage with `impl Trait`
                                 (span, format!("impl {}", bounds)),
                             ],
-                            Applicability::Unspecified,
+                            Applicability::MaybeIncorrect,
                         );
                         Some(())
                     })();

--- a/src/librustc_typeck/check/demand.rs
+++ b/src/librustc_typeck/check/demand.rs
@@ -135,7 +135,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 err.span_suggestions_with_applicability(expr.span,
                                      "try using a variant of the expected type",
                                      suggestions,
-                                     Applicability::Unspecified,
+                                     Applicability::MaybeIncorrect,
                                      );
             }
         }

--- a/src/librustc_typeck/check/demand.rs
+++ b/src/librustc_typeck/check/demand.rs
@@ -132,9 +132,11 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 let expr_text = print::to_string(print::NO_ANN, |s| s.print_expr(expr));
                 let suggestions = compatible_variants.iter()
                     .map(|v| format!("{}({})", v, expr_text)).collect::<Vec<_>>();
-                err.span_suggestions(expr.span,
+                err.span_suggestions_with_applicability(expr.span,
                                      "try using a variant of the expected type",
-                                     suggestions);
+                                     suggestions,
+                                     Applicability::Unspecified,
+                                     );
             }
         }
 

--- a/src/librustc_typeck/check/demand.rs
+++ b/src/librustc_typeck/check/demand.rs
@@ -132,11 +132,12 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 let expr_text = print::to_string(print::NO_ANN, |s| s.print_expr(expr));
                 let suggestions = compatible_variants.iter()
                     .map(|v| format!("{}({})", v, expr_text)).collect::<Vec<_>>();
-                err.span_suggestions_with_applicability(expr.span,
-                                     "try using a variant of the expected type",
-                                     suggestions,
-                                     Applicability::MaybeIncorrect,
-                                     );
+                err.span_suggestions_with_applicability(
+                                                 expr.span,
+                                                 "try using a variant of the expected type",
+                                                 suggestions,
+                                                 Applicability::MaybeIncorrect,
+                );
             }
         }
 

--- a/src/librustc_typeck/check/demand.rs
+++ b/src/librustc_typeck/check/demand.rs
@@ -133,10 +133,10 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 let suggestions = compatible_variants.iter()
                     .map(|v| format!("{}({})", v, expr_text)).collect::<Vec<_>>();
                 err.span_suggestions_with_applicability(
-                                                 expr.span,
-                                                 "try using a variant of the expected type",
-                                                 suggestions,
-                                                 Applicability::MaybeIncorrect,
+                     expr.span,
+                     "try using a variant of the expected type",
+                     suggestions,
+                     Applicability::MaybeIncorrect,
                 );
             }
         }

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -1064,7 +1064,8 @@ impl<'a, 'gcx, 'tcx> ProbeContext<'a, 'gcx, 'tcx> {
             "a method with this name may be added to the standard library in the future",
         );
 
-        // FIXME: This should be a `span_suggestion` instead of `help`. However `self.span` only
+        // FIXME: This should be a `span_suggestion_with_applicability` instead of `help`
+        // However `self.span` only
         // highlights the method name, so we can't use it. Also consider reusing the code from
         // `report_method_error()`.
         diag.help(&format!(

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -258,7 +258,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                                     format!("{}_{}",
                                                             snippet,
                                                             concrete_type),
-                                                    Applicability::Unspecified,
+                                                    Applicability::MaybeIncorrect,
                                                     );
                             }
                             hir::ExprKind::Path(ref qpath) => {  // local binding
@@ -290,7 +290,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                                         .unwrap_or(span)),
                                                     &msg,
                                                     format!("{}: {}", snippet, concrete_type),
-                                                    Applicability::Unspecified,
+                                                    Applicability::MaybeIncorrect,
                                                 );
                                             }
                                             _ => {
@@ -519,8 +519,12 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 format!("use {};\n{}", self.tcx.item_path_str(*did), additional_newline)
             }).collect();
 
-            err.span_suggestions_with_applicability(span, &msg, path_strings,
-                                                    Applicability::Unspecified);
+            err.span_suggestions_with_applicability(
+                                                    span,
+                                                    &msg,
+                                                    path_strings,
+                                                    Applicability::MaybeIncorrect,
+                                                    );
         } else {
             let limit = if candidates.len() == 5 { 5 } else { 4 };
             for (i, trait_did) in candidates.iter().take(limit).enumerate() {

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -251,7 +251,8 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                 let snippet = tcx.sess.source_map().span_to_snippet(lit.span)
                                     .unwrap_or("<numeric literal>".to_string());
 
-                                err.span_suggestion_with_applicability(lit.span,
+                                err.span_suggestion_with_applicability(
+                                                    lit.span,
                                                     &format!("you must specify a concrete type for \
                                                               this numeric value, like `{}`",
                                                              concrete_type),
@@ -259,7 +260,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                                             snippet,
                                                             concrete_type),
                                                     Applicability::MaybeIncorrect,
-                                                    );
+                                );
                             }
                             hir::ExprKind::Path(ref qpath) => {  // local binding
                                 if let &hir::QPath::Resolved(_, ref path) = &qpath {
@@ -524,7 +525,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                                     &msg,
                                                     path_strings,
                                                     Applicability::MaybeIncorrect,
-                                                    );
+            );
         } else {
             let limit = if candidates.len() == 5 { 5 } else { 4 };
             for (i, trait_did) in candidates.iter().take(limit).enumerate() {

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -251,13 +251,15 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                 let snippet = tcx.sess.source_map().span_to_snippet(lit.span)
                                     .unwrap_or("<numeric literal>".to_string());
 
-                                err.span_suggestion(lit.span,
+                                err.span_suggestion_with_applicability(lit.span,
                                                     &format!("you must specify a concrete type for \
                                                               this numeric value, like `{}`",
                                                              concrete_type),
                                                     format!("{}_{}",
                                                             snippet,
-                                                            concrete_type));
+                                                            concrete_type),
+                                                    Applicability::Unspecified,
+                                                    );
                             }
                             hir::ExprKind::Path(ref qpath) => {  // local binding
                                 if let &hir::QPath::Resolved(_, ref path) = &qpath {
@@ -281,13 +283,14 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                                 ty,
                                                 ..
                                             })) => {
-                                                err.span_suggestion(
+                                                err.span_suggestion_with_applicability(
                                                     // account for `let x: _ = 42;`
                                                     //                  ^^^^
                                                     span.to(ty.as_ref().map(|ty| ty.span)
                                                         .unwrap_or(span)),
                                                     &msg,
                                                     format!("{}: {}", snippet, concrete_type),
+                                                    Applicability::Unspecified,
                                                 );
                                             }
                                             _ => {
@@ -516,7 +519,8 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 format!("use {};\n{}", self.tcx.item_path_str(*did), additional_newline)
             }).collect();
 
-            err.span_suggestions(span, &msg, path_strings);
+            err.span_suggestions_with_applicability(span, &msg, path_strings,
+                                                    Applicability::Unspecified);
         } else {
             let limit = if candidates.len() == 5 { 5 } else { 4 };
             for (i, trait_did) in candidates.iter().take(limit).enumerate() {

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3349,11 +3349,11 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                         let msg = format!("`{}` is a native pointer; try dereferencing it", base);
                         let suggestion = format!("(*{}).{}", base, field);
                         err.span_suggestion_with_applicability(
-                                                               field.span,
-                                                               &msg,
-                                                               suggestion,
-                                                               Applicability::MaybeIncorrect,
-                                                               );
+                            field.span,
+                            &msg,
+                            suggestion,
+                            Applicability::MaybeIncorrect,
+                        );
                     }
                     _ => {}
                 }
@@ -4722,11 +4722,11 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
     ) {
         if let Some((sp, msg, suggestion)) = self.check_ref(expr, found, expected) {
             err.span_suggestion_with_applicability(
-                                                   sp,
-                                                   msg,
-                                                   suggestion,
-                                                   Applicability::MachineApplicable,
-                                                   );
+                sp,
+                msg,
+                suggestion,
+                Applicability::MachineApplicable,
+            );
         } else if !self.check_for_cast(err, expr, found, expected) {
             let methods = self.get_conversion_methods(expr.span, expected, found);
             if let Ok(expr_text) = self.sess().source_map().span_to_snippet(expr.span) {
@@ -4757,11 +4757,11 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                     }) .collect::<Vec<_>>();
                 if !suggestions.is_empty() {
                     err.span_suggestions_with_applicability(
-                                                            expr.span,
-                                                            "try using a conversion method",
-                                                            suggestions,
-                                                            Applicability::MaybeIncorrect,
-                                                            );
+                        expr.span,
+                        "try using a conversion method",
+                        suggestions,
+                        Applicability::MaybeIncorrect,
+                    );
                 }
             }
         }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3348,8 +3348,12 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                         let base = self.tcx.hir.node_to_pretty_string(base.id);
                         let msg = format!("`{}` is a native pointer; try dereferencing it", base);
                         let suggestion = format!("(*{}).{}", base, field);
-                        err.span_suggestion_with_applicability(field.span, &msg, suggestion,
-                                                               Applicability::Unspecified);
+                        err.span_suggestion_with_applicability(
+                                                               field.span,
+                                                               &msg,
+                                                               suggestion,
+                                                               Applicability::MaybeIncorrect,
+                                                               );
                     }
                     _ => {}
                 }
@@ -4717,8 +4721,12 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         found: Ty<'tcx>,
     ) {
         if let Some((sp, msg, suggestion)) = self.check_ref(expr, found, expected) {
-            err.span_suggestion_with_applicability(sp, msg, suggestion,
-                                                   Applicability::Unspecified);
+            err.span_suggestion_with_applicability(
+                                                   sp,
+                                                   msg,
+                                                   suggestion,
+                                                   Applicability::MachineApplicable,
+                                                   );
         } else if !self.check_for_cast(err, expr, found, expected) {
             let methods = self.get_conversion_methods(expr.span, expected, found);
             if let Ok(expr_text) = self.sess().source_map().span_to_snippet(expr.span) {
@@ -4748,10 +4756,11 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                         }
                     }) .collect::<Vec<_>>();
                 if !suggestions.is_empty() {
-                    err.span_suggestions_with_applicability(expr.span,
+                    err.span_suggestions_with_applicability(
+                                                            expr.span,
                                                             "try using a conversion method",
                                                             suggestions,
-                                                            Applicability::Unspecified,
+                                                            Applicability::MaybeIncorrect,
                                                             );
                 }
             }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3348,7 +3348,8 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                         let base = self.tcx.hir.node_to_pretty_string(base.id);
                         let msg = format!("`{}` is a native pointer; try dereferencing it", base);
                         let suggestion = format!("(*{}).{}", base, field);
-                        err.span_suggestion(field.span, &msg, suggestion);
+                        err.span_suggestion_with_applicability(field.span, &msg, suggestion,
+                                                               Applicability::Unspecified);
                     }
                     _ => {}
                 }
@@ -4716,7 +4717,8 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         found: Ty<'tcx>,
     ) {
         if let Some((sp, msg, suggestion)) = self.check_ref(expr, found, expected) {
-            err.span_suggestion(sp, msg, suggestion);
+            err.span_suggestion_with_applicability(sp, msg, suggestion,
+                                                   Applicability::Unspecified);
         } else if !self.check_for_cast(err, expr, found, expected) {
             let methods = self.get_conversion_methods(expr.span, expected, found);
             if let Ok(expr_text) = self.sess().source_map().span_to_snippet(expr.span) {
@@ -4746,7 +4748,11 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                         }
                     }) .collect::<Vec<_>>();
                 if !suggestions.is_empty() {
-                    err.span_suggestions(expr.span, "try using a conversion method", suggestions);
+                    err.span_suggestions_with_applicability(expr.span,
+                                                            "try using a conversion method",
+                                                            suggestions,
+                                                            Applicability::Unspecified,
+                                                            );
                 }
             }
         }

--- a/src/librustc_typeck/check/op.rs
+++ b/src/librustc_typeck/check/op.rs
@@ -464,10 +464,12 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                     is_assign,
                 ) {
                     (Ok(l), Ok(r), false) => {
-                        err.multipart_suggestion(msg, vec![
+                        err.multipart_suggestion_with_applicability(msg, vec![
                             (lhs_expr.span, format!("{}.to_owned()", l)),
                             (rhs_expr.span, format!("&{}", r)),
-                        ]);
+                        ],
+                        Applicability::Unspecified,
+                        );
                     }
                     _ => {
                         err.help(msg);

--- a/src/librustc_typeck/check/op.rs
+++ b/src/librustc_typeck/check/op.rs
@@ -16,7 +16,7 @@ use rustc::ty::{self, Ty, TypeFoldable};
 use rustc::ty::TyKind::{Ref, Adt, Str, Uint, Never, Tuple, Char, Array};
 use rustc::ty::adjustment::{Adjustment, Adjust, AllowTwoPhase, AutoBorrow, AutoBorrowMutability};
 use rustc::infer::type_variable::TypeVariableOrigin;
-use errors;
+use errors::{self,Applicability};
 use syntax_pos::Span;
 use syntax::ast::Ident;
 use rustc::hir;
@@ -444,9 +444,11 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                     err.span_label(expr.span,
                                    "`+` can't be used to concatenate two `&str` strings");
                     match source_map.span_to_snippet(lhs_expr.span) {
-                        Ok(lstring) => err.span_suggestion(lhs_expr.span,
+                        Ok(lstring) => err.span_suggestion_with_applicability(lhs_expr.span,
                                                            msg,
-                                                           format!("{}.to_owned()", lstring)),
+                                                           format!("{}.to_owned()", lstring),
+                                                           Applicability::Unspecified,
+                                                           ),
                         _ => err.help(msg),
                     };
                 }

--- a/src/librustc_typeck/check/op.rs
+++ b/src/librustc_typeck/check/op.rs
@@ -444,10 +444,11 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                     err.span_label(expr.span,
                                    "`+` can't be used to concatenate two `&str` strings");
                     match source_map.span_to_snippet(lhs_expr.span) {
-                        Ok(lstring) => err.span_suggestion_with_applicability(lhs_expr.span,
+                        Ok(lstring) => err.span_suggestion_with_applicability(
+                                                           lhs_expr.span,
                                                            msg,
                                                            format!("{}.to_owned()", lstring),
-                                                           Applicability::Unspecified,
+                                                           Applicability::MachineApplicable,
                                                            ),
                         _ => err.help(msg),
                     };
@@ -464,11 +465,13 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                     is_assign,
                 ) {
                     (Ok(l), Ok(r), false) => {
-                        err.multipart_suggestion_with_applicability(msg, vec![
-                            (lhs_expr.span, format!("{}.to_owned()", l)),
-                            (rhs_expr.span, format!("&{}", r)),
-                        ],
-                        Applicability::Unspecified,
+                        err.multipart_suggestion_with_applicability(
+                                        msg,
+                                        vec![
+                                            (lhs_expr.span, format!("{}.to_owned()", l)),
+                                            (rhs_expr.span, format!("&{}", r)),
+                                        ],
+                                        Applicability::MachineApplicable,
                         );
                     }
                     _ => {

--- a/src/librustc_typeck/check/op.rs
+++ b/src/librustc_typeck/check/op.rs
@@ -449,7 +449,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                                            msg,
                                                            format!("{}.to_owned()", lstring),
                                                            Applicability::MachineApplicable,
-                                                           ),
+                        ),
                         _ => err.help(msg),
                     };
                 }

--- a/src/librustc_typeck/check/op.rs
+++ b/src/librustc_typeck/check/op.rs
@@ -445,10 +445,10 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                    "`+` can't be used to concatenate two `&str` strings");
                     match source_map.span_to_snippet(lhs_expr.span) {
                         Ok(lstring) => err.span_suggestion_with_applicability(
-                                                           lhs_expr.span,
-                                                           msg,
-                                                           format!("{}.to_owned()", lstring),
-                                                           Applicability::MachineApplicable,
+                            lhs_expr.span,
+                            msg,
+                            format!("{}.to_owned()", lstring),
+                            Applicability::MachineApplicable,
                         ),
                         _ => err.help(msg),
                     };
@@ -466,12 +466,12 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 ) {
                     (Ok(l), Ok(r), false) => {
                         err.multipart_suggestion_with_applicability(
-                                        msg,
-                                        vec![
-                                            (lhs_expr.span, format!("{}.to_owned()", l)),
-                                            (rhs_expr.span, format!("&{}", r)),
-                                        ],
-                                        Applicability::MachineApplicable,
+                            msg,
+                            vec![
+                                (lhs_expr.span, format!("{}.to_owned()", l)),
+                                (rhs_expr.span, format!("&{}", r)),
+                            ],
+                            Applicability::MachineApplicable,
                         );
                     }
                     _ => {

--- a/src/libsyntax/config.rs
+++ b/src/libsyntax/config.rs
@@ -129,7 +129,7 @@ impl<'a> StripUnconfigured<'a> {
                                                            "expected syntax is",
                                                            suggestion.into(),
                                                            Applicability::MaybeIncorrect,
-                                                           );
+                    );
                 }
                 err.emit();
                 true

--- a/src/libsyntax/config.rs
+++ b/src/libsyntax/config.rs
@@ -124,10 +124,11 @@ impl<'a> StripUnconfigured<'a> {
             let error = |span, msg, suggestion: &str| {
                 let mut err = self.sess.span_diagnostic.struct_span_err(span, msg);
                 if !suggestion.is_empty() {
-                    err.span_suggestion_with_applicability(span,
+                    err.span_suggestion_with_applicability(
+                                                           span,
                                                            "expected syntax is",
                                                            suggestion.into(),
-                                                           Applicability::Unspecified,
+                                                           Applicability::MaybeIncorrect,
                                                            );
                 }
                 err.emit();

--- a/src/libsyntax/config.rs
+++ b/src/libsyntax/config.rs
@@ -125,10 +125,10 @@ impl<'a> StripUnconfigured<'a> {
                 let mut err = self.sess.span_diagnostic.struct_span_err(span, msg);
                 if !suggestion.is_empty() {
                     err.span_suggestion_with_applicability(
-                                                           span,
-                                                           "expected syntax is",
-                                                           suggestion.into(),
-                                                           Applicability::MaybeIncorrect,
+                        span,
+                        "expected syntax is",
+                        suggestion.into(),
+                        Applicability::MaybeIncorrect,
                     );
                 }
                 err.emit();

--- a/src/libsyntax/config.rs
+++ b/src/libsyntax/config.rs
@@ -16,6 +16,7 @@ use source_map::Spanned;
 use edition::Edition;
 use parse::{token, ParseSess};
 use OneVector;
+use errors::Applicability;
 
 use ptr::P;
 
@@ -123,7 +124,11 @@ impl<'a> StripUnconfigured<'a> {
             let error = |span, msg, suggestion: &str| {
                 let mut err = self.sess.span_diagnostic.struct_span_err(span, msg);
                 if !suggestion.is_empty() {
-                    err.span_suggestion(span, "expected syntax is", suggestion.into());
+                    err.span_suggestion_with_applicability(span,
+                                                           "expected syntax is",
+                                                           suggestion.into(),
+                                                           Applicability::Unspecified,
+                                                           );
                 }
                 err.emit();
                 true

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -189,10 +189,10 @@ fn generic_extension<'cx>(cx: &'cx mut ExtCtxt,
                         err.note("you might be missing a comma");
                     } else {
                         err.span_suggestion_short_with_applicability(
-                                                comma_span,
-                                                "missing comma here",
-                                                ", ".to_string(),
-                                                Applicability::MachineApplicable,
+                            comma_span,
+                            "missing comma here",
+                            ", ".to_string(),
+                            Applicability::MachineApplicable,
                         );
                     }
                 }

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -189,10 +189,10 @@ fn generic_extension<'cx>(cx: &'cx mut ExtCtxt,
                         err.note("you might be missing a comma");
                     } else {
                         err.span_suggestion_short_with_applicability(
-                            comma_span,
-                            "missing comma here",
-                            ", ".to_string(),
-                            Applicability::Unspecified,
+                                                comma_span,
+                                                "missing comma here",
+                                                ", ".to_string(),
+                                                Applicability::MachineApplicable,
                         );
                     }
                 }

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -32,6 +32,7 @@ use std::borrow::Cow;
 use std::collections::hash_map::Entry;
 
 use rustc_data_structures::sync::Lrc;
+use errors::Applicability;
 
 pub struct ParserAnyMacro<'a> {
     parser: Parser<'a>,
@@ -187,10 +188,11 @@ fn generic_extension<'cx>(cx: &'cx mut ExtCtxt,
                     if comma_span == DUMMY_SP {
                         err.note("you might be missing a comma");
                     } else {
-                        err.span_suggestion_short(
+                        err.span_suggestion_short_with_applicability(
                             comma_span,
                             "missing comma here",
                             ", ".to_string(),
+                            Applicability::Unspecified,
                         );
                     }
                 }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3882,7 +3882,11 @@ impl<'a> Parser<'a> {
                 if self.token == token::CloseDelim(token::Brace) {
                     // If the struct looks otherwise well formed, recover and continue.
                     if let Some(sp) = comma_sp {
-                        err.span_suggestion_short(sp, "remove this comma", String::new());
+                        err.span_suggestion_short_with_applicability(sp,
+                                                                     "remove this comma",
+                                                                     String::new(),
+                                                                     Applicability::Unspecified,
+                                                                     );
                     }
                     err.emit();
                     break;

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3883,11 +3883,11 @@ impl<'a> Parser<'a> {
                     // If the struct looks otherwise well formed, recover and continue.
                     if let Some(sp) = comma_sp {
                         err.span_suggestion_short_with_applicability(
-                                                                 sp,
-                                                                 "remove this comma",
-                                                                 String::new(),
-                                                                 Applicability::MachineApplicable,
-                                                                 );
+                            sp,
+                            "remove this comma",
+                            String::new(),
+                            Applicability::MachineApplicable,
+                        );
                     }
                     err.emit();
                     break;

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3882,11 +3882,12 @@ impl<'a> Parser<'a> {
                 if self.token == token::CloseDelim(token::Brace) {
                     // If the struct looks otherwise well formed, recover and continue.
                     if let Some(sp) = comma_sp {
-                        err.span_suggestion_short_with_applicability(sp,
-                                                                     "remove this comma",
-                                                                     String::new(),
-                                                                     Applicability::Unspecified,
-                                                                     );
+                        err.span_suggestion_short_with_applicability(
+                                                                 sp,
+                                                                 "remove this comma",
+                                                                 String::new(),
+                                                                 Applicability::MachineApplicable,
+                                                                 );
                     }
                     err.emit();
                     break;

--- a/src/libsyntax_ext/format.rs
+++ b/src/libsyntax_ext/format.rs
@@ -997,9 +997,9 @@ pub fn expand_preparsed_format_args(ecx: &mut ExtCtxt,
                     }
                     if suggestions.len() > 0 {
                         diag.multipart_suggestion_with_applicability(
-                            "format specifiers use curly braces",
-                            suggestions,
-                            Applicability::Unspecified,
+                                                    "format specifiers use curly braces",
+                                                    suggestions,
+                                                    Applicability::MachineApplicable,
                         );
                     }
                 }};

--- a/src/libsyntax_ext/format.rs
+++ b/src/libsyntax_ext/format.rs
@@ -997,9 +997,9 @@ pub fn expand_preparsed_format_args(ecx: &mut ExtCtxt,
                     }
                     if suggestions.len() > 0 {
                         diag.multipart_suggestion_with_applicability(
-                                                    "format specifiers use curly braces",
-                                                    suggestions,
-                                                    Applicability::MachineApplicable,
+                            "format specifiers use curly braces",
+                            suggestions,
+                            Applicability::MachineApplicable,
                         );
                     }
                 }};

--- a/src/libsyntax_ext/format.rs
+++ b/src/libsyntax_ext/format.rs
@@ -996,9 +996,10 @@ pub fn expand_preparsed_format_args(ecx: &mut ExtCtxt,
                         ));
                     }
                     if suggestions.len() > 0 {
-                        diag.multipart_suggestion(
+                        diag.multipart_suggestion_with_applicability(
                             "format specifiers use curly braces",
                             suggestions,
+                            Applicability::Unspecified,
                         );
                     }
                 }};


### PR DESCRIPTION
Use `Applicability::Unspecified` for all of them instead.

Shall deprecations for the non-`_with_applicability` functions be added?

Shall clippy be addressed somehow?

r? @estebank 