### PR TITLE
[WIP] rustc: check that type alias where clauses are well-formed.

### DIFF
--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -124,6 +124,13 @@ pub fn check_item_well_formed<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: Def
         hir::ItemKind::Const(..) => {
             check_item_type(tcx, item);
         }
+        hir::ItemKind::Ty(..) => {
+            for_item(tcx, item).with_fcx(|fcx, _this| {
+                let def_id = fcx.tcx.hir.local_def_id(item.id);
+                check_where_clauses(tcx, fcx, item.span, def_id, None);
+                vec![]
+            });
+        }
         hir::ItemKind::Struct(ref struct_def, ref ast_generics) => {
             check_type_defn(tcx, item, false, |fcx| {
                 vec![fcx.non_enum_variant(struct_def)]

--- a/src/test/ui/feature-gates/feature-gate-trivial_bounds.rs
+++ b/src/test/ui/feature-gates/feature-gate-trivial_bounds.rs
@@ -25,7 +25,7 @@ trait T where i32: Foo {} //~ ERROR
 
 union U where i32: Foo { f: i32 } //~ ERROR
 
-type Y where i32: Foo = (); // OK - bound is ignored
+type Y where i32: Foo = (); //~ ERROR
 
 impl Foo for () where i32: Foo { //~ ERROR
     fn test(&self) {

--- a/src/test/ui/feature-gates/feature-gate-trivial_bounds.stderr
+++ b/src/test/ui/feature-gates/feature-gate-trivial_bounds.stderr
@@ -35,6 +35,15 @@ LL | union U where i32: Foo { f: i32 } //~ ERROR
    = help: add #![feature(trivial_bounds)] to the crate attributes to enable
 
 error[E0277]: the trait bound `i32: Foo` is not satisfied
+  --> $DIR/feature-gate-trivial_bounds.rs:28:1
+   |
+LL | type Y where i32: Foo = (); //~ ERROR
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `i32`
+   |
+   = help: see issue #48214
+   = help: add #![feature(trivial_bounds)] to the crate attributes to enable
+
+error[E0277]: the trait bound `i32: Foo` is not satisfied
   --> $DIR/feature-gate-trivial_bounds.rs:30:1
    |
 LL | / impl Foo for () where i32: Foo { //~ ERROR
@@ -125,6 +134,6 @@ LL | | }
    = help: see issue #48214
    = help: add #![feature(trivial_bounds)] to the crate attributes to enable
 
-error: aborting due to 11 previous errors
+error: aborting due to 12 previous errors
 
 For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Unlike https://github.com/rust-lang/rust/pull/54033#issuecomment-422259555 /  https://github.com/rust-lang/rust/issues/49441#issuecomment-422258528, I suspect that "where clauses well-formedness" holds much more commonly than "enough bounds for the aliased type" (as the latter is by omission).
What that means is that *the bounds themselves*, and type parameter defaults, are checked.

**TODO**: provide proper examples and tests.

I'm primarily opening this PR to do a crater run, *hoping* for 0 regressions. If the number of regressions is non-0 but small, I'll include it in #54090, as that PR is likely wrong for non-WF bounds.

r? @nikomatsakis cc @Centril 