### PR TITLE
Make PhantomData #[structural_match]

### DIFF
--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -129,6 +129,7 @@
 #![feature(const_transmute)]
 #![feature(reverse_bits)]
 #![feature(non_exhaustive)]
+#![feature(structural_match)]
 
 #[prelude_import]
 #[allow(unused)]

--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -578,6 +578,7 @@ macro_rules! impls{
 ///
 /// [drop check]: ../../nomicon/dropck.html
 #[lang = "phantom_data"]
+#[structural_match]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct PhantomData<T:?Sized>;
 

--- a/src/test/ui/rfc1445/phantom-data-is-structurally-matchable.rs
+++ b/src/test/ui/rfc1445/phantom-data-is-structurally-matchable.rs
@@ -1,0 +1,53 @@
+// run-pass
+
+// This file checks that `PhantomData` is considered structurally matchable.
+
+use std::marker::PhantomData;
+
+fn main() {
+    let mut count = 0;
+
+    // A type which is not structurally matchable:
+    struct NotSM;
+
+    // And one that is:
+    #[derive(PartialEq, Eq)]
+    struct SM;
+
+    // Check that SM is #[structural_match]:
+    const CSM: SM = SM;
+    match SM {
+        CSM => count += 1,
+    };
+
+    // Check that PhantomData<T> is #[structural_match] even if T is not.
+    const CPD1: PhantomData<NotSM> = PhantomData;
+    match PhantomData {
+        CPD1 => count += 1,
+    };
+
+    // Check that PhantomData<T> is #[structural_match] when T is.
+    const CPD2: PhantomData<SM> = PhantomData;
+    match PhantomData {
+        CPD2 => count += 1,
+    };
+
+    // Check that a type which has a PhantomData is `#[structural_match]`.
+    #[derive(PartialEq, Eq, Default)]
+    struct Foo {
+        alpha: PhantomData<NotSM>,
+        beta: PhantomData<SM>,
+    }
+
+    const CFOO: Foo = Foo {
+        alpha: PhantomData,
+        beta: PhantomData,
+    };
+
+    match Foo::default() {
+        CFOO => count += 1,
+    };
+
+    // Final count must be 4 now if all
+    assert_eq!(count, 4);
+}


### PR DESCRIPTION
fixes https://github.com/rust-lang/rust/issues/55028

This makes `PhantomData<T>` structurally matchable, irrespective of whether `T` is, per the discussion on this week's language team meeting (the general consensus was that this was a bug-fix).

All types containing `PhantomData<T>` and which used `#[derive(PartialEq, Eq)]` and were previously not `#[structural_match]` only because of `PhantomData<T>` will now be `#[structural_match]`.

r? @nikomatsakis 