### PR TITLE
reword #[test] attribute error on fn items

### DIFF
--- a/src/libsyntax_ext/test.rs
+++ b/src/libsyntax_ext/test.rs
@@ -53,7 +53,7 @@ pub fn expand_test_or_bench(
         if let Annotatable::Item(i) = item { i }
         else {
             cx.parse_sess.span_diagnostic.span_fatal(item.span(),
-                "#[test] attribute is only allowed on fn items").raise();
+                "#[test] attribute is only allowed on non associated functions").raise();
         };
 
     if let ast::ItemKind::Mac(_) = item.node {

--- a/src/test/ui/test-attr-non-associated-functions.rs
+++ b/src/test/ui/test-attr-non-associated-functions.rs
@@ -1,0 +1,19 @@
+// #[test] attribute is not allowed on associated functions or methods
+// reworded error message 
+// compile-flags:--test
+
+struct A {}
+
+impl A {
+	#[test] 
+	fn new() -> A { //~ ERROR #[test] attribute is only allowed on non associated functions 
+		A {}
+	}
+}
+
+#[test]
+fn test() {
+	let _ = A::new();
+}
+
+fn main() {}

--- a/src/test/ui/test-attr-non-associated-functions.rs
+++ b/src/test/ui/test-attr-non-associated-functions.rs
@@ -1,19 +1,29 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
 // #[test] attribute is not allowed on associated functions or methods
-// reworded error message 
+// reworded error message
 // compile-flags:--test
 
 struct A {}
 
 impl A {
-	#[test] 
-	fn new() -> A { //~ ERROR #[test] attribute is only allowed on non associated functions 
-		A {}
-	}
+    #[test]
+    fn new() -> A { //~ ERROR #[test] attribute is only allowed on non associated functions
+        A {}
+    }
 }
 
 #[test]
 fn test() {
-	let _ = A::new();
+    let _ = A::new();
 }
 
 fn main() {}

--- a/src/test/ui/test-attr-non-associated-functions.stderr
+++ b/src/test/ui/test-attr-non-associated-functions.stderr
@@ -1,8 +1,7 @@
 error: #[test] attribute is only allowed on non associated functions
-  --> $DIR/test-attr-non-associated-functions.rs:9:2
+  --> $DIR/test-attr-non-associated-functions.rs:19:5
    |
-LL |       fn new() -> A { //~ ERROR #[test] attribute is only allowed on non associated functions 
-   |  _____^
+LL | /     fn new() -> A { //~ ERROR #[test] attribute is only allowed on non associated functions
 LL | |         A {}
 LL | |     }
    | |_____^

--- a/src/test/ui/test-attr-non-associated-functions.stderr
+++ b/src/test/ui/test-attr-non-associated-functions.stderr
@@ -1,0 +1,11 @@
+error: #[test] attribute is only allowed on non associated functions
+  --> $DIR/test-attr-non-associated-functions.rs:9:2
+   |
+LL |       fn new() -> A { //~ ERROR #[test] attribute is only allowed on non associated functions 
+   |  _____^
+LL | |         A {}
+LL | |     }
+   | |_____^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
fix of [#55787](https://github.com/rust-lang/rust/issues/55787)
Reworded error message from "#[test] attribute is only allowed on fn items" to "#[test] attribute is only allowed on non associated functions"