### PR TITLE
Deny warnings in libcore and libstd

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1018,8 +1018,7 @@ impl<'a> Builder<'a> {
 
         cargo.env("RUSTC_VERBOSE", self.verbosity.to_string());
 
-        // in std, we want to avoid denying warnings for stage 0 as that makes cfg's painful.
-        if self.config.deny_warnings && !(mode == Mode::Std && stage == 0) {
+        if self.config.deny_warnings {
             cargo.env("RUSTC_DENY_WARNINGS", "1");
         }
 


### PR DESCRIPTION
This probably fixes https://github.com/rust-lang/rust/issues/57178 (though there may still be some crates that need warnings denied). At least after this change, rustc currently produces no warnings during compilation.

r? @oli-obk