### PR TITLE
Switch linker for aarch64-pc-windows-msvc from LLD to MSVC

### DIFF
--- a/src/librustc_target/spec/aarch64_pc_windows_msvc.rs
+++ b/src/librustc_target/spec/aarch64_pc_windows_msvc.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use spec::{LinkerFlavor, Target, TargetResult, PanicStrategy, LldFlavor};
+use spec::{LinkerFlavor, Target, TargetResult, PanicStrategy};
 
 pub fn target() -> TargetResult {
     let mut base = super::windows_msvc_base::opts();
@@ -17,7 +17,6 @@ pub fn target() -> TargetResult {
 
     // FIXME: this shouldn't be panic=abort, it should be panic=unwind
     base.panic_strategy = PanicStrategy::Abort;
-    base.linker = Some("rust-lld".to_owned());
 
     Ok(Target {
         llvm_target: "aarch64-pc-windows-msvc".to_string(),
@@ -29,7 +28,7 @@ pub fn target() -> TargetResult {
         target_os: "windows".to_string(),
         target_env: "msvc".to_string(),
         target_vendor: "pc".to_string(),
-        linker_flavor: LinkerFlavor::Lld(LldFlavor::Link),
+        linker_flavor: LinkerFlavor::Msvc,
         options: base,
     })
 }


### PR DESCRIPTION
The MSVC linker does not seem to have the same problems with Rust symbols that LLD currently has on Windows (see https://github.com/rust-lang/rust/issues/54190#issuecomment-421288625). This PR makes MSVC the default linker for `aarch64-pc-windows-msvc`. 

r? @alexcrichton 