### PR TITLE
[NLL] Use new region infer errors when explaining borrows

### DIFF
--- a/src/librustc/ich/impls_mir.rs
+++ b/src/librustc/ich/impls_mir.rs
@@ -557,6 +557,8 @@ impl_stable_hash_for!(struct mir::ClosureOutlivesRequirement<'tcx> {
 
 impl_stable_hash_for!(enum mir::ConstraintCategory {
     Return,
+    UseAsConst,
+    UseAsStatic,
     TypeAnnotation,
     Cast,
     ClosureBounds,

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -2725,6 +2725,8 @@ pub struct ClosureOutlivesRequirement<'tcx> {
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Hash, RustcEncodable, RustcDecodable)]
 pub enum ConstraintCategory {
     Return,
+    UseAsConst,
+    UseAsStatic,
     TypeAnnotation,
     Cast,
 

--- a/src/librustc_mir/borrow_check/nll/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/mod.rs
@@ -371,3 +371,7 @@ impl ToRegionVid for RegionVid {
         self
     }
 }
+
+crate trait ConstraintDescription {
+    fn description(&self) -> &'static str;
+}

--- a/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/mod.rs
@@ -138,6 +138,8 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                 | ConstraintCategory::Boring
                 | ConstraintCategory::BoringNoLocation
                 | ConstraintCategory::Internal => false,
+                ConstraintCategory::TypeAnnotation
+                | ConstraintCategory::Return => true,
                 _ => constraint_sup_scc != target_scc,
             }
         });

--- a/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/mod.rs
@@ -13,6 +13,7 @@ use borrow_check::nll::region_infer::RegionInferenceContext;
 use borrow_check::nll::region_infer::error_reporting::region_name::RegionNameSource;
 use borrow_check::nll::type_check::Locations;
 use borrow_check::nll::universal_regions::DefiningTy;
+use util::borrowck_errors::{BorrowckErrors, Origin};
 use rustc::hir::def_id::DefId;
 use rustc::infer::error_reporting::nice_region_error::NiceRegionError;
 use rustc::infer::InferCtxt;
@@ -395,9 +396,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                                              category, span, errors_buffer);
         }
 
-        let mut diag = infcx.tcx.sess.struct_span_err(
-            span, &format!("borrowed data escapes outside of {}", escapes_from),
-        );
+        let mut diag = infcx.tcx.borrowed_data_escapes_closure(span, escapes_from, Origin::Mir);
 
         if let Some((Some(outlived_fr_name), outlived_fr_span)) = outlived_fr_name_and_span {
             diag.span_label(

--- a/src/librustc_mir/diagnostics.rs
+++ b/src/librustc_mir/diagnostics.rs
@@ -2011,6 +2011,46 @@ match 5u32 {
 ```
 "##,
 
+E0515: r##"
+Cannot return value that references local variable
+
+Local variables, function parameters and temporaries are all dropped before the
+end of the function body. So a reference to them cannot be returned.
+
+```compile_fail,E0515
+#![feature(nll)]
+fn get_dangling_reference() -> &'static i32 {
+    let x = 0;
+    &x
+}
+```
+
+```compile_fail,E0515
+#![feature(nll)]
+use std::slice::Iter;
+fn get_dangling_iterator<'a>() -> Iter<'a, i32> {
+    let v = vec![1, 2, 3];
+    v.iter()
+}
+```
+
+Consider returning an owned value instead:
+
+```
+use std::vec::IntoIter;
+
+fn get_integer() -> i32 {
+    let x = 0;
+    x
+}
+
+fn get_owned_iterator() -> IntoIter<i32> {
+    let v = vec![1, 2, 3];
+    v.into_iter()
+}
+```
+"##,
+
 E0595: r##"
 Closures cannot mutate immutable captured variables.
 

--- a/src/librustc_mir/diagnostics.rs
+++ b/src/librustc_mir/diagnostics.rs
@@ -2339,6 +2339,7 @@ register_diagnostics! {
 //  E0471, // constant evaluation error (in pattern)
 //    E0385, // {} in an aliasable location
     E0493, // destructors cannot be evaluated at compile-time
+    E0521,  // borrowed data escapes outside of closure
     E0524, // two closures require unique access to `..` at the same time
     E0526, // shuffle indices are not constant
     E0594, // cannot assign to {}

--- a/src/librustc_mir/util/borrowck_errors.rs
+++ b/src/librustc_mir/util/borrowck_errors.rs
@@ -717,6 +717,24 @@ pub trait BorrowckErrors<'cx>: Sized + Copy {
         self.cancel_if_wrong_origin(err, o)
     }
 
+    fn borrowed_data_escapes_closure(
+        self,
+        escape_span: Span,
+        escapes_from: &str,
+        o: Origin,
+    ) -> DiagnosticBuilder<'cx> {
+        let err = struct_span_err!(
+            self,
+            escape_span,
+            E0521,
+            "borrowed data escapes outside of {}{OGN}",
+            escapes_from,
+            OGN = o
+        );
+
+        self.cancel_if_wrong_origin(err, o)
+    }
+
     fn thread_local_value_does_not_live_long_enough(
         self,
         span: Span,

--- a/src/librustc_mir/util/borrowck_errors.rs
+++ b/src/librustc_mir/util/borrowck_errors.rs
@@ -632,6 +632,31 @@ pub trait BorrowckErrors<'cx>: Sized + Copy {
         self.cancel_if_wrong_origin(err, o)
     }
 
+    fn cannot_return_reference_to_local(
+        self,
+        span: Span,
+        reference_desc: &str,
+        path_desc: &str,
+        o: Origin,
+    ) -> DiagnosticBuilder<'cx> {
+        let mut err = struct_span_err!(
+            self,
+            span,
+            E0515,
+            "cannot return {REFERENCE} {LOCAL}{OGN}",
+            REFERENCE=reference_desc,
+            LOCAL=path_desc,
+            OGN = o
+        );
+
+        err.span_label(
+            span,
+            format!("returns a {} data owned by the current function", reference_desc),
+        );
+
+        self.cancel_if_wrong_origin(err, o)
+    }
+
     fn lifetime_too_short_for_reborrow(
         self,
         span: Span,

--- a/src/test/ui/borrowck/borrowck-borrow-from-temporary.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-borrow-from-temporary.nll.stderr
@@ -1,18 +1,11 @@
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/borrowck-borrow-from-temporary.rs:19:24
+error[E0515]: cannot return value referencing temporary value
+  --> $DIR/borrowck-borrow-from-temporary.rs:20:5
    |
 LL |     let &Foo(ref x) = &id(Foo(3)); //~ ERROR borrowed value does not live long enough
-   |                        ^^^^^^^^^^ creates a temporary which is freed while still in use
+   |                        ---------- temporary value created here
 LL |     x
-LL | }
-   | - temporary value is freed at the end of this statement
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 18:8...
-  --> $DIR/borrowck-borrow-from-temporary.rs:18:8
-   |
-LL | fn foo<'a>() -> &'a isize {
-   |        ^^
+   |     ^ returns a value referencing data owned by the current function
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0716`.
+For more information about this error, try `rustc --explain E0515`.

--- a/src/test/ui/borrowck/borrowck-escaping-closure-error-1.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-escaping-closure-error-1.nll.stderr
@@ -1,16 +1,21 @@
-error[E0597]: `books` does not live long enough
-  --> $DIR/borrowck-escaping-closure-error-1.rs:23:14
+error[E0373]: closure may outlive the current function, but it borrows `books`, which is owned by the current function
+  --> $DIR/borrowck-escaping-closure-error-1.rs:23:11
    |
 LL |     spawn(|| books.push(4));
-   |           -- ^^^^^ borrowed value does not live long enough
+   |           ^^ ----- `books` is borrowed here
    |           |
-   |           value captured here
-LL |     //~^ ERROR E0373
-LL | }
-   | - `books` dropped here while still borrowed
+   |           may outlive borrowed value `books`
    |
-   = note: borrowed value must be valid for the static lifetime...
+note: function requires argument type to outlive `'static`
+  --> $DIR/borrowck-escaping-closure-error-1.rs:23:5
+   |
+LL |     spawn(|| books.push(4));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
+help: to force the closure to take ownership of `books` (and any other referenced variables), use the `move` keyword
+   |
+LL |     spawn(move || books.push(4));
+   |           ^^^^^^^
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0597`.
+For more information about this error, try `rustc --explain E0373`.

--- a/src/test/ui/borrowck/borrowck-escaping-closure-error-2.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-escaping-closure-error-2.nll.stderr
@@ -1,20 +1,21 @@
-error[E0597]: `books` does not live long enough
-  --> $DIR/borrowck-escaping-closure-error-2.rs:21:17
+error[E0373]: closure may outlive the current function, but it borrows `books`, which is owned by the current function
+  --> $DIR/borrowck-escaping-closure-error-2.rs:21:14
    |
 LL |     Box::new(|| books.push(4))
-   |              -- ^^^^^ borrowed value does not live long enough
+   |              ^^ ----- `books` is borrowed here
    |              |
-   |              value captured here
-LL |     //~^ ERROR E0373
-LL | }
-   | - `books` dropped here while still borrowed
+   |              may outlive borrowed value `books`
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 19:8...
-  --> $DIR/borrowck-escaping-closure-error-2.rs:19:8
+note: closure is returned here
+  --> $DIR/borrowck-escaping-closure-error-2.rs:21:5
    |
-LL | fn foo<'a>(x: &'a i32) -> Box<FnMut()+'a> {
-   |        ^^
+LL |     Box::new(|| books.push(4))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: to force the closure to take ownership of `books` (and any other referenced variables), use the `move` keyword
+   |
+LL |     Box::new(move || books.push(4))
+   |              ^^^^^^^
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0597`.
+For more information about this error, try `rustc --explain E0373`.

--- a/src/test/ui/borrowck/borrowck-fn-in-const-c.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-fn-in-const-c.nll.stderr
@@ -2,11 +2,9 @@ error[E0713]: borrow may still be in use when destructor runs
   --> $DIR/borrowck-fn-in-const-c.rs:27:16
    |
 LL |         return &local.inner; //~ ERROR does not live long enough
-   |                ^^^^^^^^^^^^
+   |                ^^^^^^^^^^^^ returning this value requires that `local.inner` is borrowed for `'static`
 LL |     }
    |     - here, drop of `local` needs exclusive access to `local.inner`, because the type `DropString` implements the `Drop` trait
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-loan-of-static-data-issue-27616.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-loan-of-static-data-issue-27616.nll.stderr
@@ -2,12 +2,12 @@ error[E0506]: cannot assign to `*s` because it is borrowed
   --> $DIR/borrowck-loan-of-static-data-issue-27616.rs:26:5
    |
 LL |     let alias: &'static mut String = s;
-   |                                      - borrow of `*s` occurs here
+   |                -------------------   - borrow of `*s` occurs here
+   |                |
+   |                type annotation requires that `*s` is borrowed for `'static`
 ...
 LL |     *s = String::new(); //~ ERROR cannot assign
    |     ^^ assignment to borrowed `*s` occurs here
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-local-borrow-outlives-fn.ast.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-local-borrow-outlives-fn.ast.nll.stderr
@@ -1,14 +1,9 @@
-error[E0597]: `x` does not live long enough
+error[E0515]: cannot return reference to function parameter `x`
   --> $DIR/borrowck-local-borrow-outlives-fn.rs:15:5
    |
 LL |     &x
-   |     ^^ borrowed value does not live long enough
-...
-LL | }
-   |  - `x` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
+   |     ^^ returns a reference to data owned by the current function
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0597`.
+For more information about this error, try `rustc --explain E0515`.

--- a/src/test/ui/borrowck/borrowck-local-borrow-outlives-fn.mir.stderr
+++ b/src/test/ui/borrowck/borrowck-local-borrow-outlives-fn.mir.stderr
@@ -1,14 +1,9 @@
-error[E0597]: `x` does not live long enough
+error[E0515]: cannot return reference to function parameter `x`
   --> $DIR/borrowck-local-borrow-outlives-fn.rs:15:5
    |
 LL |     &x
-   |     ^^ borrowed value does not live long enough
-...
-LL | }
-   |  - `x` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
+   |     ^^ returns a reference to data owned by the current function
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0597`.
+For more information about this error, try `rustc --explain E0515`.

--- a/src/test/ui/borrowck/borrowck-local-borrow-outlives-fn.rs
+++ b/src/test/ui/borrowck/borrowck-local-borrow-outlives-fn.rs
@@ -14,7 +14,7 @@
 fn cplusplus_mode(x: isize) -> &'static isize {
     &x
     //[ast]~^ ERROR `x` does not live long enough [E0597]
-    //[mir]~^^ ERROR `x` does not live long enough [E0597]
+    //[mir]~^^ ERROR cannot return reference to function parameter `x` [E0515]
 }
 
 fn main() {}

--- a/src/test/ui/borrowck/borrowck-local-borrow-with-panic-outlives-fn.ast.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-local-borrow-with-panic-outlives-fn.ast.nll.stderr
@@ -2,12 +2,13 @@ error[E0597]: `z.1` does not live long enough
   --> $DIR/borrowck-local-borrow-with-panic-outlives-fn.rs:16:15
    |
 LL |     *x = Some(&mut z.1);
-   |               ^^^^^^^^ borrowed value does not live long enough
+   |     ----------^^^^^^^^-
+   |     |         |
+   |     |         borrowed value does not live long enough
+   |     assignment requires that `z.1` is borrowed for `'static`
 ...
 LL | }
    | - `z.1` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-local-borrow-with-panic-outlives-fn.mir.stderr
+++ b/src/test/ui/borrowck/borrowck-local-borrow-with-panic-outlives-fn.mir.stderr
@@ -2,12 +2,13 @@ error[E0597]: `z.1` does not live long enough
   --> $DIR/borrowck-local-borrow-with-panic-outlives-fn.rs:16:15
    |
 LL |     *x = Some(&mut z.1);
-   |               ^^^^^^^^ borrowed value does not live long enough
+   |     ----------^^^^^^^^-
+   |     |         |
+   |     |         borrowed value does not live long enough
+   |     assignment requires that `z.1` is borrowed for `'static`
 ...
 LL | }
    | - `z.1` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-return-variable-on-stack-via-clone.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-return-variable-on-stack-via-clone.nll.stderr
@@ -1,17 +1,12 @@
-error[E0597]: `x` does not live long enough
+error[E0515]: cannot return value referencing function parameter `x`
   --> $DIR/borrowck-return-variable-on-stack-via-clone.rs:17:5
    |
 LL |     (&x).clone() //~ ERROR `x` does not live long enough
-   |     ^^^^ borrowed value does not live long enough
-LL | }
-   | - `x` dropped here while still borrowed
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 16:9...
-  --> $DIR/borrowck-return-variable-on-stack-via-clone.rs:16:9
-   |
-LL | fn leak<'a, T>(x: T) -> &'a T {
-   |         ^^
+   |     ----^^^^^^^^
+   |     |
+   |     returns a value referencing data owned by the current function
+   |     `x` is borrowed here
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0597`.
+For more information about this error, try `rustc --explain E0515`.

--- a/src/test/ui/borrowck/borrowck-vec-pattern-element-loan.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-vec-pattern-element-loan.nll.stderr
@@ -1,48 +1,30 @@
-error[E0597]: `vec` does not live long enough
-  --> $DIR/borrowck-vec-pattern-element-loan.rs:15:25
+error[E0515]: cannot return value referencing local variable `vec`
+  --> $DIR/borrowck-vec-pattern-element-loan.rs:20:5
    |
 LL |     let vec: &[isize] = &vec; //~ ERROR does not live long enough
-   |                         ^^^^ borrowed value does not live long enough
+   |                         ---- `vec` is borrowed here
 ...
-LL | }
-   | - `vec` dropped here while still borrowed
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 13:6...
-  --> $DIR/borrowck-vec-pattern-element-loan.rs:13:6
-   |
-LL | fn a<'a>() -> &'a [isize] {
-   |      ^^
+LL |     tail
+   |     ^^^^ returns a value referencing data owned by the current function
 
-error[E0597]: `vec` does not live long enough
-  --> $DIR/borrowck-vec-pattern-element-loan.rs:25:25
+error[E0515]: cannot return value referencing local variable `vec`
+  --> $DIR/borrowck-vec-pattern-element-loan.rs:30:5
    |
 LL |     let vec: &[isize] = &vec; //~ ERROR does not live long enough
-   |                         ^^^^ borrowed value does not live long enough
+   |                         ---- `vec` is borrowed here
 ...
-LL | }
-   | - `vec` dropped here while still borrowed
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 23:6...
-  --> $DIR/borrowck-vec-pattern-element-loan.rs:23:6
-   |
-LL | fn b<'a>() -> &'a [isize] {
-   |      ^^
+LL |     init
+   |     ^^^^ returns a value referencing data owned by the current function
 
-error[E0597]: `vec` does not live long enough
-  --> $DIR/borrowck-vec-pattern-element-loan.rs:35:25
+error[E0515]: cannot return value referencing local variable `vec`
+  --> $DIR/borrowck-vec-pattern-element-loan.rs:40:5
    |
 LL |     let vec: &[isize] = &vec; //~ ERROR does not live long enough
-   |                         ^^^^ borrowed value does not live long enough
+   |                         ---- `vec` is borrowed here
 ...
-LL | }
-   | - `vec` dropped here while still borrowed
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 33:6...
-  --> $DIR/borrowck-vec-pattern-element-loan.rs:33:6
-   |
-LL | fn c<'a>() -> &'a [isize] {
-   |      ^^
+LL |     slice
+   |     ^^^^^ returns a value referencing data owned by the current function
 
 error: aborting due to 3 previous errors
 
-For more information about this error, try `rustc --explain E0597`.
+For more information about this error, try `rustc --explain E0515`.

--- a/src/test/ui/borrowck/borrowck-vec-pattern-tail-element-loan.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-vec-pattern-tail-element-loan.nll.stderr
@@ -1,18 +1,12 @@
-error[E0597]: `vec` does not live long enough
-  --> $DIR/borrowck-vec-pattern-tail-element-loan.rs:15:25
+error[E0515]: cannot return value referencing local variable `vec`
+  --> $DIR/borrowck-vec-pattern-tail-element-loan.rs:20:5
    |
 LL |     let vec: &[isize] = &vec; //~ ERROR `vec` does not live long enough
-   |                         ^^^^ borrowed value does not live long enough
+   |                         ---- `vec` is borrowed here
 ...
-LL | }
-   | - `vec` dropped here while still borrowed
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 13:6...
-  --> $DIR/borrowck-vec-pattern-tail-element-loan.rs:13:6
-   |
-LL | fn a<'a>() -> &'a isize {
-   |      ^^
+LL |     tail
+   |     ^^^^ returns a value referencing data owned by the current function
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0597`.
+For more information about this error, try `rustc --explain E0515`.

--- a/src/test/ui/borrowck/issue-45983.nll.stderr
+++ b/src/test/ui/borrowck/issue-45983.nll.stderr
@@ -1,4 +1,4 @@
-error: borrowed data escapes outside of closure
+error[E0521]: borrowed data escapes outside of closure
   --> $DIR/issue-45983.rs:36:18
    |
 LL |     let x = None;
@@ -18,4 +18,5 @@ LL |     give_any(|y| x = Some(y));
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0594`.
+Some errors occurred: E0521, E0594.
+For more information about an error, try `rustc --explain E0521`.

--- a/src/test/ui/borrowck/mut-borrow-in-loop.nll.stderr
+++ b/src/test/ui/borrowck/mut-borrow-in-loop.nll.stderr
@@ -1,38 +1,38 @@
 error[E0499]: cannot borrow `*arg` as mutable more than once at a time
   --> $DIR/mut-borrow-in-loop.rs:20:25
    |
-LL |             (self.func)(arg) //~ ERROR cannot borrow
-   |                         ^^^ mutable borrow starts here in previous iteration of loop
-   |
-note: first borrowed value must be valid for the lifetime 'a as defined on the impl at 17:6...
-  --> $DIR/mut-borrow-in-loop.rs:17:6
-   |
 LL | impl<'a, T : 'a> FuncWrapper<'a, T> {
-   |      ^^
+   |      -- lifetime `'a` defined here
+...
+LL |             (self.func)(arg) //~ ERROR cannot borrow
+   |             ------------^^^-
+   |             |           |
+   |             |           mutable borrow starts here in previous iteration of loop
+   |             argument requires that `*arg` is borrowed for `'a`
 
 error[E0499]: cannot borrow `*arg` as mutable more than once at a time
   --> $DIR/mut-borrow-in-loop.rs:26:25
    |
-LL |             (self.func)(arg) //~ ERROR cannot borrow
-   |                         ^^^ mutable borrow starts here in previous iteration of loop
-   |
-note: first borrowed value must be valid for the lifetime 'a as defined on the impl at 17:6...
-  --> $DIR/mut-borrow-in-loop.rs:17:6
-   |
 LL | impl<'a, T : 'a> FuncWrapper<'a, T> {
-   |      ^^
+   |      -- lifetime `'a` defined here
+...
+LL |             (self.func)(arg) //~ ERROR cannot borrow
+   |             ------------^^^-
+   |             |           |
+   |             |           mutable borrow starts here in previous iteration of loop
+   |             argument requires that `*arg` is borrowed for `'a`
 
 error[E0499]: cannot borrow `*arg` as mutable more than once at a time
   --> $DIR/mut-borrow-in-loop.rs:33:25
    |
-LL |             (self.func)(arg) //~ ERROR cannot borrow
-   |                         ^^^ mutable borrow starts here in previous iteration of loop
-   |
-note: first borrowed value must be valid for the lifetime 'a as defined on the impl at 17:6...
-  --> $DIR/mut-borrow-in-loop.rs:17:6
-   |
 LL | impl<'a, T : 'a> FuncWrapper<'a, T> {
-   |      ^^
+   |      -- lifetime `'a` defined here
+...
+LL |             (self.func)(arg) //~ ERROR cannot borrow
+   |             ------------^^^-
+   |             |           |
+   |             |           mutable borrow starts here in previous iteration of loop
+   |             argument requires that `*arg` is borrowed for `'a`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/borrowck/promote-ref-mut-in-let-issue-46557.nll.stderr
+++ b/src/test/ui/borrowck/promote-ref-mut-in-let-issue-46557.nll.stderr
@@ -1,57 +1,50 @@
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-ref-mut-in-let-issue-46557.rs:15:21
+error[E0515]: cannot return value referencing temporary value
+  --> $DIR/promote-ref-mut-in-let-issue-46557.rs:16:5
    |
 LL |     let ref mut x = 1234543; //~ ERROR
-   |                     ^^^^^^^ creates a temporary which is freed while still in use
+   |                     ------- temporary value created here
 LL |     x
-LL | }
-   | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
+   |     ^ returns a value referencing data owned by the current function
 
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-ref-mut-in-let-issue-46557.rs:20:25
+error[E0515]: cannot return value referencing temporary value
+  --> $DIR/promote-ref-mut-in-let-issue-46557.rs:21:5
    |
 LL |     let (ref mut x, ) = (1234543, ); //~ ERROR
-   |                         ^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |                         ----------- temporary value created here
 LL |     x
-LL | }
-   | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
+   |     ^ returns a value referencing data owned by the current function
 
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-ref-mut-in-let-issue-46557.rs:25:11
+error[E0515]: cannot return value referencing temporary value
+  --> $DIR/promote-ref-mut-in-let-issue-46557.rs:25:5
    |
-LL |     match 1234543 {
-   |           ^^^^^^^ creates a temporary which is freed while still in use
-...
-LL | }
-   | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
+LL |       match 1234543 {
+   |       ^     ------- temporary value created here
+   |  _____|
+   | |
+LL | |         ref mut x => x //~ ERROR
+LL | |     }
+   | |_____^ returns a value referencing data owned by the current function
 
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-ref-mut-in-let-issue-46557.rs:31:11
+error[E0515]: cannot return value referencing temporary value
+  --> $DIR/promote-ref-mut-in-let-issue-46557.rs:31:5
    |
-LL |     match (123443,) {
-   |           ^^^^^^^^^ creates a temporary which is freed while still in use
-...
-LL | }
-   | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
+LL |       match (123443,) {
+   |       ^     --------- temporary value created here
+   |  _____|
+   | |
+LL | |         (ref mut x,) => x, //~ ERROR
+LL | |     }
+   | |_____^ returns a value referencing data owned by the current function
 
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-ref-mut-in-let-issue-46557.rs:37:10
+error[E0515]: cannot return reference to temporary value
+  --> $DIR/promote-ref-mut-in-let-issue-46557.rs:37:5
    |
 LL |     &mut 1234543 //~ ERROR
-   |          ^^^^^^^ creates a temporary which is freed while still in use
-LL | }
-   | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
+   |     ^^^^^-------
+   |     |    |
+   |     |    temporary value created here
+   |     returns a reference to data owned by the current function
 
 error: aborting due to 5 previous errors
 
-For more information about this error, try `rustc --explain E0716`.
+For more information about this error, try `rustc --explain E0515`.

--- a/src/test/ui/borrowck/two-phase-surprise-no-conflict.nll.stderr
+++ b/src/test/ui/borrowck/two-phase-surprise-no-conflict.nll.stderr
@@ -68,17 +68,15 @@ LL |     reg.register_bound(Box::new(CapturePass::new(&reg.sess_mut)));
 error[E0502]: cannot borrow `*reg` as mutable because it is also borrowed as immutable
   --> $DIR/two-phase-surprise-no-conflict.rs:183:5
    |
-LL |     reg.register_univ(Box::new(CapturePass::new(&reg.sess_mut)));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------------^^^
-   |     |                                           |
-   |     |                                           immutable borrow occurs here
-   |     mutable borrow occurs here
-   |
-note: immutable borrowed value must be valid for the lifetime 'a as defined on the function body at 122:21...
-  --> $DIR/two-phase-surprise-no-conflict.rs:122:21
-   |
 LL | fn register_plugins<'a>(mk_reg: impl Fn() -> &'a mut Registry<'a>) {
