### PR TITLE
Don't print the profiling summary to stdout when -Zprofile-json is set

### DIFF
--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -826,7 +826,7 @@ impl Session {
     }
 
     pub fn profiler<F: FnOnce(&mut SelfProfiler) -> ()>(&self, f: F) {
-        if self.opts.debugging_opts.self_profile {
+        if self.opts.debugging_opts.self_profile || self.opts.debugging_opts.profile_json {
             let mut profiler = self.self_profiling.borrow_mut();
             f(&mut profiler);
         }

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -356,10 +356,10 @@ pub fn compile_input(
 
     if sess.opts.debugging_opts.self_profile {
         sess.print_profiler_results();
+    }
 
-        if sess.opts.debugging_opts.profile_json {
-            sess.save_json_results();
-        }
+    if sess.opts.debugging_opts.profile_json {
+        sess.save_json_results();
     }
 
     controller_entry_point!(


### PR DESCRIPTION
cc rust-lang-nursery/rustc-perf#299