### PR TITLE
Custom E0277 diagnostic for `Path`

### DIFF
--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -92,6 +92,7 @@ impl<T: ?Sized> !Send for *mut T { }
 #[stable(feature = "rust1", since = "1.0.0")]
 #[lang = "sized"]
 #[rustc_on_unimplemented(
+    on(parent_trait="std::path::Path", label="borrow the `Path` instead"),
     message="the size for values of type `{Self}` cannot be known at compilation time",
     label="doesn't have a size known at compile-time",
     note="to learn more, visit <https://doc.rust-lang.org/book/second-edition/\

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -379,6 +379,9 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                 flags.push(("from_method".to_owned(), Some(method.to_string())));
             }
         }
+        if let Some(t) = self.get_parent_trait_ref(&obligation.cause.code) {
+            flags.push(("parent_trait".to_owned(), Some(t.to_string())));
+        }
 
         if let Some(k) = obligation.cause.span.compiler_desugaring_kind() {
             flags.push(("from_desugaring".to_owned(), None));

--- a/src/test/ui/suggestions/path-by-value.rs
+++ b/src/test/ui/suggestions/path-by-value.rs
@@ -1,0 +1,6 @@
+use std::path::Path;
+
+fn f(p: Path) { }
+//~^ ERROR E0277
+
+fn main() {}

--- a/src/test/ui/suggestions/path-by-value.stderr
+++ b/src/test/ui/suggestions/path-by-value.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> $DIR/E0277.rs:23:6
+  --> $DIR/path-by-value.rs:3:6
    |
 LL | fn f(p: Path) { }
    |      ^ borrow the `Path` instead
@@ -10,18 +10,6 @@ LL | fn f(p: Path) { }
    = note: all local variables must have a statically known size
    = help: unsized locals are gated as an unstable feature
 
-error[E0277]: the trait bound `i32: Foo` is not satisfied
-  --> $DIR/E0277.rs:27:5
-   |
-LL |     some_func(5i32);
-   |     ^^^^^^^^^ the trait `Foo` is not implemented for `i32`
-   |
-note: required by `some_func`
-  --> $DIR/E0277.rs:19:1
-   |
-LL | fn some_func<T: Foo>(foo: T) {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
r? @nikomatsakis we have a way to target `Path` exclusively, we need to identify the correct text to show to consider #23286 fixed.