### PR TITLE
Mention ToString in std::fmt docs

### DIFF
--- a/src/liballoc/fmt.rs
+++ b/src/liballoc/fmt.rs
@@ -27,6 +27,9 @@
 //! will then parse the format string and determine if the list of arguments
 //! provided is suitable to pass to this format string.
 //!
+//! To convert a single value to a string, use the [`to_string`] method.  This
+//! will use the [`Display`] formatting trait.
+//!
 //! ## Positional parameters
 //!
 //! Each formatting argument is allowed to specify which value argument it's
@@ -487,6 +490,7 @@
 //! [`write!`]: ../../std/macro.write.html
 //! [`Debug`]: trait.Debug.html
 //! [`format!`]: ../../std/macro.format.html
+//! [`to_string`]: ../../std/string/trait.ToString.html
 //! [`writeln!`]: ../../std/macro.writeln.html
 //! [`write_fmt`]: ../../std/io/trait.Write.html#method.write_fmt
 //! [`std::io::Write`]: ../../std/io/trait.Write.html

--- a/src/liballoc/macros.rs
+++ b/src/liballoc/macros.rs
@@ -73,9 +73,14 @@ macro_rules! vec {
 /// The same convention is used with [`print!`] and [`write!`] macros,
 /// depending on the intended destination of the string.
 ///
+/// To convert a single value to a string, use the [`to_string`] method.  This
+/// will use the [`Display`] formatting trait.
+///
 /// [fmt]: ../std/fmt/index.html
 /// [`print!`]: ../std/macro.print.html
 /// [`write!`]: ../std/macro.write.html
+/// [`to_string`]: ../std/string/trait.ToString.html
+/// [`Display`]: ../std/fmt/trait.Display.html
 ///
 /// # Panics
 ///


### PR DESCRIPTION
I believe this should be added because `x.to_string()` is preferred over `format!("{}", x)` as the recommended way to convert a value to a string.  `std::fmt` and the `format` macro is where people look for documentation about this, and thus we should include references to this preferred functions there.

Resolves #55065