### PR TITLE
Use inner iterator may_have_side_effect for Cloned

### DIFF
--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -602,7 +602,9 @@ unsafe impl<'a, I, T: 'a> TrustedRandomAccess for Cloned<I>
     }
 
     #[inline]
-    fn may_have_side_effect() -> bool { false }
+    fn may_have_side_effect() -> bool {
+        I::may_have_side_effect()
+    }
 }
 
 #[unstable(feature = "trusted_len", issue = "37572")]

--- a/src/libcore/tests/iter.rs
+++ b/src/libcore/tests/iter.rs
@@ -1250,6 +1250,23 @@ fn test_cloned() {
 }
 
 #[test]
+fn test_cloned_side_effects() {
+    let mut count = 0;
+    {
+        let iter = [1, 2, 3]
+            .iter()
+            .map(|x| {
+                count += 1;
+                x
+            })
+            .cloned()
+            .zip(&[1]);
+        for _ in iter {}
+    }
+    assert_eq!(count, 2);
+}
+
+#[test]
 fn test_double_ended_map() {
     let xs = [1, 2, 3, 4, 5, 6];
     let mut it = xs.iter().map(|&x| x * -1);


### PR DESCRIPTION
Previous implementation wasn't correct, as an inner iterator could have had side effects. Noticed by @bluss in #56534.