### PR TITLE
Fixes #55775 -- fixed regression in Command::exec's handling of PATH.

### DIFF
--- a/src/test/run-pass/command-exec.rs
+++ b/src/test/run-pass/command-exec.rs
@@ -55,6 +55,16 @@ fn main() {
                 println!("passed");
             }
 
+            "exec-test6" => {
+                let err = Command::new("echo").arg("passed").env_clear().exec();
+                panic!("failed to spawn: {}", err);
+            }
+
+            "exec-test7" => {
+                let err = Command::new("echo").arg("passed").env_remove("PATH").exec();
+                panic!("failed to spawn: {}", err);
+            }
+
             _ => panic!("unknown argument: {}", arg),
         }
         return
@@ -81,6 +91,16 @@ fn main() {
     assert_eq!(output.stdout, b"passed\n");
 
     let output = Command::new(&me).arg("exec-test5").output().unwrap();
+    assert!(output.status.success());
+    assert!(output.stderr.is_empty());
+    assert_eq!(output.stdout, b"passed\n");
+
+    let output = Command::new(&me).arg("exec-test6").output().unwrap();
+    assert!(output.status.success());
+    assert!(output.stderr.is_empty());
+    assert_eq!(output.stdout, b"passed\n");
+
+    let output = Command::new(&me).arg("exec-test7").output().unwrap();
     assert!(output.status.success());
     assert!(output.stderr.is_empty());
     assert_eq!(output.stdout, b"passed\n");


### PR DESCRIPTION
This restores the previous behavior where if env_clear() or env_remove() was used, the parent's PATH would be consulted.

r? @alexcrichton