### PR TITLE
make asm diagnostic instruction optional

### DIFF
--- a/src/librustc_codegen_llvm/llvm/diagnostic.rs
+++ b/src/librustc_codegen_llvm/llvm/diagnostic.rs
@@ -98,7 +98,7 @@ impl OptimizationDiagnostic<'ll> {
 pub struct InlineAsmDiagnostic<'ll> {
     pub cookie: c_uint,
     pub message: &'ll Twine,
-    pub instruction: &'ll Value,
+    pub instruction: Option<&'ll Value>,
 }
 
 impl InlineAsmDiagnostic<'ll> {
@@ -117,7 +117,7 @@ impl InlineAsmDiagnostic<'ll> {
         InlineAsmDiagnostic {
             cookie,
             message: message.unwrap(),
-            instruction: instruction.unwrap(),
+            instruction,
         }
     }
 }

--- a/src/test/ui/issues/issue-23458.rs
+++ b/src/test/ui/issues/issue-23458.rs
@@ -1,0 +1,18 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(asm)]
+
+fn main() {
+    unsafe {
+        asm!("int $3"); //~ ERROR too few operands for instruction
+                        //~| ERROR invalid operand in inline asm
+    }
+}

--- a/src/test/ui/issues/issue-23458.stderr
+++ b/src/test/ui/issues/issue-23458.stderr
@@ -1,0 +1,17 @@
+error: invalid operand in inline asm: 'int $3'
+  --> $DIR/issue-23458.rs:15:9
+   |
+LL |         asm!("int $3"); //~ ERROR too few operands for instruction
+   |         ^^^^^^^^^^^^^^^
+
+error: <inline asm>:1:2: error: too few operands for instruction
+        int 
+        ^
+
+  --> $DIR/issue-23458.rs:15:9
+   |
+LL |         asm!("int $3"); //~ ERROR too few operands for instruction
+   |         ^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
`DiagnosticInfoInlineAsm::getInstruction` may return a null pointer, so
the instruction shouldn't be blindly unwrapped.

Fixes #23458.
Fixes #55216.