### PR TITLE
box: Add documentation for `From` impls

### DIFF
--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -479,7 +479,7 @@ impl<'a, T: Copy> From<&'a [T]> for Box<[T]> {
     /// ```rust
     /// // create a &[u8] which will be used to create a Box<[u8]>
     /// let slice: &[u8] = &[104, 101, 108, 108, 111];
-    /// let boxed_slice = Box::from(slice);
+    /// let boxed_slice: Box<[u8]> = Box::from(slice);
     ///
     /// println!("{:?}", boxed_slice);
     /// ```

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -481,7 +481,7 @@ impl<'a, T: Copy> From<&'a [T]> for Box<[T]> {
     /// let slice: &[u8] = &[104, 101, 108, 108, 111];
     /// let boxed_slice = Box::from(slice);
     ///
-    /// println!({:?}, boxed_slice);
+    /// println!("{:?}", boxed_slice);
     /// ```
     fn from(slice: &'a [T]) -> Box<[T]> {
         let mut boxed = unsafe { RawVec::with_capacity(slice.len()).into_box() };

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -472,8 +472,8 @@ impl<T> From<Box<T>> for Pin<Box<T>> {
 impl<'a, T: Copy> From<&'a [T]> for Box<[T]> {
     /// Converts a `&[T]` into a `Box<[T]>`
     ///
-    /// This conversion does not allocate on the heap
-    /// but performs a copy of `slice`.
+    /// This conversion allocates on the heap
+    /// and performs a copy of `slice`.
     ///
     /// # Examples
     /// ```rust
@@ -494,7 +494,8 @@ impl<'a, T: Copy> From<&'a [T]> for Box<[T]> {
 impl<'a> From<&'a str> for Box<str> {
     /// Converts a `&str` into a `Box<str>`
     ///
-    /// This conversion does not allocate on the heap and happens in place.
+    /// This conversion allocates on the heap
+    /// and performs a copy of `s`.
     ///
     /// # Examples
     /// ```rust

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -438,6 +438,18 @@ impl<T: ?Sized + Hasher> Hasher for Box<T> {
 
 #[stable(feature = "from_for_ptrs", since = "1.6.0")]
 impl<T> From<T> for Box<T> {
+    /// Converts a generic type `T` into a `Box<T>`
+    ///
+    /// The conversion allocates on the heap and moves `t`
+    /// from the stack into it.
+    ///
+    /// # Examples
+    /// ```rust
+    /// let x = 5;
+    /// let boxed = Box::new(5);
+    ///
+    /// assert_eq!(Box::from(x), boxed);
+    /// ```
     fn from(t: T) -> Self {
         Box::new(t)
     }
@@ -445,6 +457,9 @@ impl<T> From<T> for Box<T> {
 
 #[unstable(feature = "pin", issue = "49150")]
 impl<T> From<Box<T>> for Pin<Box<T>> {
+    /// Converts a `Box<T>` into a `Pin<Box<T>>`
+    ///
+    /// This conversion does not allocate on the heap and happens in place.
     fn from(boxed: Box<T>) -> Self {
         // It's not possible to move or replace the insides of a `Pin<Box<T>>`
         // when `T: !Unpin`,  so it's safe to pin it directly without any
@@ -455,6 +470,19 @@ impl<T> From<Box<T>> for Pin<Box<T>> {
 
 #[stable(feature = "box_from_slice", since = "1.17.0")]
 impl<'a, T: Copy> From<&'a [T]> for Box<[T]> {
+    /// Converts a `&[T]` into a `Box<[T]>`
+    ///
+    /// This conversion does not allocate on the heap
+    /// but performs a copy of `slice`.
+    ///
+    /// # Examples
+    /// ```rust
+    /// // create a &[u8] which will be used to create a Box<[u8]>
+    /// let slice: &[u8] = &[104, 101, 108, 108, 111];
+    /// let boxed_slice = Box::from(slice);
+    ///
+    /// println!({:?}, boxed_slice);
+    /// ```
     fn from(slice: &'a [T]) -> Box<[T]> {
         let mut boxed = unsafe { RawVec::with_capacity(slice.len()).into_box() };
         boxed.copy_from_slice(slice);
@@ -464,6 +492,15 @@ impl<'a, T: Copy> From<&'a [T]> for Box<[T]> {
 
 #[stable(feature = "box_from_slice", since = "1.17.0")]
 impl<'a> From<&'a str> for Box<str> {
+    /// Converts a `&str` into a `Box<str>`
+    ///
+    /// This conversion does not allocate on the heap and happens in place.
+    ///
+    /// # Examples
+    /// ```rust
+    /// let boxed: Box<str> = Box::from("hello");
+    /// println!("{}", boxed);
+    /// ```
     #[inline]
     fn from(s: &'a str) -> Box<str> {
         unsafe { from_boxed_utf8_unchecked(Box::from(s.as_bytes())) }
@@ -472,6 +509,22 @@ impl<'a> From<&'a str> for Box<str> {
 
 #[stable(feature = "boxed_str_conv", since = "1.19.0")]
 impl From<Box<str>> for Box<[u8]> {
+    /// Converts a `Box<str>>` into a `Box<[u8]>`
+    ///
+    /// This conversion does not allocate on the heap and happens in place.
+    ///
+    /// # Examples
+    /// ```rust
+    /// // create a Box<str> which will be used to create a Box<[u8]>
+    /// let boxed: Box<str> = Box::from("hello");
+    /// let boxed_str: Box<[u8]> = Box::from(boxed);
+    ///
+    /// // create a &[u8] which will be used to create a Box<[u8]>
+    /// let slice: &[u8] = &[104, 101, 108, 108, 111];
+    /// let boxed_slice = Box::from(slice);
+    ///
+    /// assert_eq!(boxed_slice, boxed_str);
+    /// ```
     #[inline]
     fn from(s: Box<str>) -> Self {
         unsafe { Box::from_raw(Box::into_raw(s) as *mut [u8]) }


### PR DESCRIPTION
This is a part of #51430. A brief description of the behaviour and examples are added to the documentation.

I am not sure what sort of examples to put for the `From` for `Pin` as my [code](https://play.rust-lang.org/?version=nightly&mode=debug&edition=2015&gist=97c908f44e41c9faeffec5b61d72a03e) doesn't even manage to compile using the nightly build. 

Somehow I feel that I missed out something so do let me know if more information is needed in the documentation or any of the examples require change.