### PR TITLE
Make "all possible cases" help message uniform with existing help messages

### DIFF
--- a/src/librustc_mir/hair/pattern/check_match.rs
+++ b/src/librustc_mir/hair/pattern/check_match.rs
@@ -238,8 +238,8 @@ impl<'a, 'tcx> MatchVisitor<'a, 'tcx> {
                                                         is non-empty",
                                                        pat_ty));
                     span_help!(&mut err, scrut.span,
-                               "Please ensure that all possible cases are being handled; \
-                                possibly adding wildcards or more match arms.");
+                               "ensure that all possible cases are being handled, \
+                                possibly by adding wildcards or more match arms");
                     err.emit();
                 }
                 // If the type *is* uninhabited, it's vacuously exhaustive

--- a/src/test/ui/error-codes/E0004-2.stderr
+++ b/src/test/ui/error-codes/E0004-2.stderr
@@ -4,7 +4,7 @@ error[E0004]: non-exhaustive patterns: type std::option::Option<i32> is non-empt
 LL |     match x { } //~ ERROR E0004
    |           ^
    |
-help: Please ensure that all possible cases are being handled; possibly adding wildcards or more match arms.
+help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
   --> $DIR/E0004-2.rs:14:11
    |
 LL |     match x { } //~ ERROR E0004

--- a/src/test/ui/issues/issue-3096-1.stderr
+++ b/src/test/ui/issues/issue-3096-1.stderr
@@ -4,7 +4,7 @@ error[E0004]: non-exhaustive patterns: type () is non-empty
 LL |     match () { } //~ ERROR non-exhaustive
    |           ^^
    |
-help: Please ensure that all possible cases are being handled; possibly adding wildcards or more match arms.
+help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
   --> $DIR/issue-3096-1.rs:12:11
    |
 LL |     match () { } //~ ERROR non-exhaustive

--- a/src/test/ui/issues/issue-3096-2.stderr
+++ b/src/test/ui/issues/issue-3096-2.stderr
@@ -4,7 +4,7 @@ error[E0004]: non-exhaustive patterns: type *const bottom is non-empty
 LL |     match x { } //~ ERROR non-exhaustive patterns
    |           ^
    |
-help: Please ensure that all possible cases are being handled; possibly adding wildcards or more match arms.
+help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
   --> $DIR/issue-3096-2.rs:15:11
    |
 LL |     match x { } //~ ERROR non-exhaustive patterns

--- a/src/test/ui/uninhabited/uninhabited-matches-feature-gated.stderr
+++ b/src/test/ui/uninhabited/uninhabited-matches-feature-gated.stderr
@@ -10,7 +10,7 @@ error[E0004]: non-exhaustive patterns: type &Void is non-empty
 LL |     let _ = match x {}; //~ ERROR non-exhaustive
    |                   ^
    |
-help: Please ensure that all possible cases are being handled; possibly adding wildcards or more match arms.
+help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
   --> $DIR/uninhabited-matches-feature-gated.rs:20:19
    |
 LL |     let _ = match x {}; //~ ERROR non-exhaustive
@@ -22,7 +22,7 @@ error[E0004]: non-exhaustive patterns: type (Void,) is non-empty
 LL |     let _ = match x {}; //~ ERROR non-exhaustive
    |                   ^
    |
-help: Please ensure that all possible cases are being handled; possibly adding wildcards or more match arms.
+help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
   --> $DIR/uninhabited-matches-feature-gated.rs:23:19
    |
 LL |     let _ = match x {}; //~ ERROR non-exhaustive
@@ -34,7 +34,7 @@ error[E0004]: non-exhaustive patterns: type [Void; 1] is non-empty
 LL |     let _ = match x {}; //~ ERROR non-exhaustive
    |                   ^
    |
-help: Please ensure that all possible cases are being handled; possibly adding wildcards or more match arms.
+help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
   --> $DIR/uninhabited-matches-feature-gated.rs:26:19
    |
 LL |     let _ = match x {}; //~ ERROR non-exhaustive


### PR DESCRIPTION
Specifically no capitalisation or trailing full stops.