### PR TITLE
Make #[path] always relative to the current directory

### DIFF
--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -828,7 +828,7 @@ impl<'a> ExtCtxt<'a> {
                 mark: Mark::root(),
                 depth: 0,
                 module: Rc::new(ModuleData { mod_path: Vec::new(), directory: PathBuf::new() }),
-                directory_ownership: DirectoryOwnership::Owned { relative: None },
+                directory_ownership: DirectoryOwnership::Owned { relative: vec![] },
                 crate_span: None,
             },
             expansions: FxHashMap::default(),

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -1355,14 +1355,10 @@ impl<'a, 'b> Folder for InvocationCollector<'a, 'b> {
                 let inline_module = item.span.contains(inner) || inner.is_dummy();
 
                 if inline_module {
-                    if let Some(path) = attr::first_attr_value_str_by_name(&item.attrs, "path") {
-                        orig_directory_ownership =
-                            Some(mem::replace(
-                                &mut self.cx.current_expansion.directory_ownership,
-                                DirectoryOwnership::Owned { relative: vec![] }));
-                        module.directory.push(&*path.as_str());
-                    } else {
-                        module.directory.push(&*item.ident.as_str());
+                    if let DirectoryOwnership::Owned { relative } =
+                        &mut self.directory.ownership
+                    {
+                        relative.push(item.ident);
                     }
                 } else {
                     let path = self.cx.parse_sess.source_map().span_to_unmapped_path(inner);

--- a/src/libsyntax/ext/source_util.rs
+++ b/src/libsyntax/ext/source_util.rs
@@ -100,7 +100,7 @@ pub fn expand_include<'cx>(cx: &'cx mut ExtCtxt, sp: Span, tts: &[tokenstream::T
     };
     // The file will be added to the code map by the parser
     let path = res_rel_file(cx, sp, file);
-    let directory_ownership = DirectoryOwnership::Owned { relative: None };
+    let directory_ownership = DirectoryOwnership::Owned { relative: vec![] };
     let p = parse::new_sub_parser_from_file(cx.parse_sess(), &path, directory_ownership, None, sp);
 
     struct ExpandResult<'a> {

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -156,7 +156,7 @@ fn generic_extension<'cx>(cx: &'cx mut ExtCtxt,
 
                 let directory = Directory {
                     path: Cow::from(cx.current_expansion.module.directory.as_path()),
-                    ownership: cx.current_expansion.directory_ownership,
+                    ownership: cx.current_expansion.directory_ownership.clone(),
                 };
                 let mut p = Parser::new(cx.parse_sess(), tts, Some(directory), true, false);
                 p.root_module_name = cx.current_expansion.module.mod_path.last()

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -1869,7 +1869,6 @@ mod tests {
             missing_fragment_specifiers: Lock::new(FxHashSet::default()),
             raw_identifier_spans: Lock::new(Vec::new()),
             registered_diagnostics: Lock::new(ErrorMap::new()),
-            non_modrs_mods: Lock::new(vec![]),
             buffered_lints: Lock::new(vec![]),
         }
     }

--- a/src/libsyntax/tokenstream.rs
+++ b/src/libsyntax/tokenstream.rs
@@ -107,7 +107,7 @@ impl TokenTree {
         // `None` is because we're not interpolating
         let directory = Directory {
             path: Cow::from(cx.current_expansion.module.directory.as_path()),
-            ownership: cx.current_expansion.directory_ownership,
+            ownership: cx.current_expansion.directory_ownership.clone(),
         };
         macro_parser::parse(cx.parse_sess(), tts, mtch, Some(directory), true)
     }

--- a/src/test/run-pass/modules/mod_dir_path.rs
+++ b/src/test/run-pass/modules/mod_dir_path.rs
@@ -13,21 +13,23 @@
 // ignore-pretty issue #37195
 
 mod mod_dir_simple {
-    #[path = "test.rs"]
+    #[path = "mod_dir_simple/test.rs"]
     pub mod syrup;
 }
 
 pub fn main() {
     assert_eq!(mod_dir_simple::syrup::foo(), 10);
 
-    #[path = "auxiliary"]
     mod foo {
+        #[path = "auxiliary/two_macros_2.rs"]
         mod two_macros_2;
     }
 
-    #[path = "auxiliary"]
     mod bar {
-        macro_rules! m { () => { mod two_macros_2; } }
+        macro_rules! m { () => {
+            #[path = "auxiliary/two_macros_2.rs"]
+            mod two_macros_2;
+        } }
         m!();
     }
 }

--- a/src/test/run-pass/modules/mod_dir_path2.rs
+++ b/src/test/run-pass/modules/mod_dir_path2.rs
@@ -11,9 +11,8 @@
 // run-pass
 // ignore-pretty issue #37195
 
-#[path = "mod_dir_simple"]
 mod pancakes {
-    #[path = "test.rs"]
+    #[path = "mod_dir_simple/test.rs"]
     pub mod syrup;
 }
 

--- a/src/test/run-pass/modules/mod_dir_path3.rs
+++ b/src/test/run-pass/modules/mod_dir_path3.rs
@@ -11,8 +11,8 @@
 // run-pass
 // ignore-pretty issue #37195
 
-#[path = "mod_dir_simple"]
 mod pancakes {
+    #[path = "mod_dir_simple/test.rs"]
     pub mod test;
 }
 

--- a/src/test/run-pass/modules/mod_dir_path_multi.rs
+++ b/src/test/run-pass/modules/mod_dir_path_multi.rs
@@ -11,13 +11,13 @@
 // run-pass
 // ignore-pretty issue #37195
 
-#[path = "mod_dir_simple"]
 mod biscuits {
+    #[path = "mod_dir_simple/test.rs"]
     pub mod test;
 }
 
-#[path = "mod_dir_simple"]
 mod gravy {
+    #[path = "mod_dir_simple/test.rs"]
     pub mod test;
 }
 

--- a/src/test/ui/conditional-compilation/cfg_attr_path.rs
+++ b/src/test/ui/conditional-compilation/cfg_attr_path.rs
@@ -13,8 +13,8 @@
 #![deny(unused_attributes)] // c.f #35584
 
 mod auxiliary {
-    #[cfg_attr(any(), path = "nonexistent_file.rs")] pub mod namespaced_enums;
-    #[cfg_attr(all(), path = "namespaced_enums.rs")] pub mod nonexistent_file;
+    #[cfg_attr(any(), path = "auxiliary/nonexistent_file.rs")] pub mod namespaced_enums;
+    #[cfg_attr(all(), path = "auxiliary/namespaced_enums.rs")] pub mod nonexistent_file;
 }
 
 #[rustc_error]


### PR DESCRIPTION
Previously, #[path] would be relative to the current
directory plus an offset for any inline modules.
However, it did not respect the module offset based
on a non-"mod.rs" filename unless there was *also*
a nested module.

After this commit, #[path] ignores inline modules
and is only ever relative to the current directory.
This means that the old #[path = ...] mod x { ... }
(#[path] applied to inline modules) no longer has
any effect.

This is a [breaking change]. Opening to see what a crater run says.

r? @petrochenkov 