### PR TITLE
Add std::iter::unfold

### DIFF
--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -340,7 +340,7 @@ pub use self::sources::{Empty, empty};
 #[stable(feature = "iter_once", since = "1.2.0")]
 pub use self::sources::{Once, once};
 #[unstable(feature = "iter_unfold", issue = /* FIXME */ "0")]
-pub use self::sources::{Unfold, unfold};
+pub use self::sources::{Unfold, unfold, Successors, successors};
 
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::traits::{FromIterator, IntoIterator, DoubleEndedIterator, Extend};

--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -339,6 +339,8 @@ pub use self::sources::{RepeatWith, repeat_with};
 pub use self::sources::{Empty, empty};
 #[stable(feature = "iter_once", since = "1.2.0")]
 pub use self::sources::{Once, once};
+#[unstable(feature = "iter_unfold", issue = /* FIXME */ "0")]
+pub use self::sources::{Unfold, unfold};
 
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::traits::{FromIterator, IntoIterator, DoubleEndedIterator, Extend};

--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -112,10 +112,10 @@
 //!
 //!     // next() is the only required method
 //!     fn next(&mut self) -> Option<usize> {
-//!         // increment our count. This is why we started at zero.
+//!         // Increment our count. This is why we started at zero.
 //!         self.count += 1;
 //!
-//!         // check to see if we've finished counting or not.
+//!         // Check to see if we've finished counting or not.
 //!         if self.count < 6 {
 //!             Some(self.count)
 //!         } else {

--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -339,7 +339,7 @@ pub use self::sources::{RepeatWith, repeat_with};
 pub use self::sources::{Empty, empty};
 #[stable(feature = "iter_once", since = "1.2.0")]
 pub use self::sources::{Once, once};
