### PR TITLE
rustc: Don't ICE on usage of two new target features

### DIFF
--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -2207,6 +2207,8 @@ fn from_target_feature(
                 Some("sse4a_target_feature") => rust_features.sse4a_target_feature,
                 Some("tbm_target_feature") => rust_features.tbm_target_feature,
                 Some("wasm_target_feature") => rust_features.wasm_target_feature,
+                Some("cmpxchg16b_target_feature") => rust_features.cmpxchg16b_target_feature,
+                Some("adx_target_feature") => rust_features.adx_target_feature,
                 Some(name) => bug!("unknown target feature gate {}", name),
                 None => true,
             };

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -420,6 +420,8 @@ declare_features! (
     (active, sse4a_target_feature, "1.27.0", Some(44839), None),
     (active, tbm_target_feature, "1.27.0", Some(44839), None),
     (active, wasm_target_feature, "1.30.0", Some(44839), None),
+    (active, adx_target_feature, "1.32.0", Some(44839), None),
+    (active, cmpxchg16b_target_feature, "1.32.0", Some(44839), None),
 
     // Allows macro invocations on modules expressions and statements and
     // procedural macros to expand to non-items.

--- a/src/test/ui/target-feature-gate.rs
+++ b/src/test/ui/target-feature-gate.rs
@@ -24,6 +24,9 @@
 // gate-test-mips_target_feature
 // gate-test-mmx_target_feature
 // gate-test-wasm_target_feature
+// gate-test-adx_target_feature
+// gate-test-cmpxchg16b_target_feature
+// min-llvm-version 6.0
 
 #[target_feature(enable = "avx512bw")]
 //~^ ERROR: currently unstable

--- a/src/test/ui/target-feature-gate.stderr
+++ b/src/test/ui/target-feature-gate.stderr
@@ -1,5 +1,5 @@
 error[E0658]: the target feature `avx512bw` is currently unstable (see issue #44839)
-  --> $DIR/target-feature-gate.rs:28:18
+  --> $DIR/target-feature-gate.rs:31:18
    |
 LL | #[target_feature(enable = "avx512bw")]
    |                  ^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
I seem to always forget to update this portion of the compiler...