### PR TITLE
Stable 1.31.0 release

### DIFF
--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -51,7 +51,7 @@ fi
 #
 # FIXME: need a scheme for changing this `nightly` value to `beta` and `stable`
 #        either automatically or manually.
-export RUST_RELEASE_CHANNEL=beta
+export RUST_RELEASE_CHANNEL=stable
 if [ "$DEPLOY$DEPLOY_ALT" != "" ]; then
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --release-channel=$RUST_RELEASE_CHANNEL"
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-llvm-static-stdcpp"


### PR DESCRIPTION
This also includes a patch to the edition guide inclusion such that it should actually get built. It will need to be forward-ported to master (and beta, but that'll come as master/beta promotion).

cc @rust-lang/release 