### PR TITLE
rustc: improve E0669 span

### DIFF
--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -1713,7 +1713,7 @@ pub enum StatementKind<'tcx> {
     InlineAsm {
         asm: Box<InlineAsm>,
         outputs: Box<[Place<'tcx>]>,
-        inputs: Box<[Operand<'tcx>]>,
+        inputs: Box<[(Span, Operand<'tcx>)]>,
     },
 
     /// Assert the given places to be valid inhabitants of their type.  These statements are

--- a/src/librustc/mir/visit.rs
+++ b/src/librustc/mir/visit.rs
@@ -383,7 +383,8 @@ macro_rules! make_mir_visitor {
                         for output in & $($mutability)* outputs[..] {
                             self.visit_place(output, PlaceContext::AsmOutput, location);
                         }
-                        for input in & $($mutability)* inputs[..] {
+                        for (span, input) in & $($mutability)* inputs[..] {
+                            self.visit_span(span);
                             self.visit_operand(input, location);
                         }
                     }

--- a/src/librustc_codegen_llvm/mir/statement.rs
+++ b/src/librustc_codegen_llvm/mir/statement.rs
@@ -84,18 +84,18 @@ impl FunctionCx<'a, 'll, 'tcx> {
                 }).collect();
 
                 let input_vals = inputs.iter()
-                    .try_fold(Vec::with_capacity(inputs.len()), |mut acc, input| {
+                    .try_fold(Vec::with_capacity(inputs.len()), |mut acc, (span, input)| {
                         let op = self.codegen_operand(&bx, input);
                         if let OperandValue::Immediate(_) = op.val {
                             acc.push(op.immediate());
                             Ok(acc)
                         } else {
-                            Err(op)
+                            Err(span)
                         }
                 });
 
-                if input_vals.is_err() {
-                   span_err!(bx.sess(), statement.source_info.span, E0669,
+                if let Err(span) = input_vals {
+                    span_err!(bx.sess(), span.to_owned(), E0669,
                              "invalid value for constraint in inline assembly");
                 } else {
                     let input_vals = input_vals.unwrap();

--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -565,7 +565,7 @@ impl<'cx, 'gcx, 'tcx> DataflowResultsConsumer<'cx, 'tcx> for MirBorrowckCtxt<'cx
                         );
                     }
                 }
-                for input in inputs.iter() {
+                for (_, input) in inputs.iter() {
                     self.consume_operand(context, (input, span), flow_state);
                 }
             }

--- a/src/librustc_mir/borrow_check/nll/invalidation.rs
+++ b/src/librustc_mir/borrow_check/nll/invalidation.rs
@@ -128,7 +128,7 @@ impl<'cx, 'tcx, 'gcx> Visitor<'tcx> for InvalidationGenerator<'cx, 'tcx, 'gcx> {
                         );
                     }
                 }
-                for input in inputs.iter() {
+                for (_, input) in inputs.iter() {
                     self.consume_operand(context, input);
                 }
             }

--- a/src/librustc_mir/build/expr/stmt.rs
+++ b/src/librustc_mir/build/expr/stmt.rs
@@ -167,8 +167,12 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                     .into_boxed_slice();
                 let inputs = inputs
                     .into_iter()
-                    .map(|input| unpack!(block = this.as_local_operand(block, input)))
-                    .collect::<Vec<_>>()
+                    .map(|input| {
+                        (
+                            input.span(),
+                            unpack!(block = this.as_local_operand(block, input)),
+                        )
+                    }).collect::<Vec<_>>()
                     .into_boxed_slice();
                 this.cfg.push(
                     block,

--- a/src/librustc_mir/dataflow/move_paths/builder.rs
+++ b/src/librustc_mir/dataflow/move_paths/builder.rs
@@ -290,7 +290,7 @@ impl<'b, 'a, 'gcx, 'tcx> Gatherer<'b, 'a, 'gcx, 'tcx> {
                         self.gather_init(output, InitKind::Deep);
                     }
                 }
-                for input in inputs.iter() {
+                for (_, input) in inputs.iter() {
                     self.gather_operand(input);
                 }
             }

--- a/src/test/ui/inline-asm-bad-operand.rs
+++ b/src/test/ui/inline-asm-bad-operand.rs
@@ -21,6 +21,7 @@ fn main() {
     issue_37437();
     issue_40187();
     issue_54067();
+    multiple_errors();
 }
 
 fn issue_37433() {
@@ -53,5 +54,13 @@ fn issue_54067() {
     let addr: Option<u32> = Some(123);
     unsafe {
         asm!("mov sp, $0"::"r"(addr)); //~ ERROR E0669
+    }
+}
+
+fn multiple_errors() {
+    let addr: (u32, u32) = (1, 2);
+    unsafe {
+        asm!("mov sp, $0"::"r"(addr), //~ ERROR E0669
+                           "r"("hello e0669")); //~ ERROR E0669
     }
 }

--- a/src/test/ui/inline-asm-bad-operand.stderr
+++ b/src/test/ui/inline-asm-bad-operand.stderr
@@ -1,33 +1,45 @@
 error[E0669]: invalid value for constraint in inline assembly
-  --> $DIR/inline-asm-bad-operand.rs:28:24
+  --> $DIR/inline-asm-bad-operand.rs:29:24
    |
 LL |         asm!("" :: "r"("")); //~ ERROR E0669
    |                        ^^
 
 error[E0669]: invalid value for constraint in inline assembly
-  --> $DIR/inline-asm-bad-operand.rs:33:32
+  --> $DIR/inline-asm-bad-operand.rs:34:32
    |
 LL |         asm!("ret" : : "{rdi}"(target)); //~ ERROR E0669
    |                                ^^^^^^
 
 error[E0669]: invalid value for constraint in inline assembly
-  --> $DIR/inline-asm-bad-operand.rs:40:29
+  --> $DIR/inline-asm-bad-operand.rs:41:29
    |
 LL |     unsafe { asm!("" :: "i"(hello)) }; //~ ERROR E0669
    |                             ^^^^^
 
 error[E0669]: invalid value for constraint in inline assembly
-  --> $DIR/inline-asm-bad-operand.rs:48:38
+  --> $DIR/inline-asm-bad-operand.rs:49:38
    |
 LL |         asm!("movups $1, %xmm0"::"m"(arr)); //~ ERROR E0669
    |                                      ^^^
 
 error[E0669]: invalid value for constraint in inline assembly
-  --> $DIR/inline-asm-bad-operand.rs:55:32
+  --> $DIR/inline-asm-bad-operand.rs:56:32
    |
 LL |         asm!("mov sp, $0"::"r"(addr)); //~ ERROR E0669
    |                                ^^^^
 
-error: aborting due to 5 previous errors
+error[E0669]: invalid value for constraint in inline assembly
+  --> $DIR/inline-asm-bad-operand.rs:63:32
+   |
+LL |         asm!("mov sp, $0"::"r"(addr), //~ ERROR E0669
+   |                                ^^^^
+
+error[E0669]: invalid value for constraint in inline assembly
+  --> $DIR/inline-asm-bad-operand.rs:64:32
+   |
+LL |                            "r"("hello e0669")); //~ ERROR E0669
+   |                                ^^^^^^^^^^^^^
+
+error: aborting due to 7 previous errors
 
 For more information about this error, try `rustc --explain E0669`.

--- a/src/test/ui/inline-asm-bad-operand.stderr
+++ b/src/test/ui/inline-asm-bad-operand.stderr
@@ -1,32 +1,32 @@
 error[E0669]: invalid value for constraint in inline assembly
-  --> $DIR/inline-asm-bad-operand.rs:28:9
+  --> $DIR/inline-asm-bad-operand.rs:28:24
    |
 LL |         asm!("" :: "r"("")); //~ ERROR E0669
-   |         ^^^^^^^^^^^^^^^^^^^^
+   |                        ^^
 
 error[E0669]: invalid value for constraint in inline assembly
-  --> $DIR/inline-asm-bad-operand.rs:33:9
+  --> $DIR/inline-asm-bad-operand.rs:33:32
    |
 LL |         asm!("ret" : : "{rdi}"(target)); //~ ERROR E0669
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                ^^^^^^
 
 error[E0669]: invalid value for constraint in inline assembly
-  --> $DIR/inline-asm-bad-operand.rs:40:14
+  --> $DIR/inline-asm-bad-operand.rs:40:29
    |
 LL |     unsafe { asm!("" :: "i"(hello)) }; //~ ERROR E0669
-   |              ^^^^^^^^^^^^^^^^^^^^^^
+   |                             ^^^^^
 
 error[E0669]: invalid value for constraint in inline assembly
-  --> $DIR/inline-asm-bad-operand.rs:48:9
+  --> $DIR/inline-asm-bad-operand.rs:48:38
    |
 LL |         asm!("movups $1, %xmm0"::"m"(arr)); //~ ERROR E0669
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                      ^^^
 
 error[E0669]: invalid value for constraint in inline assembly
-  --> $DIR/inline-asm-bad-operand.rs:55:9
+  --> $DIR/inline-asm-bad-operand.rs:55:32
    |
 LL |         asm!("mov sp, $0"::"r"(addr)); //~ ERROR E0669
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                ^^^^
 
 error: aborting due to 5 previous errors
 


### PR DESCRIPTION
E0669 refers to an operand that cannot be coerced into a single LLVM
value, unfortunately right now this uses the Span for the entire inline
assembly statement, which is less than ideal.

This commit preserves the Span from HIR, which lets us emit the error
using the Span for the operand itself in MIR.

r? @nagisa 
cc/ @parched 