### PR TITLE
Try to make top-level Cargo.toml work without __CARGO_TEST_ROOT.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ members = [
 exclude = [
   "src/tools/rls/test_data",
   "build",
+  # HACK(eddyb) This hardcodes the fact that our CI uses `/checkout/obj`.
+  "obj",
 ]
 
 # Curiously, LLVM 7.0 will segfault if compiled with opt-level=3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
 ]
 exclude = [
   "src/tools/rls/test_data",
+  "build",
 ]
 
 # Curiously, LLVM 7.0 will segfault if compiled with opt-level=3

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1934,7 +1934,6 @@ impl Step for Distcheck {
                 .arg("generate-lockfile")
                 .arg("--manifest-path")
                 .arg(&toml)
-                .env("__CARGO_TEST_ROOT", &dir)
                 .current_dir(&dir),
         );
     }

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -264,7 +264,6 @@ macro_rules! tool {
         $name:ident, $path:expr, $tool_name:expr, $mode:expr
         $(,llvm_tools = $llvm:expr)*
         $(,is_external_tool = $external:expr)*
-        $(,cargo_test_root = $cargo_test_root:expr)*
         ;
     )+) => {
         #[derive(Copy, PartialEq, Eq, Clone)]
@@ -286,15 +285,6 @@ macro_rules! tool {
             pub fn uses_llvm_tools(&self) -> bool {
                 match self {
                     $(Tool::$name => false $(|| $llvm)*,)+
-                }
-            }
-
-            /// Whether this tool requires may run Cargo for test crates,
-            /// which currently needs setting the environment variable
-            /// `__CARGO_TEST_ROOT` to separate it from the workspace.
-            pub fn needs_cargo_test_root(&self) -> bool {
-                match self {
-                    $(Tool::$name => false $(|| $cargo_test_root)*,)+
                 }
             }
         }
@@ -372,9 +362,8 @@ tool!(
     UnstableBookGen, "src/tools/unstable-book-gen", "unstable-book-gen", Mode::ToolBootstrap;
     Tidy, "src/tools/tidy", "tidy", Mode::ToolBootstrap;
     Linkchecker, "src/tools/linkchecker", "linkchecker", Mode::ToolBootstrap;
-    CargoTest, "src/tools/cargotest", "cargotest", Mode::ToolBootstrap, cargo_test_root = true;
-    Compiletest, "src/tools/compiletest", "compiletest", Mode::ToolBootstrap,
-        llvm_tools = true, cargo_test_root = true;
+    CargoTest, "src/tools/cargotest", "cargotest", Mode::ToolBootstrap;
+    Compiletest, "src/tools/compiletest", "compiletest", Mode::ToolBootstrap, llvm_tools = true;
     BuildManifest, "src/tools/build-manifest", "build-manifest", Mode::ToolBootstrap;
     RemoteTestClient, "src/tools/remote-test-client", "remote-test-client", Mode::ToolBootstrap;
     RustInstaller, "src/tools/rust-installer", "fabricate", Mode::ToolBootstrap,
@@ -691,11 +680,6 @@ impl<'a> Builder<'a> {
                     cmd.env("PATH", new_path);
                 }
             }
-        }
-
-        // Set `__CARGO_TEST_ROOT` to the build directory if needed.
-        if tool.needs_cargo_test_root() {
-            cmd.env("__CARGO_TEST_ROOT", &self.config.out);
         }
 
         add_lib_path(lib_paths, cmd);

--- a/src/test/run-make/thumb-none-cortex-m/Makefile
+++ b/src/test/run-make/thumb-none-cortex-m/Makefile
@@ -32,7 +32,10 @@ all:
 	mkdir -p $(WORK_DIR)
 	-cd $(WORK_DIR) && rm -rf $(CRATE)
 	cd $(WORK_DIR) && bash -x $(HERE)/../git_clone_sha1.sh $(CRATE) $(CRATE_URL) $(CRATE_SHA1)
-	cd $(WORK_DIR) && cd $(CRATE) && $(CARGO) build --target $(TARGET) -v
+	# HACK(eddyb) sets `RUSTC_BOOTSTRAP=1` so Cargo can accept nightly features.
+	# These come from the top-level Rust workspace, that this crate is not a
+	# member of, but Cargo tries to load the workspace `Cargo.toml` anyway.
+	cd $(WORK_DIR) && cd $(CRATE) && env RUSTC_BOOTSTRAP=1 $(CARGO) build --target $(TARGET) -v
 else
 
 all:

--- a/src/test/run-make/thumb-none-qemu/script.sh
+++ b/src/test/run-make/thumb-none-qemu/script.sh
@@ -8,9 +8,12 @@ pushd $WORK_DIR
     rm -rf $CRATE || echo OK
     cp -a $HERE/example .
     pushd $CRATE
-        env RUSTFLAGS="-C linker=arm-none-eabi-ld -C link-arg=-Tlink.x" \
+        # HACK(eddyb) sets `RUSTC_BOOTSTRAP=1` so Cargo can accept nightly features.
+        # These come from the top-level Rust workspace, that this crate is not a
+        # member of, but Cargo tries to load the workspace `Cargo.toml` anyway.
+        env RUSTC_BOOTSTRAP=1 RUSTFLAGS="-C linker=arm-none-eabi-ld -C link-arg=-Tlink.x" \
             $CARGO run --target $TARGET           | grep "x = 42"
-        env RUSTFLAGS="-C linker=arm-none-eabi-ld -C link-arg=-Tlink.x" \
+        env RUSTC_BOOTSTRAP=1 RUSTFLAGS="-C linker=arm-none-eabi-ld -C link-arg=-Tlink.x" \
             $CARGO run --target $TARGET --release | grep "x = 42"
     popd
 popd


### PR DESCRIPTION
The last failures I noticed before adding the `__CARGO_TEST_ROOT` hack were in `src/test/run-make/thumb-none-{cortex-m,qemu}`, and had to do with the fact that the top-level `Cargo.toml` uses nightly Cargo features.

If that's the only problem, this PR should work, and we can figure out how to unbreak RLS.