### PR TITLE
implement .trailing_ones(), .leading_ones()

### DIFF
--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -330,6 +330,27 @@ $EndFeature, "
         }
 
         doc_comment! {
+            concat!("Returns the number of leading ones in the binary representation of `self`.
+
+# Examples
+
+Basic usage:
+
+```
+", $Feature, "let n = 0b10110011", stringify!($SelfT), ";
+
+assert_eq!(n.leading_ones(), 1);",
+$EndFeature, "
+```"),
+            #[unstable(feature = "leading_ones_trailing_ones", issue = "0")]
+            #[rustc_const_unstable(feature = "const_int_ops")]
+            #[inline]
+            pub const fn leading_ones(self) -> u32 {
+                (!self as $UnsignedT).leading_zeros()
+            }
+        }
+
+        doc_comment! {
             concat!("Returns the number of trailing zeros in the binary representation of `self`.
 
 # Examples
@@ -347,6 +368,27 @@ $EndFeature, "
             #[inline]
             pub const fn trailing_zeros(self) -> u32 {
                 (self as $UnsignedT).trailing_zeros()
+            }
+        }
+
+        doc_comment! {
+            concat!("Returns the number of trailing ones in the binary representation of `self`.
+
+# Examples
+
+Basic usage:
+
+```
+", $Feature, "let n = 0b10110011", stringify!($SelfT), ";
+
+assert_eq!(n.trailing_ones(), 2);",
+$EndFeature, "
+```"),
+            #[unstable(feature = "leading_ones_trailing_ones", issue = "0")]
+            #[rustc_const_unstable(feature = "const_int_ops")]
+            #[inline]
+            pub const fn trailing_ones(self) -> u32 {
+                (!self as $UnsignedT).trailing_zeros()
             }
         }
 
@@ -2261,6 +2303,26 @@ assert_eq!(n.leading_zeros(), 2);", $EndFeature, "
         }
 
         doc_comment! {
+            concat!("Returns the number of leading ones in the binary representation of `self`.
+
+# Examples
+
+Basic usage:
+
+```
+", $Feature, "let n = 0b11001100", stringify!($SelfT), ";
+
+assert_eq!(n.leading_ones(), 2);", $EndFeature, "
+```"),
+            #[unstable(feature = "leading_ones_trailing_ones", issue = "0")]
+            #[rustc_const_unstable(feature = "const_int_ops")]
+            #[inline]
+            pub const fn leading_ones(self) -> u32 {
+                (!self).leading_zeros()
+            }
+        }
+
+        doc_comment! {
             concat!("Returns the number of trailing zeros in the binary representation
 of `self`.
 
@@ -2278,6 +2340,27 @@ assert_eq!(n.trailing_zeros(), 3);", $EndFeature, "
             #[inline]
             pub const fn trailing_zeros(self) -> u32 {
                 unsafe { uint_cttz_call!(self, $BITS) as u32 }
+            }
+        }
+
+        doc_comment! {
+            concat!("Returns the number of trailing ones in the binary representation
+of `self`.
+
+# Examples
+
+Basic usage:
+
+```
+", $Feature, "let n = 0b0101011", stringify!($SelfT), ";
+
+assert_eq!(n.trailing_ones(), 2);", $EndFeature, "
+```"),
+            #[unstable(feature = "leading_ones_trailing_ones", issue = "0")]
+            #[rustc_const_unstable(feature = "const_int_ops")]
+            #[inline]
+            pub const fn trailing_ones(self) -> u32 {
+                (!self).trailing_zeros()
             }
         }
 


### PR DESCRIPTION
Hi!

This patch implements `.trailing_ones()` and `.leading_ones()` to all number types as counterparts to the `.leading_zeros()`, and `.trailing_zeros()` methods. 

I posted [a pre-RFC for these changes on internals](https://internals.rust-lang.org/t/pre-rfc-leading-ones-trailing-ones/8762/5), but the consensus seemed to be these changes would be small enough that no RFC was needed. So hence this patch!

I've never written a PR for Rustc before, so I hope I'm doing everything right. I realize this patch is probably not good enough to land as-is, so I had a few questions:

- Should external tests be added, or are doctests enough? If yes: where should they be added?
- I'm not sure what the right stability attribute would be for these methods. The `tidy` checks are pointing out it's malformed, but I'm not sure what the correct form would be.

---

Thanks heaps!