### PR TITLE
Rollup of 12 pull requests

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -326,7 +326,7 @@ dependencies = [
  "clippy-mini-macro-test 0.2.0",
  "clippy_dev 0.0.1",
  "clippy_lints 0.0.212",
- "compiletest_rs 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "compiletest_rs 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive-new 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "compiletest_rs"
-version = "0.3.13"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -452,6 +452,7 @@ dependencies = [
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1289,7 +1290,7 @@ dependencies = [
  "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cargo_metadata 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "compiletest_rs 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "compiletest_rs 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "vergen 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3202,7 +3203,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum colored 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b0aa3473e85a3161b59845d6096b289bb577874cafeaf75ea1b1beaa6572c7fc"
 "checksum commoncrypto 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d056a8586ba25a1e4d61cb090900e495952c7886786fc55f909ab2f819b69007"
 "checksum commoncrypto-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1fed34f46747aa73dfaa578069fd8279d2818ade2b55f38f22a9401c7f4083e2"
-"checksum compiletest_rs 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "d3064bc712922596dd5ab449fca9261d411893356581fe5297b96aa8f53bb1b8"
+"checksum compiletest_rs 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "75e809f56d6aa9575b67924b0af686c4f4c1380314f47947e235e9ff7fa94bed"
 "checksum core-foundation 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cc3532ec724375c7cb7ff0a097b714fde180bb1f6ed2ab27cfcd99ffca873cd2"
 "checksum core-foundation-sys 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a3fb15cdbdd9cf8b82d97d0296bb5cd3631bba58d6e31650a002a8e7fb5721f9"
 "checksum crossbeam 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "24ce9782d4d5c53674646a6a4c1863a21a8fc0cb649b3c94dfc16e45071dea19"

--- a/src/liballoc/collections/vec_deque.rs
+++ b/src/liballoc/collections/vec_deque.rs
@@ -36,6 +36,8 @@ use vec::Vec;
 
 const INITIAL_CAPACITY: usize = 7; // 2^3 - 1
 const MINIMUM_CAPACITY: usize = 1; // 2 - 1
+#[cfg(target_pointer_width = "16")]
+const MAXIMUM_ZST_CAPACITY: usize = 1 << (16 - 1); // Largest possible power of two
 #[cfg(target_pointer_width = "32")]
 const MAXIMUM_ZST_CAPACITY: usize = 1 << (32 - 1); // Largest possible power of two
 #[cfg(target_pointer_width = "64")]

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -3022,8 +3022,14 @@ impl<'a> LoweringContext<'a> {
                             hir::VisibilityKind::Inherited => hir::VisibilityKind::Inherited,
                             hir::VisibilityKind::Restricted { ref path, id: _, hir_id: _ } => {
                                 let id = this.next_id();
+                                let mut path = path.clone();
+                                for seg in path.segments.iter_mut() {
+                                    if seg.id.is_some() {
+                                        seg.id = Some(this.next_id().node_id);
+                                    }
+                                }
                                 hir::VisibilityKind::Restricted {
-                                    path: path.clone(),
+                                    path,
                                     id: id.node_id,
                                     hir_id: id.hir_id,
                                 }

--- a/src/librustc/hir/map/collector.rs
+++ b/src/librustc/hir/map/collector.rs
@@ -217,7 +217,7 @@ impl<'a, 'hir> NodeCollector<'a, 'hir> {
                 };
 
                 bug!("inconsistent DepNode for `{}`: \
-                      current_dep_node_owner={} ({:?}), hir_id.owner={} ({:?}) {}",
+                      current_dep_node_owner={} ({:?}), hir_id.owner={} ({:?}){}",
                     node_str,
                     self.definitions
                         .def_path(self.current_dep_node_owner)

--- a/src/librustc/infer/lexical_region_resolve/graphviz.rs
+++ b/src/librustc/infer/lexical_region_resolve/graphviz.rs
@@ -230,10 +230,7 @@ impl<'a, 'gcx, 'tcx> dot::GraphWalk<'a> for ConstraintGraph<'a, 'gcx, 'tcx> {
     type Node = Node;
     type Edge = Edge<'tcx>;
     fn nodes(&self) -> dot::Nodes<'_, Node> {
-        let mut set = FxHashSet::default();
-        for node in self.node_ids.keys() {
-            set.insert(*node);
-        }
+        let set = self.node_ids.keys().cloned().collect::<FxHashSet<_>>();
         debug!("constraint graph has {} nodes", set.len());
         set.into_iter().collect()
     }

--- a/src/librustc/middle/dependency_format.rs
+++ b/src/librustc/middle/dependency_format.rs
@@ -94,12 +94,11 @@ pub enum Linkage {
 
 pub fn calculate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
     let sess = &tcx.sess;
-    let mut fmts = FxHashMap::default();
-    for &ty in sess.crate_types.borrow().iter() {
+    let fmts = sess.crate_types.borrow().iter().map(|&ty| {
         let linkage = calculate_type(tcx, ty);
         verify_ok(tcx, &linkage);
-        fmts.insert(ty, linkage);
-    }
+        (ty, linkage)
+    }).collect::<FxHashMap<_, _>>();
     sess.abort_if_errors();
     sess.dependency_formats.set(fmts);
 }

--- a/src/librustc/traits/util.rs
+++ b/src/librustc/traits/util.rs
@@ -103,11 +103,10 @@ pub fn elaborate_trait_ref<'cx, 'gcx, 'tcx>(
 
 pub fn elaborate_trait_refs<'cx, 'gcx, 'tcx>(
     tcx: TyCtxt<'cx, 'gcx, 'tcx>,
-    trait_refs: &[ty::PolyTraitRef<'tcx>])
+    trait_refs: impl Iterator<Item = ty::PolyTraitRef<'tcx>>)
     -> Elaborator<'cx, 'gcx, 'tcx>
 {
-    let predicates = trait_refs.iter()
-                               .map(|trait_ref| trait_ref.to_predicate())
+    let predicates = trait_refs.map(|trait_ref| trait_ref.to_predicate())
                                .collect();
     elaborate_predicates(tcx, predicates)
 }
@@ -271,7 +270,7 @@ pub fn supertraits<'cx, 'gcx, 'tcx>(tcx: TyCtxt<'cx, 'gcx, 'tcx>,
 }
 
 pub fn transitive_bounds<'cx, 'gcx, 'tcx>(tcx: TyCtxt<'cx, 'gcx, 'tcx>,
-                                          bounds: &[ty::PolyTraitRef<'tcx>])
+                                          bounds: impl Iterator<Item = ty::PolyTraitRef<'tcx>>)
                                           -> Supertraits<'cx, 'gcx, 'tcx>
 {
     elaborate_trait_refs(tcx, bounds).filter_to_traits()

--- a/src/librustc/ty/query/on_disk_cache.rs
+++ b/src/librustc/ty/query/on_disk_cache.rs
@@ -174,10 +174,13 @@ impl<'sess> OnDiskCache<'sess> {
         tcx.dep_graph.with_ignore(|| {
             // Allocate SourceFileIndices
             let (file_to_file_index, file_index_to_stable_id) = {
-                let mut file_to_file_index = FxHashMap::default();
-                let mut file_index_to_stable_id = FxHashMap::default();
+                let files = tcx.sess.source_map().files();
+                let mut file_to_file_index = FxHashMap::with_capacity_and_hasher(
+                    files.len(), Default::default());
+                let mut file_index_to_stable_id = FxHashMap::with_capacity_and_hasher(
+                    files.len(), Default::default());
 
-                for (index, file) in tcx.sess.source_map().files().iter().enumerate() {
+                for (index, file) in files.iter().enumerate() {
                     let index = SourceFileIndex(index as u32);
                     let file_ptr: *const SourceFile = &**file as *const _;
                     file_to_file_index.insert(file_ptr, index);

--- a/src/librustc/ty/steal.rs
+++ b/src/librustc/ty/steal.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 use rustc_data_structures::sync::{RwLock, ReadGuard, MappedReadGuard};
-use std::mem;
 
 /// The `Steal` struct is intended to used as the value for a query.
 /// Specifically, we sometimes have queries (*cough* MIR *cough*)
@@ -51,7 +50,7 @@ impl<T> Steal<T> {
 
     pub fn steal(&self) -> T {
         let value_ref = &mut *self.value.try_write().expect("stealing value which is locked");
-        let value = mem::replace(value_ref, None);
+        let value = value_ref.take();
         value.expect("attempt to read from stolen value")
     }
 }

--- a/src/librustc_data_structures/tiny_list.rs
+++ b/src/librustc_data_structures/tiny_list.rs
@@ -22,8 +22,6 @@
 //! If you expect to store more than 1 element in the common case, steer clear
 //! and use a `Vec<T>`, `Box<[T]>`, or a `SmallVec<T>`.
 
-use std::mem;
-
 #[derive(Clone, Hash, Debug, PartialEq)]
 pub struct TinyList<T: PartialEq> {
     head: Option<Element<T>>
@@ -52,7 +50,7 @@ impl<T: PartialEq> TinyList<T> {
     pub fn insert(&mut self, data: T) {
         self.head = Some(Element {
             data,
-            next: mem::replace(&mut self.head, None).map(Box::new),
+            next: self.head.take().map(Box::new)
         });
     }
 
@@ -60,7 +58,7 @@ impl<T: PartialEq> TinyList<T> {
     pub fn remove(&mut self, data: &T) -> bool {
         self.head = match self.head {
             Some(ref mut head) if head.data == *data => {
-                mem::replace(&mut head.next, None).map(|x| *x)
+                head.next.take().map(|x| *x)
             }
             Some(ref mut head) => return head.remove_next(data),
             None => return false,
@@ -100,7 +98,7 @@ impl<T: PartialEq> Element<T> {
             if next.data != *data {
                 return next.remove_next(data)
             } else {
-                mem::replace(&mut next.next, None)
+                next.next.take()
             }
         } else {
             return false

--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -278,10 +278,9 @@ impl UnusedParens {
                                 msg: &str,
                                 followed_by_block: bool) {
         if let ast::ExprKind::Paren(ref inner) = value.node {
-            let necessary = followed_by_block && if let ast::ExprKind::Ret(_) = inner.node {
-                true
-            } else {
-                parser::contains_exterior_struct_lit(&inner)
+            let necessary = followed_by_block && match inner.node {
+                ast::ExprKind::Ret(_) | ast::ExprKind::Break(..) => true,
+                _ => parser::contains_exterior_struct_lit(&inner),
             };
             if !necessary {
                 let expr_text = if let Ok(snippet) = cx.sess().source_map()

--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -346,7 +346,33 @@ fn do_mir_borrowck<'a, 'gcx, 'tcx>(
         mbcx.errors_buffer.sort_by_key(|diag| diag.span.primary_span());
 
         if tcx.migrate_borrowck() {
-            match tcx.borrowck(def_id).signalled_any_error {
+            // When borrowck=migrate, check if AST-borrowck would
+            // error on the given code.
+
+            // rust-lang/rust#55492: loop over parents to ensure that
+            // errors that AST-borrowck only detects in some parent of
+            // a closure still allows NLL to signal an error.
+            let mut curr_def_id = def_id;
+            let signalled_any_error = loop {
+                match tcx.borrowck(curr_def_id).signalled_any_error {
+                    SignalledError::NoErrorsSeen => {
+                        // keep traversing (and borrow-checking) parents
+                    }
+                    SignalledError::SawSomeError => {
+                        // stop search here
+                        break SignalledError::SawSomeError;
+                    }
+                }
+
+                if tcx.is_closure(curr_def_id) {
+                    curr_def_id = tcx.parent_def_id(curr_def_id)
+                        .expect("a closure must have a parent_def_id");
+                } else {
+                    break SignalledError::NoErrorsSeen;
+                }
+            };
+
+            match signalled_any_error {
                 SignalledError::NoErrorsSeen => {
                     // if AST-borrowck signalled no errors, then
                     // downgrade all the buffered MIR-borrowck errors

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -576,7 +576,11 @@ pub fn const_eval_provider<'a, 'tcx>(
         key.param_env.reveal = Reveal::UserFacing;
         match tcx.const_eval(key) {
             // try again with reveal all as requested
-            Err(ErrorHandled::TooGeneric) => {},
+            Err(ErrorHandled::TooGeneric) => {
+                // Promoteds should never be "too generic" when getting evaluated.
+                // They either don't get evaluated, or we are in a monomorphic context
+                assert!(key.value.promoted.is_none());
+            },
             // dedupliate calls
             other => return other,
         }

--- a/src/librustc_mir/interpret/validity.rs
+++ b/src/librustc_mir/interpret/validity.rs
@@ -303,6 +303,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
         let (lo, hi) = layout.valid_range.clone().into_inner();
         let max_hi = u128::max_value() >> (128 - size.bits()); // as big as the size fits
         assert!(hi <= max_hi);
+        // We could also write `(hi + 1) % (max_hi + 1) == lo` but `max_hi + 1` overflows for `u128`
         if (lo == 0 && hi == max_hi) || (hi + 1 == lo) {
             // Nothing to check
             return Ok(());

--- a/src/librustc_mir/interpret/validity.rs
+++ b/src/librustc_mir/interpret/validity.rs
@@ -303,7 +303,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
         let (lo, hi) = layout.valid_range.clone().into_inner();
         let max_hi = u128::max_value() >> (128 - size.bits()); // as big as the size fits
         assert!(hi <= max_hi);
-        if lo == 0 && hi == max_hi {
+        if (lo == 0 && hi == max_hi) || (hi + 1 == lo) {
             // Nothing to check
             return Ok(());
         }

--- a/src/librustc_target/spec/msp430_none_elf.rs
+++ b/src/librustc_target/spec/msp430_none_elf.rs
@@ -35,9 +35,14 @@ pub fn target() -> TargetResult {
             no_integrated_as: true,
 
             // There are no atomic CAS instructions available in the MSP430
-            // instruction set
-            max_atomic_width: Some(16),
+            // instruction set, and the LLVM backend doesn't currently support
+            // compiler fences so the Atomic* API is missing on this target.
+            // When the LLVM backend gains support for compile fences uncomment
+            // the `singlethread: true` line and set `max_atomic_width` to
+            // `Some(16)`.
+            max_atomic_width: Some(0),
             atomic_cas: false,
+            // singlethread: true,
 
             // Because these devices have very little resources having an
             // unwinder is too onerous so we default to "abort" because the

--- a/src/librustc_traits/implied_outlives_bounds.rs
+++ b/src/librustc_traits/implied_outlives_bounds.rs
@@ -159,14 +159,14 @@ fn implied_bounds_from_components(
 ) -> Vec<OutlivesBound<'tcx>> {
     sup_components
         .into_iter()
-        .flat_map(|component| {
+        .filter_map(|component| {
             match component {
                 Component::Region(r) =>
-                    vec![OutlivesBound::RegionSubRegion(sub_region, r)],
+                    Some(OutlivesBound::RegionSubRegion(sub_region, r)),
                 Component::Param(p) =>
-                    vec![OutlivesBound::RegionSubParam(sub_region, p)],
+                    Some(OutlivesBound::RegionSubParam(sub_region, p)),
                 Component::Projection(p) =>
-                    vec![OutlivesBound::RegionSubProjection(sub_region, p)],
+                    Some(OutlivesBound::RegionSubProjection(sub_region, p)),
                 Component::EscapingProjection(_) =>
                 // If the projection has escaping regions, don't
                 // try to infer any implied bounds even for its
@@ -176,9 +176,9 @@ fn implied_bounds_from_components(
                 // idea is that the WAY that the caller proves
                 // that may change in the future and we want to
                 // give ourselves room to get smarter here.
-                    vec![],
+                    None,
                 Component::UnresolvedInferenceVariable(..) =>
-                    vec![],
+                    None,
             }
         })
         .collect()

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1112,12 +1112,12 @@ impl<'o, 'gcx: 'tcx, 'tcx> dyn AstConv<'gcx, 'tcx>+'o {
     {
         let tcx = self.tcx();
 
-        let bounds: Vec<_> = self.get_type_parameter_bounds(span, ty_param_def_id)
-            .predicates.into_iter().filter_map(|(p, _)| p.to_opt_poly_trait_ref()).collect();
+        let bounds = self.get_type_parameter_bounds(span, ty_param_def_id)
+            .predicates.into_iter().filter_map(|(p, _)| p.to_opt_poly_trait_ref());
 
         // Check that there is exactly one way to find an associated type with the
         // correct name.
-        let suitable_bounds = traits::transitive_bounds(tcx, &bounds)
+        let suitable_bounds = traits::transitive_bounds(tcx, bounds)
             .filter(|b| self.trait_defines_associated_type_named(b.def_id(), assoc_name));
 
         let param_node_id = tcx.hir.as_local_node_id(ty_param_def_id).unwrap();

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -831,7 +831,7 @@ impl<'a, 'gcx, 'tcx> ProbeContext<'a, 'gcx, 'tcx> {
         }
 
         let static_candidates = mem::replace(&mut self.static_candidates, vec![]);
-        let private_candidate = mem::replace(&mut self.private_candidate, None);
+        let private_candidate = self.private_candidate.take();
         let unsatisfied_predicates = mem::replace(&mut self.unsatisfied_predicates, vec![]);
 
         // things failed, so lets look at all traits, for diagnostic purposes now:

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -31,6 +31,7 @@ use rustc::middle::stability;
 use syntax::ast;
 use syntax::util::lev_distance::{lev_distance, find_best_match_for_name};
 use syntax_pos::{Span, symbol::Symbol};
+use std::iter;
 use std::mem;
 use std::ops::Deref;
 use std::rc::Rc;
@@ -627,7 +628,7 @@ impl<'a, 'gcx, 'tcx> ProbeContext<'a, 'gcx, 'tcx> {
         // itself. Hence, a `&self` method will wind up with an
         // argument type like `&Trait`.
         let trait_ref = principal.with_self_ty(self.tcx, self_ty);
-        self.elaborate_bounds(&[trait_ref], |this, new_trait_ref, item| {
+        self.elaborate_bounds(iter::once(trait_ref), |this, new_trait_ref, item| {
             let new_trait_ref = this.erase_late_bound_regions(&new_trait_ref);
 
             let (xform_self_ty, xform_ret_ty) =
@@ -645,7 +646,7 @@ impl<'a, 'gcx, 'tcx> ProbeContext<'a, 'gcx, 'tcx> {
                                                param_ty: ty::ParamTy) {
         // FIXME -- Do we want to commit to this behavior for param bounds?
 
-        let bounds: Vec<_> = self.param_env
+        let bounds = self.param_env
             .caller_bounds
             .iter()
             .filter_map(|predicate| {
@@ -667,10 +668,9 @@ impl<'a, 'gcx, 'tcx> ProbeContext<'a, 'gcx, 'tcx> {
                     ty::Predicate::TypeOutlives(..) |
                     ty::Predicate::ConstEvaluatable(..) => None,
                 }
-            })
-            .collect();
+            });
 
-        self.elaborate_bounds(&bounds, |this, poly_trait_ref, item| {
+        self.elaborate_bounds(bounds, |this, poly_trait_ref, item| {
             let trait_ref = this.erase_late_bound_regions(&poly_trait_ref);
 
             let (xform_self_ty, xform_ret_ty) =
@@ -693,15 +693,16 @@ impl<'a, 'gcx, 'tcx> ProbeContext<'a, 'gcx, 'tcx> {
 
     // Do a search through a list of bounds, using a callback to actually
     // create the candidates.
-    fn elaborate_bounds<F>(&mut self, bounds: &[ty::PolyTraitRef<'tcx>], mut mk_cand: F)
+    fn elaborate_bounds<F>(&mut self,
+                           bounds: impl Iterator<Item = ty::PolyTraitRef<'tcx>>,
+                           mut mk_cand: F)
         where F: for<'b> FnMut(&mut ProbeContext<'b, 'gcx, 'tcx>,
                                ty::PolyTraitRef<'tcx>,
                                ty::AssociatedItem)
     {
-        debug!("elaborate_bounds(bounds={:?})", bounds);
-
         let tcx = self.tcx;
         for bound_trait_ref in traits::transitive_bounds(tcx, bounds) {
+            debug!("elaborate_bounds(bound_trait_ref={:?})", bound_trait_ref);
             for item in self.impl_or_trait_item(bound_trait_ref.def_id()) {
                 if !self.has_applicable_self(&item) {
                     self.record_static_candidate(TraitSource(bound_trait_ref.def_id()));

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3510,10 +3510,9 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
             _ => span_bug!(span, "non-ADT passed to check_expr_struct_fields")
         };
 
-        let mut remaining_fields = FxHashMap::default();
-        for (i, field) in variant.fields.iter().enumerate() {
-            remaining_fields.insert(field.ident.modern(), (i, field));
-        }
+        let mut remaining_fields = variant.fields.iter().enumerate().map(|(i, field)|
+            (field.ident.modern(), (i, field))
+        ).collect::<FxHashMap<_, _>>();
 
         let mut seen_fields = FxHashMap::default();
 
@@ -5051,10 +5050,8 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         // provided (if any) into their appropriate spaces. We'll also report
         // errors if type parameters are provided in an inappropriate place.
 
-        let mut generic_segs = FxHashSet::default();
-        for PathSeg(_, index) in &path_segs {
-            generic_segs.insert(index);
-        }
+        let generic_segs = path_segs.iter().map(|PathSeg(_, index)| index)
+            .collect::<FxHashSet<_>>();
         AstConv::prohibit_generics(self, segments.iter().enumerate().filter_map(|(index, seg)| {
             if !generic_segs.contains(&index) {
                 Some(seg)

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -2088,7 +2088,7 @@
         return wrapper;
     }
 
-    var hideItemDeclarations = getCurrentValue('rustdoc-item-declarations') === "false";
+    var showItemDeclarations = getCurrentValue('rustdoc-item-declarations') === "false";
     function buildToggleWrapper(e) {
         if (hasClass(e, 'autohide')) {
             var wrap = e.previousElementSibling;
@@ -2117,7 +2117,7 @@
             if (hasClass(e, "type-decl")) {
                 fontSize = "20px";
                 otherMessage = '&nbsp;Show&nbsp;declaration';
-                if (hideItemDeclarations === false) {
+                if (showItemDeclarations === false) {
                     extraClass = 'collapsed';
                 }
             } else if (hasClass(e, "sub-variant")) {
@@ -2136,12 +2136,13 @@
                 extraClass = "marg-left";
             }
 
-            e.parentNode.insertBefore(createToggle(otherMessage,
-                                                   fontSize,
-                                                   extraClass,
-                                                   hideItemDeclarations),
-                                      e);
-            if (otherMessage.length > 0 && hideItemDeclarations === true) {
+            e.parentNode.insertBefore(
+                createToggle(otherMessage,
+                             fontSize,
+                             extraClass,
+                             hasClass(e, "type-decl") === false || showItemDeclarations === true),
+                e);
+            if (hasClass(e, "type-decl") === true && showItemDeclarations === true) {
                 collapseDocs(e.previousSibling.childNodes[0], "toggle");
             }
         }

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -282,8 +282,11 @@ nav.sub {
 	padding-left: 0;
 }
 
-.example-wrap {
+body:not(.source) .example-wrap {
 	display: inline-flex;
+}
+
+.example-wrap {
 	width: 100%;
 }
 
@@ -296,7 +299,7 @@ nav.sub {
 	text-align: right;
 }
 
-.example-wrap > pre.rust {
+body:not(.source) .example-wrap > pre.rust {
 	width: 100%;
 }
 

--- a/src/test/run-pass/issue-55376.rs
+++ b/src/test/run-pass/issue-55376.rs
@@ -1,0 +1,25 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Tests that paths in `pub(...)` don't fail HIR verification.
+
+#![allow(unused_imports)]
+#![allow(dead_code)]
+
+pub(self) use self::my_mod::Foo;
+
+mod my_mod {
+    pub(super) use self::Foo as Bar;
+    pub(in super::my_mod) use self::Foo as Baz;
+
+    pub struct Foo;
+}
+
+fn main() {}

--- a/src/test/ui/borrowck/borrowck-closures-unique.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-closures-unique.nll.stderr
@@ -40,19 +40,15 @@ LL |     let c2 = || set(x); //~ ERROR two closures require unique access to `x`
 LL |     c1;
    |     -- first borrow later used here
 
-warning[E0594]: cannot assign to `x`, as it is not declared as mutable
+error[E0594]: cannot assign to `x`, as it is not declared as mutable
   --> $DIR/borrowck-closures-unique.rs:57:38
    |
 LL | fn e(x: &'static mut isize) {
    |      - help: consider changing this to be mutable: `mut x`
 LL |     let c1 = |y: &'static mut isize| x = y; //~ ERROR closure cannot assign to immutable argument
    |                                      ^^^^^ cannot assign
-   |
-   = warning: This error has been downgraded to a warning for backwards compatibility with previous releases.
-           It represents potential unsoundness in your code.
-           This warning will become a hard error in the future.
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 
 Some errors occurred: E0500, E0524, E0594.
 For more information about an error, try `rustc --explain E0500`.

--- a/src/test/ui/borrowck/borrowck-describe-lvalue.ast.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-describe-lvalue.ast.nll.stderr
@@ -20,7 +20,7 @@ LL |                    //[mir]~^ ERROR cannot borrow `x` as mutable more than o
 LL |                    *y = 1;
    |                    ------ first borrow later used here
 
-warning: captured variable cannot escape `FnMut` closure body
+error: captured variable cannot escape `FnMut` closure body
   --> $DIR/borrowck-describe-lvalue.rs:305:16
    |
 LL |              || {
@@ -36,9 +36,6 @@ LL | |                 }
    |
    = note: `FnMut` closures only have access to their captured variables while they are executing...
    = note: ...therefore, they cannot allow references to captured variables to escape
-   = warning: This error has been downgraded to a warning for backwards compatibility with previous releases.
-           It represents potential unsoundness in your code.
-           This warning will become a hard error in the future.
 
 error[E0503]: cannot use `f.x` because it was mutably borrowed
   --> $DIR/borrowck-describe-lvalue.rs:53:9
@@ -382,7 +379,7 @@ LL |                 drop(x); //[ast]~ ERROR use of moved value: `x`
    |
    = note: move occurs because `x` has type `std::vec::Vec<i32>`, which does not implement the `Copy` trait
 
-error: aborting due to 29 previous errors
+error: aborting due to 30 previous errors
 
 Some errors occurred: E0382, E0499, E0502, E0503.
 For more information about an error, try `rustc --explain E0382`.

--- a/src/test/ui/borrowck/issue-55492-borrowck-migrate-scans-parents.ast.stderr
+++ b/src/test/ui/borrowck/issue-55492-borrowck-migrate-scans-parents.ast.stderr
@@ -1,0 +1,55 @@
+error[E0595]: closure cannot assign to immutable argument `x`
+  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:21:22
+   |
+LL |         let mut c1 = |y: &'static mut isize| x = y;
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^ cannot borrow mutably
+help: consider removing the `&mut`, as it is an immutable binding to a mutable reference
+   |
+LL |         x
+   |
+
+error[E0595]: closure cannot assign to immutable argument `x`
+  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:29:22
+   |
+LL |         let mut c1 = |z: &'static mut isize| {
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^ cannot borrow mutably
+help: consider removing the `&mut`, as it is an immutable binding to a mutable reference
+   |
+LL |         x
+   |
+
+error[E0595]: closure cannot assign to immutable argument `x`
+  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:40:9
+   |
+LL |     pub fn capture_assign_whole(x: (i32,)) {
+   |                                 - help: make this binding mutable: `mut x`
+LL |         || { x = (1,); };
+   |         ^^ cannot borrow mutably
+
+error[E0595]: closure cannot assign to immutable argument `x`
+  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:43:9
+   |
+LL |     pub fn capture_assign_part(x: (i32,)) {
+   |                                - help: make this binding mutable: `mut x`
+LL |         || { x.0 = 1; };
+   |         ^^ cannot borrow mutably
+
+error[E0595]: closure cannot assign to immutable argument `x`
+  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:46:9
+   |
+LL |     pub fn capture_reborrow_whole(x: (i32,)) {
+   |                                   - help: make this binding mutable: `mut x`
+LL |         || { &mut x; };
+   |         ^^ cannot borrow mutably
+
+error[E0595]: closure cannot assign to immutable argument `x`
+  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:49:9
+   |
+LL |     pub fn capture_reborrow_part(x: (i32,)) {
+   |                                  - help: make this binding mutable: `mut x`
+LL |         || { &mut x.0; };
+   |         ^^ cannot borrow mutably
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0595`.

--- a/src/test/ui/borrowck/issue-55492-borrowck-migrate-scans-parents.migrate.stderr
+++ b/src/test/ui/borrowck/issue-55492-borrowck-migrate-scans-parents.migrate.stderr
@@ -1,0 +1,54 @@
+error[E0594]: cannot assign to `x`, as it is not declared as mutable
+  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:21:46
+   |
+LL |     pub fn e(x: &'static mut isize) {
+   |              - help: consider changing this to be mutable: `mut x`
+LL |         static mut Y: isize = 3;
+LL |         let mut c1 = |y: &'static mut isize| x = y;
+   |                                              ^^^^^ cannot assign
+
+error[E0594]: cannot assign to `x`, as it is not declared as mutable
+  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:30:50
+   |
+LL |     pub fn ee(x: &'static mut isize) {
+   |               - help: consider changing this to be mutable: `mut x`
+...
+LL |             let mut c2 = |y: &'static mut isize| x = y;
+   |                                                  ^^^^^ cannot assign
+
+error[E0594]: cannot assign to `x`, as it is not declared as mutable
+  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:40:14
+   |
+LL |     pub fn capture_assign_whole(x: (i32,)) {
+   |                                 - help: consider changing this to be mutable: `mut x`
+LL |         || { x = (1,); };
+   |              ^^^^^^^^ cannot assign
+
+error[E0594]: cannot assign to `x.0`, as `x` is not declared as mutable
+  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:43:14
+   |
+LL |     pub fn capture_assign_part(x: (i32,)) {
+   |                                - help: consider changing this to be mutable: `mut x`
+LL |         || { x.0 = 1; };
+   |              ^^^^^^^ cannot assign
+
+error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
+  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:46:14
+   |
+LL |     pub fn capture_reborrow_whole(x: (i32,)) {
+   |                                   - help: consider changing this to be mutable: `mut x`
+LL |         || { &mut x; };
+   |              ^^^^^^ cannot borrow as mutable
+
+error[E0596]: cannot borrow `x.0` as mutable, as `x` is not declared as mutable
+  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:49:14
+   |
+LL |     pub fn capture_reborrow_part(x: (i32,)) {
+   |                                  - help: consider changing this to be mutable: `mut x`
+LL |         || { &mut x.0; };
+   |              ^^^^^^^^ cannot borrow as mutable
+
+error: aborting due to 6 previous errors
+
+Some errors occurred: E0594, E0596.
+For more information about an error, try `rustc --explain E0594`.

--- a/src/test/ui/borrowck/issue-55492-borrowck-migrate-scans-parents.nll.stderr
+++ b/src/test/ui/borrowck/issue-55492-borrowck-migrate-scans-parents.nll.stderr
@@ -1,0 +1,54 @@
+error[E0594]: cannot assign to `x`, as it is not declared as mutable
+  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:21:46
+   |
+LL |     pub fn e(x: &'static mut isize) {
+   |              - help: consider changing this to be mutable: `mut x`
+LL |         static mut Y: isize = 3;
+LL |         let mut c1 = |y: &'static mut isize| x = y;
+   |                                              ^^^^^ cannot assign
+
+error[E0594]: cannot assign to `x`, as it is not declared as mutable
+  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:30:50
+   |
+LL |     pub fn ee(x: &'static mut isize) {
+   |               - help: consider changing this to be mutable: `mut x`
+...
+LL |             let mut c2 = |y: &'static mut isize| x = y;
+   |                                                  ^^^^^ cannot assign
+
+error[E0594]: cannot assign to `x`, as it is not declared as mutable
+  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:40:14
+   |
+LL |     pub fn capture_assign_whole(x: (i32,)) {
+   |                                 - help: consider changing this to be mutable: `mut x`
+LL |         || { x = (1,); };
+   |              ^^^^^^^^ cannot assign
+
+error[E0594]: cannot assign to `x.0`, as `x` is not declared as mutable
+  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:43:14
+   |
+LL |     pub fn capture_assign_part(x: (i32,)) {
+   |                                - help: consider changing this to be mutable: `mut x`
+LL |         || { x.0 = 1; };
+   |              ^^^^^^^ cannot assign
+
+error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
+  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:46:14
+   |
+LL |     pub fn capture_reborrow_whole(x: (i32,)) {
+   |                                   - help: consider changing this to be mutable: `mut x`
+LL |         || { &mut x; };
+   |              ^^^^^^ cannot borrow as mutable
+
+error[E0596]: cannot borrow `x.0` as mutable, as `x` is not declared as mutable
+  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:49:14
+   |
+LL |     pub fn capture_reborrow_part(x: (i32,)) {
+   |                                  - help: consider changing this to be mutable: `mut x`
+LL |         || { &mut x.0; };
+   |              ^^^^^^^^ cannot borrow as mutable
+
+error: aborting due to 6 previous errors
+
+Some errors occurred: E0594, E0596.
+For more information about an error, try `rustc --explain E0594`.

--- a/src/test/ui/borrowck/issue-55492-borrowck-migrate-scans-parents.rs
+++ b/src/test/ui/borrowck/issue-55492-borrowck-migrate-scans-parents.rs
@@ -1,0 +1,61 @@
+// rust-lang/rust#55492: errors detected during MIR-borrowck's
+// analysis of a closure body may only be caught when AST-borrowck
+// looks at some parent.
+
+// revisions: ast migrate nll
+
+// Since we are testing nll (and migration) explicitly as a separate
+// revisions, don't worry about the --compare-mode=nll on this test.
+
+// ignore-compare-mode-nll
+
+//[ast]compile-flags: -Z borrowck=ast
+//[migrate]compile-flags: -Z borrowck=migrate -Z two-phase-borrows
+//[nll]compile-flags: -Z borrowck=mir -Z two-phase-borrows
+
+
+// transcribed from borrowck-closures-unique.rs
+mod borrowck_closures_unique {
+    pub fn e(x: &'static mut isize) {
+        static mut Y: isize = 3;
+        let mut c1 = |y: &'static mut isize| x = y;
+        unsafe { c1(&mut Y); }
+    }
+}
+
+mod borrowck_closures_unique_grandparent {
+    pub fn ee(x: &'static mut isize) {
+        static mut Z: isize = 3;
+        let mut c1 = |z: &'static mut isize| {
+            let mut c2 = |y: &'static mut isize| x = y;
+            c2(z);
+        };
+        unsafe { c1(&mut Z); }
+    }
+}
+
+// adapted from mutability_errors.rs
+mod mutability_errors {
+    pub fn capture_assign_whole(x: (i32,)) {
+        || { x = (1,); };
+    }
+    pub fn capture_assign_part(x: (i32,)) {
+        || { x.0 = 1; };
+    }
+    pub fn capture_reborrow_whole(x: (i32,)) {
+        || { &mut x; };
+    }
+    pub fn capture_reborrow_part(x: (i32,)) {
+        || { &mut x.0; };
+    }
+}
+
+fn main() {
+    static mut X: isize = 2;
+    unsafe { borrowck_closures_unique::e(&mut X); }
+
+    mutability_errors::capture_assign_whole((1000,));
+    mutability_errors::capture_assign_part((2000,));
+    mutability_errors::capture_reborrow_whole((3000,));
+    mutability_errors::capture_reborrow_part((4000,));
+}

--- a/src/test/ui/borrowck/mutability-errors.nll.stderr
+++ b/src/test/ui/borrowck/mutability-errors.nll.stderr
@@ -277,7 +277,7 @@ LL |     &mut x; //~ ERROR
 LL |     &mut x.0; //~ ERROR
    |     ^^^^^^^^ cannot borrow as mutable
 
-warning[E0594]: cannot assign to `x`, as it is not declared as mutable
+error[E0594]: cannot assign to `x`, as it is not declared as mutable
   --> $DIR/mutability-errors.rs:70:9
    |
 LL | fn imm_capture(x: (i32,)) {
@@ -285,12 +285,8 @@ LL | fn imm_capture(x: (i32,)) {
 LL |     || { //~ ERROR
 LL |         x = (1,);
    |         ^^^^^^^^ cannot assign
-   |
-   = warning: This error has been downgraded to a warning for backwards compatibility with previous releases.
-           It represents potential unsoundness in your code.
-           This warning will become a hard error in the future.
 
-warning[E0594]: cannot assign to `x.0`, as `x` is not declared as mutable
+error[E0594]: cannot assign to `x.0`, as `x` is not declared as mutable
   --> $DIR/mutability-errors.rs:71:9
    |
 LL | fn imm_capture(x: (i32,)) {
@@ -298,12 +294,8 @@ LL | fn imm_capture(x: (i32,)) {
 ...
 LL |         x.0 = 1;
    |         ^^^^^^^ cannot assign
-   |
-   = warning: This error has been downgraded to a warning for backwards compatibility with previous releases.
-           It represents potential unsoundness in your code.
-           This warning will become a hard error in the future.
 
-warning[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
+error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
   --> $DIR/mutability-errors.rs:72:9
    |
 LL | fn imm_capture(x: (i32,)) {
@@ -311,12 +303,8 @@ LL | fn imm_capture(x: (i32,)) {
 ...
 LL |         &mut x;
    |         ^^^^^^ cannot borrow as mutable
-   |
-   = warning: This error has been downgraded to a warning for backwards compatibility with previous releases.
-           It represents potential unsoundness in your code.
-           This warning will become a hard error in the future.
 
-warning[E0596]: cannot borrow `x.0` as mutable, as `x` is not declared as mutable
+error[E0596]: cannot borrow `x.0` as mutable, as `x` is not declared as mutable
   --> $DIR/mutability-errors.rs:73:9
    |
 LL | fn imm_capture(x: (i32,)) {
@@ -324,10 +312,6 @@ LL | fn imm_capture(x: (i32,)) {
 ...
 LL |         &mut x.0;
    |         ^^^^^^^^ cannot borrow as mutable
-   |
-   = warning: This error has been downgraded to a warning for backwards compatibility with previous releases.
-           It represents potential unsoundness in your code.
-           This warning will become a hard error in the future.
 
 error[E0594]: cannot assign to `x`, as it is not declared as mutable
   --> $DIR/mutability-errors.rs:76:9
@@ -389,7 +373,7 @@ error[E0596]: cannot borrow `X.0` as mutable, as `X` is an immutable static item
 LL |     &mut X.0; //~ ERROR
    |     ^^^^^^^^ cannot borrow as mutable
 
-error: aborting due to 34 previous errors
+error: aborting due to 38 previous errors
 
 Some errors occurred: E0594, E0596.
 For more information about an error, try `rustc --explain E0594`.

--- a/src/test/ui/consts/const-eval/issue-49296.rs
+++ b/src/test/ui/consts/const-eval/issue-49296.rs
@@ -1,0 +1,23 @@
+// issue-49296: Unsafe shenigans in constants can result in missing errors
+
+#![feature(const_fn)]
+#![feature(const_fn_union)]
+
+const unsafe fn transmute<T: Copy, U: Copy>(t: T) -> U {
+    union Transmute<T: Copy, U: Copy> {
+        from: T,
+        to: U,
+    }
+
+    Transmute { from: t }.to
+}
+
+const fn wat(x: u64) -> &'static u64 {
+    unsafe { transmute(&x) }
+}
+const X: u64 = *wat(42);
+//~^ ERROR any use of this value will cause an error
+
+fn main() {
+    println!("{}", X);
+}

--- a/src/test/ui/consts/const-eval/issue-49296.stderr
+++ b/src/test/ui/consts/const-eval/issue-49296.stderr
@@ -1,0 +1,12 @@
+error: any use of this value will cause an error
+  --> $DIR/issue-49296.rs:18:1
+   |
+LL | const X: u64 = *wat(42);
+   | ^^^^^^^^^^^^^^^--------^
+   |                |
+   |                dangling pointer was dereferenced
+   |
+   = note: #[deny(const_err)] on by default
+
+error: aborting due to previous error
+

--- a/src/test/ui/consts/const-validation-fail-55455.rs
+++ b/src/test/ui/consts/const-validation-fail-55455.rs
@@ -1,0 +1,9 @@
+// https://github.com/rust-lang/rust/issues/55454
+// compile-pass
+
+struct This<T>(T);
+
+const C: This<Option<&i32>> = This(Some(&1));
+
+fn main() {
+}

--- a/src/test/ui/consts/promoted-validation-55454.rs
+++ b/src/test/ui/consts/promoted-validation-55454.rs
@@ -1,0 +1,9 @@
+// https://github.com/rust-lang/rust/issues/55454
+// compile-pass
+
+#[derive(PartialEq)]
+struct This<T>(T);
+
+fn main() {
+    This(Some(&1)) == This(Some(&1));
+}

--- a/src/test/ui/lint/unused_parens_json_suggestion.rs
+++ b/src/test/ui/lint/unused_parens_json_suggestion.rs
@@ -23,4 +23,13 @@ fn main() {
     // We want to suggest the properly-balanced expression `1 / (2 + 3)`, not
     // the malformed `1 / (2 + 3`
     let _a = (1 / (2 + 3));
+    f();
+}
+
+fn f() -> bool {
+    loop {
+        if (break { return true }) {
+        }
+    }
+    false
 }

--- a/src/test/ui/unboxed-closures/unboxed-closure-immutable-capture.nll.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-immutable-capture.nll.stderr
@@ -33,7 +33,7 @@ LL |     let x = 0;
 LL |     move || set(&mut x); //~ ERROR cannot borrow
    |                 ^^^^^^ cannot borrow as mutable
 
-warning[E0594]: cannot assign to `x`, as it is not declared as mutable
+error[E0594]: cannot assign to `x`, as it is not declared as mutable
   --> $DIR/unboxed-closure-immutable-capture.rs:23:8
    |
 LL |     let x = 0;
@@ -41,12 +41,8 @@ LL |     let x = 0;
 ...
 LL |     || x = 1; //~ ERROR cannot assign
    |        ^^^^^ cannot assign
-   |
-   = warning: This error has been downgraded to a warning for backwards compatibility with previous releases.
-           It represents potential unsoundness in your code.
-           This warning will become a hard error in the future.
 
-warning[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
+error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
   --> $DIR/unboxed-closure-immutable-capture.rs:25:12
    |
 LL |     let x = 0;
@@ -54,12 +50,8 @@ LL |     let x = 0;
 ...
 LL |     || set(&mut x); //~ ERROR cannot assign
    |            ^^^^^^ cannot borrow as mutable
-   |
-   = warning: This error has been downgraded to a warning for backwards compatibility with previous releases.
-           It represents potential unsoundness in your code.
-           This warning will become a hard error in the future.
 
-warning[E0594]: cannot assign to `x`, as it is not declared as mutable
+error[E0594]: cannot assign to `x`, as it is not declared as mutable
   --> $DIR/unboxed-closure-immutable-capture.rs:26:8
    |
 LL |     let x = 0;
@@ -67,12 +59,8 @@ LL |     let x = 0;
 ...
 LL |     || x = 1; //~ ERROR cannot assign
    |        ^^^^^ cannot assign
-   |
-   = warning: This error has been downgraded to a warning for backwards compatibility with previous releases.
-           It represents potential unsoundness in your code.
-           This warning will become a hard error in the future.
 
-warning[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
+error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
   --> $DIR/unboxed-closure-immutable-capture.rs:28:12
    |
 LL |     let x = 0;
@@ -80,12 +68,8 @@ LL |     let x = 0;
 ...
 LL |     || set(&mut x); //~ ERROR cannot assign
    |            ^^^^^^ cannot borrow as mutable
-   |
-   = warning: This error has been downgraded to a warning for backwards compatibility with previous releases.
-           It represents potential unsoundness in your code.
-           This warning will become a hard error in the future.
 
-error: aborting due to 4 previous errors
+error: aborting due to 8 previous errors
 
 Some errors occurred: E0594, E0596.
 For more information about an error, try `rustc --explain E0594`.

--- a/src/test/ui/unboxed-closures/unboxed-closures-infer-fnmut-calling-fnmut-no-mut.nll.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-infer-fnmut-calling-fnmut-no-mut.nll.stderr
@@ -1,4 +1,4 @@
-warning[E0596]: cannot borrow `tick1` as mutable, as it is not declared as mutable
+error[E0596]: cannot borrow `tick1` as mutable, as it is not declared as mutable
   --> $DIR/unboxed-closures-infer-fnmut-calling-fnmut-no-mut.rs:27:9
    |
 LL |     let tick1 = || {
@@ -6,10 +6,6 @@ LL |     let tick1 = || {
 ...
 LL |         tick1();
    |         ^^^^^ cannot borrow as mutable
-   |
-   = warning: This error has been downgraded to a warning for backwards compatibility with previous releases.
-           It represents potential unsoundness in your code.
-           This warning will become a hard error in the future.
 
 error[E0596]: cannot borrow `tick2` as mutable, as it is not declared as mutable
   --> $DIR/unboxed-closures-infer-fnmut-calling-fnmut-no-mut.rs:30:5
@@ -20,6 +16,6 @@ LL |     let tick2 = || { //~ ERROR closure cannot assign to immutable local var
 LL |     tick2(); //~ ERROR cannot borrow
    |     ^^^^^ cannot borrow as mutable
 
-error: aborting due to previous error
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0596`.

--- a/src/test/ui/unboxed-closures/unboxed-closures-mutate-upvar.nll.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-mutate-upvar.nll.stderr
@@ -1,4 +1,4 @@
-warning[E0594]: cannot assign to `n`, as it is not declared as mutable
+error[E0594]: cannot assign to `n`, as it is not declared as mutable
   --> $DIR/unboxed-closures-mutate-upvar.rs:25:9
    |
 LL |     let n = 0;
@@ -6,10 +6,6 @@ LL |     let n = 0;
 LL |     let mut f = to_fn_mut(|| { //~ ERROR closure cannot assign
 LL |         n += 1;
    |         ^^^^^^ cannot assign
-   |
-   = warning: This error has been downgraded to a warning for backwards compatibility with previous releases.
-           It represents potential unsoundness in your code.
-           This warning will become a hard error in the future.
 
 error[E0594]: cannot assign to `n`, as it is not declared as mutable
   --> $DIR/unboxed-closures-mutate-upvar.rs:42:9
@@ -44,6 +40,6 @@ LL | |         n += 1; //~ ERROR cannot assign
 LL | |     });
    | |_____^
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0594`.


### PR DESCRIPTION
Successful merges:

 - #54885 (Don't lint 'unused_parens` on `if (break _) { .. }`)
 - #55205 (Improve a few cases of collecting to an FxHash(Map/Set))
 - #55450 (msp430: remove the whole Atomic* API)
 - #55459 (Add UI test for #49296)
 - #55472 (Use opt.take() instead of mem::replace(opt, None))
 - #55473 (Take advantage of impl Iterator in (transitive/elaborate)_bounds)
 - #55474 (Fix validation false positive)
 - #55476 (Change a flat_map with 0/1-element vecs to a filter_map)
 - #55487 (Adjust Ids of path segments in visibility modifiers)
 - #55493 (Doc fixes)
 - #55494 (borrowck=migrate must look at parents of closures)
 - #55496 (Update clippy)

Failed merges:


r? @ghost