### PR TITLE
 Make `SortedMap::new` const, also faster `is_empty`

### DIFF
--- a/src/librustc_data_structures/lib.rs
+++ b/src/librustc_data_structures/lib.rs
@@ -30,6 +30,8 @@
 #![feature(allow_internal_unstable)]
 #![feature(vec_resize_with)]
 #![feature(hash_raw_entry)]
+#![feature(const_fn)]
+#![feature(const_vec_new)]
 
 #![cfg_attr(unix, feature(libc))]
 #![cfg_attr(test, feature(test))]

--- a/src/librustc_data_structures/sorted_map.rs
+++ b/src/librustc_data_structures/sorted_map.rs
@@ -30,9 +30,9 @@ pub struct SortedMap<K: Ord, V> {
 
 impl<K: Ord, V> SortedMap<K, V> {
     #[inline]
-    pub fn new() -> SortedMap<K, V> {
+    pub const fn new() -> SortedMap<K, V> {
         SortedMap {
-            data: vec![]
+            data: Vec::new()
         }
     }
 
@@ -144,7 +144,7 @@ impl<K: Ord, V> SortedMap<K, V> {
 
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.len() == 0
+        self.data.is_empty()
     }
 
     #[inline]


### PR DESCRIPTION
(The latter is because `[T]::is_empty` compiles to a single pointer comparison, whereas `len() == 0` first subtracts the pointers and only then compares with zero)