### PR TITLE
Miri backtrace improvements

### DIFF
--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -388,7 +388,7 @@ impl_stable_hash_for!(enum mir::interpret::ErrorHandled {
 });
 
 impl_stable_hash_for!(struct mir::interpret::FrameInfo<'tcx> {
-    span,
+    call_site,
     lint_root,
     instance
 });

--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -387,10 +387,10 @@ impl_stable_hash_for!(enum mir::interpret::ErrorHandled {
     TooGeneric
 });
 
-impl_stable_hash_for!(struct mir::interpret::FrameInfo {
+impl_stable_hash_for!(struct mir::interpret::FrameInfo<'tcx> {
     span,
     lint_root,
-    location
+    instance
 });
 
 impl_stable_hash_for!(struct ty::ClosureSubsts<'tcx> { substs });

--- a/src/librustc/mir/interpret/error.rs
+++ b/src/librustc/mir/interpret/error.rs
@@ -23,7 +23,7 @@ use backtrace::Backtrace;
 use ty::query::TyCtxtAt;
 use errors::DiagnosticBuilder;
 
-use syntax_pos::Span;
+use syntax_pos::{Pos, Span};
 use syntax::ast;
 use syntax::symbol::Symbol;
 
@@ -68,10 +68,15 @@ impl<'tcx> fmt::Display for FrameInfo<'tcx> {
             if tcx.def_key(self.instance.def_id()).disambiguated_data.data
                 == DefPathData::ClosureExpr
             {
-                write!(f, "inside call to closure")
+                write!(f, "inside call to closure")?;
             } else {
-                write!(f, "inside call to `{}`", self.instance)
+                write!(f, "inside call to `{}`", self.instance)?;
             }
+            if !self.span.is_dummy() {
+                let lo = tcx.sess.source_map().lookup_char_pos_adj(self.span.lo());
+                write!(f, " at {}:{}:{}", lo.filename, lo.line, lo.col.to_usize() + 1)?;
+            }
+            Ok(())
         })
     }
 }

--- a/src/librustc/mir/interpret/error.rs
+++ b/src/librustc/mir/interpret/error.rs
@@ -57,7 +57,7 @@ pub struct ConstEvalErr<'tcx> {
 
 #[derive(Clone, Debug, RustcEncodable, RustcDecodable)]
 pub struct FrameInfo<'tcx> {
-    pub span: Span,
+    pub call_site: Span, // this span is in the caller!
     pub instance: ty::Instance<'tcx>,
     pub lint_root: Option<ast::NodeId>,
 }
@@ -72,8 +72,8 @@ impl<'tcx> fmt::Display for FrameInfo<'tcx> {
             } else {
                 write!(f, "inside call to `{}`", self.instance)?;
             }
