### PR TITLE
Fix ICE in msg_span_from_free_region on ReEmpty

### DIFF
--- a/src/librustc/infer/error_reporting/mod.rs
+++ b/src/librustc/infer/error_reporting/mod.rs
@@ -178,6 +178,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
                 self.msg_span_from_early_bound_and_free_regions(region)
             }
             ty::ReStatic => ("the static lifetime".to_owned(), None),
+            ty::ReEmpty => ("an empty lifetime".to_owned(), None),
             _ => bug!("{:?}", region),
         }
     }

--- a/src/test/ui/impl-trait/issue-55608-captures-empty-region.rs
+++ b/src/test/ui/impl-trait/issue-55608-captures-empty-region.rs
@@ -1,0 +1,22 @@
+// This used to ICE because it creates an `impl Trait` that captures a
+// hidden empty region.
+
+#![feature(conservative_impl_trait)]
+
+fn server() -> impl FilterBase2 { //~ ERROR [E0700]
+    segment2(|| { loop { } }).map2(|| "")
+}
+
+trait FilterBase2 {
+    fn map2<F>(self, _fn: F) -> Map2<F> where Self: Sized { loop { } }
+}
+
+struct Map2<F> { _func: F }
+
+impl<F> FilterBase2 for Map2<F> { }
+
+fn segment2<F>(_fn: F) -> Map2<F> where F: Fn() -> Result<(), ()> {
+    loop { }
+}
+
+fn main() { server(); }

--- a/src/test/ui/impl-trait/issue-55608-captures-empty-region.stderr
+++ b/src/test/ui/impl-trait/issue-55608-captures-empty-region.stderr
@@ -1,0 +1,11 @@
+error[E0700]: hidden type for `impl Trait` captures lifetime that does not appear in bounds
+  --> $DIR/issue-55608-captures-empty-region.rs:6:16
+   |
+LL | fn server() -> impl FilterBase2 { //~ ERROR [E0700]
+   |                ^^^^^^^^^^^^^^^^
+   |
+   = note: hidden type `Map2<[closure@$DIR/issue-55608-captures-empty-region.rs:7:36: 7:41]>` captures an empty lifetime
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0700`.


### PR DESCRIPTION
On an example like this:

```rust
#![feature(conservative_impl_trait)]

fn server() -> impl FilterBase2 {
    segment2(|| { loop { } }).map2(|| "")
}

trait FilterBase2 {
    fn map2<F>(self, _fn: F) -> Map2<F> where Self: Sized { loop { } }
}

struct Map2<F> { _func: F }

impl<F> FilterBase2 for Map2<F> { }

fn segment2<F>(_fn: F) -> Map2<F> where F: Fn() -> Result<(), ()> {
    loop { }
}
```

we now, instead of ICE'ing, get a diagnostic like:

```
error[E0700]: hidden type for `impl Trait` captures lifetime that does not appear in bounds
 --> issue-55608.rs:3:16
  |
3 | fn server() -> impl FilterBase2 {
  |                ^^^^^^^^^^^^^^^^
  |
  = note: hidden type `Map2<[closure@issue-55608.rs:4:36: 4:41]>` captures an empty lifetime
```

Fix #55608 