### PR TITLE
Add Linker Support For L4Re

### DIFF
--- a/src/librustc_codegen_llvm/back/link.rs
+++ b/src/librustc_codegen_llvm/back/link.rs
@@ -604,6 +604,7 @@ pub fn linker_and_flavor(sess: &Session) -> (PathBuf, LinkerFlavor) {
             (None, Some(flavor)) => Some((PathBuf::from(match flavor {
                 LinkerFlavor::Em  => if cfg!(windows) { "emcc.bat" } else { "emcc" },
                 LinkerFlavor::Gcc => "cc",
+                LinkerFlavor::L4Bender => "l4-bender",
                 LinkerFlavor::Ld => "ld",
                 LinkerFlavor::Msvc => "link.exe",
                 LinkerFlavor::Lld(_) => "lld",

--- a/src/librustc_codegen_llvm/back/linker.rs
+++ b/src/librustc_codegen_llvm/back/linker.rs
@@ -90,7 +90,7 @@ impl LinkerInfo {
                     cmd,
                     sess,
                     hinted_static: false,
-                }) as Box<Linker>
+                }) as Box<dyn Linker>
             },
             LinkerFlavor::Lld(LldFlavor::Wasm) => {
                 Box::new(WasmLd {
@@ -1206,6 +1206,9 @@ impl<'a> Linker for L4Bender<'a> {
 
     fn group_start(&mut self) { self.cmd.arg("--start-group"); }
     fn group_end(&mut self) { self.cmd.arg("--end-group"); }
+    fn cross_lang_lto(&mut self) {
+        // do nothing
+    }
 }
 
 impl<'a> L4Bender<'a> {

--- a/src/librustc_codegen_llvm/back/linker.rs
+++ b/src/librustc_codegen_llvm/back/linker.rs
@@ -1218,10 +1218,6 @@ impl<'a> L4Bender<'a> {
 
         cmd.arg("--"); // separate direct l4-bender args from linker args
 
-        if let Ok(l4_ld_opts) = env::var("L4_LD_OPTIONS") {
-            L4Bender::split_cmd_args(&mut cmd, &l4_ld_opts);
-        }
-
         L4Bender {
             cmd: cmd,
             sess: sess,

--- a/src/librustc_codegen_llvm/back/linker.rs
+++ b/src/librustc_codegen_llvm/back/linker.rs
@@ -1245,10 +1245,10 @@ impl<'a> L4Bender<'a> {
                 '"' | '\'' => quoted = !quoted,
                 _ => arg.push(character),
             };
-            if arg.len() > 0 {
-                cmd.arg(&arg);
-                arg.clear();
-            }
+        }
+        if arg.len() > 0 {
+            cmd.arg(&arg);
+            arg.clear();
         }
     }
 

--- a/src/librustc_codegen_llvm/back/linker.rs
+++ b/src/librustc_codegen_llvm/back/linker.rs
@@ -1215,7 +1215,7 @@ impl<'a> L4Bender<'a> {
         if let Ok(l4bender_args) = env::var("L4_BENDER_ARGS") {
             L4Bender::split_cmd_args(&mut cmd, &l4bender_args);
         }
-        
+
         cmd.arg("--"); // separate direct l4-bender args from linker args
 
         if let Ok(l4_ld_opts) = env::var("L4_LD_OPTIONS") {
@@ -1229,7 +1229,7 @@ impl<'a> L4Bender<'a> {
     }
 
     /// This parses a shell-escaped string and unquotes the arguments. It doesn't attempt to
-    /// completely understand shell, but should instead allow passing arguments like 
+    /// completely understand shell, but should instead allow passing arguments like
     /// `-Dlinker="ld -m x86_64"`, and a copy without quotes, but spaces preserved, is added as an
     /// argument to the given Command. This means that constructs as \" are not understood, so
     /// quote wisely.

--- a/src/librustc_codegen_llvm/back/linker.rs
+++ b/src/librustc_codegen_llvm/back/linker.rs
@@ -1222,9 +1222,10 @@ impl<'a> L4Bender<'a> {
             L4Bender::split_cmd_args(&mut cmd, &l4_ld_opts);
         }
 
-        L4Bender { cmd: cmd,
-        sess: sess,
-        hinted_static: false,
+        L4Bender {
+            cmd: cmd,
+            sess: sess,
+            hinted_static: false,
         }
     }
 

--- a/src/librustc_target/spec/l4re_base.rs
+++ b/src/librustc_target/spec/l4re_base.rs
@@ -10,7 +10,6 @@
 
 use spec::{LinkArgs, LinkerFlavor, PanicStrategy, TargetOptions};
 use std::default::Default;
-//use std::process::Command;
 
 pub fn opts() -> TargetOptions {
     let mut args = LinkArgs::new();

--- a/src/librustc_target/spec/l4re_base.rs
+++ b/src/librustc_target/spec/l4re_base.rs
@@ -12,17 +12,6 @@ use spec::{LinkArgs, LinkerFlavor, PanicStrategy, TargetOptions};
 use std::default::Default;
 //use std::process::Command;
 
-// Use GCC to locate code for crt* libraries from the host, not from L4Re. Note
-// that a few files also come from L4Re, for these, the function shouldn't be
-// used. This uses GCC for the location of the file, but GCC is required for L4Re anyway.
-//fn get_path_or(filename: &str) -> String {
-//    let child = Command::new("gcc")
-//        .arg(format!("-print-file-name={}", filename)).output()
-//        .expect("Failed to execute GCC");
-//    String::from_utf8(child.stdout)
-//        .expect("Couldn't read path from GCC").trim().into()
-//}
-
 pub fn opts() -> TargetOptions {
     let mut args = LinkArgs::new();
     args.insert(LinkerFlavor::Gcc, vec![]);
@@ -32,7 +21,7 @@ pub fn opts() -> TargetOptions {
         has_elf_tls: false,
         exe_allocation_crate: None,
         panic_strategy: PanicStrategy::Abort,
-        linker: Some("ld".to_string()),
+        linker: Some("l4-bender".to_string()),
         pre_link_args: args,
         target_family: Some("unix".to_string()),
         .. Default::default()

--- a/src/librustc_target/spec/mod.rs
+++ b/src/librustc_target/spec/mod.rs
@@ -81,6 +81,7 @@ mod riscv_base;
 pub enum LinkerFlavor {
     Em,
     Gcc,
+    L4Bender,
     Ld,
     Msvc,
     Lld(LldFlavor),
@@ -150,6 +151,7 @@ macro_rules! flavor_mappings {
 flavor_mappings! {
     ((LinkerFlavor::Em), "em"),
     ((LinkerFlavor::Gcc), "gcc"),
+    ((LinkerFlavor::L4Bender), "l4-bender"),
     ((LinkerFlavor::Ld), "ld"),
     ((LinkerFlavor::Msvc), "msvc"),
     ((LinkerFlavor::Lld(LldFlavor::Wasm)), "wasm-ld"),

--- a/src/librustc_target/spec/x86_64_unknown_l4re_uclibc.rs
+++ b/src/librustc_target/spec/x86_64_unknown_l4re_uclibc.rs
@@ -25,7 +25,7 @@ pub fn target() -> TargetResult {
         target_os: "l4re".to_string(),
         target_env: "uclibc".to_string(),
         target_vendor: "unknown".to_string(),
-        linker_flavor: LinkerFlavor::Ld,
+        linker_flavor: LinkerFlavor::L4Bender,
         options: base,
     })
 }


### PR DESCRIPTION
L4Re uses a linker script called l4-bender used within the L4Re build system to cross-compile (/link) to L4Re. This PR adds l4-bender as another linker variant to Rustc.