### PR TITLE
librustc_mir: Make qualify_min_const_fn module public

### DIFF
--- a/src/librustc_mir/transform/mod.rs
+++ b/src/librustc_mir/transform/mod.rs
@@ -26,7 +26,7 @@ pub mod elaborate_drops;
 pub mod add_call_guards;
 pub mod promote_consts;
 pub mod qualify_consts;
-mod qualify_min_const_fn;
+pub mod qualify_min_const_fn;
 pub mod remove_noop_landing_pads;
 pub mod dump_mir;
 pub mod deaggregator;


### PR DESCRIPTION
Trying to write a `const_fn` lint for Clippy. @oli-obk suggested
[here][link] to use the `is_min_const_fn` function from the
`qualify_min_const_fn` module. However, the module is currently private
and this commit makes it public.

I lack any historical knowledge of the development of the `const_fn`
feature, so I'm not sure if it was private on purpose or not. fwiw, all
modules are already public except `qualify_min_const_fn`.

r? @oli-obk

[link]: https://github.com/rust-lang/rust-clippy/issues/2440#issuecomment-446109978