### PR TITLE
pass the parameter environment to `traits::find_associated_item`

### DIFF
--- a/src/librustc/traits/structural_impls.rs
+++ b/src/librustc/traits/structural_impls.rs
@@ -33,8 +33,8 @@ impl<'tcx, O: fmt::Debug> fmt::Debug for traits::Obligation<'tcx, O> {
         if ty::tls::with(|tcx| tcx.sess.verbose()) {
             write!(
                 f,
-                "Obligation(predicate={:?},cause={:?},depth={})",
-                self.predicate, self.cause, self.recursion_depth
+                "Obligation(predicate={:?},cause={:?},param_env={:?},depth={})",
+                self.predicate, self.cause, self.param_env, self.recursion_depth
             )
         } else {
             write!(

--- a/src/librustc/ty/instance.rs
+++ b/src/librustc/ty/instance.rs
@@ -347,9 +347,10 @@ fn resolve_associated_item<'a, 'tcx>(
 ) -> Option<Instance<'tcx>> {
     let def_id = trait_item.def_id;
     debug!("resolve_associated_item(trait_item={:?}, \
+            param_env={:?}, \
             trait_id={:?}, \
             rcvr_substs={:?})",
-           def_id, trait_id, rcvr_substs);
+            def_id, param_env, trait_id, rcvr_substs);
 
     let trait_ref = ty::TraitRef::from_method(tcx, trait_id, rcvr_substs);
     let vtbl = tcx.codegen_fulfill_obligation((param_env, ty::Binder::bind(trait_ref)));
@@ -359,7 +360,7 @@ fn resolve_associated_item<'a, 'tcx>(
     match vtbl {
         traits::VtableImpl(impl_data) => {
             let (def_id, substs) = traits::find_associated_item(
-                tcx, trait_item, rcvr_substs, &impl_data);
+                tcx, param_env, trait_item, rcvr_substs, &impl_data);
             let substs = tcx.erase_regions(&substs);
             Some(ty::Instance::new(def_id, substs))
         }

--- a/src/test/run-pass/issue-55380.rs
+++ b/src/test/run-pass/issue-55380.rs
@@ -1,0 +1,38 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// run-pass
+
+#![feature(specialization)]
+
+pub trait Foo {
+    fn abc() -> u32;
+    fn def() -> u32;
+}
+
+pub trait Marker {}
+
+impl Marker for () {}
+
+impl<T> Foo for T {
+    default fn abc() -> u32 { 16 }
+    default fn def() -> u32 { 42 }
+}
+
+impl<T: Marker> Foo for T {
+    fn def() -> u32 {
+        Self::abc()
+    }
+}
+
+fn main() {
+   assert_eq!(<()>::def(), 16);
+   assert_eq!(<i32>::def(), 42);
+}


### PR DESCRIPTION
dropping the param-env on the floor is obviously the wrong thing to do.

The ICE was probably exposed by #54490 adding the problem-exposing use of
`traits::find_associated_item`.

Fixes #55380.

r? @nikomatsakis