### PR TITLE
do not propagate inferred bounds on trait objects if they involve `Self`

### DIFF
--- a/src/librustc/traits/mod.rs
+++ b/src/librustc/traits/mod.rs
@@ -700,7 +700,12 @@ fn do_normalize_predicates<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                      predicates: Vec<ty::Predicate<'tcx>>)
                                      -> Result<Vec<ty::Predicate<'tcx>>, ErrorReported>
 {
-    debug!("do_normalize_predicates({:?})", predicates);
+    debug!(
+        "do_normalize_predicates(predicates={:?}, region_context={:?}, cause={:?})",
+        predicates,
+        region_context,
+        cause,
+    );
     let span = cause.span;
     tcx.infer_ctxt().enter(|infcx| {
         // FIXME. We should really... do something with these region

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1608,10 +1608,21 @@ fn predicates_defined_on<'a, 'tcx>(
     tcx: TyCtxt<'a, 'tcx, 'tcx>,
     def_id: DefId,
 ) -> Lrc<ty::GenericPredicates<'tcx>> {
+    debug!("predicates_defined_on({:?})", def_id);
     let mut result = tcx.explicit_predicates_of(def_id);
+    debug!(
+        "predicates_defined_on: explicit_predicates_of({:?}) = {:?}",
+        def_id,
+        result,
+    );
     let inferred_outlives = tcx.inferred_outlives_of(def_id);
     if !inferred_outlives.is_empty() {
         let span = tcx.def_span(def_id);
+        debug!(
+            "predicates_defined_on: inferred_outlives_of({:?}) = {:?}",
+            def_id,
+            inferred_outlives,
+        );
         Lrc::make_mut(&mut result)
             .predicates
             .extend(inferred_outlives.iter().map(|&p| (p, span)));

--- a/src/librustc_typeck/outlives/implicit_infer.rs
+++ b/src/librustc_typeck/outlives/implicit_infer.rs
@@ -245,6 +245,7 @@ fn insert_required_predicates_to_be_wf<'tcx>(
     }
 }
 
+#[derive(Debug)]
 pub struct IgnoreSelfTy(bool);
 
 /// We also have to check the explicit predicates
@@ -270,10 +271,18 @@ pub fn check_explicit_predicates<'tcx>(
     explicit_map: &mut ExplicitPredicatesMap<'tcx>,
     ignore_self_ty: IgnoreSelfTy,
 ) {
-    debug!("def_id = {:?}", &def_id);
-    debug!("substs = {:?}", &substs);
-    debug!("explicit_map =  {:?}", explicit_map);
-    debug!("required_predicates = {:?}", required_predicates);
+    debug!(
+        "check_explicit_predicates(def_id={:?}, \
+         substs={:?}, \
+         explicit_map={:?}, \
+         required_predicates={:?}, \
+         ignore_self_ty={:?})",
+        def_id,
+        substs,
+        explicit_map,
+        required_predicates,
+        ignore_self_ty,
+    );
     let explicit_predicates = explicit_map.explicit_predicates_of(tcx, *def_id);
 
     for outlives_predicate in explicit_predicates.iter() {

--- a/src/librustc_typeck/outlives/mod.rs
+++ b/src/librustc_typeck/outlives/mod.rs
@@ -67,6 +67,9 @@ fn inferred_outlives_of<'a, 'tcx>(
                     }
                     err.emit();
                 }
+
+                debug!("inferred_outlives_of({:?}) = {:?}", item_def_id, predicates);
+
                 predicates
             }
 

--- a/src/test/ui/rfc-2093-infer-outlives/issue-54467.rs
+++ b/src/test/ui/rfc-2093-infer-outlives/issue-54467.rs
@@ -1,0 +1,17 @@
+// Regression test for #54467:
+//
+// Here, the trait object has an "inferred outlives" requirement that
+// `<Self as MyIterator<'a>>::Item: 'a`; but since we don't know what
+// `Self` is, we were (incorrectly) messing things up, leading to
+// strange errors. This test ensures that we do not give compilation
+// errors.
+//
+// compile-pass
+
+trait MyIterator<'a>: Iterator where Self::Item: 'a { }
+
+struct MyStruct<'a, A> {
+    item: Box<dyn MyIterator<'a, Item = A>>
+}
+
+fn main() { }


### PR DESCRIPTION
Fixes #54467, which is a Rust 2018 Release blocking issue.

r? @eddyb 