### PR TITLE
Enable fatal warnings for the wasm32 linker

### DIFF
--- a/src/librustc_codegen_llvm/back/linker.rs
+++ b/src/librustc_codegen_llvm/back/linker.rs
@@ -1071,6 +1071,10 @@ impl<'a> Linker for WasmLd<'a> {
         // Make the default table accessible
         self.cmd.arg("--export-table");
 
+        // Rust code should never have warnings, and warnings are often
+        // indicative of bugs, let's prevent them.
+        self.cmd.arg("--fatal-warnings");
+
         let mut cmd = Command::new("");
         ::std::mem::swap(&mut cmd, &mut self.cmd);
         cmd


### PR DESCRIPTION
Historically LLD has emitted warnings for various reasons but all the bugs have
since been fixed (yay!) and by enabling fatal warnings we should be able to head
off bugs like #53390 sooner.