### PR TITLE
Update migrate warning wording.

### DIFF
--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -373,10 +373,14 @@ fn do_mir_borrowck<'a, 'gcx, 'tcx>(
                     for err in &mut mbcx.errors_buffer {
                         if err.is_error() {
                             err.level = Level::Warning;
-                            err.warn("This error has been downgraded to a warning \
-                                      for backwards compatibility with previous releases.\n\
-                                      It represents potential unsoundness in your code.\n\
-                                      This warning will become a hard error in the future.");
+                            err.warn(
+                                "this error has been downgraded to a warning for backwards \
+                                 compatibility with previous releases",
+                            );
+                            err.warn(
+                                "this represents potential undefined behavior in your code and \
+                                 this warning will become a hard error in the future",
+                            );
                         }
                     }
                 }

--- a/src/test/ui/borrowck/borrowck-anon-fields-variant.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-anon-fields-variant.nll.stderr
@@ -10,9 +10,8 @@ LL |       Foo::Y(_, ref mut b) => b,
 LL |     *a += 1;
    |     ------- borrow later used here
    |
-   = warning: This error has been downgraded to a warning for backwards compatibility with previous releases.
-           It represents potential unsoundness in your code.
-           This warning will become a hard error in the future.
+   = warning: this error has been downgraded to a warning for backwards compatibility with previous releases
+   = warning: this represents potential undefined behavior in your code and this warning will become a hard error in the future
 
 error[E0503]: cannot use `y` because it was mutably borrowed
   --> $DIR/borrowck-anon-fields-variant.rs:44:7

--- a/src/test/ui/borrowck/borrowck-describe-lvalue.ast.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-describe-lvalue.ast.nll.stderr
@@ -350,9 +350,8 @@ LL |             let p: &'a u8 = &*block.current;
 LL |             drop(x);
    |                  - mutable borrow later used here
    |
-   = warning: This error has been downgraded to a warning for backwards compatibility with previous releases.
-           It represents potential unsoundness in your code.
-           This warning will become a hard error in the future.
+   = warning: this error has been downgraded to a warning for backwards compatibility with previous releases
+   = warning: this represents potential undefined behavior in your code and this warning will become a hard error in the future
 
 warning[E0502]: cannot borrow `*block.current` as immutable because it is also borrowed as mutable
   --> $DIR/borrowck-describe-lvalue.rs:260:33
@@ -365,9 +364,8 @@ LL |             let p : *const u8 = &*(*block).current;
 LL |             drop(x);
    |                  - mutable borrow later used here
    |
-   = warning: This error has been downgraded to a warning for backwards compatibility with previous releases.
-           It represents potential unsoundness in your code.
-           This warning will become a hard error in the future.
+   = warning: this error has been downgraded to a warning for backwards compatibility with previous releases
+   = warning: this represents potential undefined behavior in your code and this warning will become a hard error in the future
 
 error[E0382]: use of moved value: `x`
   --> $DIR/borrowck-describe-lvalue.rs:318:22

--- a/src/test/ui/borrowck/borrowck-migrate-to-nll.edition.stderr
+++ b/src/test/ui/borrowck/borrowck-migrate-to-nll.edition.stderr
@@ -4,7 +4,6 @@ warning[E0507]: cannot move out of borrowed content
 LL |                 (|| { let bar = foo; bar.take() })();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot move out of borrowed content
    |
-   = warning: This error has been downgraded to a warning for backwards compatibility with previous releases.
-           It represents potential unsoundness in your code.
-           This warning will become a hard error in the future.
+   = warning: this error has been downgraded to a warning for backwards compatibility with previous releases
+   = warning: this represents potential undefined behavior in your code and this warning will become a hard error in the future
 

--- a/src/test/ui/borrowck/borrowck-migrate-to-nll.zflag.stderr
+++ b/src/test/ui/borrowck/borrowck-migrate-to-nll.zflag.stderr
@@ -4,7 +4,6 @@ warning[E0507]: cannot move out of borrowed content
 LL |                 (|| { let bar = foo; bar.take() })();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot move out of borrowed content
    |
-   = warning: This error has been downgraded to a warning for backwards compatibility with previous releases.
-           It represents potential unsoundness in your code.
-           This warning will become a hard error in the future.
+   = warning: this error has been downgraded to a warning for backwards compatibility with previous releases
+   = warning: this represents potential undefined behavior in your code and this warning will become a hard error in the future
 

