### PR TITLE
2018 edition - confusing error message when declaring unnamed parameters 

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1850,6 +1850,15 @@ impl<'a> Parser<'a> {
                         Applicability::HasPlaceholders,
                     );
                 } else if require_name && is_trait_item {
+                    if let PatKind::Ident(_, ident, _) = pat.node {
+                        err.span_suggestion_with_applicability(
+                            pat.span,
+                            "explicitly ignore parameter",
+                            format!("_: {}", ident),
+                            Applicability::MachineApplicable,
+                        );
+                    }
+
                     err.note("anonymous parameters are removed in the 2018 edition (see RFC 1685)");
                 }
 

--- a/src/test/ui/anon-params-denied-2018.stderr
+++ b/src/test/ui/anon-params-denied-2018.stderr
@@ -3,12 +3,16 @@ error: expected one of `:` or `@`, found `)`
    |
 LL |     fn foo(i32); //~ expected one of `:` or `@`, found `)`
    |               ^ expected one of `:` or `@` here
+   |
+   = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
 
 error: expected one of `:` or `@`, found `,`
   --> $DIR/anon-params-denied-2018.rs:8:36
    |
 LL |     fn bar_with_default_impl(String, String) {}
    |                                    ^ expected one of `:` or `@` here
+   |
+   = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/anon-params-denied-2018.stderr
+++ b/src/test/ui/anon-params-denied-2018.stderr
@@ -2,7 +2,9 @@ error: expected one of `:` or `@`, found `)`
   --> $DIR/anon-params-denied-2018.rs:6:15
    |
 LL |     fn foo(i32); //~ expected one of `:` or `@`, found `)`
-   |               ^ expected one of `:` or `@` here
+   |            ---^ expected one of `:` or `@` here
+   |            |
+   |            help: explicitly ignore parameter: `_: i32`
    |
    = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
 
@@ -10,7 +12,9 @@ error: expected one of `:` or `@`, found `,`
   --> $DIR/anon-params-denied-2018.rs:8:36
    |
 LL |     fn bar_with_default_impl(String, String) {}
-   |                                    ^ expected one of `:` or `@` here
+   |                              ------^ expected one of `:` or `@` here
+   |                              |
+   |                              help: explicitly ignore parameter: `_: String`
    |
    = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
 


### PR DESCRIPTION
Fixes #53990.

This PR adds a note providing context for the change to argument
names being required in the 2018 edition for trait methods and a
suggestion for the fix.