### PR TITLE
Allow extern types in #[repr(transparent)] structs

### DIFF
--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -1578,6 +1578,13 @@ impl<'a, 'gcx, 'tcx> TyS<'tcx> {
         }
     }
 
+    pub fn is_transparent(&self) -> bool {
+        match self.sty {
+            Adt(def, _) => def.repr.transparent(),
+            _ => false,
+        }
+    }
+
     pub fn sequence_element_type(&self, tcx: TyCtxt<'a, 'gcx, 'tcx>) -> Ty<'tcx> {
         match self.sty {
             Array(ty, _) | Slice(ty) => ty,

--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -359,9 +359,13 @@ where
         // Offset may need adjustment for unsized fields
         let (meta, offset) = if field_layout.is_unsized() {
             // re-use parent metadata to determine dynamic field layout
-            let (_, align) = self.size_and_align_of(base.meta, field_layout)?
-                .expect("Fields cannot be extern types");
-            (base.meta, offset.abi_align(align))
+            let size_and_align = self.size_and_align_of(base.meta, field_layout)?;
+            if size_and_align.is_none() && base.layout.ty.is_transparent() {
+                (base.meta, offset)
+            } else {
+                let (_, align) = size_and_align.expect("Fields cannot be extern types");
+                (base.meta, offset.abi_align(align))
+            }
         } else {
             // base.meta could be present; we might be accessing a sized field of an unsized
             // struct.

--- a/src/test/run-pass/extern/extern-types-in-transparent.rs
+++ b/src/test/run-pass/extern/extern-types-in-transparent.rs
@@ -1,0 +1,39 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// run-pass
+#![allow(dead_code)]
+
+// Test that extern types can be used as fields within a transparent struct. See issue #55541.
+
+#![feature(const_transmute, extern_types)]
+
+extern {
+    type A;
+}
+unsafe impl Sync for A {}
+
+#[repr(transparent)]
+struct Foo(A);
+
+#[repr(transparent)]
+struct Bar(std::marker::PhantomData<u64>, A);
+
+static FOO: &'static Foo = {
+    static VALUE: usize = b'F' as usize;
+    unsafe { std::mem::transmute(&VALUE) }
+};
+
+static BAR: &'static Bar = {
+    static VALUE: usize = b'B' as usize;
+    unsafe { std::mem::transmute(&VALUE) }
+};
+
+fn main() {}

--- a/src/test/ui/repr/repr-transparent.rs
+++ b/src/test/ui/repr/repr-transparent.rs
@@ -13,7 +13,7 @@
 // - repr-transparent-other-reprs.rs
 // - repr-transparent-other-items.rs
 
-#![feature(repr_align)]
+#![feature(extern_types, repr_align)]
 
 use std::marker::PhantomData;
 
@@ -48,5 +48,15 @@ struct ZstAlign32<T>(PhantomData<T>);
 
 #[repr(transparent)]
 struct GenericAlign<T>(ZstAlign32<T>, u32); //~ ERROR alignment larger than 1
+
+extern "C" {
+    type ExternType;
+}
+
+#[repr(transparent)]
+struct NontrivialAlignZstExtern([u16; 0], ExternType); //~ ERROR alignment larger than 1
+
+#[repr(transparent)]
+struct GenericAlignExtern<T>(ZstAlign32<T>, ExternType); //~ ERROR alignment larger than 1
 
 fn main() {}

--- a/src/test/ui/repr/repr-transparent.stderr
+++ b/src/test/ui/repr/repr-transparent.stderr
@@ -66,7 +66,19 @@ error[E0691]: zero-sized field in transparent struct has alignment larger than 1
 LL | struct GenericAlign<T>(ZstAlign32<T>, u32); //~ ERROR alignment larger than 1
    |                        ^^^^^^^^^^^^^
 
-error: aborting due to 8 previous errors
+error[E0691]: zero-sized field in transparent struct has alignment larger than 1
+  --> $DIR/repr-transparent.rs:57:33
+   |
+LL | struct NontrivialAlignZstExtern([u16; 0], ExternType); //~ ERROR alignment larger than 1
+   |                                 ^^^^^^^^
+
+error[E0691]: zero-sized field in transparent struct has alignment larger than 1
+  --> $DIR/repr-transparent.rs:60:30
+   |
+LL | struct GenericAlignExtern<T>(ZstAlign32<T>, ExternType); //~ ERROR alignment larger than 1
+   |                              ^^^^^^^^^^^^^
+
+error: aborting due to 10 previous errors
 
 Some errors occurred: E0690, E0691.
 For more information about an error, try `rustc --explain E0690`.


### PR DESCRIPTION
Fixes #55541 

This should be okay given that `#[repr(transparent)]` requires a single non-ZST field, and all other fields must be ZSTs with alignment 1.