### PR TITLE
[do not merge] Benchmark ignoring span hashes during incr. comp. for getting a lower bound for #47389

### DIFF
--- a/src/librustc/ich/hcx.rs
+++ b/src/librustc/ich/hcx.rs
@@ -320,7 +320,7 @@ impl<'a> HashStable<StableHashingContext<'a>> for Span {
         const TAG_EXPANSION: u8 = 0;
         const TAG_NO_EXPANSION: u8 = 1;
 
-        if !hcx.hash_spans {
+        if !hcx.hash_spans || true {
             return
         }
 


### PR DESCRIPTION
I figured that ignoring changes to span values might give a useful lower bound on compile times with the optimizations described in #47389 applied. Keep in mind that any improvements shown with this PR could only be achieved if we could update object files in place, which would be the "stretch goal" for #47389.