### PR TITLE
use closure def-id in returns, but base def-id in locals

### DIFF
--- a/src/librustc_mir/borrow_check/nll/type_check/input_output.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/input_output.rs
@@ -70,6 +70,7 @@ impl<'a, 'gcx, 'tcx> TypeChecker<'a, 'gcx, 'tcx> {
         if let Err(terr) = self.eq_opaque_type_and_type(
             mir_output_ty,
             normalized_output_ty,
+            self.mir_def_id,
             Locations::All(output_span),
             ConstraintCategory::BoringNoLocation,
         ) {

--- a/src/test/ui/impl-trait/closure-calling-parent-fn.rs
+++ b/src/test/ui/impl-trait/closure-calling-parent-fn.rs
@@ -1,0 +1,14 @@
+#![feature(nll)]
+
+// Regression test for #54593: the MIR type checker was going wrong
+// when a closure returns the `impl Copy` from its parent fn. It was
+// (incorrectly) replacing the `impl Copy` in its return type with the
+// hidden type (`()`) but that type resulted from a recursive call to
+// `foo` and hence is treated opaquely within the closure body.  This
+// resulted in a failed subtype relationship.
+//
+// run-pass
+
+fn foo() -> impl Copy { || foo(); }
+fn bar() -> impl Copy { || bar(); }
+fn main() { }


### PR DESCRIPTION
The refactorings to  handle `let x: impl Trait`  wound up breaking `impl Trait` in closure return types. I think there are some deeper problems with the code in question, but this a least should make @eddyb's example work.

Fixes #54593 

r? @eddyb 