### PR TITLE
Add Clippy to config.toml.example

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -161,7 +161,7 @@
 
 # Installs chosen set of extended tools if enables. By default builds all.
 # If chosen tool failed to build the installation fails.
-#tools = ["cargo", "rls", "rustfmt", "analysis", "src"]
+#tools = ["cargo", "rls", "clippy", "rustfmt", "analysis", "src"]
 
 # Verbosity level: 0 == not verbose, 1 == verbose, 2 == very verbose
 #verbose = 0


### PR DESCRIPTION
Omitted in https://github.com/rust-lang/rust/pull/51122

The order is based on https://github.com/rust-lang/rust/blob/ec194646fef1a467073ad74b8b68f6f202cfce97/src/bootstrap/install.rs#L212