### PR TITLE
Regression test for #54478.

### DIFF
--- a/src/test/rustdoc/issue-54478-demo-allocator.rs
+++ b/src/test/rustdoc/issue-54478-demo-allocator.rs
@@ -1,0 +1,42 @@
+// Issue #54478: regression test showing that we can demonstrate
+// `#[global_allocator]` in code blocks built by `rustdoc`.
+//
+// ## Background
+//
+// Changes in lang-item visibility injected failures that were only
+// exposed when compiling with `-C prefer-dynamic`. But `rustdoc` used
+// `-C prefer-dynamic` (and had done so for years, for reasons we did
+// not document at that time).
+//
+// Rather than try to revise the visbility semanics, we instead
+// decided to change `rustdoc` to behave more like the compiler's
+// default setting, by leaving off `-C prefer-dynamic`.
+
+// compile-flags:--test
+
+//! This is a doc comment
+//!
+//! ```rust
+//! use std::alloc::*;
+//!
+//! #[global_allocator]
+//! static ALLOC: A = A;
+//!
+//! static mut HIT: bool = false;
+//!
+//! struct A;
+//!
+//! unsafe impl GlobalAlloc for A {
+//!     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+//!         HIT = true;
+//!         System.alloc(layout)
+//!     }
+//!     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+//!         System.dealloc(ptr, layout);
+//!     }
+//! }
+//!
+//! fn main() {
+//!     assert!(unsafe { HIT });
+//! }
+//! ```


### PR DESCRIPTION
This is a regression test for #54478.

I confirmed that it fails on:
rustdoc 1.30.0-beta.12 (96a229824 2018-10-04)
and passes on:
rustdoc 1.31.0-nightly (f99911a4a 2018-10-23)

Fix #54478 
