### PR TITLE
Fix double_check tests on big-endian targets

### DIFF
--- a/src/test/ui/consts/const-eval/double_check.rs
+++ b/src/test/ui/consts/const-eval/double_check.rs
@@ -21,12 +21,12 @@ enum Bar {
 union Union {
     foo: &'static Foo,
     bar: &'static Bar,
-    usize: &'static usize,
+    u8: &'static u8,
 }
-static BAR: usize = 42;
+static BAR: u8 = 42;
 static FOO: (&Foo, &Bar) = unsafe {(
-    Union { usize: &BAR }.foo,
-    Union { usize: &BAR }.bar,
+    Union { u8: &BAR }.foo,
+    Union { u8: &BAR }.bar,
 )};
 
 fn main() {}

--- a/src/test/ui/consts/const-eval/double_check2.rs
+++ b/src/test/ui/consts/const-eval/double_check2.rs
@@ -19,12 +19,12 @@ enum Bar {
 union Union {
     foo: &'static Foo,
     bar: &'static Bar,
-    usize: &'static usize,
+    u8: &'static u8,
 }
-static BAR: usize = 5;
+static BAR: u8 = 5;
 static FOO: (&Foo, &Bar) = unsafe {( //~ undefined behavior
-    Union { usize: &BAR }.foo,
-    Union { usize: &BAR }.bar,
+    Union { u8: &BAR }.foo,
+    Union { u8: &BAR }.bar,
 )};
 
 fn main() {}

--- a/src/test/ui/consts/const-eval/double_check2.stderr
+++ b/src/test/ui/consts/const-eval/double_check2.stderr
@@ -2,8 +2,8 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/double_check2.rs:25:1
    |
 LL | / static FOO: (&Foo, &Bar) = unsafe {( //~ undefined behavior
-LL | |     Union { usize: &BAR }.foo,
-LL | |     Union { usize: &BAR }.bar,
+LL | |     Union { u8: &BAR }.foo,
+LL | |     Union { u8: &BAR }.bar,
 LL | | )};
    | |___^ type validation failed: encountered invalid enum discriminant 5 at .1.<deref>
    |


### PR DESCRIPTION
Since the enums get optimized down to 1 byte long, the bits set in the `usize` member don't align with the `enum` values on big-endian machines. Avoid this issue by shrinking the integer member to the
same size as the enums.