### PR TITLE
Wrap const_eval_stack_frame_limit in a LockCell

### DIFF
--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -107,7 +107,7 @@ pub struct Session {
     pub type_length_limit: Once<usize>,
 
     /// The maximum number of stackframes allowed in const eval
-    pub const_eval_stack_frame_limit: OneThread<Cell<usize>>,
+    pub const_eval_stack_frame_limit: LockCell<usize>,
 
     /// The metadata::creader module may inject an allocator/panic_runtime
     /// dependency if it didn't already find one, and this tracks what was
@@ -1159,7 +1159,7 @@ pub fn build_session_(
         features: Once::new(),
         recursion_limit: Once::new(),
         type_length_limit: Once::new(),
-        const_eval_stack_frame_limit: OneThread::new(Cell::new(100)),
+        const_eval_stack_frame_limit: LockCell::new(100),
         next_node_id: OneThread::new(Cell::new(NodeId::from_u32(1))),
         allocator_kind: Once::new(),
         injected_panic_runtime: Once::new(),

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -107,7 +107,7 @@ pub struct Session {
     pub type_length_limit: Once<usize>,
 
     /// The maximum number of stackframes allowed in const eval
-    pub const_eval_stack_frame_limit: usize,
+    pub const_eval_stack_frame_limit: OneThread<Cell<usize>>,
 
     /// The metadata::creader module may inject an allocator/panic_runtime
     /// dependency if it didn't already find one, and this tracks what was
@@ -1159,7 +1159,7 @@ pub fn build_session_(
         features: Once::new(),
         recursion_limit: Once::new(),
         type_length_limit: Once::new(),
-        const_eval_stack_frame_limit: 100,
+        const_eval_stack_frame_limit: OneThread::new(Cell::new(100)),
         next_node_id: OneThread::new(Cell::new(NodeId::from_u32(1))),
         allocator_kind: Once::new(),
         injected_panic_runtime: Once::new(),

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -489,7 +489,7 @@ impl<'a, 'mir, 'tcx: 'mir, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tc
             debug!("ENTERING({}) {}", self.cur_frame(), self.frame().instance);
         }
 
-        if self.stack.len() > self.tcx.sess.const_eval_stack_frame_limit {
+        if self.stack.len() > self.tcx.sess.const_eval_stack_frame_limit.get() {
             err!(StackFrameLimitReached)
         } else {
             Ok(())


### PR DESCRIPTION
This allows Miri to set const_eval_stack_frame_limit as needed,
while still keeping Session thread-safe