### PR TITLE
Stabilize rustdoc theme options

### DIFF
--- a/src/doc/rustdoc/src/command-line-arguments.md
+++ b/src/doc/rustdoc/src/command-line-arguments.md
@@ -355,7 +355,27 @@ $ rustdoc src/lib.rs --edition 2018
 $ rustdoc --test src/lib.rs --edition 2018
 ```
 
-This flag allows rustdoc to treat your rust code as the given edition. It will compile doctests with
+This flag allows `rustdoc` to treat your rust code as the given edition. It will compile doctests with
 the given edition as well. As with `rustc`, the default edition that `rustdoc` will use is `2015`
 (the first edition).
 
+## `themes`: add more themes to generated documentation
+
+By default, `rustdoc` only provides the "dark" and light" themes. If you want to add new ones,
+you'll need to this flag as follows:
+
+```bash
+$ rustdoc src/lib.rs --themes /path/to/your/theme/file.css
+```
+
+### `theme-checker`: check if your themes implement all the required rules
+
+This flag allows you to check if your themes implement the necessary CSS rules. To put it more
+simply, when adding a new theme, it needs to implements all the CSS rules present in the `ðark` and
+`light` CSS themes.
+
+You can use this flag like this:
+
+```bash
+$ rustdoc src/lib.rs --theme-checker /path/to/your/theme/file.css
+```

--- a/src/doc/rustdoc/src/command-line-arguments.md
+++ b/src/doc/rustdoc/src/command-line-arguments.md
@@ -374,7 +374,7 @@ Note that the theme's name will be the file name without its extension. So if yo
 ### `check-theme`: check if your themes implement all the required rules
 
 This flag allows you to check if your themes implement the necessary CSS rules. To put it more
-simply, when adding a new theme, it needs to implements all the CSS rules present in the "light"
+simply, when adding a new theme, it needs to implement all the CSS rules present in the "light"
 CSS theme.
 
 You can use this flag like this:

--- a/src/doc/rustdoc/src/command-line-arguments.md
+++ b/src/doc/rustdoc/src/command-line-arguments.md
@@ -368,6 +368,9 @@ you'll need to use this flag as follows:
 $ rustdoc src/lib.rs --themes /path/to/your/theme/file.css
 ```
 
+Note that the theme's name will be the file name without its extension. So if you pass
+`/path/to/your/theme/file.css` as theme, then the theme's name will be `file`.
+
 ### `check-theme`: check if your themes implement all the required rules
 
 This flag allows you to check if your themes implement the necessary CSS rules. To put it more
@@ -377,5 +380,5 @@ CSS theme.
 You can use this flag like this:
 
 ```bash
-$ rustdoc src/lib.rs --check-theme /path/to/your/theme/file.css
+$ rustdoc --check-theme /path/to/your/theme/file.css
 ```

--- a/src/doc/rustdoc/src/command-line-arguments.md
+++ b/src/doc/rustdoc/src/command-line-arguments.md
@@ -371,7 +371,7 @@ $ rustdoc src/lib.rs --themes /path/to/your/theme/file.css
 Note that the theme's name will be the file name without its extension. So if you pass
 `/path/to/your/theme/file.css` as theme, then the theme's name will be `file`.
 
-### `check-theme`: check if your themes implement all the required rules
+### `check-themes`: check if your themes implement all the required rules
 
 This flag allows you to check if your themes implement the necessary CSS rules. To put it more
 simply, when adding a new theme, it needs to implements all the CSS rules present in the "light"
@@ -380,5 +380,5 @@ CSS theme.
 You can use this flag like this:
 
 ```bash
-$ rustdoc --check-theme /path/to/your/theme/file.css
+$ rustdoc --check-themes /path/to/your/theme/file.css
 ```

--- a/src/doc/rustdoc/src/command-line-arguments.md
+++ b/src/doc/rustdoc/src/command-line-arguments.md
@@ -368,7 +368,7 @@ you'll need to this flag as follows:
 $ rustdoc src/lib.rs --themes /path/to/your/theme/file.css
 ```
 
-### `theme-checker`: check if your themes implement all the required rules
+### `check-theme`: check if your themes implement all the required rules
 
 This flag allows you to check if your themes implement the necessary CSS rules. To put it more
 simply, when adding a new theme, it needs to implements all the CSS rules present in the "light"
@@ -377,5 +377,5 @@ CSS theme.
 You can use this flag like this:
 
 ```bash
