### PR TITLE
Increase `Duration` approximate equal threshold to 1us

### DIFF
--- a/src/libstd/time.rs
+++ b/src/libstd/time.rs
@@ -481,7 +481,7 @@ mod tests {
             let (a, b) = ($a, $b);
             if a != b {
                 let (a, b) = if a > b {(a, b)} else {(b, a)};
-                assert!(a - Duration::new(0, 100) <= b,
+                assert!(a - Duration::new(0, 1000) <= b,
                         "{:?} is not almost equal to {:?}", a, b);
             }
         })


### PR DESCRIPTION
Previously this threshold when testing was 100ns, but the Windows
documentation states:

> which is a high resolution (<1us) time stamp

which presumably means that we could have up to 1us resolution, which
means that 100ns doesn't capture "equivalent" time intervals due to
various bits of rounding here and there.

It's hoped that this..

Closes #56034