### PR TITLE
Use compiletest timestamp to check if the tests should be rerun.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,6 +431,7 @@ dependencies = [
  "serde 1.0.81 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.81 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/src/tools/compiletest/Cargo.toml
+++ b/src/tools/compiletest/Cargo.toml
@@ -15,6 +15,7 @@ serde_json = "1.0"
 serde_derive = "1.0"
 rustfix = "0.4.1"
 lazy_static = "1.0"
+walkdir = "2"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"


### PR DESCRIPTION
An attempt to fix  #56280 by checking if timestamps of compile test files are older than the timestamp of the stamp file.

?r nagisa