### PR TITLE
make `panictry!` private to libsyntax

### DIFF
--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -32,7 +32,7 @@ extern crate rustc_metadata;
 extern crate rustc_target;
 extern crate rustc_typeck;
 extern crate serialize;
-#[macro_use] extern crate syntax;
+extern crate syntax;
 extern crate syntax_pos;
 extern crate test as testing;
 #[macro_use] extern crate log;

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -44,8 +44,6 @@ use ast::AttrId;
 // way towards a non-panic!-prone parser. It should be used for fatal parsing
 // errors; eventually we plan to convert all code using panictry to just use
 // normal try.
-// Exported for syntax_ext, not meant for general use.
-#[macro_export]
 macro_rules! panictry {
     ($e:expr) => ({
         use std::result::Result::{Ok, Err};

--- a/src/libsyntax_ext/assert.rs
+++ b/src/libsyntax_ext/assert.rs
@@ -1,9 +1,11 @@
-use syntax::ast::*;
+use errors::DiagnosticBuilder;
+use syntax::ast::{self, *};
 use syntax::source_map::Spanned;
 use syntax::ext::base::*;
 use syntax::ext::build::AstBuilder;
 use syntax::parse::token;
 use syntax::print::pprust;
+use syntax::ptr::P;
 use syntax::symbol::Symbol;
 use syntax::tokenstream::{TokenStream, TokenTree};
 use syntax_pos::{Span, DUMMY_SP};
@@ -13,33 +15,18 @@ pub fn expand_assert<'cx>(
     sp: Span,
     tts: &[TokenTree],
 ) -> Box<dyn MacResult + 'cx> {
-    let mut parser = cx.new_parser_from_tts(tts);
-
-    if parser.token == token::Eof {
-        cx.struct_span_err(sp, "macro requires a boolean expression as an argument")
-            .span_label(sp, "boolean expression required")
-            .emit();
-        return DummyResult::expr(sp);
-    }
-
-    let cond_expr = panictry!(parser.parse_expr());
-    let custom_msg_args = if parser.eat(&token::Comma) {
-        let ts = parser.parse_tokens();
-        if !ts.is_empty() {
-            Some(ts)
-        } else {
-            None
+    let Assert { cond_expr, custom_message } = match parse_assert(cx, sp, tts) {
+        Ok(assert) => assert,
+        Err(mut err) => {
+            err.emit();
+            return DummyResult::expr(sp);
         }
-    } else {
-        None
     };
 
     let sp = sp.apply_mark(cx.current_expansion.mark);
     let panic_call = Mac_ {
         path: Path::from_ident(Ident::new(Symbol::intern("panic"), sp)),
-        tts: if let Some(ts) = custom_msg_args {
-            ts.into()
-        } else {
+        tts: custom_message.unwrap_or_else(|| {
             TokenStream::from(TokenTree::Token(
                 DUMMY_SP,
                 token::Literal(
@@ -49,8 +36,8 @@ pub fn expand_assert<'cx>(
                     ))),
                     None,
                 ),
-            )).into()
-        },
+            ))
+        }).into(),
         delim: MacDelimiter::Parenthesis,
     };
     let if_expr = cx.expr_if(
@@ -66,4 +53,37 @@ pub fn expand_assert<'cx>(
         None,
     );
     MacEager::expr(if_expr)
+}
+
+struct Assert {
+    cond_expr: P<ast::Expr>,
+    custom_message: Option<TokenStream>,
+}
+
+fn parse_assert<'a>(
+    cx: &mut ExtCtxt<'a>,
+    sp: Span,
+    tts: &[TokenTree]
+) -> Result<Assert, DiagnosticBuilder<'a>> {
+    let mut parser = cx.new_parser_from_tts(tts);
+
+    if parser.token == token::Eof {
+        let mut err = cx.struct_span_err(sp, "macro requires a boolean expression as an argument");
+        err.span_label(sp, "boolean expression required");
+        return Err(err);
+    }
+
+    Ok(Assert {
+        cond_expr: parser.parse_expr()?,
+        custom_message: if parser.eat(&token::Comma) {
+            let ts = parser.parse_tokens();
+            if !ts.is_empty() {
+                Some(ts)
+            } else {
+                None
+            }
+        } else {
+            None
+        },
+    })
 }

