### PR TITLE
rustc_mir: try visit_local instead of visit_place in GatherBorrows.

### DIFF
--- a/src/librustc_mir/borrow_check/borrow_set.rs
+++ b/src/librustc_mir/borrow_check/borrow_set.rs
@@ -238,16 +238,14 @@ impl<'a, 'gcx, 'tcx> Visitor<'tcx> for GatherBorrows<'a, 'gcx, 'tcx> {
         self.super_assign(block, assigned_place, rvalue, location)
     }
 
-    fn visit_place(
+    fn visit_local(
         &mut self,
-        place: &mir::Place<'tcx>,
+        &local: &mir::Local,
         context: PlaceContext<'tcx>,
         location: Location,
     ) {
-        self.super_place(place, context, location);
-
         // We found a use of some temporary TEMP...
-        if let Place::Local(temp) = place {
+        if let Place::Local(temp) = &Place::Local(local) {
             // ... check whether we (earlier) saw a 2-phase borrow like
             //
             //     TMP = &mut place


### PR DESCRIPTION
I noticed a strange failure on a different branch and I've minimized it to this.

Is it possible NLL code is missing some locals, from `visit_place` being used instead of `visit_local`, to handle locals? AFAIK only indexing projections use locals outside of places
(`p[i]` where `p` is a `Place` but `i` is merely a `Local`).

cc @nikomatsakis @rust-lang/wg-compiler-nll 