### PR TITLE
Update emscripten

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -43,7 +43,7 @@
 	url = https://github.com/rust-lang/rust-by-example.git
 [submodule "src/llvm-emscripten"]
 	path = src/llvm-emscripten
-	url = https://github.com/kripken/emscripten-fastcomp
+	url = https://github.com/rust-lang/llvm.git
 [submodule "src/stdsimd"]
 	path = src/stdsimd
 	url = https://github.com/rust-lang-nursery/stdsimd.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -43,7 +43,7 @@
 	url = https://github.com/rust-lang/rust-by-example.git
 [submodule "src/llvm-emscripten"]
 	path = src/llvm-emscripten
-	url = https://github.com/rust-lang/llvm.git
+	url = https://github.com/kripken/emscripten-fastcomp
 [submodule "src/stdsimd"]
 	path = src/stdsimd
 	url = https://github.com/rust-lang-nursery/stdsimd.git

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -736,7 +736,7 @@ pub fn build_codegen_backend(builder: &Builder,
 
             // Pass down configuration from the LLVM build into the build of
             // librustc_llvm and librustc_codegen_llvm.
-            if builder.is_rust_llvm(target) {
+            if builder.is_rust_llvm(target) && backend != "emscripten" {
                 cargo.env("LLVM_RUSTLLVM", "1");
             }
             cargo.env("LLVM_CONFIG", &llvm_config);

--- a/src/ci/docker/asmjs/Dockerfile
+++ b/src/ci/docker/asmjs/Dockerfile
@@ -20,11 +20,11 @@ COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
 ENV PATH=$PATH:/emsdk-portable
-ENV PATH=$PATH:/emsdk-portable/clang/e1.37.13_64bit/
-ENV PATH=$PATH:/emsdk-portable/emscripten/1.37.13/
-ENV PATH=$PATH:/emsdk-portable/node/4.1.1_64bit/bin/
-ENV EMSCRIPTEN=/emsdk-portable/emscripten/1.37.13/
-ENV BINARYEN_ROOT=/emsdk-portable/clang/e1.37.13_64bit/binaryen/
+ENV PATH=$PATH:/emsdk-portable/clang/e1.38.15_64bit/
+ENV PATH=$PATH:/emsdk-portable/emscripten/1.38.15/
+ENV PATH=$PATH:/emsdk-portable/node/8.9.1_64bit/bin/
+ENV EMSCRIPTEN=/emsdk-portable/emscripten/1.38.15/
+ENV BINARYEN_ROOT=/emsdk-portable/clang/e1.38.15_64bit/binaryen/
 ENV EM_CONFIG=/emsdk-portable/.emscripten
 
 ENV TARGETS=asmjs-unknown-emscripten

--- a/src/ci/docker/disabled/wasm32/Dockerfile
+++ b/src/ci/docker/disabled/wasm32/Dockerfile
@@ -21,11 +21,11 @@ COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
 ENV PATH=$PATH:/emsdk-portable
-ENV PATH=$PATH:/emsdk-portable/clang/e1.37.13_64bit/
-ENV PATH=$PATH:/emsdk-portable/emscripten/1.37.13/
-ENV PATH=$PATH:/node-v8.0.0-linux-x64/bin/
-ENV EMSCRIPTEN=/emsdk-portable/emscripten/1.37.13/
-ENV BINARYEN_ROOT=/emsdk-portable/clang/e1.37.13_64bit/binaryen/
+ENV PATH=$PATH:/emsdk-portable/clang/e1.38.15_64bit/
+ENV PATH=$PATH:/emsdk-portable/emscripten/1.38.15/
+ENV PATH=$PATH:/emsdk-portable/node/8.9.1_64bit/bin/
+ENV EMSCRIPTEN=/emsdk-portable/emscripten/1.38.15/
+ENV BINARYEN_ROOT=/emsdk-portable/clang/e1.38.15_64bit/binaryen/
 ENV EM_CONFIG=/emsdk-portable/.emscripten
 
 ENV TARGETS=wasm32-unknown-emscripten

--- a/src/ci/docker/scripts/emscripten.sh
+++ b/src/ci/docker/scripts/emscripten.sh
@@ -46,8 +46,3 @@ rm -f a.*
 # Make emsdk usable by any user
 cp /root/.emscripten /emsdk-portable
 chmod a+rxw -R /emsdk-portable
-
-# node 8 is required to run wasm
-cd /
-curl -sL https://nodejs.org/dist/v8.0.0/node-v8.0.0-linux-x64.tar.xz | \
-  tar -xJ

--- a/src/ci/docker/scripts/emscripten.sh
+++ b/src/ci/docker/scripts/emscripten.sh
@@ -33,8 +33,8 @@ curl -fL https://s3.amazonaws.com/mozilla-games/emscripten/releases/emsdk-portab
 
 cd /emsdk-portable
 ./emsdk update
-hide_output ./emsdk install sdk-1.37.13-64bit
-./emsdk activate sdk-1.37.13-64bit
+hide_output ./emsdk install sdk-1.38.15-64bit
+./emsdk activate sdk-1.38.15-64bit
 
 # Compile and cache libc
 source ./emsdk_env.sh

--- a/src/librustc_codegen_llvm/llvm_util.rs
+++ b/src/librustc_codegen_llvm/llvm_util.rs
@@ -243,7 +243,8 @@ pub fn target_feature_whitelist(sess: &Session)
         "hexagon" => HEXAGON_WHITELIST,
         "mips" | "mips64" => MIPS_WHITELIST,
         "powerpc" | "powerpc64" => POWERPC_WHITELIST,
-        "wasm32" => WASM_WHITELIST,
+        // wasm32 on emscripten does not support these target features
+        "wasm32" if !sess.target.target.options.is_like_emscripten => WASM_WHITELIST,
         _ => &[],
     }
 }

