### PR TITLE
Make spec_extend use for_each()

### DIFF
--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -1822,12 +1822,12 @@ impl<T, I> SpecExtend<T, I> for Vec<T>
             unsafe {
                 let mut ptr = self.as_mut_ptr().add(self.len());
                 let mut local_len = SetLenOnDrop::new(&mut self.len);
-                for element in iterator {
+                iterator.for_each(move |element| {
                     ptr::write(ptr, element);
                     ptr = ptr.offset(1);
                     // NB can't overflow since we would have had to alloc the address space
                     local_len.increment_len(1);
-                }
+                });
             }
         } else {
             self.extend_desugared(iterator)


### PR DESCRIPTION
`for_each` will use an iterator's own implementation of `try_fold`, which I understand to be generally preferable (because nested iterator adapter's will use each other's `try_fold` and be designed for the specific adaptation in a way that promotes performance and inlining.