### PR TITLE
Bump stage0

### DIFF
--- a/src/stage0.txt
+++ b/src/stage0.txt
@@ -12,7 +12,7 @@
 # source tarball for a stable release you'll likely see `1.x.0` for rustc and
 # `0.x.0` for Cargo where they were released on `date`.
 
-date: 2018-12-09
+date: 2019-01-04
 rustc: beta
 cargo: beta
 


### PR DESCRIPTION
Updates stage 0
From: rustc 1.32.0-beta.2 (a01e4761a 2018-12-08)
To:   rustc 1.32.0-beta.11 (e64fee6a3 2019-01-04)

Intended to pull in #57292 which will fix #57142.

The following is a list of PRs this also pulls in in case anyone is interested in seeing the changes:

#56930
#56961
#57236
#57305
