### PR TITLE
Deny the `overflowing_literals` lint for the 2018 edition

### DIFF
--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -24,6 +24,7 @@ use std::{i8, i16, i32, i64, u8, u16, u32, u64, f32, f64};
 use syntax::{ast, attr};
 use syntax::errors::Applicability;
 use rustc_target::spec::abi::Abi;
+use syntax::edition::Edition;
 use syntax_pos::Span;
 use syntax::source_map;
 
@@ -38,7 +39,8 @@ declare_lint! {
 declare_lint! {
     OVERFLOWING_LITERALS,
     Warn,
-    "literal out of range for its type"
+    "literal out of range for its type",
+    Edition::Edition2018 => Deny
 }
 
 declare_lint! {

--- a/src/test/ui/editions/edition-deny-overflowing-literals-2018.rs
+++ b/src/test/ui/editions/edition-deny-overflowing-literals-2018.rs
@@ -1,0 +1,16 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// edition:2018
+
+fn main() {
+    let x: u8 = 256;
+    //~^ error: literal out of range for u8
+}

--- a/src/test/ui/editions/edition-deny-overflowing-literals-2018.stderr
+++ b/src/test/ui/editions/edition-deny-overflowing-literals-2018.stderr
@@ -1,0 +1,10 @@
+error: literal out of range for u8
+  --> $DIR/edition-deny-overflowing-literals-2018.rs:14:17
+   |
+LL |     let x: u8 = 256;
+   |                 ^^^
+   |
+   = note: #[deny(overflowing_literals)] on by default
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Closes https://github.com/rust-lang/rust/issues/54502
r? @varkor 