### PR TITLE
Fix grammar in compiler error for array iterators

### DIFF
--- a/src/libcore/iter/iterator.rs
+++ b/src/libcore/iter/iterator.rs
@@ -87,7 +87,7 @@ fn _assert_is_object_safe(_: &dyn Iterator<Item=()>) {}
     on(
         _Self="[]",
         label="borrow the array with `&` or call `.iter()` on it to iterate over it",
-        note="arrays are not an iterators, but slices like the following are: `&[1, 2, 3]`"
+        note="arrays are not iterators, but slices like the following are: `&[1, 2, 3]`"
     ),
     on(
         _Self="{integral}",

--- a/src/test/ui/iterators/array-of-ranges.stderr
+++ b/src/test/ui/iterators/array-of-ranges.stderr
@@ -75,7 +75,7 @@ LL |     for _ in [0..1, 2..3] {}
    |              ^^^^^^^^^^^^ borrow the array with `&` or call `.iter()` on it to iterate over it
    |
    = help: the trait `std::iter::Iterator` is not implemented for `[std::ops::Range<{integer}>; 2]`
-   = note: arrays are not an iterators, but slices like the following are: `&[1, 2, 3]`
+   = note: arrays are not iterators, but slices like the following are: `&[1, 2, 3]`
    = note: required by `std::iter::IntoIterator::into_iter`
 
 error[E0277]: `[std::ops::RangeInclusive<{integer}>; 1]` is not an iterator

--- a/src/test/ui/iterators/array.stderr
+++ b/src/test/ui/iterators/array.stderr
@@ -5,7 +5,7 @@ LL |     for _ in [1, 2] {}
    |              ^^^^^^ borrow the array with `&` or call `.iter()` on it to iterate over it
    |
    = help: the trait `std::iter::Iterator` is not implemented for `[{integer}; 2]`
-   = note: arrays are not an iterators, but slices like the following are: `&[1, 2, 3]`
+   = note: arrays are not iterators, but slices like the following are: `&[1, 2, 3]`
    = note: required by `std::iter::IntoIterator::into_iter`
 
 error[E0277]: `[{integer}; 2]` is not an iterator
@@ -15,7 +15,7 @@ LL |     for _ in x {}
    |              ^ borrow the array with `&` or call `.iter()` on it to iterate over it
    |
    = help: the trait `std::iter::Iterator` is not implemented for `[{integer}; 2]`
-   = note: arrays are not an iterators, but slices like the following are: `&[1, 2, 3]`
+   = note: arrays are not iterators, but slices like the following are: `&[1, 2, 3]`
    = note: required by `std::iter::IntoIterator::into_iter`
 
 error[E0277]: `[{float}; 2]` is not an iterator
@@ -25,7 +25,7 @@ LL |     for _ in [1.0, 2.0] {}
    |              ^^^^^^^^^^ borrow the array with `&` or call `.iter()` on it to iterate over it
    |
    = help: the trait `std::iter::Iterator` is not implemented for `[{float}; 2]`
-   = note: arrays are not an iterators, but slices like the following are: `&[1, 2, 3]`
+   = note: arrays are not iterators, but slices like the following are: `&[1, 2, 3]`
    = note: required by `std::iter::IntoIterator::into_iter`
 
 error: aborting due to 3 previous errors


### PR DESCRIPTION
This fixes a small grammatical mistake in the message the compiler gives when attempting to iterate directly over an array `arr` without calling `arr.iter()` or borrowing `&arr`.