### PR TITLE
Return &T / &mut T in ManuallyDrop Deref(Mut) impl

### DIFF
--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -1018,7 +1018,7 @@ impl<T: ?Sized> ManuallyDrop<T> {
 impl<T: ?Sized> Deref for ManuallyDrop<T> {
     type Target = T;
     #[inline]
-    fn deref(&self) -> &Self::Target {
+    fn deref(&self) -> &T {
         &self.value
     }
 }
@@ -1026,7 +1026,7 @@ impl<T: ?Sized> Deref for ManuallyDrop<T> {
 #[stable(feature = "manually_drop", since = "1.20.0")]
 impl<T: ?Sized> DerefMut for ManuallyDrop<T> {
     #[inline]
-    fn deref_mut(&mut self) -> &mut Self::Target {
+    fn deref_mut(&mut self) -> &mut T {
         &mut self.value
     }
 }


### PR DESCRIPTION
Without this change the generated documentation looks like this:

    fn deref(&self) -> &<ManuallyDrop<T> as Deref>::Target

Returning the actual type directly makes the generated docs more clear:

    fn deref(&self) -> &T

Basically, compare how the impl for `Box<T>` and `ManuallyDrop<T>` looks in this screenshot:

![rust docs for ManuallyDrop as Deref](https://user-images.githubusercontent.com/7042/47673083-fc9dc280-db89-11e8-89b0-c6bde663feef.png)