### PR TITLE
ci: Move global credentials to web configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -197,23 +197,10 @@ matrix:
         . src/ci/docker/x86_64-gnu-tools/repo.sh;
         commit_toolstate_change "$MESSAGE_FILE" "$TRAVIS_BUILD_DIR/src/tools/publish_toolstate.py" "$(git rev-parse HEAD)" "$(git log --format=%s -n1 HEAD)" "$MESSAGE_FILE" "$TOOLSTATE_REPO_ACCESS_TOKEN";
 
-env:
-  global:
-    - SCCACHE_BUCKET=rust-lang-ci-sccache2
-    - SCCACHE_REGION=us-west-1
-    - AWS_ACCESS_KEY_ID=AKIAJAMV3QAMMA6AXHFQ
-    # AWS_SECRET_ACCESS_KEY=...
-    - secure: "j96XxTVOSUf4s4r4htIxn/fvIa5DWbMgLqWl7r8z2QfgUwscmkMXAwXuFNc7s7bGTpV/+CgDiMFFM6BAFLGKutytIF6oA02s9b+usQYnM0th7YQ2AIgm9GtMTJCJp4AoyfFmh8F2faUICBZlfVLUJ34udHEe35vOklix+0k4WDo="
-    # TOOLSTATE_REPO_ACCESS_TOKEN=...
-    - secure: "ESfcXqv4N2VMhqi2iIyw6da9VrsA78I4iR1asouCaq4hzTTrkB4WNRrfURy6xg72gQ4nMhtRJbB0/2jmc9Cu1+g2CzXtyiL223aJ5CKrXdcvbitopQSDfp07dMWm+UED+hNFEanpErKAeU/6FM3A+J+60PMk8MCF1h9tqNRISJw="
-
 before_install:
-  # We'll use the AWS cli to download/upload cached docker layers, so install
-  # that here.
-  - if [ "$TRAVIS_OS_NAME" = linux ]; then
-      pip install --user awscli;
-      export PATH=$PATH:$HOME/.local/bin;
-    fi
+  # We'll use the AWS cli to download/upload cached docker layers as well as
+  # push our deployments, so download that here.
+  - pip install --user awscli; export PATH=$PATH:$HOME/.local/bin
   - mkdir -p $HOME/rustsrc
   # FIXME(#46924): these two commands are required to enable IPv6,
   # they shouldn't exist, please revert once more official solutions appeared.
@@ -276,6 +263,23 @@ after_success:
       echo "#### Build successful; Disk usage after running script:";
       df -h;
       du . | sort -nr | head -n100
