### PR TITLE
Add future incompatibility lint for #[link] without arguments

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -352,6 +352,13 @@ declare_lint! {
     "outlives requirements can be inferred"
 }
 
+declare_lint! {
+    pub INVALID_LINK_ARGUMENTS,
+    Allow,
+    "#[link(...)] must contain a nonrepeating list of arguments \
+     including a `name` argument"
+}
+
 /// Some lints that are buffered from `libsyntax`. See `syntax::early_buffered_lints`.
 pub mod parser {
     declare_lint! {
@@ -432,6 +439,7 @@ impl LintPass for HardwiredLints {
             MACRO_EXPANDED_MACRO_EXPORTS_ACCESSED_BY_ABSOLUTE_PATHS,
             parser::QUESTION_MARK_MACRO_SEP,
             DEPRECATED_IN_FUTURE,
+            INVALID_LINK_ARGUMENTS,
         )
     }
 }

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -336,6 +336,11 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
             reference: "issue #52234 <https://github.com/rust-lang/rust/issues/52234>",
             edition: None,
         },
+        FutureIncompatibleInfo {
+            id: LintId::of(INVALID_LINK_ARGUMENTS),
+            reference: "issue #53901 <https://github.com/rust-lang/rust/issues/53901>",
+            edition: None,
+        },
         ]);
 
     // Register renamed and removed lints.

--- a/src/librustc_metadata/diagnostics.rs
+++ b/src/librustc_metadata/diagnostics.rs
@@ -84,6 +84,17 @@ You need to link your code to the relevant crate in order to be able to use it
 well, and you link to them the same way.
 "##,
 
