### PR TITLE
Use placeholder scopes when promoting consts

### DIFF
--- a/src/librustc_mir/transform/promote_consts.rs
+++ b/src/librustc_mir/transform/promote_consts.rs
@@ -408,10 +408,8 @@ pub fn promote_candidates<'a, 'tcx>(mir: &mut Mir<'tcx>,
         let promoter = Promoter {
             promoted: Mir::new(
                 IndexVec::new(),
-                // FIXME: maybe try to filter this to avoid blowing up
-                // memory usage?
-                mir.source_scopes.clone(),
-                mir.source_scope_local_data.clone(),
+                IndexVec::new(),
+                ClearCrossCrate::Clear,
                 IndexVec::new(),
                 None,
                 initial_locals,


### PR DESCRIPTION
I haven't seen `source_scopes` or `source_scope_local_data` actually being used by `promote_candidate` and while I'm kind of suspicious that I might have missed something, this change still passes all the tests I am able to run.

If this is in fact a good idea, it should be a nice perf win.

r? @oli-obk 