### PR TITLE
Get rid of the `Scalar` and `ScalarPair` variants of `ConstValue`...

### DIFF
--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -456,13 +456,15 @@ impl<'a> HashStable<StableHashingContext<'a>> for mir::interpret::Allocation {
         hcx: &mut StableHashingContext<'a>,
         hasher: &mut StableHasher<W>,
     ) {
-        self.bytes.hash_stable(hcx, hasher);
-        for reloc in self.relocations.iter() {
+        trace!("hashing allocation {:?}", self);
+        let mir::interpret::Allocation { bytes, relocations, undef_mask, align, mutability } = self;
+        bytes.hash_stable(hcx, hasher);
+        for reloc in relocations.iter() {
             reloc.hash_stable(hcx, hasher);
         }
-        self.undef_mask.hash_stable(hcx, hasher);
-        self.align.hash_stable(hcx, hasher);
-        self.mutability.hash_stable(hcx, hasher);
+        undef_mask.hash_stable(hcx, hasher);
+        align.hash_stable(hcx, hasher);
+        mutability.hash_stable(hcx, hasher);
     }
 }
 

--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -457,7 +457,10 @@ impl<'a> HashStable<StableHashingContext<'a>> for mir::interpret::Allocation {
         hasher: &mut StableHasher<W>,
     ) {
         trace!("hashing allocation {:?}", self);
-        let mir::interpret::Allocation { bytes, relocations, undef_mask, align, mutability } = self;
+        let mir::interpret::Allocation {
+            bytes, relocations, undef_mask, align, mutability,
+            extra: (),
+        } = self;
         bytes.hash_stable(hcx, hasher);
         for reloc in relocations.iter() {
             reloc.hash_stable(hcx, hasher);

--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -375,13 +375,6 @@ for ::mir::interpret::ConstValue<'gcx> {
                 def_id.hash_stable(hcx, hasher);
                 substs.hash_stable(hcx, hasher);
             }
-            Scalar(val) => {
-                val.hash_stable(hcx, hasher);
-            }
-            ScalarPair(a, b) => {
-                a.hash_stable(hcx, hasher);
-                b.hash_stable(hcx, hasher);
-            }
             ByRef(id, alloc, offset) => {
                 id.hash_stable(hcx, hasher);
                 alloc.hash_stable(hcx, hasher);
@@ -512,7 +505,7 @@ for ::mir::interpret::EvalErrorKind<'gcx, O> {
                                           hasher: &mut StableHasher<W>) {
         use mir::interpret::EvalErrorKind::*;
 
-        mem::discriminant(&self).hash_stable(hcx, hasher);
+        mem::discriminant(self).hash_stable(hcx, hasher);
 
         match *self {
             FunctionArgCountMismatch |
@@ -577,11 +570,11 @@ for ::mir::interpret::EvalErrorKind<'gcx, O> {
             NoMirFor(ref s) => s.hash_stable(hcx, hasher),
             UnterminatedCString(ptr) => ptr.hash_stable(hcx, hasher),
             PointerOutOfBounds {
-                ptr,
+                offset,
                 access,
                 allocation_size,
             } => {
-                ptr.hash_stable(hcx, hasher);
+                offset.hash_stable(hcx, hasher);
                 access.hash_stable(hcx, hasher);
                 allocation_size.hash_stable(hcx, hasher)
             },

--- a/src/librustc/mir/interpret/error.rs
+++ b/src/librustc/mir/interpret/error.rs
@@ -197,7 +197,7 @@ pub enum EvalErrorKind<'tcx, O> {
     InvalidBool,
     InvalidDiscriminant(u128),
     PointerOutOfBounds {
-        ptr: Pointer,
+        offset: Size,
         access: bool,
         allocation_size: Size,
     },
@@ -440,10 +440,10 @@ impl<'tcx, O: fmt::Debug> fmt::Debug for EvalErrorKind<'tcx, O> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use self::EvalErrorKind::*;
         match *self {
-            PointerOutOfBounds { ptr, access, allocation_size } => {
-                write!(f, "{} at offset {}, outside bounds of allocation {} which has size {}",
+            PointerOutOfBounds { offset, access, allocation_size } => {
+                write!(f, "{} at offset {}, outside bounds of allocation with size {}",
                        if access { "memory access" } else { "pointer computed" },
-                       ptr.offset.bytes(), ptr.alloc_id, allocation_size.bytes())
+                       offset.bytes(), allocation_size.bytes())
             },
             MemoryLockViolation { ptr, len, frame, access, ref lock } => {
                 write!(f, "{:?} access by frame {} at {:?}, size {}, is in conflict with lock {:?}",

--- a/src/librustc/mir/interpret/mod.rs
+++ b/src/librustc/mir/interpret/mod.rs
@@ -634,7 +634,7 @@ impl<Tag: Copy, Extra: Default> Allocation<Tag, Extra> {
         offset: Size,
         required_align: Align,
     ) -> EvalResult<'tcx> {
-        if self.align.abi() > required_align.abi() {
+        if self.align.abi() < required_align.abi() {
             return err!(AlignmentCheckFailed {
                 has: self.align,
                 required: required_align,

--- a/src/librustc/mir/interpret/value.rs
+++ b/src/librustc/mir/interpret/value.rs
@@ -50,6 +50,7 @@ impl<'tcx> ConstValue<'tcx> {
     #[inline]
     pub fn try_get_bytes(&self, hdl: impl HasDataLayout, n: Size, align: Align) -> Option<&[u8]> {
         let (_, alloc, offset) = self.try_as_by_ref()?;
+        trace!("{:?}", alloc.get_bytes(hdl, offset, n, align));
         alloc.get_bytes(hdl, offset, n, align).ok()
     }
 

--- a/src/librustc/mir/interpret/value.rs
+++ b/src/librustc/mir/interpret/value.rs
@@ -75,7 +75,9 @@ impl<'tcx> ConstValue<'tcx> {
         hdl: impl HasDataLayout,
     ) -> Option<Pointer> {
         let (_, alloc, offset) = self.try_as_by_ref()?;
-        alloc.read_scalar(hdl, offset).ok()?.to_ptr().ok()
+        let size = hdl.data_layout().pointer_size;
+        let required_align = hdl.data_layout().pointer_align;
+        alloc.read_scalar(hdl, offset, size, required_align).ok()?.to_ptr().ok()
     }
 
     /// e.g. for vtables, fat pointers or single pointers

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -2487,7 +2487,9 @@ pub fn fmt_const_val(f: &mut impl Write, const_val: &ty::Const<'_>) -> fmt::Resu
             },
             // print string literals
             Ref(_, &ty::TyS { sty: Str, .. }, _) => {
-                let ptr = ty::tls::with(|tcx| alloc.read_scalar(tcx, offset));
+                let ptr = ty::tls::with(|tcx| alloc.read_scalar(
+                    tcx, offset, tcx.data_layout.pointer_size, tcx.data_layout.pointer_align,
+                ));
                 let ptr = ptr.and_then(Scalar::to_ptr);
                 if let Ok(ptr) = ptr {
                     let len = ty::tls::with(|tcx| alloc.read_bits(

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -2105,7 +2105,7 @@ impl<'tcx> Operand<'tcx> {
             span,
             ty,
             user_ty: None,
-            literal: ty::Const::zero_sized(tcx, ParamEnv::empty().and(ty)),
+            literal: ty::Const::zero_sized(tcx, tcx.param_env(def_id).and(ty)),
         })
     }
 

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -2494,7 +2494,7 @@ pub fn fmt_const_val(f: &mut impl Write, const_val: &ty::Const<'_>) -> fmt::Resu
                 if let Ok(ptr) = ptr {
                     let len = ty::tls::with(|tcx| alloc.read_bits(
                         tcx,
-                        offset,
+                        offset + tcx.data_layout.pointer_size,
                         ParamEnv::reveal_all().and(tcx.types.usize),
                     ).ok());
                     if let Some(len) = len {

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -2105,7 +2105,7 @@ impl<'tcx> Operand<'tcx> {
             span,
             ty,
             user_ty: None,
-            literal: ty::Const::zero_sized(tcx, tcx.param_env(def_id).and(ty)),
+            literal: ty::Const::fn_def(tcx, ty),
         })
     }
 

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -428,9 +428,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                     Some(format!("[{}]", self.tcx.type_of(def.did).to_string())),
                 ));
                 let tcx = self.tcx;
-                if let Some(len) = len.val.try_to_scalar().and_then(|scalar| {
-                    scalar.to_usize(tcx).ok()
-                }) {
+                if let Some(len) = len.val.try_to_usize(tcx) {
                     flags.push((
                         "_Self".to_owned(),
                         Some(format!("[{}; {}]", self.tcx.type_of(def.did).to_string(), len)),

--- a/src/librustc/ty/instance.rs
+++ b/src/librustc/ty/instance.rs
@@ -16,13 +16,13 @@ use util::ppaux;
 
 use std::fmt;
 
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, RustcEncodable, RustcDecodable)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, RustcEncodable, RustcDecodable)]
 pub struct Instance<'tcx> {
     pub def: InstanceDef<'tcx>,
     pub substs: &'tcx Substs<'tcx>,
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, RustcEncodable, RustcDecodable)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, RustcEncodable, RustcDecodable)]
 pub enum InstanceDef<'tcx> {
     Item(DefId),
     Intrinsic(DefId),

--- a/src/librustc/ty/structural_impls.rs
+++ b/src/librustc/ty/structural_impls.rs
@@ -507,10 +507,10 @@ impl<'a, 'tcx, O: Lift<'tcx>> Lift<'tcx> for interpret::EvalErrorKind<'a, O> {
             InvalidBool => InvalidBool,
             InvalidDiscriminant(val) => InvalidDiscriminant(val),
             PointerOutOfBounds {
-                ptr,
+                offset,
                 access,
                 allocation_size,
-            } => PointerOutOfBounds { ptr, access, allocation_size },
+            } => PointerOutOfBounds { offset, access, allocation_size },
             InvalidNullPointerUsage => InvalidNullPointerUsage,
             ReadPointerAsBytes => ReadPointerAsBytes,
             ReadBytesAsPointer => ReadBytesAsPointer,
@@ -1153,8 +1153,6 @@ EnumTypeFoldableImpl! {
 impl<'tcx> TypeFoldable<'tcx> for ConstValue<'tcx> {
     fn super_fold_with<'gcx: 'tcx, F: TypeFolder<'gcx, 'tcx>>(&self, folder: &mut F) -> Self {
         match *self {
-            ConstValue::Scalar(v) => ConstValue::Scalar(v),
-            ConstValue::ScalarPair(a, b) => ConstValue::ScalarPair(a, b),
             ConstValue::ByRef(id, alloc, offset) => ConstValue::ByRef(id, alloc, offset),
             ConstValue::Unevaluated(def_id, substs) => {
                 ConstValue::Unevaluated(def_id, substs.fold_with(folder))
@@ -1164,8 +1162,6 @@ impl<'tcx> TypeFoldable<'tcx> for ConstValue<'tcx> {
 
     fn super_visit_with<V: TypeVisitor<'tcx>>(&self, visitor: &mut V) -> bool {
         match *self {
-            ConstValue::Scalar(_) |
-            ConstValue::ScalarPair(_, _) |
             ConstValue::ByRef(_, _, _) => false,
             ConstValue::Unevaluated(_, substs) => substs.visit_with(visitor),
         }

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -1975,9 +1975,10 @@ impl<'tcx> Const<'tcx> {
         ty: ParamEnvAnd<'tcx, Ty<'tcx>>,
     ) -> &'tcx Self {
         let ty = tcx.lift_to_global(&ty).unwrap();
-        let layout = tcx.layout_of(ty).unwrap_or_else(|_| {
+        let layout = tcx.layout_of(ty).unwrap_or_else(|e| {
             // FIXME: add delay_span_bug call, we can only get here if there are errors
             // we produce a weird dummy layout with somewhat sane values
+            error!("failed to compute layout of {:?}: {:?}", ty, e);
             let mut layout = tcx.layout_of(ParamEnv::reveal_all().and(tcx.types.u128)).unwrap();
             layout.ty = ty.value;
             layout

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -2000,12 +2000,10 @@ impl<'tcx> Const<'tcx> {
     }
 
     #[inline]
-    pub fn zero_sized(tcx: TyCtxt<'_, '_, 'tcx>, ty: ParamEnvAnd<'tcx, Ty<'tcx>>,) -> &'tcx Self {
-        let ty = tcx.lift_to_global(&ty).unwrap();
-        let layout = tcx.layout_of(ty).unwrap_or_else(|e| {
-            panic!("could not compute layout for {:?}: {:?}", ty, e)
-        });
-        Self::from_bytes(tcx, &[], layout)
+    pub fn fn_def(tcx: TyCtxt<'_, '_, 'tcx>, ty: Ty<'tcx>) -> &'tcx Self {
+        let alloc = Allocation::from_bytes(&[], ty::layout::Align::from_bytes(1, 1).unwrap());
+        let const_val = ConstValue::from_allocation(tcx, alloc);
+        Self::from_const_value(tcx, const_val, ty)
     }
 
     #[inline]

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -1975,8 +1975,12 @@ impl<'tcx> Const<'tcx> {
         ty: ParamEnvAnd<'tcx, Ty<'tcx>>,
     ) -> &'tcx Self {
         let ty = tcx.lift_to_global(&ty).unwrap();
-        let layout = tcx.layout_of(ty).unwrap_or_else(|e| {
-            panic!("could not compute layout for {:?}: {:?}", ty, e)
+        let layout = tcx.layout_of(ty).unwrap_or_else(|_| {
+            // FIXME: add delay_span_bug call, we can only get here if there are errors
+            // we produce a weird dummy layout with somewhat sane values
+            let mut layout = tcx.layout_of(ParamEnv::reveal_all().and(tcx.types.u128)).unwrap();
+            layout.ty = ty.value;
+            layout
         });
         let mut bytes = [0_u8; 16];
         let endian = tcx.data_layout.endian;

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -1986,7 +1986,7 @@ impl<'tcx> Const<'tcx> {
         let mut bytes = [0_u8; 16];
         let endian = tcx.data_layout.endian;
         write_target_uint(endian, &mut bytes, bits).unwrap();
-        Self::from_bytes(tcx, &bytes, layout)
+        Self::from_bytes(tcx, &bytes[0..(layout.size.bytes() as usize)], layout)
     }
 
     #[inline]

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -1989,7 +1989,7 @@ impl<'tcx> Const<'tcx> {
     }
 
     #[inline]
-    pub fn from_bytes(
+    fn from_bytes(
         tcx: TyCtxt<'_, '_, 'tcx>,
         bytes: &[u8],
         layout: ty::layout::TyLayout<'tcx>,

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -2008,12 +2008,12 @@ impl<'tcx> Const<'tcx> {
 
     #[inline]
     pub fn from_bool(tcx: TyCtxt<'_, '_, 'tcx>, v: bool) -> &'tcx Self {
-        Self::from_bits(tcx, v as u128, ParamEnv::empty().and(tcx.types.bool))
+        Self::from_bits(tcx, v as u128, ParamEnv::reveal_all().and(tcx.types.bool))
     }
 
     #[inline]
     pub fn from_usize(tcx: TyCtxt<'_, '_, 'tcx>, n: u64) -> &'tcx Self {
-        Self::from_bits(tcx, n as u128, ParamEnv::empty().and(tcx.types.usize))
+        Self::from_bits(tcx, n as u128, ParamEnv::reveal_all().and(tcx.types.usize))
     }
 
     #[inline]
@@ -2044,7 +2044,7 @@ impl<'tcx> Const<'tcx> {
 
     #[inline]
     pub fn assert_bool(&self, tcx: TyCtxt<'_, '_, '_>) -> Option<bool> {
-        self.assert_bits(tcx, ParamEnv::empty().and(tcx.types.bool)).and_then(|v| match v {
+        self.assert_bits(tcx, ParamEnv::reveal_all().and(tcx.types.bool)).and_then(|v| match v {
             0 => Some(false),
             1 => Some(true),
             _ => None,
@@ -2053,7 +2053,7 @@ impl<'tcx> Const<'tcx> {
 
     #[inline]
     pub fn assert_usize(&self, tcx: TyCtxt<'_, '_, '_>) -> Option<u64> {
-        self.assert_bits(tcx, ParamEnv::empty().and(tcx.types.usize)).map(|v| v as u64)
+        self.assert_bits(tcx, ParamEnv::reveal_all().and(tcx.types.usize)).map(|v| v as u64)
     }
 
     #[inline]

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -2060,10 +2060,9 @@ impl<'tcx> Const<'tcx> {
     pub fn unwrap_bits(
         &self,
         tcx: TyCtxt<'_, '_, '_>,
-        ty: ParamEnvAnd<'tcx, Ty<'tcx>>,
     ) -> u128 {
-        self.assert_bits(tcx, ty).unwrap_or_else(||
-            bug!("expected bits of {}, got {:#?}", ty.value, self))
+        self.assert_bits(tcx, ParamEnv::empty().and(self.ty)).unwrap_or_else(||
+            bug!("expected bits of {}, got {:#?}", self.ty, self))
     }
 
     #[inline]

--- a/src/librustc_codegen_llvm/mir/constant.rs
+++ b/src/librustc_codegen_llvm/mir/constant.rs
@@ -181,6 +181,7 @@ impl FunctionCx<'a, 'll, 'tcx> {
         constant
             .and_then(|c| {
                 let field_ty = c.ty.builtin_index().unwrap();
+                let layout = bx.cx.layout_of(field_ty);
                 let fields = match c.ty.sty {
                     ty::Array(_, n) => n.unwrap_usize(bx.tcx()),
                     ref other => bug!("invalid simd shuffle type: {}", other),
@@ -195,8 +196,7 @@ impl FunctionCx<'a, 'll, 'tcx> {
                         c,
                     )?;
                     // FIXME(oli-obk): are these indices always usize?
-                    if let Some(prim) = field.val.try_to_usize(bx.tcx()) {
-                        let layout = bx.cx.layout_of(field_ty);
+                    if let Some(prim) = field.val.try_to_bits(bx.tcx(), layout) {
                         let scalar = match layout.abi {
                             layout::Abi::Scalar(ref x) => x,
                             _ => bug!("from_const: invalid ByVal layout: {:#?}", layout)

--- a/src/librustc_codegen_llvm/mir/operand.rs
+++ b/src/librustc_codegen_llvm/mir/operand.rs
@@ -112,32 +112,6 @@ impl OperandRef<'ll, 'tcx> {
                         );
                         OperandValue::Immediate(llval)
                     },
-                    layout::Abi::ScalarPair(ref a_scalar, ref b_scalar) => {
-                        let a_size = a_scalar.value.size(bx.tcx());
-                        let a = alloc.read_scalar(
-                            bx.tcx(), offset, a_size, a_scalar.value.align(bx.tcx()),
-                        ).map_err(econv)?;
-                        let b_align = b_scalar.value.align(bx.tcx());
-                        let b_offset = offset + a_size.abi_align(b_align);
-                        let b_size = b_scalar.value.size(bx.tcx());
-                        let b = alloc.read_scalar(
-                            bx.tcx(), b_offset, b_size, b_align,
-                        ).map_err(econv)?;
-                        let a_llval = scalar_to_llvm(
-                            bx.cx,
-                            a,
-                            a_scalar,
-                            layout.scalar_pair_element_llvm_type(bx.cx, 0, true),
-                        );
-                        let b_layout = layout.scalar_pair_element_llvm_type(bx.cx, 1, true);
-                        let b_llval = scalar_to_llvm(
-                            bx.cx,
-                            b,
-                            b_scalar,
-                            b_layout,
-                        );
-                        OperandValue::Pair(a_llval, b_llval)
-                    },
                     _ => return Ok(PlaceRef::from_const_alloc(bx, layout, alloc, offset).load(bx)),
                 }
             },

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1557,8 +1557,8 @@ fn validate_const<'a, 'tcx>(
 ) {
     let ecx = ::rustc_mir::const_eval::mk_eval_cx(tcx, gid.instance, param_env).unwrap();
     let result = (|| {
-        let op = ecx.const_to_op(constant)?;
-        let mut ref_tracking = ::rustc_mir::interpret::RefTracking::new(op);
+        let mplace = ecx.const_to_mplace(constant)?;
+        let mut ref_tracking = ::rustc_mir::interpret::RefTracking::new(mplace.into());
         while let Some((op, mut path)) = ref_tracking.todo.pop() {
             ecx.validate_operand(
                 op,

--- a/src/librustc_mir/build/matches/mod.rs
+++ b/src/librustc_mir/build/matches/mod.rs
@@ -978,15 +978,14 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
         // available
         match test.kind {
             TestKind::SwitchInt {
-                switch_ty,
                 ref mut options,
                 ref mut indices,
+                ..
             } => {
                 for candidate in candidates.iter() {
                     if !self.add_cases_to_switch(
                         &match_pair.place,
                         candidate,
-                        switch_ty,
                         options,
                         indices,
                     ) {

--- a/src/librustc_mir/build/matches/test.rs
+++ b/src/librustc_mir/build/matches/test.rs
@@ -112,7 +112,6 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
     pub fn add_cases_to_switch<'pat>(&mut self,
                                      test_place: &Place<'tcx>,
                                      candidate: &Candidate<'pat, 'tcx>,
-                                     switch_ty: Ty<'tcx>,
                                      options: &mut Vec<u128>,
                                      indices: &mut FxHashMap<&'tcx ty::Const<'tcx>, usize>)
                                      -> bool
@@ -124,10 +123,9 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
 
         match *match_pair.pattern.kind {
             PatternKind::Constant { value } => {
-                let switch_ty = ty::ParamEnv::empty().and(switch_ty);
                 indices.entry(value)
                        .or_insert_with(|| {
-                           options.push(value.unwrap_bits(self.hir.tcx(), switch_ty));
+                           options.push(value.unwrap_bits(self.hir.tcx()));
                            options.len() - 1
                        });
                 true

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -29,7 +29,7 @@ use syntax::ast::Mutability;
 use syntax::source_map::{Span, DUMMY_SP};
 
 use interpret::{self,
-    PlaceTy, MemPlace, MPlaceTy, OpTy, Operand, Value, Pointer, Scalar, ConstValue,
+    PlaceTy, MPlaceTy, OpTy, Pointer, Scalar, ConstValue,
     EvalResult, EvalError, EvalErrorKind, GlobalId, EvalContext, StackPopCleanup,
     Allocation, AllocId, MemoryKind,
     snapshot,
@@ -131,6 +131,7 @@ pub fn mplace_to_const<'tcx>(
         // out of the larger allocation, so we lose all information about
         // potential surrounding types with different alignment.
         align: mplace.layout.align,
+        extra: (),
     };
     for i in 0..mplace.layout.size.bytes() {
         let i = Size::from_bytes(i);

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -129,7 +129,7 @@ pub fn op_to_const<'tcx>(
             assert!(alloc.bytes.len() as u64 - ptr.offset.bytes() >= op.layout.size.bytes());
             let mut alloc = alloc.clone();
             alloc.align = align;
-            // FIXME shouldnt it be the case that `mark_static_initialized` has already
+            // FIXME shouldnt it be the case that `intern_static` has already
             // interned this?  I thought that is the entire point of that `FinishStatic` stuff?
             let alloc = ecx.tcx.intern_const_alloc(alloc);
             ConstValue::ByRef(ptr.alloc_id, alloc, ptr.offset)

--- a/src/librustc_mir/hair/cx/expr.rs
+++ b/src/librustc_mir/hair/cx/expr.rs
@@ -851,7 +851,7 @@ fn method_callee<'a, 'gcx, 'tcx>(
         ty,
         span,
         kind: ExprKind::Literal {
-            literal: ty::Const::zero_sized(cx.tcx(), ty),
+            literal: ty::Const::zero_sized(cx.tcx(), cx.param_env.and(ty)),
             user_ty,
         },
     }
@@ -912,7 +912,7 @@ fn convert_path_expr<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
             ExprKind::Literal {
                 literal: ty::Const::zero_sized(
                     cx.tcx,
-                    cx.tables().node_id_to_type(expr.hir_id),
+                    cx.param_env.and(cx.tables().node_id_to_type(expr.hir_id)),
                 ),
                 user_ty,
             }

--- a/src/librustc_mir/hair/cx/expr.rs
+++ b/src/librustc_mir/hair/cx/expr.rs
@@ -851,7 +851,7 @@ fn method_callee<'a, 'gcx, 'tcx>(
         ty,
         span,
         kind: ExprKind::Literal {
-            literal: ty::Const::zero_sized(cx.tcx(), cx.param_env.and(ty)),
+            literal: ty::Const::fn_def(cx.tcx(), ty),
             user_ty,
         },
     }
@@ -910,9 +910,9 @@ fn convert_path_expr<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
         Def::SelfCtor(..) => {
             let user_ty = user_substs_applied_to_def(cx, expr.hir_id, &def);
             ExprKind::Literal {
-                literal: ty::Const::zero_sized(
+                literal: ty::Const::fn_def(
                     cx.tcx,
-                    cx.param_env.and(cx.tables().node_id_to_type(expr.hir_id)),
+                    cx.tables().node_id_to_type(expr.hir_id),
                 ),
                 user_ty,
             }

--- a/src/librustc_mir/hair/cx/mod.rs
+++ b/src/librustc_mir/hair/cx/mod.rs
@@ -221,7 +221,7 @@ impl<'a, 'gcx, 'tcx> Cx<'a, 'gcx, 'tcx> {
             if item.kind == ty::AssociatedKind::Method && item.ident.name == method_name {
                 let method_ty = self.tcx.type_of(item.def_id);
                 let method_ty = method_ty.subst(self.tcx, substs);
-                return (method_ty, ty::Const::zero_sized(self.tcx, self.param_env.and(method_ty)));
+                return (method_ty, ty::Const::fn_def(self.tcx, method_ty));
             }
         }
 

--- a/src/librustc_mir/hair/pattern/_match.rs
+++ b/src/librustc_mir/hair/pattern/_match.rs
@@ -1364,7 +1364,7 @@ fn slice_pat_covered_by_constructor<'tcx>(
     {
         match pat.kind {
             box PatternKind::Constant { value } => {
-                let b = value.unwrap_bits(tcx, ty::ParamEnv::empty().and(pat.ty));
+                let b = value.unwrap_bits(tcx);
                 assert_eq!(b as u8 as u128, b);
                 if b as u8 != *ch {
                     return Ok(false);

--- a/src/librustc_mir/interpret/memory.rs
+++ b/src/librustc_mir/interpret/memory.rs
@@ -707,7 +707,7 @@ where
         mutability: Mutability,
     ) -> EvalResult<'tcx> {
         trace!(
-            "mark_static_initialized {:?}, mutability: {:?}",
+            "intern_static {:?}, mutability: {:?}",
             alloc_id,
             mutability
         );

--- a/src/librustc_mir/interpret/memory.rs
+++ b/src/librustc_mir/interpret/memory.rs
@@ -261,7 +261,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> Memory<'a, 'mir, 'tcx, M> {
                 // of some (potentially dead) allocation.
                 if ptr.offset > size {
                     return err!(PointerOutOfBounds {
-                        ptr: ptr.erase_tag(),
+                        offset: ptr.offset,
                         access: true,
                         allocation_size: size,
                     });
@@ -310,7 +310,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> Memory<'a, 'mir, 'tcx, M> {
         let allocation_size = alloc.bytes.len() as u64;
         if ptr.offset.bytes() > allocation_size {
             return err!(PointerOutOfBounds {
-                ptr: ptr.erase_tag(),
+                offset: ptr.offset,
                 access,
                 allocation_size: Size::from_bytes(allocation_size),
             });

--- a/src/librustc_mir/interpret/operand.rs
+++ b/src/librustc_mir/interpret/operand.rs
@@ -359,7 +359,7 @@ pub(super) fn from_known_layout<'tcx>(
 impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> {
     /// Try reading a value in memory; this is interesting particularily for ScalarPair.
     /// Return None if the layout does not permit loading this as a value.
-    pub(super) fn try_read_value_from_mplace(
+    pub(crate) fn try_read_value_from_mplace(
         &self,
         mplace: MPlaceTy<'tcx, M::PointerTag>,
     ) -> EvalResult<'tcx, Option<Value<M::PointerTag>>> {
@@ -403,7 +403,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
     /// Note that for a given layout, this operation will either always fail or always
     /// succeed!  Whether it succeeds depends on whether the layout can be represented
     /// in a `Value`, not on which data is stored there currently.
-    pub(crate) fn try_read_value(
+    pub(super)fn try_read_value(
         &self,
         src: OpTy<'tcx, M::PointerTag>,
     ) -> EvalResult<'tcx, Result<Value<M::PointerTag>, MemPlace<M::PointerTag>>> {

--- a/src/librustc_mir/monomorphize/collector.rs
+++ b/src/librustc_mir/monomorphize/collector.rs
@@ -202,7 +202,7 @@ use rustc::session::config;
 use rustc::mir::{self, Location, Promoted};
 use rustc::mir::visit::Visitor as MirVisitor;
 use rustc::mir::mono::MonoItem;
-use rustc::mir::interpret::{Scalar, GlobalId, AllocType};
+use rustc::mir::interpret::{GlobalId, AllocType};
 
 use monomorphize::{self, Instance};
 use rustc::util::nodemap::{FxHashSet, FxHashMap, DefIdMap};
@@ -1261,19 +1261,10 @@ fn collect_const<'a, 'tcx>(
     };
     match val {
         ConstValue::Unevaluated(..) => bug!("const eval yielded unevaluated const"),
-        ConstValue::ScalarPair(Scalar::Ptr(a), Scalar::Ptr(b)) => {
-            collect_miri(tcx, a.alloc_id, output);
-            collect_miri(tcx, b.alloc_id, output);
-        }
-        ConstValue::ScalarPair(_, Scalar::Ptr(ptr)) |
-        ConstValue::ScalarPair(Scalar::Ptr(ptr), _) |
-        ConstValue::Scalar(Scalar::Ptr(ptr)) =>
-            collect_miri(tcx, ptr.alloc_id, output),
         ConstValue::ByRef(_id, alloc, _offset) => {
             for &((), id) in alloc.relocations.values() {
                 collect_miri(tcx, id, output);
             }
         }
-        _ => {},
     }
 }

--- a/src/librustc_mir/shim.rs
+++ b/src/librustc_mir/shim.rs
@@ -445,7 +445,7 @@ impl<'a, 'tcx> CloneShimBuilder<'a, 'tcx> {
             span: self.span,
             ty: func_ty,
             user_ty: None,
-            literal: ty::Const::zero_sized(self.tcx, func_ty),
+            literal: ty::Const::zero_sized(self.tcx, self.tcx.param_env(self.def_id).and(func_ty)),
         });
 
         let ref_loc = self.make_place(
@@ -688,6 +688,7 @@ fn build_call_shim<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     let sig = tcx.fn_sig(def_id);
     let sig = tcx.erase_late_bound_regions(&sig);
     let span = tcx.def_span(def_id);
+    let param_env = tcx.param_env(def_id);
 
     debug!("build_call_shim: sig={:?}", sig);
 
@@ -733,7 +734,7 @@ fn build_call_shim<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                 span,
                 ty,
                 user_ty: None,
-                literal: ty::Const::zero_sized(tcx, ty),
+                literal: ty::Const::zero_sized(tcx, param_env.and(ty)),
              }),
              vec![rcvr])
         }

--- a/src/librustc_mir/shim.rs
+++ b/src/librustc_mir/shim.rs
@@ -445,7 +445,7 @@ impl<'a, 'tcx> CloneShimBuilder<'a, 'tcx> {
             span: self.span,
             ty: func_ty,
             user_ty: None,
-            literal: ty::Const::zero_sized(self.tcx, self.tcx.param_env(self.def_id).and(func_ty)),
+            literal: ty::Const::fn_def(self.tcx, func_ty),
         });
 
         let ref_loc = self.make_place(
@@ -688,7 +688,6 @@ fn build_call_shim<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     let sig = tcx.fn_sig(def_id);
     let sig = tcx.erase_late_bound_regions(&sig);
     let span = tcx.def_span(def_id);
-    let param_env = tcx.param_env(def_id);
 
     debug!("build_call_shim: sig={:?}", sig);
 
@@ -734,7 +733,7 @@ fn build_call_shim<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                 span,
                 ty,
                 user_ty: None,
-                literal: ty::Const::zero_sized(tcx, param_env.and(ty)),
+                literal: ty::Const::fn_def(tcx, ty),
              }),
              vec![rcvr])
         }

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -259,9 +259,9 @@ impl<'a, 'mir, 'tcx> ConstPropagator<'a, 'mir, 'tcx> {
         source_info: SourceInfo,
     ) -> Option<Const<'tcx>> {
         self.ecx.tcx.span = source_info.span;
-        match self.ecx.const_to_op(c.literal) {
-            Ok(op) => {
-                Some((op, c.span))
+        match self.ecx.const_to_mplace(c.literal) {
+            Ok(mplace) => {
+                Some((mplace.into(), c.span))
             },
             Err(error) => {
                 let (stacktrace, span) = self.ecx.generate_stacktrace(None);
@@ -314,7 +314,7 @@ impl<'a, 'mir, 'tcx> ConstPropagator<'a, 'mir, 'tcx> {
                     eval_promoted(this.tcx, cid, this.mir, this.param_env)
                 })?;
                 trace!("evaluated promoted {:?} to {:?}", promoted, res);
-                Some((res, source_info.span))
+                Some((res.into(), source_info.span))
             },
             _ => None,
         }

--- a/src/test/ui/consts/const-err4.rs
+++ b/src/test/ui/consts/const-err4.rs
@@ -16,7 +16,7 @@ union Foo {
 
 enum Bar {
     Boo = [unsafe { Foo { b: () }.a }; 4][3],
-    //~^ ERROR could not evaluate enum discriminant
+    //~^ ERROR constant evaluation of enum discriminant resulted in non-integer
 }
 
 fn main() {

--- a/src/test/ui/consts/const-err4.stderr
+++ b/src/test/ui/consts/const-err4.stderr
@@ -1,8 +1,8 @@
-error[E0080]: could not evaluate enum discriminant
+error[E0080]: constant evaluation of enum discriminant resulted in non-integer
   --> $DIR/const-err4.rs:18:11
    |
 LL |     Boo = [unsafe { Foo { b: () }.a }; 4][3],
-   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempted to read undefined bytes
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-eval/const-pointer-values-in-various-types.rs
+++ b/src/test/ui/consts/const-eval/const-pointer-values-in-various-types.rs
@@ -37,7 +37,7 @@ fn main() {
     //~^ ERROR this constant likely exhibits undefined behavior
 
     const I32_REF_U128_UNION: u128 = unsafe { Nonsense { int_32_ref: &3 }.uint_128 };
-    //~^ ERROR this constant cannot be used
+    //~^ ERROR this constant likely exhibits undefined behavior
 
     const I32_REF_I8_UNION: i8 = unsafe { Nonsense { int_32_ref: &3 }.int_8 };
     //~^ ERROR this constant cannot be used
@@ -52,7 +52,7 @@ fn main() {
     //~^ ERROR this constant likely exhibits undefined behavior
 
     const I32_REF_I128_UNION: i128 = unsafe { Nonsense { int_32_ref: &3 }.int_128 };
-    //~^ ERROR this constant cannot be used
+    //~^ ERROR this constant likely exhibits undefined behavior
 
     const I32_REF_F32_UNION: f32 = unsafe { Nonsense { int_32_ref: &3 }.float_32 };
     //~^ ERROR this constant cannot be used

--- a/src/test/ui/consts/const-eval/const-pointer-values-in-various-types.stderr
+++ b/src/test/ui/consts/const-eval/const-pointer-values-in-various-types.stderr
@@ -40,11 +40,13 @@ LL |     const I32_REF_U64_UNION: u64 = unsafe { Nonsense { int_32_ref: &3 }.uin
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 
-error: this constant cannot be used
+error[E0080]: this constant likely exhibits undefined behavior
   --> $DIR/const-pointer-values-in-various-types.rs:39:5
    |
 LL |     const I32_REF_U128_UNION: u128 = unsafe { Nonsense { int_32_ref: &3 }.uint_128 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempted to read undefined bytes
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected initialized plain bits
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 
 error: this constant cannot be used
   --> $DIR/const-pointer-values-in-various-types.rs:42:5
@@ -78,11 +80,13 @@ LL |     const I32_REF_I64_UNION: i64 = unsafe { Nonsense { int_32_ref: &3 }.int
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 
-error: this constant cannot be used
+error[E0080]: this constant likely exhibits undefined behavior
   --> $DIR/const-pointer-values-in-various-types.rs:54:5
    |
 LL |     const I32_REF_I128_UNION: i128 = unsafe { Nonsense { int_32_ref: &3 }.int_128 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempted to read undefined bytes
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected initialized plain bits
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 
 error: this constant cannot be used
   --> $DIR/const-pointer-values-in-various-types.rs:57:5

--- a/src/test/ui/consts/const-eval/union-const-eval-field.rs
+++ b/src/test/ui/consts/const-eval/union-const-eval-field.rs
@@ -34,7 +34,7 @@ const fn read_field2() -> Field2 {
 }
 
 const fn read_field3() -> Field3 {
-    const FIELD3: Field3 = unsafe { UNION.field3 }; //~ ERROR cannot be used
+    const FIELD3: Field3 = unsafe { UNION.field3 }; //~ ERROR likely exhibits undefined behavior
     FIELD3
 }
 

--- a/src/test/ui/consts/const-eval/union-const-eval-field.stderr
+++ b/src/test/ui/consts/const-eval/union-const-eval-field.stderr
@@ -1,10 +1,11 @@
-error: this constant cannot be used
+error[E0080]: this constant likely exhibits undefined behavior
   --> $DIR/union-const-eval-field.rs:37:5
    |
-LL |     const FIELD3: Field3 = unsafe { UNION.field3 }; //~ ERROR cannot be used
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempted to read undefined bytes
+LL |     const FIELD3: Field3 = unsafe { UNION.field3 }; //~ ERROR likely exhibits undefined behavior
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected initialized plain bits
    |
-   = note: #[deny(const_err)] on by default
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-eval/union-ice.rs
+++ b/src/test/ui/consts/const-eval/union-ice.rs
@@ -20,7 +20,7 @@ union DummyUnion {
 
 const UNION: DummyUnion = DummyUnion { field1: 1065353216 };
 
-const FIELD3: Field3 = unsafe { UNION.field3 }; //~ ERROR this constant cannot be used
+const FIELD3: Field3 = unsafe { UNION.field3 }; //~ ERROR likely exhibits undefined behavior
 
 const FIELD_PATH: Struct = Struct { //~ ERROR this constant likely exhibits undefined behavior
     a: 42,

--- a/src/test/ui/consts/const-eval/union-ice.stderr
+++ b/src/test/ui/consts/const-eval/union-ice.stderr
@@ -1,10 +1,10 @@
-error: this constant cannot be used
+error[E0080]: this constant likely exhibits undefined behavior
   --> $DIR/union-ice.rs:23:1
    |
-LL | const FIELD3: Field3 = unsafe { UNION.field3 }; //~ ERROR this constant cannot be used
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempted to read undefined bytes
+LL | const FIELD3: Field3 = unsafe { UNION.field3 }; //~ ERROR likely exhibits undefined behavior
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected initialized plain bits
    |
-   = note: #[deny(const_err)] on by default
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 
 error[E0080]: this constant likely exhibits undefined behavior
   --> $DIR/union-ice.rs:25:1


### PR DESCRIPTION
... by always using `ByRef` and reading the scalars from the backing `Allocation` where desired

Oh god this uncovered so many bugs and bugs-just-waiting-to-happen. I'm still not fully done, but I don't want to grow this PR any further. It is in a sane state except for the `const_field` function, which was hacky to begin with.

fixes #54738

r? @RalfJung 