### PR TITLE
resolve: Relax one restriction on macro namespace

### DIFF
--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -323,7 +323,7 @@ impl<'a, 'crateloader> Resolver<'a, 'crateloader> {
         // shadowing is enabled, see `macro_expanded_macro_export_errors`).
         let unexpanded_macros = !module.unresolved_invocations.borrow().is_empty();
         if let Some(binding) = resolution.binding {
-            if !unexpanded_macros || ns == MacroNS || restricted_shadowing {
+            if !unexpanded_macros || restricted_shadowing {
                 return check_usable(self, binding);
             } else {
                 return Err((Undetermined, Weak::No));
@@ -492,14 +492,8 @@ impl<'a, 'crateloader> Resolver<'a, 'crateloader> {
                         } else {
                             (binding, old_binding)
                         };
-                        if glob_binding.def() != nonglob_binding.def() &&
-                           ns == MacroNS && nonglob_binding.expansion != Mark::root() {
-                            resolution.binding = Some(this.ambiguity(AmbiguityKind::GlobVsExpanded,
-                                                                    nonglob_binding, glob_binding));
-                        } else {
-                            resolution.binding = Some(nonglob_binding);
-                            resolution.shadowed_glob = Some(glob_binding);
-                        }
+                        resolution.binding = Some(nonglob_binding);
+                        resolution.shadowed_glob = Some(glob_binding);
                     }
                     (false, false) => {
                         if let (&NameBindingKind::Def(_, true), &NameBindingKind::Def(_, true)) =

--- a/src/test/ui/macros/ambiguity-glob-vs-expanded-in-mod.rs
+++ b/src/test/ui/macros/ambiguity-glob-vs-expanded-in-mod.rs
@@ -1,0 +1,21 @@
+// compile-pass
+
+#![feature(decl_macro)]
+
+macro_rules! gen_mac { () => {
+    pub macro mac() { () }
+}}
+
+mod m1 {
+    pub macro mac() { 0 }
+}
+
+mod m2 {
+    use m1::*;
+
+    gen_mac!();
+}
+
+fn main() {
+    m2::mac!() // OK
+}


### PR DESCRIPTION
The restriction is "macro-expanded macros cannot shadow glob-imported macros during resolution in module", where "in module" means the macro path has module prefix (`module::my_macro!()`, but not `my_macro!()`).

This is a special case that was assumed to be necessary to resolve multi-segment macro paths reliably, but it's likely that the assumption was incorrect.