### PR TITLE
[NLL] Improve "borrow later used here" messages

### DIFF
--- a/src/librustc/ich/impls_mir.rs
+++ b/src/librustc/ich/impls_mir.rs
@@ -194,11 +194,13 @@ for mir::TerminatorKind<'gcx> {
             mir::TerminatorKind::Call { ref func,
                                         ref args,
                                         ref destination,
-                                        cleanup } => {
+                                        cleanup,
+                                        from_hir_call, } => {
                 func.hash_stable(hcx, hasher);
                 args.hash_stable(hcx, hasher);
                 destination.hash_stable(hcx, hasher);
                 cleanup.hash_stable(hcx, hasher);
+                from_hir_call.hash_stable(hcx, hasher);
             }
             mir::TerminatorKind::Assert { ref cond,
                                           expected,

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -1049,6 +1049,9 @@ pub enum TerminatorKind<'tcx> {
         destination: Option<(Place<'tcx>, BasicBlock)>,
         /// Cleanups to be done if the call unwinds.
         cleanup: Option<BasicBlock>,
+        /// Whether this is from a call in HIR, rather than from an overloaded
+        /// operator. True for overloaded function call.
+        from_hir_call: bool,
     },
 
     /// Jump to the target if the condition has the expected value,
@@ -2810,6 +2813,7 @@ impl<'tcx> TypeFoldable<'tcx> for Terminator<'tcx> {
                 ref args,
                 ref destination,
                 cleanup,
+                from_hir_call,
             } => {
                 let dest = destination
                     .as_ref()
@@ -2820,6 +2824,7 @@ impl<'tcx> TypeFoldable<'tcx> for Terminator<'tcx> {
                     args: args.fold_with(folder),
                     destination: dest,
                     cleanup,
+                    from_hir_call,
                 }
             }
             Assert {

--- a/src/librustc/mir/visit.rs
+++ b/src/librustc/mir/visit.rs
@@ -468,7 +468,8 @@ macro_rules! make_mir_visitor {
                     TerminatorKind::Call { ref $($mutability)* func,
                                            ref $($mutability)* args,
                                            ref $($mutability)* destination,
-                                           cleanup } => {
+                                           cleanup,
+                                           from_hir_call: _, } => {
                         self.visit_operand(func, source_location);
                         for arg in args {
                             self.visit_operand(arg, source_location);

--- a/src/librustc_codegen_llvm/mir/block.rs
+++ b/src/librustc_codegen_llvm/mir/block.rs
@@ -412,7 +412,13 @@ impl FunctionCx<'a, 'll, 'tcx> {
                 bug!("undesugared DropAndReplace in codegen: {:?}", terminator);
             }
 
-            mir::TerminatorKind::Call { ref func, ref args, ref destination, cleanup } => {
+            mir::TerminatorKind::Call {
+                ref func,
+                ref args,
+                ref destination,
+                cleanup,
+                from_hir_call: _
+            } => {
                 // Create the callee. This is a fn ptr or zero-sized and hence a kind of scalar.
                 let callee = self.codegen_operand(&bx, func);
 

--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -667,6 +667,7 @@ impl<'cx, 'gcx, 'tcx> DataflowResultsConsumer<'cx, 'tcx> for MirBorrowckCtxt<'cx
                 ref args,
                 ref destination,
                 cleanup: _,
+                from_hir_call: _,
             } => {
                 self.consume_operand(ContextKind::CallOperator.new(loc), (func, span), flow_state);
                 for arg in args {

--- a/src/librustc_mir/borrow_check/nll/invalidation.rs
+++ b/src/librustc_mir/borrow_check/nll/invalidation.rs
@@ -203,6 +203,7 @@ impl<'cx, 'tcx, 'gcx> Visitor<'tcx> for InvalidationGenerator<'cx, 'tcx, 'gcx> {
                 ref args,
                 ref destination,
                 cleanup: _,
+                from_hir_call: _,
             } => {
                 self.consume_operand(ContextKind::CallOperator.new(location), func);
                 for arg in args {

--- a/src/librustc_mir/build/expr/into.rs
+++ b/src/librustc_mir/build/expr/into.rs
@@ -264,7 +264,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                 );
                 exit_block.unit()
             }
-            ExprKind::Call { ty, fun, args } => {
+            ExprKind::Call { ty, fun, args, from_hir_call } => {
                 // FIXME(canndrew): This is_never should probably be an is_uninhabited
                 let diverges = expr.ty.is_never();
                 let intrinsic = match ty.sty {
@@ -326,6 +326,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                             } else {
                                 Some((destination.clone(), success))
                             },
+                            from_hir_call,
                         },
                     );
                     success.unit()

--- a/src/librustc_mir/build/matches/test.rs
+++ b/src/librustc_mir/build/matches/test.rs
@@ -361,6 +361,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                         args: vec![val, expect],
                         destination: Some((eq_result.clone(), eq_block)),
                         cleanup: Some(cleanup),
+                        from_hir_call: false,
                     });
 
                     // check the result

--- a/src/librustc_mir/dataflow/mod.rs
+++ b/src/librustc_mir/dataflow/mod.rs
@@ -795,7 +795,7 @@ impl<'a, 'tcx: 'a, D> DataflowAnalysis<'a, 'tcx, D> where D: BitDenotation
                     self.propagate_bits_into_entry_set_for(in_out, *target, dirty_list);
                 }
             }
-            mir::TerminatorKind::Call { cleanup, ref destination, func: _, args: _ } => {
+            mir::TerminatorKind::Call { cleanup, ref destination, .. } => {
                 if let Some(unwind) = cleanup {
                     if !self.dead_unwinds.contains(bb) {
                         self.propagate_bits_into_entry_set_for(in_out, unwind, dirty_list);

--- a/src/librustc_mir/dataflow/move_paths/builder.rs
+++ b/src/librustc_mir/dataflow/move_paths/builder.rs
@@ -380,7 +380,13 @@ impl<'b, 'a, 'gcx, 'tcx> Gatherer<'b, 'a, 'gcx, 'tcx> {
                 self.gather_operand(value);
                 self.gather_init(location, InitKind::Deep);
             }
-            TerminatorKind::Call { ref func, ref args, ref destination, cleanup: _ } => {
+            TerminatorKind::Call {
+                ref func,
+                ref args,
+                ref destination,
+                cleanup: _,
+                from_hir_call: _,
+            } => {
                 self.gather_operand(func);
                 for arg in args {
                     self.gather_operand(arg);

--- a/src/librustc_mir/hair/cx/expr.rs
+++ b/src/librustc_mir/hair/cx/expr.rs
@@ -21,6 +21,7 @@ use rustc::ty::cast::CastKind as TyCastKind;
 use rustc::hir;
 use rustc::hir::def_id::LocalDefId;
 use rustc::mir::{BorrowKind};
+use syntax_pos::Span;
 
 impl<'tcx> Mirror<'tcx> for &'tcx hir::Expr {
     type Output = Expr<'tcx>;
@@ -232,9 +233,9 @@ fn make_mirror_unadjusted<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
 
     let kind = match expr.node {
         // Here comes the interesting stuff:
-        hir::ExprKind::MethodCall(.., ref args) => {
+        hir::ExprKind::MethodCall(_, method_span, ref args) => {
             // Rewrite a.b(c) into UFCS form like Trait::b(a, c)
-            let expr = method_callee(cx, expr, None);
+            let expr = method_callee(cx, expr, method_span,None);
             let args = args.iter()
                 .map(|e| e.to_ref())
                 .collect();
@@ -242,6 +243,7 @@ fn make_mirror_unadjusted<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
                 ty: expr.ty,
                 fun: expr.to_ref(),
                 args,
+                from_hir_call: true,
             }
         }
 
@@ -254,7 +256,7 @@ fn make_mirror_unadjusted<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
 
                 // rewrite f(u, v) into FnOnce::call_once(f, (u, v))
 
-                let method = method_callee(cx, expr, None);
+                let method = method_callee(cx, expr, fun.span,None);
 
                 let arg_tys = args.iter().map(|e| cx.tables().expr_ty_adjusted(e));
                 let tupled_args = Expr {
@@ -268,6 +270,7 @@ fn make_mirror_unadjusted<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
                     ty: method.ty,
                     fun: method.to_ref(),
                     args: vec![fun.to_ref(), tupled_args.to_ref()],
+                    from_hir_call: true,
                 }
             } else {
                 let adt_data = if let hir::ExprKind::Path(hir::QPath::Resolved(_, ref path)) =
@@ -321,6 +324,7 @@ fn make_mirror_unadjusted<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
                         ty: cx.tables().node_id_to_type(fun.hir_id),
                         fun: fun.to_ref(),
                         args: args.to_ref(),
+                        from_hir_call: true,
                     }
                 }
             }
@@ -812,6 +816,7 @@ fn user_annotated_ty_for_adt(
 fn method_callee<'a, 'gcx, 'tcx>(
     cx: &mut Cx<'a, 'gcx, 'tcx>,
     expr: &hir::Expr,
+    span: Span,
     overloaded_callee: Option<(DefId, &'tcx Substs<'tcx>)>,
 ) -> Expr<'tcx> {
     let temp_lifetime = cx.region_scope_tree.temporary_scope(expr.hir_id.local_id);
@@ -832,7 +837,7 @@ fn method_callee<'a, 'gcx, 'tcx>(
     Expr {
         temp_lifetime,
         ty,
-        span: expr.span,
+        span,
         kind: ExprKind::Literal {
             literal: ty::Const::zero_sized(cx.tcx(), ty),
             user_ty,
@@ -1093,11 +1098,12 @@ fn overloaded_operator<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
                                        expr: &'tcx hir::Expr,
                                        args: Vec<ExprRef<'tcx>>)
                                        -> ExprKind<'tcx> {
-    let fun = method_callee(cx, expr, None);
+    let fun = method_callee(cx, expr, expr.span, None);
     ExprKind::Call {
         ty: fun.ty,
         fun: fun.to_ref(),
         args,
+        from_hir_call: false,
     }
 }
 
@@ -1132,7 +1138,7 @@ fn overloaded_place<'a, 'gcx, 'tcx>(
     // construct the complete expression `foo()` for the overloaded call,
     // which will yield the &T type
     let temp_lifetime = cx.region_scope_tree.temporary_scope(expr.hir_id.local_id);
-    let fun = method_callee(cx, expr, overloaded_callee);
+    let fun = method_callee(cx, expr, expr.span, overloaded_callee);
     let ref_expr = Expr {
         temp_lifetime,
         ty: ref_ty,
@@ -1141,6 +1147,7 @@ fn overloaded_place<'a, 'gcx, 'tcx>(
             ty: fun.ty,
             fun: fun.to_ref(),
             args,
+            from_hir_call: false,
         },
     };
 

--- a/src/librustc_mir/hair/mod.rs
+++ b/src/librustc_mir/hair/mod.rs
@@ -150,6 +150,9 @@ pub enum ExprKind<'tcx> {
         ty: Ty<'tcx>,
         fun: ExprRef<'tcx>,
         args: Vec<ExprRef<'tcx>>,
+        // Whether this is from a call in HIR, rather than from an overloaded
+        // operator. True for overloaded function call.
+        from_hir_call: bool,
     },
     Deref {
         arg: ExprRef<'tcx>,

--- a/src/librustc_mir/shim.rs
+++ b/src/librustc_mir/shim.rs
@@ -468,6 +468,7 @@ impl<'a, 'tcx> CloneShimBuilder<'a, 'tcx> {
             args: vec![Operand::Move(ref_loc)],
             destination: Some((dest, next)),
             cleanup: Some(cleanup),
+            from_hir_call: true,
         }, false);
     }
 
@@ -766,7 +767,8 @@ fn build_call_shim<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
             Some(BasicBlock::new(3))
         } else {
             None
-        }
+        },
+        from_hir_call: true,
     }, false);
 
     if let Adjustment::RefMut = rcvr_adjustment {

--- a/src/librustc_mir/transform/lower_128bit.rs
+++ b/src/librustc_mir/transform/lower_128bit.rs
@@ -121,6 +121,7 @@ impl Lower128Bit {
                             args: vec![lhs, rhs],
                             destination: Some((place, bb)),
                             cleanup: None,
+                            from_hir_call: false,
                         },
                     });
             }

--- a/src/librustc_mir/transform/promote_consts.rs
+++ b/src/librustc_mir/transform/promote_consts.rs
@@ -258,7 +258,7 @@ impl<'a, 'tcx> Promoter<'a, 'tcx> {
             };
 
             match terminator.kind {
-                TerminatorKind::Call { mut func, mut args, .. } => {
+                TerminatorKind::Call { mut func, mut args, from_hir_call, .. } => {
                     self.visit_operand(&mut func, loc);
                     for arg in &mut args {
                         self.visit_operand(arg, loc);
@@ -272,7 +272,8 @@ impl<'a, 'tcx> Promoter<'a, 'tcx> {
                             func,
                             args,
                             cleanup: None,
-                            destination: Some((Place::Local(new_temp), new_target))
+                            destination: Some((Place::Local(new_temp), new_target)),
+                            from_hir_call,
                         },
                         ..terminator
                     };

--- a/src/librustc_mir/transform/qualify_min_const_fn.rs
+++ b/src/librustc_mir/transform/qualify_min_const_fn.rs
@@ -318,6 +318,7 @@ fn check_terminator(
         TerminatorKind::Call {
             func,
             args,
+            from_hir_call: _,
             destination: _,
             cleanup: _,
         } => {

--- a/src/librustc_mir/util/elaborate_drops.rs
+++ b/src/librustc_mir/util/elaborate_drops.rs
@@ -545,8 +545,9 @@ impl<'l, 'b, 'tcx, D> DropCtxt<'l, 'b, 'tcx, D>
                     args: vec![Operand::Move(Place::Local(ref_place))],
                     destination: Some((unit_temp, succ)),
                     cleanup: unwind.into_option(),
+                    from_hir_call: true,
                 },
-                source_info: self.source_info
+                source_info: self.source_info,
             }),
             is_cleanup: unwind.is_cleanup(),
         };
@@ -903,7 +904,8 @@ impl<'l, 'b, 'tcx, D> DropCtxt<'l, 'b, 'tcx, D>
             func: Operand::function_handle(tcx, free_func, substs, self.source_info.span),
             args: args,
             destination: Some((unit_temp, target)),
-            cleanup: None
+            cleanup: None,
+            from_hir_call: false,
         }; // FIXME(#43234)
         let free_block = self.new_block(unwind, call);
 

--- a/src/test/ui/E0501.ast.nll.stderr
+++ b/src/test/ui/E0501.ast.nll.stderr
@@ -10,7 +10,7 @@ LL |     outside_closure_1(a); //[ast]~ ERROR cannot borrow `*a` as mutable beca
    |                       ^ borrow occurs here
 ...
 LL |     drop(bar);
-   |          --- borrow later used here
+   |          --- first borrow later used here
 
 error[E0501]: cannot borrow `*a` as immutable because previous closure requires unique access
   --> $DIR/E0501.rs:31:23
@@ -24,7 +24,7 @@ LL |     outside_closure_2(a); //[ast]~ ERROR cannot borrow `*a` as immutable be
    |                       ^ borrow occurs here
 ...
 LL |     drop(bar);
-   |          --- borrow later used here
+   |          --- first borrow later used here
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/E0501.mir.stderr
+++ b/src/test/ui/E0501.mir.stderr
@@ -10,7 +10,7 @@ LL |     outside_closure_1(a); //[ast]~ ERROR cannot borrow `*a` as mutable beca
    |                       ^ borrow occurs here
 ...
 LL |     drop(bar);
-   |          --- borrow later used here
+   |          --- first borrow later used here
 
 error[E0501]: cannot borrow `*a` as immutable because previous closure requires unique access
   --> $DIR/E0501.rs:31:23
@@ -24,7 +24,7 @@ LL |     outside_closure_2(a); //[ast]~ ERROR cannot borrow `*a` as immutable be
    |                       ^ borrow occurs here
 ...
 LL |     drop(bar);
-   |          --- borrow later used here
+   |          --- first borrow later used here
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/binop/binop-move-semantics.nll.stderr
+++ b/src/test/ui/binop/binop-move-semantics.nll.stderr
@@ -44,7 +44,7 @@ LL | |     +
 LL | |     &f;  //~ ERROR: cannot borrow `f` as immutable because it is also borrowed as mutable
    | |     ^-
    | |_____||
-   |       |borrow later used here
+   |       |mutable borrow later used here
    |       immutable borrow occurs here
 
 error[E0502]: cannot borrow `f` as mutable because it is also borrowed as immutable
@@ -59,7 +59,7 @@ LL | |     +
 LL | |     &mut f;  //~ ERROR: cannot borrow `f` as mutable because it is also borrowed as immutable
    | |     ^^^^^-
    | |_____|____|
-   |       |    borrow later used here
+   |       |    immutable borrow later used here
    |       mutable borrow occurs here
 
 error: aborting due to 6 previous errors

--- a/src/test/ui/borrowck/borrow-tuple-fields.nll.stderr
+++ b/src/test/ui/borrowck/borrow-tuple-fields.nll.stderr
@@ -17,7 +17,7 @@ LL |     let a = &x.0;
 LL |     let b = &mut x.0; //~ ERROR cannot borrow `x.0` as mutable because it is also borrowed as
    |             ^^^^^^^^ mutable borrow occurs here
 LL |     a.use_ref();
-   |     - borrow later used here
+   |     - immutable borrow later used here
 
 error[E0499]: cannot borrow `x.0` as mutable more than once at a time
   --> $DIR/borrow-tuple-fields.rs:33:13
@@ -27,7 +27,7 @@ LL |     let a = &mut x.0;
 LL |     let b = &mut x.0; //~ ERROR cannot borrow `x.0` as mutable more than once at a time
    |             ^^^^^^^^ second mutable borrow occurs here
 LL |     a.use_ref();
-   |     - borrow later used here
+   |     - first borrow later used here
 
 error[E0505]: cannot move out of `x` because it is borrowed
   --> $DIR/borrow-tuple-fields.rs:38:13
@@ -47,7 +47,7 @@ LL |     let a = &x.0;
 LL |     let b = &mut x.0; //~ ERROR cannot borrow `x.0` as mutable because it is also borrowed as
    |             ^^^^^^^^ mutable borrow occurs here
 LL |     a.use_ref();
-   |     - borrow later used here
+   |     - immutable borrow later used here
 
 error[E0499]: cannot borrow `x.0` as mutable more than once at a time
   --> $DIR/borrow-tuple-fields.rs:48:13
@@ -57,7 +57,7 @@ LL |     let a = &mut x.0;
 LL |     let b = &mut x.0; //~ ERROR cannot borrow `x.0` as mutable more than once at a time
    |             ^^^^^^^^ second mutable borrow occurs here
 LL |     a.use_mut();
-   |     - borrow later used here
+   |     - first borrow later used here
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/borrowck/borrowck-anon-fields-struct.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-anon-fields-struct.nll.stderr
@@ -8,7 +8,7 @@ LL |         Y(ref mut b, _) => b //~ ERROR cannot borrow
    |           ^^^^^^^^^ second mutable borrow occurs here
 ...
 LL |     *a += 1;
-   |     ------- borrow later used here
+   |     ------- first borrow later used here
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-anon-fields-tuple.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-anon-fields-tuple.nll.stderr
@@ -8,7 +8,7 @@ LL |         (ref mut b, _) => b //~ ERROR cannot borrow
    |          ^^^^^^^^^ second mutable borrow occurs here
 ...
 LL |     *a += 1;
