### PR TITLE
refactor: use shorthand fields

### DIFF
--- a/src/liballoc/string.rs
+++ b/src/liballoc/string.rs
@@ -502,7 +502,7 @@ impl String {
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn from_utf8(vec: Vec<u8>) -> Result<String, FromUtf8Error> {
         match str::from_utf8(&vec) {
-            Ok(..) => Ok(String { vec: vec }),
+            Ok(..) => Ok(String { vec }),
             Err(e) => {
                 Err(FromUtf8Error {
                     bytes: vec,

--- a/src/libpanic_unwind/dwarf/mod.rs
+++ b/src/libpanic_unwind/dwarf/mod.rs
@@ -29,7 +29,7 @@ struct Unaligned<T>(T);
 
 impl DwarfReader {
     pub fn new(ptr: *const u8) -> DwarfReader {
-        DwarfReader { ptr: ptr }
+        DwarfReader { ptr }
     }
 
     // DWARF streams are packed, so e.g. a u32 would not necessarily be aligned

--- a/src/libpanic_unwind/seh64_gnu.rs
+++ b/src/libpanic_unwind/seh64_gnu.rs
@@ -41,7 +41,7 @@ struct PanicData {
 }
 
 pub unsafe fn panic(data: Box<dyn Any + Send>) -> u32 {
-    let panic_ctx = Box::new(PanicData { data: data });
+    let panic_ctx = Box::new(PanicData { data });
     let params = [Box::into_raw(panic_ctx) as c::ULONG_PTR];
     c::RaiseException(RUST_PANIC,
                       c::EXCEPTION_NONCONTINUABLE,

--- a/src/librustc/infer/resolve.rs
+++ b/src/librustc/infer/resolve.rs
@@ -26,7 +26,7 @@ pub struct OpportunisticTypeResolver<'a, 'gcx: 'a+'tcx, 'tcx: 'a> {
 
 impl<'a, 'gcx, 'tcx> OpportunisticTypeResolver<'a, 'gcx, 'tcx> {
     pub fn new(infcx: &'a InferCtxt<'a, 'gcx, 'tcx>) -> Self {
-        OpportunisticTypeResolver { infcx: infcx }
+        OpportunisticTypeResolver { infcx }
     }
 }
 
@@ -54,7 +54,7 @@ pub struct OpportunisticTypeAndRegionResolver<'a, 'gcx: 'a+'tcx, 'tcx: 'a> {
 
 impl<'a, 'gcx, 'tcx> OpportunisticTypeAndRegionResolver<'a, 'gcx, 'tcx> {
     pub fn new(infcx: &'a InferCtxt<'a, 'gcx, 'tcx>) -> Self {
-        OpportunisticTypeAndRegionResolver { infcx: infcx }
+        OpportunisticTypeAndRegionResolver { infcx }
     }
 }
 

--- a/src/librustc/infer/type_variable.rs
+++ b/src/librustc/infer/type_variable.rs
@@ -169,7 +169,7 @@ impl<'tcx> TypeVariableTable<'tcx> {
         // Hack: we only need this so that `types_escaping_snapshot`
         // can see what has been unified; see the Delegate impl for
         // more details.
-        self.values.record(Instantiate { vid: vid });
+        self.values.record(Instantiate { vid });
     }
 
     /// Creates a new type variable.

--- a/src/librustc/infer/unify_key.rs
+++ b/src/librustc/infer/unify_key.rs
@@ -43,7 +43,7 @@ impl UnifyValue for RegionVidKey {
             value2.min_vid
         };
 
-        Ok(RegionVidKey { min_vid: min_vid })
+        Ok(RegionVidKey { min_vid })
     }
 }
 

--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -469,7 +469,7 @@ impl<'a, 'tcx> Index<'tcx> {
 /// Cross-references the feature names of unstable APIs with enabled
 /// features and possibly prints errors.
 pub fn check_unstable_api_usage<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
-    let mut checker = Checker { tcx: tcx };
+    let mut checker = Checker { tcx };
     tcx.hir.krate().visit_all_item_likes(&mut checker.as_deep_visitor());
 }
 

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -2871,7 +2871,7 @@ impl<'tcx> TypeFoldable<'tcx> for Terminator<'tcx> {
         use mir::TerminatorKind::*;
 
         let kind = match self.kind {
-            Goto { target } => Goto { target: target },
+            Goto { target } => Goto { target },
             SwitchInt {
                 ref discr,
                 switch_ty,

--- a/src/librustc/mir/tcx.rs
+++ b/src/librustc/mir/tcx.rs
@@ -32,7 +32,7 @@ pub enum PlaceTy<'tcx> {
 
 impl<'a, 'gcx, 'tcx> PlaceTy<'tcx> {
     pub fn from_ty(ty: Ty<'tcx>) -> PlaceTy<'tcx> {
-        PlaceTy::Ty { ty: ty }
+        PlaceTy::Ty { ty }
     }
 
     pub fn to_ty(&self, tcx: TyCtxt<'a, 'gcx, 'tcx>) -> Ty<'tcx> {

--- a/src/librustc/traits/project.rs
+++ b/src/librustc/traits/project.rs
@@ -269,7 +269,7 @@ fn project_and_unify_type<'cx, 'gcx, 'tcx>(
         },
         Err(err) => {
             debug!("project_and_unify_type: equating types encountered error {:?}", err);
-            Err(MismatchedProjectionTypes { err: err })
+            Err(MismatchedProjectionTypes { err })
         }
     }
 }

--- a/src/librustc/traits/select.rs
+++ b/src/librustc/traits/select.rs
@@ -3434,7 +3434,7 @@ impl<'cx, 'gcx, 'tcx> SelectionContext<'cx, 'gcx, 'tcx> {
             _ => bug!(),
         };
 
-        Ok(VtableBuiltinData { nested: nested })
+        Ok(VtableBuiltinData { nested })
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/librustc/ty/_match.rs
+++ b/src/librustc/ty/_match.rs
@@ -34,7 +34,7 @@ pub struct Match<'a, 'gcx: 'a+'tcx, 'tcx: 'a> {
 
 impl<'a, 'gcx, 'tcx> Match<'a, 'gcx, 'tcx> {
     pub fn new(tcx: TyCtxt<'a, 'gcx, 'tcx>) -> Match<'a, 'gcx, 'tcx> {
-        Match { tcx: tcx }
+        Match { tcx }
     }
 }
 

--- a/src/librustc/ty/fold.rs
+++ b/src/librustc/ty/fold.rs
@@ -82,7 +82,7 @@ pub trait TypeFoldable<'tcx>: fmt::Debug + Clone {
     }
 
     fn has_type_flags(&self, flags: TypeFlags) -> bool {
-        self.visit_with(&mut HasTypeFlagsVisitor { flags: flags })
+        self.visit_with(&mut HasTypeFlagsVisitor { flags })
     }
     fn has_projections(&self) -> bool {
         self.has_type_flags(TypeFlags::HAS_PROJECTION)

--- a/src/librustc_codegen_llvm/llvm/mod.rs
+++ b/src/librustc_codegen_llvm/llvm/mod.rs
@@ -190,7 +190,7 @@ impl ObjectFile {
     pub fn new(llmb: &'static mut MemoryBuffer) -> Option<ObjectFile> {
         unsafe {
             let llof = LLVMCreateObjectFile(llmb)?;
-            Some(ObjectFile { llof: llof })
+            Some(ObjectFile { llof })
         }
     }
 }

--- a/src/librustc_codegen_llvm/mir/analyze.rs
+++ b/src/librustc_codegen_llvm/mir/analyze.rs
@@ -328,7 +328,7 @@ pub fn cleanup_kinds<'a, 'tcx>(mir: &mir::Mir<'tcx>) -> IndexVec<mir::BasicBlock
                        funclet, succ, kind);
                 match kind {
                     CleanupKind::NotCleanup => {
-                        result[succ] = CleanupKind::Internal { funclet: funclet };
+                        result[succ] = CleanupKind::Internal { funclet };
                     }
                     CleanupKind::Funclet => {
                         if funclet != succ {

--- a/src/librustc_codegen_utils/symbol_names_test.rs
+++ b/src/librustc_codegen_utils/symbol_names_test.rs
@@ -32,7 +32,7 @@ pub fn report_symbol_names<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
     }
 
     tcx.dep_graph.with_ignore(|| {
-        let mut visitor = SymbolNamesTest { tcx: tcx };
+        let mut visitor = SymbolNamesTest { tcx };
         tcx.hir.krate().visit_all_item_likes(&mut visitor);
     })
 }

--- a/src/librustc_data_structures/flock.rs
+++ b/src/librustc_data_structures/flock.rs
@@ -214,7 +214,7 @@ cfg_if! {
                     unsafe { libc::close(fd); }
                     Err(err)
                 } else {
-                    Ok(Lock { fd: fd })
+                    Ok(Lock { fd })
                 }
             }
         }

--- a/src/librustc_data_structures/svh.rs
+++ b/src/librustc_data_structures/svh.rs
@@ -31,7 +31,7 @@ impl Svh {
     /// compute the SVH from some HIR, you want the `calculate_svh`
     /// function found in `librustc_incremental`.
     pub fn new(hash: u64) -> Svh {
-        Svh { hash: hash }
+        Svh { hash }
     }
 
     pub fn as_u64(&self) -> u64 {

--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -794,7 +794,7 @@ impl LintPass for ImproperCTypes {
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ImproperCTypes {
     fn check_foreign_item(&mut self, cx: &LateContext, it: &hir::ForeignItem) {
-        let mut vis = ImproperCTypesVisitor { cx: cx };
+        let mut vis = ImproperCTypesVisitor { cx };
         let abi = cx.tcx.hir.get_foreign_abi(it.id);
         if abi != Abi::RustIntrinsic && abi != Abi::PlatformIntrinsic {
             match it.node {

--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -323,7 +323,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
         index.record(DefId::local(CRATE_DEF_INDEX),
                      IsolatedEncoder::encode_info_for_mod,
                      FromId(CRATE_NODE_ID, (&krate.module, &krate.attrs, &vis)));
-        let mut visitor = EncodeVisitor { index: index };
+        let mut visitor = EncodeVisitor { index };
         krate.visit_all_item_likes(&mut visitor.as_deep_visitor());
         for macro_def in &krate.exported_macros {
             visitor.visit_macro_def(macro_def);

--- a/src/librustc_mir/build/scope.rs
+++ b/src/librustc_mir/build/scope.rs
@@ -453,7 +453,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
         }
         let scope = &self.scopes[len - scope_count];
         self.cfg.terminate(block, scope.source_info(span),
-                           TerminatorKind::Goto { target: target });
+                           TerminatorKind::Goto { target });
     }
 
     /// Creates a path that performs all required cleanup for dropping a generator.
@@ -1019,7 +1019,7 @@ fn build_diverge_scope<'a, 'gcx, 'tcx>(tcx: TyCtxt<'a, 'gcx, 'tcx>,
         } else {
             let block = cfg.start_new_cleanup_block();
             cfg.push_end_region(tcx, block, source_info(span), scope.region_scope);
-            cfg.terminate(block, source_info(span), TerminatorKind::Goto { target: target });
+            cfg.terminate(block, source_info(span), TerminatorKind::Goto { target });
             *cached_block = Some(block);
             block
         }

--- a/src/librustc_mir/dataflow/impls/borrowed_locals.rs
+++ b/src/librustc_mir/dataflow/impls/borrowed_locals.rs
@@ -28,7 +28,7 @@ pub struct HaveBeenBorrowedLocals<'a, 'tcx: 'a> {
 impl<'a, 'tcx: 'a> HaveBeenBorrowedLocals<'a, 'tcx> {
     pub fn new(mir: &'a Mir<'tcx>)
                -> Self {
-        HaveBeenBorrowedLocals { mir: mir }
+        HaveBeenBorrowedLocals { mir }
     }
 
     pub fn mir(&self) -> &Mir<'tcx> {

--- a/src/librustc_mir/dataflow/impls/storage_liveness.rs
+++ b/src/librustc_mir/dataflow/impls/storage_liveness.rs
@@ -21,7 +21,7 @@ pub struct MaybeStorageLive<'a, 'tcx: 'a> {
 impl<'a, 'tcx: 'a> MaybeStorageLive<'a, 'tcx> {
     pub fn new(mir: &'a Mir<'tcx>)
                -> Self {
-        MaybeStorageLive { mir: mir }
+        MaybeStorageLive { mir }
     }
 
     pub fn mir(&self) -> &Mir<'tcx> {

--- a/src/librustc_mir/hair/pattern/check_match.rs
+++ b/src/librustc_mir/hair/pattern/check_match.rs
@@ -52,7 +52,7 @@ impl<'a, 'tcx> Visitor<'tcx> for OuterVisitor<'a, 'tcx> {
 }
 
 pub fn check_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
-    tcx.hir.krate().visit_all_item_likes(&mut OuterVisitor { tcx: tcx }.as_deep_visitor());
+    tcx.hir.krate().visit_all_item_likes(&mut OuterVisitor { tcx }.as_deep_visitor());
     tcx.sess.abort_if_errors();
 }
 

--- a/src/librustc_mir/hair/pattern/mod.rs
+++ b/src/librustc_mir/hair/pattern/mod.rs
@@ -459,7 +459,7 @@ impl<'a, 'tcx> PatternContext<'a, 'tcx> {
                                        })
                                        .collect();
 
-                        PatternKind::Leaf { subpatterns: subpatterns }
+                        PatternKind::Leaf { subpatterns }
                     }
                     ty::Error => { // Avoid ICE (#50577)
                         return Pattern { span: pat.span, ty, kind: Box::new(PatternKind::Wild) };
@@ -666,13 +666,13 @@ impl<'a, 'tcx> PatternContext<'a, 'tcx> {
                         subpatterns,
                     }
                 } else {
-                    PatternKind::Leaf { subpatterns: subpatterns }
+                    PatternKind::Leaf { subpatterns }
                 }
             }
 
             Def::Struct(..) | Def::StructCtor(..) | Def::Union(..) |
             Def::TyAlias(..) | Def::AssociatedTy(..) | Def::SelfTy(..) | Def::SelfCtor(..) => {
-                PatternKind::Leaf { subpatterns: subpatterns }
+                PatternKind::Leaf { subpatterns }
             }
 
             _ => {

--- a/src/librustc_mir/transform/elaborate_drops.rs
+++ b/src/librustc_mir/transform/elaborate_drops.rs
@@ -495,7 +495,7 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
         let target = self.patch.new_block(BasicBlockData {
             statements: vec![assign],
             terminator: Some(Terminator {
-                kind: TerminatorKind::Goto { target: target },
+                kind: TerminatorKind::Goto { target },
                 ..*terminator
             }),
             is_cleanup: false,

--- a/src/librustc_mir/transform/simplify.rs
+++ b/src/librustc_mir/transform/simplify.rs
@@ -302,7 +302,7 @@ impl MirPass for SimplifyLocals {
 
         let map = make_local_map(&mut mir.local_decls, marker.locals);
         // Update references to all vars and tmps now
-        LocalUpdater { map: map }.visit_mir(mir);
+        LocalUpdater { map }.visit_mir(mir);
         mir.local_decls.shrink_to_fit();
     }
 }

--- a/src/librustc_mir/transform/simplify_branches.rs
+++ b/src/librustc_mir/transform/simplify_branches.rs
@@ -57,7 +57,7 @@ impl MirPass for SimplifyBranches {
                 TerminatorKind::Assert {
                     target, cond: Operand::Constant(ref c), expected, ..
                 } if (c.literal.assert_bool(tcx) == Some(true)) == expected => {
-                    TerminatorKind::Goto { target: target }
+                    TerminatorKind::Goto { target }
                 },
                 TerminatorKind::FalseEdges { real_target, .. } => {
                     TerminatorKind::Goto { target: real_target }

--- a/src/librustc_passes/ast_validation.rs
+++ b/src/librustc_passes/ast_validation.rs
@@ -691,5 +691,5 @@ pub fn check_crate(session: &Session, krate: &Crate) {
             is_banned: false,
         }, krate);
 
-    visit::walk_crate(&mut AstValidator { session: session }, krate)
+    visit::walk_crate(&mut AstValidator { session }, krate)
 }

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -4424,7 +4424,7 @@ impl<'a, 'crateloader: 'a> Resolver<'a, 'crateloader> {
                         // declared as public (due to pruning, we don't explore
                         // outside crate private modules => no need to check this)
                         if !in_module_is_extern || name_binding.vis == ty::Visibility::Public {
-                            candidates.push(ImportSuggestion { path: path });
+                            candidates.push(ImportSuggestion { path });
                         }
                     }
                 }
@@ -4533,7 +4533,7 @@ impl<'a, 'crateloader: 'a> Resolver<'a, 'crateloader> {
                             span: name_binding.span,
                             segments: path_segments,
                         };
-                        result = Some((module, ImportSuggestion { path: path }));
+                        result = Some((module, ImportSuggestion { path }));
                     } else {
                         // add the module to the lookup
                         if seen_modules.insert(module.def_id().unwrap()) {

--- a/src/librustc_save_analysis/json_dumper.rs
+++ b/src/librustc_save_analysis/json_dumper.rs
@@ -71,7 +71,7 @@ impl<'b> JsonDumper<CallbackOutput<'b>> {
         config: Config,
     ) -> JsonDumper<CallbackOutput<'b>> {
         JsonDumper {
-            output: CallbackOutput { callback: callback },
+            output: CallbackOutput { callback },
             config: config.clone(),
             result: Analysis::new(config),
         }

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -962,7 +962,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
             AdtField { ty: field_ty, span: field.span }
         })
         .collect();
-        AdtVariant { fields: fields }
+        AdtVariant { fields }
     }
 
     fn enum_variants(&self, enum_def: &hir::EnumDef) -> Vec<AdtVariant<'tcx>> {

--- a/src/librustc_typeck/coherence/orphan.rs
+++ b/src/librustc_typeck/coherence/orphan.rs
@@ -17,7 +17,7 @@ use rustc::hir::itemlikevisit::ItemLikeVisitor;
 use rustc::hir;
 
 pub fn check<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
-    let mut orphan = OrphanChecker { tcx: tcx };
+    let mut orphan = OrphanChecker { tcx };
     tcx.hir.krate().visit_all_item_likes(&mut orphan);
 }
 

--- a/src/librustc_typeck/coherence/unsafety.rs
+++ b/src/librustc_typeck/coherence/unsafety.rs
@@ -16,7 +16,7 @@ use rustc::hir::itemlikevisit::ItemLikeVisitor;
 use rustc::hir::{self, Unsafety};
 
 pub fn check<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
-    let mut unsafety = UnsafetyChecker { tcx: tcx };
+    let mut unsafety = UnsafetyChecker { tcx };
     tcx.hir.krate().visit_all_item_likes(&mut unsafety);
 }
 

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -62,7 +62,7 @@ use std::iter;
 // Main entry point
 
 pub fn collect_item_types<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
-    let mut visitor = CollectItemTypesVisitor { tcx: tcx };
+    let mut visitor = CollectItemTypesVisitor { tcx };
     tcx.hir
        .krate()
        .visit_all_item_likes(&mut visitor.as_deep_visitor());

--- a/src/librustc_typeck/impl_wf_check.rs
+++ b/src/librustc_typeck/impl_wf_check.rs
@@ -62,7 +62,7 @@ pub fn impl_wf_check<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
     // We will tag this as part of the WF check -- logically, it is,
     // but it's one that we must perform earlier than the rest of
     // WfCheck.
-    tcx.hir.krate().visit_all_item_likes(&mut ImplWfCheck { tcx: tcx });
+    tcx.hir.krate().visit_all_item_likes(&mut ImplWfCheck { tcx });
 }
 
 struct ImplWfCheck<'a, 'tcx: 'a> {

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2959,7 +2959,7 @@ impl<'tcx> Clean<Item> for ty::VariantDef {
             source: cx.tcx.def_span(self.did).clean(cx),
             visibility: Some(Inherited),
             def_id: self.did,
-            inner: VariantItem(Variant { kind: kind }),
+            inner: VariantItem(Variant { kind }),
             stability: get_stability(cx, self.did),
             deprecation: get_deprecation(cx, self.did),
         }

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -2854,7 +2854,7 @@ mod test_map {
                 slot.borrow_mut()[k] += 1;
             });
 
-            Droppable { k: k }
+            Droppable { k }
         }
     }
 

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -877,7 +877,7 @@ impl OpenOptions {
 
     fn _open(&self, path: &Path) -> io::Result<File> {
         let inner = fs_imp::File::open(path, &self.0)?;
-        Ok(File { inner: inner })
+        Ok(File { inner })
     }
 }
 

--- a/src/libstd/io/util.rs
+++ b/src/libstd/io/util.rs
@@ -150,7 +150,7 @@ pub struct Repeat { byte: u8 }
 /// assert_eq!(buffer, [0b101, 0b101, 0b101]);
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-pub fn repeat(byte: u8) -> Repeat { Repeat { byte: byte } }
+pub fn repeat(byte: u8) -> Repeat { Repeat { byte } }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Read for Repeat {

--- a/src/libstd/sync/mpsc/mod.rs
+++ b/src/libstd/sync/mpsc/mod.rs
@@ -931,7 +931,7 @@ impl<T> fmt::Debug for Sender<T> {
 
 impl<T> SyncSender<T> {
     fn new(inner: Arc<sync::Packet<T>>) -> SyncSender<T> {
-        SyncSender { inner: inner }
+        SyncSender { inner }
     }
 
     /// Sends a value on this synchronous channel.

--- a/src/libstd/sys/cloudabi/time.rs
+++ b/src/libstd/sys/cloudabi/time.rs
@@ -32,7 +32,7 @@ impl Instant {
             let mut t = mem::uninitialized();
             let ret = abi::clock_time_get(abi::clockid::MONOTONIC, 0, &mut t);
             assert_eq!(ret, abi::errno::SUCCESS);
-            Instant { t: t }
+            Instant { t }
         }
     }
 
@@ -71,7 +71,7 @@ impl SystemTime {
             let mut t = mem::uninitialized();
             let ret = abi::clock_time_get(abi::clockid::REALTIME, 0, &mut t);
             assert_eq!(ret, abi::errno::SUCCESS);
-            SystemTime { t: t }
+            SystemTime { t }
         }
     }
 

--- a/src/libstd/sys/redox/fd.rs
+++ b/src/libstd/sys/redox/fd.rs
@@ -21,7 +21,7 @@ pub struct FileDesc {
 
 impl FileDesc {
     pub fn new(fd: usize) -> FileDesc {
-        FileDesc { fd: fd }
+        FileDesc { fd }
     }
 
     pub fn raw(&self) -> usize { self.fd }

--- a/src/libstd/sys/redox/fs.rs
+++ b/src/libstd/sys/redox/fs.rs
@@ -264,7 +264,7 @@ impl File {
     pub fn file_attr(&self) -> io::Result<FileAttr> {
         let mut stat = syscall::Stat::default();
         cvt(syscall::fstat(self.0.raw(), &mut stat))?;
-        Ok(FileAttr { stat: stat })
+        Ok(FileAttr { stat })
     }
 
     pub fn fsync(&self) -> io::Result<()> {

--- a/src/libstd/sys/redox/syscall/error.rs
+++ b/src/libstd/sys/redox/syscall/error.rs
@@ -19,7 +19,7 @@ pub type Result<T> = result::Result<T, Error>;
 
 impl Error {
     pub fn new(errno: i32) -> Error {
-        Error { errno: errno }
+        Error { errno }
     }
 
     pub fn mux(result: Result<usize>) -> usize {

--- a/src/libstd/sys/redox/thread.rs
+++ b/src/libstd/sys/redox/thread.rs
@@ -38,7 +38,7 @@ impl Thread {
             panic!("thread failed to exit");
         } else {
             mem::forget(p);
-            Ok(Thread { id: id })
+            Ok(Thread { id })
         }
     }
 

--- a/src/libstd/sys/redox/time.rs
+++ b/src/libstd/sys/redox/time.rs
@@ -187,7 +187,7 @@ impl SystemTime {
 
 impl From<syscall::TimeSpec> for SystemTime {
     fn from(t: syscall::TimeSpec) -> SystemTime {
-        SystemTime { t: Timespec { t: t } }
+        SystemTime { t: Timespec { t } }
     }
 }
 

--- a/src/libstd/sys/unix/fd.rs
+++ b/src/libstd/sys/unix/fd.rs
@@ -41,7 +41,7 @@ fn max_len() -> usize {
 
 impl FileDesc {
     pub fn new(fd: c_int) -> FileDesc {
-        FileDesc { fd: fd }
+        FileDesc { fd }
     }
 
     pub fn raw(&self) -> c_int { self.fd }

--- a/src/libstd/sys/unix/fs.rs
+++ b/src/libstd/sys/unix/fs.rs
@@ -317,7 +317,7 @@ impl DirEntry {
         cvt(unsafe {
             fstatat64(fd, self.entry.d_name.as_ptr(), &mut stat, libc::AT_SYMLINK_NOFOLLOW)
         })?;
-        Ok(FileAttr { stat: stat })
+        Ok(FileAttr { stat })
     }
 
     #[cfg(not(any(target_os = "linux", target_os = "emscripten", target_os = "android")))]
@@ -526,7 +526,7 @@ impl File {
         cvt(unsafe {
             fstat64(self.0.raw(), &mut stat)
         })?;
-        Ok(FileAttr { stat: stat })
+        Ok(FileAttr { stat })
     }
 
     pub fn fsync(&self) -> io::Result<()> {
@@ -807,7 +807,7 @@ pub fn stat(p: &Path) -> io::Result<FileAttr> {
     cvt(unsafe {
         stat64(p.as_ptr(), &mut stat)
     })?;
-    Ok(FileAttr { stat: stat })
+    Ok(FileAttr { stat })
 }
 
 pub fn lstat(p: &Path) -> io::Result<FileAttr> {
@@ -816,7 +816,7 @@ pub fn lstat(p: &Path) -> io::Result<FileAttr> {
     cvt(unsafe {
         lstat64(p.as_ptr(), &mut stat)
     })?;
-    Ok(FileAttr { stat: stat })
+    Ok(FileAttr { stat })
 }
 
 pub fn canonicalize(p: &Path) -> io::Result<PathBuf> {

--- a/src/libstd/sys/unix/time.rs
+++ b/src/libstd/sys/unix/time.rs
@@ -217,7 +217,7 @@ mod inner {
 
     impl From<libc::timespec> for SystemTime {
         fn from(t: libc::timespec) -> SystemTime {
-            SystemTime { t: Timespec { t: t } }
+            SystemTime { t: Timespec { t } }
         }
     }
 
@@ -332,7 +332,7 @@ mod inner {
 
     impl From<libc::timespec> for SystemTime {
         fn from(t: libc::timespec) -> SystemTime {
-            SystemTime { t: Timespec { t: t } }
+            SystemTime { t: Timespec { t } }
         }
     }
 

--- a/src/libstd/sys/windows/process.rs
+++ b/src/libstd/sys/windows/process.rs
@@ -241,7 +241,7 @@ impl<'a> DropGuard<'a> {
     fn new(lock: &'a Mutex) -> DropGuard<'a> {
         unsafe {
             lock.lock();
-            DropGuard { lock: lock }
+            DropGuard { lock }
         }
     }
 }

--- a/src/libstd/sys/windows/time.rs
+++ b/src/libstd/sys/windows/time.rs
@@ -170,7 +170,7 @@ impl fmt::Debug for SystemTime {
 
 impl From<c::FILETIME> for SystemTime {
     fn from(t: c::FILETIME) -> SystemTime {
-        SystemTime { t: t }
+        SystemTime { t }
     }
 }
 

--- a/src/libstd/sys_common/poison.rs
+++ b/src/libstd/sys_common/poison.rs
@@ -174,7 +174,7 @@ impl<T> PoisonError<T> {
     /// [`RwLock::read`]: ../../std/sync/struct.RwLock.html#method.read
     #[stable(feature = "sync_poison", since = "1.2.0")]
     pub fn new(guard: T) -> PoisonError<T> {
-        PoisonError { guard: guard }
+        PoisonError { guard }
     }
 
     /// Consumes this error indicating that a lock is poisoned, returning the

--- a/src/libstd/sys_common/wtf8.rs
+++ b/src/libstd/sys_common/wtf8.rs
@@ -67,7 +67,7 @@ impl CodePoint {
     /// Only use when `value` is known to be less than or equal to 0x10FFFF.
     #[inline]
     pub unsafe fn from_u32_unchecked(value: u32) -> CodePoint {
-        CodePoint { value: value }
+        CodePoint { value }
     }
 
     /// Creates a new `CodePoint` if the value is a valid code point.
@@ -76,7 +76,7 @@ impl CodePoint {
     #[inline]
     pub fn from_u32(value: u32) -> Option<CodePoint> {
         match value {
-            0 ..= 0x10FFFF => Some(CodePoint { value: value }),
+            0 ..= 0x10FFFF => Some(CodePoint { value }),
             _ => None
         }
     }

--- a/src/libsyntax/ext/source_util.rs
+++ b/src/libsyntax/ext/source_util.rs
@@ -126,7 +126,7 @@ pub fn expand_include<'cx>(cx: &'cx mut ExtCtxt, sp: Span, tts: &[tokenstream::T
         }
     }
 
-    Box::new(ExpandResult { p: p })
+    Box::new(ExpandResult { p })
 }
 
 // include_str! : read the given file, insert it as a literal string expr

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -944,7 +944,7 @@ pub fn noop_fold_item_kind<T: Folder>(i: ItemKind, folder: &mut T) -> ItemKind {
         ItemKind::Enum(enum_definition, generics) => {
             let generics = folder.fold_generics(generics);
             let variants = enum_definition.variants.move_map(|x| folder.fold_variant(x));
-            ItemKind::Enum(ast::EnumDef { variants: variants }, generics)
+            ItemKind::Enum(ast::EnumDef { variants }, generics)
         }
         ItemKind::Struct(struct_def, generics) => {
             let generics = folder.fold_generics(generics);

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -6871,7 +6871,7 @@ impl<'a> Parser<'a> {
             _ => ()
         }
 
-        Ok(ast::EnumDef { variants: variants })
+        Ok(ast::EnumDef { variants })
     }
 
     /// Parse an "enum" declaration


### PR DESCRIPTION
refactor: use shorthand for single fields everywhere (excluding tests).