### PR TITLE
ICE with #![feature(nll)] and elided lifetimes

### DIFF
--- a/src/test/ui/nll/issue-55394.rs
+++ b/src/test/ui/nll/issue-55394.rs
@@ -1,0 +1,25 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(nll)]
+
+struct Bar;
+
+struct Foo<'s> {
+    bar: &'s mut Bar,
+}
+
+impl Foo<'_> {
+    fn new(bar: &mut Bar) -> Self {
+        Foo { bar }
+    }
+}
+
+fn main() { }

--- a/src/test/ui/nll/issue-55394.stderr
+++ b/src/test/ui/nll/issue-55394.stderr
@@ -1,0 +1,12 @@
+error: unsatisfied lifetime constraints
+  --> $DIR/issue-55394.rs:21:9
+   |
+LL |     fn new(bar: &mut Bar) -> Self {
+   |                 -            ---- return type is Foo<'2>
+   |                 |
+   |                 let's call the lifetime of this reference `'1`
+LL |         Foo { bar }
+   |         ^^^^^^^^^^^ returning this value requires that `'1` must outlive `'2`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fixes #55394.

This commit fixes an ICE and determines the correct return span in cases
with a method implemented on a struct with an an elided lifetime.

r? @pnkfelix 