### PR TITLE
Try perf impact of faster local dominance queries in LLVM

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src/llvm"]
 	path = src/llvm
-	url = https://github.com/rust-lang/llvm.git
+	url = https://github.com/nikic/llvm.git
 	branch = master
 [submodule "src/jemalloc"]
 	path = src/jemalloc
@@ -64,4 +64,3 @@
 	path = src/tools/clang
 	url = https://github.com/rust-lang-nursery/clang.git
 	branch = rust-release-80-v1
-  

--- a/src/rustllvm/llvm-rebuild-trigger
+++ b/src/rustllvm/llvm-rebuild-trigger
@@ -1,4 +1,4 @@
 # If this file is modified, then llvm will be (optionally) cleaned and then rebuilt.
 # The actual contents of this file do not matter, but to trigger a change on the
 # build bots then the contents should be changed so git updates the mtime.
-2018-09-16
+2018-11-01


### PR DESCRIPTION
There is an LLVM patch at https://reviews.llvm.org/D51664, which improves performance of local dominance queries through lazy instruction numbering. I think this patch would improve some areas that are often hot in rustc (e.g. pointer capture analysis), so it would be interesting to see what the impact is on compile times. If the results are good, it would be another point in favor of landing this somewhat controversial change.

**Not intended for merging, only for try + perf.**

I already tried this locally with the following wall-time results (opt+clean builds only). However I don't trust this machine for benchmarking at all, it might just be noise between two runs at different times.

<details>

```
sentry-cli-opt
	avg: -14.0%	min: -14.0%	max: -14.0%
piston-image-opt
	avg: 12.7%	min: 12.7%	max: 12.7%
html5ever-opt
	avg: -12.3%	min: -12.3%	max: -12.3%
serde-opt
	avg: -9.9%	min: -9.9%	max: -9.9%
webrender-opt
	avg: -8.8%	min: -8.8%	max: -8.8%
inflate-opt
	avg: -8.2%?	min: -8.2%?	max: -8.2%?
encoding-opt
	avg: -7.9%	min: -7.9%	max: -7.9%
deeply-nested-opt
	avg: -6.8%	min: -6.8%	max: -6.8%
style-servo-opt
	avg: -6.8%	min: -6.8%	max: -6.8%
helloworld-opt
	avg: -6.7%	min: -6.7%	max: -6.7%
tokio-webpush-simple-opt
	avg: -6.4%	min: -6.4%	max: -6.4%
regression-31157-opt
	avg: -6.1%	min: -6.1%	max: -6.1%
futures-opt
	avg: -5.9%	min: -5.9%	max: -5.9%
deep-vector-opt
	avg: -4.5%	min: -4.5%	max: -4.5%
cargo-opt
	avg: -4.4%	min: -4.4%	max: -4.4%
regex-opt
	avg: -4.4%	min: -4.4%	max: -4.4%
ctfe-stress-opt
	avg: -3.0%?	min: -3.0%?	max: -3.0%?
unify-linearly-opt
	avg: -2.1%	min: -2.1%	max: -2.1%
syn-opt
	avg: -2.0%?	min: -2.0%?	max: -2.0%?
issue-46449-opt
	avg: -1.5%	min: -1.5%	max: -1.5%
unused-warnings-opt
	avg: 1.4%	min: 1.4%	max: 1.4%
clap-rs-opt
	avg: -1.4%	min: -1.4%	max: -1.4%
coercions-opt
	avg: 1.1%?	min: 1.1%?	max: 1.1%?
ripgrep-opt
	avg: -1.0%	min: -1.0%	max: -1.0%
keccak-opt
	avg: -0.5%	min: -0.5%	max: -0.5%
tuple-stress-opt
	avg: -0.2%	min: -0.2%	max: -0.2%
ucd-opt
	avg: -0.1%	min: -0.1%	max: -0.1%
```

</details>