### PR TITLE
only issue "variant of the expected type" suggestion for enums

### DIFF
--- a/src/test/ui/did_you_mean/issue-42764.rs
+++ b/src/test/ui/did_you_mean/issue-42764.rs
@@ -20,4 +20,20 @@ fn main() {
     let n: usize = 42;
     this_function_expects_a_double_option(n);
     //~^ ERROR mismatched types
+    //~| HELP try using a variant of the expected type
+}
+
+
+// But don't issue the "try using a variant" help if the one-"variant" ADT is
+// actually a one-field struct.
+
+struct Payload;
+
+struct Wrapper { payload: Payload }
+
+struct Context { wrapper: Wrapper }
+
+fn overton() {
+    let _c = Context { wrapper: Payload{} };
+    //~^ ERROR mismatched types
 }

--- a/src/test/ui/did_you_mean/issue-42764.stderr
+++ b/src/test/ui/did_you_mean/issue-42764.stderr
@@ -13,6 +13,15 @@ LL |     this_function_expects_a_double_option(DoubleOption::FirstSome(n));
 LL |     this_function_expects_a_double_option(DoubleOption::AlternativeSome(n));
    |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to previous error
+error[E0308]: mismatched types
+  --> $DIR/issue-42764.rs:37:33
+   |
+LL |     let _c = Context { wrapper: Payload{} };
+   |                                 ^^^^^^^^^ expected struct `Wrapper`, found struct `Payload`
+   |
+   = note: expected type `Wrapper`
+              found type `Payload`
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
This suggestion (introduced in pull-request #43178 / eac74104) was being issued for one-field-struct expected types (in which case it is misleading and outright wrong), even though it was only intended for one-field enum-variants (most notably, `Some`).

Add a conditional to adhere to the original intent. (It would be possible to generalize to structs, but not obviously net desirable.) This adds a level of indentation, so the diff here is going to be
easier to read in [ignore-whitespace mode](https://github.com/rust-lang/rust/commit/b0d3d3b9?w=1).

Resolves #55250.

r? @pnkfelix 