### PR TITLE
in which unused-parens suggestions heed what the user actually wrote

### DIFF
--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -281,8 +281,13 @@ impl UnusedParens {
             let necessary = struct_lit_needs_parens &&
                             parser::contains_exterior_struct_lit(&inner);
             if !necessary {
-                let pattern = pprust::expr_to_string(value);
-                Self::remove_outer_parens(cx, value.span, &pattern, msg);
+                let expr_text = if let Ok(snippet) = cx.sess().source_map()
+                    .span_to_snippet(value.span) {
+                        snippet
+                    } else {
+                        pprust::expr_to_string(value)
+                    };
+                Self::remove_outer_parens(cx, value.span, &expr_text, msg);
             }
         }
     }
@@ -292,8 +297,13 @@ impl UnusedParens {
                                 value: &ast::Pat,
                                 msg: &str) {
         if let ast::PatKind::Paren(_) = value.node {
-            let pattern = pprust::pat_to_string(value);
-            Self::remove_outer_parens(cx, value.span, &pattern, msg);
+            let pattern_text = if let Ok(snippet) = cx.sess().source_map()
+                .span_to_snippet(value.span) {
+                    snippet
+                } else {
+                    pprust::pat_to_string(value)
+                };
+            Self::remove_outer_parens(cx, value.span, &pattern_text, msg);
         }
     }
 

--- a/src/test/ui/lint/suggestions.rs
+++ b/src/test/ui/lint/suggestions.rs
@@ -56,7 +56,7 @@ fn main() {
     while true {
     //~^ WARN denote infinite loops
     //~| HELP use `loop`
-        let mut a = (1);
+        let mut registry_no = (format!("NX-{}", 74205));
         //~^ WARN does not need to be mutable
         //~| HELP remove this `mut`
         //~| WARN unnecessary parentheses
@@ -72,6 +72,6 @@ fn main() {
             //~^ WARN this pattern is redundant
             //~| HELP remove this
         }
-        println!("{} {}", a, b);
+        println!("{} {}", registry_no, b);
     }
 }

--- a/src/test/ui/lint/suggestions.stderr
+++ b/src/test/ui/lint/suggestions.stderr
@@ -1,8 +1,8 @@
 warning: unnecessary parentheses around assigned value
-  --> $DIR/suggestions.rs:59:21
+  --> $DIR/suggestions.rs:59:31
    |
-LL |         let mut a = (1);
-   |                     ^^^ help: remove these parentheses
+LL |         let mut registry_no = (format!("NX-{}", 74205));
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove these parentheses
    |
 note: lint level defined here
   --> $DIR/suggestions.rs:13:21
@@ -21,8 +21,8 @@ LL | #[no_debug] // should suggest removal of deprecated attribute
 warning: variable does not need to be mutable
   --> $DIR/suggestions.rs:59:13
    |
-LL |         let mut a = (1);
-   |             ----^
+LL |         let mut registry_no = (format!("NX-{}", 74205));
+   |             ----^^^^^^^^^^^
    |             |
    |             help: remove this `mut`
    |


### PR DESCRIPTION
Aaron Hill pointed out that unnecessary parens around a macro call (paradigmatically, `format!`) yielded a suggestion of hideous macro-expanded code. `span_to_snippet` is fallable as far as the type system is concerned, so the pretty-printing can live on in the oft-neglected `else` branch.

Resolves #55109.