### PR TITLE
make basic CTFE tracing available on release builds

### DIFF
--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -422,7 +422,7 @@ impl<'a, 'mir, 'tcx: 'mir, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tc
         return_to_block: StackPopCleanup,
     ) -> EvalResult<'tcx> {
         if self.stack.len() > 1 { // FIXME should be "> 0", printing topmost frame crashes rustc...
-            debug!("PAUSING({}) {}", self.cur_frame(), self.frame().instance);
+            info!("PAUSING({}) {}", self.cur_frame(), self.frame().instance);
         }
         ::log_settings::settings().indentation += 1;
 
@@ -491,7 +491,7 @@ impl<'a, 'mir, 'tcx: 'mir, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tc
         }
 
         if self.stack.len() > 1 { // FIXME no check should be needed, but some instances ICE
-            debug!("ENTERING({}) {}", self.cur_frame(), self.frame().instance);
+            info!("ENTERING({}) {}", self.cur_frame(), self.frame().instance);
         }
 
         if self.stack.len() > self.tcx.sess.const_eval_stack_frame_limit {
@@ -503,7 +503,7 @@ impl<'a, 'mir, 'tcx: 'mir, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tc
 
     pub(super) fn pop_stack_frame(&mut self) -> EvalResult<'tcx> {
         if self.stack.len() > 1 { // FIXME no check should be needed, but some instances ICE
-            debug!("LEAVING({}) {}", self.cur_frame(), self.frame().instance);
+            info!("LEAVING({}) {}", self.cur_frame(), self.frame().instance);
         }
         ::log_settings::settings().indentation -= 1;
         let frame = self.stack.pop().expect(
@@ -557,7 +557,7 @@ impl<'a, 'mir, 'tcx: 'mir, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tc
         }
 
         if self.stack.len() > 1 { // FIXME should be "> 0", printing topmost frame crashes rustc...
-            debug!("CONTINUING({}) {}", self.cur_frame(), self.frame().instance);
+            info!("CONTINUING({}) {}", self.cur_frame(), self.frame().instance);
         }
 
         Ok(())

--- a/src/librustc_mir/interpret/step.rs
+++ b/src/librustc_mir/interpret/step.rs
@@ -81,7 +81,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
     }
 
     fn statement(&mut self, stmt: &mir::Statement<'tcx>) -> EvalResult<'tcx> {
-        debug!("{:?}", stmt);
+        info!("{:?}", stmt);
 
         use rustc::mir::StatementKind::*;
 
@@ -293,7 +293,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
     }
 
     fn terminator(&mut self, terminator: &mir::Terminator<'tcx>) -> EvalResult<'tcx> {
-        debug!("{:?}", terminator.kind);
+        info!("{:?}", terminator.kind);
         self.tcx.span = terminator.source_info.span;
         self.memory.tcx.span = terminator.source_info.span;
 
@@ -303,7 +303,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
         if !self.stack.is_empty() {
             // This should change *something*
             debug_assert!(self.cur_frame() != old_stack || self.frame().block != old_bb);
-            debug!("// {:?}", self.frame().block);
+            info!("// {:?}", self.frame().block);
         }
         Ok(())
     }


### PR DESCRIPTION
Debugging things going wrong in miri is currently pretty much impossible with a nightly Rust.

r? @oli-obk 