### PR TITLE
Add more rust_private attributes

### DIFF
--- a/src/libfmt_macros/lib.rs
+++ b/src/libfmt_macros/lib.rs
@@ -21,6 +21,7 @@
        test(attr(deny(warnings))))]
 
 #![feature(nll)]
+#![feature(rustc_private)]
 
 pub use self::Piece::*;
 pub use self::Position::*;

--- a/src/libproc_macro/lib.rs
+++ b/src/libproc_macro/lib.rs
@@ -35,6 +35,7 @@
 #![feature(optin_builtin_traits)]
 #![feature(non_exhaustive)]
 #![feature(specialization)]
+#![feature(rustc_private)]
 
 #![recursion_limit="256"]
 

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -69,6 +69,7 @@
 #![feature(in_band_lifetimes)]
 #![feature(crate_visibility_modifier)]
 #![feature(transpose_result)]
+#![feature(rustc_private)]
 
 #![recursion_limit="512"]
 

--- a/src/librustc_codegen_llvm/lib.rs
+++ b/src/librustc_codegen_llvm/lib.rs
@@ -35,6 +35,7 @@
 #![feature(concat_idents)]
 #![feature(link_args)]
 #![feature(static_nobundle)]
+#![feature(rustc_private)]
 
 use back::write::create_target_machine;
 use syntax_pos::symbol::Symbol;

--- a/src/librustc_codegen_utils/lib.rs
+++ b/src/librustc_codegen_utils/lib.rs
@@ -23,6 +23,7 @@
 #![allow(unused_attributes)]
 #![feature(quote)]
 #![feature(rustc_diagnostic_macros)]
+#![feature(rustc_private)]
 
 #![recursion_limit="256"]
 

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -27,6 +27,7 @@
 #![feature(set_stdio)]
 #![feature(rustc_stack_internals)]
 #![feature(no_debug)]
+#![feature(rustc_private)]
 
 #![recursion_limit="256"]
 

--- a/src/librustc_llvm/lib.rs
+++ b/src/librustc_llvm/lib.rs
@@ -10,6 +10,7 @@
 
 #![feature(nll)]
 #![feature(static_nobundle)]
+#![feature(rustc_private)]
 
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -28,6 +28,7 @@
 #![feature(step_trait)]
 #![feature(try_trait)]
 #![feature(unicode_internals)]
+#![feature(rustc_private)]
 
 #![recursion_limit="256"]
 


### PR DESCRIPTION
I'm working on enabling clippy in `x.py` and the usage of `is_xid_start` and `is_xid_continue` in the components is one of the obstacles. If we are not planning to remove this attribute then it makes sense to use it for these compiler internals, as it is already done with some of the others.

If for any reason this is undesirable, there is probably some way of working around it; otherwise it seems like the most straightforward option.

r? @alexcrichton 