### PR TITLE
Use no_default_libraries for all NetBSD flavors

### DIFF
--- a/src/librustc_target/spec/netbsd_base.rs
+++ b/src/librustc_target/spec/netbsd_base.rs
@@ -29,6 +29,7 @@ pub fn opts() -> TargetOptions {
         executables: true,
         target_family: Some("unix".to_string()),
         linker_is_gnu: true,
+        no_default_libraries: false,
         has_rpath: true,
         pre_link_args: args,
         position_independent_executables: true,

--- a/src/librustc_target/spec/x86_64_rumprun_netbsd.rs
+++ b/src/librustc_target/spec/x86_64_rumprun_netbsd.rs
@@ -21,7 +21,6 @@ pub fn target() -> TargetResult {
     base.has_rpath = false;
     base.position_independent_executables = false;
     base.disable_redzone = true;
-    base.no_default_libraries = false;
     base.exe_allocation_crate = None;
     base.stack_probes = true;
 


### PR DESCRIPTION
The no_default_libraries was introduced in #28578 because the
NetBSD-based rumprun needed to disable the link flag.
This moves the definition to be used by all NetBSD linker flavors to
close #49627.

A different solution would be adding -lc but as there is no platform
with explicit -lc, this approach is used.