### PR TITLE
Avoid directly catching BaseException in bootstrap configure script

### DIFF
--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -397,7 +397,7 @@ def is_number(value):
   try:
     float(value)
     return True
-  except:
+  except ValueError:
     return False
 
 # Here we walk through the constructed configuration we have from the parsed


### PR DESCRIPTION
It includes stuff like pressing CTRL+C, which likely isn't intended.