### PR TITLE
Remove dependency on shell32.dll

### DIFF
--- a/src/libstd/build.rs
+++ b/src/libstd/build.rs
@@ -68,7 +68,6 @@ fn main() {
         println!("cargo:rustc-link-lib=advapi32");
         println!("cargo:rustc-link-lib=ws2_32");
         println!("cargo:rustc-link-lib=userenv");
-        println!("cargo:rustc-link-lib=shell32");
     } else if target.contains("fuchsia") {
         println!("cargo:rustc-link-lib=zircon");
         println!("cargo:rustc-link-lib=fdio");

--- a/src/libstd/sys/windows/args.rs
+++ b/src/libstd/sys/windows/args.rs
@@ -182,7 +182,7 @@ impl<'a> fmt::Debug for ArgsInnerDebug<'a> {
             }
             first = false;
 
-            fmt::Debug::fmt(i, f)?;
+            fmt::Debug::fmt(&i, f)?;
         }
         f.write_str("]")?;
         Ok(())
@@ -223,7 +223,7 @@ mod tests {
             parse_lp_cmd_line(wide.as_ptr() as *const u16, || OsString::from("TEST.EXE"))
         };
         let expected: Vec<OsString> = parts.iter().map(|k| OsString::from(k)).collect();
-        assert_eq!(parsed, expected);
+        assert_eq!(parsed.as_slice(), expected.as_slice());
     }
 
     #[test]
@@ -267,7 +267,7 @@ mod tests {
             r#"EXE "this is """all""" in the same argument""#,
             &["EXE", "this is \"all\" in the same argument"]
         );
-        chk(r#"EXE "\u{1}"""#, &["EXE", "\u{1}\""]);
+        chk(r#"EXE "a"""#, &["EXE", "a\""]);
         chk(r#"EXE "a"" a"#, &["EXE", "a\"", "a"]);
     }
 }

--- a/src/libstd/sys/windows/args.rs
+++ b/src/libstd/sys/windows/args.rs
@@ -35,13 +35,20 @@ pub fn args() -> Args {
     }
 }
 
-/// Implements the Windows command-line argument parsing algorithm, described at
+/// Implements the Windows command-line argument parsing algorithm.
+///
+/// Microsoft's documentation for the Windows CLI argument format can be found at
 /// <https://docs.microsoft.com/en-us/previous-versions//17w5ykft(v=vs.85)>.
 ///
 /// Windows includes a function to do this in shell32.dll,
 /// but linking with that DLL causes the process to be registered as a GUI application.
 /// GUI applications add a bunch of overhead, even if no windows are drawn. See
 /// <https://randomascii.wordpress.com/2018/12/03/a-not-called-function-can-cause-a-5x-slowdown/>.
+///
+/// This function was tested for equivalence to the shell32.dll implementation in
+/// Windows 10 Pro v1803, using an exhaustive test suite available at
+/// <https://gist.github.com/notriddle/dde431930c392e428055b2dc22e638f5> or
+/// <https://paste.gg/p/anonymous/47d6ed5f5bd549168b1c69c799825223>.
 unsafe fn parse_lp_cmd_line<F: Fn() -> OsString>(lp_cmd_line: *const u16, exe_name: F)
                                                  -> vec::IntoIter<OsString> {
     const BACKSLASH: u16 = '\\' as u16;
@@ -176,13 +183,13 @@ impl<'a> fmt::Debug for ArgsInnerDebug<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str("[")?;
         let mut first = true;
-        for i in self.args.parsed_args_list.clone() {
+        for i in self.args.parsed_args_list.as_slice() {
             if !first {
                 f.write_str(", ")?;
             }
             first = false;
 
-            fmt::Debug::fmt(&i, f)?;
+            fmt::Debug::fmt(i, f)?;
         }
         f.write_str("]")?;
         Ok(())

--- a/src/libstd/sys/windows/args.rs
+++ b/src/libstd/sys/windows/args.rs
@@ -72,13 +72,14 @@ unsafe fn parse_lp_cmd_line<F: Fn() -> OsString>(lp_cmd_line: *const u16, exe_na
         QUOTE => {
             loop {
                 i += 1;
-                if *lp_cmd_line.offset(i) == 0 {
+                let c = *lp_cmd_line.offset(i);
+                if c == 0 {
                     ret_val.push(OsString::from_wide(
                         slice::from_raw_parts(lp_cmd_line.offset(1), i as usize - 1)
                     ));
                     return ret_val.into_iter();
                 }
-                if *lp_cmd_line.offset(i) == QUOTE {
+                if c == QUOTE {
                     break;
                 }
             }
@@ -101,13 +102,14 @@ unsafe fn parse_lp_cmd_line<F: Fn() -> OsString>(lp_cmd_line: *const u16, exe_na
         _ => {
             loop {
                 i += 1;
-                if *lp_cmd_line.offset(i) == 0 {
+                let c = *lp_cmd_line.offset(i);
+                if c == 0 {
                     ret_val.push(OsString::from_wide(
                         slice::from_raw_parts(lp_cmd_line, i as usize)
                     ));
                     return ret_val.into_iter();
                 }
-                if let 0...SPACE = *lp_cmd_line.offset(i) {
+                if c > 0 && c <= SPACE {
                     break;
                 }
             }

--- a/src/libstd/sys/windows/c.rs
+++ b/src/libstd/sys/windows/c.rs
@@ -1035,9 +1035,6 @@ extern "system" {
 
     pub fn SetLastError(dwErrCode: DWORD);
     pub fn GetCommandLineW() -> *mut LPCWSTR;
-    pub fn LocalFree(ptr: *mut c_void);
-    pub fn CommandLineToArgvW(lpCmdLine: *mut LPCWSTR,
-                              pNumArgs: *mut c_int) -> *mut *mut u16;
     pub fn GetTempPathW(nBufferLength: DWORD,
                         lpBuffer: LPCWSTR) -> DWORD;
     pub fn OpenProcessToken(ProcessHandle: HANDLE,

--- a/src/test/run-make-fulldeps/tools.mk
+++ b/src/test/run-make-fulldeps/tools.mk
@@ -76,7 +76,7 @@ endif
 # Extra flags needed to compile a working executable with the standard library
 ifdef IS_WINDOWS
 ifdef IS_MSVC
-	EXTRACFLAGS := ws2_32.lib userenv.lib shell32.lib advapi32.lib
+	EXTRACFLAGS := ws2_32.lib userenv.lib advapi32.lib
 else
 	EXTRACFLAGS := -lws2_32 -luserenv
 endif


### PR DESCRIPTION
Closes #56510 if it works on MinGW (I've only tested it on MSVC).