### PR TITLE
submodules: update clippy from 5afdf8b7 to b1d03437

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -349,6 +349,7 @@ dependencies = [
  "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]


### PR DESCRIPTION
Just a routine update.

Changes:
````
new_ret_no_self: add sample from #3313 to Known Problems section.
Support multiline comments and hopefully fix panic
Check for comments in collapsible ifs
Resolve ICE in needless range loop lint
RIIR update_lints: Update changelog links
Rename if_let_redundant_pattern_matching to redundant_pattern_matching
Add lint for redundant pattern matching for explicit return boolean
Fix issue #3322: reword help message for len_zero
Simplify manual_memcpy suggestion in some cases
Fix dogfood
Update known problems for unnecessary_fold
RIIR update_lints: Replace lint count in README.md
Rename `active_lints` to `usable_lints`
Add comment on WalkDir vs. fs::read_dir
sort_by -> sort_by_key
Some more documentation for clippy_dev
Use `WalkDir` to also gather from subdirectories
Avoid linting `boxed_local` on trait implementations.
Website: Make lint categories linkable
Restore clippy_dummy's placeholder name
Swap order of methods in `needless_range_loop` suggestion in some cases
Revert "Exclude pattern guards from unnecessary_fold lint"
Exclude pattern guards from unnecessary_fold lint
````