-#[unstable(feature = "iter_unfold", issue = /* FIXME */ "0")]
+#[unstable(feature = "iter_unfold", issue = "55977")]
 pub use self::sources::{Unfold, unfold, Successors, successors};
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcore/iter/sources.rs
+++ b/src/libcore/iter/sources.rs
@@ -428,7 +428,7 @@ pub fn once<T>(value: T) -> Once<T> {
 /// assert_eq!(counter.collect::<Vec<_>>(), &[1, 2, 3, 4, 5]);
 /// ```
 #[inline]
-#[unstable(feature = "iter_unfold", issue = /* FIXME */ "0")]
+#[unstable(feature = "iter_unfold", issue = "55977")]
 pub fn unfold<St, T, F>(initial_state: St, f: F) -> Unfold<St, F>
     where F: FnMut(&mut St) -> Option<T>
 {
@@ -445,13 +445,13 @@ pub fn unfold<St, T, F>(initial_state: St, f: F) -> Unfold<St, F>
 ///
 /// [`unfold`]: fn.unfold.html
 #[derive(Clone)]
-#[unstable(feature = "iter_unfold", issue = /* FIXME */ "0")]
+#[unstable(feature = "iter_unfold", issue = "55977")]
 pub struct Unfold<St, F> {
     state: St,
     f: F,
 }
 
-#[unstable(feature = "iter_unfold", issue = /* FIXME */ "0")]
+#[unstable(feature = "iter_unfold", issue = "55977")]
 impl<St, T, F> Iterator for Unfold<St, F>
     where F: FnMut(&mut St) -> Option<T>
 {
@@ -463,7 +463,7 @@ impl<St, T, F> Iterator for Unfold<St, F>
     }
 }
 
-#[unstable(feature = "iter_unfold", issue = /* FIXME */ "0")]
+#[unstable(feature = "iter_unfold", issue = "55977")]
 impl<St: fmt::Debug, F> fmt::Debug for Unfold<St, F> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Unfold")
@@ -484,7 +484,7 @@ impl<St: fmt::Debug, F> fmt::Debug for Unfold<St, F> {
 /// let powers_of_10 = successors(Some(1_u16), |n| n.checked_mul(10));
 /// assert_eq!(powers_of_10.collect::<Vec<_>>(), &[1, 10, 100, 1_000, 10_000]);
 /// ```
-#[unstable(feature = "iter_unfold", issue = /* FIXME */ "0")]
+#[unstable(feature = "iter_unfold", issue = "55977")]
 pub fn successors<T, F>(first: Option<T>, succ: F) -> Successors<T, F>
     where F: FnMut(&T) -> Option<T>
 {
@@ -504,13 +504,13 @@ pub fn successors<T, F>(first: Option<T>, succ: F) -> Successors<T, F>
 ///
 /// [`successors`]: fn.successors.html
 #[derive(Clone)]
-#[unstable(feature = "iter_unfold", issue = /* FIXME */ "0")]
+#[unstable(feature = "iter_unfold", issue = "55977")]
 pub struct Successors<T, F> {
     next: Option<T>,
     succ: F,
 }
 
-#[unstable(feature = "iter_unfold", issue = /* FIXME */ "0")]
+#[unstable(feature = "iter_unfold", issue = "55977")]
 impl<T, F> Iterator for Successors<T, F>
     where F: FnMut(&T) -> Option<T>
 {
@@ -534,12 +534,12 @@ impl<T, F> Iterator for Successors<T, F>
     }
 }
 
-#[unstable(feature = "iter_unfold", issue = /* FIXME */ "0")]
+#[unstable(feature = "iter_unfold", issue = "55977")]
 impl<T, F> FusedIterator for Successors<T, F>
     where F: FnMut(&T) -> Option<T>
 {}
 
-#[unstable(feature = "iter_unfold", issue = /* FIXME */ "0")]
+#[unstable(feature = "iter_unfold", issue = "55977")]
 impl<T: fmt::Debug, F> fmt::Debug for Successors<T, F> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Successors")

--- a/src/libcore/iter/sources.rs
+++ b/src/libcore/iter/sources.rs
@@ -444,7 +444,7 @@ pub fn unfold<St, T, F>(initial_state: St, f: F) -> Unfold<St, F>
 /// See its documentation for more.
 ///
 /// [`unfold`]: fn.unfold.html
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 #[unstable(feature = "iter_unfold", issue = /* FIXME */ "0")]
 pub struct Unfold<St, F> {
     state: St,

--- a/src/libcore/iter/sources.rs
+++ b/src/libcore/iter/sources.rs
@@ -471,3 +471,79 @@ impl<St: fmt::Debug, F> fmt::Debug for Unfold<St, F> {
             .finish()
     }
 }
+
+/// Creates a new iterator where each successive item is computed based on the preceding one.
+///
+/// The iterator starts with the given first item (if any)
+/// and calls the given `FnMut(&T) -> Option<T>` closure to compute each item’s successor.
+///
+/// ```
+/// #![feature(iter_unfold)]
+/// use std::iter::successors;
+///
+/// let powers_of_10 = successors(Some(1_u16), |n| n.checked_mul(10));
+/// assert_eq!(powers_of_10.collect::<Vec<_>>(), &[1, 10, 100, 1_000, 10_000]);
+/// ```
+#[unstable(feature = "iter_unfold", issue = /* FIXME */ "0")]
+pub fn successors<T, F>(first: Option<T>, succ: F) -> Successors<T, F>
+    where F: FnMut(&T) -> Option<T>
+{
+    // If this function returned `impl Iterator<Item=T>`
+    // it could be based on `unfold` and not need a dedicated type.
+    // However having a named `Successors<T, F>` type allows it to be `Clone` when `T` and `F` are.
+    Successors {
+        next: first,
+        succ,
+    }
+}
+
+/// An new iterator where each successive item is computed based on the preceding one.
+///
+/// This `struct` is created by the [`successors`] function.
+/// See its documentation for more.
+///
+/// [`successors`]: fn.successors.html
+#[derive(Clone)]
+#[unstable(feature = "iter_unfold", issue = /* FIXME */ "0")]
+pub struct Successors<T, F> {
+    next: Option<T>,
+    succ: F,
+}
+
+#[unstable(feature = "iter_unfold", issue = /* FIXME */ "0")]
+impl<T, F> Iterator for Successors<T, F>
+    where F: FnMut(&T) -> Option<T>
+{
+    type Item = T;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.next.take().map(|item| {
+            self.next = (self.succ)(&item);
+            item
+        })
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        if self.next.is_some() {
+            (1, None)
+        } else {
+            (0, Some(0))
+        }
+    }
+}
+
+#[unstable(feature = "iter_unfold", issue = /* FIXME */ "0")]
+impl<T, F> FusedIterator for Successors<T, F>
+    where F: FnMut(&T) -> Option<T>
+{}
+
+#[unstable(feature = "iter_unfold", issue = /* FIXME */ "0")]
+impl<T: fmt::Debug, F> fmt::Debug for Successors<T, F> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Successors")
+            .field("next", &self.next)
+            .finish()
+    }
+}

