### PR TITLE
Stabilize Duration::{as_millis, as_micros, as_nanos}

### DIFF
--- a/src/liballoc/benches/vec_deque_append.rs
+++ b/src/liballoc/benches/vec_deque_append.rs
@@ -1,4 +1,4 @@
-#![feature(duration_as_u128)]
+#![cfg_attr(stage0, feature(duration_as_u128))]
 use std::{collections::VecDeque, time::Instant};
 
 const VECDEQUE_LEN: i32 = 100000;

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -265,13 +265,12 @@ impl Duration {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(duration_as_u128)]
     /// use std::time::Duration;
     ///
     /// let duration = Duration::new(5, 730023852);
     /// assert_eq!(duration.as_millis(), 5730);
     /// ```
-    #[unstable(feature = "duration_as_u128", issue = "50202")]
+    #[stable(feature = "duration_as_u128", since = "1.33.0")]
     #[inline]
     pub const fn as_millis(&self) -> u128 {
         self.secs as u128 * MILLIS_PER_SEC as u128 + (self.nanos / NANOS_PER_MILLI) as u128
@@ -282,13 +281,12 @@ impl Duration {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(duration_as_u128)]
     /// use std::time::Duration;
     ///
     /// let duration = Duration::new(5, 730023852);
     /// assert_eq!(duration.as_micros(), 5730023);
     /// ```
-    #[unstable(feature = "duration_as_u128", issue = "50202")]
+    #[stable(feature = "duration_as_u128", since = "1.33.0")]
     #[inline]
     pub const fn as_micros(&self) -> u128 {
         self.secs as u128 * MICROS_PER_SEC as u128 + (self.nanos / NANOS_PER_MICRO) as u128
@@ -299,13 +297,12 @@ impl Duration {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(duration_as_u128)]
     /// use std::time::Duration;
     ///
     /// let duration = Duration::new(5, 730023852);
     /// assert_eq!(duration.as_nanos(), 5730023852);
     /// ```
-    #[unstable(feature = "duration_as_u128", issue = "50202")]
+    #[stable(feature = "duration_as_u128", since = "1.33.0")]
     #[inline]
     pub const fn as_nanos(&self) -> u128 {
         self.secs as u128 * NANOS_PER_SEC as u128 + self.nanos as u128

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -248,7 +248,7 @@
 #![feature(const_cstr_unchecked)]
 #![feature(core_intrinsics)]
 #![feature(dropck_eyepatch)]
-#![feature(duration_as_u128)]
+#![cfg_attr(stage0, feature(duration_as_u128))]
 #![feature(exact_size_is_empty)]
 #![feature(external_doc)]
 #![feature(fixed_size_array)]


### PR DESCRIPTION
Fixes #50202. :tada: 

This is the stabilization PR for the `duration_as_u128` feature. I have never made one of these before so please let me know if I missed a step. I followed the [guide in the Rust Forge](https://forge.rust-lang.org/stabilization-guide.html) and also found some old stabilization PRs ([1](https://github.com/rust-lang/rust/pull/57002), [2](https://github.com/rust-lang/rust/pull/56207)) for similar features to base my work on.