-   |                     ^^
+   |                     -- lifetime `'a` defined here
+...
+LL |     reg.register_univ(Box::new(CapturePass::new(&reg.sess_mut)));
+   |     ^^^^^^^^^^^^^^^^^^-----------------------------------------^
+   |     |                 |                         |
+   |     |                 |                         immutable borrow occurs here
+   |     |                 cast requires that `reg.sess_mut` is borrowed for `'a`
+   |     mutable borrow occurs here
 
 error[E0502]: cannot borrow `*reg` as mutable because it is also borrowed as immutable
   --> $DIR/two-phase-surprise-no-conflict.rs:188:5
@@ -112,17 +110,15 @@ LL |     reg.register_bound(Box::new(CapturePass::new_mut(&mut reg.sess_mut)));
 error[E0499]: cannot borrow `*reg` as mutable more than once at a time
   --> $DIR/two-phase-surprise-no-conflict.rs:206:5
    |
-LL |     reg.register_univ(Box::new(CapturePass::new_mut(&mut reg.sess_mut)));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------------^^^
-   |     |                                               |
-   |     |                                               first mutable borrow occurs here
-   |     second mutable borrow occurs here
-   |
-note: first borrowed value must be valid for the lifetime 'a as defined on the function body at 122:21...
-  --> $DIR/two-phase-surprise-no-conflict.rs:122:21
-   |
 LL | fn register_plugins<'a>(mk_reg: impl Fn() -> &'a mut Registry<'a>) {
-   |                     ^^
+   |                     -- lifetime `'a` defined here
+...
+LL |     reg.register_univ(Box::new(CapturePass::new_mut(&mut reg.sess_mut)));
+   |     ^^^^^^^^^^^^^^^^^^-------------------------------------------------^
+   |     |                 |                             |
+   |     |                 |                             first mutable borrow occurs here
+   |     |                 cast requires that `reg.sess_mut` is borrowed for `'a`
+   |     second mutable borrow occurs here
 
 error[E0499]: cannot borrow `reg.sess_mut` as mutable more than once at a time
   --> $DIR/two-phase-surprise-no-conflict.rs:206:53

--- a/src/test/ui/consts/const-eval/dont_promote_unstable_const_fn.nll.stderr
+++ b/src/test/ui/consts/const-eval/dont_promote_unstable_const_fn.nll.stderr
@@ -10,33 +10,33 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/dont_promote_unstable_const_fn.rs:28:28
    |
 LL |     let _: &'static u32 = &foo(); //~ ERROR does not live long enough
-   |                            ^^^^^ creates a temporary which is freed while still in use
+   |            ------------    ^^^^^ creates a temporary which is freed while still in use
+   |            |
+   |            type annotation requires that borrow lasts for `'static`
 LL | }
    | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/dont_promote_unstable_const_fn.rs:32:28
    |
 LL |     let _: &'static u32 = &meh(); //~ ERROR does not live long enough
-   |                            ^^^^^ creates a temporary which is freed while still in use
+   |            ------------    ^^^^^ creates a temporary which is freed while still in use
+   |            |
+   |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
    | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/dont_promote_unstable_const_fn.rs:33:26
    |
 LL |     let x: &'static _ = &std::time::Duration::from_millis(42).subsec_millis();
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            ----------    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            |
+   |            type annotation requires that borrow lasts for `'static`
 LL |     //~^ ERROR does not live long enough
 LL | }
    | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/consts/const-eval/dont_promote_unstable_const_fn_cross_crate.nll.stderr
+++ b/src/test/ui/consts/const-eval/dont_promote_unstable_const_fn_cross_crate.nll.stderr
@@ -2,22 +2,22 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/dont_promote_unstable_const_fn_cross_crate.rs:18:28
    |
 LL |     let _: &'static u32 = &foo(); //~ ERROR does not live long enough
-   |                            ^^^^^ creates a temporary which is freed while still in use
+   |            ------------    ^^^^^ creates a temporary which is freed while still in use
+   |            |
+   |            type annotation requires that borrow lasts for `'static`
 LL |     let _x: &'static u32 = &foo(); //~ ERROR does not live long enough
 LL | }
    | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/dont_promote_unstable_const_fn_cross_crate.rs:19:29
    |
 LL |     let _x: &'static u32 = &foo(); //~ ERROR does not live long enough
-   |                             ^^^^^ creates a temporary which is freed while still in use
+   |             ------------    ^^^^^ creates a temporary which is freed while still in use
+   |             |
+   |             type annotation requires that borrow lasts for `'static`
 LL | }
    | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/consts/const-eval/promoted_const_fn_fail.nll.stderr
+++ b/src/test/ui/consts/const-eval/promoted_const_fn_fail.nll.stderr
@@ -2,12 +2,12 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/promoted_const_fn_fail.rs:30:27
    |
 LL |     let x: &'static u8 = &(bar() + 1); //~ ERROR does not live long enough
-   |                           ^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            -----------    ^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            |
+   |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
    | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-eval/promoted_raw_ptr_ops.nll.stderr
+++ b/src/test/ui/consts/const-eval/promoted_raw_ptr_ops.nll.stderr
@@ -2,44 +2,44 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/promoted_raw_ptr_ops.rs:14:29
    |
 LL |     let x: &'static bool = &(42 as *const i32 == 43 as *const i32);
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            -------------    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            |
+   |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
    | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promoted_raw_ptr_ops.rs:16:30
    |
 LL |     let y: &'static usize = &(&1 as *const i32 as usize + 1); //~ ERROR does not live long enough
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            --------------    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            |
+   |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
    | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promoted_raw_ptr_ops.rs:17:28
    |
 LL |     let z: &'static i32 = &(unsafe { *(42 as *const i32) }); //~ ERROR does not live long enough
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            ------------    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            |
+   |            type annotation requires that borrow lasts for `'static`
 LL |     let a: &'static bool = &(main as fn() == main as fn()); //~ ERROR does not live long enough
 LL | }
    | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promoted_raw_ptr_ops.rs:18:29
    |
 LL |     let a: &'static bool = &(main as fn() == main as fn()); //~ ERROR does not live long enough
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            -------------    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            |
+   |            type annotation requires that borrow lasts for `'static`
 LL | }
    | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/consts/const-eval/transmute-const-promotion.nll.stderr
+++ b/src/test/ui/consts/const-eval/transmute-const-promotion.nll.stderr
@@ -2,12 +2,12 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/transmute-const-promotion.rs:16:37
    |
 LL |     let x: &'static u32 = unsafe { &mem::transmute(3.0f32) };
-   |                                     ^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            ------------             ^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            |
+   |            type annotation requires that borrow lasts for `'static`
 LL |     //~^ ERROR value does not live long enough
 LL | }
    | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-eval/union_promotion.nll.stderr
+++ b/src/test/ui/consts/const-eval/union_promotion.nll.stderr
@@ -2,14 +2,14 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/union_promotion.rs:19:29
    |
 LL |       let x: &'static bool = &unsafe { //~ borrowed value does not live long enough
-   |  _____________________________^
+   |  ____________-------------____^
+   | |            |
+   | |            type annotation requires that borrow lasts for `'static`
 LL | |         Foo { a: &1 }.b == Foo { a: &2 }.b
 LL | |     };
    | |_____^ creates a temporary which is freed while still in use
 LL |   }
    |   - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-int-conversion.nll.stderr
+++ b/src/test/ui/consts/const-int-conversion.nll.stderr
@@ -2,78 +2,78 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-conversion.rs:14:28
    |
 LL |     let x: &'static i32 = &(5_i32.reverse_bits());
-   |                            ^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            ------------    ^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            |
+   |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
    | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-conversion.rs:16:28
    |
 LL |     let y: &'static i32 = &(i32::from_be_bytes([0x12, 0x34, 0x56, 0x78]));
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            ------------    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            |
+   |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
    | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-conversion.rs:18:28
    |
 LL |     let z: &'static i32 = &(i32::from_le_bytes([0x12, 0x34, 0x56, 0x78]));
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            ------------    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            |
+   |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
    | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-conversion.rs:20:28
    |
 LL |     let a: &'static i32 = &(i32::from_be(i32::from_ne_bytes([0x80, 0, 0, 0])));
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            ------------    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            |
+   |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
    | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-conversion.rs:22:29
    |
 LL |     let b: &'static [u8] = &(0x12_34_56_78_i32.to_be_bytes());
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            -------------    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            |
+   |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
    | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-conversion.rs:24:29
    |
 LL |     let c: &'static [u8] = &(0x12_34_56_78_i32.to_le_bytes());
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            -------------    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            |
+   |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
    | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-conversion.rs:26:29
    |
 LL |     let d: &'static [u8] = &(i32::min_value().to_be().to_ne_bytes());
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            -------------    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            |
+   |            type annotation requires that borrow lasts for `'static`
 LL |         //~^ ERROR does not live long enough
 LL | }
    | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/consts/const-int-overflowing.nll.stderr
+++ b/src/test/ui/consts/const-int-overflowing.nll.stderr
@@ -2,33 +2,33 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-overflowing.rs:12:36
    |
 LL |     let x: &'static (i32, bool) = &(5_i32.overflowing_add(3)); //~ ERROR does not live long enough
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            --------------------    ^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            |
+   |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
    | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-overflowing.rs:13:36
    |
 LL |     let y: &'static (i32, bool) = &(5_i32.overflowing_sub(3)); //~ ERROR does not live long enough
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            --------------------    ^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            |
+   |            type annotation requires that borrow lasts for `'static`
 LL |     let z: &'static (i32, bool) = &(5_i32.overflowing_mul(3)); //~ ERROR does not live long enough
 LL | }
    | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-overflowing.rs:14:36
    |
 LL |     let z: &'static (i32, bool) = &(5_i32.overflowing_mul(3)); //~ ERROR does not live long enough
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            --------------------    ^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            |
+   |            type annotation requires that borrow lasts for `'static`
 LL | }
    | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/consts/const-int-rotate.nll.stderr
+++ b/src/test/ui/consts/const-int-rotate.nll.stderr
@@ -2,22 +2,22 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-rotate.rs:12:28
    |
 LL |     let x: &'static i32 = &(5_i32.rotate_left(3)); //~ ERROR does not live long enough
-   |                            ^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            ------------    ^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            |
+   |            type annotation requires that borrow lasts for `'static`
 LL |     let y: &'static i32 = &(5_i32.rotate_right(3)); //~ ERROR does not live long enough
 LL | }
    | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-rotate.rs:13:28
    |
 LL |     let y: &'static i32 = &(5_i32.rotate_right(3)); //~ ERROR does not live long enough
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            ------------    ^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            |
+   |            type annotation requires that borrow lasts for `'static`
 LL | }
    | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/consts/const-int-sign.nll.stderr
+++ b/src/test/ui/consts/const-int-sign.nll.stderr
@@ -2,22 +2,22 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-sign.rs:12:29
    |
 LL |     let x: &'static bool = &(5_i32.is_negative()); //~ ERROR does not live long enough
-   |                             ^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            -------------    ^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            |
+   |            type annotation requires that borrow lasts for `'static`
 LL |     let y: &'static bool = &(5_i32.is_positive()); //~ ERROR does not live long enough
 LL | }
    | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-sign.rs:13:29
    |
 LL |     let y: &'static bool = &(5_i32.is_positive()); //~ ERROR does not live long enough
-   |                             ^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            -------------    ^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            |
+   |            type annotation requires that borrow lasts for `'static`
 LL | }
    | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/consts/const-int-wrapping.nll.stderr
+++ b/src/test/ui/consts/const-int-wrapping.nll.stderr
@@ -2,55 +2,55 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-wrapping.rs:12:28
    |
 LL |     let x: &'static i32 = &(5_i32.wrapping_add(3)); //~ ERROR does not live long enough
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            ------------    ^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            |
+   |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
    | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-wrapping.rs:13:28
    |
 LL |     let y: &'static i32 = &(5_i32.wrapping_sub(3)); //~ ERROR does not live long enough
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            ------------    ^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            |
+   |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
    | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-wrapping.rs:14:28
    |
 LL |     let z: &'static i32 = &(5_i32.wrapping_mul(3)); //~ ERROR does not live long enough
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            ------------    ^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            |
+   |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
    | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-wrapping.rs:15:28
    |
 LL |     let a: &'static i32 = &(5_i32.wrapping_shl(3)); //~ ERROR does not live long enough
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            ------------    ^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            |
+   |            type annotation requires that borrow lasts for `'static`
 LL |     let b: &'static i32 = &(5_i32.wrapping_shr(3)); //~ ERROR does not live long enough
 LL | }
    | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-wrapping.rs:16:28
    |
 LL |     let b: &'static i32 = &(5_i32.wrapping_shr(3)); //~ ERROR does not live long enough
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            ------------    ^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |            |
+   |            type annotation requires that borrow lasts for `'static`
 LL | }
    | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/consts/issue-54224.stderr
+++ b/src/test/ui/consts/issue-54224.stderr
@@ -2,21 +2,21 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/issue-54224.rs:3:39
    |
 LL | const FOO: Option<&[[u8; 3]]> = Some(&[*b"foo"]); //~ ERROR temporary value dropped while borrowed
-   |                                       ^^^^^^^^^- temporary value is freed at the end of this statement
-   |                                       |
-   |                                       creates a temporary which is freed while still in use
-   |
-   = note: borrowed value must be valid for the static lifetime...
+   |                                 ------^^^^^^^^^-
+   |                                 |     |        |
+   |                                 |     |        temporary value is freed at the end of this statement
+   |                                 |     creates a temporary which is freed while still in use
+   |                                 using this value as a constant requires that borrow lasts for `'static`
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/issue-54224.rs:11:57
    |
 LL | pub const Z: Cow<'static, [ [u8; 3] ]> = Cow::Borrowed(&[*b"ABC"]);
-   |                                                         ^^^^^^^^^- temporary value is freed at the end of this statement
-   |                                                         |
-   |                                                         creates a temporary which is freed while still in use
-   |
-   = note: borrowed value must be valid for the static lifetime...
+   |                                          ---------------^^^^^^^^^-
+   |                                          |              |        |
+   |                                          |              |        temporary value is freed at the end of this statement
+   |                                          |              creates a temporary which is freed while still in use
+   |                                          using this value as a constant requires that borrow lasts for `'static`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/consts/min_const_fn/min_const_fn.nll.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn.nll.stderr
@@ -190,15 +190,15 @@ error: trait bounds other than `Sized` on const fn parameters are unstable
 LL | const fn no_dyn_trait_ret() -> &'static dyn std::fmt::Debug { &() }
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning[E0716]: temporary value dropped while borrowed
-  --> $DIR/min_const_fn.rs:142:64
+warning[E0515]: cannot return reference to temporary value
+  --> $DIR/min_const_fn.rs:142:63
    |
 LL | const fn no_dyn_trait_ret() -> &'static dyn std::fmt::Debug { &() }
-   |                                                                ^^ - temporary value is freed at the end of this statement
-   |                                                                |
-   |                                                                creates a temporary which is freed while still in use
+   |                                                               ^--
+   |                                                               ||
+   |                                                               |temporary value created here
+   |                                                               returns a reference to data owned by the current function
    |
-   = note: borrowed value must be valid for the static lifetime...
    = warning: This error has been downgraded to a warning for backwards compatibility with previous releases.
            It represents potential unsoundness in your code.
            This warning will become a hard error in the future.
@@ -223,5 +223,5 @@ LL | const fn no_fn_ptrs2() -> fn() { fn foo() {} foo }
 
 error: aborting due to 35 previous errors
 
-Some errors occurred: E0493, E0716.
+Some errors occurred: E0493, E0515.
 For more information about an error, try `rustc --explain E0493`.

--- a/src/test/ui/consts/min_const_fn/min_const_fn_dyn.nll.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn_dyn.nll.stderr
@@ -14,11 +14,11 @@ warning[E0716]: temporary value dropped while borrowed
   --> $DIR/min_const_fn_dyn.rs:22:67
    |
 LL | const fn no_inner_dyn_trait_ret() -> Hide { Hide(HasDyn { field: &0 }) }
-   |                                                                   ^    - temporary value is freed at the end of this statement
-   |                                                                   |
-   |                                                                   creates a temporary which is freed while still in use
+   |                                                                  -^    - temporary value is freed at the end of this statement
+   |                                                                  ||
+   |                                                                  |creates a temporary which is freed while still in use
+   |                                                                  cast requires that borrow lasts for `'static`
    |
-   = note: borrowed value must be valid for the static lifetime...
    = warning: This error has been downgraded to a warning for backwards compatibility with previous releases.
            It represents potential unsoundness in your code.
            This warning will become a hard error in the future.

--- a/src/test/ui/consts/min_const_fn/promotion.nll.stderr
+++ b/src/test/ui/consts/min_const_fn/promotion.nll.stderr
@@ -2,66 +2,66 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/promotion.rs:11:27
    |
 LL |     let x: &'static () = &foo1(); //~ ERROR does not live long enough
-   |                           ^^^^^^ creates a temporary which is freed while still in use
+   |            -----------    ^^^^^^ creates a temporary which is freed while still in use
+   |            |
+   |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
    | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promotion.rs:12:28
    |
 LL |     let y: &'static i32 = &foo2(42); //~ ERROR does not live long enough
-   |                            ^^^^^^^^ creates a temporary which is freed while still in use
+   |            ------------    ^^^^^^^^ creates a temporary which is freed while still in use
+   |            |
+   |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
    | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promotion.rs:13:28
    |
 LL |     let z: &'static i32 = &foo3(); //~ ERROR does not live long enough
-   |                            ^^^^^^ creates a temporary which is freed while still in use
+   |            ------------    ^^^^^^ creates a temporary which is freed while still in use
+   |            |
+   |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
    | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promotion.rs:14:34
    |
 LL |     let a: &'static Cell<i32> = &foo4();  //~ ERROR does not live long enough
-   |                                  ^^^^^^ creates a temporary which is freed while still in use
+   |            ------------------    ^^^^^^ creates a temporary which is freed while still in use
+   |            |
+   |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
    | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promotion.rs:15:42
    |
 LL |     let a: &'static Option<Cell<i32>> = &foo5(); //~ ERROR does not live long enough
-   |                                          ^^^^^^ creates a temporary which is freed while still in use
+   |            --------------------------    ^^^^^^ creates a temporary which is freed while still in use
+   |            |
+   |            type annotation requires that borrow lasts for `'static`
 LL |     let a: &'static Option<Cell<i32>> = &foo6(); //~ ERROR does not live long enough
 LL | }
    | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promotion.rs:16:42
    |
 LL |     let a: &'static Option<Cell<i32>> = &foo6(); //~ ERROR does not live long enough
-   |                                          ^^^^^^ creates a temporary which is freed while still in use
+   |            --------------------------    ^^^^^^ creates a temporary which is freed while still in use
+   |            |
+   |            type annotation requires that borrow lasts for `'static`
 LL | }
    | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/dropck/drop-with-active-borrows-2.nll.stderr
+++ b/src/test/ui/dropck/drop-with-active-borrows-2.nll.stderr
@@ -1,18 +1,12 @@
-error[E0597]: `raw_lines` does not live long enough
+error[E0515]: cannot return value referencing local variable `raw_lines`
   --> $DIR/drop-with-active-borrows-2.rs:13:5
    |
 LL |     raw_lines.iter().map(|l| l.trim()).collect()
-   |     ^^^^^^^^^ borrowed value does not live long enough
-LL |     //~^ ERROR `raw_lines` does not live long enough
-LL | }
-   | - `raw_lines` dropped here while still borrowed
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 11:24...
-  --> $DIR/drop-with-active-borrows-2.rs:11:24
-   |
-LL | fn read_lines_borrowed<'a>() -> Vec<&'a str> {
-   |                        ^^
+   |     ---------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     returns a value referencing data owned by the current function
+   |     `raw_lines` is borrowed here
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0597`.
+For more information about this error, try `rustc --explain E0515`.

--- a/src/test/ui/dropck/dropck_trait_cycle_checked.nll.stderr
+++ b/src/test/ui/dropck/dropck_trait_cycle_checked.nll.stderr
@@ -1,67 +1,72 @@
 error[E0597]: `o2` does not live long enough
   --> $DIR/dropck_trait_cycle_checked.rs:121:13
    |
+LL |     let (o1, o2, o3): (Box<Obj>, Box<Obj>, Box<Obj>) = (O::new(), O::new(), O::new());
+   |                                                                   -------- cast requires that `o2` is borrowed for `'static`
 LL |     o1.set0(&o2); //~ ERROR `o2` does not live long enough
    |             ^^^ borrowed value does not live long enough
 ...
 LL | }
    | - `o2` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0597]: `o3` does not live long enough
   --> $DIR/dropck_trait_cycle_checked.rs:122:13
    |
+LL |     let (o1, o2, o3): (Box<Obj>, Box<Obj>, Box<Obj>) = (O::new(), O::new(), O::new());
+   |                                                                             -------- cast requires that `o3` is borrowed for `'static`
+LL |     o1.set0(&o2); //~ ERROR `o2` does not live long enough
 LL |     o1.set1(&o3); //~ ERROR `o3` does not live long enough
    |             ^^^ borrowed value does not live long enough
 ...
 LL | }
    | - `o3` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0597]: `o2` does not live long enough
   --> $DIR/dropck_trait_cycle_checked.rs:123:13
    |
+LL |     let (o1, o2, o3): (Box<Obj>, Box<Obj>, Box<Obj>) = (O::new(), O::new(), O::new());
+   |                                                                   -------- cast requires that `o2` is borrowed for `'static`
+...
 LL |     o2.set0(&o2); //~ ERROR `o2` does not live long enough
    |             ^^^ borrowed value does not live long enough
 ...
 LL | }
    | - `o2` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0597]: `o3` does not live long enough
   --> $DIR/dropck_trait_cycle_checked.rs:124:13
    |
+LL |     let (o1, o2, o3): (Box<Obj>, Box<Obj>, Box<Obj>) = (O::new(), O::new(), O::new());
+   |                                                                             -------- cast requires that `o3` is borrowed for `'static`
+...
 LL |     o2.set1(&o3); //~ ERROR `o3` does not live long enough
    |             ^^^ borrowed value does not live long enough
 ...
 LL | }
    | - `o3` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0597]: `o1` does not live long enough
   --> $DIR/dropck_trait_cycle_checked.rs:125:13
    |
+LL |     let (o1, o2, o3): (Box<Obj>, Box<Obj>, Box<Obj>) = (O::new(), O::new(), O::new());
+   |                                                         -------- cast requires that `o1` is borrowed for `'static`
+...
 LL |     o3.set0(&o1); //~ ERROR `o1` does not live long enough
    |             ^^^ borrowed value does not live long enough
 LL |     o3.set1(&o2); //~ ERROR `o2` does not live long enough
 LL | }
    | - `o1` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0597]: `o2` does not live long enough
   --> $DIR/dropck_trait_cycle_checked.rs:126:13
    |
+LL |     let (o1, o2, o3): (Box<Obj>, Box<Obj>, Box<Obj>) = (O::new(), O::new(), O::new());
+   |                                                                   -------- cast requires that `o2` is borrowed for `'static`
+...
 LL |     o3.set1(&o2); //~ ERROR `o2` does not live long enough
    |             ^^^ borrowed value does not live long enough
 LL | }
    | - `o2` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/dst/dst-bad-coerce3.nll.stderr
+++ b/src/test/ui/dst/dst-bad-coerce3.nll.stderr
@@ -1,62 +1,57 @@
 error[E0597]: `f1` does not live long enough
   --> $DIR/dst-bad-coerce3.rs:26:32
    |
+LL | fn baz<'a>() {
+   |        -- lifetime `'a` defined here
+...
 LL |     let f2: &Fat<[isize; 3]> = &f1; //~ ERROR `f1` does not live long enough
    |                                ^^^ borrowed value does not live long enough
+LL |     let f3: &'a Fat<[isize]> = f2;
+   |             ---------------- type annotation requires that `f1` is borrowed for `'a`
 ...
 LL | }
    | - `f1` dropped here while still borrowed
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 23:8...
-  --> $DIR/dst-bad-coerce3.rs:23:8
-   |
-LL | fn baz<'a>() {
-   |        ^^
 
 error[E0597]: `f1` does not live long enough
   --> $DIR/dst-bad-coerce3.rs:31:25
    |
+LL | fn baz<'a>() {
+   |        -- lifetime `'a` defined here
+...
 LL |     let f2: &Fat<Foo> = &f1; //~ ERROR `f1` does not live long enough
    |                         ^^^ borrowed value does not live long enough
+LL |     let f3: &'a Fat<Bar> = f2;
+   |             ------------ type annotation requires that `f1` is borrowed for `'a`
 ...
 LL | }
    | - `f1` dropped here while still borrowed
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 23:8...
-  --> $DIR/dst-bad-coerce3.rs:23:8
-   |
-LL | fn baz<'a>() {
-   |        ^^
 
 error[E0597]: `f1` does not live long enough
   --> $DIR/dst-bad-coerce3.rs:36:30
    |
+LL | fn baz<'a>() {
+   |        -- lifetime `'a` defined here
+...
 LL |     let f2: &([isize; 3],) = &f1; //~ ERROR `f1` does not live long enough
    |                              ^^^ borrowed value does not live long enough
+LL |     let f3: &'a ([isize],) = f2;
+   |             -------------- type annotation requires that `f1` is borrowed for `'a`
 ...
 LL | }
    | - `f1` dropped here while still borrowed
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 23:8...
-  --> $DIR/dst-bad-coerce3.rs:23:8
-   |
-LL | fn baz<'a>() {
-   |        ^^
 
 error[E0597]: `f1` does not live long enough
   --> $DIR/dst-bad-coerce3.rs:41:23
    |
