### PR TITLE
Stabilize `Rc`, `Arc` and `Pin` as method receivers

### DIFF
--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -77,7 +77,9 @@ use core::iter::{Iterator, FromIterator, FusedIterator};
 use core::marker::{Unpin, Unsize};
 use core::mem;
 use core::pin::Pin;
-use core::ops::{CoerceUnsized, DispatchFromDyn, Deref, DerefMut, Generator, GeneratorState};
+use core::ops::{
+    CoerceUnsized, DispatchFromDyn, Deref, DerefMut, Receiver, Generator, GeneratorState
+};
 use core::ptr::{self, NonNull, Unique};
 use core::task::{LocalWaker, Poll};
 
@@ -582,6 +584,9 @@ impl<T: ?Sized> DerefMut for Box<T> {
         &mut **self
     }
 }
+
+#[unstable(feature = "receiver_trait", issue = "0")]
+impl<T: ?Sized> Receiver for Box<T> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<I: Iterator + ?Sized> Iterator for Box<I> {

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -104,6 +104,7 @@
 #![feature(ptr_internals)]
 #![feature(ptr_offset_from)]
 #![feature(rustc_attrs)]
+#![feature(receiver_trait)]
 #![feature(specialization)]
 #![feature(split_ascii_whitespace)]
 #![feature(staged_api)]

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -253,7 +253,7 @@ use core::intrinsics::abort;
 use core::marker;
 use core::marker::{Unpin, Unsize, PhantomData};
 use core::mem::{self, align_of_val, forget, size_of_val};
-use core::ops::Deref;
+use core::ops::{Deref, Receiver};
 use core::ops::{CoerceUnsized, DispatchFromDyn};
 use core::pin::Pin;
 use core::ptr::{self, NonNull};
@@ -812,6 +812,9 @@ impl<T: ?Sized> Deref for Rc<T> {
         &self.inner().value
     }
 }
+
+#[unstable(feature = "receiver_trait", issue = "0")]
+impl<T: ?Sized> Receiver for Rc<T> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<#[may_dangle] T: ?Sized> Drop for Rc<T> {

--- a/src/liballoc/sync.rs
+++ b/src/liballoc/sync.rs
@@ -24,7 +24,7 @@ use core::fmt;
 use core::cmp::Ordering;
 use core::intrinsics::abort;
 use core::mem::{self, align_of_val, size_of_val};
-use core::ops::Deref;
+use core::ops::{Deref, Receiver};
 use core::ops::{CoerceUnsized, DispatchFromDyn};
 use core::pin::Pin;
 use core::ptr::{self, NonNull};
@@ -766,6 +766,9 @@ impl<T: ?Sized> Deref for Arc<T> {
         &self.inner().data
     }
 }
