### PR TITLE
Make `-Z ls` list the actual filename of external dependencies

### DIFF
--- a/src/librustc_metadata/decoder.rs
+++ b/src/librustc_metadata/decoder.rs
@@ -400,7 +400,7 @@ impl<'a, 'tcx> MetadataBlob {
         for (i, dep) in root.crate_deps
                             .decode(self)
                             .enumerate() {
-            write!(out, "{} {}-{}\n", i + 1, dep.name, dep.hash)?;
+            write!(out, "{} {}{}\n", i + 1, dep.name, dep.extra_filename)?;
         }
         write!(out, "\n")?;
         Ok(())


### PR DESCRIPTION
The hash is pointless for external consumers - extra_filename is the thing that actually gets used, per https://github.com/rust-lang/rust/blob/ca2639e/src/librustc_metadata/locator.rs#L312-L313