### PR TITLE
Pass --batch to gdb

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -301,7 +301,7 @@ after_failure:
       EXE=$(echo $CORE | sed 's|obj/cores/core\.[0-9]*\.!checkout!\(.*\)|\1|;y|!|/|');
       if [ -f "$EXE" ]; then
         printf travis_fold":start:crashlog\n\033[31;1m%s\033[0m\n" "$CORE";
-        gdb -q -c "$CORE" "$EXE"
+        gdb --batch -q -c "$CORE" "$EXE"
           -iex 'set auto-load off'
           -iex 'dir src/'
           -iex 'set sysroot .'


### PR DESCRIPTION
In one of my travis builds, I was surprised to find that the gdb
pager was in use and caused travis to time out.  Adding `--batch`
to the gdb invocation will disable the pager.  Note that the
`-ex q` is retained, to make sure gdb exits with status 0, just in
case `set -e` is in effect somehow.