### PR TITLE
Improve verify_llvm_ir config option

### DIFF
--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -287,10 +287,6 @@ fn main() {
         cmd.arg("--cfg").arg("parallel_queries");
     }
 
-    if env::var_os("RUSTC_VERIFY_LLVM_IR").is_some() {
-        cmd.arg("-Z").arg("verify-llvm-ir");
-    }
-
     if env::var_os("RUSTC_DENY_WARNINGS").is_some() && env::var_os("RUSTC_EXTERNAL_TOOL").is_none()
     {
         cmd.arg("-Dwarnings");

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1000,10 +1000,6 @@ impl<'a> Builder<'a> {
             cargo.env("RUSTC_BACKTRACE_ON_ICE", "1");
         }
 
-        if self.config.rust_verify_llvm_ir {
-            cargo.env("RUSTC_VERIFY_LLVM_IR", "1");
-        }
-
         cargo.env("RUSTC_VERBOSE", self.verbosity.to_string());
 
         // in std, we want to avoid denying warnings for stage 0 as that makes cfg's painful.

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -569,6 +569,9 @@ pub fn rustc_cargo_env(builder: &Builder, cargo: &mut Command) {
     if builder.config.rustc_parallel_queries {
         cargo.env("RUSTC_PARALLEL_QUERIES", "1");
     }
+    if builder.config.rust_verify_llvm_ir {
+        cargo.env("RUSTC_VERIFY_LLVM_IR", "1");
+    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -61,6 +61,7 @@ if [ "$DEPLOY$DEPLOY_ALT" != "" ]; then
     RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --disable-llvm-assertions"
   elif [ "$DEPLOY_ALT" != "" ]; then
     RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-llvm-assertions"
+    RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set rust.verify-llvm-ir"
   fi
 else
   # We almost always want debug assertions enabled, but sometimes this takes too
@@ -74,6 +75,8 @@ else
   if [ "$NO_LLVM_ASSERTIONS" = "" ]; then
     RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-llvm-assertions"
   fi
+
+  RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set rust.verify-llvm-ir"
 fi
 
 if [ "$RUST_RELEASE_CHANNEL" = "nightly" ] || [ "$DIST_REQUIRE_ALL_TOOLS" = "" ]; then

--- a/src/librustc/build.rs
+++ b/src/librustc/build.rs
@@ -8,8 +8,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::env;
+
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-env-changed=CFG_LIBDIR_RELATIVE");
     println!("cargo:rerun-if-env-changed=CFG_COMPILER_HOST_TRIPLE");
+    println!("cargo:rerun-if-env-changed=RUSTC_VERIFY_LLVM_IR");
+
+    if env::var_os("RUSTC_VERIFY_LLVM_IR").is_some() {
+        println!("cargo:rustc-cfg=always_verify_llvm_ir");
+    }
 }

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -531,6 +531,7 @@ impl Session {
     }
     pub fn verify_llvm_ir(&self) -> bool {
         self.opts.debugging_opts.verify_llvm_ir
+            || cfg!(always_verify_llvm_ir)
     }
     pub fn borrowck_stats(&self) -> bool {
         self.opts.debugging_opts.borrowck_stats


### PR DESCRIPTION
LLVM IR verification has been disabled by default in #51230. However, the implementation doesn't quite match what was discussed in the discussion. This patch implements two changes:

* Make `verify_llvm_ir` influence the behavior of the compiled rustc binary, rather than just the rustc build system. That is, if `verify_llvm_ir=true`, even manual invocations of the built rustc will verify LLVM IR.
* Enable verification of LLVM IR in CI, for non-deploy and deploy-alt builds. This is similar to how LLVM assertions are handled.