### PR TITLE
Fix code being shown after line numbers

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -288,10 +288,6 @@ nav.sub {
 	margin-bottom: 10px;
 }
 
-.example-wrap {
-	width: 100%;
-}
-
 .example-wrap > pre.line-number {
 	overflow: initial;
 	border: 1px solid;


### PR DESCRIPTION
Fixes #56526


Before:
<img width="855" alt="screen shot 2018-12-04 at 20 38 13" src="https://user-images.githubusercontent.com/2943750/49492360-cef10c80-f80c-11e8-8666-b5af1a53583c.png">

After:
<img width="1211" alt="screen shot 2018-12-04 at 21 35 23" src="https://user-images.githubusercontent.com/2943750/49492356-c993c200-f80c-11e8-84e1-7b0ad011c5ad.png">

<img width="385" alt="screen shot 2018-12-04 at 21 47 38" src="https://user-images.githubusercontent.com/2943750/49492707-42dfe480-f80e-11e8-9769-beb66bc4647e.png">


_Fun sidenote: building the docs with the README instructions `./x.py doc` compiles the entire rustc, which takes a moment 😄_
