### PR TITLE
Replace data.clone() by Arc::clone(&data) in mutex doc.

### DIFF
--- a/src/libstd/sync/mutex.rs
+++ b/src/libstd/sync/mutex.rs
@@ -69,7 +69,7 @@ use sys_common::poison::{self, TryLockError, TryLockResult, LockResult};
 ///
 /// let (tx, rx) = channel();
 /// for _ in 0..N {
-///     let (data, tx) = (data.clone(), tx.clone());
+///     let (data, tx) = (Arc::clone(&data), tx.clone());
 ///     thread::spawn(move || {
 ///         // The shared state can only be accessed once the lock is held.
 ///         // Our non-atomic increment is safe because we're the only thread


### PR DESCRIPTION
Arc::clone(&from) is considered as more idiomatic because it conveys more explicitly the meaning of the code.
Since this clone is visible in the official documentation, I thought it could be better to use the more idiomatic version.