+  - >
+      if [ "$DEPLOY$DEPLOY_ALT" == "1" ]; then
+        mkdir -p deploy/$TRAVIS_COMMIT;
+        if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+            rm -rf build/dist/doc &&
+            cp -r build/dist/* deploy/$TRAVIS_COMMIT;
+        else
+            rm -rf obj/build/dist/doc &&
+            cp -r obj/build/dist/* deploy/$TRAVIS_COMMIT;
+        fi;
+        ls -la deploy/$TRAVIS_COMMIT;
+        deploy_dir=rustc-builds;
+        if [ "$DEPLOY_ALT" == "1" ]; then
+            deploy_dir=rustc-builds-alt;
+        fi;
+        travis_retry aws s3 cp --no-progress --recursive --acl public-read ./deploy s3://rust-lang-ci2/$deploy_dir
+      fi
 
 after_failure:
   - >
@@ -322,77 +326,3 @@ after_failure:
 
 notifications:
   email: false
-
-before_deploy:
-  - mkdir -p deploy/$TRAVIS_COMMIT
-  - >
-      if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-          rm -rf build/dist/doc &&
-          cp -r build/dist/* deploy/$TRAVIS_COMMIT;
-      else
-          rm -rf obj/build/dist/doc &&
-          cp -r obj/build/dist/* deploy/$TRAVIS_COMMIT;
-      fi
-  - ls -la deploy/$TRAVIS_COMMIT
-
-deploy:
-  - provider: s3
-    bucket: rust-lang-ci2
-    skip_cleanup: true
-    local_dir: deploy
-    upload_dir: rustc-builds
-    acl: public_read
-    region: us-west-1
-    access_key_id: AKIAJVBODR3IA4O72THQ
-    secret_access_key:
-      secure: "kUGd3t7JcVWFESgIlzvsM8viZgCA9Encs3creW0xLJaLSeI1iVjlJK4h/2/nO6y224AFrh/GUfsNr4/4AlxPuYb8OU5oC5Lv+Ff2JiRDYtuNpyQSKAQp+bRYytWMtrmhja91h118Mbm90cUfcLPwkdiINgJNTXhPKg5Cqu3VYn0="
-    on:
-      branch: auto
-      condition: $DEPLOY = 1
-
-  # this is the same as the above deployment provider except that it uploads to
-  # a slightly different directory and has a different trigger
-  - provider: s3
-    bucket: rust-lang-ci2
-    skip_cleanup: true
-    local_dir: deploy
-    upload_dir: rustc-builds-alt
-    acl: public_read
-    region: us-west-1
-    access_key_id: AKIAJVBODR3IA4O72THQ
-    secret_access_key:
-      secure: "kUGd3t7JcVWFESgIlzvsM8viZgCA9Encs3creW0xLJaLSeI1iVjlJK4h/2/nO6y224AFrh/GUfsNr4/4AlxPuYb8OU5oC5Lv+Ff2JiRDYtuNpyQSKAQp+bRYytWMtrmhja91h118Mbm90cUfcLPwkdiINgJNTXhPKg5Cqu3VYn0="
-    on:
-      branch: auto
-      condition: $DEPLOY_ALT = 1
-
-  # These two providers are the same as the two above, except deploy on the
-  # try branch. Travis does not appear to provide a way to use "or" in these
-  # conditions.
-  - provider: s3
-    bucket: rust-lang-ci2
-    skip_cleanup: true
-    local_dir: deploy
-    upload_dir: rustc-builds
-    acl: public_read
-    region: us-west-1
-    access_key_id: AKIAJVBODR3IA4O72THQ
-    secret_access_key:
-      secure: "kUGd3t7JcVWFESgIlzvsM8viZgCA9Encs3creW0xLJaLSeI1iVjlJK4h/2/nO6y224AFrh/GUfsNr4/4AlxPuYb8OU5oC5Lv+Ff2JiRDYtuNpyQSKAQp+bRYytWMtrmhja91h118Mbm90cUfcLPwkdiINgJNTXhPKg5Cqu3VYn0="
-    on:
-      branch: try
-      condition: $DEPLOY = 1
-
-  - provider: s3
-    bucket: rust-lang-ci2
-    skip_cleanup: true
-    local_dir: deploy
-    upload_dir: rustc-builds-alt
-    acl: public_read
-    region: us-west-1
-    access_key_id: AKIAJVBODR3IA4O72THQ
-    secret_access_key:
-      secure: "kUGd3t7JcVWFESgIlzvsM8viZgCA9Encs3creW0xLJaLSeI1iVjlJK4h/2/nO6y224AFrh/GUfsNr4/4AlxPuYb8OU5oC5Lv+Ff2JiRDYtuNpyQSKAQp+bRYytWMtrmhja91h118Mbm90cUfcLPwkdiINgJNTXhPKg5Cqu3VYn0="
-    on:
-      branch: try
-      condition: $DEPLOY_ALT = 1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,12 +1,5 @@
 environment:
-  SCCACHE_BUCKET: rust-lang-ci-sccache2
-  SCCACHE_REGION: us-west-1
-  AWS_ACCESS_KEY_ID: AKIAJAMV3QAMMA6AXHFQ
-  AWS_SECRET_ACCESS_KEY:
-    secure: 7Y+JiquYedOAgnUU26uL0DPzrxmTtR+qIwG6rNKSuWDffqU3vVZxbGXim9QpTO80
   SCCACHE_DIGEST: f808afabb4a4eb1d7112bcb3fa6be03b61e93412890c88e177c667eb37f46353d7ec294e559b16f9f4b5e894f2185fe7670a0df15fd064889ecbd80f0c34166c
-  TOOLSTATE_REPO_ACCESS_TOKEN:
-    secure: gKGlVktr7iuqCoYSxHxDE9ltLOKU0nYDEuQxvWbNxUIW7ri5ppn8L06jQzN0GGzN
 
   # By default schannel checks revocation of certificates unlike some other SSL
   # backends, but we've historically had problems on CI where a revocation
@@ -235,10 +228,8 @@ before_deploy:
 
 deploy:
   - provider: S3
-    skip_cleanup: true
-    access_key_id: AKIAJVBODR3IA4O72THQ
-    secret_access_key:
-      secure: tQWIE+DJHjXaV4np/3YeETkEmXngtIuIgAO/LYKQaUshGLgN8cBCFGG3cHx5lKLt
+    access_key_id: $(AWS_ACCESS_KEY_ID)
+    secret_access_key: $(AWS_SECRET_ACCESS_KEY)
     bucket: rust-lang-ci2
     set_public: true
     region: us-west-1
@@ -252,10 +243,8 @@ deploy:
   # This provider is the same as the one above except that it has a slightly
   # different upload directory and a slightly different trigger
   - provider: S3
-    skip_cleanup: true
-    access_key_id: AKIAJVBODR3IA4O72THQ
-    secret_access_key:
-      secure: tQWIE+DJHjXaV4np/3YeETkEmXngtIuIgAO/LYKQaUshGLgN8cBCFGG3cHx5lKLt
+    access_key_id: $(AWS_ACCESS_KEY_ID)
+    secret_access_key: $(AWS_SECRET_ACCESS_KEY)
     bucket: rust-lang-ci2
     set_public: true
     region: us-west-1


### PR DESCRIPTION
This commit moves a number of our encrypted credentials stored in
configuration files in this repository to env vars on the web UI. This
will hopefully make it easier to rotate credentials in the future as
well as quickly change them if the need arises. (quicker than landing a
PR that is).

This also updates the travis deployment process to always use the `aws`
command line tool which we're already installing on Linux and should
enable us to avoid all `dpl` gem issues as well as have greater control
over what's going where.