### PR TITLE
A few tweaks to iterations/collecting

### DIFF
--- a/src/librustc/cfg/graphviz.rs
+++ b/src/librustc/cfg/graphviz.rs
@@ -106,8 +106,7 @@ impl<'a> dot::GraphWalk<'a> for &'a cfg::CFG {
     type Node = Node<'a>;
     type Edge = Edge<'a>;
     fn nodes(&'a self) -> dot::Nodes<'a, Node<'a>> {
-        let mut v = Vec::new();
-        self.graph.each_node(|i, nd| { v.push((i, nd)); true });
+        let v: Vec<_> = self.graph.enumerated_nodes().collect();
         v.into()
     }
     fn edges(&'a self) -> dot::Edges<'a, Edge<'a>> {

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -1062,8 +1062,7 @@ impl<'a> LoweringContext<'a> {
         attrs
             .iter()
             .map(|a| self.lower_attr(a))
-            .collect::<Vec<_>>()
-            .into()
+            .collect()
     }
 
     fn lower_attr(&mut self, attr: &Attribute) -> Attribute {

--- a/src/librustc/ty/query/on_disk_cache.rs
+++ b/src/librustc/ty/query/on_disk_cache.rs
@@ -281,7 +281,7 @@ impl<'sess> OnDiskCache<'sess> {
                         // otherwise, abort
                         break;
                     }
-                    interpret_alloc_index.reserve(new_n);
+                    interpret_alloc_index.reserve(new_n - n);
                     for idx in n..new_n {
                         let id = encoder.interpret_allocs_inverse[idx];
                         let pos = encoder.position() as u32;

--- a/src/libserialize/hex.rs
+++ b/src/libserialize/hex.rs
@@ -146,7 +146,7 @@ impl FromHex for str {
         }
 
         match modulus {
-            0 => Ok(b.into_iter().collect()),
+            0 => Ok(b),
             _ => Err(InvalidHexLength),
         }
     }

--- a/src/libsyntax_ext/deriving/generic/mod.rs
+++ b/src/libsyntax_ext/deriving/generic/mod.rs
@@ -1200,16 +1200,14 @@ impl<'a> MethodDef<'a> {
         let sp = trait_.span;
         let variants = &enum_def.variants;
 
-        let self_arg_names = self_args.iter()
-            .enumerate()
-            .map(|(arg_count, _self_arg)| {
-                if arg_count == 0 {
-                    "__self".to_string()
-                } else {
+        let self_arg_names = iter::once("__self".to_string()).chain(
+            self_args.iter()
+                .enumerate()
+                .skip(1)
+                .map(|(arg_count, _self_arg)|
                     format!("__arg_{}", arg_count)
-                }
-            })
-            .collect::<Vec<String>>();
+                )
+            ).collect::<Vec<String>>();
 
         let self_arg_idents = self_arg_names.iter()
             .map(|name| cx.ident_of(&name[..]))
@@ -1218,7 +1216,7 @@ impl<'a> MethodDef<'a> {
         // The `vi_idents` will be bound, solely in the catch-all, to
         // a series of let statements mapping each self_arg to an int
         // value corresponding to its discriminant.
-        let vi_idents: Vec<ast::Ident> = self_arg_names.iter()
+        let vi_idents = self_arg_names.iter()
             .map(|name| {
                 let vi_suffix = format!("{}_vi", &name[..]);
                 cx.ident_of(&vi_suffix[..]).gensym()


### PR DESCRIPTION
- simplify and speed up `dot::GraphWalk::nodes` for `cfg::CFG`
- `reserve` the capacity for `edges` in `DepGraph::query`
- collect directly to a `HirVec` in `LoweringContext::lower_attrs`
- fix overallocation in `OnDiskCache::serialize`
- preallocate the `new_partitioning` vector in `merge_codegen_units`
- simplify `impl FromHex for str`
- improve the creation of `self_arg_names` in `impl MethodDef`