### PR TITLE
Rely only on base alignment and offset for computing field alignment

### DIFF
--- a/src/librustc_codegen_llvm/mir/place.rs
+++ b/src/librustc_codegen_llvm/mir/place.rs
@@ -173,10 +173,7 @@ impl PlaceRef<'ll, 'tcx> {
         let cx = bx.cx;
         let field = self.layout.field(cx, ix);
         let offset = self.layout.fields.offset(ix);
-        let effective_field_align = self.align
-            .min(self.layout.align)
-            .min(field.align)
-            .restrict_for_offset(offset);
+        let effective_field_align = self.align.restrict_for_offset(offset);
 
         let simple = || {
             // Unions and newtypes only use an offset of 0.

--- a/src/test/codegen/align-struct.rs
+++ b/src/test/codegen/align-struct.rs
@@ -48,6 +48,16 @@ pub fn align64(i : i32) -> Align64 {
     a64
 }
 
+// For issue 54028: make sure that we are specifying the correct alignment for fields of aligned
+// structs
+// CHECK-LABEL: @align64_load
+#[no_mangle]
+pub fn align64_load(a: Align64) -> i32 {
+// CHECK: [[FIELD:%.*]] = bitcast %Align64* %{{.*}} to i32*
+// CHECK: {{%.*}} = load i32, i32* [[FIELD]], align 64
+    a.0
+}
+
 // CHECK-LABEL: @nested64
 #[no_mangle]
 pub fn nested64(a: Align64, b: i32, c: i32, d: i8) -> Nested64 {


### PR DESCRIPTION
Fix #54028
r? @eddyb