### PR TITLE
[beta] Revert "Update CI-clang to 7.0.0 for Linux dists."

### DIFF
--- a/src/ci/docker/dist-i686-linux/Dockerfile
+++ b/src/ci/docker/dist-i686-linux/Dockerfile
@@ -67,7 +67,7 @@ RUN ./build-gcc.sh
 COPY dist-x86_64-linux/build-python.sh /tmp/
 RUN ./build-python.sh
 
-# Now build LLVM+Clang 7, afterwards configuring further compilations to use the
+# Now build LLVM+Clang 6, afterwards configuring further compilations to use the
 # clang/clang++ compilers.
 COPY dist-x86_64-linux/build-clang.sh /tmp/
 RUN ./build-clang.sh

--- a/src/ci/docker/dist-x86_64-linux/Dockerfile
+++ b/src/ci/docker/dist-x86_64-linux/Dockerfile
@@ -67,7 +67,7 @@ RUN ./build-gcc.sh
 COPY dist-x86_64-linux/build-python.sh /tmp/
 RUN ./build-python.sh
 
-# Now build LLVM+Clang 7, afterwards configuring further compilations to use the
+# Now build LLVM+Clang 6, afterwards configuring further compilations to use the
 # clang/clang++ compilers.
 COPY dist-x86_64-linux/build-clang.sh /tmp/
 RUN ./build-clang.sh

--- a/src/ci/docker/dist-x86_64-linux/build-clang.sh
+++ b/src/ci/docker/dist-x86_64-linux/build-clang.sh
@@ -13,7 +13,7 @@ set -ex
 
 source shared.sh
 
-LLVM=7.0.0
+LLVM=6.0.0
 
 mkdir clang
 cd clang

--- a/src/ci/docker/scripts/musl.sh
+++ b/src/ci/docker/scripts/musl.sh
@@ -51,7 +51,7 @@ hide_output make clean
 
 cd ..
 
-LLVM=70
+LLVM=60
 
 # may have been downloaded in a previous run
 if [ ! -d libunwind-release_$LLVM ]; then


### PR DESCRIPTION
This reverts commit 2ec6f340cd29f289fea1c5a672195ceeaf44c475.

Closes https://github.com/rust-lang/rust/issues/56849 on beta