### PR TITLE
ci: Upgrade Travis to Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: shell
 sudo: required
-dist: trusty
+dist: xenial
 services:
   - docker
 addons:

--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -19,10 +19,12 @@ travis_time_start
 
 if [ -f "$docker_dir/$image/Dockerfile" ]; then
     if [ "$CI" != "" ]; then
-      cksum=$(find $docker_dir/$image $docker_dir/scripts -type f | \
+      hash_key=/tmp/.docker-hash-key.txt
+      find $docker_dir/$image $docker_dir/scripts -type f | \
         sort | \
-        xargs cat | \
-        sha512sum | \
+        xargs cat >> $hash_key
+      docker --version >> $hash_key
+      cksum=$(sha512sum $hash_key | \
         awk '{print $1}')
       s3url="s3://$SCCACHE_BUCKET/docker/$cksum"
       url="https://s3-us-west-1.amazonaws.com/$SCCACHE_BUCKET/docker/$cksum"


### PR DESCRIPTION
In theory we shouldn't require trusty so long as docker continues to
work!