### PR TITLE
Bump cargo-vendor version

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -911,7 +911,7 @@ impl Step for Src {
     }
 }
 
-const CARGO_VENDOR_VERSION: &str = "0.1.4";
+const CARGO_VENDOR_VERSION: &str = "0.1.19";
 
 #[derive(Debug, PartialOrd, Ord, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct PlainSourceTarball;


### PR DESCRIPTION
Currently we pin `cargo-vendor` to 0.1.4, which doesn't set the `User-Agent` HTTP header. crates.io is going to require that header in the near future, so this PR bumps the pinned version of the crate to the latest one (which correctly sets the header).

r? @Mark-Simulacrum 
cc @sgrif