### PR TITLE
Prefer unwrap_or_else to unwrap_or in case of function calls/allocations

### DIFF
--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -430,7 +430,7 @@ impl Config {
             }
         }).unwrap_or_else(|| TomlConfig::default());
 
-        let build = toml.build.clone().unwrap_or(Build::default());
+        let build = toml.build.clone().unwrap_or_default();
         // set by bootstrap.py
         config.hosts.push(config.build.clone());
         for host in build.host.iter() {
@@ -524,7 +524,7 @@ impl Config {
             set(&mut config.llvm_link_shared, llvm.link_shared);
             config.llvm_targets = llvm.targets.clone();
             config.llvm_experimental_targets = llvm.experimental_targets.clone()
-                .unwrap_or("WebAssembly;RISCV".to_string());
+                .unwrap_or_else(|| "WebAssembly;RISCV".to_string());
             config.llvm_link_jobs = llvm.link_jobs;
             config.llvm_version_suffix = llvm.version_suffix.clone();
             config.llvm_clang_cl = llvm.clang_cl.clone();

--- a/src/build_helper/lib.rs
+++ b/src/build_helper/lib.rs
@@ -233,7 +233,8 @@ pub fn native_lib_boilerplate(
     let src_dir = current_dir.join("..").join(src_name);
     rerun_if_changed_anything_in_dir(&src_dir);
 
-    let out_dir = env::var_os("RUSTBUILD_NATIVE_DIR").unwrap_or(env::var_os("OUT_DIR").unwrap());
+    let out_dir = env::var_os("RUSTBUILD_NATIVE_DIR").unwrap_or_else(||
+        env::var_os("OUT_DIR").unwrap());
     let out_dir = PathBuf::from(out_dir).join(out_name);
     t!(fs::create_dir_all(&out_dir));
     if link_name.contains('=') {

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -1589,7 +1589,7 @@ impl<'a> LoweringContext<'a> {
 
         let resolution = self.resolver
             .get_resolution(id)
-            .unwrap_or(PathResolution::new(Def::Err));
+            .unwrap_or_else(|| PathResolution::new(Def::Err));
 
         let proj_start = p.segments.len() - resolution.unresolved_segments();
         let path = P(hir::Path {

--- a/src/librustc/lint/levels.rs
+++ b/src/librustc/lint/levels.rs
@@ -97,7 +97,7 @@ impl LintLevelSets {
 
         // If `level` is none then we actually assume the default level for this
         // lint.
-        let mut level = level.unwrap_or(lint.default_level(sess));
+        let mut level = level.unwrap_or_else(|| lint.default_level(sess));
 
         // If we're about to issue a warning, check at the last minute for any
         // directives against the warnings "lint". If, for example, there's an

--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -519,7 +519,7 @@ impl LintBuffer {
     }
 
     pub fn take(&mut self, id: ast::NodeId) -> Vec<BufferedEarlyLint> {
-        self.map.remove(&id).unwrap_or(Vec::new())
+        self.map.remove(&id).unwrap_or_default()
     }
 
     pub fn get_any(&self) -> Option<&[BufferedEarlyLint]> {

--- a/src/librustc/traits/auto_trait.rs
+++ b/src/librustc/traits/auto_trait.rs
@@ -498,8 +498,8 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
                     panic!("Missing lifetime with name {:?} for {:?}", name, region)
                 )
             )
-            .unwrap_or(&"'static".to_owned())
-            .clone()
+            .cloned()
+            .unwrap_or_else(|| "'static".to_owned())
     }
 
     // This is very similar to handle_lifetimes. However, instead of matching ty::Region's

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -352,7 +352,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
         obligation: &PredicateObligation<'tcx>,
     ) -> OnUnimplementedNote {
         let def_id = self.impl_similar_to(trait_ref, obligation)
-            .unwrap_or(trait_ref.def_id());
+            .unwrap_or_else(|| trait_ref.def_id());
         let trait_ref = *trait_ref.skip_binder();
 
         let mut flags = vec![];
@@ -639,7 +639,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                         let (post_message, pre_message) =
                             self.get_parent_trait_ref(&obligation.cause.code)
                                 .map(|t| (format!(" in `{}`", t), format!("within `{}`, ", t)))
-                            .unwrap_or((String::new(), String::new()));
+                            .unwrap_or_default();
 
                         let OnUnimplementedNote { message, label, note }
                             = self.on_unimplemented_note(trait_ref, obligation);

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -565,7 +565,7 @@ impl<'tcx> TypeckTables<'tcx> {
 
     pub fn node_substs(&self, id: hir::HirId) -> &'tcx Substs<'tcx> {
         validate_hir_id_for_typeck_tables(self.local_id_root, id, false);
-        self.node_substs.get(&id.local_id).cloned().unwrap_or(Substs::empty())
+        self.node_substs.get(&id.local_id).cloned().unwrap_or_else(|| Substs::empty())
     }
 
     pub fn node_substs_opt(&self, id: hir::HirId) -> Option<&'tcx Substs<'tcx>> {

--- a/src/librustc/ty/query/on_disk_cache.rs
+++ b/src/librustc/ty/query/on_disk_cache.rs
@@ -342,7 +342,7 @@ impl<'sess> OnDiskCache<'sess> {
             &self.prev_diagnostics_index,
             "diagnostics");
 
-        diagnostics.unwrap_or(Vec::new())
+        diagnostics.unwrap_or_default()
     }
 
     /// Store a diagnostic emitted during the current compilation session.

--- a/src/librustc_codegen_llvm/attributes.rs
+++ b/src/librustc_codegen_llvm/attributes.rs
@@ -154,7 +154,7 @@ pub fn from_fn_attrs(
     id: Option<DefId>,
 ) {
     let codegen_fn_attrs = id.map(|id| cx.tcx.codegen_fn_attrs(id))
-        .unwrap_or(CodegenFnAttrs::new());
+        .unwrap_or_else(|| CodegenFnAttrs::new());
 
     inline(cx, llfn, codegen_fn_attrs.inline);
 

--- a/src/librustc_codegen_llvm/back/rpath.rs
+++ b/src/librustc_codegen_llvm/back/rpath.rs
@@ -109,7 +109,7 @@ fn get_rpath_relative_to_output(config: &mut RPathConfig, lib: &Path) -> String 
     };
 
     let cwd = env::current_dir().unwrap();
-    let mut lib = fs::canonicalize(&cwd.join(lib)).unwrap_or(cwd.join(lib));
+    let mut lib = fs::canonicalize(&cwd.join(lib)).unwrap_or_else(|_| cwd.join(lib));
     lib.pop();
     let mut output = cwd.join(&config.out_filename);
     output.pop();

--- a/src/librustc_codegen_llvm/llvm/archive_ro.rs
+++ b/src/librustc_codegen_llvm/llvm/archive_ro.rs
@@ -40,7 +40,7 @@ impl ArchiveRO {
         return unsafe {
             let s = path2cstr(dst);
             let ar = super::LLVMRustOpenArchive(s.as_ptr()).ok_or_else(|| {
-                super::last_error().unwrap_or("failed to open archive".to_owned())
+                super::last_error().unwrap_or_else(|| "failed to open archive".to_owned())
             })?;
             Ok(ArchiveRO { raw: ar })
         };

--- a/src/librustc_codegen_llvm/llvm/diagnostic.rs
+++ b/src/librustc_codegen_llvm/llvm/diagnostic.rs
@@ -77,7 +77,7 @@ impl OptimizationDiagnostic<'ll> {
             ).ok()
         ).ok();
 
-        let mut filename = filename.unwrap_or(String::new());
+        let mut filename = filename.unwrap_or_default();
         if filename.is_empty() {
             filename.push_str("<unknown file>");
         }

--- a/src/librustc_codegen_utils/link.rs
+++ b/src/librustc_codegen_utils/link.rs
@@ -103,7 +103,7 @@ pub fn filename_for_metadata(sess: &Session,
     let libname = format!("{}{}", crate_name, sess.opts.cg.extra_filename);
 
     let out_filename = outputs.single_output_file.clone()
-        .unwrap_or(outputs.out_directory.join(&format!("lib{}.rmeta", libname)));
+        .unwrap_or_else(|| outputs.out_directory.join(&format!("lib{}.rmeta", libname)));
 
     check_file_is_writeable(&out_filename, sess);
 

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -882,7 +882,7 @@ where
         )
     });
 
-    let mut registry = registry.unwrap_or(Registry::new(sess, krate.span));
+    let mut registry = registry.unwrap_or_else(|| Registry::new(sess, krate.span));
 
     time(sess, "plugin registration", || {
         if sess.features_untracked().rustc_diagnostic_macros {

--- a/src/librustc_errors/diagnostic_builder.rs
+++ b/src/librustc_errors/diagnostic_builder.rs
@@ -128,7 +128,7 @@ impl<'a> DiagnosticBuilder<'a> {
         message: &str,
         span: Option<S>,
     ) -> &mut Self {
-        let span = span.map(|s| s.into()).unwrap_or(MultiSpan::new());
+        let span = span.map(|s| s.into()).unwrap_or_else(|| MultiSpan::new());
         self.diagnostic.sub(level, message, span, None);
         self
     }

--- a/src/librustc_metadata/locator.rs
+++ b/src/librustc_metadata/locator.rs
@@ -678,7 +678,7 @@ impl<'a> Context<'a> {
             if let Some((ref prev, _)) = ret {
                 let sysroot = self.sess.sysroot();
                 let sysroot = sysroot.canonicalize()
-                                     .unwrap_or(sysroot.to_path_buf());
+                                     .unwrap_or_else(|_| sysroot.to_path_buf());
                 if prev.starts_with(&sysroot) {
                     continue
                 }

--- a/src/librustc_mir/borrow_check/error_reporting.rs
+++ b/src/librustc_mir/borrow_check/error_reporting.rs
@@ -96,7 +96,7 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
                 span,
                 desired_action.as_noun(),
                 &self.describe_place_with_options(moved_place, IncludingDowncast(true))
-                    .unwrap_or("_".to_owned()),
+                    .unwrap_or_else(|| "_".to_owned()),
                 Origin::Mir,
             );
             err.span_label(span, format!("use of possibly uninitialized {}", item_msg));
@@ -260,7 +260,7 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
 
         let mut err = tcx.cannot_move_when_borrowed(
             span,
-            &self.describe_place(place).unwrap_or("_".to_owned()),
+            &self.describe_place(place).unwrap_or_else(|| "_".to_owned()),
             Origin::Mir,
         );
         err.span_label(borrow_span, format!("borrow of {} occurs here", borrow_msg));
@@ -299,16 +299,16 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
 
         let mut err = tcx.cannot_use_when_mutably_borrowed(
             span,
-            &self.describe_place(place).unwrap_or("_".to_owned()),
+            &self.describe_place(place).unwrap_or_else(|| "_".to_owned()),
             borrow_span,
             &self.describe_place(&borrow.borrowed_place)
-                .unwrap_or("_".to_owned()),
+                .unwrap_or_else(|| "_".to_owned()),
             Origin::Mir,
         );
 
         borrow_spans.var_span_label(&mut err, {
             let place = &borrow.borrowed_place;
-            let desc_place = self.describe_place(place).unwrap_or("_".to_owned());
+            let desc_place = self.describe_place(place).unwrap_or_else(|| "_".to_owned());
 
             format!("borrow occurs due to use of `{}`{}", desc_place, borrow_spans.describe())
         });
@@ -337,7 +337,7 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
             "closure"
         };
 
-        let desc_place = self.describe_place(place).unwrap_or("_".to_owned());
+        let desc_place = self.describe_place(place).unwrap_or_else(|| "_".to_owned());
         let tcx = self.infcx.tcx;
 
         let first_borrow_desc;
@@ -490,7 +490,8 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
             );
         } else {
             let borrow_place = &issued_borrow.borrowed_place;
-            let borrow_place_desc = self.describe_place(borrow_place).unwrap_or("_".to_owned());
+            let borrow_place_desc = self.describe_place(borrow_place)
+                                        .unwrap_or_else(|| "_".to_owned());
             issued_spans.var_span_label(
                 &mut err,
                 format!(
@@ -943,7 +944,7 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
             tcx.cannot_mutate_in_match_guard(
                 span,
                 loan_span,
-                &self.describe_place(place).unwrap_or("_".to_owned()),
+                &self.describe_place(place).unwrap_or_else(|| "_".to_owned()),
                 "assign",
                 Origin::Mir,
             )
@@ -951,7 +952,7 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
             tcx.cannot_assign_to_borrowed(
                 span,
                 loan_span,
-                &self.describe_place(place).unwrap_or("_".to_owned()),
+                &self.describe_place(place).unwrap_or_else(|| "_".to_owned()),
                 Origin::Mir,
             )
         };

--- a/src/librustc_mir/borrow_check/mutability_errors.rs
+++ b/src/librustc_mir/borrow_check/mutability_errors.rs
@@ -208,7 +208,7 @@ impl<'a, 'gcx, 'tcx> MirBorrowckCtxt<'a, 'gcx, 'tcx> {
                     format!(
                         "mutable borrow occurs due to use of `{}` in closure",
                         // always Some() if the message is printed.
-                        self.describe_place(access_place).unwrap_or(String::new()),
+                        self.describe_place(access_place).unwrap_or_default(),
                     )
                 );
                 borrow_span

--- a/src/librustc_mir/borrow_check/nll/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/mod.rs
@@ -184,7 +184,7 @@ pub(in borrow_check) fn compute_regions<'cx, 'gcx, 'tcx>(
 
         if infcx.tcx.sess.opts.debugging_opts.polonius {
             let algorithm = env::var("POLONIUS_ALGORITHM")
-                .unwrap_or(String::from("DatafrogOpt"));
+                .unwrap_or_else(|_| String::from("DatafrogOpt"));
             let algorithm = Algorithm::from_str(&algorithm).unwrap();
             debug!("compute_regions: using polonius algorithm {:?}", algorithm);
             Some(Rc::new(Output::compute(

--- a/src/librustc_mir/interpret/cast.rs
+++ b/src/librustc_mir/interpret/cast.rs
@@ -245,7 +245,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
         match dest_ty.sty {
             // float -> uint
             Uint(t) => {
-                let width = t.bit_width().unwrap_or(self.pointer_size().bits() as usize);
+                let width = t.bit_width().unwrap_or_else(|| self.pointer_size().bits() as usize);
                 let v = match fty {
                     FloatTy::F32 => Single::from_bits(bits).to_u128(width).value,
                     FloatTy::F64 => Double::from_bits(bits).to_u128(width).value,
@@ -255,7 +255,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
             },
             // float -> int
             Int(t) => {
-                let width = t.bit_width().unwrap_or(self.pointer_size().bits() as usize);
+                let width = t.bit_width().unwrap_or_else(|| self.pointer_size().bits() as usize);
                 let v = match fty {
                     FloatTy::F32 => Single::from_bits(bits).to_i128(width).value,
                     FloatTy::F64 => Double::from_bits(bits).to_i128(width).value,

--- a/src/librustc_mir/transform/elaborate_drops.rs
+++ b/src/librustc_mir/transform/elaborate_drops.rs
@@ -482,7 +482,7 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
             source_info: terminator.source_info
         };
 
-        let unwind = unwind.unwrap_or(self.patch.resume_block());
+        let unwind = unwind.unwrap_or_else(|| self.patch.resume_block());
         let unwind = self.patch.new_block(BasicBlockData {
             statements: vec![assign.clone()],
             terminator: Some(Terminator {

--- a/src/librustc_mir/util/borrowck_errors.rs
+++ b/src/librustc_mir/util/borrowck_errors.rs
@@ -476,7 +476,7 @@ pub trait BorrowckErrors<'cx>: Sized + Copy {
     ) -> DiagnosticBuilder<'cx> {
         let moved_path = moved_path
             .map(|mp| format!(": `{}`", mp))
-            .unwrap_or(String::new());
+            .unwrap_or_default();
 
         let err = struct_span_err!(
             self,

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -849,7 +849,7 @@ impl<'a, 'b:'a, 'c: 'b> ImportResolver<'a, 'b, 'c> {
     fn resolve_import(&mut self, directive: &'b ImportDirective<'b>) -> bool {
         debug!("(resolving import for module) resolving import `{}::...` in `{}`",
                names_to_string(&directive.module_path[..]),
-               module_to_string(self.current_module).unwrap_or("???".to_string()));
+               module_to_string(self.current_module).unwrap_or_else(|| "???".to_string()));
 
         self.current_module = directive.parent;
 

--- a/src/librustc_save_analysis/dump_visitor.rs
+++ b/src/librustc_save_analysis/dump_visitor.rs
@@ -163,7 +163,7 @@ impl<'l, 'tcx: 'l, 'll, O: DumpOutput + 'll> DumpVisitor<'l, 'tcx, 'll, O> {
                     .to_fingerprint()
                     .as_value(),
             },
-            crate_root: crate_root.unwrap_or("<no source>".to_owned()),
+            crate_root: crate_root.unwrap_or_else(|| "<no source>".to_owned()),
             external_crates: self.save_ctxt.get_external_crates(),
             span: self.span_from_span(krate.span),
         };
@@ -650,7 +650,7 @@ impl<'l, 'tcx: 'l, 'll, O: DumpOutput + 'll> DumpVisitor<'l, 'tcx, 'll, O> {
                         .iter()
                         .enumerate()
                         .map(|(i, f)| {
-                            f.ident.map(|i| i.to_string()).unwrap_or(i.to_string())
+                            f.ident.map(|i| i.to_string()).unwrap_or_else(|| i.to_string())
                         })
                         .collect::<Vec<_>>()
                         .join(", ");
@@ -1030,7 +1030,7 @@ impl<'l, 'tcx: 'l, 'll, O: DumpOutput + 'll> DumpVisitor<'l, 'tcx, 'll, O> {
                         .tables
                         .node_id_to_type_opt(hir_id)
                         .map(|t| t.to_string())
-                        .unwrap_or(String::new());
+                        .unwrap_or_default();
                     value.push_str(": ");
                     value.push_str(&typ);
 
@@ -1737,7 +1737,7 @@ impl<'l, 'tcx: 'l, 'll, O: DumpOutput + 'll> Visitor<'l> for DumpVisitor<'l, 'tc
         let value = l.init
             .as_ref()
             .map(|i| self.span.snippet(i.span))
-            .unwrap_or(String::new());
+            .unwrap_or_default();
         self.process_var_decl(&l.pat, value);
 
         // Just walk the initialiser and type (don't want to walk the pattern again).

--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -367,7 +367,7 @@ impl<'l, 'tcx: 'l> SaveContext<'l, 'tcx> {
                                 .as_ref()
                                 .and_then(|t| self.lookup_ref_id(t.ref_id))
                                 .map(id_from_def_id)
-                                .unwrap_or(null_id()),
+                                .unwrap_or_else(|| null_id()),
                         },
                         Impl {
                             id: impl_id,
@@ -632,7 +632,7 @@ impl<'l, 'tcx: 'l> SaveContext<'l, 'tcx> {
                     ref_id: def_id
                         .or(decl_id)
                         .map(|id| id_from_def_id(id))
-                        .unwrap_or(null_id()),
+                        .unwrap_or_else(|| null_id()),
                 }))
             }
             ast::ExprKind::Path(_, ref path) => {

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -174,7 +174,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                               .map(|arg| print::to_string(print::NO_ANN,
                                                                           |s| s.print_expr(arg)))
                                               .collect::<Vec<_>>()
-                                              .join(", ")).unwrap_or("...".to_owned())));
+                                              .join(", ")).unwrap_or_else(|| "...".to_owned())));
                     }
                 }
             }
@@ -249,7 +249,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                         match expr.node {
                             hir::ExprKind::Lit(ref lit) => { // numeric literal
                                 let snippet = tcx.sess.source_map().span_to_snippet(lit.span)
-                                    .unwrap_or("<numeric literal>".to_owned());
+                                    .unwrap_or_else(|_| "<numeric literal>".to_owned());
 
                                 err.span_suggestion_with_applicability(
                                                     lit.span,

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3115,7 +3115,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
             Ok(formal_args.iter().map(|ty| {
                 self.resolve_type_vars_if_possible(ty)
             }).collect())
-        }).unwrap_or(Vec::new());
+        }).unwrap_or_default();
         debug!("expected_inputs_for_expected_output(formal={:?} -> {:?}, expected={:?} -> {:?})",
                formal_args, formal_ret,
                expect_args, expected_ret);
@@ -4133,7 +4133,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                     // [1]
                     self.tcx.sess.delay_span_bug(body.span, "no coercion, but loop may not break");
                 }
-                ctxt.coerce.map(|c| c.complete(self)).unwrap_or(self.tcx.mk_unit())
+                ctxt.coerce.map(|c| c.complete(self)).unwrap_or_else(|| self.tcx.mk_unit())
             }
             hir::ExprKind::Match(ref discrim, ref arms, match_src) => {
                 self.check_match(expr, &discrim, arms, expected, match_src)

--- a/src/libstd/build.rs
+++ b/src/libstd/build.rs
@@ -97,8 +97,8 @@ fn build_libbacktrace(target: &str) -> Result<(), ()> {
         .file("../libbacktrace/sort.c")
         .file("../libbacktrace/state.c");
 
-    let any_debug = env::var("RUSTC_DEBUGINFO").unwrap_or(String::new()) == "true" ||
-        env::var("RUSTC_DEBUGINFO_LINES").unwrap_or(String::new()) == "true";
+    let any_debug = env::var("RUSTC_DEBUGINFO").unwrap_or_default() == "true" ||
+        env::var("RUSTC_DEBUGINFO_LINES").unwrap_or_default() == "true";
     build.debug(any_debug);
 
     if target.contains("darwin") {

--- a/src/libstd/sys/redox/args.rs
+++ b/src/libstd/sys/redox/args.rs
@@ -85,7 +85,7 @@ mod imp {
     }
 
     pub fn args() -> Args {
-        let bytes = clone().unwrap_or(Vec::new());
+        let bytes = clone().unwrap_or_default();
         let v: Vec<OsString> = bytes.into_iter().map(|v| {
             OsStringExt::from_vec(v)
         }).collect();

--- a/src/libstd/sys/unix/process/process_unix.rs
+++ b/src/libstd/sys/unix/process/process_unix.rs
@@ -331,7 +331,7 @@ impl Command {
             cvt(libc::posix_spawnattr_setflags(&mut attrs.0, flags as _))?;
 
             let envp = envp.map(|c| c.as_ptr())
-                .unwrap_or(*sys::os::environ() as *const _);
+                .unwrap_or_else(|| *sys::os::environ() as *const _);
             let ret = libc::posix_spawnp(
                 &mut p.pid,
                 self.get_argv()[0],

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3228,7 +3228,7 @@ impl<'a> Parser<'a> {
                         }));
 
                         let expr_str = self.sess.source_map().span_to_snippet(expr.span)
-                                                .unwrap_or(pprust::expr_to_string(&expr));
+                                                .unwrap_or_else(|_| pprust::expr_to_string(&expr));
                         err.span_suggestion_with_applicability(
                             expr.span,
                             &format!("try {} the cast value", op_verb),

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -3119,7 +3119,7 @@ impl<'a> State<'a> {
             if cmnt.style != comments::Trailing { return Ok(()) }
             let span_line = cm.lookup_char_pos(span.hi());
             let comment_line = cm.lookup_char_pos(cmnt.pos);
-            let next = next_pos.unwrap_or(cmnt.pos + BytePos(1));
+            let next = next_pos.unwrap_or_else(|| cmnt.pos + BytePos(1));
             if span.hi() < cmnt.pos && cmnt.pos < next && span_line.line == comment_line.line {
                 self.print_comment(cmnt)?;
             }

--- a/src/libsyntax/source_map.rs
+++ b/src/libsyntax/source_map.rs
@@ -942,7 +942,8 @@ impl SourceMap {
                 } else {
                     format!("{}<", &snippet[..offset])
                 };
-                new_snippet.push_str(&self.span_to_snippet(span).unwrap_or("T".to_string()));
+                new_snippet.push_str(
+                    &self.span_to_snippet(span).unwrap_or_else(|_| "T".to_string()));
                 new_snippet.push('>');
 
                 return Some((sugg_span, new_snippet));

--- a/src/libsyntax/tokenstream.rs
+++ b/src/libsyntax/tokenstream.rs
@@ -606,7 +606,7 @@ impl Cursor {
             CursorKind::JointTree(ref tree, _) => tree.clone().joint(),
             CursorKind::Stream(ref cursor) => TokenStream::concat_rc_vec({
                 cursor.stack.get(0).cloned().map(|(stream, _)| stream)
-                    .unwrap_or(cursor.stream.clone())
+                    .unwrap_or_else(|| cursor.stream.clone())
             }),
         }
     }


### PR DESCRIPTION
The contents of `unwrap_or` are evaluated eagerly, so it's not a good pick in case of function calls and allocations. This PR also changes a few `unwrap_or`s with `unwrap_or_default`.

An added bonus is that in some cases this change also reveals if the object it's called on is an `Option` or a `Result` (based on whether the closure takes an argument).