### PR TITLE
submodules: update clippy from b1d03437 to 3971c424

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -326,7 +326,7 @@ dependencies = [
  "clippy-mini-macro-test 0.2.0",
  "clippy_dev 0.0.1",
  "clippy_lints 0.0.212",
- "compiletest_rs 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "compiletest_rs 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive-new 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "compiletest_rs"
-version = "0.3.13"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -452,6 +452,7 @@ dependencies = [
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1289,7 +1290,7 @@ dependencies = [
  "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cargo_metadata 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "compiletest_rs 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "compiletest_rs 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "vergen 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3202,7 +3203,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum colored 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b0aa3473e85a3161b59845d6096b289bb577874cafeaf75ea1b1beaa6572c7fc"
 "checksum commoncrypto 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d056a8586ba25a1e4d61cb090900e495952c7886786fc55f909ab2f819b69007"
 "checksum commoncrypto-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1fed34f46747aa73dfaa578069fd8279d2818ade2b55f38f22a9401c7f4083e2"
-"checksum compiletest_rs 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "d3064bc712922596dd5ab449fca9261d411893356581fe5297b96aa8f53bb1b8"
+"checksum compiletest_rs 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "75e809f56d6aa9575b67924b0af686c4f4c1380314f47947e235e9ff7fa94bed"
 "checksum core-foundation 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cc3532ec724375c7cb7ff0a097b714fde180bb1f6ed2ab27cfcd99ffca873cd2"
 "checksum core-foundation-sys 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a3fb15cdbdd9cf8b82d97d0296bb5cd3631bba58d6e31650a002a8e7fb5721f9"
 "checksum crossbeam 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "24ce9782d4d5c53674646a6a4c1863a21a8fc0cb649b3c94dfc16e45071dea19"


### PR DESCRIPTION
Should make clippy tests green again on rust-toolstate

Changes:
````
compiletest: clean rmeta data (from "cargo check") before running compiletest.
dependencies: bump compiletest-rs from git to 0.3.16
UI test cleanup: Extract explicit_counter_loop tests
UI test cleanup: Extract unnecessary_operation tests
appveyor: use rustc nightly instead of master
pin compiletest dependency to git version (12c980f47971b5ba6beb7cb2ffebf8b32f6766ea) while we are waiting for a new release
rustup: fix build with rustc 1.31.0-nightly (cae6efc37 2018-10-27)
Disable rust master toolchain build temporarily
Don't expand macro in or_fun_call suggestion
Don't expand macro in single_match suggestion
Don't expand macro in identity_conversion suggestion
slightly simplify integration tests
simplify ci base-tests
fix: correctly reconstruct raw strings
fix: extra semicolon, only create callsite once
Fix string_lit_as_bytes lint for macros
travis: work around temporary test failure due to rustc crashing on hyper.
ci: allow all branches except trying.tmp and staging.tmp to be built
Move in_macro check
Use BasicBlockData::terminator
Refactor
Use lint_root
Implement visit_basic_block_data
update_references indexing_slicing
Run update_lints
Add redundant_clone lint
Revert "new_ret_no_self: add sample from #3313 to Known Problems section."
Add tests for more than one level of reference
Add test case for `mem::discriminant` inside a macro
Add `Applicability`
Add lint for calling `mem::discriminant` on a non-enum type
Check existential types in `use_self`
Disable arithmetic lints in constant items
Fix warnings introduced by #3349
new_ret_no_self added test cases
Replace remaining `krate.span` with `DUMMY_SP`
Use DUMMY_SP in multiple_crate_versions
Some fixes for wildcard_dependencies
Run util/update_lints.py
Minor changes on clippy_lints/src/wildcard_dependencies.rs
Lint for wildcard dependencies in Cargo.toml
Don't emit `new_without_default_derive` if an impl of Default exists
Fix inspector pass documentation
Add branch configuration to appveyor.yml
Setup bors
new_ret_no_self added test cases
new_ret_no_self walk return type to check for self
Update `ui/for_loop` test output
Check for known array length in `needless_range_loop`
new_ret_no_self correct false positive on raw pointer return types
new_ret_no_self correct linting of tuple return types
out_of_bounds_indexing improved reporting of out of bounds value
out_of_bounds_indexing refactoring
OUT_OF_BOUNDS_INDEXING fix #3102 false negative
````