### PR TITLE
Value visitors for miri

### DIFF
--- a/src/librustc/mir/interpret/error.rs
+++ b/src/librustc/mir/interpret/error.rs
@@ -15,7 +15,7 @@ use ty::{Ty, layout};
 use ty::layout::{Size, Align, LayoutError};
 use rustc_target::spec::abi::Abi;
 
-use super::Pointer;
+use super::{Pointer, Scalar};
 
 use backtrace::Backtrace;
 
@@ -240,7 +240,7 @@ pub enum EvalErrorKind<'tcx, O> {
     InvalidMemoryAccess,
     InvalidFunctionPointer,
     InvalidBool,
-    InvalidDiscriminant(u128),
+    InvalidDiscriminant(Scalar),
     PointerOutOfBounds {
         ptr: Pointer,
         access: bool,

--- a/src/librustc/mir/interpret/mod.rs
+++ b/src/librustc/mir/interpret/mod.rs
@@ -91,12 +91,33 @@ pub trait PointerArithmetic: layout::HasDataLayout {
     }
 
     //// Trunace the given value to the pointer size; also return whether there was an overflow
+    #[inline]
     fn truncate_to_ptr(&self, val: u128) -> (u64, bool) {
         let max_ptr_plus_1 = 1u128 << self.pointer_size().bits();
         ((val % max_ptr_plus_1) as u64, val >= max_ptr_plus_1)
     }
 
+    #[inline]
+    fn offset<'tcx>(&self, val: u64, i: u64) -> EvalResult<'tcx, u64> {
+        let (res, over) = self.overflowing_offset(val, i);
+        if over { err!(Overflow(mir::BinOp::Add)) } else { Ok(res) }
+    }
+
+    #[inline]
+    fn overflowing_offset(&self, val: u64, i: u64) -> (u64, bool) {
+        let (res, over1) = val.overflowing_add(i);
+        let (res, over2) = self.truncate_to_ptr(u128::from(res));
+        (res, over1 || over2)
+    }
+
+    #[inline]
+    fn signed_offset<'tcx>(&self, val: u64, i: i64) -> EvalResult<'tcx, u64> {
+        let (res, over) = self.overflowing_signed_offset(val, i128::from(i));
+        if over { err!(Overflow(mir::BinOp::Add)) } else { Ok(res) }
+    }
+
     // Overflow checking only works properly on the range from -u64 to +u64.
+    #[inline]
     fn overflowing_signed_offset(&self, val: u64, i: i128) -> (u64, bool) {
         // FIXME: is it possible to over/underflow here?
         if i < 0 {
@@ -107,26 +128,6 @@ pub trait PointerArithmetic: layout::HasDataLayout {
         } else {
             self.overflowing_offset(val, i as u64)
         }
-    }
-
-    fn overflowing_offset(&self, val: u64, i: u64) -> (u64, bool) {
-        let (res, over1) = val.overflowing_add(i);
-        let (res, over2) = self.truncate_to_ptr(res as u128);
-        (res, over1 || over2)
-    }
-
-    fn signed_offset<'tcx>(&self, val: u64, i: i64) -> EvalResult<'tcx, u64> {
-        let (res, over) = self.overflowing_signed_offset(val, i as i128);
-        if over { err!(Overflow(mir::BinOp::Add)) } else { Ok(res) }
-    }
-
-    fn offset<'tcx>(&self, val: u64, i: u64) -> EvalResult<'tcx, u64> {
-        let (res, over) = self.overflowing_offset(val, i);
-        if over { err!(Overflow(mir::BinOp::Add)) } else { Ok(res) }
-    }
-
-    fn wrapping_signed_offset(&self, val: u64, i: i64) -> u64 {
-        self.overflowing_signed_offset(val, i as i128).0
     }
 }
 
@@ -176,32 +177,7 @@ impl<'tcx, Tag> Pointer<Tag> {
         Pointer { alloc_id, offset, tag }
     }
 
-    pub fn wrapping_signed_offset(self, i: i64, cx: &impl HasDataLayout) -> Self {
-        Pointer::new_with_tag(
-            self.alloc_id,
-            Size::from_bytes(cx.data_layout().wrapping_signed_offset(self.offset.bytes(), i)),
-            self.tag,
-        )
-    }
-
-    pub fn overflowing_signed_offset(self, i: i128, cx: &impl HasDataLayout) -> (Self, bool) {
-        let (res, over) = cx.data_layout().overflowing_signed_offset(self.offset.bytes(), i);
-        (Pointer::new_with_tag(self.alloc_id, Size::from_bytes(res), self.tag), over)
-    }
-
-    pub fn signed_offset(self, i: i64, cx: &impl HasDataLayout) -> EvalResult<'tcx, Self> {
-        Ok(Pointer::new_with_tag(
-            self.alloc_id,
-            Size::from_bytes(cx.data_layout().signed_offset(self.offset.bytes(), i)?),
-            self.tag,
-        ))
-    }
-
-    pub fn overflowing_offset(self, i: Size, cx: &impl HasDataLayout) -> (Self, bool) {
-        let (res, over) = cx.data_layout().overflowing_offset(self.offset.bytes(), i.bytes());
-        (Pointer::new_with_tag(self.alloc_id, Size::from_bytes(res), self.tag), over)
-    }
-
+    #[inline]
     pub fn offset(self, i: Size, cx: &impl HasDataLayout) -> EvalResult<'tcx, Self> {
         Ok(Pointer::new_with_tag(
             self.alloc_id,
@@ -211,6 +187,37 @@ impl<'tcx, Tag> Pointer<Tag> {
     }
 
     #[inline]
+    pub fn overflowing_offset(self, i: Size, cx: &impl HasDataLayout) -> (Self, bool) {
+        let (res, over) = cx.data_layout().overflowing_offset(self.offset.bytes(), i.bytes());
+        (Pointer::new_with_tag(self.alloc_id, Size::from_bytes(res), self.tag), over)
+    }
+
+    #[inline(always)]
+    pub fn wrapping_offset(self, i: Size, cx: &impl HasDataLayout) -> Self {
+        self.overflowing_offset(i, cx).0
+    }
+
+    #[inline]
+    pub fn signed_offset(self, i: i64, cx: &impl HasDataLayout) -> EvalResult<'tcx, Self> {
+        Ok(Pointer::new_with_tag(
+            self.alloc_id,
+            Size::from_bytes(cx.data_layout().signed_offset(self.offset.bytes(), i)?),
+            self.tag,
+        ))
+    }
+
+    #[inline]
+    pub fn overflowing_signed_offset(self, i: i128, cx: &impl HasDataLayout) -> (Self, bool) {
+        let (res, over) = cx.data_layout().overflowing_signed_offset(self.offset.bytes(), i);
+        (Pointer::new_with_tag(self.alloc_id, Size::from_bytes(res), self.tag), over)
+    }
+
+    #[inline(always)]
+    pub fn wrapping_signed_offset(self, i: i64, cx: &impl HasDataLayout) -> Self {
+        self.overflowing_signed_offset(i128::from(i), cx).0
+    }
+
+    #[inline(always)]
     pub fn erase_tag(self) -> Pointer {
         Pointer { alloc_id: self.alloc_id, offset: self.offset, tag: () }
     }

--- a/src/librustc/mir/interpret/value.rs
+++ b/src/librustc/mir/interpret/value.rs
@@ -202,6 +202,19 @@ impl<'tcx, Tag> Scalar<Tag> {
         }
     }
 
+    /// Returns this pointers offset from the allocation base, or from NULL (for
+    /// integer pointers).
+    #[inline]
+    pub fn get_ptr_offset(self, cx: &impl HasDataLayout) -> Size {
+        match self {
+            Scalar::Bits { bits, size } => {
+                assert_eq!(size as u64, cx.pointer_size().bytes());
+                Size::from_bytes(bits as u64)
+            }
+            Scalar::Ptr(ptr) => ptr.offset,
+        }
+    }
+
     #[inline]
     pub fn is_null_ptr(self, cx: &impl HasDataLayout) -> bool {
         match self {

--- a/src/librustc/mir/interpret/value.rs
+++ b/src/librustc/mir/interpret/value.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![allow(unknown_lints)]
+use std::fmt;
 
 use ty::layout::{HasDataLayout, Size};
 use ty::subst::Substs;
@@ -97,6 +97,15 @@ pub enum Scalar<Tag=(), Id=AllocId> {
     /// relocations, but a `Scalar` is only large enough to contain one, so we just represent the
     /// relocation and its associated offset together as a `Pointer` here.
     Ptr(Pointer<Tag, Id>),
+}
+
+impl<Tag> fmt::Display for Scalar<Tag> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Scalar::Ptr(_) => write!(f, "a pointer"),
+            Scalar::Bits { bits, .. } => write!(f, "{}", bits),
+        }
+    }
 }
 
 impl<'tcx> Scalar<()> {

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -535,7 +535,7 @@ fn validate_const<'a, 'tcx>(
     key: ty::ParamEnvAnd<'tcx, GlobalId<'tcx>>,
 ) -> ::rustc::mir::interpret::ConstEvalResult<'tcx> {
     let cid = key.value;
-    let mut ecx = mk_eval_cx(tcx, cid.instance, key.param_env).unwrap();
+    let ecx = mk_eval_cx(tcx, cid.instance, key.param_env).unwrap();
     let val = (|| {
         let op = ecx.const_to_op(constant)?;
         let mut ref_tracking = RefTracking::new(op);

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -535,14 +535,14 @@ fn validate_const<'a, 'tcx>(
     key: ty::ParamEnvAnd<'tcx, GlobalId<'tcx>>,
 ) -> ::rustc::mir::interpret::ConstEvalResult<'tcx> {
     let cid = key.value;
-    let ecx = mk_eval_cx(tcx, cid.instance, key.param_env).unwrap();
+    let mut ecx = mk_eval_cx(tcx, cid.instance, key.param_env).unwrap();
     let val = (|| {
         let op = ecx.const_to_op(constant)?;
         let mut ref_tracking = RefTracking::new(op);
-        while let Some((op, mut path)) = ref_tracking.todo.pop() {
+        while let Some((op, path)) = ref_tracking.todo.pop() {
             ecx.validate_operand(
                 op,
-                &mut path,
+                path,
                 Some(&mut ref_tracking),
                 /* const_mode */ true,
             )?;

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -521,7 +521,7 @@ impl<'a, 'mir, 'tcx: 'mir, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tc
                 // return place is always a local and then this cannot happen.
                 self.validate_operand(
                     self.place_to_op(return_place)?,
-                    &mut vec![],
+                    vec![],
                     None,
                     /*const_mode*/false,
                 )?;

--- a/src/librustc_mir/interpret/machine.rs
+++ b/src/librustc_mir/interpret/machine.rs
@@ -17,11 +17,11 @@ use std::hash::Hash;
 
 use rustc::hir::{self, def_id::DefId};
 use rustc::mir;
-use rustc::ty::{self, Ty, layout::{Size, TyLayout}, query::TyCtxtAt};
+use rustc::ty::{self, layout::{Size, TyLayout}, query::TyCtxtAt};
 
 use super::{
     Allocation, AllocId, EvalResult, Scalar,
-    EvalContext, PlaceTy, OpTy, Pointer, MemPlace, MemoryKind,
+    EvalContext, PlaceTy, MPlaceTy, OpTy, Pointer, MemoryKind,
 };
 
 /// Whether this kind of memory is allowed to leak
@@ -217,26 +217,22 @@ pub trait Machine<'a, 'mir, 'tcx>: Sized {
     #[inline]
     fn tag_reference(
         _ecx: &mut EvalContext<'a, 'mir, 'tcx, Self>,
-        place: MemPlace<Self::PointerTag>,
-        _ty: Ty<'tcx>,
-        _size: Size,
+        place: MPlaceTy<'tcx, Self::PointerTag>,
         _mutability: Option<hir::Mutability>,
-    ) -> EvalResult<'tcx, MemPlace<Self::PointerTag>> {
-        Ok(place)
+    ) -> EvalResult<'tcx, Scalar<Self::PointerTag>> {
+        Ok(place.ptr)
     }
 
     /// Executed when evaluating the `*` operator: Following a reference.
-    /// This has the change to adjust the tag.  It should not change anything else!
+    /// This has the chance to adjust the tag.  It should not change anything else!
     /// `mutability` can be `None` in case a raw ptr is being dereferenced.
     #[inline]
     fn tag_dereference(
         _ecx: &EvalContext<'a, 'mir, 'tcx, Self>,
-        place: MemPlace<Self::PointerTag>,
-        _ty: Ty<'tcx>,
-        _size: Size,
+        place: MPlaceTy<'tcx, Self::PointerTag>,
         _mutability: Option<hir::Mutability>,
-    ) -> EvalResult<'tcx, MemPlace<Self::PointerTag>> {
-        Ok(place)
+    ) -> EvalResult<'tcx, Scalar<Self::PointerTag>> {
+        Ok(place.ptr)
     }
 
     /// Execute a validation operation

--- a/src/librustc_mir/interpret/mod.rs
+++ b/src/librustc_mir/interpret/mod.rs
@@ -23,6 +23,7 @@ mod terminator;
 mod traits;
 mod validity;
 mod intrinsics;
+mod visitor;
 
 pub use rustc::mir::interpret::*; // have all the `interpret` symbols in one place: here
 
@@ -37,5 +38,7 @@ pub use self::memory::{Memory, MemoryKind};
 pub use self::machine::{Machine, AllocMap, MayLeak};
 
 pub use self::operand::{ScalarMaybeUndef, Immediate, ImmTy, Operand, OpTy};
+
+pub use self::visitor::ValueVisitor;
 
 pub use self::validity::RefTracking;

--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -489,6 +489,8 @@ where
 
     /// Get the place of a field inside the place, and also the field's type.
     /// Just a convenience function, but used quite a bit.
+    /// This is the only projection that might have a side-effect: We cannot project
+    /// into the field of a local `ScalarPair`, we have to first allocate it.
     pub fn place_field(
         &mut self,
         base: PlaceTy<'tcx, M::PointerTag>,
@@ -501,7 +503,7 @@ where
     }
 
     pub fn place_downcast(
-        &mut self,
+        &self,
         base: PlaceTy<'tcx, M::PointerTag>,
         variant: usize,
     ) -> EvalResult<'tcx, PlaceTy<'tcx, M::PointerTag>> {
@@ -643,7 +645,7 @@ where
 
         if M::enforce_validity(self) {
             // Data got changed, better make sure it matches the type!
-            self.validate_operand(self.place_to_op(dest)?, &mut vec![], None, /*const_mode*/false)?;
+            self.validate_operand(self.place_to_op(dest)?, vec![], None, /*const_mode*/false)?;
         }
 
         Ok(())
@@ -765,7 +767,7 @@ where
 
         if M::enforce_validity(self) {
             // Data got changed, better make sure it matches the type!
-            self.validate_operand(self.place_to_op(dest)?, &mut vec![], None, /*const_mode*/false)?;
+            self.validate_operand(self.place_to_op(dest)?, vec![], None, /*const_mode*/false)?;
         }
 
         Ok(())
@@ -843,7 +845,7 @@ where
 
         if M::enforce_validity(self) {
             // Data got changed, better make sure it matches the type!
-            self.validate_operand(dest.into(), &mut vec![], None, /*const_mode*/false)?;
+            self.validate_operand(dest.into(), vec![], None, /*const_mode*/false)?;
         }
 
         Ok(())

--- a/src/librustc_mir/interpret/validity.rs
+++ b/src/librustc_mir/interpret/validity.rs
@@ -207,11 +207,11 @@ impl<'rt, 'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>>
     }
 
     #[inline]
-    fn with_field(
+    fn visit_field(
         &mut self,
+        ectx: &mut EvalContext<'a, 'mir, 'tcx, M>,
         val: Self::V,
         field: usize,
-        f: impl FnOnce(&mut Self) -> EvalResult<'tcx>,
     ) -> EvalResult<'tcx> {
         // Remember the old state
         let path_len = self.path.len();
@@ -219,7 +219,7 @@ impl<'rt, 'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>>
         // Perform operation
         self.push_aggregate_field_path_elem(op.layout, field);
         self.op = val;
-        f(self)?;
+        self.visit(ectx)?;
         // Undo changes
         self.path.truncate(path_len);
         self.op = op;
@@ -596,6 +596,6 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
         };
 
         // Run it
-        self.visit_value(&mut visitor)
+        visitor.visit(self)
     }
 }

