### PR TITLE
[beta] Rollup backports

### DIFF
--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -963,6 +963,10 @@ impl Session {
         self.opts.debugging_opts.teach && self.diagnostic().must_teach(code)
     }
 
+    pub fn rust_2015(&self) -> bool {
+        self.opts.edition == Edition::Edition2015
+    }
+
     /// Are we allowed to use features from the Rust 2018 edition?
     pub fn rust_2018(&self) -> bool {
         self.opts.edition >= Edition::Edition2018

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -1609,16 +1609,10 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         match self.hir.get(node_id) {
             Node::Item(item) => {
                 match item.node {
-                    ItemKind::Trait(..)
-                    | ItemKind::TraitAlias(..)
-                    | ItemKind::Mod(..)
-                    | ItemKind::ForeignMod(..)
-                    | ItemKind::GlobalAsm(..)
-                    | ItemKind::ExternCrate(..)
-                    | ItemKind::Use(..) => {
+                    ItemKind::Fn(..) => { /* type_of_def_id() will work */ }
+                    _ => {
                         return None;
                     }
-                    _ => { /* type_of_def_id() will work */ }
                 }
             }
             _ => { /* type_of_def_id() will work or panic */ }

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -17,7 +17,7 @@ use session::Session;
 use session::config::{BorrowckMode, OutputFilenames};
 use session::config::CrateType;
 use middle;
-use hir::{TraitCandidate, HirId, ItemLocalId, Node};
+use hir::{TraitCandidate, HirId, ItemKind, ItemLocalId, Node};
 use hir::def::{Def, Export};
 use hir::def_id::{CrateNum, DefId, DefIndex, LOCAL_CRATE};
 use hir::map as hir_map;
@@ -1604,6 +1604,26 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         &self,
         scope_def_id: DefId,
     ) -> Option<Ty<'tcx>> {
+        // HACK: `type_of_def_id()` will fail on these (#55796), so return None
+        let node_id = self.hir.as_local_node_id(scope_def_id).unwrap();
+        match self.hir.get(node_id) {
+            Node::Item(item) => {
+                match item.node {
+                    ItemKind::Trait(..)
+                    | ItemKind::TraitAlias(..)
+                    | ItemKind::Mod(..)
+                    | ItemKind::ForeignMod(..)
+                    | ItemKind::GlobalAsm(..)
+                    | ItemKind::ExternCrate(..)
+                    | ItemKind::Use(..) => {
+                        return None;
+                    }
+                    _ => { /* type_of_def_id() will work */ }
+                }
+            }
+            _ => { /* type_of_def_id() will work or panic */ }
+        }
+
         let ret_ty = self.type_of(scope_def_id);
         match ret_ty.sty {
             ty::FnDef(_, _) => {

--- a/src/librustc_codegen_llvm/back/linker.rs
+++ b/src/librustc_codegen_llvm/back/linker.rs
@@ -205,17 +205,6 @@ impl<'a> GccLinker<'a> {
 
         self.linker_arg(&format!("-plugin-opt={}", opt_level));
         self.linker_arg(&format!("-plugin-opt=mcpu={}", llvm_util::target_cpu(self.sess)));
-
-        match self.sess.lto() {
-            config::Lto::Thin |
-            config::Lto::ThinLocal => {
-                self.linker_arg("-plugin-opt=thin");
-            }
-            config::Lto::Fat |
-            config::Lto::No => {
-                // default to regular LTO
-            }
-        }
     }
 }
 

--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -659,10 +659,13 @@ impl<'a, 'cl> Resolver<'a, 'cl> {
                     binding.map(|binding| (binding, Flags::MODULE, Flags::empty()))
                 }
                 WhereToResolve::MacroUsePrelude => {
-                    match self.macro_use_prelude.get(&ident.name).cloned() {
-                        Some(binding) => Ok((binding, Flags::PRELUDE, Flags::empty())),
-                        None => Err(Determinacy::Determined),
+                    let mut result = Err(Determinacy::Determined);
+                    if use_prelude || self.session.rust_2015() {
+                        if let Some(binding) = self.macro_use_prelude.get(&ident.name).cloned() {
+                            result = Ok((binding, Flags::PRELUDE, Flags::empty()));
+                        }
                     }
+                    result
                 }
                 WhereToResolve::BuiltinMacros => {
                     match self.builtin_macros.get(&ident.name).cloned() {
@@ -681,7 +684,8 @@ impl<'a, 'cl> Resolver<'a, 'cl> {
                     }
                 }
                 WhereToResolve::LegacyPluginHelpers => {
-                    if self.session.plugin_attributes.borrow().iter()
+                    if (use_prelude || self.session.rust_2015()) &&
+                       self.session.plugin_attributes.borrow().iter()
                                                      .any(|(name, _)| ident.name == &**name) {
                         let binding = (Def::NonMacroAttr(NonMacroAttrKind::LegacyPluginHelper),
                                        ty::Visibility::Public, ident.span, Mark::root())

--- a/src/test/ui/hygiene/no_implicit_prelude-2018.rs
+++ b/src/test/ui/hygiene/no_implicit_prelude-2018.rs
@@ -1,0 +1,11 @@
+// edition:2018
+
+#[no_implicit_prelude]
+mod bar {
+    fn f() {
+        ::std::print!(""); // OK
+        print!(); //~ ERROR cannot find macro `print!` in this scope
+    }
+}
+
+fn main() {}

--- a/src/test/ui/hygiene/no_implicit_prelude-2018.stderr
+++ b/src/test/ui/hygiene/no_implicit_prelude-2018.stderr
@@ -1,0 +1,10 @@
+error: cannot find macro `print!` in this scope
+  --> $DIR/no_implicit_prelude-2018.rs:7:9
+   |
+LL |         print!(); //~ ERROR cannot find macro `print!` in this scope
+   |         ^^^^^
+   |
+   = help: have you added the `#[macro_use]` on the module/import?
+
+error: aborting due to previous error
+

--- a/src/test/ui/hygiene/no_implicit_prelude.rs
+++ b/src/test/ui/hygiene/no_implicit_prelude.rs
@@ -21,7 +21,10 @@ mod bar {
         Vec::new(); //~ ERROR failed to resolve
         ().clone() //~ ERROR no method named `clone` found
     }
-    fn f() { ::foo::m!(); }
+    fn f() {
+        ::foo::m!();
+        println!(); // OK on 2015 edition (at least for now)
+    }
 }
 
 fn main() {}

--- a/src/test/ui/issues/issue-55796.rs
+++ b/src/test/ui/issues/issue-55796.rs
@@ -1,0 +1,22 @@
+pub trait EdgeTrait<N> {
+    fn target(&self) -> N;
+}
+
+pub trait Graph<'a> {
+    type Node;
+    type Edge: EdgeTrait<Self::Node>;
+    type NodesIter: Iterator<Item = Self::Node> + 'a;
+    type EdgesIter: Iterator<Item = Self::Edge> + 'a;
+
+    fn nodes(&'a self) -> Self::NodesIter;
+    fn out_edges(&'a self, u: &Self::Node) -> Self::EdgesIter;
+    fn in_edges(&'a self, u: &Self::Node) -> Self::EdgesIter;
+
+    fn out_neighbors(&'a self, u: &Self::Node) -> Box<Iterator<Item = Self::Node>> {
+        Box::new(self.out_edges(u).map(|e| e.target()))
+    }
+
+    fn in_neighbors(&'a self, u: &Self::Node) -> Box<Iterator<Item = Self::Node>> {
+        Box::new(self.in_edges(u).map(|e| e.target()))
+    }
+}

--- a/src/test/ui/issues/issue-55796.stderr
+++ b/src/test/ui/issues/issue-55796.stderr
@@ -1,0 +1,50 @@
+error[E0601]: `main` function not found in crate `issue_55796`
+   |
+   = note: consider adding a `main` function to `$DIR/issue-55796.rs`
+
+error[E0495]: cannot infer an appropriate lifetime due to conflicting requirements
+  --> $DIR/issue-55796.rs:16:9
+   |
+LL |         Box::new(self.out_edges(u).map(|e| e.target()))
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: first, the lifetime cannot outlive the lifetime 'a as defined on the trait at 5:17...
+  --> $DIR/issue-55796.rs:5:17
+   |
+LL | pub trait Graph<'a> {
+   |                 ^^
+note: ...so that the type `std::iter::Map<<Self as Graph<'a>>::EdgesIter, [closure@$DIR/issue-55796.rs:16:40: 16:54]>` will meet its required lifetime bounds
+  --> $DIR/issue-55796.rs:16:9
+   |
+LL |         Box::new(self.out_edges(u).map(|e| e.target()))
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: but, the lifetime must be valid for the static lifetime...
+   = note: ...so that the expression is assignable:
+           expected std::boxed::Box<(dyn std::iter::Iterator<Item=<Self as Graph<'a>>::Node> + 'static)>
+              found std::boxed::Box<dyn std::iter::Iterator<Item=<Self as Graph<'a>>::Node>>
+
+error[E0495]: cannot infer an appropriate lifetime due to conflicting requirements
+  --> $DIR/issue-55796.rs:20:9
+   |
+LL |         Box::new(self.in_edges(u).map(|e| e.target()))
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: first, the lifetime cannot outlive the lifetime 'a as defined on the trait at 5:17...
+  --> $DIR/issue-55796.rs:5:17
+   |
+LL | pub trait Graph<'a> {
+   |                 ^^
+note: ...so that the type `std::iter::Map<<Self as Graph<'a>>::EdgesIter, [closure@$DIR/issue-55796.rs:20:39: 20:53]>` will meet its required lifetime bounds
+  --> $DIR/issue-55796.rs:20:9
+   |
+LL |         Box::new(self.in_edges(u).map(|e| e.target()))
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: but, the lifetime must be valid for the static lifetime...
+   = note: ...so that the expression is assignable:
+           expected std::boxed::Box<(dyn std::iter::Iterator<Item=<Self as Graph<'a>>::Node> + 'static)>
+              found std::boxed::Box<dyn std::iter::Iterator<Item=<Self as Graph<'a>>::Node>>
+
+error: aborting due to 3 previous errors
+
+Some errors occurred: E0495, E0601.
+For more information about an error, try `rustc --explain E0495`.


### PR DESCRIPTION
Merged and approved:

* #55947: xLTO: Don't pass --plugin-opt=thin to LLD. That's not supported anymore.
* #55800: Fix ICE in `return_type_impl_trait`
* #55630: resolve: Filter away macro prelude in modules with `#[no_implicit_prelude]` on 2018 edition

r? @ghost