### PR TITLE
std: Improve codegen size of accessing TLS

### DIFF
--- a/src/liballoc_system/lib.rs
+++ b/src/liballoc_system/lib.rs
@@ -405,6 +405,7 @@ mod platform {
 
     #[cfg(not(target_feature = "atomics"))]
     mod lock {
+        #[inline]
         pub fn lock() {} // no atomics, no threads, that's easy!
     }
 }

--- a/src/test/run-make/wasm-panic-small/Makefile
+++ b/src/test/run-make/wasm-panic-small/Makefile
@@ -11,6 +11,9 @@ all:
 	$(RUSTC) foo.rs -C lto -O --target wasm32-unknown-unknown --cfg c
 	wc -c < $(TMPDIR)/foo.wasm
 	[ "`wc -c < $(TMPDIR)/foo.wasm`" -lt "5120" ]
+	$(RUSTC) foo.rs -C lto -O --target wasm32-unknown-unknown --cfg d
+	wc -c < $(TMPDIR)/foo.wasm
+	[ "`wc -c < $(TMPDIR)/foo.wasm`" -lt "5120" ]
 else
 all:
 endif

--- a/src/test/run-make/wasm-panic-small/foo.rs
+++ b/src/test/run-make/wasm-panic-small/foo.rs
@@ -27,3 +27,11 @@ pub fn foo() {
 pub fn foo() {
     panic!("{}", "a");
 }
+
+#[no_mangle]
+#[cfg(d)]
+pub fn foo() -> usize {
+    use std::cell::Cell;
+    thread_local!(static A: Cell<Vec<u32>> = Cell::new(Vec::new()));
+    A.try_with(|x| x.replace(Vec::new()).len()).unwrap_or(0)
+}


### PR DESCRIPTION
Some code in the TLS implementation in libstd stores `Some(val)` into an
`&mut Option<T>` (effectively) and then pulls out `&T`, but it currently
uses `.unwrap()` which can codegen into a panic even though it can never
panic. With sufficient optimizations enabled (like LTO) the compiler can
see through this but this commit helps it along in normal mode
(`--release` with Cargo by default) to avoid codegen'ing the panic path.

This ends up improving the optimized codegen on wasm by ensuring that a
call to panic pulling in more file size doesn't stick around.