### PR TITLE
ignore target folders

### DIFF
--- a/src/tools/tidy/src/lib.rs
+++ b/src/tools/tidy/src/lib.rs
@@ -78,6 +78,7 @@ fn filter_dirs(path: &Path) -> bool {
         "src/tools/lldb",
         "src/target",
         "src/stdsimd",
+        "target",
     ];
     skip.iter().any(|p| path.ends_with(p))
 }


### PR DESCRIPTION
when you try to edit a crate inside the compiler tree using rls, it
generates it's assets under target/rls, then tidy is trying to validate
line lenghts for C headers, etc