### PR TITLE
Use trait impl method span when type param mismatch is due to impl Trait

### DIFF
--- a/src/librustc_typeck/check/compare_method.rs
+++ b/src/librustc_typeck/check/compare_method.rs
@@ -595,7 +595,9 @@ fn compare_number_of_generics<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     if num_impl_m_type_params != num_trait_m_type_params {
         let impl_m_node_id = tcx.hir.as_local_node_id(impl_m.def_id).unwrap();
         let impl_m_item = tcx.hir.expect_impl_item(impl_m_node_id);
-        let span = if impl_m_item.generics.params.is_empty() {
+        let span = if impl_m_item.generics.params.is_empty()
+            || impl_m_item.generics.span.is_dummy()  // impl Trait in argument position (#55374)
+        {
             impl_m_span
         } else {
             impl_m_item.generics.span

--- a/src/test/ui/issues/type-arg-mismatch-due-to-impl-trait.rs
+++ b/src/test/ui/issues/type-arg-mismatch-due-to-impl-trait.rs
@@ -1,0 +1,15 @@
+trait Foo {
+    type T;
+    fn foo(&self, t: Self::T);
+//~^ NOTE expected 0 type parameters
+}
+
+impl Foo for u32 {
+    type T = ();
+
+    fn foo(&self, t: impl Clone) {}
+//~^ ERROR method `foo` has 1 type parameter but its trait declaration has 0 type parameters
+//~| NOTE found 1 type parameter
+}
+
+fn main() {}

--- a/src/test/ui/issues/type-arg-mismatch-due-to-impl-trait.stderr
+++ b/src/test/ui/issues/type-arg-mismatch-due-to-impl-trait.stderr
@@ -1,0 +1,12 @@
+error[E0049]: method `foo` has 1 type parameter but its trait declaration has 0 type parameters
+  --> $DIR/type-arg-mismatch-due-to-impl-trait.rs:10:5
+   |
+LL |     fn foo(&self, t: Self::T);
+   |     -------------------------- expected 0 type parameters
+...
+LL |     fn foo(&self, t: impl Clone) {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ found 1 type parameter
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0049`.


### PR DESCRIPTION
Fix #55374.