### PR TITLE
Fix feature gate to point to 1.32.0 for `path_from_str`

### DIFF
--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -1461,7 +1461,7 @@ impl From<String> for PathBuf {
     }
 }
 
-#[stable(feature = "path_from_str", since = "1.26.0")]
+#[stable(feature = "path_from_str", since = "1.32.0")]
 impl FromStr for PathBuf {
     type Err = ParseError;
 


### PR DESCRIPTION
When the feature has been added back (#55148) the feature gate has not
been adjusted accordingly. We have it enabled for 1.32.0, currently in
Beta, so adjust it.

Refs: #44431.

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>