### PR TITLE
rustc: Fix regression where jemalloc isn't used

### DIFF
--- a/src/rustc/Cargo.toml
+++ b/src/rustc/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc-main"
 version = "0.0.0"
+edition = '2018'
 
 [[bin]]
 name = "rustc_binary"

--- a/src/rustc/rustc.rs
+++ b/src/rustc/rustc.rs
@@ -1,4 +1,3 @@
-#![feature(rustc_private)]
 #![feature(link_args)]
 
 // Set the stack size at link time on Windows. See rustc_driver::in_rustc_thread
@@ -11,17 +10,39 @@
 // Also, don't forget to set this for rustdoc.
 extern {}
 
-extern crate rustc_driver;
-
-// Note that the linkage here should be all that we need, on Linux we're not
-// prefixing the symbols here so this should naturally override our default
-// allocator. On OSX it should override via the zone allocator. We shouldn't
-// enable this by default on other platforms, so other platforms aren't handled
-// here yet.
-#[cfg(feature = "jemalloc-sys")]
-extern crate jemalloc_sys;
-
 fn main() {
+    // Pull in jemalloc when enabled.
+    //
+    // Note that we're pulling in a static copy of jemalloc which means that to
+    // pull it in we need to actually reference its symbols for it to get
+    // linked. The two crates we link to here, std and rustc_driver, are both
+    // dynamic libraries. That means to pull in jemalloc we need to actually
+    // reference allocation symbols one way or another (as this file is the only
+    // object code in the rustc executable).
+    #[cfg(feature = "jemalloc-sys")]
+    {
+        use std::os::raw::{c_void, c_int};
+
+        #[used]
+        static _F1: unsafe extern fn(usize, usize) -> *mut c_void =
+            jemalloc_sys::calloc;
+        #[used]
+        static _F2: unsafe extern fn(*mut *mut c_void, usize, usize) -> c_int =
+            jemalloc_sys::posix_memalign;
+        #[used]
+        static _F3: unsafe extern fn(usize, usize) -> *mut c_void =
+            jemalloc_sys::aligned_alloc;
+        #[used]
+        static _F4: unsafe extern fn(usize) -> *mut c_void =
+            jemalloc_sys::malloc;
+        #[used]
+        static _F5: unsafe extern fn(*mut c_void, usize) -> *mut c_void =
+            jemalloc_sys::realloc;
+        #[used]
+        static _F6: unsafe extern fn(*mut c_void) =
+            jemalloc_sys::free;
+    }
+
     rustc_driver::set_sigpipe_handler();
     rustc_driver::main()
 }


### PR DESCRIPTION
In #56986 the linkage of jemalloc to the compiler was switched from the
driver library to the rustc binary to ensure that only rustc itself uses
jemalloc. In doing so, however, it turns out jemalloc wasn't actually
linked in at all! None of the symbols were referenced so the static
library wasn't used. This means that jemalloc wasn't pulled in at all.

This commit performs a bit of a dance to reference jemalloc symbols,
attempting to pull it in despite LLVM's optimizations.

Closes #57115