### PR TITLE
NetBSD: link libstd with librt in addition to libpthread

### DIFF
--- a/src/libstd/build.rs
+++ b/src/libstd/build.rs
@@ -41,8 +41,11 @@ fn main() {
     } else if target.contains("freebsd") {
         println!("cargo:rustc-link-lib=execinfo");
         println!("cargo:rustc-link-lib=pthread");
+    } else if target.contains("netbsd") {
+        println!("cargo:rustc-link-lib=pthread");
+        println!("cargo:rustc-link-lib=rt");
     } else if target.contains("dragonfly") || target.contains("bitrig") ||
-              target.contains("netbsd") || target.contains("openbsd") {
+              target.contains("openbsd") {
         println!("cargo:rustc-link-lib=pthread");
     } else if target.contains("solaris") {
         println!("cargo:rustc-link-lib=socket");


### PR DESCRIPTION
Some aio(3) and mq(3) functions in the libc crate actually come from NetBSD librt, not libc or libpthread.