### PR TITLE
Automatically open an issue when a tool breaks

### DIFF
--- a/src/tools/publish_toolstate.py
+++ b/src/tools/publish_toolstate.py
@@ -46,11 +46,11 @@ def read_current_status(current_commit, path):
     return {}
 
 def issue(
-    title,
     tool,
     maintainers,
     relevant_pr_number,
     relevant_pr_user,
+    msg,
 ):
     # Open an issue about the toolstate failure.
     gh_url = 'https://api.github.com/repos/rust-lang/rust/issues'
@@ -64,8 +64,11 @@ def issue(
 
             If you have the time it would be great if you could open a PR against {} that
             fixes the fallout from your PR.
-            '''.format(relevant_pr_user, relevant_pr_number, tool, tool),
-            'title': title,
+
+            {}
+
+            '''.format(relevant_pr_user, relevant_pr_number, tool, tool, msg),
+            'title': '💔 {}'.format(tool),
             'assignees': assignees,
             'labels': ['T-compiler', 'I-nominated'],
         }),
@@ -105,6 +108,7 @@ def update_latest(
         for status in latest:
             tool = status['tool']
             changed = False
+            failures = ''
 
             for os, s in current_status.items():
                 old = status[os]
@@ -120,7 +124,11 @@ def update_latest(
                         .format(tool, os, old, new)
                     message += '{} (cc {}, @rust-lang/infra).\n' \
                         .format(title, MAINTAINERS.get(tool))
-                    issue(title, tool, MAINTAINERS.get(tool), relevant_pr_number, relevant_pr_user)
+                    failures += title
+                    failures += '\n'
+
+            if failures != '':
+                issue(tool, MAINTAINERS.get(tool), relevant_pr_number, relevant_pr_user, failures)
 
             if changed:
                 status['commit'] = current_commit

--- a/src/tools/publish_toolstate.py
+++ b/src/tools/publish_toolstate.py
@@ -67,6 +67,7 @@ def issue(
             '''.format(relevant_pr_user, relevant_pr_number, tool, tool),
             'title': title,
             'assignees': assignees,
+            'labels': ['T-compiler', 'I-nominated'],
         }),
         {
             'Authorization': 'token ' + github_token,

--- a/src/tools/publish_toolstate.py
+++ b/src/tools/publish_toolstate.py
@@ -70,7 +70,7 @@ def issue(
     response = urllib2.urlopen(urllib2.Request(
         gh_url,
         json.dumps({
-            'body': '''\
+            'body': textwrap.dedent('''\
             Hello, this is your friendly neighborhood mergebot.
             After merging PR {}, I observed that the tool {} no longer builds.
             A follow-up PR to the repository {} is needed to fix the fallout.
@@ -80,7 +80,7 @@ def issue(
 
             cc @{}, the PR reviewer, and @rust-lang/compiler -- nominating for prioritization.
 
-            '''.format(relevant_pr_number, tool, REPOS[tool], relevant_pr_user, pr_reviewer),
+            ''').format(relevant_pr_number, tool, REPOS[tool], relevant_pr_user, pr_reviewer),
             'title': '`{}` no longer builds after {}'.format(tool, relevant_pr_number),
             'assignees': assignees,
             'labels': ['T-compiler', 'I-nominated'],

--- a/src/tools/publish_toolstate.py
+++ b/src/tools/publish_toolstate.py
@@ -75,7 +75,8 @@ def issue(
             After merging PR {}, I observed that the tool {} no longer builds.
             A follow-up PR to the repository {} is needed to fix the fallout.
 
-            cc @{}, do you think you would have time to do the follow-up work? If so, that would be great!
+            cc @{}, do you think you would have time to do the follow-up work?
+            If so, that would be great!
 
             cc @{}, the PR reviewer, and @rust-lang/compiler -- nominating for prioritization.
 
@@ -144,7 +145,10 @@ def update_latest(
                         build_failed = True
 
             if build_failed:
-                issue(tool, MAINTAINERS.get(tool), relevant_pr_number, relevant_pr_user, pr_reviewer)
+                issue(
+                    tool, MAINTAINERS.get(tool),
+                    relevant_pr_number, relevant_pr_user, pr_reviewer,
+                )
 
             if changed:
                 status['commit'] = current_commit
@@ -168,7 +172,10 @@ if __name__ == '__main__':
     github_token = sys.argv[4]
 
     # assume that PR authors are also owners of the repo where the branch lives
-    relevant_pr_match = re.search('Auto merge of #([0-9]+) - ([^:]+):[^,]+ r=([^\s]+)', cur_commit_msg)
+    relevant_pr_match = re.search(
+        'Auto merge of #([0-9]+) - ([^:]+):[^,]+ r=([^\s]+)',
+        cur_commit_msg,
+    )
     if relevant_pr_match:
         number = relevant_pr_match.group(1)
         relevant_pr_user = relevant_pr_match.group(2)

--- a/src/tools/publish_toolstate.py
+++ b/src/tools/publish_toolstate.py
@@ -145,10 +145,18 @@ def update_latest(
                         build_failed = True
 
             if build_failed:
-                issue(
-                    tool, MAINTAINERS.get(tool),
-                    relevant_pr_number, relevant_pr_user, pr_reviewer,
-                )
+                try:
+                    issue(
+                        tool, MAINTAINERS.get(tool),
+                        relevant_pr_number, relevant_pr_user, pr_reviewer,
+                    )
+                except IOError as (errno, strerror):
+                    # network errors will simply end up not creating an issue, but that's better
+                    # than failing the entire build job
+                    print "I/O error({0}): {1}".format(errno, strerror)
+                except:
+                    print "Unexpected error:", sys.exc_info()[0]
+                    raise
 
             if changed:
                 status['commit'] = current_commit


### PR DESCRIPTION
cc @nikomatsakis 

fixes https://github.com/rust-lang-nursery/rust-toolstate/issues/6

documentation about issue opening via the github api: https://developer.github.com/v3/issues/#create-an-issue