### PR TITLE
Const-stabilize `const_int_ops` + `const_ip`

### DIFF
--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -1343,7 +1343,7 @@ extern "rust-intrinsic" {
     /// use std::intrinsics::ctlz;
     ///
     /// let x = 0b0001_1100_u8;
-    /// let num_leading = unsafe { ctlz(x) };
+    /// let num_leading = ctlz(x);
     /// assert_eq!(num_leading, 3);
     /// ```
     ///
@@ -1355,7 +1355,7 @@ extern "rust-intrinsic" {
     /// use std::intrinsics::ctlz;
     ///
     /// let x = 0u16;
-    /// let num_leading = unsafe { ctlz(x) };
+    /// let num_leading = ctlz(x);
     /// assert_eq!(num_leading, 16);
     /// ```
     pub fn ctlz<T>(x: T) -> T;
@@ -1386,7 +1386,7 @@ extern "rust-intrinsic" {
     /// use std::intrinsics::cttz;
     ///
     /// let x = 0b0011_1000_u8;
-    /// let num_trailing = unsafe { cttz(x) };
+    /// let num_trailing = cttz(x);
     /// assert_eq!(num_trailing, 3);
     /// ```
     ///
@@ -1398,7 +1398,7 @@ extern "rust-intrinsic" {
     /// use std::intrinsics::cttz;
     ///
     /// let x = 0u16;
-    /// let num_trailing = unsafe { cttz(x) };
+    /// let num_trailing = cttz(x);
     /// assert_eq!(num_trailing, 16);
     /// ```
     pub fn cttz<T>(x: T) -> T;

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -114,7 +114,6 @@
 #![feature(const_str_as_bytes)]
 #![feature(const_str_len)]
 #![feature(const_int_rotate)]
-#![feature(const_int_wrapping)]
 #![feature(const_int_sign)]
 #![feature(const_int_conversion)]
 #![feature(const_transmute)]

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -71,7 +71,7 @@
 #![feature(cfg_target_has_atomic)]
 #![feature(concat_idents)]
 #![feature(const_fn)]
-#![feature(const_int_ops)]
+#![cfg_attr(stage0, feature(const_int_ops))]
 #![feature(const_fn_union)]
 #![feature(custom_attribute)]
 #![feature(doc_cfg)]

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -114,7 +114,6 @@
 #![feature(const_str_as_bytes)]
 #![feature(const_str_len)]
 #![cfg_attr(stage0, feature(const_int_rotate))]
-#![feature(const_int_sign)]
 #![feature(const_int_conversion)]
 #![feature(const_transmute)]
 #![feature(reverse_bits)]

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -113,7 +113,7 @@
 #![feature(const_slice_len)]
 #![feature(const_str_as_bytes)]
 #![feature(const_str_len)]
-#![feature(const_int_rotate)]
+#![cfg_attr(stage0, feature(const_int_rotate))]
 #![feature(const_int_sign)]
 #![feature(const_int_conversion)]
 #![feature(const_transmute)]

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -994,7 +994,7 @@ assert_eq!(", stringify!($SelfT), "::max_value().wrapping_add(2), ", stringify!(
 $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_int_wrapping")]
+            #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_wrapping"))]
             #[inline]
             pub const fn wrapping_add(self, rhs: Self) -> Self {
                 unsafe {
@@ -1018,7 +1018,7 @@ stringify!($SelfT), "::max_value());",
 $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_int_wrapping")]
+            #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_wrapping"))]
             #[inline]
             pub const fn wrapping_sub(self, rhs: Self) -> Self {
                 unsafe {
@@ -1041,7 +1041,7 @@ assert_eq!(11i8.wrapping_mul(12), -124);",
 $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_int_wrapping")]
+            #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_wrapping"))]
             #[inline]
             pub const fn wrapping_mul(self, rhs: Self) -> Self {
                 unsafe {
@@ -1205,7 +1205,7 @@ assert_eq!((-1", stringify!($SelfT), ").wrapping_shl(128), -1);",
 $EndFeature, "
 ```"),
             #[stable(feature = "num_wrapping", since = "1.2.0")]
-            #[rustc_const_unstable(feature = "const_int_wrapping")]
+            #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_wrapping"))]
             #[inline]
             pub const fn wrapping_shl(self, rhs: u32) -> Self {
                 unsafe {
@@ -1233,7 +1233,7 @@ assert_eq!((-128i16).wrapping_shr(64), -128);",
 $EndFeature, "
 ```"),
             #[stable(feature = "num_wrapping", since = "1.2.0")]
-            #[rustc_const_unstable(feature = "const_int_wrapping")]
+            #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_wrapping"))]
             #[inline]
             pub const fn wrapping_shr(self, rhs: u32) -> Self {
                 unsafe {
@@ -2884,7 +2884,7 @@ assert_eq!(200", stringify!($SelfT), ".wrapping_add(", stringify!($SelfT), "::ma
 $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_int_wrapping")]
+            #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_wrapping"))]
             #[inline]
             pub const fn wrapping_add(self, rhs: Self) -> Self {
                 unsafe {
@@ -2907,7 +2907,7 @@ assert_eq!(100", stringify!($SelfT), ".wrapping_sub(", stringify!($SelfT), "::ma
 $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_int_wrapping")]
+            #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_wrapping"))]
             #[inline]
             pub const fn wrapping_sub(self, rhs: Self) -> Self {
                 unsafe {
@@ -2931,7 +2931,7 @@ $EndFeature, "
         /// assert_eq!(25u8.wrapping_mul(12), 44);
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
-        #[rustc_const_unstable(feature = "const_int_wrapping")]
+        #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_wrapping"))]
         #[inline]
         pub const fn wrapping_mul(self, rhs: Self) -> Self {
             unsafe {
@@ -3081,7 +3081,7 @@ Basic usage:
 assert_eq!(1", stringify!($SelfT), ".wrapping_shl(128), 1);", $EndFeature, "
 ```"),
             #[stable(feature = "num_wrapping", since = "1.2.0")]
-            #[rustc_const_unstable(feature = "const_int_wrapping")]
+            #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_wrapping"))]
             #[inline]
             pub const fn wrapping_shl(self, rhs: u32) -> Self {
                 unsafe {
@@ -3111,7 +3111,7 @@ Basic usage:
 assert_eq!(128", stringify!($SelfT), ".wrapping_shr(128), 128);", $EndFeature, "
 ```"),
             #[stable(feature = "num_wrapping", since = "1.2.0")]
-            #[rustc_const_unstable(feature = "const_int_wrapping")]
+            #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_wrapping"))]
             #[inline]
             pub const fn wrapping_shr(self, rhs: u32) -> Self {
                 unsafe {

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -1886,7 +1886,6 @@ assert!(!(-10", stringify!($SelfT), ").is_positive());",
 $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_int_sign")]
             #[inline]
             pub const fn is_positive(self) -> bool { self > 0 }
         }
@@ -1905,7 +1904,6 @@ assert!(!10", stringify!($SelfT), ".is_negative());",
 $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_int_sign")]
             #[inline]
             pub const fn is_negative(self) -> bool { self < 0 }
         }

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -275,7 +275,7 @@ $EndFeature, "
 ```
 "),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_int_ops")]
+            #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_ops"))]
             #[inline]
             pub const fn count_ones(self) -> u32 { (self as $UnsignedT).count_ones() }
         }
@@ -291,7 +291,7 @@ Basic usage:
 ", $Feature, "assert_eq!(", stringify!($SelfT), "::max_value().count_zeros(), 1);", $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_int_ops")]
+            #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_ops"))]
             #[inline]
             pub const fn count_zeros(self) -> u32 {
                 (!self).count_ones()
@@ -312,7 +312,7 @@ assert_eq!(n.leading_zeros(), 0);",
 $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_int_ops")]
+            #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_ops"))]
             #[inline]
             pub const fn leading_zeros(self) -> u32 {
                 (self as $UnsignedT).leading_zeros()
@@ -333,7 +333,7 @@ assert_eq!(n.trailing_zeros(), 2);",
 $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_int_ops")]
+            #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_ops"))]
             #[inline]
             pub const fn trailing_zeros(self) -> u32 {
                 (self as $UnsignedT).trailing_zeros()
@@ -404,7 +404,7 @@ let m = n.swap_bytes();
 assert_eq!(m, ", $swapped, ");
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_int_ops")]
+            #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_ops"))]
             #[inline]
             pub const fn swap_bytes(self) -> Self {
                 (self as $UnsignedT).swap_bytes() as Self
@@ -454,7 +454,7 @@ if cfg!(target_endian = \"big\") {
 $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_int_ops")]
+            #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_ops"))]
             #[inline]
             pub const fn from_be(x: Self) -> Self {
                 #[cfg(target_endian = "big")]
@@ -488,7 +488,7 @@ if cfg!(target_endian = \"little\") {
 $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_int_ops")]
+            #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_ops"))]
             #[inline]
             pub const fn from_le(x: Self) -> Self {
                 #[cfg(target_endian = "little")]
@@ -522,7 +522,7 @@ if cfg!(target_endian = \"big\") {
 $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_int_ops")]
+            #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_ops"))]
             #[inline]
             pub const fn to_be(self) -> Self { // or not to be?
                 #[cfg(target_endian = "big")]
@@ -556,7 +556,7 @@ if cfg!(target_endian = \"little\") {
 $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_int_ops")]
+            #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_ops"))]
             #[inline]
             pub const fn to_le(self) -> Self {
                 #[cfg(target_endian = "little")]
@@ -2234,10 +2234,13 @@ Basic usage:
 assert_eq!(n.count_ones(), 3);", $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_int_ops")]
+            #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_ops"))]
             #[inline]
             pub const fn count_ones(self) -> u32 {
+                #[cfg(stage0)]
                 unsafe { intrinsics::ctpop(self as $ActualT) as u32 }
+                #[cfg(not(stage0))]
+                { intrinsics::ctpop(self as $ActualT) as u32 }
             }
         }
 
@@ -2252,7 +2255,7 @@ Basic usage:
 ", $Feature, "assert_eq!(", stringify!($SelfT), "::max_value().count_zeros(), 0);", $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_int_ops")]
+            #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_ops"))]
             #[inline]
             pub const fn count_zeros(self) -> u32 {
                 (!self).count_ones()
@@ -2272,10 +2275,13 @@ Basic usage:
 assert_eq!(n.leading_zeros(), 2);", $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_int_ops")]
+            #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_ops"))]
             #[inline]
             pub const fn leading_zeros(self) -> u32 {
+                #[cfg(stage0)]
                 unsafe { intrinsics::ctlz(self as $ActualT) as u32 }
+                #[cfg(not(stage0))]
+                { intrinsics::ctlz(self as $ActualT) as u32 }
             }
         }
 
@@ -2293,10 +2299,13 @@ Basic usage:
 assert_eq!(n.trailing_zeros(), 3);", $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_int_ops")]
+            #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_ops"))]
             #[inline]
             pub const fn trailing_zeros(self) -> u32 {
+                #[cfg(stage0)]
                 unsafe { intrinsics::cttz(self) as u32 }
+                #[cfg(not(stage0))]
+                { intrinsics::cttz(self) as u32 }
             }
         }
 
@@ -2370,10 +2379,13 @@ let m = n.swap_bytes();
 assert_eq!(m, ", $swapped, ");
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_int_ops")]
+            #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_ops"))]
             #[inline]
             pub const fn swap_bytes(self) -> Self {
+                #[cfg(stage0)]
                 unsafe { intrinsics::bswap(self as $ActualT) as Self }
+                #[cfg(not(stage0))]
+                { intrinsics::bswap(self as $ActualT) as Self }
             }
         }
 
@@ -2393,10 +2405,13 @@ let m = n.reverse_bits();
 assert_eq!(m, ", $reversed, ");
 ```"),
             #[unstable(feature = "reverse_bits", issue = "48763")]
-            #[rustc_const_unstable(feature = "const_int_conversion")]
+            #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_conversion"))]
             #[inline]
             pub const fn reverse_bits(self) -> Self {
+                #[cfg(stage0)]
                 unsafe { intrinsics::bitreverse(self as $ActualT) as Self }
+                #[cfg(not(stage0))]
+                { intrinsics::bitreverse(self as $ActualT) as Self }
             }
         }
 
@@ -2420,7 +2435,7 @@ if cfg!(target_endian = \"big\") {
 }", $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_int_ops")]
+            #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_ops"))]
             #[inline]
             pub const fn from_be(x: Self) -> Self {
                 #[cfg(target_endian = "big")]
@@ -2454,7 +2469,7 @@ if cfg!(target_endian = \"little\") {
 }", $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_int_ops")]
+            #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_ops"))]
             #[inline]
             pub const fn from_le(x: Self) -> Self {
                 #[cfg(target_endian = "little")]
@@ -2488,7 +2503,7 @@ if cfg!(target_endian = \"big\") {
 }", $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_int_ops")]
+            #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_ops"))]
             #[inline]
             pub const fn to_be(self) -> Self { // or not to be?
                 #[cfg(target_endian = "big")]
@@ -2522,7 +2537,7 @@ if cfg!(target_endian = \"little\") {
 }", $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_int_ops")]
+            #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_ops"))]
             #[inline]
             pub const fn to_le(self) -> Self {
                 #[cfg(target_endian = "little")]
@@ -2957,8 +2972,8 @@ $EndFeature, "
             unsafe {
                 intrinsics::overflowing_mul(self, rhs)
             }
-                #[cfg(not(stage0))]
-                intrinsics::overflowing_mul(self, rhs)
+            #[cfg(not(stage0))]
+            intrinsics::overflowing_mul(self, rhs)
         }
 
         doc_comment! {

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -997,9 +997,12 @@ $EndFeature, "
             #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_wrapping"))]
             #[inline]
             pub const fn wrapping_add(self, rhs: Self) -> Self {
+                #[cfg(stage0)]
                 unsafe {
                     intrinsics::overflowing_add(self, rhs)
                 }
+                #[cfg(not(stage0))]
+                intrinsics::overflowing_add(self, rhs)
             }
         }
 
@@ -1021,9 +1024,12 @@ $EndFeature, "
             #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_wrapping"))]
             #[inline]
             pub const fn wrapping_sub(self, rhs: Self) -> Self {
+                #[cfg(stage0)]
                 unsafe {
                     intrinsics::overflowing_sub(self, rhs)
                 }
+                #[cfg(not(stage0))]
+                intrinsics::overflowing_sub(self, rhs)
             }
         }
 
@@ -1044,9 +1050,12 @@ $EndFeature, "
             #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_wrapping"))]
             #[inline]
             pub const fn wrapping_mul(self, rhs: Self) -> Self {
+                #[cfg(stage0)]
                 unsafe {
                     intrinsics::overflowing_mul(self, rhs)
                 }
+                #[cfg(not(stage0))]
+                intrinsics::overflowing_mul(self, rhs)
             }
         }
 
@@ -2311,7 +2320,10 @@ assert_eq!(n.rotate_left(", $rot, "), m);
             #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_rotate"))]
             #[inline]
             pub const fn rotate_left(self, n: u32) -> Self {
+                #[cfg(stage0)]
                 unsafe { intrinsics::rotate_left(self, n as $SelfT) }
+                #[cfg(not(stage0))]
+                intrinsics::rotate_left(self, n as $SelfT)
             }
         }
 
@@ -2336,7 +2348,10 @@ assert_eq!(n.rotate_right(", $rot, "), m);
             #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_rotate"))]
             #[inline]
             pub const fn rotate_right(self, n: u32) -> Self {
+                #[cfg(stage0)]
                 unsafe { intrinsics::rotate_right(self, n as $SelfT) }
+                #[cfg(not(stage0))]
+                intrinsics::rotate_right(self, n as $SelfT)
             }
         }
 
@@ -2885,9 +2900,12 @@ $EndFeature, "
             #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_wrapping"))]
             #[inline]
             pub const fn wrapping_add(self, rhs: Self) -> Self {
+                #[cfg(stage0)]
                 unsafe {
                     intrinsics::overflowing_add(self, rhs)
                 }
+                #[cfg(not(stage0))]
+                intrinsics::overflowing_add(self, rhs)
             }
         }
 
@@ -2908,9 +2926,12 @@ $EndFeature, "
             #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_wrapping"))]
             #[inline]
             pub const fn wrapping_sub(self, rhs: Self) -> Self {
+                #[cfg(stage0)]
                 unsafe {
                     intrinsics::overflowing_sub(self, rhs)
                 }
+                #[cfg(not(stage0))]
+                intrinsics::overflowing_sub(self, rhs)
             }
         }
 
@@ -2932,9 +2953,12 @@ $EndFeature, "
         #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_wrapping"))]
         #[inline]
         pub const fn wrapping_mul(self, rhs: Self) -> Self {
+            #[cfg(stage0)]
             unsafe {
                 intrinsics::overflowing_mul(self, rhs)
             }
+                #[cfg(not(stage0))]
+                intrinsics::overflowing_mul(self, rhs)
         }
 
         doc_comment! {

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -357,7 +357,7 @@ let m = ", $rot_result, ";
 assert_eq!(n.rotate_left(", $rot, "), m);
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_int_rotate")]
+            #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_rotate"))]
             #[inline]
             pub const fn rotate_left(self, n: u32) -> Self {
                 (self as $UnsignedT).rotate_left(n) as Self
@@ -382,7 +382,7 @@ let m = ", $rot_op, ";
 assert_eq!(n.rotate_right(", $rot, "), m);
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_int_rotate")]
+            #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_rotate"))]
             #[inline]
             pub const fn rotate_right(self, n: u32) -> Self {
                 (self as $UnsignedT).rotate_right(n) as Self
@@ -2310,7 +2310,7 @@ let m = ", $rot_result, ";
 assert_eq!(n.rotate_left(", $rot, "), m);
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_int_rotate")]
+            #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_rotate"))]
             #[inline]
             pub const fn rotate_left(self, n: u32) -> Self {
                 unsafe { intrinsics::rotate_left(self, n as $SelfT) }
@@ -2335,7 +2335,7 @@ let m = ", $rot_op, ";
 assert_eq!(n.rotate_right(", $rot, "), m);
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_int_rotate")]
+            #[cfg_attr(stage0, rustc_const_unstable(feature = "const_int_rotate"))]
             #[inline]
             pub const fn rotate_right(self, n: u32) -> Self {
                 unsafe { intrinsics::rotate_right(self, n as $SelfT) }

--- a/src/librustc_mir/transform/qualify_min_const_fn.rs
+++ b/src/librustc_mir/transform/qualify_min_const_fn.rs
@@ -387,7 +387,8 @@ fn check_terminator(
     }
 }
 
-/// Returns true if the `def_id` refers to an intrisic which we've whitelisted.
+/// Returns true if the `def_id` refers to an intrisic which we've whitelisted
+/// for being called from stable `const fn`s (`min_const_fn`).
 ///
 /// Adding more intrinsics requires sign-off from @rust-lang/lang.
 fn is_intrinsic_whitelisted(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) -> bool {

--- a/src/librustc_mir/transform/qualify_min_const_fn.rs
+++ b/src/librustc_mir/transform/qualify_min_const_fn.rs
@@ -342,15 +342,11 @@ fn check_terminator(
                 // some intrinsics are waved through if called inside the
                 // standard library. Users never need to call them directly
                 match tcx.fn_sig(def_id).abi() {
-                    abi::Abi::RustIntrinsic => match &tcx.item_name(def_id).as_str()[..] {
-                        | "size_of"
-                        | "min_align_of"
-                        | "needs_drop"
-                        => {},
-                        _ => return Err((
+                    abi::Abi::RustIntrinsic => if !is_intrinsic_whitelisted(tcx, def_id) {
+                        return Err((
                             span,
                             "can only call a curated list of intrinsics in `min_const_fn`".into(),
-                        )),
+                        ))
                     },
                     abi::Abi::Rust if tcx.is_min_const_fn(def_id) => {},
                     abi::Abi::Rust => return Err((
@@ -388,5 +384,24 @@ fn check_terminator(
         TerminatorKind::FalseUnwind { .. } => {
             Err((span, "loops are not allowed in const fn".into()))
         },
+    }
+}
+
+/// Returns true if the `def_id` refers to an intrisic which we've whitelisted.
+///
+/// Adding more intrinsics requires sign-off from @rust-lang/lang.
+fn is_intrinsic_whitelisted(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) -> bool {
+    match &tcx.item_name(def_id).as_str()[..] {
+        | "size_of"
+        | "min_align_of"
+        | "needs_drop"
+        // Arithmetic:
+        | "overflowing_add" // ~> wrapping_add
+        | "overflowing_sub" // ~> wrapping_sub
+        | "overflowing_mul" // ~> wrapping_mul
+        | "unchecked_shl" // ~> wrapping_shl
+        | "unchecked_shr" // ~> wrapping_shr
+        => true,
+        _ => false,
     }
 }

--- a/src/librustc_mir/transform/qualify_min_const_fn.rs
+++ b/src/librustc_mir/transform/qualify_min_const_fn.rs
@@ -396,11 +396,13 @@ fn is_intrinsic_whitelisted(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) -> bool 
         | "min_align_of"
         | "needs_drop"
         // Arithmetic:
-        | "overflowing_add" // ~> wrapping_add
-        | "overflowing_sub" // ~> wrapping_sub
-        | "overflowing_mul" // ~> wrapping_mul
-        | "unchecked_shl" // ~> wrapping_shl
-        | "unchecked_shr" // ~> wrapping_shr
+        | "overflowing_add" // ~> .wrapping_add
+        | "overflowing_sub" // ~> .wrapping_sub
+        | "overflowing_mul" // ~> .wrapping_mul
+        | "unchecked_shl" // ~> .wrapping_shl
+        | "unchecked_shr" // ~> .wrapping_shr
+        | "rotate_left" // ~> .rotate_left
+        | "rotate_right" // ~> .rotate_right
         => true,
         _ => false,
     }

--- a/src/librustc_mir/transform/qualify_min_const_fn.rs
+++ b/src/librustc_mir/transform/qualify_min_const_fn.rs
@@ -404,6 +404,11 @@ fn is_intrinsic_whitelisted(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) -> bool 
         | "unchecked_shr" // ~> .wrapping_shr
         | "rotate_left" // ~> .rotate_left
         | "rotate_right" // ~> .rotate_right
+        | "ctpop" // ~> .count_ones
+        | "ctlz" // ~> .leading_zeros
+        | "cttz" // ~> .trailing_zeros
+        | "bswap" // ~> .swap_bytes
+        | "bitreverse" // ~> .reverse_bits
         => true,
         _ => false,
     }

--- a/src/librustc_typeck/check/intrinsic.rs
+++ b/src/librustc_typeck/check/intrinsic.rs
@@ -71,7 +71,8 @@ pub fn intrisic_operation_unsafety(intrinsic: &str) -> hir::Unsafety {
     match intrinsic {
         "size_of" | "min_align_of" | "needs_drop" |
         "overflowing_add" | "overflowing_sub" | "overflowing_mul" |
-        "rotate_left" | "rotate_right"
+        "rotate_left" | "rotate_right" |
+        "ctpop" | "ctlz" | "cttz" | "bswap" | "bitreverse"
         => hir::Unsafety::Normal,
         _ => hir::Unsafety::Unsafe,
     }

--- a/src/librustc_typeck/check/intrinsic.rs
+++ b/src/librustc_typeck/check/intrinsic.rs
@@ -66,6 +66,17 @@ fn equate_intrinsic_type<'a, 'tcx>(
     require_same_types(tcx, &cause, tcx.mk_fn_ptr(tcx.fn_sig(def_id)), fty);
 }
 
+/// Returns whether the given intrinsic is unsafe to call or not.
+pub fn intrisic_operation_unsafety(intrinsic: &str) -> hir::Unsafety {
+    match intrinsic {
+        "size_of" | "min_align_of" | "needs_drop" |
+        "overflowing_add" | "overflowing_sub" | "overflowing_mul" |
+        "rotate_left" | "rotate_right"
+        => hir::Unsafety::Normal,
+        _ => hir::Unsafety::Unsafe,
+    }
+}
+
 /// Remember to add all intrinsics here, in librustc_codegen_llvm/intrinsic.rs,
 /// and in libcore/intrinsics.rs
 pub fn check_intrinsic_type<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
@@ -117,10 +128,7 @@ pub fn check_intrinsic_type<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     } else if &name[..] == "abort" || &name[..] == "unreachable" {
         (0, Vec::new(), tcx.types.never, hir::Unsafety::Unsafe)
     } else {
-        let unsafety = match &name[..] {
-            "size_of" | "min_align_of" | "needs_drop" => hir::Unsafety::Normal,
-            _ => hir::Unsafety::Unsafe,
-        };
+        let unsafety = intrisic_operation_unsafety(&name[..]);
         let (n_tps, inputs, output) = match &name[..] {
             "breakpoint" => (0, Vec::new(), tcx.mk_unit()),
             "size_of" |

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -80,7 +80,7 @@ mod closure;
 mod callee;
 mod compare_method;
 mod generator_interior;
-mod intrinsic;
+pub mod intrinsic;
 mod op;
 
 use astconv::{AstConv, PathSeg};

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -16,6 +16,7 @@
 
 use astconv::{AstConv, Bounds};
 use constrained_type_params as ctp;
+use check::intrinsic::intrisic_operation_unsafety;
 use lint;
 use middle::lang_items::SizedTraitLangItem;
 use middle::resolve_lifetime as rl;
@@ -2076,10 +2077,7 @@ fn compute_sig_of_foreign_fn_decl<'a, 'tcx>(
     abi: abi::Abi,
 ) -> ty::PolyFnSig<'tcx> {
     let unsafety = if abi == abi::Abi::RustIntrinsic {
-        match &*tcx.item_name(def_id).as_str() {
-            "size_of" | "min_align_of" | "needs_drop" => hir::Unsafety::Normal,
-            _ => hir::Unsafety::Unsafe,
-        }
+        intrisic_operation_unsafety(&*tcx.item_name(def_id).as_str())
     } else {
         hir::Unsafety::Unsafe
     };

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -242,7 +242,7 @@
 #![feature(char_error_internals)]
 #![feature(compiler_builtins_lib)]
 #![feature(concat_idents)]
-#![feature(const_int_ops)]
+#![cfg_attr(stage0, feature(const_int_ops))]
 #![feature(const_ip)]
 #![feature(const_raw_ptr_deref)]
 #![feature(const_cstr_unchecked)]

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -243,7 +243,7 @@
 #![feature(compiler_builtins_lib)]
 #![feature(concat_idents)]
 #![cfg_attr(stage0, feature(const_int_ops))]
-#![feature(const_ip)]
+#![cfg_attr(stage0, feature(const_ip))]
 #![feature(const_raw_ptr_deref)]
 #![feature(const_cstr_unchecked)]
 #![feature(core_intrinsics)]

--- a/src/libstd/net/ip.rs
+++ b/src/libstd/net/ip.rs
@@ -328,7 +328,7 @@ impl Ipv4Addr {
     /// let addr = Ipv4Addr::new(127, 0, 0, 1);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_ip")]
+    #[cfg_attr(stage0, rustc_const_unstable(feature = "const_ip"))]
     pub const fn new(a: u8, b: u8, c: u8, d: u8) -> Ipv4Addr {
         Ipv4Addr {
             inner: c::in_addr {

--- a/src/test/run-pass/const-int-conversion.rs
+++ b/src/test/run-pass/const-int-conversion.rs
@@ -1,4 +1,4 @@
-#![feature(const_int_conversion, const_int_ops, reverse_bits)]
+#![feature(const_int_conversion, reverse_bits)]
 
 const REVERSE: u32 = 0x12345678_u32.reverse_bits();
 const FROM_BE_BYTES: i32 = i32::from_be_bytes([0x12, 0x34, 0x56, 0x78]);
@@ -21,4 +21,3 @@ fn main() {
     assert_eq!(TO_LE_BYTES, ident([0x78, 0x56, 0x34, 0x12]));
     assert_eq!(TO_NE_BYTES, ident([0x80, 0, 0, 0]));
 }
-

--- a/src/test/run-pass/const-int-rotate.rs
+++ b/src/test/run-pass/const-int-rotate.rs
@@ -1,5 +1,3 @@
-#![feature(const_int_rotate)]
-
 const LEFT: u32 = 0x10000b3u32.rotate_left(8);
 const RIGHT: u32 = 0xb301u32.rotate_right(8);
 

--- a/src/test/run-pass/const-int-sign.rs
+++ b/src/test/run-pass/const-int-sign.rs
@@ -1,5 +1,3 @@
-#![feature(const_int_sign)]
-
 const NEGATIVE_A: bool = (-10i32).is_negative();
 const NEGATIVE_B: bool = 10i32.is_negative();
 const POSITIVE_A: bool= (-10i32).is_positive();

--- a/src/test/run-pass/const-int-wrapping.rs
+++ b/src/test/run-pass/const-int-wrapping.rs
@@ -1,5 +1,3 @@
-#![feature(const_int_wrapping)]
-
 const ADD_A: u32 = 200u32.wrapping_add(55);
 const ADD_B: u32 = 200u32.wrapping_add(u32::max_value());
 

--- a/src/test/run-pass/consts/const-endianess.rs
+++ b/src/test/run-pass/consts/const-endianess.rs
@@ -1,5 +1,4 @@
 // run-pass
-#![feature(const_int_ops)]
 #![feature(test)]
 
 extern crate test;
@@ -7,7 +6,6 @@ use test::black_box as b;
 
 const BE_U32: u32 = 55u32.to_be();
 const LE_U32: u32 = 55u32.to_le();
-
 
 fn main() {
     assert_eq!(BE_U32, b(55u32).to_be());

--- a/src/test/run-pass/ctfe/bswap-const.rs
+++ b/src/test/run-pass/ctfe/bswap-const.rs
@@ -4,9 +4,9 @@
 
 use std::intrinsics;
 
-const SWAPPED_U8: u8 = unsafe { intrinsics::bswap(0x12_u8) };
-const SWAPPED_U16: u16 = unsafe { intrinsics::bswap(0x12_34_u16) };
-const SWAPPED_I32: i32 = unsafe { intrinsics::bswap(0x12_34_56_78_i32) };
+const SWAPPED_U8: u8 = intrinsics::bswap(0x12_u8);
+const SWAPPED_U16: u16 = intrinsics::bswap(0x12_34_u16);
+const SWAPPED_I32: i32 = intrinsics::bswap(0x12_34_56_78_i32);
 
 fn main() {
     assert_eq!(SWAPPED_U8, 0x12);

--- a/src/test/run-pass/intrinsics/intrinsics-integer.rs
+++ b/src/test/run-pass/intrinsics/intrinsics-integer.rs
@@ -16,63 +16,63 @@ mod rusti {
 }
 
 pub fn main() {
+    use rusti::*;
+
+    assert_eq!(ctpop(0u8), 0); assert_eq!(ctpop(0i8), 0);
+    assert_eq!(ctpop(0u16), 0); assert_eq!(ctpop(0i16), 0);
+    assert_eq!(ctpop(0u32), 0); assert_eq!(ctpop(0i32), 0);
+    assert_eq!(ctpop(0u64), 0); assert_eq!(ctpop(0i64), 0);
+    assert_eq!(ctpop(0u128), 0); assert_eq!(ctpop(0i128), 0);
+
+    assert_eq!(ctpop(1u8), 1); assert_eq!(ctpop(1i8), 1);
+    assert_eq!(ctpop(1u16), 1); assert_eq!(ctpop(1i16), 1);
+    assert_eq!(ctpop(1u32), 1); assert_eq!(ctpop(1i32), 1);
+    assert_eq!(ctpop(1u64), 1); assert_eq!(ctpop(1i64), 1);
+    assert_eq!(ctpop(1u128), 1); assert_eq!(ctpop(1i128), 1);
+
+    assert_eq!(ctpop(10u8), 2); assert_eq!(ctpop(10i8), 2);
+    assert_eq!(ctpop(10u16), 2); assert_eq!(ctpop(10i16), 2);
+    assert_eq!(ctpop(10u32), 2); assert_eq!(ctpop(10i32), 2);
+    assert_eq!(ctpop(10u64), 2); assert_eq!(ctpop(10i64), 2);
+    assert_eq!(ctpop(10u128), 2); assert_eq!(ctpop(10i128), 2);
+
+    assert_eq!(ctpop(100u8), 3); assert_eq!(ctpop(100i8), 3);
+    assert_eq!(ctpop(100u16), 3); assert_eq!(ctpop(100i16), 3);
+    assert_eq!(ctpop(100u32), 3); assert_eq!(ctpop(100i32), 3);
+    assert_eq!(ctpop(100u64), 3); assert_eq!(ctpop(100i64), 3);
+    assert_eq!(ctpop(100u128), 3); assert_eq!(ctpop(100i128), 3);
+
+    assert_eq!(ctpop(-1i8 as u8), 8); assert_eq!(ctpop(-1i8), 8);
+    assert_eq!(ctpop(-1i16 as u16), 16); assert_eq!(ctpop(-1i16), 16);
+    assert_eq!(ctpop(-1i32 as u32), 32); assert_eq!(ctpop(-1i32), 32);
+    assert_eq!(ctpop(-1i64 as u64), 64); assert_eq!(ctpop(-1i64), 64);
+    assert_eq!(ctpop(-1i128 as u128), 128); assert_eq!(ctpop(-1i128), 128);
+
+    assert_eq!(ctlz(0u8), 8); assert_eq!(ctlz(0i8), 8);
+    assert_eq!(ctlz(0u16), 16); assert_eq!(ctlz(0i16), 16);
+    assert_eq!(ctlz(0u32), 32); assert_eq!(ctlz(0i32), 32);
+    assert_eq!(ctlz(0u64), 64); assert_eq!(ctlz(0i64), 64);
+    assert_eq!(ctlz(0u128), 128); assert_eq!(ctlz(0i128), 128);
+
+    assert_eq!(ctlz(1u8), 7); assert_eq!(ctlz(1i8), 7);
+    assert_eq!(ctlz(1u16), 15); assert_eq!(ctlz(1i16), 15);
+    assert_eq!(ctlz(1u32), 31); assert_eq!(ctlz(1i32), 31);
+    assert_eq!(ctlz(1u64), 63); assert_eq!(ctlz(1i64), 63);
+    assert_eq!(ctlz(1u128), 127); assert_eq!(ctlz(1i128), 127);
+
+    assert_eq!(ctlz(10u8), 4); assert_eq!(ctlz(10i8), 4);
+    assert_eq!(ctlz(10u16), 12); assert_eq!(ctlz(10i16), 12);
+    assert_eq!(ctlz(10u32), 28); assert_eq!(ctlz(10i32), 28);
+    assert_eq!(ctlz(10u64), 60); assert_eq!(ctlz(10i64), 60);
+    assert_eq!(ctlz(10u128), 124); assert_eq!(ctlz(10i128), 124);
+
+    assert_eq!(ctlz(100u8), 1); assert_eq!(ctlz(100i8), 1);
+    assert_eq!(ctlz(100u16), 9); assert_eq!(ctlz(100i16), 9);
+    assert_eq!(ctlz(100u32), 25); assert_eq!(ctlz(100i32), 25);
+    assert_eq!(ctlz(100u64), 57); assert_eq!(ctlz(100i64), 57);
+    assert_eq!(ctlz(100u128), 121); assert_eq!(ctlz(100i128), 121);
+
     unsafe {
-        use rusti::*;
-
-        assert_eq!(ctpop(0u8), 0); assert_eq!(ctpop(0i8), 0);
-        assert_eq!(ctpop(0u16), 0); assert_eq!(ctpop(0i16), 0);
-        assert_eq!(ctpop(0u32), 0); assert_eq!(ctpop(0i32), 0);
-        assert_eq!(ctpop(0u64), 0); assert_eq!(ctpop(0i64), 0);
-        assert_eq!(ctpop(0u128), 0); assert_eq!(ctpop(0i128), 0);
-
-        assert_eq!(ctpop(1u8), 1); assert_eq!(ctpop(1i8), 1);
-        assert_eq!(ctpop(1u16), 1); assert_eq!(ctpop(1i16), 1);
-        assert_eq!(ctpop(1u32), 1); assert_eq!(ctpop(1i32), 1);
-        assert_eq!(ctpop(1u64), 1); assert_eq!(ctpop(1i64), 1);
-        assert_eq!(ctpop(1u128), 1); assert_eq!(ctpop(1i128), 1);
-
-        assert_eq!(ctpop(10u8), 2); assert_eq!(ctpop(10i8), 2);
-        assert_eq!(ctpop(10u16), 2); assert_eq!(ctpop(10i16), 2);
-        assert_eq!(ctpop(10u32), 2); assert_eq!(ctpop(10i32), 2);
-        assert_eq!(ctpop(10u64), 2); assert_eq!(ctpop(10i64), 2);
-        assert_eq!(ctpop(10u128), 2); assert_eq!(ctpop(10i128), 2);
-
-        assert_eq!(ctpop(100u8), 3); assert_eq!(ctpop(100i8), 3);
-        assert_eq!(ctpop(100u16), 3); assert_eq!(ctpop(100i16), 3);
-        assert_eq!(ctpop(100u32), 3); assert_eq!(ctpop(100i32), 3);
-        assert_eq!(ctpop(100u64), 3); assert_eq!(ctpop(100i64), 3);
-        assert_eq!(ctpop(100u128), 3); assert_eq!(ctpop(100i128), 3);
-
-        assert_eq!(ctpop(-1i8 as u8), 8); assert_eq!(ctpop(-1i8), 8);
-        assert_eq!(ctpop(-1i16 as u16), 16); assert_eq!(ctpop(-1i16), 16);
-        assert_eq!(ctpop(-1i32 as u32), 32); assert_eq!(ctpop(-1i32), 32);
-        assert_eq!(ctpop(-1i64 as u64), 64); assert_eq!(ctpop(-1i64), 64);
-        assert_eq!(ctpop(-1i128 as u128), 128); assert_eq!(ctpop(-1i128), 128);
-
-        assert_eq!(ctlz(0u8), 8); assert_eq!(ctlz(0i8), 8);
-        assert_eq!(ctlz(0u16), 16); assert_eq!(ctlz(0i16), 16);
-        assert_eq!(ctlz(0u32), 32); assert_eq!(ctlz(0i32), 32);
-        assert_eq!(ctlz(0u64), 64); assert_eq!(ctlz(0i64), 64);
-        assert_eq!(ctlz(0u128), 128); assert_eq!(ctlz(0i128), 128);
-
-        assert_eq!(ctlz(1u8), 7); assert_eq!(ctlz(1i8), 7);
-        assert_eq!(ctlz(1u16), 15); assert_eq!(ctlz(1i16), 15);
-        assert_eq!(ctlz(1u32), 31); assert_eq!(ctlz(1i32), 31);
-        assert_eq!(ctlz(1u64), 63); assert_eq!(ctlz(1i64), 63);
-        assert_eq!(ctlz(1u128), 127); assert_eq!(ctlz(1i128), 127);
-
-        assert_eq!(ctlz(10u8), 4); assert_eq!(ctlz(10i8), 4);
-        assert_eq!(ctlz(10u16), 12); assert_eq!(ctlz(10i16), 12);
-        assert_eq!(ctlz(10u32), 28); assert_eq!(ctlz(10i32), 28);
-        assert_eq!(ctlz(10u64), 60); assert_eq!(ctlz(10i64), 60);
-        assert_eq!(ctlz(10u128), 124); assert_eq!(ctlz(10i128), 124);
-
-        assert_eq!(ctlz(100u8), 1); assert_eq!(ctlz(100i8), 1);
-        assert_eq!(ctlz(100u16), 9); assert_eq!(ctlz(100i16), 9);
-        assert_eq!(ctlz(100u32), 25); assert_eq!(ctlz(100i32), 25);
-        assert_eq!(ctlz(100u64), 57); assert_eq!(ctlz(100i64), 57);
-        assert_eq!(ctlz(100u128), 121); assert_eq!(ctlz(100i128), 121);
-
         assert_eq!(ctlz_nonzero(1u8), 7); assert_eq!(ctlz_nonzero(1i8), 7);
         assert_eq!(ctlz_nonzero(1u16), 15); assert_eq!(ctlz_nonzero(1i16), 15);
         assert_eq!(ctlz_nonzero(1u32), 31); assert_eq!(ctlz_nonzero(1i32), 31);
@@ -90,37 +90,39 @@ pub fn main() {
         assert_eq!(ctlz_nonzero(100u32), 25); assert_eq!(ctlz_nonzero(100i32), 25);
         assert_eq!(ctlz_nonzero(100u64), 57); assert_eq!(ctlz_nonzero(100i64), 57);
         assert_eq!(ctlz_nonzero(100u128), 121); assert_eq!(ctlz_nonzero(100i128), 121);
+    }
 
-        assert_eq!(cttz(-1i8 as u8), 0); assert_eq!(cttz(-1i8), 0);
-        assert_eq!(cttz(-1i16 as u16), 0); assert_eq!(cttz(-1i16), 0);
-        assert_eq!(cttz(-1i32 as u32), 0); assert_eq!(cttz(-1i32), 0);
-        assert_eq!(cttz(-1i64 as u64), 0); assert_eq!(cttz(-1i64), 0);
-        assert_eq!(cttz(-1i128 as u128), 0); assert_eq!(cttz(-1i128), 0);
+    assert_eq!(cttz(-1i8 as u8), 0); assert_eq!(cttz(-1i8), 0);
+    assert_eq!(cttz(-1i16 as u16), 0); assert_eq!(cttz(-1i16), 0);
+    assert_eq!(cttz(-1i32 as u32), 0); assert_eq!(cttz(-1i32), 0);
+    assert_eq!(cttz(-1i64 as u64), 0); assert_eq!(cttz(-1i64), 0);
+    assert_eq!(cttz(-1i128 as u128), 0); assert_eq!(cttz(-1i128), 0);
 
-        assert_eq!(cttz(0u8), 8); assert_eq!(cttz(0i8), 8);
-        assert_eq!(cttz(0u16), 16); assert_eq!(cttz(0i16), 16);
-        assert_eq!(cttz(0u32), 32); assert_eq!(cttz(0i32), 32);
-        assert_eq!(cttz(0u64), 64); assert_eq!(cttz(0i64), 64);
-        assert_eq!(cttz(0u128), 128); assert_eq!(cttz(0i128), 128);
+    assert_eq!(cttz(0u8), 8); assert_eq!(cttz(0i8), 8);
+    assert_eq!(cttz(0u16), 16); assert_eq!(cttz(0i16), 16);
+    assert_eq!(cttz(0u32), 32); assert_eq!(cttz(0i32), 32);
+    assert_eq!(cttz(0u64), 64); assert_eq!(cttz(0i64), 64);
+    assert_eq!(cttz(0u128), 128); assert_eq!(cttz(0i128), 128);
 
-        assert_eq!(cttz(1u8), 0); assert_eq!(cttz(1i8), 0);
-        assert_eq!(cttz(1u16), 0); assert_eq!(cttz(1i16), 0);
-        assert_eq!(cttz(1u32), 0); assert_eq!(cttz(1i32), 0);
-        assert_eq!(cttz(1u64), 0); assert_eq!(cttz(1i64), 0);
-        assert_eq!(cttz(1u128), 0); assert_eq!(cttz(1i128), 0);
+    assert_eq!(cttz(1u8), 0); assert_eq!(cttz(1i8), 0);
+    assert_eq!(cttz(1u16), 0); assert_eq!(cttz(1i16), 0);
+    assert_eq!(cttz(1u32), 0); assert_eq!(cttz(1i32), 0);
+    assert_eq!(cttz(1u64), 0); assert_eq!(cttz(1i64), 0);
+    assert_eq!(cttz(1u128), 0); assert_eq!(cttz(1i128), 0);
 
-        assert_eq!(cttz(10u8), 1); assert_eq!(cttz(10i8), 1);
-        assert_eq!(cttz(10u16), 1); assert_eq!(cttz(10i16), 1);
-        assert_eq!(cttz(10u32), 1); assert_eq!(cttz(10i32), 1);
-        assert_eq!(cttz(10u64), 1); assert_eq!(cttz(10i64), 1);
-        assert_eq!(cttz(10u128), 1); assert_eq!(cttz(10i128), 1);
+    assert_eq!(cttz(10u8), 1); assert_eq!(cttz(10i8), 1);
+    assert_eq!(cttz(10u16), 1); assert_eq!(cttz(10i16), 1);
+    assert_eq!(cttz(10u32), 1); assert_eq!(cttz(10i32), 1);
+    assert_eq!(cttz(10u64), 1); assert_eq!(cttz(10i64), 1);
+    assert_eq!(cttz(10u128), 1); assert_eq!(cttz(10i128), 1);
 
-        assert_eq!(cttz(100u8), 2); assert_eq!(cttz(100i8), 2);
-        assert_eq!(cttz(100u16), 2); assert_eq!(cttz(100i16), 2);
-        assert_eq!(cttz(100u32), 2); assert_eq!(cttz(100i32), 2);
-        assert_eq!(cttz(100u64), 2); assert_eq!(cttz(100i64), 2);
-        assert_eq!(cttz(100u128), 2); assert_eq!(cttz(100i128), 2);
+    assert_eq!(cttz(100u8), 2); assert_eq!(cttz(100i8), 2);
+    assert_eq!(cttz(100u16), 2); assert_eq!(cttz(100i16), 2);
+    assert_eq!(cttz(100u32), 2); assert_eq!(cttz(100i32), 2);
+    assert_eq!(cttz(100u64), 2); assert_eq!(cttz(100i64), 2);
+    assert_eq!(cttz(100u128), 2); assert_eq!(cttz(100i128), 2);
 
+    unsafe {
         assert_eq!(cttz_nonzero(-1i8 as u8), 0); assert_eq!(cttz_nonzero(-1i8), 0);
         assert_eq!(cttz_nonzero(-1i16 as u16), 0); assert_eq!(cttz_nonzero(-1i16), 0);
         assert_eq!(cttz_nonzero(-1i32 as u32), 0); assert_eq!(cttz_nonzero(-1i32), 0);
@@ -144,27 +146,27 @@ pub fn main() {
         assert_eq!(cttz_nonzero(100u32), 2); assert_eq!(cttz_nonzero(100i32), 2);
         assert_eq!(cttz_nonzero(100u64), 2); assert_eq!(cttz_nonzero(100i64), 2);
         assert_eq!(cttz_nonzero(100u128), 2); assert_eq!(cttz_nonzero(100i128), 2);
-
-        assert_eq!(bswap(0x0Au8), 0x0A); // no-op
-        assert_eq!(bswap(0x0Ai8), 0x0A); // no-op
-        assert_eq!(bswap(0x0A0Bu16), 0x0B0A);
-        assert_eq!(bswap(0x0A0Bi16), 0x0B0A);
-        assert_eq!(bswap(0x0ABBCC0Du32), 0x0DCCBB0A);
-        assert_eq!(bswap(0x0ABBCC0Di32), 0x0DCCBB0A);
-        assert_eq!(bswap(0x0122334455667708u64), 0x0877665544332201);
-        assert_eq!(bswap(0x0122334455667708i64), 0x0877665544332201);
-        assert_eq!(bswap(0x0122334455667708u128), 0x08776655443322010000000000000000);
-        assert_eq!(bswap(0x0122334455667708i128), 0x08776655443322010000000000000000);
-
-        assert_eq!(bitreverse(0x0Au8), 0x50);
-        assert_eq!(bitreverse(0x0Ai8), 0x50);
-        assert_eq!(bitreverse(0x0A0Cu16), 0x3050);
-        assert_eq!(bitreverse(0x0A0Ci16), 0x3050);
-        assert_eq!(bitreverse(0x0ABBCC0Eu32), 0x7033DD50);
-        assert_eq!(bitreverse(0x0ABBCC0Ei32), 0x7033DD50);
-        assert_eq!(bitreverse(0x0122334455667708u64), 0x10EE66AA22CC4480);
-        assert_eq!(bitreverse(0x0122334455667708i64), 0x10EE66AA22CC4480);
-        assert_eq!(bitreverse(0x0122334455667708u128), 0x10EE66AA22CC44800000000000000000);
-        assert_eq!(bitreverse(0x0122334455667708i128), 0x10EE66AA22CC44800000000000000000);
     }
+
+    assert_eq!(bswap(0x0Au8), 0x0A); // no-op
+    assert_eq!(bswap(0x0Ai8), 0x0A); // no-op
+    assert_eq!(bswap(0x0A0Bu16), 0x0B0A);
+    assert_eq!(bswap(0x0A0Bi16), 0x0B0A);
+    assert_eq!(bswap(0x0ABBCC0Du32), 0x0DCCBB0A);
+    assert_eq!(bswap(0x0ABBCC0Di32), 0x0DCCBB0A);
+    assert_eq!(bswap(0x0122334455667708u64), 0x0877665544332201);
+    assert_eq!(bswap(0x0122334455667708i64), 0x0877665544332201);
+    assert_eq!(bswap(0x0122334455667708u128), 0x08776655443322010000000000000000);
+    assert_eq!(bswap(0x0122334455667708i128), 0x08776655443322010000000000000000);
+
+    assert_eq!(bitreverse(0x0Au8), 0x50);
+    assert_eq!(bitreverse(0x0Ai8), 0x50);
+    assert_eq!(bitreverse(0x0A0Cu16), 0x3050);
+    assert_eq!(bitreverse(0x0A0Ci16), 0x3050);
+    assert_eq!(bitreverse(0x0ABBCC0Eu32), 0x7033DD50);
+    assert_eq!(bitreverse(0x0ABBCC0Ei32), 0x7033DD50);
+    assert_eq!(bitreverse(0x0122334455667708u64), 0x10EE66AA22CC4480);
+    assert_eq!(bitreverse(0x0122334455667708i64), 0x10EE66AA22CC4480);
+    assert_eq!(bitreverse(0x0122334455667708u128), 0x10EE66AA22CC44800000000000000000);
+    assert_eq!(bitreverse(0x0122334455667708i128), 0x10EE66AA22CC44800000000000000000);
 }

--- a/src/test/ui/bad/bad-intrinsic-monomorphization.rs
+++ b/src/test/ui/bad/bad-intrinsic-monomorphization.rs
@@ -14,7 +14,7 @@ use std::intrinsics;
 #[derive(Copy, Clone)]
 pub struct Foo(i64);
 
-pub unsafe fn test_cttz(v: Foo) -> Foo {
+pub fn test_cttz(v: Foo) -> Foo {
     intrinsics::cttz(v)
     //~^ ERROR `cttz` intrinsic: expected basic integer type, found `Foo`
 }

--- a/src/test/ui/consts/const-int-unchecked.rs
+++ b/src/test/ui/consts/const-int-unchecked.rs
@@ -2,10 +2,119 @@
 
 use std::intrinsics;
 
-const SHR: u8 = unsafe { intrinsics::unchecked_shr(5_u8, 8) };
+// The documentation of `unchecked_shl` states that it:
+//
+// Performs an unchecked left shift, resulting in undefined behavior when
+// y < 0 or y >= N, where N is the width of T in bits.
+//
+// So we check this for a few `y`.
+
+// unsigned types:
+
+const SHL_U8: u8 = unsafe { intrinsics::unchecked_shl(5_u8, 8) };
 //~^ ERROR any use of this value will cause an error
-const SHL: u8 = unsafe { intrinsics::unchecked_shl(5_u8, 8) };
+const SHL_U16: u16 = unsafe { intrinsics::unchecked_shl(5_u16, 16) };
+//~^ ERROR any use of this value will cause an error
+const SHL_U32: u32 = unsafe { intrinsics::unchecked_shl(5_u32, 32) };
+//~^ ERROR any use of this value will cause an error
+const SHL_U64: u64 = unsafe { intrinsics::unchecked_shl(5_u64, 64) };
+//~^ ERROR any use of this value will cause an error
+const SHL_U128: u128 = unsafe { intrinsics::unchecked_shl(5_u128, 128) };
 //~^ ERROR any use of this value will cause an error
 
-fn main() {
-}
+// signed types:
+
+const SHL_I8: i8 = unsafe { intrinsics::unchecked_shl(5_i8, 8) };
+//~^ ERROR any use of this value will cause an error
+const SHL_I16: i16 = unsafe { intrinsics::unchecked_shl(5_16, 16) };
+//~^ ERROR any use of this value will cause an error
+const SHL_I32: i32 = unsafe { intrinsics::unchecked_shl(5_i32, 32) };
+//~^ ERROR any use of this value will cause an error
+const SHL_I64: i64 = unsafe { intrinsics::unchecked_shl(5_i64, 64) };
+//~^ ERROR any use of this value will cause an error
+const SHL_I128: i128 = unsafe { intrinsics::unchecked_shl(5_i128, 128) };
+//~^ ERROR any use of this value will cause an error
+
+// and make sure we capture y < 0:
+
+const SHL_I8_NEG: i8 = unsafe { intrinsics::unchecked_shl(5_i8, -1) };
+//~^ ERROR any use of this value will cause an error
+const SHL_I16_NEG: i16 = unsafe { intrinsics::unchecked_shl(5_16, -1) };
+//~^ ERROR any use of this value will cause an error
+const SHL_I32_NEG: i32 = unsafe { intrinsics::unchecked_shl(5_i32, -1) };
+//~^ ERROR any use of this value will cause an error
+const SHL_I64_NEG: i64 = unsafe { intrinsics::unchecked_shl(5_i64, -1) };
+//~^ ERROR any use of this value will cause an error
+const SHL_I128_NEG: i128 = unsafe { intrinsics::unchecked_shl(5_i128, -1) };
+//~^ ERROR any use of this value will cause an error
+
+// and that there's no special relation to the value -1 by picking some
+// negative values at random:
+
+const SHL_I8_NEG_RANDOM: i8 = unsafe { intrinsics::unchecked_shl(5_i8, -6) };
+//~^ ERROR any use of this value will cause an error
+const SHL_I16_NEG_RANDOM: i16 = unsafe { intrinsics::unchecked_shl(5_16, -13) };
+//~^ ERROR any use of this value will cause an error
+const SHL_I32_NEG_RANDOM: i32 = unsafe { intrinsics::unchecked_shl(5_i32, -25) };
+//~^ ERROR any use of this value will cause an error
+const SHL_I64_NEG_RANDOM: i64 = unsafe { intrinsics::unchecked_shl(5_i64, -30) };
+//~^ ERROR any use of this value will cause an error
+const SHL_I128_NEG_RANDOM: i128 = unsafe { intrinsics::unchecked_shl(5_i128, -93) };
+//~^ ERROR any use of this value will cause an error
+
+// Repeat it all over for `unchecked_shr`
+
+// unsigned types:
+
+const SHR_U8: u8 = unsafe { intrinsics::unchecked_shr(5_u8, 8) };
+//~^ ERROR any use of this value will cause an error
+const SHR_U16: u16 = unsafe { intrinsics::unchecked_shr(5_u16, 16) };
+//~^ ERROR any use of this value will cause an error
+const SHR_U32: u32 = unsafe { intrinsics::unchecked_shr(5_u32, 32) };
+//~^ ERROR any use of this value will cause an error
+const SHR_U64: u64 = unsafe { intrinsics::unchecked_shr(5_u64, 64) };
+//~^ ERROR any use of this value will cause an error
+const SHR_U128: u128 = unsafe { intrinsics::unchecked_shr(5_u128, 128) };
+//~^ ERROR any use of this value will cause an error
+
+// signed types:
+
+const SHR_I8: i8 = unsafe { intrinsics::unchecked_shr(5_i8, 8) };
+//~^ ERROR any use of this value will cause an error
+const SHR_I16: i16 = unsafe { intrinsics::unchecked_shr(5_16, 16) };
+//~^ ERROR any use of this value will cause an error
+const SHR_I32: i32 = unsafe { intrinsics::unchecked_shr(5_i32, 32) };
+//~^ ERROR any use of this value will cause an error
+const SHR_I64: i64 = unsafe { intrinsics::unchecked_shr(5_i64, 64) };
+//~^ ERROR any use of this value will cause an error
+const SHR_I128: i128 = unsafe { intrinsics::unchecked_shr(5_i128, 128) };
+//~^ ERROR any use of this value will cause an error
+
+// and make sure we capture y < 0:
+
+const SHR_I8_NEG: i8 = unsafe { intrinsics::unchecked_shr(5_i8, -1) };
+//~^ ERROR any use of this value will cause an error
+const SHR_I16_NEG: i16 = unsafe { intrinsics::unchecked_shr(5_16, -1) };
+//~^ ERROR any use of this value will cause an error
+const SHR_I32_NEG: i32 = unsafe { intrinsics::unchecked_shr(5_i32, -1) };
+//~^ ERROR any use of this value will cause an error
+const SHR_I64_NEG: i64 = unsafe { intrinsics::unchecked_shr(5_i64, -1) };
+//~^ ERROR any use of this value will cause an error
+const SHR_I128_NEG: i128 = unsafe { intrinsics::unchecked_shr(5_i128, -1) };
+//~^ ERROR any use of this value will cause an error
+
+// and that there's no special relation to the value -1 by picking some
+// negative values at random:
+
+const SHR_I8_NEG_RANDOM: i8 = unsafe { intrinsics::unchecked_shr(5_i8, -6) };
+//~^ ERROR any use of this value will cause an error
+const SHR_I16_NEG_RANDOM: i16 = unsafe { intrinsics::unchecked_shr(5_16, -13) };
+//~^ ERROR any use of this value will cause an error
+const SHR_I32_NEG_RANDOM: i32 = unsafe { intrinsics::unchecked_shr(5_i32, -25) };
+//~^ ERROR any use of this value will cause an error
+const SHR_I64_NEG_RANDOM: i64 = unsafe { intrinsics::unchecked_shr(5_i64, -30) };
+//~^ ERROR any use of this value will cause an error
+const SHR_I128_NEG_RANDOM: i128 = unsafe { intrinsics::unchecked_shr(5_i128, -93) };
+//~^ ERROR any use of this value will cause an error
+
+fn main() {}

--- a/src/test/ui/consts/const-int-unchecked.stderr
+++ b/src/test/ui/consts/const-int-unchecked.stderr
@@ -1,20 +1,324 @@
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:5:1
+  --> $DIR/const-int-unchecked.rs:14:1
    |
-LL | const SHR: u8 = unsafe { intrinsics::unchecked_shr(5_u8, 8) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^----------------------------------^^^
-   |                          |
-   |                          Overflowing shift by 8 in unchecked_shr
+LL | const SHL_U8: u8 = unsafe { intrinsics::unchecked_shl(5_u8, 8) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^----------------------------------^^^
+   |                             |
+   |                             Overflowing shift by 8 in unchecked_shl
    |
    = note: #[deny(const_err)] on by default
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:7:1
+  --> $DIR/const-int-unchecked.rs:16:1
    |
-LL | const SHL: u8 = unsafe { intrinsics::unchecked_shl(5_u8, 8) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^----------------------------------^^^
-   |                          |
-   |                          Overflowing shift by 8 in unchecked_shl
+LL | const SHL_U16: u16 = unsafe { intrinsics::unchecked_shl(5_u16, 16) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   |                               |
+   |                               Overflowing shift by 16 in unchecked_shl
 
-error: aborting due to 2 previous errors
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:18:1
+   |
+LL | const SHL_U32: u32 = unsafe { intrinsics::unchecked_shl(5_u32, 32) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   |                               |
+   |                               Overflowing shift by 32 in unchecked_shl
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:20:1
+   |
+LL | const SHL_U64: u64 = unsafe { intrinsics::unchecked_shl(5_u64, 64) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   |                               |
+   |                               Overflowing shift by 64 in unchecked_shl
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:22:1
+   |
+LL | const SHL_U128: u128 = unsafe { intrinsics::unchecked_shl(5_u128, 128) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^--------------------------------------^^^
+   |                                 |
+   |                                 Overflowing shift by 128 in unchecked_shl
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:27:1
+   |
+LL | const SHL_I8: i8 = unsafe { intrinsics::unchecked_shl(5_i8, 8) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^----------------------------------^^^
+   |                             |
+   |                             Overflowing shift by 8 in unchecked_shl
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:29:1
+   |
+LL | const SHL_I16: i16 = unsafe { intrinsics::unchecked_shl(5_16, 16) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------------------------------^^^
+   |                               |
+   |                               Overflowing shift by 16 in unchecked_shl
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:31:1
+   |
+LL | const SHL_I32: i32 = unsafe { intrinsics::unchecked_shl(5_i32, 32) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   |                               |
+   |                               Overflowing shift by 32 in unchecked_shl
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:33:1
+   |
+LL | const SHL_I64: i64 = unsafe { intrinsics::unchecked_shl(5_i64, 64) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   |                               |
+   |                               Overflowing shift by 64 in unchecked_shl
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:35:1
+   |
+LL | const SHL_I128: i128 = unsafe { intrinsics::unchecked_shl(5_i128, 128) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^--------------------------------------^^^
+   |                                 |
+   |                                 Overflowing shift by 128 in unchecked_shl
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:40:1
+   |
+LL | const SHL_I8_NEG: i8 = unsafe { intrinsics::unchecked_shl(5_i8, -1) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------------------------------^^^
+   |                                 |
+   |                                 Overflowing shift by 255 in unchecked_shl
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:42:1
+   |
+LL | const SHL_I16_NEG: i16 = unsafe { intrinsics::unchecked_shl(5_16, -1) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------------------------------^^^
+   |                                   |
+   |                                   Overflowing shift by 65535 in unchecked_shl
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:44:1
+   |
+LL | const SHL_I32_NEG: i32 = unsafe { intrinsics::unchecked_shl(5_i32, -1) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   |                                   |
+   |                                   Overflowing shift by 4294967295 in unchecked_shl
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:46:1
+   |
+LL | const SHL_I64_NEG: i64 = unsafe { intrinsics::unchecked_shl(5_i64, -1) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   |                                   |
+   |                                   Overflowing shift by 18446744073709551615 in unchecked_shl
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:48:1
+   |
+LL | const SHL_I128_NEG: i128 = unsafe { intrinsics::unchecked_shl(5_i128, -1) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------------------------------------^^^
+   |                                     |
+   |                                     Overflowing shift by 340282366920938463463374607431768211455 in unchecked_shl
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:54:1
+   |
+LL | const SHL_I8_NEG_RANDOM: i8 = unsafe { intrinsics::unchecked_shl(5_i8, -6) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------------------------------^^^
+   |                                        |
+   |                                        Overflowing shift by 250 in unchecked_shl
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:56:1
+   |
+LL | const SHL_I16_NEG_RANDOM: i16 = unsafe { intrinsics::unchecked_shl(5_16, -13) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   |                                          |
+   |                                          Overflowing shift by 65523 in unchecked_shl
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:58:1
+   |
+LL | const SHL_I32_NEG_RANDOM: i32 = unsafe { intrinsics::unchecked_shl(5_i32, -25) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------------------------------------^^^
+   |                                          |
+   |                                          Overflowing shift by 4294967271 in unchecked_shl
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:60:1
+   |
+LL | const SHL_I64_NEG_RANDOM: i64 = unsafe { intrinsics::unchecked_shl(5_i64, -30) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------------------------------------^^^
+   |                                          |
+   |                                          Overflowing shift by 18446744073709551586 in unchecked_shl
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:62:1
+   |
+LL | const SHL_I128_NEG_RANDOM: i128 = unsafe { intrinsics::unchecked_shl(5_i128, -93) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^--------------------------------------^^^
+   |                                            |
+   |                                            Overflowing shift by 340282366920938463463374607431768211363 in unchecked_shl
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:69:1
+   |
+LL | const SHR_U8: u8 = unsafe { intrinsics::unchecked_shr(5_u8, 8) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^----------------------------------^^^
+   |                             |
+   |                             Overflowing shift by 8 in unchecked_shr
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:71:1
+   |
+LL | const SHR_U16: u16 = unsafe { intrinsics::unchecked_shr(5_u16, 16) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   |                               |
+   |                               Overflowing shift by 16 in unchecked_shr
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:73:1
+   |
+LL | const SHR_U32: u32 = unsafe { intrinsics::unchecked_shr(5_u32, 32) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   |                               |
+   |                               Overflowing shift by 32 in unchecked_shr
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:75:1
+   |
+LL | const SHR_U64: u64 = unsafe { intrinsics::unchecked_shr(5_u64, 64) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   |                               |
+   |                               Overflowing shift by 64 in unchecked_shr
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:77:1
+   |
+LL | const SHR_U128: u128 = unsafe { intrinsics::unchecked_shr(5_u128, 128) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^--------------------------------------^^^
+   |                                 |
+   |                                 Overflowing shift by 128 in unchecked_shr
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:82:1
+   |
+LL | const SHR_I8: i8 = unsafe { intrinsics::unchecked_shr(5_i8, 8) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^----------------------------------^^^
+   |                             |
+   |                             Overflowing shift by 8 in unchecked_shr
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:84:1
+   |
+LL | const SHR_I16: i16 = unsafe { intrinsics::unchecked_shr(5_16, 16) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------------------------------^^^
+   |                               |
+   |                               Overflowing shift by 16 in unchecked_shr
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:86:1
+   |
+LL | const SHR_I32: i32 = unsafe { intrinsics::unchecked_shr(5_i32, 32) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   |                               |
+   |                               Overflowing shift by 32 in unchecked_shr
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:88:1
+   |
+LL | const SHR_I64: i64 = unsafe { intrinsics::unchecked_shr(5_i64, 64) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   |                               |
+   |                               Overflowing shift by 64 in unchecked_shr
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:90:1
+   |
+LL | const SHR_I128: i128 = unsafe { intrinsics::unchecked_shr(5_i128, 128) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^--------------------------------------^^^
+   |                                 |
+   |                                 Overflowing shift by 128 in unchecked_shr
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:95:1
+   |
+LL | const SHR_I8_NEG: i8 = unsafe { intrinsics::unchecked_shr(5_i8, -1) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------------------------------^^^
+   |                                 |
+   |                                 Overflowing shift by 255 in unchecked_shr
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:97:1
+   |
+LL | const SHR_I16_NEG: i16 = unsafe { intrinsics::unchecked_shr(5_16, -1) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------------------------------^^^
+   |                                   |
+   |                                   Overflowing shift by 65535 in unchecked_shr
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:99:1
+   |
+LL | const SHR_I32_NEG: i32 = unsafe { intrinsics::unchecked_shr(5_i32, -1) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   |                                   |
+   |                                   Overflowing shift by 4294967295 in unchecked_shr
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:101:1
+   |
+LL | const SHR_I64_NEG: i64 = unsafe { intrinsics::unchecked_shr(5_i64, -1) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   |                                   |
+   |                                   Overflowing shift by 18446744073709551615 in unchecked_shr
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:103:1
+   |
+LL | const SHR_I128_NEG: i128 = unsafe { intrinsics::unchecked_shr(5_i128, -1) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------------------------------------^^^
+   |                                     |
+   |                                     Overflowing shift by 340282366920938463463374607431768211455 in unchecked_shr
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:109:1
+   |
+LL | const SHR_I8_NEG_RANDOM: i8 = unsafe { intrinsics::unchecked_shr(5_i8, -6) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------------------------------^^^
+   |                                        |
+   |                                        Overflowing shift by 250 in unchecked_shr
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:111:1
+   |
+LL | const SHR_I16_NEG_RANDOM: i16 = unsafe { intrinsics::unchecked_shr(5_16, -13) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   |                                          |
+   |                                          Overflowing shift by 65523 in unchecked_shr
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:113:1
+   |
+LL | const SHR_I32_NEG_RANDOM: i32 = unsafe { intrinsics::unchecked_shr(5_i32, -25) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------------------------------------^^^
+   |                                          |
+   |                                          Overflowing shift by 4294967271 in unchecked_shr
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:115:1
+   |
+LL | const SHR_I64_NEG_RANDOM: i64 = unsafe { intrinsics::unchecked_shr(5_i64, -30) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------------------------------------^^^
+   |                                          |
+   |                                          Overflowing shift by 18446744073709551586 in unchecked_shr
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:117:1
+   |
+LL | const SHR_I128_NEG_RANDOM: i128 = unsafe { intrinsics::unchecked_shr(5_i128, -93) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^--------------------------------------^^^
+   |                                            |
+   |                                            Overflowing shift by 340282366920938463463374607431768211363 in unchecked_shr
+
+error: aborting due to 40 previous errors
 


### PR DESCRIPTION
r? @oli-obk

## Note for relnotes: This PR includes https://github.com/rust-lang/rust/pull/57105.

I've added T-lang since this affects intrinsics and the operational semantics of Rust's `const fn` fragment.

## Stable APIs proposed for constification

+ `const_int_ops`:
    + `count_ones`
    + `count_zeros`
    + `leading_zeros`
    + `trailing_zeros`
    + `swap_bytes`
    + `from_be`
    + `from_le`
    + `to_be`
    + `to_le`
+ `const_ip`
    + `Ipv4Addr::new`

## Unstable APIs constified

+ `const_int_conversion`:
    + `reverse_bits`