### PR TITLE
Allow both explicit and elided lifetimes in the same impl header

### DIFF
--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -683,9 +683,15 @@ impl<'a> LoweringContext<'a> {
                 // Get the name we'll use to make the def-path. Note
                 // that collisions are ok here and this shouldn't
                 // really show up for end-user.
-                let str_name = match hir_name {
-                    ParamName::Plain(ident) => ident.as_interned_str(),
-                    ParamName::Fresh(_) => keywords::UnderscoreLifetime.name().as_interned_str(),
+                let (str_name, kind) = match hir_name {
+                    ParamName::Plain(ident) => (
+                        ident.as_interned_str(),
+                        hir::LifetimeParamKind::InBand,
+                    ),
+                    ParamName::Fresh(_) => (
+                        keywords::UnderscoreLifetime.name().as_interned_str(),
+                        hir::LifetimeParamKind::Elided,
+                    ),
                 };
 
                 // Add a definition for the in-band lifetime def
@@ -705,7 +711,7 @@ impl<'a> LoweringContext<'a> {
                     bounds: hir_vec![],
                     span,
                     pure_wrt_drop: false,
-                    kind: hir::GenericParamKind::Lifetime { in_band: true }
+                    kind: hir::GenericParamKind::Lifetime { kind }
                 }
             })
             .chain(in_band_ty_params.into_iter())
@@ -1452,11 +1458,15 @@ impl<'a> LoweringContext<'a> {
                         lifetime.span,
                     );
 
-                    let name = match name {
-                        hir::LifetimeName::Underscore => {
-                            hir::ParamName::Plain(keywords::UnderscoreLifetime.ident())
-                        }
-                        hir::LifetimeName::Param(param_name) => param_name,
+                    let (name, kind) = match name {
+                        hir::LifetimeName::Underscore => (
+                            hir::ParamName::Plain(keywords::UnderscoreLifetime.ident()),
+                            hir::LifetimeParamKind::Elided,
+                        ),
+                        hir::LifetimeName::Param(param_name) => (
+                            param_name,
+                            hir::LifetimeParamKind::Explicit,
+                        ),
                         _ => bug!("expected LifetimeName::Param or ParamName::Plain"),
                     };
 
@@ -1467,9 +1477,7 @@ impl<'a> LoweringContext<'a> {
                         pure_wrt_drop: false,
                         attrs: hir_vec![],
                         bounds: hir_vec![],
-                        kind: hir::GenericParamKind::Lifetime {
-                            in_band: false,
-                        }
+                        kind: hir::GenericParamKind::Lifetime { kind }
                     });
                 }
             }
@@ -2283,7 +2291,9 @@ impl<'a> LoweringContext<'a> {
                     pure_wrt_drop: attr::contains_name(&param.attrs, "may_dangle"),
                     attrs: self.lower_attrs(&param.attrs),
                     bounds,
-                    kind: hir::GenericParamKind::Lifetime { in_band: false }
+                    kind: hir::GenericParamKind::Lifetime {
+                        kind: hir::LifetimeParamKind::Explicit,
+                    }
                 };
 
                 self.is_collecting_in_band_lifetimes = was_collecting_in_band;

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -499,14 +499,27 @@ impl GenericBound {
 
 pub type GenericBounds = HirVec<GenericBound>;
 
+#[derive(Copy, Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Debug)]
+pub enum LifetimeParamKind {
+    // Indicates that the lifetime definition was explicitly declared, like:
+    // `fn foo<'a>(x: &'a u8) -> &'a u8 { x }`
+    Explicit,
+
+    // Indicates that the lifetime definition was synthetically added
+    // as a result of an in-band lifetime usage like:
+    // `fn foo(x: &'a u8) -> &'a u8 { x }`
+    InBand,
+
+    // Indication that the lifetime was elided like both cases here:
+    // `fn foo(x: &u8) -> &'_ u8 { x }`
+    Elided,
+}
+
 #[derive(Clone, RustcEncodable, RustcDecodable, Debug)]
 pub enum GenericParamKind {
     /// A lifetime definition, eg `'a: 'b + 'c + 'd`.
     Lifetime {
-        // Indicates that the lifetime definition was synthetically added
-        // as a result of an in-band lifetime usage like:
-        // `fn foo(x: &'a u8) -> &'a u8 { x }`
-        in_band: bool,
+        kind: LifetimeParamKind,
     },
     Type {
         default: Option<P<Ty>>,

--- a/src/librustc/ich/impls_hir.rs
+++ b/src/librustc/ich/impls_hir.rs
@@ -207,14 +207,20 @@ impl_stable_hash_for!(struct hir::GenericParam {
     kind
 });
 
+impl_stable_hash_for!(enum hir::LifetimeParamKind {
+    Explicit,
+    InBand,
+    Elided
+});
+
 impl<'a> HashStable<StableHashingContext<'a>> for hir::GenericParamKind {
     fn hash_stable<W: StableHasherResult>(&self,
                                           hcx: &mut StableHashingContext<'a>,
                                           hasher: &mut StableHasher<W>) {
         mem::discriminant(self).hash_stable(hcx, hasher);
         match self {
-            hir::GenericParamKind::Lifetime { in_band } => {
-                in_band.hash_stable(hcx, hasher);
+            hir::GenericParamKind::Lifetime { kind } => {
+                kind.hash_stable(hcx, hasher);
             }
             hir::GenericParamKind::Type { ref default, synthetic } => {
                 default.hash_stable(hcx, hasher);

--- a/src/test/ui/impl-header-lifetime-elision/explicit-and-elided-same-header.rs
+++ b/src/test/ui/impl-header-lifetime-elision/explicit-and-elided-same-header.rs
@@ -1,0 +1,25 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// run-pass
+
+#![allow(warnings)]
+
+#![feature(impl_header_lifetime_elision)]
+
+// This works for functions...
+fn foo<'a>(x: &str, y: &'a str) {}
+
+// ...so this should work for impls
+impl<'a> Foo<&str> for &'a str {}
+trait Foo<T> {}
+
+fn main() {
+}


### PR DESCRIPTION
While still prohibiting explicit and in-band in the same header.

Fixes #54456 

As usual, I don't know the broader context of the code I'm changing, so please let me know whatever I can do better.

Pre-existing test that mixing explicit and in-band remains an error: https://github.com/rust-lang/rust/blob/master/src/test/ui/in-band-lifetimes/E0688.rs