### PR TITLE
Fix a small mistake regarding NaNs in a deprecation message

### DIFF
--- a/src/libstd/f32.rs
+++ b/src/libstd/f32.rs
@@ -550,7 +550,8 @@ impl f32 {
     #[inline]
     #[rustc_deprecated(since = "1.10.0",
                        reason = "you probably meant `(self - other).abs()`: \
-                                 this operation is `(self - other).max(0.0)` (also \
+                                 this operation is `(self - other).max(0.0)` \
+                                 except that `abs_sub` also propagates NaNs (also \
                                  known as `fdimf` in C). If you truly need the positive \
                                  difference, consider using that expression or the C function \
                                  `fdimf`, depending on how you wish to handle NaN (please consider \

--- a/src/libstd/f64.rs
+++ b/src/libstd/f64.rs
@@ -491,7 +491,8 @@ impl f64 {
     #[inline]
     #[rustc_deprecated(since = "1.10.0",
                        reason = "you probably meant `(self - other).abs()`: \
-                                 this operation is `(self - other).max(0.0)` (also \
+                                 this operation is `(self - other).max(0.0)` \
+                                 except that `abs_sub` also propagates NaNs (also \
                                  known as `fdim` in C). If you truly need the positive \
                                  difference, consider using that expression or the C function \
                                  `fdim`, depending on how you wish to handle NaN (please consider \


### PR DESCRIPTION
`max` on floats returns the other argument if one of them is NaN, which
would be `0.0` in this case. This is unlike the C functions `fdim` and
`fdimf` which return NaN if either of their arguments is NaN.

https://doc.rust-lang.org/1.31.0/std/primitive.f32.html#method.max
https://en.cppreference.com/w/c/numeric/math/fdim