### PR TITLE
Add grammar in docs for {f32,f64}::from_str, mention known bug.

### DIFF
--- a/src/libcore/num/dec2flt/mod.rs
+++ b/src/libcore/num/dec2flt/mod.rs
@@ -146,8 +146,8 @@ macro_rules! from_str_float_impl {
             ///
             /// # Known bugs
             ///
-            /// * [#31407]: Some strings that adhere to the regular expression
-            ///   above will incorrectly return an [`Err`].
+            /// In some situations, some strings that should create a valid float
+            /// instead return an error. See [issue #31407] for details.
             ///
             /// [#31407]: https://github.com/rust-lang/rust/issues/31407
             ///

--- a/src/libcore/num/dec2flt/mod.rs
+++ b/src/libcore/num/dec2flt/mod.rs
@@ -122,10 +122,34 @@ macro_rules! from_str_float_impl {
             /// * '2.5E10', or equivalently, '2.5e10'
             /// * '2.5E-10'
             /// * '5.'
-            /// * '.5', or, equivalently,  '0.5'
+            /// * '.5', or, equivalently, '0.5'
             /// * 'inf', '-inf', 'NaN'
             ///
             /// Leading and trailing whitespace represent an error.
+            ///
+            /// # Grammar
+            ///
+            /// All strings that adhere to the following regular expression
+            /// will result in an [`Ok`] being returned:
+            ///
+            /// ```txt
+            /// (\+|-)?
+            /// (inf|
+            ///  NaN|
+            ///  ([0-9]+|
+            ///   [0-9]+\.[0-9]*|
+            ///   [0-9]*\.[0-9]+)
+            ///  ((e|E)
+            ///   (\+|-)?
+            ///   [0-9]+)?)
+            /// ```
+            ///
+            /// # Known bugs
+            ///
+            /// * [#31407]: Some strings that adhere to the regular expression
+            ///   above will incorrectly return an [`Err`].
+            ///
+            /// [#31407]: https://github.com/rust-lang/rust/issues/31407
             ///
             /// # Arguments
             ///

--- a/src/libcore/num/dec2flt/mod.rs
+++ b/src/libcore/num/dec2flt/mod.rs
@@ -129,19 +129,17 @@ macro_rules! from_str_float_impl {
             ///
             /// # Grammar
             ///
-            /// All strings that adhere to the following regular expression
+            /// All strings that adhere to the following EBNF grammar
             /// will result in an [`Ok`] being returned:
             ///
             /// ```txt
-            /// (\+|-)?
-            /// (inf|
-            ///  NaN|
-            ///  ([0-9]+|
-            ///   [0-9]+\.[0-9]*|
-            ///   [0-9]*\.[0-9]+)
-            ///  ((e|E)
-            ///   (\+|-)?
-            ///   [0-9]+)?)
+            /// Float  ::= Sign? ( 'inf' | 'NaN' | Number )
+            /// Number ::= ( Digit+ |
+            ///              Digit+ '.' Digit* |
+            ///              Digit* '.' Digit+ ) Exp?
+            /// Exp    ::= [eE] Sign? Digit+
+            /// Sign   ::= [+-]
+            /// Digit  ::= [0-9]
             /// ```
             ///
             /// # Known bugs

--- a/src/libcore/num/dec2flt/mod.rs
+++ b/src/libcore/num/dec2flt/mod.rs
@@ -129,8 +129,6 @@ macro_rules! from_str_float_impl {
             ///
             /// # Grammar
             ///
-            /// [EBNF]: https://www.w3.org/TR/REC-xml/#sec-notation
-            ///
             /// All strings that adhere to the following [EBNF] grammar
             /// will result in an [`Ok`] being returned:
             ///
@@ -143,6 +141,8 @@ macro_rules! from_str_float_impl {
             /// Sign   ::= [+-]
             /// Digit  ::= [0-9]
             /// ```
+            ///
+            /// [EBNF]: https://www.w3.org/TR/REC-xml/#sec-notation
             ///
             /// # Known bugs
             ///

--- a/src/libcore/num/dec2flt/mod.rs
+++ b/src/libcore/num/dec2flt/mod.rs
@@ -149,7 +149,7 @@ macro_rules! from_str_float_impl {
             /// In some situations, some strings that should create a valid float
             /// instead return an error. See [issue #31407] for details.
             ///
-            /// [#31407]: https://github.com/rust-lang/rust/issues/31407
+            /// [issue #31407]: https://github.com/rust-lang/rust/issues/31407
             ///
             /// # Arguments
             ///

--- a/src/libcore/num/dec2flt/mod.rs
+++ b/src/libcore/num/dec2flt/mod.rs
@@ -129,7 +129,9 @@ macro_rules! from_str_float_impl {
             ///
             /// # Grammar
             ///
-            /// All strings that adhere to the following EBNF grammar
+            /// [EBNF]: https://www.w3.org/TR/REC-xml/#sec-notation
+            ///
+            /// All strings that adhere to the following [EBNF] grammar
             /// will result in an [`Ok`] being returned:
             ///
             /// ```txt


### PR DESCRIPTION
- Original bug about documenting grammar
  - https://github.com/rust-lang/rust/issues/32243
- Known bug with parsing
  - https://github.com/rust-lang/rust/issues/31407