### PR TITLE
rustc: Move jemalloc from rustc_driver to rustc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2214,6 +2214,7 @@ dependencies = [
 name = "rustc-main"
 version = "0.0.0"
 dependencies = [
+ "jemalloc-sys 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_codegen_ssa 0.0.0",
  "rustc_driver 0.0.0",
  "rustc_target 0.0.0",
@@ -2400,7 +2401,6 @@ dependencies = [
  "arena 0.0.0",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "graphviz 0.0.0",
- "jemalloc-sys 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc 0.0.0",
  "rustc-rayon 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/librustc_driver/Cargo.toml
+++ b/src/librustc_driver/Cargo.toml
@@ -38,8 +38,3 @@ syntax = { path = "../libsyntax" }
 smallvec = { version = "0.6.7", features = ["union", "may_dangle"] }
 syntax_ext = { path = "../libsyntax_ext" }
 syntax_pos = { path = "../libsyntax_pos" }
-
-[dependencies.jemalloc-sys]
-version = '0.1.8'
-optional = true
-features = ['unprefixed_malloc_on_supported_platforms']

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -64,14 +64,6 @@ extern crate syntax;
 extern crate syntax_ext;
 extern crate syntax_pos;
 
-// Note that the linkage here should be all that we need, on Linux we're not
-// prefixing the symbols here so this should naturally override our default
-// allocator. On OSX it should override via the zone allocator. We shouldn't
-// enable this by default on other platforms, so other platforms aren't handled
-// here yet.
-#[cfg(feature = "jemalloc-sys")]
-extern crate jemalloc_sys;
-
 use driver::CompileController;
 use pretty::{PpMode, UserIdentifiedItem};
 

--- a/src/rustc/Cargo.toml
+++ b/src/rustc/Cargo.toml
@@ -15,5 +15,10 @@ rustc_driver = { path = "../librustc_driver" }
 # crate is intended to be used by codegen backends, which may not be in-tree.
 rustc_codegen_ssa = { path = "../librustc_codegen_ssa" }
 
+[dependencies.jemalloc-sys]
+version = '0.1.8'
+optional = true
+features = ['unprefixed_malloc_on_supported_platforms']
+
 [features]
-jemalloc = ['rustc_driver/jemalloc-sys']
+jemalloc = ['jemalloc-sys']

--- a/src/rustc/rustc.rs
+++ b/src/rustc/rustc.rs
@@ -23,6 +23,14 @@ extern {}
 
 extern crate rustc_driver;
 
+// Note that the linkage here should be all that we need, on Linux we're not
+// prefixing the symbols here so this should naturally override our default
+// allocator. On OSX it should override via the zone allocator. We shouldn't
+// enable this by default on other platforms, so other platforms aren't handled
+// here yet.
+#[cfg(feature = "jemalloc-sys")]
+extern crate jemalloc_sys;
+
 fn main() {
     rustc_driver::set_sigpipe_handler();
     rustc_driver::main()


### PR DESCRIPTION
This commit moves jemalloc to just the rustc binary rather than the
rustc_driver shared library, enusring that it's only used for binaries
that opt-in to it like rustc rather than other binaries using
librustc_driver like rustdoc/rls/etc. This will hopefully address #56980