### PR TITLE
Clearer error message for dead assign

### DIFF
--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -1658,10 +1658,12 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
         if let Some(name) = self.should_warn(var) {
             if is_argument {
                 self.ir.tcx.lint_hir(lint::builtin::UNUSED_ASSIGNMENTS, hir_id, sp,
-                    &format!("value passed to `{}` is never read (maybe it is overwritten before being read)", name));
+                    &format!("value passed to `{}` is never read
+                     (maybe it is overwritten before being read)", name));
             } else {
                 self.ir.tcx.lint_hir(lint::builtin::UNUSED_ASSIGNMENTS, hir_id, sp,
-                    &format!("value assigned to `{}` is never read (maybe it is overwritten before being read)", name));
+                    &format!("value assigned to `{}` is never read
+                     (maybe it is overwritten before being read)", name));
             }
         }
     }

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -1657,13 +1657,15 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
     fn report_dead_assign(&self, hir_id: HirId, sp: Span, var: Variable, is_argument: bool) {
         if let Some(name) = self.should_warn(var) {
             if is_argument {
-                self.ir.tcx.lint_hir(lint::builtin::UNUSED_ASSIGNMENTS, hir_id, sp,
-                    &format!("value passed to `{}` is never read
-                     (maybe it is overwritten before being read)", name));
+                self.ir.tcx.struct_span_lint_hir(lint::builtin::UNUSED_ASSIGNMENTS, hir_id, sp,
+                &format!("value passed to `{}` is never read", name))
+                .help("maybe it is overwritten before being read?")
+                .emit();
             } else {
-                self.ir.tcx.lint_hir(lint::builtin::UNUSED_ASSIGNMENTS, hir_id, sp,
-                    &format!("value assigned to `{}` is never read
-                     (maybe it is overwritten before being read)", name));
+                self.ir.tcx.struct_span_lint_hir(lint::builtin::UNUSED_ASSIGNMENTS, hir_id, sp,
+                &format!("value assigned to `{}` is never read", name))
+                .help("maybe it is overwritten before being read?")
+                .emit();
             }
         }
     }

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -1658,10 +1658,10 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
         if let Some(name) = self.should_warn(var) {
             if is_argument {
                 self.ir.tcx.lint_hir(lint::builtin::UNUSED_ASSIGNMENTS, hir_id, sp,
-                    &format!("value passed to `{}` is never read", name));
+                    &format!("value passed to `{}` is never read (maybe it is overwritten before being read)", name));
             } else {
                 self.ir.tcx.lint_hir(lint::builtin::UNUSED_ASSIGNMENTS, hir_id, sp,
-                    &format!("value assigned to `{}` is never read", name));
+                    &format!("value assigned to `{}` is never read (maybe it is overwritten before being read)", name));
             }
         }
     }

--- a/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.stderr
+++ b/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.stderr
@@ -44,6 +44,7 @@ LL |                          mut hours_are_suns,
    = note: consider using `_hours_are_suns` instead
 
 warning: value assigned to `hours_are_suns` is never read
+                     (maybe it is overwritten before being read)
   --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:50:9
    |
 LL |         hours_are_suns = false;

--- a/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.stderr
+++ b/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.stderr
@@ -44,7 +44,6 @@ LL |                          mut hours_are_suns,
    = note: consider using `_hours_are_suns` instead
 
 warning: value assigned to `hours_are_suns` is never read
-                     (maybe it is overwritten before being read)
   --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:50:9
    |
 LL |         hours_are_suns = false;
@@ -56,6 +55,7 @@ note: lint level defined here
 LL | #![warn(unused)] // UI tests pass `-A unused` (#43896)
    |         ^^^^^^
    = note: #[warn(unused_assignments)] implied by #[warn(unused)]
+   = help: maybe it is overwritten before being read?
 
 warning: unused variable: `fire`
   --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:54:32

--- a/src/test/ui/liveness/liveness-dead.stderr
+++ b/src/test/ui/liveness/liveness-dead.stderr
@@ -1,4 +1,5 @@
 error: value assigned to `x` is never read
+                     (maybe it is overwritten before being read)
   --> $DIR/liveness-dead.rs:19:13
    |
 LL |     let mut x: isize = 3; //~ ERROR: value assigned to `x` is never read
@@ -11,18 +12,21 @@ LL | #![deny(unused_assignments)]
    |         ^^^^^^^^^^^^^^^^^^
 
 error: value assigned to `x` is never read
+                     (maybe it is overwritten before being read)
   --> $DIR/liveness-dead.rs:27:5
    |
 LL |     x = 4; //~ ERROR: value assigned to `x` is never read
    |     ^
 
 error: value passed to `x` is never read
+                     (maybe it is overwritten before being read)
   --> $DIR/liveness-dead.rs:30:11
    |
 LL | fn f4(mut x: i32) { //~ ERROR: value passed to `x` is never read
    |           ^
 
 error: value assigned to `x` is never read
+                     (maybe it is overwritten before being read)
   --> $DIR/liveness-dead.rs:37:5
    |
 LL |     x = 4; //~ ERROR: value assigned to `x` is never read

--- a/src/test/ui/liveness/liveness-dead.stderr
+++ b/src/test/ui/liveness/liveness-dead.stderr
@@ -1,5 +1,4 @@
 error: value assigned to `x` is never read
-                     (maybe it is overwritten before being read)
   --> $DIR/liveness-dead.rs:19:13
    |
 LL |     let mut x: isize = 3; //~ ERROR: value assigned to `x` is never read
@@ -10,27 +9,31 @@ note: lint level defined here
    |
 LL | #![deny(unused_assignments)]
    |         ^^^^^^^^^^^^^^^^^^
+   = help: maybe it is overwritten before being read?
 
 error: value assigned to `x` is never read
-                     (maybe it is overwritten before being read)
   --> $DIR/liveness-dead.rs:27:5
    |
 LL |     x = 4; //~ ERROR: value assigned to `x` is never read
    |     ^
+   |
+   = help: maybe it is overwritten before being read?
 
 error: value passed to `x` is never read
-                     (maybe it is overwritten before being read)
   --> $DIR/liveness-dead.rs:30:11
    |
 LL | fn f4(mut x: i32) { //~ ERROR: value passed to `x` is never read
    |           ^
+   |
+   = help: maybe it is overwritten before being read?
 
 error: value assigned to `x` is never read
-                     (maybe it is overwritten before being read)
   --> $DIR/liveness-dead.rs:37:5
    |
 LL |     x = 4; //~ ERROR: value assigned to `x` is never read
    |     ^
+   |
+   = help: maybe it is overwritten before being read?
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/liveness/liveness-unused.stderr
+++ b/src/test/ui/liveness/liveness-unused.stderr
@@ -50,7 +50,6 @@ LL |     let mut x = 3;
    = note: consider using `_x` instead
 
 error: value assigned to `x` is never read
-                     (maybe it is overwritten before being read)
   --> $DIR/liveness-unused.rs:42:5
    |
 LL |     x += 4;
@@ -61,6 +60,7 @@ note: lint level defined here
    |
 LL | #![deny(unused_assignments)]
    |         ^^^^^^^^^^^^^^^^^^
+   = help: maybe it is overwritten before being read?
 
 error: variable `z` is assigned to, but never used
   --> $DIR/liveness-unused.rs:47:13
@@ -103,11 +103,12 @@ LL |     let x;
    = note: consider using `_x` instead
 
 error: value assigned to `x` is never read
-                     (maybe it is overwritten before being read)
   --> $DIR/liveness-unused.rs:126:9
    |
 LL |         x = 0;  //~ ERROR value assigned to `x` is never read
    |         ^
+   |
+   = help: maybe it is overwritten before being read?
 
 error: aborting due to 13 previous errors
 

--- a/src/test/ui/liveness/liveness-unused.stderr
+++ b/src/test/ui/liveness/liveness-unused.stderr
@@ -50,6 +50,7 @@ LL |     let mut x = 3;
    = note: consider using `_x` instead
 
 error: value assigned to `x` is never read
+                     (maybe it is overwritten before being read)
   --> $DIR/liveness-unused.rs:42:5
    |
 LL |     x += 4;
@@ -102,6 +103,7 @@ LL |     let x;
    = note: consider using `_x` instead
 
 error: value assigned to `x` is never read
+                     (maybe it is overwritten before being read)
   --> $DIR/liveness-unused.rs:126:9
    |
 LL |         x = 0;  //~ ERROR value assigned to `x` is never read


### PR DESCRIPTION
I'm not that this is the right place for this (if it needs an RFC or not).

I had the problem where I misunderstood the compiler lint message https://github.com/rust-lang/rust/issues/56436 and other people seem to have had the same problem https://www.reddit.com/r/rust/comments/8cy9p4/value_assigned_to_is_never_read/.

I think this new wording might be slightly clearer (and help out beginners like me). I'm very new though, so there might be some nuance I'm missing that would make this more confusing or a bad idea for other reasons.

I thought I would create a PR to make it easy to change the code if the consensus was that it would make sense to make a change.

If this is the wrong place for this sort of thing I'll happily delete/move it.