-   |     ------- borrow later used here
+   |     ------- first borrow later used here
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-anon-fields-variant.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-anon-fields-variant.nll.stderr
@@ -8,7 +8,7 @@ LL |       Foo::Y(ref mut b, _) => b, //~ ERROR cannot borrow
    |              ^^^^^^^^^ second mutable borrow occurs here
 ...
 LL |     *a += 1;
-   |     ------- borrow later used here
+   |     ------- first borrow later used here
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-assign-comp-idx.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-assign-comp-idx.nll.stderr
@@ -8,19 +8,19 @@ LL |     p[0] = 5; //~ ERROR cannot borrow
    |     ^ mutable borrow occurs here
 LL | 
 LL |     println!("{}", *q);
-   |                    -- borrow later used here
+   |                    -- immutable borrow later used here
 
 error[E0502]: cannot borrow `p` as mutable because it is also borrowed as immutable
   --> $DIR/borrowck-assign-comp-idx.rs:37:9
    |
-LL | /     borrow(
-LL | |         &p,
-   | |         -- immutable borrow occurs here
-LL | |         || p[0] = 5); //~ ERROR cannot borrow `p` as mutable
-   | |_________^^_-_______- borrow later used here
-   |           |  |
-   |           |  second borrow occurs due to use of `p` in closure
-   |           mutable borrow occurs here
+LL |     borrow(
+   |     ------ immutable borrow later used by call
+LL |         &p,
+   |         -- immutable borrow occurs here
+LL |         || p[0] = 5); //~ ERROR cannot borrow `p` as mutable
+   |         ^^ - second borrow occurs due to use of `p` in closure
+   |         |
+   |         mutable borrow occurs here
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/borrowck/borrowck-autoref-3261.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-autoref-3261.nll.stderr
@@ -1,21 +1,15 @@
 error[E0499]: cannot borrow `x` as mutable more than once at a time
   --> $DIR/borrowck-autoref-3261.rs:25:9
    |