--- a/src/rustllvm/PassWrapper.cpp
+++ b/src/rustllvm/PassWrapper.cpp
@@ -444,7 +444,7 @@ extern "C" void LLVMRustConfigurePassManagerBuilder(
     LLVMPassManagerBuilderRef PMBR, LLVMRustCodeGenOptLevel OptLevel,
     bool MergeFunctions, bool SLPVectorize, bool LoopVectorize, bool PrepareForThinLTO,
     const char* PGOGenPath, const char* PGOUsePath) {
-#if LLVM_RUSTLLVM
+#if LLVM_VERSION_GE(7, 0)
   unwrap(PMBR)->MergeFunctions = MergeFunctions;
 #endif
   unwrap(PMBR)->SLPVectorize = SLPVectorize;

--- a/src/test/run-fail/mir_drop_panics.rs
+++ b/src/test/run-fail/mir_drop_panics.rs
@@ -17,7 +17,7 @@ impl Drop for Droppable {
         if self.0 == 1 {
             panic!("panic 1");
         } else {
-            eprint!("drop {}", self.0);
+            eprintln!("drop {}", self.0);
         }
     }
 }

--- a/src/test/run-fail/panic-set-handler.rs
+++ b/src/test/run-fail/panic-set-handler.rs
@@ -14,7 +14,7 @@ use std::panic;
 
 fn main() {
     panic::set_hook(Box::new(|i| {
-        eprint!("greetings from the panic handler");
+        eprintln!("greetings from the panic handler");
     }));
     panic!("foobar");
 }

