### PR TITLE
Fix a stutter in the docs for slice::exact_chunks

### DIFF
--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -702,8 +702,7 @@ impl<T> [T] {
     /// resulting code better than in the case of [`chunks`].
     ///
     /// See [`chunks`] for a variant of this iterator that also returns the remainder as a smaller
-    /// chunk, and [`rchunks_exact`] for the same iterator but starting at the end of the slice of
-    /// the slice.
+    /// chunk, and [`rchunks_exact`] for the same iterator but starting at the end of the slice.
     ///
     /// # Panics
     ///


### PR DESCRIPTION
Before this change, the docs for `slice::exact_chunks` reads like this:

> See `chunks` for a variant of this iterator that also returns the remainder as a smaller chunk, and `rchunks_exact` for the same iterator but starting at the end of the slice of the slice.

Notice that stutter at the end? This commit fixes it.