### PR TITLE
Enable stack probes for UEFI images

### DIFF
--- a/src/librustc_target/spec/uefi_base.rs
+++ b/src/librustc_target/spec/uefi_base.rs
@@ -62,6 +62,7 @@ pub fn opts() -> TargetOptions {
         exe_suffix: ".efi".to_string(),
         allows_weak_linkage: false,
         panic_strategy: PanicStrategy::Abort,
+        stack_probes: true,
         singlethread: true,
         emit_debug_gdb_scripts: false,
 


### PR DESCRIPTION
When building UEFI images, we don't link to any CRT libraries so we need to provide a stack probe. Without `__rust_probestack`, the linker looks for `__chkstk` and fails to link if there is a function with large local variables.

r? @alexcrichton 