### PR TITLE
[librustdoc] Disable spellcheck for search field

### DIFF
--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -83,6 +83,7 @@ pub fn render<T: fmt::Display, S: fmt::Display>(
             <div class=\"search-container\">\
                 <input class=\"search-input\" name=\"search\" \
                        autocomplete=\"off\" \
+                       spellcheck=\"false\" \
                        placeholder=\"Click or press ‘S’ to search, ‘?’ for more options…\" \
                        type=\"search\">\
                 <a id=\"settings-menu\" href=\"{root_path}settings.html\">\


### PR DESCRIPTION
This disables spellchecking for the search field in the rustdoc web interface.

As someone who uses Safari to browse through Rust docs, spellchecking gets really annoying.