### PR TITLE
Suggest appropriate syntax on missing lifetime specifier in return type

### DIFF
--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -1152,7 +1152,7 @@ impl<'a> LoweringContext<'a> {
             TyKind::Slice(ref ty) => hir::TyKind::Slice(self.lower_ty(ty, itctx)),
             TyKind::Ptr(ref mt) => hir::TyKind::Ptr(self.lower_mt(mt, itctx)),
             TyKind::Rptr(ref region, ref mt) => {
-                let span = t.span.shrink_to_lo();
+                let span = self.sess.source_map().next_point(t.span.shrink_to_lo());
                 let lifetime = match *region {
                     Some(ref lt) => self.lower_lifetime(lt),
                     None => self.elided_ref_lifetime(span),

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -2252,7 +2252,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
     fn suggest_lifetime(&self, db: &mut DiagnosticBuilder<'_>, span: Span, msg: &str) -> bool {
         match self.tcx.sess.source_map().span_to_snippet(span) {
             Ok(ref snippet) => {
-                let (sugg, applicability) = if &snippet[..] == "&" {
+                let (sugg, applicability) = if snippet == "&" {
                     ("&'static ".to_owned(), Applicability::MachineApplicable)
                 } else if snippet == "'_" {
                     ("'static".to_owned(), Applicability::MachineApplicable)

--- a/src/test/ui/associated-types/bound-lifetime-in-binding-only.elision.stderr
+++ b/src/test/ui/associated-types/bound-lifetime-in-binding-only.elision.stderr
@@ -2,10 +2,7 @@ error[E0106]: missing lifetime specifier
   --> $DIR/bound-lifetime-in-binding-only.rs:62:23
    |
 LL | fn elision<T: Fn() -> &i32>() {
-   |                       ^
-   |                       |
-   |                       expected lifetime parameter
-   |                       help: consider giving it a 'static lifetime: `&'static`
+   |                       ^ help: consider giving it a 'static lifetime: `&'static`
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
 

--- a/src/test/ui/associated-types/bound-lifetime-in-binding-only.elision.stderr
+++ b/src/test/ui/associated-types/bound-lifetime-in-binding-only.elision.stderr
@@ -2,10 +2,12 @@ error[E0106]: missing lifetime specifier
   --> $DIR/bound-lifetime-in-binding-only.rs:62:23
    |
 LL | fn elision<T: Fn() -> &i32>() {
-   |                       ^ expected lifetime parameter
+   |                       ^
+   |                       |
+   |                       expected lifetime parameter
+   |                       help: consider giving it a 'static lifetime: `&'static`
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-   = help: consider giving it a 'static lifetime
 
 error: aborting due to previous error
 

--- a/src/test/ui/associated-types/bound-lifetime-in-return-only.elision.stderr
+++ b/src/test/ui/associated-types/bound-lifetime-in-return-only.elision.stderr
@@ -2,10 +2,7 @@ error[E0106]: missing lifetime specifier
   --> $DIR/bound-lifetime-in-return-only.rs:44:23
    |
 LL | fn elision(_: fn() -> &i32) {
-   |                       ^
-   |                       |
-   |                       expected lifetime parameter
-   |                       help: consider giving it a 'static lifetime: `&'static`
+   |                       ^ help: consider giving it a 'static lifetime: `&'static`
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
 

--- a/src/test/ui/associated-types/bound-lifetime-in-return-only.elision.stderr
+++ b/src/test/ui/associated-types/bound-lifetime-in-return-only.elision.stderr
@@ -2,10 +2,12 @@ error[E0106]: missing lifetime specifier
   --> $DIR/bound-lifetime-in-return-only.rs:44:23
    |
 LL | fn elision(_: fn() -> &i32) {
-   |                       ^ expected lifetime parameter
+   |                       ^
+   |                       |
+   |                       expected lifetime parameter
+   |                       help: consider giving it a 'static lifetime: `&'static`
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-   = help: consider giving it a 'static lifetime
 
 error: aborting due to previous error
 

--- a/src/test/ui/foreign-fn-return-lifetime.fixed
+++ b/src/test/ui/foreign-fn-return-lifetime.fixed
@@ -12,7 +12,7 @@
 
 extern "C" {
     pub fn g(_: &u8) -> &u8; // OK
-    pub fn f() -> &u8; //~ ERROR missing lifetime specifier
+    pub fn f() -> &'static u8; //~ ERROR missing lifetime specifier
 }
 
 fn main() {}

--- a/src/test/ui/foreign-fn-return-lifetime.stderr
+++ b/src/test/ui/foreign-fn-return-lifetime.stderr
@@ -2,10 +2,7 @@ error[E0106]: missing lifetime specifier
   --> $DIR/foreign-fn-return-lifetime.rs:15:19
    |
 LL |     pub fn f() -> &u8; //~ ERROR missing lifetime specifier
-   |                   ^
-   |                   |
-   |                   expected lifetime parameter
-   |                   help: consider giving it a 'static lifetime: `&'static`
+   |                   ^ help: consider giving it a 'static lifetime: `&'static`
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
 

--- a/src/test/ui/foreign-fn-return-lifetime.stderr
+++ b/src/test/ui/foreign-fn-return-lifetime.stderr
@@ -1,11 +1,13 @@
 error[E0106]: missing lifetime specifier
-  --> $DIR/foreign-fn-return-lifetime.rs:13:15
+  --> $DIR/foreign-fn-return-lifetime.rs:15:19
    |
-LL |     fn f() -> &u8; //~ ERROR missing lifetime specifier
-   |               ^ expected lifetime parameter
+LL |     pub fn f() -> &u8; //~ ERROR missing lifetime specifier
+   |                   ^
+   |                   |
+   |                   expected lifetime parameter
+   |                   help: consider giving it a 'static lifetime: `&'static`
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-   = help: consider giving it a 'static lifetime
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-13497.stderr
+++ b/src/test/ui/issues/issue-13497.stderr
@@ -2,10 +2,12 @@ error[E0106]: missing lifetime specifier
   --> $DIR/issue-13497.rs:12:5
    |
 LL |     &str //~ ERROR missing lifetime specifier
-   |     ^ expected lifetime parameter
+   |     ^
+   |     |
+   |     expected lifetime parameter
+   |     help: consider giving it a 'static lifetime: `&'static`
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-   = help: consider giving it a 'static lifetime
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-13497.stderr
+++ b/src/test/ui/issues/issue-13497.stderr
@@ -2,10 +2,7 @@ error[E0106]: missing lifetime specifier
   --> $DIR/issue-13497.rs:12:5
    |
 LL |     &str //~ ERROR missing lifetime specifier
-   |     ^
-   |     |
-   |     expected lifetime parameter
-   |     help: consider giving it a 'static lifetime: `&'static`
+   |     ^ help: consider giving it a 'static lifetime: `&'static`
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
 

--- a/src/test/ui/issues/issue-26638.stderr
+++ b/src/test/ui/issues/issue-26638.stderr
@@ -10,10 +10,7 @@ error[E0106]: missing lifetime specifier
   --> $DIR/issue-26638.rs:14:40
    |
 LL | fn parse_type_2(iter: fn(&u8)->&u8) -> &str { iter() }
-   |                                        ^
-   |                                        |
-   |                                        expected lifetime parameter
-   |                                        help: consider giving it an explicit bounded or 'static lifetime: `&'static`
+   |                                        ^ help: consider giving it an explicit bounded or 'static lifetime: `&'static`
    |
    = help: this function's return type contains a borrowed value with an elided lifetime, but the lifetime cannot be derived from the arguments
 
@@ -21,10 +18,7 @@ error[E0106]: missing lifetime specifier
   --> $DIR/issue-26638.rs:17:22
    |
 LL | fn parse_type_3() -> &str { unimplemented!() }
-   |                      ^
-   |                      |
-   |                      expected lifetime parameter
-   |                      help: consider giving it a 'static lifetime: `&'static`
+   |                      ^ help: consider giving it a 'static lifetime: `&'static`
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
 

--- a/src/test/ui/issues/issue-26638.stderr
+++ b/src/test/ui/issues/issue-26638.stderr
@@ -10,19 +10,23 @@ error[E0106]: missing lifetime specifier
   --> $DIR/issue-26638.rs:14:40
    |
 LL | fn parse_type_2(iter: fn(&u8)->&u8) -> &str { iter() }
-   |                                        ^ expected lifetime parameter
+   |                                        ^
+   |                                        |
+   |                                        expected lifetime parameter
+   |                                        help: consider giving it an explicit bounded or 'static lifetime: `&'static`
    |
    = help: this function's return type contains a borrowed value with an elided lifetime, but the lifetime cannot be derived from the arguments
-   = help: consider giving it an explicit bounded or 'static lifetime
 
 error[E0106]: missing lifetime specifier
   --> $DIR/issue-26638.rs:17:22
    |
 LL | fn parse_type_3() -> &str { unimplemented!() }
-   |                      ^ expected lifetime parameter
+   |                      ^
+   |                      |
+   |                      expected lifetime parameter
+   |                      help: consider giving it a 'static lifetime: `&'static`
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-   = help: consider giving it a 'static lifetime
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/lifetimes/lifetime-elision-return-type-requires-explicit-lifetime.stderr
+++ b/src/test/ui/lifetimes/lifetime-elision-return-type-requires-explicit-lifetime.stderr
@@ -2,10 +2,12 @@ error[E0106]: missing lifetime specifier
   --> $DIR/lifetime-elision-return-type-requires-explicit-lifetime.rs:12:11
    |
 LL | fn f() -> &isize {    //~ ERROR missing lifetime specifier
-   |           ^ expected lifetime parameter
+   |           ^
+   |           |
+   |           expected lifetime parameter
+   |           help: consider giving it a 'static lifetime: `&'static`
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-   = help: consider giving it a 'static lifetime
 
 error[E0106]: missing lifetime specifier
   --> $DIR/lifetime-elision-return-type-requires-explicit-lifetime.rs:17:33
@@ -27,28 +29,34 @@ error[E0106]: missing lifetime specifier
   --> $DIR/lifetime-elision-return-type-requires-explicit-lifetime.rs:31:20
    |
 LL | fn i(_x: isize) -> &isize { //~ ERROR missing lifetime specifier
-   |                    ^ expected lifetime parameter
+   |                    ^
+   |                    |
+   |                    expected lifetime parameter
+   |                    help: consider giving it an explicit bounded or 'static lifetime: `&'static`
    |
    = help: this function's return type contains a borrowed value with an elided lifetime, but the lifetime cannot be derived from the arguments
-   = help: consider giving it an explicit bounded or 'static lifetime
 
 error[E0106]: missing lifetime specifier
   --> $DIR/lifetime-elision-return-type-requires-explicit-lifetime.rs:44:24
    |
 LL | fn j(_x: StaticStr) -> &isize { //~ ERROR missing lifetime specifier
-   |                        ^ expected lifetime parameter
+   |                        ^
+   |                        |
+   |                        expected lifetime parameter
+   |                        help: consider giving it an explicit bounded or 'static lifetime: `&'static`
    |
    = help: this function's return type contains a borrowed value with an elided lifetime, but the lifetime cannot be derived from the arguments
-   = help: consider giving it an explicit bounded or 'static lifetime
 
 error[E0106]: missing lifetime specifier
   --> $DIR/lifetime-elision-return-type-requires-explicit-lifetime.rs:50:49
    |
 LL | fn k<'a, T: WithLifetime<'a>>(_x: T::Output) -> &isize {
-   |                                                 ^ expected lifetime parameter
+   |                                                 ^
+   |                                                 |
+   |                                                 expected lifetime parameter
+   |                                                 help: consider giving it an explicit bounded or 'static lifetime: `&'static`
    |
    = help: this function's return type contains a borrowed value with an elided lifetime, but the lifetime cannot be derived from the arguments
-   = help: consider giving it an explicit bounded or 'static lifetime
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/lifetimes/lifetime-elision-return-type-requires-explicit-lifetime.stderr
+++ b/src/test/ui/lifetimes/lifetime-elision-return-type-requires-explicit-lifetime.stderr
@@ -2,10 +2,7 @@ error[E0106]: missing lifetime specifier
   --> $DIR/lifetime-elision-return-type-requires-explicit-lifetime.rs:12:11
    |
 LL | fn f() -> &isize {    //~ ERROR missing lifetime specifier
-   |           ^
-   |           |
-   |           expected lifetime parameter
-   |           help: consider giving it a 'static lifetime: `&'static`
+   |           ^ help: consider giving it a 'static lifetime: `&'static`
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
 
@@ -29,10 +26,7 @@ error[E0106]: missing lifetime specifier
   --> $DIR/lifetime-elision-return-type-requires-explicit-lifetime.rs:31:20
    |
 LL | fn i(_x: isize) -> &isize { //~ ERROR missing lifetime specifier
-   |                    ^
-   |                    |
-   |                    expected lifetime parameter
-   |                    help: consider giving it an explicit bounded or 'static lifetime: `&'static`
+   |                    ^ help: consider giving it an explicit bounded or 'static lifetime: `&'static`
    |
    = help: this function's return type contains a borrowed value with an elided lifetime, but the lifetime cannot be derived from the arguments
 
@@ -40,10 +34,7 @@ error[E0106]: missing lifetime specifier
   --> $DIR/lifetime-elision-return-type-requires-explicit-lifetime.rs:44:24
    |
 LL | fn j(_x: StaticStr) -> &isize { //~ ERROR missing lifetime specifier
-   |                        ^
-   |                        |
-   |                        expected lifetime parameter
-   |                        help: consider giving it an explicit bounded or 'static lifetime: `&'static`
+   |                        ^ help: consider giving it an explicit bounded or 'static lifetime: `&'static`
    |
    = help: this function's return type contains a borrowed value with an elided lifetime, but the lifetime cannot be derived from the arguments
 
@@ -51,10 +42,7 @@ error[E0106]: missing lifetime specifier
   --> $DIR/lifetime-elision-return-type-requires-explicit-lifetime.rs:50:49
    |
 LL | fn k<'a, T: WithLifetime<'a>>(_x: T::Output) -> &isize {
-   |                                                 ^
-   |                                                 |
-   |                                                 expected lifetime parameter
-   |                                                 help: consider giving it an explicit bounded or 'static lifetime: `&'static`
+   |                                                 ^ help: consider giving it an explicit bounded or 'static lifetime: `&'static`
    |
    = help: this function's return type contains a borrowed value with an elided lifetime, but the lifetime cannot be derived from the arguments
 

--- a/src/test/ui/lifetimes/lifetime-elision-return-type-trait.rs
+++ b/src/test/ui/lifetimes/lifetime-elision-return-type-trait.rs
@@ -8,3 +8,5 @@ use std::error::Error;
 fn foo() -> impl Future<Item=(), Error=Box<Error>> {
     Ok(())
 }
+
+fn main() {}

--- a/src/test/ui/lifetimes/lifetime-elision-return-type-trait.rs
+++ b/src/test/ui/lifetimes/lifetime-elision-return-type-trait.rs
@@ -1,0 +1,10 @@
+trait Future {
+    type Item;
+    type Error;
+}
+
+use std::error::Error;
+
+fn foo() -> impl Future<Item=(), Error=Box<Error>> {
+    Ok(())
+}

--- a/src/test/ui/lifetimes/lifetime-elision-return-type-trait.stderr
+++ b/src/test/ui/lifetimes/lifetime-elision-return-type-trait.stderr
@@ -6,10 +6,7 @@ error[E0106]: missing lifetime specifier
   --> $DIR/lifetime-elision-return-type-trait.rs:8:44
    |
 LL | fn foo() -> impl Future<Item=(), Error=Box<Error>> {
-   |                                            ^^^^^
-   |                                            |
-   |                                            expected lifetime parameter
-   |                                            help: consider giving it a 'static lifetime: `Error + 'static`
+   |                                            ^^^^^ help: consider giving it a 'static lifetime: `Error + 'static`
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
 

--- a/src/test/ui/lifetimes/lifetime-elision-return-type-trait.stderr
+++ b/src/test/ui/lifetimes/lifetime-elision-return-type-trait.stderr
@@ -1,0 +1,19 @@
+error[E0601]: `main` function not found in crate `lifetime_elision_return_type_trait`
+   |
+   = note: consider adding a `main` function to `$DIR/lifetime-elision-return-type-trait.rs`
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/lifetime-elision-return-type-trait.rs:8:44
+   |
+LL | fn foo() -> impl Future<Item=(), Error=Box<Error>> {
+   |                                            ^^^^^
+   |                                            |
+   |                                            expected lifetime parameter
+   |                                            help: consider giving it a 'static lifetime: `Error + 'static`
+   |
+   = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
+
+error: aborting due to 2 previous errors
+
+Some errors occurred: E0106, E0601.
+For more information about an error, try `rustc --explain E0106`.

--- a/src/test/ui/lifetimes/lifetime-elision-return-type-trait.stderr
+++ b/src/test/ui/lifetimes/lifetime-elision-return-type-trait.stderr
@@ -1,7 +1,3 @@
-error[E0601]: `main` function not found in crate `lifetime_elision_return_type_trait`
-   |
-   = note: consider adding a `main` function to `$DIR/lifetime-elision-return-type-trait.rs`
-
 error[E0106]: missing lifetime specifier
   --> $DIR/lifetime-elision-return-type-trait.rs:8:44
    |
@@ -10,7 +6,6 @@ LL | fn foo() -> impl Future<Item=(), Error=Box<Error>> {
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
 
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
-Some errors occurred: E0106, E0601.
-For more information about an error, try `rustc --explain E0106`.
+For more information about this error, try `rustc --explain E0106`.

--- a/src/test/ui/underscore-lifetime/underscore-lifetime-binders.stderr
+++ b/src/test/ui/underscore-lifetime/underscore-lifetime-binders.stderr
@@ -26,10 +26,12 @@ error[E0106]: missing lifetime specifier
   --> $DIR/underscore-lifetime-binders.rs:24:29
    |
 LL | fn meh() -> Box<for<'_> Meh<'_>> //~ ERROR cannot be used here
-   |                             ^^ expected lifetime parameter
+   |                             ^^
+   |                             |
+   |                             expected lifetime parameter
+   |                             help: consider giving it a 'static lifetime: `'static`
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-   = help: consider giving it a 'static lifetime
 
 error[E0106]: missing lifetime specifier
   --> $DIR/underscore-lifetime-binders.rs:30:35

--- a/src/test/ui/underscore-lifetime/underscore-lifetime-binders.stderr
+++ b/src/test/ui/underscore-lifetime/underscore-lifetime-binders.stderr
@@ -26,10 +26,7 @@ error[E0106]: missing lifetime specifier
   --> $DIR/underscore-lifetime-binders.rs:24:29
    |
 LL | fn meh() -> Box<for<'_> Meh<'_>> //~ ERROR cannot be used here
-   |                             ^^
-   |                             |
-   |                             expected lifetime parameter
-   |                             help: consider giving it a 'static lifetime: `'static`
+   |                             ^^ help: consider giving it a 'static lifetime: `'static`
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
 


### PR DESCRIPTION
Suggest using `'static` when a lifetime is missing in the return type
with a structured suggestion instead of a note.

Fix #55170.