### PR TITLE
add test for #24421

### DIFF
--- a/src/test/ui/closure-expected-type/README.md
+++ b/src/test/ui/closure-expected-type/README.md
@@ -1,1 +1,0 @@
-See `src/test/run-pass/closure-expected-type`.

--- a/src/test/ui/closure-expected-type/issue-24421.rs
+++ b/src/test/ui/closure-expected-type/issue-24421.rs
@@ -1,0 +1,20 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-pass
+
+fn test<F: Fn(&u64, &u64)>(f: F) {}
+
+fn main() {
+    test(|x,      y     | {});
+    test(|x:&u64, y:&u64| {});
+    test(|x:&u64, y     | {});
+    test(|x,      y:&u64| {});
+}


### PR DESCRIPTION
Fixes #24421.

Also removes a README which points to a non-existent directory.