### PR TITLE
stabilize `Rc`, `Arc` and `Pin` as method receivers

### DIFF
--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -77,7 +77,9 @@ use core::iter::FusedIterator;
 use core::marker::{Unpin, Unsize};
 use core::mem;
 use core::pin::Pin;
-use core::ops::{CoerceUnsized, DispatchFromDyn, Deref, DerefMut, Generator, GeneratorState};
+use core::ops::{
+    CoerceUnsized, DispatchFromDyn, Deref, DerefMut, Receiver, Generator, GeneratorState
+};
 use core::ptr::{self, NonNull, Unique};
 use core::task::{LocalWaker, Poll};
 
@@ -581,6 +583,9 @@ impl<T: ?Sized> DerefMut for Box<T> {
         &mut **self
     }
 }
+
+#[unstable(feature = "receiver_trait", issue = "0")]
+impl<T: ?Sized> Receiver for Box<T> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<I: Iterator + ?Sized> Iterator for Box<I> {

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -104,6 +104,7 @@
 #![feature(ptr_internals)]
 #![feature(ptr_offset_from)]
 #![feature(rustc_attrs)]
+#![feature(receiver_trait)]
 #![feature(specialization)]
 #![feature(split_ascii_whitespace)]
 #![feature(staged_api)]

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -254,7 +254,7 @@ use core::intrinsics::abort;
 use core::marker;
 use core::marker::{Unpin, Unsize, PhantomData};
 use core::mem::{self, align_of_val, forget, size_of_val};
-use core::ops::Deref;
+use core::ops::{Deref, Receiver};
 use core::ops::{CoerceUnsized, DispatchFromDyn};
 use core::pin::Pin;
 use core::ptr::{self, NonNull};
@@ -809,6 +809,9 @@ impl<T: ?Sized> Deref for Rc<T> {
         &self.inner().value
     }
 }
+
+#[unstable(feature = "receiver_trait", issue = "0")]
+impl<T: ?Sized> Receiver for Rc<T> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<#[may_dangle] T: ?Sized> Drop for Rc<T> {

--- a/src/liballoc/sync.rs
+++ b/src/liballoc/sync.rs
@@ -24,7 +24,7 @@ use core::fmt;
 use core::cmp::Ordering;
 use core::intrinsics::abort;
 use core::mem::{self, align_of_val, size_of_val};
-use core::ops::Deref;
+use core::ops::{Deref, Receiver};
 use core::ops::{CoerceUnsized, DispatchFromDyn};
 use core::pin::Pin;
 use core::ptr::{self, NonNull};
@@ -763,6 +763,9 @@ impl<T: ?Sized> Deref for Arc<T> {
         &self.inner().data
     }
 }
