### PR TITLE
VaList::copy should not require a mutable ref

### DIFF
--- a/src/libcore/ffi.rs
+++ b/src/libcore/ffi.rs
@@ -186,7 +186,7 @@ impl<'a> VaList<'a> {
                reason = "the `c_variadic` feature has not been properly tested on \
                          all supported platforms",
                issue = "27745")]
-    pub unsafe fn copy<F, R>(&mut self, f: F) -> R
+    pub unsafe fn copy<F, R>(&self, f: F) -> R
             where F: for<'copy> FnOnce(VaList<'copy>) -> R {
         #[cfg(any(all(not(target_arch = "aarch64"), not(target_arch = "powerpc"),
                       not(target_arch = "x86_64")),


### PR DESCRIPTION
`VaList::copy` does not need to take a mutable reference. The `va_copy`
intrinsic takes a immutable reference.