### PR TITLE
Fixes #46775 -- don't mutate the process's environment in Command::exec

### DIFF
--- a/src/libstd/sys/unix/process/process_common.rs
+++ b/src/libstd/sys/unix/process/process_common.rs
@@ -141,6 +141,10 @@ impl Command {
     pub fn get_argv(&self) -> &Vec<*const c_char> {
         &self.argv.0
     }
+    #[cfg(not(target_os = "fuchsia"))]
+    pub fn get_program(&self) -> &CString {
+        return &self.program;
+    }
 
     #[allow(dead_code)]
     pub fn get_cwd(&self) -> &Option<CString> {
@@ -243,6 +247,10 @@ impl CStringArray {
     }
     pub fn as_ptr(&self) -> *const *const c_char {
         self.ptrs.as_ptr()
+    }
+    #[cfg(not(target_os = "fuchsia"))]
+    pub fn get_items(&self) -> &[CString] {
+        return &self.items;
     }
 }
 

--- a/src/test/run-pass/command-exec.rs
+++ b/src/test/run-pass/command-exec.rs
@@ -48,6 +48,13 @@ fn main() {
                 println!("passed");
             }
 
+            "exec-test5" => {
+                env::set_var("VARIABLE", "ABC");
+                Command::new("definitely-not-a-real-binary").env("VARIABLE", "XYZ").exec();
+                assert_eq!(env::var("VARIABLE").unwrap(), "ABC");
+                println!("passed");
+            }
+
             _ => panic!("unknown argument: {}", arg),
         }
         return
@@ -69,6 +76,11 @@ fn main() {
     assert_eq!(output.stdout, b"passed\n");
 
     let output = Command::new(&me).arg("exec-test4").output().unwrap();
+    assert!(output.status.success());
+    assert!(output.stderr.is_empty());
+    assert_eq!(output.stdout, b"passed\n");
+
+    let output = Command::new(&me).arg("exec-test5").output().unwrap();
     assert!(output.status.success());
     assert!(output.stderr.is_empty());
     assert_eq!(output.stdout, b"passed\n");


### PR DESCRIPTION
Instead, pass the environment to execvpe, so the kernel can apply it directly to the new process. This avoids a use-after-free in the case where exec'ing the new process fails for any reason, as well as a race condition if there are other threads alive during the exec.

Fixes #46775