### PR TITLE
Actually run compiletest tests on CI

### DIFF
--- a/src/ci/docker/mingw-check/Dockerfile
+++ b/src/ci/docker/mingw-check/Dockerfile
@@ -21,4 +21,5 @@ RUN sh /scripts/sccache.sh
 
 ENV RUN_CHECK_WITH_PARALLEL_QUERIES 1
 ENV SCRIPT python2.7 ../x.py check --target=i686-pc-windows-gnu --host=i686-pc-windows-gnu && \
-           python2.7 ../x.py build --stage 0 src/tools/build-manifest
+           python2.7 ../x.py build --stage 0 src/tools/build-manifest && \
+           python2.7 ../x.py test --stage 0 src/tools/compiletest

--- a/src/ci/docker/x86_64-gnu-tools/checktools.sh
+++ b/src/ci/docker/x86_64-gnu-tools/checktools.sh
@@ -37,11 +37,6 @@ python2.7 "$X_PY" test --no-fail-fast \
     src/tools/rls \
     src/tools/rustfmt \
     src/tools/miri \
-    src/tools/compiletest
-
-# Note that compiletest here is an exception from the other tools.
-# We are only executing the unit tests of it. We don't need to track the
-# toolstate because it's not distributed as a tool like the other items.
 
 set -e
 

--- a/src/ci/docker/x86_64-gnu-tools/checktools.sh
+++ b/src/ci/docker/x86_64-gnu-tools/checktools.sh
@@ -37,6 +37,11 @@ python2.7 "$X_PY" test --no-fail-fast \
     src/tools/rls \
     src/tools/rustfmt \
     src/tools/miri \
+    src/tools/compiletest
+
+# Note that compiletest here is an exception from the other tools.
+# We are only executing the unit tests of it. We don't need to track the
+# toolstate because it's not distributed as a tool like the other items.
 
 set -e
 


### PR DESCRIPTION
I was assuming that https://github.com/rust-lang/rust/pull/56792 would
have resulted in compiletest tests being executed on CI. However, I
couldn't find any mentions of the unit test names in any CI logs.

This adds the compiletest test execution to the checktools.sh script.