### PR TITLE
make Alloc::check_bounds_ptr private; you should use Memory::check_bounds_ptr instead

### DIFF
--- a/src/librustc/mir/interpret/allocation.rs
+++ b/src/librustc/mir/interpret/allocation.rs
@@ -147,7 +147,7 @@ impl<'tcx, Tag, Extra> Allocation<Tag, Extra> {
     /// of an allocation (i.e., at the first *inaccessible* location) *is* considered
     /// in-bounds!  This follows C's/LLVM's rules.
     /// If you want to check bounds before doing a memory access, better use `check_bounds`.
-    pub fn check_bounds_ptr(
+    fn check_bounds_ptr(
         &self,
         ptr: Pointer<Tag>,
     ) -> EvalResult<'tcx> {


### PR DESCRIPTION
r? @oli-obk 