### PR TITLE
Make `ParseIntError` and `IntErrorKind` fully public

### DIFF
--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -4768,6 +4768,7 @@ fn from_str_radix<T: FromStrRadixHelper>(src: &str, radix: u32) -> Result<T, Par
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct ParseIntError {
+    /// Stores the cause of parsing an integer failing
     pub kind: IntErrorKind,
 }
 

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -4771,6 +4771,7 @@ pub struct ParseIntError {
     pub kind: IntErrorKind,
 }
 
+/// Enum to store the various types of errors that can cause parsing an integer to fail.
 #[unstable(feature = "int_error_matching",
            reason = "it can be useful to match errors when making error messages \
                      for integer parsing",
@@ -4778,9 +4779,16 @@ pub struct ParseIntError {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum IntErrorKind {
+    /// Value being parsed is empty.
+    /// Among other causes, this variant will be constructed when parsing an empty string.
     Empty,
+    /// Contains an invalid digit.
+    /// Among other causes, this variant will be constructed when parsing a string that
+    /// contains a letter.
     InvalidDigit,
+    /// Integer is too small to store in target integer type.
     Overflow,
+    /// Integer is too large to store in target integer type.
     Underflow,
 }
 

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -4773,7 +4773,8 @@ pub struct ParseIntError {
 
 #[unstable(feature = "int_error_matching",
            reason = "it can be useful to match errors when making error messages \
-                     for integer parsing")]
+                     for integer parsing",
+           issue = "22639")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum IntErrorKind {

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -4788,9 +4788,9 @@ pub enum IntErrorKind {
     /// Among other causes, this variant will be constructed when parsing a string that
     /// contains a letter.
     InvalidDigit,
-    /// Integer is too small to store in target integer type.
-    Overflow,
     /// Integer is too large to store in target integer type.
+    Overflow,
+    /// Integer is too small to store in target integer type.
     Underflow,
 }
 

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -4772,7 +4772,8 @@ pub struct ParseIntError {
 }
 
 #[unstable(feature = "int_error_matching",
-           reason = "it can be useful to match errors when making error messages for integer parsing")]
+           reason = "it can be useful to match errors when making error messages \
+                     for integer parsing")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum IntErrorKind {

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -4801,7 +4801,7 @@ impl ParseIntError {
                          for integer parsing",
                issue = "22639")]
     pub fn kind(&self) -> &IntErrorKind {
-        self.kind
+        &self.kind
     }
     #[unstable(feature = "int_error_internals",
                reason = "available through Error trait and this method should \

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -4780,9 +4780,11 @@ pub struct ParseIntError {
 #[non_exhaustive]
 pub enum IntErrorKind {
     /// Value being parsed is empty.
+    ///
     /// Among other causes, this variant will be constructed when parsing an empty string.
     Empty,
     /// Contains an invalid digit.
+    ///
     /// Among other causes, this variant will be constructed when parsing a string that
     /// contains a letter.
     InvalidDigit,

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -4768,8 +4768,7 @@ fn from_str_radix<T: FromStrRadixHelper>(src: &str, radix: u32) -> Result<T, Par
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct ParseIntError {
-    /// Stores the cause of parsing an integer failing
-    pub kind: IntErrorKind,
+    kind: IntErrorKind,
 }
 
 /// Enum to store the various types of errors that can cause parsing an integer to fail.
@@ -4796,6 +4795,10 @@ pub enum IntErrorKind {
 }
 
 impl ParseIntError {
+    /// Outputs the detailed cause of parsing an integer failing.
+    pub fn kind(self) -> IntErrorKind {
+        self.kind
+    }
     #[unstable(feature = "int_error_internals",
                reason = "available through Error trait and this method should \
                          not be exposed publicly",

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -4800,7 +4800,7 @@ impl ParseIntError {
                reason = "it can be useful to match errors when making error messages \
                          for integer parsing",
                issue = "22639")]
-    pub fn kind(self) -> IntErrorKind {
+    pub fn kind(&self) -> &IntErrorKind {
         self.kind
     }
     #[unstable(feature = "int_error_internals",

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -4768,11 +4768,11 @@ fn from_str_radix<T: FromStrRadixHelper>(src: &str, radix: u32) -> Result<T, Par
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct ParseIntError {
-    kind: IntErrorKind,
+    pub kind: IntErrorKind,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-enum IntErrorKind {
+pub enum IntErrorKind {
     Empty,
     InvalidDigit,
     Overflow,

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -4771,7 +4771,10 @@ pub struct ParseIntError {
     pub kind: IntErrorKind,
 }
 
+#[unstable(feature = "int_error_matching",
+           reason = "it can be useful to match errors when making error messages for integer parsing")]
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum IntErrorKind {
     Empty,
     InvalidDigit,

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -4796,6 +4796,10 @@ pub enum IntErrorKind {
 
 impl ParseIntError {
     /// Outputs the detailed cause of parsing an integer failing.
+    #[unstable(feature = "int_error_matching",
+               reason = "it can be useful to match errors when making error messages \
+                         for integer parsing",
+               issue = "22639")]
     pub fn kind(self) -> IntErrorKind {
         self.kind
     }


### PR DESCRIPTION
Why would you write nice error types if I can't read them?

# Why

It can be useful to use `match` with errors produced when parsing strings to int. This would be useful for the `.err_match()` function in my [new crate](https://crates.io/crates/read_input).

---
I could also do this for `ParseFloatError` if people think it is a good idea.
I am new around hear so please tell me if I am getting anything wrong.