### PR TITLE
"(using ..." doesn't have the matching ")"

### DIFF
--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -726,7 +726,7 @@ impl OpenOptions {
     /// If a file is opened with both read and append access, beware that after
     /// opening, and after every write, the position for reading may be set at the
     /// end of the file. So, before writing, save the current position (using
-    /// [`seek`]`(`[`SeekFrom`]`::`[`Current`]`(0))`, and restore it before the next read.
+    /// [`seek`]`(`[`SeekFrom`]`::`[`Current`]`(0))`), and restore it before the next read.
     ///
     /// ## Note
     ///


### PR DESCRIPTION
Fixes #54948.