### PR TITLE
More MIR borrow check cleanup

### DIFF
--- a/src/librustc_mir/dataflow/impls/borrows.rs
+++ b/src/librustc_mir/dataflow/impls/borrows.rs
@@ -246,7 +246,7 @@ impl<'a, 'gcx, 'tcx> BitDenotation for Borrows<'a, 'gcx, 'tcx> {
                 // re-consider the current implementations of the
                 // propagate_call_return method.
 
-                if let mir::Rvalue::Ref(region, _, ref place) = **rhs {
+                if let mir::Rvalue::Ref(_, _, ref place) = **rhs {
                     if place.ignore_borrow(
                         self.tcx,
                         self.mir,
@@ -258,13 +258,6 @@ impl<'a, 'gcx, 'tcx> BitDenotation for Borrows<'a, 'gcx, 'tcx> {
                         panic!("could not find BorrowIndex for location {:?}", location);
                     });
 
-                    assert!(self.borrow_set.region_map
-                        .get(&region.to_region_vid())
-                        .unwrap_or_else(|| {
-                            panic!("could not find BorrowIndexs for RegionVid {:?}", region);
-                        })
-                        .contains(&index)
-                    );
                     sets.gen(*index);
 
                     // Issue #46746: Two-phase borrows handles

--- a/src/librustc_mir/transform/cleanup_post_borrowck.rs
+++ b/src/librustc_mir/transform/cleanup_post_borrowck.rs
@@ -10,17 +10,25 @@
 
 //! This module provides two passes:
 //!
-//!   - [CleanAscribeUserType], that replaces all
-//!     [StatementKind::AscribeUserType] statements with [StatementKind::Nop].
-//!   - [CleanFakeReadsAndBorrows], that replaces all [FakeRead] statements and
-//!     borrows that are read by [FakeReadCause::ForMatchGuard] fake reads with
-//!     [StatementKind::Nop].
+//!   - [`CleanAscribeUserType`], that replaces all [`AscribeUserType`]
+//!     statements with [`Nop`].
+//!   - [`CleanFakeReadsAndBorrows`], that replaces all [`FakeRead`] statements
+//!     and borrows that are read by [`ForMatchGuard`] fake reads with [`Nop`].
 //!
-//! The [CleanFakeReadsAndBorrows] "pass" is actually implemented as two
+//! The `CleanFakeReadsAndBorrows` "pass" is actually implemented as two
 //! traversals (aka visits) of the input MIR. The first traversal,
-//! [DeleteAndRecordFakeReads], deletes the fake reads and finds the temporaries
-//! read by [ForMatchGuard] reads, and [DeleteFakeBorrows] deletes the
-//! initialization of those temporaries.
+//! [`DeleteAndRecordFakeReads`], deletes the fake reads and finds the
+//! temporaries read by [`ForMatchGuard`] reads, and [`DeleteFakeBorrows`]
+//! deletes the initialization of those temporaries.
+//!
+//! [`CleanAscribeUserType`]: cleanup_post_borrowck::CleanAscribeUserType
+//! [`CleanFakeReadsAndBorrows`]: cleanup_post_borrowck::CleanFakeReadsAndBorrows
+//! [`DeleteAndRecordFakeReads`]: cleanup_post_borrowck::DeleteAndRecordFakeReads
+//! [`DeleteFakeBorrows`]: cleanup_post_borrowck::DeleteFakeBorrows
+//! [`AscribeUserType`]: rustc::mir::StatementKind::AscribeUserType
+//! [`Nop`]: rustc::mir::StatementKind::Nop
+//! [`FakeRead`]: rustc::mir::StatementKind::FakeRead
+//! [`ForMatchGuard`]: rustc::mir::FakeReadCause::ForMatchGuard
 
 use rustc_data_structures::fx::FxHashSet;
 


### PR DESCRIPTION
* Fix some rustc doc links
* Remove the `region_map` field from `BorrowSet`
*  Use `visit_local` to find 2PB activations

r? @nikomatsakis 