### PR TITLE
Doc fixes

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -2088,7 +2088,7 @@
         return wrapper;
     }
 
-    var hideItemDeclarations = getCurrentValue('rustdoc-item-declarations') === "false";
+    var showItemDeclarations = getCurrentValue('rustdoc-item-declarations') === "false";
     function buildToggleWrapper(e) {
         if (hasClass(e, 'autohide')) {
             var wrap = e.previousElementSibling;
@@ -2117,7 +2117,7 @@
             if (hasClass(e, "type-decl")) {
                 fontSize = "20px";
                 otherMessage = '&nbsp;Show&nbsp;declaration';
-                if (hideItemDeclarations === false) {
+                if (showItemDeclarations === false) {
                     extraClass = 'collapsed';
                 }
             } else if (hasClass(e, "sub-variant")) {
@@ -2136,12 +2136,13 @@
                 extraClass = "marg-left";
             }
 
-            e.parentNode.insertBefore(createToggle(otherMessage,
-                                                   fontSize,
-                                                   extraClass,
-                                                   hideItemDeclarations),
-                                      e);
-            if (otherMessage.length > 0 && hideItemDeclarations === true) {
+            e.parentNode.insertBefore(
+                createToggle(otherMessage,
+                             fontSize,
+                             extraClass,
+                             hasClass(e, "type-decl") === false || showItemDeclarations === true),
+                e);
+            if (hasClass(e, "type-decl") === true && showItemDeclarations === true) {
                 collapseDocs(e.previousSibling.childNodes[0], "toggle");
             }
         }

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -282,8 +282,11 @@ nav.sub {
 	padding-left: 0;
 }
 
-.example-wrap {
+body:not(.source) .example-wrap {
 	display: inline-flex;
+}
+
+.example-wrap {
 	width: 100%;
 }
 
@@ -296,7 +299,7 @@ nav.sub {
 	text-align: right;
 }
 
-.example-wrap > pre.rust {
+body:not(.source) .example-wrap > pre.rust {
 	width: 100%;
 }
 


### PR DESCRIPTION
Fixes the bug in source code page where code was below line numbers and fixed this bug too ("Expand description" is shown whereas it shouldn't):

<img width="1440" alt="screenshot 2018-10-29 at 23 11 29" src="https://user-images.githubusercontent.com/3050060/47684136-1105ad80-dbd2-11e8-9e9f-fb7f26b0f5bd.png">

r? @QuietMisdreavus 