### PR TITLE
A few cleanups and minor improvements to rustc/infer

### DIFF
--- a/src/librustc/infer/canonical/query_result.rs
+++ b/src/librustc/infer/canonical/query_result.rs
@@ -499,24 +499,22 @@ impl<'cx, 'gcx, 'tcx> InferCtxt<'cx, 'gcx, 'tcx> {
                     let ty::OutlivesPredicate(k1, r2) = constraint.skip_binder(); // restored below
                     let k1 = substitute_value(self.tcx, result_subst, k1);
                     let r2 = substitute_value(self.tcx, result_subst, r2);
-                    match k1.unpack() {
-                        UnpackedKind::Lifetime(r1) => Obligation::new(
-                            cause.clone(),
-                            param_env,
-                            ty::Predicate::RegionOutlives(ty::Binder::dummy(
-                                ty::OutlivesPredicate(r1, r2),
-                            )),
-                        ),
 
-                        UnpackedKind::Type(t1) => Obligation::new(
-                            cause.clone(),
-                            param_env,
-                            ty::Predicate::TypeOutlives(ty::Binder::dummy(ty::OutlivesPredicate(
-                                t1, r2,
-                            ))),
-                        ),
-                    }
-                }),
+                    Obligation::new(
+                        cause.clone(),
+                        param_env,
+                        match k1.unpack() {
+                            UnpackedKind::Lifetime(r1) => ty::Predicate::RegionOutlives(
+                                ty::Binder::dummy(
+                                    ty::OutlivesPredicate(r1, r2)
+                            )),
+                            UnpackedKind::Type(t1) => ty::Predicate::TypeOutlives(
+                                ty::Binder::dummy(ty::OutlivesPredicate(
+                                    t1, r2
+                            )))
+                        }
+                    )
+                })
         ) as Box<dyn Iterator<Item = _>>
     }
 

--- a/src/librustc/infer/equate.rs
+++ b/src/librustc/infer/equate.rs
@@ -77,24 +77,22 @@ impl<'combine, 'infcx, 'gcx, 'tcx> TypeRelation<'infcx, 'gcx, 'tcx>
         match (&a.sty, &b.sty) {
             (&ty::Infer(TyVar(a_id)), &ty::Infer(TyVar(b_id))) => {
                 infcx.type_variables.borrow_mut().equate(a_id, b_id);
-                Ok(a)
             }
 
             (&ty::Infer(TyVar(a_id)), _) => {
                 self.fields.instantiate(b, RelationDir::EqTo, a_id, self.a_is_expected)?;
-                Ok(a)
             }
 
             (_, &ty::Infer(TyVar(b_id))) => {
                 self.fields.instantiate(a, RelationDir::EqTo, b_id, self.a_is_expected)?;
-                Ok(a)
             }
 
             _ => {
                 self.fields.infcx.super_combine_tys(self, a, b)?;
-                Ok(a)
             }
         }
+
+        Ok(a)
     }
 
     fn regions(&mut self, a: ty::Region<'tcx>, b: ty::Region<'tcx>)

--- a/src/librustc/infer/error_reporting/mod.rs
+++ b/src/librustc/infer/error_reporting/mod.rs
@@ -406,10 +406,10 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
             errors.clone()
         } else {
             errors
-                .iter()
-                .filter(|&e| !is_bound_failure(e))
-                .cloned()
-                .collect()
+            .iter()
+            .filter(|&e| !is_bound_failure(e))
+            .cloned()
+            .collect()
         };
 
         // sort the errors by span, for better error message stability.

