### PR TITLE
Introduce and use LrcRef in ImplicitCtxt

### DIFF
--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -1890,7 +1890,7 @@ pub mod tls {
     use ty::query;
     use errors::{Diagnostic, TRACK_DIAGNOSTICS};
     use rustc_data_structures::OnDrop;
-    use rustc_data_structures::sync::{self, Lrc, Lock};
+    use rustc_data_structures::sync::{self, Lock, LrcRef};
     use dep_graph::OpenTask;
 
     #[cfg(not(parallel_queries))]
@@ -1912,7 +1912,7 @@ pub mod tls {
 
         /// The current query job, if any. This is updated by start_job in
         /// ty::query::plumbing when executing a query
-        pub query: Option<Lrc<query::QueryJob<'gcx>>>,
+        pub query: Option<LrcRef<'a, query::QueryJob<'gcx>>>,
 
         /// Used to prevent layout from recursing too deeply.
         pub layout_depth: usize,

--- a/src/librustc/ty/query/job.rs
+++ b/src/librustc/ty/query/job.rs
@@ -12,7 +12,7 @@
 
 use std::mem;
 use rustc_data_structures::fx::FxHashSet;
-use rustc_data_structures::sync::{Lock, LockGuard, Lrc, Weak};
+use rustc_data_structures::sync::{Lock, LockGuard, Lrc, LrcRef, Weak};
 use rustc_data_structures::OnDrop;
 use syntax_pos::Span;
 use ty::tls;
@@ -111,7 +111,7 @@ impl<'tcx> QueryJob<'tcx> {
     ) -> Result<(), Box<CycleError<'tcx>>> {
         tls::with_related_context(tcx, move |icx| {
             let mut waiter = Lrc::new(QueryWaiter {
-                query: icx.query.clone(),
+                query: icx.query.map(|q| LrcRef::into(q)),
                 span,
                 cycle: Lock::new(None),
                 condvar: Condvar::new(),
@@ -135,7 +135,9 @@ impl<'tcx> QueryJob<'tcx> {
         span: Span,
     ) -> CycleError<'tcx> {
         // Get the current executing query (waiter) and find the waitee amongst its parents
-        let mut current_job = tls::with_related_context(tcx, |icx| icx.query.clone());
+        let mut current_job = tls::with_related_context(tcx, |icx| {
+            icx.query.map(|q| LrcRef::into(q))
+        });
         let mut cycle = Vec::new();
 
         while let Some(job) = current_job {
@@ -156,7 +158,7 @@ impl<'tcx> QueryJob<'tcx> {
                 return CycleError { usage, cycle };
             }
 
-            current_job = job.parent.clone();
+            current_job = job.parent.as_ref().map(|parent| parent.clone());
         }
 
         panic!("did not find a cycle")

--- a/src/librustc_data_structures/sync.rs
+++ b/src/librustc_data_structures/sync.rs
@@ -39,6 +39,7 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::fmt;
 use std::ops::{Deref, DerefMut};
+use std::mem::ManuallyDrop;
 use owning_ref::{Erased, OwningRef};
 
 pub fn serial_join<A, B, RA, RB>(oper_a: A, oper_b: B) -> (RA, RB)
@@ -755,5 +756,42 @@ impl<T> DerefMut for OneThread<T> {
     fn deref_mut(&mut self) -> &mut T {
         self.check();
         &mut self.inner
+    }
+}
+
+pub struct LrcRef<'a, T: ?Sized>(&'a T);
+
+impl<'a, T: 'a + ?Sized> Clone for LrcRef<'a, T> {
+    fn clone(&self) -> Self {
+        LrcRef(self.0)
+    }
+}
+impl<'a, T: 'a + ?Sized> Copy for LrcRef<'a, T> {}
+
+impl<'a, T: 'a + ?Sized> LrcRef<'a, T> {
+    #[inline]
+    pub fn new(lrc: &Lrc<T>) -> LrcRef<'_, T> {
+        LrcRef(&*lrc)
+    }
+
+    #[inline]
+    pub fn into(self) -> Lrc<T> {
+        unsafe {
+            // We know that we have a reference to an Lrc here.
+            // Pretend to take ownership of the Lrc with from_raw
+            // and the clone a new one.
+            // We use ManuallyDrop to ensure the reference count
+            // isn't decreased
+            let lrc = ManuallyDrop::new(Lrc::from_raw(self.0));
+            (*lrc).clone()
+        }
+    }
+}
+
+impl<'a, T: ?Sized> Deref for LrcRef<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        self.0
     }
 }


### PR DESCRIPTION
`LrcRef` is basically just `&Lrc` without the double indirection, but still retains the ability to clone the `Lrc`.

r? @michaelwoerister