### PR TITLE
resolve: Do not block derive helper resolutions on single import resolutions

### DIFF
--- a/src/test/compile-fail-fulldeps/proc-macro/proc-macro-attributes.rs
+++ b/src/test/compile-fail-fulldeps/proc-macro/proc-macro-attributes.rs
@@ -11,13 +11,11 @@
 // aux-build:derive-b.rs
 // ignore-stage1
 
-#![allow(warnings)]
-
 #[macro_use]
 extern crate derive_b;
 
-#[B] //~ ERROR `B` is a derive mode
-#[C]
+#[B]
+#[C] //~ ERROR attribute `C` is currently unknown to the compiler
 #[B(D)]
 #[B(E = "foo")]
 #[B(arbitrary tokens)]

--- a/src/test/ui-fulldeps/custom-derive/auxiliary/plugin.rs
+++ b/src/test/ui-fulldeps/custom-derive/auxiliary/plugin.rs
@@ -25,3 +25,13 @@ pub fn derive_foo(input: TokenStream) -> TokenStream {
 pub fn derive_bar(input: TokenStream) -> TokenStream {
     panic!("lolnope");
 }
+
+#[proc_macro_derive(WithHelper, attributes(helper))]
+pub fn with_helper(input: TokenStream) -> TokenStream {
+    TokenStream::new()
+}
+
+#[proc_macro_attribute]
+pub fn helper(_: TokenStream, input: TokenStream) -> TokenStream {
+    input
+}

--- a/src/test/ui-fulldeps/custom-derive/helper-attr-blocked-by-import-ambig.rs
+++ b/src/test/ui-fulldeps/custom-derive/helper-attr-blocked-by-import-ambig.rs
@@ -1,0 +1,13 @@
+// aux-build:plugin.rs
+// ignore-stage1
+
+#[macro_use(WithHelper)]
+extern crate plugin;
+
+use plugin::helper;
+
+#[derive(WithHelper)]
+#[helper] //~ ERROR `helper` is ambiguous
+struct S;
+
+fn main() {}

--- a/src/test/ui-fulldeps/custom-derive/helper-attr-blocked-by-import-ambig.stderr
+++ b/src/test/ui-fulldeps/custom-derive/helper-attr-blocked-by-import-ambig.stderr
@@ -1,0 +1,20 @@
+error[E0659]: `helper` is ambiguous
+  --> $DIR/helper-attr-blocked-by-import-ambig.rs:10:3
+   |
+LL | #[helper] //~ ERROR `helper` is ambiguous
+   |   ^^^^^^ ambiguous name
+   |
+note: `helper` could refer to the name defined here
+  --> $DIR/helper-attr-blocked-by-import-ambig.rs:9:10
+   |
+LL | #[derive(WithHelper)]
+   |          ^^^^^^^^^^
+note: `helper` could also refer to the name imported here
+  --> $DIR/helper-attr-blocked-by-import-ambig.rs:7:5
+   |
+LL | use plugin::helper;
+   |     ^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0659`.

--- a/src/test/ui-fulldeps/custom-derive/helper-attr-blocked-by-import.rs
+++ b/src/test/ui-fulldeps/custom-derive/helper-attr-blocked-by-import.rs
@@ -1,0 +1,29 @@
+// compile-pass
+// aux-build:plugin.rs
+// ignore-stage1
+
+#[macro_use(WithHelper)]
+extern crate plugin;
+
+use self::one::*;
+use self::two::*;
+
+mod helper {}
+
+mod one {
+    use helper;
+
+    #[derive(WithHelper)]
+    #[helper]
+    struct One;
+}
+
+mod two {
+    use helper;
+
+    #[derive(WithHelper)]
+    #[helper]
+    struct Two;
+}
+
+fn main() {}

--- a/src/test/ui-fulldeps/proc-macro/derive-helper-shadowing.stderr
+++ b/src/test/ui-fulldeps/proc-macro/derive-helper-shadowing.stderr
@@ -4,17 +4,16 @@ error[E0659]: `my_attr` is ambiguous
 LL | #[my_attr] //~ ERROR `my_attr` is ambiguous
    |   ^^^^^^^ ambiguous name
    |
-note: `my_attr` could refer to the name imported here
-  --> $DIR/derive-helper-shadowing.rs:4:5
-   |
-LL | use derive_helper_shadowing::*;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: `my_attr` could also refer to the name defined here
+note: `my_attr` could refer to the name defined here
   --> $DIR/derive-helper-shadowing.rs:7:10
    |
 LL | #[derive(MyTrait)]
    |          ^^^^^^^
-   = note: consider adding an explicit import of `my_attr` to disambiguate
+note: `my_attr` could also refer to the name imported here
+  --> $DIR/derive-helper-shadowing.rs:4:5
+   |
+LL | use derive_helper_shadowing::*;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Derive helpers currently conflict with anything else, so if some resolution from a single import appears later, it will result in error anyway.

Fixes https://github.com/rust-lang/rust/issues/54471 (stable-to-beta regression)

r? @ghost