### PR TITLE
Fix mobile menu rendering collision with tooltip.

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -997,7 +997,7 @@ span.since {
 		margin-left: -15px;
 		padding: 0 15px;
 		position: static;
-		z-index: 1;
+		z-index: 11;
 	}
 
 	.sidebar > .location {


### PR DESCRIPTION
Bring the mobile-mode menu in front of the ⓘ icon.

Here's what the bug looks like:

![screen shot 2018-12-18 at 1 53 46 pm](https://user-images.githubusercontent.com/4282480/50185501-cbf62180-02cc-11e9-927e-3c6469901323.png)
