### PR TITLE
Emit used rustc invocation in the save-analysis file

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -2373,6 +2373,7 @@ dependencies = [
  "rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc 0.0.0",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_codegen_utils 0.0.0",
  "rustc_data_structures 0.0.0",
  "rustc_target 0.0.0",
  "rustc_typeck 0.0.0",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -57,6 +57,7 @@ cargo = { path = "tools/cargo" }
 # that we're shipping as well (to ensure that the rustfmt in RLS and the
 # `rustfmt` executable are the same exact version).
 rustfmt-nightly = { path = "tools/rustfmt" }
+rls-data = { git = "https://github.com/Xanewok/rls-data", branch = "compilation-options" }
 
 # See comments in `tools/rustc-workspace-hack/README.md` for what's going on
 # here

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -57,7 +57,6 @@ cargo = { path = "tools/cargo" }
 # that we're shipping as well (to ensure that the rustfmt in RLS and the
 # `rustfmt` executable are the same exact version).
 rustfmt-nightly = { path = "tools/rustfmt" }
-rls-data = { git = "https://github.com/Xanewok/rls-data", branch = "compilation-options" }
 
 # See comments in `tools/rustc-workspace-hack/README.md` for what's going on
 # here

--- a/src/librustc_codegen_llvm/back/link.rs
+++ b/src/librustc_codegen_llvm/back/link.rs
@@ -47,7 +47,8 @@ use std::str;
 use syntax::attr;
 
 pub use rustc_codegen_utils::link::{find_crate_name, filename_for_input, default_output_for_target,
-                                  invalid_output_for_target, out_filename, check_file_is_writeable};
+                                  invalid_output_for_target, out_filename, check_file_is_writeable,
+                                  filename_for_metadata};
 
 // The third parameter is for env vars, used on windows to set up the
 // path for MSVC to find its DLLs, and gcc to find its bundled
@@ -216,15 +217,6 @@ fn preserve_objects_for_their_debuginfo(sess: &Session) -> bool {
     }
 
     false
