### PR TITLE
Macro diagnostics tweaks

### DIFF
--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -1044,7 +1044,9 @@ impl<'a> Parser<'a> {
             );
             err.note(&msg);
             let semi_span = self.sess.source_map().next_point(span);
-            match self.sess.source_map().span_to_snippet(semi_span) {
+
+            let semi_full_span = semi_span.to(self.sess.source_map().next_point(semi_span));
+            match self.sess.source_map().span_to_snippet(semi_full_span) {
                 Ok(ref snippet) if &snippet[..] != ";" && kind_name == "expression" => {
                     err.span_suggestion_with_applicability(
                         semi_span,

--- a/src/libsyntax_pos/lib.rs
+++ b/src/libsyntax_pos/lib.rs
@@ -612,6 +612,17 @@ impl MultiSpan {
         &self.primary_spans
     }
 
+    /// Returns `true` if this contains only a dummy primary span with any hygienic context.
+    pub fn is_dummy(&self) -> bool {
+        let mut is_dummy = true;
+        for span in &self.primary_spans {
+            if !span.is_dummy() {
+                is_dummy = false;
+            }
+        }
+        is_dummy
+    }
+
     /// Replaces all occurrences of one Span with another. Used to move Spans in areas that don't
     /// display well (like std macros). Returns true if replacements occurred.
     pub fn replace(&mut self, before: Span, after: Span) -> bool {

--- a/src/test/ui/issues/issue-30007.stderr
+++ b/src/test/ui/issues/issue-30007.stderr
@@ -3,12 +3,11 @@ error: macro expansion ignores token `;` and any following
    |
 LL |     () => ( String ; );     //~ ERROR macro expansion ignores token `;`
    |                    ^
-   |
-note: caused by the macro expansion here; the usage of `t!` is likely invalid in type context
-  --> $DIR/issue-30007.rs:16:16
-   |
+...
 LL |     let i: Vec<t!()>;
-   |                ^^^^
+   |                ---- caused by the macro expansion here
+   |
+   = note: the usage of `t!` is likely invalid in type context
 
 error: aborting due to previous error
 

--- a/src/test/ui/macros/macro-context.stderr
+++ b/src/test/ui/macros/macro-context.stderr
@@ -3,36 +3,35 @@ error: macro expansion ignores token `;` and any following
    |
 LL |     () => ( i ; typeof );   //~ ERROR expected expression, found reserved keyword `typeof`
    |               ^
-   |
-note: caused by the macro expansion here; the usage of `m!` is likely invalid in type context
-  --> $DIR/macro-context.rs:20:12
-   |
+...
 LL |     let a: m!();
-   |            ^^^^
+   |            ---- caused by the macro expansion here
+   |
+   = note: the usage of `m!` is likely invalid in type context
 
 error: macro expansion ignores token `typeof` and any following
   --> $DIR/macro-context.rs:13:17
    |
 LL |     () => ( i ; typeof );   //~ ERROR expected expression, found reserved keyword `typeof`
    |                 ^^^^^^
-   |
-note: caused by the macro expansion here; the usage of `m!` is likely invalid in expression context
-  --> $DIR/macro-context.rs:21:13
-   |
+...
 LL |     let i = m!();
-   |             ^^^^
+   |             ----- help: you might be missing a semicolon here: `;`
+   |             |
+   |             caused by the macro expansion here
+   |
+   = note: the usage of `m!` is likely invalid in expression context
 
 error: macro expansion ignores token `;` and any following
   --> $DIR/macro-context.rs:13:15
    |
 LL |     () => ( i ; typeof );   //~ ERROR expected expression, found reserved keyword `typeof`
    |               ^
-   |
-note: caused by the macro expansion here; the usage of `m!` is likely invalid in pattern context
-  --> $DIR/macro-context.rs:23:9
-   |
+...
 LL |         m!() => {}
-   |         ^^^^
+   |         ---- caused by the macro expansion here
+   |
+   = note: the usage of `m!` is likely invalid in pattern context
 
 error: expected expression, found reserved keyword `typeof`
   --> $DIR/macro-context.rs:13:17

--- a/src/test/ui/macros/macro-context.stderr
+++ b/src/test/ui/macros/macro-context.stderr
@@ -16,9 +16,7 @@ LL |     () => ( i ; typeof );   //~ ERROR expected expression, found reserved k
    |                 ^^^^^^
 ...
 LL |     let i = m!();
-   |             ----- help: you might be missing a semicolon here: `;`
-   |             |
-   |             caused by the macro expansion here
+   |             ---- caused by the macro expansion here
    |
    = note: the usage of `m!` is likely invalid in expression context
 

--- a/src/test/ui/macros/macro-in-expression-context-2.rs
+++ b/src/test/ui/macros/macro-in-expression-context-2.rs
@@ -1,0 +1,7 @@
+macro_rules! empty { () => () }
+
+fn main() {
+    match 42 {
+        _ => { empty!() }
+    };
+}

--- a/src/test/ui/macros/macro-in-expression-context-2.stderr
+++ b/src/test/ui/macros/macro-in-expression-context-2.stderr
@@ -1,0 +1,8 @@
+error: expected expression, found `<eof>`
+  --> $DIR/macro-in-expression-context-2.rs:5:16
+   |
+LL |         _ => { empty!() }
+   |                ^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/macros/macro-in-expression-context.fixed
+++ b/src/test/ui/macros/macro-in-expression-context.fixed
@@ -1,0 +1,15 @@
+// run-rustfix
+
+macro_rules! foo {
+    () => {
+        assert_eq!("A", "A");
+        assert_eq!("B", "B");
+    }
+    //~^^ ERROR macro expansion ignores token `assert_eq` and any following
+    //~| NOTE the usage of `foo!` is likely invalid in expression context
+}
+
+fn main() {
+    foo!();
+    //~^ NOTE caused by the macro expansion here
+}

--- a/src/test/ui/macros/macro-in-expression-context.rs
+++ b/src/test/ui/macros/macro-in-expression-context.rs
@@ -1,0 +1,15 @@
+// run-rustfix
+
+macro_rules! foo {
+    () => {
+        assert_eq!("A", "A");
+        assert_eq!("B", "B");
+    }
+    //~^^ ERROR macro expansion ignores token `assert_eq` and any following
+    //~| NOTE the usage of `foo!` is likely invalid in expression context
+}
+
+fn main() {
+    foo!()
+    //~^ NOTE caused by the macro expansion here
+}

--- a/src/test/ui/macros/macro-in-expression-context.stderr
+++ b/src/test/ui/macros/macro-in-expression-context.stderr
@@ -1,0 +1,15 @@
+error: macro expansion ignores token `assert_eq` and any following
+  --> $DIR/macro-in-expression-context.rs:6:9
+   |
+LL |         assert_eq!("B", "B");
+   |         ^^^^^^^^^
+...
+LL |     foo!()
+   |     ------- help: you might be missing a semicolon here: `;`
+   |     |
+   |     caused by the macro expansion here
+   |
+   = note: the usage of `foo!` is likely invalid in expression context
+
+error: aborting due to previous error
+

--- a/src/test/ui/parser/macro/macro-incomplete-parse.stderr
+++ b/src/test/ui/parser/macro/macro-incomplete-parse.stderr
@@ -3,12 +3,11 @@ error: macro expansion ignores token `,` and any following
    |
 LL |         , //~ ERROR macro expansion ignores token `,`
    |         ^
-   |
-note: caused by the macro expansion here; the usage of `ignored_item!` is likely invalid in item context
-  --> $DIR/macro-incomplete-parse.rs:31:1
-   |
+...
 LL | ignored_item!();
-   | ^^^^^^^^^^^^^^^^
+   | ---------------- caused by the macro expansion here
+   |
+   = note: the usage of `ignored_item!` is likely invalid in item context
 
 error: expected one of `.`, `;`, `?`, `}`, or an operator, found `,`
   --> $DIR/macro-incomplete-parse.rs:22:14
@@ -24,12 +23,11 @@ error: macro expansion ignores token `,` and any following
    |
 LL |     () => ( 1, 2 ) //~ ERROR macro expansion ignores token `,`
    |              ^
-   |
-note: caused by the macro expansion here; the usage of `ignored_pat!` is likely invalid in pattern context
-  --> $DIR/macro-incomplete-parse.rs:36:9
-   |
+...
 LL |         ignored_pat!() => (),
-   |         ^^^^^^^^^^^^^^
+   |         -------------- caused by the macro expansion here
+   |
+   = note: the usage of `ignored_pat!` is likely invalid in pattern context
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
Fix #30128, fix #10951 by adding an appropriate span to the diagnostic.
Fix #26288 by suggesting adding semicolon to macro call.