### PR TITLE
Various changes to string format diagnostics

### DIFF
--- a/src/librustc/traits/on_unimplemented.rs
+++ b/src/librustc/traits/on_unimplemented.rs
@@ -234,7 +234,7 @@ impl<'a, 'gcx, 'tcx> OnUnimplementedFormatString {
     {
         let name = tcx.item_name(trait_def_id);
         let generics = tcx.generics_of(trait_def_id);
-        let parser = Parser::new(&self.0, None);
+        let parser = Parser::new(&self.0, None, vec![], false);
         let mut result = Ok(());
         for token in parser {
             match token {
@@ -293,7 +293,7 @@ impl<'a, 'gcx, 'tcx> OnUnimplementedFormatString {
         }).collect::<FxHashMap<String, String>>();
         let empty_string = String::new();
 
-        let parser = Parser::new(&self.0, None);
+        let parser = Parser::new(&self.0, None, vec![], false);
         parser.map(|p|
             match p {
                 Piece::String(s) => s,

--- a/src/test/ui/fmt/format-string-error-2.rs
+++ b/src/test/ui/fmt/format-string-error-2.rs
@@ -1,0 +1,70 @@
+// ignore-tidy-tab
+
+fn main() {
+    format!("{
+    a");
+    //~^ ERROR invalid format string
+    format!("{ \
+
+    b");
+    //~^ ERROR invalid format string
+    format!(r#"{ \
+
+    rawc"#);
+    //~^^^ ERROR invalid format string
+    format!(r#"{ \n
+\n
+    rawd"#);
+    //~^^^ ERROR invalid format string
+    format!("{ \n
+\n
+    e");
+    //~^ ERROR invalid format string
+    format!("
+    {
+    a");
+    //~^ ERROR invalid format string
+    format!("
+    {
+    a
+    ");
+    //~^^ ERROR invalid format string
+    format!("  \
+    { \
+    	\
+    b");
+    //~^ ERROR invalid format string
+    format!("  \
+    { \
+    	\
+    b \
+
+    ");
+    //~^^^ ERROR invalid format string
+    format!(r#"
+raw  { \
+
+    c"#);
+    //~^^^ ERROR invalid format string
+    format!(r#"
+raw  { \n
+\n
+    d"#);
+    //~^^^ ERROR invalid format string
+    format!("
+  { \n
+\n
+    e");
+    //~^ ERROR invalid format string
+
+    format!("
+    {asdf
+    }
+    ", asdf=1);
+    // ok - this is supported
+    format!("
+    {
+    asdf}
+    ", asdf=1);
+    //~^^ ERROR invalid format string
+}

--- a/src/test/ui/fmt/format-string-error-2.stderr
+++ b/src/test/ui/fmt/format-string-error-2.stderr
@@ -1,0 +1,137 @@
+error: invalid format string: expected `'}'`, found `'a'`
+  --> $DIR/format-string-error-2.rs:5:5
+   |
+LL |     format!("{
+   |              - because of this opening brace
+LL |     a");
+   |     ^ expected `}` in format string
+   |
+   = note: if you intended to print `{`, you can escape it using `{{`
+
+error: invalid format string: expected `'}'`, found `'b'`
+  --> $DIR/format-string-error-2.rs:9:5
+   |
+LL |     format!("{ /
+   |              - because of this opening brace
+LL | 
+LL |     b");
+   |     ^ expected `}` in format string
+   |
+   = note: if you intended to print `{`, you can escape it using `{{`
+
+error: invalid format string: expected `'}'`, found `'/'`
+  --> $DIR/format-string-error-2.rs:11:18
+   |
+LL |     format!(r#"{ /
+   |                - ^ expected `}` in format string
+   |                |
+   |                because of this opening brace
+   |
+   = note: if you intended to print `{`, you can escape it using `{{`
+
+error: invalid format string: expected `'}'`, found `'/'`
+  --> $DIR/format-string-error-2.rs:15:18
+   |
+LL |     format!(r#"{ /n
+   |                - ^ expected `}` in format string
+   |                |
+   |                because of this opening brace
+   |
+   = note: if you intended to print `{`, you can escape it using `{{`
+
+error: invalid format string: expected `'}'`, found `'e'`
+  --> $DIR/format-string-error-2.rs:21:5
+   |
+LL |     format!("{ /n
+   |              - because of this opening brace
+LL | /n
+LL |     e");
+   |     ^ expected `}` in format string
+   |
+   = note: if you intended to print `{`, you can escape it using `{{`
+
+error: invalid format string: expected `'}'`, found `'a'`
+  --> $DIR/format-string-error-2.rs:25:5
+   |
+LL |     {
+   |     - because of this opening brace
+LL |     a");
+   |     ^ expected `}` in format string
+   |
+   = note: if you intended to print `{`, you can escape it using `{{`
+
+error: invalid format string: expected `'}'`, found `'a'`
+  --> $DIR/format-string-error-2.rs:29:5
+   |
+LL |     {
+   |     - because of this opening brace
+LL |     a
+   |     ^ expected `}` in format string
+   |
+   = note: if you intended to print `{`, you can escape it using `{{`
+
+error: invalid format string: expected `'}'`, found `'b'`
+  --> $DIR/format-string-error-2.rs:35:5
+   |
+LL |     { /
+   |     - because of this opening brace
+LL |         /
+LL |     b");
+   |     ^ expected `}` in format string
+   |
+   = note: if you intended to print `{`, you can escape it using `{{`
+
+error: invalid format string: expected `'}'`, found `'b'`
+  --> $DIR/format-string-error-2.rs:40:5
+   |
+LL |     { /
+   |     - because of this opening brace
+LL |         /
+LL |     b /
+   |     ^ expected `}` in format string
+   |
+   = note: if you intended to print `{`, you can escape it using `{{`
+
+error: invalid format string: expected `'}'`, found `'/'`
+  --> $DIR/format-string-error-2.rs:45:8
+   |
+LL | raw  { /
+   |      - ^ expected `}` in format string
+   |      |
+   |      because of this opening brace
+   |
+   = note: if you intended to print `{`, you can escape it using `{{`
+
+error: invalid format string: expected `'}'`, found `'/'`
+  --> $DIR/format-string-error-2.rs:50:8
+   |
+LL | raw  { /n
+   |      - ^ expected `}` in format string
+   |      |
+   |      because of this opening brace
+   |
+   = note: if you intended to print `{`, you can escape it using `{{`
+
+error: invalid format string: expected `'}'`, found `'e'`
+  --> $DIR/format-string-error-2.rs:57:5
+   |
+LL |   { /n
+   |   - because of this opening brace
+LL | /n
+LL |     e");
+   |     ^ expected `}` in format string
+   |
+   = note: if you intended to print `{`, you can escape it using `{{`
+
+error: invalid format string: expected `'}'`, found `'a'`
+  --> $DIR/format-string-error-2.rs:67:5
+   |
+LL |     {
+   |     - because of this opening brace
+LL |     asdf}
+   |     ^ expected `}` in format string
+   |
+   = note: if you intended to print `{`, you can escape it using `{{`
+
+error: aborting due to 13 previous errors
+

--- a/src/test/ui/fmt/format-string-error.rs
+++ b/src/test/ui/fmt/format-string-error.rs
@@ -31,7 +31,7 @@ fn main() {
 	{
 
 "###);
-    //~^^ ERROR invalid format string
+    //~^ ERROR invalid format string
     let _ = format!(r###"
 
 

--- a/src/test/ui/fmt/format-string-error.stderr
+++ b/src/test/ui/fmt/format-string-error.stderr
@@ -2,7 +2,9 @@ error: invalid format string: expected `'}'` but string was terminated
   --> $DIR/format-string-error.rs:4:16
    |
 LL |     println!("{");
-   |                ^ expected `'}'` in format string
+   |               -^ expected `'}'` in format string
+   |               |
+   |               because of this opening brace
    |
    = note: if you intended to print `{`, you can escape it using `{{`
 
@@ -34,7 +36,9 @@ error: invalid format string: expected `'}'` but string was terminated
   --> $DIR/format-string-error.rs:13:23
    |
 LL |     let _ = format!("{");
-   |                       ^ expected `'}'` in format string
+   |                      -^ expected `'}'` in format string
+   |                      |
+   |                      because of this opening brace
    |
    = note: if you intended to print `{`, you can escape it using `{{`
 
@@ -50,13 +54,19 @@ error: invalid format string: expected `'}'`, found `'/'`
   --> $DIR/format-string-error.rs:17:23
    |
 LL |     let _ = format!("{/}");
-   |                       ^ expected `}` in format string
+   |                      -^ expected `}` in format string
+   |                      |
+   |                      because of this opening brace
+   |
+   = note: if you intended to print `{`, you can escape it using `{{`
 
 error: invalid format string: expected `'}'` but string was terminated
-  --> $DIR/format-string-error.rs:19:29
+  --> $DIR/format-string-error.rs:19:35
    |
 LL |     let _ = format!("/n/n/n{/n/n/n");
-   |                             ^ expected `'}'` in format string
+   |                            -      ^ expected `'}'` in format string
+   |                            |
+   |                            because of this opening brace
    |
    = note: if you intended to print `{`, you can escape it using `{{`
 
@@ -64,14 +74,19 @@ error: invalid format string: expected `'}'` but string was terminated
   --> $DIR/format-string-error.rs:25:3
    |
 LL |     {"###);
-   |      ^ expected `'}'` in format string
+   |     -^ expected `'}'` in format string
+   |     |
+   |     because of this opening brace
    |
    = note: if you intended to print `{`, you can escape it using `{{`
 
 error: invalid format string: expected `'}'` but string was terminated
-  --> $DIR/format-string-error.rs:32:1
+  --> $DIR/format-string-error.rs:33:1
    |
+LL |     {
+   |     - because of this opening brace
 LL | 
+LL | "###);
    | ^ expected `'}'` in format string
    |
    = note: if you intended to print `{`, you can escape it using `{{`

--- a/src/test/ui/if/ifmt-bad-arg.stderr
+++ b/src/test/ui/if/ifmt-bad-arg.stderr
@@ -168,7 +168,9 @@ error: invalid format string: expected `'}'` but string was terminated
   --> $DIR/ifmt-bad-arg.rs:51:15
    |
 LL |     format!("{"); //~ ERROR: expected `'}'` but string was terminated
-   |               ^ expected `'}'` in format string
+   |              -^ expected `'}'` in format string
+   |              |
+   |              because of this opening brace
    |
    = note: if you intended to print `{`, you can escape it using `{{`
 
@@ -207,8 +209,12 @@ LL |         {foo}
 error: invalid format string: expected `'}'`, found `'t'`
   --> $DIR/ifmt-bad-arg.rs:75:1
    |
+LL | ninth number: {
+   |               - because of this opening brace
 LL | tenth number: {}",
    | ^ expected `}` in format string
+   |
+   = note: if you intended to print `{`, you can escape it using `{{`
 
 error: aborting due to 28 previous errors
 

--- a/src/test/ui/issues/issue-51848.stderr
+++ b/src/test/ui/issues/issue-51848.stderr
@@ -2,7 +2,9 @@ error: invalid format string: expected `'}'` but string was terminated
   --> $DIR/issue-51848.rs:6:20
    |
 LL |         println!("{"); //~ ERROR invalid
-   |                    ^ expected `'}'` in format string
+   |                   -^ expected `'}'` in format string
+   |                   |
+   |                   because of this opening brace
 ...
 LL |     macro_with_error!();
    |     -------------------- in this macro invocation


### PR DESCRIPTION
- Point at opening mismatched formatting brace
- Account for differences between raw and regular strings
- Account for differences between the code snippet and `InternedString`
- Add more tests

```
error: invalid format string: expected `'}'`, found `'t'`
  --> $DIR/ifmt-bad-arg.rs:85:1
   |
LL | ninth number: {
   |               - because of this opening brace
LL | tenth number: {}",
   | ^ expected `}` in format string
   |
   = note: if you intended to print `{`, you can escape it using `{{`
```

Fix #53837.