### PR TITLE
rustc: Disable ThinLTO for LLVM's build

### DIFF
--- a/src/ci/docker/dist-x86_64-linux/Dockerfile
+++ b/src/ci/docker/dist-x86_64-linux/Dockerfile
@@ -101,7 +101,6 @@ ENV RUST_CONFIGURE_ARGS \
       --set target.x86_64-unknown-linux-gnu.linker=clang \
       --set target.x86_64-unknown-linux-gnu.ar=/rustroot/bin/llvm-ar \
       --set target.x86_64-unknown-linux-gnu.ranlib=/rustroot/bin/llvm-ranlib \
-      --set llvm.thin-lto=true \
       --set rust.jemalloc
 ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS
 ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=clang


### PR DESCRIPTION
This commit goes back to disabling ThinLTO for building LLVM and its
tools. It turns out that this caused a regression at #56849 which I
believe we'll definitely want to fix before it goes live. The bisection
turned up an [upstream LLVM bug][bug], so hopefully there'll eventually
be a fix we can backport.

I've also been a little uneasy about how we're only enabling ThinLTO for
LLVM on Linux, and we haven't had a chance to turn it on for OSX and
Windows (other "Tier 1" platforms) yet. Additionally it had an
unexpected hit to CI time we never got around to fixing. I'd ideally
prefer that we fix these issues as well before re-landing.

Closes #56849

[bug]: https://bugs.llvm.org/show_bug.cgi?id=40045