+
+#[unstable(feature = "receiver_trait", issue = "0")]
+impl<T: ?Sized> Receiver for Arc<T> {}
 
 impl<T: Clone> Arc<T> {
     /// Makes a mutable reference into the given `Arc`.

--- a/src/libcore/ops/deref.rs
+++ b/src/libcore/ops/deref.rs
@@ -177,3 +177,19 @@ pub trait DerefMut: Deref {
 impl<T: ?Sized> DerefMut for &mut T {
     fn deref_mut(&mut self) -> &mut T { *self }
 }
+
+/// Indicates that a struct can be used as a method receiver, without the
+/// `arbitrary_self_types` feature. This is implemented by stdlib pointer types like `Box<T>`,
+/// `Rc<T>`, `&T`, and `Pin<P>`.
+#[cfg_attr(not(stage0), lang = "receiver")]
+#[unstable(feature = "receiver_trait", issue = "0")]
+#[doc(hidden)]
+pub trait Receiver {
+    // Empty.
+}
+
+#[unstable(feature = "receiver_trait", issue = "0")]
+impl<T: ?Sized> Receiver for &T {}
+
+#[unstable(feature = "receiver_trait", issue = "0")]
+impl<T: ?Sized> Receiver for &mut T {}

--- a/src/libcore/ops/mod.rs
+++ b/src/libcore/ops/mod.rs
@@ -178,6 +178,9 @@ pub use self::bit::{BitAndAssign, BitOrAssign, BitXorAssign, ShlAssign, ShrAssig
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::deref::{Deref, DerefMut};
 
+#[unstable(feature = "receiver_trait", issue = "0")]
+pub use self::deref::Receiver;
+
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::drop::Drop;
 

--- a/src/libcore/pin.rs
+++ b/src/libcore/pin.rs
@@ -101,7 +101,7 @@
 
 use fmt;
 use marker::Sized;
-use ops::{Deref, DerefMut, CoerceUnsized, DispatchFromDyn};
+use ops::{Deref, DerefMut, Receiver, CoerceUnsized, DispatchFromDyn};
 
 #[doc(inline)]
 pub use marker::Unpin;
@@ -301,6 +301,9 @@ where
         Pin::get_mut(Pin::as_mut(self))
     }
 }
+
+#[unstable(feature = "receiver_trait", issue = "0")]
+impl<P: Receiver> Receiver for Pin<P> {}
 
 #[unstable(feature = "pin", issue = "49150")]
 impl<P: fmt::Debug> fmt::Debug for Pin<P> {

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -301,6 +301,7 @@ language_item_table! {
 
     DerefTraitLangItem,          "deref",              deref_trait,             Target::Trait;
     DerefMutTraitLangItem,       "deref_mut",          deref_mut_trait,         Target::Trait;
+    ReceiverTraitLangItem,       "receiver",           receiver_trait,          Target::Trait;
 
     FnTraitLangItem,             "fn",                 fn_trait,                Target::Trait;
     FnMutTraitLangItem,          "fn_mut",             fn_mut_trait,            Target::Trait;

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -795,6 +795,14 @@ fn check_method_receiver<'fcx, 'gcx, 'tcx>(fcx: &FnCtxt<'fcx, 'gcx, 'tcx>,
     }
 }
 
+/// returns true if `receiver_ty` would be considered a valid receiver type for `self_ty`. If
+/// `arbitrary_self_types` is enabled, `receiver_ty` must transitively deref to `self_ty`, possibly
+/// through a `*const/mut T` raw pointer. If the feature is not enabled, the requirements are more
+/// strict: `receiver_ty` must implement `Receiver` and directly implement `Deref<Target=self_ty>`.
+///
+/// NB: there are cases this function returns `true` but then causes an error to be raised later,
+/// particularly when `receiver_ty` derefs to a type that is the same as `self_ty` but has the
+/// wrong lifetime.
 fn receiver_is_valid<'fcx, 'tcx, 'gcx>(
     fcx: &FnCtxt<'fcx, 'gcx, 'tcx>,
     span: Span,

--- a/src/test/run-pass/arbitrary_self_types_stdlib_pointers.rs
+++ b/src/test/run-pass/arbitrary_self_types_stdlib_pointers.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(arbitrary_self_types)]
 #![feature(pin)]
 #![feature(rustc_attrs)]
 
@@ -23,6 +22,7 @@ trait Trait {
     fn by_arc(self: Arc<Self>) -> i64;
     fn by_pin_mut(self: Pin<&mut Self>) -> i64;
     fn by_pin_box(self: Pin<Box<Self>>) -> i64;
+    fn by_pin_pin_pin_ref(self: Pin<Pin<Pin<&Self>>>) -> i64;
 }
 
 impl Trait for i64 {
@@ -36,6 +36,9 @@ impl Trait for i64 {
         *self
     }
     fn by_pin_box(self: Pin<Box<Self>>) -> i64 {
+        *self
+    }
+    fn by_pin_pin_pin_ref(self: Pin<Pin<Pin<&Self>>>) -> i64 {
         *self
     }
 }
@@ -53,4 +56,8 @@ fn main() {
 
     let pin_box = Into::<Pin<Box<i64>>>::into(Box::new(4i64)) as Pin<Box<dyn Trait>>;
     assert_eq!(4, pin_box.by_pin_box());
+
+    let value = 5i64;
+    let pin_pin_pin_ref = Pin::new(Pin::new(Pin::new(&value))) as Pin<Pin<Pin<&dyn Trait>>>;
+    assert_eq!(5, pin_pin_pin_ref.by_pin_pin_pin_ref());
 }

