### PR TITLE
Implement Copy and Clone for UnsafeCell<T>

### DIFF
--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -1515,7 +1515,10 @@ impl<T: ?Sized> UnsafeCell<T> {
 #[stable(feature = "unsafe_cell_copy_clone_conservative", since = "1.31.0")]
 impl<T: Clone + Copy> Clone for UnsafeCell<T> {
     fn clone(&self) -> UnsafeCell<T> {
-        UnsafeCell::new(self.value.clone())
+        // NOTE: we are explicitly not calling `.clone()` here, to enforce the
+        // use of Copy, rather than relying on what could be a custom impl
+        // of Clone
+        UnsafeCell::new(self.value)
     }
 }
 

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -1512,6 +1512,18 @@ impl<T: ?Sized> UnsafeCell<T> {
     }
 }
 
+// TODO: correct stable attribute
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<T: Clone> Clone for UnsafeCell<T> {
+    fn clone(&self) -> UnsafeCell<T> {
+        UnsafeCell::new(self.value.clone())
+    }
+}
+
+// TODO: correct stable attribute
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<T: Copy> Copy for UnsafeCell<T> {}
+
 #[stable(feature = "unsafe_cell_default", since = "1.10.0")]
 impl<T: Default> Default for UnsafeCell<T> {
     /// Creates an `UnsafeCell`, with the `Default` value for T.

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -1512,16 +1512,14 @@ impl<T: ?Sized> UnsafeCell<T> {
     }
 }
 
-// TODO: correct stable attribute
-#[stable(feature = "rust1", since = "1.0.0")]
-impl<T: Clone> Clone for UnsafeCell<T> {
+#[stable(feature = "unsafe_cell_copy_clone_conservative", since = "1.31.0")]
+impl<T: Clone + Copy> Clone for UnsafeCell<T> {
     fn clone(&self) -> UnsafeCell<T> {
         UnsafeCell::new(self.value.clone())
     }
 }
 
-// TODO: correct stable attribute
-#[stable(feature = "rust1", since = "1.0.0")]
+#[stable(feature = "unsafe_cell_copy_clone_conservative", since = "1.31.0")]
 impl<T: Copy> Copy for UnsafeCell<T> {}
 
 #[stable(feature = "unsafe_cell_default", since = "1.10.0")]


### PR DESCRIPTION
This change implements Copy and Clone for `UnsafeCell<T>`, if `T` implements Copy and/or Clone.

I am opening this as a PR, rather than as an RFC, because I am unsure whether this falls under the category of "Nontrivial trait impl (because all trait impls are insta-stable)" or "Implementing an "obvious" trait like Clone/Debug/etc", and the guide suggests to do whatever is easier. I am happy to close this PR and write a full RFC, if necessary.

I believe this is sound, as `UnsafeCell<T>` does not provide public access to `self.value`, and the accessor methods `get()` and `set()` always refer to item contained within self. Therefore if the contained item can be cloned or copied, I believe the containing Cell should also be able to copied or cloned.

The motivation for this change is to allow the use of `UnsafeCell<T>` in static arrays, using the `[T; N]` syntax. For this syntax to work, `T` must be `Copy`. For example, if we wanted to make an array of `[UnsafeCell<u16>; 128]`, it would be necessary to fully type out the initializer 128 times, which is not desirable, and difficult to do at global scope with a const_fn or macro.

As of now, the `#[stable]` attribute is incorrect, and must be fixed before merging. I would also appreciate guidance on how to fill this out.