### PR TITLE
Revert "appveyor: Use VS2017 for all our images"

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,4 @@
 environment:
-  # This is required for at least an AArch64 compiler in one image, and is
-  # otherwise recommended by AppVeyor currently for seeing if it has any
-  # affect on our job times.
-  APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017 Preview
 
   # By default schannel checks revocation of certificates unlike some other SSL
   # backends, but we've historically had problems on CI where a revocation
@@ -91,6 +87,7 @@ environment:
     DIST_REQUIRE_ALL_TOOLS: 1
     DEPLOY: 1
     CI_JOB_NAME: dist-x86_64-msvc
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017 Preview
   - RUST_CONFIGURE_ARGS: >
       --build=i686-pc-windows-msvc
       --target=i586-pc-windows-msvc


### PR DESCRIPTION
This reverts commit 008e5dcbd55cd751717ffd35a51dd65cd40011d4 (#55935)

We suspect this causes the spurious failure in https://github.com/rust-lang/rust/pull/55906#issuecomment-441365922 and https://github.com/rust-lang/rust/pull/55915#issuecomment-441377543.

r? @alexcrichton 