### PR TITLE
rustdoc: refactor: move all static-file include!s into a single module

### DIFF
--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -29,6 +29,7 @@ use core::new_handler;
 use externalfiles::ExternalHtml;
 use html;
 use html::markdown::IdMap;
+use html::static_files;
 use opts;
 use passes::{self, DefaultPassOption};
 use theme;
@@ -261,7 +262,7 @@ impl Options {
 
         let to_check = matches.opt_strs("theme-checker");
         if !to_check.is_empty() {
-            let paths = theme::load_css_paths(include_bytes!("html/static/themes/light.css"));
+            let paths = theme::load_css_paths(static_files::themes::LIGHT.as_bytes());
             let mut errors = 0;
 
             println!("rustdoc: [theme-checker] Starting tests!");
@@ -338,7 +339,7 @@ impl Options {
 
         let mut themes = Vec::new();
         if matches.opt_present("themes") {
-            let paths = theme::load_css_paths(include_bytes!("html/static/themes/light.css"));
+            let paths = theme::load_css_paths(static_files::themes::LIGHT.as_bytes());
 
             for (theme_file, theme_s) in matches.opt_strs("themes")
                                                 .iter()

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -76,7 +76,7 @@ use html::format::{VisSpace, Method, UnsafetySpace, MutableSpace};
 use html::format::fmt_impl_for_trait_page;
 use html::item_type::ItemType;
 use html::markdown::{self, Markdown, MarkdownHtml, MarkdownSummaryLine, ErrorCodes, IdMap};
-use html::{highlight, layout};
+use html::{highlight, layout, static_files};
 
 use minifier;
 
@@ -767,10 +767,10 @@ fn write_shared(
     // overwrite them anyway to make sure that they're fresh and up-to-date.
 
     write_minify(cx.dst.join(&format!("rustdoc{}.css", cx.shared.resource_suffix)),
-                 include_str!("static/rustdoc.css"),
+                 static_files::RUSTDOC_CSS,
                  options.enable_minification)?;
     write_minify(cx.dst.join(&format!("settings{}.css", cx.shared.resource_suffix)),
-                 include_str!("static/settings.css"),
+                 static_files::SETTINGS_CSS,
                  options.enable_minification)?;
 
     // To avoid "light.css" to be overwritten, we'll first run over the received themes and only
@@ -790,15 +790,15 @@ fn write_shared(
     }
 
     write(cx.dst.join(&format!("brush{}.svg", cx.shared.resource_suffix)),
-          include_bytes!("static/brush.svg"))?;
+          static_files::BRUSH_SVG)?;
     write(cx.dst.join(&format!("wheel{}.svg", cx.shared.resource_suffix)),
-          include_bytes!("static/wheel.svg"))?;
+          static_files::WHEEL_SVG)?;
     write_minify(cx.dst.join(&format!("light{}.css", cx.shared.resource_suffix)),
-                 include_str!("static/themes/light.css"),
+                 static_files::themes::LIGHT,
                  options.enable_minification)?;
     themes.insert("light".to_owned());
     write_minify(cx.dst.join(&format!("dark{}.css", cx.shared.resource_suffix)),
-                 include_str!("static/themes/dark.css"),
+                 static_files::themes::DARK,
                  options.enable_minification)?;
     themes.insert("dark".to_owned());
 
@@ -854,16 +854,16 @@ themePicker.onblur = handleThemeButtonsBlur;
     )?;
 
     write_minify(cx.dst.join(&format!("main{}.js", cx.shared.resource_suffix)),
-                 include_str!("static/main.js"),
+                 static_files::MAIN_JS,
                  options.enable_minification)?;
     write_minify(cx.dst.join(&format!("settings{}.js", cx.shared.resource_suffix)),
-                 include_str!("static/settings.js"),
+                 static_files::SETTINGS_JS,
                  options.enable_minification)?;
 
     {
         let mut data = format!("var resourcesSuffix = \"{}\";\n",
                                cx.shared.resource_suffix);
-        data.push_str(include_str!("static/storage.js"));
+        data.push_str(static_files::STORAGE_JS);
         write_minify(cx.dst.join(&format!("storage{}.js", cx.shared.resource_suffix)),
                      &data,
                      options.enable_minification)?;
@@ -882,36 +882,36 @@ themePicker.onblur = handleThemeButtonsBlur;
         }
     }
     write_minify(cx.dst.join(&format!("normalize{}.css", cx.shared.resource_suffix)),
-                 include_str!("static/normalize.css"),
+                 static_files::NORMALIZE_CSS,
                  options.enable_minification)?;
     write(cx.dst.join("FiraSans-Regular.woff"),
-          include_bytes!("static/FiraSans-Regular.woff"))?;
+          static_files::fira_sans::REGULAR)?;
     write(cx.dst.join("FiraSans-Medium.woff"),
-          include_bytes!("static/FiraSans-Medium.woff"))?;
+          static_files::fira_sans::MEDIUM)?;
     write(cx.dst.join("FiraSans-LICENSE.txt"),
-          include_bytes!("static/FiraSans-LICENSE.txt"))?;
+          static_files::fira_sans::LICENSE)?;
     write(cx.dst.join("Heuristica-Italic.woff"),
-          include_bytes!("static/Heuristica-Italic.woff"))?;
+          static_files::heuristica::ITALIC)?;
     write(cx.dst.join("Heuristica-LICENSE.txt"),
-          include_bytes!("static/Heuristica-LICENSE.txt"))?;
+          static_files::heuristica::LICENSE)?;
     write(cx.dst.join("SourceSerifPro-Regular.woff"),
-          include_bytes!("static/SourceSerifPro-Regular.woff"))?;
+          static_files::source_serif_pro::REGULAR)?;
     write(cx.dst.join("SourceSerifPro-Bold.woff"),
-          include_bytes!("static/SourceSerifPro-Bold.woff"))?;
+          static_files::source_serif_pro::BOLD)?;
     write(cx.dst.join("SourceSerifPro-LICENSE.txt"),
-          include_bytes!("static/SourceSerifPro-LICENSE.txt"))?;
+          static_files::source_serif_pro::LICENSE)?;
     write(cx.dst.join("SourceCodePro-Regular.woff"),
-          include_bytes!("static/SourceCodePro-Regular.woff"))?;
+          static_files::source_code_pro::REGULAR)?;
     write(cx.dst.join("SourceCodePro-Semibold.woff"),
-          include_bytes!("static/SourceCodePro-Semibold.woff"))?;
+          static_files::source_code_pro::SEMIBOLD)?;
     write(cx.dst.join("SourceCodePro-LICENSE.txt"),
-          include_bytes!("static/SourceCodePro-LICENSE.txt"))?;
+          static_files::source_code_pro::LICENSE)?;
     write(cx.dst.join("LICENSE-MIT.txt"),
-          include_bytes!("static/LICENSE-MIT.txt"))?;
+          static_files::LICENSE_MIT)?;
     write(cx.dst.join("LICENSE-APACHE.txt"),
-          include_bytes!("static/LICENSE-APACHE.txt"))?;
+          static_files::LICENSE_APACHE)?;
     write(cx.dst.join("COPYRIGHT.txt"),
-          include_bytes!("static/COPYRIGHT.txt"))?;
+          static_files::COPYRIGHT)?;
 
     fn collect(path: &Path, krate: &str, key: &str) -> io::Result<(Vec<String>, Vec<String>)> {
         let mut ret = Vec::new();

--- a/src/librustdoc/html/static_files.rs
+++ b/src/librustdoc/html/static_files.rs
@@ -1,0 +1,111 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Static files bundled with documentation output.
+//!
+//! All the static files are included here for centralized access in case anything other than the
+//! HTML rendering code (say, the theme checker) needs to access one of these files.
+//!
+//! Note about types: CSS and JavaScript files are included as `&'static str` to allow for the
+//! minifier to run on them. All other files are included as `&'static [u8]` so they can be
+//! directly written to a `Write` handle.
+
+/// The file contents of the main `rustdoc.css` file, responsible for the core layout of the page.
+pub static RUSTDOC_CSS: &'static str = include_str!("static/rustdoc.css");
+
+/// The file contents of `settings.css`, responsible for the items on the settings page.
+pub static SETTINGS_CSS: &'static str = include_str!("static/settings.css");
+
+/// The file contents of `normalize.css`, included to even out standard elements between browser
+/// implementations.
+pub static NORMALIZE_CSS: &'static str = include_str!("static/normalize.css");
+
+/// The file contents of `main.js`, which contains the core JavaScript used on documentation pages,
+/// including search behavior and docblock folding, among others.
+pub static MAIN_JS: &'static str = include_str!("static/main.js");
+
+/// The file contents of `settings.js`, which contains the JavaScript used to handle the settings
+/// page.
+pub static SETTINGS_JS: &'static str = include_str!("static/settings.js");
+
+/// The file contents of `storage.js`, which contains functionality related to browser Local
+/// Storage, used to store documentation settings.
+pub static STORAGE_JS: &'static str = include_str!("static/storage.js");
+
+/// The file contents of `brush.svg`, the icon used for the theme-switch button.
+pub static BRUSH_SVG: &'static [u8] = include_bytes!("static/brush.svg");
+
+/// The file contents of `wheel.svg`, the icon used for the settings button.
+pub static WHEEL_SVG: &'static [u8] = include_bytes!("static/wheel.svg");
+
+/// The contents of `COPYRIGHT.txt`, the license listing for files distributed with documentation
+/// output.
+pub static COPYRIGHT: &'static [u8] = include_bytes!("static/COPYRIGHT.txt");
+
+/// The contents of `LICENSE-APACHE.txt`, the text of the Apache License, version 2.0.
+pub static LICENSE_APACHE: &'static [u8] = include_bytes!("static/LICENSE-APACHE.txt");
+
+/// The contents of `LICENSE-MIT.txt`, the text of the MIT License.
+pub static LICENSE_MIT: &'static [u8] = include_bytes!("static/LICENSE-MIT.txt");
+
+/// The built-in themes given to every documentation site.
+pub mod themes {
+    /// The "light" theme, selected by default when no setting is available. Used as the basis for
+    /// the `--theme-checker` functionality.
+    pub static LIGHT: &'static str = include_str!("static/themes/light.css");
+
+    /// The "dark" theme.
+    pub static DARK: &'static str = include_str!("static/themes/dark.css");
+}
+
+/// Files related to the Fira Sans font.
+pub mod fira_sans {
+    /// The file `FiraSans-Regular.woff`, the Regular variant of the Fira Sans font.
+    pub static REGULAR: &'static [u8] = include_bytes!("static/FiraSans-Regular.woff");
+
+    /// The file `FiraSans-Medium.woff`, the Medium variant of the Fira Sans font.
+    pub static MEDIUM: &'static [u8] = include_bytes!("static/FiraSans-Medium.woff");
+
+    /// The file `FiraSans-LICENSE.txt`, the license text for the Fira Sans font.
+    pub static LICENSE: &'static [u8] = include_bytes!("static/FiraSans-LICENSE.txt");
+}
+
+/// Files related to the Heuristica font.
+pub mod heuristica {
+    /// The file `Heuristica-Italic.woff`, the Italic variant of the Heuristica font.
+    pub static ITALIC: &'static [u8] = include_bytes!("static/Heuristica-Italic.woff");
+
+    /// The file `Heuristica-LICENSE.txt`, the license text for the Heuristica font.
+    pub static LICENSE: &'static [u8] = include_bytes!("static/Heuristica-LICENSE.txt");
+}
+
+/// Files related to the Source Serif Pro font.
+pub mod source_serif_pro {
+    /// The file `SourceSerifPro-Regular.woff`, the Regular variant of the Source Serif Pro font.
+    pub static REGULAR: &'static [u8] = include_bytes!("static/SourceSerifPro-Regular.woff");
+
+    /// The file `SourceSerifPro-Bold.woff`, the Bold variant of the Source Serif Pro font.
+    pub static BOLD: &'static [u8] = include_bytes!("static/SourceSerifPro-Bold.woff");
+
+    /// The file `SourceSerifPro-LICENSE.txt`, the license text for the Source Serif Pro font.
+    pub static LICENSE: &'static [u8] = include_bytes!("static/SourceSerifPro-LICENSE.txt");
+}
+
+/// Files related to the Source Code Pro font.
+pub mod source_code_pro {
+    /// The file `SourceCodePro-Regular.woff`, the Regular variant of the Source Code Pro font.
+    pub static REGULAR: &'static [u8] = include_bytes!("static/SourceCodePro-Regular.woff");
+
+    /// The file `SourceCodePro-Semibold.woff`, the Semibold variant of the Source Code Pro font.
+    pub static SEMIBOLD: &'static [u8] = include_bytes!("static/SourceCodePro-Semibold.woff");
+
+    /// The file `SourceCodePro-LICENSE.txt`, the license text of the Source Code Pro font.
+    pub static LICENSE: &'static [u8] = include_bytes!("static/SourceCodePro-LICENSE.txt");
+}

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -78,6 +78,7 @@ pub mod html {
     crate mod layout;
     pub mod markdown;
     crate mod render;
+    crate mod static_files;
     crate mod toc;
 }
 mod markdown;


### PR DESCRIPTION
This is a smaller refactor that creates a new module `rustdoc::html::static_files`, which contains a bunch of `static` variables with all the files in `html/static` that we use. The idea behind moving them all here was to remove the duplicate `include_bytes!()` that are used by the theme-checker code. It also continues to centralize more operations in rustdoc.