### PR TITLE
Rollup of 16 pull requests

### DIFF
--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -1465,6 +1465,20 @@ extern "rust-intrinsic" {
     /// y < 0 or y >= N, where N is the width of T in bits.
     pub fn unchecked_shr<T>(x: T, y: T) -> T;
 
+    /// Performs rotate left.
+    /// The stabilized versions of this intrinsic are available on the integer
+    /// primitives via the `rotate_left` method. For example,
+    /// [`std::u32::rotate_left`](../../std/primitive.u32.html#method.rotate_left)
+    #[cfg(not(stage0))]
+    pub fn rotate_left<T>(x: T, y: T) -> T;
+
+    /// Performs rotate right.
+    /// The stabilized versions of this intrinsic are available on the integer
+    /// primitives via the `rotate_right` method. For example,
+    /// [`std::u32::rotate_right`](../../std/primitive.u32.html#method.rotate_right)
+    #[cfg(not(stage0))]
+    pub fn rotate_right<T>(x: T, y: T) -> T;
+
     /// Returns (a + b) mod 2<sup>N</sup>, where N is the width of T in bits.
     /// The stabilized versions of this intrinsic are available on the integer
     /// primitives via the `wrapping_add` method. For example,

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -2301,7 +2301,12 @@ assert_eq!(n.rotate_left(", $rot, "), m);
             #[rustc_const_unstable(feature = "const_int_rotate")]
             #[inline]
             pub const fn rotate_left(self, n: u32) -> Self {
-                (self << (n % $BITS)) | (self >> (($BITS - (n % $BITS)) % $BITS))
+                #[cfg(not(stage0))] {
+                    unsafe { intrinsics::rotate_left(self, n as $SelfT) }
+                }
+                #[cfg(stage0)] {
+                    (self << (n % $BITS)) | (self >> (($BITS - (n % $BITS)) % $BITS))
+                }
             }
         }
 
@@ -2326,7 +2331,12 @@ assert_eq!(n.rotate_right(", $rot, "), m);
             #[rustc_const_unstable(feature = "const_int_rotate")]
             #[inline]
             pub const fn rotate_right(self, n: u32) -> Self {
-                (self >> (n % $BITS)) | (self << (($BITS - (n % $BITS)) % $BITS))
+                #[cfg(not(stage0))] {
+                    unsafe { intrinsics::rotate_right(self, n as $SelfT) }
+                }
+                #[cfg(stage0)] {
+                    (self >> (n % $BITS)) | (self << (($BITS - (n % $BITS)) % $BITS))
+                }
             }
         }
 

