### PR TITLE
Make sure feature gate errors are recoverable (take 2)

### DIFF
--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -2839,7 +2839,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
             self.impl_polarity(def_id1) == self.impl_polarity(def_id2)
                 && trait1_is_empty
                 && trait2_is_empty
-        } else if self.features().marker_trait_attr {
+        } else {
             let is_marker_impl = |def_id: DefId| -> bool {
                 let trait_ref = self.impl_trait_ref(def_id);
                 trait_ref.map_or(false, |tr| self.trait_def(tr.def_id).is_marker)
@@ -2847,8 +2847,6 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
             self.impl_polarity(def_id1) == self.impl_polarity(def_id2)
                 && is_marker_impl(def_id1)
                 && is_marker_impl(def_id2)
-        } else {
-            false
         };
 
         if is_legit {

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -1098,23 +1098,20 @@ where
         ast_validation::check_crate(sess, &krate)
     });
 
-    time(sess, "name resolution", || -> CompileResult {
+    time(sess, "name resolution", || {
         resolver.resolve_crate(&krate);
-        Ok(())
-    })?;
+    });
 
     // Needs to go *after* expansion to be able to check the results of macro expansion.
     time(sess, "complete gated feature checking", || {
-        sess.track_errors(|| {
-            syntax::feature_gate::check_crate(
-                &krate,
-                &sess.parse_sess,
-                &sess.features_untracked(),
-                &attributes,
-                sess.opts.unstable_features,
-            );
-        })
-    })?;
+        syntax::feature_gate::check_crate(
+            &krate,
+            &sess.parse_sess,
+            &sess.features_untracked(),
+            &attributes,
+            sess.opts.unstable_features,
+        );
+    });
 
     // Lower ast -> hir.
     // First, we need to collect the dep_graph.

--- a/src/test/ui/conditional-compilation/cfg-attr-crate-2.rs
+++ b/src/test/ui/conditional-compilation/cfg-attr-crate-2.rs
@@ -1,8 +1,8 @@
-//
-// compile-flags: --cfg broken
-
 // https://github.com/rust-lang/rust/issues/21833#issuecomment-72353044
 
+// compile-flags: --cfg broken
+
+#![crate_type = "lib"]
 #![cfg_attr(broken, no_core)] //~ ERROR no_core is experimental
 
-fn main() { }
+pub struct S {}

--- a/src/test/ui/conditional-compilation/cfg-attr-multi-invalid-1.rs
+++ b/src/test/ui/conditional-compilation/cfg-attr-multi-invalid-1.rs
@@ -1,7 +1,7 @@
-//
 // compile-flags: --cfg broken
 
 #![feature(cfg_attr_multi)]
+#![crate_type = "lib"]
 #![cfg_attr(broken, no_core, no_std)] //~ ERROR no_core is experimental
 
-fn main() { }
+pub struct S {}

--- a/src/test/ui/conditional-compilation/cfg-attr-multi-invalid-2.rs
+++ b/src/test/ui/conditional-compilation/cfg-attr-multi-invalid-2.rs
@@ -1,7 +1,7 @@
-//
 // compile-flags: --cfg broken
 
 #![feature(cfg_attr_multi)]
+#![crate_type = "lib"]
 #![cfg_attr(broken, no_std, no_core)] //~ ERROR no_core is experimental
 
-fn main() { }
+pub struct S {}

--- a/src/test/ui/feature-gates/feature-gate-abi.rs
+++ b/src/test/ui/feature-gates/feature-gate-abi.rs
@@ -1,3 +1,4 @@
+// only-x86_64
 // ignore-tidy-linelength
 // gate-test-intrinsics
 // gate-test-platform_intrinsics

--- a/src/test/ui/feature-gates/feature-gate-abi.stderr
+++ b/src/test/ui/feature-gates/feature-gate-abi.stderr
@@ -1,5 +1,5 @@
 error[E0658]: intrinsics are subject to change