-}
-
-fn filename_for_metadata(sess: &Session, crate_name: &str, outputs: &OutputFilenames) -> PathBuf {
-    let out_filename = outputs.single_output_file.clone()
-        .unwrap_or(outputs
-            .out_directory
-            .join(&format!("lib{}{}.rmeta", crate_name, sess.opts.cg.extra_filename)));
-    check_file_is_writeable(&out_filename, sess);
-    out_filename
 }
 
 pub(crate) fn each_linked_rlib(sess: &Session,

--- a/src/librustc_codegen_utils/link.rs
+++ b/src/librustc_codegen_utils/link.rs
@@ -97,6 +97,19 @@ pub fn find_crate_name(sess: Option<&Session>,
     "rust_out".to_string()
 }
 
+pub fn filename_for_metadata(sess: &Session,
+                             crate_name: &str,
+                             outputs: &OutputFilenames) -> PathBuf {
+    let libname = format!("{}{}", crate_name, sess.opts.cg.extra_filename);
+
+    let out_filename = outputs.single_output_file.clone()
+        .unwrap_or(outputs.out_directory.join(&format!("lib{}.rmeta", libname)));
+
+    check_file_is_writeable(&out_filename, sess);
+
+    out_filename
+}
+
 pub fn filename_for_input(sess: &Session,
                           crate_type: config::CrateType,
                           crate_name: &str,

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -980,6 +980,7 @@ pub fn enable_save_analysis(control: &mut CompileController) {
                                 state.expanded_crate.unwrap(),
                                 state.analysis.unwrap(),
                                 state.crate_name.unwrap(),
+                                state.input,
                                 None,
                                 DumpHandler::new(state.out_dir,
                                                  state.crate_name.unwrap()))

--- a/src/librustc_save_analysis/Cargo.toml
+++ b/src/librustc_save_analysis/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["dylib"]
 log = "0.4"
 rustc = { path = "../librustc" }
 rustc_data_structures = { path = "../librustc_data_structures" }
+rustc_codegen_utils = { path = "../librustc_codegen_utils" }
 rustc_target = { path = "../librustc_target" }
 rustc_typeck = { path = "../librustc_typeck" }
 syntax = { path = "../libsyntax" }

--- a/src/librustc_save_analysis/dump_visitor.rs
+++ b/src/librustc_save_analysis/dump_visitor.rs
@@ -51,10 +51,8 @@ use json_dumper::{Access, DumpOutput, JsonDumper};
 use span_utils::SpanUtils;
 use sig;
 
-use rls_data::{
-    CompilationOptions, CratePreludeData, Def, DefKind, GlobalCrateId, Import, ImportKind, Ref,
-    RefKind, Relation, RelationKind, SpanData,
-};
+use rls_data::{CompilationOptions, CratePreludeData, Def, DefKind, GlobalCrateId, Import,
+               ImportKind, Ref, RefKind, Relation, RelationKind, SpanData};
 
 macro_rules! down_cast_data {
     ($id:ident, $kind:ident, $sp:expr) => {

--- a/src/librustc_save_analysis/json_dumper.rs
+++ b/src/librustc_save_analysis/json_dumper.rs
@@ -12,9 +12,11 @@ use std::io::Write;
 
 use rustc_serialize::json::as_json;
 
-use rls_data::{self, Analysis, CratePreludeData, Def, DefKind, Import, MacroRef, Ref, RefKind,
-               Relation, Impl};
 use rls_data::config::Config;
+use rls_data::{
+    self, Analysis, CompilationOptions, CratePreludeData, Def, DefKind, Impl, Import, MacroRef,
+    Ref, RefKind, Relation,
+};
 use rls_span::{Column, Row};
 
 #[derive(Debug)]
@@ -87,6 +89,10 @@ impl<O: DumpOutput> Drop for JsonDumper<O> {
 impl<'b, O: DumpOutput + 'b> JsonDumper<O> {
     pub fn crate_prelude(&mut self, data: CratePreludeData) {
         self.result.prelude = Some(data)
+    }
+
+    pub fn compilation_opts(&mut self, data: CompilationOptions) {
+        self.result.compilation = Some(data);
     }
 
     pub fn macro_use(&mut self, data: MacroRef) {

--- a/src/librustc_save_analysis/json_dumper.rs
+++ b/src/librustc_save_analysis/json_dumper.rs
@@ -13,10 +13,8 @@ use std::io::Write;
 use rustc_serialize::json::as_json;
 
 use rls_data::config::Config;
-use rls_data::{
-    self, Analysis, CompilationOptions, CratePreludeData, Def, DefKind, Impl, Import, MacroRef,
-    Ref, RefKind, Relation,
-};
+use rls_data::{self, Analysis, CompilationOptions, CratePreludeData, Def, DefKind, Impl, Import,
+               MacroRef, Ref, RefKind, Relation};
 use rls_span::{Column, Row};
 
 #[derive(Debug)]

--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -72,11 +72,10 @@ use json_dumper::JsonDumper;
 use dump_visitor::DumpVisitor;
 use span_utils::SpanUtils;
 
+use rls_data::{Def, DefKind, ExternalCrateData, GlobalCrateId, MacroRef, Ref, RefKind, Relation,
+               RelationKind, SpanData, Impl, ImplKind};
 use rls_data::config::Config;
-use rls_data::{
-    Def, DefKind, ExternalCrateData, GlobalCrateId, Impl, ImplKind, MacroRef, Ref,
-    RefKind, Relation, RelationKind, SpanData,
-};
+
 
 pub struct SaveContext<'l, 'tcx: 'l> {
     tcx: TyCtxt<'l, 'tcx, 'tcx>,
@@ -144,7 +143,6 @@ impl<'l, 'tcx: 'l> SaveContext<'l, 'tcx> {
                 }
             };
             let lo_loc = self.span_utils.sess.source_map().lookup_char_pos(span.lo());
-
             result.push(ExternalCrateData {
                 // FIXME: change file_name field to PathBuf in rls-data
                 // https://github.com/nrc/rls-data/issues/7

--- a/src/librustc_save_analysis/span_utils.rs
+++ b/src/librustc_save_analysis/span_utils.rs
@@ -35,14 +35,17 @@ impl<'a> SpanUtils<'a> {
         }
     }
 
-    pub fn make_path_string(&self, path: &FileName) -> String {
-        match *path {
-            FileName::Real(ref path) if !path.is_absolute() =>
+    pub fn make_filename_string(&self, file: &SourceFile) -> String {
+        match &file.name {
+            FileName::Real(path) if !path.is_absolute() && !file.name_was_remapped => {
                 self.sess.working_dir.0
                     .join(&path)
                     .display()
-                    .to_string(),
-            _ => path.to_string(),
+                    .to_string()
+            },
+            // If the file name is already remapped, we assume the user
+            // configured it the way they wanted to, so use that directly
+            filename => filename.to_string()
         }
     }
 

--- a/src/librustc_save_analysis/span_utils.rs
+++ b/src/librustc_save_analysis/span_utils.rs
@@ -37,11 +37,18 @@ impl<'a> SpanUtils<'a> {
 
     pub fn make_filename_string(&self, file: &SourceFile) -> String {
         match &file.name {
-            FileName::Real(path) if !path.is_absolute() && !file.name_was_remapped => {
-                self.sess.working_dir.0
-                    .join(&path)
-                    .display()
-                    .to_string()
+            FileName::Real(path) if !file.name_was_remapped => {
+                if path.is_absolute() {
+                    self.sess.source_map().path_mapping()
+                        .map_prefix(path.clone()).0
+                        .display()
+                        .to_string()
+                } else {
+                    self.sess.working_dir.0
+                        .join(&path)
+                        .display()
+                        .to_string()
+                }
             },
             // If the file name is already remapped, we assume the user
             // configured it the way they wanted to, so use that directly


### PR DESCRIPTION
Blocked on https://github.com/nrc/rls-data/pull/19. (I'm guessing it won't pass CI due to an out-of-tree git dependency)

This should allow RLS to recreate a Rust compilation build plan from the save-analysis files alone, which should be useful when fetching those from external build systems, most notably Buck now.

Also this includes some more potentially useful compilation-specific options (e.g. sysroot or the actual path to extern crates) but that's not required for the build plan bits.

cc @jsgf @alexcrichton 

r? @nrc