### PR TITLE
incr.comp.: Don't automatically enable -Zshare-generics for incr. comp. builds.

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -646,7 +646,6 @@ impl Options {
         match self.debugging_opts.share_generics {
             Some(setting) => setting,
             None => {
-                self.incremental.is_some() ||
                 match self.optimize {
                     OptLevel::No   |
                     OptLevel::Less |


### PR DESCRIPTION
So far the compiler would automatically enable sharing of monomorphizations for incremental builds. That was OK because without (Thin)LTO this could have very little impact on the runtime performance of the generated code. However, since https://github.com/rust-lang/rust/pull/53673, ThinLTO and incr. comp. can be combined, so the trade-off is not as clear anymore.

This PR removes the automatic tie between the two options. Whether monomorphizations are shared between crates or not now _only_ depends on the optimization level.

r? @alexcrichton 