### PR TITLE
Detect if access to localStorage is forbidden by the user's browser

### DIFF
--- a/src/librustdoc/html/static/storage.js
+++ b/src/librustdoc/html/static/storage.js
@@ -26,21 +26,6 @@ function onEach(arr, func) {
     return false;
 }
 
-function updateLocalStorage(name, value) {
-    if (usableLocalStorage()) {
-        localStorage[name] = value;
-    } else {
-        // No Web Storage support so we do nothing
-    }
-}
-
-function getCurrentValue(name) {
-    if (usableLocalStorage() && localStorage[name] !== undefined) {
-        return localStorage[name];
-    }
-    return null;
-}
-
 function usableLocalStorage() {
     // Check if the browser supports localStorage at all:
     if (typeof(Storage) === "undefined") {
@@ -57,6 +42,21 @@ function usableLocalStorage() {
     }
 
     return true;
+}
+
+function updateLocalStorage(name, value) {
+    if (usableLocalStorage()) {
+        localStorage[name] = value;
+    } else {
+        // No Web Storage support so we do nothing
+    }
+}
+
+function getCurrentValue(name) {
+    if (usableLocalStorage() && localStorage[name] !== undefined) {
+        return localStorage[name];
+    }
+    return null;
 }
 
 function switchTheme(styleElem, mainStyleElem, newTheme) {

--- a/src/librustdoc/html/static/storage.js
+++ b/src/librustdoc/html/static/storage.js
@@ -28,6 +28,12 @@ function onEach(arr, func) {
 
 function updateLocalStorage(name, value) {
     if (typeof(Storage) !== "undefined") {
+        try {
+            window.localStorage;
+        } catch(err) {
+            // Storage is supported, but browser preferences deny access to it.
+            return;
+        }
         localStorage[name] = value;
     } else {
         // No Web Storage support so we do nothing

--- a/src/librustdoc/html/static/storage.js
+++ b/src/librustdoc/html/static/storage.js
@@ -27,13 +27,7 @@ function onEach(arr, func) {
 }
 
 function updateLocalStorage(name, value) {
-    if (typeof(Storage) !== "undefined") {
-        try {
-            window.localStorage;
-        } catch(err) {
-            // Storage is supported, but browser preferences deny access to it.
-            return;
-        }
+    if (usableLocalStorage()) {
         localStorage[name] = value;
     } else {
         // No Web Storage support so we do nothing
@@ -41,10 +35,28 @@ function updateLocalStorage(name, value) {
 }
 
 function getCurrentValue(name) {
-    if (typeof(Storage) !== "undefined" && localStorage[name] !== undefined) {
+    if (usableLocalStorage() && localStorage[name] !== undefined) {
         return localStorage[name];
     }
     return null;
+}
+
+function usableLocalStorage() {
+    // Check if the browser supports localStorage at all:
+    if (typeof(Storage) === "undefined") {
+        return false;
+    }
+    // Check if we can access it; this access will fail if the browser
+    // preferences deny access to localStorage, e.g., to prevent storage of
+    // "cookies" (or cookie-likes, as is the case here).
+    try {
+        window.localStorage;
+    } catch(err) {
+        // Storage is supported, but browser preferences deny access to it.
+        return false;
+    }
+
+    return true;
 }
 
 function switchTheme(styleElem, mainStyleElem, newTheme) {


### PR DESCRIPTION
If the user's cookie/persistent storage setting forbid access to `localStorage`, catch the exception and abort the access.

Currently, attempting to use the expand/contract links at the top of the page for structs/consts/etc. fails due to an unhandled error while accessing `localStorage`, if such access is forbidden, as the exception from the failed access propagates all the way out, interrupting the expand/contract. Instead, I would like to degrade gracefully; the access won't happen (the collapse/expand state won't get persisted) but the actual expanding/contracting of the item will go on to succeed.

Fixes #55079