### PR TITLE
[NLL] Get Polonius borrow check to work in simple cases

### DIFF
--- a/src/librustc_mir/borrow_check/nll/invalidation.rs
+++ b/src/librustc_mir/borrow_check/nll/invalidation.rs
@@ -479,7 +479,7 @@ impl<'cg, 'cx, 'tcx, 'gcx> InvalidationGenerator<'cx, 'tcx, 'gcx> {
 
     /// Generate a new invalidates(L, B) fact
     fn generate_invalidates(&mut self, b: BorrowIndex, l: Location) {
-        let lidx = self.location_table.mid_index(l);
+        let lidx = self.location_table.start_index(l);
         self.all_facts.invalidates.push((lidx, b));
     }
 }

--- a/src/librustc_mir/borrow_check/nll/type_check/free_region_relations.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/free_region_relations.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use borrow_check::location::LocationTable;
-use borrow_check::nll::facts::AllFacts;
 use borrow_check::nll::type_check::constraint_conversion;
 use borrow_check::nll::type_check::{Locations, MirTypeckRegionConstraints};
 use borrow_check::nll::universal_regions::UniversalRegions;
@@ -69,19 +67,15 @@ crate struct CreateResult<'tcx> {
 crate fn create(
     infcx: &InferCtxt<'_, '_, 'tcx>,
     param_env: ty::ParamEnv<'tcx>,
-    location_table: &LocationTable,
     implicit_region_bound: Option<ty::Region<'tcx>>,
     universal_regions: &Rc<UniversalRegions<'tcx>>,
     constraints: &mut MirTypeckRegionConstraints<'tcx>,
-    all_facts: &mut Option<AllFacts>,
 ) -> CreateResult<'tcx> {
     UniversalRegionRelationsBuilder {
         infcx,
         param_env,
         implicit_region_bound,
         constraints,
-        location_table,
-        all_facts,
         universal_regions: universal_regions.clone(),
         region_bound_pairs: Vec::new(),
         relations: UniversalRegionRelations {
@@ -210,11 +204,9 @@ impl UniversalRegionRelations<'tcx> {
 struct UniversalRegionRelationsBuilder<'this, 'gcx: 'tcx, 'tcx: 'this> {
     infcx: &'this InferCtxt<'this, 'gcx, 'tcx>,
     param_env: ty::ParamEnv<'tcx>,
-    location_table: &'this LocationTable,
     universal_regions: Rc<UniversalRegions<'tcx>>,
     implicit_region_bound: Option<ty::Region<'tcx>>,
     constraints: &'this mut MirTypeckRegionConstraints<'tcx>,
-    all_facts: &'this mut Option<AllFacts>,
 
     // outputs:
     relations: UniversalRegionRelations<'tcx>,
@@ -281,7 +273,6 @@ impl UniversalRegionRelationsBuilder<'cx, 'gcx, 'tcx> {
             constraint_conversion::ConstraintConversion::new(
                 self.infcx.tcx,
                 &self.universal_regions,
-                &self.location_table,
                 &self.region_bound_pairs,
                 self.implicit_region_bound,
                 self.param_env,
@@ -289,7 +280,6 @@ impl UniversalRegionRelationsBuilder<'cx, 'gcx, 'tcx> {
                 ConstraintCategory::Internal,
                 &mut self.constraints.outlives_constraints,
                 &mut self.constraints.type_tests,
-                &mut self.all_facts,
             ).convert_all(&data);
         }
 

--- a/src/librustc_mir/borrow_check/nll/type_check/liveness/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/liveness/mod.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use borrow_check::location::LocationTable;
 use borrow_check::nll::region_infer::values::RegionValueElements;
 use borrow_check::nll::constraints::ConstraintSet;
 use borrow_check::nll::NllLivenessMap;
@@ -40,6 +41,7 @@ pub(super) fn generate<'gcx, 'tcx>(
     elements: &Rc<RegionValueElements>,
     flow_inits: &mut FlowAtLocation<MaybeInitializedPlaces<'_, 'gcx, 'tcx>>,
     move_data: &MoveData<'tcx>,
+    location_table: &LocationTable,
 ) {
     debug!("liveness::generate");
     let free_regions = {
@@ -51,7 +53,7 @@ pub(super) fn generate<'gcx, 'tcx>(
         )
     };
     let liveness_map = NllLivenessMap::compute(typeck.tcx(), &free_regions, mir);
-    trace::trace(typeck, mir, elements, flow_inits, move_data, &liveness_map);
+    trace::trace(typeck, mir, elements, flow_inits, move_data, &liveness_map, location_table);
 }
 
 /// Compute all regions that are (currently) known to outlive free

--- a/src/librustc_mir/borrow_check/nll/type_check/liveness/trace.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/liveness/trace.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use borrow_check::location::LocationTable;
 use borrow_check::nll::constraints::ConstraintCategory;
 use borrow_check::nll::region_infer::values::{self, PointIndex, RegionValueElements};
 use borrow_check::nll::type_check::liveness::liveness_map::{LiveVar, NllLivenessMap};
@@ -49,6 +50,7 @@ pub(super) fn trace(
     flow_inits: &mut FlowAtLocation<MaybeInitializedPlaces<'_, 'gcx, 'tcx>>,
     move_data: &MoveData<'tcx>,
     liveness_map: &NllLivenessMap,
+    location_table: &LocationTable,
 ) {
     debug!("trace()");
 
@@ -67,6 +69,7 @@ pub(super) fn trace(
         move_data,
         liveness_map,
         drop_data: FxHashMap::default(),
+        location_table,
     };
 
     LivenessResults::new(cx).compute_for_all_locals();
@@ -105,6 +108,9 @@ where
 
     /// Map tracking which variables need liveness computation.
     liveness_map: &'me NllLivenessMap,
+
+    /// Maps between a MIR Location and a LocationIndex
+    location_table: &'me LocationTable,
 }
 
 struct DropData<'tcx> {
@@ -453,7 +459,13 @@ impl LivenessContext<'_, '_, '_, '_, 'tcx> {
     ) {
         debug!("add_use_live_facts_for(value={:?})", value);
 
-        Self::make_all_regions_live(self.elements, &mut self.typeck, value, live_at)
+        Self::make_all_regions_live(
+            self.elements,
+            &mut self.typeck,
+            value,
+            live_at,
+            self.location_table,
+        )
     }
 
     /// Some variable with type `live_ty` is "drop live" at `location`
