### PR TITLE
Cleanup the rest of codegen_llvm

### DIFF
--- a/src/librustc_codegen_llvm/debuginfo/create_scope_map.rs
+++ b/src/librustc_codegen_llvm/debuginfo/create_scope_map.rs
@@ -37,7 +37,7 @@ pub struct MirDebugScope<'ll> {
 
 impl MirDebugScope<'ll> {
     pub fn is_valid(&self) -> bool {
-        !self.scope_metadata.is_none()
+        self.scope_metadata.is_some()
     }
 }
 

--- a/src/librustc_codegen_llvm/debuginfo/metadata.rs
+++ b/src/librustc_codegen_llvm/debuginfo/metadata.rs
@@ -352,7 +352,7 @@ fn vec_slice_metadata(
 
     let member_descriptions = vec![
         MemberDescription {
-            name: "data_ptr".to_string(),
+            name: "data_ptr".to_owned(),
             type_metadata: data_ptr_metadata,
             offset: Size::ZERO,
             size: pointer_size,
@@ -360,7 +360,7 @@ fn vec_slice_metadata(
             flags: DIFlags::FlagZero,
         },
         MemberDescription {
-            name: "length".to_string(),
+            name: "length".to_owned(),
             type_metadata: type_metadata(cx, cx.tcx.types.usize, span),
             offset: pointer_size,
             size: usize_size,
@@ -463,7 +463,7 @@ fn trait_pointer_metadata(
     let vtable_field = layout.field(cx, 1);
     let member_descriptions = vec![
         MemberDescription {
-            name: "pointer".to_string(),
+            name: "pointer".to_owned(),
             type_metadata: type_metadata(cx,
                 cx.tcx.mk_mut_ptr(cx.tcx.types.u8),
                 syntax_pos::DUMMY_SP),
@@ -473,7 +473,7 @@ fn trait_pointer_metadata(
             flags: DIFlags::FlagArtificial,
         },
         MemberDescription {
-            name: "vtable".to_string(),
+            name: "vtable".to_owned(),
             type_metadata: type_metadata(cx, vtable_field.ty, syntax_pos::DUMMY_SP),
             offset: layout.fields.offset(1),
             size: vtable_field.size,
@@ -1362,7 +1362,7 @@ fn describe_enum_variant(
             // We have the layout of an enum variant, we need the layout of the outer enum
             let enum_layout = cx.layout_of(layout.ty);
             (Some(enum_layout.fields.offset(0)),
-             Some(("RUST$ENUM$DISR".to_string(), enum_layout.field(cx, 0).ty)))
+             Some(("RUST$ENUM$DISR".to_owned(), enum_layout.field(cx, 0).ty)))
         }
         _ => (None, None),
     };

--- a/src/librustc_codegen_llvm/debuginfo/metadata.rs
+++ b/src/librustc_codegen_llvm/debuginfo/metadata.rs
@@ -582,12 +582,12 @@ pub fn type_metadata(
         }
         ty::Dynamic(..) => {
             MetadataCreationResult::new(
-                        trait_pointer_metadata(cx, t, None, unique_type_id),
-            false)
+                trait_pointer_metadata(cx, t, None, unique_type_id),
+                false)
         }
         ty::Foreign(..) => {
             MetadataCreationResult::new(
-                        foreign_type_metadata(cx, t, unique_type_id),
+            foreign_type_metadata(cx, t, unique_type_id),
             false)
         }
         ty::RawPtr(ty::TypeAndMut{ty, ..}) |
@@ -646,16 +646,16 @@ pub fn type_metadata(
             }
             AdtKind::Union => {
                 prepare_union_metadata(cx,
-                                    t,
-                                    unique_type_id,
-                                    usage_site_span).finalize(cx)
+                                       t,
+                                       unique_type_id,
+                                       usage_site_span).finalize(cx)
             }
             AdtKind::Enum => {
                 prepare_enum_metadata(cx,
-                                    t,
-                                    def.did,
-                                    unique_type_id,
-                                    usage_site_span).finalize(cx)
+                                      t,
+                                      def.did,
+                                      unique_type_id,
+                                      usage_site_span).finalize(cx)
             }
         },
         ty::Tuple(ref elements) => {
@@ -943,7 +943,7 @@ enum MemberDescriptionFactory<'ll, 'tcx> {
 
 impl MemberDescriptionFactory<'ll, 'tcx> {
     fn create_member_descriptions(&self, cx: &CodegenCx<'ll, 'tcx>)
-                                      -> Vec<MemberDescription<'ll>> {
+                                  -> Vec<MemberDescription<'ll>> {
         match *self {
             StructMDF(ref this) => {
                 this.create_member_descriptions(cx)
@@ -977,7 +977,7 @@ struct StructMemberDescriptionFactory<'tcx> {
 
 impl<'tcx> StructMemberDescriptionFactory<'tcx> {
     fn create_member_descriptions(&self, cx: &CodegenCx<'ll, 'tcx>)
-                                      -> Vec<MemberDescription<'ll>> {
+                                  -> Vec<MemberDescription<'ll>> {
         let layout = cx.layout_of(self.ty);
         self.variant.fields.iter().enumerate().map(|(i, f)| {
             let name = if self.variant.ctor_kind == CtorKind::Fn {
@@ -1047,7 +1047,7 @@ struct TupleMemberDescriptionFactory<'tcx> {
 
 impl<'tcx> TupleMemberDescriptionFactory<'tcx> {
     fn create_member_descriptions(&self, cx: &CodegenCx<'ll, 'tcx>)
-                                      -> Vec<MemberDescription<'ll>> {
+                                  -> Vec<MemberDescription<'ll>> {
         let layout = cx.layout_of(self.ty);
         self.component_types.iter().enumerate().map(|(i, &component_type)| {
             let (size, align) = cx.size_and_align_of(component_type);
@@ -1101,7 +1101,7 @@ struct UnionMemberDescriptionFactory<'tcx> {
 
 impl<'tcx> UnionMemberDescriptionFactory<'tcx> {
     fn create_member_descriptions(&self, cx: &CodegenCx<'ll, 'tcx>)
-                                      -> Vec<MemberDescription<'ll>> {
+                                  -> Vec<MemberDescription<'ll>> {
         self.variant.fields.iter().enumerate().map(|(i, f)| {
             let field = self.layout.field(cx, i);
             let (size, align) = field.size_and_align();
@@ -1170,7 +1170,7 @@ struct EnumMemberDescriptionFactory<'ll, 'tcx> {
 
 impl EnumMemberDescriptionFactory<'ll, 'tcx> {
     fn create_member_descriptions(&self, cx: &CodegenCx<'ll, 'tcx>)
-                                      -> Vec<MemberDescription<'ll>> {
+                                  -> Vec<MemberDescription<'ll>> {
         let adt = &self.enum_type.ty_adt_def().unwrap();
         match self.layout.variants {
             layout::Variants::Single { .. } if adt.variants.is_empty() => vec![],

--- a/src/librustc_codegen_llvm/debuginfo/metadata.rs
+++ b/src/librustc_codegen_llvm/debuginfo/metadata.rs
@@ -164,7 +164,7 @@ impl TypeMap<'ll, 'tcx> {
                                       type_: Ty<'tcx>) -> UniqueTypeId {
         // Let's see if we already have something in the cache
         if let Some(unique_type_id) = self.type_to_unique_id.get(&type_).cloned() {
-            return unique_type_id
+            return unique_type_id;
         }
         // if not, generate one
 
@@ -290,7 +290,7 @@ macro_rules! return_if_metadata_created_in_meantime {
             .borrow()
             .find_metadata_for_unique_id($unique_type_id)
         {
-            return MetadataCreationResult::new(metadata, true)
+            return MetadataCreationResult::new(metadata, true);
         }
     )
 }
@@ -552,7 +552,7 @@ pub fn type_metadata(
                     .borrow()
                     .find_metadata_for_unique_id(unique_type_id)
                 {
-                    return Err(metadata)
+                    return Err(metadata);
                 }
 
                 Ok(MetadataCreationResult::new(pointer_type_metadata(cx, t, pointee_metadata),
@@ -612,7 +612,7 @@ pub fn type_metadata(
                .borrow()
                .find_metadata_for_unique_id(unique_type_id)
             {
-                return metadata
+                return metadata;
             }
 
             // This is actually a function pointer, so wrap it in pointer DI
@@ -1477,7 +1477,7 @@ fn prepare_enum_metadata(
     };
 
     if let (&layout::Abi::Scalar(_), Some(discr)) = (&layout.abi, discriminant_type_metadata) {
-        return FinalMetadata(discr)
+        return FinalMetadata(discr);
     }
 
     let (enum_type_size, enum_type_align) = layout.size_and_align();

--- a/src/librustc_codegen_llvm/debuginfo/metadata.rs
+++ b/src/librustc_codegen_llvm/debuginfo/metadata.rs
@@ -1551,7 +1551,7 @@ fn composite_type_metadata(
                                   composite_type_metadata,
                                   member_descriptions);
 
-    return composite_type_metadata;
+    composite_type_metadata
 }
 
 fn set_members_of_composite_type(cx: &CodegenCx<'ll, '_>,
@@ -1639,7 +1639,7 @@ fn create_struct_stub(
             unique_type_id.as_ptr())
     };
 
-    return metadata_stub;
+    metadata_stub
 }
 
 fn create_union_stub(
@@ -1675,7 +1675,7 @@ fn create_union_stub(
             unique_type_id.as_ptr())
     };
 
-    return metadata_stub;
+    metadata_stub
 }
 
 /// Creates debug information for the given global variable.

--- a/src/librustc_codegen_llvm/debuginfo/mod.rs
+++ b/src/librustc_codegen_llvm/debuginfo/mod.rs
@@ -271,16 +271,14 @@ pub fn create_function_debug_context(
     let mut flags = DIFlags::FlagPrototyped;
 
     let local_id = cx.tcx.hir.as_local_node_id(def_id);
-    match *cx.sess().entry_fn.borrow() {
-        Some((id, _, _)) => {
-            if local_id == Some(id) {
-                flags = flags | DIFlags::FlagMainSubprogram;
-            }
+    if let Some((id, _, _)) = *cx.sess().entry_fn.borrow() {
+        if local_id == Some(id) {
+            flags |= DIFlags::FlagMainSubprogram;
         }
-        None => {}
-    };
+    }
+
     if cx.layout_of(sig.output()).abi.is_uninhabited() {
-        flags = flags | DIFlags::FlagNoReturn;
+        flags |= DIFlags::FlagNoReturn;
     }
 
     let fn_metadata = unsafe {

--- a/src/librustc_codegen_llvm/debuginfo/mod.rs
+++ b/src/librustc_codegen_llvm/debuginfo/mod.rs
@@ -371,7 +371,7 @@ pub fn create_function_debug_context(
             }
         }
 
-        return create_DIArray(DIB(cx), &signature[..]);
+        create_DIArray(DIB(cx), &signature[..])
     }
 
     fn get_template_parameters(
@@ -428,7 +428,7 @@ pub fn create_function_debug_context(
             vec![]
         };
 
-        return create_DIArray(DIB(cx), &template_params[..]);
+        create_DIArray(DIB(cx), &template_params[..])
     }
 
     fn get_parameter_names(cx: &CodegenCx,

--- a/src/librustc_codegen_llvm/debuginfo/source_loc.rs
+++ b/src/librustc_codegen_llvm/debuginfo/source_loc.rs
@@ -56,11 +56,8 @@ pub fn set_source_location(
 /// switches source location emitting on and must therefore be called before the
 /// first real statement/expression of the function is codegened.
 pub fn start_emitting_source_locations(dbg_context: &FunctionDebugContext<'ll>) {
-    match *dbg_context {
-        FunctionDebugContext::RegularContext(ref data) => {
-            data.source_locations_enabled.set(true)
-        },
-        _ => { /* safe to ignore */ }
+    if let FunctionDebugContext::RegularContext(ref data) = *dbg_context {
+        data.source_locations_enabled.set(true)
     }
 }
 

--- a/src/librustc_codegen_llvm/debuginfo/source_loc.rs
+++ b/src/librustc_codegen_llvm/debuginfo/source_loc.rs
@@ -57,7 +57,7 @@ pub fn set_source_location(
 /// first real statement/expression of the function is codegened.
 pub fn start_emitting_source_locations(dbg_context: &FunctionDebugContext<'ll>) {
     if let FunctionDebugContext::RegularContext(ref data) = *dbg_context {
-        data.source_locations_enabled.set(true)
+        data.source_locations_enabled.set(true);
     }
 }
 

--- a/src/librustc_codegen_llvm/debuginfo/type_names.rs
+++ b/src/librustc_codegen_llvm/debuginfo/type_names.rs
@@ -179,7 +179,7 @@ pub fn push_debuginfo_type_name<'a, 'tcx>(cx: &CodegenCx<'a, 'tcx>,
         ty::GeneratorWitness(..) |
         ty::Param(_) => {
             bug!("debuginfo: Trying to create type name for \
-                unexpected type: {:?}", t);
+                  unexpected type: {:?}", t);
         }
     }
 

--- a/src/librustc_codegen_llvm/llvm/archive_ro.rs
+++ b/src/librustc_codegen_llvm/llvm/archive_ro.rs
@@ -40,7 +40,7 @@ impl ArchiveRO {
         return unsafe {
             let s = path2cstr(dst);
             let ar = super::LLVMRustOpenArchive(s.as_ptr()).ok_or_else(|| {
-                super::last_error().unwrap_or("failed to open archive".to_string())
+                super::last_error().unwrap_or("failed to open archive".to_owned())
             })?;
             Ok(ArchiveRO { raw: ar })
         };

--- a/src/librustc_codegen_llvm/mir/analyze.rs
+++ b/src/librustc_codegen_llvm/mir/analyze.rs
@@ -151,9 +151,9 @@ impl Visitor<'tcx> for LocalAnalyzer<'mir, 'a, 'll, 'tcx> {
     }
 
     fn visit_place(&mut self,
-                    place: &mir::Place<'tcx>,
-                    context: PlaceContext<'tcx>,
-                    location: Location) {
+                   place: &mir::Place<'tcx>,
+                   context: PlaceContext<'tcx>,
+                   location: Location) {
         debug!("visit_place(place={:?}, context={:?})", place, context);
         let cx = self.fx.cx;
 

--- a/src/librustc_codegen_llvm/mir/block.rs
+++ b/src/librustc_codegen_llvm/mir/block.rs
@@ -49,9 +49,9 @@ impl FunctionCx<'a, 'll, 'tcx> {
     }
 
     fn codegen_terminator(&mut self,
-                        mut bx: Builder<'a, 'll, 'tcx>,
-                        bb: mir::BasicBlock,
-                        terminator: &mir::Terminator<'tcx>)
+                          mut bx: Builder<'a, 'll, 'tcx>,
+                          bb: mir::BasicBlock,
+                          terminator: &mir::Terminator<'tcx>)
     {
         debug!("codegen_terminator: {:?}", terminator);
 
@@ -125,10 +125,10 @@ impl FunctionCx<'a, 'll, 'tcx> {
                     this.unreachable_block()
                 };
                 let invokeret = bx.invoke(fn_ptr,
-                                           &llargs,
-                                           ret_bx,
-                                           llblock(this, cleanup),
-                                           cleanup_bundle);
+                                          &llargs,
+                                          ret_bx,
+                                          llblock(this, cleanup),
+                                          cleanup_bundle);
                 fn_ty.apply_attrs_callsite(&bx, invokeret);
 
                 if let Some((ret_dest, target)) = destination {
@@ -213,7 +213,8 @@ impl FunctionCx<'a, 'll, 'tcx> {
                 } else {
                     let (otherwise, targets) = targets.split_last().unwrap();
                     let switch = bx.switch(discr.immediate(),
-                                            llblock(self, *otherwise), values.len());
+                                           llblock(self, *otherwise),
+                                           values.len());
                     let switch_llty = bx.cx.layout_of(switch_ty).immediate_llvm_type(bx.cx);
                     for (&value, target) in values.iter().zip(targets) {
                         let llval = C_uint_big(switch_llty, value);
@@ -387,8 +388,8 @@ impl FunctionCx<'a, 'll, 'tcx> {
                         let msg_str = Symbol::intern(str).as_str();
                         let msg_str = C_str_slice(bx.cx, msg_str);
                         let msg_file_line_col = C_struct(bx.cx,
-                                                     &[msg_str, filename, line, col],
-                                                     false);
+                                                         &[msg_str, filename, line, col],
+                                                         false);
                         let msg_file_line_col = consts::addr_of(bx.cx,
                                                                 msg_file_line_col,
                                                                 align,
@@ -509,8 +510,8 @@ impl FunctionCx<'a, 'll, 'tcx> {
                     let msg_str = Symbol::intern(&str).as_str();
                     let msg_str = C_str_slice(bx.cx, msg_str);
                     let msg_file_line_col = C_struct(bx.cx,
-                                                    &[msg_str, filename, line, col],
-                                                    false);
+                                                     &[msg_str, filename, line, col],
+                                                     false);
                     let msg_file_line_col = consts::addr_of(bx.cx,
                                                             msg_file_line_col,
                                                             align,
@@ -619,7 +620,7 @@ impl FunctionCx<'a, 'll, 'tcx> {
 
                     let callee_ty = instance.as_ref().unwrap().ty(bx.cx.tcx);
                     codegen_intrinsic_call(&bx, callee_ty, &fn_ty, &args, dest,
-                                         terminator.source_info.span);
+                                           terminator.source_info.span);
 
                     if let ReturnDest::IndirectOperand(dst, _) = ret_dest {
                         self.store_return(&bx, ret_dest, &fn_ty.ret, dst.llval);
@@ -756,7 +757,7 @@ impl FunctionCx<'a, 'll, 'tcx> {
             // Have to load the argument, maybe while casting it.
             if let PassMode::Cast(ty) = arg.mode {
                 llval = bx.load(bx.pointercast(llval, ty.llvm_type(bx.cx).ptr_to()),
-                                 align.min(arg.layout.align));
+                                align.min(arg.layout.align));
             } else {
                 // We can't use `PlaceRef::load` here because the argument
                 // may have a type we don't treat as immediate, but the ABI
@@ -778,10 +779,10 @@ impl FunctionCx<'a, 'll, 'tcx> {
     }
 
     fn codegen_arguments_untupled(&mut self,
-                                bx: &Builder<'a, 'll, 'tcx>,
-                                operand: &mir::Operand<'tcx>,
-                                llargs: &mut Vec<&'ll Value>,
-                                args: &[ArgType<'tcx, Ty<'tcx>>]) {
+                                  bx: &Builder<'a, 'll, 'tcx>,
+                                  operand: &mir::Operand<'tcx>,
+                                  llargs: &mut Vec<&'ll Value>,
+                                  args: &[ArgType<'tcx, Ty<'tcx>>]) {
         let tuple = self.codegen_operand(bx, operand);
 
         // Handle both by-ref and immediate tuples.
@@ -933,8 +934,8 @@ impl FunctionCx<'a, 'll, 'tcx> {
     }
 
     fn codegen_transmute(&mut self, bx: &Builder<'a, 'll, 'tcx>,
-                       src: &mir::Operand<'tcx>,
-                       dst: &mir::Place<'tcx>) {
+                         src: &mir::Operand<'tcx>,
+                         dst: &mir::Place<'tcx>) {
         if let mir::Place::Local(index) = *dst {
             match self.locals[index] {
                 LocalRef::Place(place) => self.codegen_transmute_into(bx, src, place),
@@ -961,8 +962,8 @@ impl FunctionCx<'a, 'll, 'tcx> {
     }
 
     fn codegen_transmute_into(&mut self, bx: &Builder<'a, 'll, 'tcx>,
-                            src: &mir::Operand<'tcx>,
-                            dst: PlaceRef<'ll, 'tcx>) {
+                              src: &mir::Operand<'tcx>,
+                              dst: PlaceRef<'ll, 'tcx>) {
         let src = self.codegen_operand(bx, src);
         let llty = src.layout.llvm_type(bx.cx);
         let cast_ptr = bx.pointercast(dst.llval, llty.ptr_to());

--- a/src/librustc_codegen_llvm/mir/mod.rs
+++ b/src/librustc_codegen_llvm/mir/mod.rs
@@ -162,16 +162,16 @@ impl FunctionCx<'a, 'll, 'tcx> {
     // corresponding to span's containing source scope.  If so, we need to create a DIScope
     // "extension" into that file.
     fn scope_metadata_for_loc(&self, scope_id: mir::SourceScope, pos: BytePos)
-                               -> Option<&'ll DIScope> {
+                              -> Option<&'ll DIScope> {
         let scope_metadata = self.scopes[scope_id].scope_metadata;
         if pos < self.scopes[scope_id].file_start_pos ||
            pos >= self.scopes[scope_id].file_end_pos {
             let cm = self.cx.sess().source_map();
             let defining_crate = self.debug_context.get_ref(DUMMY_SP).defining_crate;
             Some(debuginfo::extend_scope_to_file(self.cx,
-                                            scope_metadata.unwrap(),
-                                            &cm.lookup_char_pos(pos).file,
-                                            defining_crate))
+                                                 scope_metadata.unwrap(),
+                                                 &cm.lookup_char_pos(pos).file,
+                                                 defining_crate))
         } else {
             scope_metadata
         }


### PR DESCRIPTION
- improve common patterns
- convert string literals with `to_owned`
- remove explicit `return`s
- whitespace & formatting improvements