### PR TITLE
Keep last redundant linker flag, not first

### DIFF
--- a/src/librustc_metadata/lib.rs
+++ b/src/librustc_metadata/lib.rs
@@ -13,6 +13,7 @@
        html_root_url = "https://doc.rust-lang.org/nightly/")]
 
 #![feature(box_patterns)]
+#![feature(drain_filter)]
 #![feature(libc)]
 #![feature(nll)]
 #![feature(proc_macro_internals)]

--- a/src/librustc_metadata/native_libs.rs
+++ b/src/librustc_metadata/native_libs.rs
@@ -208,34 +208,31 @@ impl<'a, 'tcx> Collector<'a, 'tcx> {
         }
 
         // Update kind and, optionally, the name of all native libraries
-        // (there may be more than one) with the specified name.
+        // (there may be more than one) with the specified name.  If any
+        // library is mentioned more than once, keep the latest mention
+        // of it, so that any possible dependent libraries appear before
+        // it.  (This ensures that the linker is able to see symbols from
+        // all possible dependent libraries before linking in the library
+        // in question.)
         for &(ref name, ref new_name, kind) in &self.tcx.sess.opts.libs {
-            let mut found = false;
-            for lib in self.libs.iter_mut() {
-                let lib_name = match lib.name {
-                    Some(n) => n,
-                    None => continue,
-                };
-                if lib_name == name as &str {
-                    let mut changed = false;
-                    if let Some(k) = kind {
-                        lib.kind = k;
-                        changed = true;
+            // If we've already added any native libraries with the same
+            // name, they will be pulled out into `moved`, so that we can
+            // move them to the end of the list below.
+            let mut existing = self.libs.drain_filter(|lib| {
+                if let Some(lib_name) = lib.name {
+                    if lib_name == name as &str {
+                        if let Some(k) = kind {
+                            lib.kind = k;
+                        }
+                        if let &Some(ref new_name) = new_name {
+                            lib.name = Some(Symbol::intern(new_name));
+                        }
+                        return true;
                     }
-                    if let &Some(ref new_name) = new_name {
-                        lib.name = Some(Symbol::intern(new_name));
-                        changed = true;
-                    }
-                    if !changed {
-                        let msg = format!("redundant linker flag specified for \
-                                           library `{}`", name);
-                        self.tcx.sess.warn(&msg);
-                    }
-
-                    found = true;
                 }
-            }
-            if !found {
+                false
+            }).collect::<Vec<_>>();
+            if existing.is_empty() {
                 // Add if not found
                 let new_name = new_name.as_ref().map(|s| &**s); // &Option<String> -> Option<&str>
                 let lib = NativeLibrary {
@@ -246,6 +243,10 @@ impl<'a, 'tcx> Collector<'a, 'tcx> {
                     wasm_import_module: None,
                 };
                 self.register_native_lib(None, lib);
+            } else {
+                // Move all existing libraries with the same name to the
+                // end of the command line.
+                self.libs.append(&mut existing);
             }
         }
     }

--- a/src/librustc_metadata/native_libs.rs
+++ b/src/librustc_metadata/native_libs.rs
@@ -216,8 +216,8 @@ impl<'a, 'tcx> Collector<'a, 'tcx> {
         // in question.)
         for &(ref name, ref new_name, kind) in &self.tcx.sess.opts.libs {
             // If we've already added any native libraries with the same
-            // name, they will be pulled out into `moved`, so that we can
-            // move them to the end of the list below.
+            // name, they will be pulled out into `existing`, so that we
+            // can move them to the end of the list below.
             let mut existing = self.libs.drain_filter(|lib| {
                 if let Some(lib_name) = lib.name {
                     if lib_name == name as &str {

--- a/src/test/run-make-fulldeps/redundant-libs/Makefile
+++ b/src/test/run-make-fulldeps/redundant-libs/Makefile
@@ -1,5 +1,9 @@
 -include ../tools.mk
 
+ifdef IS_WINDOWS
+all:
+else
+
 # rustc will remove one of the two redundant references to foo below.  Depending
 # on which one gets removed, we'll get a linker error on SOME platforms (like
 # Linux).  On these platforms, when a library is referenced, the linker will
@@ -10,7 +14,6 @@
 # So in this example, we need to ensure that rustc keeps the _later_ reference
 # to foo, and not the former one.
 RUSTC_FLAGS = \
-    -C prefer-dynamic \
     -l static=bar \
     -l foo \
     -l static=baz \
@@ -20,3 +23,5 @@ RUSTC_FLAGS = \
 all: $(call DYLIB,foo) $(call STATICLIB,bar) $(call STATICLIB,baz)
 	$(RUSTC) $(RUSTC_FLAGS) main.rs
 	$(call RUN,main)
+
+endif

--- a/src/test/run-make-fulldeps/redundant-libs/Makefile
+++ b/src/test/run-make-fulldeps/redundant-libs/Makefile
@@ -10,6 +10,7 @@
 # So in this example, we need to ensure that rustc keeps the _later_ reference
 # to foo, and not the former one.
 RUSTC_FLAGS = \
+    -C prefer-dynamic \
     -l static=bar \
     -l foo \
     -l static=baz \

--- a/src/test/run-make-fulldeps/redundant-libs/Makefile
+++ b/src/test/run-make-fulldeps/redundant-libs/Makefile
@@ -1,4 +1,14 @@
 -include ../tools.mk
+
+# rustc will remove one of the two redundant references to foo below.  Depending
+# on which one gets removed, we'll get a linker error on SOME platforms (like
+# Linux).  On these platforms, when a library is referenced, the linker will
+# only pull in the symbols needed _at that point in time_.  If a later library
+# depends on additional symbols from the library, they will not have been pulled
+# in, and you'll get undefined symbols errors.
+#
+# So in this example, we need to ensure that rustc keeps the _later_ reference
+# to foo, and not the former one.
 RUSTC_FLAGS = \
     -l static=bar \
     -l foo \

--- a/src/test/run-make-fulldeps/redundant-libs/Makefile
+++ b/src/test/run-make-fulldeps/redundant-libs/Makefile
@@ -1,0 +1,11 @@
+-include ../tools.mk
+RUSTC_FLAGS = \
+    -l static=bar \
+    -l foo \
+    -l static=baz \
+    -l foo \
+    -Z print-link-args
+
+all: $(call DYLIB,foo) $(call STATICLIB,bar) $(call STATICLIB,baz)
+	$(RUSTC) $(RUSTC_FLAGS) main.rs
+	$(call RUN,main)

--- a/src/test/run-make-fulldeps/redundant-libs/bar.c
+++ b/src/test/run-make-fulldeps/redundant-libs/bar.c
@@ -1,0 +1,12 @@
+// Copyright 2019 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+void bar() {
+}

--- a/src/test/run-make-fulldeps/redundant-libs/bar.c
+++ b/src/test/run-make-fulldeps/redundant-libs/bar.c
@@ -1,12 +1,1 @@
-// Copyright 2019 The Rust Project Developers. See the COPYRIGHT
-// file at the top-level directory of this distribution and at
-// http://rust-lang.org/COPYRIGHT.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
-void bar() {
-}
+void bar() {}

--- a/src/test/run-make-fulldeps/redundant-libs/baz.c
+++ b/src/test/run-make-fulldeps/redundant-libs/baz.c
@@ -1,0 +1,17 @@
+// Copyright 2019 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern void foo1();
+extern void foo2();
+
+void baz() {
+  foo1();
+  foo2();
+}

--- a/src/test/run-make-fulldeps/redundant-libs/baz.c
+++ b/src/test/run-make-fulldeps/redundant-libs/baz.c
@@ -1,13 +1,3 @@
-// Copyright 2019 The Rust Project Developers. See the COPYRIGHT
-// file at the top-level directory of this distribution and at
-// http://rust-lang.org/COPYRIGHT.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 extern void foo1();
 extern void foo2();
 

--- a/src/test/run-make-fulldeps/redundant-libs/foo.c
+++ b/src/test/run-make-fulldeps/redundant-libs/foo.c
@@ -1,0 +1,12 @@
+// Copyright 2019 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+void foo1() {}
+void foo2() {}

--- a/src/test/run-make-fulldeps/redundant-libs/foo.c
+++ b/src/test/run-make-fulldeps/redundant-libs/foo.c
@@ -1,12 +1,2 @@
-// Copyright 2019 The Rust Project Developers. See the COPYRIGHT
-// file at the top-level directory of this distribution and at
-// http://rust-lang.org/COPYRIGHT.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 void foo1() {}
 void foo2() {}

--- a/src/test/run-make-fulldeps/redundant-libs/main.rs
+++ b/src/test/run-make-fulldeps/redundant-libs/main.rs
@@ -1,0 +1,30 @@
+// Copyright 2019 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// rustc will remove one of the two redundant references to foo below.  Depending on which one gets
+// removed, we'll get a linker error on SOME platforms (like Linux).  On these platforms, when a
+// library is referenced, the linker will only pull in the symbols needed _at that point in time_.
+// If a later library depends on additional symbols from the library, they will not have been
+// pulled in, and you'll get undefined symbols errors.
+//
+// So in this example, we need to ensure that rustc keeps the _later_ reference to foo, and not the
+// former one.
+
+extern "C" {
+    fn bar();
+    fn baz();
+}
+
+fn main() {
+    unsafe {
+        bar();
+        baz();
+    }
+}

--- a/src/test/run-make-fulldeps/redundant-libs/main.rs
+++ b/src/test/run-make-fulldeps/redundant-libs/main.rs
@@ -8,15 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// rustc will remove one of the two redundant references to foo below.  Depending on which one gets
-// removed, we'll get a linker error on SOME platforms (like Linux).  On these platforms, when a
-// library is referenced, the linker will only pull in the symbols needed _at that point in time_.
-// If a later library depends on additional symbols from the library, they will not have been
-// pulled in, and you'll get undefined symbols errors.
-//
-// So in this example, we need to ensure that rustc keeps the _later_ reference to foo, and not the
-// former one.
-
 extern "C" {
     fn bar();
     fn baz();

--- a/src/test/run-make-fulldeps/redundant-libs/main.rs
+++ b/src/test/run-make-fulldeps/redundant-libs/main.rs
@@ -1,13 +1,3 @@
-// Copyright 2019 The Rust Project Developers. See the COPYRIGHT
-// file at the top-level directory of this distribution and at
-// http://rust-lang.org/COPYRIGHT.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 extern "C" {
     fn bar();
     fn baz();


### PR DESCRIPTION
When a library (L1) is passed to the linker multiple times, this is sometimes purposeful: there might be several other libraries in the linker command (L2 and L3) that all depend on L1.  You'd end up with a (simplified) linker command that looks like:

```
-l2 -l1 -l3 -l1
```

With the previous behavior, when rustc encountered a redundant library, it would keep the first instance, and remove the later ones, resulting in:

```
-l2 -l1 -l3
```

This can cause a linker error, because on some platforms (e.g. Linux), the linker will only include symbols from L1 that are needed *at the point it's referenced in the command line*.  So if L3 depends on additional symbols from L1, which aren't needed by L2, the linker won't know to include them, and you'll end up with "undefined symbols" errors.

A better behavior is to keep the *last* instance of the library:

```
-l2 -l3 -l1
```

This ensures that all "downstream" libraries have been included in the linker command before the "upstream" library is referenced.

Fixes rust-lang#47989