### PR TITLE
Add `crate::` to trait suggestions in Rust 2018.

### DIFF
--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -28,17 +28,16 @@ use util::common::ProfileQueriesMsg;
 use rustc_data_structures::base_n;
 use rustc_data_structures::sync::{self, Lrc, Lock, LockCell, OneThread, Once, RwLock};
 
-use syntax::ast::NodeId;
 use errors::{self, DiagnosticBuilder, DiagnosticId, Applicability};
 use errors::emitter::{Emitter, EmitterWriter};
+use syntax::ast::{self, NodeId};
 use syntax::edition::Edition;
+use syntax::feature_gate::{self, AttributeType};
 use syntax::json::JsonEmitter;
-use syntax::feature_gate;
-use syntax::parse;
-use syntax::parse::ParseSess;
-use syntax::{ast, source_map};
-use syntax::feature_gate::AttributeType;
-use syntax_pos::{MultiSpan, Span, symbol::Symbol};
+use syntax::source_map;
+use syntax::symbol::Symbol;
+use syntax::parse::{self, ParseSess};
+use syntax_pos::{MultiSpan, Span};
 use util::profiling::SelfProfiler;
 
 use rustc_target::spec::PanicStrategy;

--- a/src/librustc/ty/item_path.rs
+++ b/src/librustc/ty/item_path.rs
@@ -281,7 +281,9 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
                     // In particular, don't recurse to print the crate root if we
                     // just printed `std`. In doing this, we are able to add
                     // `crate::` to trait import suggestions.
-                    DefPathData::CrateRoot if data.as_interned_str() == "std" => {},
+                    DefPathData::CrateRoot if self.sess.extern_prelude.contains(
+                        &data.as_interned_str().as_symbol()
+                    ) => {},
                     _ => self.push_item_path(buffer, parent_def_id),
                 }
 

--- a/src/librustc_codegen_utils/symbol_names.rs
+++ b/src/librustc_codegen_utils/symbol_names.rs
@@ -338,6 +338,7 @@ fn compute_symbol_name<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, instance: Instance
 //
 // To be able to work on all platforms and get *some* reasonable output, we
 // use C++ name-mangling.
+#[derive(Debug)]
 struct SymbolPathBuffer {
     result: String,
     temp_buf: String,

--- a/src/librustc_codegen_utils/symbol_names.rs
+++ b/src/librustc_codegen_utils/symbol_names.rs
@@ -228,7 +228,7 @@ fn get_symbol_hash<'a, 'tcx>(
 fn def_symbol_name<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) -> ty::SymbolName {
     let mut buffer = SymbolPathBuffer::new();
     item_path::with_forced_absolute_paths(|| {
-        tcx.push_item_path(&mut buffer, def_id);
+        tcx.push_item_path(&mut buffer, def_id, false);
     });
     buffer.into_interned()
 }

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -16,6 +16,7 @@ use rustc::hir::map as hir_map;
 use hir::Node;
 use rustc_data_structures::sync::Lrc;
 use rustc::ty::{self, Ty, TyCtxt, ToPolyTraitRef, ToPredicate, TypeFoldable};
+use rustc::ty::item_path::with_crate_prefix;
 use hir::def::Def;
 use hir::def_id::{CRATE_DEF_INDEX, DefId};
 use middle::lang_items::FnOnceTraitLangItem;
@@ -515,7 +516,11 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 } else {
                     "\n"
                 };
