### PR TITLE
Fix repeated word typos

### DIFF
--- a/src/doc/rustc/src/lints/listing/warn-by-default.md
+++ b/src/doc/rustc/src/lints/listing/warn-by-default.md
@@ -24,7 +24,7 @@ warning: attempt to add with overflow
 
 ## dead-code
 
-This lint detects detect unused, unexported items. Some
+This lint detects unused, unexported items. Some
 example code that triggers this lint:
 
 ```rust
@@ -44,7 +44,7 @@ warning: function is never used: `foo`
 
 ## deprecated
 
-This lint detects detects use of deprecated items. Some
+This lint detects use of deprecated items. Some
 example code that triggers this lint:
 
 ```rust
@@ -119,7 +119,7 @@ warning: found struct without foreign-function-safe representation annotation in
 
 ## late-bound-lifetime-arguments
 
-This lint detects detects generic lifetime arguments in path segments with
+This lint detects generic lifetime arguments in path segments with
 late bound lifetime parameters. Some example code that triggers this lint:
 
 ```rust
@@ -381,7 +381,7 @@ extern crate macro_crate_test;
 
 ## private-in-public
 
-This lint detects detect private items in public interfaces not caught by the old implementation. Some
+This lint detects private items in public interfaces not caught by the old implementation. Some
 example code that triggers this lint:
 
 ```rust,ignore
@@ -659,7 +659,7 @@ warning: unknown lint: `not_a_real_lint`
 
 ## unreachable-code
 
-This lint detects detects unreachable code paths. Some example code that
+This lint detects unreachable code paths. Some example code that
 triggers this lint:
 
 ```rust,no_run
@@ -681,7 +681,7 @@ warning: unreachable statement
 
 ## unreachable-patterns
 
-This lint detects detects unreachable patterns. Some
+This lint detects unreachable patterns. Some
 example code that triggers this lint:
 
 ```rust
@@ -716,11 +716,11 @@ annotations now.
 
 ## unused-allocation
 
-This lint detects detects unnecessary allocations that can be eliminated.
+This lint detects unnecessary allocations that can be eliminated.
 
 ## unused-assignments
 
-This lint detects detect assignments that will never be read. Some
+This lint detects assignments that will never be read. Some
 example code that triggers this lint:
 
 ```rust
@@ -741,7 +741,7 @@ warning: value assigned to `x` is never read
 
 ## unused-attributes
 
-This lint detects detects attributes that were not used by the compiler. Some
+This lint detects attributes that were not used by the compiler. Some
 example code that triggers this lint:
 
 ```rust
@@ -785,7 +785,7 @@ warning: comparison is useless due to type limits
 
 ## unused-doc-comment
 
-This lint detects detects doc comments that aren't used by rustdoc. Some
+This lint detects doc comments that aren't used by rustdoc. Some
 example code that triggers this lint:
 
 ```rust
@@ -831,7 +831,7 @@ warning: unused import: `std::collections::HashMap`
 
 ## unused-macros
 
-This lint detects detects macros that were not used. Some example code that
+This lint detects macros that were not used. Some example code that
 triggers this lint:
 
 ```rust
@@ -884,7 +884,7 @@ warning: unused `std::result::Result` that must be used
 
 ## unused-mut
 
-This lint detects detect mut variables which don't need to be mutable. Some
+This lint detects mut variables which don't need to be mutable. Some
 example code that triggers this lint:
 
 ```rust
@@ -946,7 +946,7 @@ warning: unnecessary `unsafe` block
 
 ## unused-variables
 
-This lint detects detect variables which are not used in any way. Some
+This lint detects variables which are not used in any way. Some
 example code that triggers this lint:
 
 ```rust

--- a/src/doc/rustdoc/src/documentation-tests.md
+++ b/src/doc/rustdoc/src/documentation-tests.md
@@ -171,7 +171,7 @@ compiles, while only showing the parts that are relevant to that part of your
 explanation.
 
 The `#`-hiding of lines can be prevented by using two consecutive hashes
-`##`. This only needs to be done with with the first `#` which would've
+`##`. This only needs to be done with the first `#` which would've
 otherwise caused hiding. If we have a string literal like the following,
 which has a line that starts with a `#`:
 