--- a/src/libcore/iter/sources.rs
+++ b/src/libcore/iter/sources.rs
@@ -415,10 +415,10 @@ pub fn once<T>(value: T) -> Once<T> {
 /// ```
 /// #![feature(iter_unfold)]
 /// let counter = std::iter::unfold(0, |count| {
-///     // increment our count. This is why we started at zero.
+///     // Increment our count. This is why we started at zero.
 ///     *count += 1;
 ///
-///     // check to see if we've finished counting or not.
+///     // Check to see if we've finished counting or not.
 ///     if *count < 6 {
 ///         Some(*count)
 ///     } else {

--- a/src/libcore/iter/sources.rs
+++ b/src/libcore/iter/sources.rs
@@ -444,7 +444,7 @@ pub fn unfold<St, T, F>(initial_state: St, f: F) -> Unfold<St, F>
 /// See its documentation for more.
 ///
 /// [`unfold`]: fn.unfold.html
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone)]
 #[unstable(feature = "iter_unfold", issue = /* FIXME */ "0")]
 pub struct Unfold<St, F> {
     state: St,
@@ -460,5 +460,14 @@ impl<St, T, F> Iterator for Unfold<St, F>
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         (self.f)(&mut self.state)
+    }
+}
+
+#[unstable(feature = "iter_unfold", issue = /* FIXME */ "0")]
+impl<St: fmt::Debug, F> fmt::Debug for Unfold<St, F> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Unfold")
+            .field("state", &self.state)
+            .finish()
     }
 }

--- a/src/libcore/tests/iter.rs
+++ b/src/libcore/tests/iter.rs
@@ -1760,6 +1760,17 @@ fn test_repeat_with_take_collect() {
 }
 
 #[test]
+fn test_successors() {
+    let mut powers_of_10 = successors(Some(1_u16), |n| n.checked_mul(10));
+    assert_eq!(powers_of_10.by_ref().collect::<Vec<_>>(), &[1, 10, 100, 1_000, 10_000]);
+    assert_eq!(powers_of_10.next(), None);
+
+    let mut empty = successors(None::<u32>, |_| unimplemented!());
+    assert_eq!(empty.next(), None);
+    assert_eq!(empty.next(), None);
+}
+
+#[test]
 fn test_fuse() {
     let mut it = 0..3;
     assert_eq!(it.len(), 3);

--- a/src/libcore/tests/lib.rs
+++ b/src/libcore/tests/lib.rs
@@ -19,6 +19,7 @@
 #![feature(flt2dec)]
 #![feature(fmt_internals)]
 #![feature(hashmap_internals)]
+#![feature(iter_unfold)]
 #![feature(pattern)]
 #![feature(range_is_empty)]
 #![feature(raw)]


### PR DESCRIPTION
This adds an **unstable** ~`std::iter::iterate`~ `std::iter::unfold` function and ~`std::iter::Iterate`~ `std::iter::Unfold` type that trivially wrap a ~`FnMut() -> Option<T>`~ `FnMut(&mut State) -> Option<T>` closure to create an iterator. ~Iterator state can be kept in the closure’s environment or captures.~

This is intended to help reduce amount of boilerplate needed when defining an iterator that is only created in one place. Compare the existing example of the `std::iter` module: (explanatory comments elided)

```rust
struct Counter {
    count: usize,
}

impl Counter {
    fn new() -> Counter {
        Counter { count: 0 }
    }
}

impl Iterator for Counter {
    type Item = usize;

    fn next(&mut self) -> Option<usize> {
        self.count += 1;
        if self.count < 6 {
            Some(self.count)
        } else {
            None
        }
    }
}
```

… with the same algorithm rewritten to use this new API:

```rust
fn counter() -> impl Iterator<Item=usize> {
    std::iter::unfold(0, |count| {
        *count += 1;
        if *count < 6 {
            Some(*count)
        } else {
            None
        }
    })
}
```

-----

This also add unstable `std::iter::successors` which takes an (optional) initial item and a closure that takes an item and computes the next one (its successor).

```rust
let powers_of_10 = successors(Some(1_u16), |n| n.checked_mul(10));
assert_eq!(powers_of_10.collect::<Vec<_>>(), &[1, 10, 100, 1_000, 10_000]);
```
