### PR TITLE
Reference count `crate_inherent_impls`s return value.

### DIFF
--- a/src/librustc/ty/query/mod.rs
+++ b/src/librustc/ty/query/mod.rs
@@ -291,7 +291,8 @@ define_queries! { <'tcx>
         /// Gets a complete map from all types to their inherent impls.
         /// Not meant to be used directly outside of coherence.
         /// (Defined only for LOCAL_CRATE)
-        [] fn crate_inherent_impls: crate_inherent_impls_dep_node(CrateNum) -> CrateInherentImpls,
+        [] fn crate_inherent_impls: crate_inherent_impls_dep_node(CrateNum)
+            -> Lrc<CrateInherentImpls>,
 
         /// Checks all types in the krate for overlap in their inherent impls. Reports errors.
         /// Not meant to be used directly outside of coherence.

--- a/src/librustc_typeck/coherence/inherent_impls.rs
+++ b/src/librustc_typeck/coherence/inherent_impls.rs
@@ -31,7 +31,7 @@ use syntax_pos::Span;
 /// On-demand query: yields a map containing all types mapped to their inherent impls.
 pub fn crate_inherent_impls<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                       crate_num: CrateNum)
-                                      -> CrateInherentImpls {
+                                      -> Lrc<CrateInherentImpls> {
     assert_eq!(crate_num, LOCAL_CRATE);
 
     let krate = tcx.hir.krate();
@@ -42,7 +42,7 @@ pub fn crate_inherent_impls<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         }
     };
     krate.visit_all_item_likes(&mut collect);
-    collect.impls_map
+    Lrc::new(collect.impls_map)
 }
 
 /// On-demand query: yields a vector of the inherent impls for a specific type.


### PR DESCRIPTION
The repeated cloning of the result in `inherent_impls` queries has quite
an impact on crates with many inherent trait implementations.

For instance on https://github.com/jmesmon/stm32f429, `cargo check` went from 75 seconds to 38 seconds on my machine.