--- a/src/librustc/infer/opaque_types/mod.rs
+++ b/src/librustc/infer/opaque_types/mod.rs
@@ -19,7 +19,7 @@ pub type OpaqueTypeMap<'tcx> = DefIdMap<OpaqueTypeDecl<'tcx>>;
 /// appear in the return type).
 #[derive(Copy, Clone, Debug)]
 pub struct OpaqueTypeDecl<'tcx> {
-    /// The substitutions that we apply to the abstract that that this
+    /// The substitutions that we apply to the abstract that this
     /// `impl Trait` desugars to. e.g., if:
     ///
     ///     fn foo<'a, 'b, T>() -> impl Trait<'a>

--- a/src/librustc/mir/interpret/value.rs
+++ b/src/librustc/mir/interpret/value.rs
@@ -87,7 +87,7 @@ pub enum Scalar<Tag=(), Id=AllocId> {
     /// The raw bytes of a simple value.
     Bits {
         /// The first `size` bytes are the value.
-        /// Do not try to read less or more bytes that that. The remaining bytes must be 0.
+        /// Do not try to read less or more bytes than that. The remaining bytes must be 0.
         size: u8,
         bits: u128,
     },

--- a/src/librustc/ty/fold.rs
+++ b/src/librustc/ty/fold.rs
@@ -110,7 +110,7 @@ pub trait TypeFoldable<'tcx>: fmt::Debug + Clone {
         self.has_type_flags(TypeFlags::HAS_FREE_REGIONS)
     }
 
-    /// True if there any any un-erased free regions.
+    /// True if there any un-erased free regions.
     fn has_erasable_regions(&self) -> bool {
         self.has_type_flags(TypeFlags::HAS_FREE_REGIONS)
     }

--- a/src/librustc/ty/fold.rs
+++ b/src/librustc/ty/fold.rs
@@ -110,7 +110,7 @@ pub trait TypeFoldable<'tcx>: fmt::Debug + Clone {
         self.has_type_flags(TypeFlags::HAS_FREE_REGIONS)
     }
 
-    /// True if there any un-erased free regions.
+    /// True if there are any un-erased free regions.
     fn has_erasable_regions(&self) -> bool {
         self.has_type_flags(TypeFlags::HAS_FREE_REGIONS)
     }

--- a/src/librustc_apfloat/ieee.rs
+++ b/src/librustc_apfloat/ieee.rs
@@ -2341,7 +2341,7 @@ mod sig {
             // Our exponent should not underflow.
             *exp = exp.checked_sub(bits as ExpInt).unwrap();
 
-            // Jump is the inter-limb jump; shift is is intra-limb shift.
+            // Jump is the inter-limb jump; shift is the intra-limb shift.
             let jump = bits / LIMB_BITS;
             let shift = bits % LIMB_BITS;
 
@@ -2375,7 +2375,7 @@ mod sig {
             // Our exponent should not overflow.
             *exp = exp.checked_add(bits as ExpInt).unwrap();
 
-            // Jump is the inter-limb jump; shift is is intra-limb shift.
+            // Jump is the inter-limb jump; shift is the intra-limb shift.
             let jump = bits / LIMB_BITS;
             let shift = bits % LIMB_BITS;
 

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -673,7 +673,7 @@ impl EarlyLintPass for AnonymousParameters {
     }
 }
 
-/// Checks for incorrect use use of `repr` attributes.
+/// Checks for incorrect use of `repr` attributes.
 #[derive(Clone)]
 pub struct BadRepr;
 

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -192,7 +192,7 @@ use foo::core;  // error: an extern crate named `core` has already
 fn main() {}
 ```
 
-To fix issue issue, you have to rename at least one of the two imports.
+To fix this issue, you have to rename at least one of the two imports.
 Example:
 
 ```

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1,6 +1,6 @@
 //! Conversion from AST representation of types to the `ty.rs` representation.
-//! The main routine here is `ast_ty_to_ty()`; each use is is parameterized by
-//! an instance of `AstConv`.
+//! The main routine here is `ast_ty_to_ty()`; each use is parameterized by an
+//! instance of `AstConv`.
 
 use errors::{Applicability, FatalError, DiagnosticId};
 use hir::{self, GenericArg, GenericArgs};

--- a/src/librustc_typeck/check/demand.rs
+++ b/src/librustc_typeck/check/demand.rs
@@ -335,7 +335,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 // we may want to suggest adding a `*`, or removing
                 // a `&`.
                 //
-                // (But, also check check the `expn_info()` to see if this is
+                // (But, also check the `expn_info()` to see if this is
                 // a macro; if so, it's hard to extract the text and make a good
                 // suggestion, so don't bother.)
                 if self.infcx.can_sub(self.param_env, checked, &expected).is_ok() &&

--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -534,7 +534,7 @@ impl<'a, 'tcx, 'rcx> AutoTraitFinder<'a, 'tcx, 'rcx> {
             did, param_env, type_generics, existing_predicates
         );
 
-        // The `Sized` trait must be handled specially, since we only only display it when
+        // The `Sized` trait must be handled specially, since we only display it when
         // it is *not* required (i.e., '?Sized')
         let sized_trait = self.cx
             .tcx

--- a/src/libstd/collections/hash/set.rs
+++ b/src/libstd/collections/hash/set.rs
@@ -179,7 +179,7 @@ impl<T, S> HashSet<T, S>
         HashSet { map: HashMap::with_hasher(hasher) }
     }
 
