### PR TITLE
Propagate all closure requirements to the caller

### DIFF
--- a/src/librustc_mir/borrow_check/nll/region_infer/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/mod.rs
@@ -1208,7 +1208,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                         blame_span: blame_span_category.1,
                         category: blame_span_category.0,
                     });
-                    return;
+                    continue;
                 }
             }
 

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -355,13 +355,13 @@ fn check_item_type<'a, 'tcx>(
 ) {
     debug!("check_item_type: {:?}", item_id);
 
-    for_id(tcx, item_id, ty_span).with_fcx(|fcx, _this| {
-        let ty = fcx.tcx.type_of(fcx.tcx.hir.local_def_id(item_id));
+    for_id(tcx, item_id, ty_span).with_fcx(|fcx, gcx| {
+        let ty = gcx.type_of(gcx.hir.local_def_id(item_id));
         let item_ty = fcx.normalize_associated_types_in(ty_span, &ty);
 
         let mut forbid_unsized = true;
         if allow_foreign_ty {
-            if let TyKind::Foreign(_) = tcx.struct_tail(item_ty).sty {
+            if let TyKind::Foreign(_) = fcx.tcx.struct_tail(item_ty).sty {
                 forbid_unsized = false;
             }
         }

--- a/src/test/ui/nll/closure-requirements/propagate-multiple-requirements.rs
+++ b/src/test/ui/nll/closure-requirements/propagate-multiple-requirements.rs
@@ -1,0 +1,25 @@
+// Test that we propagate *all* requirements to the caller, not just the first
+// one.
+
+#![feature(nll)]
+
+fn once<S, T, U, F: FnOnce(S, T) -> U>(f: F, s: S, t: T) -> U {
+    f(s, t)
+}
+
+pub fn dangle() -> &'static [i32] {
+    let other_local_arr = [0, 2, 4];
+    let local_arr = other_local_arr;
+    let mut out: &mut &'static [i32] = &mut (&[1] as _);
+    once(|mut z: &[i32], mut out_val: &mut &[i32]| {
+        // We unfortunately point to the first use in the closure in the error
+        // message
+        z = &local_arr; //~ ERROR
+        *out_val = &local_arr;
+    }, &[] as &[_], &mut *out);
+    *out
+}
+
+fn main() {
+    println!("{:?}", dangle());
+}

--- a/src/test/ui/nll/closure-requirements/propagate-multiple-requirements.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-multiple-requirements.stderr
@@ -1,0 +1,17 @@
+error[E0597]: `local_arr` does not live long enough
+  --> $DIR/propagate-multiple-requirements.rs:17:14
+   |
+LL |     let mut out: &mut &'static [i32] = &mut (&[1] as _);
+   |                  ------------------- type annotation requires that `local_arr` is borrowed for `'static`
+LL |     once(|mut z: &[i32], mut out_val: &mut &[i32]| {
+   |          ----------------------------------------- value captured here
+...
+LL |         z = &local_arr; //~ ERROR
+   |              ^^^^^^^^^ borrowed value does not live long enough
+...
+LL | }
+   | - `local_arr` dropped here while still borrowed
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0597`.


### PR DESCRIPTION
Closes #56477

This should be backported to 1.32 if it doesn't make the cut.

r? @pnkfelix 
cc @nikomatsakis 