+LL | fn baz<'a>() {
+   |        -- lifetime `'a` defined here
+...
 LL |     let f2: &(Foo,) = &f1; //~ ERROR `f1` does not live long enough
    |                       ^^^ borrowed value does not live long enough
 LL |     let f3: &'a (Bar,) = f2;
+   |             ---------- type annotation requires that `f1` is borrowed for `'a`
 LL | }
    | - `f1` dropped here while still borrowed
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 23:8...
-  --> $DIR/dst-bad-coerce3.rs:23:8
-   |
-LL | fn baz<'a>() {
-   |        ^^
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/generator/generator-region-requirements.nll.stderr
+++ b/src/test/ui/generator/generator-region-requirements.nll.stderr
@@ -1,11 +1,11 @@
 error[E0621]: explicit lifetime required in the type of `x`
-  --> $DIR/generator-region-requirements.rs:11:9
+  --> $DIR/generator-region-requirements.rs:15:51
    |
 LL | fn dangle(x: &mut i32) -> &'static mut i32 {
    |              -------- help: add explicit lifetime `'static` to the type of `x`: `&'static mut i32`
 ...
-LL |         x
-   |         ^ lifetime `'static` required
+LL |             GeneratorState::Complete(c) => return c,
+   |                                                   ^ lifetime `'static` required
 
 error: aborting due to previous error
 

--- a/src/test/ui/generator/ref-escapes-but-not-over-yield.nll.stderr
+++ b/src/test/ui/generator/ref-escapes-but-not-over-yield.nll.stderr
@@ -1,12 +1,15 @@
-error[E0597]: `b` does not live long enough
-  --> $DIR/ref-escapes-but-not-over-yield.rs:24:13
+error[E0521]: borrowed data escapes outside of generator
+  --> $DIR/ref-escapes-but-not-over-yield.rs:24:9
    |
+LL |     let mut a = &3;
+   |         ----- `a` is declared here, outside of the generator body
+...
 LL |         a = &b;
-   |             ^^ borrowed value does not live long enough
-LL |         //~^ ERROR `b` does not live long enough
-LL |     };
-   |     - `b` dropped here while still borrowed
+   |         ^^^^--
+   |         |   |
+   |         |   borrow is only valid in the generator body
+   |         reference to `b` escapes the generator body here
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0597`.
+For more information about this error, try `rustc --explain E0521`.

--- a/src/test/ui/issues/issue-11681.nll.stderr
+++ b/src/test/ui/issues/issue-11681.nll.stderr
@@ -1,18 +1,11 @@
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/issue-11681.rs:22:20
+error[E0515]: cannot return value referencing temporary value
+  --> $DIR/issue-11681.rs:23:10
    |
 LL |   let testValue = &Test; //~ ERROR borrowed value does not live long enough
-   |                    ^^^^ creates a temporary which is freed while still in use
+   |                    ---- temporary value created here
 LL |   return testValue;
-LL | }
-   | - temporary value is freed at the end of this statement
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 21:15...
-  --> $DIR/issue-11681.rs:21:15
-   |
-LL | fn createTest<'a>() -> &'a Test {
-   |               ^^
+   |          ^^^^^^^^^ returns a value referencing data owned by the current function
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0716`.
+For more information about this error, try `rustc --explain E0515`.

--- a/src/test/ui/issues/issue-12470.nll.stderr
+++ b/src/test/ui/issues/issue-12470.nll.stderr
@@ -1,18 +1,11 @@
-error[E0597]: `*b` does not live long enough
-  --> $DIR/issue-12470.rs:38:18
+error[E0515]: cannot return value referencing local data `*b`
+  --> $DIR/issue-12470.rs:39:5
    |
 LL |     let bb: &B = &*b;    //~ ERROR does not live long enough
-   |                  ^^^ borrowed value does not live long enough
+   |                  --- `*b` is borrowed here
 LL |     make_a(bb)
-LL | }
-   | - `*b` dropped here while still borrowed
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 36:16...
-  --> $DIR/issue-12470.rs:36:16
-   |
-LL | fn make_make_a<'a>() -> A<'a> {
-   |                ^^
+   |     ^^^^^^^^^^ returns a value referencing data owned by the current function
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0597`.
+For more information about this error, try `rustc --explain E0515`.

--- a/src/test/ui/issues/issue-13497-2.nll.stderr
+++ b/src/test/ui/issues/issue-13497-2.nll.stderr
@@ -1,18 +1,14 @@
-error[E0597]: `rawLines` does not live long enough
+error[E0515]: cannot return value referencing local variable `rawLines`
   --> $DIR/issue-13497-2.rs:13:5
    |
-LL |     rawLines //~ ERROR `rawLines` does not live long enough
-   |     ^^^^^^^^ borrowed value does not live long enough
-LL |         .iter().map(|l| l.trim()).collect()
-LL | }
-   | - `rawLines` dropped here while still borrowed
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 11:24...
-  --> $DIR/issue-13497-2.rs:11:24
-   |
-LL | fn read_lines_borrowed<'a>() -> Vec<&'a str> {
-   |                        ^^
+LL |       rawLines //~ ERROR `rawLines` does not live long enough
+   |       ^-------
+   |       |
+   |  _____`rawLines` is borrowed here
+   | |
+LL | |         .iter().map(|l| l.trim()).collect()
+   | |___________________________________________^ returns a value referencing data owned by the current function
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0597`.
+For more information about this error, try `rustc --explain E0515`.

--- a/src/test/ui/issues/issue-17545.nll.stderr
+++ b/src/test/ui/issues/issue-17545.nll.stderr
@@ -1,16 +1,15 @@
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/issue-17545.rs:17:10
    |
-LL |         &id(()), //~ ERROR borrowed value does not live long enough
-   |          ^^^^^^ creates a temporary which is freed while still in use
-LL |     ));
-   |       - temporary value is freed at the end of this statement
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 15:12...
-  --> $DIR/issue-17545.rs:15:12
-   |
-LL | pub fn foo<'a, F: Fn(&'a ())>(bar: F) {
-   |            ^^
+LL |   pub fn foo<'a, F: Fn(&'a ())>(bar: F) {
+   |              -- lifetime `'a` defined here
+LL | /     bar.call((
+LL | |         &id(()), //~ ERROR borrowed value does not live long enough
+   | |          ^^^^^^ creates a temporary which is freed while still in use
+LL | |     ));
+   | |      -- temporary value is freed at the end of this statement
+   | |______|
+   |        argument requires that borrow lasts for `'a`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-17718-constants-not-static.nll.stderr
+++ b/src/test/ui/issues/issue-17718-constants-not-static.nll.stderr
@@ -1,13 +1,12 @@
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/issue-17718-constants-not-static.rs:15:31
+error[E0515]: cannot return reference to temporary value
+  --> $DIR/issue-17718-constants-not-static.rs:15:30
    |
 LL | fn foo() -> &'static usize { &id(FOO) }
-   |                               ^^^^^^^ - temporary value is freed at the end of this statement
-   |                               |
-   |                               creates a temporary which is freed while still in use
-   |
-   = note: borrowed value must be valid for the static lifetime...
+   |                              ^-------
+   |                              ||
+   |                              |temporary value created here
+   |                              returns a reference to data owned by the current function
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0716`.
+For more information about this error, try `rustc --explain E0515`.

--- a/src/test/ui/issues/issue-18118.nll.stderr
+++ b/src/test/ui/issues/issue-18118.nll.stderr
@@ -54,12 +54,13 @@ error[E0597]: `p` does not live long enough
   --> $DIR/issue-18118.rs:18:9
    |
 LL |         &p //~ ERROR `p` does not live long enough
-   |         ^^ borrowed value does not live long enough
+   |         ^^
+   |         |
+   |         borrowed value does not live long enough
+   |         using this value as a constant requires that `p` is borrowed for `'static`
 LL |         //~^ ERROR let bindings in constants are unstable
 LL |     };
    |     - `p` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/issues/issue-27592.nll.stderr
+++ b/src/test/ui/issues/issue-27592.nll.stderr
@@ -1,19 +1,21 @@
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/issue-27592.rs:26:27
+error[E0515]: cannot return value referencing temporary value
+  --> $DIR/issue-27592.rs:26:14
    |
 LL |     write(|| format_args!("{}", String::from("Hello world")));
-   |                           ^^^^                             - temporary value is freed at the end of this statement
-   |                           |
-   |                           creates a temporary which is freed while still in use
+   |              ^^^^^^^^^^^^^^^^^^^---------------------------^
+   |              |                  |
+   |              |                  temporary value created here
+   |              returns a value referencing data owned by the current function
 
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/issue-27592.rs:26:33
+error[E0515]: cannot return value referencing temporary value
+  --> $DIR/issue-27592.rs:26:14
    |
 LL |     write(|| format_args!("{}", String::from("Hello world")));
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^- temporary value is freed at the end of this statement
-   |                                 |
-   |                                 creates a temporary which is freed while still in use
+   |              ^^^^^^^^^^^^^----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              |            |
+   |              |            temporary value created here
+   |              returns a value referencing data owned by the current function
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0716`.
+For more information about this error, try `rustc --explain E0515`.

--- a/src/test/ui/issues/issue-30438-a.nll.stderr
+++ b/src/test/ui/issues/issue-30438-a.nll.stderr
@@ -1,20 +1,12 @@
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/issue-30438-a.rs:22:17
+error[E0515]: cannot return reference to temporary value
+  --> $DIR/issue-30438-a.rs:22:16
    |
 LL |         return &Test { s: &self.s};
-   |                 ^^^^^^^^^^^^^^^^^^- temporary value is freed at the end of this statement
-   |                 |
-   |                 creates a temporary which is freed while still in use
-   |
-note: borrowed value must be valid for the anonymous lifetime #1 defined on the method body at 21:5...
-  --> $DIR/issue-30438-a.rs:21:5
-   |
-LL | /     fn index(&self, _: usize) -> &Self::Output {
-LL | |         return &Test { s: &self.s};
-LL | |         //~^ ERROR: borrowed value does not live long enough
-LL | |     }
-   | |_____^
+   |                ^------------------
+   |                ||
+   |                |temporary value created here
+   |                returns a reference to data owned by the current function
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0716`.
+For more information about this error, try `rustc --explain E0515`.

--- a/src/test/ui/issues/issue-30438-b.nll.stderr
+++ b/src/test/ui/issues/issue-30438-b.nll.stderr
@@ -1,21 +1,12 @@
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/issue-30438-b.rs:23:10
+error[E0515]: cannot return reference to temporary value
+  --> $DIR/issue-30438-b.rs:23:9
    |
 LL |         &Test { s: &self.s}
-   |          ^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
-LL |         //~^ ERROR: borrowed value does not live long enough
-LL |     }
-   |     - temporary value is freed at the end of this statement
-   |
-note: borrowed value must be valid for the anonymous lifetime #1 defined on the method body at 22:5...
-  --> $DIR/issue-30438-b.rs:22:5
-   |
-LL | /     fn index(&self, _: usize) -> &Self::Output {
-LL | |         &Test { s: &self.s}
-LL | |         //~^ ERROR: borrowed value does not live long enough
-LL | |     }
-   | |_____^
+   |         ^------------------
+   |         ||
+   |         |temporary value created here
+   |         returns a reference to data owned by the current function
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0716`.
+For more information about this error, try `rustc --explain E0515`.

--- a/src/test/ui/issues/issue-30438-c.nll.stderr
+++ b/src/test/ui/issues/issue-30438-c.nll.stderr
@@ -1,21 +1,9 @@
-error[E0597]: `x` does not live long enough
+error[E0515]: cannot return reference to local variable `x`
   --> $DIR/issue-30438-c.rs:19:5
    |
-LL | fn silly<'y, 'z>(_s: &'y Test<'z>) -> &'y <Test<'z> as Trait>::Out where 'z: 'static {
-   |                       --               -- also has lifetime `'y`
-   |                       |
-   |                       has lifetime `'y`
-LL |     let x = Test { s: "this cannot last" };
 LL |     &x
-   |     ^^ `x` would have to be valid for `'y`...
-LL |     //~^ ERROR: `x` does not live long enough
-LL | }
-   | - ...but `x` will be dropped here, when the function `silly` returns
-   |
-   = help: use data from the highlighted arguments which match the `'y` lifetime of the return type
-   = note: functions cannot return a borrow to data owned within the function's scope, functions can only return borrows to data passed as arguments
-   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch04-02-references-and-borrowing.html#dangling-references>
+   |     ^^ returns a reference to data owned by the current function
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0597`.
+For more information about this error, try `rustc --explain E0515`.

--- a/src/test/ui/issues/issue-4335.nll.stderr
+++ b/src/test/ui/issues/issue-4335.nll.stderr
@@ -15,24 +15,25 @@ LL |     id(Box::new(|| *v))
    |                    cannot move out of `*v` which is behind a `&` reference
    |                    cannot move
 
-error[E0597]: `v` does not live long enough
-  --> $DIR/issue-4335.rs:16:21
+error[E0373]: closure may outlive the current function, but it borrows `v`, which is owned by the current function
+  --> $DIR/issue-4335.rs:16:17
    |
 LL |     id(Box::new(|| *v))
-   |                 --  ^ borrowed value does not live long enough
+   |                 ^^  - `v` is borrowed here
    |                 |
-   |                 value captured here
-...
-LL | }
-   | - `v` dropped here while still borrowed
+   |                 may outlive borrowed value `v`
    |
-note: borrowed value must be valid for the lifetime 'r as defined on the function body at 15:6...
-  --> $DIR/issue-4335.rs:15:6
+note: closure is returned here
+  --> $DIR/issue-4335.rs:16:5
    |
-LL | fn f<'r, T>(v: &'r T) -> Box<FnMut() -> T + 'r> {
-   |      ^^
+LL |     id(Box::new(|| *v))
+   |     ^^^^^^^^^^^^^^^^^^^
+help: to force the closure to take ownership of `v` (and any other referenced variables), use the `move` keyword
+   |
+LL |     id(Box::new(move || *v))
+   |                 ^^^^^^^
 
 error: aborting due to 3 previous errors
 
-Some errors occurred: E0507, E0597.
-For more information about an error, try `rustc --explain E0507`.
+Some errors occurred: E0373, E0507.
+For more information about an error, try `rustc --explain E0373`.

--- a/src/test/ui/issues/issue-44373.nll.stderr
+++ b/src/test/ui/issues/issue-44373.nll.stderr
@@ -2,11 +2,11 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/issue-44373.rs:15:42
    |
 LL |     let _val: &'static [&'static u32] = &[&FOO]; //~ ERROR borrowed value does not live long enough
-   |                                          ^^^^^^ creates a temporary which is freed while still in use
+   |               -----------------------    ^^^^^^ creates a temporary which is freed while still in use
+   |               |
+   |               type annotation requires that borrow lasts for `'static`
 LL | }
    | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-45696-scribble-on-boxed-borrow.migrate.stderr
+++ b/src/test/ui/issues/issue-45696-scribble-on-boxed-borrow.migrate.stderr
@@ -1,17 +1,14 @@
 warning[E0713]: borrow may still be in use when destructor runs
   --> $DIR/issue-45696-scribble-on-boxed-borrow.rs:63:5
    |
+LL | fn scribbled<'a>(s: Scribble<'a>) -> &'a mut u32 {
+   |              -- lifetime `'a` defined here
 LL |     &mut *s.0 //[nll]~ ERROR borrow may still be in use when destructor runs [E0713]
-   |     ^^^^^^^^^
+   |     ^^^^^^^^^ returning this value requires that `*s.0` is borrowed for `'a`
 ...
 LL | }
    | - here, drop of `s` needs exclusive access to `*s.0`, because the type `Scribble<'_>` implements the `Drop` trait
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 62:14...
-  --> $DIR/issue-45696-scribble-on-boxed-borrow.rs:62:14
-   |
-LL | fn scribbled<'a>(s: Scribble<'a>) -> &'a mut u32 {
-   |              ^^
    = warning: This error has been downgraded to a warning for backwards compatibility with previous releases.
            It represents potential unsoundness in your code.
            This warning will become a hard error in the future.
@@ -19,17 +16,14 @@ LL | fn scribbled<'a>(s: Scribble<'a>) -> &'a mut u32 {
 warning[E0713]: borrow may still be in use when destructor runs
   --> $DIR/issue-45696-scribble-on-boxed-borrow.rs:73:5
    |
+LL | fn boxed_scribbled<'a>(s: Box<Scribble<'a>>) -> &'a mut u32 {
+   |                    -- lifetime `'a` defined here
 LL |     &mut *(*s).0 //[nll]~ ERROR borrow may still be in use when destructor runs [E0713]
-   |     ^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^ returning this value requires that `*s.0` is borrowed for `'a`
 ...
 LL | }
    | - here, drop of `s` needs exclusive access to `*s.0`, because the type `Scribble<'_>` implements the `Drop` trait
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 72:20...
-  --> $DIR/issue-45696-scribble-on-boxed-borrow.rs:72:20
-   |
-LL | fn boxed_scribbled<'a>(s: Box<Scribble<'a>>) -> &'a mut u32 {
-   |                    ^^
    = warning: This error has been downgraded to a warning for backwards compatibility with previous releases.
            It represents potential unsoundness in your code.
            This warning will become a hard error in the future.
@@ -37,17 +31,14 @@ LL | fn boxed_scribbled<'a>(s: Box<Scribble<'a>>) -> &'a mut u32 {
 warning[E0713]: borrow may still be in use when destructor runs
   --> $DIR/issue-45696-scribble-on-boxed-borrow.rs:83:5
    |
+LL | fn boxed_boxed_scribbled<'a>(s: Box<Box<Scribble<'a>>>) -> &'a mut u32 {
+   |                          -- lifetime `'a` defined here
 LL |     &mut *(**s).0 //[nll]~ ERROR borrow may still be in use when destructor runs [E0713]
-   |     ^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^ returning this value requires that `*s.0` is borrowed for `'a`
 ...
 LL | }
    | - here, drop of `s` needs exclusive access to `*s.0`, because the type `Scribble<'_>` implements the `Drop` trait
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 82:26...
-  --> $DIR/issue-45696-scribble-on-boxed-borrow.rs:82:26
-   |
-LL | fn boxed_boxed_scribbled<'a>(s: Box<Box<Scribble<'a>>>) -> &'a mut u32 {
-   |                          ^^
    = warning: This error has been downgraded to a warning for backwards compatibility with previous releases.
            It represents potential unsoundness in your code.
            This warning will become a hard error in the future.

--- a/src/test/ui/issues/issue-45696-scribble-on-boxed-borrow.nll.stderr
+++ b/src/test/ui/issues/issue-45696-scribble-on-boxed-borrow.nll.stderr
@@ -1,47 +1,35 @@
 error[E0713]: borrow may still be in use when destructor runs
   --> $DIR/issue-45696-scribble-on-boxed-borrow.rs:63:5
    |
+LL | fn scribbled<'a>(s: Scribble<'a>) -> &'a mut u32 {
+   |              -- lifetime `'a` defined here
 LL |     &mut *s.0 //[nll]~ ERROR borrow may still be in use when destructor runs [E0713]
-   |     ^^^^^^^^^
+   |     ^^^^^^^^^ returning this value requires that `*s.0` is borrowed for `'a`
 ...
 LL | }
    | - here, drop of `s` needs exclusive access to `*s.0`, because the type `Scribble<'_>` implements the `Drop` trait
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 62:14...
-  --> $DIR/issue-45696-scribble-on-boxed-borrow.rs:62:14
-   |
-LL | fn scribbled<'a>(s: Scribble<'a>) -> &'a mut u32 {
-   |              ^^
 
 error[E0713]: borrow may still be in use when destructor runs
   --> $DIR/issue-45696-scribble-on-boxed-borrow.rs:73:5
    |
+LL | fn boxed_scribbled<'a>(s: Box<Scribble<'a>>) -> &'a mut u32 {
+   |                    -- lifetime `'a` defined here
 LL |     &mut *(*s).0 //[nll]~ ERROR borrow may still be in use when destructor runs [E0713]
-   |     ^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^ returning this value requires that `*s.0` is borrowed for `'a`
 ...
 LL | }
    | - here, drop of `s` needs exclusive access to `*s.0`, because the type `Scribble<'_>` implements the `Drop` trait
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 72:20...
-  --> $DIR/issue-45696-scribble-on-boxed-borrow.rs:72:20
-   |
-LL | fn boxed_scribbled<'a>(s: Box<Scribble<'a>>) -> &'a mut u32 {
-   |                    ^^
 
 error[E0713]: borrow may still be in use when destructor runs
   --> $DIR/issue-45696-scribble-on-boxed-borrow.rs:83:5
    |
+LL | fn boxed_boxed_scribbled<'a>(s: Box<Box<Scribble<'a>>>) -> &'a mut u32 {
+   |                          -- lifetime `'a` defined here
 LL |     &mut *(**s).0 //[nll]~ ERROR borrow may still be in use when destructor runs [E0713]
-   |     ^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^ returning this value requires that `*s.0` is borrowed for `'a`
 ...
 LL | }
    | - here, drop of `s` needs exclusive access to `*s.0`, because the type `Scribble<'_>` implements the `Drop` trait
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 82:26...
-  --> $DIR/issue-45696-scribble-on-boxed-borrow.rs:82:26
-   |
-LL | fn boxed_boxed_scribbled<'a>(s: Box<Box<Scribble<'a>>>) -> &'a mut u32 {
-   |                          ^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/issues/issue-46036.stderr
+++ b/src/test/ui/issues/issue-46036.stderr
@@ -2,12 +2,13 @@ error[E0597]: `a` does not live long enough
   --> $DIR/issue-46036.rs:19:24
    |
 LL |     let foo = Foo { x: &a }; //~ ERROR E0597
-   |                        ^^ borrowed value does not live long enough
+   |                        ^^
+   |                        |
+   |                        borrowed value does not live long enough
+   |                        requires that `a` is borrowed for `'static`
 LL |     loop { }
 LL | }
    | - `a` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-46471.rs
+++ b/src/test/ui/issues/issue-46471.rs
@@ -14,7 +14,7 @@ fn foo() -> &'static u32 {
     let x = 0;
     &x
     //~^ ERROR `x` does not live long enough (Ast) [E0597]
-    //~| ERROR `x` does not live long enough (Mir) [E0597]
+    //~| ERROR cannot return reference to local variable `x` (Mir) [E0515]
 }
 
 fn main() { }

--- a/src/test/ui/issues/issue-46471.stderr
+++ b/src/test/ui/issues/issue-46471.stderr
@@ -9,17 +9,13 @@ LL | }
    |
    = note: borrowed value must be valid for the static lifetime...
 
-error[E0597]: `x` does not live long enough (Mir)
+error[E0515]: cannot return reference to local variable `x` (Mir)
   --> $DIR/issue-46471.rs:15:5
    |
 LL |     &x
-   |     ^^ borrowed value does not live long enough
-...
-LL | }
-   | - `x` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
+   |     ^^ returns a reference to data owned by the current function
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0597`.
+Some errors occurred: E0515, E0597.
+For more information about an error, try `rustc --explain E0515`.

--- a/src/test/ui/issues/issue-46472.rs
+++ b/src/test/ui/issues/issue-46472.rs
@@ -13,7 +13,7 @@
 fn bar<'a>() -> &'a mut u32 {
     &mut 4
     //~^ ERROR borrowed value does not live long enough (Ast) [E0597]
-    //~| ERROR temporary value dropped while borrowed (Mir) [E0716]
+    //~| ERROR cannot return reference to temporary value (Mir) [E0515]
 }
 
 fn main() { }

--- a/src/test/ui/issues/issue-46472.stderr
+++ b/src/test/ui/issues/issue-46472.stderr
@@ -13,22 +13,16 @@ note: borrowed value must be valid for the lifetime 'a as defined on the functio
 LL | fn bar<'a>() -> &'a mut u32 {
    |        ^^
 
-error[E0716]: temporary value dropped while borrowed (Mir)
-  --> $DIR/issue-46472.rs:14:10
+error[E0515]: cannot return reference to temporary value (Mir)
+  --> $DIR/issue-46472.rs:14:5
    |
 LL |     &mut 4
-   |          ^ creates a temporary which is freed while still in use
-...
-LL | }
-   | - temporary value is freed at the end of this statement
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 13:8...
-  --> $DIR/issue-46472.rs:13:8
-   |
-LL | fn bar<'a>() -> &'a mut u32 {
-   |        ^^
+   |     ^^^^^-
+   |     |    |
+   |     |    temporary value created here
+   |     returns a reference to data owned by the current function
 
 error: aborting due to 2 previous errors
 
-Some errors occurred: E0597, E0716.
-For more information about an error, try `rustc --explain E0597`.
+Some errors occurred: E0515, E0597.
+For more information about an error, try `rustc --explain E0515`.

--- a/src/test/ui/issues/issue-47184.stderr
+++ b/src/test/ui/issues/issue-47184.stderr
@@ -2,11 +2,10 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/issue-47184.rs:14:44
    |
 LL |     let _vec: Vec<&'static String> = vec![&String::new()];
-   |                                            ^^^^^^^^^^^^^ - temporary value is freed at the end of this statement
-   |                                            |
-   |                                            creates a temporary which is freed while still in use
-   |
-   = note: borrowed value must be valid for the static lifetime...
+   |               --------------------         ^^^^^^^^^^^^^ - temporary value is freed at the end of this statement
+   |               |                            |
+   |               |                            creates a temporary which is freed while still in use
+   |               type annotation requires that borrow lasts for `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-52049.nll.stderr
+++ b/src/test/ui/issues/issue-52049.nll.stderr
@@ -2,11 +2,12 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/issue-52049.rs:16:10
    |
 LL |     foo(&unpromotable(5u32));
