### PR TITLE
liballoc: mark str.to_owned() and String::from(&str) as #[inline].

### DIFF
--- a/src/liballoc/str.rs
+++ b/src/liballoc/str.rs
@@ -203,6 +203,7 @@ impl Borrow<str> for String {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl ToOwned for str {
     type Owned = String;
+    #[inline]
     fn to_owned(&self) -> String {
         unsafe { String::from_utf8_unchecked(self.as_bytes().to_owned()) }
     }

--- a/src/liballoc/string.rs
+++ b/src/liballoc/string.rs
@@ -2196,6 +2196,7 @@ impl AsRef<[u8]> for String {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a> From<&'a str> for String {
+    #[inline]
     fn from(s: &'a str) -> String {
         s.to_owned()
     }


### PR DESCRIPTION
Fixes #53681