### PR TITLE
NLL says "borrowed content" instead of more precise "dereference of raw pointer"

### DIFF
--- a/src/test/ui/borrowck/borrowck-move-from-unsafe-ptr.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-move-from-unsafe-ptr.nll.stderr
@@ -1,10 +1,10 @@
-error[E0507]: cannot move out of borrowed content
+error[E0507]: cannot move out of dereference of raw pointer
   --> $DIR/borrowck-move-from-unsafe-ptr.rs:13:13
    |
 LL |     let y = *x; //~ ERROR cannot move out of dereference of raw pointer
    |             ^^
    |             |
-   |             cannot move out of borrowed content
+   |             cannot move out of dereference of raw pointer
    |             help: consider removing the `*`: `x`
 
 error: aborting due to previous error

--- a/src/test/ui/issues/issue-20801.nll.stderr
+++ b/src/test/ui/issues/issue-20801.nll.stderr
@@ -16,22 +16,22 @@ LL |     let b = unsafe { *imm_ref() };
    |                      cannot move out of borrowed content
    |                      help: consider removing the `*`: `imm_ref()`
 
-error[E0507]: cannot move out of borrowed content
+error[E0507]: cannot move out of dereference of raw pointer
   --> $DIR/issue-20801.rs:42:22
    |
 LL |     let c = unsafe { *mut_ptr() };
    |                      ^^^^^^^^^^
    |                      |
-   |                      cannot move out of borrowed content
+   |                      cannot move out of dereference of raw pointer
    |                      help: consider removing the `*`: `mut_ptr()`
 
-error[E0507]: cannot move out of borrowed content
+error[E0507]: cannot move out of dereference of raw pointer
   --> $DIR/issue-20801.rs:45:22
    |
 LL |     let d = unsafe { *const_ptr() };
    |                      ^^^^^^^^^^^^
    |                      |
-   |                      cannot move out of borrowed content
+   |                      cannot move out of dereference of raw pointer
    |                      help: consider removing the `*`: `const_ptr()`
 
 error: aborting due to 4 previous errors


### PR DESCRIPTION
Part of #52663.

Previously, move errors involving the dereference of a raw pointer would
say "borrowed content". This commit changes it to say "dereference of
raw pointer".

r? @nikomatsakis 
cc @pnkfelix 