### PR TITLE
Update the stdsimd submodule

### DIFF
--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -118,6 +118,7 @@
 #![feature(mips_target_feature)]
 #![feature(aarch64_target_feature)]
 #![feature(wasm_target_feature)]
+#![feature(avx512_target_feature)]
 #![feature(const_slice_len)]
 #![feature(const_str_as_bytes)]
 #![feature(const_str_len)]

--- a/src/libstd/sys/wasm/alloc.rs
+++ b/src/libstd/sys/wasm/alloc.rs
@@ -74,7 +74,7 @@ mod lock {
                 return DropLock
             }
             unsafe {
-                let r = wasm32::atomic::wait_i32(
+                let r = wasm32::i32_atomic_wait(
                     &LOCKED as *const AtomicI32 as *mut i32,
                     1,  // expected value
                     -1, // timeout
@@ -89,7 +89,7 @@ mod lock {
             let r = LOCKED.swap(0, SeqCst);
             debug_assert_eq!(r, 1);
             unsafe {
-                wasm32::atomic::wake(
+                wasm32::atomic_notify(
                     &LOCKED as *const AtomicI32 as *mut i32,
                     1, // only one thread
                 );

--- a/src/libstd/sys/wasm/mutex_atomics.rs
+++ b/src/libstd/sys/wasm/mutex_atomics.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use arch::wasm32::atomic;
+use arch::wasm32;
 use cell::UnsafeCell;
 use mem;
 use sync::atomic::{AtomicUsize, AtomicU32, Ordering::SeqCst};
@@ -36,7 +36,7 @@ impl Mutex {
 
     pub unsafe fn lock(&self) {
         while !self.try_lock() {
-            let val = atomic::wait_i32(
+            let val = wasm32::i32_atomic_wait(
                 self.ptr(),
                 1,  // we expect our mutex is locked
                 -1, // wait infinitely
@@ -50,7 +50,7 @@ impl Mutex {
     pub unsafe fn unlock(&self) {
         let prev = self.locked.swap(0, SeqCst);
         debug_assert_eq!(prev, 1);
-        atomic::wake(self.ptr(), 1); // wake up one waiter, if any
+        wasm32::atomic_notify(self.ptr(), 1); // wake up one waiter, if any
     }
 
     #[inline]
@@ -104,7 +104,7 @@ impl ReentrantMutex {
     pub unsafe fn lock(&self) {
         let me = thread::my_id();
         while let Err(owner) = self._try_lock(me) {
-            let val = atomic::wait_i32(self.ptr(), owner as i32, -1);
+            let val = wasm32::i32_atomic_wait(self.ptr(), owner as i32, -1);
             debug_assert!(val == 0 || val == 1);
         }
     }
@@ -143,7 +143,7 @@ impl ReentrantMutex {
         match *self.recursions.get() {
             0 => {
                 self.owner.swap(0, SeqCst);
-                atomic::wake(self.ptr() as *mut i32, 1); // wake up one waiter, if any
+                wasm32::atomic_notify(self.ptr() as *mut i32, 1); // wake up one waiter, if any
             }
             ref mut n => *n -= 1,
         }

--- a/src/libstd/sys/wasm/thread.rs
+++ b/src/libstd/sys/wasm/thread.rs
@@ -41,7 +41,7 @@ impl Thread {
 
     #[cfg(target_feature = "atomics")]
     pub fn sleep(dur: Duration) {
-        use arch::wasm32::atomic;
+        use arch::wasm32;
         use cmp;
 
         // Use an atomic wait to block the current thread artificially with a
@@ -53,7 +53,7 @@ impl Thread {
         while nanos > 0 {
             let amt = cmp::min(i64::max_value() as u128, nanos);
             let mut x = 0;
-            let val = unsafe { atomic::wait_i32(&mut x, 0, amt as i64) };
+            let val = unsafe { wasm32::i32_atomic_wait(&mut x, 0, amt as i64) };
             debug_assert_eq!(val, 2);
             nanos -= amt;
         }
@@ -108,7 +108,7 @@ cfg_if! {
             panic!("thread local data not implemented on wasm with atomics yet")
         }
 
-        pub fn tcb_set(ptr: *mut u8) {
+        pub fn tcb_set(_ptr: *mut u8) {
             panic!("thread local data not implemented on wasm with atomics yet")
         }
     } else {


### PR DESCRIPTION
This brings in a few updates:

* Update wasm intrinsic naming for atomics
* Update and reimplement most simd128 wasm intrinsics
* Other misc improvements here and there, including a small start to
  AVX-512 intrinsics