### PR TITLE
WIP: Get rid of the `Immediate` optimization for locals in the miri engine

### DIFF
--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -32,7 +32,7 @@ use syntax::ast::Mutability;
 use syntax::source_map::{Span, DUMMY_SP};
 
 use interpret::{self,
-    PlaceTy, MemPlace, OpTy, Operand, Value, Pointer, Scalar, ConstValue,
+    PlaceTy, Place, OpTy, Operand, Value, Pointer, Scalar, ConstValue,
     EvalResult, EvalError, EvalErrorKind, GlobalId, EvalContext, StackPopCleanup,
     Allocation, AllocId, MemoryKind,
     snapshot, RefTracking,
@@ -118,12 +118,12 @@ pub fn op_to_const<'tcx>(
         ecx.try_read_value(op)?
     } else {
         match op.op {
-            Operand::Indirect(mplace) => Err(mplace),
+            Operand::Indirect(place) => Err(place),
             Operand::Immediate(val) => Ok(val)
         }
     };
     let val = match normalized_op {
-        Err(MemPlace { ptr, align, meta }) => {
+        Err(Place { ptr, align, meta }) => {
             // extract alloc-offset pair
             assert!(meta.is_none());
             let ptr = ptr.to_ptr()?;
@@ -639,7 +639,7 @@ pub fn const_eval_raw_provider<'a, 'tcx>(
     res.and_then(|op| {
         let normalize = tcx.is_static(def_id).is_none() && cid.promoted.is_none();
         if !normalize {
-            // Sanity check: These must always be a MemPlace
+            // Sanity check: These must always be a Place
             match op.op {
                 Operand::Indirect(_) => { /* all is good */ },
                 Operand::Immediate(_) => bug!("const eval gave us an Immediate"),

--- a/src/librustc_mir/interpret/cast.rs
+++ b/src/librustc_mir/interpret/cast.rs
@@ -52,7 +52,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
                     assert!(dest.layout.ty.is_unsafe_ptr());
                     // For the purpose of the "ptr tag hooks", treat this as creating
                     // a new, raw reference.
-                    let place = self.ref_to_mplace(src)?;
+                    let place = self.ref_to_place(src)?;
                     self.create_ref(place, None)?
                 } else {
                     *src
@@ -384,9 +384,9 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
                     if dst_field.layout.is_zst() {
                         continue;
                     }
-                    let src_field = match src.try_as_mplace() {
-                        Ok(mplace) => {
-                            let src_field = self.mplace_field(mplace, i as u64)?;
+                    let src_field = match src.try_as_place() {
+                        Ok(place) => {
+                            let src_field = self.place_field(place, i as u64)?;
                             src_field.into()
                         }
                         Err(..) => {

--- a/src/librustc_mir/interpret/intrinsics.rs
+++ b/src/librustc_mir/interpret/intrinsics.rs
@@ -184,17 +184,17 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
             assert!(args.len() == 1);
             // &(&'static str, &'static str, u32, u32)
             let ptr = self.read_value(args[0])?;
-            let place = self.ref_to_mplace(ptr)?;
+            let place = self.ref_to_place(ptr)?;
             let (msg, file, line, col) = (
-                self.mplace_field(place, 0)?,
-                self.mplace_field(place, 1)?,
-                self.mplace_field(place, 2)?,
-                self.mplace_field(place, 3)?,
+                self.place_field(place, 0)?,
+                self.place_field(place, 1)?,
+                self.place_field(place, 2)?,
+                self.place_field(place, 3)?,
             );
 
-            let msg_place = self.ref_to_mplace(self.read_value(msg.into())?)?;
+            let msg_place = self.ref_to_place(self.read_value(msg.into())?)?;
             let msg = Symbol::intern(self.read_str(msg_place)?);
-            let file_place = self.ref_to_mplace(self.read_value(file.into())?)?;
+            let file_place = self.ref_to_place(self.read_value(file.into())?)?;
             let file = Symbol::intern(self.read_str(file_place)?);
             let line = self.read_scalar(line.into())?.to_u32()?;
             let col = self.read_scalar(col.into())?.to_u32()?;
@@ -204,16 +204,16 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
             // &'static str, &(&'static str, u32, u32)
             let msg = args[0];
             let ptr = self.read_value(args[1])?;
-            let place = self.ref_to_mplace(ptr)?;
+            let place = self.ref_to_place(ptr)?;
             let (file, line, col) = (
-                self.mplace_field(place, 0)?,
-                self.mplace_field(place, 1)?,
-                self.mplace_field(place, 2)?,
+                self.place_field(place, 0)?,
+                self.place_field(place, 1)?,
+                self.place_field(place, 2)?,
             );
 
-            let msg_place = self.ref_to_mplace(self.read_value(msg.into())?)?;
+            let msg_place = self.ref_to_place(self.read_value(msg.into())?)?;
             let msg = Symbol::intern(self.read_str(msg_place)?);
-            let file_place = self.ref_to_mplace(self.read_value(file.into())?)?;
+            let file_place = self.ref_to_place(self.read_value(file.into())?)?;
             let file = Symbol::intern(self.read_str(file_place)?);
             let line = self.read_scalar(line.into())?.to_u32()?;
             let col = self.read_scalar(col.into())?.to_u32()?;

--- a/src/librustc_mir/interpret/mod.rs
+++ b/src/librustc_mir/interpret/mod.rs
@@ -30,7 +30,7 @@ pub use self::eval_context::{
     EvalContext, Frame, StackPopCleanup, LocalValue,
 };
 
-pub use self::place::{Place, PlaceTy, MemPlace, MPlaceTy};
+pub use self::place::{Place, PlaceTy};
 
 pub use self::memory::{Memory, MemoryKind};
 

--- a/src/librustc_mir/interpret/snapshot.rs
+++ b/src/librustc_mir/interpret/snapshot.rs
@@ -24,7 +24,7 @@ use syntax::ast::Mutability;
 use syntax::source_map::Span;
 
 use super::eval_context::{LocalValue, StackPopCleanup};
-use super::{Frame, Memory, Operand, MemPlace, Place, Value, ScalarMaybeUndef};
+use super::{Frame, Memory, Operand, Place, Value, ScalarMaybeUndef};
 use const_eval::CompileTimeInterpreter;
 
 #[derive(Default)]
@@ -205,37 +205,16 @@ impl_snapshot_for!(enum ScalarMaybeUndef {
     Undef,
 });
 
-impl_stable_hash_for!(struct ::interpret::MemPlace {
+impl_stable_hash_for!(struct ::interpret::Place {
     ptr,
     align,
     meta,
 });
-impl_snapshot_for!(struct MemPlace {
+impl_snapshot_for!(struct Place {
     ptr,
     meta,
     align -> *align, // just copy alignment verbatim
 });
-
-impl_stable_hash_for!(enum ::interpret::Place {
-    Ptr(mem_place),
-    Local { frame, local },
-});
-impl<'a, Ctx> Snapshot<'a, Ctx> for Place
-    where Ctx: SnapshotContext<'a>,
-{
-    type Item = Place<(), AllocIdSnapshot<'a>>;
-
-    fn snapshot(&self, ctx: &'a Ctx) -> Self::Item {
-        match self {
-            Place::Ptr(p) => Place::Ptr(p.snapshot(ctx)),
-
-            Place::Local{ frame, local } => Place::Local{
-                frame: *frame,
-                local: *local,
-            },
-        }
-    }
-}
 
 impl_stable_hash_for!(enum ::interpret::Value {
     Scalar(x),


### PR DESCRIPTION
r? @RalfJung 

let's see what perf says. @eddyb said even if it's an improvement now, it might be slow for evaluations when we have const generics (which are mostly immediate?)