### PR TITLE
Deny the `overflowing_literals` lint for all editions

### DIFF
--- a/src/doc/rustc/src/lints/listing/deny-by-default.md
+++ b/src/doc/rustc/src/lints/listing/deny-by-default.md
@@ -149,6 +149,26 @@ error: const items should never be #[no_mangle]
   |
 ```
 
+## overflowing-literals
+
+This lint detects literal out of range for its type. Some
+example code that triggers this lint:
+
+```rust,compile_fail
+let x: u8 = 1000;
+```
+
+This will produce:
+
+```text
+error: literal out of range for u8
+ --> src/main.rs:2:17
+  |
+2 |     let x: u8 = 1000;
+  |                 ^^^^
+  |
+```
+
 ## parenthesized-params-in-types-and-modules
 
 This lint detects incorrect parentheses. Some example code that triggers this

--- a/src/doc/rustc/src/lints/listing/warn-by-default.md
+++ b/src/doc/rustc/src/lints/listing/warn-by-default.md
@@ -285,26 +285,6 @@ warning: functions generic over types must be mangled
   |
 ```
 
-## overflowing-literals
-
-This lint detects literal out of range for its type. Some
-example code that triggers this lint:
-
-```rust
-let x: u8 = 1000;
-```
-
-This will produce:
-
-```text
-warning: literal out of range for u8
- --> src/main.rs:2:17
-  |
-2 |     let x: u8 = 1000;
-  |                 ^^^^
-  |
-```
-
 ## path-statements
 
 This lint detects path statements with no effect. Some example code that

--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -15,7 +15,6 @@ use std::{i8, i16, i32, i64, u8, u16, u32, u64, f32, f64};
 use syntax::{ast, attr};
 use syntax::errors::Applicability;
 use rustc_target::spec::abi::Abi;
-use syntax::edition::Edition;
 use syntax_pos::Span;
 use syntax::source_map;
 
