### PR TITLE
Add gdb to the build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -52,6 +52,10 @@
 	path = src/tools/clang
 	url = https://github.com/rust-lang-nursery/clang.git
 	branch = rust-release-80-v2
+[submodule "src/tools/gdb"]
+	path = src/tools/gdb
+	url = https://github.com/rust-dev-tools/gdb.git
+	branch = rust-8.2
 [submodule "src/doc/rustc-guide"]
 	path = src/doc/rustc-guide
 	url = https://github.com/rust-lang/rustc-guide.git

--- a/config.toml.example
+++ b/config.toml.example
@@ -383,6 +383,9 @@
 # This is only built if LLVM is also being built.
 #lldb = false
 
+# Indicates whether GDB will also be built.
+#build-gdb = false
+
 # Whether to deny warnings in crates
 #deny-warnings = true
 

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -723,6 +723,10 @@ class RustBuild(object):
                 config = self.get_toml('lldb')
                 if config is None or config == 'false':
                     continue
+            if module.endswith("gdb"):
+                config = self.get_toml('build-gdb')
+                if config is None or config == 'false':
+                    continue
             check = self.check_submodule(module, slow_submodules)
             filtered_submodules.append((module, check))
             submodules_names.append(module)

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -363,6 +363,7 @@ impl<'a> Builder<'a> {
                 tool::Rustdoc,
                 tool::Clippy,
                 native::Llvm,
+                native::Gdb,
                 tool::Rustfmt,
                 tool::Miri,
                 native::Lld
@@ -461,6 +462,7 @@ impl<'a> Builder<'a> {
                 dist::Clippy,
                 dist::LlvmTools,
                 dist::Lldb,
+                dist::Gdb,
                 dist::Extended,
                 dist::HashSign
             ),

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -92,6 +92,8 @@ pub struct Config {
     pub lldb_enabled: bool,
     pub llvm_tools_enabled: bool,
 
+    pub gdb_enabled: bool,
+
     // rust codegen options
     pub rust_optimize: bool,
     pub rust_codegen_units: Option<u32>,
@@ -320,6 +322,7 @@ struct Rust {
     wasm_syscall: Option<bool>,
     lld: Option<bool>,
     lldb: Option<bool>,
+    build_gdb: Option<bool>,
     llvm_tools: Option<bool>,
     deny_warnings: Option<bool>,
     backtrace_on_ice: Option<bool>,
@@ -552,6 +555,7 @@ impl Config {
             set(&mut config.wasm_syscall, rust.wasm_syscall);
             set(&mut config.lld_enabled, rust.lld);
             set(&mut config.lldb_enabled, rust.lldb);
+            set(&mut config.gdb_enabled, rust.build_gdb);
             set(&mut config.llvm_tools_enabled, rust.llvm_tools);
             config.rustc_parallel_queries = rust.experimental_parallel_queries.unwrap_or(false);
             config.rustc_default_linker = rust.default_linker.clone();

--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -70,6 +70,7 @@ o("emscripten", None, "compile the emscripten backend as well as LLVM")
 o("full-tools", None, "enable all tools")
 o("lld", "rust.lld", "build lld")
 o("lldb", "rust.lldb", "build lldb")
+o("gdb", "rust.build-gdb", "build gdb")
 o("missing-tools", "dist.missing-tools", "allow failures when building tools")
 
 # Optimization and debugging options. These may be overridden by the release

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -594,6 +594,11 @@ impl Build {
         self.out.join(&*target).join("lld")
     }
 
+    /// Output directory for gdb build.
+    fn gdb_out(&self, target: Interned<String>) -> PathBuf {
+        self.out.join(&*target).join("gdb")
+    }
+
     /// Output directory for all documentation for a target
     fn doc_out(&self, target: Interned<String>) -> PathBuf {
         self.out.join(&*target).join("doc")
@@ -1044,6 +1049,14 @@ impl Build {
     }
 
     fn lldb_vers(&self) -> String {
+        self.rust_version()
+    }
+
+    fn gdb_package_vers(&self) -> String {
+        self.package_vers(&self.rust_version())
+    }
+
+    fn gdb_vers(&self) -> String {
         self.rust_version()
     }
 

--- a/src/bootstrap/sanity.rs
+++ b/src/bootstrap/sanity.rs
@@ -126,8 +126,7 @@ pub fn check(build: &mut Build) {
         .or_else(|| cmd_finder.maybe_have("node"))
         .or_else(|| cmd_finder.maybe_have("nodejs"));
 
-    build.config.gdb = build.config.gdb.take().map(|p| cmd_finder.must_have(p))
-        .or_else(|| cmd_finder.maybe_have("gdb"));
+    build.config.gdb = build.config.gdb.take().map(|p| cmd_finder.must_have(p));
 
     // We're gonna build some custom C code here and there, host triples
     // also build some C++ shims for LLVM so we need a C++ compiler.

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1111,8 +1111,14 @@ impl Step for Compiletest {
             cmd.arg("--lldb-python").arg(builder.python());
         }
 
+        // If config.toml specifies a gdb, use it; otherwise, if we
+        // built a gdb, prefer that.
         if let Some(ref gdb) = builder.config.gdb {
             cmd.arg("--gdb").arg(gdb);
+        } else if builder.config.gdb_enabled {
+            cmd.arg("--gdb").arg(builder.gdb_out(target).join("install/bin/gdb"));
+        } else {
+            cmd.arg("--gdb").arg("gdb");
         }
 
         let run = |cmd: &mut Command| {

--- a/src/ci/docker/dist-i686-linux/Dockerfile
+++ b/src/ci/docker/dist-i686-linux/Dockerfile
@@ -23,7 +23,13 @@ RUN yum upgrade -y && yum install -y \
       pkgconfig \
       wget \
       autoconf \
-      gettext
+      gettext \
+      xz-static \
+      xz-devel \
+      expat-static \
+      expat-devel \
+      ncurses-static \
+      ncurses-devel
 
 ENV PATH=/rustroot/bin:$PATH
 ENV LD_LIBRARY_PATH=/rustroot/lib64:/rustroot/lib
@@ -95,6 +101,7 @@ ENV HOSTS=i686-unknown-linux-gnu
 
 ENV RUST_CONFIGURE_ARGS \
       --enable-full-tools \
+      --enable-gdb \
       --enable-sanitizers \
       --enable-profiler \
       --set target.i686-unknown-linux-gnu.linker=clang \

--- a/src/ci/docker/dist-x86_64-linux/Dockerfile
+++ b/src/ci/docker/dist-x86_64-linux/Dockerfile
@@ -23,7 +23,13 @@ RUN yum upgrade -y && yum install -y \
       pkgconfig \
       wget \
       autoconf \
-      gettext
+      gettext \
+      xz-static \
+      xz-devel \
+      expat-static \
+      expat-devel \
+      ncurses-static \
+      ncurses-devel
 
 ENV PATH=/rustroot/bin:$PATH
 ENV LD_LIBRARY_PATH=/rustroot/lib64:/rustroot/lib
@@ -95,6 +101,7 @@ ENV HOSTS=x86_64-unknown-linux-gnu
 
 ENV RUST_CONFIGURE_ARGS \
       --enable-full-tools \
+      --enable-gdb \
       --enable-sanitizers \
       --enable-profiler \
       --enable-compiler-docs \

--- a/src/etc/rust-gdb
+++ b/src/etc/rust-gdb
@@ -16,10 +16,22 @@ set -e
 RUSTC_SYSROOT=`rustc --print=sysroot`
 GDB_PYTHON_MODULE_DIRECTORY="$RUSTC_SYSROOT/lib/rustlib/etc"
 
+if [ -z "$RUST_GDB" ]; then
+    # Find the host triple so we can find lldb in rustlib.
+    host=`rustc -vV | sed -n -e 's/^host: //p'`
+    RUST_GDB=gdb
+    if [ -f "$RUSTC_SYSROOT/lib/rustlib/$host/bin/gdb" ]; then
+        bin="$RUSTC_SYSROOT/lib/rustlib/$host/bin"
+        # Pass the path to real-gdb to the wrapper.  This avoids
+        # having to modify PATH here, which might possibly be
+        # confusing inside gdb.
+        RUST_GDB="$bin/gdb $bin/real-gdb"
+    fi
+fi
+
 # Run GDB with the additional arguments that load the pretty printers
 # Set the environment variable `RUST_GDB` to overwrite the call to a
 # different/specific command (defaults to `gdb`).
-RUST_GDB="${RUST_GDB:-gdb}"
 PYTHONPATH="$PYTHONPATH:$GDB_PYTHON_MODULE_DIRECTORY" exec ${RUST_GDB} \
   --directory="$GDB_PYTHON_MODULE_DIRECTORY" \
   -iex "add-auto-load-safe-path $GDB_PYTHON_MODULE_DIRECTORY" \

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -200,6 +200,7 @@ struct Builder {
     rustfmt_release: String,
     llvm_tools_release: String,
     lldb_release: String,
+    gdb_release: String,
 
     input: PathBuf,
     output: PathBuf,
@@ -215,6 +216,7 @@ struct Builder {
     rustfmt_version: Option<String>,
     llvm_tools_version: Option<String>,
     lldb_version: Option<String>,
+    gdb_version: Option<String>,
 
     rust_git_commit_hash: Option<String>,
     cargo_git_commit_hash: Option<String>,
@@ -223,6 +225,7 @@ struct Builder {
     rustfmt_git_commit_hash: Option<String>,
     llvm_tools_git_commit_hash: Option<String>,
     lldb_git_commit_hash: Option<String>,
+    gdb_git_commit_hash: Option<String>,
 
     should_sign: bool,
 }
@@ -251,6 +254,7 @@ fn main() {
     let rustfmt_release = args.next().unwrap();
     let llvm_tools_release = args.next().unwrap();
     let lldb_release = args.next().unwrap();
+    let gdb_release = args.next().unwrap();
     let s3_address = args.next().unwrap();
 
     // Do not ask for a passphrase while manually testing
@@ -267,6 +271,7 @@ fn main() {
         rustfmt_release,
         llvm_tools_release,
         lldb_release,
+        gdb_release,
 
         input,
         output,
@@ -282,6 +287,7 @@ fn main() {
         rustfmt_version: None,
         llvm_tools_version: None,
         lldb_version: None,
+        gdb_version: None,
 
         rust_git_commit_hash: None,
         cargo_git_commit_hash: None,
@@ -290,6 +296,7 @@ fn main() {
         rustfmt_git_commit_hash: None,
         llvm_tools_git_commit_hash: None,
         lldb_git_commit_hash: None,
+        gdb_git_commit_hash: None,
 
         should_sign,
     }.build();
@@ -305,6 +312,7 @@ impl Builder {
         self.llvm_tools_version = self.version("llvm-tools", "x86_64-unknown-linux-gnu");
         // lldb is only built for macOS.
         self.lldb_version = self.version("lldb", "x86_64-apple-darwin");
+        self.gdb_version = self.version("lldb", "x86_64-unknown-linux-gnu");
 
         self.rust_git_commit_hash = self.git_commit_hash("rust", "x86_64-unknown-linux-gnu");
         self.cargo_git_commit_hash = self.git_commit_hash("cargo", "x86_64-unknown-linux-gnu");
@@ -314,6 +322,7 @@ impl Builder {
         self.llvm_tools_git_commit_hash = self.git_commit_hash("llvm-tools",
                                                                "x86_64-unknown-linux-gnu");
         self.lldb_git_commit_hash = self.git_commit_hash("lldb", "x86_64-unknown-linux-gnu");
+        self.lldb_git_commit_hash = self.git_commit_hash("gdb", "x86_64-unknown-linux-gnu");
 
         self.digest_and_sign();
         let manifest = self.build_manifest();
@@ -353,6 +362,7 @@ impl Builder {
         self.package("rust-analysis", &mut manifest.pkg, TARGETS);
         self.package("llvm-tools-preview", &mut manifest.pkg, TARGETS);
         self.package("lldb-preview", &mut manifest.pkg, TARGETS);
+        self.package("gdb", &mut manifest.pkg, TARGETS);
 
         manifest.renames.insert("rls".to_owned(), Rename { to: "rls-preview".to_owned() });
         manifest.renames.insert("rustfmt".to_owned(), Rename { to: "rustfmt-preview".to_owned() });
@@ -403,6 +413,7 @@ impl Builder {
                 Component { pkg: "rustfmt-preview".to_string(), target: host.to_string() },
                 Component { pkg: "llvm-tools-preview".to_string(), target: host.to_string() },
                 Component { pkg: "lldb-preview".to_string(), target: host.to_string() },
+                Component { pkg: "gdb".to_string(), target: host.to_string() },
                 Component { pkg: "rust-analysis".to_string(), target: host.to_string() },
             ]);
 
@@ -524,6 +535,8 @@ impl Builder {
             format!("llvm-tools-{}-{}.tar.gz", self.llvm_tools_release, target)
         } else if component == "lldb" || component == "lldb-preview" {
             format!("lldb-{}-{}.tar.gz", self.lldb_release, target)
+        } else if component == "gdb" {
+            format!("gdb-{}-{}.tar.gz", self.gdb_release, target)
         } else {
             format!("{}-{}-{}.tar.gz", component, self.rust_release, target)
         }
@@ -542,6 +555,8 @@ impl Builder {
             &self.llvm_tools_version
         } else if component == "lldb" || component == "lldb-preview" {
             &self.lldb_version
+        } else if component == "gdb" {
+            &self.gdb_version
         } else {
             &self.rust_version
         }
@@ -560,6 +575,8 @@ impl Builder {
             &self.llvm_tools_git_commit_hash
         } else if component == "lldb" || component == "lldb-preview" {
             &self.lldb_git_commit_hash
+        } else if component == "gdb" {
+            &self.gdb_git_commit_hash
         } else {
             &self.rust_git_commit_hash
         }

--- a/src/tools/tidy/src/lib.rs
+++ b/src/tools/tidy/src/lib.rs
@@ -70,6 +70,7 @@ fn filter_dirs(path: &Path) -> bool {
         "src/tools/miri",
         "src/tools/lld",
         "src/tools/lldb",
+        "src/tools/gdb",
         "src/target",
         "src/stdsimd",
         "src/rust-sgx",


### PR DESCRIPTION
This optionally adds gdb to the Rust build, allowing gdb to be
installed via rustup.  This makes it simpler to make debuginfo
changes, as gdb updates can now be shipped immediately.

If gdb is not checked out, nothing changes.

The build is perhaps a bit chatty, as gdb's "make" and "make install"
are run each time, even if they do nothing.

rust-gdb is modified to prefer the gdb installed by rustup.  This is
analogous to what was done for rust-lldb.

The built gdb requires Python 2.7 as a shared library (other
dependencies are statically linked).  This is a
least-common-denominator Python that is widely available and stable;
dynamic linking is used to avoid breaking existing gdb Python code
that might load shared libraries that themselves require a dynamic
libpython.  To avoid problems here, a small wrapper program is used
that attemps to dlopen libpython; with failures being reported to the
user in an intelligible way.

Two of the Linux dist builds are updated to build gdb.  More could be
added if need be.

If gdb is built as part of the build, and if no other gdb was
specified in config.toml, then the just-built gdb will be used for
debuginfo testing.

Closes #34457