### PR TITLE
Remove incorrect span for second label inner macro invocation

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -772,6 +772,11 @@ impl<'a> Parser<'a> {
                     //   |                   expected one of 8 possible tokens here
                     err.span_label(self.span, label_exp);
                 }
+                _ if self.prev_span == syntax_pos::DUMMY_SP => {
+                    // Account for macro context where the previous span might not be
+                    // available to avoid incorrect output (#54841).
+                    err.span_label(self.span, "unexpected token");
+                }
                 _ => {
                     err.span_label(sp, label_exp);
                     err.span_label(self.span, "unexpected token");

--- a/src/test/ui/macros/issue-54441.stderr
+++ b/src/test/ui/macros/issue-54441.stderr
@@ -1,9 +1,6 @@
 error: expected one of `crate`, `fn`, `pub`, `static`, or `type`, found `let`
   --> $DIR/issue-54441.rs:5:9
    |
-LL | #![feature(macros_in_extern)]
-   | - expected one of `crate`, `fn`, `pub`, `static`, or `type` here
-...
 LL |         let //~ ERROR expected
    |         ^^^ unexpected token
 ...


### PR DESCRIPTION
A fix for issue #54841