### PR TITLE
Do not put noalias annotations by default

### DIFF
--- a/src/test/codegen/function-arguments.rs
+++ b/src/test/codegen/function-arguments.rs
@@ -53,13 +53,13 @@ pub fn named_borrow<'r>(_: &'r i32) {
 pub fn unsafe_borrow(_: &UnsafeInner) {
 }
 
-// CHECK: @mutable_unsafe_borrow(i16* noalias dereferenceable(2) %arg0)
+// CHECK: @mutable_unsafe_borrow(i16* dereferenceable(2) %arg0)
 // ... unless this is a mutable borrow, those never alias
 #[no_mangle]
 pub fn mutable_unsafe_borrow(_: &mut UnsafeInner) {
 }
 
-// CHECK: @mutable_borrow(i32* noalias dereferenceable(4) %arg0)
+// CHECK: @mutable_borrow(i32* dereferenceable(4) %arg0)
 // FIXME #25759 This should also have `nocapture`
 #[no_mangle]
 pub fn mutable_borrow(_: &mut i32) {
@@ -102,7 +102,7 @@ pub fn helper(_: usize) {
 pub fn slice(_: &[u8]) {
 }
 
-// CHECK: @mutable_slice([0 x i8]* noalias nonnull %arg0.0, [[USIZE]] %arg0.1)
+// CHECK: @mutable_slice([0 x i8]* nonnull %arg0.0, [[USIZE]] %arg0.1)
 // FIXME #25759 This should also have `nocapture`
 #[no_mangle]
 pub fn mutable_slice(_: &mut [u8]) {

--- a/src/test/run-pass/issue-54462-mutable-noalias-correctness.rs
+++ b/src/test/run-pass/issue-54462-mutable-noalias-correctness.rs
@@ -1,0 +1,33 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+//
+// compile-flags: -Ccodegen-units=1 -O
+
+fn linidx(row: usize, col: usize) -> usize {
+    row * 1 + col * 3
+}
+
+fn main() {
+    let mut mat = [1.0f32, 5.0, 9.0, 2.0, 6.0, 10.0, 3.0, 7.0, 11.0, 4.0, 8.0, 12.0];
+
+    for i in 0..2 {
+        for j in i+1..3 {
+            if mat[linidx(j, 3)] > mat[linidx(i, 3)] {
+                    for k in 0..4 {
+                            let (x, rest) = mat.split_at_mut(linidx(i, k) + 1);
+                            let a = x.last_mut().unwrap();
+                            let b = rest.get_mut(linidx(j, k) - linidx(i, k) - 1).unwrap();
+                            ::std::mem::swap(a, b);
+                    }
+            }
+        }
+    }
+    assert_eq!([9.0, 5.0, 1.0, 10.0, 6.0, 2.0, 11.0, 7.0, 3.0, 12.0, 8.0, 4.0], mat);
+}


### PR DESCRIPTION
This will be re-enabled sooner or later depending on results of further
investigation.

Fixes #54462 

Beta backport is: #54640

r? @nikomatsakis 