### PR TITLE
std: Activate compiler_builtins `mem` feature for no_std targets

### DIFF
--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -155,7 +155,9 @@ pub fn std_cargo(builder: &Builder,
         cargo
             .args(&["-p", "alloc"])
             .arg("--manifest-path")
-            .arg(builder.src.join("src/liballoc/Cargo.toml"));
+            .arg(builder.src.join("src/liballoc/Cargo.toml"))
+            .arg("--features")
+            .arg("compiler-builtins-mem");
     } else {
         let features = builder.std_features();
 

--- a/src/liballoc/Cargo.toml
+++ b/src/liballoc/Cargo.toml
@@ -28,3 +28,6 @@ path = "../liballoc/benches/lib.rs"
 name = "vec_deque_append_bench"
 path = "../liballoc/benches/vec_deque_append.rs"
 harness = false
+
+[features]
+compiler-builtins-mem = ['compiler_builtins/mem']


### PR DESCRIPTION
This was an accidental regression from #56092, but for `no_std` targets
being built and distributed we want to be sure to activate the
compiler-builtins `mem` feature which demangles important memory-related
intrinsics.