### PR TITLE
avoid shared ref in UnsafeCell::get

### DIFF
--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -1509,6 +1509,8 @@ impl<T: ?Sized> UnsafeCell<T> {
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub const fn get(&self) -> *mut T {
+        // We can just cast the pointer from `UnsafeCell<T>` to `T` because of
+        // #[repr(transparent)]
         self as *const UnsafeCell<T> as *const T as *mut T
     }
 }

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -1509,7 +1509,7 @@ impl<T: ?Sized> UnsafeCell<T> {
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub const fn get(&self) -> *mut T {
-        &self.value as *const T as *mut T
+        self as *const UnsafeCell<T> as *const T as *mut T
     }
 }
 


### PR DESCRIPTION
Avoid taking a shared reference in `UnsafeCell::get`. This *should* be taking a raw reference (see https://github.com/rust-lang/rfcs/pull/2582), but that operation is not currently available, so I propose we exploit `repr(transparent)` instead and cast the pointer around.

This is required to make `UnsafeCell::get` pass the [stacked borrows implementation](https://www.ralfj.de/blog/2018/11/16/stacked-borrows-implementation.html) in miri (currently, `UnsafeCell::get` is on a whitelist, but that is of course not very satisfying). It shouldn't affect normal execution/codegen. Would be great if we could get this landed and shrink miri's whitelist!

Cc @nikomatsakis 