### PR TITLE
Rename `MaybeUninit` to `MaybeUninitialized`

### DIFF
--- a/src/liballoc/collections/btree/node.rs
+++ b/src/liballoc/collections/btree/node.rs
@@ -42,7 +42,7 @@
 //   This implies that even an empty internal node has at least one edge.
 
 use core::marker::PhantomData;
-use core::mem::{self, MaybeUninit};
+use core::mem::{self, MaybeUninitialized};
 use core::ptr::{self, Unique, NonNull};
 use core::slice;
 
@@ -70,7 +70,7 @@ struct LeafNode<K, V> {
     /// This node's index into the parent node's `edges` array.
     /// `*node.parent.edges[node.parent_idx]` should be the same thing as `node`.
     /// This is only guaranteed to be initialized when `parent` is non-null.
-    parent_idx: MaybeUninit<u16>,
+    parent_idx: MaybeUninitialized<u16>,
 
     /// The number of keys and values this node stores.
     ///
@@ -80,8 +80,8 @@ struct LeafNode<K, V> {
 
     /// The arrays storing the actual data of the node. Only the first `len` elements of each
     /// array are initialized and valid.
-    keys: MaybeUninit<[K; CAPACITY]>,
-    vals: MaybeUninit<[V; CAPACITY]>,
+    keys: MaybeUninitialized<[K; CAPACITY]>,
+    vals: MaybeUninitialized<[V; CAPACITY]>,
 }
 
 impl<K, V> LeafNode<K, V> {
@@ -91,10 +91,10 @@ impl<K, V> LeafNode<K, V> {
         LeafNode {
             // As a general policy, we leave fields uninitialized if they can be, as this should
             // be both slightly faster and easier to track in Valgrind.
-            keys: MaybeUninit::uninitialized(),
-            vals: MaybeUninit::uninitialized(),
+            keys: MaybeUninitialized::uninitialized(),
+            vals: MaybeUninitialized::uninitialized(),
             parent: ptr::null(),
-            parent_idx: MaybeUninit::uninitialized(),
+            parent_idx: MaybeUninitialized::uninitialized(),
             len: 0
         }
     }
@@ -112,10 +112,10 @@ unsafe impl Sync for LeafNode<(), ()> {}
 // ever take a pointer past the first key.
 static EMPTY_ROOT_NODE: LeafNode<(), ()> = LeafNode {
     parent: ptr::null(),
-    parent_idx: MaybeUninit::uninitialized(),
+    parent_idx: MaybeUninitialized::uninitialized(),
     len: 0,
-    keys: MaybeUninit::uninitialized(),
-    vals: MaybeUninit::uninitialized(),
+    keys: MaybeUninitialized::uninitialized(),
+    vals: MaybeUninitialized::uninitialized(),
 };
 
 /// The underlying representation of internal nodes. As with `LeafNode`s, these should be hidden

--- a/src/libcore/fmt/float.rs
+++ b/src/libcore/fmt/float.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use fmt::{Formatter, Result, LowerExp, UpperExp, Display, Debug};
-use mem::MaybeUninit;
+use mem::MaybeUninitialized;
 use num::flt2dec;
 
 // Don't inline this so callers don't use the stack space this function
@@ -20,10 +20,10 @@ fn float_to_decimal_common_exact<T>(fmt: &mut Formatter, num: &T,
     where T: flt2dec::DecodableFloat
 {
     unsafe {
-        let mut buf = MaybeUninit::<[u8; 1024]>::uninitialized(); // enough for f32 and f64
-        let mut parts = MaybeUninit::<[flt2dec::Part; 4]>::uninitialized();
+        let mut buf = MaybeUninitialized::<[u8; 1024]>::uninitialized(); // enough for f32 and f64
+        let mut parts = MaybeUninitialized::<[flt2dec::Part; 4]>::uninitialized();
         // FIXME(#53491): Technically, this is calling `get_mut` on an uninitialized
-        // `MaybeUninit` (here and elsewhere in this file).  Revisit this once
+        // `MaybeUninitialized` (here and elsewhere in this file).  Revisit this once
         // we decided whether that is valid or not.
         let formatted = flt2dec::to_exact_fixed_str(flt2dec::strategy::grisu::format_exact,
                                                     *num, sign, precision,
@@ -41,8 +41,8 @@ fn float_to_decimal_common_shortest<T>(fmt: &mut Formatter, num: &T,
 {
     unsafe {
         // enough for f32 and f64
-        let mut buf = MaybeUninit::<[u8; flt2dec::MAX_SIG_DIGITS]>::uninitialized();
-        let mut parts = MaybeUninit::<[flt2dec::Part; 4]>::uninitialized();
+        let mut buf = MaybeUninitialized::<[u8; flt2dec::MAX_SIG_DIGITS]>::uninitialized();
+        let mut parts = MaybeUninitialized::<[flt2dec::Part; 4]>::uninitialized();
         let formatted = flt2dec::to_shortest_str(flt2dec::strategy::grisu::format_shortest, *num,
                                                  sign, precision, false, buf.get_mut(),
                                                  parts.get_mut());
@@ -79,8 +79,8 @@ fn float_to_exponential_common_exact<T>(fmt: &mut Formatter, num: &T,
     where T: flt2dec::DecodableFloat
 {
     unsafe {
-        let mut buf = MaybeUninit::<[u8; 1024]>::uninitialized(); // enough for f32 and f64
-        let mut parts = MaybeUninit::<[flt2dec::Part; 6]>::uninitialized();
+        let mut buf = MaybeUninitialized::<[u8; 1024]>::uninitialized(); // enough for f32 and f64
+        let mut parts = MaybeUninitialized::<[flt2dec::Part; 6]>::uninitialized();
         let formatted = flt2dec::to_exact_exp_str(flt2dec::strategy::grisu::format_exact,
                                                   *num, sign, precision,
                                                   upper, buf.get_mut(), parts.get_mut());
@@ -98,8 +98,8 @@ fn float_to_exponential_common_shortest<T>(fmt: &mut Formatter,
 {
     unsafe {
         // enough for f32 and f64
-        let mut buf = MaybeUninit::<[u8; flt2dec::MAX_SIG_DIGITS]>::uninitialized();
-        let mut parts = MaybeUninit::<[flt2dec::Part; 6]>::uninitialized();
+        let mut buf = MaybeUninitialized::<[u8; flt2dec::MAX_SIG_DIGITS]>::uninitialized();
+        let mut parts = MaybeUninitialized::<[flt2dec::Part; 6]>::uninitialized();
         let formatted = flt2dec::to_shortest_exp_str(flt2dec::strategy::grisu::format_shortest,
                                                      *num, sign, (0, 0), upper,
                                                      buf.get_mut(), parts.get_mut());

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -79,7 +79,7 @@ use ops::{CoerceUnsized, DispatchFromDyn};
 use fmt;
 use hash;
 use marker::{PhantomData, Unsize};
-use mem::{self, MaybeUninit};
+use mem::{self, MaybeUninitialized};
 use nonzero::NonZero;
 
 use cmp::Ordering::{self, Less, Equal, Greater};
@@ -306,8 +306,8 @@ pub const fn null_mut<T>() -> *mut T { 0 as *mut T }
 #[stable(feature = "rust1", since = "1.0.0")]
 pub unsafe fn swap<T>(x: *mut T, y: *mut T) {
     // Give ourselves some scratch space to work with.
-    // We do not have to worry about drops: `MaybeUninit` does nothing when dropped.
-    let mut tmp = MaybeUninit::<T>::uninitialized();
+    // We do not have to worry about drops: `MaybeUninitialized` does nothing when dropped.
+    let mut tmp = MaybeUninitialized::<T>::uninitialized();
 
     // Perform the swap
     copy_nonoverlapping(x, tmp.as_mut_ptr(), 1);
@@ -399,7 +399,7 @@ unsafe fn swap_nonoverlapping_bytes(x: *mut u8, y: *mut u8, len: usize) {
     while i + block_size <= len {
         // Create some uninitialized memory as scratch space
         // Declaring `t` here avoids aligning the stack when this loop is unused
-        let mut t = mem::MaybeUninit::<Block>::uninitialized();
+        let mut t = mem::MaybeUninitialized::<Block>::uninitialized();
         let t = t.as_mut_ptr() as *mut u8;
         let x = x.add(i);
         let y = y.add(i);
@@ -414,7 +414,7 @@ unsafe fn swap_nonoverlapping_bytes(x: *mut u8, y: *mut u8, len: usize) {
 
     if i < len {
         // Swap any remaining bytes
-        let mut t = mem::MaybeUninit::<UnalignedBlock>::uninitialized();
+        let mut t = mem::MaybeUninitialized::<UnalignedBlock>::uninitialized();
         let rem = len - i;
 
         let t = t.as_mut_ptr() as *mut u8;
@@ -582,7 +582,7 @@ pub unsafe fn replace<T>(dst: *mut T, mut src: T) -> T {
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub unsafe fn read<T>(src: *const T) -> T {
-    let mut tmp = MaybeUninit::<T>::uninitialized();
+    let mut tmp = MaybeUninitialized::<T>::uninitialized();
     copy_nonoverlapping(src, tmp.as_mut_ptr(), 1);
     tmp.into_inner()
 }
@@ -649,7 +649,7 @@ pub unsafe fn read<T>(src: *const T) -> T {
 #[inline]
 #[stable(feature = "ptr_unaligned", since = "1.17.0")]
 pub unsafe fn read_unaligned<T>(src: *const T) -> T {
-    let mut tmp = MaybeUninit::<T>::uninitialized();
+    let mut tmp = MaybeUninitialized::<T>::uninitialized();
     copy_nonoverlapping(src as *const u8,
                         tmp.as_mut_ptr() as *mut u8,
                         mem::size_of::<T>());

--- a/src/libcore/slice/rotate.rs
+++ b/src/libcore/slice/rotate.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use cmp;
-use mem::{self, MaybeUninit};
+use mem::{self, MaybeUninitialized};
 use ptr;
 
 /// Rotation is much faster if it has access to a little bit of memory. This
@@ -82,7 +82,7 @@ pub unsafe fn ptr_rotate<T>(mut left: usize, mid: *mut T, mut right: usize) {
         }
     }
 
-    let mut rawarray = MaybeUninit::<RawArray<T>>::uninitialized();
+    let mut rawarray = MaybeUninitialized::<RawArray<T>>::uninitialized();
     let buf = &mut (*rawarray.as_mut_ptr()).typed as *mut [T; 2] as *mut T;
 
     let dim = mid.sub(left).add(right);

--- a/src/libcore/slice/sort.rs
+++ b/src/libcore/slice/sort.rs
@@ -17,7 +17,7 @@
 //! stable sorting implementation.
 
 use cmp;
-use mem::{self, MaybeUninit};
+use mem::{self, MaybeUninitialized};
 use ptr;
 
 /// When dropped, copies from `src` into `dest`.
@@ -226,14 +226,14 @@ fn partition_in_blocks<T, F>(v: &mut [T], pivot: &T, is_less: &mut F) -> usize
     let mut block_l = BLOCK;
     let mut start_l = ptr::null_mut();
     let mut end_l = ptr::null_mut();
-    let mut offsets_l = MaybeUninit::<[u8; BLOCK]>::uninitialized();
+    let mut offsets_l = MaybeUninitialized::<[u8; BLOCK]>::uninitialized();
 
     // The current block on the right side (from `r.sub(block_r)` to `r`).
     let mut r = unsafe { l.add(v.len()) };
     let mut block_r = BLOCK;
     let mut start_r = ptr::null_mut();
     let mut end_r = ptr::null_mut();
-    let mut offsets_r = MaybeUninit::<[u8; BLOCK]>::uninitialized();
+    let mut offsets_r = MaybeUninitialized::<[u8; BLOCK]>::uninitialized();
 
     // FIXME: When we get VLAs, try creating one array of length `min(v.len(), 2 * BLOCK)` rather
     // than two fixed-size arrays of length `BLOCK`. VLAs might be more cache-efficient.

--- a/src/librustc_mir/interpret/visitor.rs
+++ b/src/librustc_mir/interpret/visitor.rs
@@ -310,7 +310,7 @@ macro_rules! make_value_visitor {
                     },
                     layout::FieldPlacement::Arbitrary { ref offsets, .. } => {
                         // Special handling needed for generators: All but the first field
-                        // (which is the state) are actually implicitly `MaybeUninit`, i.e.,
+                        // (which is the state) are actually implicitly `MaybeUninitialized`, i.e.,
                         // they may or may not be initialized, so we cannot visit them.
                         match v.layout().ty.sty {
                             ty::Generator(..) => {

--- a/src/libstd/sys/windows/mutex.rs
+++ b/src/libstd/sys/windows/mutex.rs
@@ -30,7 +30,7 @@
 //! detect recursive locks.
 
 use cell::UnsafeCell;
-use mem::{self, MaybeUninit};
+use mem::{self, MaybeUninitialized};
 use sync::atomic::{AtomicUsize, Ordering};
 use sys::c;
 use sys::compat;
@@ -157,14 +157,14 @@ fn kind() -> Kind {
     return ret;
 }
 
-pub struct ReentrantMutex { inner: UnsafeCell<MaybeUninit<c::CRITICAL_SECTION>> }
+pub struct ReentrantMutex { inner: UnsafeCell<MaybeUninitialized<c::CRITICAL_SECTION>> }
 
 unsafe impl Send for ReentrantMutex {}
 unsafe impl Sync for ReentrantMutex {}
 
 impl ReentrantMutex {
     pub fn uninitialized() -> ReentrantMutex {
-        ReentrantMutex { inner: UnsafeCell::new(MaybeUninit::uninitialized()) }
+        ReentrantMutex { inner: UnsafeCell::new(MaybeUninitialized::uninitialized()) }
     }
 
     pub unsafe fn init(&mut self) {

--- a/src/test/codegen/box-maybe-uninit.rs
+++ b/src/test/codegen/box-maybe-uninit.rs
@@ -12,12 +12,12 @@
 #![crate_type="lib"]
 #![feature(maybe_uninit)]
 
-use std::mem::MaybeUninit;
+use std::mem::MaybeUninitialized;
 
-// Boxing a `MaybeUninit` value should not copy junk from the stack
+// Boxing a `MaybeUninitialized` value should not copy junk from the stack
 #[no_mangle]
-pub fn box_uninitialized() -> Box<MaybeUninit<usize>> {
+pub fn box_uninitialized() -> Box<MaybeUninitialized<usize>> {
     // CHECK-LABEL: @box_uninitialized
     // CHECK-NOT: store
-    Box::new(MaybeUninit::uninitialized())
+    Box::new(MaybeUninitialized::uninitialized())
 }

--- a/src/test/debuginfo/nil-enum.rs
+++ b/src/test/debuginfo/nil-enum.rs
@@ -35,7 +35,7 @@
 #![feature(maybe_uninit)]
 #![omit_gdb_pretty_printer_section]
 
-use std::mem::MaybeUninit;
+use std::mem::MaybeUninitialized;
 
 enum ANilEnum {}
 enum AnotherNilEnum {}
@@ -45,8 +45,8 @@ enum AnotherNilEnum {}
 // The error from gdbr is expected since nil enums are not supposed to exist.
 fn main() {
     unsafe {
-        let first: ANilEnum = MaybeUninit::uninitialized().into_inner();
-        let second: AnotherNilEnum = MaybeUninit::uninitialized().into_inner();
+        let first: ANilEnum = MaybeUninitialized::uninitialized().into_inner();
+        let second: AnotherNilEnum = MaybeUninitialized::uninitialized().into_inner();
 
         zzz(); // #break
     }


### PR DESCRIPTION
Proposal to finalize the name as `MaybeUninit` https://github.com/rust-lang/rust/pull/56138#issuecomment-456192667 -- as in, the FCP is to *close* this PR.

rfcbot comment is [here](https://github.com/rust-lang/rust/pull/56138#issuecomment-456192671)

------------------

Changed via:

```
git ls-files -z | xargs -0 -L1 gsed --in-place 's@\bMaybeUninit\b@MaybeUninitialized@'
```

Checked via:

```
rg -uuu '\bMaybeUninit\b'
```
