### PR TITLE
Add TryClone trait

### DIFF
--- a/src/libcore/clone.rs
+++ b/src/libcore/clone.rs
@@ -133,6 +133,29 @@ pub trait Clone : Sized {
     }
 }
 
+/// Falliable version of [`Clone`].
+#[unstable(feature = "try_clone", issue = "0")]
+pub trait TryClone : Sized {
+    /// The type returned when cloning fails.
+    type Error;
+
+    /// Returns a copy of the value, or an error if the value could not be cloned.
+    #[unstable(feature = "try_clone", issue = "0")]
+    #[must_use = "cloning is often expensive and is not expected to have side effects"]
+    fn try_clone(&self) -> Result<Self, Self::Error>;
+}
+
+// Infallible clones are semantically equivalent to fallible clones
+// with an uninhabited error type.
+#[unstable(feature = "try_clone", issue = "0")]
+impl<T> TryClone for T where T: Clone {
+    type Error = !;
+
+    fn try_clone(&self) -> Result<Self, Self::Error> {
+        Ok(self.clone())
+    }
+}
+
 // FIXME(aburka): these structs are used solely by #[derive] to
 // assert that every component of a type implements Clone or Copy.
 //

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -7,6 +7,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
+use clone::TryClone;
 use fmt;
 use ffi::OsString;
 use io::{self, SeekFrom, Seek, Read, Initializer, Write};
@@ -569,6 +570,14 @@ impl File {
     #[stable(feature = "set_permissions_atomic", since = "1.16.0")]
     pub fn set_permissions(&self, perm: Permissions) -> io::Result<()> {
         self.inner.set_permissions(perm.0)
+    }
+}
+
+#[unstable(feature = "try_clone", issue = "0")]
+impl TryClone for File {
+    type Error = io::Error;
+    fn try_clone(&self) -> io::Result<File> {
+        File::try_clone(self)
     }
 }
 

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -289,6 +289,7 @@
 #![feature(rustc_private)]
 #![feature(thread_local)]
 #![feature(toowned_clone_into)]
+#![feature(try_clone)]
 #![feature(try_from)]
 #![feature(try_reserve)]
 #![feature(unboxed_closures)]

--- a/src/libstd/net/tcp.rs
+++ b/src/libstd/net/tcp.rs
@@ -1,5 +1,6 @@
 use io::prelude::*;
 
+use clone::TryClone;
 use fmt;
 use io::{self, Initializer};
 use net::{ToSocketAddrs, SocketAddr, Shutdown};
@@ -565,6 +566,14 @@ impl TcpStream {
     }
 }
 
+#[unstable(feature = "try_clone", issue = "0")]
+impl TryClone for TcpStream {
+    type Error = io::Error;
+    fn try_clone(&self) -> io::Result<TcpStream> {
+        TcpStream::try_clone(self)
+    }
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Read for TcpStream {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> { self.0.read(buf) }
@@ -877,6 +886,14 @@ impl TcpListener {
     #[stable(feature = "net2_mutators", since = "1.9.0")]
     pub fn set_nonblocking(&self, nonblocking: bool) -> io::Result<()> {
         self.0.set_nonblocking(nonblocking)
+    }
+}
+
+#[unstable(feature = "try_clone", issue = "0")]
+impl TryClone for TcpListener {
+    type Error = io::Error;
+    fn try_clone(&self) -> io::Result<TcpListener> {
+        TcpListener::try_clone(self)
     }
 }
 

--- a/src/libstd/net/udp.rs
+++ b/src/libstd/net/udp.rs
@@ -1,3 +1,4 @@
+use clone::TryClone;
 use fmt;
 use io::{self, Error, ErrorKind};
 use net::{ToSocketAddrs, SocketAddr, Ipv4Addr, Ipv6Addr};
@@ -784,6 +785,14 @@ impl UdpSocket {
     #[stable(feature = "net2_mutators", since = "1.9.0")]
     pub fn set_nonblocking(&self, nonblocking: bool) -> io::Result<()> {
         self.0.set_nonblocking(nonblocking)
+    }
+}
+
+#[unstable(feature = "try_clone", issue = "0")]
+impl TryClone for UdpSocket {
+    type Error = io::Error;
+    fn try_clone(&self) -> io::Result<UdpSocket> {
+        UdpSocket::try_clone(self)
     }
 }
 


### PR DESCRIPTION
Presumably, this will require an RFC to properly stabilise, but this seems simple enough to warrant opening a PR. I doubt the API would be substantially different from the one I've provided, as it's very simple.

Basically, there are a few things in the standard library that have a `try_clone` method, and it seems very reasonable to add a `TryClone` trait as an analogue to `TryFrom` and `TryInto`. I've personally run into a few cases where it'd be useful to have a trait like this, although again, it's up to others on whether this is useful.

A few unanswered questions:

* Would `#[derive(TryClone)]` even make sense? What would the error type be?
* Should there be a `try_clone_from`? What would the behaviour be if the clone fails?
* Once this trait is added, should the inherent methods be soft-deprecated?