### PR TITLE
Rustdoc dark theme improvements

### DIFF
--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -21,10 +21,10 @@ h1, h2, h3:not(.impl):not(.method):not(.type):not(.tymethod), h4:not(.method):no
 	color: #ddd;
 }
 h1.fqn {
-	border-bottom-color: #d2d2d2;
+	border-bottom-color: #515151;
 }
 h2, h3:not(.impl):not(.method):not(.type):not(.tymethod), h4:not(.method):not(.type):not(.tymethod) {
-	border-bottom-color: #d2d2d2;
+	border-bottom-color: #515151;
 }
 
 .invisible {
@@ -39,7 +39,7 @@ pre {
 }
 
 .sidebar {
-	background-color: #505050;
+	background-color: #444;
 }
 
 .sidebar .current {
@@ -75,7 +75,7 @@ pre {
 }
 
 .docblock h1, .docblock h2, .docblock h3, .docblock h4, .docblock h5 {
-	border-bottom-color: #DDD;
+	border-bottom-color: #515151;
 }
 
 .docblock table {
@@ -199,8 +199,8 @@ a.test-arrow {
 }
 
 #help > div {
-	background: #4d4d4d;
-	border-color: #bfbfbf;
+	background: #434343;
+	border-color: #5f5f5f;
 }
 
 .since {

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -27,10 +27,6 @@ h2, h3:not(.impl):not(.method):not(.type):not(.tymethod), h4:not(.method):not(.t
 	border-bottom-color: #d2d2d2;
 }
 
-.in-band {
-	background-color: #353535;
-}
-
 .invisible {
 	background: rgba(0, 0, 0, 0);
 }

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -207,12 +207,6 @@ a.test-arrow {
 	border-color: #bfbfbf;
 }
 
-#help dt {
-	border-color: #bfbfbf;
-	background: rgba(0,0,0,0);
-	color: black;
-}
-
 .since {
 	color: grey;
 }

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -108,47 +108,45 @@ pre {
 	color: #eee !important;
 	background-color: #616161;
 }
-.content .highlighted a, .content .highlighted span { color: #eee !important; }
-.content .highlighted.trait { background-color: #013191; }
+.content .highlighted a, .content .highlighted span { color: #000 !important; }
+.content .highlighted.trait { background-color: #ffffff; }
 .content .highlighted.mod,
-.content .highlighted.externcrate { background-color: #afc6e4; }
-.content .highlighted.mod { background-color: #803a1b; }
-.content .highlighted.externcrate { background-color: #396bac; }
-.content .highlighted.enum { background-color: #5b4e68; }
-.content .highlighted.struct { background-color: #194e9f; }
-.content .highlighted.union { background-color: #b7bd49; }
+.content .highlighted.externcrate { background-color: #f9fbfd; }
+.content .highlighted.enum { background-color: #f2f7f2; }
+.content .highlighted.struct { background-color: #fbf2ef; }
+.content .highlighted.union { background-color: #d4d892; }
 .content .highlighted.fn,
 .content .highlighted.method,
-.content .highlighted.tymethod { background-color: #4950ed; }
-.content .highlighted.type { background-color: #38902c; }
-.content .highlighted.foreigntype { background-color: #b200d6; }
+.content .highlighted.tymethod { background-color: #efe9ea; }
+.content .highlighted.type { background-color: #fffaf4; }
+.content .highlighted.foreigntype { background-color: #ffffff; }
 .content .highlighted.attr,
 .content .highlighted.derive,
-.content .highlighted.macro { background-color: #217d1c; }
+.content .highlighted.macro { background-color: #daf6d9; }
 .content .highlighted.constant,
-.content .highlighted.static { background-color: #0063cc; }
-.content .highlighted.primitive { background-color: #00708a; }
-.content .highlighted.keyword { background-color: #884719; }
+.content .highlighted.static { background-color: #ffffff; }
+.content .highlighted.primitive { background-color: #fdffff; }
+.content .highlighted.keyword { background-color: #fcd0b0; }
 
-.content span.enum, .content a.enum, .block a.current.enum { color: #82b089; }
-.content span.struct, .content a.struct, .block a.current.struct { color: #2dbfb8; }
-.content span.type, .content a.type, .block a.current.type { color: #ff7f00; }
-.content span.foreigntype, .content a.foreigntype, .block a.current.foreigntype { color: #dd7de8; }
+.content span.enum, .content a.enum, .block a.current.enum { color: #83b28a; }
+.content span.struct, .content a.struct, .block a.current.struct { color: #cf86ba; }
+.content span.type, .content a.type, .block a.current.type { color: #ff8f1f; }
+.content span.foreigntype, .content a.foreigntype, .block a.current.foreigntype { color: #ee47ff; }
 .content span.attr, .content a.attr, .block a.current.attr,
 .content span.derive, .content a.derive, .block a.current.derive,
-.content span.macro, .content a.macro, .block a.current.macro { color: #09bd00; }
-.content span.union, .content a.union, .block a.current.union { color: #a6ae37; }
+.content span.macro, .content a.macro, .block a.current.macro { color: #0be400; }
+.content span.union, .content a.union, .block a.current.union { color: #bcc343; }
 .content span.constant, .content a.constant, .block a.current.constant,
-.content span.static, .content a.static, .block a.current.static { color: #82a5c9; }
-.content span.primitive, .content a.primitive, .block a.current.primitive { color: #43aec7; }
+.content span.static, .content a.static, .block a.current.static { color: #8aa0b8; }
+.content span.primitive, .content a.primitive, .block a.current.primitive { color: #57b7cd; }
 .content span.externcrate,
-.content span.mod, .content a.mod, .block a.current.mod { color: #bda000; }
-.content span.trait, .content a.trait, .block a.current.trait { color: #b78cf2; }
+.content span.mod, .content a.mod, .block a.current.mod { color: #91abce; }
+.content span.trait, .content a.trait, .block a.current.trait { color: #c6b7fa; }
 .content span.fn, .content a.fn, .block a.current.fn,
 .content span.method, .content a.method, .block a.current.method,
 .content span.tymethod, .content a.tymethod, .block a.current.tymethod,
-.content .fnname{ color: #2BAB63; }
-.content span.keyword, .content a.keyword, .block a.current.keyword { color: #de5249; }
+.content .fnname { color: #cda062; }
+.content span.keyword, .content a.keyword, .block a.current.keyword { color: #eda29d; }
 
 pre.rust .comment { color: #8d8d8b; }
 pre.rust .doccomment { color: #8ca375; }
@@ -169,7 +167,7 @@ a {
 
 .docblock:not(.type-decl) a:not(.srclink):not(.test-arrow),
 .docblock-short a:not(.srclink):not(.test-arrow), .stability a {
-	color: #D2991D;
+	color: #76a5d3;
 }
 
 a.test-arrow {

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -10,6 +10,8 @@
  * except according to those terms.
  */
 
+/* General structure and fonts */
+
 body {
 	background-color: #353535;
 	color: #ddd;

--- a/src/librustdoc/html/static/themes/light.css
+++ b/src/librustdoc/html/static/themes/light.css
@@ -27,10 +27,6 @@ h2, h3:not(.impl):not(.method):not(.type):not(.tymethod), h4:not(.method):not(.t
 	border-bottom-color: #DDDDDD;
 }
 
-.in-band {
-	background-color: white;
-}
-
 .invisible {
 	background: rgba(0, 0, 0, 0);
 }


### PR DESCRIPTION
This PR combines a handful of changes — I’ll happily split them if asked.

The changes:

* Adjust the lightness of the dark theme to mark the contrast in the light theme. This affects the sidebar color, but especially the borders, which are quite subtle in the light theme but not so in the dark theme.

* Adjust the colors of the dark theme to match the colors of the light theme. Links are now blue in both themes, and the entity types have the same colors in both themes.

**DEMO:** [old](https://ddfreyne.github.io/cargo-dark-theme-examples/old/csv/) — [new](https://ddfreyne.github.io/cargo-dark-theme-examples/new/csv/) ⬅️ 

* * *

For reference, this is what the light theme currently looks like:

![light-a](https://user-images.githubusercontent.com/6269/48970518-62585f80-f00d-11e8-8ad1-0e5027ba20a5.png)
![light-b](https://user-images.githubusercontent.com/6269/48970519-62585f80-f00d-11e8-881e-aa9e2a61ddb6.png)
![light-c](https://user-images.githubusercontent.com/6269/48970520-62585f80-f00d-11e8-8600-ac2792d5e803.png)

* * *

Here is what the dark theme *currently* looks like:

![dark-a](https://user-images.githubusercontent.com/6269/48970535-74d29900-f00d-11e8-9dcd-159a7886add3.png)
![dark-b](https://user-images.githubusercontent.com/6269/48970536-74d29900-f00d-11e8-8096-56825e8eef6a.png)
![dark-c](https://user-images.githubusercontent.com/6269/48970537-74d29900-f00d-11e8-87da-4bcddc4ddf80.png)

* * *

Here is what the dark theme looks like *after the modifications*:
![dark-new-a](https://user-images.githubusercontent.com/6269/48970544-7f8d2e00-f00d-11e8-8f6e-1ff999a0097f.png)
![dark-new-b](https://user-images.githubusercontent.com/6269/48970545-8025c480-f00d-11e8-89fd-6255104d010f.png)
![dark-new-c](https://user-images.githubusercontent.com/6269/48970546-8025c480-f00d-11e8-93ee-ac6c2857b9a3.png)
