### PR TITLE
Add regression test for ICE

### DIFF
--- a/src/test/ui/issue-55846.rs
+++ b/src/test/ui/issue-55846.rs
@@ -1,0 +1,39 @@
+// run-pass
+
+// Regression test for #55846, which once caused an ICE.
+
+use std::marker::PhantomData;
+
+struct Foo;
+
+struct Bar<A> {
+    a: PhantomData<A>,
+}
+
+impl Fooifier for Foo {
+    type Assoc = Foo;
+}
+
+trait Fooifier {
+    type Assoc;
+}
+
+trait Barifier<H> {
+    fn barify();
+}
+
+impl<H> Barifier<H> for Bar<H> {
+    fn barify() {
+        println!("All correct!");
+    }
+}
+
+impl Bar<<Foo as Fooifier>::Assoc> {
+    fn this_shouldnt_crash() {
+        <Self as Barifier<<Foo as Fooifier>::Assoc>>::barify();
+    }
+}
+
+fn main() {
+    Bar::<Foo>::this_shouldnt_crash();
+}


### PR DESCRIPTION
Fixes #55846 with a minimal (or as best as I can manage) test case. I tested this against 1.30.0 manually to confirm it crashes.

The issue seemed to have something to do with associated types. It's possible someone with more knowledge can shrink the test case down further, or make it clearer.