### PR TITLE
Format BtreeMap::range_mut example

### DIFF
--- a/src/liballoc/collections/btree/map.rs
+++ b/src/liballoc/collections/btree/map.rs
@@ -853,9 +853,10 @@ impl<K: Ord, V> BTreeMap<K, V> {
     /// ```
     /// use std::collections::BTreeMap;
     ///
-    /// let mut map: BTreeMap<&str, i32> = ["Alice", "Bob", "Carol", "Cheryl"].iter()
-    ///                                                                       .map(|&s| (s, 0))
-    ///                                                                       .collect();
+    /// let mut map: BTreeMap<&str, i32> = ["Alice", "Bob", "Carol", "Cheryl"]
+    ///     .iter()
+    ///     .map(|&s| (s, 0))
+    ///     .collect();
     /// for (_, balance) in map.range_mut("B".."Cheryl") {
     ///     *balance += 100;
     /// }


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/16046705/48049184-36517780-e1e1-11e8-8da2-a3ae858d5a76.png)
After:
![image](https://user-images.githubusercontent.com/16046705/48049210-45382a00-e1e1-11e8-87b3-84ae60ef798e.png)
