### PR TITLE
resolve: Fix some asserts in import validation

### DIFF
--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -842,12 +842,14 @@ impl<'a, 'b:'a, 'c: 'b> ImportResolver<'a, 'b, 'c> {
                 module
             }
             PathResult::Failed(span, msg, false) => {
-                assert!(directive.imported_module.get().is_none());
+                assert!(!self.ambiguity_errors.is_empty() ||
+                        directive.imported_module.get().is_none());
                 resolve_error(self, span, ResolutionError::FailedToResolve(&msg));
                 return None;
             }
             PathResult::Failed(span, msg, true) => {
-                assert!(directive.imported_module.get().is_none());
+                assert!(!self.ambiguity_errors.is_empty() ||
+                        directive.imported_module.get().is_none());
                 return if let Some((suggested_path, note)) = self.make_path_suggestion(
                     span, directive.module_path.clone(), &directive.parent_scope
                 ) {

--- a/src/test/ui/imports/auxiliary/issue-56125.rs
+++ b/src/test/ui/imports/auxiliary/issue-56125.rs
@@ -1,0 +1,9 @@
+pub mod last_segment {
+    pub mod issue_56125 {}
+}
+
+pub mod non_last_segment {
+    pub mod non_last_segment {
+        pub mod issue_56125 {}
+    }
+}

--- a/src/test/ui/imports/issue-56125.rs
+++ b/src/test/ui/imports/issue-56125.rs
@@ -1,0 +1,12 @@
+// edition:2018
+// compile-flags:--extern issue_56125
+// aux-build:issue-56125.rs
+
+use issue_56125::last_segment::*;
+//~^ ERROR `issue_56125` is ambiguous
+//~| ERROR unresolved import `issue_56125::last_segment`
+use issue_56125::non_last_segment::non_last_segment::*;
+//~^ ERROR `issue_56125` is ambiguous
+//~| ERROR failed to resolve: could not find `non_last_segment` in `issue_56125`
+
+fn main() {}

--- a/src/test/ui/imports/issue-56125.stderr
+++ b/src/test/ui/imports/issue-56125.stderr
@@ -1,0 +1,46 @@
+error[E0433]: failed to resolve: could not find `non_last_segment` in `issue_56125`
+  --> $DIR/issue-56125.rs:8:18
+   |
+LL | use issue_56125::non_last_segment::non_last_segment::*;
+   |                  ^^^^^^^^^^^^^^^^ could not find `non_last_segment` in `issue_56125`
+
+error[E0432]: unresolved import `issue_56125::last_segment`
+  --> $DIR/issue-56125.rs:5:18
+   |
+LL | use issue_56125::last_segment::*;
+   |                  ^^^^^^^^^^^^ could not find `last_segment` in `issue_56125`
+
+error[E0659]: `issue_56125` is ambiguous (name vs any other name during import resolution)
+  --> $DIR/issue-56125.rs:5:5
+   |
+LL | use issue_56125::last_segment::*;
+   |     ^^^^^^^^^^^ ambiguous name
+   |
+   = note: `issue_56125` could refer to an extern crate passed with `--extern`
+   = help: use `::issue_56125` to refer to this extern crate unambiguously
+note: `issue_56125` could also refer to the module imported here
+  --> $DIR/issue-56125.rs:5:5
+   |
+LL | use issue_56125::last_segment::*;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: use `self::issue_56125` to refer to this module unambiguously
+
+error[E0659]: `issue_56125` is ambiguous (name vs any other name during import resolution)
+  --> $DIR/issue-56125.rs:8:5
+   |
+LL | use issue_56125::non_last_segment::non_last_segment::*;
+   |     ^^^^^^^^^^^ ambiguous name
+   |
+   = note: `issue_56125` could refer to an extern crate passed with `--extern`
+   = help: use `::issue_56125` to refer to this extern crate unambiguously
+note: `issue_56125` could also refer to the module imported here
+  --> $DIR/issue-56125.rs:5:5
+   |
+LL | use issue_56125::last_segment::*;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: use `self::issue_56125` to refer to this module unambiguously
+
+error: aborting due to 4 previous errors
+
+Some errors occurred: E0432, E0433, E0659.
+For more information about an error, try `rustc --explain E0432`.


### PR DESCRIPTION
The asserts are not actually correct in presence of ambiguity errors.

Fixes https://github.com/rust-lang/rust/issues/56125