### PR TITLE
Tell LLVM about NonZero integer types

### DIFF
--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -88,7 +88,9 @@ assert_eq!(size_of::<Option<std::num::", stringify!($Ty), ">>(), size_of::<", st
                 #[stable(feature = "nonzero", since = "1.28.0")]
                 #[inline]
                 pub fn get(self) -> $Int {
-                    self.0 .0
+                    let r = self.0 .0;
+                    unsafe { intrinsics::assume(r != 0) };
+                    r
                 }
 
             }

--- a/src/test/codegen/nonzero-assume.rs
+++ b/src/test/codegen/nonzero-assume.rs
@@ -1,0 +1,23 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -O
+
+#![crate_type = "lib"]
+
+use std::num::NonZeroU64;
+
+// CHECK-LABEL: @assume_nonzero
+#[no_mangle]
+pub fn assume_nonzero(x: u64, y: NonZeroU64) -> u64 {
+    x / y.get()
+    // CHECK: icmp ne i64 %y, 0
+    // CHECK: @llvm.assume
+}


### PR DESCRIPTION
Change the `get` method on NonZero integer types to insert an
`assume`, so that LLVM can optimize better.

Closes #54868