### PR TITLE
xLTO: Don't pass --plugin-opt=thin to LLD. That's not supported anymore.

### DIFF
--- a/src/librustc_codegen_utils/linker.rs
+++ b/src/librustc_codegen_utils/linker.rs
@@ -209,17 +209,6 @@ impl<'a> GccLinker<'a> {
         self.linker_arg(&format!("-plugin-opt={}", opt_level));
         let target_cpu = self.target_cpu;
         self.linker_arg(&format!("-plugin-opt=mcpu={}", target_cpu));
-
-        match self.sess.lto() {
-            config::Lto::Thin |
-            config::Lto::ThinLocal => {
-                self.linker_arg("-plugin-opt=thin");
-            }
-            config::Lto::Fat |
-            config::Lto::No => {
-                // default to regular LTO
-            }
-        }
     }
 }
 


### PR DESCRIPTION
It seems that `-plugin-opt=thin` is not needed anymore when invoking LLD for ThinLTO. Unfortunately, still passing the option makes LLD crash instead of giving a deprecation warning or something.