-   |          ^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
+   |     -----^^^^^^^^^^^^^^^^^^-
+   |     |    |
+   |     |    creates a temporary which is freed while still in use
+   |     argument requires that borrow lasts for `'static`
 LL | }
    | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/borrowed-universal-error-2.rs
+++ b/src/test/ui/nll/borrowed-universal-error-2.rs
@@ -14,7 +14,7 @@
 fn foo<'a>(x: &'a (u32,)) -> &'a u32 {
     let v = 22;
     &v
-    //~^ ERROR `v` does not live long enough [E0597]
+    //~^ ERROR cannot return reference to local variable `v` [E0515]
 }
 
 fn main() {}

--- a/src/test/ui/nll/borrowed-universal-error-2.stderr
+++ b/src/test/ui/nll/borrowed-universal-error-2.stderr
@@ -1,21 +1,9 @@
-error[E0597]: `v` does not live long enough
+error[E0515]: cannot return reference to local variable `v`
   --> $DIR/borrowed-universal-error-2.rs:16:5
    |
-LL | fn foo<'a>(x: &'a (u32,)) -> &'a u32 {
-   |                --             -- also has lifetime `'a`
-   |                |
-   |                has lifetime `'a`
-LL |     let v = 22;
 LL |     &v
-   |     ^^ `v` would have to be valid for `'a`...
-LL |     //~^ ERROR `v` does not live long enough [E0597]
-LL | }
-   | - ...but `v` will be dropped here, when the function `foo` returns
-   |
-   = help: use data from the highlighted arguments which match the `'a` lifetime of the return type
-   = note: functions cannot return a borrow to data owned within the function's scope, functions can only return borrows to data passed as arguments
-   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch04-02-references-and-borrowing.html#dangling-references>
+   |     ^^ returns a reference to data owned by the current function
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0597`.
+For more information about this error, try `rustc --explain E0515`.

--- a/src/test/ui/nll/borrowed-universal-error.rs
+++ b/src/test/ui/nll/borrowed-universal-error.rs
@@ -18,7 +18,7 @@ fn gimme(x: &(u32,)) -> &u32 {
 fn foo<'a>(x: &'a (u32,)) -> &'a u32 {
     let v = 22;
     gimme(&(v,))
-    //~^ ERROR temporary value dropped while borrowed [E0716]
+    //~^ ERROR cannot return value referencing temporary value [E0515]
 }
 
 fn main() {}

--- a/src/test/ui/nll/borrowed-universal-error.stderr
+++ b/src/test/ui/nll/borrowed-universal-error.stderr
@@ -1,18 +1,12 @@
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/borrowed-universal-error.rs:20:12
+error[E0515]: cannot return value referencing temporary value
+  --> $DIR/borrowed-universal-error.rs:20:5
    |
 LL |     gimme(&(v,))
-   |            ^^^^ creates a temporary which is freed while still in use
-LL |     //~^ ERROR temporary value dropped while borrowed [E0716]
-LL | }
-   | - temporary value is freed at the end of this statement
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 18:8...
-  --> $DIR/borrowed-universal-error.rs:18:8
-   |
-LL | fn foo<'a>(x: &'a (u32,)) -> &'a u32 {
-   |        ^^
+   |     ^^^^^^^----^
+   |     |      |
+   |     |      temporary value created here
+   |     returns a value referencing data owned by the current function
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0716`.
+For more information about this error, try `rustc --explain E0515`.

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
@@ -71,12 +71,13 @@ error[E0597]: `a` does not live long enough
   --> $DIR/propagate-approximated-shorter-to-static-comparing-against-free.rs:40:26
    |
 LL |     let cell = Cell::new(&a);
-   |                          ^^ borrowed value does not live long enough
+   |                ----------^^-
+   |                |         |
+   |                |         borrowed value does not live long enough
+   |                argument requires that `a` is borrowed for `'static`
 ...
 LL | }
    | - `a` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
@@ -13,7 +13,7 @@ LL | |     })
                for<'r> extern "rust-call" fn((std::cell::Cell<&'_#1r u32>, std::cell::Cell<&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0:0), 'r)) u32>))
            ]
 
-error: borrowed data escapes outside of closure
+error[E0521]: borrowed data escapes outside of closure
   --> $DIR/propagate-approximated-shorter-to-static-comparing-against-free.rs:32:9
    |
 LL |     foo(cell, |cell_a, cell_x| {
@@ -80,4 +80,5 @@ LL | }
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0597`.
+Some errors occurred: E0521, E0597.
+For more information about an error, try `rustc --explain E0521`.

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-no-bound.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-no-bound.stderr
@@ -34,7 +34,7 @@ LL | | }
    |
    = note: defining type: DefId(0/0:6 ~ propagate_approximated_shorter_to_static_no_bound[317d]::supply[0]) with substs []
 
-error: borrowed data escapes outside of function
+error[E0521]: borrowed data escapes outside of function
   --> $DIR/propagate-approximated-shorter-to-static-no-bound.rs:45:5
    |
 LL |   fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
@@ -61,3 +61,4 @@ LL |         demand_y(x, y, x.get())
 
 error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0521`.

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-wrong-bound.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-wrong-bound.stderr
@@ -33,7 +33,7 @@ LL | | }
    |
    = note: defining type: DefId(0/0:6 ~ propagate_approximated_shorter_to_static_wrong_bound[317d]::supply[0]) with substs []
 
-error: borrowed data escapes outside of function
+error[E0521]: borrowed data escapes outside of function
   --> $DIR/propagate-approximated-shorter-to-static-wrong-bound.rs:48:5
    |
 LL |   fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
@@ -59,3 +59,4 @@ LL |         demand_y(x, y, x.get())
 
 error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0521`.

--- a/src/test/ui/nll/do-not-ignore-lifetime-bounds-in-copy.stderr
+++ b/src/test/ui/nll/do-not-ignore-lifetime-bounds-in-copy.stderr
@@ -3,11 +3,11 @@ error[E0597]: `s` does not live long enough
    |
 LL |     let a = Foo(&s); //~ ERROR `s` does not live long enough [E0597]
    |                 ^^ borrowed value does not live long enough
-...
+LL |     drop(a);
+   |          - copying this value requires that `s` is borrowed for `'static`
+LL |     drop(a);
 LL | }
    | - `s` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/enum-drop-access.stderr
+++ b/src/test/ui/nll/enum-drop-access.stderr
@@ -1,44 +1,30 @@
 error[E0713]: borrow may still be in use when destructor runs
   --> $DIR/enum-drop-access.rs:15:31
    |
+LL | fn drop_enum(opt: DropOption<&mut i32>) -> Option<&mut i32> {
+   |                              - let's call the lifetime of this reference `'1`
+LL |     match opt {
 LL |         DropOption::Some(&mut ref mut r) => { //~ ERROR
    |                               ^^^^^^^^^
+LL |             Some(r)
+   |             ------- returning this value requires that `*opt.0` is borrowed for `'1`
 ...
 LL | }
    | - here, drop of `opt` needs exclusive access to `*opt.0`, because the type `DropOption<&mut i32>` implements the `Drop` trait
-   |
-note: borrowed value must be valid for the anonymous lifetime #1 defined on the function body at 13:1...
-  --> $DIR/enum-drop-access.rs:13:1
-   |
-LL | / fn drop_enum(opt: DropOption<&mut i32>) -> Option<&mut i32> {
-LL | |     match opt {
-LL | |         DropOption::Some(&mut ref mut r) => { //~ ERROR
-LL | |             Some(r)
-...  |
-LL | |     }
-LL | | }
-   | |_^
 
 error[E0713]: borrow may still be in use when destructor runs
   --> $DIR/enum-drop-access.rs:24:36
    |
+LL | fn optional_drop_enum(opt: Option<DropOption<&mut i32>>) -> Option<&mut i32> {
+   |                                              - let's call the lifetime of this reference `'1`
+LL |     match opt {
 LL |         Some(DropOption::Some(&mut ref mut r)) => { //~ ERROR
    |                                    ^^^^^^^^^
+LL |             Some(r)
+   |             ------- returning this value requires that `*opt.0.0` is borrowed for `'1`
 ...
 LL | }
    | - here, drop of `opt` needs exclusive access to `*opt.0.0`, because the type `DropOption<&mut i32>` implements the `Drop` trait
-   |
-note: borrowed value must be valid for the anonymous lifetime #1 defined on the function body at 22:1...
-  --> $DIR/enum-drop-access.rs:22:1
-   |
-LL | / fn optional_drop_enum(opt: Option<DropOption<&mut i32>>) -> Option<&mut i32> {
-LL | |     match opt {
-LL | |         Some(DropOption::Some(&mut ref mut r)) => { //~ ERROR
-LL | |             Some(r)
-...  |
-LL | |     }
-LL | | }
-   | |_^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/nll/get_default.nll.stderr
+++ b/src/test/ui/nll/get_default.nll.stderr
@@ -37,65 +37,47 @@ LL | }
 error[E0502]: cannot borrow `*map` as mutable because it is also borrowed as immutable (Mir)
   --> $DIR/get_default.rs:33:17
    |
+LL | fn ok(map: &mut Map) -> &String {
+   |            - let's call the lifetime of this reference `'1`
+LL |     loop {
 LL |         match map.get() {
    |               --- immutable borrow occurs here
+LL |             Some(v) => {
+LL |                 return v;
+   |                        - returning this value requires that `*map` is borrowed for `'1`
 ...
 LL |                 map.set(String::new()); // Ideally, this would not error.
    |                 ^^^^^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
-   |
-note: immutable borrowed value must be valid for the anonymous lifetime #1 defined on the function body at 26:1...
-  --> $DIR/get_default.rs:26:1
-   |
-LL | / fn ok(map: &mut Map) -> &String {
-LL | |     loop {
-LL | |         match map.get() {
-LL | |             Some(v) => {
-...  |
-LL | |     }
-LL | | }
-   | |_^
 
 error[E0502]: cannot borrow `*map` as mutable because it is also borrowed as immutable (Mir)
   --> $DIR/get_default.rs:45:17
    |
+LL | fn err(map: &mut Map) -> &String {
+   |             - let's call the lifetime of this reference `'1`
+LL |     loop {
 LL |         match map.get() {
    |               --- immutable borrow occurs here
 LL |             Some(v) => {
 LL |                 map.set(String::new()); // Both AST and MIR error here
    |                 ^^^^^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
-   |
-note: immutable borrowed value must be valid for the anonymous lifetime #1 defined on the function body at 41:1...
-  --> $DIR/get_default.rs:41:1
-   |
-LL | / fn err(map: &mut Map) -> &String {
-LL | |     loop {
-LL | |         match map.get() {
-LL | |             Some(v) => {
-...  |
-LL | |     }
-LL | | }
-   | |_^
+...
+LL |                 return v;
+   |                        - returning this value requires that `*map` is borrowed for `'1`
 
 error[E0502]: cannot borrow `*map` as mutable because it is also borrowed as immutable (Mir)
   --> $DIR/get_default.rs:51:17
    |
+LL | fn err(map: &mut Map) -> &String {
+   |             - let's call the lifetime of this reference `'1`
+LL |     loop {
 LL |         match map.get() {
    |               --- immutable borrow occurs here
 ...
+LL |                 return v;
+   |                        - returning this value requires that `*map` is borrowed for `'1`
+...
 LL |                 map.set(String::new()); // Ideally, just AST would error here
    |                 ^^^^^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
-   |
-note: immutable borrowed value must be valid for the anonymous lifetime #1 defined on the function body at 41:1...
-  --> $DIR/get_default.rs:41:1
-   |
-LL | / fn err(map: &mut Map) -> &String {
-LL | |     loop {
-LL | |         match map.get() {
-LL | |             Some(v) => {
-...  |
-LL | |     }
-LL | | }
-   | |_^
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/nll/get_default.stderr
+++ b/src/test/ui/nll/get_default.stderr
@@ -37,65 +37,47 @@ LL | }
 error[E0502]: cannot borrow `*map` as mutable because it is also borrowed as immutable (Mir)
   --> $DIR/get_default.rs:33:17
    |
+LL | fn ok(map: &mut Map) -> &String {
+   |            - let's call the lifetime of this reference `'1`
+LL |     loop {
 LL |         match map.get() {
    |               --- immutable borrow occurs here
+LL |             Some(v) => {
+LL |                 return v;
+   |                        - returning this value requires that `*map` is borrowed for `'1`
 ...
 LL |                 map.set(String::new()); // Ideally, this would not error.
    |                 ^^^ mutable borrow occurs here
-   |
-note: immutable borrowed value must be valid for the anonymous lifetime #1 defined on the function body at 26:1...
-  --> $DIR/get_default.rs:26:1
-   |
-LL | / fn ok(map: &mut Map) -> &String {
-LL | |     loop {
-LL | |         match map.get() {
-LL | |             Some(v) => {
-...  |
-LL | |     }
-LL | | }
-   | |_^
 
 error[E0502]: cannot borrow `*map` as mutable because it is also borrowed as immutable (Mir)
   --> $DIR/get_default.rs:45:17
    |
+LL | fn err(map: &mut Map) -> &String {
+   |             - let's call the lifetime of this reference `'1`
+LL |     loop {
 LL |         match map.get() {
    |               --- immutable borrow occurs here
 LL |             Some(v) => {
 LL |                 map.set(String::new()); // Both AST and MIR error here
    |                 ^^^ mutable borrow occurs here
-   |
-note: immutable borrowed value must be valid for the anonymous lifetime #1 defined on the function body at 41:1...
-  --> $DIR/get_default.rs:41:1
-   |
-LL | / fn err(map: &mut Map) -> &String {
-LL | |     loop {
-LL | |         match map.get() {
-LL | |             Some(v) => {
-...  |
-LL | |     }
-LL | | }
-   | |_^
+...
+LL |                 return v;
+   |                        - returning this value requires that `*map` is borrowed for `'1`
 
 error[E0502]: cannot borrow `*map` as mutable because it is also borrowed as immutable (Mir)
   --> $DIR/get_default.rs:51:17
    |
+LL | fn err(map: &mut Map) -> &String {
+   |             - let's call the lifetime of this reference `'1`
+LL |     loop {
 LL |         match map.get() {
    |               --- immutable borrow occurs here
 ...
+LL |                 return v;
+   |                        - returning this value requires that `*map` is borrowed for `'1`
+...
 LL |                 map.set(String::new()); // Ideally, just AST would error here
    |                 ^^^ mutable borrow occurs here
-   |
-note: immutable borrowed value must be valid for the anonymous lifetime #1 defined on the function body at 41:1...
-  --> $DIR/get_default.rs:41:1
-   |
-LL | / fn err(map: &mut Map) -> &String {
-LL | |     loop {
-LL | |         match map.get() {
-LL | |             Some(v) => {
-...  |
-LL | |     }
-LL | | }
-   | |_^
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/nll/issue-31567.stderr
+++ b/src/test/ui/nll/issue-31567.stderr
@@ -1,17 +1,15 @@
 error[E0713]: borrow may still be in use when destructor runs
   --> $DIR/issue-31567.rs:22:26
    |
+LL | fn get_dangling<'a>(v: VecWrapper<'a>) -> &'a u32 {
+   |                 -- lifetime `'a` defined here
 LL |     let s_inner: &'a S = &*v.0; //~ ERROR borrow may still be in use when destructor runs [E0713]
-   |                          ^^^^^
+   |                  -----   ^^^^^
+   |                  |
+   |                  type annotation requires that `*v.0` is borrowed for `'a`
 LL |     &s_inner.0
 LL | }
    | - here, drop of `v` needs exclusive access to `*v.0`, because the type `VecWrapper<'_>` implements the `Drop` trait
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 21:17...
-  --> $DIR/issue-31567.rs:21:17
-   |
-LL | fn get_dangling<'a>(v: VecWrapper<'a>) -> &'a u32 {
-   |                 ^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/issue-47470.rs
+++ b/src/test/ui/nll/issue-47470.rs
@@ -24,7 +24,7 @@ impl<'a> Bar for Foo<'a> {
     type Assoc = &'a u32;
     fn get(self) -> Self::Assoc {
         let local = 42;
-        &local //~ ERROR `local` does not live long enough
+        &local //~ ERROR cannot return reference to local variable `local`
     }
 }
 

--- a/src/test/ui/nll/issue-47470.stderr
+++ b/src/test/ui/nll/issue-47470.stderr
@@ -1,17 +1,9 @@
-error[E0597]: `local` does not live long enough
+error[E0515]: cannot return reference to local variable `local`
   --> $DIR/issue-47470.rs:27:9
    |
-LL |         &local //~ ERROR `local` does not live long enough
-   |         ^^^^^^ borrowed value does not live long enough
-LL |     }
-   |     - `local` dropped here while still borrowed
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the impl at 23:6...
-  --> $DIR/issue-47470.rs:23:6
-   |
-LL | impl<'a> Bar for Foo<'a> {
-   |      ^^
+LL |         &local //~ ERROR cannot return reference to local variable `local`
+   |         ^^^^^^ returns a reference to data owned by the current function
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0597`.
+For more information about this error, try `rustc --explain E0515`.

--- a/src/test/ui/nll/issue-52059-report-when-borrow-and-drop-conflict.stderr
+++ b/src/test/ui/nll/issue-52059-report-when-borrow-and-drop-conflict.stderr
@@ -1,50 +1,32 @@
 error[E0713]: borrow may still be in use when destructor runs
   --> $DIR/issue-52059-report-when-borrow-and-drop-conflict.rs:14:5
    |
+LL | fn finish_1(s: S) -> &mut String {
+   |             - has type `S<'1>`
 LL |     s.url
-   |     ^^^^^
+   |     ^^^^^ returning this value requires that `*s.url` is borrowed for `'1`
 LL | }
    | - here, drop of `s` needs exclusive access to `*s.url`, because the type `S<'_>` implements the `Drop` trait
-   |
-note: borrowed value must be valid for the anonymous lifetime #1 defined on the function body at 13:1...
-  --> $DIR/issue-52059-report-when-borrow-and-drop-conflict.rs:13:1
-   |
-LL | / fn finish_1(s: S) -> &mut String {
-LL | |     s.url
-LL | | }
-   | |_^
 
 error[E0713]: borrow may still be in use when destructor runs
   --> $DIR/issue-52059-report-when-borrow-and-drop-conflict.rs:19:13
    |
+LL | fn finish_2(s: S) -> &mut String {
+   |             - has type `S<'1>`
 LL |     let p = &mut *s.url; p
-   |             ^^^^^^^^^^^
+   |             ^^^^^^^^^^^  - returning this value requires that `*s.url` is borrowed for `'1`
 LL | }
    | - here, drop of `s` needs exclusive access to `*s.url`, because the type `S<'_>` implements the `Drop` trait
-   |
-note: borrowed value must be valid for the anonymous lifetime #1 defined on the function body at 18:1...
-  --> $DIR/issue-52059-report-when-borrow-and-drop-conflict.rs:18:1
-   |
-LL | / fn finish_2(s: S) -> &mut String {
-LL | |     let p = &mut *s.url; p
-LL | | }
-   | |_^
 
 error[E0713]: borrow may still be in use when destructor runs
   --> $DIR/issue-52059-report-when-borrow-and-drop-conflict.rs:24:21
    |
+LL | fn finish_3(s: S) -> &mut String {
+   |             - has type `S<'1>`
 LL |     let p: &mut _ = s.url; p
-   |                     ^^^^^
+   |                     ^^^^^  - returning this value requires that `*s.url` is borrowed for `'1`
 LL | }
    | - here, drop of `s` needs exclusive access to `*s.url`, because the type `S<'_>` implements the `Drop` trait
-   |
-note: borrowed value must be valid for the anonymous lifetime #1 defined on the function body at 23:1...
-  --> $DIR/issue-52059-report-when-borrow-and-drop-conflict.rs:23:1
-   |
-LL | / fn finish_3(s: S) -> &mut String {
-LL | |     let p: &mut _ = s.url; p
-LL | | }
-   | |_^
 
 error[E0509]: cannot move out of type `S<'_>`, which implements the `Drop` trait
   --> $DIR/issue-52059-report-when-borrow-and-drop-conflict.rs:29:13

--- a/src/test/ui/nll/issue-52534-1.stderr
+++ b/src/test/ui/nll/issue-52534-1.stderr
@@ -1,141 +1,57 @@
-error[E0597]: `x` does not live long enough
+error[E0515]: cannot return reference to local variable `x`
   --> $DIR/issue-52534-1.rs:19:9
    |
-LL |     fn bar(&self, x: &u32) -> &u32 {
-   |            -----              ---- has type `&'0 u32`
-   |            |
-   |            has type `&'0 Test`
-LL |         let x = 22;
 LL |         &x
-   |         ^^ `x` would have to be valid for `'0`...
-LL |     }
-   |     - ...but `x` will be dropped here, when the function `bar` returns
-   |
-   = note: argument and return type have the same lifetime due to lifetime elision rules
-   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch10-03-lifetime-syntax.html#lifetime-elision>
-   = note: functions cannot return a borrow to data owned within the function's scope, functions can only return borrows to data passed as arguments
-   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch04-02-references-and-borrowing.html#dangling-references>
+   |         ^^ returns a reference to data owned by the current function
 
-error[E0597]: `x` does not live long enough
+error[E0515]: cannot return reference to local variable `x`
   --> $DIR/issue-52534-1.rs:25:5
    |
-LL | fn foo(x: &u32) -> &u32 {
-   |           ----     ---- also has type `&'0 u32`
-   |           |
-   |           has type `&'0 u32`
-LL |     let x = 22;
 LL |     &x
-   |     ^^ `x` would have to be valid for `'0`...
-LL | }
-   | - ...but `x` will be dropped here, when the function `foo` returns
-   |
-   = note: argument and return type have the same lifetime due to lifetime elision rules
-   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch10-03-lifetime-syntax.html#lifetime-elision>
-   = note: functions cannot return a borrow to data owned within the function's scope, functions can only return borrows to data passed as arguments
-   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch04-02-references-and-borrowing.html#dangling-references>
+   |     ^^ returns a reference to data owned by the current function
 
-error[E0597]: `x` does not live long enough
-  --> $DIR/issue-52534-1.rs:30:6
-   |
-LL | fn baz(x: &u32) -> &&u32 {
-   |           ----     ----- has type `&'0 &'0 u32`
-   |           |
-   |           has type `&'0 u32`
-LL |     let x = 22;
-LL |     &&x
-   |      ^^ `x` would have to be valid for `'0`...
-LL | }
-   | - ...but `x` will be dropped here, when the function `baz` returns
-   |
-   = note: argument and return type have the same lifetime due to lifetime elision rules
-   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch10-03-lifetime-syntax.html#lifetime-elision>
-   = note: functions cannot return a borrow to data owned within the function's scope, functions can only return borrows to data passed as arguments
-   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch04-02-references-and-borrowing.html#dangling-references>
-
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/issue-52534-1.rs:30:6
+error[E0515]: cannot return value referencing local variable `x`
+  --> $DIR/issue-52534-1.rs:30:5
    |
 LL |     &&x
-   |      ^^ creates a temporary which is freed while still in use
-LL | }
-   | - temporary value is freed at the end of this statement
-   |
-note: borrowed value must be valid for the anonymous lifetime #1 defined on the function body at 28:1...
-  --> $DIR/issue-52534-1.rs:28:1
-   |
-LL | / fn baz(x: &u32) -> &&u32 {
-LL | |     let x = 22;
-LL | |     &&x
-LL | | }
-   | |_^
+   |     ^--
+   |     ||
+   |     |`x` is borrowed here
+   |     returns a value referencing data owned by the current function
 
-error[E0597]: `x` does not live long enough
+error[E0515]: cannot return reference to temporary value
+  --> $DIR/issue-52534-1.rs:30:5
+   |
+LL |     &&x
+   |     ^--
+   |     ||
+   |     |temporary value created here
+   |     returns a reference to data owned by the current function
+
+error[E0515]: cannot return reference to local variable `x`
   --> $DIR/issue-52534-1.rs:35:5
    |
-LL | fn foobazbar<'a>(x: u32, y: &'a u32) -> &'a u32 {
-   |                              --          -- also has lifetime `'a`
-   |                              |
-   |                              has lifetime `'a`
-LL |     let x = 22;
 LL |     &x
-   |     ^^ `x` would have to be valid for `'a`...
-LL | }
-   | - ...but `x` will be dropped here, when the function `foobazbar` returns
-   |
-   = help: use data from the highlighted arguments which match the `'a` lifetime of the return type
-   = note: functions cannot return a borrow to data owned within the function's scope, functions can only return borrows to data passed as arguments
-   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch04-02-references-and-borrowing.html#dangling-references>
+   |     ^^ returns a reference to data owned by the current function
 
-error[E0597]: `x` does not live long enough
+error[E0515]: cannot return reference to local variable `x`
   --> $DIR/issue-52534-1.rs:40:5
    |
-LL | fn foobar<'a>(x: &'a u32) -> &'a u32 {
-   |                   --          -- also has lifetime `'a`
-   |                   |
-   |                   has lifetime `'a`
-LL |     let x = 22;
 LL |     &x
-   |     ^^ `x` would have to be valid for `'a`...
-LL | }
-   | - ...but `x` will be dropped here, when the function `foobar` returns
-   |
-   = help: use data from the highlighted arguments which match the `'a` lifetime of the return type
-   = note: functions cannot return a borrow to data owned within the function's scope, functions can only return borrows to data passed as arguments
-   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch04-02-references-and-borrowing.html#dangling-references>
+   |     ^^ returns a reference to data owned by the current function
 
-error[E0597]: `x` does not live long enough
+error[E0515]: cannot return reference to local variable `x`
   --> $DIR/issue-52534-1.rs:45:5
    |
-LL | fn foobaz<'a, 'b>(x: &'a u32, y: &'b u32) -> &'a u32 {
-   |                       -- has lifetime `'a`    -- also has lifetime `'a`
-LL |     let x = 22;
 LL |     &x
-   |     ^^ `x` would have to be valid for `'a`...
-LL | }
-   | - ...but `x` will be dropped here, when the function `foobaz` returns
-   |
-   = help: use data from the highlighted arguments which match the `'a` lifetime of the return type
-   = note: functions cannot return a borrow to data owned within the function's scope, functions can only return borrows to data passed as arguments
-   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch04-02-references-and-borrowing.html#dangling-references>
+   |     ^^ returns a reference to data owned by the current function
 
-error[E0597]: `x` does not live long enough
+error[E0515]: cannot return reference to local variable `x`
   --> $DIR/issue-52534-1.rs:50:5
    |
-LL | fn foobarbaz<'a, 'b>(x: &'a u32, y: &'b u32, z: &'a u32) -> &'a u32 {
-   |                          --                      --          -- also has lifetime `'a`
-   |                          |                       |
-   |                          has lifetime `'a`       has lifetime `'a`
-LL |     let x = 22;
 LL |     &x
-   |     ^^ `x` would have to be valid for `'a`...
-LL | }
-   | - ...but `x` will be dropped here, when the function `foobarbaz` returns
-   |
-   = help: use data from the highlighted arguments which match the `'a` lifetime of the return type
-   = note: functions cannot return a borrow to data owned within the function's scope, functions can only return borrows to data passed as arguments
-   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch04-02-references-and-borrowing.html#dangling-references>
+   |     ^^ returns a reference to data owned by the current function
 
 error: aborting due to 8 previous errors
 
-Some errors occurred: E0597, E0716.
-For more information about an error, try `rustc --explain E0597`.
+For more information about this error, try `rustc --explain E0515`.

--- a/src/test/ui/nll/polonius-smoke-test.stderr
+++ b/src/test/ui/nll/polonius-smoke-test.stderr
@@ -1,12 +1,8 @@
-error[E0597]: `x` does not live long enough
+error[E0515]: cannot return reference to local variable `x`
   --> $DIR/polonius-smoke-test.rs:7:5
    |
 LL |     &x //~ ERROR
-   |     ^^ borrowed value does not live long enough
-LL | }
-   | - `x` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
+   |     ^^ returns a reference to data owned by the current function
 
 error[E0503]: cannot use `x` because it was mutably borrowed
   --> $DIR/polonius-smoke-test.rs:13:13
@@ -41,5 +37,5 @@ LL |     tmp;
 
 error: aborting due to 4 previous errors
 
-Some errors occurred: E0503, E0505, E0597.
+Some errors occurred: E0503, E0505, E0515.
 For more information about an error, try `rustc --explain E0503`.

--- a/src/test/ui/nll/relate_tys/var-appears-twice.stderr
+++ b/src/test/ui/nll/relate_tys/var-appears-twice.stderr
@@ -2,12 +2,12 @@ error[E0597]: `b` does not live long enough
   --> $DIR/var-appears-twice.rs:33:38
    |
 LL |     let x: DoubleCell<_> = make_cell(&b); //~ ERROR
-   |                                      ^^ borrowed value does not live long enough
+   |            -------------             ^^ borrowed value does not live long enough
+   |            |
+   |            type annotation requires that `b` is borrowed for `'static`
 ...
 LL | }
    | - `b` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/return-ref-mut-issue-46557.rs
+++ b/src/test/ui/nll/return-ref-mut-issue-46557.rs
@@ -14,8 +14,8 @@
 #![allow(dead_code)]
 
 fn gimme_static_mut() -> &'static mut u32 {
-    let ref mut x = 1234543; //~ ERROR temporary value dropped while borrowed [E0716]
-    x
+    let ref mut x = 1234543;
+    x //~ ERROR cannot return value referencing temporary value [E0515]
 }
 
 fn main() {}

--- a/src/test/ui/nll/return-ref-mut-issue-46557.stderr
+++ b/src/test/ui/nll/return-ref-mut-issue-46557.stderr
@@ -1,14 +1,11 @@
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/return-ref-mut-issue-46557.rs:17:21
+error[E0515]: cannot return value referencing temporary value
+  --> $DIR/return-ref-mut-issue-46557.rs:18:5
    |
-LL |     let ref mut x = 1234543; //~ ERROR temporary value dropped while borrowed [E0716]
-   |                     ^^^^^^^ creates a temporary which is freed while still in use
-LL |     x
-LL | }
-   | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
+LL |     let ref mut x = 1234543;
+   |                     ------- temporary value created here
+LL |     x //~ ERROR cannot return value referencing temporary value [E0515]
+   |     ^ returns a value referencing data owned by the current function
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0716`.
+For more information about this error, try `rustc --explain E0515`.

--- a/src/test/ui/nll/user-annotations/adt-brace-enums.stderr
+++ b/src/test/ui/nll/user-annotations/adt-brace-enums.stderr
@@ -2,39 +2,40 @@ error[E0597]: `c` does not live long enough
   --> $DIR/adt-brace-enums.rs:37:48
    |
 LL |     SomeEnum::SomeVariant::<&'static u32> { t: &c }; //~ ERROR
-   |                                                ^^ borrowed value does not live long enough
+   |                                                ^^
+   |                                                |
+   |                                                borrowed value does not live long enough
+   |                                                requires that `c` is borrowed for `'static`
 LL | }
    | - `c` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-brace-enums.rs:42:43
    |
