### PR TITLE
ignore {std,fast,vector,this}call on non-x86 windows

### DIFF
--- a/src/librustc_target/spec/mod.rs
+++ b/src/librustc_target/spec/mod.rs
@@ -761,7 +761,7 @@ impl Default for TargetOptions {
 }
 
 impl Target {
-    /// Given a function ABI, turn "System" into the correct ABI for this target.
+    /// Given a function ABI, turn it into the correct ABI for this target.
     pub fn adjust_abi(&self, abi: Abi) -> Abi {
         match abi {
             Abi::System => {
@@ -769,6 +769,16 @@ impl Target {
                     Abi::Stdcall
                 } else {
                     Abi::C
+                }
+            },
+            // These ABI kinds are ignored on non-x86 Windows targets.
+            // See https://docs.microsoft.com/en-us/cpp/cpp/argument-passing-and-naming-conventions
+            // and the individual pages for __stdcall et al.
+            Abi::Stdcall | Abi::Fastcall | Abi::Vectorcall | Abi::Thiscall => {
+                if self.options.is_like_windows && self.arch != "x86" {
+                    Abi::C
+                } else {
+                    abi
                 }
             },
             abi => abi

--- a/src/test/codegen/issue-32364.rs
+++ b/src/test/codegen/issue-32364.rs
@@ -8,8 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-arm
-// ignore-aarch64
+// Test that `extern "stdcall"` is properly translated.
+
+// only-x86
 
 // compile-flags: -C no-prepopulate-passes
 


### PR DESCRIPTION
MSVC ignores these keywords for C/C++ and uses the standard system
calling convention.  Rust should do so as well.

Fixes #54569.