### PR TITLE
resolve: Reduce some clutter in import ambiguity errors

### DIFF
--- a/src/test/ui/imports/issue-56125.rs
+++ b/src/test/ui/imports/issue-56125.rs
@@ -7,13 +7,11 @@
 mod m1 {
     use issue_56125::last_segment::*;
     //~^ ERROR `issue_56125` is ambiguous
-    //~| ERROR unresolved import `issue_56125::last_segment`
 }
 
 mod m2 {
     use issue_56125::non_last_segment::non_last_segment::*;
     //~^ ERROR `issue_56125` is ambiguous
-    //~| ERROR failed to resolve: could not find `non_last_segment` in `issue_56125`
 }
 
 mod m3 {

--- a/src/test/ui/imports/issue-56125.stderr
+++ b/src/test/ui/imports/issue-56125.stderr
@@ -1,17 +1,5 @@
-error[E0433]: failed to resolve: could not find `non_last_segment` in `issue_56125`
-  --> $DIR/issue-56125.rs:14:22
-   |
-LL |     use issue_56125::non_last_segment::non_last_segment::*;
-   |                      ^^^^^^^^^^^^^^^^ could not find `non_last_segment` in `issue_56125`
-
-error[E0432]: unresolved import `issue_56125::last_segment`
-  --> $DIR/issue-56125.rs:8:22
-   |
-LL |     use issue_56125::last_segment::*;
-   |                      ^^^^^^^^^^^^ could not find `last_segment` in `issue_56125`
-
 error[E0432]: unresolved import `empty::issue_56125`
-  --> $DIR/issue-56125.rs:21:9
+  --> $DIR/issue-56125.rs:19:9
    |
 LL |     use empty::issue_56125; //~ ERROR unresolved import `empty::issue_56125`
    |         ^^^^^^^^^^^^^^^^^^ no `issue_56125` in `m3::empty`
@@ -32,7 +20,7 @@ LL |     use issue_56125::last_segment::*;
    = help: use `self::issue_56125` to refer to this module unambiguously
 
 error[E0659]: `issue_56125` is ambiguous (name vs any other name during import resolution)
-  --> $DIR/issue-56125.rs:14:9
+  --> $DIR/issue-56125.rs:13:9
    |
 LL |     use issue_56125::non_last_segment::non_last_segment::*;
    |         ^^^^^^^^^^^ ambiguous name
@@ -40,14 +28,14 @@ LL |     use issue_56125::non_last_segment::non_last_segment::*;
    = note: `issue_56125` could refer to an extern crate passed with `--extern`
    = help: use `::issue_56125` to refer to this extern crate unambiguously
 note: `issue_56125` could also refer to the module imported here
-  --> $DIR/issue-56125.rs:14:9
+  --> $DIR/issue-56125.rs:13:9
    |
 LL |     use issue_56125::non_last_segment::non_last_segment::*;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: use `self::issue_56125` to refer to this module unambiguously
 
 error[E0659]: `issue_56125` is ambiguous (name vs any other name during import resolution)
-  --> $DIR/issue-56125.rs:22:9
+  --> $DIR/issue-56125.rs:20:9
    |
 LL |     use issue_56125::*; //~ ERROR `issue_56125` is ambiguous
    |         ^^^^^^^^^^^ ambiguous name
@@ -55,13 +43,13 @@ LL |     use issue_56125::*; //~ ERROR `issue_56125` is ambiguous
    = note: `issue_56125` could refer to an extern crate passed with `--extern`
    = help: use `::issue_56125` to refer to this extern crate unambiguously
 note: `issue_56125` could also refer to the unresolved item imported here
-  --> $DIR/issue-56125.rs:21:9
+  --> $DIR/issue-56125.rs:19:9
    |
 LL |     use empty::issue_56125; //~ ERROR unresolved import `empty::issue_56125`
    |         ^^^^^^^^^^^^^^^^^^
    = help: use `self::issue_56125` to refer to this unresolved item unambiguously
 
-error: aborting due to 6 previous errors
+error: aborting due to 4 previous errors
 
-Some errors occurred: E0432, E0433, E0659.
+Some errors occurred: E0432, E0659.
 For more information about an error, try `rustc --explain E0432`.


### PR DESCRIPTION
Noticed in https://www.reddit.com/r/rust/comments/a3pyrw/announcing_rust_131_and_rust_2018/eb8alhi/.
The first error is distracting, but unnecessary, it's a *consequence* of the ambiguity error and appears because one of the ambiguous `actix` modules (unsurprisingly) doesn't have the expected name in it.