### PR TITLE
Don't call `FieldPlacement::count` when count is too large

### DIFF
--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -1852,7 +1852,11 @@ impl<'a, 'tcx> LayoutCx<'tcx, TyCtxt<'a, 'tcx, 'tcx>> {
                 return Ok(None);
             }
         }
-        if let FieldPlacement::Array { .. } = layout.fields {
+        if let FieldPlacement::Array { count: original_64_bit_count, .. } = layout.fields {
+            // rust-lang/rust#57038: avoid ICE within FieldPlacement::count when count too big
+            if original_64_bit_count > usize::max_value() as u64 {
+                return Err(LayoutError::SizeOverflow(layout.ty));
+            }
             if layout.fields.count() > 0 {
                 return self.find_niche(layout.field(self, 0)?);
             } else {


### PR DESCRIPTION
Sidestep ICE in `FieldPlacement::count` by not calling it when count will not fit in host's usize.

(I briefly played with trying to fix this by changing `FieldPlacement::count` to return a `u64`. However, based on how `FieldPlacement` is used, it seems like this would be a largely pointless pursuit... I'm open to counter-arguments, however.)

Fix #57038 