### PR TITLE
Avoid panic when matching function call

### DIFF
--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -802,6 +802,7 @@ https://doc.rust-lang.org/reference/types.html#trait-objects");
 
         // Resolve the path and check the definition for errors.
         let (def, opt_ty, segments) = self.resolve_ty_and_def_ufcs(qpath, pat.id, pat.span);
+
         if def == Def::Err {
             self.set_tainted_by_errors();
             on_error();
@@ -814,11 +815,6 @@ https://doc.rust-lang.org/reference/types.html#trait-objects");
             report_unexpected_def(def);
             return self.tcx.types.err;
         }
-        // Replace constructor type with constructed type for tuple struct patterns.
-        let pat_ty = pat_ty.fn_sig(tcx).output();
-        let pat_ty = pat_ty.no_bound_vars().expect("expected fn type");
-
-        self.demand_eqtype(pat.span, expected, pat_ty);
 
         let variant = match def {
             Def::Err => {
@@ -836,6 +832,13 @@ https://doc.rust-lang.org/reference/types.html#trait-objects");
             }
             _ => bug!("unexpected pattern definition: {:?}", def)
         };
+
+        // Replace constructor type with constructed type for tuple struct patterns.
+        let pat_ty = pat_ty.fn_sig(tcx).output();
+        let pat_ty = pat_ty.no_bound_vars().expect("expected fn type");
+
+        self.demand_eqtype(pat.span, expected, pat_ty);
+
         // Type check subpatterns.
         if subpats.len() == variant.fields.len() ||
                 subpats.len() < variant.fields.len() && ddpos.is_some() {

--- a/src/test/ui/match/match-fn-call.rs
+++ b/src/test/ui/match/match-fn-call.rs
@@ -1,0 +1,10 @@
+use std::path::Path;
+
+fn main() {
+    let path = Path::new("foo");
+    match path {
+        Path::new("foo") => println!("foo"),
+        Path::new("bar") => println!("bar"),
+        _ => (),
+    }
+}

--- a/src/test/ui/match/match-fn-call.stderr
+++ b/src/test/ui/match/match-fn-call.stderr
@@ -1,0 +1,15 @@
+error[E0164]: expected tuple struct/variant, found method `<Path>::new`
+  --> $DIR/match-fn-call.rs:6:9
+   |
+LL |         Path::new("foo") => println!("foo"),
+   |         ^^^^^^^^^^^^^^^^ not a tuple variant or struct
+
+error[E0164]: expected tuple struct/variant, found method `<Path>::new`
+  --> $DIR/match-fn-call.rs:7:9
+   |
+LL |         Path::new("bar") => println!("bar"),
+   |         ^^^^^^^^^^^^^^^^ not a tuple variant or struct
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0164`.


### PR DESCRIPTION
Fix #55718

This bug is introduced by #53751. The original code checked `Def::AssociatedConst(..) | Def::Method(..)` before `pat_ty.no_bound_vars().expect("expected fn type")`. But somehow I exchanged the sequence carelessly. Sorry about that.

r? @petrochenkov 