### PR TITLE
NLL: Fix bug in associated constant type annotations.

### DIFF
--- a/src/librustc_mir/build/matches/simplify.rs
+++ b/src/librustc_mir/build/matches/simplify.rs
@@ -56,11 +56,19 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                                  -> Result<(), MatchPair<'pat, 'tcx>> {
         let tcx = self.hir.tcx();
         match *match_pair.pattern.kind {
-            PatternKind::AscribeUserType { ref subpattern, ref user_ty, user_ty_span } => {
+            PatternKind::AscribeUserType {
+                ref subpattern,
+                variance,
+                ref user_ty,
+                user_ty_span
+            } => {
+                // Apply the type ascription to the value at `match_pair.place`, which is the
+                // value being matched, taking the variance field into account.
                 candidate.ascriptions.push(Ascription {
                     span: user_ty_span,
                     user_ty: user_ty.clone(),
                     source: match_pair.place.clone(),
+                    variance,
                 });
 
                 candidate.match_pairs.push(MatchPair::new(match_pair.place, subpattern));

--- a/src/librustc_mir/hair/cx/block.rs
+++ b/src/librustc_mir/hair/cx/block.rs
@@ -3,6 +3,7 @@ use hair::cx::Cx;
 use hair::cx::to_ref::ToRef;
 use rustc::middle::region;
 use rustc::hir;
+use rustc::ty;
 
 use rustc_data_structures::indexed_vec::Idx;
 
@@ -86,7 +87,8 @@ fn mirror_stmts<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
                                     kind: Box::new(PatternKind::AscribeUserType {
                                         user_ty: PatternTypeProjection::from_user_type(user_ty),
                                         user_ty_span: ty.span,
-                                        subpattern: pattern
+                                        subpattern: pattern,
+                                        variance: ty::Variance::Covariant,
                                     })
                                 };
                             }

--- a/src/test/ui/nll/issue-57280-1.rs
+++ b/src/test/ui/nll/issue-57280-1.rs
@@ -1,0 +1,21 @@
+#![feature(nll)]
+
+// compile-pass
+
+trait Foo<'a> {
+    const C: &'a u32;
+}
+
+impl<'a, T> Foo<'a> for T {
+    const C: &'a u32 = &22;
+}
+
+fn foo() {
+    let a = 22;
+    match &a {
+        <() as Foo<'static>>::C => { }
+        &_ => { }
+    }
+}
+
+fn main() {}

--- a/src/test/ui/nll/issue-57280.rs
+++ b/src/test/ui/nll/issue-57280.rs
@@ -1,0 +1,22 @@
+#![feature(nll)]
+
+// compile-pass
+
+trait Foo {
+    const BLAH: &'static str;
+}
+
+struct Placeholder;
+
+impl Foo for Placeholder {
+    const BLAH: &'static str = "hi";
+}
+
+fn foo(x: &str) {
+    match x {
+        <Placeholder as Foo>::BLAH => { }
+        _ => { }
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes #57280.

This PR reverses the variance used when relating types from the type
annotation of an associated constant - this matches the behaviour of the
lexical borrow checker and fixes a bug whereby matching a `&'a str`
against a `&'static str` would produce an error.

r? @nikomatsakis 