### PR TITLE
rust: Add a `-C default-linker-libraries` option

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -1135,6 +1135,8 @@ options! {CodegenOptions, CodegenSetter, basic_codegen_options,
         [TRACKED], "panic strategy to compile crate with"),
     incremental: Option<String> = (None, parse_opt_string, [UNTRACKED],
           "enable incremental compilation"),
+    default_linker_libraries: Option<bool> = (None, parse_opt_bool, [UNTRACKED],
+          "allow the linker to link its default libraries"),
 }
 
 options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,

--- a/src/librustc_codegen_llvm/back/link.rs
+++ b/src/librustc_codegen_llvm/back/link.rs
@@ -1138,12 +1138,16 @@ fn link_args(cmd: &mut dyn Linker,
     // Pass debuginfo flags down to the linker.
     cmd.debuginfo();
 
-    // We want to prevent the compiler from accidentally leaking in any system
-    // libraries, so we explicitly ask gcc to not link to any libraries by
-    // default. Note that this does not happen for windows because windows pulls
-    // in some large number of libraries and I couldn't quite figure out which
-    // subset we wanted.
-    if t.options.no_default_libraries {
+    // We want to, by default, prevent the compiler from accidentally leaking in
+    // any system libraries, so we may explicitly ask linkers to not link to any
+    // libraries by default. Note that this does not happen for windows because
+    // windows pulls in some large number of libraries and I couldn't quite
+    // figure out which subset we wanted.
+    //
+    // This is all naturally configurable via the standard methods as well.
+    if !sess.opts.cg.default_linker_libraries.unwrap_or(false) &&
+        t.options.no_default_libraries
+    {
         cmd.no_default_libraries();
     }
 


### PR DESCRIPTION
This commit adds a new codegen option for the compiler which disables
rustc's passing of `-nodefaultlibs` by default on relevant platforms.
Sometimes Rust is linked with C code which fails to link with
`-nodefaultlibs` and is unnecessarily onerous to get linking correctly
with `-nodefaultlibs`.

An example of this is that when you compile C code with sanitizers and
then pass `-fsanitize=address` to the linker, it's incompatible with
`-nodefaultlibs` also being passed to the linker.

In these situations it's easiest to turn off Rust's default passing of
`-nodefaultlibs`, which was more ideological to start with than
anything! Preserving the default is somewhat important but having this
be opt-in shouldn't cause any breakage.

Closes #54237