### PR TITLE
Add x86_64-musl as a host architecture

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
   include:
     # Images used in testing PR and try-build should be run first.
     - env: IMAGE=x86_64-gnu-llvm-5.0 RUST_BACKTRACE=1
-      if: type = pull_request OR branch = auto
+      if: branch = auto
 
     - env: IMAGE=dist-x86_64-linux DEPLOY=1
       if: branch = try OR branch = auto
@@ -159,7 +159,7 @@ matrix:
     - env: IMAGE=dist-x86_64-freebsd DEPLOY=1
       if: branch = auto
     - env: IMAGE=dist-x86_64-musl DEPLOY=1
-      if: branch = auto
+#      if: branch = auto
     - env: IMAGE=dist-x86_64-netbsd DEPLOY=1
       if: branch = auto
     - env: IMAGE=asmjs
@@ -185,7 +185,7 @@ matrix:
     - env: IMAGE=x86_64-gnu-distcheck
       if: branch = auto
     - env: IMAGE=mingw-check
-      if: type = pull_request OR branch = auto
+      if: branch = auto
 
     - stage: publish toolstate
       if: branch = master AND type = push

--- a/src/ci/docker/dist-x86_64-musl/Dockerfile
+++ b/src/ci/docker/dist-x86_64-musl/Dockerfile
@@ -4,6 +4,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   g++ \
   make \
   file \
+  wget \
   curl \
   ca-certificates \
   python2.7 \
@@ -18,19 +19,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /build/
 
-COPY scripts/musl.sh /build/
+COPY scripts/musl-toolchain.sh /build/
 # We need to mitigate rust-lang/rust#34978 when compiling musl itself as well
-RUN CC=gcc \
-    CFLAGS="-Wa,-mrelax-relocations=no" \
-    CXX=g++ \
-    CXXFLAGS="-Wa,-mrelax-relocations=no" \
-    bash musl.sh x86_64 && rm -rf /build
+# TODO: Check what this issue is and if we can ignore it
+
+RUN bash musl-toolchain.sh x86_64-linux-musl && rm -rf build
 
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
 ENV RUST_CONFIGURE_ARGS \
-      --musl-root-x86_64=/musl-x86_64 \
+      --musl-root-x86_64=/usr/local/x86_64-linux-musl \
       --enable-extended \
       --disable-docs
 
@@ -39,9 +38,14 @@ ENV RUST_CONFIGURE_ARGS \
 # way to produce "super compatible" binaries.
 #
 # See: https://github.com/rust-lang/rust/issues/34978
-ENV CFLAGS_x86_64_unknown_linux_musl=-Wa,-mrelax-relocations=no
+#ENV CFLAGS_x86_64_unknown_linux_musl=-Wa,-mrelax-relocations=no
 
-ENV HOSTS=x86_64-unknown-linux-musl
+ENV HOSTS=x86_64-unknown-linux-musl \
+    CC_x86_64_unknown_linux_musl=x86_64-linux-musl-gcc \
+    CXX_x86_64_unknown_linux_musl=x86_64-linux-musl-g++
+
+#    CARGO_TARGET_ARM_UNKNOWN_LINUX_MUSLEABIHF_LINKER=musl-gcc \
+#    CARGO_TARGET_ARM_UNKNOWN_LINUX_MUSLEABIHF_RUNNER="qemu-arm -L /musl-arm"
 
 ENV RUSTFLAGS="-C target-feature=-crt-static"
 

--- a/src/ci/docker/dist-x86_64-musl/Dockerfile
+++ b/src/ci/docker/dist-x86_64-musl/Dockerfile
@@ -41,6 +41,8 @@ ENV RUST_CONFIGURE_ARGS \
 # See: https://github.com/rust-lang/rust/issues/34978
 ENV CFLAGS_x86_64_unknown_linux_musl=-Wa,-mrelax-relocations=no
 
+ENV HOSTS=x86_64-unknown-linux-musl
+
 ENV SCRIPT \