-            if !self.span.is_dummy() {
-                let lo = tcx.sess.source_map().lookup_char_pos_adj(self.span.lo());
+            if !self.call_site.is_dummy() {
+                let lo = tcx.sess.source_map().lookup_char_pos_adj(self.call_site.lo());
                 write!(f, " at {}:{}:{}", lo.filename, lo.line, lo.col.to_usize() + 1)?;
             }
             Ok(())
@@ -159,7 +159,7 @@ impl<'a, 'gcx, 'tcx> ConstEvalErr<'tcx> {
         // on constant values.
         if self.stacktrace.len() > 0 {
             for frame_info in &self.stacktrace[..self.stacktrace.len()-1] {
-                err.span_label(frame_info.span, frame_info.to_string());
+                err.span_label(frame_info.call_site, frame_info.to_string());
             }
         }
         Ok(err)

--- a/src/librustc/mir/interpret/error.rs
+++ b/src/librustc/mir/interpret/error.rs
@@ -191,16 +191,23 @@ fn print_backtrace(backtrace: &mut Backtrace) -> String {
     write!(trace_text, "backtrace frames: {}\n", backtrace.frames().len()).unwrap();
     'frames: for (i, frame) in backtrace.frames().iter().enumerate() {
         if frame.symbols().is_empty() {
-            write!(trace_text, "{}: no symbols\n", i).unwrap();
+            write!(trace_text, "  {}: no symbols\n", i).unwrap();
         }
+        let mut first = true;
         for symbol in frame.symbols() {
-            write!(trace_text, "{}: ", i).unwrap();
+            if first {
+                write!(trace_text, "  {}: ", i).unwrap();
+                first = false;
+            } else {
+                let len = i.to_string().len();
+                write!(trace_text, "  {}  ", " ".repeat(len)).unwrap();
+            }
             if let Some(name) = symbol.name() {
                 write!(trace_text, "{}\n", name).unwrap();
             } else {
                 write!(trace_text, "<unknown>\n").unwrap();
             }
-            write!(trace_text, "\tat ").unwrap();
+            write!(trace_text, "           at ").unwrap();
             if let Some(file_path) = symbol.filename() {
                 write!(trace_text, "{}", file_path.display()).unwrap();
             } else {

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -679,7 +679,7 @@ impl<'a, 'mir, 'tcx: 'mir, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tc
                 mir::ClearCrossCrate::Set(ref ivs) => Some(ivs[source_info.scope].lint_root),
                 mir::ClearCrossCrate::Clear => None,
             };
-            frames.push(FrameInfo { span, instance, lint_root });
+            frames.push(FrameInfo { call_site: span, instance, lint_root });
         }
         trace!("generate stacktrace: {:#?}, {:?}", frames, explicit_span);
         frames

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -14,7 +14,6 @@ use std::mem;
 use syntax::source_map::{self, Span, DUMMY_SP};
 use rustc::hir::def_id::DefId;
 use rustc::hir::def::Def;
-use rustc::hir::map::definitions::DefPathData;
 use rustc::mir;
 use rustc::ty::layout::{
     self, Size, Align, HasDataLayout, LayoutOf, TyLayout
@@ -654,11 +653,10 @@ impl<'a, 'mir, 'tcx: 'mir, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tc
         }
     }
 
-    pub fn generate_stacktrace(&self, explicit_span: Option<Span>) -> Vec<FrameInfo> {
+    pub fn generate_stacktrace(&self, explicit_span: Option<Span>) -> Vec<FrameInfo<'tcx>> {
         let mut last_span = None;
         let mut frames = Vec::new();
-        // skip 1 because the last frame is just the environment of the constant
-        for &Frame { instance, span, mir, block, stmt, .. } in self.stack().iter().skip(1).rev() {
+        for &Frame { instance, span, mir, block, stmt, .. } in self.stack().iter().rev() {
             // make sure we don't emit frames that are duplicates of the previous
             if explicit_span == Some(span) {
                 last_span = Some(span);
@@ -671,13 +669,6 @@ impl<'a, 'mir, 'tcx: 'mir, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tc
             } else {
                 last_span = Some(span);
             }
-            let location = if self.tcx.def_key(instance.def_id()).disambiguated_data.data
-                == DefPathData::ClosureExpr
-            {
-                "closure".to_owned()
-            } else {
-                instance.to_string()
-            };
             let block = &mir.basic_blocks()[block];
             let source_info = if stmt < block.statements.len() {
                 block.statements[stmt].source_info
@@ -688,7 +679,7 @@ impl<'a, 'mir, 'tcx: 'mir, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tc
                 mir::ClearCrossCrate::Set(ref ivs) => Some(ivs[source_info.scope].lint_root),
                 mir::ClearCrossCrate::Clear => None,
             };
-            frames.push(FrameInfo { span, location, lint_root });
+            frames.push(FrameInfo { span, instance, lint_root });
         }
         trace!("generate stacktrace: {:#?}, {:?}", frames, explicit_span);
         frames

--- a/src/test/ui/infinite/infinite-recursion-const-fn.stderr
+++ b/src/test/ui/infinite/infinite-recursion-const-fn.stderr
@@ -5,61 +5,61 @@ LL | const fn a() -> usize { b() } //~ ERROR evaluation of constant value failed
    |                         ^^^
    |                         |
    |                         reached the configured maximum number of stack frames
-   |                         inside call to `b`
+   |                         inside call to `b` at $DIR/infinite-recursion-const-fn.rs:13:25
 LL | const fn b() -> usize { a() }
    |                         ---
    |                         |
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
-   |                         inside call to `a`
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
+   |                         inside call to `a` at $DIR/infinite-recursion-const-fn.rs:14:25
 LL | const ARR: [i32; a()] = [5; 6];
-   |                  --- inside call to `a`
+   |                  --- inside call to `a` at $DIR/infinite-recursion-const-fn.rs:15:18
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Nicer pretty-printing of the `RUST_CTFE_BACKTRACE`-backtraces:
```
  0: backtrace::backtrace::libunwind::trace::hc410fcb66fe85b11
           at /home/r/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.9/src/backtrace/libunwind.rs:53
     backtrace::backtrace::trace::h2106294a22648407
           at /home/r/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.9/src/backtrace/mod.rs:42
  1: backtrace::capture::Backtrace::new_unresolved::h5d8d98b993d092ba
           at /home/r/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.9/src/capture.rs:88
  2: <rustc::mir::interpret::error::EvalError<'tcx> as core::convert::From<rustc::mir::interpret::error::EvalErrorKind<'tcx, u64>>>::from::h6355269b2a661412
           at librustc/mir/interpret/error.rs:236
  3: <T as core::convert::Into<U>>::into::h70fcb917509539bd
           at /home/r/src/rust/rustc.2/src/libcore/convert.rs:455
  4: <rustc_mir::interpret::eval_context::EvalContext<'a, 'mir, 'tcx, miri::Evaluator<'tcx>> as miri::fn_call::EvalContextExt<'tcx, 'mir>>::emulate_foreign_item::h9cde0e3ce7455a4a
           at src/fn_call.rs:292
  5: <rustc_mir::interpret::eval_context::EvalContext<'a, 'mir, 'tcx, miri::Evaluator<'tcx>> as miri::fn_call::EvalContextExt<'tcx, 'mir>>::find_fn::h83f89524b9d1a49a
           at src/fn_call.rs:74
  6: <miri::Evaluator<'tcx> as rustc_mir::interpret::machine::Machine<'a, 'mir, 'tcx>>::find_fn::hf9980473c4775f0c
           at src/lib.rs:345
     rustc_mir::interpret::terminator::<impl rustc_mir::interpret::eval_context::EvalContext<'a, 'mir, 'tcx, M>>::eval_fn_call::h401dec4a687f96e9
           at /home/r/src/rust/rustc.2/src/librustc_mir/interpret/terminator.rs:285
```
Indentation is now consistent with `RUST_BACKTRACE`, and the frame number is not repeated when there are multiple symbols for a frame.

Also preserve the `ty::Instance` for the internal backtrace (showing which frames in the user code where on the interpreter stack when the error happened), used by miri to avoid printing spans for libstd internals:
```
error[E0080]: constant evaluation error: the evaluated program panicked
   --> /home/r/src/rust/rustc.2/src/libstd/panicking.rs:525:9
    |
525 |         __rust_start_panic(obj as usize)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked
    |
    = note: inside call to `std::panicking::rust_panic` at /home/r/src/rust/rustc.2/src/libstd/panicking.rs:496:5
    = note: inside call to `std::panicking::rust_panic_with_hook` at /home/r/src/rust/rustc.2/src/libstd/panicking.rs:390:5
    = note: inside call to `std::panicking::continue_panic_fmt` at /home/r/src/rust/rustc.2/src/libstd/panicking.rs:345:5
note: inside call to `std::rt::begin_panic_fmt` at <::std::macros::panic macros>:8:1
   --> tests/compile-fail/panic.rs:4:5
    |
4   |     assert_eq!(5, 6);
    |     ^^^^^^^^^^^^^^^^^
    = note: inside call to `main` at /home/r/src/rust/rustc.2/src/libstd/rt.rs:74:34
    = note: inside call to closure at /home/r/src/rust/rustc.2/src/libstd/rt.rs:59:75
    = note: inside call to closure at /home/r/src/rust/rustc.2/src/libstd/sys_common/backtrace.rs:136:5
    = note: inside call to `std::sys_common::backtrace::__rust_begin_short_backtrace::<[closure@DefId(1/1:1913 ~ std[78f0]::rt[0]::lang_start_internal[0]::{{closure}}[0]::{{closure}}[0]) 0:&dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe], i32>` at /home/r/src/rust/rustc.2/src/libstd/rt.rs:59:13
    = note: inside call to closure at /home/r/src/rust/rustc.2/src/libstd/panicking.rs:310:40
    = note: inside call to `std::panicking::try::do_call::<[closure@DefId(1/1:1912 ~ std[78f0]::rt[0]::lang_start_internal[0]::{{closure}}[0]) 0:&&dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe], i32>` at /home/r/src/rust/rustc.2/src/libstd/panicking.rs:306:5
    = note: inside call to `std::panicking::try::<i32, [closure@DefId(1/1:1912 ~ std[78f0]::rt[0]::lang_start_internal[0]::{{closure}}[0]) 0:&&dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe]>` at /home/r/src/rust/rustc.2/src/libstd/panic.rs:398:9
    = note: inside call to `std::panic::catch_unwind::<[closure@DefId(1/1:1912 ~ std[78f0]::rt[0]::lang_start_internal[0]::{{closure}}[0]) 0:&&dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe], i32>` at /home/r/src/rust/rustc.2/src/libstd/rt.rs:58:25
    = note: inside call to `std::rt::lang_start_internal` at /home/r/src/rust/rustc.2/src/libstd/rt.rs:74:5
    = note: inside call to `std::rt::lang_start::<()>`
```
Also notice that we show filenames and line numbers here now.

r? @oli-obk 