### PR TITLE
Check for negative impls when finding auto traits

### DIFF
--- a/src/librustc/traits/auto_trait.rs
+++ b/src/librustc/traits/auto_trait.rs
@@ -339,7 +339,7 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
             match &result {
                 &Ok(Some(ref vtable)) => {
                     // If we see an explicit negative impl (e.g. 'impl !Send for MyStruct'),
-                    // we immediately bail out, since it's impossible for us to continue'
+                    // we immediately bail out, since it's impossible for us to continue.
                     match vtable {
                         Vtable::VtableImpl(VtableImplData { impl_def_id, .. }) => {
                             // Blame tidy for the weird bracket placement

--- a/src/librustc/traits/auto_trait.rs
+++ b/src/librustc/traits/auto_trait.rs
@@ -342,7 +342,9 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
                     // we immediately bail out, since it's impossible for us to continue'
                     match vtable {
                         Vtable::VtableImpl(VtableImplData { impl_def_id, .. }) => {
-                            if infcx.tcx.impl_polarity(*impl_def_id) == hir::ImplPolarity::Negative {
+                            // Blame tidy for the weird bracket placement
+                            if infcx.tcx.impl_polarity(*impl_def_id) == hir::ImplPolarity::Negative
+                            {
                                 debug!("evaluate_nested_obligations: Found explicit negative impl\
                                         {:?}, bailing out", impl_def_id);
                                 return None;

--- a/src/librustc/traits/auto_trait.rs
+++ b/src/librustc/traits/auto_trait.rs
@@ -309,7 +309,7 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
     ) -> Option<(ty::ParamEnv<'c>, ty::ParamEnv<'c>)> {
         let tcx = infcx.tcx;
 
-        let mut select = SelectionContext::new(&infcx);
+        let mut select = SelectionContext::with_negative(&infcx, true);
 
         let mut already_visited = FxHashSet::default();
         let mut predicates = VecDeque::new();
@@ -338,6 +338,19 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
 
             match &result {
                 &Ok(Some(ref vtable)) => {
+                    // If we see an explicit negative impl (e.g. 'impl !Send for MyStruct'),
+                    // we immediately bail out, since it's impossible for us to continue'
+                    match vtable {
+                        Vtable::VtableImpl(VtableImplData { impl_def_id, .. }) => {
+                            if infcx.tcx.impl_polarity(*impl_def_id) == hir::ImplPolarity::Negative {
+                                debug!("evaluate_nested_obligations: Found explicit negative impl\
+                                        {:?}, bailing out", impl_def_id);
+                                return None;
+                            }
+                        },
+                        _ => {}
+                    }
+
                     let obligations = vtable.clone().nested_obligations().into_iter();
 
                     if !self.evaluate_nested_obligations(

--- a/src/test/rustdoc/issue-55321.rs
+++ b/src/test/rustdoc/issue-55321.rs
@@ -1,0 +1,27 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+#![feature(optin_builtin_traits)]
+
+// @has issue_55321/struct.A.html
+// @has - '//*[@id="implementations-list"]/*[@class="impl"]//*/code' "impl !Send for A"
+// @has - '//*[@id="implementations-list"]/*[@class="impl"]//*/code' "impl !Sync for A"
+pub struct A();
+
+impl !Send for A {}
+impl !Sync for A {}
+
+// @has issue_55321/struct.B.html
+// @has - '//*[@id="synthetic-implementations-list"]/*[@class="impl"]//*/code' "impl<T> !Send for \
+// B<T>"
+// @has - '//*[@id="synthetic-implementations-list"]/*[@class="impl"]//*/code' "impl<T> !Sync for \
+// B<T>"
+pub struct B<T: ?Sized>(A, Box<T>);


### PR DESCRIPTION
Fixes #55321

When AutoTraitFinder begins examining a type, it checks for an explicit
negative impl. However, it wasn't checking for negative impls found when
calling 'select' on predicates found from nested obligations.

This commit makes AutoTraitFinder check for negative impls whenever it
makes a call to 'select'. If a negative impl is found, it immediately
bails out.

Normal users of SelectioContext don't need to worry about this, since
they stop as soon as an Unimplemented error is encountered. However, we
add predicates to our ParamEnv when we encounter this error, so we need
to handle negative impls specially (so that we don't try adding them to
our ParamEnv).