### PR TITLE
Implement FromStr for PathBuf

### DIFF
--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -87,6 +87,8 @@ use io;
 use iter::{self, FusedIterator};
 use ops::{self, Deref};
 use rc::Rc;
+use str::FromStr;
+use string::ParseError;
 use sync::Arc;
 
 use ffi::{OsStr, OsString};
@@ -1440,6 +1442,15 @@ impl From<PathBuf> for OsString {
 impl From<String> for PathBuf {
     fn from(s: String) -> PathBuf {
         PathBuf::from(OsString::from(s))
+    }
+}
+
+#[stable(feature = "path_from_str", since = "1.26.0")]
+impl FromStr for PathBuf {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(PathBuf::from(s))
     }
 }
 


### PR DESCRIPTION
Initially landed in https://github.com/rust-lang/rust/pull/48292 and reverted in https://github.com/rust-lang/rust/pull/50401. This time, use `std::string::ParseError` as suggested in https://github.com/rust-lang/rust/issues/44431#issuecomment-428112632