### PR TITLE
Get rid of `ConstValue::ScalarPair`

### DIFF
--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -313,6 +313,7 @@ impl_stable_hash_for!(
     impl<'tcx> for enum mir::interpret::ConstValue<'tcx> [ mir::interpret::ConstValue ] {
         Unevaluated(def_id, substs),
         Scalar(val),
+        Slice(id, alloc),
         ByRef(id, alloc, offset),
     }
 );

--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -313,7 +313,6 @@ impl_stable_hash_for!(
     impl<'tcx> for enum mir::interpret::ConstValue<'tcx> [ mir::interpret::ConstValue ] {
         Unevaluated(def_id, substs),
         Scalar(val),
-        ScalarPair(a, b),
         ByRef(id, alloc, offset),
     }
 );

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -15,7 +15,7 @@
 use hir::def::CtorKind;
 use hir::def_id::DefId;
 use hir::{self, HirId, InlineAsm};
-use mir::interpret::{ConstValue, EvalErrorKind, Scalar, Pointer, EvalResult};
+use mir::interpret::{ConstValue, EvalErrorKind, Scalar};
 use mir::visit::MirVisitable;
 use rustc_apfloat::ieee::{Double, Single};
 use rustc_apfloat::Float;
@@ -39,7 +39,7 @@ use syntax_pos::{Span, DUMMY_SP};
 use ty::fold::{TypeFoldable, TypeFolder, TypeVisitor};
 use ty::subst::{CanonicalUserSubsts, Subst, Substs};
 use ty::{self, AdtDef, CanonicalTy, ClosureSubsts, GeneratorSubsts, Region, Ty, TyCtxt};
-use ty::layout::{VariantIdx, Size};
+use ty::layout::VariantIdx;
 use util::ppaux;
 
 pub use mir::interpret::AssertMessage;
@@ -2623,29 +2623,12 @@ pub fn fmt_const_val(f: &mut impl Write, const_val: &ty::Const<'_>) -> fmt::Resu
         return write!(f, "{}", item_path_str(did));
     }
     // print string literals
-    if let ConstValue::ByRef(alloc_id, alloc, offset) = value {
+    if let ConstValue::Slice(_, alloc) = value {
         if let Ref(_, &ty::TyS { sty: Str, .. }, _) = ty.sty {
-            return ty::tls::with(|tcx| {
-                let mut dummy = || -> EvalResult<'_, _> {
-                    let ptr = Pointer::new(alloc_id, offset);
-                    let slice_ptr = alloc.read_ptr(&tcx, ptr)?;
-                    let ptr = ptr.offset(tcx.data_layout.pointer_size, &tcx)?;
-                    let len = alloc.read_usize(&tcx, ptr)?;
-                    let alloc = tcx.alloc_map.lock().get(slice_ptr.alloc_id);
-                    if let Some(interpret::AllocType::Memory(alloc)) = alloc {
-                        let slice = alloc.get_bytes(&tcx, slice_ptr, Size::from_bytes(len))?;
-                        let s = ::std::str::from_utf8(slice)
-                            .map_err(|err| EvalErrorKind::ValidationFailure(err.to_string()))?;
-                        Ok(write!(f, "{:?}", s))
-                    } else {
-                        Ok(write!(f, "broken str slice: {:?}", alloc))
-                    }
-                };
-                match dummy() {
-                    Ok(res) => res,
-                    Err(err) => write!(f, "broken str constant: {:?}", err),
-                }
-            });
+            return match ::std::str::from_utf8(&alloc.bytes) {
+                Ok(s) => write!(f, "{:?}", s),
+                Err(_) => write!(f, "broken str slice: {:?}", alloc),
+            }
         }
     }
     // just raw dump everything else

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -1053,11 +1053,11 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
     }
 
     /// Allocates a byte or string literal for `mir::interpret`, read-only