+LL | fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
+   |                                   -- lifetime `'a` defined here
+LL |     let c = 66;
 LL |     SomeEnum::SomeVariant::<&'a u32> { t: &c }; //~ ERROR
-   |                                           ^^ borrowed value does not live long enough
+   |                                           ^^
+   |                                           |
+   |                                           borrowed value does not live long enough
+   |                                           requires that `c` is borrowed for `'a`
 LL | }
    | - `c` dropped here while still borrowed
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 40:35...
-  --> $DIR/adt-brace-enums.rs:40:35
-   |
-LL | fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
-   |                                   ^^
 
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-brace-enums.rs:52:47
    |
+LL | fn annot_reference_named_lifetime_in_closure<'a>(_: &'a u32) {
+   |                                              -- lifetime `'a` defined here
+...
 LL |         SomeEnum::SomeVariant::<&'a u32> { t: &c }; //~ ERROR
-   |                                               ^^ borrowed value does not live long enough
+   |                                               ^^
+   |                                               |
+   |                                               borrowed value does not live long enough
+   |                                               requires that `c` is borrowed for `'a`
 LL |     };
    |     - `c` dropped here while still borrowed
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 49:46...
-  --> $DIR/adt-brace-enums.rs:49:46
-   |
-LL | fn annot_reference_named_lifetime_in_closure<'a>(_: &'a u32) {
-   |                                              ^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/nll/user-annotations/adt-brace-structs.stderr
+++ b/src/test/ui/nll/user-annotations/adt-brace-structs.stderr
@@ -2,39 +2,40 @@ error[E0597]: `c` does not live long enough
   --> $DIR/adt-brace-structs.rs:35:37
    |
 LL |     SomeStruct::<&'static u32> { t: &c }; //~ ERROR
-   |                                     ^^ borrowed value does not live long enough
+   |                                     ^^
+   |                                     |
+   |                                     borrowed value does not live long enough
+   |                                     requires that `c` is borrowed for `'static`
 LL | }
    | - `c` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-brace-structs.rs:40:32
    |
+LL | fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
+   |                                   -- lifetime `'a` defined here
+LL |     let c = 66;
 LL |     SomeStruct::<&'a u32> { t: &c }; //~ ERROR
-   |                                ^^ borrowed value does not live long enough
+   |                                ^^
+   |                                |
+   |                                borrowed value does not live long enough
+   |                                requires that `c` is borrowed for `'a`
 LL | }
    | - `c` dropped here while still borrowed
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 38:35...
-  --> $DIR/adt-brace-structs.rs:38:35
-   |
-LL | fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
-   |                                   ^^
 
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-brace-structs.rs:50:36
    |
+LL | fn annot_reference_named_lifetime_in_closure<'a>(_: &'a u32) {
+   |                                              -- lifetime `'a` defined here
+...
 LL |         SomeStruct::<&'a u32> { t: &c }; //~ ERROR
-   |                                    ^^ borrowed value does not live long enough
+   |                                    ^^
+   |                                    |
+   |                                    borrowed value does not live long enough
+   |                                    requires that `c` is borrowed for `'a`
 LL |     };
    |     - `c` dropped here while still borrowed
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 47:46...
-  --> $DIR/adt-brace-structs.rs:47:46
-   |
-LL | fn annot_reference_named_lifetime_in_closure<'a>(_: &'a u32) {
-   |                                              ^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/nll/user-annotations/adt-nullary-enums.stderr
+++ b/src/test/ui/nll/user-annotations/adt-nullary-enums.stderr
@@ -2,42 +2,43 @@ error[E0597]: `c` does not live long enough
   --> $DIR/adt-nullary-enums.rs:44:41
    |
 LL |         SomeEnum::SomeVariant(Cell::new(&c)), //~ ERROR
-   |                                         ^^ borrowed value does not live long enough
+   |                               ----------^^-
+   |                               |         |
+   |                               |         borrowed value does not live long enough
+   |                               argument requires that `c` is borrowed for `'static`
 ...
 LL | }
    | - `c` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-nullary-enums.rs:52:41
    |
+LL | fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
+   |                                   -- lifetime `'a` defined here
+...
 LL |         SomeEnum::SomeVariant(Cell::new(&c)), //~ ERROR
-   |                                         ^^ borrowed value does not live long enough
+   |                               ----------^^-
+   |                               |         |
+   |                               |         borrowed value does not live long enough
+   |                               argument requires that `c` is borrowed for `'a`
 ...
 LL | }
    | - `c` dropped here while still borrowed
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 49:35...
-  --> $DIR/adt-nullary-enums.rs:49:35
-   |
-LL | fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
-   |                                   ^^
 
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-nullary-enums.rs:65:45
    |
+LL | fn annot_reference_named_lifetime_in_closure<'a>(_: &'a u32) {
+   |                                              -- lifetime `'a` defined here
+...
 LL |             SomeEnum::SomeVariant(Cell::new(&c)), //~ ERROR
-   |                                             ^^ borrowed value does not live long enough
+   |                                   ----------^^-
+   |                                   |         |
+   |                                   |         borrowed value does not live long enough
+   |                                   argument requires that `c` is borrowed for `'a`
 ...
 LL |     };
    |     - `c` dropped here while still borrowed
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 61:46...
-  --> $DIR/adt-nullary-enums.rs:61:46
-   |
-LL | fn annot_reference_named_lifetime_in_closure<'a>(_: &'a u32) {
-   |                                              ^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/nll/user-annotations/adt-tuple-enums.stderr
+++ b/src/test/ui/nll/user-annotations/adt-tuple-enums.stderr
@@ -2,39 +2,40 @@ error[E0597]: `c` does not live long enough
   --> $DIR/adt-tuple-enums.rs:39:43
    |
 LL |     SomeEnum::SomeVariant::<&'static u32>(&c); //~ ERROR
-   |                                           ^^ borrowed value does not live long enough
+   |                                           ^^
+   |                                           |
+   |                                           borrowed value does not live long enough
+   |                                           requires that `c` is borrowed for `'static`
 LL | }
    | - `c` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-tuple-enums.rs:44:38
    |
+LL | fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
+   |                                   -- lifetime `'a` defined here
+LL |     let c = 66;
 LL |     SomeEnum::SomeVariant::<&'a u32>(&c); //~ ERROR
-   |                                      ^^ borrowed value does not live long enough
+   |                                      ^^
+   |                                      |
+   |                                      borrowed value does not live long enough
+   |                                      requires that `c` is borrowed for `'a`
 LL | }
    | - `c` dropped here while still borrowed
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 42:35...
-  --> $DIR/adt-tuple-enums.rs:42:35
-   |
-LL | fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
-   |                                   ^^
 
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-tuple-enums.rs:54:42
    |
+LL | fn annot_reference_named_lifetime_in_closure<'a>(_: &'a u32) {
+   |                                              -- lifetime `'a` defined here
+...
 LL |         SomeEnum::SomeVariant::<&'a u32>(&c); //~ ERROR
-   |                                          ^^ borrowed value does not live long enough
+   |                                          ^^
+   |                                          |
+   |                                          borrowed value does not live long enough
+   |                                          requires that `c` is borrowed for `'a`
 LL |     };
    |     - `c` dropped here while still borrowed
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 51:46...
-  --> $DIR/adt-tuple-enums.rs:51:46
-   |
-LL | fn annot_reference_named_lifetime_in_closure<'a>(_: &'a u32) {
-   |                                              ^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/nll/user-annotations/adt-tuple-struct.stderr
+++ b/src/test/ui/nll/user-annotations/adt-tuple-struct.stderr
@@ -2,39 +2,40 @@ error[E0597]: `c` does not live long enough
   --> $DIR/adt-tuple-struct.rs:35:32
    |
 LL |     SomeStruct::<&'static u32>(&c); //~ ERROR
-   |                                ^^ borrowed value does not live long enough
+   |                                ^^
+   |                                |
+   |                                borrowed value does not live long enough
+   |                                requires that `c` is borrowed for `'static`
 LL | }
    | - `c` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-tuple-struct.rs:40:27
    |
+LL | fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
+   |                                   -- lifetime `'a` defined here
+LL |     let c = 66;
 LL |     SomeStruct::<&'a u32>(&c); //~ ERROR
-   |                           ^^ borrowed value does not live long enough
+   |                           ^^
+   |                           |
+   |                           borrowed value does not live long enough
+   |                           requires that `c` is borrowed for `'a`
 LL | }
    | - `c` dropped here while still borrowed
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 38:35...
-  --> $DIR/adt-tuple-struct.rs:38:35
-   |
-LL | fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
-   |                                   ^^
 
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-tuple-struct.rs:50:31
    |
+LL | fn annot_reference_named_lifetime_in_closure<'a>(_: &'a u32) {
+   |                                              -- lifetime `'a` defined here
+...
 LL |         SomeStruct::<&'a u32>(&c); //~ ERROR
-   |                               ^^ borrowed value does not live long enough
+   |                               ^^
+   |                               |
+   |                               borrowed value does not live long enough
+   |                               requires that `c` is borrowed for `'a`
 LL |     };
    |     - `c` dropped here while still borrowed
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 47:46...
-  --> $DIR/adt-tuple-struct.rs:47:46
-   |
-LL | fn annot_reference_named_lifetime_in_closure<'a>(_: &'a u32) {
-   |                                              ^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/nll/user-annotations/cast_static_lifetime.stderr
+++ b/src/test/ui/nll/user-annotations/cast_static_lifetime.stderr
@@ -2,11 +2,12 @@ error[E0597]: `x` does not live long enough
   --> $DIR/cast_static_lifetime.rs:16:19
    |
 LL |     let y: &u32 = (&x) as &'static u32;
-   |                   ^^^^ borrowed value does not live long enough
+   |                   ^^^^----------------
+   |                   |
+   |                   borrowed value does not live long enough
+   |                   type annotation requires that `x` is borrowed for `'static`
 LL | }
    | - `x` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/user-annotations/fns.stderr
+++ b/src/test/ui/nll/user-annotations/fns.stderr
@@ -2,39 +2,40 @@ error[E0597]: `c` does not live long enough
   --> $DIR/fns.rs:35:29
    |
 LL |     some_fn::<&'static u32>(&c); //~ ERROR
-   |                             ^^ borrowed value does not live long enough
+   |     ------------------------^^-
+   |     |                       |
+   |     |                       borrowed value does not live long enough
+   |     argument requires that `c` is borrowed for `'static`
 LL | }
    | - `c` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0597]: `c` does not live long enough
   --> $DIR/fns.rs:40:24
    |
+LL | fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
+   |                                   -- lifetime `'a` defined here
+LL |     let c = 66;
 LL |     some_fn::<&'a u32>(&c); //~ ERROR
-   |                        ^^ borrowed value does not live long enough
+   |     -------------------^^-
+   |     |                  |
+   |     |                  borrowed value does not live long enough
+   |     argument requires that `c` is borrowed for `'a`
 LL | }
    | - `c` dropped here while still borrowed
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 38:35...
-  --> $DIR/fns.rs:38:35
-   |
-LL | fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
-   |                                   ^^
 
 error[E0597]: `c` does not live long enough
   --> $DIR/fns.rs:50:28
    |
+LL | fn annot_reference_named_lifetime_in_closure<'a>(_: &'a u32) {
+   |                                              -- lifetime `'a` defined here
+...
 LL |         some_fn::<&'a u32>(&c); //~ ERROR
-   |                            ^^ borrowed value does not live long enough
+   |         -------------------^^-
+   |         |                  |
+   |         |                  borrowed value does not live long enough
+   |         argument requires that `c` is borrowed for `'a`
 LL |     };
    |     - `c` dropped here while still borrowed
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 47:46...
-  --> $DIR/fns.rs:47:46
-   |
-LL | fn annot_reference_named_lifetime_in_closure<'a>(_: &'a u32) {
-   |                                              ^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/nll/user-annotations/method-call.stderr
+++ b/src/test/ui/nll/user-annotations/method-call.stderr
@@ -2,39 +2,40 @@ error[E0597]: `c` does not live long enough
   --> $DIR/method-call.rs:48:34
    |
 LL |     a.method::<&'static u32>(b,  &c); //~ ERROR
-   |                                  ^^ borrowed value does not live long enough
+   |     -----------------------------^^-
+   |     |                            |
+   |     |                            borrowed value does not live long enough
+   |     argument requires that `c` is borrowed for `'static`
 LL | }
    | - `c` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0597]: `c` does not live long enough
   --> $DIR/method-call.rs:55:29
    |
+LL | fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
+   |                                   -- lifetime `'a` defined here
+...
 LL |     a.method::<&'a u32>(b,  &c); //~ ERROR
-   |                             ^^ borrowed value does not live long enough
+   |     ------------------------^^-
+   |     |                       |
+   |     |                       borrowed value does not live long enough
+   |     argument requires that `c` is borrowed for `'a`
 LL | }
    | - `c` dropped here while still borrowed
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 51:35...
-  --> $DIR/method-call.rs:51:35
-   |
-LL | fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
-   |                                   ^^
 
 error[E0597]: `c` does not live long enough
   --> $DIR/method-call.rs:69:33
    |
+LL | fn annot_reference_named_lifetime_in_closure<'a>(_: &'a u32) {
+   |                                              -- lifetime `'a` defined here
+...
 LL |         a.method::<&'a u32>(b,  &c); //~ ERROR
-   |                                 ^^ borrowed value does not live long enough
+   |         ------------------------^^-
+   |         |                       |
+   |         |                       borrowed value does not live long enough
+   |         argument requires that `c` is borrowed for `'a`
 LL |     };
    |     - `c` dropped here while still borrowed
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 64:46...
-  --> $DIR/method-call.rs:64:46
-   |
-LL | fn annot_reference_named_lifetime_in_closure<'a>(_: &'a u32) {
-   |                                              ^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/nll/user-annotations/method-ufcs-1.stderr
+++ b/src/test/ui/nll/user-annotations/method-ufcs-1.stderr
@@ -2,43 +2,44 @@ error[E0597]: `a` does not live long enough
   --> $DIR/method-ufcs-1.rs:42:7
    |
 LL |     x(&a, b, c); //~ ERROR
-   |       ^^ borrowed value does not live long enough
+   |     --^^-------
+   |     | |
+   |     | borrowed value does not live long enough
+   |     argument requires that `a` is borrowed for `'static`
 LL | }
    | - `a` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0597]: `a` does not live long enough
   --> $DIR/method-ufcs-1.rs:49:36
    |
+LL | fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
+   |                                   -- lifetime `'a` defined here
+...
 LL |     <&'a u32 as Bazoom<_>>::method(&a, b, c); //~ ERROR
-   |                                    ^^ borrowed value does not live long enough
+   |     -------------------------------^^-------
+   |     |                              |
+   |     |                              borrowed value does not live long enough
+   |     argument requires that `a` is borrowed for `'a`
 LL | }
    | - `a` dropped here while still borrowed
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 45:35...
-  --> $DIR/method-ufcs-1.rs:45:35
-   |
-LL | fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
-   |                                   ^^
 
 error[E0597]: `a` does not live long enough
   --> $DIR/method-ufcs-1.rs:63:41
    |
+LL | fn annot_reference_named_lifetime_in_closure<'a>(_: &'a u32) {
+   |                                              -- lifetime `'a` defined here
+...
 LL |     let _closure = || {
    |                    -- value captured here
 LL |         let c = 66;
 LL |         <&'a u32 as Bazoom<_>>::method(&a, b, c); //~ ERROR
-   |                                         ^ borrowed value does not live long enough
+   |         --------------------------------^-------
+   |         |                               |
+   |         |                               borrowed value does not live long enough
+   |         argument requires that `a` is borrowed for `'a`
 LL |     };
 LL | }
    | - `a` dropped here while still borrowed
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 58:46...
-  --> $DIR/method-ufcs-1.rs:58:46
-   |
-LL | fn annot_reference_named_lifetime_in_closure<'a>(_: &'a u32) {
-   |                                              ^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/nll/user-annotations/method-ufcs-2.stderr
+++ b/src/test/ui/nll/user-annotations/method-ufcs-2.stderr
@@ -2,43 +2,44 @@ error[E0597]: `a` does not live long enough
   --> $DIR/method-ufcs-2.rs:42:7
    |
 LL |     x(&a, b, c); //~ ERROR
-   |       ^^ borrowed value does not live long enough
+   |     --^^-------
+   |     | |
+   |     | borrowed value does not live long enough
+   |     argument requires that `a` is borrowed for `'static`
 LL | }
    | - `a` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0597]: `b` does not live long enough
   --> $DIR/method-ufcs-2.rs:49:39
    |
+LL | fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
+   |                                   -- lifetime `'a` defined here
+...
 LL |     <_ as Bazoom<&'a u32>>::method(a, &b, c); //~ ERROR
-   |                                       ^^ borrowed value does not live long enough
+   |     ----------------------------------^^----
+   |     |                                 |
+   |     |                                 borrowed value does not live long enough
+   |     argument requires that `b` is borrowed for `'a`
 LL | }
    | - `b` dropped here while still borrowed
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 45:35...
-  --> $DIR/method-ufcs-2.rs:45:35
-   |
-LL | fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
-   |                                   ^^
 
 error[E0597]: `b` does not live long enough
   --> $DIR/method-ufcs-2.rs:63:44
    |
+LL | fn annot_reference_named_lifetime_in_closure<'a>(_: &'a u32) {
+   |                                              -- lifetime `'a` defined here
+...
 LL |     let _closure = || {
    |                    -- value captured here
 LL |         let c = 66;
 LL |         <_ as Bazoom<&'a u32>>::method(a, &b, c); //~ ERROR
-   |                                            ^ borrowed value does not live long enough
+   |         -----------------------------------^----
+   |         |                                  |
+   |         |                                  borrowed value does not live long enough
+   |         argument requires that `b` is borrowed for `'a`
 LL |     };
 LL | }
    | - `b` dropped here while still borrowed
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 58:46...
-  --> $DIR/method-ufcs-2.rs:58:46
-   |
-LL | fn annot_reference_named_lifetime_in_closure<'a>(_: &'a u32) {
-   |                                              ^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/nll/user-annotations/method-ufcs-3.stderr
+++ b/src/test/ui/nll/user-annotations/method-ufcs-3.stderr
@@ -2,39 +2,40 @@ error[E0597]: `c` does not live long enough
   --> $DIR/method-ufcs-3.rs:48:53
    |
 LL |     <_ as Bazoom<_>>::method::<&'static u32>(&a, b, &c); //~ ERROR
-   |                                                     ^^ borrowed value does not live long enough
+   |     ------------------------------------------------^^-
+   |     |                                               |
+   |     |                                               borrowed value does not live long enough
+   |     argument requires that `c` is borrowed for `'static`
 LL | }
    | - `c` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0597]: `c` does not live long enough
   --> $DIR/method-ufcs-3.rs:55:48
    |
+LL | fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
+   |                                   -- lifetime `'a` defined here
+...
 LL |     <_ as Bazoom<_>>::method::<&'a u32>(&a, b, &c); //~ ERROR
-   |                                                ^^ borrowed value does not live long enough
+   |     -------------------------------------------^^-
+   |     |                                          |
+   |     |                                          borrowed value does not live long enough
+   |     argument requires that `c` is borrowed for `'a`
 LL | }
    | - `c` dropped here while still borrowed
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 51:35...
-  --> $DIR/method-ufcs-3.rs:51:35
-   |
-LL | fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
-   |                                   ^^
 
 error[E0597]: `c` does not live long enough
   --> $DIR/method-ufcs-3.rs:69:52
    |
