### PR TITLE
Add specific diagnostic when attempting to transmute between equal generic types

### DIFF
--- a/src/librustc/diagnostics.rs
+++ b/src/librustc/diagnostics.rs
@@ -1552,7 +1552,8 @@ fn takes_u8(_: u8) {}
 
 fn main() {
     unsafe { takes_u8(::std::mem::transmute(0u16)); }
-    // error: transmute called with types of different sizes
+    // error: cannot transmute between types of different sizes,
+    //        or dependently-sized types
 }
 ```
 

--- a/src/librustc/middle/intrinsicck.rs
+++ b/src/librustc/middle/intrinsicck.rs
@@ -97,11 +97,11 @@ impl<'a, 'tcx> ExprVisitor<'a, 'tcx> {
                     format!("{} bits", size.bits())
                 }
                 Ok(SizeSkeleton::Pointer { tail, .. }) => {
-                    format!("pointer to {}", tail)
+                    format!("pointer to `{}`", tail)
                 }
                 Err(LayoutError::Unknown(bad)) => {
                     if bad == ty {
-                        "this type's size can vary".to_owned()
+                        "this type does not have a fixed size".to_owned()
                     } else {
                         format!("size can vary because of {}", bad)
                     }
@@ -110,11 +110,12 @@ impl<'a, 'tcx> ExprVisitor<'a, 'tcx> {
             }
         };
 
-        struct_span_err!(self.tcx.sess, span, E0512,
-                         "transmute called with types of different sizes")
-            .note(&format!("source type: {} ({})", from, skeleton_string(from, sk_from)))
-            .note(&format!("target type: {} ({})", to, skeleton_string(to, sk_to)))
-            .emit();
+        let mut err = struct_span_err!(self.tcx.sess, span, E0512,
+                                       "cannot transmute between types of different sizes, \
+                                        or dependently-sized types");
+            err.note(&format!("source type: `{}` ({})", from, skeleton_string(from, sk_from)))
+                .note(&format!("target type: `{}` ({})", to, skeleton_string(to, sk_to)));
+        err.emit()
     }
 }
 

--- a/src/librustc/middle/intrinsicck.rs
+++ b/src/librustc/middle/intrinsicck.rs
@@ -113,8 +113,12 @@ impl<'a, 'tcx> ExprVisitor<'a, 'tcx> {
         let mut err = struct_span_err!(self.tcx.sess, span, E0512,
                                        "cannot transmute between types of different sizes, \
                                         or dependently-sized types");
+        if from == to {
+            err.note(&format!("`{}` does not have a fixed size", from));
+        } else {
             err.note(&format!("source type: `{}` ({})", from, skeleton_string(from, sk_from)))
                 .note(&format!("target type: `{}` ({})", to, skeleton_string(to, sk_to)));
+        }
         err.emit()
     }
 }

--- a/src/test/ui/error-codes/E0512.stderr
+++ b/src/test/ui/error-codes/E0512.stderr
@@ -1,11 +1,11 @@
-error[E0512]: transmute called with types of different sizes
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> $DIR/E0512.rs:4:23
    |
 LL |     unsafe { takes_u8(::std::mem::transmute(0u16)); } //~ ERROR E0512
    |                       ^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: source type: u16 (16 bits)
-   = note: target type: u8 (8 bits)
+   = note: source type: `u16` (16 bits)
+   = note: target type: `u8` (8 bits)
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-21174.rs
+++ b/src/test/ui/issues/issue-21174.rs
@@ -5,7 +5,7 @@ trait Trait<'a> {
 
 fn foo<'a, T: Trait<'a>>(value: T::A) {
     let new: T::B = unsafe { std::mem::transmute(value) };
-//~^ ERROR: transmute called with types of different sizes
+//~^ ERROR: cannot transmute between types of different sizes, or dependently-sized types
 }
 
 fn main() { }

--- a/src/test/ui/issues/issue-21174.stderr
+++ b/src/test/ui/issues/issue-21174.stderr
@@ -1,11 +1,11 @@
-error[E0512]: transmute called with types of different sizes
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> $DIR/issue-21174.rs:7:30
    |
 LL |     let new: T::B = unsafe { std::mem::transmute(value) };
    |                              ^^^^^^^^^^^^^^^^^^^
    |
-   = note: source type: <T as Trait<'a>>::A (size can vary because of <T as Trait>::A)
-   = note: target type: <T as Trait<'a>>::B (size can vary because of <T as Trait>::B)
+   = note: source type: `<T as Trait<'a>>::A` (size can vary because of <T as Trait>::A)
+   = note: target type: `<T as Trait<'a>>::B` (size can vary because of <T as Trait>::B)
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-28625.rs
+++ b/src/test/ui/issues/issue-28625.rs
@@ -9,7 +9,7 @@ struct ArrayPeano<T: Bar> {
 }
 
 fn foo<T>(a: &ArrayPeano<T>) -> &[T] where T: Bar {
-    unsafe { std::mem::transmute(a) } //~ ERROR transmute called with types of different sizes
+    unsafe { std::mem::transmute(a) } //~ ERROR cannot transmute between types of different sizes
 }
 
 impl Bar for () {

--- a/src/test/ui/issues/issue-28625.stderr
+++ b/src/test/ui/issues/issue-28625.stderr
@@ -1,11 +1,11 @@
-error[E0512]: transmute called with types of different sizes
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> $DIR/issue-28625.rs:12:14
    |
-LL |     unsafe { std::mem::transmute(a) } //~ ERROR transmute called with types of different sizes
+LL |     unsafe { std::mem::transmute(a) } //~ ERROR cannot transmute between types of different sizes
    |              ^^^^^^^^^^^^^^^^^^^
    |
-   = note: source type: &ArrayPeano<T> (N bits)
-   = note: target type: &[T] (N bits)
+   = note: source type: `&ArrayPeano<T>` (N bits)
+   = note: target type: `&[T]` (N bits)
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-32377.rs
+++ b/src/test/ui/issues/issue-32377.rs
@@ -13,7 +13,7 @@ struct Bar<U: Foo> {
 
 fn foo<U: Foo>(x: [usize; 2]) -> Bar<U> {
     unsafe { mem::transmute(x) }
-    //~^ ERROR transmute called with types of different sizes
+    //~^ ERROR cannot transmute between types of different sizes, or dependently-sized types
 }
 
 fn main() {}

--- a/src/test/ui/issues/issue-32377.stderr
+++ b/src/test/ui/issues/issue-32377.stderr
@@ -1,11 +1,11 @@
-error[E0512]: transmute called with types of different sizes
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> $DIR/issue-32377.rs:15:14
    |
 LL |     unsafe { mem::transmute(x) }
    |              ^^^^^^^^^^^^^^
    |
-   = note: source type: [usize; 2] (N bits)
-   = note: target type: Bar<U> (N bits)
+   = note: source type: `[usize; 2]` (N bits)
+   = note: target type: `Bar<U>` (N bits)
 
 error: aborting due to previous error
 

--- a/src/test/ui/packed-struct/packed-struct-generic-transmute.rs
+++ b/src/test/ui/packed-struct/packed-struct-generic-transmute.rs
@@ -3,7 +3,7 @@
 // the error points to the start of the file, not the line with the
 // transmute
 
-// error-pattern: transmute called with types of different sizes
+// error-pattern: cannot transmute between types of different sizes, or dependently-sized types
 
 use std::mem;
 

--- a/src/test/ui/packed-struct/packed-struct-generic-transmute.stderr
+++ b/src/test/ui/packed-struct/packed-struct-generic-transmute.stderr
@@ -1,11 +1,11 @@
-error[E0512]: transmute called with types of different sizes
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> $DIR/packed-struct-generic-transmute.rs:24:38
    |
 LL |         let oof: Oof<[u8; 5], i32> = mem::transmute(foo);
    |                                      ^^^^^^^^^^^^^^
    |
-   = note: source type: Foo<[u8; 5], i32> (72 bits)
-   = note: target type: Oof<[u8; 5], i32> (96 bits)
+   = note: source type: `Foo<[u8; 5], i32>` (72 bits)
+   = note: target type: `Oof<[u8; 5], i32>` (96 bits)
 
 error: aborting due to previous error
 

--- a/src/test/ui/packed-struct/packed-struct-transmute.rs
+++ b/src/test/ui/packed-struct/packed-struct-transmute.rs
@@ -4,7 +4,7 @@
 // transmute
 
 // normalize-stderr-test "\d+ bits" -> "N bits"
-// error-pattern: transmute called with types of different sizes
+// error-pattern: cannot transmute between types of different sizes, or dependently-sized types
 
 use std::mem;
 

--- a/src/test/ui/packed-struct/packed-struct-transmute.stderr
+++ b/src/test/ui/packed-struct/packed-struct-transmute.stderr
@@ -1,11 +1,11 @@
-error[E0512]: transmute called with types of different sizes
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> $DIR/packed-struct-transmute.rs:26:24
    |
 LL |         let oof: Oof = mem::transmute(foo);
    |                        ^^^^^^^^^^^^^^
    |
-   = note: source type: Foo (N bits)
-   = note: target type: Oof (N bits)
+   = note: source type: `Foo` (N bits)
+   = note: target type: `Oof` (N bits)
 
 error: aborting due to previous error
 

--- a/src/test/ui/transmute-equal-assoc-types.rs
+++ b/src/test/ui/transmute-equal-assoc-types.rs
@@ -1,0 +1,9 @@
+trait Foo {
+    type Bar;
+}
+
+unsafe fn noop<F: Foo>(foo: F::Bar) -> F::Bar {
+    ::std::mem::transmute(foo) //~ ERROR cannot transmute between types of different sizes
+}
+
+fn main() {}

--- a/src/test/ui/transmute-equal-assoc-types.stderr
+++ b/src/test/ui/transmute-equal-assoc-types.stderr
@@ -1,0 +1,11 @@
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> $DIR/transmute-equal-assoc-types.rs:6:5
+   |
+LL |     ::std::mem::transmute(foo) //~ ERROR cannot transmute between types of different sizes
+   |     ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `<F as Foo>::Bar` does not have a fixed size
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0512`.

--- a/src/test/ui/transmute/main.rs
+++ b/src/test/ui/transmute/main.rs
@@ -13,20 +13,20 @@ pub trait TypeConstructor<'a> {
 unsafe fn transmute_lifetime<'a, 'b, C>(x: <C as TypeConstructor<'a>>::T)
                                         -> <C as TypeConstructor<'b>>::T
 where for<'z> C: TypeConstructor<'z> {
-    transmute(x) //~ ERROR transmute called with types of different sizes
+    transmute(x) //~ ERROR cannot transmute between types of different sizes
 }
 
 unsafe fn sizes() {
-    let x: u8 = transmute(10u16); //~ ERROR transmute called with types of different sizes
+    let x: u8 = transmute(10u16); //~ ERROR cannot transmute between types of different sizes
 }
 
 unsafe fn ptrs() {
-    let x: u8 = transmute("test"); //~ ERROR transmute called with types of different sizes
+    let x: u8 = transmute("test"); //~ ERROR cannot transmute between types of different sizes
 }
 
 union Foo { x: () }
 unsafe fn vary() {
-    let x: Foo = transmute(10); //~ ERROR transmute called with types of different sizes
+    let x: Foo = transmute(10); //~ ERROR cannot transmute between types of different sizes
 }
 
 fn main() {}

--- a/src/test/ui/transmute/main.rs
+++ b/src/test/ui/transmute/main.rs
@@ -1,5 +1,5 @@
-// normalize-stderr-32bit: "&str \(64 bits\)" -> "&str ($$STR bits)"
-// normalize-stderr-64bit: "&str \(128 bits\)" -> "&str ($$STR bits)"
+// normalize-stderr-32bit: "`&str` \(64 bits\)" -> "`&str` ($$STR bits)"
+// normalize-stderr-64bit: "`&str` \(128 bits\)" -> "`&str` ($$STR bits)"
 
 
 

--- a/src/test/ui/transmute/main.stderr
+++ b/src/test/ui/transmute/main.stderr
@@ -22,7 +22,7 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
 LL |     let x: u8 = transmute("test"); //~ ERROR cannot transmute between types of different sizes
    |                 ^^^^^^^^^
    |
-   = note: source type: `&str` (128 bits)
+   = note: source type: `&str` ($STR bits)
    = note: target type: `u8` (8 bits)
 
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types

--- a/src/test/ui/transmute/main.stderr
+++ b/src/test/ui/transmute/main.stderr
@@ -1,38 +1,38 @@
-error[E0512]: transmute called with types of different sizes
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> $DIR/main.rs:16:5
    |
-LL |     transmute(x) //~ ERROR transmute called with types of different sizes
+LL |     transmute(x) //~ ERROR cannot transmute between types of different sizes
    |     ^^^^^^^^^
    |
-   = note: source type: <C as TypeConstructor<'a>>::T (size can vary because of <C as TypeConstructor>::T)
-   = note: target type: <C as TypeConstructor<'b>>::T (size can vary because of <C as TypeConstructor>::T)
+   = note: source type: `<C as TypeConstructor<'a>>::T` (size can vary because of <C as TypeConstructor>::T)
+   = note: target type: `<C as TypeConstructor<'b>>::T` (size can vary because of <C as TypeConstructor>::T)
 
-error[E0512]: transmute called with types of different sizes
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> $DIR/main.rs:20:17
    |
-LL |     let x: u8 = transmute(10u16); //~ ERROR transmute called with types of different sizes
+LL |     let x: u8 = transmute(10u16); //~ ERROR cannot transmute between types of different sizes
    |                 ^^^^^^^^^
    |
-   = note: source type: u16 (16 bits)
-   = note: target type: u8 (8 bits)
+   = note: source type: `u16` (16 bits)
+   = note: target type: `u8` (8 bits)
 
-error[E0512]: transmute called with types of different sizes
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> $DIR/main.rs:24:17
    |
-LL |     let x: u8 = transmute("test"); //~ ERROR transmute called with types of different sizes
+LL |     let x: u8 = transmute("test"); //~ ERROR cannot transmute between types of different sizes
    |                 ^^^^^^^^^
    |
-   = note: source type: &str ($STR bits)
-   = note: target type: u8 (8 bits)
+   = note: source type: `&str` (128 bits)
+   = note: target type: `u8` (8 bits)
 
-error[E0512]: transmute called with types of different sizes
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> $DIR/main.rs:29:18
    |
-LL |     let x: Foo = transmute(10); //~ ERROR transmute called with types of different sizes
+LL |     let x: Foo = transmute(10); //~ ERROR cannot transmute between types of different sizes
    |                  ^^^^^^^^^
    |
-   = note: source type: i32 (32 bits)
-   = note: target type: Foo (0 bits)
+   = note: source type: `i32` (32 bits)
+   = note: target type: `Foo` (0 bits)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/transmute/transmute-different-sizes.rs
+++ b/src/test/ui/transmute/transmute-different-sizes.rs
@@ -9,12 +9,12 @@ use std::mem::transmute;
 
 unsafe fn f() {
     let _: i8 = transmute(16i16);
-    //~^ ERROR transmute called with types of different sizes
+    //~^ ERROR cannot transmute between types of different sizes, or dependently-sized types
 }
 
 unsafe fn g<T>(x: &T) {
     let _: i8 = transmute(x);
-    //~^ ERROR transmute called with types of different sizes
+    //~^ ERROR cannot transmute between types of different sizes, or dependently-sized types
 }
 
 trait Specializable { type Output; }
@@ -25,7 +25,7 @@ impl<T> Specializable for T {
 
 unsafe fn specializable<T>(x: u16) -> <T as Specializable>::Output {
     transmute(x)
-    //~^ ERROR transmute called with types of different sizes
+    //~^ ERROR cannot transmute between types of different sizes, or dependently-sized types
 }
 
 fn main() {}

--- a/src/test/ui/transmute/transmute-different-sizes.stderr
+++ b/src/test/ui/transmute/transmute-different-sizes.stderr
@@ -1,29 +1,29 @@
-error[E0512]: transmute called with types of different sizes
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> $DIR/transmute-different-sizes.rs:11:17
    |
 LL |     let _: i8 = transmute(16i16);
    |                 ^^^^^^^^^
    |
-   = note: source type: i16 (N bits)
-   = note: target type: i8 (N bits)
+   = note: source type: `i16` (N bits)
+   = note: target type: `i8` (N bits)
 
-error[E0512]: transmute called with types of different sizes
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> $DIR/transmute-different-sizes.rs:16:17
    |
 LL |     let _: i8 = transmute(x);
    |                 ^^^^^^^^^
    |
-   = note: source type: &T (N bits)
-   = note: target type: i8 (N bits)
+   = note: source type: `&T` (N bits)
+   = note: target type: `i8` (N bits)
 
-error[E0512]: transmute called with types of different sizes
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> $DIR/transmute-different-sizes.rs:27:5
    |
 LL |     transmute(x)
    |     ^^^^^^^^^
    |
-   = note: source type: u16 (N bits)
-   = note: target type: <T as Specializable>::Output (this type's size can vary)
+   = note: source type: `u16` (N bits)
+   = note: target type: `<T as Specializable>::Output` (this type does not have a fixed size)
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/transmute/transmute-fat-pointers.rs
+++ b/src/test/ui/transmute/transmute-fat-pointers.rs
@@ -7,11 +7,11 @@
 use std::mem::transmute;
 
 fn a<T, U: ?Sized>(x: &[T]) -> &U {
-    unsafe { transmute(x) } //~ ERROR transmute called with types of different sizes
+    unsafe { transmute(x) } //~ ERROR cannot transmute between types of different sizes
 }
 
 fn b<T: ?Sized, U: ?Sized>(x: &T) -> &U {
-    unsafe { transmute(x) } //~ ERROR transmute called with types of different sizes
+    unsafe { transmute(x) } //~ ERROR cannot transmute between types of different sizes
 }
 
 fn c<T, U>(x: &T) -> &U {
@@ -23,11 +23,11 @@ fn d<T, U>(x: &[T]) -> &[U] {
 }
 
 fn e<T: ?Sized, U>(x: &T) -> &U {
-    unsafe { transmute(x) } //~ ERROR transmute called with types of different sizes
+    unsafe { transmute(x) } //~ ERROR cannot transmute between types of different sizes
 }
 
 fn f<T, U: ?Sized>(x: &T) -> &U {
-    unsafe { transmute(x) } //~ ERROR transmute called with types of different sizes
+    unsafe { transmute(x) } //~ ERROR cannot transmute between types of different sizes
 }
 
 fn main() { }

--- a/src/test/ui/transmute/transmute-fat-pointers.stderr
+++ b/src/test/ui/transmute/transmute-fat-pointers.stderr
@@ -1,38 +1,38 @@
-error[E0512]: transmute called with types of different sizes
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> $DIR/transmute-fat-pointers.rs:10:14
    |
-LL |     unsafe { transmute(x) } //~ ERROR transmute called with types of different sizes
+LL |     unsafe { transmute(x) } //~ ERROR cannot transmute between types of different sizes
    |              ^^^^^^^^^
    |
-   = note: source type: &[T] (N bits)
-   = note: target type: &U (pointer to U)
+   = note: source type: `&[T]` (N bits)
+   = note: target type: `&U` (pointer to `U`)
 
-error[E0512]: transmute called with types of different sizes
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> $DIR/transmute-fat-pointers.rs:14:14
    |
-LL |     unsafe { transmute(x) } //~ ERROR transmute called with types of different sizes
+LL |     unsafe { transmute(x) } //~ ERROR cannot transmute between types of different sizes
    |              ^^^^^^^^^
    |
-   = note: source type: &T (pointer to T)
-   = note: target type: &U (pointer to U)
+   = note: source type: `&T` (pointer to `T`)
+   = note: target type: `&U` (pointer to `U`)
 
-error[E0512]: transmute called with types of different sizes
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> $DIR/transmute-fat-pointers.rs:26:14
    |
-LL |     unsafe { transmute(x) } //~ ERROR transmute called with types of different sizes
+LL |     unsafe { transmute(x) } //~ ERROR cannot transmute between types of different sizes
    |              ^^^^^^^^^
    |
-   = note: source type: &T (pointer to T)
-   = note: target type: &U (N bits)
+   = note: source type: `&T` (pointer to `T`)
+   = note: target type: `&U` (N bits)
 
-error[E0512]: transmute called with types of different sizes
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> $DIR/transmute-fat-pointers.rs:30:14
    |
-LL |     unsafe { transmute(x) } //~ ERROR transmute called with types of different sizes
+LL |     unsafe { transmute(x) } //~ ERROR cannot transmute between types of different sizes
    |              ^^^^^^^^^
    |
-   = note: source type: &T (N bits)
-   = note: target type: &U (pointer to U)
+   = note: source type: `&T` (N bits)
+   = note: target type: `&U` (pointer to `U`)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/transmute/transmute-from-fn-item-types-error.rs
+++ b/src/test/ui/transmute/transmute-from-fn-item-types-error.rs
@@ -2,7 +2,7 @@ use std::mem;
 
 unsafe fn foo() -> (i8, *const (), Option<fn()>) {
     let i = mem::transmute(bar);
-    //~^ ERROR transmute called with types of different sizes
+    //~^ ERROR cannot transmute between types of different sizes, or dependently-sized types
 
 
     let p = mem::transmute(foo);
@@ -19,7 +19,7 @@ unsafe fn foo() -> (i8, *const (), Option<fn()>) {
 unsafe fn bar() {
     // Error as usual if the resulting type is not pointer-sized.
     mem::transmute::<_, u8>(main);
-    //~^ ERROR transmute called with types of different sizes
+    //~^ ERROR cannot transmute between types of different sizes, or dependently-sized types
 
 
     mem::transmute::<_, *mut ()>(foo);

--- a/src/test/ui/transmute/transmute-from-fn-item-types-error.stderr
+++ b/src/test/ui/transmute/transmute-from-fn-item-types-error.stderr
@@ -1,11 +1,11 @@
-error[E0512]: transmute called with types of different sizes
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> $DIR/transmute-from-fn-item-types-error.rs:4:13
    |
 LL |     let i = mem::transmute(bar);
    |             ^^^^^^^^^^^^^^
    |
-   = note: source type: unsafe fn() {bar} (0 bits)
-   = note: target type: i8 (8 bits)
+   = note: source type: `unsafe fn() {bar}` (0 bits)
+   = note: target type: `i8` (8 bits)
 
 error[E0591]: can't transmute zero-sized type
   --> $DIR/transmute-from-fn-item-types-error.rs:8:13
@@ -27,14 +27,14 @@ LL |     let of = mem::transmute(main);
    = note: target type: std::option::Option<fn()>
    = help: cast with `as` to a pointer instead
 
-error[E0512]: transmute called with types of different sizes
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> $DIR/transmute-from-fn-item-types-error.rs:21:5
    |
 LL |     mem::transmute::<_, u8>(main);
    |     ^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: source type: fn() {main} (0 bits)
-   = note: target type: u8 (8 bits)
+   = note: source type: `fn() {main}` (0 bits)
+   = note: target type: `u8` (8 bits)
 
 error[E0591]: can't transmute zero-sized type
   --> $DIR/transmute-from-fn-item-types-error.rs:25:5

--- a/src/test/ui/transmute/transmute-impl.rs
+++ b/src/test/ui/transmute/transmute-impl.rs
@@ -18,7 +18,7 @@ impl<T: ?Sized> Foo<T> {
 
     fn n(x: &T) -> &isize {
         // Not OK here, because T : Sized is not in scope.
-        unsafe { transmute(x) } //~ ERROR transmute called with types of different sizes
+        unsafe { transmute(x) } //~ ERROR cannot transmute between types of different sizes
     }
 }
 

--- a/src/test/ui/transmute/transmute-impl.stderr
+++ b/src/test/ui/transmute/transmute-impl.stderr
@@ -1,11 +1,11 @@
-error[E0512]: transmute called with types of different sizes
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> $DIR/transmute-impl.rs:21:18
    |
-LL |         unsafe { transmute(x) } //~ ERROR transmute called with types of different sizes
+LL |         unsafe { transmute(x) } //~ ERROR cannot transmute between types of different sizes
    |                  ^^^^^^^^^
    |
-   = note: source type: &T (pointer to T)
-   = note: target type: &isize (N bits)
+   = note: source type: `&T` (pointer to `T`)
+   = note: target type: `&isize` (N bits)
 
 error: aborting due to previous error
 

--- a/src/test/ui/transmute/transmute-type-parameters.rs
+++ b/src/test/ui/transmute/transmute-type-parameters.rs
@@ -4,17 +4,17 @@ use std::mem::transmute;
 
 unsafe fn f<T>(x: T) {
     let _: i32 = transmute(x);
-//~^ ERROR transmute called with types of different sizes
+//~^ ERROR cannot transmute between types of different sizes, or dependently-sized types
 }
 
 unsafe fn g<T>(x: (T, i32)) {
     let _: i32 = transmute(x);
-//~^ ERROR transmute called with types of different sizes
+//~^ ERROR cannot transmute between types of different sizes, or dependently-sized types
 }
 
 unsafe fn h<T>(x: [T; 10]) {
     let _: i32 = transmute(x);
-//~^ ERROR transmute called with types of different sizes
+//~^ ERROR cannot transmute between types of different sizes, or dependently-sized types
 }
 
 struct Bad<T> {
@@ -23,7 +23,7 @@ struct Bad<T> {
 
 unsafe fn i<T>(x: Bad<T>) {
     let _: i32 = transmute(x);
-//~^ ERROR transmute called with types of different sizes
+//~^ ERROR cannot transmute between types of different sizes, or dependently-sized types
 }
 
 enum Worse<T> {
@@ -33,12 +33,12 @@ enum Worse<T> {
 
 unsafe fn j<T>(x: Worse<T>) {
     let _: i32 = transmute(x);
-//~^ ERROR transmute called with types of different sizes
+//~^ ERROR cannot transmute between types of different sizes, or dependently-sized types
 }
 
 unsafe fn k<T>(x: Option<T>) {
     let _: i32 = transmute(x);
-//~^ ERROR transmute called with types of different sizes
+//~^ ERROR cannot transmute between types of different sizes, or dependently-sized types
 }
 
 fn main() {}

--- a/src/test/ui/transmute/transmute-type-parameters.stderr
+++ b/src/test/ui/transmute/transmute-type-parameters.stderr
@@ -1,56 +1,56 @@
-error[E0512]: transmute called with types of different sizes
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> $DIR/transmute-type-parameters.rs:6:18
    |
 LL |     let _: i32 = transmute(x);
    |                  ^^^^^^^^^
    |
-   = note: source type: T (this type's size can vary)
-   = note: target type: i32 (32 bits)
+   = note: source type: `T` (this type does not have a fixed size)
+   = note: target type: `i32` (32 bits)
 
-error[E0512]: transmute called with types of different sizes
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> $DIR/transmute-type-parameters.rs:11:18
    |
 LL |     let _: i32 = transmute(x);
    |                  ^^^^^^^^^
    |
-   = note: source type: (T, i32) (size can vary because of T)
-   = note: target type: i32 (32 bits)
+   = note: source type: `(T, i32)` (size can vary because of T)
+   = note: target type: `i32` (32 bits)
 
-error[E0512]: transmute called with types of different sizes
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> $DIR/transmute-type-parameters.rs:16:18
    |
 LL |     let _: i32 = transmute(x);
    |                  ^^^^^^^^^
    |
-   = note: source type: [T; 10] (size can vary because of T)
-   = note: target type: i32 (32 bits)
+   = note: source type: `[T; 10]` (size can vary because of T)
+   = note: target type: `i32` (32 bits)
 
-error[E0512]: transmute called with types of different sizes
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> $DIR/transmute-type-parameters.rs:25:18
    |
 LL |     let _: i32 = transmute(x);
    |                  ^^^^^^^^^
    |
-   = note: source type: Bad<T> (size can vary because of T)
-   = note: target type: i32 (32 bits)
+   = note: source type: `Bad<T>` (size can vary because of T)
+   = note: target type: `i32` (32 bits)
 
-error[E0512]: transmute called with types of different sizes
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> $DIR/transmute-type-parameters.rs:35:18
    |
 LL |     let _: i32 = transmute(x);
    |                  ^^^^^^^^^
    |
-   = note: source type: Worse<T> (size can vary because of T)
-   = note: target type: i32 (32 bits)
+   = note: source type: `Worse<T>` (size can vary because of T)
+   = note: target type: `i32` (32 bits)
 
-error[E0512]: transmute called with types of different sizes
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> $DIR/transmute-type-parameters.rs:40:18
    |
 LL |     let _: i32 = transmute(x);
    |                  ^^^^^^^^^
    |
-   = note: source type: std::option::Option<T> (size can vary because of T)
-   = note: target type: i32 (32 bits)
+   = note: source type: `std::option::Option<T>` (size can vary because of T)
+   = note: target type: `i32` (32 bits)
 
 error: aborting due to 6 previous errors
 


### PR DESCRIPTION
Also clarifies the wording of E0512.

Fixes https://github.com/rust-lang/rust/issues/49793.