### PR TITLE
Fix BTreeSet and BTreeMap gdb pretty-printers

### DIFF
--- a/src/etc/debugger_pretty_printers_common.py
+++ b/src/etc/debugger_pretty_printers_common.py
@@ -375,32 +375,6 @@ def extract_tail_head_ptr_and_cap_from_std_vecdeque(vec_val):
     assert data_ptr.type.get_dwarf_type_kind() == DWARF_TYPE_CODE_PTR
     return (tail, head, data_ptr, capacity)
 
-
-def extract_length_and_ptr_from_std_btreeset(vec_val):
-    assert vec_val.type.get_type_kind() == TYPE_KIND_STD_BTREESET
-    map = vec_val.get_child_at_index(0)
-    root = map.get_child_at_index(0)
-    length = map.get_child_at_index(1).as_integer()
-    node = root.get_child_at_index(0)
-    ptr = node.get_child_at_index(0)
-    unique_ptr_val = ptr.get_child_at_index(0)
-    data_ptr = unique_ptr_val.get_child_at_index(0)
-    assert data_ptr.type.get_dwarf_type_kind() == DWARF_TYPE_CODE_PTR
-    return (length, data_ptr)
-
-
-def extract_length_and_ptr_from_std_btreemap(vec_val):
-    assert vec_val.type.get_type_kind() == TYPE_KIND_STD_BTREEMAP
-    root = vec_val.get_child_at_index(0)
-    length = vec_val.get_child_at_index(1).as_integer()
-    node = root.get_child_at_index(0)
-    ptr = node.get_child_at_index(0)
-    unique_ptr_val = ptr.get_child_at_index(0)
-    data_ptr = unique_ptr_val.get_child_at_index(0)
-    assert data_ptr.type.get_dwarf_type_kind() == DWARF_TYPE_CODE_PTR
-    return (length, data_ptr)
-
-
 def extract_length_and_ptr_from_slice(slice_val):
     assert (slice_val.type.get_type_kind() == TYPE_KIND_SLICE or
             slice_val.type.get_type_kind() == TYPE_KIND_STR_SLICE)

--- a/src/test/debuginfo/pretty-std-collections.rs
+++ b/src/test/debuginfo/pretty-std-collections.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-tidy-linelength
 // ignore-windows failing on win32 bot
 // ignore-freebsd: gdb package too new
 // ignore-android: FIXME(#10381)
@@ -20,10 +21,10 @@
 // gdb-command: run
 
 // gdb-command: print btree_set
-// gdb-check:$1 = BTreeSet<i32>(len: 3) = {3, 5, 7}
+// gdb-check:$1 = BTreeSet<i32>(len: 15) = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14}
 
 // gdb-command: print btree_map
-// gdb-check:$2 = BTreeMap<i32, i32>(len: 3) = {[3] = 3, [5] = 7, [7] = 4}
+// gdb-check:$2 = BTreeMap<i32, i32>(len: 15) = {[0] = 0, [1] = 1, [2] = 2, [3] = 3, [4] = 4, [5] = 5, [6] = 6, [7] = 7, [8] = 8, [9] = 9, [10] = 10, [11] = 11, [12] = 12, [13] = 13, [14] = 14}
 
 // gdb-command: print vec_deque
 // gdb-check:$3 = VecDeque<i32>(len: 3, cap: 8) = {5, 3, 7}
@@ -38,15 +39,15 @@ fn main() {
 
     // BTreeSet
     let mut btree_set = BTreeSet::new();
-    btree_set.insert(5);
-    btree_set.insert(3);
-    btree_set.insert(7);
+    for i in 0..15 {
+        btree_set.insert(i);
+    }
 
     // BTreeMap
     let mut btree_map = BTreeMap::new();
-    btree_map.insert(5, 7);
-    btree_map.insert(3, 3);
-    btree_map.insert(7, 4);
+    for i in 0..15 {
+        btree_map.insert(i, i);
+    }
 
     // VecDeque
     let mut vec_deque = VecDeque::new();


### PR DESCRIPTION
The BTreeSet and BTreeMap gdb pretty-printers did not take the node
structure into account, and consequently only worked for shallow sets.
This fixes the problem by iterating over child nodes when needed.

This patch avoids the current approach of implementing some of the
value manipulations in debugger-indepdendent code.  This was done for
convenience: a type lookup was needed for the first time, and there
currently are no lldb formatters for these types.

Closes #55771