+LL | fn annot_reference_named_lifetime_in_closure<'a>(_: &'a u32) {
+   |                                              -- lifetime `'a` defined here
+...
 LL |         <_ as Bazoom<_>>::method::<&'a u32>(&a, b, &c); //~ ERROR
-   |                                                    ^^ borrowed value does not live long enough
+   |         -------------------------------------------^^-
+   |         |                                          |
+   |         |                                          borrowed value does not live long enough
+   |         argument requires that `c` is borrowed for `'a`
 LL |     };
    |     - `c` dropped here while still borrowed
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 64:46...
-  --> $DIR/method-ufcs-3.rs:64:46
-   |
-LL | fn annot_reference_named_lifetime_in_closure<'a>(_: &'a u32) {
-   |                                              ^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/nll/user-annotations/method-ufcs-inherent-1.stderr
+++ b/src/test/ui/nll/user-annotations/method-ufcs-inherent-1.stderr
@@ -1,17 +1,17 @@
 error[E0597]: `v` does not live long enough
   --> $DIR/method-ufcs-inherent-1.rs:16:26
    |
+LL | fn foo<'a>() {
+   |        -- lifetime `'a` defined here
+LL |     let v = 22;
 LL |     let x = A::<'a>::new(&v, 22);
-   |                          ^^ borrowed value does not live long enough
+   |             -------------^^-----
+   |             |            |
+   |             |            borrowed value does not live long enough
+   |             argument requires that `v` is borrowed for `'a`
 LL |     //~^ ERROR
 LL | }
    | - `v` dropped here while still borrowed
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 14:8...
-  --> $DIR/method-ufcs-inherent-1.rs:14:8
-   |
-LL | fn foo<'a>() {
-   |        ^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/user-annotations/method-ufcs-inherent-2.stderr
+++ b/src/test/ui/nll/user-annotations/method-ufcs-inherent-2.stderr
@@ -1,32 +1,32 @@
 error[E0597]: `v` does not live long enough
   --> $DIR/method-ufcs-inherent-2.rs:16:37
    |
+LL | fn foo<'a>() {
+   |        -- lifetime `'a` defined here
+LL |     let v = 22;
 LL |     let x = A::<'a>::new::<&'a u32>(&v, &v);
-   |                                     ^^ borrowed value does not live long enough
+   |             ------------------------^^-----
+   |             |                       |
+   |             |                       borrowed value does not live long enough
+   |             argument requires that `v` is borrowed for `'a`
 ...
 LL | }
    | - `v` dropped here while still borrowed
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 14:8...
-  --> $DIR/method-ufcs-inherent-2.rs:14:8
-   |
-LL | fn foo<'a>() {
-   |        ^^
 
 error[E0597]: `v` does not live long enough
   --> $DIR/method-ufcs-inherent-2.rs:16:41
    |
+LL | fn foo<'a>() {
+   |        -- lifetime `'a` defined here
+LL |     let v = 22;
 LL |     let x = A::<'a>::new::<&'a u32>(&v, &v);
-   |                                         ^^ borrowed value does not live long enough
+   |             ----------------------------^^-
+   |             |                           |
+   |             |                           borrowed value does not live long enough
+   |             argument requires that `v` is borrowed for `'a`
 ...
 LL | }
    | - `v` dropped here while still borrowed
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 14:8...
-  --> $DIR/method-ufcs-inherent-2.rs:14:8
-   |
-LL | fn foo<'a>() {
-   |        ^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/nll/user-annotations/method-ufcs-inherent-3.stderr
+++ b/src/test/ui/nll/user-annotations/method-ufcs-inherent-3.stderr
@@ -1,17 +1,17 @@
 error[E0597]: `v` does not live long enough
   --> $DIR/method-ufcs-inherent-3.rs:16:26
    |
+LL | fn foo<'a>() {
+   |        -- lifetime `'a` defined here
+LL |     let v = 22;
 LL |     let x = <A<'a>>::new(&v, 22);
-   |                          ^^ borrowed value does not live long enough
+   |             -------------^^-----
+   |             |            |
+   |             |            borrowed value does not live long enough
+   |             argument requires that `v` is borrowed for `'a`
 LL |     //~^ ERROR
 LL | }
    | - `v` dropped here while still borrowed
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 14:8...
-  --> $DIR/method-ufcs-inherent-3.rs:14:8
-   |
-LL | fn foo<'a>() {
-   |        ^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/user-annotations/method-ufcs-inherent-4.stderr
+++ b/src/test/ui/nll/user-annotations/method-ufcs-inherent-4.stderr
@@ -1,32 +1,32 @@
 error[E0597]: `v` does not live long enough
   --> $DIR/method-ufcs-inherent-4.rs:17:37
    |
+LL | fn foo<'a>() {
+   |        -- lifetime `'a` defined here
+LL |     let v = 22;
 LL |     let x = <A<'a>>::new::<&'a u32>(&v, &v);
-   |                                     ^^ borrowed value does not live long enough
+   |             ------------------------^^-----
+   |             |                       |
+   |             |                       borrowed value does not live long enough
+   |             argument requires that `v` is borrowed for `'a`
 ...
 LL | }
    | - `v` dropped here while still borrowed
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 15:8...
-  --> $DIR/method-ufcs-inherent-4.rs:15:8
-   |
-LL | fn foo<'a>() {
-   |        ^^
 
 error[E0597]: `v` does not live long enough
   --> $DIR/method-ufcs-inherent-4.rs:17:41
    |
+LL | fn foo<'a>() {
+   |        -- lifetime `'a` defined here
+LL |     let v = 22;
 LL |     let x = <A<'a>>::new::<&'a u32>(&v, &v);
-   |                                         ^^ borrowed value does not live long enough
+   |             ----------------------------^^-
+   |             |                           |
+   |             |                           borrowed value does not live long enough
+   |             argument requires that `v` is borrowed for `'a`
 ...
 LL | }
    | - `v` dropped here while still borrowed
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 15:8...
-  --> $DIR/method-ufcs-inherent-4.rs:15:8
-   |
-LL | fn foo<'a>() {
-   |        ^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/nll/user-annotations/normalization.stderr
+++ b/src/test/ui/nll/user-annotations/normalization.stderr
@@ -2,11 +2,11 @@ error[E0597]: `a` does not live long enough
   --> $DIR/normalization.rs:12:31
    |
 LL |     let b: <() as Foo>::Out = &a; //~ ERROR
-   |                               ^^ borrowed value does not live long enough
+   |            ----------------   ^^ borrowed value does not live long enough
+   |            |
+   |            type annotation requires that `a` is borrowed for `'static`
 LL | }
    | - `a` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/user-annotations/pattern_substs_on_brace_enum_variant.stderr
+++ b/src/test/ui/nll/user-annotations/pattern_substs_on_brace_enum_variant.stderr
@@ -3,11 +3,11 @@ error[E0597]: `y` does not live long enough
    |
 LL |     let foo = Foo::Bar { field: &y };
    |                                 ^^ borrowed value does not live long enough
-...
+LL |     //~^ ERROR `y` does not live long enough
+LL |     let Foo::Bar::<'static> { field: _z } = foo;
+   |         --------------------------------- type annotation requires that `y` is borrowed for `'static`
 LL | }
    | - `y` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0597]: `y` does not live long enough
   --> $DIR/pattern_substs_on_brace_enum_variant.rs:16:33
@@ -15,10 +15,11 @@ error[E0597]: `y` does not live long enough
 LL |     let foo = Foo::Bar { field: &y };
    |                                 ^^ borrowed value does not live long enough
 ...
+LL |         Foo::Bar::<'static> { field: _z } => {
+   |         --------------------------------- type annotation requires that `y` is borrowed for `'static`
+...
 LL | }
    | - `y` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/nll/user-annotations/pattern_substs_on_brace_struct.stderr
+++ b/src/test/ui/nll/user-annotations/pattern_substs_on_brace_struct.stderr
@@ -3,11 +3,11 @@ error[E0597]: `y` does not live long enough
    |
 LL |     let foo = Foo { field: &y };
    |                            ^^ borrowed value does not live long enough
-...
+LL |     //~^ ERROR `y` does not live long enough
+LL |     let Foo::<'static> { field: _z } = foo;
+   |         ---------------------------- type annotation requires that `y` is borrowed for `'static`
 LL | }
    | - `y` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0597]: `y` does not live long enough
   --> $DIR/pattern_substs_on_brace_struct.rs:14:28
@@ -15,10 +15,11 @@ error[E0597]: `y` does not live long enough
 LL |     let foo = Foo { field: &y };
    |                            ^^ borrowed value does not live long enough
 ...
+LL |         Foo::<'static> { field: _z } => {
+   |         ---------------------------- type annotation requires that `y` is borrowed for `'static`
+...
 LL | }
    | - `y` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/nll/user-annotations/pattern_substs_on_tuple_enum_variant.stderr
+++ b/src/test/ui/nll/user-annotations/pattern_substs_on_tuple_enum_variant.stderr
@@ -3,11 +3,11 @@ error[E0597]: `y` does not live long enough
    |
 LL |     let foo = Foo::Bar(&y);
    |                        ^^ borrowed value does not live long enough
-...
+LL |     //~^ ERROR `y` does not live long enough
+LL |     let Foo::Bar::<'static>(_z) = foo;
+   |         ----------------------- type annotation requires that `y` is borrowed for `'static`
 LL | }
    | - `y` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0597]: `y` does not live long enough
   --> $DIR/pattern_substs_on_tuple_enum_variant.rs:16:24
@@ -15,10 +15,11 @@ error[E0597]: `y` does not live long enough
 LL |     let foo = Foo::Bar(&y);
    |                        ^^ borrowed value does not live long enough
 ...
+LL |         Foo::Bar::<'static>(_z) => {
+   |         ----------------------- type annotation requires that `y` is borrowed for `'static`
+...
 LL | }
    | - `y` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/nll/user-annotations/pattern_substs_on_tuple_struct.stderr
+++ b/src/test/ui/nll/user-annotations/pattern_substs_on_tuple_struct.stderr
@@ -3,11 +3,11 @@ error[E0597]: `y` does not live long enough
    |
 LL |     let foo = Foo(&y);
    |                   ^^ borrowed value does not live long enough
-...
+LL |     //~^ ERROR `y` does not live long enough
+LL |     let Foo::<'static>(_z) = foo;
+   |         ------------------ type annotation requires that `y` is borrowed for `'static`
 LL | }
    | - `y` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0597]: `y` does not live long enough
   --> $DIR/pattern_substs_on_tuple_struct.rs:14:19
@@ -15,10 +15,11 @@ error[E0597]: `y` does not live long enough
 LL |     let foo = Foo(&y);
    |                   ^^ borrowed value does not live long enough
 ...
+LL |         Foo::<'static>(_z) => {
+   |         ------------------ type annotation requires that `y` is borrowed for `'static`
+...
 LL | }
    | - `y` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/nll/user-annotations/patterns.stderr
+++ b/src/test/ui/nll/user-annotations/patterns.stderr
@@ -1,125 +1,122 @@
 error[E0597]: `x` does not live long enough
   --> $DIR/patterns.rs:8:9
    |
+LL |     let y: &'static u32;
+   |            ------------ type annotation requires that `x` is borrowed for `'static`
 LL |     y = &x; //~ ERROR
    |         ^^ borrowed value does not live long enough
 LL | }
    | - `x` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0597]: `x` does not live long enough
   --> $DIR/patterns.rs:22:13
    |
 LL |     let y = &x; //~ ERROR
    |             ^^ borrowed value does not live long enough
-...
+LL |     let ref z: &'static u32 = y;
+   |                ------------ type annotation requires that `x` is borrowed for `'static`
+LL |     **z
 LL | }
    | - `x` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0597]: `x` does not live long enough
   --> $DIR/patterns.rs:46:27
    |
 LL |     let y: &'static u32 = &x; //~ ERROR
-   |                           ^^ borrowed value does not live long enough
+   |            ------------   ^^ borrowed value does not live long enough
+   |            |
+   |            type annotation requires that `x` is borrowed for `'static`
 LL | }
    | - `x` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0597]: `x` does not live long enough
   --> $DIR/patterns.rs:51:27
    |
 LL |     let _: &'static u32 = &x; //~ ERROR
-   |                           ^^ borrowed value does not live long enough
+   |            ------------   ^^ borrowed value does not live long enough
+   |            |
+   |            type annotation requires that `x` is borrowed for `'static`
 ...
 LL | }
    | - `x` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/patterns.rs:53:41
    |
 LL |     let _: Vec<&'static String> = vec![&String::new()];
-   |                                         ^^^^^^^^^^^^^ - temporary value is freed at the end of this statement
-   |                                         |
-   |                                         creates a temporary which is freed while still in use
-   |
-   = note: borrowed value must be valid for the static lifetime...
+   |            --------------------         ^^^^^^^^^^^^^ - temporary value is freed at the end of this statement
+   |            |                            |
+   |            |                            creates a temporary which is freed while still in use
+   |            type annotation requires that borrow lasts for `'static`
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/patterns.rs:56:52
    |
 LL |     let (_, a): (Vec<&'static String>, _) = (vec![&String::new()], 44);
-   |                                                    ^^^^^^^^^^^^^      - temporary value is freed at the end of this statement
-   |                                                    |
-   |                                                    creates a temporary which is freed while still in use
-   |
-   = note: borrowed value must be valid for the static lifetime...
+   |                 -------------------------          ^^^^^^^^^^^^^      - temporary value is freed at the end of this statement
+   |                 |                                  |
+   |                 |                                  creates a temporary which is freed while still in use
+   |                 type annotation requires that borrow lasts for `'static`
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/patterns.rs:59:53
    |
 LL |     let (_a, b): (Vec<&'static String>, _) = (vec![&String::new()], 44);
-   |                                                     ^^^^^^^^^^^^^      - temporary value is freed at the end of this statement
-   |                                                     |
-   |                                                     creates a temporary which is freed while still in use
-   |
-   = note: borrowed value must be valid for the static lifetime...
+   |                  -------------------------          ^^^^^^^^^^^^^      - temporary value is freed at the end of this statement
+   |                  |                                  |
+   |                  |                                  creates a temporary which is freed while still in use
+   |                  type annotation requires that borrow lasts for `'static`
 
 error[E0597]: `x` does not live long enough
   --> $DIR/patterns.rs:65:40
    |
 LL |     let (_, _): (&'static u32, u32) = (&x, 44); //~ ERROR
-   |                                        ^^ borrowed value does not live long enough
+   |                 -------------------    ^^ borrowed value does not live long enough
+   |                 |
+   |                 type annotation requires that `x` is borrowed for `'static`
 LL | }
    | - `x` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0597]: `x` does not live long enough
   --> $DIR/patterns.rs:70:40
    |
 LL |     let (y, _): (&'static u32, u32) = (&x, 44); //~ ERROR
-   |                                        ^^ borrowed value does not live long enough
+   |                 -------------------    ^^ borrowed value does not live long enough
+   |                 |
+   |                 type annotation requires that `x` is borrowed for `'static`
 LL | }
    | - `x` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0597]: `x` does not live long enough
   --> $DIR/patterns.rs:75:69
    |
 LL |     let Single { value: y }: Single<&'static u32> = Single { value: &x }; //~ ERROR
-   |                                                                     ^^ borrowed value does not live long enough
+   |                              --------------------                   ^^ borrowed value does not live long enough
+   |                              |
+   |                              type annotation requires that `x` is borrowed for `'static`
 LL | }
    | - `x` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0597]: `x` does not live long enough
   --> $DIR/patterns.rs:80:69
    |
 LL |     let Single { value: _ }: Single<&'static u32> = Single { value: &x }; //~ ERROR
-   |                                                                     ^^ borrowed value does not live long enough
+   |                              --------------------                   ^^ borrowed value does not live long enough
+   |                              |
+   |                              type annotation requires that `x` is borrowed for `'static`
 LL | }
    | - `x` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0597]: `x` does not live long enough
   --> $DIR/patterns.rs:88:17
    |
+LL |     let Double { value1: _, value2: _ }: Double<&'static u32> = Double {
+   |                                          -------------------- type annotation requires that `x` is borrowed for `'static`
 LL |         value1: &x, //~ ERROR
    |                 ^^ borrowed value does not live long enough
 ...
 LL | }
    | - `x` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error: unsatisfied lifetime constraints
   --> $DIR/patterns.rs:101:5

--- a/src/test/ui/nll/user-annotations/type_ascription_static_lifetime.stderr
+++ b/src/test/ui/nll/user-annotations/type_ascription_static_lifetime.stderr
@@ -2,11 +2,12 @@ error[E0597]: `x` does not live long enough
   --> $DIR/type_ascription_static_lifetime.rs:18:19
    |
 LL |     let y: &u32 = &x: &'static u32; //~ ERROR E0597
-   |                   ^^ borrowed value does not live long enough
+   |                   ^^--------------
+   |                   |
+   |                   borrowed value does not live long enough
+   |                   type annotation requires that `x` is borrowed for `'static`
 LL | }
    | - `x` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/where_clauses_in_functions.stderr
+++ b/src/test/ui/nll/where_clauses_in_functions.stderr
@@ -6,7 +6,7 @@ LL | fn bar<'a, 'b>(x: &'a u32, y: &'b u32) -> (&'a u32, &'b u32) {
    |        |
    |        lifetime `'a` defined here
 LL |     foo(x, y)
-   |     ^^^^^^^^^ argument requires that `'a` must outlive `'b`
+   |     ^^^^^^^^^ function was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/region-borrow-params-issue-29793-big.ast.nll.stderr
+++ b/src/test/ui/regions/region-borrow-params-issue-29793-big.ast.nll.stderr
@@ -1,25 +1,39 @@
-error[E0597]: `x` does not live long enough
-  --> $DIR/region-borrow-params-issue-29793-big.rs:81:43
+error[E0373]: closure may outlive the current function, but it borrows `x`, which is owned by the current function
+  --> $DIR/region-borrow-params-issue-29793-big.rs:81:26
    |
 LL |         WrapB::new().set(|t: bool| if t { x } else { y }) // (separate errors for `x` vs `y`)
-   |                          ---------        ^ borrowed value does not live long enough
+   |                          ^^^^^^^^^        - `x` is borrowed here
    |                          |
-   |                          value captured here
-...
-LL |     });
-   |     - `x` dropped here while still borrowed
+   |                          may outlive borrowed value `x`
+   |
+note: closure is returned here
+  --> $DIR/region-borrow-params-issue-29793-big.rs:81:9
+   |
+LL |         WrapB::new().set(|t: bool| if t { x } else { y }) // (separate errors for `x` vs `y`)
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: to force the closure to take ownership of `x` (and any other referenced variables), use the `move` keyword
+   |
+LL |         WrapB::new().set(move |t: bool| if t { x } else { y }) // (separate errors for `x` vs `y`)
+   |                          ^^^^^^^^^^^^^^
 
-error[E0597]: `y` does not live long enough
-  --> $DIR/region-borrow-params-issue-29793-big.rs:81:54
+error[E0373]: closure may outlive the current function, but it borrows `y`, which is owned by the current function
+  --> $DIR/region-borrow-params-issue-29793-big.rs:81:26
    |
 LL |         WrapB::new().set(|t: bool| if t { x } else { y }) // (separate errors for `x` vs `y`)
-   |                          ---------                   ^ borrowed value does not live long enough
+   |                          ^^^^^^^^^                   - `y` is borrowed here
    |                          |
-   |                          value captured here
-...
-LL |     });
-   |     - `y` dropped here while still borrowed
+   |                          may outlive borrowed value `y`
+   |
+note: closure is returned here
+  --> $DIR/region-borrow-params-issue-29793-big.rs:81:9
+   |
+LL |         WrapB::new().set(|t: bool| if t { x } else { y }) // (separate errors for `x` vs `y`)
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: to force the closure to take ownership of `y` (and any other referenced variables), use the `move` keyword
+   |
+LL |         WrapB::new().set(move |t: bool| if t { x } else { y }) // (separate errors for `x` vs `y`)
+   |                          ^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0597`.
+For more information about this error, try `rustc --explain E0373`.

--- a/src/test/ui/regions/region-borrow-params-issue-29793-big.mir.stderr
+++ b/src/test/ui/regions/region-borrow-params-issue-29793-big.mir.stderr
@@ -1,25 +1,39 @@
-error[E0597]: `x` does not live long enough
-  --> $DIR/region-borrow-params-issue-29793-big.rs:81:43
+error[E0373]: closure may outlive the current function, but it borrows `x`, which is owned by the current function
+  --> $DIR/region-borrow-params-issue-29793-big.rs:81:26
    |
 LL |         WrapB::new().set(|t: bool| if t { x } else { y }) // (separate errors for `x` vs `y`)
-   |                          ---------        ^ borrowed value does not live long enough
+   |                          ^^^^^^^^^        - `x` is borrowed here
    |                          |
-   |                          value captured here
-...
-LL |     });
-   |     - `x` dropped here while still borrowed
+   |                          may outlive borrowed value `x`
+   |
+note: closure is returned here
+  --> $DIR/region-borrow-params-issue-29793-big.rs:81:9
+   |
+LL |         WrapB::new().set(|t: bool| if t { x } else { y }) // (separate errors for `x` vs `y`)
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: to force the closure to take ownership of `x` (and any other referenced variables), use the `move` keyword
+   |
+LL |         WrapB::new().set(move |t: bool| if t { x } else { y }) // (separate errors for `x` vs `y`)
+   |                          ^^^^^^^^^^^^^^
 
-error[E0597]: `y` does not live long enough
-  --> $DIR/region-borrow-params-issue-29793-big.rs:81:54
+error[E0373]: closure may outlive the current function, but it borrows `y`, which is owned by the current function
+  --> $DIR/region-borrow-params-issue-29793-big.rs:81:26
    |
 LL |         WrapB::new().set(|t: bool| if t { x } else { y }) // (separate errors for `x` vs `y`)
-   |                          ---------                   ^ borrowed value does not live long enough
+   |                          ^^^^^^^^^                   - `y` is borrowed here
    |                          |
-   |                          value captured here
-...
-LL |     });
-   |     - `y` dropped here while still borrowed
+   |                          may outlive borrowed value `y`
+   |
+note: closure is returned here
+  --> $DIR/region-borrow-params-issue-29793-big.rs:81:9
+   |
+LL |         WrapB::new().set(|t: bool| if t { x } else { y }) // (separate errors for `x` vs `y`)
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: to force the closure to take ownership of `y` (and any other referenced variables), use the `move` keyword
+   |
+LL |         WrapB::new().set(move |t: bool| if t { x } else { y }) // (separate errors for `x` vs `y`)
+   |                          ^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0597`.
+For more information about this error, try `rustc --explain E0373`.

--- a/src/test/ui/regions/region-borrow-params-issue-29793-big.rs
+++ b/src/test/ui/regions/region-borrow-params-issue-29793-big.rs
@@ -81,8 +81,8 @@ fn main() {
         WrapB::new().set(|t: bool| if t { x } else { y }) // (separate errors for `x` vs `y`)
             //[ast]~^ ERROR `x` does not live long enough
             //[ast]~| ERROR `y` does not live long enough
-            //[mir]~^^^ ERROR `x` does not live long enough
-            //[mir]~| ERROR `y` does not live long enough
+            //[mir]~^^^ ERROR closure may outlive the current function
+            //[mir]~| ERROR closure may outlive the current function
     });
 
     w.handle(); // This works

--- a/src/test/ui/regions/region-borrow-params-issue-29793-small.nll.stderr
+++ b/src/test/ui/regions/region-borrow-params-issue-29793-small.nll.stderr
@@ -1,319 +1,363 @@
-error[E0597]: `x` does not live long enough
-  --> $DIR/region-borrow-params-issue-29793-small.rs:19:34
+error[E0373]: closure may outlive the current function, but it borrows `x`, which is owned by the current function
+  --> $DIR/region-borrow-params-issue-29793-small.rs:19:17
    |
 LL |         let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
-   |                 ---------        ^ borrowed value does not live long enough
+   |                 ^^^^^^^^^        - `x` is borrowed here
    |                 |
-   |                 value captured here
-...
-LL |     };
-   |      - `x` dropped here while still borrowed
+   |                 may outlive borrowed value `x`
+   |
+note: closure is returned here
+  --> $DIR/region-borrow-params-issue-29793-small.rs:22:16
+   |
+LL |         return f;
+   |                ^
+help: to force the closure to take ownership of `x` (and any other referenced variables), use the `move` keyword
+   |
+LL |         let f = move |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+   |                 ^^^^^^^^^^^^^^
 
-error[E0597]: `y` does not live long enough
-  --> $DIR/region-borrow-params-issue-29793-small.rs:19:45
+error[E0373]: closure may outlive the current function, but it borrows `y`, which is owned by the current function
+  --> $DIR/region-borrow-params-issue-29793-small.rs:19:17
    |
 LL |         let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
-   |                 ---------                   ^ borrowed value does not live long enough
+   |                 ^^^^^^^^^                   - `y` is borrowed here
    |                 |
-   |                 value captured here
-...
-LL |     };
-   |      - `y` dropped here while still borrowed
+   |                 may outlive borrowed value `y`
+   |
+note: closure is returned here
+  --> $DIR/region-borrow-params-issue-29793-small.rs:22:16
+   |
+LL |         return f;
+   |                ^
+help: to force the closure to take ownership of `y` (and any other referenced variables), use the `move` keyword
+   |
+LL |         let f = move |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+   |                 ^^^^^^^^^^^^^^
 
-error[E0597]: `x` does not live long enough
-  --> $DIR/region-borrow-params-issue-29793-small.rs:34:34
+error[E0373]: closure may outlive the current function, but it borrows `x`, which is owned by the current function
+  --> $DIR/region-borrow-params-issue-29793-small.rs:34:17
    |
 LL |         let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
-   |                 ---------        ^ borrowed value does not live long enough
+   |                 ^^^^^^^^^        - `x` is borrowed here
    |                 |
-   |                 value captured here
-...
-LL |     };
-   |      - `x` dropped here while still borrowed
+   |                 may outlive borrowed value `x`
+   |
+note: closure is returned here
+  --> $DIR/region-borrow-params-issue-29793-small.rs:37:9
+   |
+LL |         f
+   |         ^
+help: to force the closure to take ownership of `x` (and any other referenced variables), use the `move` keyword
+   |
+LL |         let f = move |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+   |                 ^^^^^^^^^^^^^^
 
-error[E0597]: `y` does not live long enough
-  --> $DIR/region-borrow-params-issue-29793-small.rs:34:45
+error[E0373]: closure may outlive the current function, but it borrows `y`, which is owned by the current function
+  --> $DIR/region-borrow-params-issue-29793-small.rs:34:17
    |
 LL |         let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