--- a/src/libsyntax_ext/cfg.rs
+++ b/src/libsyntax_ext/cfg.rs
@@ -2,6 +2,8 @@
 /// a literal `true` or `false` based on whether the given cfg matches the
 /// current compilation environment.
 
+use errors::DiagnosticBuilder;
+use syntax::ast;
 use syntax::ext::base::*;
 use syntax::ext::base;
 use syntax::ext::build::AstBuilder;
@@ -15,16 +17,39 @@ pub fn expand_cfg<'cx>(cx: &mut ExtCtxt,
                        tts: &[tokenstream::TokenTree])
                        -> Box<dyn base::MacResult + 'static> {
     let sp = sp.apply_mark(cx.current_expansion.mark);
+
+    match parse_cfg(cx, sp, tts) {
+        Ok(cfg) => {
+            let matches_cfg = attr::cfg_matches(&cfg, cx.parse_sess, cx.ecfg.features);
+            MacEager::expr(cx.expr_bool(sp, matches_cfg))
+        }
+        Err(mut err) => {
+            err.emit();
+            DummyResult::expr(sp)
+        }
+    }
+}
+
+fn parse_cfg<'a>(
+    cx: &mut ExtCtxt<'a>,
+    sp: Span,
+    tts: &[tokenstream::TokenTree],
+) -> Result<ast::MetaItem, DiagnosticBuilder<'a>> {
     let mut p = cx.new_parser_from_tts(tts);
-    let cfg = panictry!(p.parse_meta_item());
+
+    if p.token == token::Eof {
+        let mut err = cx.struct_span_err(sp, "macro requires a cfg-pattern as an argument");
+        err.span_label(sp, "cfg-pattern required");
+        return Err(err);
+    }
+
+    let cfg = p.parse_meta_item()?;
 
     let _ = p.eat(&token::Comma);
 
     if !p.eat(&token::Eof) {
-        cx.span_err(sp, "expected 1 cfg-pattern");
-        return DummyResult::expr(sp);
+        return Err(cx.struct_span_err(sp, "expected 1 cfg-pattern"));
     }
 
-    let matches_cfg = attr::cfg_matches(&cfg, cx.parse_sess, cx.ecfg.features);
-    MacEager::expr(cx.expr_bool(sp, matches_cfg))
+    Ok(cfg)
 }

--- a/src/test/rustdoc-ui/failed-doctest-output.stdout
+++ b/src/test/rustdoc-ui/failed-doctest-output.stdout
@@ -12,7 +12,7 @@ error[E0425]: cannot find value `no` in this scope
 3 | no
   | ^^ not found in this scope
 
-thread '$DIR/failed-doctest-output.rs - OtherStruct (line 17)' panicked at 'couldn't compile the test', src/librustdoc/test.rs:316:13
+thread '$DIR/failed-doctest-output.rs - OtherStruct (line 17)' panicked at 'couldn't compile the test', src/librustdoc/test.rs:321:13
 note: Run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
 
 ---- $DIR/failed-doctest-output.rs - SomeStruct (line 11) stdout ----
@@ -21,7 +21,7 @@ thread '$DIR/failed-doctest-output.rs - SomeStruct (line 11)' panicked at 'test 
 thread 'main' panicked at 'oh no', $DIR/failed-doctest-output.rs:3:1
 note: Run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
 
-', src/librustdoc/test.rs:351:17
+', src/librustdoc/test.rs:356:17
 
 
 failures:

