### PR TITLE
add an appveyor config for aarch64-pc-windows-msvc

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -82,11 +82,13 @@ environment:
   # 32/64 bit MSVC and GNU deployment
   - RUST_CONFIGURE_ARGS: >
       --build=x86_64-pc-windows-msvc
+      --target=x86_64-pc-windows-msvc,aarch64-pc-windows-msvc
       --enable-full-tools
       --enable-profiler
     SCRIPT: python x.py dist
     DEPLOY: 1
     CI_JOB_NAME: dist-x86_64-msvc
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017 Preview
   - RUST_CONFIGURE_ARGS: >
       --build=i686-pc-windows-msvc
       --target=i586-pc-windows-msvc

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -149,9 +149,9 @@ install:
   # Note that the LLVM installer is an NSIS installer
   #
   # Original downloaded here came from
-  # http://releases.llvm.org/6.0.0/LLVM-6.0.0-win64.exe
-  - if NOT defined MINGW_URL appveyor-retry appveyor DownloadFile https://s3-us-west-1.amazonaws.com/rust-lang-ci2/rust-ci-mirror/LLVM-6.0.0-win64.exe
-  - if NOT defined MINGW_URL .\LLVM-6.0.0-win64.exe /S /NCRC /D=C:\clang-rust
+  # http://releases.llvm.org/7.0.0/LLVM-7.0.0-win64.exe
+  - if NOT defined MINGW_URL appveyor-retry appveyor DownloadFile https://s3-us-west-1.amazonaws.com/rust-lang-ci2/rust-ci-mirror/LLVM-7.0.0-win64.exe
+  - if NOT defined MINGW_URL .\LLVM-7.0.0-win64.exe /S /NCRC /D=C:\clang-rust
   - if NOT defined MINGW_URL set RUST_CONFIGURE_ARGS=%RUST_CONFIGURE_ARGS% --set llvm.clang-cl=C:\clang-rust\bin\clang-cl.exe
 
   # Here we do a pretty heinous thing which is to mangle the MinGW installation


### PR DESCRIPTION
This is purely a cargo-cult of things to solicit feedback from humans and/or automation failures.  Not sure that the build artifacts would get packaged properly to start providing nightly tarballs for `libstd`, but this is at least a start.

Fixes #53864.