### PR TITLE
Make the NonZero* methods const fn

### DIFF
--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -86,8 +86,9 @@ assert_eq!(size_of::<Option<std::num::", stringify!($Ty), ">>(), size_of::<", st
 
                 /// Returns the value as a primitive type.
                 #[stable(feature = "nonzero", since = "1.28.0")]
+                #[rustc_const_unstable(feature = "const_nonzero_methods")]
                 #[inline]
-                pub fn get(self) -> $Int {
+                pub const fn get(self) -> $Int {
                     self.0 .0
                 }
 

--- a/src/librustc/hir/def_id.rs
+++ b/src/librustc/hir/def_id.rs
@@ -48,7 +48,7 @@ impl ::std::fmt::Debug for CrateNum {
 
 /// Item definitions in the currently-compiled crate would have the CrateNum
 /// LOCAL_CRATE in their DefId.
-pub const LOCAL_CRATE: CrateNum = CrateNum::Index(CrateId::from_u32_const(0));
+pub const LOCAL_CRATE: CrateNum = CrateNum::Index(CrateId::from_u32(0));
 
 
 impl Idx for CrateNum {

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -70,6 +70,8 @@
 #![feature(macro_at_most_once_rep)]
 #![feature(crate_visibility_modifier)]
 #![feature(transpose_result)]
+#![feature(const_fn)]
+#![feature(const_nonzero_methods)]
 
 #![recursion_limit="512"]
 

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -1498,7 +1498,7 @@ newtype_index! {
 impl_stable_hash_for!(struct UniverseIndex { private });
 
 impl UniverseIndex {
-    pub const ROOT: UniverseIndex = UniverseIndex::from_u32_const(0);
+    pub const ROOT: UniverseIndex = UniverseIndex::from_u32(0);
 
     /// Returns the "next" universe index in order -- this new index
     /// is considered to extend all previous universes. This

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -1325,7 +1325,7 @@ impl DebruijnIndex {
     ///
     /// you would need to shift the index for `'a` into 1 new binder.
     #[must_use]
-    pub fn shifted_in(self, amount: u32) -> DebruijnIndex {
+    pub const fn shifted_in(self, amount: u32) -> DebruijnIndex {
         DebruijnIndex::from_u32(self.as_u32() + amount)
     }
 
@@ -1338,7 +1338,7 @@ impl DebruijnIndex {
     /// Returns the resulting index when this value is moved out from
     /// `amount` number of new binders.
     #[must_use]
-    pub fn shifted_out(self, amount: u32) -> DebruijnIndex {
+    pub const fn shifted_out(self, amount: u32) -> DebruijnIndex {
         DebruijnIndex::from_u32(self.as_u32() - amount)
     }
 

--- a/src/librustc_data_structures/indexed_vec.rs
+++ b/src/librustc_data_structures/indexed_vec.rs
@@ -101,7 +101,7 @@ macro_rules! newtype_index {
         #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, $($derives),*)]
         #[rustc_layout_scalar_valid_range_end($max)]
         $v struct $type {
-            private: ::std::num::NonZeroU32
+            private: u32
         }
 
         impl $type {
@@ -134,7 +134,7 @@ macro_rules! newtype_index {
 
             #[inline]
             $v const unsafe fn from_u32_unchecked(value: u32) -> Self {
-                $type { private: ::std::num::NonZeroU32::new_unchecked(value + 1) }
+                $type { private: value }
             }
 
             /// Extract value of this index as an integer.
@@ -146,7 +146,7 @@ macro_rules! newtype_index {
             /// Extract value of this index as a usize.
             #[inline]
             $v const fn as_u32(self) -> u32 {
-                self.private.get() - 1
+                self.private
             }
 
             /// Extract value of this index as a u32.

--- a/src/librustc_data_structures/lib.rs
+++ b/src/librustc_data_structures/lib.rs
@@ -29,6 +29,7 @@
 #![feature(nll)]
 #![feature(allow_internal_unstable)]
 #![feature(vec_resize_with)]
+#![feature(const_nonzero_methods)]
 
 #![cfg_attr(unix, feature(libc))]
 #![cfg_attr(test, feature(test))]

--- a/src/librustc_driver/test.rs
+++ b/src/librustc_driver/test.rs
@@ -199,13 +199,8 @@ fn test_env_with_pool<F>(
     );
 }
 
-fn d1() -> ty::DebruijnIndex {
-    ty::INNERMOST
-}
-
-fn d2() -> ty::DebruijnIndex {
-    d1().shifted_in(1)
-}
+const D1: ty::DebruijnIndex = ty::INNERMOST;
+const D2: ty::DebruijnIndex = D1.shifted_in(1);
 
 impl<'a, 'gcx, 'tcx> Env<'a, 'gcx, 'tcx> {
     pub fn tcx(&self) -> TyCtxt<'a, 'gcx, 'tcx> {
@@ -385,7 +380,7 @@ impl<'a, 'gcx, 'tcx> Env<'a, 'gcx, 'tcx> {
     }
 
     pub fn t_rptr_late_bound(&self, id: u32) -> Ty<'tcx> {
-        let r = self.re_late_bound_with_debruijn(id, d1());
+        let r = self.re_late_bound_with_debruijn(id, D1);
         self.infcx.tcx.mk_imm_ref(r, self.tcx().types.isize)
     }
 
@@ -559,7 +554,7 @@ fn subst_ty_renumber_bound() {
 
         // t_expected = fn(&'a isize)
         let t_expected = {
-            let t_ptr_bound2 = env.t_rptr_late_bound_with_debruijn(1, d2());
+            let t_ptr_bound2 = env.t_rptr_late_bound_with_debruijn(1, D2);
             env.t_fn(&[t_ptr_bound2], env.t_nil())
         };
 
@@ -595,7 +590,7 @@ fn subst_ty_renumber_some_bounds() {
         //
         // but not that the Debruijn index is different in the different cases.
         let t_expected = {
-            let t_rptr_bound2 = env.t_rptr_late_bound_with_debruijn(1, d2());
+            let t_rptr_bound2 = env.t_rptr_late_bound_with_debruijn(1, D2);
             env.t_pair(t_rptr_bound1, env.t_fn(&[t_rptr_bound2], env.t_nil()))
         };
 
@@ -621,11 +616,11 @@ fn escaping() {
         let t_rptr_free1 = env.t_rptr_free(1);
         assert!(!t_rptr_free1.has_escaping_bound_vars());
 
-        let t_rptr_bound1 = env.t_rptr_late_bound_with_debruijn(1, d1());
-        assert!(t_rptr_bound1.has_escaping_bound_vars());
+        let t_rptr_bound1 = env.t_rptr_late_bound_with_debruijn(1, D1);
+        assert!(t_rptr_bound1.has_escaping_regions());
 
-        let t_rptr_bound2 = env.t_rptr_late_bound_with_debruijn(1, d2());
-        assert!(t_rptr_bound2.has_escaping_bound_vars());
+        let t_rptr_bound2 = env.t_rptr_late_bound_with_debruijn(1, D2);
+        assert!(t_rptr_bound2.has_escaping_regions());
 
         // t_fn = fn(A)
         let t_param = env.t_param(0);
@@ -640,7 +635,7 @@ fn escaping() {
 #[test]
 fn subst_region_renumber_region() {
     test_env(EMPTY_SOURCE_STR, errors(&[]), |env| {
-        let re_bound1 = env.re_late_bound_with_debruijn(1, d1());
+        let re_bound1 = env.re_late_bound_with_debruijn(1, D1);
 
         // type t_source<'a> = fn(&'a isize)
         let t_source = {
@@ -655,7 +650,7 @@ fn subst_region_renumber_region() {
         //
         // but not that the Debruijn index is different in the different cases.
         let t_expected = {
-            let t_rptr_bound2 = env.t_rptr_late_bound_with_debruijn(1, d2());
+            let t_rptr_bound2 = env.t_rptr_late_bound_with_debruijn(1, D2);
             env.t_fn(&[t_rptr_bound2], env.t_nil())
         };
 

--- a/src/librustc_mir/lib.rs
+++ b/src/librustc_mir/lib.rs
@@ -38,6 +38,7 @@ Rust MIR: a lowered representation of Rust. Also: an experiment!
 #![feature(try_from)]
 #![feature(reverse_bits)]
 #![feature(underscore_imports)]
+#![feature(const_nonzero_methods)]
 
 #![recursion_limit="256"]
 

--- a/src/librustc_target/lib.rs
+++ b/src/librustc_target/lib.rs
@@ -24,6 +24,7 @@
 #![feature(box_syntax)]
 #![feature(nll)]
 #![feature(slice_patterns)]
+#![feature(const_fn)]
 
 #[macro_use]
 extern crate bitflags;

--- a/src/test/run-pass-fulldeps/newtype_index.rs
+++ b/src/test/run-pass-fulldeps/newtype_index.rs
@@ -1,4 +1,4 @@
-#![feature(rustc_attrs, rustc_private, step_trait)]
+#![feature(rustc_attrs, rustc_private, step_trait, const_fn)]
 
 #[macro_use] extern crate rustc_data_structures;
 extern crate rustc_serialize;

--- a/src/test/ui/consts/const-nonzero.rs
+++ b/src/test/ui/consts/const-nonzero.rs
@@ -1,0 +1,11 @@
+// compile-pass
+
+#![feature(const_nonzero_methods)]
+
+use std::num::NonZeroU8;
+
+const X: NonZeroU8 = unsafe { NonZeroU8::new_unchecked(5) };
+const Y: u8 = X.get();
+
+fn main() {
+}


### PR DESCRIPTION
- Makes the `get` method a `const fn`, with a regression test added. Enabled with `feature(const_nonzero_methods)`.
- Makes some methods in the `indexed_vec!` data structure `const fn`.
- Revert some `const` -> `fn` changes in #53315

Fixes #53331

r? @oli-obk 