### PR TITLE
Update libc version required by rustc

### DIFF
--- a/src/librustc_codegen_ssa/Cargo.toml
+++ b/src/librustc_codegen_ssa/Cargo.toml
@@ -16,7 +16,7 @@ num_cpus = "1.0"
 rustc-demangle = "0.1.4"
 memmap = "0.6"
 log = "0.4.5"
-libc = "0.2.43"
+libc = "0.2.44"
 jobserver = "0.1.11"
 
 serialize = { path = "../libserialize" }


### PR DESCRIPTION
This is meant to be an easy-to-backport fix for #55465