### PR TITLE
ci: Only run compare-mode tests on one builder

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -400,6 +400,11 @@
 # override the default allocator for rustc and LLVM.
 #jemalloc = false
 
+# Run tests in various test suites with the "nll compare mode" in addition to
+# running the tests in normal mode. Largely only used on CI and during local
+# development of NLL
+#test-compare-mode = false
+
 # =============================================================================
 # Options for specific targets
 #

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -58,6 +58,7 @@ pub struct Config {
     pub ignore_git: bool,
     pub exclude: Vec<PathBuf>,
     pub rustc_error_format: Option<String>,
+    pub test_compare_mode: bool,
 
     pub run_host_only: bool,
 
@@ -326,6 +327,7 @@ struct Rust {
     verify_llvm_ir: Option<bool>,
     remap_debuginfo: Option<bool>,
     jemalloc: Option<bool>,
+    test_compare_mode: Option<bool>,
 }
 
 /// TOML representation of how each build target is configured.
@@ -540,6 +542,7 @@ impl Config {
             set(&mut config.codegen_tests, rust.codegen_tests);
             set(&mut config.rust_rpath, rust.rpath);
             set(&mut config.jemalloc, rust.jemalloc);
+            set(&mut config.test_compare_mode, rust.test_compare_mode);
             set(&mut config.backtrace, rust.backtrace);
             set(&mut config.channel, rust.channel.clone());
             set(&mut config.rust_dist_src, rust.dist_src);

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1022,7 +1022,13 @@ impl Step for Compiletest {
             cmd.arg("--bless");
         }
 
-        let compare_mode = builder.config.cmd.compare_mode().or(self.compare_mode);
+        let compare_mode = builder.config.cmd.compare_mode().or_else(|| {
+            if builder.config.test_compare_mode {
+                self.compare_mode
+            } else {
+                None
+            }
+        });
 
         if let Some(ref nodejs) = builder.config.nodejs {
             cmd.arg("--nodejs").arg(nodejs);

--- a/src/ci/docker/x86_64-gnu-nopt/Dockerfile
+++ b/src/ci/docker/x86_64-gnu-nopt/Dockerfile
@@ -16,5 +16,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
-ENV RUST_CONFIGURE_ARGS --build=x86_64-unknown-linux-gnu --disable-optimize-tests
+ENV RUST_CONFIGURE_ARGS --build=x86_64-unknown-linux-gnu \
+  --disable-optimize-tests \
+  --set rust.test-compare-mode
 ENV RUST_CHECK_TARGET check


### PR DESCRIPTION
The run-pass test suite currently takes 30 minutes on Windows, and
that appears to be roughly split between two 15 minute runs of the test
suite: one without NLL and one with NLL. In discussion on Discord the
platform coverage of the NLL compare mode may not necessarily be worth
it, so this commit removes the NLL compare mode from tests by default,
and then reenables it on only one builder.