### PR TITLE
Implement checked_add_duration for SystemTime

### DIFF
--- a/src/libstd/sys/redox/time.rs
+++ b/src/libstd/sys/redox/time.rs
@@ -46,25 +46,18 @@ impl Timespec {
     }
 
     fn checked_add_duration(&self, other: &Duration) -> Option<Timespec> {
-        let mut secs = match other
+        let mut secs = other
             .as_secs()
             .try_into() // <- target type would be `i64`
             .ok()
-            .and_then(|secs| self.t.tv_sec.checked_add(secs))
-        {
-            Some(ts) => ts,
-            None => return None,
-        };
+            .and_then(|secs| self.t.tv_sec.checked_add(secs))?;
 
         // Nano calculations can't overflow because nanos are <1B which fit
         // in a u32.
         let mut nsec = other.subsec_nanos() + self.t.tv_nsec as u32;
         if nsec >= NSEC_PER_SEC as u32 {
             nsec -= NSEC_PER_SEC as u32;
-            secs = match secs.checked_add(1) {
-                Some(ts) => ts,
-                None => return None,
-            }
+            secs = secs.checked_add(1)?;
         }
         Some(Timespec {
             t: syscall::TimeSpec {

--- a/src/libstd/sys/redox/time.rs
+++ b/src/libstd/sys/redox/time.rs
@@ -42,27 +42,36 @@ impl Timespec {
     }
 
     fn add_duration(&self, other: &Duration) -> Timespec {
-        let mut secs = other
+        self.checked_add_duration(other).expect("overflow when adding duration to time")
+    }
+
+    fn checked_add_duration(&self, other: &Duration) -> Option<Timespec> {
+        let mut secs = match other
             .as_secs()
             .try_into() // <- target type would be `i64`
             .ok()
             .and_then(|secs| self.t.tv_sec.checked_add(secs))
-            .expect("overflow when adding duration to time");
+        {
+            Some(ts) => ts,
+            None => return None,
+        };
 
         // Nano calculations can't overflow because nanos are <1B which fit
         // in a u32.
         let mut nsec = other.subsec_nanos() + self.t.tv_nsec as u32;
         if nsec >= NSEC_PER_SEC as u32 {
             nsec -= NSEC_PER_SEC as u32;
-            secs = secs.checked_add(1).expect("overflow when adding \
-                                               duration to time");
+            secs = match secs.checked_add(1) {
+                Some(ts) => ts,
+                None => return None,
+            }
         }
-        Timespec {
+        Some(Timespec {
             t: syscall::TimeSpec {
                 tv_sec: secs,
                 tv_nsec: nsec as i32,
             },
-        }
+        })
     }
 
     fn sub_duration(&self, other: &Duration) -> Timespec {
@@ -178,6 +187,10 @@ impl SystemTime {
 
     pub fn add_duration(&self, other: &Duration) -> SystemTime {
         SystemTime { t: self.t.add_duration(other) }
+    }
+
+    pub fn checked_add_duration(&self, other: &Duration) -> Option<SystemTime> {
+        self.t.checked_add_duration(other).map(|t| SystemTime { t })
     }
 
     pub fn sub_duration(&self, other: &Duration) -> SystemTime {

--- a/src/libstd/sys/unix/time.rs
+++ b/src/libstd/sys/unix/time.rs
@@ -43,27 +43,36 @@ impl Timespec {
     }
 
     fn add_duration(&self, other: &Duration) -> Timespec {
-        let mut secs = other
+        self.checked_add_duration(other).expect("overflow when adding duration to time")
+    }
+
+    fn checked_add_duration(&self, other: &Duration) -> Option<Timespec> {
+        let mut secs = match other
             .as_secs()
             .try_into() // <- target type would be `libc::time_t`
             .ok()
             .and_then(|secs| self.t.tv_sec.checked_add(secs))
-            .expect("overflow when adding duration to time");
+        {
+            Some(ts) => ts,
+            None => return None,
+        };
 
         // Nano calculations can't overflow because nanos are <1B which fit
         // in a u32.
         let mut nsec = other.subsec_nanos() + self.t.tv_nsec as u32;
         if nsec >= NSEC_PER_SEC as u32 {
             nsec -= NSEC_PER_SEC as u32;
-            secs = secs.checked_add(1).expect("overflow when adding \
-                                               duration to time");
+            secs = match secs.checked_add(1) {
+                Some(ts) => ts,
+                None => return None,
+            }
         }
-        Timespec {
+        Some(Timespec {
             t: libc::timespec {
                 tv_sec: secs,
                 tv_nsec: nsec as _,
             },
-        }
+        })
     }
 
     fn sub_duration(&self, other: &Duration) -> Timespec {
@@ -201,6 +210,10 @@ mod inner {
             SystemTime { t: self.t.add_duration(other) }
         }
 
+        pub fn checked_add_duration(&self, other: &Duration) -> Option<SystemTime> {
+            self.t.checked_add_duration(other).map(|t| SystemTime { t })
+        }
+
         pub fn sub_duration(&self, other: &Duration) -> SystemTime {
             SystemTime { t: self.t.sub_duration(other) }
         }
@@ -323,6 +336,10 @@ mod inner {
 
         pub fn add_duration(&self, other: &Duration) -> SystemTime {
             SystemTime { t: self.t.add_duration(other) }
+        }
+
+        pub fn checked_add_duration(&self, other: &Duration) -> Option<SystemTime> {
+            self.t.checked_add_duration(other).map(|t| SystemTime { t })
         }
 
         pub fn sub_duration(&self, other: &Duration) -> SystemTime {

--- a/src/libstd/sys/wasm/time.rs
+++ b/src/libstd/sys/wasm/time.rs
@@ -51,6 +51,10 @@ impl SystemTime {
         SystemTime(self.0 + *other)
     }
 
+    pub fn checked_add_duration(&self, other: &Duration) -> Option<SystemTime> {
+        self.0.checked_add(*other).map(|d| SystemTime(d))
+    }
+
     pub fn sub_duration(&self, other: &Duration) -> SystemTime {
         SystemTime(self.0 - *other)
     }

--- a/src/libstd/time.rs
+++ b/src/libstd/time.rs
@@ -357,6 +357,14 @@ impl SystemTime {
     pub fn elapsed(&self) -> Result<Duration, SystemTimeError> {
         SystemTime::now().duration_since(*self)
     }
+
+    /// Returns `Some(t)` where `t` is the time `self + duration` if `t` can be represented as
+    /// `SystemTime` (which means it's inside the bounds of the underlying data structure), `None`
+    /// otherwise.
+    #[stable(feature = "time_checked_add", since = "1.32.0")]
+    pub fn checked_add_duration(&self, duration: &Duration) -> Option<SystemTime> {
+        self.0.checked_add_duration(duration).map(|t| SystemTime(t))
+    }
 }
 
 #[stable(feature = "time2", since = "1.8.0")]
@@ -557,6 +565,19 @@ mod tests {
         let one_second_from_epoch2 = UNIX_EPOCH + Duration::new(0, 500_000_000)
             + Duration::new(0, 500_000_000);
         assert_eq!(one_second_from_epoch, one_second_from_epoch2);
+
+        // checked_add_duration will not panic on overflow
+        let mut maybe_t = Some(SystemTime::UNIX_EPOCH);
+        let max_duration = Duration::from_secs(u64::max_value());
+        // in case `SystemTime` can store `>= UNIX_EPOCH + max_duration`.
+        for _ in 0..2 {
+            maybe_t = maybe_t.and_then(|t| t.checked_add_duration(&max_duration));
+        }
+        assert_eq!(maybe_t, None);
+
+        // checked_add_duration calculates the right time and will work for another year
+        let year = Duration::from_secs(60 * 60 * 24 * 365);
+        assert_eq!(a + year, a.checked_add_duration(&year).unwrap());
     }
 
     #[test]

--- a/src/libstd/time.rs
+++ b/src/libstd/time.rs
@@ -361,9 +361,9 @@ impl SystemTime {
     /// Returns `Some(t)` where `t` is the time `self + duration` if `t` can be represented as
     /// `SystemTime` (which means it's inside the bounds of the underlying data structure), `None`
     /// otherwise.
-    #[stable(feature = "time_checked_add", since = "1.32.0")]
-    pub fn checked_add_duration(&self, duration: &Duration) -> Option<SystemTime> {
-        self.0.checked_add_duration(duration).map(|t| SystemTime(t))
+    #[unstable(feature = "time_checked_add", issue = "55940")]
+    pub fn checked_add(&self, duration: Duration) -> Option<SystemTime> {
+        self.0.checked_add_duration(&duration).map(|t| SystemTime(t))
     }
 }
 
@@ -571,13 +571,13 @@ mod tests {
         let max_duration = Duration::from_secs(u64::max_value());
         // in case `SystemTime` can store `>= UNIX_EPOCH + max_duration`.
         for _ in 0..2 {
-            maybe_t = maybe_t.and_then(|t| t.checked_add_duration(&max_duration));
+            maybe_t = maybe_t.and_then(|t| t.checked_add(max_duration));
         }
         assert_eq!(maybe_t, None);
 
         // checked_add_duration calculates the right time and will work for another year
         let year = Duration::from_secs(60 * 60 * 24 * 365);
-        assert_eq!(a + year, a.checked_add_duration(&year).unwrap());
+        assert_eq!(a + year, a.checked_add(year).unwrap());
     }
 
     #[test]


### PR DESCRIPTION
[Original discussion on the rust user forum](https://users.rust-lang.org/t/std-systemtime-misses-a-checked-add-function/21785)

Since `SystemTime` is opaque there is no way to check if the result of an addition will be in bounds. That makes the `Add<Duration>` trait completely unusable with untrusted data. This is a big problem because adding a `Duration` to `UNIX_EPOCH` is the standard way of constructing a `SystemTime` from a unix timestamp.

This PR implements `checked_add_duration(&self, &Duration) -> Option<SystemTime>` for `std::time::SystemTime` and as a prerequisite also for all platform specific time structs. This also led to the refactoring of many `add_duration(&self, &Duration) -> SystemTime` functions to avoid redundancy (they now unwrap the result of `checked_add_duration`).

Some basic unit tests for the newly introduced function were added too.

I wasn't sure which stabilization attribute to add to the newly introduced function, so I just chose `#[stable(feature = "time_checked_add", since = "1.32.0")]` for now to make it compile. Please let me know how I should change it or if I violated any other conventions.

P.S.: I could only test on Linux so far, so I don't necessarily expect it to compile for all platforms.