### PR TITLE
Use platform-dependent mcount function

### DIFF
--- a/src/librustc_codegen_llvm/attributes.rs
+++ b/src/librustc_codegen_llvm/attributes.rs
@@ -84,9 +84,22 @@ pub fn set_instrument_function(cx: &CodegenCx<'ll, '_>, llfn: &'ll Value) {
     if cx.sess().instrument_mcount() {
         // Similar to `clang -pg` behavior. Handled by the
         // `post-inline-ee-instrument` LLVM pass.
+
+        // The function name varies on platforms.
+        // See test/CodeGen/mcount.c in clang.
+        let mcount_name = if cfg!(target_os = "netbsd") {
+            const_cstr!("__mcount")
+        } else if cfg!(any(
+                target_arch = "mips", target_arch = "mips64",
+                target_arch = "powerpc", target_arch = "powerpc64")) {
+            const_cstr!("_mcount")
+        } else {
+            const_cstr!("mcount")
+        };
+
         llvm::AddFunctionAttrStringValue(
             llfn, llvm::AttributePlace::Function,
-            const_cstr!("instrument-function-entry-inlined"), const_cstr!("mcount"));
+            const_cstr!("instrument-function-entry-inlined"), mcount_name);
     }
 }
 

--- a/src/test/codegen/instrument-mcount.rs
+++ b/src/test/codegen/instrument-mcount.rs
@@ -1,0 +1,7 @@
+// ignore-tidy-linelength
+// compile-flags: -Z instrument-mcount
+
+#![crate_type = "lib"]
+
+// CHECK: attributes #{{.*}} "instrument-function-entry-inlined"="{{_*}}mcount" "no-frame-pointer-elim"="true"
+pub fn foo() {}


### PR DESCRIPTION
Follow up with @nagisa's comment on #57220. Not all platforms use the
`mcount` name. Added a test.