### PR TITLE
A few tweaks to dropck_outlives

### DIFF
--- a/src/librustc/traits/query/dropck_outlives.rs
+++ b/src/librustc/traits/query/dropck_outlives.rs
@@ -55,8 +55,8 @@ impl<'cx, 'gcx, 'tcx> At<'cx, 'gcx, 'tcx> {
         let c_ty = self.infcx.canonicalize_query(&self.param_env.and(ty), &mut orig_values);
         let span = self.cause.span;
         debug!("c_ty = {:?}", c_ty);
-        match &gcx.dropck_outlives(c_ty) {
-            Ok(result) if result.is_proven() => {
+        if let Ok(result) = &gcx.dropck_outlives(c_ty) {
+            if result.is_proven() {
                 if let Ok(InferOk { value, obligations }) =
                     self.infcx.instantiate_query_response_and_region_obligations(
                     self.cause,
@@ -72,8 +72,6 @@ impl<'cx, 'gcx, 'tcx> At<'cx, 'gcx, 'tcx> {
                     };
                 }
             }
-
-            _ => { /* fallthrough to error-handling code below */ }
         }
 
         // Errors and ambiuity in dropck occur in two cases:
@@ -82,10 +80,11 @@ impl<'cx, 'gcx, 'tcx> At<'cx, 'gcx, 'tcx> {
         // Either of these should have created an error before.
         tcx.sess
             .delay_span_bug(span, "dtorck encountered internal error");
-        return InferOk {
+
+        InferOk {
             value: vec![],
             obligations: vec![],
-        };
+        }
     }
 }
 
@@ -102,7 +101,7 @@ impl<'tcx> DropckOutlivesResult<'tcx> {
         span: Span,
         ty: Ty<'tcx>,
     ) {
-        for overflow_ty in self.overflows.iter().take(1) {
+        if let Some(overflow_ty) = self.overflows.iter().next() {
             let mut err = struct_span_err!(
                 tcx.sess,
                 span,

--- a/src/librustc/traits/query/dropck_outlives.rs
+++ b/src/librustc/traits/query/dropck_outlives.rs
@@ -227,7 +227,7 @@ pub fn trivial_dropck_outlives<'tcx>(tcx: TyCtxt<'_, '_, 'tcx>, ty: Ty<'tcx>) ->
 
         // (T1..Tn) and closures have same properties as T1..Tn --
         // check if *any* of those are trivial.
-        ty::Tuple(ref tys) => tys.iter().cloned().all(|t| trivial_dropck_outlives(tcx, t)),
+        ty::Tuple(ref tys) => tys.iter().all(|t| trivial_dropck_outlives(tcx, t)),
         ty::Closure(def_id, ref substs) => substs
             .upvar_tys(def_id, tcx)
             .all(|t| trivial_dropck_outlives(tcx, t)),


### PR DESCRIPTION
- remove an unnecessary call to `cloned()`
- simplify common patterns