### PR TITLE
make copy_within #[inline]

### DIFF
--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -2004,6 +2004,7 @@ impl<T> [T] {
     /// assert_eq!(&bytes, b"Hello, Wello!");
     /// ```
     #[unstable(feature = "copy_within", issue = "54236")]
+    #[inline]
     pub fn copy_within<R: ops::RangeBounds<usize>>(&mut self, src: R, dest: usize)
     where
         T: Copy,


### PR DESCRIPTION
@briansmith suggested this in
https://github.com/rust-lang/rust/issues/54236#issuecomment-447617175.