### PR TITLE
 stop returning non-principal objects in issue #33140 relate mode

### DIFF
--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1618,6 +1618,7 @@ fn predicates_defined_on<'a, 'tcx>(
             .predicates
             .extend(inferred_outlives.iter().map(|&p| (p, span)));
     }
+    debug!("predicates_defined_on({:?}) = {:?}", def_id, result);
     result
 }
 
@@ -1645,6 +1646,7 @@ fn predicates_of<'a, 'tcx>(
             .predicates
             .push((ty::TraitRef::identity(tcx, def_id).to_predicate(), span));
     }
+    debug!("predicates_of(def_id={:?}) = {:?}", def_id, result);
     result
 }
 
@@ -1972,10 +1974,12 @@ fn explicit_predicates_of<'a, 'tcx>(
         );
     }
 
-    Lrc::new(ty::GenericPredicates {
+    let result = Lrc::new(ty::GenericPredicates {
         parent: generics.parent,
         predicates,
-    })
+    });
+    debug!("explicit_predicates_of(def_id={:?}) = {:?}", def_id, result);
+    result
 }
 
 pub enum SizedByDefault {

--- a/src/test/ui/issues/issue-57162.rs
+++ b/src/test/ui/issues/issue-57162.rs
@@ -1,0 +1,7 @@
+// compile-pass
+
+trait Foo {}
+impl Foo for dyn Send {}
+
+impl<T: Sync + Sync> Foo for T {}
+fn main() {}


### PR DESCRIPTION
Fixes issue #57162.

Note: this PR does not need to be merged if #56837 gets into the beta (Jan 18). In that case, I'll copy over the test from that issue.