### PR TITLE
Remove mention of required memory to build

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,17 +186,14 @@ fetch snapshots, and an OS that can execute the available snapshot binaries.
 
 Snapshot binaries are currently built and tested on several platforms:
 
-| Platform / Architecture        | x86 | x86_64 |
-|--------------------------------|-----|--------|
-| Windows (7, 8, Server 2008 R2) | ✓   | ✓      |
-| Linux (2.6.18 or later)        | ✓   | ✓      |
-| OSX (10.7 Lion or later)       | ✓   | ✓      |
+| Platform / Architecture  | x86 | x86_64 |
+|--------------------------|-----|--------|
+| Windows (7, 8, 10, ...)  | ✓   | ✓      |
+| Linux (2.6.18 or later)  | ✓   | ✓      |
+| OSX (10.7 Lion or later) | ✓   | ✓      |
 
 You may find that other platforms work, but these are our officially
 supported build environments that are most likely to work.
-
-Rust currently needs between 600MiB and 1.5GiB of RAM to build, depending on platform.
-If it hits swap, it will take a very long time to build.
 
 There is more advice about hacking on Rust in [CONTRIBUTING.md].
 


### PR DESCRIPTION
Because it, obviously, changes all the time and 600MiB is way out-of-date now.