### PR TITLE
Use pinning for generators to make trait safe

### DIFF
--- a/src/doc/unstable-book/src/language-features/generators.md
+++ b/src/doc/unstable-book/src/language-features/generators.md
@@ -29,6 +29,7 @@ A syntactical example of a generator is:
 #![feature(generators, generator_trait)]
 
 use std::ops::{Generator, GeneratorState};
+use std::pin::Pin;
 
 fn main() {
     let mut generator = || {
@@ -36,11 +37,11 @@ fn main() {
         return "foo"
     };
 
-    match unsafe { generator.resume() } {
+    match Pin::new(&mut generator).resume() {
         GeneratorState::Yielded(1) => {}
         _ => panic!("unexpected value from resume"),
     }
-    match unsafe { generator.resume() } {
+    match Pin::new(&mut generator).resume() {
         GeneratorState::Complete("foo") => {}
         _ => panic!("unexpected value from resume"),
     }
@@ -60,6 +61,7 @@ prints all numbers in order:
 #![feature(generators, generator_trait)]
 
 use std::ops::Generator;
+use std::pin::Pin;
 
 fn main() {
     let mut generator = || {
@@ -69,9 +71,9 @@ fn main() {
     };
 
     println!("1");
-    unsafe { generator.resume() };
+    Pin::new(&mut generator).resume();
     println!("3");
-    unsafe { generator.resume() };
+    Pin::new(&mut generator).resume();
     println!("5");
 }
 ```
@@ -86,13 +88,14 @@ Feedback on the design and usage is always appreciated!
 The `Generator` trait in `std::ops` currently looks like:
 
 ```
-# #![feature(generator_trait)]
+# #![feature(arbitrary_self_types, generator_trait)]
 # use std::ops::GeneratorState;
+# use std::pin::Pin;
 
 pub trait Generator {
     type Yield;
     type Return;
-    unsafe fn resume(&mut self) -> GeneratorState<Self::Yield, Self::Return>;
+    fn resume(self: Pin<&mut Self>) -> GeneratorState<Self::Yield, Self::Return>;
 }
 ```
 
@@ -167,6 +170,7 @@ Let's take a look at an example to see what's going on here:
 #![feature(generators, generator_trait)]
 
 use std::ops::Generator;
+use std::pin::Pin;
 
 fn main() {
     let ret = "foo";
@@ -175,17 +179,18 @@ fn main() {
         return ret
     };
 
-    unsafe { generator.resume() };
-    unsafe { generator.resume() };
+    Pin::new(&mut generator).resume();
+    Pin::new(&mut generator).resume();
 }
 ```
 
 This generator literal will compile down to something similar to:
 
 ```rust
-#![feature(generators, generator_trait)]
+#![feature(arbitrary_self_types, generators, generator_trait)]
 
 use std::ops::{Generator, GeneratorState};
+use std::pin::Pin;
 
 fn main() {
     let ret = "foo";
@@ -200,9 +205,9 @@ fn main() {
             type Yield = i32;
             type Return = &'static str;
 
-            unsafe fn resume(&mut self) -> GeneratorState<i32, &'static str> {
+            fn resume(mut self: Pin<&mut Self>) -> GeneratorState<i32, &'static str> {
                 use std::mem;
-                match mem::replace(self, __Generator::Done) {
+                match mem::replace(&mut *self, __Generator::Done) {
                     __Generator::Start(s) => {
                         *self = __Generator::Yield1(s);
                         GeneratorState::Yielded(1)
@@ -223,8 +228,8 @@ fn main() {
         __Generator::Start(ret)
     };
 
-    unsafe { generator.resume() };
-    unsafe { generator.resume() };
+    Pin::new(&mut generator).resume();
+    Pin::new(&mut generator).resume();
 }
 ```
 

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -882,6 +882,16 @@ impl<G: ?Sized + Generator + Unpin> Generator for Box<G> {
     }
 }
 
+#[unstable(feature = "generator_trait", issue = "43122")]
+impl<G: ?Sized + Generator> Generator for Pin<Box<G>> {
+    type Yield = G::Yield;
+    type Return = G::Return;
+
+    fn resume(mut self: Pin<&mut Self>) -> GeneratorState<Self::Yield, Self::Return> {
+        G::resume((*self).as_mut())
+    }
+}
+
 #[unstable(feature = "futures_api", issue = "50547")]
 impl<F: ?Sized + Future + Unpin> Future for Box<F> {
     type Output = F::Output;

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -873,13 +873,12 @@ impl<T: ?Sized> AsMut<T> for Box<T> {
 impl<T: ?Sized> Unpin for Box<T> { }
 
 #[unstable(feature = "generator_trait", issue = "43122")]
-impl<T> Generator for Box<T>
-    where T: Generator + ?Sized
-{
-    type Yield = T::Yield;
-    type Return = T::Return;
-    unsafe fn resume(&mut self) -> GeneratorState<Self::Yield, Self::Return> {
-        (**self).resume()
+impl<G: ?Sized + Generator + Unpin> Generator for Box<G> {
+    type Yield = G::Yield;
+    type Return = G::Return;
+
+    fn resume(mut self: Pin<&mut Self>) -> GeneratorState<Self::Yield, Self::Return> {
+        G::resume(Pin::new(&mut *self))
     }
 }
 

--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -627,6 +627,7 @@ unsafe impl<T: ?Sized> Freeze for &mut T {}
 /// [`Pin`]: ../pin/struct.Pin.html
 /// [`pin module`]: ../../std/pin/index.html
 #[stable(feature = "pin", since = "1.33.0")]
+#[cfg_attr(not(stage0), lang = "unpin")]
 pub auto trait Unpin {}
 
 /// A marker type which does not implement `Unpin`.

--- a/src/libcore/pin.rs
+++ b/src/libcore/pin.rs
@@ -117,6 +117,7 @@ use ops::{Deref, DerefMut, Receiver, CoerceUnsized, DispatchFromDyn};
 // implementations, are allowed because they all only use `&P`, so they cannot move
 // the value behind `pointer`.
 #[stable(feature = "pin", since = "1.33.0")]
+#[cfg_attr(not(stage0), lang = "pin")]
 #[fundamental]
 #[repr(transparent)]
 #[derive(Copy, Clone, Hash, Eq, Ord)]

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -299,6 +299,7 @@ language_item_table! {
 
     GeneratorStateLangItem,      "generator_state",    gen_state,               Target::Enum;
     GeneratorTraitLangItem,      "generator",          gen_trait,               Target::Trait;
+    UnpinTraitLangItem,          "unpin",              unpin_trait,             Target::Trait;
 
     EqTraitLangItem,             "eq",                 eq_trait,                Target::Trait;
     PartialOrdTraitLangItem,     "partial_ord",        partial_ord_trait,       Target::Trait;

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -300,6 +300,7 @@ language_item_table! {
     GeneratorStateLangItem,      "generator_state",    gen_state,               Target::Enum;
     GeneratorTraitLangItem,      "generator",          gen_trait,               Target::Trait;
     UnpinTraitLangItem,          "unpin",              unpin_trait,             Target::Trait;
+    PinTypeLangItem,             "pin",                pin_type,                Target::Struct;
 
     EqTraitLangItem,             "eq",                 eq_trait,                Target::Trait;
     PartialOrdTraitLangItem,     "partial_ord",        partial_ord_trait,       Target::Trait;

--- a/src/librustc/traits/select.rs
+++ b/src/librustc/traits/select.rs
@@ -2017,12 +2017,24 @@ impl<'cx, 'gcx, 'tcx> SelectionContext<'cx, 'gcx, 'tcx> {
                     // the auto impl might apply, we don't know
                     candidates.ambiguous = true;
                 }
-                ty::Generator(_, _, hir::GeneratorMovability::Static)
+                ty::Generator(_, _, movability)
                     if self.tcx().lang_items().unpin_trait() == Some(def_id) =>
                 {
-                    // Immovable generators are never `Unpin`, so suppress the
-                    // normal auto-impl candidate for it.
+                    match movability {
+                        hir::GeneratorMovability::Static => {
+                            // Immovable generators are never `Unpin`, so
+                            // suppress the normal auto-impl candidate for it.
+                        }
+                        hir::GeneratorMovability::Movable => {
+                            // Movable generators are always `Unpin`, so add an
+                            // unconditional builtin candidate.
+                            candidates.vec.push(BuiltinCandidate {
+                                has_nested: false,
+                            });
+                        }
+                    }
                 }
+
                 _ => candidates.vec.push(AutoImplCandidate(def_id.clone())),
             }
         }

--- a/src/librustc/traits/select.rs
+++ b/src/librustc/traits/select.rs
@@ -2017,6 +2017,12 @@ impl<'cx, 'gcx, 'tcx> SelectionContext<'cx, 'gcx, 'tcx> {
                     // the auto impl might apply, we don't know
                     candidates.ambiguous = true;
                 }
+                ty::Generator(_, _, hir::GeneratorMovability::Static)
+                    if self.tcx().lang_items().unpin_trait() == Some(def_id) =>
+                {
+                    // Immovable generators are never `Unpin`, so suppress the
+                    // normal auto-impl candidate for it.
+                }
                 _ => candidates.vec.push(AutoImplCandidate(def_id.clone())),
             }
         }

--- a/src/librustc/ty/instance.rs
+++ b/src/librustc/ty/instance.rs
@@ -76,6 +76,11 @@ impl<'a, 'tcx> Instance<'tcx> {
                 let env_region = ty::ReLateBound(ty::INNERMOST, ty::BrEnv);
                 let env_ty = tcx.mk_mut_ref(tcx.mk_region(env_region), ty);
 
+                let pin_did = tcx.lang_items().pin_type().unwrap();
+                let pin_adt_ref = tcx.adt_def(pin_did);
+                let pin_substs = tcx.intern_substs(&[env_ty.into()]);
+                let env_ty = tcx.mk_adt(pin_adt_ref, pin_substs);
+
                 sig.map_bound(|sig| {
                     let state_did = tcx.lang_items().gen_state().unwrap();
                     let state_adt_ref = tcx.adt_def(state_did);

--- a/src/libstd/future.rs
+++ b/src/libstd/future.rs
@@ -33,7 +33,9 @@ impl<T: Generator<Yield = ()>> !Unpin for GenFuture<T> {}
 impl<T: Generator<Yield = ()>> Future for GenFuture<T> {
     type Output = T::Return;
     fn poll(self: Pin<&mut Self>, lw: &LocalWaker) -> Poll<Self::Output> {
-        set_task_waker(lw, || match unsafe { Pin::get_unchecked_mut(self).0.resume() } {
+        // Safe because we're !Unpin + !Drop mapping to a ?Unpin value
+        let gen = unsafe { Pin::map_unchecked_mut(self, |s| &mut s.0) };
+        set_task_waker(lw, || match gen.resume() {
             GeneratorState::Yielded(()) => Poll::Pending,
             GeneratorState::Complete(x) => Poll::Ready(x),
         })

--- a/src/test/debuginfo/generators.rs
+++ b/src/test/debuginfo/generators.rs
@@ -1,0 +1,36 @@
+// min-lldb-version: 310
+
+// compile-flags:-g
+
+// === GDB TESTS ===================================================================================
+
+// gdb-command:run
+// gdb-command:print a
+// gdb-check:$1 = 5
+
+// === LLDB TESTS ==================================================================================
+
+// lldb-command:run
+// lldb-command:print a
+// lldbg-check:(int) $0 = 5
+// lldbr-check:(int) a = 5
+
+#![feature(omit_gdb_pretty_printer_section, generators, generator_trait, pin)]
+#![omit_gdb_pretty_printer_section]
+
+use std::ops::Generator;
+use std::pin::Pin;
+
+fn main() {
+    let mut a = 5;
+    let mut b = || {
+        yield;
+        _zzz(); // #break
+        a = 6;
+    };
+    Pin::new(&mut b).resume();
+    Pin::new(&mut b).resume();
+    _zzz(); // #break
+}
+
+fn _zzz() {()}

--- a/src/test/run-pass/drop/dynamic-drop.rs
+++ b/src/test/run-pass/drop/dynamic-drop.rs
@@ -12,6 +12,7 @@
 use std::cell::{Cell, RefCell};
 use std::ops::Generator;
 use std::panic;
+use std::pin::Pin;
 use std::usize;
 
 struct InjectedFailure;
@@ -172,7 +173,7 @@ fn generator(a: &Allocator, run_count: usize) {
          );
     };
     for _ in 0..run_count {
-        unsafe { gen.resume(); }
+        Pin::new(&mut gen).resume();
     }
 }
 

--- a/src/test/run-pass/generator/auxiliary/xcrate.rs
+++ b/src/test/run-pass/generator/auxiliary/xcrate.rs
@@ -1,5 +1,6 @@
 #![feature(generators, generator_trait)]
 
+use std::marker::Unpin;
 use std::ops::Generator;
 
 pub fn foo() -> impl Generator<Yield = (), Return = ()> {
@@ -10,7 +11,7 @@ pub fn foo() -> impl Generator<Yield = (), Return = ()> {
     }
 }
 
-pub fn bar<T: 'static>(t: T) -> Box<Generator<Yield = T, Return = ()>> {
+pub fn bar<T: Unpin + 'static>(t: T) -> Box<Generator<Yield = T, Return = ()> + Unpin> {
     Box::new(|| {
         yield t;
     })

--- a/src/test/run-pass/generator/auxiliary/xcrate.rs
+++ b/src/test/run-pass/generator/auxiliary/xcrate.rs
@@ -11,7 +11,7 @@ pub fn foo() -> impl Generator<Yield = (), Return = ()> {
     }
 }
 
-pub fn bar<T: Unpin + 'static>(t: T) -> Box<Generator<Yield = T, Return = ()> + Unpin> {
+pub fn bar<T: 'static>(t: T) -> Box<Generator<Yield = T, Return = ()> + Unpin> {
     Box::new(|| {
         yield t;
     })

--- a/src/test/run-pass/generator/conditional-drop.rs
+++ b/src/test/run-pass/generator/conditional-drop.rs
@@ -3,6 +3,7 @@
 #![feature(generators, generator_trait)]
 
 use std::ops::Generator;
+use std::pin::Pin;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 static A: AtomicUsize = AtomicUsize::new(0);
@@ -34,9 +35,9 @@ fn t1() {
     };
 
     let n = A.load(Ordering::SeqCst);
-    unsafe { a.resume() };
+    Pin::new(&mut a).resume();
     assert_eq!(A.load(Ordering::SeqCst), n + 1);
-    unsafe { a.resume() };
+    Pin::new(&mut a).resume();
     assert_eq!(A.load(Ordering::SeqCst), n + 1);
 }
 
@@ -50,8 +51,8 @@ fn t2() {
     };
 
     let n = A.load(Ordering::SeqCst);
-    unsafe { a.resume() };
+    Pin::new(&mut a).resume();
     assert_eq!(A.load(Ordering::SeqCst), n);
-    unsafe { a.resume() };
+    Pin::new(&mut a).resume();
     assert_eq!(A.load(Ordering::SeqCst), n + 1);
 }

--- a/src/test/run-pass/generator/control-flow.rs
+++ b/src/test/run-pass/generator/control-flow.rs
@@ -2,13 +2,15 @@
 
 #![feature(generators, generator_trait)]
 
+use std::marker::Unpin;
 use std::ops::{GeneratorState, Generator};
+use std::pin::Pin;
 
 fn finish<T>(mut amt: usize, mut t: T) -> T::Return
-    where T: Generator<Yield = ()>
+    where T: Generator<Yield = ()> + Unpin,
 {
     loop {
-        match unsafe { t.resume() } {
+        match Pin::new(&mut t).resume() {
             GeneratorState::Yielded(()) => amt = amt.checked_sub(1).unwrap(),
             GeneratorState::Complete(ret) => {
                 assert_eq!(amt, 0);

--- a/src/test/run-pass/generator/drop-env.rs
+++ b/src/test/run-pass/generator/drop-env.rs
@@ -3,6 +3,7 @@
 #![feature(generators, generator_trait)]
 
 use std::ops::Generator;
+use std::pin::Pin;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 static A: AtomicUsize = AtomicUsize::new(0);
@@ -29,7 +30,7 @@ fn t1() {
     };
 
     let n = A.load(Ordering::SeqCst);
-    drop(unsafe { foo.resume() });
+    drop(Pin::new(&mut foo).resume());
     assert_eq!(A.load(Ordering::SeqCst), n);
     drop(foo);
     assert_eq!(A.load(Ordering::SeqCst), n + 1);
@@ -42,7 +43,7 @@ fn t2() {
     };
 
     let n = A.load(Ordering::SeqCst);
-    drop(unsafe { foo.resume() });
+    drop(Pin::new(&mut foo).resume());
     assert_eq!(A.load(Ordering::SeqCst), n + 1);
     drop(foo);
     assert_eq!(A.load(Ordering::SeqCst), n + 1);

--- a/src/test/run-pass/generator/issue-44197.rs
+++ b/src/test/run-pass/generator/issue-44197.rs
@@ -3,6 +3,7 @@
 #![feature(generators, generator_trait)]
 
 use std::ops::{ Generator, GeneratorState };
+use std::pin::Pin;
 
 fn foo(_: &str) -> String {
     String::new()
@@ -27,8 +28,6 @@ fn bar2(baz: String) -> impl Generator<Yield = String, Return = ()> {
 }
 
 fn main() {
-    unsafe {
-        assert_eq!(bar(String::new()).resume(), GeneratorState::Yielded(String::new()));
-        assert_eq!(bar2(String::new()).resume(), GeneratorState::Complete(()));
-    }
+    assert_eq!(Pin::new(&mut bar(String::new())).resume(), GeneratorState::Yielded(String::new()));
+    assert_eq!(Pin::new(&mut bar2(String::new())).resume(), GeneratorState::Complete(()));
 }

--- a/src/test/run-pass/generator/iterator-count.rs
+++ b/src/test/run-pass/generator/iterator-count.rs
@@ -2,24 +2,26 @@
 
 #![feature(generators, generator_trait)]
 
+use std::marker::Unpin;
 use std::ops::{GeneratorState, Generator};
+use std::pin::Pin;
 
 struct W<T>(T);
 
 // This impl isn't safe in general, but the generator used in this test is movable
 // so it won't cause problems.
-impl<T: Generator<Return = ()>> Iterator for W<T> {
+impl<T: Generator<Return = ()> + Unpin> Iterator for W<T> {
     type Item = T::Yield;
 
     fn next(&mut self) -> Option<Self::Item> {
-        match unsafe { self.0.resume() } {
+        match Pin::new(&mut self.0).resume() {
             GeneratorState::Complete(..) => None,
             GeneratorState::Yielded(v) => Some(v),
         }
     }
 }
 
-fn test() -> impl Generator<Return=(), Yield=u8> {
+fn test() -> impl Generator<Return=(), Yield=u8> + Unpin {
     || {
         for i in 1..6 {
             yield i

--- a/src/test/run-pass/generator/live-upvar-across-yield.rs
+++ b/src/test/run-pass/generator/live-upvar-across-yield.rs
@@ -3,11 +3,12 @@
 #![feature(generators, generator_trait)]
 
 use std::ops::Generator;
+use std::pin::Pin;
 
 fn main() {
     let b = |_| 3;
     let mut a = || {
         b(yield);
     };
-    unsafe { a.resume() };
+    Pin::new(&mut a).resume();
 }

--- a/src/test/run-pass/generator/nested_generators.rs
+++ b/src/test/run-pass/generator/nested_generators.rs
@@ -1,10 +1,9 @@
 // run-pass
 
-#![feature(generators)]
-#![feature(generator_trait)]
+#![feature(generators, generator_trait)]
 
-use std::ops::Generator;
-use std::ops::GeneratorState;
+use std::ops::{Generator, GeneratorState};
+use std::pin::Pin;
 
 fn main() {
     let _generator = || {
@@ -12,7 +11,7 @@ fn main() {
             yield 2;
         };
 
-        match unsafe { sub_generator.resume() } {
+        match Pin::new(&mut sub_generator).resume() {
             GeneratorState::Yielded(x) => {
                 yield x;
             }

--- a/src/test/run-pass/generator/non-static-is-unpin.rs
+++ b/src/test/run-pass/generator/non-static-is-unpin.rs
@@ -1,0 +1,18 @@
+// run-pass
+
+#![feature(generators, generator_trait)]
+
+use std::marker::{PhantomPinned, Unpin};
+
+fn assert_unpin<G: Unpin>(_: G) {
+}
+
+fn main() {
+    // Even though this generator holds a `PhantomPinned` in its environment, it
+    // remains `Unpin`.
+    assert_unpin(|| {
+        let pinned = PhantomPinned;
+        yield;
+        drop(pinned);
+    });
+}

--- a/src/test/run-pass/generator/panic-drops.rs
+++ b/src/test/run-pass/generator/panic-drops.rs
@@ -6,6 +6,7 @@
 
 use std::ops::Generator;
 use std::panic;
+use std::pin::Pin;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 static A: AtomicUsize = AtomicUsize::new(0);
@@ -34,7 +35,7 @@ fn main() {
 
     assert_eq!(A.load(Ordering::SeqCst), 0);
     let res = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-        unsafe { foo.resume() }
+        Pin::new(&mut foo).resume()
     }));
     assert!(res.is_err());
     assert_eq!(A.load(Ordering::SeqCst), 1);
@@ -49,7 +50,7 @@ fn main() {
 
     assert_eq!(A.load(Ordering::SeqCst), 1);
     let res = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-        unsafe { foo.resume() }
+        Pin::new(&mut foo).resume()
     }));
     assert!(res.is_err());
     assert_eq!(A.load(Ordering::SeqCst), 1);

--- a/src/test/run-pass/generator/panic-safe.rs
+++ b/src/test/run-pass/generator/panic-safe.rs
@@ -5,6 +5,7 @@
 #![feature(generators, generator_trait)]
 
 use std::ops::Generator;
+use std::pin::Pin;
 use std::panic;
 
 fn main() {
@@ -16,13 +17,13 @@ fn main() {
     };
 
     let res = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-        unsafe { foo.resume() }
+        Pin::new(&mut foo).resume()
     }));
     assert!(res.is_err());
 
     for _ in 0..10 {
         let res = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-            unsafe { foo.resume() }
+            Pin::new(&mut foo).resume()
         }));
         assert!(res.is_err());
     }

--- a/src/test/run-pass/generator/pin-box-generator.rs
+++ b/src/test/run-pass/generator/pin-box-generator.rs
@@ -1,0 +1,13 @@
+// run-pass
+
+#![feature(generators, generator_trait)]
+
+use std::ops::Generator;
+
+fn assert_generator<G: Generator>(_: G) {
+}
+
+fn main() {
+    assert_generator(static || yield);
+    assert_generator(Box::pin(static || yield));
+}

--- a/src/test/run-pass/generator/resume-after-return.rs
+++ b/src/test/run-pass/generator/resume-after-return.rs
@@ -5,6 +5,7 @@
 #![feature(generators, generator_trait)]
 
 use std::ops::{GeneratorState, Generator};
+use std::pin::Pin;
 use std::panic;
 
 fn main() {
@@ -15,12 +16,12 @@ fn main() {
         yield;
     };
 
-    match unsafe { foo.resume() } {
+    match Pin::new(&mut foo).resume() {
         GeneratorState::Complete(()) => {}
         s => panic!("bad state: {:?}", s),
     }
 
-    match panic::catch_unwind(move || unsafe { foo.resume() }) {
+    match panic::catch_unwind(move || Pin::new(&mut foo).resume()) {
         Ok(_) => panic!("generator successfully resumed"),
         Err(_) => {}
     }

--- a/src/test/run-pass/generator/smoke.rs
+++ b/src/test/run-pass/generator/smoke.rs
@@ -6,6 +6,7 @@
 #![feature(generators, generator_trait)]
 
 use std::ops::{GeneratorState, Generator};
+use std::pin::Pin;
 use std::thread;
 
 #[test]
@@ -16,7 +17,7 @@ fn simple() {
         }
     };
 
-    match unsafe { foo.resume() } {
+    match Pin::new(&mut foo).resume() {
         GeneratorState::Complete(()) => {}
         s => panic!("bad state: {:?}", s),
     }
@@ -32,7 +33,7 @@ fn return_capture() {
         a
     };
 
-    match unsafe { foo.resume() } {
+    match Pin::new(&mut foo).resume() {
         GeneratorState::Complete(ref s) if *s == "foo" => {}
         s => panic!("bad state: {:?}", s),
     }
@@ -44,11 +45,11 @@ fn simple_yield() {
         yield;
     };
 
-    match unsafe { foo.resume() } {
+    match Pin::new(&mut foo).resume() {
         GeneratorState::Yielded(()) => {}
         s => panic!("bad state: {:?}", s),
     }
-    match unsafe { foo.resume() } {
+    match Pin::new(&mut foo).resume() {
         GeneratorState::Complete(()) => {}
         s => panic!("bad state: {:?}", s),
     }
@@ -61,11 +62,11 @@ fn yield_capture() {
         yield b;
     };
 
-    match unsafe { foo.resume() } {
+    match Pin::new(&mut foo).resume() {
         GeneratorState::Yielded(ref s) if *s == "foo" => {}
         s => panic!("bad state: {:?}", s),
     }
-    match unsafe { foo.resume() } {
+    match Pin::new(&mut foo).resume() {
         GeneratorState::Complete(()) => {}
         s => panic!("bad state: {:?}", s),
     }
@@ -78,11 +79,11 @@ fn simple_yield_value() {
         return String::from("foo")
     };
 
-    match unsafe { foo.resume() } {
+    match Pin::new(&mut foo).resume() {
         GeneratorState::Yielded(ref s) if *s == "bar" => {}
         s => panic!("bad state: {:?}", s),
     }
-    match unsafe { foo.resume() } {
+    match Pin::new(&mut foo).resume() {
         GeneratorState::Complete(ref s) if *s == "foo" => {}
         s => panic!("bad state: {:?}", s),
     }
@@ -96,11 +97,11 @@ fn return_after_yield() {
         return a
     };
 
-    match unsafe { foo.resume() } {
+    match Pin::new(&mut foo).resume() {
         GeneratorState::Yielded(()) => {}
         s => panic!("bad state: {:?}", s),
     }
-    match unsafe { foo.resume() } {
+    match Pin::new(&mut foo).resume() {
         GeneratorState::Complete(ref s) if *s == "foo" => {}
         s => panic!("bad state: {:?}", s),
     }
@@ -148,11 +149,11 @@ fn send_and_sync() {
 fn send_over_threads() {
     let mut foo = || { yield };
     thread::spawn(move || {
-        match unsafe { foo.resume() } {
+        match Pin::new(&mut foo).resume() {
             GeneratorState::Yielded(()) => {}
             s => panic!("bad state: {:?}", s),
         }
-        match unsafe { foo.resume() } {
+        match Pin::new(&mut foo).resume() {
             GeneratorState::Complete(()) => {}
             s => panic!("bad state: {:?}", s),
         }
@@ -161,11 +162,11 @@ fn send_over_threads() {
     let a = String::from("a");
     let mut foo = || { yield a };
     thread::spawn(move || {
-        match unsafe { foo.resume() } {
+        match Pin::new(&mut foo).resume() {
             GeneratorState::Yielded(ref s) if *s == "a" => {}
             s => panic!("bad state: {:?}", s),
         }
-        match unsafe { foo.resume() } {
+        match Pin::new(&mut foo).resume() {
             GeneratorState::Complete(()) => {}
             s => panic!("bad state: {:?}", s),
         }

--- a/src/test/run-pass/generator/static-generators.rs
+++ b/src/test/run-pass/generator/static-generators.rs
@@ -2,6 +2,7 @@
 
 #![feature(generators, generator_trait)]
 
+use std::pin::Pin;
 use std::ops::{Generator, GeneratorState};
 
 fn main() {
@@ -11,8 +12,9 @@ fn main() {
         yield;
         assert_eq!(b as *const _, &a as *const _);
     };
-    unsafe {
-        assert_eq!(generator.resume(), GeneratorState::Yielded(()));
-        assert_eq!(generator.resume(), GeneratorState::Complete(()));
-    }
+    // Safety: We shadow the original generator variable so have no safe API to
+    // move it after this point.
+    let mut generator = unsafe { Pin::new_unchecked(&mut generator) };
+    assert_eq!(generator.as_mut().resume(), GeneratorState::Yielded(()));
+    assert_eq!(generator.as_mut().resume(), GeneratorState::Complete(()));
 }

--- a/src/test/run-pass/generator/xcrate-reachable.rs
+++ b/src/test/run-pass/generator/xcrate-reachable.rs
@@ -7,7 +7,8 @@
 extern crate xcrate_reachable as foo;
 
 use std::ops::Generator;
+use std::pin::Pin;
 
 fn main() {
-    unsafe { foo::foo().resume(); }
+    Pin::new(&mut foo::foo()).resume();
 }

--- a/src/test/run-pass/generator/xcrate.rs
+++ b/src/test/run-pass/generator/xcrate.rs
@@ -7,22 +7,23 @@
 extern crate xcrate;
 
 use std::ops::{GeneratorState, Generator};
+use std::pin::Pin;
 
 fn main() {
     let mut foo = xcrate::foo();
 
-    match unsafe { foo.resume() } {
+    match Pin::new(&mut foo).resume() {
         GeneratorState::Complete(()) => {}
         s => panic!("bad state: {:?}", s),
     }
 
     let mut foo = xcrate::bar(3);
 
-    match unsafe { foo.resume() } {
+    match Pin::new(&mut foo).resume() {
         GeneratorState::Yielded(3) => {}
         s => panic!("bad state: {:?}", s),
     }
-    match unsafe { foo.resume() } {
+    match Pin::new(&mut foo).resume() {
         GeneratorState::Complete(()) => {}
         s => panic!("bad state: {:?}", s),
     }

--- a/src/test/ui/generator/borrowing.nll.stderr
+++ b/src/test/ui/generator/borrowing.nll.stderr
@@ -1,12 +1,12 @@
 error[E0597]: `a` does not live long enough
-  --> $DIR/borrowing.rs:8:29
+  --> $DIR/borrowing.rs:9:33
    |
-LL |         unsafe { (|| yield &a).resume() }
-   |                  -----------^-
-   |                  ||         |
-   |                  ||         borrowed value does not live long enough
-   |                  |value captured here by generator
-   |                  a temporary with access to the borrow is created here ...
+LL |         Pin::new(&mut || yield &a).resume()
+   |                       ----------^
+   |                       |         |
+   |                       |         borrowed value does not live long enough
+   |                       value captured here by generator
+   |                       a temporary with access to the borrow is created here ...
 LL |         //~^ ERROR: `a` does not live long enough
 LL |     };
    |     -- ... and the borrow might be used here, when that temporary is dropped and runs the destructor for generator
@@ -16,7 +16,7 @@ LL |     };
    = note: The temporary is part of an expression at the end of a block. Consider forcing this temporary to be dropped sooner, before the block's local variables are dropped. For example, you could save the expression's value in a new local variable `x` and then make `x` be the expression at the end of the block.
 
 error[E0597]: `a` does not live long enough
-  --> $DIR/borrowing.rs:15:20
+  --> $DIR/borrowing.rs:16:20
    |
 LL |     let _b = {
    |         -- borrow later stored here

--- a/src/test/ui/generator/borrowing.rs
+++ b/src/test/ui/generator/borrowing.rs
@@ -1,11 +1,12 @@
 #![feature(generators, generator_trait)]
 
 use std::ops::Generator;
+use std::pin::Pin;
 
 fn main() {
     let _b = {
         let a = 3;
-        unsafe { (|| yield &a).resume() }
+        Pin::new(&mut || yield &a).resume()
         //~^ ERROR: `a` does not live long enough
     };
 

--- a/src/test/ui/generator/borrowing.stderr
+++ b/src/test/ui/generator/borrowing.stderr
@@ -1,10 +1,10 @@
 error[E0597]: `a` does not live long enough
-  --> $DIR/borrowing.rs:8:29
+  --> $DIR/borrowing.rs:9:33
    |
-LL |         unsafe { (|| yield &a).resume() }
-   |                   --        ^ borrowed value does not live long enough
-   |                   |
-   |                   capture occurs here
+LL |         Pin::new(&mut || yield &a).resume()
+   |                       --        ^ borrowed value does not live long enough
+   |                       |
+   |                       capture occurs here
 LL |         //~^ ERROR: `a` does not live long enough
 LL |     };
    |     - borrowed value only lives until here
@@ -13,7 +13,7 @@ LL | }
    | - borrowed value needs to live until here
 
 error[E0597]: `a` does not live long enough
-  --> $DIR/borrowing.rs:15:20
+  --> $DIR/borrowing.rs:16:20
    |
 LL |         || {
    |         -- capture occurs here

--- a/src/test/ui/generator/dropck.nll.stderr
+++ b/src/test/ui/generator/dropck.nll.stderr
@@ -1,5 +1,5 @@
 error[E0597]: `*cell` does not live long enough
-  --> $DIR/dropck.rs:9:40
+  --> $DIR/dropck.rs:10:40
    |
 LL |     let ref_ = Box::leak(Box::new(Some(cell.borrow_mut())));
    |                                        ^^^^ borrowed value does not live long enough
@@ -13,7 +13,7 @@ LL | }
    = note: values in a scope are dropped in the opposite order they are defined
 
 error[E0597]: `ref_` does not live long enough
-  --> $DIR/dropck.rs:14:18
+  --> $DIR/dropck.rs:15:18
    |
 LL |     gen = || {
    |           -- value captured here by generator

--- a/src/test/ui/generator/dropck.rs
+++ b/src/test/ui/generator/dropck.rs
@@ -2,6 +2,7 @@
 
 use std::cell::RefCell;
 use std::ops::Generator;
+use std::pin::Pin;
 
 fn main() {
     let (mut gen, cell);
@@ -14,6 +15,6 @@ fn main() {
         let _d = ref_.take(); //~ ERROR `ref_` does not live long enough
         yield;
     };
-    unsafe { gen.resume(); }
+    Pin::new(&mut gen).resume();
     // drops the RefCell and then the Ref, leading to use-after-free
 }

--- a/src/test/ui/generator/dropck.stderr
+++ b/src/test/ui/generator/dropck.stderr
@@ -1,5 +1,5 @@
 error[E0597]: `*cell` does not live long enough
-  --> $DIR/dropck.rs:9:40
+  --> $DIR/dropck.rs:10:40
    |
 LL |     let ref_ = Box::leak(Box::new(Some(cell.borrow_mut())));
    |                                        ^^^^ borrowed value does not live long enough
@@ -10,7 +10,7 @@ LL | }
    = note: values in a scope are dropped in the opposite order they are created
 
 error[E0597]: `ref_` does not live long enough
-  --> $DIR/dropck.rs:14:18
+  --> $DIR/dropck.rs:15:18
    |
 LL |     gen = || {
    |           -- capture occurs here

--- a/src/test/ui/generator/generator-region-requirements.ast.stderr
+++ b/src/test/ui/generator/generator-region-requirements.ast.stderr
@@ -1,5 +1,5 @@
 error[E0621]: explicit lifetime required in the type of `x`
-  --> $DIR/generator-region-requirements.rs:15:51
+  --> $DIR/generator-region-requirements.rs:16:51
    |
 LL | fn dangle(x: &mut i32) -> &'static mut i32 {
    |              -------- help: add explicit lifetime `'static` to the type of `x`: `&'static mut i32`

--- a/src/test/ui/generator/generator-region-requirements.nll.stderr
+++ b/src/test/ui/generator/generator-region-requirements.nll.stderr
@@ -1,5 +1,5 @@
 error[E0621]: explicit lifetime required in the type of `x`
-  --> $DIR/generator-region-requirements.rs:15:51
+  --> $DIR/generator-region-requirements.rs:16:51
    |
 LL | fn dangle(x: &mut i32) -> &'static mut i32 {
    |              -------- help: add explicit lifetime `'static` to the type of `x`: `&'static mut i32`

--- a/src/test/ui/generator/generator-region-requirements.rs
+++ b/src/test/ui/generator/generator-region-requirements.rs
@@ -4,6 +4,7 @@
 #![feature(generators, generator_trait)]
 #![cfg_attr(nll, feature(nll))]
 use std::ops::{Generator, GeneratorState};
+use std::pin::Pin;
 
 fn dangle(x: &mut i32) -> &'static mut i32 {
     let mut g = || {
@@ -11,7 +12,7 @@ fn dangle(x: &mut i32) -> &'static mut i32 {
         x
     };
     loop {
-        match unsafe { g.resume() } {
+        match Pin::new(&mut g).resume() {
             GeneratorState::Complete(c) => return c,
 //[nll]~^ ERROR explicit lifetime required
 //[ast]~^^ ERROR explicit lifetime required

--- a/src/test/ui/generator/ref-escapes-but-not-over-yield.nll.stderr
+++ b/src/test/ui/generator/ref-escapes-but-not-over-yield.nll.stderr
@@ -1,5 +1,5 @@
 error[E0521]: borrowed data escapes outside of generator
-  --> $DIR/ref-escapes-but-not-over-yield.rs:14:9
+  --> $DIR/ref-escapes-but-not-over-yield.rs:11:9
    |
 LL |     let mut a = &3;
    |         ----- `a` is declared here, outside of the generator body

--- a/src/test/ui/generator/ref-escapes-but-not-over-yield.rs
+++ b/src/test/ui/generator/ref-escapes-but-not-over-yield.rs
@@ -1,7 +1,4 @@
-#![feature(generators, generator_trait)]
-
-use std::ops::{GeneratorState, Generator};
-use std::cell::Cell;
+#![feature(generators)]
 
 fn foo(x: &i32) {
     // In this case, a reference to `b` escapes the generator, but not

--- a/src/test/ui/generator/ref-escapes-but-not-over-yield.stderr
+++ b/src/test/ui/generator/ref-escapes-but-not-over-yield.stderr
@@ -1,5 +1,5 @@
 error[E0597]: `b` does not live long enough
-  --> $DIR/ref-escapes-but-not-over-yield.rs:14:14
+  --> $DIR/ref-escapes-but-not-over-yield.rs:11:14
    |
 LL |         a = &b;
    |              ^ borrowed value does not live long enough

--- a/src/test/ui/generator/sized-yield.rs
+++ b/src/test/ui/generator/sized-yield.rs
@@ -1,6 +1,7 @@
 #![feature(generators, generator_trait)]
 
 use std::ops::Generator;
+use std::pin::Pin;
 
 fn main() {
    let s = String::from("foo");
@@ -8,6 +9,6 @@ fn main() {
    //~^ ERROR the size for values of type
        yield s[..];
    };
-   unsafe { gen.resume(); }
+   Pin::new(&mut gen).resume();
    //~^ ERROR the size for values of type
 }

--- a/src/test/ui/generator/sized-yield.stderr
+++ b/src/test/ui/generator/sized-yield.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/sized-yield.rs:7:26
+  --> $DIR/sized-yield.rs:8:26
    |
 LL |      let mut gen = move || {
    |  __________________________^
@@ -13,10 +13,10 @@ LL | |    };
    = note: the yield type of a generator must have a statically known size
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/sized-yield.rs:11:17
+  --> $DIR/sized-yield.rs:12:23
    |
-LL |    unsafe { gen.resume(); }
-   |                 ^^^^^^ doesn't have a size known at compile-time
+LL |    Pin::new(&mut gen).resume();
+   |                       ^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `str`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>

--- a/src/test/ui/generator/static-not-unpin.rs
+++ b/src/test/ui/generator/static-not-unpin.rs
@@ -1,0 +1,13 @@
+#![feature(generators)]
+
+use std::marker::Unpin;
+
+fn assert_unpin<T: Unpin>(_: T) {
+}
+
+fn main() {
+    let mut generator = static || {
+        yield;
+    };
+    assert_unpin(generator); //~ ERROR std::marker::Unpin` is not satisfied
+}

--- a/src/test/ui/generator/static-not-unpin.rs
+++ b/src/test/ui/generator/static-not-unpin.rs
@@ -1,5 +1,7 @@
 #![feature(generators)]
 
+// normalize-stderr-test "std::pin::Unpin" -> "std::marker::Unpin"
+
 use std::marker::Unpin;
 
 fn assert_unpin<T: Unpin>(_: T) {

--- a/src/test/ui/generator/static-not-unpin.stderr
+++ b/src/test/ui/generator/static-not-unpin.stderr
@@ -1,0 +1,15 @@
+error[E0277]: the trait bound `[static generator@$DIR/static-not-unpin.rs:9:25: 11:6 _]: std::marker::Unpin` is not satisfied
+  --> $DIR/static-not-unpin.rs:12:5
+   |
+LL |     assert_unpin(generator); //~ ERROR std::marker::Unpin` is not satisfied
+   |     ^^^^^^^^^^^^ the trait `std::marker::Unpin` is not implemented for `[static generator@$DIR/static-not-unpin.rs:9:25: 11:6 _]`
+   |
+note: required by `assert_unpin`
+  --> $DIR/static-not-unpin.rs:5:1
+   |
+LL | fn assert_unpin<T: Unpin>(_: T) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/generator/static-not-unpin.stderr
+++ b/src/test/ui/generator/static-not-unpin.stderr
@@ -1,11 +1,11 @@
-error[E0277]: the trait bound `[static generator@$DIR/static-not-unpin.rs:9:25: 11:6 _]: std::marker::Unpin` is not satisfied
-  --> $DIR/static-not-unpin.rs:12:5
+error[E0277]: the trait bound `[static generator@$DIR/static-not-unpin.rs:11:25: 13:6 _]: std::marker::Unpin` is not satisfied
+  --> $DIR/static-not-unpin.rs:14:5
    |
 LL |     assert_unpin(generator); //~ ERROR std::marker::Unpin` is not satisfied
-   |     ^^^^^^^^^^^^ the trait `std::marker::Unpin` is not implemented for `[static generator@$DIR/static-not-unpin.rs:9:25: 11:6 _]`
+   |     ^^^^^^^^^^^^ the trait `std::marker::Unpin` is not implemented for `[static generator@$DIR/static-not-unpin.rs:11:25: 13:6 _]`
    |
 note: required by `assert_unpin`
-  --> $DIR/static-not-unpin.rs:5:1
+  --> $DIR/static-not-unpin.rs:7:1
    |
 LL | fn assert_unpin<T: Unpin>(_: T) {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/generator/yield-while-iterating.nll.stderr
+++ b/src/test/ui/generator/yield-while-iterating.nll.stderr
@@ -1,5 +1,5 @@
 error[E0626]: borrow may still be in use when generator yields
-  --> $DIR/yield-while-iterating.rs:12:18
+  --> $DIR/yield-while-iterating.rs:13:18
    |
 LL |         for p in &x { //~ ERROR
    |                  ^^
@@ -7,7 +7,7 @@ LL |             yield();
    |             ------- possible yield occurs here
 
 error[E0502]: cannot borrow `x` as immutable because it is also borrowed as mutable
-  --> $DIR/yield-while-iterating.rs:57:20
+  --> $DIR/yield-while-iterating.rs:58:20
    |
 LL |     let mut b = || {
    |                 -- mutable borrow occurs here
@@ -16,8 +16,8 @@ LL |         for p in &mut x {
 ...
 LL |     println!("{}", x[0]); //~ ERROR
    |                    ^ immutable borrow occurs here
-LL |     b.resume();
-   |     - mutable borrow later used here
+LL |     Pin::new(&mut b).resume();
+   |              ------ mutable borrow later used here
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/generator/yield-while-iterating.rs
+++ b/src/test/ui/generator/yield-while-iterating.rs
@@ -2,6 +2,7 @@
 
 use std::ops::{GeneratorState, Generator};
 use std::cell::Cell;
+use std::pin::Pin;
 
 fn yield_during_iter_owned_data(x: Vec<i32>) {
     // The generator owns `x`, so we error out when yielding with a
@@ -33,7 +34,7 @@ fn yield_during_iter_borrowed_slice_2() {
     println!("{:?}", x);
 }
 
-unsafe fn yield_during_iter_borrowed_slice_3() {
+fn yield_during_iter_borrowed_slice_3() {
     // OK to take a mutable ref to `x` and yield
     // up pointers from it:
     let mut x = vec![22_i32];
@@ -42,10 +43,10 @@ unsafe fn yield_during_iter_borrowed_slice_3() {
             yield p;
         }
     };
-    b.resume();
+    Pin::new(&mut b).resume();
 }
 
-unsafe fn yield_during_iter_borrowed_slice_4() {
+fn yield_during_iter_borrowed_slice_4() {
     // ...but not OK to do that while reading
     // from `x` too
     let mut x = vec![22_i32];
@@ -55,10 +56,10 @@ unsafe fn yield_during_iter_borrowed_slice_4() {
         }
     };
     println!("{}", x[0]); //~ ERROR
-    b.resume();
+    Pin::new(&mut b).resume();
 }
 
-unsafe fn yield_during_range_iter() {
+fn yield_during_range_iter() {
     // Should be OK.
     let mut b = || {
         let v = vec![1,2,3];
@@ -68,7 +69,7 @@ unsafe fn yield_during_range_iter() {
             yield x;
         }
     };
-    b.resume();
+    Pin::new(&mut b).resume();
 }
 
 fn main() { }

--- a/src/test/ui/generator/yield-while-iterating.stderr
+++ b/src/test/ui/generator/yield-while-iterating.stderr
@@ -1,5 +1,5 @@
 error[E0626]: borrow may still be in use when generator yields
-  --> $DIR/yield-while-iterating.rs:12:19
+  --> $DIR/yield-while-iterating.rs:13:19
    |
 LL |         for p in &x { //~ ERROR
    |                   ^
@@ -7,7 +7,7 @@ LL |             yield();
    |             ------- possible yield occurs here
 
 error[E0502]: cannot borrow `x` as immutable because it is also borrowed as mutable
-  --> $DIR/yield-while-iterating.rs:57:20
+  --> $DIR/yield-while-iterating.rs:58:20
    |
 LL |     let mut b = || {
    |                 -- mutable borrow occurs here
@@ -16,7 +16,7 @@ LL |         for p in &mut x {
 ...
 LL |     println!("{}", x[0]); //~ ERROR
    |                    ^ immutable borrow occurs here
-LL |     b.resume();
+LL |     Pin::new(&mut b).resume();
 LL | }
    | - mutable borrow ends here
 

--- a/src/test/ui/generator/yield-while-local-borrowed.rs
+++ b/src/test/ui/generator/yield-while-local-borrowed.rs
@@ -4,8 +4,9 @@
 
 use std::ops::{GeneratorState, Generator};
 use std::cell::Cell;
+use std::pin::Pin;
 
-unsafe fn borrow_local_inline() {
+fn borrow_local_inline() {
     // Not OK to yield with a borrow of a temporary.
     //
     // (This error occurs because the region shows up in the type of
@@ -17,10 +18,10 @@ unsafe fn borrow_local_inline() {
         yield();
         println!("{}", a);
     };
-    b.resume();
+    Pin::new(&mut b).resume();
 }
 
-unsafe fn borrow_local_inline_done() {
+fn borrow_local_inline_done() {
     // No error here -- `a` is not in scope at the point of `yield`.
     let mut b = move || {
         {
@@ -28,10 +29,10 @@ unsafe fn borrow_local_inline_done() {
         }
         yield();
     };
-    b.resume();
+    Pin::new(&mut b).resume();
 }
 
-unsafe fn borrow_local() {
+fn borrow_local() {
     // Not OK to yield with a borrow of a temporary.
     //
     // (This error occurs because the region shows up in the type of
@@ -46,7 +47,7 @@ unsafe fn borrow_local() {
             println!("{}", b);
         }
     };
-    b.resume();
+    Pin::new(&mut b).resume();
 }
 
 fn main() { }

--- a/src/test/ui/generator/yield-while-local-borrowed.stderr
+++ b/src/test/ui/generator/yield-while-local-borrowed.stderr
@@ -1,5 +1,5 @@
 error[E0626]: borrow may still be in use when generator yields (Ast)
-  --> $DIR/yield-while-local-borrowed.rs:14:22
+  --> $DIR/yield-while-local-borrowed.rs:15:22
    |
 LL |         let a = &mut 3;
    |                      ^
@@ -8,7 +8,7 @@ LL |         yield();
    |         ------- possible yield occurs here
 
 error[E0626]: borrow may still be in use when generator yields (Ast)
-  --> $DIR/yield-while-local-borrowed.rs:42:22
+  --> $DIR/yield-while-local-borrowed.rs:43:22
    |
 LL |             let b = &a;
    |                      ^
@@ -17,7 +17,7 @@ LL |             yield();
    |             ------- possible yield occurs here
 
 error[E0626]: borrow may still be in use when generator yields (Mir)
-  --> $DIR/yield-while-local-borrowed.rs:14:17
+  --> $DIR/yield-while-local-borrowed.rs:15:17
    |
 LL |         let a = &mut 3;
    |                 ^^^^^^
@@ -26,7 +26,7 @@ LL |         yield();
    |         ------- possible yield occurs here
 
 error[E0626]: borrow may still be in use when generator yields (Mir)
-  --> $DIR/yield-while-local-borrowed.rs:42:21
+  --> $DIR/yield-while-local-borrowed.rs:43:21
    |
 LL |             let b = &a;
    |                     ^^

--- a/src/test/ui/generator/yield-while-ref-reborrowed.nll.stderr
+++ b/src/test/ui/generator/yield-while-ref-reborrowed.nll.stderr
@@ -1,5 +1,5 @@
 error[E0501]: cannot borrow `x` as immutable because previous closure requires unique access
-  --> $DIR/yield-while-ref-reborrowed.rs:35:20
+  --> $DIR/yield-while-ref-reborrowed.rs:36:20
    |
 LL |     let mut b = || {
    |                 -- generator construction occurs here
@@ -8,8 +8,8 @@ LL |         let a = &mut *x;
 ...
 LL |     println!("{}", x); //~ ERROR
    |                    ^ second borrow occurs here
-LL |     b.resume();
-   |     - first borrow later used here
+LL |     Pin::new(&mut b).resume();
+   |              ------ first borrow later used here
 
 error: aborting due to previous error
 

--- a/src/test/ui/generator/yield-while-ref-reborrowed.rs
+++ b/src/test/ui/generator/yield-while-ref-reborrowed.rs
@@ -2,8 +2,9 @@
 
 use std::ops::{GeneratorState, Generator};
 use std::cell::Cell;
+use std::pin::Pin;
 
-unsafe fn reborrow_shared_ref(x: &i32) {
+fn reborrow_shared_ref(x: &i32) {
     // This is OK -- we have a borrow live over the yield, but it's of
     // data that outlives the generator.
     let mut b = move || {
@@ -11,10 +12,10 @@ unsafe fn reborrow_shared_ref(x: &i32) {
         yield();
         println!("{}", a);
     };
-    b.resume();
+    Pin::new(&mut b).resume();
 }
 
-unsafe fn reborrow_mutable_ref(x: &mut i32) {
+fn reborrow_mutable_ref(x: &mut i32) {
     // This is OK -- we have a borrow live over the yield, but it's of
     // data that outlives the generator.
     let mut b = move || {
@@ -22,10 +23,10 @@ unsafe fn reborrow_mutable_ref(x: &mut i32) {
         yield();
         println!("{}", a);
     };
-    b.resume();
+    Pin::new(&mut b).resume();
 }
 
-unsafe fn reborrow_mutable_ref_2(x: &mut i32) {
+fn reborrow_mutable_ref_2(x: &mut i32) {
     // ...but not OK to go on using `x`.
     let mut b = || {
         let a = &mut *x;
@@ -33,7 +34,7 @@ unsafe fn reborrow_mutable_ref_2(x: &mut i32) {
         println!("{}", a);
     };
     println!("{}", x); //~ ERROR
-    b.resume();
+    Pin::new(&mut b).resume();
 }
 
 fn main() { }

--- a/src/test/ui/generator/yield-while-ref-reborrowed.stderr
+++ b/src/test/ui/generator/yield-while-ref-reborrowed.stderr
@@ -1,5 +1,5 @@
 error[E0501]: cannot borrow `x` as immutable because previous closure requires unique access
-  --> $DIR/yield-while-ref-reborrowed.rs:35:20
+  --> $DIR/yield-while-ref-reborrowed.rs:36:20
    |
 LL |     let mut b = || {
    |                 -- closure construction occurs here
@@ -8,7 +8,7 @@ LL |         let a = &mut *x;
 ...
 LL |     println!("{}", x); //~ ERROR
    |                    ^ borrow occurs here
-LL |     b.resume();
+LL |     Pin::new(&mut b).resume();
 LL | }
    | - borrow from closure ends here
 

--- a/src/test/ui/nll/issue-55850.rs
+++ b/src/test/ui/nll/issue-55850.rs
@@ -1,23 +1,23 @@
 #![allow(unused_mut)]
 #![feature(generators, generator_trait)]
 
+use std::marker::Unpin;
 use std::ops::Generator;
 use std::ops::GeneratorState::Yielded;
+use std::pin::Pin;
 
 pub struct GenIter<G>(G);
 
 impl <G> Iterator for GenIter<G>
 where
-    G: Generator,
+    G: Generator + Unpin,
 {
     type Item = G::Yield;
 
     fn next(&mut self) -> Option<Self::Item> {
-        unsafe {
-            match self.0.resume() {
-                Yielded(y) => Some(y),
-                _ => None
-            }
+        match Pin::new(&mut self.0).resume() {
+            Yielded(y) => Some(y),
+            _ => None
         }
     }
 }


### PR DESCRIPTION
I'm unsure whether there needs to be any changes to the actual generator transform. Tests are passing so the fact that `Pin<&mut T>` is fundamentally the same as `&mut T` seems to allow it to still work, but maybe there's something subtle here that could go wrong.

This is specified in [RFC 2349 § Immovable generators](https://github.com/rust-lang/rfcs/blob/master/text/2349-pin.md#immovable-generators) (although, since that RFC it has become safe to create an immovable generator, and instead it's unsafe to resume any generator; with these changes both are now safe and instead the unsafety is moved to creating a `Pin<&mut [static generator]>` which there are safe APIs for).

CC #43122