### PR TITLE
Made doc example of `impl Default for …` use `-> Self` instead of explicit self type

### DIFF
--- a/src/libcore/default.rs
+++ b/src/libcore/default.rs
@@ -76,7 +76,7 @@
 /// }
 ///
 /// impl Default for Kind {
-///     fn default() -> Kind { Kind::A }
+///     fn default() -> Self { Kind::A }
 /// }
 /// ```
 ///
@@ -118,7 +118,7 @@ pub trait Default: Sized {
     /// }
     ///
     /// impl Default for Kind {
-    ///     fn default() -> Kind { Kind::A }
+    ///     fn default() -> Self { Kind::A }
     /// }
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]


### PR DESCRIPTION
There is no need to state the explicit type of `self`.