### PR TITLE
[beta] Rollup backports

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,124 @@
+Version 1.30.0 (2018-10-25)
+==========================
+
+Language
+--------
+- [Procedural macros are now available.][52081] These kinds of macros allow for
+  more powerful code generation, there is a [new chapter available][proc-macros]
+  in Rust Programming Language book that goes further in depth.
+- [You can now use keywords as identifiers using the raw identifiers
+  syntax (`r#`).][53236] e.g. `let r#bool = true;`
+- [Using anonymous parameters in traits is now deprecated with a warning and
+  will be a hard error in the 2018 edition.][53272]
+- [You can now use `crate` in paths.][54404] This allows you to refer to the
+  crate root in the path. e.g. `use crate::foo;` refers to `foo` in `src/lib.rs`.
+- [Using a external crate now no longer requires being prefixed with `::`.][54404]
+  e.g. previously using a external crate in a module without a use statement
+  required `let json = ::serde_json::from_str(foo);` can now be written
+  as `let json = serde_json::from_str(foo);`.
+- [You can now apply the `#[used]` attribute to static items to prevent the
+  compiler from optimising them away even if they appear to be unused.][51363]
+  e.g. `#[used] static FOO: u32 = 1;`
+- [You can now import and reexport macros from other crates with the `use`
+  syntax.][50911] Macros exported with `#[macro_export]` are now placed into
+  the root module of the crate. If your macro relies on calling other local
+  macros it is recommended to export with the
+  `#[macro_export(local_inner_macros)]` attribute so that users won't have to
+  import those macros.
+- [`mod.rs` files are now optional.][54146] Previously if you had a `foo` module
+  with a `bar` submodule, you would have `src/foo/mod.rs` and `src/foo/bar.rs`.
+  Now you can have `src/foo.rs` and `src/foo/bar.rs` to achieve the same effect.
+- [You can now catch visibility keywords (e.g. `pub`, `pub(crate)`) in macros
+  using the `vis` specifier.][53370]
+- [Non-macro attributes now allow all forms of literals not just
+  strings.][53044] e.g. Previously you would write `#[attr("true")]` you can now
+  write `#[attr(true)]`.
+- [You can now specify a function to handle a panic in the Rust runtime with the
+  `#[panic_handler]` attribute.][51366]
+
+Compiler
+--------
+- [Added the `riscv32imc-unknown-none-elf` target.][53822]
+- [Added the `aarch64-unknown-netbsd` target][53165]
+
+Libraries
+---------
+- [`ManuallyDrop` now allows the inner type to be unsized.][53033]
+
+Stabilized APIs
+---------------
+- [`Ipv4Addr::BROADCAST`]
+- [`Ipv4Addr::LOCALHOST`]
+- [`Ipv4Addr::UNSPECIFIED`]
+- [`Ipv6Addr::LOCALHOST`]
+- [`Ipv6Addr::UNSPECIFIED`]
+- [`Iterator::find_map`]
+
+  The following methods are a replacement methods for `trim_left`, `trim_right`,
+  `trim_left_matches`, and `trim_right_matches`. Which will be deprecated
+  in 1.33.0.
+- [`str::trim_end_matches`]
+- [`str::trim_end`]
+- [`str::trim_start_matches`]
+- [`str::trim_start`]
+
+Cargo
+----
+- [`cargo run` doesn't require specifying a package in workspaces.][cargo/5877]
+- [`cargo doc` now supports `--message-format=json`.][cargo/5878] This is
+  equivalent to calling `rustdoc --error-format=json`.
+- [You can specify which edition to create a project in cargo
+  with `cargo new --edition`.][cargo/5984] Currently only `2015` is a
+  valid option.
+- [Cargo will now provide a progress bar for builds.][cargo/5995]
+
+Misc
+----
+- [`rustdoc` allows you to specify what edition to treat your code as with the
+  `--edition` option.][54057]
+- [`rustdoc` now has the `--color` (Specify whether to output color) and
+  `--error-format` (Specify error format e.g. `json`) options.][53003]
+- [We now distribute a `rust-gdbgui` script that invokes `gdbgui` with Rust
+  debug symbols.][53774]
+- [Attributes from Rust tools such as `rustfmt` or `clippy` are now
+  available.][53459] e.g. `#[rustfmt::skip]` will skip formatting the next item.
+
+[50911]: https://github.com/rust-lang/rust/pull/50911/
+[51363]: https://github.com/rust-lang/rust/pull/51363/
+[51366]: https://github.com/rust-lang/rust/pull/51366/
+[52081]: https://github.com/rust-lang/rust/pull/52081/
+[53003]: https://github.com/rust-lang/rust/pull/53003/
+[53033]: https://github.com/rust-lang/rust/pull/53033/
+[53044]: https://github.com/rust-lang/rust/pull/53044/
+[53165]: https://github.com/rust-lang/rust/pull/53165/
+[53213]: https://github.com/rust-lang/rust/pull/53213/
+[53236]: https://github.com/rust-lang/rust/pull/53236/
+[53272]: https://github.com/rust-lang/rust/pull/53272/
+[53370]: https://github.com/rust-lang/rust/pull/53370/
+[53459]: https://github.com/rust-lang/rust/pull/53459/
+[53774]: https://github.com/rust-lang/rust/pull/53774/
+[53822]: https://github.com/rust-lang/rust/pull/53822/
+[54057]: https://github.com/rust-lang/rust/pull/54057/
+[54146]: https://github.com/rust-lang/rust/pull/54146/
+[54404]: https://github.com/rust-lang/rust/pull/54404/
+[cargo/5877]: https://github.com/rust-lang/cargo/pull/5877/
+[cargo/5878]: https://github.com/rust-lang/cargo/pull/5878/
+[cargo/5984]: https://github.com/rust-lang/cargo/pull/5984/
+[cargo/5995]: https://github.com/rust-lang/cargo/pull/5995/
+[proc-macros]: https://doc.rust-lang.org/book/2018-edition/ch19-06-macros.html
+
+[`Ipv4Addr::BROADCAST`]: https://doc.rust-lang.org/nightly/std/net/struct.Ipv4Addr.html#associatedconstant.BROADCAST
+[`Ipv4Addr::LOCALHOST`]: https://doc.rust-lang.org/nightly/std/net/struct.Ipv4Addr.html#associatedconstant.LOCALHOST
+[`Ipv4Addr::UNSPECIFIED`]: https://doc.rust-lang.org/nightly/std/net/struct.Ipv4Addr.html#associatedconstant.UNSPECIFIED
+[`Ipv6Addr::LOCALHOST`]: https://doc.rust-lang.org/nightly/std/net/struct.Ipv6Addr.html#associatedconstant.LOCALHOST
+[`Ipv6Addr::UNSPECIFIED`]: https://doc.rust-lang.org/nightly/std/net/struct.Ipv6Addr.html#associatedconstant.UNSPECIFIED
+[`Iterator::find_map`]: https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.find_map
+[`str::trim_end_matches`]: https://doc.rust-lang.org/nightly/std/primitive.str.html#method.trim_end_matches
+[`str::trim_end`]: https://doc.rust-lang.org/nightly/std/primitive.str.html#method.trim_end
+[`str::trim_start_matches`]: https://doc.rust-lang.org/nightly/std/primitive.str.html#method.trim_start_matches
+[`str::trim_start`]: https://doc.rust-lang.org/nightly/std/primitive.str.html#method.trim_start
+
+
 Version 1.29.2 (2018-10-11)
 ===========================
 
@@ -5,6 +126,7 @@ Version 1.29.2 (2018-10-11)
 - The `rls-preview` component on the windows-gnu targets has been restored.
 
 [54639]: https://github.com/rust-lang/rust/pull/54639
+
 
 Version 1.29.1 (2018-09-25)
 ===========================
@@ -18,6 +140,7 @@ Security Notes
 
   Thank you to Scott McMurray for responsibily disclosing this vulnerability to
   us.
+
 
 Version 1.29.0 (2018-09-13)
 ==========================
@@ -73,7 +196,10 @@ Compatibility Notes
   Consider using the `home_dir` function from
   https://crates.io/crates/dirs instead.
 - [`rustc` will no longer silently ignore invalid data in target spec.][52330]
+- [`cfg` attributes and `--cfg` command line flags are now more
+  strictly validated.][53893]
 
+[53893]: https://github.com/rust-lang/rust/pull/53893/
 [52861]: https://github.com/rust-lang/rust/pull/52861/
 [52656]: https://github.com/rust-lang/rust/pull/52656/
 [52239]: https://github.com/rust-lang/rust/pull/52239/

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -37,7 +37,7 @@ use syntax::parse;
 use syntax::parse::ParseSess;
 use syntax::{ast, source_map};
 use syntax::feature_gate::AttributeType;
-use syntax_pos::{MultiSpan, Span, symbol::Symbol};
+use syntax_pos::{MultiSpan, Span};
 use util::profiling::SelfProfiler;
 
 use rustc_target::spec::PanicStrategy;
@@ -164,10 +164,6 @@ pub struct Session {
 
     /// Cap lint level specified by a driver specifically.
     pub driver_lint_caps: FxHashMap<lint::LintId, lint::Level>,
-
-    /// All the crate names specified with `--extern`, and the builtin ones.
-    /// Starting with the Rust 2018 edition, absolute paths resolve in this set.
-    pub extern_prelude: FxHashSet<Symbol>,
 }
 
 pub struct PerfStats {
@@ -1113,17 +1109,6 @@ pub fn build_session_(
     };
     let working_dir = file_path_mapping.map_prefix(working_dir);
 
-    let mut extern_prelude: FxHashSet<Symbol> =
-        sopts.externs.iter().map(|kv| Symbol::intern(kv.0)).collect();
-
-    // HACK(eddyb) this ignores the `no_{core,std}` attributes.
-    // FIXME(eddyb) warn (somewhere) if core/std is used with `no_{core,std}`.
-    // if !attr::contains_name(&krate.attrs, "no_core") {
-    // if !attr::contains_name(&krate.attrs, "no_std") {
-    extern_prelude.insert(Symbol::intern("core"));
-    extern_prelude.insert(Symbol::intern("std"));
-    extern_prelude.insert(Symbol::intern("meta"));
-
     let sess = Session {
         target: target_cfg,
         host,
@@ -1198,7 +1183,6 @@ pub fn build_session_(
         has_global_allocator: Once::new(),
         has_panic_handler: Once::new(),
         driver_lint_caps: FxHashMap(),
-        extern_prelude,
     };
 
     validate_commandline_args_with_session_available(&sess);

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -927,8 +927,8 @@ pub struct GlobalCtxt<'tcx> {
     freevars: FxHashMap<DefId, Lrc<Vec<hir::Freevar>>>,
 
     maybe_unused_trait_imports: FxHashSet<DefId>,
-
     maybe_unused_extern_crates: Vec<(DefId, Span)>,
+    pub extern_prelude: FxHashSet<ast::Name>,
 
     // Internal cache for metadata decoding. No need to track deps on this.
     pub rcache: Lock<FxHashMap<ty::CReaderCacheKey, Ty<'tcx>>>,
@@ -1245,6 +1245,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
                     .into_iter()
                     .map(|(id, sp)| (hir.local_def_id(id), sp))
                     .collect(),
+            extern_prelude: resolutions.extern_prelude,
             hir,
             def_path_hash_to_def_id,
             queries: query::Queries::new(

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -36,7 +36,7 @@ use ty::subst::{Subst, Substs};
 use ty::util::{IntTypeExt, Discr};
 use ty::walk::TypeWalker;
 use util::captures::Captures;
-use util::nodemap::{NodeSet, DefIdMap, FxHashMap};
+use util::nodemap::{NodeSet, DefIdMap, FxHashMap, FxHashSet};
 use arena::SyncDroplessArena;
 use session::DataTypeKind;
 
@@ -139,6 +139,7 @@ pub struct Resolutions {
     pub maybe_unused_trait_imports: NodeSet,
     pub maybe_unused_extern_crates: Vec<(NodeId, Span)>,
     pub export_map: ExportMap,
+    pub extern_prelude: FxHashSet<Name>,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -790,6 +790,7 @@ where
                 trait_map: resolver.trait_map,
                 maybe_unused_trait_imports: resolver.maybe_unused_trait_imports,
                 maybe_unused_extern_crates: resolver.maybe_unused_extern_crates,
+                extern_prelude: resolver.extern_prelude,
             },
 
             analysis: ty::CrateAnalysis {

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -1361,6 +1361,7 @@ pub struct Resolver<'a, 'b: 'a> {
     graph_root: Module<'a>,
 
     prelude: Option<Module<'a>>,
+    extern_prelude: FxHashSet<Name>,
 
     /// n.b. This is used only for better diagnostics, not name resolution itself.
     has_self: FxHashSet<DefId>,
@@ -1674,6 +1675,17 @@ impl<'a, 'crateloader: 'a> Resolver<'a, 'crateloader> {
         DefCollector::new(&mut definitions, Mark::root())
             .collect_root(crate_name, session.local_crate_disambiguator());
 
+        let mut extern_prelude: FxHashSet<Name> =
+            session.opts.externs.iter().map(|kv| Symbol::intern(kv.0)).collect();
+
+        // HACK(eddyb) this ignore the `no_{core,std}` attributes.
+        // FIXME(eddyb) warn (elsewhere) if core/std is used with `no_{core,std}`.
+        // if !attr::contains_name(&krate.attrs, "no_core") {
+        // if !attr::contains_name(&krate.attrs, "no_std") {
+        extern_prelude.insert(Symbol::intern("core"));
+        extern_prelude.insert(Symbol::intern("std"));
+        extern_prelude.insert(Symbol::intern("meta"));
+
         let mut invocations = FxHashMap();
         invocations.insert(Mark::root(),
                            arenas.alloc_invocation_data(InvocationData::root(graph_root)));
@@ -1692,6 +1704,7 @@ impl<'a, 'crateloader: 'a> Resolver<'a, 'crateloader> {
             // AST.
             graph_root,
             prelude: None,
+            extern_prelude,
 
             has_self: FxHashSet(),
             field_names: FxHashMap(),
@@ -1963,7 +1976,7 @@ impl<'a, 'crateloader: 'a> Resolver<'a, 'crateloader> {
 
         if !module.no_implicit_prelude {
             // `record_used` means that we don't try to load crates during speculative resolution
-            if record_used && ns == TypeNS && self.session.extern_prelude.contains(&ident.name) {
+            if record_used && ns == TypeNS && self.extern_prelude.contains(&ident.name) {
                 let crate_id = self.crate_loader.process_path_extern(ident.name, ident.span);
                 let crate_root = self.get_module(DefId { krate: crate_id, index: CRATE_DEF_INDEX });
                 self.populate_module_if_necessary(&crate_root);
@@ -3950,7 +3963,7 @@ impl<'a, 'crateloader: 'a> Resolver<'a, 'crateloader> {
                     } else {
                         // Items from the prelude
                         if !module.no_implicit_prelude {
-                            names.extend(self.session.extern_prelude.iter().cloned());
+                            names.extend(self.extern_prelude.iter().cloned());
                             if let Some(prelude) = self.prelude {
                                 add_module_candidates(prelude, &mut names);
                             }
@@ -4396,7 +4409,8 @@ impl<'a, 'crateloader: 'a> Resolver<'a, 'crateloader> {
         );
 
         if self.session.rust_2018() {
-            for &name in &self.session.extern_prelude {
+            let extern_prelude_names = self.extern_prelude.clone();
+            for &name in extern_prelude_names.iter() {
                 let ident = Ident::with_empty_ctxt(name);
                 match self.crate_loader.maybe_process_path_extern(name, ident.span) {
                     Some(crate_id) => {

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -1977,9 +1977,15 @@ impl<'a, 'crateloader: 'a> Resolver<'a, 'crateloader> {
         }
 
         if !module.no_implicit_prelude {
-            // `record_used` means that we don't try to load crates during speculative resolution
-            if record_used && ns == TypeNS && self.extern_prelude.contains(&ident.name) {
-                let crate_id = self.crate_loader.process_path_extern(ident.name, ident.span);
+            if ns == TypeNS && self.extern_prelude.contains(&ident.name) {
+                let crate_id = if record_used {
+                    self.crate_loader.process_path_extern(ident.name, ident.span)
+                } else if let Some(crate_id) =
+                        self.crate_loader.maybe_process_path_extern(ident.name, ident.span) {
+                    crate_id
+                } else {
+                    return None;
+                };
                 let crate_root = self.get_module(DefId { krate: crate_id, index: CRATE_DEF_INDEX });
                 self.populate_module_if_necessary(&crate_root);
 

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -1678,13 +1678,15 @@ impl<'a, 'crateloader: 'a> Resolver<'a, 'crateloader> {
         let mut extern_prelude: FxHashSet<Name> =
             session.opts.externs.iter().map(|kv| Symbol::intern(kv.0)).collect();
 
-        // HACK(eddyb) this ignore the `no_{core,std}` attributes.
-        // FIXME(eddyb) warn (elsewhere) if core/std is used with `no_{core,std}`.
-        // if !attr::contains_name(&krate.attrs, "no_core") {
-        // if !attr::contains_name(&krate.attrs, "no_std") {
-        extern_prelude.insert(Symbol::intern("core"));
-        extern_prelude.insert(Symbol::intern("std"));
-        extern_prelude.insert(Symbol::intern("meta"));
+        if !attr::contains_name(&krate.attrs, "no_core") {
+            extern_prelude.insert(Symbol::intern("core"));
+            if !attr::contains_name(&krate.attrs, "no_std") {
+                extern_prelude.insert(Symbol::intern("std"));
+                if session.rust_2018() {
+                    extern_prelude.insert(Symbol::intern("meta"));
+                }
+            }
+        }
 
         let mut invocations = FxHashMap();
         invocations.insert(Mark::root(),

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -1361,7 +1361,7 @@ pub struct Resolver<'a, 'b: 'a> {
     graph_root: Module<'a>,
 
     prelude: Option<Module<'a>>,
-    extern_prelude: FxHashSet<Name>,
+    pub extern_prelude: FxHashSet<Name>,
 
     /// n.b. This is used only for better diagnostics, not name resolution itself.
     has_self: FxHashSet<DefId>,

--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -681,7 +681,7 @@ impl<'a, 'cl> Resolver<'a, 'cl> {
                     result
                 }
                 WhereToResolve::ExternPrelude => {
-                    if use_prelude && self.session.extern_prelude.contains(&ident.name) {
+                    if use_prelude && self.extern_prelude.contains(&ident.name) {
                         let crate_id =
                             self.crate_loader.process_path_extern(ident.name, ident.span);
                         let crate_root =

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -199,7 +199,7 @@ impl<'a, 'crateloader> Resolver<'a, 'crateloader> {
                     if !(
                         ns == TypeNS &&
                         !ident.is_path_segment_keyword() &&
-                        self.session.extern_prelude.contains(&ident.name)
+                        self.extern_prelude.contains(&ident.name)
                     ) {
                         // ... unless the crate name is not in the `extern_prelude`.
                         return binding;
@@ -218,7 +218,7 @@ impl<'a, 'crateloader> Resolver<'a, 'crateloader> {
                 } else if
                     ns == TypeNS &&
                     !ident.is_path_segment_keyword() &&
-                    self.session.extern_prelude.contains(&ident.name)
+                    self.extern_prelude.contains(&ident.name)
                 {
                     let crate_id =
                         self.crate_loader.process_path_extern(ident.name, ident.span);
@@ -736,7 +736,7 @@ impl<'a, 'b:'a, 'c: 'b> ImportResolver<'a, 'b, 'c> {
         let uniform_paths_feature = self.session.features_untracked().uniform_paths;
         for ((span, _, ns), results) in uniform_paths_canaries {
             let name = results.name;
-            let external_crate = if ns == TypeNS && self.session.extern_prelude.contains(&name) {
+            let external_crate = if ns == TypeNS && self.extern_prelude.contains(&name) {
                 let crate_id =
                     self.crate_loader.process_path_extern(name, span);
                 Some(Def::Mod(DefId { krate: crate_id, index: CRATE_DEF_INDEX }))

--- a/src/librustc_typeck/check_unused.rs
+++ b/src/librustc_typeck/check_unused.rs
@@ -158,7 +158,7 @@ fn unused_crates_lint<'tcx>(tcx: TyCtxt<'_, 'tcx, 'tcx>) {
         // If the extern crate isn't in the extern prelude,
         // there is no way it can be written as an `use`.
         let orig_name = extern_crate.orig_name.unwrap_or(item.name);
-        if !tcx.sess.extern_prelude.contains(&orig_name) {
+        if !tcx.extern_prelude.contains(&orig_name) {
             continue;
         }
 

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -457,6 +457,7 @@ pub fn run_core(search_paths: SearchPaths,
             trait_map: resolver.trait_map.clone(),
             maybe_unused_trait_imports: resolver.maybe_unused_trait_imports.clone(),
             maybe_unused_extern_crates: resolver.maybe_unused_extern_crates.clone(),
+            extern_prelude: resolver.extern_prelude.clone(),
         };
         let analysis = ty::CrateAnalysis {
             access_levels: Lrc::new(AccessLevels::default()),

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -220,7 +220,6 @@ fn run_test(test: &str, cratename: &str, filename: &FileName, line: usize,
         output_types: outputs,
         externs,
         cg: config::CodegenOptions {
-            prefer_dynamic: true,
             linker,
             ..cg
         },

--- a/src/test/rustdoc-ui/failed-doctest-output.stdout
+++ b/src/test/rustdoc-ui/failed-doctest-output.stdout
@@ -12,7 +12,7 @@ error[E0425]: cannot find value `no` in this scope
 3 | no
   | ^^ not found in this scope
 
-thread '$DIR/failed-doctest-output.rs - OtherStruct (line 26)' panicked at 'couldn't compile the test', librustdoc/test.rs:333:13
+thread '$DIR/failed-doctest-output.rs - OtherStruct (line 26)' panicked at 'couldn't compile the test', librustdoc/test.rs:332:13
 note: Run with `RUST_BACKTRACE=1` for a backtrace.
 
 ---- $DIR/failed-doctest-output.rs - SomeStruct (line 20) stdout ----
@@ -21,7 +21,7 @@ thread '$DIR/failed-doctest-output.rs - SomeStruct (line 20)' panicked at 'test 
 thread 'main' panicked at 'oh no', $DIR/failed-doctest-output.rs:3:1
 note: Run with `RUST_BACKTRACE=1` for a backtrace.
 
-', librustdoc/test.rs:368:17
+', librustdoc/test.rs:367:17
 
 
 failures:

--- a/src/test/ui/impl-trait/auxiliary/extra-item.rs
+++ b/src/test/ui/impl-trait/auxiliary/extra-item.rs
@@ -1,0 +1,1 @@
+pub trait MyTrait {}

--- a/src/test/ui/impl-trait/extra-item.rs
+++ b/src/test/ui/impl-trait/extra-item.rs
@@ -1,0 +1,10 @@
+// aux-build:extra-item.rs
+// compile-flags:--extern extra_item
+
+struct S;
+
+impl extra_item::MyTrait for S {
+    fn extra() {} //~ ERROR method `extra` is not a member of trait `extra_item::MyTrait`
+}
+
+fn main() {}

--- a/src/test/ui/impl-trait/extra-item.stderr
+++ b/src/test/ui/impl-trait/extra-item.stderr
@@ -1,0 +1,9 @@
+error[E0407]: method `extra` is not a member of trait `extra_item::MyTrait`
+  --> $DIR/extra-item.rs:7:5
+   |
+LL |     fn extra() {} //~ ERROR method `extra` is not a member of trait `extra_item::MyTrait`
+   |     ^^^^^^^^^^^^^ not a member of trait `extra_item::MyTrait`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0407`.

--- a/src/test/ui/run-pass/extern/extern-prelude-no-speculative.rs
+++ b/src/test/ui/run-pass/extern/extern-prelude-no-speculative.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // run-pass
-// compile-flags: --extern LooksLikeExternCrate=/path/to/nowhere
+// compile-flags: --extern LooksLikeExternCrate
 
 mod m {
     pub struct LooksLikeExternCrate;


### PR DESCRIPTION
Merged and approved:

* #54300: Updated RELEASES.md for 1.30.0
* #54939: rustdoc: don't prefer dynamic linking in doc tests
* #54671: resolve: Scale back hard-coded extern prelude additions on 2015 edition
* #55102: resolve: Do not skip extern prelude during speculative resolution 

r? @ghost