### PR TITLE
rustc 1.30.0's linker flavor inference is a non-backwards compat change to -Clinker

### DIFF
--- a/src/librustc_codegen_ssa/back/link.rs
+++ b/src/librustc_codegen_ssa/back/link.rs
@@ -161,7 +161,11 @@ pub fn linker_and_flavor(sess: &Session) -> (PathBuf, LinkerFlavor) {
                 LinkerFlavor::Lld(_) => "lld",
             }), flavor)),
             (Some(linker), None) => {
-                let stem = linker.file_stem().and_then(|stem| stem.to_str()).unwrap_or_else(|| {
+                let stem = if linker.extension().and_then(|ext| ext.to_str()) == Some("exe") {
+                    linker.file_stem().and_then(|stem| stem.to_str())
+                } else {
+                    linker.to_str()
+                }.unwrap_or_else(|| {
                     sess.fatal("couldn't extract file stem from specified linker");
                 }).to_owned();
 


### PR DESCRIPTION
Part of #55396.

This commit modifies linker flavor inference to only remove the extension
to the linker when performing inference if that extension is a 'exe'.

r? @nagisa 
cc @alexcrichton @japaric 