--- a/src/librustc_mir/interpret/validity.rs
+++ b/src/librustc_mir/interpret/validity.rs
@@ -470,8 +470,11 @@ impl<'rt, 'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>>
         }
     }
 
-    fn visit_array(&mut self, op: OpTy<'tcx, M::PointerTag>) -> EvalResult<'tcx>
-    {
+    fn visit_aggregate(
+        &mut self,
+        op: OpTy<'tcx, M::PointerTag>,
+        fields: impl Iterator<Item=EvalResult<'tcx, Self::V>>,
+    ) -> EvalResult<'tcx> {
         match op.layout.ty.sty {
             ty::Str => {
                 let mplace = op.to_mem_place(); // strings are never immediate
@@ -538,7 +541,7 @@ impl<'rt, 'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>>
                 }
             }
             _ => {
-                self.walk_array(op)? // default handler
+                self.walk_aggregate(op, fields)? // default handler
             }
         }
         Ok(())

--- a/src/librustc_mir/interpret/validity.rs
+++ b/src/librustc_mir/interpret/validity.rs
@@ -129,7 +129,7 @@ struct ValidityVisitor<'rt, 'a: 'rt, 'mir: 'rt, 'tcx: 'a+'rt+'mir, M: Machine<'a
     path: Vec<PathElem>,
     ref_tracking: Option<&'rt mut RefTracking<'tcx, M::PointerTag>>,
     const_mode: bool,
-    ecx: &'rt mut EvalContext<'a, 'mir, 'tcx, M>,
+    ecx: &'rt EvalContext<'a, 'mir, 'tcx, M>,
 }
 
 impl<'rt, 'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> ValidityVisitor<'rt, 'a, 'mir, 'tcx, M> {
@@ -188,8 +188,8 @@ impl<'rt, 'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>>
     type V = OpTy<'tcx, M::PointerTag>;
 
     #[inline(always)]
-    fn ecx(&mut self) -> &mut EvalContext<'a, 'mir, 'tcx, M> {
-        &mut self.ecx
+    fn ecx(&self) -> &EvalContext<'a, 'mir, 'tcx, M> {
+        &self.ecx
     }
 
     #[inline]
