### PR TITLE
Improve bug! message for impossible case in Relate

### DIFF
--- a/src/librustc/ty/relate.rs
+++ b/src/librustc/ty/relate.rs
@@ -702,7 +702,9 @@ impl<'tcx> Relate<'tcx> for Kind<'tcx> {
             (UnpackedKind::Type(a_ty), UnpackedKind::Type(b_ty)) => {
                 Ok(relation.relate(&a_ty, &b_ty)?.into())
             }
-            (UnpackedKind::Lifetime(_), _) | (UnpackedKind::Type(_), _) => bug!()
+            (UnpackedKind::Lifetime(unpacked), x) | (UnpackedKind::Type(unpacked), x) => {
+                bug!("impossible case reached: can't relate: {:?} with {:?}", unpacked, x)
+            }
         }
     }
 }


### PR DESCRIPTION
Hitting this branch [in Clippy][clippy_issue] and I think it makes sense to print
both values here in case other users hit this branch, too.

(I'm not really sure what type `x` would be here)

[clippy_issue]: https://github.com/rust-lang-nursery/rust-clippy/issues/2831#issuecomment-424597092