### PR TITLE
make non_camel_case_types an early lint

### DIFF
--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -123,6 +123,7 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
                        UnusedDocComment,
                        BadRepr,
                        EllipsisInclusiveRangePatterns,
+                       NonCamelCaseTypes,
                        );
 
     add_early_builtin_with_new!(sess,
@@ -138,7 +139,6 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
         UnusedAttributes: UnusedAttributes,
         PathStatements: PathStatements,
         UnusedResults: UnusedResults,
-        NonCamelCaseTypes: NonCamelCaseTypes,
         NonSnakeCase: NonSnakeCase,
         NonUpperCaseGlobals: NonUpperCaseGlobals,
         NonShorthandFieldPatterns: NonShorthandFieldPatterns,

--- a/src/test/ui/access-mode-in-closures.nll.stderr
+++ b/src/test/ui/access-mode-in-closures.nll.stderr
@@ -1,17 +1,17 @@
 error[E0507]: cannot move out of borrowed content
-  --> $DIR/access-mode-in-closures.rs:19:15
+  --> $DIR/access-mode-in-closures.rs:18:15
    |
-LL |         match *s { sty(v) => v } //~ ERROR cannot move out
-   |               ^^       - data moved here
+LL |         match *s { S(v) => v } //~ ERROR cannot move out
+   |               ^^     - data moved here
    |               |
    |               cannot move out of borrowed content
    |               help: consider removing the `*`: `s`
    |
 note: move occurs because `v` has type `std::vec::Vec<isize>`, which does not implement the `Copy` trait
-  --> $DIR/access-mode-in-closures.rs:19:24
+  --> $DIR/access-mode-in-closures.rs:18:22
    |
-LL |         match *s { sty(v) => v } //~ ERROR cannot move out
-   |                        ^
+LL |         match *s { S(v) => v } //~ ERROR cannot move out
+   |                      ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/access-mode-in-closures.rs
+++ b/src/test/ui/access-mode-in-closures.rs
@@ -8,14 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+struct S(Vec<isize>);
 
-struct sty(Vec<isize> );
-
-fn unpack<F>(_unpack: F) where F: FnOnce(&sty) -> Vec<isize> {}
+fn unpack<F>(_unpack: F) where F: FnOnce(&S) -> Vec<isize> {}
 
 fn main() {
     let _foo = unpack(|s| {
         // Test that `s` is moved here.
-        match *s { sty(v) => v } //~ ERROR cannot move out
+        match *s { S(v) => v } //~ ERROR cannot move out
     });
 }

--- a/src/test/ui/access-mode-in-closures.stderr
+++ b/src/test/ui/access-mode-in-closures.stderr
@@ -1,8 +1,8 @@
 error[E0507]: cannot move out of borrowed content
-  --> $DIR/access-mode-in-closures.rs:19:15
+  --> $DIR/access-mode-in-closures.rs:18:15
    |
-LL |         match *s { sty(v) => v } //~ ERROR cannot move out
-   |               ^^       - hint: to prevent move, use `ref v` or `ref mut v`
+LL |         match *s { S(v) => v } //~ ERROR cannot move out
+   |               ^^     - hint: to prevent move, use `ref v` or `ref mut v`
    |               |
    |               cannot move out of borrowed content
 

--- a/src/test/ui/assign-to-method.rs
+++ b/src/test/ui/assign-to-method.rs
@@ -8,24 +8,24 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-struct cat {
+struct Cat {
   meows : usize,
 
   how_hungry : isize,
 }
 
-impl cat {
+impl Cat {
     pub fn speak(&self) { self.meows += 1; }
 }
 
-fn cat(in_x : usize, in_y : isize) -> cat {
-    cat {
+fn cat(in_x : usize, in_y : isize) -> Cat {
+    Cat {
         meows: in_x,
         how_hungry: in_y
     }
 }
 
 fn main() {
-  let nyan : cat = cat(52, 99);
+  let nyan : Cat = cat(52, 99);
   nyan.speak = || println!("meow"); //~ ERROR attempted to take value of method
 }

--- a/src/test/ui/assign-to-method.stderr
+++ b/src/test/ui/assign-to-method.stderr
@@ -1,4 +1,4 @@
-error[E0615]: attempted to take value of method `speak` on type `cat`
+error[E0615]: attempted to take value of method `speak` on type `Cat`
   --> $DIR/assign-to-method.rs:30:8
    |
 LL |   nyan.speak = || println!("meow"); //~ ERROR attempted to take value of method

--- a/src/test/ui/autoderef-full-lval.rs
+++ b/src/test/ui/autoderef-full-lval.rs
@@ -10,24 +10,24 @@
 
 #![feature(box_syntax)]
 
-struct clam {
+struct Clam {
     x: Box<isize>,
     y: Box<isize>,
 }
 
-struct fish {
+struct Fish {
     a: Box<isize>,
 }
 
 fn main() {
-    let a: clam = clam{x: box 1, y: box 2};
-    let b: clam = clam{x: box 10, y: box 20};
+    let a: Clam = Clam{x: box 1, y: box 2};
+    let b: Clam = Clam{x: box 10, y: box 20};
     let z: isize = a.x + b.y;
     //~^ ERROR binary operation `+` cannot be applied to type `std::boxed::Box<isize>`
     println!("{}", z);
     assert_eq!(z, 21);
-    let forty: fish = fish{a: box 40};
-    let two: fish = fish{a: box 2};
+    let forty: Fish = Fish{a: box 40};
+    let two: Fish = Fish{a: box 2};
     let answer: isize = forty.a + two.a;
     //~^ ERROR binary operation `+` cannot be applied to type `std::boxed::Box<isize>`
     println!("{}", answer);

--- a/src/test/ui/bad/bad-method-typaram-kind.rs
+++ b/src/test/ui/bad/bad-method-typaram-kind.rs
@@ -12,11 +12,11 @@ fn foo<T:'static>() {
     1.bar::<T>(); //~ ERROR `T` cannot be sent between threads safely
 }
 
-trait bar {
+trait Bar {
     fn bar<T:Send>(&self);
 }
 
-impl bar for usize {
+impl Bar for usize {
     fn bar<T:Send>(&self) {
     }
 }

--- a/src/test/ui/bind-by-move/bind-by-move-neither-can-live-while-the-other-survives-3.rs
+++ b/src/test/ui/bind-by-move/bind-by-move-neither-can-live-while-the-other-survives-3.rs
@@ -16,13 +16,13 @@ impl Drop for X {
     }
 }
 
-enum double_option<T,U> { some2(T,U), none2 }
+enum DoubleOption<T,U> { Some2(T,U), None2 }
 
 fn main() {
-    let x = double_option::some2(X { x: () }, X { x: () });
+    let x = DoubleOption::Some2(X { x: () }, X { x: () });
     match x {
-        double_option::some2(ref _y, _z) => { },
+        DoubleOption::Some2(ref _y, _z) => { },
         //~^ ERROR cannot bind by-move and by-ref in the same pattern
-        double_option::none2 => panic!()
+        DoubleOption::None2 => panic!()
     }
 }

--- a/src/test/ui/bind-by-move/bind-by-move-neither-can-live-while-the-other-survives-3.stderr
+++ b/src/test/ui/bind-by-move/bind-by-move-neither-can-live-while-the-other-survives-3.stderr
@@ -1,10 +1,10 @@
 error[E0009]: cannot bind by-move and by-ref in the same pattern
-  --> $DIR/bind-by-move-neither-can-live-while-the-other-survives-3.rs:24:38
+  --> $DIR/bind-by-move-neither-can-live-while-the-other-survives-3.rs:24:37
    |
-LL |         double_option::some2(ref _y, _z) => { },
-   |                              ------  ^^ by-move pattern here
-   |                              |
-   |                              both by-ref and by-move used
+LL |         DoubleOption::Some2(ref _y, _z) => { },
+   |                             ------  ^^ by-move pattern here
+   |                             |
+   |                             both by-ref and by-move used
 
 error: aborting due to previous error
 

--- a/src/test/ui/blind/blind-item-block-middle.rs
+++ b/src/test/ui/blind/blind-item-block-middle.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
+
 mod foo { pub struct bar; }
 
 fn main() {

--- a/src/test/ui/blind/blind-item-block-middle.stderr
+++ b/src/test/ui/blind/blind-item-block-middle.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/blind-item-block-middle.rs:14:9
+  --> $DIR/blind-item-block-middle.rs:16:9
    |
 LL |     let bar = 5;
    |         ^^^ expected integral variable, found struct `foo::bar`

--- a/src/test/ui/block-result/block-must-not-have-result-res.rs
+++ b/src/test/ui/block-result/block-must-not-have-result-res.rs
@@ -8,9 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-struct r;
+struct R;
 
-impl Drop for r {
+impl Drop for R {
     fn drop(&mut self) {
         true //~  ERROR mismatched types
     }

--- a/src/test/ui/bogus-tag.rs
+++ b/src/test/ui/bogus-tag.rs
@@ -8,14 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-
-enum color { rgb(isize, isize, isize), rgba(isize, isize, isize, isize), }
+enum Color { Rgb(isize, isize, isize), Rgba(isize, isize, isize, isize), }
 
 fn main() {
-    let red: color = color::rgb(255, 0, 0);
+    let red: Color = Color::Rgb(255, 0, 0);
     match red {
-      color::rgb(r, g, b) => { println!("rgb"); }
-      color::hsl(h, s, l) => { println!("hsl"); }
+      Color::Rgb(r, g, b) => { println!("rgb"); }
+      Color::Hsl(h, s, l) => { println!("hsl"); }
       //~^ ERROR no variant
     }
 }

--- a/src/test/ui/bogus-tag.stderr
+++ b/src/test/ui/bogus-tag.stderr
@@ -1,11 +1,11 @@
-error[E0599]: no variant named `hsl` found for type `color` in the current scope
-  --> $DIR/bogus-tag.rs:18:7
+error[E0599]: no variant named `Hsl` found for type `Color` in the current scope
+  --> $DIR/bogus-tag.rs:17:7
    |
-LL | enum color { rgb(isize, isize, isize), rgba(isize, isize, isize, isize), }
-   | ---------- variant `hsl` not found here
+LL | enum Color { Rgb(isize, isize, isize), Rgba(isize, isize, isize, isize), }
+   | ---------- variant `Hsl` not found here
 ...
-LL |       color::hsl(h, s, l) => { println!("hsl"); }
-   |       ^^^^^^^^^^^^^^^^^^^ variant not found in `color`
+LL |       Color::Hsl(h, s, l) => { println!("hsl"); }
+   |       ^^^^^^^^^^^^^^^^^^^ variant not found in `Color`
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-assign-comp.ast.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-assign-comp.ast.nll.stderr
@@ -15,7 +15,7 @@ error[E0506]: cannot assign to `p` because it is borrowed
    |
 LL |     let q = &p.y;
    |             ---- borrow of `p` occurs here
-LL |     p = point {x: 5, y: 7};//[ast]~ ERROR cannot assign to `p`
+LL |     p = Point {x: 5, y: 7};//[ast]~ ERROR cannot assign to `p`
    |     ^^^^^^^^^^^^^^^^^^^^^^ assignment to borrowed `p` occurs here
 ...
 LL |     *q; // stretch loan

--- a/src/test/ui/borrowck/borrowck-assign-comp.ast.stderr
+++ b/src/test/ui/borrowck/borrowck-assign-comp.ast.stderr
@@ -12,7 +12,7 @@ error[E0506]: cannot assign to `p` because it is borrowed
    |
 LL |     let q = &p.y;
    |              --- borrow of `p` occurs here
-LL |     p = point {x: 5, y: 7};//[ast]~ ERROR cannot assign to `p`
+LL |     p = Point {x: 5, y: 7};//[ast]~ ERROR cannot assign to `p`
    |     ^^^^^^^^^^^^^^^^^^^^^^ assignment to borrowed `p` occurs here
 
 error[E0506]: cannot assign to `p.y` because it is borrowed

--- a/src/test/ui/borrowck/borrowck-assign-comp.mir.stderr
+++ b/src/test/ui/borrowck/borrowck-assign-comp.mir.stderr
@@ -15,7 +15,7 @@ error[E0506]: cannot assign to `p` because it is borrowed
    |
 LL |     let q = &p.y;
    |             ---- borrow of `p` occurs here
-LL |     p = point {x: 5, y: 7};//[ast]~ ERROR cannot assign to `p`
+LL |     p = Point {x: 5, y: 7};//[ast]~ ERROR cannot assign to `p`
    |     ^^^^^^^^^^^^^^^^^^^^^^ assignment to borrowed `p` occurs here
 ...
 LL |     *q; // stretch loan

--- a/src/test/ui/borrowck/borrowck-assign-comp.rs
+++ b/src/test/ui/borrowck/borrowck-assign-comp.rs
@@ -11,10 +11,10 @@
 // revisions: ast mir
 //[mir]compile-flags: -Z borrowck=mir
 
-struct point { x: isize, y: isize }
+struct Point { x: isize, y: isize }
 
 fn a() {
-    let mut p = point {x: 3, y: 4};
+    let mut p = Point {x: 3, y: 4};
     let q = &p;
 
     // This assignment is illegal because the field x is not
@@ -29,9 +29,9 @@ fn c() {
     // this is sort of the opposite.  We take a loan to the interior of `p`
     // and then try to overwrite `p` as a whole.
 
-    let mut p = point {x: 3, y: 4};
+    let mut p = Point {x: 3, y: 4};
     let q = &p.y;
-    p = point {x: 5, y: 7};//[ast]~ ERROR cannot assign to `p`
+    p = Point {x: 5, y: 7};//[ast]~ ERROR cannot assign to `p`
                            //[mir]~^ ERROR cannot assign to `p` because it is borrowed
     p.x; // silence warning
     *q; // stretch loan
@@ -41,7 +41,7 @@ fn d() {
     // just for completeness's sake, the easy case, where we take the
     // address of a subcomponent and then modify that subcomponent:
 
-    let mut p = point {x: 3, y: 4};
+    let mut p = Point {x: 3, y: 4};
     let q = &p.y;
     p.y = 5; //[ast]~ ERROR cannot assign to `p.y`
              //[mir]~^ ERROR cannot assign to `p.y` because it is borrowed

--- a/src/test/ui/borrowck/borrowck-borrowed-uniq-rvalue-2.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-borrowed-uniq-rvalue-2.nll.stderr
@@ -1,7 +1,7 @@
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/borrowck-borrowed-uniq-rvalue-2.rs:32:20
+  --> $DIR/borrowck-borrowed-uniq-rvalue-2.rs:30:20
    |
-LL |     let x = defer(&vec!["Goodbye", "world!"]);
+LL |     let x = defer(&vec!["Goodbye", "world!"]); //~ ERROR borrowed value does not live long enough
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^ - temporary value is freed at the end of this statement
    |                    |
    |                    creates a temporary which is freed while still in use

--- a/src/test/ui/borrowck/borrowck-borrowed-uniq-rvalue-2.rs
+++ b/src/test/ui/borrowck/borrowck-borrowed-uniq-rvalue-2.rs
@@ -8,13 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: borrowed value does not live long enough
-
-struct defer<'a> {
+struct Defer<'a> {
     x: &'a [&'a str],
 }
 
-impl<'a> Drop for defer<'a> {
+impl<'a> Drop for Defer<'a> {
     fn drop(&mut self) {
         unsafe {
             println!("{:?}", self.x);
@@ -22,13 +20,13 @@ impl<'a> Drop for defer<'a> {
     }
 }
 
-fn defer<'r>(x: &'r [&'r str]) -> defer<'r> {
-    defer {
+fn defer<'r>(x: &'r [&'r str]) -> Defer<'r> {
+    Defer {
         x: x
     }
 }
 
 fn main() {
-    let x = defer(&vec!["Goodbye", "world!"]);
+    let x = defer(&vec!["Goodbye", "world!"]); //~ ERROR borrowed value does not live long enough
     x.x[0];
 }

--- a/src/test/ui/borrowck/borrowck-borrowed-uniq-rvalue-2.stderr
+++ b/src/test/ui/borrowck/borrowck-borrowed-uniq-rvalue-2.stderr
@@ -1,7 +1,7 @@
 error[E0597]: borrowed value does not live long enough
-  --> $DIR/borrowck-borrowed-uniq-rvalue-2.rs:32:20
+  --> $DIR/borrowck-borrowed-uniq-rvalue-2.rs:30:20
    |
-LL |     let x = defer(&vec!["Goodbye", "world!"]);
+LL |     let x = defer(&vec!["Goodbye", "world!"]); //~ ERROR borrowed value does not live long enough
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^ - temporary value dropped here while still borrowed
    |                    |
    |                    temporary value does not live long enough

--- a/src/test/ui/borrowck/borrowck-init-in-fru.ast.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-init-in-fru.ast.nll.stderr
@@ -1,8 +1,8 @@
 error[E0381]: use of possibly uninitialized variable: `origin`
   --> $DIR/borrowck-init-in-fru.rs:22:5
    |
-LL |     origin = point {x: 10,.. origin};
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of possibly uninitialized `origin.y`
+LL |     origin = Point { x: 10, ..origin };
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of possibly uninitialized `origin.y`
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-init-in-fru.ast.stderr
+++ b/src/test/ui/borrowck/borrowck-init-in-fru.ast.stderr
@@ -1,8 +1,8 @@
 error[E0381]: use of possibly uninitialized variable: `origin.y`
-  --> $DIR/borrowck-init-in-fru.rs:22:30
+  --> $DIR/borrowck-init-in-fru.rs:22:31
    |
-LL |     origin = point {x: 10,.. origin};
-   |                              ^^^^^^ use of possibly uninitialized `origin.y`
+LL |     origin = Point { x: 10, ..origin };
+   |                               ^^^^^^ use of possibly uninitialized `origin.y`
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-init-in-fru.mir.stderr
+++ b/src/test/ui/borrowck/borrowck-init-in-fru.mir.stderr
@@ -1,8 +1,8 @@
 error[E0381]: use of possibly uninitialized variable: `origin`
   --> $DIR/borrowck-init-in-fru.rs:22:5
    |
-LL |     origin = point {x: 10,.. origin};
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of possibly uninitialized `origin.y`
+LL |     origin = Point { x: 10, ..origin };
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of possibly uninitialized `origin.y`
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-init-in-fru.rs
+++ b/src/test/ui/borrowck/borrowck-init-in-fru.rs
@@ -12,14 +12,14 @@
 //[mir]compile-flags: -Z borrowck=mir
 
 #[derive(Clone)]
-struct point {
+struct Point {
     x: isize,
     y: isize,
 }
 
 fn main() {
-    let mut origin: point;
-    origin = point {x: 10,.. origin};
+    let mut origin: Point;
+    origin = Point { x: 10, ..origin };
     //[ast]~^ ERROR use of possibly uninitialized variable: `origin.y` [E0381]
     //[mir]~^^ ERROR [E0381]
     origin.clone();

--- a/src/test/ui/borrowck/borrowck-loan-in-overloaded-op.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-loan-in-overloaded-op.nll.stderr
@@ -6,7 +6,7 @@ LL |     let _y = {x} + x.clone(); // the `{x}` forces a move to occur
    |               |
    |               value moved here
    |
-   = note: move occurs because `x` has type `foo`, which does not implement the `Copy` trait
+   = note: move occurs because `x` has type `Foo`, which does not implement the `Copy` trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-loan-in-overloaded-op.rs
+++ b/src/test/ui/borrowck/borrowck-loan-in-overloaded-op.rs
@@ -14,20 +14,20 @@
 use std::ops::Add;
 
 #[derive(Clone)]
-struct foo(Box<usize>);
+struct Foo(Box<usize>);
 
-impl Add for foo {
-    type Output = foo;
+impl Add for Foo {
+    type Output = Foo;
 
-    fn add(self, f: foo) -> foo {
-        let foo(box i) = self;
-        let foo(box j) = f;
-        foo(box (i + j))
+    fn add(self, f: Foo) -> Foo {
+        let Foo(box i) = self;
+        let Foo(box j) = f;
+        Foo(box (i + j))
     }
 }
 
 fn main() {
-    let x = foo(box 3);
+    let x = Foo(box 3);
     let _y = {x} + x.clone(); // the `{x}` forces a move to occur
     //~^ ERROR use of moved value: `x`
 }

--- a/src/test/ui/borrowck/borrowck-loan-in-overloaded-op.stderr
+++ b/src/test/ui/borrowck/borrowck-loan-in-overloaded-op.stderr
@@ -6,7 +6,7 @@ LL |     let _y = {x} + x.clone(); // the `{x}` forces a move to occur
    |               |
    |               value moved here
    |
-   = note: move occurs because `x` has type `foo`, which does not implement the `Copy` trait
+   = note: move occurs because `x` has type `Foo`, which does not implement the `Copy` trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-loan-rcvr.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-loan-rcvr.nll.stderr
@@ -1,5 +1,5 @@
 error[E0502]: cannot borrow `p` as mutable because it is also borrowed as immutable
-  --> $DIR/borrowck-loan-rcvr.rs:34:14
+  --> $DIR/borrowck-loan-rcvr.rs:33:14
    |
 LL |     p.blockm(|| { //~ ERROR cannot borrow `p` as mutable
    |     - ------ ^^ mutable borrow occurs here
@@ -10,7 +10,7 @@ LL |         p.x = 10;
    |         - second borrow occurs due to use of `p` in closure
 
 error[E0502]: cannot borrow `p` as immutable because it is also borrowed as mutable
-  --> $DIR/borrowck-loan-rcvr.rs:45:5
+  --> $DIR/borrowck-loan-rcvr.rs:44:5
    |
 LL |     let l = &mut p;
    |             ------ mutable borrow occurs here

--- a/src/test/ui/borrowck/borrowck-loan-rcvr.rs
+++ b/src/test/ui/borrowck/borrowck-loan-rcvr.rs
@@ -8,15 +8,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+struct Point { x: isize, y: isize }
 
-struct point { x: isize, y: isize }
-
-trait methods {
+trait Methods {
     fn impurem(&self);
     fn blockm<F>(&self, f: F) where F: FnOnce();
 }
 
-impl methods for point {
+impl Methods for Point {
     fn impurem(&self) {
     }
 
@@ -24,7 +23,7 @@ impl methods for point {
 }
 
 fn a() {
-    let mut p = point {x: 3, y: 4};
+    let mut p = Point {x: 3, y: 4};
 
     // Here: it's ok to call even though receiver is mutable, because we
     // can loan it out.
@@ -37,7 +36,7 @@ fn a() {
 }
 
 fn b() {
-    let mut p = point {x: 3, y: 4};
+    let mut p = Point {x: 3, y: 4};
 
     // Here I create an outstanding loan and check that we get conflicts:
 

--- a/src/test/ui/borrowck/borrowck-loan-rcvr.stderr
+++ b/src/test/ui/borrowck/borrowck-loan-rcvr.stderr
@@ -1,5 +1,5 @@
 error[E0502]: cannot borrow `p` as mutable because it is also borrowed as immutable
-  --> $DIR/borrowck-loan-rcvr.rs:34:14
+  --> $DIR/borrowck-loan-rcvr.rs:33:14
    |
 LL |     p.blockm(|| { //~ ERROR cannot borrow `p` as mutable
    |     -        ^^ mutable borrow occurs here
@@ -11,7 +11,7 @@ LL |     })
    |      - immutable borrow ends here
 
 error[E0502]: cannot borrow `p` as immutable because it is also borrowed as mutable
-  --> $DIR/borrowck-loan-rcvr.rs:45:5
+  --> $DIR/borrowck-loan-rcvr.rs:44:5
    |
 LL |     let l = &mut p;
    |                  - mutable borrow occurs here

--- a/src/test/ui/borrowck/borrowck-no-cycle-in-exchange-heap.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-no-cycle-in-exchange-heap.nll.stderr
@@ -1,7 +1,7 @@
 error[E0505]: cannot move out of `x` because it is borrowed
   --> $DIR/borrowck-no-cycle-in-exchange-heap.rs:26:15
    |
-LL |       cycle::node(ref mut y) => {
+LL |       Cycle::Node(ref mut y) => {
    |                   --------- borrow of `x.0` occurs here
 LL |         y.a = x; //~ ERROR cannot move out of
    |         ---   ^ move out of `x` occurs here

--- a/src/test/ui/borrowck/borrowck-no-cycle-in-exchange-heap.rs
+++ b/src/test/ui/borrowck/borrowck-no-cycle-in-exchange-heap.rs
@@ -10,21 +10,21 @@
 
 #![feature(box_syntax)]
 
-struct node_ {
-    a: Box<cycle>
+struct Node_ {
+    a: Box<Cycle>
 }
 
-enum cycle {
-    node(node_),
-    empty
+enum Cycle {
+    Node(Node_),
+    Empty,
 }
 fn main() {
-    let mut x: Box<_> = box cycle::node(node_ {a: box cycle::empty});
+    let mut x: Box<_> = box Cycle::Node(Node_ {a: box Cycle::Empty});
     // Create a cycle!
     match *x {
-      cycle::node(ref mut y) => {
+      Cycle::Node(ref mut y) => {
         y.a = x; //~ ERROR cannot move out of
       }
-      cycle::empty => {}
+      Cycle::Empty => {}
     };
 }

--- a/src/test/ui/borrowck/borrowck-no-cycle-in-exchange-heap.stderr
+++ b/src/test/ui/borrowck/borrowck-no-cycle-in-exchange-heap.stderr
@@ -1,7 +1,7 @@
 error[E0505]: cannot move out of `x` because it is borrowed
   --> $DIR/borrowck-no-cycle-in-exchange-heap.rs:26:15
    |
-LL |       cycle::node(ref mut y) => {
+LL |       Cycle::Node(ref mut y) => {
    |                   --------- borrow of `x.0` occurs here
 LL |         y.a = x; //~ ERROR cannot move out of
    |               ^ move out of `x` occurs here

--- a/src/test/ui/class-cast-to-trait.rs
+++ b/src/test/ui/class-cast-to-trait.rs
@@ -10,18 +10,18 @@
 
 #![feature(box_syntax)]
 
-trait noisy {
+trait Noisy {
   fn speak(&self);
 }
 
-struct cat {
+struct Cat {
   meows : usize,
 
   how_hungry : isize,
   name : String,
 }
 
-impl cat {
+impl Cat {
   pub fn eat(&self) -> bool {
     if self.how_hungry > 0 {
         println!("OM NOM NOM");
@@ -35,12 +35,12 @@ impl cat {
   }
 }
 
-impl noisy for cat {
+impl Noisy for Cat {
   fn speak(&self) { self.meow(); }
 
 }
 
-impl cat {
+impl Cat {
     fn meow(&self) {
       println!("Meow");
       self.meows += 1;
@@ -50,8 +50,8 @@ impl cat {
     }
 }
 
-fn cat(in_x : usize, in_y : isize, in_name: String) -> cat {
-    cat {
+fn cat(in_x : usize, in_y : isize, in_name: String) -> Cat {
+    Cat {
         meows: in_x,
         how_hungry: in_y,
         name: in_name
@@ -59,6 +59,6 @@ fn cat(in_x : usize, in_y : isize, in_name: String) -> cat {
 }
 
 fn main() {
-  let nyan: Box<noisy> = box cat(0, 2, "nyan".to_string()) as Box<noisy>;
+  let nyan: Box<Noisy> = box cat(0, 2, "nyan".to_string()) as Box<Noisy>;
   nyan.eat(); //~ ERROR no method named `eat` found
 }

--- a/src/test/ui/class-cast-to-trait.stderr
+++ b/src/test/ui/class-cast-to-trait.stderr
@@ -1,4 +1,4 @@
-error[E0599]: no method named `eat` found for type `std::boxed::Box<dyn noisy>` in the current scope
+error[E0599]: no method named `eat` found for type `std::boxed::Box<dyn Noisy>` in the current scope
   --> $DIR/class-cast-to-trait.rs:63:8
    |
 LL |   nyan.eat(); //~ ERROR no method named `eat` found

--- a/src/test/ui/class-method-missing.rs
+++ b/src/test/ui/class-method-missing.rs
@@ -8,20 +8,20 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-trait animal {
+trait Animal {
   fn eat(&self);
 }
 
-struct cat {
+struct Cat {
   meows: usize,
 }
 
-impl animal for cat {
+impl Animal for Cat {
     //~^ ERROR not all trait items implemented, missing: `eat`
 }
 
-fn cat(in_x : usize) -> cat {
-    cat {
+fn cat(in_x : usize) -> Cat {
+    Cat {
         meows: in_x
     }
 }

--- a/src/test/ui/class-method-missing.stderr
+++ b/src/test/ui/class-method-missing.stderr
@@ -4,7 +4,7 @@ error[E0046]: not all trait items implemented, missing: `eat`
 LL |   fn eat(&self);
    |   -------------- `eat` from trait
 ...
-LL | impl animal for cat {
+LL | impl Animal for Cat {
    | ^^^^^^^^^^^^^^^^^^^ missing `eat` in implementation
 
 error: aborting due to previous error

--- a/src/test/ui/class-missing-self.rs
+++ b/src/test/ui/class-missing-self.rs
@@ -8,11 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-struct cat {
+struct Cat {
   meows : usize,
 }
 
-impl cat {
+impl Cat {
     fn sleep(&self) { loop{} }
     fn meow(&self) {
       println!("Meow");

--- a/src/test/ui/copy-a-resource.rs
+++ b/src/test/ui/copy-a-resource.rs
@@ -9,16 +9,16 @@
 // except according to those terms.
 
 #[derive(Debug)]
-struct foo {
+struct Foo {
   i: isize,
 }
 
-impl Drop for foo {
+impl Drop for Foo {
     fn drop(&mut self) {}
 }
 
-fn foo(i:isize) -> foo {
-    foo {
+fn foo(i:isize) -> Foo {
+    Foo {
         i: i
     }
 }

--- a/src/test/ui/copy-a-resource.stderr
+++ b/src/test/ui/copy-a-resource.stderr
@@ -1,7 +1,7 @@
-error[E0599]: no method named `clone` found for type `foo` in the current scope
+error[E0599]: no method named `clone` found for type `Foo` in the current scope
   --> $DIR/copy-a-resource.rs:28:16
    |
-LL | struct foo {
+LL | struct Foo {
    | ---------- method `clone` not found for this
 ...
 LL |     let _y = x.clone();

--- a/src/test/ui/enum/enum-in-scope.rs
+++ b/src/test/ui/enum/enum-in-scope.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
+
 struct hello(isize);
 
 fn main() {

--- a/src/test/ui/enum/enum-in-scope.stderr
+++ b/src/test/ui/enum/enum-in-scope.stderr
@@ -1,5 +1,5 @@
 error[E0530]: let bindings cannot shadow tuple structs
-  --> $DIR/enum-in-scope.rs:14:9
+  --> $DIR/enum-in-scope.rs:16:9
    |
 LL | struct hello(isize);
    | -------------------- the tuple struct `hello` is defined here

--- a/src/test/ui/error-codes/E0252.rs
+++ b/src/test/ui/error-codes/E0252.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
+
 use foo::baz;
 use bar::baz; //~ ERROR E0252
 

--- a/src/test/ui/error-codes/E0252.stderr
+++ b/src/test/ui/error-codes/E0252.stderr
@@ -1,5 +1,5 @@
 error[E0252]: the name `baz` is defined multiple times
-  --> $DIR/E0252.rs:12:5
+  --> $DIR/E0252.rs:14:5
    |
 LL | use foo::baz;
    |     -------- previous import of the type `baz` here

--- a/src/test/ui/error-codes/E0254.rs
+++ b/src/test/ui/error-codes/E0254.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 #![feature(alloc)]
-#![allow(unused_extern_crates)]
+#![allow(unused_extern_crates, non_camel_case_types)]
 
 extern crate alloc;
 

--- a/src/test/ui/error-codes/E0440.rs
+++ b/src/test/ui/error-codes/E0440.rs
@@ -10,6 +10,7 @@
 
 #![feature(repr_simd)]
 #![feature(platform_intrinsics)]
+#![allow(non_camel_case_types)]
 
 #[repr(simd)]
 struct f64x2(f64, f64);

--- a/src/test/ui/error-codes/E0440.stderr
+++ b/src/test/ui/error-codes/E0440.stderr
@@ -1,5 +1,5 @@
 error[E0440]: platform-specific intrinsic has wrong number of type parameters: found 1, expected 0
-  --> $DIR/E0440.rs:18:5
+  --> $DIR/E0440.rs:19:5
    |
 LL |     fn x86_mm_movemask_pd<T>(x: f64x2) -> i32; //~ ERROR E0440
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/error-codes/E0441.rs
+++ b/src/test/ui/error-codes/E0441.rs
@@ -10,6 +10,7 @@
 
 #![feature(repr_simd)]
 #![feature(platform_intrinsics)]
+#![allow(non_camel_case_types)]
 
 #[repr(simd)]
 struct i16x8(i16, i16, i16, i16, i16, i16, i16, i16);

--- a/src/test/ui/error-codes/E0441.stderr
+++ b/src/test/ui/error-codes/E0441.stderr
@@ -1,5 +1,5 @@
 error[E0441]: unrecognized platform-specific intrinsic function: `x86_mm_adds_ep16`
-  --> $DIR/E0441.rs:18:5
+  --> $DIR/E0441.rs:19:5
    |
 LL |     fn x86_mm_adds_ep16(x: i16x8, y: i16x8) -> i16x8; //~ ERROR E0441
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/error-codes/E0442.rs
+++ b/src/test/ui/error-codes/E0442.rs
@@ -10,6 +10,7 @@
 
 #![feature(repr_simd)]
 #![feature(platform_intrinsics)]
+#![allow(non_camel_case_types)]
 
 #[repr(simd)]
 struct i8x16(i8, i8, i8, i8, i8, i8, i8, i8,

--- a/src/test/ui/error-codes/E0442.stderr
+++ b/src/test/ui/error-codes/E0442.stderr
@@ -1,17 +1,17 @@
 error[E0442]: intrinsic argument 1 has wrong type: found vector with length 16, expected length 8
-  --> $DIR/E0442.rs:23:5
+  --> $DIR/E0442.rs:24:5
    |
 LL |     fn x86_mm_adds_epi16(x: i8x16, y: i32x4) -> i64x2;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0442]: intrinsic argument 2 has wrong type: found vector with length 4, expected length 8
-  --> $DIR/E0442.rs:23:5
+  --> $DIR/E0442.rs:24:5
    |
 LL |     fn x86_mm_adds_epi16(x: i8x16, y: i32x4) -> i64x2;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0442]: intrinsic return value has wrong type: found vector with length 2, expected length 8
-  --> $DIR/E0442.rs:23:5
+  --> $DIR/E0442.rs:24:5
    |
 LL |     fn x86_mm_adds_epi16(x: i8x16, y: i32x4) -> i64x2;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/error-codes/E0443.rs
+++ b/src/test/ui/error-codes/E0443.rs
@@ -10,6 +10,7 @@
 
 #![feature(repr_simd)]
 #![feature(platform_intrinsics)]
+#![allow(non_camel_case_types)]
 
 #[repr(simd)]
 struct i16x8(i16, i16, i16, i16, i16, i16, i16, i16);

--- a/src/test/ui/error-codes/E0443.stderr
+++ b/src/test/ui/error-codes/E0443.stderr
@@ -1,5 +1,5 @@
 error[E0443]: intrinsic return value has wrong type: found `i64x8`, expected `i16x8` which was used for this vector type previously in this signature
-  --> $DIR/E0443.rs:20:5
+  --> $DIR/E0443.rs:21:5
    |
 LL |     fn x86_mm_adds_epi16(x: i16x8, y: i16x8) -> i64x8; //~ ERROR E0443
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/error-codes/E0444.rs
+++ b/src/test/ui/error-codes/E0444.rs
@@ -10,6 +10,7 @@
 
 #![feature(repr_simd)]
 #![feature(platform_intrinsics)]
+#![allow(non_camel_case_types)]
 
 #[repr(simd)]
 struct f64x2(f64, f64);

--- a/src/test/ui/error-codes/E0444.stderr
+++ b/src/test/ui/error-codes/E0444.stderr
@@ -1,5 +1,5 @@
 error[E0444]: platform-specific intrinsic has invalid number of arguments: found 3, expected 1
-  --> $DIR/E0444.rs:18:5
+  --> $DIR/E0444.rs:19:5
    |
 LL |     fn x86_mm_movemask_pd(x: f64x2, y: f64x2, z: f64x2) -> i32; //~ ERROR E0444
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/export-tag-variant.rs
+++ b/src/test/ui/export-tag-variant.rs
@@ -11,7 +11,7 @@
 mod foo {
     pub fn x() { }
 
-    enum y { y1, }
+    enum Y { Y1 }
 }
 
-fn main() { let z = foo::y::y1; } //~ ERROR: enum `y` is private
+fn main() { let z = foo::Y::Y1; } //~ ERROR: enum `Y` is private

--- a/src/test/ui/export-tag-variant.stderr
+++ b/src/test/ui/export-tag-variant.stderr
@@ -1,7 +1,7 @@
-error[E0603]: enum `y` is private
+error[E0603]: enum `Y` is private
   --> $DIR/export-tag-variant.rs:17:26
    |
-LL | fn main() { let z = foo::y::y1; } //~ ERROR: enum `y` is private
+LL | fn main() { let z = foo::Y::Y1; } //~ ERROR: enum `Y` is private
    |                          ^
 
 error: aborting due to previous error

--- a/src/test/ui/fully-qualified-type/fully-qualified-type-name2.rs
+++ b/src/test/ui/fully-qualified-type/fully-qualified-type-name2.rs
@@ -11,19 +11,19 @@
 // Test that we use fully-qualified type names in error messages.
 
 mod x {
-    pub enum foo { }
+    pub enum Foo { }
 }
 
 mod y {
-    pub enum foo { }
+    pub enum Foo { }
 }
 
-fn bar(x: x::foo) -> y::foo {
+fn bar(x: x::Foo) -> y::Foo {
     return x;
     //~^ ERROR mismatched types
-    //~| expected type `y::foo`
-    //~| found type `x::foo`
-    //~| expected enum `y::foo`, found enum `x::foo`
+    //~| expected type `y::Foo`
+    //~| found type `x::Foo`
+    //~| expected enum `y::Foo`, found enum `x::Foo`
 }
 
 fn main() {

--- a/src/test/ui/fully-qualified-type/fully-qualified-type-name2.stderr
+++ b/src/test/ui/fully-qualified-type/fully-qualified-type-name2.stderr
@@ -2,10 +2,10 @@ error[E0308]: mismatched types
   --> $DIR/fully-qualified-type-name2.rs:22:12
    |
 LL |     return x;
-   |            ^ expected enum `y::foo`, found enum `x::foo`
+   |            ^ expected enum `y::Foo`, found enum `x::Foo`
    |
-   = note: expected type `y::foo`
-              found type `x::foo`
+   = note: expected type `y::Foo`
+              found type `x::Foo`
 
 error: aborting due to previous error
 

--- a/src/test/ui/infinite/infinite-tag-type-recursion.rs
+++ b/src/test/ui/infinite/infinite-tag-type-recursion.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-enum mlist { cons(isize, mlist), nil, }
-//~^ ERROR recursive type `mlist` has infinite size
+enum MList { Cons(isize, MList), Nil }
+//~^ ERROR recursive type `MList` has infinite size
 
-fn main() { let a = mlist::cons(10, mlist::cons(11, mlist::nil)); }
+fn main() { let a = MList::Cons(10, MList::Cons(11, MList::Nil)); }

--- a/src/test/ui/infinite/infinite-tag-type-recursion.stderr
+++ b/src/test/ui/infinite/infinite-tag-type-recursion.stderr
@@ -1,12 +1,12 @@
-error[E0072]: recursive type `mlist` has infinite size
+error[E0072]: recursive type `MList` has infinite size
   --> $DIR/infinite-tag-type-recursion.rs:11:1
    |
-LL | enum mlist { cons(isize, mlist), nil, }
+LL | enum MList { Cons(isize, MList), Nil }
    | ^^^^^^^^^^               ----- recursive without indirection
    | |
    | recursive type has infinite size
    |
-   = help: insert indirection (e.g., a `Box`, `Rc`, or `&`) at some point to make `mlist` representable
+   = help: insert indirection (e.g., a `Box`, `Rc`, or `&`) at some point to make `MList` representable
 
 error: aborting due to previous error
 

--- a/src/test/ui/infinite/infinite-vec-type-recursion.rs
+++ b/src/test/ui/infinite/infinite-vec-type-recursion.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-type x = Vec<x>;
+type X = Vec<X>;
 //~^ ERROR cycle detected
 
-fn main() { let b: x = Vec::new(); }
+fn main() { let b: X = Vec::new(); }

--- a/src/test/ui/infinite/infinite-vec-type-recursion.stderr
+++ b/src/test/ui/infinite/infinite-vec-type-recursion.stderr
@@ -1,10 +1,10 @@
-error[E0391]: cycle detected when processing `x`
+error[E0391]: cycle detected when processing `X`
   --> $DIR/infinite-vec-type-recursion.rs:11:14
    |
-LL | type x = Vec<x>;
+LL | type X = Vec<X>;
    |              ^
    |
-   = note: ...which again requires processing `x`, completing the cycle
+   = note: ...which again requires processing `X`, completing the cycle
 
 error: aborting due to previous error
 

--- a/src/test/ui/intrinsic-invalid-number-of-arguments.rs
+++ b/src/test/ui/intrinsic-invalid-number-of-arguments.rs
@@ -12,6 +12,7 @@
 // This is the error E0444
 
 #![feature(repr_simd, platform_intrinsics)]
+#![allow(non_camel_case_types)]
 
 #[repr(simd)]
 struct f64x2(f64, f64);

--- a/src/test/ui/intrinsic-invalid-number-of-arguments.stderr
+++ b/src/test/ui/intrinsic-invalid-number-of-arguments.stderr
@@ -1,5 +1,5 @@
 error[E0444]: platform-specific intrinsic has invalid number of arguments: found 3, expected 1
-  --> $DIR/intrinsic-invalid-number-of-arguments.rs:20:5
+  --> $DIR/intrinsic-invalid-number-of-arguments.rs:21:5
    |
 LL |     fn x86_mm_movemask_pd(x: f64x2, y: f64x2, z: f64x2) -> i32; //~ platform-specific intrinsic
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/issues/issue-12511.rs
+++ b/src/test/ui/issues/issue-12511.rs
@@ -8,11 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-trait t1 : t2 {
+trait T1 : T2 {
 //~^ ERROR cycle detected
 }
 
-trait t2 : t1 {
+trait T2 : T1 {
 }
 
 fn main() { }

--- a/src/test/ui/issues/issue-12511.stderr
+++ b/src/test/ui/issues/issue-12511.stderr
@@ -1,15 +1,15 @@
-error[E0391]: cycle detected when computing the supertraits of `t1`
+error[E0391]: cycle detected when computing the supertraits of `T1`
   --> $DIR/issue-12511.rs:11:12
    |
-LL | trait t1 : t2 {
+LL | trait T1 : T2 {
    |            ^^
    |
-note: ...which requires computing the supertraits of `t2`...
+note: ...which requires computing the supertraits of `T2`...
   --> $DIR/issue-12511.rs:15:12
    |
-LL | trait t2 : t1 {
+LL | trait T2 : T1 {
    |            ^^
-   = note: ...which again requires computing the supertraits of `t1`, completing the cycle
+   = note: ...which again requires computing the supertraits of `T1`, completing the cycle
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-14541.rs
+++ b/src/test/ui/issues/issue-14541.rs
@@ -8,15 +8,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-struct vec2 { y: f32 }
-struct vec3 { y: f32, z: f32 }
+struct Vec2 { y: f32 }
+struct Vec3 { y: f32, z: f32 }
 
-fn make(v: vec2) {
-    let vec3 { y: _, z: _ } = v;
+fn make(v: Vec2) {
+    let Vec3 { y: _, z: _ } = v;
     //~^ ERROR mismatched types
-    //~| expected type `vec2`
-    //~| found type `vec3`
-    //~| expected struct `vec2`, found struct `vec3`
+    //~| expected type `Vec2`
+    //~| found type `Vec3`
+    //~| expected struct `Vec2`, found struct `Vec3`
 }
 
 fn main() { }

--- a/src/test/ui/issues/issue-14541.stderr
+++ b/src/test/ui/issues/issue-14541.stderr
@@ -1,11 +1,11 @@
 error[E0308]: mismatched types
   --> $DIR/issue-14541.rs:15:9
    |
-LL |     let vec3 { y: _, z: _ } = v;
-   |         ^^^^^^^^^^^^^^^^^^^ expected struct `vec2`, found struct `vec3`
+LL |     let Vec3 { y: _, z: _ } = v;
+   |         ^^^^^^^^^^^^^^^^^^^ expected struct `Vec2`, found struct `Vec3`
    |
-   = note: expected type `vec2`
-              found type `vec3`
+   = note: expected type `Vec2`
+              found type `Vec3`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-19707.rs
+++ b/src/test/ui/issues/issue-19707.rs
@@ -10,7 +10,7 @@
 
 #![allow(dead_code)]
 
-type foo = fn(&u8, &u8) -> &u8; //~ ERROR missing lifetime specifier
+type Foo = fn(&u8, &u8) -> &u8; //~ ERROR missing lifetime specifier
 
 fn bar<F: Fn(&u8, &u8) -> &u8>(f: &F) {} //~ ERROR missing lifetime specifier
 

--- a/src/test/ui/issues/issue-19707.stderr
+++ b/src/test/ui/issues/issue-19707.stderr
@@ -1,7 +1,7 @@
 error[E0106]: missing lifetime specifier
   --> $DIR/issue-19707.rs:13:28
    |
-LL | type foo = fn(&u8, &u8) -> &u8; //~ ERROR missing lifetime specifier
+LL | type Foo = fn(&u8, &u8) -> &u8; //~ ERROR missing lifetime specifier
    |                            ^ expected lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from argument 1 or argument 2

--- a/src/test/ui/issues/issue-2149.rs
+++ b/src/test/ui/issues/issue-2149.rs
@@ -8,11 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-trait vec_monad<A> {
+trait VecMonad<A> {
     fn bind<B, F>(&self, f: F) where F: FnMut(A) -> Vec<B>;
 }
 
-impl<A> vec_monad<A> for Vec<A> {
+impl<A> VecMonad<A> for Vec<A> {
     fn bind<B, F>(&self, mut f: F) where F: FnMut(A) -> Vec<B> {
         let mut r = panic!();
         for elt in self { r = r + f(*elt); }

--- a/src/test/ui/issues/issue-2149.stderr
+++ b/src/test/ui/issues/issue-2149.stderr
@@ -14,7 +14,7 @@ LL |     ["hi"].bind(|x| [x] );
    |
    = help: items from traits can only be used if the trait is implemented and in scope
    = note: the following trait defines an item `bind`, perhaps you need to implement it:
-           candidate #1: `vec_monad`
+           candidate #1: `VecMonad`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-2330.rs
+++ b/src/test/ui/issues/issue-2330.rs
@@ -8,14 +8,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-enum chan { }
+enum Chan { }
 
-trait channel<T> {
+trait Channel<T> {
     fn send(&self, v: T);
 }
 
-// `chan` is not a trait, it's an enum
-impl chan for isize { //~ ERROR expected trait, found enum `chan`
+// `Chan` is not a trait, it's an enum
+impl Chan for isize { //~ ERROR expected trait, found enum `Chan`
     fn send(&self, v: isize) { panic!() }
 }
 

--- a/src/test/ui/issues/issue-2330.stderr
+++ b/src/test/ui/issues/issue-2330.stderr
@@ -1,7 +1,7 @@
-error[E0404]: expected trait, found enum `chan`
+error[E0404]: expected trait, found enum `Chan`
   --> $DIR/issue-2330.rs:18:6
    |
-LL | impl chan for isize { //~ ERROR expected trait, found enum `chan`
+LL | impl Chan for isize { //~ ERROR expected trait, found enum `Chan`
    |      ^^^^ not a trait
 
 error: aborting due to previous error

--- a/src/test/ui/issues/issue-25396.rs
+++ b/src/test/ui/issues/issue-25396.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
+
 use foo::baz;
 use bar::baz; //~ ERROR the name `baz` is defined multiple times
 

--- a/src/test/ui/issues/issue-25396.stderr
+++ b/src/test/ui/issues/issue-25396.stderr
@@ -1,5 +1,5 @@
 error[E0252]: the name `baz` is defined multiple times
-  --> $DIR/issue-25396.rs:12:5
+  --> $DIR/issue-25396.rs:14:5
    |
 LL | use foo::baz;
    |     -------- previous import of the module `baz` here
@@ -13,7 +13,7 @@ LL | use bar::baz as other_baz; //~ ERROR the name `baz` is defined multiple tim
    |     ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0252]: the name `Quux` is defined multiple times
-  --> $DIR/issue-25396.rs:15:5
+  --> $DIR/issue-25396.rs:17:5
    |
 LL | use foo::Quux;
    |     --------- previous import of the trait `Quux` here
@@ -27,7 +27,7 @@ LL | use bar::Quux as OtherQuux; //~ ERROR the name `Quux` is defined multiple t
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0252]: the name `blah` is defined multiple times
-  --> $DIR/issue-25396.rs:18:5
+  --> $DIR/issue-25396.rs:20:5
    |
 LL | use foo::blah;
    |     --------- previous import of the type `blah` here
@@ -41,7 +41,7 @@ LL | use bar::blah as other_blah; //~ ERROR the name `blah` is defined multiple 
    |     ^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0252]: the name `WOMP` is defined multiple times
-  --> $DIR/issue-25396.rs:21:5
+  --> $DIR/issue-25396.rs:23:5
    |
 LL | use foo::WOMP;
    |     --------- previous import of the value `WOMP` here

--- a/src/test/ui/issues/issue-2590.nll.stderr
+++ b/src/test/ui/issues/issue-2590.nll.stderr
@@ -1,5 +1,5 @@
 error[E0507]: cannot move out of borrowed content
-  --> $DIR/issue-2590.rs:22:9
+  --> $DIR/issue-2590.rs:21:9
    |
 LL |         self.tokens //~ ERROR cannot move out of borrowed content
    |         ^^^^^^^^^^^ cannot move out of borrowed content

--- a/src/test/ui/issues/issue-2590.rs
+++ b/src/test/ui/issues/issue-2590.rs
@@ -8,16 +8,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-
-struct parser {
+struct Parser {
     tokens: Vec<isize> ,
 }
 
-trait parse {
+trait Parse {
     fn parse(&self) -> Vec<isize> ;
 }
 
-impl parse for parser {
+impl Parse for Parser {
     fn parse(&self) -> Vec<isize> {
         self.tokens //~ ERROR cannot move out of borrowed content
     }

--- a/src/test/ui/issues/issue-2590.stderr
+++ b/src/test/ui/issues/issue-2590.stderr
@@ -1,5 +1,5 @@
 error[E0507]: cannot move out of borrowed content
-  --> $DIR/issue-2590.rs:22:9
+  --> $DIR/issue-2590.rs:21:9
    |
 LL |         self.tokens //~ ERROR cannot move out of borrowed content
    |         ^^^^ cannot move out of borrowed content

--- a/src/test/ui/issues/issue-2718-a.rs
+++ b/src/test/ui/issues/issue-2718-a.rs
@@ -8,15 +8,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-pub struct send_packet<T> {
+pub struct SendPacket<T> {
     p: T
 }
 
 mod pingpong {
-    use send_packet;
-    pub type ping = send_packet<pong>;
-    pub struct pong(send_packet<ping>);
-    //~^ ERROR recursive type `pingpong::pong` has infinite size
+    use SendPacket;
+    pub type Ping = SendPacket<Pong>;
+    pub struct Pong(SendPacket<Ping>);
+    //~^ ERROR recursive type `pingpong::Pong` has infinite size
 }
 
 fn main() {}

--- a/src/test/ui/issues/issue-2718-a.stderr
+++ b/src/test/ui/issues/issue-2718-a.stderr
@@ -1,13 +1,13 @@
-error[E0072]: recursive type `pingpong::pong` has infinite size
+error[E0072]: recursive type `pingpong::Pong` has infinite size
   --> $DIR/issue-2718-a.rs:18:5
    |
-LL |     pub struct pong(send_packet<ping>);
-   |     ^^^^^^^^^^^^^^^^-----------------^^
+LL |     pub struct Pong(SendPacket<Ping>);
+   |     ^^^^^^^^^^^^^^^^----------------^^
    |     |               |
    |     |               recursive without indirection
    |     recursive type has infinite size
    |
-   = help: insert indirection (e.g., a `Box`, `Rc`, or `&`) at some point to make `pingpong::pong` representable
+   = help: insert indirection (e.g., a `Box`, `Rc`, or `&`) at some point to make `pingpong::Pong` representable
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-2848.rs
+++ b/src/test/ui/issues/issue-2848.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[allow(non_camel_case_types)]
+
 mod bar {
     pub enum foo {
         alpha,

--- a/src/test/ui/issues/issue-2848.stderr
+++ b/src/test/ui/issues/issue-2848.stderr
@@ -1,5 +1,5 @@
 error[E0408]: variable `beta` is not bound in all patterns
-  --> $DIR/issue-2848.rs:22:7
+  --> $DIR/issue-2848.rs:24:7
    |
 LL |       alpha | beta => {} //~  ERROR variable `beta` is not bound in all patterns
    |       ^^^^^   ---- variable not in all patterns

--- a/src/test/ui/issues/issue-2849.rs
+++ b/src/test/ui/issues/issue-2849.rs
@@ -8,11 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-enum foo { alpha, beta(isize) }
+enum Foo { Alpha, Beta(isize) }
 
 fn main() {
-    match foo::alpha {
-      foo::alpha | foo::beta(i) => {}
+    match Foo::Alpha {
+      Foo::Alpha | Foo::Beta(i) => {}
       //~^ ERROR variable `i` is not bound in all patterns
     }
 }

--- a/src/test/ui/issues/issue-2849.stderr
+++ b/src/test/ui/issues/issue-2849.stderr
@@ -1,7 +1,7 @@
 error[E0408]: variable `i` is not bound in all patterns
   --> $DIR/issue-2849.rs:15:7
    |
-LL |       foo::alpha | foo::beta(i) => {}
+LL |       Foo::Alpha | Foo::Beta(i) => {}
    |       ^^^^^^^^^^             - variable not in all patterns
    |       |
    |       pattern doesn't bind `i`

--- a/src/test/ui/issues/issue-29124.rs
+++ b/src/test/ui/issues/issue-29124.rs
@@ -8,22 +8,22 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-struct ret;
-struct obj;
+struct Ret;
+struct Obj;
 
-impl obj {
-    fn func() -> ret {
-        ret
+impl Obj {
+    fn func() -> Ret {
+        Ret
     }
 }
 
-fn func() -> ret {
-    ret
+fn func() -> Ret {
+    Ret
 }
 
 fn main() {
-    obj::func.x();
-    //~^ ERROR no method named `x` found for type `fn() -> ret {obj::func}` in the current scope
+    Obj::func.x();
+    //~^ ERROR no method named `x` found for type `fn() -> Ret {Obj::func}` in the current scope
     func.x();
-    //~^ ERROR no method named `x` found for type `fn() -> ret {func}` in the current scope
+    //~^ ERROR no method named `x` found for type `fn() -> Ret {func}` in the current scope
 }

--- a/src/test/ui/issues/issue-29124.stderr
+++ b/src/test/ui/issues/issue-29124.stderr
@@ -1,12 +1,12 @@
-error[E0599]: no method named `x` found for type `fn() -> ret {obj::func}` in the current scope
+error[E0599]: no method named `x` found for type `fn() -> Ret {Obj::func}` in the current scope
   --> $DIR/issue-29124.rs:25:15
    |
-LL |     obj::func.x();
+LL |     Obj::func.x();
    |               ^
    |
-   = note: obj::func is a function, perhaps you wish to call it
+   = note: Obj::func is a function, perhaps you wish to call it
 
-error[E0599]: no method named `x` found for type `fn() -> ret {func}` in the current scope
+error[E0599]: no method named `x` found for type `fn() -> Ret {func}` in the current scope
   --> $DIR/issue-29124.rs:27:10
    |
 LL |     func.x();

--- a/src/test/ui/issues/issue-3008-2.rs
+++ b/src/test/ui/issues/issue-3008-2.rs
@@ -8,8 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-enum foo { foo_(bar) }
-struct bar { x: bar }
+enum Foo { Foo_(Bar) }
+struct Bar { x: Bar }
 //~^ ERROR E0072
 
 fn main() {

--- a/src/test/ui/issues/issue-3008-2.stderr
+++ b/src/test/ui/issues/issue-3008-2.stderr
@@ -1,12 +1,12 @@
-error[E0072]: recursive type `bar` has infinite size
+error[E0072]: recursive type `Bar` has infinite size
   --> $DIR/issue-3008-2.rs:12:1
    |
-LL | struct bar { x: bar }
+LL | struct Bar { x: Bar }
    | ^^^^^^^^^^   ------ recursive without indirection
    | |
    | recursive type has infinite size
    |
-   = help: insert indirection (e.g., a `Box`, `Rc`, or `&`) at some point to make `bar` representable
+   = help: insert indirection (e.g., a `Box`, `Rc`, or `&`) at some point to make `Bar` representable
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-3021-b.rs
+++ b/src/test/ui/issues/issue-3021-b.rs
@@ -10,11 +10,11 @@
 
 fn siphash(k0 : u64) {
 
-    struct siphash {
+    struct SipHash {
         v0: u64,
     }
 
-    impl siphash {
+    impl SipHash {
         pub fn reset(&mut self) {
            self.v0 = k0 ^ 0x736f6d6570736575; //~ ERROR can't capture dynamic environment
         }

--- a/src/test/ui/issues/issue-3021-c.rs
+++ b/src/test/ui/issues/issue-3021-c.rs
@@ -10,7 +10,7 @@
 
 fn siphash<T>() {
 
-    trait t {
+    trait U {
         fn g(&self, x: T) -> T;  //~ ERROR can't use type parameters from outer function
         //~^ ERROR can't use type parameters from outer function
     }

--- a/src/test/ui/issues/issue-3021-d.rs
+++ b/src/test/ui/issues/issue-3021-d.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-trait siphash {
+trait SipHash {
     fn result(&self) -> u64;
     fn reset(&self);
 }
@@ -26,7 +26,7 @@ fn siphash(k0 : u64, k1 : u64) {
         return v0 ^ v1;
     }
 
-   impl siphash for SipState {
+   impl SipHash for SipState {
         fn reset(&self) {
             self.v0 = k0 ^ 0x736f6d6570736575; //~ ERROR can't capture dynamic environment
             self.v1 = k1 ^ 0x646f72616e646f6d; //~ ERROR can't capture dynamic environment

--- a/src/test/ui/issues/issue-3038.rs
+++ b/src/test/ui/issues/issue-3038.rs
@@ -8,23 +8,23 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-enum f { g(isize, isize) }
+enum F { G(isize, isize) }
 
-enum h { i(j, k) }
+enum H { I(J, K) }
 
-enum j { l(isize, isize) }
-enum k { m(isize, isize) }
+enum J { L(isize, isize) }
+enum K { M(isize, isize) }
 
 fn main()
 {
 
-    let _z = match f::g(1, 2) {
-      f::g(x, x) => { println!("{}", x + x); }
+    let _z = match F::G(1, 2) {
+      F::G(x, x) => { println!("{}", x + x); }
       //~^ ERROR identifier `x` is bound more than once in the same pattern
     };
 
-    let _z = match h::i(j::l(1, 2), k::m(3, 4)) {
-      h::i(j::l(x, _), k::m(_, x))
+    let _z = match H::I(J::L(1, 2), K::M(3, 4)) {
+      H::I(J::L(x, _), K::M(_, x))
       //~^ ERROR identifier `x` is bound more than once in the same pattern
         => { println!("{}", x + x); }
     };

--- a/src/test/ui/issues/issue-3038.stderr
+++ b/src/test/ui/issues/issue-3038.stderr
@@ -1,13 +1,13 @@
 error[E0416]: identifier `x` is bound more than once in the same pattern
   --> $DIR/issue-3038.rs:22:15
    |
-LL |       f::g(x, x) => { println!("{}", x + x); }
+LL |       F::G(x, x) => { println!("{}", x + x); }
    |               ^ used in a pattern more than once
 
 error[E0416]: identifier `x` is bound more than once in the same pattern
   --> $DIR/issue-3038.rs:27:32
    |
-LL |       h::i(j::l(x, _), k::m(_, x))
+LL |       H::I(J::L(x, _), K::M(_, x))
    |                                ^ used in a pattern more than once
 
 error[E0416]: identifier `x` is bound more than once in the same pattern

--- a/src/test/ui/issues/issue-3080.rs
+++ b/src/test/ui/issues/issue-3080.rs
@@ -8,11 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-struct x(());
-impl x {
+struct X(());
+impl X {
     pub unsafe fn with(&self) { }
 }
 
 fn main() {
-    x(()).with(); //~ ERROR requires unsafe function or block
+    X(()).with(); //~ ERROR requires unsafe function or block
 }

--- a/src/test/ui/issues/issue-3080.stderr
+++ b/src/test/ui/issues/issue-3080.stderr
@@ -1,7 +1,7 @@
 error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
   --> $DIR/issue-3080.rs:17:5
    |
-LL |     x(()).with(); //~ ERROR requires unsafe function or block
+LL |     X(()).with(); //~ ERROR requires unsafe function or block
    |     ^^^^^^^^^^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior

--- a/src/test/ui/issues/issue-3096-2.rs
+++ b/src/test/ui/issues/issue-3096-2.rs
@@ -8,9 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-enum bottom { }
+enum Bottom { }
 
 fn main() {
-    let x = &() as *const () as *const bottom;
+    let x = &() as *const () as *const Bottom;
     match x { } //~ ERROR non-exhaustive patterns
 }

--- a/src/test/ui/issues/issue-3096-2.stderr
+++ b/src/test/ui/issues/issue-3096-2.stderr
@@ -1,4 +1,4 @@
-error[E0004]: non-exhaustive patterns: type `*const bottom` is non-empty
+error[E0004]: non-exhaustive patterns: type `*const Bottom` is non-empty
   --> $DIR/issue-3096-2.rs:15:11
    |
 LL |     match x { } //~ ERROR non-exhaustive patterns

--- a/src/test/ui/issues/issue-3099-a.rs
+++ b/src/test/ui/issues/issue-3099-a.rs
@@ -8,8 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-enum a { b, c }
+enum A { B, C }
 
-enum a { d, e } //~ ERROR the name `a` is defined multiple times
+enum A { D, E } //~ ERROR the name `A` is defined multiple times
 
 fn main() {}

--- a/src/test/ui/issues/issue-3099-a.stderr
+++ b/src/test/ui/issues/issue-3099-a.stderr
@@ -1,13 +1,13 @@
-error[E0428]: the name `a` is defined multiple times
+error[E0428]: the name `A` is defined multiple times
   --> $DIR/issue-3099-a.rs:13:1
    |
-LL | enum a { b, c }
-   | ------ previous definition of the type `a` here
+LL | enum A { B, C }
+   | ------ previous definition of the type `A` here
 LL | 
-LL | enum a { d, e } //~ ERROR the name `a` is defined multiple times
-   | ^^^^^^ `a` redefined here
+LL | enum A { D, E } //~ ERROR the name `A` is defined multiple times
+   | ^^^^^^ `A` redefined here
    |
-   = note: `a` must be defined only once in the type namespace of this module
+   = note: `A` must be defined only once in the type namespace of this module
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-3154.rs
+++ b/src/test/ui/issues/issue-3154.rs
@@ -8,12 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-struct thing<'a, Q:'a> {
+struct Thing<'a, Q:'a> {
     x: &'a Q
 }
 
-fn thing<'a,Q>(x: &Q) -> thing<'a,Q> {
-    thing{ x: x } //~ ERROR 16:5: 16:18: explicit lifetime required in the type of `x` [E0621]
+fn thing<'a,Q>(x: &Q) -> Thing<'a,Q> {
+    Thing { x: x } //~ ERROR explicit lifetime required in the type of `x` [E0621]
 }
 
 fn main() {

--- a/src/test/ui/issues/issue-3154.stderr
+++ b/src/test/ui/issues/issue-3154.stderr
@@ -1,10 +1,10 @@
 error[E0621]: explicit lifetime required in the type of `x`
   --> $DIR/issue-3154.rs:16:5
    |
-LL | fn thing<'a,Q>(x: &Q) -> thing<'a,Q> {
+LL | fn thing<'a,Q>(x: &Q) -> Thing<'a,Q> {
    |                   -- help: add explicit lifetime `'a` to the type of `x`: `&'a Q`
-LL |     thing{ x: x } //~ ERROR 16:5: 16:18: explicit lifetime required in the type of `x` [E0621]
-   |     ^^^^^^^^^^^^^ lifetime `'a` required
+LL |     Thing { x: x } //~ ERROR explicit lifetime required in the type of `x` [E0621]
+   |     ^^^^^^^^^^^^^^ lifetime `'a` required
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-3214.rs
+++ b/src/test/ui/issues/issue-3214.rs
@@ -9,11 +9,11 @@
 // except according to those terms.
 
 fn foo<T>() {
-    struct foo {
+    struct Foo {
         x: T, //~ ERROR can't use type parameters from outer function
     }
 
-    impl<T> Drop for foo<T> {
+    impl<T> Drop for Foo<T> {
         //~^ ERROR wrong number of type arguments
         fn drop(&mut self) {}
     }

--- a/src/test/ui/issues/issue-3214.stderr
+++ b/src/test/ui/issues/issue-3214.stderr
@@ -5,14 +5,14 @@ LL | fn foo<T>() {
    |    --- - type variable from outer function
    |    |
    |    try adding a local type parameter in this method instead
-LL |     struct foo {
+LL |     struct Foo {
 LL |         x: T, //~ ERROR can't use type parameters from outer function
    |            ^ use of type variable from outer function
 
 error[E0107]: wrong number of type arguments: expected 0, found 1
   --> $DIR/issue-3214.rs:16:26
    |
-LL |     impl<T> Drop for foo<T> {
+LL |     impl<T> Drop for Foo<T> {
    |                          ^ unexpected type argument
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/issues/issue-3344.rs
+++ b/src/test/ui/issues/issue-3344.rs
@@ -9,9 +9,9 @@
 // except according to those terms.
 
 #[derive(PartialEq)]
-struct thing(usize);
-impl PartialOrd for thing { //~ ERROR not all trait items implemented, missing: `partial_cmp`
-    fn le(&self, other: &thing) -> bool { true }
-    fn ge(&self, other: &thing) -> bool { true }
+struct Thing(usize);
+impl PartialOrd for Thing { //~ ERROR not all trait items implemented, missing: `partial_cmp`
+    fn le(&self, other: &Thing) -> bool { true }
+    fn ge(&self, other: &Thing) -> bool { true }
 }
 fn main() {}

--- a/src/test/ui/issues/issue-3344.stderr
+++ b/src/test/ui/issues/issue-3344.stderr
@@ -1,7 +1,7 @@
 error[E0046]: not all trait items implemented, missing: `partial_cmp`
   --> $DIR/issue-3344.rs:13:1
    |
-LL | impl PartialOrd for thing { //~ ERROR not all trait items implemented, missing: `partial_cmp`
+LL | impl PartialOrd for Thing { //~ ERROR not all trait items implemented, missing: `partial_cmp`
    | ^^^^^^^^^^^^^^^^^^^^^^^^^ missing `partial_cmp` in implementation
    |
    = note: `partial_cmp` from trait: `fn(&Self, &Rhs) -> std::option::Option<std::cmp::Ordering>`

--- a/src/test/ui/issues/issue-4366-2.rs
+++ b/src/test/ui/issues/issue-4366-2.rs
@@ -18,12 +18,12 @@ mod foo {
 mod a {
     pub mod b {
         use foo::foo;
-        type bar = isize;
+        type Bar = isize;
     }
     pub mod sub {
         use a::b::*;
-        fn sub() -> bar { 1 }
-        //~^ ERROR cannot find type `bar` in this scope
+        fn sub() -> Bar { 1 }
+        //~^ ERROR cannot find type `Bar` in this scope
     }
 }
 

--- a/src/test/ui/issues/issue-4366-2.stderr
+++ b/src/test/ui/issues/issue-4366-2.stderr
@@ -1,11 +1,11 @@
-error[E0412]: cannot find type `bar` in this scope
+error[E0412]: cannot find type `Bar` in this scope
   --> $DIR/issue-4366-2.rs:25:21
    |
-LL |         fn sub() -> bar { 1 }
+LL |         fn sub() -> Bar { 1 }
    |                     ^^^ not found in this scope
 help: possible candidate is found in another module, you can import it into scope
    |
-LL |         use a::b::bar;
+LL |         use a::b::Bar;
    |
 
 error[E0423]: expected function, found module `foo`

--- a/src/test/ui/issues/issue-4366.rs
+++ b/src/test/ui/issues/issue-4366.rs
@@ -21,7 +21,7 @@ mod foo {
 mod a {
     pub mod b {
         use foo::foo;
-        type bar = isize;
+        type Bar = isize;
     }
     pub mod sub {
         use a::b::*;

--- a/src/test/ui/lint/lint-group-nonstandard-style.stderr
+++ b/src/test/ui/lint/lint-group-nonstandard-style.stderr
@@ -1,3 +1,16 @@
+warning: type `snake_case` should have a camel case name such as `SnakeCase`
+  --> $DIR/lint-group-nonstandard-style.rs:32:9
+   |
+LL |         struct snake_case; //~ WARN should have a camel
+   |         ^^^^^^^^^^^^^^^^^^
+   |
+note: lint level defined here
+  --> $DIR/lint-group-nonstandard-style.rs:28:17
+   |
+LL |         #![warn(nonstandard_style)]
+   |                 ^^^^^^^^^^^^^^^^^
+   = note: #[warn(non_camel_case_types)] implied by #[warn(nonstandard_style)]
+
 error: function `CamelCase` should have a snake case name such as `camel_case`
   --> $DIR/lint-group-nonstandard-style.rs:14:1
    |
@@ -49,19 +62,6 @@ note: lint level defined here
 LL |         #![warn(nonstandard_style)]
    |                 ^^^^^^^^^^^^^^^^^
    = note: #[warn(non_snake_case)] implied by #[warn(nonstandard_style)]
-
-warning: type `snake_case` should have a camel case name such as `SnakeCase`
-  --> $DIR/lint-group-nonstandard-style.rs:32:9
-   |
-LL |         struct snake_case; //~ WARN should have a camel
-   |         ^^^^^^^^^^^^^^^^^^
-   |
-note: lint level defined here
-  --> $DIR/lint-group-nonstandard-style.rs:28:17
-   |
-LL |         #![warn(nonstandard_style)]
-   |                 ^^^^^^^^^^^^^^^^^
-   = note: #[warn(non_camel_case_types)] implied by #[warn(nonstandard_style)]
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/liveness/liveness-use-after-send.rs
+++ b/src/test/ui/liveness/liveness-use-after-send.rs
@@ -10,18 +10,18 @@
 
 use std::marker;
 
-fn send<T:Send + std::fmt::Debug>(ch: _chan<T>, data: T) {
+fn send<T:Send + std::fmt::Debug>(ch: Chan<T>, data: T) {
     println!("{:?}", ch);
     println!("{:?}", data);
     panic!();
 }
 
 #[derive(Debug)]
-struct _chan<T>(isize, marker::PhantomData<T>);
+struct Chan<T>(isize, marker::PhantomData<T>);
 
 // Tests that "log(debug, message);" is flagged as using
 // message after the send deinitializes it
-fn test00_start(ch: _chan<Box<isize>>, message: Box<isize>, _count: Box<isize>) {
+fn test00_start(ch: Chan<Box<isize>>, message: Box<isize>, _count: Box<isize>) {
     send(ch, message);
     println!("{}", message); //~ ERROR use of moved value: `message`
 }

--- a/src/test/ui/match/match-pattern-field-mismatch-2.rs
+++ b/src/test/ui/match/match-pattern-field-mismatch-2.rs
@@ -9,18 +9,18 @@
 // except according to those terms.
 
 fn main() {
-    enum color {
-        rgb(usize, usize, usize),
-        cmyk(usize, usize, usize, usize),
-        no_color,
+    enum Color {
+        Rgb(usize, usize, usize),
+        Cmyk(usize, usize, usize, usize),
+        NoColor,
     }
 
-    fn foo(c: color) {
+    fn foo(c: Color) {
         match c {
-          color::rgb(_, _, _) => { }
-          color::cmyk(_, _, _, _) => { }
-          color::no_color(_) => { }
-          //~^ ERROR expected tuple struct/variant, found unit variant `color::no_color`
+          Color::Rgb(_, _, _) => { }
+          Color::Cmyk(_, _, _, _) => { }
+          Color::NoColor(_) => { }
+          //~^ ERROR expected tuple struct/variant, found unit variant `Color::NoColor`
         }
     }
 }

--- a/src/test/ui/match/match-pattern-field-mismatch-2.stderr
+++ b/src/test/ui/match/match-pattern-field-mismatch-2.stderr
@@ -1,8 +1,8 @@
-error[E0532]: expected tuple struct/variant, found unit variant `color::no_color`
+error[E0532]: expected tuple struct/variant, found unit variant `Color::NoColor`
   --> $DIR/match-pattern-field-mismatch-2.rs:22:11
    |
-LL |           color::no_color(_) => { }
-   |           ^^^^^^^^^^^^^^^ not a tuple struct/variant
+LL |           Color::NoColor(_) => { }
+   |           ^^^^^^^^^^^^^^ not a tuple struct/variant
 
 error: aborting due to previous error
 

--- a/src/test/ui/match/match-pattern-field-mismatch.rs
+++ b/src/test/ui/match/match-pattern-field-mismatch.rs
@@ -9,18 +9,18 @@
 // except according to those terms.
 
 fn main() {
-    enum color {
-        rgb(usize, usize, usize),
-        cmyk(usize, usize, usize, usize),
-        no_color,
+    enum Color {
+        Rgb(usize, usize, usize),
+        Cmyk(usize, usize, usize, usize),
+        NoColor,
     }
 
-    fn foo(c: color) {
+    fn foo(c: Color) {
         match c {
-          color::rgb(_, _) => { }
+          Color::Rgb(_, _) => { }
           //~^ ERROR this pattern has 2 fields, but the corresponding tuple variant has 3 fields
-          color::cmyk(_, _, _, _) => { }
-          color::no_color => { }
+          Color::Cmyk(_, _, _, _) => { }
+          Color::NoColor => { }
         }
     }
 }

--- a/src/test/ui/match/match-pattern-field-mismatch.stderr
+++ b/src/test/ui/match/match-pattern-field-mismatch.stderr
@@ -1,7 +1,7 @@
 error[E0023]: this pattern has 2 fields, but the corresponding tuple variant has 3 fields
   --> $DIR/match-pattern-field-mismatch.rs:20:11
    |
-LL |           color::rgb(_, _) => { }
+LL |           Color::Rgb(_, _) => { }
    |           ^^^^^^^^^^^^^^^^ expected 3 fields, found 2
 
 error: aborting due to previous error

--- a/src/test/ui/match/match-tag-nullary.rs
+++ b/src/test/ui/match/match-tag-nullary.rs
@@ -8,9 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: mismatched types
+enum A { A }
+enum B { B }
 
-enum a { A, }
-enum b { B, }
-
-fn main() { let x: a = a::A; match x { b::B => { } } }
+fn main() { let x: A = A::A; match x { B::B => { } } } //~ ERROR mismatched types

--- a/src/test/ui/match/match-tag-nullary.stderr
+++ b/src/test/ui/match/match-tag-nullary.stderr
@@ -1,11 +1,11 @@
 error[E0308]: mismatched types
-  --> $DIR/match-tag-nullary.rs:16:40
+  --> $DIR/match-tag-nullary.rs:14:40
    |
-LL | fn main() { let x: a = a::A; match x { b::B => { } } }
-   |                                        ^^^^ expected enum `a`, found enum `b`
+LL | fn main() { let x: A = A::A; match x { B::B => { } } } //~ ERROR mismatched types
+   |                                        ^^^^ expected enum `A`, found enum `B`
    |
-   = note: expected type `a`
-              found type `b`
+   = note: expected type `A`
+              found type `B`
 
 error: aborting due to previous error
 

--- a/src/test/ui/match/match-tag-unary.rs
+++ b/src/test/ui/match/match-tag-unary.rs
@@ -8,9 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: mismatched types
+enum A { A(isize) }
+enum B { B(isize) }
 
-enum a { A(isize), }
-enum b { B(isize), }
-
-fn main() { let x: a = a::A(0); match x { b::B(y) => { } } }
+fn main() { let x: A = A::A(0); match x { B::B(y) => { } } } //~ ERROR mismatched types

--- a/src/test/ui/match/match-tag-unary.stderr
+++ b/src/test/ui/match/match-tag-unary.stderr
@@ -1,11 +1,11 @@
 error[E0308]: mismatched types
-  --> $DIR/match-tag-unary.rs:16:43
+  --> $DIR/match-tag-unary.rs:14:43
    |
-LL | fn main() { let x: a = a::A(0); match x { b::B(y) => { } } }
-   |                                           ^^^^^^^ expected enum `a`, found enum `b`
+LL | fn main() { let x: A = A::A(0); match x { B::B(y) => { } } } //~ ERROR mismatched types
+   |                                           ^^^^^^^ expected enum `A`, found enum `B`
    |
-   = note: expected type `a`
-              found type `b`
+   = note: expected type `A`
+              found type `B`
 
 error: aborting due to previous error
 

--- a/src/test/ui/methods/auxiliary/ambig_impl_2_lib.rs
+++ b/src/test/ui/methods/auxiliary/ambig_impl_2_lib.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-pub trait me {
+pub trait Me {
     fn me(&self) -> usize;
 }
-impl me for usize { fn me(&self) -> usize { *self } }
+impl Me for usize { fn me(&self) -> usize { *self } }

--- a/src/test/ui/methods/method-ambig-one-trait-unknown-int-type.rs
+++ b/src/test/ui/methods/method-ambig-one-trait-unknown-int-type.rs
@@ -8,19 +8,19 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Test that we invoking `foo()` successfully resolves to the trait `foo`
+// Test that we invoking `foo()` successfully resolves to the trait `Foo`
 // (prompting the mismatched types error) but does not influence the choice
 // of what kind of `Vec` we have, eventually leading to a type error.
 
-trait foo {
+trait Foo {
     fn foo(&self) -> isize;
 }
 
-impl foo for Vec<usize> {
+impl Foo for Vec<usize> {
     fn foo(&self) -> isize {1}
 }
 
-impl foo for Vec<isize> {
+impl Foo for Vec<isize> {
     fn foo(&self) -> isize {2}
 }
 

--- a/src/test/ui/methods/method-ambig-two-traits-cross-crate.rs
+++ b/src/test/ui/methods/method-ambig-two-traits-cross-crate.rs
@@ -13,9 +13,9 @@
 
 // aux-build:ambig_impl_2_lib.rs
 extern crate ambig_impl_2_lib;
-use ambig_impl_2_lib::me;
-trait me2 {
+use ambig_impl_2_lib::Me;
+trait Me2 {
     fn me(&self) -> usize;
 }
-impl me2 for usize { fn me(&self) -> usize { *self } }
+impl Me2 for usize { fn me(&self) -> usize { *self } }
 fn main() { 1_usize.me(); } //~ ERROR E0034

--- a/src/test/ui/methods/method-ambig-two-traits-cross-crate.stderr
+++ b/src/test/ui/methods/method-ambig-two-traits-cross-crate.stderr
@@ -4,12 +4,12 @@ error[E0034]: multiple applicable items in scope
 LL | fn main() { 1_usize.me(); } //~ ERROR E0034
    |                     ^^ multiple `me` found
    |
-note: candidate #1 is defined in an impl of the trait `me2` for the type `usize`
+note: candidate #1 is defined in an impl of the trait `Me2` for the type `usize`
   --> $DIR/method-ambig-two-traits-cross-crate.rs:20:22
    |
-LL | impl me2 for usize { fn me(&self) -> usize { *self } }
+LL | impl Me2 for usize { fn me(&self) -> usize { *self } }
    |                      ^^^^^^^^^^^^^^^^^^^^^
-   = note: candidate #2 is defined in an impl of the trait `ambig_impl_2_lib::me` for the type `usize`
+   = note: candidate #2 is defined in an impl of the trait `ambig_impl_2_lib::Me` for the type `usize`
 
 error: aborting due to previous error
 

--- a/src/test/ui/mismatched_types/issue-35030.rs
+++ b/src/test/ui/mismatched_types/issue-35030.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// rustc-env:RUST_NEW_ERROR_FORMAT
+#![allow(non_camel_case_types)]
 
 trait Parser<T> {
     fn parse(text: &str) -> Option<T>;

--- a/src/test/ui/mut/mutable-class-fields-2.rs
+++ b/src/test/ui/mut/mutable-class-fields-2.rs
@@ -8,27 +8,27 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-struct cat {
+struct Cat {
   meows : usize,
 
   how_hungry : isize,
 }
 
-impl cat {
+impl Cat {
   pub fn eat(&self) {
     self.how_hungry -= 5; //~ ERROR cannot assign
   }
 
 }
 
-fn cat(in_x : usize, in_y : isize) -> cat {
-    cat {
+fn cat(in_x : usize, in_y : isize) -> Cat {
+    Cat {
         meows: in_x,
         how_hungry: in_y
     }
 }
 
 fn main() {
-  let nyan : cat = cat(52, 99);
+  let nyan : Cat = cat(52, 99);
   nyan.eat();
 }

--- a/src/test/ui/mut/mutable-class-fields.ast.nll.stderr
+++ b/src/test/ui/mut/mutable-class-fields.ast.nll.stderr
@@ -1,7 +1,7 @@
 error[E0594]: cannot assign to `nyan.how_hungry`, as `nyan` is not declared as mutable
   --> $DIR/mutable-class-fields.rs:28:3
    |
-LL |   let nyan : cat = cat(52, 99);
+LL |   let nyan : Cat = cat(52, 99);
    |       ---- help: consider changing this to be mutable: `mut nyan`
 LL |   nyan.how_hungry = 0; //[ast]~ ERROR cannot assign
    |   ^^^^^^^^^^^^^^^^^^^ cannot assign

--- a/src/test/ui/mut/mutable-class-fields.ast.stderr
+++ b/src/test/ui/mut/mutable-class-fields.ast.stderr
@@ -1,7 +1,7 @@
 error[E0594]: cannot assign to field `nyan.how_hungry` of immutable binding
   --> $DIR/mutable-class-fields.rs:28:3
    |
-LL |   let nyan : cat = cat(52, 99);
+LL |   let nyan : Cat = cat(52, 99);
    |       ---- help: make this binding mutable: `mut nyan`
 LL |   nyan.how_hungry = 0; //[ast]~ ERROR cannot assign
    |   ^^^^^^^^^^^^^^^^^^^ cannot mutably borrow field of immutable binding

--- a/src/test/ui/mut/mutable-class-fields.mir.stderr
+++ b/src/test/ui/mut/mutable-class-fields.mir.stderr
@@ -1,7 +1,7 @@
 error[E0594]: cannot assign to `nyan.how_hungry`, as `nyan` is not declared as mutable
   --> $DIR/mutable-class-fields.rs:28:3
    |
-LL |   let nyan : cat = cat(52, 99);
+LL |   let nyan : Cat = cat(52, 99);
    |       ---- help: consider changing this to be mutable: `mut nyan`
 LL |   nyan.how_hungry = 0; //[ast]~ ERROR cannot assign
    |   ^^^^^^^^^^^^^^^^^^^ cannot assign

--- a/src/test/ui/mut/mutable-class-fields.rs
+++ b/src/test/ui/mut/mutable-class-fields.rs
@@ -11,20 +11,20 @@
 // revisions: ast mir
 //[mir]compile-flags: -Z borrowck=mir
 
-struct cat {
+struct Cat {
   meows : usize,
   how_hungry : isize,
 }
 
-fn cat(in_x : usize, in_y : isize) -> cat {
-    cat {
+fn cat(in_x : usize, in_y : isize) -> Cat {
+    Cat {
         meows: in_x,
         how_hungry: in_y
     }
 }
 
 fn main() {
-  let nyan : cat = cat(52, 99);
+  let nyan : Cat = cat(52, 99);
   nyan.how_hungry = 0; //[ast]~ ERROR cannot assign
   //[mir]~^ ERROR cannot assign
 }

--- a/src/test/ui/nll/type-alias-free-regions.rs
+++ b/src/test/ui/nll/type-alias-free-regions.rs
@@ -3,30 +3,30 @@
 
 #![feature(nll)]
 
-type a<'a> = &'a isize;
-type b<'a> = Box<a<'a>>;
+type A<'a> = &'a isize;
+type B<'a> = Box<A<'a>>;
 
-struct c<'a> {
-    f: Box<b<'a>>
+struct C<'a> {
+    f: Box<B<'a>>
 }
 
 trait FromBox<'a> {
-    fn from_box(b: Box<b>) -> Self;
+    fn from_box(b: Box<B>) -> Self;
 }
 
-impl<'a> FromBox<'a> for c<'a> {
-    fn from_box(b: Box<b>) -> Self {
-        c { f: b } //~ ERROR
+impl<'a> FromBox<'a> for C<'a> {
+    fn from_box(b: Box<B>) -> Self {
+        C { f: b } //~ ERROR
     }
 }
 
 trait FromTuple<'a> {
-    fn from_tuple( b: (b,)) -> Self;
+    fn from_tuple( b: (B,)) -> Self;
 }
 
-impl<'a> FromTuple<'a> for c<'a> {
-    fn from_tuple(b: (b,)) -> Self {
-        c { f: Box::new(b.0) } //~ ERROR
+impl<'a> FromTuple<'a> for C<'a> {
+    fn from_tuple(b: (B,)) -> Self {
+        C { f: Box::new(b.0) } //~ ERROR
     }
 }
 

--- a/src/test/ui/nll/type-alias-free-regions.stderr
+++ b/src/test/ui/nll/type-alias-free-regions.stderr
@@ -1,21 +1,21 @@
 error: unsatisfied lifetime constraints
   --> $DIR/type-alias-free-regions.rs:19:9
    |
-LL | impl<'a> FromBox<'a> for c<'a> {
+LL | impl<'a> FromBox<'a> for C<'a> {
    |      -- lifetime `'a` defined here
-LL |     fn from_box(b: Box<b>) -> Self {
+LL |     fn from_box(b: Box<B>) -> Self {
    |                 - has type `std::boxed::Box<std::boxed::Box<&'1 isize>>`
-LL |         c { f: b } //~ ERROR
+LL |         C { f: b } //~ ERROR
    |         ^^^^^^^^^^ returning this value requires that `'1` must outlive `'a`
 
 error: unsatisfied lifetime constraints
   --> $DIR/type-alias-free-regions.rs:29:9
    |
-LL | impl<'a> FromTuple<'a> for c<'a> {
+LL | impl<'a> FromTuple<'a> for C<'a> {
    |      -- lifetime `'a` defined here
-LL |     fn from_tuple(b: (b,)) -> Self {
+LL |     fn from_tuple(b: (B,)) -> Self {
    |                   - has type `(std::boxed::Box<&'1 isize>,)`
-LL |         c { f: Box::new(b.0) } //~ ERROR
+LL |         C { f: Box::new(b.0) } //~ ERROR
    |         ^^^^^^^^^^^^^^^^^^^^^^ returning this value requires that `'1` must outlive `'a`
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/no-send-res-ports.rs
+++ b/src/test/ui/no-send-res-ports.rs
@@ -16,16 +16,16 @@ struct Port<T>(Rc<T>);
 
 fn main() {
     #[derive(Debug)]
-    struct foo {
+    struct Foo {
       _x: Port<()>,
     }
 
-    impl Drop for foo {
+    impl Drop for Foo {
         fn drop(&mut self) {}
     }
 
-    fn foo(x: Port<()>) -> foo {
-        foo {
+    fn foo(x: Port<()>) -> Foo {
+        Foo {
             _x: x
         }
     }

--- a/src/test/ui/no-send-res-ports.stderr
+++ b/src/test/ui/no-send-res-ports.stderr
@@ -4,10 +4,10 @@ error[E0277]: `std::rc::Rc<()>` cannot be sent between threads safely
 LL |     thread::spawn(move|| {
    |     ^^^^^^^^^^^^^ `std::rc::Rc<()>` cannot be sent between threads safely
    |
-   = help: within `[closure@$DIR/no-send-res-ports.rs:35:19: 39:6 x:main::foo]`, the trait `std::marker::Send` is not implemented for `std::rc::Rc<()>`
+   = help: within `[closure@$DIR/no-send-res-ports.rs:35:19: 39:6 x:main::Foo]`, the trait `std::marker::Send` is not implemented for `std::rc::Rc<()>`
    = note: required because it appears within the type `Port<()>`
-   = note: required because it appears within the type `main::foo`
-   = note: required because it appears within the type `[closure@$DIR/no-send-res-ports.rs:35:19: 39:6 x:main::foo]`
+   = note: required because it appears within the type `main::Foo`
+   = note: required because it appears within the type `[closure@$DIR/no-send-res-ports.rs:35:19: 39:6 x:main::Foo]`
    = note: required by `std::thread::spawn`
 
 error: aborting due to previous error

--- a/src/test/ui/non-exhaustive/non-exhaustive-match-nested.rs
+++ b/src/test/ui/non-exhaustive/non-exhaustive-match-nested.rs
@@ -10,8 +10,8 @@
 
 #![feature(slice_patterns)]
 
-enum t { a(u), b }
-enum u { c, d }
+enum T { A(U), B }
+enum U { C, D }
 
 fn match_nested_vecs<'a, T>(l1: Option<&'a [T]>, l2: Result<&'a [T], ()>) -> &'static str {
     match (l1, l2) { //~ ERROR non-exhaustive patterns: `(Some(&[]), Err(_))` not covered
@@ -23,9 +23,9 @@ fn match_nested_vecs<'a, T>(l1: Option<&'a [T]>, l2: Result<&'a [T], ()>) -> &'s
 }
 
 fn main() {
-    let x = t::a(u::c);
-    match x { //~ ERROR non-exhaustive patterns: `a(c)` not covered
-        t::a(u::d) => { panic!("hello"); }
-        t::b => { panic!("goodbye"); }
+    let x = T::A(U::C);
+    match x { //~ ERROR non-exhaustive patterns: `A(C)` not covered
+        T::A(U::D) => { panic!("hello"); }
+        T::B => { panic!("goodbye"); }
     }
 }

--- a/src/test/ui/non-exhaustive/non-exhaustive-match-nested.stderr
+++ b/src/test/ui/non-exhaustive/non-exhaustive-match-nested.stderr
@@ -4,11 +4,11 @@ error[E0004]: non-exhaustive patterns: `(Some(&[]), Err(_))` not covered
 LL |     match (l1, l2) { //~ ERROR non-exhaustive patterns: `(Some(&[]), Err(_))` not covered
    |           ^^^^^^^^ pattern `(Some(&[]), Err(_))` not covered
 
-error[E0004]: non-exhaustive patterns: `a(c)` not covered
+error[E0004]: non-exhaustive patterns: `A(C)` not covered
   --> $DIR/non-exhaustive-match-nested.rs:27:11
    |
-LL |     match x { //~ ERROR non-exhaustive patterns: `a(c)` not covered
-   |           ^ pattern `a(c)` not covered
+LL |     match x { //~ ERROR non-exhaustive patterns: `A(C)` not covered
+   |           ^ pattern `A(C)` not covered
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/non-exhaustive/non-exhaustive-match.rs
+++ b/src/test/ui/non-exhaustive/non-exhaustive-match.rs
@@ -11,11 +11,11 @@
 #![feature(slice_patterns)]
 #![allow(illegal_floating_point_literal_pattern)]
 
-enum t { a, b, }
+enum T { A, B }
 
 fn main() {
-    let x = t::a;
-    match x { t::b => { } } //~ ERROR non-exhaustive patterns: `a` not covered
+    let x = T::A;
+    match x { T::B => { } } //~ ERROR non-exhaustive patterns: `A` not covered
     match true { //~ ERROR non-exhaustive patterns: `false` not covered
       true => {}
     }
@@ -26,18 +26,18 @@ fn main() {
                       //  and `(_, _, 5i32..=2147483647i32)` not covered
       (_, _, 4) => {}
     }
-    match (t::a, t::a) { //~ ERROR non-exhaustive patterns: `(a, a)` not covered
-      (t::a, t::b) => {}
-      (t::b, t::a) => {}
+    match (T::A, T::A) { //~ ERROR non-exhaustive patterns: `(A, A)` not covered
+      (T::A, T::B) => {}
+      (T::B, T::A) => {}
     }
-    match t::a { //~ ERROR non-exhaustive patterns: `b` not covered
-      t::a => {}
+    match T::A { //~ ERROR non-exhaustive patterns: `B` not covered
+      T::A => {}
     }
     // This is exhaustive, though the algorithm got it wrong at one point
-    match (t::a, t::b) {
-      (t::a, _) => {}
-      (_, t::a) => {}
-      (t::b, t::b) => {}
+    match (T::A, T::B) {
+      (T::A, _) => {}
+      (_, T::A) => {}
+      (T::B, T::B) => {}
     }
     let vec = vec![Some(42), None, Some(21)];
     let vec: &[Option<isize>] = &vec;

--- a/src/test/ui/non-exhaustive/non-exhaustive-match.stderr
+++ b/src/test/ui/non-exhaustive/non-exhaustive-match.stderr
@@ -1,8 +1,8 @@
-error[E0004]: non-exhaustive patterns: `a` not covered
+error[E0004]: non-exhaustive patterns: `A` not covered
   --> $DIR/non-exhaustive-match.rs:18:11
    |
-LL |     match x { t::b => { } } //~ ERROR non-exhaustive patterns: `a` not covered
-   |           ^ pattern `a` not covered
+LL |     match x { T::B => { } } //~ ERROR non-exhaustive patterns: `A` not covered
+   |           ^ pattern `A` not covered
 
 error[E0004]: non-exhaustive patterns: `false` not covered
   --> $DIR/non-exhaustive-match.rs:19:11
@@ -22,17 +22,17 @@ error[E0004]: non-exhaustive patterns: `(_, _, -2147483648i32..=3i32)` and `(_, 
 LL |     match (2, 3, 4) { //~ ERROR non-exhaustive patterns: `(_, _, -2147483648i32..=3i32)`
    |           ^^^^^^^^^ patterns `(_, _, -2147483648i32..=3i32)` and `(_, _, 5i32..=2147483647i32)` not covered
 
-error[E0004]: non-exhaustive patterns: `(a, a)` not covered
+error[E0004]: non-exhaustive patterns: `(A, A)` not covered
   --> $DIR/non-exhaustive-match.rs:29:11
    |
-LL |     match (t::a, t::a) { //~ ERROR non-exhaustive patterns: `(a, a)` not covered
-   |           ^^^^^^^^^^^^ pattern `(a, a)` not covered
+LL |     match (T::A, T::A) { //~ ERROR non-exhaustive patterns: `(A, A)` not covered
+   |           ^^^^^^^^^^^^ pattern `(A, A)` not covered
 
-error[E0004]: non-exhaustive patterns: `b` not covered
+error[E0004]: non-exhaustive patterns: `B` not covered
   --> $DIR/non-exhaustive-match.rs:33:11
    |
-LL |     match t::a { //~ ERROR non-exhaustive patterns: `b` not covered
-   |           ^^^^ pattern `b` not covered
+LL |     match T::A { //~ ERROR non-exhaustive patterns: `B` not covered
+   |           ^^^^ pattern `B` not covered
 
 error[E0004]: non-exhaustive patterns: `[]` not covered
   --> $DIR/non-exhaustive-match.rs:44:11

--- a/src/test/ui/noncopyable-class.rs
+++ b/src/test/ui/noncopyable-class.rs
@@ -12,28 +12,28 @@
 // copied
 
 #[derive(Debug)]
-struct bar {
+struct Bar {
   x: isize,
 }
 
-impl Drop for bar {
+impl Drop for Bar {
     fn drop(&mut self) {}
 }
 
-fn bar(x:isize) -> bar {
-    bar {
+fn bar(x:isize) -> Bar {
+    Bar {
         x: x
     }
 }
 
 #[derive(Debug)]
-struct foo {
+struct Foo {
   i: isize,
-  j: bar,
+  j: Bar,
 }
 
-fn foo(i:isize) -> foo {
-    foo {
+fn foo(i:isize) -> Foo {
+    Foo {
         i: i,
         j: bar(5)
     }

--- a/src/test/ui/noncopyable-class.stderr
+++ b/src/test/ui/noncopyable-class.stderr
@@ -1,7 +1,7 @@
-error[E0599]: no method named `clone` found for type `foo` in the current scope
+error[E0599]: no method named `clone` found for type `Foo` in the current scope
   --> $DIR/noncopyable-class.rs:44:16
    |
-LL | struct foo {
+LL | struct Foo {
    | ---------- method `clone` not found for this
 ...
 LL |     let _y = x.clone(); //~ ERROR no method named `clone` found

--- a/src/test/ui/nonscalar-cast.rs
+++ b/src/test/ui/nonscalar-cast.rs
@@ -9,10 +9,10 @@
 // except according to those terms.
 
 #[derive(Debug)]
-struct foo {
+struct Foo {
     x: isize
 }
 
 fn main() {
-    println!("{}", foo{ x: 1 } as isize); //~ non-primitive cast: `foo` as `isize` [E0605]
+    println!("{}", Foo { x: 1 } as isize); //~ non-primitive cast: `Foo` as `isize` [E0605]
 }

--- a/src/test/ui/nonscalar-cast.stderr
+++ b/src/test/ui/nonscalar-cast.stderr
@@ -1,8 +1,8 @@
-error[E0605]: non-primitive cast: `foo` as `isize`
+error[E0605]: non-primitive cast: `Foo` as `isize`
   --> $DIR/nonscalar-cast.rs:17:20
    |
-LL |     println!("{}", foo{ x: 1 } as isize); //~ non-primitive cast: `foo` as `isize` [E0605]
-   |                    ^^^^^^^^^^^^^^^^^^^^
+LL |     println!("{}", Foo { x: 1 } as isize); //~ non-primitive cast: `Foo` as `isize` [E0605]
+   |                    ^^^^^^^^^^^^^^^^^^^^^
    |
    = note: an `as` expression can only be used to convert between primitive types. Consider using the `From` trait
 

--- a/src/test/ui/occurs-check-3.rs
+++ b/src/test/ui/occurs-check-3.rs
@@ -8,7 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:mismatched types
 // From Issue #778
-enum clam<T> { a(T), }
-fn main() { let c; c = clam::a(c); match c { clam::a::<isize>(_) => { } } }
+
+enum Clam<T> { A(T) }
+fn main() { let c; c = Clam::A(c); match c { Clam::A::<isize>(_) => { } } }
+//~^ ERROR mismatched types

--- a/src/test/ui/occurs-check-3.stderr
+++ b/src/test/ui/occurs-check-3.stderr
@@ -1,7 +1,7 @@
 error[E0308]: mismatched types
   --> $DIR/occurs-check-3.rs:14:24
    |
-LL | fn main() { let c; c = clam::a(c); match c { clam::a::<isize>(_) => { } } }
+LL | fn main() { let c; c = Clam::A(c); match c { Clam::A::<isize>(_) => { } } }
    |                        ^^^^^^^^^^ cyclic type of infinite size
 
 error: aborting due to previous error

--- a/src/test/ui/or-pattern-mismatch.rs
+++ b/src/test/ui/or-pattern-mismatch.rs
@@ -8,8 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: mismatched types
+enum Blah { A(isize, isize, usize), B(isize, isize) }
 
-enum blah { a(isize, isize, usize), b(isize, isize), }
-
-fn main() { match blah::a(1, 1, 2) { blah::a(_, x, y) | blah::b(x, y) => { } } }
+fn main() { match Blah::A(1, 1, 2) { Blah::A(_, x, y) | Blah::B(x, y) => { } } }
+//~^ ERROR mismatched types

--- a/src/test/ui/or-pattern-mismatch.stderr
+++ b/src/test/ui/or-pattern-mismatch.stderr
@@ -1,7 +1,7 @@
 error[E0308]: mismatched types
-  --> $DIR/or-patter-mismatch.rs:15:68
+  --> $DIR/or-pattern-mismatch.rs:13:68
    |
-LL | fn main() { match blah::a(1, 1, 2) { blah::a(_, x, y) | blah::b(x, y) => { } } }
+LL | fn main() { match Blah::A(1, 1, 2) { Blah::A(_, x, y) | Blah::B(x, y) => { } } }
    |                                                                    ^ expected usize, found isize
    |
    = note: expected type `usize`

--- a/src/test/ui/pattern/pat-shadow-in-nested-binding.rs
+++ b/src/test/ui/pattern/pat-shadow-in-nested-binding.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[allow(non_camel_case_types)]
 struct foo(usize);
 
 fn main() {

--- a/src/test/ui/pattern/pat-shadow-in-nested-binding.stderr
+++ b/src/test/ui/pattern/pat-shadow-in-nested-binding.stderr
@@ -1,5 +1,5 @@
 error[E0530]: let bindings cannot shadow tuple structs
-  --> $DIR/pat-shadow-in-nested-binding.rs:14:10
+  --> $DIR/pat-shadow-in-nested-binding.rs:15:10
    |
 LL | struct foo(usize);
    | ------------------ the tuple struct `foo` is defined here

--- a/src/test/ui/pattern/pattern-tyvar-2.rs
+++ b/src/test/ui/pattern/pattern-tyvar-2.rs
@@ -8,10 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-enum bar { t1((), Option<Vec<isize>>), t2, }
+enum Bar { T1((), Option<Vec<isize>>), T2, }
 
-// n.b. my change changes this error message, but I think it's right -- tjc
-fn foo(t: bar) -> isize { match t { bar::t1(_, Some(x)) => { return x * 3; } _ => { panic!(); } } }
+fn foo(t: Bar) -> isize { match t { Bar::T1(_, Some(x)) => { return x * 3; } _ => { panic!(); } } }
 //~^ ERROR binary operation `*` cannot be applied to
 
 fn main() { }

--- a/src/test/ui/pattern/pattern-tyvar-2.stderr
+++ b/src/test/ui/pattern/pattern-tyvar-2.stderr
@@ -1,7 +1,7 @@
 error[E0369]: binary operation `*` cannot be applied to type `std::vec::Vec<isize>`
-  --> $DIR/pattern-tyvar-2.rs:14:69
+  --> $DIR/pattern-tyvar-2.rs:13:69
    |
-LL | fn foo(t: bar) -> isize { match t { bar::t1(_, Some(x)) => { return x * 3; } _ => { panic!(); } } }
+LL | fn foo(t: Bar) -> isize { match t { Bar::T1(_, Some(x)) => { return x * 3; } _ => { panic!(); } } }
    |                                                                     ^^^^^
    |
    = note: an implementation of `std::ops::Mul` might be missing for `std::vec::Vec<isize>`

--- a/src/test/ui/pattern/pattern-tyvar.rs
+++ b/src/test/ui/pattern/pattern-tyvar.rs
@@ -8,13 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: mismatched types
+enum Bar { T1((), Option<Vec<isize>>), T2 }
 
-enum bar { t1((), Option<Vec<isize> >), t2, }
-
-fn foo(t: bar) {
+fn foo(t: Bar) {
     match t {
-      bar::t1(_, Some::<isize>(x)) => {
+      Bar::T1(_, Some::<isize>(x)) => { //~ ERROR mismatched types
         println!("{}", x);
       }
       _ => { panic!(); }

--- a/src/test/ui/pattern/pattern-tyvar.stderr
+++ b/src/test/ui/pattern/pattern-tyvar.stderr
@@ -1,7 +1,7 @@
 error[E0308]: mismatched types
-  --> $DIR/pattern-tyvar.rs:17:18
+  --> $DIR/pattern-tyvar.rs:15:18
    |
-LL |       bar::t1(_, Some::<isize>(x)) => {
+LL |       Bar::T1(_, Some::<isize>(x)) => { //~ ERROR mismatched types
    |                  ^^^^^^^^^^^^^^^^ expected struct `std::vec::Vec`, found isize
    |
    = note: expected type `std::option::Option<std::vec::Vec<isize>>`

--- a/src/test/ui/privacy/private-method.rs
+++ b/src/test/ui/privacy/private-method.rs
@@ -8,21 +8,19 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:method `nap` is private
-
 mod kitties {
-    pub struct cat {
+    pub struct Cat {
         meows : usize,
 
         how_hungry : isize,
     }
 
-    impl cat {
+    impl Cat {
         fn nap(&self) {}
     }
 
-    pub fn cat(in_x : usize, in_y : isize) -> cat {
-        cat {
+    pub fn cat(in_x : usize, in_y : isize) -> Cat {
+        Cat {
             meows: in_x,
             how_hungry: in_y
         }
@@ -30,6 +28,6 @@ mod kitties {
 }
 
 fn main() {
-  let nyan : kitties::cat = kitties::cat(52, 99);
-  nyan.nap();
+  let nyan : kitties::Cat = kitties::cat(52, 99);
+  nyan.nap(); //~ ERROR method `nap` is private
 }

--- a/src/test/ui/privacy/private-method.stderr
+++ b/src/test/ui/privacy/private-method.stderr
@@ -1,7 +1,7 @@
 error[E0624]: method `nap` is private
-  --> $DIR/private-method.rs:34:8
+  --> $DIR/private-method.rs:32:8
    |
-LL |   nyan.nap();
+LL |   nyan.nap(); //~ ERROR method `nap` is private
    |        ^^^
 
 error: aborting due to previous error

--- a/src/test/ui/recursion/recursive-enum.rs
+++ b/src/test/ui/recursion/recursive-enum.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-enum list<T> { cons(T, list<T>), nil }
-//~^ ERROR recursive type `list` has infinite size
+enum List<T> { Cons(T, List<T>), Nil }
+//~^ ERROR recursive type `List` has infinite size
 
 fn main() {}

--- a/src/test/ui/recursion/recursive-enum.stderr
+++ b/src/test/ui/recursion/recursive-enum.stderr
@@ -1,12 +1,12 @@
-error[E0072]: recursive type `list` has infinite size
+error[E0072]: recursive type `List` has infinite size
   --> $DIR/recursive-enum.rs:11:1
    |
-LL | enum list<T> { cons(T, list<T>), nil }
+LL | enum List<T> { Cons(T, List<T>), Nil }
    | ^^^^^^^^^^^^           ------- recursive without indirection
    | |
    | recursive type has infinite size
    |
-   = help: insert indirection (e.g., a `Box`, `Rc`, or `&`) at some point to make `list` representable
+   = help: insert indirection (e.g., a `Box`, `Rc`, or `&`) at some point to make `List` representable
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-addr-of-self.rs
+++ b/src/test/ui/regions/regions-addr-of-self.rs
@@ -8,11 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-struct dog {
+struct Dog {
     cats_chased: usize,
 }
 
-impl dog {
+impl Dog {
     pub fn chase_cat(&mut self) {
         let p: &'static mut usize = &mut self.cats_chased; //~ ERROR cannot infer
         *p += 1;
@@ -24,8 +24,8 @@ impl dog {
     }
 }
 
-fn dog() -> dog {
-    dog {
+fn dog() -> Dog {
+    Dog {
         cats_chased: 0
     }
 }

--- a/src/test/ui/regions/regions-addr-of-upvar-self.rs
+++ b/src/test/ui/regions/regions-addr-of-upvar-self.rs
@@ -10,11 +10,11 @@
 
 use std::usize;
 
-struct dog {
+struct Dog {
     food: usize,
 }
 
-impl dog {
+impl Dog {
     pub fn chase_cat(&mut self) {
         let _f = || {
             let p: &'static mut usize = &mut self.food; //~ ERROR cannot infer

--- a/src/test/ui/regions/regions-bounds.rs
+++ b/src/test/ui/regions/regions-bounds.rs
@@ -12,14 +12,14 @@
 // nominal types (but not on other types) and that they are type
 // checked.
 
-struct an_enum<'a>(&'a isize);
-struct a_class<'a> { x:&'a isize }
+struct TupleStruct<'a>(&'a isize);
+struct Struct<'a> { x:&'a isize }
 
-fn a_fn1<'a,'b>(e: an_enum<'a>) -> an_enum<'b> {
+fn a_fn1<'a,'b>(e: TupleStruct<'a>) -> TupleStruct<'b> {
     return e; //~ ERROR mismatched types
 }
 
-fn a_fn3<'a,'b>(e: a_class<'a>) -> a_class<'b> {
+fn a_fn3<'a,'b>(e: Struct<'a>) -> Struct<'b> {
     return e; //~ ERROR mismatched types
 }
 

--- a/src/test/ui/regions/regions-bounds.stderr
+++ b/src/test/ui/regions/regions-bounds.stderr
@@ -4,17 +4,17 @@ error[E0308]: mismatched types
 LL |     return e; //~ ERROR mismatched types
    |            ^ lifetime mismatch
    |
-   = note: expected type `an_enum<'b>`
-              found type `an_enum<'a>`
+   = note: expected type `TupleStruct<'b>`
+              found type `TupleStruct<'a>`
 note: the lifetime 'a as defined on the function body at 18:10...
   --> $DIR/regions-bounds.rs:18:10
    |
-LL | fn a_fn1<'a,'b>(e: an_enum<'a>) -> an_enum<'b> {
+LL | fn a_fn1<'a,'b>(e: TupleStruct<'a>) -> TupleStruct<'b> {
    |          ^^
 note: ...does not necessarily outlive the lifetime 'b as defined on the function body at 18:13
   --> $DIR/regions-bounds.rs:18:13
    |
-LL | fn a_fn1<'a,'b>(e: an_enum<'a>) -> an_enum<'b> {
+LL | fn a_fn1<'a,'b>(e: TupleStruct<'a>) -> TupleStruct<'b> {
    |             ^^
 
 error[E0308]: mismatched types
@@ -23,17 +23,17 @@ error[E0308]: mismatched types
 LL |     return e; //~ ERROR mismatched types
    |            ^ lifetime mismatch
    |
-   = note: expected type `a_class<'b>`
-              found type `a_class<'a>`
+   = note: expected type `Struct<'b>`
+              found type `Struct<'a>`
 note: the lifetime 'a as defined on the function body at 22:10...
   --> $DIR/regions-bounds.rs:22:10
    |
-LL | fn a_fn3<'a,'b>(e: a_class<'a>) -> a_class<'b> {
+LL | fn a_fn3<'a,'b>(e: Struct<'a>) -> Struct<'b> {
    |          ^^
 note: ...does not necessarily outlive the lifetime 'b as defined on the function body at 22:13
   --> $DIR/regions-bounds.rs:22:13
    |
-LL | fn a_fn3<'a,'b>(e: a_class<'a>) -> a_class<'b> {
+LL | fn a_fn3<'a,'b>(e: Struct<'a>) -> Struct<'b> {
    |             ^^
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/regions/regions-creating-enums.nll.stderr
+++ b/src/test/ui/regions/regions-creating-enums.nll.stderr
@@ -1,7 +1,7 @@
 error[E0515]: cannot return reference to temporary value
   --> $DIR/regions-creating-enums.rs:33:16
    |
-LL |         return &ast::num((*f)(x)); //~ ERROR borrowed value does not live long enough
+LL |         return &Ast::Num((*f)(x)); //~ ERROR borrowed value does not live long enough
    |                ^-----------------
    |                ||
    |                |temporary value created here
@@ -10,7 +10,7 @@ LL |         return &ast::num((*f)(x)); //~ ERROR borrowed value does not live l
 error[E0515]: cannot return reference to temporary value
   --> $DIR/regions-creating-enums.rs:38:16
    |
-LL |         return &ast::add(m_x, m_y);  //~ ERROR borrowed value does not live long enough
+LL |         return &Ast::Add(m_x, m_y);  //~ ERROR borrowed value does not live long enough
    |                ^------------------
    |                ||
    |                |temporary value created here

--- a/src/test/ui/regions/regions-creating-enums.rs
+++ b/src/test/ui/regions/regions-creating-enums.rs
@@ -8,34 +8,34 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-enum ast<'a> {
-    num(usize),
-    add(&'a ast<'a>, &'a ast<'a>)
+enum Ast<'a> {
+    Num(usize),
+    Add(&'a Ast<'a>, &'a Ast<'a>)
 }
 
 fn build() {
-    let x = ast::num(3);
-    let y = ast::num(4);
-    let z = ast::add(&x, &y);
+    let x = Ast::Num(3);
+    let y = Ast::Num(4);
+    let z = Ast::Add(&x, &y);
     compute(&z);
 }
 
-fn compute(x: &ast) -> usize {
+fn compute(x: &Ast) -> usize {
     match *x {
-      ast::num(x) => { x }
-      ast::add(x, y) => { compute(x) + compute(y) }
+      Ast::Num(x) => { x }
+      Ast::Add(x, y) => { compute(x) + compute(y) }
     }
 }
 
-fn map_nums<'a,'b, F>(x: &ast, f: &mut F) -> &'a ast<'b> where F: FnMut(usize) -> usize {
+fn map_nums<'a,'b, F>(x: &Ast, f: &mut F) -> &'a Ast<'b> where F: FnMut(usize) -> usize {
     match *x {
-      ast::num(x) => {
-        return &ast::num((*f)(x)); //~ ERROR borrowed value does not live long enough
+      Ast::Num(x) => {
+        return &Ast::Num((*f)(x)); //~ ERROR borrowed value does not live long enough
       }
-      ast::add(x, y) => {
+      Ast::Add(x, y) => {
         let m_x = map_nums(x, f);
         let m_y = map_nums(y, f);
-        return &ast::add(m_x, m_y);  //~ ERROR borrowed value does not live long enough
+        return &Ast::Add(m_x, m_y);  //~ ERROR borrowed value does not live long enough
       }
     }
 }

--- a/src/test/ui/regions/regions-creating-enums.stderr
+++ b/src/test/ui/regions/regions-creating-enums.stderr
@@ -1,7 +1,7 @@
 error[E0597]: borrowed value does not live long enough
   --> $DIR/regions-creating-enums.rs:33:17
    |
-LL |         return &ast::num((*f)(x)); //~ ERROR borrowed value does not live long enough
+LL |         return &Ast::Num((*f)(x)); //~ ERROR borrowed value does not live long enough
    |                 ^^^^^^^^^^^^^^^^^- temporary value only lives until here
    |                 |
    |                 temporary value does not live long enough
@@ -9,14 +9,14 @@ LL |         return &ast::num((*f)(x)); //~ ERROR borrowed value does not live l
 note: borrowed value must be valid for the lifetime 'a as defined on the function body at 30:13...
   --> $DIR/regions-creating-enums.rs:30:13
    |
-LL | fn map_nums<'a,'b, F>(x: &ast, f: &mut F) -> &'a ast<'b> where F: FnMut(usize) -> usize {
+LL | fn map_nums<'a,'b, F>(x: &Ast, f: &mut F) -> &'a Ast<'b> where F: FnMut(usize) -> usize {
    |             ^^
    = note: consider using a `let` binding to increase its lifetime
 
 error[E0597]: borrowed value does not live long enough
   --> $DIR/regions-creating-enums.rs:38:17
    |
-LL |         return &ast::add(m_x, m_y);  //~ ERROR borrowed value does not live long enough
+LL |         return &Ast::Add(m_x, m_y);  //~ ERROR borrowed value does not live long enough
    |                 ^^^^^^^^^^^^^^^^^^- temporary value only lives until here
    |                 |
    |                 temporary value does not live long enough
@@ -24,7 +24,7 @@ LL |         return &ast::add(m_x, m_y);  //~ ERROR borrowed value does not live
 note: borrowed value must be valid for the lifetime 'a as defined on the function body at 30:13...
   --> $DIR/regions-creating-enums.rs:30:13
    |
-LL | fn map_nums<'a,'b, F>(x: &ast, f: &mut F) -> &'a ast<'b> where F: FnMut(usize) -> usize {
+LL | fn map_nums<'a,'b, F>(x: &Ast, f: &mut F) -> &'a Ast<'b> where F: FnMut(usize) -> usize {
    |             ^^
    = note: consider using a `let` binding to increase its lifetime
 

--- a/src/test/ui/regions/regions-creating-enums3.rs
+++ b/src/test/ui/regions/regions-creating-enums3.rs
@@ -8,13 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-enum ast<'a> {
-    num(usize),
-    add(&'a ast<'a>, &'a ast<'a>)
+enum Ast<'a> {
+    Num(usize),
+    Add(&'a Ast<'a>, &'a Ast<'a>)
 }
 
-fn mk_add_bad1<'a,'b>(x: &'a ast<'a>, y: &'b ast<'b>) -> ast<'a> {
-    ast::add(x, y) //~ ERROR 17:5: 17:19: lifetime mismatch [E0623]
+fn mk_add_bad1<'a,'b>(x: &'a Ast<'a>, y: &'b Ast<'b>) -> Ast<'a> {
+    Ast::Add(x, y) //~ ERROR 17:5: 17:19: lifetime mismatch [E0623]
 }
 
 fn main() {

--- a/src/test/ui/regions/regions-creating-enums3.stderr
+++ b/src/test/ui/regions/regions-creating-enums3.stderr
@@ -1,11 +1,11 @@
 error[E0623]: lifetime mismatch
   --> $DIR/regions-creating-enums3.rs:17:5
    |
-LL | fn mk_add_bad1<'a,'b>(x: &'a ast<'a>, y: &'b ast<'b>) -> ast<'a> {
+LL | fn mk_add_bad1<'a,'b>(x: &'a Ast<'a>, y: &'b Ast<'b>) -> Ast<'a> {
    |                                          -----------     -------
    |                                          |
    |                                          this parameter and the return type are declared with different lifetimes...
-LL |     ast::add(x, y) //~ ERROR 17:5: 17:19: lifetime mismatch [E0623]
+LL |     Ast::Add(x, y) //~ ERROR 17:5: 17:19: lifetime mismatch [E0623]
    |     ^^^^^^^^^^^^^^ ...but data from `y` is returned here
 
 error: aborting due to previous error

--- a/src/test/ui/regions/regions-creating-enums4.rs
+++ b/src/test/ui/regions/regions-creating-enums4.rs
@@ -8,13 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-enum ast<'a> {
-    num(usize),
-    add(&'a ast<'a>, &'a ast<'a>)
+enum Ast<'a> {
+    Num(usize),
+    Add(&'a Ast<'a>, &'a Ast<'a>)
 }
 
-fn mk_add_bad2<'a,'b>(x: &'a ast<'a>, y: &'a ast<'a>, z: &ast) -> ast<'b> {
-    ast::add(x, y) //~ ERROR cannot infer
+fn mk_add_bad2<'a,'b>(x: &'a Ast<'a>, y: &'a Ast<'a>, z: &Ast) -> Ast<'b> {
+    Ast::Add(x, y) //~ ERROR cannot infer
 }
 
 fn main() {

--- a/src/test/ui/regions/regions-creating-enums4.stderr
+++ b/src/test/ui/regions/regions-creating-enums4.stderr
@@ -1,25 +1,25 @@
 error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'a` due to conflicting requirements
   --> $DIR/regions-creating-enums4.rs:17:5
    |
-LL |     ast::add(x, y) //~ ERROR cannot infer
+LL |     Ast::Add(x, y) //~ ERROR cannot infer
    |     ^^^^^^^^
    |
 note: first, the lifetime cannot outlive the lifetime 'a as defined on the function body at 16:16...
   --> $DIR/regions-creating-enums4.rs:16:16
    |
-LL | fn mk_add_bad2<'a,'b>(x: &'a ast<'a>, y: &'a ast<'a>, z: &ast) -> ast<'b> {
+LL | fn mk_add_bad2<'a,'b>(x: &'a Ast<'a>, y: &'a Ast<'a>, z: &Ast) -> Ast<'b> {
    |                ^^
    = note: ...so that the expression is assignable:
-           expected &ast<'_>
-              found &ast<'a>
+           expected &Ast<'_>
+              found &Ast<'a>
 note: but, the lifetime must be valid for the lifetime 'b as defined on the function body at 16:19...
   --> $DIR/regions-creating-enums4.rs:16:19
    |
-LL | fn mk_add_bad2<'a,'b>(x: &'a ast<'a>, y: &'a ast<'a>, z: &ast) -> ast<'b> {
+LL | fn mk_add_bad2<'a,'b>(x: &'a Ast<'a>, y: &'a Ast<'a>, z: &Ast) -> Ast<'b> {
    |                   ^^
    = note: ...so that the expression is assignable:
-           expected ast<'b>
-              found ast<'_>
+           expected Ast<'b>
+              found Ast<'_>
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-in-enums.rs
+++ b/src/test/ui/regions/regions-in-enums.rs
@@ -11,19 +11,19 @@
 // Test that lifetimes must be declared for use on enums.
 // See also regions-undeclared.rs
 
-enum yes0<'lt> {
+enum Yes0<'lt> {
     X3(&'lt usize)
 }
 
-enum yes1<'a> {
+enum Yes1<'a> {
     X4(&'a usize)
 }
 
-enum no0 {
+enum No0 {
     X5(&'foo usize) //~ ERROR use of undeclared lifetime name `'foo`
 }
 
-enum no1 {
+enum No1 {
     X6(&'a usize) //~ ERROR use of undeclared lifetime name `'a`
 }
 

--- a/src/test/ui/regions/regions-in-structs.rs
+++ b/src/test/ui/regions/regions-in-structs.rs
@@ -8,11 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-struct yes1<'a> {
+struct Yes1<'a> {
   x: &'a usize,
 }
 
-struct yes2<'a> {
+struct Yes2<'a> {
   x: &'a usize,
 }
 

--- a/src/test/ui/regions/regions-infer-at-fn-not-param.rs
+++ b/src/test/ui/regions/regions-infer-at-fn-not-param.rs
@@ -8,22 +8,22 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-struct parameterized1<'a> {
+struct Parameterized1<'a> {
     g: Box<FnMut() + 'a>
 }
 
-struct not_parameterized1 {
+struct NotParameterized1 {
     g: Box<FnMut() + 'static>
 }
 
-struct not_parameterized2 {
+struct NotParameterized2 {
     g: Box<FnMut() + 'static>
 }
 
-fn take1<'a>(p: parameterized1) -> parameterized1<'a> { p }
+fn take1<'a>(p: Parameterized1) -> Parameterized1<'a> { p }
 //~^ ERROR explicit lifetime required in the type of `p`
 
-fn take3(p: not_parameterized1) -> not_parameterized1 { p }
-fn take4(p: not_parameterized2) -> not_parameterized2 { p }
+fn take3(p: NotParameterized1) -> NotParameterized1 { p }
+fn take4(p: NotParameterized2) -> NotParameterized2 { p }
 
 fn main() {}

--- a/src/test/ui/regions/regions-infer-at-fn-not-param.stderr
+++ b/src/test/ui/regions/regions-infer-at-fn-not-param.stderr
@@ -1,10 +1,10 @@
 error[E0621]: explicit lifetime required in the type of `p`
   --> $DIR/regions-infer-at-fn-not-param.rs:23:57
    |
-LL | fn take1<'a>(p: parameterized1) -> parameterized1<'a> { p }
+LL | fn take1<'a>(p: Parameterized1) -> Parameterized1<'a> { p }
    |                 --------------                          ^ lifetime `'a` required
    |                 |
-   |                 help: add explicit lifetime `'a` to the type of `p`: `parameterized1<'a>`
+   |                 help: add explicit lifetime `'a` to the type of `p`: `Parameterized1<'a>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-infer-borrow-scope-too-big.nll.stderr
+++ b/src/test/ui/regions/regions-infer-borrow-scope-too-big.nll.stderr
@@ -1,5 +1,5 @@
 error[E0515]: cannot return value referencing local data `*p`
-  --> $DIR/regions-infer-borrow-scope-too-big.rs:24:12
+  --> $DIR/regions-infer-borrow-scope-too-big.rs:23:12
    |
 LL |     let xc = x_coord(&*p); //~ ERROR `*p` does not live long enough
    |                      --- `*p` is borrowed here

--- a/src/test/ui/regions/regions-infer-borrow-scope-too-big.rs
+++ b/src/test/ui/regions/regions-infer-borrow-scope-too-big.rs
@@ -8,17 +8,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-
-struct point {
+struct Point {
     x: isize,
     y: isize,
 }
 
-fn x_coord<'r>(p: &'r point) -> &'r isize {
+fn x_coord<'r>(p: &'r Point) -> &'r isize {
     return &p.x;
 }
 
-fn foo<'a>(p: Box<point>) -> &'a isize {
+fn foo<'a>(p: Box<Point>) -> &'a isize {
     let xc = x_coord(&*p); //~ ERROR `*p` does not live long enough
     assert_eq!(*xc, 3);
     return xc;

--- a/src/test/ui/regions/regions-infer-borrow-scope-too-big.stderr
+++ b/src/test/ui/regions/regions-infer-borrow-scope-too-big.stderr
@@ -1,5 +1,5 @@
 error[E0597]: `*p` does not live long enough
-  --> $DIR/regions-infer-borrow-scope-too-big.rs:22:23
+  --> $DIR/regions-infer-borrow-scope-too-big.rs:21:23
    |
 LL |     let xc = x_coord(&*p); //~ ERROR `*p` does not live long enough
    |                       ^^ borrowed value does not live long enough
@@ -7,10 +7,10 @@ LL |     let xc = x_coord(&*p); //~ ERROR `*p` does not live long enough
 LL | }
    | - borrowed value only lives until here
    |
-note: borrowed value must be valid for the lifetime 'a as defined on the function body at 21:8...
-  --> $DIR/regions-infer-borrow-scope-too-big.rs:21:8
+note: borrowed value must be valid for the lifetime 'a as defined on the function body at 20:8...
+  --> $DIR/regions-infer-borrow-scope-too-big.rs:20:8
    |
-LL | fn foo<'a>(p: Box<point>) -> &'a isize {
+LL | fn foo<'a>(p: Box<Point>) -> &'a isize {
    |        ^^
 
 error: aborting due to previous error

--- a/src/test/ui/regions/regions-infer-invariance-due-to-decl.rs
+++ b/src/test/ui/regions/regions-infer-invariance-due-to-decl.rs
@@ -10,15 +10,15 @@
 
 use std::marker;
 
-struct invariant<'a> {
+struct Invariant<'a> {
     marker: marker::PhantomData<*mut &'a()>
 }
 
-fn to_same_lifetime<'r>(b_isize: invariant<'r>) {
-    let bj: invariant<'r> = b_isize;
+fn to_same_lifetime<'r>(b_isize: Invariant<'r>) {
+    let bj: Invariant<'r> = b_isize;
 }
 
-fn to_longer_lifetime<'r>(b_isize: invariant<'r>) -> invariant<'static> {
+fn to_longer_lifetime<'r>(b_isize: Invariant<'r>) -> Invariant<'static> {
     b_isize //~ ERROR mismatched types
 }
 

--- a/src/test/ui/regions/regions-infer-invariance-due-to-decl.stderr
+++ b/src/test/ui/regions/regions-infer-invariance-due-to-decl.stderr
@@ -4,12 +4,12 @@ error[E0308]: mismatched types
 LL |     b_isize //~ ERROR mismatched types
    |     ^^^^^^^ lifetime mismatch
    |
-   = note: expected type `invariant<'static>`
-              found type `invariant<'r>`
+   = note: expected type `Invariant<'static>`
+              found type `Invariant<'r>`
 note: the lifetime 'r as defined on the function body at 21:23...
   --> $DIR/regions-infer-invariance-due-to-decl.rs:21:23
    |
-LL | fn to_longer_lifetime<'r>(b_isize: invariant<'r>) -> invariant<'static> {
+LL | fn to_longer_lifetime<'r>(b_isize: Invariant<'r>) -> Invariant<'static> {
    |                       ^^
    = note: ...does not necessarily outlive the static lifetime
 

--- a/src/test/ui/regions/regions-infer-invariance-due-to-mutability-3.rs
+++ b/src/test/ui/regions/regions-infer-invariance-due-to-mutability-3.rs
@@ -9,15 +9,15 @@
 // except according to those terms.
 
 
-struct invariant<'a> {
+struct Invariant<'a> {
     f: Box<FnOnce(&mut &'a isize) + 'static>,
 }
 
-fn to_same_lifetime<'r>(b_isize: invariant<'r>) {
-    let bj: invariant<'r> = b_isize;
+fn to_same_lifetime<'r>(b_isize: Invariant<'r>) {
+    let bj: Invariant<'r> = b_isize;
 }
 
-fn to_longer_lifetime<'r>(b_isize: invariant<'r>) -> invariant<'static> {
+fn to_longer_lifetime<'r>(b_isize: Invariant<'r>) -> Invariant<'static> {
     b_isize //~ ERROR mismatched types
 }
 

--- a/src/test/ui/regions/regions-infer-invariance-due-to-mutability-3.stderr
+++ b/src/test/ui/regions/regions-infer-invariance-due-to-mutability-3.stderr
@@ -4,12 +4,12 @@ error[E0308]: mismatched types
 LL |     b_isize //~ ERROR mismatched types
    |     ^^^^^^^ lifetime mismatch
    |
-   = note: expected type `invariant<'static>`
-              found type `invariant<'r>`
+   = note: expected type `Invariant<'static>`
+              found type `Invariant<'r>`
 note: the lifetime 'r as defined on the function body at 20:23...
   --> $DIR/regions-infer-invariance-due-to-mutability-3.rs:20:23
    |
-LL | fn to_longer_lifetime<'r>(b_isize: invariant<'r>) -> invariant<'static> {
+LL | fn to_longer_lifetime<'r>(b_isize: Invariant<'r>) -> Invariant<'static> {
    |                       ^^
    = note: ...does not necessarily outlive the static lifetime
 

--- a/src/test/ui/regions/regions-infer-not-param.rs
+++ b/src/test/ui/regions/regions-infer-not-param.rs
@@ -8,29 +8,29 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-struct direct<'a> {
+struct Direct<'a> {
     f: &'a isize
 }
 
-struct indirect1 {
+struct Indirect1 {
     // Here the lifetime parameter of direct is bound by the fn()
-    g: Box<FnOnce(direct) + 'static>
+    g: Box<FnOnce(Direct) + 'static>
 }
 
-struct indirect2<'a> {
+struct Indirect2<'a> {
     // But here it is set to 'a
-    g: Box<FnOnce(direct<'a>) + 'static>
+    g: Box<FnOnce(Direct<'a>) + 'static>
 }
 
-fn take_direct<'a,'b>(p: direct<'a>) -> direct<'b> { p } //~ ERROR mismatched types
+fn take_direct<'a,'b>(p: Direct<'a>) -> Direct<'b> { p } //~ ERROR mismatched types
 
-fn take_indirect1(p: indirect1) -> indirect1 { p }
+fn take_indirect1(p: Indirect1) -> Indirect1 { p }
 
-fn take_indirect2<'a,'b>(p: indirect2<'a>) -> indirect2<'b> { p } //~ ERROR mismatched types
-//~| expected type `indirect2<'b>`
-//~| found type `indirect2<'a>`
+fn take_indirect2<'a,'b>(p: Indirect2<'a>) -> Indirect2<'b> { p } //~ ERROR mismatched types
+//~| expected type `Indirect2<'b>`
+//~| found type `Indirect2<'a>`
 //~| ERROR mismatched types
-//~| expected type `indirect2<'b>`
-//~| found type `indirect2<'a>`
+//~| expected type `Indirect2<'b>`
+//~| found type `Indirect2<'a>`
 
 fn main() {}

--- a/src/test/ui/regions/regions-infer-not-param.stderr
+++ b/src/test/ui/regions/regions-infer-not-param.stderr
@@ -1,58 +1,58 @@
 error[E0308]: mismatched types
   --> $DIR/regions-infer-not-param.rs:25:54
    |
-LL | fn take_direct<'a,'b>(p: direct<'a>) -> direct<'b> { p } //~ ERROR mismatched types
+LL | fn take_direct<'a,'b>(p: Direct<'a>) -> Direct<'b> { p } //~ ERROR mismatched types
    |                                                      ^ lifetime mismatch
    |
-   = note: expected type `direct<'b>`
-              found type `direct<'a>`
+   = note: expected type `Direct<'b>`
+              found type `Direct<'a>`
 note: the lifetime 'a as defined on the function body at 25:16...
   --> $DIR/regions-infer-not-param.rs:25:16
    |
-LL | fn take_direct<'a,'b>(p: direct<'a>) -> direct<'b> { p } //~ ERROR mismatched types
+LL | fn take_direct<'a,'b>(p: Direct<'a>) -> Direct<'b> { p } //~ ERROR mismatched types
    |                ^^
 note: ...does not necessarily outlive the lifetime 'b as defined on the function body at 25:19
   --> $DIR/regions-infer-not-param.rs:25:19
    |
-LL | fn take_direct<'a,'b>(p: direct<'a>) -> direct<'b> { p } //~ ERROR mismatched types
+LL | fn take_direct<'a,'b>(p: Direct<'a>) -> Direct<'b> { p } //~ ERROR mismatched types
    |                   ^^
 
 error[E0308]: mismatched types
   --> $DIR/regions-infer-not-param.rs:29:63
    |
-LL | fn take_indirect2<'a,'b>(p: indirect2<'a>) -> indirect2<'b> { p } //~ ERROR mismatched types
+LL | fn take_indirect2<'a,'b>(p: Indirect2<'a>) -> Indirect2<'b> { p } //~ ERROR mismatched types
    |                                                               ^ lifetime mismatch
    |
-   = note: expected type `indirect2<'b>`
-              found type `indirect2<'a>`
+   = note: expected type `Indirect2<'b>`
+              found type `Indirect2<'a>`
 note: the lifetime 'a as defined on the function body at 29:19...
   --> $DIR/regions-infer-not-param.rs:29:19
    |
-LL | fn take_indirect2<'a,'b>(p: indirect2<'a>) -> indirect2<'b> { p } //~ ERROR mismatched types
+LL | fn take_indirect2<'a,'b>(p: Indirect2<'a>) -> Indirect2<'b> { p } //~ ERROR mismatched types
    |                   ^^
 note: ...does not necessarily outlive the lifetime 'b as defined on the function body at 29:22
   --> $DIR/regions-infer-not-param.rs:29:22
    |
-LL | fn take_indirect2<'a,'b>(p: indirect2<'a>) -> indirect2<'b> { p } //~ ERROR mismatched types
+LL | fn take_indirect2<'a,'b>(p: Indirect2<'a>) -> Indirect2<'b> { p } //~ ERROR mismatched types
    |                      ^^
 
 error[E0308]: mismatched types
   --> $DIR/regions-infer-not-param.rs:29:63
    |
-LL | fn take_indirect2<'a,'b>(p: indirect2<'a>) -> indirect2<'b> { p } //~ ERROR mismatched types
+LL | fn take_indirect2<'a,'b>(p: Indirect2<'a>) -> Indirect2<'b> { p } //~ ERROR mismatched types
    |                                                               ^ lifetime mismatch
    |
-   = note: expected type `indirect2<'b>`
-              found type `indirect2<'a>`
+   = note: expected type `Indirect2<'b>`
+              found type `Indirect2<'a>`
 note: the lifetime 'b as defined on the function body at 29:22...
   --> $DIR/regions-infer-not-param.rs:29:22
    |
-LL | fn take_indirect2<'a,'b>(p: indirect2<'a>) -> indirect2<'b> { p } //~ ERROR mismatched types
+LL | fn take_indirect2<'a,'b>(p: Indirect2<'a>) -> Indirect2<'b> { p } //~ ERROR mismatched types
    |                      ^^
 note: ...does not necessarily outlive the lifetime 'a as defined on the function body at 29:19
   --> $DIR/regions-infer-not-param.rs:29:19
    |
-LL | fn take_indirect2<'a,'b>(p: indirect2<'a>) -> indirect2<'b> { p } //~ ERROR mismatched types
+LL | fn take_indirect2<'a,'b>(p: Indirect2<'a>) -> Indirect2<'b> { p } //~ ERROR mismatched types
    |                   ^^
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/regions/regions-infer-paramd-indirect.rs
+++ b/src/test/ui/regions/regions-infer-paramd-indirect.rs
@@ -12,24 +12,24 @@
 // Check that we correctly infer that b and c must be region
 // parameterized because they reference a which requires a region.
 
-type a<'a> = &'a isize;
-type b<'a> = Box<a<'a>>;
+type A<'a> = &'a isize;
+type B<'a> = Box<A<'a>>;
 
-struct c<'a> {
-    f: Box<b<'a>>
+struct C<'a> {
+    f: Box<B<'a>>
 }
 
-trait set_f<'a> {
-    fn set_f_ok(&mut self, b: Box<b<'a>>);
-    fn set_f_bad(&mut self, b: Box<b>);
+trait SetF<'a> {
+    fn set_f_ok(&mut self, b: Box<B<'a>>);
+    fn set_f_bad(&mut self, b: Box<B>);
 }
 
-impl<'a> set_f<'a> for c<'a> {
-    fn set_f_ok(&mut self, b: Box<b<'a>>) {
+impl<'a> SetF<'a> for C<'a> {
+    fn set_f_ok(&mut self, b: Box<B<'a>>) {
         self.f = b;
     }
 
-    fn set_f_bad(&mut self, b: Box<b>) {
+    fn set_f_bad(&mut self, b: Box<B>) {
         self.f = b;
         //~^ ERROR mismatched types
         //~| expected type `std::boxed::Box<std::boxed::Box<&'a isize>>`

--- a/src/test/ui/regions/regions-infer-paramd-indirect.stderr
+++ b/src/test/ui/regions/regions-infer-paramd-indirect.stderr
@@ -9,7 +9,7 @@ LL |         self.f = b;
 note: the anonymous lifetime #2 defined on the method body at 32:5...
   --> $DIR/regions-infer-paramd-indirect.rs:32:5
    |
-LL | /     fn set_f_bad(&mut self, b: Box<b>) {
+LL | /     fn set_f_bad(&mut self, b: Box<B>) {
 LL | |         self.f = b;
 LL | |         //~^ ERROR mismatched types
 LL | |         //~| expected type `std::boxed::Box<std::boxed::Box<&'a isize>>`
@@ -20,7 +20,7 @@ LL | |     }
 note: ...does not necessarily outlive the lifetime 'a as defined on the impl at 27:6
   --> $DIR/regions-infer-paramd-indirect.rs:27:6
    |
-LL | impl<'a> set_f<'a> for c<'a> {
+LL | impl<'a> SetF<'a> for C<'a> {
    |      ^^
 
 error: aborting due to previous error

--- a/src/test/ui/regions/regions-steal-closure.rs
+++ b/src/test/ui/regions/regions-steal-closure.rs
@@ -10,12 +10,12 @@
 
 #![feature(fn_traits)]
 
-struct closure_box<'a> {
+struct ClosureBox<'a> {
     cl: Box<FnMut() + 'a>,
 }
 
-fn box_it<'r>(x: Box<FnMut() + 'r>) -> closure_box<'r> {
-    closure_box {cl: x}
+fn box_it<'r>(x: Box<FnMut() + 'r>) -> ClosureBox<'r> {
+    ClosureBox {cl: x}
 }
 
 fn main() {

--- a/src/test/ui/regions/regions-trait-1.rs
+++ b/src/test/ui/regions/regions-trait-1.rs
@@ -10,31 +10,31 @@
 
 #![feature(box_syntax)]
 
-struct ctxt { v: usize }
+struct Ctxt { v: usize }
 
-trait get_ctxt {
+trait GetCtxt {
     // Here the `&` is bound in the method definition:
-    fn get_ctxt(&self) -> &ctxt;
+    fn get_ctxt(&self) -> &Ctxt;
 }
 
-struct has_ctxt<'a> { c: &'a ctxt }
+struct HasCtxt<'a> { c: &'a Ctxt }
 
-impl<'a> get_ctxt for has_ctxt<'a> {
+impl<'a> GetCtxt for HasCtxt<'a> {
 
     // Here an error occurs because we used `&self` but
     // the definition used `&`:
-    fn get_ctxt(&self) -> &'a ctxt { //~ ERROR method not compatible with trait
+    fn get_ctxt(&self) -> &'a Ctxt { //~ ERROR method not compatible with trait
         self.c
     }
 
 }
 
-fn get_v(gc: Box<get_ctxt>) -> usize {
+fn get_v(gc: Box<GetCtxt>) -> usize {
     gc.get_ctxt().v
 }
 
 fn main() {
-    let ctxt = ctxt { v: 22 };
-    let hc = has_ctxt { c: &ctxt };
-    assert_eq!(get_v(box hc as Box<get_ctxt>), 22);
+    let ctxt = Ctxt { v: 22 };
+    let hc = HasCtxt { c: &ctxt };
+    assert_eq!(get_v(box hc as Box<GetCtxt>), 22);
 }

--- a/src/test/ui/regions/regions-trait-1.stderr
+++ b/src/test/ui/regions/regions-trait-1.stderr
@@ -1,20 +1,20 @@
 error[E0308]: method not compatible with trait
   --> $DIR/regions-trait-1.rs:26:5
    |
-LL |     fn get_ctxt(&self) -> &'a ctxt { //~ ERROR method not compatible with trait
+LL |     fn get_ctxt(&self) -> &'a Ctxt { //~ ERROR method not compatible with trait
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
-   = note: expected type `fn(&has_ctxt<'a>) -> &ctxt`
-              found type `fn(&has_ctxt<'a>) -> &'a ctxt`
+   = note: expected type `fn(&HasCtxt<'a>) -> &Ctxt`
+              found type `fn(&HasCtxt<'a>) -> &'a Ctxt`
 note: the lifetime 'a as defined on the impl at 22:6...
   --> $DIR/regions-trait-1.rs:22:6
    |
-LL | impl<'a> get_ctxt for has_ctxt<'a> {
+LL | impl<'a> GetCtxt for HasCtxt<'a> {
    |      ^^
 note: ...does not necessarily outlive the anonymous lifetime #1 defined on the method body at 26:5
   --> $DIR/regions-trait-1.rs:26:5
    |
-LL | /     fn get_ctxt(&self) -> &'a ctxt { //~ ERROR method not compatible with trait
+LL | /     fn get_ctxt(&self) -> &'a Ctxt { //~ ERROR method not compatible with trait
 LL | |         self.c
 LL | |     }
    | |_____^

--- a/src/test/ui/reject-specialized-drops-8142.rs
+++ b/src/test/ui/reject-specialized-drops-8142.rs
@@ -41,16 +41,16 @@ impl                    Drop for N<'static>     { fn drop(&mut self) { } } // RE
 //~| expected type `N<'n>`
 //~|    found type `N<'static>`
 
-impl<Cok_nobound> Drop for O<Cok_nobound> { fn drop(&mut self) { } } // ACCEPT
+impl<COkNoBound> Drop for O<COkNoBound> { fn drop(&mut self) { } } // ACCEPT
 
 impl              Drop for P<i8>          { fn drop(&mut self) { } } // REJECT
 //~^ ERROR Implementations of Drop cannot be specialized
 
-impl<Adds_bnd:Bound> Drop for Q<Adds_bnd> { fn drop(&mut self) { } } // REJECT
-//~^ ERROR The requirement `Adds_bnd: Bound` is added only by the Drop impl.
+impl<AddsBnd:Bound> Drop for Q<AddsBnd> { fn drop(&mut self) { } } // REJECT
+//~^ ERROR The requirement `AddsBnd: Bound` is added only by the Drop impl.
 
-impl<'rbnd,Adds_rbnd:'rbnd> Drop for R<Adds_rbnd> { fn drop(&mut self) { } } // REJECT
-//~^ ERROR The requirement `Adds_rbnd : 'rbnd` is added only by the Drop impl.
+impl<'rbnd,AddsRBnd:'rbnd> Drop for R<AddsRBnd> { fn drop(&mut self) { } } // REJECT
+//~^ ERROR The requirement `AddsRBnd : 'rbnd` is added only by the Drop impl.
 
 impl<Bs:Bound>    Drop for S<Bs>          { fn drop(&mut self) { } } // ACCEPT
 

--- a/src/test/ui/reject-specialized-drops-8142.stderr
+++ b/src/test/ui/reject-specialized-drops-8142.stderr
@@ -53,11 +53,11 @@ note: Use same sequence of generic type and region parameters that is on the str
 LL | struct P<Tp> { x: *const Tp }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0367]: The requirement `Adds_bnd: Bound` is added only by the Drop impl.
+error[E0367]: The requirement `AddsBnd: Bound` is added only by the Drop impl.
   --> $DIR/reject-specialized-drops-8142.rs:49:1
    |
-LL | impl<Adds_bnd:Bound> Drop for Q<Adds_bnd> { fn drop(&mut self) { } } // REJECT
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | impl<AddsBnd:Bound> Drop for Q<AddsBnd> { fn drop(&mut self) { } } // REJECT
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: The same requirement must be part of the struct/enum definition
   --> $DIR/reject-specialized-drops-8142.rs:21:1
@@ -65,11 +65,11 @@ note: The same requirement must be part of the struct/enum definition
 LL | struct Q<Tq> { x: *const Tq }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0367]: The requirement `Adds_rbnd : 'rbnd` is added only by the Drop impl.
+error[E0367]: The requirement `AddsRBnd : 'rbnd` is added only by the Drop impl.
   --> $DIR/reject-specialized-drops-8142.rs:52:1
    |
-LL | impl<'rbnd,Adds_rbnd:'rbnd> Drop for R<Adds_rbnd> { fn drop(&mut self) { } } // REJECT
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | impl<'rbnd,AddsRBnd:'rbnd> Drop for R<AddsRBnd> { fn drop(&mut self) { } } // REJECT
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: The same requirement must be part of the struct/enum definition
   --> $DIR/reject-specialized-drops-8142.rs:22:1

--- a/src/test/ui/resolve/issue-2356.rs
+++ b/src/test/ui/resolve/issue-2356.rs
@@ -12,7 +12,7 @@ trait Groom {
     fn shave(other: usize);
 }
 
-pub struct cat {
+pub struct Cat {
   whiskers: isize,
 }
 
@@ -29,14 +29,14 @@ impl MaybeDog {
   }
 }
 
-impl Clone for cat {
+impl Clone for Cat {
   fn clone(&self) -> Self {
     clone();
     //~^ ERROR cannot find function `clone`
     loop {}
   }
 }
-impl Default for cat {
+impl Default for Cat {
   fn default() -> Self {
     default();
     //~^ ERROR cannot find function `default`
@@ -44,7 +44,7 @@ impl Default for cat {
   }
 }
 
-impl Groom for cat {
+impl Groom for Cat {
   fn shave(other: usize) {
     whiskers -= other;
     //~^ ERROR cannot find value `whiskers`
@@ -55,7 +55,7 @@ impl Groom for cat {
   }
 }
 
-impl cat {
+impl Cat {
     fn static_method() {}
 
     fn purr_louder() {
@@ -70,7 +70,7 @@ impl cat {
     }
 }
 
-impl cat {
+impl Cat {
   fn meow() {
     if self.whiskers > 3 {
         //~^ ERROR expected value, found module `self`

--- a/src/test/ui/resolve/resolve-inconsistent-binding-mode.rs
+++ b/src/test/ui/resolve/resolve-inconsistent-binding-mode.rs
@@ -8,42 +8,42 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-enum opts {
-    a(isize), b(isize), c(isize)
+enum Opts {
+    A(isize), B(isize), C(isize)
 }
 
-fn matcher1(x: opts) {
+fn matcher1(x: Opts) {
     match x {
-      opts::a(ref i) | opts::b(i) => {}
+      Opts::A(ref i) | Opts::B(i) => {}
       //~^ ERROR variable `i` is bound in inconsistent ways within the same match arm
       //~^^ ERROR mismatched types
-      opts::c(_) => {}
+      Opts::C(_) => {}
     }
 }
 
-fn matcher2(x: opts) {
+fn matcher2(x: Opts) {
     match x {
-      opts::a(ref i) | opts::b(i) => {}
+      Opts::A(ref i) | Opts::B(i) => {}
       //~^ ERROR variable `i` is bound in inconsistent ways within the same match arm
       //~^^ ERROR mismatched types
-      opts::c(_) => {}
+      Opts::C(_) => {}
     }
 }
 
-fn matcher4(x: opts) {
+fn matcher4(x: Opts) {
     match x {
-      opts::a(ref mut i) | opts::b(ref i) => {}
+      Opts::A(ref mut i) | Opts::B(ref i) => {}
       //~^ ERROR variable `i` is bound in inconsistent ways within the same match arm
       //~^^ ERROR mismatched types
-      opts::c(_) => {}
+      Opts::C(_) => {}
     }
 }
 
 
-fn matcher5(x: opts) {
+fn matcher5(x: Opts) {
     match x {
-      opts::a(ref i) | opts::b(ref i) => {}
-      opts::c(_) => {}
+      Opts::A(ref i) | Opts::B(ref i) => {}
+      Opts::C(_) => {}
     }
 }
 

--- a/src/test/ui/resolve/resolve-inconsistent-binding-mode.stderr
+++ b/src/test/ui/resolve/resolve-inconsistent-binding-mode.stderr
@@ -1,7 +1,7 @@
 error[E0409]: variable `i` is bound in inconsistent ways within the same match arm
   --> $DIR/resolve-inconsistent-binding-mode.rs:17:32
    |
-LL |       opts::a(ref i) | opts::b(i) => {}
+LL |       Opts::A(ref i) | Opts::B(i) => {}
    |                   -            ^ bound in different ways
    |                   |
    |                   first binding
@@ -9,7 +9,7 @@ LL |       opts::a(ref i) | opts::b(i) => {}
 error[E0409]: variable `i` is bound in inconsistent ways within the same match arm
   --> $DIR/resolve-inconsistent-binding-mode.rs:26:32
    |
-LL |       opts::a(ref i) | opts::b(i) => {}
+LL |       Opts::A(ref i) | Opts::B(i) => {}
    |                   -            ^ bound in different ways
    |                   |
    |                   first binding
@@ -17,13 +17,13 @@ LL |       opts::a(ref i) | opts::b(i) => {}
 error[E0409]: variable `i` is bound in inconsistent ways within the same match arm
   --> $DIR/resolve-inconsistent-binding-mode.rs:35:40
    |
-LL |       opts::a(ref mut i) | opts::b(ref i) => {}
+LL |       Opts::A(ref mut i) | Opts::B(ref i) => {}
    |                       - first binding  ^ bound in different ways
 
 error[E0308]: mismatched types
   --> $DIR/resolve-inconsistent-binding-mode.rs:17:32
    |
-LL |       opts::a(ref i) | opts::b(i) => {}
+LL |       Opts::A(ref i) | Opts::B(i) => {}
    |                                ^ expected &isize, found isize
    |
    = note: expected type `&isize`
@@ -32,7 +32,7 @@ LL |       opts::a(ref i) | opts::b(i) => {}
 error[E0308]: mismatched types
   --> $DIR/resolve-inconsistent-binding-mode.rs:26:32
    |
-LL |       opts::a(ref i) | opts::b(i) => {}
+LL |       Opts::A(ref i) | Opts::B(i) => {}
    |                                ^ expected &isize, found isize
    |
    = note: expected type `&isize`
@@ -41,7 +41,7 @@ LL |       opts::a(ref i) | opts::b(i) => {}
 error[E0308]: mismatched types
   --> $DIR/resolve-inconsistent-binding-mode.rs:35:36
    |
-LL |       opts::a(ref mut i) | opts::b(ref i) => {}
+LL |       Opts::A(ref mut i) | Opts::B(ref i) => {}
    |                                    ^^^^^ types differ in mutability
    |
    = note: expected type `&mut isize`

--- a/src/test/ui/rust-2018/future-proofing-locals.rs
+++ b/src/test/ui/rust-2018/future-proofing-locals.rs
@@ -1,6 +1,7 @@
 // edition:2018
 
 #![feature(uniform_paths)]
+#![allow(non_camel_case_types)]
 
 mod T {
     pub struct U;

--- a/src/test/ui/rust-2018/future-proofing-locals.stderr
+++ b/src/test/ui/rust-2018/future-proofing-locals.stderr
@@ -1,47 +1,47 @@
 error: imports cannot refer to type parameters
-  --> $DIR/future-proofing-locals.rs:13:9
+  --> $DIR/future-proofing-locals.rs:14:9
    |
 LL |     use T as _; //~ ERROR imports cannot refer to type parameters
    |         ^
 
 error: imports cannot refer to type parameters
-  --> $DIR/future-proofing-locals.rs:14:9
+  --> $DIR/future-proofing-locals.rs:15:9
    |
 LL |     use T::U; //~ ERROR imports cannot refer to type parameters
    |         ^
 
 error: imports cannot refer to type parameters
-  --> $DIR/future-proofing-locals.rs:15:9
+  --> $DIR/future-proofing-locals.rs:16:9
    |
 LL |     use T::*; //~ ERROR imports cannot refer to type parameters
    |         ^
 
 error: imports cannot refer to local variables
-  --> $DIR/future-proofing-locals.rs:25:9
+  --> $DIR/future-proofing-locals.rs:26:9
    |
 LL |     use x as _; //~ ERROR imports cannot refer to local variables
    |         ^
 
 error: imports cannot refer to local variables
-  --> $DIR/future-proofing-locals.rs:31:9
+  --> $DIR/future-proofing-locals.rs:32:9
    |
 LL |     use x; //~ ERROR imports cannot refer to local variables
    |         ^
 
 error: imports cannot refer to local variables
-  --> $DIR/future-proofing-locals.rs:37:17
+  --> $DIR/future-proofing-locals.rs:38:17
    |
 LL |             use x; //~ ERROR imports cannot refer to local variables
    |                 ^
 
 error: imports cannot refer to type parameters
-  --> $DIR/future-proofing-locals.rs:45:10
+  --> $DIR/future-proofing-locals.rs:46:10
    |
 LL |     use {T as _, x}; //~ ERROR imports cannot refer to type parameters
    |          ^
 
 error: imports cannot refer to local variables
-  --> $DIR/future-proofing-locals.rs:45:18
+  --> $DIR/future-proofing-locals.rs:46:18
    |
 LL |     use {T as _, x}; //~ ERROR imports cannot refer to type parameters
    |                  ^

--- a/src/test/ui/rust-2018/uniform-paths/ambiguity-macros-nested.rs
+++ b/src/test/ui/rust-2018/uniform-paths/ambiguity-macros-nested.rs
@@ -12,6 +12,8 @@
 
 // This test is similar to `ambiguity-macros.rs`, but nested in a module.
 
+#![allow(non_camel_case_types)]
+
 mod foo {
     pub use std::io;
     //~^ ERROR `std` is ambiguous

--- a/src/test/ui/rust-2018/uniform-paths/ambiguity-macros-nested.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/ambiguity-macros-nested.stderr
@@ -1,5 +1,5 @@
 error[E0659]: `std` is ambiguous (name vs any other name during import resolution)
-  --> $DIR/ambiguity-macros-nested.rs:16:13
+  --> $DIR/ambiguity-macros-nested.rs:18:13
    |
 LL |     pub use std::io;
    |             ^^^ ambiguous name
@@ -7,7 +7,7 @@ LL |     pub use std::io;
    = note: `std` could refer to a built-in extern crate
    = help: use `::std` to refer to this extern crate unambiguously
 note: `std` could also refer to the module defined here
-  --> $DIR/ambiguity-macros-nested.rs:21:13
+  --> $DIR/ambiguity-macros-nested.rs:23:13
    |
 LL | /             mod std {
 LL | |                 pub struct io;

--- a/src/test/ui/rust-2018/uniform-paths/ambiguity-macros.rs
+++ b/src/test/ui/rust-2018/uniform-paths/ambiguity-macros.rs
@@ -12,6 +12,8 @@
 
 // This test is similar to `ambiguity.rs`, but with macros defining local items.
 
+#![allow(non_camel_case_types)]
+
 use std::io;
 //~^ ERROR `std` is ambiguous
 

--- a/src/test/ui/rust-2018/uniform-paths/ambiguity-macros.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/ambiguity-macros.stderr
@@ -1,5 +1,5 @@
 error[E0659]: `std` is ambiguous (name vs any other name during import resolution)
-  --> $DIR/ambiguity-macros.rs:15:5
+  --> $DIR/ambiguity-macros.rs:17:5
    |
 LL | use std::io;
    |     ^^^ ambiguous name
@@ -7,7 +7,7 @@ LL | use std::io;
    = note: `std` could refer to a built-in extern crate
    = help: use `::std` to refer to this extern crate unambiguously
 note: `std` could also refer to the module defined here
-  --> $DIR/ambiguity-macros.rs:20:9
+  --> $DIR/ambiguity-macros.rs:22:9
    |
 LL | /         mod std {
 LL | |             pub struct io;

--- a/src/test/ui/rust-2018/uniform-paths/ambiguity-nested.rs
+++ b/src/test/ui/rust-2018/uniform-paths/ambiguity-nested.rs
@@ -12,6 +12,8 @@
 
 // This test is similar to `ambiguity.rs`, but nested in a module.
 
+#![allow(non_camel_case_types)]
+
 mod foo {
     pub use std::io;
     //~^ ERROR `std` is ambiguous

--- a/src/test/ui/rust-2018/uniform-paths/ambiguity-nested.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/ambiguity-nested.stderr
@@ -1,5 +1,5 @@
 error[E0659]: `std` is ambiguous (name vs any other name during import resolution)
-  --> $DIR/ambiguity-nested.rs:16:13
+  --> $DIR/ambiguity-nested.rs:18:13
    |
 LL |     pub use std::io;
    |             ^^^ ambiguous name
@@ -7,7 +7,7 @@ LL |     pub use std::io;
    = note: `std` could refer to a built-in extern crate
    = help: use `::std` to refer to this extern crate unambiguously
 note: `std` could also refer to the module defined here
-  --> $DIR/ambiguity-nested.rs:19:5
+  --> $DIR/ambiguity-nested.rs:21:5
    |
 LL | /     mod std {
 LL | |         pub struct io;

--- a/src/test/ui/rust-2018/uniform-paths/ambiguity.rs
+++ b/src/test/ui/rust-2018/uniform-paths/ambiguity.rs
@@ -10,6 +10,8 @@
 
 // edition:2018
 
+#![allow(non_camel_case_types)]
+
 use std::io;
 //~^ ERROR `std` is ambiguous
 

--- a/src/test/ui/rust-2018/uniform-paths/ambiguity.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/ambiguity.stderr
@@ -1,5 +1,5 @@
 error[E0659]: `std` is ambiguous (name vs any other name during import resolution)
-  --> $DIR/ambiguity.rs:13:5
+  --> $DIR/ambiguity.rs:15:5
    |
 LL | use std::io;
    |     ^^^ ambiguous name
@@ -7,7 +7,7 @@ LL | use std::io;
    = note: `std` could refer to a built-in extern crate
    = help: use `::std` to refer to this extern crate unambiguously
 note: `std` could also refer to the module defined here
-  --> $DIR/ambiguity.rs:16:1
+  --> $DIR/ambiguity.rs:18:1
    |
 LL | / mod std {
 LL | |     pub struct io;

--- a/src/test/ui/rust-2018/uniform-paths/block-scoped-shadow.rs
+++ b/src/test/ui/rust-2018/uniform-paths/block-scoped-shadow.rs
@@ -10,6 +10,8 @@
 
 // edition:2018
 
+#![allow(non_camel_case_types)]
+
 enum Foo {}
 
 struct std;

--- a/src/test/ui/rust-2018/uniform-paths/block-scoped-shadow.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/block-scoped-shadow.stderr
@@ -1,52 +1,52 @@
 error[E0659]: `Foo` is ambiguous (name vs any other name during import resolution)
-  --> $DIR/block-scoped-shadow.rs:19:9
+  --> $DIR/block-scoped-shadow.rs:21:9
    |
 LL |     use Foo::*;
    |         ^^^ ambiguous name
    |
 note: `Foo` could refer to the enum defined here
-  --> $DIR/block-scoped-shadow.rs:18:5
+  --> $DIR/block-scoped-shadow.rs:20:5
    |
 LL |     enum Foo { A, B }
    |     ^^^^^^^^^^^^^^^^^
 note: `Foo` could also refer to the enum defined here
-  --> $DIR/block-scoped-shadow.rs:13:1
+  --> $DIR/block-scoped-shadow.rs:15:1
    |
 LL | enum Foo {}
    | ^^^^^^^^^^^
    = help: use `crate::Foo` to refer to this enum unambiguously
 
 error[E0659]: `std` is ambiguous (name vs any other name during import resolution)
-  --> $DIR/block-scoped-shadow.rs:26:9
+  --> $DIR/block-scoped-shadow.rs:28:9
    |
 LL |     use std as foo;
    |         ^^^ ambiguous name
    |
 note: `std` could refer to the enum defined here
-  --> $DIR/block-scoped-shadow.rs:25:5
+  --> $DIR/block-scoped-shadow.rs:27:5
    |
 LL |     enum std {}
    |     ^^^^^^^^^^^
 note: `std` could also refer to the struct defined here
-  --> $DIR/block-scoped-shadow.rs:15:1
+  --> $DIR/block-scoped-shadow.rs:17:1
    |
 LL | struct std;
    | ^^^^^^^^^^^
    = help: use `crate::std` to refer to this struct unambiguously
 
 error[E0659]: `std` is ambiguous (name vs any other name during import resolution)
-  --> $DIR/block-scoped-shadow.rs:26:9
+  --> $DIR/block-scoped-shadow.rs:28:9
    |
 LL |     use std as foo;
    |         ^^^ ambiguous name
    |
 note: `std` could refer to the function defined here
-  --> $DIR/block-scoped-shadow.rs:24:5
+  --> $DIR/block-scoped-shadow.rs:26:5
    |
 LL |     fn std() {}
    |     ^^^^^^^^^^^
 note: `std` could also refer to the unit struct defined here
-  --> $DIR/block-scoped-shadow.rs:15:1
+  --> $DIR/block-scoped-shadow.rs:17:1
    |
 LL | struct std;
    | ^^^^^^^^^^^

--- a/src/test/ui/rust-2018/uniform-paths/macro-rules.rs
+++ b/src/test/ui/rust-2018/uniform-paths/macro-rules.rs
@@ -3,6 +3,7 @@
 // For the time being `macro_rules` items are treated as *very* private...
 
 #![feature(decl_macro, uniform_paths)]
+#![allow(non_camel_case_types)]
 
 mod m1 {
     macro_rules! legacy_macro { () => () }

--- a/src/test/ui/rust-2018/uniform-paths/macro-rules.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/macro-rules.stderr
@@ -1,52 +1,52 @@
 error[E0364]: `legacy_macro` is private, and cannot be re-exported
-  --> $DIR/macro-rules.rs:11:9
+  --> $DIR/macro-rules.rs:12:9
    |
 LL |     use legacy_macro as _; //~ ERROR `legacy_macro` is private, and cannot be re-exported
    |         ^^^^^^^^^^^^^^^^^
    |
 note: consider marking `legacy_macro` as `pub` in the imported module
-  --> $DIR/macro-rules.rs:11:9
+  --> $DIR/macro-rules.rs:12:9
    |
 LL |     use legacy_macro as _; //~ ERROR `legacy_macro` is private, and cannot be re-exported
    |         ^^^^^^^^^^^^^^^^^
 
 error[E0364]: `legacy_macro` is private, and cannot be re-exported
-  --> $DIR/macro-rules.rs:30:13
+  --> $DIR/macro-rules.rs:31:13
    |
 LL |         use legacy_macro as _; //~ ERROR `legacy_macro` is ambiguous
    |             ^^^^^^^^^^^^^^^^^
    |
 note: consider marking `legacy_macro` as `pub` in the imported module
-  --> $DIR/macro-rules.rs:30:13
+  --> $DIR/macro-rules.rs:31:13
    |
 LL |         use legacy_macro as _; //~ ERROR `legacy_macro` is ambiguous
    |             ^^^^^^^^^^^^^^^^^
 
 error[E0364]: `legacy_macro` is private, and cannot be re-exported
-  --> $DIR/macro-rules.rs:41:9
+  --> $DIR/macro-rules.rs:42:9
    |
 LL |     use legacy_macro as _; //~ ERROR `legacy_macro` is private, and cannot be re-exported
    |         ^^^^^^^^^^^^^^^^^
    |
 note: consider marking `legacy_macro` as `pub` in the imported module
-  --> $DIR/macro-rules.rs:41:9
+  --> $DIR/macro-rules.rs:42:9
    |
 LL |     use legacy_macro as _; //~ ERROR `legacy_macro` is private, and cannot be re-exported
    |         ^^^^^^^^^^^^^^^^^
 
 error[E0659]: `legacy_macro` is ambiguous (name vs any other name during import resolution)
-  --> $DIR/macro-rules.rs:30:13
+  --> $DIR/macro-rules.rs:31:13
    |
 LL |         use legacy_macro as _; //~ ERROR `legacy_macro` is ambiguous
    |             ^^^^^^^^^^^^ ambiguous name
    |
 note: `legacy_macro` could refer to the macro defined here
-  --> $DIR/macro-rules.rs:27:9
+  --> $DIR/macro-rules.rs:28:9
    |
 LL |         macro_rules! legacy_macro { () => () }
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `legacy_macro` could also refer to the macro defined here
-  --> $DIR/macro-rules.rs:24:5
+  --> $DIR/macro-rules.rs:25:5
    |
 LL |     macro legacy_macro() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/seq-args.rs
+++ b/src/test/ui/seq-args.rs
@@ -9,12 +9,12 @@
 // except according to those terms.
 
 fn main() {
-trait seq { }
+trait Seq { }
 
-impl<T> seq<T> for Vec<T> { //~ ERROR wrong number of type arguments
+impl<T> Seq<T> for Vec<T> { //~ ERROR wrong number of type arguments
     /* ... */
 }
-impl seq<bool> for u32 { //~ ERROR wrong number of type arguments
+impl Seq<bool> for u32 { //~ ERROR wrong number of type arguments
    /* Treat the integer as a sequence of bits */
 }
 

--- a/src/test/ui/seq-args.stderr
+++ b/src/test/ui/seq-args.stderr
@@ -1,13 +1,13 @@
 error[E0107]: wrong number of type arguments: expected 0, found 1
   --> $DIR/seq-args.rs:14:13
    |
-LL | impl<T> seq<T> for Vec<T> { //~ ERROR wrong number of type arguments
+LL | impl<T> Seq<T> for Vec<T> { //~ ERROR wrong number of type arguments
    |             ^ unexpected type argument
 
 error[E0107]: wrong number of type arguments: expected 0, found 1
   --> $DIR/seq-args.rs:17:10
    |
-LL | impl seq<bool> for u32 { //~ ERROR wrong number of type arguments
+LL | impl Seq<bool> for u32 { //~ ERROR wrong number of type arguments
    |          ^^^^ unexpected type argument
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/simd-intrinsic/simd-intrinsic-declaration-type.rs
+++ b/src/test/ui/simd-intrinsic/simd-intrinsic-declaration-type.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![feature(repr_simd, platform_intrinsics)]
+#![allow(non_camel_case_types)]
 
 #[repr(simd)]
 struct i16x8(i16, i16, i16, i16, i16, i16, i16, i16);

--- a/src/test/ui/simd-intrinsic/simd-intrinsic-declaration-type.stderr
+++ b/src/test/ui/simd-intrinsic/simd-intrinsic-declaration-type.stderr
@@ -1,71 +1,71 @@
 error[E0442]: intrinsic argument 1 has wrong type: found `u16`, expected `i16`
-  --> $DIR/simd-intrinsic-declaration-type.rs:42:9
+  --> $DIR/simd-intrinsic-declaration-type.rs:43:9
    |
 LL |         fn x86_mm_adds_epi16(x: u16x8, y: u16x8) -> u16x8;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0442]: intrinsic argument 2 has wrong type: found `u16`, expected `i16`
-  --> $DIR/simd-intrinsic-declaration-type.rs:42:9
+  --> $DIR/simd-intrinsic-declaration-type.rs:43:9
    |
 LL |         fn x86_mm_adds_epi16(x: u16x8, y: u16x8) -> u16x8;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0442]: intrinsic return value has wrong type: found `u16`, expected `i16`
-  --> $DIR/simd-intrinsic-declaration-type.rs:42:9
+  --> $DIR/simd-intrinsic-declaration-type.rs:43:9
    |
 LL |         fn x86_mm_adds_epi16(x: u16x8, y: u16x8) -> u16x8;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0442]: intrinsic argument 1 has wrong type: found `i16`, expected `u16`
-  --> $DIR/simd-intrinsic-declaration-type.rs:46:9
+  --> $DIR/simd-intrinsic-declaration-type.rs:47:9
    |
 LL |         fn x86_mm_adds_epu16(x: i16x8, y: i16x8) -> i16x8;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0442]: intrinsic argument 2 has wrong type: found `i16`, expected `u16`
-  --> $DIR/simd-intrinsic-declaration-type.rs:46:9
+  --> $DIR/simd-intrinsic-declaration-type.rs:47:9
    |
 LL |         fn x86_mm_adds_epu16(x: i16x8, y: i16x8) -> i16x8;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0442]: intrinsic return value has wrong type: found `i16`, expected `u16`
-  --> $DIR/simd-intrinsic-declaration-type.rs:46:9
+  --> $DIR/simd-intrinsic-declaration-type.rs:47:9
    |
 LL |         fn x86_mm_adds_epu16(x: i16x8, y: i16x8) -> i16x8;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0442]: intrinsic argument 1 has wrong type: found vector with length 16, expected length 8
-  --> $DIR/simd-intrinsic-declaration-type.rs:54:5
+  --> $DIR/simd-intrinsic-declaration-type.rs:55:5
    |
 LL |     fn x86_mm_adds_epi16(x: i8x16, y: i32x4) -> i64x2;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0442]: intrinsic argument 2 has wrong type: found vector with length 4, expected length 8
-  --> $DIR/simd-intrinsic-declaration-type.rs:54:5
+  --> $DIR/simd-intrinsic-declaration-type.rs:55:5
    |
 LL |     fn x86_mm_adds_epi16(x: i8x16, y: i32x4) -> i64x2;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0442]: intrinsic return value has wrong type: found vector with length 2, expected length 8
-  --> $DIR/simd-intrinsic-declaration-type.rs:54:5
+  --> $DIR/simd-intrinsic-declaration-type.rs:55:5
    |
 LL |     fn x86_mm_adds_epi16(x: i8x16, y: i32x4) -> i64x2;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0442]: intrinsic argument 1 has wrong type: found `i32`, expected `f32`
-  --> $DIR/simd-intrinsic-declaration-type.rs:61:5
+  --> $DIR/simd-intrinsic-declaration-type.rs:62:5
    |
 LL |     fn x86_mm_max_ps(x: i32x4, y: i32x4) -> i32x4;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0442]: intrinsic argument 2 has wrong type: found `i32`, expected `f32`
-  --> $DIR/simd-intrinsic-declaration-type.rs:61:5
+  --> $DIR/simd-intrinsic-declaration-type.rs:62:5
    |
 LL |     fn x86_mm_max_ps(x: i32x4, y: i32x4) -> i32x4;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0442]: intrinsic return value has wrong type: found `i32`, expected `f32`
-  --> $DIR/simd-intrinsic-declaration-type.rs:61:5
+  --> $DIR/simd-intrinsic-declaration-type.rs:62:5
    |
 LL |     fn x86_mm_max_ps(x: i32x4, y: i32x4) -> i32x4;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/simd-type.rs
+++ b/src/test/ui/simd-type.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![feature(repr_simd)]
+#![allow(non_camel_case_types)]
 
 #[repr(simd)]
 struct empty; //~ ERROR SIMD vector cannot be empty

--- a/src/test/ui/simd-type.stderr
+++ b/src/test/ui/simd-type.stderr
@@ -1,17 +1,17 @@
 error[E0075]: SIMD vector cannot be empty
-  --> $DIR/simd-type.rs:14:1
+  --> $DIR/simd-type.rs:15:1
    |
 LL | struct empty; //~ ERROR SIMD vector cannot be empty
    | ^^^^^^^^^^^^^
 
 error[E0076]: SIMD vector should be homogeneous
-  --> $DIR/simd-type.rs:17:1
+  --> $DIR/simd-type.rs:18:1
    |
 LL | struct i64f64(i64, f64); //~ ERROR SIMD vector should be homogeneous
    | ^^^^^^^^^^^^^^^^^^^^^^^^ SIMD elements must have the same type
 
 error[E0077]: SIMD vector element type should be machine type
-  --> $DIR/simd-type.rs:20:1
+  --> $DIR/simd-type.rs:21:1
    |
 LL | struct int4(isize, isize, isize, isize); //~ ERROR SIMD vector element type should be machine type
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/staticness-mismatch.rs
+++ b/src/test/ui/staticness-mismatch.rs
@@ -8,12 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-trait foo {
+trait Foo {
     fn dummy(&self) { }
     fn bar();
 }
 
-impl foo for isize {
+impl Foo for isize {
     fn bar(&self) {}
     //~^ ERROR method `bar` has a `&self` declaration in the impl, but not in the trait
 }

--- a/src/test/ui/structs/struct-pat-derived-error.rs
+++ b/src/test/ui/structs/struct-pat-derived-error.rs
@@ -8,15 +8,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-struct a {
+struct A {
     b: usize,
     c: usize
 }
 
-impl a {
+impl A {
     fn foo(&self) {
-        let a { x, y } = self.d; //~ ERROR no field `d` on type `&a`
-        //~^ ERROR struct `a` does not have fields named `x`, `y`
+        let A { x, y } = self.d; //~ ERROR no field `d` on type `&A`
+        //~^ ERROR struct `A` does not have fields named `x`, `y`
         //~| ERROR pattern does not mention fields `b`, `c`
     }
 }

--- a/src/test/ui/structs/struct-pat-derived-error.stderr
+++ b/src/test/ui/structs/struct-pat-derived-error.stderr
@@ -1,19 +1,19 @@
-error[E0609]: no field `d` on type `&a`
+error[E0609]: no field `d` on type `&A`
   --> $DIR/struct-pat-derived-error.rs:18:31
    |
-LL |         let a { x, y } = self.d; //~ ERROR no field `d` on type `&a`
+LL |         let A { x, y } = self.d; //~ ERROR no field `d` on type `&A`
    |                               ^
 
-error[E0026]: struct `a` does not have fields named `x`, `y`
+error[E0026]: struct `A` does not have fields named `x`, `y`
   --> $DIR/struct-pat-derived-error.rs:18:17
    |
-LL |         let a { x, y } = self.d; //~ ERROR no field `d` on type `&a`
-   |                 ^  ^ struct `a` does not have these fields
+LL |         let A { x, y } = self.d; //~ ERROR no field `d` on type `&A`
+   |                 ^  ^ struct `A` does not have these fields
 
 error[E0027]: pattern does not mention fields `b`, `c`
   --> $DIR/struct-pat-derived-error.rs:18:13
    |
-LL |         let a { x, y } = self.d; //~ ERROR no field `d` on type `&a`
+LL |         let A { x, y } = self.d; //~ ERROR no field `d` on type `&A`
    |             ^^^^^^^^^^ missing fields `b`, `c`
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/tag-type-args.rs
+++ b/src/test/ui/tag-type-args.rs
@@ -8,10 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:wrong number of type arguments
+enum Quux<T> { Bar }
 
-enum quux<T> { bar }
-
-fn foo(c: quux) { assert!((false)); }
+fn foo(c: Quux) { assert!((false)); } //~ ERROR wrong number of type arguments
 
 fn main() { panic!(); }

--- a/src/test/ui/tag-type-args.stderr
+++ b/src/test/ui/tag-type-args.stderr
@@ -1,7 +1,7 @@
 error[E0107]: wrong number of type arguments: expected 1, found 0
-  --> $DIR/tag-type-args.rs:15:11
+  --> $DIR/tag-type-args.rs:13:11
    |
-LL | fn foo(c: quux) { assert!((false)); }
+LL | fn foo(c: Quux) { assert!((false)); } //~ ERROR wrong number of type arguments
    |           ^^^^ expected 1 type argument
 
 error: aborting due to previous error

--- a/src/test/ui/tag-variant-cast-non-nullary.rs
+++ b/src/test/ui/tag-variant-cast-non-nullary.rs
@@ -8,12 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-enum non_nullary {
-    nullary,
-    other(isize),
+enum NonNullary {
+    Nullary,
+    Other(isize),
 }
 
 fn main() {
-    let v = non_nullary::nullary;
-    let val = v as isize; //~ ERROR non-primitive cast: `non_nullary` as `isize` [E0605]
+    let v = NonNullary::Nullary;
+    let val = v as isize; //~ ERROR non-primitive cast: `NonNullary` as `isize` [E0605]
 }

--- a/src/test/ui/tag-variant-cast-non-nullary.stderr
+++ b/src/test/ui/tag-variant-cast-non-nullary.stderr
@@ -1,7 +1,7 @@
-error[E0605]: non-primitive cast: `non_nullary` as `isize`
+error[E0605]: non-primitive cast: `NonNullary` as `isize`
   --> $DIR/tag-variant-cast-non-nullary.rs:18:15
    |
-LL |     let val = v as isize; //~ ERROR non-primitive cast: `non_nullary` as `isize` [E0605]
+LL |     let val = v as isize; //~ ERROR non-primitive cast: `NonNullary` as `isize` [E0605]
    |               ^^^^^^^^^^
    |
    = note: an `as` expression can only be used to convert between primitive types. Consider using the `From` trait

--- a/src/test/ui/tag-variant-disr-dup.rs
+++ b/src/test/ui/tag-variant-disr-dup.rs
@@ -8,16 +8,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//error-pattern:discriminant value
+// Black and White have the same discriminator value ...
 
-// black and white have the same discriminator value ...
-
-enum color {
-    red = 0xff0000,
-    green = 0x00ff00,
-    blue = 0x0000ff,
-    black = 0x000000,
-    white = 0x000000,
+enum Color {
+    Red = 0xff0000,
+    Green = 0x00ff00,
+    Blue = 0x0000ff,
+    Black = 0x000000,
+    White = 0x000000, //~ ERROR discriminant value `0` already exists
 }
 
 fn main() { }

--- a/src/test/ui/tag-variant-disr-dup.stderr
+++ b/src/test/ui/tag-variant-disr-dup.stderr
@@ -1,9 +1,9 @@
 error[E0081]: discriminant value `0` already exists
-  --> $DIR/tag-variant-disr-dup.rs:20:13
+  --> $DIR/tag-variant-disr-dup.rs:18:13
    |
-LL |     black = 0x000000,
+LL |     Black = 0x000000,
    |             -------- first use of `0`
-LL |     white = 0x000000,
+LL |     White = 0x000000, //~ ERROR discriminant value `0` already exists
    |             ^^^^^^^^ enum already has `0`
 
 error: aborting due to previous error

--- a/src/test/ui/terr-in-field.rs
+++ b/src/test/ui/terr-in-field.rs
@@ -8,22 +8,22 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-struct foo {
+struct Foo {
     a: isize,
     b: isize,
 }
 
-struct bar {
+struct Bar {
     a: isize,
     b: usize,
 }
 
-fn want_foo(f: foo) {}
-fn have_bar(b: bar) {
+fn want_foo(f: Foo) {}
+fn have_bar(b: Bar) {
     want_foo(b); //~  ERROR mismatched types
-                 //~| expected type `foo`
-                 //~| found type `bar`
-                 //~| expected struct `foo`, found struct `bar`
+                 //~| expected type `Foo`
+                 //~| found type `Bar`
+                 //~| expected struct `Foo`, found struct `Bar`
 }
 
 fn main() {}

--- a/src/test/ui/terr-in-field.stderr
+++ b/src/test/ui/terr-in-field.stderr
@@ -2,10 +2,10 @@ error[E0308]: mismatched types
   --> $DIR/terr-in-field.rs:23:14
    |
 LL |     want_foo(b); //~  ERROR mismatched types
-   |              ^ expected struct `foo`, found struct `bar`
+   |              ^ expected struct `Foo`, found struct `Bar`
    |
-   = note: expected type `foo`
-              found type `bar`
+   = note: expected type `Foo`
+              found type `Bar`
 
 error: aborting due to previous error
 

--- a/src/test/ui/terr-sorts.rs
+++ b/src/test/ui/terr-sorts.rs
@@ -9,18 +9,18 @@
 // except according to those terms.
 
 
-struct foo {
+struct Foo {
     a: isize,
     b: isize,
 }
 
-type bar = Box<foo>;
+type Bar = Box<Foo>;
 
-fn want_foo(f: foo) {}
-fn have_bar(b: bar) {
+fn want_foo(f: Foo) {}
+fn have_bar(b: Bar) {
     want_foo(b); //~  ERROR mismatched types
-                 //~| expected type `foo`
-                 //~| found type `std::boxed::Box<foo>`
+                 //~| expected type `Foo`
+                 //~| found type `std::boxed::Box<Foo>`
 }
 
 fn main() {}

--- a/src/test/ui/terr-sorts.stderr
+++ b/src/test/ui/terr-sorts.stderr
@@ -2,10 +2,10 @@ error[E0308]: mismatched types
   --> $DIR/terr-sorts.rs:21:14
    |
 LL |     want_foo(b); //~  ERROR mismatched types
-   |              ^ expected struct `foo`, found struct `std::boxed::Box`
+   |              ^ expected struct `Foo`, found struct `std::boxed::Box`
    |
-   = note: expected type `foo`
-              found type `std::boxed::Box<foo>`
+   = note: expected type `Foo`
+              found type `std::boxed::Box<Foo>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/trait-impl-different-num-params.rs
+++ b/src/test/ui/traits/trait-impl-different-num-params.rs
@@ -8,12 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-trait foo {
+trait Foo {
     fn bar(&self, x: usize) -> Self;
 }
-impl foo for isize {
+impl Foo for isize {
     fn bar(&self) -> isize {
-        //~^ ERROR method `bar` has 1 parameter but the declaration in trait `foo::bar` has 2
+        //~^ ERROR method `bar` has 1 parameter but the declaration in trait `Foo::bar` has 2
         *self
     }
 }

--- a/src/test/ui/traits/trait-impl-different-num-params.stderr
+++ b/src/test/ui/traits/trait-impl-different-num-params.stderr
@@ -1,4 +1,4 @@
-error[E0050]: method `bar` has 1 parameter but the declaration in trait `foo::bar` has 2
+error[E0050]: method `bar` has 1 parameter but the declaration in trait `Foo::bar` has 2
   --> $DIR/trait-impl-different-num-params.rs:15:12
    |
 LL |     fn bar(&self, x: usize) -> Self;

--- a/src/test/ui/traits/trait-test-2.rs
+++ b/src/test/ui/traits/trait-test-2.rs
@@ -10,6 +10,7 @@
 
 #![feature(box_syntax)]
 
+#[allow(non_camel_case_types)]
 trait bar { fn dup(&self) -> Self; fn blah<X>(&self); }
 impl bar for i32 { fn dup(&self) -> i32 { *self } fn blah<X>(&self) {} }
 impl bar for u32 { fn dup(&self) -> u32 { *self } fn blah<X>(&self) {} }

--- a/src/test/ui/traits/trait-test-2.stderr
+++ b/src/test/ui/traits/trait-test-2.stderr
@@ -1,17 +1,17 @@
 error[E0107]: wrong number of type arguments: expected 0, found 1
-  --> $DIR/trait-test-2.rs:18:14
+  --> $DIR/trait-test-2.rs:19:14
    |
 LL |     10.dup::<i32>(); //~ ERROR wrong number of type arguments: expected 0, found 1
    |              ^^^ unexpected type argument
 
 error[E0107]: wrong number of type arguments: expected 1, found 2
-  --> $DIR/trait-test-2.rs:19:20
+  --> $DIR/trait-test-2.rs:20:20
    |
 LL |     10.blah::<i32, i32>(); //~ ERROR wrong number of type arguments: expected 1, found 2
    |                    ^^^ unexpected type argument
 
 error[E0038]: the trait `bar` cannot be made into an object
-  --> $DIR/trait-test-2.rs:20:16
+  --> $DIR/trait-test-2.rs:21:16
    |
 LL |     (box 10 as Box<bar>).dup();
    |                ^^^^^^^^ the trait `bar` cannot be made into an object
@@ -20,7 +20,7 @@ LL |     (box 10 as Box<bar>).dup();
    = note: method `blah` has generic type parameters
 
 error[E0038]: the trait `bar` cannot be made into an object
-  --> $DIR/trait-test-2.rs:20:6
+  --> $DIR/trait-test-2.rs:21:6
    |
 LL |     (box 10 as Box<bar>).dup();
    |      ^^^^^^ the trait `bar` cannot be made into an object

--- a/src/test/ui/traits/trait-test.rs
+++ b/src/test/ui/traits/trait-test.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[allow(non_camel_case_types)]
 trait foo { fn foo(&self); }
 
 impl isize for usize { fn foo(&self) {} } //~ ERROR trait

--- a/src/test/ui/traits/trait-test.stderr
+++ b/src/test/ui/traits/trait-test.stderr
@@ -1,5 +1,5 @@
 error[E0404]: expected trait, found builtin type `isize`
-  --> $DIR/trait-test.rs:13:6
+  --> $DIR/trait-test.rs:14:6
    |
 LL | impl isize for usize { fn foo(&self) {} } //~ ERROR trait
    |      ^^^^^ not a trait

--- a/src/test/ui/type/type-mismatch.rs
+++ b/src/test/ui/type/type-mismatch.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(non_camel_case_types)]
+
 trait Qux {}
 struct A;
 struct B;

--- a/src/test/ui/type/type-mismatch.stderr
+++ b/src/test/ui/type/type-mismatch.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:25:17
+  --> $DIR/type-mismatch.rs:27:17
    |
 LL |     want::<foo>(f); //~ ERROR mismatched types
    |                 ^ expected struct `foo`, found usize
@@ -8,7 +8,7 @@ LL |     want::<foo>(f); //~ ERROR mismatched types
               found type `usize`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:26:17
+  --> $DIR/type-mismatch.rs:28:17
    |
 LL |     want::<bar>(f); //~ ERROR mismatched types
    |                 ^ expected struct `bar`, found usize
@@ -17,7 +17,7 @@ LL |     want::<bar>(f); //~ ERROR mismatched types
               found type `usize`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:27:24
+  --> $DIR/type-mismatch.rs:29:24
    |
 LL |     want::<Foo<usize>>(f); //~ ERROR mismatched types
    |                        ^ expected struct `Foo`, found usize
@@ -26,7 +26,7 @@ LL |     want::<Foo<usize>>(f); //~ ERROR mismatched types
               found type `usize`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:28:27
+  --> $DIR/type-mismatch.rs:30:27
    |
 LL |     want::<Foo<usize, B>>(f); //~ ERROR mismatched types
    |                           ^ expected struct `Foo`, found usize
@@ -35,7 +35,7 @@ LL |     want::<Foo<usize, B>>(f); //~ ERROR mismatched types
               found type `usize`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:29:22
+  --> $DIR/type-mismatch.rs:31:22
    |
 LL |     want::<Foo<foo>>(f); //~ ERROR mismatched types
    |                      ^ expected struct `Foo`, found usize
@@ -44,7 +44,7 @@ LL |     want::<Foo<foo>>(f); //~ ERROR mismatched types
               found type `usize`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:30:25
+  --> $DIR/type-mismatch.rs:32:25
    |
 LL |     want::<Foo<foo, B>>(f); //~ ERROR mismatched types
    |                         ^ expected struct `Foo`, found usize
@@ -53,7 +53,7 @@ LL |     want::<Foo<foo, B>>(f); //~ ERROR mismatched types
               found type `usize`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:31:22
+  --> $DIR/type-mismatch.rs:33:22
    |
 LL |     want::<Foo<bar>>(f); //~ ERROR mismatched types
    |                      ^ expected struct `Foo`, found usize
@@ -62,7 +62,7 @@ LL |     want::<Foo<bar>>(f); //~ ERROR mismatched types
               found type `usize`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:32:25
+  --> $DIR/type-mismatch.rs:34:25
    |
 LL |     want::<Foo<bar, B>>(f); //~ ERROR mismatched types
    |                         ^ expected struct `Foo`, found usize
@@ -71,7 +71,7 @@ LL |     want::<Foo<bar, B>>(f); //~ ERROR mismatched types
               found type `usize`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:36:19
+  --> $DIR/type-mismatch.rs:38:19
    |
 LL |     want::<usize>(f); //~ ERROR mismatched types
    |                   ^ expected usize, found struct `foo`
@@ -80,7 +80,7 @@ LL |     want::<usize>(f); //~ ERROR mismatched types
               found type `foo`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:37:17
+  --> $DIR/type-mismatch.rs:39:17
    |
 LL |     want::<bar>(f); //~ ERROR mismatched types
    |                 ^ expected struct `bar`, found struct `foo`
@@ -89,7 +89,7 @@ LL |     want::<bar>(f); //~ ERROR mismatched types
               found type `foo`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:38:24
+  --> $DIR/type-mismatch.rs:40:24
    |
 LL |     want::<Foo<usize>>(f); //~ ERROR mismatched types
    |                        ^ expected struct `Foo`, found struct `foo`
@@ -98,7 +98,7 @@ LL |     want::<Foo<usize>>(f); //~ ERROR mismatched types
               found type `foo`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:39:27
+  --> $DIR/type-mismatch.rs:41:27
    |
 LL |     want::<Foo<usize, B>>(f); //~ ERROR mismatched types
    |                           ^ expected struct `Foo`, found struct `foo`
@@ -107,7 +107,7 @@ LL |     want::<Foo<usize, B>>(f); //~ ERROR mismatched types
               found type `foo`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:40:22
+  --> $DIR/type-mismatch.rs:42:22
    |
 LL |     want::<Foo<foo>>(f); //~ ERROR mismatched types
    |                      ^ expected struct `Foo`, found struct `foo`
@@ -116,7 +116,7 @@ LL |     want::<Foo<foo>>(f); //~ ERROR mismatched types
               found type `foo`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:41:25
+  --> $DIR/type-mismatch.rs:43:25
    |
 LL |     want::<Foo<foo, B>>(f); //~ ERROR mismatched types
    |                         ^ expected struct `Foo`, found struct `foo`
@@ -125,7 +125,7 @@ LL |     want::<Foo<foo, B>>(f); //~ ERROR mismatched types
               found type `foo`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:42:22
+  --> $DIR/type-mismatch.rs:44:22
    |
 LL |     want::<Foo<bar>>(f); //~ ERROR mismatched types
    |                      ^ expected struct `Foo`, found struct `foo`
@@ -134,7 +134,7 @@ LL |     want::<Foo<bar>>(f); //~ ERROR mismatched types
               found type `foo`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:43:25
+  --> $DIR/type-mismatch.rs:45:25
    |
 LL |     want::<Foo<bar, B>>(f); //~ ERROR mismatched types
    |                         ^ expected struct `Foo`, found struct `foo`
@@ -143,7 +143,7 @@ LL |     want::<Foo<bar, B>>(f); //~ ERROR mismatched types
               found type `foo`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:47:19
+  --> $DIR/type-mismatch.rs:49:19
    |
 LL |     want::<usize>(f); //~ ERROR mismatched types
    |                   ^ expected usize, found struct `Foo`
@@ -152,7 +152,7 @@ LL |     want::<usize>(f); //~ ERROR mismatched types
               found type `Foo<foo>`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:48:17
+  --> $DIR/type-mismatch.rs:50:17
    |
 LL |     want::<foo>(f); //~ ERROR mismatched types
    |                 ^ expected struct `foo`, found struct `Foo`
@@ -161,7 +161,7 @@ LL |     want::<foo>(f); //~ ERROR mismatched types
               found type `Foo<foo>`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:49:17
+  --> $DIR/type-mismatch.rs:51:17
    |
 LL |     want::<bar>(f); //~ ERROR mismatched types
    |                 ^ expected struct `bar`, found struct `Foo`
@@ -170,7 +170,7 @@ LL |     want::<bar>(f); //~ ERROR mismatched types
               found type `Foo<foo>`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:50:24
+  --> $DIR/type-mismatch.rs:52:24
    |
 LL |     want::<Foo<usize>>(f); //~ ERROR mismatched types
    |                        ^ expected usize, found struct `foo`
@@ -179,7 +179,7 @@ LL |     want::<Foo<usize>>(f); //~ ERROR mismatched types
               found type `Foo<foo>`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:51:27
+  --> $DIR/type-mismatch.rs:53:27
    |
 LL |     want::<Foo<usize, B>>(f); //~ ERROR mismatched types
    |                           ^ expected usize, found struct `foo`
@@ -188,7 +188,7 @@ LL |     want::<Foo<usize, B>>(f); //~ ERROR mismatched types
               found type `Foo<foo, A>`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:52:25
+  --> $DIR/type-mismatch.rs:54:25
    |
 LL |     want::<Foo<foo, B>>(f); //~ ERROR mismatched types
    |                         ^ expected struct `B`, found struct `A`
@@ -197,7 +197,7 @@ LL |     want::<Foo<foo, B>>(f); //~ ERROR mismatched types
               found type `Foo<_, A>`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:53:22
+  --> $DIR/type-mismatch.rs:55:22
    |
 LL |     want::<Foo<bar>>(f); //~ ERROR mismatched types
    |                      ^ expected struct `bar`, found struct `foo`
@@ -206,7 +206,7 @@ LL |     want::<Foo<bar>>(f); //~ ERROR mismatched types
               found type `Foo<foo>`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:54:25
+  --> $DIR/type-mismatch.rs:56:25
    |
 LL |     want::<Foo<bar, B>>(f); //~ ERROR mismatched types
    |                         ^ expected struct `bar`, found struct `foo`
@@ -215,7 +215,7 @@ LL |     want::<Foo<bar, B>>(f); //~ ERROR mismatched types
               found type `Foo<foo, A>`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:55:23
+  --> $DIR/type-mismatch.rs:57:23
    |
 LL |     want::<&Foo<foo>>(f); //~ ERROR mismatched types
    |                       ^
@@ -227,7 +227,7 @@ LL |     want::<&Foo<foo>>(f); //~ ERROR mismatched types
               found type `Foo<foo>`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:56:26
+  --> $DIR/type-mismatch.rs:58:26
    |
 LL |     want::<&Foo<foo, B>>(f); //~ ERROR mismatched types
    |                          ^ expected reference, found struct `Foo`
@@ -236,7 +236,7 @@ LL |     want::<&Foo<foo, B>>(f); //~ ERROR mismatched types
               found type `Foo<foo>`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:60:19
+  --> $DIR/type-mismatch.rs:62:19
    |
 LL |     want::<usize>(f); //~ ERROR mismatched types
    |                   ^ expected usize, found struct `Foo`
@@ -245,7 +245,7 @@ LL |     want::<usize>(f); //~ ERROR mismatched types
               found type `Foo<foo, B>`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:61:17
+  --> $DIR/type-mismatch.rs:63:17
    |
 LL |     want::<foo>(f); //~ ERROR mismatched types
    |                 ^ expected struct `foo`, found struct `Foo`
@@ -254,7 +254,7 @@ LL |     want::<foo>(f); //~ ERROR mismatched types
               found type `Foo<foo, B>`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:62:17
+  --> $DIR/type-mismatch.rs:64:17
    |
 LL |     want::<bar>(f); //~ ERROR mismatched types
    |                 ^ expected struct `bar`, found struct `Foo`
@@ -263,7 +263,7 @@ LL |     want::<bar>(f); //~ ERROR mismatched types
               found type `Foo<foo, B>`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:63:24
+  --> $DIR/type-mismatch.rs:65:24
    |
 LL |     want::<Foo<usize>>(f); //~ ERROR mismatched types
    |                        ^ expected usize, found struct `foo`
@@ -272,7 +272,7 @@ LL |     want::<Foo<usize>>(f); //~ ERROR mismatched types
               found type `Foo<foo, B>`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:64:27
+  --> $DIR/type-mismatch.rs:66:27
    |
 LL |     want::<Foo<usize, B>>(f); //~ ERROR mismatched types
    |                           ^ expected usize, found struct `foo`
@@ -281,7 +281,7 @@ LL |     want::<Foo<usize, B>>(f); //~ ERROR mismatched types
               found type `Foo<foo, _>`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:65:22
+  --> $DIR/type-mismatch.rs:67:22
    |
 LL |     want::<Foo<foo>>(f); //~ ERROR mismatched types
    |                      ^ expected struct `A`, found struct `B`
@@ -290,7 +290,7 @@ LL |     want::<Foo<foo>>(f); //~ ERROR mismatched types
               found type `Foo<_, B>`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:66:22
+  --> $DIR/type-mismatch.rs:68:22
    |
 LL |     want::<Foo<bar>>(f); //~ ERROR mismatched types
    |                      ^ expected struct `bar`, found struct `foo`
@@ -299,7 +299,7 @@ LL |     want::<Foo<bar>>(f); //~ ERROR mismatched types
               found type `Foo<foo, B>`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:67:25
+  --> $DIR/type-mismatch.rs:69:25
    |
 LL |     want::<Foo<bar, B>>(f); //~ ERROR mismatched types
    |                         ^ expected struct `bar`, found struct `foo`
@@ -308,7 +308,7 @@ LL |     want::<Foo<bar, B>>(f); //~ ERROR mismatched types
               found type `Foo<foo, _>`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:68:23
+  --> $DIR/type-mismatch.rs:70:23
    |
 LL |     want::<&Foo<foo>>(f); //~ ERROR mismatched types
    |                       ^ expected &Foo<foo>, found struct `Foo`
@@ -317,7 +317,7 @@ LL |     want::<&Foo<foo>>(f); //~ ERROR mismatched types
               found type `Foo<foo, B>`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:69:26
+  --> $DIR/type-mismatch.rs:71:26
    |
 LL |     want::<&Foo<foo, B>>(f); //~ ERROR mismatched types
    |                          ^
@@ -329,7 +329,7 @@ LL |     want::<&Foo<foo, B>>(f); //~ ERROR mismatched types
               found type `Foo<foo, B>`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:73:19
+  --> $DIR/type-mismatch.rs:75:19
    |
 LL |     want::<usize>(f); //~ ERROR mismatched types
    |                   ^ expected usize, found struct `Foo`
@@ -338,7 +338,7 @@ LL |     want::<usize>(f); //~ ERROR mismatched types
               found type `Foo<foo, B, A>`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:74:17
+  --> $DIR/type-mismatch.rs:76:17
    |
 LL |     want::<foo>(f); //~ ERROR mismatched types
    |                 ^ expected struct `foo`, found struct `Foo`
@@ -347,7 +347,7 @@ LL |     want::<foo>(f); //~ ERROR mismatched types
               found type `Foo<foo, B, A>`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:75:17
+  --> $DIR/type-mismatch.rs:77:17
    |
 LL |     want::<bar>(f); //~ ERROR mismatched types
    |                 ^ expected struct `bar`, found struct `Foo`
@@ -356,7 +356,7 @@ LL |     want::<bar>(f); //~ ERROR mismatched types
               found type `Foo<foo, B, A>`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:76:24
+  --> $DIR/type-mismatch.rs:78:24
    |
 LL |     want::<Foo<usize>>(f); //~ ERROR mismatched types
    |                        ^ expected usize, found struct `foo`
@@ -365,7 +365,7 @@ LL |     want::<Foo<usize>>(f); //~ ERROR mismatched types
               found type `Foo<foo, B, A>`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:77:27
+  --> $DIR/type-mismatch.rs:79:27
    |
 LL |     want::<Foo<usize, B>>(f); //~ ERROR mismatched types
    |                           ^ expected usize, found struct `foo`
@@ -374,7 +374,7 @@ LL |     want::<Foo<usize, B>>(f); //~ ERROR mismatched types
               found type `Foo<foo, _, A>`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:78:22
+  --> $DIR/type-mismatch.rs:80:22
    |
 LL |     want::<Foo<foo>>(f); //~ ERROR mismatched types
    |                      ^ expected struct `A`, found struct `B`
@@ -383,7 +383,7 @@ LL |     want::<Foo<foo>>(f); //~ ERROR mismatched types
               found type `Foo<_, B, A>`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:79:25
+  --> $DIR/type-mismatch.rs:81:25
    |
 LL |     want::<Foo<foo, B>>(f); //~ ERROR mismatched types
    |                         ^ expected struct `B`, found struct `A`
@@ -392,7 +392,7 @@ LL |     want::<Foo<foo, B>>(f); //~ ERROR mismatched types
               found type `Foo<_, _, A>`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:80:22
+  --> $DIR/type-mismatch.rs:82:22
    |
 LL |     want::<Foo<bar>>(f); //~ ERROR mismatched types
    |                      ^ expected struct `bar`, found struct `foo`
@@ -401,7 +401,7 @@ LL |     want::<Foo<bar>>(f); //~ ERROR mismatched types
               found type `Foo<foo, B, A>`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:81:25
+  --> $DIR/type-mismatch.rs:83:25
    |
 LL |     want::<Foo<bar, B>>(f); //~ ERROR mismatched types
    |                         ^ expected struct `bar`, found struct `foo`
@@ -410,7 +410,7 @@ LL |     want::<Foo<bar, B>>(f); //~ ERROR mismatched types
               found type `Foo<foo, _, A>`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:82:23
+  --> $DIR/type-mismatch.rs:84:23
    |
 LL |     want::<&Foo<foo>>(f); //~ ERROR mismatched types
    |                       ^ expected &Foo<foo>, found struct `Foo`
@@ -419,7 +419,7 @@ LL |     want::<&Foo<foo>>(f); //~ ERROR mismatched types
               found type `Foo<foo, B, A>`
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch.rs:83:26
+  --> $DIR/type-mismatch.rs:85:26
    |
 LL |     want::<&Foo<foo, B>>(f); //~ ERROR mismatched types
    |                          ^ expected reference, found struct `Foo`

--- a/src/test/ui/type/type-recursive.rs
+++ b/src/test/ui/type/type-recursive.rs
@@ -8,9 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-struct t1 { //~ ERROR E0072
+struct T1 { //~ ERROR E0072
     foo: isize,
-    foolish: t1
+    foolish: T1
 }
 
 fn main() { }

--- a/src/test/ui/type/type-recursive.stderr
+++ b/src/test/ui/type/type-recursive.stderr
@@ -1,13 +1,13 @@
-error[E0072]: recursive type `t1` has infinite size
+error[E0072]: recursive type `T1` has infinite size
   --> $DIR/type-recursive.rs:11:1
    |
-LL | struct t1 { //~ ERROR E0072
+LL | struct T1 { //~ ERROR E0072
    | ^^^^^^^^^ recursive type has infinite size
 LL |     foo: isize,
-LL |     foolish: t1
+LL |     foolish: T1
    |     ----------- recursive without indirection
    |
-   = help: insert indirection (e.g., a `Box`, `Rc`, or `&`) at some point to make `t1` representable
+   = help: insert indirection (e.g., a `Box`, `Rc`, or `&`) at some point to make `T1` representable
 
 error: aborting due to previous error
 

--- a/src/test/ui/unique-pinned-nocopy.rs
+++ b/src/test/ui/unique-pinned-nocopy.rs
@@ -9,16 +9,16 @@
 // except according to those terms.
 
 #[derive(Debug)]
-struct r {
+struct R {
   b: bool,
 }
 
-impl Drop for r {
+impl Drop for R {
     fn drop(&mut self) {}
 }
 
 fn main() {
-    let i = Box::new(r { b: true });
+    let i = Box::new(R { b: true });
     let _j = i.clone(); //~ ERROR no method named `clone` found
     println!("{:?}", i);
 }

--- a/src/test/ui/unique-pinned-nocopy.stderr
+++ b/src/test/ui/unique-pinned-nocopy.stderr
@@ -1,11 +1,11 @@
-error[E0599]: no method named `clone` found for type `std::boxed::Box<r>` in the current scope
+error[E0599]: no method named `clone` found for type `std::boxed::Box<R>` in the current scope
   --> $DIR/unique-pinned-nocopy.rs:22:16
    |
 LL |     let _j = i.clone(); //~ ERROR no method named `clone` found
    |                ^^^^^
    |
    = note: the method `clone` exists but the following trait bounds were not satisfied:
-           `std::boxed::Box<r> : std::clone::Clone`
+           `std::boxed::Box<R> : std::clone::Clone`
    = help: items from traits can only be used if the trait is implemented and in scope
    = note: the following trait defines an item `clone`, perhaps you need to implement it:
            candidate #1: `std::clone::Clone`

--- a/src/test/ui/unresolved/unresolved-import.rs
+++ b/src/test/ui/unresolved/unresolved-import.rs
@@ -27,11 +27,11 @@ mod bar {
 }
 
 mod food {
-    pub use self::zug::baz::{self as bag, foobar as beans};
+    pub use self::zug::baz::{self as bag, Foobar as beans};
 
     mod zug {
         pub mod baz {
-            pub struct foobar;
+            pub struct Foobar;
         }
     }
 }

--- a/src/test/ui/vec/vec-res-add.rs
+++ b/src/test/ui/vec/vec-res-add.rs
@@ -9,13 +9,13 @@
 // except according to those terms.
 
 #[derive(Debug)]
-struct r {
+struct R {
   i:isize
 }
 
-fn r(i:isize) -> r { r { i: i } }
+fn r(i:isize) -> R { R { i: i } }
 
-impl Drop for r {
+impl Drop for R {
     fn drop(&mut self) {}
 }
 

--- a/src/test/ui/vec/vec-res-add.stderr
+++ b/src/test/ui/vec/vec-res-add.stderr
@@ -1,10 +1,10 @@
-error[E0369]: binary operation `+` cannot be applied to type `std::vec::Vec<r>`
+error[E0369]: binary operation `+` cannot be applied to type `std::vec::Vec<R>`
   --> $DIR/vec-res-add.rs:26:13
    |
 LL |     let k = i + j;
    |             ^^^^^
    |
-   = note: an implementation of `std::ops::Add` might be missing for `std::vec::Vec<r>`
+   = note: an implementation of `std::ops::Add` might be missing for `std::vec::Vec<R>`
 
 error: aborting due to previous error
 


### PR DESCRIPTION
This allows us to catch these kinds of style violations much earlier, as evidenced by the large number of tests that had to be updated for this change.