### PR TITLE
Miri and miri-related code contains repetitions of `(n << amt) >> amt`

### DIFF
--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -21,6 +21,8 @@ use syntax::source_map;
 
 use rustc::hir;
 
+use rustc::mir::interpret::{sign_extend, truncate};
+
 declare_lint! {
     UNUSED_COMPARISONS,
     Warn,
@@ -368,14 +370,14 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TypeLimits {
             let (t, actually) = match ty {
                 ty::Int(t) => {
                     let ity = attr::IntType::SignedInt(t);
-                    let bits = layout::Integer::from_attr(&cx.tcx, ity).size().bits();
-                    let actually = (val << (128 - bits)) as i128 >> (128 - bits);
+                    let size = layout::Integer::from_attr(&cx.tcx, ity).size();
+                    let actually = sign_extend(val, size);
                     (format!("{:?}", t), actually.to_string())
                 }
                 ty::Uint(t) => {
                     let ity = attr::IntType::UnsignedInt(t);
-                    let bits = layout::Integer::from_attr(&cx.tcx, ity).size().bits();
-                    let actually = (val << (128 - bits)) >> (128 - bits);
+                    let size = layout::Integer::from_attr(&cx.tcx, ity).size();
+                    let actually = truncate(val, size);
                     (format!("{:?}", t), actually.to_string())
                 }
                 _ => bug!(),

--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -371,7 +371,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TypeLimits {
                 ty::Int(t) => {
                     let ity = attr::IntType::SignedInt(t);
                     let size = layout::Integer::from_attr(&cx.tcx, ity).size();
-                    let actually = sign_extend(val, size);
+                    let actually = sign_extend(val, size) as i128;
                     (format!("{:?}", t), actually.to_string())
                 }
                 ty::Uint(t) => {


### PR DESCRIPTION
I reduced some code repetitions contains `(n << amt) >> amt`.
This pull request is related to #49937.

