### PR TITLE
Improvements to finding LLVM's FileCheck

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -322,6 +322,7 @@
 
 # Flag indicating whether codegen tests will be run or not. If you get an error
 # saying that the FileCheck executable is missing, you may want to disable this.
+# Also see the target's llvm-filecheck option.
 #codegen-tests = true
 
 # Flag indicating whether git info will be retrieved from .git automatically.
@@ -415,6 +416,10 @@
 # against. Note that if this is specified we don't compile LLVM at all for this
 # target.
 #llvm-config = "../path/to/llvm/root/bin/llvm-config"
+
+# Normally the build system can find LLVM's FileCheck utility, but if
+# not, you can specify an explicit file name for it.
+#llvm-filecheck = "/path/to/FileCheck"
 
 # Path to the custom jemalloc static library to link into the standard library
 # by default. This is only used if jemalloc is still enabled above

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -162,6 +162,8 @@ pub struct Config {
 pub struct Target {
     /// Some(path to llvm-config) if using an external LLVM.
     pub llvm_config: Option<PathBuf>,
+    /// Some(path to FileCheck) if one was specified.
+    pub llvm_filecheck: Option<PathBuf>,
     pub jemalloc: Option<PathBuf>,
     pub cc: Option<PathBuf>,
     pub cxx: Option<PathBuf>,
@@ -330,6 +332,7 @@ struct Rust {
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 struct TomlTarget {
     llvm_config: Option<String>,
+    llvm_filecheck: Option<String>,
     jemalloc: Option<String>,
     cc: Option<String>,
     cxx: Option<String>,
@@ -582,6 +585,9 @@ impl Config {
 
                 if let Some(ref s) = cfg.llvm_config {
                     target.llvm_config = Some(config.src.join(s));
+                }
+                if let Some(ref s) = cfg.llvm_filecheck {
+                    target.llvm_filecheck = Some(config.src.join(s));
                 }
                 if let Some(ref s) = cfg.jemalloc {
                     target.jemalloc = Some(config.src.join(s));

--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -95,6 +95,8 @@ v("docdir", "install.docdir", "install documentation in PATH")
 v("bindir", "install.bindir", "install binaries")
 
 v("llvm-root", None, "set LLVM root")
+v("llvm-config", None, "set path to llvm-config")
+v("llvm-filecheck", None, "set path to LLVM's FileCheck utility")
 v("python", "build.python", "set path to python")
 v("jemalloc-root", None, "set directory where libjemalloc_pic.a is located")
 v("android-cross-path", "target.arm-linux-androideabi.android-ndk",
@@ -323,6 +325,10 @@ for key in known_args:
         set('build.cargo', value + '/bin/cargo')
     elif option.name == 'llvm-root':
         set('target.{}.llvm-config'.format(build()), value + '/bin/llvm-config')
+    elif option.name == 'llvm-config':
+        set('target.{}.llvm-config'.format(build()), value)
+    elif option.name == 'llvm-filecheck':
+        set('target.{}.llvm-filecheck'.format(build()), value)
     elif option.name == 'jemalloc-root':
         set('target.{}.jemalloc'.format(build()), value + '/libjemalloc_pic.a')
     elif option.name == 'tools':


### PR DESCRIPTION
This patch adds a few improvements to how the build system finds
LLVM's FileCheck program.

* On Fedora, the system LLVM installs FileCheck in the "llvm"
  subdirectory of the LLVM libdir.  This patch teaches the build
  system to look there.

* This adds a configure option to specify which llvm-config executable
  to use.  This is handy on systems that can parallel install multiple
  versions of LLVM; for example I can now:

    ./configure --llvm-config=/bin/llvm-config-5.0-64

  ... to build against LLVM 5, rather than whatever the default
  llvm-config might be.

* Finally, this adds a configure- and config.toml- option to set the
  path to FileCheck.  This is handy when building against an LLVM
  where FileCheck was not installed.  This happens on compatibility
  installs of LLVM on Fedora.