### PR TITLE
rustc_codegen_llvm: don't overalign loads of pair operands.

### DIFF
--- a/src/test/codegen/issue-56267-2.rs
+++ b/src/test/codegen/issue-56267-2.rs
@@ -1,0 +1,18 @@
+// compile-flags: -C no-prepopulate-passes
+
+#![crate_type="rlib"]
+
+#[allow(dead_code)]
+pub struct Foo<T> {
+    foo: u64,
+    bar: T,
+}
+
+// The load from bar.1 should have alignment 4. Not checking
+// other loads here, as the alignment will be platform-dependent.
+
+// CHECK: %{{.+}} = load i32, i32* %{{.+}}, align 4
+#[no_mangle]
+pub fn test(x: Foo<(i32, i32)>) -> (i32, i32) {
+    x.bar
+}


### PR DESCRIPTION
Counterpart to #56300, but for loads instead of stores.