### PR TITLE
[experiment] Allocate DepGraph::read_index de-duplication hashset more lazily.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2063,6 +2063,7 @@ dependencies = [
  "backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "chalk-engine 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fmt_macros 0.0.0",

--- a/src/librustc/Cargo.toml
+++ b/src/librustc/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["dylib"]
 [dependencies]
 arena = { path = "../libarena" }
 bitflags = "1.0"
+cfg-if = "0.1.2"
 fmt_macros = { path = "../libfmt_macros" }
 graphviz = { path = "../libgraphviz" }
 jobserver = "0.1"

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -69,6 +69,7 @@
 #![feature(in_band_lifetimes)]
 #![feature(crate_visibility_modifier)]
 #![feature(transpose_result)]
+#![cfg_attr(not(stage0), feature(stdsimd))]
 
 #![recursion_limit="512"]
 
@@ -108,6 +109,8 @@ extern crate backtrace;
 
 #[macro_use]
 extern crate smallvec;
+#[macro_use]
+extern crate cfg_if;
 
 // Note that librustc doesn't actually depend on these crates, see the note in
 // `Cargo.toml` for this crate about why these are here.


### PR DESCRIPTION
Possibly an optimization for `DepGraph::read_index()`. Might need some tweaking. I also want to try a SIMD-based version.