### PR TITLE
Add link to std::mem::size_of to size_of intrinsic documentation

### DIFF
--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -675,7 +675,6 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is
     /// [`std::mem::size_of`](../../std/mem/fn.size_of.html).
-
     pub fn size_of<T>() -> usize;
 
     /// Moves a value to an uninitialized memory location.

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -672,6 +672,10 @@ extern "rust-intrinsic" {
     ///
     /// More specifically, this is the offset in bytes between successive
     /// items of the same type, including alignment padding.
+    ///
+    /// The stabilized version of this intrinsic is
+    /// [`std::mem::size_of`](../../std/mem/fn.size_of.html).
+
     pub fn size_of<T>() -> usize;
 
     /// Moves a value to an uninitialized memory location.


### PR DESCRIPTION
The other intrinsics with safe/stable alternatives already have documentation to this effect.