### PR TITLE
rustbuild: fix remap-debuginfo when building a release

### DIFF
--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -765,7 +765,7 @@ impl Build {
 
         let path = match which {
             GitRepo::Rustc => {
-                let sha = self.rust_info.sha().expect("failed to find sha");
+                let sha = self.rust_sha().unwrap_or(channel::CFG_RELEASE_NUM);
                 format!("/rustc/{}", sha)
             }
             GitRepo::Llvm => format!("/rustc/llvm"),


### PR DESCRIPTION
Fallback to the release number as we can't get the git commit sha as we're not in a git repository.

Fixes #55341 