### PR TITLE
miri: layout should not affect CTFE checks (outside of validation)

### DIFF
--- a/src/librustc_mir/interpret/operand.rs
+++ b/src/librustc_mir/interpret/operand.rs
@@ -688,9 +688,6 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
         rval: OpTy<'tcx, M::PointerTag>,
     ) -> EvalResult<'tcx, (u128, usize)> {
         trace!("read_discriminant_value {:#?}", rval.layout);
-        if rval.layout.abi.is_uninhabited() {
-            return err!(Unreachable);
-        }
 
         match rval.layout.variants {
             layout::Variants::Single { index } => {


### PR DESCRIPTION
Either the enum has no valid discriminant, then the code later will catch that; or it does, then we shouldn't error out so early (absent enforcing validity).

Interestingly, the miri test suite still passes; my guess is we don't even get here for uninhabited types?

r? @oli-obk 