@@ -557,7 +557,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
     /// This also toggles between "run-time" (no recursion) and "compile-time" (with recursion)
     /// validation (e.g., pointer values are fine in integers at runtime).
     pub fn validate_operand(
-        &mut self,
+        &self,
         op: OpTy<'tcx, M::PointerTag>,
         path: Vec<PathElem>,
         ref_tracking: Option<&mut RefTracking<'tcx, M::PointerTag>>,

--- a/src/librustc_mir/interpret/validity.rs
+++ b/src/librustc_mir/interpret/validity.rs
@@ -8,24 +8,24 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::fmt::Write;
+use std::fmt::{self, Write};
 use std::hash::Hash;
 
 use syntax_pos::symbol::Symbol;
 use rustc::ty::layout::{self, Size, Align, TyLayout, LayoutOf};
-use rustc::ty;
+use rustc::ty::{self, TyCtxt};
 use rustc_data_structures::fx::FxHashSet;
 use rustc::mir::interpret::{
     Scalar, AllocType, EvalResult, EvalErrorKind
 };
 
 use super::{
-    ImmTy, OpTy, MPlaceTy, Machine, EvalContext, ScalarMaybeUndef
+    OpTy, MPlaceTy, Machine, EvalContext, ScalarMaybeUndef, ValueVisitor
 };
 
 macro_rules! validation_failure {
     ($what:expr, $where:expr, $details:expr) => {{
-        let where_ = path_format($where);
+        let where_ = path_format(&$where);
         let where_ = if where_.is_empty() {
             String::new()
         } else {
@@ -37,7 +37,7 @@ macro_rules! validation_failure {
         )))
     }};
     ($what:expr, $where:expr) => {{
-        let where_ = path_format($where);
+        let where_ = path_format(&$where);
         let where_ = if where_.is_empty() {
             String::new()
         } else {
@@ -129,6 +129,43 @@ fn path_format(path: &Vec<PathElem>) -> String {
     out
 }
 
+fn aggregate_field_path_elem<'a, 'tcx>(
+    layout: TyLayout<'tcx>,
+    field: usize,
+    tcx: TyCtxt<'a, 'tcx, 'tcx>,
+) -> PathElem {
+    match layout.ty.sty {
+        // generators and closures.
+        ty::Closure(def_id, _) | ty::Generator(def_id, _, _) => {
+            if let Some(upvar) = tcx.optimized_mir(def_id).upvar_decls.get(field) {
+                PathElem::ClosureVar(upvar.debug_name)
+            } else {
+                // Sometimes the index is beyond the number of freevars (seen
+                // for a generator).
+                PathElem::ClosureVar(Symbol::intern(&field.to_string()))
+            }
+        }
+
+        // tuples
+        ty::Tuple(_) => PathElem::TupleElem(field),
+
+        // enums
+        ty::Adt(def, ..) if def.is_enum() => {
+            let variant = match layout.variants {
+                layout::Variants::Single { index } => &def.variants[index],
+                _ => bug!("aggregate_field_path_elem: got enum but not in a specific variant"),
+            };
+            PathElem::Field(variant.fields[field].ident.name)
+        }
+
+        // other ADTs
+        ty::Adt(def, _) => PathElem::Field(def.non_enum_variant().fields[field].ident.name),
+
+        // nothing else has an aggregate layout
+        _ => bug!("aggregate_field_path_elem: got non-aggregate type {:?}", layout.ty),
+    }
+}
+
 fn scalar_format<Tag>(value: ScalarMaybeUndef<Tag>) -> String {
     match value {
         ScalarMaybeUndef::Undef =>
@@ -140,37 +177,92 @@ fn scalar_format<Tag>(value: ScalarMaybeUndef<Tag>) -> String {
     }
 }
 
-impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> {
-    /// Make sure that `value` is valid for `ty`, *assuming* `ty` is a primitive type.
-    fn validate_primitive_type(
-        &self,
-        value: ImmTy<'tcx, M::PointerTag>,
-        path: &Vec<PathElem>,
-        ref_tracking: Option<&mut RefTracking<'tcx, M::PointerTag>>,
-        const_mode: bool,
-    ) -> EvalResult<'tcx> {
+struct ValidityVisitor<'rt, 'tcx, Tag> {
+    op: OpTy<'tcx, Tag>,
+    /// The `path` may be pushed to, but the part that is present when a function
+    /// starts must not be changed!  `visit_fields` and `visit_array` rely on
+    /// this stack discipline.
+    path: Vec<PathElem>,
+    ref_tracking: Option<&'rt mut RefTracking<'tcx, Tag>>,
+    const_mode: bool,
+}
+
+impl<Tag: fmt::Debug> fmt::Debug for ValidityVisitor<'_, '_, Tag> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?} ({:?})", *self.op, self.op.layout.ty)
+    }
+}
+
+impl<'rt, 'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>>
+    ValueVisitor<'a, 'mir, 'tcx, M> for ValidityVisitor<'rt, 'tcx, M::PointerTag>
+{
+    #[inline(always)]
+    fn layout(&self) -> TyLayout<'tcx> {
+        self.op.layout
+    }
+
+    fn downcast_enum(&mut self, ectx: &EvalContext<'a, 'mir, 'tcx, M>)
+        -> EvalResult<'tcx>
+    {
+        let variant = match ectx.read_discriminant(self.op) {
+            Ok(res) => res.1,
+            Err(err) => return match err.kind {
+                EvalErrorKind::InvalidDiscriminant(val) =>
+                    validation_failure!(
+                        format!("invalid enum discriminant {}", val), self.path
+                    ),
+                _ =>
+                    validation_failure!(
+                        format!("non-integer enum discriminant"), self.path
+                    ),
+            }
+        };
+        // Put the variant projection onto the path, as a field
+        self.path.push(PathElem::Field(self.op.layout.ty
+                                    .ty_adt_def()
+                                    .unwrap()
+                                    .variants[variant].name));
+        // Proceed with this variant
+        self.op = ectx.operand_downcast(self.op, variant)?;
+        Ok(())
+    }
+
+    fn downcast_dyn_trait(&mut self, ectx: &EvalContext<'a, 'mir, 'tcx, M>)
+        -> EvalResult<'tcx>
+    {
+        // FIXME: Should we reflect this in `self.path`?
+        let dest = self.op.to_mem_place(); // immediate trait objects are not a thing
+        self.op = ectx.unpack_dyn_trait(dest)?.1.into();
+        Ok(())
+    }
+
+    fn visit_primitive(&mut self, ectx: &mut EvalContext<'a, 'mir, 'tcx, M>)
+        -> EvalResult<'tcx>
+    {
+        let value = try_validation!(ectx.read_immediate(self.op),
+            "uninitialized or unrepresentable data", self.path);
         // Go over all the primitive types
         let ty = value.layout.ty;
         match ty.sty {
             ty::Bool => {
                 let value = value.to_scalar_or_undef();
                 try_validation!(value.to_bool(),
-                    scalar_format(value), path, "a boolean");
+                    scalar_format(value), self.path, "a boolean");
             },
             ty::Char => {
                 let value = value.to_scalar_or_undef();
                 try_validation!(value.to_char(),
-                    scalar_format(value), path, "a valid unicode codepoint");
+                    scalar_format(value), self.path, "a valid unicode codepoint");
             },
             ty::Float(_) | ty::Int(_) | ty::Uint(_) => {
                 // NOTE: Keep this in sync with the array optimization for int/float
                 // types below!
                 let size = value.layout.size;
                 let value = value.to_scalar_or_undef();
-                if const_mode {
+                if self.const_mode {
                     // Integers/floats in CTFE: Must be scalar bits, pointers are dangerous
                     try_validation!(value.to_bits(size),
-                        scalar_format(value), path, "initialized plain bits");
+                        scalar_format(value), self.path, "initialized plain bits");
                 } else {
                     // At run-time, for now, we accept *anything* for these types, including
                     // undef. We should fix that, but let's start low.
@@ -180,33 +272,33 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
                 // No undef allowed here.  Eventually this should be consistent with
                 // the integer types.
                 let _ptr = try_validation!(value.to_scalar_ptr(),
-                    "undefined address in pointer", path);
+                    "undefined address in pointer", self.path);
                 let _meta = try_validation!(value.to_meta(),
-                    "uninitialized data in fat pointer metadata", path);
+                    "uninitialized data in fat pointer metadata", self.path);
             }
             _ if ty.is_box() || ty.is_region_ptr() => {
                 // Handle fat pointers.
                 // Check metadata early, for better diagnostics
                 let ptr = try_validation!(value.to_scalar_ptr(),
-                    "undefined address in pointer", path);
+                    "undefined address in pointer", self.path);
                 let meta = try_validation!(value.to_meta(),
-                    "uninitialized data in fat pointer metadata", path);
-                let layout = self.layout_of(value.layout.ty.builtin_deref(true).unwrap().ty)?;
+                    "uninitialized data in fat pointer metadata", self.path);
+                let layout = ectx.layout_of(value.layout.ty.builtin_deref(true).unwrap().ty)?;
                 if layout.is_unsized() {
-                    let tail = self.tcx.struct_tail(layout.ty);
+                    let tail = ectx.tcx.struct_tail(layout.ty);
                     match tail.sty {
                         ty::Dynamic(..) => {
                             let vtable = try_validation!(meta.unwrap().to_ptr(),
-                                "non-pointer vtable in fat pointer", path);
-                            try_validation!(self.read_drop_type_from_vtable(vtable),
-                                "invalid drop fn in vtable", path);
-                            try_validation!(self.read_size_and_align_from_vtable(vtable),
-                                "invalid size or align in vtable", path);
+                                "non-pointer vtable in fat pointer", self.path);
+                            try_validation!(ectx.read_drop_type_from_vtable(vtable),
+                                "invalid drop fn in vtable", self.path);
+                            try_validation!(ectx.read_size_and_align_from_vtable(vtable),
+                                "invalid size or align in vtable", self.path);
                             // FIXME: More checks for the vtable.
                         }
                         ty::Slice(..) | ty::Str => {
-                            try_validation!(meta.unwrap().to_usize(self),
-                                "non-integer slice length in fat pointer", path);
+                            try_validation!(meta.unwrap().to_usize(ectx),
+                                "non-integer slice length in fat pointer", self.path);
                         }
                         ty::Foreign(..) => {
                             // Unsized, but not fat.
@@ -216,25 +308,25 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
                     }
                 }
                 // Make sure this is non-NULL and aligned
-                let (size, align) = self.size_and_align_of(meta, layout)?
+                let (size, align) = ectx.size_and_align_of(meta, layout)?
                     // for the purpose of validity, consider foreign types to have
                     // alignment and size determined by the layout (size will be 0,
                     // alignment should take attributes into account).
                     .unwrap_or_else(|| layout.size_and_align());
-                match self.memory.check_align(ptr, align) {
+                match ectx.memory.check_align(ptr, align) {
                     Ok(_) => {},
                     Err(err) => {
                         error!("{:?} is not aligned to {:?}", ptr, align);
                         match err.kind {
                             EvalErrorKind::InvalidNullPointerUsage =>
-                                return validation_failure!("NULL reference", path),
+                                return validation_failure!("NULL reference", self.path),
                             EvalErrorKind::AlignmentCheckFailed { .. } =>
-                                return validation_failure!("unaligned reference", path),
+                                return validation_failure!("unaligned reference", self.path),
                             _ =>
                                 return validation_failure!(
                                     "dangling (out-of-bounds) reference (might be NULL at \
                                         run-time)",
-                                    path
+                                    self.path
                                 ),
                         }
                     }
@@ -242,29 +334,29 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
                 // Turn ptr into place.
                 // `ref_to_mplace` also calls the machine hook for (re)activating the tag,
                 // which in turn will (in full miri) check if the pointer is dereferencable.
-                let place = self.ref_to_mplace(value)?;
+                let place = ectx.ref_to_mplace(value)?;
                 // Recursive checking
-                if let Some(ref_tracking) = ref_tracking {
-                    assert!(const_mode, "We should only do recursie checking in const mode");
+                if let Some(ref mut ref_tracking) = self.ref_tracking {
+                    assert!(self.const_mode, "We should only do recursie checking in const mode");
                     if size != Size::ZERO {
                         // Non-ZST also have to be dereferencable
                         let ptr = try_validation!(place.ptr.to_ptr(),
-                            "integer pointer in non-ZST reference", path);
+                            "integer pointer in non-ZST reference", self.path);
                         // Skip validation entirely for some external statics
-                        let alloc_kind = self.tcx.alloc_map.lock().get(ptr.alloc_id);
+                        let alloc_kind = ectx.tcx.alloc_map.lock().get(ptr.alloc_id);
                         if let Some(AllocType::Static(did)) = alloc_kind {
                             // `extern static` cannot be validated as they have no body.
                             // FIXME: Statics from other crates are also skipped.
                             // They might be checked at a different type, but for now we
                             // want to avoid recursing too deeply.  This is not sound!
-                            if !did.is_local() || self.tcx.is_foreign_item(did) {
+                            if !did.is_local() || ectx.tcx.is_foreign_item(did) {
                                 return Ok(());
                             }
                         }
                         // Maintain the invariant that the place we are checking is
                         // already verified to be in-bounds.
-                        try_validation!(self.memory.check_bounds(ptr, size, false),
-                            "dangling (not entirely in bounds) reference", path);
+                        try_validation!(ectx.memory.check_bounds(ptr, size, false),
+                            "dangling (not entirely in bounds) reference", self.path);
                     }
                     // Check if we have encountered this pointer+layout combination
                     // before.  Proceed recursively even for integer pointers, no
@@ -273,16 +365,16 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
                     let op = place.into();
                     if ref_tracking.seen.insert(op) {
                         trace!("Recursing below ptr {:#?}", *op);
-                        ref_tracking.todo.push((op, path_clone_and_deref(path)));
+                        ref_tracking.todo.push((op, path_clone_and_deref(&self.path)));
                     }
                 }
             }
             ty::FnPtr(_sig) => {
                 let value = value.to_scalar_or_undef();
                 let ptr = try_validation!(value.to_ptr(),
-                    scalar_format(value), path, "a pointer");
-                let _fn = try_validation!(self.memory.get_fn(ptr),
-                    scalar_format(value), path, "a function pointer");
+                    scalar_format(value), self.path, "a pointer");
+                let _fn = try_validation!(ectx.memory.get_fn(ptr),
+                    scalar_format(value), self.path, "a function pointer");
                 // FIXME: Check if the signature matches
             }
             // This should be all the primitive types
@@ -292,16 +384,15 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
         Ok(())
     }
 
-    /// Make sure that `value` matches the
-    fn validate_scalar_layout(
-        &self,
-        value: ScalarMaybeUndef<M::PointerTag>,
-        size: Size,
-        path: &Vec<PathElem>,
-        layout: &layout::Scalar,
-    ) -> EvalResult<'tcx> {
+    fn visit_scalar(&mut self, ectx: &mut EvalContext<'a, 'mir, 'tcx, M>, layout: &layout::Scalar)
+        -> EvalResult<'tcx>
+    {
+        let value = try_validation!(ectx.read_scalar(self.op),
+            "uninitialized or unrepresentable data", self.path);
+        // Determine the allowed range
         let (lo, hi) = layout.valid_range.clone().into_inner();
-        let max_hi = u128::max_value() >> (128 - size.bits()); // as big as the size fits
+        // `max_hi` is as big as the size fits
+        let max_hi = u128::max_value() >> (128 - self.op.layout.size.bits());
         assert!(hi <= max_hi);
         // We could also write `(hi + 1) % (max_hi + 1) == lo` but `max_hi + 1` overflows for `u128`
         if (lo == 0 && hi == max_hi) || (hi + 1 == lo) {
@@ -310,7 +401,8 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
         }
         // At least one value is excluded. Get the bits.
         let value = try_validation!(value.not_undef(),
-            scalar_format(value), path, format!("something in the range {:?}", layout.valid_range));
+            scalar_format(value), self.path,
+            format!("something in the range {:?}", layout.valid_range));
         let bits = match value {
             Scalar::Ptr(ptr) => {
                 if lo == 1 && hi == max_hi {
@@ -318,13 +410,13 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
                     // We can call `check_align` to check non-NULL-ness, but have to also look
                     // for function pointers.
                     let non_null =
-                        self.memory.check_align(
+                        ectx.memory.check_align(
                             Scalar::Ptr(ptr), Align::from_bytes(1, 1).unwrap()
                         ).is_ok() ||
-                        self.memory.get_fn(ptr).is_ok();
+                        ectx.memory.get_fn(ptr).is_ok();
                     if !non_null {
                         // could be NULL
-                        return validation_failure!("a potentially NULL pointer", path);
+                        return validation_failure!("a potentially NULL pointer", self.path);
                     }
                     return Ok(());
                 } else {
@@ -332,7 +424,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
                     // value.
                     return validation_failure!(
                         "a pointer",
-                        path,
+                        self.path,
                         format!(
                             "something that cannot possibly be outside the (wrapping) range {:?}",
                             layout.valid_range
@@ -340,8 +432,8 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
                     );
                 }
             }
-            Scalar::Bits { bits, size: value_size } => {
-                assert_eq!(value_size as u64, size.bytes());
+            Scalar::Bits { bits, size } => {
+                assert_eq!(size as u64, self.op.layout.size.bytes());
                 bits
             }
         };
@@ -355,7 +447,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
             } else {
                 validation_failure!(
                     bits,
-                    path,
+                    self.path,
                     format!("something in the range {:?} or {:?}", 0..=hi, lo..=max_hi)
                 )
             }
@@ -365,7 +457,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
             } else {
                 validation_failure!(
                     bits,
-                    path,
+                    self.path,
                     if hi == max_hi {
                         format!("something greater or equal to {}", lo)
                     } else {
@@ -376,250 +468,147 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
         }
     }
 
+    fn visit_fields(&mut self, ectx: &mut EvalContext<'a, 'mir, 'tcx, M>, num_fields: usize)
+        -> EvalResult<'tcx>
+    {
+        // Remember some stuff that will change for the recursive calls
+        let op = self.op;
+        let path_len = self.path.len();
+        // Go look at all the fields
+        for i in 0..num_fields {
+            // Adapt our state
+            self.op = ectx.operand_field(op, i as u64)?;
+            self.path.push(aggregate_field_path_elem(op.layout, i, *ectx.tcx));
+            // Recursive visit
+            ectx.visit_value(self)?;
+            // Restore original state
+            self.op = op;
+            self.path.truncate(path_len);
+        }
+        Ok(())
+    }
+
+    fn visit_str(&mut self, ectx: &mut EvalContext<'a, 'mir, 'tcx, M>)
+        -> EvalResult<'tcx>
+    {
+        let mplace = self.op.to_mem_place(); // strings are never immediate
+        try_validation!(ectx.read_str(mplace),
+            "uninitialized or non-UTF-8 data in str", self.path);
+        Ok(())
+    }
+
+    fn visit_array(&mut self, ectx: &mut EvalContext<'a, 'mir, 'tcx, M>) -> EvalResult<'tcx>
+    {
+        let mplace = if self.op.layout.is_zst() {
+            // it's a ZST, the memory content cannot matter
+            MPlaceTy::dangling(self.op.layout, ectx)
+        } else {
+            // non-ZST array/slice/str cannot be immediate
+            self.op.to_mem_place()
+        };
+        match self.op.layout.ty.sty {
+            ty::Str => bug!("Strings should be handled separately"),
+            // Special handling for arrays/slices of builtin integer types
+            ty::Array(tys, ..) | ty::Slice(tys) if {
+                // This optimization applies only for integer and floating point types
+                // (i.e., types that can hold arbitrary bytes).
+                match tys.sty {
+                    ty::Int(..) | ty::Uint(..) | ty::Float(..) => true,
+                    _ => false,
+                }
+            } => {
+                // This is the length of the array/slice.
+                let len = mplace.len(ectx)?;
+                // This is the element type size.
+                let ty_size = ectx.layout_of(tys)?.size;
+                // This is the size in bytes of the whole array.
+                let size = ty_size * len;
+
+                // NOTE: Keep this in sync with the handling of integer and float
+                // types above, in `visit_primitive`.
+                // In run-time mode, we accept pointers in here.  This is actually more
+                // permissive than a per-element check would be, e.g. we accept
+                // an &[u8] that contains a pointer even though bytewise checking would
+                // reject it.  However, that's good: We don't inherently want
+                // to reject those pointers, we just do not have the machinery to
+                // talk about parts of a pointer.
+                // We also accept undef, for consistency with the type-based checks.
+                match ectx.memory.check_bytes(
+                    mplace.ptr,
+                    size,
+                    /*allow_ptr_and_undef*/!self.const_mode,
+                ) {
+                    // In the happy case, we needn't check anything else.
+                    Ok(()) => {},
+                    // Some error happened, try to provide a more detailed description.
+                    Err(err) => {
+                        // For some errors we might be able to provide extra information
+                        match err.kind {
+                            EvalErrorKind::ReadUndefBytes(offset) => {
+                                // Some byte was undefined, determine which
+                                // element that byte belongs to so we can
+                                // provide an index.
+                                let i = (offset.bytes() / ty_size.bytes()) as usize;
+                                self.path.push(PathElem::ArrayElem(i));
+
+                                return validation_failure!(
+                                    "undefined bytes", self.path
+                                )
+                            },
+                            // Other errors shouldn't be possible
+                            _ => return Err(err),
+                        }
+                    }
+                }
+            },
+            _ => {
+                // Remember some stuff that will change for the recursive calls
+                let op = self.op;
+                let path_len = self.path.len();
+                // This handles the unsized case correctly as well, as well as
+                // SIMD and all sorts of other array-like types.
+                for (i, field) in ectx.mplace_array_fields(mplace)?.enumerate() {
+                    // Adapt our state
+                    self.op = field?.into();
+                    self.path.push(PathElem::ArrayElem(i));
+                    // Recursive visit
+                    ectx.visit_value(self)?;
+                    // Restore original state
+                    self.op = op;
+                    self.path.truncate(path_len);
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> {
     /// This function checks the data at `op`.  `op` is assumed to cover valid memory if it
     /// is an indirect operand.
     /// It will error if the bits at the destination do not match the ones described by the layout.
-    /// The `path` may be pushed to, but the part that is present when the function
-    /// starts must not be changed!
     ///
     /// `ref_tracking` can be None to avoid recursive checking below references.
     /// This also toggles between "run-time" (no recursion) and "compile-time" (with recursion)
     /// validation (e.g., pointer values are fine in integers at runtime).
     pub fn validate_operand(
-        &self,
-        dest: OpTy<'tcx, M::PointerTag>,
-        path: &mut Vec<PathElem>,
-        mut ref_tracking: Option<&mut RefTracking<'tcx, M::PointerTag>>,
+        &mut self,
+        op: OpTy<'tcx, M::PointerTag>,
+        path: Vec<PathElem>,
+        ref_tracking: Option<&mut RefTracking<'tcx, M::PointerTag>>,
         const_mode: bool,
     ) -> EvalResult<'tcx> {
-        trace!("validate_operand: {:?}, {:?}", *dest, dest.layout.ty);
+        trace!("validate_operand: {:?}, {:?}", *op, op.layout.ty);
 
-        // If this is a multi-variant layout, we have find the right one and proceed with that.
-        // (No good reasoning to make this recursion, but it is equivalent to that.)
-        let dest = match dest.layout.variants {
-            layout::Variants::NicheFilling { .. } |
-            layout::Variants::Tagged { .. } => {
-                let variant = match self.read_discriminant(dest) {
-                    Ok(res) => res.1,
-                    Err(err) => match err.kind {
-                        EvalErrorKind::InvalidDiscriminant(val) =>
-                            return validation_failure!(
-                                format!("invalid enum discriminant {}", val), path
-                            ),
-                        _ =>
-                            return validation_failure!(
-                                String::from("non-integer enum discriminant"), path
-                            ),
-                    }
-                };
-                // Put the variant projection onto the path, as a field
-                path.push(PathElem::Field(dest.layout.ty
-                                          .ty_adt_def()
-                                          .unwrap()
-                                          .variants[variant].name));
-                // Proceed with this variant
-                let dest = self.operand_downcast(dest, variant)?;
-                trace!("variant layout: {:#?}", dest.layout);
-                dest
-            },
-            layout::Variants::Single { .. } => dest,
+        // Construct a visitor
+        let mut visitor = ValidityVisitor {
+            op,
+            path,
+            ref_tracking,
+            const_mode
         };
 
-        // First thing, find the real type:
-        // If it is a trait object, switch to the actual type that was used to create it.
-        let dest = match dest.layout.ty.sty {
-            ty::Dynamic(..) => {
-                let dest = dest.to_mem_place(); // immediate trait objects are not a thing
-                self.unpack_dyn_trait(dest)?.1.into()
-            },
-            _ => dest
-        };
-
-        // If this is a scalar, validate the scalar layout.
-        // Things can be aggregates and have scalar layout at the same time, and that
-        // is very relevant for `NonNull` and similar structs: We need to validate them
-        // at their scalar layout *before* descending into their fields.
-        // FIXME: We could avoid some redundant checks here. For newtypes wrapping
-        // scalars, we do the same check on every "level" (e.g. first we check
-        // MyNewtype and then the scalar in there).
-        match dest.layout.abi {
-            layout::Abi::Uninhabited =>
-                return validation_failure!("a value of an uninhabited type", path),
-            layout::Abi::Scalar(ref layout) => {
-                let value = try_validation!(self.read_scalar(dest),
-                            "uninitialized or unrepresentable data", path);
-                self.validate_scalar_layout(value, dest.layout.size, &path, layout)?;
-            }
-            // FIXME: Should we do something for ScalarPair? Vector?
-            _ => {}
-        }
-
-        // Check primitive types.  We do this after checking the scalar layout,
-        // just to have that done as well.  Primitives can have varying layout,
-        // so we check them separately and before aggregate handling.
-        // It is CRITICAL that we get this check right, or we might be
-        // validating the wrong thing!
-        let primitive = match dest.layout.fields {
-            // Primitives appear as Union with 0 fields -- except for fat pointers.
-            layout::FieldPlacement::Union(0) => true,
-            _ => dest.layout.ty.builtin_deref(true).is_some(),
-        };
-        if primitive {
-            let value = try_validation!(self.read_immediate(dest),
-                "uninitialized or unrepresentable data", path);
-            return self.validate_primitive_type(
-                value,
-                &path,
-                ref_tracking,
-                const_mode,
-            );
-        }
-
-        // Validate all fields of compound data structures
-        let path_len = path.len(); // Remember the length, in case we need to truncate
-        match dest.layout.fields {
-            layout::FieldPlacement::Union(fields) => {
-                // Empty unions are not accepted by rustc. That's great, it means we can
-                // use that as an unambiguous signal for detecting primitives.  Make sure
-                // we did not miss any primitive.
-                debug_assert!(fields > 0);
-                // We can't check unions, their bits are allowed to be anything.
-                // The fields don't need to correspond to any bit pattern of the union's fields.
-                // See https://github.com/rust-lang/rust/issues/32836#issuecomment-406875389
-            },
-            layout::FieldPlacement::Arbitrary { ref offsets, .. } => {
-                // Go look at all the fields
-                for i in 0..offsets.len() {
-                    let field = self.operand_field(dest, i as u64)?;
-                    path.push(self.aggregate_field_path_elem(dest.layout, i));
-                    self.validate_operand(
-                        field,
-                        path,
-                        ref_tracking.as_mut().map(|r| &mut **r),
-                        const_mode,
-                    )?;
-                    path.truncate(path_len);
-                }
-            }
-            layout::FieldPlacement::Array { stride, .. } => {
-                let dest = if dest.layout.is_zst() {
-                    // it's a ZST, the memory content cannot matter
-                    MPlaceTy::dangling(dest.layout, self)
-                } else {
-                    // non-ZST array/slice/str cannot be immediate
-                    dest.to_mem_place()
-                };
-                match dest.layout.ty.sty {
-                    // Special handling for strings to verify UTF-8
-                    ty::Str => {
-                        try_validation!(self.read_str(dest),
-                            "uninitialized or non-UTF-8 data in str", path);
-                    }
-                    // Special handling for arrays/slices of builtin integer types
-                    ty::Array(tys, ..) | ty::Slice(tys) if {
-                        // This optimization applies only for integer and floating point types
-                        // (i.e., types that can hold arbitrary bytes).
-                        match tys.sty {
-                            ty::Int(..) | ty::Uint(..) | ty::Float(..) => true,
-                            _ => false,
-                        }
-                    } => {
-                        // This is the length of the array/slice.
-                        let len = dest.len(self)?;
-                        // Since primitive types are naturally aligned and tightly packed in arrays,
-                        // we can use the stride to get the size of the integral type.
-                        let ty_size = stride.bytes();
-                        // This is the size in bytes of the whole array.
-                        let size = Size::from_bytes(ty_size * len);
-
-                        // NOTE: Keep this in sync with the handling of integer and float
-                        // types above, in `validate_primitive_type`.
-                        // In run-time mode, we accept pointers in here.  This is actually more
-                        // permissive than a per-element check would be, e.g. we accept
-                        // an &[u8] that contains a pointer even though bytewise checking would
-                        // reject it.  However, that's good: We don't inherently want
-                        // to reject those pointers, we just do not have the machinery to
-                        // talk about parts of a pointer.
-                        // We also accept undef, for consistency with the type-based checks.
-                        match self.memory.check_bytes(
-                            dest.ptr,
-                            size,
-                            /*allow_ptr_and_undef*/!const_mode,
-                        ) {
-                            // In the happy case, we needn't check anything else.
-                            Ok(()) => {},
-                            // Some error happened, try to provide a more detailed description.
-                            Err(err) => {
-                                // For some errors we might be able to provide extra information
-                                match err.kind {
-                                    EvalErrorKind::ReadUndefBytes(offset) => {
-                                        // Some byte was undefined, determine which
-                                        // element that byte belongs to so we can
-                                        // provide an index.
-                                        let i = (offset.bytes() / ty_size) as usize;
-                                        path.push(PathElem::ArrayElem(i));
-
-                                        return validation_failure!(
-                                            "undefined bytes", path
-                                        )
-                                    },
-                                    // Other errors shouldn't be possible
-                                    _ => return Err(err),
-                                }
-                            }
-                        }
-                    },
-                    _ => {
-                        // This handles the unsized case correctly as well, as well as
-                        // SIMD an all sorts of other array-like types.
-                        for (i, field) in self.mplace_array_fields(dest)?.enumerate() {
-                            let field = field?;
-                            path.push(PathElem::ArrayElem(i));
-                            self.validate_operand(
-                                field.into(),
-                                path,
-                                ref_tracking.as_mut().map(|r| &mut **r),
-                                const_mode,
-                            )?;
-                            path.truncate(path_len);
-                        }
-                    }
-                }
-            },
-        }
-        Ok(())
-    }
-
-    fn aggregate_field_path_elem(&self, layout: TyLayout<'tcx>, field: usize) -> PathElem {
-        match layout.ty.sty {
-            // generators and closures.
-            ty::Closure(def_id, _) | ty::Generator(def_id, _, _) => {
-                if let Some(upvar) = self.tcx.optimized_mir(def_id).upvar_decls.get(field) {
-                    PathElem::ClosureVar(upvar.debug_name)
-                } else {
-                    // Sometimes the index is beyond the number of freevars (seen
-                    // for a generator).
-                    PathElem::ClosureVar(Symbol::intern(&field.to_string()))
-                }
-            }
-
-            // tuples
-            ty::Tuple(_) => PathElem::TupleElem(field),
-
-            // enums
-            ty::Adt(def, ..) if def.is_enum() => {
-                let variant = match layout.variants {
-                    layout::Variants::Single { index } => &def.variants[index],
-                    _ => bug!("aggregate_field_path_elem: got enum but not in a specific variant"),
-                };
-                PathElem::Field(variant.fields[field].ident.name)
-            }
-
-            // other ADTs
-            ty::Adt(def, _) => PathElem::Field(def.non_enum_variant().fields[field].ident.name),
-
-            // nothing else has an aggregate layout
-            _ => bug!("aggregate_field_path_elem: got non-aggregate type {:?}", layout.ty),
-        }
+        // Run it
+        self.visit_value(&mut visitor)
     }
 }

--- a/src/librustc_mir/interpret/validity.rs
+++ b/src/librustc_mir/interpret/validity.rs
@@ -133,7 +133,7 @@ fn scalar_format<Tag>(value: ScalarMaybeUndef<Tag>) -> String {
     }
 }
 
-struct ValidityVisitor<'rt, 'a, 'tcx, Tag> {
+struct ValidityVisitor<'rt, 'a, 'tcx: 'a+'rt, Tag: 'static> {
     op: OpTy<'tcx, Tag>,
     /// The `path` may be pushed to, but the part that is present when a function
     /// starts must not be changed!  `visit_fields` and `visit_array` rely on

--- a/src/librustc_mir/interpret/visitor.rs
+++ b/src/librustc_mir/interpret/visitor.rs
@@ -10,34 +10,103 @@ use rustc::mir::interpret::{
 };
 
 use super::{
-    Machine, EvalContext,
+    Machine, EvalContext, MPlaceTy, OpTy,
 };
 
-// How to traverse a value and what to do when we are at the leaves.
-// In the future, we might want to turn this into two traits, but so far the
-// only implementations we have couldn't share any code anyway.
-pub trait ValueVisitor<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>>: fmt::Debug {
+// A thing that we can project into, and that has a layout.
+// This wouldn't have to depend on `Machine` but with the current type inference,
+// that's just more convenient to work with (avoids repeading all the `Machine` bounds).
+pub trait Value<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>>: Copy
+{
     // Get this value's layout.
     fn layout(&self) -> TyLayout<'tcx>;
 
-    // Downcast functions.  These change the value as a side-effect.
+    // Get the underlying `MPlaceTy`, or panic if there is no such thing.
+    fn to_mem_place(self) -> MPlaceTy<'tcx, M::PointerTag>;
+
+    // Create this from an `MPlaceTy`
+    fn from_mem_place(MPlaceTy<'tcx, M::PointerTag>) -> Self;
+
+    // Project to the n-th field
+    fn project_field(
+        self,
+        ectx: &mut EvalContext<'a, 'mir, 'tcx, M>,
+        field: u64,
+    ) -> EvalResult<'tcx, Self>;
+}
+
+// Operands and places are both values
+impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> Value<'a, 'mir, 'tcx, M>
+    for OpTy<'tcx, M::PointerTag>
+{
+    #[inline(always)]
+    fn layout(&self) -> TyLayout<'tcx> {
+        self.layout
+    }
+
+    #[inline(always)]
+    fn to_mem_place(self) -> MPlaceTy<'tcx, M::PointerTag> {
+        self.to_mem_place()
+    }
+
+    #[inline(always)]
+    fn from_mem_place(mplace: MPlaceTy<'tcx, M::PointerTag>) -> Self {
+        mplace.into()
+    }
+
+    #[inline(always)]
+    fn project_field(
+        self,
+        ectx: &mut EvalContext<'a, 'mir, 'tcx, M>,
+        field: u64,
+    ) -> EvalResult<'tcx, Self> {
+        ectx.operand_field(self, field)
+    }
+}
+
+// How to traverse a value and what to do when we are at the leaves.
+pub trait ValueVisitor<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>>: fmt::Debug {
+    type V: Value<'a, 'mir, 'tcx, M>;
+
+    // There's a value in here.
+    fn value(&self) -> &Self::V;
+
+    // The value's layout (not meant to be overwritten).
+    #[inline(always)]
+    fn layout(&self) -> TyLayout<'tcx> {
+        self.value().layout()
+    }
+
+    // Replace the value by `val`, which must be the `field`th field of `self`,
+    // then call `f` and then un-do everything that might have happened to the visitor state.
+    // The point of this is that some visitors keep a stack of fields that we projected below,
+    // and this lets us avoid copying that stack; instead they will pop the stack after
+    // executing `f`.
+    fn with_field(
+        &mut self,
+        val: Self::V,
+        field: usize,
+        f: impl FnOnce(&mut Self) -> EvalResult<'tcx>,
+    ) -> EvalResult<'tcx>;
+
+    // This is an enum, downcast it to whatever the current variant is.
+    // (We do this here and not in `Value` to keep error handling
+    // under control of th visitor.)
     fn downcast_enum(&mut self, ectx: &EvalContext<'a, 'mir, 'tcx, M>)
         -> EvalResult<'tcx>;
-    fn downcast_dyn_trait(&mut self, ectx: &EvalContext<'a, 'mir, 'tcx, M>)
-        -> EvalResult<'tcx>;
 
-    // Visit all fields of a compound.
-    // Just call `visit_value` if you want to go on recursively.
-    fn visit_fields(&mut self, ectx: &mut EvalContext<'a, 'mir, 'tcx, M>, num_fields: usize)
-        -> EvalResult<'tcx>;
-    // Optimized handling for arrays -- avoid computing the layout for every field.
-    // Also it is the value's responsibility to figure out the length.
-    fn visit_array(&mut self, ectx: &mut EvalContext<'a, 'mir, 'tcx, M>) -> EvalResult<'tcx>;
-    // Special handling for strings.
-    fn visit_str(&mut self, ectx: &mut EvalContext<'a, 'mir, 'tcx, M>)
-        -> EvalResult<'tcx>;
+    // A chance for the visitor to do special (different or more efficient) handling for some
+    // array types.  Return `true` if the value was handled and we should return.
+    #[inline]
+    fn handle_array(&mut self, _ectx: &EvalContext<'a, 'mir, 'tcx, M>)
+        -> EvalResult<'tcx, bool>
+    {
+        Ok(false)
+    }
 
     // Actions on the leaves.
+    fn visit_uninhabited(&mut self, ectx: &mut EvalContext<'a, 'mir, 'tcx, M>)
+        -> EvalResult<'tcx>;
     fn visit_scalar(&mut self, ectx: &mut EvalContext<'a, 'mir, 'tcx, M>, layout: &layout::Scalar)
         -> EvalResult<'tcx>;
     fn visit_primitive(&mut self, ectx: &mut EvalContext<'a, 'mir, 'tcx, M>)
@@ -45,7 +114,10 @@ pub trait ValueVisitor<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>>: fmt::Debug {
 }
 
 impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> {
-    pub fn visit_value<V: ValueVisitor<'a, 'mir, 'tcx, M>>(&mut self, v: &mut V) -> EvalResult<'tcx> {
+    pub fn visit_value<V: ValueVisitor<'a, 'mir, 'tcx, M>>(
+        &mut self,
+        v: &mut V,
+    ) -> EvalResult<'tcx> {
         trace!("visit_value: {:?}", v);
 
         // If this is a multi-variant layout, we have find the right one and proceed with that.
@@ -63,7 +135,10 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
         // If it is a trait object, switch to the actual type that was used to create it.
         match v.layout().ty.sty {
             ty::Dynamic(..) => {
-                v.downcast_dyn_trait(self)?;
+                let dest = v.value().to_mem_place(); // immediate trait objects are not a thing
+                let inner = self.unpack_dyn_trait(dest)?.1;
+                // recurse with the inner type
+                return v.with_field(Value::from_mem_place(inner), 0, |v| self.visit_value(v));
             },
             _ => {},
         };
@@ -76,6 +151,9 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
         // scalars, we do the same check on every "level" (e.g. first we check
         // MyNewtype and then the scalar in there).
         match v.layout().abi {
+            layout::Abi::Uninhabited => {
+                v.visit_uninhabited(self)?;
+            }
             layout::Abi::Scalar(ref layout) => {
                 v.visit_scalar(self, layout)?;
             }
@@ -107,19 +185,31 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
                 // We can't traverse unions, their bits are allowed to be anything.
                 // The fields don't need to correspond to any bit pattern of the union's fields.
                 // See https://github.com/rust-lang/rust/issues/32836#issuecomment-406875389
-                Ok(())
             },
             layout::FieldPlacement::Arbitrary { ref offsets, .. } => {
-                v.visit_fields(self, offsets.len())
+                for i in 0..offsets.len() {
+                    let val = v.value().project_field(self, i as u64)?;
+                    v.with_field(val, i, |v| self.visit_value(v))?;
+                }
             },
             layout::FieldPlacement::Array { .. } => {
-                match v.layout().ty.sty {
-                    // Strings have properties that cannot be expressed pointwise.
-                    ty::Str => v.visit_str(self),
-                    // General case -- might also be SIMD vector or so
-                    _ => v.visit_array(self),
+                if !v.handle_array(self)? {
+                    // We still have to work!
+                    // Let's get an mplace first.
+                    let mplace = if v.layout().is_zst() {
+                        // it's a ZST, the memory content cannot matter
+                        MPlaceTy::dangling(v.layout(), self)
+                    } else {
+                        // non-ZST array/slice/str cannot be immediate
+                        v.value().to_mem_place()
+                    };
+                    // Now iterate over it.
+                    for (i, field) in self.mplace_array_fields(mplace)?.enumerate() {
+                        v.with_field(Value::from_mem_place(field?), i, |v| self.visit_value(v))?;
+                    }
                 }
             }
         }
+        Ok(())
     }
 }

--- a/src/librustc_mir/interpret/visitor.rs
+++ b/src/librustc_mir/interpret/visitor.rs
@@ -210,6 +210,7 @@ macro_rules! make_value_visitor {
             }
             fn walk_value(&mut self, v: Self::V) -> EvalResult<'tcx>
             {
+                trace!("walk_value: type: {}", v.layout().ty);
                 // If this is a multi-variant layout, we have find the right one and proceed with
                 // that.
                 match v.layout().variants {

--- a/src/librustc_mir/interpret/visitor.rs
+++ b/src/librustc_mir/interpret/visitor.rs
@@ -8,7 +8,7 @@ use rustc::mir::interpret::{
 };
 
 use super::{
-    Machine, EvalContext, MPlaceTy, PlaceTy, OpTy, ImmTy,
+    Machine, EvalContext, MPlaceTy, OpTy, ImmTy,
 };
 
 // A thing that we can project into, and that has a layout.
@@ -38,12 +38,13 @@ pub trait Value<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>>: Copy
     /// Project to the n-th field.
     fn project_field(
         self,
-        ecx: &mut EvalContext<'a, 'mir, 'tcx, M>,
+        ecx: &EvalContext<'a, 'mir, 'tcx, M>,
         field: u64,
     ) -> EvalResult<'tcx, Self>;
 }
 
-// Operands and places are both values
+// Operands and memory-places are both values.
+// Places in general are not due to `place_field` having to do `force_allocation`.
 impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> Value<'a, 'mir, 'tcx, M>
     for OpTy<'tcx, M::PointerTag>
 {
@@ -77,7 +78,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> Value<'a, 'mir, 'tcx, M>
     #[inline(always)]
     fn project_field(
         self,
-        ecx: &mut EvalContext<'a, 'mir, 'tcx, M>,
+        ecx: &EvalContext<'a, 'mir, 'tcx, M>,
         field: u64,
     ) -> EvalResult<'tcx, Self> {
         ecx.operand_field(self, field)
@@ -116,233 +117,203 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> Value<'a, 'mir, 'tcx, M>
     #[inline(always)]
     fn project_field(
         self,
-        ecx: &mut EvalContext<'a, 'mir, 'tcx, M>,
+        ecx: &EvalContext<'a, 'mir, 'tcx, M>,
         field: u64,
     ) -> EvalResult<'tcx, Self> {
         ecx.mplace_field(self, field)
     }
 }
-impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> Value<'a, 'mir, 'tcx, M>
-    for PlaceTy<'tcx, M::PointerTag>
-{
-    #[inline(always)]
-    fn layout(&self) -> TyLayout<'tcx> {
-        self.layout
-    }
 
-    #[inline(always)]
-    fn to_op(
-        self,
-        ecx: &EvalContext<'a, 'mir, 'tcx, M>,
-    ) -> EvalResult<'tcx, OpTy<'tcx, M::PointerTag>> {
-        ecx.place_to_op(self)
-    }
+macro_rules! make_value_visitor {
+    ($visitor_trait_name:ident, $($mutability:ident)*) => {
+        // How to traverse a value and what to do when we are at the leaves.
+        pub trait $visitor_trait_name<'a, 'mir, 'tcx: 'mir+'a, M: Machine<'a, 'mir, 'tcx>>: Sized {
+            type V: Value<'a, 'mir, 'tcx, M>;
 
-    #[inline(always)]
-    fn from_mem_place(mplace: MPlaceTy<'tcx, M::PointerTag>) -> Self {
-        mplace.into()
-    }
+            /// The visitor must have an `EvalContext` in it.
+            fn ecx(&$($mutability)* self)
+                -> &$($mutability)* EvalContext<'a, 'mir, 'tcx, M>;
 
-    #[inline(always)]
-    fn project_downcast(
-        self,
-        ecx: &EvalContext<'a, 'mir, 'tcx, M>,
-        variant: usize,
-    ) -> EvalResult<'tcx, Self> {
-        ecx.place_downcast(self, variant)
-    }
-
-    #[inline(always)]
-    fn project_field(
-        self,
-        ecx: &mut EvalContext<'a, 'mir, 'tcx, M>,
-        field: u64,
-    ) -> EvalResult<'tcx, Self> {
-        ecx.place_field(self, field)
-    }
-}
-
-// How to traverse a value and what to do when we are at the leaves.
-pub trait ValueVisitor<'a, 'mir, 'tcx: 'mir+'a, M: Machine<'a, 'mir, 'tcx>>: Sized {
-    type V: Value<'a, 'mir, 'tcx, M>;
-
-    /// The visitor must have an `EvalContext` in it.
-    fn ecx(&mut self) -> &mut EvalContext<'a, 'mir, 'tcx, M>;
-
-    // Recursive actions, ready to be overloaded.
-    /// Visit the given value, dispatching as appropriate to more specialized visitors.
-    #[inline(always)]
-    fn visit_value(&mut self, v: Self::V) -> EvalResult<'tcx>
-    {
-        self.walk_value(v)
-    }
-    /// Visit the given value as a union.  No automatic recursion can happen here.
-    #[inline(always)]
-    fn visit_union(&mut self, _v: Self::V) -> EvalResult<'tcx>
-    {
-        Ok(())
-    }
-    /// Visit this vale as an aggregate, you are even getting an iterator yielding
-    /// all the fields (still in an `EvalResult`, you have to do error handling yourself).
-    /// Recurses into the fields.
-    #[inline(always)]
-    fn visit_aggregate(
-        &mut self,
-        v: Self::V,
-        fields: impl Iterator<Item=EvalResult<'tcx, Self::V>>,
-    ) -> EvalResult<'tcx> {
-        self.walk_aggregate(v, fields)
-    }
-    /// Called each time we recurse down to a field, passing in old and new value.
-    /// This gives the visitor the chance to track the stack of nested fields that
-    /// we are descending through.
-    #[inline(always)]
-    fn visit_field(
-        &mut self,
-        _old_val: Self::V,
-        _field: usize,
-        new_val: Self::V,
-    ) -> EvalResult<'tcx> {
-        self.visit_value(new_val)
-    }
-
-    /// Called whenever we reach a value with uninhabited layout.
-    /// Recursing to fields will *always* continue after this!  This is not meant to control
-    /// whether and how we descend recursively/ into the scalar's fields if there are any, it is
-    /// meant to provide the chance for additional checks when a value of uninhabited layout is
-    /// detected.
-    #[inline(always)]
-    fn visit_uninhabited(&mut self) -> EvalResult<'tcx>
-    { Ok(()) }
-    /// Called whenever we reach a value with scalar layout.
-    /// We do NOT provide a `ScalarMaybeUndef` here to avoid accessing memory if the visitor is not
-    /// even interested in scalars.
-    /// Recursing to fields will *always* continue after this!  This is not meant to control
-    /// whether and how we descend recursively/ into the scalar's fields if there are any, it is
-    /// meant to provide the chance for additional checks when a value of scalar layout is detected.
-    #[inline(always)]
-    fn visit_scalar(&mut self, _v: Self::V, _layout: &layout::Scalar) -> EvalResult<'tcx>
-    { Ok(()) }
-
-    /// Called whenever we reach a value of primitive type.  There can be no recursion
-    /// below such a value.  This is the leave function.
-    #[inline(always)]
-    fn visit_primitive(&mut self, _val: ImmTy<'tcx, M::PointerTag>) -> EvalResult<'tcx>
-    { Ok(()) }
-
-    // Default recursors. Not meant to be overloaded.
-    fn walk_aggregate(
-        &mut self,
-        v: Self::V,
-        fields: impl Iterator<Item=EvalResult<'tcx, Self::V>>,
-    ) -> EvalResult<'tcx> {
-        // Now iterate over it.
-        for (idx, field_val) in fields.enumerate() {
-            self.visit_field(v, idx, field_val?)?;
-        }
-        Ok(())
-    }
-    fn walk_value(&mut self, v: Self::V) -> EvalResult<'tcx>
-    {
-        // If this is a multi-variant layout, we have find the right one and proceed with that.
-        // (No benefit from making this recursion, but it is equivalent to that.)
-        match v.layout().variants {
-            layout::Variants::NicheFilling { .. } |
-            layout::Variants::Tagged { .. } => {
-                let op = v.to_op(self.ecx())?;
-                let idx = self.ecx().read_discriminant(op)?.1;
-                let inner = v.project_downcast(self.ecx(), idx)?;
-                trace!("walk_value: variant layout: {:#?}", inner.layout());
-                // recurse with the inner type
-                return self.visit_field(v, idx, inner);
+            // Recursive actions, ready to be overloaded.
+            /// Visit the given value, dispatching as appropriate to more specialized visitors.
+            #[inline(always)]
+            fn visit_value(&mut self, v: Self::V) -> EvalResult<'tcx>
+            {
+                self.walk_value(v)
             }
-            layout::Variants::Single { .. } => {}
-        }
-
-        // Even for single variants, we might be able to get a more refined type:
-        // If it is a trait object, switch to the actual type that was used to create it.
-        match v.layout().ty.sty {
-            ty::Dynamic(..) => {
-                // immediate trait objects are not a thing
-                let dest = v.to_op(self.ecx())?.to_mem_place();
-                let inner = self.ecx().unpack_dyn_trait(dest)?.1;
-                trace!("walk_value: dyn object layout: {:#?}", inner.layout);
-                // recurse with the inner type
-                return self.visit_field(v, 0, Value::from_mem_place(inner));
-            },
-            _ => {},
-        };
-
-        // If this is a scalar, visit it as such.
-        // Things can be aggregates and have scalar layout at the same time, and that
-        // is very relevant for `NonNull` and similar structs: We need to visit them
-        // at their scalar layout *before* descending into their fields.
-        // FIXME: We could avoid some redundant checks here. For newtypes wrapping
-        // scalars, we do the same check on every "level" (e.g. first we check
-        // MyNewtype and then the scalar in there).
-        match v.layout().abi {
-            layout::Abi::Uninhabited => {
-                self.visit_uninhabited()?;
+            /// Visit the given value as a union.  No automatic recursion can happen here.
+            #[inline(always)]
+            fn visit_union(&mut self, _v: Self::V) -> EvalResult<'tcx>
+            {
+                Ok(())
             }
-            layout::Abi::Scalar(ref layout) => {
-                self.visit_scalar(v, layout)?;
+            /// Visit this vale as an aggregate, you are even getting an iterator yielding
+            /// all the fields (still in an `EvalResult`, you have to do error handling yourself).
+            /// Recurses into the fields.
+            #[inline(always)]
+            fn visit_aggregate(
+                &mut self,
+                v: Self::V,
+                fields: impl Iterator<Item=EvalResult<'tcx, Self::V>>,
+            ) -> EvalResult<'tcx> {
+                self.walk_aggregate(v, fields)
             }
-            // FIXME: Should we do something for ScalarPair? Vector?
-            _ => {}
-        }
+            /// Called each time we recurse down to a field, passing in old and new value.
+            /// This gives the visitor the chance to track the stack of nested fields that
+            /// we are descending through.
+            #[inline(always)]
+            fn visit_field(
+                &mut self,
+                _old_val: Self::V,
+                _field: usize,
+                new_val: Self::V,
+            ) -> EvalResult<'tcx> {
+                self.visit_value(new_val)
+            }
 
-        // Check primitive types.  We do this after checking the scalar layout,
-        // just to have that done as well.  Primitives can have varying layout,
-        // so we check them separately and before aggregate handling.
-        // It is CRITICAL that we get this check right, or we might be
-        // validating the wrong thing!
-        let primitive = match v.layout().fields {
-            // Primitives appear as Union with 0 fields -- except for Boxes and fat pointers.
-            layout::FieldPlacement::Union(0) => true,
-            _ => v.layout().ty.builtin_deref(true).is_some(),
-        };
-        if primitive {
-            let op = v.to_op(self.ecx())?;
-            let val = self.ecx().read_immediate(op)?;
-            return self.visit_primitive(val);
-        }
+            /// Called whenever we reach a value with uninhabited layout.
+            /// Recursing to fields will *always* continue after this!  This is not meant to control
+            /// whether and how we descend recursively/ into the scalar's fields if there are any,
+            /// it is meant to provide the chance for additional checks when a value of uninhabited
+            /// layout is detected.
+            #[inline(always)]
+            fn visit_uninhabited(&mut self) -> EvalResult<'tcx>
+            { Ok(()) }
+            /// Called whenever we reach a value with scalar layout.
+            /// We do NOT provide a `ScalarMaybeUndef` here to avoid accessing memory if the
+            /// visitor is not even interested in scalars.
+            /// Recursing to fields will *always* continue after this!  This is not meant to control
+            /// whether and how we descend recursively/ into the scalar's fields if there are any,
+            /// it is meant to provide the chance for additional checks when a value of scalar
+            /// layout is detected.
+            #[inline(always)]
+            fn visit_scalar(&mut self, _v: Self::V, _layout: &layout::Scalar) -> EvalResult<'tcx>
+            { Ok(()) }
 
-        // Proceed into the fields.
-        match v.layout().fields {
-            layout::FieldPlacement::Union(fields) => {
-                // Empty unions are not accepted by rustc. That's great, it means we can
-                // use that as an unambiguous signal for detecting primitives.  Make sure
-                // we did not miss any primitive.
-                debug_assert!(fields > 0);
-                self.visit_union(v)?;
-            },
-            layout::FieldPlacement::Arbitrary { ref offsets, .. } => {
-                // FIXME: We collect in a vec because otherwise there are lifetime errors:
-                // Projecting to a field needs (mutable!) access to `ecx`.
-                let fields: Vec<EvalResult<'tcx, Self::V>> =
-                    (0..offsets.len()).map(|i| {
-                        v.project_field(self.ecx(), i as u64)
-                    })
-                    .collect();
-                self.visit_aggregate(v, fields.into_iter())?;
-            },
-            layout::FieldPlacement::Array { .. } => {
-                // Let's get an mplace first.
-                let mplace = if v.layout().is_zst() {
-                    // it's a ZST, the memory content cannot matter
-                    MPlaceTy::dangling(v.layout(), self.ecx())
-                } else {
-                    // non-ZST array/slice/str cannot be immediate
-                    v.to_op(self.ecx())?.to_mem_place()
+            /// Called whenever we reach a value of primitive type.  There can be no recursion
+            /// below such a value.  This is the leave function.
+            #[inline(always)]
+            fn visit_primitive(&mut self, _val: ImmTy<'tcx, M::PointerTag>) -> EvalResult<'tcx>
+            { Ok(()) }
+
+            // Default recursors. Not meant to be overloaded.
+            fn walk_aggregate(
+                &mut self,
+                v: Self::V,
+                fields: impl Iterator<Item=EvalResult<'tcx, Self::V>>,
+            ) -> EvalResult<'tcx> {
+                // Now iterate over it.
+                for (idx, field_val) in fields.enumerate() {
+                    self.visit_field(v, idx, field_val?)?;
+                }
+                Ok(())
+            }
+            fn walk_value(&mut self, v: Self::V) -> EvalResult<'tcx>
+            {
+                // If this is a multi-variant layout, we have find the right one and proceed with
+                // that.
+                match v.layout().variants {
+                    layout::Variants::NicheFilling { .. } |
+                    layout::Variants::Tagged { .. } => {
+                        let op = v.to_op(self.ecx())?;
+                        let idx = self.ecx().read_discriminant(op)?.1;
+                        let inner = v.project_downcast(self.ecx(), idx)?;
+                        trace!("walk_value: variant layout: {:#?}", inner.layout());
+                        // recurse with the inner type
+                        return self.visit_field(v, idx, inner);
+                    }
+                    layout::Variants::Single { .. } => {}
+                }
+
+                // Even for single variants, we might be able to get a more refined type:
+                // If it is a trait object, switch to the actual type that was used to create it.
+                match v.layout().ty.sty {
+                    ty::Dynamic(..) => {
+                        // immediate trait objects are not a thing
+                        let dest = v.to_op(self.ecx())?.to_mem_place();
+                        let inner = self.ecx().unpack_dyn_trait(dest)?.1;
+                        trace!("walk_value: dyn object layout: {:#?}", inner.layout);
+                        // recurse with the inner type
+                        return self.visit_field(v, 0, Value::from_mem_place(inner));
+                    },
+                    _ => {},
                 };
-                // Now we can go over all the fields.
-                let iter = self.ecx().mplace_array_fields(mplace)?
-                    .map(|f| f.and_then(|f| {
-                        Ok(Value::from_mem_place(f))
-                    }));
-                self.visit_aggregate(v, iter)?;
+
+                // If this is a scalar, visit it as such.
+                // Things can be aggregates and have scalar layout at the same time, and that
+                // is very relevant for `NonNull` and similar structs: We need to visit them
+                // at their scalar layout *before* descending into their fields.
+                // FIXME: We could avoid some redundant checks here. For newtypes wrapping
+                // scalars, we do the same check on every "level" (e.g. first we check
+                // MyNewtype and then the scalar in there).
+                match v.layout().abi {
+                    layout::Abi::Uninhabited => {
+                        self.visit_uninhabited()?;
+                    }
+                    layout::Abi::Scalar(ref layout) => {
+                        self.visit_scalar(v, layout)?;
+                    }
+                    // FIXME: Should we do something for ScalarPair? Vector?
+                    _ => {}
+                }
+
+                // Check primitive types.  We do this after checking the scalar layout,
+                // just to have that done as well.  Primitives can have varying layout,
+                // so we check them separately and before aggregate handling.
+                // It is CRITICAL that we get this check right, or we might be
+                // validating the wrong thing!
+                let primitive = match v.layout().fields {
+                    // Primitives appear as Union with 0 fields - except for Boxes and fat pointers.
+                    layout::FieldPlacement::Union(0) => true,
+                    _ => v.layout().ty.builtin_deref(true).is_some(),
+                };
+                if primitive {
+                    let op = v.to_op(self.ecx())?;
+                    let val = self.ecx().read_immediate(op)?;
+                    return self.visit_primitive(val);
+                }
+
+                // Proceed into the fields.
+                match v.layout().fields {
+                    layout::FieldPlacement::Union(fields) => {
+                        // Empty unions are not accepted by rustc. That's great, it means we can
+                        // use that as an unambiguous signal for detecting primitives.  Make sure
+                        // we did not miss any primitive.
+                        debug_assert!(fields > 0);
+                        self.visit_union(v)?;
+                    },
+                    layout::FieldPlacement::Arbitrary { ref offsets, .. } => {
+                        // FIXME: We collect in a vec because otherwise there are lifetime errors:
+                        // Projecting to a field needs (mutable!) access to `ecx`.
+                        let fields: Vec<EvalResult<'tcx, Self::V>> =
+                            (0..offsets.len()).map(|i| {
+                                v.project_field(self.ecx(), i as u64)
+                            })
+                            .collect();
+                        self.visit_aggregate(v, fields.into_iter())?;
+                    },
+                    layout::FieldPlacement::Array { .. } => {
+                        // Let's get an mplace first.
+                        let mplace = if v.layout().is_zst() {
+                            // it's a ZST, the memory content cannot matter
+                            MPlaceTy::dangling(v.layout(), self.ecx())
+                        } else {
+                            // non-ZST array/slice/str cannot be immediate
+                            v.to_op(self.ecx())?.to_mem_place()
+                        };
+                        // Now we can go over all the fields.
+                        let iter = self.ecx().mplace_array_fields(mplace)?
+                            .map(|f| f.and_then(|f| {
+                                Ok(Value::from_mem_place(f))
+                            }));
+                        self.visit_aggregate(v, iter)?;
+                    }
+                }
+                Ok(())
             }
         }
-        Ok(())
     }
 }
+
+make_value_visitor!(ValueVisitor,);
+make_value_visitor!(MutValueVisitor,mut);

--- a/src/librustc_mir/interpret/visitor.rs
+++ b/src/librustc_mir/interpret/visitor.rs
@@ -179,12 +179,15 @@ pub trait ValueVisitor<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>>: fmt::Debug +
     }
 
     // Actions on the leaves.
-    fn visit_uninhabited(&mut self, ectx: &mut EvalContext<'a, 'mir, 'tcx, M>)
-        -> EvalResult<'tcx>;
-    fn visit_scalar(&mut self, ectx: &mut EvalContext<'a, 'mir, 'tcx, M>, layout: &layout::Scalar)
-        -> EvalResult<'tcx>;
-    fn visit_primitive(&mut self, ectx: &mut EvalContext<'a, 'mir, 'tcx, M>)
-        -> EvalResult<'tcx>;
+    fn visit_uninhabited(&mut self, _ectx: &mut EvalContext<'a, 'mir, 'tcx, M>)
+        -> EvalResult<'tcx>
+    { Ok(()) }
+    fn visit_scalar(&mut self, _ectx: &mut EvalContext<'a, 'mir, 'tcx, M>, _layout: &layout::Scalar)
+        -> EvalResult<'tcx>
+    { Ok(()) }
+    fn visit_primitive(&mut self, _ectx: &mut EvalContext<'a, 'mir, 'tcx, M>)
+        -> EvalResult<'tcx>
+    { Ok(()) }
 }
 
 impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> {

--- a/src/librustc_mir/interpret/visitor.rs
+++ b/src/librustc_mir/interpret/visitor.rs
@@ -317,7 +317,7 @@ pub trait ValueVisitor<'a, 'mir, 'tcx: 'mir+'a, M: Machine<'a, 'mir, 'tcx>>: Siz
                 self.visit_union(v)?;
             },
             layout::FieldPlacement::Arbitrary { ref offsets, .. } => {
-                // We collect in a vec because otherwise there are lifetime errors:
+                // FIXME: We collect in a vec because otherwise there are lifetime errors:
                 // Projecting to a field needs (mutable!) access to `ecx`.
                 let fields: Vec<EvalResult<'tcx, Self::V>> =
                     (0..offsets.len()).map(|i| {

--- a/src/librustc_mir/interpret/visitor.rs
+++ b/src/librustc_mir/interpret/visitor.rs
@@ -1,0 +1,125 @@
+//! Visitor for a run-time value with a given layout: Traverse enums, structs and other compound
+//! types until we arrive at the leaves, with custom handling for primitive types.
+
+use std::fmt;
+
+use rustc::ty::layout::{self, TyLayout};
+use rustc::ty;
+use rustc::mir::interpret::{
+    EvalResult,
+};
+
+use super::{
+    Machine, EvalContext,
+};
+
+// How to traverse a value and what to do when we are at the leaves.
+// In the future, we might want to turn this into two traits, but so far the
+// only implementations we have couldn't share any code anyway.
+pub trait ValueVisitor<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>>: fmt::Debug {
+    // Get this value's layout.
+    fn layout(&self) -> TyLayout<'tcx>;
+
+    // Downcast functions.  These change the value as a side-effect.
+    fn downcast_enum(&mut self, ectx: &EvalContext<'a, 'mir, 'tcx, M>)
+        -> EvalResult<'tcx>;
+    fn downcast_dyn_trait(&mut self, ectx: &EvalContext<'a, 'mir, 'tcx, M>)
+        -> EvalResult<'tcx>;
+
+    // Visit all fields of a compound.
+    // Just call `visit_value` if you want to go on recursively.
+    fn visit_fields(&mut self, ectx: &mut EvalContext<'a, 'mir, 'tcx, M>, num_fields: usize)
+        -> EvalResult<'tcx>;
+    // Optimized handling for arrays -- avoid computing the layout for every field.
+    // Also it is the value's responsibility to figure out the length.
+    fn visit_array(&mut self, ectx: &mut EvalContext<'a, 'mir, 'tcx, M>) -> EvalResult<'tcx>;
+    // Special handling for strings.
+    fn visit_str(&mut self, ectx: &mut EvalContext<'a, 'mir, 'tcx, M>)
+        -> EvalResult<'tcx>;
+
+    // Actions on the leaves.
+    fn visit_scalar(&mut self, ectx: &mut EvalContext<'a, 'mir, 'tcx, M>, layout: &layout::Scalar)
+        -> EvalResult<'tcx>;
+    fn visit_primitive(&mut self, ectx: &mut EvalContext<'a, 'mir, 'tcx, M>)
+        -> EvalResult<'tcx>;
+}
+
+impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> {
+    pub fn visit_value<V: ValueVisitor<'a, 'mir, 'tcx, M>>(&mut self, v: &mut V) -> EvalResult<'tcx> {
+        trace!("visit_value: {:?}", v);
+
+        // If this is a multi-variant layout, we have find the right one and proceed with that.
+        // (No benefit from making this recursion, but it is equivalent to that.)
+        match v.layout().variants {
+            layout::Variants::NicheFilling { .. } |
+            layout::Variants::Tagged { .. } => {
+                v.downcast_enum(self)?;
+                trace!("variant layout: {:#?}", v.layout());
+            }
+            layout::Variants::Single { .. } => {}
+        }
+
+        // Even for single variants, we might be able to get a more refined type:
+        // If it is a trait object, switch to the actual type that was used to create it.
+        match v.layout().ty.sty {
+            ty::Dynamic(..) => {
+                v.downcast_dyn_trait(self)?;
+            },
+            _ => {},
+        };
+
+        // If this is a scalar, visit it as such.
+        // Things can be aggregates and have scalar layout at the same time, and that
+        // is very relevant for `NonNull` and similar structs: We need to visit them
+        // at their scalar layout *before* descending into their fields.
+        // FIXME: We could avoid some redundant checks here. For newtypes wrapping
+        // scalars, we do the same check on every "level" (e.g. first we check
+        // MyNewtype and then the scalar in there).
+        match v.layout().abi {
+            layout::Abi::Scalar(ref layout) => {
+                v.visit_scalar(self, layout)?;
+            }
+            // FIXME: Should we do something for ScalarPair? Vector?
+            _ => {}
+        }
+
+        // Check primitive types.  We do this after checking the scalar layout,
+        // just to have that done as well.  Primitives can have varying layout,
+        // so we check them separately and before aggregate handling.
+        // It is CRITICAL that we get this check right, or we might be
+        // validating the wrong thing!
+        let primitive = match v.layout().fields {
+            // Primitives appear as Union with 0 fields -- except for Boxes and fat pointers.
+            layout::FieldPlacement::Union(0) => true,
+            _ => v.layout().ty.builtin_deref(true).is_some(),
+        };
+        if primitive {
+            return v.visit_primitive(self);
+        }
+
+        // Proceed into the fields.
+        match v.layout().fields {
+            layout::FieldPlacement::Union(fields) => {
+                // Empty unions are not accepted by rustc. That's great, it means we can
+                // use that as an unambiguous signal for detecting primitives.  Make sure
+                // we did not miss any primitive.
+                debug_assert!(fields > 0);
+                // We can't traverse unions, their bits are allowed to be anything.
+                // The fields don't need to correspond to any bit pattern of the union's fields.
+                // See https://github.com/rust-lang/rust/issues/32836#issuecomment-406875389
+                Ok(())
+            },
+            layout::FieldPlacement::Arbitrary { ref offsets, .. } => {
+                v.visit_fields(self, offsets.len())
+            },
+            layout::FieldPlacement::Array { .. } => {
+                match v.layout().ty.sty {
+                    // Strings have properties that cannot be expressed pointwise.
+                    ty::Str => v.visit_str(self),
+                    // General case -- might also be SIMD vector or so
+                    _ => v.visit_array(self),
+                }
+            }
+        }
+    }
+}

--- a/src/test/ui/consts/const-eval/double_check2.stderr
+++ b/src/test/ui/consts/const-eval/double_check2.stderr
@@ -5,7 +5,7 @@ LL | / static FOO: (&Foo, &Bar) = unsafe {( //~ undefined behavior
 LL | |     Union { u8: &BAR }.foo,
 LL | |     Union { u8: &BAR }.bar,
 LL | | )};
-   | |___^ type validation failed: encountered invalid enum discriminant 5 at .1.<deref>
+   | |___^ type validation failed: encountered 5 at .1.<deref>, but expected a valid enum discriminant
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 

--- a/src/test/ui/consts/const-eval/ub-enum.rs
+++ b/src/test/ui/consts/const-eval/ub-enum.rs
@@ -33,8 +33,13 @@ enum Enum2 {
 union TransmuteEnum2 {
     a: usize,
     b: Enum2,
+    c: (),
 }
 const BAD_ENUM2 : Enum2 = unsafe { TransmuteEnum2 { a: 0 }.b };
+//~^ ERROR is undefined behavior
+
+// Undef enum discriminant. In an arry to avoid `Scalar` layout.
+const BAD_ENUM3 : [Enum2; 2] = [unsafe { TransmuteEnum2 { c: () }.b }; 2];
 //~^ ERROR is undefined behavior
 
 // Invalid enum field content (mostly to test printing of apths for enum tuple

--- a/src/test/ui/consts/const-eval/ub-enum.rs
+++ b/src/test/ui/consts/const-eval/ub-enum.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(const_err)] // make sure we cannot allow away the errors tested here
+
 #[repr(usize)]
 #[derive(Copy, Clone)]
 enum Enum {

--- a/src/test/ui/consts/const-eval/ub-enum.stderr
+++ b/src/test/ui/consts/const-eval/ub-enum.stderr
@@ -7,7 +7,7 @@ LL | const BAD_ENUM: Enum = unsafe { TransmuteEnum { a: &1 }.b };
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-enum.rs:37:1
+  --> $DIR/ub-enum.rs:38:1
    |
 LL | const BAD_ENUM2 : Enum2 = unsafe { TransmuteEnum2 { a: 0 }.b };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0, but expected a valid enum discriminant
@@ -15,13 +15,21 @@ LL | const BAD_ENUM2 : Enum2 = unsafe { TransmuteEnum2 { a: 0 }.b };
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-enum.rs:47:1
+  --> $DIR/ub-enum.rs:42:1
+   |
+LL | const BAD_ENUM3 : [Enum2; 2] = [unsafe { TransmuteEnum2 { c: () }.b }; 2];
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempted to read undefined bytes
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/ub-enum.rs:52:1
    |
 LL | const BAD_ENUM_CHAR : Option<(char, char)> = Some(('x', unsafe { TransmuteChar { a: !0 }.b }));
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 4294967295 at .Some.0.1, but expected something in the range 0..=1114111
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-eval/ub-enum.stderr
+++ b/src/test/ui/consts/const-eval/ub-enum.stderr
@@ -1,21 +1,21 @@
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-enum.rs:22:1
+  --> $DIR/ub-enum.rs:24:1
    |
 LL | const BAD_ENUM: Enum = unsafe { TransmuteEnum { a: &1 }.b };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered non-integer enum discriminant
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a pointer, but expected a valid enum discriminant
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-enum.rs:35:1
+  --> $DIR/ub-enum.rs:37:1
    |
 LL | const BAD_ENUM2 : Enum2 = unsafe { TransmuteEnum2 { a: 0 }.b };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered invalid enum discriminant 0
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0, but expected a valid enum discriminant
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-enum.rs:45:1
+  --> $DIR/ub-enum.rs:47:1
    |
 LL | const BAD_ENUM_CHAR : Option<(char, char)> = Some(('x', unsafe { TransmuteChar { a: !0 }.b }));
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 4294967295 at .Some.0.1, but expected something in the range 0..=1114111

--- a/src/test/ui/consts/const-eval/ub-nonnull.rs
+++ b/src/test/ui/consts/const-eval/ub-nonnull.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![feature(const_transmute)]
+#![allow(const_err)] // make sure we cannot allow away the errors tested here
 
 use std::mem;
 use std::ptr::NonNull;

--- a/src/test/ui/consts/const-eval/ub-nonnull.stderr
+++ b/src/test/ui/consts/const-eval/ub-nonnull.stderr
@@ -1,5 +1,5 @@
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:17:1
+  --> $DIR/ub-nonnull.rs:18:1
    |
 LL | const NULL_PTR: NonNull<u8> = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0, but expected something greater or equal to 1
@@ -7,7 +7,7 @@ LL | const NULL_PTR: NonNull<u8> = unsafe { mem::transmute(0usize) };
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:20:1
+  --> $DIR/ub-nonnull.rs:21:1
    |
 LL | const NULL_U8: NonZeroU8 = unsafe { mem::transmute(0u8) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0, but expected something greater or equal to 1
@@ -15,7 +15,7 @@ LL | const NULL_U8: NonZeroU8 = unsafe { mem::transmute(0u8) };
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:22:1
+  --> $DIR/ub-nonnull.rs:23:1
    |
 LL | const NULL_USIZE: NonZeroUsize = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0, but expected something greater or equal to 1

--- a/src/test/ui/consts/const-eval/ub-ref.rs
+++ b/src/test/ui/consts/const-eval/ub-ref.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![feature(const_transmute)]
+#![allow(const_err)] // make sure we cannot allow away the errors tested here
 
 use std::mem;
 

--- a/src/test/ui/consts/const-eval/ub-ref.stderr
+++ b/src/test/ui/consts/const-eval/ub-ref.stderr
@@ -1,5 +1,5 @@
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref.rs:15:1
+  --> $DIR/ub-ref.rs:16:1
    |
 LL | const UNALIGNED: &u16 = unsafe { mem::transmute(&[0u8; 4]) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered unaligned reference
@@ -7,7 +7,7 @@ LL | const UNALIGNED: &u16 = unsafe { mem::transmute(&[0u8; 4]) };
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref.rs:18:1
+  --> $DIR/ub-ref.rs:19:1
    |
 LL | const NULL: &u16 = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0, but expected something greater or equal to 1
@@ -15,7 +15,7 @@ LL | const NULL: &u16 = unsafe { mem::transmute(0usize) };
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref.rs:21:1
+  --> $DIR/ub-ref.rs:22:1
    |
 LL | const REF_AS_USIZE: usize = unsafe { mem::transmute(&0) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a pointer, but expected initialized plain bits
@@ -23,7 +23,7 @@ LL | const REF_AS_USIZE: usize = unsafe { mem::transmute(&0) };
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref.rs:24:1
+  --> $DIR/ub-ref.rs:25:1
    |
 LL | const REF_AS_USIZE_SLICE: &[usize] = &[unsafe { mem::transmute(&0) }];
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ a raw memory access tried to access part of a pointer value as raw bytes
@@ -31,7 +31,7 @@ LL | const REF_AS_USIZE_SLICE: &[usize] = &[unsafe { mem::transmute(&0) }];
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref.rs:27:1
+  --> $DIR/ub-ref.rs:28:1
    |
 LL | const USIZE_AS_REF: &'static u8 = unsafe { mem::transmute(1337usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered integer pointer in non-ZST reference

--- a/src/test/ui/consts/const-eval/ub-ref.stderr
+++ b/src/test/ui/consts/const-eval/ub-ref.stderr
@@ -26,7 +26,7 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-ref.rs:25:1
    |
 LL | const REF_AS_USIZE_SLICE: &[usize] = &[unsafe { mem::transmute(&0) }];
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ a raw memory access tried to access part of a pointer value as raw bytes
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a pointer at .<deref>, but expected plain bytes
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 

--- a/src/test/ui/consts/const-eval/ub-uninhabit.rs
+++ b/src/test/ui/consts/const-eval/ub-uninhabit.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![feature(const_transmute)]
+#![allow(const_err)] // make sure we cannot allow away the errors tested here
 
 use std::mem;
 

--- a/src/test/ui/consts/const-eval/ub-uninhabit.stderr
+++ b/src/test/ui/consts/const-eval/ub-uninhabit.stderr
@@ -1,5 +1,5 @@
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-uninhabit.rs:18:1
+  --> $DIR/ub-uninhabit.rs:19:1
    |
 LL | const BAD_BAD_BAD: Bar = unsafe { mem::transmute(()) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a value of an uninhabited type
@@ -7,7 +7,7 @@ LL | const BAD_BAD_BAD: Bar = unsafe { mem::transmute(()) };
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-uninhabit.rs:21:1
+  --> $DIR/ub-uninhabit.rs:22:1
    |
 LL | const BAD_BAD_REF: &Bar = unsafe { mem::transmute(1usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a value of an uninhabited type at .<deref>
@@ -15,7 +15,7 @@ LL | const BAD_BAD_REF: &Bar = unsafe { mem::transmute(1usize) };
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-uninhabit.rs:24:1
+  --> $DIR/ub-uninhabit.rs:25:1
    |
 LL | const BAD_BAD_ARRAY: [Bar; 1] = unsafe { mem::transmute(()) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a value of an uninhabited type at [0]

--- a/src/test/ui/consts/const-eval/ub-upvars.rs
+++ b/src/test/ui/consts/const-eval/ub-upvars.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![feature(const_transmute,const_let)]
+#![allow(const_err)] // make sure we cannot allow away the errors tested here
 
 use std::mem;
 

--- a/src/test/ui/consts/const-eval/ub-upvars.stderr
+++ b/src/test/ui/consts/const-eval/ub-upvars.stderr
@@ -1,5 +1,5 @@
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-upvars.rs:15:1
+  --> $DIR/ub-upvars.rs:16:1
    |
 LL | / const BAD_UPVAR: &FnOnce() = &{ //~ ERROR it is undefined behavior to use this value
 LL | |     let bad_ref: &'static u16 = unsafe { mem::transmute(0usize) };

--- a/src/test/ui/consts/const-eval/ub-upvars.stderr
+++ b/src/test/ui/consts/const-eval/ub-upvars.stderr
@@ -6,7 +6,7 @@ LL | |     let bad_ref: &'static u16 = unsafe { mem::transmute(0usize) };
 LL | |     let another_var = 13;
 LL | |     move || { let _ = bad_ref; let _ = another_var; }
 LL | | };
-   | |__^ type validation failed: encountered 0 at .<deref>.<closure-var(bad_ref)>, but expected something greater or equal to 1
+   | |__^ type validation failed: encountered 0 at .<deref>.<dyn-downcast>.<closure-var(bad_ref)>, but expected something greater or equal to 1
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 

--- a/src/test/ui/consts/const-eval/union-ub-fat-ptr.rs
+++ b/src/test/ui/consts/const-eval/union-ub-fat-ptr.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![allow(unused)]
+#![allow(const_err)] // make sure we cannot allow away the errors tested here
 
 // normalize-stderr-test "alignment \d+" -> "alignment N"
 // normalize-stderr-test "offset \d+" -> "offset N"

--- a/src/test/ui/consts/const-eval/union-ub-fat-ptr.stderr
+++ b/src/test/ui/consts/const-eval/union-ub-fat-ptr.stderr
@@ -1,5 +1,5 @@
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/union-ub-fat-ptr.rs:87:1
+  --> $DIR/union-ub-fat-ptr.rs:88:1
    |
 LL | const B: &str = unsafe { SliceTransmute { repr: SliceRepr { ptr: &42, len: 999 } }.str};
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered dangling (not entirely in bounds) reference
@@ -7,7 +7,7 @@ LL | const B: &str = unsafe { SliceTransmute { repr: SliceRepr { ptr: &42, len: 
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/union-ub-fat-ptr.rs:90:1
+  --> $DIR/union-ub-fat-ptr.rs:91:1
    |
 LL | const C: &str = unsafe { SliceTransmute { bad: BadSliceRepr { ptr: &42, len: &3 } }.str};
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered non-integer slice length in fat pointer
@@ -15,7 +15,7 @@ LL | const C: &str = unsafe { SliceTransmute { bad: BadSliceRepr { ptr: &42, len
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/union-ub-fat-ptr.rs:93:1
+  --> $DIR/union-ub-fat-ptr.rs:94:1
    |
 LL | const C2: &MyStr = unsafe { SliceTransmute { bad: BadSliceRepr { ptr: &42, len: &3 } }.my_str};
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered non-integer slice length in fat pointer
@@ -23,7 +23,7 @@ LL | const C2: &MyStr = unsafe { SliceTransmute { bad: BadSliceRepr { ptr: &42, 
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/union-ub-fat-ptr.rs:99:1
+  --> $DIR/union-ub-fat-ptr.rs:100:1
    |
 LL | const B2: &[u8] = unsafe { SliceTransmute { repr: SliceRepr { ptr: &42, len: 999 } }.slice};
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered dangling (not entirely in bounds) reference
@@ -31,7 +31,7 @@ LL | const B2: &[u8] = unsafe { SliceTransmute { repr: SliceRepr { ptr: &42, len
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/union-ub-fat-ptr.rs:102:1
+  --> $DIR/union-ub-fat-ptr.rs:103:1
    |
 LL | const C3: &[u8] = unsafe { SliceTransmute { bad: BadSliceRepr { ptr: &42, len: &3 } }.slice};
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered non-integer slice length in fat pointer
@@ -39,7 +39,7 @@ LL | const C3: &[u8] = unsafe { SliceTransmute { bad: BadSliceRepr { ptr: &42, l
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/union-ub-fat-ptr.rs:106:1
+  --> $DIR/union-ub-fat-ptr.rs:107:1
    |
 LL | const D: &Trait = unsafe { DynTransmute { repr: DynRepr { ptr: &92, vtable: &3 } }.rust};
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered invalid drop fn in vtable
@@ -47,7 +47,7 @@ LL | const D: &Trait = unsafe { DynTransmute { repr: DynRepr { ptr: &92, vtable:
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/union-ub-fat-ptr.rs:109:1
+  --> $DIR/union-ub-fat-ptr.rs:110:1
    |
 LL | const E: &Trait = unsafe { DynTransmute { repr2: DynRepr2 { ptr: &92, vtable: &3 } }.rust};
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered invalid drop fn in vtable
@@ -55,7 +55,7 @@ LL | const E: &Trait = unsafe { DynTransmute { repr2: DynRepr2 { ptr: &92, vtabl
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/union-ub-fat-ptr.rs:112:1
+  --> $DIR/union-ub-fat-ptr.rs:113:1
    |
 LL | const F: &Trait = unsafe { DynTransmute { bad: BadDynRepr { ptr: &92, vtable: 3 } }.rust};
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered non-pointer vtable in fat pointer
@@ -63,7 +63,7 @@ LL | const F: &Trait = unsafe { DynTransmute { bad: BadDynRepr { ptr: &92, vtabl
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/union-ub-fat-ptr.rs:116:1
+  --> $DIR/union-ub-fat-ptr.rs:117:1
    |
 LL | const G: &Trait = &unsafe { BoolTransmute { val: 3 }.bl };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 3 at .<deref>.<dyn-downcast>, but expected something in the range 0..=1
@@ -71,7 +71,7 @@ LL | const G: &Trait = &unsafe { BoolTransmute { val: 3 }.bl };
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/union-ub-fat-ptr.rs:120:1
+  --> $DIR/union-ub-fat-ptr.rs:121:1
    |
 LL | const H: &[bool] = &[unsafe { BoolTransmute { val: 3 }.bl }];
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 3 at .<deref>[0], but expected something in the range 0..=1
@@ -79,7 +79,7 @@ LL | const H: &[bool] = &[unsafe { BoolTransmute { val: 3 }.bl }];
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/union-ub-fat-ptr.rs:126:1
+  --> $DIR/union-ub-fat-ptr.rs:127:1
    |
 LL | const I2: &MySliceBool = &MySlice(unsafe { BoolTransmute { val: 3 }.bl }, [false]);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 3 at .<deref>.0, but expected something in the range 0..=1
@@ -87,7 +87,7 @@ LL | const I2: &MySliceBool = &MySlice(unsafe { BoolTransmute { val: 3 }.bl }, [
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/union-ub-fat-ptr.rs:129:1
+  --> $DIR/union-ub-fat-ptr.rs:130:1
    |
 LL | const I3: &MySliceBool = &MySlice(true, [unsafe { BoolTransmute { val: 3 }.bl }]);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 3 at .<deref>.1[0], but expected something in the range 0..=1
@@ -95,7 +95,7 @@ LL | const I3: &MySliceBool = &MySlice(true, [unsafe { BoolTransmute { val: 3 }.
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/union-ub-fat-ptr.rs:133:1
+  --> $DIR/union-ub-fat-ptr.rs:134:1
    |
 LL | const J1: &str = unsafe { SliceTransmute { slice: &[0xFF] }.str };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized or non-UTF-8 data in str at .<deref>
@@ -103,7 +103,7 @@ LL | const J1: &str = unsafe { SliceTransmute { slice: &[0xFF] }.str };
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/union-ub-fat-ptr.rs:136:1
+  --> $DIR/union-ub-fat-ptr.rs:137:1
    |
 LL | const J2: &MyStr = unsafe { SliceTransmute { slice: &[0xFF] }.my_str };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized or non-UTF-8 data in str at .<deref>.0

--- a/src/test/ui/consts/const-eval/union-ub-fat-ptr.stderr
+++ b/src/test/ui/consts/const-eval/union-ub-fat-ptr.stderr
@@ -66,7 +66,7 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/union-ub-fat-ptr.rs:116:1
    |
 LL | const G: &Trait = &unsafe { BoolTransmute { val: 3 }.bl };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 3 at .<deref>, but expected something in the range 0..=1
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 3 at .<deref>.<dyn-downcast>, but expected something in the range 0..=1
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 

--- a/src/test/ui/consts/const-eval/union-ub.rs
+++ b/src/test/ui/consts/const-eval/union-ub.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(const_err)] // make sure we cannot allow away the errors tested here
+
 union DummyUnion {
     u8: u8,
     bool: bool,

--- a/src/test/ui/consts/const-eval/union-ub.stderr
+++ b/src/test/ui/consts/const-eval/union-ub.stderr
@@ -1,5 +1,5 @@
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/union-ub.rs:36:1
+  --> $DIR/union-ub.rs:38:1
    |
 LL | const BAD_BOOL: bool = unsafe { DummyUnion { u8: 42 }.bool};
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 42, but expected something in the range 0..=1


### PR DESCRIPTION
Generalize the traversal part of validation to a `ValueVisitor`.

~~This includes https://github.com/rust-lang/rust/pull/55316, [click here](https://github.com/RalfJung/rust/compare/retagging...RalfJung:miri-visitor) for just the new commits.~~