### PR TITLE
Remove checks for LLVM < 4.0

### DIFF
--- a/src/librustc_codegen_llvm/back/write.rs
+++ b/src/librustc_codegen_llvm/back/write.rs
@@ -10,7 +10,7 @@
 
 use attributes;
 use back::bytecode::{self, RLIB_BYTECODE_EXTENSION};
-use back::lto::{self, ModuleBuffer, ThinBuffer, SerializedModule};
+use back::lto::{self, ThinBuffer, SerializedModule};
 use back::link::{self, get_linker, remove};
 use back::command::Command;
 use back::linker::LinkerInfo;
@@ -564,8 +564,8 @@ unsafe fn optimize(cgcx: &CodegenContext,
             // Some options cause LLVM bitcode to be emitted, which uses ThinLTOBuffers, so we need
             // to make sure we run LLVM's NameAnonGlobals pass when emitting bitcode; otherwise
             // we'll get errors in LLVM.
-            let using_thin_buffers = llvm::LLVMRustThinLTOAvailable() && (config.emit_bc
-                || config.obj_is_bitcode || config.emit_bc_compressed || config.embed_bitcode);
+            let using_thin_buffers = config.emit_bc || config.obj_is_bitcode
+                || config.emit_bc_compressed || config.embed_bitcode;
             let mut have_name_anon_globals_pass = false;
             if !config.no_prepopulate_passes {
                 llvm::LLVMRustAddAnalysisPasses(tm, fpm, llmod);
@@ -729,15 +729,8 @@ unsafe fn codegen(cgcx: &CodegenContext,
 
 
         if write_bc || config.emit_bc_compressed || config.embed_bitcode {
-            let thin;
-            let old;
-            let data = if llvm::LLVMRustThinLTOAvailable() {
-                thin = ThinBuffer::new(llmod);
-                thin.data()
-            } else {
-                old = ModuleBuffer::new(llmod);
-                old.data()
-            };
+            let thin = ThinBuffer::new(llmod);
+            let data = thin.data();
             timeline.record("make-bc");
 
             if write_bc {
@@ -1385,12 +1378,8 @@ fn execute_optimize_work_item(cgcx: &CodegenContext,
         // builds we don't actually want to LTO the allocator modules if
         // it shows up. This is due to various linker shenanigans that
         // we'll encounter later.
-        //
-        // Additionally here's where we also factor in the current LLVM
-        // version. If it doesn't support ThinLTO we skip this.
         Lto::ThinLocal => {
-            module.kind != ModuleKind::Allocator &&
-                unsafe { llvm::LLVMRustThinLTOAvailable() }
+            module.kind != ModuleKind::Allocator
         }
     };
 

--- a/src/librustc_codegen_llvm/base.rs
+++ b/src/librustc_codegen_llvm/base.rs
@@ -738,19 +738,6 @@ pub fn codegen_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 {
     check_for_rustc_errors_attr(tcx);
 
-    if let Some(true) = tcx.sess.opts.debugging_opts.thinlto {
-        if unsafe { !llvm::LLVMRustThinLTOAvailable() } {
-            tcx.sess.fatal("this compiler's LLVM does not support ThinLTO");
-        }
-    }
-
-    if (tcx.sess.opts.debugging_opts.pgo_gen.is_some() ||
-        !tcx.sess.opts.debugging_opts.pgo_use.is_empty()) &&
-        unsafe { !llvm::LLVMRustPGOAvailable() }
-    {
-        tcx.sess.fatal("this compiler's LLVM does not support PGO");
-    }
-
     let cgu_name_builder = &mut CodegenUnitNameBuilder::new(tcx);
 
     // Codegen the metadata.

--- a/src/librustc_codegen_llvm/llvm/ffi.rs
+++ b/src/librustc_codegen_llvm/llvm/ffi.rs
@@ -1626,8 +1626,6 @@ extern "C" {
     pub fn LLVMRustModuleBufferFree(p: &'static mut ModuleBuffer);
     pub fn LLVMRustModuleCost(M: &Module) -> u64;
 
-    pub fn LLVMRustThinLTOAvailable() -> bool;
-    pub fn LLVMRustPGOAvailable() -> bool;
     pub fn LLVMRustThinLTOBufferCreate(M: &Module) -> &'static mut ThinLTOBuffer;
     pub fn LLVMRustThinLTOBufferFree(M: &'static mut ThinLTOBuffer);
     pub fn LLVMRustThinLTOBufferPtr(M: &ThinLTOBuffer) -> *const c_char;

--- a/src/rustllvm/ArchiveWrapper.cpp
+++ b/src/rustllvm/ArchiveWrapper.cpp
@@ -145,7 +145,6 @@ extern "C" void LLVMRustArchiveIteratorFree(LLVMRustArchiveIteratorRef RAI) {
 
 extern "C" const char *
 LLVMRustArchiveChildName(LLVMRustArchiveChildConstRef Child, size_t *Size) {
-#if LLVM_VERSION_GE(4, 0)
   Expected<StringRef> NameOrErr = Child->getName();
   if (!NameOrErr) {
     // rustc_codegen_llvm currently doesn't use this error string, but it might be
@@ -154,11 +153,6 @@ LLVMRustArchiveChildName(LLVMRustArchiveChildConstRef Child, size_t *Size) {
     LLVMRustSetLastError(toString(NameOrErr.takeError()).c_str());
     return nullptr;
   }
-#else
-  ErrorOr<StringRef> NameOrErr = Child->getName();
-  if (NameOrErr.getError())
-    return nullptr;
-#endif
   StringRef Name = NameOrErr.get();
   *Size = Name.size();
   return Name.data();
@@ -167,19 +161,11 @@ LLVMRustArchiveChildName(LLVMRustArchiveChildConstRef Child, size_t *Size) {
 extern "C" const char *LLVMRustArchiveChildData(LLVMRustArchiveChildRef Child,
                                                 size_t *Size) {
   StringRef Buf;
-#if LLVM_VERSION_GE(4, 0)
   Expected<StringRef> BufOrErr = Child->getBuffer();
   if (!BufOrErr) {
     LLVMRustSetLastError(toString(BufOrErr.takeError()).c_str());
     return nullptr;
   }
-#else
-  ErrorOr<StringRef> BufOrErr = Child->getBuffer();
-  if (BufOrErr.getError()) {
-    LLVMRustSetLastError(BufOrErr.getError().message().c_str());
-    return nullptr;
-  }
-#endif
   Buf = BufOrErr.get();
   *Size = Buf.size();
   return Buf.data();

--- a/src/rustllvm/Linker.cpp
+++ b/src/rustllvm/Linker.cpp
@@ -42,7 +42,6 @@ LLVMRustLinkerAdd(RustLinker *L, char *BC, size_t Len) {
   std::unique_ptr<MemoryBuffer> Buf =
       MemoryBuffer::getMemBufferCopy(StringRef(BC, Len));
 
-#if LLVM_VERSION_GE(4, 0)
   Expected<std::unique_ptr<Module>> SrcOrError =
       llvm::getLazyBitcodeModule(Buf->getMemBufferRef(), L->Ctx);
   if (!SrcOrError) {
@@ -51,20 +50,8 @@ LLVMRustLinkerAdd(RustLinker *L, char *BC, size_t Len) {
   }
 
   auto Src = std::move(*SrcOrError);
-#else
-  ErrorOr<std::unique_ptr<Module>> Src =
-      llvm::getLazyBitcodeModule(std::move(Buf), L->Ctx);
-  if (!Src) {
-    LLVMRustSetLastError(Src.getError().message().c_str());
-    return false;
-  }
-#endif
 
-#if LLVM_VERSION_GE(4, 0)
   if (L->L.linkInModule(std::move(Src))) {
-#else
-  if (L->L.linkInModule(std::move(Src.get()))) {
-#endif
     LLVMRustSetLastError("");
     return false;
   }

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -907,10 +907,8 @@ LLVMRustDIBuilderCreateNameSpace(LLVMRustDIBuilderRef Builder,
       ,
       unwrapDI<DIFile>(File), LineNo
 #endif
-#if LLVM_VERSION_GE(4, 0)
       ,
       false // ExportSymbols (only relevant for C++ anonymous namespaces)
-#endif
       ));
 }
 
@@ -1544,14 +1542,6 @@ LLVMRustBuildVectorReduceFMin(LLVMBuilderRef, LLVMValueRef, bool) {
 extern "C" LLVMValueRef
 LLVMRustBuildVectorReduceFMax(LLVMBuilderRef, LLVMValueRef, bool) {
   return nullptr;
-}
-#endif
-
-#if LLVM_VERSION_LT(4, 0)
-extern "C" LLVMValueRef
-LLVMBuildExactUDiv(LLVMBuilderRef B, LLVMValueRef LHS,
-                   LLVMValueRef RHS, const char *Name) {
-  return wrap(unwrap(B)->CreateExactUDiv(unwrap(LHS), unwrap(RHS), Name));
 }
 #endif
 

--- a/src/rustllvm/rustllvm.h
+++ b/src/rustllvm/rustllvm.h
@@ -57,12 +57,8 @@
 
 #include "llvm/IR/LegacyPassManager.h"
 
-#if LLVM_VERSION_GE(4, 0)
 #include "llvm/Bitcode/BitcodeReader.h"
 #include "llvm/Bitcode/BitcodeWriter.h"
-#else
-#include "llvm/Bitcode/ReaderWriter.h"
-#endif
 
 #include "llvm/IR/DIBuilder.h"
 #include "llvm/IR/DebugInfo.h"


### PR DESCRIPTION
While we still have to support LLVM 4.0 for Emscripten, we can drop checks for LLVM >= 4.0 and < 4.0.