### PR TITLE
Disable some pretty-printers when gdb is rust-enabled

### DIFF
--- a/src/etc/gdb_rust_pretty_printing.py
+++ b/src/etc/gdb_rust_pretty_printing.py
@@ -18,6 +18,8 @@ import debugger_pretty_printers_common as rustpp
 if sys.version_info[0] >= 3:
     xrange = range
 
+rust_enabled = 'set language rust' in gdb.execute('complete set language ru', to_string = True)
+
 #===============================================================================
 # GDB Pretty Printing Module for Rust
 #===============================================================================
@@ -99,26 +101,8 @@ def rust_pretty_printer_lookup_function(gdb_val):
     val = GdbValue(gdb_val)
     type_kind = val.type.get_type_kind()
 
-    if type_kind == rustpp.TYPE_KIND_EMPTY:
-        return RustEmptyPrinter(val)
-
-    if type_kind == rustpp.TYPE_KIND_REGULAR_STRUCT:
-        return RustStructPrinter(val,
-                                 omit_first_field = False,
-                                 omit_type_name = False,
-                                 is_tuple_like = False)
-
-    if type_kind == rustpp.TYPE_KIND_STRUCT_VARIANT:
-        return RustStructPrinter(val,
-                                 omit_first_field = True,
-                                 omit_type_name = False,
-                                 is_tuple_like = False)
-
     if type_kind == rustpp.TYPE_KIND_SLICE:
         return RustSlicePrinter(val)
-
-    if type_kind == rustpp.TYPE_KIND_STR_SLICE:
-        return RustStringSlicePrinter(val)
 
     if type_kind == rustpp.TYPE_KIND_STD_VEC:
         return RustStdVecPrinter(val)
@@ -137,6 +121,29 @@ def rust_pretty_printer_lookup_function(gdb_val):
 
     if type_kind == rustpp.TYPE_KIND_OS_STRING:
         return RustOsStringPrinter(val)
+
+    # Checks after this point should only be for "compiler" types --
+    # things that gdb's Rust language support knows about.
+    if rust_enabled:
+        return None
+
+    if type_kind == rustpp.TYPE_KIND_EMPTY:
+        return RustEmptyPrinter(val)
+
+    if type_kind == rustpp.TYPE_KIND_REGULAR_STRUCT:
+        return RustStructPrinter(val,
+                                 omit_first_field = False,
+                                 omit_type_name = False,
+                                 is_tuple_like = False)
+
+    if type_kind == rustpp.TYPE_KIND_STRUCT_VARIANT:
+        return RustStructPrinter(val,
+                                 omit_first_field = True,
+                                 omit_type_name = False,
+                                 is_tuple_like = False)
+
+    if type_kind == rustpp.TYPE_KIND_STR_SLICE:
+        return RustStringSlicePrinter(val)
 
     if type_kind == rustpp.TYPE_KIND_TUPLE:
         return RustStructPrinter(val,

--- a/src/test/debuginfo/gdb-pretty-struct-and-enums.rs
+++ b/src/test/debuginfo/gdb-pretty-struct-and-enums.rs
@@ -8,34 +8,34 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-bitrig
-// ignore-solaris
-// ignore-windows failing on win32 bot
-// ignore-freebsd: gdb package too new
 // ignore-tidy-linelength
 // ignore-lldb
 // ignore-android: FIXME(#10381)
+// min-gdb-version: 7.11
+
 // compile-flags:-g
 
 // gdb-command: run
 
 // gdb-command: print regular_struct
-// gdb-check:$1 = RegularStruct = {the_first_field = 101, the_second_field = 102.5, the_third_field = false}
+// gdbg-check:$1 = RegularStruct = {the_first_field = 101, the_second_field = 102.5, the_third_field = false}
+// gdbr-check:$1 = gdb_pretty_struct_and_enums::RegularStruct {the_first_field: 101, the_second_field: 102.5, the_third_field: false}
 
 // gdb-command: print empty_struct
-// gdb-check:$2 = EmptyStruct
+// gdbg-check:$2 = EmptyStruct
+// gdbr-check:$2 = gdb_pretty_struct_and_enums::EmptyStruct
 
 // gdb-command: print c_style_enum1
 // gdbg-check:$3 = CStyleEnumVar1
-// gdbr-check:$3 = gdb_pretty_struct_and_enums_pre_gdb_7_7::CStyleEnum::CStyleEnumVar1
+// gdbr-check:$3 = gdb_pretty_struct_and_enums::CStyleEnum::CStyleEnumVar1
 
 // gdb-command: print c_style_enum2
 // gdbg-check:$4 = CStyleEnumVar2
-// gdbr-check:$4 = gdb_pretty_struct_and_enums_pre_gdb_7_7::CStyleEnum::CStyleEnumVar2
+// gdbr-check:$4 = gdb_pretty_struct_and_enums::CStyleEnum::CStyleEnumVar2
 
 // gdb-command: print c_style_enum3
 // gdbg-check:$5 = CStyleEnumVar3
-// gdbr-check:$5 = gdb_pretty_struct_and_enums_pre_gdb_7_7::CStyleEnum::CStyleEnumVar3
+// gdbr-check:$5 = gdb_pretty_struct_and_enums::CStyleEnum::CStyleEnumVar3
 
 #![allow(dead_code, unused_variables)]
 


### PR DESCRIPTION
A rust-enabled gdb already knows how to display string slices,
structs, tuples, and enums (and after #54004, the pretty-printers
can't handle enums at all).  This patch disables these pretty-printers
when gdb is rust-enabled.

The "gdb-pretty-struct-and-enums-pre-gdb-7-7.rs" test is renamed,
because it does not seem to depend on any behavior of that version of
gdb, and because gdb 7.7 is 4 years old now.