-LL |       (&mut x).with(
-   |       --------
-   |       |
-   |  _____first mutable borrow occurs here
-   | |
-LL | |         |opt| { //~ ERROR cannot borrow `x` as mutable more than once at a time
-   | |         ^^^^^ second mutable borrow occurs here
-LL | |             match opt {
-LL | |                 &Either::Right(ref f) => {
-LL | |                     x = X(Either::Left((0, 0)));
-   | |                     - second borrow occurs due to use of `x` in closure
-...  |
-LL | |             }
-LL | |         })
-   | |__________- borrow later used here
+LL |     (&mut x).with(
+   |     -------- ---- first borrow later used by call
+   |     |
+   |     first mutable borrow occurs here
+LL |         |opt| { //~ ERROR cannot borrow `x` as mutable more than once at a time
+   |         ^^^^^ second mutable borrow occurs here
+...
+LL |                     x = X(Either::Left((0, 0)));
+   |                     - second borrow occurs due to use of `x` in closure
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-bad-nested-calls-free.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-bad-nested-calls-free.nll.stderr
@@ -1,24 +1,22 @@
 error[E0502]: cannot borrow `a` as mutable because it is also borrowed as immutable
   --> $DIR/borrowck-bad-nested-calls-free.rs:35:17
    |
-LL | /     add(
-LL | |         &*a,
-   | |         --- immutable borrow occurs here
-LL | |         rewrite(&mut a)); //~ ERROR cannot borrow
-   | |_________________^^^^^^_- borrow later used here
-   |                   |
-   |                   mutable borrow occurs here
+LL |     add(
+   |     --- immutable borrow later used by call
+LL |         &*a,
+   |         --- immutable borrow occurs here
+LL |         rewrite(&mut a)); //~ ERROR cannot borrow
+   |                 ^^^^^^ mutable borrow occurs here
 
 error[E0502]: cannot borrow `a` as mutable because it is also borrowed as immutable
   --> $DIR/borrowck-bad-nested-calls-free.rs:42:17
    |
-LL | /     add(
-LL | |         &*a,
-   | |         --- immutable borrow occurs here
-LL | |         rewrite(&mut a)); //~ ERROR cannot borrow
-   | |_________________^^^^^^_- borrow later used here
-   |                   |
-   |                   mutable borrow occurs here
+LL |     add(
+   |     --- immutable borrow later used by call
+LL |         &*a,
+   |         --- immutable borrow occurs here
+LL |         rewrite(&mut a)); //~ ERROR cannot borrow
+   |                 ^^^^^^ mutable borrow occurs here
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/borrowck/borrowck-bad-nested-calls-move.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-bad-nested-calls-move.nll.stderr
@@ -1,24 +1,22 @@
 error[E0505]: cannot move out of `a` because it is borrowed
   --> $DIR/borrowck-bad-nested-calls-move.rs:35:9
    |
-LL | /     add(
-LL | |         &*a,
-   | |         --- borrow of `*a` occurs here
-LL | |         a); //~ ERROR cannot move
-   | |_________^- borrow later used here
-   |           |
-   |           move out of `a` occurs here
+LL |     add(
+   |     --- borrow later used by call
+LL |         &*a,
+   |         --- borrow of `*a` occurs here
+LL |         a); //~ ERROR cannot move
+   |         ^ move out of `a` occurs here
 
 error[E0505]: cannot move out of `a` because it is borrowed
   --> $DIR/borrowck-bad-nested-calls-move.rs:42:9
    |
-LL | /     add(
-LL | |         &*a,
-   | |         --- borrow of `*a` occurs here
-LL | |         a); //~ ERROR cannot move
-   | |_________^- borrow later used here
-   |           |
-   |           move out of `a` occurs here
+LL |     add(
+   |     --- borrow later used by call
+LL |         &*a,
+   |         --- borrow of `*a` occurs here
+LL |         a); //~ ERROR cannot move
+   |         ^ move out of `a` occurs here
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/borrowck/borrowck-borrow-from-owned-ptr.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-borrow-from-owned-ptr.nll.stderr
@@ -6,7 +6,7 @@ LL |     let bar1 = &mut foo.bar1;
 LL |     let _bar2 = &mut foo.bar1;  //~ ERROR cannot borrow
    |                 ^^^^^^^^^^^^^ second mutable borrow occurs here
 LL |     *bar1;
-   |     ----- borrow later used here
+   |     ----- first borrow later used here
 
 error[E0502]: cannot borrow `foo.bar1` as immutable because it is also borrowed as mutable
   --> $DIR/borrowck-borrow-from-owned-ptr.rs:36:17
@@ -16,7 +16,7 @@ LL |     let bar1 = &mut foo.bar1;
 LL |     let _bar2 = &foo.bar1;  //~ ERROR cannot borrow
    |                 ^^^^^^^^^ immutable borrow occurs here
 LL |     *bar1;
-   |     ----- borrow later used here
+   |     ----- mutable borrow later used here
 
 error[E0502]: cannot borrow `foo.bar1` as mutable because it is also borrowed as immutable
   --> $DIR/borrowck-borrow-from-owned-ptr.rs:43:17
@@ -26,7 +26,7 @@ LL |     let bar1 = &foo.bar1;
 LL |     let _bar2 = &mut foo.bar1;  //~ ERROR cannot borrow
    |                 ^^^^^^^^^^^^^ mutable borrow occurs here
 LL |     *bar1;
-   |     ----- borrow later used here
+   |     ----- immutable borrow later used here
 
 error[E0499]: cannot borrow `foo.bar1` as mutable more than once at a time
   --> $DIR/borrowck-borrow-from-owned-ptr.rs:73:21
@@ -38,7 +38,7 @@ LL |         Foo { bar1: ref mut _bar1, bar2: _ } => {}
    |                     ^^^^^^^^^^^^^ second mutable borrow occurs here
 ...
 LL |     *bar1;
-   |     ----- borrow later used here
+   |     ----- first borrow later used here
 
 error[E0502]: cannot borrow `foo.bar1` as immutable because it is also borrowed as mutable
   --> $DIR/borrowck-borrow-from-owned-ptr.rs:82:17
@@ -49,7 +49,7 @@ LL |     let _foo1 = &foo.bar1; //~ ERROR cannot borrow
    |                 ^^^^^^^^^ immutable borrow occurs here
 LL |     let _foo2 = &*foo; //~ ERROR cannot borrow
 LL |     *bar1;
-   |     ----- borrow later used here
+   |     ----- mutable borrow later used here
 
 error[E0502]: cannot borrow `*foo` as immutable because it is also borrowed as mutable
   --> $DIR/borrowck-borrow-from-owned-ptr.rs:83:17
@@ -60,7 +60,7 @@ LL |     let _foo1 = &foo.bar1; //~ ERROR cannot borrow
 LL |     let _foo2 = &*foo; //~ ERROR cannot borrow
    |                 ^^^^^ immutable borrow occurs here
 LL |     *bar1;
-   |     ----- borrow later used here
+   |     ----- mutable borrow later used here
 
 error[E0499]: cannot borrow `foo.bar1` as mutable more than once at a time
   --> $DIR/borrowck-borrow-from-owned-ptr.rs:90:17
@@ -70,7 +70,7 @@ LL |     let bar1 = &mut foo.bar1.int1;
 LL |     let _foo1 = &mut foo.bar1; //~ ERROR cannot borrow
    |                 ^^^^^^^^^^^^^ second mutable borrow occurs here
 LL |     *bar1;
-   |     ----- borrow later used here
+   |     ----- first borrow later used here
 
 error[E0499]: cannot borrow `*foo` as mutable more than once at a time
   --> $DIR/borrowck-borrow-from-owned-ptr.rs:97:17
@@ -80,7 +80,7 @@ LL |     let bar1 = &mut foo.bar1.int1;
 LL |     let _foo2 = &mut *foo; //~ ERROR cannot borrow
    |                 ^^^^^^^^^ second mutable borrow occurs here
 LL |     *bar1;
-   |     ----- borrow later used here
+   |     ----- first borrow later used here
 
 error[E0502]: cannot borrow `foo.bar1` as mutable because it is also borrowed as immutable
   --> $DIR/borrowck-borrow-from-owned-ptr.rs:104:17
@@ -90,7 +90,7 @@ LL |     let bar1 = &foo.bar1.int1;
 LL |     let _foo1 = &mut foo.bar1; //~ ERROR cannot borrow
    |                 ^^^^^^^^^^^^^ mutable borrow occurs here
 LL |     *bar1;
-   |     ----- borrow later used here
+   |     ----- immutable borrow later used here
 
 error[E0502]: cannot borrow `*foo` as mutable because it is also borrowed as immutable
   --> $DIR/borrowck-borrow-from-owned-ptr.rs:111:17
@@ -100,7 +100,7 @@ LL |     let bar1 = &foo.bar1.int1;
 LL |     let _foo2 = &mut *foo; //~ ERROR cannot borrow
    |                 ^^^^^^^^^ mutable borrow occurs here
 LL |     *bar1;
-   |     ----- borrow later used here
+   |     ----- immutable borrow later used here
 
 error[E0596]: cannot borrow `foo.bar1` as mutable, as `foo` is not declared as mutable
   --> $DIR/borrowck-borrow-from-owned-ptr.rs:132:16

--- a/src/test/ui/borrowck/borrowck-borrow-from-stack-variable.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-borrow-from-stack-variable.nll.stderr
@@ -6,7 +6,7 @@ LL |     let bar1 = &mut foo.bar1;
 LL |     let _bar2 = &mut foo.bar1;  //~ ERROR cannot borrow
    |                 ^^^^^^^^^^^^^ second mutable borrow occurs here
 LL |     *bar1;
-   |     ----- borrow later used here
+   |     ----- first borrow later used here
 
 error[E0502]: cannot borrow `foo.bar1` as immutable because it is also borrowed as mutable
   --> $DIR/borrowck-borrow-from-stack-variable.rs:35:17
@@ -16,7 +16,7 @@ LL |     let bar1 = &mut foo.bar1;
 LL |     let _bar2 = &foo.bar1;  //~ ERROR cannot borrow
    |                 ^^^^^^^^^ immutable borrow occurs here
 LL |     *bar1;
-   |     ----- borrow later used here
+   |     ----- mutable borrow later used here
 
 error[E0502]: cannot borrow `foo.bar1` as mutable because it is also borrowed as immutable
   --> $DIR/borrowck-borrow-from-stack-variable.rs:42:17
@@ -26,7 +26,7 @@ LL |     let bar1 = &foo.bar1;
 LL |     let _bar2 = &mut foo.bar1;  //~ ERROR cannot borrow
    |                 ^^^^^^^^^^^^^ mutable borrow occurs here
 LL |     *bar1;
-   |     ----- borrow later used here
+   |     ----- immutable borrow later used here
 
 error[E0499]: cannot borrow `foo.bar1` as mutable more than once at a time
   --> $DIR/borrowck-borrow-from-stack-variable.rs:71:21
@@ -38,7 +38,7 @@ LL |         Foo { bar1: ref mut _bar1, bar2: _ } => {} //
    |                     ^^^^^^^^^^^^^ second mutable borrow occurs here
 ...
 LL |     *bar1;
-   |     ----- borrow later used here
+   |     ----- first borrow later used here
 
 error[E0502]: cannot borrow `foo.bar1` as immutable because it is also borrowed as mutable
   --> $DIR/borrowck-borrow-from-stack-variable.rs:80:17
@@ -49,7 +49,7 @@ LL |     let _foo1 = &foo.bar1; //~ ERROR cannot borrow
    |                 ^^^^^^^^^ immutable borrow occurs here
 LL |     let _foo2 = &foo; //~ ERROR cannot borrow
 LL |     *bar1;
-   |     ----- borrow later used here
+   |     ----- mutable borrow later used here
 
 error[E0502]: cannot borrow `foo` as immutable because it is also borrowed as mutable
   --> $DIR/borrowck-borrow-from-stack-variable.rs:81:17
@@ -60,7 +60,7 @@ LL |     let _foo1 = &foo.bar1; //~ ERROR cannot borrow
 LL |     let _foo2 = &foo; //~ ERROR cannot borrow
    |                 ^^^^ immutable borrow occurs here
 LL |     *bar1;
-   |     ----- borrow later used here
+   |     ----- mutable borrow later used here
 
 error[E0499]: cannot borrow `foo.bar1` as mutable more than once at a time
   --> $DIR/borrowck-borrow-from-stack-variable.rs:88:17
@@ -70,7 +70,7 @@ LL |     let bar1 = &mut foo.bar1.int1;
 LL |     let _foo1 = &mut foo.bar1; //~ ERROR cannot borrow
    |                 ^^^^^^^^^^^^^ second mutable borrow occurs here
 LL |     *bar1;
-   |     ----- borrow later used here
+   |     ----- first borrow later used here
 
 error[E0499]: cannot borrow `foo` as mutable more than once at a time
   --> $DIR/borrowck-borrow-from-stack-variable.rs:95:17
@@ -80,7 +80,7 @@ LL |     let bar1 = &mut foo.bar1.int1;
 LL |     let _foo2 = &mut foo; //~ ERROR cannot borrow
    |                 ^^^^^^^^ second mutable borrow occurs here
 LL |     *bar1;
-   |     ----- borrow later used here
+   |     ----- first borrow later used here
 
 error[E0502]: cannot borrow `foo.bar1` as mutable because it is also borrowed as immutable
   --> $DIR/borrowck-borrow-from-stack-variable.rs:102:17
@@ -90,7 +90,7 @@ LL |     let bar1 = &foo.bar1.int1;
 LL |     let _foo1 = &mut foo.bar1; //~ ERROR cannot borrow
    |                 ^^^^^^^^^^^^^ mutable borrow occurs here
 LL |     *bar1;
-   |     ----- borrow later used here
+   |     ----- immutable borrow later used here
 
 error[E0502]: cannot borrow `foo` as mutable because it is also borrowed as immutable
   --> $DIR/borrowck-borrow-from-stack-variable.rs:109:17
@@ -100,7 +100,7 @@ LL |     let bar1 = &foo.bar1.int1;
 LL |     let _foo2 = &mut foo; //~ ERROR cannot borrow
    |                 ^^^^^^^^ mutable borrow occurs here
 LL |     *bar1;
-   |     ----- borrow later used here
+   |     ----- immutable borrow later used here
 
 error[E0596]: cannot borrow `foo.bar1` as mutable, as `foo` is not declared as mutable
   --> $DIR/borrowck-borrow-from-stack-variable.rs:130:16

--- a/src/test/ui/borrowck/borrowck-borrow-mut-base-ptr-in-aliasable-loc.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-borrow-mut-base-ptr-in-aliasable-loc.nll.stderr
@@ -15,7 +15,7 @@ LL |     let t1 = &mut *t0;
 LL |     let p: &isize = &**t0; //~ ERROR cannot borrow
    |                     ^^^^^ immutable borrow occurs here
 LL |     **t1 = 22;
-   |     --------- borrow later used here
+   |     --------- mutable borrow later used here
 
 error[E0596]: cannot borrow `**t0` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-borrow-mut-base-ptr-in-aliasable-loc.rs:29:26

--- a/src/test/ui/borrowck/borrowck-borrow-mut-object-twice.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-borrow-mut-object-twice.nll.stderr
@@ -6,7 +6,7 @@ LL |     let y = x.f1();
 LL |     x.f2(); //~ ERROR cannot borrow `*x` as mutable
    |     ^ second mutable borrow occurs here
 LL |     y.use_ref();
-   |     - borrow later used here
+   |     - first borrow later used here
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-closures-mut-and-imm.ast.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-closures-mut-and-imm.ast.nll.stderr
@@ -11,7 +11,7 @@ LL |     let c2 = || x * 5; //[ast]~ ERROR cannot borrow `x`
    |              immutable borrow occurs here
 LL |     //[mir]~^ ERROR cannot borrow `x` as immutable because it is also borrowed as mutable
 LL |     drop(c1);
-   |          -- borrow later used here
+   |          -- mutable borrow later used here
 
 error[E0502]: cannot borrow `x` as immutable because it is also borrowed as mutable
   --> $DIR/borrowck-closures-mut-and-imm.rs:39:14
@@ -26,7 +26,7 @@ LL |     let c2 = || get(&x); //[ast]~ ERROR cannot borrow `x`
    |              immutable borrow occurs here
 LL |                          //[mir]~^ ERROR cannot borrow `x` as immutable because it is also borrowed as mutable
 LL |     drop(c1);
-   |          -- borrow later used here
+   |          -- mutable borrow later used here
 
 error[E0502]: cannot borrow `x` as immutable because it is also borrowed as mutable
   --> $DIR/borrowck-closures-mut-and-imm.rs:47:14
@@ -41,7 +41,7 @@ LL |     let c2 = || x * 5; //[ast]~ ERROR cannot borrow `x`
    |              immutable borrow occurs here
 LL |                        //[mir]~^ ERROR cannot borrow `x` as immutable because it is also borrowed as mutable
 LL |     drop(c1);
-   |          -- borrow later used here
+   |          -- mutable borrow later used here
 
 error[E0506]: cannot assign to `x` because it is borrowed
   --> $DIR/borrowck-closures-mut-and-imm.rs:55:5
@@ -108,7 +108,7 @@ LL |     let c2 = || *x.f = 5; //[ast]~ ERROR cannot borrow `x` as mutable
    |              mutable borrow occurs here
 LL |                           //[mir]~^ ERROR cannot borrow `x` as mutable because it is also borrowed as immutable
 LL |     drop(c1);
-   |          -- borrow later used here
+   |          -- immutable borrow later used here
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/borrowck/borrowck-closures-mut-and-imm.mir.stderr
+++ b/src/test/ui/borrowck/borrowck-closures-mut-and-imm.mir.stderr
@@ -11,7 +11,7 @@ LL |     let c2 = || x * 5; //[ast]~ ERROR cannot borrow `x`
    |              immutable borrow occurs here
 LL |     //[mir]~^ ERROR cannot borrow `x` as immutable because it is also borrowed as mutable
 LL |     drop(c1);
-   |          -- borrow later used here
+   |          -- mutable borrow later used here
 
 error[E0502]: cannot borrow `x` as immutable because it is also borrowed as mutable
   --> $DIR/borrowck-closures-mut-and-imm.rs:39:14
@@ -26,7 +26,7 @@ LL |     let c2 = || get(&x); //[ast]~ ERROR cannot borrow `x`
    |              immutable borrow occurs here
 LL |                          //[mir]~^ ERROR cannot borrow `x` as immutable because it is also borrowed as mutable
 LL |     drop(c1);
-   |          -- borrow later used here
+   |          -- mutable borrow later used here
 
 error[E0502]: cannot borrow `x` as immutable because it is also borrowed as mutable
   --> $DIR/borrowck-closures-mut-and-imm.rs:47:14
@@ -41,7 +41,7 @@ LL |     let c2 = || x * 5; //[ast]~ ERROR cannot borrow `x`
    |              immutable borrow occurs here
 LL |                        //[mir]~^ ERROR cannot borrow `x` as immutable because it is also borrowed as mutable
 LL |     drop(c1);
-   |          -- borrow later used here
+   |          -- mutable borrow later used here
 
 error[E0506]: cannot assign to `x` because it is borrowed
   --> $DIR/borrowck-closures-mut-and-imm.rs:55:5
@@ -108,7 +108,7 @@ LL |     let c2 = || *x.f = 5; //[ast]~ ERROR cannot borrow `x` as mutable
    |              mutable borrow occurs here
 LL |                           //[mir]~^ ERROR cannot borrow `x` as mutable because it is also borrowed as immutable
 LL |     drop(c1);
-   |          -- borrow later used here
+   |          -- immutable borrow later used here
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/borrowck/borrowck-closures-two-mut-fail.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-closures-two-mut-fail.nll.stderr
@@ -10,7 +10,7 @@ LL |     let c2 = to_fn_mut(|| x = 5); //~ ERROR cannot borrow `x` as mutable mo
    |                        |
    |                        second mutable borrow occurs here
 LL |     c1;
-   |     -- borrow later used here
+   |     -- first borrow later used here
 
 error[E0499]: cannot borrow `x` as mutable more than once at a time
   --> $DIR/borrowck-closures-two-mut-fail.rs:37:24
@@ -24,7 +24,7 @@ LL |     let c2 = to_fn_mut(|| set(&mut x)); //~ ERROR cannot borrow `x` as muta
    |                        |
    |                        second mutable borrow occurs here
 LL |     c1;
-   |     -- borrow later used here
+   |     -- first borrow later used here
 
 error[E0499]: cannot borrow `x` as mutable more than once at a time
   --> $DIR/borrowck-closures-two-mut-fail.rs:44:24
@@ -38,7 +38,7 @@ LL |     let c2 = to_fn_mut(|| set(&mut x)); //~ ERROR cannot borrow `x` as muta
    |                        |
    |                        second mutable borrow occurs here
 LL |     c1;
-   |     -- borrow later used here
+   |     -- first borrow later used here
 
 error[E0499]: cannot borrow `x` as mutable more than once at a time
   --> $DIR/borrowck-closures-two-mut-fail.rs:51:24
@@ -53,7 +53,7 @@ LL |     let c2 = to_fn_mut(|| { let _y = to_fn_mut(|| set(&mut x)); }); // (nes
    |                        second mutable borrow occurs here
 LL |     //~^ ERROR cannot borrow `x` as mutable more than once
 LL |     c1;
-   |     -- borrow later used here
+   |     -- first borrow later used here
 
 error[E0499]: cannot borrow `x` as mutable more than once at a time
   --> $DIR/borrowck-closures-two-mut-fail.rs:63:24
@@ -68,7 +68,7 @@ LL |     let c2 = to_fn_mut(|| set(&mut *x.f));
    |                        second mutable borrow occurs here
 LL |     //~^ ERROR cannot borrow `x` as mutable more than once
 LL |     c1;
-   |     -- borrow later used here
+   |     -- first borrow later used here
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/borrowck/borrowck-closures-two-mut.stderr
+++ b/src/test/ui/borrowck/borrowck-closures-two-mut.stderr
@@ -86,7 +86,7 @@ LL |     let c2 = to_fn_mut(|| x = 5); //~ ERROR cannot borrow `x` as mutable mo
    |                        second mutable borrow occurs here
 LL |     //~| ERROR cannot borrow `x` as mutable more than once
 LL |     drop((c1, c2));
-   |           -- borrow later used here
+   |           -- first borrow later used here
 
 error[E0499]: cannot borrow `x` as mutable more than once at a time (Mir)
   --> $DIR/borrowck-closures-two-mut.rs:36:24
@@ -101,7 +101,7 @@ LL |     let c2 = to_fn_mut(|| set(&mut x)); //~ ERROR cannot borrow `x` as muta
    |                        second mutable borrow occurs here
 LL |     //~| ERROR cannot borrow `x` as mutable more than once
 LL |     drop((c1, c2));
-   |           -- borrow later used here
+   |           -- first borrow later used here
 
 error[E0499]: cannot borrow `x` as mutable more than once at a time (Mir)
   --> $DIR/borrowck-closures-two-mut.rs:44:24
@@ -116,7 +116,7 @@ LL |     let c2 = to_fn_mut(|| set(&mut x)); //~ ERROR cannot borrow `x` as muta
    |                        second mutable borrow occurs here
 LL |     //~| ERROR cannot borrow `x` as mutable more than once
 LL |     drop((c1, c2));
-   |           -- borrow later used here
+   |           -- first borrow later used here
 
 error[E0499]: cannot borrow `x` as mutable more than once at a time (Mir)
   --> $DIR/borrowck-closures-two-mut.rs:52:24
@@ -131,7 +131,7 @@ LL |     let c2 = to_fn_mut(|| { let _y = to_fn_mut(|| set(&mut x)); }); // (nes
    |                        second mutable borrow occurs here
 ...
 LL |     drop((c1, c2));
-   |           -- borrow later used here
+   |           -- first borrow later used here
 
 error[E0499]: cannot borrow `x` as mutable more than once at a time (Mir)
   --> $DIR/borrowck-closures-two-mut.rs:65:24
@@ -146,7 +146,7 @@ LL |     let c2 = to_fn_mut(|| set(&mut *x.f));
    |                        second mutable borrow occurs here
 ...
 LL |     drop((c1, c2));
-   |           -- borrow later used here
+   |           -- first borrow later used here
 
 error: aborting due to 10 previous errors
 

--- a/src/test/ui/borrowck/borrowck-closures-unique-imm.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-closures-unique-imm.nll.stderr
@@ -6,7 +6,7 @@ LL |         let p = &this.x;
 LL |         &mut this.x; //~ ERROR cannot borrow
    |         ^^^^^^^^^^^ mutable borrow occurs here
 LL |         p.use_ref();
-   |         - borrow later used here
+   |         - immutable borrow later used here
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-closures-unique.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-closures-unique.nll.stderr
@@ -10,7 +10,7 @@ LL |     let c2 = || set(x); //~ ERROR closure requires unique access to `x`
    |              |
    |              closure construction occurs here
 LL |     c1;
-   |     -- borrow later used here
+   |     -- first borrow later used here
 
 error[E0500]: closure requires unique access to `x` but it is already borrowed
   --> $DIR/borrowck-closures-unique.rs:42:14
@@ -24,7 +24,7 @@ LL |     let c2 = || { get(x); set(x); }; //~ ERROR closure requires unique acce
    |              |
    |              closure construction occurs here
 LL |     c1;
-   |     -- borrow later used here
+   |     -- first borrow later used here
 
 error[E0524]: two closures require unique access to `x` at the same time
   --> $DIR/borrowck-closures-unique.rs:48:14
@@ -38,7 +38,7 @@ LL |     let c2 = || set(x); //~ ERROR two closures require unique access to `x`
    |              |
    |              second closure is constructed here
 LL |     c1;
-   |     -- borrow later used here
+   |     -- first borrow later used here
 
 error[E0594]: cannot assign to `x`, as it is not declared as mutable
   --> $DIR/borrowck-closures-unique.rs:57:38

--- a/src/test/ui/borrowck/borrowck-closures-use-after-free.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-closures-use-after-free.nll.stderr
@@ -7,10 +7,9 @@ LL |     ptr = box Foo { x: ptr.x + 1 };
    |     --- first borrow occurs due to use of `ptr` in closure
 LL |   };
 LL |   test(&*ptr); //~ ERROR cannot borrow `*ptr`
-   |   -----^^^^^-
-   |   |    |
-   |   |    immutable borrow occurs here
-   |   borrow later used here
+   |   ---- ^^^^^ immutable borrow occurs here
+   |   |
+   |   mutable borrow later used by call
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-describe-lvalue.ast.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-describe-lvalue.ast.nll.stderr
@@ -7,7 +7,7 @@ LL |             &mut x; //[ast]~ ERROR cannot borrow `**x` as mutable more than
    |             ^^^^^^ second mutable borrow occurs here
 LL |                     //[mir]~^ ERROR cannot borrow `x` as mutable more than once at a time
 LL |             *y = 1;
-   |             ------ borrow later used here
+   |             ------ first borrow later used here
 
 error[E0499]: cannot borrow `x` as mutable more than once at a time
   --> $DIR/borrowck-describe-lvalue.rs:307:20
@@ -18,7 +18,7 @@ LL |                    &mut x; //[ast]~ ERROR cannot borrow `**x` as mutable mo
    |                    ^^^^^^ second mutable borrow occurs here
 LL |                    //[mir]~^ ERROR cannot borrow `x` as mutable more than once at a time
 LL |                    *y = 1;
-   |                    ------ borrow later used here
+   |                    ------ first borrow later used here
 
 error: unsatisfied lifetime constraints
   --> $DIR/borrowck-describe-lvalue.rs:305:16
@@ -269,7 +269,7 @@ LL |             E::A(ref ax) =>
    |                  ^^^^^^ immutable borrow occurs here
 ...
 LL |         drop(x);
-   |              - borrow later used here
+   |              - mutable borrow later used here
 
 error[E0502]: cannot borrow `e.x` as immutable because it is also borrowed as mutable
   --> $DIR/borrowck-describe-lvalue.rs:207:23
@@ -281,7 +281,7 @@ LL |             E::B { x: ref bx } =>
    |                       ^^^^^^ immutable borrow occurs here
 ...
 LL |         drop(x);
-   |              - borrow later used here
+   |              - mutable borrow later used here
 
 error[E0502]: cannot borrow `s.y.0` as immutable because it is also borrowed as mutable
   --> $DIR/borrowck-describe-lvalue.rs:221:22
@@ -293,7 +293,7 @@ LL |             S  { y: (ref y0, _), .. } =>
    |                      ^^^^^^ immutable borrow occurs here
 ...
 LL |         drop(x);
-   |              - borrow later used here
+   |              - mutable borrow later used here
 
 error[E0502]: cannot borrow `s.x.y` as immutable because it is also borrowed as mutable
   --> $DIR/borrowck-describe-lvalue.rs:228:28
@@ -305,7 +305,7 @@ LL |             S  { x: F { y: ref x0, .. }, .. } =>
    |                            ^^^^^^ immutable borrow occurs here
 ...
 LL |         drop(x);
-   |              - borrow later used here
+   |              - mutable borrow later used here
 
 error[E0503]: cannot use `*v` because it was mutably borrowed
   --> $DIR/borrowck-describe-lvalue.rs:271:9
@@ -339,7 +339,7 @@ LL |             &[_, F {x: ref xf, ..}] => println!("{}", xf),
    |                        ^^^^^^ immutable borrow occurs here
 ...
 LL |         drop(x);
-   |              - borrow later used here
+   |              - mutable borrow later used here
 
 error[E0502]: cannot borrow `*block.current` as immutable because it is also borrowed as mutable
   --> $DIR/borrowck-describe-lvalue.rs:245:29
@@ -350,7 +350,7 @@ LL |             let p: &'a u8 = &*block.current;
    |                             ^^^^^^^^^^^^^^^ immutable borrow occurs here
 ...
 LL |             drop(x);
-   |                  - borrow later used here
+   |                  - mutable borrow later used here
 
 error[E0502]: cannot borrow `*block.current` as immutable because it is also borrowed as mutable
   --> $DIR/borrowck-describe-lvalue.rs:260:33
@@ -361,7 +361,7 @@ LL |             let p : *const u8 = &*(*block).current;
    |                                 ^^^^^^^^^^^^^^^^^^ immutable borrow occurs here
 ...
 LL |             drop(x);
-   |                  - borrow later used here
+   |                  - mutable borrow later used here
 
 error[E0382]: use of moved value: `x`
   --> $DIR/borrowck-describe-lvalue.rs:318:22

--- a/src/test/ui/borrowck/borrowck-describe-lvalue.mir.stderr
+++ b/src/test/ui/borrowck/borrowck-describe-lvalue.mir.stderr
@@ -7,7 +7,7 @@ LL |             &mut x; //[ast]~ ERROR cannot borrow `**x` as mutable more than
    |             ^^^^^^ second mutable borrow occurs here
 LL |                     //[mir]~^ ERROR cannot borrow `x` as mutable more than once at a time
 LL |             *y = 1;
-   |             ------ borrow later used here
+   |             ------ first borrow later used here
 
 error[E0499]: cannot borrow `x` as mutable more than once at a time
   --> $DIR/borrowck-describe-lvalue.rs:307:20
@@ -18,7 +18,7 @@ LL |                    &mut x; //[ast]~ ERROR cannot borrow `**x` as mutable mo
    |                    ^^^^^^ second mutable borrow occurs here
 LL |                    //[mir]~^ ERROR cannot borrow `x` as mutable more than once at a time
 LL |                    *y = 1;
-   |                    ------ borrow later used here
+   |                    ------ first borrow later used here
 
 error: unsatisfied lifetime constraints
   --> $DIR/borrowck-describe-lvalue.rs:305:16
@@ -269,7 +269,7 @@ LL |             E::A(ref ax) =>
    |                  ^^^^^^ immutable borrow occurs here
 ...
 LL |         drop(x);
-   |              - borrow later used here
+   |              - mutable borrow later used here
 
 error[E0502]: cannot borrow `e.x` as immutable because it is also borrowed as mutable
   --> $DIR/borrowck-describe-lvalue.rs:207:23
@@ -281,7 +281,7 @@ LL |             E::B { x: ref bx } =>
    |                       ^^^^^^ immutable borrow occurs here
 ...
 LL |         drop(x);
-   |              - borrow later used here
+   |              - mutable borrow later used here
 
 error[E0502]: cannot borrow `s.y.0` as immutable because it is also borrowed as mutable
   --> $DIR/borrowck-describe-lvalue.rs:221:22
@@ -293,7 +293,7 @@ LL |             S  { y: (ref y0, _), .. } =>
    |                      ^^^^^^ immutable borrow occurs here
 ...
 LL |         drop(x);
-   |              - borrow later used here
+   |              - mutable borrow later used here
 
 error[E0502]: cannot borrow `s.x.y` as immutable because it is also borrowed as mutable
   --> $DIR/borrowck-describe-lvalue.rs:228:28
@@ -305,7 +305,7 @@ LL |             S  { x: F { y: ref x0, .. }, .. } =>
    |                            ^^^^^^ immutable borrow occurs here
 ...
 LL |         drop(x);
-   |              - borrow later used here
+   |              - mutable borrow later used here
 
 error[E0503]: cannot use `*v` because it was mutably borrowed
   --> $DIR/borrowck-describe-lvalue.rs:271:9
@@ -339,7 +339,7 @@ LL |             &[_, F {x: ref xf, ..}] => println!("{}", xf),
    |                        ^^^^^^ immutable borrow occurs here
 ...
 LL |         drop(x);
-   |              - borrow later used here
+   |              - mutable borrow later used here
 
 error[E0502]: cannot borrow `*block.current` as immutable because it is also borrowed as mutable
   --> $DIR/borrowck-describe-lvalue.rs:245:29
@@ -350,7 +350,7 @@ LL |             let p: &'a u8 = &*block.current;
    |                             ^^^^^^^^^^^^^^^ immutable borrow occurs here
 ...
 LL |             drop(x);
-   |                  - borrow later used here
+   |                  - mutable borrow later used here
 
 error[E0502]: cannot borrow `*block.current` as immutable because it is also borrowed as mutable
   --> $DIR/borrowck-describe-lvalue.rs:260:33
@@ -361,7 +361,7 @@ LL |             let p : *const u8 = &*(*block).current;
    |                                 ^^^^^^^^^^^^^^^^^^ immutable borrow occurs here
 ...
 LL |             drop(x);
-   |                  - borrow later used here
+   |                  - mutable borrow later used here
 
 error[E0382]: use of moved value: `x`
   --> $DIR/borrowck-describe-lvalue.rs:318:22

--- a/src/test/ui/borrowck/borrowck-field-sensitivity.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-field-sensitivity.nll.stderr
@@ -62,7 +62,7 @@ LL |     let p = &mut x.a;
 LL |     let q = &mut x.a; //~ ERROR cannot borrow `x.a` as mutable more than once at a time
    |             ^^^^^^^^ second mutable borrow occurs here
 LL |     drop(*p);
-   |          -- borrow later used here
+   |          -- first borrow later used here
 
 error[E0382]: use of moved value: `x.b`
   --> $DIR/borrowck-field-sensitivity.rs:66:10

--- a/src/test/ui/borrowck/borrowck-for-loop-head-linkage.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-for-loop-head-linkage.nll.stderr
@@ -5,7 +5,7 @@ LL |     for &x in &vector {
    |               -------
    |               |
    |               immutable borrow occurs here
-   |               borrow used here, in later iteration of loop
+   |               immutable borrow used here, in later iteration of loop
 LL |         let cap = vector.capacity();
 LL |         vector.extend(repeat(0));      //~ ERROR cannot borrow
    |         ^^^^^^^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
@@ -17,7 +17,7 @@ LL |     for &x in &vector {
    |               -------
    |               |
    |               immutable borrow occurs here
-   |               borrow used here, in later iteration of loop
+   |               immutable borrow used here, in later iteration of loop
 ...
 LL |         vector[1] = 5;   //~ ERROR cannot borrow
    |         ^^^^^^ mutable borrow occurs here

--- a/src/test/ui/borrowck/borrowck-insert-during-each.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-insert-during-each.nll.stderr
@@ -1,34 +1,28 @@
 error[E0501]: cannot borrow `*f` as mutable because previous closure requires unique access
   --> $DIR/borrowck-insert-during-each.rs:26:3
    |
-LL |      f.foo(
-   |   ___^
-   |  |___|
-   | ||
-LL | ||         |a| { //~ ERROR closure requires unique access to `f`
-   | ||         --- closure construction occurs here
-LL | ||             f.n.insert(*a);
-   | ||             - first borrow occurs due to use of `f` in closure
-LL | ||         })
-   | ||          ^
-   | ||__________|
-   | |___________borrow occurs here
-   |             borrow later used here
+LL |     f.foo(
+   |     ^ --- first borrow later used by call
+   |  ___|
+   | |
+LL | |         |a| { //~ ERROR closure requires unique access to `f`
+   | |         --- closure construction occurs here
+LL | |             f.n.insert(*a);
+   | |             - first borrow occurs due to use of `f` in closure
+LL | |         })
+   | |__________^ borrow occurs here
 
 error[E0500]: closure requires unique access to `f` but it is already borrowed
   --> $DIR/borrowck-insert-during-each.rs:27:9
    |
-LL |     f.foo(
-   |     -
-   |     |
-   |  ___borrow occurs here
-   | |
-LL | |         |a| { //~ ERROR closure requires unique access to `f`
-   | |         ^^^ closure construction occurs here
-LL | |             f.n.insert(*a);
-   | |             - second borrow occurs due to use of `f` in closure
-LL | |         })
-   | |__________- borrow later used here
+LL |   f.foo(
+   |   - --- first borrow later used by call
+   |   |
+   |   borrow occurs here
+LL |         |a| { //~ ERROR closure requires unique access to `f`
+   |         ^^^ closure construction occurs here
+LL |             f.n.insert(*a);
+   |             - second borrow occurs due to use of `f` in closure
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/borrowck/borrowck-lend-flow-if.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-lend-flow-if.nll.stderr
@@ -7,7 +7,7 @@ LL |     }
 LL |     borrow_mut(&mut *v); //~ ERROR cannot borrow
    |                ^^^^^^^ mutable borrow occurs here
 LL |     _w.use_ref();
-   |     -- borrow later used here
+   |     -- immutable borrow later used here
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-lend-flow-loop.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-lend-flow-loop.nll.stderr
@@ -8,13 +8,13 @@ LL |         borrow(&*v); //~ ERROR cannot borrow
    |                ^^^ immutable borrow occurs here
 LL |     }
 LL |     *x = box 5;
-   |     -- borrow used here, in later iteration of loop
+   |     -- mutable borrow used here, in later iteration of loop
 
 error[E0502]: cannot borrow `*v` as immutable because it is also borrowed as mutable
   --> $DIR/borrowck-lend-flow-loop.rs:109:16
    |
 LL |         **x += 1;
-   |         -------- borrow used here, in later iteration of loop
+   |         -------- mutable borrow used here, in later iteration of loop
 LL |         borrow(&*v); //~ ERROR cannot borrow
    |                ^^^ immutable borrow occurs here
 LL |         if cond2 {

--- a/src/test/ui/borrowck/borrowck-lend-flow.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-lend-flow.nll.stderr
@@ -6,7 +6,7 @@ LL |     let _w = &v;
 LL |     borrow_mut(&mut *v); //~ ERROR cannot borrow
    |                ^^^^^^^ mutable borrow occurs here
 LL |     _w.use_ref();
-   |     -- borrow later used here
+   |     -- immutable borrow later used here
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-loan-blocks-mut-uniq.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-loan-blocks-mut-uniq.nll.stderr
@@ -1,18 +1,14 @@
 error[E0502]: cannot borrow `v` as mutable because it is also borrowed as immutable
   --> $DIR/borrowck-loan-blocks-mut-uniq.rs:20:12
    |
-LL |       borrow(&*v,
-   |       -      --- immutable borrow occurs here
-   |  _____|
-   | |
-LL | |            |w| { //~ ERROR cannot borrow `v` as mutable
-   | |            ^^^ mutable borrow occurs here
-LL | |             v = box 4;
-   | |             - second borrow occurs due to use of `v` in closure
-LL | |             assert_eq!(*v, 3);
-LL | |             assert_eq!(*w, 4);
-LL | |         })
-   | |__________- borrow later used here
+LL |     borrow(&*v,
+   |     ------ --- immutable borrow occurs here
+   |     |
+   |     immutable borrow later used by call
+LL |            |w| { //~ ERROR cannot borrow `v` as mutable
+   |            ^^^ mutable borrow occurs here
+LL |             v = box 4;
+   |             - second borrow occurs due to use of `v` in closure
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-loan-rcvr-overloaded-op.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-loan-rcvr-overloaded-op.nll.stderr
@@ -20,7 +20,7 @@ LL |     p.times(3); //~ ERROR cannot borrow `p`
    |     ^ immutable borrow occurs here
 LL | 
 LL |     *q + 3; // OK to use the new alias `q`
-   |     -- borrow later used here
+   |     -- mutable borrow later used here
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/borrowck/borrowck-loan-rcvr.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-loan-rcvr.nll.stderr
@@ -1,15 +1,13 @@
 error[E0502]: cannot borrow `p` as mutable because it is also borrowed as immutable
   --> $DIR/borrowck-loan-rcvr.rs:34:14
    |
-LL |       p.blockm(|| { //~ ERROR cannot borrow `p` as mutable
-   |       -        ^^ mutable borrow occurs here
-   |       |
-   |  _____immutable borrow occurs here
-   | |
-LL | |         p.x = 10;
-   | |         - second borrow occurs due to use of `p` in closure
-LL | |     })
-   | |______- borrow later used here
+LL |     p.blockm(|| { //~ ERROR cannot borrow `p` as mutable
+   |     - ------ ^^ mutable borrow occurs here
+   |     | |
+   |     | immutable borrow later used by call
+   |     immutable borrow occurs here
+LL |         p.x = 10;
+   |         - second borrow occurs due to use of `p` in closure
 
 error[E0502]: cannot borrow `p` as immutable because it is also borrowed as mutable
   --> $DIR/borrowck-loan-rcvr.rs:45:5
@@ -20,7 +18,7 @@ LL |     p.impurem(); //~ ERROR cannot borrow
    |     ^ immutable borrow occurs here
 LL | 
 LL |     l.x += 1;
-   |     -------- borrow later used here
+   |     -------- mutable borrow later used here
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/borrowck/borrowck-loan-vec-content.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-loan-vec-content.nll.stderr
@@ -1,15 +1,14 @@
 error[E0502]: cannot borrow `v` as mutable because it is also borrowed as immutable
   --> $DIR/borrowck-loan-vec-content.rs:28:9
    |
-LL | /     takes_imm_elt(
-LL | |         &v[0],
-   | |          - immutable borrow occurs here
-LL | |         || { //~ ERROR cannot borrow `v` as mutable
-   | |         ^^ mutable borrow occurs here
-LL | |             v[1] = 4;
-   | |             - second borrow occurs due to use of `v` in closure
-LL | |         })
-   | |__________- borrow later used here
+LL |     takes_imm_elt(
+   |     ------------- immutable borrow later used by call
+LL |         &v[0],
+   |          - immutable borrow occurs here
+LL |         || { //~ ERROR cannot borrow `v` as mutable
+   |         ^^ mutable borrow occurs here
+LL |             v[1] = 4;
+   |             - second borrow occurs due to use of `v` in closure
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-mut-borrow-linear-errors.ast.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-mut-borrow-linear-errors.ast.nll.stderr
@@ -4,7 +4,7 @@ error[E0499]: cannot borrow `x` as mutable more than once at a time
 LL |             1 => { addr.push(&mut x); } //[ast]~ ERROR [E0499]
    |                    ----      ^^^^^^ second mutable borrow occurs here
    |                    |
-   |                    borrow used here, in later iteration of loop
+   |                    first borrow used here, in later iteration of loop
 ...
 LL |             _ => { addr.push(&mut x); } //[ast]~ ERROR [E0499]
    |                              ------ first mutable borrow occurs here
@@ -13,7 +13,7 @@ error[E0499]: cannot borrow `x` as mutable more than once at a time
   --> $DIR/borrowck-mut-borrow-linear-errors.rs:25:30
    |
 LL |             1 => { addr.push(&mut x); } //[ast]~ ERROR [E0499]
-   |                    ---- borrow used here, in later iteration of loop
+   |                    ---- first borrow used here, in later iteration of loop
 LL |             //[mir]~^ ERROR [E0499]
 LL |             2 => { addr.push(&mut x); } //[ast]~ ERROR [E0499]
    |                              ^^^^^^ second mutable borrow occurs here

--- a/src/test/ui/borrowck/borrowck-mut-borrow-linear-errors.mir.stderr
+++ b/src/test/ui/borrowck/borrowck-mut-borrow-linear-errors.mir.stderr
@@ -4,7 +4,7 @@ error[E0499]: cannot borrow `x` as mutable more than once at a time
 LL |             1 => { addr.push(&mut x); } //[ast]~ ERROR [E0499]
    |                    ----      ^^^^^^ second mutable borrow occurs here
    |                    |
-   |                    borrow used here, in later iteration of loop
+   |                    first borrow used here, in later iteration of loop
 ...
 LL |             _ => { addr.push(&mut x); } //[ast]~ ERROR [E0499]
    |                              ------ first mutable borrow occurs here
@@ -13,7 +13,7 @@ error[E0499]: cannot borrow `x` as mutable more than once at a time
   --> $DIR/borrowck-mut-borrow-linear-errors.rs:25:30
    |
 LL |             1 => { addr.push(&mut x); } //[ast]~ ERROR [E0499]
-   |                    ---- borrow used here, in later iteration of loop
+   |                    ---- first borrow used here, in later iteration of loop
 LL |             //[mir]~^ ERROR [E0499]
 LL |             2 => { addr.push(&mut x); } //[ast]~ ERROR [E0499]
    |                              ^^^^^^ second mutable borrow occurs here

--- a/src/test/ui/borrowck/borrowck-mut-borrow-of-mut-base-ptr.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-mut-borrow-of-mut-base-ptr.nll.stderr
@@ -7,7 +7,7 @@ LL |     let mut t2 = &mut t0;   //~ ERROR cannot borrow `t0`
    |                  ^^^^^^^ mutable borrow occurs here
 LL |     **t2 += 1;              // Mutates `*t0`
 LL |     p.use_ref();
-   |     - borrow later used here
+   |     - immutable borrow later used here
 
 error[E0499]: cannot borrow `t0` as mutable more than once at a time
   --> $DIR/borrowck-mut-borrow-of-mut-base-ptr.rs:29:18
@@ -18,7 +18,7 @@ LL |     let mut t2 = &mut t0;       //~ ERROR cannot borrow `t0`
    |                  ^^^^^^^ second mutable borrow occurs here
 LL |     **t2 += 1;                  // Mutates `*t0` but not through `*p`
 LL |     p.use_mut();
-   |     - borrow later used here
+   |     - first borrow later used here
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/borrowck/borrowck-object-lifetime.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-object-lifetime.nll.stderr
@@ -6,7 +6,7 @@ LL |     let y = x.borrowed();
 LL |     let z = x.mut_borrowed(); //~ ERROR cannot borrow
    |             ^^^^^^^^^^^^^^^^ mutable borrow occurs here
 LL |     y.use_ref();
-   |     - borrow later used here
+   |     - immutable borrow later used here
 
 error[E0502]: cannot borrow `x` as mutable because it is also borrowed as immutable
   --> $DIR/borrowck-object-lifetime.rs:36:13
@@ -16,7 +16,7 @@ LL |     let y = x.borrowed();
 LL |     let z = &mut x; //~ ERROR cannot borrow
    |             ^^^^^^ mutable borrow occurs here
 LL |     y.use_ref();
-   |     - borrow later used here
+   |     - immutable borrow later used here
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/borrowck/borrowck-overloaded-index-autoderef.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-overloaded-index-autoderef.nll.stderr
@@ -6,7 +6,7 @@ LL |     let p = &mut f[&s];
 LL |     let q = &f[&s]; //~ ERROR cannot borrow
    |              ^ immutable borrow occurs here
 LL |     p.use_mut();
-   |     - borrow later used here
+   |     - mutable borrow later used here
 
 error[E0499]: cannot borrow `*f` as mutable more than once at a time
   --> $DIR/borrowck-overloaded-index-autoderef.rs:53:18
@@ -16,7 +16,7 @@ LL |     let p = &mut f[&s];
 LL |     let q = &mut f[&s]; //~ ERROR cannot borrow
    |                  ^ second mutable borrow occurs here
 LL |     p.use_mut();
-   |     - borrow later used here
+   |     - first borrow later used here
 
 error[E0499]: cannot borrow `f.foo` as mutable more than once at a time
   --> $DIR/borrowck-overloaded-index-autoderef.rs:63:18
@@ -26,7 +26,7 @@ LL |     let p = &mut f.foo[&s];
 LL |     let q = &mut f.foo[&s]; //~ ERROR cannot borrow
    |                  ^^^^^ second mutable borrow occurs here
 LL |     p.use_mut();
-   |     - borrow later used here
+   |     - first borrow later used here
 
 error[E0502]: cannot borrow `f.foo` as mutable because it is also borrowed as immutable
   --> $DIR/borrowck-overloaded-index-autoderef.rs:75:18
@@ -36,7 +36,7 @@ LL |     let p = &f.foo[&s];
 LL |     let q = &mut f.foo[&s]; //~ ERROR cannot borrow
    |                  ^^^^^ mutable borrow occurs here
 LL |     p.use_ref();
-   |     - borrow later used here
+   |     - immutable borrow later used here
 
 error[E0506]: cannot assign to `f.foo` because it is borrowed
   --> $DIR/borrowck-overloaded-index-autoderef.rs:81:5

--- a/src/test/ui/borrowck/borrowck-overloaded-index-ref-index.ast.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-overloaded-index-ref-index.ast.nll.stderr
@@ -7,7 +7,7 @@ LL |     println!("{}", f[&s]);
    |                      ^^ immutable borrow occurs here
 ...
 LL |     drop(rs);
-   |          -- borrow later used here
+   |          -- mutable borrow later used here
 
 error[E0502]: cannot borrow `s` as immutable because it is also borrowed as mutable
   --> $DIR/borrowck-overloaded-index-ref-index.rs:65:7
@@ -19,7 +19,7 @@ LL |     f[&s] = 10;
    |       ^^ immutable borrow occurs here
 ...
 LL |     drop(rs);
-   |          -- borrow later used here
+   |          -- mutable borrow later used here
 
 error[E0594]: cannot assign to data in a `&` reference
   --> $DIR/borrowck-overloaded-index-ref-index.rs:71:5

--- a/src/test/ui/borrowck/borrowck-overloaded-index-ref-index.mir.stderr
+++ b/src/test/ui/borrowck/borrowck-overloaded-index-ref-index.mir.stderr
@@ -7,7 +7,7 @@ LL |     println!("{}", f[&s]);
    |                      ^^ immutable borrow occurs here
 ...
 LL |     drop(rs);
-   |          -- borrow later used here
+   |          -- mutable borrow later used here
 
 error[E0502]: cannot borrow `s` as immutable because it is also borrowed as mutable
   --> $DIR/borrowck-overloaded-index-ref-index.rs:65:7
@@ -19,7 +19,7 @@ LL |     f[&s] = 10;
    |       ^^ immutable borrow occurs here
 ...
 LL |     drop(rs);
-   |          -- borrow later used here
+   |          -- mutable borrow later used here
 
 error[E0594]: cannot assign to data in a `&` reference
   --> $DIR/borrowck-overloaded-index-ref-index.rs:71:5

--- a/src/test/ui/borrowck/borrowck-report-with-custom-diagnostic.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-report-with-custom-diagnostic.nll.stderr
@@ -8,7 +8,7 @@ LL |     let z = &x; //~ ERROR cannot borrow
    |             ^^ immutable borrow occurs here
 ...
 LL |     y.use_mut();
-   |     - borrow later used here
+   |     - mutable borrow later used here
 
 error[E0502]: cannot borrow `x` as mutable because it is also borrowed as immutable
   --> $DIR/borrowck-report-with-custom-diagnostic.rs:30:21
@@ -20,7 +20,7 @@ LL |             let z = &mut x; //~ ERROR cannot borrow
    |                     ^^^^^^ mutable borrow occurs here
 ...
 LL |             y.use_ref();
-   |             - borrow later used here
+   |             - immutable borrow later used here
 
 error[E0499]: cannot borrow `x` as mutable more than once at a time
   --> $DIR/borrowck-report-with-custom-diagnostic.rs:45:17
@@ -32,7 +32,7 @@ LL |         let z = &mut x; //~ ERROR cannot borrow
    |                 ^^^^^^ second mutable borrow occurs here
 ...
 LL |         y.use_mut();
-   |         - borrow later used here
+   |         - first borrow later used here
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/borrowck/borrowck-slice-pattern-element-loan.stderr
+++ b/src/test/ui/borrowck/borrowck-slice-pattern-element-loan.stderr
@@ -6,7 +6,7 @@ LL |     if let [ref first, ref second, ..] = *s {
 LL |         if let [_, ref mut  second2, ref mut third, ..] = *s { //~ERROR
    |                    ^^^^^^^^^^^^^^^^ mutable borrow occurs here
 LL |             nop(&[first, second, second2, third]);
-   |                          ------ borrow later used here
+   |                          ------ immutable borrow later used here
 
 error[E0502]: cannot borrow `s[..]` as mutable because it is also borrowed as immutable
   --> $DIR/borrowck-slice-pattern-element-loan.rs:44:21
@@ -16,7 +16,7 @@ LL |     if let [.., ref fourth, ref third, _, ref first] = *s {
 LL |         if let [.., ref mut third2, _, _] = *s { //~ERROR
    |                     ^^^^^^^^^^^^^^ mutable borrow occurs here
 LL |             nop(&[first, third, third2, fourth]);
-   |                          ----- borrow later used here
+   |                          ----- immutable borrow later used here
 
 error[E0502]: cannot borrow `s[..]` as mutable because it is also borrowed as immutable
   --> $DIR/borrowck-slice-pattern-element-loan.rs:55:20
@@ -27,7 +27,7 @@ LL |     if let [.., _, ref from_end4, ref from_end3, _, ref from_end1] = *s {
 LL |         if let [_, ref mut from_begin1, ..] = *s { //~ERROR
    |                    ^^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
 LL |             nop(&[from_begin1, from_end1, from_end3, from_end4]);
-   |                                                      --------- borrow later used here
+   |                                                      --------- immutable borrow later used here
 
 error[E0502]: cannot borrow `s[..]` as mutable because it is also borrowed as immutable
   --> $DIR/borrowck-slice-pattern-element-loan.rs:58:23
@@ -38,7 +38,7 @@ LL |     if let [.., _, ref from_end4, ref from_end3, _, ref from_end1] = *s {
 LL |         if let [_, _, ref mut from_begin2, ..] = *s { //~ERROR
    |                       ^^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
 LL |             nop(&[from_begin2, from_end1, from_end3, from_end4]);
-   |                                           --------- borrow later used here
+   |                                           --------- immutable borrow later used here
 
 error[E0502]: cannot borrow `s[..]` as mutable because it is also borrowed as immutable
   --> $DIR/borrowck-slice-pattern-element-loan.rs:61:26
@@ -49,7 +49,7 @@ LL |     if let [.., _, ref from_end4, ref from_end3, _, ref from_end1] = *s {
 LL |         if let [_, _, _, ref mut from_begin3, ..] = *s { //~ERROR
    |                          ^^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
 LL |             nop(&[from_begin3, from_end1, from_end3, from_end4]);
-   |                                           --------- borrow later used here
+   |                                           --------- immutable borrow later used here
 
 error[E0502]: cannot borrow `s[..]` as mutable because it is also borrowed as immutable
   --> $DIR/borrowck-slice-pattern-element-loan.rs:69:21
@@ -60,7 +60,7 @@ LL |     if let [ref from_begin0, ref from_begin1, _, ref from_begin3, _, ..] = 
 LL |         if let [.., ref mut from_end2, _] = *s { //~ERROR
    |                     ^^^^^^^^^^^^^^^^^ mutable borrow occurs here
 LL |             nop(&[from_begin0, from_begin1, from_begin3, from_end2]);
-   |                                             ----------- borrow later used here
+   |                                             ----------- immutable borrow later used here
 
 error[E0502]: cannot borrow `s[..]` as mutable because it is also borrowed as immutable
   --> $DIR/borrowck-slice-pattern-element-loan.rs:72:21
@@ -71,7 +71,7 @@ LL |     if let [ref from_begin0, ref from_begin1, _, ref from_begin3, _, ..] = 
 LL |         if let [.., ref mut from_end3, _,  _] = *s { //~ERROR
    |                     ^^^^^^^^^^^^^^^^^ mutable borrow occurs here
 LL |             nop(&[from_begin0, from_begin1, from_begin3, from_end3]);
-   |                                             ----------- borrow later used here
+   |                                             ----------- immutable borrow later used here
 
 error[E0502]: cannot borrow `s[..]` as mutable because it is also borrowed as immutable
   --> $DIR/borrowck-slice-pattern-element-loan.rs:75:21
@@ -82,7 +82,7 @@ LL |     if let [ref from_begin0, ref from_begin1, _, ref from_begin3, _, ..] = 
 LL |         if let [.., ref mut from_end4, _, _, _] = *s { //~ERROR
    |                     ^^^^^^^^^^^^^^^^^ mutable borrow occurs here
 LL |             nop(&[from_begin0, from_begin1, from_begin3, from_end4]);
-   |                                ----------- borrow later used here
+   |                                ----------- immutable borrow later used here
 
 error[E0502]: cannot borrow `s[..]` as mutable because it is also borrowed as immutable
   --> $DIR/borrowck-slice-pattern-element-loan.rs:92:20
@@ -92,7 +92,7 @@ LL |     if let [ref first, ref second, ..] = *s {
 LL |         if let [_, ref mut tail..] = *s { //~ERROR
    |                    ^^^^^^^^^^^^ mutable borrow occurs here
 LL |             nop(&[first, second]);
-   |                          ------ borrow later used here
+   |                          ------ immutable borrow later used here
 
 error[E0502]: cannot borrow `s[..]` as mutable because it is also borrowed as immutable
   --> $DIR/borrowck-slice-pattern-element-loan.rs:110:17
@@ -102,7 +102,7 @@ LL |     if let [.., ref second, ref first] = *s {
 LL |         if let [ref mut tail.., _] = *s { //~ERROR
    |                 ^^^^^^^^^^^^ mutable borrow occurs here
 LL |             nop(&[first, second]);
-   |                          ------ borrow later used here
+   |                          ------ immutable borrow later used here
 
 error[E0502]: cannot borrow `s[..]` as mutable because it is also borrowed as immutable
   --> $DIR/borrowck-slice-pattern-element-loan.rs:119:17
@@ -112,7 +112,7 @@ LL |     if let [_, _, _, ref s1..] = *s {
 LL |         if let [ref mut s2.., _, _, _] = *s { //~ERROR
    |                 ^^^^^^^^^^ mutable borrow occurs here
 LL |             nop_subslice(s1);
-   |                          -- borrow later used here
+   |                          -- immutable borrow later used here
 
 error: aborting due to 11 previous errors
 

--- a/src/test/ui/borrowck/borrowck-swap-mut-base-ptr.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-swap-mut-base-ptr.nll.stderr
@@ -7,7 +7,7 @@ LL |     swap(&mut t0, &mut t1); //~ ERROR cannot borrow `t0`
    |          ^^^^^^^ mutable borrow occurs here
 LL |     *t1 = 22;
 LL |     p.use_ref();
-   |     - borrow later used here
+   |     - immutable borrow later used here
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-union-borrow.ast.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-union-borrow.ast.nll.stderr
@@ -7,7 +7,7 @@ LL |             let rma = &mut u.a; //[ast]~ ERROR cannot borrow `u.a` as mutab
    |                       ^^^^^^^^ mutable borrow occurs here
 LL |                                 //[mir]~^ ERROR cannot borrow `u.a` as mutable because it is also borrowed as immutable
 LL |             drop(ra);
-   |                  -- borrow later used here
+   |                  -- immutable borrow later used here
 
 error[E0506]: cannot assign to `u.a` because it is borrowed
   --> $DIR/borrowck-union-borrow.rs:43:13
@@ -29,7 +29,7 @@ LL |             let rmb = &mut u.b; //[ast]~ ERROR cannot borrow `u` (via `u.b`
    |                       ^^^^^^^^ mutable borrow occurs here
 LL |                                 //[mir]~^ ERROR cannot borrow `u.b` as mutable because it is also borrowed as immutable
 LL |             drop(ra);
-   |                  -- borrow later used here
+   |                  -- immutable borrow later used here
 
 error[E0506]: cannot assign to `u.b` because it is borrowed
   --> $DIR/borrowck-union-borrow.rs:66:13
@@ -51,7 +51,7 @@ LL |             let ra = &u.a; //[ast]~ ERROR cannot borrow `u.a` as immutable 
    |                      ^^^^ immutable borrow occurs here
 LL |                          //[mir]~^ ERROR cannot borrow `u.a` as immutable because it is also borrowed as mutable
 LL |             drop(rma);
-   |                  --- borrow later used here
+   |                  --- mutable borrow later used here
 
 error[E0503]: cannot use `u.a` because it was mutably borrowed
   --> $DIR/borrowck-union-borrow.rs:79:21
@@ -73,7 +73,7 @@ LL |             let rma2 = &mut u.a; //[ast]~ ERROR cannot borrow `u.a` as muta
    |                        ^^^^^^^^ second mutable borrow occurs here
 LL |                                  //[mir]~^ ERROR cannot borrow `u.a` as mutable more than once at a time
 LL |             drop(rma);
-   |                  --- borrow later used here
+   |                  --- first borrow later used here
 
 error[E0506]: cannot assign to `u.a` because it is borrowed
   --> $DIR/borrowck-union-borrow.rs:91:13
@@ -95,7 +95,7 @@ LL |             let rb = &u.b; //[ast]~ ERROR cannot borrow `u` (via `u.b`) as 
    |                      ^^^^ immutable borrow occurs here
 LL |                            //[mir]~^ ERROR cannot borrow `u.b` as immutable because it is also borrowed as mutable
 LL |             drop(rma);
-   |                  --- borrow later used here
+   |                  --- mutable borrow later used here
 
 error[E0503]: cannot use `u.b` because it was mutably borrowed
   --> $DIR/borrowck-union-borrow.rs:104:21
@@ -117,7 +117,7 @@ LL |             let rmb2 = &mut u.b; //[ast]~ ERROR cannot borrow `u` (via `u.b
    |                        ^^^^^^^^ second mutable borrow occurs here
 LL |                                  //[mir]~^ ERROR cannot borrow `u.b` as mutable more than once at a time
 LL |             drop(rma);
-   |                  --- borrow later used here
+   |                  --- first borrow later used here
 
 error[E0506]: cannot assign to `u.b` because it is borrowed
   --> $DIR/borrowck-union-borrow.rs:117:13

--- a/src/test/ui/borrowck/borrowck-union-borrow.mir.stderr
+++ b/src/test/ui/borrowck/borrowck-union-borrow.mir.stderr
@@ -7,7 +7,7 @@ LL |             let rma = &mut u.a; //[ast]~ ERROR cannot borrow `u.a` as mutab
    |                       ^^^^^^^^ mutable borrow occurs here
 LL |                                 //[mir]~^ ERROR cannot borrow `u.a` as mutable because it is also borrowed as immutable
 LL |             drop(ra);
-   |                  -- borrow later used here
+   |                  -- immutable borrow later used here
 
 error[E0506]: cannot assign to `u.a` because it is borrowed
   --> $DIR/borrowck-union-borrow.rs:43:13
@@ -29,7 +29,7 @@ LL |             let rmb = &mut u.b; //[ast]~ ERROR cannot borrow `u` (via `u.b`
    |                       ^^^^^^^^ mutable borrow occurs here
 LL |                                 //[mir]~^ ERROR cannot borrow `u.b` as mutable because it is also borrowed as immutable
 LL |             drop(ra);
-   |                  -- borrow later used here
+   |                  -- immutable borrow later used here
 
 error[E0506]: cannot assign to `u.b` because it is borrowed
   --> $DIR/borrowck-union-borrow.rs:66:13
@@ -51,7 +51,7 @@ LL |             let ra = &u.a; //[ast]~ ERROR cannot borrow `u.a` as immutable 
    |                      ^^^^ immutable borrow occurs here
 LL |                          //[mir]~^ ERROR cannot borrow `u.a` as immutable because it is also borrowed as mutable
 LL |             drop(rma);
-   |                  --- borrow later used here
+   |                  --- mutable borrow later used here
 
 error[E0503]: cannot use `u.a` because it was mutably borrowed
   --> $DIR/borrowck-union-borrow.rs:79:21
@@ -73,7 +73,7 @@ LL |             let rma2 = &mut u.a; //[ast]~ ERROR cannot borrow `u.a` as muta
    |                        ^^^^^^^^ second mutable borrow occurs here
 LL |                                  //[mir]~^ ERROR cannot borrow `u.a` as mutable more than once at a time
 LL |             drop(rma);
-   |                  --- borrow later used here
+   |                  --- first borrow later used here
 
 error[E0506]: cannot assign to `u.a` because it is borrowed
   --> $DIR/borrowck-union-borrow.rs:91:13
@@ -95,7 +95,7 @@ LL |             let rb = &u.b; //[ast]~ ERROR cannot borrow `u` (via `u.b`) as 
    |                      ^^^^ immutable borrow occurs here
 LL |                            //[mir]~^ ERROR cannot borrow `u.b` as immutable because it is also borrowed as mutable
 LL |             drop(rma);
-   |                  --- borrow later used here
+   |                  --- mutable borrow later used here
 
 error[E0503]: cannot use `u.b` because it was mutably borrowed
   --> $DIR/borrowck-union-borrow.rs:104:21
@@ -117,7 +117,7 @@ LL |             let rmb2 = &mut u.b; //[ast]~ ERROR cannot borrow `u` (via `u.b
    |                        ^^^^^^^^ second mutable borrow occurs here
 LL |                                  //[mir]~^ ERROR cannot borrow `u.b` as mutable more than once at a time
 LL |             drop(rma);
-   |                  --- borrow later used here
+   |                  --- first borrow later used here
 
 error[E0506]: cannot assign to `u.b` because it is borrowed
   --> $DIR/borrowck-union-borrow.rs:117:13

--- a/src/test/ui/borrowck/borrowck-uniq-via-lend.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-uniq-via-lend.nll.stderr
@@ -6,7 +6,7 @@ LL |     let w = &mut v;
 LL |     borrow(&*v); //~ ERROR cannot borrow `*v`
    |            ^^^ immutable borrow occurs here
 LL |     w.use_mut();
-   |     - borrow later used here
+   |     - mutable borrow later used here
 
 error[E0502]: cannot borrow `*v` as immutable because it is also borrowed as mutable
   --> $DIR/borrowck-uniq-via-lend.rs:63:12
@@ -16,7 +16,7 @@ LL |     x = &mut v;
 LL |     borrow(&*v); //~ ERROR cannot borrow `*v`
    |            ^^^ immutable borrow occurs here
 LL |     x.use_mut();
-   |     - borrow later used here
+   |     - mutable borrow later used here
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/borrowck/borrowck-vec-pattern-loan-from-mut.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-vec-pattern-loan-from-mut.nll.stderr
@@ -5,7 +5,7 @@ LL |     let vb: &mut [isize] = &mut v;
    |                            ------ first mutable borrow occurs here
 ...
 LL |             v.push(tail[0] + tail[1]); //~ ERROR cannot borrow
-   |             ^      ------- borrow later used here
+   |             ^      ------- first borrow later used here
    |             |
    |             second mutable borrow occurs here
 

--- a/src/test/ui/borrowck/issue-51117.nll.stderr
+++ b/src/test/ui/borrowck/issue-51117.nll.stderr
@@ -6,7 +6,7 @@ LL |         Some(baz) => {
 LL |             bar.take(); //~ ERROR cannot borrow
    |             ^^^ second mutable borrow occurs here
 LL |             drop(baz);
-   |                  --- borrow later used here
+   |                  --- first borrow later used here
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/mut-borrow-in-loop.nll.stderr
+++ b/src/test/ui/borrowck/mut-borrow-in-loop.nll.stderr
@@ -4,7 +4,7 @@ error[E0499]: cannot borrow `*arg` as mutable more than once at a time
 LL |             (self.func)(arg) //~ ERROR cannot borrow
    |                         ^^^ mutable borrow starts here in previous iteration of loop
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the impl at 17:6...
+note: first borrowed value must be valid for the lifetime 'a as defined on the impl at 17:6...
   --> $DIR/mut-borrow-in-loop.rs:17:6
    |
 LL | impl<'a, T : 'a> FuncWrapper<'a, T> {
@@ -16,7 +16,7 @@ error[E0499]: cannot borrow `*arg` as mutable more than once at a time
 LL |             (self.func)(arg) //~ ERROR cannot borrow
    |                         ^^^ mutable borrow starts here in previous iteration of loop
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the impl at 17:6...
+note: first borrowed value must be valid for the lifetime 'a as defined on the impl at 17:6...
   --> $DIR/mut-borrow-in-loop.rs:17:6
    |
 LL | impl<'a, T : 'a> FuncWrapper<'a, T> {
@@ -28,7 +28,7 @@ error[E0499]: cannot borrow `*arg` as mutable more than once at a time
 LL |             (self.func)(arg) //~ ERROR cannot borrow
    |                         ^^^ mutable borrow starts here in previous iteration of loop
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the impl at 17:6...
+note: first borrowed value must be valid for the lifetime 'a as defined on the impl at 17:6...
   --> $DIR/mut-borrow-in-loop.rs:17:6
    |
 LL | impl<'a, T : 'a> FuncWrapper<'a, T> {

--- a/src/test/ui/borrowck/mut-borrow-outside-loop.nll.stderr
+++ b/src/test/ui/borrowck/mut-borrow-outside-loop.nll.stderr
@@ -6,7 +6,7 @@ LL |     let first = &mut void;
 LL |     let second = &mut void; //~ ERROR cannot borrow
    |                  ^^^^^^^^^ second mutable borrow occurs here
 LL |     first.use_mut();
-   |     ----- borrow later used here
+   |     ----- first borrow later used here
 
 error[E0499]: cannot borrow `inner_void` as mutable more than once at a time
   --> $DIR/mut-borrow-outside-loop.rs:25:28
@@ -17,7 +17,7 @@ LL |         let inner_second = &mut inner_void; //~ ERROR cannot borrow
    |                            ^^^^^^^^^^^^^^^ second mutable borrow occurs here
 LL |         inner_second.use_mut();
 LL |         inner_first.use_mut();
-   |         ----------- borrow used here, in later iteration of loop
+   |         ----------- first borrow used here, in later iteration of loop
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/borrowck/two-phase-activation-sharing-interference.nll_target.stderr
+++ b/src/test/ui/borrowck/two-phase-activation-sharing-interference.nll_target.stderr
@@ -7,7 +7,7 @@ LL |     { let z = &x; read(z); }
    |               ^^ immutable borrow occurs here
 LL |     //[nll_target]~^ ERROR cannot borrow `x` as immutable because it is also borrowed as mutable
 LL |     *y += 1;
-   |     ------- borrow later used here
+   |     ------- mutable borrow later used here
 
 error[E0502]: cannot borrow `x` as immutable because it is also borrowed as mutable
   --> $DIR/two-phase-activation-sharing-interference.rs:50:13
@@ -18,7 +18,7 @@ LL |     let z = &x;
    |             ^^ immutable borrow occurs here
 LL |     //[nll_target]~^ ERROR cannot borrow `x` as immutable because it is also borrowed as mutable
 LL |     *y += 1;
-   |     ------- borrow later used here
+   |     ------- mutable borrow later used here
 
 error[E0502]: cannot borrow `x` as immutable because it is also borrowed as mutable
   --> $DIR/two-phase-activation-sharing-interference.rs:61:13
@@ -29,7 +29,7 @@ LL |     let z = &x;
    |             ^^ immutable borrow occurs here
 ...
 LL |     *y += 1;
-   |     ------- borrow later used here
+   |     ------- mutable borrow later used here
 
 error[E0502]: cannot borrow `x` as immutable because it is also borrowed as mutable
   --> $DIR/two-phase-activation-sharing-interference.rs:72:14
@@ -40,7 +40,7 @@ LL |     let _z = &x;
    |              ^^ immutable borrow occurs here
 LL |     //[nll_target]~^ ERROR cannot borrow `x` as immutable because it is also borrowed as mutable
 LL |     *y += 1;
-   |     ------- borrow later used here
+   |     ------- mutable borrow later used here
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/borrowck/two-phase-cannot-nest-mut-self-calls.stderr
+++ b/src/test/ui/borrowck/two-phase-cannot-nest-mut-self-calls.stderr
@@ -1,19 +1,13 @@
 error[E0502]: cannot borrow `vec` as mutable because it is also borrowed as immutable
   --> $DIR/two-phase-cannot-nest-mut-self-calls.rs:26:9
    |
-LL |       vec.get({
-   |       ---
-   |       |
-   |  _____immutable borrow occurs here
-   | |
-LL | |
-LL | |         vec.push(2);
-   | |         ^^^^^^^^^^^ mutable borrow occurs here
-LL | |         //~^ ERROR cannot borrow `vec` as mutable because it is also borrowed as immutable
-LL | |
-LL | |         0
-LL | |     });
-   | |______- borrow later used here
+LL |     vec.get({
+   |     --- --- immutable borrow later used by call
+   |     |
+   |     immutable borrow occurs here
+LL | 
+LL |         vec.push(2);
+   |         ^^^^^^^^^^^ mutable borrow occurs here
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/two-phase-multi-mut.stderr
+++ b/src/test/ui/borrowck/two-phase-multi-mut.stderr
@@ -2,21 +2,20 @@ error[E0499]: cannot borrow `foo` as mutable more than once at a time
   --> $DIR/two-phase-multi-mut.rs:23:5
    |
 LL |     foo.method(&mut foo);
-   |     ^^^^^^^^^^^--------^
-   |     |          |
-   |     |          first mutable borrow occurs here
+   |     ^^^^------^--------^
+   |     |   |      |
+   |     |   |      first mutable borrow occurs here
+   |     |   first borrow later used by call
    |     second mutable borrow occurs here
-   |     borrow later used here
 
 error[E0499]: cannot borrow `foo` as mutable more than once at a time
   --> $DIR/two-phase-multi-mut.rs:23:16
    |
 LL |     foo.method(&mut foo);
-   |     -----------^^^^^^^^-
-   |     |          |
-   |     |          second mutable borrow occurs here
+   |     --- ------ ^^^^^^^^ second mutable borrow occurs here
+   |     |   |
+   |     |   first borrow later used by call
    |     first mutable borrow occurs here
-   |     borrow later used here
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/borrowck/two-phase-nonrecv-autoref.ast.nll.stderr
+++ b/src/test/ui/borrowck/two-phase-nonrecv-autoref.ast.nll.stderr
@@ -2,11 +2,10 @@ error[E0499]: cannot borrow `*f` as mutable more than once at a time
   --> $DIR/two-phase-nonrecv-autoref.rs:70:11
    |
 LL |         f(f(10));
-   |         --^-----
-   |         | |
-   |         | second mutable borrow occurs here
+   |         - ^ second mutable borrow occurs here
+   |         |
    |         first mutable borrow occurs here
-   |         borrow later used here
+   |         first borrow later used by call
 
 error[E0382]: use of moved value: `*f`
   --> $DIR/two-phase-nonrecv-autoref.rs:79:11
@@ -20,11 +19,10 @@ error[E0499]: cannot borrow `*f` as mutable more than once at a time
   --> $DIR/two-phase-nonrecv-autoref.rs:86:11
    |
 LL |         f(f(10));
-   |         --^-----
-   |         | |
-   |         | second mutable borrow occurs here
+   |         - ^ second mutable borrow occurs here
+   |         |
    |         first mutable borrow occurs here
-   |         borrow later used here
+   |         first borrow later used by call
 
 error[E0161]: cannot move a value of type dyn std::ops::FnOnce(i32) -> i32: the size of dyn std::ops::FnOnce(i32) -> i32 cannot be statically determined
   --> $DIR/two-phase-nonrecv-autoref.rs:95:9
@@ -50,11 +48,10 @@ error[E0502]: cannot borrow `a` as immutable because it is also borrowed as muta
   --> $DIR/two-phase-nonrecv-autoref.rs:139:27
    |
 LL |     double_access(&mut a, &a);
-   |     ----------------------^^-
-   |     |             |       |
-   |     |             |       immutable borrow occurs here
+   |     ------------- ------  ^^ immutable borrow occurs here
+   |     |             |
    |     |             mutable borrow occurs here
-   |     borrow later used here
+   |     mutable borrow later used by call
 
 error[E0502]: cannot borrow `i` as immutable because it is also borrowed as mutable
   --> $DIR/two-phase-nonrecv-autoref.rs:167:7
@@ -64,7 +61,7 @@ LL |     i[i[3]] = 4;
    |     | |
    |     | immutable borrow occurs here
    |     mutable borrow occurs here
-   |     borrow later used here
+   |     mutable borrow later used here
 
 error[E0502]: cannot borrow `i` as immutable because it is also borrowed as mutable
   --> $DIR/two-phase-nonrecv-autoref.rs:173:7
@@ -74,7 +71,7 @@ LL |     i[i[3]] = i[4];
    |     | |
    |     | immutable borrow occurs here
    |     mutable borrow occurs here
-   |     borrow later used here
+   |     mutable borrow later used here
 
 error: aborting due to 9 previous errors
 

--- a/src/test/ui/borrowck/two-phase-nonrecv-autoref.nll.stderr
+++ b/src/test/ui/borrowck/two-phase-nonrecv-autoref.nll.stderr
@@ -2,11 +2,10 @@ error[E0499]: cannot borrow `*f` as mutable more than once at a time
   --> $DIR/two-phase-nonrecv-autoref.rs:70:11
    |
 LL |         f(f(10));
-   |         --^-----
-   |         | |
-   |         | second mutable borrow occurs here
+   |         - ^ second mutable borrow occurs here
+   |         |
    |         first mutable borrow occurs here
-   |         borrow later used here
+   |         first borrow later used by call
 
 error[E0382]: use of moved value: `*f`
   --> $DIR/two-phase-nonrecv-autoref.rs:79:11
@@ -20,11 +19,10 @@ error[E0499]: cannot borrow `*f` as mutable more than once at a time
   --> $DIR/two-phase-nonrecv-autoref.rs:86:11
    |
 LL |         f(f(10));
-   |         --^-----
-   |         | |
-   |         | second mutable borrow occurs here
+   |         - ^ second mutable borrow occurs here
+   |         |
    |         first mutable borrow occurs here
-   |         borrow later used here
+   |         first borrow later used by call
 
 error[E0161]: cannot move a value of type dyn std::ops::FnOnce(i32) -> i32: the size of dyn std::ops::FnOnce(i32) -> i32 cannot be statically determined
   --> $DIR/two-phase-nonrecv-autoref.rs:95:9
@@ -50,11 +48,10 @@ error[E0502]: cannot borrow `a` as immutable because it is also borrowed as muta
   --> $DIR/two-phase-nonrecv-autoref.rs:139:27
    |
 LL |     double_access(&mut a, &a);
-   |     ----------------------^^-
-   |     |             |       |
-   |     |             |       immutable borrow occurs here
+   |     ------------- ------  ^^ immutable borrow occurs here
+   |     |             |
    |     |             mutable borrow occurs here
-   |     borrow later used here
+   |     mutable borrow later used by call
 
 error[E0502]: cannot borrow `i` as immutable because it is also borrowed as mutable
   --> $DIR/two-phase-nonrecv-autoref.rs:167:7
@@ -64,7 +61,7 @@ LL |     i[i[3]] = 4;
    |     | |
    |     | immutable borrow occurs here
    |     mutable borrow occurs here
-   |     borrow later used here
+   |     mutable borrow later used here
 
 error[E0502]: cannot borrow `i` as immutable because it is also borrowed as mutable
   --> $DIR/two-phase-nonrecv-autoref.rs:173:7
@@ -74,7 +71,7 @@ LL |     i[i[3]] = i[4];
    |     | |
    |     | immutable borrow occurs here
    |     mutable borrow occurs here
-   |     borrow later used here
+   |     mutable borrow later used here
 
 error: aborting due to 9 previous errors
 

--- a/src/test/ui/borrowck/two-phase-reservation-sharing-interference.nll_target.stderr
+++ b/src/test/ui/borrowck/two-phase-reservation-sharing-interference.nll_target.stderr
@@ -8,7 +8,7 @@ LL |         delay = &mut vec;
    |                 ^^^^^^^^ mutable borrow occurs here
 ...
 LL |         shared[0];
-   |         ------ borrow later used here
+   |         ------ immutable borrow later used here
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/two-phase-sneaky.nll.stderr
+++ b/src/test/ui/borrowck/two-phase-sneaky.nll.stderr
@@ -1,19 +1,13 @@
 error[E0499]: cannot borrow `v` as mutable more than once at a time
   --> $DIR/two-phase-sneaky.rs:22:9
    |
-LL |       v[0].push_str({
-   |       -
-   |       |
-   |  _____first mutable borrow occurs here
-   | |
-LL | |
-LL | |         v.push(format!("foo"));
-   | |         ^ second mutable borrow occurs here
-LL | |         //~^   ERROR cannot borrow `v` as mutable more than once at a time [E0499]
-LL | |
-LL | |         "World!"
-LL | |     });
-   | |______- borrow later used here
+LL |     v[0].push_str({
+   |     -    -------- first borrow later used by call
+   |     |
+   |     first mutable borrow occurs here
+LL | 
+LL |         v.push(format!("foo"));
+   |         ^ second mutable borrow occurs here
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/two-phase-surprise-no-conflict.nll.stderr
+++ b/src/test/ui/borrowck/two-phase-surprise-no-conflict.nll.stderr
@@ -13,61 +13,57 @@ error[E0502]: cannot borrow `*self` as mutable because it is also borrowed as im
   --> $DIR/two-phase-surprise-no-conflict.rs:79:17
    |
 LL |                 self.hash_expr(&self.cx_mut.body(eid).value);
-   |                 ^^^^^^^^^^^^^^^^-----------^^^^^^^^^^^^^^^^^
-   |                 |               |
-   |                 |               immutable borrow occurs here
+   |                 ^^^^^---------^^-----------^^^^^^^^^^^^^^^^^
+   |                 |    |          |
+   |                 |    |          immutable borrow occurs here
+   |                 |    immutable borrow later used by call
    |                 mutable borrow occurs here
-   |                 borrow later used here
 
 error[E0499]: cannot borrow `reg.sess_mut` as mutable more than once at a time
   --> $DIR/two-phase-surprise-no-conflict.rs:151:51
    |
 LL |     reg.register_static(Box::new(TrivialPass::new(&mut reg.sess_mut)));
-   |     ----------------------------------------------^^^^^^^^^^^^^^^^^---
-   |     |                                             |
-   |     |                                             second mutable borrow occurs here
+   |     --- ---------------                           ^^^^^^^^^^^^^^^^^ second mutable borrow occurs here
+   |     |   |
+   |     |   first borrow later used by call
    |     first mutable borrow occurs here
-   |     borrow later used here
 
 error[E0499]: cannot borrow `reg.sess_mut` as mutable more than once at a time
   --> $DIR/two-phase-surprise-no-conflict.rs:156:54
    |
 LL |     reg.register_bound(Box::new(TrivialPass::new_mut(&mut reg.sess_mut)));
-   |     -------------------------------------------------^^^^^^^^^^^^^^^^^---
-   |     |                                                |
-   |     |                                                second mutable borrow occurs here
+   |     --- --------------                               ^^^^^^^^^^^^^^^^^ second mutable borrow occurs here
+   |     |   |
+   |     |   first borrow later used by call
    |     first mutable borrow occurs here
-   |     borrow later used here
 
 error[E0499]: cannot borrow `reg.sess_mut` as mutable more than once at a time
   --> $DIR/two-phase-surprise-no-conflict.rs:161:53
    |
 LL |     reg.register_univ(Box::new(TrivialPass::new_mut(&mut reg.sess_mut)));
-   |     ------------------------------------------------^^^^^^^^^^^^^^^^^---
-   |     |                                               |
-   |     |                                               second mutable borrow occurs here
+   |     --- -------------                               ^^^^^^^^^^^^^^^^^ second mutable borrow occurs here
+   |     |   |
+   |     |   first borrow later used by call
    |     first mutable borrow occurs here
-   |     borrow later used here
 
 error[E0499]: cannot borrow `reg.sess_mut` as mutable more than once at a time
   --> $DIR/two-phase-surprise-no-conflict.rs:166:44
    |
 LL |     reg.register_ref(&TrivialPass::new_mut(&mut reg.sess_mut));
-   |     ---------------------------------------^^^^^^^^^^^^^^^^^--
-   |     |                                      |
-   |     |                                      second mutable borrow occurs here
+   |     --- ------------                       ^^^^^^^^^^^^^^^^^ second mutable borrow occurs here
+   |     |   |
+   |     |   first borrow later used by call
    |     first mutable borrow occurs here
-   |     borrow later used here
 
 error[E0502]: cannot borrow `*reg` as mutable because it is also borrowed as immutable
   --> $DIR/two-phase-surprise-no-conflict.rs:178:5
    |
 LL |     reg.register_bound(Box::new(CapturePass::new(&reg.sess_mut)));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------------^^^
-   |     |                                            |
-   |     |                                            immutable borrow occurs here
+   |     ^^^^--------------^^^^^^^^^^^^^^^^^^^^^^^^^^^-------------^^^
+   |     |   |                                        |
+   |     |   |                                        immutable borrow occurs here
+   |     |   immutable borrow later used by call
    |     mutable borrow occurs here
-   |     borrow later used here
 
 error[E0502]: cannot borrow `*reg` as mutable because it is also borrowed as immutable
   --> $DIR/two-phase-surprise-no-conflict.rs:183:5
@@ -78,7 +74,7 @@ LL |     reg.register_univ(Box::new(CapturePass::new(&reg.sess_mut)));
    |     |                                           immutable borrow occurs here
    |     mutable borrow occurs here
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 122:21...
+note: immutable borrowed value must be valid for the lifetime 'a as defined on the function body at 122:21...
   --> $DIR/two-phase-surprise-no-conflict.rs:122:21
    |
 LL | fn register_plugins<'a>(mk_reg: impl Fn() -> &'a mut Registry<'a>) {
@@ -88,31 +84,30 @@ error[E0502]: cannot borrow `*reg` as mutable because it is also borrowed as imm
   --> $DIR/two-phase-surprise-no-conflict.rs:188:5
    |
 LL |     reg.register_ref(&CapturePass::new(&reg.sess_mut));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------------^^
-   |     |                                  |
-   |     |                                  immutable borrow occurs here
+   |     ^^^^------------^^^^^^^^^^^^^^^^^^^-------------^^
+   |     |   |                              |
+   |     |   |                              immutable borrow occurs here
+   |     |   immutable borrow later used by call
    |     mutable borrow occurs here
-   |     borrow later used here
 
 error[E0499]: cannot borrow `*reg` as mutable more than once at a time
   --> $DIR/two-phase-surprise-no-conflict.rs:200:5
    |
 LL |     reg.register_bound(Box::new(CapturePass::new_mut(&mut reg.sess_mut)));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------------^^^
-   |     |                                                |
-   |     |                                                first mutable borrow occurs here
+   |     ^^^^--------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------------^^^
+   |     |   |                                            |
+   |     |   |                                            first mutable borrow occurs here
+   |     |   first borrow later used by call
    |     second mutable borrow occurs here
-   |     borrow later used here
 
 error[E0499]: cannot borrow `reg.sess_mut` as mutable more than once at a time
   --> $DIR/two-phase-surprise-no-conflict.rs:200:54
    |
 LL |     reg.register_bound(Box::new(CapturePass::new_mut(&mut reg.sess_mut)));
-   |     -------------------------------------------------^^^^^^^^^^^^^^^^^---
-   |     |                                                |
-   |     |                                                second mutable borrow occurs here
+   |     --- --------------                               ^^^^^^^^^^^^^^^^^ second mutable borrow occurs here
+   |     |   |
+   |     |   first borrow later used by call
    |     first mutable borrow occurs here
-   |     borrow later used here
 
 error[E0499]: cannot borrow `*reg` as mutable more than once at a time
   --> $DIR/two-phase-surprise-no-conflict.rs:206:5
@@ -123,7 +118,7 @@ LL |     reg.register_univ(Box::new(CapturePass::new_mut(&mut reg.sess_mut)));
    |     |                                               first mutable borrow occurs here
    |     second mutable borrow occurs here
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 122:21...
+note: first borrowed value must be valid for the lifetime 'a as defined on the function body at 122:21...
   --> $DIR/two-phase-surprise-no-conflict.rs:122:21
    |
 LL | fn register_plugins<'a>(mk_reg: impl Fn() -> &'a mut Registry<'a>) {
@@ -133,31 +128,29 @@ error[E0499]: cannot borrow `reg.sess_mut` as mutable more than once at a time
   --> $DIR/two-phase-surprise-no-conflict.rs:206:53
    |
 LL |     reg.register_univ(Box::new(CapturePass::new_mut(&mut reg.sess_mut)));
-   |     ------------------------------------------------^^^^^^^^^^^^^^^^^---
-   |     |                                               |
-   |     |                                               second mutable borrow occurs here
+   |     --- -------------                               ^^^^^^^^^^^^^^^^^ second mutable borrow occurs here
+   |     |   |
+   |     |   first borrow later used by call
    |     first mutable borrow occurs here
-   |     borrow later used here
 
 error[E0499]: cannot borrow `*reg` as mutable more than once at a time
   --> $DIR/two-phase-surprise-no-conflict.rs:212:5
    |
 LL |     reg.register_ref(&CapturePass::new_mut(&mut reg.sess_mut));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------------^^
-   |     |                                      |
-   |     |                                      first mutable borrow occurs here
+   |     ^^^^------------^^^^^^^^^^^^^^^^^^^^^^^-----------------^^
+   |     |   |                                  |
+   |     |   |                                  first mutable borrow occurs here
+   |     |   first borrow later used by call
    |     second mutable borrow occurs here
-   |     borrow later used here
 
 error[E0499]: cannot borrow `reg.sess_mut` as mutable more than once at a time
   --> $DIR/two-phase-surprise-no-conflict.rs:212:44
    |
 LL |     reg.register_ref(&CapturePass::new_mut(&mut reg.sess_mut));
-   |     ---------------------------------------^^^^^^^^^^^^^^^^^--
-   |     |                                      |
-   |     |                                      second mutable borrow occurs here
+   |     --- ------------                       ^^^^^^^^^^^^^^^^^ second mutable borrow occurs here
+   |     |   |
+   |     |   first borrow later used by call
    |     first mutable borrow occurs here
-   |     borrow later used here
 
 error: aborting due to 15 previous errors
 

--- a/src/test/ui/borrowck/two-phase-surprise-no-conflict.no2pb.stderr
+++ b/src/test/ui/borrowck/two-phase-surprise-no-conflict.no2pb.stderr
@@ -13,161 +13,145 @@ error[E0502]: cannot borrow `*self.cx` as immutable because it is also borrowed 
   --> $DIR/two-phase-surprise-no-conflict.rs:64:33
    |
 LL |                 self.hash_expr(&self.cx.body(eid).value);
-   |                 ----------------^^^^^^^-----------------
-   |                 |               |
-   |                 |               immutable borrow occurs here
+   |                 ---- ---------  ^^^^^^^ immutable borrow occurs here
+   |                 |    |
+   |                 |    mutable borrow later used by call
    |                 mutable borrow occurs here
-   |                 borrow later used here
 
 error[E0502]: cannot borrow `*self.cx_mut` as immutable because it is also borrowed as mutable
   --> $DIR/two-phase-surprise-no-conflict.rs:79:33
    |
 LL |                 self.hash_expr(&self.cx_mut.body(eid).value);
-   |                 ----------------^^^^^^^^^^^-----------------
-   |                 |               |
-   |                 |               immutable borrow occurs here
+   |                 ---- ---------  ^^^^^^^^^^^ immutable borrow occurs here
+   |                 |    |
+   |                 |    mutable borrow later used by call
    |                 mutable borrow occurs here
-   |                 borrow later used here
 
 error[E0502]: cannot borrow `reg.sess_mut` as immutable because it is also borrowed as mutable
   --> $DIR/two-phase-surprise-no-conflict.rs:131:51
    |
 LL |     reg.register_static(Box::new(TrivialPass::new(&reg.sess_mut)));
-   |     ----------------------------------------------^^^^^^^^^^^^^---
-   |     |                                             |
-   |     |                                             immutable borrow occurs here
+   |     --- ---------------                           ^^^^^^^^^^^^^ immutable borrow occurs here
+   |     |   |
+   |     |   mutable borrow later used by call
    |     mutable borrow occurs here
-   |     borrow later used here
 
 error[E0502]: cannot borrow `reg.sess_mut` as immutable because it is also borrowed as mutable
   --> $DIR/two-phase-surprise-no-conflict.rs:135:50
    |
 LL |     reg.register_bound(Box::new(TrivialPass::new(&reg.sess_mut)));
-   |     ---------------------------------------------^^^^^^^^^^^^^---
-   |     |                                            |
-   |     |                                            immutable borrow occurs here
+   |     --- --------------                           ^^^^^^^^^^^^^ immutable borrow occurs here
+   |     |   |
+   |     |   mutable borrow later used by call
    |     mutable borrow occurs here
-   |     borrow later used here
 
 error[E0502]: cannot borrow `reg.sess_mut` as immutable because it is also borrowed as mutable
   --> $DIR/two-phase-surprise-no-conflict.rs:139:49
    |
 LL |     reg.register_univ(Box::new(TrivialPass::new(&reg.sess_mut)));
-   |     --------------------------------------------^^^^^^^^^^^^^---
-   |     |                                           |
-   |     |                                           immutable borrow occurs here
+   |     --- -------------                           ^^^^^^^^^^^^^ immutable borrow occurs here
+   |     |   |
+   |     |   mutable borrow later used by call
    |     mutable borrow occurs here
-   |     borrow later used here
 
 error[E0502]: cannot borrow `reg.sess_mut` as immutable because it is also borrowed as mutable
   --> $DIR/two-phase-surprise-no-conflict.rs:143:40
    |
 LL |     reg.register_ref(&TrivialPass::new(&reg.sess_mut));
-   |     -----------------------------------^^^^^^^^^^^^^--
-   |     |                                  |
-   |     |                                  immutable borrow occurs here
+   |     --- ------------                   ^^^^^^^^^^^^^ immutable borrow occurs here
+   |     |   |
+   |     |   mutable borrow later used by call
    |     mutable borrow occurs here
-   |     borrow later used here
 
 error[E0499]: cannot borrow `reg.sess_mut` as mutable more than once at a time
   --> $DIR/two-phase-surprise-no-conflict.rs:151:51
    |
 LL |     reg.register_static(Box::new(TrivialPass::new(&mut reg.sess_mut)));
-   |     ----------------------------------------------^^^^^^^^^^^^^^^^^---
-   |     |                                             |
-   |     |                                             second mutable borrow occurs here
+   |     --- ---------------                           ^^^^^^^^^^^^^^^^^ second mutable borrow occurs here
+   |     |   |
+   |     |   first borrow later used by call
    |     first mutable borrow occurs here
-   |     borrow later used here
 
 error[E0499]: cannot borrow `reg.sess_mut` as mutable more than once at a time
   --> $DIR/two-phase-surprise-no-conflict.rs:156:54
    |
 LL |     reg.register_bound(Box::new(TrivialPass::new_mut(&mut reg.sess_mut)));
-   |     -------------------------------------------------^^^^^^^^^^^^^^^^^---
-   |     |                                                |
-   |     |                                                second mutable borrow occurs here
+   |     --- --------------                               ^^^^^^^^^^^^^^^^^ second mutable borrow occurs here
+   |     |   |
+   |     |   first borrow later used by call
    |     first mutable borrow occurs here
-   |     borrow later used here
 
 error[E0499]: cannot borrow `reg.sess_mut` as mutable more than once at a time
   --> $DIR/two-phase-surprise-no-conflict.rs:161:53
    |
 LL |     reg.register_univ(Box::new(TrivialPass::new_mut(&mut reg.sess_mut)));
-   |     ------------------------------------------------^^^^^^^^^^^^^^^^^---
-   |     |                                               |
-   |     |                                               second mutable borrow occurs here
+   |     --- -------------                               ^^^^^^^^^^^^^^^^^ second mutable borrow occurs here
+   |     |   |
+   |     |   first borrow later used by call
    |     first mutable borrow occurs here
-   |     borrow later used here
 
 error[E0499]: cannot borrow `reg.sess_mut` as mutable more than once at a time
   --> $DIR/two-phase-surprise-no-conflict.rs:166:44
    |
 LL |     reg.register_ref(&TrivialPass::new_mut(&mut reg.sess_mut));
-   |     ---------------------------------------^^^^^^^^^^^^^^^^^--
-   |     |                                      |
-   |     |                                      second mutable borrow occurs here
+   |     --- ------------                       ^^^^^^^^^^^^^^^^^ second mutable borrow occurs here
+   |     |   |
+   |     |   first borrow later used by call
    |     first mutable borrow occurs here
-   |     borrow later used here
 
 error[E0502]: cannot borrow `reg.sess_mut` as immutable because it is also borrowed as mutable
   --> $DIR/two-phase-surprise-no-conflict.rs:178:50
    |
 LL |     reg.register_bound(Box::new(CapturePass::new(&reg.sess_mut)));
-   |     ---------------------------------------------^^^^^^^^^^^^^---
-   |     |                                            |
-   |     |                                            immutable borrow occurs here
+   |     --- --------------                           ^^^^^^^^^^^^^ immutable borrow occurs here
+   |     |   |
+   |     |   mutable borrow later used by call
    |     mutable borrow occurs here
-   |     borrow later used here
 
 error[E0502]: cannot borrow `reg.sess_mut` as immutable because it is also borrowed as mutable
   --> $DIR/two-phase-surprise-no-conflict.rs:183:49
    |
 LL |     reg.register_univ(Box::new(CapturePass::new(&reg.sess_mut)));
-   |     --------------------------------------------^^^^^^^^^^^^^---
-   |     |                                           |
-   |     |                                           immutable borrow occurs here
+   |     --- -------------                           ^^^^^^^^^^^^^ immutable borrow occurs here
+   |     |   |
+   |     |   mutable borrow later used by call
    |     mutable borrow occurs here
-   |     borrow later used here
 
 error[E0502]: cannot borrow `reg.sess_mut` as immutable because it is also borrowed as mutable
   --> $DIR/two-phase-surprise-no-conflict.rs:188:40
    |
 LL |     reg.register_ref(&CapturePass::new(&reg.sess_mut));
-   |     -----------------------------------^^^^^^^^^^^^^--
-   |     |                                  |
-   |     |                                  immutable borrow occurs here
+   |     --- ------------                   ^^^^^^^^^^^^^ immutable borrow occurs here
+   |     |   |
+   |     |   mutable borrow later used by call
    |     mutable borrow occurs here
-   |     borrow later used here
 
 error[E0499]: cannot borrow `reg.sess_mut` as mutable more than once at a time
   --> $DIR/two-phase-surprise-no-conflict.rs:200:54
    |
 LL |     reg.register_bound(Box::new(CapturePass::new_mut(&mut reg.sess_mut)));
-   |     -------------------------------------------------^^^^^^^^^^^^^^^^^---
-   |     |                                                |
-   |     |                                                second mutable borrow occurs here
+   |     --- --------------                               ^^^^^^^^^^^^^^^^^ second mutable borrow occurs here
+   |     |   |
+   |     |   first borrow later used by call
    |     first mutable borrow occurs here
-   |     borrow later used here
 
 error[E0499]: cannot borrow `reg.sess_mut` as mutable more than once at a time
   --> $DIR/two-phase-surprise-no-conflict.rs:206:53
    |
 LL |     reg.register_univ(Box::new(CapturePass::new_mut(&mut reg.sess_mut)));
-   |     ------------------------------------------------^^^^^^^^^^^^^^^^^---
-   |     |                                               |
-   |     |                                               second mutable borrow occurs here
+   |     --- -------------                               ^^^^^^^^^^^^^^^^^ second mutable borrow occurs here
+   |     |   |
+   |     |   first borrow later used by call
    |     first mutable borrow occurs here
-   |     borrow later used here
 
 error[E0499]: cannot borrow `reg.sess_mut` as mutable more than once at a time
   --> $DIR/two-phase-surprise-no-conflict.rs:212:44
    |
 LL |     reg.register_ref(&CapturePass::new_mut(&mut reg.sess_mut));
-   |     ---------------------------------------^^^^^^^^^^^^^^^^^--
-   |     |                                      |
-   |     |                                      second mutable borrow occurs here
+   |     --- ------------                       ^^^^^^^^^^^^^^^^^ second mutable borrow occurs here
+   |     |   |
+   |     |   first borrow later used by call
    |     first mutable borrow occurs here
-   |     borrow later used here
 
 error: aborting due to 17 previous errors
 

--- a/src/test/ui/codemap_tests/issue-11715.nll.stderr
+++ b/src/test/ui/codemap_tests/issue-11715.nll.stderr
@@ -7,7 +7,7 @@ LL |     let z = &mut x; //~ ERROR cannot borrow
    |             ^^^^^^ second mutable borrow occurs here
 LL |     z.use_mut();
 LL |     y.use_mut();
-   |     - borrow later used here
+   |     - first borrow later used here
 
 error: aborting due to previous error
 

--- a/src/test/ui/codemap_tests/one_line.nll.stderr
+++ b/src/test/ui/codemap_tests/one_line.nll.stderr
@@ -2,11 +2,10 @@ error[E0499]: cannot borrow `v` as mutable more than once at a time
   --> $DIR/one_line.rs:13:12
    |
 LL |     v.push(v.pop().unwrap()); //~ ERROR cannot borrow
-   |     -------^----------------
-   |     |      |
-   |     |      second mutable borrow occurs here
+   |     - ---- ^ second mutable borrow occurs here
+   |     | |
+   |     | first borrow later used by call
    |     first mutable borrow occurs here
-   |     borrow later used here
 
 error: aborting due to previous error
 

--- a/src/test/ui/coercion/coerce-overloaded-autoderef.ast.nll.stderr
+++ b/src/test/ui/coercion/coerce-overloaded-autoderef.ast.nll.stderr
@@ -7,7 +7,7 @@ LL |     let z = borrow_mut(x);
    |                        ^ second mutable borrow occurs here
 ...
 LL |     drop((y, z));
-   |           - borrow later used here
+   |           - first borrow later used here
 
 error[E0506]: cannot assign to `**x` because it is borrowed
   --> $DIR/coerce-overloaded-autoderef.rs:31:5
@@ -25,21 +25,20 @@ error[E0499]: cannot borrow `*x` as mutable more than once at a time
   --> $DIR/coerce-overloaded-autoderef.rs:38:20
    |
 LL |     borrow_mut2(x, x);
-   |     ---------------^-
-   |     |           |  |
-   |     |           |  second mutable borrow occurs here
+   |     ----------- -  ^ second mutable borrow occurs here
+   |     |           |
    |     |           first mutable borrow occurs here
-   |     borrow later used here
+   |     first borrow later used by call
 
 error[E0502]: cannot borrow `*x` as mutable because it is also borrowed as immutable
   --> $DIR/coerce-overloaded-autoderef.rs:44:5
    |
 LL |     borrow2(x, x);
-   |     ^^^^^^^^^^^-^
+   |     -------^^^^-^
    |     |          |
    |     |          immutable borrow occurs here
    |     mutable borrow occurs here
-   |     borrow later used here
+   |     immutable borrow later used by call
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/coercion/coerce-overloaded-autoderef.mir.nll.stderr
+++ b/src/test/ui/coercion/coerce-overloaded-autoderef.mir.nll.stderr
@@ -7,7 +7,7 @@ LL |     let z = borrow_mut(x);
    |                        ^ second mutable borrow occurs here
 ...
 LL |     drop((y, z));
-   |           - borrow later used here
+   |           - first borrow later used here
 
 error[E0506]: cannot assign to `**x` because it is borrowed
   --> $DIR/coerce-overloaded-autoderef.rs:31:5
@@ -25,21 +25,20 @@ error[E0499]: cannot borrow `*x` as mutable more than once at a time
   --> $DIR/coerce-overloaded-autoderef.rs:38:20
    |
 LL |     borrow_mut2(x, x);
-   |     ---------------^-
-   |     |           |  |
-   |     |           |  second mutable borrow occurs here
+   |     ----------- -  ^ second mutable borrow occurs here
+   |     |           |
    |     |           first mutable borrow occurs here
-   |     borrow later used here
+   |     first borrow later used by call
 
 error[E0502]: cannot borrow `*x` as mutable because it is also borrowed as immutable
   --> $DIR/coerce-overloaded-autoderef.rs:44:5
    |
 LL |     borrow2(x, x);
-   |     ^^^^^^^^^^^-^
+   |     -------^^^^-^
    |     |          |
    |     |          immutable borrow occurs here
    |     mutable borrow occurs here
-   |     borrow later used here
+   |     immutable borrow later used by call
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/coercion/coerce-overloaded-autoderef.mir.stderr
+++ b/src/test/ui/coercion/coerce-overloaded-autoderef.mir.stderr
@@ -7,7 +7,7 @@ LL |     let z = borrow_mut(x);
    |                        ^ second mutable borrow occurs here
 ...
 LL |     drop((y, z));
-   |           - borrow later used here
+   |           - first borrow later used here
 
 error[E0506]: cannot assign to `**x` because it is borrowed
   --> $DIR/coerce-overloaded-autoderef.rs:31:5
@@ -25,21 +25,19 @@ error[E0499]: cannot borrow `*x` as mutable more than once at a time
   --> $DIR/coerce-overloaded-autoderef.rs:38:20
    |
 LL |     borrow_mut2(x, x);
-   |     ---------------^-
-   |     |           |  |
-   |     |           |  second mutable borrow occurs here
+   |     ----------- -  ^ second mutable borrow occurs here
+   |     |           |
    |     |           first mutable borrow occurs here
-   |     borrow later used here
+   |     first borrow later used by call
 
 error[E0502]: cannot borrow `*x` as immutable because it is also borrowed as mutable
   --> $DIR/coerce-overloaded-autoderef.rs:44:16
    |
 LL |     borrow2(x, x);
-   |     -----------^-
-   |     |       |  |
-   |     |       |  immutable borrow occurs here
+   |     ------- -  ^ immutable borrow occurs here
+   |     |       |
    |     |       mutable borrow occurs here
-   |     borrow later used here
+   |     mutable borrow later used by call
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/did_you_mean/issue-34126.nll.stderr
+++ b/src/test/ui/did_you_mean/issue-34126.nll.stderr
@@ -11,11 +11,10 @@ error[E0502]: cannot borrow `self` as mutable because it is also borrowed as imm
   --> $DIR/issue-34126.rs:16:18
    |
 LL |         self.run(&mut self); //~ ERROR cannot borrow
-   |         ---------^^^^^^^^^-
-   |         |        |
-   |         |        mutable borrow occurs here
+   |         ---- --- ^^^^^^^^^ mutable borrow occurs here
+   |         |    |
+   |         |    immutable borrow later used by call
    |         immutable borrow occurs here
-   |         borrow later used here
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/error-codes/E0499.nll.stderr
+++ b/src/test/ui/error-codes/E0499.nll.stderr
@@ -7,7 +7,7 @@ LL |     let mut a = &mut i; //~ ERROR E0499
    |                 ^^^^^^ second mutable borrow occurs here
 LL |     a.use_mut();
 LL |     x.use_mut();
-   |     - borrow later used here
+   |     - first borrow later used here
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0502.nll.stderr
+++ b/src/test/ui/error-codes/E0502.nll.stderr
@@ -6,7 +6,7 @@ LL |     let ref y = a;
 LL |     bar(a); //~ ERROR E0502
    |     ^^^^^^ mutable borrow occurs here
 LL |     y.use_ref();
-   |     - borrow later used here
+   |     - immutable borrow later used here
 
 error: aborting due to previous error
 

--- a/src/test/ui/generator/yield-while-iterating.nll.stderr
+++ b/src/test/ui/generator/yield-while-iterating.nll.stderr
@@ -19,7 +19,7 @@ LL | |     };
 LL |       println!("{}", x[0]); //~ ERROR
    |                      ^ immutable borrow occurs here
 LL |       b.resume();
-   |       - borrow later used here
+   |       - mutable borrow later used here
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/generator/yield-while-ref-reborrowed.nll.stderr
+++ b/src/test/ui/generator/yield-while-ref-reborrowed.nll.stderr
@@ -11,7 +11,7 @@ LL | |     };
 LL |       println!("{}", x); //~ ERROR
    |                      ^ borrow occurs here
 LL |       b.resume();
-   |       - borrow later used here
+   |       - first borrow later used here
 
 error: aborting due to previous error
 

--- a/src/test/ui/hashmap-iter-value-lifetime.nll.stderr
+++ b/src/test/ui/hashmap-iter-value-lifetime.nll.stderr
@@ -8,7 +8,7 @@ LL |     my_stuff.clear(); //~ ERROR cannot borrow
    |     ^^^^^^^^^^^^^^^^ mutable borrow occurs here
 LL | 
 LL |     println!("{}", *thing);
-   |                    ------ borrow later used here
+   |                    ------ immutable borrow later used here
 
 error: aborting due to previous error
 

--- a/src/test/ui/hashmap-lifetimes.nll.stderr
+++ b/src/test/ui/hashmap-lifetimes.nll.stderr
@@ -6,7 +6,7 @@ LL |     let mut it = my_stuff.iter();
 LL |     my_stuff.insert(1, 43); //~ ERROR cannot borrow
    |     ^^^^^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
 LL |     it;
-   |     -- borrow later used here
+   |     -- immutable borrow later used here
 
 error: aborting due to previous error
 

--- a/src/test/ui/hrtb/hrtb-debruijn-in-receiver.nll.stderr
+++ b/src/test/ui/hrtb/hrtb-debruijn-in-receiver.nll.stderr
@@ -7,7 +7,7 @@ LL |     foo.insert(); //~ ERROR cannot borrow
    |     ^^^
    |     |
    |     second mutable borrow occurs here
-   |     borrow later used here
+   |     first borrow later used here
 
 error: aborting due to previous error
 

--- a/src/test/ui/hygiene/fields-numeric-borrowck.nll.stderr
+++ b/src/test/ui/hygiene/fields-numeric-borrowck.nll.stderr
@@ -7,7 +7,7 @@ LL |     let S { 0: ref mut borrow2 } = s;
    |                ^^^^^^^^^^^^^^^ second mutable borrow occurs here
 ...
 LL |     borrow1.use_mut();
-   |     ------- borrow later used here
+   |     ------- first borrow later used here
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-11192.nll.stderr
+++ b/src/test/ui/issues/issue-11192.nll.stderr
@@ -8,10 +8,9 @@ LL |         ptr = box Foo { x: ptr.x + 1 };
    |         --- first borrow occurs due to use of `ptr` in closure
 ...
 LL |     test(&*ptr);
-   |     -----^^^^^-
-   |     |    |
-   |     |    immutable borrow occurs here
-   |     borrow later used here
+   |     ---- ^^^^^ immutable borrow occurs here
+   |     |
+   |     mutable borrow later used by call
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-18566.nll.stderr
+++ b/src/test/ui/issues/issue-18566.nll.stderr
@@ -2,11 +2,10 @@ error[E0499]: cannot borrow `*s` as mutable more than once at a time
   --> $DIR/issue-18566.rs:33:19
    |
 LL |     MyPtr(s).poke(s);
-   |     --------------^-
-   |     |     |       |
-   |     |     |       second mutable borrow occurs here
-   |     |     first mutable borrow occurs here
-   |     borrow later used here
+   |           -  ---- ^ second mutable borrow occurs here
+   |           |  |
+   |           |  first borrow later used by call
+   |           first mutable borrow occurs here
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-18783.nll.stderr
+++ b/src/test/ui/issues/issue-18783.nll.stderr
@@ -11,7 +11,7 @@ LL |     c.push(Box::new(|| y = 0));
    |                     second mutable borrow occurs here
 LL | //~^ ERROR cannot borrow `y` as mutable more than once at a time
 LL | }
-   | - borrow later used here, when `c` is dropped
+   | - first borrow later used here, when `c` is dropped
 
 error[E0499]: cannot borrow `y` as mutable more than once at a time
   --> $DIR/issue-18783.rs:26:29
@@ -26,7 +26,7 @@ LL |     Push::push(&c, Box::new(|| y = 0));
    |                             second mutable borrow occurs here
 LL | //~^ ERROR cannot borrow `y` as mutable more than once at a time
 LL | }
-   | - borrow later used here, when `c` is dropped
+   | - first borrow later used here, when `c` is dropped
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-25793.nll.stderr
+++ b/src/test/ui/issues/issue-25793.nll.stderr
@@ -7,10 +7,9 @@ LL |         $this.width.unwrap()
 LL |         let r = &mut *self;
    |                 ---------- borrow of `*self` occurs here
 LL |         r.get_size(width!(self))
-   |         ------------------------
-   |         |          |
-   |         |          in this macro invocation
-   |         borrow later used here
+   |           -------- ------------ in this macro invocation
+   |           |
+   |           borrow later used by call
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-42106.nll.stderr
+++ b/src/test/ui/issues/issue-42106.nll.stderr
@@ -6,7 +6,7 @@ LL |     let _a = &collection;
 LL |     collection.swap(1, 2); //~ ERROR also borrowed as immutable
    |     ^^^^^^^^^^ mutable borrow occurs here
 LL |     _a.use_ref();
-   |     -- borrow later used here
+   |     -- immutable borrow later used here
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-45157.stderr
+++ b/src/test/ui/issues/issue-45157.stderr
@@ -8,7 +8,7 @@ LL |         let nref = &u.z.c;
    |                    ^^^^^^ immutable borrow occurs here
 LL |         //~^ ERROR cannot borrow `u.z.c` as immutable because it is also borrowed as mutable [E0502]
 LL |         println!("{} {}", mref, nref)
-   |                           ---- borrow later used here
+   |                           ---- mutable borrow later used here
 
 error: aborting due to previous error
 

--- a/src/test/ui/methods/method-self-arg-2.nll.stderr
+++ b/src/test/ui/methods/method-self-arg-2.nll.stderr
@@ -6,7 +6,7 @@ LL |     let y = &mut x;
 LL |     Foo::bar(&x); //~ERROR cannot borrow `x`
    |              ^^ immutable borrow occurs here
 LL |     y.use_mut();
-   |     - borrow later used here
+   |     - mutable borrow later used here
 
 error[E0499]: cannot borrow `x` as mutable more than once at a time
   --> $DIR/method-self-arg-2.rs:30:14
@@ -16,7 +16,7 @@ LL |     let y = &mut x;
 LL |     Foo::baz(&mut x); //~ERROR cannot borrow `x`
    |              ^^^^^^ second mutable borrow occurs here
 LL |     y.use_mut();
-   |     - borrow later used here
+   |     - first borrow later used here
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/moves/moves-based-on-type-no-recursive-stack-closure.nll.stderr
+++ b/src/test/ui/moves/moves-based-on-type-no-recursive-stack-closure.nll.stderr
@@ -2,11 +2,10 @@ error[E0499]: cannot borrow `*f` as mutable more than once at a time
   --> $DIR/moves-based-on-type-no-recursive-stack-closure.rs:30:27
    |
 LL |                     (f.c)(f, true);
-   |                     ------^-------
-   |                     |     |
-   |                     |     second mutable borrow occurs here
+   |                     ----- ^ second mutable borrow occurs here
+   |                     |
    |                     first mutable borrow occurs here
-   |                     borrow later used here
+   |                     first borrow later used by call
 
 error[E0382]: borrow of moved value: `f`
   --> $DIR/moves-based-on-type-no-recursive-stack-closure.rs:42:5

--- a/src/test/ui/mut/mut-cant-alias.nll.stderr
+++ b/src/test/ui/mut/mut-cant-alias.nll.stderr
@@ -6,7 +6,7 @@ LL |     let b1 = &mut *b;
 LL |     let b2 = &mut *b; //~ ERROR cannot borrow
    |                    ^ second mutable borrow occurs here
 LL |     b1.use_mut();
-   |     -- borrow later used here
+   |     -- first borrow later used here
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/borrowed-local-error.stderr
+++ b/src/test/ui/nll/borrowed-local-error.stderr
@@ -1,16 +1,14 @@
 error[E0597]: `v` does not live long enough
   --> $DIR/borrowed-local-error.rs:20:9
    |
-LL |       let x = gimme({
-   |  _____________-
-LL | |         let v = (22,);
-LL | |         &v
-   | |         ^^ borrowed value does not live long enough
-LL | |         //~^ ERROR `v` does not live long enough [E0597]
-LL | |     });
-   | |_____-- borrow later used here
-   |       |
-   |       `v` dropped here while still borrowed
+LL |     let x = gimme({
+   |             ----- borrow later used by call
+LL |         let v = (22,);
+LL |         &v
+   |         ^^ borrowed value does not live long enough
+LL |         //~^ ERROR `v` does not live long enough [E0597]
+LL |     });
+   |     - `v` dropped here while still borrowed
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/borrowed-referent-issue-38899.stderr
+++ b/src/test/ui/nll/borrowed-referent-issue-38899.stderr
@@ -8,7 +8,7 @@ LL |     let p: &'a u8 = &*block.current;
    |                     ^^^^^^^^^^^^^^^ immutable borrow occurs here
 LL |     //~^ ERROR cannot borrow `*block.current` as immutable because it is also borrowed as mutable
 LL |     drop(x);
-   |          - borrow later used here
+   |          - mutable borrow later used here
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/closure-access-spans.stderr
+++ b/src/test/ui/nll/closure-access-spans.stderr
@@ -8,7 +8,7 @@ LL |     || x; //~ ERROR
    |     |
    |     immutable borrow occurs here
 LL |     r.use_mut();
-   |     - borrow later used here
+   |     - mutable borrow later used here
 
 error[E0499]: cannot borrow `x` as mutable more than once at a time
   --> $DIR/closure-access-spans.rs:23:5
@@ -20,7 +20,7 @@ LL |     || x = 2; //~ ERROR
    |     |
    |     second mutable borrow occurs here
 LL |     r.use_mut();
-   |     - borrow later used here
+   |     - first borrow later used here
 
 error[E0500]: closure requires unique access to `x` but it is already borrowed
   --> $DIR/closure-access-spans.rs:29:5
@@ -32,7 +32,7 @@ LL |     || *x = 2; //~ ERROR
    |     |
    |     closure construction occurs here
 LL |     r.use_mut();
-   |     - borrow later used here
+   |     - first borrow later used here
 
 error[E0503]: cannot use `x` because it was mutably borrowed
   --> $DIR/closure-access-spans.rs:35:13

--- a/src/test/ui/nll/closure-borrow-spans.stderr
+++ b/src/test/ui/nll/closure-borrow-spans.stderr
@@ -20,7 +20,7 @@ LL |     let f = || x;
 LL |     let y = &mut x; //~ ERROR
    |             ^^^^^^ mutable borrow occurs here
 LL |     f.use_ref();
-   |     - borrow later used here
+   |     - immutable borrow later used here
 
 error[E0597]: `x` does not live long enough
   --> $DIR/closure-borrow-spans.rs:31:16
@@ -68,7 +68,7 @@ LL |     let f = || x = 0;
 LL |     let y = &x; //~ ERROR
    |             ^^ immutable borrow occurs here
 LL |     f.use_ref();
-   |     - borrow later used here
+   |     - mutable borrow later used here
 
 error[E0499]: cannot borrow `x` as mutable more than once at a time
   --> $DIR/closure-borrow-spans.rs:56:13
@@ -80,7 +80,7 @@ LL |     let f = || x = 0;
 LL |     let y = &mut x; //~ ERROR
    |             ^^^^^^ second mutable borrow occurs here
 LL |     f.use_ref();
-   |     - borrow later used here
+   |     - first borrow later used here
 
 error[E0597]: `x` does not live long enough
   --> $DIR/closure-borrow-spans.rs:64:16
@@ -128,7 +128,7 @@ LL |     let f = || *x = 0;
 LL |     let y = &x; //~ ERROR
    |             ^^ borrow occurs here
 LL |     f.use_ref();
-   |     - borrow later used here
+   |     - first borrow later used here
 
 error[E0501]: cannot borrow `x` as mutable because previous closure requires unique access
   --> $DIR/closure-borrow-spans.rs:89:13
@@ -140,7 +140,7 @@ LL |     let f = || *x = 0;
 LL |     let y = &mut x; //~ ERROR
    |             ^^^^^^ borrow occurs here
 LL |     f.use_ref();
-   |     - borrow later used here
+   |     - first borrow later used here
 
 error[E0597]: `x` does not live long enough
   --> $DIR/closure-borrow-spans.rs:98:17

--- a/src/test/ui/nll/get_default.nll.stderr
+++ b/src/test/ui/nll/get_default.nll.stderr
@@ -43,7 +43,7 @@ LL |         match map.get() {
 LL |                 map.set(String::new()); // Ideally, this would not error.
    |                 ^^^^^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
    |
-note: borrowed value must be valid for the anonymous lifetime #1 defined on the function body at 26:1...
+note: immutable borrowed value must be valid for the anonymous lifetime #1 defined on the function body at 26:1...
   --> $DIR/get_default.rs:26:1
    |
 LL | / fn ok(map: &mut Map) -> &String {
@@ -64,7 +64,7 @@ LL |             Some(v) => {
 LL |                 map.set(String::new()); // Both AST and MIR error here
    |                 ^^^^^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
    |
-note: borrowed value must be valid for the anonymous lifetime #1 defined on the function body at 41:1...
+note: immutable borrowed value must be valid for the anonymous lifetime #1 defined on the function body at 41:1...
   --> $DIR/get_default.rs:41:1
    |
 LL | / fn err(map: &mut Map) -> &String {
@@ -85,7 +85,7 @@ LL |         match map.get() {
 LL |                 map.set(String::new()); // Ideally, just AST would error here
    |                 ^^^^^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
    |
-note: borrowed value must be valid for the anonymous lifetime #1 defined on the function body at 41:1...
+note: immutable borrowed value must be valid for the anonymous lifetime #1 defined on the function body at 41:1...
   --> $DIR/get_default.rs:41:1
    |
 LL | / fn err(map: &mut Map) -> &String {

--- a/src/test/ui/nll/get_default.stderr
+++ b/src/test/ui/nll/get_default.stderr
@@ -43,7 +43,7 @@ LL |         match map.get() {
 LL |                 map.set(String::new()); // Ideally, this would not error.
    |                 ^^^ mutable borrow occurs here
    |
-note: borrowed value must be valid for the anonymous lifetime #1 defined on the function body at 26:1...
+note: immutable borrowed value must be valid for the anonymous lifetime #1 defined on the function body at 26:1...
   --> $DIR/get_default.rs:26:1
    |
 LL | / fn ok(map: &mut Map) -> &String {
@@ -64,7 +64,7 @@ LL |             Some(v) => {
 LL |                 map.set(String::new()); // Both AST and MIR error here
    |                 ^^^ mutable borrow occurs here
    |
-note: borrowed value must be valid for the anonymous lifetime #1 defined on the function body at 41:1...
+note: immutable borrowed value must be valid for the anonymous lifetime #1 defined on the function body at 41:1...
   --> $DIR/get_default.rs:41:1
    |
 LL | / fn err(map: &mut Map) -> &String {
@@ -85,7 +85,7 @@ LL |         match map.get() {
 LL |                 map.set(String::new()); // Ideally, just AST would error here
    |                 ^^^ mutable borrow occurs here
    |
-note: borrowed value must be valid for the anonymous lifetime #1 defined on the function body at 41:1...
+note: immutable borrowed value must be valid for the anonymous lifetime #1 defined on the function body at 41:1...
   --> $DIR/get_default.rs:41:1
    |
 LL | / fn err(map: &mut Map) -> &String {

--- a/src/test/ui/nll/issue-51268.stderr
+++ b/src/test/ui/nll/issue-51268.stderr
@@ -1,19 +1,16 @@
 error[E0502]: cannot borrow `self.thing` as mutable because it is also borrowed as immutable
   --> $DIR/issue-51268.rs:28:9
    |
-LL |            self.thing.bar(|| {
-   |            ^              -- immutable borrow occurs here
-   |   _________|
-   |  |_________|
-   | ||
-LL | ||         //~^ ERROR cannot borrow `self.thing` as mutable because it is also borrowed as immutable [E0502]
-LL | ||             &self.number;
-   | ||              ---- first borrow occurs due to use of `self` in closure
-LL | ||         });
-   | ||          ^
-   | ||__________|
-   | |___________mutable borrow occurs here
-   |             borrow later used here
+LL |           self.thing.bar(|| {
+   |           ^          --- -- immutable borrow occurs here
+   |           |          |
+   |  _________|          immutable borrow later used by call
+   | |
+LL | |         //~^ ERROR cannot borrow `self.thing` as mutable because it is also borrowed as immutable [E0502]
+LL | |             &self.number;
+   | |              ---- first borrow occurs due to use of `self` in closure
+LL | |         });
+   | |__________^ mutable borrow occurs here
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/loan_ends_mid_block_vec.stderr
+++ b/src/test/ui/nll/loan_ends_mid_block_vec.stderr
@@ -80,7 +80,7 @@ LL |     data.push('d');
    |     ^^^^ second mutable borrow occurs here
 ...
 LL |     capitalize(slice);
-   |                ----- borrow later used here
+   |                ----- first borrow later used here
 
 error[E0499]: cannot borrow `data` as mutable more than once at a time (Mir)
   --> $DIR/loan_ends_mid_block_vec.rs:27:5
@@ -92,7 +92,7 @@ LL |     data.push('e');
    |     ^^^^ second mutable borrow occurs here
 ...
 LL |     capitalize(slice);
-   |                ----- borrow later used here
+   |                ----- first borrow later used here
 
 error[E0499]: cannot borrow `data` as mutable more than once at a time (Mir)
   --> $DIR/loan_ends_mid_block_vec.rs:30:5
@@ -104,7 +104,7 @@ LL |     data.push('f');
    |     ^^^^ second mutable borrow occurs here
 ...
 LL |     capitalize(slice);
-   |                ----- borrow later used here
+   |                ----- first borrow later used here
 
 error: aborting due to 9 previous errors
 

--- a/src/test/ui/nll/region-ends-after-if-condition.nll.stderr
+++ b/src/test/ui/nll/region-ends-after-if-condition.nll.stderr
@@ -32,7 +32,7 @@ LL |         my_struct.field.push_str("Hello, world!");
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
 ...
 LL |     drop(value);
-   |          ----- borrow later used here
+   |          ----- immutable borrow later used here
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/nll/region-ends-after-if-condition.stderr
+++ b/src/test/ui/nll/region-ends-after-if-condition.stderr
@@ -32,7 +32,7 @@ LL |         my_struct.field.push_str("Hello, world!");
    |         ^^^^^^^^^^^^^^^ mutable borrow occurs here
 ...
 LL |     drop(value);
-   |          ----- borrow later used here
+   |          ----- immutable borrow later used here
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/nll/return_from_loop.stderr
+++ b/src/test/ui/nll/return_from_loop.stderr
@@ -32,7 +32,7 @@ LL |         my_struct.field.push_str("Hello, world!");
    |         ^^^^^^^^^^^^^^^ second mutable borrow occurs here
 ...
 LL |         value.len();
-   |         ----- borrow later used here
+   |         ----- first borrow later used here
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/regions/region-bound-on-closure-outlives-call.nll.stderr
+++ b/src/test/ui/regions/region-bound-on-closure-outlives-call.nll.stderr
@@ -2,12 +2,11 @@ error[E0505]: cannot move out of `f` because it is borrowed
   --> $DIR/region-bound-on-closure-outlives-call.rs:12:25
    |
 LL |     (|x| f(x))(call_rec(f)) //~ ERROR cannot move out of `f`
-   |     --------------------^--
-   |     ||   |              |
-   |     ||   |              move out of `f` occurs here
+   |     ----------          ^ move out of `f` occurs here
+   |     ||   |
    |     ||   borrow occurs due to use in closure
    |     |borrow of `f` occurs here
-   |     borrow later used here
+   |     borrow later used by call
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-adjusted-lvalue-op.nll.stderr
+++ b/src/test/ui/regions/regions-adjusted-lvalue-op.nll.stderr
@@ -2,21 +2,19 @@ error[E0502]: cannot borrow `v` as immutable because it is also borrowed as muta
   --> $DIR/regions-adjusted-lvalue-op.rs:24:16
    |
 LL |     v[0].oh_no(&v); //~ ERROR cannot borrow `v` as immutable because
-   |     -----------^^-
-   |     |          |
-   |     |          immutable borrow occurs here
+   |     -    ----- ^^ immutable borrow occurs here
+   |     |    |
+   |     |    mutable borrow later used by call
    |     mutable borrow occurs here
-   |     borrow later used here
 
 error[E0502]: cannot borrow `v` as immutable because it is also borrowed as mutable
   --> $DIR/regions-adjusted-lvalue-op.rs:25:16
    |
 LL |     (*v).oh_no(&v); //~ ERROR cannot borrow `v` as immutable because
-   |     -----------^^-
-   |     | |        |
-   |     | |        immutable borrow occurs here
-   |     | mutable borrow occurs here
-   |     borrow later used here
+   |       -  ----- ^^ immutable borrow occurs here
+   |       |  |
+   |       |  mutable borrow later used by call
+   |       mutable borrow occurs here
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/rfc-2005-default-binding-mode/borrowck-issue-49631.nll.stderr
+++ b/src/test/ui/rfc-2005-default-binding-mode/borrowck-issue-49631.nll.stderr
@@ -7,7 +7,7 @@ LL |         foo.mutate();
    |         ^^^^^^^^^^^^ mutable borrow occurs here
 LL |         //~^ ERROR cannot borrow `foo` as mutable
 LL |         println!("foo={:?}", *string);
-   |                              ------- borrow used here, in later iteration of loop
+   |                              ------- immutable borrow used here, in later iteration of loop
 
 error: aborting due to previous error
 

--- a/src/test/ui/span/borrowck-call-is-borrow-issue-12224.nll.stderr
+++ b/src/test/ui/span/borrowck-call-is-borrow-issue-12224.nll.stderr
@@ -1,16 +1,14 @@
 error[E0499]: cannot borrow `f` as mutable more than once at a time
   --> $DIR/borrowck-call-is-borrow-issue-12224.rs:22:16
    |
-LL |       f(Box::new(|| {
-   |       -          ^^ second mutable borrow occurs here
-   |       |
-   |  _____first mutable borrow occurs here
-   | |
-LL | |     //~^ ERROR: cannot borrow `f` as mutable more than once
-LL | |         f((Box::new(|| {})))
-   | |         - second borrow occurs due to use of `f` in closure
-LL | |     }));
-   | |_______- borrow later used here
+LL |     f(Box::new(|| {
+   |     -          ^^ second mutable borrow occurs here
+   |     |
+   |     first mutable borrow occurs here
+   |     first borrow later used by call
+LL |     //~^ ERROR: cannot borrow `f` as mutable more than once
+LL |         f((Box::new(|| {})))
+   |         - second borrow occurs due to use of `f` in closure
 
 error[E0596]: cannot borrow `*f` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-call-is-borrow-issue-12224.rs:35:5
@@ -40,17 +38,13 @@ LL |         foo(f);
 error[E0505]: cannot move out of `f` because it is borrowed
   --> $DIR/borrowck-call-is-borrow-issue-12224.rs:65:16
    |
-LL |       f(Box::new(|a| {
-   |       -          ^^^ move out of `f` occurs here
-   |       |
-   |  _____borrow of `f` occurs here
-   | |
-LL | |         foo(f);
-   | |             - move occurs due to use in closure
-LL | |         //~^ ERROR cannot move `f` into closure because it is borrowed
-LL | |         //~| ERROR cannot move out of captured outer variable in an `FnMut` closure
-LL | |     }), 3);
-   | |__________- borrow later used here
+LL |     f(Box::new(|a| {
+   |     -          ^^^ move out of `f` occurs here
+   |     |
+   |     borrow of `f` occurs here
+   |     borrow later used by call
+LL |         foo(f);
+   |             - move occurs due to use in closure
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/unboxed-closures/unboxed-closures-recursive-fn-using-fn-mut.nll.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-recursive-fn-using-fn-mut.nll.stderr
@@ -2,11 +2,10 @@ error[E0499]: cannot borrow `*self` as mutable more than once at a time
   --> $DIR/unboxed-closures-recursive-fn-using-fn-mut.rs:32:21
    |
 LL |         (self.func)(self, arg)
-   |         ------------^^^^------
-   |         |           |
-   |         |           second mutable borrow occurs here
+   |         ----------- ^^^^ second mutable borrow occurs here
+   |         |
    |         first mutable borrow occurs here
-   |         borrow later used here
+   |         first borrow later used by call
 
 error: aborting due to previous error
 

--- a/src/test/ui/vec/vec-mut-iter-borrow.nll.stderr
+++ b/src/test/ui/vec/vec-mut-iter-borrow.nll.stderr
@@ -5,7 +5,7 @@ LL |     for x in &mut xs {
    |              -------
    |              |
    |              first mutable borrow occurs here
-   |              borrow used here, in later iteration of loop
+   |              first borrow used here, in later iteration of loop
 LL |         xs.push(1) //~ ERROR cannot borrow `xs`
    |         ^^ second mutable borrow occurs here
 


### PR DESCRIPTION
* In the case of two conflicting borrows, the later used message says which borrow it's referring to
* If the later use is a function call (from the users point of view) say that the later use is for the call. Point just to the function.

r? @pnkfelix 
Closes #48643