### PR TITLE
Enable NLL compare mode for more tests

### DIFF
--- a/src/test/ui/borrowck/borrowck-lend-flow-if.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-lend-flow-if.nll.stderr
@@ -1,0 +1,14 @@
+error[E0502]: cannot borrow `*v` as mutable because it is also borrowed as immutable
+  --> $DIR/borrowck-lend-flow-if.rs:39:16
+   |
+LL |         _w = &v;
+   |              -- immutable borrow occurs here
+LL |     }
+LL |     borrow_mut(&mut *v); //~ ERROR cannot borrow
+   |                ^^^^^^^ mutable borrow occurs here
+LL |     _w.use_ref();
+   |     -- borrow later used here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0502`.

--- a/src/test/ui/borrowck/borrowck-lend-flow-if.rs
+++ b/src/test/ui/borrowck/borrowck-lend-flow-if.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-compare-mode-nll
-
 // Note: the borrowck analysis is currently flow-insensitive.
 // Therefore, some of these errors are marked as spurious and could be
 // corrected by a simple change to the analysis.  The others are
@@ -32,25 +30,32 @@ fn pre_freeze_cond() {
     // In this instance, the freeze is conditional and starts before
     // the mut borrow.
 
+    let u = box 0;
     let mut v: Box<_> = box 3;
-    let _w;
+    let mut _w = &u;
     if cond() {
         _w = &v;
     }
     borrow_mut(&mut *v); //~ ERROR cannot borrow
+    _w.use_ref();
 }
 
 fn pre_freeze_else() {
     // In this instance, the freeze and mut borrow are on separate sides
     // of the if.
 
+    let u = box 0;
     let mut v: Box<_> = box 3;
-    let _w;
+    let mut _w = &u;
     if cond() {
         _w = &v;
     } else {
         borrow_mut(&mut *v);
     }
+    _w.use_ref();
 }
 
 fn main() {}
+
+trait Fake { fn use_mut(&mut self) { } fn use_ref(&self) { }  }
+impl<T> Fake for T { }

--- a/src/test/ui/borrowck/borrowck-lend-flow-if.stderr
+++ b/src/test/ui/borrowck/borrowck-lend-flow-if.stderr
@@ -1,11 +1,12 @@
 error[E0502]: cannot borrow `*v` as mutable because `v` is also borrowed as immutable
-  --> $DIR/borrowck-lend-flow-if.rs:40:21
+  --> $DIR/borrowck-lend-flow-if.rs:39:21
    |
 LL |         _w = &v;
    |               - immutable borrow occurs here
 LL |     }
 LL |     borrow_mut(&mut *v); //~ ERROR cannot borrow
    |                     ^^ mutable borrow occurs here
+LL |     _w.use_ref();
 LL | }
    | - immutable borrow ends here
 

--- a/src/test/ui/borrowck/borrowck-lend-flow.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-lend-flow.nll.stderr
@@ -1,0 +1,13 @@
+error[E0502]: cannot borrow `*v` as mutable because it is also borrowed as immutable
+  --> $DIR/borrowck-lend-flow.rs:34:16
+   |
+LL |     let _w = &v;
+   |              -- immutable borrow occurs here
+LL |     borrow_mut(&mut *v); //~ ERROR cannot borrow
+   |                ^^^^^^^ mutable borrow occurs here
+LL |     _w.use_ref();
+   |     -- borrow later used here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0502`.

--- a/src/test/ui/borrowck/borrowck-lend-flow.rs
+++ b/src/test/ui/borrowck/borrowck-lend-flow.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-compare-mode-nll
-
 // Note: the borrowck analysis is currently flow-insensitive.
 // Therefore, some of these errors are marked as spurious and could be
 // corrected by a simple change to the analysis.  The others are
@@ -34,6 +32,7 @@ fn pre_freeze() {
     let mut v: Box<_> = box 3;
     let _w = &v;
     borrow_mut(&mut *v); //~ ERROR cannot borrow
+    _w.use_ref();
 }
 
 fn post_freeze() {
@@ -45,3 +44,6 @@ fn post_freeze() {
 }
 
 fn main() {}
+
+trait Fake { fn use_mut(&mut self) { } fn use_ref(&self) { }  }
+impl<T> Fake for T { }

--- a/src/test/ui/borrowck/borrowck-lend-flow.stderr
+++ b/src/test/ui/borrowck/borrowck-lend-flow.stderr
@@ -1,10 +1,11 @@
 error[E0502]: cannot borrow `*v` as mutable because `v` is also borrowed as immutable
-  --> $DIR/borrowck-lend-flow.rs:36:21
+  --> $DIR/borrowck-lend-flow.rs:34:21
    |
 LL |     let _w = &v;
    |               - immutable borrow occurs here
 LL |     borrow_mut(&mut *v); //~ ERROR cannot borrow
    |                     ^^ mutable borrow occurs here
+LL |     _w.use_ref();
 LL | }
    | - immutable borrow ends here
 

--- a/src/test/ui/closure_promotion.rs
+++ b/src/test/ui/closure_promotion.rs
@@ -12,8 +12,7 @@
 
 #![allow(const_err)]
 
-// nll successfully compiles this. It is a bug.
-// See https://github.com/rust-lang/rust/issues/52384
+// nll successfully compiles this.
 fn main() {
     let x: &'static _ = &|| { let z = 3; z }; //~ ERROR does not live long enough
 }

--- a/src/test/ui/closure_promotion.stderr
+++ b/src/test/ui/closure_promotion.stderr
@@ -1,5 +1,5 @@
 error[E0597]: borrowed value does not live long enough
-  --> $DIR/closure_promotion.rs:18:26
+  --> $DIR/closure_promotion.rs:17:26
    |
 LL |     let x: &'static _ = &|| { let z = 3; z }; //~ ERROR does not live long enough
    |                          ^^^^^^^^^^^^^^^^^^^ temporary value does not live long enough

