### PR TITLE
Unused result warning: "X which must" ↦ "X that must"

### DIFF
--- a/src/doc/rustc/src/lints/listing/warn-by-default.md
+++ b/src/doc/rustc/src/lints/listing/warn-by-default.md
@@ -279,7 +279,7 @@ warning: functions generic over types must be mangled
 1 |   #[no_mangle]
   |   ------------ help: remove this attribute
 2 | / fn foo<T>(t: T) {
-3 | |     
+3 | |
 4 | | }
   | |_^
   |
@@ -513,7 +513,7 @@ This will produce:
 warning: borrow of packed field requires unsafe function or block (error E0133)
   --> src/main.rs:11:13
    |
-11 |     let y = &x.data.0; 
+11 |     let y = &x.data.0;
    |             ^^^^^^^^^
    |
    = note: #[warn(safe_packed_borrows)] on by default
@@ -874,7 +874,7 @@ fn main() {
 This will produce:
 
 ```text
-warning: unused `std::result::Result` which must be used
+warning: unused `std::result::Result` that must be used
  --> src/main.rs:6:5
   |
 6 |     returns_result();

--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -253,7 +253,7 @@
 //! using it. The compiler will warn us about this kind of behavior:
 //!
 //! ```text
-//! warning: unused result which must be used: iterator adaptors are lazy and
+//! warning: unused result that must be used: iterator adaptors are lazy and
 //! do nothing unless consumed
 //! ```
 //!

--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -143,7 +143,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedResults {
 
         if let Some(must_use_op) = must_use_op {
             cx.span_lint(UNUSED_MUST_USE, expr.span,
-                         &format!("unused {} which must be used", must_use_op));
+                         &format!("unused {} that must be used", must_use_op));
             op_warned = true;
         }
 
@@ -154,7 +154,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedResults {
         fn check_must_use(cx: &LateContext, def_id: DefId, sp: Span, describe_path: &str) -> bool {
             for attr in cx.tcx.get_attrs(def_id).iter() {
                 if attr.check_name("must_use") {
-                    let msg = format!("unused {}`{}` which must be used",
+                    let msg = format!("unused {}`{}` that must be used",
                                           describe_path, cx.tcx.item_path_str(def_id));
                     let mut err = cx.struct_span_lint(UNUSED_MUST_USE, sp, &msg);
                     // check for #[must_use = "..."]

--- a/src/test/ui/conditional-compilation/cfg-attr-multi-true.rs
+++ b/src/test/ui/conditional-compilation/cfg-attr-multi-true.rs
@@ -18,5 +18,5 @@ impl MustUseDeprecated { //~ warning: use of deprecated item
 
 fn main() {
     MustUseDeprecated::new(); //~ warning: use of deprecated item
-    //| warning: unused `MustUseDeprecated` which must be used
+    //| warning: unused `MustUseDeprecated` that must be used
 }

--- a/src/test/ui/conditional-compilation/cfg-attr-multi-true.stderr
+++ b/src/test/ui/conditional-compilation/cfg-attr-multi-true.stderr
@@ -24,7 +24,7 @@ warning: use of deprecated item 'MustUseDeprecated'
 LL |         MustUseDeprecated {} //~ warning: use of deprecated item
    |         ^^^^^^^^^^^^^^^^^
 
-warning: unused `MustUseDeprecated` which must be used
+warning: unused `MustUseDeprecated` that must be used
   --> $DIR/cfg-attr-multi-true.rs:20:5
    |
 LL |     MustUseDeprecated::new(); //~ warning: use of deprecated item

--- a/src/test/ui/fn_must_use.stderr
+++ b/src/test/ui/fn_must_use.stderr
@@ -1,4 +1,4 @@
-warning: unused return value of `need_to_use_this_value` which must be used
+warning: unused return value of `need_to_use_this_value` that must be used
   --> $DIR/fn_must_use.rs:65:5
    |
 LL |     need_to_use_this_value(); //~ WARN unused return value
@@ -11,13 +11,13 @@ LL | #![warn(unused_must_use)]
    |         ^^^^^^^^^^^^^^^
    = note: it's important
 
-warning: unused return value of `MyStruct::need_to_use_this_method_value` which must be used
+warning: unused return value of `MyStruct::need_to_use_this_method_value` that must be used
   --> $DIR/fn_must_use.rs:70:5
    |
 LL |     m.need_to_use_this_method_value(); //~ WARN unused return value
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: unused return value of `EvenNature::is_even` which must be used
+warning: unused return value of `EvenNature::is_even` that must be used
   --> $DIR/fn_must_use.rs:71:5
    |
 LL |     m.is_even(); // trait method!
@@ -25,31 +25,31 @@ LL |     m.is_even(); // trait method!
    |
    = note: no side effects
 
-warning: unused return value of `MyStruct::need_to_use_this_associated_function_value` which must be used
+warning: unused return value of `MyStruct::need_to_use_this_associated_function_value` that must be used
   --> $DIR/fn_must_use.rs:74:5
    |
 LL |     MyStruct::need_to_use_this_associated_function_value();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: unused return value of `std::cmp::PartialEq::eq` which must be used
+warning: unused return value of `std::cmp::PartialEq::eq` that must be used
   --> $DIR/fn_must_use.rs:80:5
    |
 LL |     2.eq(&3); //~ WARN unused return value
    |     ^^^^^^^^^
 
-warning: unused return value of `std::cmp::PartialEq::eq` which must be used
+warning: unused return value of `std::cmp::PartialEq::eq` that must be used
   --> $DIR/fn_must_use.rs:81:5
    |
 LL |     m.eq(&n); //~ WARN unused return value
    |     ^^^^^^^^^
 
-warning: unused comparison which must be used
+warning: unused comparison that must be used
   --> $DIR/fn_must_use.rs:84:5
    |
 LL |     2 == 3; //~ WARN unused comparison
    |     ^^^^^^
 
-warning: unused comparison which must be used
+warning: unused comparison that must be used
   --> $DIR/fn_must_use.rs:85:5
    |
 LL |     m == n; //~ WARN unused comparison

--- a/src/test/ui/lint/must-use-ops.stderr
+++ b/src/test/ui/lint/must-use-ops.stderr
@@ -1,4 +1,4 @@
-warning: unused comparison which must be used
+warning: unused comparison that must be used
   --> $DIR/must-use-ops.rs:22:5
    |
 LL |     val == 1;
@@ -10,121 +10,121 @@ note: lint level defined here
 LL | #![warn(unused_must_use)]
    |         ^^^^^^^^^^^^^^^
 
-warning: unused comparison which must be used
+warning: unused comparison that must be used
   --> $DIR/must-use-ops.rs:23:5
    |
 LL |     val < 1;
    |     ^^^^^^^
 
-warning: unused comparison which must be used
+warning: unused comparison that must be used
   --> $DIR/must-use-ops.rs:24:5
    |
 LL |     val <= 1;
    |     ^^^^^^^^
 
-warning: unused comparison which must be used
+warning: unused comparison that must be used
   --> $DIR/must-use-ops.rs:25:5
    |
 LL |     val != 1;
    |     ^^^^^^^^
 
-warning: unused comparison which must be used
+warning: unused comparison that must be used
   --> $DIR/must-use-ops.rs:26:5
    |
 LL |     val >= 1;
    |     ^^^^^^^^
 
-warning: unused comparison which must be used
+warning: unused comparison that must be used
   --> $DIR/must-use-ops.rs:27:5
    |
 LL |     val > 1;
    |     ^^^^^^^
 
-warning: unused arithmetic operation which must be used
+warning: unused arithmetic operation that must be used
   --> $DIR/must-use-ops.rs:30:5
    |
 LL |     val + 2;
    |     ^^^^^^^
 
-warning: unused arithmetic operation which must be used
+warning: unused arithmetic operation that must be used
   --> $DIR/must-use-ops.rs:31:5
    |
 LL |     val - 2;
    |     ^^^^^^^
 
-warning: unused arithmetic operation which must be used
+warning: unused arithmetic operation that must be used
   --> $DIR/must-use-ops.rs:32:5
    |
 LL |     val / 2;
    |     ^^^^^^^
 
-warning: unused arithmetic operation which must be used
+warning: unused arithmetic operation that must be used
   --> $DIR/must-use-ops.rs:33:5
    |
 LL |     val * 2;
    |     ^^^^^^^
 
-warning: unused arithmetic operation which must be used
+warning: unused arithmetic operation that must be used
   --> $DIR/must-use-ops.rs:34:5
    |
 LL |     val % 2;
    |     ^^^^^^^
 
-warning: unused logical operation which must be used
+warning: unused logical operation that must be used
   --> $DIR/must-use-ops.rs:37:5
    |
 LL |     true && true;
    |     ^^^^^^^^^^^^
 
-warning: unused logical operation which must be used
+warning: unused logical operation that must be used
   --> $DIR/must-use-ops.rs:38:5
    |
 LL |     false || true;
    |     ^^^^^^^^^^^^^
 
-warning: unused bitwise operation which must be used
+warning: unused bitwise operation that must be used
   --> $DIR/must-use-ops.rs:41:5
    |
 LL |     5 ^ val;
    |     ^^^^^^^
 
-warning: unused bitwise operation which must be used
+warning: unused bitwise operation that must be used
   --> $DIR/must-use-ops.rs:42:5
    |
 LL |     5 & val;
    |     ^^^^^^^
 
-warning: unused bitwise operation which must be used
+warning: unused bitwise operation that must be used
   --> $DIR/must-use-ops.rs:43:5
    |
 LL |     5 | val;
    |     ^^^^^^^
 
-warning: unused bitwise operation which must be used
+warning: unused bitwise operation that must be used
   --> $DIR/must-use-ops.rs:44:5
    |
 LL |     5 << val;
    |     ^^^^^^^^
 
-warning: unused bitwise operation which must be used
+warning: unused bitwise operation that must be used
   --> $DIR/must-use-ops.rs:45:5
    |
 LL |     5 >> val;
    |     ^^^^^^^^
 
-warning: unused unary operation which must be used
+warning: unused unary operation that must be used
   --> $DIR/must-use-ops.rs:48:5
    |
 LL |     !val;
    |     ^^^^
 
-warning: unused unary operation which must be used
+warning: unused unary operation that must be used
   --> $DIR/must-use-ops.rs:49:5
    |
 LL |     -val;
    |     ^^^^
 
-warning: unused unary operation which must be used
+warning: unused unary operation that must be used
   --> $DIR/must-use-ops.rs:50:5
    |
 LL |     *val_pointer;

--- a/src/test/ui/lint/must_use-unit.stderr
+++ b/src/test/ui/lint/must_use-unit.stderr
@@ -1,4 +1,4 @@
-error: unused return value of `foo` which must be used
+error: unused return value of `foo` that must be used
   --> $DIR/must_use-unit.rs:14:5
    |
 LL |     foo(); //~ unused return value of `foo`
@@ -10,7 +10,7 @@ note: lint level defined here
 LL | #![deny(unused_must_use)]
    |         ^^^^^^^^^^^^^^^
 
-error: unused return value of `bar` which must be used
+error: unused return value of `bar` that must be used
   --> $DIR/must_use-unit.rs:16:5
    |
 LL |     bar(); //~ unused return value of `bar`

--- a/src/test/ui/unused/unused-result.rs
+++ b/src/test/ui/unused/unused-result.rs
@@ -28,8 +28,8 @@ fn qux() -> MustUseMsg { return foo::<MustUseMsg>(); }
 #[allow(unused_results)]
 fn test() {
     foo::<isize>();
-    foo::<MustUse>(); //~ ERROR: unused `MustUse` which must be used
-    foo::<MustUseMsg>(); //~ ERROR: unused `MustUseMsg` which must be used
+    foo::<MustUse>(); //~ ERROR: unused `MustUse` that must be used
+    foo::<MustUseMsg>(); //~ ERROR: unused `MustUseMsg` that must be used
     //~^ NOTE: some message
 }
 
@@ -42,8 +42,8 @@ fn test2() {
 
 fn main() {
     foo::<isize>(); //~ ERROR: unused result
-    foo::<MustUse>(); //~ ERROR: unused `MustUse` which must be used
-    foo::<MustUseMsg>(); //~ ERROR: unused `MustUseMsg` which must be used
+    foo::<MustUse>(); //~ ERROR: unused `MustUse` that must be used
+    foo::<MustUseMsg>(); //~ ERROR: unused `MustUseMsg` that must be used
     //~^ NOTE: some message
 
     let _ = foo::<isize>();

--- a/src/test/ui/unused/unused-result.stderr
+++ b/src/test/ui/unused/unused-result.stderr
@@ -1,7 +1,7 @@
-error: unused `MustUse` which must be used
+error: unused `MustUse` that must be used
   --> $DIR/unused-result.rs:31:5
    |
-LL |     foo::<MustUse>(); //~ ERROR: unused `MustUse` which must be used
+LL |     foo::<MustUse>(); //~ ERROR: unused `MustUse` that must be used
    |     ^^^^^^^^^^^^^^^^^
    |
 note: lint level defined here
@@ -10,10 +10,10 @@ note: lint level defined here
 LL | #![deny(unused_results, unused_must_use)]
    |                         ^^^^^^^^^^^^^^^
 
-error: unused `MustUseMsg` which must be used
+error: unused `MustUseMsg` that must be used
   --> $DIR/unused-result.rs:32:5
    |
-LL |     foo::<MustUseMsg>(); //~ ERROR: unused `MustUseMsg` which must be used
+LL |     foo::<MustUseMsg>(); //~ ERROR: unused `MustUseMsg` that must be used
    |     ^^^^^^^^^^^^^^^^^^^^
    |
    = note: some message
@@ -30,16 +30,16 @@ note: lint level defined here
 LL | #![deny(unused_results, unused_must_use)]
    |         ^^^^^^^^^^^^^^
 
-error: unused `MustUse` which must be used
+error: unused `MustUse` that must be used
   --> $DIR/unused-result.rs:45:5
    |
-LL |     foo::<MustUse>(); //~ ERROR: unused `MustUse` which must be used
+LL |     foo::<MustUse>(); //~ ERROR: unused `MustUse` that must be used
    |     ^^^^^^^^^^^^^^^^^
 
-error: unused `MustUseMsg` which must be used
+error: unused `MustUseMsg` that must be used
   --> $DIR/unused-result.rs:46:5
    |
-LL |     foo::<MustUseMsg>(); //~ ERROR: unused `MustUseMsg` which must be used
+LL |     foo::<MustUseMsg>(); //~ ERROR: unused `MustUseMsg` that must be used
    |     ^^^^^^^^^^^^^^^^^^^^
    |
    = note: some message


### PR DESCRIPTION
Address a little grammatical faux pas in the unused result warning.