### PR TITLE
Encode `TraitAlias` as if they were `Trait`

### DIFF
--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -1141,7 +1141,8 @@ impl<'a, 'b: 'a, 'tcx: 'b> IsolatedEncoder<'a, 'b, 'tcx> {
 
                 EntryKind::Impl(self.lazy(&data))
             }
-            hir::ItemKind::Trait(..) => {
+            hir::ItemKind::Trait(..) |
+            hir::ItemKind::TraitAlias(..) => {
                 let trait_def = tcx.trait_def(def_id);
                 let data = TraitData {
                     unsafety: trait_def.unsafety,
@@ -1154,7 +1155,6 @@ impl<'a, 'b: 'a, 'tcx: 'b> IsolatedEncoder<'a, 'b, 'tcx> {
                 EntryKind::Trait(self.lazy(&data))
             }
             hir::ItemKind::ExternCrate(_) |
-            hir::ItemKind::TraitAlias(..) |
             hir::ItemKind::Use(..) => bug!("cannot encode info for item {:?}", item),
         };
 

--- a/src/test/ui/run-pass/traits/trait-alias.rs
+++ b/src/test/ui/run-pass/traits/trait-alias.rs
@@ -1,0 +1,7 @@
+// run-pass
+#![feature(trait_alias)]
+
+pub trait Foo {}
+pub trait FooAlias = Foo;
+
+fn main() {}


### PR DESCRIPTION
Fix #56539.