### PR TITLE
Show platform-specific modules in `std::os` when building those platforms

### DIFF
--- a/src/libstd/os/mod.rs
+++ b/src/libstd/os/mod.rs
@@ -29,25 +29,10 @@ cfg_if! {
 
         #[doc(cfg(target_os = "linux"))]
         pub mod linux;
-
     } else {
 
-        // If we're not documenting libstd then we just expose everything as we
-        // otherwise would.
-
-        #[cfg(target_os = "android")]    pub mod android;
-        #[cfg(target_os = "bitrig")]     pub mod bitrig;
-        #[cfg(target_os = "dragonfly")]  pub mod dragonfly;
-        #[cfg(target_os = "freebsd")]    pub mod freebsd;
-        #[cfg(target_os = "haiku")]      pub mod haiku;
-        #[cfg(target_os = "ios")]        pub mod ios;
-        #[cfg(target_os = "macos")]      pub mod macos;
-        #[cfg(target_os = "netbsd")]     pub mod netbsd;
-        #[cfg(target_os = "openbsd")]    pub mod openbsd;
-        #[cfg(target_os = "solaris")]    pub mod solaris;
-        #[cfg(target_os = "emscripten")] pub mod emscripten;
-        #[cfg(target_os = "fuchsia")]    pub mod fuchsia;
-        #[cfg(target_os = "hermit")]     pub mod hermit;
+        // If we're not documenting libstd then we just expose the main modules
+        // as we otherwise would.
 
         #[cfg(any(target_os = "redox", unix))]
         #[stable(feature = "rust1", since = "1.0.0")]
@@ -62,5 +47,19 @@ cfg_if! {
 
     }
 }
+
+#[cfg(target_os = "android")]    pub mod android;
+#[cfg(target_os = "bitrig")]     pub mod bitrig;
+#[cfg(target_os = "dragonfly")]  pub mod dragonfly;
+#[cfg(target_os = "freebsd")]    pub mod freebsd;
+#[cfg(target_os = "haiku")]      pub mod haiku;
+#[cfg(target_os = "ios")]        pub mod ios;
+#[cfg(target_os = "macos")]      pub mod macos;
+#[cfg(target_os = "netbsd")]     pub mod netbsd;
+#[cfg(target_os = "openbsd")]    pub mod openbsd;
+#[cfg(target_os = "solaris")]    pub mod solaris;
+#[cfg(target_os = "emscripten")] pub mod emscripten;
+#[cfg(target_os = "fuchsia")]    pub mod fuchsia;
+#[cfg(target_os = "hermit")]     pub mod hermit;
 
 pub mod raw;


### PR DESCRIPTION
r? @steveklabnik 