### PR TITLE
rustc: keep a Span for each predicate in ty::GenericPredicates.

### DIFF
--- a/src/librustc/infer/outlives/verify.rs
+++ b/src/librustc/infer/outlives/verify.rs
@@ -297,12 +297,15 @@ impl<'cx, 'gcx, 'tcx> VerifyBoundCx<'cx, 'gcx, 'tcx> {
         let tcx = self.tcx;
         let assoc_item = tcx.associated_item(assoc_item_def_id);
         let trait_def_id = assoc_item.container.assert_trait();
-        let trait_predicates = tcx.predicates_of(trait_def_id);
+        let trait_predicates = tcx.predicates_of(trait_def_id).predicates
+            .into_iter()
+            .map(|(p, _)| p)
+            .collect();
         let identity_substs = Substs::identity_for_item(tcx, assoc_item_def_id);
         let identity_proj = tcx.mk_projection(assoc_item_def_id, identity_substs);
         self.collect_outlives_from_predicate_list(
             move |ty| ty == identity_proj,
-            traits::elaborate_predicates(tcx, trait_predicates.predicates),
+            traits::elaborate_predicates(tcx, trait_predicates),
         ).map(|b| b.1)
     }
 

--- a/src/librustc/traits/coherence.rs
+++ b/src/librustc/traits/coherence.rs
@@ -96,10 +96,10 @@ fn with_fresh_ty_vars<'cx, 'gcx, 'tcx>(selcx: &mut SelectionContext<'cx, 'gcx, '
 
     let header = ty::ImplHeader {
         impl_def_id,
-        self_ty: tcx.type_of(impl_def_id),
-        trait_ref: tcx.impl_trait_ref(impl_def_id),
-        predicates: tcx.predicates_of(impl_def_id).predicates
-    }.subst(tcx, impl_substs);
+        self_ty: tcx.type_of(impl_def_id).subst(tcx, impl_substs),
+        trait_ref: tcx.impl_trait_ref(impl_def_id).subst(tcx, impl_substs),
+        predicates: tcx.predicates_of(impl_def_id).instantiate(tcx, impl_substs).predicates,
+    };
 
     let Normalized { value: mut header, obligations } =
         traits::normalize(selcx, param_env, ObligationCause::dummy(), &header);

