### PR TITLE
 Override <RangeInclusive as Iterator>::try_(r)fold 

### DIFF
--- a/src/libcore/benches/iter.rs
+++ b/src/libcore/benches/iter.rs
@@ -310,3 +310,39 @@ fn bench_skip_then_zip(b: &mut Bencher) {
         assert_eq!(s, 2009900);
     });
 }
+
+#[bench]
+fn bench_triples_inclusive_range(b: &mut Bencher) {
+    // Example from #45222
+    b.iter(|| {
+        (1..)
+            .flat_map(|z| {
+                (1u32..=z).flat_map(move |x| {
+                    (x..=z)
+                        .filter(move |&y| x.pow(2) + y.pow(2) == z.pow(2))
+                        .map(move |y| (x, y, z))
+                })
+            })
+            .take(20)
+            .map(|(x, y, z)| x + y + z)
+            .sum::<u32>()
+    })
+}
+
+#[bench]
+fn bench_triples_range(b: &mut Bencher) {
+    // Example from #45222
+    b.iter(|| {
+        (1..)
+            .flat_map(|z| {
+                (1u32..z+1).flat_map(move |x| {
+                    (x..z+1)
+                        .filter(move |&y| x.pow(2) + y.pow(2) == z.pow(2))
+                        .map(move |y| (x, y, z))
+                })
+            })
+            .take(20)
+            .map(|(x, y, z)| x + y + z)
+            .sum::<u32>()
+    })
+}

--- a/src/libcore/iter/range.rs
+++ b/src/libcore/iter/range.rs
@@ -270,6 +270,23 @@ impl<A: Step> Iterator for ops::Range<A> {
     fn max(mut self) -> Option<A> {
         self.next_back()
     }
+
+    #[inline]
+    fn try_fold<B, F, R>(&mut self, init: B, mut f: F) -> R where
+        Self: Sized, F: FnMut(B, Self::Item) -> R, R: Try<Ok=B>
+    {
+        let mut accum = init;
+        if self.start >= self.end {
+            return Try::from_ok(accum);
+        }
+
+        while self.start < self.end {
+            let n = self.start.add_one();
+            accum = f(accum, mem::replace(&mut self.start, n))?;
+        }
+
+        Try::from_ok(accum)
+    }
 }
 
 // These macros generate `ExactSizeIterator` impls for various range types.


### PR DESCRIPTION
cc #45222

* [Here](https://github.com/rust-lang/rust/blob/128a1fa4e1f85e04f522653bb9bee83ed6523440/src/libcore/tests/iter.rs#L1699-L1716
) preexists a test for `fold`ing inclusive ranges.
* `try_rfold` for `Range` is left unoverrided since I didn't see performance gain for it.

Benchmarks:

```
 name                           orig ns/iter  override ns/iter  diff ns/iter   diff %  speedup 
 bench_triples_inclusive_range  41,481        28,547                 -12,934  -31.18%   x 1.45 
 bench_triples_range            25,245        21,600                  -3,645  -14.44%   x 1.17
```