### PR TITLE
Fix invalid line number match

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -134,7 +134,6 @@ summary {
 
 code, pre {
 	font-family: "Source Code Pro", monospace;
-	white-space: pre-wrap;
 }
 .docblock code, .docblock-short code {
 	border-radius: 3px;
@@ -301,6 +300,7 @@ body:not(.source) .example-wrap {
 
 body:not(.source) .example-wrap > pre.rust {
 	width: 100%;
+	overflow-x: auto;
 }
 
 #search {


### PR DESCRIPTION
If a code line is longer than the width, it then gets to the next line making the line number not matching it anymore.

r? @QuietMisdreavus 