### PR TITLE
Reduce the amount of bold text at doc.rlo

### DIFF
--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -21,6 +21,9 @@ nav {
 #search-but:hover, #search-input:focus {
     border-color: #55a9ff;
 }
+h2 {
+    font-size: 18px;
+}
 </style>
 
 Welcome to an overview of the documentation provided by the Rust project.


### PR DESCRIPTION
Currently, all of the text is either huge or small. IMHO this is hard to read, so I propose that we make the second-level headings smaller, without making them any less prominent.

# Before:

![image](https://user-images.githubusercontent.com/8827840/48737315-50447e80-ec13-11e8-8243-6211dbba1aa1.png)


# After:

![image](https://user-images.githubusercontent.com/8827840/48737258-32771980-ec13-11e8-814e-e7851954c05a.png)
