### PR TITLE
Compile the libstd we distribute with -Ccodegen-unit=1

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -277,6 +277,10 @@
 # compiler.
 #codegen-units = 1
 
+# Sets the number of codegen units to build the standard library with,
+# regardless of what the codegen-unit setting for the rest of the compiler is.
+#codegen-units-std = 1
+
 # Whether or not debug assertions are enabled for the compiler and standard
 # library. Also enables compilation of debug! and trace! logging macros.
 #debug-assertions = false

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1119,10 +1119,15 @@ impl<'a> Builder<'a> {
             cargo.arg("-v");
         }
 
-        // This must be kept before the thinlto check, as we set codegen units
-        // to 1 forcibly there.
-        if let Some(n) = self.config.rust_codegen_units {
-            cargo.env("RUSTC_CODEGEN_UNITS", n.to_string());
+        match (mode, self.config.rust_codegen_units_std, self.config.rust_codegen_units) {
+            (Mode::Std, Some(n), _) |
+            (Mode::Test, Some(n), _) |
+            (_, _, Some(n)) => {
+                cargo.env("RUSTC_CODEGEN_UNITS", n.to_string());
+            }
+            _ => {
+                // Don't set anything
+            }
         }
 
         if self.config.rust_optimize {

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -95,6 +95,7 @@ pub struct Config {
     // rust codegen options
     pub rust_optimize: bool,
     pub rust_codegen_units: Option<u32>,
+    pub rust_codegen_units_std: Option<u32>,
     pub rust_debug_assertions: bool,
     pub rust_debuginfo: bool,
     pub rust_debuginfo_lines: bool,
@@ -294,6 +295,7 @@ impl Default for StringOrBool {
 struct Rust {
     optimize: Option<bool>,
     codegen_units: Option<u32>,
+    codegen_units_std: Option<u32>,
     debug_assertions: Option<bool>,
     debuginfo: Option<bool>,
     debuginfo_lines: Option<bool>,
@@ -580,6 +582,8 @@ impl Config {
                 Some(n) => config.rust_codegen_units = Some(n),
                 None => {}
             }
+
+            config.rust_codegen_units_std = rust.codegen_units_std;
         }
 
         if let Some(ref t) = toml.target {

--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -393,6 +393,13 @@ for target in configured_targets:
     targets[target][0] = targets[target][0].replace("x86_64-unknown-linux-gnu", target)
 
 
+def is_number(value):
+  try:
+    float(value)
+    return True
+  except:
+    return False
+
 # Here we walk through the constructed configuration we have from the parsed
 # command line arguments. We then apply each piece of configuration by
 # basically just doing a `sed` to change the various configuration line to what
@@ -406,7 +413,11 @@ def to_toml(value):
     elif isinstance(value, list):
         return '[' + ', '.join(map(to_toml, value)) + ']'
     elif isinstance(value, str):
-        return "'" + value + "'"
+        # Don't put quotes around numeric values
+        if is_number(value):
+            return value
+        else:
+            return "'" + value + "'"
     else:
         raise RuntimeError('no toml')
 

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -40,6 +40,7 @@ RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-sccache"
 RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --disable-manage-submodules"
 RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-locked-deps"
 RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-cargo-native-static"
+RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set rust.codegen-units-std=1"
 
 if [ "$DIST_SRC" = "" ]; then
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --disable-dist-src"


### PR DESCRIPTION
This PR
 - adds the `single-codegen-unit-std` option to `config.toml` which allows for setting the CGU count for `libstd` and `libtest` independently of the one for the rest of the compiler, and
 - sets the new option to `true` for all dist jobs in CI.

Fixes #54872.

r? @Mark-Simulacrum 
cc @rust-lang/release 