### PR TITLE
Partial implementation of uniform paths 2.0 to land before beta

### DIFF
--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -3133,7 +3133,8 @@ impl<'a> LoweringContext<'a> {
                 // Privatize the degenerate import base, used only to check
                 // the stability of `use a::{};`, to avoid it showing up as
                 // a re-export by accident when `pub`, e.g. in documentation.
-                let path = P(self.lower_path(id, &prefix, ParamMode::Explicit));
+                let def = self.expect_full_def_from_use(id).next().unwrap_or(Def::Err);
+                let path = P(self.lower_path_extra(def, &prefix, None, ParamMode::Explicit, None));
                 *vis = respan(prefix.span.shrink_to_lo(), hir::VisibilityKind::Inherited);
                 hir::ItemKind::Use(path, hir::UseKind::ListStem)
             }

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -1207,7 +1207,7 @@ enum NameBindingKind<'a> {
     }
 }
 
-struct PrivacyError<'a>(Span, Name, &'a NameBinding<'a>);
+struct PrivacyError<'a>(Span, Ident, &'a NameBinding<'a>);
 
 struct UseError<'a> {
     err: DiagnosticBuilder<'a>,
@@ -4743,9 +4743,11 @@ impl<'a, 'crateloader: 'a> Resolver<'a, 'crateloader> {
             }
         }
 
-        for &PrivacyError(span, name, binding) in &self.privacy_errors {
-            if !reported_spans.insert(span) { continue }
-            span_err!(self.session, span, E0603, "{} `{}` is private", binding.descr(), name);
+        for &PrivacyError(dedup_span, ident, binding) in &self.privacy_errors {
+            if reported_spans.insert(dedup_span) {
+                span_err!(self.session, ident.span, E0603, "{} `{}` is private",
+                          binding.descr(), ident.name);
+            }
         }
     }
 

--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -43,7 +43,7 @@ use std::cell::Cell;
 use std::mem;
 use rustc_data_structures::sync::Lrc;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct InvocationData<'a> {
     def_index: DefIndex,
     /// Module in which the macro was invoked.
@@ -70,6 +70,7 @@ impl<'a> InvocationData<'a> {
 
 /// Binding produced by a `macro_rules` item.
 /// Not modularized, can shadow previous legacy bindings, etc.
+#[derive(Debug)]
 pub struct LegacyBinding<'a> {
     binding: &'a NameBinding<'a>,
     /// Legacy scope into which the `macro_rules` item was planted.
@@ -82,7 +83,7 @@ pub struct LegacyBinding<'a> {
 /// (named or unnamed), or even further if it escapes with `#[macro_use]`.
 /// Some macro invocations need to introduce legacy scopes too because they
 /// potentially can expand into macro definitions.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum LegacyScope<'a> {
     /// Created when invocation data is allocated in the arena,
     /// must be replaced with a proper scope later.
@@ -96,8 +97,8 @@ pub enum LegacyScope<'a> {
     Invocation(&'a InvocationData<'a>),
 }
 
-/// Everything you need to resolve a macro path.
-#[derive(Clone)]
+/// Everything you need to resolve a macro or import path.
+#[derive(Clone, Debug)]
 pub struct ParentScope<'a> {
     crate module: Module<'a>,
     crate expansion: Mark,

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -16,6 +16,7 @@ use {NameBinding, NameBindingKind, ToNameBinding, PathResult, PrivacyError};
 use {Resolver, Segment};
 use {names_to_string, module_to_string};
 use {resolve_error, ResolutionError};
+use macros::ParentScope;
 
 use rustc_data_structures::ptr_key::PtrKey;
 use rustc::ty;
@@ -88,13 +89,12 @@ pub struct ImportDirective<'a> {
     /// Span of the *root* use tree (see `root_id`).
     pub root_span: Span,
 
-    pub parent: Module<'a>,
+    pub parent_scope: ParentScope<'a>,
     pub module_path: Vec<Segment>,
     /// The resolution of `module_path`.
     pub imported_module: Cell<Option<ModuleOrUniformRoot<'a>>>,
     pub subclass: ImportDirectiveSubclass<'a>,
     pub vis: Cell<ty::Visibility>,
-    pub expansion: Mark,
     pub used: Cell<bool>,
 
     /// Whether this import is a "canary" for the `uniform_paths` feature,
@@ -307,8 +307,9 @@ impl<'a, 'crateloader> Resolver<'a, 'crateloader> {
             };
             match self.resolve_ident_in_module(module, ident, ns, false, path_span) {
                 Err(Determined) => continue,
-                Ok(binding)
-                    if !self.is_accessible_from(binding.vis, single_import.parent) => continue,
+                Ok(binding) if !self.is_accessible_from(
+                    binding.vis, single_import.parent_scope.module
+                ) => continue,
                 Ok(_) | Err(Undetermined) => return Err(Undetermined),
             }
         }
@@ -381,8 +382,9 @@ impl<'a, 'crateloader> Resolver<'a, 'crateloader> {
 
             match result {
                 Err(Determined) => continue,
-                Ok(binding)
-                    if !self.is_accessible_from(binding.vis, glob_import.parent) => continue,
+                Ok(binding) if !self.is_accessible_from(
+                    binding.vis, glob_import.parent_scope.module
+                ) => continue,
                 Ok(_) | Err(Undetermined) => return Err(Undetermined),
             }
         }
@@ -400,11 +402,11 @@ impl<'a, 'crateloader> Resolver<'a, 'crateloader> {
                                 root_span: Span,
                                 root_id: NodeId,
                                 vis: ty::Visibility,
-                                expansion: Mark,
+                                parent_scope: ParentScope<'a>,
                                 is_uniform_paths_canary: bool) {
-        let current_module = self.current_module;
+        let current_module = parent_scope.module;
         let directive = self.arenas.alloc_import_directive(ImportDirective {
-            parent: current_module,
+            parent_scope,
             module_path,
             imported_module: Cell::new(None),
             subclass,
@@ -413,7 +415,6 @@ impl<'a, 'crateloader> Resolver<'a, 'crateloader> {
             root_span,
             root_id,
             vis: Cell::new(vis),
-            expansion,
             used: Cell::new(false),
             is_uniform_paths_canary,
         });
@@ -431,7 +432,7 @@ impl<'a, 'crateloader> Resolver<'a, 'crateloader> {
             // We don't add prelude imports to the globs since they only affect lexical scopes,
             // which are not relevant to import resolution.
             GlobImport { is_prelude: true, .. } => {}
-            GlobImport { .. } => self.current_module.globs.borrow_mut().push(directive),
+            GlobImport { .. } => current_module.globs.borrow_mut().push(directive),
             _ => unreachable!(),
         }
     }
@@ -462,7 +463,7 @@ impl<'a, 'crateloader> Resolver<'a, 'crateloader> {
             },
             span: directive.span,
             vis,
-            expansion: directive.expansion,
+            expansion: directive.parent_scope.expansion,
         })
     }
 
@@ -568,12 +569,12 @@ impl<'a, 'crateloader> Resolver<'a, 'crateloader> {
             let scope = match ident.span.reverse_glob_adjust(module.expansion,
                                                              directive.span.ctxt().modern()) {
                 Some(Some(def)) => self.macro_def_scope(def),
-                Some(None) => directive.parent,
+                Some(None) => directive.parent_scope.module,
                 None => continue,
             };
             if self.is_accessible_from(binding.vis, scope) {
                 let imported_binding = self.import(binding, directive);
-                let _ = self.try_define(directive.parent, ident, ns, imported_binding);
+                let _ = self.try_define(directive.parent_scope.module, ident, ns, imported_binding);
             }
         }
 
@@ -587,7 +588,7 @@ impl<'a, 'crateloader> Resolver<'a, 'crateloader> {
             let dummy_binding = self.dummy_binding;
             let dummy_binding = self.import(dummy_binding, directive);
             self.per_ns(|this, ns| {
-                let _ = this.try_define(directive.parent, target, ns, dummy_binding);
+                let _ = this.try_define(directive.parent_scope.module, target, ns, dummy_binding);
             });
         }
     }
@@ -856,8 +857,7 @@ impl<'a, 'b:'a, 'c: 'b> ImportResolver<'a, 'b, 'c> {
                Segment::names_to_string(&directive.module_path[..]),
                module_to_string(self.current_module).unwrap_or_else(|| "???".to_string()));
 
