### PR TITLE
Fix the UB recommended in the wrapping_offset docs

### DIFF
--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -1103,8 +1103,7 @@ impl<T: ?Sized> *const T {
     /// unless `x` and `y` point into the same allocated object.
     ///
     /// Always use `.offset(count)` instead when possible, because `offset`
-    /// allows the compiler to optimize better.  If you need to cross object
-    /// boundaries, cast the pointer to an integer and do the arithmetic there.
+    /// allows the compiler to optimize better.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
If we do want to make this not UB (which I doubt we do), it would require an RFC. Fixes #56697