### PR TITLE
use `MIN`/`MAX` constant names in integer pattern coverage messages

### DIFF
--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1458,6 +1458,29 @@ impl IntTy {
             IntTy::I128 => 128,
         })
     }
+
+    pub fn min_as_i128(&self) -> i128 {
+        match *self {
+            IntTy::Isize => ::std::isize::MIN as i128,
+            IntTy::I8 => ::std::i8::MIN as i128,
+            IntTy::I16 => ::std::i16::MIN as i128,
+            IntTy::I32 => ::std::i32::MIN as i128,
+            IntTy::I64 => ::std::i64::MIN as i128,
+            IntTy::I128 => ::std::i128::MIN,
+        }
+    }
+
+    pub fn max_as_i128(&self) -> i128 {
+        match *self {
+            IntTy::Isize => ::std::isize::MAX as i128,
+            IntTy::I8 => ::std::i8::MAX as i128,
+            IntTy::I16 => ::std::i16::MAX as i128,
+            IntTy::I32 => ::std::i32::MAX as i128,
+            IntTy::I64 => ::std::i64::MAX as i128,
+            IntTy::I128 => ::std::i128::MAX,
+        }
+    }
+
 }
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, RustcEncodable, RustcDecodable, Copy)]
@@ -1495,6 +1518,17 @@ impl UintTy {
             UintTy::U64 => 64,
             UintTy::U128 => 128,
         })
+    }
+
+    pub fn max_as_u128(&self) -> u128 {
+        match *self {
+            UintTy::Usize => ::std::usize::MAX as u128,
+            UintTy::U8 => ::std::u8::MAX as u128,
+            UintTy::U16 => ::std::u16::MAX as u128,
+            UintTy::U32 => ::std::u32::MAX as u128,
+            UintTy::U64 => ::std::u64::MAX as u128,
+            UintTy::U128 => ::std::u128::MAX,
+        }
     }
 }
 

--- a/src/test/ui/consts/const-match-check.eval1.stderr
+++ b/src/test/ui/consts/const-match-check.eval1.stderr
@@ -1,8 +1,8 @@
-error[E0005]: refutable pattern in local binding: `-2147483648i32..=-1i32` not covered
+error[E0005]: refutable pattern in local binding: `::std::i32::MIN..=-1i32` not covered
   --> $DIR/const-match-check.rs:35:15
    |
 LL |     A = { let 0 = 0; 0 },
-   |               ^ pattern `-2147483648i32..=-1i32` not covered
+   |               ^ pattern `::std::i32::MIN..=-1i32` not covered
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-match-check.eval2.stderr
+++ b/src/test/ui/consts/const-match-check.eval2.stderr
@@ -1,8 +1,8 @@
-error[E0005]: refutable pattern in local binding: `-2147483648i32..=-1i32` not covered
+error[E0005]: refutable pattern in local binding: `::std::i32::MIN..=-1i32` not covered
   --> $DIR/const-match-check.rs:41:24
    |
 LL |     let x: [i32; { let 0 = 0; 0 }] = [];
-   |                        ^ pattern `-2147483648i32..=-1i32` not covered
+   |                        ^ pattern `::std::i32::MIN..=-1i32` not covered
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-match-check.matchck.stderr
+++ b/src/test/ui/consts/const-match-check.matchck.stderr
@@ -1,26 +1,26 @@
-error[E0005]: refutable pattern in local binding: `-2147483648i32..=-1i32` not covered
+error[E0005]: refutable pattern in local binding: `::std::i32::MIN..=-1i32` not covered
   --> $DIR/const-match-check.rs:14:22
    |
 LL | const X: i32 = { let 0 = 0; 0 };
-   |                      ^ pattern `-2147483648i32..=-1i32` not covered
+   |                      ^ pattern `::std::i32::MIN..=-1i32` not covered
 
-error[E0005]: refutable pattern in local binding: `-2147483648i32..=-1i32` not covered
+error[E0005]: refutable pattern in local binding: `::std::i32::MIN..=-1i32` not covered
   --> $DIR/const-match-check.rs:18:23
    |
 LL | static Y: i32 = { let 0 = 0; 0 };
-   |                       ^ pattern `-2147483648i32..=-1i32` not covered
+   |                       ^ pattern `::std::i32::MIN..=-1i32` not covered
 
-error[E0005]: refutable pattern in local binding: `-2147483648i32..=-1i32` not covered
+error[E0005]: refutable pattern in local binding: `::std::i32::MIN..=-1i32` not covered
   --> $DIR/const-match-check.rs:23:26
    |
 LL |     const X: i32 = { let 0 = 0; 0 };