-$ rustdoc src/lib.rs --theme-checker /path/to/your/theme/file.css
+$ rustdoc src/lib.rs --check-theme /path/to/your/theme/file.css
 ```

--- a/src/doc/rustdoc/src/command-line-arguments.md
+++ b/src/doc/rustdoc/src/command-line-arguments.md
@@ -371,8 +371,8 @@ $ rustdoc src/lib.rs --themes /path/to/your/theme/file.css
 ### `theme-checker`: check if your themes implement all the required rules
 
 This flag allows you to check if your themes implement the necessary CSS rules. To put it more
-simply, when adding a new theme, it needs to implements all the CSS rules present in the `ðark` and
-`light` CSS themes.
+simply, when adding a new theme, it needs to implements all the CSS rules present in the "light"
+CSS theme.
 
 You can use this flag like this:
 

--- a/src/doc/rustdoc/src/command-line-arguments.md
+++ b/src/doc/rustdoc/src/command-line-arguments.md
@@ -359,19 +359,19 @@ This flag allows `rustdoc` to treat your rust code as the given edition. It will
 the given edition as well. As with `rustc`, the default edition that `rustdoc` will use is `2015`
 (the first edition).
 
-## `themes`: add more themes to generated documentation
+## `theme`: add more themes to generated documentation
 
 By default, `rustdoc` only provides the "dark" and "light" themes. If you want to add new ones,
 you'll need to use this flag as follows:
 
 ```bash
-$ rustdoc src/lib.rs --themes /path/to/your/theme/file.css
+$ rustdoc src/lib.rs --theme /path/to/your/theme/file.css
 ```
 
 Note that the theme's name will be the file name without its extension. So if you pass
 `/path/to/your/theme/file.css` as theme, then the theme's name will be `file`.
 
-### `check-themes`: check if your themes implement all the required rules
+### `check-theme`: check if your themes implement all the required rules
 
 This flag allows you to check if your themes implement the necessary CSS rules. To put it more
 simply, when adding a new theme, it needs to implements all the CSS rules present in the "light"
@@ -380,5 +380,5 @@ CSS theme.
 You can use this flag like this:
 
 ```bash
-$ rustdoc --check-themes /path/to/your/theme/file.css
+$ rustdoc --check-theme /path/to/your/theme/file.css
 ```

--- a/src/doc/rustdoc/src/command-line-arguments.md
+++ b/src/doc/rustdoc/src/command-line-arguments.md
@@ -361,8 +361,8 @@ the given edition as well. As with `rustc`, the default edition that `rustdoc` w
 
 ## `themes`: add more themes to generated documentation
 
-By default, `rustdoc` only provides the "dark" and light" themes. If you want to add new ones,
-you'll need to this flag as follows:
+By default, `rustdoc` only provides the "dark" and "light" themes. If you want to add new ones,
+you'll need to use this flag as follows:
 
 ```bash
 $ rustdoc src/lib.rs --themes /path/to/your/theme/file.css

--- a/src/doc/rustdoc/src/command-line-arguments.md
+++ b/src/doc/rustdoc/src/command-line-arguments.md
@@ -359,26 +359,34 @@ This flag allows `rustdoc` to treat your rust code as the given edition. It will
 the given edition as well. As with `rustc`, the default edition that `rustdoc` will use is `2015`
 (the first edition).
 
-## `theme`: add more themes to generated documentation
+## `--theme`: add a theme to the documentation output
 
-By default, `rustdoc` only provides the "dark" and "light" themes. If you want to add new ones,
-you'll need to use this flag as follows:
-
-```bash
-$ rustdoc src/lib.rs --theme /path/to/your/theme/file.css
-```
-
-Note that the theme's name will be the file name without its extension. So if you pass
-`/path/to/your/theme/file.css` as theme, then the theme's name will be `file`.
-
-### `check-theme`: check if your themes implement all the required rules
-
-This flag allows you to check if your themes implement the necessary CSS rules. To put it more
-simply, when adding a new theme, it needs to implement all the CSS rules present in the "light"
-CSS theme.
-
-You can use this flag like this:
+Using this flag looks like this:
 
 ```bash
-$ rustdoc --check-theme /path/to/your/theme/file.css
+$ rustdoc src/lib.rs --theme /path/to/your/custom-theme.css
 ```