@@ -505,7 +517,13 @@ impl LivenessContext<'_, '_, '_, '_, 'tcx> {
         // All things in the `outlives` array may be touched by
         // the destructor and must be live at this point.
         for &kind in &drop_data.dropck_result.kinds {
-            Self::make_all_regions_live(self.elements, &mut self.typeck, kind, live_at);
+            Self::make_all_regions_live(
+                self.elements,
+                &mut self.typeck,
+                kind,
+                live_at,
+                self.location_table,
+            );
         }
     }
 
@@ -514,6 +532,7 @@ impl LivenessContext<'_, '_, '_, '_, 'tcx> {
         typeck: &mut TypeChecker<'_, '_, 'tcx>,
         value: impl TypeFoldable<'tcx>,
         live_at: &HybridBitSet<PointIndex>,
+        location_table: &LocationTable,
     ) {
         debug!("make_all_regions_live(value={:?})", value);
         debug!(
@@ -532,8 +551,12 @@ impl LivenessContext<'_, '_, '_, '_, 'tcx> {
                 .liveness_constraints
                 .add_elements(live_region_vid, live_at);
 
-            if let Some(_) = borrowck_context.all_facts {
-                bug!("polonius liveness facts not implemented yet")
+            if let Some(facts) = borrowck_context.all_facts {
+                for point in live_at.iter() {
+                    let loc = elements.to_location(point);
+                    facts.region_live_at.push((live_region_vid, location_table.start_index(loc)));
+                    facts.region_live_at.push((live_region_vid, location_table.mid_index(loc)));
+                }
             }
         });
     }

--- a/src/librustc_mir/borrow_check/nll/type_check/relate_tys.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/relate_tys.rs
@@ -227,8 +227,6 @@ impl TypeRelatingDelegate<'tcx> for NllTypeRelatingDelegate<'_, '_, '_, 'tcx> {
                     locations: self.locations,
                     category: self.category,
                 });