@@ -29,9 +28,8 @@ declare_lint! {
 
 declare_lint! {
     OVERFLOWING_LITERALS,
-    Warn,
-    "literal out of range for its type",
-    Edition::Edition2018 => Deny
+    Deny,
+    "literal out of range for its type"
 }
 
 declare_lint! {

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -2865,8 +2865,8 @@ E0370: r##"
 The maximum value of an enum was reached, so it cannot be automatically
 set in the next enum value. Erroneous code example:
 
-```compile_fail
-#[deny(overflowing_literals)]
+```compile_fail,E0370
+#[repr(i64)]
 enum Foo {
     X = 0x7fffffffffffffff,
     Y, // error: enum discriminant overflowed on value after
@@ -2879,6 +2879,7 @@ To fix this, please set manually the next enum value or put the enum variant
 with the maximum value at the end of the enum. Examples:
 
 ```
+#[repr(i64)]
 enum Foo {
     X = 0x7fffffffffffffff,
     Y = 0, // ok!
@@ -2888,6 +2889,7 @@ enum Foo {
 Or:
 
 ```
+#[repr(i64)]
 enum Foo {
     Y = 0, // ok!
     X = 0x7fffffffffffffff,

--- a/src/test/ui/lint/deny-overflowing-literals.rs
+++ b/src/test/ui/lint/deny-overflowing-literals.rs
@@ -1,5 +1,3 @@
-// edition:2018
-
 fn main() {
     let x: u8 = 256;
     //~^ error: literal out of range for u8

--- a/src/test/ui/lint/deny-overflowing-literals.stderr
+++ b/src/test/ui/lint/deny-overflowing-literals.stderr
@@ -1,5 +1,5 @@
 error: literal out of range for u8
-  --> $DIR/edition-deny-overflowing-literals-2018.rs:4:17
+  --> $DIR/deny-overflowing-literals.rs:2:17
    |
 LL |     let x: u8 = 256;
    |                 ^^^

--- a/src/test/ui/lint/lint-type-limits2.rs
+++ b/src/test/ui/lint/lint-type-limits2.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+#![warn(overflowing_literals)]
 
 // compile-flags: -D unused-comparisons
 fn main() { }

--- a/src/test/ui/lint/lint-type-limits2.stderr
+++ b/src/test/ui/lint/lint-type-limits2.stderr
@@ -1,5 +1,5 @@
 error: comparison is useless due to type limits
-  --> $DIR/lint-type-limits2.rs:12:5
+  --> $DIR/lint-type-limits2.rs:13:5
    |
 LL |     128 > bar() //~ ERROR comparison is useless due to type limits
    |     ^^^^^^^^^^^
@@ -7,12 +7,16 @@ LL |     128 > bar() //~ ERROR comparison is useless due to type limits
    = note: requested on the command line with `-D unused-comparisons`
 
 warning: literal out of range for i8
-  --> $DIR/lint-type-limits2.rs:12:5
+  --> $DIR/lint-type-limits2.rs:13:5
    |
 LL |     128 > bar() //~ ERROR comparison is useless due to type limits
    |     ^^^
    |
-   = note: #[warn(overflowing_literals)] on by default
+note: lint level defined here
+  --> $DIR/lint-type-limits2.rs:2:9
+   |
+LL | #![warn(overflowing_literals)]
+   |         ^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/lint/lint-type-limits3.rs
+++ b/src/test/ui/lint/lint-type-limits3.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+#![warn(overflowing_literals)]
 
 // compile-flags: -D unused-comparisons
 fn main() { }

--- a/src/test/ui/lint/lint-type-limits3.stderr
+++ b/src/test/ui/lint/lint-type-limits3.stderr
@@ -1,5 +1,5 @@
 error: comparison is useless due to type limits
-  --> $DIR/lint-type-limits3.rs:8:11
+  --> $DIR/lint-type-limits3.rs:9:11
    |
 LL |     while 200 != i { //~ ERROR comparison is useless due to type limits
    |           ^^^^^^^^
@@ -7,12 +7,16 @@ LL |     while 200 != i { //~ ERROR comparison is useless due to type limits
    = note: requested on the command line with `-D unused-comparisons`
 
 warning: literal out of range for i8
-  --> $DIR/lint-type-limits3.rs:8:11
+  --> $DIR/lint-type-limits3.rs:9:11
    |
 LL |     while 200 != i { //~ ERROR comparison is useless due to type limits
    |           ^^^
    |
-   = note: #[warn(overflowing_literals)] on by default
+note: lint level defined here
+  --> $DIR/lint-type-limits3.rs:2:9
+   |
+LL | #![warn(overflowing_literals)]
+   |         ^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/lint/type-overflow.rs
+++ b/src/test/ui/lint/type-overflow.rs
@@ -1,4 +1,5 @@
 // compile-pass
+#![warn(overflowing_literals)]
 
 fn main() {
     let error = 255i8; //~WARNING literal out of range for i8

--- a/src/test/ui/lint/type-overflow.stderr
+++ b/src/test/ui/lint/type-overflow.stderr
@@ -1,13 +1,17 @@
 warning: literal out of range for i8
-  --> $DIR/type-overflow.rs:4:17
+  --> $DIR/type-overflow.rs:5:17
    |
 LL |     let error = 255i8; //~WARNING literal out of range for i8
    |                 ^^^^^
    |
-   = note: #[warn(overflowing_literals)] on by default
+note: lint level defined here
+  --> $DIR/type-overflow.rs:2:9
+   |
+LL | #![warn(overflowing_literals)]
+   |         ^^^^^^^^^^^^^^^^^^^^
 
 warning: literal out of range for i8
-  --> $DIR/type-overflow.rs:9:16
+  --> $DIR/type-overflow.rs:10:16
    |
 LL |     let fail = 0b1000_0001i8; //~WARNING literal out of range for i8
    |                ^^^^^^^^^^^^^ help: consider using `u8` instead: `0b1000_0001u8`
@@ -15,7 +19,7 @@ LL |     let fail = 0b1000_0001i8; //~WARNING literal out of range for i8
    = note: the literal `0b1000_0001i8` (decimal `129`) does not fit into an `i8` and will become `-127i8`
 
 warning: literal out of range for i64
-  --> $DIR/type-overflow.rs:11:16
+  --> $DIR/type-overflow.rs:12:16
    |
 LL |     let fail = 0x8000_0000_0000_0000i64; //~WARNING literal out of range for i64
    |                ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `u64` instead: `0x8000_0000_0000_0000u64`
@@ -23,7 +27,7 @@ LL |     let fail = 0x8000_0000_0000_0000i64; //~WARNING literal out of range fo
    = note: the literal `0x8000_0000_0000_0000i64` (decimal `9223372036854775808`) does not fit into an `i64` and will become `-9223372036854775808i64`
 
 warning: literal out of range for u32
-  --> $DIR/type-overflow.rs:13:16
+  --> $DIR/type-overflow.rs:14:16
    |
 LL |     let fail = 0x1_FFFF_FFFFu32; //~WARNING literal out of range for u32
    |                ^^^^^^^^^^^^^^^^ help: consider using `u64` instead: `0x1_FFFF_FFFFu64`
@@ -31,7 +35,7 @@ LL |     let fail = 0x1_FFFF_FFFFu32; //~WARNING literal out of range for u32
    = note: the literal `0x1_FFFF_FFFFu32` (decimal `8589934591`) does not fit into an `u32` and will become `4294967295u32`
 
 warning: literal out of range for i128
-  --> $DIR/type-overflow.rs:15:22
+  --> $DIR/type-overflow.rs:16:22
    |
 LL |     let fail: i128 = 0x8000_0000_0000_0000_0000_0000_0000_0000;
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -40,7 +44,7 @@ LL |     let fail: i128 = 0x8000_0000_0000_0000_0000_0000_0000_0000;
    = help: consider using `u128` instead
 
 warning: literal out of range for i32
-  --> $DIR/type-overflow.rs:18:16
+  --> $DIR/type-overflow.rs:19:16
    |
 LL |     let fail = 0x8FFF_FFFF_FFFF_FFFE; //~WARNING literal out of range for i32
    |                ^^^^^^^^^^^^^^^^^^^^^
@@ -49,7 +53,7 @@ LL |     let fail = 0x8FFF_FFFF_FFFF_FFFE; //~WARNING literal out of range for i
    = help: consider using `i128` instead
 
 warning: literal out of range for i8
-  --> $DIR/type-overflow.rs:20:17
+  --> $DIR/type-overflow.rs:21:17
    |
 LL |     let fail = -0b1111_1111i8; //~WARNING literal out of range for i8
    |                 ^^^^^^^^^^^^^ help: consider using `i16` instead: `0b1111_1111i16`


### PR DESCRIPTION
The `overflowing_literals` was made deny by default for the 2018 edition by #54507, however I'm not aware of any reason it can't be made deny by default for the 2015 edition as well.