### PR TITLE
[beta] Rollup backports

### DIFF
--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -1756,7 +1756,7 @@ bitflags! {
         const IS_ENUM             = 1 << 0;
         const IS_UNION            = 1 << 1;
         const IS_STRUCT           = 1 << 2;
-        const IS_TUPLE_STRUCT     = 1 << 3;
+        const HAS_CTOR            = 1 << 3;
         const IS_PHANTOM_DATA     = 1 << 4;
         const IS_FUNDAMENTAL      = 1 << 5;
         const IS_BOX              = 1 << 6;
@@ -2096,7 +2096,7 @@ impl<'a, 'gcx, 'tcx> AdtDef {
             let variant_def = &variants[VariantIdx::new(0)];
             let def_key = tcx.def_key(variant_def.did);
             match def_key.disambiguated_data.data {
-                DefPathData::StructCtor => flags |= AdtFlags::IS_TUPLE_STRUCT,
+                DefPathData::StructCtor => flags |= AdtFlags::HAS_CTOR,
                 _ => (),
             }
         }
@@ -2129,12 +2129,6 @@ impl<'a, 'gcx, 'tcx> AdtDef {
     #[inline]
     pub fn is_struct(&self) -> bool {
         self.flags.contains(AdtFlags::IS_STRUCT)
-    }
-
-    /// If this function returns `true`, it implies that `is_struct` must return `true`.
-    #[inline]
-    pub fn is_tuple_struct(&self) -> bool {
-        self.flags.contains(AdtFlags::IS_TUPLE_STRUCT)
     }
 
     #[inline]
@@ -2179,6 +2173,12 @@ impl<'a, 'gcx, 'tcx> AdtDef {
             AdtKind::Union => "union",
             AdtKind::Enum => "variant",
         }
+    }
+
+    /// If this function returns `true`, it implies that `is_struct` must return `true`.
+    #[inline]
+    pub fn has_ctor(&self) -> bool {
+        self.flags.contains(AdtFlags::HAS_CTOR)
     }
 
     /// Returns whether this type is `#[fundamental]` for the purposes

--- a/src/librustc_mir/interpret/memory.rs
+++ b/src/librustc_mir/interpret/memory.rs
@@ -707,10 +707,15 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> Memory<'a, 'mir, 'tcx, M> {
                 new_relocations.extend(
                     relocations
                     .iter()
-                    .map(|&(offset, reloc)| (
-                        offset + dest.offset - src.offset + (i * size),
-                        reloc,
-                    ))
+                    .map(|&(offset, reloc)| {
+                        // compute offset for current repetition
+                        let dest_offset = dest.offset + (i * size);
+                        (
+                            // shift offsets from source allocation to destination allocation
+                            offset + dest_offset - src.offset,
+                            reloc,
+                        )
+                    })
                 );
             }
 

--- a/src/librustc_mir/interpret/memory.rs
+++ b/src/librustc_mir/interpret/memory.rs
@@ -707,10 +707,10 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> Memory<'a, 'mir, 'tcx, M> {
                 new_relocations.extend(
                     relocations
                     .iter()
-                    .map(|&(offset, reloc)| {
-                    (offset + dest.offset - src.offset + (i * size * relocations.len() as u64),
-                     reloc)
-                    })
+                    .map(|&(offset, reloc)| (
+                        offset + dest.offset - src.offset + (i * size),
+                        reloc,
+                    ))
                 );
             }
 