-      python2.7 ../x.py test --target x86_64-unknown-linux-musl && \
-      python2.7 ../x.py dist --target x86_64-unknown-linux-musl
+      python2.7 ../x.py test --host $HOSTS --target $HOSTS && \
+      python2.7 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/dist-x86_64-musl/Dockerfile
+++ b/src/ci/docker/dist-x86_64-musl/Dockerfile
@@ -43,6 +43,8 @@ ENV CFLAGS_x86_64_unknown_linux_musl=-Wa,-mrelax-relocations=no
 
 ENV HOSTS=x86_64-unknown-linux-musl
 
+ENV RUSTFLAGS="-C target-feature=-crt-static"
+
 ENV SCRIPT \
       python2.7 ../x.py test --host $HOSTS --target $HOSTS && \
       python2.7 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/dist-x86_64-musl/Dockerfile
+++ b/src/ci/docker/dist-x86_64-musl/Dockerfile
@@ -47,8 +47,6 @@ ENV HOSTS=x86_64-unknown-linux-musl \
 #    CARGO_TARGET_ARM_UNKNOWN_LINUX_MUSLEABIHF_LINKER=musl-gcc \
 #    CARGO_TARGET_ARM_UNKNOWN_LINUX_MUSLEABIHF_RUNNER="qemu-arm -L /musl-arm"
 
-ENV RUSTFLAGS="-C target-feature=-crt-static"
-
 ENV SCRIPT \
       python2.7 ../x.py test --host $HOSTS --target $HOSTS && \
       python2.7 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/scripts/musl-toolchain.sh
+++ b/src/ci/docker/scripts/musl-toolchain.sh
@@ -28,6 +28,10 @@ exit 1
 }
 
 TARGET=$1
+#ARCH=$1
+#TARGET=linux-musl-$ARCH
+ARCH=x86_64
+
 OUTPUT=/usr/local
 shift
 
@@ -38,6 +42,13 @@ hide_output make -j$(nproc) TARGET=$TARGET
 hide_output make install TARGET=$TARGET OUTPUT=$OUTPUT
 
 cd ..
+
+# Make musl binaries executable
+
+ln -s $OUTPUT/$TARGET/lib/ld-musl-$ARCH.so.1 /lib
+ln -s $OUTPUT/$TARGET/lib/libc.so /lib
+echo $OUTPUT/$TARGET/lib >> /etc/ld-musl-$ARCH.path
+
 
 export CC=$TARGET-gcc
 export CXX=$TARGET-g++

--- a/src/ci/docker/scripts/musl-toolchain.sh
+++ b/src/ci/docker/scripts/musl-toolchain.sh
@@ -45,8 +45,7 @@ cd ..
 
 # Make musl binaries executable
 
-ln -s $OUTPUT/$TARGET/lib/ld-musl-$ARCH.so.1 /lib
-ln -s $OUTPUT/$TARGET/lib/libc.so /lib
+ln -s $OUTPUT/$TARGET/lib/libc.so /lib/ld-musl-$ARCH.so.1
 echo $OUTPUT/$TARGET/lib >> /etc/ld-musl-$ARCH.path
 
 