--- a/src/test/ui/asm/asm-parse-errors.rs
+++ b/src/test/ui/asm/asm-parse-errors.rs
@@ -1,0 +1,15 @@
+#![feature(asm)]
+
+fn main() {
+    asm!(); //~ ERROR requires a string literal as an argument
+    asm!("nop" : struct); //~ ERROR expected string literal
+    asm!("mov %eax, $$0x2" : struct); //~ ERROR expected string literal
+    asm!("mov %eax, $$0x2" : "={eax}" struct); //~ ERROR expected `(`
+    asm!("mov %eax, $$0x2" : "={eax}"(struct)); //~ ERROR expected expression
+    asm!("in %dx, %al" : "={al}"(result) : struct); //~ ERROR expected string literal
+    asm!("in %dx, %al" : "={al}"(result) : "{dx}" struct); //~ ERROR expected `(`
+    asm!("in %dx, %al" : "={al}"(result) : "{dx}"(struct)); //~ ERROR expected expression
+    asm!("mov $$0x200, %eax" : : : struct); //~ ERROR expected string literal
+    asm!("mov eax, 2" : "={eax}"(foo) : : : struct); //~ ERROR expected string literal
+    asm!(123); //~ ERROR inline assembly must be a string literal
+}

--- a/src/test/ui/asm/asm-parse-errors.stderr
+++ b/src/test/ui/asm/asm-parse-errors.stderr
@@ -1,0 +1,68 @@
+error: macro requires a string literal as an argument
+  --> $DIR/asm-parse-errors.rs:4:5
+   |
+LL |     asm!(); //~ ERROR requires a string literal as an argument
+   |     ^^^^^^^ string literal required
+
+error: expected string literal
+  --> $DIR/asm-parse-errors.rs:5:18
+   |
+LL |     asm!("nop" : struct); //~ ERROR expected string literal
+   |                  ^^^^^^ expected string literal
+
+error: expected string literal
+  --> $DIR/asm-parse-errors.rs:6:30
+   |
+LL |     asm!("mov %eax, $$0x2" : struct); //~ ERROR expected string literal
+   |                              ^^^^^^ expected string literal
+
+error: expected `(`, found keyword `struct`
+  --> $DIR/asm-parse-errors.rs:7:39
+   |
+LL |     asm!("mov %eax, $$0x2" : "={eax}" struct); //~ ERROR expected `(`
+   |                                       ^^^^^^ expected `(`
+
+error: expected expression, found keyword `struct`
+  --> $DIR/asm-parse-errors.rs:8:39
+   |
+LL |     asm!("mov %eax, $$0x2" : "={eax}"(struct)); //~ ERROR expected expression
+   |                                       ^^^^^^ expected expression
+
+error: expected string literal
+  --> $DIR/asm-parse-errors.rs:9:44
+   |
+LL |     asm!("in %dx, %al" : "={al}"(result) : struct); //~ ERROR expected string literal
+   |                                            ^^^^^^ expected string literal
+
+error: expected `(`, found keyword `struct`
+  --> $DIR/asm-parse-errors.rs:10:51
+   |
+LL |     asm!("in %dx, %al" : "={al}"(result) : "{dx}" struct); //~ ERROR expected `(`
+   |                                                   ^^^^^^ expected `(`
+
+error: expected expression, found keyword `struct`
+  --> $DIR/asm-parse-errors.rs:11:51
+   |
+LL |     asm!("in %dx, %al" : "={al}"(result) : "{dx}"(struct)); //~ ERROR expected expression
+   |                                                   ^^^^^^ expected expression
+
+error: expected string literal
+  --> $DIR/asm-parse-errors.rs:12:36
+   |
+LL |     asm!("mov $$0x200, %eax" : : : struct); //~ ERROR expected string literal
+   |                                    ^^^^^^ expected string literal
+
+error: expected string literal
+  --> $DIR/asm-parse-errors.rs:13:45
+   |
+LL |     asm!("mov eax, 2" : "={eax}"(foo) : : : struct); //~ ERROR expected string literal
+   |                                             ^^^^^^ expected string literal
+
+error: inline assembly must be a string literal
+  --> $DIR/asm-parse-errors.rs:14:10
+   |
+LL |     asm!(123); //~ ERROR inline assembly must be a string literal
+   |          ^^^
+
+error: aborting due to 11 previous errors
+

