### PR TITLE
experiment: Support aliasing local crate root in extern prelude

### DIFF
--- a/src/librustc_typeck/check_unused.rs
+++ b/src/librustc_typeck/check_unused.rs
@@ -113,11 +113,12 @@ fn unused_crates_lint<'tcx>(tcx: TyCtxt<'_, 'tcx, 'tcx>) {
             true
         })
         .filter(|&&(def_id, _)| {
-            let cnum = tcx.extern_mod_stmt_cnum(def_id).unwrap();
-            !tcx.is_compiler_builtins(cnum)
-                && !tcx.is_panic_runtime(cnum)
-                && !tcx.has_global_allocator(cnum)
-                && !tcx.has_panic_handler(cnum)
+            tcx.extern_mod_stmt_cnum(def_id).map_or(true, |cnum| {
+                !tcx.is_compiler_builtins(cnum) &&
+                !tcx.is_panic_runtime(cnum) &&
+                !tcx.has_global_allocator(cnum) &&
+                !tcx.has_panic_handler(cnum)
+            })
         })
         .cloned()
         .collect();

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -492,6 +492,9 @@ declare_features! (
 
     // `reason = ` in lint attributes and `expect` lint attribute
     (active, lint_reasons, "1.31.0", Some(54503), None),
+
+    // `extern crate self as foo;` puts local crate root into extern prelude under name `foo`.
+    (active, extern_crate_self, "1.31.0", Some(54658), None),
 );
 
 declare_features! (

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -6783,7 +6783,11 @@ impl<'a> Parser<'a> {
         let error_msg = "crate name using dashes are not valid in `extern crate` statements";
         let suggestion_msg = "if the original crate name uses dashes you need to use underscores \
                               in the code";
-        let mut ident = self.parse_ident()?;
+        let mut ident = if self.token.is_keyword(keywords::SelfValue) {
+            self.parse_path_segment_ident()
+        } else {
+            self.parse_ident()
+        }?;
         let mut idents = vec![];
         let mut replacement = vec![];
         let mut fixed_crate_name = false;

--- a/src/test/ui/feature-gates/feature-gate-extern_crate_self.rs
+++ b/src/test/ui/feature-gates/feature-gate-extern_crate_self.rs
@@ -1,0 +1,3 @@
+extern crate self as foo; //~ ERROR `extern crate self` is unstable
+
+fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-extern_crate_self.stderr
+++ b/src/test/ui/feature-gates/feature-gate-extern_crate_self.stderr
@@ -1,0 +1,11 @@
+error[E0658]: `extern crate self` is unstable (see issue #54658)
+  --> $DIR/feature-gate-extern_crate_self.rs:1:1
+   |
+LL | extern crate self as foo; //~ ERROR `extern crate self` is unstable
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(extern_crate_self)] to the crate attributes to enable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/imports/extern-crate-self-fail.rs
+++ b/src/test/ui/imports/extern-crate-self-fail.rs
@@ -1,0 +1,8 @@
+#![feature(extern_crate_self)]
+
+extern crate self; //~ ERROR `extern crate self;` requires renaming
+
+#[macro_use] //~ ERROR `macro_use` is not supported on `extern crate self`
+extern crate self as foo;
+
+fn main() {}

--- a/src/test/ui/imports/extern-crate-self-fail.stderr
+++ b/src/test/ui/imports/extern-crate-self-fail.stderr
@@ -1,0 +1,14 @@
+error: `extern crate self;` requires renaming
+  --> $DIR/extern-crate-self-fail.rs:3:1
+   |
+LL | extern crate self; //~ ERROR `extern crate self;` requires renaming
+   | ^^^^^^^^^^^^^^^^^^ help: try: `extern crate self as name;`
+
+error: `macro_use` is not supported on `extern crate self`
+  --> $DIR/extern-crate-self-fail.rs:5:1
+   |
+LL | #[macro_use] //~ ERROR `macro_use` is not supported on `extern crate self`
+   | ^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/imports/extern-crate-self-pass.rs
+++ b/src/test/ui/imports/extern-crate-self-pass.rs
@@ -1,0 +1,15 @@
+// compile-pass
+
+#![feature(extern_crate_self)]
+
+extern crate self as foo;
+
+struct S;
+
+mod m {
+    fn check() {
+        foo::S; // OK
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
This PR provides some minimally invasive solution for the 2018 edition migration issue described in https://github.com/rust-lang/rust/issues/54647 and affecting proc macro crates.

`extern crate NAME as RENAME;` now accepts `NAME`=`self` and interprets it as referring to the local crate.
As with other `extern crate` items, `RENAME` in this case gets into extern prelude in accordance with https://github.com/rust-lang/rust/pull/54658, thus resolving https://github.com/rust-lang/rust/issues/54647.
```rust
extern crate self as serde; // Adds local crate to extern prelude as `serde`
```
This solution doesn't introduce any new syntax and has minimal maintenance cost, so it can be easily deprecated if something better is found in the future.

Closes https://github.com/rust-lang/rust/issues/54647