### PR TITLE
Issue 56128 segment id ice nightly

### DIFF
--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -2752,7 +2752,7 @@ impl<'a> LoweringContext<'a> {
         id: NodeId,
         name: &mut Name,
         attrs: &hir::HirVec<Attribute>,
-        vis: &mut hir::Visibility,
+        vis: &hir::Visibility,
         i: &ItemKind,
     ) -> hir::ItemKind {
         match *i {
@@ -2955,7 +2955,7 @@ impl<'a> LoweringContext<'a> {
         tree: &UseTree,
         prefix: &Path,
         id: NodeId,
-        vis: &mut hir::Visibility,
+        vis: &hir::Visibility,
         name: &mut Name,
         attrs: &hir::HirVec<Attribute>,
     ) -> hir::ItemKind {
@@ -3086,7 +3086,7 @@ impl<'a> LoweringContext<'a> {
                         hir_id: new_hir_id,
                     } = self.lower_node_id(id);
 
-                    let mut vis = vis.clone();
+                    let vis = vis.clone();
                     let mut name = name.clone();
                     let mut prefix = prefix.clone();
 
@@ -3104,7 +3104,7 @@ impl<'a> LoweringContext<'a> {
                         let item = this.lower_use_tree(use_tree,
                                                        &prefix,
                                                        new_id,
-                                                       &mut vis,
+                                                       &vis,
                                                        &mut name,
                                                        attrs);
 
@@ -3384,7 +3384,7 @@ impl<'a> LoweringContext<'a> {
 
     pub fn lower_item(&mut self, i: &Item) -> Option<hir::Item> {
         let mut name = i.ident.name;
-        let mut vis = self.lower_visibility(&i.vis, None);
+        let vis = self.lower_visibility(&i.vis, None);
         let attrs = self.lower_attrs(&i.attrs);
         if let ItemKind::MacroDef(ref def) = i.node {
             if !def.legacy || attr::contains_name(&i.attrs, "macro_export") ||
@@ -3403,7 +3403,7 @@ impl<'a> LoweringContext<'a> {
             return None;
         }
 
-        let node = self.lower_item_kind(i.id, &mut name, &attrs, &mut vis, &i.node);
+        let node = self.lower_item_kind(i.id, &mut name, &attrs, &vis, &i.node);
 
         let LoweredNodeId { node_id, hir_id } = self.lower_node_id(i.id);
 

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -3139,12 +3139,8 @@ impl<'a> LoweringContext<'a> {
                     });
                 }
 
-                // Privatize the degenerate import base, used only to check
-                // the stability of `use a::{};`, to avoid it showing up as
-                // a re-export by accident when `pub`, e.g. in documentation.
                 let def = self.expect_full_def_from_use(id).next().unwrap_or(Def::Err);
                 let path = P(self.lower_path_extra(def, &prefix, ParamMode::Explicit, None));
-                *vis = respan(prefix.span.shrink_to_lo(), hir::VisibilityKind::Inherited);
                 hir::ItemKind::Use(path, hir::UseKind::ListStem)
             }
         }

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -1866,6 +1866,10 @@ impl<'a> LoweringContext<'a> {
         } else {
             self.lower_node_id(segment.id)
         };
+        debug!(
+            "lower_path_segment: ident={:?} original-id={:?} new-id={:?}",
+            segment.ident, segment.id, id,
+        );
 
         hir::PathSegment::new(
             segment.ident,
@@ -2955,6 +2959,9 @@ impl<'a> LoweringContext<'a> {
         name: &mut Name,
         attrs: &hir::HirVec<Attribute>,
     ) -> hir::ItemKind {
+        debug!("lower_use_tree(tree={:?})", tree);
+        debug!("lower_use_tree: vis = {:?}", vis);
+
         let path = &tree.prefix;
         let segments = prefix
             .segments
@@ -4540,6 +4547,7 @@ impl<'a> LoweringContext<'a> {
             VisibilityKind::Public => hir::VisibilityKind::Public,
             VisibilityKind::Crate(sugar) => hir::VisibilityKind::Crate(sugar),
             VisibilityKind::Restricted { ref path, id } => {
+                debug!("lower_visibility: restricted path id = {:?}", id);
                 let lowered_id = if let Some(owner) = explicit_owner {
                     self.lower_node_id_with_owner(id, owner)
                 } else {

--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -1032,14 +1032,14 @@ pub fn map_crate<'hir>(sess: &::session::Session,
         let mut collector = NodeCollector::root(&forest.krate,
                                                 &forest.dep_graph,
                                                 &definitions,
-                                                hcx);
+                                                hcx,
+                                                sess.source_map());
         intravisit::walk_crate(&mut collector, &forest.krate);
 
         let crate_disambiguator = sess.local_crate_disambiguator();
         let cmdline_args = sess.opts.dep_tracking_hash();
         collector.finalize_and_compute_crate_hash(crate_disambiguator,
                                                   cstore,
-                                                  sess.source_map(),
                                                   cmdline_args)
     };
 

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1136,7 +1136,15 @@ impl UnreachablePub {
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnreachablePub {
     fn check_item(&mut self, cx: &LateContext, item: &hir::Item) {
-        self.perform_lint(cx, "item", item.id, &item.vis, item.span, true);
+        match item.node {
+            hir::ItemKind::Use(_, hir::UseKind::ListStem) => {
+                // Hack: ignore these `use foo::{}` remnants which are just a figment
+                // our IR.
+            }
+            _ => {
+                self.perform_lint(cx, "item", item.id, &item.vis, item.span, true);
+            }
+        }
     }
 
     fn check_foreign_item(&mut self, cx: &LateContext, foreign_item: &hir::ForeignItem) {

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1136,15 +1136,7 @@ impl UnreachablePub {
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnreachablePub {
     fn check_item(&mut self, cx: &LateContext, item: &hir::Item) {
-        match item.node {
-            hir::ItemKind::Use(_, hir::UseKind::ListStem) => {
-                // Hack: ignore these `use foo::{}` remnants which are just a figment
-                // our IR.
-            }
-            _ => {
-                self.perform_lint(cx, "item", item.id, &item.vis, item.span, true);
-            }
-        }
+        self.perform_lint(cx, "item", item.id, &item.vis, item.span, true);
     }
 
     fn check_foreign_item(&mut self, cx: &LateContext, foreign_item: &hir::ForeignItem) {

--- a/src/test/ui/issues/issue-56128.rs
+++ b/src/test/ui/issues/issue-56128.rs
@@ -1,5 +1,7 @@
 // Regression test for #56128. When this `pub(super) use...` gets
 // exploded in the HIR, we were not handling ids correctly.
+//
+// compile-pass
 
 mod bar {
     pub(super) use self::baz::{x, y};

--- a/src/test/ui/issues/issue-56128.rs
+++ b/src/test/ui/issues/issue-56128.rs
@@ -1,0 +1,13 @@
+// Regression test for #56128. When this `pub(super) use...` gets
+// exploded in the HIR, we were not handling ids correctly.
+
+mod bar {
+    pub(super) use self::baz::{x, y};
+
+    mod baz {
+        pub fn x() { }
+        pub fn y() { }
+    }
+}
+
+fn main() { }


### PR DESCRIPTION
Tentative fix for #56128 

From what I can tell, the problem is that if you have `pub(super) use foo::{a, b}`, then when we explode the `a` and `b`, the segment ids from the `super` path were not getting cloned. However, once I fixed *that*, then I ran into a problem that the "visibility" node-ids were not present in the final HIR -- this is because the visibility of the "stem" that is returned in this case was getting reset to inherited. I don't *think* it is a problem to undo that, so that the visibility is returned unmodified.

Fixes #55475
Fixes #56128 

cc @nrc @petrochenkov 