### PR TITLE
Always set the RDRAND and RDSEED features on SGX

### DIFF
--- a/src/librustc_target/spec/x86_64_fortanix_unknown_sgx.rs
+++ b/src/librustc_target/spec/x86_64_fortanix_unknown_sgx.rs
@@ -49,6 +49,7 @@ pub fn target() -> Result<Target, String> {
         max_atomic_width: Some(64),
         panic_strategy: PanicStrategy::Abort,
         cpu: "x86-64".into(),
+        features: "+rdrnd,+rdseed".into(),
         position_independent_executables: true,
         pre_link_args: iter::once(
                 (LinkerFlavor::Gcc, PRE_LINK_ARGS.iter().cloned().map(String::from).collect())


### PR DESCRIPTION
Not sure if this is 100% correct.

This [Intel article](https://software.intel.com/en-us/articles/intel-software-guard-extensions-tutorial-part-5-enclave-development) goes in great depth regarding using (untrusted) CPUID to see whether RDRAND/RDSEED is supported, and explains what happens to the enclave if the CPUID result is faked.

I'd say that an implementation of SGX that doesn't make RDRAND available to the enclave is so severely limited/broken that it's ok if you get #UD in that case. The case is less clear for RDSEED, but it so far every processor released by Intel with SGX support also has RDSEED (including Gemini Lake).

cc @briansmith