### PR TITLE
core/tests/num: Simplify `test_int_from_str_overflow()` test code

### DIFF
--- a/src/libcore/tests/num/mod.rs
+++ b/src/libcore/tests/num/mod.rs
@@ -82,36 +82,28 @@ fn from_str_issue7588() {
 
 #[test]
 fn test_int_from_str_overflow() {
-    let mut i8_val: i8 = 127;
-    assert_eq!("127".parse::<i8>().ok(), Some(i8_val));
+    assert_eq!("127".parse::<i8>().ok(), Some(127i8));
     assert_eq!("128".parse::<i8>().ok(), None);
 
-    i8_val = i8_val.wrapping_add(1);
-    assert_eq!("-128".parse::<i8>().ok(), Some(i8_val));
+    assert_eq!("-128".parse::<i8>().ok(), Some(-128i8));
     assert_eq!("-129".parse::<i8>().ok(), None);
 
-    let mut i16_val: i16 = 32_767;
-    assert_eq!("32767".parse::<i16>().ok(), Some(i16_val));
+    assert_eq!("32767".parse::<i16>().ok(), Some(32_767i16));
     assert_eq!("32768".parse::<i16>().ok(), None);
 
-    i16_val = i16_val.wrapping_add(1);
-    assert_eq!("-32768".parse::<i16>().ok(), Some(i16_val));
+    assert_eq!("-32768".parse::<i16>().ok(), Some(-32_768i16));
     assert_eq!("-32769".parse::<i16>().ok(), None);
 
-    let mut i32_val: i32 = 2_147_483_647;
-    assert_eq!("2147483647".parse::<i32>().ok(), Some(i32_val));
+    assert_eq!("2147483647".parse::<i32>().ok(), Some(2_147_483_647i32));
     assert_eq!("2147483648".parse::<i32>().ok(), None);
 
-    i32_val = i32_val.wrapping_add(1);
-    assert_eq!("-2147483648".parse::<i32>().ok(), Some(i32_val));
+    assert_eq!("-2147483648".parse::<i32>().ok(), Some(-2_147_483_648i32));
     assert_eq!("-2147483649".parse::<i32>().ok(), None);
 
-    let mut i64_val: i64 = 9_223_372_036_854_775_807;
-    assert_eq!("9223372036854775807".parse::<i64>().ok(), Some(i64_val));
+    assert_eq!("9223372036854775807".parse::<i64>().ok(), Some(9_223_372_036_854_775_807i64));
     assert_eq!("9223372036854775808".parse::<i64>().ok(), None);
 
-    i64_val = i64_val.wrapping_add(1);
-    assert_eq!("-9223372036854775808".parse::<i64>().ok(), Some(i64_val));
+    assert_eq!("-9223372036854775808".parse::<i64>().ok(), Some(-9_223_372_036_854_775_808i64));
     assert_eq!("-9223372036854775809".parse::<i64>().ok(), None);
 }
 


### PR DESCRIPTION
This commit changes the test code to compare against easier-to-read, static values instead of relying on the result of `wrapping_add()` which may or may not result in the value that we expect.