### PR TITLE
Change bounds on `TryFrom` blanket impl to use `Into` instead of `From`

### DIFF
--- a/src/libcore/convert.rs
+++ b/src/libcore/convert.rs
@@ -476,11 +476,11 @@ impl<T, U> TryInto<U> for T where U: TryFrom<T>
 // Infallible conversions are semantically equivalent to fallible conversions
 // with an uninhabited error type.
 #[unstable(feature = "try_from", issue = "33417")]
-impl<T, U> TryFrom<U> for T where T: From<U> {
+impl<T, U> TryFrom<U> for T where U: Into<T> {
     type Error = !;
 
     fn try_from(value: U) -> Result<Self, Self::Error> {
-        Ok(T::from(value))
+        Ok(U::into(value))
     }
 }
 

--- a/src/test/run-pass/try_from.rs
+++ b/src/test/run-pass/try_from.rs
@@ -1,0 +1,43 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This test relies on `TryFrom` being auto impl for all `T: Into`
+// and `TryInto` being auto impl for all `U: TryFrom`
+
+// This test was added to show the motivation for doing this
+// over `TryFrom` being auto impl for all `T: From`
+
+#![feature(try_from, never_type)]
+
+use std::convert::TryInto;
+
+struct Foo<T> {
+    t: T
+}
+
+/*
+// This fails to compile due to coherence restrictions
+// as of rust version 1.32.x
+impl<T> From<Foo<T>> for Box<T> {
+    fn from(foo: Foo<T>) -> Box<T> {
+        Box::new(foo.t)
+    }
+}
+*/
+
+impl<T> Into<Box<T>> for Foo<T> {
+    fn into(self) -> Box<T> {
+        Box::new(self.t)
+    }
+}
+
+pub fn main() {
+    let _: Result<Box<i32>, !> = Foo { t: 10 }.try_into();
+}

--- a/src/test/run-pass/try_from.rs
+++ b/src/test/run-pass/try_from.rs
@@ -32,12 +32,13 @@ impl<T> From<Foo<T>> for Box<T> {
 }
 */
 
-impl<T> Into<Box<T>> for Foo<T> {
-    fn into(self) -> Box<T> {
-        Box::new(self.t)
+impl<T> Into<Vec<T>> for Foo<T> {
+    fn into(self) -> Vec<T> {
+        vec![self.t]
     }
 }
 
 pub fn main() {
-    let _: Result<Box<i32>, !> = Foo { t: 10 }.try_into();
+    let _: Result<Vec<i32>, !> = Foo { t: 10 }.try_into();
 }
+

--- a/src/test/run-pass/try_from.rs
+++ b/src/test/run-pass/try_from.rs
@@ -1,30 +1,23 @@
-// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
-// file at the top-level directory of this distribution and at
-// http://rust-lang.org/COPYRIGHT.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
-// This test relies on `TryFrom` being auto impl for all `T: Into`
-// and `TryInto` being auto impl for all `U: TryFrom`
+// This test relies on `TryFrom` being blanket impl for all `T: Into`
+// and `TryInto` being blanket impl for all `U: TryFrom`
 
 // This test was added to show the motivation for doing this
-// over `TryFrom` being auto impl for all `T: From`
+// over `TryFrom` being blanket impl for all `T: From`
 
 #![feature(try_from, never_type)]
 
 use std::convert::TryInto;
 
 struct Foo<T> {
-    t: T
+    t: T,
 }
 
-/*
 // This fails to compile due to coherence restrictions
-// as of rust version 1.32.x
+// as of Rust version 1.32.x, therefore it could not be used
+// instead of the `Into` version of the impl, and serves as
+// motivation for a blanket impl for all `T: Into`, instead
+// of a blanket impl for all `T: From`
+/*
 impl<T> From<Foo<T>> for Box<T> {
     fn from(foo: Foo<T>) -> Box<T> {
         Box::new(foo.t)

--- a/src/test/ui/e0119/conflict-with-std.stderr
+++ b/src/test/ui/e0119/conflict-with-std.stderr
@@ -25,7 +25,7 @@ LL | impl TryFrom<X> for X { //~ ERROR conflicting implementations
    |
    = note: conflicting implementation in crate `core`:
            - impl<T, U> std::convert::TryFrom<U> for T
-             where T: std::convert::From<U>;
+             where T: std::convert::Into<U>;
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/e0119/conflict-with-std.stderr
+++ b/src/test/ui/e0119/conflict-with-std.stderr
@@ -25,7 +25,7 @@ LL | impl TryFrom<X> for X { //~ ERROR conflicting implementations
    |
    = note: conflicting implementation in crate `core`:
            - impl<T, U> std::convert::TryFrom<U> for T
-             where T: std::convert::Into<U>;
+             where U: std::convert::Into<T>;
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
This is from this [comment](https://github.com/rust-lang/rust/issues/33417#issuecomment-447111156) I made.

This will expand the impls available for `TryFrom` and `TryInto`, without losing anything in the process.