### PR TITLE
Ignore two tests on s390x

### DIFF
--- a/src/test/codegen/x86_mmx.rs
+++ b/src/test/codegen/x86_mmx.rs
@@ -18,6 +18,7 @@
 // ignore-powerpc64le
 // ignore-sparc
 // ignore-sparc64
+// ignore-s390x
 // compile-flags: -O
 
 #![feature(repr_simd)]

--- a/src/test/ui/target-feature-gate.rs
+++ b/src/test/ui/target-feature-gate.rs
@@ -19,6 +19,7 @@
 // ignore-powerpc64le
 // ignore-sparc
 // ignore-sparc64
+// ignore-s390x
 // gate-test-sse4a_target_feature
 // gate-test-powerpc_target_feature
 // gate-test-avx512_target_feature

--- a/src/test/ui/target-feature-gate.stderr
+++ b/src/test/ui/target-feature-gate.stderr
@@ -1,5 +1,5 @@
 error[E0658]: the target feature `avx512bw` is currently unstable (see issue #44839)
-  --> $DIR/target-feature-gate.rs:36:18
+  --> $DIR/target-feature-gate.rs:37:18
    |
 LL | #[target_feature(enable = "avx512bw")]
    |                  ^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Ignore two tests on s390x which don't make sense on s390x as they are x86-specific.