### PR TITLE
Enable line-only debuginfo by default.

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -289,7 +289,7 @@
 #debuginfo = false
 
 # Whether or not line number debug information is emitted
-#debuginfo-lines = false
+#debuginfo-lines = true
 
 # Whether or not to only build debuginfo for the standard library if enabled.
 # If enabled, this will not compile the compiler with debuginfo, just the

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -625,13 +625,11 @@ impl Config {
         let default = true;
         config.rust_optimize = optimize.unwrap_or(default);
 
-        let default = match &config.channel[..] {
-            "stable" | "beta" | "nightly" => true,
-            _ => false,
-        };
         config.rust_debuginfo_lines = debuginfo_lines.unwrap_or(default);
+
+        let default = false;
         config.rust_debuginfo_only_std = debuginfo_only_std.unwrap_or(default);
-        config.rust_debuginfo_tools = debuginfo_tools.unwrap_or(false);
+        config.rust_debuginfo_tools = debuginfo_tools.unwrap_or(default);
 
         let default = debug == Some(true);
         config.rust_debuginfo = debuginfo.unwrap_or(default);


### PR DESCRIPTION
Previously, only official builds (stable/beta/nightly) had `debuginfo-lines` enabled, but it was in conjunction with `debuginfo-only-std`, meaning that the compiler had *no* debuginfo.

In my experience, when you have a panic/crash in `rustc`, line debuginfo is *necessary* to get a readable backtrace, and we would've saved ourselves some pain and time, had we done this earlier.

At least we can try to explore and discuss the tradeoffs involved here.

r? @alexcrichton cc @rust-lang/infra @rust-lang/compiler 