### PR TITLE
[beta] Backport fixes to build-manifest

### DIFF
--- a/src/ci/docker/mingw-check/Dockerfile
+++ b/src/ci/docker/mingw-check/Dockerfile
@@ -20,4 +20,5 @@ COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
 ENV RUN_CHECK_WITH_PARALLEL_QUERIES 1
-ENV SCRIPT python2.7 ../x.py check --target=i686-pc-windows-gnu --host=i686-pc-windows-gnu
+ENV SCRIPT python2.7 ../x.py check --target=i686-pc-windows-gnu --host=i686-pc-windows-gnu && \
+           python2.7 ../x.py build --stage 0 src/tools/build-manifest

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -623,6 +623,7 @@ impl Builder {
         let mut cmd = Command::new("gpg");
         cmd.arg("--no-tty")
             .arg("--yes")
+            .arg("--batch")
             .arg("--passphrase-fd").arg("0")
             .arg("--personal-digest-preferences").arg("SHA512")
             .arg("--armor")

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -621,7 +621,8 @@ impl Builder {
         let asc = self.output.join(format!("{}.asc", filename));
         println!("signing: {:?}", path);
         let mut cmd = Command::new("gpg");
-        cmd.arg("--no-tty")
+        cmd.arg("--pinentry-mode=loopback")
+            .arg("--no-tty")
             .arg("--yes")
             .arg("--batch")
             .arg("--passphrase-fd").arg("0")


### PR DESCRIPTION
Backports the following changes to beta:

* #56703: Fix build of the `build-manifest` tool *(partial, just added last commit)*
* #56783: Add `--pinentry-mode=loopback` to deployment script
* #56735: Fix gpg signing in manifest builder 

r? @ghost
cc @Mark-Simulacrum @alexcrichton 