### PR TITLE
Add doc comments about safest way to initialize a vector of zeros

### DIFF
--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -120,7 +120,9 @@ use raw_vec::RawVec;
 /// assert_eq!(vec, [1, 2, 3, 4]);
 /// ```
 ///
-/// It can also initialize each element of a `Vec<T>` with a given value:
+/// It can also initialize each element of a `Vec<T>` with a given value.
+/// Initializing a `Vec<T>` in this manner is the most efficient and safest way to allocate a
+/// vector of zeros as previously zeroed memory is requested from the operating system:
 ///
 /// ```
 /// let vec = vec![0; 5];

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -121,12 +121,16 @@ use raw_vec::RawVec;
 /// ```
 ///
 /// It can also initialize each element of a `Vec<T>` with a given value.
-/// Initializing a `Vec<T>` in this manner is the most efficient and safest way to allocate a
-/// vector of zeros as previously zeroed memory is requested from the operating system:
+/// This may be more efficient than performing allocation and initialization
+/// in separate steps, especially when initializing a vector of zeros:
 ///
 /// ```
 /// let vec = vec![0; 5];
 /// assert_eq!(vec, [0, 0, 0, 0, 0]);
+///
+/// // The following is equivalent, but potentially slower:
+/// let mut vec1 = Vec::with_capacity(5);
+/// vec1.resize(5, 0);
 /// ```
 ///
 /// Use a `Vec<T>` as an efficient stack:


### PR DESCRIPTION
This adds more information about the vec! macro as discussed in #54628. I think this is a good starting point, but I think additional detail is needed so that we can explain why vec! is safer than the alternatives.