### PR TITLE
Add filtering option to `rustc_on_unimplemented` and reword `Iterator` E0277 errors

### DIFF
--- a/src/libcore/iter/iterator.rs
+++ b/src/libcore/iter/iterator.rs
@@ -33,8 +33,32 @@ fn _assert_is_object_safe(_: &dyn Iterator<Item=()>) {}
     on(
         _Self="[std::ops::Range<Idx>; 1]",
         label="if you meant to iterate between two values, remove the square brackets",
-        note="`[start..end]` is an array of one `Range`, you might have meant to have a `Range`: \
-              `start..end`"
+        note="`[start..end]` is an array of one `Range`; you might have meant to have a `Range` \
+              without the brackets: `start..end`"
+    ),
+    on(
+        _Self="[std::ops::RangeFrom<Idx>; 1]",
+        label="if you meant to iterate from a value onwards, remove the square brackets",
+        note="`[start..]` is an array of one `RangeFrom`; you might have meant to have a \
+              `RangeFrom` without the brackets: `start..`"
+    ),
+    on(
+        _Self="[std::ops::RangeTo<Idx>; 1]",
+        label="if you meant to iterate until a value, remove the square brackets",
+        note="`[..end]` is an array of one `RangeTo`; you might have meant to have a \
+              `RangeTo` without the brackets: `..end`"
+    ),
+    on(
+        _Self="[std::ops::RangeInclusive<Idx>; 1]",
+        label="if you meant to iterate between two values, remove the square brackets",
+        note="`[start..=end]` is an array of one `RangeInclusive`; you might have meant to have a \
+              `RangeInclusive` without the brackets: `start..=end`"
+    ),
+    on(
+        _Self="[std::ops::RangeToInclusive<Idx>; 1]",
+        label="if you meant to iterate until a value, remove the square brackets",
+        note="`[..=end]` is an array of one `RangeToInclusive`; you might have meant to have a \
+              `RangeToInclusive` without the brackets: `..=end`"
     ),
     on(
         _Self="&str",
@@ -51,8 +75,8 @@ fn _assert_is_object_safe(_: &dyn Iterator<Item=()>) {}
     ),
     on(
         _Self="{integral}",
-        note="if you want to iterate between `0` until a value `end`, use the range syntax: \
-              `0..end`"
+        note="if you want to iterate between `start` until a value `end`, use the exclusive range \
+              syntax `start..end` or the inclusive range syntax `start..=end`"
     ),
     label="`{Self}` is not an iterator",
     message="`{Self}` is not an iterator"