-   |                 ---------                   ^ borrowed value does not live long enough
+   |                 ^^^^^^^^^                   - `y` is borrowed here
    |                 |
-   |                 value captured here
-...
-LL |     };
-   |      - `y` dropped here while still borrowed
+   |                 may outlive borrowed value `y`
+   |
+note: closure is returned here
+  --> $DIR/region-borrow-params-issue-29793-small.rs:37:9
+   |
+LL |         f
+   |         ^
+help: to force the closure to take ownership of `y` (and any other referenced variables), use the `move` keyword
+   |
+LL |         let f = move |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+   |                 ^^^^^^^^^^^^^^
 
-error[E0597]: `x` does not live long enough
-  --> $DIR/region-borrow-params-issue-29793-small.rs:65:34
+error[E0373]: closure may outlive the current function, but it borrows `x`, which is owned by the current function
+  --> $DIR/region-borrow-params-issue-29793-small.rs:65:17
    |
 LL |         let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
-   |                 ---------        ^ borrowed value does not live long enough
+   |                 ^^^^^^^^^        - `x` is borrowed here
    |                 |
-   |                 value captured here
-...
-LL |     };
-   |     - `x` dropped here while still borrowed
+   |                 may outlive borrowed value `x`
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 64:10...
-  --> $DIR/region-borrow-params-issue-29793-small.rs:64:10
+note: closure is returned here
+  --> $DIR/region-borrow-params-issue-29793-small.rs:68:16
    |
-LL |     fn g<'a>(x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
-   |          ^^
+LL |         return Box::new(f);
+   |                ^^^^^^^^^^^
+help: to force the closure to take ownership of `x` (and any other referenced variables), use the `move` keyword
+   |
+LL |         let f = move |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+   |                 ^^^^^^^^^^^^^^
 
-error[E0597]: `y` does not live long enough
-  --> $DIR/region-borrow-params-issue-29793-small.rs:65:45
+error[E0373]: closure may outlive the current function, but it borrows `y`, which is owned by the current function
+  --> $DIR/region-borrow-params-issue-29793-small.rs:65:17
    |
 LL |         let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
-   |                 ---------                   ^ borrowed value does not live long enough
+   |                 ^^^^^^^^^                   - `y` is borrowed here
    |                 |
-   |                 value captured here
-...
-LL |     };
-   |     - `y` dropped here while still borrowed
+   |                 may outlive borrowed value `y`
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 64:10...
-  --> $DIR/region-borrow-params-issue-29793-small.rs:64:10
+note: closure is returned here
+  --> $DIR/region-borrow-params-issue-29793-small.rs:68:16
    |
-LL |     fn g<'a>(x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
-   |          ^^
+LL |         return Box::new(f);
+   |                ^^^^^^^^^^^
+help: to force the closure to take ownership of `y` (and any other referenced variables), use the `move` keyword
+   |
+LL |         let f = move |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+   |                 ^^^^^^^^^^^^^^
 
-error[E0597]: `x` does not live long enough
-  --> $DIR/region-borrow-params-issue-29793-small.rs:76:34
+error[E0373]: closure may outlive the current function, but it borrows `x`, which is owned by the current function
+  --> $DIR/region-borrow-params-issue-29793-small.rs:76:17
    |
 LL |         let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
-   |                 ---------        ^ borrowed value does not live long enough
+   |                 ^^^^^^^^^        - `x` is borrowed here
    |                 |
-   |                 value captured here
-...
-LL |     };
-   |     - `x` dropped here while still borrowed
+   |                 may outlive borrowed value `x`
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 75:10...
-  --> $DIR/region-borrow-params-issue-29793-small.rs:75:10
+note: closure is returned here
+  --> $DIR/region-borrow-params-issue-29793-small.rs:79:9
    |
-LL |     fn g<'a>(x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
-   |          ^^
+LL |         Box::new(f)
+   |         ^^^^^^^^^^^
+help: to force the closure to take ownership of `x` (and any other referenced variables), use the `move` keyword
+   |
+LL |         let f = move |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+   |                 ^^^^^^^^^^^^^^
 
-error[E0597]: `y` does not live long enough
-  --> $DIR/region-borrow-params-issue-29793-small.rs:76:45
+error[E0373]: closure may outlive the current function, but it borrows `y`, which is owned by the current function
+  --> $DIR/region-borrow-params-issue-29793-small.rs:76:17
    |
 LL |         let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
-   |                 ---------                   ^ borrowed value does not live long enough
+   |                 ^^^^^^^^^                   - `y` is borrowed here
    |                 |
-   |                 value captured here
-...
-LL |     };
-   |     - `y` dropped here while still borrowed
+   |                 may outlive borrowed value `y`
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 75:10...
-  --> $DIR/region-borrow-params-issue-29793-small.rs:75:10
+note: closure is returned here
+  --> $DIR/region-borrow-params-issue-29793-small.rs:79:9
    |
-LL |     fn g<'a>(x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
-   |          ^^
+LL |         Box::new(f)
+   |         ^^^^^^^^^^^
+help: to force the closure to take ownership of `y` (and any other referenced variables), use the `move` keyword
+   |
+LL |         let f = move |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+   |                 ^^^^^^^^^^^^^^
 
-error[E0597]: `x` does not live long enough
-  --> $DIR/region-borrow-params-issue-29793-small.rs:100:38
+error[E0373]: closure may outlive the current function, but it borrows `x`, which is owned by the current function
+  --> $DIR/region-borrow-params-issue-29793-small.rs:100:21
    |
 LL |             let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
-   |                     ---------        ^ borrowed value does not live long enough
+   |                     ^^^^^^^^^        - `x` is borrowed here
    |                     |
-   |                     value captured here
-...
-LL |         }
-   |         - `x` dropped here while still borrowed
+   |                     may outlive borrowed value `x`
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the method body at 99:14...
-  --> $DIR/region-borrow-params-issue-29793-small.rs:99:14
+note: closure is returned here
+  --> $DIR/region-borrow-params-issue-29793-small.rs:103:20
    |
-LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
-   |              ^^
+LL |             return Box::new(f);
+   |                    ^^^^^^^^^^^
+help: to force the closure to take ownership of `x` (and any other referenced variables), use the `move` keyword
+   |
+LL |             let f = move |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+   |                     ^^^^^^^^^^^^^^
 
-error[E0597]: `y` does not live long enough
-  --> $DIR/region-borrow-params-issue-29793-small.rs:100:49
+error[E0373]: closure may outlive the current function, but it borrows `y`, which is owned by the current function
+  --> $DIR/region-borrow-params-issue-29793-small.rs:100:21
    |
 LL |             let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
-   |                     ---------                   ^ borrowed value does not live long enough
+   |                     ^^^^^^^^^                   - `y` is borrowed here
    |                     |
-   |                     value captured here
-...
-LL |         }
-   |         - `y` dropped here while still borrowed
+   |                     may outlive borrowed value `y`
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the method body at 99:14...
-  --> $DIR/region-borrow-params-issue-29793-small.rs:99:14
+note: closure is returned here
+  --> $DIR/region-borrow-params-issue-29793-small.rs:103:20
    |
-LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
-   |              ^^
+LL |             return Box::new(f);
+   |                    ^^^^^^^^^^^
+help: to force the closure to take ownership of `y` (and any other referenced variables), use the `move` keyword
+   |
+LL |             let f = move |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+   |                     ^^^^^^^^^^^^^^
 
-error[E0597]: `x` does not live long enough
-  --> $DIR/region-borrow-params-issue-29793-small.rs:114:38
+error[E0373]: closure may outlive the current function, but it borrows `x`, which is owned by the current function
+  --> $DIR/region-borrow-params-issue-29793-small.rs:114:21
    |
 LL |             let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
-   |                     ---------        ^ borrowed value does not live long enough
+   |                     ^^^^^^^^^        - `x` is borrowed here
    |                     |
-   |                     value captured here
-...
-LL |         }
-   |         - `x` dropped here while still borrowed
+   |                     may outlive borrowed value `x`
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the method body at 113:14...
-  --> $DIR/region-borrow-params-issue-29793-small.rs:113:14
+note: closure is returned here
+  --> $DIR/region-borrow-params-issue-29793-small.rs:117:13
    |
-LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
-   |              ^^
+LL |             Box::new(f)
+   |             ^^^^^^^^^^^
+help: to force the closure to take ownership of `x` (and any other referenced variables), use the `move` keyword
+   |
+LL |             let f = move |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+   |                     ^^^^^^^^^^^^^^
 
-error[E0597]: `y` does not live long enough
-  --> $DIR/region-borrow-params-issue-29793-small.rs:114:49
+error[E0373]: closure may outlive the current function, but it borrows `y`, which is owned by the current function
+  --> $DIR/region-borrow-params-issue-29793-small.rs:114:21
    |
 LL |             let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
-   |                     ---------                   ^ borrowed value does not live long enough
+   |                     ^^^^^^^^^                   - `y` is borrowed here
    |                     |
-   |                     value captured here
-...
-LL |         }
-   |         - `y` dropped here while still borrowed
+   |                     may outlive borrowed value `y`
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the method body at 113:14...
-  --> $DIR/region-borrow-params-issue-29793-small.rs:113:14
+note: closure is returned here
+  --> $DIR/region-borrow-params-issue-29793-small.rs:117:13
    |
-LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
-   |              ^^
+LL |             Box::new(f)
+   |             ^^^^^^^^^^^
+help: to force the closure to take ownership of `y` (and any other referenced variables), use the `move` keyword
+   |
+LL |             let f = move |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+   |                     ^^^^^^^^^^^^^^
 
-error[E0597]: `x` does not live long enough
-  --> $DIR/region-borrow-params-issue-29793-small.rs:142:38
+error[E0373]: closure may outlive the current function, but it borrows `x`, which is owned by the current function
+  --> $DIR/region-borrow-params-issue-29793-small.rs:142:21
    |
 LL |             let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
-   |                     ---------        ^ borrowed value does not live long enough
+   |                     ^^^^^^^^^        - `x` is borrowed here
    |                     |
-   |                     value captured here
-...
-LL |         }
-   |         - `x` dropped here while still borrowed
+   |                     may outlive borrowed value `x`
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the method body at 141:14...
-  --> $DIR/region-borrow-params-issue-29793-small.rs:141:14
+note: closure is returned here
+  --> $DIR/region-borrow-params-issue-29793-small.rs:145:20
    |
-LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
-   |              ^^
+LL |             return Box::new(f);
+   |                    ^^^^^^^^^^^
+help: to force the closure to take ownership of `x` (and any other referenced variables), use the `move` keyword
+   |
+LL |             let f = move |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+   |                     ^^^^^^^^^^^^^^
 
-error[E0597]: `y` does not live long enough
-  --> $DIR/region-borrow-params-issue-29793-small.rs:142:49
+error[E0373]: closure may outlive the current function, but it borrows `y`, which is owned by the current function
+  --> $DIR/region-borrow-params-issue-29793-small.rs:142:21
    |
 LL |             let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
-   |                     ---------                   ^ borrowed value does not live long enough
+   |                     ^^^^^^^^^                   - `y` is borrowed here
    |                     |
-   |                     value captured here
-...
-LL |         }
-   |         - `y` dropped here while still borrowed
+   |                     may outlive borrowed value `y`
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the method body at 141:14...
-  --> $DIR/region-borrow-params-issue-29793-small.rs:141:14
+note: closure is returned here
+  --> $DIR/region-borrow-params-issue-29793-small.rs:145:20
    |
-LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
-   |              ^^
+LL |             return Box::new(f);
+   |                    ^^^^^^^^^^^
+help: to force the closure to take ownership of `y` (and any other referenced variables), use the `move` keyword
+   |
+LL |             let f = move |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+   |                     ^^^^^^^^^^^^^^
 
-error[E0597]: `x` does not live long enough
-  --> $DIR/region-borrow-params-issue-29793-small.rs:157:38
+error[E0373]: closure may outlive the current function, but it borrows `x`, which is owned by the current function
+  --> $DIR/region-borrow-params-issue-29793-small.rs:157:21
    |
 LL |             let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
-   |                     ---------        ^ borrowed value does not live long enough
+   |                     ^^^^^^^^^        - `x` is borrowed here
    |                     |
-   |                     value captured here
-...
-LL |         }
-   |         - `x` dropped here while still borrowed
+   |                     may outlive borrowed value `x`
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the method body at 156:14...
-  --> $DIR/region-borrow-params-issue-29793-small.rs:156:14
+note: closure is returned here
+  --> $DIR/region-borrow-params-issue-29793-small.rs:160:13
    |
-LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
-   |              ^^
+LL |             Box::new(f)
+   |             ^^^^^^^^^^^
+help: to force the closure to take ownership of `x` (and any other referenced variables), use the `move` keyword
+   |
+LL |             let f = move |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+   |                     ^^^^^^^^^^^^^^
 
-error[E0597]: `y` does not live long enough
-  --> $DIR/region-borrow-params-issue-29793-small.rs:157:49
+error[E0373]: closure may outlive the current function, but it borrows `y`, which is owned by the current function
+  --> $DIR/region-borrow-params-issue-29793-small.rs:157:21
    |
 LL |             let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
-   |                     ---------                   ^ borrowed value does not live long enough
+   |                     ^^^^^^^^^                   - `y` is borrowed here
    |                     |
-   |                     value captured here
-...
-LL |         }
-   |         - `y` dropped here while still borrowed
+   |                     may outlive borrowed value `y`
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the method body at 156:14...
-  --> $DIR/region-borrow-params-issue-29793-small.rs:156:14
+note: closure is returned here
+  --> $DIR/region-borrow-params-issue-29793-small.rs:160:13
    |
-LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
-   |              ^^
+LL |             Box::new(f)
+   |             ^^^^^^^^^^^
+help: to force the closure to take ownership of `y` (and any other referenced variables), use the `move` keyword
+   |
+LL |             let f = move |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+   |                     ^^^^^^^^^^^^^^
 
-error[E0597]: `x` does not live long enough
-  --> $DIR/region-borrow-params-issue-29793-small.rs:185:38
+error[E0373]: closure may outlive the current function, but it borrows `x`, which is owned by the current function
+  --> $DIR/region-borrow-params-issue-29793-small.rs:185:21
    |
 LL |             let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
-   |                     ---------        ^ borrowed value does not live long enough
+   |                     ^^^^^^^^^        - `x` is borrowed here
    |                     |
-   |                     value captured here
-...
-LL |         }
-   |         - `x` dropped here while still borrowed
+   |                     may outlive borrowed value `x`
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the method body at 184:14...
-  --> $DIR/region-borrow-params-issue-29793-small.rs:184:14
+note: closure is returned here
+  --> $DIR/region-borrow-params-issue-29793-small.rs:188:20
    |
-LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
-   |              ^^
+LL |             return Box::new(f);
+   |                    ^^^^^^^^^^^
+help: to force the closure to take ownership of `x` (and any other referenced variables), use the `move` keyword
+   |
+LL |             let f = move |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+   |                     ^^^^^^^^^^^^^^
 
-error[E0597]: `y` does not live long enough
-  --> $DIR/region-borrow-params-issue-29793-small.rs:185:49
+error[E0373]: closure may outlive the current function, but it borrows `y`, which is owned by the current function
+  --> $DIR/region-borrow-params-issue-29793-small.rs:185:21
    |
 LL |             let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
-   |                     ---------                   ^ borrowed value does not live long enough
+   |                     ^^^^^^^^^                   - `y` is borrowed here
    |                     |
-   |                     value captured here
-...
-LL |         }
-   |         - `y` dropped here while still borrowed
+   |                     may outlive borrowed value `y`
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the method body at 184:14...
-  --> $DIR/region-borrow-params-issue-29793-small.rs:184:14
+note: closure is returned here
+  --> $DIR/region-borrow-params-issue-29793-small.rs:188:20
    |
-LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
-   |              ^^
+LL |             return Box::new(f);
+   |                    ^^^^^^^^^^^
+help: to force the closure to take ownership of `y` (and any other referenced variables), use the `move` keyword
+   |
+LL |             let f = move |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+   |                     ^^^^^^^^^^^^^^
 
-error[E0597]: `x` does not live long enough
-  --> $DIR/region-borrow-params-issue-29793-small.rs:199:38
+error[E0373]: closure may outlive the current function, but it borrows `x`, which is owned by the current function
+  --> $DIR/region-borrow-params-issue-29793-small.rs:199:21
    |
 LL |             let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
-   |                     ---------        ^ borrowed value does not live long enough
+   |                     ^^^^^^^^^        - `x` is borrowed here
    |                     |
-   |                     value captured here
-...
-LL |         }
-   |         - `x` dropped here while still borrowed
+   |                     may outlive borrowed value `x`
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the method body at 198:14...
-  --> $DIR/region-borrow-params-issue-29793-small.rs:198:14
+note: closure is returned here
+  --> $DIR/region-borrow-params-issue-29793-small.rs:202:13
    |
-LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
-   |              ^^
+LL |             Box::new(f)
+   |             ^^^^^^^^^^^
+help: to force the closure to take ownership of `x` (and any other referenced variables), use the `move` keyword
+   |
+LL |             let f = move |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+   |                     ^^^^^^^^^^^^^^
 
-error[E0597]: `y` does not live long enough
-  --> $DIR/region-borrow-params-issue-29793-small.rs:199:49
+error[E0373]: closure may outlive the current function, but it borrows `y`, which is owned by the current function
+  --> $DIR/region-borrow-params-issue-29793-small.rs:199:21
    |
 LL |             let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
-   |                     ---------                   ^ borrowed value does not live long enough
+   |                     ^^^^^^^^^                   - `y` is borrowed here
    |                     |
-   |                     value captured here
-...
-LL |         }
-   |         - `y` dropped here while still borrowed
+   |                     may outlive borrowed value `y`
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the method body at 198:14...
-  --> $DIR/region-borrow-params-issue-29793-small.rs:198:14
+note: closure is returned here
+  --> $DIR/region-borrow-params-issue-29793-small.rs:202:13
    |
-LL |         fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
-   |              ^^
+LL |             Box::new(f)
+   |             ^^^^^^^^^^^
+help: to force the closure to take ownership of `y` (and any other referenced variables), use the `move` keyword
+   |
+LL |             let f = move |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+   |                     ^^^^^^^^^^^^^^
 
 error: aborting due to 20 previous errors
 
-For more information about this error, try `rustc --explain E0597`.
+For more information about this error, try `rustc --explain E0373`.

--- a/src/test/ui/regions/region-object-lifetime-5.nll.stderr
+++ b/src/test/ui/regions/region-object-lifetime-5.nll.stderr
@@ -1,13 +1,12 @@
-error[E0597]: `*x` does not live long enough
+error[E0515]: cannot return value referencing local data `*x`
   --> $DIR/region-object-lifetime-5.rs:21:5
    |
 LL |     x.borrowed() //~ ERROR `*x` does not live long enough
-   |     ^ borrowed value does not live long enough
-LL | }
-   | - `*x` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
+   |     -^^^^^^^^^^^
+   |     |
+   |     returns a value referencing data owned by the current function
+   |     `*x` is borrowed here
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0597`.
+For more information about this error, try `rustc --explain E0515`.

--- a/src/test/ui/regions/regions-addr-of-arg.nll.stderr
+++ b/src/test/ui/regions/regions-addr-of-arg.nll.stderr
@@ -2,26 +2,19 @@ error[E0597]: `a` does not live long enough
   --> $DIR/regions-addr-of-arg.rs:15:30
    |
 LL |     let _p: &'static isize = &a; //~ ERROR `a` does not live long enough
-   |                              ^^ borrowed value does not live long enough
+   |             --------------   ^^ borrowed value does not live long enough
+   |             |
+   |             type annotation requires that `a` is borrowed for `'static`
 LL | }
    |  - `a` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
-error[E0597]: `a` does not live long enough
+error[E0515]: cannot return reference to function parameter `a`
   --> $DIR/regions-addr-of-arg.rs:23:5
    |
 LL |     &a //~ ERROR `a` does not live long enough
-   |     ^^ borrowed value does not live long enough
-LL | }
-   |  - `a` dropped here while still borrowed
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 22:8...
-  --> $DIR/regions-addr-of-arg.rs:22:8
-   |
-LL | fn zed<'a>(a: isize) -> &'a isize {
-   |        ^^
+   |     ^^ returns a reference to data owned by the current function
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0597`.
+Some errors occurred: E0515, E0597.
+For more information about an error, try `rustc --explain E0515`.

--- a/src/test/ui/regions/regions-close-object-into-object-1.nll.stderr
+++ b/src/test/ui/regions/regions-close-object-into-object-1.nll.stderr
@@ -1,13 +1,12 @@
-error[E0597]: `*v` does not live long enough
-  --> $DIR/regions-close-object-into-object-1.rs:22:11
+error[E0515]: cannot return value referencing local data `*v`
+  --> $DIR/regions-close-object-into-object-1.rs:22:5
    |
 LL |     box B(&*v) as Box<X> //~ ERROR `*v` does not live long enough
-   |           ^^^ borrowed value does not live long enough
-LL | }
-   | - `*v` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
+   |     ^^^^^^---^^^^^^^^^^^
+   |     |     |
+   |     |     `*v` is borrowed here
+   |     returns a value referencing data owned by the current function
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0597`.
+For more information about this error, try `rustc --explain E0515`.

--- a/src/test/ui/regions/regions-close-object-into-object-3.nll.stderr
+++ b/src/test/ui/regions/regions-close-object-into-object-3.nll.stderr
@@ -1,13 +1,12 @@
-error[E0597]: `*v` does not live long enough
-  --> $DIR/regions-close-object-into-object-3.rs:21:11
+error[E0515]: cannot return value referencing local data `*v`
+  --> $DIR/regions-close-object-into-object-3.rs:21:5
    |
 LL |     box B(&*v) as Box<X> //~ ERROR `*v` does not live long enough
-   |           ^^^ borrowed value does not live long enough
-LL | }
-   | - `*v` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
+   |     ^^^^^^---^^^^^^^^^^^
+   |     |     |
+   |     |     `*v` is borrowed here
+   |     returns a value referencing data owned by the current function
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0597`.
+For more information about this error, try `rustc --explain E0515`.

--- a/src/test/ui/regions/regions-creating-enums.nll.stderr
+++ b/src/test/ui/regions/regions-creating-enums.nll.stderr
@@ -1,31 +1,21 @@
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/regions-creating-enums.rs:33:17
+error[E0515]: cannot return reference to temporary value
+  --> $DIR/regions-creating-enums.rs:33:16
    |
 LL |         return &ast::num((*f)(x)); //~ ERROR borrowed value does not live long enough
-   |                 ^^^^^^^^^^^^^^^^^- temporary value is freed at the end of this statement
-   |                 |
-   |                 creates a temporary which is freed while still in use
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 30:13...
-  --> $DIR/regions-creating-enums.rs:30:13
-   |
-LL | fn map_nums<'a,'b, F>(x: &ast, f: &mut F) -> &'a ast<'b> where F: FnMut(usize) -> usize {
-   |             ^^
+   |                ^-----------------
+   |                ||
+   |                |temporary value created here
+   |                returns a reference to data owned by the current function
 
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/regions-creating-enums.rs:38:17
+error[E0515]: cannot return reference to temporary value
+  --> $DIR/regions-creating-enums.rs:38:16
    |
 LL |         return &ast::add(m_x, m_y);  //~ ERROR borrowed value does not live long enough
-   |                 ^^^^^^^^^^^^^^^^^^- temporary value is freed at the end of this statement
-   |                 |
-   |                 creates a temporary which is freed while still in use
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 30:13...
-  --> $DIR/regions-creating-enums.rs:30:13
-   |
-LL | fn map_nums<'a,'b, F>(x: &ast, f: &mut F) -> &'a ast<'b> where F: FnMut(usize) -> usize {
-   |             ^^
+   |                ^------------------
+   |                ||
+   |                |temporary value created here
+   |                returns a reference to data owned by the current function
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0716`.
+For more information about this error, try `rustc --explain E0515`.

--- a/src/test/ui/regions/regions-free-region-ordering-caller1.nll.stderr
+++ b/src/test/ui/regions/regions-free-region-ordering-caller1.nll.stderr
@@ -1,32 +1,30 @@
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/regions-free-region-ordering-caller1.rs:19:27
    |
