### PR TITLE
clarify pointer add/sub function safety concerns

### DIFF
--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -1255,7 +1255,7 @@ impl<T: ?Sized> *const T {
     /// Behavior:
     ///
     /// * Both the starting and resulting pointer must be either in bounds or one
-    ///   byte past the end of an allocated object.
+    ///   byte past the end of the same allocated object.
     ///
     /// * The computed offset, **in bytes**, cannot overflow an `isize`.
     ///
@@ -1312,7 +1312,7 @@ impl<T: ?Sized> *const T {
     /// Behavior:
     ///
     /// * Both the starting and resulting pointer must be either in bounds or one
-    ///   byte past the end of an allocated object.
+    ///   byte past the end of the same allocated object.
     ///
     /// * The computed offset cannot exceed `isize::MAX` **bytes**.
     ///
@@ -1893,7 +1893,7 @@ impl<T: ?Sized> *mut T {
     /// Behavior:
     ///
     /// * Both the starting and resulting pointer must be either in bounds or one
-    ///   byte past the end of an allocated object.
+    ///   byte past the end of the same allocated object.
     ///
     /// * The computed offset, **in bytes**, cannot overflow an `isize`.
     ///
@@ -1950,7 +1950,7 @@ impl<T: ?Sized> *mut T {
     /// Behavior:
     ///
     /// * Both the starting and resulting pointer must be either in bounds or one
-    ///   byte past the end of an allocated object.
+    ///   byte past the end of the same allocated object.
     ///
     /// * The computed offset cannot exceed `isize::MAX` **bytes**.
     ///

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -1037,7 +1037,7 @@ impl<T: ?Sized> *const T {
     /// Behavior:
     ///
     /// * Both the starting and resulting pointer must be either in bounds or one
-    ///   byte past the end of *the same* allocated object.
+    ///   byte past the end of the same allocated object.
     ///
     /// * The computed offset, **in bytes**, cannot overflow an `isize`.
     ///
@@ -1657,7 +1657,7 @@ impl<T: ?Sized> *mut T {
     /// Behavior:
     ///
     /// * Both the starting and resulting pointer must be either in bounds or one
-    ///   byte past the end of *the same* allocated object.
+    ///   byte past the end of the same allocated object.
     ///
     /// * The computed offset, **in bytes**, cannot overflow an `isize`.
     ///


### PR DESCRIPTION
Ralf Jung made the same changes to the offset functions' documentation
in commit fb089156. As add/sub just call offset, the same limitation
applies here, as well.

I did not copy the whole explanation ("In particular, the resulting pointer may *not* be used to access a different allocated object [...]") because I'd consider that as being too repetitive. The documentation of add/sub already refers to the offset function, so people interested in the details can look it up, there.
But changing 'an object' to 'the same object' is a small change which improves clarity a lot.