### PR TITLE
Set BINARYEN_TRAP_MODE=clamp

### DIFF
--- a/src/librustc_target/spec/wasm32_unknown_emscripten.rs
+++ b/src/librustc_target/spec/wasm32_unknown_emscripten.rs
@@ -11,12 +11,18 @@
 use super::{LinkArgs, LinkerFlavor, Target, TargetOptions};
 
 pub fn target() -> Result<Target, String> {
+    // FIXME(nikic) BINARYEN_TRAP_MODE=clamp is needed to avoid trapping in our
+    // -Zsaturating-float-casts implementation. This can be dropped if/when
+    // we have native fpto[su]i.sat intrinsics, or the implementation otherwise
+    // stops relying on non-trapping fpto[su]i.
     let mut post_link_args = LinkArgs::new();
     post_link_args.insert(LinkerFlavor::Em,
                           vec!["-s".to_string(),
                                "BINARYEN=1".to_string(),
                                "-s".to_string(),
-                               "ERROR_ON_UNDEFINED_SYMBOLS=1".to_string()]);
+                               "ERROR_ON_UNDEFINED_SYMBOLS=1".to_string(),
+                               "-s".to_string(),
+                               "BINARYEN_TRAP_MODE='clamp'".to_string()]);
 
     let opts = TargetOptions {
         dynamic_linking: false,


### PR DESCRIPTION
This fixes the wasm32-unknown-emscripten test failure mentioned in https://github.com/rust-lang/rust/pull/55626#issuecomment-437084774, by making binaryen operate in clamp rather than trap mode.

The issue is that the current `-Zsaturating-float-casts` implementation uses `fpto[us]i` unconditionally (and selects afterwards), which does not work with trapping implementations of fpto[su]i, which emscripten uses by default.

I've left a FIXME to drop this flag once we have a better solution for saturating casts on the LLVM side.

r? @alexcrichton