### PR TITLE
Renumber `proc_macro` tracking issues

### DIFF
--- a/src/libproc_macro/lib.rs
+++ b/src/libproc_macro/lib.rs
@@ -881,7 +881,7 @@ impl Ident {
     }
 
     /// Same as `Ident::new`, but creates a raw identifier (`r#ident`).
-    #[unstable(feature = "proc_macro_raw_ident", issue = "38356")]
+    #[unstable(feature = "proc_macro_raw_ident", issue = "54723")]
     pub fn new_raw(string: &str, span: Span) -> Ident {
         if !Ident::is_valid(string) {
             panic!("`{:?}` is not a valid identifier", string)

--- a/src/libproc_macro/lib.rs
+++ b/src/libproc_macro/lib.rs
@@ -283,7 +283,7 @@ macro_rules! diagnostic_method {
 
 impl Span {
     /// A span that resolves at the macro definition site.
-    #[unstable(feature = "proc_macro_span", issue = "38356")]
+    #[unstable(feature = "proc_macro_def_site", issue = "54724")]
     pub fn def_site() -> Span {
         ::__internal::with_sess(|_, data| data.def_site)
     }

--- a/src/libproc_macro/lib.rs
+++ b/src/libproc_macro/lib.rs
@@ -142,7 +142,7 @@ impl fmt::Debug for TokenStream {
     }
 }
 
-#[unstable(feature = "proc_macro_quote", issue = "38356")]
+#[unstable(feature = "proc_macro_quote", issue = "54722")]
 pub use quote::{quote, quote_span};
 
 /// Creates a token stream containing a single token tree.
@@ -252,7 +252,7 @@ pub mod token_stream {
 /// To quote `$` itself, use `$$`.
 ///
 /// This is a dummy macro, the actual implementation is in `quote::quote`.`
-#[unstable(feature = "proc_macro_quote", issue = "38356")]
+#[unstable(feature = "proc_macro_quote", issue = "54722")]
 #[macro_export]
 macro_rules! quote { () => {} }
 

--- a/src/libproc_macro/lib.rs
+++ b/src/libproc_macro/lib.rs
@@ -298,7 +298,7 @@ impl Span {
     }
 
     /// The original source file into which this span points.
-    #[unstable(feature = "proc_macro_span", issue = "38356")]
+    #[unstable(feature = "proc_macro_span", issue = "54725")]
     pub fn source_file(&self) -> SourceFile {
         SourceFile {
             source_file: __internal::lookup_char_pos(self.0.lo()).file,
@@ -307,7 +307,7 @@ impl Span {
 
     /// The `Span` for the tokens in the previous macro expansion from which
     /// `self` was generated from, if any.
-    #[unstable(feature = "proc_macro_span", issue = "38356")]
+    #[unstable(feature = "proc_macro_span", issue = "54725")]
     pub fn parent(&self) -> Option<Span> {
         self.0.parent().map(Span)
     }
@@ -315,13 +315,13 @@ impl Span {
     /// The span for the origin source code that `self` was generated from. If
     /// this `Span` wasn't generated from other macro expansions then the return
     /// value is the same as `*self`.
-    #[unstable(feature = "proc_macro_span", issue = "38356")]
+    #[unstable(feature = "proc_macro_span", issue = "54725")]
     pub fn source(&self) -> Span {
         Span(self.0.source_callsite())
     }
 
     /// Get the starting line/column in the source file for this span.
-    #[unstable(feature = "proc_macro_span", issue = "38356")]
+    #[unstable(feature = "proc_macro_span", issue = "54725")]
     pub fn start(&self) -> LineColumn {
         let loc = __internal::lookup_char_pos(self.0.lo());
         LineColumn {
@@ -331,7 +331,7 @@ impl Span {
     }
 
     /// Get the ending line/column in the source file for this span.
-    #[unstable(feature = "proc_macro_span", issue = "38356")]
+    #[unstable(feature = "proc_macro_span", issue = "54725")]
     pub fn end(&self) -> LineColumn {
         let loc = __internal::lookup_char_pos(self.0.hi());
         LineColumn {
@@ -343,7 +343,7 @@ impl Span {
     /// Create a new span encompassing `self` and `other`.
     ///
     /// Returns `None` if `self` and `other` are from different files.
-    #[unstable(feature = "proc_macro_span", issue = "38356")]
+    #[unstable(feature = "proc_macro_span", issue = "54725")]
     pub fn join(&self, other: Span) -> Option<Span> {
         let self_loc = __internal::lookup_char_pos(self.0.lo());
         let other_loc = __internal::lookup_char_pos(other.0.lo());
@@ -355,20 +355,20 @@ impl Span {
 
     /// Creates a new span with the same line/column information as `self` but
     /// that resolves symbols as though it were at `other`.
-    #[unstable(feature = "proc_macro_span", issue = "38356")]
+    #[unstable(feature = "proc_macro_span", issue = "54725")]
     pub fn resolved_at(&self, other: Span) -> Span {
         Span(self.0.with_ctxt(other.0.ctxt()))
     }
 
     /// Creates a new span with the same name resolution behavior as `self` but
     /// with the line/column information of `other`.
-    #[unstable(feature = "proc_macro_span", issue = "38356")]
+    #[unstable(feature = "proc_macro_span", issue = "54725")]
     pub fn located_at(&self, other: Span) -> Span {
         other.resolved_at(*self)
     }
 
     /// Compares to spans to see if they're equal.
-    #[unstable(feature = "proc_macro_span", issue = "38356")]
+    #[unstable(feature = "proc_macro_span", issue = "54725")]
     pub fn eq(&self, other: &Span) -> bool {
         self.0 == other.0
     }
@@ -391,33 +391,33 @@ impl fmt::Debug for Span {
 }
 
 /// A line-column pair representing the start or end of a `Span`.
-#[unstable(feature = "proc_macro_span", issue = "38356")]
+#[unstable(feature = "proc_macro_span", issue = "54725")]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct LineColumn {
     /// The 1-indexed line in the source file on which the span starts or ends (inclusive).
-    #[unstable(feature = "proc_macro_span", issue = "38356")]
+    #[unstable(feature = "proc_macro_span", issue = "54725")]
     pub line: usize,
     /// The 0-indexed column (in UTF-8 characters) in the source file on which
     /// the span starts or ends (inclusive).
-    #[unstable(feature = "proc_macro_span", issue = "38356")]
+    #[unstable(feature = "proc_macro_span", issue = "54725")]
     pub column: usize
 }
 
-#[unstable(feature = "proc_macro_span", issue = "38356")]
+#[unstable(feature = "proc_macro_span", issue = "54725")]
 impl !Send for LineColumn {}
-#[unstable(feature = "proc_macro_span", issue = "38356")]
+#[unstable(feature = "proc_macro_span", issue = "54725")]
 impl !Sync for LineColumn {}
 
 /// The source file of a given `Span`.
-#[unstable(feature = "proc_macro_span", issue = "38356")]
+#[unstable(feature = "proc_macro_span", issue = "54725")]
 #[derive(Clone)]
 pub struct SourceFile {
     source_file: Lrc<syntax_pos::SourceFile>,
 }
 
-#[unstable(feature = "proc_macro_span", issue = "38356")]
+#[unstable(feature = "proc_macro_span", issue = "54725")]
 impl !Send for SourceFile {}
-#[unstable(feature = "proc_macro_span", issue = "38356")]
+#[unstable(feature = "proc_macro_span", issue = "54725")]
 impl !Sync for SourceFile {}
 
 impl SourceFile {
@@ -431,7 +431,7 @@ impl SourceFile {
     /// the command line, the path as given may not actually be valid.
     ///
     /// [`is_real`]: #method.is_real
-    #[unstable(feature = "proc_macro_span", issue = "38356")]
+    #[unstable(feature = "proc_macro_span", issue = "54725")]
     pub fn path(&self) -> PathBuf {
         match self.source_file.name {
             FileName::Real(ref path) => path.clone(),
@@ -441,7 +441,7 @@ impl SourceFile {
 
     /// Returns `true` if this source file is a real source file, and not generated by an external
     /// macro's expansion.
-    #[unstable(feature = "proc_macro_span", issue = "38356")]
+    #[unstable(feature = "proc_macro_span", issue = "54725")]
     pub fn is_real(&self) -> bool {
         // This is a hack until intercrate spans are implemented and we can have real source files
         // for spans generated in external macros.
@@ -451,7 +451,7 @@ impl SourceFile {
 }
 
 
-#[unstable(feature = "proc_macro_span", issue = "38356")]
+#[unstable(feature = "proc_macro_span", issue = "54725")]
 impl fmt::Debug for SourceFile {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("SourceFile")
@@ -461,14 +461,14 @@ impl fmt::Debug for SourceFile {
     }
 }
 
-#[unstable(feature = "proc_macro_span", issue = "38356")]
+#[unstable(feature = "proc_macro_span", issue = "54725")]
 impl PartialEq for SourceFile {
     fn eq(&self, other: &Self) -> bool {
         Lrc::ptr_eq(&self.source_file, &other.source_file)
     }
 }
 
-#[unstable(feature = "proc_macro_span", issue = "38356")]
+#[unstable(feature = "proc_macro_span", issue = "54725")]
 impl Eq for SourceFile {}
 
 /// A single token or a delimited sequence of token trees (e.g. `[1, (), ..]`).
@@ -679,7 +679,7 @@ impl Group {
     /// pub fn span_open(&self) -> Span {
     ///                 ^
     /// ```
-    #[unstable(feature = "proc_macro_span", issue = "38356")]
+    #[unstable(feature = "proc_macro_span", issue = "54725")]
     pub fn span_open(&self) -> Span {
         Span(self.span.open)
     }
@@ -690,7 +690,7 @@ impl Group {
     /// pub fn span_close(&self) -> Span {
     ///                        ^
     /// ```
-    #[unstable(feature = "proc_macro_span", issue = "38356")]
+    #[unstable(feature = "proc_macro_span", issue = "54725")]
     pub fn span_close(&self) -> Span {
         Span(self.span.close)
     }

--- a/src/libproc_macro/quote.rs
+++ b/src/libproc_macro/quote.rs
@@ -70,7 +70,7 @@ macro_rules! quote {
 /// This is the actual `quote!()` proc macro.
 ///
 /// It is manually loaded in `CStore::load_macro_untracked`.
-#[unstable(feature = "proc_macro_quote", issue = "38356")]
+#[unstable(feature = "proc_macro_quote", issue = "54722")]
 pub fn quote(stream: TokenStream) -> TokenStream {
     if stream.is_empty() {
         return quote!(::TokenStream::new());
@@ -144,7 +144,7 @@ pub fn quote(stream: TokenStream) -> TokenStream {
 
 /// Quote a `Span` into a `TokenStream`.
 /// This is needed to implement a custom quoter.
-#[unstable(feature = "proc_macro_quote", issue = "38356")]
+#[unstable(feature = "proc_macro_quote", issue = "54722")]
 pub fn quote_span(_: Span) -> TokenStream {
     quote!(::Span::def_site())
 }

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -441,10 +441,10 @@ declare_features! (
 
     // Allows macro invocations on modules expressions and statements and
     // procedural macros to expand to non-items.
-    (active, proc_macro_mod, "1.27.0", Some(38356), None),
-    (active, proc_macro_expr, "1.27.0", Some(38356), None),
-    (active, proc_macro_non_items, "1.27.0", Some(38356), None),
-    (active, proc_macro_gen, "1.27.0", Some(38356), None),
+    (active, proc_macro_mod, "1.27.0", Some(54727), None),
+    (active, proc_macro_expr, "1.27.0", Some(54727), None),
+    (active, proc_macro_non_items, "1.27.0", Some(54727), None),
+    (active, proc_macro_gen, "1.27.0", Some(54727), None),
 
     // #[doc(alias = "...")]
     (active, doc_alias, "1.27.0", Some(50146), None),
@@ -502,7 +502,7 @@ declare_features! (
     (active, custom_test_frameworks, "1.30.0", Some(50297), None),
 
     // Non-builtin attributes in inner attribute position
-    (active, custom_inner_attributes, "1.30.0", Some(38356), None),
+    (active, custom_inner_attributes, "1.30.0", Some(54726), None),
 
     // Self struct constructor  (RFC 2302)
     (active, self_struct_ctor, "1.30.0", Some(51994), None),

--- a/src/test/ui-fulldeps/proc-macro/auxiliary/multispan.rs
+++ b/src/test/ui-fulldeps/proc-macro/auxiliary/multispan.rs
@@ -11,7 +11,7 @@
 // no-prefer-dynamic
 
 #![crate_type = "proc-macro"]
-#![feature(proc_macro_diagnostic, proc_macro_span)]
+#![feature(proc_macro_diagnostic, proc_macro_span, proc_macro_def_site)]
 
 extern crate proc_macro;
 

--- a/src/test/ui-fulldeps/proc-macro/auxiliary/three-equals.rs
+++ b/src/test/ui-fulldeps/proc-macro/auxiliary/three-equals.rs
@@ -11,7 +11,7 @@
 // no-prefer-dynamic
 
 #![crate_type = "proc-macro"]
-#![feature(proc_macro_diagnostic, proc_macro_span)]
+#![feature(proc_macro_diagnostic, proc_macro_span, proc_macro_def_site)]
 
 extern crate proc_macro;
 

--- a/src/test/ui/span/issue-36530.stderr
+++ b/src/test/ui/span/issue-36530.stderr
@@ -6,7 +6,7 @@ LL | #[foo] //~ ERROR is currently unknown to the compiler
    |
    = help: add #![feature(custom_attribute)] to the crate attributes to enable
 
-error[E0658]: non-builtin inner attributes are unstable (see issue #38356)
+error[E0658]: non-builtin inner attributes are unstable (see issue #54726)
   --> $DIR/issue-36530.rs:15:5
    |
 LL |     #![foo] //~ ERROR is currently unknown to the compiler


### PR DESCRIPTION
Lots of issue links in the compiler still point to https://github.com/rust-lang/rust/issues/38356 which is a bit of a monster issue that isn't serving much purpose any more. I've split the issue into a number of more fine-grained tracking issues to track stabilizations.