### PR TITLE
resolve: Make "empty import canaries" invisible from other crates

### DIFF
--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -1164,7 +1164,10 @@ impl<'a, 'b:'a, 'c: 'b> ImportResolver<'a, 'b, 'c> {
                 None => continue,
             };
 
-            if binding.is_import() || binding.is_macro_def() {
+            // Filter away "empty import canaries".
+            let is_non_canary_import =
+                binding.is_import() && binding.vis != ty::Visibility::Invisible;
+            if is_non_canary_import || binding.is_macro_def() {
                 let def = binding.def();
                 if def != Def::Err {
                     if let Some(def_id) = def.opt_def_id() {

--- a/src/test/ui/imports/auxiliary/issue-55811.rs
+++ b/src/test/ui/imports/auxiliary/issue-55811.rs
@@ -1,0 +1,5 @@
+mod m {}
+
+// These two imports should not conflict when this crate is loaded from some other crate.
+use m::{};
+use m::{};

--- a/src/test/ui/imports/issue-55811.rs
+++ b/src/test/ui/imports/issue-55811.rs
@@ -1,0 +1,6 @@
+// compile-pass
+// aux-build:issue-55811.rs
+
+extern crate issue_55811;
+
+fn main() {}


### PR DESCRIPTION
Empty imports `use prefix::{};` are desugared into `use prefix::{self as _};` to make sure the prefix is checked for privacy/stability/etc.
This caused issues in cross-crate scenarios because gensyms are lost in crate metadata (the `_` is a gensym).

Fixes https://github.com/rust-lang/rust/issues/55811