### PR TITLE
std: Don't let `rust_panic` get inlined

### DIFF
--- a/src/libstd/panicking.rs
+++ b/src/libstd/panicking.rs
@@ -517,6 +517,7 @@ pub fn update_count_then_panic(msg: Box<dyn Any + Send>) -> ! {
 }
 
 /// A private no-mangle function on which to slap yer breakpoints.
+#[inline(never)]
 #[no_mangle]
 #[allow(private_no_mangle_fns)] // yes we get it, but we like breakpoints
 pub fn rust_panic(mut msg: &mut dyn BoxMeUp) -> ! {


### PR DESCRIPTION
It's meant for breakpoints, so if it gets inlined we can't set a
breakpoint on it easily!

Will hopefully help fix at least one aspect of https://github.com/rust-lang/rust/issues/49013