### PR TITLE
Ignore non-semantic tokens for 'probably_eq' streams.

### DIFF
--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -570,8 +570,9 @@ impl Token {
         //
         // Instead the "probably equal" check here is "does each token
         // recursively have the same discriminant?" We basically don't look at
-        // the token values here and assume that such fine grained modifications
-        // of token streams doesn't happen.
+        // the token values here and assume that such fine grained token stream
+        // modifications, including adding/removing typically non-semantic
+        // tokens such as extra braces and commas, don't happen.
         if let Some(tokens) = tokens {
             if tokens.probably_equal_for_proc_macro(&tokens_for_real) {
                 return tokens

--- a/src/test/ui-fulldeps/proc-macro/auxiliary/span-preservation.rs
+++ b/src/test/ui-fulldeps/proc-macro/auxiliary/span-preservation.rs
@@ -1,0 +1,12 @@
+// no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+
+#[proc_macro_attribute]
+pub fn foo(_: TokenStream, input: TokenStream) -> TokenStream {
+    input.into_iter().collect()
+}

--- a/src/test/ui-fulldeps/proc-macro/span-preservation.rs
+++ b/src/test/ui-fulldeps/proc-macro/span-preservation.rs
@@ -1,0 +1,51 @@
+// aux-build:span-preservation.rs
+
+// For each of these, we should get the appropriate type mismatch error message,
+// and the function should be echoed.
+
+extern crate span_preservation as foo;
+
+use foo::foo;
+
+#[foo]
+fn a() {
+    let x: usize = "hello";;;;;
+}
+
+#[foo]
+fn b(x: Option<isize>) -> usize {
+    match x {
+        Some(x) => { return x },
+        None => 10
+    }
+}
+
+#[foo]
+fn c() {
+    struct Foo {
+        a: usize
+    }
+
+    struct Bar {
+        a: usize,
+        b: usize
+    }
+
+    let x = Foo { a: 10isize };
+    let y = Foo { a: 10, b: 10isize };
+}
+
+// FIXME: This doesn't work at the moment. See the one below. The pretty-printer
+// injects a "C" between `extern` and `fn` which causes a "probably_eq"
+// `TokenStream` mismatch. The lack of `"C"` should be preserved in the AST.
+#[foo]
+extern fn bar() {
+    0
+}
+
+#[foo]
+extern "C" fn baz() {
+    0
+}
+
+fn main() {}

--- a/src/test/ui-fulldeps/proc-macro/span-preservation.stderr
+++ b/src/test/ui-fulldeps/proc-macro/span-preservation.stderr
@@ -1,0 +1,49 @@
+error[E0308]: mismatched types
+   |
+   = note: expected type `()`
+              found type `{integer}`
+
+error[E0308]: mismatched types
+  --> $DIR/span-preservation.rs:12:20
+   |
+LL |     let x: usize = "hello";;;;;
+   |                    ^^^^^^^ expected usize, found reference
+   |
+   = note: expected type `usize`
+              found type `&'static str`
+
+error[E0308]: mismatched types
+  --> $DIR/span-preservation.rs:18:29
+   |
+LL |         Some(x) => { return x },
+   |                             ^ expected usize, found isize
+
+error[E0308]: mismatched types
+  --> $DIR/span-preservation.rs:34:22
+   |
+LL |     let x = Foo { a: 10isize };
+   |                      ^^^^^^^ expected usize, found isize
+
+error[E0560]: struct `c::Foo` has no field named `b`
+  --> $DIR/span-preservation.rs:35:26
+   |
+LL |     let y = Foo { a: 10, b: 10isize };
+   |                          ^ `c::Foo` does not have this field
+   |
+   = note: available fields are: `a`
+
+error[E0308]: mismatched types
+  --> $DIR/span-preservation.rs:48:5
+   |
+LL | extern "C" fn baz() {
+   |                     - possibly return type missing here?
+LL |     0
+   |     ^ expected (), found integral variable
+   |
+   = note: expected type `()`
+              found type `{integer}`
+
+error: aborting due to 6 previous errors
+
+Some errors occurred: E0308, E0560.
+For more information about an error, try `rustc --explain E0308`.


### PR DESCRIPTION
Improves the situation in #43081 by skipping typically non-semantic tokens when checking for 'probably_eq'.

r? @alexcrichton