### PR TITLE
Fix gpg signing in manifest builder

### DIFF
--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -623,6 +623,7 @@ impl Builder {
         let mut cmd = Command::new("gpg");
         cmd.arg("--no-tty")
             .arg("--yes")
+            .arg("--batch")
             .arg("--passphrase-fd").arg("0")
             .arg("--personal-digest-preferences").arg("SHA512")
             .arg("--armor")


### PR DESCRIPTION
GPG versions 2.x+ require that --batch be passed if --passphrase-fd is
to be accepted.

From the man page:

       --passphrase-fd n
              Read  the passphrase from file descriptor n. Only the first line
              will be read from file descriptor n. If you use  0  for  n,  the
              passphrase  will  be  read  from STDIN. This can only be used if
              only one passphrase is supplied.

              Note that this passphrase is only used if the option --batch has
              also been given.  This is different from GnuPG version 1.x.
