### PR TITLE
#53840: Consolidate pattern check errors

### DIFF
--- a/src/test/ui/issue-53840.rs
+++ b/src/test/ui/issue-53840.rs
@@ -1,0 +1,27 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+enum E {
+    Foo(String, String, String),
+}
+
+struct Bar {
+    a: String,
+    b: String,
+}
+
+fn main() {
+    let bar = Bar { a: "1".to_string(), b: "2".to_string() };
+    match E::Foo("".into(), "".into(), "".into()) {
+        E::Foo(a, b, ref c) => {}
+    }
+    match bar {
+        Bar {a, ref b} => {}
+    }
+}

--- a/src/test/ui/issue-53840.stderr
+++ b/src/test/ui/issue-53840.stderr
@@ -1,0 +1,20 @@
+error[E0009]: cannot bind by-move and by-ref in the same pattern
+  --> $DIR/issue-53840.rs:22:16
+   |
+LL |         E::Foo(a, b, ref c) => {}
+   |                ^  ^  ----- both by-ref and by-move used
+   |                |  |
+   |                |  by-move pattern here
+   |                by-move pattern here
+
+error[E0009]: cannot bind by-move and by-ref in the same pattern
+  --> $DIR/issue-53840.rs:25:14
+   |
+LL |         Bar {a, ref b} => {}
+   |              ^  ----- both by-ref and by-move used
+   |              |
+   |              by-move pattern here
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0009`.


### PR DESCRIPTION
#53840  on this PR we are aggregating `cannot bind by-move and by-ref in the same pattern` message present on the different lines into one diagnostic message. Here we are first gathering those `spans` on `vector` then we are throwing them with the help of `MultiSpan`
r? @estebank 

Addresses: #53480