--- a/src/test/ui/issues/issue-22644.rs
+++ b/src/test/ui/issues/issue-22644.rs
@@ -1,5 +1,7 @@
+#![feature(type_ascription)]
+
 fn main() {
-    let a : u32 = 0;
+    let a : usize = 0;
     let long_name : usize = 0;
 
     println!("{}", a as usize > long_name);

--- a/src/test/ui/issues/issue-22644.stderr
+++ b/src/test/ui/issues/issue-22644.stderr
@@ -1,5 +1,5 @@
 error: `<` is interpreted as a start of generic arguments for `usize`, not a comparison
-  --> $DIR/issue-22644.rs:6:31
+  --> $DIR/issue-22644.rs:8:31
    |
 LL |     println!("{}", a as usize < long_name); //~ ERROR `<` is interpreted as a start of generic
    |                    ---------- ^ --------- interpreted as generic arguments
@@ -8,7 +8,7 @@ LL |     println!("{}", a as usize < long_name); //~ ERROR `<` is interpreted as
    |                    help: try comparing the cast value: `(a as usize)`
 
 error: `<` is interpreted as a start of generic arguments for `usize`, not a comparison
-  --> $DIR/issue-22644.rs:7:33
+  --> $DIR/issue-22644.rs:9:33
    |
 LL |     println!("{}{}", a as usize < long_name, long_name);
    |                      ---------- ^ -------------------- interpreted as generic arguments
@@ -17,7 +17,7 @@ LL |     println!("{}{}", a as usize < long_name, long_name);
    |                      help: try comparing the cast value: `(a as usize)`
 
 error: `<` is interpreted as a start of generic arguments for `usize`, not a comparison
-  --> $DIR/issue-22644.rs:9:31
+  --> $DIR/issue-22644.rs:11:31
    |
 LL |     println!("{}", a as usize < 4); //~ ERROR `<` is interpreted as a start of generic
    |                    ---------- ^ - interpreted as generic arguments
@@ -26,7 +26,7 @@ LL |     println!("{}", a as usize < 4); //~ ERROR `<` is interpreted as a start
    |                    help: try comparing the cast value: `(a as usize)`
 
 error: `<` is interpreted as a start of generic arguments for `usize`, not a comparison
-  --> $DIR/issue-22644.rs:11:31
+  --> $DIR/issue-22644.rs:13:31
    |
 LL |     println!("{}{}", a: usize < long_name, long_name);
    |                      -------- ^ -------------------- interpreted as generic arguments
@@ -35,7 +35,7 @@ LL |     println!("{}{}", a: usize < long_name, long_name);
    |                      help: try comparing the cast value: `(a: usize)`
 
 error: `<` is interpreted as a start of generic arguments for `usize`, not a comparison
-  --> $DIR/issue-22644.rs:13:29
+  --> $DIR/issue-22644.rs:15:29
    |
 LL |     println!("{}", a: usize < 4); //~ ERROR `<` is interpreted as a start of generic
    |                    -------- ^ - interpreted as generic arguments
@@ -44,7 +44,7 @@ LL |     println!("{}", a: usize < 4); //~ ERROR `<` is interpreted as a start o
    |                    help: try comparing the cast value: `(a: usize)`
 
 error: `<` is interpreted as a start of generic arguments for `usize`, not a comparison
-  --> $DIR/issue-22644.rs:18:20
+  --> $DIR/issue-22644.rs:20:20
    |
 LL |                    < //~ ERROR `<` is interpreted as a start of generic
    |                    ^ not interpreted as comparison
@@ -58,7 +58,7 @@ LL |                    usize)
    |
 
 error: `<` is interpreted as a start of generic arguments for `usize`, not a comparison
