### PR TITLE
in which we include attributes in unused `extern crate` suggestion spans

### DIFF
--- a/src/librustc_typeck/check_unused.rs
+++ b/src/librustc_typeck/check_unused.rs
@@ -140,9 +140,15 @@ fn unused_crates_lint<'tcx>(tcx: TyCtxt<'_, 'tcx, 'tcx>) {
                 let hir_id = tcx.hir.definitions().def_index_to_hir_id(extern_crate.def_id.index);
                 let id = tcx.hir.hir_to_node_id(hir_id);
                 let msg = "unused extern crate";
+
+                // Removal suggestion span needs to include attributes (Issue #54400)
+                let span_with_attrs = tcx.get_attrs(extern_crate.def_id).iter()
+                    .map(|attr| attr.span)
+                    .fold(span, |acc, attr_span| acc.to(attr_span));
+
                 tcx.struct_span_lint_node(lint, id, span, msg)
                     .span_suggestion_short_with_applicability(
-                        span,
+                        span_with_attrs,
                         "remove it",
                         String::new(),
                         Applicability::MachineApplicable)

--- a/src/test/ui/rust-2018/issue-54400-unused-extern-crate-attr-span.fixed
+++ b/src/test/ui/rust-2018/issue-54400-unused-extern-crate-attr-span.fixed
@@ -1,0 +1,24 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:edition-lint-paths.rs
+// run-rustfix
+// compile-flags:--extern edition_lint_paths --cfg blandiloquence
+// edition:2018
+
+#![deny(rust_2018_idioms)]
+#![allow(dead_code)]
+
+// The suggestion span should include the attribute.
+
+
+//~^ ERROR unused extern crate
+
+fn main() {}

--- a/src/test/ui/rust-2018/issue-54400-unused-extern-crate-attr-span.rs
+++ b/src/test/ui/rust-2018/issue-54400-unused-extern-crate-attr-span.rs
@@ -1,0 +1,25 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:edition-lint-paths.rs
+// run-rustfix
+// compile-flags:--extern edition_lint_paths --cfg blandiloquence
+// edition:2018
+
+#![deny(rust_2018_idioms)]
+#![allow(dead_code)]
+
+// The suggestion span should include the attribute.
+
+#[cfg(blandiloquence)] //~ HELP remove it
+extern crate edition_lint_paths;
+//~^ ERROR unused extern crate
+
+fn main() {}

--- a/src/test/ui/rust-2018/issue-54400-unused-extern-crate-attr-span.stderr
+++ b/src/test/ui/rust-2018/issue-54400-unused-extern-crate-attr-span.stderr
@@ -1,0 +1,18 @@
+error: unused extern crate
+  --> $DIR/issue-54400-unused-extern-crate-attr-span.rs:22:1
+   |
+LL | / #[cfg(blandiloquence)] //~ HELP remove it
+LL | | extern crate edition_lint_paths;
+   | | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
+   | |________________________________|
+   |                                  help: remove it
+   |
+note: lint level defined here
+  --> $DIR/issue-54400-unused-extern-crate-attr-span.rs:16:9
+   |
+LL | #![deny(rust_2018_idioms)]
+   |         ^^^^^^^^^^^^^^^^
+   = note: #[deny(unused_extern_crates)] implied by #[deny(rust_2018_idioms)]
+
+error: aborting due to previous error
+


### PR DESCRIPTION
![unused_extern](https://user-images.githubusercontent.com/1076988/45921698-50243e80-be6f-11e8-930a-7b2a33b4935c.png)

Resolves #54400.

r? @estebank 