### PR TITLE
Set RUST_BACKTRACE=0 for rustdoc-ui/failed-doctest-output.rs

### DIFF
--- a/src/test/rustdoc-ui/failed-doctest-output.rs
+++ b/src/test/rustdoc-ui/failed-doctest-output.rs
@@ -15,6 +15,7 @@
 // compile-flags:--test
 // normalize-stdout-test: "src/test/rustdoc-ui" -> "$$DIR"
 // failure-status: 101
+// rustc-env:RUST_BACKTRACE=0
 
 // doctest fails at runtime
 /// ```

--- a/src/test/rustdoc-ui/failed-doctest-output.stdout
+++ b/src/test/rustdoc-ui/failed-doctest-output.stdout
@@ -1,22 +1,22 @@
 
 running 2 tests
-test $DIR/failed-doctest-output.rs - OtherStruct (line 26) ... FAILED
-test $DIR/failed-doctest-output.rs - SomeStruct (line 20) ... FAILED
+test $DIR/failed-doctest-output.rs - OtherStruct (line 27) ... FAILED
+test $DIR/failed-doctest-output.rs - SomeStruct (line 21) ... FAILED
 
 failures:
 
----- $DIR/failed-doctest-output.rs - OtherStruct (line 26) stdout ----
+---- $DIR/failed-doctest-output.rs - OtherStruct (line 27) stdout ----
 error[E0425]: cannot find value `no` in this scope
- --> $DIR/failed-doctest-output.rs:27:1
+ --> $DIR/failed-doctest-output.rs:28:1
   |
 3 | no
   | ^^ not found in this scope
 
-thread '$DIR/failed-doctest-output.rs - OtherStruct (line 26)' panicked at 'couldn't compile the test', librustdoc/test.rs:332:13
+thread '$DIR/failed-doctest-output.rs - OtherStruct (line 27)' panicked at 'couldn't compile the test', librustdoc/test.rs:332:13
 note: Run with `RUST_BACKTRACE=1` for a backtrace.
 
----- $DIR/failed-doctest-output.rs - SomeStruct (line 20) stdout ----
-thread '$DIR/failed-doctest-output.rs - SomeStruct (line 20)' panicked at 'test executable failed:
+---- $DIR/failed-doctest-output.rs - SomeStruct (line 21) stdout ----
+thread '$DIR/failed-doctest-output.rs - SomeStruct (line 21)' panicked at 'test executable failed:
 
 thread 'main' panicked at 'oh no', $DIR/failed-doctest-output.rs:3:1
 note: Run with `RUST_BACKTRACE=1` for a backtrace.
@@ -25,8 +25,8 @@ note: Run with `RUST_BACKTRACE=1` for a backtrace.
 
 
 failures:
-    $DIR/failed-doctest-output.rs - OtherStruct (line 26)
-    $DIR/failed-doctest-output.rs - SomeStruct (line 20)
+    $DIR/failed-doctest-output.rs - OtherStruct (line 27)
+    $DIR/failed-doctest-output.rs - SomeStruct (line 21)
 
 test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out
 


### PR DESCRIPTION
This UI test is sensitive to backtrace output, so it should make sure
that backtraces are not enabled by the environment.