--- a/src/test/run-pass/consts/const-endianess.rs
+++ b/src/test/run-pass/consts/const-endianess.rs
@@ -23,7 +23,7 @@ fn main() {
     assert_eq!(BE_U32, b(55u32).to_be());
     assert_eq!(LE_U32, b(55u32).to_le());
 
-    #[cfg(not(target_arch = "asmjs"))]
+    #[cfg(not(target_os = "emscripten"))]
     {
         const BE_U128: u128 = 999999u128.to_be();
         const LE_I128: i128 = (-999999i128).to_le();

--- a/src/test/ui/inline-asm-bad-constraint.rs
+++ b/src/test/ui/inline-asm-bad-constraint.rs
@@ -10,6 +10,8 @@
 
 // Test that the compiler will catch invalid inline assembly constraints.
 
+// ignore-emscripten
+
 #![feature(asm)]
 
 extern "C" {

--- a/src/test/ui/inline-asm-bad-constraint.stderr
+++ b/src/test/ui/inline-asm-bad-constraint.stderr
@@ -1,17 +1,17 @@
 error[E0668]: malformed inline assembly
-  --> $DIR/inline-asm-bad-constraint.rs:29:9
+  --> $DIR/inline-asm-bad-constraint.rs:31:9
    |
 LL |         asm!("" :"={rax"(rax)) //~ ERROR E0668
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0668]: malformed inline assembly
-  --> $DIR/inline-asm-bad-constraint.rs:37:9
+  --> $DIR/inline-asm-bad-constraint.rs:39:9
    |
 LL |         asm!("callq $0" : : "0"(foo)) //~ ERROR E0668
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0668]: malformed inline assembly
-  --> $DIR/inline-asm-bad-constraint.rs:44:9
+  --> $DIR/inline-asm-bad-constraint.rs:46:9
    |
 LL |         asm!("addb $1, $0" : "={rax}"((0i32, rax))); //~ ERROR E0668
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/inline-asm-bad-operand.rs
+++ b/src/test/ui/inline-asm-bad-operand.rs
@@ -11,6 +11,8 @@
 // Test that the compiler will catch passing invalid values to inline assembly
 // operands.
 
+// ignore-emscripten
+
 #![feature(asm)]
 
 #[repr(C)]

--- a/src/test/ui/inline-asm-bad-operand.stderr
+++ b/src/test/ui/inline-asm-bad-operand.stderr
@@ -1,41 +1,41 @@
 error[E0669]: invalid value for constraint in inline assembly
-  --> $DIR/inline-asm-bad-operand.rs:29:24
+  --> $DIR/inline-asm-bad-operand.rs:31:24
    |
 LL |         asm!("" :: "r"("")); //~ ERROR E0669
    |                        ^^
 
 error[E0669]: invalid value for constraint in inline assembly
-  --> $DIR/inline-asm-bad-operand.rs:34:32
+  --> $DIR/inline-asm-bad-operand.rs:36:32
    |
 LL |         asm!("ret" : : "{rdi}"(target)); //~ ERROR E0669
    |                                ^^^^^^
 
 error[E0669]: invalid value for constraint in inline assembly
-  --> $DIR/inline-asm-bad-operand.rs:41:29
+  --> $DIR/inline-asm-bad-operand.rs:43:29
    |
 LL |     unsafe { asm!("" :: "i"(hello)) }; //~ ERROR E0669
    |                             ^^^^^
 
 error[E0669]: invalid value for constraint in inline assembly
-  --> $DIR/inline-asm-bad-operand.rs:49:38
+  --> $DIR/inline-asm-bad-operand.rs:51:38
    |
 LL |         asm!("movups $1, %xmm0"::"m"(arr)); //~ ERROR E0669
    |                                      ^^^
 
 error[E0669]: invalid value for constraint in inline assembly
-  --> $DIR/inline-asm-bad-operand.rs:56:32
+  --> $DIR/inline-asm-bad-operand.rs:58:32
    |
 LL |         asm!("mov sp, $0"::"r"(addr)); //~ ERROR E0669
    |                                ^^^^
 
 error[E0669]: invalid value for constraint in inline assembly
-  --> $DIR/inline-asm-bad-operand.rs:63:32
+  --> $DIR/inline-asm-bad-operand.rs:65:32
    |
 LL |         asm!("mov sp, $0"::"r"(addr), //~ ERROR E0669
    |                                ^^^^
 
 error[E0669]: invalid value for constraint in inline assembly
-  --> $DIR/inline-asm-bad-operand.rs:64:32
+  --> $DIR/inline-asm-bad-operand.rs:66:32
    |
 LL |                            "r"("hello e0669")); //~ ERROR E0669
    |                                ^^^^^^^^^^^^^

--- a/src/test/ui/issues/issue-49579.rs
+++ b/src/test/ui/issues/issue-49579.rs
@@ -8,8 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-
 // compile-pass
+// ignore-emscripten no i128 support
 
 #![feature(nll)]
 

--- a/src/test/ui/range/issue-54505-no-std.rs
+++ b/src/test/ui/range/issue-54505-no-std.rs
@@ -11,7 +11,7 @@
 
 use core::ops::RangeBounds;
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
 #[lang = "eh_personality"]
 extern fn eh_personality() {}
 

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1870,11 +1870,9 @@ impl<'test> TestCx<'test> {
             } else {
                 self.fatal("no NodeJS binary found (--nodejs)");
             }
-        }
-
-        // If this is otherwise wasm , then run tests under nodejs with our
+        // If this is otherwise wasm, then run tests under nodejs with our
         // shim
-        if self.config.target.contains("wasm32") {
+        } else if self.config.target.contains("wasm32") {
             if let Some(ref p) = self.config.nodejs {
                 args.push(p.clone());
             } else {


### PR DESCRIPTION
This updates emscripten to 1.38.15, which is based on LLVM 6.0.1 and would allow us to drop code for handling LLVM 4.

The main issue I ran into is that exporting statics through `EXPORTED_FUNCTIONS` no longer works. As far as I understand exporting non-functions doesn't really make sense under emscripten anyway, so I've modified the symbol export code to not even try.

Closes #52323.