--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -517,7 +517,7 @@ impl<'a, 'tcx> Visitor<'tcx> for Qualifier<'a, 'tcx, 'tcx> {
 
                 // Only allow statics (not consts) to refer to other statics.
                 if self.mode == Mode::Static || self.mode == Mode::StaticMut {
-                    if context.is_mutating_use() {
+                    if self.mode == Mode::Static && context.is_mutating_use() {
                         // this is not strictly necessary as miri will also bail out
                         // For interior mutability we can't really catch this statically as that
                         // goes through raw pointers and intermediate temporaries, so miri has

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1013,6 +1013,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> dyn AstConv<'gcx, 'tcx>+'o {
         let mut associated_types = BTreeSet::default();
 
         for tr in traits::elaborate_trait_ref(tcx, principal) {
+            debug!("conv_object_ty_poly_trait_ref: observing object predicate `{:?}`", tr);
             match tr {
                 ty::Predicate::Trait(pred) => {
                     associated_types.extend(tcx.associated_items(pred.def_id())
@@ -1020,8 +1021,31 @@ impl<'o, 'gcx: 'tcx, 'tcx> dyn AstConv<'gcx, 'tcx>+'o {
                                     .map(|item| item.def_id));
                 }
                 ty::Predicate::Projection(pred) => {
-                    // Include projections defined on supertraits.
-                    projection_bounds.push((pred, DUMMY_SP))
+                    // A `Self` within the original bound will be substituted with a
+                    // `TRAIT_OBJECT_DUMMY_SELF`, so check for that.
+                    let references_self =
+                        pred.skip_binder().ty.walk().any(|t| t == dummy_self);
+
+                    // If the projection output contains `Self`, force the user to
+                    // elaborate it explicitly to avoid a bunch of complexity.
+                    //
+                    // The "classicaly useful" case is the following:
+                    // ```
+                    //     trait MyTrait: FnMut() -> <Self as MyTrait>::MyOutput {
+                    //         type MyOutput;
+                    //     }
+                    // ```
+                    //
+                    // Here, the user could theoretically write `dyn MyTrait<Output=X>`,
+                    // but actually supporting that would "expand" to an infinitely-long type
+                    // `fix $ τ → dyn MyTrait<MyOutput=X, Output=<τ as MyTrait>::MyOutput`.
+                    //
+                    // Instead, we force the user to write `dyn MyTrait<MyOutput=X, Output=X>`,
+                    // which is uglier but works. See the discussion in #56288 for alternatives.
+                    if !references_self {
+                        // Include projections defined on supertraits,
+                        projection_bounds.push((pred, DUMMY_SP))
+                    }
                 }
                 _ => ()
             }

--- a/src/librustc_typeck/check/callee.rs
+++ b/src/librustc_typeck/check/callee.rs
@@ -280,7 +280,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                         Def::Local(id) | Def::Upvar(id, ..) => {
                             Some(self.tcx.hir.span(id))
                         }
-                        _ => self.tcx.hir.span_if_local(def.def_id())
+                        _ => def.opt_def_id().and_then(|did| self.tcx.hir.span_if_local(did)),
                     };
                     if let Some(span) = def_span {
                         let label = match (unit_variant, inner_callee_path) {

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -98,7 +98,8 @@ use rustc::mir::interpret::{ConstValue, GlobalId};
 use rustc::ty::subst::{CanonicalUserSubsts, UnpackedKind, Subst, Substs,
                        UserSelfTy, UserSubsts};
 use rustc::traits::{self, ObligationCause, ObligationCauseCode, TraitEngine};
-use rustc::ty::{self, Ty, TyCtxt, GenericParamDefKind, Visibility, ToPredicate, RegionKind};
+use rustc::ty::{self, AdtKind, Ty, TyCtxt, GenericParamDefKind, Visibility, ToPredicate,
+                RegionKind};
 use rustc::ty::adjustment::{Adjust, Adjustment, AllowTwoPhase, AutoBorrow, AutoBorrowMutability};
 use rustc::ty::fold::TypeFoldable;
 use rustc::ty::query::Providers;
@@ -3222,8 +3223,8 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                             return_expr_ty);
     }
 
-    // A generic function for checking the then and else in an if
-    // or if-else.
+    // A generic function for checking the 'then' and 'else' clauses in an 'if'
+    // or 'if-else' expression.
     fn check_then_else(&self,
                        cond_expr: &'gcx hir::Expr,
                        then_expr: &'gcx hir::Expr,
@@ -3548,8 +3549,8 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
 
                 // we don't look at stability attributes on
                 // struct-like enums (yet...), but it's definitely not
-                // a bug to have construct one.
-                if adt_kind != ty::AdtKind::Enum {
+                // a bug to have constructed one.
+                if adt_kind != AdtKind::Enum {
                     tcx.check_stability(v_field.did, Some(expr_id), field.span);
                 }
 
@@ -5161,26 +5162,48 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         }).unwrap_or(false);
 
         let mut new_def = def;
-        let (def_id, ty) = if let Def::SelfCtor(impl_def_id) = def {
-            let ty = self.impl_self_ty(span, impl_def_id).ty;
+        let (def_id, ty) = match def {
+            Def::SelfCtor(impl_def_id) => {
+                let ty = self.impl_self_ty(span, impl_def_id).ty;
+                let adt_def = ty.ty_adt_def();
 
-            match ty.ty_adt_def() {
-                Some(adt_def) if adt_def.is_struct() => {
-                    let variant = adt_def.non_enum_variant();
-                    new_def = Def::StructCtor(variant.did, variant.ctor_kind);
-                    (variant.did, self.tcx.type_of(variant.did))
-                }
-                _ => {
-                    (impl_def_id, self.tcx.types.err)
+                match adt_def {
+                    Some(adt_def) if adt_def.is_tuple_struct() => {
+                        let variant = adt_def.non_enum_variant();
+                        new_def = Def::StructCtor(variant.did, variant.ctor_kind);
+                        (variant.did, self.tcx.type_of(variant.did))
+                    }
+                    _ => {
+                        let mut err = self.tcx.sess.struct_span_err(span,
+                            "the `Self` constructor can only be used with tuple or unit structs");
+                        if let Some(adt_def) = adt_def {
+                            match adt_def.adt_kind() {
+                                AdtKind::Enum => {
+                                    err.note("did you mean to use one of the enum's variants?");
+                                },
+                                AdtKind::Union => {},
+                                AdtKind::Struct => {
+                                    err.span_label(
+                                        span,
+                                        format!("did you mean `Self {{ /* fields */ }}`?"),
+                                    );
+                                }
+                            }
+                        }
+                        err.emit();
+
+                        (impl_def_id, self.tcx.types.err)
+                    }
                 }
             }
-        } else {
-            let def_id = def.def_id();
+            _ => {
+                let def_id = def.def_id();
 
-            // The things we are substituting into the type should not contain
-            // escaping late-bound regions, and nor should the base type scheme.
-            let ty = self.tcx.type_of(def_id);
-            (def_id, ty)
+                // The things we are substituting into the type should not contain
+                // escaping late-bound regions, and nor should the base type scheme.
+                let ty = self.tcx.type_of(def_id);
+                (def_id, ty)
+            }
         };
 
         let substs = AstConv::create_substs_for_generic_args(

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -5168,7 +5168,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 let adt_def = ty.ty_adt_def();
 
                 match adt_def {
-                    Some(adt_def) if adt_def.is_tuple_struct() => {
+                    Some(adt_def) if adt_def.has_ctor() => {
                         let variant = adt_def.non_enum_variant();
                         new_def = Def::StructCtor(variant.did, variant.ctor_kind);
                         (variant.did, self.tcx.type_of(variant.did))
@@ -5181,8 +5181,8 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                 AdtKind::Enum => {
                                     err.note("did you mean to use one of the enum's variants?");
                                 },
-                                AdtKind::Union => {},
-                                AdtKind::Struct => {
+                                AdtKind::Struct |
+                                AdtKind::Union => {
                                     err.span_label(
                                         span,
                                         format!("did you mean `Self {{ /* fields */ }}`?"),

--- a/src/test/ui/consts/promoted_regression.rs
+++ b/src/test/ui/consts/promoted_regression.rs
@@ -1,0 +1,9 @@
+// compile-pass
+
+fn main() {
+    let _ = &[("", ""); 3];
+}
+
+const FOO: &[(&str, &str)] = &[("", ""); 3];
+const BAR: &[(&str, &str); 5] = &[("", ""); 5];
+const BAA: &[[&str; 12]; 11] = &[[""; 12]; 11];

--- a/src/test/ui/consts/static_mut_containing_mut_ref.rs
+++ b/src/test/ui/consts/static_mut_containing_mut_ref.rs
@@ -1,0 +1,7 @@
+// compile-pass
+
+static mut STDERR_BUFFER_SPACE: [u8; 42] = [0u8; 42];
+
+pub static mut STDERR_BUFFER: *mut [u8] = unsafe { &mut STDERR_BUFFER_SPACE };
+
+fn main() {}

--- a/src/test/ui/consts/static_mut_containing_mut_ref2.rs
+++ b/src/test/ui/consts/static_mut_containing_mut_ref2.rs
@@ -1,0 +1,8 @@
+#![feature(const_let)]
+
+static mut STDERR_BUFFER_SPACE: u8 = 0;
+
+pub static mut STDERR_BUFFER: () = unsafe { *(&mut STDERR_BUFFER_SPACE) = 42; };
+//~^ references in statics may only refer to immutable values
+
+fn main() {}

--- a/src/test/ui/consts/static_mut_containing_mut_ref2.rs
+++ b/src/test/ui/consts/static_mut_containing_mut_ref2.rs
@@ -4,5 +4,6 @@ static mut STDERR_BUFFER_SPACE: u8 = 0;
 
 pub static mut STDERR_BUFFER: () = unsafe { *(&mut STDERR_BUFFER_SPACE) = 42; };
 //~^ ERROR references in statics may only refer to immutable values
+//~| ERROR static contains unimplemented expression type
 
 fn main() {}

--- a/src/test/ui/consts/static_mut_containing_mut_ref2.rs
+++ b/src/test/ui/consts/static_mut_containing_mut_ref2.rs
@@ -3,6 +3,6 @@
 static mut STDERR_BUFFER_SPACE: u8 = 0;
 
 pub static mut STDERR_BUFFER: () = unsafe { *(&mut STDERR_BUFFER_SPACE) = 42; };
-//~^ references in statics may only refer to immutable values
+//~^ ERROR references in statics may only refer to immutable values
 
 fn main() {}

--- a/src/test/ui/consts/static_mut_containing_mut_ref2.rs
+++ b/src/test/ui/consts/static_mut_containing_mut_ref2.rs
@@ -4,6 +4,5 @@ static mut STDERR_BUFFER_SPACE: u8 = 0;
 
 pub static mut STDERR_BUFFER: () = unsafe { *(&mut STDERR_BUFFER_SPACE) = 42; };
 //~^ ERROR references in statics may only refer to immutable values
-//~| ERROR static contains unimplemented expression type
 
 fn main() {}

--- a/src/test/ui/consts/static_mut_containing_mut_ref2.stderr
+++ b/src/test/ui/consts/static_mut_containing_mut_ref2.stderr
@@ -1,0 +1,9 @@
+error[E0017]: references in statics may only refer to immutable values
+  --> $DIR/static_mut_containing_mut_ref2.rs:5:46
+   |
+LL | pub static mut STDERR_BUFFER: () = unsafe { *(&mut STDERR_BUFFER_SPACE) = 42; };
+   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^ statics require immutable values
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0017`.

--- a/src/test/ui/consts/static_mut_containing_mut_ref2.stderr
+++ b/src/test/ui/consts/static_mut_containing_mut_ref2.stderr
@@ -4,6 +4,13 @@ error[E0017]: references in statics may only refer to immutable values
 LL | pub static mut STDERR_BUFFER: () = unsafe { *(&mut STDERR_BUFFER_SPACE) = 42; };
    |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^ statics require immutable values
 
-error: aborting due to previous error
+error[E0019]: static contains unimplemented expression type
+  --> $DIR/static_mut_containing_mut_ref2.rs:5:45
+   |
+LL | pub static mut STDERR_BUFFER: () = unsafe { *(&mut STDERR_BUFFER_SPACE) = 42; };
+   |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-For more information about this error, try `rustc --explain E0017`.
+error: aborting due to 2 previous errors
+
+Some errors occurred: E0017, E0019.
+For more information about an error, try `rustc --explain E0017`.

--- a/src/test/ui/consts/static_mut_containing_mut_ref2.stderr
+++ b/src/test/ui/consts/static_mut_containing_mut_ref2.stderr
@@ -4,13 +4,6 @@ error[E0017]: references in statics may only refer to immutable values
 LL | pub static mut STDERR_BUFFER: () = unsafe { *(&mut STDERR_BUFFER_SPACE) = 42; };
    |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^ statics require immutable values
 
-error[E0019]: static contains unimplemented expression type
-  --> $DIR/static_mut_containing_mut_ref2.rs:5:45
-   |
-LL | pub static mut STDERR_BUFFER: () = unsafe { *(&mut STDERR_BUFFER_SPACE) = 42; };
-   |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+error: aborting due to previous error
 
-error: aborting due to 2 previous errors
-
-Some errors occurred: E0017, E0019.
-For more information about an error, try `rustc --explain E0017`.
+For more information about this error, try `rustc --explain E0017`.

--- a/src/test/ui/consts/static_mut_containing_mut_ref3.rs
+++ b/src/test/ui/consts/static_mut_containing_mut_ref3.rs
@@ -1,0 +1,8 @@
+#![feature(const_let)]
+
+static mut FOO: (u8, u8) = (42, 43);
+
+static mut BAR: () = unsafe { FOO.0 = 99; };
+//~^ ERROR could not evaluate static initializer
+
+fn main() {}

--- a/src/test/ui/consts/static_mut_containing_mut_ref3.stderr
+++ b/src/test/ui/consts/static_mut_containing_mut_ref3.stderr
@@ -1,0 +1,9 @@
+error[E0080]: could not evaluate static initializer
+  --> $DIR/static_mut_containing_mut_ref3.rs:5:31
+   |
+LL | static mut BAR: () = unsafe { FOO.0 = 99; };
+   |                               ^^^^^^^^^^ tried to modify a static's initial value from another static's initializer
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/issues/issue-56199.rs
+++ b/src/test/ui/issues/issue-56199.rs
@@ -1,0 +1,23 @@
+
+enum Foo {}
+struct Bar {}
+
+impl Foo {
+    fn foo() {
+        let _ = Self;
+        //~^ ERROR the `Self` constructor can only be used with tuple structs
+        let _ = Self();
+        //~^ ERROR the `Self` constructor can only be used with tuple structs
+    }
+}
+
+impl Bar {
+    fn bar() {
+        let _ = Self;
+        //~^ ERROR the `Self` constructor can only be used with tuple structs
+        let _ = Self();
+        //~^ ERROR the `Self` constructor can only be used with tuple structs
+    }
+}
+
+fn main() {}

--- a/src/test/ui/issues/issue-56199.rs
+++ b/src/test/ui/issues/issue-56199.rs
@@ -5,18 +5,18 @@ struct Bar {}
 impl Foo {
     fn foo() {
         let _ = Self;
-        //~^ ERROR the `Self` constructor can only be used with tuple structs
+        //~^ ERROR the `Self` constructor can only be used with tuple or unit structs
         let _ = Self();
-        //~^ ERROR the `Self` constructor can only be used with tuple structs
+        //~^ ERROR the `Self` constructor can only be used with tuple or unit structs
     }
 }
 
 impl Bar {
     fn bar() {
         let _ = Self;
-        //~^ ERROR the `Self` constructor can only be used with tuple structs
+        //~^ ERROR the `Self` constructor can only be used with tuple or unit structs
         let _ = Self();
-        //~^ ERROR the `Self` constructor can only be used with tuple structs
+        //~^ ERROR the `Self` constructor can only be used with tuple or unit structs
     }
 }
 

--- a/src/test/ui/issues/issue-56199.stderr
+++ b/src/test/ui/issues/issue-56199.stderr
@@ -1,4 +1,4 @@
-error: the `Self` constructor can only be used with tuple structs
+error: the `Self` constructor can only be used with tuple or unit structs
   --> $DIR/issue-56199.rs:7:17
    |
 LL |         let _ = Self;
@@ -6,7 +6,7 @@ LL |         let _ = Self;
    |
    = note: did you mean to use one of the enum's variants?
 
-error: the `Self` constructor can only be used with tuple structs
+error: the `Self` constructor can only be used with tuple or unit structs
   --> $DIR/issue-56199.rs:9:17
    |
 LL |         let _ = Self();
@@ -14,13 +14,13 @@ LL |         let _ = Self();
    |
    = note: did you mean to use one of the enum's variants?
 
-error: the `Self` constructor can only be used with tuple structs
+error: the `Self` constructor can only be used with tuple or unit structs
   --> $DIR/issue-56199.rs:16:17
    |
 LL |         let _ = Self;
    |                 ^^^^ did you mean `Self { /* fields */ }`?
 
-error: the `Self` constructor can only be used with tuple structs
+error: the `Self` constructor can only be used with tuple or unit structs
   --> $DIR/issue-56199.rs:18:17
    |
 LL |         let _ = Self();

--- a/src/test/ui/issues/issue-56199.stderr
+++ b/src/test/ui/issues/issue-56199.stderr
@@ -1,0 +1,30 @@
+error: the `Self` constructor can only be used with tuple structs
+  --> $DIR/issue-56199.rs:7:17
+   |
+LL |         let _ = Self;
+   |                 ^^^^
+   |
+   = note: did you mean to use one of the enum's variants?
+
+error: the `Self` constructor can only be used with tuple structs
+  --> $DIR/issue-56199.rs:9:17
+   |
+LL |         let _ = Self();
+   |                 ^^^^
+   |
+   = note: did you mean to use one of the enum's variants?
+
+error: the `Self` constructor can only be used with tuple structs
+  --> $DIR/issue-56199.rs:16:17
+   |
+LL |         let _ = Self;
+   |                 ^^^^ did you mean `Self { /* fields */ }`?
+
+error: the `Self` constructor can only be used with tuple structs
+  --> $DIR/issue-56199.rs:18:17
+   |
+LL |         let _ = Self();
+   |                 ^^^^ did you mean `Self { /* fields */ }`?
+
+error: aborting due to 4 previous errors
+

--- a/src/test/ui/issues/issue-56835.rs
+++ b/src/test/ui/issues/issue-56835.rs
@@ -1,0 +1,10 @@
+
+pub struct Foo {}
+
+impl Foo {
+    fn bar(Self(foo): Self) {}
+    //~^ ERROR the `Self` constructor can only be used with tuple structs
+    //~^^ ERROR expected tuple struct/variant, found self constructor `Self` [E0164]
+}
+
+fn main() {}

--- a/src/test/ui/issues/issue-56835.rs
+++ b/src/test/ui/issues/issue-56835.rs
@@ -3,7 +3,7 @@ pub struct Foo {}
 
 impl Foo {
     fn bar(Self(foo): Self) {}
-    //~^ ERROR the `Self` constructor can only be used with tuple structs
+    //~^ ERROR the `Self` constructor can only be used with tuple or unit structs
     //~^^ ERROR expected tuple struct/variant, found self constructor `Self` [E0164]
 }
 

--- a/src/test/ui/issues/issue-56835.stderr
+++ b/src/test/ui/issues/issue-56835.stderr
@@ -1,4 +1,4 @@
-error: the `Self` constructor can only be used with tuple structs
+error: the `Self` constructor can only be used with tuple or unit structs
   --> $DIR/issue-56835.rs:5:12
    |
 LL |     fn bar(Self(foo): Self) {}

--- a/src/test/ui/issues/issue-56835.stderr
+++ b/src/test/ui/issues/issue-56835.stderr
@@ -1,0 +1,15 @@
+error: the `Self` constructor can only be used with tuple structs
+  --> $DIR/issue-56835.rs:5:12
+   |
+LL |     fn bar(Self(foo): Self) {}
+   |            ^^^^^^^^^ did you mean `Self { /* fields */ }`?
+
+error[E0164]: expected tuple struct/variant, found self constructor `Self`
+  --> $DIR/issue-56835.rs:5:12
+   |
+LL |     fn bar(Self(foo): Self) {}
+   |            ^^^^^^^^^ not a tuple variant or struct
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0164`.

--- a/src/test/ui/traits/trait-object-with-self-in-projection-output-bad.rs
+++ b/src/test/ui/traits/trait-object-with-self-in-projection-output-bad.rs
@@ -1,3 +1,7 @@
+// Regression test for #56288. Checks that if a supertrait defines an associated type
+// projection that references `Self`, then that associated type must still be explicitly
+// specified in the `dyn Trait` variant, since we don't know what `Self` is anymore.
+
 trait Base {
     type Output;
 }
@@ -16,7 +20,31 @@ impl Helper for u32
     type Target = i32;
 }
 
+trait ConstI32 {
+    type Out;
+}
+
+impl<T: ?Sized> ConstI32 for T {
+    type Out = i32;
+}
+
+// Test that you still need to manually give a projection type if the Output type
+// is normalizable.
+trait NormalizableHelper:
+    Base<Output=<Self as ConstI32>::Out>
+{
+    type Target;
+}
+
+impl NormalizableHelper for u32
+{
+    type Target = i32;
+}
+
 fn main() {
     let _x: Box<dyn Helper<Target=i32>> = Box::new(2u32);
+    //~^ ERROR the value of the associated type `Output` (from the trait `Base`) must be specified
+
+    let _y: Box<dyn NormalizableHelper<Target=i32>> = Box::new(2u32);
     //~^ ERROR the value of the associated type `Output` (from the trait `Base`) must be specified
 }

--- a/src/test/ui/traits/trait-object-with-self-in-projection-output-bad.rs
+++ b/src/test/ui/traits/trait-object-with-self-in-projection-output-bad.rs
@@ -1,0 +1,22 @@
+trait Base {
+    type Output;
+}
+
+trait Helper: Base<Output=<Self as Helper>::Target> {
+    type Target;
+}
+
+impl Base for u32
+{
+    type Output = i32;
+}
+
+impl Helper for u32
+{
+    type Target = i32;
+}
+
+fn main() {
+    let _x: Box<dyn Helper<Target=i32>> = Box::new(2u32);
+    //~^ ERROR the value of the associated type `Output` (from the trait `Base`) must be specified
+}

--- a/src/test/ui/traits/trait-object-with-self-in-projection-output-bad.stderr
+++ b/src/test/ui/traits/trait-object-with-self-in-projection-output-bad.stderr
@@ -1,5 +1,5 @@
 error[E0191]: the value of the associated type `Output` (from the trait `Base`) must be specified
-  --> $DIR/trait-object-with-self-in-projection-output-bad.rs:20:17
+  --> $DIR/trait-object-with-self-in-projection-output-bad.rs:45:17
    |
 LL |     type Output;
    |     ------------ `Output` defined here
@@ -7,6 +7,15 @@ LL |     type Output;
 LL |     let _x: Box<dyn Helper<Target=i32>> = Box::new(2u32);
    |                 ^^^^^^^^^^^^^^^^^^^^^^ associated type `Output` must be specified
 
-error: aborting due to previous error
+error[E0191]: the value of the associated type `Output` (from the trait `Base`) must be specified
+  --> $DIR/trait-object-with-self-in-projection-output-bad.rs:48:17
+   |
+LL |     type Output;
+   |     ------------ `Output` defined here
+...
+LL |     let _y: Box<dyn NormalizableHelper<Target=i32>> = Box::new(2u32);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ associated type `Output` must be specified
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0191`.

--- a/src/test/ui/traits/trait-object-with-self-in-projection-output-bad.stderr
+++ b/src/test/ui/traits/trait-object-with-self-in-projection-output-bad.stderr
@@ -1,0 +1,12 @@
+error[E0191]: the value of the associated type `Output` (from the trait `Base`) must be specified
+  --> $DIR/trait-object-with-self-in-projection-output-bad.rs:20:17
+   |
+LL |     type Output;
+   |     ------------ `Output` defined here
+...
+LL |     let _x: Box<dyn Helper<Target=i32>> = Box::new(2u32);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^ associated type `Output` must be specified
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0191`.

--- a/src/test/ui/traits/trait-object-with-self-in-projection-output-good.rs
+++ b/src/test/ui/traits/trait-object-with-self-in-projection-output-good.rs
@@ -1,0 +1,23 @@
+// compile-pass
+
+trait Base {
+    type Output;
+}
+
+trait Helper: Base<Output=<Self as Helper>::Target> {
+    type Target;
+}
+
+impl Base for u32
+{
+    type Output = i32;
+}
+
+impl Helper for u32
+{
+    type Target = i32;
+}
+
+fn main() {
+    let _x: Box<dyn Helper<Target=i32, Output=i32>> = Box::new(2u32);
+}

--- a/src/test/ui/traits/trait-object-with-self-in-projection-output-good.rs
+++ b/src/test/ui/traits/trait-object-with-self-in-projection-output-good.rs
@@ -1,5 +1,10 @@
 // compile-pass
 
+// Regression test related to #56288. Check that a supertrait projection (of
+// `Output`) that references `Self` can be ok if it is referencing a projection (of
+// `Self::Target`, in this case). Note that we still require the user to manually
+// specify both `Target` and `Output` for now.
+
 trait Base {
     type Output;
 }

--- a/src/test/ui/traits/trait-object-with-self-in-projection-output-repeated-supertrait.rs
+++ b/src/test/ui/traits/trait-object-with-self-in-projection-output-repeated-supertrait.rs
@@ -1,0 +1,48 @@
+// compile-pass
+
+// Regression test related to #56288. Check that a supertrait projection (of
+// `Output`) that references `Self` is ok if there is another occurence of
+// the same supertrait that specifies the projection explicitly, even if
+// the projection's associated type is not explicitly specified in the object type.
+//
+// Note that in order for this to compile, we need the `Self`-referencing projection
+// to normalize fairly directly to a concrete type, otherwise the trait resolver
+// will hate us.
+//
+// There is a test in `trait-object-with-self-in-projection-output-bad.rs` that
+// having a normalizing, but `Self`-containing projection does not *by itself*
+// allow you to avoid writing the projected type (`Output`, in this example)
+// explicitly.
+
+trait ConstI32 {
+    type Out;
+}
+
+impl<T: ?Sized> ConstI32 for T {
+    type Out = i32;
+}
+
+trait Base {
+    type Output;
+}
+
+trait NormalizingHelper: Base<Output=<Self as ConstI32>::Out> + Base<Output=i32> {
+    type Target;
+}
+
+impl Base for u32
+{
+    type Output = i32;
+}
+
+impl NormalizingHelper for u32
+{
+    type Target = i32;
+}
+
+fn main() {
+    // Make sure this works both with and without the associated type
+    // being specified.
+    let _x: Box<dyn NormalizingHelper<Target=i32>> = Box::new(2u32);
+    let _y: Box<dyn NormalizingHelper<Target=i32, Output=i32>> = Box::new(2u32);
+}

--- a/src/test/ui/write-to-static-mut-in-static.rs
+++ b/src/test/ui/write-to-static-mut-in-static.rs
@@ -12,10 +12,10 @@
 
 pub static mut A: u32 = 0;
 pub static mut B: () = unsafe { A = 1; };
-//~^ ERROR cannot mutate statics in the initializer of another static
+//~^ ERROR could not evaluate static initializer
 
 pub static mut C: u32 = unsafe { C = 1; 0 };
-//~^ ERROR cannot mutate statics in the initializer of another static
+//~^ ERROR cycle detected
 
 pub static D: u32 = D;
 

--- a/src/test/ui/write-to-static-mut-in-static.stderr
+++ b/src/test/ui/write-to-static-mut-in-static.stderr
@@ -1,14 +1,28 @@
-error: cannot mutate statics in the initializer of another static
+error[E0080]: could not evaluate static initializer
   --> $DIR/write-to-static-mut-in-static.rs:14:33
    |
 LL | pub static mut B: () = unsafe { A = 1; };
-   |                                 ^^^^^
+   |                                 ^^^^^ tried to modify a static's initial value from another static's initializer
 
-error: cannot mutate statics in the initializer of another static
+error[E0391]: cycle detected when const-evaluating `C`
   --> $DIR/write-to-static-mut-in-static.rs:17:34
    |
 LL | pub static mut C: u32 = unsafe { C = 1; 0 };
    |                                  ^^^^^
+   |
+note: ...which requires const-evaluating `C`...
+  --> $DIR/write-to-static-mut-in-static.rs:17:1
+   |
+LL | pub static mut C: u32 = unsafe { C = 1; 0 };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: ...which again requires const-evaluating `C`, completing the cycle
+note: cycle used when const-evaluating + checking `C`
+  --> $DIR/write-to-static-mut-in-static.rs:17:1
+   |
+LL | pub static mut C: u32 = unsafe { C = 1; 0 };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 
+Some errors occurred: E0080, E0391.
+For more information about an error, try `rustc --explain E0080`.


### PR DESCRIPTION
* #56919: Remove a wrong multiplier on relocation offset computation
* #56916: Fix mutable references in `static mut`
* #56863: fix trait objects with a Self-containing projection values
* #56850: Fixed issue with using `Self` ctor in typedefs 

r? @ghost