### PR TITLE
resolve: Fix false-positives from lint `absolute_paths_not_starting_with_crate`

### DIFF
--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -3950,7 +3950,7 @@ impl<'a, 'crateloader: 'a> Resolver<'a, 'crateloader> {
 
         let first_name = match path.get(0) {
             // In the 2018 edition this lint is a hard error, so nothing to do
-            Some(seg) if seg.ident.span.rust_2015() => seg.ident.name,
+            Some(seg) if seg.ident.span.rust_2015() && self.session.rust_2015() => seg.ident.name,
             _ => return,
         };
 

--- a/src/test/ui/rust-2018/auxiliary/edition-lint-paths.rs
+++ b/src/test/ui/rust-2018/auxiliary/edition-lint-paths.rs
@@ -9,3 +9,14 @@
 // except according to those terms.
 
 pub fn foo() {}
+
+#[macro_export]
+macro_rules! macro_2015 {
+    () => {
+        use edition_lint_paths as other_name;
+        use edition_lint_paths::foo as other_foo;
+        fn check_macro_2015() {
+            ::edition_lint_paths::foo();
+        }
+    }
+}

--- a/src/test/ui/rust-2018/edition-lint-paths-2018.rs
+++ b/src/test/ui/rust-2018/edition-lint-paths-2018.rs
@@ -1,0 +1,10 @@
+// compile-pass
+// edition:2018
+// compile-flags:--extern edition_lint_paths
+// aux-build:edition-lint-paths.rs
+
+#![deny(absolute_paths_not_starting_with_crate)]
+
+edition_lint_paths::macro_2015!(); // OK
+
+fn main() {}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/56311 (stable-to-beta regression)