### PR TITLE
rustdoc: force binary filename for compiled doctests

### DIFF
--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -273,7 +273,7 @@ fn run_test(test: &str, cratename: &str, filename: &FileName, line: usize,
         target_features::add_configuration(&mut cfg, &sess, &*codegen_backend);
         sess.parse_sess.config = cfg;
 
-        let out = Some(outdir.lock().unwrap().path().to_path_buf());
+        let out = Some(outdir.lock().unwrap().path().join("rust_out"));
 
         if no_run {
             control.after_analysis.stop = Compilation::Stop;
@@ -286,8 +286,8 @@ fn run_test(test: &str, cratename: &str, filename: &FileName, line: usize,
                 &cstore,
                 &None,
                 &input,
-                &out,
                 &None,
+                &out,
                 None,
                 &control
             )

--- a/src/test/rustdoc/doctest-manual-crate-name.rs
+++ b/src/test/rustdoc/doctest-manual-crate-name.rs
@@ -1,0 +1,7 @@
+// compile-flags:--test
+
+//! ```
+//! #![crate_name="asdf"]
+//!
+//! println!("yo");
+//! ```


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/57317, needed for https://github.com/rust-lang/rust-by-example/issues/1137

Right now, when building a doctest, rustdoc provides the compiler an output directory (a temp dir) but lets the compiler name the executable. If the doctest needs to be executed, it then tries to run a binary named `rust_out` from that directory. For the most part, this works fine. However, if the doctest sets its own crate name, the compiler uses that name for the output binary instead. This causes rustdoc to try to execute a nonexistent binary, causing the test to fail.

This PR changes the paths rustdoc gives to the compiler when building doctests to force the output *filename* instead of just the *directory*.