### PR TITLE
Stablilize const_int_{rotate,wrapping,sign}

### DIFF
--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -114,7 +114,6 @@
 #![feature(const_str_as_bytes)]
 #![feature(const_str_len)]
 #![feature(const_int_rotate)]
-#![feature(const_int_wrapping)]
 #![feature(const_int_sign)]
 #![feature(const_int_conversion)]
 #![feature(const_transmute)]

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -114,7 +114,6 @@
 #![feature(const_str_as_bytes)]
 #![feature(const_str_len)]
 #![cfg_attr(stage0, feature(const_int_rotate))]
-#![feature(const_int_sign)]
 #![feature(const_int_conversion)]
 #![feature(const_transmute)]
 #![feature(reverse_bits)]

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -113,7 +113,7 @@
 #![feature(const_slice_len)]
 #![feature(const_str_as_bytes)]
 #![feature(const_str_len)]
-#![feature(const_int_rotate)]
+#![cfg_attr(stage0, feature(const_int_rotate))]
 #![feature(const_int_sign)]
 #![feature(const_int_conversion)]
 #![feature(const_transmute)]

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -994,7 +994,7 @@ assert_eq!(", stringify!($SelfT), "::max_value().wrapping_add(2), ", stringify!(
 $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_int_wrapping")]
+            #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_wrapping"))]
             #[inline]
             pub const fn wrapping_add(self, rhs: Self) -> Self {
                 unsafe {
@@ -1018,7 +1018,7 @@ stringify!($SelfT), "::max_value());",
 $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_int_wrapping")]
+            #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_wrapping"))]
             #[inline]
             pub const fn wrapping_sub(self, rhs: Self) -> Self {
                 unsafe {
@@ -1041,7 +1041,7 @@ assert_eq!(11i8.wrapping_mul(12), -124);",
 $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_int_wrapping")]
+            #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_wrapping"))]
             #[inline]
             pub const fn wrapping_mul(self, rhs: Self) -> Self {
                 unsafe {
@@ -1205,7 +1205,7 @@ assert_eq!((-1", stringify!($SelfT), ").wrapping_shl(128), -1);",
 $EndFeature, "
 ```"),
             #[stable(feature = "num_wrapping", since = "1.2.0")]
-            #[rustc_const_unstable(feature = "const_int_wrapping")]
+            #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_wrapping"))]
             #[inline]
             pub const fn wrapping_shl(self, rhs: u32) -> Self {
                 unsafe {
@@ -1233,7 +1233,7 @@ assert_eq!((-128i16).wrapping_shr(64), -128);",
 $EndFeature, "
 ```"),
             #[stable(feature = "num_wrapping", since = "1.2.0")]
-            #[rustc_const_unstable(feature = "const_int_wrapping")]
+            #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_wrapping"))]
             #[inline]
             pub const fn wrapping_shr(self, rhs: u32) -> Self {
                 unsafe {
@@ -2884,7 +2884,7 @@ assert_eq!(200", stringify!($SelfT), ".wrapping_add(", stringify!($SelfT), "::ma
 $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_int_wrapping")]
+            #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_wrapping"))]
             #[inline]
             pub const fn wrapping_add(self, rhs: Self) -> Self {
                 unsafe {
@@ -2907,7 +2907,7 @@ assert_eq!(100", stringify!($SelfT), ".wrapping_sub(", stringify!($SelfT), "::ma
 $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_int_wrapping")]
+            #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_wrapping"))]
             #[inline]
             pub const fn wrapping_sub(self, rhs: Self) -> Self {
                 unsafe {
@@ -2931,7 +2931,7 @@ $EndFeature, "
         /// assert_eq!(25u8.wrapping_mul(12), 44);
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
-        #[rustc_const_unstable(feature = "const_int_wrapping")]
+        #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_wrapping"))]
         #[inline]
         pub const fn wrapping_mul(self, rhs: Self) -> Self {
             unsafe {
@@ -3081,7 +3081,7 @@ Basic usage:
 assert_eq!(1", stringify!($SelfT), ".wrapping_shl(128), 1);", $EndFeature, "
 ```"),
             #[stable(feature = "num_wrapping", since = "1.2.0")]
-            #[rustc_const_unstable(feature = "const_int_wrapping")]
+            #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_wrapping"))]
             #[inline]
             pub const fn wrapping_shl(self, rhs: u32) -> Self {
                 unsafe {
@@ -3111,7 +3111,7 @@ Basic usage:
 assert_eq!(128", stringify!($SelfT), ".wrapping_shr(128), 128);", $EndFeature, "
 ```"),
             #[stable(feature = "num_wrapping", since = "1.2.0")]
-            #[rustc_const_unstable(feature = "const_int_wrapping")]
+            #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_wrapping"))]
             #[inline]
             pub const fn wrapping_shr(self, rhs: u32) -> Self {
                 unsafe {

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -1886,7 +1886,6 @@ assert!(!(-10", stringify!($SelfT), ").is_positive());",
 $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_int_sign")]
             #[inline]
             pub const fn is_positive(self) -> bool { self > 0 }
         }
@@ -1905,7 +1904,6 @@ assert!(!10", stringify!($SelfT), ".is_negative());",
 $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_int_sign")]
             #[inline]
             pub const fn is_negative(self) -> bool { self < 0 }
         }

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -997,9 +997,12 @@ $EndFeature, "
             #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_wrapping"))]
             #[inline]
             pub const fn wrapping_add(self, rhs: Self) -> Self {
+                #[cfg(stage0)]
                 unsafe {
                     intrinsics::overflowing_add(self, rhs)
                 }
+                #[cfg(not(stage0))]
+                intrinsics::overflowing_add(self, rhs)
             }
         }
 
@@ -1021,9 +1024,12 @@ $EndFeature, "
             #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_wrapping"))]
             #[inline]
             pub const fn wrapping_sub(self, rhs: Self) -> Self {
+                #[cfg(stage0)]
                 unsafe {
                     intrinsics::overflowing_sub(self, rhs)
                 }
+                #[cfg(not(stage0))]
+                intrinsics::overflowing_sub(self, rhs)
             }
         }
 
@@ -1044,9 +1050,12 @@ $EndFeature, "
             #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_wrapping"))]
             #[inline]
             pub const fn wrapping_mul(self, rhs: Self) -> Self {
+                #[cfg(stage0)]
                 unsafe {
                     intrinsics::overflowing_mul(self, rhs)
                 }
+                #[cfg(not(stage0))]
+                intrinsics::overflowing_mul(self, rhs)
             }
         }
 
@@ -2311,7 +2320,10 @@ assert_eq!(n.rotate_left(", $rot, "), m);
             #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_rotate"))]
             #[inline]
             pub const fn rotate_left(self, n: u32) -> Self {
+                #[cfg(stage0)]
                 unsafe { intrinsics::rotate_left(self, n as $SelfT) }
+                #[cfg(not(stage0))]
+                intrinsics::rotate_left(self, n as $SelfT)
             }
         }
 
@@ -2336,7 +2348,10 @@ assert_eq!(n.rotate_right(", $rot, "), m);
             #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_rotate"))]
             #[inline]
             pub const fn rotate_right(self, n: u32) -> Self {
+                #[cfg(stage0)]
                 unsafe { intrinsics::rotate_right(self, n as $SelfT) }
+                #[cfg(not(stage0))]
+                intrinsics::rotate_right(self, n as $SelfT)
             }
         }
 
@@ -2885,9 +2900,12 @@ $EndFeature, "
             #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_wrapping"))]
             #[inline]
             pub const fn wrapping_add(self, rhs: Self) -> Self {
+                #[cfg(stage0)]
                 unsafe {
                     intrinsics::overflowing_add(self, rhs)
                 }
+                #[cfg(not(stage0))]
+                intrinsics::overflowing_add(self, rhs)
             }
         }
 
@@ -2908,9 +2926,12 @@ $EndFeature, "
             #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_wrapping"))]
             #[inline]
             pub const fn wrapping_sub(self, rhs: Self) -> Self {
+                #[cfg(stage0)]
                 unsafe {
                     intrinsics::overflowing_sub(self, rhs)
                 }
+                #[cfg(not(stage0))]
+                intrinsics::overflowing_sub(self, rhs)
             }
         }
 
@@ -2932,9 +2953,12 @@ $EndFeature, "
         #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_wrapping"))]
         #[inline]
         pub const fn wrapping_mul(self, rhs: Self) -> Self {
+            #[cfg(stage0)]
             unsafe {
                 intrinsics::overflowing_mul(self, rhs)
             }
+                #[cfg(not(stage0))]
+                intrinsics::overflowing_mul(self, rhs)
         }
 
         doc_comment! {

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -357,7 +357,7 @@ let m = ", $rot_result, ";
 assert_eq!(n.rotate_left(", $rot, "), m);
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_int_rotate")]
+            #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_rotate"))]
             #[inline]
             pub const fn rotate_left(self, n: u32) -> Self {
                 (self as $UnsignedT).rotate_left(n) as Self
@@ -382,7 +382,7 @@ let m = ", $rot_op, ";
 assert_eq!(n.rotate_right(", $rot, "), m);
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_int_rotate")]
+            #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_rotate"))]
             #[inline]
             pub const fn rotate_right(self, n: u32) -> Self {
                 (self as $UnsignedT).rotate_right(n) as Self
@@ -2310,7 +2310,7 @@ let m = ", $rot_result, ";
 assert_eq!(n.rotate_left(", $rot, "), m);
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_int_rotate")]
+            #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_rotate"))]
             #[inline]
             pub const fn rotate_left(self, n: u32) -> Self {
                 unsafe { intrinsics::rotate_left(self, n as $SelfT) }
@@ -2335,7 +2335,7 @@ let m = ", $rot_op, ";
 assert_eq!(n.rotate_right(", $rot, "), m);
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_int_rotate")]
+            #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_rotate"))]
             #[inline]
             pub const fn rotate_right(self, n: u32) -> Self {
                 unsafe { intrinsics::rotate_right(self, n as $SelfT) }

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -2957,8 +2957,8 @@ $EndFeature, "
             unsafe {
                 intrinsics::overflowing_mul(self, rhs)
             }
-                #[cfg(not(stage0))]
-                intrinsics::overflowing_mul(self, rhs)
+            #[cfg(not(stage0))]
+            intrinsics::overflowing_mul(self, rhs)
         }
 
         doc_comment! {

--- a/src/librustc_mir/transform/qualify_min_const_fn.rs
+++ b/src/librustc_mir/transform/qualify_min_const_fn.rs
@@ -387,7 +387,8 @@ fn check_terminator(
     }
 }
 
-/// Returns true if the `def_id` refers to an intrisic which we've whitelisted.
+/// Returns true if the `def_id` refers to an intrisic which we've whitelisted
+/// for being called from stable `const fn`s (`min_const_fn`).
 ///
 /// Adding more intrinsics requires sign-off from @rust-lang/lang.
 fn is_intrinsic_whitelisted(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) -> bool {

--- a/src/librustc_mir/transform/qualify_min_const_fn.rs
+++ b/src/librustc_mir/transform/qualify_min_const_fn.rs
@@ -342,15 +342,11 @@ fn check_terminator(
                 // some intrinsics are waved through if called inside the
                 // standard library. Users never need to call them directly
                 match tcx.fn_sig(def_id).abi() {
-                    abi::Abi::RustIntrinsic => match &tcx.item_name(def_id).as_str()[..] {
-                        | "size_of"
-                        | "min_align_of"
-                        | "needs_drop"
-                        => {},
-                        _ => return Err((
+                    abi::Abi::RustIntrinsic => if !is_intrinsic_whitelisted(tcx, def_id) {
+                        return Err((
                             span,
                             "can only call a curated list of intrinsics in `min_const_fn`".into(),
-                        )),
+                        ))
                     },
                     abi::Abi::Rust if tcx.is_min_const_fn(def_id) => {},
                     abi::Abi::Rust => return Err((
@@ -388,5 +384,24 @@ fn check_terminator(
         TerminatorKind::FalseUnwind { .. } => {
             Err((span, "loops are not allowed in const fn".into()))
         },
+    }
+}
+
+/// Returns true if the `def_id` refers to an intrisic which we've whitelisted.
+///
+/// Adding more intrinsics requires sign-off from @rust-lang/lang.
+fn is_intrinsic_whitelisted(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) -> bool {
+    match &tcx.item_name(def_id).as_str()[..] {
+        | "size_of"
+        | "min_align_of"
+        | "needs_drop"
+        // Arithmetic:
+        | "overflowing_add" // ~> wrapping_add
+        | "overflowing_sub" // ~> wrapping_sub
+        | "overflowing_mul" // ~> wrapping_mul
+        | "unchecked_shl" // ~> wrapping_shl
+        | "unchecked_shr" // ~> wrapping_shr
+        => true,
+        _ => false,
     }
 }

--- a/src/librustc_mir/transform/qualify_min_const_fn.rs
+++ b/src/librustc_mir/transform/qualify_min_const_fn.rs
@@ -396,11 +396,13 @@ fn is_intrinsic_whitelisted(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) -> bool 
         | "min_align_of"
         | "needs_drop"
         // Arithmetic:
-        | "overflowing_add" // ~> wrapping_add
-        | "overflowing_sub" // ~> wrapping_sub
-        | "overflowing_mul" // ~> wrapping_mul
-        | "unchecked_shl" // ~> wrapping_shl
-        | "unchecked_shr" // ~> wrapping_shr
+        | "overflowing_add" // ~> .wrapping_add
+        | "overflowing_sub" // ~> .wrapping_sub
+        | "overflowing_mul" // ~> .wrapping_mul
+        | "unchecked_shl" // ~> .wrapping_shl
+        | "unchecked_shr" // ~> .wrapping_shr
+        | "rotate_left" // ~> .rotate_left
+        | "rotate_right" // ~> .rotate_right
         => true,
         _ => false,
     }

--- a/src/librustc_typeck/check/intrinsic.rs
+++ b/src/librustc_typeck/check/intrinsic.rs
@@ -66,6 +66,17 @@ fn equate_intrinsic_type<'a, 'tcx>(
     require_same_types(tcx, &cause, tcx.mk_fn_ptr(tcx.fn_sig(def_id)), fty);
 }
 
+/// Returns whether the given intrinsic is unsafe to call or not.
+pub fn intrisic_operation_unsafety(intrinsic: &str) -> hir::Unsafety {
+    match intrinsic {
+        "size_of" | "min_align_of" | "needs_drop" |
+        "overflowing_add" | "overflowing_sub" | "overflowing_mul" |
+        "rotate_left" | "rotate_right"
+        => hir::Unsafety::Normal,
+        _ => hir::Unsafety::Unsafe,
+    }
+}
+
 /// Remember to add all intrinsics here, in librustc_codegen_llvm/intrinsic.rs,
 /// and in libcore/intrinsics.rs
 pub fn check_intrinsic_type<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
@@ -117,10 +128,7 @@ pub fn check_intrinsic_type<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     } else if &name[..] == "abort" || &name[..] == "unreachable" {
         (0, Vec::new(), tcx.types.never, hir::Unsafety::Unsafe)
     } else {
-        let unsafety = match &name[..] {
-            "size_of" | "min_align_of" | "needs_drop" => hir::Unsafety::Normal,
-            _ => hir::Unsafety::Unsafe,
-        };
+        let unsafety = intrisic_operation_unsafety(&name[..]);
         let (n_tps, inputs, output) = match &name[..] {
             "breakpoint" => (0, Vec::new(), tcx.mk_unit()),
             "size_of" |

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -80,7 +80,7 @@ mod closure;
 mod callee;
 mod compare_method;
 mod generator_interior;
-mod intrinsic;
+pub mod intrinsic;
 mod op;
 
 use astconv::{AstConv, PathSeg};

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -16,6 +16,7 @@
 
 use astconv::{AstConv, Bounds};
 use constrained_type_params as ctp;
+use check::intrinsic::intrisic_operation_unsafety;
 use lint;
 use middle::lang_items::SizedTraitLangItem;
 use middle::resolve_lifetime as rl;
@@ -2076,10 +2077,7 @@ fn compute_sig_of_foreign_fn_decl<'a, 'tcx>(
     abi: abi::Abi,
 ) -> ty::PolyFnSig<'tcx> {
     let unsafety = if abi == abi::Abi::RustIntrinsic {
-        match &*tcx.item_name(def_id).as_str() {
-            "size_of" | "min_align_of" | "needs_drop" => hir::Unsafety::Normal,
-            _ => hir::Unsafety::Unsafe,
-        }
+        intrisic_operation_unsafety(&*tcx.item_name(def_id).as_str())
     } else {
         hir::Unsafety::Unsafe
     };

--- a/src/test/run-pass/const-int-rotate.rs
+++ b/src/test/run-pass/const-int-rotate.rs
@@ -1,5 +1,3 @@
-#![feature(const_int_rotate)]
-
 const LEFT: u32 = 0x10000b3u32.rotate_left(8);
 const RIGHT: u32 = 0xb301u32.rotate_right(8);
 

--- a/src/test/run-pass/const-int-sign.rs
+++ b/src/test/run-pass/const-int-sign.rs
@@ -1,5 +1,3 @@
-#![feature(const_int_sign)]
-
 const NEGATIVE_A: bool = (-10i32).is_negative();
 const NEGATIVE_B: bool = 10i32.is_negative();
 const POSITIVE_A: bool= (-10i32).is_positive();

--- a/src/test/run-pass/const-int-wrapping.rs
+++ b/src/test/run-pass/const-int-wrapping.rs
@@ -1,5 +1,3 @@
-#![feature(const_int_wrapping)]
-
 const ADD_A: u32 = 200u32.wrapping_add(55);
 const ADD_B: u32 = 200u32.wrapping_add(u32::max_value());
 

--- a/src/test/ui/consts/const-int-unchecked.rs
+++ b/src/test/ui/consts/const-int-unchecked.rs
@@ -2,10 +2,119 @@
 
 use std::intrinsics;
 
-const SHR: u8 = unsafe { intrinsics::unchecked_shr(5_u8, 8) };
+// The documentation of `unchecked_shl` states that it:
+//
+// Performs an unchecked left shift, resulting in undefined behavior when
+// y < 0 or y >= N, where N is the width of T in bits.
+//
+// So we check this for a few `y`.
+
+// unsigned types:
+
+const SHL_U8: u8 = unsafe { intrinsics::unchecked_shl(5_u8, 8) };
 //~^ ERROR any use of this value will cause an error
-const SHL: u8 = unsafe { intrinsics::unchecked_shl(5_u8, 8) };
+const SHL_U16: u16 = unsafe { intrinsics::unchecked_shl(5_u16, 16) };
+//~^ ERROR any use of this value will cause an error
+const SHL_U32: u32 = unsafe { intrinsics::unchecked_shl(5_u32, 32) };
+//~^ ERROR any use of this value will cause an error
+const SHL_U64: u64 = unsafe { intrinsics::unchecked_shl(5_u64, 64) };
+//~^ ERROR any use of this value will cause an error
+const SHL_U128: u128 = unsafe { intrinsics::unchecked_shl(5_u128, 128) };
 //~^ ERROR any use of this value will cause an error
 
-fn main() {
-}
+// signed types:
+
+const SHL_I8: i8 = unsafe { intrinsics::unchecked_shl(5_i8, 8) };
+//~^ ERROR any use of this value will cause an error
+const SHL_I16: i16 = unsafe { intrinsics::unchecked_shl(5_16, 16) };
+//~^ ERROR any use of this value will cause an error
+const SHL_I32: i32 = unsafe { intrinsics::unchecked_shl(5_i32, 32) };
+//~^ ERROR any use of this value will cause an error
+const SHL_I64: i64 = unsafe { intrinsics::unchecked_shl(5_i64, 64) };
+//~^ ERROR any use of this value will cause an error
+const SHL_I128: i128 = unsafe { intrinsics::unchecked_shl(5_i128, 128) };
+//~^ ERROR any use of this value will cause an error
+
+// and make sure we capture y < 0:
+
+const SHL_I8_NEG: i8 = unsafe { intrinsics::unchecked_shl(5_i8, -1) };
+//~^ ERROR any use of this value will cause an error
+const SHL_I16_NEG: i16 = unsafe { intrinsics::unchecked_shl(5_16, -1) };
+//~^ ERROR any use of this value will cause an error
+const SHL_I32_NEG: i32 = unsafe { intrinsics::unchecked_shl(5_i32, -1) };
+//~^ ERROR any use of this value will cause an error
+const SHL_I64_NEG: i64 = unsafe { intrinsics::unchecked_shl(5_i64, -1) };
+//~^ ERROR any use of this value will cause an error
+const SHL_I128_NEG: i128 = unsafe { intrinsics::unchecked_shl(5_i128, -1) };
+//~^ ERROR any use of this value will cause an error
+
+// and that there's no special relation to the value -1 by picking some
+// negative values at random:
+
+const SHL_I8_NEG_RANDOM: i8 = unsafe { intrinsics::unchecked_shl(5_i8, -6) };
+//~^ ERROR any use of this value will cause an error
+const SHL_I16_NEG_RANDOM: i16 = unsafe { intrinsics::unchecked_shl(5_16, -13) };
+//~^ ERROR any use of this value will cause an error
+const SHL_I32_NEG_RANDOM: i32 = unsafe { intrinsics::unchecked_shl(5_i32, -25) };
+//~^ ERROR any use of this value will cause an error
+const SHL_I64_NEG_RANDOM: i64 = unsafe { intrinsics::unchecked_shl(5_i64, -30) };
+//~^ ERROR any use of this value will cause an error
+const SHL_I128_NEG_RANDOM: i128 = unsafe { intrinsics::unchecked_shl(5_i128, -93) };
+//~^ ERROR any use of this value will cause an error
+
+// Repeat it all over for `unchecked_shr`
+
+// unsigned types:
+
+const SHR_U8: u8 = unsafe { intrinsics::unchecked_shr(5_u8, 8) };
+//~^ ERROR any use of this value will cause an error
+const SHR_U16: u16 = unsafe { intrinsics::unchecked_shr(5_u16, 16) };
+//~^ ERROR any use of this value will cause an error
+const SHR_U32: u32 = unsafe { intrinsics::unchecked_shr(5_u32, 32) };
+//~^ ERROR any use of this value will cause an error
+const SHR_U64: u64 = unsafe { intrinsics::unchecked_shr(5_u64, 64) };
+//~^ ERROR any use of this value will cause an error
+const SHR_U128: u128 = unsafe { intrinsics::unchecked_shr(5_u128, 128) };
+//~^ ERROR any use of this value will cause an error
+
+// signed types:
+
+const SHR_I8: i8 = unsafe { intrinsics::unchecked_shr(5_i8, 8) };
+//~^ ERROR any use of this value will cause an error
+const SHR_I16: i16 = unsafe { intrinsics::unchecked_shr(5_16, 16) };
+//~^ ERROR any use of this value will cause an error
+const SHR_I32: i32 = unsafe { intrinsics::unchecked_shr(5_i32, 32) };
+//~^ ERROR any use of this value will cause an error
+const SHR_I64: i64 = unsafe { intrinsics::unchecked_shr(5_i64, 64) };
+//~^ ERROR any use of this value will cause an error
+const SHR_I128: i128 = unsafe { intrinsics::unchecked_shr(5_i128, 128) };
+//~^ ERROR any use of this value will cause an error
+
+// and make sure we capture y < 0:
+
+const SHR_I8_NEG: i8 = unsafe { intrinsics::unchecked_shr(5_i8, -1) };
+//~^ ERROR any use of this value will cause an error
+const SHR_I16_NEG: i16 = unsafe { intrinsics::unchecked_shr(5_16, -1) };
+//~^ ERROR any use of this value will cause an error
+const SHR_I32_NEG: i32 = unsafe { intrinsics::unchecked_shr(5_i32, -1) };
+//~^ ERROR any use of this value will cause an error
+const SHR_I64_NEG: i64 = unsafe { intrinsics::unchecked_shr(5_i64, -1) };
+//~^ ERROR any use of this value will cause an error
+const SHR_I128_NEG: i128 = unsafe { intrinsics::unchecked_shr(5_i128, -1) };
+//~^ ERROR any use of this value will cause an error
+
+// and that there's no special relation to the value -1 by picking some
+// negative values at random:
+
+const SHR_I8_NEG_RANDOM: i8 = unsafe { intrinsics::unchecked_shr(5_i8, -6) };
+//~^ ERROR any use of this value will cause an error
+const SHR_I16_NEG_RANDOM: i16 = unsafe { intrinsics::unchecked_shr(5_16, -13) };
+//~^ ERROR any use of this value will cause an error
+const SHR_I32_NEG_RANDOM: i32 = unsafe { intrinsics::unchecked_shr(5_i32, -25) };
+//~^ ERROR any use of this value will cause an error
+const SHR_I64_NEG_RANDOM: i64 = unsafe { intrinsics::unchecked_shr(5_i64, -30) };
+//~^ ERROR any use of this value will cause an error
+const SHR_I128_NEG_RANDOM: i128 = unsafe { intrinsics::unchecked_shr(5_i128, -93) };
+//~^ ERROR any use of this value will cause an error
+
+fn main() {}

--- a/src/test/ui/consts/const-int-unchecked.stderr
+++ b/src/test/ui/consts/const-int-unchecked.stderr
@@ -1,20 +1,324 @@
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:5:1
+  --> $DIR/const-int-unchecked.rs:14:1
    |
-LL | const SHR: u8 = unsafe { intrinsics::unchecked_shr(5_u8, 8) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^----------------------------------^^^
-   |                          |
-   |                          Overflowing shift by 8 in unchecked_shr
+LL | const SHL_U8: u8 = unsafe { intrinsics::unchecked_shl(5_u8, 8) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^----------------------------------^^^
+   |                             |
+   |                             Overflowing shift by 8 in unchecked_shl
    |
    = note: #[deny(const_err)] on by default
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:7:1
+  --> $DIR/const-int-unchecked.rs:16:1
    |
-LL | const SHL: u8 = unsafe { intrinsics::unchecked_shl(5_u8, 8) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^----------------------------------^^^
-   |                          |
-   |                          Overflowing shift by 8 in unchecked_shl
+LL | const SHL_U16: u16 = unsafe { intrinsics::unchecked_shl(5_u16, 16) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   |                               |
+   |                               Overflowing shift by 16 in unchecked_shl
 
-error: aborting due to 2 previous errors
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:18:1
+   |
+LL | const SHL_U32: u32 = unsafe { intrinsics::unchecked_shl(5_u32, 32) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   |                               |
+   |                               Overflowing shift by 32 in unchecked_shl
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:20:1
+   |
+LL | const SHL_U64: u64 = unsafe { intrinsics::unchecked_shl(5_u64, 64) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   |                               |
+   |                               Overflowing shift by 64 in unchecked_shl
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:22:1
+   |
+LL | const SHL_U128: u128 = unsafe { intrinsics::unchecked_shl(5_u128, 128) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^--------------------------------------^^^
+   |                                 |
+   |                                 Overflowing shift by 128 in unchecked_shl
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:27:1
+   |
+LL | const SHL_I8: i8 = unsafe { intrinsics::unchecked_shl(5_i8, 8) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^----------------------------------^^^
+   |                             |
+   |                             Overflowing shift by 8 in unchecked_shl
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:29:1
+   |
+LL | const SHL_I16: i16 = unsafe { intrinsics::unchecked_shl(5_16, 16) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------------------------------^^^
+   |                               |
+   |                               Overflowing shift by 16 in unchecked_shl
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:31:1
+   |
+LL | const SHL_I32: i32 = unsafe { intrinsics::unchecked_shl(5_i32, 32) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   |                               |
+   |                               Overflowing shift by 32 in unchecked_shl
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:33:1
+   |
+LL | const SHL_I64: i64 = unsafe { intrinsics::unchecked_shl(5_i64, 64) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   |                               |
+   |                               Overflowing shift by 64 in unchecked_shl
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:35:1
+   |
+LL | const SHL_I128: i128 = unsafe { intrinsics::unchecked_shl(5_i128, 128) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^--------------------------------------^^^
+   |                                 |
+   |                                 Overflowing shift by 128 in unchecked_shl
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:40:1
+   |
+LL | const SHL_I8_NEG: i8 = unsafe { intrinsics::unchecked_shl(5_i8, -1) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------------------------------^^^
+   |                                 |
+   |                                 Overflowing shift by 255 in unchecked_shl
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:42:1
+   |
+LL | const SHL_I16_NEG: i16 = unsafe { intrinsics::unchecked_shl(5_16, -1) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------------------------------^^^
+   |                                   |
+   |                                   Overflowing shift by 65535 in unchecked_shl
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:44:1
+   |
+LL | const SHL_I32_NEG: i32 = unsafe { intrinsics::unchecked_shl(5_i32, -1) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   |                                   |
+   |                                   Overflowing shift by 4294967295 in unchecked_shl
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:46:1
+   |
+LL | const SHL_I64_NEG: i64 = unsafe { intrinsics::unchecked_shl(5_i64, -1) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   |                                   |
+   |                                   Overflowing shift by 18446744073709551615 in unchecked_shl
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:48:1
+   |
+LL | const SHL_I128_NEG: i128 = unsafe { intrinsics::unchecked_shl(5_i128, -1) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------------------------------------^^^
+   |                                     |
+   |                                     Overflowing shift by 340282366920938463463374607431768211455 in unchecked_shl
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:54:1
+   |
+LL | const SHL_I8_NEG_RANDOM: i8 = unsafe { intrinsics::unchecked_shl(5_i8, -6) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------------------------------^^^
+   |                                        |
+   |                                        Overflowing shift by 250 in unchecked_shl
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:56:1
+   |
+LL | const SHL_I16_NEG_RANDOM: i16 = unsafe { intrinsics::unchecked_shl(5_16, -13) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   |                                          |
+   |                                          Overflowing shift by 65523 in unchecked_shl
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:58:1
+   |
+LL | const SHL_I32_NEG_RANDOM: i32 = unsafe { intrinsics::unchecked_shl(5_i32, -25) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------------------------------------^^^
+   |                                          |
+   |                                          Overflowing shift by 4294967271 in unchecked_shl
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:60:1
+   |
+LL | const SHL_I64_NEG_RANDOM: i64 = unsafe { intrinsics::unchecked_shl(5_i64, -30) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------------------------------------^^^
+   |                                          |
+   |                                          Overflowing shift by 18446744073709551586 in unchecked_shl
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:62:1
+   |
+LL | const SHL_I128_NEG_RANDOM: i128 = unsafe { intrinsics::unchecked_shl(5_i128, -93) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^--------------------------------------^^^
+   |                                            |
+   |                                            Overflowing shift by 340282366920938463463374607431768211363 in unchecked_shl
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:69:1
+   |
+LL | const SHR_U8: u8 = unsafe { intrinsics::unchecked_shr(5_u8, 8) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^----------------------------------^^^
+   |                             |
+   |                             Overflowing shift by 8 in unchecked_shr
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:71:1
+   |
+LL | const SHR_U16: u16 = unsafe { intrinsics::unchecked_shr(5_u16, 16) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   |                               |
+   |                               Overflowing shift by 16 in unchecked_shr
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:73:1
+   |
+LL | const SHR_U32: u32 = unsafe { intrinsics::unchecked_shr(5_u32, 32) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   |                               |
+   |                               Overflowing shift by 32 in unchecked_shr
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:75:1
+   |
+LL | const SHR_U64: u64 = unsafe { intrinsics::unchecked_shr(5_u64, 64) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   |                               |
+   |                               Overflowing shift by 64 in unchecked_shr
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:77:1
+   |
+LL | const SHR_U128: u128 = unsafe { intrinsics::unchecked_shr(5_u128, 128) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^--------------------------------------^^^
+   |                                 |
+   |                                 Overflowing shift by 128 in unchecked_shr
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:82:1
+   |
+LL | const SHR_I8: i8 = unsafe { intrinsics::unchecked_shr(5_i8, 8) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^----------------------------------^^^
+   |                             |
+   |                             Overflowing shift by 8 in unchecked_shr
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:84:1
+   |
+LL | const SHR_I16: i16 = unsafe { intrinsics::unchecked_shr(5_16, 16) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------------------------------^^^
+   |                               |
+   |                               Overflowing shift by 16 in unchecked_shr
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:86:1
+   |
+LL | const SHR_I32: i32 = unsafe { intrinsics::unchecked_shr(5_i32, 32) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   |                               |
+   |                               Overflowing shift by 32 in unchecked_shr
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:88:1
+   |
+LL | const SHR_I64: i64 = unsafe { intrinsics::unchecked_shr(5_i64, 64) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   |                               |
+   |                               Overflowing shift by 64 in unchecked_shr
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:90:1
+   |
+LL | const SHR_I128: i128 = unsafe { intrinsics::unchecked_shr(5_i128, 128) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^--------------------------------------^^^
+   |                                 |
+   |                                 Overflowing shift by 128 in unchecked_shr
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:95:1
+   |
+LL | const SHR_I8_NEG: i8 = unsafe { intrinsics::unchecked_shr(5_i8, -1) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------------------------------^^^
+   |                                 |
+   |                                 Overflowing shift by 255 in unchecked_shr
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:97:1
+   |
+LL | const SHR_I16_NEG: i16 = unsafe { intrinsics::unchecked_shr(5_16, -1) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------------------------------^^^
+   |                                   |
+   |                                   Overflowing shift by 65535 in unchecked_shr
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:99:1
+   |
+LL | const SHR_I32_NEG: i32 = unsafe { intrinsics::unchecked_shr(5_i32, -1) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   |                                   |
+   |                                   Overflowing shift by 4294967295 in unchecked_shr
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:101:1
+   |
+LL | const SHR_I64_NEG: i64 = unsafe { intrinsics::unchecked_shr(5_i64, -1) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   |                                   |
+   |                                   Overflowing shift by 18446744073709551615 in unchecked_shr
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:103:1
+   |
+LL | const SHR_I128_NEG: i128 = unsafe { intrinsics::unchecked_shr(5_i128, -1) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------------------------------------^^^
+   |                                     |
+   |                                     Overflowing shift by 340282366920938463463374607431768211455 in unchecked_shr
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:109:1
+   |
+LL | const SHR_I8_NEG_RANDOM: i8 = unsafe { intrinsics::unchecked_shr(5_i8, -6) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------------------------------^^^
+   |                                        |
+   |                                        Overflowing shift by 250 in unchecked_shr
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:111:1
+   |
+LL | const SHR_I16_NEG_RANDOM: i16 = unsafe { intrinsics::unchecked_shr(5_16, -13) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   |                                          |
+   |                                          Overflowing shift by 65523 in unchecked_shr
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:113:1
+   |
+LL | const SHR_I32_NEG_RANDOM: i32 = unsafe { intrinsics::unchecked_shr(5_i32, -25) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------------------------------------^^^
+   |                                          |
+   |                                          Overflowing shift by 4294967271 in unchecked_shr
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:115:1
+   |
+LL | const SHR_I64_NEG_RANDOM: i64 = unsafe { intrinsics::unchecked_shr(5_i64, -30) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------------------------------------^^^
+   |                                          |
+   |                                          Overflowing shift by 18446744073709551586 in unchecked_shr
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:117:1
+   |
+LL | const SHR_I128_NEG_RANDOM: i128 = unsafe { intrinsics::unchecked_shr(5_i128, -93) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^--------------------------------------^^^
+   |                                            |
+   |                                            Overflowing shift by 340282366920938463463374607431768211363 in unchecked_shr
+
+error: aborting due to 40 previous errors
 


### PR DESCRIPTION
This PR intends to stabilize the following *stable* methods *as `const fn`s*:
- `const_int_rotate`
  - `rotate_left`
  - `rotate_right`
- `const_int_wrapping`
  - `wrapping_add`
  - `wrapping_sub`
  - `wrapping_mul`
  - `wrapping_shl`
  - `wrapping_shr`
- `const_int_sign`
  -  `is_positive`
  - `is_negative`

(this is the current set; and may be reduced during review...)

r? @oli-obk 
(please review this until you think its in a ready state for team review; but don't r+)

cc @RalfJung wrt. state of miri re. the aforementioned methods.
cc https://github.com/rust-lang/rust/issues/53718

I've added T-lang since this affects intrinsics and the operational semantics of Rust's `const fn` fragment.
Once @oli-obk thinks its ready for team review I'll fcp-merge.