### PR TITLE
Fixed the bug in bootstrap where --exclude was ignored for run-pass test

### DIFF
--- a/src/bootstrap/cache.rs
+++ b/src/bootstrap/cache.rs
@@ -286,4 +286,9 @@ impl Cache {
         v.sort_by_key(|&(a, _)| a);
         v
     }
+
+    #[cfg(test)]
+    pub fn contains<S: Step>(&self) -> bool {
+        self.0.borrow().contains_key(&TypeId::of::<S>())
+    }
 }

--- a/src/bootstrap/mk/Makefile.in
+++ b/src/bootstrap/mk/Makefile.in
@@ -85,7 +85,12 @@ check-stage2-T-arm-linux-androideabi-H-x86_64-unknown-linux-gnu:
 check-stage2-T-x86_64-unknown-linux-musl-H-x86_64-unknown-linux-gnu:
 	$(Q)$(BOOTSTRAP) test --target x86_64-unknown-linux-musl
 
-TESTS_IN_2 := src/test/run-pass src/test/compile-fail src/test/run-pass-fulldeps
+TESTS_IN_2 := \
+	src/test/ui \
+	src/test/run-pass \
+	src/test/compile-fail \
+	src/test/run-pass-fulldeps \
+	src/tools/linkchecker
 
 appveyor-subset-1:
 	$(Q)$(BOOTSTRAP) test $(TESTS_IN_2:%=--exclude %)


### PR DESCRIPTION
This should fix the 3 hour timeout on AppVeyor which happened a lot recently.

Additionally, further rebalanced the AppVeyor subsets by moving "ui" and "linkchecker" into Set 2. 

