### PR TITLE
in which we lint `#[must_use]` functions with discardable return type

### DIFF
--- a/src/test/ui/feature-gate/issue-43106-gating-of-builtin-attrs.rs
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-builtin-attrs.rs
@@ -648,7 +648,7 @@ mod deprecated {
 mod must_use {
     mod inner { #![must_use="1400"] }
 
-    #[must_use = "1400"] fn f() { }
+    #[must_use = "1400"] fn f() -> usize { 1 }
 
     #[must_use = "1400"] struct S;
 

--- a/src/test/ui/lint/issue-54828-unused-must-use-attribute.rs
+++ b/src/test/ui/lint/issue-54828-unused-must-use-attribute.rs
@@ -1,0 +1,31 @@
+#![allow(dead_code)]
+#![deny(unused_attributes)]
+
+#[must_use]
+fn truth() {}
+
+#[must_use]
+fn pain() -> () {}
+
+#[must_use]
+fn dignity() -> ! { panic!("despair"); }
+
+struct Fear{}
+
+impl Fear {
+    #[must_use] fn bravery() {}
+}
+
+trait Suspicion {
+    #[must_use] fn inspect();
+}
+
+impl Suspicion for Fear {
+    // FIXME: it's actually rather problematic for this to get the unused-attributes
+    // lint on account of the return type—the unused-attributes lint should fire
+    // here, but it should be because `#[must_use]` needs to go on the trait
+    // definition, not the impl (Issue #48486)
+    #[must_use] fn inspect() {}
+}
+
+fn main() {}

--- a/src/test/ui/lint/issue-54828-unused-must-use-attribute.stderr
+++ b/src/test/ui/lint/issue-54828-unused-must-use-attribute.stderr
@@ -1,0 +1,48 @@
+error: unused attribute
+  --> $DIR/issue-54828-unused-must-use-attribute.rs:4:1
+   |
+LL | #[must_use]
+   | ^^^^^^^^^^^ help: remove it
+LL | fn truth() {}
+   |            - the return type `()` can be discarded
+   |
+note: lint level defined here
+  --> $DIR/issue-54828-unused-must-use-attribute.rs:2:9
+   |
+LL | #![deny(unused_attributes)]
+   |         ^^^^^^^^^^^^^^^^^
+
+error: unused attribute
+  --> $DIR/issue-54828-unused-must-use-attribute.rs:7:1
+   |
+LL | #[must_use]
+   | ^^^^^^^^^^^ help: remove it
+LL | fn pain() -> () {}
+   |              -- the return type `()` can be discarded
+
+error: unused attribute
+  --> $DIR/issue-54828-unused-must-use-attribute.rs:10:1
+   |
+LL | #[must_use]
+   | ^^^^^^^^^^^ help: remove it
+LL | fn dignity() -> ! { panic!("despair"); }
+   |                 - the return type `!` can be discarded
+
+error: unused attribute
+  --> $DIR/issue-54828-unused-must-use-attribute.rs:16:5
+   |
+LL |     #[must_use] fn bravery() {}
+   |     ^^^^^^^^^^^              - the return type `()` can be discarded
+   |     |
+   |     help: remove it
+
+error: unused attribute
+  --> $DIR/issue-54828-unused-must-use-attribute.rs:28:5
+   |
+LL |     #[must_use] fn inspect() {}
+   |     ^^^^^^^^^^^              - the return type `()` can be discarded
+   |     |
+   |     help: remove it
+
+error: aborting due to 5 previous errors
+


### PR DESCRIPTION
A rejoinder to discussion on #54828. cc @abonander @Centril @Havvy 

It's arguably pretty misleading that this also lints on trait impls (see the FIXME in the UI test), which _should_ also be unused-attributes, but for a different reason, namely, that the `#[must_use]` should go on the signature in the trait definition, not the implementation for a particular type (#48486). Unfortunately, I can't seem to figure out how to distinguish trait method impls from functions or inherent methods in `LateLintPass`/HIR?? Maybe reviewers have opinions on whether this is worth merging or needs more work?

![useless_must_use](https://user-images.githubusercontent.com/1076988/46578331-58719300-c9b2-11e8-91a0-73bb4288e8a7.png)
