### PR TITLE
Exit with code 101 on fatal codegen errors

### DIFF
--- a/src/librustc_codegen_llvm/back/write.rs
+++ b/src/librustc_codegen_llvm/back/write.rs
@@ -2031,9 +2031,7 @@ fn start_executing_work(tcx: TyCtxt,
                     main_thread_worker_state = MainThreadWorkerState::Idle;
                 }
                 Message::Done { result: Err(()), worker_id: _ } => {
-                    shared_emitter.fatal("aborting due to worker thread failure");
-                    // Exit the coordinator thread
-                    return Err(())
+                    bug!("worker thread panicked");
                 }
                 Message::CodegenItem => {
                     bug!("the coordinator should not receive codegen requests")
@@ -2392,7 +2390,7 @@ impl OngoingCodegen {
                 panic!("expected abort due to worker thread errors")
             },
             Err(_) => {
-                sess.fatal("Error during codegen/LLVM phase.");
+                bug!("panic during codegen/LLVM phase");
             }
         };
 

--- a/src/librustc_codegen_llvm/llvm/ffi.rs
+++ b/src/librustc_codegen_llvm/llvm/ffi.rs
@@ -482,6 +482,8 @@ pub mod debuginfo {
 extern { pub type ModuleBuffer; }
 
 extern "C" {
+    pub fn LLVMRustInstallFatalErrorHandler();
+
     // Create and destroy contexts.
     pub fn LLVMRustContextCreate(shouldDiscardNames: bool) -> &'static mut Context;
     pub fn LLVMContextDispose(C: &'static mut Context);

--- a/src/librustc_codegen_llvm/llvm_util.rs
+++ b/src/librustc_codegen_llvm/llvm_util.rs
@@ -56,6 +56,8 @@ unsafe fn configure_llvm(sess: &Session) {
     let mut llvm_c_strs = Vec::with_capacity(n_args + 1);
     let mut llvm_args = Vec::with_capacity(n_args + 1);
 
+    llvm::LLVMRustInstallFatalErrorHandler();
+
     {
         let mut add = |arg: &str| {
             let s = CString::new(arg).unwrap();


### PR DESCRIPTION
Fixes #54992.

This PR installs a custom fatal error handler that prints the error from LLVM and exits with 101. There should be no visible change in the output from LLVM. This allows distinguishing a fatal LLVM error with a compilation error by exit code.

This PR also modifies the LLVM codegen backend to ICE instead of emitting a fatal error when encountering a LLVM worker thread panic for the same reason.

r? @cuviper 