### PR TITLE
[stable] Add a few critical fixes to the 1.31.0 release

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -443,7 +443,8 @@ impl<'a> Builder<'a> {
                 doc::RustdocBook,
                 doc::RustByExample,
                 doc::RustcBook,
-                doc::CargoBook
+                doc::CargoBook,
+                doc::EditionGuide,
             ),
             Kind::Dist => describe!(
                 dist::Docs,

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -91,7 +91,7 @@ pub fn spawn_thread_pool<F: FnOnce(config::Options) -> R + sync::Send, R: sync::
     let config = ThreadPoolBuilder::new()
         .num_threads(Session::query_threads_from_opts(&opts))
         .deadlock_handler(|| unsafe { ty::query::handle_deadlock() })
-        .stack_size(16 * 1024 * 1024);
+        .stack_size(::STACK_SIZE);
 
     let with_pool = move |pool: &ThreadPool| {
         pool.install(move || f(opts))

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -1460,6 +1460,11 @@ fn parse_crate_attrs<'a>(sess: &'a Session, input: &Input) -> PResult<'a, Vec<as
     }
 }
 
+// Temporarily have stack size set to 32MB to deal with various crates with long method
+// chains or deep syntax trees.
+// FIXME(oli-obk): get https://github.com/rust-lang/rust/pull/55617 the finish line
+const STACK_SIZE: usize = 32 * 1024 * 1024; // 32MB
+
 /// Runs `f` in a suitable thread for running `rustc`; returns a `Result` with either the return
 /// value of `f` or -- if a panic occurs -- the panic value.
 ///
@@ -1469,9 +1474,6 @@ pub fn in_named_rustc_thread<F, R>(name: String, f: F) -> Result<R, Box<dyn Any 
     where F: FnOnce() -> R + Send + 'static,
           R: Send + 'static,
 {
-    // Temporarily have stack size set to 16MB to deal with nom-using crates failing
-    const STACK_SIZE: usize = 16 * 1024 * 1024; // 16MB
-
     #[cfg(all(unix, not(target_os = "haiku")))]
     let spawn_thread = unsafe {
         // Fetch the current resource limits

--- a/src/librustc_mir/borrow_check/nll/region_infer/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/mod.rs
@@ -1196,7 +1196,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                         blame_span: blame_span_category.1,
                         category: blame_span_category.0,
                     });
-                    return;
+                    continue;
                 }
             }
 

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -343,8 +343,8 @@ fn check_item_fn<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, item: &hir::Item) {
 fn check_item_type<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, item_id: ast::NodeId, ty_span: Span) {
     debug!("check_item_type: {:?}", item_id);
 
-    for_id(tcx, item_id, ty_span).with_fcx(|fcx, _this| {
-        let ty = fcx.tcx.type_of(fcx.tcx.hir.local_def_id(item_id));
+    for_id(tcx, item_id, ty_span).with_fcx(|fcx, gcx| {
+        let ty = gcx.type_of(gcx.hir.local_def_id(item_id));
         let item_ty = fcx.normalize_associated_types_in(ty_span, &ty);
 
         fcx.register_wf_obligation(item_ty, ty_span, ObligationCauseCode::MiscObligation);

--- a/src/test/ui/nll/closure-requirements/propagate-multiple-requirements.rs
+++ b/src/test/ui/nll/closure-requirements/propagate-multiple-requirements.rs
@@ -1,0 +1,25 @@
+// Test that we propagate *all* requirements to the caller, not just the first
+// one.
+
+#![feature(nll)]
+
+fn once<S, T, U, F: FnOnce(S, T) -> U>(f: F, s: S, t: T) -> U {
+    f(s, t)
+}
+
+pub fn dangle() -> &'static [i32] {
+    let other_local_arr = [0, 2, 4];
+    let local_arr = other_local_arr;
+    let mut out: &mut &'static [i32] = &mut (&[1] as _);
+    once(|mut z: &[i32], mut out_val: &mut &[i32]| {
+        // We unfortunately point to the first use in the closure in the error
+        // message
+        z = &local_arr; //~ ERROR
+        *out_val = &local_arr;
+    }, &[] as &[_], &mut *out);
+    *out
+}
+
+fn main() {
+    println!("{:?}", dangle());
+}

--- a/src/test/ui/nll/closure-requirements/propagate-multiple-requirements.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-multiple-requirements.stderr
@@ -1,0 +1,17 @@
+error[E0597]: `local_arr` does not live long enough
+  --> $DIR/propagate-multiple-requirements.rs:17:14
+   |
+LL |     let mut out: &mut &'static [i32] = &mut (&[1] as _);
+   |                  ------------------- type annotation requires that `local_arr` is borrowed for `'static`
+LL |     once(|mut z: &[i32], mut out_val: &mut &[i32]| {
+   |          ----------------------------------------- value captured here
+...
+LL |         z = &local_arr; //~ ERROR
+   |              ^^^^^^^^^ borrowed value does not live long enough
+...
+LL | }
+   | - `local_arr` dropped here while still borrowed
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0597`.


### PR DESCRIPTION
This PR cherry-picks the following PRs to stable:

* #56467: Bump stack size to 32MB
* #56486: Propagate all closure requirements to the caller
* #56519: update edition guide

The changes will be included in the final 1.31.0 binary (to avoid a point release). To deploy the build to dev-static the old manifest needs to be removed from the bucket after the PR is merged.

cc @rust-lang/core @rust-lang/release @rust-lang/compiler 
r? @alexcrichton 