-    /// Creates an empty `HashSet` with with the specified capacity, using
+    /// Creates an empty `HashSet` with the specified capacity, using
     /// `hasher` to hash the keys.
     ///
     /// The hash set will be able to hold at least `capacity` elements without

--- a/src/libstd/sys/cloudabi/abi/cloudabi.rs
+++ b/src/libstd/sys/cloudabi/abi/cloudabi.rs
@@ -107,7 +107,7 @@
 //!
 //! ## Specification of the ABI
 //!
-//! The entire ABI is specified in a a file called
+//! The entire ABI is specified in a file called
 //! [`cloudabi.txt`](https://github.com/NuxiNL/cloudabi/blob/master/cloudabi.txt),
 //! from which all
 //! [headers](https://github.com/NuxiNL/cloudabi/tree/master/headers)

--- a/src/libstd/sys/windows/ext/fs.rs
+++ b/src/libstd/sys/windows/ext/fs.rs
@@ -126,7 +126,7 @@ pub trait OpenOptionsExt {
     ///
     /// By default `share_mode` is set to
     /// `FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE`. This allows
-    /// other processes to to read, write, and delete/rename the same file
+    /// other processes to read, write, and delete/rename the same file
     /// while it is open. Removing any of the flags will prevent other
     /// processes from performing the corresponding operation until the file
     /// handle is closed.

--- a/src/libsyntax/ext/tt/macro_parser.rs
+++ b/src/libsyntax/ext/tt/macro_parser.rs
@@ -161,7 +161,7 @@ struct MatcherPos<'root, 'tt: 'root> {
     /// The position of the "dot" in this matcher
     idx: usize,
 
-    /// The first span of source source that the beginning of this matcher corresponds to. In other
+    /// The first span of source that the beginning of this matcher corresponds to. In other
     /// words, the token in the source whose span is `sp_open` is matched against the first token of
     /// the matcher.
     sp_open: Span,

--- a/src/test/debuginfo/simd.rs
+++ b/src/test/debuginfo/simd.rs
@@ -4,7 +4,7 @@
 
 // FIXME: LLVM generates invalid debug info for variables requiring
 // dynamic stack realignment, which is the case on s390x for vector
-// types with with non-vector ABI.
+// types with non-vector ABI.
 // ignore-s390x
 
 // compile-flags:-g

--- a/src/test/run-make-fulldeps/relro-levels/Makefile
+++ b/src/test/run-make-fulldeps/relro-levels/Makefile
@@ -1,6 +1,6 @@
 -include ../tools.mk
 
-# This tests the different -Zrelro-level values, and makes sure that they they work properly.
+# This tests the different -Zrelro-level values, and makes sure that they work properly.
 
 all:
 ifeq ($(UNAME),Linux)

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2569,7 +2569,7 @@ impl<'test> TestCx<'test> {
             .env("LLVM_CXXFLAGS", &self.config.llvm_cxxflags)
 
             // We for sure don't want these tests to run in parallel, so make
-            // sure they don't have access to these vars if we we run via `make`
+            // sure they don't have access to these vars if we run via `make`
             // at the top level
             .env_remove("MAKEFLAGS")
             .env_remove("MFLAGS")


### PR DESCRIPTION
Inspired by #57295 (I skipped 'be be' because of it) and my [PR in another repo
](https://github.com/e-maxx-eng/e-maxx-eng/pull/389)
Not a stupid `sed`, I actually tried to fix case by case.