### PR TITLE
rustdoc: don't run doctests on private items (by default)

### DIFF
--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -532,6 +532,7 @@ fn main_args(args: &[String]) -> isize {
     let sort_modules_alphabetically = !matches.opt_present("sort-modules-by-appearance");
     let resource_suffix = matches.opt_str("resource-suffix");
     let enable_minification = !matches.opt_present("disable-minification");
+    let document_private_items = matches.opt_present("document-private-items");
 
     let edition = matches.opt_str("edition").unwrap_or("2015".to_string());
     let edition = match edition.parse() {
@@ -551,7 +552,8 @@ fn main_args(args: &[String]) -> isize {
         }
         (true, false) => {
             return test::run(Path::new(input), cfgs, libs, externs, test_args, crate_name,
-                             maybe_sysroot, display_warnings, linker, edition, cg)
+                             maybe_sysroot, display_warnings, linker, edition, cg,
+                             document_private_items)
         }
         (false, true) => return markdown::render(Path::new(input),
                                                  output.unwrap_or(PathBuf::from("doc")),

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -955,11 +955,8 @@ assert_eq!(2+2, 4);
     fn make_test_no_crate_inject() {
         //even if you do use the crate within the test, setting `opts.no_crate_inject` will skip
         //adding it anyway
-        let opts = TestOptions {
-            no_crate_inject: true,
-            display_warnings: false,
-            attrs: vec![],
-        };
+        let mut opts = TestOptions::default();
+        opts.no_crate_inject = true;
         let input =
 "use asdf::qwop;
 assert_eq!(2+2, 4);";

--- a/src/test/rustdoc/private-doctests-private.rs
+++ b/src/test/rustdoc/private-doctests-private.rs
@@ -1,0 +1,49 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: --test --document-private-items
+// should-fail
+
+// issue #30094: rustdoc runs doctests on private items even though those docs don't appear
+//
+// in this version, we show that passing --document-private-items causes the private doctests to
+// run
+
+mod private {
+    /// Does all the work.
+    ///
+    /// ```
+    /// panic!("oh no");
+    /// ```
+    pub fn real_job(a: u32, b: u32) -> u32 {
+        return a + b;
+    }
+}
+
+pub mod public {
+    use super::private;
+
+    /// ```
+    /// // this was originally meant to link to public::function but we can't do that here
+    /// assert_eq!(2+2, 4);
+    /// ```
+    pub fn function(a: u32, b: u32) -> u32 {
+        return complex_helper(a, b);
+    }
+
+    /// Helps with stuff.
+    ///
+    /// ```
+    /// panic!("oh no");
+    /// ```
+    fn complex_helper(a: u32, b: u32) -> u32 {
+        return private::real_job(a, b);
+    }
+}

--- a/src/test/rustdoc/private-doctests.rs
+++ b/src/test/rustdoc/private-doctests.rs
@@ -1,0 +1,45 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: --test
+
+// issue #30094: rustdoc runs doctests on private items even though those docs don't appear
+
+mod private {
+    /// Does all the work.
+    ///
+    /// ```
+    /// panic!("oh no");
+    /// ```
+    pub fn real_job(a: u32, b: u32) -> u32 {
+        return a + b;
+    }
+}
+
+pub mod public {
+    use super::private;
+
+    /// ```
+    /// // this was originally meant to link to public::function but we can't do that here
+    /// assert_eq!(2+2, 4);
+    /// ```
+    pub fn function(a: u32, b: u32) -> u32 {
+        return complex_helper(a, b);
+    }
+
+    /// Helps with stuff.
+    ///
+    /// ```
+    /// panic!("oh no");
+    /// ```
+    fn complex_helper(a: u32, b: u32) -> u32 {
+        return private::real_job(a, b);
+    }
+}


### PR DESCRIPTION
fixes https://github.com/rust-lang/rust/issues/30094

Currently, rustdoc will scan the whole crate for doctests, regardless of whether the docs it finds are actually being shown in documentation, or actually useful docs. This PR changes the doctest collection scan to account for module visibility. Public re-exports of items will also pull in their doctests, if their original location was private. I added a check to make sure that items are not tested twice, to make sure that re-exporting an item into multiple places (say, if the original location is private, you export it into its "canonical" location, and you also include it in a prelude).

To continue running all tests, you can pass `--document-private-items` to rustdoc, like this:

```sh
RUSTDOCFLAGS="--document-private-items" cargo test --doc
```

While typing this up, i noticed that impls inside non-module scope also get skipped here, though running private tests will catch it. If desired, i can try and add it, though i'm not sure how severe it is to be missing.