### PR TITLE
do not borrow non-Sync data in constants

### DIFF
--- a/src/librustc/dep_graph/dep_node.rs
+++ b/src/librustc/dep_graph/dep_node.rs
@@ -538,6 +538,7 @@ define_dep_nodes!( <'tcx>
     [] IsCopy { param_env: ParamEnvAnd<'tcx, Ty<'tcx>> },
     [] IsSized { param_env: ParamEnvAnd<'tcx, Ty<'tcx>> },
     [] IsFreeze { param_env: ParamEnvAnd<'tcx, Ty<'tcx>> },
+    [] IsSync { param_env: ParamEnvAnd<'tcx, Ty<'tcx>> },
     [] NeedsDrop { param_env: ParamEnvAnd<'tcx, Ty<'tcx>> },
     [] Layout { param_env: ParamEnvAnd<'tcx, Ty<'tcx>> },
 

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -346,8 +346,6 @@ struct ElisionFailureInfo {
 
 type ScopeRef<'a> = &'a Scope<'a>;
 
-const ROOT_SCOPE: ScopeRef<'static> = &Scope::Root;
-
 pub fn provide(providers: &mut ty::query::Providers<'_>) {
     *providers = ty::query::Providers {
         resolve_lifetimes,
@@ -431,7 +429,7 @@ fn krate<'tcx>(tcx: TyCtxt<'_, 'tcx, 'tcx>) -> NamedRegionMap {
         let mut visitor = LifetimeContext {
             tcx,
             map: &mut map,
-            scope: ROOT_SCOPE,
+            scope: &Scope::Root,
             trait_ref_hack: false,
             is_in_fn_syntax: false,
             labels_in_fn: vec![],
@@ -490,7 +488,7 @@ impl<'a, 'tcx> Visitor<'tcx> for LifetimeContext<'a, 'tcx> {
                 // No lifetime parameters, but implied 'static.
                 let scope = Scope::Elision {
                     elide: Elide::Exact(Region::Static),
-                    s: ROOT_SCOPE,
+                    s: &Scope::Root,
                 };
                 self.with(scope, |_, this| intravisit::walk_item(this, item));
             }
@@ -534,7 +532,7 @@ impl<'a, 'tcx> Visitor<'tcx> for LifetimeContext<'a, 'tcx> {
                     next_early_index: index + type_count,
                     abstract_type_parent: true,
                     track_lifetime_uses,
-                    s: ROOT_SCOPE,
+                    s: &Scope::Root,
                 };
                 self.with(scope, |old_scope, this| {
                     this.check_lifetime_params(old_scope, &generics.params);

--- a/src/librustc/ty/query/config.rs
+++ b/src/librustc/ty/query/config.rs
@@ -181,6 +181,12 @@ impl<'tcx> QueryDescription<'tcx> for queries::is_freeze_raw<'tcx> {
     }
 }
 
+impl<'tcx> QueryDescription<'tcx> for queries::is_sync_raw<'tcx> {
+    fn describe(_tcx: TyCtxt, env: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> String {
+        format!("computing whether `{}` is `Sync`", env.value)
+    }
+}
+
 impl<'tcx> QueryDescription<'tcx> for queries::needs_drop_raw<'tcx> {
     fn describe(_tcx: TyCtxt<'_, '_, '_>, env: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> String {
         format!("computing whether `{}` needs drop", env.value)

--- a/src/librustc/ty/query/config.rs
+++ b/src/librustc/ty/query/config.rs
@@ -182,7 +182,7 @@ impl<'tcx> QueryDescription<'tcx> for queries::is_freeze_raw<'tcx> {
 }
 
 impl<'tcx> QueryDescription<'tcx> for queries::is_sync_raw<'tcx> {
-    fn describe(_tcx: TyCtxt, env: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> String {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, env: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> String {
         format!("computing whether `{}` is `Sync`", env.value)
     }
 }

--- a/src/librustc/ty/query/mod.rs
+++ b/src/librustc/ty/query/mod.rs
@@ -366,6 +366,7 @@ define_queries! { <'tcx>
         [] fn is_copy_raw: is_copy_dep_node(ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> bool,
         [] fn is_sized_raw: is_sized_dep_node(ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> bool,
         [] fn is_freeze_raw: is_freeze_dep_node(ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> bool,
+        [] fn is_sync_raw: is_sync_dep_node(ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> bool,
         [] fn needs_drop_raw: needs_drop_dep_node(ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> bool,
         [] fn layout_raw: layout_dep_node(ty::ParamEnvAnd<'tcx, Ty<'tcx>>)
                                     -> Result<&'tcx ty::layout::LayoutDetails,
@@ -765,6 +766,10 @@ fn is_sized_dep_node<'tcx>(param_env: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> DepCon
 
 fn is_freeze_dep_node<'tcx>(param_env: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> DepConstructor<'tcx> {
     DepConstructor::IsFreeze { param_env }
+}
+
+fn is_sync_dep_node<'tcx>(param_env: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> DepConstructor<'tcx> {
+    DepConstructor::IsSync { param_env }
 }
 
 fn needs_drop_dep_node<'tcx>(param_env: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> DepConstructor<'tcx> {

--- a/src/librustc/ty/query/plumbing.rs
+++ b/src/librustc/ty/query/plumbing.rs
@@ -1059,6 +1059,7 @@ pub fn force_from_dep_node<'a, 'gcx, 'lcx>(tcx: TyCtxt<'a, 'gcx, 'lcx>,
         DepKind::IsCopy |
         DepKind::IsSized |
         DepKind::IsFreeze |
+        DepKind::IsSync |
         DepKind::NeedsDrop |
         DepKind::Layout |
         DepKind::ConstEval |

--- a/src/test/run-make-fulldeps/atomic-lock-free/atomic_lock_free.rs
+++ b/src/test/run-make-fulldeps/atomic-lock-free/atomic_lock_free.rs
@@ -22,6 +22,8 @@ trait Sized {}
 trait Copy {}
 #[lang = "freeze"]
 trait Freeze {}
+#[lang = "sync"]
+trait Sync {}
 
 impl<T: ?Sized> Copy for *mut T {}
 

--- a/src/test/run-make-fulldeps/simd-ffi/simd.rs
+++ b/src/test/run-make-fulldeps/simd-ffi/simd.rs
@@ -75,6 +75,9 @@ pub trait Sized { }
 #[lang = "copy"]
 pub trait Copy { }
 
+#[lang="sync"]
+pub trait Sync { }
+
 impl Copy for f32 {}
 impl Copy for i32 {}
 

--- a/src/test/run-make-fulldeps/target-specs/foo.rs
+++ b/src/test/run-make-fulldeps/target-specs/foo.rs
@@ -17,6 +17,9 @@ trait Copy { }
 #[lang="sized"]
 trait Sized { }
 
+#[lang="sync"]
+trait Sync { }
+
 #[lang = "freeze"]
 auto trait Freeze {}
 

--- a/src/test/run-pass/issues/issue-22777.rs
+++ b/src/test/run-pass/issues/issue-22777.rs
@@ -16,6 +16,7 @@
 // pretty-expanded FIXME #23616
 
 #![allow(non_camel_case_types)]
+#![recursion_limit="128"]
 
 pub fn noop_fold_impl_item() -> SmallVector<ImplItem> {
     loop  { }

--- a/src/test/run-pass/issues/issue-49955-2.rs
+++ b/src/test/run-pass/issues/issue-49955-2.rs
@@ -12,16 +12,23 @@
 // compile-flags: -Z borrowck=mir
 
 use std::cell::Cell;
+use std::sync::atomic::AtomicUsize;
 
 #[inline(never)]
 fn tuple_field() -> &'static u32 {
     // This test is MIR-borrowck-only because the old borrowck
     // doesn't agree that borrows of "frozen" (i.e. without any
-    // interior mutability) fields of non-frozen temporaries,
+    // interior mutability) fields of non-frozen (even non-Sync!) temporaries,
     // should be promoted, while MIR promotion does promote them.
     &(Cell::new(5), 42).1
 }
 
+#[inline(never)]
+fn tuple_field2() -> &'static u32 {
+    &(AtomicUsize::new(5), 42).1
+}
+
 fn main() {
     assert_eq!(tuple_field().to_string(), "42");
+    assert_eq!(*tuple_field2(), 42);
 }

--- a/src/test/ui/consts/const-eval/dont_promote_non_sync.nll.stderr
+++ b/src/test/ui/consts/const-eval/dont_promote_non_sync.nll.stderr
@@ -1,0 +1,83 @@
+error[E0716]: temporary value dropped while borrowed
+  --> $DIR/dont_promote_non_sync.rs:18:32
+   |
+LL | fn mk_foo() -> &'static Foo { &Foo } //~ ERROR does not live long enough
+   |                                ^^^ - temporary value is freed at the end of this statement
+   |                                |
+   |                                creates a temporary which is freed while still in use
+   |
+   = note: borrowed value must be valid for the static lifetime...
+
+error[E0716]: temporary value dropped while borrowed
+  --> $DIR/dont_promote_non_sync.rs:19:32
+   |
+LL | fn mk_bar() -> &'static Bar { &Bar(0) } //~ ERROR does not live long enough
+   |                                ^^^^^^ - temporary value is freed at the end of this statement
+   |                                |
+   |                                creates a temporary which is freed while still in use
+   |
+   = note: borrowed value must be valid for the static lifetime...
+
+error[E0716]: temporary value dropped while borrowed
+  --> $DIR/dont_promote_non_sync.rs:20:32
+   |
+LL | fn mk_baz() -> &'static Baz { &Baz { field: 0 } } //~ ERROR does not live long enough
+   |                                ^^^^^^^^^^^^^^^^ - temporary value is freed at the end of this statement
+   |                                |
+   |                                creates a temporary which is freed while still in use
+   |
+   = note: borrowed value must be valid for the static lifetime...
+
+error[E0716]: temporary value dropped while borrowed
+  --> $DIR/dont_promote_non_sync.rs:21:34
+   |
+LL | fn mk_bla_t() -> &'static Bla { &Bla::T(0) } //~ ERROR does not live long enough
+   |                                  ^^^^^^^^^ - temporary value is freed at the end of this statement
+   |                                  |
+   |                                  creates a temporary which is freed while still in use
+   |
+   = note: borrowed value must be valid for the static lifetime...
+
+error[E0716]: temporary value dropped while borrowed
+  --> $DIR/dont_promote_non_sync.rs:22:34
+   |
+LL | fn mk_bla_s() -> &'static Bla { &Bla::S { field: 0 } } //~ ERROR does not live long enough
+   |                                  ^^^^^^^^^^^^^^^^^^^ - temporary value is freed at the end of this statement
+   |                                  |
+   |                                  creates a temporary which is freed while still in use
+   |
+   = note: borrowed value must be valid for the static lifetime...
+
+error[E0716]: temporary value dropped while borrowed
+  --> $DIR/dont_promote_non_sync.rs:26:42
+   |
+LL | fn mk_foo2<T: FooT>() -> &'static Foo { &T::C } //~ ERROR does not live long enough
+   |                                          ^^^^ - temporary value is freed at the end of this statement
+   |                                          |
+   |                                          creates a temporary which is freed while still in use
+   |
+   = note: borrowed value must be valid for the static lifetime...
+
+error[E0716]: temporary value dropped while borrowed
+  --> $DIR/dont_promote_non_sync.rs:29:42
+   |
+LL | fn mk_bar2<T: BarT>() -> &'static Bar { &T::C } //~ ERROR does not live long enough
+   |                                          ^^^^ - temporary value is freed at the end of this statement
+   |                                          |
+   |                                          creates a temporary which is freed while still in use
+   |
+   = note: borrowed value must be valid for the static lifetime...
+
+error[E0716]: temporary value dropped while borrowed
+  --> $DIR/dont_promote_non_sync.rs:32:60
+   |
+LL | fn mk_capturing_closure() -> &'static Fn() { let x = Foo; &move || { &x; } } //~ ERROR does not live long enough
+   |                                                            ^^^^^^^^^^^^^^^ - temporary value is freed at the end of this statement
+   |                                                            |
+   |                                                            creates a temporary which is freed while still in use
+   |
+   = note: borrowed value must be valid for the static lifetime...
+
+error: aborting due to 8 previous errors
+
+For more information about this error, try `rustc --explain E0716`.

--- a/src/test/ui/consts/const-eval/dont_promote_non_sync.rs
+++ b/src/test/ui/consts/const-eval/dont_promote_non_sync.rs
@@ -26,4 +26,7 @@ fn mk_foo2<T: FooT>() -> &'static Foo { &T::C } //~ ERROR does not live long eno
 trait BarT { const C: Bar; }
 fn mk_bar2<T: BarT>() -> &'static Bar { &T::C } //~ ERROR does not live long enough
 
+// Closure capturing non-Sync data
+fn mk_capturing_closure() -> &'static Fn() { let x = Foo; &move || { &x; } } //~ ERROR does not live long enough
+
 fn main() {}

--- a/src/test/ui/consts/const-eval/dont_promote_non_sync.rs
+++ b/src/test/ui/consts/const-eval/dont_promote_non_sync.rs
@@ -1,0 +1,29 @@
+#![feature(optin_builtin_traits)]
+
+struct Foo;
+impl !Sync for Foo {}
+
+struct Bar(i32);
+impl !Sync for Bar {}
+
+struct Baz { field: i32 }
+impl !Sync for Baz {}
+
+enum Bla { T(i32), S { field: i32 } }
+impl !Sync for Bla {}
+
+// Known values of the given types
+fn mk_foo() -> &'static Foo { &Foo } //~ ERROR does not live long enough
+fn mk_bar() -> &'static Bar { &Bar(0) } //~ ERROR does not live long enough
+fn mk_baz() -> &'static Baz { &Baz { field: 0 } } //~ ERROR does not live long enough
+fn mk_bla_t() -> &'static Bla { &Bla::T(0) } //~ ERROR does not live long enough
+fn mk_bla_s() -> &'static Bla { &Bla::S { field: 0 } } //~ ERROR does not live long enough
+
+// Unknown values of the given types (test a ZST and a non-ZST)
+trait FooT { const C: Foo; }
+fn mk_foo2<T: FooT>() -> &'static Foo { &T::C } //~ ERROR does not live long enough
+
+trait BarT { const C: Bar; }
+fn mk_bar2<T: BarT>() -> &'static Bar { &T::C } //~ ERROR does not live long enough
+
+fn main() {}

--- a/src/test/ui/consts/const-eval/dont_promote_non_sync.rs
+++ b/src/test/ui/consts/const-eval/dont_promote_non_sync.rs
@@ -1,3 +1,5 @@
+// ignore-tidy-linelength
+
 #![feature(optin_builtin_traits)]
 
 struct Foo;

--- a/src/test/ui/consts/const-eval/dont_promote_non_sync.stderr
+++ b/src/test/ui/consts/const-eval/dont_promote_non_sync.stderr
@@ -1,5 +1,5 @@
 error[E0597]: borrowed value does not live long enough
-  --> $DIR/dont_promote_non_sync.rs:16:32
+  --> $DIR/dont_promote_non_sync.rs:18:32
    |
 LL | fn mk_foo() -> &'static Foo { &Foo } //~ ERROR does not live long enough
    |                                ^^^ - temporary value only lives until here
@@ -9,7 +9,7 @@ LL | fn mk_foo() -> &'static Foo { &Foo } //~ ERROR does not live long enough
    = note: borrowed value must be valid for the static lifetime...
 
 error[E0597]: borrowed value does not live long enough
-  --> $DIR/dont_promote_non_sync.rs:17:32
+  --> $DIR/dont_promote_non_sync.rs:19:32
    |
 LL | fn mk_bar() -> &'static Bar { &Bar(0) } //~ ERROR does not live long enough
    |                                ^^^^^^ - temporary value only lives until here
@@ -19,7 +19,7 @@ LL | fn mk_bar() -> &'static Bar { &Bar(0) } //~ ERROR does not live long enough
    = note: borrowed value must be valid for the static lifetime...
 
 error[E0597]: borrowed value does not live long enough
-  --> $DIR/dont_promote_non_sync.rs:18:32
+  --> $DIR/dont_promote_non_sync.rs:20:32
    |
 LL | fn mk_baz() -> &'static Baz { &Baz { field: 0 } } //~ ERROR does not live long enough
    |                                ^^^^^^^^^^^^^^^^ - temporary value only lives until here
@@ -29,7 +29,7 @@ LL | fn mk_baz() -> &'static Baz { &Baz { field: 0 } } //~ ERROR does not live l
    = note: borrowed value must be valid for the static lifetime...
 
 error[E0597]: borrowed value does not live long enough
-  --> $DIR/dont_promote_non_sync.rs:19:34
+  --> $DIR/dont_promote_non_sync.rs:21:34
    |
 LL | fn mk_bla_t() -> &'static Bla { &Bla::T(0) } //~ ERROR does not live long enough
    |                                  ^^^^^^^^^ - temporary value only lives until here
@@ -39,7 +39,7 @@ LL | fn mk_bla_t() -> &'static Bla { &Bla::T(0) } //~ ERROR does not live long e
    = note: borrowed value must be valid for the static lifetime...
 
 error[E0597]: borrowed value does not live long enough
-  --> $DIR/dont_promote_non_sync.rs:20:34
+  --> $DIR/dont_promote_non_sync.rs:22:34
    |
 LL | fn mk_bla_s() -> &'static Bla { &Bla::S { field: 0 } } //~ ERROR does not live long enough
    |                                  ^^^^^^^^^^^^^^^^^^^ - temporary value only lives until here
@@ -49,7 +49,7 @@ LL | fn mk_bla_s() -> &'static Bla { &Bla::S { field: 0 } } //~ ERROR does not l
    = note: borrowed value must be valid for the static lifetime...
 
 error[E0597]: borrowed value does not live long enough
-  --> $DIR/dont_promote_non_sync.rs:24:42
+  --> $DIR/dont_promote_non_sync.rs:26:42
    |
 LL | fn mk_foo2<T: FooT>() -> &'static Foo { &T::C } //~ ERROR does not live long enough
    |                                          ^^^^ - temporary value only lives until here
@@ -59,7 +59,7 @@ LL | fn mk_foo2<T: FooT>() -> &'static Foo { &T::C } //~ ERROR does not live lon
    = note: borrowed value must be valid for the static lifetime...
 
 error[E0597]: borrowed value does not live long enough
-  --> $DIR/dont_promote_non_sync.rs:27:42
+  --> $DIR/dont_promote_non_sync.rs:29:42
    |
 LL | fn mk_bar2<T: BarT>() -> &'static Bar { &T::C } //~ ERROR does not live long enough
    |                                          ^^^^ - temporary value only lives until here
@@ -69,7 +69,7 @@ LL | fn mk_bar2<T: BarT>() -> &'static Bar { &T::C } //~ ERROR does not live lon
    = note: borrowed value must be valid for the static lifetime...
 
 error[E0597]: borrowed value does not live long enough
-  --> $DIR/dont_promote_non_sync.rs:30:60
+  --> $DIR/dont_promote_non_sync.rs:32:60
    |
 LL | fn mk_capturing_closure() -> &'static Fn() { let x = Foo; &move || { &x; } } //~ ERROR does not live long enough
    |                                                            ^^^^^^^^^^^^^^^ - temporary value only lives until here

--- a/src/test/ui/consts/const-eval/dont_promote_non_sync.stderr
+++ b/src/test/ui/consts/const-eval/dont_promote_non_sync.stderr
@@ -1,0 +1,73 @@
+error[E0597]: borrowed value does not live long enough
+  --> $DIR/dont_promote_non_sync.rs:16:32
+   |
+LL | fn mk_foo() -> &'static Foo { &Foo } //~ ERROR does not live long enough
+   |                                ^^^ - temporary value only lives until here
+   |                                |
+   |                                temporary value does not live long enough
+   |
+   = note: borrowed value must be valid for the static lifetime...
+
+error[E0597]: borrowed value does not live long enough
+  --> $DIR/dont_promote_non_sync.rs:17:32
+   |
+LL | fn mk_bar() -> &'static Bar { &Bar(0) } //~ ERROR does not live long enough
+   |                                ^^^^^^ - temporary value only lives until here
+   |                                |
+   |                                temporary value does not live long enough
+   |
+   = note: borrowed value must be valid for the static lifetime...
+
+error[E0597]: borrowed value does not live long enough
+  --> $DIR/dont_promote_non_sync.rs:18:32
+   |
+LL | fn mk_baz() -> &'static Baz { &Baz { field: 0 } } //~ ERROR does not live long enough
+   |                                ^^^^^^^^^^^^^^^^ - temporary value only lives until here
+   |                                |
+   |                                temporary value does not live long enough
+   |
+   = note: borrowed value must be valid for the static lifetime...
+
+error[E0597]: borrowed value does not live long enough
+  --> $DIR/dont_promote_non_sync.rs:19:34
+   |
+LL | fn mk_bla_t() -> &'static Bla { &Bla::T(0) } //~ ERROR does not live long enough
+   |                                  ^^^^^^^^^ - temporary value only lives until here
+   |                                  |
+   |                                  temporary value does not live long enough
+   |
+   = note: borrowed value must be valid for the static lifetime...
+
+error[E0597]: borrowed value does not live long enough
+  --> $DIR/dont_promote_non_sync.rs:20:34
+   |
+LL | fn mk_bla_s() -> &'static Bla { &Bla::S { field: 0 } } //~ ERROR does not live long enough
+   |                                  ^^^^^^^^^^^^^^^^^^^ - temporary value only lives until here
+   |                                  |
+   |                                  temporary value does not live long enough
+   |
+   = note: borrowed value must be valid for the static lifetime...
+
+error[E0597]: borrowed value does not live long enough
+  --> $DIR/dont_promote_non_sync.rs:24:42
+   |
+LL | fn mk_foo2<T: FooT>() -> &'static Foo { &T::C } //~ ERROR does not live long enough
+   |                                          ^^^^ - temporary value only lives until here
+   |                                          |
+   |                                          temporary value does not live long enough
+   |
+   = note: borrowed value must be valid for the static lifetime...
+
+error[E0597]: borrowed value does not live long enough
+  --> $DIR/dont_promote_non_sync.rs:27:42
+   |
+LL | fn mk_bar2<T: BarT>() -> &'static Bar { &T::C } //~ ERROR does not live long enough
+   |                                          ^^^^ - temporary value only lives until here
+   |                                          |
+   |                                          temporary value does not live long enough
+   |
+   = note: borrowed value must be valid for the static lifetime...
+
+error: aborting due to 7 previous errors
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/consts/const-eval/dont_promote_non_sync.stderr
+++ b/src/test/ui/consts/const-eval/dont_promote_non_sync.stderr
@@ -68,6 +68,16 @@ LL | fn mk_bar2<T: BarT>() -> &'static Bar { &T::C } //~ ERROR does not live lon
    |
    = note: borrowed value must be valid for the static lifetime...
 
-error: aborting due to 7 previous errors
+error[E0597]: borrowed value does not live long enough
+  --> $DIR/dont_promote_non_sync.rs:30:60
+   |
+LL | fn mk_capturing_closure() -> &'static Fn() { let x = Foo; &move || { &x; } } //~ ERROR does not live long enough
+   |                                                            ^^^^^^^^^^^^^^^ - temporary value only lives until here
+   |                                                            |
+   |                                                            temporary value does not live long enough
+   |
+   = note: borrowed value must be valid for the static lifetime...
+
+error: aborting due to 8 previous errors
 
 For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/consts/const-eval/non_sync_const.nll.stderr
+++ b/src/test/ui/consts/const-eval/non_sync_const.nll.stderr
@@ -1,0 +1,84 @@
+error[E0492]: cannot borrow a constant which may contain interior mutability or non-`Sync` data. If your data is `Sync`, create a static instead
+  --> $DIR/non_sync_const.rs:10:21
+   |
+LL | const FOO1 : &Foo = &Foo; //~ ERROR cannot borrow
+   |                     ^^^^
+
+error[E0492]: cannot borrow a constant which may contain interior mutability or non-`Sync` data. If your data is `Sync`, create a static instead
+  --> $DIR/non_sync_const.rs:11:34
+   |
+LL | const FOO2 : Option<&Foo> = Some(&Foo); //~ ERROR cannot borrow
+   |                                  ^^^^
+
+error[E0716]: temporary value dropped while borrowed
+  --> $DIR/non_sync_const.rs:11:35
+   |
+LL | const FOO2 : Option<&Foo> = Some(&Foo); //~ ERROR cannot borrow
+   |                                   ^^^- temporary value is freed at the end of this statement
+   |                                   |
+   |                                   creates a temporary which is freed while still in use
+   |
+   = note: borrowed value must be valid for the static lifetime...
+
+error[E0492]: cannot borrow a constant which may contain interior mutability or non-`Sync` data. If your data is `Sync`, create a static instead
+  --> $DIR/non_sync_const.rs:13:29
+   |
+LL | const FOO3 : &Option<Foo> = &Some(Foo); //~ ERROR cannot borrow
+   |                             ^^^^^^^^^^
+
+error[E0492]: cannot borrow a constant which may contain interior mutability or non-`Sync` data. If your data is `Sync`, create a static instead
+  --> $DIR/non_sync_const.rs:15:21
+   |
+LL | const BAR1 : &Bar = &Bar(42); //~ ERROR cannot borrow
+   |                     ^^^^^^^^
+
+error[E0492]: cannot borrow a constant which may contain interior mutability or non-`Sync` data. If your data is `Sync`, create a static instead
+  --> $DIR/non_sync_const.rs:16:34
+   |
+LL | const BAR2 : Option<&Bar> = Some(&Bar(42)); //~ ERROR cannot borrow
+   |                                  ^^^^^^^^
+
+error[E0716]: temporary value dropped while borrowed
+  --> $DIR/non_sync_const.rs:16:35
+   |
+LL | const BAR2 : Option<&Bar> = Some(&Bar(42)); //~ ERROR cannot borrow
+   |                                   ^^^^^^^- temporary value is freed at the end of this statement
+   |                                   |
+   |                                   creates a temporary which is freed while still in use
+   |
+   = note: borrowed value must be valid for the static lifetime...
+
+error[E0492]: cannot borrow a constant which may contain interior mutability or non-`Sync` data. If your data is `Sync`, create a static instead
+  --> $DIR/non_sync_const.rs:18:29
+   |
+LL | const BAR3 : &Option<Bar> = &Some(Bar(42)); //~ ERROR cannot borrow
+   |                             ^^^^^^^^^^^^^^
+
+error[E0492]: cannot borrow a constant which may contain interior mutability or non-`Sync` data. If your data is `Sync`, create a static instead
+  --> $DIR/non_sync_const.rs:27:32
+   |
+LL | const OPT1 : &MyOption1<i32> = &MyOption1::None; //~ ERROR cannot borrow
+   |                                ^^^^^^^^^^^^^^^^
+
+error[E0492]: cannot borrow a constant which may contain interior mutability or non-`Sync` data. If your data is `Sync`, create a static instead
+  --> $DIR/non_sync_const.rs:28:32
+   |
+LL | const OPT2 : &MyOption2<Foo> = &MyOption2::None; //~ ERROR cannot borrow
+   |                                ^^^^^^^^^^^^^^^^
+
+error[E0492]: cannot borrow a constant which may contain interior mutability or non-`Sync` data. If your data is `Sync`, create a static instead
+  --> $DIR/non_sync_const.rs:31:26
+   |
+LL |   const TESTS: &FnOnce() = &{ //~ ERROR cannot borrow
+   |  __________________________^
+LL | |     let x = Cell::new(32);
+LL | |     move || {
+LL | |         x;
+LL | |     }
+LL | | };
+   | |_^
+
+error: aborting due to 11 previous errors
+
+Some errors occurred: E0492, E0716.
+For more information about an error, try `rustc --explain E0492`.

--- a/src/test/ui/consts/const-eval/non_sync_const.rs
+++ b/src/test/ui/consts/const-eval/non_sync_const.rs
@@ -1,4 +1,5 @@
-#![feature(optin_builtin_traits)]
+#![feature(optin_builtin_traits,const_let)]
+use std::cell::Cell;
 
 struct Foo;
 impl !Sync for Foo {}
@@ -6,14 +7,32 @@ impl !Sync for Foo {}
 struct Bar(i32);
 impl !Sync for Bar {}
 
-const FOO : &Foo = &Foo; //~ ERROR cannot borrow
+const FOO1 : &Foo = &Foo; //~ ERROR cannot borrow
 const FOO2 : Option<&Foo> = Some(&Foo); //~ ERROR cannot borrow
 //~^ ERROR borrowed value does not live long enough
 const FOO3 : &Option<Foo> = &Some(Foo); //~ ERROR cannot borrow
 
-const BAR : &Bar = &Bar(42); //~ ERROR cannot borrow
+const BAR1 : &Bar = &Bar(42); //~ ERROR cannot borrow
 const BAR2 : Option<&Bar> = Some(&Bar(42)); //~ ERROR cannot borrow
 //~^ ERROR borrowed value does not live long enough
 const BAR3 : &Option<Bar> = &Some(Bar(42)); //~ ERROR cannot borrow
+
+/// Tests making sure that value-based reasoning does not go too far.
+enum MyOption1<T> { Some(Cell<T>), None } // Never Sync, we shouldnt assume it has Sync values
+
+trait NotSync {} // private trait!
+impl NotSync for Foo {}
+enum MyOption2<T: NotSync> { Some(T), None } // Never Sync, we shouldnt assume it has Sync values
+
+const OPT1 : &MyOption1<i32> = &MyOption1::None; //~ ERROR cannot borrow
+const OPT2 : &MyOption2<Foo> = &MyOption2::None; //~ ERROR cannot borrow
+
+// Hiding in closure variables
+const TESTS: &FnOnce() = &{ //~ ERROR cannot borrow
+    let x = Cell::new(32);
+    move || {
+        x;
+    }
+};
 
 fn main() {}

--- a/src/test/ui/consts/const-eval/non_sync_const.rs
+++ b/src/test/ui/consts/const-eval/non_sync_const.rs
@@ -1,0 +1,19 @@
+#![feature(optin_builtin_traits)]
+
+struct Foo;
+impl !Sync for Foo {}
+
+struct Bar(i32);
+impl !Sync for Bar {}
+
+const FOO : &Foo = &Foo; //~ ERROR cannot borrow
+const FOO2 : Option<&Foo> = Some(&Foo); //~ ERROR cannot borrow
+//~^ ERROR borrowed value does not live long enough
+const FOO3 : &Option<Foo> = &Some(Foo); //~ ERROR cannot borrow
+
+const BAR : &Bar = &Bar(42); //~ ERROR cannot borrow
+const BAR2 : Option<&Bar> = Some(&Bar(42)); //~ ERROR cannot borrow
+//~^ ERROR borrowed value does not live long enough
+const BAR3 : &Option<Bar> = &Some(Bar(42)); //~ ERROR cannot borrow
+
+fn main() {}

--- a/src/test/ui/consts/const-eval/non_sync_const.stderr
+++ b/src/test/ui/consts/const-eval/non_sync_const.stderr
@@ -1,17 +1,17 @@
 error[E0492]: cannot borrow a constant which may contain interior mutability or non-`Sync` data. If your data is `Sync`, create a static instead
-  --> $DIR/non_sync_const.rs:9:20
+  --> $DIR/non_sync_const.rs:10:21
    |
-LL | const FOO : &Foo = &Foo; //~ ERROR cannot borrow
-   |                    ^^^^
+LL | const FOO1 : &Foo = &Foo; //~ ERROR cannot borrow
+   |                     ^^^^
 
 error[E0492]: cannot borrow a constant which may contain interior mutability or non-`Sync` data. If your data is `Sync`, create a static instead
-  --> $DIR/non_sync_const.rs:10:34
+  --> $DIR/non_sync_const.rs:11:34
    |
 LL | const FOO2 : Option<&Foo> = Some(&Foo); //~ ERROR cannot borrow
    |                                  ^^^^
 
 error[E0597]: borrowed value does not live long enough
-  --> $DIR/non_sync_const.rs:10:35
+  --> $DIR/non_sync_const.rs:11:35
    |
 LL | const FOO2 : Option<&Foo> = Some(&Foo); //~ ERROR cannot borrow
    |                                   ^^^- temporary value only lives until here
@@ -21,25 +21,25 @@ LL | const FOO2 : Option<&Foo> = Some(&Foo); //~ ERROR cannot borrow
    = note: borrowed value must be valid for the static lifetime...
 
 error[E0492]: cannot borrow a constant which may contain interior mutability or non-`Sync` data. If your data is `Sync`, create a static instead
-  --> $DIR/non_sync_const.rs:12:29
+  --> $DIR/non_sync_const.rs:13:29
    |
 LL | const FOO3 : &Option<Foo> = &Some(Foo); //~ ERROR cannot borrow
    |                             ^^^^^^^^^^
 
 error[E0492]: cannot borrow a constant which may contain interior mutability or non-`Sync` data. If your data is `Sync`, create a static instead
-  --> $DIR/non_sync_const.rs:14:20
+  --> $DIR/non_sync_const.rs:15:21
    |
-LL | const BAR : &Bar = &Bar(42); //~ ERROR cannot borrow
-   |                    ^^^^^^^^
+LL | const BAR1 : &Bar = &Bar(42); //~ ERROR cannot borrow
+   |                     ^^^^^^^^
 
 error[E0492]: cannot borrow a constant which may contain interior mutability or non-`Sync` data. If your data is `Sync`, create a static instead
-  --> $DIR/non_sync_const.rs:15:34
+  --> $DIR/non_sync_const.rs:16:34
    |
 LL | const BAR2 : Option<&Bar> = Some(&Bar(42)); //~ ERROR cannot borrow
    |                                  ^^^^^^^^
 
 error[E0597]: borrowed value does not live long enough
-  --> $DIR/non_sync_const.rs:15:35
+  --> $DIR/non_sync_const.rs:16:35
    |
 LL | const BAR2 : Option<&Bar> = Some(&Bar(42)); //~ ERROR cannot borrow
    |                                   ^^^^^^^- temporary value only lives until here
@@ -49,12 +49,36 @@ LL | const BAR2 : Option<&Bar> = Some(&Bar(42)); //~ ERROR cannot borrow
    = note: borrowed value must be valid for the static lifetime...
 
 error[E0492]: cannot borrow a constant which may contain interior mutability or non-`Sync` data. If your data is `Sync`, create a static instead
-  --> $DIR/non_sync_const.rs:17:29
+  --> $DIR/non_sync_const.rs:18:29
    |
 LL | const BAR3 : &Option<Bar> = &Some(Bar(42)); //~ ERROR cannot borrow
    |                             ^^^^^^^^^^^^^^
 
-error: aborting due to 8 previous errors
+error[E0492]: cannot borrow a constant which may contain interior mutability or non-`Sync` data. If your data is `Sync`, create a static instead
+  --> $DIR/non_sync_const.rs:27:32
+   |
+LL | const OPT1 : &MyOption1<i32> = &MyOption1::None; //~ ERROR cannot borrow
+   |                                ^^^^^^^^^^^^^^^^
+
+error[E0492]: cannot borrow a constant which may contain interior mutability or non-`Sync` data. If your data is `Sync`, create a static instead
+  --> $DIR/non_sync_const.rs:28:32
+   |
+LL | const OPT2 : &MyOption2<Foo> = &MyOption2::None; //~ ERROR cannot borrow
+   |                                ^^^^^^^^^^^^^^^^
+
+error[E0492]: cannot borrow a constant which may contain interior mutability or non-`Sync` data. If your data is `Sync`, create a static instead
+  --> $DIR/non_sync_const.rs:31:26
+   |
+LL |   const TESTS: &FnOnce() = &{ //~ ERROR cannot borrow
+   |  __________________________^
+LL | |     let x = Cell::new(32);
+LL | |     move || {
+LL | |         x;
+LL | |     }
+LL | | };
+   | |_^
+
+error: aborting due to 11 previous errors
 
 Some errors occurred: E0492, E0597.
 For more information about an error, try `rustc --explain E0492`.

--- a/src/test/ui/consts/const-eval/non_sync_const.stderr
+++ b/src/test/ui/consts/const-eval/non_sync_const.stderr
@@ -1,0 +1,60 @@
+error[E0492]: cannot borrow a constant which may contain interior mutability or non-`Sync` data. If your data is `Sync`, create a static instead
+  --> $DIR/non_sync_const.rs:9:20
+   |
+LL | const FOO : &Foo = &Foo; //~ ERROR cannot borrow
+   |                    ^^^^
+
+error[E0492]: cannot borrow a constant which may contain interior mutability or non-`Sync` data. If your data is `Sync`, create a static instead
+  --> $DIR/non_sync_const.rs:10:34
+   |
+LL | const FOO2 : Option<&Foo> = Some(&Foo); //~ ERROR cannot borrow
+   |                                  ^^^^
+
+error[E0597]: borrowed value does not live long enough
+  --> $DIR/non_sync_const.rs:10:35
+   |
+LL | const FOO2 : Option<&Foo> = Some(&Foo); //~ ERROR cannot borrow
+   |                                   ^^^- temporary value only lives until here
+   |                                   |
+   |                                   temporary value does not live long enough
+   |
+   = note: borrowed value must be valid for the static lifetime...
+
+error[E0492]: cannot borrow a constant which may contain interior mutability or non-`Sync` data. If your data is `Sync`, create a static instead
+  --> $DIR/non_sync_const.rs:12:29
+   |
+LL | const FOO3 : &Option<Foo> = &Some(Foo); //~ ERROR cannot borrow
+   |                             ^^^^^^^^^^
+
+error[E0492]: cannot borrow a constant which may contain interior mutability or non-`Sync` data. If your data is `Sync`, create a static instead
+  --> $DIR/non_sync_const.rs:14:20
+   |
+LL | const BAR : &Bar = &Bar(42); //~ ERROR cannot borrow
+   |                    ^^^^^^^^
+
+error[E0492]: cannot borrow a constant which may contain interior mutability or non-`Sync` data. If your data is `Sync`, create a static instead
+  --> $DIR/non_sync_const.rs:15:34
+   |
+LL | const BAR2 : Option<&Bar> = Some(&Bar(42)); //~ ERROR cannot borrow
+   |                                  ^^^^^^^^
+
+error[E0597]: borrowed value does not live long enough
+  --> $DIR/non_sync_const.rs:15:35
+   |
+LL | const BAR2 : Option<&Bar> = Some(&Bar(42)); //~ ERROR cannot borrow
+   |                                   ^^^^^^^- temporary value only lives until here
+   |                                   |
+   |                                   temporary value does not live long enough
+   |
+   = note: borrowed value must be valid for the static lifetime...
+
+error[E0492]: cannot borrow a constant which may contain interior mutability or non-`Sync` data. If your data is `Sync`, create a static instead
+  --> $DIR/non_sync_const.rs:17:29
+   |
+LL | const BAR3 : &Option<Bar> = &Some(Bar(42)); //~ ERROR cannot borrow
+   |                             ^^^^^^^^^^^^^^
+
+error: aborting due to 8 previous errors
+
+Some errors occurred: E0492, E0597.
+For more information about an error, try `rustc --explain E0492`.

--- a/src/test/ui/consts/const-eval/value-based-reasoning.rs
+++ b/src/test/ui/consts/const-eval/value-based-reasoning.rs
@@ -1,0 +1,16 @@
+// Things that we *can* take references of in consts even though their
+// type is not Freeze+Sync.
+
+// compile-pass
+
+use std::cell::Cell;
+
+// test const qualification
+const CLOSURE: &Fn() = &|| {};
+const NO_CELL: &Option<Cell<i32>> = &None;
+
+// test promotion
+fn mk_closure() -> &'static Fn() { &|| {} }
+fn mk_no_cell() -> &'static Option<Cell<i32>> { &None }
+
+fn main() {}

--- a/src/test/ui/error-codes/E0492.stderr
+++ b/src/test/ui/error-codes/E0492.stderr
@@ -1,4 +1,4 @@
-error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
+error[E0492]: cannot borrow a constant which may contain interior mutability or non-`Sync` data. If your data is `Sync`, create a static instead
   --> $DIR/E0492.rs:14:34
    |
 LL | static B: &'static AtomicUsize = &A; //~ ERROR E0492

--- a/src/test/ui/inhabitedness-infinite-loop.rs
+++ b/src/test/ui/inhabitedness-infinite-loop.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // error-pattern:reached recursion limit
+// ignore-test FIXME #54419
 
 #![feature(never_type)]
 #![feature(exhaustive_patterns)]

--- a/src/test/ui/issues/issue-17718-const-borrow.stderr
+++ b/src/test/ui/issues/issue-17718-const-borrow.stderr
@@ -1,16 +1,16 @@
-error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
+error[E0492]: cannot borrow a constant which may contain interior mutability or non-`Sync` data. If your data is `Sync`, create a static instead
   --> $DIR/issue-17718-const-borrow.rs:14:39
    |
 LL | const B: &'static UnsafeCell<usize> = &A;
    |                                       ^^
 
-error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
+error[E0492]: cannot borrow a constant which may contain interior mutability or non-`Sync` data. If your data is `Sync`, create a static instead
   --> $DIR/issue-17718-const-borrow.rs:19:39
    |
 LL | const E: &'static UnsafeCell<usize> = &D.a;
    |                                       ^^^^
 
-error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
+error[E0492]: cannot borrow a constant which may contain interior mutability or non-`Sync` data. If your data is `Sync`, create a static instead
   --> $DIR/issue-17718-const-borrow.rs:21:23
    |
 LL | const F: &'static C = &D;

--- a/src/test/ui/required-lang-item.rs
+++ b/src/test/ui/required-lang-item.rs
@@ -13,6 +13,7 @@
 
 #[lang="copy"] pub trait Copy { }
 #[lang="sized"] pub trait Sized { }
+#[lang="sync"] pub trait Sync { }
 
 // error-pattern:requires `start` lang_item
 

--- a/src/test/ui/union-ub-fat-ptr.rs
+++ b/src/test/ui/union-ub-fat-ptr.rs
@@ -68,7 +68,7 @@ union DynTransmute {
     repr: DynRepr,
     repr2: DynRepr2,
     bad: BadDynRepr,
-    rust: &'static Trait,
+    rust: &'static (Trait+Sync),
 }
 
 trait Trait {}


### PR DESCRIPTION
We cannot share that data across threads. non-Sync is as bad as non-Freeze in that regard.

This is currently WIP because it ignores a test that is broken by https://github.com/rust-lang/rust/issues/54419. But it is good enough to get crater going.

Fixes https://github.com/rust-lang/rust/issues/49206.

Cc @eddyb @nikomatsakis 