-  --> $DIR/feature-gate-abi.rs:11:1
+  --> $DIR/feature-gate-abi.rs:12:1
    |
 LL | extern "rust-intrinsic" fn f1() {} //~ ERROR intrinsics are subject to change
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL | extern "rust-intrinsic" fn f1() {} //~ ERROR intrinsics are subject to chan
    = help: add #![feature(intrinsics)] to the crate attributes to enable
 
 error[E0658]: platform intrinsics are experimental and possibly buggy (see issue #27731)
-  --> $DIR/feature-gate-abi.rs:12:1
+  --> $DIR/feature-gate-abi.rs:13:1
    |
 LL | extern "platform-intrinsic" fn f2() {} //~ ERROR platform intrinsics are experimental
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -15,7 +15,7 @@ LL | extern "platform-intrinsic" fn f2() {} //~ ERROR platform intrinsics are ex
    = help: add #![feature(platform_intrinsics)] to the crate attributes to enable
 
 error[E0658]: vectorcall is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:13:1
+  --> $DIR/feature-gate-abi.rs:14:1
    |
 LL | extern "vectorcall" fn f3() {} //~ ERROR vectorcall is experimental and subject to change
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -23,7 +23,7 @@ LL | extern "vectorcall" fn f3() {} //~ ERROR vectorcall is experimental and sub
    = help: add #![feature(abi_vectorcall)] to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change (see issue #29625)
-  --> $DIR/feature-gate-abi.rs:14:1
+  --> $DIR/feature-gate-abi.rs:15:1
    |
 LL | extern "rust-call" fn f4() {} //~ ERROR rust-call ABI is subject to change
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -31,7 +31,7 @@ LL | extern "rust-call" fn f4() {} //~ ERROR rust-call ABI is subject to change
    = help: add #![feature(unboxed_closures)] to the crate attributes to enable
 
 error[E0658]: msp430-interrupt ABI is experimental and subject to change (see issue #38487)
-  --> $DIR/feature-gate-abi.rs:15:1
+  --> $DIR/feature-gate-abi.rs:16:1
    |
 LL | extern "msp430-interrupt" fn f5() {} //~ ERROR msp430-interrupt ABI is experimental
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -39,7 +39,7 @@ LL | extern "msp430-interrupt" fn f5() {} //~ ERROR msp430-interrupt ABI is expe
    = help: add #![feature(abi_msp430_interrupt)] to the crate attributes to enable
 
 error[E0658]: PTX ABIs are experimental and subject to change (see issue #38788)
-  --> $DIR/feature-gate-abi.rs:16:1
+  --> $DIR/feature-gate-abi.rs:17:1
    |
 LL | extern "ptx-kernel" fn f6() {} //~ ERROR PTX ABIs are experimental and subject to change
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -47,7 +47,7 @@ LL | extern "ptx-kernel" fn f6() {} //~ ERROR PTX ABIs are experimental and subj
    = help: add #![feature(abi_ptx)] to the crate attributes to enable
 
 error[E0658]: x86-interrupt ABI is experimental and subject to change (see issue #40180)
-  --> $DIR/feature-gate-abi.rs:17:1
+  --> $DIR/feature-gate-abi.rs:18:1
    |
 LL | extern "x86-interrupt" fn f7() {} //~ ERROR x86-interrupt ABI is experimental
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -55,7 +55,7 @@ LL | extern "x86-interrupt" fn f7() {} //~ ERROR x86-interrupt ABI is experiment
    = help: add #![feature(abi_x86_interrupt)] to the crate attributes to enable
 
 error[E0658]: thiscall is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:18:1
+  --> $DIR/feature-gate-abi.rs:19:1
    |
 LL | extern "thiscall" fn f8() {} //~ ERROR thiscall is experimental and subject to change
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -63,7 +63,7 @@ LL | extern "thiscall" fn f8() {} //~ ERROR thiscall is experimental and subject
    = help: add #![feature(abi_thiscall)] to the crate attributes to enable
 
 error[E0658]: amdgpu-kernel ABI is experimental and subject to change (see issue #51575)
-  --> $DIR/feature-gate-abi.rs:19:1
+  --> $DIR/feature-gate-abi.rs:20:1
    |
 LL | extern "amdgpu-kernel" fn f9() {} //~ ERROR amdgpu-kernel ABI is experimental and subject to change
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -71,7 +71,7 @@ LL | extern "amdgpu-kernel" fn f9() {} //~ ERROR amdgpu-kernel ABI is experiment
    = help: add #![feature(abi_amdgpu_kernel)] to the crate attributes to enable
 
 error[E0658]: intrinsics are subject to change
-  --> $DIR/feature-gate-abi.rs:23:5
+  --> $DIR/feature-gate-abi.rs:24:5
    |
 LL |     extern "rust-intrinsic" fn m1(); //~ ERROR intrinsics are subject to change
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -79,7 +79,7 @@ LL |     extern "rust-intrinsic" fn m1(); //~ ERROR intrinsics are subject to ch
    = help: add #![feature(intrinsics)] to the crate attributes to enable
 
 error[E0658]: platform intrinsics are experimental and possibly buggy (see issue #27731)
-  --> $DIR/feature-gate-abi.rs:24:5
+  --> $DIR/feature-gate-abi.rs:25:5
    |
 LL |     extern "platform-intrinsic" fn m2(); //~ ERROR platform intrinsics are experimental
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -87,7 +87,7 @@ LL |     extern "platform-intrinsic" fn m2(); //~ ERROR platform intrinsics are 
    = help: add #![feature(platform_intrinsics)] to the crate attributes to enable
 
 error[E0658]: vectorcall is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:25:5
+  --> $DIR/feature-gate-abi.rs:26:5
    |
 LL |     extern "vectorcall" fn m3(); //~ ERROR vectorcall is experimental and subject to change
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -95,7 +95,7 @@ LL |     extern "vectorcall" fn m3(); //~ ERROR vectorcall is experimental and s
    = help: add #![feature(abi_vectorcall)] to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change (see issue #29625)
-  --> $DIR/feature-gate-abi.rs:26:5
+  --> $DIR/feature-gate-abi.rs:27:5
    |
 LL |     extern "rust-call" fn m4(); //~ ERROR rust-call ABI is subject to change
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -103,7 +103,7 @@ LL |     extern "rust-call" fn m4(); //~ ERROR rust-call ABI is subject to chang
    = help: add #![feature(unboxed_closures)] to the crate attributes to enable
 
 error[E0658]: msp430-interrupt ABI is experimental and subject to change (see issue #38487)
-  --> $DIR/feature-gate-abi.rs:27:5
+  --> $DIR/feature-gate-abi.rs:28:5
    |
 LL |     extern "msp430-interrupt" fn m5(); //~ ERROR msp430-interrupt ABI is experimental
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -111,7 +111,7 @@ LL |     extern "msp430-interrupt" fn m5(); //~ ERROR msp430-interrupt ABI is ex
    = help: add #![feature(abi_msp430_interrupt)] to the crate attributes to enable
 
 error[E0658]: PTX ABIs are experimental and subject to change (see issue #38788)
-  --> $DIR/feature-gate-abi.rs:28:5
+  --> $DIR/feature-gate-abi.rs:29:5
    |
 LL |     extern "ptx-kernel" fn m6(); //~ ERROR PTX ABIs are experimental and subject to change
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -119,7 +119,7 @@ LL |     extern "ptx-kernel" fn m6(); //~ ERROR PTX ABIs are experimental and su
    = help: add #![feature(abi_ptx)] to the crate attributes to enable
 
 error[E0658]: x86-interrupt ABI is experimental and subject to change (see issue #40180)
-  --> $DIR/feature-gate-abi.rs:29:5
+  --> $DIR/feature-gate-abi.rs:30:5
    |
 LL |     extern "x86-interrupt" fn m7(); //~ ERROR x86-interrupt ABI is experimental
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -127,7 +127,7 @@ LL |     extern "x86-interrupt" fn m7(); //~ ERROR x86-interrupt ABI is experime
    = help: add #![feature(abi_x86_interrupt)] to the crate attributes to enable
 
 error[E0658]: thiscall is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:30:5
+  --> $DIR/feature-gate-abi.rs:31:5
    |
 LL |     extern "thiscall" fn m8(); //~ ERROR thiscall is experimental and subject to change
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -135,7 +135,7 @@ LL |     extern "thiscall" fn m8(); //~ ERROR thiscall is experimental and subje
    = help: add #![feature(abi_thiscall)] to the crate attributes to enable
 
 error[E0658]: amdgpu-kernel ABI is experimental and subject to change (see issue #51575)
-  --> $DIR/feature-gate-abi.rs:31:5
+  --> $DIR/feature-gate-abi.rs:32:5
    |
 LL |     extern "amdgpu-kernel" fn m9(); //~ ERROR amdgpu-kernel ABI is experimental and subject to change
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -143,7 +143,7 @@ LL |     extern "amdgpu-kernel" fn m9(); //~ ERROR amdgpu-kernel ABI is experime
    = help: add #![feature(abi_amdgpu_kernel)] to the crate attributes to enable
 
 error[E0658]: intrinsics are subject to change
-  --> $DIR/feature-gate-abi.rs:33:5
+  --> $DIR/feature-gate-abi.rs:34:5
    |
 LL |     extern "rust-intrinsic" fn dm1() {} //~ ERROR intrinsics are subject to change
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -151,7 +151,7 @@ LL |     extern "rust-intrinsic" fn dm1() {} //~ ERROR intrinsics are subject to
    = help: add #![feature(intrinsics)] to the crate attributes to enable
 
 error[E0658]: platform intrinsics are experimental and possibly buggy (see issue #27731)
-  --> $DIR/feature-gate-abi.rs:34:5
+  --> $DIR/feature-gate-abi.rs:35:5
    |
 LL |     extern "platform-intrinsic" fn dm2() {} //~ ERROR platform intrinsics are experimental
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -159,7 +159,7 @@ LL |     extern "platform-intrinsic" fn dm2() {} //~ ERROR platform intrinsics a
    = help: add #![feature(platform_intrinsics)] to the crate attributes to enable
 
 error[E0658]: vectorcall is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:35:5
+  --> $DIR/feature-gate-abi.rs:36:5
    |
 LL |     extern "vectorcall" fn dm3() {} //~ ERROR vectorcall is experimental and subject to change
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -167,7 +167,7 @@ LL |     extern "vectorcall" fn dm3() {} //~ ERROR vectorcall is experimental an
    = help: add #![feature(abi_vectorcall)] to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change (see issue #29625)
-  --> $DIR/feature-gate-abi.rs:36:5
+  --> $DIR/feature-gate-abi.rs:37:5
    |
 LL |     extern "rust-call" fn dm4() {} //~ ERROR rust-call ABI is subject to change
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -175,7 +175,7 @@ LL |     extern "rust-call" fn dm4() {} //~ ERROR rust-call ABI is subject to ch
    = help: add #![feature(unboxed_closures)] to the crate attributes to enable
 
 error[E0658]: msp430-interrupt ABI is experimental and subject to change (see issue #38487)
-  --> $DIR/feature-gate-abi.rs:37:5
+  --> $DIR/feature-gate-abi.rs:38:5
    |
 LL |     extern "msp430-interrupt" fn dm5() {} //~ ERROR msp430-interrupt ABI is experimental
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -183,7 +183,7 @@ LL |     extern "msp430-interrupt" fn dm5() {} //~ ERROR msp430-interrupt ABI is
    = help: add #![feature(abi_msp430_interrupt)] to the crate attributes to enable
 
 error[E0658]: PTX ABIs are experimental and subject to change (see issue #38788)
-  --> $DIR/feature-gate-abi.rs:38:5
+  --> $DIR/feature-gate-abi.rs:39:5
    |
 LL |     extern "ptx-kernel" fn dm6() {} //~ ERROR PTX ABIs are experimental and subject to change
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -191,7 +191,7 @@ LL |     extern "ptx-kernel" fn dm6() {} //~ ERROR PTX ABIs are experimental and
    = help: add #![feature(abi_ptx)] to the crate attributes to enable
 
 error[E0658]: x86-interrupt ABI is experimental and subject to change (see issue #40180)
-  --> $DIR/feature-gate-abi.rs:39:5
+  --> $DIR/feature-gate-abi.rs:40:5
    |
 LL |     extern "x86-interrupt" fn dm7() {} //~ ERROR x86-interrupt ABI is experimental
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -199,7 +199,7 @@ LL |     extern "x86-interrupt" fn dm7() {} //~ ERROR x86-interrupt ABI is exper
    = help: add #![feature(abi_x86_interrupt)] to the crate attributes to enable
 
 error[E0658]: thiscall is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:40:5
+  --> $DIR/feature-gate-abi.rs:41:5
    |
 LL |     extern "thiscall" fn dm8() {} //~ ERROR thiscall is experimental and subject to change
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -207,7 +207,7 @@ LL |     extern "thiscall" fn dm8() {} //~ ERROR thiscall is experimental and su
    = help: add #![feature(abi_thiscall)] to the crate attributes to enable
 
 error[E0658]: amdgpu-kernel ABI is experimental and subject to change (see issue #51575)
-  --> $DIR/feature-gate-abi.rs:41:5
+  --> $DIR/feature-gate-abi.rs:42:5
    |
 LL |     extern "amdgpu-kernel" fn dm9() {} //~ ERROR amdgpu-kernel ABI is experimental and subject to change
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -215,7 +215,7 @@ LL |     extern "amdgpu-kernel" fn dm9() {} //~ ERROR amdgpu-kernel ABI is exper
    = help: add #![feature(abi_amdgpu_kernel)] to the crate attributes to enable
 
 error[E0658]: intrinsics are subject to change
-  --> $DIR/feature-gate-abi.rs:48:5
+  --> $DIR/feature-gate-abi.rs:49:5
    |
 LL |     extern "rust-intrinsic" fn m1() {} //~ ERROR intrinsics are subject to change
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -223,7 +223,7 @@ LL |     extern "rust-intrinsic" fn m1() {} //~ ERROR intrinsics are subject to 
    = help: add #![feature(intrinsics)] to the crate attributes to enable
 
 error[E0658]: platform intrinsics are experimental and possibly buggy (see issue #27731)
-  --> $DIR/feature-gate-abi.rs:49:5
+  --> $DIR/feature-gate-abi.rs:50:5
    |
 LL |     extern "platform-intrinsic" fn m2() {} //~ ERROR platform intrinsics are experimental
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -231,7 +231,7 @@ LL |     extern "platform-intrinsic" fn m2() {} //~ ERROR platform intrinsics ar
    = help: add #![feature(platform_intrinsics)] to the crate attributes to enable
 
 error[E0658]: vectorcall is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:50:5
+  --> $DIR/feature-gate-abi.rs:51:5
    |
 LL |     extern "vectorcall" fn m3() {} //~ ERROR vectorcall is experimental and subject to change
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -239,7 +239,7 @@ LL |     extern "vectorcall" fn m3() {} //~ ERROR vectorcall is experimental and
    = help: add #![feature(abi_vectorcall)] to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change (see issue #29625)
-  --> $DIR/feature-gate-abi.rs:51:5
+  --> $DIR/feature-gate-abi.rs:52:5
    |
 LL |     extern "rust-call" fn m4() {} //~ ERROR rust-call ABI is subject to change
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -247,7 +247,7 @@ LL |     extern "rust-call" fn m4() {} //~ ERROR rust-call ABI is subject to cha
    = help: add #![feature(unboxed_closures)] to the crate attributes to enable
 
 error[E0658]: msp430-interrupt ABI is experimental and subject to change (see issue #38487)
-  --> $DIR/feature-gate-abi.rs:52:5
+  --> $DIR/feature-gate-abi.rs:53:5
    |
 LL |     extern "msp430-interrupt" fn m5() {} //~ ERROR msp430-interrupt ABI is experimental
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -255,7 +255,7 @@ LL |     extern "msp430-interrupt" fn m5() {} //~ ERROR msp430-interrupt ABI is 
    = help: add #![feature(abi_msp430_interrupt)] to the crate attributes to enable
 
 error[E0658]: PTX ABIs are experimental and subject to change (see issue #38788)
-  --> $DIR/feature-gate-abi.rs:53:5
+  --> $DIR/feature-gate-abi.rs:54:5
    |
 LL |     extern "ptx-kernel" fn m6() {} //~ ERROR PTX ABIs are experimental and subject to change
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -263,7 +263,7 @@ LL |     extern "ptx-kernel" fn m6() {} //~ ERROR PTX ABIs are experimental and 
    = help: add #![feature(abi_ptx)] to the crate attributes to enable
 
 error[E0658]: x86-interrupt ABI is experimental and subject to change (see issue #40180)
-  --> $DIR/feature-gate-abi.rs:54:5
+  --> $DIR/feature-gate-abi.rs:55:5
    |
 LL |     extern "x86-interrupt" fn m7() {} //~ ERROR x86-interrupt ABI is experimental
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -271,7 +271,7 @@ LL |     extern "x86-interrupt" fn m7() {} //~ ERROR x86-interrupt ABI is experi
    = help: add #![feature(abi_x86_interrupt)] to the crate attributes to enable
 
 error[E0658]: thiscall is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:55:5
+  --> $DIR/feature-gate-abi.rs:56:5
    |
 LL |     extern "thiscall" fn m8() {} //~ ERROR thiscall is experimental and subject to change
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -279,7 +279,7 @@ LL |     extern "thiscall" fn m8() {} //~ ERROR thiscall is experimental and sub
    = help: add #![feature(abi_thiscall)] to the crate attributes to enable
 
 error[E0658]: amdgpu-kernel ABI is experimental and subject to change (see issue #51575)
-  --> $DIR/feature-gate-abi.rs:56:5
+  --> $DIR/feature-gate-abi.rs:57:5
    |
 LL |     extern "amdgpu-kernel" fn m9() {} //~ ERROR amdgpu-kernel ABI is experimental and subject to change
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -287,7 +287,7 @@ LL |     extern "amdgpu-kernel" fn m9() {} //~ ERROR amdgpu-kernel ABI is experi
    = help: add #![feature(abi_amdgpu_kernel)] to the crate attributes to enable
 
 error[E0658]: intrinsics are subject to change
-  --> $DIR/feature-gate-abi.rs:61:5
+  --> $DIR/feature-gate-abi.rs:62:5
    |
 LL |     extern "rust-intrinsic" fn im1() {} //~ ERROR intrinsics are subject to change
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -295,7 +295,7 @@ LL |     extern "rust-intrinsic" fn im1() {} //~ ERROR intrinsics are subject to
    = help: add #![feature(intrinsics)] to the crate attributes to enable
 
 error[E0658]: platform intrinsics are experimental and possibly buggy (see issue #27731)
-  --> $DIR/feature-gate-abi.rs:62:5
+  --> $DIR/feature-gate-abi.rs:63:5
    |
 LL |     extern "platform-intrinsic" fn im2() {} //~ ERROR platform intrinsics are experimental
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -303,7 +303,7 @@ LL |     extern "platform-intrinsic" fn im2() {} //~ ERROR platform intrinsics a
    = help: add #![feature(platform_intrinsics)] to the crate attributes to enable
 
 error[E0658]: vectorcall is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:63:5
+  --> $DIR/feature-gate-abi.rs:64:5
    |
 LL |     extern "vectorcall" fn im3() {} //~ ERROR vectorcall is experimental and subject to change
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -311,7 +311,7 @@ LL |     extern "vectorcall" fn im3() {} //~ ERROR vectorcall is experimental an
    = help: add #![feature(abi_vectorcall)] to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change (see issue #29625)
-  --> $DIR/feature-gate-abi.rs:64:5
+  --> $DIR/feature-gate-abi.rs:65:5
    |
 LL |     extern "rust-call" fn im4() {} //~ ERROR rust-call ABI is subject to change
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -319,7 +319,7 @@ LL |     extern "rust-call" fn im4() {} //~ ERROR rust-call ABI is subject to ch
    = help: add #![feature(unboxed_closures)] to the crate attributes to enable
 
 error[E0658]: msp430-interrupt ABI is experimental and subject to change (see issue #38487)
-  --> $DIR/feature-gate-abi.rs:65:5
+  --> $DIR/feature-gate-abi.rs:66:5
    |
 LL |     extern "msp430-interrupt" fn im5() {} //~ ERROR msp430-interrupt ABI is experimental
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -327,7 +327,7 @@ LL |     extern "msp430-interrupt" fn im5() {} //~ ERROR msp430-interrupt ABI is
    = help: add #![feature(abi_msp430_interrupt)] to the crate attributes to enable
 
 error[E0658]: PTX ABIs are experimental and subject to change (see issue #38788)
-  --> $DIR/feature-gate-abi.rs:66:5
+  --> $DIR/feature-gate-abi.rs:67:5
    |
 LL |     extern "ptx-kernel" fn im6() {} //~ ERROR PTX ABIs are experimental and subject to change
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -335,7 +335,7 @@ LL |     extern "ptx-kernel" fn im6() {} //~ ERROR PTX ABIs are experimental and
    = help: add #![feature(abi_ptx)] to the crate attributes to enable
 
 error[E0658]: x86-interrupt ABI is experimental and subject to change (see issue #40180)
-  --> $DIR/feature-gate-abi.rs:67:5
+  --> $DIR/feature-gate-abi.rs:68:5
    |
 LL |     extern "x86-interrupt" fn im7() {} //~ ERROR x86-interrupt ABI is experimental
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -343,7 +343,7 @@ LL |     extern "x86-interrupt" fn im7() {} //~ ERROR x86-interrupt ABI is exper
    = help: add #![feature(abi_x86_interrupt)] to the crate attributes to enable
 
 error[E0658]: thiscall is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:68:5
+  --> $DIR/feature-gate-abi.rs:69:5
    |
 LL |     extern "thiscall" fn im8() {} //~ ERROR thiscall is experimental and subject to change
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -351,7 +351,7 @@ LL |     extern "thiscall" fn im8() {} //~ ERROR thiscall is experimental and su
    = help: add #![feature(abi_thiscall)] to the crate attributes to enable
 
 error[E0658]: amdgpu-kernel ABI is experimental and subject to change (see issue #51575)
-  --> $DIR/feature-gate-abi.rs:69:5
+  --> $DIR/feature-gate-abi.rs:70:5
    |
 LL |     extern "amdgpu-kernel" fn im9() {} //~ ERROR amdgpu-kernel ABI is experimental and subject to change
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -359,7 +359,7 @@ LL |     extern "amdgpu-kernel" fn im9() {} //~ ERROR amdgpu-kernel ABI is exper
    = help: add #![feature(abi_amdgpu_kernel)] to the crate attributes to enable
 
 error[E0658]: intrinsics are subject to change
-  --> $DIR/feature-gate-abi.rs:73:11
+  --> $DIR/feature-gate-abi.rs:74:11
    |
 LL | type A1 = extern "rust-intrinsic" fn(); //~ ERROR intrinsics are subject to change
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -367,7 +367,7 @@ LL | type A1 = extern "rust-intrinsic" fn(); //~ ERROR intrinsics are subject to
    = help: add #![feature(intrinsics)] to the crate attributes to enable
 
 error[E0658]: platform intrinsics are experimental and possibly buggy (see issue #27731)
-  --> $DIR/feature-gate-abi.rs:74:11
+  --> $DIR/feature-gate-abi.rs:75:11
    |
 LL | type A2 = extern "platform-intrinsic" fn(); //~ ERROR platform intrinsics are experimental
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -375,7 +375,7 @@ LL | type A2 = extern "platform-intrinsic" fn(); //~ ERROR platform intrinsics a
    = help: add #![feature(platform_intrinsics)] to the crate attributes to enable
 
 error[E0658]: vectorcall is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:75:11
+  --> $DIR/feature-gate-abi.rs:76:11
    |
 LL | type A3 = extern "vectorcall" fn(); //~ ERROR vectorcall is experimental and subject to change
    |           ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -383,7 +383,7 @@ LL | type A3 = extern "vectorcall" fn(); //~ ERROR vectorcall is experimental an
    = help: add #![feature(abi_vectorcall)] to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change (see issue #29625)
-  --> $DIR/feature-gate-abi.rs:76:11
+  --> $DIR/feature-gate-abi.rs:77:11
    |
 LL | type A4 = extern "rust-call" fn(); //~ ERROR rust-call ABI is subject to change
    |           ^^^^^^^^^^^^^^^^^^^^^^^
@@ -391,7 +391,7 @@ LL | type A4 = extern "rust-call" fn(); //~ ERROR rust-call ABI is subject to ch
    = help: add #![feature(unboxed_closures)] to the crate attributes to enable
 
 error[E0658]: msp430-interrupt ABI is experimental and subject to change (see issue #38487)
-  --> $DIR/feature-gate-abi.rs:77:11
+  --> $DIR/feature-gate-abi.rs:78:11
    |
 LL | type A5 = extern "msp430-interrupt" fn(); //~ ERROR msp430-interrupt ABI is experimental
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -399,7 +399,7 @@ LL | type A5 = extern "msp430-interrupt" fn(); //~ ERROR msp430-interrupt ABI is
    = help: add #![feature(abi_msp430_interrupt)] to the crate attributes to enable
 
 error[E0658]: PTX ABIs are experimental and subject to change (see issue #38788)
-  --> $DIR/feature-gate-abi.rs:78:11
+  --> $DIR/feature-gate-abi.rs:79:11
    |
 LL | type A6 = extern "ptx-kernel" fn (); //~ ERROR PTX ABIs are experimental and subject to change
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -407,7 +407,7 @@ LL | type A6 = extern "ptx-kernel" fn (); //~ ERROR PTX ABIs are experimental an
    = help: add #![feature(abi_ptx)] to the crate attributes to enable
 
 error[E0658]: x86-interrupt ABI is experimental and subject to change (see issue #40180)
-  --> $DIR/feature-gate-abi.rs:79:11
+  --> $DIR/feature-gate-abi.rs:80:11
    |
 LL | type A7 = extern "x86-interrupt" fn(); //~ ERROR x86-interrupt ABI is experimental
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -415,7 +415,7 @@ LL | type A7 = extern "x86-interrupt" fn(); //~ ERROR x86-interrupt ABI is exper
    = help: add #![feature(abi_x86_interrupt)] to the crate attributes to enable
 
 error[E0658]: thiscall is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:80:11
+  --> $DIR/feature-gate-abi.rs:81:11
    |
 LL | type A8 = extern "thiscall" fn(); //~ ERROR thiscall is experimental and subject to change
    |           ^^^^^^^^^^^^^^^^^^^^^^
@@ -423,7 +423,7 @@ LL | type A8 = extern "thiscall" fn(); //~ ERROR thiscall is experimental and su
    = help: add #![feature(abi_thiscall)] to the crate attributes to enable
 
 error[E0658]: amdgpu-kernel ABI is experimental and subject to change (see issue #51575)
-  --> $DIR/feature-gate-abi.rs:81:11
+  --> $DIR/feature-gate-abi.rs:82:11
    |
 LL | type A9 = extern "amdgpu-kernel" fn(); //~ ERROR amdgpu-kernel ABI is experimental and subject to change
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -431,7 +431,7 @@ LL | type A9 = extern "amdgpu-kernel" fn(); //~ ERROR amdgpu-kernel ABI is exper
    = help: add #![feature(abi_amdgpu_kernel)] to the crate attributes to enable
 
 error[E0658]: intrinsics are subject to change
-  --> $DIR/feature-gate-abi.rs:84:1
+  --> $DIR/feature-gate-abi.rs:85:1
    |
 LL | extern "rust-intrinsic" {} //~ ERROR intrinsics are subject to change
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -439,7 +439,7 @@ LL | extern "rust-intrinsic" {} //~ ERROR intrinsics are subject to change
    = help: add #![feature(intrinsics)] to the crate attributes to enable
 
 error[E0658]: platform intrinsics are experimental and possibly buggy (see issue #27731)
-  --> $DIR/feature-gate-abi.rs:85:1
+  --> $DIR/feature-gate-abi.rs:86:1
    |
 LL | extern "platform-intrinsic" {} //~ ERROR platform intrinsics are experimental
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -447,7 +447,7 @@ LL | extern "platform-intrinsic" {} //~ ERROR platform intrinsics are experiment
    = help: add #![feature(platform_intrinsics)] to the crate attributes to enable
 
 error[E0658]: vectorcall is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:86:1
+  --> $DIR/feature-gate-abi.rs:87:1
    |
 LL | extern "vectorcall" {} //~ ERROR vectorcall is experimental and subject to change
    | ^^^^^^^^^^^^^^^^^^^^^^
@@ -455,7 +455,7 @@ LL | extern "vectorcall" {} //~ ERROR vectorcall is experimental and subject to 
    = help: add #![feature(abi_vectorcall)] to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change (see issue #29625)
-  --> $DIR/feature-gate-abi.rs:87:1
+  --> $DIR/feature-gate-abi.rs:88:1
    |
 LL | extern "rust-call" {} //~ ERROR rust-call ABI is subject to change
    | ^^^^^^^^^^^^^^^^^^^^^
@@ -463,7 +463,7 @@ LL | extern "rust-call" {} //~ ERROR rust-call ABI is subject to change
    = help: add #![feature(unboxed_closures)] to the crate attributes to enable
 
 error[E0658]: msp430-interrupt ABI is experimental and subject to change (see issue #38487)
-  --> $DIR/feature-gate-abi.rs:88:1
+  --> $DIR/feature-gate-abi.rs:89:1
    |
 LL | extern "msp430-interrupt" {} //~ ERROR msp430-interrupt ABI is experimental
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -471,7 +471,7 @@ LL | extern "msp430-interrupt" {} //~ ERROR msp430-interrupt ABI is experimental
    = help: add #![feature(abi_msp430_interrupt)] to the crate attributes to enable
 
 error[E0658]: PTX ABIs are experimental and subject to change (see issue #38788)
-  --> $DIR/feature-gate-abi.rs:89:1
+  --> $DIR/feature-gate-abi.rs:90:1
    |
 LL | extern "ptx-kernel" {} //~ ERROR PTX ABIs are experimental and subject to change
    | ^^^^^^^^^^^^^^^^^^^^^^
@@ -479,7 +479,7 @@ LL | extern "ptx-kernel" {} //~ ERROR PTX ABIs are experimental and subject to c
    = help: add #![feature(abi_ptx)] to the crate attributes to enable
 
 error[E0658]: x86-interrupt ABI is experimental and subject to change (see issue #40180)
-  --> $DIR/feature-gate-abi.rs:90:1
+  --> $DIR/feature-gate-abi.rs:91:1
    |
 LL | extern "x86-interrupt" {} //~ ERROR x86-interrupt ABI is experimental
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -487,7 +487,7 @@ LL | extern "x86-interrupt" {} //~ ERROR x86-interrupt ABI is experimental
    = help: add #![feature(abi_x86_interrupt)] to the crate attributes to enable
 
 error[E0658]: thiscall is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:91:1
+  --> $DIR/feature-gate-abi.rs:92:1
    |
 LL | extern "thiscall" {} //~ ERROR thiscall is experimental and subject to change
    | ^^^^^^^^^^^^^^^^^^^^
@@ -495,7 +495,7 @@ LL | extern "thiscall" {} //~ ERROR thiscall is experimental and subject to chan
    = help: add #![feature(abi_thiscall)] to the crate attributes to enable
 
 error[E0658]: amdgpu-kernel ABI is experimental and subject to change (see issue #51575)
-  --> $DIR/feature-gate-abi.rs:92:1
+  --> $DIR/feature-gate-abi.rs:93:1
    |
 LL | extern "amdgpu-kernel" {} //~ ERROR amdgpu-kernel ABI is experimental and subject to change
    | ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/feature-gates/feature-gate-alloc-error-handler.rs
+++ b/src/test/ui/feature-gates/feature-gate-alloc-error-handler.rs
@@ -9,3 +9,6 @@ use core::alloc::Layout;
 fn oom(info: Layout) -> ! {
     loop {}
 }
+
+#[panic_handler]
+fn panic(_: &core::panic::PanicInfo) -> ! { loop {} }

--- a/src/test/ui/feature-gates/feature-gate-allow_fail.rs
+++ b/src/test/ui/feature-gates/feature-gate-allow_fail.rs
@@ -5,3 +5,4 @@ fn ok_to_fail() {
     assert!(false);
 }
 
+fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-async-await-2015-edition.rs
+++ b/src/test/ui/feature-gates/feature-gate-async-await-2015-edition.rs
@@ -6,5 +6,5 @@ async fn foo() {} //~ ERROR async fn is unstable
 
 fn main() {
     let _ = async {}; //~ ERROR cannot find struct, variant or union type `async`
-    let _ = async || {}; //~ ERROR cannot find value `async` in this scope
+    let _ = async || { true }; //~ ERROR cannot find value `async` in this scope
 }

--- a/src/test/ui/feature-gates/feature-gate-async-await-2015-edition.stderr
+++ b/src/test/ui/feature-gates/feature-gate-async-await-2015-edition.stderr
@@ -7,7 +7,7 @@ LL |     let _ = async {}; //~ ERROR cannot find struct, variant or union type `
 error[E0425]: cannot find value `async` in this scope
   --> $DIR/feature-gate-async-await-2015-edition.rs:9:13
    |
-LL |     let _ = async || {}; //~ ERROR cannot find value `async` in this scope
+LL |     let _ = async || { true }; //~ ERROR cannot find value `async` in this scope
    |             ^^^^^ not found in this scope
 
 error[E0658]: async fn is unstable (see issue #50547)

--- a/src/test/ui/feature-gates/feature-gate-const_fn.rs
+++ b/src/test/ui/feature-gates/feature-gate-const_fn.rs
@@ -9,12 +9,14 @@ trait Foo {
                                 //~| ERROR trait fns cannot be declared const
 }
 
-impl Foo {
-    const fn baz() -> u32 { 0 } // ok
-}
-
 impl Foo for u32 {
     const fn foo() -> u32 { 0 } //~ ERROR trait fns cannot be declared const
+}
+
+trait Bar {}
+
+impl dyn Bar {
+    const fn baz() -> u32 { 0 } // ok
 }
 
 static FOO: usize = foo();

--- a/src/test/ui/feature-gates/feature-gate-const_fn.stderr
+++ b/src/test/ui/feature-gates/feature-gate-const_fn.stderr
@@ -11,7 +11,7 @@ LL |     const fn bar() -> u32 { 0 } //~ ERROR const fn is unstable
    |     ^^^^^ trait fns cannot be const
 
 error[E0379]: trait fns cannot be declared const
-  --> $DIR/feature-gate-const_fn.rs:17:5
+  --> $DIR/feature-gate-const_fn.rs:13:5
    |
 LL |     const fn foo() -> u32 { 0 } //~ ERROR trait fns cannot be declared const
    |     ^^^^^ trait fns cannot be const

--- a/src/test/ui/feature-gates/feature-gate-doc_keyword.rs
+++ b/src/test/ui/feature-gates/feature-gate-doc_keyword.rs
@@ -1,3 +1,5 @@
 #[doc(keyword = "match")] //~ ERROR: #[doc(keyword = "...")] is experimental
 /// wonderful
 mod foo{}
+
+fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-dropck-ugeh.rs
+++ b/src/test/ui/feature-gates/feature-gate-dropck-ugeh.rs
@@ -1,13 +1,10 @@
 // gate-test-dropck_parametricity
 
 // Ensure that attempts to use the unsafe attribute are feature-gated.
-
 // Example adapted from RFC 1238 text (just left out the feature gate).
 
 // https://github.com/rust-lang/rfcs/blob/master/text/1238-nonparametric-dropck.md
 //     #example-of-the-unguarded-escape-hatch
-
-// #![feature(dropck_parametricity)]
 
 use std::cell::Cell;
 
@@ -18,6 +15,7 @@ struct Foo<T> { data: Vec<T> }
 impl<T> Drop for Foo<T> {
     #[unsafe_destructor_blind_to_params] // This is the UGEH attribute
     //~^ ERROR unsafe_destructor_blind_to_params has been replaced
+    //~| WARN use of deprecated attribute `dropck_parametricity`
     fn drop(&mut self) { }
 }
 
@@ -29,4 +27,3 @@ fn main() {
     foo.data[0].1.set(Some(&foo.data[1]));
     foo.data[1].1.set(Some(&foo.data[0]));
 }
-

--- a/src/test/ui/feature-gates/feature-gate-dropck-ugeh.stderr
+++ b/src/test/ui/feature-gates/feature-gate-dropck-ugeh.stderr
@@ -1,10 +1,18 @@
 error[E0658]: unsafe_destructor_blind_to_params has been replaced by may_dangle and will be removed in the future (see issue #28498)
-  --> $DIR/feature-gate-dropck-ugeh.rs:19:5
+  --> $DIR/feature-gate-dropck-ugeh.rs:16:5
    |
 LL |     #[unsafe_destructor_blind_to_params] // This is the UGEH attribute
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add #![feature(dropck_parametricity)] to the crate attributes to enable
+
+warning: use of deprecated attribute `dropck_parametricity`: unsafe_destructor_blind_to_params has been replaced by may_dangle and will be removed in the future. See https://github.com/rust-lang/rust/issues/34761
+  --> $DIR/feature-gate-dropck-ugeh.rs:16:5
+   |
+LL |     #[unsafe_destructor_blind_to_params] // This is the UGEH attribute
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace this attribute with `#[may_dangle]`
+   |
+   = note: #[warn(deprecated)] on by default
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-existential-type.rs
+++ b/src/test/ui/feature-gates/feature-gate-existential-type.rs
@@ -1,15 +1,17 @@
 // Check that existential types must be ungated to use the `existential` keyword
 
-
-
 existential type Foo: std::fmt::Debug; //~ ERROR existential types are unstable
 
 trait Bar {
     type Baa: std::fmt::Debug;
+    fn define() -> Self::Baa;
 }
 
 impl Bar for () {
     existential type Baa: std::fmt::Debug; //~ ERROR existential types are unstable
+    fn define() -> Self::Baa { 0 }
 }
+
+fn define() -> Foo { 0 }
 
 fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-existential-type.stderr
+++ b/src/test/ui/feature-gates/feature-gate-existential-type.stderr
@@ -1,5 +1,5 @@
 error[E0658]: existential types are unstable (see issue #34511)
-  --> $DIR/feature-gate-existential-type.rs:5:1
+  --> $DIR/feature-gate-existential-type.rs:3:1
    |
 LL | existential type Foo: std::fmt::Debug; //~ ERROR existential types are unstable
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL | existential type Foo: std::fmt::Debug; //~ ERROR existential types are unst
    = help: add #![feature(existential_type)] to the crate attributes to enable
 
 error[E0658]: existential types are unstable (see issue #34511)
-  --> $DIR/feature-gate-existential-type.rs:12:5
+  --> $DIR/feature-gate-existential-type.rs:11:5
    |
 LL |     existential type Baa: std::fmt::Debug; //~ ERROR existential types are unstable
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/feature-gates/feature-gate-generators.rs
+++ b/src/test/ui/feature-gates/feature-gate-generators.rs
@@ -1,3 +1,4 @@
 fn main() {
     yield true; //~ ERROR yield syntax is experimental
+                //~^ ERROR yield statement outside of generator literal
 }

--- a/src/test/ui/feature-gates/feature-gate-generators.stderr
+++ b/src/test/ui/feature-gates/feature-gate-generators.stderr
@@ -6,6 +6,13 @@ LL |     yield true; //~ ERROR yield syntax is experimental
    |
    = help: add #![feature(generators)] to the crate attributes to enable
 
-error: aborting due to previous error
+error[E0627]: yield statement outside of generator literal
+  --> $DIR/feature-gate-generators.rs:2:5
+   |
+LL |     yield true; //~ ERROR yield syntax is experimental
+   |     ^^^^^^^^^^
 
-For more information about this error, try `rustc --explain E0658`.
+error: aborting due to 2 previous errors
+
+Some errors occurred: E0627, E0658.
+For more information about an error, try `rustc --explain E0627`.

--- a/src/test/ui/feature-gates/feature-gate-generic_associated_types.rs
+++ b/src/test/ui/feature-gates/feature-gate-generic_associated_types.rs
@@ -11,9 +11,9 @@ trait PointerFamily<U> {
 struct Foo;
 
 impl PointerFamily<u32> for Foo {
-    type Pointer<usize> = Box<usize>;
+    type Pointer<Usize> = Box<Usize>;
     //~^ ERROR generic associated types are unstable
-    type Pointer2<u32> = Box<u32>;
+    type Pointer2<U32> = Box<U32>;
     //~^ ERROR generic associated types are unstable
 }
 

--- a/src/test/ui/feature-gates/feature-gate-generic_associated_types.stderr
+++ b/src/test/ui/feature-gates/feature-gate-generic_associated_types.stderr
@@ -25,7 +25,7 @@ LL |     type Pointer2<T>: Deref<Target = T> where T: Clone, U: Clone;
 error[E0658]: generic associated types are unstable (see issue #44265)
   --> $DIR/feature-gate-generic_associated_types.rs:14:5
    |
-LL |     type Pointer<usize> = Box<usize>;
+LL |     type Pointer<Usize> = Box<Usize>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add #![feature(generic_associated_types)] to the crate attributes to enable
@@ -33,7 +33,7 @@ LL |     type Pointer<usize> = Box<usize>;
 error[E0658]: generic associated types are unstable (see issue #44265)
   --> $DIR/feature-gate-generic_associated_types.rs:16:5
    |
-LL |     type Pointer2<u32> = Box<u32>;
+LL |     type Pointer2<U32> = Box<U32>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add #![feature(generic_associated_types)] to the crate attributes to enable

--- a/src/test/ui/feature-gates/feature-gate-intrinsics.rs
+++ b/src/test/ui/feature-gates/feature-gate-intrinsics.rs
@@ -1,9 +1,7 @@
 extern "rust-intrinsic" {   //~ ERROR intrinsics are subject to change
-    fn bar();
+    fn bar(); //~ ERROR unrecognized intrinsic function: `bar`
 }
 
-extern "rust-intrinsic" fn baz() {  //~ ERROR intrinsics are subject to change
-}
+extern "rust-intrinsic" fn baz() {} //~ ERROR intrinsics are subject to change
 
-fn main() {
-}
+fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-intrinsics.stderr
+++ b/src/test/ui/feature-gates/feature-gate-intrinsics.stderr
@@ -2,7 +2,7 @@ error[E0658]: intrinsics are subject to change
   --> $DIR/feature-gate-intrinsics.rs:1:1
    |
 LL | / extern "rust-intrinsic" {   //~ ERROR intrinsics are subject to change
-LL | |     fn bar();
+LL | |     fn bar(); //~ ERROR unrecognized intrinsic function: `bar`
 LL | | }
    | |_^
    |
@@ -11,12 +11,18 @@ LL | | }
 error[E0658]: intrinsics are subject to change
   --> $DIR/feature-gate-intrinsics.rs:5:1
    |
-LL | / extern "rust-intrinsic" fn baz() {  //~ ERROR intrinsics are subject to change
-LL | | }
-   | |_^
+LL | extern "rust-intrinsic" fn baz() {} //~ ERROR intrinsics are subject to change
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add #![feature(intrinsics)] to the crate attributes to enable
 
-error: aborting due to 2 previous errors
+error[E0093]: unrecognized intrinsic function: `bar`
+  --> $DIR/feature-gate-intrinsics.rs:2:5
+   |
+LL |     fn bar(); //~ ERROR unrecognized intrinsic function: `bar`
+   |     ^^^^^^^^^ unrecognized intrinsic
 
-For more information about this error, try `rustc --explain E0658`.
+error: aborting due to 3 previous errors
+
+Some errors occurred: E0093, E0658.
+For more information about an error, try `rustc --explain E0093`.

--- a/src/test/ui/feature-gates/feature-gate-lang-items.rs
+++ b/src/test/ui/feature-gates/feature-gate-lang-items.rs
@@ -1,5 +1,5 @@
-#[lang="foo"]   //~ ERROR language items are subject to change
+#[lang = "foo"] //~ ERROR language items are subject to change
+                //~^ ERROR definition of an unknown language item: `foo`
 trait Foo {}
 
-fn main() {
-}
+fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-lang-items.stderr
+++ b/src/test/ui/feature-gates/feature-gate-lang-items.stderr
@@ -1,11 +1,18 @@
 error[E0658]: language items are subject to change
   --> $DIR/feature-gate-lang-items.rs:1:1
    |
-LL | #[lang="foo"]   //~ ERROR language items are subject to change
-   | ^^^^^^^^^^^^^
+LL | #[lang = "foo"] //~ ERROR language items are subject to change
+   | ^^^^^^^^^^^^^^^
    |
    = help: add #![feature(lang_items)] to the crate attributes to enable
 
-error: aborting due to previous error
+error[E0522]: definition of an unknown language item: `foo`
+  --> $DIR/feature-gate-lang-items.rs:1:1
+   |
+LL | #[lang = "foo"] //~ ERROR language items are subject to change
+   | ^^^^^^^^^^^^^^^ definition of unknown language item `foo`
 
-For more information about this error, try `rustc --explain E0658`.
+error: aborting due to 2 previous errors
+
+Some errors occurred: E0522, E0658.
+For more information about an error, try `rustc --explain E0522`.

--- a/src/test/ui/feature-gates/feature-gate-linkage.rs
+++ b/src/test/ui/feature-gates/feature-gate-linkage.rs
@@ -2,3 +2,5 @@ extern {
     #[linkage = "extern_weak"] static foo: isize;
     //~^ ERROR: the `linkage` attribute is experimental and not portable
 }
+
+fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-may-dangle.rs
+++ b/src/test/ui/feature-gates/feature-gate-may-dangle.rs
@@ -3,7 +3,9 @@
 // Check that `may_dangle` is rejected if `dropck_eyepatch` feature gate is absent.
 
 struct Pt<A>(A);
-impl<#[may_dangle] A> Drop for Pt<A> {
+unsafe impl<#[may_dangle] A> Drop for Pt<A> {
     //~^ ERROR may_dangle has unstable semantics and may be removed in the future
     fn drop(&mut self) { }
 }
+
+fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-may-dangle.stderr
+++ b/src/test/ui/feature-gates/feature-gate-may-dangle.stderr
@@ -1,8 +1,8 @@
 error[E0658]: may_dangle has unstable semantics and may be removed in the future (see issue #34761)
-  --> $DIR/feature-gate-may-dangle.rs:6:6
+  --> $DIR/feature-gate-may-dangle.rs:6:13
    |
-LL | impl<#[may_dangle] A> Drop for Pt<A> {
-   |      ^^^^^^^^^^^^^
+LL | unsafe impl<#[may_dangle] A> Drop for Pt<A> {
+   |             ^^^^^^^^^^^^^
    |
    = help: add #![feature(dropck_eyepatch)] to the crate attributes to enable
 

--- a/src/test/ui/feature-gates/feature-gate-min_const_fn.rs
+++ b/src/test/ui/feature-gates/feature-gate-min_const_fn.rs
@@ -9,12 +9,14 @@ trait Foo {
                                 //~| ERROR trait fns cannot be declared const
 }
 
-impl Foo {
-    const fn baz() -> u32 { 0 } // stabilized
-}
-
 impl Foo for u32 {
     const fn foo() -> u32 { 0 } //~ ERROR trait fns cannot be declared const
+}
+
+trait Bar {}
+
+impl dyn Bar {
+    const fn baz() -> u32 { 0 } // stabilized
 }
 
 static FOO: usize = foo();

--- a/src/test/ui/feature-gates/feature-gate-min_const_fn.stderr
+++ b/src/test/ui/feature-gates/feature-gate-min_const_fn.stderr
@@ -11,7 +11,7 @@ LL |     const fn bar() -> u32 { 0 } //~ ERROR const fn is unstable
    |     ^^^^^ trait fns cannot be const
 
 error[E0379]: trait fns cannot be declared const
-  --> $DIR/feature-gate-min_const_fn.rs:17:5
+  --> $DIR/feature-gate-min_const_fn.rs:13:5
    |
 LL |     const fn foo() -> u32 { 0 } //~ ERROR trait fns cannot be declared const
    |     ^^^^^ trait fns cannot be const

--- a/src/test/ui/feature-gates/feature-gate-naked_functions.rs
+++ b/src/test/ui/feature-gates/feature-gate-naked_functions.rs
@@ -7,3 +7,5 @@ fn naked() {}
 fn naked_2() -> isize {
     0
 }
+
+fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-never_type.rs
+++ b/src/test/ui/feature-gates/feature-gate-never_type.rs
@@ -6,8 +6,8 @@ trait Foo {
 
 type Ma = (u32, !, i32); //~ ERROR type is experimental
 type Meeshka = Vec<!>; //~ ERROR type is experimental
-type Mow = &fn(!) -> !; //~ ERROR type is experimental
-type Skwoz = &mut !; //~ ERROR type is experimental
+type Mow = &'static fn(!) -> !; //~ ERROR type is experimental
+type Skwoz = &'static mut !; //~ ERROR type is experimental
 
 impl Foo for Meeshka {
     type Wub = !; //~ ERROR type is experimental

--- a/src/test/ui/feature-gates/feature-gate-never_type.stderr
+++ b/src/test/ui/feature-gates/feature-gate-never_type.stderr
@@ -15,18 +15,18 @@ LL | type Meeshka = Vec<!>; //~ ERROR type is experimental
    = help: add #![feature(never_type)] to the crate attributes to enable
 
 error[E0658]: The `!` type is experimental (see issue #35121)
-  --> $DIR/feature-gate-never_type.rs:9:16
+  --> $DIR/feature-gate-never_type.rs:9:24
    |
-LL | type Mow = &fn(!) -> !; //~ ERROR type is experimental
-   |                ^
+LL | type Mow = &'static fn(!) -> !; //~ ERROR type is experimental
+   |                        ^
    |
    = help: add #![feature(never_type)] to the crate attributes to enable
 
 error[E0658]: The `!` type is experimental (see issue #35121)
-  --> $DIR/feature-gate-never_type.rs:10:19
+  --> $DIR/feature-gate-never_type.rs:10:27
    |
-LL | type Skwoz = &mut !; //~ ERROR type is experimental
-   |                   ^
+LL | type Skwoz = &'static mut !; //~ ERROR type is experimental
+   |                           ^
    |
    = help: add #![feature(never_type)] to the crate attributes to enable
 

--- a/src/test/ui/feature-gates/feature-gate-no_core.rs
+++ b/src/test/ui/feature-gates/feature-gate-no_core.rs
@@ -1,3 +1,5 @@
+#![crate_type = "rlib"]
+
 #![no_core] //~ ERROR no_core is experimental
 
-fn main() {}
+pub struct S {}

--- a/src/test/ui/feature-gates/feature-gate-no_core.stderr
+++ b/src/test/ui/feature-gates/feature-gate-no_core.stderr
@@ -1,5 +1,5 @@
 error[E0658]: no_core is experimental (see issue #29639)
-  --> $DIR/feature-gate-no_core.rs:1:1
+  --> $DIR/feature-gate-no_core.rs:3:1
    |
 LL | #![no_core] //~ ERROR no_core is experimental
    | ^^^^^^^^^^^

--- a/src/test/ui/feature-gates/feature-gate-optin-builtin-traits.rs
+++ b/src/test/ui/feature-gates/feature-gate-optin-builtin-traits.rs
@@ -3,14 +3,10 @@
 
 struct DummyStruct;
 
-trait DummyTrait {
-    fn dummy(&self) {}
-}
-
 auto trait AutoDummyTrait {}
 //~^ ERROR auto traits are experimental and possibly buggy
 
-impl !DummyTrait for DummyStruct {}
+impl !AutoDummyTrait for DummyStruct {}
 //~^ ERROR negative trait bounds are not yet fully implemented; use marker types for now
 
 fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-optin-builtin-traits.stderr
+++ b/src/test/ui/feature-gates/feature-gate-optin-builtin-traits.stderr
@@ -1,5 +1,5 @@
 error[E0658]: auto traits are experimental and possibly buggy (see issue #13231)
-  --> $DIR/feature-gate-optin-builtin-traits.rs:10:1
+  --> $DIR/feature-gate-optin-builtin-traits.rs:6:1
    |
 LL | auto trait AutoDummyTrait {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -7,10 +7,10 @@ LL | auto trait AutoDummyTrait {}
    = help: add #![feature(optin_builtin_traits)] to the crate attributes to enable
 
 error[E0658]: negative trait bounds are not yet fully implemented; use marker types for now (see issue #13231)
-  --> $DIR/feature-gate-optin-builtin-traits.rs:13:1
+  --> $DIR/feature-gate-optin-builtin-traits.rs:9:1
    |
-LL | impl !DummyTrait for DummyStruct {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | impl !AutoDummyTrait for DummyStruct {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add #![feature(optin_builtin_traits)] to the crate attributes to enable
 

--- a/src/test/ui/feature-gates/feature-gate-repr-simd.rs
+++ b/src/test/ui/feature-gates/feature-gate-repr-simd.rs
@@ -1,7 +1,7 @@
 #[repr(simd)] //~ error: SIMD types are experimental
 struct Foo(u64, u64);
 
-#[repr(C)]
+#[repr(C)] //~ warn: conflicting representation hints
 #[repr(simd)] //~ error: SIMD types are experimental
 struct Bar(u64, u64);
 

--- a/src/test/ui/feature-gates/feature-gate-repr-simd.stderr
+++ b/src/test/ui/feature-gates/feature-gate-repr-simd.stderr
@@ -14,6 +14,15 @@ LL | #[repr(simd)] //~ error: SIMD types are experimental
    |
    = help: add #![feature(repr_simd)] to the crate attributes to enable
 
+warning[E0566]: conflicting representation hints
+  --> $DIR/feature-gate-repr-simd.rs:4:8
+   |
+LL | #[repr(C)] //~ warn: conflicting representation hints
+   |        ^
+LL | #[repr(simd)] //~ error: SIMD types are experimental
+   |        ^^^^
+
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0658`.
+Some errors occurred: E0566, E0658.
+For more information about an error, try `rustc --explain E0566`.

--- a/src/test/ui/feature-gates/feature-gate-rustc-attrs-1.rs
+++ b/src/test/ui/feature-gates/feature-gate-rustc-attrs-1.rs
@@ -5,4 +5,4 @@
 #[rustc_variance] //~ ERROR the `#[rustc_variance]` attribute is just used for rustc unit tests and will never be stable
 #[rustc_error] //~ ERROR the `#[rustc_error]` attribute is just used for rustc unit tests and will never be stable
 
-fn main() {}
+fn main() {} //~ ERROR []

--- a/src/test/ui/feature-gates/feature-gate-rustc-attrs-1.stderr
+++ b/src/test/ui/feature-gates/feature-gate-rustc-attrs-1.stderr
@@ -14,6 +14,13 @@ LL | #[rustc_error] //~ ERROR the `#[rustc_error]` attribute is just used for ru
    |
    = help: add #![feature(rustc_attrs)] to the crate attributes to enable
 
-error: aborting due to 2 previous errors
+error[E0208]: []
+  --> $DIR/feature-gate-rustc-attrs-1.rs:8:1
+   |
+LL | fn main() {} //~ ERROR []
+   | ^^^^^^^^^^^^
 
-For more information about this error, try `rustc --explain E0658`.
+error: aborting due to 3 previous errors
+
+Some errors occurred: E0208, E0658.
+For more information about an error, try `rustc --explain E0208`.

--- a/src/test/ui/feature-gates/feature-gate-start.rs
+++ b/src/test/ui/feature-gates/feature-gate-start.rs
@@ -1,2 +1,3 @@
 #[start]
-fn foo() {} //~ ERROR: a #[start] function is an experimental feature
+fn foo(_: isize, _: *const *const u8) -> isize { 0 }
+//~^ ERROR a #[start] function is an experimental feature

--- a/src/test/ui/feature-gates/feature-gate-start.stderr
+++ b/src/test/ui/feature-gates/feature-gate-start.stderr
@@ -1,8 +1,8 @@
 error[E0658]: a #[start] function is an experimental feature whose signature may change over time (see issue #29633)
   --> $DIR/feature-gate-start.rs:2:1
    |
-LL | fn foo() {} //~ ERROR: a #[start] function is an experimental feature
-   | ^^^^^^^^^^^
+LL | fn foo(_: isize, _: *const *const u8) -> isize { 0 }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add #![feature(start)] to the crate attributes to enable
 

--- a/src/test/ui/feature-gates/feature-gate-thread_local.rs
+++ b/src/test/ui/feature-gates/feature-gate-thread_local.rs
@@ -8,8 +8,4 @@
 #[thread_local] //~ ERROR `#[thread_local]` is an experimental feature
 static FOO: i32 = 3;
 
-pub fn main() {
-    FOO.with(|x| {
-        println!("x: {}", x);
-    });
-}
+pub fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.rs
+++ b/src/test/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.rs
@@ -3,25 +3,29 @@
 // never triggers (yet), because they encounter other problems around
 // angle bracket vs parentheses notation.
 
-#![allow(dead_code)]
+#![feature(fn_traits)]
 
 struct Foo;
 impl Fn<()> for Foo {
+//~^ ERROR the precise format of `Fn`-family traits' type parameters is subject to change
     extern "rust-call" fn call(self, args: ()) -> () {}
     //~^ ERROR rust-call ABI is subject to change
 }
 struct Foo1;
 impl FnOnce() for Foo1 {
+//~^ ERROR associated type bindings are not allowed here
     extern "rust-call" fn call_once(self, args: ()) -> () {}
     //~^ ERROR rust-call ABI is subject to change
 }
 struct Bar;
 impl FnMut<()> for Bar {
+//~^ ERROR the precise format of `Fn`-family traits' type parameters is subject to change
     extern "rust-call" fn call_mut(&self, args: ()) -> () {}
     //~^ ERROR rust-call ABI is subject to change
 }
 struct Baz;
 impl FnOnce<()> for Baz {
+//~^ ERROR the precise format of `Fn`-family traits' type parameters is subject to change
     extern "rust-call" fn call_once(&self, args: ()) -> () {}
     //~^ ERROR rust-call ABI is subject to change
 }

--- a/src/test/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.stderr
+++ b/src/test/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.stderr
@@ -1,5 +1,5 @@
 error[E0658]: rust-call ABI is subject to change (see issue #29625)
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:10:5
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:11:5
    |
 LL |     extern "rust-call" fn call(self, args: ()) -> () {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL |     extern "rust-call" fn call(self, args: ()) -> () {}
    = help: add #![feature(unboxed_closures)] to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change (see issue #29625)
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:15:5
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:17:5
    |
 LL |     extern "rust-call" fn call_once(self, args: ()) -> () {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -15,7 +15,7 @@ LL |     extern "rust-call" fn call_once(self, args: ()) -> () {}
    = help: add #![feature(unboxed_closures)] to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change (see issue #29625)
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:20:5
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:23:5
    |
 LL |     extern "rust-call" fn call_mut(&self, args: ()) -> () {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -23,13 +23,44 @@ LL |     extern "rust-call" fn call_mut(&self, args: ()) -> () {}
    = help: add #![feature(unboxed_closures)] to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change (see issue #29625)
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:25:5
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:29:5
    |
 LL |     extern "rust-call" fn call_once(&self, args: ()) -> () {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add #![feature(unboxed_closures)] to the crate attributes to enable
 
-error: aborting due to 4 previous errors
+error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change. Use parenthetical notation (Fn(Foo, Bar) -> Baz) instead (see issue #29625)
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:9:6
+   |
+LL | impl Fn<()> for Foo {
+   |      ^^^^^^
+   |
+   = help: add #![feature(unboxed_closures)] to the crate attributes to enable
 
-For more information about this error, try `rustc --explain E0658`.
+error[E0229]: associated type bindings are not allowed here
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:15:12
+   |
+LL | impl FnOnce() for Foo1 {
+   |            ^^ associated type not allowed here
+
+error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change. Use parenthetical notation (Fn(Foo, Bar) -> Baz) instead (see issue #29625)
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:21:6
+   |
+LL | impl FnMut<()> for Bar {
+   |      ^^^^^^^^^
+   |
+   = help: add #![feature(unboxed_closures)] to the crate attributes to enable
+
+error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change. Use parenthetical notation (Fn(Foo, Bar) -> Baz) instead (see issue #29625)
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:27:6
+   |
+LL | impl FnOnce<()> for Baz {
+   |      ^^^^^^^^^^
+   |
+   = help: add #![feature(unboxed_closures)] to the crate attributes to enable
+
+error: aborting due to 8 previous errors
+
+Some errors occurred: E0229, E0658.
+For more information about an error, try `rustc --explain E0229`.

--- a/src/test/ui/feature-gates/feature-gate-unboxed-closures.rs
+++ b/src/test/ui/feature-gates/feature-gate-unboxed-closures.rs
@@ -1,6 +1,9 @@
+#![feature(fn_traits)]
+
 struct Test;
 
 impl FnOnce<(u32, u32)> for Test {
+//~^ ERROR the precise format of `Fn`-family traits' type parameters is subject to change
     type Output = u32;
 
     extern "rust-call" fn call_once(self, (a, b): (u32, u32)) -> u32 {

--- a/src/test/ui/feature-gates/feature-gate-unboxed-closures.stderr
+++ b/src/test/ui/feature-gates/feature-gate-unboxed-closures.stderr
@@ -1,5 +1,5 @@
 error[E0658]: rust-call ABI is subject to change (see issue #29625)
-  --> $DIR/feature-gate-unboxed-closures.rs:6:5
+  --> $DIR/feature-gate-unboxed-closures.rs:9:5
    |
 LL | /     extern "rust-call" fn call_once(self, (a, b): (u32, u32)) -> u32 {
 LL | |         a + b
@@ -8,6 +8,14 @@ LL | |     }
    |
    = help: add #![feature(unboxed_closures)] to the crate attributes to enable
 
-error: aborting due to previous error
+error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change. Use parenthetical notation (Fn(Foo, Bar) -> Baz) instead (see issue #29625)
+  --> $DIR/feature-gate-unboxed-closures.rs:5:6
+   |
+LL | impl FnOnce<(u32, u32)> for Test {
+   |      ^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(unboxed_closures)] to the crate attributes to enable
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/issues/issue-51279.rs
+++ b/src/test/ui/issues/issue-51279.rs
@@ -15,7 +15,7 @@ pub struct Y<#[cfg(none)] T>(T); // shouldn't care when the entire item is strip
 
 struct M<T>(*const T);
 
-unsafe impl<#[cfg_attr(none, may_dangle)] T> Drop for M<T> {
+impl<#[cfg_attr(none, may_dangle)] T> Drop for M<T> {
     //~^ ERROR #[cfg_attr] cannot be applied on a generic parameter
     fn drop(&mut self) {}
 }
@@ -23,3 +23,5 @@ unsafe impl<#[cfg_attr(none, may_dangle)] T> Drop for M<T> {
 type Z<#[ignored] 'a, #[cfg(none)] T> = X<'a, T>;
 //~^ ERROR #[cfg] cannot be applied on a generic parameter
 //~| ERROR attribute `ignored` is currently unknown to the compiler
+
+fn main() {}

--- a/src/test/ui/issues/issue-51279.stderr
+++ b/src/test/ui/issues/issue-51279.stderr
@@ -35,10 +35,10 @@ LL | pub fn f<#[cfg(none)] 'a, #[cfg(none)] T>(_: &'a T) {}
    |                           ^^^^^^^^^^^^
 
 error: #[cfg_attr] cannot be applied on a generic parameter
-  --> $DIR/issue-51279.rs:18:13
+  --> $DIR/issue-51279.rs:18:6
    |
-LL | unsafe impl<#[cfg_attr(none, may_dangle)] T> Drop for M<T> {
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | impl<#[cfg_attr(none, may_dangle)] T> Drop for M<T> {
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: #[cfg] cannot be applied on a generic parameter
   --> $DIR/issue-51279.rs:23:23

--- a/src/test/ui/on-unimplemented/expected-comma-found-token.rs
+++ b/src/test/ui/on-unimplemented/expected-comma-found-token.rs
@@ -4,11 +4,10 @@
 
 #![feature(on_unimplemented)]
 
-#[rustc_on_unimplemented(
+#[rustc_on_unimplemented( //~ ERROR `#[rustc_on_unimplemented]` requires a value
     message="the message"
-    label="the label"
+    label="the label" //~ ERROR expected one of `)` or `,`, found `label`
 )]
 trait T {}
-//~^^^ ERROR expected one of `)` or `,`, found `label`
 
 fn main() {  }

--- a/src/test/ui/on-unimplemented/expected-comma-found-token.stderr
+++ b/src/test/ui/on-unimplemented/expected-comma-found-token.stderr
@@ -3,8 +3,20 @@ error: expected one of `)` or `,`, found `label`
    |
 LL |     message="the message"
    |                          - expected one of `)` or `,` here
-LL |     label="the label"
+LL |     label="the label" //~ ERROR expected one of `)` or `,`, found `label`
    |     ^^^^^ unexpected token
 
-error: aborting due to previous error
+error[E0232]: `#[rustc_on_unimplemented]` requires a value
+  --> $DIR/expected-comma-found-token.rs:7:1
+   |
+LL | / #[rustc_on_unimplemented( //~ ERROR `#[rustc_on_unimplemented]` requires a value
+LL | |     message="the message"
+LL | |     label="the label" //~ ERROR expected one of `)` or `,`, found `label`
+LL | | )]
+   | |__^ value required here
+   |
+   = note: eg `#[rustc_on_unimplemented(message="foo")]`
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0232`.

--- a/src/test/ui/span/gated-features-attr-spans.rs
+++ b/src/test/ui/span/gated-features-attr-spans.rs
@@ -1,7 +1,7 @@
 #[repr(simd)] //~ ERROR are experimental
-struct Weapon {
-    name: String,
-    damage: u32
+struct Coord {
+    x: u32,
+    y: u32,
 }
 
 fn main() {}

--- a/src/test/ui/utf8_idents.rs
+++ b/src/test/ui/utf8_idents.rs
@@ -3,6 +3,7 @@
 fn foo<
     'β, //~ ERROR non-ascii idents are not fully supported
     γ  //~ ERROR non-ascii idents are not fully supported
+       //~^ WARN type parameter `γ` should have a camel case name such as `Γ`
 >() {}
 
 struct X {

--- a/src/test/ui/utf8_idents.stderr
+++ b/src/test/ui/utf8_idents.stderr
@@ -15,7 +15,7 @@ LL |     γ  //~ ERROR non-ascii idents are not fully supported
    = help: add #![feature(non_ascii_idents)] to the crate attributes to enable
 
 error[E0658]: non-ascii idents are not fully supported. (see issue #55467)
-  --> $DIR/utf8_idents.rs:9:5
+  --> $DIR/utf8_idents.rs:10:5
    |
 LL |     δ: usize //~ ERROR non-ascii idents are not fully supported
    |     ^
@@ -23,12 +23,20 @@ LL |     δ: usize //~ ERROR non-ascii idents are not fully supported
    = help: add #![feature(non_ascii_idents)] to the crate attributes to enable
 
 error[E0658]: non-ascii idents are not fully supported. (see issue #55467)
-  --> $DIR/utf8_idents.rs:13:9
+  --> $DIR/utf8_idents.rs:14:9
    |
 LL |     let α = 0.00001f64; //~ ERROR non-ascii idents are not fully supported
    |         ^
    |
    = help: add #![feature(non_ascii_idents)] to the crate attributes to enable
+
+warning: type parameter `γ` should have a camel case name such as `Γ`
+  --> $DIR/utf8_idents.rs:5:5
+   |
+LL |     γ  //~ ERROR non-ascii idents are not fully supported
+   |     ^
+   |
+   = note: #[warn(non_camel_case_types)] on by default
 
 error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Continuation of https://github.com/rust-lang/rust/pull/56999/commits/15cefe4b2a65bb2a4febcd353cb37b90dfafa4f1.
Turns out I missed the most important part - the main feature gate checking pass.