### PR TITLE
Add short emoji status to toolstate updates

### DIFF
--- a/src/tools/publish_toolstate.py
+++ b/src/tools/publish_toolstate.py
@@ -34,6 +34,16 @@ MAINTAINERS = {
     'rust-by-example': '@steveklabnik @marioidival @projektir',
 }
 
+EMOJI = {
+    'miri': '🛰️',
+    'clippy-driver': '📎',
+    'rls': '💻',
+    'rustfmt': '📝',
+    'book': '📖',
+    'nomicon': '👿',
+    'reference': '📚',
+    'rust-by-example': '👩‍🏫',
+}
 
 def read_current_status(current_commit, path):
     '''Reads build status of `current_commit` from content of `history/*.tsv`
@@ -63,13 +73,12 @@ def update_latest(
         }
 
         slug = 'rust-lang/rust'
-        message = textwrap.dedent('''\
-            📣 Toolstate changed by {}!
-
+        long_message = textwrap.dedent('''\
             Tested on commit {}@{}.
             Direct link to PR: <{}>
 
-        ''').format(relevant_pr_number, slug, current_commit, relevant_pr_url)
+        ''').format(slug, current_commit, relevant_pr_url)
+        emoji_status = []
         anything_changed = False
         for status in latest:
             tool = status['tool']
@@ -81,12 +90,18 @@ def update_latest(
                 status[os] = new
                 if new > old:
                     changed = True
-                    message += '🎉 {} on {}: {} → {} (cc {}, @rust-lang/infra).\n' \
-                        .format(tool, os, old, new, MAINTAINERS.get(tool))
+                    long_message += '🎉 {} on {}: {} → {}.\n' \
+                        .format(tool, os, old, new)
+                    emoji = "{}🎉".format(EMOJI.get(tool))
+                    if msg not in emoji_status:
+                        emoji_status += [msg]
                 elif new < old:
                     changed = True
-                    message += '💔 {} on {}: {} → {} (cc {}, @rust-lang/infra).\n' \
+                    long_message += '💔 {} on {}: {} → {} (cc {}, @rust-lang/infra).\n' \
                         .format(tool, os, old, new, MAINTAINERS.get(tool))
+                    emoji = "{}💔".format(EMOJI.get(tool))
+                    if msg not in emoji_status:
+                        emoji_status += [msg]
 
             if changed:
                 status['commit'] = current_commit
@@ -96,6 +111,9 @@ def update_latest(
         if not anything_changed:
             return ''
 
+        short_message = "📣 Toolstate changed by {}! ({})"
+            .format(relevant_pr_number, '/'.join(emoji_status))
+        message = short_message + "\n\n" + long_message
         f.seek(0)
         f.truncate(0)
         json.dump(latest, f, indent=4, separators=(',', ': '))


### PR DESCRIPTION
I get a lot of these emails and it's good to know which ones I should be paying closer attention to -- i.e. the ones where clippy breaks. This adds a short emoji status report to the first line of the commit message, which shows up in notifications directly


I haven't been able to test it, and the actual emoji are just suggestions.

r? @kennytm

cc @rust-lang/infra @rust-lang/devtools