### PR TITLE
[beta] Rollup backports

### DIFF
--- a/src/librustc/traits/auto_trait.rs
+++ b/src/librustc/traits/auto_trait.rs
@@ -742,9 +742,9 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
                     }
 
                     // We can only call poly_project_and_unify_type when our predicate's
-                    // Ty is an inference variable - otherwise, there won't be anything to
+                    // Ty contains an inference variable - otherwise, there won't be anything to
                     // unify
-                    if p.ty().skip_binder().is_ty_infer() {
+                    if p.ty().skip_binder().has_infer_types() {
                         debug!("Projecting and unifying projection predicate {:?}",
                                predicate);
                         match poly_project_and_unify_type(select, &obligation.with(p.clone())) {

--- a/src/librustc/traits/auto_trait.rs
+++ b/src/librustc/traits/auto_trait.rs
@@ -334,7 +334,12 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
                 continue;
             }
 
-            let result = select.select(&Obligation::new(dummy_cause.clone(), new_env, pred));
+            // Call infcx.resolve_type_vars_if_possible to see if we can
+            // get rid of any inference variables.
+            let obligation = infcx.resolve_type_vars_if_possible(
+                &Obligation::new(dummy_cause.clone(), new_env, pred)
+            );
+            let result = select.select(&obligation);
 
             match &result {
                 &Ok(Some(ref vtable)) => {
@@ -369,7 +374,7 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
                 }
                 &Ok(None) => {}
                 &Err(SelectionError::Unimplemented) => {
-                    if self.is_of_param(pred.skip_binder().trait_ref.substs) {
+                    if self.is_of_param(pred.skip_binder().self_ty()) {
                         already_visited.remove(&pred);
                         self.add_user_pred(
                             &mut user_computed_preds,
@@ -631,14 +636,10 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
         finished_map
     }
 
-    pub fn is_of_param(&self, substs: &Substs<'_>) -> bool {
-        if substs.is_noop() {
-            return false;
-        }
-
-        return match substs.type_at(0).sty {
+    pub fn is_of_param(&self, ty: Ty<'_>) -> bool {
+        return match ty.sty {
             ty::Param(_) => true,
-            ty::Projection(p) => self.is_of_param(p.substs),
+            ty::Projection(p) => self.is_of_param(p.self_ty()),
             _ => false,
         };
     }
@@ -661,28 +662,61 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
     ) -> bool {
         let dummy_cause = ObligationCause::misc(DUMMY_SP, ast::DUMMY_NODE_ID);
 
-        for (obligation, predicate) in nested
-            .filter(|o| o.recursion_depth == 1)
+        for (obligation, mut predicate) in nested
             .map(|o| (o.clone(), o.predicate.clone()))
         {
             let is_new_pred =
                 fresh_preds.insert(self.clean_pred(select.infcx(), predicate.clone()));
 
+            // Resolve any inference variables that we can, to help selection succeed
+            predicate = select.infcx().resolve_type_vars_if_possible(&predicate);
+
+            // We only add a predicate as a user-displayable bound if
+            // it involves a generic parameter, and doesn't contain
+            // any inference variables.
+            //
+            // Displaying a bound involving a concrete type (instead of a generic
+            // parameter) would be pointless, since it's always true
+            // (e.g. u8: Copy)
+            // Displaying an inference variable is impossible, since they're
+            // an internal compiler detail without a defined visual representation
+            //
+            // We check this by calling is_of_param on the relevant types
+            // from the various possible predicates
             match &predicate {
                 &ty::Predicate::Trait(ref p) => {
-                    let substs = &p.skip_binder().trait_ref.substs;
+                    if self.is_of_param(p.skip_binder().self_ty())
+                        && !only_projections
+                        && is_new_pred {
 
-                    if self.is_of_param(substs) && !only_projections && is_new_pred {
                         self.add_user_pred(computed_preds, predicate);
                     }
                     predicates.push_back(p.clone());
                 }
                 &ty::Predicate::Projection(p) => {
-                    // If the projection isn't all type vars, then
-                    // we don't want to add it as a bound
-                    if self.is_of_param(p.skip_binder().projection_ty.substs) && is_new_pred {
+                    debug!("evaluate_nested_obligations: examining projection predicate {:?}",
+                           predicate);
+
+                    // As described above, we only want to display
+                    // bounds which include a generic parameter but don't include
+                    // an inference variable.
+                    // Additionally, we check if we've seen this predicate before,
+                    // to avoid rendering duplicate bounds to the user.
+                    if self.is_of_param(p.skip_binder().projection_ty.self_ty())
+                        && !p.ty().skip_binder().is_ty_infer()
+                        && is_new_pred {
+                            debug!("evaluate_nested_obligations: adding projection predicate\
+                            to computed_preds: {:?}", predicate);
+
                         self.add_user_pred(computed_preds, predicate);
-                    } else {
+                    }
+
+                    // We can only call poly_project_and_unify_type when our predicate's
+                    // Ty is an inference variable - otherwise, there won't be anything to
+                    // unify
+                    if p.ty().skip_binder().is_ty_infer() {
+                        debug!("Projecting and unifying projection predicate {:?}",
+                               predicate);
                         match poly_project_and_unify_type(select, &obligation.with(p.clone())) {
                             Err(e) => {
                                 debug!(

--- a/src/librustc_codegen_ssa/mir/rvalue.rs
+++ b/src/librustc_codegen_ssa/mir/rvalue.rs
@@ -131,8 +131,9 @@ impl<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 let keep_going = header_bx.icmp(IntPredicate::IntNE, current, end);
                 header_bx.cond_br(keep_going, body_bx.llbb(), next_bx.llbb());
 
+                let align = dest.align.restrict_for_offset(dest.layout.field(bx.cx(), 0).size);
                 cg_elem.val.store(&mut body_bx,
-                    PlaceRef::new_sized(current, cg_elem.layout, dest.align));
+                    PlaceRef::new_sized(current, cg_elem.layout, align));
 
                 let next = body_bx.inbounds_gep(current, &[bx.cx().const_usize(1)]);
                 body_bx.br(header_bx.llbb());

--- a/src/librustc_mir/borrow_check/nll/type_check/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/mod.rs
@@ -1415,7 +1415,7 @@ impl<'a, 'gcx, 'tcx> TypeChecker<'a, 'gcx, 'tcx> {
                 self.check_call_dest(mir, term, &sig, destination, term_location);
 
                 self.prove_predicates(
-                    sig.inputs().iter().map(|ty| ty::Predicate::WellFormed(ty)),
+                    sig.inputs_and_output.iter().map(|ty| ty::Predicate::WellFormed(ty)),
                     term_location.to_locations(),
                     ConstraintCategory::Boring,
                 );

--- a/src/librustc_mir/interpret/machine.rs
+++ b/src/librustc_mir/interpret/machine.rs
@@ -86,7 +86,7 @@ pub trait Machine<'a, 'mir, 'tcx>: Sized {
     type MemoryExtra: Default;
 
     /// Extra data stored in every allocation.
-    type AllocExtra: AllocationExtra<Self::PointerTag, Self::MemoryExtra>;
+    type AllocExtra: AllocationExtra<Self::PointerTag, Self::MemoryExtra> + 'static;
 
     /// Memory's allocation map
     type MemoryMap:

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -1022,11 +1022,11 @@ enum ModuleOrUniformRoot<'a> {
     CurrentScope,
 }
 
-impl<'a> PartialEq for ModuleOrUniformRoot<'a> {
-    fn eq(&self, other: &Self) -> bool {
-        match (*self, *other) {
+impl ModuleOrUniformRoot<'_> {
+    fn same_def(lhs: Self, rhs: Self) -> bool {
+        match (lhs, rhs) {
             (ModuleOrUniformRoot::Module(lhs),
-             ModuleOrUniformRoot::Module(rhs)) => ptr::eq(lhs, rhs),
+             ModuleOrUniformRoot::Module(rhs)) => lhs.def() == rhs.def(),
             (ModuleOrUniformRoot::CrateRootAndExternPrelude,
              ModuleOrUniformRoot::CrateRootAndExternPrelude) |
             (ModuleOrUniformRoot::ExternPrelude, ModuleOrUniformRoot::ExternPrelude) |

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -836,7 +836,9 @@ impl<'a, 'b:'a, 'c: 'b> ImportResolver<'a, 'b, 'c> {
             PathResult::Module(module) => {
                 // Consistency checks, analogous to `finalize_current_module_macro_resolutions`.
                 if let Some(initial_module) = directive.imported_module.get() {
-                    if module != initial_module && self.ambiguity_errors.is_empty() {
+                    if !ModuleOrUniformRoot::same_def(module, initial_module)
+                        && self.ambiguity_errors.is_empty()
+                    {
                         span_bug!(directive.span, "inconsistent resolution for an import");
                     }
                 } else {

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -465,6 +465,10 @@ impl<'a, 'crateloader> Resolver<'a, 'crateloader> {
         self.set_binding_parent_module(binding, module);
         self.update_resolution(module, ident, ns, |this, resolution| {
             if let Some(old_binding) = resolution.binding {
+                if binding.def() == Def::Err {
+                    // Do not override real bindings with `Def::Err`s from error recovery.
+                    return Ok(());
+                }
                 match (old_binding.is_glob_import(), binding.is_glob_import()) {
                     (true, true) => {
                         if binding.def() != old_binding.def() {

--- a/src/stage0.txt
+++ b/src/stage0.txt
@@ -12,8 +12,8 @@
 # source tarball for a stable release you'll likely see `1.x.0` for rustc and
 # `0.x.0` for Cargo where they were released on `date`.
 
-date: 2018-12-06
-rustc: 1.31.0
+date: 2018-12-20
+rustc: 1.31.1
 cargo: 0.32.0
 
 # When making a stable release the process currently looks like:

--- a/src/test/codegen/issue-56927.rs
+++ b/src/test/codegen/issue-56927.rs
@@ -1,0 +1,44 @@
+// compile-flags: -C no-prepopulate-passes
+
+#![crate_type="rlib"]
+use std::usize;
+
+#[repr(align(16))]
+pub struct S {
+    arr: [u32; 4],
+}
+
+// CHECK-LABEL: @test1
+// CHECK: store i32 0, i32* %{{.+}}, align 16
+// CHECK: store i32 1, i32* %{{.+}}, align 4
+// CHECK: store i32 2, i32* %{{.+}}, align 8
+// CHECK: store i32 3, i32* %{{.+}}, align 4
+#[no_mangle]
+pub fn test1(s: &mut S) {
+    s.arr[0] = 0;
+    s.arr[1] = 1;
+    s.arr[2] = 2;
+    s.arr[3] = 3;
+}
+
+// CHECK-LABEL: @test2
+// CHECK: store i32 4, i32* %{{.+}}, align 4
+#[allow(const_err)]
+#[no_mangle]
+pub fn test2(s: &mut S) {
+    s.arr[usize::MAX / 4 + 1] = 4;
+}
+
+// CHECK-LABEL: @test3
+// CHECK: store i32 5, i32* %{{.+}}, align 4
+#[no_mangle]
+pub fn test3(s: &mut S, i: usize) {
+    s.arr[i] = 5;
+}
+
+// CHECK-LABEL: @test4
+// CHECK: store i32 6, i32* %{{.+}}, align 4
+#[no_mangle]
+pub fn test4(s: &mut S) {
+    s.arr = [6; 4];
+}

--- a/src/test/codegen/packed.rs
+++ b/src/test/codegen/packed.rs
@@ -84,6 +84,42 @@ pub fn call_pkd2(f: fn() -> Array) -> BigPacked2 {
     BigPacked2 { dealign: 0, data: f() }
 }
 
+// CHECK-LABEL: @write_packed_array1
+// CHECK: store i32 0, i32* %{{.+}}, align 1
+// CHECK: store i32 1, i32* %{{.+}}, align 1
+// CHECK: store i32 2, i32* %{{.+}}, align 1
+#[no_mangle]
+pub fn write_packed_array1(p: &mut BigPacked1) {
+    p.data.0[0] = 0;
+    p.data.0[1] = 1;
+    p.data.0[2] = 2;
+}
+
+// CHECK-LABEL: @write_packed_array2
+// CHECK: store i32 0, i32* %{{.+}}, align 2
+// CHECK: store i32 1, i32* %{{.+}}, align 2
+// CHECK: store i32 2, i32* %{{.+}}, align 2
+#[no_mangle]
+pub fn write_packed_array2(p: &mut BigPacked2) {
+    p.data.0[0] = 0;
+    p.data.0[1] = 1;
+    p.data.0[2] = 2;
+}
+
+// CHECK-LABEL: @repeat_packed_array1
+// CHECK: store i32 42, i32* %{{.+}}, align 1
+#[no_mangle]
+pub fn repeat_packed_array1(p: &mut BigPacked1) {
+    p.data.0 = [42; 8];
+}
+
+// CHECK-LABEL: @repeat_packed_array2
+// CHECK: store i32 42, i32* %{{.+}}, align 2
+#[no_mangle]
+pub fn repeat_packed_array2(p: &mut BigPacked2) {
+    p.data.0 = [42; 8];
+}
+
 #[repr(packed)]
 #[derive(Copy, Clone)]
 pub struct Packed1Pair(u8, u32);

--- a/src/test/rustdoc/issue-50159.rs
+++ b/src/test/rustdoc/issue-50159.rs
@@ -1,0 +1,31 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+pub trait Signal {
+    type Item;
+}
+
+pub trait Signal2 {
+    type Item2;
+}
+
+impl<B, C> Signal2 for B where B: Signal<Item = C> {
+    type Item2 = C;
+}
+
+// @has issue_50159/struct.Switch.html
+// @has - '//code' 'impl<B> Send for Switch<B> where <B as Signal>::Item: Send'
+// @has - '//code' 'impl<B> Sync for Switch<B> where <B as Signal>::Item: Sync'
+// @count - '//*[@id="implementations-list"]/*[@class="impl"]' 0
+// @count - '//*[@id="synthetic-implementations-list"]/*[@class="impl"]' 2
+pub struct Switch<B: Signal> {
+    pub inner: <B as Signal2>::Item2,
+}

--- a/src/test/rustdoc/issue-56822.rs
+++ b/src/test/rustdoc/issue-56822.rs
@@ -1,0 +1,34 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Wrapper<T>(T);
+
+trait MyTrait {
+    type Output;
+}
+
+impl<'a, I, T: 'a> MyTrait for Wrapper<I>
+    where I: MyTrait<Output=&'a T>
+{
+    type Output = T;
+}
+
+struct Inner<'a, T>(&'a T);
+
+impl<'a, T> MyTrait for Inner<'a, T> {
+    type Output = &'a T;
+}
+
+// @has issue_56822/struct.Parser.html
+// @has - '//*[@id="synthetic-implementations-list"]/*[@class="impl"]//*/code' "impl<'a> Send for \
+// Parser<'a>"
+pub struct Parser<'a> {
+    field: <Wrapper<Inner<'a, u8>> as MyTrait>::Output
+}

--- a/src/test/rustdoc/synthetic_auto/self-referential.rs
+++ b/src/test/rustdoc/synthetic_auto/self-referential.rs
@@ -1,0 +1,40 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Some unusual code minimized from
+// https://github.com/sile/handy_async/tree/7b619b762c06544fc67792c8ff8ebc24a88fdb98
+
+pub trait Pattern {
+    type Value;
+}
+
+pub struct Constrain<A, B = A, C = A>(A, B, C);
+
+impl<A, B, C> Pattern for Constrain<A, B, C>
+    where A: Pattern,
+          B: Pattern<Value = A::Value>,
+          C: Pattern<Value = A::Value>,
+{
+    type Value = A::Value;
+}
+
+pub struct Wrapper<T>(T);
+
+impl<T> Pattern for Wrapper<T> {
+    type Value = T;
+}
+
+
+// @has self_referential/struct.WriteAndThen.html
+// @has - '//*[@id="synthetic-implementations-list"]/*[@class="impl"]//*/code' "impl<P1> Send for \
+// WriteAndThen<P1>  where  <P1 as Pattern>::Value: Send"
+pub struct WriteAndThen<P1>(pub P1::Value, pub <Constrain<P1, Wrapper<P1::Value>> as Pattern>::Value)
+    where P1: Pattern;
+

--- a/src/test/rustdoc/synthetic_auto/self-referential.rs
+++ b/src/test/rustdoc/synthetic_auto/self-referential.rs
@@ -35,6 +35,6 @@ impl<T> Pattern for Wrapper<T> {
 // @has self_referential/struct.WriteAndThen.html
 // @has - '//*[@id="synthetic-implementations-list"]/*[@class="impl"]//*/code' "impl<P1> Send for \
 // WriteAndThen<P1>  where  <P1 as Pattern>::Value: Send"
-pub struct WriteAndThen<P1>(pub P1::Value, pub <Constrain<P1, Wrapper<P1::Value>> as Pattern>::Value)
+pub struct WriteAndThen<P1>(pub P1::Value,pub <Constrain<P1, Wrapper<P1::Value>> as Pattern>::Value)
     where P1: Pattern;
 

--- a/src/test/ui/imports/duplicate.rs
+++ b/src/test/ui/imports/duplicate.rs
@@ -43,7 +43,7 @@ mod g {
 fn main() {
     e::foo();
     f::foo(); //~ ERROR `foo` is ambiguous
-    g::foo(); //~ ERROR `foo` is ambiguous
+    g::foo();
 }
 
 mod ambiguous_module_errors {

--- a/src/test/ui/imports/duplicate.stderr
+++ b/src/test/ui/imports/duplicate.stderr
@@ -51,25 +51,6 @@ LL |     pub use b::*;
    = help: consider adding an explicit import of `foo` to disambiguate
 
 error[E0659]: `foo` is ambiguous (glob import vs glob import in the same module)
-  --> $DIR/duplicate.rs:46:8
-   |
-LL |     g::foo(); //~ ERROR `foo` is ambiguous
-   |        ^^^ ambiguous name
-   |
-note: `foo` could refer to the function imported here
-  --> $DIR/duplicate.rs:39:13
-   |
-LL |     pub use a::*;
-   |             ^^^^
-   = help: consider adding an explicit import of `foo` to disambiguate
-note: `foo` could also refer to the unresolved item imported here
-  --> $DIR/duplicate.rs:40:13
-   |
-LL |     pub use f::*;
-   |             ^^^^
-   = help: consider adding an explicit import of `foo` to disambiguate
-
-error[E0659]: `foo` is ambiguous (glob import vs glob import in the same module)
   --> $DIR/duplicate.rs:59:9
    |
 LL |         foo::bar(); //~ ERROR `foo` is ambiguous
@@ -88,7 +69,7 @@ LL |     use self::m2::*;
    |         ^^^^^^^^^^^
    = help: consider adding an explicit import of `foo` to disambiguate
 
-error: aborting due to 5 previous errors
+error: aborting due to 4 previous errors
 
 Some errors occurred: E0252, E0659.
 For more information about an error, try `rustc --explain E0252`.

--- a/src/test/ui/imports/issue-56125.stderr
+++ b/src/test/ui/imports/issue-56125.stderr
@@ -54,12 +54,12 @@ LL |     use issue_56125::*; //~ ERROR `issue_56125` is ambiguous
    |
    = note: `issue_56125` could refer to an extern crate passed with `--extern`
    = help: use `::issue_56125` to refer to this extern crate unambiguously
-note: `issue_56125` could also refer to the unresolved item imported here
-  --> $DIR/issue-56125.rs:21:9
+note: `issue_56125` could also refer to the module imported here
+  --> $DIR/issue-56125.rs:22:9
    |
-LL |     use empty::issue_56125; //~ ERROR unresolved import `empty::issue_56125`
-   |         ^^^^^^^^^^^^^^^^^^
-   = help: use `self::issue_56125` to refer to this unresolved item unambiguously
+LL |     use issue_56125::*; //~ ERROR `issue_56125` is ambiguous
+   |         ^^^^^^^^^^^^^^
+   = help: use `self::issue_56125` to refer to this module unambiguously
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/imports/issue-57015.rs
+++ b/src/test/ui/imports/issue-57015.rs
@@ -1,0 +1,13 @@
+mod glob_ok {
+    pub mod something {
+        pub mod something_else {}
+    }
+}
+
+mod single_err {}
+
+use glob_ok::*; // glob_ok::something
+use single_err::something; //~ ERROR unresolved import `single_err::something`
+use something::something_else;
+
+fn main() {}

--- a/src/test/ui/imports/issue-57015.stderr
+++ b/src/test/ui/imports/issue-57015.stderr
@@ -1,0 +1,9 @@
+error[E0432]: unresolved import `single_err::something`
+  --> $DIR/issue-57015.rs:10:5
+   |
+LL | use single_err::something; //~ ERROR unresolved import `single_err::something`
+   |     ^^^^^^^^^^^^^^^^^^^^^ no `something` in `single_err`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0432`.

--- a/src/test/ui/nll/issue-57265-return-type-wf-check.rs
+++ b/src/test/ui/nll/issue-57265-return-type-wf-check.rs
@@ -1,0 +1,26 @@
+#![feature(nll)]
+
+use std::any::Any;
+
+#[derive(Debug, Clone)]
+struct S<T: 'static>(T);
+
+// S<&'a T> is in the return type, so we get an implied bound
+// &'a T: 'static
+fn foo<'a, T>(x: &'a T) -> (S<&'a T>, Box<dyn Any + 'static>) {
+    let y = S(x);
+
+    let z = Box::new(y.clone()) as Box<dyn Any + 'static>;
+    (y, z)
+}
+
+fn main() {
+    let x = 5;
+
+    // Check that we require that the argument is of type `&'static String`,
+    // so that the return type is well-formed.
+    let (_, z) = foo(&"hello".to_string());
+    //~^ ERROR temporary value dropped while borrowed
+
+    println!("{:?}", z.downcast_ref::<S<&'static String>>());
+}

--- a/src/test/ui/nll/issue-57265-return-type-wf-check.stderr
+++ b/src/test/ui/nll/issue-57265-return-type-wf-check.stderr
@@ -1,0 +1,12 @@
+error[E0716]: temporary value dropped while borrowed
+  --> $DIR/issue-57265-return-type-wf-check.rs:22:23
+   |
+LL |     let (_, z) = foo(&"hello".to_string());
+   |                  -----^^^^^^^^^^^^^^^^^^^-- temporary value is freed at the end of this statement
+   |                  |    |
+   |                  |    creates a temporary which is freed while still in use
+   |                  argument requires that borrow lasts for `'static`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0716`.

--- a/src/test/ui/rust-2018/uniform-paths/auxiliary/issue-56596-2.rs
+++ b/src/test/ui/rust-2018/uniform-paths/auxiliary/issue-56596-2.rs
@@ -1,0 +1,1 @@
+pub extern crate core;

--- a/src/test/ui/rust-2018/uniform-paths/issue-56596-2.rs
+++ b/src/test/ui/rust-2018/uniform-paths/issue-56596-2.rs
@@ -1,0 +1,11 @@
+// compile-pass
+// edition:2018
+// compile-flags: --extern issue_56596_2
+// aux-build:issue-56596-2.rs
+
+mod m {
+    use core::any;
+    pub use issue_56596_2::*;
+}
+
+fn main() {}


### PR DESCRIPTION
Cherry-picked:

* #57053: Fix alignment for array indexing
* #57181: resolve: Fix another ICE in import validation
* #57185: resolve: Fix one more ICE in import validation
* #57282: Wf-check the output type of a function in MIR-typeck
* #55318: Ensure that Rustdoc discovers all necessary auto trait bounds
* #56838: Call poly_project_and_unify_type on types that contain inference types

Rolled up:

* #57300: [beta] Update RLS to include 100% CPU on hover bugfix
* #57301: beta: bootstrap from latest stable (1.31.1)
* #57292: [BETA] Update cargo

r? @ghost