### PR TITLE
Fix doc of `std::fs::canonicalize`

### DIFF
--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -1729,7 +1729,7 @@ pub fn read_link<P: AsRef<Path>>(path: P) -> io::Result<PathBuf> {
 /// limited to just these cases:
 ///
 /// * `path` does not exist.
-/// * A component in path is not a directory.
+/// * A non-final component in path is not a directory.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
Point out that the final component of the path name might be a filename
(and not a directory name). Previously, the doc said that all components
of the path must be directory names, when it actually only ment all but
the final one.

Fixes #54056.