### PR TITLE
Remove unneccessary error from test, revealing NLL error.

### DIFF
--- a/src/test/ui/issues/issue-13058.nll.stderr
+++ b/src/test/ui/issues/issue-13058.nll.stderr
@@ -1,15 +1,12 @@
-error[E0308]: mismatched types
-  --> $DIR/issue-13058.rs:36:11
+error[E0621]: explicit lifetime required in the type of `cont`
+  --> $DIR/issue-13058.rs:24:21
    |
-LL |     check((3, 5));
-   |           ^^^^^^
-   |           |
-   |           expected reference, found tuple
-   |           help: consider borrowing here: `&(3, 5)`
-   |
-   = note: expected type `&_`
-              found type `({integer}, {integer})`
+LL | fn check<'r, I: Iterator<Item=usize>, T: Itble<'r, usize, I>>(cont: &T) -> bool
+   |                                                                     -- help: add explicit lifetime `'r` to the type of `cont`: `&'r T`
+LL | {
+LL |     let cont_iter = cont.iter();
+   |                     ^^^^^^^^^^^ lifetime `'r` required
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0308`.
+For more information about this error, try `rustc --explain E0621`.

--- a/src/test/ui/issues/issue-13058.rs
+++ b/src/test/ui/issues/issue-13058.rs
@@ -33,6 +33,5 @@ fn check<'r, I: Iterator<Item=usize>, T: Itble<'r, usize, I>>(cont: &T) -> bool
 }
 
 fn main() {
-    check((3, 5));
-//~^ ERROR mismatched types
+    check(&(3, 5));
 }

--- a/src/test/ui/issues/issue-13058.stderr
+++ b/src/test/ui/issues/issue-13058.stderr
@@ -7,19 +7,6 @@ LL | {
 LL |     let cont_iter = cont.iter();
    |                          ^^^^ lifetime `'r` required
 
-error[E0308]: mismatched types
-  --> $DIR/issue-13058.rs:36:11
-   |
-LL |     check((3, 5));
-   |           ^^^^^^
-   |           |
-   |           expected reference, found tuple
-   |           help: consider borrowing here: `&(3, 5)`
-   |
-   = note: expected type `&_`
-              found type `({integer}, {integer})`
+error: aborting due to previous error
 
-error: aborting due to 2 previous errors
-
-Some errors occurred: E0308, E0621.
-For more information about an error, try `rustc --explain E0308`.
+For more information about this error, try `rustc --explain E0621`.


### PR DESCRIPTION
Part of #52663.

Removes unnecessary type mismatch error from test that was hiding
borrow check error from NLL stderr.

r? @nikomatsakis 