-   |                          ^ pattern `-2147483648i32..=-1i32` not covered
+   |                          ^ pattern `::std::i32::MIN..=-1i32` not covered
 
-error[E0005]: refutable pattern in local binding: `-2147483648i32..=-1i32` not covered
+error[E0005]: refutable pattern in local binding: `::std::i32::MIN..=-1i32` not covered
   --> $DIR/const-match-check.rs:29:26
    |
 LL |     const X: i32 = { let 0 = 0; 0 };
-   |                          ^ pattern `-2147483648i32..=-1i32` not covered
+   |                          ^ pattern `::std::i32::MIN..=-1i32` not covered
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/exhaustive_integer_patterns.stderr
+++ b/src/test/ui/exhaustive_integer_patterns.stderr
@@ -10,11 +10,11 @@ note: lint level defined here
 LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
-error[E0004]: non-exhaustive patterns: `128u8..=255u8` not covered
+error[E0004]: non-exhaustive patterns: `128u8..=::std::u8::MAX` not covered
   --> $DIR/exhaustive_integer_patterns.rs:38:11
    |
 LL |     match x { //~ ERROR non-exhaustive patterns
-   |           ^ pattern `128u8..=255u8` not covered
+   |           ^ pattern `128u8..=::std::u8::MAX` not covered
 
 error[E0004]: non-exhaustive patterns: `11u8..=19u8`, `31u8..=34u8`, `36u8..=69u8` and 1 more not covered
   --> $DIR/exhaustive_integer_patterns.rs:43:11
@@ -28,17 +28,17 @@ error: unreachable pattern
 LL |         -2..=20 => {} //~ ERROR unreachable pattern
    |         ^^^^^^^
 
-error[E0004]: non-exhaustive patterns: `-128i8..=-8i8`, `-6i8`, `121i8..=124i8` and 1 more not covered
+error[E0004]: non-exhaustive patterns: `::std::i8::MIN..=-8i8`, `-6i8`, `121i8..=124i8` and 1 more not covered
   --> $DIR/exhaustive_integer_patterns.rs:51:11
    |
 LL |     match x { //~ ERROR non-exhaustive patterns
-   |           ^ patterns `-128i8..=-8i8`, `-6i8`, `121i8..=124i8` and 1 more not covered
+   |           ^ patterns `::std::i8::MIN..=-8i8`, `-6i8`, `121i8..=124i8` and 1 more not covered
 
-error[E0004]: non-exhaustive patterns: `-128i8` not covered
+error[E0004]: non-exhaustive patterns: `::std::i8::MIN` not covered
   --> $DIR/exhaustive_integer_patterns.rs:92:11
    |
 LL |     match 0i8 { //~ ERROR non-exhaustive patterns
-   |           ^^^ pattern `-128i8` not covered
+   |           ^^^ pattern `::std::i8::MIN` not covered
 
 error[E0004]: non-exhaustive patterns: `0i16` not covered
   --> $DIR/exhaustive_integer_patterns.rs:100:11
@@ -46,17 +46,17 @@ error[E0004]: non-exhaustive patterns: `0i16` not covered
 LL |     match 0i16 { //~ ERROR non-exhaustive patterns
    |           ^^^^ pattern `0i16` not covered
 
-error[E0004]: non-exhaustive patterns: `128u8..=255u8` not covered
+error[E0004]: non-exhaustive patterns: `128u8..=::std::u8::MAX` not covered
   --> $DIR/exhaustive_integer_patterns.rs:118:11
    |
 LL |     match 0u8 { //~ ERROR non-exhaustive patterns
-   |           ^^^ pattern `128u8..=255u8` not covered
+   |           ^^^ pattern `128u8..=::std::u8::MAX` not covered
 
-error[E0004]: non-exhaustive patterns: `(0u8, Some(_))` and `(2u8..=255u8, Some(_))` not covered
+error[E0004]: non-exhaustive patterns: `(0u8, Some(_))` and `(2u8..=::std::u8::MAX, Some(_))` not covered
   --> $DIR/exhaustive_integer_patterns.rs:130:11
    |
 LL |     match (0u8, Some(())) { //~ ERROR non-exhaustive patterns
-   |           ^^^^^^^^^^^^^^^ patterns `(0u8, Some(_))` and `(2u8..=255u8, Some(_))` not covered
+   |           ^^^^^^^^^^^^^^^ patterns `(0u8, Some(_))` and `(2u8..=::std::u8::MAX, Some(_))` not covered
 
 error[E0004]: non-exhaustive patterns: `(126u8..=127u8, false)` not covered
   --> $DIR/exhaustive_integer_patterns.rs:135:11
@@ -64,17 +64,17 @@ error[E0004]: non-exhaustive patterns: `(126u8..=127u8, false)` not covered
 LL |     match (0u8, true) { //~ ERROR non-exhaustive patterns
    |           ^^^^^^^^^^^ pattern `(126u8..=127u8, false)` not covered
 
-error[E0004]: non-exhaustive patterns: `340282366920938463463374607431768211455u128` not covered
+error[E0004]: non-exhaustive patterns: `::std::u128::MAX` not covered
   --> $DIR/exhaustive_integer_patterns.rs:155:11
    |
 LL |     match 0u128 { //~ ERROR non-exhaustive patterns
-   |           ^^^^^ pattern `340282366920938463463374607431768211455u128` not covered
+   |           ^^^^^ pattern `::std::u128::MAX` not covered
 
-error[E0004]: non-exhaustive patterns: `5u128..=340282366920938463463374607431768211455u128` not covered
+error[E0004]: non-exhaustive patterns: `5u128..=::std::u128::MAX` not covered
   --> $DIR/exhaustive_integer_patterns.rs:159:11
    |
 LL |     match 0u128 { //~ ERROR non-exhaustive patterns
-   |           ^^^^^ pattern `5u128..=340282366920938463463374607431768211455u128` not covered
+   |           ^^^^^ pattern `5u128..=::std::u128::MAX` not covered
 
 error[E0004]: non-exhaustive patterns: `0u128..=3u128` not covered
   --> $DIR/exhaustive_integer_patterns.rs:163:11

--- a/src/test/ui/for/for-loop-refutable-pattern-error-message.stderr
+++ b/src/test/ui/for/for-loop-refutable-pattern-error-message.stderr
@@ -1,8 +1,8 @@
-error[E0005]: refutable pattern in `for` loop binding: `&-2147483648i32..=0i32` not covered
+error[E0005]: refutable pattern in `for` loop binding: `&::std::i32::MIN..=0i32` not covered
   --> $DIR/for-loop-refutable-pattern-error-message.rs:12:9
    |
 LL |     for &1 in [1].iter() {} //~ ERROR refutable pattern in `for` loop binding
-   |         ^^ pattern `&-2147483648i32..=0i32` not covered
+   |         ^^ pattern `&::std::i32::MIN..=0i32` not covered
 
 error: aborting due to previous error
 

--- a/src/test/ui/match/match-non-exhaustive.stderr
+++ b/src/test/ui/match/match-non-exhaustive.stderr
@@ -1,8 +1,8 @@
-error[E0004]: non-exhaustive patterns: `-2147483648i32..=0i32` and `2i32..=2147483647i32` not covered
+error[E0004]: non-exhaustive patterns: `::std::i32::MIN..=0i32` and `2i32..=::std::i32::MAX` not covered
   --> $DIR/match-non-exhaustive.rs:12:11
    |
 LL |     match 0 { 1 => () } //~ ERROR non-exhaustive patterns
-   |           ^ patterns `-2147483648i32..=0i32` and `2i32..=2147483647i32` not covered
+   |           ^ patterns `::std::i32::MIN..=0i32` and `2i32..=::std::i32::MAX` not covered
 
 error[E0004]: non-exhaustive patterns: `_` not covered
   --> $DIR/match-non-exhaustive.rs:13:11

--- a/src/test/ui/non-exhaustive/non-exhaustive-match.rs
+++ b/src/test/ui/non-exhaustive/non-exhaustive-match.rs
@@ -22,8 +22,8 @@ fn main() {
     match Some(10) { //~ ERROR non-exhaustive patterns: `Some(_)` not covered
       None => {}
     }
-    match (2, 3, 4) { //~ ERROR non-exhaustive patterns: `(_, _, -2147483648i32..=3i32)`
-                      //  and `(_, _, 5i32..=2147483647i32)` not covered
+    match (2, 3, 4) { //~ ERROR non-exhaustive patterns: `(_, _, ::std::i32::MIN..=3i32)`
+                      //  and `(_, _, 5i32..=::std::i32::MAX)` not covered
       (_, _, 4) => {}
     }
     match (t::a, t::a) { //~ ERROR non-exhaustive patterns: `(a, a)` not covered

--- a/src/test/ui/non-exhaustive/non-exhaustive-match.stderr
+++ b/src/test/ui/non-exhaustive/non-exhaustive-match.stderr
@@ -16,11 +16,11 @@ error[E0004]: non-exhaustive patterns: `Some(_)` not covered
 LL |     match Some(10) { //~ ERROR non-exhaustive patterns: `Some(_)` not covered
    |           ^^^^^^^^ pattern `Some(_)` not covered
 
-error[E0004]: non-exhaustive patterns: `(_, _, -2147483648i32..=3i32)` and `(_, _, 5i32..=2147483647i32)` not covered
+error[E0004]: non-exhaustive patterns: `(_, _, ::std::i32::MIN..=3i32)` and `(_, _, 5i32..=::std::i32::MAX)` not covered
   --> $DIR/non-exhaustive-match.rs:25:11
    |
-LL |     match (2, 3, 4) { //~ ERROR non-exhaustive patterns: `(_, _, -2147483648i32..=3i32)`
-   |           ^^^^^^^^^ patterns `(_, _, -2147483648i32..=3i32)` and `(_, _, 5i32..=2147483647i32)` not covered
+LL |     match (2, 3, 4) { //~ ERROR non-exhaustive patterns: `(_, _, ::std::i32::MIN..=3i32)`
+   |           ^^^^^^^^^ patterns `(_, _, ::std::i32::MIN..=3i32)` and `(_, _, 5i32..=::std::i32::MAX)` not covered
 
 error[E0004]: non-exhaustive patterns: `(a, a)` not covered
   --> $DIR/non-exhaustive-match.rs:29:11

--- a/src/test/ui/precise_pointer_size_matching.stderr
+++ b/src/test/ui/precise_pointer_size_matching.stderr
@@ -1,14 +1,14 @@
-error[E0004]: non-exhaustive patterns: `$ISIZE_MIN..=-6isize` and `21isize..=$ISIZE_MAX` not covered
+error[E0004]: non-exhaustive patterns: `::std::isize::MIN..=-6isize` and `21isize..=::std::isize::MAX` not covered
   --> $DIR/precise_pointer_size_matching.rs:24:11
    |
 LL |     match 0isize { //~ ERROR non-exhaustive patterns
-   |           ^^^^^^ patterns `$ISIZE_MIN..=-6isize` and `21isize..=$ISIZE_MAX` not covered
+   |           ^^^^^^ patterns `::std::isize::MIN..=-6isize` and `21isize..=::std::isize::MAX` not covered
 
-error[E0004]: non-exhaustive patterns: `0usize` and `21usize..=$USIZE_MAX` not covered
+error[E0004]: non-exhaustive patterns: `0usize` and `21usize..=::std::usize::MAX` not covered
   --> $DIR/precise_pointer_size_matching.rs:29:11
    |
 LL |     match 0usize { //~ ERROR non-exhaustive patterns
-   |           ^^^^^^ patterns `0usize` and `21usize..=$USIZE_MAX` not covered
+   |           ^^^^^^ patterns `0usize` and `21usize..=::std::usize::MAX` not covered
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/refutable-pattern-errors.rs
+++ b/src/test/ui/refutable-pattern-errors.rs
@@ -14,5 +14,5 @@ fn func((1, (Some(1), 2..=3)): (isize, (Option<isize>, isize))) { }
 
 fn main() {
     let (1, (Some(1), 2..=3)) = (1, (None, 2));
-    //~^ ERROR refutable pattern in local binding: `(-2147483648i32..=0i32, _)` not covered
+    //~^ ERROR refutable pattern in local binding: `(::std::i32::MIN..=0i32, _)` not covered
 }

--- a/src/test/ui/refutable-pattern-errors.stderr
+++ b/src/test/ui/refutable-pattern-errors.stderr
@@ -4,11 +4,11 @@ error[E0005]: refutable pattern in function argument: `(_, _)` not covered
 LL | fn func((1, (Some(1), 2..=3)): (isize, (Option<isize>, isize))) { }
    |         ^^^^^^^^^^^^^^^^^^^^^ pattern `(_, _)` not covered
 
-error[E0005]: refutable pattern in local binding: `(-2147483648i32..=0i32, _)` not covered
+error[E0005]: refutable pattern in local binding: `(::std::i32::MIN..=0i32, _)` not covered
   --> $DIR/refutable-pattern-errors.rs:16:9
    |
 LL |     let (1, (Some(1), 2..=3)) = (1, (None, 2));
-   |         ^^^^^^^^^^^^^^^^^^^^^ pattern `(-2147483648i32..=0i32, _)` not covered
+   |         ^^^^^^^^^^^^^^^^^^^^^ pattern `(::std::i32::MIN..=0i32, _)` not covered
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
While many programmers may intuitively appreciate the significance of magic numbers like −2147483648, Rust is about [empowering everyone to build reliable and efficient software](https://www.rust-lang.org/)! It's a bit more legible to print the constant names.

The `max_as_i128`, &c. methods strewn in libsyntax are a bit unsightly, but I fear this is really the most natural way to solve the problem.

Question: is it OK to have chosen `::std::isize::MIN` (_&c._) as the symbolic names, or will `no_std` crate authors be mad??

Resolves #56393.

r? @varkor 