### PR TITLE
Use `?` Kleene operator again

### DIFF
--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -114,7 +114,8 @@ macro_rules! declare_lint {
     ($vis: vis $NAME: ident, $Level: ident, $desc: expr $(,)?) => (
         declare_lint!{$vis $NAME, $Level, $desc, false}
     );
-    ($vis: vis $NAME: ident, $Level: ident, $desc: expr, report_in_external_macro: $rep: expr $(,)?) => (
+    ($vis: vis $NAME: ident, $Level: ident, $desc: expr,
+     report_in_external_macro: $rep: expr $(,)?) => (
         declare_lint!{$vis $NAME, $Level, $desc, $rep}
     );
     ($vis: vis $NAME: ident, $Level: ident, $desc: expr, $external: expr $(,)?) => (

--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -111,13 +111,13 @@ impl Lint {
 /// Declare a static item of type `&'static Lint`.
 #[macro_export]
 macro_rules! declare_lint {
-    ($vis: vis $NAME: ident, $Level: ident, $desc: expr) => (
+    ($vis: vis $NAME: ident, $Level: ident, $desc: expr $(,)?) => (
         declare_lint!{$vis $NAME, $Level, $desc, false}
     );
-    ($vis: vis $NAME: ident, $Level: ident, $desc: expr, report_in_external_macro: $rep: expr) => (
+    ($vis: vis $NAME: ident, $Level: ident, $desc: expr, report_in_external_macro: $rep: expr $(,)?) => (
         declare_lint!{$vis $NAME, $Level, $desc, $rep}
     );
-    ($vis: vis $NAME: ident, $Level: ident, $desc: expr, $external: expr) => (
+    ($vis: vis $NAME: ident, $Level: ident, $desc: expr, $external: expr $(,)?) => (
         $vis static $NAME: &$crate::lint::Lint = &$crate::lint::Lint {
             name: stringify!($NAME),
             default_level: $crate::lint::$Level,
@@ -127,7 +127,7 @@ macro_rules! declare_lint {
         };
     );
     ($vis: vis $NAME: ident, $Level: ident, $desc: expr,
-     $lint_edition: expr => $edition_level: ident
+     $lint_edition: expr => $edition_level: ident $(,)?
     ) => (
         $vis static $NAME: &$crate::lint::Lint = &$crate::lint::Lint {
             name: stringify!($NAME),
@@ -141,14 +141,14 @@ macro_rules! declare_lint {
 
 #[macro_export]
 macro_rules! declare_tool_lint {
-    ($vis: vis $tool: ident ::$NAME: ident, $Level: ident, $desc: expr) => (
+    ($vis: vis $tool: ident ::$NAME: ident, $Level: ident, $desc: expr $(,)?) => (
         declare_tool_lint!{$vis $tool::$NAME, $Level, $desc, false}
     );
     ($vis: vis $tool: ident ::$NAME: ident, $Level: ident, $desc: expr,
-     report_in_external_macro: $rep: expr) => (
+     report_in_external_macro: $rep: expr $(,)?) => (
          declare_tool_lint!{$vis $tool::$NAME, $Level, $desc, $rep}
     );
-    ($vis: vis $tool: ident ::$NAME: ident, $Level: ident, $desc: expr, $external: expr) => (
+    ($vis: vis $tool: ident ::$NAME: ident, $Level: ident, $desc: expr, $external: expr $(,)?) => (
         $vis static $NAME: &$crate::lint::Lint = &$crate::lint::Lint {
             name: &concat!(stringify!($tool), "::", stringify!($NAME)),
             default_level: $crate::lint::$Level,
@@ -162,8 +162,7 @@ macro_rules! declare_tool_lint {
 /// Declare a static `LintArray` and return it as an expression.
 #[macro_export]
 macro_rules! lint_array {
-    ($( $lint:expr ),* ,) => { lint_array!( $($lint),* ) };
-    ($( $lint:expr ),*) => {{
+    ($( $lint:expr ),*  $(,)?) => {{
         vec![$($lint),*]
     }}
 }

--- a/src/librustc/macros.rs
+++ b/src/librustc/macros.rs
@@ -72,38 +72,36 @@ macro_rules! __impl_stable_hash_field {
 #[macro_export]
 macro_rules! impl_stable_hash_for {
     // Enums
-    // FIXME(mark-i-m): Some of these should be `?` rather than `*`. See the git blame and change
-    // them back when `?` is supported again.
     (enum $enum_name:path {
         $( $variant:ident
            // this incorrectly allows specifying both tuple-like and struct-like fields, as in `Variant(a,b){c,d}`,
            // when it should be only one or the other
-           $( ( $($field:ident $(-> $delegate:tt)*),* ) )*
+           $( ( $($field:ident $(-> $delegate:tt)?),* ) )*
            $( { $($named_field:ident $(-> $named_delegate:tt)*),* } )*
-        ),* $(,)*
+        ),* $(,)?
     }) => {
         impl_stable_hash_for!(
             impl<> for enum $enum_name [ $enum_name ] { $( $variant
-                $( ( $($field $(-> $delegate)*),* ) )*
+                $( ( $($field $(-> $delegate)?),* ) )*
                 $( { $($named_field $(-> $named_delegate)*),* } )*
-            ),* }
+            ),? }
         );
     };
     // We want to use the enum name both in the `impl ... for $enum_name` as well as for
     // importing all the variants. Unfortunately it seems we have to take the name
     // twice for this purpose
-    (impl<$($lt:lifetime $(: $lt_bound:lifetime)* ),* $(,)* $($T:ident),* $(,)*>
+    (impl<$($lt:lifetime $(: $lt_bound:lifetime)? ),* $(,)? $($T:ident),* $(,)?>
         for enum $enum_name:path
         [ $enum_path:path ]
     {
         $( $variant:ident
            // this incorrectly allows specifying both tuple-like and struct-like fields, as in `Variant(a,b){c,d}`,
            // when it should be only one or the other
-           $( ( $($field:ident $(-> $delegate:tt)*),* ) )*
-           $( { $($named_field:ident $(-> $named_delegate:tt)*),* } )*
-        ),* $(,)*
+           $( ( $($field:ident $(-> $delegate:tt)?),* ) )?
+           $( { $($named_field:ident $(-> $named_delegate:tt)?),* } )?
+        ),* $(,)?
     }) => {
-        impl<'a, $($lt $(: $lt_bound)*,)* $($T,)*>
+        impl<'a, $($lt $(: $lt_bound)?,)* $($T,)*>
             ::rustc_data_structures::stable_hasher::HashStable<$crate::ich::StableHashingContext<'a>>
             for $enum_name
             where $($T: ::rustc_data_structures::stable_hasher::HashStable<$crate::ich::StableHashingContext<'a>>),*
@@ -117,9 +115,9 @@ macro_rules! impl_stable_hash_for {
 
                 match *self {
                     $(
-                        $variant $( ( $(ref $field),* ) )* $( { $(ref $named_field),* } )* => {
-                            $($( __impl_stable_hash_field!($field, __ctx, __hasher $(, $delegate)*) );*)*
-                            $($( __impl_stable_hash_field!($named_field, __ctx, __hasher $(, $named_delegate)*) );*)*
+                        $variant $( ( $(ref $field),* ) )? $( { $(ref $named_field),* } )? => {
+                            $($( __impl_stable_hash_field!($field, __ctx, __hasher $(, $delegate)?) );?)*
+                            $($( __impl_stable_hash_field!($named_field, __ctx, __hasher $(, $named_delegate)?) );?)*
                         }
                     )*
                 }
@@ -127,16 +125,15 @@ macro_rules! impl_stable_hash_for {
         }
     };
     // Structs
-    // FIXME(mark-i-m): same here.
-    (struct $struct_name:path { $($field:ident $(-> $delegate:tt)*),*  $(,)* }) => {
+    (struct $struct_name:path { $($field:ident $(-> $delegate:tt)?),*  $(,)? }) => {
         impl_stable_hash_for!(
-            impl<'tcx> for struct $struct_name { $($field $(-> $delegate)*),* }
+            impl<'tcx> for struct $struct_name { $($field $(-> $delegate)?),* }
         );
     };
-    (impl<$($lt:lifetime $(: $lt_bound:lifetime)* ),* $(,)* $($T:ident),* $(,)*> for struct $struct_name:path {
-        $($field:ident $(-> $delegate:tt)*),* $(,)*
+    (impl<$($lt:lifetime $(: $lt_bound:lifetime)? ),* $(,)? $($T:ident),* $(,)?> for struct $struct_name:path {
+        $($field:ident $(-> $delegate:tt)?),* $(,)?
     }) => {
-        impl<'a, $($lt $(: $lt_bound)*,)* $($T,)*>
+        impl<'a, $($lt $(: $lt_bound)?,)* $($T,)*>
             ::rustc_data_structures::stable_hasher::HashStable<$crate::ich::StableHashingContext<'a>> for $struct_name
             where $($T: ::rustc_data_structures::stable_hasher::HashStable<$crate::ich::StableHashingContext<'a>>),*
         {
@@ -148,21 +145,20 @@ macro_rules! impl_stable_hash_for {
                     $(ref $field),*
                 } = *self;
 
-                $( __impl_stable_hash_field!($field, __ctx, __hasher $(, $delegate)*) );*
+                $( __impl_stable_hash_field!($field, __ctx, __hasher $(, $delegate)?) );*
             }
         }
     };
     // Tuple structs
-    // We cannot use normale parentheses here, the parser won't allow it
-    // FIXME(mark-i-m): same here.
-    (tuple_struct $struct_name:path { $($field:ident $(-> $delegate:tt)*),*  $(,)* }) => {
+    // We cannot use normal parentheses here, the parser won't allow it
+    (tuple_struct $struct_name:path { $($field:ident $(-> $delegate:tt)?),*  $(,)? }) => {
         impl_stable_hash_for!(
-            impl<'tcx> for tuple_struct $struct_name { $($field $(-> $delegate)*),* }
+            impl<'tcx> for tuple_struct $struct_name { $($field $(-> $delegate)?),* }
         );
     };
-    (impl<$($lt:lifetime $(: $lt_bound:lifetime)* ),* $(,)* $($T:ident),* $(,)*>
-     for tuple_struct $struct_name:path { $($field:ident $(-> $delegate:tt)*),*  $(,)* }) => {
-        impl<'a, $($lt $(: $lt_bound)*,)* $($T,)*>
+    (impl<$($lt:lifetime $(: $lt_bound:lifetime)? ),* $(,)? $($T:ident),* $(,)?>
+     for tuple_struct $struct_name:path { $($field:ident $(-> $delegate:tt)?),*  $(,)? }) => {
+        impl<'a, $($lt $(: $lt_bound)?,)* $($T,)*>
             ::rustc_data_structures::stable_hasher::HashStable<$crate::ich::StableHashingContext<'a>> for $struct_name
             where $($T: ::rustc_data_structures::stable_hasher::HashStable<$crate::ich::StableHashingContext<'a>>),*
         {
@@ -174,7 +170,7 @@ macro_rules! impl_stable_hash_for {
                     $(ref $field),*
                 ) = *self;
 
-                $( __impl_stable_hash_field!($field, __ctx, __hasher $(, $delegate)*) );*
+                $( __impl_stable_hash_field!($field, __ctx, __hasher $(, $delegate)?) );*
             }
         }
     };

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1389,7 +1389,7 @@ impl LintPass for SoftLints {
             UNIONS_WITH_DROP_FIELDS,
             UNREACHABLE_PUB,
             TYPE_ALIAS_BOUNDS,
-            TRIVIAL_BOUNDS
+            TRIVIAL_BOUNDS,
         )
     }
 }

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -44,10 +44,8 @@ macro_rules! ast_fragments {
     (
         $($Kind:ident($AstTy:ty) {
             $kind_name:expr;
-            // FIXME: HACK: this should be `$(one ...)?` and `$(many ...)?` but `?` macro
-            // repetition was removed from 2015 edition in #51587 because of ambiguities.
-            $(one fn $fold_ast:ident; fn $visit_ast:ident;)*
-            $(many fn $fold_ast_elt:ident; fn $visit_ast_elt:ident;)*
+            $(one fn $fold_ast:ident; fn $visit_ast:ident;)?
+            $(many fn $fold_ast_elt:ident; fn $visit_ast_elt:ident;)?
             fn $make_ast:ident;
         })*
     ) => {
@@ -102,11 +100,11 @@ macro_rules! ast_fragments {
                     AstFragment::OptExpr(expr) =>
                         AstFragment::OptExpr(expr.and_then(|expr| folder.fold_opt_expr(expr))),
                     $($(AstFragment::$Kind(ast) =>
-                        AstFragment::$Kind(folder.$fold_ast(ast)),)*)*
+                        AstFragment::$Kind(folder.$fold_ast(ast)),)?)*
                     $($(AstFragment::$Kind(ast) =>
                         AstFragment::$Kind(ast.into_iter()
                                               .flat_map(|ast| folder.$fold_ast_elt(ast))
-                                              .collect()),)*)*
+                                              .collect()),)?)*
                 }
             }
 
@@ -128,10 +126,10 @@ macro_rules! ast_fragments {
             }
             $($(fn $fold_ast(&mut self, ast: $AstTy) -> $AstTy {
                 self.expand_fragment(AstFragment::$Kind(ast)).$make_ast()
-            })*)*
+            })?)*
             $($(fn $fold_ast_elt(&mut self, ast_elt: <$AstTy as IntoIterator>::Item) -> $AstTy {
                 self.expand_fragment(AstFragment::$Kind(smallvec![ast_elt])).$make_ast()
-            })*)*
+            })?)*
         }
 
         impl<'a> MacResult for ::ext::tt::macro_rules::ParserAnyMacro<'a> {


### PR DESCRIPTION
In https://github.com/rust-lang/rust/pull/51587 I removed a bunch of uses of the `?` Kleene operator. Now `?` is stable, so I am adding them back :tada: 

Unfortunately, the macros had all changed slightly since that PR. In particular, a few of them have extra arms, which I also tried to apply `?` to. I think I got it right, but I would appreciate an extra careful review...