### PR TITLE
[beta] Prepare the 1.30.0 release

### DIFF
--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -51,7 +51,7 @@ fi
 #
 # FIXME: need a scheme for changing this `nightly` value to `beta` and `stable`
 #        either automatically or manually.
-export RUST_RELEASE_CHANNEL=nightly
+export RUST_RELEASE_CHANNEL=beta
 if [ "$DEPLOY$DEPLOY_ALT" != "" ]; then
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --release-channel=$RUST_RELEASE_CHANNEL"
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-llvm-static-stdcpp"

--- a/src/stage0.txt
+++ b/src/stage0.txt
@@ -12,9 +12,9 @@
 # source tarball for a stable release you'll likely see `1.x.0` for rustc and
 # `0.x.0` for Cargo where they were released on `date`.
 
-date: 2018-09-11
-rustc: beta
-cargo: beta
+date: 2018-09-13
+rustc: 1.29.0
+cargo: 0.30.0
 
 # When making a stable release the process currently looks like:
 #


### PR DESCRIPTION
This commit prepares the 1.30.0 beta release for the newly branched beta branch.