--- a/src/test/ui/feature-gates/feature-gate-arbitrary-self-types.rs
+++ b/src/test/ui/feature-gates/feature-gate-arbitrary-self-types.rs
@@ -8,20 +8,32 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::rc::Rc;
+use std::{
+    ops::Deref,
+};
+
+struct Ptr<T: ?Sized>(Box<T>);
+
+impl<T: ?Sized> Deref for Ptr<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &*self.0
+    }
+}
 
 trait Foo {
-    fn foo(self: Rc<Box<Self>>); //~ ERROR arbitrary `self` types are unstable
+    fn foo(self: Ptr<Self>); //~ ERROR `Ptr<Self>` cannot be used as the type of `self` without
 }
 
 struct Bar;
 
 impl Foo for Bar {
-    fn foo(self: Rc<Box<Self>>) {} //~ ERROR arbitrary `self` types are unstable
+    fn foo(self: Ptr<Self>) {} //~ ERROR `Ptr<Bar>` cannot be used as the type of `self` without
 }
 
 impl Bar {
-    fn bar(self: Box<Rc<Self>>) {} //~ ERROR arbitrary `self` types are unstable
+    fn bar(self: Box<Ptr<Self>>) {} //~ ERROR `std::boxed::Box<Ptr<Bar>>` cannot be used as the
 }
 
 fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-arbitrary-self-types.stderr
