### PR TITLE
Build rlibs for the core compile crates

### DIFF
--- a/src/libarena/Cargo.toml
+++ b/src/libarena/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.0.0"
 [lib]
 name = "arena"
 path = "lib.rs"
-crate-type = ["dylib"]
+crate-type = ["dylib", "rlib"]
 
 [dependencies]
 rustc_data_structures = { path = "../librustc_data_structures" }

--- a/src/libfmt_macros/Cargo.toml
+++ b/src/libfmt_macros/Cargo.toml
@@ -6,4 +6,4 @@ version = "0.0.0"
 [lib]
 name = "fmt_macros"
 path = "lib.rs"
-crate-type = ["dylib"]
+crate-type = ["dylib", "rlib"]

--- a/src/libgraphviz/Cargo.toml
+++ b/src/libgraphviz/Cargo.toml
@@ -6,4 +6,4 @@ version = "0.0.0"
 [lib]
 name = "graphviz"
 path = "lib.rs"
-crate-type = ["dylib"]
+crate-type = ["dylib", "rlib"]

--- a/src/libproc_macro/Cargo.toml
+++ b/src/libproc_macro/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.0.0"
 
 [lib]
 path = "lib.rs"
-crate-type = ["dylib"]
+crate-type = ["dylib", "rlib"]
 
 [dependencies]
 syntax = { path = "../libsyntax" }

--- a/src/librustc/Cargo.toml
+++ b/src/librustc/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.0.0"
 [lib]
 name = "rustc"
 path = "lib.rs"
-crate-type = ["dylib"]
+crate-type = ["dylib", "rlib"]
 
 [dependencies]
 arena = { path = "../libarena" }

--- a/src/librustc_allocator/Cargo.toml
+++ b/src/librustc_allocator/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.0.0"
 
 [lib]
 path = "lib.rs"
-crate-type = ["dylib"]
+crate-type = ["dylib", "rlib"]
 test = false
 
 [dependencies]

--- a/src/librustc_borrowck/Cargo.toml
+++ b/src/librustc_borrowck/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.0.0"
 [lib]
 name = "rustc_borrowck"
 path = "lib.rs"
-crate-type = ["dylib"]
+crate-type = ["dylib", "rlib"]
 test = false
 
 [dependencies]

--- a/src/librustc_codegen_utils/Cargo.toml
+++ b/src/librustc_codegen_utils/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.0.0"
 [lib]
 name = "rustc_codegen_utils"
 path = "lib.rs"
-crate-type = ["dylib"]
+crate-type = ["dylib", "rlib"]
 test = false
 
 [dependencies]

--- a/src/librustc_cratesio_shim/Cargo.toml
+++ b/src/librustc_cratesio_shim/Cargo.toml
@@ -17,7 +17,7 @@ name = "rustc_cratesio_shim"
 version = "0.0.0"
 
 [lib]
-crate-type = ["dylib"]
+crate-type = ["dylib", "rlib"]
 
 [dependencies]
 bitflags = "1.0"

--- a/src/librustc_data_structures/Cargo.toml
+++ b/src/librustc_data_structures/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.0.0"
 [lib]
 name = "rustc_data_structures"
 path = "lib.rs"
-crate-type = ["dylib"]
+crate-type = ["dylib", "rlib"]
 
 [dependencies]
 ena = "0.9.3"

--- a/src/librustc_driver/Cargo.toml
+++ b/src/librustc_driver/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.0.0"
 [lib]
 name = "rustc_driver"
 path = "lib.rs"
-crate-type = ["dylib"]
+crate-type = ["dylib", "rlib"]
 
 [dependencies]
 arena = { path = "../libarena" }

--- a/src/librustc_errors/Cargo.toml
+++ b/src/librustc_errors/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.0.0"
 [lib]
 name = "rustc_errors"
 path = "lib.rs"
-crate-type = ["dylib"]
+crate-type = ["dylib", "rlib"]
 
 [dependencies]
 log = "0.4"

--- a/src/librustc_fs_util/Cargo.toml
+++ b/src/librustc_fs_util/Cargo.toml
@@ -6,6 +6,6 @@ version = "0.0.0"
 [lib]
 name = "rustc_fs_util"
 path = "lib.rs"
-crate-type = ["dylib"]
+crate-type = ["dylib", "rlib"]
 
 [dependencies]

--- a/src/librustc_incremental/Cargo.toml
+++ b/src/librustc_incremental/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.0.0"
 [lib]
 name = "rustc_incremental"
 path = "lib.rs"
-crate-type = ["dylib"]
+crate-type = ["dylib", "rlib"]
 
 [dependencies]
 graphviz = { path = "../libgraphviz" }

--- a/src/librustc_lint/Cargo.toml
+++ b/src/librustc_lint/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.0.0"
 [lib]
 name = "rustc_lint"
 path = "lib.rs"
