### PR TITLE
do not panic just because cargo failed

### DIFF
--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -22,7 +22,7 @@ use std::fs::{self, File};
 use std::io::BufReader;
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::{Command, Stdio, exit};
 use std::str;
 
 use build_helper::{output, mtime, up_to_date};
@@ -1098,7 +1098,7 @@ pub fn run_cargo(builder: &Builder,
     });
 
     if !ok {
-        panic!("cargo must succeed");
+        exit(1);
     }
 
     // Ok now we need to actually find all the files listed in `toplevel`. We've


### PR DESCRIPTION
Currently, a rustc ICE during bootstrap shows *two* backtraces with `RUST_BACKTRACE`. Fix that by making bootstrap just exit when cargo fails. This matches what we do [when building a tool fails](https://github.com/rust-lang/rust/blob/master/src/bootstrap/tool.rs#L189) and [when other stuff (not called through `stream_cargo`, like `cargo test`) fails](https://github.com/rust-lang/rust/blob/master/src/build_helper/lib.rs#L43).

Fixes https://github.com/rust-lang/rust/issues/53379