### PR TITLE
Fix invalid_const_promotion test on some archs

### DIFF
--- a/src/test/run-pass/invalid_const_promotion.rs
+++ b/src/test/run-pass/invalid_const_promotion.rs
@@ -39,6 +39,7 @@ fn check_status(status: std::process::ExitStatus)
     use std::os::unix::process::ExitStatusExt;
 
     assert!(status.signal() == Some(libc::SIGILL)
+            || status.signal() == Some(libc::SIGTRAP)
             || status.signal() == Some(libc::SIGABRT));
 }
 


### PR DESCRIPTION
On at least AArch64 `llvm.trap` raises SIGTRAP.

r? @RalfJung