### PR TITLE
Point to variable in `asm!` macro when failing borrowck

### DIFF
--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -3953,6 +3953,7 @@ impl<'a> LoweringContext<'a> {
                             constraint: out.constraint.clone(),
                             is_rw: out.is_rw,
                             is_indirect: out.is_indirect,
+                            span: out.expr.span,
                         })
                         .collect(),
                     asm: asm.asm.clone(),

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -1812,6 +1812,7 @@ pub struct InlineAsmOutput {
     pub constraint: Symbol,
     pub is_rw: bool,
     pub is_indirect: bool,
+    pub span: Span,
 }
 
 #[derive(Clone, RustcEncodable, RustcDecodable, Debug)]

--- a/src/librustc/ich/impls_hir.rs
+++ b/src/librustc/ich/impls_hir.rs
@@ -983,7 +983,8 @@ impl<'a> ToStableHashKey<StableHashingContext<'a>> for hir::BodyId {
 impl_stable_hash_for!(struct hir::InlineAsmOutput {
     constraint,
     is_rw,
-    is_indirect
+    is_indirect,
+    span
 });
 
 impl_stable_hash_for!(struct hir::GlobalAsm {

--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -544,7 +544,7 @@ impl<'cx, 'gcx, 'tcx> DataflowResultsConsumer<'cx, 'tcx> for MirBorrowckCtxt<'cx
                         // be encoeded through MIR place derefs instead.
                         self.access_place(
                             context,
-                            (output, span),
+                            (output, o.span),
                             (Deep, Read(ReadKind::Copy)),
                             LocalMutationIsAllowed::No,
                             flow_state,
@@ -552,13 +552,13 @@ impl<'cx, 'gcx, 'tcx> DataflowResultsConsumer<'cx, 'tcx> for MirBorrowckCtxt<'cx
                         self.check_if_path_or_subpath_is_moved(
                             context,
                             InitializationRequiringAction::Use,
-                            (output, span),
+                            (output, o.span),
                             flow_state,
                         );
                     } else {
                         self.mutate_place(
                             context,
-                            (output, span),
+                            (output, o.span),
                             if o.is_rw { Deep } else { Shallow(None) },
                             if o.is_rw { WriteAndRead } else { JustWrite },
                             flow_state,

--- a/src/test/ui/asm/asm-out-assign-imm.nll.stderr
+++ b/src/test/ui/asm/asm-out-assign-imm.nll.stderr
@@ -1,5 +1,5 @@
 error[E0384]: cannot assign twice to immutable variable `x`
-  --> $DIR/asm-out-assign-imm.rs:34:9
+  --> $DIR/asm-out-assign-imm.rs:34:34
    |
 LL |     let x: isize;
    |         - help: make this binding mutable: `mut x`
@@ -7,7 +7,7 @@ LL |     x = 1;
    |     ----- first assignment to `x`
 ...
 LL |         asm!("mov $1, $0" : "=r"(x) : "r"(5));
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot assign twice to immutable variable
+   |                                  ^ cannot assign twice to immutable variable
 
 error: aborting due to previous error
 

--- a/src/test/ui/asm/asm-out-assign-imm.stderr
+++ b/src/test/ui/asm/asm-out-assign-imm.stderr
@@ -1,11 +1,11 @@
 error[E0384]: cannot assign twice to immutable variable `x`
-  --> $DIR/asm-out-assign-imm.rs:34:9
+  --> $DIR/asm-out-assign-imm.rs:34:34
    |
 LL |     x = 1;
    |     ----- first assignment to `x`
 ...
 LL |         asm!("mov $1, $0" : "=r"(x) : "r"(5));
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot assign twice to immutable variable
+   |                                  ^ cannot assign twice to immutable variable
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-asm.ast.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-asm.ast.nll.stderr
@@ -22,7 +22,7 @@ LL |         let z = y;
    |                 - borrow later used here
 
 error[E0384]: cannot assign twice to immutable variable `x`
-  --> $DIR/borrowck-asm.rs:54:13
+  --> $DIR/borrowck-asm.rs:54:31
    |
 LL |         let x = 3;
    |             -
@@ -31,10 +31,10 @@ LL |         let x = 3;
    |             help: make this binding mutable: `mut x`
 LL |         unsafe {
 LL |             asm!("nop" : "=r"(x));  //[ast]~ ERROR cannot assign twice
-   |             ^^^^^^^^^^^^^^^^^^^^^^ cannot assign twice to immutable variable
+   |                               ^ cannot assign twice to immutable variable
 
 error[E0384]: cannot assign twice to immutable variable `x`
-  --> $DIR/borrowck-asm.rs:70:13
+  --> $DIR/borrowck-asm.rs:70:31
    |
 LL |         let x = 3;
    |             -
@@ -43,22 +43,22 @@ LL |         let x = 3;
    |             help: make this binding mutable: `mut x`
 LL |         unsafe {
 LL |             asm!("nop" : "+r"(x));  //[ast]~ ERROR cannot assign twice
-   |             ^^^^^^^^^^^^^^^^^^^^^^ cannot assign twice to immutable variable
+   |                               ^ cannot assign twice to immutable variable
 
 error[E0381]: use of possibly uninitialized variable: `x`
-  --> $DIR/borrowck-asm.rs:78:13
+  --> $DIR/borrowck-asm.rs:78:32
    |
 LL |             asm!("nop" : "=*r"(x)); //[ast]~ ERROR use of possibly uninitialized variable
-   |             ^^^^^^^^^^^^^^^^^^^^^^^ use of possibly uninitialized `x`
+   |                                ^ use of possibly uninitialized `x`
 
 error[E0506]: cannot assign to `x` because it is borrowed
-  --> $DIR/borrowck-asm.rs:87:13
+  --> $DIR/borrowck-asm.rs:87:31
    |
 LL |         let y = &*x;
    |                 --- borrow of `x` occurs here
 LL |         unsafe {
 LL |             asm!("nop" : "+r"(x));  //[ast]~ ERROR cannot assign to `x` because it is borrowed
-   |             ^^^^^^^^^^^^^^^^^^^^^^ assignment to borrowed `x` occurs here
+   |                               ^ assignment to borrowed `x` occurs here
 ...
 LL |         let z = y;
    |                 - borrow later used here

--- a/src/test/ui/borrowck/borrowck-asm.ast.stderr
+++ b/src/test/ui/borrowck/borrowck-asm.ast.stderr
@@ -19,31 +19,31 @@ LL |             asm!("nop" : : "r"(x)); //[ast]~ ERROR cannot use
    |                                ^ use of borrowed `x`
 
 error[E0384]: cannot assign twice to immutable variable `x`
-  --> $DIR/borrowck-asm.rs:54:13
+  --> $DIR/borrowck-asm.rs:54:31
    |
 LL |         let x = 3;
    |             - first assignment to `x`
 LL |         unsafe {
 LL |             asm!("nop" : "=r"(x));  //[ast]~ ERROR cannot assign twice
-   |             ^^^^^^^^^^^^^^^^^^^^^^ cannot assign twice to immutable variable
+   |                               ^ cannot assign twice to immutable variable
 
 error[E0506]: cannot assign to `a` because it is borrowed
-  --> $DIR/borrowck-asm.rs:60:13
+  --> $DIR/borrowck-asm.rs:60:31
    |
 LL |         let b = &*a;
    |                  -- borrow of `a` occurs here
 LL |         unsafe {
 LL |             asm!("nop" : "=r"(a));  //[ast]~ ERROR cannot assign to `a` because it is borrowed
-   |             ^^^^^^^^^^^^^^^^^^^^^^ assignment to borrowed `a` occurs here
+   |                               ^ assignment to borrowed `a` occurs here
 
 error[E0384]: cannot assign twice to immutable variable `x`
-  --> $DIR/borrowck-asm.rs:70:13
+  --> $DIR/borrowck-asm.rs:70:31
    |
 LL |         let x = 3;
    |             - first assignment to `x`
 LL |         unsafe {
 LL |             asm!("nop" : "+r"(x));  //[ast]~ ERROR cannot assign twice
-   |             ^^^^^^^^^^^^^^^^^^^^^^ cannot assign twice to immutable variable
+   |                               ^ cannot assign twice to immutable variable
 
 error[E0381]: use of possibly uninitialized variable: `x`
   --> $DIR/borrowck-asm.rs:78:32
@@ -52,13 +52,13 @@ LL |             asm!("nop" : "=*r"(x)); //[ast]~ ERROR use of possibly uninitia
    |                                ^ use of possibly uninitialized `x`
 
 error[E0506]: cannot assign to `x` because it is borrowed
-  --> $DIR/borrowck-asm.rs:87:13
+  --> $DIR/borrowck-asm.rs:87:31
    |
 LL |         let y = &*x;
    |                  -- borrow of `x` occurs here
 LL |         unsafe {
 LL |             asm!("nop" : "+r"(x));  //[ast]~ ERROR cannot assign to `x` because it is borrowed
-   |             ^^^^^^^^^^^^^^^^^^^^^^ assignment to borrowed `x` occurs here
+   |                               ^ assignment to borrowed `x` occurs here
 
 error[E0382]: use of moved value: `x`
   --> $DIR/borrowck-asm.rs:96:40

--- a/src/test/ui/borrowck/borrowck-asm.mir.stderr
+++ b/src/test/ui/borrowck/borrowck-asm.mir.stderr
@@ -22,7 +22,7 @@ LL |         let z = y;
    |                 - borrow later used here
 
 error[E0384]: cannot assign twice to immutable variable `x`
-  --> $DIR/borrowck-asm.rs:54:13
+  --> $DIR/borrowck-asm.rs:54:31
    |
 LL |         let x = 3;
    |             -
@@ -31,10 +31,10 @@ LL |         let x = 3;
    |             help: make this binding mutable: `mut x`
 LL |         unsafe {
 LL |             asm!("nop" : "=r"(x));  //[ast]~ ERROR cannot assign twice
-   |             ^^^^^^^^^^^^^^^^^^^^^^ cannot assign twice to immutable variable
+   |                               ^ cannot assign twice to immutable variable
 
 error[E0384]: cannot assign twice to immutable variable `x`
-  --> $DIR/borrowck-asm.rs:70:13
+  --> $DIR/borrowck-asm.rs:70:31
    |
 LL |         let x = 3;
    |             -
@@ -43,22 +43,22 @@ LL |         let x = 3;
    |             help: make this binding mutable: `mut x`
 LL |         unsafe {
 LL |             asm!("nop" : "+r"(x));  //[ast]~ ERROR cannot assign twice
-   |             ^^^^^^^^^^^^^^^^^^^^^^ cannot assign twice to immutable variable
+   |                               ^ cannot assign twice to immutable variable
 
 error[E0381]: use of possibly uninitialized variable: `x`
-  --> $DIR/borrowck-asm.rs:78:13
+  --> $DIR/borrowck-asm.rs:78:32
    |
 LL |             asm!("nop" : "=*r"(x)); //[ast]~ ERROR use of possibly uninitialized variable
-   |             ^^^^^^^^^^^^^^^^^^^^^^^ use of possibly uninitialized `x`
+   |                                ^ use of possibly uninitialized `x`
 
 error[E0506]: cannot assign to `x` because it is borrowed
-  --> $DIR/borrowck-asm.rs:87:13
+  --> $DIR/borrowck-asm.rs:87:31
    |
 LL |         let y = &*x;
    |                 --- borrow of `x` occurs here
 LL |         unsafe {
 LL |             asm!("nop" : "+r"(x));  //[ast]~ ERROR cannot assign to `x` because it is borrowed
-   |             ^^^^^^^^^^^^^^^^^^^^^^ assignment to borrowed `x` occurs here
+   |                               ^ assignment to borrowed `x` occurs here
 ...
 LL |         let z = y;
    |                 - borrow later used here


### PR DESCRIPTION
Fix #34940.