-    pub fn allocate_bytes(self, bytes: &[u8]) -> interpret::AllocId {
+    pub fn allocate_bytes(self, bytes: &[u8]) -> (interpret::AllocId, &'tcx Allocation) {
         // create an allocation that just contains these bytes
         let alloc = interpret::Allocation::from_byte_aligned_bytes(bytes, ());
         let alloc = self.intern_const_alloc(alloc);
-        self.alloc_map.lock().allocate(alloc)
+        (self.alloc_map.lock().allocate(alloc), alloc)
     }
 
     pub fn intern_stability(self, stab: attr::Stability) -> &'gcx attr::Stability {

--- a/src/librustc/ty/structural_impls.rs
+++ b/src/librustc/ty/structural_impls.rs
@@ -1032,7 +1032,6 @@ impl<'tcx> TypeFoldable<'tcx> for ConstValue<'tcx> {
     fn super_fold_with<'gcx: 'tcx, F: TypeFolder<'gcx, 'tcx>>(&self, folder: &mut F) -> Self {
         match *self {
             ConstValue::Scalar(v) => ConstValue::Scalar(v),
-            ConstValue::ScalarPair(a, b) => ConstValue::ScalarPair(a, b),
             ConstValue::ByRef(id, alloc, offset) => ConstValue::ByRef(id, alloc, offset),
             ConstValue::Unevaluated(def_id, substs) => {
                 ConstValue::Unevaluated(def_id, substs.fold_with(folder))
@@ -1043,7 +1042,6 @@ impl<'tcx> TypeFoldable<'tcx> for ConstValue<'tcx> {
     fn super_visit_with<V: TypeVisitor<'tcx>>(&self, visitor: &mut V) -> bool {
         match *self {
             ConstValue::Scalar(_) |
-            ConstValue::ScalarPair(_, _) |
             ConstValue::ByRef(_, _, _) => false,
             ConstValue::Unevaluated(_, substs) => substs.visit_with(visitor),
         }

--- a/src/librustc/ty/structural_impls.rs
+++ b/src/librustc/ty/structural_impls.rs
@@ -1033,6 +1033,7 @@ impl<'tcx> TypeFoldable<'tcx> for ConstValue<'tcx> {
         match *self {
             ConstValue::Scalar(v) => ConstValue::Scalar(v),
             ConstValue::ByRef(id, alloc, offset) => ConstValue::ByRef(id, alloc, offset),
+            ConstValue::Slice(id, alloc) => ConstValue::Slice(id, alloc),
             ConstValue::Unevaluated(def_id, substs) => {
                 ConstValue::Unevaluated(def_id, substs.fold_with(folder))
             }
@@ -1042,6 +1043,7 @@ impl<'tcx> TypeFoldable<'tcx> for ConstValue<'tcx> {
     fn super_visit_with<V: TypeVisitor<'tcx>>(&self, visitor: &mut V) -> bool {
         match *self {
             ConstValue::Scalar(_) |
+            ConstValue::Slice(..) |
             ConstValue::ByRef(_, _, _) => false,
             ConstValue::Unevaluated(_, substs) => substs.visit_with(visitor),
         }

--- a/src/librustc_codegen_ssa/mir/operand.rs
+++ b/src/librustc_codegen_ssa/mir/operand.rs
@@ -99,23 +99,6 @@ impl<'a, 'tcx: 'a, V: CodegenObject> OperandRef<'tcx, V> {
                 );
                 OperandValue::Immediate(llval)
             },
-            ConstValue::ScalarPair(a, b) => {
-                let (a_scalar, b_scalar) = match layout.abi {
-                    layout::Abi::ScalarPair(ref a, ref b) => (a, b),
-                    _ => bug!("from_const: invalid ScalarPair layout: {:#?}", layout)
-                };
-                let a_llval = bx.cx().scalar_to_backend(
-                    a,
-                    a_scalar,
-                    bx.cx().scalar_pair_element_backend_type(layout, 0, true),
-                );
-                let b_llval = bx.cx().scalar_to_backend(
-                    b,
-                    b_scalar,
-                    bx.cx().scalar_pair_element_backend_type(layout, 1, true),
-                );
-                OperandValue::Pair(a_llval, b_llval)
-            },
             ConstValue::ByRef(_, alloc, offset) => {
                 return Ok(bx.load_operand(bx.cx().from_const_alloc(layout, alloc, offset)));
             },

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -164,7 +164,7 @@ pub fn const_to_op<'tcx>(
     ecx: &CompileTimeEvalContext<'_, '_, 'tcx>,
     cnst: &ty::Const<'tcx>,
 ) -> EvalResult<'tcx, OpTy<'tcx>> {
-    let op = ecx.const_value_to_op(cnst.val)?;
+    let op = ecx.const_value_to_op(cnst)?;
     Ok(OpTy { op, layout: ecx.layout_of(cnst.ty)? })
 }
 

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -143,7 +143,11 @@ pub fn op_to_const<'tcx>(
             ConstValue::Scalar(x.not_undef()?),
         Ok(Immediate::ScalarPair(a, b)) => {
             // create an allocation just for the fat pointer
-            let mut allocation = Allocation::undef(op.layout.size, op.layout.align.abi, Default::default());
+            let mut allocation = Allocation::undef(
+                op.layout.size,
+                op.layout.align.abi,
+                Default::default(),
+            );
             let alloc_id = ecx.tcx.alloc_map.lock().reserve();
             let ptr = Pointer::from(alloc_id);
             // write the fat pointer into the allocation

--- a/src/librustc_mir/hair/cx/mod.rs
+++ b/src/librustc_mir/hair/cx/mod.rs
@@ -165,12 +165,12 @@ impl<'a, 'gcx, 'tcx> Cx<'a, 'gcx, 'tcx> {
         let lit = match *lit {
             LitKind::Str(ref s, _) => {
                 let s = s.as_str();
-                let id = self.tcx.allocate_bytes(s.as_bytes());
-                ConstValue::new_slice(Scalar::Ptr(id.into()), s.len() as u64, self.tcx)
+                let (id, a) = self.tcx.allocate_bytes(s.as_bytes());
+                ConstValue::Slice(id, a)
             },
             LitKind::ByteStr(ref data) => {
-                let id = self.tcx.allocate_bytes(data);
-                ConstValue::Scalar(Scalar::Ptr(id.into()))
+                let (id, a) = self.tcx.allocate_bytes(data);
+                ConstValue::Slice(id, a)
             },
             LitKind::Byte(n) => ConstValue::Scalar(Scalar::Bits {
                 bits: n as u128,

--- a/src/librustc_mir/hair/cx/mod.rs
+++ b/src/librustc_mir/hair/cx/mod.rs
@@ -166,7 +166,7 @@ impl<'a, 'gcx, 'tcx> Cx<'a, 'gcx, 'tcx> {
             LitKind::Str(ref s, _) => {
                 let s = s.as_str();
                 let id = self.tcx.allocate_bytes(s.as_bytes());
-                ConstValue::new_slice(Scalar::Ptr(id.into()), s.len() as u64, &self.tcx)
+                ConstValue::new_slice(Scalar::Ptr(id.into()), s.len() as u64, self.tcx)
             },
             LitKind::ByteStr(ref data) => {
                 let id = self.tcx.allocate_bytes(data);

--- a/src/librustc_mir/hair/pattern/_match.rs
+++ b/src/librustc_mir/hair/pattern/_match.rs
@@ -179,10 +179,10 @@ use super::{PatternFoldable, PatternFolder, compare_const_vals};
 use rustc::hir::def_id::DefId;
 use rustc::hir::RangeEnd;
 use rustc::ty::{self, Ty, TyCtxt, TypeFoldable};
-use rustc::ty::layout::{Integer, IntegerExt, VariantIdx};
+use rustc::ty::layout::{Integer, IntegerExt, VariantIdx, Size};
 
 use rustc::mir::Field;
-use rustc::mir::interpret::ConstValue;
+use rustc::mir::interpret::{ConstValue, Scalar, Pointer};
 use rustc::util::common::ErrorReported;
 
 use syntax::attr::{SignedInt, UnsignedInt};
@@ -1387,21 +1387,27 @@ fn slice_pat_covered_by_constructor<'tcx>(
 ) -> Result<bool, ErrorReported> {
     let data: &[u8] = match *ctor {
         ConstantValue(const_val) => {
-            let val = match const_val.val {
-                ConstValue::Unevaluated(..) |
-                ConstValue::ByRef(..) => bug!("unexpected ConstValue: {:?}", const_val),
-                ConstValue::Scalar(val) | ConstValue::ScalarPair(val, _) => val,
+            let (ptr, len) = match const_val.val {
+                ConstValue::ByRef(alloc_id, alloc, offset) => {
+                    let ptr = Pointer::new(alloc_id, offset);
+                    let slice_ptr = alloc.read_ptr(&tcx, ptr).unwrap();
+                    let len_ptr = ptr.offset(tcx.data_layout.pointer_size, &tcx).unwrap();
+                    let len = alloc.read_usize(&tcx, len_ptr).unwrap();
+                    (slice_ptr, len)
+                }
+                ConstValue::Scalar(Scalar::Ptr(ptr)) => {
+                    match const_val.ty.builtin_deref(true).unwrap().ty.sty {
+                        ty::TyKind::Array(e, n) => {
+                            assert!(e == tcx.types.u8);
+                            (ptr, n.unwrap_usize(tcx))
+                        },
+                        _ => bug!("bad ConstValue type: {:#?}", const_val),
+                    }
+                },
+                _ => bug!("unexpected ConstValue: {:#?}", const_val),
             };
-            if let Ok(ptr) = val.to_ptr() {
-                let is_array_ptr = const_val.ty
-                    .builtin_deref(true)
-                    .and_then(|t| t.ty.builtin_index())
-                    .map_or(false, |t| t == tcx.types.u8);
-                assert!(is_array_ptr);
-                tcx.alloc_map.lock().unwrap_memory(ptr.alloc_id).bytes.as_ref()
-            } else {
-                bug!("unexpected non-ptr ConstantValue")
-            }
+            let len = Size::from_bytes(len);
+            tcx.alloc_map.lock().unwrap_memory(ptr.alloc_id).get_bytes(&tcx, ptr, len).unwrap()
         }
         _ => bug!()
     };

--- a/src/librustc_mir/interpret/memory.rs
+++ b/src/librustc_mir/interpret/memory.rs
@@ -124,7 +124,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> Memory<'a, 'mir, 'tcx, M> {
     }
 
     pub fn allocate_static_bytes(&mut self, bytes: &[u8]) -> Pointer {
-        Pointer::from(self.tcx.allocate_bytes(bytes))
+        Pointer::from(self.tcx.allocate_bytes(bytes).0)
     }
 
     pub fn allocate_with(

--- a/src/librustc_mir/interpret/operand.rs
+++ b/src/librustc_mir/interpret/operand.rs
@@ -568,11 +568,6 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
                     MemPlace::from_ptr(Pointer::new(id, offset), alloc.align)
                 ).with_default_tag())
             },
-            ConstValue::ScalarPair(a, b) =>
-                Ok(Operand::Immediate(Immediate::ScalarPair(
-                    a.into(),
-                    b.into(),
-                )).with_default_tag()),
             ConstValue::Scalar(x) =>
                 Ok(Operand::Immediate(Immediate::Scalar(x.into())).with_default_tag()),
         }

--- a/src/librustc_mir/monomorphize/collector.rs
+++ b/src/librustc_mir/monomorphize/collector.rs
@@ -1263,12 +1263,6 @@ fn collect_const<'a, 'tcx>(
     };
     match val {
         ConstValue::Unevaluated(..) => bug!("const eval yielded unevaluated const"),
-        ConstValue::ScalarPair(Scalar::Ptr(a), Scalar::Ptr(b)) => {
-            collect_miri(tcx, a.alloc_id, output);
-            collect_miri(tcx, b.alloc_id, output);
-        }
-        ConstValue::ScalarPair(_, Scalar::Ptr(ptr)) |
-        ConstValue::ScalarPair(Scalar::Ptr(ptr), _) |
         ConstValue::Scalar(Scalar::Ptr(ptr)) =>
             collect_miri(tcx, ptr.alloc_id, output),
         ConstValue::ByRef(_id, alloc, _offset) => {

--- a/src/librustc_mir/monomorphize/collector.rs
+++ b/src/librustc_mir/monomorphize/collector.rs
@@ -1265,11 +1265,12 @@ fn collect_const<'a, 'tcx>(
         ConstValue::Unevaluated(..) => bug!("const eval yielded unevaluated const"),
         ConstValue::Scalar(Scalar::Ptr(ptr)) =>
             collect_miri(tcx, ptr.alloc_id, output),
-        ConstValue::ByRef(_id, alloc, _offset) => {
+        ConstValue::Slice(_, alloc) |
+        ConstValue::ByRef(_, alloc, _) => {
             for &((), id) in alloc.relocations.values() {
                 collect_miri(tcx, id, output);
             }
         }
-        _ => {},
+        ConstValue::Scalar(Scalar::Bits { .. }) => {},
     }
 }


### PR DESCRIPTION
based on https://github.com/rust-lang/rust/pull/55293 (only the last commit is part of this PR)