### PR TITLE
Sidestep link error from rustfix'ed code by using a *defined* static.

### DIFF
--- a/src/test/ui/extern/extern-const.fixed
+++ b/src/test/ui/extern/extern-const.fixed
@@ -12,7 +12,7 @@ extern crate libc;
 
 #[link(name = "rust_test_helpers", kind = "static")]
 extern "C" {
-    const rust_dbg_static_mut: libc::c_int; //~ ERROR extern items cannot be `const`
+    static rust_dbg_static_mut: libc::c_int; //~ ERROR extern items cannot be `const`
 }
 
 fn main() {

--- a/src/test/ui/extern/extern-const.fixed
+++ b/src/test/ui/extern/extern-const.fixed
@@ -1,11 +1,11 @@
-// This test is checking that extern items cannot be const.  It also
-// checks that `rustfix` suggests the alternative of using an extern
-// static.
+// Check extern items cannot be const + `rustfix` suggests using
+// extern static.
 //
 // #54388: an unused reference to an undefined static may or may not
 // compile. To sidestep this by using one that *is* defined.
 
 // run-rustfix
+// ignore-wasm32 no external library to link to.
 // compile-flags: -g -Z continue-parse-after-error
 #![feature(libc)]
 extern crate libc;

--- a/src/test/ui/extern/extern-const.rs
+++ b/src/test/ui/extern/extern-const.rs
@@ -1,11 +1,11 @@
-// This test is checking that extern items cannot be const.  It also
-// checks that `rustfix` suggests the alternative of using an extern
-// static.
+// Check extern items cannot be const + `rustfix` suggests using
+// extern static.
 //
 // #54388: an unused reference to an undefined static may or may not
 // compile. To sidestep this by using one that *is* defined.
 
 // run-rustfix
+// ignore-wasm32 no external library to link to.
 // compile-flags: -g -Z continue-parse-after-error
 #![feature(libc)]
 extern crate libc;

--- a/src/test/ui/extern/extern-const.stderr
+++ b/src/test/ui/extern/extern-const.stderr
@@ -1,7 +1,7 @@
 error: extern items cannot be `const`
   --> $DIR/extern-const.rs:15:5
    |
-LL |     const C: u8; //~ ERROR extern items cannot be `const`
+LL |     const rust_dbg_static_mut: libc::c_int; //~ ERROR extern items cannot be `const`
    |     ^^^^^ help: try using a static value: `static`
 
 error: aborting due to previous error


### PR DESCRIPTION
As a drive-by, added `-g` to the compile-flags so that the test more
reliably fails to compile when the extern static in question is *not*
provided. (I.e. this is making the test more robust in the face of
potential future revisions.)

Fix #54388.