### PR TITLE
Add libproc_macro to rust-src distribution

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -853,6 +853,7 @@ impl Step for Src {
             "src/jemalloc",
             "src/libprofiler_builtins",
             "src/stdsimd",
+            "src/libproc_macro",
         ];
         let std_src_dirs_exclude = [
             "src/libcompiler_builtins/compiler-rt/test",


### PR DESCRIPTION
Fixes #55279