### PR TITLE
Accept trailing comma in `cfg_attr`

### DIFF
--- a/src/libsyntax/config.rs
+++ b/src/libsyntax/config.rs
@@ -90,6 +90,7 @@ impl<'a> StripUnconfigured<'a> {
             parser.expect(&token::Comma)?;
             let lo = parser.span.lo();
             let (path, tokens) = parser.parse_meta_item_unrestricted()?;
+            parser.eat(&token::Comma); // Optional trailing comma
             parser.expect(&token::CloseDelim(token::Paren))?;
             Ok((cfg, path, tokens, parser.prev_span.with_lo(lo)))
         }) {

--- a/src/test/ui/cfg-attr-trailing-comma.rs
+++ b/src/test/ui/cfg-attr-trailing-comma.rs
@@ -1,0 +1,13 @@
+// compile-flags: --cfg TRUE
+
+#[cfg_attr(TRUE, inline,)] // OK
+fn f() {}
+
+#[cfg_attr(FALSE, inline,)] // OK
+fn g() {}
+
+#[cfg_attr(TRUE, inline,,)] //~ ERROR expected `)`, found `,`
+fn h() {}
+
+#[cfg_attr(FALSE, inline,,)] //~ ERROR expected `)`, found `,`
+fn i() {}

--- a/src/test/ui/cfg-attr-trailing-comma.stderr
+++ b/src/test/ui/cfg-attr-trailing-comma.stderr
@@ -1,0 +1,14 @@
+error: expected `)`, found `,`
+  --> $DIR/cfg-attr-trailing-comma.rs:9:25
+   |
+LL | #[cfg_attr(TRUE, inline,,)] //~ ERROR expected `)`, found `,`
+   |                         ^ expected `)`
+
+error: expected `)`, found `,`
+  --> $DIR/cfg-attr-trailing-comma.rs:12:26
+   |
+LL | #[cfg_attr(FALSE, inline,,)] //~ ERROR expected `)`, found `,`
+   |                          ^ expected `)`
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/54463 (stable-to-beta regression)