### PR TITLE
Revert #56944.

### DIFF
--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -48,6 +48,7 @@ impl Step for Std {
         builder.info(&format!("Checking std artifacts ({} -> {})", &compiler.host, target));
         run_cargo(builder,
                   &mut cargo,
+                  vec![],
                   &libstd_stamp(builder, compiler, target),
                   true);
 
@@ -94,6 +95,7 @@ impl Step for Rustc {
         builder.info(&format!("Checking compiler artifacts ({} -> {})", &compiler.host, target));
         run_cargo(builder,
                   &mut cargo,
+                  vec![],
                   &librustc_stamp(builder, compiler, target),
                   true);
 
@@ -144,6 +146,7 @@ impl Step for CodegenBackend {
         let _folder = builder.fold_output(|| format!("stage{}-rustc_codegen_llvm", compiler.stage));
         run_cargo(builder,
                   &mut cargo,
+                  vec![],
                   &codegen_backend_stamp(builder, compiler, target, backend),
                   true);
     }
@@ -181,6 +184,7 @@ impl Step for Test {
         builder.info(&format!("Checking test artifacts ({} -> {})", &compiler.host, target));
         run_cargo(builder,
                   &mut cargo,
+                  vec![],
                   &libtest_stamp(builder, compiler, target),
                   true);
 
@@ -228,6 +232,7 @@ impl Step for Rustdoc {
         println!("Checking rustdoc artifacts ({} -> {})", &compiler.host, target);
         run_cargo(builder,
                   &mut cargo,
+                  vec![],
                   &rustdoc_stamp(builder, compiler, target),
                   true);
 

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -1887,13 +1887,13 @@ impl Step for HashSign {
 // LLVM tools are linked dynamically.
 // Note: This function does no yet support Windows but we also don't support
 //       linking LLVM tools dynamically on Windows yet.
-pub fn maybe_install_llvm_dylib(builder: &Builder,
-                                target: Interned<String>,
-                                sysroot: &Path) {
+fn maybe_install_llvm_dylib(builder: &Builder,
+                            target: Interned<String>,
+                            image: &Path) {
     let src_libdir = builder
         .llvm_out(target)
         .join("lib");
-    let dst_libdir = sysroot.join("lib/rustlib").join(&*target).join("lib");
+    let dst_libdir = image.join("lib/rustlib").join(&*target).join("lib");
     t!(fs::create_dir_all(&dst_libdir));
 
     if target.contains("apple-darwin") {

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -87,7 +87,7 @@ impl Step for ToolBuild {
         let _folder = builder.fold_output(|| format!("stage{}-{}", compiler.stage, tool));
         builder.info(&format!("Building stage{} tool {} ({})", compiler.stage, tool, target));
         let mut duplicates = Vec::new();
-        let is_expected = compile::stream_cargo(builder, &mut cargo, &mut |msg| {
+        let is_expected = compile::stream_cargo(builder, &mut cargo, vec![], &mut |msg| {
             // Only care about big things like the RLS/Cargo for now
             match tool {
                 | "rls"

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -210,7 +210,14 @@ pub fn run<F>(run_compiler: F) -> isize
 }
 
 fn load_backend_from_dylib(path: &Path) -> fn() -> Box<dyn CodegenBackend> {
-    let lib = DynamicLibrary::open(Some(path)).unwrap_or_else(|err| {
+    // Note that we're specifically using `open_global_now` here rather than
+    // `open`, namely we want the behavior on Unix of RTLD_GLOBAL and RTLD_NOW,
+    // where NOW means "bind everything right now" because we don't want
+    // surprises later on and RTLD_GLOBAL allows the symbols to be made
+    // available for future dynamic libraries opened. This is currently used by
+    // loading LLVM and then making its symbols available for other dynamic
+    // libraries.
+    let lib = DynamicLibrary::open_global_now(path).unwrap_or_else(|err| {
         let err = format!("couldn't load codegen backend {:?}: {:?}", path, err);
         early_error(ErrorOutputType::default(), &err);
     });

--- a/src/librustc_llvm/build.rs
+++ b/src/librustc_llvm/build.rs
@@ -142,10 +142,6 @@ fn main() {
             continue;
         }
 
-        if flag.starts_with("-flto") {
-            continue;
-        }
-
         // -Wdate-time is not supported by the netbsd cross compiler
         if is_crossed && target.contains("netbsd") && flag.contains("date-time") {
             continue;

--- a/src/test/run-make-fulldeps/llvm-pass/Makefile
+++ b/src/test/run-make-fulldeps/llvm-pass/Makefile
@@ -1,0 +1,28 @@
+-include ../tools.mk
+
+ifeq ($(UNAME),Darwin)
+PLUGIN_FLAGS := -C link-args=-Wl,-undefined,dynamic_lookup
+endif
+
+ifeq ($(findstring stage1,$(RUST_BUILD_STAGE)),stage1)
+# ignore stage1
+all:
+
+else
+# Windows doesn't correctly handle include statements with escaping paths,
+# so this test will not get run on Windows.
+ifdef IS_WINDOWS
+all:
+else
+all: $(call NATIVE_STATICLIB,llvm-function-pass) $(call NATIVE_STATICLIB,llvm-module-pass)
+	$(RUSTC) plugin.rs -C prefer-dynamic $(PLUGIN_FLAGS)
+	$(RUSTC) main.rs
+
+$(TMPDIR)/libllvm-function-pass.o:
+	$(CXX) $(CFLAGS) $(LLVM_CXXFLAGS) -c llvm-function-pass.so.cc -o $(TMPDIR)/libllvm-function-pass.o
+
+$(TMPDIR)/libllvm-module-pass.o:
+	$(CXX) $(CFLAGS) $(LLVM_CXXFLAGS) -c llvm-module-pass.so.cc -o $(TMPDIR)/libllvm-module-pass.o
+endif
+
+endif

--- a/src/test/run-make-fulldeps/llvm-pass/llvm-function-pass.so.cc
+++ b/src/test/run-make-fulldeps/llvm-pass/llvm-function-pass.so.cc
@@ -1,0 +1,56 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "llvm/Pass.h"
+#include "llvm/IR/Function.h"
+
+using namespace llvm;
+
+namespace {
+
+  class TestLLVMPass : public FunctionPass {
+
+  public:
+
+    static char ID;
+    TestLLVMPass() : FunctionPass(ID) { }
+
+    bool runOnFunction(Function &F) override;
+
+    StringRef getPassName() const override {
+      return "Some LLVM pass";
+    }
+
+  };
+
+}
+
+bool TestLLVMPass::runOnFunction(Function &F) {
+  // A couple examples of operations that previously caused segmentation faults
+  // https://github.com/rust-lang/rust/issues/31067
+
+  for (auto N = F.begin(); N != F.end(); ++N) {
+    /* code */
+  }
+
+  LLVMContext &C = F.getContext();
+  IntegerType *Int8Ty  = IntegerType::getInt8Ty(C);
+  PointerType::get(Int8Ty, 0);
+  return true;
+}
+
+char TestLLVMPass::ID = 0;
+
+static RegisterPass<TestLLVMPass> RegisterAFLPass(
+  "some-llvm-function-pass", "Some LLVM pass");

--- a/src/test/run-make-fulldeps/llvm-pass/llvm-module-pass.so.cc
+++ b/src/test/run-make-fulldeps/llvm-pass/llvm-module-pass.so.cc
@@ -1,0 +1,55 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "llvm/IR/Module.h"
+
+using namespace llvm;
+
+namespace {
+
+  class TestLLVMPass : public ModulePass {
+
+  public:
+
+    static char ID;
+    TestLLVMPass() : ModulePass(ID) { }
+
+    bool runOnModule(Module &M) override;
+
+    StringRef getPassName() const override {
+      return "Some LLVM pass";
+    }
+
+  };
+
+}
+
+bool TestLLVMPass::runOnModule(Module &M) {
+  // A couple examples of operations that previously caused segmentation faults
+  // https://github.com/rust-lang/rust/issues/31067
+
+  for (auto F = M.begin(); F != M.end(); ++F) {
+    /* code */
+  }
+
+  LLVMContext &C = M.getContext();
+  IntegerType *Int8Ty  = IntegerType::getInt8Ty(C);
+  PointerType::get(Int8Ty, 0);
+  return true;
+}
+
+char TestLLVMPass::ID = 0;
+
+static RegisterPass<TestLLVMPass> RegisterAFLPass(
+  "some-llvm-module-pass", "Some LLVM pass");

--- a/src/test/run-make-fulldeps/llvm-pass/main.rs
+++ b/src/test/run-make-fulldeps/llvm-pass/main.rs
@@ -1,0 +1,14 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(plugin)]
+#![plugin(some_plugin)]
+
+fn main() {}

--- a/src/test/run-make-fulldeps/llvm-pass/plugin.rs
+++ b/src/test/run-make-fulldeps/llvm-pass/plugin.rs
@@ -1,0 +1,28 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(plugin_registrar, rustc_private)]
+#![crate_type = "dylib"]
+#![crate_name = "some_plugin"]
+
+extern crate rustc;
+extern crate rustc_plugin;
+
+#[link(name = "llvm-function-pass", kind = "static")]
+#[link(name = "llvm-module-pass", kind = "static")]
+extern {}
+
+use rustc_plugin::registry::Registry;
+
+#[plugin_registrar]
+pub fn plugin_registrar(reg: &mut Registry) {
+    reg.register_llvm_pass("some-llvm-function-pass");
+    reg.register_llvm_pass("some-llvm-module-pass");
+}


### PR DESCRIPTION
This should fix #57111, since #56944 is the only PR involving LLVM. 

#57111 is caused by both the rustc and rust-std tarballs providing libLLVM.

r? @alexcrichton 
