### PR TITLE
Fix incorrect link in println! documentation

### DIFF
--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -139,7 +139,7 @@ macro_rules! print {
 ///
 /// [`format!`]: ../std/macro.format.html
 /// [`std::fmt`]: ../std/fmt/index.html
-/// [`eprintln!`]: ../std/macro.eprint.html
+/// [`eprintln!`]: ../std/macro.eprintln.html
 /// # Panics
 ///
 /// Panics if writing to `io::stdout` fails.


### PR DESCRIPTION
The eprintln! link was incorrectly linking to eprint! instead