### PR TITLE
Fix small doc mistake on std::io::read::read_to_end

### DIFF
--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -431,7 +431,7 @@ fn read_to_end_with_reservation<R: Read + ?Sized>(r: &mut R,
 ///     // read up to 10 bytes
 ///     f.read(&mut buffer)?;
 ///
-///     let mut buffer = vec![0; 10];
+///     let mut buffer = Vec::new();
 ///     // read the whole file
 ///     f.read_to_end(&mut buffer)?;
 ///


### PR DESCRIPTION
The std::io::read main documentation can lead to error because the buffer is prefilled with 10 zeros that will pad the response.
Using an empty vector is better.

The `read_to_end` documentation is already correct though.

This is my first rust PR, don't hesitate to tell me if I did something wrong.