### PR TITLE
Don't warn about parentheses on `match (return)`

### DIFF
--- a/src/test/ui/lint/no-unused-parens-return-block.rs
+++ b/src/test/ui/lint/no-unused-parens-return-block.rs
@@ -1,5 +1,8 @@
 // run-pass
 
+#![deny(unused_parens)]
+#![allow(unreachable_code)]
+
 fn main() {
     match (return) {} // ok
     if (return) {} // ok

--- a/src/test/ui/lint/no-unused-parens-return-block.rs
+++ b/src/test/ui/lint/no-unused-parens-return-block.rs
@@ -1,0 +1,6 @@
+// run-pass
+
+fn main() {
+    match (return) {} // ok
+    if (return) {} // ok
+}


### PR DESCRIPTION
Fixes #55164.