### PR TITLE
msp430: remove the whole Atomic* API

### DIFF
--- a/src/liballoc/collections/vec_deque.rs
+++ b/src/liballoc/collections/vec_deque.rs
@@ -36,6 +36,8 @@ use vec::Vec;
 
 const INITIAL_CAPACITY: usize = 7; // 2^3 - 1
 const MINIMUM_CAPACITY: usize = 1; // 2 - 1
+#[cfg(target_pointer_width = "16")]
+const MAXIMUM_ZST_CAPACITY: usize = 1 << (16 - 1); // Largest possible power of two
 #[cfg(target_pointer_width = "32")]
 const MAXIMUM_ZST_CAPACITY: usize = 1 << (32 - 1); // Largest possible power of two
 #[cfg(target_pointer_width = "64")]

--- a/src/librustc_target/spec/msp430_none_elf.rs
+++ b/src/librustc_target/spec/msp430_none_elf.rs
@@ -35,9 +35,14 @@ pub fn target() -> TargetResult {
             no_integrated_as: true,
 
             // There are no atomic CAS instructions available in the MSP430
-            // instruction set
-            max_atomic_width: Some(16),
+            // instruction set, and the LLVM backend doesn't currently support
+            // compiler fences so the Atomic* API is missing on this target.
+            // When the LLVM backend gains support for compile fences uncomment
+            // the `singlethread: true` line and set `max_atomic_width` to
+            // `Some(16)`.
+            max_atomic_width: Some(0),
             atomic_cas: false,
+            // singlethread: true,
 
             // Because these devices have very little resources having an
             // unwinder is too onerous so we default to "abort" because the


### PR DESCRIPTION
PR #51953 enabled the Atomic*.{load,store} API on MSP430. Unfortunately,
the LLVM backend doesn't currently support those atomic operations, so this
commit removes the API and leaves instructions on how and when to enable it
in the future.

the second fixes compiling liballoc for msp430

closes #54511
r? @alexcrichton
cc @chernomor @awygle @cr1901 @pftbest