### PR TITLE
Fix Once perf regression

### DIFF
--- a/src/libstd/sync/once.rs
+++ b/src/libstd/sync/once.rs
@@ -330,6 +330,7 @@ impl Once {
     /// assert_eq!(INIT.is_completed(), false);
     /// ```
     #[unstable(feature = "once_is_completed", issue = "42")]
+    #[inline]
     pub fn is_completed(&self) -> bool {
         // An `Acquire` load is enough because that makes all the initialization
         // operations visible to us, and, this being a fast path, weaker


### PR DESCRIPTION
Because `call_once` is generic, but `is_completed` is not, we need
`#[inline]` annotation to allow LLVM to inline `is_completed` into
`call_once` in downstream crates.

cc https://github.com/rust-lang/rust/pull/53027/files#r221418859