### PR TITLE
Add rustc-guide as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -62,3 +62,6 @@
 	url = https://github.com/rust-lang-nursery/clang.git
 	branch = rust-release-80-v1
 
+[submodule "src/doc/rustc-guide"]
+	path = src/doc/rustc-guide
+	url = https://github.com/rust-lang/rustc-guide.git


### PR DESCRIPTION
Adding this as a submodule will allow two things:
- Linking to the guide from doc.rlo
- Doing a link check as part of the rust CI build

Key question: Do we want to wait for the book to be filled out more? e.g. do we ever want to move it out of the nursery?

r? @nikomatsakis 

cc @steveklabnik 