### PR TITLE
Fix 'be be' constructs

### DIFF
--- a/src/librustc/lint/levels.rs
+++ b/src/librustc/lint/levels.rs
@@ -173,8 +173,8 @@ impl<'a> LintLevelsBuilder<'a> {
 
     /// Pushes a list of AST lint attributes onto this context.
     ///
-    /// This function will return a `BuilderPush` object which should be be
-    /// passed to `pop` when this scope for the attributes provided is exited.
+    /// This function will return a `BuilderPush` object which should be passed
+    /// to `pop` when this scope for the attributes provided is exited.
     ///
     /// This function will perform a number of tasks:
     ///

--- a/src/librustc/ty/query/plumbing.rs
+++ b/src/librustc/ty/query/plumbing.rs
@@ -974,7 +974,7 @@ macro_rules! define_queries_inner {
                         // HACK(eddyb) it's possible crates may be loaded after
                         // the query engine is created, and because crate loading
                         // is not yet integrated with the query engine, such crates
-                        // would be be missing appropriate entries in `providers`.
+                        // would be missing appropriate entries in `providers`.
                         .unwrap_or(&tcx.queries.fallback_extern_providers)
                         .$name;
                     provider(tcx.global_tcx(), key)

--- a/src/librustc_typeck/check/closure.rs
+++ b/src/librustc_typeck/check/closure.rs
@@ -494,7 +494,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         self.infcx.commit_if_ok(|_| {
             let mut all_obligations = vec![];
 
-            // The liberated version of this signature should be be a subtype
+            // The liberated version of this signature should be a subtype
             // of the liberated form of the expectation.
             for ((hir_ty, &supplied_ty), expected_ty) in decl.inputs.iter()
                .zip(*supplied_sig.inputs().skip_binder()) // binder moved to (*) below


### PR DESCRIPTION
I noticed a duplicated "be" somewhere in the code. A search for it
manifested a couple more locations with the same problem. This change
removes one of the "be"s.