### PR TITLE
use top level `fs` functions where appropriate

### DIFF
--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -15,8 +15,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::env;
-use std::fs::{self, File};
-use std::io::prelude::*;
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::process;
 use std::cmp;
@@ -416,9 +415,7 @@ impl Config {
         config.run_host_only = !(flags.host.is_empty() && !flags.target.is_empty());
 
         let toml = file.map(|file| {
-            let mut f = t!(File::open(&file));
-            let mut contents = String::new();
-            t!(f.read_to_string(&mut contents));
+            let contents = t!(fs::read_to_string(&file));
             match toml::from_str(&contents) {
                 Ok(table) => table,
                 Err(err) => {

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -19,8 +19,8 @@
 //! pieces of `rustup.rs`!
 
 use std::env;
-use std::fs::{self, File};
-use std::io::{Read, Write};
+use std::fs;
+use std::io::Write;
 use std::path::{PathBuf, Path};
 use std::process::{Command, Stdio};
 
@@ -1511,8 +1511,7 @@ impl Step for Extended {
         }
 
         let xform = |p: &Path| {
-            let mut contents = String::new();
-            t!(t!(File::open(p)).read_to_string(&mut contents));
+            let mut contents = t!(fs::read_to_string(p));
             if rls_installer.is_none() {
                 contents = filter(&contents, "rls");
             }
@@ -1523,8 +1522,8 @@ impl Step for Extended {
                 contents = filter(&contents, "rustfmt");
             }
             let ret = tmp.join(p.file_name().unwrap());
-            t!(t!(File::create(&ret)).write_all(contents.as_bytes()));
-            return ret
+            t!(fs::write(&ret, &contents));
+            ret
         };
 
         if target.contains("apple-darwin") {
@@ -1869,8 +1868,7 @@ impl Step for HashSign {
         let file = builder.config.dist_gpg_password_file.as_ref().unwrap_or_else(|| {
             panic!("\n\nfailed to specify `dist.gpg-password-file` in `config.toml`\n\n")
         });
-        let mut pass = String::new();
-        t!(t!(File::open(&file)).read_to_string(&mut pass));
+        let pass = t!(fs::read_to_string(&file));
 
         let today = output(Command::new("date").arg("+%Y-%m-%d"));
 

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -18,8 +18,7 @@
 //! `rustdoc`.
 
 use std::collections::HashSet;
-use std::fs::{self, File};
-use std::io::prelude::*;
+use std::fs;
 use std::io;
 use std::path::{PathBuf, Path};
 
@@ -379,12 +378,11 @@ impl Step for Standalone {
         let version_info = out.join("version_info.html");
 
         if !builder.config.dry_run && !up_to_date(&version_input, &version_info) {
-            let mut info = String::new();
-            t!(t!(File::open(&version_input)).read_to_string(&mut info));
-            let info = info.replace("VERSION", &builder.rust_release())
-                           .replace("SHORT_HASH", builder.rust_info.sha_short().unwrap_or(""))
-                           .replace("STAMP", builder.rust_info.sha().unwrap_or(""));
-            t!(t!(File::create(&version_info)).write_all(info.as_bytes()));
+            let info = t!(fs::read_to_string(&version_input))
+                .replace("VERSION", &builder.rust_release())
+                .replace("SHORT_HASH", builder.rust_info.sha_short().unwrap_or(""))
+                .replace("STAMP", builder.rust_info.sha().unwrap_or(""));
+            t!(fs::write(&version_info, &info));
         }
 
         for file in t!(fs::read_dir(builder.src.join("src/doc"))) {

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -1067,9 +1067,8 @@ impl Build {
 
     /// Returns the `a.b.c` version that the given package is at.
     fn release_num(&self, package: &str) -> String {
-        let mut toml = String::new();
         let toml_file_name = self.src.join(&format!("src/tools/{}/Cargo.toml", package));
-        t!(t!(File::open(toml_file_name)).read_to_string(&mut toml));
+        let toml = t!(fs::read_to_string(&toml_file_name));
         for line in toml.lines() {
             let prefix = "version = \"";
             let suffix = "\"";
@@ -1151,8 +1150,7 @@ impl Build {
         }
 
         let mut paths = Vec::new();
-        let mut contents = Vec::new();
-        t!(t!(File::open(stamp)).read_to_end(&mut contents));
+        let contents = t!(fs::read(stamp));
         // This is the method we use for extracting paths from the stamp file passed to us. See
         // run_cargo for more information (in compile.rs).
         for part in contents.split(|b| *b == 0) {

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -21,7 +21,6 @@
 use std::env;
 use std::ffi::OsString;
 use std::fs::{self, File};
-use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -75,8 +74,7 @@ impl Step for Llvm {
         }
 
         let rebuild_trigger = builder.src.join("src/rustllvm/llvm-rebuild-trigger");
-        let mut rebuild_trigger_contents = String::new();
-        t!(t!(File::open(&rebuild_trigger)).read_to_string(&mut rebuild_trigger_contents));
+        let rebuild_trigger_contents = t!(fs::read_to_string(&rebuild_trigger));
 
         let (out_dir, llvm_config_ret_dir) = if emscripten {
             let dir = builder.emscripten_llvm_out(target);
@@ -93,8 +91,7 @@ impl Step for Llvm {
         let build_llvm_config = llvm_config_ret_dir
             .join(exe("llvm-config", &*builder.config.build));
         if done_stamp.exists() {
-            let mut done_contents = String::new();
-            t!(t!(File::open(&done_stamp)).read_to_string(&mut done_contents));
+            let done_contents = t!(fs::read_to_string(&done_stamp));
 
             // If LLVM was already built previously and contents of the rebuild-trigger file
             // didn't change from the previous build, then no action is required.
@@ -261,7 +258,7 @@ impl Step for Llvm {
 
         cfg.build();
 
-        t!(t!(File::create(&done_stamp)).write_all(rebuild_trigger_contents.as_bytes()));
+        t!(fs::write(&done_stamp, &rebuild_trigger_contents));
 
         build_llvm_config
     }

--- a/src/bootstrap/sanity.rs
+++ b/src/bootstrap/sanity.rs
@@ -21,8 +21,7 @@
 use std::collections::HashMap;
 use std::env;
 use std::ffi::{OsString, OsStr};
-use std::fs::{self, File};
-use std::io::Read;
+use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -235,9 +234,7 @@ $ pacman -R cmake && pacman -S mingw-w64-x86_64-cmake
     }
 
     if build.config.channel == "stable" {
-        let mut stage0 = String::new();
-        t!(t!(File::open(build.src.join("src/stage0.txt")))
-            .read_to_string(&mut stage0));
+        let stage0 = t!(fs::read_to_string(build.src.join("src/stage0.txt")));
         if stage0.contains("\ndev:") {
             panic!("bootstrapping from a dev compiler in a stable release, but \
                     should only be bootstrapping from a released compiler!");

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -16,8 +16,7 @@
 use std::env;
 use std::ffi::OsString;
 use std::fmt;
-use std::fs::{self, File};
-use std::io::Read;
+use std::fs;
 use std::iter;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -1427,10 +1426,8 @@ impl Step for ErrorIndex {
 }
 
 fn markdown_test(builder: &Builder, compiler: Compiler, markdown: &Path) -> bool {
-    match File::open(markdown) {
-        Ok(mut file) => {
-            let mut contents = String::new();
-            t!(file.read_to_string(&mut contents));
+    match fs::read_to_string(markdown) {
+        Ok(contents) => {
             if !contents.contains("```") {
                 return true;
             }

--- a/src/libcore/convert.rs
+++ b/src/libcore/convert.rs
@@ -327,7 +327,8 @@ pub trait Into<T>: Sized {
 /// An example usage for error handling:
 ///
 /// ```
-/// use std::io::{self, Read};
+/// use std::fs;
+/// use std::io;
 /// use std::num;
 ///
 /// enum CliError {
@@ -348,9 +349,7 @@ pub trait Into<T>: Sized {
 /// }
 ///
 /// fn open_and_parse_file(file_name: &str) -> Result<i32, CliError> {
-///     let mut file = std::fs::File::open("test")?;
-///     let mut contents = String::new();
-///     file.read_to_string(&mut contents)?;
+///     let mut contents = fs::read_to_string(&file_name)?;
 ///     let num: i32 = contents.trim().parse()?;
 ///     Ok(num)
 /// }

--- a/src/librustc/infer/lexical_region_resolve/graphviz.rs
+++ b/src/librustc/infer/lexical_region_resolve/graphviz.rs
@@ -31,9 +31,8 @@ use std::borrow::Cow;
 use std::collections::hash_map::Entry::Vacant;
 use std::collections::btree_map::BTreeMap;
 use std::env;
-use std::fs::File;
+use std::fs;
 use std::io;
-use std::io::prelude::*;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 fn print_help_message() {
@@ -268,5 +267,5 @@ fn dump_region_data_to<'a, 'gcx, 'tcx>(region_rels: &RegionRelations<'a, 'gcx, '
     debug!("dump_region_data calling render");
     let mut v = Vec::new();
     dot::render(&g, &mut v).unwrap();
-    File::create(path).and_then(|mut f| f.write_all(&v))
+    fs::write(path, &v)
 }

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -778,10 +778,7 @@ fn write_shared(
     let mut themes: FxHashSet<String> = FxHashSet::default();
 
     for entry in &cx.shared.themes {
-        let mut content = Vec::with_capacity(100000);
-
-        let mut f = try_err!(File::open(&entry), &entry);
-        try_err!(f.read_to_end(&mut content), &entry);
+        let content = try_err!(fs::read(&entry), &entry);
         let theme = try_none!(try_none!(entry.file_stem(), &entry).to_str(), &entry);
         let extension = try_none!(try_none!(entry.extension(), &entry).to_str(), &entry);
         write(cx.dst.join(format!("{}{}.{}", theme, cx.shared.resource_suffix, extension)),
@@ -881,10 +878,7 @@ themePicker.onblur = handleThemeButtonsBlur;
         if !options.enable_minification {
             try_err!(fs::copy(css, out), css);
         } else {
-            let mut f = try_err!(File::open(css), css);
-            let mut buffer = String::with_capacity(1000);
-
-            try_err!(f.read_to_string(&mut buffer), css);
+            let buffer = try_err!(fs::read_to_string(css), css);
             write_minify(out, &buffer, options.enable_minification)?;
         }
     }
@@ -2102,8 +2096,7 @@ impl Context {
                 if !buf.is_empty() {
                     try_err!(this.shared.ensure_dir(&this.dst), &this.dst);
                     let joint_dst = this.dst.join("index.html");
-                    let mut dst = try_err!(File::create(&joint_dst), &joint_dst);
-                    try_err!(dst.write_all(&buf), &joint_dst);
+                    try_err!(fs::write(&joint_dst, buf), &joint_dst);
                 }
 
                 let m = match item.inner {
@@ -2137,8 +2130,7 @@ impl Context {
                 let file_name = &item_path(item_type, name);
                 try_err!(self.shared.ensure_dir(&self.dst), &self.dst);
                 let joint_dst = self.dst.join(file_name);
-                let mut dst = try_err!(File::create(&joint_dst), &joint_dst);
-                try_err!(dst.write_all(&buf), &joint_dst);
+                try_err!(fs::write(&joint_dst, buf), &joint_dst);
 
                 if !self.render_redirect_pages {
                     all.append(full_path(self, &item), &item_type);

--- a/src/librustdoc/theme.rs
+++ b/src/librustdoc/theme.rs
@@ -9,9 +9,8 @@
 // except according to those terms.
 
 use rustc_data_structures::fx::FxHashSet;
-use std::fs::File;
+use std::fs;
 use std::hash::{Hash, Hasher};
-use std::io::Read;
 use std::path::Path;
 
 use errors::Handler;
@@ -278,12 +277,9 @@ pub fn get_differences(against: &CssPath, other: &CssPath, v: &mut Vec<String>) 
 pub fn test_theme_against<P: AsRef<Path>>(f: &P, against: &CssPath, diag: &Handler)
     -> (bool, Vec<String>)
 {
-    let mut file = try_something!(File::open(f), diag, (false, Vec::new()));
-    let mut data = Vec::with_capacity(1000);
-
-    try_something!(file.read_to_end(&mut data), diag, (false, Vec::new()));
+    let data = try_something!(fs::read(f), diag, (false, vec![]));
     let paths = load_css_paths(&data);
-    let mut ret = Vec::new();
+    let mut ret = vec![];
     get_differences(against, &paths, &mut ret);
     (true, ret)
 }

--- a/src/libsyntax/ext/source_util.rs
+++ b/src/libsyntax/ext/source_util.rs
@@ -21,8 +21,8 @@ use smallvec::SmallVec;
 use symbol::Symbol;
 use tokenstream;
 
-use std::fs::File;
-use std::io::prelude::*;
+use std::fs;
+use std::io::ErrorKind;
 use std::path::PathBuf;
 use rustc_data_structures::sync::Lrc;
 
@@ -137,18 +137,7 @@ pub fn expand_include_str(cx: &mut ExtCtxt, sp: Span, tts: &[tokenstream::TokenT
         None => return DummyResult::expr(sp)
     };
     let file = res_rel_file(cx, sp, file);
-    let mut bytes = Vec::new();
-    match File::open(&file).and_then(|mut f| f.read_to_end(&mut bytes)) {
-        Ok(..) => {}
-        Err(e) => {
-            cx.span_err(sp,
-                        &format!("couldn't read {}: {}",
-                                file.display(),
-                                e));
-            return DummyResult::expr(sp);
-        }
-    };
-    match String::from_utf8(bytes) {
+    match fs::read_to_string(&file) {
         Ok(src) => {
             let interned_src = Symbol::intern(&src);
 
@@ -157,11 +146,13 @@ pub fn expand_include_str(cx: &mut ExtCtxt, sp: Span, tts: &[tokenstream::TokenT
             cx.source_map().new_source_file(file.into(), src);
 
             base::MacEager::expr(cx.expr_str(sp, interned_src))
+        },
+        Err(ref e) if e.kind() == ErrorKind::InvalidData => {
+            cx.span_err(sp, &format!("{} wasn't a utf-8 file", file.display()));
+            DummyResult::expr(sp)
         }
-        Err(_) => {
-            cx.span_err(sp,
-                        &format!("{} wasn't a utf-8 file",
-                                file.display()));
+        Err(e) => {
+            cx.span_err(sp, &format!("couldn't read {}: {}", file.display(), e));
             DummyResult::expr(sp)
         }
     }
@@ -174,22 +165,23 @@ pub fn expand_include_bytes(cx: &mut ExtCtxt, sp: Span, tts: &[tokenstream::Toke
         None => return DummyResult::expr(sp)
     };
     let file = res_rel_file(cx, sp, file);
-    let mut bytes = Vec::new();
-    match File::open(&file).and_then(|mut f| f.read_to_end(&mut bytes)) {
-        Err(e) => {
-            cx.span_err(sp,
-                        &format!("couldn't read {}: {}", file.display(), e));
-            DummyResult::expr(sp)
-        }
-        Ok(..) => {
-            let src = match String::from_utf8(bytes.clone()) {
-                Ok(contents) => contents,
-                Err(..) => "".to_string()
+    match fs::read(&file) {
+        Ok(bytes) => {
+            // Add the contents to the source map if it contains UTF-8.
+            let (contents, bytes) = match String::from_utf8(bytes) {
+                Ok(s) => {
+                    let bytes = s.as_bytes().to_owned();
+                    (s, bytes)
+                },
+                Err(e) => (String::new(), e.into_bytes()),
             };
-
-            cx.source_map().new_source_file(file.into(), src);
+            cx.source_map().new_source_file(file.into(), contents);
 
             base::MacEager::expr(cx.expr_lit(sp, ast::LitKind::ByteStr(Lrc::new(bytes))))
+        },
+        Err(e) => {
+            cx.span_err(sp, &format!("couldn't read {}: {}", file.display(), e));
+            DummyResult::expr(sp)
         }
     }
 }

--- a/src/libsyntax/source_map.rs
+++ b/src/libsyntax/source_map.rs
@@ -31,7 +31,7 @@ use std::path::{Path, PathBuf};
 
 use std::env;
 use std::fs;
-use std::io::{self, Read};
+use std::io;
 use errors::SourceMapper;
 
 /// Return the span itself if it doesn't come from a macro expansion,
@@ -96,9 +96,7 @@ impl FileLoader for RealFileLoader {
     }
 
     fn read_file(&self, path: &Path) -> io::Result<String> {
-        let mut src = String::new();
-        fs::File::open(path)?.read_to_string(&mut src)?;
-        Ok(src)
+        fs::read_to_string(path)
     }
 }
 

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -606,7 +606,7 @@ impl Builder {
 
         let filename = path.file_name().unwrap().to_str().unwrap();
         let sha256 = self.output.join(format!("{}.sha256", filename));
-        t!(t!(File::create(&sha256)).write_all(&sha.stdout));
+        t!(fs::write(&sha256, &sha.stdout));
 
         let stdout = String::from_utf8_lossy(&sha.stdout);
         stdout.split_whitespace().next().unwrap().to_string()
@@ -643,7 +643,7 @@ impl Builder {
 
     fn write(&self, contents: &str, channel_name: &str, suffix: &str) {
         let dst = self.output.join(format!("channel-rust-{}{}", channel_name, suffix));
-        t!(t!(File::create(&dst)).write_all(contents.as_bytes()));
+        t!(fs::write(&dst, contents));
         self.hash(&dst);
         self.sign(&dst);
     }

--- a/src/tools/cargotest/main.rs
+++ b/src/tools/cargotest/main.rs
@@ -11,8 +11,7 @@
 use std::env;
 use std::process::Command;
 use std::path::{Path, PathBuf};
-use std::fs::File;
-use std::io::Write;
+use std::fs;
 
 struct Test {
     repo: &'static str,
@@ -91,10 +90,7 @@ fn test_repo(cargo: &Path, out_dir: &Path, test: &Test) {
     println!("testing {}", test.repo);
     let dir = clone_repo(test, out_dir);
     if let Some(lockfile) = test.lock {
-        File::create(&dir.join("Cargo.lock"))
-            .expect("")
-            .write_all(lockfile.as_bytes())
-            .expect("");
+        fs::write(&dir.join("Cargo.lock"), lockfile).unwrap();
     }
     if !run_cargo_test(cargo, &dir, test.packages) {
         panic!("tests failed for {}", test.repo);

--- a/src/tools/error_index_generator/main.rs
+++ b/src/tools/error_index_generator/main.rs
@@ -18,8 +18,8 @@ extern crate serialize as rustc_serialize;
 use std::collections::BTreeMap;
 use std::env;
 use std::error::Error;
-use std::fs::{read_dir, File};
-use std::io::{Read, Write};
+use std::fs::{self, read_dir, File};
+use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
 use std::cell::RefCell;
@@ -210,8 +210,7 @@ fn load_all_errors(metadata_dir: &Path) -> Result<ErrorMetadataMap, Box<dyn Erro
     for entry in read_dir(metadata_dir)? {
         let path = entry?.path();
 
-        let mut metadata_str = String::new();
-        File::open(&path).and_then(|mut f| f.read_to_string(&mut metadata_str))?;
+        let metadata_str = fs::read_to_string(&path)?;
 
         let some_errors: ErrorMetadataMap = json::decode(&metadata_str)?;
 

--- a/src/tools/tidy/src/bins.rs
+++ b/src/tools/tidy/src/bins.rs
@@ -24,13 +24,10 @@ pub fn check(_path: &Path, _bad: &mut bool) {}
 #[cfg(unix)]
 pub fn check(path: &Path, bad: &mut bool) {
     use std::fs;
-    use std::io::Read;
     use std::process::{Command, Stdio};
     use std::os::unix::prelude::*;
 
-    if let Ok(mut file) = fs::File::open("/proc/version") {
-        let mut contents = String::new();
-        file.read_to_string(&mut contents).unwrap();
+    if let Ok(contents) = fs::read_to_string("/proc/version") {
         // Probably on Windows Linux Subsystem or Docker via VirtualBox,
         // all files will be marked as executable, so skip checking.
         if contents.contains("Microsoft") || contents.contains("boot2docker") {

--- a/src/tools/tidy/src/cargo.rs
+++ b/src/tools/tidy/src/cargo.rs
@@ -15,8 +15,7 @@
 //! `extern crate` declarations. This should help us keep the DAG correctly
 //! structured through various refactorings to prune out unnecessary edges.
 
-use std::io::prelude::*;
-use std::fs::File;
+use std::fs;
 use std::path::Path;
 
 pub fn check(path: &Path, bad: &mut bool) {
@@ -41,10 +40,8 @@ pub fn check(path: &Path, bad: &mut bool) {
 // Verify that the dependencies in Cargo.toml at `tomlfile` are sync'd with the
 // `extern crate` annotations in the lib.rs at `libfile`.
 fn verify(tomlfile: &Path, libfile: &Path, bad: &mut bool) {
-    let mut toml = String::new();
-    let mut librs = String::new();
-    t!(t!(File::open(tomlfile)).read_to_string(&mut toml));
-    t!(t!(File::open(libfile)).read_to_string(&mut librs));
+    let toml = t!(fs::read_to_string(&tomlfile));
+    let librs = t!(fs::read_to_string(&libfile));
 
     if toml.contains("name = \"bootstrap\"") {
         return

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -11,8 +11,7 @@
 //! Check license of third-party deps by inspecting vendor
 
 use std::collections::{BTreeSet, HashSet, HashMap};
-use std::fs::File;
-use std::io::Read;
+use std::fs;
 use std::path::Path;
 use std::process::Command;
 
@@ -262,8 +261,7 @@ fn check_license(path: &Path) -> bool {
     if !path.exists() {
         panic!("{} does not exist", path.display());
     }
-    let mut contents = String::new();
-    t!(t!(File::open(path)).read_to_string(&mut contents));
+    let contents = t!(fs::read_to_string(&path));
 
     let mut found_license = false;
     for line in contents.lines() {

--- a/src/tools/tidy/src/extdeps.rs
+++ b/src/tools/tidy/src/extdeps.rs
@@ -10,8 +10,7 @@
 
 // ! Check for external package sources. Allow only vendorable packages.
 
-use std::fs::File;
-use std::io::Read;
+use std::fs;
 use std::path::Path;
 
 /// List of whitelisted sources for packages
@@ -25,8 +24,7 @@ pub fn check(path: &Path, bad: &mut bool) {
     let path = path.join("../Cargo.lock");
 
     // open and read the whole file
-    let mut cargo_lock = String::new();
-    t!(t!(File::open(path)).read_to_string(&mut cargo_lock));
+    let cargo_lock = t!(fs::read_to_string(&path));
 
     // process each line
     for line in cargo_lock.lines() {

--- a/src/tools/tidy/src/features.rs
+++ b/src/tools/tidy/src/features.rs
@@ -20,7 +20,7 @@
 
 use std::collections::HashMap;
 use std::fmt;
-use std::fs::File;
+use std::fs::{self, File};
 use std::io::prelude::*;
 use std::path::Path;
 
@@ -183,9 +183,7 @@ fn test_filen_gate(filen_underscore: &str, features: &mut Features) -> bool {
 }
 
 pub fn collect_lang_features(base_src_path: &Path, bad: &mut bool) -> Features {
-    let mut contents = String::new();
-    let path = base_src_path.join("libsyntax/feature_gate.rs");
-    t!(t!(File::open(path)).read_to_string(&mut contents));
+    let contents = t!(fs::read_to_string(base_src_path.join("libsyntax/feature_gate.rs")));
 
     // we allow rustc-internal features to omit a tracking issue.
     // these features must be marked with `// rustc internal` in its own group.


### PR DESCRIPTION
This commit replaces many usages of `File::open` and reading or writing
with `fs::read_to_string`, `fs::read` and `fs::write`. This reduces code
complexity, and will improve performance for most reads, since the
functions allocate the buffer to be the size of the file.

I believe that this commit will not impact behavior in any way, so some
matches will check the error kind in case the file was not valid UTF-8.
Some of these cases may not actually care about the error.