### PR TITLE
rustdoc: rename the type in an impl to match its containing page

### DIFF
--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -25,6 +25,7 @@
 #![feature(crate_visibility_modifier)]
 #![feature(const_fn)]
 #![feature(drain_filter)]
+#![feature(inner_deref)]
 
 #![recursion_limit="256"]
 

--- a/src/test/rustdoc/inline_local/rename.rs
+++ b/src/test/rustdoc/inline_local/rename.rs
@@ -1,0 +1,24 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+mod inner {
+    pub struct SomeStruct;
+
+    impl SomeStruct {
+        pub fn new() -> SomeStruct { SomeStruct }
+    }
+}
+
+// @has rename/index.html
+// @has - '//a/@href' 'struct.MyStruct.html'
+// @has rename/struct.MyStruct.html
+// @has - '//code' 'impl MyStruct'
+// @!has - '//code' 'impl SomeStruct'
+pub use inner::SomeStruct as MyStruct;


### PR DESCRIPTION
Currently, if you `pub use Something as SomethingElse`, and `Something` has some `impl` blocks on it, they won't be renamed to match `SomethingElse`, creating confusion if the original type name is not actually public, or expected to be the public API of that type. This leads to situations where the file name, page title, and item definition section will use the name from the re-export, and all the impls will use the original name. This PR changes how we render impls if they come from item pages, so that their name matches their containing item instead of the original declaration.