### PR TITLE
Initial addition of the Embedded Rust Book

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -44,3 +44,6 @@
 	path = src/llvm-project
 	url = https://github.com/rust-lang/llvm-project.git
 	branch = rustc/8.0-2019-01-16
+[submodule "src/doc/embedded-book"]
+	path = src/doc/embedded-book
+	url = https://github.com/rust-embedded/book.git

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -430,6 +430,7 @@ impl<'a> Builder<'a> {
                 doc::RustByExample,
                 doc::RustcBook,
                 doc::CargoBook,
+                doc::EmbeddedBook,
                 doc::EditionGuide,
             ),
             Kind::Dist => describe!(

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -61,6 +61,7 @@ macro_rules! book {
 // adding a build step in `src/bootstrap/builder.rs`!
 book!(
     EditionGuide, "src/doc/edition-guide", "edition-guide", RustbookVersion::MdBook1;
+    EmbeddedBook, "src/doc/embedded-book", "embedded-book", RustbookVersion::MdBook2;
     Nomicon, "src/doc/nomicon", "nomicon", RustbookVersion::MdBook1;
     Reference, "src/doc/reference", "reference", RustbookVersion::MdBook1;
     RustByExample, "src/doc/rust-by-example", "rust-by-example", RustbookVersion::MdBook1;
@@ -71,10 +72,6 @@ book!(
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 enum RustbookVersion {
     MdBook1,
-
-    /// Note: Currently no books use mdBook v2, but we want the option
-    /// to be available
-    #[allow(dead_code)]
     MdBook2,
 }
 

--- a/src/ci/docker/x86_64-gnu-tools/checktools.sh
+++ b/src/ci/docker/x86_64-gnu-tools/checktools.sh
@@ -23,6 +23,7 @@ python2.7 "$X_PY" test --no-fail-fast \
     src/doc/nomicon \
     src/doc/reference \
     src/doc/rust-by-example \
+    src/doc/embedded-book \
     src/tools/clippy \
     src/tools/rls \
     src/tools/rustfmt \

--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -117,3 +117,19 @@ Rust. It's also sometimes called "the 'nomicon."
 [The `rustc` Guide](https://rust-lang.github.io/rustc-guide/) documents how
 the compiler works and how to contribute to it. This is useful if you want to build
 or modify the Rust compiler from source (e.g. to target something non-standard).
+
+# Specialize Rust
+
+When using Rust in specific domain areas, consider using the following resources tailored to each domain.
+
+## Embedded Systems
+
+When developing for Bare Metal or Embedded Linux systems, you may find these resources maintained by the [Embedded Working Group] useful.
+
+[Embedded Working Group]: https://github.com/rust-embedded
+
+### The Embedded Rust Book
+
+[The Embedded Rust Book] is targeted at developers familiar with embedded development and familiar with Rust, but have not used Rust for embedded development.
+
+[The Embedded Rust Book]: embedded-book/index.html


### PR DESCRIPTION
This PR adds the Embedded Rust Book to the bookshelf as a submodule, and adds text for the bookshelf page. I have added a new section after "Master Rust" called "Specialize Rust", with the plan that future domain WG books can also reside here. This now extends the titles down to H3, where formerly only H1 and H2 were used.

The added submodule tracks the master branch of the Embedded WG repo.

If there are additional steps necessary to make this work in CI (perhaps adding this to `src/ci/docker/x86_64-gnu-tools/checktools.sh:32` or so?), please let me know.

CC @steveklabnik @japaric 

Also CC issue https://github.com/rust-embedded/wg/issues/257