--- a/src/librustc/traits/mod.rs
+++ b/src/librustc/traits/mod.rs
@@ -816,11 +816,10 @@ fn substitute_normalize_and_test_predicates<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx
                                                       key: (DefId, &'tcx Substs<'tcx>))
                                                       -> bool
 {
-    use ty::subst::Subst;
     debug!("substitute_normalize_and_test_predicates(key={:?})",
            key);
 
-    let predicates = tcx.predicates_of(key.0).predicates.subst(tcx, key.1);
+    let predicates = tcx.predicates_of(key.0).instantiate(tcx, key.1).predicates;
     let result = normalize_and_test_predicates(tcx, predicates);
 
     debug!("substitute_normalize_and_test_predicates(key={:?}) = {:?}",

--- a/src/librustc/traits/object_safety.rs
+++ b/src/librustc/traits/object_safety.rs
@@ -179,7 +179,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         predicates
             .predicates
             .into_iter()
-            .map(|predicate| predicate.subst_supertrait(self, &trait_ref))
+            .map(|(predicate, _)| predicate.subst_supertrait(self, &trait_ref))
             .any(|predicate| {
                 match predicate {
                     ty::Predicate::Trait(ref data) => {
@@ -311,7 +311,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         if self.predicates_of(method.def_id).predicates.into_iter()
                 // A trait object can't claim to live more than the concrete type,
                 // so outlives predicates will always hold.
-                .filter(|p| p.to_opt_type_outlives().is_none())
+                .filter(|(p, _)| p.to_opt_type_outlives().is_none())
                 .collect::<Vec<_>>()
                 // Do a shallow visit so that `contains_illegal_self_type_reference`
                 // may apply it's custom visiting.

--- a/src/librustc/traits/select.rs
+++ b/src/librustc/traits/select.rs
@@ -3401,7 +3401,7 @@ impl<'cx, 'gcx, 'tcx> SelectionContext<'cx, 'gcx, 'tcx> {
         // that order.
         let predicates = tcx.predicates_of(def_id);
         assert_eq!(predicates.parent, None);
-        let mut predicates: Vec<_> = predicates.predicates.iter().flat_map(|predicate| {
+        let mut predicates: Vec<_> = predicates.predicates.iter().flat_map(|(predicate, _)| {
             let predicate = normalize_with_depth(self, param_env, cause.clone(), recursion_depth,
                                                  &predicate.subst(tcx, substs));
             predicate.obligations.into_iter().chain(

--- a/src/librustc/traits/specialize/mod.rs
+++ b/src/librustc/traits/specialize/mod.rs
@@ -428,7 +428,7 @@ fn to_pretty_impl_header(tcx: TyCtxt, impl_def_id: DefId) -> Option<String> {
     let mut pretty_predicates = Vec::with_capacity(
         predicates.len() + types_without_default_bounds.len());
 
-    for p in predicates {
+    for (p, _) in predicates {
         if let Some(poly_trait_ref) = p.to_opt_poly_trait_ref() {
             if Some(poly_trait_ref.def_id()) == sized_trait {
                 types_without_default_bounds.remove(poly_trait_ref.self_ty());

--- a/src/librustc/traits/util.rs
+++ b/src/librustc/traits/util.rs
@@ -137,7 +137,7 @@ impl<'cx, 'gcx, 'tcx> Elaborator<'cx, 'gcx, 'tcx> {
                 let mut predicates: Vec<_> =
                     predicates.predicates
                               .iter()
-                              .map(|p| p.subst_supertrait(tcx, &data.to_poly_trait_ref()))
+                              .map(|(p, _)| p.subst_supertrait(tcx, &data.to_poly_trait_ref()))
                               .collect();
 
                 debug!("super_predicates: data={:?} predicates={:?}",
@@ -311,7 +311,7 @@ impl<'cx, 'gcx, 'tcx> Iterator for SupertraitDefIds<'cx, 'gcx, 'tcx> {
         self.stack.extend(
             predicates.predicates
                       .iter()
-                      .filter_map(|p| p.to_opt_poly_trait_ref())
+                      .filter_map(|(p, _)| p.to_opt_poly_trait_ref())
                       .map(|t| t.def_id())
                       .filter(|&super_def_id| visited.insert(super_def_id)));
         Some(def_id)

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1736,8 +1736,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TrivialConstraints {
         if cx.tcx.features().trivial_bounds {
             let def_id = cx.tcx.hir.local_def_id(item.id);
             let predicates = cx.tcx.predicates_of(def_id);
-            for predicate in &predicates.predicates {
-                let predicate_kind_name = match *predicate {
+            for &(predicate, span) in &predicates.predicates {
+                let predicate_kind_name = match predicate {
                     Trait(..) => "Trait",
                     TypeOutlives(..) |
                     RegionOutlives(..) => "Lifetime",
@@ -1755,7 +1755,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TrivialConstraints {
                 if predicate.is_global() {
                     cx.span_lint(
                         TRIVIAL_BOUNDS,
-                        item.span,
+                        span,
                         &format!("{} bound {} does not depend on any type \
                                 or lifetime parameters", predicate_kind_name, predicate),
                     );

--- a/src/librustc_mir/transform/qualify_min_const_fn.rs
+++ b/src/librustc_mir/transform/qualify_min_const_fn.rs
@@ -15,7 +15,7 @@ pub fn is_min_const_fn(
     let mut current = def_id;
     loop {
         let predicates = tcx.predicates_of(current);
-        for predicate in &predicates.predicates {
+        for (predicate, _) in &predicates.predicates {
             match predicate {
                 | Predicate::RegionOutlives(_)
                 | Predicate::TypeOutlives(_)

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -434,7 +434,7 @@ impl<'b, 'a, 'tcx> ReachEverythingInTheInterfaceVisitor<'b, 'a, 'tcx> {
 
     fn predicates(&mut self) -> &mut Self {
         let predicates = self.ev.tcx.predicates_of(self.item_def_id);
-        for predicate in &predicates.predicates {
+        for (predicate, _) in &predicates.predicates {
             predicate.visit_with(self);
             match predicate {
                 &ty::Predicate::Trait(poly_predicate) => {
@@ -781,7 +781,7 @@ impl<'a, 'tcx> Visitor<'tcx> for TypePrivacyVisitor<'a, 'tcx> {
             if self.check_trait_ref(*principal.skip_binder()) {
                 return;
             }
-            for poly_predicate in projections {
+            for (poly_predicate, _) in projections {
                 let tcx = self.tcx;
                 if self.check_trait_ref(poly_predicate.skip_binder().projection_ty.trait_ref(tcx)) {
                     return;
@@ -956,7 +956,7 @@ impl<'a, 'tcx> TypeVisitor<'tcx> for TypePrivacyVisitor<'a, 'tcx> {
                 }
             }
             ty::Opaque(def_id, ..) => {
-                for predicate in &self.tcx.predicates_of(def_id).predicates {
+                for (predicate, _) in &self.tcx.predicates_of(def_id).predicates {
                     let trait_ref = match *predicate {
                         ty::Predicate::Trait(ref poly_trait_predicate) => {
                             Some(poly_trait_predicate.skip_binder().trait_ref)
@@ -1387,7 +1387,7 @@ impl<'a, 'tcx: 'a> SearchInterfaceForPrivateItemsVisitor<'a, 'tcx> {
         // for the inferred outlives rules; see
         // `src/test/ui/rfc-2093-infer-outlives/privacy.rs`.
         let predicates = self.tcx.explicit_predicates_of(self.item_def_id);
-        for predicate in &predicates.predicates {
+        for (predicate, _) in &predicates.predicates {
             predicate.visit_with(self);
             match predicate {
                 &ty::Predicate::Trait(poly_predicate) => {

--- a/src/librustc_typeck/check/dropck.rs
+++ b/src/librustc_typeck/check/dropck.rs
@@ -212,7 +212,7 @@ fn ensure_drop_predicates_are_implied_by_item_defn<'a, 'tcx>(
     // just to look for all the predicates directly.
 
     assert_eq!(dtor_predicates.parent, None);
-    for predicate in &dtor_predicates.predicates {
+    for (predicate, _) in &dtor_predicates.predicates {
         // (We do not need to worry about deep analysis of type
         // expressions etc because the Drop impls are already forced
         // to take on a structure that is roughly an alpha-renaming of

--- a/src/librustc_typeck/impl_wf_check.rs
+++ b/src/librustc_typeck/impl_wf_check.rs
@@ -100,7 +100,7 @@ fn enforce_impl_params_are_constrained<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 
     let mut input_parameters = ctp::parameters_for_impl(impl_self_ty, impl_trait_ref);
     ctp::identify_constrained_type_params(
-        tcx, &impl_predicates.predicates.as_slice(), impl_trait_ref, &mut input_parameters);
+        tcx, &impl_predicates, impl_trait_ref, &mut input_parameters);
 
     // Disallow unconstrained lifetimes, but only if they appear in assoc types.
     let lifetimes_in_associated_types: FxHashSet<_> = impl_item_refs.iter()

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -392,7 +392,7 @@ pub fn hir_ty_to_ty<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, hir_ty: &hir::Ty) -> 
 }
 
 pub fn hir_trait_to_predicates<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, hir_trait: &hir::TraitRef)
-        -> (ty::PolyTraitRef<'tcx>, Vec<ty::PolyProjectionPredicate<'tcx>>) {
+        -> (ty::PolyTraitRef<'tcx>, Vec<(ty::PolyProjectionPredicate<'tcx>, Span)>) {
     // In case there are any projections etc, find the "environment"
     // def-id that will be used to determine the traits/predicates in
     // scope.  This is derived from the enclosing item-like thing.

--- a/src/librustc_typeck/outlives/explicit.rs
+++ b/src/librustc_typeck/outlives/explicit.rs
@@ -40,7 +40,7 @@ impl<'tcx> ExplicitPredicatesMap<'tcx> {
             let mut required_predicates = RequiredPredicates::default();
 
             // process predicates and convert to `RequiredPredicates` entry, see below
-            for pred in predicates.into_iter() {
+            for (pred, _) in predicates.into_iter() {
                 match pred {
                     ty::Predicate::TypeOutlives(predicate) => {
                         let OutlivesPredicate(ref ty, ref reg) = predicate.skip_binder();

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1571,7 +1571,9 @@ impl<'a, 'tcx> Clean<Generics> for (&'a ty::Generics,
             }
         }).collect::<Vec<GenericParamDef>>();
 
-        let mut where_predicates = preds.predicates.to_vec().clean(cx);
+        let mut where_predicates = preds.predicates.iter()
+            .map(|(p, _)| p.clean(cx))
+            .collect::<Vec<_>>();
 
         // Type parameters and have a Sized bound by default unless removed with
         // ?Sized. Scan through the predicates and mark any type parameter with

--- a/src/librustdoc/clean/simplify.rs
+++ b/src/librustdoc/clean/simplify.rs
@@ -157,7 +157,7 @@ fn trait_is_same_or_supertrait(cx: &DocContext, child: DefId,
         return true
     }
     let predicates = cx.tcx.super_predicates_of(child).predicates;
-    predicates.iter().filter_map(|pred| {
+    predicates.iter().filter_map(|(pred, _)| {
         if let ty::Predicate::Trait(ref pred) = *pred {
             if pred.skip_binder().trait_ref.self_ty().is_self() {
                 Some(pred.def_id())

--- a/src/test/ui/cycle-trait/cycle-trait-supertrait-direct.stderr
+++ b/src/test/ui/cycle-trait/cycle-trait-supertrait-direct.stderr
@@ -1,8 +1,8 @@
 error[E0391]: cycle detected when computing the supertraits of `Chromosome`
-  --> $DIR/cycle-trait-supertrait-direct.rs:13:1
+  --> $DIR/cycle-trait-supertrait-direct.rs:13:19
    |
 LL | trait Chromosome: Chromosome {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                   ^^^^^^^^^^
    |
    = note: ...which again requires computing the supertraits of `Chromosome`, completing the cycle
 

--- a/src/test/ui/cycle-trait/cycle-trait-supertrait-indirect.stderr
+++ b/src/test/ui/cycle-trait/cycle-trait-supertrait-indirect.stderr
@@ -1,20 +1,20 @@
 error[E0391]: cycle detected when computing the supertraits of `B`
-  --> $DIR/cycle-trait-supertrait-indirect.rs:17:1
+  --> $DIR/cycle-trait-supertrait-indirect.rs:17:10
    |
 LL | trait B: C {
-   | ^^^^^^^^^^
+   |          ^
    |
 note: ...which requires computing the supertraits of `C`...
-  --> $DIR/cycle-trait-supertrait-indirect.rs:21:1
+  --> $DIR/cycle-trait-supertrait-indirect.rs:21:10
    |
 LL | trait C: B { }
-   | ^^^^^^^^^^
+   |          ^
    = note: ...which again requires computing the supertraits of `B`, completing the cycle
 note: cycle used when computing the supertraits of `A`
-  --> $DIR/cycle-trait-supertrait-indirect.rs:14:1
+  --> $DIR/cycle-trait-supertrait-indirect.rs:14:10
    |
 LL | trait A: B {
-   | ^^^^^^^^^^
+   |          ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-12511.stderr
+++ b/src/test/ui/issues/issue-12511.stderr
@@ -1,14 +1,14 @@
 error[E0391]: cycle detected when computing the supertraits of `t1`
-  --> $DIR/issue-12511.rs:11:1
+  --> $DIR/issue-12511.rs:11:12
    |
 LL | trait t1 : t2 {
-   | ^^^^^^^^^^^^^
+   |            ^^
    |
 note: ...which requires computing the supertraits of `t2`...
-  --> $DIR/issue-12511.rs:15:1
+  --> $DIR/issue-12511.rs:15:12
    |
 LL | trait t2 : t1 {
-   | ^^^^^^^^^^^^^
+   |            ^^
    = note: ...which again requires computing the supertraits of `t1`, completing the cycle
 
 error: aborting due to previous error

--- a/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-copy.stderr
+++ b/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-copy.stderr
@@ -1,41 +1,26 @@
 warning: Trait bound std::string::String: std::marker::Copy does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-inconsistent-copy.rs:16:1
+  --> $DIR/trivial-bounds-inconsistent-copy.rs:16:51
    |
-LL | / fn copy_string(t: String) -> String where String: Copy {
-LL | |     is_copy(&t);
-LL | |     let x = t;
-LL | |     drop(t);
-LL | |     t
-LL | | }
-   | |_^
+LL | fn copy_string(t: String) -> String where String: Copy {
+   |                                                   ^^^^
    |
    = note: #[warn(trivial_bounds)] on by default
 
 warning: Trait bound std::string::String: std::marker::Copy does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-inconsistent-copy.rs:23:1
+  --> $DIR/trivial-bounds-inconsistent-copy.rs:23:56
    |
-LL | / fn copy_out_string(t: &String) -> String where String: Copy {
-LL | |     *t
-LL | | }
-   | |_^
+LL | fn copy_out_string(t: &String) -> String where String: Copy {
+   |                                                        ^^^^
 
 warning: Trait bound std::string::String: std::marker::Copy does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-inconsistent-copy.rs:27:1
+  --> $DIR/trivial-bounds-inconsistent-copy.rs:27:55
    |
-LL | / fn copy_string_with_param<T>(x: String) where String: Copy {
-LL | |     let y = x;
-LL | |     let z = x;
-LL | | }
-   | |_^
+LL | fn copy_string_with_param<T>(x: String) where String: Copy {
+   |                                                       ^^^^
 
 warning: Trait bound for<'b> &'b mut i32: std::marker::Copy does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-inconsistent-copy.rs:33:1
+  --> $DIR/trivial-bounds-inconsistent-copy.rs:33:76
    |
-LL | / fn copy_mut<'a>(t: &&'a mut i32) -> &'a mut i32 where for<'b> &'b mut i32: Copy {
-LL | |     is_copy(t);
-LL | |     let x = *t;
-LL | |     drop(x);
-LL | |     x
-LL | | }
-   | |_^
+LL | fn copy_mut<'a>(t: &&'a mut i32) -> &'a mut i32 where for<'b> &'b mut i32: Copy {
+   |                                                                            ^^^^
 

--- a/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-projection.stderr
+++ b/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-projection.stderr
@@ -1,57 +1,44 @@
 warning: Trait bound B: A does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-inconsistent-projection.rs:29:1
+  --> $DIR/trivial-bounds-inconsistent-projection.rs:31:8
    |
-LL | / fn underspecified_bound() -> u8
-LL | | where
-LL | |     B: A
-LL | | {
-LL | |     B::get_x()
-LL | | }
-   | |_^
+LL |     B: A
+   |        ^
    |
    = note: #[warn(trivial_bounds)] on by default
 
 warning: Trait bound B: A does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-inconsistent-projection.rs:36:1
+  --> $DIR/trivial-bounds-inconsistent-projection.rs:38:8
    |
-LL | / fn inconsistent_bound() -> i32
-LL | | where
-LL | |     B: A<X = i32>
-LL | | {
-LL | |     B::get_x()
-LL | | }
-   | |_^
+LL |     B: A<X = i32>
+   |        ^^^^^^^^^^
 
 warning: Trait bound B: A does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-inconsistent-projection.rs:43:1
+  --> $DIR/trivial-bounds-inconsistent-projection.rs:45:8
    |
-LL | / fn redundant_bound() -> u8
-LL | | where
-LL | |     B: A<X = u8>
-LL | | {
-LL | |     B::get_x()
-LL | | }
-   | |_^
+LL |     B: A<X = u8>
+   |        ^^^^^^^^^
 
 warning: Trait bound B: A does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-inconsistent-projection.rs:50:1
+  --> $DIR/trivial-bounds-inconsistent-projection.rs:52:8
    |
-LL | / fn inconsistent_dup_bound() -> i32
-LL | | where
-LL | |     B: A<X = i32> + A
-LL | | {
-LL | |     B::get_x()
-LL | | }
-   | |_^
+LL |     B: A<X = i32> + A
+   |        ^^^^^^^^^^
 
 warning: Trait bound B: A does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-inconsistent-projection.rs:57:1
+  --> $DIR/trivial-bounds-inconsistent-projection.rs:52:21
    |
-LL | / fn redundant_dup_bound() -> u8
-LL | | where
-LL | |     B: A<X = u8> + A
-LL | | {
-LL | |     B::get_x()
-LL | | }
-   | |_^
+LL |     B: A<X = i32> + A
+   |                     ^
+
+warning: Trait bound B: A does not depend on any type or lifetime parameters
+  --> $DIR/trivial-bounds-inconsistent-projection.rs:59:8
+   |
+LL |     B: A<X = u8> + A
+   |        ^^^^^^^^^
+
+warning: Trait bound B: A does not depend on any type or lifetime parameters
+  --> $DIR/trivial-bounds-inconsistent-projection.rs:59:20
+   |
+LL |     B: A<X = u8> + A
+   |                    ^
 

--- a/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-sized.stderr
+++ b/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-sized.stderr
@@ -1,24 +1,20 @@
 warning: Trait bound str: std::marker::Sized does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-inconsistent-sized.rs:24:1
+  --> $DIR/trivial-bounds-inconsistent-sized.rs:24:31
    |
 LL | struct S(str, str) where str: Sized;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                               ^^^^^
    |
    = note: #[warn(trivial_bounds)] on by default
 
 warning: Trait bound for<'a> T<(dyn A + 'a)>: std::marker::Sized does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-inconsistent-sized.rs:26:1
+  --> $DIR/trivial-bounds-inconsistent-sized.rs:26:45
    |
-LL | / fn unsized_local() where for<'a> T<A + 'a>: Sized {
-LL | |     let x: T<A> = *(Box::new(T { x: 1 }) as Box<T<A>>);
-LL | | }
-   | |_^
+LL | fn unsized_local() where for<'a> T<A + 'a>: Sized {
+   |                                             ^^^^^
 
 warning: Trait bound str: std::marker::Sized does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-inconsistent-sized.rs:30:1
+  --> $DIR/trivial-bounds-inconsistent-sized.rs:30:35
    |
-LL | / fn return_str() -> str where str: Sized {
-LL | |     *"Sized".to_string().into_boxed_str()
-LL | | }
-   | |_^
+LL | fn return_str() -> str where str: Sized {
+   |                                   ^^^^^
 

--- a/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-well-formed.stderr
+++ b/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-well-formed.stderr
@@ -1,20 +1,14 @@
 warning: Trait bound std::vec::Vec<str>: std::fmt::Debug does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-inconsistent-well-formed.rs:17:1
+  --> $DIR/trivial-bounds-inconsistent-well-formed.rs:17:30
    |
-LL | / pub fn foo() where Vec<str>: Debug, str: Copy {
-LL | |     let x = vec![*"1"];
-LL | |     println!("{:?}", x);
-LL | | }
-   | |_^
+LL | pub fn foo() where Vec<str>: Debug, str: Copy {
+   |                              ^^^^^
    |
    = note: #[warn(trivial_bounds)] on by default
 
 warning: Trait bound str: std::marker::Copy does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-inconsistent-well-formed.rs:17:1
+  --> $DIR/trivial-bounds-inconsistent-well-formed.rs:17:42
    |
-LL | / pub fn foo() where Vec<str>: Debug, str: Copy {
-LL | |     let x = vec![*"1"];
-LL | |     println!("{:?}", x);
-LL | | }
-   | |_^
+LL | pub fn foo() where Vec<str>: Debug, str: Copy {
+   |                                          ^^^^
 

--- a/src/test/ui/trivial-bounds/trivial-bounds-inconsistent.stderr
+++ b/src/test/ui/trivial-bounds/trivial-bounds-inconsistent.stderr
@@ -1,28 +1,28 @@
 warning: Trait bound i32: Foo does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-inconsistent.rs:24:1
+  --> $DIR/trivial-bounds-inconsistent.rs:24:19
    |
 LL | enum E where i32: Foo { V }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                   ^^^
    |
    = note: #[warn(trivial_bounds)] on by default
 
 warning: Trait bound i32: Foo does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-inconsistent.rs:26:1
+  --> $DIR/trivial-bounds-inconsistent.rs:26:21
    |
 LL | struct S where i32: Foo;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                     ^^^
 
 warning: Trait bound i32: Foo does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-inconsistent.rs:28:1
+  --> $DIR/trivial-bounds-inconsistent.rs:28:20
    |
 LL | trait T where i32: Foo {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                    ^^^
 
 warning: Trait bound i32: Foo does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-inconsistent.rs:30:1
+  --> $DIR/trivial-bounds-inconsistent.rs:30:20
    |
 LL | union U where i32: Foo { f: i32 }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                    ^^^
 
 warning: where clauses are not enforced in type aliases
   --> $DIR/trivial-bounds-inconsistent.rs:32:14
@@ -34,79 +34,56 @@ LL | type Y where i32: Foo = ();
    = help: the clause will not be checked when the type alias is used, and should be removed
 
 warning: Trait bound i32: Foo does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-inconsistent.rs:32:1
+  --> $DIR/trivial-bounds-inconsistent.rs:32:19
    |
 LL | type Y where i32: Foo = ();
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                   ^^^
 
 warning: Trait bound i32: Foo does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-inconsistent.rs:34:1
+  --> $DIR/trivial-bounds-inconsistent.rs:34:28
    |
-LL | / impl Foo for () where i32: Foo {
-LL | |     fn test(&self) {
-LL | |         3i32.test();
-LL | |         Foo::test(&4i32);
-LL | |         generic_function(5i32);
-LL | |     }
-LL | | }
-   | |_^
+LL | impl Foo for () where i32: Foo {
+   |                            ^^^
 
 warning: Trait bound i32: Foo does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-inconsistent.rs:42:1
+  --> $DIR/trivial-bounds-inconsistent.rs:42:19
    |
-LL | / fn f() where i32: Foo {
-LL | |     let s = S;
-LL | |     3i32.test();
-LL | |     Foo::test(&4i32);
-LL | |     generic_function(5i32);
-LL | | }
-   | |_^
+LL | fn f() where i32: Foo {
+   |                   ^^^
 
 warning: Trait bound &'static str: Foo does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-inconsistent.rs:49:1
+  --> $DIR/trivial-bounds-inconsistent.rs:49:28
    |
-LL | / fn g() where &'static str: Foo {
-LL | |     "Foo".test();
-LL | |     Foo::test(&"Foo");
-LL | |     generic_function("Foo");
-LL | | }
-   | |_^
+LL | fn g() where &'static str: Foo {
+   |                            ^^^
 
 warning: Trait bound str: std::marker::Sized does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-inconsistent.rs:63:1
+  --> $DIR/trivial-bounds-inconsistent.rs:63:37
    |
 LL | struct TwoStrs(str, str) where str: Sized;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                     ^^^^^
 
 warning: Trait bound for<'a> Dst<(dyn A + 'a)>: std::marker::Sized does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-inconsistent.rs:65:1
+  --> $DIR/trivial-bounds-inconsistent.rs:65:47
    |
-LL | / fn unsized_local() where for<'a> Dst<A + 'a>: Sized {
-LL | |     let x: Dst<A> = *(Box::new(Dst { x: 1 }) as Box<Dst<A>>);
-LL | | }
-   | |_^
+LL | fn unsized_local() where for<'a> Dst<A + 'a>: Sized {
+   |                                               ^^^^^
 
 warning: Trait bound str: std::marker::Sized does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-inconsistent.rs:69:1
+  --> $DIR/trivial-bounds-inconsistent.rs:69:35
    |
-LL | / fn return_str() -> str where str: Sized {
-LL | |     *"Sized".to_string().into_boxed_str()
-LL | | }
-   | |_^
+LL | fn return_str() -> str where str: Sized {
+   |                                   ^^^^^
 
 warning: Trait bound std::string::String: std::ops::Neg does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-inconsistent.rs:73:1
+  --> $DIR/trivial-bounds-inconsistent.rs:73:46
    |
-LL | / fn use_op(s: String) -> String where String: ::std::ops::Neg<Output=String> {
-LL | |     -s
-LL | | }
-   | |_^
+LL | fn use_op(s: String) -> String where String: ::std::ops::Neg<Output=String> {
+   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: Trait bound i32: std::iter::Iterator does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-inconsistent.rs:77:1
+  --> $DIR/trivial-bounds-inconsistent.rs:77:25
    |
-LL | / fn use_for() where i32: Iterator {
-LL | |     for _ in 2i32 {}
-LL | | }
-   | |_^
+LL | fn use_for() where i32: Iterator {
+   |                         ^^^^^^^^
 

--- a/src/test/ui/trivial-bounds/trivial-bounds-lint.stderr
+++ b/src/test/ui/trivial-bounds/trivial-bounds-lint.stderr
@@ -1,8 +1,8 @@
 error: Trait bound i32: std::marker::Copy does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-lint.rs:15:1
+  --> $DIR/trivial-bounds-lint.rs:15:21
    |
 LL | struct A where i32: Copy; //~ ERROR
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                     ^^^^
    |
 note: lint level defined here
   --> $DIR/trivial-bounds-lint.rs:13:9
@@ -11,40 +11,40 @@ LL | #![deny(trivial_bounds)]
    |         ^^^^^^^^^^^^^^
 
 error: Trait bound i32: X<()> does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-lint.rs:28:1
+  --> $DIR/trivial-bounds-lint.rs:28:30
    |
 LL | fn global_param() where i32: X<()> {} //~ ERROR
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                              ^^^^^
 
 error: Trait bound i32: Z does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-lint.rs:32:1
+  --> $DIR/trivial-bounds-lint.rs:32:35
    |
 LL | fn global_projection() where i32: Z<S = i32> {} //~ ERROR
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                   ^^^^^^^^^^
 
 error: Lifetime bound i32 : 'static does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-lint.rs:39:1
+  --> $DIR/trivial-bounds-lint.rs:39:34
    |
 LL | fn global_lifetimes() where i32: 'static, &'static str: 'static {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                  ^^^^^^^
 
 error: Lifetime bound &'static str : 'static does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-lint.rs:39:1
+  --> $DIR/trivial-bounds-lint.rs:39:57
    |
 LL | fn global_lifetimes() where i32: 'static, &'static str: 'static {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                                         ^^^^^^^
 
 error: Lifetime bound 'static : 'static does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-lint.rs:45:1
+  --> $DIR/trivial-bounds-lint.rs:45:37
    |
 LL | fn global_outlives() where 'static: 'static {} //~ ERROR
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                     ^^^^^^^
 
 error: Trait bound i32: std::marker::Copy does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-lint.rs:48:1
+  --> $DIR/trivial-bounds-lint.rs:48:46
    |
 LL | fn mixed_bounds<T: Copy>() where i32: X<T> + Copy {} //~ ERROR
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                              ^^^^
 
 error: aborting due to 7 previous errors
 


### PR DESCRIPTION
This should allow finer-grained diagnostics, including migration suggestions for #54090.
(Note that I haven't changed most of the users of `predicates_of` to use the new spans)

r? @nikomatsakis 