### PR TITLE
Pass additional linker flags when targeting Fuchsia

### DIFF
--- a/src/librustc_target/spec/fuchsia_base.rs
+++ b/src/librustc_target/spec/fuchsia_base.rs
@@ -12,9 +12,11 @@ use spec::{LldFlavor, LinkArgs, LinkerFlavor, TargetOptions};
 use std::default::Default;
 
 pub fn opts() -> TargetOptions {
-    let mut args = LinkArgs::new();
-    args.insert(LinkerFlavor::Lld(LldFlavor::Ld), vec![
-        "--build-id".to_string(), "--hash-style=gnu".to_string(),
+    let mut pre_link_args = LinkArgs::new();
+    pre_link_args.insert(LinkerFlavor::Lld(LldFlavor::Ld), vec![
+        "--build-id".to_string(),
+        "--eh-frame-hdr".to_string(),
+        "--hash-style=gnu".to_string(),
         "-z".to_string(), "rodynamic".to_string(),
     ]);
 
@@ -24,9 +26,13 @@ pub fn opts() -> TargetOptions {
         dynamic_linking: true,
         executables: true,
         target_family: Some("unix".to_string()),
+        is_like_fuchsia: true,
         linker_is_gnu: true,
         has_rpath: false,
-        pre_link_args: args,
+        pre_link_args: pre_link_args,
+        pre_link_objects_exe: vec![
+            "Scrt1.o".to_string()
+        ],
         position_independent_executables: true,
         has_elf_tls: true,
         .. Default::default()

--- a/src/librustc_target/spec/mod.rs
+++ b/src/librustc_target/spec/mod.rs
@@ -558,6 +558,8 @@ pub struct TargetOptions {
     /// Emscripten toolchain.
     /// Defaults to false.
     pub is_like_emscripten: bool,
+    /// Whether the target toolchain is like Fuchsia's.
+    pub is_like_fuchsia: bool,
     /// Whether the linker support GNU-like arguments such as -O. Defaults to false.
     pub linker_is_gnu: bool,
     /// The MinGW toolchain has a known issue that prevents it from correctly
@@ -723,6 +725,7 @@ impl Default for TargetOptions {
             is_like_android: false,
             is_like_emscripten: false,
             is_like_msvc: false,
+            is_like_fuchsia: false,
             linker_is_gnu: false,
             allows_weak_linkage: true,
             has_rpath: false,
@@ -1013,6 +1016,7 @@ impl Target {
         key!(is_like_msvc, bool);
         key!(is_like_emscripten, bool);
         key!(is_like_android, bool);
+        key!(is_like_fuchsia, bool);
         key!(linker_is_gnu, bool);
         key!(allows_weak_linkage, bool);
         key!(has_rpath, bool);
@@ -1222,6 +1226,7 @@ impl ToJson for Target {
         target_option_val!(is_like_msvc);
         target_option_val!(is_like_emscripten);
         target_option_val!(is_like_android);
+        target_option_val!(is_like_fuchsia);
         target_option_val!(linker_is_gnu);
         target_option_val!(allows_weak_linkage);
         target_option_val!(has_rpath);


### PR DESCRIPTION
This is a follow up to 8aa9267 which changed the driver to use lld
directly rather than invoking it through Clang. This change ensures
we pass all the necessary flags to lld.