### PR TITLE
Move a flaky process test out of libstd

### DIFF
--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -1890,42 +1890,6 @@ mod tests {
     }
 
     #[test]
-    fn test_inherit_env() {
-        use env;
-
-        let result = env_cmd().output().unwrap();
-        let output = String::from_utf8(result.stdout).unwrap();
-
-        for (ref k, ref v) in env::vars() {
-            // Don't check android RANDOM variable which seems to change
-            // whenever the shell runs, and our `env_cmd` is indeed running a
-            // shell which means it'll get a different RANDOM than we probably
-            // have.
-            //
-            // Also skip env vars with `-` in the name on android because, well,
-            // I'm not sure. It appears though that the `set` command above does
-            // not print env vars with `-` in the name, so we just skip them
-            // here as we won't find them in the output. Note that most env vars
-            // use `_` instead of `-`, but our build system sets a few env vars
-            // with `-` in the name.
-            if cfg!(target_os = "android") &&
-               (*k == "RANDOM" || k.contains("-")) {
-                continue
-            }
-
-            // Windows has hidden environment variables whose names start with
-            // equals signs (`=`). Those do not show up in the output of the
-            // `set` command.
-            assert!((cfg!(windows) && k.starts_with("=")) ||
-                    k.starts_with("DYLD") ||
-                    output.contains(&format!("{}={}", *k, *v)) ||
-                    output.contains(&format!("{}='{}'", *k, *v)),
-                    "output doesn't contain `{}={}`\n{}",
-                    k, v, output);
-        }
-    }
-
-    #[test]
     fn test_override_env() {
         use env;
 

--- a/src/test/run-pass/inherit-env.rs
+++ b/src/test/run-pass/inherit-env.rs
@@ -1,0 +1,25 @@
+// ignore-emscripten
+// ignore-wasm32
+
+use std::env;
+use std::process::Command;
+
+fn main() {
+    if env::args().nth(1).map(|s| s == "print").unwrap_or(false) {
+        for (k, v) in env::vars() {
+            println!("{}={}", k, v);
+        }
+        return
+    }
+
+    let me = env::current_exe().unwrap();
+    let result = Command::new(me).arg("print").output().unwrap();
+    let output = String::from_utf8(result.stdout).unwrap();
+
+    for (k, v) in env::vars() {
+        assert!(output.contains(&format!("{}={}", k, v)),
+                "output doesn't contain `{}={}`\n{}",
+                k, v, output);
+    }
+}
+


### PR DESCRIPTION
This test ensures that everything in `env::vars()` is inherited but
that's not actually true because other tests may add env vars after we
spawn the process, causing the test to be flaky! This commit moves the
test to a run-pass test where it can execute in isolation.

Along the way this removes a lot of the platform specificity of the
test, using iteslf to print the environment instead of a foreign process.