--- a/src/ci/docker/scripts/musl-toolchain.sh
+++ b/src/ci/docker/scripts/musl-toolchain.sh
@@ -1,0 +1,66 @@
+# Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution and at
+# http://rust-lang.org/COPYRIGHT.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+set -ex
+
+hide_output() {
+  set +x
+  on_err="
+echo ERROR: An error was encountered with the build.
+cat /tmp/build.log
+exit 1
+"
+  trap "$on_err" ERR
+  bash -c "while true; do sleep 30; echo \$(date) - building ...; done" &
+  PING_LOOP_PID=$!
+  $@ &> /tmp/build.log
+  trap - ERR
+  kill $PING_LOOP_PID
+  rm /tmp/build.log
+  set -x
+}
+
+TARGET=$1
+OUTPUT=/usr/local
+shift
+
+git clone https://github.com/richfelker/musl-cross-make -b v0.9.7
+cd musl-cross-make
+
+hide_output make -j$(nproc) TARGET=$TARGET
+hide_output make install TARGET=$TARGET OUTPUT=$OUTPUT
+
+cd ..
+
+export CC=$TARGET-gcc
+export CXX=$TARGET-g++
+
+LLVM=60
+
+# may have been downloaded in a previous run
+if [ ! -d libunwind-release_$LLVM ]; then
+  curl -L https://github.com/llvm-mirror/llvm/archive/release_$LLVM.tar.gz | tar xzf -
+  curl -L https://github.com/llvm-mirror/libunwind/archive/release_$LLVM.tar.gz | tar xzf -
+fi
+
+mkdir libunwind-build
+cd libunwind-build
+cmake ../libunwind-release_$LLVM \
+          -DLLVM_PATH=/build/llvm-release_$LLVM \
+          -DLIBUNWIND_ENABLE_SHARED=0 \
+          -DCMAKE_C_COMPILER=$CC \
+          -DCMAKE_CXX_COMPILER=$CXX \
+          -DCMAKE_C_FLAGS="$CFLAGS" \
+          -DCMAKE_CXX_FLAGS="$CXXFLAGS"
+
+hide_output make -j$(nproc)
+cp lib/libunwind.a $OUTPUT/$TARGET/lib
+cd ../ && rm -rf libunwind-build
+

--- a/src/librustc_target/spec/linux_musl_base.rs
+++ b/src/librustc_target/spec/linux_musl_base.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use spec::{LinkerFlavor, TargetOptions};
+use spec::{LinkerFlavor, TargetOptions, RelroLevel};
 
 pub fn opts() -> TargetOptions {
     let mut base = super::linux_base::opts();
@@ -46,7 +46,7 @@ pub fn opts() -> TargetOptions {
     base.has_elf_tls = true;
     base.has_rpath = true;
     base.position_independent_executables = true;
-    base.relro_level = true;
+    base.relro_level = RelroLevel::Full;
 
     base
 }

--- a/src/librustc_target/spec/linux_musl_base.rs
+++ b/src/librustc_target/spec/linux_musl_base.rs
@@ -40,5 +40,13 @@ pub fn opts() -> TargetOptions {
     // These targets allow the user to choose between static and dynamic linking.
     base.crt_static_respected = true;
 
+    // Defaults for dynamic linking
+    base.dynamic_linking = true;
+    base.executables = true;
+    base.has_elf_tls = true;
+    base.has_rpath = true;
+    base.position_independent_executables = true;
+    base.relro_level = true;
+
     base
 }

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1582,7 +1582,6 @@ impl<'test> TestCx<'test> {
                 None
             } else if self.config.target.contains("cloudabi")
                 || self.config.target.contains("emscripten")
-                || (self.config.target.contains("musl") && !aux_props.force_host)
                 || self.config.target.contains("wasm32")
             {
                 // We primarily compile all auxiliary libraries as dynamic libraries
@@ -1590,10 +1589,8 @@ impl<'test> TestCx<'test> {
                 // for the test suite (otherwise including libstd statically in all
                 // executables takes up quite a bit of space).
                 //
-                // For targets like MUSL or Emscripten, however, there is no support for
-                // dynamic libraries so we just go back to building a normal library. Note,
-                // however, that for MUSL if the library is built with `force_host` then
-                // it's ok to be a dylib as the host should always support dylibs.
+                // For targets like Emscripten, however, there is no support for
+                // dynamic libraries so we just go back to building a normal library.
                 Some("lib")
             } else {
                 Some("dylib")


### PR DESCRIPTION
rustc is already shipped on Alpine Linux, this should be an easy thing to also enable it for the rustup channels.

This PR contains an additional commit for testing the build with Travis, i will remove it once that worked.