### PR TITLE
Remove is_null

### DIFF
--- a/src/librustc/mir/interpret/value.rs
+++ b/src/librustc/mir/interpret/value.rs
@@ -181,19 +181,11 @@ impl<'tcx, Tag> Scalar<Tag> {
     #[inline]
     pub fn is_null_ptr(self, cx: impl HasDataLayout) -> bool {
         match self {
-            Scalar::Bits { bits, size } =>  {
+            Scalar::Bits { bits, size } => {
                 assert_eq!(size as u64, cx.data_layout().pointer_size.bytes());
                 bits == 0
             },
             Scalar::Ptr(_) => false,
-        }
-    }
-
-    #[inline]
-    pub fn is_null(self) -> bool {
-        match self {
-            Scalar::Bits { bits, .. } => bits == 0,
-            Scalar::Ptr(_) => false
         }
     }
 


### PR DESCRIPTION
It was confusingly named (`is_zero` would have been better, as someone pointed out somewhere but I forgot who or where), and it didn't even reliably test for "is this value 0 at run-time" because out-of-bounds pointers *can* be 0.

It's not used in rustc, and miri only really needs `is_null_ptr` and `to_bytes() == 0`, so let's just kill this method.

r? @oli-obk 