### PR TITLE
avoid loading constructor attributes in AdtDef decoding

### DIFF
--- a/src/librustc_metadata/decoder.rs
+++ b/src/librustc_metadata/decoder.rs
@@ -556,9 +556,12 @@ impl<'a, 'tcx> CrateMetadata {
             _ => bug!(),
         };
 
+        let def_id = self.local_def_id(data.struct_ctor.unwrap_or(index));
+        let attribute_def_id = self.local_def_id(index);
+
         ty::VariantDef::new(
             tcx,
-            self.local_def_id(data.struct_ctor.unwrap_or(index)),
+            def_id,
             self.item_name(index).as_symbol(),
             data.discr,
             item.children.decode(self).map(|index| {
@@ -570,7 +573,8 @@ impl<'a, 'tcx> CrateMetadata {
                 }
             }).collect(),
             adt_kind,
-            data.ctor_kind
+            data.ctor_kind,
+            attribute_def_id
         )
     }
 

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -555,7 +555,8 @@ fn convert_variant<'a, 'tcx>(
     name: ast::Name,
     discr: ty::VariantDiscr,
     def: &hir::VariantData,
-    adt_kind: ty::AdtKind
+    adt_kind: ty::AdtKind,
+    attribute_def_id: DefId
 ) -> ty::VariantDef {
     let mut seen_fields: FxHashMap<ast::Ident, Span> = FxHashMap();
     let node_id = tcx.hir.as_local_node_id(did).unwrap();
@@ -592,7 +593,8 @@ fn convert_variant<'a, 'tcx>(
         discr,
         fields,
         adt_kind,
-        CtorKind::from_hir(def))
+        CtorKind::from_hir(def),
+        attribute_def_id)
 }
 
 fn adt_def<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) -> &'tcx ty::AdtDef {
@@ -622,7 +624,8 @@ fn adt_def<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) -> &'tcx ty::Ad
                         };
                         distance_from_explicit += 1;
 
-                        convert_variant(tcx, did, v.node.name, discr, &v.node.data, AdtKind::Enum)
+                        convert_variant(tcx, did, v.node.name, discr, &v.node.data, AdtKind::Enum,
+                                        did)
                     })
                     .collect(),
             )
@@ -642,7 +645,8 @@ fn adt_def<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) -> &'tcx ty::Ad
                     item.name,
                     ty::VariantDiscr::Relative(0),
                     def,
-                    AdtKind::Struct
+                    AdtKind::Struct,
+                    def_id
                 )],
             )
         }
@@ -654,7 +658,8 @@ fn adt_def<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) -> &'tcx ty::Ad
                 item.name,
                 ty::VariantDiscr::Relative(0),
                 def,
-                AdtKind::Union
+                AdtKind::Union,
+                def_id
             )],
         ),
         _ => bug!(),


### PR DESCRIPTION
During metadata loading, the AdtDefs for every ADT in the universe need
to be loaded (for example, for coherence of builtin traits). For that,
the attributes of the AdtDef need to be loaded too.

The attributes of a struct are duplicated between 2 def ids - the
constructor def-id, and the "type" def id. Loading attributes for both
def-ids, which was done in #53721, slowed the compilation of small
crates by 2-3%. This PR makes sure we only load the attributes for the
"type" def-id, avoiding the slowdown.

r? @eddyb & cc @nnethercote  