### PR TITLE
Use opt.take() instead of mem::replace(opt, None)

### DIFF
--- a/src/librustc/ty/steal.rs
+++ b/src/librustc/ty/steal.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 use rustc_data_structures::sync::{RwLock, ReadGuard, MappedReadGuard};
-use std::mem;
 
 /// The `Steal` struct is intended to used as the value for a query.
 /// Specifically, we sometimes have queries (*cough* MIR *cough*)
@@ -51,7 +50,7 @@ impl<T> Steal<T> {
 
     pub fn steal(&self) -> T {
         let value_ref = &mut *self.value.try_write().expect("stealing value which is locked");
-        let value = mem::replace(value_ref, None);
+        let value = value_ref.take();
         value.expect("attempt to read from stolen value")
     }
 }

--- a/src/librustc_data_structures/tiny_list.rs
+++ b/src/librustc_data_structures/tiny_list.rs
@@ -22,8 +22,6 @@
 //! If you expect to store more than 1 element in the common case, steer clear
 //! and use a `Vec<T>`, `Box<[T]>`, or a `SmallVec<T>`.
 
-use std::mem;
-
 #[derive(Clone, Hash, Debug, PartialEq)]
 pub struct TinyList<T: PartialEq> {
     head: Option<Element<T>>
@@ -52,7 +50,7 @@ impl<T: PartialEq> TinyList<T> {
     pub fn insert(&mut self, data: T) {
         self.head = Some(Element {
             data,
-            next: mem::replace(&mut self.head, None).map(Box::new),
+            next: self.head.take().map(Box::new)
         });
     }
 
@@ -60,7 +58,7 @@ impl<T: PartialEq> TinyList<T> {
     pub fn remove(&mut self, data: &T) -> bool {
         self.head = match self.head {
             Some(ref mut head) if head.data == *data => {
-                mem::replace(&mut head.next, None).map(|x| *x)
+                head.next.take().map(|x| *x)
             }
             Some(ref mut head) => return head.remove_next(data),
             None => return false,
@@ -100,7 +98,7 @@ impl<T: PartialEq> Element<T> {
             if next.data != *data {
                 return next.remove_next(data)
             } else {
-                mem::replace(&mut next.next, None)
+                next.next.take()
             }
         } else {
             return false

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -831,7 +831,7 @@ impl<'a, 'gcx, 'tcx> ProbeContext<'a, 'gcx, 'tcx> {
         }
 
         let static_candidates = mem::replace(&mut self.static_candidates, vec![]);
-        let private_candidate = mem::replace(&mut self.private_candidate, None);
+        let private_candidate = self.private_candidate.take();
         let unsatisfied_predicates = mem::replace(&mut self.unsatisfied_predicates, vec![]);
 
         // things failed, so lets look at all traits, for diagnostic purposes now:


### PR DESCRIPTION
It's easier to read.