### PR TITLE
[beta] Fix wrong validation clasisfication of `Option<&T>::Some` values

### DIFF
--- a/src/librustc_mir/interpret/validity.rs
+++ b/src/librustc_mir/interpret/validity.rs
@@ -289,7 +289,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
         let (lo, hi) = layout.valid_range.clone().into_inner();
         let max_hi = u128::max_value() >> (128 - size.bits()); // as big as the size fits
         assert!(hi <= max_hi);
-        if lo == 0 && hi == max_hi {
+        if (lo == 0 && hi == max_hi) || (hi + 1 == lo) {
             // Nothing to check
             return Ok(());
         }

--- a/src/test/ui/consts/const-validation-fail-55455.rs
+++ b/src/test/ui/consts/const-validation-fail-55455.rs
@@ -1,0 +1,9 @@
+// https://github.com/rust-lang/rust/issues/55454
+// compile-pass
+
+struct This<T>(T);
+
+const C: This<Option<&i32>> = This(Some(&1));
+
+fn main() {
+}

--- a/src/test/ui/consts/promoted-validation-55454.rs
+++ b/src/test/ui/consts/promoted-validation-55454.rs
@@ -1,0 +1,9 @@
+// https://github.com/rust-lang/rust/issues/55454
+// compile-pass
+
+#[derive(PartialEq)]
+struct This<T>(T);
+
+fn main() {
+    This(Some(&1)) == This(Some(&1));
+}


### PR DESCRIPTION
r? @pietroalbini 

original PR: https://github.com/rust-lang/rust/pull/55474