### PR TITLE
Add a regression test for mutating a non-mut #[thread_local]

### DIFF
--- a/src/test/ui/thread-local-mutation.nll.stderr
+++ b/src/test/ui/thread-local-mutation.nll.stderr
@@ -1,0 +1,9 @@
+error[E0594]: cannot assign to immutable static item `S`
+  --> $DIR/thread-local-mutation.rs:11:5
+   |
+LL |     S = "after"; //~ ERROR cannot assign to immutable
+   |     ^^^^^^^^^^^ cannot assign
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0594`.

--- a/src/test/ui/thread-local-mutation.rs
+++ b/src/test/ui/thread-local-mutation.rs
@@ -1,0 +1,18 @@
+// Regression test for #54901: immutable thread locals could be mutated. See:
+// https://github.com/rust-lang/rust/issues/29594#issuecomment-328177697
+// https://github.com/rust-lang/rust/issues/54901
+
+#![feature(thread_local)]
+
+#[thread_local]
+static S: &str = "before";
+
+fn set_s() {
+    S = "after"; //~ ERROR cannot assign to immutable
+}
+
+fn main() {
+    println!("{}", S);
+    set_s();
+    println!("{}", S);
+}

--- a/src/test/ui/thread-local-mutation.stderr
+++ b/src/test/ui/thread-local-mutation.stderr
@@ -1,0 +1,9 @@
+error[E0594]: cannot assign to immutable thread-local static item
+  --> $DIR/thread-local-mutation.rs:11:5
+   |
+LL |     S = "after"; //~ ERROR cannot assign to immutable
+   |     ^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0594`.


### PR DESCRIPTION
This should close #54901 since the regression has since been fixed.