### PR TITLE
x.py: fixup 6130fc884bc1dff9bb835894a7bb2042c110b011, fix submodule handling

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -678,7 +678,7 @@ class RustBuild(object):
 
         print("Updating submodule", module)
 
-        run(["git", "submodule", "-q", "sync", "--progress", module],
+        run(["git", "submodule", "-q", "sync", module],
             cwd=self.rust_root, verbose=self.verbose)
         run(["git", "submodule", "update",
             "--init", "--recursive", "--progress", module],


### PR DESCRIPTION
./x.py used to automatically check out the right commit when a submodule was outdated and ./x.py build was run
and submodules handling was enabled in config.toml (submodules = true).

But it threw an error:
[...]
failed to run: git submodule -q sync --progress src/tools/clippy

The commit removes the --progress from git submodule call.

Fixes #57080