### PR TITLE
Use the previous AppVeyor 2017 image

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -87,7 +87,7 @@ environment:
     DIST_REQUIRE_ALL_TOOLS: 1
     DEPLOY: 1
     CI_JOB_NAME: dist-x86_64-msvc
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017 Preview
+    APPVEYOR_BUILD_WORKER_IMAGE: Previous Visual Studio 2017 Preview
   - RUST_CONFIGURE_ARGS: >
       --build=i686-pc-windows-msvc
       --target=i586-pc-windows-msvc


### PR DESCRIPTION
They've rolled out some updates [1] but we're not compatible with it
[2], let's give us some more time to work through the issues!

[1]: https://help.appveyor.com/discussions/problems/18543-detection-of-clexe-just-started-failing-in-default-build-image
[2]: https://ci.appveyor.com/project/rust-lang/rust/builds/20943647/job/x4rbo1h4lrm1xltb