### PR TITLE
Implement optimize(size) and optimize(speed) attributes

### DIFF
--- a/src/librustc/dep_graph/dep_node.rs
+++ b/src/librustc/dep_graph/dep_node.rs
@@ -642,6 +642,7 @@ define_dep_nodes!( <'tcx>
     [eval_always] CollectAndPartitionMonoItems,
     [] IsCodegenedItem(DefId),
     [] CodegenUnit(InternedString),
+    [] BackendOptimizationLevel(CrateNum),
     [] CompileCodegenUnit(InternedString),
     [input] OutputFilenames,
     [] NormalizeProjectionTy(CanonicalProjectionGoal<'tcx>),

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -21,7 +21,7 @@ use syntax::source_map::Spanned;
 use rustc_target::spec::abi::Abi;
 use syntax::ast::{self, CrateSugar, Ident, Name, NodeId, DUMMY_NODE_ID, AsmDialect};
 use syntax::ast::{Attribute, Label, Lit, StrStyle, FloatTy, IntTy, UintTy};
-use syntax::attr::InlineAttr;
+use syntax::attr::{InlineAttr, OptimizeAttr};
 use syntax::ext::hygiene::SyntaxContext;
 use syntax::ptr::P;
 use syntax::symbol::{Symbol, keywords};
@@ -2416,6 +2416,8 @@ pub struct CodegenFnAttrs {
     pub flags: CodegenFnAttrFlags,
     /// Parsed representation of the `#[inline]` attribute
     pub inline: InlineAttr,
+    /// Parsed representation of the `#[optimize]` attribute
+    pub optimize: OptimizeAttr,
     /// The `#[export_name = "..."]` attribute, indicating a custom symbol a
     /// function should be exported under
     pub export_name: Option<Symbol>,
@@ -2476,6 +2478,7 @@ impl CodegenFnAttrs {
         CodegenFnAttrs {
             flags: CodegenFnAttrFlags::empty(),
             inline: InlineAttr::None,
+            optimize: OptimizeAttr::None,
             export_name: None,
             link_name: None,
             target_features: vec![],

--- a/src/librustc/ich/impls_hir.rs
+++ b/src/librustc/ich/impls_hir.rs
@@ -1159,6 +1159,7 @@ impl<'a> ToStableHashKey<StableHashingContext<'a>> for hir::TraitCandidate {
 impl_stable_hash_for!(struct hir::CodegenFnAttrs {
     flags,
     inline,
+    optimize,
     export_name,
     link_name,
     target_features,
@@ -1176,6 +1177,14 @@ impl<'hir> HashStable<StableHashingContext<'hir>> for hir::CodegenFnAttrFlags
 }
 
 impl<'hir> HashStable<StableHashingContext<'hir>> for attr::InlineAttr {
+    fn hash_stable<W: StableHasherResult>(&self,
+                                          hcx: &mut StableHashingContext<'hir>,
+                                          hasher: &mut StableHasher<W>) {
+        mem::discriminant(self).hash_stable(hcx, hasher);
+    }
+}
+
+impl<'hir> HashStable<StableHashingContext<'hir>> for attr::OptimizeAttr {
     fn hash_stable<W: StableHasherResult>(&self,
                                           hcx: &mut StableHashingContext<'hir>,
                                           hasher: &mut StableHasher<W>) {

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -58,6 +58,8 @@ pub enum OptLevel {
     SizeMin,    // -Oz
 }
 
+impl_stable_hash_via_hash!(OptLevel);
+
 /// This is what the `LtoCli` values get mapped to after resolving defaults and
 /// and taking other command line options into account.
 #[derive(Clone, Copy, PartialEq, Hash, Debug)]

--- a/src/librustc/ty/query/config.rs
+++ b/src/librustc/ty/query/config.rs
@@ -967,6 +967,12 @@ impl<'tcx> QueryDescription<'tcx> for queries::dllimport_foreign_items<'tcx> {
     }
 }
 
+impl<'tcx> QueryDescription<'tcx> for queries::backend_optimization_level<'tcx> {
+    fn describe(_tcx: TyCtxt<'_, '_, '_>, _: CrateNum) -> Cow<'static, str> {
+        "optimization level used by backend".into()
+    }
+}
+
 macro_rules! impl_disk_cacheable_query(
     ($query_name:ident, |$key:tt| $cond:expr) => {
         impl<'tcx> QueryDescription<'tcx> for queries::$query_name<'tcx> {

--- a/src/librustc/ty/query/mod.rs
+++ b/src/librustc/ty/query/mod.rs
@@ -22,7 +22,7 @@ use mir::mono::CodegenUnit;
 use mir;
 use mir::interpret::GlobalId;
 use session::{CompileResult, CrateDisambiguator};
-use session::config::{EntryFnType, OutputFilenames};
+use session::config::{EntryFnType, OutputFilenames, OptLevel};
 use traits::{self, Vtable};
 use traits::query::{
     CanonicalPredicateGoal, CanonicalProjectionGoal,
@@ -573,6 +573,7 @@ define_queries! { <'tcx>
             -> (Arc<DefIdSet>, Arc<Vec<Arc<CodegenUnit<'tcx>>>>),
         [] fn is_codegened_item: IsCodegenedItem(DefId) -> bool,
         [] fn codegen_unit: CodegenUnit(InternedString) -> Arc<CodegenUnit<'tcx>>,
+        [] fn backend_optimization_level: BackendOptimizationLevel(CrateNum) -> OptLevel,
     },
 
     Other {

--- a/src/librustc/ty/query/plumbing.rs
+++ b/src/librustc/ty/query/plumbing.rs
@@ -1410,6 +1410,9 @@ pub fn force_from_dep_node<'a, 'gcx, 'lcx>(tcx: TyCtxt<'a, 'gcx, 'lcx>,
         DepKind::UpstreamMonomorphizationsFor => {
             force!(upstream_monomorphizations_for, def_id!());
         }
+        DepKind::BackendOptimizationLevel => {
+            force!(backend_optimization_level, krate!());
+        }
     }
 
     true

--- a/src/librustc_codegen_llvm/attributes.rs
+++ b/src/librustc_codegen_llvm/attributes.rs
@@ -5,7 +5,7 @@ use std::ffi::CString;
 use rustc::hir::{CodegenFnAttrFlags, CodegenFnAttrs};
 use rustc::hir::def_id::{DefId, LOCAL_CRATE};
 use rustc::session::Session;
-use rustc::session::config::Sanitizer;
+use rustc::session::config::{Sanitizer, OptLevel};
 use rustc::ty::{self, TyCtxt, PolyFnSig};
 use rustc::ty::layout::HasTyCtxt;
 use rustc::ty::query::Providers;
@@ -20,7 +20,7 @@ use attributes;
 use llvm::{self, Attribute};
 use llvm::AttributePlace::Function;
 use llvm_util;
-pub use syntax::attr::{self, InlineAttr};
+pub use syntax::attr::{self, InlineAttr, OptimizeAttr};
 
 use context::CodegenCx;
 use value::Value;
@@ -55,13 +55,6 @@ pub fn emit_uwtable(val: &'ll Value, emit: bool) {
 #[inline]
 fn unwind(val: &'ll Value, can_unwind: bool) {
     Attribute::NoUnwind.toggle_llfn(Function, val, !can_unwind);
-}
-
-/// Tell LLVM whether it should optimize function for size.
-#[inline]
-#[allow(dead_code)] // possibly useful function
-pub fn set_optimize_for_size(val: &'ll Value, optimize: bool) {
-    Attribute::OptimizeForSize.toggle_llfn(Function, val, optimize);
 }
 
 /// Tell LLVM if this function should be 'naked', i.e., skip the epilogue and prologue.
@@ -163,6 +156,39 @@ pub fn from_fn_attrs(
         .unwrap_or_else(|| CodegenFnAttrs::new());
 
     inline(cx, llfn, codegen_fn_attrs.inline);
+
+    match codegen_fn_attrs.optimize {
+        OptimizeAttr::None => {
+            match cx.tcx.sess.opts.optimize {
+                OptLevel::Size => {
+                    llvm::Attribute::MinSize.unapply_llfn(Function, llfn);
+                    llvm::Attribute::OptimizeForSize.apply_llfn(Function, llfn);
+                    llvm::Attribute::OptimizeNone.unapply_llfn(Function, llfn);
+                },
+                OptLevel::SizeMin => {
+                    llvm::Attribute::MinSize.apply_llfn(Function, llfn);
+                    llvm::Attribute::OptimizeForSize.apply_llfn(Function, llfn);
+                    llvm::Attribute::OptimizeNone.unapply_llfn(Function, llfn);
+                }
+                OptLevel::No => {
+                    llvm::Attribute::MinSize.unapply_llfn(Function, llfn);
+                    llvm::Attribute::OptimizeForSize.unapply_llfn(Function, llfn);
+                    llvm::Attribute::OptimizeNone.apply_llfn(Function, llfn);
+                }
+                _ => {}
+            }
+        }
+        OptimizeAttr::Speed => {
+            llvm::Attribute::MinSize.unapply_llfn(Function, llfn);
+            llvm::Attribute::OptimizeForSize.unapply_llfn(Function, llfn);
+            llvm::Attribute::OptimizeNone.unapply_llfn(Function, llfn);
+        }
+        OptimizeAttr::Size => {
+            llvm::Attribute::MinSize.apply_llfn(Function, llfn);
+            llvm::Attribute::OptimizeForSize.apply_llfn(Function, llfn);
+            llvm::Attribute::OptimizeNone.unapply_llfn(Function, llfn);
+        }
+    }
 
     // The `uwtable` attribute according to LLVM is:
     //

--- a/src/librustc_codegen_llvm/attributes.rs
+++ b/src/librustc_codegen_llvm/attributes.rs
@@ -155,8 +155,6 @@ pub fn from_fn_attrs(
     let codegen_fn_attrs = id.map(|id| cx.tcx.codegen_fn_attrs(id))
         .unwrap_or_else(|| CodegenFnAttrs::new());
 
-    inline(cx, llfn, codegen_fn_attrs.inline);
-
     match codegen_fn_attrs.optimize {
         OptimizeAttr::None => {
             match cx.tcx.sess.opts.optimize {
@@ -173,7 +171,7 @@ pub fn from_fn_attrs(
                 OptLevel::No => {
                     llvm::Attribute::MinSize.unapply_llfn(Function, llfn);
                     llvm::Attribute::OptimizeForSize.unapply_llfn(Function, llfn);
-                    llvm::Attribute::OptimizeNone.apply_llfn(Function, llfn);
+                    llvm::Attribute::OptimizeNone.unapply_llfn(Function, llfn);
                 }
                 _ => {}
             }
@@ -189,6 +187,8 @@ pub fn from_fn_attrs(
             llvm::Attribute::OptimizeNone.unapply_llfn(Function, llfn);
         }
     }
+
+    inline(cx, llfn, codegen_fn_attrs.inline);
 
     // The `uwtable` attribute according to LLVM is:
     //

--- a/src/librustc_codegen_llvm/back/lto.rs
+++ b/src/librustc_codegen_llvm/back/lto.rs
@@ -3,7 +3,7 @@ use rustc_codegen_ssa::back::symbol_export;
 use rustc_codegen_ssa::back::write::{ModuleConfig, CodegenContext, pre_lto_bitcode_filename};
 use rustc_codegen_ssa::back::lto::{SerializedModule, LtoModuleCodegen, ThinShared, ThinModule};
 use rustc_codegen_ssa::traits::*;
-use back::write::{self, DiagnosticHandlers, with_llvm_pmb, save_temp_bitcode, get_llvm_opt_level};
+use back::write::{self, DiagnosticHandlers, with_llvm_pmb, save_temp_bitcode, to_llvm_opt_settings};
 use errors::{FatalError, Handler};
 use llvm::archive_ro::ArchiveRO;
 use llvm::{self, True, False};
@@ -532,7 +532,7 @@ pub(crate) fn run_pass_manager(cgcx: &CodegenContext<LlvmCodegenBackend>,
         // Note that in general this shouldn't matter too much as you typically
         // only turn on ThinLTO when you're compiling with optimizations
         // otherwise.
-        let opt_level = config.opt_level.map(get_llvm_opt_level)
+        let opt_level = config.opt_level.map(|x| to_llvm_opt_settings(x).0)
             .unwrap_or(llvm::CodeGenOptLevel::None);
         let opt_level = match opt_level {
             llvm::CodeGenOptLevel::None => llvm::CodeGenOptLevel::Less,

--- a/src/librustc_codegen_llvm/base.rs
+++ b/src/librustc_codegen_llvm/base.rs
@@ -136,7 +136,7 @@ pub fn iter_globals(llmod: &'ll llvm::Module) -> ValueIter<'ll> {
     }
 }
 
-pub fn compile_codegen_unit<'ll, 'tcx>(tcx: TyCtxt<'ll, 'tcx, 'tcx>,
+pub fn compile_codegen_unit<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                   cgu_name: InternedString)
                                   -> Stats {
     let start_time = Instant::now();
@@ -164,7 +164,7 @@ pub fn compile_codegen_unit<'ll, 'tcx>(tcx: TyCtxt<'ll, 'tcx, 'tcx>,
         let backend = LlvmCodegenBackend(());
         let cgu = tcx.codegen_unit(cgu_name);
         // Instantiate monomorphizations without filling out definitions yet...
-        let llvm_module = backend.new_metadata(tcx.sess, &cgu_name.as_str());
+        let llvm_module = backend.new_metadata(tcx, &cgu_name.as_str());
         let stats = {
             let cx = CodegenCx::new(tcx, cgu, &llvm_module);
             let mono_items = cx.codegen_unit

--- a/src/librustc_codegen_llvm/context.rs
+++ b/src/librustc_codegen_llvm/context.rs
@@ -144,16 +144,17 @@ pub fn is_pie_binary(sess: &Session) -> bool {
 }
 
 pub unsafe fn create_module(
-    sess: &Session,
+    tcx: TyCtxt,
     llcx: &'ll llvm::Context,
     mod_name: &str,
 ) -> &'ll llvm::Module {
+    let sess = tcx.sess;
     let mod_name = SmallCStr::new(mod_name);
     let llmod = llvm::LLVMModuleCreateWithNameInContext(mod_name.as_ptr(), llcx);
 
     // Ensure the data-layout values hardcoded remain the defaults.
     if sess.target.target.options.is_builtin {
-        let tm = ::back::write::create_target_machine(sess, false);
+        let tm = ::back::write::create_target_machine(tcx, false);
         llvm::LLVMRustSetDataLayoutFromTargetMachine(llmod, tm);
         llvm::LLVMRustDisposeTargetMachine(tm);
 

--- a/src/librustc_codegen_llvm/declare.rs
+++ b/src/librustc_codegen_llvm/declare.rs
@@ -15,7 +15,7 @@ use llvm;
 use llvm::AttributePlace::Function;
 use rustc::ty::{self, PolyFnSig};
 use rustc::ty::layout::LayoutOf;
-use rustc::session::config::{Sanitizer, OptLevel};
+use rustc::session::config::Sanitizer;
 use rustc_data_structures::small_c_str::SmallCStr;
 use abi::{FnType, FnTypeExt};
 use attributes;
@@ -65,28 +65,8 @@ fn declare_raw_fn(
         }
     }
 
-    // FIXME(opt): this is kinda duplicated with similar code in attributes::from_fn_attrs…
-    match cx.tcx.sess.opts.optimize {
-        OptLevel::Size => {
-            llvm::Attribute::MinSize.unapply_llfn(Function, llfn);
-            llvm::Attribute::OptimizeForSize.apply_llfn(Function, llfn);
-            llvm::Attribute::OptimizeNone.unapply_llfn(Function, llfn);
-        },
-        OptLevel::SizeMin => {
-            llvm::Attribute::MinSize.apply_llfn(Function, llfn);
-            llvm::Attribute::OptimizeForSize.apply_llfn(Function, llfn);
-            llvm::Attribute::OptimizeNone.unapply_llfn(Function, llfn);
-        }
-        OptLevel::No => {
-            llvm::Attribute::MinSize.unapply_llfn(Function, llfn);
-            llvm::Attribute::OptimizeForSize.unapply_llfn(Function, llfn);
-            llvm::Attribute::OptimizeNone.unapply_llfn(Function, llfn);
-        }
-        _ => {}
-    }
-
+    attributes::default_optimisation_attrs(cx.tcx.sess, llfn);
     attributes::non_lazy_bind(cx.sess(), llfn);
-
     llfn
 }
 

--- a/src/librustc_codegen_llvm/declare.rs
+++ b/src/librustc_codegen_llvm/declare.rs
@@ -65,7 +65,7 @@ fn declare_raw_fn(
         }
     }
 
-    // FIXME(opt): this is kinda duplicated with similar code in attributes::from_fm_attrs…
+    // FIXME(opt): this is kinda duplicated with similar code in attributes::from_fn_attrs…
     match cx.tcx.sess.opts.optimize {
         OptLevel::Size => {
             llvm::Attribute::MinSize.unapply_llfn(Function, llfn);
@@ -80,7 +80,7 @@ fn declare_raw_fn(
         OptLevel::No => {
             llvm::Attribute::MinSize.unapply_llfn(Function, llfn);
             llvm::Attribute::OptimizeForSize.unapply_llfn(Function, llfn);
-            llvm::Attribute::OptimizeNone.apply_llfn(Function, llfn);
+            llvm::Attribute::OptimizeNone.unapply_llfn(Function, llfn);
         }
         _ => {}
     }

--- a/src/librustc_codegen_llvm/lib.rs
+++ b/src/librustc_codegen_llvm/lib.rs
@@ -73,7 +73,7 @@ use rustc::dep_graph::DepGraph;
 use rustc::middle::allocator::AllocatorKind;
 use rustc::middle::cstore::{EncodedMetadata, MetadataLoader};
 use rustc::session::{Session, CompileIncomplete};
-use rustc::session::config::{OutputFilenames, OutputType, PrintRequest};
+use rustc::session::config::{OutputFilenames, OutputType, PrintRequest, OptLevel};
 use rustc::ty::{self, TyCtxt};
 use rustc::util::time_graph;
 use rustc::util::profiling::ProfileCategory;
@@ -122,8 +122,8 @@ mod va_arg;
 pub struct LlvmCodegenBackend(());
 
 impl ExtraBackendMethods for LlvmCodegenBackend {
-    fn new_metadata(&self, sess: &Session, mod_name: &str) -> ModuleLlvm {
-        ModuleLlvm::new(sess, mod_name)
+    fn new_metadata(&self, tcx: TyCtxt, mod_name: &str) -> ModuleLlvm {
+        ModuleLlvm::new(tcx, mod_name)
     }
     fn write_metadata<'b, 'gcx>(
         &self,
@@ -145,10 +145,11 @@ impl ExtraBackendMethods for LlvmCodegenBackend {
     fn target_machine_factory(
         &self,
         sess: &Session,
+        optlvl: OptLevel,
         find_features: bool
     ) -> Arc<dyn Fn() ->
         Result<&'static mut llvm::TargetMachine, String> + Send + Sync> {
-        back::write::target_machine_factory(sess, find_features)
+        back::write::target_machine_factory(sess, optlvl, find_features)
     }
     fn target_cpu<'b>(&self, sess: &'b Session) -> &'b str {
         llvm_util::target_cpu(sess)
@@ -364,15 +365,15 @@ unsafe impl Send for ModuleLlvm { }
 unsafe impl Sync for ModuleLlvm { }
 
 impl ModuleLlvm {
-    fn new(sess: &Session, mod_name: &str) -> Self {
+    fn new(tcx: TyCtxt, mod_name: &str) -> Self {
         unsafe {
-            let llcx = llvm::LLVMRustContextCreate(sess.fewer_names());
-            let llmod_raw = context::create_module(sess, llcx, mod_name) as *const _;
+            let llcx = llvm::LLVMRustContextCreate(tcx.sess.fewer_names());
+            let llmod_raw = context::create_module(tcx, llcx, mod_name) as *const _;
 
             ModuleLlvm {
                 llmod_raw,
                 llcx,
-                tm: create_target_machine(sess, false),
+                tm: create_target_machine(tcx, false),
             }
         }
     }

--- a/src/librustc_codegen_llvm/llvm/ffi.rs
+++ b/src/librustc_codegen_llvm/llvm/ffi.rs
@@ -115,6 +115,7 @@ pub enum Attribute {
     SanitizeAddress = 21,
     SanitizeMemory  = 22,
     NonLazyBind     = 23,
+    OptimizeNone    = 24,
 }
 
 /// LLVMIntPredicate

--- a/src/librustc_codegen_llvm/llvm_util.rs
+++ b/src/librustc_codegen_llvm/llvm_util.rs
@@ -1,5 +1,5 @@
 use syntax_pos::symbol::Symbol;
-use back::write::create_target_machine;
+use back::write::create_informational_target_machine;
 use llvm;
 use rustc::session::Session;
 use rustc::session::config::PrintRequest;
@@ -223,7 +223,7 @@ pub fn to_llvm_feature<'a>(sess: &Session, s: &'a str) -> &'a str {
 }
 
 pub fn target_features(sess: &Session) -> Vec<Symbol> {
-    let target_machine = create_target_machine(sess, true);
+    let target_machine = create_informational_target_machine(sess, true);
     target_feature_whitelist(sess)
         .iter()
         .filter_map(|&(feature, gate)| {
@@ -276,7 +276,7 @@ pub fn print_passes() {
 
 pub(crate) fn print(req: PrintRequest, sess: &Session) {
     require_inited();
-    let tm = create_target_machine(sess, true);
+    let tm = create_informational_target_machine(sess, true);
     unsafe {
         match req {
             PrintRequest::TargetCPUs => llvm::LLVMRustPrintTargetCPUs(tm),

--- a/src/librustc_codegen_ssa/back/write.rs
+++ b/src/librustc_codegen_ssa/back/write.rs
@@ -982,6 +982,7 @@ fn start_executing_work<B: ExtraBackendMethods>(
         None
     };
 
+    let ol = tcx.backend_optimization_level(LOCAL_CRATE);
     let cgcx = CodegenContext::<B> {
         backend: backend.clone(),
         crate_types: sess.crate_types.borrow().clone(),
@@ -1005,7 +1006,7 @@ fn start_executing_work<B: ExtraBackendMethods>(
         regular_module_config: modules_config,
         metadata_module_config: metadata_config,
         allocator_module_config: allocator_config,
-        tm_factory: TargetMachineFactory(backend.target_machine_factory(tcx.sess, false)),
+        tm_factory: TargetMachineFactory(backend.target_machine_factory(tcx.sess, ol, false)),
         total_cgus,
         msvc_imps_needed: msvc_imps_needed(tcx),
         target_pointer_width: tcx.sess.target.target.target_pointer_width.clone(),

--- a/src/librustc_codegen_ssa/traits/backend.rs
+++ b/src/librustc_codegen_ssa/traits/backend.rs
@@ -6,7 +6,7 @@ use super::CodegenObject;
 use rustc::middle::allocator::AllocatorKind;
 use rustc::middle::cstore::EncodedMetadata;
 use rustc::mir::mono::Stats;
-use rustc::session::Session;
+use rustc::session::{Session, config};
 use rustc::ty::TyCtxt;
 use rustc_codegen_utils::codegen_backend::CodegenBackend;
 use std::sync::Arc;
@@ -32,7 +32,7 @@ impl<'tcx, T> Backend<'tcx> for T where
 }
 
 pub trait ExtraBackendMethods: CodegenBackend + WriteBackendMethods + Sized + Send {
-    fn new_metadata(&self, sess: &Session, mod_name: &str) -> Self::Module;
+    fn new_metadata(&self, sess: TyCtxt, mod_name: &str) -> Self::Module;
     fn write_metadata<'b, 'gcx>(
         &self,
         tcx: TyCtxt<'b, 'gcx, 'gcx>,
@@ -50,6 +50,7 @@ pub trait ExtraBackendMethods: CodegenBackend + WriteBackendMethods + Sized + Se
     fn target_machine_factory(
         &self,
         sess: &Session,
+        opt_level: config::OptLevel,
         find_features: bool,
     ) -> Arc<dyn Fn() -> Result<Self::TargetMachine, String> + Send + Sync>;
     fn target_cpu<'b>(&self, sess: &'b Session) -> &'b str;

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -36,7 +36,7 @@ use rustc_target::spec::abi;
 
 use syntax::ast;
 use syntax::ast::{Ident, MetaItemKind};
-use syntax::attr::{InlineAttr, list_contains_name, mark_used};
+use syntax::attr::{InlineAttr, OptimizeAttr, list_contains_name, mark_used};
 use syntax::source_map::Spanned;
 use syntax::feature_gate;
 use syntax::symbol::{keywords, Symbol};
@@ -2286,49 +2286,6 @@ fn codegen_fn_attrs<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, id: DefId) -> Codegen
             codegen_fn_attrs.flags |= CodegenFnAttrFlags::USED;
         } else if attr.check_name("thread_local") {
             codegen_fn_attrs.flags |= CodegenFnAttrFlags::THREAD_LOCAL;
-        } else if attr.check_name("inline") {
-            codegen_fn_attrs.inline = attrs.iter().fold(InlineAttr::None, |ia, attr| {
-                if attr.path != "inline" {
-                    return ia;
-                }
-                let meta = match attr.meta() {
-                    Some(meta) => meta.node,
-                    None => return ia,
-                };
-                match meta {
-                    MetaItemKind::Word => {
-                        mark_used(attr);
-                        InlineAttr::Hint
-                    }
-                    MetaItemKind::List(ref items) => {
-                        mark_used(attr);
-                        inline_span = Some(attr.span);
-                        if items.len() != 1 {
-                            span_err!(
-                                tcx.sess.diagnostic(),
-                                attr.span,
-                                E0534,
-                                "expected one argument"
-                            );
-                            InlineAttr::None
-                        } else if list_contains_name(&items[..], "always") {
-                            InlineAttr::Always
-                        } else if list_contains_name(&items[..], "never") {
-                            InlineAttr::Never
-                        } else {
-                            span_err!(
-                                tcx.sess.diagnostic(),
-                                items[0].span,
-                                E0535,
-                                "invalid argument"
-                            );
-
-                            InlineAttr::None
-                        }
-                    }
-                    _ => ia,
-                }
-            });
         } else if attr.check_name("export_name") {
             if let Some(s) = attr.value_str() {
                 if s.as_str().contains("\0") {
@@ -2377,6 +2334,76 @@ fn codegen_fn_attrs<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, id: DefId) -> Codegen
             codegen_fn_attrs.link_name = attr.value_str();
         }
     }
+
+    codegen_fn_attrs.inline = attrs.iter().fold(InlineAttr::None, |ia, attr| {
+        if attr.path != "inline" {
+            return ia;
+        }
+        match attr.meta().map(|i| i.node) {
+            Some(MetaItemKind::Word) => {
+                mark_used(attr);
+                InlineAttr::Hint
+            }
+            Some(MetaItemKind::List(ref items)) => {
+                mark_used(attr);
+                inline_span = Some(attr.span);
+                if items.len() != 1 {
+                    span_err!(
+                        tcx.sess.diagnostic(),
+                        attr.span,
+                        E0534,
+                        "expected one argument"
+                    );
+                    InlineAttr::None
+                } else if list_contains_name(&items[..], "always") {
+                    InlineAttr::Always
+                } else if list_contains_name(&items[..], "never") {
+                    InlineAttr::Never
+                } else {
+                    span_err!(
+                        tcx.sess.diagnostic(),
+                        items[0].span,
+                        E0535,
+                        "invalid argument"
+                    );
+
+                    InlineAttr::None
+                }
+            }
+            Some(MetaItemKind::NameValue(_)) => ia,
+            None => ia,
+        }
+    });
+
+    codegen_fn_attrs.optimize = attrs.iter().fold(OptimizeAttr::None, |ia, attr| {
+        if attr.path != "optimize" {
+            return ia;
+        }
+        let err = |sp, s| span_err!(tcx.sess.diagnostic(), sp, E0720, "{}", s);
+        match attr.meta().map(|i| i.node) {
+            Some(MetaItemKind::Word) => {
+                err(attr.span, "expected one argument");
+                ia
+            }
+            Some(MetaItemKind::List(ref items)) => {
+                mark_used(attr);
+                inline_span = Some(attr.span);
+                if items.len() != 1 {
+                    err(attr.span, "expected one argument");
+                    OptimizeAttr::None
+                } else if list_contains_name(&items[..], "size") {
+                    OptimizeAttr::Size
+                } else if list_contains_name(&items[..], "speed") {
+                    OptimizeAttr::Speed
+                } else {
+                    err(items[0].span, "invalid argument");
+                    OptimizeAttr::None
+                }
+            }
+            Some(MetaItemKind::NameValue(_)) => ia,
+            None => ia,
+        }
+    });
 
     // If a function uses #[target_feature] it can't be inlined into general
     // purpose functions as they wouldn't have the right target features

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -2379,7 +2379,7 @@ fn codegen_fn_attrs<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, id: DefId) -> Codegen
         if attr.path != "optimize" {
             return ia;
         }
-        let err = |sp, s| span_err!(tcx.sess.diagnostic(), sp, E0720, "{}", s);
+        let err = |sp, s| span_err!(tcx.sess.diagnostic(), sp, E0722, "{}", s);
         match attr.meta().map(|i| i.node) {
             Some(MetaItemKind::Word) => {
                 err(attr.span, "expected one argument");

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -4719,4 +4719,5 @@ register_diagnostics! {
     E0645, // trait aliases not finished
     E0698, // type inside generator must be known in this context
     E0719, // duplicate values for associated type binding
+    E0720, // Malformed #[optimize] attribute
 }

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -4719,5 +4719,5 @@ register_diagnostics! {
     E0645, // trait aliases not finished
     E0698, // type inside generator must be known in this context
     E0719, // duplicate values for associated type binding
-    E0720, // Malformed #[optimize] attribute
+    E0722, // Malformed #[optimize] attribute
 }

--- a/src/libsyntax/attr/builtin.rs
+++ b/src/libsyntax/attr/builtin.rs
@@ -63,6 +63,13 @@ pub enum InlineAttr {
     Never,
 }
 
+#[derive(Copy, Clone, Hash, PartialEq, RustcEncodable, RustcDecodable)]
+pub enum OptimizeAttr {
+    None,
+    Speed,
+    Size,
+}
+
 #[derive(Copy, Clone, PartialEq)]
 pub enum UnwindAttr {
     Allowed,

--- a/src/libsyntax/attr/mod.rs
+++ b/src/libsyntax/attr/mod.rs
@@ -4,8 +4,8 @@ mod builtin;
 
 pub use self::builtin::{
     cfg_matches, contains_feature_attr, eval_condition, find_crate_name, find_deprecation,
-    find_repr_attrs, find_stability, find_unwind_attr, Deprecation, InlineAttr, IntType, ReprAttr,
-    RustcDeprecation, Stability, StabilityLevel, UnwindAttr,
+    find_repr_attrs, find_stability, find_unwind_attr, Deprecation, InlineAttr, OptimizeAttr,
+    IntType, ReprAttr, RustcDeprecation, Stability, StabilityLevel, UnwindAttr,
 };
 pub use self::IntType::*;
 pub use self::ReprAttr::*;

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -1219,7 +1219,7 @@ pub const BUILTIN_ATTRIBUTES: &[(&str, AttributeType, AttributeTemplate, Attribu
                            cfg_fn!(alloc_error_handler))),
 
     // RFC 2412
-    ("optimize", Whitelisted, Gated(Stability::Unstable,
+    ("optimize", Whitelisted, template!(List: "size|speed"), Gated(Stability::Unstable,
                                "optimize_attribute",
                                "#[optimize] attribute is an unstable feature",
                                cfg_fn!(optimize_attribute))),

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -462,6 +462,9 @@ declare_features! (
 
     // Re-Rebalance coherence
     (active, re_rebalance_coherence, "1.32.0", Some(55437), None),
+
+    // #[optimize(X)]
+    (active, optimize_attribute, "1.34.0", Some(54882), None),
 );
 
 declare_features! (
@@ -1214,6 +1217,12 @@ pub const BUILTIN_ATTRIBUTES: &[(&str, AttributeType, AttributeTemplate, Attribu
                            "alloc_error_handler",
                            "#[alloc_error_handler] is an unstable feature",
                            cfg_fn!(alloc_error_handler))),
+
+    // RFC 2412
+    ("optimize", Whitelisted, Gated(Stability::Unstable,
+                               "optimize_attribute",
+                               "#[optimize] attribute is an unstable feature",
+                               cfg_fn!(optimize_attribute))),
 
     // Crate level attributes
     ("crate_name", CrateLevel, template!(NameValueStr: "name"), Ungated),

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -188,6 +188,8 @@ static Attribute::AttrKind fromRust(LLVMRustAttribute Kind) {
     return Attribute::SanitizeMemory;
   case NonLazyBind:
     return Attribute::NonLazyBind;
+  case OptimizeNone:
+    return Attribute::OptimizeNone;
   }
   report_fatal_error("bad AttributeKind");
 }

--- a/src/rustllvm/rustllvm.h
+++ b/src/rustllvm/rustllvm.h
@@ -84,6 +84,7 @@ enum LLVMRustAttribute {
   SanitizeAddress = 21,
   SanitizeMemory = 22,
   NonLazyBind = 23,
+  OptimizeNone = 24,
 };
 
 typedef struct OpaqueRustString *RustStringRef;

--- a/src/test/codegen/inline-always-works-always.rs
+++ b/src/test/codegen/inline-always-works-always.rs
@@ -1,0 +1,21 @@
+// revisions: NO-OPT SIZE-OPT SPEED-OPT
+//[NO-OPT] compile-flags: -Copt-level=0
+//[SIZE-OPT] compile-flags: -Copt-level=s
+//[SPEED-OPT] compile-flags: -Copt-level=3
+
+#![crate_type="rlib"]
+
+#[no_mangle]
+#[inline(always)]
+pub extern "C" fn callee() -> u32 {
+    4 + 4
+}
+
+// CHECK-LABEL: caller
+// SIZE-OPT: ret i32 8
+// SPEED-OPT: ret i32 8
+// NO-OPT: ret i32 8
+#[no_mangle]
+pub extern "C" fn caller() -> u32 {
+    callee()
+}

--- a/src/test/codegen/optimize-attr-1.rs
+++ b/src/test/codegen/optimize-attr-1.rs
@@ -1,49 +1,50 @@
 // revisions: NO-OPT SIZE-OPT SPEED-OPT
-// [NO-OPT]compile-flags: -Copt-level=0
-// [SIZE-OPT]compile-flags: -Copt-level=s
-// [SPEED-OPT]compile-flags: -Copt-level=3
+//[NO-OPT] compile-flags: -Copt-level=0 -Ccodegen-units=1
+//[SIZE-OPT] compile-flags: -Copt-level=s -Ccodegen-units=1
+//[SPEED-OPT] compile-flags: -Copt-level=3 -Ccodegen-units=1
 
 #![feature(optimize_attribute)]
 #![crate_type="rlib"]
 
-// NO-OPT: Function Attrs:{{.*}}optnone
-// NO-OPT-NOT: {{optsize|minsize}}
-// NO-OPT-NEXT: @nothing
+// CHECK-LABEL: define i32 @nothing
+// CHECK-SAME: [[NOTHING_ATTRS:#[0-9]+]]
 // NO-OPT: ret i32 %1
-//
-// SIZE-OPT: Function Attrs:{{.*}}optsize
-// SIZE-OPT-NOT: {{minsize|optnone}}
-// SIZE-OPT-NEXT: @nothing
-// SIZE-OPT-NEXT: start
-// SIZE-OPT-NEXT: ret i32 4
-//
-// SPEED-OPT: Function Attrs:
-// SPEED-OPT-NOT: {{minsize|optnone|optsize}}
-// SPEED-OPT-NEXT: @nothing
-// SPEED-OPT-NEXT: start
-// SPEED-OPT-NEXT: ret i32 4
+// SIZE-OPT: ret i32 4
+// SPEEC-OPT: ret i32 4
 #[no_mangle]
 pub fn nothing() -> i32 {
     2 + 2
 }
 
-// CHECK: Function Attrs:{{.*}} minsize{{.*}}optsize
-// CHECK-NEXT: @size
-// CHECK-NEXT: start
-// CHECK-NEXT: ret i32 4
+// CHECK-LABEL: define i32 @size
+// CHECK-SAME: [[SIZE_ATTRS:#[0-9]+]]
+// NO-OPT: ret i32 %1
+// SIZE-OPT: ret i32 6
+// SPEED-OPT: ret i32 6
 #[optimize(size)]
 #[no_mangle]
 pub fn size() -> i32 {
-    2 + 2
+    3 + 3
 }
 
-// CHECK: Function Attrs:
-// CHECK-NOT: {{minsize|optsize|optnone}}
-// CHECK-NEXT: @speed
-// CHECK-NEXT: start
-// CHECK-NEXT: ret i32 4
+// CHECK-LABEL: define i32 @speed
+// NO-OPT-SAME: [[NOTHING_ATTRS]]
+// SPEED-OPT-SAME: [[NOTHING_ATTRS]]
+// SIZE-OPT-SAME: [[SPEED_ATTRS:#[0-9]+]]
+// NO-OPT: ret i32 %1
+// SIZE-OPT: ret i32 8
+// SPEED-OPT: ret i32 8
 #[optimize(speed)]
 #[no_mangle]
 pub fn speed() -> i32 {
-    2 + 2
+    4 + 4
 }
+
+// NO-OPT-DAG: attributes [[SIZE_ATTRS]] = {{.*}}minsize{{.*}}optsize{{.*}}
+// SPEED-OPT-DAG: attributes [[SIZE_ATTRS]] = {{.*}}minsize{{.*}}optsize{{.*}}
+// SIZE-OPT-DAG: attributes [[NOTHING_ATTRS]] = {{.*}}optsize{{.*}}
+// SIZE-OPT-DAG: attributes [[SIZE_ATTRS]] = {{.*}}minsize{{.*}}optsize{{.*}}
+
+// SIZE-OPT: attributes [[SPEED_ATTRS]]
+// SIZE-OPT-NOT: minsize
+// SIZE-OPT-NOT: optsize

--- a/src/test/codegen/optimize-attr-1.rs
+++ b/src/test/codegen/optimize-attr-1.rs
@@ -1,0 +1,49 @@
+// revisions: NO-OPT SIZE-OPT SPEED-OPT
+// [NO-OPT]compile-flags: -Copt-level=0
+// [SIZE-OPT]compile-flags: -Copt-level=s
+// [SPEED-OPT]compile-flags: -Copt-level=3
+
+#![feature(optimize_attribute)]
+#![crate_type="rlib"]
+
+// NO-OPT: Function Attrs:{{.*}}optnone
+// NO-OPT-NOT: {{optsize|minsize}}
+// NO-OPT-NEXT: @nothing
+// NO-OPT: ret i32 %1
+//
+// SIZE-OPT: Function Attrs:{{.*}}optsize
+// SIZE-OPT-NOT: {{minsize|optnone}}
+// SIZE-OPT-NEXT: @nothing
+// SIZE-OPT-NEXT: start
+// SIZE-OPT-NEXT: ret i32 4
+//
+// SPEED-OPT: Function Attrs:
+// SPEED-OPT-NOT: {{minsize|optnone|optsize}}
+// SPEED-OPT-NEXT: @nothing
+// SPEED-OPT-NEXT: start
+// SPEED-OPT-NEXT: ret i32 4
+#[no_mangle]
+pub fn nothing() -> i32 {
+    2 + 2
+}
+
+// CHECK: Function Attrs:{{.*}} minsize{{.*}}optsize
+// CHECK-NEXT: @size
+// CHECK-NEXT: start
+// CHECK-NEXT: ret i32 4
+#[optimize(size)]
+#[no_mangle]
+pub fn size() -> i32 {
+    2 + 2
+}
+
+// CHECK: Function Attrs:
+// CHECK-NOT: {{minsize|optsize|optnone}}
+// CHECK-NEXT: @speed
+// CHECK-NEXT: start
+// CHECK-NEXT: ret i32 4
+#[optimize(speed)]
+#[no_mangle]
+pub fn speed() -> i32 {
+    2 + 2
+}

--- a/src/test/ui/feature-gate-optimize_attribute.rs
+++ b/src/test/ui/feature-gate-optimize_attribute.rs
@@ -1,0 +1,25 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+#![crate_type="rlib"]
+#![optimize(speed)] //~ ERROR #54882
+
+#[optimize(size)] //~ ERROR #54882
+mod module {
+
+#[optimize(size)] //~ ERROR #54882
+fn size() {}
+
+#[optimize(speed)] //~ ERROR #54882
+fn speed() {}
+
+#[optimize(banana)] //~ ERROR #54882
+fn not_known() {}
+
+}

--- a/src/test/ui/feature-gate-optimize_attribute.rs
+++ b/src/test/ui/feature-gate-optimize_attribute.rs
@@ -1,12 +1,3 @@
-// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
-// file at the top-level directory of this distribution and at
-// http://rust-lang.org/COPYRIGHT.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
 #![crate_type="rlib"]
 #![optimize(speed)] //~ ERROR #54882
 
@@ -19,7 +10,9 @@ fn size() {}
 #[optimize(speed)] //~ ERROR #54882
 fn speed() {}
 
-#[optimize(banana)] //~ ERROR #54882
+#[optimize(banana)]
+//~^ ERROR #54882
+//~| ERROR E0722
 fn not_known() {}
 
 }

--- a/src/test/ui/feature-gate-optimize_attribute.stderr
+++ b/src/test/ui/feature-gate-optimize_attribute.stderr
@@ -1,0 +1,43 @@
+error[E0658]: #[optimize] attribute is an unstable feature (see issue #54882)
+  --> $DIR/feature-gate-optimize_attribute.rs:16:1
+   |
+LL | #[optimize(size)] //~ ERROR #54882
+   | ^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(optimize_attribute)] to the crate attributes to enable
+
+error[E0658]: #[optimize] attribute is an unstable feature (see issue #54882)
+  --> $DIR/feature-gate-optimize_attribute.rs:19:1
+   |
+LL | #[optimize(speed)] //~ ERROR #54882
+   | ^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(optimize_attribute)] to the crate attributes to enable
+
+error[E0658]: #[optimize] attribute is an unstable feature (see issue #54882)
+  --> $DIR/feature-gate-optimize_attribute.rs:22:1
+   |
+LL | #[optimize(banana)] //~ ERROR #54882
+   | ^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(optimize_attribute)] to the crate attributes to enable
+
+error[E0658]: #[optimize] attribute is an unstable feature (see issue #54882)
+  --> $DIR/feature-gate-optimize_attribute.rs:13:1
+   |
+LL | #[optimize(size)] //~ ERROR #54882
+   | ^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(optimize_attribute)] to the crate attributes to enable
+
+error[E0658]: #[optimize] attribute is an unstable feature (see issue #54882)
+  --> $DIR/feature-gate-optimize_attribute.rs:11:1
+   |
+LL | #![optimize(speed)] //~ ERROR #54882
+   | ^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(optimize_attribute)] to the crate attributes to enable
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/feature-gate-optimize_attribute.stderr
+++ b/src/test/ui/feature-gate-optimize_attribute.stderr
@@ -1,5 +1,5 @@
 error[E0658]: #[optimize] attribute is an unstable feature (see issue #54882)
-  --> $DIR/feature-gate-optimize_attribute.rs:16:1
+  --> $DIR/feature-gate-optimize_attribute.rs:7:1
    |
 LL | #[optimize(size)] //~ ERROR #54882
    | ^^^^^^^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL | #[optimize(size)] //~ ERROR #54882
    = help: add #![feature(optimize_attribute)] to the crate attributes to enable
 
 error[E0658]: #[optimize] attribute is an unstable feature (see issue #54882)
-  --> $DIR/feature-gate-optimize_attribute.rs:19:1
+  --> $DIR/feature-gate-optimize_attribute.rs:10:1
    |
 LL | #[optimize(speed)] //~ ERROR #54882
    | ^^^^^^^^^^^^^^^^^^
@@ -15,15 +15,15 @@ LL | #[optimize(speed)] //~ ERROR #54882
    = help: add #![feature(optimize_attribute)] to the crate attributes to enable
 
 error[E0658]: #[optimize] attribute is an unstable feature (see issue #54882)
-  --> $DIR/feature-gate-optimize_attribute.rs:22:1
+  --> $DIR/feature-gate-optimize_attribute.rs:13:1
    |
-LL | #[optimize(banana)] //~ ERROR #54882
+LL | #[optimize(banana)]
    | ^^^^^^^^^^^^^^^^^^^
    |
    = help: add #![feature(optimize_attribute)] to the crate attributes to enable
 
 error[E0658]: #[optimize] attribute is an unstable feature (see issue #54882)
-  --> $DIR/feature-gate-optimize_attribute.rs:13:1
+  --> $DIR/feature-gate-optimize_attribute.rs:4:1
    |
 LL | #[optimize(size)] //~ ERROR #54882
    | ^^^^^^^^^^^^^^^^^
@@ -31,13 +31,20 @@ LL | #[optimize(size)] //~ ERROR #54882
    = help: add #![feature(optimize_attribute)] to the crate attributes to enable
 
 error[E0658]: #[optimize] attribute is an unstable feature (see issue #54882)
-  --> $DIR/feature-gate-optimize_attribute.rs:11:1
+  --> $DIR/feature-gate-optimize_attribute.rs:2:1
    |
 LL | #![optimize(speed)] //~ ERROR #54882
    | ^^^^^^^^^^^^^^^^^^^
    |
    = help: add #![feature(optimize_attribute)] to the crate attributes to enable
 
-error: aborting due to 5 previous errors
+error[E0722]: invalid argument
+  --> $DIR/feature-gate-optimize_attribute.rs:13:12
+   |
+LL | #[optimize(banana)]
+   |            ^^^^^^
 
-For more information about this error, try `rustc --explain E0658`.
+error: aborting due to 6 previous errors
+
+Some errors occurred: E0658, E0722.
+For more information about an error, try `rustc --explain E0658`.

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -542,6 +542,8 @@ fn iter_header(testfile: &Path, cfg: Option<&str>, it: &mut dyn FnMut(&str)) {
         "#"
     };
 
+    // FIXME: would be nice to allow some whitespace between comment and brace :)
+    // It took me like 2 days to debug why compile-flags weren’t taken into account for my test :)
     let comment_with_brace = comment.to_string() + "[";
 
     let rdr = BufReader::new(File::open(testfile).unwrap());


### PR DESCRIPTION
This PR implements both `optimize(size)` and `optimize(speed)` attributes.

While the functionality itself works fine now, this PR is not yet complete: the code might be messy in places and, most importantly, the compiletest must be improved with functionality to run tests with custom optimization levels. Otherwise the new attribute cannot be tested properly. Oh, and not all of the RFC is implemented – attribute propagation is not implemented for example.

# TODO

* [x] Improve compiletest so that tests can be written;
* [x] Assign a proper error number (E9999 currently, no idea how to allocate a number properly);
* [ ] Perhaps reduce the duplication in LLVM attribute assignment code…