### PR TITLE
Use get_unchecked(_mut) in first(_mut) and last(_mut)

### DIFF
--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -119,7 +119,7 @@ impl<T> [T] {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn first(&self) -> Option<&T> {
-        if self.is_empty() { None } else { Some(&self[0]) }
+        if self.is_empty() { None } else { unsafe { Some(self.get_unchecked(0)) } }
     }
 
     /// Returns a mutable pointer to the first element of the slice, or `None` if it is empty.
@@ -137,7 +137,7 @@ impl<T> [T] {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn first_mut(&mut self) -> Option<&mut T> {
-        if self.is_empty() { None } else { Some(&mut self[0]) }
+        if self.is_empty() { None } else { unsafe { Some(self.get_unchecked_mut(0)) } }
     }
 
     /// Returns the first and all the rest of the elements of the slice, or `None` if it is empty.
@@ -239,7 +239,7 @@ impl<T> [T] {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn last(&self) -> Option<&T> {
-        if self.is_empty() { None } else { Some(&self[self.len() - 1]) }
+        if self.is_empty() { None } else { unsafe { Some(self.get_unchecked(self.len() - 1)) } }
     }
 
     /// Returns a mutable pointer to the last item in the slice.
@@ -257,9 +257,12 @@ impl<T> [T] {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn last_mut(&mut self) -> Option<&mut T> {
-        let len = self.len();
-        if len == 0 { return None; }
-        Some(&mut self[len - 1])
+        if self.is_empty() {
+            None
+        } else {
+            let last_idx = self.len() - 1;
+            unsafe { Some(self.get_unchecked_mut(last_idx)) }
+        }
     }
 
     /// Returns a reference to an element or subslice depending on the type of


### PR DESCRIPTION
Since all these methods first check if the slice is empty, the bounds check required by indexation is redundant and the use of `get_unchecked(_mut)` is perfectly safe.