+E0494: r##"
+A link was used with repeated arguments. Erroneous code example:
+
+```ignore (cannot-test-this-because-rustdoc-stops-compile-fail-before-codegen)
+#[link(name = "foo", name = "bar)] extern {}
+// error: #[link(...)] contains repeated `name` arguments
+```
+
+Each argument may occur at most once.
+"##,
+
 }
 
 register_diagnostics! {

--- a/src/librustc_metadata/diagnostics.rs
+++ b/src/librustc_metadata/diagnostics.rs
@@ -84,7 +84,7 @@ You need to link your code to the relevant crate in order to be able to use it
 well, and you link to them the same way.
 "##,
 
-E0494: r##"
+E0649: r##"
 A link was used with repeated arguments. Erroneous code example:
 
 ```ignore (cannot-test-this-because-rustdoc-stops-compile-fail-before-codegen)

--- a/src/librustc_metadata/diagnostics.rs
+++ b/src/librustc_metadata/diagnostics.rs
@@ -84,17 +84,6 @@ You need to link your code to the relevant crate in order to be able to use it
 well, and you link to them the same way.
 "##,
 
-E0649: r##"
-A link was used with repeated arguments. Erroneous code example:
-
-```ignore (cannot-test-this-because-rustdoc-stops-compile-fail-before-codegen)
-#[link(name = "foo", name = "bar)] extern {}
-// error: #[link(...)] contains repeated `name` arguments
-```
-
-Each argument may occur at most once.
-"##,
-
 }
 
 register_diagnostics! {
@@ -108,4 +97,5 @@ register_diagnostics! {
     E0465, // multiple .. candidates for `..` found
     E0519, // local crate and dependency have same (crate-name, disambiguator)
     E0523, // two dependencies have same (crate-name, disambiguator) but different SVH
+    E0649, // `link` was used with repeated arguments
 }

--- a/src/librustc_metadata/diagnostics.rs
+++ b/src/librustc_metadata/diagnostics.rs
@@ -2,13 +2,13 @@
 
 register_long_diagnostics! {
 E0454: r##"
-A link name was given with an empty name. Erroneous code example:
+An empty `link` name was provided. Erroneous code example:
 
 ```ignore (cannot-test-this-because-rustdoc-stops-compile-fail-before-codegen)
 #[link(name = "")] extern {} // error: #[link(name = "")] given with empty name
 ```
 
-The rust compiler cannot link to an external library if you don't give it its
+The Rust compiler cannot link to an external library if you don't give it its
 name. Example:
 
 ```no_run
@@ -17,7 +17,7 @@ name. Example:
 "##,
 
 E0455: r##"
-Linking with `kind=framework` is only supported when targeting macOS,
+Linking with `kind = "framework"` is only supported when targeting macOS,
 as frameworks are specific to that operating system.
 
 Erroneous code example:
@@ -39,31 +39,31 @@ https://doc.rust-lang.org/book/first-edition/conditional-compilation.html
 "##,
 
 E0458: r##"
-An unknown "kind" was specified for a link attribute. Erroneous code example:
+An unknown `kind` was specified for a `link` attribute. Erroneous code example:
 
 ```ignore (cannot-test-this-because-rustdoc-stops-compile-fail-before-codegen)
 #[link(kind = "wonderful_unicorn")] extern {}
 // error: unknown kind: `wonderful_unicorn`
 ```
 
-Please specify a valid "kind" value, from one of the following:
-
-* static
-* dylib
-* framework
+The follow values are valid `kind`s:
+* `"static"`
+* `"static-nobundle"`
+* `"dylib"`
+* `"framework"` (on macOS only)
 
 "##,
 
 E0459: r##"
-A link was used without a name parameter. Erroneous code example:
+`link` was specified without a name parameter. Erroneous code example:
 
 ```ignore (cannot-test-this-because-rustdoc-stops-compile-fail-before-codegen)
 #[link(kind = "dylib")] extern {}
 // error: #[link(...)] specified without `name = "foo"`
 ```
 
-Please add the name parameter to allow the rust compiler to find the library
-you want. Example:
+The Rust compiler cannot link to an external library if you don't give it its
+name. Example:
 
 ```no_run
 #[link(kind = "dylib", name = "some_lib")] extern {} // ok!

--- a/src/librustc_metadata/diagnostics.rs
+++ b/src/librustc_metadata/diagnostics.rs
@@ -97,5 +97,4 @@ register_diagnostics! {
     E0465, // multiple .. candidates for `..` found
     E0519, // local crate and dependency have same (crate-name, disambiguator)
     E0523, // two dependencies have same (crate-name, disambiguator) but different SVH
-    E0649, // `link` was used with repeated arguments
 }

--- a/src/librustc_metadata/native_libs.rs
+++ b/src/librustc_metadata/native_libs.rs
@@ -187,7 +187,7 @@ impl<'a, 'tcx> Collector<'a, 'tcx> {
                                            "link_cfg",
                                            span.unwrap(),
                                            GateIssue::Language,
-                                           "is feature gated");
+                                           "#[link(cfg(...))] is feature gated");
         }
         if lib.kind == cstore::NativeStaticNobundle &&
            !self.tcx.features().static_nobundle {
@@ -195,7 +195,7 @@ impl<'a, 'tcx> Collector<'a, 'tcx> {
                                            "static_nobundle",
                                            span.unwrap(),
                                            GateIssue::Language,
-                                           "kind=\"static-nobundle\" is feature gated");
+                                           "#[link(kind=\"static-nobundle\")] is feature gated");
         }
         self.libs.push(lib);
     }

--- a/src/librustc_metadata/native_libs.rs
+++ b/src/librustc_metadata/native_libs.rs
@@ -80,7 +80,7 @@ impl<'a, 'tcx> ItemLikeVisitor<'tcx> for Collector<'a, 'tcx> {
             for item in items.iter() {
                 let handle_duplicate_arg = |name, report| {
                     if report {
-                        struct_span_err!(self.tcx.sess, m.span, E0494,
+                        struct_span_err!(self.tcx.sess, m.span, E0649,
                             "#[link(...)] contains repeated `{}` arguments", name)
                         .span_label(item.span, format!("repeated `{}` argument", name))
                         .emit();

--- a/src/test/ui/bad/bad-extern-link-attrs.rs
+++ b/src/test/ui/bad/bad-extern-link-attrs.rs
@@ -2,6 +2,8 @@
 #[link(name = "")] //~ ERROR: with empty name
 #[link(name = "foo")]
 #[link(name = "foo", kind = "bar")] //~ ERROR: unknown kind
+#[link] //~ ERROR #[link(...)] specified without arguments
+#[link = "foo"] //~ ERROR #[link(...)] specified without arguments
 extern {}
 
 fn main() {}

--- a/src/test/ui/bad/bad-extern-link-attrs.rs
+++ b/src/test/ui/bad/bad-extern-link-attrs.rs
@@ -1,9 +1,18 @@
+#![feature(link_cfg)]
+
 #[link()] //~ ERROR: specified without `name =
 #[link(name = "")] //~ ERROR: with empty name
 #[link(name = "foo")]
 #[link(name = "foo", kind = "bar")] //~ ERROR: unknown kind
 #[link] //~ ERROR #[link(...)] specified without arguments
 #[link = "foo"] //~ ERROR #[link(...)] specified without arguments
+#[link(name = "foo", name = "bar")] //~ ERROR #[link(...)] contains repeated `name` arguments
+#[link(name = "foo", kind = "dylib", kind = "dylib")]
+//~^ ERROR #[link(...)] contains repeated `kind` arguments
+#[link(name = "foo", cfg(foo), cfg(bar))]
+//~^ ERROR #[link(...)] contains repeated `cfg` arguments
+#[link(wasm_import_module = "foo", wasm_import_module = "bar")]
+//~^ ERROR #[link(...)] contains repeated `wasm_import_module` arguments
 extern {}
 
 fn main() {}

--- a/src/test/ui/bad/bad-extern-link-attrs.rs
+++ b/src/test/ui/bad/bad-extern-link-attrs.rs
@@ -1,18 +1,26 @@
+#![deny(invalid_link_arguments)]
+
 #![feature(link_cfg)]
 
 #[link()] //~ ERROR: specified without `name =
 #[link(name = "")] //~ ERROR: with empty name
 #[link(name = "foo")]
 #[link(name = "foo", kind = "bar")] //~ ERROR: unknown kind
-#[link] //~ ERROR #[link(...)] specified without arguments
-#[link = "foo"] //~ ERROR #[link(...)] specified without arguments
-#[link(name = "foo", name = "bar")] //~ ERROR #[link(...)] contains repeated `name` arguments
+#[link] //~ ERROR #[link(...)] requires an argument list
+        //~^ this was previously accepted by the compiler
+#[link = "foo"] //~ ERROR #[link(...)] requires an argument list
+                //~^ this was previously accepted by the compiler
+#[link(name = "foo", name = "bar")] //~ ERROR #[link(...)] should not contain repeated arguments
+                                    //~^ this was previously accepted by the compiler
 #[link(name = "foo", kind = "dylib", kind = "dylib")]
-//~^ ERROR #[link(...)] contains repeated `kind` arguments
+//~^ ERROR #[link(...)] should not contain repeated arguments
+//~^^ this was previously accepted by the compiler
 #[link(name = "foo", cfg(foo), cfg(bar))]
-//~^ ERROR #[link(...)] contains repeated `cfg` arguments
+//~^ ERROR #[link(...)] should not contain repeated arguments
+//~^^ this was previously accepted by the compiler
 #[link(wasm_import_module = "foo", wasm_import_module = "bar")]
-//~^ ERROR #[link(...)] contains repeated `wasm_import_module` arguments
+//~^ ERROR #[link(...)] should not contain repeated arguments
+//~^^ this was previously accepted by the compiler
 extern {}
 
 fn main() {}

--- a/src/test/ui/bad/bad-extern-link-attrs.stderr
+++ b/src/test/ui/bad/bad-extern-link-attrs.stderr
@@ -30,7 +30,7 @@ error[E0459]: #[link(...)] specified without arguments
 LL | #[link = "foo"] //~ ERROR #[link(...)] specified without arguments
    | ^^^^^^^^^^^^^^^ help: specify a `name` argument instead: `#[link(name = "foo")]`
 
-error[E0494]: #[link(...)] contains repeated `name` arguments
+error[E0649]: #[link(...)] contains repeated `name` arguments
   --> $DIR/bad-extern-link-attrs.rs:9:1
    |
 LL | #[link(name = "foo", name = "bar")] //~ ERROR #[link(...)] contains repeated `name` arguments
@@ -38,7 +38,7 @@ LL | #[link(name = "foo", name = "bar")] //~ ERROR #[link(...)] contains repeate
    |                      |
    |                      repeated `name` argument
 
-error[E0494]: #[link(...)] contains repeated `kind` arguments
+error[E0649]: #[link(...)] contains repeated `kind` arguments
   --> $DIR/bad-extern-link-attrs.rs:10:1
    |
 LL | #[link(name = "foo", kind = "dylib", kind = "dylib")]
@@ -46,7 +46,7 @@ LL | #[link(name = "foo", kind = "dylib", kind = "dylib")]
    |                                      |
    |                                      repeated `kind` argument
 
-error[E0494]: #[link(...)] contains repeated `cfg` arguments
+error[E0649]: #[link(...)] contains repeated `cfg` arguments
   --> $DIR/bad-extern-link-attrs.rs:12:1
    |
 LL | #[link(name = "foo", cfg(foo), cfg(bar))]
@@ -54,7 +54,7 @@ LL | #[link(name = "foo", cfg(foo), cfg(bar))]
    |                                |
    |                                repeated `cfg` argument
 
-error[E0494]: #[link(...)] contains repeated `wasm_import_module` arguments
+error[E0649]: #[link(...)] contains repeated `wasm_import_module` arguments
   --> $DIR/bad-extern-link-attrs.rs:14:1
    |
 LL | #[link(wasm_import_module = "foo", wasm_import_module = "bar")]
@@ -64,5 +64,5 @@ LL | #[link(wasm_import_module = "foo", wasm_import_module = "bar")]
 
 error: aborting due to 9 previous errors
 
-Some errors occurred: E0454, E0458, E0459, E0494.
+Some errors occurred: E0454, E0458, E0459, E0649.
 For more information about an error, try `rustc --explain E0454`.

--- a/src/test/ui/bad/bad-extern-link-attrs.stderr
+++ b/src/test/ui/bad/bad-extern-link-attrs.stderr
@@ -18,7 +18,19 @@ LL | #[link(name = "foo", kind = "bar")] //~ ERROR: unknown kind
    |                      |
    |                      unknown kind
 
-error: aborting due to 3 previous errors
+error[E0459]: #[link(...)] specified without arguments
+  --> $DIR/bad-extern-link-attrs.rs:5:1
+   |
+LL | #[link] //~ ERROR #[link(...)] specified without arguments
+   | ^^^^^^^
+
+error[E0459]: #[link(...)] specified without arguments
+  --> $DIR/bad-extern-link-attrs.rs:6:1
+   |
+LL | #[link = "foo"] //~ ERROR #[link(...)] specified without arguments
+   | ^^^^^^^^^^^^^^^ help: specify a `name` argument instead: `#[link(name = "foo")]`
+
+error: aborting due to 5 previous errors
 
 Some errors occurred: E0454, E0458, E0459.
 For more information about an error, try `rustc --explain E0454`.

--- a/src/test/ui/bad/bad-extern-link-attrs.stderr
+++ b/src/test/ui/bad/bad-extern-link-attrs.stderr
@@ -1,17 +1,17 @@
 error[E0459]: #[link(...)] specified without `name = "foo"`
-  --> $DIR/bad-extern-link-attrs.rs:1:1
+  --> $DIR/bad-extern-link-attrs.rs:3:1
    |
 LL | #[link()] //~ ERROR: specified without `name =
    | ^^^^^^^^^ missing `name` argument
 
 error[E0454]: #[link(name = "")] given with empty name
-  --> $DIR/bad-extern-link-attrs.rs:2:1
+  --> $DIR/bad-extern-link-attrs.rs:4:1
    |
 LL | #[link(name = "")] //~ ERROR: with empty name
    | ^^^^^^^^^^^^^^^^^^ empty name given
 
 error[E0458]: unknown kind: `bar`
-  --> $DIR/bad-extern-link-attrs.rs:4:1
+  --> $DIR/bad-extern-link-attrs.rs:6:1
    |
 LL | #[link(name = "foo", kind = "bar")] //~ ERROR: unknown kind
    | ^^^^^^^^^^^^^^^^^^^^^------------^^
@@ -19,18 +19,50 @@ LL | #[link(name = "foo", kind = "bar")] //~ ERROR: unknown kind
    |                      unknown kind
 
 error[E0459]: #[link(...)] specified without arguments
-  --> $DIR/bad-extern-link-attrs.rs:5:1
+  --> $DIR/bad-extern-link-attrs.rs:7:1
    |
 LL | #[link] //~ ERROR #[link(...)] specified without arguments
    | ^^^^^^^
 
 error[E0459]: #[link(...)] specified without arguments
-  --> $DIR/bad-extern-link-attrs.rs:6:1
+  --> $DIR/bad-extern-link-attrs.rs:8:1
    |
 LL | #[link = "foo"] //~ ERROR #[link(...)] specified without arguments
    | ^^^^^^^^^^^^^^^ help: specify a `name` argument instead: `#[link(name = "foo")]`
 
-error: aborting due to 5 previous errors
+error[E0494]: #[link(...)] contains repeated `name` arguments
+  --> $DIR/bad-extern-link-attrs.rs:9:1
+   |
+LL | #[link(name = "foo", name = "bar")] //~ ERROR #[link(...)] contains repeated `name` arguments
+   | ^^^^^^^^^^^^^^^^^^^^^------------^^
+   |                      |
+   |                      repeated `name` argument
 
-Some errors occurred: E0454, E0458, E0459.
+error[E0494]: #[link(...)] contains repeated `kind` arguments
+  --> $DIR/bad-extern-link-attrs.rs:10:1
+   |
+LL | #[link(name = "foo", kind = "dylib", kind = "dylib")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^--------------^^
+   |                                      |
+   |                                      repeated `kind` argument
+
+error[E0494]: #[link(...)] contains repeated `cfg` arguments
+  --> $DIR/bad-extern-link-attrs.rs:12:1
+   |
+LL | #[link(name = "foo", cfg(foo), cfg(bar))]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^--------^^
+   |                                |
+   |                                repeated `cfg` argument
+
+error[E0494]: #[link(...)] contains repeated `wasm_import_module` arguments
+  --> $DIR/bad-extern-link-attrs.rs:14:1
+   |
+LL | #[link(wasm_import_module = "foo", wasm_import_module = "bar")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^--------------------------^^
+   |                                    |
+   |                                    repeated `wasm_import_module` argument
+
+error: aborting due to 9 previous errors
+
+Some errors occurred: E0454, E0458, E0459, E0494.
 For more information about an error, try `rustc --explain E0454`.

--- a/src/test/ui/bad/bad-extern-link-attrs.stderr
+++ b/src/test/ui/bad/bad-extern-link-attrs.stderr
@@ -1,68 +1,91 @@
 error[E0459]: #[link(...)] specified without `name = "foo"`
-  --> $DIR/bad-extern-link-attrs.rs:3:1
+  --> $DIR/bad-extern-link-attrs.rs:5:1
    |
 LL | #[link()] //~ ERROR: specified without `name =
    | ^^^^^^^^^ missing `name` argument
 
 error[E0454]: #[link(name = "")] given with empty name
-  --> $DIR/bad-extern-link-attrs.rs:4:1
+  --> $DIR/bad-extern-link-attrs.rs:6:1
    |
 LL | #[link(name = "")] //~ ERROR: with empty name
    | ^^^^^^^^^^^^^^^^^^ empty name given
 
 error[E0458]: unknown kind: `bar`
-  --> $DIR/bad-extern-link-attrs.rs:6:1
+  --> $DIR/bad-extern-link-attrs.rs:8:1
    |
 LL | #[link(name = "foo", kind = "bar")] //~ ERROR: unknown kind
    | ^^^^^^^^^^^^^^^^^^^^^------------^^
    |                      |
    |                      unknown kind
 
-error[E0459]: #[link(...)] specified without arguments
-  --> $DIR/bad-extern-link-attrs.rs:7:1
-   |
-LL | #[link] //~ ERROR #[link(...)] specified without arguments
-   | ^^^^^^^
-
-error[E0459]: #[link(...)] specified without arguments
-  --> $DIR/bad-extern-link-attrs.rs:8:1
-   |
-LL | #[link = "foo"] //~ ERROR #[link(...)] specified without arguments
-   | ^^^^^^^^^^^^^^^ help: specify a `name` argument instead: `#[link(name = "foo")]`
-
-error[E0649]: #[link(...)] contains repeated `name` arguments
+error: #[link(...)] requires an argument list
   --> $DIR/bad-extern-link-attrs.rs:9:1
    |
-LL | #[link(name = "foo", name = "bar")] //~ ERROR #[link(...)] contains repeated `name` arguments
+LL | #[link] //~ ERROR #[link(...)] requires an argument list
+   | ^^^^^^^
+   |
+note: lint level defined here
+  --> $DIR/bad-extern-link-attrs.rs:1:9
+   |
+LL | #![deny(invalid_link_arguments)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #53901 <https://github.com/rust-lang/rust/issues/53901>
+
+error: #[link(...)] requires an argument list
+  --> $DIR/bad-extern-link-attrs.rs:11:1
+   |
+LL | #[link = "foo"] //~ ERROR #[link(...)] requires an argument list
+   | ^^^^^^^^^^^^^^^ help: specify a `name` argument instead: `#[link(name = "foo")]`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #53901 <https://github.com/rust-lang/rust/issues/53901>
+
+error: #[link(...)] should not contain repeated arguments
+  --> $DIR/bad-extern-link-attrs.rs:13:1
+   |
+LL | #[link(name = "foo", name = "bar")] //~ ERROR #[link(...)] should not contain repeated arguments
    | ^^^^^^^^^^^^^^^^^^^^^------------^^
    |                      |
    |                      repeated `name` argument
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #53901 <https://github.com/rust-lang/rust/issues/53901>
 
-error[E0649]: #[link(...)] contains repeated `kind` arguments
-  --> $DIR/bad-extern-link-attrs.rs:10:1
+error: #[link(...)] should not contain repeated arguments
+  --> $DIR/bad-extern-link-attrs.rs:15:1
    |
 LL | #[link(name = "foo", kind = "dylib", kind = "dylib")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^--------------^^
    |                                      |
    |                                      repeated `kind` argument
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #53901 <https://github.com/rust-lang/rust/issues/53901>
 
-error[E0649]: #[link(...)] contains repeated `cfg` arguments
-  --> $DIR/bad-extern-link-attrs.rs:12:1
+error: #[link(...)] should not contain repeated arguments
+  --> $DIR/bad-extern-link-attrs.rs:18:1
    |
 LL | #[link(name = "foo", cfg(foo), cfg(bar))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^--------^^
    |                                |
    |                                repeated `cfg` argument
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #53901 <https://github.com/rust-lang/rust/issues/53901>
 
-error[E0649]: #[link(...)] contains repeated `wasm_import_module` arguments
-  --> $DIR/bad-extern-link-attrs.rs:14:1
+error: #[link(...)] should not contain repeated arguments
+  --> $DIR/bad-extern-link-attrs.rs:21:1
    |
 LL | #[link(wasm_import_module = "foo", wasm_import_module = "bar")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^--------------------------^^
    |                                    |
    |                                    repeated `wasm_import_module` argument
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #53901 <https://github.com/rust-lang/rust/issues/53901>
 
 error: aborting due to 9 previous errors
 
-Some errors occurred: E0454, E0458, E0459, E0649.
+Some errors occurred: E0454, E0458, E0459.
 For more information about an error, try `rustc --explain E0454`.

--- a/src/test/ui/feature-gates/feature-gate-link_cfg.stderr
+++ b/src/test/ui/feature-gates/feature-gate-link_cfg.stderr
@@ -1,4 +1,4 @@
-error[E0658]: is feature gated (see issue #37406)
+error[E0658]: #[link(cfg(...))] is feature gated (see issue #37406)
   --> $DIR/feature-gate-link_cfg.rs:1:1
    |
 LL | #[link(name = "foo", cfg(foo))]

--- a/src/test/ui/feature-gates/feature-gate-static-nobundle.rs
+++ b/src/test/ui/feature-gates/feature-gate-static-nobundle.rs
@@ -1,5 +1,5 @@
 #[link(name="foo", kind="static-nobundle")]
-//~^ ERROR: kind="static-nobundle" is feature gated
+//~^ ERROR: #[link(kind="static-nobundle")] is feature gated
 extern {}
 
 fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-static-nobundle.stderr
+++ b/src/test/ui/feature-gates/feature-gate-static-nobundle.stderr
@@ -1,4 +1,4 @@
-error[E0658]: kind="static-nobundle" is feature gated (see issue #37403)
+error[E0658]: #[link(kind="static-nobundle")] is feature gated (see issue #37403)
   --> $DIR/feature-gate-static-nobundle.rs:1:1
    |
 LL | #[link(name="foo", kind="static-nobundle")]


### PR DESCRIPTION
- Add a lint `invalid_link_arguments` for `#[link = "foo"]` (rather than `#[link(name = "foo")]`).
- Add a lint for duplicate arguments.
- Improve feature gate diagnostics for `#[link]`.
Fixes #53901.