### PR TITLE
Cleanup: remove graphviz::IntoCow

### DIFF
--- a/src/librustc/cfg/graphviz.rs
+++ b/src/librustc/cfg/graphviz.rs
@@ -13,7 +13,6 @@
 
 // For clarity, rename the graphviz crate locally to dot.
 use graphviz as dot;
-use graphviz::IntoCow;
 
 use cfg;
 use hir;
@@ -71,21 +70,21 @@ impl<'a, 'hir> dot::Labeller<'a> for LabelledCFG<'a, 'hir> {
 
     fn node_label(&'a self, &(i, n): &Node<'a>) -> dot::LabelText<'a> {
         if i == self.cfg.entry {
-            dot::LabelText::LabelStr("entry".into_cow())
+            dot::LabelText::LabelStr("entry".into())
         } else if i == self.cfg.exit {
-            dot::LabelText::LabelStr("exit".into_cow())
+            dot::LabelText::LabelStr("exit".into())
         } else if n.data.id() == hir::DUMMY_ITEM_LOCAL_ID {
-            dot::LabelText::LabelStr("(dummy_node)".into_cow())
+            dot::LabelText::LabelStr("(dummy_node)".into())
         } else {
             let s = self.local_id_to_string(n.data.id());
-            dot::LabelText::EscStr(s.into_cow())
+            dot::LabelText::EscStr(s.into())
         }
     }
 
     fn edge_label(&self, e: &Edge<'a>) -> dot::LabelText<'a> {
         let mut label = String::new();
         if !self.labelled_edges {
-            return dot::LabelText::EscStr(label.into_cow());
+            return dot::LabelText::EscStr(label.into());
         }
         let mut put_one = false;
         for (i, &id) in e.data.exiting_scopes.iter().enumerate() {
@@ -99,7 +98,7 @@ impl<'a, 'hir> dot::Labeller<'a> for LabelledCFG<'a, 'hir> {
                                    i,
                                    &s[..]));
         }
-        dot::LabelText::EscStr(label.into_cow())
+        dot::LabelText::EscStr(label.into())
     }
 }
 
@@ -109,7 +108,7 @@ impl<'a> dot::GraphWalk<'a> for &'a cfg::CFG {
     fn nodes(&'a self) -> dot::Nodes<'a, Node<'a>> {
         let mut v = Vec::new();
         self.graph.each_node(|i, nd| { v.push((i, nd)); true });
-        v.into_cow()
+        v.into()
     }
     fn edges(&'a self) -> dot::Edges<'a, Edge<'a>> {
         self.graph.all_edges().iter().collect()

--- a/src/librustc_borrowck/graphviz.rs
+++ b/src/librustc_borrowck/graphviz.rs
@@ -23,7 +23,6 @@ use dot;
 use rustc::cfg::CFGIndex;
 use dataflow::{DataFlowOperator, DataFlowContext, EntryOrExit};
 use std::rc::Rc;
-use dot::IntoCow;
 
 #[derive(Debug, Copy, Clone)]
 pub enum Variant {
@@ -139,8 +138,8 @@ impl<'a, 'tcx> dot::Labeller<'a> for DataflowLabeller<'a, 'tcx> {
         let suffix = self.dataflow_for(EntryOrExit::Exit, n);
         let inner_label = self.inner.node_label(n);
         inner_label
-            .prefix_line(dot::LabelText::LabelStr(prefix.into_cow()))
-            .suffix_line(dot::LabelText::LabelStr(suffix.into_cow()))
+            .prefix_line(dot::LabelText::LabelStr(prefix.into()))
+            .suffix_line(dot::LabelText::LabelStr(suffix.into()))
     }
     fn edge_label(&'a self, e: &Edge<'a>) -> dot::LabelText<'a> { self.inner.edge_label(e) }
 }

--- a/src/librustc_incremental/assert_dep_graph.rs
+++ b/src/librustc_incremental/assert_dep_graph.rs
@@ -55,7 +55,6 @@ use rustc_data_structures::graph::implementation::{
 use rustc::hir;
 use rustc::hir::intravisit::{self, NestedVisitorMap, Visitor};
 use rustc::ich::{ATTR_IF_THIS_CHANGED, ATTR_THEN_THIS_WOULD_NEED};
-use graphviz::IntoCow;
 use std::env;
 use std::fs::{self, File};
 use std::io::Write;
@@ -274,10 +273,10 @@ impl<'a, 'tcx, 'q> dot::GraphWalk<'a> for GraphvizDepGraph<'q> {
     type Edge = (&'q DepNode, &'q DepNode);
     fn nodes(&self) -> dot::Nodes<&'q DepNode> {
         let nodes: Vec<_> = self.0.iter().cloned().collect();
-        nodes.into_cow()
+        nodes.into()
     }
     fn edges(&self) -> dot::Edges<(&'q DepNode, &'q DepNode)> {
-        self.1[..].into_cow()
+        self.1[..].into()
     }
     fn source(&self, edge: &(&'q DepNode, &'q DepNode)) -> &'q DepNode {
         edge.0

