### PR TITLE
add -Zui-testing to rustdoc

### DIFF
--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -263,6 +263,7 @@ impl DocAccessLevels for AccessLevels<DefId> {
 pub fn new_handler(error_format: ErrorOutputType,
                    source_map: Option<Lrc<source_map::SourceMap>>,
                    treat_err_as_bug: bool,
+                   ui_testing: bool,
 ) -> errors::Handler {
     // rustdoc doesn't override (or allow to override) anything from this that is relevant here, so
     // stick to the defaults
@@ -274,7 +275,7 @@ pub fn new_handler(error_format: ErrorOutputType,
                 source_map.map(|cm| cm as _),
                 false,
                 sessopts.debugging_opts.teach,
-            ).ui_testing(sessopts.debugging_opts.ui_testing)
+            ).ui_testing(ui_testing)
         ),
         ErrorOutputType::Json(pretty) => {
             let source_map = source_map.unwrap_or_else(
@@ -284,7 +285,7 @@ pub fn new_handler(error_format: ErrorOutputType,
                     None,
                     source_map,
                     pretty,
-                ).ui_testing(sessopts.debugging_opts.ui_testing)
+                ).ui_testing(ui_testing)
             )
         },
         ErrorOutputType::Short(color_config) => Box::new(
@@ -326,6 +327,7 @@ pub fn run_core(search_paths: SearchPaths,
                 mut manual_passes: Vec<String>,
                 mut default_passes: passes::DefaultPassOption,
                 treat_err_as_bug: bool,
+                ui_testing: bool,
 ) -> (clean::Crate, RenderInfo, Vec<String>) {
     // Parse, resolve, and typecheck the given crate.
 
@@ -380,6 +382,8 @@ pub fn run_core(search_paths: SearchPaths,
         actually_rustdoc: true,
         debugging_opts: config::DebuggingOptions {
             force_unstable_if_unmarked,
+            treat_err_as_bug,
+            ui_testing,
             ..config::basic_debugging_options()
         },
         error_format,
@@ -391,7 +395,8 @@ pub fn run_core(search_paths: SearchPaths,
         let source_map = Lrc::new(source_map::SourceMap::new(sessopts.file_path_mapping()));
         let diagnostic_handler = new_handler(error_format,
                                              Some(source_map.clone()),
-                                             treat_err_as_bug);
+                                             treat_err_as_bug,
+                                             ui_testing);
 
         let mut sess = session::build_session_(
             sessopts, cpath, diagnostic_handler, source_map,

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -407,8 +407,11 @@ fn main_args(args: &[String]) -> isize {
     let treat_err_as_bug = matches.opt_strs("Z").iter().any(|x| {
         *x == "treat-err-as-bug"
     });
+    let ui_testing = matches.opt_strs("Z").iter().any(|x| {
+        *x == "ui-testing"
+    });
 
-    let diag = core::new_handler(error_format, None, treat_err_as_bug);
+    let diag = core::new_handler(error_format, None, treat_err_as_bug, ui_testing);
 
     // check for deprecated options
     check_deprecated_options(&matches, &diag);
@@ -563,7 +566,7 @@ fn main_args(args: &[String]) -> isize {
     let res = acquire_input(PathBuf::from(input), externs, edition, cg, &matches, error_format,
                             move |out| {
         let Output { krate, passes, renderinfo } = out;
-        let diag = core::new_handler(error_format, None, treat_err_as_bug);
+        let diag = core::new_handler(error_format, None, treat_err_as_bug, ui_testing);
         info!("going to format");
         match output_format.as_ref().map(|s| &**s) {
             Some("html") | None => {
@@ -700,6 +703,9 @@ where R: 'static + Send,
     let treat_err_as_bug = matches.opt_strs("Z").iter().any(|x| {
         *x == "treat-err-as-bug"
     });
+    let ui_testing = matches.opt_strs("Z").iter().any(|x| {
+        *x == "ui-testing"
+    });
 
     let (lint_opts, describe_lints, lint_cap) = get_cmd_lint_options(matches, error_format);
 
@@ -713,7 +719,7 @@ where R: 'static + Send,
                            display_warnings, crate_name.clone(),
                            force_unstable_if_unmarked, edition, cg, error_format,
                            lint_opts, lint_cap, describe_lints, manual_passes, default_passes,
-                           treat_err_as_bug);
+                           treat_err_as_bug, ui_testing);
 
         info!("finished with rustc");
 

--- a/src/test/rustdoc-ui/deny-intra-link-resolution-failure.stderr
+++ b/src/test/rustdoc-ui/deny-intra-link-resolution-failure.stderr
@@ -1,13 +1,13 @@
 error: `[v2]` cannot be resolved, ignoring it...
   --> $DIR/deny-intra-link-resolution-failure.rs:13:6
    |
-13 | /// [v2] //~ ERROR
+LL | /// [v2] //~ ERROR
    |      ^^ cannot be resolved, ignoring
    |
 note: lint level defined here
   --> $DIR/deny-intra-link-resolution-failure.rs:11:9
    |
-11 | #![deny(intra_doc_link_resolution_failure)]
+LL | #![deny(intra_doc_link_resolution_failure)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: to escape `[` and `]` characters, just add '/' before them like `/[` or `/]`
 

--- a/src/test/rustdoc-ui/deprecated-attrs.stderr
+++ b/src/test/rustdoc-ui/deprecated-attrs.stderr
@@ -1,9 +1,9 @@
 warning: the `#![doc(no_default_passes)]` attribute is considered deprecated
-  |
-  = warning: please see https://github.com/rust-lang/rust/issues/44136
-  = help: you may want to use `#![doc(document_private_items)]`
+   |
+   = warning: please see https://github.com/rust-lang/rust/issues/44136
+   = help: you may want to use `#![doc(document_private_items)]`
 
 warning: the `#![doc(passes = "...")]` attribute is considered deprecated
-  |
-  = warning: please see https://github.com/rust-lang/rust/issues/44136
+   |
+   = warning: please see https://github.com/rust-lang/rust/issues/44136
 

--- a/src/test/rustdoc-ui/intra-doc-alias-ice.stderr
+++ b/src/test/rustdoc-ui/intra-doc-alias-ice.stderr
@@ -1,13 +1,13 @@
 error: `[TypeAlias::hoge]` cannot be resolved, ignoring it...
   --> $DIR/intra-doc-alias-ice.rs:15:30
    |
-15 | /// [broken cross-reference](TypeAlias::hoge) //~ ERROR
+LL | /// [broken cross-reference](TypeAlias::hoge) //~ ERROR
    |                              ^^^^^^^^^^^^^^^ cannot be resolved, ignoring
    |
 note: lint level defined here
   --> $DIR/intra-doc-alias-ice.rs:11:9
    |
-11 | #![deny(intra_doc_link_resolution_failure)]
+LL | #![deny(intra_doc_link_resolution_failure)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: to escape `[` and `]` characters, just add '/' before them like `/[` or `/]`
 

--- a/src/test/rustdoc-ui/intra-links-warning.stderr
+++ b/src/test/rustdoc-ui/intra-links-warning.stderr
@@ -1,7 +1,7 @@
 warning: `[Foo::baz]` cannot be resolved, ignoring it...
   --> $DIR/intra-links-warning.rs:13:23
    |
-13 |        //! Test with [Foo::baz], [Bar::foo], ...
+LL |        //! Test with [Foo::baz], [Bar::foo], ...
    |                       ^^^^^^^^ cannot be resolved, ignoring
    |
    = note: #[warn(intra_doc_link_resolution_failure)] on by default
@@ -10,7 +10,7 @@ warning: `[Foo::baz]` cannot be resolved, ignoring it...
 warning: `[Bar::foo]` cannot be resolved, ignoring it...
   --> $DIR/intra-links-warning.rs:13:35
    |
-13 |        //! Test with [Foo::baz], [Bar::foo], ...
+LL |        //! Test with [Foo::baz], [Bar::foo], ...
    |                                   ^^^^^^^^ cannot be resolved, ignoring
    |
    = help: to escape `[` and `]` characters, just add '/' before them like `/[` or `/]`
@@ -18,7 +18,7 @@ warning: `[Bar::foo]` cannot be resolved, ignoring it...
 warning: `[Uniooon::X]` cannot be resolved, ignoring it...
   --> $DIR/intra-links-warning.rs:14:13
    |
-14 |      //! , [Uniooon::X] and [Qux::Z].
+LL |      //! , [Uniooon::X] and [Qux::Z].
    |             ^^^^^^^^^^ cannot be resolved, ignoring
    |
    = help: to escape `[` and `]` characters, just add '/' before them like `/[` or `/]`
@@ -26,7 +26,7 @@ warning: `[Uniooon::X]` cannot be resolved, ignoring it...
 warning: `[Qux::Z]` cannot be resolved, ignoring it...
   --> $DIR/intra-links-warning.rs:14:30
    |
-14 |      //! , [Uniooon::X] and [Qux::Z].
+LL |      //! , [Uniooon::X] and [Qux::Z].
    |                              ^^^^^^ cannot be resolved, ignoring
    |
    = help: to escape `[` and `]` characters, just add '/' before them like `/[` or `/]`
@@ -34,7 +34,7 @@ warning: `[Qux::Z]` cannot be resolved, ignoring it...
 warning: `[Uniooon::X]` cannot be resolved, ignoring it...
   --> $DIR/intra-links-warning.rs:16:14
    |
-16 |       //! , [Uniooon::X] and [Qux::Z].
+LL |       //! , [Uniooon::X] and [Qux::Z].
    |              ^^^^^^^^^^ cannot be resolved, ignoring
    |
    = help: to escape `[` and `]` characters, just add '/' before them like `/[` or `/]`
@@ -42,7 +42,7 @@ warning: `[Uniooon::X]` cannot be resolved, ignoring it...
 warning: `[Qux::Z]` cannot be resolved, ignoring it...
   --> $DIR/intra-links-warning.rs:16:31
    |
-16 |       //! , [Uniooon::X] and [Qux::Z].
+LL |       //! , [Uniooon::X] and [Qux::Z].
    |                               ^^^^^^ cannot be resolved, ignoring
    |
    = help: to escape `[` and `]` characters, just add '/' before them like `/[` or `/]`
@@ -50,7 +50,7 @@ warning: `[Qux::Z]` cannot be resolved, ignoring it...
 warning: `[Qux:Y]` cannot be resolved, ignoring it...
   --> $DIR/intra-links-warning.rs:18:13
    |
-18 |        /// [Qux:Y]
+LL |        /// [Qux:Y]
    |             ^^^^^ cannot be resolved, ignoring
    |
    = help: to escape `[` and `]` characters, just add '/' before them like `/[` or `/]`
@@ -58,7 +58,7 @@ warning: `[Qux:Y]` cannot be resolved, ignoring it...
 warning: `[BarA]` cannot be resolved, ignoring it...
   --> $DIR/intra-links-warning.rs:24:10
    |
-24 | /// bar [BarA] bar
+LL | /// bar [BarA] bar
    |          ^^^^ cannot be resolved, ignoring
    |
    = help: to escape `[` and `]` characters, just add '/' before them like `/[` or `/]`
@@ -66,11 +66,11 @@ warning: `[BarA]` cannot be resolved, ignoring it...
 warning: `[BarB]` cannot be resolved, ignoring it...
   --> $DIR/intra-links-warning.rs:28:1
    |
-28 | / /**
-29 | |  * Foo
-30 | |  * bar [BarB] bar
-31 | |  * baz
-32 | |  */
+LL | / /**
+LL | |  * Foo
+LL | |  * bar [BarB] bar
+LL | |  * baz
+LL | |  */
    | |___^
    |
    = note: the link appears in this line:
@@ -82,13 +82,13 @@ warning: `[BarB]` cannot be resolved, ignoring it...
 warning: `[BarC]` cannot be resolved, ignoring it...
   --> $DIR/intra-links-warning.rs:35:1
    |
-35 | / /** Foo
-36 | |
-37 | | bar [BarC] bar
-38 | | baz
+LL | / /** Foo
+LL | |
+LL | | bar [BarC] bar
+LL | | baz
 ...  |
-44 | |
-45 | | */
+LL | |
+LL | | */
    | |__^
    |
    = note: the link appears in this line:
@@ -100,7 +100,7 @@ warning: `[BarC]` cannot be resolved, ignoring it...
 warning: `[BarD]` cannot be resolved, ignoring it...
   --> $DIR/intra-links-warning.rs:48:1
    |
-48 | #[doc = "Foo/nbar [BarD] bar/nbaz"]
+LL | #[doc = "Foo/nbar [BarD] bar/nbaz"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: the link appears in this line:
@@ -112,10 +112,10 @@ warning: `[BarD]` cannot be resolved, ignoring it...
 warning: `[BarF]` cannot be resolved, ignoring it...
   --> $DIR/intra-links-warning.rs:53:9
    |
-53 |         #[doc = $f]
+LL |         #[doc = $f]
    |         ^^^^^^^^^^^
 ...
-57 | f!("Foo/nbar [BarF] bar/nbaz");
+LL | f!("Foo/nbar [BarF] bar/nbaz");
    | ------------------------------- in this macro invocation
    |
    = note: the link appears in this line:


### PR DESCRIPTION
Before we depend on the `rustdoc-ui` tests some more, let's make rustdoc act the same as the compiler when they're actually being executed.