### PR TITLE
update rls to 32d457717ce37babef199fe4984b1e20d4e108d4

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1801,6 +1801,7 @@ dependencies = [
  "rls-vfs 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-workspace-hack 1.0.0",
+ "rustc_tools_util 0.1.0",
  "rustfmt-nightly 0.99.4",
  "serde 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -64,3 +64,4 @@ rustc-workspace-hack = { path = 'tools/rustc-workspace-hack' }
 
 [patch."https://github.com/rust-lang-nursery/rust-clippy"]
 clippy_lints = { path = "tools/clippy/clippy_lints" }
+rustc_tools_util = { path = "tools/clippy/rustc_tools_util" }


### PR DESCRIPTION
I patched rls to use the `rustc_tools_utils` supplied by the clippy submodule to get around the tidy warning.

Should fix rls and toolstate.