### PR TITLE
Switch wasm math symbols to their original names

### DIFF
--- a/src/libstd/sys/wasm/cmath.rs
+++ b/src/libstd/sys/wasm/cmath.rs
@@ -74,46 +74,19 @@ pub unsafe fn tanhf(n: f32) -> f32 {
     f64::tanh(n as f64) as f32
 }
 
-// Right now all these functions, the f64 version of the functions above, all
-// shell out to random names. These names aren't actually defined anywhere, per
-// se, but we need this to compile somehow.
-//
-// The idea with this is that when you're using wasm then, for now, we have no
-// way of providing an implementation of these which delegates to a "correct"
-// implementation. For example most wasm applications probably just want to
-// delegate to the javascript `Math` object and its related functions, but wasm
-// doesn't currently have the ability to seamlessly do that (when you
-// instantiate a module you have to set that up).
-//
-// As a result these are just defined here with "hopefully helpful" names. The
-// symbols won't ever be needed or show up unless these functions are called,
-// and hopefully when they're called the errors are self-explanatory enough to
-// figure out what's going on.
-
+// These symbols are all defined in `compiler-builtins`
 extern {
-    #[link_name = "Math_acos"]
     pub fn acos(n: f64) -> f64;
-    #[link_name = "Math_asin"]
     pub fn asin(n: f64) -> f64;
-    #[link_name = "Math_atan"]
     pub fn atan(n: f64) -> f64;
-    #[link_name = "Math_atan2"]
     pub fn atan2(a: f64, b: f64) -> f64;
-    #[link_name = "Math_cbrt"]
     pub fn cbrt(n: f64) -> f64;
-    #[link_name = "Math_cosh"]
     pub fn cosh(n: f64) -> f64;
-    #[link_name = "Math_expm1"]
     pub fn expm1(n: f64) -> f64;
     pub fn fdim(a: f64, b: f64) -> f64;
-    #[link_name = "Math_log1p"]
     pub fn log1p(n: f64) -> f64;
-    #[link_name = "Math_sinh"]
     pub fn sinh(n: f64) -> f64;
-    #[link_name = "Math_tan"]
     pub fn tan(n: f64) -> f64;
-    #[link_name = "Math_tanh"]
     pub fn tanh(n: f64) -> f64;
-    #[link_name = "Math_hypot"]
     pub fn hypot(x: f64, y: f64) -> f64;
 }


### PR DESCRIPTION
The names `Math_*` were given to help undefined symbol messages indicate how to
implement them, but these are all implemented in compiler-rt now so there's no
need to rename them! This change should make it so wasm binaries by default, no
matter the math symbols used, will not have unresolved symbols.