### PR TITLE
regression test for move out of borrow via pattern

### DIFF
--- a/src/test/ui/borrowck/issue-54597-reject-move-out-of-borrow-via-pat.rs
+++ b/src/test/ui/borrowck/issue-54597-reject-move-out-of-borrow-via-pat.rs
@@ -1,0 +1,22 @@
+#![feature(nll)]
+
+#![allow(dead_code)]
+
+#[derive(Debug)]
+struct Value;
+impl Value {
+    fn as_array(&self) -> Option<&Vec<Value>> {
+        None
+    }
+}
+
+fn foo(val: Value) {
+    let _reviewers_original: Vec<Value> = match val.as_array() {
+        Some(array) => {
+            *array
+        }
+        None => vec![]
+    };
+}
+
+fn main() { }

--- a/src/test/ui/borrowck/issue-54597-reject-move-out-of-borrow-via-pat.stderr
+++ b/src/test/ui/borrowck/issue-54597-reject-move-out-of-borrow-via-pat.stderr
@@ -1,0 +1,12 @@
+error[E0507]: cannot move out of borrowed content
+  --> $DIR/issue-54597-reject-move-out-of-borrow-via-pat.rs:16:13
+   |
+LL |             *array
+   |             ^^^^^^
+   |             |
+   |             cannot move out of borrowed content
+   |             help: consider removing the `*`: `array`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0507`.


### PR DESCRIPTION
regression test for issue #54597.

(We may have other tests that cover this, but I couldn't immediately find them associated with the PR that originally fixed the ICE here.)