### PR TITLE
Introduce ptr::hash for references

### DIFF
--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -2532,7 +2532,7 @@ pub fn eq<T: ?Sized>(a: *const T, b: *const T) -> bool {
 ///
 /// assert_eq!(actual, expected);
 /// ```
-#[unstable(feature = "ptr_hash", reason = "newly added", issue = "56285")]
+#[unstable(feature = "ptr_hash", reason = "newly added", issue = "56286")]
 pub fn hash<T, S: hash::Hasher>(hashee: &T, into: &mut S) {
     use hash::Hash;
     NonNull::from(hashee).hash(into)

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -2534,7 +2534,7 @@ pub fn eq<T: ?Sized>(a: *const T, b: *const T) -> bool {
 /// assert_eq!(actual, expected);
 /// ```
 #[unstable(feature = "ptr_hash", reason = "newly added", issue = "56286")]
-pub fn hash<T, S: hash::Hasher>(hashee: &T, into: &mut S) {
+pub fn hash<T, S: hash::Hasher>(hashee: *const T, into: &mut S) {
     use hash::Hash;
     NonNull::from(hashee).hash(into)
 }

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -2526,7 +2526,7 @@ pub fn eq<T: ?Sized>(a: *const T, b: *const T) -> bool {
 /// ptr::hash(five_ref, hasher);
 /// println!("Hash is {:x}!", hasher.finish());
 /// ```
-#[stable(feature = "rust1", since = "1.0.0")] // TODO: replace with ???
+#[stable(feature = "rust1", since = "1.0.0")] // FIXME: replace with ???
 pub fn hash<T, S: hash::Hasher>(a: &T, into: &mut S) {
     use hash::Hash;
     NonNull::from(a).hash(into)

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -2527,9 +2527,9 @@ pub fn eq<T: ?Sized>(a: *const T, b: *const T) -> bool {
 /// println!("Hash is {:x}!", hasher.finish());
 /// ```
 #[unstable(feature = "ptr_hash", reason = "newly added", issue = "56285")]
-pub fn hash<T, S: hash::Hasher>(a: &T, into: &mut S) {
+pub fn hash<T, S: hash::Hasher>(hashee: &T, into: &mut S) {
     use hash::Hash;
-    NonNull::from(a).hash(into)
+    NonNull::from(hashee).hash(into)
 }
 
 // Impls for function pointers

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -2523,7 +2523,7 @@ pub fn eq<T: ?Sized>(a: *const T, b: *const T) -> bool {
 /// let five_ref = &five;
 ///
 /// let mut hasher = DefaultHasher::new();
-/// ptr::hash(five_ref, hasher);
+/// ptr::hash(five_ref, &mut hasher);
 /// println!("Hash is {:x}!", hasher.finish());
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")] // FIXME: replace with ???

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -2516,18 +2516,19 @@ pub fn eq<T: ?Sized>(a: *const T, b: *const T) -> bool {
 ///
 /// ```
 /// use std::collections::hash_map::DefaultHasher;
-/// use std::hash::Hasher;
+/// use std::hash::{Hash, Hasher};
 /// use std::ptr;
 ///
 /// let five = 5;
 /// let five_ref = &five;
 ///
 /// let mut hasher = DefaultHasher::new();
+/// #[feature(ptr_hash)]
 /// ptr::hash(five_ref, &mut hasher);
 /// let actual = hasher.finish();
 ///
 /// let mut hasher = DefaultHasher::new();
-/// (five_ref as *const T).hash(&mut hasher);
+/// (five_ref as *const i32).hash(&mut hasher);
 /// let expected = hasher.finish();
 ///
 /// assert_eq!(actual, expected);

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -2515,6 +2515,7 @@ pub fn eq<T: ?Sized>(a: *const T, b: *const T) -> bool {
 /// # Examples
 ///
 /// ```
+/// #![feature(ptr_hash)]
 /// use std::collections::hash_map::DefaultHasher;
 /// use std::hash::{Hash, Hasher};
 /// use std::ptr;
@@ -2523,7 +2524,6 @@ pub fn eq<T: ?Sized>(a: *const T, b: *const T) -> bool {
 /// let five_ref = &five;
 ///
 /// let mut hasher = DefaultHasher::new();
-/// #[feature(ptr_hash)]
 /// ptr::hash(five_ref, &mut hasher);
 /// let actual = hasher.finish();
 ///

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -2526,7 +2526,7 @@ pub fn eq<T: ?Sized>(a: *const T, b: *const T) -> bool {
 /// ptr::hash(five_ref, &mut hasher);
 /// println!("Hash is {:x}!", hasher.finish());
 /// ```
-#[stable(feature = "rust1", since = "1.0.0")] // FIXME: replace with ???
+#[unstable(feature = "ptr_hash", reason = "newly added", issue = "56285")]
 pub fn hash<T, S: hash::Hasher>(a: &T, into: &mut S) {
     use hash::Hash;
     NonNull::from(a).hash(into)

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -2524,7 +2524,13 @@ pub fn eq<T: ?Sized>(a: *const T, b: *const T) -> bool {
 ///
 /// let mut hasher = DefaultHasher::new();
 /// ptr::hash(five_ref, &mut hasher);
-/// println!("Hash is {:x}!", hasher.finish());
+/// let actual = hasher.finish();
+///
+/// let mut hasher = DefaultHasher::new();
+/// (five_ref as *const T).hash(&mut hasher);
+/// let expected = hasher.finish();
+///
+/// assert_eq!(actual, expected);
 /// ```
 #[unstable(feature = "ptr_hash", reason = "newly added", issue = "56285")]
 pub fn hash<T, S: hash::Hasher>(hashee: &T, into: &mut S) {

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -2536,7 +2536,7 @@ pub fn eq<T: ?Sized>(a: *const T, b: *const T) -> bool {
 #[unstable(feature = "ptr_hash", reason = "newly added", issue = "56286")]
 pub fn hash<T, S: hash::Hasher>(hashee: *const T, into: &mut S) {
     use hash::Hash;
-    NonNull::from(hashee).hash(into)
+    hashee.hash(into);
 }
 
 // Impls for function pointers

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -2509,6 +2509,29 @@ pub fn eq<T: ?Sized>(a: *const T, b: *const T) -> bool {
     a == b
 }
 
+/// Hash the raw pointer address behind a reference, rather than the value
+/// it points to.
+///
+/// # Examples
+///
+/// ```
+/// use std::collections::hash_map::DefaultHasher;
+/// use std::hash::Hasher;
+/// use std::ptr;
+///
+/// let five = 5;
+/// let five_ref = &five;
+///
+/// let mut hasher = DefaultHasher::new();
+/// ptr::hash(five_ref, hasher);
+/// println!("Hash is {:x}!", hasher.finish());
+/// ```
+#[stable(feature = "rust1", since = "1.0.0")] // TODO: replace with ???
+pub fn hash<T, S: hash::Hasher>(a: &T, into: &mut S) {
+    use hash::Hash;
+    NonNull::from(a).hash(into)
+}
+
 // Impls for function pointers
 macro_rules! fnptr_impls_safety_abi {
     ($FnTy: ty, $($Arg: ident),*) => {


### PR DESCRIPTION
The RHS is what I used, which wasn't as convenient as `ptr::eq`, so I wondered: should `ptr::hash` exist?

My first Rust PR, so I'm going to need some guidance. :)