### PR TITLE
Cleanup rustc/driver

### DIFF
--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -1578,9 +1578,10 @@ pub fn collect_crate_types(session: &Session, attrs: &[ast::Attribute]) -> Vec<c
             base.push(::rustc_codegen_utils::link::default_output_for_target(
                 session,
             ));
+        } else {
+            base.sort();
+            base.dedup();
         }
-        base.sort();
-        base.dedup();
     }
 
     base.retain(|crate_type| {

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -1021,6 +1021,7 @@ where
             .cloned()
             .collect();
         missing_fragment_specifiers.sort();
+
         for span in missing_fragment_specifiers {
             let lint = lint::builtin::MISSING_FRAGMENT_SPECIFIER;
             let msg = "missing fragment specifier";
@@ -1517,6 +1518,7 @@ pub fn collect_crate_types(session: &Session, attrs: &[ast::Attribute]) -> Vec<c
                             Symbol::intern("proc-macro"),
                             Symbol::intern("bin")
                         ];
+
                         if let ast::MetaItemKind::NameValue(spanned) = a.meta().unwrap().node {
                             let span = spanned.span;
                             let lev_candidate = find_best_match_for_name(
@@ -1587,12 +1589,12 @@ pub fn collect_crate_types(session: &Session, attrs: &[ast::Attribute]) -> Vec<c
     base.retain(|crate_type| {
         let res = !::rustc_codegen_utils::link::invalid_output_for_target(session, *crate_type);
 
-            if !res {
-                session.warn(&format!(
-                    "dropping unsupported crate type `{}` for target `{}`",
-                    *crate_type, session.opts.target_triple
-                ));
-            }
+        if !res {
+            session.warn(&format!(
+                "dropping unsupported crate type `{}` for target `{}`",
+                *crate_type, session.opts.target_triple
+            ));
+        }
 
         res
     });

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -1548,7 +1548,7 @@ pub fn collect_crate_types(session: &Session, attrs: &[ast::Attribute]) -> Vec<c
                         }
                         None
                     }
-                    _ => {
+                    None => {
                         session
                             .struct_span_err(a.span, "`crate_type` requires a value")
                             .note("for example: `#![crate_type=\"lib\"]`")

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -1586,9 +1586,8 @@ pub fn collect_crate_types(session: &Session, attrs: &[ast::Attribute]) -> Vec<c
         base.dedup();
     }
 
-    base.into_iter()
-        .filter(|crate_type| {
-            let res = !::rustc_codegen_utils::link::invalid_output_for_target(session, *crate_type);
+    base.retain(|crate_type| {
+        let res = !::rustc_codegen_utils::link::invalid_output_for_target(session, *crate_type);
 
             if !res {
                 session.warn(&format!(
@@ -1597,9 +1596,10 @@ pub fn collect_crate_types(session: &Session, attrs: &[ast::Attribute]) -> Vec<c
                 ));
             }
 
-            res
-        })
-        .collect()
+        res
+    });
+
+    base
 }
 
 pub fn compute_crate_disambiguator(session: &Session) -> CrateDisambiguator {

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -1484,15 +1484,12 @@ fn write_out_deps(sess: &Session, outputs: &OutputFilenames, out_filenames: &[Pa
         Ok(())
     })();
 
-    match result {
-        Ok(()) => {}
-        Err(e) => {
-            sess.fatal(&format!(
-                "error writing dependencies to `{}`: {}",
-                deps_filename.display(),
-                e
-            ));
-        }
+    if let Err(e) = result {
+        sess.fatal(&format!(
+            "error writing dependencies to `{}`: {}",
+            deps_filename.display(),
+            e
+        ));
     }
 }
 
@@ -1650,10 +1647,7 @@ pub fn build_output_filenames(
             // "-" as input file will cause the parser to read from stdin so we
             // have to make up a name
             // We want to toss everything after the final '.'
-            let dirpath = match *odir {
-                Some(ref d) => d.clone(),
-                None => PathBuf::new(),
-            };
+            let dirpath = (*odir).as_ref().cloned().unwrap_or_else(|| PathBuf::new());
 
             // If a crate name is present, we use it as the link name
             let stem = sess.opts

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -44,7 +44,7 @@ use serialize::json;
 
 use std::any::Any;
 use std::env;
-use std::ffi::{OsStr, OsString};
+use std::ffi::OsString;
 use std::fs;
 use std::io::{self, Write};
 use std::iter;
@@ -1648,14 +1648,14 @@ pub fn build_output_filenames(
             // "-" as input file will cause the parser to read from stdin so we
             // have to make up a name
             // We want to toss everything after the final '.'
-            let dirpath = (*odir).as_ref().cloned().unwrap_or_else(|| PathBuf::new());
+            let dirpath = (*odir).as_ref().cloned().unwrap_or_default();
 
             // If a crate name is present, we use it as the link name
             let stem = sess.opts
                 .crate_name
                 .clone()
                 .or_else(|| attr::find_crate_name(attrs).map(|n| n.to_string()))
-                .unwrap_or(input.filestem());
+                .unwrap_or_else(|| input.filestem());
 
             OutputFilenames {
                 out_directory: dirpath,
@@ -1688,13 +1688,11 @@ pub fn build_output_filenames(
                 sess.warn("ignoring -C extra-filename flag due to -o flag");
             }
 
-            let cur_dir = Path::new("");
-
             OutputFilenames {
-                out_directory: out_file.parent().unwrap_or(cur_dir).to_path_buf(),
+                out_directory: out_file.parent().unwrap_or_else(|| Path::new("")).to_path_buf(),
                 out_filestem: out_file
                     .file_stem()
-                    .unwrap_or(OsStr::new(""))
+                    .unwrap_or_default()
                     .to_str()
                     .unwrap()
                     .to_string(),

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -1472,7 +1472,7 @@ fn write_out_deps(sess: &Session, outputs: &OutputFilenames, out_filenames: &[Pa
             .collect();
         let mut file = fs::File::create(&deps_filename)?;
         for path in out_filenames {
-            write!(file, "{}: {}\n\n", path.display(), files.join(" "))?;
+            writeln!(file, "{}: {}\n", path.display(), files.join(" "))?;
         }
 
         // Emit a fake target for each input file to the compilation. This

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -188,14 +188,16 @@ pub fn run<F>(run_compiler: F) -> isize
                     }
                     None => {
                         let emitter =
-                            errors::emitter::EmitterWriter::stderr(errors::ColorConfig::Auto,
-                                                                None,
-                                                                true,
-                                                                false);
+                            errors::emitter::EmitterWriter::stderr(
+                                errors::ColorConfig::Auto,
+                                None,
+                                true,
+                                false
+                            );
                         let handler = errors::Handler::with_emitter(true, false, Box::new(emitter));
                         handler.emit(&MultiSpan::new(),
-                                    "aborting due to previous error(s)",
-                                    errors::Level::Fatal);
+                                     "aborting due to previous error(s)",
+                                     errors::Level::Fatal);
                         panic::resume_unwind(Box::new(errors::FatalErrorMarker));
                     }
                 }
@@ -316,9 +318,8 @@ fn get_codegen_sysroot(backend_name: &str) -> fn() -> Box<dyn CodegenBackend> {
     let sysroot = sysroot_candidates.iter()
         .map(|sysroot| {
             let libdir = filesearch::relative_target_lib_path(&sysroot, &target);
-            sysroot.join(libdir)
-                .with_file_name(option_env!("CFG_CODEGEN_BACKENDS_DIR")
-                                .unwrap_or("codegen-backends"))
+            sysroot.join(libdir).with_file_name(
+                option_env!("CFG_CODEGEN_BACKENDS_DIR").unwrap_or("codegen-backends"))
         })
         .filter(|f| {
             info!("codegen backend candidate: {}", f.display());
@@ -360,8 +361,8 @@ fn get_codegen_sysroot(backend_name: &str) -> fn() -> Box<dyn CodegenBackend> {
         }
         if let Some(ref prev) = file {
             let err = format!("duplicate codegen backends found\n\
-                first:  {}\n\
-                second: {}\n\
+                               first:  {}\n\
+                               second: {}\n\
             ", prev.display(), path.display());
             early_error(ErrorOutputType::default(), &err);
         }
@@ -373,7 +374,7 @@ fn get_codegen_sysroot(backend_name: &str) -> fn() -> Box<dyn CodegenBackend> {
         None => {
             let err = format!("failed to load default codegen backend for `{}`, \
                                no appropriate codegen dylib found in `{}`",
-                               backend_name, sysroot.display());
+                              backend_name, sysroot.display());
             early_error(ErrorOutputType::default(), &err);
         }
     }
@@ -1010,7 +1011,7 @@ impl RustcDefaultCalls {
         use rustc::session::config::PrintRequest::*;
         // PrintRequest::NativeStaticLibs is special - printed during linking
         // (empty iterator returns true)
-        if sess.opts.prints.iter().all(|&p| p==PrintRequest::NativeStaticLibs) {
+        if sess.opts.prints.iter().all(|&p| p == PrintRequest::NativeStaticLibs) {
             return Compilation::Continue;
         }
 
@@ -1054,10 +1055,7 @@ impl RustcDefaultCalls {
                             &id,
                             &t_outputs
                         );
-                        println!("{}",
-                                 fname.file_name()
-                                      .unwrap()
-                                      .to_string_lossy());
+                        println!("{}", fname.file_name().unwrap().to_string_lossy());
                     }
                 }
                 Cfg => {
@@ -1129,9 +1127,8 @@ fn commit_date_str() -> Option<&'static str> {
 pub fn version(binary: &str, matches: &getopts::Matches) {
     let verbose = matches.opt_present("verbose");
 
-    println!("{} {}",
-             binary,
-             option_env!("CFG_VERSION").unwrap_or("unknown version"));
+    println!("{} {}", binary, option_env!("CFG_VERSION").unwrap_or("unknown version"));
+
     if verbose {
         fn unw(x: Option<&str>) -> &str {
             x.unwrap_or("unknown")
@@ -1251,8 +1248,6 @@ Available lint options:
     };
 
     print_lints(builtin);
-
-
 
     let max_name_len = max("warnings".len(),
                            plugin_groups.iter()
@@ -1429,6 +1424,7 @@ pub fn handle_options(args: &[String]) -> Option<getopts::Matches> {
     }
 
     let cg_flags = matches.opt_strs("C");
+
     if cg_flags.iter().any(|x| *x == "help") {
         describe_codegen_flags();
         return None;
@@ -1477,7 +1473,7 @@ pub fn in_named_rustc_thread<F, R>(name: String, f: F) -> Result<R, Box<dyn Any 
     // Temporarily have stack size set to 16MB to deal with nom-using crates failing
     const STACK_SIZE: usize = 16 * 1024 * 1024; // 16MB
 
-    #[cfg(all(unix,not(target_os = "haiku")))]
+    #[cfg(all(unix, not(target_os = "haiku")))]
     let spawn_thread = unsafe {
         // Fetch the current resource limits
         let mut rlim = libc::rlimit {
@@ -1531,7 +1527,7 @@ pub fn in_named_rustc_thread<F, R>(name: String, f: F) -> Result<R, Box<dyn Any 
         }
     };
 
-    #[cfg(not(any(windows,unix)))]
+    #[cfg(not(any(windows, unix)))]
     let spawn_thread = true;
 
     // The or condition is added from backward compatibility.

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -997,7 +997,7 @@ impl RustcDefaultCalls {
             return Compilation::Stop;
         }
 
-        return Compilation::Continue;
+        Compilation::Continue
     }
 
 

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -579,7 +579,7 @@ pub fn set_sigpipe_handler() {
     unsafe {
         // Set the SIGPIPE signal handler, so that an EPIPE
         // will cause rustc to terminate, as expected.
-        assert!(libc::signal(libc::SIGPIPE, libc::SIG_DFL) != libc::SIG_ERR);
+        assert_ne!(libc::signal(libc::SIGPIPE, libc::SIG_DFL), libc::SIG_ERR);
     }
 }
 

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -152,21 +152,14 @@ pub const EXIT_SUCCESS: isize = 0;
 /// Exit status code used for compilation failures and  invalid flags.
 pub const EXIT_FAILURE: isize = 1;
 
-const BUG_REPORT_URL: &'static str = "https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.\
-                                      md#bug-reports";
+const BUG_REPORT_URL: &str = "https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.\
+                              md#bug-reports";
 
-const ICE_REPORT_COMPILER_FLAGS: &'static [&'static str] = &[
-    "Z",
-    "C",
-    "crate-type",
-];
-const ICE_REPORT_COMPILER_FLAGS_EXCLUDE: &'static [&'static str] = &[
-    "metadata",
-    "extra-filename",
-];
-const ICE_REPORT_COMPILER_FLAGS_STRIP_VALUE: &'static [&'static str] = &[
-    "incremental",
-];
+const ICE_REPORT_COMPILER_FLAGS: &[&str] = &["Z", "C", "crate-type"];
+
+const ICE_REPORT_COMPILER_FLAGS_EXCLUDE: &[&str] = &["metadata", "extra-filename"];
+
+const ICE_REPORT_COMPILER_FLAGS_STRIP_VALUE: &[&str] = &["incremental"];
 
 pub fn abort_on_err<T>(result: Result<T, CompileIncomplete>, sess: &Session) -> T {
     match result {

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -90,6 +90,7 @@ use rustc_codegen_utils::codegen_backend::CodegenBackend;
 use serialize::json::ToJson;
 
 use std::any::Any;
+use std::borrow::Cow;
 use std::cmp::max;
 use std::default::Default;
 use std::env::consts::{DLL_PREFIX, DLL_SUFFIX};
@@ -1678,25 +1679,25 @@ pub fn monitor<F: FnOnce() + Send + 'static>(f: F) -> Result<(), CompilationFail
                              errors::Level::Bug);
             }
 
-            let mut xs = vec![
-                "the compiler unexpectedly panicked. this is a bug.".to_string(),
-                format!("we would appreciate a bug report: {}", BUG_REPORT_URL),
+            let mut xs: Vec<Cow<'static, str>> = vec![
+                "the compiler unexpectedly panicked. this is a bug.".into(),
+                format!("we would appreciate a bug report: {}", BUG_REPORT_URL).into(),
                 format!("rustc {} running on {}",
                         option_env!("CFG_VERSION").unwrap_or("unknown_version"),
-                        config::host_triple()),
+                        config::host_triple()).into(),
             ];
 
             if let Some((flags, excluded_cargo_defaults)) = extra_compiler_flags() {
-                xs.push(format!("compiler flags: {}", flags.join(" ")));
+                xs.push(format!("compiler flags: {}", flags.join(" ")).into());
 
                 if excluded_cargo_defaults {
-                    xs.push("some of the compiler flags provided by cargo are hidden".to_string());
+                    xs.push("some of the compiler flags provided by cargo are hidden".into());
                 }
             }
 
             for note in &xs {
                 handler.emit(&MultiSpan::new(),
-                             &note,
+                             note,
                              errors::Level::Note);
             }
 

--- a/src/librustc_driver/pretty.rs
+++ b/src/librustc_driver/pretty.rs
@@ -167,10 +167,10 @@ pub fn parse_pretty(sess: &Session,
 impl PpSourceMode {
     /// Constructs a `PrinterSupport` object and passes it to `f`.
     fn call_with_pp_support<'tcx, A, F>(&self,
-                                           sess: &'tcx Session,
-                                           hir_map: Option<&hir_map::Map<'tcx>>,
-                                           f: F)
-                                           -> A
+                                        sess: &'tcx Session,
+                                        hir_map: Option<&hir_map::Map<'tcx>>,
+                                        f: F)
+                                        -> A
         where F: FnOnce(&dyn PrinterSupport) -> A
     {
         match *self {
@@ -198,17 +198,18 @@ impl PpSourceMode {
             _ => panic!("Should use call_with_pp_support_hir"),
         }
     }
-    fn call_with_pp_support_hir<'tcx, A, F>(&self,
-                                               sess: &'tcx Session,
-                                               cstore: &'tcx CStore,
-                                               hir_map: &hir_map::Map<'tcx>,
-                                               analysis: &ty::CrateAnalysis,
-                                               resolutions: &Resolutions,
-                                               arenas: &'tcx AllArenas<'tcx>,
-                                               output_filenames: &OutputFilenames,
-                                               id: &str,
-                                               f: F)
-                                               -> A
+    fn call_with_pp_support_hir<'tcx, A, F>(
+        &self,
+        sess: &'tcx Session,
+        cstore: &'tcx CStore,
+        hir_map: &hir_map::Map<'tcx>,
+        analysis: &ty::CrateAnalysis,
+        resolutions: &Resolutions,
+        arenas: &'tcx AllArenas<'tcx>,
+        output_filenames: &OutputFilenames,
+        id: &str,
+        f: F
+    ) -> A
         where F: FnOnce(&dyn HirPrinterSupport, &hir::Crate) -> A
     {
         match *self {
@@ -952,18 +953,17 @@ pub fn print_after_parsing(sess: &Session,
         // Silently ignores an identified node.
         let out: &mut dyn Write = &mut out;
         s.call_with_pp_support(sess, None, move |annotation| {
-                debug!("pretty printing source code {:?}", s);
-                let sess = annotation.sess();
-                pprust::print_crate(sess.source_map(),
-                                    &sess.parse_sess,
-                                    krate,
-                                    src_name,
-                                    &mut rdr,
-                                    box out,
-                                    annotation.pp_ann(),
-                                    false)
-            })
-            .unwrap()
+            debug!("pretty printing source code {:?}", s);
+            let sess = annotation.sess();
+            pprust::print_crate(sess.source_map(),
+                                &sess.parse_sess,
+                                krate,
+                                src_name,
+                                &mut rdr,
+                                box out,
+                                annotation.pp_ann(),
+                                false)
+        }).unwrap()
     } else {
         unreachable!();
     };

--- a/src/librustc_driver/pretty.rs
+++ b/src/librustc_driver/pretty.rs
@@ -855,7 +855,7 @@ fn print_flowgraph<'a, 'tcx, W: Write>(variants: Vec<borrowck_dot::Variant>,
                     break n.body();
                 }
                 let parent = tcx.hir.get_parent_node(node_id);
-                assert!(node_id != parent);
+                assert_ne!(node_id, parent);
                 node_id = parent;
             }
         }

--- a/src/librustc_driver/profile/mod.rs
+++ b/src/librustc_driver/profile/mod.rs
@@ -109,17 +109,14 @@ fn profile_queries_thread(r:Receiver<ProfileQueriesMsg>) {
                     let counts_path = format!("{}.counts.txt", params.path);
                     let mut counts_file = File::create(&counts_path).unwrap();
 
-                    write!(html_file, "<html>\n").unwrap();
-                    write!(html_file,
-                           "<head>\n<link rel=\"stylesheet\" type=\"text/css\" href=\"{}\">\n",
-                           "profile_queries.css").unwrap();
-                    write!(html_file, "<style>\n").unwrap();
+                    writeln!(html_file,
+                        "<html>\n<head>\n<link rel=\"stylesheet\" type=\"text/css\" href=\"{}\">",
+                        "profile_queries.css").unwrap();
+                    writeln!(html_file, "<style>").unwrap();
                     trace::write_style(&mut html_file);
-                    write!(html_file, "</style>\n").unwrap();
-                    write!(html_file, "</head>\n").unwrap();
-                    write!(html_file, "<body>\n").unwrap();
+                    writeln!(html_file, "</style>\n</head>\n<body>").unwrap();
                     trace::write_traces(&mut html_file, &mut counts_file, &frame.traces);
-                    write!(html_file, "</body>\n</html>\n").unwrap();
+                    writeln!(html_file, "</body>\n</html>").unwrap();
 
                     let ack_path = format!("{}.ack", params.path);
                     let ack_file = File::create(&ack_path).unwrap();

--- a/src/librustc_driver/profile/mod.rs
+++ b/src/librustc_driver/profile/mod.rs
@@ -90,7 +90,7 @@ fn profile_queries_thread(r:Receiver<ProfileQueriesMsg>) {
         match msg {
             ProfileQueriesMsg::Halt => return,
             ProfileQueriesMsg::Dump(params) => {
-                assert!(stack.len() == 0);
+                assert!(stack.is_empty());
                 assert!(frame.parse_st == ParseState::Clear);
                 {
                     // write log of all messages
@@ -141,7 +141,7 @@ fn profile_queries_thread(r:Receiver<ProfileQueriesMsg>) {
                      ProfileQueriesMsg::QueryBegin(span,querymsg)) => {
                         let start = Instant::now();
                         frame.parse_st = ParseState::HaveQuery
-                            (Query{span:span, msg:querymsg}, start)
+                            (Query { span, msg: querymsg }, start)
                     },
                     (ParseState::Clear,
                      ProfileQueriesMsg::CacheHit) => {

--- a/src/librustc_driver/profile/mod.rs
+++ b/src/librustc_driver/profile/mod.rs
@@ -23,7 +23,7 @@ pub fn begin(sess: &Session) {
     use std::sync::mpsc::{channel};
     let (tx, rx) = channel();
     if profq_set_chan(sess, tx) {
-        thread::spawn(move||profile_queries_thread(rx));
+        thread::spawn(move || profile_queries_thread(rx));
     }
 }
 
@@ -34,11 +34,12 @@ pub fn begin(sess: &Session) {
 pub fn dump(sess: &Session, path: String) {
     use std::sync::mpsc::{channel};
     let (tx, rx) = channel();
-    let params = ProfQDumpParams{
-        path, ack:tx,
+    let params = ProfQDumpParams {
+        path,
+        ack: tx,
         // FIXME: Add another compiler flag to toggle whether this log
         // is written; false for now
-        dump_profq_msg_log:true,
+        dump_profq_msg_log: true,
     };
     profq_msg(sess, ProfileQueriesMsg::Dump(params));
     let _ = rx.recv().unwrap();
@@ -63,20 +64,20 @@ struct StackFrame {
 }
 
 fn total_duration(traces: &[trace::Rec]) -> Duration {
-    let mut sum : Duration = Duration::new(0,0);
+    let mut sum : Duration = Duration::new(0, 0);
     for t in traces.iter() { sum += t.dur_total; }
     return sum
 }
 
 // profiling thread; retains state (in local variables) and dump traces, upon request.
-fn profile_queries_thread(r:Receiver<ProfileQueriesMsg>) {
+fn profile_queries_thread(r: Receiver<ProfileQueriesMsg>) {
     use self::trace::*;
     use std::fs::File;
     use std::time::{Instant};
 
-    let mut profq_msgs : Vec<ProfileQueriesMsg> = vec![];
-    let mut frame : StackFrame = StackFrame{ parse_st:ParseState::Clear, traces:vec![] };
-    let mut stack : Vec<StackFrame> = vec![];
+    let mut profq_msgs: Vec<ProfileQueriesMsg> = vec![];
+    let mut frame: StackFrame = StackFrame { parse_st: ParseState::Clear, traces: vec![] };
+    let mut stack: Vec<StackFrame> = vec![];
     loop {
         let msg = r.recv();
         if let Err(_recv_err) = msg {
@@ -138,7 +139,7 @@ fn profile_queries_thread(r:Receiver<ProfileQueriesMsg>) {
 
                     // Parse State: Clear
                     (ParseState::Clear,
-                     ProfileQueriesMsg::QueryBegin(span,querymsg)) => {
+                     ProfileQueriesMsg::QueryBegin(span, querymsg)) => {
                         let start = Instant::now();
                         frame.parse_st = ParseState::HaveQuery
                             (Query { span, msg: querymsg }, start)
@@ -284,8 +285,6 @@ fn profile_queries_thread(r:Receiver<ProfileQueriesMsg>) {
                         frame = StackFrame{parse_st:ParseState::Clear, traces:vec![]};
                     },
 
-                    //
-                    //
                     // Parse errors:
 
                     (ParseState::HaveQuery(q,_),
@@ -307,7 +306,6 @@ fn profile_queries_thread(r:Receiver<ProfileQueriesMsg>) {
                         unreachable!()
                     },
                 }
-
             }
         }
     }

--- a/src/librustc_driver/profile/trace.rs
+++ b/src/librustc_driver/profile/trace.rs
@@ -108,11 +108,7 @@ fn html_of_fraction(frac: f64) -> (String, &'static str) {
 }
 
 fn total_duration(traces: &[Rec]) -> Duration {
-    let mut sum : Duration = Duration::new(0,0);
-    for t in traces.iter() {
-        sum += t.dur_total;
-    }
-    return sum
+    Duration::new(0, 0) + traces.iter().map(|t| t.dur_total).sum()
 }
 
 fn duration_div(nom: Duration, den: Duration) -> f64 {

--- a/src/librustc_driver/profile/trace.rs
+++ b/src/librustc_driver/profile/trace.rs
@@ -89,18 +89,18 @@ fn html_of_duration(_start: &Instant, dur: &Duration) -> (String, String) {
     )
 }
 
-fn html_of_fraction(frac: f64) -> (String, String) {
+fn html_of_fraction(frac: f64) -> (String, &'static str) {
     let css = {
-        if       frac > 0.50  { "frac-50".to_string() }
-        else if  frac > 0.40  { "frac-40".to_string() }
-        else if  frac > 0.30  { "frac-30".to_string() }
-        else if  frac > 0.20  { "frac-20".to_string() }
-        else if  frac > 0.10  { "frac-10".to_string() }
-        else if  frac > 0.05  { "frac-05".to_string() }
-        else if  frac > 0.02  { "frac-02".to_string() }
-        else if  frac > 0.01  { "frac-01".to_string() }
-        else if  frac > 0.001 { "frac-001".to_string() }
-        else                  { "frac-0".to_string() }
+        if       frac > 0.50  { "frac-50" }
+        else if  frac > 0.40  { "frac-40" }
+        else if  frac > 0.30  { "frac-30" }
+        else if  frac > 0.20  { "frac-20" }
+        else if  frac > 0.10  { "frac-10" }
+        else if  frac > 0.05  { "frac-05" }
+        else if  frac > 0.02  { "frac-02" }
+        else if  frac > 0.01  { "frac-01" }
+        else if  frac > 0.001 { "frac-001" }
+        else                  { "frac-0" }
     };
     let percent = frac * 100.0;
     if percent > 0.1 { (format!("{:.1}%", percent), css) }
@@ -148,6 +148,7 @@ fn write_traces_rec(file: &mut File, traces: &[Rec], total: Duration, depth: usi
 }
 
 fn compute_counts_rec(counts: &mut FxHashMap<String,QueryMetric>, traces: &[Rec]) {
+    counts.reserve(traces.len());
     for t in traces.iter() {
         match t.effect {
             Effect::TimeBegin(ref msg) => {

--- a/src/librustc_driver/profile/trace.rs
+++ b/src/librustc_driver/profile/trace.rs
@@ -43,18 +43,18 @@ pub struct QueryMetric {
     pub dur_total: Duration,
 }
 
+fn cons(s: &str) -> String {
+    let first = s.split(|d| d == '(' || d == '{').next();
+    assert!(first.is_some() && first != Some(""));
+    first.unwrap().to_owned()
+}
+
 pub fn cons_of_query_msg(q: &trace::Query) -> String {
-    let s = format!("{:?}", q.msg);
-    let cons: Vec<&str> = s.split(|d| d == '(' || d == '{').collect();
-    assert!(cons.len() > 0 && cons[0] != "");
-    cons[0].to_string()
+    cons(&format!("{:?}", q.msg))
 }
 
 pub fn cons_of_key(k: &DepNode) -> String {
-    let s = format!("{:?}", k);
-    let cons: Vec<&str> = s.split(|d| d == '(' || d == '{').collect();
-    assert!(cons.len() > 0 && cons[0] != "");
-    cons[0].to_string()
+    cons(&format!("{:?}", k))
 }
 
 // First return value is text; second return value is a CSS class

--- a/src/librustc_driver/profile/trace.rs
+++ b/src/librustc_driver/profile/trace.rs
@@ -130,22 +130,20 @@ fn write_traces_rec(file: &mut File, traces: &[Rec], total: Duration, depth: usi
         let fraction = duration_div(t.dur_total, total);
         let percent = fraction * 100.0;
         let (frc_text, frc_css_classes) = html_of_fraction(fraction);
-        write!(file, "<div class=\"trace depth-{} extent-{}{} {} {} {}\">\n",
-               depth,
-               t.extent.len(),
-               /* Heuristic for 'important' CSS class: */
-               if t.extent.len() > 5 || percent >= 1.0 {
-                   " important" }
-               else { "" },
-               eff_css_classes,
-               dur_css_classes,
-               frc_css_classes,
+        writeln!(file, "<div class=\"trace depth-{} extent-{}{} {} {} {}\">",
+                 depth,
+                 t.extent.len(),
+                 /* Heuristic for 'important' CSS class: */
+                 if t.extent.len() > 5 || percent >= 1.0 { " important" } else { "" },
+                 eff_css_classes,
+                 dur_css_classes,
+                 frc_css_classes,
         ).unwrap();
-        write!(file, "<div class=\"eff\">{}</div>\n", eff_text).unwrap();
-        write!(file, "<div class=\"dur\">{}</div>\n", dur_text).unwrap();
-        write!(file, "<div class=\"frc\">{}</div>\n", frc_text).unwrap();
+        writeln!(file, "<div class=\"eff\">{}</div>", eff_text).unwrap();
+        writeln!(file, "<div class=\"dur\">{}</div>", dur_text).unwrap();
+        writeln!(file, "<div class=\"frc\">{}</div>", frc_text).unwrap();
         write_traces_rec(file, &t.extent, total, depth + 1);
-        write!(file, "</div>\n").unwrap();
+        writeln!(file, "</div>").unwrap();
     }
 }
 
@@ -209,10 +207,10 @@ pub fn write_counts(count_file: &mut File, counts: &mut FxHashMap<String,QueryMe
     ).collect::<Vec<_>>();
     data.sort_by_key(|k| Reverse(k.3));
     for (cons, count, dur_total, dur_self) in data {
-        write!(count_file, "{}, {}, {}, {}\n",
-               cons, count,
-               duration_to_secs_str(dur_total),
-               duration_to_secs_str(dur_self)
+        writeln!(count_file, "{}, {}, {}, {}",
+                 cons, count,
+                 duration_to_secs_str(dur_total),
+                 duration_to_secs_str(dur_self)
         ).unwrap();
     }
 }


### PR DESCRIPTION
- improve/remove allocations
- simplify `profile::trace::cons*`
- don't sort `base` if it only has one element
- use `Cow<str>` where applicable
- use `unwrap_or_else` with function calls
- remove an explicit `return`, add an explicit `None`
- remove lifetimes from `const`s
- improve common patterns
- improve macro calls
- whitespace & formatting fixes