### PR TITLE
Call poly_project_and_unify_type on types that contain inference types

### DIFF
--- a/src/librustc/traits/auto_trait.rs
+++ b/src/librustc/traits/auto_trait.rs
@@ -742,9 +742,9 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
                     }
 
                     // We can only call poly_project_and_unify_type when our predicate's
-                    // Ty is an inference variable - otherwise, there won't be anything to
+                    // Ty contains an inference variable - otherwise, there won't be anything to
                     // unify
-                    if p.ty().skip_binder().is_ty_infer() {
+                    if p.ty().skip_binder().has_infer_types() {
                         debug!("Projecting and unifying projection predicate {:?}",
                                predicate);
                         match poly_project_and_unify_type(select, &obligation.with(p.clone())) {

--- a/src/test/rustdoc/issue-56822.rs
+++ b/src/test/rustdoc/issue-56822.rs
@@ -1,0 +1,34 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Wrapper<T>(T);
+
+trait MyTrait {
+    type Output;
+}
+
+impl<'a, I, T: 'a> MyTrait for Wrapper<I>
+    where I: MyTrait<Output=&'a T>
+{
+    type Output = T;
+}
+
+struct Inner<'a, T>(&'a T);
+
+impl<'a, T> MyTrait for Inner<'a, T> {
+    type Output = &'a T;
+}
+
+// @has issue_56822/struct.Parser.html
+// @has - '//*[@id="synthetic-implementations-list"]/*[@class="impl"]//*/code' "impl<'a> Send for \
+// Parser<'a>"
+pub struct Parser<'a> {
+    field: <Wrapper<Inner<'a, u8>> as MyTrait>::Output
+}


### PR DESCRIPTION
Commit f57247c48cb59 (Ensure that Rusdoc discovers all necessary auto
trait bounds) added a check to ensure that we only attempt to unify a
projection predicatre with inference variables. However, the check it
added was too strict - instead of checking that a type *contains* an
inference variable (e.g. '&_', 'MyType<_>'), it required the type to
*be* an inference variable (i.e. only '_' would match).

This commit relaxes the check to use 'ty.has_infer_types', ensuring that
we perform unification wherever possible.

Fixes #56822