### PR TITLE
resolve: Extern prelude is for type namespace only

### DIFF
--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -173,7 +173,9 @@ impl<'a, 'crateloader> Resolver<'a, 'crateloader> {
             }
             ModuleOrUniformRoot::ExternPrelude => {
                 assert!(!restricted_shadowing);
-                return if let Some(binding) = self.extern_prelude_get(ident, !record_used) {
+                return if ns != TypeNS {
+                    Err((Determined, Weak::No))
+                } else if let Some(binding) = self.extern_prelude_get(ident, !record_used) {
                     Ok(binding)
                 } else if !self.graph_root.unresolved_invocations.borrow().is_empty() {
                     // Macro-expanded `extern crate` items can add names to extern prelude.

--- a/src/test/ui/imports/issue-56263.rs
+++ b/src/test/ui/imports/issue-56263.rs
@@ -1,0 +1,8 @@
+// compile-pass
+// edition:2018
+
+use ::std;
+
+fn main() {
+    let std = 10;
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/56263 (stable-to-beta regression)