### PR TITLE
Fix ordering of nested modules in non-mod.rs mods

### DIFF
--- a/src/test/ui/non_modrs_mods_and_inline_mods/non_modrs_mods_and_inline_mods.rs
+++ b/src/test/ui/non_modrs_mods_and_inline_mods/non_modrs_mods_and_inline_mods.rs
@@ -1,0 +1,5 @@
+// compile-pass
+
+mod x;
+
+fn main() {}

--- a/src/test/ui/non_modrs_mods_and_inline_mods/x.rs
+++ b/src/test/ui/non_modrs_mods_and_inline_mods/x.rs
@@ -1,0 +1,5 @@
+// ignore-test: not a test
+
+pub mod y {
+    pub mod z;
+}

--- a/src/test/ui/non_modrs_mods_and_inline_mods/x/y/z/mod.rs
+++ b/src/test/ui/non_modrs_mods_and_inline_mods/x/y/z/mod.rs
@@ -1,0 +1,1 @@
+// ignore-test: not a test


### PR DESCRIPTION
Flatten relative offset into directory path before adding inline
(mod x { ... }) module names to the current directory path.

Fix #55094