-
-            // FIXME all facts!
         }
     }
 }

--- a/src/test/ui/nll/polonius-smoke-test.rs
+++ b/src/test/ui/nll/polonius-smoke-test.rs
@@ -1,0 +1,47 @@
+// Check that Polonius borrow check works for simple cases.
+// ignore-compare-mode-nll
+// compile-flags: -Z borrowck=mir -Zpolonius
+
+pub fn return_ref_to_local() -> &'static i32 {
+    let x = 0;
+    &x //~ ERROR
+}
+
+pub fn use_while_mut() {
+    let mut x = 0;
+    let y = &mut x;
+    let z = x; //~ ERROR
+    let w = y;
+}
+
+pub fn use_while_mut_fr(x: &mut i32) -> &mut i32 {
+    let y = &mut *x;
+    let z = x; //~ ERROR
+    y
+}
+
+// Cases like this are why we have Polonius.
+pub fn position_dependent_outlives(x: &mut i32, cond: bool) -> &mut i32 {
+    let y = &mut *x;
+    if cond {
+        return y;
+    } else {
+        *x = 0;
+        return x;
+    }
+}
+
+fn foo<'a, 'b>(p: &'b &'a mut usize) -> &'b usize {
+    p
+}
+
+// Check that we create constraints for well-formedness of function arguments
+fn well_formed_function_inputs() {
+    let s = &mut 1;
+    let r = &mut *s;
+    let tmp = foo(&r);
+    s; //~ ERROR
+    tmp;
+}
+
+fn main() {}

--- a/src/test/ui/nll/polonius-smoke-test.stderr
+++ b/src/test/ui/nll/polonius-smoke-test.stderr
@@ -1,0 +1,45 @@
+error[E0597]: `x` does not live long enough
+  --> $DIR/polonius-smoke-test.rs:7:5
+   |
+LL |     &x //~ ERROR
+   |     ^^ borrowed value does not live long enough
+LL | }
+   | - `x` dropped here while still borrowed
+   |
+   = note: borrowed value must be valid for the static lifetime...
+
+error[E0503]: cannot use `x` because it was mutably borrowed
+  --> $DIR/polonius-smoke-test.rs:13:13
+   |
+LL |     let y = &mut x;
+   |             ------ borrow of `x` occurs here
+LL |     let z = x; //~ ERROR
+   |             ^ use of borrowed `x`
+LL |     let w = y;
+   |             - borrow later used here
+
+error[E0505]: cannot move out of `x` because it is borrowed
+  --> $DIR/polonius-smoke-test.rs:19:13
+   |
+LL |     let y = &mut *x;
+   |             ------- borrow of `*x` occurs here
+LL |     let z = x; //~ ERROR
+   |             ^ move out of `x` occurs here
+LL |     y
+   |     - borrow later used here
+
+error[E0505]: cannot move out of `s` because it is borrowed
+  --> $DIR/polonius-smoke-test.rs:43:5
+   |
+LL |     let r = &mut *s;
+   |             ------- borrow of `*s` occurs here
+LL |     let tmp = foo(&r);
+LL |     s; //~ ERROR
+   |     ^ move out of `s` occurs here
+LL |     tmp;
+   |     --- borrow later used here
+
+error: aborting due to 4 previous errors
+
+Some errors occurred: E0503, E0505, E0597.
+For more information about an error, try `rustc --explain E0503`.


### PR DESCRIPTION
* Restores the generation of outlives facts from subtyping.
* Restore liveness facts.
* Generate invalidates facts at the start point of each location,
  where we check for errors.
* Add a small test for simple cases (previously these cases have compiled, and more recently ICEd).

Closes #54212
cc #53142 (will need test)

### Known limitations

* Two phase borrows aren't implemented for Polonius yet
* Invalidation facts haven't been updated for some of the recent changes to make `Drop` terminators access fewer things.
* Fact generation is not as optimized as it could be.
* Around 30 tests fail in compare mode, often tests that are ignored in nll compare mode

r? @nikomatsakis 