+
+`rustdoc`'s default output includes two themes: `light` (the default) and
+`dark`. This flag allows you to add custom themes to the output. Giving a CSS
+file to this flag adds it to your documentation as an additional theme choice.
+The theme's name is determined by its filename; a theme file named
+`custom-theme.css` will add a theme named `custom-theme` to the documentation.
+
+## `--check-theme`: verify custom themes against the default theme
+
+Using this flag looks like this:
+
+```bash
+$ rustdoc --check-theme /path/to/your/custom-theme.css
+```
+
+While `rustdoc`'s HTML output is more-or-less consistent between versions, there
+is no guarantee that a theme file will have the same effect. The `--theme` flag
+will still allow you to add the theme to your documentation, but to ensure that
+your theme works as expected, you can use this flag to verify that it implements
+the same CSS rules as the official `light` theme.
+
+`--check-theme` is a separate mode in `rustdoc`. When `rustdoc` sees the
+`--check-theme` flag, it discards all other flags and only performs the CSS rule
+comparison operation.

--- a/src/doc/rustdoc/src/unstable-features.md
+++ b/src/doc/rustdoc/src/unstable-features.md
@@ -304,14 +304,14 @@ $ rustdoc src/lib.rs -Z unstable-options --themes theme.css
 
 Giving this flag to `rustdoc` will make it copy your theme into the generated crate docs and enable
 it in the theme selector. Note that `rustdoc` will reject your theme file if it doesn't style
-everything the "light" theme does. See `--theme-checker` below for details.
+everything the "light" theme does. See `--check-theme` below for details.
 
-### `--theme-checker`: verify theme CSS for validity
+### `--check-theme`: verify theme CSS for validity
 
 Using this flag looks like this:
 
 ```bash
-$ rustdoc -Z unstable-options --theme-checker theme.css
+$ rustdoc -Z unstable-options --check-theme theme.css
 ```
 
 Before including your theme in crate docs, `rustdoc` will compare all the CSS rules it contains

--- a/src/doc/rustdoc/src/unstable-features.md
+++ b/src/doc/rustdoc/src/unstable-features.md
@@ -294,30 +294,6 @@ some consideration for their stability, and names that end in a number). Giving 
 `rustdoc` will disable this sorting and instead make it print the items in the order they appear in
 the source.
 
