### PR TITLE
Don't lint 'unused_parens` on `if (break _) { .. }`

### DIFF
--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -278,10 +278,9 @@ impl UnusedParens {
                                 msg: &str,
                                 followed_by_block: bool) {
         if let ast::ExprKind::Paren(ref inner) = value.node {
-            let necessary = followed_by_block && if let ast::ExprKind::Ret(_) = inner.node {
-                true
-            } else {
-                parser::contains_exterior_struct_lit(&inner)
+            let necessary = followed_by_block && match inner.node {
+                ast::ExprKind::Ret(_) | ast::ExprKind::Break(..) => true,
+                _ => parser::contains_exterior_struct_lit(&inner),
             };
             if !necessary {
                 let expr_text = if let Ok(snippet) = cx.sess().source_map()

--- a/src/test/ui/lint/unused_parens_json_suggestion.rs
+++ b/src/test/ui/lint/unused_parens_json_suggestion.rs
@@ -23,4 +23,13 @@ fn main() {
     // We want to suggest the properly-balanced expression `1 / (2 + 3)`, not
     // the malformed `1 / (2 + 3`
     let _a = (1 / (2 + 3));
+    f();
+}
+
+fn f() -> bool {
+    loop {
+        if (break { return true }) {
+        }
+    }
+    false
 }


### PR DESCRIPTION
This fixes #54704