### PR TITLE
Make std::cmp::Ord documentation specify what it means to agree with ParitalEq

### DIFF
--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -474,8 +474,9 @@ impl<T: Ord> Ord for Reverse<T> {
 ///
 /// Implementations of `PartialEq`, `PartialOrd`, and `Ord` *must*
 /// agree with each other. That is, `a.cmp(b) == Ordering::Equal` if
-/// and only if `a == b`. It's easy to accidentally make them disagree
-/// by deriving some of the traits and manually implementing others.
+/// and only if `a == b` and `Some(a.cmp(b)) == a.partial_cmp(b)` for
+/// all `a` and `b`. It's easy to accidentally make them disagree by
+/// deriving some of the traits and manually implementing others.
 ///
 /// Here's an example where you want to sort people by height only, disregarding `id`
 /// and `name`:

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -472,9 +472,10 @@ impl<T: Ord> Ord for Reverse<T> {
 /// Then you must define an implementation for `cmp()`. You may find it useful to use
 /// `cmp()` on your type's fields.
 ///
-/// Implementations of `PartialEq`, `PartialOrd`, and `Ord` *must* agree with each other. It's
-/// easy to accidentally make them disagree by deriving some of the traits and manually
-/// implementing others.
+/// Implementations of `PartialEq`, `PartialOrd`, and `Ord` *must*
+/// agree with each other. That is, `a.cmp(b) == Ordering::Equal` if
+/// and only if `a == b`. It's easy to accidentally make them disagree
+/// by deriving some of the traits and manually implementing others.
 ///
 /// Here's an example where you want to sort people by height only, disregarding `id`
 /// and `name`:


### PR DESCRIPTION
Resolves #57157 