### PR TITLE
Correct doc for WorkQueue<T>::pop().

### DIFF
--- a/src/librustc_data_structures/work_queue.rs
+++ b/src/librustc_data_structures/work_queue.rs
@@ -53,7 +53,7 @@ impl<T: Idx> WorkQueue<T> {
         }
     }
 
-    /// Attempt to enqueue `element` in the work queue. Returns false if it was already present.
+    /// Attempt to pop an element from the work queue.
     #[inline]
     pub fn pop(&mut self) -> Option<T> {
         if let Some(element) = self.deque.pop_front() {


### PR DESCRIPTION
The old function doc looks like copy-pasta from WorkQueue::insert().

WorkQueue::pop() does not enqueue nor does it return a boolean false.  Doc corrected accordingly.