-crate-type = ["dylib"]
+crate-type = ["dylib", "rlib"]
 test = false
 
 [dependencies]

--- a/src/librustc_metadata/Cargo.toml
+++ b/src/librustc_metadata/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.0.0"
 [lib]
 name = "rustc_metadata"
 path = "lib.rs"
-crate-type = ["dylib"]
+crate-type = ["dylib", "rlib"]
 
 [dependencies]
 flate2 = "1.0"

--- a/src/librustc_mir/Cargo.toml
+++ b/src/librustc_mir/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.0.0"
 [lib]
 name = "rustc_mir"
 path = "lib.rs"
-crate-type = ["dylib"]
+crate-type = ["dylib", "rlib"]
 
 [dependencies]
 arena = { path = "../libarena" }

--- a/src/librustc_passes/Cargo.toml
+++ b/src/librustc_passes/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.0.0"
 [lib]
 name = "rustc_passes"
 path = "lib.rs"
-crate-type = ["dylib"]
+crate-type = ["dylib", "rlib"]
 
 [dependencies]
 log = "0.4"

--- a/src/librustc_platform_intrinsics/Cargo.toml
+++ b/src/librustc_platform_intrinsics/Cargo.toml
@@ -6,4 +6,4 @@ version = "0.0.0"
 [lib]
 name = "rustc_platform_intrinsics"
 path = "lib.rs"
-crate-type = ["dylib"]
+crate-type = ["dylib", "rlib"]

--- a/src/librustc_plugin/Cargo.toml
+++ b/src/librustc_plugin/Cargo.toml
@@ -7,7 +7,7 @@ build = false
 [lib]
 name = "rustc_plugin"
 path = "lib.rs"
-crate-type = ["dylib"]
+crate-type = ["dylib", "rlib"]
 
 [dependencies]
 rustc = { path = "../librustc" }

--- a/src/librustc_privacy/Cargo.toml
+++ b/src/librustc_privacy/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.0.0"
 [lib]
 name = "rustc_privacy"
 path = "lib.rs"
-crate-type = ["dylib"]
+crate-type = ["dylib", "rlib"]
 
 [dependencies]
 rustc = { path = "../librustc" }

--- a/src/librustc_resolve/Cargo.toml
+++ b/src/librustc_resolve/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.0.0"
 [lib]
 name = "rustc_resolve"
 path = "lib.rs"
-crate-type = ["dylib"]
+crate-type = ["dylib", "rlib"]
 test = false
 
 [dependencies]

--- a/src/librustc_save_analysis/Cargo.toml
+++ b/src/librustc_save_analysis/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.0.0"
 [lib]
 name = "rustc_save_analysis"
 path = "lib.rs"
-crate-type = ["dylib"]
+crate-type = ["dylib", "rlib"]
 
 [dependencies]
 log = "0.4"

--- a/src/librustc_target/Cargo.toml
+++ b/src/librustc_target/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.0.0"
 [lib]
 name = "rustc_target"
 path = "lib.rs"
-crate-type = ["dylib"]
+crate-type = ["dylib", "rlib"]
 
 [dependencies]
 bitflags = "1.0"

--- a/src/librustc_traits/Cargo.toml
+++ b/src/librustc_traits/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.0.0"
 [lib]
 name = "rustc_traits"
 path = "lib.rs"
-crate-type = ["dylib"]
+crate-type = ["dylib", "rlib"]
 
 [dependencies]
 bitflags = "1.0"

--- a/src/librustc_typeck/Cargo.toml
+++ b/src/librustc_typeck/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.0.0"
 [lib]
 name = "rustc_typeck"
 path = "lib.rs"
-crate-type = ["dylib"]
+crate-type = ["dylib", "rlib"]
 test = false
 
 [dependencies]

--- a/src/libsyntax/Cargo.toml
+++ b/src/libsyntax/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.0.0"
 [lib]
 name = "syntax"
 path = "lib.rs"
-crate-type = ["dylib"]
+crate-type = ["dylib", "rlib"]
 
 [dependencies]
 bitflags = "1.0"

--- a/src/libsyntax_ext/Cargo.toml
+++ b/src/libsyntax_ext/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.0.0"
 [lib]
 name = "syntax_ext"
 path = "lib.rs"
-crate-type = ["dylib"]
+crate-type = ["dylib", "rlib"]
 
 [dependencies]
 fmt_macros = { path = "../libfmt_macros" }

--- a/src/libsyntax_pos/Cargo.toml
+++ b/src/libsyntax_pos/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.0.0"
 [lib]
 name = "syntax_pos"
 path = "lib.rs"
-crate-type = ["dylib"]
+crate-type = ["dylib", "rlib"]
 
 [dependencies]
 serialize = { path = "../libserialize" }


### PR DESCRIPTION
Allows the compiler to be embedded in a staticlib, suitable for
invoking from a C application on a platform lacking a dynamic linker.

See #55741