### PR TITLE
Add a small search box to seach Rust's standary library

### DIFF
--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -43,6 +43,13 @@ Rust's standard library has [extensive API documentation](std/index.html),
 with explanations of how to use various things, as well as example code for
 accomplishing various tasks.
 
+<div>
+  <form action="std/index.html" method="get">
+    <input type="search" name="search"/>
+    <button>Search</button>
+  </form>
+</div>
+
 ## The Rustc Book
 
 [The Rustc Book](rustc/index.html) describes the Rust compiler, `rustc`.


### PR DESCRIPTION
This change partially addresses #14572. No CSS doesn't look fancy
but at least it is functional.