### PR TITLE
Rollup of 14 pull requests

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -243,18 +243,35 @@
 # =============================================================================
 [rust]
 
-# Indicates that the build should be optimized for debugging Rust. Note that
-# this is typically not what you want as it takes an incredibly large amount of
-# time to have a debug-mode rustc compile any code (notably libstd). If this
-# value is set to `true` it will affect a number of configuration options below
-# as well, if unconfigured.
-#debug = false
-
-# Whether or not to optimize the compiler and standard library
+# Whether or not to optimize the compiler and standard library.
+#
 # Note: the slowness of the non optimized compiler compiling itself usually
 #       outweighs the time gains in not doing optimizations, therefore a
-#       full bootstrap takes much more time with optimize set to false.
+#       full bootstrap takes much more time with `optimize` set to false.
 #optimize = true
+
+# Indicates that the build should be configured for debugging Rust. A
+# `debug`-enabled compiler and standard library will be somewhat
+# slower (due to e.g. checking of debug assertions) but should remain
+# usable.
+#
+# Note: If this value is set to `true`, it will affect a number of
+#       configuration options below as well, if they have been left
+#       unconfigured in this file.
+#
+# Note: changes to the `debug` setting do *not* affect `optimize`
+#       above. In theory, a "maximally debuggable" environment would
+#       set `optimize` to `false` above to assist the introspection
+#       facilities of debuggers like lldb and gdb. To recreate such an
+#       environment, explicitly set `optimize` to `false` and `debug`
+#       to `true`. In practice, everyone leaves `optimize` set to
+#       `true`, because an unoptimized rustc with debugging
+#       enabled becomes *unusably slow* (e.g. rust-lang/rust#24840
+#       reported a 25x slowdown) and bootstrapping the supposed
+#       "maximally debuggable" environment (notably libstd) takes
+#       hours to build.
+#
+#debug = false
 
 # Number of codegen units to use for each compiler invocation. A value of 0
 # means "the number of cores on this machine", and 1+ is passed through to the

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -204,7 +204,7 @@ dependencies = [
  "env_logger 0.5.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "filetime 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "flate2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fwdansi 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -737,7 +737,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "flate2"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -969,7 +969,7 @@ version = "0.0.0"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "flate2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1900,7 +1900,7 @@ dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "chalk-engine 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "flate2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fmt_macros 0.0.0",
  "graphviz 0.0.0",
  "jobserver 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2144,7 +2144,7 @@ dependencies = [
 name = "rustc_codegen_utils"
 version = "0.0.0"
 dependencies = [
- "flate2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc 0.0.0",
  "rustc_data_structures 0.0.0",
@@ -2287,7 +2287,7 @@ dependencies = [
 name = "rustc_metadata"
 version = "0.0.0"
 dependencies = [
- "flate2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc_macro 0.0.0",
  "rustc 0.0.0",
@@ -3234,7 +3234,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum failure_derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "946d0e98a50d9831f5d589038d2ca7f8f455b1c21028c0db0e84116a12696426"
 "checksum filetime 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "da4b9849e77b13195302c174324b5ba73eec9b236b24c221a61000daefb95c5f"
 "checksum fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
-"checksum flate2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "37847f133aae7acf82bb9577ccd8bda241df836787642654286e79679826a54b"
+"checksum flate2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4af030962d89d62aa52cd9492083b1cd9b2d1a77764878102a6c0f86b4d5444d"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 "checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1659,7 +1659,7 @@ dependencies = [
 
 [[package]]
 name = "racer"
-version = "2.1.6"
+version = "2.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1807,7 +1807,7 @@ dependencies = [
  "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ordslice 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "racer 2.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "racer 2.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1824,6 +1824,7 @@ dependencies = [
  "serde 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3331,7 +3332,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
 "checksum quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dd636425967c33af890042c483632d33fa7a18f19ad1d7ea72e8998c6ef8dea5"
-"checksum racer 2.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "99e820b7f7701c834c3f6f8226f388c19c0ea948a3ef79ddc96aa7398b5ba87a"
+"checksum racer 2.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0beefbfaed799c3554021a48856113ad53862311395f6d75376192884ba5fbe6"
 "checksum rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8356f47b32624fef5b3301c1be97e5944ecdd595409cc5da11d05f211db6cfbd"
 "checksum rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e464cd887e869cddcae8792a4ee31d23c7edd516700695608f5b98c67ee0131c"
 "checksum rand_core 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "edecf0f94da5551fc9b492093e30b041a891657db7940ee221f9d2f66e82eef2"

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -624,6 +624,9 @@ impl Config {
         let default = false;
         config.llvm_assertions = llvm_assertions.unwrap_or(default);
 
+        let default = true;
+        config.rust_optimize = optimize.unwrap_or(default);
+
         let default = match &config.channel[..] {
             "stable" | "beta" | "nightly" => true,
             _ => false,
@@ -636,7 +639,6 @@ impl Config {
         config.debug_jemalloc = debug_jemalloc.unwrap_or(default);
         config.rust_debuginfo = debuginfo.unwrap_or(default);
         config.rust_debug_assertions = debug_assertions.unwrap_or(default);
-        config.rust_optimize = optimize.unwrap_or(!default);
 
         let default = config.channel == "dev";
         config.ignore_git = ignore_git.unwrap_or(default);

--- a/src/build_helper/lib.rs
+++ b/src/build_helper/lib.rs
@@ -91,13 +91,13 @@ pub fn try_run_suppressed(cmd: &mut Command) -> bool {
     output.status.success()
 }
 
-pub fn gnu_target(target: &str) -> String {
+pub fn gnu_target(target: &str) -> &str {
     match target {
-        "i686-pc-windows-msvc" => "i686-pc-win32".to_string(),
-        "x86_64-pc-windows-msvc" => "x86_64-pc-win32".to_string(),
-        "i686-pc-windows-gnu" => "i686-w64-mingw32".to_string(),
-        "x86_64-pc-windows-gnu" => "x86_64-w64-mingw32".to_string(),
-        s => s.to_string(),
+        "i686-pc-windows-msvc" => "i686-pc-win32",
+        "x86_64-pc-windows-msvc" => "x86_64-pc-win32",
+        "i686-pc-windows-gnu" => "i686-w64-mingw32",
+        "x86_64-pc-windows-gnu" => "x86_64-w64-mingw32",
+        s => s,
     }
 }
 

--- a/src/doc/rustc/src/lints/listing/warn-by-default.md
+++ b/src/doc/rustc/src/lints/listing/warn-by-default.md
@@ -279,7 +279,7 @@ warning: functions generic over types must be mangled
 1 |   #[no_mangle]
   |   ------------ help: remove this attribute
 2 | / fn foo<T>(t: T) {
-3 | |     
+3 | |
 4 | | }
   | |_^
   |
@@ -513,7 +513,7 @@ This will produce:
 warning: borrow of packed field requires unsafe function or block (error E0133)
   --> src/main.rs:11:13
    |
-11 |     let y = &x.data.0; 
+11 |     let y = &x.data.0;
    |             ^^^^^^^^^
    |
    = note: #[warn(safe_packed_borrows)] on by default
@@ -874,7 +874,7 @@ fn main() {
 This will produce:
 
 ```text
-warning: unused `std::result::Result` which must be used
+warning: unused `std::result::Result` that must be used
  --> src/main.rs:6:5
   |
 6 |     returns_result();

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -120,7 +120,9 @@ use raw_vec::RawVec;
 /// assert_eq!(vec, [1, 2, 3, 4]);
 /// ```
 ///
-/// It can also initialize each element of a `Vec<T>` with a given value:
+/// It can also initialize each element of a `Vec<T>` with a given value.
+/// Initializing a `Vec<T>` in this manner is the most efficient and safest way to allocate a
+/// vector of zeros as previously zeroed memory is requested from the operating system:
 ///
 /// ```
 /// let vec = vec![0; 5];

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -121,12 +121,16 @@ use raw_vec::RawVec;
 /// ```
 ///
 /// It can also initialize each element of a `Vec<T>` with a given value.
-/// Initializing a `Vec<T>` in this manner is the most efficient and safest way to allocate a
-/// vector of zeros as previously zeroed memory is requested from the operating system:
+/// This may be more efficient than performing allocation and initialization
+/// in separate steps, especially when initializing a vector of zeros:
 ///
 /// ```
 /// let vec = vec![0; 5];
 /// assert_eq!(vec, [0, 0, 0, 0, 0]);
+///
+/// // The following is equivalent, but potentially slower:
+/// let mut vec1 = Vec::with_capacity(5);
+/// vec1.resize(5, 0);
 /// ```
 ///
 /// Use a `Vec<T>` as an efficient stack:

--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -253,7 +253,7 @@
 //! using it. The compiler will warn us about this kind of behavior:
 //!
 //! ```text
-//! warning: unused result which must be used: iterator adaptors are lazy and
+//! warning: unused result that must be used: iterator adaptors are lazy and
 //! do nothing unless consumed
 //! ```
 //!

--- a/src/librustc/macros.rs
+++ b/src/librustc/macros.rs
@@ -63,6 +63,16 @@ macro_rules! span_bug {
 }
 
 #[macro_export]
+macro_rules! static_assert {
+    ($name:ident: $test:expr) => {
+        // Use the bool to access an array such that if the bool is false, the access
+        // is out-of-bounds.
+        #[allow(dead_code)]
+        static $name: () = [()][!$test as usize];
+    }
+}
+
+#[macro_export]
 macro_rules! __impl_stable_hash_field {
     ($field:ident, $ctx:expr, $hasher:expr) => ($field.hash_stable($ctx, $hasher));
     ($field:ident, $ctx:expr, $hasher:expr, _) => ({ let _ = $field; });

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -167,8 +167,7 @@ newtype_index! {
 impl_stable_hash_for!(struct ::middle::region::FirstStatementIndex { private });
 
 // compilation error if size of `ScopeData` is not the same as a `u32`
-#[allow(dead_code)]
-static ASSERT: () = [()][!(mem::size_of::<ScopeData>() == 4) as usize];
+static_assert!(ASSERT_SCOPE_DATA: mem::size_of::<ScopeData>() == 4);
 
 impl Scope {
     /// Returns a item-local id associated with this scope.

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -827,12 +827,9 @@ impl<'tcx> CommonTypes<'tcx> {
     fn new(interners: &CtxtInterners<'tcx>) -> CommonTypes<'tcx> {
         // Ensure our type representation does not grow
         #[cfg(target_pointer_width = "64")]
-        #[allow(dead_code)]
-        static ASSERT_TY_KIND: () =
-            [()][!(::std::mem::size_of::<ty::TyKind<'_>>() <= 24) as usize];
+        static_assert!(ASSERT_TY_KIND: ::std::mem::size_of::<ty::TyKind<'_>>() <= 24);
         #[cfg(target_pointer_width = "64")]
-        #[allow(dead_code)]
-        static ASSERT_TYS: () = [()][!(::std::mem::size_of::<ty::TyS<'_>>() <= 32) as usize];
+        static_assert!(ASSERT_TYS: ::std::mem::size_of::<ty::TyS<'_>>() <= 32);
 
         let mk = |sty| CtxtInterners::intern_ty(interners, interners, sty);
         let mk_region = |r| {

--- a/src/librustc_errors/diagnostic.rs
+++ b/src/librustc_errors/diagnostic.rs
@@ -76,9 +76,9 @@ pub enum StringPart {
 }
 
 impl StringPart {
-    pub fn content(&self) -> String {
+    pub fn content(&self) -> &str {
         match self {
-            &StringPart::Normal(ref s) | & StringPart::Highlighted(ref s) => s.to_owned()
+            &StringPart::Normal(ref s) | & StringPart::Highlighted(ref s) => s
         }
     }
 }
@@ -398,7 +398,7 @@ impl Diagnostic {
     }
 
     pub fn message(&self) -> String {
-        self.message.iter().map(|i| i.0.to_owned()).collect::<String>()
+        self.message.iter().map(|i| i.0.as_str()).collect::<String>()
     }
 
     pub fn styled_message(&self) -> &Vec<(String, Style)> {
@@ -448,7 +448,7 @@ impl Diagnostic {
 
 impl SubDiagnostic {
     pub fn message(&self) -> String {
-        self.message.iter().map(|i| i.0.to_owned()).collect::<String>()
+        self.message.iter().map(|i| i.0.as_str()).collect::<String>()
     }
 
     pub fn styled_message(&self) -> &Vec<(String, Style)> {

--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -135,7 +135,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedResults {
 
         if let Some(must_use_op) = must_use_op {
             cx.span_lint(UNUSED_MUST_USE, expr.span,
-                         &format!("unused {} which must be used", must_use_op));
+                         &format!("unused {} that must be used", must_use_op));
             op_warned = true;
         }
 
@@ -146,7 +146,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedResults {
         fn check_must_use(cx: &LateContext, def_id: DefId, sp: Span, describe_path: &str) -> bool {
             for attr in cx.tcx.get_attrs(def_id).iter() {
                 if attr.check_name("must_use") {
-                    let msg = format!("unused {}`{}` which must be used",
+                    let msg = format!("unused {}`{}` that must be used",
                                           describe_path, cx.tcx.item_path_str(def_id));
                     let mut err = cx.struct_span_lint(UNUSED_MUST_USE, sp, &msg);
                     // check for #[must_use = "..."]
@@ -233,7 +233,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedAttributes {
                 .find(|&&(builtin, ty, _)| name == builtin && ty == AttributeType::CrateLevel)
                 .is_some();
 
-            // Has a plugin registered this attribute as one which must be used at
+            // Has a plugin registered this attribute as one that must be used at
             // the crate level?
             let plugin_crate = plugin_attributes.iter()
                 .find(|&&(ref x, t)| name == &**x && AttributeType::CrateLevel == t)

--- a/src/librustc_mir/interpret/operand.rs
+++ b/src/librustc_mir/interpret/operand.rs
@@ -11,7 +11,6 @@
 //! Functions concerning immediate values and operands, and reading from operands.
 //! All high-level functions to read from memory work on operands as sources.
 
-use std::hash::{Hash, Hasher};
 use std::convert::TryInto;
 
 use rustc::{mir, ty};
@@ -290,7 +289,7 @@ impl<Tag> Operand<Tag> {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 pub struct OpTy<'tcx, Tag=()> {
     crate op: Operand<Tag>, // ideally we'd make this private, but const_prop needs this
     pub layout: TyLayout<'tcx>,
@@ -323,26 +322,6 @@ impl<'tcx, Tag> From<ValTy<'tcx, Tag>> for OpTy<'tcx, Tag> {
         }
     }
 }
-
-// Validation needs to hash OpTy, but we cannot hash Layout -- so we just hash the type
-impl<'tcx, Tag> Hash for OpTy<'tcx, Tag>
-    where Tag: Hash
-{
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.op.hash(state);
-        self.layout.ty.hash(state);
-    }
-}
-impl<'tcx, Tag> PartialEq for OpTy<'tcx, Tag>
-    where Tag: PartialEq
-{
-    fn eq(&self, other: &Self) -> bool {
-        self.op == other.op && self.layout.ty == other.layout.ty
-    }
-}
-impl<'tcx, Tag> Eq for OpTy<'tcx, Tag>
-    where Tag: Eq
-{}
 
 impl<'tcx, Tag> OpTy<'tcx, Tag>
 {

--- a/src/librustc_target/abi/mod.rs
+++ b/src/librustc_target/abi/mod.rs
@@ -874,7 +874,7 @@ impl LayoutDetails {
 /// to those obtained from `layout_of(ty)`, as we need to produce
 /// layouts for which Rust types do not exist, such as enum variants
 /// or synthetic fields of enums (i.e. discriminants) and fat pointers.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct TyLayout<'a, Ty> {
     pub ty: Ty,
     pub details: &'a LayoutDetails

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -726,7 +726,7 @@ impl OpenOptions {
     /// If a file is opened with both read and append access, beware that after
     /// opening, and after every write, the position for reading may be set at the
     /// end of the file. So, before writing, save the current position (using
-    /// [`seek`]`(`[`SeekFrom`]`::`[`Current`]`(0))`, and restore it before the next read.
+    /// [`seek`]`(`[`SeekFrom`]`::`[`Current`]`(0))`), and restore it before the next read.
     ///
     /// ## Note
     ///

--- a/src/libstd/panic.rs
+++ b/src/libstd/panic.rs
@@ -79,7 +79,7 @@ pub use core::panic::{PanicInfo, Location};
 ///
 /// Simply put, a type `T` implements `UnwindSafe` if it cannot easily allow
 /// witnessing a broken invariant through the use of `catch_unwind` (catching a
-/// panic). This trait is a marker trait, so it is automatically implemented for
+/// panic). This trait is an auto trait, so it is automatically implemented for
 /// many types, and it is also structurally composed (e.g. a struct is unwind
 /// safe if all of its components are unwind safe).
 ///

--- a/src/libstd/primitive_docs.rs
+++ b/src/libstd/primitive_docs.rs
@@ -909,12 +909,12 @@ mod prim_usize { }
 /// references with longer lifetimes can be freely coerced into references with shorter ones.
 ///
 /// Reference equality by address, instead of comparing the values pointed to, is accomplished via
-/// implicit reference-pointer coercion and raw pointer equality via [`ptr::eq`], while 
+/// implicit reference-pointer coercion and raw pointer equality via [`ptr::eq`], while
 /// [`PartialEq`] compares values.
-/// 
+///
 /// [`ptr::eq`]: ptr/fn.eq.html
 /// [`PartialEq`]: cmp/trait.PartialEq.html
-/// 
+///
 /// ```
 /// use std::ptr;
 ///
@@ -930,14 +930,14 @@ mod prim_usize { }
 /// assert!(ptr::eq(five_ref, same_five_ref));
 /// assert!(!ptr::eq(five_ref, other_five_ref));
 /// ```
-/// 
+///
 /// For more information on how to use references, see [the book's section on "References and
 /// Borrowing"][book-refs].
 ///
 /// [book-refs]: ../book/second-edition/ch04-02-references-and-borrowing.html
 ///
 /// # Trait implementations
-/// 
+///
 /// The following traits are implemented for all `&T`, regardless of the type of its referent:
 ///
 /// * [`Copy`]

--- a/src/libstd/primitive_docs.rs
+++ b/src/libstd/primitive_docs.rs
@@ -908,11 +908,36 @@ mod prim_usize { }
 /// `&mut T` references can be freely coerced into `&T` references with the same referent type, and
 /// references with longer lifetimes can be freely coerced into references with shorter ones.
 ///
+/// Reference equality by address, instead of comparing the values pointed to, is accomplished via
+/// implicit reference-pointer coercion and raw pointer equality via [`ptr::eq`], while 
+/// [`PartialEq`] compares values.
+/// 
+/// [`ptr::eq`]: ptr/fn.eq.html
+/// [`PartialEq`]: cmp/trait.PartialEq.html
+/// 
+/// ```
+/// use std::ptr;
+///
+/// let five = 5;
+/// let other_five = 5;
+/// let five_ref = &five;
+/// let same_five_ref = &five;
+/// let other_five_ref = &other_five;
+///
+/// assert!(five_ref == same_five_ref);
+/// assert!(five_ref == other_five_ref);
+///
+/// assert!(ptr::eq(five_ref, same_five_ref));
+/// assert!(!ptr::eq(five_ref, other_five_ref));
+/// ```
+/// 
 /// For more information on how to use references, see [the book's section on "References and
 /// Borrowing"][book-refs].
 ///
 /// [book-refs]: ../book/second-edition/ch04-02-references-and-borrowing.html
 ///
+/// # Trait implementations
+/// 
 /// The following traits are implemented for all `&T`, regardless of the type of its referent:
 ///
 /// * [`Copy`]

--- a/src/libstd/sync/once.rs
+++ b/src/libstd/sync/once.rs
@@ -329,7 +329,7 @@ impl Once {
     /// assert!(handle.join().is_err());
     /// assert_eq!(INIT.is_completed(), false);
     /// ```
-    #[unstable(feature = "once_is_completed", issue = "42")]
+    #[unstable(feature = "once_is_completed", issue = "54890")]
     #[inline]
     pub fn is_completed(&self) -> bool {
         // An `Acquire` load is enough because that makes all the initialization

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -772,6 +772,11 @@ impl<'a> Parser<'a> {
                     //   |                   expected one of 8 possible tokens here
                     err.span_label(self.span, label_exp);
                 }
+                _ if self.prev_span == syntax_pos::DUMMY_SP => {
+                    // Account for macro context where the previous span might not be
+                    // available to avoid incorrect output (#54841).
+                    err.span_label(self.span, "unexpected token");
+                }
                 _ => {
                     err.span_label(sp, label_exp);
                     err.span_label(self.span, "unexpected token");

--- a/src/test/ui/borrowck/borrowck-move-from-unsafe-ptr.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-move-from-unsafe-ptr.nll.stderr
@@ -1,10 +1,10 @@
-error[E0507]: cannot move out of borrowed content
+error[E0507]: cannot move out of dereference of raw pointer
   --> $DIR/borrowck-move-from-unsafe-ptr.rs:13:13
    |
 LL |     let y = *x; //~ ERROR cannot move out of dereference of raw pointer
    |             ^^
    |             |
-   |             cannot move out of borrowed content
+   |             cannot move out of dereference of raw pointer
    |             help: consider removing the `*`: `x`
 
 error: aborting due to previous error

--- a/src/test/ui/fn_must_use.stderr
+++ b/src/test/ui/fn_must_use.stderr
@@ -1,4 +1,4 @@
-warning: unused return value of `need_to_use_this_value` which must be used
+warning: unused return value of `need_to_use_this_value` that must be used
   --> $DIR/fn_must_use.rs:60:5
    |
 LL |     need_to_use_this_value(); //~ WARN unused return value
@@ -11,13 +11,13 @@ LL | #![warn(unused_must_use)]
    |         ^^^^^^^^^^^^^^^
    = note: it's important
 
-warning: unused return value of `MyStruct::need_to_use_this_method_value` which must be used
+warning: unused return value of `MyStruct::need_to_use_this_method_value` that must be used
   --> $DIR/fn_must_use.rs:65:5
    |
 LL |     m.need_to_use_this_method_value(); //~ WARN unused return value
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: unused return value of `EvenNature::is_even` which must be used
+warning: unused return value of `EvenNature::is_even` that must be used
   --> $DIR/fn_must_use.rs:66:5
    |
 LL |     m.is_even(); // trait method!
@@ -25,25 +25,25 @@ LL |     m.is_even(); // trait method!
    |
    = note: no side effects
 
-warning: unused return value of `std::cmp::PartialEq::eq` which must be used
+warning: unused return value of `std::cmp::PartialEq::eq` that must be used
   --> $DIR/fn_must_use.rs:72:5
    |
 LL |     2.eq(&3); //~ WARN unused return value
    |     ^^^^^^^^^
 
-warning: unused return value of `std::cmp::PartialEq::eq` which must be used
+warning: unused return value of `std::cmp::PartialEq::eq` that must be used
   --> $DIR/fn_must_use.rs:73:5
    |
 LL |     m.eq(&n); //~ WARN unused return value
    |     ^^^^^^^^^
 
-warning: unused comparison which must be used
+warning: unused comparison that must be used
   --> $DIR/fn_must_use.rs:76:5
    |
 LL |     2 == 3; //~ WARN unused comparison
    |     ^^^^^^
 
-warning: unused comparison which must be used
+warning: unused comparison that must be used
   --> $DIR/fn_must_use.rs:77:5
    |
 LL |     m == n; //~ WARN unused comparison

--- a/src/test/ui/issues/issue-20801.nll.stderr
+++ b/src/test/ui/issues/issue-20801.nll.stderr
@@ -16,22 +16,22 @@ LL |     let b = unsafe { *imm_ref() };
    |                      cannot move out of borrowed content
    |                      help: consider removing the `*`: `imm_ref()`
 
-error[E0507]: cannot move out of borrowed content
+error[E0507]: cannot move out of dereference of raw pointer
   --> $DIR/issue-20801.rs:42:22
    |
 LL |     let c = unsafe { *mut_ptr() };
    |                      ^^^^^^^^^^
    |                      |
-   |                      cannot move out of borrowed content
+   |                      cannot move out of dereference of raw pointer
    |                      help: consider removing the `*`: `mut_ptr()`
 
-error[E0507]: cannot move out of borrowed content
+error[E0507]: cannot move out of dereference of raw pointer
   --> $DIR/issue-20801.rs:45:22
    |
 LL |     let d = unsafe { *const_ptr() };
    |                      ^^^^^^^^^^^^
    |                      |
-   |                      cannot move out of borrowed content
+   |                      cannot move out of dereference of raw pointer
    |                      help: consider removing the `*`: `const_ptr()`
 
 error: aborting due to 4 previous errors

--- a/src/test/ui/lint/must-use-ops.stderr
+++ b/src/test/ui/lint/must-use-ops.stderr
@@ -1,4 +1,4 @@
-warning: unused comparison which must be used
+warning: unused comparison that must be used
   --> $DIR/must-use-ops.rs:22:5
    |
 LL |     val == 1;
@@ -10,121 +10,121 @@ note: lint level defined here
 LL | #![warn(unused_must_use)]
    |         ^^^^^^^^^^^^^^^
 
-warning: unused comparison which must be used
+warning: unused comparison that must be used
   --> $DIR/must-use-ops.rs:23:5
    |
 LL |     val < 1;
    |     ^^^^^^^
 
-warning: unused comparison which must be used
+warning: unused comparison that must be used
   --> $DIR/must-use-ops.rs:24:5
    |
 LL |     val <= 1;
    |     ^^^^^^^^
 
-warning: unused comparison which must be used
+warning: unused comparison that must be used
   --> $DIR/must-use-ops.rs:25:5
    |
 LL |     val != 1;
    |     ^^^^^^^^
 
-warning: unused comparison which must be used
+warning: unused comparison that must be used
   --> $DIR/must-use-ops.rs:26:5
    |
 LL |     val >= 1;
    |     ^^^^^^^^
 
-warning: unused comparison which must be used
+warning: unused comparison that must be used
   --> $DIR/must-use-ops.rs:27:5
    |
 LL |     val > 1;
    |     ^^^^^^^
 
-warning: unused arithmetic operation which must be used
+warning: unused arithmetic operation that must be used
   --> $DIR/must-use-ops.rs:30:5
    |
 LL |     val + 2;
    |     ^^^^^^^
 
-warning: unused arithmetic operation which must be used
+warning: unused arithmetic operation that must be used
   --> $DIR/must-use-ops.rs:31:5
    |
 LL |     val - 2;
    |     ^^^^^^^
 
-warning: unused arithmetic operation which must be used
+warning: unused arithmetic operation that must be used
   --> $DIR/must-use-ops.rs:32:5
    |
 LL |     val / 2;
    |     ^^^^^^^
 
-warning: unused arithmetic operation which must be used
+warning: unused arithmetic operation that must be used
   --> $DIR/must-use-ops.rs:33:5
    |
 LL |     val * 2;
    |     ^^^^^^^
 
-warning: unused arithmetic operation which must be used
+warning: unused arithmetic operation that must be used
   --> $DIR/must-use-ops.rs:34:5
    |
 LL |     val % 2;
    |     ^^^^^^^
 
-warning: unused logical operation which must be used
+warning: unused logical operation that must be used
   --> $DIR/must-use-ops.rs:37:5
    |
 LL |     true && true;
    |     ^^^^^^^^^^^^
 
-warning: unused logical operation which must be used
+warning: unused logical operation that must be used
   --> $DIR/must-use-ops.rs:38:5
    |
 LL |     false || true;
    |     ^^^^^^^^^^^^^
 
-warning: unused bitwise operation which must be used
+warning: unused bitwise operation that must be used
   --> $DIR/must-use-ops.rs:41:5
    |
 LL |     5 ^ val;
    |     ^^^^^^^
 
-warning: unused bitwise operation which must be used
+warning: unused bitwise operation that must be used
   --> $DIR/must-use-ops.rs:42:5
    |
 LL |     5 & val;
    |     ^^^^^^^
 
-warning: unused bitwise operation which must be used
+warning: unused bitwise operation that must be used
   --> $DIR/must-use-ops.rs:43:5
    |
 LL |     5 | val;
    |     ^^^^^^^
 
-warning: unused bitwise operation which must be used
+warning: unused bitwise operation that must be used
   --> $DIR/must-use-ops.rs:44:5
    |
 LL |     5 << val;
    |     ^^^^^^^^
 
-warning: unused bitwise operation which must be used
+warning: unused bitwise operation that must be used
   --> $DIR/must-use-ops.rs:45:5
    |
 LL |     5 >> val;
    |     ^^^^^^^^
 
-warning: unused unary operation which must be used
+warning: unused unary operation that must be used
   --> $DIR/must-use-ops.rs:48:5
    |
 LL |     !val;
    |     ^^^^
 
-warning: unused unary operation which must be used
+warning: unused unary operation that must be used
   --> $DIR/must-use-ops.rs:49:5
    |
 LL |     -val;
    |     ^^^^
 
-warning: unused unary operation which must be used
+warning: unused unary operation that must be used
   --> $DIR/must-use-ops.rs:50:5
    |
 LL |     *val_pointer;

--- a/src/test/ui/lint/must_use-unit.rs
+++ b/src/test/ui/lint/must_use-unit.rs
@@ -1,0 +1,17 @@
+#![feature(never_type)]
+
+#![deny(unused_must_use)]
+
+#[must_use]
+fn foo() {}
+
+#[must_use]
+fn bar() -> ! {
+    unimplemented!()
+}
+
+fn main() {
+    foo(); //~ unused return value of `foo`
+
+    bar(); //~ unused return value of `bar`
+}

--- a/src/test/ui/lint/must_use-unit.stderr
+++ b/src/test/ui/lint/must_use-unit.stderr
@@ -1,0 +1,20 @@
+error: unused return value of `foo` which must be used
+  --> $DIR/must_use-unit.rs:14:5
+   |
+LL |     foo(); //~ unused return value of `foo`
+   |     ^^^^^^
+   |
+note: lint level defined here
+  --> $DIR/must_use-unit.rs:3:9
+   |
+LL | #![deny(unused_must_use)]
+   |         ^^^^^^^^^^^^^^^
+
+error: unused return value of `bar` which must be used
+  --> $DIR/must_use-unit.rs:16:5
+   |
+LL |     bar(); //~ unused return value of `bar`
+   |     ^^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/macros/issue-54441.stderr
+++ b/src/test/ui/macros/issue-54441.stderr
@@ -1,9 +1,6 @@
 error: expected one of `crate`, `fn`, `pub`, `static`, or `type`, found `let`
   --> $DIR/issue-54441.rs:5:9
    |
-LL | #![feature(macros_in_extern)]
-   | - expected one of `crate`, `fn`, `pub`, `static`, or `type` here
-...
 LL |         let //~ ERROR expected
    |         ^^^ unexpected token
 ...

--- a/src/test/ui/unused/unused-result.rs
+++ b/src/test/ui/unused/unused-result.rs
@@ -28,8 +28,8 @@ fn qux() -> MustUseMsg { return foo::<MustUseMsg>(); }
 #[allow(unused_results)]
 fn test() {
     foo::<isize>();
-    foo::<MustUse>(); //~ ERROR: unused `MustUse` which must be used
-    foo::<MustUseMsg>(); //~ ERROR: unused `MustUseMsg` which must be used
+    foo::<MustUse>(); //~ ERROR: unused `MustUse` that must be used
+    foo::<MustUseMsg>(); //~ ERROR: unused `MustUseMsg` that must be used
     //~^ NOTE: some message
 }
 
@@ -42,8 +42,8 @@ fn test2() {
 
 fn main() {
     foo::<isize>(); //~ ERROR: unused result
-    foo::<MustUse>(); //~ ERROR: unused `MustUse` which must be used
-    foo::<MustUseMsg>(); //~ ERROR: unused `MustUseMsg` which must be used
+    foo::<MustUse>(); //~ ERROR: unused `MustUse` that must be used
+    foo::<MustUseMsg>(); //~ ERROR: unused `MustUseMsg` that must be used
     //~^ NOTE: some message
 
     let _ = foo::<isize>();

--- a/src/test/ui/unused/unused-result.stderr
+++ b/src/test/ui/unused/unused-result.stderr
@@ -1,7 +1,7 @@
-error: unused `MustUse` which must be used
+error: unused `MustUse` that must be used
   --> $DIR/unused-result.rs:31:5
    |
-LL |     foo::<MustUse>(); //~ ERROR: unused `MustUse` which must be used
+LL |     foo::<MustUse>(); //~ ERROR: unused `MustUse` that must be used
    |     ^^^^^^^^^^^^^^^^^
    |
 note: lint level defined here
@@ -10,10 +10,10 @@ note: lint level defined here
 LL | #![deny(unused_results, unused_must_use)]
    |                         ^^^^^^^^^^^^^^^
 
-error: unused `MustUseMsg` which must be used
+error: unused `MustUseMsg` that must be used
   --> $DIR/unused-result.rs:32:5
    |
-LL |     foo::<MustUseMsg>(); //~ ERROR: unused `MustUseMsg` which must be used
+LL |     foo::<MustUseMsg>(); //~ ERROR: unused `MustUseMsg` that must be used
    |     ^^^^^^^^^^^^^^^^^^^^
    |
    = note: some message
@@ -30,16 +30,16 @@ note: lint level defined here
 LL | #![deny(unused_results, unused_must_use)]
    |         ^^^^^^^^^^^^^^
 
-error: unused `MustUse` which must be used
+error: unused `MustUse` that must be used
   --> $DIR/unused-result.rs:45:5
    |
-LL |     foo::<MustUse>(); //~ ERROR: unused `MustUse` which must be used
+LL |     foo::<MustUse>(); //~ ERROR: unused `MustUse` that must be used
    |     ^^^^^^^^^^^^^^^^^
 
-error: unused `MustUseMsg` which must be used
+error: unused `MustUseMsg` that must be used
   --> $DIR/unused-result.rs:46:5
    |
-LL |     foo::<MustUseMsg>(); //~ ERROR: unused `MustUseMsg` which must be used
+LL |     foo::<MustUseMsg>(); //~ ERROR: unused `MustUseMsg` that must be used
    |     ^^^^^^^^^^^^^^^^^^^^
    |
    = note: some message


### PR DESCRIPTION
Successful merges:

 - #54755 (Documents reference equality by address (#54197))
 - #54811 (During rustc bootstrap, make default for `optimize` independent of `debug`)
 - #54825 (NLL says "borrowed content" instead of more precise "dereference of raw pointer")
 - #54860 (Add doc comments about safest way to initialize a vector of zeros)
 - #54891 (Fix tracking issue for Once::is_completed)
 - #54913 (doc fix: it's auto traits that make for automatic implementations)
 - #54916 (submodules: update clippy, rls and cargo, fix toolstate)
 - #54917 (Unused result warning: "X which must" ↦ "X that must")
 - #54920 (Fix handling of #[must_use] on unit and uninhabited types)
 - #54932 (A handful of random string-related improvements)
 - #54936 (impl Eq+Hash for TyLayout)
 - #54956 ("(using ..." doesn't have the matching ")")
 - #54958 (add a macro for static (compile-time) assertions)
 - #54967 (Remove incorrect span for second label inner macro invocation)

Failed merges:


r? @ghost