### PR TITLE
Fix a regression in 1.30 by reverting #53564

### DIFF
--- a/src/liballoc/collections/vec_deque.rs
+++ b/src/liballoc/collections/vec_deque.rs
@@ -202,22 +202,6 @@ impl<T> VecDeque<T> {
                                  len);
     }
 
-    /// Copies all values from `src` to `self`, wrapping around if needed.
-    /// Assumes capacity is sufficient.
-    #[inline]
-    unsafe fn copy_slice(&mut self, src: &[T]) {
-        let dst_high_ptr = self.ptr().add(self.head);
-        let dst_high_len = self.cap() - self.head;
-
-        let split = cmp::min(src.len(), dst_high_len);
-        let (src_high, src_low) = src.split_at(split);
-
-        ptr::copy_nonoverlapping(src_high.as_ptr(), dst_high_ptr, src_high.len());
-        ptr::copy_nonoverlapping(src_low.as_ptr(), self.ptr(), src_low.len());
-
-        self.head = self.wrap_add(self.head, src.len());
-    }
-
     /// Copies a potentially wrapping block of memory len long from src to dest.
     /// (abs(dst - src) + len) must be no larger than cap() (There must be at
     /// most one continuous overlapping region between src and dest).
@@ -1850,17 +1834,8 @@ impl<T> VecDeque<T> {
     #[inline]
     #[stable(feature = "append", since = "1.4.0")]
     pub fn append(&mut self, other: &mut Self) {
-        // Guarantees there is space in `self` for `other
-        self.reserve(other.len());
-
-        unsafe {
-            let (src_high, src_low) = other.as_slices();
-            self.copy_slice(src_low);
-            self.copy_slice(src_high);
-        }
-
-        // Some values now exist in both `other` and `self` but are made inaccessible in `other`.
-        other.tail = other.head;
+        // naive impl
+        self.extend(other.drain(..));
     }
 
     /// Retains only the elements specified by the predicate.

--- a/src/liballoc/collections/vec_deque.rs
+++ b/src/liballoc/collections/vec_deque.rs
@@ -1024,7 +1024,7 @@ impl<T> VecDeque<T> {
             iter: Iter {
                 tail: drain_tail,
                 head: drain_head,
-                ring: unsafe { self.buffer_as_slice() },
+                ring: unsafe { self.buffer_as_mut_slice() },
             },
         }
     }
@@ -2593,8 +2593,8 @@ impl<T> From<VecDeque<T>> for Vec<T> {
                         let mut right_offset = 0;
                         for i in left_edge..right_edge {
                             right_offset = (i - left_edge) % (cap - right_edge);
-                            let src = right_edge + right_offset;
-                            ptr::swap(buf.add(i), buf.add(src));
+                            let src: isize = (right_edge + right_offset) as isize;
+                            ptr::swap(buf.add(i), buf.offset(src));
                         }
                         let n_ops = right_edge - left_edge;
                         left_edge += n_ops;

--- a/src/liballoc/collections/vec_deque.rs
+++ b/src/liballoc/collections/vec_deque.rs
@@ -19,7 +19,6 @@
 
 use core::cmp::Ordering;
 use core::fmt;
-use core::isize;
 use core::iter::{repeat, FromIterator, FusedIterator};
 use core::mem;
 use core::ops::Bound::{Excluded, Included, Unbounded};
@@ -211,9 +210,6 @@ impl<T> VecDeque<T> {
     /// If so, this function never panics.
     #[inline]
     unsafe fn copy_slice(&mut self, src: &[T]) {
-        /// This is guaranteed by `RawVec`.
-        debug_assert!(self.capacity() <= isize::MAX as usize);
-
         let expected_new_len = self.len() + src.len();
         debug_assert!(self.capacity() >= expected_new_len);
 

--- a/src/liballoc/collections/vec_deque.rs
+++ b/src/liballoc/collections/vec_deque.rs
@@ -1870,8 +1870,7 @@ impl<T> VecDeque<T> {
                 self.copy_slice(src_high);
             }
 
-            // Some values now exist in both `other` and `self` but are made inaccessible
-            // in`other`.
+            // Some values now exist in both `other` and `self` but are made inaccessible in `other`.
             other.tail = other.head;
         }
     }

--- a/src/liballoc/collections/vec_deque.rs
+++ b/src/liballoc/collections/vec_deque.rs
@@ -202,17 +202,10 @@ impl<T> VecDeque<T> {
                                  len);
     }
 
-    /// Copies all values from `src` to the back of `self`, wrapping around if needed.
-    ///
-    /// # Safety
-    ///
-    /// The capacity must be sufficient to hold self.len() + src.len() elements.
-    /// If so, this function never panics.
+    /// Copies all values from `src` to `self`, wrapping around if needed.
+    /// Assumes capacity is sufficient.
     #[inline]
     unsafe fn copy_slice(&mut self, src: &[T]) {
-        let expected_new_len = self.len() + src.len();
-        debug_assert!(self.capacity() >= expected_new_len);
-
         let dst_high_ptr = self.ptr().add(self.head);
         let dst_high_len = self.cap() - self.head;
 
@@ -223,7 +216,6 @@ impl<T> VecDeque<T> {
         ptr::copy_nonoverlapping(src_low.as_ptr(), self.ptr(), src_low.len());
 
         self.head = self.wrap_add(self.head, src.len());
-        debug_assert!(self.len() == expected_new_len);
     }
 
     /// Copies a potentially wrapping block of memory len long from src to dest.
@@ -1858,21 +1850,17 @@ impl<T> VecDeque<T> {
     #[inline]
     #[stable(feature = "append", since = "1.4.0")]
     pub fn append(&mut self, other: &mut Self) {
+        // Guarantees there is space in `self` for `other
+        self.reserve(other.len());
+
         unsafe {
-            // Guarantees there is space in `self` for `other`.
-            self.reserve(other.len());
-
-            {
-                let (src_high, src_low) = other.as_slices();
-
-                // This is only safe because copy_slice never panics when capacity is sufficient.
-                self.copy_slice(src_low);
-                self.copy_slice(src_high);
-            }
-
-            // Some values now exist in both `other` and `self` but are made inaccessible in `other`.
-            other.tail = other.head;
+            let (src_high, src_low) = other.as_slices();
+            self.copy_slice(src_low);
+            self.copy_slice(src_high);
         }
+
+        // Some values now exist in both `other` and `self` but are made inaccessible in `other`.
+        other.tail = other.head;
     }
 
     /// Retains only the elements specified by the predicate.


### PR DESCRIPTION
Investigation on #54477 revealed https://github.com/rust-lang/rust/pull/53564 as the culprit in the regression for that crate. I've reproduced the regression with the [detailed test cases provided](https://github.com/rust-lang/rust/issues/54477#issuecomment-427398456). While we figure out how to fix the regression this commit reverts the current culprit.