### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -43,6 +43,13 @@ Rust's standard library has [extensive API documentation](std/index.html),
 with explanations of how to use various things, as well as example code for
 accomplishing various tasks.
 
+<div>
+  <form action="std/index.html" method="get">
+    <input type="search" name="search"/>
+    <button>Search</button>
+  </form>
+</div>
+
 ## The Rustc Book
 
 [The Rustc Book](rustc/index.html) describes the Rust compiler, `rustc`.

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -732,6 +732,12 @@ impl<'a> Parser<'a> {
                   format!("expected {} here", expect)))
             };
             let mut err = self.fatal(&msg_exp);
+            if self.token.is_ident_named("and") {
+                err.help("Use `&&` instead of `and` for the boolean operator");
+            }
+            if self.token.is_ident_named("or") {
+                err.help("Use `||` instead of `or` for the boolean operator");
+            }
             let sp = if self.token == token::Token::Eof {
                 // This is EOF, don't want to point at the following char, but rather the last token
                 self.prev_span
@@ -4749,6 +4755,13 @@ impl<'a> Parser<'a> {
             if self.token.is_keyword(keywords::In) || self.token == token::Colon {
                 do_not_suggest_help = true;
                 e.span_label(sp, "expected `{`");
+            }
+
+            if self.token.is_ident_named("and") {
+                e.help("Use `&&` instead of `and` for the boolean operator");
+            }
+            if self.token.is_ident_named("or") {
+                e.help("Use `||` instead of `or` for the boolean operator");
             }
 
             // Check to see if the user has written something like

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -733,10 +733,20 @@ impl<'a> Parser<'a> {
             };
             let mut err = self.fatal(&msg_exp);
             if self.token.is_ident_named("and") {
-                err.help("Use `&&` instead of `and` for the boolean operator");
+                err.span_suggestion_with_applicability(
+                    self.span,
+                    "use `&&` instead of `and` for the boolean operator",
+                    "&&".to_string(),
+                    Applicability::MaybeIncorrect,
+                );
             }
             if self.token.is_ident_named("or") {
-                err.help("Use `||` instead of `or` for the boolean operator");
+                err.span_suggestion_with_applicability(
+                    self.span,
+                    "use `||` instead of `or` for the boolean operator",
+                    "||".to_string(),
+                    Applicability::MaybeIncorrect,
+                );
             }
             let sp = if self.token == token::Token::Eof {
                 // This is EOF, don't want to point at the following char, but rather the last token
@@ -4758,10 +4768,20 @@ impl<'a> Parser<'a> {
             }
 
             if self.token.is_ident_named("and") {
-                e.help("Use `&&` instead of `and` for the boolean operator");
+                e.span_suggestion_with_applicability(
+                    self.span,
+                    "use `&&` instead of `and` for the boolean operator",
+                    "&&".to_string(),
+                    Applicability::MaybeIncorrect,
+                );
             }
             if self.token.is_ident_named("or") {
-                e.help("Use `||` instead of `or` for the boolean operator");
+                e.span_suggestion_with_applicability(
+                    self.span,
+                    "use `||` instead of `or` for the boolean operator",
+                    "||".to_string(),
+                    Applicability::MaybeIncorrect,
+                );
             }
 
             // Check to see if the user has written something like

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -733,7 +733,7 @@ impl<'a> Parser<'a> {
             };
             let mut err = self.fatal(&msg_exp);
             if self.token.is_ident_named("and") {
-                err.span_suggestion_with_applicability(
+                err.span_suggestion_short_with_applicability(
                     self.span,
                     "use `&&` instead of `and` for the boolean operator",
                     "&&".to_string(),
@@ -741,7 +741,7 @@ impl<'a> Parser<'a> {
                 );
             }
             if self.token.is_ident_named("or") {
-                err.span_suggestion_with_applicability(
+                err.span_suggestion_short_with_applicability(
                     self.span,
                     "use `||` instead of `or` for the boolean operator",
                     "||".to_string(),
@@ -4768,7 +4768,7 @@ impl<'a> Parser<'a> {
             }
 
             if self.token.is_ident_named("and") {
-                e.span_suggestion_with_applicability(
+                e.span_suggestion_short_with_applicability(
                     self.span,
                     "use `&&` instead of `and` for the boolean operator",
                     "&&".to_string(),
@@ -4776,7 +4776,7 @@ impl<'a> Parser<'a> {
                 );
             }
             if self.token.is_ident_named("or") {
-                e.span_suggestion_with_applicability(
+                e.span_suggestion_short_with_applicability(
                     self.span,
                     "use `||` instead of `or` for the boolean operator",
                     "||".to_string(),

--- a/src/test/rustdoc/issue-53812.rs
+++ b/src/test/rustdoc/issue-53812.rs
@@ -1,0 +1,26 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub trait MyIterator {
+}
+
+pub struct MyStruct<T>(T);
+
+macro_rules! array_impls {
+    ($($N:expr)+) => {
+        $(
+            impl<'a, T> MyIterator for &'a MyStruct<[T; $N]> {
+            }
+        )+
+    }
+}
+
+// @has issue_53812/trait.MyIterator.html '//*[@id="implementors-list"]//h3[1]' 'MyStruct<[T; 0]>'
+array_impls! { 10 3 2 1 0 }

--- a/src/test/rustdoc/issue-53812.rs
+++ b/src/test/rustdoc/issue-53812.rs
@@ -23,4 +23,8 @@ macro_rules! array_impls {
 }
 
 // @has issue_53812/trait.MyIterator.html '//*[@id="implementors-list"]//h3[1]' 'MyStruct<[T; 0]>'
+// @has - '//*[@id="implementors-list"]//h3[2]' 'MyStruct<[T; 1]>'
+// @has - '//*[@id="implementors-list"]//h3[3]' 'MyStruct<[T; 2]>'
+// @has - '//*[@id="implementors-list"]//h3[4]' 'MyStruct<[T; 3]>'
+// @has - '//*[@id="implementors-list"]//h3[5]' 'MyStruct<[T; 10]>'
 array_impls! { 10 3 2 1 0 }

--- a/src/test/ui/did_you_mean/issue-54109-and_instead_of_ampersands.rs
+++ b/src/test/ui/did_you_mean/issue-54109-and_instead_of_ampersands.rs
@@ -1,0 +1,48 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn test_and() {
+    let a = true;
+    let b = false;
+    if a and b {
+        //~^ ERROR expected `{`, found `and`
+        println!("both");
+    }
+}
+
+fn test_or() {
+    let a = true;
+    let b = false;
+    if a or b {
+        //~^ ERROR expected `{`, found `or`
+        println!("both");
+    }
+}
+
+fn test_and_par() {
+    let a = true;
+    let b = false;
+    if (a and b) {
+        //~^ ERROR expected one of `!`, `)`, `,`, `.`, `::`, `?`, `{`, or an operator, found `and`
+        println!("both");
+    }
+}
+
+fn test_or_par() {
+    let a = true;
+    let b = false;
+    if (a or b) {
+        //~^ ERROR expected one of `!`, `)`, `,`, `.`, `::`, `?`, `{`, or an operator, found `or`
+        println!("both");
+    }
+}
+
+fn main() {
+}

--- a/src/test/ui/did_you_mean/issue-54109-and_instead_of_ampersands.rs
+++ b/src/test/ui/did_you_mean/issue-54109-and_instead_of_ampersands.rs
@@ -44,5 +44,23 @@ fn test_or_par() {
     }
 }
 
+fn test_while_and() {
+    let a = true;
+    let b = false;
+    while a and b {
+        //~^ ERROR expected one of `!`, `.`, `::`, `?`, `{`, or an operator, found `and`
+        println!("both");
+    }
+}
+
+fn test_while_or() {
+    let a = true;
+    let b = false;
+    while a or b {
+        //~^ ERROR expected one of `!`, `.`, `::`, `?`, `{`, or an operator, found `or`
+        println!("both");
+    }
+}
+
 fn main() {
 }

--- a/src/test/ui/did_you_mean/issue-54109-and_instead_of_ampersands.stderr
+++ b/src/test/ui/did_you_mean/issue-54109-and_instead_of_ampersands.stderr
@@ -32,4 +32,23 @@ LL |     if (a or b) {
    |           expected one of 8 possible tokens here
    |           help: use `||` instead of `or` for the boolean operator: `||`
 
-error: aborting due to 4 previous errors
+error: expected one of `!`, `.`, `::`, `?`, `{`, or an operator, found `and`
+  --> $DIR/issue-54109-and_instead_of_ampersands.rs:50:13
+   |
+LL |     while a and b {
+   |             ^^^
+   |             |
+   |             expected one of `!`, `.`, `::`, `?`, `{`, or an operator here
+   |             help: use `&&` instead of `and` for the boolean operator: `&&`
+
+error: expected one of `!`, `.`, `::`, `?`, `{`, or an operator, found `or`
+  --> $DIR/issue-54109-and_instead_of_ampersands.rs:59:13
+   |
+LL |     while a or b {
+   |             ^^
+   |             |
+   |             expected one of `!`, `.`, `::`, `?`, `{`, or an operator here
+   |             help: use `||` instead of `or` for the boolean operator: `||`
+
+error: aborting due to 6 previous errors
+

--- a/src/test/ui/did_you_mean/issue-54109-and_instead_of_ampersands.stderr
+++ b/src/test/ui/did_you_mean/issue-54109-and_instead_of_ampersands.stderr
@@ -1,0 +1,38 @@
+error: expected `{`, found `and`
+  --> $DIR/issue-54109-and_instead_of_ampersands.rs:14:10
+   |
+LL |     if a and b {
+   |     --   ^^^
+   |     |
+   |     this `if` statement has a condition, but no block
+   |
+   = help: Use `&&` instead of `and` for the boolean operator
+
+error: expected `{`, found `or`
+  --> $DIR/issue-54109-and_instead_of_ampersands.rs:23:10
+   |
+LL |     if a or b {
+   |     --   ^^
+   |     |
+   |     this `if` statement has a condition, but no block
+   |
+   = help: Use `||` instead of `or` for the boolean operator
+
+error: expected one of `!`, `)`, `,`, `.`, `::`, `?`, `{`, or an operator, found `and`
+  --> $DIR/issue-54109-and_instead_of_ampersands.rs:32:11
+   |
+LL |     if (a and b) {
+   |           ^^^ expected one of 8 possible tokens here
+   |
+   = help: Use `&&` instead of `and` for the boolean operator
+
+error: expected one of `!`, `)`, `,`, `.`, `::`, `?`, `{`, or an operator, found `or`
+  --> $DIR/issue-54109-and_instead_of_ampersands.rs:41:11
+   |
+LL |     if (a or b) {
+   |           ^^ expected one of 8 possible tokens here
+   |
+   = help: Use `||` instead of `or` for the boolean operator
+
+error: aborting due to 4 previous errors
+

--- a/src/test/ui/did_you_mean/issue-54109-and_instead_of_ampersands.stderr
+++ b/src/test/ui/did_you_mean/issue-54109-and_instead_of_ampersands.stderr
@@ -2,37 +2,34 @@ error: expected `{`, found `and`
   --> $DIR/issue-54109-and_instead_of_ampersands.rs:14:10
    |
 LL |     if a and b {
-   |     --   ^^^
+   |     --   ^^^ help: use `&&` instead of `and` for the boolean operator: `&&`
    |     |
    |     this `if` statement has a condition, but no block
-   |
-   = help: Use `&&` instead of `and` for the boolean operator
 
 error: expected `{`, found `or`
   --> $DIR/issue-54109-and_instead_of_ampersands.rs:23:10
    |
 LL |     if a or b {
-   |     --   ^^
+   |     --   ^^ help: use `||` instead of `or` for the boolean operator: `||`
    |     |
    |     this `if` statement has a condition, but no block
-   |
-   = help: Use `||` instead of `or` for the boolean operator
 
 error: expected one of `!`, `)`, `,`, `.`, `::`, `?`, `{`, or an operator, found `and`
   --> $DIR/issue-54109-and_instead_of_ampersands.rs:32:11
    |
 LL |     if (a and b) {
-   |           ^^^ expected one of 8 possible tokens here
-   |
-   = help: Use `&&` instead of `and` for the boolean operator
+   |           ^^^
+   |           |
+   |           expected one of 8 possible tokens here
+   |           help: use `&&` instead of `and` for the boolean operator: `&&`
 
 error: expected one of `!`, `)`, `,`, `.`, `::`, `?`, `{`, or an operator, found `or`
   --> $DIR/issue-54109-and_instead_of_ampersands.rs:41:11
    |
 LL |     if (a or b) {
-   |           ^^ expected one of 8 possible tokens here
-   |
-   = help: Use `||` instead of `or` for the boolean operator
+   |           ^^
+   |           |
+   |           expected one of 8 possible tokens here
+   |           help: use `||` instead of `or` for the boolean operator: `||`
 
 error: aborting due to 4 previous errors
-

--- a/src/test/ui/did_you_mean/issue-54109-and_instead_of_ampersands.stderr
+++ b/src/test/ui/did_you_mean/issue-54109-and_instead_of_ampersands.stderr
@@ -2,7 +2,7 @@ error: expected `{`, found `and`
   --> $DIR/issue-54109-and_instead_of_ampersands.rs:14:10
    |
 LL |     if a and b {
-   |     --   ^^^ help: use `&&` instead of `and` for the boolean operator: `&&`
+   |     --   ^^^ help: use `&&` instead of `and` for the boolean operator
    |     |
    |     this `if` statement has a condition, but no block
 
@@ -10,7 +10,7 @@ error: expected `{`, found `or`
   --> $DIR/issue-54109-and_instead_of_ampersands.rs:23:10
    |
 LL |     if a or b {
-   |     --   ^^ help: use `||` instead of `or` for the boolean operator: `||`
+   |     --   ^^ help: use `||` instead of `or` for the boolean operator
    |     |
    |     this `if` statement has a condition, but no block
 
@@ -21,7 +21,7 @@ LL |     if (a and b) {
    |           ^^^
    |           |
    |           expected one of 8 possible tokens here
-   |           help: use `&&` instead of `and` for the boolean operator: `&&`
+   |           help: use `&&` instead of `and` for the boolean operator
 
 error: expected one of `!`, `)`, `,`, `.`, `::`, `?`, `{`, or an operator, found `or`
   --> $DIR/issue-54109-and_instead_of_ampersands.rs:41:11
@@ -30,7 +30,7 @@ LL |     if (a or b) {
    |           ^^
    |           |
    |           expected one of 8 possible tokens here
-   |           help: use `||` instead of `or` for the boolean operator: `||`
+   |           help: use `||` instead of `or` for the boolean operator
 
 error: expected one of `!`, `.`, `::`, `?`, `{`, or an operator, found `and`
   --> $DIR/issue-54109-and_instead_of_ampersands.rs:50:13
@@ -39,7 +39,7 @@ LL |     while a and b {
    |             ^^^
    |             |
    |             expected one of `!`, `.`, `::`, `?`, `{`, or an operator here
-   |             help: use `&&` instead of `and` for the boolean operator: `&&`
+   |             help: use `&&` instead of `and` for the boolean operator
 
 error: expected one of `!`, `.`, `::`, `?`, `{`, or an operator, found `or`
   --> $DIR/issue-54109-and_instead_of_ampersands.rs:59:13
@@ -48,7 +48,7 @@ LL |     while a or b {
    |             ^^
    |             |
    |             expected one of `!`, `.`, `::`, `?`, `{`, or an operator here
-   |             help: use `||` instead of `or` for the boolean operator: `||`
+   |             help: use `||` instead of `or` for the boolean operator
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/run-pass/macros/macro-comma-support.rs
+++ b/src/test/ui/run-pass/macros/macro-comma-support.rs
@@ -62,30 +62,30 @@ fn assert_ne() {
 
 #[test]
 fn cfg() {
-    cfg!(pants);
-    cfg!(pants,);
-    cfg!(pants = "pants");
-    cfg!(pants = "pants",);
-    cfg!(all(pants));
-    cfg!(all(pants),);
-    cfg!(all(pants,));
-    cfg!(all(pants,),);
+    let _ = cfg!(pants);
+    let _ = cfg!(pants,);
+    let _ = cfg!(pants = "pants");
+    let _ = cfg!(pants = "pants",);
+    let _ = cfg!(all(pants));
+    let _ = cfg!(all(pants),);
+    let _ = cfg!(all(pants,));
+    let _ = cfg!(all(pants,),);
 }
 
 #[test]
 fn column() {
-    column!();
+    let _ = column!();
 }
 
 // compile_error! is in a companion to this test in compile-fail
 
 #[test]
 fn concat() {
-    concat!();
-    concat!("hello");
-    concat!("hello",);
-    concat!("hello", " world");
-    concat!("hello", " world",);
+    let _ = concat!();
+    let _ = concat!("hello");
+    let _ = concat!("hello",);
+    let _ = concat!("hello", " world");
+    let _ = concat!("hello", " world",);
 }
 
 #[test]
@@ -131,10 +131,10 @@ fn debug_assert_ne() {
 
 #[test]
 fn env() {
-    env!("PATH");
-    env!("PATH",);
-    env!("PATH", "not found");
-    env!("PATH", "not found",);
+    let _ = env!("PATH");
+    let _ = env!("PATH",);
+    let _ = env!("PATH", "not found");
+    let _ = env!("PATH", "not found",);
 }
 
 #[cfg(std)]
@@ -158,58 +158,58 @@ fn eprintln() {
 
 #[test]
 fn file() {
-    file!();
+    let _ = file!();
 }
 
 #[cfg(std)]
 #[test]
 fn format() {
-    format!("hello");
-    format!("hello",);
-    format!("hello {}", "world");
-    format!("hello {}", "world",);
+    let _ = format!("hello");
+    let _ = format!("hello",);
+    let _ = format!("hello {}", "world");
+    let _ = format!("hello {}", "world",);
 }
 
 #[test]
 fn format_args() {
-    format_args!("hello");
-    format_args!("hello",);
-    format_args!("hello {}", "world");
-    format_args!("hello {}", "world",);
+    let _ = format_args!("hello");
+    let _ = format_args!("hello",);
+    let _ = format_args!("hello {}", "world");
+    let _ = format_args!("hello {}", "world",);
 }
 
 #[test]
 fn include() {
-    include!("auxiliary/macro-comma-support.rs");
-    include!("auxiliary/macro-comma-support.rs",);
+    let _ = include!("auxiliary/macro-comma-support.rs");
+    let _ = include!("auxiliary/macro-comma-support.rs",);
 }
 
 #[test]
 fn include_bytes() {
-    include_bytes!("auxiliary/macro-comma-support.rs");
-    include_bytes!("auxiliary/macro-comma-support.rs",);
+    let _ = include_bytes!("auxiliary/macro-comma-support.rs");
+    let _ = include_bytes!("auxiliary/macro-comma-support.rs",);
 }
 
 #[test]
 fn include_str() {
-    include_str!("auxiliary/macro-comma-support.rs");
-    include_str!("auxiliary/macro-comma-support.rs",);
+    let _ = include_str!("auxiliary/macro-comma-support.rs");
+    let _ = include_str!("auxiliary/macro-comma-support.rs",);
 }
 
 #[test]
 fn line() {
-    line!();
+    let _ = line!();
 }
 
 #[test]
 fn module_path() {
-    module_path!();
+    let _ = module_path!();
 }
 
 #[test]
 fn option_env() {
-    option_env!("PATH");
-    option_env!("PATH",);
+    let _ = option_env!("PATH");
+    let _ = option_env!("PATH",);
 }
 
 #[test]
@@ -309,10 +309,10 @@ fn unreachable() {
 #[test]
 fn vec() {
     let _: Vec<()> = vec![];
-    vec![0];
-    vec![0,];
-    vec![0, 1];
-    vec![0, 1,];
+    let _ = vec![0];
+    let _ = vec![0,];
+    let _ = vec![0, 1];
+    let _ = vec![0, 1,];
 }
 
 // give a test body access to a fmt::Formatter, which seems
@@ -340,21 +340,21 @@ macro_rules! test_with_formatter {
 test_with_formatter! {
     #[test]
     fn write(f: &mut fmt::Formatter) {
-        write!(f, "hello");
-        write!(f, "hello",);
-        write!(f, "hello {}", "world");
-        write!(f, "hello {}", "world",);
+        let _ = write!(f, "hello");
+        let _ = write!(f, "hello",);
+        let _ = write!(f, "hello {}", "world");
+        let _ = write!(f, "hello {}", "world",);
     }
 }
 
 test_with_formatter! {
     #[test]
     fn writeln(f: &mut fmt::Formatter) {
-        writeln!(f);
-        writeln!(f,);
-        writeln!(f, "hello");
-        writeln!(f, "hello",);
-        writeln!(f, "hello {}", "world");
-        writeln!(f, "hello {}", "world",);
+        let _ = writeln!(f);
+        let _ = writeln!(f,);
+        let _ = writeln!(f, "hello");
+        let _ = writeln!(f, "hello",);
+        let _ = writeln!(f, "hello {}", "world");
+        let _ = writeln!(f, "hello {}", "world",);
     }
 }


### PR DESCRIPTION
Successful merges:

 - #53941 (rustdoc: Sort implementors)
 - #54181 (Suggest && and || instead of 'and' and 'or')
 - #54209 (Partially revert 674a5db "Fix undesirable fallout [from macro modularization]")
 - #54213 (De-overlap the lifetimes of `flow_inits` and `flow_{un,ever_}inits`.)
 - #54244 (Add a small search box to seach Rust's standary library)

Failed merges:


r? @ghost