### PR TITLE
better error message for trailing doc comment in traits (issue #56766)

### DIFF
--- a/src/test/ui/useless-doc-comment/trait-impl.rs
+++ b/src/test/ui/useless-doc-comment/trait-impl.rs
@@ -1,0 +1,14 @@
+//! issue #56766
+//!
+//! invalid doc comment at the end of a trait declaration
+
+trait Foo {
+    ///
+    fn foo(&self);
+    /// I am not documenting anything
+    //~^ ERROR: found a documentation comment that doesn't document anything [E0585]
+}
+
+fn main() {
+
+}

--- a/src/test/ui/useless-doc-comment/trait-impl.stderr
+++ b/src/test/ui/useless-doc-comment/trait-impl.stderr
@@ -1,0 +1,11 @@
+error[E0585]: found a documentation comment that doesn't document anything
+  --> $DIR/trait-impl.rs:8:5
+   |
+LL |     /// I am not documenting anything
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: doc comments must come before what they document, maybe a comment was intended with `//`?
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0585`.


### PR DESCRIPTION
closes #56766 
r? @estebank 