### PR TITLE
Issue 54246

### DIFF
--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -783,7 +783,7 @@ impl EarlyLintPass for DeprecatedAttr {
     fn check_attribute(&mut self, cx: &EarlyContext, attr: &ast::Attribute) {
         for &&(n, _, ref g) in &self.depr_attrs {
             if attr.name() == n {
-                if let &AttributeGate::Gated(Stability::Deprecated(link),
+                if let &AttributeGate::Gated(Stability::Deprecated(link, suggestion),
                                              ref name,
                                              ref reason,
                                              _) = g {
@@ -792,7 +792,7 @@ impl EarlyLintPass for DeprecatedAttr {
                     let mut err = cx.struct_span_lint(DEPRECATED, attr.span, &msg);
                     err.span_suggestion_short_with_applicability(
                         attr.span,
-                        "remove this attribute",
+                        suggestion.unwrap_or("remove this attribute"),
                         String::new(),
                         Applicability::MachineApplicable
                     );

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -1138,7 +1138,7 @@ pub const BUILTIN_ATTRIBUTES: &'static [(&'static str, AttributeType, AttributeG
      Gated(Stability::Deprecated("https://github.com/rust-lang/rust/issues/44489\
                                   #issuecomment-415140224"),
            "panic_implementation",
-           "This attribute was renamed to `panic_handler`",
+           "this attribute was renamed to `panic_handler`",
            cfg_fn!(panic_implementation))),
 
     // RFC 2070

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -711,7 +711,7 @@ pub enum AttributeGate {
 impl AttributeGate {
     fn is_deprecated(&self) -> bool {
         match *self {
-            Gated(Stability::Deprecated(_), ..) => true,
+            Gated(Stability::Deprecated(_, _), ..) => true,
             _ => false,
         }
     }
@@ -720,8 +720,9 @@ impl AttributeGate {
 #[derive(Copy, Clone, Debug)]
 pub enum Stability {
     Unstable,
-    // Argument is tracking issue link.
-    Deprecated(&'static str),
+    // First argument is tracking issue link; second argument is an optional
+    // help message, which defaults to "remove this attribute"
+    Deprecated(&'static str, Option<&'static str>),
 }
 
 // fn() is not Debug
@@ -1044,7 +1045,7 @@ pub const BUILTIN_ATTRIBUTES: &'static [(&'static str, AttributeType, AttributeG
     ("no_builtins", Whitelisted, Ungated),
     ("no_mangle", Whitelisted, Ungated),
     ("no_debug", Whitelisted, Gated(
-        Stability::Deprecated("https://github.com/rust-lang/rust/issues/29721"),
+        Stability::Deprecated("https://github.com/rust-lang/rust/issues/29721", None),
         "no_debug",
         "the `#[no_debug]` attribute was an experimental feature that has been \
          deprecated due to lack of demand",
@@ -1057,7 +1058,8 @@ pub const BUILTIN_ATTRIBUTES: &'static [(&'static str, AttributeType, AttributeG
                                                        cfg_fn!(omit_gdb_pretty_printer_section))),
     ("unsafe_destructor_blind_to_params",
      Normal,
-     Gated(Stability::Deprecated("https://github.com/rust-lang/rust/issues/34761"),
+     Gated(Stability::Deprecated("https://github.com/rust-lang/rust/issues/34761",
+                                 Some("replace this attribute with `#[may_dangle]`")),
            "dropck_parametricity",
            "unsafe_destructor_blind_to_params has been replaced by \
             may_dangle and will be removed in the future",
@@ -1136,7 +1138,8 @@ pub const BUILTIN_ATTRIBUTES: &'static [(&'static str, AttributeType, AttributeG
     ("panic_implementation",
      Normal,
      Gated(Stability::Deprecated("https://github.com/rust-lang/rust/issues/44489\
-                                  #issuecomment-415140224"),
+                                  #issuecomment-415140224",
+                                 Some("replace this attribute with `#[panic_handler]`")),
            "panic_implementation",
            "this attribute was renamed to `panic_handler`",
            cfg_fn!(panic_implementation))),

--- a/src/test/ui/feature-gates/feature-gate-dropck-ugeh-2.stderr
+++ b/src/test/ui/feature-gates/feature-gate-dropck-ugeh-2.stderr
@@ -2,7 +2,7 @@ error: use of deprecated attribute `dropck_parametricity`: unsafe_destructor_bli
   --> $DIR/feature-gate-dropck-ugeh-2.rs:17:5
    |
 LL |     #[unsafe_destructor_blind_to_params]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace this attribute with `#[may_dangle]`
    |
 note: lint level defined here
   --> $DIR/feature-gate-dropck-ugeh-2.rs:11:9

--- a/src/test/ui/feature-gates/feature-gate-panic-implementation.rs
+++ b/src/test/ui/feature-gates/feature-gate-panic-implementation.rs
@@ -15,7 +15,7 @@
 
 use core::panic::PanicInfo;
 
-#[panic_implementation] //~ ERROR This attribute was renamed to `panic_handler` (see issue #44489)
+#[panic_implementation] //~ ERROR this attribute was renamed to `panic_handler` (see issue #44489)
 fn panic(info: &PanicInfo) -> ! {
     loop {}
 }

--- a/src/test/ui/feature-gates/feature-gate-panic-implementation.stderr
+++ b/src/test/ui/feature-gates/feature-gate-panic-implementation.stderr
@@ -1,7 +1,7 @@
-error[E0658]: This attribute was renamed to `panic_handler` (see issue #44489)
+error[E0658]: this attribute was renamed to `panic_handler` (see issue #44489)
   --> $DIR/feature-gate-panic-implementation.rs:18:1
    |
-LL | #[panic_implementation] //~ ERROR This attribute was renamed to `panic_handler` (see issue #44489)
+LL | #[panic_implementation] //~ ERROR this attribute was renamed to `panic_handler` (see issue #44489)
    | ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add #![feature(panic_implementation)] to the crate attributes to enable

--- a/src/test/ui/panic-implementation/panic-implementation-deprecated.stderr
+++ b/src/test/ui/panic-implementation/panic-implementation-deprecated.stderr
@@ -1,4 +1,4 @@
-error: use of deprecated attribute `panic_implementation`: This attribute was renamed to `panic_handler`. See https://github.com/rust-lang/rust/issues/44489#issuecomment-415140224
+error: use of deprecated attribute `panic_implementation`: this attribute was renamed to `panic_handler`. See https://github.com/rust-lang/rust/issues/44489#issuecomment-415140224
   --> $DIR/panic-implementation-deprecated.rs:19:1
    |
 LL | #[panic_implementation]

--- a/src/test/ui/panic-implementation/panic-implementation-deprecated.stderr
+++ b/src/test/ui/panic-implementation/panic-implementation-deprecated.stderr
@@ -2,7 +2,7 @@ error: use of deprecated attribute `panic_implementation`: this attribute was re
   --> $DIR/panic-implementation-deprecated.rs:19:1
    |
 LL | #[panic_implementation]
-   | ^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   | ^^^^^^^^^^^^^^^^^^^^^^^ help: replace this attribute with `#[panic_handler]`
    |
 note: lint level defined here
   --> $DIR/panic-implementation-deprecated.rs:13:9


### PR DESCRIPTION
I added the option of providing a help message for deprecated features, that takes precedence over the default `help: remove this attribute` message, along with messages for the features that mention replacements in the reason for deprecation.

Fixes #54246.