### PR TITLE
rustc: Request ansi colors if stderr isn't a tty

### DIFF
--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -108,7 +108,13 @@ pub enum ColorConfig {
 impl ColorConfig {
     fn to_color_choice(&self) -> ColorChoice {
         match *self {
-            ColorConfig::Always => ColorChoice::Always,
+            ColorConfig::Always => {
+                if atty::is(atty::Stream::Stderr) {
+                    ColorChoice::Always
+                } else {
+                    ColorChoice::AlwaysAnsi
+                }
+            }
             ColorConfig::Never => ColorChoice::Never,
             ColorConfig::Auto if atty::is(atty::Stream::Stderr) => {
                 ColorChoice::Auto


### PR DESCRIPTION
Currently Cargo will always capture the output of rustc meaning that
rustc is never hooked up to a tty. To retain colors Cargo uses the
`fwdansi` crate to ensure that ansi color codes are translated to
windows terminal methods (and ansi codes otherwise just go their natural
route on Unix).

Cargo passes `--color always` to rustc to ensure that using a pipe
doesn't trick it into not emitting colors at all. It turns out, however,
that `--color always` ends up still accidentally using the native shell
api on native windows shells.

The fix here is to instead pass `AlwaysAnsi` to `termcolor` instead of
`Always`, ensuring that when `--color always` is passed to rustc and its
output isn't a terminal, we're always generating ansi colors regardless
of the platform.

Closes #55769