### PR TITLE
docs(rustc): make hello() public

### DIFF
--- a/src/doc/rustc/src/what-is-rustc.md
+++ b/src/doc/rustc/src/what-is-rustc.md
@@ -50,7 +50,7 @@ fn main() {
 And a `foo.rs` that had this:
 
 ```rust,ignore
-fn hello() {
+pub fn hello() {
     println!("Hello, world!");
 }
 ```


### PR DESCRIPTION
Running the example code [here](https://doc.rust-lang.org/rustc/what-is-rustc.html#basic-usage) throws error:
```
error[E0603]: function `hello` is private
 --> src/main.rs:4:10
  |
4 |     foo::hello();
  |          ^^^^^
```
Making  `hello()` public fixes the problem.