### PR TITLE
stop treating trait objects from #[fundamental] traits as fundamental

### DIFF
--- a/src/librustc/traits/coherence.rs
+++ b/src/librustc/traits/coherence.rs
@@ -393,7 +393,7 @@ fn uncovered_tys<'tcx>(tcx: TyCtxt<'_, '_, '_>, ty: Ty<'tcx>, in_crate: InCrate)
                        -> Vec<Ty<'tcx>> {
     if ty_is_local_constructor(ty, in_crate) {
         vec![]
-    } else if fundamental_ty(tcx, ty) {
+    } else if fundamental_ty(ty) {
         ty.walk_shallow()
           .flat_map(|t| uncovered_tys(tcx, t, in_crate))
           .collect()
@@ -411,14 +411,13 @@ fn is_possibly_remote_type(ty: Ty<'_>, _in_crate: InCrate) -> bool {
 
 fn ty_is_local(tcx: TyCtxt<'_, '_, '_>, ty: Ty<'_>, in_crate: InCrate) -> bool {
     ty_is_local_constructor(ty, in_crate) ||
-        fundamental_ty(tcx, ty) && ty.walk_shallow().any(|t| ty_is_local(tcx, t, in_crate))
+        fundamental_ty(ty) && ty.walk_shallow().any(|t| ty_is_local(tcx, t, in_crate))
 }
 
-fn fundamental_ty(tcx: TyCtxt<'_, '_, '_>, ty: Ty<'_>) -> bool {
+fn fundamental_ty(ty: Ty<'_>) -> bool {
     match ty.sty {
         ty::Ref(..) => true,
         ty::Adt(def, _) => def.is_fundamental(),
-        ty::Dynamic(ref data, ..) => tcx.has_attr(data.principal().def_id(), "fundamental"),
         _ => false
     }
 }

--- a/src/test/ui/coherence/auxiliary/coherence_fundamental_trait_lib.rs
+++ b/src/test/ui/coherence/auxiliary/coherence_fundamental_trait_lib.rs
@@ -1,0 +1,7 @@
+#![crate_type = "rlib"]
+#![feature(fundamental)]
+
+pub trait Misc {}
+
+#[fundamental]
+pub trait Fundamental<T> {}

--- a/src/test/ui/coherence/coherence-fundamental-trait-objects.rs
+++ b/src/test/ui/coherence/coherence-fundamental-trait-objects.rs
@@ -1,0 +1,15 @@
+// Check that trait objects from #[fundamental] traits are not
+// treated as #[fundamental] types - the 2 meanings of #[fundamental]
+// are distinct.
+
+// aux-build:coherence_fundamental_trait_lib.rs
+
+extern crate coherence_fundamental_trait_lib;
+
+use coherence_fundamental_trait_lib::{Fundamental, Misc};
+
+pub struct Local;
+impl Misc for dyn Fundamental<Local> {}
+//~^ ERROR E0117
+
+fn main() {}

--- a/src/test/ui/coherence/coherence-fundamental-trait-objects.stderr
+++ b/src/test/ui/coherence/coherence-fundamental-trait-objects.stderr
@@ -1,0 +1,12 @@
+error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
+  --> $DIR/coherence-fundamental-trait-objects.rs:12:1
+   |
+LL | impl Misc for dyn Fundamental<Local> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   |
+   = note: the impl does not reference any types defined in this crate
+   = note: define and implement a trait or new type instead
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0117`.


### PR DESCRIPTION
This is a [breaking-change] to code that exploits this functionality (which should be limited to code using `#![feature(fundamental)]`.

Fixes #56503.

r? @nikomatsakis