--- a/src/test/ui/regions/regions-bounded-by-trait-requiring-static.nll.stderr
+++ b/src/test/ui/regions/regions-bounded-by-trait-requiring-static.nll.stderr
@@ -1,0 +1,50 @@
+error: unsatisfied lifetime constraints
+  --> $DIR/regions-bounded-by-trait-requiring-static.rs:32:5
+   |
+LL | fn param_not_ok<'a>(x: &'a isize) {
+   |                 -- lifetime `'a` defined here
+LL |     assert_send::<&'a isize>(); //~ ERROR does not fulfill the required lifetime
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
+
+error: unsatisfied lifetime constraints
+  --> $DIR/regions-bounded-by-trait-requiring-static.rs:36:5
+   |
+LL | fn param_not_ok1<'a>(_: &'a isize) {
+   |                  -- lifetime `'a` defined here
+LL |     assert_send::<&'a str>(); //~ ERROR does not fulfill the required lifetime
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
+
+error: unsatisfied lifetime constraints
+  --> $DIR/regions-bounded-by-trait-requiring-static.rs:40:5
+   |
+LL | fn param_not_ok2<'a>(_: &'a isize) {
+   |                  -- lifetime `'a` defined here
+LL |     assert_send::<&'a [isize]>(); //~ ERROR does not fulfill the required lifetime
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
+
+error: unsatisfied lifetime constraints
+  --> $DIR/regions-bounded-by-trait-requiring-static.rs:54:5
+   |
+LL | fn box_with_region_not_ok<'a>() {
+   |                           -- lifetime `'a` defined here
+LL |     assert_send::<Box<&'a isize>>(); //~ ERROR does not fulfill the required lifetime
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
+
+error: unsatisfied lifetime constraints
+  --> $DIR/regions-bounded-by-trait-requiring-static.rs:65:5
+   |
+LL | fn unsafe_ok2<'a>(_: &'a isize) {
+   |               -- lifetime `'a` defined here
+LL |     assert_send::<*const &'a isize>(); //~ ERROR does not fulfill the required lifetime
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
+
+error: unsatisfied lifetime constraints
+  --> $DIR/regions-bounded-by-trait-requiring-static.rs:69:5
+   |
+LL | fn unsafe_ok3<'a>(_: &'a isize) {
+   |               -- lifetime `'a` defined here
+LL |     assert_send::<*mut &'a isize>(); //~ ERROR does not fulfill the required lifetime
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
+
+error: aborting due to 6 previous errors
+

--- a/src/test/ui/regions/regions-bounded-by-trait-requiring-static.rs
+++ b/src/test/ui/regions/regions-bounded-by-trait-requiring-static.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-compare-mode-nll
-
 // Test which of the builtin types are considered sendable. The tests
 // in this file all test region bound and lifetime violations that are
 // detected during type check.

--- a/src/test/ui/regions/regions-bounded-by-trait-requiring-static.stderr
+++ b/src/test/ui/regions/regions-bounded-by-trait-requiring-static.stderr
@@ -1,5 +1,5 @@
 error[E0477]: the type `&'a isize` does not fulfill the required lifetime
-  --> $DIR/regions-bounded-by-trait-requiring-static.rs:34:5
+  --> $DIR/regions-bounded-by-trait-requiring-static.rs:32:5
    |
 LL |     assert_send::<&'a isize>(); //~ ERROR does not fulfill the required lifetime
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL |     assert_send::<&'a isize>(); //~ ERROR does not fulfill the required lif
    = note: type must satisfy the static lifetime
 
 error[E0477]: the type `&'a str` does not fulfill the required lifetime
-  --> $DIR/regions-bounded-by-trait-requiring-static.rs:38:5
+  --> $DIR/regions-bounded-by-trait-requiring-static.rs:36:5
    |
 LL |     assert_send::<&'a str>(); //~ ERROR does not fulfill the required lifetime
    |     ^^^^^^^^^^^^^^^^^^^^^^
@@ -15,7 +15,7 @@ LL |     assert_send::<&'a str>(); //~ ERROR does not fulfill the required lifet
    = note: type must satisfy the static lifetime
 
 error[E0477]: the type `&'a [isize]` does not fulfill the required lifetime
-  --> $DIR/regions-bounded-by-trait-requiring-static.rs:42:5
+  --> $DIR/regions-bounded-by-trait-requiring-static.rs:40:5
    |
 LL |     assert_send::<&'a [isize]>(); //~ ERROR does not fulfill the required lifetime
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -23,7 +23,7 @@ LL |     assert_send::<&'a [isize]>(); //~ ERROR does not fulfill the required l
    = note: type must satisfy the static lifetime
 
 error[E0477]: the type `std::boxed::Box<&'a isize>` does not fulfill the required lifetime
-  --> $DIR/regions-bounded-by-trait-requiring-static.rs:56:5
+  --> $DIR/regions-bounded-by-trait-requiring-static.rs:54:5
    |
 LL |     assert_send::<Box<&'a isize>>(); //~ ERROR does not fulfill the required lifetime
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -31,7 +31,7 @@ LL |     assert_send::<Box<&'a isize>>(); //~ ERROR does not fulfill the require
    = note: type must satisfy the static lifetime
 
 error[E0477]: the type `*const &'a isize` does not fulfill the required lifetime
-  --> $DIR/regions-bounded-by-trait-requiring-static.rs:67:5
+  --> $DIR/regions-bounded-by-trait-requiring-static.rs:65:5
    |
 LL |     assert_send::<*const &'a isize>(); //~ ERROR does not fulfill the required lifetime
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -39,7 +39,7 @@ LL |     assert_send::<*const &'a isize>(); //~ ERROR does not fulfill the requi
    = note: type must satisfy the static lifetime
 
 error[E0477]: the type `*mut &'a isize` does not fulfill the required lifetime
-  --> $DIR/regions-bounded-by-trait-requiring-static.rs:71:5
+  --> $DIR/regions-bounded-by-trait-requiring-static.rs:69:5
    |
 LL |     assert_send::<*mut &'a isize>(); //~ ERROR does not fulfill the required lifetime
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/regions/regions-bounded-method-type-parameters.nll.stderr
+++ b/src/test/ui/regions/regions-bounded-method-type-parameters.nll.stderr
@@ -1,0 +1,19 @@
+error[E0621]: explicit lifetime required in the type of `x`
+  --> $DIR/regions-bounded-method-type-parameters.rs:22:5
+   |
+LL | fn caller<'a>(x: &isize) {
+   |                  ------ help: add explicit lifetime `'a` to the type of `x`: `&'a isize`
+LL |     Foo.some_method::<&'a isize>();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ lifetime `'a` required
+
+error: unsatisfied lifetime constraints
+  --> $DIR/regions-bounded-method-type-parameters.rs:22:5
+   |
+LL | fn caller<'a>(x: &isize) {
+   |           -- lifetime `'a` defined here
+LL |     Foo.some_method::<&'a isize>();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0621`.

--- a/src/test/ui/regions/regions-bounded-method-type-parameters.rs
+++ b/src/test/ui/regions/regions-bounded-method-type-parameters.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-compare-mode-nll
-
 // Check that explicit region bounds are allowed on the various
 // nominal types (but not on other types) and that they are type
 // checked.

--- a/src/test/ui/regions/regions-bounded-method-type-parameters.stderr
+++ b/src/test/ui/regions/regions-bounded-method-type-parameters.stderr
@@ -1,5 +1,5 @@
 error[E0477]: the type `&'a isize` does not fulfill the required lifetime
-  --> $DIR/regions-bounded-method-type-parameters.rs:24:9
+  --> $DIR/regions-bounded-method-type-parameters.rs:22:9
    |
 LL |     Foo.some_method::<&'a isize>();
    |         ^^^^^^^^^^^

--- a/src/test/ui/regions/regions-infer-contravariance-due-to-decl.nll.stderr
+++ b/src/test/ui/regions/regions-infer-contravariance-due-to-decl.nll.stderr
@@ -1,0 +1,13 @@
+error: unsatisfied lifetime constraints
+  --> $DIR/regions-infer-contravariance-due-to-decl.rs:35:9
+   |
+LL | fn use_<'short,'long>(c: Contravariant<'short>,
+   |         ------ ----- lifetime `'long` defined here
+   |         |
+   |         lifetime `'short` defined here
+...
+LL |     let _: Contravariant<'long> = c; //~ ERROR E0623
+   |         ^ type annotation requires that `'short` must outlive `'long`
+
+error: aborting due to previous error
+

--- a/src/test/ui/regions/regions-infer-contravariance-due-to-decl.rs
+++ b/src/test/ui/regions/regions-infer-contravariance-due-to-decl.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-compare-mode-nll
-
 // Test that a type which is contravariant with respect to its region
 // parameter yields an error when used in a covariant way.
 //

--- a/src/test/ui/regions/regions-infer-contravariance-due-to-decl.stderr
+++ b/src/test/ui/regions/regions-infer-contravariance-due-to-decl.stderr
@@ -1,5 +1,5 @@
 error[E0623]: lifetime mismatch
-  --> $DIR/regions-infer-contravariance-due-to-decl.rs:37:35
+  --> $DIR/regions-infer-contravariance-due-to-decl.rs:35:35
    |
 LL | fn use_<'short,'long>(c: Contravariant<'short>,
    |                          --------------------- these two types are declared with different lifetimes...

--- a/src/test/ui/regions/regions-infer-covariance-due-to-decl.nll.stderr
+++ b/src/test/ui/regions/regions-infer-covariance-due-to-decl.nll.stderr
@@ -1,0 +1,13 @@
+error: unsatisfied lifetime constraints
+  --> $DIR/regions-infer-covariance-due-to-decl.rs:32:9
+   |
+LL | fn use_<'short,'long>(c: Covariant<'long>,
+   |         ------ ----- lifetime `'long` defined here
+   |         |
+   |         lifetime `'short` defined here
+...
+LL |     let _: Covariant<'short> = c; //~ ERROR E0623
+   |         ^ type annotation requires that `'short` must outlive `'long`
+
+error: aborting due to previous error
+

--- a/src/test/ui/regions/regions-infer-covariance-due-to-decl.rs
+++ b/src/test/ui/regions/regions-infer-covariance-due-to-decl.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-compare-mode-nll
-
 // Test that a type which is covariant with respect to its region
 // parameter yields an error when used in a contravariant way.
 //

--- a/src/test/ui/regions/regions-infer-covariance-due-to-decl.stderr
+++ b/src/test/ui/regions/regions-infer-covariance-due-to-decl.stderr
@@ -1,5 +1,5 @@
 error[E0623]: lifetime mismatch
-  --> $DIR/regions-infer-covariance-due-to-decl.rs:34:32
+  --> $DIR/regions-infer-covariance-due-to-decl.rs:32:32
    |
 LL | fn use_<'short,'long>(c: Covariant<'long>,
    |                          ----------------

--- a/src/test/ui/regions/regions-outlives-projection-container.rs
+++ b/src/test/ui/regions/regions-outlives-projection-container.rs
@@ -14,8 +14,6 @@
 // type of a bound that appears in the where clause on a struct must
 // outlive the location in which the type appears. Issue #22246.
 
-// ignore-compare-mode-nll
-
 #![allow(dead_code)]
 #![feature(rustc_attrs)]
 

--- a/src/test/ui/regions/regions-outlives-projection-container.stderr
+++ b/src/test/ui/regions/regions-outlives-projection-container.stderr
@@ -1,67 +1,67 @@
 error[E0491]: in type `&'a WithAssoc<TheType<'b>>`, reference has a longer lifetime than the data it references
-  --> $DIR/regions-outlives-projection-container.rs:52:12
+  --> $DIR/regions-outlives-projection-container.rs:50:12
    |
 LL |     let _: &'a WithAssoc<TheType<'b>> = loop { }; //~ ERROR reference has a longer lifetime
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the pointer is valid for the lifetime 'a as defined on the function body at 46:15
-  --> $DIR/regions-outlives-projection-container.rs:46:15
+note: the pointer is valid for the lifetime 'a as defined on the function body at 44:15
+  --> $DIR/regions-outlives-projection-container.rs:44:15
    |
 LL | fn with_assoc<'a,'b>() {
    |               ^^
-note: but the referenced data is only valid for the lifetime 'b as defined on the function body at 46:18
-  --> $DIR/regions-outlives-projection-container.rs:46:18
+note: but the referenced data is only valid for the lifetime 'b as defined on the function body at 44:18
+  --> $DIR/regions-outlives-projection-container.rs:44:18
    |
 LL | fn with_assoc<'a,'b>() {
    |                  ^^
 
 error[E0491]: in type `&'a WithoutAssoc<TheType<'b>>`, reference has a longer lifetime than the data it references
-  --> $DIR/regions-outlives-projection-container.rs:69:12
+  --> $DIR/regions-outlives-projection-container.rs:67:12
    |
 LL |     let _: &'a WithoutAssoc<TheType<'b>> = loop { }; //~ ERROR reference has a longer lifetime
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the pointer is valid for the lifetime 'a as defined on the function body at 65:18
-  --> $DIR/regions-outlives-projection-container.rs:65:18
+note: the pointer is valid for the lifetime 'a as defined on the function body at 63:18
+  --> $DIR/regions-outlives-projection-container.rs:63:18
    |
 LL | fn without_assoc<'a,'b>() {
    |                  ^^
-note: but the referenced data is only valid for the lifetime 'b as defined on the function body at 65:21
-  --> $DIR/regions-outlives-projection-container.rs:65:21
+note: but the referenced data is only valid for the lifetime 'b as defined on the function body at 63:21
+  --> $DIR/regions-outlives-projection-container.rs:63:21
    |
 LL | fn without_assoc<'a,'b>() {
    |                     ^^
 
 error[E0491]: in type `&'a WithAssoc<TheType<'b>>`, reference has a longer lifetime than the data it references
-  --> $DIR/regions-outlives-projection-container.rs:77:12
+  --> $DIR/regions-outlives-projection-container.rs:75:12
    |
 LL |     call::<&'a WithAssoc<TheType<'b>>>();
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the pointer is valid for the lifetime 'a as defined on the function body at 72:20
-  --> $DIR/regions-outlives-projection-container.rs:72:20
+note: the pointer is valid for the lifetime 'a as defined on the function body at 70:20
+  --> $DIR/regions-outlives-projection-container.rs:70:20
    |
 LL | fn call_with_assoc<'a,'b>() {
    |                    ^^
-note: but the referenced data is only valid for the lifetime 'b as defined on the function body at 72:23
-  --> $DIR/regions-outlives-projection-container.rs:72:23
+note: but the referenced data is only valid for the lifetime 'b as defined on the function body at 70:23
+  --> $DIR/regions-outlives-projection-container.rs:70:23
    |
 LL | fn call_with_assoc<'a,'b>() {
    |                       ^^
 
 error[E0491]: in type `&'a WithoutAssoc<TheType<'b>>`, reference has a longer lifetime than the data it references
-  --> $DIR/regions-outlives-projection-container.rs:84:12
+  --> $DIR/regions-outlives-projection-container.rs:82:12
    |
 LL |     call::<&'a WithoutAssoc<TheType<'b>>>(); //~ ERROR reference has a longer lifetime
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the pointer is valid for the lifetime 'a as defined on the function body at 81:23
-  --> $DIR/regions-outlives-projection-container.rs:81:23
+note: the pointer is valid for the lifetime 'a as defined on the function body at 79:23
+  --> $DIR/regions-outlives-projection-container.rs:79:23
    |
 LL | fn call_without_assoc<'a,'b>() {
    |                       ^^
-note: but the referenced data is only valid for the lifetime 'b as defined on the function body at 81:26
-  --> $DIR/regions-outlives-projection-container.rs:81:26
+note: but the referenced data is only valid for the lifetime 'b as defined on the function body at 79:26
+  --> $DIR/regions-outlives-projection-container.rs:79:26
    |
 LL | fn call_without_assoc<'a,'b>() {
    |                          ^^

--- a/src/test/ui/regions/regions-variance-contravariant-use-covariant-in-second-position.nll.stderr
+++ b/src/test/ui/regions/regions-variance-contravariant-use-covariant-in-second-position.nll.stderr
@@ -1,0 +1,13 @@
+error: unsatisfied lifetime constraints
+  --> $DIR/regions-variance-contravariant-use-covariant-in-second-position.rs:35:9
+   |
+LL | fn use_<'short,'long>(c: S<'long, 'short>,
+   |         ------ ----- lifetime `'long` defined here
+   |         |
+   |         lifetime `'short` defined here
+...
+LL |     let _: S<'long, 'long> = c; //~ ERROR E0623
+   |         ^ type annotation requires that `'short` must outlive `'long`
+
+error: aborting due to previous error
+

--- a/src/test/ui/regions/regions-variance-contravariant-use-covariant-in-second-position.rs
+++ b/src/test/ui/regions/regions-variance-contravariant-use-covariant-in-second-position.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-compare-mode-nll
-
 // Test that a type which is covariant with respect to its region
 // parameter yields an error when used in a contravariant way.
 //

--- a/src/test/ui/regions/regions-variance-contravariant-use-covariant-in-second-position.stderr
+++ b/src/test/ui/regions/regions-variance-contravariant-use-covariant-in-second-position.stderr
@@ -1,5 +1,5 @@
 error[E0623]: lifetime mismatch
-  --> $DIR/regions-variance-contravariant-use-covariant-in-second-position.rs:37:30
+  --> $DIR/regions-variance-contravariant-use-covariant-in-second-position.rs:35:30
    |
 LL | fn use_<'short,'long>(c: S<'long, 'short>,
    |                          ----------------

--- a/src/test/ui/regions/regions-variance-contravariant-use-covariant.nll.stderr
+++ b/src/test/ui/regions/regions-variance-contravariant-use-covariant.nll.stderr
@@ -1,0 +1,13 @@
+error: unsatisfied lifetime constraints
+  --> $DIR/regions-variance-contravariant-use-covariant.rs:33:9
+   |
+LL | fn use_<'short,'long>(c: Contravariant<'short>,
+   |         ------ ----- lifetime `'long` defined here
+   |         |
+   |         lifetime `'short` defined here
+...
+LL |     let _: Contravariant<'long> = c; //~ ERROR E0623
+   |         ^ type annotation requires that `'short` must outlive `'long`
+
+error: aborting due to previous error
+

--- a/src/test/ui/regions/regions-variance-contravariant-use-covariant.rs
+++ b/src/test/ui/regions/regions-variance-contravariant-use-covariant.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-compare-mode-nll
-
 // Test that a type which is covariant with respect to its region
 // parameter yields an error when used in a contravariant way.
 //

--- a/src/test/ui/regions/regions-variance-contravariant-use-covariant.stderr
+++ b/src/test/ui/regions/regions-variance-contravariant-use-covariant.stderr
@@ -1,5 +1,5 @@
 error[E0623]: lifetime mismatch
-  --> $DIR/regions-variance-contravariant-use-covariant.rs:35:35
+  --> $DIR/regions-variance-contravariant-use-covariant.rs:33:35
    |
 LL | fn use_<'short,'long>(c: Contravariant<'short>,
    |                          --------------------- these two types are declared with different lifetimes...

--- a/src/test/ui/regions/regions-variance-covariant-use-contravariant.nll.stderr
+++ b/src/test/ui/regions/regions-variance-covariant-use-contravariant.nll.stderr
@@ -1,0 +1,13 @@
+error: unsatisfied lifetime constraints
+  --> $DIR/regions-variance-covariant-use-contravariant.rs:33:9
+   |
+LL | fn use_<'short,'long>(c: Covariant<'long>,
+   |         ------ ----- lifetime `'long` defined here
+   |         |
+   |         lifetime `'short` defined here
+...
+LL |     let _: Covariant<'short> = c; //~ ERROR E0623
+   |         ^ type annotation requires that `'short` must outlive `'long`
+
+error: aborting due to previous error
+

--- a/src/test/ui/regions/regions-variance-covariant-use-contravariant.rs
+++ b/src/test/ui/regions/regions-variance-covariant-use-contravariant.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-compare-mode-nll
-
 // Test that a type which is covariant with respect to its region
 // parameter yields an error when used in a contravariant way.
 //

--- a/src/test/ui/regions/regions-variance-covariant-use-contravariant.stderr
+++ b/src/test/ui/regions/regions-variance-covariant-use-contravariant.stderr
@@ -1,5 +1,5 @@
 error[E0623]: lifetime mismatch
-  --> $DIR/regions-variance-covariant-use-contravariant.rs:35:32
+  --> $DIR/regions-variance-covariant-use-contravariant.rs:33:32
    |
 LL | fn use_<'short,'long>(c: Covariant<'long>,
    |                          ----------------

--- a/src/test/ui/regions/regions-variance-invariant-use-contravariant.nll.stderr
+++ b/src/test/ui/regions/regions-variance-invariant-use-contravariant.nll.stderr
@@ -1,0 +1,13 @@
+error: unsatisfied lifetime constraints
+  --> $DIR/regions-variance-invariant-use-contravariant.rs:30:9
+   |
+LL | fn use_<'short,'long>(c: Invariant<'long>,
+   |         ------ ----- lifetime `'long` defined here
+   |         |
+   |         lifetime `'short` defined here
+...
+LL |     let _: Invariant<'short> = c; //~ ERROR E0623
+   |         ^ type annotation requires that `'short` must outlive `'long`
+
+error: aborting due to previous error
+

--- a/src/test/ui/regions/regions-variance-invariant-use-contravariant.rs
+++ b/src/test/ui/regions/regions-variance-invariant-use-contravariant.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-compare-mode-nll
-
 // Test that an invariant region parameter used in a contravariant way
 // yields an error.
 //

--- a/src/test/ui/regions/regions-variance-invariant-use-contravariant.stderr
+++ b/src/test/ui/regions/regions-variance-invariant-use-contravariant.stderr
@@ -1,5 +1,5 @@
 error[E0623]: lifetime mismatch
-  --> $DIR/regions-variance-invariant-use-contravariant.rs:32:32
+  --> $DIR/regions-variance-invariant-use-contravariant.rs:30:32
    |
 LL | fn use_<'short,'long>(c: Invariant<'long>,
    |                          ----------------

--- a/src/test/ui/regions/regions-variance-invariant-use-covariant.nll.stderr
+++ b/src/test/ui/regions/regions-variance-invariant-use-covariant.nll.stderr
@@ -1,0 +1,11 @@
+error: unsatisfied lifetime constraints
+  --> $DIR/regions-variance-invariant-use-covariant.rs:27:9
+   |
+LL | fn use_<'b>(c: Invariant<'b>) {
+   |         -- lifetime `'b` defined here
+...
+LL |     let _: Invariant<'static> = c; //~ ERROR mismatched types
+   |         ^ type annotation requires that `'b` must outlive `'static`
+
+error: aborting due to previous error
+

--- a/src/test/ui/regions/regions-variance-invariant-use-covariant.rs
+++ b/src/test/ui/regions/regions-variance-invariant-use-covariant.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-compare-mode-nll
-
 // Test that a type which is invariant with respect to its region
 // parameter used in a covariant way yields an error.
 //

--- a/src/test/ui/regions/regions-variance-invariant-use-covariant.stderr
+++ b/src/test/ui/regions/regions-variance-invariant-use-covariant.stderr
@@ -1,13 +1,13 @@
 error[E0308]: mismatched types
-  --> $DIR/regions-variance-invariant-use-covariant.rs:29:33
+  --> $DIR/regions-variance-invariant-use-covariant.rs:27:33
    |
 LL |     let _: Invariant<'static> = c; //~ ERROR mismatched types
    |                                 ^ lifetime mismatch
    |
    = note: expected type `Invariant<'static>`
               found type `Invariant<'b>`
-note: the lifetime 'b as defined on the function body at 23:9...
-  --> $DIR/regions-variance-invariant-use-covariant.rs:23:9
+note: the lifetime 'b as defined on the function body at 21:9...
+  --> $DIR/regions-variance-invariant-use-covariant.rs:21:9
    |
 LL | fn use_<'b>(c: Invariant<'b>) {
    |         ^^

--- a/src/test/ui/variance/variance-cell-is-invariant.nll.stderr
+++ b/src/test/ui/variance/variance-cell-is-invariant.nll.stderr
@@ -1,0 +1,13 @@
+error: unsatisfied lifetime constraints
+  --> $DIR/variance-cell-is-invariant.rs:24:9
+   |
+LL | fn use_<'short,'long>(c: Foo<'short>,
+   |         ------ ----- lifetime `'long` defined here
+   |         |
+   |         lifetime `'short` defined here
+...
+LL |     let _: Foo<'long> = c; //~ ERROR E0623
+   |         ^ type annotation requires that `'short` must outlive `'long`
+
+error: aborting due to previous error
+

--- a/src/test/ui/variance/variance-cell-is-invariant.rs
+++ b/src/test/ui/variance/variance-cell-is-invariant.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-compare-mode-nll
-
 // Test that Cell is considered invariant with respect to its
 // type.
 

--- a/src/test/ui/variance/variance-cell-is-invariant.stderr
+++ b/src/test/ui/variance/variance-cell-is-invariant.stderr
@@ -1,5 +1,5 @@
 error[E0623]: lifetime mismatch
-  --> $DIR/variance-cell-is-invariant.rs:26:25
+  --> $DIR/variance-cell-is-invariant.rs:24:25
    |
 LL | fn use_<'short,'long>(c: Foo<'short>,
    |                          ----------- these two types are declared with different lifetimes...

--- a/src/test/ui/variance/variance-contravariant-arg-trait-match.nll.stderr
+++ b/src/test/ui/variance/variance-contravariant-arg-trait-match.nll.stderr
@@ -1,0 +1,24 @@
+error: unsatisfied lifetime constraints
+  --> $DIR/variance-contravariant-arg-trait-match.rs:23:5
+   |
+LL | fn get_min_from_max<'min, 'max, G>()
+   |                     ----  ---- lifetime `'max` defined here
+   |                     |
+   |                     lifetime `'min` defined here
+...
+LL |     impls_get::<G,&'min i32>() //~ ERROR mismatched types
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'min` must outlive `'max`
+
+error: unsatisfied lifetime constraints
+  --> $DIR/variance-contravariant-arg-trait-match.rs:31:5
+   |
+LL | fn get_max_from_min<'min, 'max, G>()
+   |                     ----  ---- lifetime `'max` defined here
+   |                     |
+   |                     lifetime `'min` defined here
+...
+LL |     impls_get::<G,&'max i32>() //~ ERROR mismatched types
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'min` must outlive `'max`
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/variance/variance-contravariant-arg-trait-match.rs
+++ b/src/test/ui/variance/variance-contravariant-arg-trait-match.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-compare-mode-nll
-
 #![allow(dead_code)]
 
 // Test that even when `T` is only used in contravariant position, it

--- a/src/test/ui/variance/variance-contravariant-arg-trait-match.stderr
+++ b/src/test/ui/variance/variance-contravariant-arg-trait-match.stderr
@@ -1,37 +1,37 @@
 error[E0308]: mismatched types
-  --> $DIR/variance-contravariant-arg-trait-match.rs:25:5
+  --> $DIR/variance-contravariant-arg-trait-match.rs:23:5
    |
 LL |     impls_get::<G,&'min i32>() //~ ERROR mismatched types
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
    = note: expected type `Get<&'min i32>`
               found type `Get<&'max i32>`
-note: the lifetime 'min as defined on the function body at 22:21...
-  --> $DIR/variance-contravariant-arg-trait-match.rs:22:21
+note: the lifetime 'min as defined on the function body at 20:21...
+  --> $DIR/variance-contravariant-arg-trait-match.rs:20:21
    |
 LL | fn get_min_from_max<'min, 'max, G>()
    |                     ^^^^
-note: ...does not necessarily outlive the lifetime 'max as defined on the function body at 22:27
-  --> $DIR/variance-contravariant-arg-trait-match.rs:22:27
+note: ...does not necessarily outlive the lifetime 'max as defined on the function body at 20:27
+  --> $DIR/variance-contravariant-arg-trait-match.rs:20:27
    |
 LL | fn get_min_from_max<'min, 'max, G>()
    |                           ^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/variance-contravariant-arg-trait-match.rs:33:5
+  --> $DIR/variance-contravariant-arg-trait-match.rs:31:5
    |
 LL |     impls_get::<G,&'max i32>() //~ ERROR mismatched types
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
    = note: expected type `Get<&'max i32>`
               found type `Get<&'min i32>`
-note: the lifetime 'min as defined on the function body at 28:21...
-  --> $DIR/variance-contravariant-arg-trait-match.rs:28:21
+note: the lifetime 'min as defined on the function body at 26:21...
+  --> $DIR/variance-contravariant-arg-trait-match.rs:26:21
    |
 LL | fn get_max_from_min<'min, 'max, G>()
    |                     ^^^^
-note: ...does not necessarily outlive the lifetime 'max as defined on the function body at 28:27
-  --> $DIR/variance-contravariant-arg-trait-match.rs:28:27
+note: ...does not necessarily outlive the lifetime 'max as defined on the function body at 26:27
+  --> $DIR/variance-contravariant-arg-trait-match.rs:26:27
    |
 LL | fn get_max_from_min<'min, 'max, G>()
    |                           ^^^^

--- a/src/test/ui/variance/variance-contravariant-self-trait-match.nll.stderr
+++ b/src/test/ui/variance/variance-contravariant-self-trait-match.nll.stderr
@@ -1,0 +1,24 @@
+error: unsatisfied lifetime constraints
+  --> $DIR/variance-contravariant-self-trait-match.rs:23:5
+   |
+LL | fn get_min_from_max<'min, 'max, G>()
+   |                     ----  ---- lifetime `'max` defined here
+   |                     |
+   |                     lifetime `'min` defined here
+...
+LL |     impls_get::<&'min G>(); //~ ERROR mismatched types
+   |     ^^^^^^^^^^^^^^^^^^^^^^ requires that `'min` must outlive `'max`
+
+error: unsatisfied lifetime constraints
+  --> $DIR/variance-contravariant-self-trait-match.rs:32:5
+   |
+LL | fn get_max_from_min<'min, 'max, G>()
+   |                     ----  ---- lifetime `'max` defined here
+   |                     |
+   |                     lifetime `'min` defined here
+...
+LL |     impls_get::<&'max G>(); //~ ERROR mismatched types
+   |     ^^^^^^^^^^^^^^^^^^^^^^ requires that `'min` must outlive `'max`
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/variance/variance-contravariant-self-trait-match.rs
+++ b/src/test/ui/variance/variance-contravariant-self-trait-match.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-compare-mode-nll
-
 #![allow(dead_code)]
 
 // Test that even when `Self` is only used in contravariant position, it

--- a/src/test/ui/variance/variance-contravariant-self-trait-match.stderr
+++ b/src/test/ui/variance/variance-contravariant-self-trait-match.stderr
@@ -1,37 +1,37 @@
 error[E0308]: mismatched types
-  --> $DIR/variance-contravariant-self-trait-match.rs:25:5
+  --> $DIR/variance-contravariant-self-trait-match.rs:23:5
    |
 LL |     impls_get::<&'min G>(); //~ ERROR mismatched types
    |     ^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
    = note: expected type `Get`
               found type `Get`
-note: the lifetime 'min as defined on the function body at 22:21...
-  --> $DIR/variance-contravariant-self-trait-match.rs:22:21
+note: the lifetime 'min as defined on the function body at 20:21...
+  --> $DIR/variance-contravariant-self-trait-match.rs:20:21
    |
 LL | fn get_min_from_max<'min, 'max, G>()
    |                     ^^^^
-note: ...does not necessarily outlive the lifetime 'max as defined on the function body at 22:27
-  --> $DIR/variance-contravariant-self-trait-match.rs:22:27
+note: ...does not necessarily outlive the lifetime 'max as defined on the function body at 20:27
+  --> $DIR/variance-contravariant-self-trait-match.rs:20:27
    |
 LL | fn get_min_from_max<'min, 'max, G>()
    |                           ^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/variance-contravariant-self-trait-match.rs:34:5
+  --> $DIR/variance-contravariant-self-trait-match.rs:32:5
    |
 LL |     impls_get::<&'max G>(); //~ ERROR mismatched types
    |     ^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
    = note: expected type `Get`
               found type `Get`
-note: the lifetime 'min as defined on the function body at 28:21...
-  --> $DIR/variance-contravariant-self-trait-match.rs:28:21
+note: the lifetime 'min as defined on the function body at 26:21...
+  --> $DIR/variance-contravariant-self-trait-match.rs:26:21
    |
 LL | fn get_max_from_min<'min, 'max, G>()
    |                     ^^^^
-note: ...does not necessarily outlive the lifetime 'max as defined on the function body at 28:27
-  --> $DIR/variance-contravariant-self-trait-match.rs:28:27
+note: ...does not necessarily outlive the lifetime 'max as defined on the function body at 26:27
+  --> $DIR/variance-contravariant-self-trait-match.rs:26:27
    |
 LL | fn get_max_from_min<'min, 'max, G>()
    |                           ^^^^

--- a/src/test/ui/variance/variance-covariant-arg-trait-match.nll.stderr
+++ b/src/test/ui/variance/variance-covariant-arg-trait-match.nll.stderr
@@ -1,0 +1,24 @@
+error: unsatisfied lifetime constraints
+  --> $DIR/variance-covariant-arg-trait-match.rs:24:5
+   |
+LL | fn get_min_from_max<'min, 'max, G>()
+   |                     ----  ---- lifetime `'max` defined here
+   |                     |
+   |                     lifetime `'min` defined here
+...
+LL |     impls_get::<G,&'min i32>() //~ ERROR mismatched types
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'min` must outlive `'max`
+
+error: unsatisfied lifetime constraints
+  --> $DIR/variance-covariant-arg-trait-match.rs:30:5
+   |
+LL | fn get_max_from_min<'min, 'max, G>()
+   |                     ----  ---- lifetime `'max` defined here
+   |                     |
+   |                     lifetime `'min` defined here
+...
+LL |     impls_get::<G,&'max i32>() //~ ERROR mismatched types
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'min` must outlive `'max`
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/variance/variance-covariant-arg-trait-match.rs
+++ b/src/test/ui/variance/variance-covariant-arg-trait-match.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-compare-mode-nll
-
 #![allow(dead_code)]
 
 // Test that even when `T` is only used in covariant position, it

--- a/src/test/ui/variance/variance-covariant-arg-trait-match.stderr
+++ b/src/test/ui/variance/variance-covariant-arg-trait-match.stderr
@@ -1,37 +1,37 @@
 error[E0308]: mismatched types
-  --> $DIR/variance-covariant-arg-trait-match.rs:26:5
+  --> $DIR/variance-covariant-arg-trait-match.rs:24:5
    |
 LL |     impls_get::<G,&'min i32>() //~ ERROR mismatched types
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
    = note: expected type `Get<&'min i32>`
               found type `Get<&'max i32>`
-note: the lifetime 'min as defined on the function body at 22:21...
-  --> $DIR/variance-covariant-arg-trait-match.rs:22:21
+note: the lifetime 'min as defined on the function body at 20:21...
+  --> $DIR/variance-covariant-arg-trait-match.rs:20:21
    |
 LL | fn get_min_from_max<'min, 'max, G>()
    |                     ^^^^
-note: ...does not necessarily outlive the lifetime 'max as defined on the function body at 22:27
-  --> $DIR/variance-covariant-arg-trait-match.rs:22:27
+note: ...does not necessarily outlive the lifetime 'max as defined on the function body at 20:27
+  --> $DIR/variance-covariant-arg-trait-match.rs:20:27
    |
 LL | fn get_min_from_max<'min, 'max, G>()
    |                           ^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/variance-covariant-arg-trait-match.rs:32:5
+  --> $DIR/variance-covariant-arg-trait-match.rs:30:5
    |
 LL |     impls_get::<G,&'max i32>() //~ ERROR mismatched types
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
    = note: expected type `Get<&'max i32>`
               found type `Get<&'min i32>`
-note: the lifetime 'min as defined on the function body at 29:21...
-  --> $DIR/variance-covariant-arg-trait-match.rs:29:21
+note: the lifetime 'min as defined on the function body at 27:21...
+  --> $DIR/variance-covariant-arg-trait-match.rs:27:21
    |
 LL | fn get_max_from_min<'min, 'max, G>()
    |                     ^^^^
-note: ...does not necessarily outlive the lifetime 'max as defined on the function body at 29:27
-  --> $DIR/variance-covariant-arg-trait-match.rs:29:27
+note: ...does not necessarily outlive the lifetime 'max as defined on the function body at 27:27
+  --> $DIR/variance-covariant-arg-trait-match.rs:27:27
    |
 LL | fn get_max_from_min<'min, 'max, G>()
    |                           ^^^^

--- a/src/test/ui/variance/variance-covariant-self-trait-match.nll.stderr
+++ b/src/test/ui/variance/variance-covariant-self-trait-match.nll.stderr
@@ -1,0 +1,24 @@
+error: unsatisfied lifetime constraints
+  --> $DIR/variance-covariant-self-trait-match.rs:24:5
+   |
+LL | fn get_min_from_max<'min, 'max, G>()
+   |                     ----  ---- lifetime `'max` defined here
+   |                     |
+   |                     lifetime `'min` defined here
+...
+LL |     impls_get::<&'min G>(); //~ ERROR mismatched types
+   |     ^^^^^^^^^^^^^^^^^^^^^^ requires that `'min` must outlive `'max`
+
+error: unsatisfied lifetime constraints
+  --> $DIR/variance-covariant-self-trait-match.rs:30:5
+   |
+LL | fn get_max_from_min<'min, 'max, G>()
+   |                     ----  ---- lifetime `'max` defined here
+   |                     |
+   |                     lifetime `'min` defined here
+...
+LL |     impls_get::<&'max G>(); //~ ERROR mismatched types
+   |     ^^^^^^^^^^^^^^^^^^^^^^ requires that `'min` must outlive `'max`
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/variance/variance-covariant-self-trait-match.rs
+++ b/src/test/ui/variance/variance-covariant-self-trait-match.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-compare-mode-nll
-
 #![allow(dead_code)]
 
 // Test that even when `Self` is only used in covariant position, it

--- a/src/test/ui/variance/variance-covariant-self-trait-match.stderr
+++ b/src/test/ui/variance/variance-covariant-self-trait-match.stderr
@@ -1,37 +1,37 @@
 error[E0308]: mismatched types
-  --> $DIR/variance-covariant-self-trait-match.rs:26:5
+  --> $DIR/variance-covariant-self-trait-match.rs:24:5
    |
 LL |     impls_get::<&'min G>(); //~ ERROR mismatched types
    |     ^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
    = note: expected type `Get`
               found type `Get`
-note: the lifetime 'min as defined on the function body at 22:21...
-  --> $DIR/variance-covariant-self-trait-match.rs:22:21
+note: the lifetime 'min as defined on the function body at 20:21...
+  --> $DIR/variance-covariant-self-trait-match.rs:20:21
    |
 LL | fn get_min_from_max<'min, 'max, G>()
    |                     ^^^^
-note: ...does not necessarily outlive the lifetime 'max as defined on the function body at 22:27
-  --> $DIR/variance-covariant-self-trait-match.rs:22:27
+note: ...does not necessarily outlive the lifetime 'max as defined on the function body at 20:27
+  --> $DIR/variance-covariant-self-trait-match.rs:20:27
    |
 LL | fn get_min_from_max<'min, 'max, G>()
    |                           ^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/variance-covariant-self-trait-match.rs:32:5
+  --> $DIR/variance-covariant-self-trait-match.rs:30:5
    |
 LL |     impls_get::<&'max G>(); //~ ERROR mismatched types
    |     ^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
    = note: expected type `Get`
               found type `Get`
-note: the lifetime 'min as defined on the function body at 29:21...
-  --> $DIR/variance-covariant-self-trait-match.rs:29:21
+note: the lifetime 'min as defined on the function body at 27:21...
+  --> $DIR/variance-covariant-self-trait-match.rs:27:21
    |
 LL | fn get_max_from_min<'min, 'max, G>()
    |                     ^^^^
-note: ...does not necessarily outlive the lifetime 'max as defined on the function body at 29:27
-  --> $DIR/variance-covariant-self-trait-match.rs:29:27
+note: ...does not necessarily outlive the lifetime 'max as defined on the function body at 27:27
+  --> $DIR/variance-covariant-self-trait-match.rs:27:27
    |
 LL | fn get_max_from_min<'min, 'max, G>()
    |                           ^^^^

--- a/src/test/ui/variance/variance-invariant-arg-trait-match.nll.stderr
+++ b/src/test/ui/variance/variance-invariant-arg-trait-match.nll.stderr
@@ -1,0 +1,24 @@
+error: unsatisfied lifetime constraints
+  --> $DIR/variance-invariant-arg-trait-match.rs:20:5
+   |
+LL | fn get_min_from_max<'min, 'max, G>()
+   |                     ----  ---- lifetime `'max` defined here
+   |                     |
+   |                     lifetime `'min` defined here
+...
+LL |     impls_get::<G,&'min i32>() //~ ERROR mismatched types
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'min` must outlive `'max`
+
+error: unsatisfied lifetime constraints
+  --> $DIR/variance-invariant-arg-trait-match.rs:26:5
+   |
+LL | fn get_max_from_min<'min, 'max, G>()
+   |                     ----  ---- lifetime `'max` defined here
+   |                     |
+   |                     lifetime `'min` defined here
+...
+LL |     impls_get::<G,&'max i32>() //~ ERROR mismatched types
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'min` must outlive `'max`
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/variance/variance-invariant-arg-trait-match.rs
+++ b/src/test/ui/variance/variance-invariant-arg-trait-match.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-compare-mode-nll
-
 #![allow(dead_code)]
 
 trait Get<T> {

--- a/src/test/ui/variance/variance-invariant-arg-trait-match.stderr
+++ b/src/test/ui/variance/variance-invariant-arg-trait-match.stderr
@@ -1,37 +1,37 @@
 error[E0308]: mismatched types
-  --> $DIR/variance-invariant-arg-trait-match.rs:22:5
+  --> $DIR/variance-invariant-arg-trait-match.rs:20:5
    |
 LL |     impls_get::<G,&'min i32>() //~ ERROR mismatched types
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
    = note: expected type `Get<&'min i32>`
               found type `Get<&'max i32>`
-note: the lifetime 'min as defined on the function body at 19:21...
-  --> $DIR/variance-invariant-arg-trait-match.rs:19:21
+note: the lifetime 'min as defined on the function body at 17:21...
+  --> $DIR/variance-invariant-arg-trait-match.rs:17:21
    |
 LL | fn get_min_from_max<'min, 'max, G>()
    |                     ^^^^
-note: ...does not necessarily outlive the lifetime 'max as defined on the function body at 19:27
-  --> $DIR/variance-invariant-arg-trait-match.rs:19:27
+note: ...does not necessarily outlive the lifetime 'max as defined on the function body at 17:27
+  --> $DIR/variance-invariant-arg-trait-match.rs:17:27
    |
 LL | fn get_min_from_max<'min, 'max, G>()
    |                           ^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/variance-invariant-arg-trait-match.rs:28:5
+  --> $DIR/variance-invariant-arg-trait-match.rs:26:5
    |
 LL |     impls_get::<G,&'max i32>() //~ ERROR mismatched types
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
    = note: expected type `Get<&'max i32>`
               found type `Get<&'min i32>`
-note: the lifetime 'min as defined on the function body at 25:21...
-  --> $DIR/variance-invariant-arg-trait-match.rs:25:21
+note: the lifetime 'min as defined on the function body at 23:21...
+  --> $DIR/variance-invariant-arg-trait-match.rs:23:21
    |
 LL | fn get_max_from_min<'min, 'max, G>()
    |                     ^^^^
-note: ...does not necessarily outlive the lifetime 'max as defined on the function body at 25:27
-  --> $DIR/variance-invariant-arg-trait-match.rs:25:27
+note: ...does not necessarily outlive the lifetime 'max as defined on the function body at 23:27
+  --> $DIR/variance-invariant-arg-trait-match.rs:23:27
    |
 LL | fn get_max_from_min<'min, 'max, G>()
    |                           ^^^^

--- a/src/test/ui/variance/variance-invariant-self-trait-match.nll.stderr
+++ b/src/test/ui/variance/variance-invariant-self-trait-match.nll.stderr
@@ -1,0 +1,24 @@
+error: unsatisfied lifetime constraints
+  --> $DIR/variance-invariant-self-trait-match.rs:20:5
+   |
+LL | fn get_min_from_max<'min, 'max, G>()
+   |                     ----  ---- lifetime `'max` defined here
+   |                     |
+   |                     lifetime `'min` defined here
+...
+LL |     impls_get::<&'min G>(); //~ ERROR mismatched types
+   |     ^^^^^^^^^^^^^^^^^^^^^^ requires that `'min` must outlive `'max`
+
+error: unsatisfied lifetime constraints
+  --> $DIR/variance-invariant-self-trait-match.rs:26:5
+   |
+LL | fn get_max_from_min<'min, 'max, G>()
+   |                     ----  ---- lifetime `'max` defined here
+   |                     |
+   |                     lifetime `'min` defined here
+...
+LL |     impls_get::<&'max G>(); //~ ERROR mismatched types
+   |     ^^^^^^^^^^^^^^^^^^^^^^ requires that `'min` must outlive `'max`
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/variance/variance-invariant-self-trait-match.rs
+++ b/src/test/ui/variance/variance-invariant-self-trait-match.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-compare-mode-nll
-
 #![allow(dead_code)]
 
 trait Get {

--- a/src/test/ui/variance/variance-invariant-self-trait-match.stderr
+++ b/src/test/ui/variance/variance-invariant-self-trait-match.stderr
@@ -1,37 +1,37 @@
 error[E0308]: mismatched types
-  --> $DIR/variance-invariant-self-trait-match.rs:22:5
+  --> $DIR/variance-invariant-self-trait-match.rs:20:5
    |
 LL |     impls_get::<&'min G>(); //~ ERROR mismatched types
    |     ^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
    = note: expected type `Get`
               found type `Get`
-note: the lifetime 'min as defined on the function body at 19:21...
-  --> $DIR/variance-invariant-self-trait-match.rs:19:21
+note: the lifetime 'min as defined on the function body at 17:21...
+  --> $DIR/variance-invariant-self-trait-match.rs:17:21
    |
 LL | fn get_min_from_max<'min, 'max, G>()
    |                     ^^^^
-note: ...does not necessarily outlive the lifetime 'max as defined on the function body at 19:27
-  --> $DIR/variance-invariant-self-trait-match.rs:19:27
+note: ...does not necessarily outlive the lifetime 'max as defined on the function body at 17:27
+  --> $DIR/variance-invariant-self-trait-match.rs:17:27
    |
 LL | fn get_min_from_max<'min, 'max, G>()
    |                           ^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/variance-invariant-self-trait-match.rs:28:5
+  --> $DIR/variance-invariant-self-trait-match.rs:26:5
    |
 LL |     impls_get::<&'max G>(); //~ ERROR mismatched types
    |     ^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
    = note: expected type `Get`
               found type `Get`
-note: the lifetime 'min as defined on the function body at 25:21...
-  --> $DIR/variance-invariant-self-trait-match.rs:25:21
+note: the lifetime 'min as defined on the function body at 23:21...
+  --> $DIR/variance-invariant-self-trait-match.rs:23:21
    |
 LL | fn get_max_from_min<'min, 'max, G>()
    |                     ^^^^
-note: ...does not necessarily outlive the lifetime 'max as defined on the function body at 25:27
-  --> $DIR/variance-invariant-self-trait-match.rs:25:27
+note: ...does not necessarily outlive the lifetime 'max as defined on the function body at 23:27
+  --> $DIR/variance-invariant-self-trait-match.rs:23:27
    |
 LL | fn get_max_from_min<'min, 'max, G>()
    |                           ^^^^


### PR DESCRIPTION
Most of these tests were disabled due to NLL bugs that have since been fixed. A few needed updating for NLL.

r? @nikomatsakis 