--- a/src/libpanic_abort/lib.rs
+++ b/src/libpanic_abort/lib.rs
@@ -97,7 +97,10 @@ pub unsafe extern fn __rust_start_panic(_payload: usize) -> u32 {
 pub mod personalities {
     #[no_mangle]
     #[cfg(not(any(
-        target_arch = "wasm32",
+        all(
+            target_arch = "wasm32",
+            not(target_os = "emscripten"),
+        ),
         all(
             target_os = "windows",
             target_env = "gnu",

--- a/src/librustc/ich/impls_mir.rs
+++ b/src/librustc/ich/impls_mir.rs
@@ -37,68 +37,31 @@ impl_stable_hash_for!(struct mir::BasicBlockData<'tcx> { statements, terminator,
 impl_stable_hash_for!(struct mir::UnsafetyViolation { source_info, description, details, kind });
 impl_stable_hash_for!(struct mir::UnsafetyCheckResult { violations, unsafe_blocks });
 
-impl<'a> HashStable<StableHashingContext<'a>>
-for mir::BorrowKind {
-    #[inline]
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
-        mem::discriminant(self).hash_stable(hcx, hasher);
+impl_stable_hash_for!(enum mir::BorrowKind {
+    Shared,
+    Shallow,
+    Unique,
+    Mut { allow_two_phase_borrow },
+});
 
-        match *self {
-            mir::BorrowKind::Shared |
-            mir::BorrowKind::Shallow |
-            mir::BorrowKind::Unique => {}
-            mir::BorrowKind::Mut { allow_two_phase_borrow } => {
-                allow_two_phase_borrow.hash_stable(hcx, hasher);
-            }
-        }
-    }
-}
-
-
-impl<'a> HashStable<StableHashingContext<'a>>
-for mir::UnsafetyViolationKind {
-    #[inline]
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
-
-        mem::discriminant(self).hash_stable(hcx, hasher);
-
-        match *self {
-            mir::UnsafetyViolationKind::General => {}
-            mir::UnsafetyViolationKind::MinConstFn => {}
-            mir::UnsafetyViolationKind::ExternStatic(lint_node_id) |
-            mir::UnsafetyViolationKind::BorrowPacked(lint_node_id) => {
-                lint_node_id.hash_stable(hcx, hasher);
-            }
-
-        }
-    }
-}
+impl_stable_hash_for!(enum mir::UnsafetyViolationKind {
+    General,
+    MinConstFn,
+    ExternStatic(lint_node_id),
+    BorrowPacked(lint_node_id),
+});
 
 impl_stable_hash_for!(struct mir::Terminator<'tcx> {
     kind,
     source_info
 });
 
-impl<'a, 'gcx, T> HashStable<StableHashingContext<'a>> for mir::ClearCrossCrate<T>
-    where T: HashStable<StableHashingContext<'a>>
-{
-    #[inline]
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
-        mem::discriminant(self).hash_stable(hcx, hasher);
-        match *self {
-            mir::ClearCrossCrate::Clear => {}
-            mir::ClearCrossCrate::Set(ref value) => {
-                value.hash_stable(hcx, hasher);
-            }
-        }
+impl_stable_hash_for!(
+    impl<T> for enum mir::ClearCrossCrate<T> [ mir::ClearCrossCrate ] {
+        Clear,
+        Set(value),
     }
-}
+);
 
 impl<'a> HashStable<StableHashingContext<'a>> for mir::Local {
     #[inline]

--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -224,20 +224,10 @@ impl_stable_hash_for!(enum ty::BorrowKind {
     MutBorrow
 });
 
-impl<'a, 'gcx> HashStable<StableHashingContext<'a>>
-for ty::UpvarCapture<'gcx> {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
-        mem::discriminant(self).hash_stable(hcx, hasher);
-        match *self {
-            ty::UpvarCapture::ByValue => {}
-            ty::UpvarCapture::ByRef(ref up_var_borrow) => {
-                up_var_borrow.hash_stable(hcx, hasher);
-            }
-        }
-    }
-}
+impl_stable_hash_for!(impl<'gcx> for enum ty::UpvarCapture<'gcx> [ ty::UpvarCapture ] {
+    ByValue,
+    ByRef(up_var_borrow),
+});
 
 impl_stable_hash_for!(struct ty::GenSig<'tcx> {
     yield_ty,
@@ -272,64 +262,23 @@ impl_stable_hash_for!(enum ty::Visibility {
 impl_stable_hash_for!(struct ty::TraitRef<'tcx> { def_id, substs });
 impl_stable_hash_for!(struct ty::TraitPredicate<'tcx> { trait_ref });
 impl_stable_hash_for!(struct ty::SubtypePredicate<'tcx> { a_is_expected, a, b });
-
-impl<'a, 'gcx, A, B> HashStable<StableHashingContext<'a>>
-for ty::OutlivesPredicate<A, B>
-    where A: HashStable<StableHashingContext<'a>>,
-          B: HashStable<StableHashingContext<'a>>,
-{
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
-        let ty::OutlivesPredicate(ref a, ref b) = *self;
-        a.hash_stable(hcx, hasher);
-        b.hash_stable(hcx, hasher);
-    }
-}
-
+impl_stable_hash_for!(impl<A, B> for tuple_struct ty::OutlivesPredicate<A, B> { a, b });
 impl_stable_hash_for!(struct ty::ProjectionPredicate<'tcx> { projection_ty, ty });
 impl_stable_hash_for!(struct ty::ProjectionTy<'tcx> { substs, item_def_id });
 
-
-impl<'a, 'gcx> HashStable<StableHashingContext<'a>> for ty::Predicate<'gcx> {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
-        mem::discriminant(self).hash_stable(hcx, hasher);
-        match *self {
-            ty::Predicate::Trait(ref pred) => {
-                pred.hash_stable(hcx, hasher);
-            }
-            ty::Predicate::Subtype(ref pred) => {
-                pred.hash_stable(hcx, hasher);
-            }
-            ty::Predicate::RegionOutlives(ref pred) => {
-                pred.hash_stable(hcx, hasher);
-            }
-            ty::Predicate::TypeOutlives(ref pred) => {
-                pred.hash_stable(hcx, hasher);
-            }
-            ty::Predicate::Projection(ref pred) => {
-                pred.hash_stable(hcx, hasher);
-            }
-            ty::Predicate::WellFormed(ty) => {
-                ty.hash_stable(hcx, hasher);
-            }
-            ty::Predicate::ObjectSafe(def_id) => {
-                def_id.hash_stable(hcx, hasher);
-            }
-            ty::Predicate::ClosureKind(def_id, closure_substs, closure_kind) => {
-                def_id.hash_stable(hcx, hasher);
-                closure_substs.hash_stable(hcx, hasher);
-                closure_kind.hash_stable(hcx, hasher);
-            }
-            ty::Predicate::ConstEvaluatable(def_id, substs) => {
-                def_id.hash_stable(hcx, hasher);
-                substs.hash_stable(hcx, hasher);
-            }
-        }
+impl_stable_hash_for!(
+    impl<'tcx> for enum ty::Predicate<'tcx> [ ty::Predicate ] {
+        Trait(pred),
+        Subtype(pred),
+        RegionOutlives(pred),
+        TypeOutlives(pred),
+        Projection(pred),
+        WellFormed(ty),
+        ObjectSafe(def_id),
+        ClosureKind(def_id, closure_substs, closure_kind),
+        ConstEvaluatable(def_id, substs),
     }
-}
+);
 
 impl<'a> HashStable<StableHashingContext<'a>> for ty::AdtFlags {
     fn hash_stable<W: StableHasherResult>(&self,
@@ -358,70 +307,39 @@ impl_stable_hash_for!(struct ty::FieldDef {
     vis,
 });
 
-impl<'a, 'gcx> HashStable<StableHashingContext<'a>>
-for ::mir::interpret::ConstValue<'gcx> {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
-        use mir::interpret::ConstValue::*;
+impl_stable_hash_for!(
+    impl<'tcx> for enum mir::interpret::ConstValue<'tcx> [ mir::interpret::ConstValue ] {
+        Unevaluated(def_id, substs),
+        Scalar(val),
+        ScalarPair(a, b),
+        ByRef(id, alloc, offset),
+    }
+);
 
-        mem::discriminant(self).hash_stable(hcx, hasher);
-
-        match *self {
-            Unevaluated(def_id, substs) => {
-                def_id.hash_stable(hcx, hasher);
-                substs.hash_stable(hcx, hasher);
-            }
-            Scalar(val) => {
-                val.hash_stable(hcx, hasher);
-            }
-            ScalarPair(a, b) => {
-                a.hash_stable(hcx, hasher);
-                b.hash_stable(hcx, hasher);
-            }
-            ByRef(id, alloc, offset) => {
-                id.hash_stable(hcx, hasher);
-                alloc.hash_stable(hcx, hasher);
-                offset.hash_stable(hcx, hasher);
-            }
-        }
+impl_stable_hash_for! {
+    impl<Tag> for struct mir::interpret::Pointer<Tag> {
+        alloc_id,
+        offset,
+        tag,
     }
 }
 
-impl<'a, Tag> HashStable<StableHashingContext<'a>>
-for ::mir::interpret::Pointer<Tag>
-where Tag: HashStable<StableHashingContext<'a>>
-{
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
-        let ::mir::interpret::Pointer { alloc_id, offset, tag } = self;
-        alloc_id.hash_stable(hcx, hasher);
-        offset.hash_stable(hcx, hasher);
-        tag.hash_stable(hcx, hasher);
+impl_stable_hash_for!(
+    impl<Tag> for enum mir::interpret::Scalar<Tag> [ mir::interpret::Scalar ] {
+        Bits { bits, size },
+        Ptr(ptr),
     }
-}
+);
 
-impl<'a, Tag> HashStable<StableHashingContext<'a>>
-for ::mir::interpret::Scalar<Tag>
-where Tag: HashStable<StableHashingContext<'a>>
-{
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
-        use mir::interpret::Scalar::*;
-
-        mem::discriminant(self).hash_stable(hcx, hasher);
-        match self {
-            Bits { bits, size } => {
-                bits.hash_stable(hcx, hasher);
-                size.hash_stable(hcx, hasher);
-            },
-            Ptr(ptr) => ptr.hash_stable(hcx, hasher),
-        }
+impl_stable_hash_for!(
+    impl<'tcx, M> for enum mir::interpret::AllocType<'tcx, M> [ mir::interpret::AllocType ] {
+        Function(instance),
+        Static(def_id),
+        Memory(mem),
     }
-}
+);
 
+// AllocIds get resolved to whatever they point to (to be stable)
 impl<'a> HashStable<StableHashingContext<'a>> for mir::interpret::AllocId {
     fn hash_stable<W: StableHasherResult>(
         &self,
@@ -437,23 +355,7 @@ impl<'a> HashStable<StableHashingContext<'a>> for mir::interpret::AllocId {
     }
 }
 
-impl<'a, 'gcx, M: HashStable<StableHashingContext<'a>>> HashStable<StableHashingContext<'a>>
-for mir::interpret::AllocType<'gcx, M> {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
-        use mir::interpret::AllocType::*;
-
-        mem::discriminant(self).hash_stable(hcx, hasher);
-
-        match *self {
-            Function(instance) => instance.hash_stable(hcx, hasher),
-            Static(def_id) => def_id.hash_stable(hcx, hasher),
-            Memory(ref mem) => mem.hash_stable(hcx, hasher),
-        }
-    }
-}
-
+// Allocations treat their relocations specially
 impl<'a> HashStable<StableHashingContext<'a>> for mir::interpret::Allocation {
     fn hash_stable<W: StableHasherResult>(
         &self,
@@ -485,7 +387,7 @@ impl_stable_hash_for!(enum mir::interpret::ErrorHandled {
     TooGeneric
 });
 
-impl_stable_hash_for!(struct ::mir::interpret::FrameInfo {
+impl_stable_hash_for!(struct mir::interpret::FrameInfo {
     span,
     lint_root,
     location
@@ -499,124 +401,75 @@ impl_stable_hash_for!(struct ty::GenericPredicates<'tcx> {
     predicates
 });
 
-impl<'a, 'gcx, O: HashStable<StableHashingContext<'a>>> HashStable<StableHashingContext<'a>>
-for ::mir::interpret::EvalErrorKind<'gcx, O> {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
-        use mir::interpret::EvalErrorKind::*;
-
-        mem::discriminant(&self).hash_stable(hcx, hasher);
-
-        match *self {
-            FunctionArgCountMismatch |
-            DanglingPointerDeref |
-            DoubleFree |
-            InvalidMemoryAccess |
-            InvalidFunctionPointer |
-            InvalidBool |
-            InvalidNullPointerUsage |
-            ReadPointerAsBytes |
-            ReadBytesAsPointer |
-            ReadForeignStatic |
-            InvalidPointerMath |
-            DeadLocal |
-            StackFrameLimitReached |
-            OutOfTls |
-            TlsOutOfBounds |
-            CalledClosureAsFunction |
-            VtableForArgumentlessMethod |
-            ModifiedConstantMemory |
-            AssumptionNotHeld |
-            InlineAsm |
-            ReallocateNonBasePtr |
-            DeallocateNonBasePtr |
-            HeapAllocZeroBytes |
-            Unreachable |
-            ReadFromReturnPointer |
-            UnimplementedTraitSelection |
-            TypeckError |
-            TooGeneric |
-            DerefFunctionPointer |
-            ExecuteMemory |
-            OverflowNeg |
-            RemainderByZero |
-            DivisionByZero |
-            GeneratorResumedAfterReturn |
-            GeneratorResumedAfterPanic |
-            ReferencedConstant |
-            InfiniteLoop => {}
-            ReadUndefBytes(offset) => offset.hash_stable(hcx, hasher),
-            InvalidDiscriminant(val) => val.hash_stable(hcx, hasher),
-            Panic { ref msg, ref file, line, col } => {
-                msg.hash_stable(hcx, hasher);
-                file.hash_stable(hcx, hasher);
-                line.hash_stable(hcx, hasher);
-                col.hash_stable(hcx, hasher);
-            },
-            MachineError(ref err) => err.hash_stable(hcx, hasher),
-            FunctionAbiMismatch(a, b) => {
-                a.hash_stable(hcx, hasher);
-                b.hash_stable(hcx, hasher)
-            },
-            FunctionArgMismatch(a, b) => {
-                a.hash_stable(hcx, hasher);
-                b.hash_stable(hcx, hasher)
-            },
-            FunctionRetMismatch(a, b) => {
-                a.hash_stable(hcx, hasher);
-                b.hash_stable(hcx, hasher)
-            },
-            NoMirFor(ref s) => s.hash_stable(hcx, hasher),
-            UnterminatedCString(ptr) => ptr.hash_stable(hcx, hasher),
-            PointerOutOfBounds {
-                ptr,
-                access,
-                allocation_size,
-            } => {
-                ptr.hash_stable(hcx, hasher);
-                access.hash_stable(hcx, hasher);
-                allocation_size.hash_stable(hcx, hasher)
-            },
-            InvalidBoolOp(bop) => bop.hash_stable(hcx, hasher),
-            Unimplemented(ref s) => s.hash_stable(hcx, hasher),
-            BoundsCheck { ref len, ref index } => {
-                len.hash_stable(hcx, hasher);
-                index.hash_stable(hcx, hasher)
-            },
-            Intrinsic(ref s) => s.hash_stable(hcx, hasher),
-            InvalidChar(c) => c.hash_stable(hcx, hasher),
-            AbiViolation(ref s) => s.hash_stable(hcx, hasher),
-            AlignmentCheckFailed {
-                required,
-                has,
-            } => {
-                required.hash_stable(hcx, hasher);
-                has.hash_stable(hcx, hasher)
-            },
-            ValidationFailure(ref s) => s.hash_stable(hcx, hasher),
-            TypeNotPrimitive(ty) => ty.hash_stable(hcx, hasher),
-            ReallocatedWrongMemoryKind(ref a, ref b) => {
-                a.hash_stable(hcx, hasher);
-                b.hash_stable(hcx, hasher)
-            },
-            DeallocatedWrongMemoryKind(ref a, ref b) => {
-                a.hash_stable(hcx, hasher);
-                b.hash_stable(hcx, hasher)
-            },
-            IncorrectAllocationInformation(a, b, c, d) => {
-                a.hash_stable(hcx, hasher);
-                b.hash_stable(hcx, hasher);
-                c.hash_stable(hcx, hasher);
-                d.hash_stable(hcx, hasher)
-            },
-            Layout(lay) => lay.hash_stable(hcx, hasher),
-            HeapAllocNonPowerOfTwoAlignment(n) => n.hash_stable(hcx, hasher),
-            PathNotFound(ref v) => v.hash_stable(hcx, hasher),
-            Overflow(op) => op.hash_stable(hcx, hasher),
-        }
+impl_stable_hash_for!(
+    impl<'tcx, O> for enum mir::interpret::EvalErrorKind<'tcx, O>
+        [ mir::interpret::EvalErrorKind ]
+    {
+        FunctionArgCountMismatch,
+        DanglingPointerDeref,
+        DoubleFree,
+        InvalidMemoryAccess,
+        InvalidFunctionPointer,
+        InvalidBool,
+        InvalidNullPointerUsage,
+        ReadPointerAsBytes,
+        ReadBytesAsPointer,
+        ReadForeignStatic,
+        InvalidPointerMath,
+        DeadLocal,
+        StackFrameLimitReached,
+        OutOfTls,
+        TlsOutOfBounds,
+        CalledClosureAsFunction,
+        VtableForArgumentlessMethod,
+        ModifiedConstantMemory,
+        AssumptionNotHeld,
+        InlineAsm,
+        ReallocateNonBasePtr,
+        DeallocateNonBasePtr,
+        HeapAllocZeroBytes,
+        Unreachable,
+        ReadFromReturnPointer,
+        UnimplementedTraitSelection,
+        TypeckError,
+        TooGeneric,
+        DerefFunctionPointer,
+        ExecuteMemory,
+        OverflowNeg,
+        RemainderByZero,
+        DivisionByZero,
+        GeneratorResumedAfterReturn,
+        GeneratorResumedAfterPanic,
+        ReferencedConstant,
+        InfiniteLoop,
+        ReadUndefBytes(offset),
+        InvalidDiscriminant(val),
+        Panic { msg, file, line, col },
+        MachineError(err),
+        FunctionAbiMismatch(a, b),
+        FunctionArgMismatch(a, b),
+        FunctionRetMismatch(a, b),
+        NoMirFor(s),
+        UnterminatedCString(ptr),
+        PointerOutOfBounds { ptr, access, allocation_size },
+        InvalidBoolOp(bop),
+        Unimplemented(s),
+        BoundsCheck { len, index },
+        Intrinsic(s),
+        InvalidChar(c),
+        AbiViolation(s),
+        AlignmentCheckFailed { required, has },
+        ValidationFailure(s),
+        TypeNotPrimitive(ty),
+        ReallocatedWrongMemoryKind(a, b),
+        DeallocatedWrongMemoryKind(a, b),
+        IncorrectAllocationInformation(a, b, c, d),
+        Layout(lay),
+        HeapAllocNonPowerOfTwoAlignment(n),
+        PathNotFound(v),
+        Overflow(op),
     }
-}
+);
 
 impl_stable_hash_for!(enum mir::interpret::Lock {
     NoLock,
@@ -663,47 +516,18 @@ impl_stable_hash_for!(struct ty::GenericParamDef {
     kind
 });
 
-impl<'a> HashStable<StableHashingContext<'a>> for ty::GenericParamDefKind {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
-        mem::discriminant(self).hash_stable(hcx, hasher);
-        match *self {
-            ty::GenericParamDefKind::Lifetime => {}
-            ty::GenericParamDefKind::Type {
-                has_default,
-                ref object_lifetime_default,
-                ref synthetic,
-            } => {
-                has_default.hash_stable(hcx, hasher);
-                object_lifetime_default.hash_stable(hcx, hasher);
-                synthetic.hash_stable(hcx, hasher);
-            }
-        }
-    }
-}
+impl_stable_hash_for!(enum ty::GenericParamDefKind {
+    Lifetime,
+    Type { has_default, object_lifetime_default, synthetic },
+});
 
-impl<'a, 'gcx, T> HashStable<StableHashingContext<'a>>
-for ::middle::resolve_lifetime::Set1<T>
-    where T: HashStable<StableHashingContext<'a>>
-{
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
-        use middle::resolve_lifetime::Set1;
-
-        mem::discriminant(self).hash_stable(hcx, hasher);
-        match *self {
-            Set1::Empty |
-            Set1::Many => {
-                // Nothing to do.
-            }
-            Set1::One(ref value) => {
-                value.hash_stable(hcx, hasher);
-            }
-        }
+impl_stable_hash_for!(
+    impl<T> for enum ::middle::resolve_lifetime::Set1<T> [ ::middle::resolve_lifetime::Set1 ] {
+        Empty,
+        Many,
+        One(value),
     }
-}
+);
 
 impl_stable_hash_for!(enum ::middle::resolve_lifetime::LifetimeDefOrigin {
     ExplicitOrElided,
@@ -1250,7 +1074,7 @@ impl_stable_hash_for!(
 );
 
 impl_stable_hash_for!(
-    impl<'tcx> for struct infer::canonical::CanonicalVarValues<'tcx> {
+    struct infer::canonical::CanonicalVarValues<'tcx> {
         var_values
     }
 );
@@ -1369,7 +1193,7 @@ impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for traits::Goal<'tcx> {
 }
 
 impl_stable_hash_for!(
-    impl<'tcx> for struct traits::ProgramClause<'tcx> {
+    struct traits::ProgramClause<'tcx> {
         goal, hypotheses, category
     }
 );
@@ -1404,7 +1228,7 @@ impl_stable_hash_for!(struct ty::subst::UserSubsts<'tcx> { substs, user_self_ty 
 impl_stable_hash_for!(struct ty::subst::UserSelfTy<'tcx> { impl_def_id, self_ty });
 
 impl_stable_hash_for!(
-    impl<'tcx> for struct traits::Environment<'tcx> {
+    struct traits::Environment<'tcx> {
         clauses,
     }
 );

--- a/src/librustc/infer/error_reporting/mod.rs
+++ b/src/librustc/infer/error_reporting/mod.rs
@@ -178,6 +178,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
                 self.msg_span_from_early_bound_and_free_regions(region)
             }
             ty::ReStatic => ("the static lifetime".to_owned(), None),
+            ty::ReEmpty => ("an empty lifetime".to_owned(), None),
             _ => bug!("{:?}", region),
         }
     }

--- a/src/librustc/macros.rs
+++ b/src/librustc/macros.rs
@@ -81,6 +81,7 @@ macro_rules! __impl_stable_hash_field {
 
 #[macro_export]
 macro_rules! impl_stable_hash_for {
+    // Enums
     // FIXME(mark-i-m): Some of these should be `?` rather than `*`. See the git blame and change
     // them back when `?` is supported again.
     (enum $enum_name:path {
@@ -91,12 +92,37 @@ macro_rules! impl_stable_hash_for {
            $( { $($named_field:ident $(-> $named_delegate:tt)*),* } )*
         ),* $(,)*
     }) => {
-        impl<'a, 'tcx> ::rustc_data_structures::stable_hasher::HashStable<$crate::ich::StableHashingContext<'a>> for $enum_name {
+        impl_stable_hash_for!(
+            impl<> for enum $enum_name [ $enum_name ] { $( $variant
+                $( ( $($field $(-> $delegate)*),* ) )*
+                $( { $($named_field $(-> $named_delegate)*),* } )*
+            ),* }
+        );
+    };
+    // We want to use the enum name both in the `impl ... for $enum_name` as well as for
+    // importing all the variants. Unfortunately it seems we have to take the name
+    // twice for this purpose
+    (impl<$($lt:lifetime $(: $lt_bound:lifetime)* ),* $(,)* $($T:ident),* $(,)*>
+        for enum $enum_name:path
+        [ $enum_path:path ]
+    {
+        $( $variant:ident
+           // this incorrectly allows specifying both tuple-like and struct-like fields, as in `Variant(a,b){c,d}`,
+           // when it should be only one or the other
+           $( ( $($field:ident $(-> $delegate:tt)*),* ) )*
+           $( { $($named_field:ident $(-> $named_delegate:tt)*),* } )*
+        ),* $(,)*
+    }) => {
+        impl<'a, $($lt $(: $lt_bound)*,)* $($T,)*>
+            ::rustc_data_structures::stable_hasher::HashStable<$crate::ich::StableHashingContext<'a>>
+            for $enum_name
+            where $($T: ::rustc_data_structures::stable_hasher::HashStable<$crate::ich::StableHashingContext<'a>>),*
+        {
             #[inline]
             fn hash_stable<W: ::rustc_data_structures::stable_hasher::StableHasherResult>(&self,
                                                   __ctx: &mut $crate::ich::StableHashingContext<'a>,
                                                   __hasher: &mut ::rustc_data_structures::stable_hasher::StableHasher<W>) {
-                use $enum_name::*;
+                use $enum_path::*;
                 ::std::mem::discriminant(self).hash_stable(__ctx, __hasher);
 
                 match *self {
@@ -110,41 +136,17 @@ macro_rules! impl_stable_hash_for {
             }
         }
     };
+    // Structs
     // FIXME(mark-i-m): same here.
     (struct $struct_name:path { $($field:ident $(-> $delegate:tt)*),*  $(,)* }) => {
-        impl<'a, 'tcx> ::rustc_data_structures::stable_hasher::HashStable<$crate::ich::StableHashingContext<'a>> for $struct_name {
-            #[inline]
-            fn hash_stable<W: ::rustc_data_structures::stable_hasher::StableHasherResult>(&self,
-                                                  __ctx: &mut $crate::ich::StableHashingContext<'a>,
-                                                  __hasher: &mut ::rustc_data_structures::stable_hasher::StableHasher<W>) {
-                let $struct_name {
-                    $(ref $field),*
-                } = *self;
-
-                $( __impl_stable_hash_field!($field, __ctx, __hasher $(, $delegate)*) );*
-            }
-        }
+        impl_stable_hash_for!(
+            impl<'tcx> for struct $struct_name { $($field $(-> $delegate)*),* }
+        );
     };
-    // FIXME(mark-i-m): same here.
-    (tuple_struct $struct_name:path { $($field:ident $(-> $delegate:tt)*),*  $(,)* }) => {
-        impl<'a, 'tcx> ::rustc_data_structures::stable_hasher::HashStable<$crate::ich::StableHashingContext<'a>> for $struct_name {
-            #[inline]
-            fn hash_stable<W: ::rustc_data_structures::stable_hasher::StableHasherResult>(&self,
-                                                  __ctx: &mut $crate::ich::StableHashingContext<'a>,
-                                                  __hasher: &mut ::rustc_data_structures::stable_hasher::StableHasher<W>) {
-                let $struct_name (
-                    $(ref $field),*
-                ) = *self;
-
-                $( __impl_stable_hash_field!($field, __ctx, __hasher $(, $delegate)*) );*
-            }
-        }
-    };
-
-    (impl<$tcx:lifetime $(, $lt:lifetime $(: $lt_bound:lifetime)*)* $(, $T:ident)*> for struct $struct_name:path {
+    (impl<$($lt:lifetime $(: $lt_bound:lifetime)* ),* $(,)* $($T:ident),* $(,)*> for struct $struct_name:path {
         $($field:ident $(-> $delegate:tt)*),* $(,)*
     }) => {
-        impl<'a, $tcx, $($lt $(: $lt_bound)*,)* $($T,)*>
+        impl<'a, $($lt $(: $lt_bound)*,)* $($T,)*>
             ::rustc_data_structures::stable_hasher::HashStable<$crate::ich::StableHashingContext<'a>> for $struct_name
             where $($T: ::rustc_data_structures::stable_hasher::HashStable<$crate::ich::StableHashingContext<'a>>),*
         {
@@ -155,6 +157,32 @@ macro_rules! impl_stable_hash_for {
                 let $struct_name {
                     $(ref $field),*
                 } = *self;
+
+                $( __impl_stable_hash_field!($field, __ctx, __hasher $(, $delegate)*) );*
+            }
+        }
+    };
+    // Tuple structs
+    // We cannot use normale parentheses here, the parser won't allow it
+    // FIXME(mark-i-m): same here.
+    (tuple_struct $struct_name:path { $($field:ident $(-> $delegate:tt)*),*  $(,)* }) => {
+        impl_stable_hash_for!(
+            impl<'tcx> for tuple_struct $struct_name { $($field $(-> $delegate)*),* }
+        );
+    };
+    (impl<$($lt:lifetime $(: $lt_bound:lifetime)* ),* $(,)* $($T:ident),* $(,)*>
+     for tuple_struct $struct_name:path { $($field:ident $(-> $delegate:tt)*),*  $(,)* }) => {
+        impl<'a, $($lt $(: $lt_bound)*,)* $($T,)*>
+            ::rustc_data_structures::stable_hasher::HashStable<$crate::ich::StableHashingContext<'a>> for $struct_name
+            where $($T: ::rustc_data_structures::stable_hasher::HashStable<$crate::ich::StableHashingContext<'a>>),*
+        {
+            #[inline]
+            fn hash_stable<W: ::rustc_data_structures::stable_hasher::StableHasherResult>(&self,
+                                                  __ctx: &mut $crate::ich::StableHashingContext<'a>,
+                                                  __hasher: &mut ::rustc_data_structures::stable_hasher::StableHasher<W>) {
+                let $struct_name (
+                    $(ref $field),*
+                ) = *self;
 
                 $( __impl_stable_hash_field!($field, __ctx, __hasher $(, $delegate)*) );*
             }

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -304,6 +304,20 @@ impl<'tcx> Mir<'tcx> {
         })
     }
 
+    /// Returns an iterator over all user-declared mutable locals.
+    #[inline]
+    pub fn mut_vars_iter<'a>(&'a self) -> impl Iterator<Item = Local> + 'a {
+        (self.arg_count + 1..self.local_decls.len()).filter_map(move |index| {
+            let local = Local::new(index);
+            let decl = &self.local_decls[local];
+            if decl.is_user_variable.is_some() && decl.mutability == Mutability::Mut {
+                Some(local)
+            } else {
+                None
+            }
+        })
+    }
+
     /// Returns an iterator over all user-declared mutable arguments and locals.
     #[inline]
     pub fn mut_vars_and_args_iter<'a>(&'a self) -> impl Iterator<Item = Local> + 'a {

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -2083,7 +2083,7 @@ pub fn build_session_options_and_crate_config(
                         error_format,
                         &format!(
                             "optimization level needs to be \
-                             between 0-3 (instead was `{}`)",
+                             between 0-3, s or z (instead was `{}`)",
                             arg
                         ),
                     );

--- a/src/librustc/traits/specialize/mod.rs
+++ b/src/librustc/traits/specialize/mod.rs
@@ -396,7 +396,10 @@ fn to_pretty_impl_header(tcx: TyCtxt<'_, '_, '_>, impl_def_id: DefId) -> Option<
     if !substs.is_noop() {
         types_without_default_bounds.extend(substs.types());
         w.push('<');
-        w.push_str(&substs.iter().map(|k| k.to_string()).collect::<Vec<_>>().join(", "));
+        w.push_str(&substs.iter()
+            .map(|k| k.to_string())
+            .filter(|k| &k[..] != "'_")
+            .collect::<Vec<_>>().join(", "));
         w.push('>');
     }
 

--- a/src/librustc/ty/query/on_disk_cache.rs
+++ b/src/librustc/ty/query/on_disk_cache.rs
@@ -450,8 +450,7 @@ impl<'sess> OnDiskCache<'sess> {
                                      .map(|&(cnum, ..)| cnum)
                                      .max()
                                      .unwrap_or(0) + 1;
-            let mut map = IndexVec::new();
-            map.resize(map_size as usize, None);
+            let mut map = IndexVec::from_elem_n(None, map_size as usize);
 
             for &(prev_cnum, ref crate_name, crate_disambiguator) in prev_cnums {
                 let key = (crate_name.clone(), crate_disambiguator);

--- a/src/librustc_codegen_llvm/context.rs
+++ b/src/librustc_codegen_llvm/context.rs
@@ -726,6 +726,18 @@ fn declare_intrinsic(cx: &CodegenCx<'ll, '_>, key: &str) -> Option<&'ll Value> {
     ifn!("llvm.bitreverse.i64", fn(t_i64) -> t_i64);
     ifn!("llvm.bitreverse.i128", fn(t_i128) -> t_i128);
 
+    ifn!("llvm.fshl.i8", fn(t_i8, t_i8, t_i8) -> t_i8);
+    ifn!("llvm.fshl.i16", fn(t_i16, t_i16, t_i16) -> t_i16);
+    ifn!("llvm.fshl.i32", fn(t_i32, t_i32, t_i32) -> t_i32);
+    ifn!("llvm.fshl.i64", fn(t_i64, t_i64, t_i64) -> t_i64);
+    ifn!("llvm.fshl.i128", fn(t_i128, t_i128, t_i128) -> t_i128);
+
+    ifn!("llvm.fshr.i8", fn(t_i8, t_i8, t_i8) -> t_i8);
+    ifn!("llvm.fshr.i16", fn(t_i16, t_i16, t_i16) -> t_i16);
+    ifn!("llvm.fshr.i32", fn(t_i32, t_i32, t_i32) -> t_i32);
+    ifn!("llvm.fshr.i64", fn(t_i64, t_i64, t_i64) -> t_i64);
+    ifn!("llvm.fshr.i128", fn(t_i128, t_i128, t_i128) -> t_i128);
+
     ifn!("llvm.sadd.with.overflow.i8", fn(t_i8, t_i8) -> mk_struct!{t_i8, i1});
     ifn!("llvm.sadd.with.overflow.i16", fn(t_i16, t_i16) -> mk_struct!{t_i16, i1});
     ifn!("llvm.sadd.with.overflow.i32", fn(t_i32, t_i32) -> mk_struct!{t_i32, i1});

--- a/src/librustc_codegen_llvm/debuginfo/metadata.rs
+++ b/src/librustc_codegen_llvm/debuginfo/metadata.rs
@@ -23,6 +23,7 @@ use value::Value;
 use llvm;
 use llvm::debuginfo::{DIType, DIFile, DIScope, DIDescriptor,
                       DICompositeType, DILexicalBlock, DIFlags};
+use llvm_util;
 
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc::hir::CodegenFnAttrFlags;
@@ -1169,9 +1170,8 @@ fn prepare_union_metadata(
 fn use_enum_fallback(cx: &CodegenCx) -> bool {
     // On MSVC we have to use the fallback mode, because LLVM doesn't
     // lower variant parts to PDB.
-    return cx.sess().target.target.options.is_like_msvc || unsafe {
-        llvm::LLVMRustVersionMajor() < 7
-    };
+    return cx.sess().target.target.options.is_like_msvc
+        || llvm_util::get_major_version() < 7;
 }
 
 // Describes the members of an enum value: An enum is described as a union of

--- a/src/librustc_codegen_llvm/llvm_util.rs
+++ b/src/librustc_codegen_llvm/llvm_util.rs
@@ -256,6 +256,10 @@ pub fn print_version() {
     }
 }
 
+pub fn get_major_version() -> u32 {
+    unsafe { llvm::LLVMRustVersionMajor() }
+}
+
 pub fn print_passes() {
     // Can be called without initializing LLVM
     unsafe { llvm::LLVMRustPrintPasses(); }

--- a/src/librustc_codegen_llvm/meth.rs
+++ b/src/librustc_codegen_llvm/meth.rs
@@ -39,7 +39,7 @@ impl<'a, 'tcx> VirtualIndex {
         // Load the data pointer from the object.
         debug!("get_fn({:?}, {:?})", llvtable, self);
 
-        let llvtable = bx.pointercast(llvtable, fn_ty.llvm_type(bx.cx).ptr_to().ptr_to());
+        let llvtable = bx.pointercast(llvtable, fn_ty.ptr_to_llvm_type(bx.cx).ptr_to());
         let ptr_align = bx.tcx().data_layout.pointer_align;
         let ptr = bx.load(bx.inbounds_gep(llvtable, &[C_usize(bx.cx, self.0)]), ptr_align);
         bx.nonnull_metadata(ptr);

--- a/src/librustc_codegen_llvm/mir/mod.rs
+++ b/src/librustc_codegen_llvm/mir/mod.rs
@@ -12,6 +12,7 @@ use common::{C_i32, C_null};
 use libc::c_uint;
 use llvm::{self, BasicBlock};
 use llvm::debuginfo::DIScope;
+use llvm_util;
 use rustc::ty::{self, Ty, TypeFoldable, UpvarSubsts};
 use rustc::ty::layout::{LayoutOf, TyLayout};
 use rustc::mir::{self, Mir};
@@ -612,7 +613,7 @@ fn arg_local_refs(
             // doesn't actually strip the offset when splitting the closure
             // environment into its components so it ends up out of bounds.
             // (cuviper) It seems to be fine without the alloca on LLVM 6 and later.
-            let env_alloca = !env_ref && unsafe { llvm::LLVMRustVersionMajor() < 6 };
+            let env_alloca = !env_ref && llvm_util::get_major_version() < 6;
             let env_ptr = if env_alloca {
                 let scratch = PlaceRef::alloca(bx,
                     bx.cx.layout_of(tcx.mk_mut_ptr(arg.layout.ty)),

--- a/src/librustc_codegen_llvm/type_.rs
+++ b/src/librustc_codegen_llvm/type_.rs
@@ -234,6 +234,8 @@ impl Type {
     }
 
     pub fn ptr_to(&self) -> &Type {
+        assert_ne!(self.kind(), TypeKind::Function,
+                   "don't call ptr_to on function types, use ptr_to_llvm_type on FnType instead");
         unsafe {
             llvm::LLVMPointerType(self, 0)
         }

--- a/src/librustc_codegen_llvm/type_of.rs
+++ b/src/librustc_codegen_llvm/type_of.rs
@@ -265,7 +265,7 @@ impl<'tcx> LayoutLlvmExt<'tcx> for TyLayout<'tcx> {
                         ty::ParamEnv::reveal_all(),
                         &sig,
                     );
-                    FnType::new(cx, sig, &[]).llvm_type(cx).ptr_to()
+                    FnType::new(cx, sig, &[]).ptr_to_llvm_type(cx)
                 }
                 _ => self.scalar_llvm_type_at(cx, scalar, Size::ZERO)
             };

--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -108,7 +108,13 @@ pub enum ColorConfig {
 impl ColorConfig {
     fn to_color_choice(&self) -> ColorChoice {
         match *self {
-            ColorConfig::Always => ColorChoice::Always,
+            ColorConfig::Always => {
+                if atty::is(atty::Stream::Stderr) {
+                    ColorChoice::Always
+                } else {
+                    ColorChoice::AlwaysAnsi
+                }
+            }
             ColorConfig::Never => ColorChoice::Never,
             ColorConfig::Auto if atty::is(atty::Stream::Stderr) => {
                 ColorChoice::Auto

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -377,6 +377,9 @@ impl<'a, 'mir, 'tcx: 'mir, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tc
                         // A field with extern type.  If this field is at offset 0 and the sized
                         // part makes no alignment constraints, we behave like the underlying
                         // extern type.
+                        // FIXME: Once we have made decisions for how to handle size and alignment
+                        // of `extern type`, this should be adapted.  It is just a temporary hack
+                        // to get some code to work that probably ought to work.
                         if sized_size == Size::ZERO && sized_align.abi() == 1 {
                             return Ok(None)
                         } else {

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -374,13 +374,12 @@ impl<'a, 'mir, 'tcx: 'mir, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tc
                 let (unsized_size, unsized_align) = match self.size_and_align_of(metadata, field)? {
                     Some(size_and_align) => size_and_align,
                     None => {
-                        // A field with extern type.  If this field is at offset 0 and the sized
-                        // part makes no alignment constraints, we behave like the underlying
-                        // extern type.
+                        // A field with extern type.  If this field is at offset 0, we behave
+                        // like the underlying extern type.
                         // FIXME: Once we have made decisions for how to handle size and alignment
                         // of `extern type`, this should be adapted.  It is just a temporary hack
                         // to get some code to work that probably ought to work.
-                        if sized_size == Size::ZERO && sized_align.abi() == 1 {
+                        if sized_size == Size::ZERO {
                             return Ok(None)
                         } else {
                             bug!("Fields cannot be extern types, unless they are at offset 0")

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -374,13 +374,13 @@ impl<'a, 'mir, 'tcx: 'mir, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tc
                 let (unsized_size, unsized_align) = match self.size_and_align_of(metadata, field)? {
                     Some(size_and_align) => size_and_align,
                     None => {
-                        // A field with extern type.  If this is the only field,
-                        // we treat this struct just the same.  Else, this is an error
-                        // (for now).
-                        if layout.fields.count() == 1 {
+                        // A field with extern type.  If this field is at offset 0 and the sized
+                        // part makes no alignment constraints, we behave like the underlying
+                        // extern type.
+                        if sized_size == Size::ZERO && sized_align.abi() == 1 {
                             return Ok(None)
                         } else {
-                            bug!("Fields cannot be extern types, unless they are the only field")
+                            bug!("Fields cannot be extern types, unless they are at offset 0")
                         }
                     }
                 };

--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -353,9 +353,10 @@ where
         // Offset may need adjustment for unsized fields
         let (meta, offset) = if field_layout.is_unsized() {
             // re-use parent metadata to determine dynamic field layout
-            let (_, align) = self.size_and_align_of(base.meta, field_layout)?
-                // If this is an extern type, we fall back to its static size and alignment.
-                .unwrap_or_else(|| base.layout.size_and_align());
+            let align = self.size_and_align_of(base.meta, field_layout)?
+                .map(|(_, align)| align)
+                // If this is an extern type, we fall back to its static alignment.
+                .unwrap_or_else(|| base.layout.align);
             (base.meta, offset.abi_align(align))
         } else {
             // base.meta could be present; we might be accessing a sized field of an unsized

--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -353,13 +353,17 @@ where
         // Offset may need adjustment for unsized fields
         let (meta, offset) = if field_layout.is_unsized() {
             // re-use parent metadata to determine dynamic field layout
-            let align = self.size_and_align_of(base.meta, field_layout)?
-                .map(|(_, align)| align)
-                // If this is an extern type, we fall back to its static alignment.
-                // FIXME: Once we have made decisions for how to handle size and alignment
-                // of `extern type`, this should be adapted.  It is just a temporary hack
-                // to get some code to work that probably ought to work.
-                .unwrap_or_else(|| base.layout.align);
+            let align = match self.size_and_align_of(base.meta, field_layout)? {
+                Some((_, align)) => align,
+                None if offset == Size::ZERO =>
+                    // An extern type at offset 0, we fall back to its static alignment.
+                    // FIXME: Once we have made decisions for how to handle size and alignment
+                    // of `extern type`, this should be adapted.  It is just a temporary hack
+                    // to get some code to work that probably ought to work.
+                    field_layout.align,
+                None =>
+                    bug!("Cannot compute offset for extern type field at non-0 offset"),
+            };
             (base.meta, offset.abi_align(align))
         } else {
             // base.meta could be present; we might be accessing a sized field of an unsized

--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -356,6 +356,9 @@ where
             let align = self.size_and_align_of(base.meta, field_layout)?
                 .map(|(_, align)| align)
                 // If this is an extern type, we fall back to its static alignment.
+                // FIXME: Once we have made decisions for how to handle size and alignment
+                // of `extern type`, this should be adapted.  It is just a temporary hack
+                // to get some code to work that probably ought to work.
                 .unwrap_or_else(|| base.layout.align);
             (base.meta, offset.abi_align(align))
         } else {

--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -354,7 +354,8 @@ where
         let (meta, offset) = if field_layout.is_unsized() {
             // re-use parent metadata to determine dynamic field layout
             let (_, align) = self.size_and_align_of(base.meta, field_layout)?
-                .expect("Fields cannot be extern types");
+                // If this is an extern type, we fall back to its static size and alignment.
+                .unwrap_or_else(|| base.layout.size_and_align());
             (base.meta, offset.abi_align(align))
         } else {
             // base.meta could be present; we might be accessing a sized field of an unsized

--- a/src/librustc_mir/shim.rs
+++ b/src/librustc_mir/shim.rs
@@ -196,7 +196,7 @@ fn build_drop_shim<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     let source_info = SourceInfo { span, scope: OUTERMOST_SOURCE_SCOPE };
 
     let return_block = BasicBlock::new(1);
-    let mut blocks = IndexVec::new();
+    let mut blocks = IndexVec::with_capacity(2);
     let block = |blocks: &mut IndexVec<_, _>, kind| {
         blocks.push(BasicBlockData {
             statements: vec![],
@@ -768,7 +768,8 @@ fn build_call_shim<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         }));
     }
 
-    let mut blocks = IndexVec::new();
+    let n_blocks = if let Adjustment::RefMut = rcvr_adjustment { 5 } else { 2 };
+    let mut blocks = IndexVec::with_capacity(n_blocks);
     let block = |blocks: &mut IndexVec<_, _>, statements, kind, is_cleanup| {
         blocks.push(BasicBlockData {
             statements,

--- a/src/librustc_mir/transform/promote_consts.rs
+++ b/src/librustc_mir/transform/promote_consts.rs
@@ -310,16 +310,11 @@ impl<'a, 'tcx> Promoter<'a, 'tcx> {
                     match statement.kind {
                         StatementKind::Assign(_, box Rvalue::Ref(_, _, ref mut place)) => {
                             // Find the underlying local for this (necessarily interior) borrow.
-                            // HACK(eddyb) using a recursive function because of mutable borrows.
-                            fn interior_base<'a, 'tcx>(place: &'a mut Place<'tcx>)
-                                                       -> &'a mut Place<'tcx> {
-                                if let Place::Projection(ref mut proj) = *place {
-                                    assert_ne!(proj.elem, ProjectionElem::Deref);
-                                    return interior_base(&mut proj.base);
-                                }
-                                place
-                            }
-                            let place = interior_base(place);
+                            let mut place = place;
+                            while let Place::Projection(ref mut proj) = *place {
+                                assert_ne!(proj.elem, ProjectionElem::Deref);
+                                place = &mut proj.base;
+                            };
 
                             let ty = place.ty(local_decls, self.tcx).to_ty(self.tcx);
                             let span = statement.source_info.span;

--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -869,6 +869,8 @@ impl<'a, 'tcx> Visitor<'tcx> for Qualifier<'a, 'tcx, 'tcx> {
                             | "overflowing_mul"
                             | "unchecked_shl"
                             | "unchecked_shr"
+                            | "rotate_left"
+                            | "rotate_right"
                             | "add_with_overflow"
                             | "sub_with_overflow"
                             | "mul_with_overflow"

--- a/src/librustc_typeck/check/intrinsic.rs
+++ b/src/librustc_typeck/check/intrinsic.rs
@@ -292,7 +292,8 @@ pub fn check_intrinsic_type<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 
             "unchecked_div" | "unchecked_rem" | "exact_div" =>
                 (1, vec![param(0), param(0)], param(0)),
-            "unchecked_shl" | "unchecked_shr" =>
+            "unchecked_shl" | "unchecked_shr" |
+            "rotate_left" | "rotate_right" =>
                 (1, vec![param(0), param(0)], param(0)),
 
             "overflowing_add" | "overflowing_sub" | "overflowing_mul" =>

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -70,7 +70,7 @@
 /* General structure and fonts */
 
 body {
-	font: 16px/1.4 "Source Serif Pro", Georgia, Times, "Times New Roman", serif;
+	font: 16px/1.4 "Source Serif Pro", serif;
 	margin: 0;
 	position: relative;
 	padding: 10px 15px 20px 15px;
@@ -114,7 +114,7 @@ h3.impl, h3.method, h3.type {
 h1, h2, h3, h4,
 .sidebar, a.source, .search-input, .content table :not(code)>a,
 .collapse-toggle, div.item-list .out-of-band {
-	font-family: "Fira Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+	font-family: "Fira Sans", sans-serif;
 }
 
 ol, ul {
@@ -133,7 +133,7 @@ summary {
 }
 
 code, pre {
-	font-family: "Source Code Pro", Menlo, Monaco, Consolas, "DejaVu Sans Mono", Inconsolata, monospace;
+	font-family: "Source Code Pro", monospace;
 	white-space: pre-wrap;
 }
 .docblock code, .docblock-short code {
@@ -415,7 +415,7 @@ h4 > code, h3 > code, .invisible > code {
 }
 #main > .since {
 	top: inherit;
-	font-family: "Fira Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+	font-family: "Fira Sans", sans-serif;
 }
 
 .content table:not(.table-display) {
@@ -1338,7 +1338,7 @@ h3.important {
 kbd {
 	display: inline-block;
 	padding: 3px 5px;
-	font: 15px "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
+	font: 15px monospace;
 	line-height: 10px;
 	vertical-align: middle;
 	border: solid 1px;

--- a/src/test/ui/coherence/coherence-impls-copy.stderr
+++ b/src/test/ui/coherence/coherence-impls-copy.stderr
@@ -14,7 +14,7 @@ LL | impl Copy for &'static NotSync {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: conflicting implementation in crate `core`:
-           - impl<'_, T> std::marker::Copy for &T
+           - impl<T> std::marker::Copy for &T
              where T: ?Sized;
 
 error[E0119]: conflicting implementations of trait `std::marker::Copy` for type `&[NotSync]`:
@@ -24,7 +24,7 @@ LL | impl Copy for &'static [NotSync] {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: conflicting implementation in crate `core`:
-           - impl<'_, T> std::marker::Copy for &T
+           - impl<T> std::marker::Copy for &T
              where T: ?Sized;
 
 error[E0206]: the trait `Copy` may not be implemented for this type

--- a/src/test/ui/consts/const-eval/issue-55541.rs
+++ b/src/test/ui/consts/const-eval/issue-55541.rs
@@ -1,0 +1,21 @@
+// compile-pass
+
+// Test that we can handle newtypes wrapping extern types
+
+#![feature(extern_types, const_transmute)]
+
+extern "C" {
+  pub type ExternType;
+}
+unsafe impl Sync for ExternType {}
+
+#[repr(transparent)]
+pub struct Wrapper(ExternType);
+
+static MAGIC_FFI_STATIC: u8 = 42;
+
+pub static MAGIC_FFI_REF: &'static Wrapper = unsafe {
+  std::mem::transmute(&MAGIC_FFI_STATIC)
+};
+
+fn main() {}

--- a/src/test/ui/consts/const-eval/issue-55541.rs
+++ b/src/test/ui/consts/const-eval/issue-55541.rs
@@ -4,17 +4,23 @@
 
 #![feature(extern_types, const_transmute)]
 
+use std::marker::PhantomData;
+
 extern "C" {
   pub type ExternType;
 }
 unsafe impl Sync for ExternType {}
+static MAGIC_FFI_STATIC: u8 = 42;
 
 #[repr(transparent)]
 pub struct Wrapper(ExternType);
-
-static MAGIC_FFI_STATIC: u8 = 42;
-
 pub static MAGIC_FFI_REF: &'static Wrapper = unsafe {
+  std::mem::transmute(&MAGIC_FFI_STATIC)
+};
+
+#[repr(transparent)]
+pub struct Wrapper2(PhantomData<Vec<i32>>, ExternType);
+pub static MAGIC_FFI_REF2: &'static Wrapper2 = unsafe {
   std::mem::transmute(&MAGIC_FFI_STATIC)
 };
 

--- a/src/test/ui/e0119/issue-28981.stderr
+++ b/src/test/ui/e0119/issue-28981.stderr
@@ -5,7 +5,7 @@ LL | impl<Foo> Deref for Foo { } //~ ERROR must be used
    | ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: conflicting implementation in crate `core`:
-           - impl<'_, T> std::ops::Deref for &T
+           - impl<T> std::ops::Deref for &T
              where T: ?Sized;
 
 error[E0210]: type parameter `Foo` must be used as the type parameter for some local type (e.g. `MyStruct<Foo>`)

--- a/src/test/ui/extern/extern-const.fixed
+++ b/src/test/ui/extern/extern-const.fixed
@@ -12,7 +12,7 @@ extern crate libc;
 
 #[link(name = "rust_test_helpers", kind = "static")]
 extern "C" {
-    const rust_dbg_static_mut: libc::c_int; //~ ERROR extern items cannot be `const`
+    static rust_dbg_static_mut: libc::c_int; //~ ERROR extern items cannot be `const`
 }
 
 fn main() {

--- a/src/test/ui/extern/extern-const.fixed
+++ b/src/test/ui/extern/extern-const.fixed
@@ -1,11 +1,11 @@
-// This test is checking that extern items cannot be const.  It also
-// checks that `rustfix` suggests the alternative of using an extern
-// static.
+// Check extern items cannot be const + `rustfix` suggests using
+// extern static.
 //
 // #54388: an unused reference to an undefined static may or may not
 // compile. To sidestep this by using one that *is* defined.
 
 // run-rustfix
+// ignore-wasm32 no external library to link to.
 // compile-flags: -g -Z continue-parse-after-error
 #![feature(libc)]
 extern crate libc;

--- a/src/test/ui/extern/extern-const.rs
+++ b/src/test/ui/extern/extern-const.rs
@@ -1,11 +1,11 @@
-// This test is checking that extern items cannot be const.  It also
-// checks that `rustfix` suggests the alternative of using an extern
-// static.
+// Check extern items cannot be const + `rustfix` suggests using
+// extern static.
 //
 // #54388: an unused reference to an undefined static may or may not
 // compile. To sidestep this by using one that *is* defined.
 
 // run-rustfix
+// ignore-wasm32 no external library to link to.
 // compile-flags: -g -Z continue-parse-after-error
 #![feature(libc)]
 extern crate libc;

--- a/src/test/ui/extern/extern-const.stderr
+++ b/src/test/ui/extern/extern-const.stderr
@@ -1,7 +1,7 @@
 error: extern items cannot be `const`
   --> $DIR/extern-const.rs:15:5
    |
-LL |     const C: u8; //~ ERROR extern items cannot be `const`
+LL |     const rust_dbg_static_mut: libc::c_int; //~ ERROR extern items cannot be `const`
    |     ^^^^^ help: try using a static value: `static`
 
 error: aborting due to previous error

--- a/src/test/ui/impl-trait/issue-55608-captures-empty-region.rs
+++ b/src/test/ui/impl-trait/issue-55608-captures-empty-region.rs
@@ -1,0 +1,22 @@
+// This used to ICE because it creates an `impl Trait` that captures a
+// hidden empty region.
+
+#![feature(conservative_impl_trait)]
+
+fn server() -> impl FilterBase2 { //~ ERROR [E0700]
+    segment2(|| { loop { } }).map2(|| "")
+}
+
+trait FilterBase2 {
+    fn map2<F>(self, _fn: F) -> Map2<F> where Self: Sized { loop { } }
+}
+
+struct Map2<F> { _func: F }
+
+impl<F> FilterBase2 for Map2<F> { }
+
+fn segment2<F>(_fn: F) -> Map2<F> where F: Fn() -> Result<(), ()> {
+    loop { }
+}
+
+fn main() { server(); }

--- a/src/test/ui/impl-trait/issue-55608-captures-empty-region.stderr
+++ b/src/test/ui/impl-trait/issue-55608-captures-empty-region.stderr
@@ -1,0 +1,11 @@
+error[E0700]: hidden type for `impl Trait` captures lifetime that does not appear in bounds
+  --> $DIR/issue-55608-captures-empty-region.rs:6:16
+   |
+LL | fn server() -> impl FilterBase2 { //~ ERROR [E0700]
+   |                ^^^^^^^^^^^^^^^^
+   |
+   = note: hidden type `Map2<[closure@$DIR/issue-55608-captures-empty-region.rs:7:36: 7:41]>` captures an empty lifetime
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0700`.

--- a/src/test/ui/nll/issue-55344.rs
+++ b/src/test/ui/nll/issue-55344.rs
@@ -1,0 +1,26 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-pass
+
+#![feature(nll)]
+#![allow(unreachable_code)]
+#![deny(unused_mut)]
+
+pub fn foo() {
+    return;
+
+    let mut v = 0;
+    assert_eq!(v, 0);
+    v = 1;
+    assert_eq!(v, 1);
+}
+
+fn main() {}


### PR DESCRIPTION
Successful merges:

 - #54993 (Support for the program data address space option of LLVM's Target Datalayout)
 - #55576 (Clarify error message for -C opt-level)
 - #55638 (Fix ICE in msg_span_from_free_region on ReEmpty)
 - #55650 (Implement rotate using funnel shift on LLVM >= 7)
 - #55672 (miri: accept extern types in structs if they are the only field)
 - #55719 (Sidestep link error from rustfix'ed code by using a *defined* static.)
 - #55722 (impl_stable_hash_for: support enums and tuple structs with generic parameters)
 - #55736 (Elide anon lifetimes in conflicting impl note)
 - #55739 (Consume optimization fuel from the MIR inliner)
 - #55753 (borrow_set: remove a helper function and a clone it uses)
 - #55755 (Improve creation of 3 IndexVecs)
 - #55758 ([regression - rust2018]: unused_mut lint false positives on nightly)
 - #55760 (Remove intermediate font specs)
 - #55761 (mir: remove a hacky recursive helper function)
 - #55774 (wasm32-unknown-emscripten expects the rust_eh_personality symbol)
 - #55788 (rustc: Request ansi colors if stderr isn't a tty)

Failed merges:


r? @ghost