### PR TITLE
Calculate privacy access only via query

### DIFF
--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -122,7 +122,6 @@ mod sty;
 /// *on-demand* infrastructure.
 #[derive(Clone)]
 pub struct CrateAnalysis {
-    pub name: String,
     pub glob_map: Option<hir::GlobMap>,
 }
 

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -14,7 +14,6 @@ use ich::Fingerprint;
 use ich::StableHashingContext;
 use infer::canonical::Canonical;
 use middle::lang_items::{FnTraitLangItem, FnMutTraitLangItem, FnOnceTraitLangItem};
-use middle::privacy::AccessLevels;
 use middle::resolve_lifetime::ObjectLifetimeDefault;
 use mir::Mir;
 use mir::interpret::{GlobalId, ErrorHandled};
@@ -123,7 +122,6 @@ mod sty;
 /// *on-demand* infrastructure.
 #[derive(Clone)]
 pub struct CrateAnalysis {
-    pub access_levels: Lrc<AccessLevels>,
     pub name: String,
     pub glob_map: Option<hir::GlobMap>,
 }

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -784,7 +784,6 @@ where
             },
 
             analysis: ty::CrateAnalysis {
-                name: crate_name.to_string(),
                 glob_map: if resolver.make_glob_map {
                     Some(resolver.glob_map)
                 } else {

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -4,7 +4,6 @@ use rustc::hir::lowering::lower_crate;
 use rustc::hir::map as hir_map;
 use rustc::lint;
 use rustc::middle::{self, reachable, resolve_lifetime, stability};
-use rustc::middle::privacy::AccessLevels;
 use rustc::ty::{self, AllArenas, Resolutions, TyCtxt};
 use rustc::traits;
 use rustc::util::common::{install_panic_hook, time, ErrorReported};
@@ -18,7 +17,7 @@ use rustc_borrowck as borrowck;
 use rustc_codegen_utils::codegen_backend::CodegenBackend;
 use rustc_data_structures::fingerprint::Fingerprint;
 use rustc_data_structures::stable_hasher::StableHasher;
-use rustc_data_structures::sync::{self, Lrc, Lock};
+use rustc_data_structures::sync::{self, Lock};
 use rustc_incremental;
 use rustc_metadata::creader::CrateLoader;
 use rustc_metadata::cstore::{self, CStore};
@@ -785,7 +784,6 @@ where
             },
 
             analysis: ty::CrateAnalysis {
-                access_levels: Lrc::new(AccessLevels::default()),
                 name: crate_name.to_string(),
                 glob_map: if resolver.make_glob_map {
                     Some(resolver.glob_map)
@@ -1193,7 +1191,7 @@ pub fn phase_3_run_analysis_passes<'tcx, F, R>(
     sess: &'tcx Session,
     cstore: &'tcx CStore,
     hir_map: hir_map::Map<'tcx>,
-    mut analysis: ty::CrateAnalysis,
+    analysis: ty::CrateAnalysis,
     resolutions: Resolutions,
     arenas: &'tcx mut AllArenas<'tcx>,
     name: &str,
@@ -1275,8 +1273,9 @@ where
                 rvalue_promotion::check_crate(tcx)
             });
 
-            analysis.access_levels =
-                time(sess, "privacy checking", || rustc_privacy::check_crate(tcx));
+            time(sess, "privacy checking", || {
+                rustc_privacy::check_crate(tcx)
+            });
 
             time(sess, "intrinsic checking", || {
                 middle::intrinsicck::check_crate(tcx)

--- a/src/librustc_save_analysis/dump_visitor.rs
+++ b/src/librustc_save_analysis/dump_visitor.rs
@@ -14,7 +14,7 @@
 //! recording the output.
 
 use rustc::hir::def::Def as HirDef;
-use rustc::hir::def_id::DefId;
+use rustc::hir::def_id::{DefId, LOCAL_CRATE};
 use rustc::session::config::Input;
 use rustc::ty::{self, TyCtxt};
 use rustc_data_structures::fx::FxHashSet;
@@ -56,14 +56,14 @@ macro_rules! access_from {
     ($save_ctxt:expr, $vis:expr, $id:expr) => {
         Access {
             public: $vis.node.is_pub(),
-            reachable: $save_ctxt.analysis.access_levels.is_reachable($id),
+            reachable: $save_ctxt.tcx.privacy_access_levels(LOCAL_CRATE).is_reachable($id),
         }
     };
 
     ($save_ctxt:expr, $item:expr) => {
         Access {
             public: $item.vis.node.is_pub(),
-            reachable: $save_ctxt.analysis.access_levels.is_reachable($item.id),
+            reachable: $save_ctxt.tcx.privacy_access_levels(LOCAL_CRATE).is_reachable($item.id),
         }
     };
 }

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -470,7 +470,6 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
             }).collect(),
         };
         let analysis = ty::CrateAnalysis {
-            access_levels: Lrc::new(AccessLevels::default()),
             name: name.to_string(),
             glob_map: if resolver.make_glob_map { Some(resolver.glob_map.clone()) } else { None },
         };
@@ -494,12 +493,12 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
                                                         &mut arenas,
                                                         &name,
                                                         &output_filenames,
-                                                        |tcx, analysis, _, result| {
+                                                        |tcx, _, _, result| {
             if result.is_err() {
                 sess.fatal("Compilation failed, aborting rustdoc");
             }
 
-            let ty::CrateAnalysis { access_levels, .. } = analysis;
+            let access_levels = tcx.privacy_access_levels(LOCAL_CRATE);
 
             // Convert from a NodeId set to a DefId set since we don't always have easy access
             // to the map from defid -> nodeid

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -470,7 +470,6 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
             }).collect(),
         };
         let analysis = ty::CrateAnalysis {
-            name: name.to_string(),
             glob_map: if resolver.make_glob_map { Some(resolver.glob_map.clone()) } else { None },
         };
 


### PR DESCRIPTION
Initially converted to query in https://github.com/rust-lang/rust/commit/a9f6babcda1479f4e5566d1aadbf9a0d99aa3182 and then changed to respect dependencies https://github.com/rust-lang/rust/commit/8281e883dd12260f00ce650aa8824507d9c447af.

I did this as an effort to prune `CrateAnalysis` from librustc_save_analysis, with the only thing remaining being the glob map (`name` is unused, existing `crate_name` is exposed in the compiler passes, instead).

Since calculating the glob map is opt-in, it'd be great if we could calculate that on-demand. However, it seems that it'd require converting resolution to queries, which I'm not sure how to do yet.

In an effort to get rid of `CrateAnalysis` altogether, could we try unconditionally calculating the glob_map in the resolver, thus completely removing `CrateAnalysis` struct, and doing a perf run?

r? @nikomatsakis 

cc @petrochenkov do you have any idea how/if at all could we querify the resolver? I've stumbled upon a comment that's ~3? years old at the moment, so I'm guessing things might have changed and it actually may be feasible now. https://github.com/rust-lang/rust/blob/fe0c10019d7ee96909cc42cc265ef999a6b5dd70/src/librustc_driver/driver.rs#L589-L593