-  --> $DIR/issue-22644.rs:27:20
+  --> $DIR/issue-22644.rs:29:20
    |
 LL |                    < //~ ERROR `<` is interpreted as a start of generic
    |                    ^ not interpreted as comparison
@@ -75,7 +75,7 @@ LL |
  ...
 
 error: `<` is interpreted as a start of generic arguments for `usize`, not a shift
-  --> $DIR/issue-22644.rs:30:31
+  --> $DIR/issue-22644.rs:32:31
    |
 LL |     println!("{}", a as usize << long_name); //~ ERROR `<` is interpreted as a start of generic
    |                    ---------- ^^ --------- interpreted as generic arguments
@@ -84,7 +84,7 @@ LL |     println!("{}", a as usize << long_name); //~ ERROR `<` is interpreted a
    |                    help: try shifting the cast value: `(a as usize)`
 
 error: expected type, found `4`
-  --> $DIR/issue-22644.rs:32:28
+  --> $DIR/issue-22644.rs:34:28
    |
 LL |     println!("{}", a: &mut 4); //~ ERROR expected type, found `4`
    |                            ^ expecting a type here because of type ascription

--- a/src/test/ui/macros/assert.rs
+++ b/src/test/ui/macros/assert.rs
@@ -1,4 +1,6 @@
 fn main() {
     assert!();  //~ ERROR requires a boolean expression
+    assert!(struct); //~ ERROR expected expression
     debug_assert!(); //~ ERROR requires a boolean expression
+    debug_assert!(struct); //~ ERROR expected expression
 }

--- a/src/test/ui/macros/assert.stderr
+++ b/src/test/ui/macros/assert.stderr
@@ -4,13 +4,25 @@ error: macro requires a boolean expression as an argument
 LL |     assert!();  //~ ERROR requires a boolean expression
    |     ^^^^^^^^^^ boolean expression required
 
+error: expected expression, found keyword `struct`
+  --> $DIR/assert.rs:3:13
+   |
+LL |     assert!(struct); //~ ERROR expected expression
+   |             ^^^^^^ expected expression
+
 error: macro requires a boolean expression as an argument
-  --> $DIR/assert.rs:3:5
+  --> $DIR/assert.rs:4:5
    |
 LL |     debug_assert!(); //~ ERROR requires a boolean expression
    |     ^^^^^^^^^^^^^^^^ boolean expression required
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
-error: aborting due to 2 previous errors
+error: expected expression, found keyword `struct`
+  --> $DIR/assert.rs:5:19
+   |
+LL |     debug_assert!(struct); //~ ERROR expected expression
+   |                   ^^^^^^ expected expression
+
+error: aborting due to 4 previous errors
 

--- a/src/test/ui/macros/cfg.rs
+++ b/src/test/ui/macros/cfg.rs
@@ -1,0 +1,5 @@
+fn main() {
+    cfg!(); //~ ERROR macro requires a cfg-pattern
+    cfg!(123); //~ ERROR expected identifier
+    cfg!(foo = 123); //~ ERROR literal in `cfg` predicate value must be a string
+}

