### PR TITLE
Switch AppVeyor builds to the GCE cloud

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,12 @@ environment:
   # server goes down presumably. See #43333 for more info
   CARGO_HTTP_CHECK_REVOKE: false
 
+  # Recommended by AppVeyor this moves our builds to GCE which incurs a 3-4
+  # minute startup overhead, but that's paltry compared to our overall build
+  # times so we're will to eat the cost. This is intended to give us better
+  # performance I believe!
+  appveyor_build_worker_cloud: gce
+
   matrix:
   # 32/64 bit MSVC tests
   - MSYS_BITS: 64


### PR DESCRIPTION
[Recommended by AppVeyor][1] this isn't done by default for all builds
due to the high startup overhead (3-4 minutes for a VM), but that's
paltry compared to our overall build times so should be more than
applicable!

[1]: https://help.appveyor.com/discussions/questions/29832-did-recent-changes-apply-to-possibly-slow-down-builds#comment_46494058