### PR TITLE
[WIP experiment] Hybrid sorted map

### DIFF
--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -52,13 +52,13 @@ use lint::builtin::{self, PARENTHESIZED_PARAMS_IN_TYPES_AND_MODULES,
 use middle::cstore::CrateStore;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_data_structures::indexed_vec::IndexVec;
+use rustc_data_structures::sorted_map::HybridSortedMap;
 use rustc_data_structures::thin_vec::ThinVec;
 use session::Session;
 use session::config::nightly_options;
 use util::common::FN_OUTPUT_NAME;
 use util::nodemap::{DefIdMap, NodeMap};
 
-use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::mem;
 use smallvec::SmallVec;
@@ -91,15 +91,15 @@ pub struct LoweringContext<'a> {
     resolver: &'a mut dyn Resolver,
 
     /// The items being lowered are collected here.
-    items: BTreeMap<NodeId, hir::Item>,
+    items: HybridSortedMap<NodeId, hir::Item>,
 
-    trait_items: BTreeMap<hir::TraitItemId, hir::TraitItem>,
-    impl_items: BTreeMap<hir::ImplItemId, hir::ImplItem>,
-    bodies: BTreeMap<hir::BodyId, hir::Body>,
+    trait_items: HybridSortedMap<hir::TraitItemId, hir::TraitItem>,
+    impl_items: HybridSortedMap<hir::ImplItemId, hir::ImplItem>,
+    bodies: HybridSortedMap<hir::BodyId, hir::Body>,
     exported_macros: Vec<hir::MacroDef>,
 
-    trait_impls: BTreeMap<DefId, Vec<NodeId>>,
-    trait_auto_impl: BTreeMap<DefId, NodeId>,
+    trait_impls: HybridSortedMap<DefId, Vec<NodeId>>,
+    trait_auto_impl: HybridSortedMap<DefId, NodeId>,
 
     is_generator: bool,
 
@@ -233,12 +233,12 @@ pub fn lower_crate(
         sess,
         cstore,
         resolver,
-        items: BTreeMap::new(),
-        trait_items: BTreeMap::new(),
-        impl_items: BTreeMap::new(),
-        bodies: BTreeMap::new(),
-        trait_impls: BTreeMap::new(),
-        trait_auto_impl: BTreeMap::new(),
+        items: HybridSortedMap::new(),
+        trait_items: HybridSortedMap::new(),
+        impl_items: HybridSortedMap::new(),
+        bodies: HybridSortedMap::new(),
+        trait_impls: HybridSortedMap::new(),
+        trait_auto_impl: HybridSortedMap::new(),
         exported_macros: Vec::new(),
         catch_scopes: Vec::new(),
         loop_scopes: Vec::new(),
@@ -5057,7 +5057,7 @@ impl<'a> LoweringContext<'a> {
     }
 }
 
-fn body_ids(bodies: &BTreeMap<hir::BodyId, hir::Body>) -> Vec<hir::BodyId> {
+fn body_ids(bodies: &HybridSortedMap<hir::BodyId, hir::Body>) -> Vec<hir::BodyId> {
     // Sorting by span ensures that we get things in order within a
     // file, and also puts the files in a sensible order.
     let mut body_ids: Vec<_> = bodies.keys().cloned().collect();

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -37,11 +37,11 @@ use syntax::util::parser::ExprPrecedence;
 use ty::AdtKind;
 use ty::query::Providers;
 
+use rustc_data_structures::sorted_map::HybridSortedMap;
 use rustc_data_structures::sync::{ParallelIterator, par_iter, Send, Sync, scope};
 use rustc_data_structures::thin_vec::ThinVec;
 
 use serialize::{self, Encoder, Encodable, Decoder, Decodable};
-use std::collections::BTreeMap;
 use std::fmt;
 
 /// HIR doesn't commit to a concrete storage type and has its own alias for a vector.
@@ -697,19 +697,19 @@ pub struct Crate {
     pub span: Span,
     pub exported_macros: HirVec<MacroDef>,
 
-    // NB: We use a BTreeMap here so that `visit_all_items` iterates
+    // NB: We use a HybridSortedMap here so that `visit_all_items` iterates
     // over the ids in increasing order. In principle it should not
     // matter what order we visit things in, but in *practice* it
     // does, because it can affect the order in which errors are
     // detected, which in turn can make compile-fail tests yield
     // slightly different results.
-    pub items: BTreeMap<NodeId, Item>,
+    pub items: HybridSortedMap<NodeId, Item>,
 
-    pub trait_items: BTreeMap<TraitItemId, TraitItem>,
-    pub impl_items: BTreeMap<ImplItemId, ImplItem>,
-    pub bodies: BTreeMap<BodyId, Body>,
-    pub trait_impls: BTreeMap<DefId, Vec<NodeId>>,
-    pub trait_auto_impl: BTreeMap<DefId, NodeId>,
+    pub trait_items: HybridSortedMap<TraitItemId, TraitItem>,
+    pub impl_items: HybridSortedMap<ImplItemId, ImplItem>,
+    pub bodies: HybridSortedMap<BodyId, Body>,
+    pub trait_impls: HybridSortedMap<DefId, Vec<NodeId>>,
+    pub trait_auto_impl: HybridSortedMap<DefId, NodeId>,
 
     /// A list of the body ids written out in the order in which they
     /// appear in the crate. If you're going to process all the bodies

--- a/src/librustc/infer/lexical_region_resolve/graphviz.rs
+++ b/src/librustc/infer/lexical_region_resolve/graphviz.rs
@@ -25,11 +25,11 @@ use middle::region;
 use super::Constraint;
 use infer::SubregionOrigin;
 use infer::region_constraints::RegionConstraintData;
+use rustc_data_structures::sorted_map::HybridSortedMap;
 use util::nodemap::{FxHashMap, FxHashSet};
 
 use std::borrow::Cow;
 use std::collections::hash_map::Entry::Vacant;
-use std::collections::btree_map::BTreeMap;
 use std::env;
 use std::fs::File;
 use std::io;
@@ -121,7 +121,7 @@ pub fn maybe_print_constraints_for<'a, 'gcx, 'tcx>(
 struct ConstraintGraph<'a, 'gcx: 'a+'tcx, 'tcx: 'a> {
     graph_name: String,
     region_rels: &'a RegionRelations<'a, 'gcx, 'tcx>,
-    map: &'a BTreeMap<Constraint<'tcx>, SubregionOrigin<'tcx>>,
+    map: &'a HybridSortedMap<Constraint<'tcx>, SubregionOrigin<'tcx>>,
     node_ids: FxHashMap<Node, usize>,
 }
 
@@ -255,7 +255,7 @@ impl<'a, 'gcx, 'tcx> dot::GraphWalk<'a> for ConstraintGraph<'a, 'gcx, 'tcx> {
     }
 }
 
-pub type ConstraintMap<'tcx> = BTreeMap<Constraint<'tcx>, SubregionOrigin<'tcx>>;
+pub type ConstraintMap<'tcx> = HybridSortedMap<Constraint<'tcx>, SubregionOrigin<'tcx>>;
 
 fn dump_region_data_to<'a, 'gcx, 'tcx>(region_rels: &RegionRelations<'a, 'gcx, 'tcx>,
                                        map: &ConstraintMap<'tcx>,

--- a/src/librustc/infer/mod.rs
+++ b/src/librustc/infer/mod.rs
@@ -24,10 +24,10 @@ use infer::canonical::{Canonical, CanonicalVarValues};
 use middle::free_region::RegionRelations;
 use middle::lang_items;
 use middle::region;
+use rustc_data_structures::sorted_map::HybridSortedMap;
 use rustc_data_structures::unify as ut;
 use session::config::BorrowckMode;
 use std::cell::{Cell, Ref, RefCell, RefMut};
-use std::collections::BTreeMap;
 use std::fmt;
 use syntax::ast;
 use syntax_pos::symbol::InternedString;
@@ -230,7 +230,7 @@ pub struct InferCtxt<'a, 'gcx: 'a + 'tcx, 'tcx: 'a> {
 /// A map returned by `replace_late_bound_regions_with_placeholders()`
 /// indicating the placeholder region that each late-bound region was
 /// replaced with.
-pub type PlaceholderMap<'tcx> = BTreeMap<ty::BoundRegion, ty::Region<'tcx>>;
+pub type PlaceholderMap<'tcx> = HybridSortedMap<ty::BoundRegion, ty::Region<'tcx>>;
 
 /// See `error_reporting` module for more details
 #[derive(Clone, Debug)]
@@ -1333,7 +1333,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
         span: Span,
         lbrct: LateBoundRegionConversionTime,
         value: &ty::Binder<T>
-    ) -> (T, BTreeMap<ty::BoundRegion, ty::Region<'tcx>>)
+    ) -> (T, HybridSortedMap<ty::BoundRegion, ty::Region<'tcx>>)
     where
         T: TypeFoldable<'tcx>
     {

--- a/src/librustc/infer/region_constraints/mod.rs
+++ b/src/librustc/infer/region_constraints/mod.rs
@@ -18,13 +18,13 @@ use super::{MiscVariable, RegionVariableOrigin, SubregionOrigin};
 
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_data_structures::indexed_vec::IndexVec;
+use rustc_data_structures::sorted_map::HybridSortedMap;
 use rustc_data_structures::unify as ut;
 use ty::ReStatic;
 use ty::{self, Ty, TyCtxt};
 use ty::{BrFresh, ReLateBound, ReVar};
 use ty::{Region, RegionVid};
 
-use std::collections::BTreeMap;
 use std::{cmp, fmt, mem, u32};
 
 mod taint;
@@ -85,7 +85,7 @@ pub type VarInfos = IndexVec<RegionVid, RegionVariableInfo>;
 pub struct RegionConstraintData<'tcx> {
     /// Constraints of the form `A <= B`, where either `A` or `B` can
     /// be a region variable (or neither, as it happens).
-    pub constraints: BTreeMap<Constraint<'tcx>, SubregionOrigin<'tcx>>,
+    pub constraints: HybridSortedMap<Constraint<'tcx>, SubregionOrigin<'tcx>>,
 
     /// A "verify" is something that we need to verify after inference
     /// is done, but which does not directly affect inference in any

--- a/src/librustc/traits/structural_impls.rs
+++ b/src/librustc/traits/structural_impls.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 use chalk_engine;
+use rustc_data_structures::sorted_map::HybridSortedMap;
 use smallvec::SmallVec;
 use traits;
 use traits::project::Normalized;
@@ -18,7 +19,7 @@ use syntax::symbol::InternedString;
 
 use std::fmt;
 use std::rc::Rc;
-use std::collections::{BTreeSet, BTreeMap};
+use std::collections::BTreeSet;
 
 // structural impls for the structs in traits
 
@@ -274,7 +275,7 @@ struct BoundNamesCollector {
 
     // Sort by `BoundVar` index, so usually this should be equivalent to the order given
     // by the list of type parameters.
-    types: BTreeMap<u32, InternedString>,
+    types: HybridSortedMap<u32, InternedString>,
 
     binder_index: ty::DebruijnIndex,
 }
@@ -283,7 +284,7 @@ impl BoundNamesCollector {
     fn new() -> Self {
         BoundNamesCollector {
             regions: BTreeSet::new(),
-            types: BTreeMap::new(),
+            types: HybridSortedMap::new(),
             binder_index: ty::INNERMOST,
         }
     }

--- a/src/librustc/ty/fold.rs
+++ b/src/librustc/ty/fold.rs
@@ -41,9 +41,9 @@
 
 use mir::interpret::ConstValue;
 use hir::def_id::DefId;
+use rustc_data_structures::sorted_map::HybridSortedMap;
 use ty::{self, Binder, Ty, TyCtxt, TypeFlags};
 
-use std::collections::BTreeMap;
 use std::fmt;
 use util::nodemap::FxHashSet;
 
@@ -521,7 +521,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         self,
         value: &Binder<T>,
         fld_r: F
-    ) -> (T, BTreeMap<ty::BoundRegion, ty::Region<'tcx>>)
+    ) -> (T, HybridSortedMap<ty::BoundRegion, ty::Region<'tcx>>)
         where F: FnMut(ty::BoundRegion) -> ty::Region<'tcx>,
               T: TypeFoldable<'tcx>
     {
@@ -537,12 +537,12 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         value: &T,
         mut fld_r: F,
         mut fld_t: G
-    ) -> (T, BTreeMap<ty::BoundRegion, ty::Region<'tcx>>)
+    ) -> (T, HybridSortedMap<ty::BoundRegion, ty::Region<'tcx>>)
         where F: FnMut(ty::BoundRegion) -> ty::Region<'tcx>,
               G: FnMut(ty::BoundTy) -> ty::Ty<'tcx>,
               T: TypeFoldable<'tcx>
     {
-        let mut map = BTreeMap::new();
+        let mut map = HybridSortedMap::new();
 
         if !value.has_escaping_bound_vars() {
             (value.clone(), map)
@@ -565,7 +565,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         value: &Binder<T>,
         fld_r: F,
         fld_t: G
-    ) -> (T, BTreeMap<ty::BoundRegion, ty::Region<'tcx>>)
+    ) -> (T, HybridSortedMap<ty::BoundRegion, ty::Region<'tcx>>)
         where F: FnMut(ty::BoundRegion) -> ty::Region<'tcx>,
               G: FnMut(ty::BoundTy) -> ty::Ty<'tcx>,
               T: TypeFoldable<'tcx>

--- a/src/librustc_data_structures/sorted_map.rs
+++ b/src/librustc_data_structures/sorted_map.rs
@@ -8,9 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use stable_hasher::{HashStable, StableHasher, ToStableHashKey, StableHasherResult};
+
 use std::borrow::Borrow;
 use std::cmp::Ordering;
+use std::collections::btree_map::{self, BTreeMap};
 use std::convert::From;
+use std::iter::FromIterator;
 use std::mem;
 use std::ops::{RangeBounds, Bound, Index, IndexMut};
 
@@ -27,6 +31,9 @@ use std::ops::{RangeBounds, Bound, Index, IndexMut};
 pub struct SortedMap<K: Ord, V> {
     data: Vec<(K,V)>
 }
+
+unsafe impl<K: Ord + Sync, V: Sync> Sync for SortedMap<K, V> { }
+unsafe impl<K: Ord + Send, V: Send> Send for SortedMap<K, V> { }
 
 impl<K: Ord, V> SortedMap<K, V> {
 
@@ -135,6 +142,11 @@ impl<K: Ord, V> SortedMap<K, V> {
     #[inline]
     pub fn len(&self) -> usize {
         self.data.len()
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 
     #[inline]
@@ -247,6 +259,19 @@ impl<K: Ord, V> SortedMap<K, V> {
 
         (start, end)
     }
+
+    fn entry(&mut self, key: K) -> Entry<K, V> {
+        match self.lookup_index_for(&key) {
+            Ok(index) => {
+                unsafe {
+                    Entry::Occupied(self.data.get_unchecked_mut(index))
+                }
+            }
+            Err(index) => {
+                Entry::Vacant(key, index, self)
+            }
+        }
+    }
 }
 
 impl<K: Ord, V> IntoIterator for SortedMap<K, V> {
@@ -282,6 +307,380 @@ impl<K: Ord, V, I: Iterator<Item=(K, V)>> From<I> for SortedMap<K, V> {
         SortedMap {
             data
         }
+    }
+}
+
+// FIXME: duplicates the code of impl From<Iterator> for SortedMap<K, V>; it's probably a good
+// idea to remove that piece of code and adjust places where it's used.
+impl<K: Ord, V> FromIterator<(K, V)> for SortedMap<K, V> {
+    fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> Self {
+        let mut data: Vec<(K, V)> = iter.into_iter().collect();
+        data.sort_unstable_by(|&(ref k1, _), &(ref k2, _)| k1.cmp(k2));
+        data.dedup_by(|&mut (ref k1, _), &mut (ref k2, _)| {
+            k1.cmp(k2) == Ordering::Equal
+        });
+        SortedMap {
+            data
+        }
+    }
+}
+
+pub enum Entry<'a, K: Ord + 'a, V: 'a> {
+    // FIXME: change to a mutable reference to a newly created empty spot? This would probably
+    // require some unsafe pointer magic, though.
+    Vacant(K, usize, &'a mut SortedMap<K, V>),
+    Occupied(&'a mut (K, V))
+}
+
+const SMALL_MAX: usize = 50;
+
+/// A sorted map which uses a vector-backed storage in case of a small number (up to a maximum of
+/// SMALL_MAX) of elements in order to take advantage of performance benefits it provides over a
+/// BTreeMap in that scale.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, RustcEncodable,
+         RustcDecodable)]
+pub enum HybridSortedMap<K: Ord, V> {
+    Small(SortedMap<K, V>),
+    Big(BTreeMap<K, V>)
+}
+
+unsafe impl<K: Ord + Sync, V: Sync> Sync for HybridSortedMap<K, V> { }
+unsafe impl<K: Ord + Send, V: Send> Send for HybridSortedMap<K, V> { }
+
+impl<K: Ord, V> Default for HybridSortedMap<K, V> {
+    fn default() -> Self {
+        HybridSortedMap::Small(SortedMap::new())
+    }
+}
+
+impl<K: Ord, V> HybridSortedMap<K, V> {
+    pub fn new() -> HybridSortedMap<K, V> {
+        HybridSortedMap::Small(SortedMap::new())
+    }
+
+    pub fn from_presorted_elements(elements: Vec<(K, V)>) -> HybridSortedMap<K, V> {
+        if elements.len() <= SMALL_MAX {
+            HybridSortedMap::Small(SortedMap::from_presorted_elements(elements))
+        } else {
+            HybridSortedMap::Big(elements.into_iter().collect())
+        }
+    }
+
+    pub fn insert(&mut self, key: K, value: V) -> Option<V> {
+        match self {
+            HybridSortedMap::Small(small) => {
+                if small.len() < SMALL_MAX {
+                    small.insert(key, value)
+                } else if let Some(ref mut v) = small.get_mut(&key) {
+                    // If the key is already there, the value gets replaced, so
+                    // the length is not a concern.
+                    Some(mem::replace(v, value)) // return the previous value
+                } else {
+                    // FIXME: remove this replace
+                    let small = mem::replace(small, SortedMap::new());
+                    let big = small.into_iter().chain(Some((key, value))).collect();
+                    *self = HybridSortedMap::Big(big);
+                    None // the key was not present, we already checked that earlier
+                }
+            },
+            HybridSortedMap::Big(big) => {
+                big.insert(key, value)
+            }
+        }
+    }
+
+    pub fn remove(&mut self, key: &K) -> Option<V> {
+        match self {
+            HybridSortedMap::Small(small) => small.remove(key),
+            HybridSortedMap::Big(big) => big.remove(key)
+        }
+    }
+
+    pub fn get(&self, key: &K) -> Option<&V> {
+        match self {
+            HybridSortedMap::Small(small) => small.get(key),
+            HybridSortedMap::Big(big) => big.get(key)
+        }
+    }
+
+    pub fn get_mut(&mut self, key: &K) -> Option<&mut V> {
+        match self {
+            HybridSortedMap::Small(small) => small.get_mut(key),
+            HybridSortedMap::Big(big) => big.get_mut(key)
+        }
+    }
+
+    pub fn clear(&mut self) {
+        match self {
+            HybridSortedMap::Small(small) => small.clear(),
+            HybridSortedMap::Big(big) => big.clear()
+        }
+    }
+
+    pub fn iter(&self) -> HybridSortedMapIter<K, V> {
+        match self {
+            HybridSortedMap::Small(small) => HybridSortedMapIter::Small(small.iter()),
+            HybridSortedMap::Big(big) => HybridSortedMapIter::Big(big.iter())
+        }
+    }
+
+    pub fn into_iter(self) -> HybridSortedMapIntoIter<K, V> {
+        match self {
+            HybridSortedMap::Small(small) => HybridSortedMapIntoIter::Small(small.into_iter()),
+            HybridSortedMap::Big(big) => HybridSortedMapIntoIter::Big(big.into_iter())
+        }
+    }
+
+    pub fn keys(&self) -> HybridSortedMapKeys<K, V> {
+        match self {
+            HybridSortedMap::Small(small) => HybridSortedMapKeys::Small(small.iter()),
+            HybridSortedMap::Big(big) => HybridSortedMapKeys::Big(big.keys())
+        }
+    }
+
+    pub fn values(&self) -> HybridSortedMapValues<K, V> {
+        match self {
+            HybridSortedMap::Small(small) => HybridSortedMapValues::Small(small.iter()),
+            HybridSortedMap::Big(big) => HybridSortedMapValues::Big(big.values())
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        match self {
+            HybridSortedMap::Small(small) => small.len(),
+            HybridSortedMap::Big(big) => big.len()
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        match self {
+            HybridSortedMap::Small(small) => small.is_empty(),
+            HybridSortedMap::Big(big) => big.is_empty()
+        }
+    }
+
+    pub fn contains_key<Q>(&self, key: &Q) -> bool
+        where K: Borrow<Q>,
+              Q: Ord + Borrow<K> + ?Sized
+    {
+        match self {
+            HybridSortedMap::Small(small) => {
+                let k: &K = key.borrow();
+                small.get(k).is_some()
+            },
+            HybridSortedMap::Big(big) => {
+                big.get(key).is_some()
+            }
+        }
+    }
+
+    pub fn entry(&mut self, key: K) -> HybridSortedMapEntry<K, V> {
+        match self {
+            HybridSortedMap::Small(small) => HybridSortedMapEntry::Small(small.entry(key)),
+            HybridSortedMap::Big(big) => HybridSortedMapEntry::Big(big.entry(key))
+        }
+    }
+}
+
+pub enum HybridSortedMapIter<'a, K: 'a, V: 'a> {
+    Small(::std::slice::Iter<'a, (K, V)>),
+    Big(::std::collections::btree_map::Iter<'a, K, V>)
+}
+
+impl<'a, K: 'a, V: 'a> Iterator for HybridSortedMapIter<'a, K, V> {
+    type Item = (&'a K, &'a V);
+
+    fn next(&mut self) -> Option<((&'a K, &'a V))> {
+        match self {
+            HybridSortedMapIter::Small(ref mut small) => {
+                if let Some((k, v)) = small.next() {
+                    Some((&k, &v))
+                } else {
+                    None
+                }
+            },
+            HybridSortedMapIter::Big(ref mut big) => big.next()
+        }
+    }
+}
+
+pub enum HybridSortedMapIntoIter<K, V> {
+    Small(::std::vec::IntoIter<(K, V)>),
+    Big(::std::collections::btree_map::IntoIter<K, V>)
+}
+
+impl<K, V> Iterator for HybridSortedMapIntoIter<K, V> {
+    type Item = (K, V);
+
+    fn next(&mut self) -> Option<(K, V)> {
+        match self {
+            HybridSortedMapIntoIter::Small(ref mut small) => small.next(),
+            HybridSortedMapIntoIter::Big(ref mut big) => big.next()
+        }
+    }
+}
+
+impl<K: Ord, V> IntoIterator for HybridSortedMap<K, V> {
+    type Item = (K, V);
+    type IntoIter = HybridSortedMapIntoIter<K, V>;
+
+    fn into_iter(self) -> HybridSortedMapIntoIter<K, V> {
+        self.into_iter()
+    }
+}
+
+impl<'a, K: Ord + 'a, V: 'a> IntoIterator for &'a HybridSortedMap<K, V> {
+    type Item = (&'a K, &'a V);
+    type IntoIter = HybridSortedMapIter<'a, K, V>;
+
+    fn into_iter(self) -> HybridSortedMapIter<'a, K, V> {
+        self.iter()
+    }
+}
+
+impl<K: Ord, V> FromIterator<(K, V)> for HybridSortedMap<K, V> {
+    fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> HybridSortedMap<K, V> {
+        let iter = iter.into_iter();
+        let (low, _) = iter.size_hint();
+
+        if low > 0 {
+            if low <= SMALL_MAX {
+                HybridSortedMap::Small(SortedMap::from_iter(iter))
+            } else {
+                HybridSortedMap::Big(BTreeMap::from_iter(iter))
+            }
+        } else {
+            let mut map = HybridSortedMap::new();
+            for (k, v) in iter.into_iter() {
+                map.insert(k, v);
+            }
+            map
+        }
+    }
+}
+
+pub enum HybridSortedMapKeys<'a, K: 'a, V: 'a> {
+    Small(::std::slice::Iter<'a, (K, V)>),
+    Big(::std::collections::btree_map::Keys<'a, K, V>)
+}
+
+impl<'a, K: 'a, V: 'a> Iterator for HybridSortedMapKeys<'a, K, V> {
+    type Item = &'a K;
+
+    fn next(&mut self) -> Option<(&'a K)> {
+        match self {
+            HybridSortedMapKeys::Small(ref mut small) => {
+                if let Some((k, _)) = small.next() {
+                    Some(&k)
+                } else {
+                    None
+                }
+            },
+            HybridSortedMapKeys::Big(ref mut big) => big.next()
+        }
+    }
+}
+
+pub enum HybridSortedMapValues<'a, K: 'a, V: 'a> {
+    Small(::std::slice::Iter<'a, (K, V)>),
+    Big(::std::collections::btree_map::Values<'a, K, V>)
+}
+
+impl<'a, K: 'a, V: 'a> Iterator for HybridSortedMapValues<'a, K, V> {
+    type Item = &'a V;
+
+    fn next(&mut self) -> Option<(&'a V)> {
+        match self {
+            HybridSortedMapValues::Small(ref mut small) => {
+                if let Some((_, v)) = small.next() {
+                    Some(&v)
+                } else {
+                    None
+                }
+            },
+            HybridSortedMapValues::Big(ref mut big) => big.next()
+        }
+    }
+}
+
+impl<'a, K, Q, V> Index<&'a Q> for HybridSortedMap<K, V>
+    where K: Ord + Borrow<Q>, // FIXME: SortedMap restriction
+          Q: Ord + Borrow<K> + ?Sized
+{
+    type Output = V;
+
+    fn index(&self, key: &Q) -> &V {
+        match self {
+            HybridSortedMap::Small(small) => {
+                let k: &K = key.borrow();
+                small.get(k).expect("no entry found for key")
+            },
+            HybridSortedMap::Big(big) => {
+                big.get(key).expect("no entry found for key")
+            }
+        }
+    }
+}
+
+pub enum HybridSortedMapEntry<'a, K: Ord + 'a, V: 'a> {
+    Small(Entry<'a, K, V>),
+    Big(btree_map::Entry<'a, K, V>)
+}
+
+impl<'a, K: Ord + 'a, V: Default + 'a> HybridSortedMapEntry<'a, K, V> {
+    pub fn or_default(self) -> &'a mut V {
+        match self {
+            HybridSortedMapEntry::Small(entry) => {
+                match entry {
+                    Entry::Occupied((_, v)) => {
+                        v
+                    },
+                    Entry::Vacant(k, index, small) => {
+                        small.data.insert(index, (k, Default::default()));
+                        &mut small.data[index].1
+                    }
+                }
+            },
+            HybridSortedMapEntry::Big(entry) => {
+                entry.or_default()
+            }
+        }
+    }
+}
+
+impl<'a, K: Ord + 'a, V: 'a> HybridSortedMapEntry<'a, K, V> {
+    pub fn or_insert_with<F: FnOnce() -> V>(self, default: F) -> &'a mut V {
+        match self {
+            HybridSortedMapEntry::Small(entry) => {
+                match entry {
+                    Entry::Occupied((_, v)) => {
+                        v
+                    },
+                    Entry::Vacant(k, index, small) => {
+                        small.data.insert(index, (k, default()));
+                        &mut small.data[index].1
+                    }
+                }
+            },
+            HybridSortedMapEntry::Big(entry) => {
+                entry.or_insert_with(default)
+            }
+        }
+    }
+}
+
+impl<K, V, HCX> HashStable<HCX> for HybridSortedMap<K, V>
+    where K: Ord + ToStableHashKey<HCX>,
+          V: HashStable<HCX>,
+{
+    fn hash_stable<W: StableHasherResult>(&self,
+                                          hcx: &mut HCX,
+                                          hasher: &mut StableHasher<W>) {
+        let mut entries: Vec<_> = self.iter()
+                                      .map(|(k, v)| (k.to_stable_hash_key(hcx), v))
+                                      .collect();
+        entries.sort_unstable_by(|&(ref sk1, _), &(ref sk2, _)| sk1.cmp(sk2));
+        entries.hash_stable(hcx, hasher);
     }
 }
 

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -8,13 +8,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 use std::fmt;
 use std::path::PathBuf;
 
 use errors;
 use errors::emitter::ColorConfig;
 use getopts;
+use rustc_data_structures::sorted_map::HybridSortedMap;
 use rustc::lint::Level;
 use rustc::session::early_error;
 use rustc::session::config::{CodegenOptions, DebuggingOptions, ErrorOutputType, Externs};
@@ -166,7 +167,7 @@ pub struct RenderOptions {
     /// If present, CSS file that contains rules to add to the default CSS.
     pub extension_css: Option<PathBuf>,
     /// A map of crate names to the URL to use instead of querying the crate's `html_root_url`.
-    pub extern_html_root_urls: BTreeMap<String, String>,
+    pub extern_html_root_urls: HybridSortedMap<String, String>,
     /// If present, suffix added to CSS/JavaScript files when referencing them in generated pages.
     pub resource_suffix: String,
     /// Whether to run the static CSS/JavaScript through a minifier when outputting them. `true` by
@@ -528,8 +529,8 @@ fn check_deprecated_options(matches: &getopts::Matches, diag: &errors::Handler) 
 /// describing the issue.
 fn parse_extern_html_roots(
     matches: &getopts::Matches,
-) -> Result<BTreeMap<String, String>, &'static str> {
-    let mut externs = BTreeMap::new();
+) -> Result<HybridSortedMap<String, String>, &'static str> {
+    let mut externs = HybridSortedMap::new();
     for arg in &matches.opt_strs("extern-html-root-url") {
         let mut parts = arg.splitn(2, '=');
         let name = parts.next().ok_or("--extern-html-root-url must not be empty")?;
@@ -545,7 +546,7 @@ fn parse_extern_html_roots(
 /// error message.
 // FIXME(eddyb) This shouldn't be duplicated with `rustc::session`.
 fn parse_externs(matches: &getopts::Matches) -> Result<Externs, String> {
-    let mut externs: BTreeMap<_, BTreeSet<_>> = BTreeMap::new();
+    let mut externs: HybridSortedMap<_, BTreeSet<_>> = HybridSortedMap::new();
     for arg in &matches.opt_strs("extern") {
         let mut parts = arg.splitn(2, '=');
         let name = parts.next().ok_or("--extern value must not be empty".to_string())?;


### PR DESCRIPTION
I was wondering if the performance advantages of `SortedMap` for small maps could be utilized by introducing a hybrid data structure like the one in `bit_set`. A `HybridSortedMap` is:
```
pub enum HybridSortedMap<K: Ord, V> {
    Small(SortedMap<K, V>), // for maps with a maximum of 50 pairs
    Big(BTreeMap<K, V>) // for bigger maps
}
```


It is an experiment, but at a stage advanced enough to replace all `BTreeMap`s in `librustc` and indicate if this approach could possibly improve the performance of sorted maps used in rustc. If this approach shows promise I could also create a `HybridSortedSet` with the same characteristics.

If this makes sense, I would like to run it by perf.