+
+#[unstable(feature = "receiver_trait", issue = "0")]
+impl<T: ?Sized> Receiver for Arc<T> {}
 
 impl<T: Clone> Arc<T> {
     /// Makes a mutable reference into the given `Arc`.

--- a/src/libcore/ops/deref.rs
+++ b/src/libcore/ops/deref.rs
@@ -177,3 +177,18 @@ pub trait DerefMut: Deref {
 impl<T: ?Sized> DerefMut for &mut T {
     fn deref_mut(&mut self) -> &mut T { *self }
 }
+
+/// A subtrait of `Deref` that indicates that a struct can be used as a method receiver, without the
+/// `arbitrary_self_types` feature. This is implemented by stdlib pointer types like `Box<T>`,
+/// `Rc<T>`, `&T`, and `Pin<P>`.
+#[cfg_attr(not(stage0), lang = "receiver")]
+#[unstable(feature = "receiver_trait", issue = "0")]
+pub trait Receiver: Deref {
+    // Empty.
+}
+
+#[unstable(feature = "receiver_trait", issue = "0")]
+impl<T: ?Sized> Receiver for &T {}
+
+#[unstable(feature = "receiver_trait", issue = "0")]
+impl<T: ?Sized> Receiver for &mut T {}

--- a/src/libcore/ops/mod.rs
+++ b/src/libcore/ops/mod.rs
@@ -178,6 +178,9 @@ pub use self::bit::{BitAndAssign, BitOrAssign, BitXorAssign, ShlAssign, ShrAssig
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::deref::{Deref, DerefMut};
 
+#[unstable(feature = "receiver_trait", issue = "0")]
+pub use self::deref::Receiver;
+
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::drop::Drop;
 

--- a/src/libcore/pin.rs
+++ b/src/libcore/pin.rs
@@ -91,7 +91,7 @@
 
 use fmt;
 use marker::Sized;
-use ops::{Deref, DerefMut, CoerceUnsized, DispatchFromDyn};
+use ops::{Deref, DerefMut, Receiver, CoerceUnsized, DispatchFromDyn};
 
 #[doc(inline)]
 pub use marker::Unpin;
@@ -291,6 +291,9 @@ where
         Pin::get_mut(Pin::as_mut(self))
     }
 }
+
+#[unstable(feature = "receiver_trait", issue = "0")]
+impl<P: Receiver> Receiver for Pin<P> {}
 
 #[unstable(feature = "pin", issue = "49150")]
 impl<P: fmt::Debug> fmt::Debug for Pin<P> {

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -302,6 +302,7 @@ language_item_table! {
 
     DerefTraitLangItem,          "deref",              deref_trait,             Target::Trait;
     DerefMutTraitLangItem,       "deref_mut",          deref_mut_trait,         Target::Trait;
+    ReceiverTraitLangItem,       "receiver",           receiver_trait,          Target::Trait;
 
     FnTraitLangItem,             "fn",                 fn_trait,                Target::Trait;
     FnMutTraitLangItem,          "fn_mut",             fn_mut_trait,            Target::Trait;

--- a/src/test/run-pass/arbitrary_self_types_stdlib_pointers.rs
+++ b/src/test/run-pass/arbitrary_self_types_stdlib_pointers.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(arbitrary_self_types)]
 #![feature(pin)]
 #![feature(rustc_attrs)]
 
@@ -23,6 +22,7 @@ trait Trait {
     fn by_arc(self: Arc<Self>) -> i64;
     fn by_pin_mut(self: Pin<&mut Self>) -> i64;
     fn by_pin_box(self: Pin<Box<Self>>) -> i64;
+    fn by_pin_pin_pin_ref(self: Pin<Pin<Pin<&Self>>>) -> i64;
 }
 
 impl Trait for i64 {
@@ -38,6 +38,17 @@ impl Trait for i64 {
     fn by_pin_box(self: Pin<Box<Self>>) -> i64 {
         *self
     }
+    fn by_pin_pin_pin_ref(self: Pin<Pin<Pin<&Self>>>) -> i64 {
+        *self
+    }
+}
+
+struct Foo;
+
+impl Foo {
+   fn by_box_rc(self: Box<Rc<Self>>) -> i32 {
+       11
+   }
 }
 
 fn main() {
@@ -53,4 +64,10 @@ fn main() {
 
     let pin_box = Into::<Pin<Box<i64>>>::into(Box::new(4i64)) as Pin<Box<dyn Trait>>;
     assert_eq!(4, pin_box.by_pin_box());
+
+    let value = 5i64;
+    let pin_pin_pin_ref = Pin::new(Pin::new(Pin::new(&value))) as Pin<Pin<Pin<&dyn Trait>>>;
+    assert_eq!(5, pin_pin_pin_ref.by_pin_pin_pin_ref());
+
+    assert_eq!(11, Box::new(Rc::new(Foo)).by_box_rc());
 }

--- a/src/test/ui/feature-gates/feature-gate-arbitrary-self-types.rs
+++ b/src/test/ui/feature-gates/feature-gate-arbitrary-self-types.rs
@@ -8,20 +8,32 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::rc::Rc;
+use std::{
+    ops::Deref,
+};
+
+struct Ptr<T: ?Sized>(Box<T>);
+
+impl<T: ?Sized> Deref for Ptr<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &*self.0
+    }
+}
 
 trait Foo {
-    fn foo(self: Rc<Box<Self>>); //~ ERROR arbitrary `self` types are unstable
+    fn foo(self: Ptr<Self>); //~ ERROR `Ptr<Self>` cannot be used as the type of `self` without
 }
 
 struct Bar;
 
 impl Foo for Bar {
-    fn foo(self: Rc<Box<Self>>) {} //~ ERROR arbitrary `self` types are unstable
+    fn foo(self: Ptr<Self>) {} //~ ERROR `Ptr<Bar>` cannot be used as the type of `self` without
 }
 
 impl Bar {
-    fn bar(self: Box<Rc<Self>>) {} //~ ERROR arbitrary `self` types are unstable
+    fn bar(self: Box<Ptr<Self>>) {} //~ ERROR `std::boxed::Box<Ptr<Bar>>` cannot be used as the
 }
 
 fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-arbitrary-self-types.stderr
+++ b/src/test/ui/feature-gates/feature-gate-arbitrary-self-types.stderr
@@ -1,26 +1,26 @@
-error[E0658]: arbitrary `self` types are unstable (see issue #44874)
-  --> $DIR/feature-gate-arbitrary-self-types.rs:14:18
+error[E0658]: `Ptr<Self>` cannot be used as the type of `self` without the `arbitrary_self_types` feature (see issue #44874)
+  --> $DIR/feature-gate-arbitrary-self-types.rs:26:18
    |
-LL |     fn foo(self: Rc<Box<Self>>); //~ ERROR arbitrary `self` types are unstable
-   |                  ^^^^^^^^^^^^^
-   |
-   = help: add #![feature(arbitrary_self_types)] to the crate attributes to enable
-   = help: consider changing to `self`, `&self`, `&mut self`, or `self: Box<Self>`
-
-error[E0658]: arbitrary `self` types are unstable (see issue #44874)
-  --> $DIR/feature-gate-arbitrary-self-types.rs:20:18
-   |
-LL |     fn foo(self: Rc<Box<Self>>) {} //~ ERROR arbitrary `self` types are unstable
-   |                  ^^^^^^^^^^^^^
+LL |     fn foo(self: Ptr<Self>); //~ ERROR `Ptr<Self>` cannot be used as the type of `self` without
+   |                  ^^^^^^^^^
    |
    = help: add #![feature(arbitrary_self_types)] to the crate attributes to enable
    = help: consider changing to `self`, `&self`, `&mut self`, or `self: Box<Self>`
 
-error[E0658]: arbitrary `self` types are unstable (see issue #44874)
-  --> $DIR/feature-gate-arbitrary-self-types.rs:24:18
+error[E0658]: `Ptr<Bar>` cannot be used as the type of `self` without the `arbitrary_self_types` feature (see issue #44874)
+  --> $DIR/feature-gate-arbitrary-self-types.rs:32:18
    |
-LL |     fn bar(self: Box<Rc<Self>>) {} //~ ERROR arbitrary `self` types are unstable
-   |                  ^^^^^^^^^^^^^
+LL |     fn foo(self: Ptr<Self>) {} //~ ERROR `Ptr<Bar>` cannot be used as the type of `self` without
+   |                  ^^^^^^^^^
+   |
+   = help: add #![feature(arbitrary_self_types)] to the crate attributes to enable
+   = help: consider changing to `self`, `&self`, `&mut self`, or `self: Box<Self>`
+
+error[E0658]: `std::boxed::Box<Ptr<Bar>>` cannot be used as the type of `self` without the `arbitrary_self_types` feature (see issue #44874)
+  --> $DIR/feature-gate-arbitrary-self-types.rs:36:18
+   |
+LL |     fn bar(self: Box<Ptr<Self>>) {} //~ ERROR `std::boxed::Box<Ptr<Bar>>` cannot be used as the
+   |                  ^^^^^^^^^^^^^^
    |
    = help: add #![feature(arbitrary_self_types)] to the crate attributes to enable
    = help: consider changing to `self`, `&self`, `&mut self`, or `self: Box<Self>`

--- a/src/test/ui/feature-gates/feature-gate-arbitrary_self_types-raw-pointer.rs
+++ b/src/test/ui/feature-gates/feature-gate-arbitrary_self_types-raw-pointer.rs
@@ -12,17 +12,17 @@ struct Foo;
 
 impl Foo {
     fn foo(self: *const Self) {}
-    //~^ ERROR raw pointer `self` is unstable
+    //~^ ERROR `*const Foo` cannot be used as the type of `self` without
 }
 
 trait Bar {
     fn bar(self: *const Self);
-    //~^ ERROR raw pointer `self` is unstable
+    //~^ ERROR `*const Self` cannot be used as the type of `self` without
 }
 
 impl Bar for () {
     fn bar(self: *const Self) {}
-    //~^ ERROR raw pointer `self` is unstable
+    //~^ ERROR `*const ()` cannot be used as the type of `self` without
 }
 
 fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-arbitrary_self_types-raw-pointer.stderr
+++ b/src/test/ui/feature-gates/feature-gate-arbitrary_self_types-raw-pointer.stderr
@@ -1,4 +1,4 @@
-error[E0658]: raw pointer `self` is unstable (see issue #44874)
+error[E0658]: `*const Self` cannot be used as the type of `self` without the `arbitrary_self_types` feature (see issue #44874)
   --> $DIR/feature-gate-arbitrary_self_types-raw-pointer.rs:19:18
    |
 LL |     fn bar(self: *const Self);
@@ -7,7 +7,7 @@ LL |     fn bar(self: *const Self);
    = help: add #![feature(arbitrary_self_types)] to the crate attributes to enable
    = help: consider changing to `self`, `&self`, `&mut self`, or `self: Box<Self>`
 
-error[E0658]: raw pointer `self` is unstable (see issue #44874)
+error[E0658]: `*const Foo` cannot be used as the type of `self` without the `arbitrary_self_types` feature (see issue #44874)
   --> $DIR/feature-gate-arbitrary_self_types-raw-pointer.rs:14:18
    |
 LL |     fn foo(self: *const Self) {}
@@ -16,7 +16,7 @@ LL |     fn foo(self: *const Self) {}
    = help: add #![feature(arbitrary_self_types)] to the crate attributes to enable
    = help: consider changing to `self`, `&self`, `&mut self`, or `self: Box<Self>`
 
-error[E0658]: raw pointer `self` is unstable (see issue #44874)
+error[E0658]: `*const ()` cannot be used as the type of `self` without the `arbitrary_self_types` feature (see issue #44874)
   --> $DIR/feature-gate-arbitrary_self_types-raw-pointer.rs:24:18
    |
 LL |     fn bar(self: *const Self) {}


### PR DESCRIPTION
This introduces a new `Receiver` trait, which requires `Self: Deref`. If the `arbitrary_self_types` feature is not enabled, then in `check_method_receiver` we require not only that the receiver type transitively derefs to `Self`, but also that each type in the deref chain implements `Receiver` in addition to `Deref`.

By keeping the `Receiver` trait unstable, we ensure that only receiver types from the standard library can be used in stable Rust.

This allows the following to be used as the type of `self`, without a feature flag:

- `Self`, `&Self`, `&mut Self`, `Box<Self>` (already allowed)
- `Rc<Self>`, `Arc<Self>`
- `Pin<&Self>`, `Pin<&mut Self>`, etc.
- any combination of the above, e.g. `&Box<Rc<Self>>`, `Pin<Pin<Pin<&mut Self>>>`

An FCP is required here to stabilize `Rc` and `Arc` as receiver types. As a more conservative approach, we could remove the `impl`s of `Receiver` for `Rc` and `Arc` for now, and add them back later pending an RFC. We would still allow `Pin` to be used as a receiver type without a feature flag, but that wouldn't be a stabilization because `Pin` still requires the `pin` feature. EDIT: An FCP would still be required because we would be allowing things like `&&Self`.

cc #44874 #55786 