### PR TITLE
Parallel query tweaks

### DIFF
--- a/src/librustc/ty/query/job.rs
+++ b/src/librustc/ty/query/job.rs
@@ -390,11 +390,9 @@ fn remove_cycle<'tcx>(
                                       DUMMY_SP,
                                       &mut stack,
                                       &mut visited) {
-        // Reverse the stack so earlier entries require later entries
-        stack.reverse();
-
-        // The stack is a vector of pairs of spans and queries
-        let (mut spans, queries): (Vec<_>, Vec<_>) = stack.into_iter().unzip();
+        // The stack is a vector of pairs of spans and queries; reverse it so that
+        // the earlier entries require later entries
+        let (mut spans, queries): (Vec<_>, Vec<_>) = stack.into_iter().rev().unzip();
 
         // Shift the spans so that queries are matched with the span for their waitee
         spans.rotate_right(1);

--- a/src/librustc/ty/query/job.rs
+++ b/src/librustc/ty/query/job.rs
@@ -295,7 +295,7 @@ fn cycle_check<'tcx>(query: Lrc<QueryJob<'tcx>>,
             // We detected a query cycle, fix up the initial span and return Some
 
             // Remove previous stack entries
-            stack.splice(0..p, iter::empty());
+            stack.drain(0..p);
             // Replace the span for the first query with the cycle cause
             stack[0].0 = span;
             Some(None)

--- a/src/librustc/ty/query/job.rs
+++ b/src/librustc/ty/query/job.rs
@@ -406,7 +406,7 @@ fn remove_cycle<'tcx>(
 
         // Find the queries in the cycle which are
         // connected to queries outside the cycle
-        let entry_points: Vec<_> = stack.iter().filter_map(|(span, query)| {
+        let entry_points = stack.iter().filter_map(|(span, query)| {
             if query.parent.is_none() {
                 // This query is connected to the root (it has no query parent)
                 Some((*span, query.clone(), None))
@@ -431,10 +431,7 @@ fn remove_cycle<'tcx>(
                     Some((*span, query.clone(), Some(waiter)))
                 }
             }
-        }).collect();
-
-        let entry_points: Vec<(Span, Lrc<QueryJob<'tcx>>, Option<(Span, Lrc<QueryJob<'tcx>>)>)>
-         = entry_points;
+        }).collect::<Vec<(Span, Lrc<QueryJob<'tcx>>, Option<(Span, Lrc<QueryJob<'tcx>>)>)>>();
 
         // Deterministically pick an entry point
         let (_, entry_point, usage) = pick_query(tcx, &entry_points, |e| (e.0, e.1.clone()));

--- a/src/librustc/ty/query/on_disk_cache.rs
+++ b/src/librustc/ty/query/on_disk_cache.rs
@@ -398,11 +398,7 @@ impl<'sess> OnDiskCache<'sess> {
                              -> Option<T>
         where T: Decodable
     {
-        let pos = if let Some(&pos) = index.get(&dep_node_index) {
-            pos
-        } else {
-            return None
-        };
+        let pos = index.get(&dep_node_index).cloned()?;
 
         // Initialize the cnum_map using the value from the thread which finishes the closure first
         self.cnum_map.init_nonlocking_same(|| {


### PR DESCRIPTION
- faster stack reversal in `remove_cycle`
- insert visited queries more eagerly
- simplify stack trimming in `cycle_check`
- minor refactoring in 2 spots