-                format!("use {};\n{}", self.tcx.item_path_str(*did), additional_newline)
+                format!(
+                    "use {};\n{}",
+                    with_crate_prefix(|| self.tcx.item_path_str(*did)),
+                    additional_newline
+                )
             }).collect();
 
             err.span_suggestions_with_applicability(
@@ -528,12 +533,20 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
             let limit = if candidates.len() == 5 { 5 } else { 4 };
             for (i, trait_did) in candidates.iter().take(limit).enumerate() {
                 if candidates.len() > 1 {
-                    msg.push_str(&format!("\ncandidate #{}: `use {};`",
-                                            i + 1,
-                                            self.tcx.item_path_str(*trait_did)));
+                    msg.push_str(
+                        &format!(
+                            "\ncandidate #{}: `use {};`",
+                            i + 1,
+                            with_crate_prefix(|| self.tcx.item_path_str(*trait_did))
+                        )
+                    );
                 } else {
-                    msg.push_str(&format!("\n`use {};`",
-                                            self.tcx.item_path_str(*trait_did)));
+                    msg.push_str(
+                        &format!(
+                            "\n`use {};`",
+                            with_crate_prefix(|| self.tcx.item_path_str(*trait_did))
+                        )
+                    );
                 }
             }
             if candidates.len() > limit {

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -3990,6 +3990,7 @@ pub fn path_to_def(tcx: &TyCtxt, path: &[&str]) -> Option<DefId> {
 
 pub fn get_path_for_type<F>(tcx: TyCtxt, def_id: DefId, def_ctor: F) -> hir::Path
 where F: Fn(DefId) -> Def {
+    #[derive(Debug)]
     struct AbsolutePathBuffer {
         names: Vec<String>,
     }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -4008,7 +4008,7 @@ where F: Fn(DefId) -> Def {
 
     let mut apb = AbsolutePathBuffer { names: vec![] };
 
-    tcx.push_item_path(&mut apb, def_id);
+    tcx.push_item_path(&mut apb, def_id, false);
 
     hir::Path {
         span: DUMMY_SP,

--- a/src/test/ui/rust-2018/auxiliary/trait-import-suggestions.rs
+++ b/src/test/ui/rust-2018/auxiliary/trait-import-suggestions.rs
@@ -1,0 +1,15 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub trait Baz {
+    fn baz(&self) { }
+}
+
+impl Baz for u32 { }

--- a/src/test/ui/rust-2018/trait-import-suggestions.rs
+++ b/src/test/ui/rust-2018/trait-import-suggestions.rs
@@ -1,0 +1,41 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// edition:2018
+// aux-build:trait-import-suggestions.rs
+// compile-flags:--extern trait-import-suggestions
+
+mod foo {
+    mod foobar {
+        pub(crate) trait Foobar {
+            fn foobar(&self) { }
+        }
+
+        impl Foobar for u32 { }
+    }
+
+    pub(crate) trait Bar {
+        fn bar(&self) { }
+    }
+
+    impl Bar for u32 { }
+
+    fn in_foo() {
+        let x: u32 = 22;
+        x.foobar();
+    }
+}
+
+fn main() {
+    let x: u32 = 22;
+    x.bar();
+    x.baz();
+    let y = u32::from_str("33");
+}

--- a/src/test/ui/rust-2018/trait-import-suggestions.stderr
+++ b/src/test/ui/rust-2018/trait-import-suggestions.stderr
@@ -1,0 +1,43 @@
+error[E0599]: no method named `foobar` found for type `u32` in the current scope
+  --> $DIR/trait-import-suggestions.rs:32:11
+   |
+LL |         x.foobar();
+   |           ^^^^^^
+   |
+   = help: items from traits can only be used if the trait is in scope
+   = note: the following trait is implemented but not in scope, perhaps add a `use` for it:
+           `use crate::foo::foobar::Foobar;`
+
+error[E0599]: no method named `bar` found for type `u32` in the current scope
+  --> $DIR/trait-import-suggestions.rs:38:7
+   |
+LL |     x.bar();
+   |       ^^^
+   |
+   = help: items from traits can only be used if the trait is in scope
+help: the following trait is implemented but not in scope, perhaps add a `use` for it:
+   |
+LL | use crate::foo::Bar;
+   |
+
+error[E0599]: no method named `baz` found for type `u32` in the current scope
+  --> $DIR/trait-import-suggestions.rs:39:7
+   |
+LL |     x.baz();
+   |       ^^^
+
+error[E0599]: no function or associated item named `from_str` found for type `u32` in the current scope
+  --> $DIR/trait-import-suggestions.rs:40:13
+   |
+LL |     let y = u32::from_str("33");
+   |             ^^^^^^^^^^^^^ function or associated item not found in `u32`
+   |
+   = help: items from traits can only be used if the trait is in scope
+help: the following trait is implemented but not in scope, perhaps add a `use` for it:
+   |
+LL | use std::str::FromStr;
+   |
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0599`.


### PR DESCRIPTION
Fixes #54559. 

In the 2018 edition, when suggesting traits to import that implement a
given method that is being invoked, suggestions will now include the
`crate::` prefix if the suggested trait is local to the current crate.

r? @nikomatsakis 