### PR TITLE
Make NonNull::dangling a const fn

### DIFF
--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -2874,10 +2874,9 @@ impl<T: Sized> NonNull<T> {
     /// sentinel value. Types that lazily allocate must track initialization by
     /// some other means.
     #[stable(feature = "nonnull", since = "1.25.0")]
-    pub fn dangling() -> Self {
+    pub const fn dangling() -> Self {
         unsafe {
-            let ptr = mem::align_of::<T>() as *mut T;
-            NonNull::new_unchecked(ptr)
+            NonNull::new_unchecked(mem::align_of::<T>() as *mut T)
         }
     }
 }


### PR DESCRIPTION
This is useful for other `const fn` constructors