--- a/src/test/ui/macros/cfg.stderr
+++ b/src/test/ui/macros/cfg.stderr
@@ -1,0 +1,21 @@
+error: macro requires a cfg-pattern as an argument
+  --> $DIR/cfg.rs:2:5
+   |
+LL |     cfg!(); //~ ERROR macro requires a cfg-pattern
+   |     ^^^^^^^ cfg-pattern required
+
+error: expected identifier, found `123`
+  --> $DIR/cfg.rs:3:10
+   |
+LL |     cfg!(123); //~ ERROR expected identifier
+   |          ^^^ expected identifier
+
+error[E0565]: literal in `cfg` predicate value must be a string
+  --> $DIR/cfg.rs:4:16
+   |
+LL |     cfg!(foo = 123); //~ ERROR literal in `cfg` predicate value must be a string
+   |                ^^^
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0565`.

--- a/src/test/ui/macros/format-parse-errors.rs
+++ b/src/test/ui/macros/format-parse-errors.rs
@@ -1,0 +1,10 @@
+fn main() {
+    format!(); //~ ERROR requires at least a format string argument
+    format!(struct); //~ ERROR expected expression
+    format!("s", name =); //~ ERROR expected expression
+    format!("s", foo = struct); //~ ERROR expected expression
+    format!("s", struct); //~ ERROR expected expression
+
+    // This error should come after parsing errors to ensure they are non-fatal.
+    format!(123); //~ ERROR format argument must be a string literal
+}

--- a/src/test/ui/macros/format-parse-errors.stderr
+++ b/src/test/ui/macros/format-parse-errors.stderr
@@ -1,0 +1,44 @@
+error: requires at least a format string argument
+  --> $DIR/format-parse-errors.rs:2:5
+   |
+LL |     format!(); //~ ERROR requires at least a format string argument
+   |     ^^^^^^^^^^
+   |
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: expected expression, found keyword `struct`
+  --> $DIR/format-parse-errors.rs:3:13
+   |
+LL |     format!(struct); //~ ERROR expected expression
+   |             ^^^^^^ expected expression
+
+error: expected expression, found `<eof>`
+  --> $DIR/format-parse-errors.rs:4:23
+   |
+LL |     format!("s", name =); //~ ERROR expected expression
+   |                       ^ expected expression
+
+error: expected expression, found keyword `struct`
+  --> $DIR/format-parse-errors.rs:5:24
+   |
+LL |     format!("s", foo = struct); //~ ERROR expected expression
+   |                        ^^^^^^ expected expression
+
+error: expected expression, found keyword `struct`
+  --> $DIR/format-parse-errors.rs:6:18
+   |
+LL |     format!("s", struct); //~ ERROR expected expression
+   |                  ^^^^^^ expected expression
+
+error: format argument must be a string literal
+  --> $DIR/format-parse-errors.rs:9:13
+   |
+LL |     format!(123); //~ ERROR format argument must be a string literal
+   |             ^^^
+help: you might be missing a string literal to format with
+   |
+LL |     format!("{}", 123); //~ ERROR format argument must be a string literal
+   |             ^^^^^
+
+error: aborting due to 6 previous errors
+

--- a/src/test/ui/macros/global-asm.rs
+++ b/src/test/ui/macros/global-asm.rs
@@ -1,0 +1,7 @@
+#![feature(global_asm)]
+
+fn main() {
+    global_asm!();  //~ ERROR requires a string literal as an argument
+    global_asm!(struct); //~ ERROR expected expression
+    global_asm!(123); //~ ERROR inline assembly must be a string literal
+}

--- a/src/test/ui/macros/global-asm.stderr
+++ b/src/test/ui/macros/global-asm.stderr
@@ -1,0 +1,20 @@
+error: macro requires a string literal as an argument
+  --> $DIR/global-asm.rs:4:5
+   |
+LL |     global_asm!();  //~ ERROR requires a string literal as an argument
+   |     ^^^^^^^^^^^^^^ string literal required
+
+error: expected expression, found keyword `struct`
+  --> $DIR/global-asm.rs:5:17
+   |
+LL |     global_asm!(struct); //~ ERROR expected expression
+   |                 ^^^^^^ expected expression
+
+error: inline assembly must be a string literal
+  --> $DIR/global-asm.rs:6:17
+   |
+LL |     global_asm!(123); //~ ERROR inline assembly must be a string literal
+   |                 ^^^
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
This commit completely removes usage of the `panictry!` macro from
outside libsyntax. The macro causes parse errors to be fatal, so using
it in libsyntax_ext caused parse failures *within* a syntax extension to
be fatal, which is probably not intended.

Furthermore, this commit adds spans to diagnostics emitted by empty
extensions if they were missing, à la #56491.