### PR TITLE
Fix ItemKind::TraitAlias encoding

### DIFF
--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -1141,7 +1141,7 @@ impl<'a, 'b: 'a, 'tcx: 'b> IsolatedEncoder<'a, 'b, 'tcx> {
 
                 EntryKind::Impl(self.lazy(&data))
             }
-            hir::ItemKind::Trait(..) => {
+            hir::ItemKind::Trait(..) | hir::ItemKind::TraitAlias(..) => {
                 let trait_def = tcx.trait_def(def_id);
                 let data = TraitData {
                     unsafety: trait_def.unsafety,
@@ -1154,7 +1154,6 @@ impl<'a, 'b: 'a, 'tcx: 'b> IsolatedEncoder<'a, 'b, 'tcx> {
                 EntryKind::Trait(self.lazy(&data))
             }
             hir::ItemKind::ExternCrate(_) |
-            hir::ItemKind::TraitAlias(..) |
             hir::ItemKind::Use(..) => bug!("cannot encode info for item {:?}", item),
         };
 

--- a/src/test/run-pass/traits/trait-alias-syntax.rs
+++ b/src/test/run-pass/traits/trait-alias-syntax.rs
@@ -10,6 +10,11 @@
 
 #![feature(trait_alias)]
 
+mod alpha {
+    pub trait A { }
+    pub trait C = A;
+}
+
 trait SimpleAlias = Default;
 trait GenericAlias<T> = Iterator<Item = T>;
 trait Partial<T> = IntoIterator<Item = T>;


### PR DESCRIPTION
`ItemKind::TraitAlias` should be encoded just like a regular `Trait`.

Fixes: #56488