### PR TITLE
Contexually dependent error message for E0424 when value is assigned to "self"

### DIFF
--- a/src/test/ui/error-codes/E0424.rs
+++ b/src/test/ui/error-codes/E0424.rs
@@ -19,4 +19,5 @@ impl Foo {
 }
 
 fn main () {
+    let self = "self"; //~ ERROR E0424
 }

--- a/src/test/ui/error-codes/E0424.stderr
+++ b/src/test/ui/error-codes/E0424.stderr
@@ -4,6 +4,12 @@ error[E0424]: expected value, found module `self`
 LL |         self.bar(); //~ ERROR E0424
    |         ^^^^ `self` value is a keyword only available in methods with `self` parameter
 
-error: aborting due to previous error
+error[E0424]: expected unit struct/variant or constant, found module `self`
+  --> $DIR/E0424.rs:22:9
+   |
+LL |     let self = "self"; //~ ERROR E0424
+   |         ^^^^ `self` value is a keyword and may not be bound to variables or shadowed
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0424`.


### PR DESCRIPTION
This is an improvement for pull request #54495 referencing issue #54369. If the "self" keyword is assigned a value as though it were a valid identifier, it will now report:
```
let self = "self";
    ^^^^ `self` value is a keyword and may not be bound to variables or shadowed
```
instead of
```
let self = "self";
    ^^^^ `self` value is a keyword only available in methods with `self` parameter
```
If anyone has a better idea for what the error should be I'd be happy to modify it appropriately.