### PR TITLE
Optimize `Vec`'s `IntoIter`'s methods

### DIFF
--- a/src/liballoc/tests/vec.rs
+++ b/src/liballoc/tests/vec.rs
@@ -698,8 +698,37 @@ fn test_into_iter_debug() {
 }
 
 #[test]
+fn test_into_iter_len() {
+    let mut into_iter = vec![1, 2, 3].into_iter();
+    assert_eq!(into_iter.len(), 3);
+    into_iter.next();
+    assert_eq!(into_iter.len(), 2);
+}
+
+#[test]
 fn test_into_iter_count() {
     assert_eq!(vec![1, 2, 3].into_iter().count(), 3);
+}
+
+#[test]
+fn test_into_iter_nth() {
+    let mut into_iter = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10].into_iter();
+    assert_eq!(into_iter.nth(0), Some(1));
+    assert_eq!(into_iter.nth(2), Some(4));
+    assert_eq!(into_iter.nth(1), Some(6));
+    assert_eq!(into_iter.nth(3), Some(10));
+    assert_eq!(into_iter.nth(3), None);
+    assert_eq!(into_iter.nth(3), None);
+}
+
+#[test]
+fn test_into_iter_next_back() {
+    let mut into_iter = vec![1, 2, 3].into_iter();
+    assert_eq!(into_iter.next_back(), Some(3));
+    assert_eq!(into_iter.next_back(), Some(2));
+    assert_eq!(into_iter.next_back(), Some(1));
+    assert_eq!(into_iter.next_back(), None);
+    assert_eq!(into_iter.next_back(), None);
 }
 
 #[test]

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2340,17 +2340,18 @@ impl<T> Iterator for IntoIter<T> {
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let exact = if mem::size_of::<T>() == 0 {
-            (self.end as usize).wrapping_sub(self.ptr as usize)
-        } else {
-            unsafe { self.end.offset_from(self.ptr) as usize }
-        };
+        let exact = self.len();
         (exact, Some(exact))
     }
 
     #[inline]
     fn count(self) -> usize {
         self.len()
+    }
+
+    #[inline]
+    fn last(mut self) -> Option<T> {
+        self.next_back()
     }
 }
 
@@ -2380,6 +2381,14 @@ impl<T> DoubleEndedIterator for IntoIter<T> {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T> ExactSizeIterator for IntoIter<T> {
+    fn len(&self) -> usize {
+        if mem::size_of::<T>() == 0 {
+            (self.end as usize).wrapping_sub(self.ptr as usize)
+        } else {
+            unsafe { self.end.offset_from(self.ptr) as usize }
+        }
+    }
+
     fn is_empty(&self) -> bool {
         self.ptr == self.end
     }


### PR DESCRIPTION
In particular `nth` and `last`.  To do: implement `nth_back`.