--- a/src/test/ui/consts/min_const_fn/min_const_fn.nll.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn.nll.stderr
@@ -199,9 +199,8 @@ LL | const fn no_dyn_trait_ret() -> &'static dyn std::fmt::Debug { &() }
    |                                                               |temporary value created here
    |                                                               returns a reference to data owned by the current function
    |
-   = warning: This error has been downgraded to a warning for backwards compatibility with previous releases.
-           It represents potential unsoundness in your code.
-           This warning will become a hard error in the future.
+   = warning: this error has been downgraded to a warning for backwards compatibility with previous releases
+   = warning: this represents potential undefined behavior in your code and this warning will become a hard error in the future
 
 error: trait bounds other than `Sized` on const fn parameters are unstable
   --> $DIR/min_const_fn.rs:147:41

--- a/src/test/ui/consts/min_const_fn/min_const_fn_dyn.nll.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn_dyn.nll.stderr
@@ -19,9 +19,8 @@ LL | const fn no_inner_dyn_trait_ret() -> Hide { Hide(HasDyn { field: &0 }) }
    |                                                                  |creates a temporary which is freed while still in use
    |                                                                  cast requires that borrow lasts for `'static`
    |
-   = warning: This error has been downgraded to a warning for backwards compatibility with previous releases.
-           It represents potential unsoundness in your code.
-           This warning will become a hard error in the future.
+   = warning: this error has been downgraded to a warning for backwards compatibility with previous releases
+   = warning: this represents potential undefined behavior in your code and this warning will become a hard error in the future
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-40510-1.nll.stderr
+++ b/src/test/ui/issues/issue-40510-1.nll.stderr
@@ -8,7 +8,6 @@ LL |         &mut x
    |
    = note: `FnMut` closures only have access to their captured variables while they are executing...
    = note: ...therefore, they cannot allow references to captured variables to escape
-   = warning: This error has been downgraded to a warning for backwards compatibility with previous releases.
-           It represents potential unsoundness in your code.
-           This warning will become a hard error in the future.
+   = warning: this error has been downgraded to a warning for backwards compatibility with previous releases
+   = warning: this represents potential undefined behavior in your code and this warning will become a hard error in the future
 

--- a/src/test/ui/issues/issue-40510-3.nll.stderr
+++ b/src/test/ui/issues/issue-40510-3.nll.stderr
@@ -10,7 +10,6 @@ LL | |         }
    |
    = note: `FnMut` closures only have access to their captured variables while they are executing...
    = note: ...therefore, they cannot allow references to captured variables to escape
-   = warning: This error has been downgraded to a warning for backwards compatibility with previous releases.
-           It represents potential unsoundness in your code.
-           This warning will become a hard error in the future.
+   = warning: this error has been downgraded to a warning for backwards compatibility with previous releases
+   = warning: this represents potential undefined behavior in your code and this warning will become a hard error in the future
 

--- a/src/test/ui/issues/issue-45696-scribble-on-boxed-borrow.ast.stderr
+++ b/src/test/ui/issues/issue-45696-scribble-on-boxed-borrow.ast.stderr
@@ -1,5 +1,5 @@
 error: compilation successful
-  --> $DIR/issue-45696-scribble-on-boxed-borrow.rs:89:1
+  --> $DIR/issue-45696-scribble-on-boxed-borrow.rs:92:1
    |
 LL | / fn main() { //[ast]~ ERROR compilation successful
 LL | |      //[migrate]~^ ERROR compilation successful

--- a/src/test/ui/issues/issue-45696-scribble-on-boxed-borrow.migrate.stderr
+++ b/src/test/ui/issues/issue-45696-scribble-on-boxed-borrow.migrate.stderr
@@ -9,12 +9,11 @@ LL |     &mut *s.0 //[nll]~ ERROR borrow may still be in use when destructor run
 LL | }
    | - here, drop of `s` needs exclusive access to `*s.0`, because the type `Scribble<'_>` implements the `Drop` trait
    |
-   = warning: This error has been downgraded to a warning for backwards compatibility with previous releases.
-           It represents potential unsoundness in your code.
-           This warning will become a hard error in the future.
+   = warning: this error has been downgraded to a warning for backwards compatibility with previous releases
+   = warning: this represents potential undefined behavior in your code and this warning will become a hard error in the future
 
 warning[E0713]: borrow may still be in use when destructor runs
-  --> $DIR/issue-45696-scribble-on-boxed-borrow.rs:73:5
+  --> $DIR/issue-45696-scribble-on-boxed-borrow.rs:74:5
    |
 LL | fn boxed_scribbled<'a>(s: Box<Scribble<'a>>) -> &'a mut u32 {
    |                    -- lifetime `'a` defined here
