### PR TITLE
fix rust-lang/rust issue #50583

### DIFF
--- a/src/ci/docker/dist-various-1/Dockerfile
+++ b/src/ci/docker/dist-various-1/Dockerfile
@@ -52,8 +52,8 @@ RUN env \
     CXX=arm-linux-gnueabi-g++ CXXFLAGS="-march=armv6 -marm" \
     bash musl.sh arm && \
     env \
-    CC=arm-linux-gnueabihf-gcc CFLAGS="-march=armv6 -marm" \
-    CXX=arm-linux-gnueabihf-g++ CXXFLAGS="-march=armv6 -marm" \
+    CC=arm-linux-gnueabihf-gcc CFLAGS="-march=armv6 -marm -mfpu=vfp" \
+    CXX=arm-linux-gnueabihf-g++ CXXFLAGS="-march=armv6 -marm -mfpu=vfp" \
     bash musl.sh armhf && \
     env \
     CC=arm-linux-gnueabihf-gcc CFLAGS="-march=armv7-a" \


### PR DESCRIPTION
Rationale for the fix is in #50583.  I've verified that before the fix /musl-armhf/lib/libc.a is riddled with the illegal variant of vmov.f64 and after the fix the version built doesn't contain any of these illegal instructions.

I originally thought that the arm-linux-gnueabi version also needed fixing - to add a -mfloat-abi-soft but that's unnecessary as it's compiled with the gnueabi (not hf) compiler (I've some a quick check that the libc.a produced doesn't include VFP instructions).

r? @alexcrichton 