### PR TITLE
Use vec![x; n] instead of iter::repeat(x).take(n).collect()

### DIFF
--- a/src/librustc/mir/interpret/mod.rs
+++ b/src/librustc/mir/interpret/mod.rs
@@ -295,12 +295,10 @@ impl AllocDecodingState {
     }
 
     pub fn new(data_offsets: Vec<u32>) -> AllocDecodingState {
-        let decoding_state: Vec<_> = ::std::iter::repeat(Mutex::new(State::Empty))
-            .take(data_offsets.len())
-            .collect();
+        let decoding_state = vec![Mutex::new(State::Empty); data_offsets.len()];
 
         AllocDecodingState {
-            decoding_state: decoding_state,
+            decoding_state,
             data_offsets,
         }
     }

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -34,7 +34,6 @@ use hir::def_id::DefId;
 use infer::{self, InferCtxt};
 use infer::type_variable::TypeVariableOrigin;
 use std::fmt;
-use std::iter;
 use syntax::ast;
 use session::DiagnosticMessageId;
 use ty::{self, AdtKind, ToPredicate, ToPolyTraitRef, Ty, TyCtxt, TypeFoldable};
@@ -1095,10 +1094,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
             // found arguments is empty (assume the user just wants to ignore args in this case).
             // For example, if `expected_args_length` is 2, suggest `|_, _|`.
             if found_args.is_empty() && is_closure {
-                let underscores = iter::repeat("_")
-                                      .take(expected_args.len())
-                                      .collect::<Vec<_>>()
-                                      .join(", ");
+                let underscores = vec!["_"; expected_args.len()].join(", ");
                 err.span_suggestion_with_applicability(
                     found_span,
                     &format!(


### PR DESCRIPTION
It's shorter and possibly easier to optimize.