### PR TITLE
Disable btree pretty-printers on older gdbs

### DIFF
--- a/src/test/debuginfo/pretty-std-collections.rs
+++ b/src/test/debuginfo/pretty-std-collections.rs
@@ -13,7 +13,11 @@
 // ignore-freebsd: gdb package too new
 // ignore-android: FIXME(#10381)
 // compile-flags:-g
-// min-gdb-version 7.7
+
+// The pretty printers being tested here require the patch from
+// https://sourceware.org/bugzilla/show_bug.cgi?id=21763
+// min-gdb-version 8.1
+
 // min-lldb-version: 310
 
 // === GDB TESTS ===================================================================================


### PR DESCRIPTION
gdb versions before 8.1 have a bug that prevents the BTreeSet and
BTreeMap pretty-printers from working.  This patch disables the test
on those versions, and also disables the pretty-printers there as
well.

Closes #56730