--- a/src/libcore/iter/iterator.rs
+++ b/src/libcore/iter/iterator.rs
@@ -31,10 +31,29 @@ fn _assert_is_object_safe(_: &dyn Iterator<Item=()>) {}
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_on_unimplemented(
     on(
+        _Self="[std::ops::Range<Idx>; 1]",
+        label="if you meant to iterate between two values, remove the square brackets",
+        note="`[start..end]` is an array of one `Range`, you might have meant to have a `Range`: `start..end`"
+    ),
+    on(
         _Self="&str",
         label="`{Self}` is not an iterator; try calling `.chars()` or `.bytes()`"
     ),
-    label="`{Self}` is not an iterator; maybe try calling `.iter()` or a similar method"
+    on(
+        _Self="std::string::String",
+        label="`{Self}` is not an iterator; try calling `.chars()` or `.bytes()`"
+    ),
+    on(
+        _Self="[]",
+        label="borrow the array with `&` or call `.iter()` on it to iterate over it",
+        note="arrays are not an iterators, but slices like the following are: `&[1, 2, 3]`"
+    ),
+    on(
+        _Self="{integral}",
+        note="if you want to iterate between `0` until a value `end`, use the range syntax: `0..end`"
+    ),
+    label="`{Self}` is not an iterator",
+    message="`{Self}` is not an iterator"
 )]
 #[doc(spotlight)]
 pub trait Iterator {

--- a/src/libcore/iter/iterator.rs
+++ b/src/libcore/iter/iterator.rs
@@ -33,7 +33,8 @@ fn _assert_is_object_safe(_: &dyn Iterator<Item=()>) {}
     on(
         _Self="[std::ops::Range<Idx>; 1]",
         label="if you meant to iterate between two values, remove the square brackets",
-        note="`[start..end]` is an array of one `Range`, you might have meant to have a `Range`: `start..end`"
+        note="`[start..end]` is an array of one `Range`, you might have meant to have a `Range`: \
+              `start..end`"
     ),
     on(
         _Self="&str",
@@ -50,7 +51,8 @@ fn _assert_is_object_safe(_: &dyn Iterator<Item=()>) {}
     ),
     on(
         _Self="{integral}",
-        note="if you want to iterate between `0` until a value `end`, use the range syntax: `0..end`"
+        note="if you want to iterate between `0` until a value `end`, use the range syntax: \
+              `0..end`"
     ),
     label="`{Self}` is not an iterator",
     message="`{Self}` is not an iterator"

--- a/src/libcore/iter/iterator.rs
+++ b/src/libcore/iter/iterator.rs
@@ -40,13 +40,16 @@ fn _assert_is_object_safe(_: &dyn Iterator<Item=()>) {}
         _Self="[std::ops::RangeFrom<Idx>; 1]",
         label="if you meant to iterate from a value onwards, remove the square brackets",
         note="`[start..]` is an array of one `RangeFrom`; you might have meant to have a \
-              `RangeFrom` without the brackets: `start..`"
+              `RangeFrom` without the brackets: `start..`, keeping in mind that iterating over an \
+              unbounded iterator will run forever unless you `break` or `return` from within the \
+              loop"
     ),
     on(
         _Self="[std::ops::RangeTo<Idx>; 1]",
-        label="if you meant to iterate until a value, remove the square brackets",
-        note="`[..end]` is an array of one `RangeTo`; you might have meant to have a \
-              `RangeTo` without the brackets: `..end`"
+        label="if you meant to iterate until a value, remove the square brackets and add a \
+               starting value",
+        note="`[..end]` is an array of one `RangeTo`; you might have meant to have a bounded \
+              `Range` without the brackets: `0..end`"
     ),
     on(
         _Self="[std::ops::RangeInclusive<Idx>; 1]",
@@ -56,9 +59,22 @@ fn _assert_is_object_safe(_: &dyn Iterator<Item=()>) {}
     ),
     on(
         _Self="[std::ops::RangeToInclusive<Idx>; 1]",
-        label="if you meant to iterate until a value, remove the square brackets",
+        label="if you meant to iterate until a value (including it), remove the square brackets \
+               and add a starting value",
         note="`[..=end]` is an array of one `RangeToInclusive`; you might have meant to have a \
-              `RangeToInclusive` without the brackets: `..=end`"
+              bounded `RangeInclusive` without the brackets: `0..=end`"
+    ),
+    on(
+        _Self="std::ops::RangeTo<Idx>",
+        label="if you meant to iterate until a value, add a starting value",
+        note="`..end` is a `RangeTo`, which cannot be iterated on; you might have meant to have a \
+              bounded `Range`: `0..end`"
+    ),
+    on(
+        _Self="std::ops::RangeToInclusive<Idx>",
+        label="if you meant to iterate until a value (including it), add a starting value",
+        note="`..=end` is a `RangeToInclusive`, which cannot be iterated on; you might have meant \
+              to have a bounded `RangeInclusive`: `0..=end`"
     ),
     on(
         _Self="&str",

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -349,10 +349,9 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
     fn on_unimplemented_note(
         &self,
         trait_ref: ty::PolyTraitRef<'tcx>,
-        obligation: &PredicateObligation<'tcx>) ->
-        OnUnimplementedNote
-    {
-        let def_id = self.impl_similar_to(trait_ref, obligation)
+        obligation: &PredicateObligation<'tcx>,
+    ) -> OnUnimplementedNote {
+    let def_id = self.impl_similar_to(trait_ref, obligation)
             .unwrap_or(trait_ref.def_id());
         let trait_ref = *trait_ref.skip_binder();
 
@@ -408,6 +407,37 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
 
         if let Some(true) = self_ty.ty_adt_def().map(|def| def.did.is_local()) {
             flags.push(("crate_local".to_owned(), None));
+        }
+
+        // Allow targetting all integers using `{integral}`, even if the exact type was resolved
+        if self_ty.is_integral() {
+            flags.push(("_Self".to_owned(), Some("{integral}".to_owned())));
+        }
+
+        if let ty::Array(aty, len) = self_ty.sty {
+            flags.push(("_Self".to_owned(), Some("[]".to_owned())));
+            flags.push(("_Self".to_owned(), Some(format!("[{}]", aty))));
+            if let Some(def) = aty.ty_adt_def() {
+                // We also want to be able to select the array's type's original
+                // signature with no type arguments resolved
+                flags.push((
+                    "_Self".to_owned(),
+                    Some(format!("[{}]", self.tcx.type_of(def.did).to_string())),
+                ));
+                if let Some(len) = len.val.try_to_scalar().and_then(|scalar| {
+                    scalar.to_u64().ok()
+                }) {
+                    flags.push((
+                        "_Self".to_owned(),
+                        Some(format!("[{}; {}]", self.tcx.type_of(def.did).to_string(), len)),
+                    ));
+                } else {
+                    flags.push((
+                        "_Self".to_owned(),
+                        Some(format!("[{}; _]", self.tcx.type_of(def.did).to_string())),
+                    ));
+                }
+            }
         }
 
         if let Ok(Some(command)) = OnUnimplementedDirective::of_item(

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -351,7 +351,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
         trait_ref: ty::PolyTraitRef<'tcx>,
         obligation: &PredicateObligation<'tcx>,
     ) -> OnUnimplementedNote {
-    let def_id = self.impl_similar_to(trait_ref, obligation)
+        let def_id = self.impl_similar_to(trait_ref, obligation)
             .unwrap_or(trait_ref.def_id());
         let trait_ref = *trait_ref.skip_binder();
 

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -424,8 +424,9 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                     "_Self".to_owned(),
                     Some(format!("[{}]", self.tcx.type_of(def.did).to_string())),
                 ));
+                let tcx = self.tcx;
                 if let Some(len) = len.val.try_to_scalar().and_then(|scalar| {
-                    scalar.to_u64().ok()
+                    scalar.to_usize(tcx).ok()
                 }) {
                     flags.push((
                         "_Self".to_owned(),

--- a/src/test/ui/conservative_impl_trait.rs
+++ b/src/test/ui/conservative_impl_trait.rs
@@ -11,7 +11,7 @@
 // #39872, #39553
 
 fn will_ice(something: &u32) -> impl Iterator<Item = &u32> {
-    //~^ ERROR the trait bound `(): std::iter::Iterator` is not satisfied [E0277]
+    //~^ ERROR `()` is not an iterator
 }
 
 fn main() {}

--- a/src/test/ui/conservative_impl_trait.stderr
+++ b/src/test/ui/conservative_impl_trait.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `(): std::iter::Iterator` is not satisfied
+error[E0277]: `()` is not an iterator
   --> $DIR/conservative_impl_trait.rs:13:33
    |
 LL | fn will_ice(something: &u32) -> impl Iterator<Item = &u32> {
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ `()` is not an iterator; maybe try calling `.iter()` or a similar method
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ `()` is not an iterator
    |
    = help: the trait `std::iter::Iterator` is not implemented for `()`
    = note: the return type of a function must have a statically known size

--- a/src/test/ui/feature-gates/feature-gate-trivial_bounds.stderr
+++ b/src/test/ui/feature-gates/feature-gate-trivial_bounds.stderr
@@ -75,15 +75,16 @@ LL | | }
    = help: see issue #48214
    = help: add #![feature(trivial_bounds)] to the crate attributes to enable
 
-error[E0277]: the trait bound `i32: std::iter::Iterator` is not satisfied
+error[E0277]: `i32` is not an iterator
   --> $DIR/feature-gate-trivial_bounds.rs:50:1
    |
 LL | / fn use_for() where i32: Iterator { //~ ERROR
 LL | |     for _ in 2i32 {}
 LL | | }
-   | |_^ `i32` is not an iterator; maybe try calling `.iter()` or a similar method
+   | |_^ `i32` is not an iterator
    |
    = help: the trait `std::iter::Iterator` is not implemented for `i32`
+   = note: if you want to iterate between `0` until a value `end`, use the range syntax: `0..end`
    = help: see issue #48214
    = help: add #![feature(trivial_bounds)] to the crate attributes to enable
 

--- a/src/test/ui/feature-gates/feature-gate-trivial_bounds.stderr
+++ b/src/test/ui/feature-gates/feature-gate-trivial_bounds.stderr
@@ -84,7 +84,7 @@ LL | | }
    | |_^ `i32` is not an iterator
    |
    = help: the trait `std::iter::Iterator` is not implemented for `i32`
-   = note: if you want to iterate between `0` until a value `end`, use the range syntax: `0..end`
+   = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
    = help: see issue #48214
    = help: add #![feature(trivial_bounds)] to the crate attributes to enable
 

--- a/src/test/ui/for/for-c-in-str.rs
+++ b/src/test/ui/for/for-c-in-str.rs
@@ -12,7 +12,7 @@
 
 fn main() {
     for c in "asdf" {
-    //~^ ERROR the trait bound `&str: std::iter::Iterator` is not satisfied
+    //~^ ERROR `&str` is not an iterator
     //~| NOTE `&str` is not an iterator
     //~| HELP the trait `std::iter::Iterator` is not implemented for `&str`
     //~| NOTE required by `std::iter::IntoIterator::into_iter`

--- a/src/test/ui/for/for-c-in-str.stderr
+++ b/src/test/ui/for/for-c-in-str.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the trait bound `&str: std::iter::Iterator` is not satisfied
+error[E0277]: `&str` is not an iterator
   --> $DIR/for-c-in-str.rs:14:14
    |
 LL |     for c in "asdf" {

--- a/src/test/ui/for/for-loop-bogosity.rs
+++ b/src/test/ui/for/for-loop-bogosity.rs
@@ -24,7 +24,8 @@ pub fn main() {
         x: 1,
         y: 2,
     };
-    for x in bogus { //~ ERROR `MyStruct: std::iter::Iterator` is not satisfied
+    for x in bogus {
+    //~^ ERROR `MyStruct` is not an iterator
         drop(x);
     }
 }

--- a/src/test/ui/for/for-loop-bogosity.stderr
+++ b/src/test/ui/for/for-loop-bogosity.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `MyStruct: std::iter::Iterator` is not satisfied
+error[E0277]: `MyStruct` is not an iterator
   --> $DIR/for-loop-bogosity.rs:27:14
    |
-LL |     for x in bogus { //~ ERROR `MyStruct: std::iter::Iterator` is not satisfied
-   |              ^^^^^ `MyStruct` is not an iterator; maybe try calling `.iter()` or a similar method
+LL |     for x in bogus {
+   |              ^^^^^ `MyStruct` is not an iterator
    |
    = help: the trait `std::iter::Iterator` is not implemented for `MyStruct`
    = note: required by `std::iter::IntoIterator::into_iter`

--- a/src/test/ui/issues/issue-22872.rs
+++ b/src/test/ui/issues/issue-22872.rs
@@ -1,0 +1,23 @@
+trait Wrap<'b> {
+    fn foo(&'b mut self);
+}
+
+struct Wrapper<P>(P);
+
+impl<'b, P> Wrap<'b> for Wrapper<P>
+where P: Process<'b>,
+      <P as Process<'b>>::Item: Iterator {
+    fn foo(&mut self) {}
+}
+
+
+pub trait Process<'a> {
+    type Item;
+    fn bar(&'a self);
+}
+
+fn push_process<P>(process: P) where P: Process<'static> {
+    let _: Box<for<'b> Wrap<'b>> = Box::new(Wrapper(process));
+}
+
+fn main() {}

--- a/src/test/ui/issues/issue-22872.stderr
+++ b/src/test/ui/issues/issue-22872.stderr
@@ -1,0 +1,23 @@
+error[E0277]: the trait bound `for<'b> P: Process<'b>` is not satisfied
+  --> $DIR/issue-22872.rs:20:36
+   |
+LL |     let _: Box<for<'b> Wrap<'b>> = Box::new(Wrapper(process));
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `for<'b> Process<'b>` is not implemented for `P`
+   |
+   = help: consider adding a `where for<'b> P: Process<'b>` bound
+   = note: required because of the requirements on the impl of `for<'b> Wrap<'b>` for `Wrapper<P>`
+   = note: required for the cast to the object type `dyn for<'b> Wrap<'b>`
+
+error[E0277]: `<P as Process<'b>>::Item` is not an iterator
+  --> $DIR/issue-22872.rs:20:36
+   |
+LL |     let _: Box<for<'b> Wrap<'b>> = Box::new(Wrapper(process));
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^ `<P as Process<'b>>::Item` is not an iterator
+   |
+   = help: the trait `for<'b> std::iter::Iterator` is not implemented for `<P as Process<'b>>::Item`
+   = note: required because of the requirements on the impl of `for<'b> Wrap<'b>` for `Wrapper<P>`
+   = note: required for the cast to the object type `dyn for<'b> Wrap<'b>`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/issues/issue-28098.rs
+++ b/src/test/ui/issues/issue-28098.rs
@@ -10,13 +10,13 @@
 
 fn main() {
     let _ = Iterator::next(&mut ());
-    //~^ ERROR `(): std::iter::Iterator` is not satisfied
+    //~^ ERROR `()` is not an iterator
 
     for _ in false {}
-    //~^ ERROR `bool: std::iter::Iterator` is not satisfied
+    //~^ ERROR `bool` is not an iterator
 
     let _ = Iterator::next(&mut ());
-    //~^ ERROR `(): std::iter::Iterator` is not satisfied
+    //~^ ERROR `()` is not an iterator
 
     other()
 }
@@ -25,11 +25,11 @@ pub fn other() {
     // check errors are still reported globally
 
     let _ = Iterator::next(&mut ());
-    //~^ ERROR `(): std::iter::Iterator` is not satisfied
+    //~^ ERROR `()` is not an iterator
 
     let _ = Iterator::next(&mut ());
-    //~^ ERROR `(): std::iter::Iterator` is not satisfied
+    //~^ ERROR `()` is not an iterator
 
     for _ in false {}
-    //~^ ERROR `bool: std::iter::Iterator` is not satisfied
+    //~^ ERROR `bool` is not an iterator
 }

--- a/src/test/ui/issues/issue-28098.stderr
+++ b/src/test/ui/issues/issue-28098.stderr
@@ -1,53 +1,53 @@
-error[E0277]: the trait bound `(): std::iter::Iterator` is not satisfied
+error[E0277]: `()` is not an iterator
   --> $DIR/issue-28098.rs:12:13
    |
 LL |     let _ = Iterator::next(&mut ());
-   |             ^^^^^^^^^^^^^^ `()` is not an iterator; maybe try calling `.iter()` or a similar method
+   |             ^^^^^^^^^^^^^^ `()` is not an iterator
    |
    = help: the trait `std::iter::Iterator` is not implemented for `()`
    = note: required by `std::iter::Iterator::next`
 
-error[E0277]: the trait bound `bool: std::iter::Iterator` is not satisfied
+error[E0277]: `bool` is not an iterator
   --> $DIR/issue-28098.rs:15:14
    |
 LL |     for _ in false {}
-   |              ^^^^^ `bool` is not an iterator; maybe try calling `.iter()` or a similar method
+   |              ^^^^^ `bool` is not an iterator
    |
    = help: the trait `std::iter::Iterator` is not implemented for `bool`
    = note: required by `std::iter::IntoIterator::into_iter`
 
-error[E0277]: the trait bound `(): std::iter::Iterator` is not satisfied
+error[E0277]: `()` is not an iterator
   --> $DIR/issue-28098.rs:18:13
    |
 LL |     let _ = Iterator::next(&mut ());
-   |             ^^^^^^^^^^^^^^ `()` is not an iterator; maybe try calling `.iter()` or a similar method
+   |             ^^^^^^^^^^^^^^ `()` is not an iterator
    |
    = help: the trait `std::iter::Iterator` is not implemented for `()`
    = note: required by `std::iter::Iterator::next`
 
-error[E0277]: the trait bound `(): std::iter::Iterator` is not satisfied
+error[E0277]: `()` is not an iterator
   --> $DIR/issue-28098.rs:27:13
    |
 LL |     let _ = Iterator::next(&mut ());
-   |             ^^^^^^^^^^^^^^ `()` is not an iterator; maybe try calling `.iter()` or a similar method
+   |             ^^^^^^^^^^^^^^ `()` is not an iterator
    |
    = help: the trait `std::iter::Iterator` is not implemented for `()`
    = note: required by `std::iter::Iterator::next`
 
-error[E0277]: the trait bound `(): std::iter::Iterator` is not satisfied
+error[E0277]: `()` is not an iterator
   --> $DIR/issue-28098.rs:30:13
    |
 LL |     let _ = Iterator::next(&mut ());
-   |             ^^^^^^^^^^^^^^ `()` is not an iterator; maybe try calling `.iter()` or a similar method
+   |             ^^^^^^^^^^^^^^ `()` is not an iterator
    |
    = help: the trait `std::iter::Iterator` is not implemented for `()`
    = note: required by `std::iter::Iterator::next`
 
-error[E0277]: the trait bound `bool: std::iter::Iterator` is not satisfied
+error[E0277]: `bool` is not an iterator
   --> $DIR/issue-28098.rs:33:14
    |
 LL |     for _ in false {}
-   |              ^^^^^ `bool` is not an iterator; maybe try calling `.iter()` or a similar method
+   |              ^^^^^ `bool` is not an iterator
    |
    = help: the trait `std::iter::Iterator` is not implemented for `bool`
    = note: required by `std::iter::IntoIterator::into_iter`

--- a/src/test/ui/issues/issue-50480.rs
+++ b/src/test/ui/issues/issue-50480.rs
@@ -12,6 +12,6 @@
 //~^ ERROR the trait `Copy` may not be implemented for this type
 struct Foo(NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
 //~^ ERROR cannot find type `NotDefined` in this scope
-//~| ERROR the trait bound `i32: std::iter::Iterator` is not satisfied
+//~| ERROR `i32` is not an iterator
 
 fn main() {}

--- a/src/test/ui/issues/issue-50480.stderr
+++ b/src/test/ui/issues/issue-50480.stderr
@@ -11,7 +11,7 @@ LL | struct Foo(NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
    |                        ^^^^^^^^^^^^^^^^^^^^^^^ `i32` is not an iterator
    |
    = help: the trait `std::iter::Iterator` is not implemented for `i32`
-   = note: if you want to iterate between `0` until a value `end`, use the range syntax: `0..end`
+   = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
 
 error[E0204]: the trait `Copy` may not be implemented for this type
   --> $DIR/issue-50480.rs:11:17

--- a/src/test/ui/issues/issue-50480.stderr
+++ b/src/test/ui/issues/issue-50480.stderr
@@ -4,13 +4,14 @@ error[E0412]: cannot find type `NotDefined` in this scope
 LL | struct Foo(NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
    |            ^^^^^^^^^^ not found in this scope
 
-error[E0277]: the trait bound `i32: std::iter::Iterator` is not satisfied
+error[E0277]: `i32` is not an iterator
   --> $DIR/issue-50480.rs:13:24
    |
 LL | struct Foo(NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
-   |                        ^^^^^^^^^^^^^^^^^^^^^^^ `i32` is not an iterator; maybe try calling `.iter()` or a similar method
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^ `i32` is not an iterator
    |
    = help: the trait `std::iter::Iterator` is not implemented for `i32`
+   = note: if you want to iterate between `0` until a value `end`, use the range syntax: `0..end`
 
 error[E0204]: the trait `Copy` may not be implemented for this type
   --> $DIR/issue-50480.rs:11:17

--- a/src/test/ui/iterators/array-of-ranges.rs
+++ b/src/test/ui/iterators/array-of-ranges.rs
@@ -1,0 +1,9 @@
+fn main() {
+    for _ in [0..1] {}
+    let start = 0;
+    let end = 0;
+    for _ in [start..end] {}
+    let array_of_range = [start..end];
+    for _ in array_of_range {}
+    for _ in [0..1, 2..3] {}
+}

--- a/src/test/ui/iterators/array-of-ranges.rs
+++ b/src/test/ui/iterators/array-of-ranges.rs
@@ -1,9 +1,14 @@
 fn main() {
     for _ in [0..1] {}
+    for _ in [0..=1] {}
+    for _ in [0..] {}
+    for _ in [..1] {}
+    for _ in [..=1] {}
     let start = 0;
     let end = 0;
     for _ in [start..end] {}
     let array_of_range = [start..end];
     for _ in array_of_range {}
     for _ in [0..1, 2..3] {}
+    for _ in [0..=1] {}
 }

--- a/src/test/ui/iterators/array-of-ranges.stderr
+++ b/src/test/ui/iterators/array-of-ranges.stderr
@@ -1,0 +1,43 @@
+error[E0277]: `[std::ops::Range<{integer}>; 1]` is not an iterator
+  --> $DIR/array-of-ranges.rs:2:14
+   |
+LL |     for _ in [0..1] {}
+   |              ^^^^^^ if you meant to iterate between two values, remove the square brackets
+   |
+   = help: the trait `std::iter::Iterator` is not implemented for `[std::ops::Range<{integer}>; 1]`
+   = note: `[start..end]` is an array of one `Range`, you might have meant to have a `Range`: `start..end`
+   = note: required by `std::iter::IntoIterator::into_iter`
+
+error[E0277]: `[std::ops::Range<{integer}>; 1]` is not an iterator
+  --> $DIR/array-of-ranges.rs:5:14
+   |
+LL |     for _ in [start..end] {}
+   |              ^^^^^^^^^^^^ if you meant to iterate between two values, remove the square brackets
+   |
+   = help: the trait `std::iter::Iterator` is not implemented for `[std::ops::Range<{integer}>; 1]`
+   = note: `[start..end]` is an array of one `Range`, you might have meant to have a `Range`: `start..end`
+   = note: required by `std::iter::IntoIterator::into_iter`
+
+error[E0277]: `[std::ops::Range<{integer}>; 1]` is not an iterator
+  --> $DIR/array-of-ranges.rs:7:14
+   |
+LL |     for _ in array_of_range {}
+   |              ^^^^^^^^^^^^^^ if you meant to iterate between two values, remove the square brackets
+   |
+   = help: the trait `std::iter::Iterator` is not implemented for `[std::ops::Range<{integer}>; 1]`
+   = note: `[start..end]` is an array of one `Range`, you might have meant to have a `Range`: `start..end`
+   = note: required by `std::iter::IntoIterator::into_iter`
+
+error[E0277]: `[std::ops::Range<{integer}>; 2]` is not an iterator
+  --> $DIR/array-of-ranges.rs:8:14
+   |
+LL |     for _ in [0..1, 2..3] {}
+   |              ^^^^^^^^^^^^ borrow the array with `&` or call `.iter()` on it to iterate over it
+   |
+   = help: the trait `std::iter::Iterator` is not implemented for `[std::ops::Range<{integer}>; 2]`
+   = note: arrays are not an iterators, but slices like the following are: `&[1, 2, 3]`
+   = note: required by `std::iter::IntoIterator::into_iter`
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/iterators/array-of-ranges.stderr
+++ b/src/test/ui/iterators/array-of-ranges.stderr
@@ -5,7 +5,7 @@ LL |     for _ in [0..1] {}
    |              ^^^^^^ if you meant to iterate between two values, remove the square brackets
    |
    = help: the trait `std::iter::Iterator` is not implemented for `[std::ops::Range<{integer}>; 1]`
-   = note: `[start..end]` is an array of one `Range`, you might have meant to have a `Range`: `start..end`
+   = note: `[start..end]` is an array of one `Range`; you might have meant to have a `Range` without the brackets: `start..end`
    = note: required by `std::iter::IntoIterator::into_iter`
 
 error[E0277]: `[std::ops::Range<{integer}>; 1]` is not an iterator
@@ -15,7 +15,7 @@ LL |     for _ in [start..end] {}
    |              ^^^^^^^^^^^^ if you meant to iterate between two values, remove the square brackets
    |
    = help: the trait `std::iter::Iterator` is not implemented for `[std::ops::Range<{integer}>; 1]`
-   = note: `[start..end]` is an array of one `Range`, you might have meant to have a `Range`: `start..end`
+   = note: `[start..end]` is an array of one `Range`; you might have meant to have a `Range` without the brackets: `start..end`
    = note: required by `std::iter::IntoIterator::into_iter`
 
 error[E0277]: `[std::ops::Range<{integer}>; 1]` is not an iterator
@@ -25,7 +25,7 @@ LL |     for _ in array_of_range {}
    |              ^^^^^^^^^^^^^^ if you meant to iterate between two values, remove the square brackets
    |
    = help: the trait `std::iter::Iterator` is not implemented for `[std::ops::Range<{integer}>; 1]`
-   = note: `[start..end]` is an array of one `Range`, you might have meant to have a `Range`: `start..end`
+   = note: `[start..end]` is an array of one `Range`; you might have meant to have a `Range` without the brackets: `start..end`
    = note: required by `std::iter::IntoIterator::into_iter`
 
 error[E0277]: `[std::ops::Range<{integer}>; 2]` is not an iterator

--- a/src/test/ui/iterators/array-of-ranges.stderr
+++ b/src/test/ui/iterators/array-of-ranges.stderr
@@ -8,8 +8,48 @@ LL |     for _ in [0..1] {}
    = note: `[start..end]` is an array of one `Range`; you might have meant to have a `Range` without the brackets: `start..end`
    = note: required by `std::iter::IntoIterator::into_iter`
 
-error[E0277]: `[std::ops::Range<{integer}>; 1]` is not an iterator
+error[E0277]: `[std::ops::RangeInclusive<{integer}>; 1]` is not an iterator
+  --> $DIR/array-of-ranges.rs:3:14
+   |
+LL |     for _ in [0..=1] {}
+   |              ^^^^^^^ if you meant to iterate between two values, remove the square brackets
+   |
+   = help: the trait `std::iter::Iterator` is not implemented for `[std::ops::RangeInclusive<{integer}>; 1]`
+   = note: `[start..=end]` is an array of one `RangeInclusive`; you might have meant to have a `RangeInclusive` without the brackets: `start..=end`
+   = note: required by `std::iter::IntoIterator::into_iter`
+
+error[E0277]: `[std::ops::RangeFrom<{integer}>; 1]` is not an iterator
+  --> $DIR/array-of-ranges.rs:4:14
+   |
+LL |     for _ in [0..] {}
+   |              ^^^^^ if you meant to iterate from a value onwards, remove the square brackets
+   |
+   = help: the trait `std::iter::Iterator` is not implemented for `[std::ops::RangeFrom<{integer}>; 1]`
+   = note: `[start..]` is an array of one `RangeFrom`; you might have meant to have a `RangeFrom` without the brackets: `start..`, keeping in mind that iterating over an unbounded iterator will run forever unless you `break` or `return` from within the loop
+   = note: required by `std::iter::IntoIterator::into_iter`
+
+error[E0277]: `[std::ops::RangeTo<{integer}>; 1]` is not an iterator
   --> $DIR/array-of-ranges.rs:5:14
+   |
+LL |     for _ in [..1] {}
+   |              ^^^^^ if you meant to iterate until a value, remove the square brackets and add a starting value
+   |
+   = help: the trait `std::iter::Iterator` is not implemented for `[std::ops::RangeTo<{integer}>; 1]`
+   = note: `[..end]` is an array of one `RangeTo`; you might have meant to have a bounded `Range` without the brackets: `0..end`
+   = note: required by `std::iter::IntoIterator::into_iter`
+
+error[E0277]: `[std::ops::RangeToInclusive<{integer}>; 1]` is not an iterator
+  --> $DIR/array-of-ranges.rs:6:14
+   |
+LL |     for _ in [..=1] {}
+   |              ^^^^^^ if you meant to iterate until a value (including it), remove the square brackets and add a starting value
+   |
+   = help: the trait `std::iter::Iterator` is not implemented for `[std::ops::RangeToInclusive<{integer}>; 1]`
+   = note: `[..=end]` is an array of one `RangeToInclusive`; you might have meant to have a bounded `RangeInclusive` without the brackets: `0..=end`
+   = note: required by `std::iter::IntoIterator::into_iter`
+
+error[E0277]: `[std::ops::Range<{integer}>; 1]` is not an iterator
+  --> $DIR/array-of-ranges.rs:9:14
    |
 LL |     for _ in [start..end] {}
    |              ^^^^^^^^^^^^ if you meant to iterate between two values, remove the square brackets
@@ -19,7 +59,7 @@ LL |     for _ in [start..end] {}
    = note: required by `std::iter::IntoIterator::into_iter`
 
 error[E0277]: `[std::ops::Range<{integer}>; 1]` is not an iterator
-  --> $DIR/array-of-ranges.rs:7:14
+  --> $DIR/array-of-ranges.rs:11:14
    |
 LL |     for _ in array_of_range {}
    |              ^^^^^^^^^^^^^^ if you meant to iterate between two values, remove the square brackets
@@ -29,7 +69,7 @@ LL |     for _ in array_of_range {}
    = note: required by `std::iter::IntoIterator::into_iter`
 
 error[E0277]: `[std::ops::Range<{integer}>; 2]` is not an iterator
-  --> $DIR/array-of-ranges.rs:8:14
+  --> $DIR/array-of-ranges.rs:12:14
    |
 LL |     for _ in [0..1, 2..3] {}
    |              ^^^^^^^^^^^^ borrow the array with `&` or call `.iter()` on it to iterate over it
@@ -38,6 +78,16 @@ LL |     for _ in [0..1, 2..3] {}
    = note: arrays are not an iterators, but slices like the following are: `&[1, 2, 3]`
    = note: required by `std::iter::IntoIterator::into_iter`
 
-error: aborting due to 4 previous errors
+error[E0277]: `[std::ops::RangeInclusive<{integer}>; 1]` is not an iterator
+  --> $DIR/array-of-ranges.rs:13:14
+   |
+LL |     for _ in [0..=1] {}
+   |              ^^^^^^^ if you meant to iterate between two values, remove the square brackets
+   |
+   = help: the trait `std::iter::Iterator` is not implemented for `[std::ops::RangeInclusive<{integer}>; 1]`
+   = note: `[start..=end]` is an array of one `RangeInclusive`; you might have meant to have a `RangeInclusive` without the brackets: `start..=end`
+   = note: required by `std::iter::IntoIterator::into_iter`
+
+error: aborting due to 9 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/iterators/array.rs
+++ b/src/test/ui/iterators/array.rs
@@ -1,0 +1,6 @@
+fn main() {
+    for _ in [1, 2] {}
+    let x = [1, 2];
+    for _ in x {}
+    for _ in [1.0, 2.0] {}
+}

--- a/src/test/ui/iterators/array.stderr
+++ b/src/test/ui/iterators/array.stderr
@@ -1,0 +1,33 @@
+error[E0277]: `[{integer}; 2]` is not an iterator
+  --> $DIR/array.rs:2:14
+   |
+LL |     for _ in [1, 2] {}
+   |              ^^^^^^ borrow the array with `&` or call `.iter()` on it to iterate over it
+   |
+   = help: the trait `std::iter::Iterator` is not implemented for `[{integer}; 2]`
+   = note: arrays are not an iterators, but slices like the following are: `&[1, 2, 3]`
+   = note: required by `std::iter::IntoIterator::into_iter`
+
+error[E0277]: `[{integer}; 2]` is not an iterator
+  --> $DIR/array.rs:4:14
+   |
+LL |     for _ in x {}
+   |              ^ borrow the array with `&` or call `.iter()` on it to iterate over it
+   |
+   = help: the trait `std::iter::Iterator` is not implemented for `[{integer}; 2]`
+   = note: arrays are not an iterators, but slices like the following are: `&[1, 2, 3]`
+   = note: required by `std::iter::IntoIterator::into_iter`
+
+error[E0277]: `[{float}; 2]` is not an iterator
+  --> $DIR/array.rs:5:14
+   |
+LL |     for _ in [1.0, 2.0] {}
+   |              ^^^^^^^^^^ borrow the array with `&` or call `.iter()` on it to iterate over it
+   |
+   = help: the trait `std::iter::Iterator` is not implemented for `[{float}; 2]`
+   = note: arrays are not an iterators, but slices like the following are: `&[1, 2, 3]`
+   = note: required by `std::iter::IntoIterator::into_iter`
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/iterators/bound.rs
+++ b/src/test/ui/iterators/bound.rs
@@ -1,0 +1,3 @@
+struct S<I: Iterator>(I);
+struct T(S<u8>);
+fn main() {}

--- a/src/test/ui/iterators/bound.stderr
+++ b/src/test/ui/iterators/bound.stderr
@@ -1,0 +1,17 @@
+error[E0277]: `u8` is not an iterator
+  --> $DIR/bound.rs:2:10
+   |
+LL | struct T(S<u8>);
+   |          ^^^^^ `u8` is not an iterator
+   |
+   = help: the trait `std::iter::Iterator` is not implemented for `u8`
+   = note: if you want to iterate between `0` until a value `end`, use the range syntax: `0..end`
+note: required by `S`
+  --> $DIR/bound.rs:1:1
+   |
+LL | struct S<I: Iterator>(I);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/iterators/bound.stderr
+++ b/src/test/ui/iterators/bound.stderr
@@ -5,7 +5,7 @@ LL | struct T(S<u8>);
    |          ^^^^^ `u8` is not an iterator
    |
    = help: the trait `std::iter::Iterator` is not implemented for `u8`
-   = note: if you want to iterate between `0` until a value `end`, use the range syntax: `0..end`
+   = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
 note: required by `S`
   --> $DIR/bound.rs:1:1
    |

--- a/src/test/ui/iterators/integral.rs
+++ b/src/test/ui/iterators/integral.rs
@@ -1,0 +1,26 @@
+fn main() {
+    for _ in 42 {}
+    //~^ ERROR `{integer}` is not an iterator
+    for _ in 42 as u8 {}
+    //~^ ERROR `u8` is not an iterator
+    for _ in 42 as i8 {}
+    //~^ ERROR `i8` is not an iterator
+    for _ in 42 as u16 {}
+    //~^ ERROR `u16` is not an iterator
+    for _ in 42 as i16 {}
+    //~^ ERROR `i16` is not an iterator
+    for _ in 42 as u32 {}
+    //~^ ERROR `u32` is not an iterator
+    for _ in 42 as i32 {}
+    //~^ ERROR `i32` is not an iterator
+    for _ in 42 as u64 {}
+    //~^ ERROR `u64` is not an iterator
+    for _ in 42 as i64 {}
+    //~^ ERROR `i64` is not an iterator
+    for _ in 42 as usize {}
+    //~^ ERROR `usize` is not an iterator
+    for _ in 42 as isize {}
+    //~^ ERROR `isize` is not an iterator
+    for _ in 42.0 {}
+    //~^ ERROR `{float}` is not an iterator
+}

--- a/src/test/ui/iterators/integral.stderr
+++ b/src/test/ui/iterators/integral.stderr
@@ -1,0 +1,122 @@
+error[E0277]: `{integer}` is not an iterator
+  --> $DIR/integral.rs:2:14
+   |
+LL |     for _ in 42 {}
+   |              ^^ `{integer}` is not an iterator
+   |
+   = help: the trait `std::iter::Iterator` is not implemented for `{integer}`
+   = note: if you want to iterate between `0` until a value `end`, use the range syntax: `0..end`
+   = note: required by `std::iter::IntoIterator::into_iter`
+
+error[E0277]: `u8` is not an iterator
+  --> $DIR/integral.rs:4:14
+   |
+LL |     for _ in 42 as u8 {}
+   |              ^^^^^^^^ `u8` is not an iterator
+   |
+   = help: the trait `std::iter::Iterator` is not implemented for `u8`
+   = note: if you want to iterate between `0` until a value `end`, use the range syntax: `0..end`
+   = note: required by `std::iter::IntoIterator::into_iter`
+
+error[E0277]: `i8` is not an iterator
+  --> $DIR/integral.rs:6:14
+   |
+LL |     for _ in 42 as i8 {}
+   |              ^^^^^^^^ `i8` is not an iterator
+   |
+   = help: the trait `std::iter::Iterator` is not implemented for `i8`
+   = note: if you want to iterate between `0` until a value `end`, use the range syntax: `0..end`
+   = note: required by `std::iter::IntoIterator::into_iter`
+
+error[E0277]: `u16` is not an iterator
+  --> $DIR/integral.rs:8:14
+   |
+LL |     for _ in 42 as u16 {}
+   |              ^^^^^^^^^ `u16` is not an iterator
+   |
+   = help: the trait `std::iter::Iterator` is not implemented for `u16`
+   = note: if you want to iterate between `0` until a value `end`, use the range syntax: `0..end`
+   = note: required by `std::iter::IntoIterator::into_iter`
+
+error[E0277]: `i16` is not an iterator
+  --> $DIR/integral.rs:10:14
+   |
+LL |     for _ in 42 as i16 {}
+   |              ^^^^^^^^^ `i16` is not an iterator
+   |
+   = help: the trait `std::iter::Iterator` is not implemented for `i16`
+   = note: if you want to iterate between `0` until a value `end`, use the range syntax: `0..end`
+   = note: required by `std::iter::IntoIterator::into_iter`
+
+error[E0277]: `u32` is not an iterator
+  --> $DIR/integral.rs:12:14
+   |
+LL |     for _ in 42 as u32 {}
+   |              ^^^^^^^^^ `u32` is not an iterator
+   |
+   = help: the trait `std::iter::Iterator` is not implemented for `u32`
+   = note: if you want to iterate between `0` until a value `end`, use the range syntax: `0..end`
+   = note: required by `std::iter::IntoIterator::into_iter`
+
+error[E0277]: `i32` is not an iterator
+  --> $DIR/integral.rs:14:14
+   |
+LL |     for _ in 42 as i32 {}
+   |              ^^^^^^^^^ `i32` is not an iterator
+   |
+   = help: the trait `std::iter::Iterator` is not implemented for `i32`
+   = note: if you want to iterate between `0` until a value `end`, use the range syntax: `0..end`
+   = note: required by `std::iter::IntoIterator::into_iter`
+
+error[E0277]: `u64` is not an iterator
+  --> $DIR/integral.rs:16:14
+   |
+LL |     for _ in 42 as u64 {}
+   |              ^^^^^^^^^ `u64` is not an iterator
+   |
+   = help: the trait `std::iter::Iterator` is not implemented for `u64`
+   = note: if you want to iterate between `0` until a value `end`, use the range syntax: `0..end`
+   = note: required by `std::iter::IntoIterator::into_iter`
+
+error[E0277]: `i64` is not an iterator
+  --> $DIR/integral.rs:18:14
+   |
+LL |     for _ in 42 as i64 {}
+   |              ^^^^^^^^^ `i64` is not an iterator
+   |
+   = help: the trait `std::iter::Iterator` is not implemented for `i64`
+   = note: if you want to iterate between `0` until a value `end`, use the range syntax: `0..end`
+   = note: required by `std::iter::IntoIterator::into_iter`
+
+error[E0277]: `usize` is not an iterator
+  --> $DIR/integral.rs:20:14
+   |
+LL |     for _ in 42 as usize {}
+   |              ^^^^^^^^^^^ `usize` is not an iterator
+   |
+   = help: the trait `std::iter::Iterator` is not implemented for `usize`
+   = note: if you want to iterate between `0` until a value `end`, use the range syntax: `0..end`
+   = note: required by `std::iter::IntoIterator::into_iter`
+
+error[E0277]: `isize` is not an iterator
+  --> $DIR/integral.rs:22:14
+   |
+LL |     for _ in 42 as isize {}
+   |              ^^^^^^^^^^^ `isize` is not an iterator
+   |
+   = help: the trait `std::iter::Iterator` is not implemented for `isize`
+   = note: if you want to iterate between `0` until a value `end`, use the range syntax: `0..end`
+   = note: required by `std::iter::IntoIterator::into_iter`
+
+error[E0277]: `{float}` is not an iterator
+  --> $DIR/integral.rs:24:14
+   |
+LL |     for _ in 42.0 {}
+   |              ^^^^ `{float}` is not an iterator
+   |
+   = help: the trait `std::iter::Iterator` is not implemented for `{float}`
+   = note: required by `std::iter::IntoIterator::into_iter`
+
+error: aborting due to 12 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/iterators/integral.stderr
+++ b/src/test/ui/iterators/integral.stderr
@@ -5,7 +5,7 @@ LL |     for _ in 42 {}
    |              ^^ `{integer}` is not an iterator
    |
    = help: the trait `std::iter::Iterator` is not implemented for `{integer}`
-   = note: if you want to iterate between `0` until a value `end`, use the range syntax: `0..end`
+   = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
    = note: required by `std::iter::IntoIterator::into_iter`
 
 error[E0277]: `u8` is not an iterator
@@ -15,7 +15,7 @@ LL |     for _ in 42 as u8 {}
    |              ^^^^^^^^ `u8` is not an iterator
    |
    = help: the trait `std::iter::Iterator` is not implemented for `u8`
-   = note: if you want to iterate between `0` until a value `end`, use the range syntax: `0..end`
+   = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
    = note: required by `std::iter::IntoIterator::into_iter`
 
 error[E0277]: `i8` is not an iterator
@@ -25,7 +25,7 @@ LL |     for _ in 42 as i8 {}
    |              ^^^^^^^^ `i8` is not an iterator
    |
    = help: the trait `std::iter::Iterator` is not implemented for `i8`
-   = note: if you want to iterate between `0` until a value `end`, use the range syntax: `0..end`
+   = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
    = note: required by `std::iter::IntoIterator::into_iter`
 
 error[E0277]: `u16` is not an iterator
@@ -35,7 +35,7 @@ LL |     for _ in 42 as u16 {}
    |              ^^^^^^^^^ `u16` is not an iterator
    |
    = help: the trait `std::iter::Iterator` is not implemented for `u16`
-   = note: if you want to iterate between `0` until a value `end`, use the range syntax: `0..end`
+   = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
    = note: required by `std::iter::IntoIterator::into_iter`
 
 error[E0277]: `i16` is not an iterator
@@ -45,7 +45,7 @@ LL |     for _ in 42 as i16 {}
    |              ^^^^^^^^^ `i16` is not an iterator
    |
    = help: the trait `std::iter::Iterator` is not implemented for `i16`
-   = note: if you want to iterate between `0` until a value `end`, use the range syntax: `0..end`
+   = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
    = note: required by `std::iter::IntoIterator::into_iter`
 
 error[E0277]: `u32` is not an iterator
@@ -55,7 +55,7 @@ LL |     for _ in 42 as u32 {}
    |              ^^^^^^^^^ `u32` is not an iterator
    |
    = help: the trait `std::iter::Iterator` is not implemented for `u32`
-   = note: if you want to iterate between `0` until a value `end`, use the range syntax: `0..end`
+   = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
    = note: required by `std::iter::IntoIterator::into_iter`
 
 error[E0277]: `i32` is not an iterator
@@ -65,7 +65,7 @@ LL |     for _ in 42 as i32 {}
    |              ^^^^^^^^^ `i32` is not an iterator
    |
    = help: the trait `std::iter::Iterator` is not implemented for `i32`
-   = note: if you want to iterate between `0` until a value `end`, use the range syntax: `0..end`
+   = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
    = note: required by `std::iter::IntoIterator::into_iter`
 
 error[E0277]: `u64` is not an iterator
@@ -75,7 +75,7 @@ LL |     for _ in 42 as u64 {}
    |              ^^^^^^^^^ `u64` is not an iterator
    |
    = help: the trait `std::iter::Iterator` is not implemented for `u64`
-   = note: if you want to iterate between `0` until a value `end`, use the range syntax: `0..end`
+   = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
    = note: required by `std::iter::IntoIterator::into_iter`
 
 error[E0277]: `i64` is not an iterator
@@ -85,7 +85,7 @@ LL |     for _ in 42 as i64 {}
    |              ^^^^^^^^^ `i64` is not an iterator
    |
    = help: the trait `std::iter::Iterator` is not implemented for `i64`
-   = note: if you want to iterate between `0` until a value `end`, use the range syntax: `0..end`
+   = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
    = note: required by `std::iter::IntoIterator::into_iter`
 
 error[E0277]: `usize` is not an iterator
@@ -95,7 +95,7 @@ LL |     for _ in 42 as usize {}
    |              ^^^^^^^^^^^ `usize` is not an iterator
    |
    = help: the trait `std::iter::Iterator` is not implemented for `usize`
-   = note: if you want to iterate between `0` until a value `end`, use the range syntax: `0..end`
+   = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
    = note: required by `std::iter::IntoIterator::into_iter`
 
 error[E0277]: `isize` is not an iterator
@@ -105,7 +105,7 @@ LL |     for _ in 42 as isize {}
    |              ^^^^^^^^^^^ `isize` is not an iterator
    |
    = help: the trait `std::iter::Iterator` is not implemented for `isize`
-   = note: if you want to iterate between `0` until a value `end`, use the range syntax: `0..end`
+   = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
    = note: required by `std::iter::IntoIterator::into_iter`
 
 error[E0277]: `{float}` is not an iterator

--- a/src/test/ui/iterators/ranges.rs
+++ b/src/test/ui/iterators/ranges.rs
@@ -1,0 +1,9 @@
+fn main() {
+    for _ in ..10 {}
+    //~^ ERROR E0277
+    for _ in ..=10 {}
+    //~^ ERROR E0277
+    for _ in 0..10 {}
+    for _ in 0..=10 {}
+    for _ in 0.. {}
+}

--- a/src/test/ui/iterators/ranges.stderr
+++ b/src/test/ui/iterators/ranges.stderr
@@ -1,0 +1,23 @@
+error[E0277]: `std::ops::RangeTo<{integer}>` is not an iterator
+  --> $DIR/ranges.rs:2:14
+   |
+LL |     for _ in ..10 {}
+   |              ^^^^ if you meant to iterate until a value, add a starting value
+   |
+   = help: the trait `std::iter::Iterator` is not implemented for `std::ops::RangeTo<{integer}>`
+   = note: `..end` is a `RangeTo`, which cannot be iterated on; you might have meant to have a bounded `Range`: `0..end`
+   = note: required by `std::iter::IntoIterator::into_iter`
+
+error[E0277]: `std::ops::RangeToInclusive<{integer}>` is not an iterator
+  --> $DIR/ranges.rs:4:14
+   |
+LL |     for _ in ..=10 {}
+   |              ^^^^^ if you meant to iterate until a value (including it), add a starting value
+   |
+   = help: the trait `std::iter::Iterator` is not implemented for `std::ops::RangeToInclusive<{integer}>`
+   = note: `..=end` is a `RangeToInclusive`, which cannot be iterated on; you might have meant to have a bounded `RangeInclusive`: `0..=end`
+   = note: required by `std::iter::IntoIterator::into_iter`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/iterators/string.rs
+++ b/src/test/ui/iterators/string.rs
@@ -1,0 +1,6 @@
+fn main() {
+    for _ in "".to_owned() {}
+    //~^ ERROR `std::string::String` is not an iterator
+    for _ in "" {}
+    //~^ ERROR `&str` is not an iterator
+}

--- a/src/test/ui/iterators/string.stderr
+++ b/src/test/ui/iterators/string.stderr
@@ -1,0 +1,21 @@
+error[E0277]: `std::string::String` is not an iterator
+  --> $DIR/string.rs:2:14
+   |
+LL |     for _ in "".to_owned() {}
+   |              ^^^^^^^^^^^^^ `std::string::String` is not an iterator; try calling `.chars()` or `.bytes()`
+   |
+   = help: the trait `std::iter::Iterator` is not implemented for `std::string::String`
+   = note: required by `std::iter::IntoIterator::into_iter`
+
+error[E0277]: `&str` is not an iterator
+  --> $DIR/string.rs:4:14
+   |
+LL |     for _ in "" {}
+   |              ^^ `&str` is not an iterator; try calling `.chars()` or `.bytes()`
+   |
+   = help: the trait `std::iter::Iterator` is not implemented for `&str`
+   = note: required by `std::iter::IntoIterator::into_iter`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/suggestions/suggest-remove-refs-1.rs
+++ b/src/test/ui/suggestions/suggest-remove-refs-1.rs
@@ -12,7 +12,7 @@ fn main() {
     let v = vec![0, 1, 2, 3];
 
     for (i, n) in &v.iter().enumerate() {
-        //~^ ERROR the trait bound
+        //~^ ERROR `&std::iter::Enumerate<std::slice::Iter<'_, {integer}>>` is not an iterator
         println!("{}", i);
     }
 }

--- a/src/test/ui/suggestions/suggest-remove-refs-1.stderr
+++ b/src/test/ui/suggestions/suggest-remove-refs-1.stderr
@@ -1,10 +1,10 @@
-error[E0277]: the trait bound `&std::iter::Enumerate<std::slice::Iter<'_, {integer}>>: std::iter::Iterator` is not satisfied
+error[E0277]: `&std::iter::Enumerate<std::slice::Iter<'_, {integer}>>` is not an iterator
   --> $DIR/suggest-remove-refs-1.rs:14:19
    |
 LL |     for (i, n) in &v.iter().enumerate() {
    |                   -^^^^^^^^^^^^^^^^^^^^
    |                   |
-   |                   `&std::iter::Enumerate<std::slice::Iter<'_, {integer}>>` is not an iterator; maybe try calling `.iter()` or a similar method
+   |                   `&std::iter::Enumerate<std::slice::Iter<'_, {integer}>>` is not an iterator
    |                   help: consider removing 1 leading `&`-references
    |
    = help: the trait `std::iter::Iterator` is not implemented for `&std::iter::Enumerate<std::slice::Iter<'_, {integer}>>`

--- a/src/test/ui/suggestions/suggest-remove-refs-2.rs
+++ b/src/test/ui/suggestions/suggest-remove-refs-2.rs
@@ -12,7 +12,7 @@ fn main() {
     let v = vec![0, 1, 2, 3];
 
     for (i, n) in & & & & &v.iter().enumerate() {
-        //~^ ERROR the trait bound
+        //~^ ERROR `&&&&&std::iter::Enumerate<std::slice::Iter<'_, {integer}>>` is not an iterator
         println!("{}", i);
     }
 }

--- a/src/test/ui/suggestions/suggest-remove-refs-2.stderr
+++ b/src/test/ui/suggestions/suggest-remove-refs-2.stderr
@@ -1,10 +1,10 @@
-error[E0277]: the trait bound `&&&&&std::iter::Enumerate<std::slice::Iter<'_, {integer}>>: std::iter::Iterator` is not satisfied
+error[E0277]: `&&&&&std::iter::Enumerate<std::slice::Iter<'_, {integer}>>` is not an iterator
   --> $DIR/suggest-remove-refs-2.rs:14:19
    |
 LL |     for (i, n) in & & & & &v.iter().enumerate() {
    |                   ---------^^^^^^^^^^^^^^^^^^^^
    |                   |
-   |                   `&&&&&std::iter::Enumerate<std::slice::Iter<'_, {integer}>>` is not an iterator; maybe try calling `.iter()` or a similar method
+   |                   `&&&&&std::iter::Enumerate<std::slice::Iter<'_, {integer}>>` is not an iterator
    |                   help: consider removing 5 leading `&`-references
    |
    = help: the trait `std::iter::Iterator` is not implemented for `&&&&&std::iter::Enumerate<std::slice::Iter<'_, {integer}>>`

--- a/src/test/ui/suggestions/suggest-remove-refs-3.rs
+++ b/src/test/ui/suggestions/suggest-remove-refs-3.rs
@@ -15,7 +15,7 @@ fn main() {
         & &v
         .iter()
         .enumerate() {
-        //~^^^^ ERROR the trait bound
+        //~^^^^ ERROR `&&&&&std::iter::Enumerate<std::slice::Iter<'_, {integer}>>` is not an
         println!("{}", i);
     }
 }

--- a/src/test/ui/suggestions/suggest-remove-refs-3.stderr
+++ b/src/test/ui/suggestions/suggest-remove-refs-3.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the trait bound `&&&&&std::iter::Enumerate<std::slice::Iter<'_, {integer}>>: std::iter::Iterator` is not satisfied
+error[E0277]: `&&&&&std::iter::Enumerate<std::slice::Iter<'_, {integer}>>` is not an iterator
   --> $DIR/suggest-remove-refs-3.rs:14:19
    |
 LL |        for (i, n) in & & &
@@ -9,7 +9,7 @@ LL | ||         & &v
    | ||___________- help: consider removing 5 leading `&`-references
 LL | |          .iter()
 LL | |          .enumerate() {
-   | |_____________________^ `&&&&&std::iter::Enumerate<std::slice::Iter<'_, {integer}>>` is not an iterator; maybe try calling `.iter()` or a similar method
+   | |_____________________^ `&&&&&std::iter::Enumerate<std::slice::Iter<'_, {integer}>>` is not an iterator
    |
    = help: the trait `std::iter::Iterator` is not implemented for `&&&&&std::iter::Enumerate<std::slice::Iter<'_, {integer}>>`
    = note: required by `std::iter::IntoIterator::into_iter`


### PR DESCRIPTION
 - Add more targetting filters for arrays to `rustc_on_unimplemented` (Fix #53766)
 - Detect one element array of `Range` type, which is potentially a typo:
   `for _ in [0..10] {}` where iterating between `0` and `10` was intended.
   (Fix #23141)
 - Suggest `.bytes()` and `.chars()` for `String`.
 - Suggest borrowing or `.iter()` on arrays (Fix #36391)
 - Suggest using range literal when iterating on integers (Fix #34353)
 - Do not suggest `.iter()` by default (Fix #50773, fix #46806)
 - Add regression test (Fix #22872)