### PR TITLE
doc fix: it's auto traits that make for automatic implementations

### DIFF
--- a/src/libstd/panic.rs
+++ b/src/libstd/panic.rs
@@ -79,7 +79,7 @@ pub use core::panic::{PanicInfo, Location};
 ///
 /// Simply put, a type `T` implements `UnwindSafe` if it cannot easily allow
 /// witnessing a broken invariant through the use of `catch_unwind` (catching a
-/// panic). This trait is a marker trait, so it is automatically implemented for
+/// panic). This trait is an auto trait, so it is automatically implemented for
 /// many types, and it is also structurally composed (e.g. a struct is unwind
 /// safe if all of its components are unwind safe).
 ///


### PR DESCRIPTION
Being a marker trait is not good enough (that just means "no items in the trait").

r? @alexcrichton who [originally wrote these docs](https://github.com/RalfJung/rust/commit/0a13f1abafe70cddf34bf2b2ba3946c418ed6241).