### PR TITLE
Remove HybridBitSet::dummy

### DIFF
--- a/src/librustc_data_structures/bit_set.rs
+++ b/src/librustc_data_structures/bit_set.rs
@@ -423,15 +423,6 @@ pub enum HybridBitSet<T: Idx> {
 }
 
 impl<T: Idx> HybridBitSet<T> {
-    // FIXME: This function is used in conjunction with `mem::replace()` in
-    // several pieces of awful code below. I can't work out how else to appease
-    // the borrow checker.
-    fn dummy() -> Self {
-        // The cheapest HybridBitSet to construct, which is only used to get
-        // around the borrow checker.
-        HybridBitSet::Sparse(SparseBitSet::new_empty(0))
-    }
-
     pub fn new_empty(domain_size: usize) -> Self {
         HybridBitSet::Sparse(SparseBitSet::new_empty(domain_size))
     }
@@ -487,20 +478,14 @@ impl<T: Idx> HybridBitSet<T> {
                 // that doesn't matter because `elem` is already present.
                 false
             }
-            HybridBitSet::Sparse(_) => {
+            HybridBitSet::Sparse(sparse) => {
                 // The set is sparse and full. Convert to a dense set.
-                match mem::replace(self, HybridBitSet::dummy()) {
-                    HybridBitSet::Sparse(sparse) => {
-                        let mut dense = sparse.to_dense();
-                        let changed = dense.insert(elem);
-                        assert!(changed);
-                        *self = HybridBitSet::Dense(dense);
-                        changed
-                    }
-                    _ => unreachable!()
-                }
+                let mut dense = sparse.to_dense();
+                let changed = dense.insert(elem);
+                assert!(changed);
+                *self = HybridBitSet::Dense(dense);
+                changed
             }
-
             HybridBitSet::Dense(dense) => dense.insert(elem),
         }
     }
@@ -525,33 +510,26 @@ impl<T: Idx> HybridBitSet<T> {
 
     pub fn union(&mut self, other: &HybridBitSet<T>) -> bool {
         match self {
-            HybridBitSet::Sparse(_) => {
+            HybridBitSet::Sparse(self_sparse) => {
                 match other {
                     HybridBitSet::Sparse(other_sparse) => {
                         // Both sets are sparse. Add the elements in
-                        // `other_sparse` to `self_hybrid` one at a time. This
-                        // may or may not cause `self_hybrid` to be densified.
+                        // `other_sparse` to `self` one at a time. This
+                        // may or may not cause `self` to be densified.
                         assert_eq!(self.domain_size(), other.domain_size());
-                        let mut self_hybrid = mem::replace(self, HybridBitSet::dummy());
                         let mut changed = false;
                         for elem in other_sparse.iter() {
-                            changed |= self_hybrid.insert(*elem);
+                            changed |= self.insert(*elem);
                         }
-                        *self = self_hybrid;
                         changed
                     }
                     HybridBitSet::Dense(other_dense) => {
                         // `self` is sparse and `other` is dense. Densify
                         // `self` and then do the bitwise union.
-                        match mem::replace(self, HybridBitSet::dummy()) {
-                            HybridBitSet::Sparse(self_sparse) => {
-                                let mut new_dense = self_sparse.to_dense();
-                                let changed = new_dense.union(other_dense);
-                                *self = HybridBitSet::Dense(new_dense);
-                                changed
-                            }
-                            _ => unreachable!()
-                        }
+                        let mut new_dense = self_sparse.to_dense();
+                        let changed = new_dense.union(other_dense);
+                        *self = HybridBitSet::Dense(new_dense);
+                        changed
                     }
                 }
             }


### PR DESCRIPTION
This simplifies some of the `HybridBitSet` code.

cc @nnethercote 