### PR TITLE
Remove unnecessary mut in iterator.find_map documentation example, R…

### DIFF
--- a/src/libcore/iter/iterator.rs
+++ b/src/libcore/iter/iterator.rs
@@ -1857,7 +1857,7 @@ pub trait Iterator {
     /// ```
     /// let a = ["lol", "NaN", "2", "5"];
     ///
-    /// let mut first_number = a.iter().find_map(|s| s.parse().ok());
+    /// let first_number = a.iter().find_map(|s| s.parse().ok());
     ///
     /// assert_eq!(first_number, Some(2));
     /// ```


### PR DESCRIPTION
Relates to #49098

Removes a mut that could induce newcomers to put a mut in their code that the compiler would comply about.

https://github.com/rust-lang/rust/pull/49098/files#r227422388