### PR TITLE
make the C part of compiler-builtins opt-out

### DIFF
--- a/src/libstd/Cargo.toml
+++ b/src/libstd/Cargo.toml
@@ -18,7 +18,7 @@ panic_unwind = { path = "../libpanic_unwind", optional = true }
 panic_abort = { path = "../libpanic_abort" }
 core = { path = "../libcore" }
 libc = { path = "../rustc/libc_shim" }
-compiler_builtins = { path = "../rustc/compiler_builtins_shim" }
+compiler_builtins = { path = "../rustc/compiler_builtins_shim", features = ["c"] }
 profiler_builtins = { path = "../libprofiler_builtins", optional = true }
 unwind = { path = "../libunwind" }
 

--- a/src/libstd/Cargo.toml
+++ b/src/libstd/Cargo.toml
@@ -18,7 +18,7 @@ panic_unwind = { path = "../libpanic_unwind", optional = true }
 panic_abort = { path = "../libpanic_abort" }
 core = { path = "../libcore" }
 libc = { path = "../rustc/libc_shim" }
-compiler_builtins = { path = "../rustc/compiler_builtins_shim", features = ["c"] }
+compiler_builtins = { path = "../rustc/compiler_builtins_shim" }
 profiler_builtins = { path = "../libprofiler_builtins", optional = true }
 unwind = { path = "../libunwind" }
 
@@ -43,9 +43,12 @@ cc = "1.0"
 build_helper = { path = "../build_helper" }
 
 [features]
+default = ["compiler_builtins_c"]
+
 backtrace = []
 panic-unwind = ["panic_unwind"]
 profiler = ["profiler_builtins"]
+compiler_builtins_c = ["compiler_builtins/c"]
 
 # Make panics and failed asserts immediately abort without formatting any message
 panic_immediate_abort = ["core/panic_immediate_abort"]

--- a/src/rustc/compiler_builtins_shim/Cargo.toml
+++ b/src/rustc/compiler_builtins_shim/Cargo.toml
@@ -34,7 +34,7 @@ cc = "1.0.1"
 
 [features]
 c = []
-default = ["c", "rustbuild", "compiler-builtins"]
+default = ["rustbuild", "compiler-builtins"]
 mem = []
 rustbuild = []
 compiler-builtins = []


### PR DESCRIPTION
I'd like to be able to use Xargo to build a libstd without having a full C toolchain for the target.  This is a start (but the fact that libstd is a dylib is still a problem).

However, compiler_builtin already has somewhat similar logic to not require a C compiler for wasm:

https://github.com/rust-lang-nursery/compiler-builtins/blob/fe74674f6e4be76d47b66f67d529ebf4186f4eb1/build.rs#L36-L41

(WTF GitHub, why doesn't this show an embedded code preview??)

I wonder if there is a way to not have two separate mechanisms? Like, move the above wasm logic to some place that controls the libstd feature, or so? Or is it okay to have these two mechanisms co-exist?

Cc @alexcrichton 