### PR TITLE
Fix stability hole with `static _`

### DIFF
--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -1583,6 +1583,7 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                 }
             }
 
+            ast::ItemKind::Static(..) |
             ast::ItemKind::Const(_,_) => {
                 if i.ident.name == "_" {
                     gate_feature_post!(&self, underscore_const_names, i.span,

--- a/src/test/ui/underscore_const_names_feature_gate.rs
+++ b/src/test/ui/underscore_const_names_feature_gate.rs
@@ -1,0 +1,14 @@
+// Copyright 2012-2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+const _: () = (); //~ ERROR is unstable
+static _: () = (); //~ ERROR is unstable
+
+fn main() {}

--- a/src/test/ui/underscore_const_names_feature_gate.stderr
+++ b/src/test/ui/underscore_const_names_feature_gate.stderr
@@ -1,0 +1,19 @@
+error[E0658]: naming constants with `_` is unstable (see issue #54912)
+  --> $DIR/underscore_const_names_feature_gate.rs:11:1
+   |
+LL | const _: () = ();
+   | ^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(underscore_const_names)] to the crate attributes to enable
+
+error[E0658]: naming constants with `_` is unstable (see issue #54912)
+  --> $DIR/underscore_const_names_feature_gate.rs:12:1
+   |
+LL | static _: () = ();
+   | ^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(underscore_const_names)] to the crate attributes to enable
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/underscore_const_names_feature_gate.stderr
+++ b/src/test/ui/underscore_const_names_feature_gate.stderr
@@ -1,7 +1,7 @@
 error[E0658]: naming constants with `_` is unstable (see issue #54912)
   --> $DIR/underscore_const_names_feature_gate.rs:11:1
    |
-LL | const _: () = ();
+LL | const _: () = (); //~ ERROR is unstable
    | ^^^^^^^^^^^^^^^^^
    |
    = help: add #![feature(underscore_const_names)] to the crate attributes to enable
@@ -9,7 +9,7 @@ LL | const _: () = ();
 error[E0658]: naming constants with `_` is unstable (see issue #54912)
   --> $DIR/underscore_const_names_feature_gate.rs:12:1
    |
-LL | static _: () = ();
+LL | static _: () = (); //~ ERROR is unstable
    | ^^^^^^^^^^^^^^^^^^
    |
    = help: add #![feature(underscore_const_names)] to the crate attributes to enable


### PR DESCRIPTION
The `underscore_const_names` only gated const items with `_` as the name.

`static _: () = ();` works on beta without feature gates right now, this PR fixes that.