### PR TITLE
Re-export `getopts` so custom drivers can reference it.

### DIFF
--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -32,7 +32,7 @@
 #![recursion_limit="256"]
 
 extern crate arena;
-extern crate getopts;
+pub extern crate getopts;
 extern crate graphviz;
 extern crate env_logger;
 #[cfg(unix)]


### PR DESCRIPTION
Otherwise, custom drivers will have to use their own copy of `getopts`, which won't match the types used in `CompilerCalls`.