### PR TITLE
avoid leaking host details in proc macro metadata decoding

### DIFF
--- a/src/librustc_metadata/cstore_impl.rs
+++ b/src/librustc_metadata/cstore_impl.rs
@@ -259,12 +259,6 @@ provide! { <'tcx> tcx, def_id, other, cdata,
         let cnum = cdata.cnum;
         assert!(cnum != LOCAL_CRATE);
 
-        // If this crate is a custom derive crate, then we're not even going to
-        // link those in so we skip those crates.
-        if cdata.root.macro_derive_registrar.is_some() {
-            return Arc::new(Vec::new())
-        }
-
         Arc::new(cdata.exported_symbols(tcx))
     }
 }

--- a/src/test/incremental-fulldeps/auxiliary/issue_54059.rs
+++ b/src/test/incremental-fulldeps/auxiliary/issue_54059.rs
@@ -1,0 +1,59 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+
+// check that having extern "C" functions in a proc macro doesn't crash.
+
+#![crate_type="proc-macro"]
+#![allow(non_snake_case)]
+
+extern crate proc_macro;
+
+macro_rules! proc_macro_tokenstream {
+    () => {
+        ::proc_macro::TokenStream
+    };
+}
+
+macro_rules! proc_macro_expr_impl {
+    ($(
+        $( #[$attr:meta] )*
+        pub fn $func:ident($input:ident: &str) -> String $body:block
+    )+) => {
+        $(
+            // Parses an input that looks like:
+            //
+            // ```
+            // #[allow(unused)]
+            // enum ProcMacroHack {
+            //     Input = (stringify!(ARGS), 0).1,
+            // }
+            // ```
+            $( #[$attr] )*
+            #[proc_macro_derive($func)]
+            pub fn $func(input: proc_macro_tokenstream!()) -> proc_macro_tokenstream!() {
+                unsafe { rust_dbg_extern_identity_u64(0); }
+                panic!()
+            }
+        )+
+    };
+}
+
+proc_macro_expr_impl! {
+    pub fn base2_impl(input: &str) -> String {
+        panic!()
+    }
+}
+
+#[link(name="rust_test_helpers")]
+extern "C" {
+    pub fn rust_dbg_extern_identity_u64(v: u64) -> u64;
+}

--- a/src/test/incremental-fulldeps/issue-54059.rs
+++ b/src/test/incremental-fulldeps/issue-54059.rs
@@ -11,6 +11,7 @@
 // aux-build:issue_54059.rs
 // ignore-stage1
 // ignore-wasm32-bare no libc for ffi testing
+// ignore-windows - dealing with weird symbols issues on dylibs isn't worth it
 // revisions: rpass1
 
 extern crate issue_54059;

--- a/src/test/incremental-fulldeps/issue-54059.rs
+++ b/src/test/incremental-fulldeps/issue-54059.rs
@@ -1,0 +1,18 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:issue_54059.rs
+// ignore-stage1
+// ignore-wasm32-bare no libc for ffi testing
+// revisions: rpass1
+
+extern crate issue_54059;
+
+fn main() {}


### PR DESCRIPTION
proc macro crates are essentially implemented as dynamic libraries using
a dlopen-based ABI. They are also Rust crates, so they have 2 worlds -
the "host" world in which they are defined, and the "target" world in
which they are used.

For all the "target" world knows, the proc macro crate might not even
be implemented in Rust, so leaks of details from the host to the target
must be avoided for correctness.

Because the "host" DefId space is different from the "target" DefId
space, any leak involving a DefId will have a nonsensical or
out-of-bounds DefKey, and will cause all sorts of crashes.

This PR fixes all leaks I have found in `decoder`. In particular, #54059
was caused by host native libraries leaking into the target, which feels
like it might even be a correctness issue if it doesn't cause an ICE.

Fixes #54059