### PR TITLE
Add examples to `TyKind::FnDef` and `TyKind::FnPtr` docs

### DIFF
--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -127,9 +127,26 @@ pub enum TyKind<'tcx> {
 
     /// The anonymous type of a function declaration/definition. Each
     /// function has a unique type.
+    ///
+    /// For example the type of `a` here:
+    ///
+    /// ```rust
+    /// fn foo() -> i32 { 1 }
+    ///
+    /// fn hello() {
+    ///     let a = foo;
+    /// }
+    /// ```
     FnDef(DefId, &'tcx Substs<'tcx>),
 
     /// A pointer to a function.  Written as `fn() -> i32`.
+    ///
+    /// For example the type of `a` here:
+    ///
+    /// ```rust
+    /// fn foo() -> i32 { 1 }
+    /// let a: fn() -> i32 = foo;
+    /// ```
     FnPtr(PolyFnSig<'tcx>),
 
     /// A trait, defined with `trait`.

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -126,26 +126,24 @@ pub enum TyKind<'tcx> {
     Ref(Region<'tcx>, Ty<'tcx>, hir::Mutability),
 
     /// The anonymous type of a function declaration/definition. Each
-    /// function has a unique type.
+    /// function has a unique type, which is output (for a function
+    /// named `foo` returning an `i32`) as `fn() -> i32 {foo}`.
     ///
-    /// For example the type of `a` here:
+    /// For example the type of `bar` here:
     ///
     /// ```rust
     /// fn foo() -> i32 { 1 }
-    ///
-    /// fn hello() {
-    ///     let a = foo;
-    /// }
+    /// let bar = foo; // bar: fn() -> i32 {foo}
     /// ```
     FnDef(DefId, &'tcx Substs<'tcx>),
 
     /// A pointer to a function.  Written as `fn() -> i32`.
     ///
-    /// For example the type of `a` here:
+    /// For example the type of `bar` here:
     ///
     /// ```rust
     /// fn foo() -> i32 { 1 }
-    /// let a: fn() -> i32 = foo;
+    /// let bar: fn() -> i32 = foo;
     /// ```
     FnPtr(PolyFnSig<'tcx>),
 


### PR DESCRIPTION
This adds two examples to the docs of `TyKind::FnDef` and `TyKind::FnPtr`.

I found these two types a bit confusing when I learned about them and I think adding these examples might help others.