### PR TITLE
Fix right arrow size for crate filter

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -641,7 +641,7 @@ a {
 	text-overflow: "";
 	background-repeat: no-repeat;
 	background-color: transparent;
-	background-size: 16%;
+	background-size: 20px;
 	background-position: calc(100% - 1px) 56%;
 }
 .search-container > .top-button {


### PR DESCRIPTION
This bug only appears when a crate has a long name:

<img width="1440" alt="screenshot 2018-12-08 at 16 36 21" src="https://user-images.githubusercontent.com/3050060/49687728-7de06180-fb07-11e8-8554-d32597351fac.png">

With this fix, it goes back to normal, whatever the size:

<img width="1440" alt="screenshot 2018-12-08 at 16 36 05" src="https://user-images.githubusercontent.com/3050060/49687730-8769c980-fb07-11e8-91b7-b5e1961211a2.png">

r? @QuietMisdreavus 