### PR TITLE
read_c_str should call the AllocationExtra hooks

### DIFF
--- a/src/librustc/mir/interpret/allocation.rs
+++ b/src/librustc/mir/interpret/allocation.rs
@@ -172,10 +172,9 @@ impl<'tcx, Tag: Copy, Extra: AllocationExtra<Tag>> Allocation<Tag, Extra> {
         let offset = ptr.offset.bytes() as usize;
         match self.bytes[offset..].iter().position(|&c| c == 0) {
             Some(size) => {
-                let p1 = Size::from_bytes((size + 1) as u64);
-                self.check_relocations(cx, ptr, p1)?;
-                self.check_defined(ptr, p1)?;
-                Ok(&self.bytes[offset..offset + size])
+                let size = Size::from_bytes((size + 1) as u64);
+                // Go through `get_bytes` for checks and AllocationExtra hooks
+                self.get_bytes(cx, ptr, size)
             }
             None => err!(UnterminatedCString(ptr.erase_tag())),
         }

--- a/src/librustc/mir/interpret/allocation.rs
+++ b/src/librustc/mir/interpret/allocation.rs
@@ -174,7 +174,7 @@ impl<'tcx, Tag: Copy, Extra: AllocationExtra<Tag>> Allocation<Tag, Extra> {
             Some(size) => {
                 let size_with_null = Size::from_bytes((size + 1) as u64);
                 // Go through `get_bytes` for checks and AllocationExtra hooks.
-                // We read the null, so we include it in the requestm, but we want it removed
+                // We read the null, so we include it in the request, but we want it removed
                 // from the result!
                 Ok(&self.get_bytes(cx, ptr, size_with_null)?[..size])
             }

--- a/src/librustc/mir/interpret/allocation.rs
+++ b/src/librustc/mir/interpret/allocation.rs
@@ -172,9 +172,11 @@ impl<'tcx, Tag: Copy, Extra: AllocationExtra<Tag>> Allocation<Tag, Extra> {
         let offset = ptr.offset.bytes() as usize;
         match self.bytes[offset..].iter().position(|&c| c == 0) {
             Some(size) => {
-                let size = Size::from_bytes((size + 1) as u64);
-                // Go through `get_bytes` for checks and AllocationExtra hooks
-                self.get_bytes(cx, ptr, size)
+                let size_with_null = Size::from_bytes((size + 1) as u64);
+                // Go through `get_bytes` for checks and AllocationExtra hooks.
+                // We read the null, so we include it in the requestm, but we want it removed
+                // from the result!
+                Ok(&self.get_bytes(cx, ptr, size_with_null)?[..size])
             }
             None => err!(UnterminatedCString(ptr.erase_tag())),
         }

--- a/src/librustc/mir/interpret/allocation.rs
+++ b/src/librustc/mir/interpret/allocation.rs
@@ -314,11 +314,9 @@ impl<'tcx, Tag: Copy, Extra: AllocationExtra<Tag>> Allocation<Tag, Extra> {
             },
         };
 
-        {
-            let endian = cx.data_layout().endian;
-            let dst = self.get_bytes_mut(cx, ptr, type_size)?;
-            write_target_uint(endian, dst, bytes).unwrap();
-        }
+        let endian = cx.data_layout().endian;
+        let dst = self.get_bytes_mut(cx, ptr, type_size)?;
+        write_target_uint(endian, dst, bytes).unwrap();
 
         // See if we have to also write a relocation
         match val {


### PR DESCRIPTION
I just hope we do not have other methods that bypass `get_bytes`/`get_bytes_mut`... (looking over the file, I could not find any)

r? @oli-obk 