### PR TITLE
Fix VecDeque pretty-printer

### DIFF
--- a/src/etc/gdb_rust_pretty_printing.py
+++ b/src/etc/gdb_rust_pretty_printing.py
@@ -293,15 +293,23 @@ class RustStdVecDequePrinter(object):
     def to_string(self):
         (tail, head, data_ptr, cap) = \
             rustpp.extract_tail_head_ptr_and_cap_from_std_vecdeque(self.__val)
+        if head >= tail:
+            size = head - tail
+        else:
+            size = cap + head - tail
         return (self.__val.type.get_unqualified_type_name() +
-                ("(len: %i, cap: %i)" % (head - tail, cap)))
+                ("(len: %i, cap: %i)" % (size, cap)))
 
     def children(self):
         (tail, head, data_ptr, cap) = \
             rustpp.extract_tail_head_ptr_and_cap_from_std_vecdeque(self.__val)
         gdb_ptr = data_ptr.get_wrapped_value()
-        for index in xrange(tail, head):
-            yield (str(index), (gdb_ptr + index).dereference())
+        if head >= tail:
+            size = head - tail
+        else:
+            size = cap + head - tail
+        for index in xrange(0, size):
+            yield (str(index), (gdb_ptr + ((tail + index) % cap)).dereference())
 
 
 class RustStdBTreeSetPrinter(object):

--- a/src/test/debuginfo/pretty-std-collections.rs
+++ b/src/test/debuginfo/pretty-std-collections.rs
@@ -28,6 +28,9 @@
 // gdb-command: print vec_deque
 // gdb-check:$3 = VecDeque<i32>(len: 3, cap: 8) = {5, 3, 7}
 
+// gdb-command: print vec_deque2
+// gdb-check:$4 = VecDeque<i32>(len: 7, cap: 8) = {2, 3, 4, 5, 6, 7, 8}
+
 #![allow(unused_variables)]
 use std::collections::BTreeSet;
 use std::collections::BTreeMap;
@@ -53,6 +56,14 @@ fn main() {
     vec_deque.push_back(5);
     vec_deque.push_back(3);
     vec_deque.push_back(7);
+
+    // VecDeque where an element was popped.
+    let mut vec_deque2 = VecDeque::new();
+    for i in 1..8 {
+        vec_deque2.push_back(i)
+    }
+    vec_deque2.pop_front();
+    vec_deque2.push_back(8);
 
     zzz(); // #break
 }


### PR DESCRIPTION
This fixes the VecDeque pretty-printer to handle cases where
head < tail.
Closes #55944