### PR TITLE
Add SGX target to rustc

### DIFF
--- a/src/librustc_codegen_ssa/back/linker.rs
+++ b/src/librustc_codegen_ssa/back/linker.rs
@@ -1050,6 +1050,10 @@ impl<'a> Linker for WasmLd<'a> {
 }
 
 fn exported_symbols(tcx: TyCtxt, crate_type: CrateType) -> Vec<String> {
+    if let Some(ref exports) = tcx.sess.target.target.options.override_export_symbols {
+        return exports.clone()
+    }
+
     let mut symbols = Vec::new();
 
     let export_threshold = symbol_export::crates_export_threshold(&[crate_type]);

--- a/src/librustc_target/spec/mod.rs
+++ b/src/librustc_target/spec/mod.rs
@@ -683,6 +683,10 @@ pub struct TargetOptions {
     /// target features. This is `true` by default, and `false` for targets like
     /// wasm32 where the whole program either has simd or not.
     pub simd_types_indirect: bool,
+
+    /// If set, have the linker export exactly these symbols, instead of using
+    /// the usual logic to figure this out from the crate itself.
+    pub override_export_symbols: Option<Vec<String>>
 }
 
 impl Default for TargetOptions {
@@ -763,6 +767,7 @@ impl Default for TargetOptions {
             emit_debug_gdb_scripts: true,
             requires_uwtable: false,
             simd_types_indirect: true,
+            override_export_symbols: None,
         }
     }
 }
@@ -895,6 +900,14 @@ impl Target {
                 obj.find(&name[..]).map(|o| o.as_array()
                     .map(|v| base.options.$key_name = v.iter()
                         .map(|a| a.as_string().unwrap().to_string()).collect()
+                        )
+                    );
+            } );
+            ($key_name:ident, opt_list) => ( {
+                let name = (stringify!($key_name)).replace("_", "-");
+                obj.find(&name[..]).map(|o| o.as_array()
+                    .map(|v| base.options.$key_name = Some(v.iter()
+                        .map(|a| a.as_string().unwrap().to_string()).collect())
                         )
                     );
             } );
@@ -1044,6 +1057,7 @@ impl Target {
         key!(emit_debug_gdb_scripts, bool);
         key!(requires_uwtable, bool);
         key!(simd_types_indirect, bool);
+        key!(override_export_symbols, opt_list);
 
         if let Some(array) = obj.find("abi-blacklist").and_then(Json::as_array) {
             for name in array.iter().filter_map(|abi| abi.as_string()) {
@@ -1253,6 +1267,7 @@ impl ToJson for Target {
         target_option_val!(emit_debug_gdb_scripts);
         target_option_val!(requires_uwtable);
         target_option_val!(simd_types_indirect);
+        target_option_val!(override_export_symbols);
 
         if default.abi_blacklist != self.options.abi_blacklist {
             d.insert("abi-blacklist".to_string(), self.options.abi_blacklist.iter()

--- a/src/librustc_target/spec/mod.rs
+++ b/src/librustc_target/spec/mod.rs
@@ -412,6 +412,8 @@ supported_targets! {
     ("riscv32imac-unknown-none-elf", riscv32imac_unknown_none_elf),
 
     ("aarch64-unknown-none", aarch64_unknown_none),
+
+    ("x86_64-fortanix-unknown-sgx", x86_64_fortanix_unknown_sgx),
 }
 
 /// Everything `rustc` knows about how to compile for a specific target.

--- a/src/librustc_target/spec/x86_64_fortanix_unknown_sgx.rs
+++ b/src/librustc_target/spec/x86_64_fortanix_unknown_sgx.rs
@@ -1,0 +1,72 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::iter;
+
+use super::{LinkerFlavor, Target, TargetOptions, PanicStrategy};
+
+pub fn target() -> Result<Target, String> {
+    const PRE_LINK_ARGS: &[&str] = &[
+        "-Wl,--as-needed",
+        "-Wl,-z,noexecstack",
+        "-m64",
+         "-fuse-ld=gold",
+         "-nostdlib",
+         "-shared",
+         "-Wl,-e,sgx_entry",
+         "-Wl,-Bstatic",
+         "-Wl,--gc-sections",
+         "-Wl,-z,text",
+         "-Wl,-z,norelro",
+         "-Wl,--rosegment",
+         "-Wl,--no-undefined",
+         "-Wl,--error-unresolved-symbols",
+         "-Wl,--no-undefined-version",
+         "-Wl,-Bsymbolic",
+         "-Wl,--export-dynamic",
+    ];
+    const EXPORT_SYMBOLS: &[&str] = &[
+        "sgx_entry",
+        "HEAP_BASE",
+        "HEAP_SIZE",
+        "RELA",
+        "RELACOUNT",
+        "ENCLAVE_SIZE",
+        "CFGDATA_BASE",
+        "DEBUG",
+    ];
+    let opts = TargetOptions {
+        dynamic_linking: false,
+        executables: true,
+        linker_is_gnu: true,
+        max_atomic_width: Some(64),
+        panic_strategy: PanicStrategy::Abort,
+        cpu: "x86-64".into(),
+        position_independent_executables: true,
+        pre_link_args: iter::once(
+                (LinkerFlavor::Gcc, PRE_LINK_ARGS.iter().cloned().map(String::from).collect())
+        ).collect(),
+        override_export_symbols: Some(EXPORT_SYMBOLS.iter().cloned().map(String::from).collect()),
+        ..Default::default()
+    };
+    Ok(Target {
+        llvm_target: "x86_64-unknown-linux-gnu".into(),
+        target_endian: "little".into(),
+        target_pointer_width: "64".into(),
+        target_c_int_width: "32".into(),
+        target_os: "unknown".into(),
+        target_env: "sgx".into(),
+        target_vendor: "fortanix".into(),
+        data_layout: "e-m:e-i64:64-f80:128-n8:16:32:64-S128".into(),
+        arch: "x86_64".into(),
+        linker_flavor: LinkerFlavor::Gcc,
+        options: opts,
+    })
+}


### PR DESCRIPTION
This adds the `x86_64-fortanix-unknown-sgx` target specification to the Rust compiler. See #56066 for more details about this target.