### PR TITLE
wasm32-unknown-emscripten expects the rust_eh_personality symbol

### DIFF
--- a/src/libpanic_abort/lib.rs
+++ b/src/libpanic_abort/lib.rs
@@ -97,7 +97,10 @@ pub unsafe extern fn __rust_start_panic(_payload: usize) -> u32 {
 pub mod personalities {
     #[no_mangle]
     #[cfg(not(any(
-        target_arch = "wasm32",
+        all(
+            target_arch = "wasm32",
+            not(target_os = "emscripten"),
+        ),
         all(
             target_os = "windows",
             target_env = "gnu",


### PR DESCRIPTION
The `wasm32-unknown-emscripten` expects the `rust_eh_personality` symbol to be there, but a cfg checking for `target_arch = "wasm32"` which was meant to remove the symbol from the `wasm32-unknown-unknown` target, didn't check for whether `emscripten` is targeted or not, so the symbol accidentally got filtered out there as well.

Fixes #55276