### PR TITLE
Fix #56237: normalize type before deferred sizedness checking.

### DIFF
--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3970,7 +3970,13 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                         //
                         // to work in stable even if the Sized bound on `drop` is relaxed.
                         for i in 0..fn_sig.inputs().skip_binder().len() {
-                            let input = tcx.erase_late_bound_regions(&fn_sig.input(i));
+                            // We just want to check sizedness, so instead of introducing
+                            // placeholder lifetimes with probing, we just replace higher lifetimes
+                            // with fresh vars.
+                            let input = self.replace_bound_vars_with_fresh_vars(
+                                expr.span,
+                                infer::LateBoundRegionConversionTime::FnCall,
+                                &fn_sig.input(i)).0;
                             self.require_type_is_sized_deferred(input, expr.span,
                                                                 traits::SizedArgumentType);
                         }
@@ -3978,7 +3984,13 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                     // Here we want to prevent struct constructors from returning unsized types.
                     // There were two cases this happened: fn pointer coercion in stable
                     // and usual function call in presense of unsized_locals.
-                    let output = tcx.erase_late_bound_regions(&fn_sig.output());
+                    // Also, as we just want to check sizedness, instead of introducing
+                    // placeholder lifetimes with probing, we just replace higher lifetimes
+                    // with fresh vars.
+                    let output = self.replace_bound_vars_with_fresh_vars(
+                        expr.span,
+                        infer::LateBoundRegionConversionTime::FnCall,
+                        &fn_sig.output()).0;
                     self.require_type_is_sized_deferred(output, expr.span, traits::SizedReturnType);
                 }
 

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -914,6 +914,7 @@ fn typeck_tables_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         fcx.resolve_generator_interiors(def_id);
 
         for (ty, span, code) in fcx.deferred_sized_obligations.borrow_mut().drain(..) {
+            let ty = fcx.normalize_ty(span, ty);
             fcx.require_type_is_sized(ty, span, code);
         }
         fcx.select_all_obligations_or_error();

--- a/src/test/run-pass/issue-56237.rs
+++ b/src/test/run-pass/issue-56237.rs
@@ -1,0 +1,11 @@
+use std::ops::Deref;
+
+fn foo<P>(_value: <P as Deref>::Target)
+where
+    P: Deref,
+    <P as Deref>::Target: Sized,
+{}
+
+fn main() {
+    foo::<Box<u32>>(2);
+}


### PR DESCRIPTION
This seems to fix #56237, which was introduced by #56045. I don't thoroughly understand how this works, but the problem seemed to be a lack of normalization.

r? @cramertj