### PR TITLE
Add --progress to git submodule commands in x.py

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -678,10 +678,10 @@ class RustBuild(object):
 
         print("Updating submodule", module)
 
-        run(["git", "submodule", "-q", "sync", module],
+        run(["git", "submodule", "-q", "sync", "--progress", module],
             cwd=self.rust_root, verbose=self.verbose)
         run(["git", "submodule", "update",
-            "--init", "--recursive", module],
+            "--init", "--recursive", "--progress", module],
             cwd=self.rust_root, verbose=self.verbose)
         run(["git", "reset", "-q", "--hard"],
             cwd=module_path, verbose=self.verbose)


### PR DESCRIPTION
This is a relatively new flag, but it means that git will indicate the progress of the update as it would with regular clones. This is especially helpful as some of the submodules are really big and it's difficult to tell if it's hanging or still updating.