### PR TITLE
enforce unused-must-use lint in macros

### DIFF
--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -29,7 +29,8 @@ use rustc::hir;
 declare_lint! {
     pub UNUSED_MUST_USE,
     Warn,
-    "unused result of a type flagged as #[must_use]"
+    "unused result of a type flagged as #[must_use]",
+    report_in_external_macro: true
 }
 
 declare_lint! {

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -36,7 +36,6 @@ use syntax_pos::{MultiSpan, Span};
 
 use std::cell::{Cell, RefCell};
 use std::collections::BTreeMap;
-use std::fmt::Write;
 use std::{mem, ptr};
 
 /// Contains data for specific types of import directives.
@@ -780,17 +779,14 @@ impl<'a, 'b:'a, 'c: 'b> ImportResolver<'a, 'b, 'c> {
 
             let msg = format!("`{}` import is ambiguous", name);
             let mut err = self.session.struct_span_err(span, &msg);
-            let mut suggestion_choices = String::new();
+            let mut suggestion_choices = vec![];
             if external_crate.is_some() {
-                write!(suggestion_choices, "`::{}`", name);
+                suggestion_choices.push(format!("`::{}`", name));
                 err.span_label(span,
                     format!("can refer to external crate `::{}`", name));
             }
             if let Some(result) = results.module_scope {
-                if !suggestion_choices.is_empty() {
-                    suggestion_choices.push_str(" or ");
-                }
-                write!(suggestion_choices, "`self::{}`", name);
+                suggestion_choices.push(format!("`self::{}`", name));
                 if uniform_paths_feature {
                     err.span_label(result.span,
                         format!("can refer to `self::{}`", name));
@@ -803,7 +799,7 @@ impl<'a, 'b:'a, 'c: 'b> ImportResolver<'a, 'b, 'c> {
                 err.span_label(result.span,
                     format!("shadowed by block-scoped `{}`", name));
             }
-            err.help(&format!("write {} explicitly instead", suggestion_choices));
+            err.help(&format!("write {} explicitly instead", suggestion_choices.join(" or ")));
             if uniform_paths_feature {
                 err.note("relative `use` paths enabled by `#![feature(uniform_paths)]`");
             } else {

--- a/src/test/run-pass/impl-trait/example-calendar.rs
+++ b/src/test/run-pass/impl-trait/example-calendar.rs
@@ -310,10 +310,10 @@ trait IteratorExt: Iterator + Sized {
     where Self::Item: std::fmt::Display {
         let mut s = String::new();
         if let Some(e) = self.next() {
-            write!(s, "{}", e);
+            write!(s, "{}", e).unwrap();
             for e in self {
                 s.push_str(sep);
-                write!(s, "{}", e);
+                write!(s, "{}", e).unwrap();
             }
         }
         s
@@ -537,7 +537,7 @@ fn format_weeks(it: impl Iterator<Item = impl DateIterator>) -> impl Iterator<It
                 first = false;
             }
 
-            write!(buf, " {:>2}", d.day());
+            write!(buf, " {:>2}", d.day()).unwrap();
         }
 
         // Insert more filler at the end to fill up the remainder of the week,

--- a/src/test/run-pass/macros/colorful-write-macros.rs
+++ b/src/test/run-pass/macros/colorful-write-macros.rs
@@ -27,18 +27,18 @@ impl fmt::Write for Bar {
 }
 
 fn borrowing_writer_from_struct_and_formatting_struct_field(foo: Foo) {
-    write!(foo.writer, "{}", foo.other);
+    write!(foo.writer, "{}", foo.other).unwrap();
 }
 
 fn main() {
     let mut w = Vec::new();
-    write!(&mut w as &mut Write, "");
-    write!(&mut w, ""); // should coerce
+    write!(&mut w as &mut Write, "").unwrap();
+    write!(&mut w, "").unwrap(); // should coerce
     println!("ok");
 
     let mut s = Bar;
     {
         use std::fmt::Write;
-        write!(&mut s, "test");
+        write!(&mut s, "test").unwrap();
     }
 }

--- a/src/test/ui/macros/must-use-in-macro-55516.rs
+++ b/src/test/ui/macros/must-use-in-macro-55516.rs
@@ -1,0 +1,21 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-pass
+// compile-flags: -Wunused
+
+// make sure write!() can't hide its unused Result
+
+fn main() {
+    use std::fmt::Write;
+    let mut example = String::new();
+    write!(&mut example, "{}", 42); //~WARN must be used
+}
+

--- a/src/test/ui/macros/must-use-in-macro-55516.stderr
+++ b/src/test/ui/macros/must-use-in-macro-55516.stderr
@@ -1,0 +1,10 @@
+warning: unused `std::result::Result` that must be used
+  --> $DIR/must-use-in-macro-55516.rs:19:5
+   |
+LL |     write!(&mut example, "{}", 42); //~WARN must be used
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-W unused-must-use` implied by `-W unused`
+   = note: this `Result` may be an `Err` variant, which should be handled
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+


### PR DESCRIPTION
Fixes #55516 by turning on the UNUSED_MUST_USE lint within macros.