### PR TITLE
fix futures creating aliasing mutable and shared ref

### DIFF
--- a/src/libstd/future.rs
+++ b/src/libstd/future.rs
@@ -95,10 +95,10 @@ where
     });
     let _reset_waker = SetOnDrop(waker_ptr);
 
-    let mut waker_ptr = waker_ptr.expect(
+    let waker_ptr = waker_ptr.expect(
         "TLS LocalWaker not set. This is a rustc bug. \
         Please file an issue on https://github.com/rust-lang/rust.");
-    unsafe { f(waker_ptr.as_mut()) }
+    unsafe { f(waker_ptr.as_ref()) }
 }
 
 #[unstable(feature = "gen_future", issue = "50547")]


### PR DESCRIPTION
Fixes the problem described in https://github.com/solson/miri/issues/532#issuecomment-442552764: `set_task_waker` takes a shared reference and puts a copy into the TLS (in a `NonNull`), but `get_task_waker` gets it back out as a mutable reference. That violates "mutable references must not alias anything"!