### PR TITLE
remove text about slices being read-only.

### DIFF
--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -171,7 +171,7 @@ use raw_vec::RawVec;
 ///
 /// # Slicing
 ///
-/// A `Vec` can be mutable. Slices, on the other hand, are read-only objects.
+/// A slice is a reference to a part of the vector.
 /// To get a slice, use `&`. Example:
 ///
 /// ```


### PR DESCRIPTION
slices can be mutable (since 1.7.0, I'm told), so this line no longer makes a good introduction.