### PR TITLE
rustdoc: Use dyn keyword when rendering dynamic traits

### DIFF
--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -553,6 +553,9 @@ fn fmt_type(t: &clean::Type, f: &mut fmt::Formatter, use_absolute: bool) -> fmt:
             f.write_str(name)
         }
         clean::ResolvedPath{ did, ref typarams, ref path, is_generic } => {
+            if typarams.is_some() {
+                f.write_str("dyn ")?;
+            }
             // Paths like T::Output and Self::Output should be rendered with all segments
             resolved_path(f, did, path, is_generic, use_absolute)?;
             tybounds(f, typarams)

--- a/src/test/rustdoc/assoc-consts.rs
+++ b/src/test/rustdoc/assoc-consts.rs
@@ -52,7 +52,7 @@ pub fn f(_: &(ToString + 'static)) {}
 
 impl Bar {
     // @has assoc_consts/struct.Bar.html '//*[@id="associatedconstant.F"]' \
-    //      "const F: fn(_: &(ToString + 'static))"
+    //      "const F: fn(_: &(dyn ToString + 'static))"
     pub const F: fn(_: &(ToString + 'static)) = f;
 }
 

--- a/src/test/rustdoc/inline_cross/issue-32881.rs
+++ b/src/test/rustdoc/inline_cross/issue-32881.rs
@@ -15,8 +15,8 @@
 extern crate rustdoc_trait_object_impl;
 
 // @has issue_32881/trait.Bar.html
-// @has - '//code' "impl<'a> Bar"
-// @has - '//code' "impl<'a> Debug for Bar"
+// @has - '//code' "impl<'a> dyn Bar"
+// @has - '//code' "impl<'a> Debug for dyn Bar"
 
 pub use rustdoc_trait_object_impl::Bar;
 

--- a/src/test/rustdoc/test-parens.rs
+++ b/src/test/rustdoc/test-parens.rs
@@ -11,5 +11,5 @@
 #![crate_name = "foo"]
 
 // @has foo/fn.foo.html
-// @has - '//*[@class="rust fn"]' "_: &(ToString + 'static)"
+// @has - '//*[@class="rust fn"]' "_: &(dyn ToString + 'static)"
 pub fn foo(_: &(ToString + 'static)) {}


### PR DESCRIPTION
The dyn keyword has been stable for a while now so rustdoc should start using it.

r? @QuietMisdreavus