--- a/src/librustc/infer/error_reporting/mod.rs
+++ b/src/librustc/infer/error_reporting/mod.rs
@@ -455,11 +455,10 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
             TypeError::Sorts(ref exp_found) => {
                 // if they are both "path types", there's a chance of ambiguity
                 // due to different versions of the same crate
-                match (&exp_found.expected.sty, &exp_found.found.sty) {
-                    (&ty::Adt(exp_adt, _), &ty::Adt(found_adt, _)) => {
-                        report_path_match(err, exp_adt.did, found_adt.did);
-                    }
-                    _ => (),
+                if let (&ty::Adt(exp_adt, _), &ty::Adt(found_adt, _))
+                     = (&exp_found.expected.sty, &exp_found.found.sty)
+                {
+                    report_path_match(err, exp_adt.did, found_adt.did);
                 }
             }
             TypeError::Traits(ref exp_found) => {

--- a/src/librustc/infer/error_reporting/need_type_info.rs
+++ b/src/librustc/infer/error_reporting/need_type_info.rs
@@ -100,7 +100,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
         let mut labels = vec![(
             span,
             if &name == "_" {
-                "cannot infer type".to_string()
+                "cannot infer type".to_owned()
             } else {
                 format!("cannot infer type for `{}`", name)
             },
@@ -138,7 +138,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
             // ```
             labels.clear();
             labels.push(
-                (pattern.span, "consider giving this closure parameter a type".to_string()));
+                (pattern.span, "consider giving this closure parameter a type".to_owned()));
         } else if let Some(pattern) = local_visitor.found_local_pattern {
             if let Some(simple_ident) = pattern.simple_ident() {
                 match pattern.span.compiler_desugaring_kind() {
@@ -146,12 +146,12 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                                          format!("consider giving `{}` a type", simple_ident))),
                     Some(CompilerDesugaringKind::ForLoop) => labels.push((
                         pattern.span,
-                        "the element type for this iterator is not specified".to_string(),
+                        "the element type for this iterator is not specified".to_owned(),
                     )),
                     _ => {}
                 }
             } else {
-                labels.push((pattern.span, "consider giving the pattern a type".to_string()));
+                labels.push((pattern.span, "consider giving the pattern a type".to_owned()));
             }
         }
 

