### PR TITLE
ci: Add Dockerfile for dist-powerpcspe-linux

### DIFF
--- a/src/ci/docker/disabled/dist-powerpcspe-linux/Dockerfile
+++ b/src/ci/docker/disabled/dist-powerpcspe-linux/Dockerfile
@@ -1,0 +1,26 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  g++ \
+  make \
+  file \
+  curl \
+  ca-certificates \
+  python2.7 \
+  git \
+  cmake \
+  sudo \
+  gdb \
+  xz-utils \
+  g++-powerpc-linux-gnuspe \
+  libssl-dev \
+  pkg-config
+
+
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
+
+ENV HOSTS=powerpc-unknown-linux-gnuspe
+
+ENV RUST_CONFIGURE_ARGS --enable-extended --disable-docs
+ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS


### PR DESCRIPTION
This adds the Dockerfile for cross-building Rust for the powerpcspe target. It's currently disabled.