+++ b/src/test/ui/feature-gates/feature-gate-arbitrary-self-types.stderr
@@ -1,26 +1,26 @@
-error[E0658]: arbitrary `self` types are unstable (see issue #44874)
-  --> $DIR/feature-gate-arbitrary-self-types.rs:14:18
+error[E0658]: `Ptr<Self>` cannot be used as the type of `self` without the `arbitrary_self_types` feature (see issue #44874)
+  --> $DIR/feature-gate-arbitrary-self-types.rs:26:18
    |
-LL |     fn foo(self: Rc<Box<Self>>); //~ ERROR arbitrary `self` types are unstable
-   |                  ^^^^^^^^^^^^^
-   |
-   = help: add #![feature(arbitrary_self_types)] to the crate attributes to enable
-   = help: consider changing to `self`, `&self`, `&mut self`, or `self: Box<Self>`
-
-error[E0658]: arbitrary `self` types are unstable (see issue #44874)
-  --> $DIR/feature-gate-arbitrary-self-types.rs:20:18
-   |
-LL |     fn foo(self: Rc<Box<Self>>) {} //~ ERROR arbitrary `self` types are unstable
-   |                  ^^^^^^^^^^^^^
+LL |     fn foo(self: Ptr<Self>); //~ ERROR `Ptr<Self>` cannot be used as the type of `self` without
+   |                  ^^^^^^^^^
    |
    = help: add #![feature(arbitrary_self_types)] to the crate attributes to enable
    = help: consider changing to `self`, `&self`, `&mut self`, or `self: Box<Self>`
 
-error[E0658]: arbitrary `self` types are unstable (see issue #44874)
-  --> $DIR/feature-gate-arbitrary-self-types.rs:24:18
+error[E0658]: `Ptr<Bar>` cannot be used as the type of `self` without the `arbitrary_self_types` feature (see issue #44874)
+  --> $DIR/feature-gate-arbitrary-self-types.rs:32:18
    |
-LL |     fn bar(self: Box<Rc<Self>>) {} //~ ERROR arbitrary `self` types are unstable
-   |                  ^^^^^^^^^^^^^
+LL |     fn foo(self: Ptr<Self>) {} //~ ERROR `Ptr<Bar>` cannot be used as the type of `self` without
+   |                  ^^^^^^^^^
+   |
+   = help: add #![feature(arbitrary_self_types)] to the crate attributes to enable
+   = help: consider changing to `self`, `&self`, `&mut self`, or `self: Box<Self>`
+
+error[E0658]: `std::boxed::Box<Ptr<Bar>>` cannot be used as the type of `self` without the `arbitrary_self_types` feature (see issue #44874)
+  --> $DIR/feature-gate-arbitrary-self-types.rs:36:18
+   |
+LL |     fn bar(self: Box<Ptr<Self>>) {} //~ ERROR `std::boxed::Box<Ptr<Bar>>` cannot be used as the
+   |                  ^^^^^^^^^^^^^^
    |
    = help: add #![feature(arbitrary_self_types)] to the crate attributes to enable
    = help: consider changing to `self`, `&self`, `&mut self`, or `self: Box<Self>`

--- a/src/test/ui/feature-gates/feature-gate-arbitrary_self_types-raw-pointer.rs
+++ b/src/test/ui/feature-gates/feature-gate-arbitrary_self_types-raw-pointer.rs
@@ -12,17 +12,17 @@ struct Foo;
 
 impl Foo {
     fn foo(self: *const Self) {}
-    //~^ ERROR raw pointer `self` is unstable
+    //~^ ERROR `*const Foo` cannot be used as the type of `self` without
 }
 
 trait Bar {
     fn bar(self: *const Self);
-    //~^ ERROR raw pointer `self` is unstable
+    //~^ ERROR `*const Self` cannot be used as the type of `self` without
 }
 
 impl Bar for () {
     fn bar(self: *const Self) {}
-    //~^ ERROR raw pointer `self` is unstable
+    //~^ ERROR `*const ()` cannot be used as the type of `self` without
 }
 
 fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-arbitrary_self_types-raw-pointer.stderr
+++ b/src/test/ui/feature-gates/feature-gate-arbitrary_self_types-raw-pointer.stderr
@@ -1,4 +1,4 @@
-error[E0658]: raw pointer `self` is unstable (see issue #44874)
+error[E0658]: `*const Self` cannot be used as the type of `self` without the `arbitrary_self_types` feature (see issue #44874)
   --> $DIR/feature-gate-arbitrary_self_types-raw-pointer.rs:19:18
    |
 LL |     fn bar(self: *const Self);
@@ -7,7 +7,7 @@ LL |     fn bar(self: *const Self);
    = help: add #![feature(arbitrary_self_types)] to the crate attributes to enable
    = help: consider changing to `self`, `&self`, `&mut self`, or `self: Box<Self>`
 
-error[E0658]: raw pointer `self` is unstable (see issue #44874)
+error[E0658]: `*const Foo` cannot be used as the type of `self` without the `arbitrary_self_types` feature (see issue #44874)
   --> $DIR/feature-gate-arbitrary_self_types-raw-pointer.rs:14:18
    |
 LL |     fn foo(self: *const Self) {}
@@ -16,7 +16,7 @@ LL |     fn foo(self: *const Self) {}
    = help: add #![feature(arbitrary_self_types)] to the crate attributes to enable
    = help: consider changing to `self`, `&self`, `&mut self`, or `self: Box<Self>`
 
-error[E0658]: raw pointer `self` is unstable (see issue #44874)
+error[E0658]: `*const ()` cannot be used as the type of `self` without the `arbitrary_self_types` feature (see issue #44874)
   --> $DIR/feature-gate-arbitrary_self_types-raw-pointer.rs:24:18
    |
 LL |     fn bar(self: *const Self) {}

--- a/src/test/ui/privacy/privacy1.rs
+++ b/src/test/ui/privacy/privacy1.rs
@@ -17,6 +17,20 @@ pub trait Sized {}
 #[lang="copy"]
 pub trait Copy {}
 
+#[lang="deref"]
+pub trait Deref {
+    type Target;
+}
+
+#[lang="receiver"]
+pub trait Receiver: Deref {}
+
+impl<'a, T> Deref for &'a T {
+    type Target = T;
+}
+
+impl<'a, T> Receiver for &'a T {}
+
 mod bar {
     // shouldn't bring in too much
     pub use self::glob::*;

--- a/src/test/ui/privacy/privacy1.stderr
+++ b/src/test/ui/privacy/privacy1.stderr
@@ -1,101 +1,101 @@
 error[E0603]: module `baz` is private
-  --> $DIR/privacy1.rs:128:18
+  --> $DIR/privacy1.rs:142:18
    |
 LL |         use bar::baz::{foo, bar};
    |                  ^^^
 
 error[E0603]: module `baz` is private
-  --> $DIR/privacy1.rs:136:18
+  --> $DIR/privacy1.rs:150:18
    |
 LL |         use bar::baz;
    |                  ^^^
 
 error[E0603]: module `i` is private
-  --> $DIR/privacy1.rs:160:20
+  --> $DIR/privacy1.rs:174:20
    |
 LL |     use self::foo::i::A; //~ ERROR: module `i` is private
    |                    ^
 
 error[E0603]: module `baz` is private
-  --> $DIR/privacy1.rs:100:16
+  --> $DIR/privacy1.rs:114:16
    |
 LL |         ::bar::baz::A::foo();   //~ ERROR: module `baz` is private
    |                ^^^
 
 error[E0603]: module `baz` is private
-  --> $DIR/privacy1.rs:101:16
+  --> $DIR/privacy1.rs:115:16
    |
 LL |         ::bar::baz::A::bar();   //~ ERROR: module `baz` is private
    |                ^^^
 
 error[E0603]: module `baz` is private
-  --> $DIR/privacy1.rs:103:16
+  --> $DIR/privacy1.rs:117:16
    |
 LL |         ::bar::baz::A.foo2();   //~ ERROR: module `baz` is private
    |                ^^^
 
 error[E0603]: module `baz` is private
-  --> $DIR/privacy1.rs:104:16
+  --> $DIR/privacy1.rs:118:16
    |
 LL |         ::bar::baz::A.bar2();   //~ ERROR: module `baz` is private
    |                ^^^
 
 error[E0603]: trait `B` is private
-  --> $DIR/privacy1.rs:108:16
+  --> $DIR/privacy1.rs:122:16
    |
 LL |         ::bar::B::foo();        //~ ERROR: trait `B` is private
    |                ^
 
 error[E0603]: function `epriv` is private
-  --> $DIR/privacy1.rs:114:20
+  --> $DIR/privacy1.rs:128:20
    |
 LL |             ::bar::epriv(); //~ ERROR: function `epriv` is private
    |                    ^^^^^
 
 error[E0603]: module `baz` is private
-  --> $DIR/privacy1.rs:123:16
+  --> $DIR/privacy1.rs:137:16
    |
 LL |         ::bar::baz::foo(); //~ ERROR: module `baz` is private
    |                ^^^
 
 error[E0603]: module `baz` is private
-  --> $DIR/privacy1.rs:124:16
+  --> $DIR/privacy1.rs:138:16
    |
 LL |         ::bar::baz::bar(); //~ ERROR: module `baz` is private
    |                ^^^
 
 error[E0603]: trait `B` is private
-  --> $DIR/privacy1.rs:152:17
+  --> $DIR/privacy1.rs:166:17
    |
 LL |     impl ::bar::B for f32 { fn foo() -> f32 { 1.0 } }
    |                 ^
 
 error[E0624]: method `bar` is private
-  --> $DIR/privacy1.rs:73:9
+  --> $DIR/privacy1.rs:87:9
    |
 LL |         self::baz::A::bar(); //~ ERROR: method `bar` is private
    |         ^^^^^^^^^^^^^^^^^
 
 error[E0624]: method `bar` is private
-  --> $DIR/privacy1.rs:91:5
+  --> $DIR/privacy1.rs:105:5
    |
 LL |     bar::A::bar(); //~ ERROR: method `bar` is private
    |     ^^^^^^^^^^^
 
 error[E0624]: method `bar` is private
-  --> $DIR/privacy1.rs:98:9
+  --> $DIR/privacy1.rs:112:9
    |
 LL |         ::bar::A::bar();        //~ ERROR: method `bar` is private
    |         ^^^^^^^^^^^^^
 
 error[E0624]: method `bar` is private
-  --> $DIR/privacy1.rs:101:9
+  --> $DIR/privacy1.rs:115:9
    |
 LL |         ::bar::baz::A::bar();   //~ ERROR: module `baz` is private
    |         ^^^^^^^^^^^^^^^^^^
 
 error[E0624]: method `bar2` is private
-  --> $DIR/privacy1.rs:104:23
+  --> $DIR/privacy1.rs:118:23
    |
 LL |         ::bar::baz::A.bar2();   //~ ERROR: module `baz` is private
    |                       ^^^^

--- a/src/test/ui/span/issue-27522.rs
+++ b/src/test/ui/span/issue-27522.rs
@@ -13,7 +13,7 @@
 struct SomeType {}
 
 trait Foo {
-    fn handler(self: &SomeType); //~ ERROR invalid `self` type
+    fn handler(self: &SomeType); //~ ERROR invalid method receiver type
 }
 
 fn main() {}

--- a/src/test/ui/span/issue-27522.stderr
+++ b/src/test/ui/span/issue-27522.stderr
@@ -1,7 +1,7 @@
-error[E0307]: invalid `self` type: &SomeType
+error[E0307]: invalid method receiver type: &SomeType
   --> $DIR/issue-27522.rs:16:22
    |
-LL |     fn handler(self: &SomeType); //~ ERROR invalid `self` type
+LL |     fn handler(self: &SomeType); //~ ERROR invalid method receiver type
    |                      ^^^^^^^^^
    |
    = note: type must be `Self` or a type that dereferences to it

--- a/src/test/ui/ufcs/ufcs-explicit-self-bad.rs
+++ b/src/test/ui/ufcs/ufcs-explicit-self-bad.rs
@@ -16,7 +16,7 @@ struct Foo {
 
 impl Foo {
     fn foo(self: isize, x: isize) -> isize {
-        //~^ ERROR invalid `self` type
+        //~^ ERROR invalid method receiver type
         self.f + x
     }
 }
@@ -27,11 +27,11 @@ struct Bar<T> {
 
 impl<T> Bar<T> {
     fn foo(self: Bar<isize>, x: isize) -> isize {
-        //~^ ERROR invalid `self` type
+        //~^ ERROR invalid method receiver type
         x
     }
     fn bar(self: &Bar<usize>, x: isize) -> isize {
-        //~^ ERROR invalid `self` type
+        //~^ ERROR invalid method receiver type
         x
     }
 }

--- a/src/test/ui/ufcs/ufcs-explicit-self-bad.stderr
+++ b/src/test/ui/ufcs/ufcs-explicit-self-bad.stderr
@@ -1,28 +1,28 @@
-error[E0307]: invalid `self` type: isize
+error[E0307]: invalid method receiver type: isize
   --> $DIR/ufcs-explicit-self-bad.rs:18:18
    |
 LL |     fn foo(self: isize, x: isize) -> isize {
    |                  ^^^^^
    |
-   = note: type must be `Foo` or a type that dereferences to it
+   = note: type must be `Self` or a type that dereferences to it
    = help: consider changing to `self`, `&self`, `&mut self`, or `self: Box<Self>`
 
-error[E0307]: invalid `self` type: Bar<isize>
+error[E0307]: invalid method receiver type: Bar<isize>
   --> $DIR/ufcs-explicit-self-bad.rs:29:18
    |
 LL |     fn foo(self: Bar<isize>, x: isize) -> isize {
    |                  ^^^^^^^^^^
    |
-   = note: type must be `Bar<T>` or a type that dereferences to it
+   = note: type must be `Self` or a type that dereferences to it
    = help: consider changing to `self`, `&self`, `&mut self`, or `self: Box<Self>`
 
-error[E0307]: invalid `self` type: &Bar<usize>
+error[E0307]: invalid method receiver type: &Bar<usize>
   --> $DIR/ufcs-explicit-self-bad.rs:33:18
    |
 LL |     fn bar(self: &Bar<usize>, x: isize) -> isize {
    |                  ^^^^^^^^^^^
    |
-   = note: type must be `Bar<T>` or a type that dereferences to it
+   = note: type must be `Self` or a type that dereferences to it
    = help: consider changing to `self`, `&self`, `&mut self`, or `self: Box<Self>`
 
 error[E0308]: mismatched method receiver


### PR DESCRIPTION
Replaces #55880
Closes  #55786 
r? @nikomatsakis 
cc @withoutboats @cramertj

This lets you write methods using `self: Rc<Self>`, `self: Arc<Self>`, `self: Pin<&mut Self>`, `self: Pin<Box<Self>`, and other combinations involving `Pin` and another stdlib receiver type, without needing the `arbitrary_self_types`. Other user-created receiver types can be used, but they still require the feature flag to use.

This is implemented by introducing a new trait, `Receiver`, which the method receiver's type must implement if the `arbitrary_self_types` feature is not enabled. To keep composed receiver types such as `&Arc<Self>` unstable, the receiver type is also required to implement `Deref<Target=Self>` when the feature flag is not enabled.

This lets you use `self: Rc<Self>` and `self: Arc<Self>` in stable Rust, which was not allowed previously. It was agreed that they would be stabilized in #55786. `self: Pin<&Self>` and other pinned receiver types do not require the `arbitrary_self_types` feature, but they cannot be used on stable because `Pin` still requires the `pin` feature.