### PR TITLE
[Rustc Book] Explain --cfg's arguments

### DIFF
--- a/src/doc/rustc/src/command-line-arguments.md
+++ b/src/doc/rustc/src/command-line-arguments.md
@@ -10,6 +10,11 @@ This flag will print out help information for `rustc`.
 
 This flag can turn on or off various `#[cfg]` settings.
 
+The value can either be a single identifier or two identifiers separated by `=`.
+
+For examples, `--cfg 'verbose'` or `--cfg 'feature=serde'`. These correspond
+to `#[cfg(verbose)]` and `#[cfg(feature = "serde")]` respectively.
+
 ## `-L`: add a directory to the library search path
 
 When looking for external crates, a directory passed to this flag will be searched.

--- a/src/doc/rustc/src/command-line-arguments.md
+++ b/src/doc/rustc/src/command-line-arguments.md
@@ -12,7 +12,7 @@ This flag can turn on or off various `#[cfg]` settings.
 
 The value can either be a single identifier or two identifiers separated by `=`.
 
-For examples, `--cfg 'verbose'` or `--cfg 'feature=serde'`. These correspond
+For examples, `--cfg 'verbose'` or `--cfg 'feature="serde"'`. These correspond
 to `#[cfg(verbose)]` and `#[cfg(feature = "serde")]` respectively.
 
 ## `-L`: add a directory to the library search path


### PR DESCRIPTION
I removed this from the reference since it's rustc specific, and noticed it wasn't well documented on the page that should document it well. It does seem to go against the grain of one line per command line flag though.

r? @GuillaumeGomez 