### PR TITLE
Allow #[must_use] on traits

### DIFF
--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -183,7 +183,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedResults {
             for attr in cx.tcx.get_attrs(def_id).iter() {
                 if attr.check_name("must_use") {
                     let msg = format!("unused {}`{}`{} that must be used",
-                        descr_pre_path, descr_post_path, cx.tcx.item_path_str(def_id));
+                        descr_pre_path, cx.tcx.item_path_str(def_id), descr_post_path);
                     let mut err = cx.struct_span_lint(UNUSED_MUST_USE, sp, &msg);
                     // check for #[must_use = "..."]
                     if let Some(note) = attr.value_str() {

--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -68,7 +68,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedResults {
                 ty::Adt(def, _) => check_must_use(cx, def.did, s.span, "", ""),
                 ty::Opaque(def, _) => {
                     let mut must_use = false;
-                    for (predicate, _) in cx.tcx.predicates_of(def).predicates {
+                    for (predicate, _) in &cx.tcx.predicates_of(def).predicates {
                         if let ty::Predicate::Trait(ref poly_trait_predicate) = predicate {
                             let trait_ref = poly_trait_predicate.skip_binder().trait_ref;
                             if check_must_use(cx, trait_ref.def_id, s.span, "implementer of ", "") {

--- a/src/test/ui/lint/must_use-trait.rs
+++ b/src/test/ui/lint/must_use-trait.rs
@@ -1,0 +1,22 @@
+#![deny(unused_must_use)]
+
+#[must_use]
+trait Critical {}
+
+trait NotSoCritical {}
+
+trait DecidedlyUnimportant {}
+
+struct Anon;
+
+impl Critical for Anon {}
+impl NotSoCritical for Anon {}
+impl DecidedlyUnimportant for Anon {}
+
+fn get_critical() -> impl NotSoCritical + Critical + DecidedlyUnimportant {
+    Anon {}
+}
+
+fn main() {
+    get_critical(); //~ ERROR unused implementer of `Critical` that must be used
+}

--- a/src/test/ui/lint/must_use-trait.stderr
+++ b/src/test/ui/lint/must_use-trait.stderr
@@ -1,0 +1,14 @@
+error: unused implementer of `Critical` that must be used
+  --> $DIR/must_use-trait.rs:21:5
+   |
+LL |     get_critical(); //~ ERROR unused implementer of `Critical` that must be used
+   |     ^^^^^^^^^^^^^^^
+   |
+note: lint level defined here
+  --> $DIR/must_use-trait.rs:1:9
+   |
+LL | #![deny(unused_must_use)]
+   |         ^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Addresses https://github.com/rust-lang/rust/issues/55506, but we'll probably want to add it to some library traits like `Iterator` before the issue is considered fixed. Fixes https://github.com/rust-lang/rust/issues/51560.

`#[must_use]` is already permitted on traits, with no effect, so this seems like a bug fix, but I might be overlooking something. This currently warns for `impl Trait` or `dyn Trait` when the `Trait` is `#[must_use]` (although I don't think the latter is currently possible, so it's simply future-proofed).