### PR TITLE
Document that `-C opt-level=0` implies `-C debug-assertions`.

### DIFF
--- a/src/doc/rustc/src/codegen-options/index.md
+++ b/src/doc/rustc/src/codegen-options/index.md
@@ -187,7 +187,7 @@ This flag lets you control debug information:
 
 This flag lets you control the optimization level.
 
-* `0`: no optimizations
+* `0`: no optimizations, also turn on `cfg(debug_assertions)`.
 * `1`: basic optimizations
 * `2`: some optimizations
 * `3`: all optimizations


### PR DESCRIPTION
I couldn't find it stated anywhere else (https://doc.rust-lang.org/nightly/rustc/codegen-options/index.html#opt-level).
It was a problem before here: https://github.com/rust-lang/rust/issues/39449, it got lost in the migration to the new documentation I assume.

On a sidenote: I think that `-C opt-level=0` having a sideeffect on another flag should be changed. Having compiler flags affecting others doesn't make much sense to me, they are used to fine tune anyway.
In any case, this plays no role in this PR.