### PR TITLE
bump bootstrap compiler to rustc beta 2018-10-13

### DIFF
--- a/src/stage0.txt
+++ b/src/stage0.txt
@@ -12,7 +12,7 @@
 # source tarball for a stable release you'll likely see `1.x.0` for rustc and
 # `0.x.0` for Cargo where they were released on `date`.
 
-date: 2018-09-23
+date: 2018-10-13
 rustc: beta
 cargo: beta
 


### PR DESCRIPTION
beta was switched to bootstrap from stable 1.29.2 since 1.29.2 got the aliasing bug workaround.
For extra sanity we should probably bootstrap from a beta that was built with these fixed applied in the host compiler.