### PR TITLE
Add UI test for deref recursion limit printing twice

### DIFF
--- a/src/test/ui/issues/issue-38940.rs
+++ b/src/test/ui/issues/issue-38940.rs
@@ -1,0 +1,51 @@
+// issue-38940: error printed twice for deref recursion limit exceeded
+// Test that the recursion limit can be changed. In this case, we have
+// deeply nested types that will fail the `Send` check by overflow
+// when the recursion limit is set very low.
+#![allow(dead_code)]
+#![recursion_limit="10"]
+macro_rules! link {
+    ($outer:ident, $inner:ident) => {
+        struct $outer($inner);
+        impl $outer {
+            fn new() -> $outer {
+                $outer($inner::new())
+            }
+        }
+        impl std::ops::Deref for $outer {
+            type Target = $inner;
+            fn deref(&self) -> &$inner {
+                &self.0
+            }
+        }
+    }
+}
+struct Bottom;
+impl Bottom {
+    fn new() -> Bottom {
+        Bottom
+    }
+}
+link!(Top, A);
+link!(A, B);
+link!(B, C);
+link!(C, D);
+link!(D, E);
+link!(E, F);
+link!(F, G);
+link!(G, H);
+link!(H, I);
+link!(I, J);
+link!(J, K);
+link!(K, Bottom);
+fn main() {
+    let t = Top::new();
+    let x: &Bottom = &t;
+    //~^ ERROR mismatched types
+    //~| NOTE expected type `&Bottom`
+    //~| NOTE found type `&Top`
+    //~| NOTE expected struct `Bottom`, found struct `Top`
+    //~| ERROR reached the recursion limit while auto-dereferencing I
+    //~| NOTE deref recursion limit reached
+    //~| NOTE consider adding a `#![recursion_limit="20"]` attribute to your crate
+}

--- a/src/test/ui/issues/issue-38940.rs
+++ b/src/test/ui/issues/issue-38940.rs
@@ -42,10 +42,5 @@ fn main() {
     let t = Top::new();
     let x: &Bottom = &t;
     //~^ ERROR mismatched types
-    //~| NOTE expected type `&Bottom`
-    //~| NOTE found type `&Top`
-    //~| NOTE expected struct `Bottom`, found struct `Top`
     //~| ERROR reached the recursion limit while auto-dereferencing I
-    //~| NOTE deref recursion limit reached
-    //~| NOTE consider adding a `#![recursion_limit="20"]` attribute to your crate
 }

--- a/src/test/ui/issues/issue-38940.stderr
+++ b/src/test/ui/issues/issue-38940.stderr
@@ -1,0 +1,21 @@
+error[E0055]: reached the recursion limit while auto-dereferencing I
+  --> $DIR/issue-38940.rs:43:22
+   |
+LL |     let x: &Bottom = &t;
+   |                      ^^ deref recursion limit reached
+   |
+   = help: consider adding a `#![recursion_limit="20"]` attribute to your crate
+
+error[E0308]: mismatched types
+  --> $DIR/issue-38940.rs:43:22
+   |
+LL |     let x: &Bottom = &t;
+   |                      ^^ expected struct `Bottom`, found struct `Top`
+   |
+   = note: expected type `&Bottom`
+              found type `&Top`
+
+error: aborting due to 2 previous errors
+
+Some errors occurred: E0055, E0308.
+For more information about an error, try `rustc --explain E0055`.


### PR DESCRIPTION
Closes #38940

Does ``NOTE`` in the test need to be changed to ``HELP`` if its in the stderr?
``help: consider adding a `#![recursion_limit="20"]` attribute to your crate``

It doesn't appear to complaining locally that the line isn't set to ``HELP`` in the test, and the guide says
 > HELP and SUGGESTION*
> * Note: SUGGESTION must follow immediately after HELP.

yet there's no concrete suggestion emitted.

r? @estebank 