### PR TITLE
Unconditionally emit the target-cpu LLVM attribute.

### DIFF
--- a/src/librustc_codegen_llvm/attributes.rs
+++ b/src/librustc_codegen_llvm/attributes.rs
@@ -18,6 +18,7 @@ use rustc::session::config::Sanitizer;
 use rustc::ty::TyCtxt;
 use rustc::ty::layout::HasTyCtxt;
 use rustc::ty::query::Providers;
+use rustc_data_structures::small_c_str::SmallCStr;
 use rustc_data_structures::sync::Lrc;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_target::spec::PanicStrategy;
@@ -129,8 +130,7 @@ pub fn llvm_target_features(sess: &Session) -> impl Iterator<Item = &str> {
 }
 
 pub fn apply_target_cpu_attr(cx: &CodegenCx<'ll, '_>, llfn: &'ll Value) {
-    let cpu = llvm_util::target_cpu(cx.tcx.sess);
-    let target_cpu = CString::new(cpu).unwrap();
+    let target_cpu = SmallCStr::new(llvm_util::target_cpu(cx.tcx.sess));
     llvm::AddFunctionAttrStringValue(
             llfn,
             llvm::AttributePlace::Function,
@@ -220,11 +220,7 @@ pub fn from_fn_attrs(
     // Always annotate functions with the target-cpu they are compiled for.
     // Without this, ThinLTO won't inline Rust functions into Clang generated
     // functions (because Clang annotates functions this way too).
-    // NOTE: For now we just apply this if -Zcross-lang-lto is specified, since
-    //       it introduce a little overhead and isn't really necessary otherwise.
-    if cx.tcx.sess.opts.debugging_opts.cross_lang_lto.enabled() {
-        apply_target_cpu_attr(cx, llfn);
-    }
+    apply_target_cpu_attr(cx, llfn);
 
     let features = llvm_target_features(cx.tcx.sess)
         .map(|s| s.to_string())


### PR DESCRIPTION
This PR makes `rustc` always emit the `target-cpu` LLVM attribute for functions. The goal is to allow for cross-language inlining of functions defined in `libstd`. So far `libstd` functions were the only function without a `target-cpu` attribute, so in whole-crate-graph cross-lang LTO scenarios they were not eligible for inlining into foreign code.

r? @alexcrichton 