@@ -24,12 +23,11 @@ LL |     &mut *(*s).0 //[nll]~ ERROR borrow may still be in use when destructor 
 LL | }
    | - here, drop of `s` needs exclusive access to `*s.0`, because the type `Scribble<'_>` implements the `Drop` trait
    |
-   = warning: This error has been downgraded to a warning for backwards compatibility with previous releases.
-           It represents potential unsoundness in your code.
-           This warning will become a hard error in the future.
+   = warning: this error has been downgraded to a warning for backwards compatibility with previous releases
+   = warning: this represents potential undefined behavior in your code and this warning will become a hard error in the future
 
 warning[E0713]: borrow may still be in use when destructor runs
-  --> $DIR/issue-45696-scribble-on-boxed-borrow.rs:83:5
+  --> $DIR/issue-45696-scribble-on-boxed-borrow.rs:85:5
    |
 LL | fn boxed_boxed_scribbled<'a>(s: Box<Box<Scribble<'a>>>) -> &'a mut u32 {
    |                          -- lifetime `'a` defined here
@@ -39,12 +37,11 @@ LL |     &mut *(**s).0 //[nll]~ ERROR borrow may still be in use when destructor
 LL | }
    | - here, drop of `s` needs exclusive access to `*s.0`, because the type `Scribble<'_>` implements the `Drop` trait
    |
-   = warning: This error has been downgraded to a warning for backwards compatibility with previous releases.
-           It represents potential unsoundness in your code.
-           This warning will become a hard error in the future.
+   = warning: this error has been downgraded to a warning for backwards compatibility with previous releases
+   = warning: this represents potential undefined behavior in your code and this warning will become a hard error in the future
 
 error: compilation successful
-  --> $DIR/issue-45696-scribble-on-boxed-borrow.rs:89:1
+  --> $DIR/issue-45696-scribble-on-boxed-borrow.rs:92:1
    |
 LL | / fn main() { //[ast]~ ERROR compilation successful
 LL | |      //[migrate]~^ ERROR compilation successful

--- a/src/test/ui/issues/issue-45696-scribble-on-boxed-borrow.nll.stderr
+++ b/src/test/ui/issues/issue-45696-scribble-on-boxed-borrow.nll.stderr
@@ -10,7 +10,7 @@ LL | }
    | - here, drop of `s` needs exclusive access to `*s.0`, because the type `Scribble<'_>` implements the `Drop` trait
 
 error[E0713]: borrow may still be in use when destructor runs
-  --> $DIR/issue-45696-scribble-on-boxed-borrow.rs:73:5
+  --> $DIR/issue-45696-scribble-on-boxed-borrow.rs:74:5
    |
 LL | fn boxed_scribbled<'a>(s: Box<Scribble<'a>>) -> &'a mut u32 {
    |                    -- lifetime `'a` defined here
@@ -21,7 +21,7 @@ LL | }
    | - here, drop of `s` needs exclusive access to `*s.0`, because the type `Scribble<'_>` implements the `Drop` trait
 
 error[E0713]: borrow may still be in use when destructor runs
-  --> $DIR/issue-45696-scribble-on-boxed-borrow.rs:83:5
+  --> $DIR/issue-45696-scribble-on-boxed-borrow.rs:85:5
    |
 LL | fn boxed_boxed_scribbled<'a>(s: Box<Box<Scribble<'a>>>) -> &'a mut u32 {
    |                          -- lifetime `'a` defined here

--- a/src/test/ui/issues/issue-45696-scribble-on-boxed-borrow.rs
+++ b/src/test/ui/issues/issue-45696-scribble-on-boxed-borrow.rs
@@ -62,7 +62,8 @@ fn boxed_boxed_borrowed_scribble<'a>(s: Box<Box<&'a mut Scribble>>) -> &'a mut u
 fn scribbled<'a>(s: Scribble<'a>) -> &'a mut u32 {
     &mut *s.0 //[nll]~ ERROR borrow may still be in use when destructor runs [E0713]
     //[migrate]~^ WARNING borrow may still be in use when destructor runs [E0713]
-    //[migrate]~| WARNING This error has been downgraded to a warning for backwards compatibility
+    //[migrate]~| WARNING this error has been downgraded to a warning for backwards compatibility
+    //[migrate]~| WARNING this represents potential undefined behavior in your code
 }
 
 // This, by analogy to previous case, is *also* not okay.