--- a/src/librustc/infer/error_reporting/nice_region_error/different_lifetimes.rs
+++ b/src/librustc/infer/error_reporting/nice_region_error/different_lifetimes.rs
@@ -113,12 +113,12 @@ impl<'a, 'gcx, 'tcx> NiceRegionError<'a, 'gcx, 'tcx> {
             (None, None) => {
                 let (main_label_1, span_label_1) = if ty_sup.id == ty_sub.id {
                     (
-                        "this type is declared with multiple lifetimes...".to_string(),
-                        "...but data with one lifetime flows into the other here".to_string()
+                        "this type is declared with multiple lifetimes...".to_owned(),
+                        "...but data with one lifetime flows into the other here".to_owned()
                     )
                 } else {
                     (
-                        "these two types are declared with different lifetimes...".to_string(),
+                        "these two types are declared with different lifetimes...".to_owned(),
                         format!(
                             "...but data{} flows{} here",
                             span_label_var1,
@@ -133,7 +133,7 @@ impl<'a, 'gcx, 'tcx> NiceRegionError<'a, 'gcx, 'tcx> {
                 ty_sub.span,
                 ret_span,
                 "this parameter and the return type are declared \
-                 with different lifetimes...".to_string()
+                 with different lifetimes...".to_owned()
                 ,
                 format!("...but data{} is returned here", span_label_var1),
             ),
@@ -141,7 +141,7 @@ impl<'a, 'gcx, 'tcx> NiceRegionError<'a, 'gcx, 'tcx> {
                 ty_sup.span,
                 ret_span,
                 "this parameter and the return type are declared \
-                 with different lifetimes...".to_string()
+                 with different lifetimes...".to_owned()
                 ,
                 format!("...but data{} is returned here", span_label_var1),
             ),

--- a/src/librustc/infer/error_reporting/nice_region_error/static_impl_trait.rs
+++ b/src/librustc/infer/error_reporting/nice_region_error/static_impl_trait.rs
@@ -20,64 +20,62 @@ impl<'a, 'gcx, 'tcx> NiceRegionError<'a, 'gcx, 'tcx> {
     /// Print the error message for lifetime errors when the return type is a static impl Trait.
     pub(super) fn try_report_static_impl_trait(&self) -> Option<ErrorReported> {
         if let Some(ref error) = self.error {
-            match error.clone() {
-                RegionResolutionError::SubSupConflict(
+            if let RegionResolutionError::SubSupConflict(
                     var_origin,
                     sub_origin,
                     sub_r,
                     sup_origin,
                     sup_r,
-                ) => {
-                    let anon_reg_sup = self.tcx.is_suitable_region(sup_r)?;
-                    if sub_r == &RegionKind::ReStatic &&
-                        self.tcx.return_type_impl_trait(anon_reg_sup.def_id).is_some()
-                    {
-                        let sp = var_origin.span();
-                        let return_sp = sub_origin.span();
-                        let mut err = self.tcx.sess.struct_span_err(
-                            sp,
-                            "cannot infer an appropriate lifetime",
-                        );
-                        err.span_label(
-                            return_sp,
-                            "this return type evaluates to the `'static` lifetime...",
-                        );
-                        err.span_label(
-                            sup_origin.span(),
-                            "...but this borrow...",
-                        );
+                ) = error.clone()
+            {
+                let anon_reg_sup = self.tcx.is_suitable_region(sup_r)?;
+                if sub_r == &RegionKind::ReStatic &&
+                    self.tcx.return_type_impl_trait(anon_reg_sup.def_id).is_some()
+                {
+                    let sp = var_origin.span();
+                    let return_sp = sub_origin.span();
+                    let mut err = self.tcx.sess.struct_span_err(
+                        sp,
+                        "cannot infer an appropriate lifetime",
+                    );
+                    err.span_label(
+                        return_sp,
+                        "this return type evaluates to the `'static` lifetime...",
+                    );
+                    err.span_label(
+                        sup_origin.span(),
+                        "...but this borrow...",
+                    );
 
-                        let (lifetime, lt_sp_opt) = self.tcx.msg_span_from_free_region(sup_r);
-                        if let Some(lifetime_sp) = lt_sp_opt {
-                            err.span_note(
-                                lifetime_sp,
-                                &format!("...can't outlive {}", lifetime),
-                            );
-                        }
-
-                        let lifetime_name = match sup_r {
-                            RegionKind::ReFree(FreeRegion {
-                                bound_region: BoundRegion::BrNamed(_, ref name), ..
-                            }) => name.to_string(),
-                            _ => "'_".to_owned(),
-                        };
-                        if let Ok(snippet) = self.tcx.sess.source_map().span_to_snippet(return_sp) {
-                            err.span_suggestion_with_applicability(
-                                return_sp,
-                                &format!(
-                                    "you can add a constraint to the return type to make it last \
-                                     less than `'static` and match {}",
-                                    lifetime,
-                                ),
-                                format!("{} + {}", snippet, lifetime_name),
-                                Applicability::Unspecified,
-                            );
-                        }
-                        err.emit();
-                        return Some(ErrorReported);
+                    let (lifetime, lt_sp_opt) = self.tcx.msg_span_from_free_region(sup_r);
+                    if let Some(lifetime_sp) = lt_sp_opt {
+                        err.span_note(
+                            lifetime_sp,
+                            &format!("...can't outlive {}", lifetime),
+                        );
                     }
+
+                    let lifetime_name = match sup_r {
+                        RegionKind::ReFree(FreeRegion {
+                            bound_region: BoundRegion::BrNamed(_, ref name), ..
+                        }) => name.to_string(),
+                        _ => "'_".to_owned(),
+                    };
+                    if let Ok(snippet) = self.tcx.sess.source_map().span_to_snippet(return_sp) {
+                        err.span_suggestion_with_applicability(
+                            return_sp,
+                            &format!(
+                                "you can add a constraint to the return type to make it last \
+                                 less than `'static` and match {}",
+                                lifetime,
+                            ),
+                            format!("{} + {}", snippet, lifetime_name),
+                            Applicability::Unspecified,
+                        );
+                    }
+                    err.emit();
+                    return Some(ErrorReported);
                 }
-                _ => {}
             }
         }
         None

--- a/src/librustc/infer/error_reporting/nice_region_error/util.rs
+++ b/src/librustc/infer/error_reporting/nice_region_error/util.rs
@@ -119,16 +119,13 @@ impl<'a, 'gcx, 'tcx> NiceRegionError<'a, 'gcx, 'tcx> {
         decl: &hir::FnDecl,
     ) -> Option<Span> {
         let ret_ty = self.tcx.type_of(scope_def_id);
-        match ret_ty.sty {
-            ty::FnDef(_, _) => {
-                let sig = ret_ty.fn_sig(self.tcx);
-                let late_bound_regions = self.tcx
-                    .collect_referenced_late_bound_regions(&sig.output());
-                if late_bound_regions.iter().any(|r| *r == br) {
-                    return Some(decl.output.span());
-                }
+        if let ty::FnDef(_, _) = ret_ty.sty {
+            let sig = ret_ty.fn_sig(self.tcx);
+            let late_bound_regions = self.tcx
+                .collect_referenced_late_bound_regions(&sig.output());
+            if late_bound_regions.iter().any(|r| *r == br) {
+                return Some(decl.output.span());
             }
-            _ => {}
         }
         None
     }

--- a/src/librustc/infer/error_reporting/nice_region_error/util.rs
+++ b/src/librustc/infer/error_reporting/nice_region_error/util.rs
@@ -137,8 +137,8 @@ impl<'a, 'gcx, 'tcx> NiceRegionError<'a, 'gcx, 'tcx> {
     pub(super) fn is_self_anon(&self, is_first: bool, scope_def_id: DefId) -> bool {
         is_first
             && self.tcx
-                .opt_associated_item(scope_def_id)
-                .map(|i| i.method_has_self_argument) == Some(true)
+                   .opt_associated_item(scope_def_id)
+                   .map(|i| i.method_has_self_argument) == Some(true)
     }
 
 }

--- a/src/librustc/infer/lexical_region_resolve/graphviz.rs
+++ b/src/librustc/infer/lexical_region_resolve/graphviz.rs
@@ -187,12 +187,9 @@ impl<'a, 'gcx, 'tcx> dot::Labeller<'a> for ConstraintGraph<'a, 'gcx, 'tcx> {
             None => bug!("no node_id found for node: {:?}", n),
         };
         let name = || format!("node_{}", node_id);
-        match dot::Id::new(name()) {
-            Ok(id) => id,
-            Err(_) => {
-                bug!("failed to create graphviz node identified by {}", name());
-            }
-        }
+
+        dot::Id::new(name()).unwrap_or_else(|_|
+            bug!("failed to create graphviz node identified by {}", name()))
     }
     fn node_label(&self, n: &Node) -> dot::LabelText {
         match *n {

--- a/src/librustc/infer/lexical_region_resolve/graphviz.rs
+++ b/src/librustc/infer/lexical_region_resolve/graphviz.rs
@@ -112,12 +112,9 @@ pub fn maybe_print_constraints_for<'a, 'gcx, 'tcx>(
         }
     };
 
-    match dump_region_data_to(region_rels, &region_data.constraints, &output_path) {
-        Ok(()) => {}
-        Err(e) => {
-            let msg = format!("io error dumping region constraints: {}", e);
-            tcx.sess.err(&msg)
-        }
+    if let Err(e) = dump_region_data_to(region_rels, &region_data.constraints, &output_path) {
+        let msg = format!("io error dumping region constraints: {}", e);
+        tcx.sess.err(&msg)
     }
 }
 

--- a/src/librustc/infer/lexical_region_resolve/graphviz.rs
+++ b/src/librustc/infer/lexical_region_resolve/graphviz.rs
@@ -198,7 +198,7 @@ impl<'a, 'gcx, 'tcx> dot::Labeller<'a> for ConstraintGraph<'a, 'gcx, 'tcx> {
         match *e {
             Edge::Constraint(ref c) =>
                 dot::LabelText::label(format!("{:?}", self.map.get(c).unwrap())),
-            Edge::EnclScope(..) => dot::LabelText::label("(enclosed)".to_string()),
+            Edge::EnclScope(..) => dot::LabelText::label("(enclosed)".to_owned()),
         }
     }
 }

--- a/src/librustc/infer/lexical_region_resolve/mod.rs
+++ b/src/librustc/infer/lexical_region_resolve/mod.rs
@@ -147,9 +147,7 @@ impl<'cx, 'gcx, 'tcx> LexicalResolver<'cx, 'gcx, 'tcx> {
     fn construct_var_data(&self, tcx: TyCtxt<'_, '_, 'tcx>) -> LexicalRegionResolutions<'tcx> {
         LexicalRegionResolutions {
             error_region: tcx.types.re_static,
-            values: (0..self.num_vars())
-                .map(|_| VarValue::Value(tcx.types.re_empty))
-                .collect(),
+            values: IndexVec::from_elem_n(VarValue::Value(tcx.types.re_empty), self.num_vars())
         }
     }
 

--- a/src/librustc/infer/opaque_types/mod.rs
+++ b/src/librustc/infer/opaque_types/mod.rs
@@ -803,6 +803,7 @@ impl<'a, 'gcx, 'tcx> Instantiator<'a, 'gcx, 'tcx> {
         );
         debug!("instantiate_opaque_types: ty_var={:?}", ty_var);
 
+        self.obligations.reserve(bounds.predicates.len());
         for predicate in bounds.predicates {
             // Change the predicate to refer to the type variable,
             // which will be the concrete type instead of the opaque type.

--- a/src/librustc/infer/region_constraints/mod.rs
+++ b/src/librustc/infer/region_constraints/mod.rs
@@ -661,11 +661,10 @@ impl<'tcx> RegionConstraintCollector<'tcx> {
         debug!("RegionConstraintCollector: add_verify({:?})", verify);
 
         // skip no-op cases known to be satisfied
-        match verify.bound {
-            VerifyBound::AllBounds(ref bs) if bs.len() == 0 => {
+        if let VerifyBound::AllBounds(ref bs) = verify.bound {
+            if bs.len() == 0 {
                 return;
             }
-            _ => {}
         }
 
         let index = self.data.verifys.len();

--- a/src/librustc/infer/region_constraints/mod.rs
+++ b/src/librustc/infer/region_constraints/mod.rs
@@ -443,7 +443,7 @@ impl<'tcx> RegionConstraintCollector<'tcx> {
         assert!(self.undo_log[snapshot.length] == OpenSnapshot);
 
         if snapshot.length == 0 {
-            self.undo_log.truncate(0);
+            self.undo_log.clear();
         } else {
             (*self.undo_log)[snapshot.length] = CommitedSnapshot;
         }

--- a/src/librustc/infer/resolve.rs
+++ b/src/librustc/infer/resolve.rs
@@ -153,8 +153,8 @@ impl<'a, 'gcx, 'tcx> TypeFolder<'gcx, 'tcx> for FullTypeResolver<'a, 'gcx, 'tcx>
     fn fold_ty(&mut self, t: Ty<'tcx>) -> Ty<'tcx> {
         if !t.needs_infer() && !ty::keep_local(&t) {
             t // micro-optimize -- if there is nothing in this type that this fold affects...
-                // ^ we need to have the `keep_local` check to un-default
-                // defaulted tuples.
+              // ^ we need to have the `keep_local` check to un-default
+              // defaulted tuples.
         } else {
             let t = self.infcx.shallow_resolve(t);
             match t.sty {

--- a/src/librustc/infer/type_variable.rs
+++ b/src/librustc/infer/type_variable.rs
@@ -273,11 +273,8 @@ impl<'tcx> TypeVariableTable<'tcx> {
     pub fn rollback_to(&mut self, s: Snapshot<'tcx>) {
         debug!("rollback_to{:?}", {
             for action in self.values.actions_since_snapshot(&s.snapshot) {
-                match *action {
-                    sv::UndoLog::NewElem(index) => {
-                        debug!("inference variable _#{}t popped", index)
-                    }
-                    _ => { }
+                if let sv::UndoLog::NewElem(index) = *action {
+                    debug!("inference variable _#{}t popped", index)
                 }
             }
         });


### PR DESCRIPTION
- use unwrap_or(_else) where applicable
- convert single-branch matches to if-let
- use to_owned instead of to_string with string literals
- improve vector allocations
- readability improvements
- miscellaneous minor code improvements