### PR TITLE
Accept `Option<Box<$t:ty>>` in macro argument

### DIFF
--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -902,7 +902,8 @@ fn is_in_follow(tok: &quoted::TokenTree, frag: &str) -> Result<bool, (String, &'
             "path" | "ty" => match *tok {
                 TokenTree::Token(_, ref tok) => match *tok {
                     OpenDelim(token::DelimToken::Brace) | OpenDelim(token::DelimToken::Bracket) |
-                    Comma | FatArrow | Colon | Eq | Gt | Semi | BinOp(token::Or) => Ok(true),
+                    Comma | FatArrow | Colon | Eq | Gt | BinOp(token::Shr) | Semi |
+                    BinOp(token::Or) => Ok(true),
                     Ident(i, false) if i.name == "as" || i.name == "where" => Ok(true),
                     _ => Ok(false)
                 },

--- a/src/test/run-pass/macros/issue-25274.rs
+++ b/src/test/run-pass/macros/issue-25274.rs
@@ -1,0 +1,16 @@
+macro_rules! test {
+    (
+        fn fun() -> Option<Box<$t:ty>>;
+    ) => {
+        fn fun(x: $t) -> Option<Box<$t>>
+        { Some(Box::new(x)) }
+    }
+}
+
+test! {
+    fn fun() -> Option<Box<i32>>;
+}
+
+fn main() {
+    println!("{}", fun(0).unwrap());
+}


### PR DESCRIPTION
Given the following code, compile successfuly:

```
macro_rules! test {
    (
        fn fun() -> Option<Box<$t:ty>>;
    ) => {
        fn fun(x: $t) -> Option<Box<$t>>
        { Some(Box::new(x)) }
    }
}

test! {
    fn fun() -> Option<Box<i32>>;
}
```

Fix #25274.