### PR TITLE
Encode a custom "producers" section in wasm files

### DIFF
--- a/src/librustc_codegen_llvm/back/link.rs
+++ b/src/librustc_codegen_llvm/back/link.rs
@@ -692,6 +692,11 @@ fn link_natively(sess: &Session,
 
     if sess.opts.target_triple.triple() == "wasm32-unknown-unknown" {
         wasm::rewrite_imports(&out_filename, &codegen_results.crate_info.wasm_imports);
+        wasm::add_producer_section(
+            &out_filename,
+            &sess.edition().to_string(),
+            option_env!("CFG_VERSION").unwrap_or("unknown"),
+        );
     }
 }
 


### PR DESCRIPTION
This commit implements WebAssembly/tool-conventions#65 for wasm files
produced by the Rust compiler. This adds a bit of metadata to wasm
modules to indicate that the file's language includes Rust and the
file's "processed-by" tools includes rustc.

The thinking with this section is to eventually have telemetry in
browsers tracking all this.