### PR TITLE
rustdoc: add bottom margin spacing to nested lists

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -121,7 +121,7 @@ ol, ul {
 	padding-left: 25px;
 }
 ul ul, ol ul, ul ol, ol ol {
-	margin-bottom: 0;
+	margin-bottom: .6em;
 }
 
 p {


### PR DESCRIPTION
the current CSS for nested lists sets margin-bottom to zero, which means that a nested list is squished up against subsequent list items/paragraphs

this changes the bottom margin to .6em, same as for paragraphs

before:
![before](https://user-images.githubusercontent.com/33935229/49176291-699ba800-f342-11e8-9d33-c4acd4df2beb.png)
after:
![after](https://user-images.githubusercontent.com/33935229/49176299-6f918900-f342-11e8-90c3-aa14db195b45.png)

