### PR TITLE
test/linkage-visibility: Ignore on musl targets

### DIFF
--- a/src/test/run-pass-fulldeps/auxiliary/linkage-visibility.rs
+++ b/src/test/run-pass-fulldeps/auxiliary/linkage-visibility.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-musl - dlsym doesn't see symbols without "-C link-arg=-Wl,--export-dynamic"
+
 #![feature(rustc_private)]
 
 // We're testing linkage visibility; the compiler warns us, but we want to


### PR DESCRIPTION
DynamicLibrary uses libc's dlsym() function internally to find symbols.
Some implementations of dlsym(), like musl's, only look at dynamically-
exported symbols, as found in shared libraries. To also export symbols
from the main executable, pass --export-dynamic to the linker.

(Plus see [here](https://stackoverflow.com/questions/4184017) and [here](https://stackoverflow.com/questions/6121838) for examples of where this is necessary on glibc as well.)