### PR TITLE
rustdoc: Fix local reexports of proc macros

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1512,7 +1512,8 @@ impl DocFolder for Cache {
             clean::FunctionItem(..) | clean::ModuleItem(..) |
             clean::ForeignFunctionItem(..) | clean::ForeignStaticItem(..) |
             clean::ConstantItem(..) | clean::StaticItem(..) |
-            clean::UnionItem(..) | clean::ForeignTypeItem | clean::MacroItem(..)
+            clean::UnionItem(..) | clean::ForeignTypeItem |
+            clean::MacroItem(..) | clean::ProcMacroItem(..)
             if !self.stripped_mod => {
                 // Re-exported items mean that the same id can show up twice
                 // in the rustdoc ast that we're looking at. We know,

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -424,10 +424,11 @@ impl<'a, 'tcx, 'rcx, 'cstore> RustdocVisitor<'a, 'tcx, 'rcx, 'cstore> {
             hir::ItemKind::Use(ref path, kind) => {
                 let is_glob = kind == hir::UseKind::Glob;
 
-                // Struct and variant constructors always show up alongside their definitions, we've
-                // already processed them so just discard these.
+                // Struct and variant constructors and proc macro stubs always show up alongside
+                // their definitions, we've already processed them so just discard these.
                 match path.def {
-                    Def::StructCtor(..) | Def::VariantCtor(..) | Def::SelfCtor(..) => return,
+                    Def::StructCtor(..) | Def::VariantCtor(..) | Def::SelfCtor(..) |
+                    Def::Macro(_, MacroKind::ProcMacroStub) => return,
                     _ => {}
                 }
 

--- a/src/test/rustdoc/proc-macro.rs
+++ b/src/test/rustdoc/proc-macro.rs
@@ -61,3 +61,16 @@ pub fn some_proc_attr(_attr: TokenStream, item: TokenStream) -> TokenStream {
 pub fn some_derive(_item: TokenStream) -> TokenStream {
     TokenStream::new()
 }
+
+// @has some_macros/foo/index.html
+pub mod foo {
+    // @has - '//code' 'pub use some_proc_macro;'
+    // @has - '//a/@href' '../../some_macros/macro.some_proc_macro.html'
+    pub use some_proc_macro;
+    // @has - '//code' 'pub use some_proc_attr;'
+    // @has - '//a/@href' '../../some_macros/attr.some_proc_attr.html'
+    pub use some_proc_attr;
+    // @has - '//code' 'pub use some_derive;'
+    // @has - '//a/@href' '../../some_macros/derive.SomeDerive.html'
+    pub use some_derive;
+}


### PR DESCRIPTION
Filter out `ProcMacroStub`s to avoid an ICE during cleaning.

Also add proc macros to `cache().paths` so it can generate links.

r? @QuietMisdreavus