-### `--themes`: provide additional themes
-
-Using this flag looks like this:
-
-```bash
-$ rustdoc src/lib.rs -Z unstable-options --themes theme.css
-```
-
-Giving this flag to `rustdoc` will make it copy your theme into the generated crate docs and enable
-it in the theme selector. Note that `rustdoc` will reject your theme file if it doesn't style
-everything the "light" theme does. See `--check-theme` below for details.
-
-### `--check-theme`: verify theme CSS for validity
-
-Using this flag looks like this:
-
-```bash
-$ rustdoc -Z unstable-options --check-theme theme.css
-```
-
-Before including your theme in crate docs, `rustdoc` will compare all the CSS rules it contains
-against the "light" theme included by default. Using this flag will allow you to see which rules are
-missing if `rustdoc` rejects your theme.
-
 ### `--resource-suffix`: modifying the name of CSS/JavaScript in crate docs
 
 Using this flag looks like this:

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -365,13 +365,13 @@ impl Options {
                                                 .iter()
                                                 .map(|s| (PathBuf::from(&s), s.to_owned())) {
                 if !theme_file.is_file() {
-                    diag.struct_err(&format!("invalid file: \"{}\"", theme_s))
-                        .help("option --theme arguments must all be files")
+                    diag.struct_err(&format!("invalid argument: \"{}\"", theme_s))
+                        .help("arguments to --theme must be files")
                         .emit();
                     return Err(1);
                 }
                 if theme_file.extension() != Some(OsStr::new("css")) {
-                    diag.struct_err(&format!("invalid file: \"{}\": expected CSS file", theme_s))
+                    diag.struct_err(&format!("invalid argument: \"{}\"", theme_s))
                         .emit();
                     return Err(1);
                 }

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -370,9 +370,15 @@ impl Options {
                     return Err(1);
                 }
                 let (success, ret) = theme::test_theme_against(&theme_file, &paths, &diag);
-                if !success || !ret.is_empty() {
-                    diag.struct_warn(&format!("invalid theme: \"{}\"", theme_s))
-                        .help("check what's wrong with the --theme-checker option")
+                if !success {
+                    diag.struct_warn(&format!("error loading theme file: \"{}\"", theme_s)).emit();
+                    return Err(1);
+                } else if !ret.is_empty() {
+                    diag.struct_warn(&format!("theme file \"{}\" is missing CSS rules from the \
+                                               default theme", theme_s))
+                        .warn("the theme may appear incorrect when loaded")
+                        .help(&format!("to see what rules are missing, call `rustdoc \
+                                        --theme-checker \"{}\"`", theme_s))
                         .emit();
                 }
                 themes.push(theme_file);

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -282,12 +282,12 @@ impl Options {
         // check for deprecated options
         check_deprecated_options(&matches, &diag);
 
-        let to_check = matches.opt_strs("check-themes");
+        let to_check = matches.opt_strs("check-theme");
         if !to_check.is_empty() {
             let paths = theme::load_css_paths(static_files::themes::LIGHT.as_bytes());
             let mut errors = 0;
 
-            println!("rustdoc: [check-themes] Starting tests! (Ignoring all other arguments)");
+            println!("rustdoc: [check-theme] Starting tests! (Ignoring all other arguments)");
             for theme_file in to_check.iter() {
                 print!(" - Checking \"{}\"...", theme_file);
                 let (success, differences) = theme::test_theme_against(theme_file, &paths, &diag);
@@ -358,15 +358,15 @@ impl Options {
         }
 
         let mut themes = Vec::new();
-        if matches.opt_present("themes") {
+        if matches.opt_present("theme") {
             let paths = theme::load_css_paths(static_files::themes::LIGHT.as_bytes());
 
-            for (theme_file, theme_s) in matches.opt_strs("themes")
+            for (theme_file, theme_s) in matches.opt_strs("theme")
                                                 .iter()
                                                 .map(|s| (PathBuf::from(&s), s.to_owned())) {
                 if !theme_file.is_file() {
                     diag.struct_err(&format!("invalid file: \"{}\"", theme_s))
-                        .help("option --themes arguments must all be files")
+                        .help("option --theme arguments must all be files")
                         .emit();
                     return Err(1);
                 }
@@ -384,7 +384,7 @@ impl Options {
                                                default theme", theme_s))
                         .warn("the theme may appear incorrect when loaded")
                         .help(&format!("to see what rules are missing, call `rustdoc \
-                                        --check-themes \"{}\"`", theme_s))
+                                        --check-theme \"{}\"`", theme_s))
                         .emit();
                 }
                 themes.push(theme_file);

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -364,7 +364,9 @@ impl Options {
                                                 .iter()
                                                 .map(|s| (PathBuf::from(&s), s.to_owned())) {
                 if !theme_file.is_file() {
-                    diag.struct_err("option --themes arguments must all be files").emit();
+                    diag.struct_err(&format!("invalid file: \"{}\"", theme_s))
+                        .help("option --themes arguments must all be files")
+                        .emit();
                     return Err(1);
                 }
                 let (success, ret) = theme::test_theme_against(&theme_file, &paths, &diag);

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::ffi::OsStr;
 use std::fmt;
 use std::path::PathBuf;
 
@@ -369,9 +370,14 @@ impl Options {
                         .emit();
                     return Err(1);
                 }
+                if theme_file.extension() != Some(OsStr::new("css")) {
+                    diag.struct_err(&format!("invalid file: \"{}\": expected CSS file", theme_s))
+                        .emit();
+                    return Err(1);
+                }
                 let (success, ret) = theme::test_theme_against(&theme_file, &paths, &diag);
                 if !success {
-                    diag.struct_warn(&format!("error loading theme file: \"{}\"", theme_s)).emit();
+                    diag.struct_err(&format!("error loading theme file: \"{}\"", theme_s)).emit();
                     return Err(1);
                 } else if !ret.is_empty() {
                     diag.struct_warn(&format!("theme file \"{}\" is missing CSS rules from the \

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -281,12 +281,12 @@ impl Options {
         // check for deprecated options
         check_deprecated_options(&matches, &diag);
 
-        let to_check = matches.opt_strs("theme-checker");
+        let to_check = matches.opt_strs("check-theme");
         if !to_check.is_empty() {
             let paths = theme::load_css_paths(static_files::themes::LIGHT.as_bytes());
             let mut errors = 0;
 
-            println!("rustdoc: [theme-checker] Starting tests!");
+            println!("rustdoc: [check-theme] Starting tests! (Ignoring all other arguments)");
             for theme_file in to_check.iter() {
                 print!(" - Checking \"{}\"...", theme_file);
                 let (success, differences) = theme::test_theme_against(theme_file, &paths, &diag);
@@ -378,7 +378,7 @@ impl Options {
                                                default theme", theme_s))
                         .warn("the theme may appear incorrect when loaded")
                         .help(&format!("to see what rules are missing, call `rustdoc \
-                                        --theme-checker \"{}\"`", theme_s))
+                                        --check-theme \"{}\"`", theme_s))
                         .emit();
                 }
                 themes.push(theme_file);

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -371,10 +371,9 @@ impl Options {
                 }
                 let (success, ret) = theme::test_theme_against(&theme_file, &paths, &diag);
                 if !success || !ret.is_empty() {
-                    diag.struct_err(&format!("invalid theme: \"{}\"", theme_s))
+                    diag.struct_warn(&format!("invalid theme: \"{}\"", theme_s))
                         .help("check what's wrong with the --theme-checker option")
                         .emit();
-                    return Err(1);
                 }
                 themes.push(theme_file);
             }

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -282,12 +282,12 @@ impl Options {
         // check for deprecated options
         check_deprecated_options(&matches, &diag);
 
-        let to_check = matches.opt_strs("check-theme");
+        let to_check = matches.opt_strs("check-themes");
         if !to_check.is_empty() {
             let paths = theme::load_css_paths(static_files::themes::LIGHT.as_bytes());
             let mut errors = 0;
 
-            println!("rustdoc: [check-theme] Starting tests! (Ignoring all other arguments)");
+            println!("rustdoc: [check-themes] Starting tests! (Ignoring all other arguments)");
             for theme_file in to_check.iter() {
                 print!(" - Checking \"{}\"...", theme_file);
                 let (success, differences) = theme::test_theme_against(theme_file, &paths, &diag);
@@ -384,7 +384,7 @@ impl Options {
                                                default theme", theme_s))
                         .warn("the theme may appear incorrect when loaded")
                         .help(&format!("to see what rules are missing, call `rustdoc \
-                                        --check-theme \"{}\"`", theme_s))
+                                        --check-themes \"{}\"`", theme_s))
                         .emit();
                 }
                 themes.push(theme_file);

--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use crate::externalfiles::ExternalHtml;
+use crate::html::escape::Escape;
 use crate::html::render::ensure_trailing_slash;
 use crate::html::format::{Buffer, Print};
 
@@ -166,10 +167,11 @@ pub fn render<T: Print, S: Print>(
     themes = themes.iter()
                    .filter_map(|t| t.file_stem())
                    .filter_map(|t| t.to_str())
-                   .map(|t| format!(r#"<link rel="stylesheet" type="text/css" href="{}{}{}.css">"#,
-                                    static_root_path,
-                                    t,
-                                    page.resource_suffix))
+                   .map(|t| format!(r#"<link rel="stylesheet" type="text/css" href="{}.css">"#,
+                                    Escape(&format!("{}{}{}",
+                                                    static_root_path,
+                                                    t,
+                                                    page.resource_suffix))))
                    .collect::<String>(),
     suffix=page.resource_suffix,
     static_extra_scripts=page.static_extra_scripts.iter().map(|e| {

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -635,7 +635,7 @@ function handleThemeButtonsBlur(e) {{
 
 themePicker.onclick = switchThemeButtonState;
 themePicker.onblur = handleThemeButtonsBlur;
-[{}].forEach(function(item) {{
+{}.forEach(function(item) {{
     var but = document.createElement('button');
     but.innerHTML = item;
     but.onclick = function(el) {{
@@ -644,10 +644,7 @@ themePicker.onblur = handleThemeButtonsBlur;
     but.onblur = handleThemeButtonsBlur;
     themes.appendChild(but);
 }});"#,
-                 themes.iter()
-                       .map(|s| format!("\"{}\"", s.replace("\\", "\\\\").replace("\"", "\\\"")))
-                       .collect::<Vec<String>>()
-                       .join(","));
+                 as_json(&themes));
     write(cx.dst.join(&format!("theme{}.js", cx.shared.resource_suffix)),
           theme_js.as_bytes()
     )?;

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -569,7 +569,9 @@ fn write_shared(
         let content = try_err!(fs::read(&entry), &entry);
         let theme = try_none!(try_none!(entry.file_stem(), &entry).to_str(), &entry);
         let extension = try_none!(try_none!(entry.extension(), &entry).to_str(), &entry);
-        cx.shared.fs.write(cx.path(&format!("{}.{}", theme, extension)), content.as_slice())?;
+        cx.shared.fs.write(
+            cx.path(&format!("{}.{}", Escape(theme), extension)),
+            content.as_slice())?;
         themes.insert(theme.to_owned());
     }
 

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -645,7 +645,7 @@ themePicker.onblur = handleThemeButtonsBlur;
     themes.appendChild(but);
 }});"#,
                  themes.iter()
-                       .map(|s| format!("\"{}\"", s))
+                       .map(|s| format!("\"{}\"", s.replace("\\", "\\\\").replace("\"", "\\\"")))
                        .collect::<Vec<String>>()
                        .join(","));
     write(cx.dst.join(&format!("theme{}.js", cx.shared.resource_suffix)),

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -569,9 +569,7 @@ fn write_shared(
         let content = try_err!(fs::read(&entry), &entry);
         let theme = try_none!(try_none!(entry.file_stem(), &entry).to_str(), &entry);
         let extension = try_none!(try_none!(entry.extension(), &entry).to_str(), &entry);
-        cx.shared.fs.write(
-            cx.path(&format!("{}.{}", Escape(theme), extension)),
-            content.as_slice())?;
+        cx.shared.fs.write(cx.path(&format!("{}.{}", theme, extension)), content.as_slice())?;
         themes.insert(theme.to_owned());
     }
 
@@ -637,7 +635,7 @@ themePicker.onclick = switchThemeButtonState;
 themePicker.onblur = handleThemeButtonsBlur;
 {}.forEach(function(item) {{
     var but = document.createElement('button');
-    but.innerHTML = item;
+    but.textContent = item;
     but.onclick = function(el) {{
         switchTheme(currentTheme, mainTheme, item, true);
     }};

--- a/src/librustdoc/html/static_files.rs
+++ b/src/librustdoc/html/static_files.rs
@@ -59,7 +59,7 @@ pub static RUST_FAVICON: &'static [u8] = include_bytes!("static/favicon.ico");
 /// The built-in themes given to every documentation site.
 pub mod themes {
     /// The "light" theme, selected by default when no setting is available. Used as the basis for
-    /// the `--theme-checker` functionality.
+    /// the `--check-theme` functionality.
     pub static LIGHT: &'static str = include_str!("static/themes/light.css");
 
     /// The "dark" theme.

--- a/src/librustdoc/html/static_files.rs
+++ b/src/librustdoc/html/static_files.rs
@@ -59,7 +59,7 @@ pub static RUST_FAVICON: &'static [u8] = include_bytes!("static/favicon.ico");
 /// The built-in themes given to every documentation site.
 pub mod themes {
     /// The "light" theme, selected by default when no setting is available. Used as the basis for
-    /// the `--check-theme` functionality.
+    /// the `--check-themes` functionality.
     pub static LIGHT: &'static str = include_str!("static/themes/light.css");
 
     /// The "dark" theme.

--- a/src/librustdoc/html/static_files.rs
+++ b/src/librustdoc/html/static_files.rs
@@ -59,7 +59,7 @@ pub static RUST_FAVICON: &'static [u8] = include_bytes!("static/favicon.ico");
 /// The built-in themes given to every documentation site.
 pub mod themes {
     /// The "light" theme, selected by default when no setting is available. Used as the basis for
-    /// the `--check-themes` functionality.
+    /// the `--check-theme` functionality.
     pub static LIGHT: &'static str = include_str!("static/themes/light.css");
 
     /// The "dark" theme.

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -256,8 +256,8 @@ fn opts() -> Vec<RustcOptGroup> {
                        "additional themes which will be added to the generated docs",
                        "FILES")
         }),
-        stable("check-theme", |o| {
-            o.optmulti("", "check-theme",
+        stable("check-themes", |o| {
+            o.optmulti("", "check-themes",
                        "check if given theme is valid",
                        "FILES")
         }),

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -256,8 +256,8 @@ fn opts() -> Vec<RustcOptGroup> {
                        "additional themes which will be added to the generated docs",
                        "FILES")
         }),
-        stable("theme-checker", |o| {
-            o.optmulti("", "theme-checker",
+        stable("check-theme", |o| {
+            o.optmulti("", "check-theme",
                        "check if given theme is valid",
                        "FILES")
         }),

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -251,12 +251,12 @@ fn opts() -> Vec<RustcOptGroup> {
             o.optflag("", "sort-modules-by-appearance", "sort modules by where they appear in the \
                                                          program, rather than alphabetically")
         }),
-        unstable("themes", |o| {
+        stable("themes", |o| {
             o.optmulti("", "themes",
                        "additional themes which will be added to the generated docs",
                        "FILES")
         }),
-        unstable("theme-checker", |o| {
+        stable("theme-checker", |o| {
             o.optmulti("", "theme-checker",
                        "check if given theme is valid",
                        "FILES")

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -251,13 +251,13 @@ fn opts() -> Vec<RustcOptGroup> {
             o.optflag("", "sort-modules-by-appearance", "sort modules by where they appear in the \
                                                          program, rather than alphabetically")
         }),
-        stable("themes", |o| {
-            o.optmulti("", "themes",
+        stable("theme", |o| {
+            o.optmulti("", "theme",
                        "additional themes which will be added to the generated docs",
                        "FILES")
         }),
-        stable("check-themes", |o| {
-            o.optmulti("", "check-themes",
+        stable("check-theme", |o| {
+            o.optmulti("", "check-theme",
                        "check if given theme is valid",
                        "FILES")
         }),

--- a/src/librustdoc/theme.rs
+++ b/src/librustdoc/theme.rs
@@ -273,6 +273,7 @@ pub fn test_theme_against<P: AsRef<Path>>(
     diag: &Handler,
 ) -> (bool, Vec<String>) {
     let data = try_something!(fs::read(f), diag, (false, vec![]));
+
     let paths = load_css_paths(&data);
     let mut ret = vec![];
     get_differences(against, &paths, &mut ret);

--- a/src/test/run-make-fulldeps/rustdoc-themes/Makefile
+++ b/src/test/run-make-fulldeps/rustdoc-themes/Makefile
@@ -7,3 +7,4 @@ OUTPUT_DIR := "$(TMPDIR)/rustdoc-themes"
 all:
 	cp $(S)/src/librustdoc/html/static/themes/light.css $(TMPDIR)/test.css
 	$(RUSTDOC) -o $(OUTPUT_DIR) foo.rs --theme $(TMPDIR)/test.css
+	$(HTMLDOCCK) $(OUTPUT_DIR) foo.rs

--- a/src/test/run-make-fulldeps/rustdoc-themes/Makefile
+++ b/src/test/run-make-fulldeps/rustdoc-themes/Makefile
@@ -7,4 +7,3 @@ OUTPUT_DIR := "$(TMPDIR)/rustdoc-themes"
 all:
 	cp $(S)/src/librustdoc/html/static/themes/light.css $(TMPDIR)/test.css
 	$(RUSTDOC) -o $(OUTPUT_DIR) foo.rs --theme $(TMPDIR)/test.css
-	$(HTMLDOCCK) $(OUTPUT_DIR) foo.rs

--- a/src/test/run-make-fulldeps/rustdoc-themes/Makefile
+++ b/src/test/run-make-fulldeps/rustdoc-themes/Makefile
@@ -1,0 +1,10 @@
+-include ../tools.mk
+
+# Test that rustdoc will properly load in a theme file and display it in the theme selector.
+
+OUTPUT_DIR := "$(TMPDIR)/rustdoc-themes"
+
+all:
+	cp $(S)/src/librustdoc/html/static/themes/light.css $(TMPDIR)/test.css
+	$(RUSTDOC) -o $(OUTPUT_DIR) foo.rs --themes $(TMPDIR)/test.css
+	$(HTMLDOCCK) $(OUTPUT_DIR) foo.rs

--- a/src/test/run-make-fulldeps/rustdoc-themes/Makefile
+++ b/src/test/run-make-fulldeps/rustdoc-themes/Makefile
@@ -6,5 +6,5 @@ OUTPUT_DIR := "$(TMPDIR)/rustdoc-themes"
 
 all:
 	cp $(S)/src/librustdoc/html/static/themes/light.css $(TMPDIR)/test.css
-	$(RUSTDOC) -o $(OUTPUT_DIR) foo.rs --themes $(TMPDIR)/test.css
+	$(RUSTDOC) -o $(OUTPUT_DIR) foo.rs --theme $(TMPDIR)/test.css
 	$(HTMLDOCCK) $(OUTPUT_DIR) foo.rs

--- a/src/test/run-make-fulldeps/rustdoc-themes/foo.rs
+++ b/src/test/run-make-fulldeps/rustdoc-themes/foo.rs
@@ -1,0 +1,4 @@
+// @has test.css
+// @has foo/struct.Foo.html
+// @has - '//link[@rel="stylesheet"]/@href' '../test.css'
+pub struct Foo;

--- a/src/test/run-make-fulldeps/tools.mk
+++ b/src/test/run-make-fulldeps/tools.mk
@@ -15,7 +15,7 @@ RUSTC := $(RUSTC) -Clinker=$(RUSTC_LINKER)
 RUSTDOC := $(RUSTDOC) -Clinker=$(RUSTC_LINKER)
 endif
 #CC := $(CC) -L $(TMPDIR)
-HTMLDOCCK := $(PYTHON) $(S)/src/etc/htmldocck.py
+HTMLDOCCK := '$(PYTHON)' '$(S)/src/etc/htmldocck.py'
 CGREP := "$(S)/src/etc/cat-and-grep.sh"
 
 # This is the name of the binary we will generate and run; use this

--- a/src/tools/rustdoc-themes/main.rs
+++ b/src/tools/rustdoc-themes/main.rs
@@ -40,7 +40,6 @@ fn main() {
     }
     let arg_name = "--check-theme".to_owned();
     let status = Command::new(rustdoc_bin)
-                        .args(&["-Z", "unstable-options"])
                         .args(&themes.iter()
                                      .flat_map(|t| vec![&arg_name, t].into_iter())
                                      .collect::<Vec<_>>())

--- a/src/tools/rustdoc-themes/main.rs
+++ b/src/tools/rustdoc-themes/main.rs
@@ -38,9 +38,12 @@ fn main() {
         eprintln!("No theme found in \"{}\"...", themes_folder);
         exit(1);
     }
+    let arg_name = "--check-theme".to_owned();
     let status = Command::new(rustdoc_bin)
-                        .args(&["-Z", "unstable-options", "--check-themes"])
-                        .args(&themes)
+                        .args(&["-Z", "unstable-options"])
+                        .args(&themes.iter()
+                                     .flat_map(|t| vec![&arg_name, t].into_iter())
+                                     .collect::<Vec<_>>())
                         .status()
                         .expect("failed to execute child");
     if !status.success() {

--- a/src/tools/rustdoc-themes/main.rs
+++ b/src/tools/rustdoc-themes/main.rs
@@ -39,7 +39,7 @@ fn main() {
         exit(1);
     }
     let status = Command::new(rustdoc_bin)
-                        .args(&["-Z", "unstable-options", "--theme-checker"])
+                        .args(&["-Z", "unstable-options", "--check-theme"])
                         .args(&themes)
                         .status()
                         .expect("failed to execute child");

--- a/src/tools/rustdoc-themes/main.rs
+++ b/src/tools/rustdoc-themes/main.rs
@@ -39,7 +39,7 @@ fn main() {
         exit(1);
     }
     let status = Command::new(rustdoc_bin)
-                        .args(&["-Z", "unstable-options", "--check-theme"])
+                        .args(&["-Z", "unstable-options", "--check-themes"])
                         .args(&themes)
                         .status()
                         .expect("failed to execute child");


### PR DESCRIPTION
Closes #54730

This PR stabilizes the `--themes` (now `--theme`) and `--theme-checker` (now `--check-theme`) options, for allowing users to add custom themes to their documentation.

Rustdoc includes two themes by default: `light` and `dark`. Using the `--theme` option, you can give rustdoc a CSS file to include as an extra theme for that render. Themes are named after the CSS file used, so using `--theme /path/to/your/custom-theme.css` will add a theme called `custom-theme` to the documentation.

Even though the CLI flag to add a theme is getting stabilized, there's no guarantee that a theme file will always have the same effect on documentation generated with future versions of rustdoc. To aid in ensuring that a theme will work, the flag `--check-theme` is also available, which compares the CSS rules defined by a custom theme against the ones used in the `light` theme. If the `light` theme defines a CSS rule that the custom theme does not, rustdoc will report an error. (Rustdoc also performs this check for themes given to `--theme`, but only reports a warning when a difference is found.)