### PR TITLE
Use read_unaligned instead of read in transmute_copy

### DIFF
--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -818,7 +818,7 @@ pub fn drop<T>(_x: T) { }
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub unsafe fn transmute_copy<T, U>(src: &T) -> U {
-    ptr::read(src as *const T as *const U)
+    ptr::read_unaligned(src as *const T as *const U)
 }
 
 /// Opaque type representing the discriminant of an enum.


### PR DESCRIPTION
Closes: #55044

This change could result in performance regression on non-x86 platforms. (but it also can fix some of UB which lurks in existing programs) An alternative would be to update `transmute_copy` documentation with alignment requirements.