### PR TITLE
Bump nightly to 1.32.0

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -198,14 +198,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cargo"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "bufstream 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytesize 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "crates-io 0.20.0",
+ "crates-io 0.21.0",
  "crossbeam-utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto-hash 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "curl 0.4.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -483,7 +483,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "crates-io"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "curl 0.4.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1784,7 +1784,7 @@ dependencies = [
 name = "rls"
 version = "0.130.5"
 dependencies = [
- "cargo 0.32.0",
+ "cargo 0.33.0",
  "cargo_metadata 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy_lints 0.0.212",
  "crossbeam-channel 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/bootstrap/channel.rs
+++ b/src/bootstrap/channel.rs
@@ -24,7 +24,7 @@ use Build;
 use config::Config;
 
 // The version number
-pub const CFG_RELEASE_NUM: &str = "1.31.0";
+pub const CFG_RELEASE_NUM: &str = "1.32.0";
 
 pub struct GitInfo {
     inner: Option<Info>,

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -86,7 +86,6 @@
 #![feature(box_syntax)]
 #![feature(cfg_target_has_atomic)]
 #![feature(coerce_unsized)]
-#![cfg_attr(stage0, feature(min_const_fn))]
 #![feature(core_intrinsics)]
 #![feature(custom_attribute)]
 #![feature(dropck_eyepatch)]

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -282,7 +282,7 @@ struct RcBox<T: ?Sized> {
 /// type `T`.
 ///
 /// [get_mut]: #method.get_mut
-#[cfg_attr(all(not(stage0), not(test)), lang = "rc")]
+#[cfg_attr(not(test), lang = "rc")]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Rc<T: ?Sized> {
     ptr: NonNull<RcBox<T>>,

--- a/src/liballoc/sync.rs
+++ b/src/liballoc/sync.rs
@@ -199,7 +199,7 @@ const MAX_REFCOUNT: usize = (isize::MAX) as usize;
 /// counting in general.
 ///
 /// [rc_examples]: ../../std/rc/index.html#examples
-#[cfg_attr(all(not(stage0), not(test)), lang = "arc")]
+#[cfg_attr(not(test), lang = "arc")]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Arc<T: ?Sized> {
     ptr: NonNull<ArcInner<T>>,

--- a/src/liballoc/tests/lib.rs
+++ b/src/liballoc/tests/lib.rs
@@ -11,7 +11,6 @@
 #![feature(allocator_api)]
 #![feature(alloc_system)]
 #![feature(box_syntax)]
-#![cfg_attr(stage0, feature(min_const_fn))]
 #![feature(drain_filter)]
 #![feature(exact_size_is_empty)]
 #![feature(pattern)]

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -88,7 +88,6 @@
 #![feature(doc_spotlight)]
 #![feature(extern_types)]
 #![feature(fundamental)]
-#![cfg_attr(stage0, feature(impl_header_lifetime_elision))]
 #![feature(intrinsics)]
 #![feature(lang_items)]
 #![feature(link_llvm_intrinsics)]

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -285,7 +285,7 @@ pub fn forget<T>(t: T) {
 /// [alignment]: ./fn.align_of.html
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[cfg_attr(not(stage0), rustc_promotable)]
+#[rustc_promotable]
 pub const fn size_of<T>() -> usize {
     intrinsics::size_of::<T>()
 }
@@ -377,7 +377,7 @@ pub fn min_align_of_val<T: ?Sized>(val: &T) -> usize {
 /// ```
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[cfg_attr(not(stage0), rustc_promotable)]
+#[rustc_promotable]
 pub const fn align_of<T>() -> usize {
     intrinsics::min_align_of::<T>()
 }
@@ -458,17 +458,8 @@ pub fn align_of_val<T: ?Sized>(val: &T) -> usize {
 #[inline]
 #[stable(feature = "needs_drop", since = "1.21.0")]
 #[rustc_const_unstable(feature = "const_needs_drop")]
-#[cfg(not(stage0))]
 pub const fn needs_drop<T>() -> bool {
     intrinsics::needs_drop::<T>()
-}
-
-#[inline]
-#[stable(feature = "needs_drop", since = "1.21.0")]
-#[cfg(stage0)]
-/// Ceci n'est pas la documentation
-pub fn needs_drop<T>() -> bool {
-    unsafe { intrinsics::needs_drop::<T>() }
 }
 
 /// Creates a value whose bytes are all zero.

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -216,7 +216,7 @@ $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
             #[inline]
-            #[cfg_attr(not(stage0), rustc_promotable)]
+            #[rustc_promotable]
             pub const fn min_value() -> Self {
                 !0 ^ ((!0 as $UnsignedT) >> 1) as Self
             }
@@ -235,7 +235,7 @@ $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
             #[inline]
-            #[cfg_attr(not(stage0), rustc_promotable)]
+            #[rustc_promotable]
             pub const fn max_value() -> Self {
                 !Self::min_value()
             }

--- a/src/libcore/ops/range.rs
+++ b/src/libcore/ops/range.rs
@@ -391,7 +391,7 @@ impl<Idx> RangeInclusive<Idx> {
     /// ```
     #[stable(feature = "inclusive_range_methods", since = "1.27.0")]
     #[inline]
-    #[cfg_attr(not(stage0), rustc_promotable)]
+    #[rustc_promotable]
     pub const fn new(start: Idx, end: Idx) -> Self {
         Self { start, end, is_empty: None }
     }

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -209,7 +209,7 @@ pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T) {
 /// ```
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[cfg_attr(not(stage0), rustc_promotable)]
+#[rustc_promotable]
 pub const fn null<T>() -> *const T { 0 as *const T }
 
 /// Creates a null mutable raw pointer.
@@ -224,7 +224,7 @@ pub const fn null<T>() -> *const T { 0 as *const T }
 /// ```
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[cfg_attr(not(stage0), rustc_promotable)]
+#[rustc_promotable]
 pub const fn null_mut<T>() -> *mut T { 0 as *mut T }
 
 /// Swaps the values at two mutable locations of the same type, without

--- a/src/libcore/tests/lib.rs
+++ b/src/libcore/tests/lib.rs
@@ -19,7 +19,6 @@
 #![feature(flt2dec)]
 #![feature(fmt_internals)]
 #![feature(hashmap_internals)]
-#![cfg_attr(stage0, feature(impl_header_lifetime_elision))]
 #![feature(pattern)]
 #![feature(range_is_empty)]
 #![feature(raw)]

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -109,7 +109,7 @@ impl Duration {
     /// ```
     #[stable(feature = "duration", since = "1.3.0")]
     #[inline]
-    #[cfg_attr(not(stage0), rustc_promotable)]
+    #[rustc_promotable]
     pub const fn from_secs(secs: u64) -> Duration {
         Duration { secs, nanos: 0 }
     }
@@ -128,7 +128,7 @@ impl Duration {
     /// ```
     #[stable(feature = "duration", since = "1.3.0")]
     #[inline]
-    #[cfg_attr(not(stage0), rustc_promotable)]
+    #[rustc_promotable]
     pub const fn from_millis(millis: u64) -> Duration {
         Duration {
             secs: millis / MILLIS_PER_SEC,
@@ -150,7 +150,7 @@ impl Duration {
     /// ```
     #[stable(feature = "duration_from_micros", since = "1.27.0")]
     #[inline]
-    #[cfg_attr(not(stage0), rustc_promotable)]
+    #[rustc_promotable]
     pub const fn from_micros(micros: u64) -> Duration {
         Duration {
             secs: micros / MICROS_PER_SEC,
@@ -172,7 +172,7 @@ impl Duration {
     /// ```
     #[stable(feature = "duration_extras", since = "1.27.0")]
     #[inline]
-    #[cfg_attr(not(stage0), rustc_promotable)]
+    #[rustc_promotable]
     pub const fn from_nanos(nanos: u64) -> Duration {
         Duration {
             secs: nanos / (NANOS_PER_SEC as u64),

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -42,7 +42,6 @@
 
 #![feature(box_patterns)]
 #![feature(box_syntax)]
-#![cfg_attr(stage0, feature(min_const_fn))]
 #![feature(core_intrinsics)]
 #![feature(drain_filter)]
 #![cfg_attr(windows, feature(libc))]
@@ -67,7 +66,6 @@
 #![feature(step_trait)]
 #![feature(integer_atomics)]
 #![feature(test)]
-#![cfg_attr(stage0, feature(impl_header_lifetime_elision))]
 #![feature(in_band_lifetimes)]
 #![feature(macro_at_most_once_rep)]
 #![feature(crate_visibility_modifier)]

--- a/src/librustc_data_structures/lib.rs
+++ b/src/librustc_data_structures/lib.rs
@@ -21,7 +21,6 @@
       html_root_url = "https://doc.rust-lang.org/nightly/")]
 
 #![feature(in_band_lifetimes)]
-#![cfg_attr(stage0, feature(impl_header_lifetime_elision))]
 #![feature(unboxed_closures)]
 #![feature(fn_traits)]
 #![feature(unsize)]

--- a/src/librustc_mir/lib.rs
+++ b/src/librustc_mir/lib.rs
@@ -16,7 +16,6 @@ Rust MIR: a lowered representation of Rust. Also: an experiment!
 
 #![feature(nll)]
 #![feature(in_band_lifetimes)]
-#![cfg_attr(stage0, feature(impl_header_lifetime_elision))]
 #![feature(slice_patterns)]
 #![feature(slice_sort_by_cached_key)]
 #![feature(box_patterns)]

--- a/src/librustc_target/lib.rs
+++ b/src/librustc_target/lib.rs
@@ -22,7 +22,6 @@
       html_root_url = "https://doc.rust-lang.org/nightly/")]
 
 #![feature(box_syntax)]
-#![cfg_attr(stage0, feature(min_const_fn))]
 #![feature(nll)]
 #![feature(slice_patterns)]
 

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -250,7 +250,6 @@
 #![feature(cfg_target_vendor)]
 #![feature(char_error_internals)]
 #![feature(compiler_builtins_lib)]
-#![cfg_attr(stage0, feature(min_const_fn))]
 #![feature(const_int_ops)]
 #![feature(const_ip)]
 #![feature(const_raw_ptr_deref)]

--- a/src/stage0.txt
+++ b/src/stage0.txt
@@ -12,7 +12,7 @@
 # source tarball for a stable release you'll likely see `1.x.0` for rustc and
 # `0.x.0` for Cargo where they were released on `date`.
 
-date: 2018-10-13
+date: 2018-10-30
 rustc: beta
 cargo: beta
 


### PR DESCRIPTION
* Also update the bootstrap compiler
* Update cargo to 1.32.0
* Clean out stage0 annotations