### PR TITLE
When using value after move, point at span of local

### DIFF
--- a/src/librustc_mir/borrow_check/error_reporting.rs
+++ b/src/librustc_mir/borrow_check/error_reporting.rs
@@ -214,6 +214,7 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
                                 note_msg, ty,
                         ));
                         note = false;
+                        break;
                     }
                 }
                 if note {

--- a/src/librustc_mir/borrow_check/error_reporting.rs
+++ b/src/librustc_mir/borrow_check/error_reporting.rs
@@ -217,6 +217,17 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
                         break;
                     }
                 }
+                if let ty::TyKind::Param(param_ty) = ty.sty {
+                    let tcx = self.infcx.tcx;
+                    let generics = tcx.generics_of(self.mir_def_id);
+                    let def_id = generics.type_param(&param_ty, tcx).def_id;
+                    if let Some(sp) = tcx.hir().span_if_local(def_id) {
+                        err.span_label(
+                            sp,
+                            "consider adding a `Copy` constraint to this type argument",
+                        );
+                    }
+                }
                 if note {
                     err.note(&format!(
                         "move occurs because {} has type `{}`, \

--- a/src/test/ui/binop/binop-consume-args.nll.stderr
+++ b/src/test/ui/binop/binop-consume-args.nll.stderr
@@ -1,0 +1,253 @@
+error[E0382]: use of moved value: `lhs`
+  --> $DIR/binop-consume-args.rs:7:10
+   |
+LL | fn add<A: Add<B, Output=()>, B>(lhs: A, rhs: B) {
+   |        -                        --- move occurs because `lhs` has type `A`, which does not implement the `Copy` trait
+   |        |
+   |        consider adding a `Copy` constraint to this type argument
+LL |     lhs + rhs;
+   |     --- value moved here
+LL |     drop(lhs);  //~ ERROR use of moved value: `lhs`
+   |          ^^^ value used here after move
+
+error[E0382]: use of moved value: `rhs`
+  --> $DIR/binop-consume-args.rs:8:10
+   |
+LL | fn add<A: Add<B, Output=()>, B>(lhs: A, rhs: B) {
+   |                              -          --- move occurs because `rhs` has type `B`, which does not implement the `Copy` trait
+   |                              |
+   |                              consider adding a `Copy` constraint to this type argument
+LL |     lhs + rhs;
+   |           --- value moved here
+LL |     drop(lhs);  //~ ERROR use of moved value: `lhs`
+LL |     drop(rhs);  //~ ERROR use of moved value: `rhs`
+   |          ^^^ value used here after move
+
+error[E0382]: use of moved value: `lhs`
+  --> $DIR/binop-consume-args.rs:13:10
+   |
+LL | fn sub<A: Sub<B, Output=()>, B>(lhs: A, rhs: B) {
+   |        -                        --- move occurs because `lhs` has type `A`, which does not implement the `Copy` trait
+   |        |
+   |        consider adding a `Copy` constraint to this type argument
+LL |     lhs - rhs;
+   |     --- value moved here
+LL |     drop(lhs);  //~ ERROR use of moved value: `lhs`
+   |          ^^^ value used here after move
+
+error[E0382]: use of moved value: `rhs`
+  --> $DIR/binop-consume-args.rs:14:10
+   |
+LL | fn sub<A: Sub<B, Output=()>, B>(lhs: A, rhs: B) {
+   |                              -          --- move occurs because `rhs` has type `B`, which does not implement the `Copy` trait
+   |                              |
+   |                              consider adding a `Copy` constraint to this type argument
+LL |     lhs - rhs;
+   |           --- value moved here
+LL |     drop(lhs);  //~ ERROR use of moved value: `lhs`
+LL |     drop(rhs);  //~ ERROR use of moved value: `rhs`
+   |          ^^^ value used here after move
+
+error[E0382]: use of moved value: `lhs`
+  --> $DIR/binop-consume-args.rs:19:10
+   |
+LL | fn mul<A: Mul<B, Output=()>, B>(lhs: A, rhs: B) {
+   |        -                        --- move occurs because `lhs` has type `A`, which does not implement the `Copy` trait
+   |        |
+   |        consider adding a `Copy` constraint to this type argument
+LL |     lhs * rhs;
+   |     --- value moved here
+LL |     drop(lhs);  //~ ERROR use of moved value: `lhs`
+   |          ^^^ value used here after move
+
+error[E0382]: use of moved value: `rhs`
+  --> $DIR/binop-consume-args.rs:20:10
+   |
+LL | fn mul<A: Mul<B, Output=()>, B>(lhs: A, rhs: B) {
+   |                              -          --- move occurs because `rhs` has type `B`, which does not implement the `Copy` trait
+   |                              |
+   |                              consider adding a `Copy` constraint to this type argument
+LL |     lhs * rhs;
+   |           --- value moved here
+LL |     drop(lhs);  //~ ERROR use of moved value: `lhs`
+LL |     drop(rhs);  //~ ERROR use of moved value: `rhs`
+   |          ^^^ value used here after move
+
+error[E0382]: use of moved value: `lhs`
+  --> $DIR/binop-consume-args.rs:25:10
+   |
+LL | fn div<A: Div<B, Output=()>, B>(lhs: A, rhs: B) {
+   |        -                        --- move occurs because `lhs` has type `A`, which does not implement the `Copy` trait
+   |        |
+   |        consider adding a `Copy` constraint to this type argument
+LL |     lhs / rhs;
+   |     --- value moved here
+LL |     drop(lhs);  //~ ERROR use of moved value: `lhs`
+   |          ^^^ value used here after move
+
+error[E0382]: use of moved value: `rhs`
+  --> $DIR/binop-consume-args.rs:26:10
+   |
+LL | fn div<A: Div<B, Output=()>, B>(lhs: A, rhs: B) {
+   |                              -          --- move occurs because `rhs` has type `B`, which does not implement the `Copy` trait
+   |                              |
+   |                              consider adding a `Copy` constraint to this type argument
+LL |     lhs / rhs;
+   |           --- value moved here
+LL |     drop(lhs);  //~ ERROR use of moved value: `lhs`
+LL |     drop(rhs);  //~ ERROR use of moved value: `rhs`
+   |          ^^^ value used here after move
+
+error[E0382]: use of moved value: `lhs`
+  --> $DIR/binop-consume-args.rs:31:10
+   |
+LL | fn rem<A: Rem<B, Output=()>, B>(lhs: A, rhs: B) {
+   |        -                        --- move occurs because `lhs` has type `A`, which does not implement the `Copy` trait
+   |        |
+   |        consider adding a `Copy` constraint to this type argument
+LL |     lhs % rhs;
+   |     --- value moved here
+LL |     drop(lhs);  //~ ERROR use of moved value: `lhs`
+   |          ^^^ value used here after move
+
+error[E0382]: use of moved value: `rhs`
+  --> $DIR/binop-consume-args.rs:32:10
+   |
+LL | fn rem<A: Rem<B, Output=()>, B>(lhs: A, rhs: B) {
+   |                              -          --- move occurs because `rhs` has type `B`, which does not implement the `Copy` trait
+   |                              |
+   |                              consider adding a `Copy` constraint to this type argument
+LL |     lhs % rhs;
+   |           --- value moved here
+LL |     drop(lhs);  //~ ERROR use of moved value: `lhs`
+LL |     drop(rhs);  //~ ERROR use of moved value: `rhs`
+   |          ^^^ value used here after move
+
+error[E0382]: use of moved value: `lhs`
+  --> $DIR/binop-consume-args.rs:37:10
+   |
+LL | fn bitand<A: BitAnd<B, Output=()>, B>(lhs: A, rhs: B) {
+   |           -                           --- move occurs because `lhs` has type `A`, which does not implement the `Copy` trait
+   |           |
+   |           consider adding a `Copy` constraint to this type argument
+LL |     lhs & rhs;
+   |     --- value moved here
+LL |     drop(lhs);  //~ ERROR use of moved value: `lhs`
+   |          ^^^ value used here after move
+
+error[E0382]: use of moved value: `rhs`
+  --> $DIR/binop-consume-args.rs:38:10
+   |
+LL | fn bitand<A: BitAnd<B, Output=()>, B>(lhs: A, rhs: B) {
+   |                                    -          --- move occurs because `rhs` has type `B`, which does not implement the `Copy` trait
+   |                                    |
+   |                                    consider adding a `Copy` constraint to this type argument
+LL |     lhs & rhs;
+   |           --- value moved here
+LL |     drop(lhs);  //~ ERROR use of moved value: `lhs`
+LL |     drop(rhs);  //~ ERROR use of moved value: `rhs`
+   |          ^^^ value used here after move
+
+error[E0382]: use of moved value: `lhs`
+  --> $DIR/binop-consume-args.rs:43:10
+   |
+LL | fn bitor<A: BitOr<B, Output=()>, B>(lhs: A, rhs: B) {
+   |          -                          --- move occurs because `lhs` has type `A`, which does not implement the `Copy` trait
+   |          |
+   |          consider adding a `Copy` constraint to this type argument
+LL |     lhs | rhs;
+   |     --- value moved here
+LL |     drop(lhs);  //~ ERROR use of moved value: `lhs`
+   |          ^^^ value used here after move
+
+error[E0382]: use of moved value: `rhs`
+  --> $DIR/binop-consume-args.rs:44:10
+   |
+LL | fn bitor<A: BitOr<B, Output=()>, B>(lhs: A, rhs: B) {
+   |                                  -          --- move occurs because `rhs` has type `B`, which does not implement the `Copy` trait
+   |                                  |
+   |                                  consider adding a `Copy` constraint to this type argument
+LL |     lhs | rhs;
+   |           --- value moved here
+LL |     drop(lhs);  //~ ERROR use of moved value: `lhs`
+LL |     drop(rhs);  //~ ERROR use of moved value: `rhs`
+   |          ^^^ value used here after move
+
+error[E0382]: use of moved value: `lhs`
+  --> $DIR/binop-consume-args.rs:49:10
+   |
+LL | fn bitxor<A: BitXor<B, Output=()>, B>(lhs: A, rhs: B) {
+   |           -                           --- move occurs because `lhs` has type `A`, which does not implement the `Copy` trait
+   |           |
+   |           consider adding a `Copy` constraint to this type argument
+LL |     lhs ^ rhs;
+   |     --- value moved here
+LL |     drop(lhs);  //~ ERROR use of moved value: `lhs`
+   |          ^^^ value used here after move
+
+error[E0382]: use of moved value: `rhs`
+  --> $DIR/binop-consume-args.rs:50:10
+   |
+LL | fn bitxor<A: BitXor<B, Output=()>, B>(lhs: A, rhs: B) {
+   |                                    -          --- move occurs because `rhs` has type `B`, which does not implement the `Copy` trait
+   |                                    |
+   |                                    consider adding a `Copy` constraint to this type argument
+LL |     lhs ^ rhs;
+   |           --- value moved here
+LL |     drop(lhs);  //~ ERROR use of moved value: `lhs`
+LL |     drop(rhs);  //~ ERROR use of moved value: `rhs`
+   |          ^^^ value used here after move
+
+error[E0382]: use of moved value: `lhs`
+  --> $DIR/binop-consume-args.rs:55:10
+   |
+LL | fn shl<A: Shl<B, Output=()>, B>(lhs: A, rhs: B) {
+   |        -                        --- move occurs because `lhs` has type `A`, which does not implement the `Copy` trait
+   |        |
+   |        consider adding a `Copy` constraint to this type argument
+LL |     lhs << rhs;
+   |     --- value moved here
+LL |     drop(lhs);  //~ ERROR use of moved value: `lhs`
+   |          ^^^ value used here after move
+
+error[E0382]: use of moved value: `rhs`
+  --> $DIR/binop-consume-args.rs:56:10
+   |
+LL | fn shl<A: Shl<B, Output=()>, B>(lhs: A, rhs: B) {
+   |                              -          --- move occurs because `rhs` has type `B`, which does not implement the `Copy` trait
+   |                              |
+   |                              consider adding a `Copy` constraint to this type argument
+LL |     lhs << rhs;
+   |            --- value moved here
+LL |     drop(lhs);  //~ ERROR use of moved value: `lhs`
+LL |     drop(rhs);  //~ ERROR use of moved value: `rhs`
+   |          ^^^ value used here after move
+
+error[E0382]: use of moved value: `lhs`
+  --> $DIR/binop-consume-args.rs:61:10
+   |
+LL | fn shr<A: Shr<B, Output=()>, B>(lhs: A, rhs: B) {
+   |        -                        --- move occurs because `lhs` has type `A`, which does not implement the `Copy` trait
+   |        |
+   |        consider adding a `Copy` constraint to this type argument
+LL |     lhs >> rhs;
+   |     --- value moved here
+LL |     drop(lhs);  //~ ERROR use of moved value: `lhs`
+   |          ^^^ value used here after move
+
+error[E0382]: use of moved value: `rhs`
+  --> $DIR/binop-consume-args.rs:62:10
+   |
+LL | fn shr<A: Shr<B, Output=()>, B>(lhs: A, rhs: B) {
+   |                              -          --- move occurs because `rhs` has type `B`, which does not implement the `Copy` trait
+   |                              |
+   |                              consider adding a `Copy` constraint to this type argument
+LL |     lhs >> rhs;
+   |            --- value moved here
+LL |     drop(lhs);  //~ ERROR use of moved value: `lhs`
+LL |     drop(rhs);  //~ ERROR use of moved value: `rhs`
+   |          ^^^ value used here after move
+
+error: aborting due to 20 previous errors
+
+For more information about this error, try `rustc --explain E0382`.

--- a/src/test/ui/binop/binop-move-semantics.nll.stderr
+++ b/src/test/ui/binop/binop-move-semantics.nll.stderr
@@ -1,24 +1,28 @@
 error[E0382]: use of moved value: `x`
   --> $DIR/binop-move-semantics.rs:8:5
    |
+LL | fn double_move<T: Add<Output=()>>(x: T) {
+   |                -                  - move occurs because `x` has type `T`, which does not implement the `Copy` trait
+   |                |
+   |                consider adding a `Copy` constraint to this type argument
 LL |     x
    |     - value moved here
 LL |     +
 LL |     x;  //~ ERROR: use of moved value
    |     ^ value used here after move
-   |
-   = note: move occurs because `x` has type `T`, which does not implement the `Copy` trait
 
 error[E0382]: borrow of moved value: `x`
   --> $DIR/binop-move-semantics.rs:14:5
    |
+LL | fn move_then_borrow<T: Add<Output=()> + Clone>(x: T) {
+   |                     -                          - move occurs because `x` has type `T`, which does not implement the `Copy` trait
+   |                     |
+   |                     consider adding a `Copy` constraint to this type argument
 LL |     x
    |     - value moved here
 LL |     +
 LL |     x.clone();  //~ ERROR: use of moved value
    |     ^ value borrowed here after move
-   |
-   = note: move occurs because `x` has type `T`, which does not implement the `Copy` trait
 
 error[E0505]: cannot move out of `x` because it is borrowed
   --> $DIR/binop-move-semantics.rs:21:5

--- a/src/test/ui/borrowck/borrowck-asm.ast.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-asm.ast.nll.stderr
@@ -1,13 +1,14 @@
 error[E0382]: use of moved value: `x`
   --> $DIR/borrowck-asm.rs:27:17
    |
+LL |         let x = &mut 0isize;
+   |             - move occurs because `x` has type `&mut isize`, which does not implement the `Copy` trait
+LL |         unsafe {
 LL |             asm!("nop" : : "r"(x));
    |                                - value moved here
 LL |         }
 LL |         let z = x;  //[ast]~ ERROR use of moved value: `x`
    |                 ^ value used here after move
-   |
-   = note: move occurs because `x` has type `&mut isize`, which does not implement the `Copy` trait
 
 error[E0503]: cannot use `x` because it was mutably borrowed
   --> $DIR/borrowck-asm.rs:35:32
@@ -66,12 +67,13 @@ LL |         let z = y;
 error[E0382]: use of moved value: `x`
   --> $DIR/borrowck-asm.rs:86:40
    |
+LL |         let x = &mut 2;
+   |             - move occurs because `x` has type `&mut i32`, which does not implement the `Copy` trait
+LL |         unsafe {
 LL |             asm!("nop" : : "r"(x), "r"(x) );    //[ast]~ ERROR use of moved value
    |                                -       ^ value used here after move
    |                                |
    |                                value moved here
-   |
-   = note: move occurs because `x` has type `&mut i32`, which does not implement the `Copy` trait
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/borrowck/borrowck-asm.mir.stderr
+++ b/src/test/ui/borrowck/borrowck-asm.mir.stderr
@@ -1,13 +1,14 @@
 error[E0382]: use of moved value: `x`
   --> $DIR/borrowck-asm.rs:27:17
    |
+LL |         let x = &mut 0isize;
+   |             - move occurs because `x` has type `&mut isize`, which does not implement the `Copy` trait
+LL |         unsafe {
 LL |             asm!("nop" : : "r"(x));
    |                                - value moved here
 LL |         }
 LL |         let z = x;  //[ast]~ ERROR use of moved value: `x`
    |                 ^ value used here after move
-   |
-   = note: move occurs because `x` has type `&mut isize`, which does not implement the `Copy` trait
 
 error[E0503]: cannot use `x` because it was mutably borrowed
   --> $DIR/borrowck-asm.rs:35:32
@@ -66,12 +67,13 @@ LL |         let z = y;
 error[E0382]: use of moved value: `x`
   --> $DIR/borrowck-asm.rs:86:40
    |
+LL |         let x = &mut 2;
+   |             - move occurs because `x` has type `&mut i32`, which does not implement the `Copy` trait
+LL |         unsafe {
 LL |             asm!("nop" : : "r"(x), "r"(x) );    //[ast]~ ERROR use of moved value
    |                                -       ^ value used here after move
    |                                |
    |                                value moved here
-   |
-   = note: move occurs because `x` has type `&mut i32`, which does not implement the `Copy` trait
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/borrowck/borrowck-consume-unsize-vec.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-consume-unsize-vec.nll.stderr
@@ -1,8 +1,8 @@
 error[E0382]: use of moved value: `b`
-  --> $DIR/borrowck-consume-upcast-box.rs:10:13
+  --> $DIR/borrowck-consume-unsize-vec.rs:8:13
    |
-LL | fn foo(b: Box<Foo+Send>) {
-   |        - move occurs because `b` has type `std::boxed::Box<dyn Foo + std::marker::Send>`, which does not implement the `Copy` trait
+LL | fn foo(b: Box<[i32;5]>) {
+   |        - move occurs because `b` has type `std::boxed::Box<[i32; 5]>`, which does not implement the `Copy` trait
 LL |     consume(b);
    |             - value moved here
 LL |     consume(b); //~ ERROR use of moved value

--- a/src/test/ui/borrowck/borrowck-drop-from-guard.stderr
+++ b/src/test/ui/borrowck/borrowck-drop-from-guard.stderr
@@ -1,13 +1,14 @@
 error[E0382]: use of moved value: `my_str`
   --> $DIR/borrowck-drop-from-guard.rs:11:23
    |
+LL |     let my_str = "hello".to_owned();
+   |         ------ move occurs because `my_str` has type `std::string::String`, which does not implement the `Copy` trait
+LL |     match Some(42) {
 LL |         Some(_) if { drop(my_str); false } => {}
    |                           ------ value moved here
 LL |         Some(_) => {}
 LL |         None => { foo(my_str); } //~ ERROR [E0382]
    |                       ^^^^^^ value used here after move
-   |
-   = note: move occurs because `my_str` has type `std::string::String`, which does not implement the `Copy` trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-issue-48962.stderr
+++ b/src/test/ui/borrowck/borrowck-issue-48962.stderr
@@ -1,22 +1,22 @@
 error[E0382]: use of moved value: `src`
   --> $DIR/borrowck-issue-48962.rs:16:5
    |
+LL |     let mut src = &mut node;
+   |         ------- move occurs because `src` has type `&mut Node`, which does not implement the `Copy` trait
 LL |     {src};
    |      --- value moved here
 LL |     src.next = None; //~ ERROR use of moved value: `src` [E0382]
    |     ^^^^^^^^ value used here after move
-   |
-   = note: move occurs because `src` has type `&mut Node`, which does not implement the `Copy` trait
 
 error[E0382]: use of moved value: `src`
   --> $DIR/borrowck-issue-48962.rs:22:5
    |
+LL |     let mut src = &mut (22, 44);
+   |         ------- move occurs because `src` has type `&mut (i32, i32)`, which does not implement the `Copy` trait
 LL |     {src};
    |      --- value moved here
 LL |     src.0 = 66; //~ ERROR use of moved value: `src` [E0382]
    |     ^^^^^^^^^^ value used here after move
-   |
-   = note: move occurs because `src` has type `&mut (i32, i32)`, which does not implement the `Copy` trait
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/borrowck/borrowck-loan-in-overloaded-op.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-loan-in-overloaded-op.nll.stderr
@@ -1,12 +1,12 @@
 error[E0382]: borrow of moved value: `x`
   --> $DIR/borrowck-loan-in-overloaded-op.rs:21:20
    |
+LL |     let x = Foo(box 3);
+   |         - move occurs because `x` has type `Foo`, which does not implement the `Copy` trait
 LL |     let _y = {x} + x.clone(); // the `{x}` forces a move to occur
    |               -    ^ value borrowed here after move
    |               |
    |               value moved here
-   |
-   = note: move occurs because `x` has type `Foo`, which does not implement the `Copy` trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-move-moved-value-into-closure.ast.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-move-moved-value-into-closure.ast.nll.stderr
@@ -1,6 +1,9 @@
 error[E0382]: use of moved value: `t`
   --> $DIR/borrowck-move-moved-value-into-closure.rs:14:12
    |
+LL |     let t: Box<_> = box 3;
+   |         - move occurs because `t` has type `std::boxed::Box<isize>`, which does not implement the `Copy` trait
+LL | 
 LL |     call_f(move|| { *t + 1 });
    |            ------    - variable moved due to use in closure
    |            |
@@ -9,8 +12,6 @@ LL |     call_f(move|| { *t + 1 }); //[ast]~ ERROR capture of moved value
    |            ^^^^^^    - use occurs due to use in closure
    |            |
    |            value used here after move
-   |
-   = note: move occurs because `t` has type `std::boxed::Box<isize>`, which does not implement the `Copy` trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-move-moved-value-into-closure.mir.stderr
+++ b/src/test/ui/borrowck/borrowck-move-moved-value-into-closure.mir.stderr
@@ -1,6 +1,9 @@
 error[E0382]: use of moved value: `t`
   --> $DIR/borrowck-move-moved-value-into-closure.rs:14:12
    |
+LL |     let t: Box<_> = box 3;
+   |         - move occurs because `t` has type `std::boxed::Box<isize>`, which does not implement the `Copy` trait
+LL | 
 LL |     call_f(move|| { *t + 1 });
    |            ------    - variable moved due to use in closure
    |            |
@@ -9,8 +12,6 @@ LL |     call_f(move|| { *t + 1 }); //[ast]~ ERROR capture of moved value
    |            ^^^^^^    - use occurs due to use in closure
    |            |
    |            value used here after move
-   |
-   = note: move occurs because `t` has type `std::boxed::Box<isize>`, which does not implement the `Copy` trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-multiple-captures.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-multiple-captures.nll.stderr
@@ -29,6 +29,8 @@ LL |     borrow(&*p2);
 error[E0382]: use of moved value: `x1`
   --> $DIR/borrowck-multiple-captures.rs:25:19
    |
+LL |     let x1: Box<_> = box 1;
+   |         -- move occurs because `x1` has type `std::boxed::Box<i32>`, which does not implement the `Copy` trait
 LL |     drop(x1);
    |          -- value moved here
 ...
@@ -36,12 +38,12 @@ LL |     thread::spawn(move|| {
    |                   ^^^^^^ value used here after move
 LL |         drop(x1); //~ ERROR capture of moved value: `x1`
    |              -- use occurs due to use in closure
-   |
-   = note: move occurs because `x1` has type `std::boxed::Box<i32>`, which does not implement the `Copy` trait
 
 error[E0382]: use of moved value: `x2`
   --> $DIR/borrowck-multiple-captures.rs:25:19
    |
+LL |     let x2: Box<_> = box 2;
+   |         -- move occurs because `x2` has type `std::boxed::Box<i32>`, which does not implement the `Copy` trait
 LL |     drop(x2);
    |          -- value moved here
 LL |     thread::spawn(move|| {
@@ -49,8 +51,6 @@ LL |     thread::spawn(move|| {
 LL |         drop(x1); //~ ERROR capture of moved value: `x1`
 LL |         drop(x2); //~ ERROR capture of moved value: `x2`
    |              -- use occurs due to use in closure
-   |
-   = note: move occurs because `x2` has type `std::boxed::Box<i32>`, which does not implement the `Copy` trait
 
 error[E0382]: use of moved value: `x`
   --> $DIR/borrowck-multiple-captures.rs:36:14
@@ -88,14 +88,14 @@ LL |         drop(x); //~ ERROR use of moved value: `x`
 error[E0382]: use of moved value: `x`
   --> $DIR/borrowck-multiple-captures.rs:44:19
    |
+LL |     let x: Box<_> = box 1;
+   |         - move occurs because `x` has type `std::boxed::Box<i32>`, which does not implement the `Copy` trait
 LL |     drop(x);
    |          - value moved here
 LL |     thread::spawn(move|| {
    |                   ^^^^^^ value used here after move
 LL |         drop(x); //~ ERROR capture of moved value: `x`
    |              - use occurs due to use in closure
-   |
-   = note: move occurs because `x` has type `std::boxed::Box<i32>`, which does not implement the `Copy` trait
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/borrowck/borrowck-overloaded-call.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-overloaded-call.nll.stderr
@@ -20,12 +20,13 @@ LL |     s(3);   //~ ERROR cannot borrow immutable local variable `s` as mutable
 error[E0382]: use of moved value: `s`
   --> $DIR/borrowck-overloaded-call.rs:75:5
    |
+LL |     let s = SFnOnce {
+   |         - move occurs because `s` has type `SFnOnce`, which does not implement the `Copy` trait
+...
 LL |     s(" world".to_string());
    |     - value moved here
 LL |     s(" world".to_string());    //~ ERROR use of moved value: `s`
    |     ^ value used here after move
-   |
-   = note: move occurs because `s` has type `SFnOnce`, which does not implement the `Copy` trait
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/borrowck/borrowck-overloaded-index-move-index.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-overloaded-index-move-index.nll.stderr
@@ -25,13 +25,14 @@ LL |     use_mut(rs);
 error[E0382]: use of moved value: `s`
   --> $DIR/borrowck-overloaded-index-move-index.rs:53:7
    |
+LL |     let mut s = "hello".to_string();
+   |         ----- move occurs because `s` has type `std::string::String`, which does not implement the `Copy` trait
+...
 LL |     println!("{}", f[s]);
    |                      - value moved here
 ...
 LL |     f[s] = 10;
    |       ^ value used here after move
-   |
-   = note: move occurs because `s` has type `std::string::String`, which does not implement the `Copy` trait
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/borrowck/borrowck-partial-reinit-1.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-partial-reinit-1.nll.stderr
@@ -1,22 +1,24 @@
 error[E0382]: assign of moved value: `t`
   --> $DIR/borrowck-partial-reinit-1.rs:27:5
    |
+LL |     let mut t = Test2 { b: None };
+   |         ----- move occurs because `t` has type `Test2`, which does not implement the `Copy` trait
+LL |     let u = Test;
 LL |     drop(t);
    |          - value moved here
 LL |     t.b = Some(u);
    |     ^^^ value assigned here after move
-   |
-   = note: move occurs because `t` has type `Test2`, which does not implement the `Copy` trait
 
 error[E0382]: assign of moved value: `t`
   --> $DIR/borrowck-partial-reinit-1.rs:33:5
    |
+LL |     let mut t = Test3(None);
+   |         ----- move occurs because `t` has type `Test3`, which does not implement the `Copy` trait
+LL |     let u = Test;
 LL |     drop(t);
    |          - value moved here
 LL |     t.0 = Some(u);
    |     ^^^ value assigned here after move
-   |
-   = note: move occurs because `t` has type `Test3`, which does not implement the `Copy` trait
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/borrowck/borrowck-partial-reinit-2.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-partial-reinit-2.nll.stderr
@@ -1,12 +1,12 @@
 error[E0382]: assign of moved value: `t`
   --> $DIR/borrowck-partial-reinit-2.rs:15:5
    |
+LL |     let mut t = Test { a: 1, b: None};
+   |         ----- move occurs because `t` has type `Test`, which does not implement the `Copy` trait
 LL |     let mut u = Test { a: 2, b: Some(Box::new(t))};
    |                                               - value moved here
 LL |     t.b = Some(Box::new(u));
    |     ^^^ value assigned here after move
-   |
-   = note: move occurs because `t` has type `Test`, which does not implement the `Copy` trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-reinit.stderr
+++ b/src/test/ui/borrowck/borrowck-reinit.stderr
@@ -11,12 +11,13 @@ LL |     let _ = (1,x); //~ ERROR use of moved value: `x` (Ast)
 error[E0382]: use of moved value: `x` (Mir)
   --> $DIR/borrowck-reinit.rs:8:16
    |
+LL |     let mut x = Box::new(0);
+   |         ----- move occurs because `x` has type `std::boxed::Box<i32>`, which does not implement the `Copy` trait
+...
 LL |     drop(x);
    |          - value moved here
 LL |     let _ = (1,x); //~ ERROR use of moved value: `x` (Ast)
    |                ^ value used here after move
-   |
-   = note: move occurs because `x` has type `std::boxed::Box<i32>`, which does not implement the `Copy` trait
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/borrowck/borrowck-unboxed-closures.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-unboxed-closures.nll.stderr
@@ -19,12 +19,14 @@ LL |     f(1, 2);    //~ ERROR cannot borrow immutable argument
 error[E0382]: use of moved value: `f`
   --> $DIR/borrowck-unboxed-closures.rs:12:5
    |
+LL | fn c<F:FnOnce(isize, isize) -> isize>(f: F) {
+   |      -                                - move occurs because `f` has type `F`, which does not implement the `Copy` trait
+   |      |
+   |      consider adding a `Copy` constraint to this type argument
 LL |     f(1, 2);
    |     - value moved here
 LL |     f(1, 2);    //~ ERROR use of moved value
    |     ^ value used here after move
-   |
-   = note: move occurs because `f` has type `F`, which does not implement the `Copy` trait
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/borrowck/borrowck-union-move-assign.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-union-move-assign.nll.stderr
@@ -1,12 +1,12 @@
 error[E0382]: use of moved value: `u`
   --> $DIR/borrowck-union-move-assign.rs:17:21
    |
+LL |             let mut u = U { a: A };
+   |                 ----- move occurs because `u` has type `U`, which does not implement the `Copy` trait
 LL |             let a = u.a;
    |                     --- value moved here
 LL |             let a = u.a; //~ ERROR use of moved value: `u.a`
    |                     ^^^ value used here after move
-   |
-   = note: move occurs because `u` has type `U`, which does not implement the `Copy` trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-union-move.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-union-move.nll.stderr
@@ -1,62 +1,62 @@
 error[E0382]: use of moved value: `u`
   --> $DIR/borrowck-union-move.rs:26:21
    |
+LL |             let mut u = Unn { n1: NonCopy };
+   |                 ----- move occurs because `u` has type `Unn`, which does not implement the `Copy` trait
 LL |             let a = u.n1;
    |                     ---- value moved here
 LL |             let a = u.n1; //~ ERROR use of moved value: `u.n1`
    |                     ^^^^ value used here after move
-   |
-   = note: move occurs because `u` has type `Unn`, which does not implement the `Copy` trait
 
 error[E0382]: use of moved value: `u`
   --> $DIR/borrowck-union-move.rs:31:21
    |
+LL |             let mut u = Unn { n1: NonCopy };
+   |                 ----- move occurs because `u` has type `Unn`, which does not implement the `Copy` trait
 LL |             let a = u.n1;
    |                     ---- value moved here
 LL |             let a = u; //~ ERROR use of partially moved value: `u`
    |                     ^ value used here after move
-   |
-   = note: move occurs because `u` has type `Unn`, which does not implement the `Copy` trait
 
 error[E0382]: use of moved value: `u`
   --> $DIR/borrowck-union-move.rs:36:21
    |
+LL |             let mut u = Unn { n1: NonCopy };
+   |                 ----- move occurs because `u` has type `Unn`, which does not implement the `Copy` trait
 LL |             let a = u.n1;
    |                     ---- value moved here
 LL |             let a = u.n2; //~ ERROR use of moved value: `u.n2`
    |                     ^^^^ value used here after move
-   |
-   = note: move occurs because `u` has type `Unn`, which does not implement the `Copy` trait
 
 error[E0382]: use of moved value: `u`
   --> $DIR/borrowck-union-move.rs:63:21
    |
+LL |             let mut u = Ucn { c: Copy };
+   |                 ----- move occurs because `u` has type `Ucn`, which does not implement the `Copy` trait
 LL |             let a = u.n;
    |                     --- value moved here
 LL |             let a = u.n; //~ ERROR use of moved value: `u.n`
    |                     ^^^ value used here after move
-   |
-   = note: move occurs because `u` has type `Ucn`, which does not implement the `Copy` trait
 
 error[E0382]: use of moved value: `u`
   --> $DIR/borrowck-union-move.rs:68:21
    |
+LL |             let mut u = Ucn { c: Copy };
+   |                 ----- move occurs because `u` has type `Ucn`, which does not implement the `Copy` trait
 LL |             let a = u.n;
    |                     --- value moved here
 LL |             let a = u.c; //~ ERROR use of moved value: `u.c`
    |                     ^^^ value used here after move
-   |
-   = note: move occurs because `u` has type `Ucn`, which does not implement the `Copy` trait
 
 error[E0382]: use of moved value: `u`
   --> $DIR/borrowck-union-move.rs:83:21
    |
+LL |             let mut u = Ucn { c: Copy };
+   |                 ----- move occurs because `u` has type `Ucn`, which does not implement the `Copy` trait
 LL |             let a = u.n;
    |                     --- value moved here
 LL |             let a = u; //~ ERROR use of partially moved value: `u`
    |                     ^ value used here after move
-   |
-   = note: move occurs because `u` has type `Ucn`, which does not implement the `Copy` trait
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/borrowck/issue-41962.stderr
+++ b/src/test/ui/borrowck/issue-41962.stderr
@@ -19,10 +19,13 @@ LL |         if let Some(thing) = maybe {
 error[E0382]: use of moved value (Mir)
   --> $DIR/issue-41962.rs:7:21
    |
+LL |     let maybe = Some(vec![true, true]);
+   |                      ---------------- move occurs because value has type `std::vec::Vec<bool>`, which does not implement the `Copy` trait
+...
 LL |         if let Some(thing) = maybe {
    |                     ^^^^^ value moved here, in previous iteration of loop
    |
-   = note: move occurs because value has type `std::vec::Vec<bool>`, which does not implement the `Copy` trait
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/borrowck/issue-41962.stderr
+++ b/src/test/ui/borrowck/issue-41962.stderr
@@ -19,13 +19,10 @@ LL |         if let Some(thing) = maybe {
 error[E0382]: use of moved value (Mir)
   --> $DIR/issue-41962.rs:7:21
    |
-LL |     let maybe = Some(vec![true, true]);
-   |                      ---------------- move occurs because value has type `std::vec::Vec<bool>`, which does not implement the `Copy` trait
-...
 LL |         if let Some(thing) = maybe {
    |                     ^^^^^ value moved here, in previous iteration of loop
    |
-   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+   = note: move occurs because value has type `std::vec::Vec<bool>`, which does not implement the `Copy` trait
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/borrowck/issue-54499-field-mutation-of-moved-out-with-mut.nll.stderr
+++ b/src/test/ui/borrowck/issue-54499-field-mutation-of-moved-out-with-mut.nll.stderr
@@ -1,32 +1,32 @@
 error[E0382]: assign to part of moved value: `t`
   --> $DIR/issue-54499-field-mutation-of-moved-out-with-mut.rs:23:9
    |
+LL |         let mut t: Tuple = (S(0), 0);
+   |             ----- move occurs because `t` has type `(S, i32)`, which does not implement the `Copy` trait
 LL |         drop(t);
    |              - value moved here
 LL |         t.0 = S(1);
    |         ^^^^^^^^^^ value partially assigned here after move
-   |
-   = note: move occurs because `t` has type `(S, i32)`, which does not implement the `Copy` trait
 
 error[E0382]: assign to part of moved value: `u`
   --> $DIR/issue-54499-field-mutation-of-moved-out-with-mut.rs:34:9
    |
+LL |         let mut u: Tpair = Tpair(S(0), 0);
+   |             ----- move occurs because `u` has type `Tpair`, which does not implement the `Copy` trait
 LL |         drop(u);
    |              - value moved here
 LL |         u.0 = S(1);
    |         ^^^^^^^^^^ value partially assigned here after move
-   |
-   = note: move occurs because `u` has type `Tpair`, which does not implement the `Copy` trait
 
 error[E0382]: assign to part of moved value: `v`
   --> $DIR/issue-54499-field-mutation-of-moved-out-with-mut.rs:45:9
    |
+LL |         let mut v: Spair = Spair { x: S(0), y: 0 };
+   |             ----- move occurs because `v` has type `Spair`, which does not implement the `Copy` trait
 LL |         drop(v);
    |              - value moved here
 LL |         v.x = S(1);
    |         ^^^^^^^^^^ value partially assigned here after move
-   |
-   = note: move occurs because `v` has type `Spair`, which does not implement the `Copy` trait
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/borrowck/issue-54499-field-mutation-of-moved-out.nll.stderr
+++ b/src/test/ui/borrowck/issue-54499-field-mutation-of-moved-out.nll.stderr
@@ -10,12 +10,12 @@ LL |         t.0 = S(1);
 error[E0382]: assign to part of moved value: `t`
   --> $DIR/issue-54499-field-mutation-of-moved-out.rs:23:9
    |
+LL |         let t: Tuple = (S(0), 0);
+   |             - move occurs because `t` has type `(S, i32)`, which does not implement the `Copy` trait
 LL |         drop(t);
    |              - value moved here
 LL |         t.0 = S(1);
    |         ^^^^^^^^^^ value partially assigned here after move
-   |
-   = note: move occurs because `t` has type `(S, i32)`, which does not implement the `Copy` trait
 
 error[E0594]: cannot assign to `t.1`, as `t` is not declared as mutable
   --> $DIR/issue-54499-field-mutation-of-moved-out.rs:27:9
@@ -38,12 +38,12 @@ LL |         u.0 = S(1);
 error[E0382]: assign to part of moved value: `u`
   --> $DIR/issue-54499-field-mutation-of-moved-out.rs:38:9
    |
+LL |         let u: Tpair = Tpair(S(0), 0);
+   |             - move occurs because `u` has type `Tpair`, which does not implement the `Copy` trait
 LL |         drop(u);
    |              - value moved here
 LL |         u.0 = S(1);
    |         ^^^^^^^^^^ value partially assigned here after move
-   |
-   = note: move occurs because `u` has type `Tpair`, which does not implement the `Copy` trait
 
 error[E0594]: cannot assign to `u.1`, as `u` is not declared as mutable
   --> $DIR/issue-54499-field-mutation-of-moved-out.rs:42:9
@@ -66,12 +66,12 @@ LL |         v.x = S(1);
 error[E0382]: assign to part of moved value: `v`
   --> $DIR/issue-54499-field-mutation-of-moved-out.rs:53:9
    |
+LL |         let v: Spair = Spair { x: S(0), y: 0 };
+   |             - move occurs because `v` has type `Spair`, which does not implement the `Copy` trait
 LL |         drop(v);
    |              - value moved here
 LL |         v.x = S(1);
    |         ^^^^^^^^^^ value partially assigned here after move
-   |
-   = note: move occurs because `v` has type `Spair`, which does not implement the `Copy` trait
 
 error[E0594]: cannot assign to `v.y`, as `v` is not declared as mutable
   --> $DIR/issue-54499-field-mutation-of-moved-out.rs:57:9

--- a/src/test/ui/borrowck/two-phase-nonrecv-autoref.ast.nll.stderr
+++ b/src/test/ui/borrowck/two-phase-nonrecv-autoref.ast.nll.stderr
@@ -10,6 +10,8 @@ LL |         f(f(10));
 error[E0382]: use of moved value: `*f`
   --> $DIR/two-phase-nonrecv-autoref.rs:69:11
    |
+LL |     fn twice_ten_so<F: FnOnce(i32) -> i32>(f: Box<F>) {
+   |                     - consider adding a `Copy` constraint to this type argument
 LL |         f(f(10));
    |         - ^ value used here after move
    |         |

--- a/src/test/ui/borrowck/two-phase-nonrecv-autoref.nll.stderr
+++ b/src/test/ui/borrowck/two-phase-nonrecv-autoref.nll.stderr
@@ -10,6 +10,8 @@ LL |         f(f(10));
 error[E0382]: use of moved value: `*f`
   --> $DIR/two-phase-nonrecv-autoref.rs:69:11
    |
+LL |     fn twice_ten_so<F: FnOnce(i32) -> i32>(f: Box<F>) {
+   |                     - consider adding a `Copy` constraint to this type argument
 LL |         f(f(10));
    |         - ^ value used here after move
    |         |

--- a/src/test/ui/codemap_tests/tab_3.nll.stderr
+++ b/src/test/ui/codemap_tests/tab_3.nll.stderr
@@ -1,13 +1,13 @@
 error[E0382]: borrow of moved value: `some_vec`
   --> $DIR/tab_3.rs:7:20
    |
+LL |     let some_vec = vec!["hi"];
+   |         -------- move occurs because `some_vec` has type `std::vec::Vec<&str>`, which does not implement the `Copy` trait
 LL |     some_vec.into_iter();
    |     -------- value moved here
 LL |     {
 LL |         println!("{:?}", some_vec); //~ ERROR use of moved
    |                          ^^^^^^^^ value borrowed here after move
-   |
-   = note: move occurs because `some_vec` has type `std::vec::Vec<&str>`, which does not implement the `Copy` trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-17385.nll.stderr
+++ b/src/test/ui/issues/issue-17385.nll.stderr
@@ -1,23 +1,23 @@
 error[E0382]: use of moved value: `foo`
   --> $DIR/issue-17385.rs:19:11
    |
+LL |     let foo = X(1);
+   |         --- move occurs because `foo` has type `X`, which does not implement the `Copy` trait
 LL |     drop(foo);
    |          --- value moved here
 LL |     match foo { //~ ERROR use of moved value
 LL |         X(1) => (),
    |           ^ value used here after move
-   |
-   = note: move occurs because `foo` has type `X`, which does not implement the `Copy` trait
 
 error[E0382]: use of moved value: `e`
   --> $DIR/issue-17385.rs:25:11
    |
+LL |     let e = Enum::Variant2;
+   |         - move occurs because `e` has type `Enum`, which does not implement the `Copy` trait
 LL |     drop(e);
    |          - value moved here
 LL |     match e { //~ ERROR use of moved value
    |           ^ value used here after move
-   |
-   = note: move occurs because `e` has type `Enum`, which does not implement the `Copy` trait
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-24357.nll.stderr
+++ b/src/test/ui/issues/issue-24357.nll.stderr
@@ -1,6 +1,8 @@
 error[E0382]: use of moved value: `x`
   --> $DIR/issue-24357.rs:6:12
    |
+LL |    let x = NoCopy;
+   |        - move occurs because `x` has type `NoCopy`, which does not implement the `Copy` trait
 LL |    let f = move || { let y = x; };
    |            -------           - variable moved due to use in closure
    |            |
@@ -8,8 +10,6 @@ LL |    let f = move || { let y = x; };
 LL |    //~^ NOTE value moved (into closure) here
 LL |    let z = x;
    |            ^ value used here after move
-   |
-   = note: move occurs because `x` has type `NoCopy`, which does not implement the `Copy` trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-25700.nll.stderr
+++ b/src/test/ui/issues/issue-25700.nll.stderr
@@ -1,0 +1,13 @@
+error[E0382]: use of moved value: `t`
+  --> $DIR/issue-25700.rs:13:10
+   |
+LL |     let t = S::<()>(None);
+   |         - move occurs because `t` has type `S<()>`, which does not implement the `Copy` trait
+LL |     drop(t);
+   |          - value moved here
+LL |     drop(t); //~ ERROR use of moved value
+   |          ^ value used here after move
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0382`.

--- a/src/test/ui/issues/issue-27282-move-match-input-into-guard.stderr
+++ b/src/test/ui/issues/issue-27282-move-match-input-into-guard.stderr
@@ -1,6 +1,9 @@
 error[E0382]: use of moved value: `b`
   --> $DIR/issue-27282-move-match-input-into-guard.rs:18:14
    |
+LL |     let b = &mut true;
+   |         - move occurs because `b` has type `&mut bool`, which does not implement the `Copy` trait
+...
 LL |         _ if { (|| { let bar = b; *bar = false; })();
    |                 --             - variable moved due to use in closure
    |                 |
@@ -8,8 +11,6 @@ LL |         _ if { (|| { let bar = b; *bar = false; })();
 LL |                      false } => { },
 LL |         &mut true => { println!("You might think we should get here"); },
    |              ^^^^ value used here after move
-   |
-   = note: move occurs because `b` has type `&mut bool`, which does not implement the `Copy` trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-29723.stderr
+++ b/src/test/ui/issues/issue-29723.stderr
@@ -1,13 +1,14 @@
 error[E0382]: use of moved value: `s`
   --> $DIR/issue-29723.rs:12:13
    |
+LL |     let s = String::new();
+   |         - move occurs because `s` has type `std::string::String`, which does not implement the `Copy` trait
+LL |     let _s = match 0 {
 LL |         0 if { drop(s); false } => String::from("oops"),
    |                     - value moved here
 ...
 LL |             s
    |             ^ value used here after move
-   |
-   = note: move occurs because `s` has type `std::string::String`, which does not implement the `Copy` trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-34721.rs
+++ b/src/test/ui/issues/issue-34721.rs
@@ -1,0 +1,34 @@
+#![feature(nll)]
+
+pub trait Foo {
+    fn zero(self) -> Self;
+}
+
+impl Foo for u32 {
+    fn zero(self) -> u32 { 0u32 }
+}
+
+pub mod bar {
+    pub use Foo;
+    pub fn bar<T: Foo>(x: T) -> T {
+      x.zero()
+    }
+}
+
+mod baz {
+    use bar;
+    use Foo;
+    pub fn baz<T: Foo>(x: T) -> T {
+        if 0 == 1 {
+            bar::bar(x.zero())
+        } else {
+            x.zero()
+        };
+        x.zero()
+        //~^ ERROR use of moved value
+    }
+}
+
+fn main() {
+    let _ = baz::baz(0u32);
+}

--- a/src/test/ui/issues/issue-34721.stderr
+++ b/src/test/ui/issues/issue-34721.stderr
@@ -2,7 +2,9 @@ error[E0382]: use of moved value: `x`
   --> $DIR/issue-34721.rs:27:9
    |
 LL |     pub fn baz<T: Foo>(x: T) -> T {
-   |                        - move occurs because `x` has type `T`, which does not implement the `Copy` trait
+   |                -       - move occurs because `x` has type `T`, which does not implement the `Copy` trait
+   |                |
+   |                consider adding a `Copy` constraint to this type argument
 LL |         if 0 == 1 {
 LL |             bar::bar(x.zero())
    |                      - value moved here

--- a/src/test/ui/issues/issue-34721.stderr
+++ b/src/test/ui/issues/issue-34721.stderr
@@ -1,0 +1,18 @@
+error[E0382]: use of moved value: `x`
+  --> $DIR/issue-34721.rs:27:9
+   |
+LL |     pub fn baz<T: Foo>(x: T) -> T {
+   |                        - move occurs because `x` has type `T`, which does not implement the `Copy` trait
+LL |         if 0 == 1 {
+LL |             bar::bar(x.zero())
+   |                      - value moved here
+LL |         } else {
+LL |             x.zero()
+   |             - value moved here
+LL |         };
+LL |         x.zero()
+   |         ^ value used here after move
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0382`.

--- a/src/test/ui/issues/issue-42796.nll.stderr
+++ b/src/test/ui/issues/issue-42796.nll.stderr
@@ -1,13 +1,13 @@
 error[E0382]: borrow of moved value: `s`
   --> $DIR/issue-42796.rs:18:20
    |
+LL |     let s = "Hello!".to_owned();
+   |         - move occurs because `s` has type `std::string::String`, which does not implement the `Copy` trait
 LL |     let mut s_copy = s;
    |                      - value moved here
 ...
 LL |     println!("{}", s); //~ ERROR use of moved value
    |                    ^ value borrowed here after move
-   |
-   = note: move occurs because `s` has type `std::string::String`, which does not implement the `Copy` trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/liveness/liveness-move-call-arg.nll.stderr
+++ b/src/test/ui/liveness/liveness-move-call-arg.nll.stderr
@@ -1,10 +1,11 @@
 error[E0382]: use of moved value: `x`
   --> $DIR/liveness-move-call-arg.rs:9:14
    |
+LL |     let x: Box<isize> = box 25;
+   |         - move occurs because `x` has type `std::boxed::Box<isize>`, which does not implement the `Copy` trait
+LL |     loop {
 LL |         take(x); //~ ERROR use of moved value: `x`
    |              ^ value moved here, in previous iteration of loop
-   |
-   = note: move occurs because `x` has type `std::boxed::Box<isize>`, which does not implement the `Copy` trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/liveness/liveness-move-in-loop.nll.stderr
+++ b/src/test/ui/liveness/liveness-move-in-loop.nll.stderr
@@ -1,10 +1,11 @@
 error[E0382]: use of moved value: `y`
   --> $DIR/liveness-move-in-loop.rs:11:25
    |
+LL |     let y: Box<isize> = box 42;
+   |         - move occurs because `y` has type `std::boxed::Box<isize>`, which does not implement the `Copy` trait
+...
 LL |                     x = y; //~ ERROR use of moved value
    |                         ^ value moved here, in previous iteration of loop
-   |
-   = note: move occurs because `y` has type `std::boxed::Box<isize>`, which does not implement the `Copy` trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/liveness/liveness-move-in-while.nll.stderr
+++ b/src/test/ui/liveness/liveness-move-in-while.nll.stderr
@@ -1,12 +1,13 @@
 error[E0382]: borrow of moved value: `y`
   --> $DIR/liveness-move-in-while.rs:7:24
    |
+LL |     let y: Box<isize> = box 42;
+   |         - move occurs because `y` has type `std::boxed::Box<isize>`, which does not implement the `Copy` trait
+...
 LL |         println!("{}", y); //~ ERROR use of moved value: `y`
    |                        ^ value borrowed here after move
 LL |         while true { while true { while true { x = y; x.clone(); } } }
    |                                                    - value moved here, in previous iteration of loop
-   |
-   = note: move occurs because `y` has type `std::boxed::Box<isize>`, which does not implement the `Copy` trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/liveness/liveness-use-after-move.nll.stderr
+++ b/src/test/ui/liveness/liveness-use-after-move.nll.stderr
@@ -1,12 +1,12 @@
 error[E0382]: borrow of moved value: `x`
   --> $DIR/liveness-use-after-move.rs:6:20
    |
+LL |     let x: Box<_> = box 5;
+   |         - move occurs because `x` has type `std::boxed::Box<i32>`, which does not implement the `Copy` trait
 LL |     let y = x;
    |             - value moved here
 LL |     println!("{}", *x); //~ ERROR use of moved value: `*x`
    |                    ^^ value borrowed here after move
-   |
-   = note: move occurs because `x` has type `std::boxed::Box<i32>`, which does not implement the `Copy` trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/liveness/liveness-use-after-send.nll.stderr
+++ b/src/test/ui/liveness/liveness-use-after-send.nll.stderr
@@ -1,12 +1,12 @@
 error[E0382]: borrow of moved value: `message`
   --> $DIR/liveness-use-after-send.rs:16:20
    |
+LL | fn test00_start(ch: Chan<Box<isize>>, message: Box<isize>, _count: Box<isize>) {
+   |                                       ------- move occurs because `message` has type `std::boxed::Box<isize>`, which does not implement the `Copy` trait
 LL |     send(ch, message);
    |              ------- value moved here
 LL |     println!("{}", message); //~ ERROR use of moved value: `message`
    |                    ^^^^^^^ value borrowed here after move
-   |
-   = note: move occurs because `message` has type `std::boxed::Box<isize>`, which does not implement the `Copy` trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/moves/move-guard-same-consts.nll.stderr
+++ b/src/test/ui/moves/move-guard-same-consts.nll.stderr
@@ -1,11 +1,13 @@
 error[E0382]: use of moved value: `x`
-  --> $DIR/move-in-guard-2.rs:10:24
+  --> $DIR/move-guard-same-consts.rs:20:24
    |
 LL |     let x: Box<_> = box 1;
    |         - move occurs because `x` has type `std::boxed::Box<i32>`, which does not implement the `Copy` trait
 ...
-LL |         (_, 2) if take(x) => (), //~ ERROR use of moved value: `x`
-   |                        ^ value moved here, in previous iteration of loop
+LL |         (1, 2) if take(x) => (),
+   |                        - value moved here
+LL |         (1, 2) if take(x) => (), //~ ERROR use of moved value: `x`
+   |                        ^ value used here after move
 
 error: aborting due to previous error
 

--- a/src/test/ui/moves/move-in-guard-1.nll.stderr
+++ b/src/test/ui/moves/move-in-guard-1.nll.stderr
@@ -1,11 +1,13 @@
 error[E0382]: use of moved value: `x`
-  --> $DIR/move-in-guard-2.rs:10:24
+  --> $DIR/move-in-guard-1.rs:10:24
    |
 LL |     let x: Box<_> = box 1;
    |         - move occurs because `x` has type `std::boxed::Box<i32>`, which does not implement the `Copy` trait
 ...
+LL |         (1, _) if take(x) => (),
+   |                        - value moved here
 LL |         (_, 2) if take(x) => (), //~ ERROR use of moved value: `x`
-   |                        ^ value moved here, in previous iteration of loop
+   |                        ^ value used here after move
 
 error: aborting due to previous error
 

--- a/src/test/ui/moves/move-into-dead-array-2.nll.stderr
+++ b/src/test/ui/moves/move-into-dead-array-2.nll.stderr
@@ -1,12 +1,12 @@
 error[E0382]: use of moved value: `a`
   --> $DIR/move-into-dead-array-2.rs:14:5
    |
+LL | fn foo(mut a: [D; 4], i: usize) {
+   |        ----- move occurs because `a` has type `[D; 4]`, which does not implement the `Copy` trait
 LL |     drop(a);
    |          - value moved here
 LL |     a[i] = d(); //~ ERROR use of moved value: `a`
    |     ^^^^ value used here after move
-   |
-   = note: move occurs because `a` has type `[D; 4]`, which does not implement the `Copy` trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/moves/moves-based-on-type-access-to-field.nll.stderr
+++ b/src/test/ui/moves/moves-based-on-type-access-to-field.nll.stderr
@@ -1,12 +1,12 @@
 error[E0382]: borrow of moved value: `x`
   --> $DIR/moves-based-on-type-access-to-field.rs:11:12
    |
+LL |     let x = vec!["hi".to_string()];
+   |         - move occurs because `x` has type `std::vec::Vec<std::string::String>`, which does not implement the `Copy` trait
 LL |     consume(x.into_iter().next().unwrap());
    |             - value moved here
 LL |     touch(&x[0]); //~ ERROR use of moved value: `x`
    |            ^ value borrowed here after move
-   |
-   = note: move occurs because `x` has type `std::vec::Vec<std::string::String>`, which does not implement the `Copy` trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/moves/moves-based-on-type-capture-clause-bad.nll.stderr
+++ b/src/test/ui/moves/moves-based-on-type-capture-clause-bad.nll.stderr
@@ -1,6 +1,8 @@
 error[E0382]: borrow of moved value: `x`
   --> $DIR/moves-based-on-type-capture-clause-bad.rs:8:20
    |
+LL |     let x = "Hello world!".to_string();
+   |         - move occurs because `x` has type `std::string::String`, which does not implement the `Copy` trait
 LL |     thread::spawn(move|| {
    |                   ------ value moved into closure here
 LL |         println!("{}", x);
@@ -8,8 +10,6 @@ LL |         println!("{}", x);
 LL |     });
 LL |     println!("{}", x); //~ ERROR use of moved value
    |                    ^ value borrowed here after move
-   |
-   = note: move occurs because `x` has type `std::string::String`, which does not implement the `Copy` trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/moves/moves-based-on-type-distribute-copy-over-paren.nll.stderr
+++ b/src/test/ui/moves/moves-based-on-type-distribute-copy-over-paren.nll.stderr
@@ -1,24 +1,24 @@
 error[E0382]: borrow of moved value: `x`
   --> $DIR/moves-based-on-type-distribute-copy-over-paren.rs:11:11
    |
+LL |     let x = "hi".to_string();
+   |         - move occurs because `x` has type `std::string::String`, which does not implement the `Copy` trait
 LL |     let _y = Foo { f:x };
    |                      - value moved here
 LL |     //~^ NOTE value moved here
 LL |     touch(&x); //~ ERROR use of moved value: `x`
    |           ^^ value borrowed here after move
-   |
-   = note: move occurs because `x` has type `std::string::String`, which does not implement the `Copy` trait
 
 error[E0382]: borrow of moved value: `x`
   --> $DIR/moves-based-on-type-distribute-copy-over-paren.rs:20:11
    |
+LL |     let x = "hi".to_string();
+   |         - move occurs because `x` has type `std::string::String`, which does not implement the `Copy` trait
 LL |     let _y = Foo { f:(((x))) };
    |                      ------- value moved here
 LL |     //~^ NOTE value moved here
 LL |     touch(&x); //~ ERROR use of moved value: `x`
    |           ^^ value borrowed here after move
-   |
-   = note: move occurs because `x` has type `std::string::String`, which does not implement the `Copy` trait
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/moves/moves-based-on-type-exprs.nll.stderr
+++ b/src/test/ui/moves/moves-based-on-type-exprs.nll.stderr
@@ -1,117 +1,122 @@
 error[E0382]: borrow of moved value: `x`
   --> $DIR/moves-based-on-type-exprs.rs:12:11
    |
+LL |     let x = "hi".to_string();
+   |         - move occurs because `x` has type `std::string::String`, which does not implement the `Copy` trait
 LL |     let _y = Foo { f:x };
    |                      - value moved here
 LL |     touch(&x); //~ ERROR use of moved value: `x`
    |           ^^ value borrowed here after move
-   |
-   = note: move occurs because `x` has type `std::string::String`, which does not implement the `Copy` trait
 
 error[E0382]: borrow of moved value: `x`
   --> $DIR/moves-based-on-type-exprs.rs:18:11
    |
+LL |     let x = "hi".to_string();
+   |         - move occurs because `x` has type `std::string::String`, which does not implement the `Copy` trait
 LL |     let _y = (x, 3);
    |               - value moved here
 LL |     touch(&x); //~ ERROR use of moved value: `x`
    |           ^^ value borrowed here after move
-   |
-   = note: move occurs because `x` has type `std::string::String`, which does not implement the `Copy` trait
 
 error[E0382]: borrow of moved value: `x`
   --> $DIR/moves-based-on-type-exprs.rs:35:11
    |
+LL |     let x = "hi".to_string();
+   |         - move occurs because `x` has type `std::string::String`, which does not implement the `Copy` trait
+...
 LL |         x
    |         - value moved here
 ...
 LL |     touch(&x); //~ ERROR use of moved value: `x`
    |           ^^ value borrowed here after move
-   |
-   = note: move occurs because `x` has type `std::string::String`, which does not implement the `Copy` trait
 
 error[E0382]: borrow of moved value: `y`
   --> $DIR/moves-based-on-type-exprs.rs:36:11
    |
+LL |     let y = "ho".to_string();
+   |         - move occurs because `y` has type `std::string::String`, which does not implement the `Copy` trait
+...
 LL |         y
    |         - value moved here
 ...
 LL |     touch(&y); //~ ERROR use of moved value: `y`
    |           ^^ value borrowed here after move
-   |
-   = note: move occurs because `y` has type `std::string::String`, which does not implement the `Copy` trait
 
 error[E0382]: borrow of moved value: `x`
   --> $DIR/moves-based-on-type-exprs.rs:46:11
    |
+LL |     let x = "hi".to_string();
+   |         - move occurs because `x` has type `std::string::String`, which does not implement the `Copy` trait
+...
 LL |         true => x,
    |                 - value moved here
 ...
 LL |     touch(&x); //~ ERROR use of moved value: `x`
    |           ^^ value borrowed here after move
-   |
-   = note: move occurs because `x` has type `std::string::String`, which does not implement the `Copy` trait
 
 error[E0382]: borrow of moved value: `y`
   --> $DIR/moves-based-on-type-exprs.rs:47:11
    |
+LL |     let y = "ho".to_string();
+   |         - move occurs because `y` has type `std::string::String`, which does not implement the `Copy` trait
+...
 LL |         false => y
    |                  - value moved here
 ...
 LL |     touch(&y); //~ ERROR use of moved value: `y`
    |           ^^ value borrowed here after move
-   |
-   = note: move occurs because `y` has type `std::string::String`, which does not implement the `Copy` trait
 
 error[E0382]: borrow of moved value: `x`
   --> $DIR/moves-based-on-type-exprs.rs:58:11
    |
+LL |     let x = "hi".to_string();
+   |         - move occurs because `x` has type `std::string::String`, which does not implement the `Copy` trait
+...
 LL |         _ if guard(x) => 10,
    |                    - value moved here
 ...
 LL |     touch(&x); //~ ERROR use of moved value: `x`
    |           ^^ value borrowed here after move
-   |
-   = note: move occurs because `x` has type `std::string::String`, which does not implement the `Copy` trait
 
 error[E0382]: borrow of moved value: `x`
   --> $DIR/moves-based-on-type-exprs.rs:65:11
    |
+LL |     let x = "hi".to_string();
+   |         - move occurs because `x` has type `std::string::String`, which does not implement the `Copy` trait
 LL |     let _y = [x];
    |               - value moved here
 LL |     touch(&x); //~ ERROR use of moved value: `x`
    |           ^^ value borrowed here after move
-   |
-   = note: move occurs because `x` has type `std::string::String`, which does not implement the `Copy` trait
 
 error[E0382]: borrow of moved value: `x`
   --> $DIR/moves-based-on-type-exprs.rs:71:11
    |
+LL |     let x = "hi".to_string();
+   |         - move occurs because `x` has type `std::string::String`, which does not implement the `Copy` trait
 LL |     let _y = vec![x];
    |                   - value moved here
 LL |     touch(&x); //~ ERROR use of moved value: `x`
    |           ^^ value borrowed here after move
-   |
-   = note: move occurs because `x` has type `std::string::String`, which does not implement the `Copy` trait
 
 error[E0382]: borrow of moved value: `x`
   --> $DIR/moves-based-on-type-exprs.rs:77:11
    |
+LL |     let x = vec!["hi".to_string()];
+   |         - move occurs because `x` has type `std::vec::Vec<std::string::String>`, which does not implement the `Copy` trait
 LL |     let _y = x.into_iter().next().unwrap();
    |              - value moved here
 LL |     touch(&x); //~ ERROR use of moved value: `x`
    |           ^^ value borrowed here after move
-   |
-   = note: move occurs because `x` has type `std::vec::Vec<std::string::String>`, which does not implement the `Copy` trait
 
 error[E0382]: borrow of moved value: `x`
   --> $DIR/moves-based-on-type-exprs.rs:83:11
    |
+LL |     let x = vec!["hi".to_string()];
+   |         - move occurs because `x` has type `std::vec::Vec<std::string::String>`, which does not implement the `Copy` trait
 LL |     let _y = [x.into_iter().next().unwrap(); 1];
    |               - value moved here
 LL |     touch(&x); //~ ERROR use of moved value: `x`
    |           ^^ value borrowed here after move
-   |
-   = note: move occurs because `x` has type `std::vec::Vec<std::string::String>`, which does not implement the `Copy` trait
 
 error: aborting due to 11 previous errors
 

--- a/src/test/ui/moves/moves-based-on-type-no-recursive-stack-closure.nll.stderr
+++ b/src/test/ui/moves/moves-based-on-type-no-recursive-stack-closure.nll.stderr
@@ -10,12 +10,14 @@ LL |                     (f.c)(f, true);
 error[E0382]: borrow of moved value: `f`
   --> $DIR/moves-based-on-type-no-recursive-stack-closure.rs:32:5
    |
+LL | fn conspirator<F>(mut f: F) where F: FnMut(&mut R, bool) {
+   |                -  ----- move occurs because `f` has type `F`, which does not implement the `Copy` trait
+   |                |
+   |                consider adding a `Copy` constraint to this type argument
 LL |     let mut r = R {c: Box::new(f)};
    |                                - value moved here
 LL |     f(&mut r, false) //~ ERROR use of moved value
    |     ^ value borrowed here after move
-   |
-   = note: move occurs because `f` has type `F`, which does not implement the `Copy` trait
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/moves/moves-based-on-type-tuple.stderr
+++ b/src/test/ui/moves/moves-based-on-type-tuple.stderr
@@ -11,12 +11,12 @@ LL |     box (x, x)
 error[E0382]: use of moved value: `x` (Mir)
   --> $DIR/moves-based-on-type-tuple.rs:6:13
    |
+LL | fn dup(x: Box<isize>) -> Box<(Box<isize>,Box<isize>)> {
+   |        - move occurs because `x` has type `std::boxed::Box<isize>`, which does not implement the `Copy` trait
 LL |     box (x, x)
    |          -  ^ value used here after move
    |          |
    |          value moved here
-   |
-   = note: move occurs because `x` has type `std::boxed::Box<isize>`, which does not implement the `Copy` trait
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/nll/closure-access-spans.stderr
+++ b/src/test/ui/nll/closure-access-spans.stderr
@@ -59,50 +59,50 @@ LL |     r.use_ref();
 error[E0382]: borrow of moved value: `x`
   --> $DIR/closure-access-spans.rs:37:5
    |
+LL | fn closure_imm_capture_moved(mut x: String) {
+   |                              ----- move occurs because `x` has type `std::string::String`, which does not implement the `Copy` trait
 LL |     let r = x;
    |             - value moved here
 LL |     || x.len(); //~ ERROR
    |     ^^ - borrow occurs due to use in closure
    |     |
    |     value borrowed here after move
-   |
-   = note: move occurs because `x` has type `std::string::String`, which does not implement the `Copy` trait
 
 error[E0382]: borrow of moved value: `x`
   --> $DIR/closure-access-spans.rs:42:5
    |
+LL | fn closure_mut_capture_moved(mut x: String) {
+   |                              ----- move occurs because `x` has type `std::string::String`, which does not implement the `Copy` trait
 LL |     let r = x;
    |             - value moved here
 LL |     || x = String::new(); //~ ERROR
    |     ^^ - borrow occurs due to use in closure
    |     |
    |     value borrowed here after move
-   |
-   = note: move occurs because `x` has type `std::string::String`, which does not implement the `Copy` trait
 
 error[E0382]: borrow of moved value: `x`
   --> $DIR/closure-access-spans.rs:47:5
    |
+LL | fn closure_unique_capture_moved(x: &mut String) {
+   |                                 - move occurs because `x` has type `&mut std::string::String`, which does not implement the `Copy` trait
 LL |     let r = x;
    |             - value moved here
 LL |     || *x = String::new(); //~ ERROR
    |     ^^  - borrow occurs due to use in closure
    |     |
    |     value borrowed here after move
-   |
-   = note: move occurs because `x` has type `&mut std::string::String`, which does not implement the `Copy` trait
 
 error[E0382]: use of moved value: `x`
   --> $DIR/closure-access-spans.rs:52:5
    |
+LL | fn closure_move_capture_moved(x: &mut String) {
+   |                               - move occurs because `x` has type `&mut std::string::String`, which does not implement the `Copy` trait
 LL |     let r = x;
    |             - value moved here
 LL |     || x; //~ ERROR
    |     ^^ - use occurs due to use in closure
    |     |
    |     value used here after move
-   |
-   = note: move occurs because `x` has type `&mut std::string::String`, which does not implement the `Copy` trait
 
 error: aborting due to 9 previous errors
 

--- a/src/test/ui/nll/closure-move-spans.stderr
+++ b/src/test/ui/nll/closure-move-spans.stderr
@@ -1,38 +1,38 @@
 error[E0382]: use of moved value: `x`
   --> $DIR/closure-move-spans.rs:7:13
    |
+LL | fn move_after_move(x: String) {
+   |                    - move occurs because `x` has type `std::string::String`, which does not implement the `Copy` trait
 LL |     || x;
    |     -- - variable moved due to use in closure
    |     |
    |     value moved into closure here
 LL |     let y = x; //~ ERROR
    |             ^ value used here after move
-   |
-   = note: move occurs because `x` has type `std::string::String`, which does not implement the `Copy` trait
 
 error[E0382]: borrow of moved value: `x`
   --> $DIR/closure-move-spans.rs:12:13
    |
+LL | fn borrow_after_move(x: String) {
+   |                      - move occurs because `x` has type `std::string::String`, which does not implement the `Copy` trait
 LL |     || x;
    |     -- - variable moved due to use in closure
    |     |
    |     value moved into closure here
 LL |     let y = &x; //~ ERROR
    |             ^^ value borrowed here after move
-   |
-   = note: move occurs because `x` has type `std::string::String`, which does not implement the `Copy` trait
 
 error[E0382]: borrow of moved value: `x`
   --> $DIR/closure-move-spans.rs:17:13
    |
+LL | fn borrow_mut_after_move(mut x: String) {
+   |                          ----- move occurs because `x` has type `std::string::String`, which does not implement the `Copy` trait
 LL |     || x;
    |     -- - variable moved due to use in closure
    |     |
    |     value moved into closure here
 LL |     let y = &mut x; //~ ERROR
    |             ^^^^^^ value borrowed here after move
-   |
-   = note: move occurs because `x` has type `std::string::String`, which does not implement the `Copy` trait
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/nll/closures-in-loops.stderr
+++ b/src/test/ui/nll/closures-in-loops.stderr
@@ -1,12 +1,13 @@
 error[E0382]: use of moved value: `x`
   --> $DIR/closures-in-loops.rs:8:9
    |
+LL | fn repreated_move(x: String) {
+   |                   - move occurs because `x` has type `std::string::String`, which does not implement the `Copy` trait
+LL |     for i in 0..10 {
 LL |         || x; //~ ERROR
    |         ^^ - use occurs due to use in closure
    |         |
    |         value moved into closure here, in previous iteration of loop
-   |
-   = note: move occurs because `x` has type `std::string::String`, which does not implement the `Copy` trait
 
 error[E0499]: cannot borrow `x` as mutable more than once at a time
   --> $DIR/closures-in-loops.rs:15:16

--- a/src/test/ui/nll/issue-21232-partial-init-and-erroneous-use.stderr
+++ b/src/test/ui/nll/issue-21232-partial-init-and-erroneous-use.stderr
@@ -13,12 +13,12 @@ LL |     d.x = 10;
 error[E0382]: assign of moved value: `d`
   --> $DIR/issue-21232-partial-init-and-erroneous-use.rs:43:5
    |
+LL |     let mut d = D { x: 0, s: S{ y: 0, z: 0 } };
+   |         ----- move occurs because `d` has type `D`, which does not implement the `Copy` trait
 LL |     drop(d);
    |          - value moved here
 LL |     d.x = 10;
    |     ^^^^^^^^ value assigned here after move
-   |
-   = note: move occurs because `d` has type `D`, which does not implement the `Copy` trait
 
 error[E0381]: assign to part of possibly uninitialized variable: `d`
   --> $DIR/issue-21232-partial-init-and-erroneous-use.rs:49:5
@@ -35,12 +35,12 @@ LL |     d.s.y = 20;
 error[E0382]: assign to part of moved value: `d`
   --> $DIR/issue-21232-partial-init-and-erroneous-use.rs:62:5
    |
+LL |     let mut d = D { x: 0, s: S{ y: 0, z: 0} };
+   |         ----- move occurs because `d` has type `D`, which does not implement the `Copy` trait
 LL |     drop(d);
    |          - value moved here
 LL |     d.s.y = 20;
    |     ^^^^^^^^^^ value partially assigned here after move
-   |
-   = note: move occurs because `d` has type `D`, which does not implement the `Copy` trait
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/nll/issue-21232-partial-init-and-use.stderr
+++ b/src/test/ui/nll/issue-21232-partial-init-and-use.stderr
@@ -14,21 +14,21 @@ error[E0382]: assign to part of moved value: `s`
   --> $DIR/issue-21232-partial-init-and-use.rs:113:5
    |
 LL |     let mut s: S<B> = S::new(); drop(s);
-   |                                      - value moved here
+   |         -----                        - value moved here
+   |         |
+   |         move occurs because `s` has type `S<std::boxed::Box<u32>>`, which does not implement the `Copy` trait
 LL |     s.x = 10; s.y = Box::new(20);
    |     ^^^^^^^^ value partially assigned here after move
-   |
-   = note: move occurs because `s` has type `S<std::boxed::Box<u32>>`, which does not implement the `Copy` trait
 
 error[E0382]: assign to part of moved value: `t`
   --> $DIR/issue-21232-partial-init-and-use.rs:120:5
    |
 LL |     let mut t: T = (0, Box::new(0)); drop(t);
-   |                                           - value moved here
+   |         -----                             - value moved here
+   |         |
+   |         move occurs because `t` has type `(u32, std::boxed::Box<u32>)`, which does not implement the `Copy` trait
 LL |     t.0 = 10; t.1 = Box::new(20);
    |     ^^^^^^^^ value partially assigned here after move
-   |
-   = note: move occurs because `t` has type `(u32, std::boxed::Box<u32>)`, which does not implement the `Copy` trait
 
 error[E0381]: assign to part of possibly uninitialized variable: `s`
   --> $DIR/issue-21232-partial-init-and-use.rs:127:5
@@ -46,21 +46,21 @@ error[E0382]: assign to part of moved value: `s`
   --> $DIR/issue-21232-partial-init-and-use.rs:141:5
    |
 LL |     let mut s: S<B> = S::new(); drop(s);
-   |                                      - value moved here
+   |         -----                        - value moved here
+   |         |
+   |         move occurs because `s` has type `S<std::boxed::Box<u32>>`, which does not implement the `Copy` trait
 LL |     s.x = 10;
    |     ^^^^^^^^ value partially assigned here after move
-   |
-   = note: move occurs because `s` has type `S<std::boxed::Box<u32>>`, which does not implement the `Copy` trait
 
 error[E0382]: assign to part of moved value: `t`
   --> $DIR/issue-21232-partial-init-and-use.rs:148:5
    |
 LL |     let mut t: T = (0, Box::new(0)); drop(t);
-   |                                           - value moved here
+   |         -----                             - value moved here
+   |         |
+   |         move occurs because `t` has type `(u32, std::boxed::Box<u32>)`, which does not implement the `Copy` trait
 LL |     t.0 = 10;
    |     ^^^^^^^^ value partially assigned here after move
-   |
-   = note: move occurs because `t` has type `(u32, std::boxed::Box<u32>)`, which does not implement the `Copy` trait
 
 error[E0381]: assign to part of possibly uninitialized variable: `s`
   --> $DIR/issue-21232-partial-init-and-use.rs:155:5
@@ -153,22 +153,24 @@ LL |     q.r.f.0 = 10;
 error[E0382]: assign to part of moved value: `c`
   --> $DIR/issue-21232-partial-init-and-use.rs:259:13
    |
+LL |     let mut c = (1, "".to_owned());
+   |         ----- move occurs because `c` has type `(i32, std::string::String)`, which does not implement the `Copy` trait
+LL |     match c {
 LL |         c2 => {
    |         -- value moved here
 LL |             c.0 = 2; //~ ERROR assign to part of moved value
    |             ^^^^^^^ value partially assigned here after move
-   |
-   = note: move occurs because `c` has type `(i32, std::string::String)`, which does not implement the `Copy` trait
 
 error[E0382]: assign to part of moved value: `c`
   --> $DIR/issue-21232-partial-init-and-use.rs:269:13
    |
+LL |     let mut c = (1, (1, "".to_owned()));
+   |         ----- move occurs because `c` has type `(i32, (i32, std::string::String))`, which does not implement the `Copy` trait
+LL |     match c {
 LL |         c2 => {
    |         -- value moved here
 LL |             (c.1).0 = 2; //~ ERROR assign to part of moved value
    |             ^^^^^^^^^^^ value partially assigned here after move
-   |
-   = note: move occurs because `c` has type `(i32, (i32, std::string::String))`, which does not implement the `Copy` trait
 
 error[E0382]: assign to part of moved value: `c.1`
   --> $DIR/issue-21232-partial-init-and-use.rs:277:13

--- a/src/test/ui/nll/issue-51512.stderr
+++ b/src/test/ui/nll/issue-51512.stderr
@@ -1,12 +1,12 @@
 error[E0382]: use of moved value: `range`
   --> $DIR/issue-51512.rs:7:13
    |
+LL |     let range = 0..1;
+   |         ----- move occurs because `range` has type `std::ops::Range<i32>`, which does not implement the `Copy` trait
 LL |     let r = range;
    |             ----- value moved here
 LL |     let x = range.start;
    |             ^^^^^^^^^^^ value used here after move
-   |
-   = note: move occurs because `range` has type `std::ops::Range<i32>`, which does not implement the `Copy` trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/issue-52669.stderr
+++ b/src/test/ui/nll/issue-52669.stderr
@@ -1,12 +1,13 @@
 error[E0382]: borrow of moved value: `a.b`
   --> $DIR/issue-52669.rs:15:5
    |
+LL | fn bar(mut a: A) -> B {
+   |        ----- move occurs because `a` has type `A`, which does not implement the `Copy` trait
+LL |     a.b = B;
 LL |     foo(a);
    |         - value moved here
 LL |     a.b.clone()
    |     ^^^ value borrowed here after move
-   |
-   = note: move occurs because `a` has type `A`, which does not implement the `Copy` trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/no-capture-arc.nll.stderr
+++ b/src/test/ui/no-capture-arc.nll.stderr
@@ -1,6 +1,9 @@
 error[E0382]: borrow of moved value: `arc_v`
   --> $DIR/no-capture-arc.rs:14:18
    |
+LL |     let arc_v = Arc::new(v);
+   |         ----- move occurs because `arc_v` has type `std::sync::Arc<std::vec::Vec<i32>>`, which does not implement the `Copy` trait
+LL | 
 LL |     thread::spawn(move|| {
    |                   ------ value moved into closure here
 LL |         assert_eq!((*arc_v)[3], 4);
@@ -8,8 +11,6 @@ LL |         assert_eq!((*arc_v)[3], 4);
 ...
 LL |     assert_eq!((*arc_v)[2], 3);
    |                  ^^^^^ value borrowed here after move
-   |
-   = note: move occurs because `arc_v` has type `std::sync::Arc<std::vec::Vec<i32>>`, which does not implement the `Copy` trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/no-reuse-move-arc.nll.stderr
+++ b/src/test/ui/no-reuse-move-arc.nll.stderr
@@ -1,6 +1,9 @@
 error[E0382]: borrow of moved value: `arc_v`
   --> $DIR/no-reuse-move-arc.rs:12:18
    |
+LL |     let arc_v = Arc::new(v);
+   |         ----- move occurs because `arc_v` has type `std::sync::Arc<std::vec::Vec<i32>>`, which does not implement the `Copy` trait
+LL | 
 LL |     thread::spawn(move|| {
    |                   ------ value moved into closure here
 LL |         assert_eq!((*arc_v)[3], 4);
@@ -8,8 +11,6 @@ LL |         assert_eq!((*arc_v)[3], 4);
 ...
 LL |     assert_eq!((*arc_v)[2], 3); //~ ERROR use of moved value: `arc_v`
    |                  ^^^^^ value borrowed here after move
-   |
-   = note: move occurs because `arc_v` has type `std::sync::Arc<std::vec::Vec<i32>>`, which does not implement the `Copy` trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/once-cant-call-twice-on-heap.nll.stderr
+++ b/src/test/ui/once-cant-call-twice-on-heap.nll.stderr
@@ -1,0 +1,15 @@
+error[E0382]: use of moved value: `blk`
+  --> $DIR/once-cant-call-twice-on-heap.rs:9:5
+   |
+LL | fn foo<F:FnOnce()>(blk: F) {
+   |        -           --- move occurs because `blk` has type `F`, which does not implement the `Copy` trait
+   |        |
+   |        consider adding a `Copy` constraint to this type argument
+LL |     blk();
+   |     --- value moved here
+LL |     blk(); //~ ERROR use of moved value
+   |     ^^^ value used here after move
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0382`.

--- a/src/test/ui/ref-suggestion.nll.stderr
+++ b/src/test/ui/ref-suggestion.nll.stderr
@@ -1,22 +1,22 @@
 error[E0382]: use of moved value: `x`
   --> $DIR/ref-suggestion.rs:4:5
    |
+LL |     let x = vec![1];
+   |         - move occurs because `x` has type `std::vec::Vec<i32>`, which does not implement the `Copy` trait
 LL |     let y = x;
    |             - value moved here
 LL |     x; //~ ERROR use of moved value
    |     ^ value used here after move
-   |
-   = note: move occurs because `x` has type `std::vec::Vec<i32>`, which does not implement the `Copy` trait
 
 error[E0382]: use of moved value: `x`
   --> $DIR/ref-suggestion.rs:8:5
    |
+LL |     let x = vec![1];
+   |         - move occurs because `x` has type `std::vec::Vec<i32>`, which does not implement the `Copy` trait
 LL |     let mut y = x;
    |                 - value moved here
 LL |     x; //~ ERROR use of moved value
    |     ^ value used here after move
-   |
-   = note: move occurs because `x` has type `std::vec::Vec<i32>`, which does not implement the `Copy` trait
 
 error[E0382]: use of moved value: `x`
   --> $DIR/ref-suggestion.rs:16:5

--- a/src/test/ui/rfc-2361-dbg-macro/dbg-macro-move-semantics.nll.stderr
+++ b/src/test/ui/rfc-2361-dbg-macro/dbg-macro-move-semantics.nll.stderr
@@ -1,12 +1,13 @@
 error[E0382]: use of moved value: `a`
   --> $DIR/dbg-macro-move-semantics.rs:9:18
    |
+LL |     let a = NoCopy(0);
+   |         - move occurs because `a` has type `NoCopy`, which does not implement the `Copy` trait
 LL |     let _ = dbg!(a);
    |             ------- value moved here
 LL |     let _ = dbg!(a); //~ ERROR use of moved value
    |                  ^ value used here after move
    |
-   = note: move occurs because `a` has type `NoCopy`, which does not implement the `Copy` trait
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/try-block/try-block-bad-lifetime.stderr
+++ b/src/test/ui/try-block/try-block-bad-lifetime.stderr
@@ -25,13 +25,14 @@ LL |         ::std::mem::drop(k); //~ ERROR use of moved value: `k`
 error[E0382]: use of moved value: `k`
   --> $DIR/try-block-bad-lifetime.rs:31:26
    |
+LL |         let k = &mut i;
+   |             - move occurs because `k` has type `&mut i32`, which does not implement the `Copy` trait
+LL |         let mut j: Result<(), &mut i32> = try {
 LL |             Err(k) ?;
    |                 - value moved here
 ...
 LL |         ::std::mem::drop(k); //~ ERROR use of moved value: `k`
    |                          ^ value used here after move
-   |
-   = note: move occurs because `k` has type `&mut i32`, which does not implement the `Copy` trait
 
 error[E0506]: cannot assign to `i` because it is borrowed
   --> $DIR/try-block-bad-lifetime.rs:32:9

--- a/src/test/ui/try-block/try-block-maybe-bad-lifetime.stderr
+++ b/src/test/ui/try-block/try-block-maybe-bad-lifetime.stderr
@@ -13,13 +13,14 @@ LL |         do_something_with(x);
 error[E0382]: borrow of moved value: `x`
   --> $DIR/try-block-maybe-bad-lifetime.rs:28:24
    |
+LL |         let x = String::new();
+   |             - move occurs because `x` has type `std::string::String`, which does not implement the `Copy` trait
+...
 LL |             ::std::mem::drop(x);
    |                              - value moved here
 LL |         };
 LL |         println!("{}", x); //~ ERROR borrow of moved value: `x`
    |                        ^ value borrowed here after move
-   |
-   = note: move occurs because `x` has type `std::string::String`, which does not implement the `Copy` trait
 
 error[E0506]: cannot assign to `i` because it is borrowed
   --> $DIR/try-block-maybe-bad-lifetime.rs:40:9

--- a/src/test/ui/union/union-borrow-move-parent-sibling.nll.stderr
+++ b/src/test/ui/union/union-borrow-move-parent-sibling.nll.stderr
@@ -13,12 +13,12 @@ LL |     use_borrow(a);
 error[E0382]: use of moved value: `u`
   --> $DIR/union-borrow-move-parent-sibling.rs:22:13
    |
+LL |     let u = U { x: ((Vec::new(), Vec::new()), Vec::new()) };
+   |         - move occurs because `u` has type `U`, which does not implement the `Copy` trait
 LL |     let a = u.x.0;
    |             ----- value moved here
 LL |     let b = u.y; //~ ERROR use of moved value: `u.y`
    |             ^^^ value used here after move
-   |
-   = note: move occurs because `u` has type `U`, which does not implement the `Copy` trait
 
 error[E0502]: cannot borrow `u` (via `u.y`) as immutable because it is also borrowed as mutable (via `u.x.0.0`)
   --> $DIR/union-borrow-move-parent-sibling.rs:28:13
@@ -35,12 +35,12 @@ LL |     use_borrow(a);
 error[E0382]: use of moved value: `u`
   --> $DIR/union-borrow-move-parent-sibling.rs:35:13
    |
+LL |     let u = U { x: ((Vec::new(), Vec::new()), Vec::new()) };
+   |         - move occurs because `u` has type `U`, which does not implement the `Copy` trait
 LL |     let a = (u.x.0).0;
    |             --------- value moved here
 LL |     let b = u.y; //~ ERROR use of moved value: `u.y`
    |             ^^^ value used here after move
-   |
-   = note: move occurs because `u` has type `U`, which does not implement the `Copy` trait
 
 error[E0502]: cannot borrow `u` (via `u.x`) as immutable because it is also borrowed as mutable (via `*u.y`)
   --> $DIR/union-borrow-move-parent-sibling.rs:41:13
@@ -57,12 +57,12 @@ LL |     use_borrow(a);
 error[E0382]: use of moved value: `u`
   --> $DIR/union-borrow-move-parent-sibling.rs:48:13
    |
+LL |     let u = U { x: ((Vec::new(), Vec::new()), Vec::new()) };
+   |         - move occurs because `u` has type `U`, which does not implement the `Copy` trait
 LL |     let a = *u.y;
    |             ---- value moved here
 LL |     let b = u.x; //~ ERROR use of moved value: `u.x`
    |             ^^^ value used here after move
-   |
-   = note: move occurs because `u` has type `U`, which does not implement the `Copy` trait
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/unop-move-semantics.nll.stderr
+++ b/src/test/ui/unop-move-semantics.nll.stderr
@@ -1,13 +1,15 @@
 error[E0382]: borrow of moved value: `x`
   --> $DIR/unop-move-semantics.rs:8:5
    |
+LL | fn move_then_borrow<T: Not<Output=T> + Clone>(x: T) {
+   |                     -                         - move occurs because `x` has type `T`, which does not implement the `Copy` trait
+   |                     |
+   |                     consider adding a `Copy` constraint to this type argument
 LL |     !x;
    |      - value moved here
 LL | 
 LL |     x.clone();  //~ ERROR: use of moved value
    |     ^ value borrowed here after move
-   |
-   = note: move occurs because `x` has type `T`, which does not implement the `Copy` trait
 
 error[E0505]: cannot move out of `x` because it is borrowed
   --> $DIR/unop-move-semantics.rs:15:6

--- a/src/test/ui/unsized-locals/borrow-after-move.nll.stderr
+++ b/src/test/ui/unsized-locals/borrow-after-move.nll.stderr
@@ -12,13 +12,13 @@ LL |         println!("{}", &x);
 error[E0382]: borrow of moved value: `y`
   --> $DIR/borrow-after-move.rs:22:24
    |
+LL |         let y = *x;
+   |             - move occurs because `y` has type `str`, which does not implement the `Copy` trait
 LL |         drop_unsized(y);
    |                      - value moved here
 ...
 LL |         println!("{}", &y);
    |                        ^^ value borrowed here after move
-   |
-   = note: move occurs because `y` has type `str`, which does not implement the `Copy` trait
 
 error[E0382]: borrow of moved value: `x`
   --> $DIR/borrow-after-move.rs:30:24
@@ -34,13 +34,13 @@ LL |         println!("{}", &x);
 error[E0382]: borrow of moved value: `y`
   --> $DIR/borrow-after-move.rs:32:24
    |
+LL |         let y = *x;
+   |             - move occurs because `y` has type `str`, which does not implement the `Copy` trait
 LL |         y.foo();
    |         - value moved here
 ...
 LL |         println!("{}", &y);
    |                        ^^ value borrowed here after move
-   |
-   = note: move occurs because `y` has type `str`, which does not implement the `Copy` trait
 
 error[E0382]: borrow of moved value: `x`
   --> $DIR/borrow-after-move.rs:39:24

--- a/src/test/ui/unsized-locals/double-move.nll.stderr
+++ b/src/test/ui/unsized-locals/double-move.nll.stderr
@@ -1,12 +1,12 @@
 error[E0382]: use of moved value: `y`
   --> $DIR/double-move.rs:20:22
    |
+LL |         let y = *x;
+   |             - move occurs because `y` has type `str`, which does not implement the `Copy` trait
 LL |         drop_unsized(y);
    |                      - value moved here
 LL |         drop_unsized(y); //~ERROR use of moved value
    |                      ^ value used here after move
-   |
-   = note: move occurs because `y` has type `str`, which does not implement the `Copy` trait
 
 error[E0382]: use of moved value: `x`
   --> $DIR/double-move.rs:26:22
@@ -21,22 +21,22 @@ LL |         drop_unsized(x); //~ERROR use of moved value
 error[E0382]: use of moved value: `*x`
   --> $DIR/double-move.rs:32:18
    |
+LL |         let x = "hello".to_owned().into_boxed_str();
+   |             - move occurs because `x` has type `std::boxed::Box<str>`, which does not implement the `Copy` trait
 LL |         drop_unsized(x);
    |                      - value moved here
 LL |         let _y = *x; //~ERROR use of moved value
    |                  ^^ value used here after move
-   |
-   = note: move occurs because `x` has type `std::boxed::Box<str>`, which does not implement the `Copy` trait
 
 error[E0382]: use of moved value: `y`
   --> $DIR/double-move.rs:39:9
    |
+LL |         let y = *x;
+   |             - move occurs because `y` has type `str`, which does not implement the `Copy` trait
 LL |         y.foo();
    |         - value moved here
 LL |         y.foo(); //~ERROR use of moved value
    |         ^ value used here after move
-   |
-   = note: move occurs because `y` has type `str`, which does not implement the `Copy` trait
 
 error[E0382]: use of moved value: `*x`
   --> $DIR/double-move.rs:45:9

--- a/src/test/ui/use/use-after-move-based-on-type.nll.stderr
+++ b/src/test/ui/use/use-after-move-based-on-type.nll.stderr
@@ -1,12 +1,12 @@
 error[E0382]: borrow of moved value: `x`
   --> $DIR/use-after-move-based-on-type.rs:4:20
    |
+LL |     let x = "Hello!".to_string();
+   |         - move occurs because `x` has type `std::string::String`, which does not implement the `Copy` trait
 LL |     let _y = x;
    |              - value moved here
 LL |     println!("{}", x); //~ ERROR use of moved value
    |                    ^ value borrowed here after move
-   |
-   = note: move occurs because `x` has type `std::string::String`, which does not implement the `Copy` trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/use/use-after-move-implicity-coerced-object.nll.stderr
+++ b/src/test/ui/use/use-after-move-implicity-coerced-object.nll.stderr
@@ -1,12 +1,13 @@
 error[E0382]: borrow of moved value: `n`
   --> $DIR/use-after-move-implicity-coerced-object.rs:28:13
    |
+LL |     let n: Box<_> = box Number { n: 42 };
+   |         - move occurs because `n` has type `std::boxed::Box<Number>`, which does not implement the `Copy` trait
+LL |     let mut l: Box<_> = box List { list: Vec::new() };
 LL |     l.push(n);
    |            - value moved here
 LL |     let x = n.to_string();
    |             ^ value borrowed here after move
-   |
-   = note: move occurs because `n` has type `std::boxed::Box<Number>`, which does not implement the `Copy` trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/use/use-after-move-self-based-on-type.nll.stderr
+++ b/src/test/ui/use/use-after-move-self-based-on-type.nll.stderr
@@ -1,12 +1,12 @@
 error[E0382]: use of moved value: `self`
   --> $DIR/use-after-move-self-based-on-type.rs:12:16
    |
+LL |     pub fn foo(self) -> isize {
+   |                ---- move occurs because `self` has type `S`, which does not implement the `Copy` trait
 LL |         self.bar();
    |         ---- value moved here
 LL |         return self.x;  //~ ERROR use of moved value: `self.x`
    |                ^^^^^^ value used here after move
-   |
-   = note: move occurs because `self` has type `S`, which does not implement the `Copy` trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/use/use-after-move-self.nll.stderr
+++ b/src/test/ui/use/use-after-move-self.nll.stderr
@@ -1,12 +1,12 @@
 error[E0382]: use of moved value: `self`
   --> $DIR/use-after-move-self.rs:10:16
    |
+LL |     pub fn foo(self) -> isize {
+   |                ---- move occurs because `self` has type `S`, which does not implement the `Copy` trait
 LL |         self.bar();
    |         ---- value moved here
 LL |         return *self.x;  //~ ERROR use of moved value: `*self.x`
    |                ^^^^^^^ value used here after move
-   |
-   = note: move occurs because `self` has type `S`, which does not implement the `Copy` trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/walk-struct-literal-with.nll.stderr
+++ b/src/test/ui/walk-struct-literal-with.nll.stderr
@@ -1,12 +1,12 @@
 error[E0382]: borrow of moved value: `start`
   --> $DIR/walk-struct-literal-with.rs:16:20
    |
+LL |     let start = Mine{test:"Foo".to_string(), other_val:0};
+   |         ----- move occurs because `start` has type `Mine`, which does not implement the `Copy` trait
 LL |     let end = Mine{other_val:1, ..start.make_string_bar()};
    |                                   ----- value moved here
 LL |     println!("{}", start.test); //~ ERROR use of moved value: `start.test`
    |                    ^^^^^^^^^^ value borrowed here after move
-   |
-   = note: move occurs because `start` has type `Mine`, which does not implement the `Copy` trait
 
 error: aborting due to previous error
 


### PR DESCRIPTION
When trying to use a value after move, instead of using a note, point
at the local declaration that has a type that doesn't implement `Copy`
trait.

```
error[E0382]: use of moved value: `x`
  --> $DIR/issue-34721.rs:27:9
   |
LL |     pub fn baz<T: Foo>(x: T) -> T {
   |                -       - move occurs because `x` has type `T`, which does not implement the `Copy` trait
   |                |
   |                consider adding a `Copy` constraint to this type argument
LL |         if 0 == 1 {
LL |             bar::bar(x.zero())
   |                      - value moved here
LL |         } else {
LL |             x.zero()
   |             - value moved here
LL |         };
LL |         x.zero()
   |         ^ value used here after move
```

Fix #34721.