### PR TITLE
NLL: Fix migrate mode issue by not buffering lints.

### DIFF
--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -321,20 +321,20 @@ fn do_mir_borrowck<'a, 'gcx, 'tcx>(
                 continue;
             }
 
-            let mut err = tcx.struct_span_lint_node(
+            let mut_span = tcx.sess.source_map().span_until_non_whitespace(span);
+            tcx.struct_span_lint_node(
                 UNUSED_MUT,
                 vsi[local_decl.source_info.scope].lint_root,
                 span,
                 "variable does not need to be mutable",
-            );
-            let mut_span = tcx.sess.source_map().span_until_non_whitespace(span);
-            err.span_suggestion_short_with_applicability(
+            )
+            .span_suggestion_short_with_applicability(
                 mut_span,
                 "remove this `mut`",
                 String::new(),
-                Applicability::MachineApplicable);
-
-            err.buffer(&mut mbcx.errors_buffer);
+                Applicability::MachineApplicable,
+            )
+            .emit();
         }
     }
 


### PR DESCRIPTION
When lints are emitted from the AST borrow checker, they do not signal
an error as it is not known at that time whether, due to attributes,
that lint will error or warn. This means that when lints are buffered
in the MIR they will always be downgraded, as the AST borrowck will not
have been marked as having errored, even if a lint was upgraded to
an error after being emitted from the AST borrowck. The simple solution
to this is to not buffer any lints from the MIR borrowck.

r? @pnkfelix 