### PR TITLE
Make `dyn` a keyword in the 2018 edition

### DIFF
--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1937,8 +1937,7 @@ impl EarlyLintPass for KeywordIdents {
         let next_edition = match cx.sess.edition() {
             Edition::Edition2015 => {
                 match &ident.as_str()[..] {
-                    "async" |
-                    "try" => Edition::Edition2018,
+                    "async" | "try" | "dyn" => Edition::Edition2018,
                     _ => return,
                 }
             }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1562,8 +1562,9 @@ impl<'a> Parser<'a> {
             impl_dyn_multi = bounds.len() > 1 || self.prev_token_kind == PrevTokenKind::Plus;
             TyKind::ImplTrait(ast::DUMMY_NODE_ID, bounds)
         } else if self.check_keyword(keywords::Dyn) &&
-                  self.look_ahead(1, |t| t.can_begin_bound() &&
-                                         !can_continue_type_after_non_fn_ident(t)) {
+                  (self.span.edition() == Edition::Edition2018 ||
+                   self.look_ahead(1, |t| t.can_begin_bound() &&
+                                         !can_continue_type_after_non_fn_ident(t))) {
             self.bump(); // `dyn`
             // Always parse bounds greedily for better error recovery.
             let bounds = self.parse_generic_bounds()?;

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -136,6 +136,7 @@ fn ident_can_begin_type(ident: ast::Ident, is_raw: bool) -> bool {
         keywords::Unsafe.name(),
         keywords::Extern.name(),
         keywords::Typeof.name(),
+        keywords::Dyn.name(),
     ].contains(&ident.name)
 }
 

--- a/src/libsyntax_pos/symbol.rs
+++ b/src/libsyntax_pos/symbol.rs
@@ -414,26 +414,25 @@ declare_keywords! {
     (50, Yield,              "yield")
 
     // Edition-specific keywords reserved for future use.
-    (51, Async,              "async") // >= 2018 Edition Only
-    (52, Try,                "try") // >= 2018 Edition Only
+    (51, Async,              "async") // >= 2018 Edition only
+    (52, Dyn,                "dyn") // >= 2018 Edition only
+    (53, Try,                "try") // >= 2018 Edition only
 
     // Special lifetime names
-    (53, UnderscoreLifetime, "'_")
-    (54, StaticLifetime,     "'static")
+    (54, UnderscoreLifetime, "'_")
+    (55, StaticLifetime,     "'static")
 
     // Weak keywords, have special meaning only in specific contexts.
-    (55, Auto,               "auto")
-    (56, Catch,              "catch")
-    (57, Default,            "default")
-    (58, Dyn,                "dyn")
+    (56, Auto,               "auto")
+    (57, Catch,              "catch")
+    (58, Default,            "default")
     (59, Union,              "union")
     (60, Existential,        "existential")
 }
 
 impl Symbol {
     fn is_unused_keyword_2018(self) -> bool {
-        self >= keywords::Async.name() &&
-        self <= keywords::Try.name()
+        self >= keywords::Async.name() && self <= keywords::Try.name()
     }
 }
 

--- a/src/test/ui/rust-2018/dyn-keyword.fixed
+++ b/src/test/ui/rust-2018/dyn-keyword.fixed
@@ -1,0 +1,10 @@
+// edition:2015
+// run-rustfix
+
+#![allow(unused_variables)]
+#![deny(keyword_idents)]
+
+fn main() {
+    let r#dyn = (); //~ ERROR dyn
+    //~^ WARN hard error in the 2018 edition
+}

--- a/src/test/ui/rust-2018/dyn-keyword.rs
+++ b/src/test/ui/rust-2018/dyn-keyword.rs
@@ -1,0 +1,10 @@
+// edition:2015
+// run-rustfix
+
+#![allow(unused_variables)]
+#![deny(keyword_idents)]
+
+fn main() {
+    let dyn = (); //~ ERROR dyn
+    //~^ WARN hard error in the 2018 edition
+}

--- a/src/test/ui/rust-2018/dyn-keyword.stderr
+++ b/src/test/ui/rust-2018/dyn-keyword.stderr
@@ -1,0 +1,16 @@
+error: `dyn` is a keyword in the 2018 edition
+  --> $DIR/dyn-keyword.rs:8:9
+   |
+LL |     let dyn = (); //~ ERROR dyn
+   |         ^^^ help: you can use a raw identifier to stay compatible: `r#dyn`
+   |
+note: lint level defined here
+  --> $DIR/dyn-keyword.rs:5:9
+   |
+LL | #![deny(keyword_idents)]
+   |         ^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
+
+error: aborting due to previous error
+

--- a/src/test/ui/rust-2018/dyn-trait-compatibility.rs
+++ b/src/test/ui/rust-2018/dyn-trait-compatibility.rs
@@ -1,0 +1,8 @@
+// edition:2018
+
+type A0 = dyn;
+type A1 = dyn::dyn; //~ERROR expected identifier, found reserved keyword
+type A2 = dyn<dyn, dyn>; //~ERROR expected identifier, found `<`
+type A3 = dyn<<dyn as dyn>::dyn>;
+
+fn main() {}

--- a/src/test/ui/rust-2018/dyn-trait-compatibility.stderr
+++ b/src/test/ui/rust-2018/dyn-trait-compatibility.stderr
@@ -1,0 +1,14 @@
+error: expected identifier, found reserved keyword `dyn`
+  --> $DIR/dyn-trait-compatibility.rs:4:16
+   |
+LL | type A1 = dyn::dyn; //~ERROR expected identifier, found reserved keyword
+   |                ^^^ expected identifier, found reserved keyword
+
+error: expected identifier, found `<`
+  --> $DIR/dyn-trait-compatibility.rs:5:14
+   |
+LL | type A2 = dyn<dyn, dyn>; //~ERROR expected identifier, found `<`
+   |              ^ expected identifier
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Proposed in https://github.com/rust-lang/rust/issues/44662#issuecomment-421596088.