--- a/src/librustc_mir/borrow_check/nll/region_infer/graphviz.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/graphviz.rs
@@ -14,7 +14,7 @@
 
 use super::*;
 use borrow_check::nll::constraints::OutlivesConstraint;
-use dot::{self, IntoCow};
+use dot;
 use std::borrow::Cow;
 use std::io::{self, Write};
 
@@ -49,7 +49,7 @@ impl<'a, 'this, 'tcx> dot::Labeller<'this> for RawConstraints<'a, 'tcx> {
     type Edge = OutlivesConstraint;
 
     fn graph_id(&'this self) -> dot::Id<'this> {
-        dot::Id::new("RegionInferenceContext".to_string()).unwrap()
+        dot::Id::new("RegionInferenceContext").unwrap()
     }
     fn node_id(&'this self, n: &RegionVid) -> dot::Id<'this> {
         dot::Id::new(format!("r{}", n.index())).unwrap()
@@ -58,10 +58,10 @@ impl<'a, 'this, 'tcx> dot::Labeller<'this> for RawConstraints<'a, 'tcx> {
         Some(dot::LabelText::LabelStr(Cow::Borrowed("box")))
     }
     fn node_label(&'this self, n: &RegionVid) -> dot::LabelText<'this> {
-        dot::LabelText::LabelStr(format!("{:?}", n).into_cow())
+        dot::LabelText::LabelStr(format!("{:?}", n).into())
     }
     fn edge_label(&'this self, e: &OutlivesConstraint) -> dot::LabelText<'this> {
-        dot::LabelText::LabelStr(format!("{:?}", e.locations).into_cow())
+        dot::LabelText::LabelStr(format!("{:?}", e.locations).into())
     }
 }
 
@@ -71,10 +71,10 @@ impl<'a, 'this, 'tcx> dot::GraphWalk<'this> for RawConstraints<'a, 'tcx> {
 
     fn nodes(&'this self) -> dot::Nodes<'this, RegionVid> {
         let vids: Vec<RegionVid> = self.regioncx.definitions.indices().collect();
-        vids.into_cow()
+        vids.into()
     }
     fn edges(&'this self) -> dot::Edges<'this, OutlivesConstraint> {
-        (&self.regioncx.constraints.raw[..]).into_cow()
+        (&self.regioncx.constraints.raw[..]).into()
     }
 
     // Render `a: b` as `a -> b`, indicating the flow
@@ -109,7 +109,7 @@ impl<'a, 'this, 'tcx> dot::Labeller<'this> for SccConstraints<'a, 'tcx> {
     }
     fn node_label(&'this self, n: &ConstraintSccIndex) -> dot::LabelText<'this> {
         let nodes = &self.nodes_per_scc[*n];
-        dot::LabelText::LabelStr(format!("{:?} = {:?}", n, nodes).into_cow())
+        dot::LabelText::LabelStr(format!("{:?} = {:?}", n, nodes).into())
     }
 }
 
@@ -119,7 +119,7 @@ impl<'a, 'this, 'tcx> dot::GraphWalk<'this> for SccConstraints<'a, 'tcx> {
 
     fn nodes(&'this self) -> dot::Nodes<'this, ConstraintSccIndex> {
         let vids: Vec<ConstraintSccIndex> = self.regioncx.constraint_sccs.all_sccs().collect();
-        vids.into_cow()
+        vids.into()
     }
     fn edges(&'this self) -> dot::Edges<'this, (ConstraintSccIndex, ConstraintSccIndex)> {
         let edges: Vec<_> = self.regioncx
@@ -134,7 +134,7 @@ impl<'a, 'this, 'tcx> dot::GraphWalk<'this> for SccConstraints<'a, 'tcx> {
             })
             .collect();
 
-        edges.into_cow()
+        edges.into()
     }
 
     // Render `a: b` as `a -> b`, indicating the flow

--- a/src/librustc_mir/dataflow/graphviz.rs
+++ b/src/librustc_mir/dataflow/graphviz.rs
@@ -14,7 +14,6 @@ use syntax::ast::NodeId;
 use rustc::mir::{BasicBlock, Mir};
 
 use dot;
-use dot::IntoCow;
 
 use std::fs;
 use std::io;
@@ -257,7 +256,7 @@ impl<'a, 'tcx, MWF, P> dot::GraphWalk<'a> for Graph<'a, 'tcx, MWF, P>
             .basic_blocks()
             .indices()
             .collect::<Vec<_>>()
-            .into_cow()
+            .into()
     }
 
     fn edges(&self) -> dot::Edges<Edge> {
@@ -267,7 +266,7 @@ impl<'a, 'tcx, MWF, P> dot::GraphWalk<'a> for Graph<'a, 'tcx, MWF, P>
            .indices()
            .flat_map(|bb| outgoing(mir, bb))
            .collect::<Vec<_>>()
-           .into_cow()
+           .into()
     }
 
     fn source(&self, edge: &Edge) -> Node {


### PR DESCRIPTION
It's just `Into<Cow<...>>` and the applicable methods already exist for `Vec`/`[T]` and `String`/`str`.