### PR TITLE
docs(rustc): Link to the book's source in rustc

### DIFF
--- a/src/doc/rustc/src/contributing.md
+++ b/src/doc/rustc/src/contributing.md
@@ -1,6 +1,12 @@
 # Contributing to rustc
 
 We'd love to have your help improving `rustc`! To that end, we've written [a
-whole book](https://rust-lang.github.io/rustc-guide/) on its
+whole book][rustc_guide] on its
 internals, how it works, and how to get started working on it. To learn
 more, you'll want to check that out.
+
+If you would like to contribute to _this_ book, you can find its source in the
+rustc source at [src/doc/rustc][rustc_book].
+
+[rustc_guide]: https://rust-lang.github.io/rustc-guide/
+[rustc_book]: https://github.com/rust-lang/rust/tree/master/src/doc/rustc


### PR DESCRIPTION
This makes the source of [the rustc book](https://doc.rust-lang.org/rustc/what-is-rustc.html) book a bit more discoverable.