### PR TITLE
aarch64-pc-windows-msvc: Don't link libpanic_unwind to libtest.

### DIFF
--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -45,8 +45,16 @@
 extern crate getopts;
 #[cfg(any(unix, target_os = "cloudabi"))]
 extern crate libc;
-extern crate panic_unwind;
 extern crate term;
+
+// FIXME(#54291): rustc and/or LLVM don't yet support building with panic-unwind
+//                on aarch64-pc-windows-msvc, so we don't link libtest against
+//                libunwind (for the time being), even though it means that
+//                libtest won't be fully functional on this platform.
+//
+// See also: https://github.com/rust-lang/rust/issues/54190#issuecomment-422904437
+#[cfg(not(all(windows, target_arch = "aarch64")))]
+extern crate panic_unwind;
 
 pub use self::TestFn::*;
 pub use self::ColorConfig::*;


### PR DESCRIPTION
This implements the suggestion from https://github.com/rust-lang/rust/issues/54190#issuecomment-422904437 in order to unbreak bootstrapping for the `aarch64-pc-windows-msvc` target. With this applied and using MSVC 15.8.3 for linking the bootstrap actually works and I can cross-compile a hello-world program. 

r? @alexcrichton 