### PR TITLE
Avoid the Box in `TyCtxt::associated_items`.

### DIFF
--- a/src/librustc/traits/specialize/specialization_graph.rs
+++ b/src/librustc/traits/specialize/specialization_graph.rs
@@ -366,7 +366,7 @@ impl<'a, 'gcx, 'tcx> Node {
     pub fn items(
         &self,
         tcx: TyCtxt<'a, 'gcx, 'tcx>,
-    ) -> impl Iterator<Item = ty::AssociatedItem> + 'a {
+    ) -> ty::AssociatedItemsIterator<'a, 'gcx, 'tcx> {
         tcx.associated_items(self.def_id())
     }
 


### PR DESCRIPTION
This reduces instruction counts on `packed_simd` by 2%.

r? @nikomatsakis 