### PR TITLE
Add 'Span::len()' and 'Span::trimmed()' proc-macro methods.

### DIFF
--- a/src/test/ui-fulldeps/proc-macro/auxiliary/trimmed-span.rs
+++ b/src/test/ui-fulldeps/proc-macro/auxiliary/trimmed-span.rs
@@ -1,0 +1,48 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+#![feature(proc_macro_diagnostic, proc_macro_span)]
+
+extern crate proc_macro;
+
+use proc_macro::{TokenStream, TokenTree, Span, Diagnostic};
+
+fn parse(input: TokenStream) -> Result<(), Diagnostic> {
+    if let Some(TokenTree::Literal(lit)) = input.into_iter().next() {
+        let mut spans = vec![];
+        let string = lit.to_string();
+        for hi in string.matches("hi") {
+            let index = hi.as_ptr() as usize - string.as_ptr() as usize;
+            let remaining = string.len() - (index + 2);
+            let sub_span = lit.span().trimmed(index, remaining).unwrap();
+            spans.push(sub_span);
+        }
+
+        if !spans.is_empty() {
+            Err(Span::call_site().error("found 'hi's").span_note(spans, "here"))
+        } else {
+            Ok(())
+        }
+    } else {
+        Err(Span::call_site().error("invalid input: expected string literal"))
+    }
+}
+
+#[proc_macro]
+pub fn trimmed(input: TokenStream) -> TokenStream {
+    if let Err(diag) = parse(input) {
+        diag.emit();
+    }
+
+    TokenStream::new()
+}

--- a/src/test/ui-fulldeps/proc-macro/trimmed-span.rs
+++ b/src/test/ui-fulldeps/proc-macro/trimmed-span.rs
@@ -1,0 +1,39 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:trimmed-span.rs
+// ignore-stage1
+
+#![feature(proc_macro_non_items)]
+
+extern crate trimmed_span;
+
+use trimmed_span::trimmed;
+
+fn main() {
+    // This one emits no error.
+    trimmed!("");
+
+    // Exactly one 'hi'.
+    trimmed!("hi"); //~ ERROR found 'hi's
+
+    // Now two, back to back.
+    trimmed!("hihi"); //~ ERROR found 'hi's
+
+    // Now three, back to back.
+    trimmed!("hihihi"); //~ ERROR found 'hi's
+
+    // Now several, with spacing.
+    trimmed!("why I hide? hi!"); //~ ERROR found 'hi's
+    trimmed!("hey, hi, hidy, hidy, hi hi"); //~ ERROR found 'hi's
+    trimmed!("this is a hi, and this is another hi"); //~ ERROR found 'hi's
+    trimmed!("how are you this evening"); //~ ERROR found 'hi's
+    trimmed!("this is highly eradic"); //~ ERROR found 'hi's
+}

--- a/src/test/ui-fulldeps/proc-macro/trimmed-span.stderr
+++ b/src/test/ui-fulldeps/proc-macro/trimmed-span.stderr
@@ -1,0 +1,98 @@
+error: found 'hi's
+  --> $DIR/trimmed-span.rs:25:5
+   |
+LL |     trimmed!("hi"); //~ ERROR found 'hi's
+   |     ^^^^^^^^^^^^^^^
+   |
+note: here
+  --> $DIR/trimmed-span.rs:25:15
+   |
+LL |     trimmed!("hi"); //~ ERROR found 'hi's
+   |               ^^
+
+error: found 'hi's
+  --> $DIR/trimmed-span.rs:28:5
+   |
+LL |     trimmed!("hihi"); //~ ERROR found 'hi's
+   |     ^^^^^^^^^^^^^^^^^
+   |
+note: here
+  --> $DIR/trimmed-span.rs:28:15
+   |
+LL |     trimmed!("hihi"); //~ ERROR found 'hi's
+   |               ^^^^
+
+error: found 'hi's
+  --> $DIR/trimmed-span.rs:31:5
+   |
+LL |     trimmed!("hihihi"); //~ ERROR found 'hi's
+   |     ^^^^^^^^^^^^^^^^^^^
+   |
+note: here
+  --> $DIR/trimmed-span.rs:31:15
+   |
+LL |     trimmed!("hihihi"); //~ ERROR found 'hi's
+   |               ^^^^^^
+
+error: found 'hi's
+  --> $DIR/trimmed-span.rs:34:5
+   |
+LL |     trimmed!("why I hide? hi!"); //~ ERROR found 'hi's
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: here
+  --> $DIR/trimmed-span.rs:34:21
+   |
+LL |     trimmed!("why I hide? hi!"); //~ ERROR found 'hi's
+   |                     ^^    ^^
+
+error: found 'hi's
+  --> $DIR/trimmed-span.rs:35:5
+   |
+LL |     trimmed!("hey, hi, hidy, hidy, hi hi"); //~ ERROR found 'hi's
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: here
+  --> $DIR/trimmed-span.rs:35:20
+   |
+LL |     trimmed!("hey, hi, hidy, hidy, hi hi"); //~ ERROR found 'hi's
+   |                    ^^  ^^    ^^    ^^ ^^
+
+error: found 'hi's
+  --> $DIR/trimmed-span.rs:36:5
+   |
+LL |     trimmed!("this is a hi, and this is another hi"); //~ ERROR found 'hi's
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: here
+  --> $DIR/trimmed-span.rs:36:16
+   |
+LL |     trimmed!("this is a hi, and this is another hi"); //~ ERROR found 'hi's
+   |                ^^       ^^       ^^             ^^
+
+error: found 'hi's
+  --> $DIR/trimmed-span.rs:37:5
+   |
+LL |     trimmed!("how are you this evening"); //~ ERROR found 'hi's
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: here
+  --> $DIR/trimmed-span.rs:37:28
+   |
+LL |     trimmed!("how are you this evening"); //~ ERROR found 'hi's
+   |                            ^^
+
+error: found 'hi's
+  --> $DIR/trimmed-span.rs:38:5
+   |
+LL |     trimmed!("this is highly eradic"); //~ ERROR found 'hi's
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: here
+  --> $DIR/trimmed-span.rs:38:16
+   |
+LL |     trimmed!("this is highly eradic"); //~ ERROR found 'hi's
+   |                ^^     ^^
+
+error: aborting due to 8 previous errors
+


### PR DESCRIPTION
`Span::len()` is fairly self explanatory. The latter, `trimmed()`, is necessary to get sub-spans of an existing `Span`. Rocket uses this, for instance, to point into slices of a string.