### PR TITLE
src/jemalloc is gone, remove its mention from COPYRIGHT

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -229,35 +229,3 @@ their own copyright notices and license terms:
     NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
     USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
     OF SUCH DAMAGE.  */
-
-* jemalloc, under src/jemalloc:
-
-    Copyright (C) 2002-2014 Jason Evans
-    <jasone@canonware.com>. All rights reserved.
-    Copyright (C) 2007-2012 Mozilla Foundation.
-    All rights reserved.
-    Copyright (C) 2009-2014 Facebook, Inc.
-    All rights reserved.
-
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    1. Redistributions of source code must retain the above copyright notice(s),
-       this list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright notice(s),
-       this list of conditions and the following disclaimer in the documentation
-       and/or other materials provided with the distribution.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER(S)
-    ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-    MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER(S)
-    BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-    EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-    HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
-    IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-    NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-    USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
-    OF SUCH DAMAGE.


### PR DESCRIPTION
The `src/jemalloc` submodule was removed in 61e89446ef6e115630faa75c985c599d739f7586 / https://github.com/rust-lang/rust/pull/55238.