### PR TITLE
Short-circuit DefIdForest::intersection()

### DIFF
--- a/src/librustc/ty/inhabitedness/def_id_forest.rs
+++ b/src/librustc/ty/inhabitedness/def_id_forest.rs
@@ -74,10 +74,21 @@ impl<'a, 'gcx, 'tcx> DefIdForest {
                            iter: I) -> DefIdForest
             where I: IntoIterator<Item=DefIdForest>
     {
-        let mut ret = DefIdForest::full(tcx);
+        let mut iter = iter.into_iter();
+        let mut ret = if let Some(first) = iter.next() {
+            first
+        } else {
+            return DefIdForest::full(tcx);
+        };
+
         let mut next_ret = SmallVec::new();
         let mut old_ret: SmallVec<[DefId; 1]> = SmallVec::new();
         for next_forest in iter {
+            // No need to continue if the intersection is already empty.
+            if ret.is_empty() {
+                break;
+            }
+
             for id in ret.root_ids.drain() {
                 if next_forest.contains(tcx, id) {
                     next_ret.push(id);


### PR DESCRIPTION
If the forest is already empty, there is no point in intersecting further.

Also handle the first element separately, so we don't compute an unnecessary intersection between the full forest and the first element, which is always equal to the first element.

This is the second try at fixing #57028, as the previous attempt only recovered part of the regression. I checked locally that this drops time spent in ty::inhabitedness for syn-check a lot, though not to zero.

r? @varkor