### PR TITLE
rustdoc: Replaces fn main search and extern crate search with proper parsing during doctests.

### DIFF
--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -407,7 +407,7 @@ pub fn make_test(s: &str,
     let (already_has_main, already_has_extern_crate) = crate::syntax::with_globals(|| {
         use crate::syntax::{ast, parse::{self, ParseSess}, source_map::FilePathMapping};
         use crate::syntax_pos::FileName;
-        
+
         let filename = FileName::Anon;
         let source = s.to_owned();
         let sess = ParseSess::new(FilePathMapping::empty());
@@ -424,11 +424,11 @@ pub fn make_test(s: &str,
                         found_main = true;
                     }
                 }
-            } 
-            
-            if !found_extern_crate { 
+            }
+
+            if !found_extern_crate {
                 if let ast::ItemKind::ExternCrate(original) = item.node {
-                    // This code will never be reached if `cratename` is none ecause
+                    // This code will never be reached if `cratename` is none because
                     // `found_extern_crate` is initialized to `true` if it is none.
                     let cratename = cratename.unwrap();
 
@@ -1051,7 +1051,7 @@ assert_eq!(2+2, 4);
     #[test]
     fn make_test_issues_21299_33731() {
         let opts = TestOptions::default();
-        
+
         let input =
 "// fn main
 assert_eq!(2+2, 4);";

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -412,6 +412,8 @@ pub fn make_test(s: &str,
         let source = crates + &everything_else;
         let sess = ParseSess::new(FilePathMapping::empty());
 
+        debug!("about to parse: \n{}", source);
+
         let mut parser = parse::new_parser_from_source_str(&sess, filename, source);
 
         let mut found_main = false;
@@ -503,6 +505,7 @@ fn partition_source(s: &str) -> (String, String, String) {
             if trimline.starts_with("#[macro_use] extern crate")
                 || trimline.starts_with("extern crate") {
                 crates.push_str(line);
+                crates.push_str("\n");
             }
             before.push_str(line);
             before.push_str("\n");

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -70,6 +70,23 @@ macro_rules! panictry {
     })
 }
 
+// A variant of 'panictry!' that works on a Vec<Diagnostic> instead of a single DiagnosticBuilder.
+macro_rules! panictry_buffer {
+    ($handler:expr, $e:expr) => ({
+        use std::result::Result::{Ok, Err};
+        use errors::{FatalError, DiagnosticBuilder};
+        match $e {
+            Ok(e) => e,
+            Err(errs) => {
+                for e in errs {
+                    DiagnosticBuilder::new_diagnostic($handler, e).emit();
+                }
+                FatalError.raise()
+            }
+        }
+    })
+}
+
 #[macro_export]
 macro_rules! unwrap_or {
     ($opt:expr, $default:expr) => {

--- a/src/tools/error_index_generator/main.rs
+++ b/src/tools/error_index_generator/main.rs
@@ -10,6 +10,7 @@
 
 #![feature(rustc_private)]
 
+extern crate env_logger;
 extern crate syntax;
 extern crate rustdoc;
 extern crate serialize as rustc_serialize;
@@ -264,6 +265,7 @@ fn parse_args() -> (OutputFormat, PathBuf) {
 }
 
 fn main() {
+    env_logger::init();
     PLAYGROUND.with(|slot| {
         *slot.borrow_mut() = Some((None, String::from("https://play.rust-lang.org/")));
     });


### PR DESCRIPTION
Fixes #21299.
Fixes #33731.

Let me know if there's any additional changes you'd like made!