### PR TITLE
Cleanup rustdoc tests with `@!has` and `@!matches`

### DIFF
--- a/src/test/rustdoc/deprecated-impls.rs
+++ b/src/test/rustdoc/deprecated-impls.rs
@@ -109,7 +109,7 @@ impl Bar for Foo2 {
 
     // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.5: fn_def_with_doc'
     // @has - 'fn_def_with_doc short'
-    // @!has - 'fn_def_with full'
+    // @!has - 'fn_def_with_doc full'
     fn fn_def_with_doc() {}
 
     // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.6: fn_def_without_doc'

--- a/src/test/rustdoc/dont-show-const-contents.rs
+++ b/src/test/rustdoc/dont-show-const-contents.rs
@@ -8,8 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Test that we HTML-escape Rust expressions, where HTML special chars
-// can occur, and we know it's definitely not markup.
+// Test that the contents of constants are not displayed as part of the
+// documentation.
 
-// @!has escape_rust_expr/constant.CONST_S.html '//pre[@class="rust const"]' '"<script>"'
-pub const CONST_S: &'static str = "<script>";
+// @!has dont_show_const_contents/constant.CONST_S.html 'dont show this'
+pub const CONST_S: &'static str = "dont show this";

--- a/src/test/rustdoc/empty-section.rs
+++ b/src/test/rustdoc/empty-section.rs
@@ -15,6 +15,6 @@
 pub struct Foo;
 
 // @has foo/struct.Foo.html
-// @!has - '//*[@class="synthetic-implementations"]' 'Auto Trait Implementations'
+// @!has - 'Auto Trait Implementations'
 impl !Send for Foo {}
 impl !Sync for Foo {}

--- a/src/test/rustdoc/hidden-methods.rs
+++ b/src/test/rustdoc/hidden-methods.rs
@@ -28,12 +28,12 @@ pub mod hidden {
 
 // @has foo/struct.Foo.html
 // @!has - 'Methods'
-// @!has - 'impl Foo'
+// @!has - '//code' 'impl Foo'
 // @!has - 'this_should_be_hidden'
 pub use hidden::Foo;
 
 // @has foo/struct.Bar.html
 // @!has - 'Methods'
-// @!has - 'impl Bar'
+// @!has - '//code' 'impl Bar'
 // @!has - 'this_should_be_hidden'
 pub use hidden::Bar;

--- a/src/test/rustdoc/issue-13698.rs
+++ b/src/test/rustdoc/issue-13698.rs
@@ -22,5 +22,5 @@ pub trait Bar {
     fn bar(&self) {}
 }
 
-// @!has issue_13698/struct.Foo.html '//*[@id="method.foo"]' 'fn bar'
+// @!has issue_13698/struct.Foo.html '//*[@id="method.bar"]' 'fn bar'
 impl Bar for Foo {}

--- a/src/test/rustdoc/issue-46767.rs
+++ b/src/test/rustdoc/issue-46767.rs
@@ -15,4 +15,5 @@ mod private {
 }
 pub use self::private::Enum::*;
 
-// @!has foo/index.html '//a/@href' './private/index.html'
+// @!has-dir foo/private
+// @!has foo/index.html '//a/@href' 'private/index.html'

--- a/src/test/rustdoc/manual_impl.rs
+++ b/src/test/rustdoc/manual_impl.rs
@@ -35,7 +35,6 @@ pub trait T {
 // @has  - '//*[@class="docblock"]' 'Docs associated with the S1 trait a_method implementation.'
 // @!has - '//*[@class="docblock"]' 'Docs associated with the trait a_method definition.'
 // @has - '//*[@class="docblock"]' 'Docs associated with the trait b_method definition.'
-// @has - '//*[@class="docblock"]' 'Docs associated with the trait b_method definition.'
 // @has - '//*[@class="docblock"]' 'Docs associated with the trait c_method definition.'
 // @!has - '//*[@class="docblock"]' 'There is another line'
 // @has - '//*[@class="docblock"]' 'Read more'

--- a/src/test/rustdoc/playground-empty.rs
+++ b/src/test/rustdoc/playground-empty.rs
@@ -12,6 +12,8 @@
 
 #![doc(html_playground_url = "")]
 
+// compile-flags:-Z unstable-options --playground-url https://play.rust-lang.org/
+
 //! module docs
 //!
 //! ```

--- a/src/test/rustdoc/redirect.rs
+++ b/src/test/rustdoc/redirect.rs
@@ -43,6 +43,7 @@ mod private_no_inline {
 
 // @has redirect/index.html
 // @has - '//code' 'pub use private_no_inline::Qux'
-// @!has - '//code/a' 'Qux'
+// @!has - '//a' 'Qux'
+// @!has redirect/struct.Qux.html
 #[doc(no_inline)]
 pub use private_no_inline::Qux;

--- a/src/test/rustdoc/unneeded-trait-implementations-title.rs
+++ b/src/test/rustdoc/unneeded-trait-implementations-title.rs
@@ -12,4 +12,4 @@
 
 pub struct Bar;
 
-// @!has foo/struct.Bar.html '//*[@id="implementations"]'
+// @count foo/struct.Bar.html '//*[@id="implementations"]' 0


### PR DESCRIPTION
Fixes #49713

Here's a _long_ list of all the places that include `@!has`. I have marked the ones I have looked at so far.

 - [x] search-index.rs:        fn priv_method() {} // @!has - priv_method
 - [x] search-index.rs:        fn trait_method(&self) {} // @!has - priv_method
 - [x] search-index.rs:    // @!has search-index.js Target
 - [x] short-dockblock.rs:// @!has foo/index.html '//*[@class="docblock-short"]/p/h1' 'fooo'
 - [x] short-dockblock.rs:// @!has foo/index.html '//*[@class="docblock-short"]/p/h2' 'mooood'
 - [x] keyword.rs:// @!has foo/index.html '//a/@href' 'foo/index.html'
 - [x] keyword.rs:// @!has foo/foo/index.html
 - [x] keyword.rs:// @!has-dir foo/foo
 - [x] issue-46380-2.rs:// @!has - '//*[@class="impl"]' 'impl PublicTrait<PrivateStruct> for PublicStruct' 
 - [x] escape-rust-expr.rs:// @!has escape_rust_expr/constant.CONST_S.html '//pre[@class="rust const"]' '"<script>"'
 - [x] issue-33069.rs:// @!has - '//code' 'impl Bar for Foo'
 - [x] playground-empty.rs:// @!has foo/index.html '//a[@class="test-arrow"]' "Run"
 - [x] issue-34473.rs:// @!has - SomeTypeWithLongName
 - [x] issue-34473.rs:// @!has - SomeTypeWithLongName
 - [x] issue-34473.rs:// @!has foo/struct.SomeTypeWithLongName.html
 - [x] issue-29584.rs:// @!has - 'impl Bar for'
 - [x] hidden-line.rs:// @!has hidden_line/fn.foo.html invisible
 - [x] manual_impl.rs:// @!has - '//*[@class="docblock"]' 'Docs associated with the trait a_method definition.'
 - [x] manual_impl.rs:// @!has - '//*[@class="docblock"]' 'There is another line'
 - [x] manual_impl.rs:// @!has - '//*[@class="docblock"]' 'Docs associated with the trait a_method definition.'
 - [x] manual_impl.rs:// @!has - '//*[@class="docblock"]' 'Docs associated with the trait c_method definition.'
 - [x] issue-19190-2.rs:// @!has - '//*[@id="method.new"]' 'fn new() -> String'
 - [x] unneeded-trait-implementations-title.rs:// @!has foo/struct.Bar.html '//*[@id="implementations"]'
 - [x] masked.rs:// @!has 'search-index.js' 'masked_method'
 - [x] masked.rs:// @!has 'foo/struct.String.html' 'MaskedTrait'
 - [x] masked.rs:// @!has 'foo/struct.String.html' 'masked_method'
 - [x] masked.rs:// @!has 'foo/trait.Clone.html' 'MaskedStruct'
 - [x] masked.rs:// @!has 'foo/struct.MyStruct.html' 'MaskedTrait'
 - [x] masked.rs:// @!has 'foo/struct.MyStruct.html' 'masked_method'
 - [x] masked.rs:// @!has 'foo/trait.MyTrait.html' 'MaskedStruct'
 - [x] redirect.rs:// @!has - '//code/a' 'Qux'
 - [x] issue-43701.rs:// @!has implementors/core/clone/trait.Clone.js
 - [x] union.rs:    // @!has - //pre "b: u16"
 - [x] prim-title.rs:// @!has - '//head/title' 'foo'
 - [x] empty-section.rs:// @!has - '//*[@class="synthetic-implementations"]' 'Auto Trait Implementations'
 - [x] traits-in-bodies-private.rs:// @!has - '//code' 'impl HiddenTrait for SomeStruct'
 - [x] playground-none.rs:// @!has foo/index.html '//a[@class="test-arrow"]' "Run"
 - [x] issue-34025.rs:// @!has 'foo/sys/index.html'
 - [x] issue-34025.rs:// @!has 'foo/sys/sidebar-items.js'
 - [x] issue-34025.rs:        // @!has 'foo/sys/fn.foo.html'
 - [x] issue-23812.rs:// @!has - '/// Outer comment'
 - [x] issue-23812.rs:// @!has - '//! Inner comment'
 - [x] issue-23812.rs:// @!has - '/** Outer block comment */'
 - [x] issue-23812.rs:// @!has - '/*! Inner block comment */'
 - [x] pub-use-extern-macros.rs:// @!has pub_use_extern_macros/index.html '//code' 'pub use macros::bar;'
 - [x] pub-use-extern-macros.rs:// @!has pub_use_extern_macros/index.html '//code' 'pub use macros::baz;'
 - [x] pub-use-extern-macros.rs:// @!has pub_use_extern_macros/macro.quux.html
 - [x] pub-use-extern-macros.rs:// @!has pub_use_extern_macros/index.html '//code' 'pub use macros::quux;'
 - [x] issue-26606.rs:// @!has - '//a/@href' '../src/'
 - [x] foreigntype-reexport.rs:// @!has foreigntype_reexport/foreigntype.X4.html
 - [x] foreigntype-reexport.rs:// @!has foreigntype_reexport/index.html '//a[@class="foreigntype"]' 'X4'
 - [x] issue-31899.rs:// @!has - 'rust rust-example-rendered'
 - [x] issue-31899.rs:// @!has - 'use ndarray::arr2'
 - [x] issue-31899.rs:// @!has - 'prohibited'
 - [x] hidden-trait-struct-impls.rs:// @!has foo/struct.Bar.html '//*[@id="impl-Foo"]' 'impl Foo for Bar'
 - [x] hidden-trait-struct-impls.rs:// @!has foo/struct.Bar.html '//*[@id="impl-Dark"]' 'impl Dark for Bar'
 - [x] hidden-trait-struct-impls.rs:// @!has foo/trait.Bam.html '//*[@id="implementors-list"]' 'impl Bam for Hidden'
 - [x] hidden-impls.rs:// @!has - 'Foo'
 - [x] hidden-impls.rs:// @!has - 'Foo'
 - [x] module-impls.rs:// @!has foo/index.html 'Implementations'
 - [x] issue-35169.rs:// @!has - '//*[@id="by_mut_ref.v"]' 'fn by_mut_ref(&mut self)'
 - [x] issue-35169.rs:// @!has - '//*[@id="method.by_mut_ref"]' 'fn by_mut_ref(&mut self)'
 - [x] issue-35169.rs:// @!has - '//*[@id="by_explicit_mut_ref.v"]' 'fn by_explicit_mut_ref(self: &mut Foo)'
 - [x] issue-35169.rs:// @!has - '//*[@id="method.by_explicit_mut_ref"]' 'fn by_explicit_mut_ref(self: &mut Foo)'
 - [x] issue-35169.rs:// @!has - '//*[@id="by_explicit_box.v"]' 'fn by_explicit_box(self: Box<Foo>)'
 - [x] issue-35169.rs:// @!has - '//*[@id="method.by_explicit_box"]' 'fn by_explicit_box(self: Box<Foo>)'
 - [x] issue-35169.rs:// @!has - '//*[@id="by_explicit_self_box.v"]' 'fn by_explicit_self_box(self: Box<Self>)'
 - [x] issue-35169.rs:// @!has - '//*[@id="method.by_explicit_self_box"]' 'fn by_explicit_self_box(self: Box<Self>)'
 - [x] issue-35169.rs:// @!has - '//*[@id="static_foo.v"]' 'fn static_foo()'
 - [x] issue-35169.rs:// @!has - '//*[@id="method.static_foo"]' 'fn static_foo()'
 - [x] extern-links.rs:// @!has foo/index.html '//a' 'extern_links'
 - [x] extern-links.rs:// @!has foo/index.html '//a' 'Foo'
 - [x] extern-links.rs:    // @!has foo/hidden/extern_links/index.html
 - [x] extern-links.rs:    // @!has foo/hidden/extern_links/struct.Foo.html
 - [x] issue-33178-1.rs:// @!has - //a/@title empty
 - [x] issue-33178-1.rs:// @!has - //a/@title variant_struct
 - [x] issue-47038.rs:// @!has - '//*[@id="macros"]' 'Macros'
 - [x] issue-47038.rs:// @!has - '//a/@href' 'macro.vec.html'
 - [x] issue-47038.rs:// @!has 'foo/macro.vec.html'
 - [x] issue-46766.rs:// @!has foo/index.html '//a/@href' './Enum/index.html'
 - [x] issue-32395.rs:// @!has - 'pub qux'
 - [x] issue-32395.rs:// @!has - 'pub Bar'
 - [x] issue-32395.rs:// @!has - 'pub qux'
 - [x] issue-32395.rs:// @!has - 'pub Bar'
 - [x] hidden-methods.rs:// @!has - 'Methods'
 - [x] hidden-methods.rs:// @!has - 'impl Foo'
 - [x] hidden-methods.rs:// @!has - 'this_should_be_hidden'
 - [x] hidden-methods.rs:// @!has - 'Methods'
 - [x] hidden-methods.rs:// @!has - 'impl Bar'
 - [x] hidden-methods.rs:// @!has - 'this_should_be_hidden'
 - [x] structfields.rs:    // @!has - //pre "b: ()"
 - [x] structfields.rs:    // @!has - //pre "c: usize"
 - [x] structfields.rs:    // @!has - //pre "// some fields omitted"
 - [x] structfields.rs:        // @!has - //pre "b: ()"
 - [x] issue-46767.rs:// @!has foo/index.html '//a/@href' './private/index.html'
 - [x] assoc-consts.rs:    // @!has - FOO_HIDDEN
 - [x] assoc-consts.rs:    // @!has - FOO_HIDDEN
 - [x] assoc-consts.rs:    // @!has assoc_consts/struct.Bar.html 'BAR_PRIVATE'
 - [x] assoc-consts.rs:    // @!has assoc_consts/struct.Bar.html 'BAR_HIDDEN'
 - [x] issue-53689.rs:// @!has - 'MyStruct'
 - [x] search-index-summaries.rs:// @!has - 'www.example.com'
 - [x] search-index-summaries.rs:// @!has - 'More Foo.'
 - [x] impl-everywhere.rs:// @!has foo/fn.foo.html '//section[@id="main"]//pre' "x: &\'x impl Foo"
 - [x] impl-everywhere.rs:// @!has foo/fn.foo.html '//section[@id="main"]//pre' "-> &\'x impl Foo {"
 - [x] impl-everywhere.rs:// @!has foo/fn.foo2.html '//section[@id="main"]//pre' "x: &\'x impl Foo"
 - [x] impl-everywhere.rs:// @!has foo/fn.foo2.html '//section[@id="main"]//pre' '-> impl Foo2 {'
 - [x] impl-everywhere.rs:// @!has foo/fn.foo_foo.html '//section[@id="main"]//pre' '-> impl Foo + Foo2 {'
 - [x] impl-everywhere.rs:// @!has foo/fn.foo2.html '//section[@id="main"]//pre' "x: &'x (impl Foo + Foo2)"
 - [x] issue-19190.rs:// @!has - '//*[@id="static_foo.v"]' 'fn static_foo()'
 - [x] issue-19190.rs:// @!has - '//*[@id="method.static_foo"]' 'fn static_foo()'
 - [x] deprecated-impls.rs:    // @!has - 'fn_def_def_with_doc full'
 - [x] deprecated-impls.rs:    // @!has - 'fn_empty_with_doc full'
 - [x] deprecated-impls.rs:    // @!has - 'fn_def_with full'
 - [x] deprecated-impls.rs:    // @!has - 'fn_def_def_with_doc full'
 - [x] issue-19190-3.rs:// @!has - '//*[@id="method.new"]' 'fn new() -> String'
 - [x] issue-19190-3.rs:// @!has - '//*[@id="method.static_baz"]' 'fn static_baz()'
 - [x] issue-19190-3.rs:// @!has - '//*[@id="method.static_baz"]' 'fn static_baz()'
 - [x] sidebar-items.rs:// @!has - '//*[@class="sidebar-links"]/a' 'waza'
 - [x] sidebar-items.rs:// @!has - '//*[@class="sidebar-links"]/a' 'waza'
 - [x] issue-27104.rs:// @!has - 'extern crate std'
 - [x] issue-27104.rs:// @!has - 'use std::prelude::'
 - [x] issue-13698.rs:// @!has issue_13698/struct.Foo.html '//*[@id="method.foo"]' 'fn foo'
 - [x] issue-13698.rs:// @!has issue_13698/struct.Foo.html '//*[@id="method.foo"]' 'fn bar'
 - [x] issue-41783.rs:// @!has - 'space'
 - [x] issue-41783.rs:// @!has - 'comment'
 - [x] trait-self-link.rs:// @!has trait_self_link/trait.Foo.html //a/@href ../trait_self_link/trait.Foo.html
 - [x] generic-impl.rs:// @!has foo/struct.Bar.html '//h3[@id="impl-ToString"]//code' 'impl<T> ToString for T'
 - [x] all.rs:// @!has foo/all.html 'private_module'
 - [x] issue-35169-2.rs:// @!has - '//*[@id="by_explicit_box.v"]' 'fn by_explicit_box(self: Box<Foo>)'
 - [x] issue-35169-2.rs:// @!has - '//*[@id="method.by_explicit_box"]' 'fn by_explicit_box(self: Box<Foo>)'
 - [x] issue-35169-2.rs:// @!has - '//*[@id="by_explicit_self_box.v"]' 'fn by_explicit_self_box(self: Box<Self>)'
 - [x] issue-35169-2.rs:// @!has - '//*[@id="method.by_explicit_self_box"]' 'fn by_explicit_self_box(self: Box<Self>)'
 - [x] issue-35169-2.rs:// @!has - '//*[@id="static_foo.v"]' 'fn static_foo()'
 - [x] issue-35169-2.rs:// @!has - '//*[@id="method.static_foo"]' 'fn static_foo()'
 - [x] doc-cfg.rs:// @!has - '//*[@id="main"]/*[@class="stability"]/*[@class="stab portability"]' ''
 - [x] inline_local/glob-private.rs:// @!has - "mod1"
 - [x] inline_local/glob-private.rs:// @!has - "Mod1Private"
 - [x] inline_local/glob-private.rs:// @!has - "mod2"
 - [x] inline_local/glob-private.rs:// @!has - "Mod2Private"
 - [x] inline_local/glob-private.rs:// @!has foo/struct.Mod1Private.html
 - [x] inline_local/glob-private.rs:// @!has foo/struct.Mod2Private.html
 - [x] inline_local/glob-private.rs:// @!has foo/mod1/index.html
 - [x] inline_local/glob-private.rs:// @!has foo/mod1/struct.Mod1Private.html
 - [x] inline_local/glob-private.rs:// @!has foo/mod1/struct.Mod2Public.html
 - [x] inline_local/glob-private.rs:// @!has foo/mod1/struct.Mod2Private.html
 - [x] inline_local/glob-private.rs:// @!has foo/mod1/mod2/index.html
 - [x] inline_local/glob-private.rs:// @!has foo/mod1/mod2/struct.Mod2Private.html
 - [x] inline_local/glob-private.rs:// @!has-dir foo/mod2
 - [x] inline_local/glob-private.rs:// @!has foo/mod2/index.html
 - [x] inline_local/glob-private.rs:// @!has foo/mod2/struct.Mod2Public.html
 - [x] inline_local/glob-private.rs:// @!has foo/mod2/struct.Mod2Private.html
 - [x] inline_local/hidden-use.rs:// @!has - 'private'
 - [x] inline_local/hidden-use.rs:// @!has - 'Foo'
 - [x] inline_local/hidden-use.rs:// @!has hidden_use/struct.Foo.html
 - [x] inline_local/glob-extern-no-defaults.rs:// @!has - "private_fn"
 - [x] inline_local/glob-extern-no-defaults.rs:// @!has foo/fn.private_fn.html
 - [x] inline_local/issue-32343.rs:// @!has issue_32343/struct.Foo.html
 - [x] inline_local/issue-32343.rs:// @!has - '//code/a' 'Foo'
 - [x] inline_local/issue-32343.rs:// @!has issue_32343/struct.Bar.html
 - [x] inline_local/glob-private-no-defaults.rs:// @!has - "Mod1Private"
 - [x] inline_local/glob-private-no-defaults.rs:// @!has - "mod2"
 - [x] inline_local/glob-private-no-defaults.rs:// @!has - "Mod2Private"
 - [x] inline_local/glob-private-no-defaults.rs:// @!has foo/struct.Mod1Private.html
 - [x] inline_local/glob-private-no-defaults.rs:// @!has foo/struct.Mod2Private.html
 - [x] inline_local/glob-private-no-defaults.rs:// @!has - "Mod2Public"
 - [x] inline_local/glob-private-no-defaults.rs:// @!has - "Mod2Private"
 - [x] inline_local/glob-private-no-defaults.rs:// @!has foo/mod1/struct.Mod2Public.html
 - [x] inline_local/glob-private-no-defaults.rs:// @!has foo/mod1/struct.Mod2Private.html
 - [x] inline_local/glob-private-no-defaults.rs:// @!has foo/mod2/index.html
 - [x] inline_local/glob-private-no-defaults.rs:// @!has foo/mod2/struct.Mod2Public.html
 - [x] inline_local/glob-private-no-defaults.rs:// @!has foo/mod2/struct.Mod2Private.html
 - [x] inline_local/glob-extern.rs:// @!has - "mod1"
 - [x] inline_local/glob-extern.rs:// @!has - "private_fn"
 - [x] inline_local/glob-extern.rs:// @!has foo/fn.private_fn.html
 - [x] inline_local/glob-extern.rs:// @!has foo/mod1/index.html
 - [x] inline_local/glob-extern.rs:// @!has foo/mod1/fn.private_fn.html
 - [x] inline_local/please_inline.rs:    // @!has - 'pub use foo::'
 - [x] inline_local/please_inline.rs:    // @!has please_inline/b/struct.Foo.html
 - [x] inline_cross/hidden-use.rs:// @!has - 'rustdoc_hidden'
 - [x] inline_cross/hidden-use.rs:// @!has - 'Bar'
 - [x] inline_cross/hidden-use.rs:// @!has hidden_use/struct.Bar.html
 - [x] inline_cross/inline_hidden.rs:// @!has - '//a/@title' 'Foo'
 - [x] inline_cross/assoc-items.rs:// @!has - 'PrivateConst'
 - [x] inline_cross/assoc-items.rs:// @!has - 'private_method'
 - [x] inline_cross/cross-glob.rs:// @!has cross_glob/index.html '//code' 'pub use inner::*;'
 - [x] inline_cross/macro-vis.rs:// @!has - '//pre' 'some_macro'
 - [x] inline_cross/macro-vis.rs:// @!has macro_vis/macro.other_macro.html
 - [x] inline_cross/macro-vis.rs:// @!has macro_vis/index.html '//a/@href' 'macro.other_macro.html'
 - [x] inline_cross/macro-vis.rs:// @!has - '//code' 'pub use qwop::other_macro;'
 - [x] inline_cross/macro-vis.rs:// @!has macro_vis/macro.super_macro.html
 - [x] inline_cross/issue-31948.rs:// @!has - '//*[@class="impl"]//code' 'Bar for'
 - [x] inline_cross/issue-31948.rs:// @!has - '//*[@class="impl"]//code' 'Qux for'
 - [x] inline_cross/issue-31948.rs:// @!has - '//code' 'for Wibble'
 - [x] inline_cross/issue-31948.rs:// @!has - '//code' 'for Wobble'
 - [x] inline_cross/issue-31948.rs:// @!has - '//code' 'for Wibble'
 - [x] inline_cross/issue-31948.rs:// @!has - '//code' 'for Wobble'
 - [x] inline_cross/issue-31948.rs:// @!has issue_31948/trait.Bar.html
 - [x] inline_cross/issue-31948.rs:// @!has issue_31948/trait.Qux.html
 - [x] inline_cross/issue-31948.rs:// @!has issue_31948/struct.Wibble.html
 - [x] inline_cross/issue-31948.rs:// @!has issue_31948/struct.Wobble.html
 - [x] inline_cross/issue-31948-1.rs:// @!has - '//*[@class="impl"]//code' 'Bar for'
 - [x] inline_cross/issue-31948-1.rs:// @!has - '//*[@class="impl"]//code' 'Qux for'
 - [x] inline_cross/issue-31948-1.rs:// @!has - '//code' 'for Wibble'
 - [x] inline_cross/issue-31948-1.rs:// @!has - '//code' 'for Wibble'
 - [x] inline_cross/issue-31948-1.rs:// @!has issue_31948_1/trait.Bar.html
 - [x] inline_cross/issue-31948-1.rs:// @!has issue_31948_1/trait.Qux.html
 - [x] inline_cross/issue-28480.rs:// @!has -  '//a/@title' 'Hidden'
 - [x] inline_cross/issue-28480.rs:// @!has -  '//a/@title' 'Hidden'
 - [x] inline_cross/issue-31948-2.rs:// @!has - '//*[@class="impl"]//code' 'Bar for'
 - [x] inline_cross/issue-31948-2.rs:// @!has issue_31948_2/trait.Bar.html
 - [x] inline_cross/issue-31948-2.rs:// @!has issue_31948_2/trait.Woof.html
 - [x] inline_cross/issue-31948-2.rs:// @!has issue_31948_2/trait.Bark.html

It doesn't look like `@!matches` is used anywhere.