### PR TITLE
resolve: Fix another ICE in import validation

### DIFF
--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -1014,11 +1014,11 @@ enum ModuleOrUniformRoot<'a> {
     CurrentScope,
 }
 
-impl<'a> PartialEq for ModuleOrUniformRoot<'a> {
-    fn eq(&self, other: &Self) -> bool {
-        match (*self, *other) {
+impl ModuleOrUniformRoot<'_> {
+    fn same_def(lhs: Self, rhs: Self) -> bool {
+        match (lhs, rhs) {
             (ModuleOrUniformRoot::Module(lhs),
-             ModuleOrUniformRoot::Module(rhs)) => ptr::eq(lhs, rhs),
+             ModuleOrUniformRoot::Module(rhs)) => lhs.def() == rhs.def(),
             (ModuleOrUniformRoot::CrateRootAndExternPrelude,
              ModuleOrUniformRoot::CrateRootAndExternPrelude) |
             (ModuleOrUniformRoot::ExternPrelude, ModuleOrUniformRoot::ExternPrelude) |

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -842,7 +842,7 @@ impl<'a, 'b:'a> ImportResolver<'a, 'b> {
             PathResult::Module(module) => {
                 // Consistency checks, analogous to `finalize_current_module_macro_resolutions`.
                 if let Some(initial_module) = directive.imported_module.get() {
-                    if module != initial_module && no_ambiguity {
+                    if !ModuleOrUniformRoot::same_def(module, initial_module) && no_ambiguity {
                         span_bug!(directive.span, "inconsistent resolution for an import");
                     }
                 } else {

--- a/src/test/ui/rust-2018/uniform-paths/auxiliary/issue-56596-2.rs
+++ b/src/test/ui/rust-2018/uniform-paths/auxiliary/issue-56596-2.rs
@@ -1,0 +1,1 @@
+pub extern crate core;

--- a/src/test/ui/rust-2018/uniform-paths/issue-56596-2.rs
+++ b/src/test/ui/rust-2018/uniform-paths/issue-56596-2.rs
@@ -1,0 +1,11 @@
+// compile-pass
+// edition:2018
+// compile-flags: --extern issue_56596_2
+// aux-build:issue-56596-2.rs
+
+mod m {
+    use core::any;
+    pub use issue_56596_2::*;
+}
+
+fn main() {}


### PR DESCRIPTION
Imports are allowed to have ambiguous resolutions as long as all of them have same `Def`.
As it turned out, it's possible for different `Module`s to have same `Def` when `extern crate` items are involved.

Fixes https://github.com/rust-lang/rust/issues/56596