@@ -72,7 +73,8 @@ fn scribbled<'a>(s: Scribble<'a>) -> &'a mut u32 {
 fn boxed_scribbled<'a>(s: Box<Scribble<'a>>) -> &'a mut u32 {
     &mut *(*s).0 //[nll]~ ERROR borrow may still be in use when destructor runs [E0713]
     //[migrate]~^ WARNING borrow may still be in use when destructor runs [E0713]
-    //[migrate]~| WARNING This error has been downgraded to a warning for backwards compatibility
+    //[migrate]~| WARNING this error has been downgraded to a warning for backwards compatibility
+    //[migrate]~| WARNING this represents potential undefined behavior in your code
 }
 
 // This, by analogy to previous case, is *also* not okay.
@@ -82,7 +84,8 @@ fn boxed_scribbled<'a>(s: Box<Scribble<'a>>) -> &'a mut u32 {
 fn boxed_boxed_scribbled<'a>(s: Box<Box<Scribble<'a>>>) -> &'a mut u32 {
     &mut *(**s).0 //[nll]~ ERROR borrow may still be in use when destructor runs [E0713]
     //[migrate]~^ WARNING borrow may still be in use when destructor runs [E0713]
-    //[migrate]~| WARNING This error has been downgraded to a warning for backwards compatibility
+    //[migrate]~| WARNING this error has been downgraded to a warning for backwards compatibility
+    //[migrate]~| WARNING this represents potential undefined behavior in your code
 }
 
 #[rustc_error]

--- a/src/test/ui/issues/issue-49824.nll.stderr
+++ b/src/test/ui/issues/issue-49824.nll.stderr
@@ -10,9 +10,8 @@ LL | |         }
    |
    = note: `FnMut` closures only have access to their captured variables while they are executing...
    = note: ...therefore, they cannot allow references to captured variables to escape
-   = warning: This error has been downgraded to a warning for backwards compatibility with previous releases.
-           It represents potential unsoundness in your code.
-           This warning will become a hard error in the future.
+   = warning: this error has been downgraded to a warning for backwards compatibility with previous releases
+   = warning: this represents potential undefined behavior in your code and this warning will become a hard error in the future
 
 error: compilation successful
   --> $DIR/issue-49824.rs:18:1

--- a/src/test/ui/nll/match-guards-always-borrow.ast.nll.stderr
+++ b/src/test/ui/nll/match-guards-always-borrow.ast.nll.stderr
@@ -4,9 +4,8 @@ warning[E0507]: cannot move out of borrowed content
 LL |             (|| { let bar = foo; bar.take() })();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot move out of borrowed content
    |
-   = warning: This error has been downgraded to a warning for backwards compatibility with previous releases.
-           It represents potential unsoundness in your code.
-           This warning will become a hard error in the future.
+   = warning: this error has been downgraded to a warning for backwards compatibility with previous releases
+   = warning: this represents potential undefined behavior in your code and this warning will become a hard error in the future
 
 error: compilation successful
   --> $DIR/match-guards-always-borrow.rs:57:1

--- a/src/test/ui/thread-local-in-ctfe.nll.stderr
+++ b/src/test/ui/thread-local-in-ctfe.nll.stderr
@@ -18,9 +18,8 @@ LL | static C: &u32 = &A;
    |                  |
    |                  thread-local variables cannot be borrowed beyond the end of the function
    |
-   = warning: This error has been downgraded to a warning for backwards compatibility with previous releases.
-           It represents potential unsoundness in your code.
-           This warning will become a hard error in the future.
+   = warning: this error has been downgraded to a warning for backwards compatibility with previous releases
+   = warning: this represents potential undefined behavior in your code and this warning will become a hard error in the future
 
 error[E0625]: thread-local statics cannot be accessed at compile-time
   --> $DIR/thread-local-in-ctfe.rs:22:16
@@ -42,9 +41,8 @@ LL | const E: &u32 = &A;
    |                 |
    |                 thread-local variables cannot be borrowed beyond the end of the function
    |
-   = warning: This error has been downgraded to a warning for backwards compatibility with previous releases.
-           It represents potential unsoundness in your code.
-           This warning will become a hard error in the future.
+   = warning: this error has been downgraded to a warning for backwards compatibility with previous releases
+   = warning: this represents potential undefined behavior in your code and this warning will become a hard error in the future
 
 error[E0625]: thread-local statics cannot be accessed at compile-time
   --> $DIR/thread-local-in-ctfe.rs:29:5


### PR DESCRIPTION
This PR modifies the wording of the warning for backwards-incompatible changes in migrate mode. The warning messages are changed to be lowercase and not include line-breaks in order to be consistent with other compiler diagnostics.

r? @pnkfelix 