### PR TITLE
Add Into<NonNull<T>> impls for Box<T>/Arc<T>/Rc<T>

### DIFF
--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -481,7 +481,7 @@ impl From<Box<str>> for Box<[u8]> {
 }
 
 #[allow(incoherent_fundamental_impls)]
-#[stable(feature = "box_into_raw_non_null", issue = "47336")]
+#[stable(feature = "box_into_raw_non_null", issue = "47336", since = "1.32.0")]
 impl<T: ?Sized> Into<NonNull<T>> for Box<T> {
     #[inline]
     fn into(self) -> NonNull<T> {

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -170,7 +170,8 @@ impl<T: ?Sized> Box<T> {
     #[stable(feature = "box_raw", since = "1.4.0")]
     #[inline]
     pub fn into_raw(b: Box<T>) -> *mut T {
-        Box::into_raw_non_null(b).as_ptr()
+        let p: NonNull<T> = b.into();
+        p.as_ptr()
     }
 
     /// Consumes the `Box`, returning the wrapped pointer as `NonNull<T>`.

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -194,6 +194,7 @@ impl<T: ?Sized> Box<T> {
     ///
     /// ```
     /// #![feature(box_into_raw_non_null)]
+    /// #![allow(deprecated)]
     ///
     /// fn main() {
     ///     let x = Box::new(5);

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -201,6 +201,7 @@ impl<T: ?Sized> Box<T> {
     /// ```
     #[unstable(feature = "box_into_raw_non_null", issue = "47336")]
     #[inline]
+    #[deprecated(note = "Use `.into()`")]
     pub fn into_raw_non_null(b: Box<T>) -> NonNull<T> {
         Box::into_unique(b).into()
     }

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -201,7 +201,7 @@ impl<T: ?Sized> Box<T> {
     /// ```
     #[unstable(feature = "box_into_raw_non_null", issue = "47336")]
     #[inline]
-    #[rustc_deprecated(note = "Use `.into()`")]
+    #[rustc_deprecated(note = "Use `.into()`", since = "1.32.0")]
     pub fn into_raw_non_null(b: Box<T>) -> NonNull<T> {
         Box::into_unique(b).into()
     }

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -481,7 +481,7 @@ impl From<Box<str>> for Box<[u8]> {
 }
 
 #[allow(incoherent_fundamental_impls)]
-#[stable(feature = "box_into_raw_non_null", issue = "47336", since = "1.32.0")]
+#[stable(feature = "box_into_non_null", since = "1.32.0")]
 impl<T: ?Sized> Into<NonNull<T>> for Box<T> {
     #[inline]
     fn into(self) -> NonNull<T> {

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -483,7 +483,7 @@ impl From<Box<str>> for Box<[u8]> {
 }
 
 #[allow(incoherent_fundamental_impls)]
-#[stable(feature = "box_into_non_null", since = "1.32.0")]
+#[stable(feature = "box_into_non_null", since = "1.34.0")]
 impl<T: ?Sized> Into<NonNull<T>> for Box<T> {
     #[inline]
     fn into(self) -> NonNull<T> {

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -201,7 +201,7 @@ impl<T: ?Sized> Box<T> {
     /// ```
     #[unstable(feature = "box_into_raw_non_null", issue = "47336")]
     #[inline]
-    #[rustc_deprecated(note = "Use `.into()`", since = "1.32.0")]
+    #[rustc_deprecated(reason = "Use `.into()`", since = "1.32.0")]
     pub fn into_raw_non_null(b: Box<T>) -> NonNull<T> {
         Box::into_unique(b).into()
     }

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -201,7 +201,7 @@ impl<T: ?Sized> Box<T> {
     /// ```
     #[unstable(feature = "box_into_raw_non_null", issue = "47336")]
     #[inline]
-    #[deprecated(note = "Use `.into()`")]
+    #[rustc_deprecated(note = "Use `.into()`")]
     pub fn into_raw_non_null(b: Box<T>) -> NonNull<T> {
         Box::into_unique(b).into()
     }

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -479,6 +479,15 @@ impl From<Box<str>> for Box<[u8]> {
     }
 }
 
+#[allow(incoherent_fundamental_impls)]
+#[unstable(feature = "box_into_raw_non_null", issue = "47336")]
+impl<T: ?Sized> Into<NonNull<T>> for Box<T> {
+    #[inline]
+    fn into(self) -> NonNull<T> {
+        Box::into_unique(self).into()
+    }
+}
+
 impl Box<dyn Any> {
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -480,7 +480,7 @@ impl From<Box<str>> for Box<[u8]> {
 }
 
 #[allow(incoherent_fundamental_impls)]
-#[unstable(feature = "box_into_raw_non_null", issue = "47336")]
+#[stable(feature = "box_into_raw_non_null", issue = "47336")]
 impl<T: ?Sized> Into<NonNull<T>> for Box<T> {
     #[inline]
     fn into(self) -> NonNull<T> {

--- a/src/liballoc/boxed_test.rs
+++ b/src/liballoc/boxed_test.rs
@@ -148,3 +148,11 @@ fn boxed_slice_from_iter() {
     assert_eq!(boxed.len(), 100);
     assert_eq!(boxed[7], 7);
 }
+
+#[test]
+fn to_nonnull() {
+    let boxed: Box<i32> = Box::from(0);
+    let ptr: std::ptr::NonNull<i32> = boxed.into();
+    let deref = unsafe { *ptr.as_ref() };
+    assert_eq!(deref, 0);
+}

--- a/src/liballoc/collections/linked_list.rs
+++ b/src/liballoc/collections/linked_list.rs
@@ -156,7 +156,7 @@ impl<T> LinkedList<T> {
         unsafe {
             node.next = self.head;
             node.prev = None;
-            let node = Some(Box::into_raw_non_null(node));
+            let node = Some(node.into());
 
             match self.head {
                 None => self.tail = node,
@@ -191,7 +191,7 @@ impl<T> LinkedList<T> {
         unsafe {
             node.next = None;
             node.prev = self.tail;
-            let node = Some(Box::into_raw_non_null(node));
+            let node = Some(node.into());
 
             match self.tail {
                 None => self.head = node,
@@ -933,11 +933,11 @@ impl<'a, T> IterMut<'a, T> {
                     Some(prev) => prev,
                 };
 
-                let node = Some(Box::into_raw_non_null(box Node {
+                let node = Some((box Node {
                     next: Some(head),
                     prev: Some(prev),
                     element,
-                }));
+                }).into());
 
                 prev.as_mut().next = node;
                 head.as_mut().prev = node;

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -316,11 +316,11 @@ impl<T> Rc<T> {
             // pointers, which ensures that the weak destructor never frees
             // the allocation while the strong destructor is running, even
             // if the weak pointer is stored inside the strong one.
-            ptr: Box::into_raw_non_null(box RcBox {
+            ptr: (box RcBox {
                 strong: Cell::new(1),
                 weak: Cell::new(1),
                 value,
-            }),
+            }).into(),
             phantom: PhantomData,
         }
     }

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -1179,6 +1179,14 @@ impl<T> From<Vec<T>> for Rc<[T]> {
     }
 }
 
+#[unstable(feature = "rc_into_nonnull", reason = "newly added", issue = "0")]
+impl<T: ?Sized> Into<NonNull<T>> for Rc<T> {
+    #[inline]
+    fn into(self) -> NonNull<T> {
+        unsafe { NonNull::new_unchecked(Rc::into_raw(self) as *mut _) }
+    }
+}
+
 /// `Weak` is a version of [`Rc`] that holds a non-owning reference to the
 /// managed value. The value is accessed by calling [`upgrade`] on the `Weak`
 /// pointer, which returns an [`Option`]`<`[`Rc`]`<T>>`.

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -1179,7 +1179,7 @@ impl<T> From<Vec<T>> for Rc<[T]> {
     }
 }
 
-#[unstable(feature = "rc_into_nonnull", reason = "newly added", issue = "0")]
+#[stable(feature = "rc_into_nonnull", since = "1.34.0")]
 impl<T: ?Sized> Into<NonNull<T>> for Rc<T> {
     #[inline]
     fn into(self) -> NonNull<T> {

--- a/src/liballoc/sync.rs
+++ b/src/liballoc/sync.rs
@@ -1574,7 +1574,7 @@ impl<T> From<Vec<T>> for Arc<[T]> {
     }
 }
 
-#[unstable(feature = "arc_into_nonnull", reason = "newly added", issue = "0")]
+#[stable(feature = "arc_into_nonnull", since = "1.34.0")]
 impl<T: ?Sized> Into<NonNull<T>> for Arc<T> {
     #[inline]
     fn into(self) -> NonNull<T> {

--- a/src/liballoc/sync.rs
+++ b/src/liballoc/sync.rs
@@ -1574,6 +1574,14 @@ impl<T> From<Vec<T>> for Arc<[T]> {
     }
 }
 
+#[unstable(feature = "arc_into_nonnull", reason = "newly added", issue = "0")]
+impl<T: ?Sized> Into<NonNull<T>> for Arc<T> {
+    #[inline]
+    fn into(self) -> NonNull<T> {
+        unsafe { NonNull::new_unchecked(Arc::into_raw(self) as *mut _) }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::boxed::Box;

--- a/src/liballoc/sync.rs
+++ b/src/liballoc/sync.rs
@@ -300,7 +300,7 @@ impl<T> Arc<T> {
             weak: atomic::AtomicUsize::new(1),
             data,
         };
-        Arc { ptr: Box::into_raw_non_null(x), phantom: PhantomData }
+        Arc { ptr: x.into(), phantom: PhantomData }
     }
 
     #[unstable(feature = "pin", issue = "49150")]

--- a/src/liballoc/tests/arc.rs
+++ b/src/liballoc/tests/arc.rs
@@ -95,3 +95,8 @@ fn eq() {
     assert!(!(x != x));
     assert_eq!(*x.0.borrow(), 0);
 }
+
+#[test]
+fn to_nonnull() {
+    let _: std::ptr::NonNull<i32> = Arc::new(0).into();
+}

--- a/src/liballoc/tests/arc.rs
+++ b/src/liballoc/tests/arc.rs
@@ -98,5 +98,7 @@ fn eq() {
 
 #[test]
 fn to_nonnull() {
-    let _: std::ptr::NonNull<i32> = Arc::new(0).into();
+    let ptr: std::ptr::NonNull<i32> = Arc::new(0).into();
+    let deref = unsafe { *ptr.as_ref() };
+    assert_eq!(deref, 0);
 }

--- a/src/liballoc/tests/rc.rs
+++ b/src/liballoc/tests/rc.rs
@@ -98,5 +98,7 @@ fn eq() {
 
 #[test]
 fn to_nonnull() {
-    let _: std::ptr::NonNull<i32> = Rc::new(0).into();
+    let ptr: std::ptr::NonNull<i32> = Rc::new(0).into();
+    let deref = unsafe { *ptr.as_ref() };
+    assert_eq!(deref, 0);
 }

--- a/src/liballoc/tests/rc.rs
+++ b/src/liballoc/tests/rc.rs
@@ -95,3 +95,8 @@ fn eq() {
     assert!(!(x != x));
     assert_eq!(*x.0.borrow(), 0);
 }
+
+#[test]
+fn to_nonnull() {
+    let _: std::ptr::NonNull<i32> = Rc::new(0).into();
+}


### PR DESCRIPTION
/cc @withoutboats who mentioned to me this might be worth adding to the standard library, in withoutboats/smart#4
/cc @kennytm who last year didn't love the idea of having an Into<NonNull<T>> for Box<T>, in #46952