### PR TITLE
Return impl Iterator from required_region_bounds

### DIFF
--- a/src/librustc/infer/opaque_types/mod.rs
+++ b/src/librustc/infer/opaque_types/mod.rs
@@ -775,10 +775,11 @@ impl<'a, 'gcx, 'tcx> Instantiator<'a, 'gcx, 'tcx> {
         let bounds = predicates_of.instantiate(tcx, substs);
         debug!("instantiate_opaque_types: bounds={:?}", bounds);
 
-        let required_region_bounds = tcx.required_region_bounds(ty, bounds.predicates.clone());
+        let mut required_region_bounds = tcx.required_region_bounds(ty, bounds.predicates.clone())
+            .peekable();
         debug!(
             "instantiate_opaque_types: required_region_bounds={:?}",
-            required_region_bounds
+            tcx.required_region_bounds(ty, bounds.predicates.clone()).collect::<Vec<_>>()
         );
 
         // make sure that we are in fact defining the *entire* type
@@ -798,7 +799,7 @@ impl<'a, 'gcx, 'tcx> Instantiator<'a, 'gcx, 'tcx> {
             OpaqueTypeDecl {
                 substs,
                 concrete_ty: ty_var,
-                has_required_region_bounds: !required_region_bounds.is_empty(),
+                has_required_region_bounds: required_region_bounds.peek().is_some(),
             },
         );
         debug!("instantiate_opaque_types: ty_var={:?}", ty_var);

--- a/src/librustc/ty/wf.rs
+++ b/src/librustc/ty/wf.rs
@@ -18,6 +18,7 @@ use std::iter::once;
 use syntax::ast;
 use syntax_pos::Span;
 use middle::lang_items;
+use util::captures::Captures;
 
 /// Returns the set of obligations needed to make `ty` well-formed.
 /// If `ty` contains unresolved inference variables, this may include
@@ -495,7 +496,6 @@ impl<'a, 'gcx, 'tcx> WfPredicates<'a, 'gcx, 'tcx> {
 
             let explicit_bound = region;
 
-            self.out.reserve(implicit_bounds.len());
             for implicit_bound in implicit_bounds {
                 let cause = self.cause(traits::ObjectTypeBound(ty, explicit_bound));
                 let outlives = ty::Binder::dummy(
@@ -517,7 +517,7 @@ impl<'a, 'gcx, 'tcx> WfPredicates<'a, 'gcx, 'tcx> {
 pub fn object_region_bounds<'a, 'gcx, 'tcx>(
     tcx: TyCtxt<'a, 'gcx, 'tcx>,
     existential_predicates: ty::Binder<&'tcx ty::List<ty::ExistentialPredicate<'tcx>>>)
-    -> Vec<ty::Region<'tcx>>
+    -> impl Iterator<Item = ty::Region<'tcx>> + Captures<'gcx> + 'a
 {
     // Since we don't actually *know* the self type for an object,
     // this "open(err)" serves as a kind of dummy standin -- basically


### PR DESCRIPTION
This removes the vector from `ty::util::required_region_bounds` by returning `impl Iterator`; it also makes `typeck::astconv::compute_object_lifetime_bound` go through `derived_region_bounds` only once.

There is one downside (that I can detect) - `ty::wf::from_object_ty` can no longer precisely preallocate one vector in case `!data.has_escaping_regions()` is true. We might want to verify if this is beneficial enough with a perf run.