### PR TITLE
Add Iterator::single

### DIFF
--- a/src/libcore/iter/iterator.rs
+++ b/src/libcore/iter/iterator.rs
@@ -1898,10 +1898,15 @@ pub trait Iterator {
     /// ```rust
     /// #![feature(iterator_single)]
     ///
-    /// assert_eq!(&[].iter().single(), None);
-    /// assert_eq!(&[42].iter().single(), Some(42));
-    /// assert_eq!(&[42, 24].iter().single(), None);
-    /// assert_eq!(&[42, 24, 0].iter().single(), None);
+    /// let zero: [u8; 0] = [];
+    /// let one: [u8; 1] = [42];
+    /// let two: [u8; 2] = [42, 24];
+    /// let three: [u8; 3] = [42, 24, 0];
+    ///
+    /// assert_eq!(zero.iter().single(), None);
+    /// assert_eq!(one.iter().single(), Some(42));
+    /// assert_eq!(two.iter().single(), None);
+    /// assert_eq!(three.iter().single(), None);
     /// ```
     ///
     /// # Invariants

--- a/src/libcore/iter/iterator.rs
+++ b/src/libcore/iter/iterator.rs
@@ -1875,6 +1875,50 @@ pub trait Iterator {
         }).break_value()
     }
 
+    /// Extracts the single remaining element out of the iterator.
+    ///
+    /// [`next()`]: #method.next
+    /// [`by_ref()`]: #method.by_ref
+    /// [`Some(x)`]: ../../std/option/enum.Option.html#variant.Some
+    /// [`None`]: ../../std/option/enum.Option.html#variant.None
+    ///
+    /// If [`next()`] will return [`Some(x)`] the first time, and then return
+    /// [`None`] the next time around, then `single()` will return `Some(x)`.
+    /// If there are no elements to extract or if there more than one,
+    /// then the iterator will will return `None`.
+    ///
+    /// This method takes ownership of the iterator it is called on.
+    /// If you want to retain ownership, call [`by_ref()`] on the iterator
+    /// first before calling `single()`.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```rust
+    /// #![feature(iterator_single)]
+    ///
+    /// assert_eq!(&[].iter().single(), None);
+    /// assert_eq!(&[42].iter().single(), Some(42));
+    /// assert_eq!(&[42, 24].iter().single(), None);
+    /// assert_eq!(&[42, 24, 0].iter().single(), None);
+    /// ```
+    ///
+    /// # Invariants
+    ///
+    /// If `count()` does not panic and returns `1`, then `single()` will
+    /// return `Some(element)`. Otherwise, `single()` will return `None`.
+    #[inline]
+    #[unstable(feature = "iterator_single", issue = "55354")]
+    fn single(mut self) -> Option<Self::Item> where Self: Sized {
+        if let x@Some(_) = self.next() {
+            if let None = self.next() {
+                return x
+            }
+        }
+        None
+    }
+
     /// Searches for an element in an iterator, returning its index.
     ///
     /// `position()` takes a closure that returns `true` or `false`. It applies

--- a/src/libcore/iter/iterator.rs
+++ b/src/libcore/iter/iterator.rs
@@ -1904,7 +1904,7 @@ pub trait Iterator {
     /// let three: [u8; 3] = [42, 24, 0];
     ///
     /// assert_eq!(zero.iter().single(), None);
-    /// assert_eq!(one.iter().single(), Some(42));
+    /// assert_eq!(one.iter().single(), Some(&42));
     /// assert_eq!(two.iter().single(), None);
     /// assert_eq!(three.iter().single(), None);
     /// ```


### PR DESCRIPTION
Tracking issue: https://github.com/rust-lang/rust/issues/55354

Suggested and discussed in https://internals.rust-lang.org/t/what-do-you-think-about-iterator-single/8608.

## Alternatives

### Designs

Alternative designs could use a dedicated enum:
```rust
enum IteratorSingleError<T> {
    MoreThanOneItem(T),
    EmptyIterator,
}
```
but I think the common case doesn't need that.
This addition is also cheaper complexity wise this way.

### Bikeshed

- singleton
- one

I picked `single` since it strikes a balance between brevity and clarity.

r? @alexcrichton 