### PR TITLE
Include path in stamp hash for debuginfo tests

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -224,6 +224,19 @@ pub fn run(config: Config, testpaths: &TestPaths, revision: Option<&str>) {
 pub fn compute_stamp_hash(config: &Config) -> String {
     let mut hash = DefaultHasher::new();
     config.stage_id.hash(&mut hash);
+    match config.mode {
+        DebugInfoGdb => match config.gdb {
+            None => env::var_os("PATH").hash(&mut hash),
+            Some(ref s) if s.is_empty() => env::var_os("PATH").hash(&mut hash),
+            Some(ref s) => s.hash(&mut hash),
+        },
+        DebugInfoLldb => {
+            env::var_os("PATH").hash(&mut hash);
+            env::var_os("PYTHONPATH").hash(&mut hash);
+        },
+
+        _ => {},
+    };
     format!("{:x}", hash.finish())
 }
 


### PR DESCRIPTION
The debuginfo tests are exposed to the environment in a couple of
ways: the path to the gdb executable matters, as does the Python path
used when loading lldb.

This patch incorporates these paths into the hash that is written to
the stamp file, so that changing the path will cause the tests to be
re-run.