### PR TITLE
Don't test issue-44056.rs on non-AVX hardware

### DIFF
--- a/src/test/ui/issues/issue-44056.rs
+++ b/src/test/ui/issues/issue-44056.rs
@@ -10,6 +10,7 @@
 
 // compile-pass
 // only-x86_64
+// gate-test-avx512_target_feature
 // no-prefer-dynamic
 // compile-flags: -Ctarget-feature=+avx -Clto
 


### PR DESCRIPTION
Otherwise it fails with SIGILL, e.g. on binet.debian.org:

- https://buildd.debian.org/status/fetch.php?pkg=rustc&arch=amd64&ver=1.30.0%2Bdfsg1-2&stamp=1541192488&raw=0
- https://buildd.debian.org/status/fetch.php?pkg=rustc&arch=amd64&ver=1.30.0%2Bdfsg1-1%7Eexp1&stamp=1540974588&raw=0