### PR TITLE
Don't collect to vectors where unnecessary

### DIFF
--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -60,7 +60,6 @@ use util::nodemap::{DefIdMap, NodeMap};
 
 use std::collections::BTreeMap;
 use std::fmt::Debug;
-use std::iter;
 use std::mem;
 use smallvec::SmallVec;
 use syntax::attr;
@@ -3888,9 +3887,7 @@ impl<'a> LoweringContext<'a> {
                     .collect::<P<[hir::Field]>>();
 
                 let is_unit = fields.is_empty();
-                let struct_path = iter::once("ops")
-                    .chain(iter::once(path))
-                    .collect::<Vec<_>>();
+                let struct_path = ["ops", path];
                 let struct_path = self.std_path(e.span, &struct_path, None, is_unit);
                 let struct_path = hir::QPath::Resolved(None, P(struct_path));
 

--- a/src/librustc_traits/lowering.rs
+++ b/src/librustc_traits/lowering.rs
@@ -306,8 +306,7 @@ fn program_clauses_for_trait<'a, 'tcx>(
     let wf_conditions = iter::once(ty::Binder::dummy(trait_pred.lower()))
         .chain(
             where_clauses
-                .iter()
-                .cloned()
+                .into_iter()
                 .map(|wc| wc.map_bound(|goal| goal.into_well_formed_goal()))
         );
 
@@ -350,15 +349,13 @@ fn program_clauses_for_impl<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId
     // `WC`
     let where_clauses = tcx.predicates_of(def_id).predicates
         .into_iter()
-        .map(|(wc, _)| wc.lower())
-        .collect::<Vec<_>>();
+        .map(|(wc, _)| wc.lower());
 
     // `Implemented(A0: Trait<A1..An>) :- WC`
     let clause = ProgramClause {
         goal: trait_pred,
         hypotheses: tcx.mk_goals(
             where_clauses
-                .into_iter()
                 .map(|wc| tcx.mk_goal(GoalKind::from_poly_domain_goal(wc, tcx))),
         ),
     };

--- a/src/librustc_typeck/check/demand.rs
+++ b/src/librustc_typeck/check/demand.rs
@@ -115,7 +115,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         // field is of the found type, suggest such variants. See Issue
         // #42764.
         if let ty::Adt(expected_adt, substs) = expected.sty {
-            let compatible_variants = expected_adt.variants
+            let mut compatible_variants = expected_adt.variants
                                                   .iter()
                                                   .filter(|variant| variant.fields.len() == 1)
                                                   .filter_map(|variant| {
@@ -127,12 +127,12 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 } else {
                     None
                 }
-            }).collect::<Vec<_>>();
+            }).peekable();
 
-            if !compatible_variants.is_empty() {
+            if compatible_variants.peek().is_some() {
                 let expr_text = print::to_string(print::NO_ANN, |s| s.print_expr(expr));
-                let suggestions = compatible_variants.iter()
-                    .map(|v| format!("{}({})", v, expr_text)).collect::<Vec<_>>();
+                let suggestions = compatible_variants.map(|v|
+                    format!("{}({})", v, expr_text)).collect::<Vec<_>>();
                 err.span_suggestions_with_applicability(
                      expr.span,
                      "try using a variant of the expected type",


### PR DESCRIPTION
This removes 3 vector allocations and a call to `cloned()`.