### PR TITLE
Change a flat_map with 0/1-element vecs to a filter_map

### DIFF
--- a/src/librustc_traits/implied_outlives_bounds.rs
+++ b/src/librustc_traits/implied_outlives_bounds.rs
@@ -159,14 +159,14 @@ fn implied_bounds_from_components(
 ) -> Vec<OutlivesBound<'tcx>> {
     sup_components
         .into_iter()
-        .flat_map(|component| {
+        .filter_map(|component| {
             match component {
                 Component::Region(r) =>
-                    vec![OutlivesBound::RegionSubRegion(sub_region, r)],
+                    Some(OutlivesBound::RegionSubRegion(sub_region, r)),
                 Component::Param(p) =>
-                    vec![OutlivesBound::RegionSubParam(sub_region, p)],
+                    Some(OutlivesBound::RegionSubParam(sub_region, p)),
                 Component::Projection(p) =>
-                    vec![OutlivesBound::RegionSubProjection(sub_region, p)],
+                    Some(OutlivesBound::RegionSubProjection(sub_region, p)),
                 Component::EscapingProjection(_) =>
                 // If the projection has escaping regions, don't
                 // try to infer any implied bounds even for its
@@ -176,9 +176,9 @@ fn implied_bounds_from_components(
                 // idea is that the WAY that the caller proves
                 // that may change in the future and we want to
                 // give ourselves room to get smarter here.
-                    vec![],
+                    None,
                 Component::UnresolvedInferenceVariable(..) =>
-                    vec![],
+                    None,
             }
         })
         .collect()


### PR DESCRIPTION
No need to use vectors in this case - `Option`s are quite sufficient.