### PR TITLE
Add Result::map_into and Result::map_err_into

### DIFF
--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -933,6 +933,26 @@ impl<T: Default, E> Result<T, E> {
             Err(_) => Default::default(),
         }
     }
+
+    /// Maps the contained value of an [`Ok`] using the `Into` trait
+    ///
+    /// [`Into`]: ../convert/trait.Into.html
+    pub fn map_into<U>(self) -> Result<U, E>
+    where
+        T: Into<U>
+    {
+        self.map(T::into)
+    }
+    
+    /// Maps the contained value of an [`Err`] using the `Into` trait
+    ///
+    /// [`Into`]: ../convert/trait.Into.html
+    fn map_err_into<F>(self) -> Result<T, F>
+    where
+        E: Into<F>
+    {
+        self.map_err(E::into)
+    }
 }
 
 #[unstable(feature = "inner_deref", reason = "newly added", issue = "50264")]

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -240,6 +240,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
+use convert::Into;
 use fmt;
 use iter::{FromIterator, FusedIterator, TrustedLen};
 use ops::{self, Deref};
@@ -895,6 +896,26 @@ impl<T: fmt::Debug, E> Result<T, E> {
             Err(e) => e,
         }
     }
+
+    /// Maps the contained value of an [`Ok`] using the `Into` trait
+    ///
+    /// [`Into`]: ../convert/trait.Into.html
+    pub fn map_into<U>(self) -> Result<U, E>
+    where
+        T: Into<U>
+    {
+        self.map(T::into)
+    }
+
+    /// Maps the contained value of an [`Err`] using the `Into` trait
+    ///
+    /// [`Into`]: ../convert/trait.Into.html
+    fn map_err_into<F>(self) -> Result<T, F>
+    where
+        E: Into<F>
+    {
+        self.map_err(E::into)
+    }
 }
 
 impl<T: Default, E> Result<T, E> {
@@ -932,26 +953,6 @@ impl<T: Default, E> Result<T, E> {
             Ok(x) => x,
             Err(_) => Default::default(),
         }
-    }
-
-    /// Maps the contained value of an [`Ok`] using the `Into` trait
-    ///
-    /// [`Into`]: ../convert/trait.Into.html
-    pub fn map_into<U>(self) -> Result<U, E>
-    where
-        T: Into<U>
-    {
-        self.map(T::into)
-    }
-    
-    /// Maps the contained value of an [`Err`] using the `Into` trait
-    ///
-    /// [`Into`]: ../convert/trait.Into.html
-    fn map_err_into<F>(self) -> Result<T, F>
-    where
-        E: Into<F>
-    {
-        self.map_err(E::into)
     }
 }
 


### PR DESCRIPTION
This PR adds two convenience methods to Result: `map_into` and `map_err_into`. These functions use the `Into` trait to convert the contained types.

I've found myself using this a lot working with futures, and futures 0.1 currently has this built in for errors: https://docs.rs/futures/0.1.25/futures/future/trait.Future.html#method.map_err .

Note that I did not test if the documentation is correctly showing since I can't get `cargo doc` to work for some reason.