+LL | fn call1<'a>(x: &'a usize) {
+   |          -- lifetime `'a` defined here
+...
 LL |     let z: &'a & usize = &(&y);
-   |                           ^^^^ creates a temporary which is freed while still in use
+   |            -----------    ^^^^ creates a temporary which is freed while still in use
+   |            |
+   |            type annotation requires that borrow lasts for `'a`
 ...
 LL | }
    | - temporary value is freed at the end of this statement
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 15:10...
-  --> $DIR/regions-free-region-ordering-caller1.rs:15:10
-   |
-LL | fn call1<'a>(x: &'a usize) {
-   |          ^^
 
 error[E0597]: `y` does not live long enough
   --> $DIR/regions-free-region-ordering-caller1.rs:19:27
    |
+LL | fn call1<'a>(x: &'a usize) {
+   |          -- lifetime `'a` defined here
+...
 LL |     let z: &'a & usize = &(&y);
-   |                           ^^^^ borrowed value does not live long enough
+   |            -----------    ^^^^ borrowed value does not live long enough
+   |            |
+   |            type annotation requires that `y` is borrowed for `'a`
 ...
 LL | }
    | - `y` dropped here while still borrowed
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 15:10...
-  --> $DIR/regions-free-region-ordering-caller1.rs:15:10
-   |
-LL | fn call1<'a>(x: &'a usize) {
-   |          ^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/regions/regions-infer-borrow-scope-too-big.nll.stderr
+++ b/src/test/ui/regions/regions-infer-borrow-scope-too-big.nll.stderr
@@ -1,18 +1,12 @@
-error[E0597]: `*p` does not live long enough
-  --> $DIR/regions-infer-borrow-scope-too-big.rs:22:22
+error[E0515]: cannot return value referencing local data `*p`
+  --> $DIR/regions-infer-borrow-scope-too-big.rs:24:12
    |
 LL |     let xc = x_coord(&*p); //~ ERROR `*p` does not live long enough
-   |                      ^^^ borrowed value does not live long enough
-...
-LL | }
-   | - `*p` dropped here while still borrowed
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 21:8...
-  --> $DIR/regions-infer-borrow-scope-too-big.rs:21:8
-   |
-LL | fn foo<'a>(p: Box<point>) -> &'a isize {
-   |        ^^
+   |                      --- `*p` is borrowed here
+LL |     assert_eq!(*xc, 3);
+LL |     return xc;
+   |            ^^ returns a value referencing data owned by the current function
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0597`.
+For more information about this error, try `rustc --explain E0515`.

--- a/src/test/ui/regions/regions-infer-proc-static-upvar.nll.stderr
+++ b/src/test/ui/regions/regions-infer-proc-static-upvar.nll.stderr
@@ -1,13 +1,14 @@
 error[E0597]: `x` does not live long enough
   --> $DIR/regions-infer-proc-static-upvar.rs:20:13
    |
-LL |     let y = &x; //~ ERROR `x` does not live long enough
-   |             ^^ borrowed value does not live long enough
-...
-LL | }
-   | - `x` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
+LL |       let y = &x; //~ ERROR `x` does not live long enough
+   |               ^^ borrowed value does not live long enough
+LL | /     foo(move|| {
+LL | |         let _a = *y;
+LL | |     });
+   | |______- argument requires that `x` is borrowed for `'static`
+LL |   }
+   |   - `x` dropped here while still borrowed
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-lifetime-of-struct-or-enum-variant.nll.stderr
+++ b/src/test/ui/regions/regions-lifetime-of-struct-or-enum-variant.nll.stderr
@@ -1,33 +1,21 @@
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/regions-lifetime-of-struct-or-enum-variant.rs:24:20
+error[E0515]: cannot return value referencing temporary value
+  --> $DIR/regions-lifetime-of-struct-or-enum-variant.rs:26:3
    |
 LL |   let testValue = &id(Test);
-   |                    ^^^^^^^^ creates a temporary which is freed while still in use
-...
-LL | }
-   | - temporary value is freed at the end of this statement
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 23:19...
-  --> $DIR/regions-lifetime-of-struct-or-enum-variant.rs:23:19
-   |
-LL | fn structLifetime<'a>() -> &'a Test {
-   |                   ^^
+   |                    -------- temporary value created here
+LL |   //~^ ERROR borrowed value does not live long enough
+LL |   testValue
+   |   ^^^^^^^^^ returns a value referencing data owned by the current function
 
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/regions-lifetime-of-struct-or-enum-variant.rs:30:20
+error[E0515]: cannot return value referencing temporary value
+  --> $DIR/regions-lifetime-of-struct-or-enum-variant.rs:32:3
    |
 LL |   let testValue = &id(MyEnum::Variant1);
-   |                    ^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
-...
-LL | }
-   | - temporary value is freed at the end of this statement
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 29:20...
-  --> $DIR/regions-lifetime-of-struct-or-enum-variant.rs:29:20
-   |
-LL | fn variantLifetime<'a>() -> &'a MyEnum {
-   |                    ^^
+   |                    -------------------- temporary value created here
+LL |   //~^ ERROR borrowed value does not live long enough
+LL |   testValue
+   |   ^^^^^^^^^ returns a value referencing data owned by the current function
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0716`.
+For more information about this error, try `rustc --explain E0515`.

--- a/src/test/ui/regions/regions-nested-fns-2.nll.stderr
+++ b/src/test/ui/regions/regions-nested-fns-2.nll.stderr
@@ -5,12 +5,13 @@ LL |         |z| {
    |         --- value captured here
 LL |             //~^ ERROR E0373
 LL |             if false { &y } else { z }
-   |                         ^ borrowed value does not live long enough
+   |                        -^
+   |                        ||
+   |                        |borrowed value does not live long enough
+   |                        returning this value requires that `y` is borrowed for `'static`
 LL |         });
 LL | }
    | - `y` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-pattern-typing-issue-19552.nll.stderr
+++ b/src/test/ui/regions/regions-pattern-typing-issue-19552.nll.stderr
@@ -3,11 +3,11 @@ error[E0597]: `line` does not live long enough
    |
 LL |     match [&*line] { //~ ERROR `line` does not live long enough
    |              ^^^^ borrowed value does not live long enough
-...
+LL |         [ word ] => { assert_static(word); }
+   |                       ------------------- argument requires that `line` is borrowed for `'static`
+LL |     }
 LL | }
    | - `line` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-ref-in-fn-arg.nll.stderr
+++ b/src/test/ui/regions/regions-ref-in-fn-arg.nll.stderr
@@ -1,22 +1,19 @@
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/regions-ref-in-fn-arg.rs:14:13
+error[E0515]: cannot return value referencing function parameter
+  --> $DIR/regions-ref-in-fn-arg.rs:15:5
    |
 LL | fn arg_item(box ref x: Box<isize>) -> &'static isize {
-   |             ^^^^^^^^^ creates a temporary which is freed while still in use
+   |             --------- function parameter borrowed here
 LL |     x //~^ ERROR borrowed value does not live long enough
-LL | }
-   | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
+   |     ^ returns a value referencing data owned by the current function
 
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/regions-ref-in-fn-arg.rs:21:11
+error[E0515]: cannot return value referencing function parameter
+  --> $DIR/regions-ref-in-fn-arg.rs:21:22
    |
 LL |     with(|box ref x| x) //~ ERROR borrowed value does not live long enough
-   |           ^^^^^^^^^  - temporary value is freed at the end of this statement
+   |           ---------  ^ returns a value referencing data owned by the current function
    |           |
-   |           creates a temporary which is freed while still in use
+   |           function parameter borrowed here
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0716`.
+For more information about this error, try `rustc --explain E0515`.

--- a/src/test/ui/regions/regions-ret.nll.stderr
+++ b/src/test/ui/regions/regions-ret.nll.stderr
@@ -1,19 +1,12 @@
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/regions-ret.rs:14:13
+error[E0515]: cannot return reference to temporary value
+  --> $DIR/regions-ret.rs:14:12
    |
 LL |     return &id(3); //~ ERROR borrowed value does not live long enough
-   |             ^^^^^- temporary value is freed at the end of this statement
-   |             |
-   |             creates a temporary which is freed while still in use
-   |
-note: borrowed value must be valid for the anonymous lifetime #1 defined on the function body at 13:1...
-  --> $DIR/regions-ret.rs:13:1
-   |
-LL | / fn f(_x: &isize) -> &isize {
-LL | |     return &id(3); //~ ERROR borrowed value does not live long enough
-LL | | }
-   | |_^
+   |            ^-----
+   |            ||
+   |            |temporary value created here
+   |            returns a reference to data owned by the current function
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0716`.
+For more information about this error, try `rustc --explain E0515`.

--- a/src/test/ui/regions/regions-return-stack-allocated-vec.nll.stderr
+++ b/src/test/ui/regions/regions-return-stack-allocated-vec.nll.stderr
@@ -1,13 +1,12 @@
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/regions-return-stack-allocated-vec.rs:14:6
+error[E0515]: cannot return reference to temporary value
+  --> $DIR/regions-return-stack-allocated-vec.rs:14:5
    |
 LL |     &[x] //~ ERROR borrowed value does not live long enough
-   |      ^^^ creates a temporary which is freed while still in use
-LL | }
-   | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
+   |     ^---
+   |     ||
+   |     |temporary value created here
+   |     returns a reference to data owned by the current function
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0716`.
+For more information about this error, try `rustc --explain E0515`.

--- a/src/test/ui/regions/regions-trait-variance.nll.stderr
+++ b/src/test/ui/regions/regions-trait-variance.nll.stderr
@@ -1,18 +1,11 @@
-error[E0597]: `*b` does not live long enough
-  --> $DIR/regions-trait-variance.rs:47:18
+error[E0515]: cannot return value referencing local data `*b`
+  --> $DIR/regions-trait-variance.rs:48:5
    |
 LL |     let bb: &B = &*b; //~ ERROR `*b` does not live long enough
-   |                  ^^^ borrowed value does not live long enough
+   |                  --- `*b` is borrowed here
 LL |     make_a(bb)
-LL | }
-   | - `*b` dropped here while still borrowed
-   |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 43:16...
-  --> $DIR/regions-trait-variance.rs:43:16
-   |
-LL | fn make_make_a<'a>() -> A<'a> {
-   |                ^^
+   |     ^^^^^^^^^^ returns a value referencing data owned by the current function
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0597`.
+For more information about this error, try `rustc --explain E0515`.

--- a/src/test/ui/span/issue-11925.nll.stderr
+++ b/src/test/ui/span/issue-11925.nll.stderr
@@ -1,12 +1,9 @@
-error[E0597]: `x` does not live long enough
+error[E0515]: cannot return reference to local data `x`
   --> $DIR/issue-11925.rs:18:35
    |
 LL |         let f = to_fn_once(move|| &x); //~ ERROR does not live long enough
-   |                                   ^-
-   |                                   ||
-   |                                   |`x` dropped here while still borrowed
-   |                                   borrowed value does not live long enough
+   |                                   ^^ returns a reference to data owned by the current function
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0597`.
+For more information about this error, try `rustc --explain E0515`.

--- a/src/test/ui/static/static-drop-scope.nll.stderr
+++ b/src/test/ui/static/static-drop-scope.nll.stderr
@@ -8,11 +8,11 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/static-drop-scope.rs:19:60
    |
 LL | static PROMOTION_FAIL_S: Option<&'static WithDtor> = Some(&WithDtor);
-   |                                                            ^^^^^^^^- temporary value is freed at the end of this statement
-   |                                                            |
-   |                                                            creates a temporary which is freed while still in use
-   |
-   = note: borrowed value must be valid for the static lifetime...
+   |                                                      ------^^^^^^^^-
+   |                                                      |     |       |
+   |                                                      |     |       temporary value is freed at the end of this statement
+   |                                                      |     creates a temporary which is freed while still in use
+   |                                                      using this value as a static requires that borrow lasts for `'static`
 
 error[E0493]: destructors cannot be evaluated at compile-time
   --> $DIR/static-drop-scope.rs:23:59
@@ -24,11 +24,11 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/static-drop-scope.rs:23:59
    |
 LL | const PROMOTION_FAIL_C: Option<&'static WithDtor> = Some(&WithDtor);
-   |                                                           ^^^^^^^^- temporary value is freed at the end of this statement
-   |                                                           |
-   |                                                           creates a temporary which is freed while still in use
-   |
-   = note: borrowed value must be valid for the static lifetime...
+   |                                                     ------^^^^^^^^-
+   |                                                     |     |       |
+   |                                                     |     |       temporary value is freed at the end of this statement
+   |                                                     |     creates a temporary which is freed while still in use
+   |                                                     using this value as a constant requires that borrow lasts for `'static`
 
 error[E0493]: destructors cannot be evaluated at compile-time
   --> $DIR/static-drop-scope.rs:27:28

--- a/src/test/ui/static/static-lifetime-bound.nll.stderr
+++ b/src/test/ui/static/static-lifetime-bound.nll.stderr
@@ -10,11 +10,12 @@ error[E0597]: `x` does not live long enough
   --> $DIR/static-lifetime-bound.rs:15:7
    |
 LL |     f(&x); //~ERROR does not live long enough
-   |       ^^ borrowed value does not live long enough
+   |     --^^-
+   |     | |
+   |     | borrowed value does not live long enough
+   |     argument requires that `x` is borrowed for `'static`
 LL | }
    | - `x` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error: aborting due to previous error
 

--- a/src/test/ui/static/static-reference-to-fn-2.nll.stderr
+++ b/src/test/ui/static/static-reference-to-fn-2.nll.stderr
@@ -1,68 +1,47 @@
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/static-reference-to-fn-2.rs:28:22
    |
+LL | fn state1(self_: &mut StateMachineIter) -> Option<&'static str> {
+   |           ----- has type `&mut StateMachineIter<'1>`
 LL |     self_.statefn = &id(state2 as StateMachineFunc);
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^- temporary value is freed at the end of this statement
-   |                      |
-   |                      creates a temporary which is freed while still in use
-   |
-note: borrowed value must be valid for the anonymous lifetime #2 defined on the function body at 27:1...
-  --> $DIR/static-reference-to-fn-2.rs:27:1
-   |
-LL | / fn state1(self_: &mut StateMachineIter) -> Option<&'static str> {
-LL | |     self_.statefn = &id(state2 as StateMachineFunc);
-LL | |     //~^ ERROR borrowed value does not live long enough
-LL | |     return Some("state1");
-LL | | }
-   | |_^
+   |     -----------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^- temporary value is freed at the end of this statement
+   |     |                |
+   |     |                creates a temporary which is freed while still in use
+   |     assignment requires that borrow lasts for `'1`
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/static-reference-to-fn-2.rs:34:22
    |
+LL | fn state2(self_: &mut StateMachineIter) -> Option<(&'static str)> {
+   |           ----- has type `&mut StateMachineIter<'1>`
 LL |     self_.statefn = &id(state3 as StateMachineFunc);
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^- temporary value is freed at the end of this statement
-   |                      |
-   |                      creates a temporary which is freed while still in use
-   |
-note: borrowed value must be valid for the anonymous lifetime #2 defined on the function body at 33:1...
-  --> $DIR/static-reference-to-fn-2.rs:33:1
-   |
-LL | / fn state2(self_: &mut StateMachineIter) -> Option<(&'static str)> {
-LL | |     self_.statefn = &id(state3 as StateMachineFunc);
-LL | |     //~^ ERROR borrowed value does not live long enough
-LL | |     return Some("state2");
-LL | | }
-   | |_^
+   |     -----------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^- temporary value is freed at the end of this statement
+   |     |                |
+   |     |                creates a temporary which is freed while still in use
+   |     assignment requires that borrow lasts for `'1`
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/static-reference-to-fn-2.rs:40:22
    |
+LL | fn state3(self_: &mut StateMachineIter) -> Option<(&'static str)> {
+   |           ----- has type `&mut StateMachineIter<'1>`
 LL |     self_.statefn = &id(finished as StateMachineFunc);
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^- temporary value is freed at the end of this statement
-   |                      |
-   |                      creates a temporary which is freed while still in use
-   |
-note: borrowed value must be valid for the anonymous lifetime #2 defined on the function body at 39:1...
-  --> $DIR/static-reference-to-fn-2.rs:39:1
-   |
-LL | / fn state3(self_: &mut StateMachineIter) -> Option<(&'static str)> {
-LL | |     self_.statefn = &id(finished as StateMachineFunc);
-LL | |     //~^ ERROR borrowed value does not live long enough
-LL | |     return Some("state3");
-LL | | }
-   | |_^
+   |     -----------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^- temporary value is freed at the end of this statement
+   |     |                |
+   |     |                creates a temporary which is freed while still in use
+   |     assignment requires that borrow lasts for `'1`
 
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/static-reference-to-fn-2.rs:51:19
+error[E0515]: cannot return value referencing temporary value
+  --> $DIR/static-reference-to-fn-2.rs:50:5
    |
-LL |         statefn: &id(state1 as StateMachineFunc)
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
-...
-LL | }
-   | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
+LL | /     StateMachineIter {
+LL | |         statefn: &id(state1 as StateMachineFunc)
+   | |                   ------------------------------ temporary value created here
+LL | |         //~^ ERROR borrowed value does not live long enough
+LL | |     }
+   | |_____^ returns a value referencing data owned by the current function
 
 error: aborting due to 4 previous errors
 
-For more information about this error, try `rustc --explain E0716`.
+Some errors occurred: E0515, E0716.
+For more information about an error, try `rustc --explain E0515`.

--- a/src/test/ui/static/static-region-bound.nll.stderr
+++ b/src/test/ui/static/static-region-bound.nll.stderr
@@ -4,10 +4,9 @@ error[E0716]: temporary value dropped while borrowed
 LL |     let x = &id(3); //~ ERROR borrowed value does not live long enough
    |              ^^^^^ creates a temporary which is freed while still in use
 LL |     f(x);
+   |     ---- argument requires that borrow lasts for `'static`
 LL | }
    | - temporary value is freed at the end of this statement
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/trait-coercion-generic-regions.nll.stderr
+++ b/src/test/ui/traits/trait-coercion-generic-regions.nll.stderr
@@ -2,12 +2,13 @@ error[E0597]: `person` does not live long enough
   --> $DIR/trait-coercion-generic-regions.rs:27:24
    |
 LL |     let person: &str = &person;  //~ ERROR `person` does not live long enough
-   |                        ^^^^^^^ borrowed value does not live long enough
+   |                        ^^^^^^^
+   |                        |
+   |                        borrowed value does not live long enough
+   |                        assignment requires that `person` is borrowed for `'static`
 LL |     let s: Box<Trait<&'static str>> = Box::new(Struct { person: person });
 LL | }
    | - `person` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error: aborting due to previous error
 

--- a/src/test/ui/unboxed-closures/unboxed-closures-failed-recursive-fn-1.nll.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-failed-recursive-fn-1.nll.stderr
@@ -29,6 +29,9 @@ LL |     factorial = Some(Box::new(f));
 error[E0597]: `factorial` does not live long enough
   --> $DIR/unboxed-closures-failed-recursive-fn-1.rs:38:17
    |
+LL |     let mut factorial: Option<Box<Fn(u32) -> u32 + 'static>> = None;
+   |                        ------------------------------------- type annotation requires that `factorial` is borrowed for `'static`
+LL | 
 LL |     let f = |x: u32| -> u32 {
    |             --------------- value captured here
 LL |         //~^ ERROR closure may outlive the current function, but it borrows `factorial`
@@ -37,12 +40,13 @@ LL |         let g = factorial.as_ref().unwrap();
 ...
 LL | }
    | - `factorial` dropped here while still borrowed
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error[E0506]: cannot assign to `factorial` because it is borrowed
   --> $DIR/unboxed-closures-failed-recursive-fn-1.rs:42:5
    |
+LL |     let mut factorial: Option<Box<Fn(u32) -> u32 + 'static>> = None;
+   |                        ------------------------------------- type annotation requires that `factorial` is borrowed for `'static`
+LL | 
 LL |     let f = |x: u32| -> u32 {
    |             --------------- borrow of `factorial` occurs here
 LL |         //~^ ERROR closure may outlive the current function, but it borrows `factorial`
@@ -51,8 +55,6 @@ LL |         let g = factorial.as_ref().unwrap();
 ...
 LL |     factorial = Some(Box::new(f));
    |     ^^^^^^^^^ assignment to borrowed `factorial` occurs here
-   |
-   = note: borrowed value must be valid for the static lifetime...
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/wf/wf-misc-methods-issue-28609.nll.stderr
+++ b/src/test/ui/wf/wf-misc-methods-issue-28609.nll.stderr
@@ -1,112 +1,55 @@
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/wf-misc-methods-issue-28609.rs:32:31
+error[E0515]: cannot return value referencing temporary value
+  --> $DIR/wf-misc-methods-issue-28609.rs:32:5
    |
 LL |     s.transmute_inherent(&mut 42) //~ ERROR does not live long enough
-   |                               ^^ creates a temporary which is freed while still in use
-LL | }
-   | - temporary value is freed at the end of this statement
-   |
-note: borrowed value must be valid for the anonymous lifetime #1 defined on the function body at 30:1...
-  --> $DIR/wf-misc-methods-issue-28609.rs:30:1
-   |
-LL | / fn return_dangling_pointer_inherent(s: S2) -> &u32 {
-LL | |     let s = s;
-LL | |     s.transmute_inherent(&mut 42) //~ ERROR does not live long enough
-LL | | }
-   | |_^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^--^
+   |     |                         |
+   |     |                         temporary value created here
+   |     returns a value referencing data owned by the current function
 
-error[E0597]: `four` does not live long enough
-  --> $DIR/wf-misc-methods-issue-28609.rs:45:19
+error[E0515]: cannot return value referencing local variable `four`
+  --> $DIR/wf-misc-methods-issue-28609.rs:46:5
    |
 LL |     s.bomb = Some(&four); //~ ERROR does not live long enough
-   |                   ^^^^^ borrowed value does not live long enough
+   |                   ----- `four` is borrowed here
 LL |     &s
-LL | }
-   | - `four` dropped here while still borrowed
-   |
-note: borrowed value must be valid for the anonymous lifetime #1 defined on the function body at 42:1...
-  --> $DIR/wf-misc-methods-issue-28609.rs:42:1
-   |
-LL | / fn return_dangling_pointer_coerce(s: S2) -> &u32 {
-LL | |     let four = 4;
-LL | |     let mut s = s;
-LL | |     s.bomb = Some(&four); //~ ERROR does not live long enough
-LL | |     &s
-LL | | }
-   | |_^
+   |     ^^ returns a value referencing data owned by the current function
 
-error[E0597]: `four` does not live long enough
-  --> $DIR/wf-misc-methods-issue-28609.rs:52:19
+error[E0515]: cannot return value referencing local variable `four`
+  --> $DIR/wf-misc-methods-issue-28609.rs:53:5
    |
 LL |     s.bomb = Some(&four); //~ ERROR does not live long enough
-   |                   ^^^^^ borrowed value does not live long enough
+   |                   ----- `four` is borrowed here
 LL |     &*s
-LL | }
-   | - `four` dropped here while still borrowed
-   |
-note: borrowed value must be valid for the anonymous lifetime #1 defined on the function body at 49:1...
-  --> $DIR/wf-misc-methods-issue-28609.rs:49:1
-   |
-LL | / fn return_dangling_pointer_unary_op(s: S2) -> &u32 {
-LL | |     let four = 4;
-LL | |     let mut s = s;
-LL | |     s.bomb = Some(&four); //~ ERROR does not live long enough
-LL | |     &*s
-LL | | }
-   | |_^
+   |     ^^^ returns a value referencing data owned by the current function
 
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/wf-misc-methods-issue-28609.rs:63:15
+error[E0515]: cannot return value referencing temporary value
+  --> $DIR/wf-misc-methods-issue-28609.rs:63:5
    |
 LL |     s << &mut 3 //~ ERROR does not live long enough
-   |               ^ creates a temporary which is freed while still in use
-LL | }
-   | - temporary value is freed at the end of this statement
-   |
-note: borrowed value must be valid for the anonymous lifetime #1 defined on the function body at 61:1...
-  --> $DIR/wf-misc-methods-issue-28609.rs:61:1
-   |
-LL | / fn return_dangling_pointer_binary_op(s: S2) -> &u32 {
-LL | |     let s = s;
-LL | |     s << &mut 3 //~ ERROR does not live long enough
-LL | | }
-   | |_^
+   |     ^^^^^^^^^^-
+   |     |         |
+   |     |         temporary value created here
+   |     returns a value referencing data owned by the current function
 
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/wf-misc-methods-issue-28609.rs:68:16
+error[E0515]: cannot return value referencing temporary value
+  --> $DIR/wf-misc-methods-issue-28609.rs:68:5
    |
 LL |     s.shl(&mut 3) //~ ERROR does not live long enough
-   |                ^ creates a temporary which is freed while still in use
-LL | }
-   | - temporary value is freed at the end of this statement
-   |
-note: borrowed value must be valid for the anonymous lifetime #1 defined on the function body at 66:1...
-  --> $DIR/wf-misc-methods-issue-28609.rs:66:1
-   |
-LL | / fn return_dangling_pointer_method(s: S2) -> &u32 {
-LL | |     let s = s;
-LL | |     s.shl(&mut 3) //~ ERROR does not live long enough
-LL | | }
-   | |_^
+   |     ^^^^^^^^^^^-^
+   |     |          |
+   |     |          temporary value created here
+   |     returns a value referencing data owned by the current function
 
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/wf-misc-methods-issue-28609.rs:73:21
+error[E0515]: cannot return value referencing temporary value
+  --> $DIR/wf-misc-methods-issue-28609.rs:73:5
    |
 LL |     S2::shl(s, &mut 3) //~ ERROR does not live long enough
-   |                     ^ creates a temporary which is freed while still in use
-LL | }
-   | - temporary value is freed at the end of this statement
-   |
-note: borrowed value must be valid for the anonymous lifetime #1 defined on the function body at 71:1...
-  --> $DIR/wf-misc-methods-issue-28609.rs:71:1
-   |
-LL | / fn return_dangling_pointer_ufcs(s: S2) -> &u32 {
-LL | |     let s = s;
-LL | |     S2::shl(s, &mut 3) //~ ERROR does not live long enough
-LL | | }
-   | |_^
+   |     ^^^^^^^^^^^^^^^^-^
+   |     |               |
+   |     |               temporary value created here
+   |     returns a value referencing data owned by the current function
 
 error: aborting due to 6 previous errors
 
-Some errors occurred: E0597, E0716.
-For more information about an error, try `rustc --explain E0597`.
+For more information about this error, try `rustc --explain E0515`.


### PR DESCRIPTION
Use the new free region infer errors for explaining borrows

This gives at least some explanation for why a borrow is expected to
last for a certain free region. Also:

* Reports E0373: "closure may outlive the current function" with NLL.
* Special cases the case of returning a reference to (or value referencing) a local variable or temporary (E0515).
* Special case assigning a reference to a local variable in a closure to a captured variable. (E0521)

Closes #51026 - `regions-nested-fns-2.rs` isn't changed to that diagnostic, since that would not be the correct error here.
Closes #51169 
cc #53882 - The error is (IMO) better now, but it could be better when we trace lifetimes in these error messages.

r? @nikomatsakis cc @pnkfelix 
