### PR TITLE
Include bounds from promoted constants in NLL

### DIFF
--- a/src/librustc_mir/borrow_check/nll/region_infer/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/mod.rs
@@ -1357,7 +1357,6 @@ pub trait ClosureRegionRequirementsExt<'gcx, 'tcx> {
     fn apply_requirements(
         &self,
         tcx: TyCtxt<'_, 'gcx, 'tcx>,
-        location: Location,
         closure_def_id: DefId,
         closure_substs: SubstsRef<'tcx>,
     ) -> Vec<QueryRegionConstraint<'tcx>>;
@@ -1388,13 +1387,12 @@ impl<'gcx, 'tcx> ClosureRegionRequirementsExt<'gcx, 'tcx> for ClosureRegionRequi
     fn apply_requirements(
         &self,
         tcx: TyCtxt<'_, 'gcx, 'tcx>,
-        location: Location,
         closure_def_id: DefId,
         closure_substs: SubstsRef<'tcx>,
     ) -> Vec<QueryRegionConstraint<'tcx>> {
         debug!(
-            "apply_requirements(location={:?}, closure_def_id={:?}, closure_substs={:?})",
-            location, closure_def_id, closure_substs
+            "apply_requirements(closure_def_id={:?}, closure_substs={:?})",
+            closure_def_id, closure_substs
         );
 
         // Extract the values of the free regions in `closure_substs`

--- a/src/librustc_mir/borrow_check/nll/region_infer/values.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/values.rs
@@ -154,10 +154,10 @@ impl<N: Idx> LivenessValues<N> {
     /// Creates a new set of "region values" that tracks causal information.
     /// Each of the regions in num_region_variables will be initialized with an
     /// empty set of points and no causal information.
-    crate fn new(elements: &Rc<RegionValueElements>) -> Self {
+    crate fn new(elements: Rc<RegionValueElements>) -> Self {
         Self {
-            elements: elements.clone(),
             points: SparseBitMatrix::new(elements.num_points),
+            elements: elements,
         }
     }
 

--- a/src/librustc_mir/borrow_check/nll/renumber.rs
+++ b/src/librustc_mir/borrow_check/nll/renumber.rs
@@ -47,6 +47,14 @@ impl<'a, 'gcx, 'tcx> NLLVisitor<'a, 'gcx, 'tcx> {
 }
 
 impl<'a, 'gcx, 'tcx> MutVisitor<'tcx> for NLLVisitor<'a, 'gcx, 'tcx> {
+    fn visit_mir(&mut self, mir: &mut Mir<'tcx>) {
+        for promoted in mir.promoted.iter_mut() {
+            self.visit_mir(promoted);
+        }
+
+        self.super_mir(mir);
+    }
+
     fn visit_ty(&mut self, ty: &mut Ty<'tcx>, ty_context: TyContext) {
         debug!("visit_ty(ty={:?}, ty_context={:?})", ty, ty_context);
 

--- a/src/test/ui/nll/issue-48697.rs
+++ b/src/test/ui/nll/issue-48697.rs
@@ -1,14 +1,12 @@
 // Regression test for #48697
 
-// compile-pass
-
 #![feature(nll)]
 
 fn foo(x: &i32) -> &i32 {
     let z = 4;
     let f = &|y| y;
     let k = f(&z);
-    f(x)
+    f(x) //~ cannot return value referencing local variable
 }
 
 fn main() {}

--- a/src/test/ui/nll/issue-48697.stderr
+++ b/src/test/ui/nll/issue-48697.stderr
@@ -1,0 +1,11 @@
+error[E0515]: cannot return value referencing local variable `z`
+  --> $DIR/issue-48697.rs:9:5
+   |
+LL |     let k = f(&z);
+   |               -- `z` is borrowed here
+LL |     f(x) //~ cannot return value referencing local variable
+   |     ^^^^ returns a value referencing data owned by the current function
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0515`.

--- a/src/test/ui/nll/promoted-bounds.rs
+++ b/src/test/ui/nll/promoted-bounds.rs
@@ -1,0 +1,27 @@
+#![feature(nll)]
+
+fn shorten_lifetime<'a, 'b, 'min>(a: &'a i32, b: &'b i32) -> &'min i32
+where
+    'a: 'min,
+    'b: 'min,
+{
+    if *a < *b {
+        &a
+    } else {
+        &b
+    }
+}
+
+fn main() {
+    let promoted_fn_item_ref = &shorten_lifetime;
+
+    let a = &5;
+    let ptr = {
+        let l = 3;
+        let b = &l; //~ ERROR does not live long enough
+        let c = promoted_fn_item_ref(a, b);
+        c
+    };
+
+    println!("ptr = {:?}", ptr);
+}

--- a/src/test/ui/nll/promoted-bounds.stderr
+++ b/src/test/ui/nll/promoted-bounds.stderr
@@ -1,0 +1,15 @@
+error[E0597]: `l` does not live long enough
+  --> $DIR/promoted-bounds.rs:21:17
+   |
+LL |     let ptr = {
+   |         --- borrow later stored here
+LL |         let l = 3;
+LL |         let b = &l; //~ ERROR does not live long enough
+   |                 ^^ borrowed value does not live long enough
+...
+LL |     };
+   |     - `l` dropped here while still borrowed
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/nll/promoted-closure-pair.rs
+++ b/src/test/ui/nll/promoted-closure-pair.rs
@@ -1,0 +1,12 @@
+// Check that we handle multiple closures in the same promoted constant.
+
+#![feature(nll)]
+
+fn foo() -> &'static i32 {
+    let z = 0;
+    let p = &(|y| y, |y| y);
+    p.0(&z);
+    p.1(&z)         //~ ERROR cannot return
+}
+
+fn main() {}

--- a/src/test/ui/nll/promoted-closure-pair.stderr
+++ b/src/test/ui/nll/promoted-closure-pair.stderr
@@ -1,0 +1,12 @@
+error[E0515]: cannot return value referencing local variable `z`
+  --> $DIR/promoted-closure-pair.rs:9:5
+   |
+LL |     p.1(&z)         //~ ERROR cannot return
+   |     ^^^^--^
+   |     |   |
+   |     |   `z` is borrowed here
+   |     returns a value referencing data owned by the current function
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0515`.

--- a/src/test/ui/nll/user-annotations/promoted-annotation.rs
+++ b/src/test/ui/nll/user-annotations/promoted-annotation.rs
@@ -1,0 +1,12 @@
+// Test that type annotations are checked in promoted constants correctly.
+
+#![feature(nll)]
+
+fn foo<'a>() {
+    let x = 0;
+    let f = &drop::<&'a i32>;
+    f(&x);
+    //~^ ERROR `x` does not live long enough
+}
+
+fn main() {}

--- a/src/test/ui/nll/user-annotations/promoted-annotation.stderr
+++ b/src/test/ui/nll/user-annotations/promoted-annotation.stderr
@@ -1,0 +1,17 @@
+error[E0597]: `x` does not live long enough
+  --> $DIR/promoted-annotation.rs:8:7
+   |
+LL | fn foo<'a>() {
+   |        -- lifetime `'a` defined here
+LL |     let x = 0;
+LL |     let f = &drop::<&'a i32>;
+   |             ---------------- assignment requires that `x` is borrowed for `'a`
+LL |     f(&x);
+   |       ^^ borrowed value does not live long enough
+LL |     //~^ ERROR `x` does not live long enough
+LL | }
+   | - `x` dropped here while still borrowed
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0597`.


### PR DESCRIPTION
Previously a promoted function wouldn't have its bound propagated out to
the main function body.

When we visit a promoted, we now type check the MIR of the promoted
and transfer any lifetime constraints to back to the main function's MIR.

Fixes #57170 

r? @nikomatsakis 