### PR TITLE
NLL: regression test for "dropck: track order of destruction for r-value temporaries"

### DIFF
--- a/src/test/ui/nll/issue-22323-temp-destruction.rs
+++ b/src/test/ui/nll/issue-22323-temp-destruction.rs
@@ -1,0 +1,32 @@
+// rust-lang/rust#22323: regression test demonstrating that NLL
+// precisely tracks temporary destruction order.
+
+// compile-pass
+
+#![feature(nll)]
+
+fn main() {
+    let _s = construct().borrow().consume_borrowed();
+}
+
+fn construct() -> Value { Value }
+
+pub struct Value;
+
+impl Value {
+    fn borrow<'a>(&'a self) -> Borrowed<'a> { unimplemented!() }
+}
+
+pub struct Borrowed<'a> {
+    _inner: Guard<'a, Value>,
+}
+
+impl<'a> Borrowed<'a> {
+    fn consume_borrowed(self) -> String { unimplemented!() }
+}
+
+pub struct Guard<'a, T: ?Sized + 'a> {
+    _lock: &'a T,
+}
+
+impl<'a, T: ?Sized> Drop for Guard<'a, T> { fn drop(&mut self) {} }


### PR DESCRIPTION
Once this lands, we can remove the E-needstest from #22323.

(We shouldn't close the bug itself, however, because we are leaving the NLL-fixed-by-NLL bugs open until NLL is turned on by default.)