### PR TITLE
Add `--pinentry-mode=loopback` to deployment script

### DIFF
--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -621,7 +621,8 @@ impl Builder {
         let asc = self.output.join(format!("{}.asc", filename));
         println!("signing: {:?}", path);
         let mut cmd = Command::new("gpg");
-        cmd.arg("--no-tty")
+        cmd.arg("--pinentry-mode=loopback")
+            .arg("--no-tty")
             .arg("--yes")
             .arg("--batch")
             .arg("--passphrase-fd").arg("0")


### PR DESCRIPTION
Apparently this changed with gpg2 or... something like that?