### PR TITLE
Make core::mem::MaybeUninit::zeroed a const fn

### DIFF
--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -128,6 +128,7 @@
 #![feature(const_transmute)]
 #![feature(reverse_bits)]
 #![feature(non_exhaustive)]
+#![cfg_attr(not(stage0), feature(const_write_bytes))]
 
 #[prelude_import]
 #[allow(unused)]

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -1040,8 +1040,24 @@ impl<T> MaybeUninit<T> {
     /// It is your responsibility to make sure `T` gets dropped if it got initialized.
     #[unstable(feature = "maybe_uninit", issue = "53491")]
     #[rustc_const_unstable(feature = "const_maybe_uninit_zeroed")]
+    #[cfg(not(stage0))]
     pub const fn zeroed() -> MaybeUninit<T> {
-        MaybeUninit { value: unsafe { intrinsics::init() } }
+        let mut u = MaybeUninit::<T>::uninitialized();
+        unsafe {
+            (&mut *u.value as *mut T).write_bytes(0u8, 1);
+        }
+        u
+    }
+
+    #[unstable(feature = "maybe_uninit", issue = "53491")]
+    #[cfg(stage0)]
+    /// Ceci n'est pas la documentation
+    pub fn zeroed() -> MaybeUninit<T> {
+        let mut u = MaybeUninit::<T>::uninitialized();
+        unsafe {
+            u.as_mut_ptr().write_bytes(0u8, 1);
+        }
+        u
     }
 
     /// Set the value of the `MaybeUninit`. This overwrites any previous value without dropping it.

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -1039,6 +1039,14 @@ impl<T> MaybeUninit<T> {
     /// Note that dropping a `MaybeUninit` will never call `T`'s drop code.
     /// It is your responsibility to make sure `T` gets dropped if it got initialized.
     #[unstable(feature = "maybe_uninit", issue = "53491")]
+    #[cfg(not(stage0))]
+    pub const fn zeroed() -> MaybeUninit<T> {
+        MaybeUninit { value: unsafe { intrinsics::init() } }
+    }
+
+    #[unstable(feature = "maybe_uninit", issue = "53491")]
+    #[cfg(stage0)]
+    /// Ceci n'est pas la documentation
     pub fn zeroed() -> MaybeUninit<T> {
         let mut u = MaybeUninit::<T>::uninitialized();
         unsafe {

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -1039,20 +1039,9 @@ impl<T> MaybeUninit<T> {
     /// Note that dropping a `MaybeUninit` will never call `T`'s drop code.
     /// It is your responsibility to make sure `T` gets dropped if it got initialized.
     #[unstable(feature = "maybe_uninit", issue = "53491")]
-    #[cfg(not(stage0))]
+    #[rustc_const_unstable(feature = "const_maybe_uninit_zeroed")]
     pub const fn zeroed() -> MaybeUninit<T> {
         MaybeUninit { value: unsafe { intrinsics::init() } }
-    }
-
-    #[unstable(feature = "maybe_uninit", issue = "53491")]
-    #[cfg(stage0)]
-    /// Ceci n'est pas la documentation
-    pub fn zeroed() -> MaybeUninit<T> {
-        let mut u = MaybeUninit::<T>::uninitialized();
-        unsafe {
-            u.as_mut_ptr().write_bytes(0u8, 1);
-        }
-        u
     }
 
     /// Set the value of the `MaybeUninit`. This overwrites any previous value without dropping it.

--- a/src/librustc_mir/interpret/intrinsics.rs
+++ b/src/librustc_mir/interpret/intrinsics.rs
@@ -150,6 +150,9 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
                 }
                 self.write_scalar(val, dest)?;
             }
+            "init" => {
+                self.force_allocation(dest)?;
+            }
             "transmute" => {
                 // Go through an allocation, to make sure the completely different layouts
                 // do not pose a problem.  (When the user transmutes through a union,

--- a/src/librustc_mir/interpret/intrinsics.rs
+++ b/src/librustc_mir/interpret/intrinsics.rs
@@ -151,8 +151,9 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
                 self.write_scalar(val, dest)?;
             }
             "init" => {
-                // Check fast path: we don't want to force an allocation in case the destination is a simple value,
-                // but we also do not want to create a new allocation with 0s and then copy that over.
+                // Check fast path: we don't want to force an allocation in case the destination is
+                // a simple value, but we also do not want to create a new allocation with 0s and
+                // then copy that over.
                 if !dest.layout.is_zst() { // notzhing to do for ZST
                     match dest.layout.abi {
                         layout::Abi::Scalar(ref s) => {

--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -839,6 +839,7 @@ impl<'a, 'tcx> Visitor<'tcx> for Qualifier<'a, 'tcx, 'tcx> {
                             | "add_with_overflow"
                             | "sub_with_overflow"
                             | "mul_with_overflow"
+                            | "init"
                             // no need to check feature gates, intrinsics are only callable from the
                             // libstd or with forever unstable feature gates
                             => is_const_fn = true,

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -243,6 +243,9 @@ declare_features! (
     // Allows panicking during const eval (produces compile-time errors)
     (active, const_panic, "1.30.0", Some(51999), None),
 
+    // Allows writing repeated bytes to a pointer during const eval.
+    (active, const_write_bytes, "1.31.0", Some(53491), None),
+
     // Allows using #[prelude_import] on glob `use` items.
     //
     // rustc internal

--- a/src/test/run-pass/const-maybe-init-zeroed.rs
+++ b/src/test/run-pass/const-maybe-init-zeroed.rs
@@ -7,7 +7,7 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-#![feature(maybe_uninit)]
+#![feature(maybe_uninit, const_maybe_uninit_zeroed)]
 
 use std::mem;
 

--- a/src/test/run-pass/const-maybe-init-zeroed.rs
+++ b/src/test/run-pass/const-maybe-init-zeroed.rs
@@ -1,0 +1,26 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+#![feature(maybe_uninit)]
+
+use std::mem;
+
+fn main() {
+    const UNIT: mem::MaybeUninit<()> = mem::MaybeUninit::zeroed();
+    let bytes: [u8; 0] = unsafe { mem::transmute(UNIT) };
+    assert_eq!(bytes, [0u8; 0]);
+
+    const STRING: mem::MaybeUninit<String> = mem::MaybeUninit::zeroed();
+    let bytes: [u8; mem::size_of::<String>()] = unsafe { mem::transmute(STRING) };
+    assert_eq!(bytes, [0u8; mem::size_of::<String>()]);
+
+    const U8: mem::MaybeUninit<u8> = mem::MaybeUninit::zeroed();
+    let bytes: [u8; 1] = unsafe { mem::transmute(U8) };
+    assert_eq!(bytes, [0u8; 1]);
+}

--- a/src/test/ui/feature-gates/feature-gate-const_write_bytes.rs
+++ b/src/test/ui/feature-gates/feature-gate-const_write_bytes.rs
@@ -1,0 +1,18 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(const_fn, const_let)]
+
+fn main() {}
+
+const unsafe fn foo(u: *mut u32) {
+    std::ptr::write_bytes(u, 0u8, 1);
+    //~^ ERROR The use of std::ptr::write_bytes() is gated in constant functions (see issue #53491)
+}

--- a/src/test/ui/feature-gates/feature-gate-const_write_bytes.stderr
+++ b/src/test/ui/feature-gates/feature-gate-const_write_bytes.stderr
@@ -1,0 +1,11 @@
+error[E0658]: The use of std::ptr::write_bytes() is gated in constant functions (see issue #53491)
+  --> $DIR/feature-gate-const_write_bytes.rs:16:5
+   |
+LL |     std::ptr::write_bytes(u, 0u8, 1);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(const_write_bytes)] to the crate attributes to enable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
First, let me say I have no idea what I'm doing, so this might be completely wrong. @RalfJung (and others), please let me know if this accidentally causes undefined behavior.

I believe miri zero-fills allocations, and that `force_allocation` is the right way to allocate something in miri, but if either of those assumptions are incorrect please let me know.

I'm happy to add this behind a feature gate (as [suggested by @Centril](https://github.com/rust-lang/rust/issues/53491#issuecomment-424965457)). I didn't here since `MaybeUninit` is already unstable and I'm hoping this isn't too controversial.