### PR TITLE
Rename sanitizer runtime libraries on OSX

### DIFF
--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -249,7 +249,7 @@ impl Step for StdLink {
 
 fn copy_apple_sanitizer_dylibs(builder: &Builder, native_dir: &Path, platform: &str, into: &Path) {
     for &sanitizer in &["asan", "tsan"] {
-        let filename = format!("libclang_rt.{}_{}_dynamic.dylib", sanitizer, platform);
+        let filename = format!("lib__rustc__clang_rt.{}_{}_dynamic.dylib", sanitizer, platform);
         let mut src_path = native_dir.join(sanitizer);
         src_path.push("build");
         src_path.push("lib");

--- a/src/librustc_asan/build.rs
+++ b/src/librustc_asan/build.rs
@@ -31,6 +31,7 @@ fn main() {
             .out_dir(&native.out_dir)
             .build_target(&target)
             .build();
+        native.fixup_sanitizer_lib_name("asan");
     }
     println!("cargo:rerun-if-env-changed=LLVM_CONFIG");
 }

--- a/src/librustc_tsan/build.rs
+++ b/src/librustc_tsan/build.rs
@@ -31,6 +31,7 @@ fn main() {
             .out_dir(&native.out_dir)
             .build_target(&target)
             .build();
+        native.fixup_sanitizer_lib_name("tsan");
     }
     println!("cargo:rerun-if-env-changed=LLVM_CONFIG");
 }


### PR DESCRIPTION
Currently we ship sanitizer libraries as they're built, but these names
unfortunately conflict with the names of the sanitizer libraries
installed on the system. If a crate, for example, links in C code that
wants to use the system sanitizer and the Rust code doesn't use
sanitizers at all, then using `cargo` may accidentally pull in the
Rust-installed sanitizer library due to a conflict in names.

This change is intended to be entirely transparent for Rust users of
sanitizers, it should only hopefully improve our story with other users!

Closes #54134