### PR TITLE
A few iterator-related improvements

### DIFF
--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -71,6 +71,7 @@
 #![feature(in_band_lifetimes)]
 #![feature(macro_at_most_once_rep)]
 #![feature(crate_visibility_modifier)]
+#![feature(transpose_result)]
 
 #![recursion_limit="512"]
 

--- a/src/librustc/ty/util.rs
+++ b/src/librustc/ty/util.rs
@@ -681,7 +681,7 @@ impl<'a, 'tcx> ty::TyS<'tcx> {
                 match (r1, r2) {
                     (Representability::SelfRecursive(v1),
                      Representability::SelfRecursive(v2)) => {
-                        Representability::SelfRecursive(v1.iter().map(|s| *s).chain(v2).collect())
+                        Representability::SelfRecursive(v1.into_iter().chain(v2).collect())
                     }
                     (r1, r2) => cmp::max(r1, r2)
                 }

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1592,8 +1592,8 @@ impl<'o, 'gcx: 'tcx, 'tcx> dyn AstConv<'gcx, 'tcx>+'o {
         debug!("ty_of_fn");
 
         let tcx = self.tcx();
-        let input_tys: Vec<Ty> =
-            decl.inputs.iter().map(|a| self.ty_of_arg(a, None)).collect();
+        let input_tys =
+            decl.inputs.iter().map(|a| self.ty_of_arg(a, None));
 
         let output_ty = match decl.output {
             hir::Return(ref output) => self.ast_ty_to_ty(output),
@@ -1603,7 +1603,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> dyn AstConv<'gcx, 'tcx>+'o {
         debug!("ty_of_fn: output_ty={:?}", output_ty);
 
         let bare_fn_ty = ty::Binder::bind(tcx.mk_fn_sig(
-            input_tys.into_iter(),
+            input_tys,
             output_ty,
             decl.variadic,
             unsafety,

--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -626,7 +626,7 @@ https://doc.rust-lang.org/reference/types.html#trait-objects");
 
         // Typecheck the patterns first, so that we get types for all the
         // bindings.
-        let all_arm_pats_diverge: Vec<_> = arms.iter().map(|arm| {
+        let all_arm_pats_diverge = arms.iter().map(|arm| {
             let mut all_pats_diverge = Diverges::WarnedAlways;
             for p in &arm.pats {
                 self.diverges.set(Diverges::Maybe);
@@ -642,7 +642,7 @@ https://doc.rust-lang.org/reference/types.html#trait-objects");
                 Diverges::Maybe => Diverges::Maybe,
                 Diverges::Always | Diverges::WarnedAlways => Diverges::WarnedAlways,
             }
-        }).collect();
+        });
 
         // Now typecheck the blocks.
         //


### PR DESCRIPTION
- typeck: don't collect into a vector when unnecessary
- create only one vector when winnowing candidates
- change a cloning map to `into_iter`