-
-        self.current_module = directive.parent;
+        self.current_module = directive.parent_scope.module;
 
         let module = if let Some(module) = directive.imported_module.get() {
             module
@@ -868,7 +868,7 @@ impl<'a, 'b:'a, 'c: 'b> ImportResolver<'a, 'b, 'c> {
             directive.vis.set(ty::Visibility::Invisible);
             let result = self.resolve_path(
                 Some(if directive.is_uniform_paths_canary {
-                    ModuleOrUniformRoot::Module(directive.parent)
+                    ModuleOrUniformRoot::Module(directive.parent_scope.module)
                 } else {
                     ModuleOrUniformRoot::UniformRoot(keywords::Invalid.name())
                 }),
@@ -910,7 +910,7 @@ impl<'a, 'b:'a, 'c: 'b> ImportResolver<'a, 'b, 'c> {
                 return
             };
 
-            let parent = directive.parent;
+            let parent = directive.parent_scope.module;
             match result[ns].get() {
                 Err(Undetermined) => indeterminate = true,
                 Err(Determined) => {
@@ -942,12 +942,12 @@ impl<'a, 'b:'a, 'c: 'b> ImportResolver<'a, 'b, 'c> {
 
     // If appropriate, returns an error to report.
     fn finalize_import(&mut self, directive: &'b ImportDirective<'b>) -> Option<(Span, String)> {
-        self.current_module = directive.parent;
+        self.current_module = directive.parent_scope.module;
         let ImportDirective { ref module_path, span, .. } = *directive;
 
         let module_result = self.resolve_path(
             Some(if directive.is_uniform_paths_canary {
-                ModuleOrUniformRoot::Module(directive.parent)
+                ModuleOrUniformRoot::Module(directive.parent_scope.module)
             } else {
                 ModuleOrUniformRoot::UniformRoot(keywords::Invalid.name())
             }),
@@ -995,7 +995,7 @@ impl<'a, 'b:'a, 'c: 'b> ImportResolver<'a, 'b, 'c> {
                 }
 
                 if let ModuleOrUniformRoot::Module(module) = module {
-                    if module.def_id() == directive.parent.def_id() {
+                    if module.def_id() == directive.parent_scope.module.def_id() {
                         // Importing a module into itself is not allowed.
                         return Some((directive.span,
                             "Cannot glob-import a module into itself.".to_string()));
@@ -1189,7 +1189,7 @@ impl<'a, 'b:'a, 'c: 'b> ImportResolver<'a, 'b, 'c> {
         if let Some(Def::Trait(_)) = module.def() {
             self.session.span_err(directive.span, "items in traits are not importable.");
             return;
-        } else if module.def_id() == directive.parent.def_id()  {
+        } else if module.def_id() == directive.parent_scope.module.def_id()  {
             return;
         } else if let GlobImport { is_prelude: true, .. } = directive.subclass {
             self.prelude = Some(module);
@@ -1213,7 +1213,7 @@ impl<'a, 'b:'a, 'c: 'b> ImportResolver<'a, 'b, 'c> {
             };
             if self.is_accessible_from(binding.pseudo_vis(), scope) {
                 let imported_binding = self.import(binding, directive);
-                let _ = self.try_define(directive.parent, ident, ns, imported_binding);
+                let _ = self.try_define(directive.parent_scope.module, ident, ns, imported_binding);
             }
         }
 

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -275,7 +275,7 @@ impl<'a, 'crateloader> Resolver<'a, 'crateloader> {
                     return Ok(self.dummy_binding);
                 }
                 if !self.is_accessible(binding.vis) {
-                    self.privacy_errors.push(PrivacyError(path_span, ident.name, binding));
+                    self.privacy_errors.push(PrivacyError(path_span, ident, binding));
                 }
             }
 

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -226,6 +226,9 @@ impl<'a, 'crateloader> Resolver<'a, 'crateloader> {
                         let module = self.get_module(binding.def().def_id());
                         self.populate_module_if_necessary(module);
                         return Ok(binding);
+                    } else if !self.graph_root.unresolved_invocations.borrow().is_empty() {
+                        // Macro-expanded `extern crate`items still can add names to extern prelude.
+                        return Err(Undetermined);
                     } else {
                         return Err(Determined);
                     }

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -877,6 +877,7 @@ impl<'a, 'b:'a, 'c: 'b> ImportResolver<'a, 'b, 'c> {
                 }),
                 &directive.module_path[..],
                 None,
+                &directive.parent_scope,
                 false,
                 directive.span,
                 directive.crate_lint(),
@@ -956,6 +957,7 @@ impl<'a, 'b:'a, 'c: 'b> ImportResolver<'a, 'b, 'c> {
             }),
             &module_path,
             None,
+            &directive.parent_scope,
             true,
             span,
             directive.crate_lint(),
@@ -968,7 +970,7 @@ impl<'a, 'b:'a, 'c: 'b> ImportResolver<'a, 'b, 'c> {
             }
             PathResult::Failed(span, msg, true) => {
                 return if let Some(suggested_path) = self.make_path_suggestion(
-                    span, module_path.clone()
+                    span, module_path.clone(), &directive.parent_scope
                 ) {
                     Some((
                         span,

--- a/src/test/run-pass/macros/macro-use-all-and-none.stderr
+++ b/src/test/run-pass/macros/macro-use-all-and-none.stderr
@@ -1,0 +1,8 @@
+warning: unused attribute
+  --> $DIR/macro-use-all-and-none.rs:15:1
+   |
+LL | #[macro_use()]
+   | ^^^^^^^^^^^^^^
+   |
+   = note: #[warn(unused_attributes)] on by default
+

--- a/src/test/ui/error-codes/E0603.stderr
+++ b/src/test/ui/error-codes/E0603.stderr
@@ -1,8 +1,8 @@
 error[E0603]: constant `PRIVATE` is private
-  --> $DIR/E0603.rs:16:5
+  --> $DIR/E0603.rs:16:17
    |
 LL |     SomeModule::PRIVATE; //~ ERROR E0603
-   |     ^^^^^^^^^^^^^^^^^^^
+   |                 ^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-festival.stderr
+++ b/src/test/ui/error-festival.stderr
@@ -5,10 +5,10 @@ LL |     y = 2;
    |     ^ did you mean `x`?
 
 error[E0603]: constant `FOO` is private
-  --> $DIR/error-festival.rs:32:5
+  --> $DIR/error-festival.rs:32:10
    |
 LL |     foo::FOO;
-   |     ^^^^^^^^
+   |          ^^^
 
 error[E0368]: binary assignment operation `+=` cannot be applied to type `&str`
   --> $DIR/error-festival.rs:22:5

--- a/src/test/ui/export-import.stderr
+++ b/src/test/ui/export-import.stderr
@@ -1,8 +1,8 @@
 error[E0603]: function `unexported` is private
-  --> $DIR/export-import.rs:11:5
+  --> $DIR/export-import.rs:11:8
    |
 LL | use m::unexported;
-   |     ^^^^^^^^^^^^^
+   |        ^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/export-tag-variant.stderr
+++ b/src/test/ui/export-tag-variant.stderr
@@ -1,8 +1,8 @@
 error[E0603]: enum `y` is private
-  --> $DIR/export-tag-variant.rs:17:21
+  --> $DIR/export-tag-variant.rs:17:26
    |
 LL | fn main() { let z = foo::y::y1; } //~ ERROR: enum `y` is private
-   |                     ^^^^^^^^^^
+   |                          ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/export.stderr
+++ b/src/test/ui/export.stderr
@@ -23,10 +23,10 @@ LL |     fn z(y: isize) { log(debug, y); }
    |                          ^^^^^ not found in this scope
 
 error[E0603]: function `z` is private
-  --> $DIR/export.rs:20:13
+  --> $DIR/export.rs:20:18
    |
 LL | fn main() { foo::z(10); } //~ ERROR function `z` is private
-   |             ^^^^^^
+   |                  ^
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/extern/extern-crate-visibility.stderr
+++ b/src/test/ui/extern/extern-crate-visibility.stderr
@@ -1,14 +1,14 @@
 error[E0603]: extern crate `core` is private
-  --> $DIR/extern-crate-visibility.rs:16:5
+  --> $DIR/extern-crate-visibility.rs:16:10
    |
 LL | use foo::core::cell; //~ ERROR extern crate `core` is private
-   |     ^^^^^^^^^^^^^^^
+   |          ^^^^
 
 error[E0603]: extern crate `core` is private
-  --> $DIR/extern-crate-visibility.rs:19:5
+  --> $DIR/extern-crate-visibility.rs:19:10
    |
 LL |     foo::core::cell::Cell::new(0); //~ ERROR extern crate `core` is private
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |          ^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/hygiene/privacy.stderr
+++ b/src/test/ui/hygiene/privacy.stderr
@@ -1,8 +1,8 @@
 error[E0603]: function `f` is private
-  --> $DIR/privacy.rs:26:9
+  --> $DIR/privacy.rs:26:14
    |
 LL |         foo::f() //~ ERROR `f` is private
-   |         ^^^^^^
+   |              ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/import.stderr
+++ b/src/test/ui/import.stderr
@@ -11,10 +11,10 @@ LL |     use foo; //~ ERROR unresolved import `foo` [E0432]
    |         ^^^ no `foo` in the root
 
 error[E0603]: unresolved item `foo` is private
-  --> $DIR/import.rs:23:5
+  --> $DIR/import.rs:23:10
    |
 LL |     zed::foo(); //~ ERROR `foo` is private
-   |     ^^^^^^^^
+   |          ^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/imports/extern-prelude-extern-crate-absolute-expanded.rs
+++ b/src/test/ui/imports/extern-prelude-extern-crate-absolute-expanded.rs
@@ -1,0 +1,18 @@
+// compile-pass
+// edition:2018
+
+#![feature(extern_crate_item_prelude)]
+
+macro_rules! define_iso { () => {
+    extern crate std as iso;
+}}
+
+::iso::thread_local! {
+    static S: u8 = 0;
+}
+
+define_iso!();
+
+fn main() {
+    let s = S;
+}

--- a/src/test/ui/imports/reexports.stderr
+++ b/src/test/ui/imports/reexports.stderr
@@ -17,16 +17,16 @@ LL |         pub use super::*; //~ ERROR must import something with the glob's v
    |                 ^^^^^^^^
 
 error[E0603]: module `foo` is private
-  --> $DIR/reexports.rs:38:9
+  --> $DIR/reexports.rs:38:15
    |
 LL |     use b::a::foo::S; //~ ERROR `foo`
-   |         ^^^^^^^^^^^^
+   |               ^^^
 
 error[E0603]: module `foo` is private
-  --> $DIR/reexports.rs:39:9
+  --> $DIR/reexports.rs:39:15
    |
 LL |     use b::b::foo::S as T; //~ ERROR `foo`
-   |         ^^^^^^^^^^^^^^^^^
+   |               ^^^
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/issues/issue-10545.stderr
+++ b/src/test/ui/issues/issue-10545.stderr
@@ -1,8 +1,8 @@
 error[E0603]: struct `S` is private
-  --> $DIR/issue-10545.rs:17:11
+  --> $DIR/issue-10545.rs:17:14
    |
 LL | fn foo(_: a::S) { //~ ERROR: struct `S` is private
-   |           ^^^^
+   |              ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-11593.stderr
+++ b/src/test/ui/issues/issue-11593.stderr
@@ -1,8 +1,8 @@
 error[E0603]: trait `Foo` is private
-  --> $DIR/issue-11593.rs:17:6
+  --> $DIR/issue-11593.rs:17:24
    |
 LL | impl private_trait_xc::Foo for Bar {}
-   |      ^^^^^^^^^^^^^^^^^^^^^
+   |                        ^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-11680.stderr
+++ b/src/test/ui/issues/issue-11680.stderr
@@ -1,14 +1,14 @@
 error[E0603]: enum `Foo` is private
-  --> $DIR/issue-11680.rs:16:14
+  --> $DIR/issue-11680.rs:16:21
    |
 LL |     let _b = other::Foo::Bar(1);
-   |              ^^^^^^^^^^^^^^^
+   |                     ^^^
 
 error[E0603]: enum `Foo` is private
-  --> $DIR/issue-11680.rs:19:14
+  --> $DIR/issue-11680.rs:19:27
    |
 LL |     let _b = other::test::Foo::Bar(1);
-   |              ^^^^^^^^^^^^^^^^^^^^^
+   |                           ^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-13407.stderr
+++ b/src/test/ui/issues/issue-13407.stderr
@@ -1,8 +1,8 @@
 error[E0603]: unit struct `C` is private
-  --> $DIR/issue-13407.rs:16:5
+  --> $DIR/issue-13407.rs:16:8
    |
 LL |     A::C = 1;
-   |     ^^^^
+   |        ^
 
 error[E0308]: mismatched types
   --> $DIR/issue-13407.rs:16:12

--- a/src/test/ui/issues/issue-13641.stderr
+++ b/src/test/ui/issues/issue-13641.stderr
@@ -1,14 +1,14 @@
 error[E0603]: struct `Foo` is private
-  --> $DIR/issue-13641.rs:19:5
+  --> $DIR/issue-13641.rs:19:8
    |
 LL |     a::Foo::new();
-   |     ^^^^^^^^^^^
+   |        ^^^
 
 error[E0603]: enum `Bar` is private
-  --> $DIR/issue-13641.rs:21:5
+  --> $DIR/issue-13641.rs:21:8
    |
 LL |     a::Bar::new();
-   |     ^^^^^^^^^^^
+   |        ^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-16725.stderr
+++ b/src/test/ui/issues/issue-16725.stderr
@@ -1,8 +1,8 @@
 error[E0603]: function `bar` is private
-  --> $DIR/issue-16725.rs:16:14
+  --> $DIR/issue-16725.rs:16:19
    |
 LL |     unsafe { foo::bar(); }
-   |              ^^^^^^^^
+   |                   ^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-17718-const-privacy.stderr
+++ b/src/test/ui/issues/issue-17718-const-privacy.stderr
@@ -1,8 +1,8 @@
 error[E0603]: constant `B` is private
-  --> $DIR/issue-17718-const-privacy.rs:15:5
+  --> $DIR/issue-17718-const-privacy.rs:15:8
    |
 LL | use a::B; //~ ERROR: constant `B` is private
-   |     ^^^^
+   |        ^
 
 error[E0603]: constant `BAR` is private
   --> $DIR/issue-17718-const-privacy.rs:18:5

--- a/src/test/ui/issues/issue-28388-1.rs
+++ b/src/test/ui/issues/issue-28388-1.rs
@@ -10,6 +10,6 @@
 
 // Prefix in imports with empty braces should be resolved and checked privacy, stability, etc.
 
-use foo::{}; //~ ERROR cannot find module or enum `foo` in the crate root
+use foo::{}; //~ ERROR unresolved import `foo`
 
 fn main() {}

--- a/src/test/ui/issues/issue-28388-1.stderr
+++ b/src/test/ui/issues/issue-28388-1.stderr
@@ -1,9 +1,9 @@
-error[E0578]: cannot find module or enum `foo` in the crate root
+error[E0432]: unresolved import `foo`
   --> $DIR/issue-28388-1.rs:13:5
    |
-LL | use foo::{}; //~ ERROR cannot find module or enum `foo` in the crate root
-   |     ^^^ not found in the crate root
+LL | use foo::{}; //~ ERROR unresolved import `foo`
+   |     ^^^^^^^ no `foo` in the root
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0578`.
+For more information about this error, try `rustc --explain E0432`.

--- a/src/test/ui/issues/issue-28388-2.stderr
+++ b/src/test/ui/issues/issue-28388-2.stderr
@@ -1,8 +1,8 @@
 error[E0603]: module `n` is private
-  --> $DIR/issue-28388-2.rs:17:5
+  --> $DIR/issue-28388-2.rs:17:8
    |
 LL | use m::n::{};
-   |     ^^^^^^^^
+   |        ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-29161.stderr
+++ b/src/test/ui/issues/issue-29161.stderr
@@ -5,10 +5,10 @@ LL |         pub fn default() -> A { //~ ERROR unnecessary visibility qualifier
    |         ^^^ `pub` not permitted here because it's implied
 
 error[E0603]: struct `A` is private
-  --> $DIR/issue-29161.rs:23:5
+  --> $DIR/issue-29161.rs:23:8
    |
 LL |     a::A::default();
-   |     ^^^^^^^^^^^^^
+   |        ^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-38857.stderr
+++ b/src/test/ui/issues/issue-38857.stderr
@@ -5,10 +5,10 @@ LL |     let a = std::sys::imp::process::process_common::StdioPipes { ..panic!()
    |                       ^^^ Could not find `imp` in `sys`
 
 error[E0603]: module `sys` is private
-  --> $DIR/issue-38857.rs:12:13
+  --> $DIR/issue-38857.rs:12:18
    |
 LL |     let a = std::sys::imp::process::process_common::StdioPipes { ..panic!() };
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                  ^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-3993.stderr
+++ b/src/test/ui/issues/issue-3993.stderr
@@ -1,8 +1,8 @@
 error[E0603]: function `fly` is private
-  --> $DIR/issue-3993.rs:11:5
+  --> $DIR/issue-3993.rs:11:10
    |
 LL | use zoo::fly; //~ ERROR: function `fly` is private
-   |     ^^^^^^^^
+   |          ^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/macros/macro-local-data-key-priv.stderr
+++ b/src/test/ui/macros/macro-local-data-key-priv.stderr
@@ -1,8 +1,8 @@
 error[E0603]: constant `baz` is private
-  --> $DIR/macro-local-data-key-priv.rs:18:5
+  --> $DIR/macro-local-data-key-priv.rs:18:10
    |
 LL |     bar::baz.with(|_| ());
-   |     ^^^^^^^^
+   |          ^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/privacy/privacy-in-paths.stderr
+++ b/src/test/ui/privacy/privacy-in-paths.stderr
@@ -1,20 +1,20 @@
 error[E0603]: module `bar` is private
-  --> $DIR/privacy-in-paths.rs:34:9
+  --> $DIR/privacy-in-paths.rs:34:16
    |
 LL |         ::foo::bar::baz::f(); //~ERROR module `bar` is private
-   |         ^^^^^^^^^^^^^^^^^^
+   |                ^^^
 
 error[E0603]: module `bar` is private
-  --> $DIR/privacy-in-paths.rs:35:9
+  --> $DIR/privacy-in-paths.rs:35:16
    |
 LL |         ::foo::bar::S::f(); //~ERROR module `bar` is private
-   |         ^^^^^^^^^^^^^^^^
+   |                ^^^
 
 error[E0603]: trait `T` is private
-  --> $DIR/privacy-in-paths.rs:36:9
+  --> $DIR/privacy-in-paths.rs:36:23
    |
 LL |         <() as ::foo::T>::Assoc::f(); //~ERROR trait `T` is private
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                       ^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/privacy/privacy-ns2.stderr
+++ b/src/test/ui/privacy/privacy-ns2.stderr
@@ -55,16 +55,16 @@ LL | use foo3::Bar;
    |
 
 error[E0603]: trait `Bar` is private
-  --> $DIR/privacy-ns2.rs:70:9
+  --> $DIR/privacy-ns2.rs:70:15
    |
 LL |     use foo3::Bar;  //~ ERROR `Bar` is private
-   |         ^^^^^^^^^
+   |               ^^^
 
 error[E0603]: trait `Bar` is private
-  --> $DIR/privacy-ns2.rs:74:9
+  --> $DIR/privacy-ns2.rs:74:15
    |
 LL |     use foo3::Bar;  //~ ERROR `Bar` is private
-   |         ^^^^^^^^^
+   |               ^^^
 
 error[E0603]: trait `Bar` is private
   --> $DIR/privacy-ns2.rs:81:16

--- a/src/test/ui/privacy/privacy-ufcs.stderr
+++ b/src/test/ui/privacy/privacy-ufcs.stderr
@@ -1,8 +1,8 @@
 error[E0603]: trait `Bar` is private
-  --> $DIR/privacy-ufcs.rs:22:5
+  --> $DIR/privacy-ufcs.rs:22:20
    |
 LL |     <i32 as ::foo::Bar>::baz(); //~ERROR trait `Bar` is private
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                    ^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/privacy/privacy1.rs
+++ b/src/test/ui/privacy/privacy1.rs
@@ -127,7 +127,6 @@ mod foo {
     fn test2() {
         use bar::baz::{foo, bar};
         //~^ ERROR: module `baz` is private
-        //~| ERROR: module `baz` is private
 
         foo();
         bar();

--- a/src/test/ui/privacy/privacy1.stderr
+++ b/src/test/ui/privacy/privacy1.stderr
@@ -1,80 +1,74 @@
 error[E0603]: module `baz` is private
-  --> $DIR/privacy1.rs:128:24
+  --> $DIR/privacy1.rs:128:18
    |
 LL |         use bar::baz::{foo, bar};
-   |                        ^^^
+   |                  ^^^
 
 error[E0603]: module `baz` is private
-  --> $DIR/privacy1.rs:128:29
-   |
-LL |         use bar::baz::{foo, bar};
-   |                             ^^^
-
-error[E0603]: module `baz` is private
-  --> $DIR/privacy1.rs:137:13
+  --> $DIR/privacy1.rs:136:18
    |
 LL |         use bar::baz;
-   |             ^^^^^^^^
+   |                  ^^^
 
 error[E0603]: module `i` is private
-  --> $DIR/privacy1.rs:161:9
+  --> $DIR/privacy1.rs:160:20
    |
 LL |     use self::foo::i::A; //~ ERROR: module `i` is private
-   |         ^^^^^^^^^^^^^^^
+   |                    ^
 
 error[E0603]: module `baz` is private
-  --> $DIR/privacy1.rs:100:9
+  --> $DIR/privacy1.rs:100:16
    |
 LL |         ::bar::baz::A::foo();   //~ ERROR: module `baz` is private
-   |         ^^^^^^^^^^^^^^^^^^
+   |                ^^^
 
 error[E0603]: module `baz` is private
-  --> $DIR/privacy1.rs:101:9
+  --> $DIR/privacy1.rs:101:16
    |
 LL |         ::bar::baz::A::bar();   //~ ERROR: module `baz` is private
-   |         ^^^^^^^^^^^^^^^^^^
+   |                ^^^
 
 error[E0603]: module `baz` is private
-  --> $DIR/privacy1.rs:103:9
+  --> $DIR/privacy1.rs:103:16
    |
 LL |         ::bar::baz::A.foo2();   //~ ERROR: module `baz` is private
-   |         ^^^^^^^^^^^^^
+   |                ^^^
 
 error[E0603]: module `baz` is private
-  --> $DIR/privacy1.rs:104:9
+  --> $DIR/privacy1.rs:104:16
    |
 LL |         ::bar::baz::A.bar2();   //~ ERROR: module `baz` is private
-   |         ^^^^^^^^^^^^^
+   |                ^^^
 
 error[E0603]: trait `B` is private
-  --> $DIR/privacy1.rs:108:9
+  --> $DIR/privacy1.rs:108:16
    |
 LL |         ::bar::B::foo();        //~ ERROR: trait `B` is private
-   |         ^^^^^^^^^^^^^
+   |                ^
 
 error[E0603]: function `epriv` is private
-  --> $DIR/privacy1.rs:114:13
+  --> $DIR/privacy1.rs:114:20
    |
 LL |             ::bar::epriv(); //~ ERROR: function `epriv` is private
-   |             ^^^^^^^^^^^^
+   |                    ^^^^^
 
 error[E0603]: module `baz` is private
-  --> $DIR/privacy1.rs:123:9
+  --> $DIR/privacy1.rs:123:16
    |
 LL |         ::bar::baz::foo(); //~ ERROR: module `baz` is private
-   |         ^^^^^^^^^^^^^^^
+   |                ^^^
 
 error[E0603]: module `baz` is private
-  --> $DIR/privacy1.rs:124:9
+  --> $DIR/privacy1.rs:124:16
    |
 LL |         ::bar::baz::bar(); //~ ERROR: module `baz` is private
-   |         ^^^^^^^^^^^^^^^
+   |                ^^^
 
 error[E0603]: trait `B` is private
-  --> $DIR/privacy1.rs:153:10
+  --> $DIR/privacy1.rs:152:17
    |
 LL |     impl ::bar::B for f32 { fn foo() -> f32 { 1.0 } }
-   |          ^^^^^^^^
+   |                 ^
 
 error[E0624]: method `bar` is private
   --> $DIR/privacy1.rs:73:9
@@ -106,7 +100,7 @@ error[E0624]: method `bar2` is private
 LL |         ::bar::baz::A.bar2();   //~ ERROR: module `baz` is private
    |                       ^^^^
 
-error: aborting due to 18 previous errors
+error: aborting due to 17 previous errors
 
 Some errors occurred: E0603, E0624.
 For more information about an error, try `rustc --explain E0603`.

--- a/src/test/ui/privacy/privacy2.stderr
+++ b/src/test/ui/privacy/privacy2.stderr
@@ -5,10 +5,10 @@ LL |     use bar::foo;
    |         ^^^^^^^^ no `foo` in `bar`
 
 error[E0603]: function `foo` is private
-  --> $DIR/privacy2.rs:33:9
+  --> $DIR/privacy2.rs:33:20
    |
 LL |     use bar::glob::foo;
-   |         ^^^^^^^^^^^^^^
+   |                    ^^^
 
 error: requires `sized` lang_item
 

--- a/src/test/ui/privacy/privacy4.stderr
+++ b/src/test/ui/privacy/privacy4.stderr
@@ -1,8 +1,8 @@
 error[E0603]: module `glob` is private
-  --> $DIR/privacy4.rs:31:9
+  --> $DIR/privacy4.rs:31:14
    |
 LL |     use bar::glob::gpriv; //~ ERROR: module `glob` is private
-   |         ^^^^^^^^^^^^^^^^
+   |              ^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/privacy/privacy5.stderr
+++ b/src/test/ui/privacy/privacy5.stderr
@@ -1,290 +1,290 @@
 error[E0603]: tuple struct `A` is private
-  --> $DIR/privacy5.rs:61:13
+  --> $DIR/privacy5.rs:61:16
    |
 LL |     let a = a::A(()); //~ ERROR tuple struct `A` is private
-   |             ^^^^
+   |                ^
 
 error[E0603]: tuple struct `B` is private
-  --> $DIR/privacy5.rs:62:13
+  --> $DIR/privacy5.rs:62:16
    |
 LL |     let b = a::B(2); //~ ERROR tuple struct `B` is private
-   |             ^^^^
+   |                ^
 
 error[E0603]: tuple struct `C` is private
-  --> $DIR/privacy5.rs:63:13
+  --> $DIR/privacy5.rs:63:16
    |
 LL |     let c = a::C(2, 3); //~ ERROR tuple struct `C` is private
-   |             ^^^^
+   |                ^
 
 error[E0603]: tuple struct `A` is private
-  --> $DIR/privacy5.rs:66:9
+  --> $DIR/privacy5.rs:66:12
    |
 LL |     let a::A(()) = a; //~ ERROR tuple struct `A` is private
-   |         ^^^^
+   |            ^
 
 error[E0603]: tuple struct `A` is private
-  --> $DIR/privacy5.rs:67:9
+  --> $DIR/privacy5.rs:67:12
    |
 LL |     let a::A(_) = a; //~ ERROR tuple struct `A` is private
-   |         ^^^^
+   |            ^
 
 error[E0603]: tuple struct `A` is private
-  --> $DIR/privacy5.rs:68:15
+  --> $DIR/privacy5.rs:68:18
    |
 LL |     match a { a::A(()) => {} } //~ ERROR tuple struct `A` is private
-   |               ^^^^
+   |                  ^
 
 error[E0603]: tuple struct `A` is private
-  --> $DIR/privacy5.rs:69:15
+  --> $DIR/privacy5.rs:69:18
    |
 LL |     match a { a::A(_) => {} } //~ ERROR tuple struct `A` is private
-   |               ^^^^
+   |                  ^
 
 error[E0603]: tuple struct `B` is private
-  --> $DIR/privacy5.rs:71:9
+  --> $DIR/privacy5.rs:71:12
    |
 LL |     let a::B(_) = b; //~ ERROR tuple struct `B` is private
-   |         ^^^^
+   |            ^
 
 error[E0603]: tuple struct `B` is private
-  --> $DIR/privacy5.rs:72:9
+  --> $DIR/privacy5.rs:72:12
    |
 LL |     let a::B(_b) = b; //~ ERROR tuple struct `B` is private
-   |         ^^^^
+   |            ^
 
 error[E0603]: tuple struct `B` is private
-  --> $DIR/privacy5.rs:73:15
+  --> $DIR/privacy5.rs:73:18
    |
 LL |     match b { a::B(_) => {} } //~ ERROR tuple struct `B` is private
-   |               ^^^^
+   |                  ^
 
 error[E0603]: tuple struct `B` is private
-  --> $DIR/privacy5.rs:74:15
+  --> $DIR/privacy5.rs:74:18
    |
 LL |     match b { a::B(_b) => {} } //~ ERROR tuple struct `B` is private
-   |               ^^^^
+   |                  ^
 
 error[E0603]: tuple struct `B` is private
-  --> $DIR/privacy5.rs:75:15
+  --> $DIR/privacy5.rs:75:18
    |
 LL |     match b { a::B(1) => {} a::B(_) => {} } //~ ERROR tuple struct `B` is private
-   |               ^^^^
+   |                  ^
 
 error[E0603]: tuple struct `B` is private
-  --> $DIR/privacy5.rs:75:29
+  --> $DIR/privacy5.rs:75:32
    |
 LL |     match b { a::B(1) => {} a::B(_) => {} } //~ ERROR tuple struct `B` is private
-   |                             ^^^^
+   |                                ^
 
 error[E0603]: tuple struct `C` is private
-  --> $DIR/privacy5.rs:78:9
+  --> $DIR/privacy5.rs:78:12
    |
 LL |     let a::C(_, _) = c; //~ ERROR tuple struct `C` is private
-   |         ^^^^
+   |            ^
 
 error[E0603]: tuple struct `C` is private
-  --> $DIR/privacy5.rs:79:9
+  --> $DIR/privacy5.rs:79:12
    |
 LL |     let a::C(_a, _) = c; //~ ERROR tuple struct `C` is private
-   |         ^^^^
+   |            ^
 
 error[E0603]: tuple struct `C` is private
-  --> $DIR/privacy5.rs:80:9
+  --> $DIR/privacy5.rs:80:12
    |
 LL |     let a::C(_, _b) = c; //~ ERROR tuple struct `C` is private
-   |         ^^^^
+   |            ^
 
 error[E0603]: tuple struct `C` is private
-  --> $DIR/privacy5.rs:81:9
+  --> $DIR/privacy5.rs:81:12
    |
 LL |     let a::C(_a, _b) = c; //~ ERROR tuple struct `C` is private
-   |         ^^^^
+   |            ^
 
 error[E0603]: tuple struct `C` is private
-  --> $DIR/privacy5.rs:82:15
+  --> $DIR/privacy5.rs:82:18
    |
 LL |     match c { a::C(_, _) => {} } //~ ERROR tuple struct `C` is private
-   |               ^^^^
+   |                  ^
 
 error[E0603]: tuple struct `C` is private
-  --> $DIR/privacy5.rs:83:15
+  --> $DIR/privacy5.rs:83:18
    |
 LL |     match c { a::C(_a, _) => {} } //~ ERROR tuple struct `C` is private
-   |               ^^^^
+   |                  ^
 
 error[E0603]: tuple struct `C` is private
-  --> $DIR/privacy5.rs:84:15
+  --> $DIR/privacy5.rs:84:18
    |
 LL |     match c { a::C(_, _b) => {} } //~ ERROR tuple struct `C` is private
-   |               ^^^^
+   |                  ^
 
 error[E0603]: tuple struct `C` is private
-  --> $DIR/privacy5.rs:85:15
+  --> $DIR/privacy5.rs:85:18
    |
 LL |     match c { a::C(_a, _b) => {} } //~ ERROR tuple struct `C` is private
-   |               ^^^^
+   |                  ^
 
 error[E0603]: tuple struct `A` is private
-  --> $DIR/privacy5.rs:93:14
+  --> $DIR/privacy5.rs:93:17
    |
 LL |     let a2 = a::A; //~ ERROR tuple struct `A` is private
-   |              ^^^^
+   |                 ^
 
 error[E0603]: tuple struct `B` is private
-  --> $DIR/privacy5.rs:94:14
+  --> $DIR/privacy5.rs:94:17
    |
 LL |     let b2 = a::B; //~ ERROR tuple struct `B` is private
-   |              ^^^^
+   |                 ^
 
 error[E0603]: tuple struct `C` is private
-  --> $DIR/privacy5.rs:95:14
+  --> $DIR/privacy5.rs:95:17
    |
 LL |     let c2 = a::C; //~ ERROR tuple struct `C` is private
-   |              ^^^^
+   |                 ^
 
 error[E0603]: tuple struct `A` is private
-  --> $DIR/privacy5.rs:100:13
+  --> $DIR/privacy5.rs:100:20
    |
 LL |     let a = other::A(()); //~ ERROR tuple struct `A` is private
-   |             ^^^^^^^^
+   |                    ^
 
 error[E0603]: tuple struct `B` is private
-  --> $DIR/privacy5.rs:101:13
+  --> $DIR/privacy5.rs:101:20
    |
 LL |     let b = other::B(2); //~ ERROR tuple struct `B` is private
-   |             ^^^^^^^^
+   |                    ^
 
 error[E0603]: tuple struct `C` is private
-  --> $DIR/privacy5.rs:102:13
+  --> $DIR/privacy5.rs:102:20
    |
 LL |     let c = other::C(2, 3); //~ ERROR tuple struct `C` is private
-   |             ^^^^^^^^
+   |                    ^
 
 error[E0603]: tuple struct `A` is private
-  --> $DIR/privacy5.rs:105:9
+  --> $DIR/privacy5.rs:105:16
    |
 LL |     let other::A(()) = a; //~ ERROR tuple struct `A` is private
-   |         ^^^^^^^^
+   |                ^
 
 error[E0603]: tuple struct `A` is private
-  --> $DIR/privacy5.rs:106:9
+  --> $DIR/privacy5.rs:106:16
    |
 LL |     let other::A(_) = a; //~ ERROR tuple struct `A` is private
-   |         ^^^^^^^^
+   |                ^
 
 error[E0603]: tuple struct `A` is private
-  --> $DIR/privacy5.rs:107:15
+  --> $DIR/privacy5.rs:107:22
    |
 LL |     match a { other::A(()) => {} } //~ ERROR tuple struct `A` is private
-   |               ^^^^^^^^
+   |                      ^
 
 error[E0603]: tuple struct `A` is private
-  --> $DIR/privacy5.rs:108:15
+  --> $DIR/privacy5.rs:108:22
    |
 LL |     match a { other::A(_) => {} } //~ ERROR tuple struct `A` is private
-   |               ^^^^^^^^
+   |                      ^
 
 error[E0603]: tuple struct `B` is private
-  --> $DIR/privacy5.rs:110:9
+  --> $DIR/privacy5.rs:110:16
    |
 LL |     let other::B(_) = b; //~ ERROR tuple struct `B` is private
-   |         ^^^^^^^^
+   |                ^
 
 error[E0603]: tuple struct `B` is private
-  --> $DIR/privacy5.rs:111:9
+  --> $DIR/privacy5.rs:111:16
    |
 LL |     let other::B(_b) = b; //~ ERROR tuple struct `B` is private
-   |         ^^^^^^^^
+   |                ^
 
 error[E0603]: tuple struct `B` is private
-  --> $DIR/privacy5.rs:112:15
+  --> $DIR/privacy5.rs:112:22
    |
 LL |     match b { other::B(_) => {} } //~ ERROR tuple struct `B` is private
-   |               ^^^^^^^^
+   |                      ^
 
 error[E0603]: tuple struct `B` is private
-  --> $DIR/privacy5.rs:113:15
+  --> $DIR/privacy5.rs:113:22
    |
 LL |     match b { other::B(_b) => {} } //~ ERROR tuple struct `B` is private
-   |               ^^^^^^^^
+   |                      ^
 
 error[E0603]: tuple struct `B` is private
-  --> $DIR/privacy5.rs:114:15
+  --> $DIR/privacy5.rs:114:22
    |
 LL |     match b { other::B(1) => {} other::B(_) => {} } //~ ERROR tuple struct `B` is private
-   |               ^^^^^^^^
+   |                      ^
 
 error[E0603]: tuple struct `B` is private
-  --> $DIR/privacy5.rs:114:33
+  --> $DIR/privacy5.rs:114:40
    |
 LL |     match b { other::B(1) => {} other::B(_) => {} } //~ ERROR tuple struct `B` is private
-   |                                 ^^^^^^^^
+   |                                        ^
 
 error[E0603]: tuple struct `C` is private
-  --> $DIR/privacy5.rs:117:9
+  --> $DIR/privacy5.rs:117:16
    |
 LL |     let other::C(_, _) = c; //~ ERROR tuple struct `C` is private
-   |         ^^^^^^^^
+   |                ^
 
 error[E0603]: tuple struct `C` is private
-  --> $DIR/privacy5.rs:118:9
+  --> $DIR/privacy5.rs:118:16
    |
 LL |     let other::C(_a, _) = c; //~ ERROR tuple struct `C` is private
-   |         ^^^^^^^^
+   |                ^
 
 error[E0603]: tuple struct `C` is private
-  --> $DIR/privacy5.rs:119:9
+  --> $DIR/privacy5.rs:119:16
    |
 LL |     let other::C(_, _b) = c; //~ ERROR tuple struct `C` is private
-   |         ^^^^^^^^
+   |                ^
 
 error[E0603]: tuple struct `C` is private
-  --> $DIR/privacy5.rs:120:9
+  --> $DIR/privacy5.rs:120:16
    |
 LL |     let other::C(_a, _b) = c; //~ ERROR tuple struct `C` is private
-   |         ^^^^^^^^
+   |                ^
 
 error[E0603]: tuple struct `C` is private
-  --> $DIR/privacy5.rs:121:15
+  --> $DIR/privacy5.rs:121:22
    |
 LL |     match c { other::C(_, _) => {} } //~ ERROR tuple struct `C` is private
-   |               ^^^^^^^^
+   |                      ^
 
 error[E0603]: tuple struct `C` is private
-  --> $DIR/privacy5.rs:122:15
+  --> $DIR/privacy5.rs:122:22
    |
 LL |     match c { other::C(_a, _) => {} } //~ ERROR tuple struct `C` is private
-   |               ^^^^^^^^
+   |                      ^
 
 error[E0603]: tuple struct `C` is private
-  --> $DIR/privacy5.rs:123:15
+  --> $DIR/privacy5.rs:123:22
    |
 LL |     match c { other::C(_, _b) => {} } //~ ERROR tuple struct `C` is private
-   |               ^^^^^^^^
+   |                      ^
 
 error[E0603]: tuple struct `C` is private
-  --> $DIR/privacy5.rs:124:15
+  --> $DIR/privacy5.rs:124:22
    |
 LL |     match c { other::C(_a, _b) => {} } //~ ERROR tuple struct `C` is private
-   |               ^^^^^^^^
+   |                      ^
 
 error[E0603]: tuple struct `A` is private
-  --> $DIR/privacy5.rs:132:14
+  --> $DIR/privacy5.rs:132:21
    |
 LL |     let a2 = other::A; //~ ERROR tuple struct `A` is private
-   |              ^^^^^^^^
+   |                     ^
 
 error[E0603]: tuple struct `B` is private
-  --> $DIR/privacy5.rs:133:14
+  --> $DIR/privacy5.rs:133:21
    |
 LL |     let b2 = other::B; //~ ERROR tuple struct `B` is private
-   |              ^^^^^^^^
+   |                     ^
 
 error[E0603]: tuple struct `C` is private
-  --> $DIR/privacy5.rs:134:14
+  --> $DIR/privacy5.rs:134:21
    |
 LL |     let c2 = other::C; //~ ERROR tuple struct `C` is private
-   |              ^^^^^^^^
+   |                     ^
 
 error: aborting due to 48 previous errors
 

--- a/src/test/ui/privacy/private-item-simple.stderr
+++ b/src/test/ui/privacy/private-item-simple.stderr
@@ -1,8 +1,8 @@
 error[E0603]: function `f` is private
-  --> $DIR/private-item-simple.rs:16:5
+  --> $DIR/private-item-simple.rs:16:8
    |
 LL |     a::f(); //~ ERROR function `f` is private
-   |     ^^^^
+   |        ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/privacy/restricted/test.stderr
+++ b/src/test/ui/privacy/restricted/test.stderr
@@ -23,16 +23,16 @@ LL |         pub(super) use foo::bar::f as g; //~ ERROR cannot be re-exported
    |                        ^^^^^^^^^^^^^^^^
 
 error[E0603]: struct `Crate` is private
-  --> $DIR/test.rs:48:9
+  --> $DIR/test.rs:48:25
    |
 LL |     use pub_restricted::Crate; //~ ERROR private
-   |         ^^^^^^^^^^^^^^^^^^^^^
+   |                         ^^^^^
 
 error[E0603]: function `f` is private
-  --> $DIR/test.rs:40:9
+  --> $DIR/test.rs:40:19
    |
 LL |     use foo::bar::f; //~ ERROR private
-   |         ^^^^^^^^^^^
+   |                   ^
 
 error[E0616]: field `x` of struct `foo::bar::S` is private
   --> $DIR/test.rs:41:5

--- a/src/test/ui/resolve/privacy-enum-ctor.stderr
+++ b/src/test/ui/resolve/privacy-enum-ctor.stderr
@@ -132,28 +132,28 @@ LL | use m::n::Z;
    |
 
 error[E0603]: enum `Z` is private
-  --> $DIR/privacy-enum-ctor.rs:67:16
+  --> $DIR/privacy-enum-ctor.rs:67:22
    |
 LL |     let _: Z = m::n::Z;
-   |                ^^^^^^^
+   |                      ^
 
 error[E0603]: enum `Z` is private
-  --> $DIR/privacy-enum-ctor.rs:71:16
+  --> $DIR/privacy-enum-ctor.rs:71:22
    |
 LL |     let _: Z = m::n::Z::Fn;
-   |                ^^^^^^^^^^^
+   |                      ^
 
 error[E0603]: enum `Z` is private
-  --> $DIR/privacy-enum-ctor.rs:74:16
+  --> $DIR/privacy-enum-ctor.rs:74:22
    |
 LL |     let _: Z = m::n::Z::Struct;
-   |                ^^^^^^^^^^^^^^^
+   |                      ^
 
 error[E0603]: enum `Z` is private
-  --> $DIR/privacy-enum-ctor.rs:78:16
+  --> $DIR/privacy-enum-ctor.rs:78:22
    |
 LL |     let _: Z = m::n::Z::Unit {};
-   |                ^^^^^^^^^^^^^
+   |                      ^
 
 error[E0308]: mismatched types
   --> $DIR/privacy-enum-ctor.rs:37:20

--- a/src/test/ui/resolve/privacy-struct-ctor.stderr
+++ b/src/test/ui/resolve/privacy-struct-ctor.stderr
@@ -38,40 +38,40 @@ LL | use m::S;
    |
 
 error[E0603]: tuple struct `Z` is private
-  --> $DIR/privacy-struct-ctor.rs:28:9
+  --> $DIR/privacy-struct-ctor.rs:28:12
    |
 LL |         n::Z;
-   |         ^^^^
+   |            ^
 
 error[E0603]: tuple struct `S` is private
-  --> $DIR/privacy-struct-ctor.rs:39:5
+  --> $DIR/privacy-struct-ctor.rs:39:8
    |
 LL |     m::S;
-   |     ^^^^
+   |        ^
 
 error[E0603]: tuple struct `S` is private
-  --> $DIR/privacy-struct-ctor.rs:41:16
+  --> $DIR/privacy-struct-ctor.rs:41:19
    |
 LL |     let _: S = m::S(2);
-   |                ^^^^
+   |                   ^
 
 error[E0603]: tuple struct `Z` is private
-  --> $DIR/privacy-struct-ctor.rs:45:5
+  --> $DIR/privacy-struct-ctor.rs:45:11
    |
 LL |     m::n::Z;
-   |     ^^^^^^^
+   |           ^
 
 error[E0603]: tuple struct `S` is private
-  --> $DIR/privacy-struct-ctor.rs:51:5
+  --> $DIR/privacy-struct-ctor.rs:51:16
    |
 LL |     xcrate::m::S;
-   |     ^^^^^^^^^^^^
+   |                ^
 
 error[E0603]: tuple struct `Z` is private
-  --> $DIR/privacy-struct-ctor.rs:55:5
+  --> $DIR/privacy-struct-ctor.rs:55:19
    |
 LL |     xcrate::m::n::Z;
-   |     ^^^^^^^^^^^^^^^
+   |                   ^
 
 error: aborting due to 10 previous errors
 

--- a/src/test/ui/resolve/resolve-bad-import-prefix.rs
+++ b/src/test/ui/resolve/resolve-bad-import-prefix.rs
@@ -17,8 +17,8 @@ use {}; // OK
 use ::{}; // OK
 use m::{}; // OK
 use E::{}; // OK
-use S::{}; //~ ERROR expected module or enum, found struct `S`
-use Tr::{}; //~ ERROR expected module or enum, found trait `Tr`
-use Nonexistent::{}; //~ ERROR cannot find module or enum `Nonexistent` in the crate root
+use S::{}; // FIXME, this and `use S::{self};` should be an error
+use Tr::{}; // FIXME, this and `use Tr::{self};` should be an error
+use Nonexistent::{}; //~ ERROR unresolved import `Nonexistent`
 
 fn main () {}

--- a/src/test/ui/resolve/resolve-bad-import-prefix.stderr
+++ b/src/test/ui/resolve/resolve-bad-import-prefix.stderr
@@ -1,24 +1,9 @@
-error[E0577]: expected module or enum, found struct `S`
-  --> $DIR/resolve-bad-import-prefix.rs:20:5
-   |
-LL | use S::{}; //~ ERROR expected module or enum, found struct `S`
-   |     -^^^^
-   |     |
-   |     did you mean `E`?
-
-error[E0577]: expected module or enum, found trait `Tr`
-  --> $DIR/resolve-bad-import-prefix.rs:21:5
-   |
-LL | use Tr::{}; //~ ERROR expected module or enum, found trait `Tr`
-   |     ^^^^^^ not a module or enum
-
-error[E0578]: cannot find module or enum `Nonexistent` in the crate root
+error[E0432]: unresolved import `Nonexistent`
   --> $DIR/resolve-bad-import-prefix.rs:22:5
    |
-LL | use Nonexistent::{}; //~ ERROR cannot find module or enum `Nonexistent` in the crate root
-   |     ^^^^^^^^^^^ not found in the crate root
+LL | use Nonexistent::{}; //~ ERROR unresolved import `Nonexistent`
+   |     ^^^^^^^^^^^^^^^ no `Nonexistent` in the root
 
-error: aborting due to 3 previous errors
+error: aborting due to previous error
 
-Some errors occurred: E0577, E0578.
-For more information about an error, try `rustc --explain E0577`.
+For more information about this error, try `rustc --explain E0432`.

--- a/src/test/ui/rfc-2008-non-exhaustive/structs.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/structs.stderr
@@ -11,16 +11,16 @@ LL |     let us = UnitStruct;
    |              ^^^^^^^^^^ constructor is not visible here due to private fields
 
 error[E0603]: tuple struct `TupleStruct` is private
-  --> $DIR/structs.rs:33:23
+  --> $DIR/structs.rs:33:32
    |
 LL |     let ts_explicit = structs::TupleStruct(640, 480);
-   |                       ^^^^^^^^^^^^^^^^^^^^
+   |                                ^^^^^^^^^^^
 
 error[E0603]: unit struct `UnitStruct` is private
-  --> $DIR/structs.rs:42:23
+  --> $DIR/structs.rs:42:32
    |
 LL |     let us_explicit = structs::UnitStruct;
-   |                       ^^^^^^^^^^^^^^^^^^^
+   |                                ^^^^^^^^^^
 
 error[E0639]: cannot create non-exhaustive struct using struct expression
   --> $DIR/structs.rs:17:14

--- a/src/test/ui/shadowed/shadowed-use-visibility.stderr
+++ b/src/test/ui/shadowed/shadowed-use-visibility.stderr
@@ -1,14 +1,14 @@
 error[E0603]: module `bar` is private
-  --> $DIR/shadowed-use-visibility.rs:19:9
+  --> $DIR/shadowed-use-visibility.rs:19:14
    |
 LL |     use foo::bar::f as g; //~ ERROR module `bar` is private
-   |         ^^^^^^^^^^^^^^^^
+   |              ^^^
 
 error[E0603]: module `f` is private
-  --> $DIR/shadowed-use-visibility.rs:25:5
+  --> $DIR/shadowed-use-visibility.rs:25:10
    |
 LL | use bar::f::f; //~ ERROR module `f` is private
-   |     ^^^^^^^^^
+   |          ^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/static/static-priv-by-default2.stderr
+++ b/src/test/ui/static/static-priv-by-default2.stderr
@@ -1,14 +1,14 @@
 error[E0603]: static `private` is private
-  --> $DIR/static-priv-by-default2.rs:25:9
+  --> $DIR/static-priv-by-default2.rs:25:30
    |
 LL |     use child::childs_child::private;
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                              ^^^^^^^
 
 error[E0603]: static `private` is private
-  --> $DIR/static-priv-by-default2.rs:33:9
+  --> $DIR/static-priv-by-default2.rs:33:33
    |
 LL |     use static_priv_by_default::private;
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                 ^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/structs/struct-variant-privacy-xc.stderr
+++ b/src/test/ui/structs/struct-variant-privacy-xc.stderr
@@ -1,14 +1,14 @@
 error[E0603]: enum `Bar` is private
-  --> $DIR/struct-variant-privacy-xc.rs:14:9
+  --> $DIR/struct-variant-privacy-xc.rs:14:33
    |
 LL | fn f(b: struct_variant_privacy::Bar) { //~ ERROR enum `Bar` is private
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                 ^^^
 
 error[E0603]: enum `Bar` is private
-  --> $DIR/struct-variant-privacy-xc.rs:16:9
+  --> $DIR/struct-variant-privacy-xc.rs:16:33
    |
 LL |         struct_variant_privacy::Bar::Baz { a: _a } => {} //~ ERROR enum `Bar` is private
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                 ^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/structs/struct-variant-privacy.stderr
+++ b/src/test/ui/structs/struct-variant-privacy.stderr
@@ -1,14 +1,14 @@
 error[E0603]: enum `Bar` is private
-  --> $DIR/struct-variant-privacy.rs:16:9
+  --> $DIR/struct-variant-privacy.rs:16:14
    |
 LL | fn f(b: foo::Bar) { //~ ERROR enum `Bar` is private
-   |         ^^^^^^^^
+   |              ^^^
 
 error[E0603]: enum `Bar` is private
-  --> $DIR/struct-variant-privacy.rs:18:9
+  --> $DIR/struct-variant-privacy.rs:18:14
    |
 LL |         foo::Bar::Baz { a: _a } => {} //~ ERROR enum `Bar` is private
-   |         ^^^^^^^^^^^^^
+   |              ^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/unreachable/unreachable-variant.stderr
+++ b/src/test/ui/unreachable/unreachable-variant.stderr
@@ -1,8 +1,8 @@
 error[E0603]: module `super_sekrit` is private
-  --> $DIR/unreachable-variant.rs:16:14
+  --> $DIR/unreachable-variant.rs:16:21
    |
 LL |     let _x = other::super_sekrit::sooper_sekrit::baz; //~ ERROR is private
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/use/use-from-trait-xc.stderr
+++ b/src/test/ui/use/use-from-trait-xc.stderr
@@ -41,16 +41,16 @@ LL | use use_from_trait_xc::Baz::new as baznew;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `new` in `Baz`
 
 error[E0603]: struct `Foo` is private
-  --> $DIR/use-from-trait-xc.rs:24:5
+  --> $DIR/use-from-trait-xc.rs:24:24
    |
 LL | use use_from_trait_xc::Foo::new; //~ ERROR struct `Foo` is private
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                        ^^^
 
 error[E0603]: struct `Foo` is private
-  --> $DIR/use-from-trait-xc.rs:27:5
+  --> $DIR/use-from-trait-xc.rs:27:24
    |
 LL | use use_from_trait_xc::Foo::C; //~ ERROR struct `Foo` is private
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                        ^^^
 
 error: aborting due to 9 previous errors
 

--- a/src/test/ui/use/use-mod/use-mod-3.rs
+++ b/src/test/ui/use/use-mod/use-mod-3.rs
@@ -8,11 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use foo::bar::{
-    self //~ ERROR module `bar` is private
+use foo::bar::{ //~ ERROR module `bar` is private
+    self
 };
-use foo::bar::{
-    Bar //~ ERROR module `bar` is private
+use foo::bar::{ //~ ERROR module `bar` is private
+    Bar
 };
 
 mod foo {

--- a/src/test/ui/use/use-mod/use-mod-3.stderr
+++ b/src/test/ui/use/use-mod/use-mod-3.stderr
@@ -1,14 +1,14 @@
 error[E0603]: module `bar` is private
-  --> $DIR/use-mod-3.rs:12:5
+  --> $DIR/use-mod-3.rs:11:10
    |
-LL |     self //~ ERROR module `bar` is private
-   |     ^^^^
+LL | use foo::bar::{ //~ ERROR module `bar` is private
+   |          ^^^
 
 error[E0603]: module `bar` is private
-  --> $DIR/use-mod-3.rs:15:5
+  --> $DIR/use-mod-3.rs:14:10
    |
-LL |     Bar //~ ERROR module `bar` is private
-   |     ^^^
+LL | use foo::bar::{ //~ ERROR module `bar` is private
+   |          ^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/xcrate/xcrate-private-by-default.stderr
+++ b/src/test/ui/xcrate/xcrate-private-by-default.stderr
@@ -1,62 +1,62 @@
 error[E0603]: static `j` is private
-  --> $DIR/xcrate-private-by-default.rs:33:5
+  --> $DIR/xcrate-private-by-default.rs:33:29
    |
 LL |     static_priv_by_default::j;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                             ^
 
 error[E0603]: function `k` is private
-  --> $DIR/xcrate-private-by-default.rs:35:5
+  --> $DIR/xcrate-private-by-default.rs:35:29
    |
 LL |     static_priv_by_default::k;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                             ^
 
 error[E0603]: unit struct `l` is private
-  --> $DIR/xcrate-private-by-default.rs:37:5
+  --> $DIR/xcrate-private-by-default.rs:37:29
    |
 LL |     static_priv_by_default::l;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                             ^
 
 error[E0603]: enum `m` is private
-  --> $DIR/xcrate-private-by-default.rs:39:11
+  --> $DIR/xcrate-private-by-default.rs:39:35
    |
 LL |     foo::<static_priv_by_default::m>();
-   |           ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                   ^
 
 error[E0603]: type alias `n` is private
-  --> $DIR/xcrate-private-by-default.rs:41:11
+  --> $DIR/xcrate-private-by-default.rs:41:35
    |
 LL |     foo::<static_priv_by_default::n>();
-   |           ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                   ^
 
 error[E0603]: module `foo` is private
-  --> $DIR/xcrate-private-by-default.rs:45:5
+  --> $DIR/xcrate-private-by-default.rs:45:29
    |
 LL |     static_priv_by_default::foo::a;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                             ^^^
 
 error[E0603]: module `foo` is private
-  --> $DIR/xcrate-private-by-default.rs:47:5
+  --> $DIR/xcrate-private-by-default.rs:47:29
    |
 LL |     static_priv_by_default::foo::b;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                             ^^^
 
 error[E0603]: module `foo` is private
-  --> $DIR/xcrate-private-by-default.rs:49:5
+  --> $DIR/xcrate-private-by-default.rs:49:29
    |
 LL |     static_priv_by_default::foo::c;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                             ^^^
 
 error[E0603]: module `foo` is private
-  --> $DIR/xcrate-private-by-default.rs:51:11
+  --> $DIR/xcrate-private-by-default.rs:51:35
    |
 LL |     foo::<static_priv_by_default::foo::d>();
-   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                   ^^^
 
 error[E0603]: module `foo` is private
-  --> $DIR/xcrate-private-by-default.rs:53:11
+  --> $DIR/xcrate-private-by-default.rs:53:35
    |
 LL |     foo::<static_priv_by_default::foo::e>();
-   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                   ^^^
 
 error: aborting due to 10 previous errors
 


### PR DESCRIPTION
Reimplementation of uniform paths using in-scope resolution rather than canaries is a minor breaking change due to stricter future-proofing, so it needs to be landed before beta or backported later.

I hope to implement at least something until beta so we have less to backport.
r? @Mark-Simulacrum 