### PR TITLE
Make "await" a pseudo-edition keyword

### DIFF
--- a/src/librustc_lint/diagnostics.rs
+++ b/src/librustc_lint/diagnostics.rs
@@ -1,0 +1,13 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+register_diagnostics! {
+    E0721, // `await` keyword
+}

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -32,6 +32,7 @@
 #![feature(rustc_diagnostic_macros)]
 #![feature(macro_at_most_once_rep)]
 
+#[macro_use]
 extern crate syntax;
 #[macro_use]
 extern crate rustc;
@@ -61,6 +62,7 @@ use syntax::edition::Edition;
 use lint::LintId;
 use lint::FutureIncompatibleInfo;
 
+mod diagnostics;
 mod nonstandard_style;
 pub mod builtin;
 mod types;

--- a/src/test/ui/await-keyword/2015-edition-no-warnings-with-feature-gate.rs
+++ b/src/test/ui/await-keyword/2015-edition-no-warnings-with-feature-gate.rs
@@ -1,0 +1,16 @@
+// compile-pass
+
+#![feature(async_await)]
+#![allow(non_camel_case_types)]
+#![deny(keyword_idents)]
+
+mod outer_mod {
+    pub mod await {
+        pub struct await;
+    }
+}
+use outer_mod::await::await;
+
+fn main() {
+    match await { await => {} }
+}

--- a/src/test/ui/await-keyword/2015-edition-warning.fixed
+++ b/src/test/ui/await-keyword/2015-edition-warning.fixed
@@ -1,0 +1,15 @@
+// run-rustfix
+
+#![allow(non_camel_case_types)]
+#![deny(keyword_idents)]
+
+mod outer_mod {
+    pub mod r#await {
+        pub struct r#await;
+    }
+}
+use outer_mod::r#await::r#await;
+
+fn main() {
+    match r#await { r#await => {} }
+}

--- a/src/test/ui/await-keyword/2015-edition-warning.rs
+++ b/src/test/ui/await-keyword/2015-edition-warning.rs
@@ -1,0 +1,15 @@
+// run-rustfix
+
+#![allow(non_camel_case_types)]
+#![deny(keyword_idents)]
+
+mod outer_mod {
+    pub mod await {
+        pub struct await;
+    }
+}
+use outer_mod::await::await;
+
+fn main() {
+    match await { await => {} }
+}

--- a/src/test/ui/await-keyword/2015-edition-warning.stderr
+++ b/src/test/ui/await-keyword/2015-edition-warning.stderr
@@ -1,0 +1,61 @@
+error: `await` is a keyword in the 2018 edition
+  --> $DIR/2015-edition-warning.rs:7:13
+   |
+LL |     pub mod await {
+   |             ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
+   |
+note: lint level defined here
+  --> $DIR/2015-edition-warning.rs:4:9
+   |
+LL | #![deny(keyword_idents)]
+   |         ^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
+
+error: `await` is a keyword in the 2018 edition
+  --> $DIR/2015-edition-warning.rs:8:20
+   |
+LL |         pub struct await;
+   |                    ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
+
+error: `await` is a keyword in the 2018 edition
+  --> $DIR/2015-edition-warning.rs:11:16
+   |
+LL | use outer_mod::await::await;
+   |                ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
+
+error: `await` is a keyword in the 2018 edition
+  --> $DIR/2015-edition-warning.rs:11:23
+   |
+LL | use outer_mod::await::await;
+   |                       ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
+
+error: `await` is a keyword in the 2018 edition
+  --> $DIR/2015-edition-warning.rs:14:11
+   |
+LL |     match await { await => {} }
+   |           ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
+
+error: `await` is a keyword in the 2018 edition
+  --> $DIR/2015-edition-warning.rs:14:19
+   |
+LL |     match await { await => {} }
+   |                   ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
+
+error: aborting due to 6 previous errors
+

--- a/src/test/ui/await-keyword/2018-edition-error.rs
+++ b/src/test/ui/await-keyword/2018-edition-error.rs
@@ -1,0 +1,13 @@
+// edition:2018
+#![allow(non_camel_case_types)]
+
+mod outer_mod {
+    pub mod await {
+        pub struct await;
+    }
+}
+use self::outer_mod::await::await;
+
+fn main() {
+    match await { await => () }
+}

--- a/src/test/ui/await-keyword/2018-edition-error.stderr
+++ b/src/test/ui/await-keyword/2018-edition-error.stderr
@@ -1,0 +1,39 @@
+error[E0721]: `await` is a keyword in the 2018 edition
+  --> $DIR/2018-edition-error.rs:5:13
+   |
+LL |     pub mod await {
+   |             ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
+
+error[E0721]: `await` is a keyword in the 2018 edition
+  --> $DIR/2018-edition-error.rs:6:20
+   |
+LL |         pub struct await;
+   |                    ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
+
+error[E0721]: `await` is a keyword in the 2018 edition
+  --> $DIR/2018-edition-error.rs:9:22
+   |
+LL | use self::outer_mod::await::await;
+   |                      ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
+
+error[E0721]: `await` is a keyword in the 2018 edition
+  --> $DIR/2018-edition-error.rs:9:29
+   |
+LL | use self::outer_mod::await::await;
+   |                             ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
+
+error[E0721]: `await` is a keyword in the 2018 edition
+  --> $DIR/2018-edition-error.rs:12:11
+   |
+LL |     match await { await => () }
+   |           ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
+
+error[E0721]: `await` is a keyword in the 2018 edition
+  --> $DIR/2018-edition-error.rs:12:19
+   |
+LL |     match await { await => () }
+   |                   ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0721`.

--- a/src/test/ui/await-keyword/2018-edition-no-error-with-feature-gate.rs
+++ b/src/test/ui/await-keyword/2018-edition-no-error-with-feature-gate.rs
@@ -1,0 +1,16 @@
+// compile-pass
+// edition:2018
+
+#![allow(non_camel_case_types)]
+#![feature(async_await)]
+
+mod outer_mod {
+    pub mod await {
+        pub struct await;
+    }
+}
+use self::outer_mod::await::await;
+
+fn main() {
+    match await { await => () }
+}

--- a/src/test/ui/await-keyword/post_expansion_error.rs
+++ b/src/test/ui/await-keyword/post_expansion_error.rs
@@ -1,0 +1,9 @@
+// edition:2018
+
+macro_rules! r#await {
+    () => { println!("Hello, world!") }
+}
+
+fn main() {
+    await!()
+}

--- a/src/test/ui/await-keyword/post_expansion_error.stderr
+++ b/src/test/ui/await-keyword/post_expansion_error.stderr
@@ -1,0 +1,9 @@
+error[E0721]: `await` is a keyword in the 2018 edition
+  --> $DIR/post_expansion_error.rs:8:5
+   |
+LL |     await!()
+   |     ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0721`.


### PR DESCRIPTION
This change makes "await" ident an error in 2018 edition without async_await
feature and adds "await" to the 2018 edition keyword lint group that
suggest migration on the 2015 edition.

cc https://github.com/rust-lang/rust/issues/53834

r? @nikomatsakis 