### PR TITLE
#45829 when a renamed import conflict with a previous import

### DIFF
--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -449,7 +449,10 @@ impl<'a, 'cl> Resolver<'a, 'cl> {
                     id: item.id,
                     parent,
                     imported_module: Cell::new(Some(ModuleOrUniformRoot::Module(module))),
-                    subclass: ImportDirectiveSubclass::ExternCrate(orig_name),
+                    subclass: ImportDirectiveSubclass::ExternCrate {
+                        source: orig_name,
+                        target: ident,
+                    },
                     root_span: item.span,
                     span: item.span,
                     module_path: Vec::new(),

--- a/src/librustc_resolve/check_unused.rs
+++ b/src/librustc_resolve/check_unused.rs
@@ -144,7 +144,7 @@ pub fn check_crate(resolver: &mut Resolver, krate: &ast::Crate) {
                     }
                 }
             }
-            ImportDirectiveSubclass::ExternCrate(_) => {
+            ImportDirectiveSubclass::ExternCrate { .. } => {
                 resolver.maybe_unused_extern_crates.push((directive.id, directive.span));
             }
             ImportDirectiveSubclass::MacroUse => {

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -4796,10 +4796,18 @@ impl<'a, 'crateloader: 'a> Resolver<'a, 'crateloader> {
                 err.span_suggestion_with_applicability(
                     binding.span,
                     rename_msg,
-                    if snippet.ends_with(';') {
-                        format!("{} as {};", &snippet[..snippet.len() - 1], suggested_name)
+                    if snippet.contains(" as ") {
+                        format!(
+                            "{} as {}",
+                            &snippet[..snippet.find(" as ").unwrap()],
+                            suggested_name,
+                        )
                     } else {
-                        format!("{} as {}", snippet, suggested_name)
+                        if snippet.ends_with(';') {
+                            format!("{} as {};", &snippet[..snippet.len() - 1], suggested_name)
+                        } else {
+                            format!("{} as {}", snippet, suggested_name)
+                        }
                     },
                     Applicability::MachineApplicable,
                 );

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -4786,7 +4786,10 @@ impl<'a, 'crateloader: 'a> Resolver<'a, 'crateloader> {
                 err.span_suggestion_with_applicability(
                     binding.span,
                     rename_msg,
-                    match (snippet.split_whitespace().find(|w| *w == "as"), snippet.ends_with(";")) {
+                    match (
+                        snippet.split_whitespace().find(|w| *w == "as"),
+                        snippet.ends_with(";")
+                    ) {
                         (Some(_), false) => format!("{} as {}",
                             &snippet[..snippet.find(" as ").unwrap()],
                             suggested_name,
@@ -4796,7 +4799,7 @@ impl<'a, 'crateloader: 'a> Resolver<'a, 'crateloader> {
                             suggested_name,
                         ),
                         (None, false) => format!("{} as {}", snippet, suggested_name),
-                        (None, true) => format!("{} as {};", 
+                        (None, true) => format!("{} as {};",
                             &snippet[..snippet.len() - 1],
                             suggested_name
                         ),

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -52,7 +52,10 @@ pub enum ImportDirectiveSubclass<'a> {
         max_vis: Cell<ty::Visibility>, // The visibility of the greatest re-export.
         // n.b. `max_vis` is only used in `finalize_import` to check for re-export errors.
     },
-    ExternCrate(Option<Name>),
+    ExternCrate {
+        source: Option<Name>,
+        target: Ident,
+    },
     MacroUse,
 }
 
@@ -1342,7 +1345,7 @@ fn import_directive_subclass_to_string(subclass: &ImportDirectiveSubclass) -> St
     match *subclass {
         SingleImport { source, .. } => source.to_string(),
         GlobImport { .. } => "*".to_string(),
-        ExternCrate(_) => "<extern crate>".to_string(),
+        ExternCrate { .. } => "<extern crate>".to_string(),
         MacroUse => "#[macro_use]".to_string(),
     }
 }

--- a/src/test/ui/blind/blind-item-block-item-shadow.stderr
+++ b/src/test/ui/blind/blind-item-block-item-shadow.stderr
@@ -7,7 +7,7 @@ LL |         use foo::Bar;
    |             ^^^^^^^^ `Bar` reimported here
    |
    = note: `Bar` must be defined only once in the type namespace of this block
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL |         use foo::Bar as OtherBar;
    |             ^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/blind/blind-item-item-shadow.stderr
+++ b/src/test/ui/blind/blind-item-item-shadow.stderr
@@ -8,7 +8,7 @@ LL | use foo::foo;
    |     ^^^^^^^^ `foo` reimported here
    |
    = note: `foo` must be defined only once in the type namespace of this module
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL | use foo::foo as other_foo;
    |     ^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/double-import.stderr
+++ b/src/test/ui/double-import.stderr
@@ -7,7 +7,7 @@ LL | use sub2::foo; //~ ERROR the name `foo` is defined multiple times
    |     ^^^^^^^^^ `foo` reimported here
    |
    = note: `foo` must be defined only once in the value namespace of this module
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL | use sub2::foo as other_foo; //~ ERROR the name `foo` is defined multiple times
    |     ^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/double-type-import.stderr
+++ b/src/test/ui/double-type-import.stderr
@@ -7,7 +7,7 @@ LL |     use self::bar::X;
    |         ^^^^^^^^^^^^ `X` reimported here
    |
    = note: `X` must be defined only once in the type namespace of this module
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL |     use self::bar::X as OtherX;
    |         ^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/duplicate/duplicate-check-macro-exports.stderr
+++ b/src/test/ui/duplicate/duplicate-check-macro-exports.stderr
@@ -8,7 +8,7 @@ LL | macro_rules! panic { () => {} } //~ ERROR the name `panic` is defined multi
    | ^^^^^^^^^^^^^^^^^^ `panic` redefined here
    |
    = note: `panic` must be defined only once in the macro namespace of this module
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL | pub use std::panic as other_panic;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/error-codes/E0252.stderr
+++ b/src/test/ui/error-codes/E0252.stderr
@@ -7,7 +7,7 @@ LL | use bar::baz; //~ ERROR E0252
    |     ^^^^^^^^ `baz` reimported here
    |
    = note: `baz` must be defined only once in the type namespace of this module
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL | use bar::baz as other_baz; //~ ERROR E0252
    |     ^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/error-codes/E0254.stderr
+++ b/src/test/ui/error-codes/E0254.stderr
@@ -8,7 +8,7 @@ LL | use foo::alloc;
    |     ^^^^^^^^^^ `alloc` reimported here
    |
    = note: `alloc` must be defined only once in the type namespace of this module
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL | use foo::alloc as other_alloc;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/error-codes/E0255.stderr
+++ b/src/test/ui/error-codes/E0255.stderr
@@ -8,7 +8,7 @@ LL | fn foo() {} //~ ERROR E0255
    | ^^^^^^^^ `foo` redefined here
    |
    = note: `foo` must be defined only once in the value namespace of this module
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL | use bar::foo as other_foo;
    |     ^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/error-codes/E0259.stderr
+++ b/src/test/ui/error-codes/E0259.stderr
@@ -5,12 +5,13 @@ LL | extern crate alloc;
    | ------------------- previous import of the extern crate `alloc` here
 LL | 
 LL | extern crate libc as alloc;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   | |
-   | `alloc` reimported here
-   | You can use `as` to change the binding name of the import
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `alloc` reimported here
    |
    = note: `alloc` must be defined only once in the type namespace of this module
+help: you can use `as` to change the binding name of the import
+   |
+LL | extern crate libc as other_alloc;
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0260.stderr
+++ b/src/test/ui/error-codes/E0260.stderr
@@ -8,7 +8,7 @@ LL | mod alloc {
    | ^^^^^^^^^ `alloc` redefined here
    |
    = note: `alloc` must be defined only once in the type namespace of this module
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL | extern crate alloc as other_alloc;
    |

--- a/src/test/ui/error-codes/E0430.stderr
+++ b/src/test/ui/error-codes/E0430.stderr
@@ -15,7 +15,7 @@ LL | use std::fmt::{self, self}; //~ ERROR E0430
    |                previous import of the module `fmt` here
    |
    = note: `fmt` must be defined only once in the type namespace of this module
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL | use std::fmt::{self, self as other_fmt}; //~ ERROR E0430
    |                      ^^^^^^^^^^^^^^^^^

--- a/src/test/ui/extern/extern-crate-rename.stderr
+++ b/src/test/ui/extern/extern-crate-rename.stderr
@@ -4,12 +4,13 @@ error[E0259]: the name `m1` is defined multiple times
 LL | extern crate m1;
    | ---------------- previous import of the extern crate `m1` here
 LL | extern crate m2 as m1; //~ ERROR is defined multiple times
-   | ^^^^^^^^^^^^^^^^^^^^^^
-   | |
-   | `m1` reimported here
-   | You can use `as` to change the binding name of the import
+   | ^^^^^^^^^^^^^^^^^^^^^^ `m1` reimported here
    |
    = note: `m1` must be defined only once in the type namespace of this module
+help: you can use `as` to change the binding name of the import
+   |
+LL | extern crate m2 as other_m1; //~ ERROR is defined multiple times
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/imports/duplicate.stderr
+++ b/src/test/ui/imports/duplicate.stderr
@@ -7,7 +7,7 @@ LL |     use a::foo; //~ ERROR the name `foo` is defined multiple times
    |         ^^^^^^ `foo` reimported here
    |
    = note: `foo` must be defined only once in the value namespace of this module
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL |     use a::foo as other_foo; //~ ERROR the name `foo` is defined multiple times
    |         ^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/issues/issue-19498.stderr
+++ b/src/test/ui/issues/issue-19498.stderr
@@ -8,7 +8,7 @@ LL | mod A {} //~ ERROR the name `A` is defined multiple times
    | ^^^^^ `A` redefined here
    |
    = note: `A` must be defined only once in the type namespace of this module
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL | use self::A as OtherA;
    |     ^^^^^^^^^^^^^^^^^
@@ -23,7 +23,7 @@ LL | pub mod B {} //~ ERROR the name `B` is defined multiple times
    | ^^^^^^^^^ `B` redefined here
    |
    = note: `B` must be defined only once in the type namespace of this module
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL | use self::B as OtherB;
    |     ^^^^^^^^^^^^^^^^^
@@ -37,7 +37,7 @@ LL |     mod D {} //~ ERROR the name `D` is defined multiple times
    |     ^^^^^ `D` redefined here
    |
    = note: `D` must be defined only once in the type namespace of this module
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL |     use C::D as OtherD;
    |         ^^^^^^^^^^^^^^

--- a/src/test/ui/issues/issue-24081.stderr
+++ b/src/test/ui/issues/issue-24081.stderr
@@ -8,7 +8,7 @@ LL | type Add = bool; //~ ERROR the name `Add` is defined multiple times
    | ^^^^^^^^^^^^^^^^ `Add` redefined here
    |
    = note: `Add` must be defined only once in the type namespace of this module
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL | use std::ops::Add as OtherAdd;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -23,7 +23,7 @@ LL | struct Sub { x: f32 } //~ ERROR the name `Sub` is defined multiple times
    | ^^^^^^^^^^ `Sub` redefined here
    |
    = note: `Sub` must be defined only once in the type namespace of this module
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL | use std::ops::Sub as OtherSub;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -38,7 +38,7 @@ LL | enum Mul { A, B } //~ ERROR the name `Mul` is defined multiple times
    | ^^^^^^^^ `Mul` redefined here
    |
    = note: `Mul` must be defined only once in the type namespace of this module
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL | use std::ops::Mul as OtherMul;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -53,7 +53,7 @@ LL | mod Div { } //~ ERROR the name `Div` is defined multiple times
    | ^^^^^^^ `Div` redefined here
    |
    = note: `Div` must be defined only once in the type namespace of this module
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL | use std::ops::Div as OtherDiv;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -68,7 +68,7 @@ LL | trait Rem {  } //~ ERROR the name `Rem` is defined multiple times
    | ^^^^^^^^^ `Rem` redefined here
    |
    = note: `Rem` must be defined only once in the type namespace of this module
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL | use std::ops::Rem as OtherRem;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/issues/issue-25396.stderr
+++ b/src/test/ui/issues/issue-25396.stderr
@@ -7,7 +7,7 @@ LL | use bar::baz; //~ ERROR the name `baz` is defined multiple times
    |     ^^^^^^^^ `baz` reimported here
    |
    = note: `baz` must be defined only once in the type namespace of this module
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL | use bar::baz as other_baz; //~ ERROR the name `baz` is defined multiple times
    |     ^^^^^^^^^^^^^^^^^^^^^
@@ -21,7 +21,7 @@ LL | use bar::Quux; //~ ERROR the name `Quux` is defined multiple times
    |     ^^^^^^^^^ `Quux` reimported here
    |
    = note: `Quux` must be defined only once in the type namespace of this module
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL | use bar::Quux as OtherQuux; //~ ERROR the name `Quux` is defined multiple times
    |     ^^^^^^^^^^^^^^^^^^^^^^
@@ -35,7 +35,7 @@ LL | use bar::blah; //~ ERROR the name `blah` is defined multiple times
    |     ^^^^^^^^^ `blah` reimported here
    |
    = note: `blah` must be defined only once in the type namespace of this module
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL | use bar::blah as other_blah; //~ ERROR the name `blah` is defined multiple times
    |     ^^^^^^^^^^^^^^^^^^^^^^^
@@ -49,7 +49,7 @@ LL | use bar::WOMP; //~ ERROR the name `WOMP` is defined multiple times
    |     ^^^^^^^^^ `WOMP` reimported here
    |
    = note: `WOMP` must be defined only once in the value namespace of this module
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL | use bar::WOMP as OtherWOMP; //~ ERROR the name `WOMP` is defined multiple times
    |     ^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/issues/issue-26886.stderr
+++ b/src/test/ui/issues/issue-26886.stderr
@@ -7,7 +7,7 @@ LL | use std::sync::Arc; //~ ERROR the name `Arc` is defined multiple times
    |     ^^^^^^^^^^^^^^ `Arc` reimported here
    |
    = note: `Arc` must be defined only once in the type namespace of this module
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL | use std::sync::Arc as OtherArc; //~ ERROR the name `Arc` is defined multiple times
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -22,7 +22,7 @@ LL | use std::sync; //~ ERROR the name `sync` is defined multiple times
    |     ^^^^^^^^^ `sync` reimported here
    |
    = note: `sync` must be defined only once in the type namespace of this module
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL | use std::sync as other_sync; //~ ERROR the name `sync` is defined multiple times
    |     ^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/issues/issue-32354-suggest-import-rename.stderr
+++ b/src/test/ui/issues/issue-32354-suggest-import-rename.stderr
@@ -7,7 +7,7 @@ LL | use extension2::ConstructorExtension; //~ ERROR is defined multiple times
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ConstructorExtension` reimported here
    |
    = note: `ConstructorExtension` must be defined only once in the type namespace of this module
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL | use extension2::ConstructorExtension as OtherConstructorExtension; //~ ERROR is defined multiple times
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/issues/issue-45799-bad-extern-crate-rename-suggestion-formatting.stderr
+++ b/src/test/ui/issues/issue-45799-bad-extern-crate-rename-suggestion-formatting.stderr
@@ -5,7 +5,7 @@ LL | extern crate std;
    | ^^^^^^^^^^^^^^^^^ `std` reimported here
    |
    = note: `std` must be defined only once in the type namespace of this module
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL | extern crate std as other_std;
    |

--- a/src/test/ui/issues/issue-45829/auxiliary/issue_45829_a.rs
+++ b/src/test/ui/issues/issue-45829/auxiliary/issue_45829_a.rs
@@ -1,0 +1,11 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub const FOO: usize = *&0;

--- a/src/test/ui/issues/issue-45829/auxiliary/issue_45829_b.rs
+++ b/src/test/ui/issues/issue-45829/auxiliary/issue_45829_b.rs
@@ -1,0 +1,11 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub const FOO: usize = *&0;

--- a/src/test/ui/issues/issue-45829/import-self.rs
+++ b/src/test/ui/issues/issue-45829/import-self.rs
@@ -1,0 +1,22 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+mod foo {
+    pub struct A;
+    pub struct B;
+}
+
+use foo::{self};
+
+use foo as self;
+
+use foo::self;
+
+fn main() {}

--- a/src/test/ui/issues/issue-45829/import-self.stderr
+++ b/src/test/ui/issues/issue-45829/import-self.stderr
@@ -1,0 +1,31 @@
+error: expected identifier, found keyword `self`
+  --> $DIR/import-self.rs:18:12
+   |
+LL | use foo as self;
+   |            ^^^^ expected identifier, found keyword
+
+error[E0429]: `self` imports are only allowed within a { } list
+  --> $DIR/import-self.rs:20:5
+   |
+LL | use foo::self;
+   |     ^^^^^^^^^
+
+error[E0255]: the name `foo` is defined multiple times
+  --> $DIR/import-self.rs:16:11
+   |
+LL | mod foo {
+   | ------- previous definition of the module `foo` here
+...
+LL | use foo::{self};
+   |           ^^^^ `foo` reimported here
+   |
+   = note: `foo` must be defined only once in the type namespace of this module
+help: you can use `as` to change the binding name of the import
+   |
+LL | use foo::{self as other_foo};
+   |           ^^^^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+
+Some errors occurred: E0255, E0429.
+For more information about an error, try `rustc --explain E0255`.

--- a/src/test/ui/issues/issue-45829/import-twice.rs
+++ b/src/test/ui/issues/issue-45829/import-twice.rs
@@ -1,0 +1,18 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+mod foo {
+    pub struct A;
+    pub struct B;
+}
+
+use foo::{A, A};
+
+fn main() {}

--- a/src/test/ui/issues/issue-45829/import-twice.stderr
+++ b/src/test/ui/issues/issue-45829/import-twice.stderr
@@ -1,0 +1,17 @@
+error[E0252]: the name `A` is defined multiple times
+  --> $DIR/import-twice.rs:16:14
+   |
+LL | use foo::{A, A};
+   |           -  ^ `A` reimported here
+   |           |
+   |           previous import of the type `A` here
+   |
+   = note: `A` must be defined only once in the type namespace of this module
+help: you can use `as` to change the binding name of the import
+   |
+LL | use foo::{A, A as OtherA};
+   |              ^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0252`.

--- a/src/test/ui/issues/issue-45829/issue-45829.rs
+++ b/src/test/ui/issues/issue-45829/issue-45829.rs
@@ -8,13 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// aux-build:issue_45829_b.rs
-
 mod foo {
-    pub mod bar {}
+    pub struct A;
+    pub struct B;
 }
 
-use foo::bar;
-extern crate issue_45829_b as bar;
+use foo::{A, B as A};
 
 fn main() {}

--- a/src/test/ui/issues/issue-45829/issue-45829.stderr
+++ b/src/test/ui/issues/issue-45829/issue-45829.stderr
@@ -1,16 +1,16 @@
 error[E0252]: the name `A` is defined multiple times
-  --> $DIR/rename-with-path.rs:11:38
+  --> $DIR/issue-45829.rs:16:14
    |
-LL | use std::{collections::HashMap as A, sync::Arc as A};
-   |           -------------------------  ^^^^^^^^^^^^^^ `A` reimported here
+LL | use foo::{A, B as A};
+   |           -  ^^^^^^ `A` reimported here
    |           |
    |           previous import of the type `A` here
    |
    = note: `A` must be defined only once in the type namespace of this module
 help: you can use `as` to change the binding name of the import
    |
-LL | use std::{collections::HashMap as A, sync::Arc as OtherA};
-   |                                      ^^^^^^^^^^^^^^^^^^^
+LL | use foo::{A, B as OtherA};
+   |              ^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-45829/rename-extern-vs-use.rs
+++ b/src/test/ui/issues/issue-45829/rename-extern-vs-use.rs
@@ -1,0 +1,16 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:issue_45829_b.rs
+
+use std;
+extern crate issue_45829_b as std;
+
+fn main() {}

--- a/src/test/ui/issues/issue-45829/rename-extern-vs-use.stderr
+++ b/src/test/ui/issues/issue-45829/rename-extern-vs-use.stderr
@@ -1,0 +1,27 @@
+error[E0259]: the name `std` is defined multiple times
+  --> $DIR/rename-extern-vs-use.rs:14:1
+   |
+LL | extern crate issue_45829_b as std;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | |
+   | `std` reimported here
+   | You can use `as` to change the binding name of the import
+   |
+   = note: `std` must be defined only once in the type namespace of this module
+
+error[E0254]: the name `std` is defined multiple times
+  --> $DIR/rename-extern-vs-use.rs:13:5
+   |
+LL | use std;
+   |     ^^^ `std` reimported here
+   |
+   = note: `std` must be defined only once in the type namespace of this module
+help: You can use `as` to change the binding name of the import
+   |
+LL | use std as other_std;
+   |     ^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+
+Some errors occurred: E0254, E0259.
+For more information about an error, try `rustc --explain E0254`.

--- a/src/test/ui/issues/issue-45829/rename-extern-vs-use.stderr
+++ b/src/test/ui/issues/issue-45829/rename-extern-vs-use.stderr
@@ -1,27 +1,17 @@
-error[E0259]: the name `std` is defined multiple times
-  --> $DIR/rename-extern-vs-use.rs:14:1
+error[E0254]: the name `bar` is defined multiple times
+  --> $DIR/rename-extern-vs-use.rs:18:1
    |
-LL | extern crate issue_45829_b as std;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   | |
-   | `std` reimported here
-   | You can use `as` to change the binding name of the import
+LL | use foo::bar;
+   |     -------- previous import of the module `bar` here
+LL | extern crate issue_45829_b as bar;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `bar` reimported here
    |
-   = note: `std` must be defined only once in the type namespace of this module
+   = note: `bar` must be defined only once in the type namespace of this module
+help: you can use `as` to change the binding name of the import
+   |
+LL | extern crate issue_45829_b as other_bar;
+   |
 
-error[E0254]: the name `std` is defined multiple times
-  --> $DIR/rename-extern-vs-use.rs:13:5
-   |
-LL | use std;
-   |     ^^^ `std` reimported here
-   |
-   = note: `std` must be defined only once in the type namespace of this module
-help: You can use `as` to change the binding name of the import
-   |
-LL | use std as other_std;
-   |     ^^^^^^^^^^^^^^^^
+error: aborting due to previous error
 
-error: aborting due to 2 previous errors
-
-Some errors occurred: E0254, E0259.
-For more information about an error, try `rustc --explain E0254`.
+For more information about this error, try `rustc --explain E0254`.

--- a/src/test/ui/issues/issue-45829/rename-extern-with-tab.rs
+++ b/src/test/ui/issues/issue-45829/rename-extern-with-tab.rs
@@ -1,0 +1,17 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:issue_45829_a.rs
+// aux-build:issue_45829_b.rs
+
+extern crate issue_45829_a;
+extern  crate    issue_45829_b  as  issue_45829_a;
+
+fn main() {}

--- a/src/test/ui/issues/issue-45829/rename-extern-with-tab.stderr
+++ b/src/test/ui/issues/issue-45829/rename-extern-with-tab.stderr
@@ -1,0 +1,17 @@
+error[E0259]: the name `issue_45829_a` is defined multiple times
+  --> $DIR/rename-extern-with-tab.rs:15:1
+   |
+LL | extern crate issue_45829_a;
+   | --------------------------- previous import of the extern crate `issue_45829_a` here
+LL | extern  crate    issue_45829_b  as  issue_45829_a;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `issue_45829_a` reimported here
+   |
+   = note: `issue_45829_a` must be defined only once in the type namespace of this module
+help: you can use `as` to change the binding name of the import
+   |
+LL | extern crate issue_45829_b as other_issue_45829_a;
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0259`.

--- a/src/test/ui/issues/issue-45829/rename-extern.rs
+++ b/src/test/ui/issues/issue-45829/rename-extern.rs
@@ -1,0 +1,17 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:issue_45829_a.rs
+// aux-build:issue_45829_b.rs
+
+extern crate issue_45829_a;
+extern crate issue_45829_b as issue_45829_a;
+
+fn main() {}

--- a/src/test/ui/issues/issue-45829/rename-extern.stderr
+++ b/src/test/ui/issues/issue-45829/rename-extern.stderr
@@ -1,0 +1,16 @@
+error[E0259]: the name `issue_45829_a` is defined multiple times
+  --> $DIR/rename-extern.rs:15:1
+   |
+LL | extern crate issue_45829_a;
+   | --------------------------- previous import of the extern crate `issue_45829_a` here
+LL | extern crate issue_45829_b as issue_45829_a;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | |
+   | `issue_45829_a` reimported here
+   | You can use `as` to change the binding name of the import
+   |
+   = note: `issue_45829_a` must be defined only once in the type namespace of this module
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0259`.

--- a/src/test/ui/issues/issue-45829/rename-extern.stderr
+++ b/src/test/ui/issues/issue-45829/rename-extern.stderr
@@ -4,12 +4,13 @@ error[E0259]: the name `issue_45829_a` is defined multiple times
 LL | extern crate issue_45829_a;
    | --------------------------- previous import of the extern crate `issue_45829_a` here
 LL | extern crate issue_45829_b as issue_45829_a;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   | |
-   | `issue_45829_a` reimported here
-   | You can use `as` to change the binding name of the import
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `issue_45829_a` reimported here
    |
    = note: `issue_45829_a` must be defined only once in the type namespace of this module
+help: you can use `as` to change the binding name of the import
+   |
+LL | extern crate issue_45829_b as other_issue_45829_a;
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-45829/rename-use-vs-extern.rs
+++ b/src/test/ui/issues/issue-45829/rename-use-vs-extern.rs
@@ -1,0 +1,16 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:issue_45829_b.rs
+
+extern crate issue_45829_b;
+use std as issue_45829_b;
+
+fn main() {}

--- a/src/test/ui/issues/issue-45829/rename-use-vs-extern.stderr
+++ b/src/test/ui/issues/issue-45829/rename-use-vs-extern.stderr
@@ -1,0 +1,17 @@
+error[E0254]: the name `issue_45829_b` is defined multiple times
+  --> $DIR/rename-use-vs-extern.rs:14:5
+   |
+LL | extern crate issue_45829_b;
+   | --------------------------- previous import of the extern crate `issue_45829_b` here
+LL | use std as issue_45829_b;
+   |     ^^^^^^^^^^^^^^^^^^^^ `issue_45829_b` reimported here
+   |
+   = note: `issue_45829_b` must be defined only once in the type namespace of this module
+help: You can use `as` to change the binding name of the import
+   |
+LL | use std as other_issue_45829_b;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0254`.

--- a/src/test/ui/issues/issue-45829/rename-use-vs-extern.stderr
+++ b/src/test/ui/issues/issue-45829/rename-use-vs-extern.stderr
@@ -7,7 +7,7 @@ LL | use std as issue_45829_b;
    |     ^^^^^^^^^^^^^^^^^^^^ `issue_45829_b` reimported here
    |
    = note: `issue_45829_b` must be defined only once in the type namespace of this module
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL | use std as other_issue_45829_b;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/issues/issue-45829/rename-use-with-tabs.rs
+++ b/src/test/ui/issues/issue-45829/rename-use-with-tabs.rs
@@ -1,0 +1,21 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+mod foo {
+    pub struct A;
+
+    pub mod bar {
+        pub struct B;
+    }
+}
+
+use foo::{A, bar::B    as    A};
+
+fn main() {}

--- a/src/test/ui/issues/issue-45829/rename-use-with-tabs.stderr
+++ b/src/test/ui/issues/issue-45829/rename-use-with-tabs.stderr
@@ -1,0 +1,17 @@
+error[E0252]: the name `A` is defined multiple times
+  --> $DIR/rename-use-with-tabs.rs:19:14
+   |
+LL | use foo::{A, bar::B    as    A};
+   |           -  ^^^^^^^^^^^^^^^^^ `A` reimported here
+   |           |
+   |           previous import of the type `A` here
+   |
+   = note: `A` must be defined only once in the type namespace of this module
+help: you can use `as` to change the binding name of the import
+   |
+LL | use foo::{A, bar::B as OtherA};
+   |              ^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0252`.

--- a/src/test/ui/issues/issue-45829/rename-with-path.rs
+++ b/src/test/ui/issues/issue-45829/rename-with-path.rs
@@ -1,0 +1,13 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::{collections::HashMap as A, sync::Arc as A};
+
+fn main() {}

--- a/src/test/ui/issues/issue-45829/rename-with-path.stderr
+++ b/src/test/ui/issues/issue-45829/rename-with-path.stderr
@@ -1,0 +1,17 @@
+error[E0252]: the name `A` is defined multiple times
+  --> $DIR/rename-with-path.rs:11:38
+   |
+LL | use std::{collections::HashMap as A, sync::Arc as A};
+   |           -------------------------  ^^^^^^^^^^^^^^ `A` reimported here
+   |           |
+   |           previous import of the type `A` here
+   |
+   = note: `A` must be defined only once in the type namespace of this module
+help: You can use `as` to change the binding name of the import
+   |
+LL | use std::{collections::HashMap as A, sync::Arc as OtherA};
+   |                                      ^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0252`.

--- a/src/test/ui/issues/issue-45829/rename.rs
+++ b/src/test/ui/issues/issue-45829/rename.rs
@@ -1,0 +1,16 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use core;
+use std as core;
+
+fn main() {
+    1 + 1;
+}

--- a/src/test/ui/issues/issue-45829/rename.stderr
+++ b/src/test/ui/issues/issue-45829/rename.stderr
@@ -1,0 +1,17 @@
+error[E0252]: the name `core` is defined multiple times
+  --> $DIR/rename.rs:12:5
+   |
+LL | use core;
+   |     ---- previous import of the module `core` here
+LL | use std as core;
+   |     ^^^^^^^^^^^ `core` reimported here
+   |
+   = note: `core` must be defined only once in the type namespace of this module
+help: You can use `as` to change the binding name of the import
+   |
+LL | use std as other_core;
+   |     ^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0252`.

--- a/src/test/ui/issues/issue-45829/rename.stderr
+++ b/src/test/ui/issues/issue-45829/rename.stderr
@@ -7,7 +7,7 @@ LL | use std as core;
    |     ^^^^^^^^^^^ `core` reimported here
    |
    = note: `core` must be defined only once in the type namespace of this module
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL | use std as other_core;
    |     ^^^^^^^^^^^^^^^^^

--- a/src/test/ui/issues/issue-8640.stderr
+++ b/src/test/ui/issues/issue-8640.stderr
@@ -7,7 +7,7 @@ LL |     mod bar {}
    |     ^^^^^^^ `bar` redefined here
    |
    = note: `bar` must be defined only once in the type namespace of this module
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL |     use baz::bar as other_bar;
    |         ^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/no-std-inject.stderr
+++ b/src/test/ui/no-std-inject.stderr
@@ -5,7 +5,7 @@ LL | extern crate core; //~ ERROR: the name `core` is defined multiple times
    | ^^^^^^^^^^^^^^^^^^ `core` reimported here
    |
    = note: `core` must be defined only once in the type namespace of this module
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL | extern crate core as other_core; //~ ERROR: the name `core` is defined multiple times
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/resolve/resolve-conflict-extern-crate-vs-extern-crate.stderr
+++ b/src/test/ui/resolve/resolve-conflict-extern-crate-vs-extern-crate.stderr
@@ -5,7 +5,7 @@ LL | extern crate std;
    | ^^^^^^^^^^^^^^^^^ `std` reimported here
    |
    = note: `std` must be defined only once in the type namespace of this module
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL | extern crate std as other_std;
    |

--- a/src/test/ui/resolve/resolve-conflict-import-vs-extern-crate.stderr
+++ b/src/test/ui/resolve/resolve-conflict-import-vs-extern-crate.stderr
@@ -7,8 +7,8 @@ LL | use std::slice as std; //~ ERROR the name `std` is defined multiple times
    = note: `std` must be defined only once in the type namespace of this module
 help: You can use `as` to change the binding name of the import
    |
-LL | use std::slice as std as other_std; //~ ERROR the name `std` is defined multiple times
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | use std::slice as other_std; //~ ERROR the name `std` is defined multiple times
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/resolve/resolve-conflict-import-vs-extern-crate.stderr
+++ b/src/test/ui/resolve/resolve-conflict-import-vs-extern-crate.stderr
@@ -5,7 +5,7 @@ LL | use std::slice as std; //~ ERROR the name `std` is defined multiple times
    |     ^^^^^^^^^^^^^^^^^ `std` reimported here
    |
    = note: `std` must be defined only once in the type namespace of this module
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL | use std::slice as other_std; //~ ERROR the name `std` is defined multiple times
    |     ^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/resolve/resolve-conflict-import-vs-import.stderr
+++ b/src/test/ui/resolve/resolve-conflict-import-vs-import.stderr
@@ -7,7 +7,7 @@ LL | use std::mem::transmute;
    |     ^^^^^^^^^^^^^^^^^^^ `transmute` reimported here
    |
    = note: `transmute` must be defined only once in the value namespace of this module
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL | use std::mem::transmute as other_transmute;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/resolve/resolve-conflict-item-vs-extern-crate.stderr
+++ b/src/test/ui/resolve/resolve-conflict-item-vs-extern-crate.stderr
@@ -5,10 +5,6 @@ LL | mod std {}    //~ ERROR the name `std` is defined multiple times
    | ^^^^^^^ `std` redefined here
    |
    = note: `std` must be defined only once in the type namespace of this module
-help: you can use `as` to change the binding name of the import
-   |
-LL |  as other_std// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
-   |  ^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/resolve/resolve-conflict-item-vs-extern-crate.stderr
+++ b/src/test/ui/resolve/resolve-conflict-item-vs-extern-crate.stderr
@@ -5,7 +5,7 @@ LL | mod std {}    //~ ERROR the name `std` is defined multiple times
    | ^^^^^^^ `std` redefined here
    |
    = note: `std` must be defined only once in the type namespace of this module
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL |  as other_std// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
    |  ^^^^^^^^^^^^

--- a/src/test/ui/resolve/resolve-conflict-item-vs-import.stderr
+++ b/src/test/ui/resolve/resolve-conflict-item-vs-import.stderr
@@ -8,7 +8,7 @@ LL | fn transmute() {}
    | ^^^^^^^^^^^^^^ `transmute` redefined here
    |
    = note: `transmute` must be defined only once in the value namespace of this module
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL | use std::mem::transmute as other_transmute;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/resolve/resolve-conflict-type-vs-import.stderr
+++ b/src/test/ui/resolve/resolve-conflict-type-vs-import.stderr
@@ -8,7 +8,7 @@ LL | struct Iter;
    | ^^^^^^^^^^^^ `Iter` redefined here
    |
    = note: `Iter` must be defined only once in the type namespace of this module
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL | use std::slice::Iter as OtherIter;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/unresolved/unresolved-extern-mod-suggestion.stderr
+++ b/src/test/ui/unresolved/unresolved-extern-mod-suggestion.stderr
@@ -7,7 +7,7 @@ LL | use core;
    |     ^^^^ `core` reimported here
    |
    = note: `core` must be defined only once in the type namespace of this module
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL | use core as other_core;
    |     ^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/use/use-mod.stderr
+++ b/src/test/ui/use/use-mod.stderr
@@ -23,7 +23,7 @@ LL |     self
    |     ^^^^ `bar` reimported here
    |
    = note: `bar` must be defined only once in the type namespace of this module
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL |     self as other_bar
    |

--- a/src/test/ui/use/use-paths-as-items.stderr
+++ b/src/test/ui/use/use-paths-as-items.stderr
@@ -7,7 +7,7 @@ LL | use std::mem; //~ ERROR the name `mem` is defined multiple times
    |     ^^^^^^^^ `mem` reimported here
    |
    = note: `mem` must be defined only once in the type namespace of this module
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL | use std::mem as other_mem; //~ ERROR the name `mem` is defined multiple times
    |     ^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/variants/variant-namespacing.stderr
+++ b/src/test/ui/variants/variant-namespacing.stderr
@@ -8,7 +8,7 @@ LL | pub use variant_namespacing::XE::{XStruct, XTuple, XUnit};
    |                                   ^^^^^^^ `XStruct` reimported here
    |
    = note: `XStruct` must be defined only once in the type namespace of this module
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL | pub use variant_namespacing::XE::{XStruct as OtherXStruct, XTuple, XUnit};
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^
@@ -23,7 +23,7 @@ LL | pub use variant_namespacing::XE::{XStruct, XTuple, XUnit};
    |                                            ^^^^^^ `XTuple` reimported here
    |
    = note: `XTuple` must be defined only once in the type namespace of this module
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL | pub use variant_namespacing::XE::{XStruct, XTuple as OtherXTuple, XUnit};
    |                                            ^^^^^^^^^^^^^^^^^^^^^
@@ -38,7 +38,7 @@ LL | pub use variant_namespacing::XE::{XStruct, XTuple, XUnit};
    |                                                    ^^^^^ `XUnit` reimported here
    |
    = note: `XUnit` must be defined only once in the type namespace of this module
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL | pub use variant_namespacing::XE::{XStruct, XTuple, XUnit as OtherXUnit};
    |                                                    ^^^^^^^^^^^^^^^^^^^
@@ -53,7 +53,7 @@ LL | pub use E::{Struct, Tuple, Unit};
    |             ^^^^^^ `Struct` reimported here
    |
    = note: `Struct` must be defined only once in the type namespace of this module
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL | pub use E::{Struct as OtherStruct, Tuple, Unit};
    |             ^^^^^^^^^^^^^^^^^^^^^
@@ -68,7 +68,7 @@ LL | pub use E::{Struct, Tuple, Unit};
    |                     ^^^^^ `Tuple` reimported here
    |
    = note: `Tuple` must be defined only once in the type namespace of this module
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL | pub use E::{Struct, Tuple as OtherTuple, Unit};
    |                     ^^^^^^^^^^^^^^^^^^^
@@ -83,7 +83,7 @@ LL | pub use E::{Struct, Tuple, Unit};
    |                            ^^^^ `Unit` reimported here
    |
    = note: `Unit` must be defined only once in the type namespace of this module
-help: You can use `as` to change the binding name of the import
+help: you can use `as` to change the binding name of the import
    |
 LL | pub use E::{Struct, Tuple, Unit as OtherUnit};
    |                            ^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Fix the suggestion when a renamed import conflict.

It check if the snipped contains `" as "`, and if so uses everything before for the suggestion.