### PR TITLE
Better error note on unimplemented Index trait for string

### DIFF
--- a/src/libcore/ops/index.rs
+++ b/src/libcore/ops/index.rs
@@ -51,6 +51,21 @@
 /// ```
 #[lang = "index"]
 #[rustc_on_unimplemented(
+    on(
+        _Self="&str",
+        note="you can use `.chars().nth()` or `.bytes().nth()`
+see chapter in The Book <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>"
+    ),
+    on(
+        _Self="str",
+        note="you can use `.chars().nth()` or `.bytes().nth()`
+see chapter in The Book <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>"
+    ),
+    on(
+        _Self="std::string::String",
+        note="you can use `.chars().nth()` or `.bytes().nth()`
+see chapter in The Book <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>"
+    ),
     message="the type `{Self}` cannot be indexed by `{Idx}`",
     label="`{Self}` cannot be indexed by `{Idx}`",
 )]
@@ -141,6 +156,21 @@ pub trait Index<Idx: ?Sized> {
 /// ```
 #[lang = "index_mut"]
 #[rustc_on_unimplemented(
+    on(
+        _Self="&str",
+        note="you can use `.chars().nth()` or `.bytes().nth()`
+see chapter in The Book <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>"
+    ),
+    on(
+        _Self="str",
+        note="you can use `.chars().nth()` or `.bytes().nth()`
+see chapter in The Book <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>"
+    ),
+    on(
+        _Self="std::string::String",
+        note="you can use `.chars().nth()` or `.bytes().nth()`
+see chapter in The Book <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>"
+    ),
     message="the type `{Self}` cannot be mutably indexed by `{Idx}`",
     label="`{Self}` cannot be mutably indexed by `{Idx}`",
 )]

--- a/src/test/ui/str/str-idx.stderr
+++ b/src/test/ui/str/str-idx.stderr
@@ -5,6 +5,8 @@ LL |     let c: u8 = s[4]; //~ ERROR the type `str` cannot be indexed by `{integ
    |                 ^^^^ `str` cannot be indexed by `{integer}`
    |
    = help: the trait `std::ops::Index<{integer}>` is not implemented for `str`
+   = note: you can use `.chars().nth()` or `.bytes().nth()`
+           see chapter in The Book <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>
 
 error: aborting due to previous error
 

--- a/src/test/ui/str/str-mut-idx.stderr
+++ b/src/test/ui/str/str-mut-idx.stderr
@@ -29,6 +29,8 @@ LL |     s[1usize] = bot();
    |     ^^^^^^^^^ `str` cannot be mutably indexed by `usize`
    |
    = help: the trait `std::ops::IndexMut<usize>` is not implemented for `str`
+   = note: you can use `.chars().nth()` or `.bytes().nth()`
+           see chapter in The Book <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
fixes #56740 

I've tried to compile suggestion from comments in the issue #56740, but unsure of it. So I'm open to advice :)

Current output will be like this:
```rust
error[E0277]: the type `str` cannot be indexed by `{integer}`
  --> $DIR/str-idx.rs:3:17
   |
LL |     let c: u8 = s[4]; //~ ERROR the type `str` cannot be indexed by `{integer}`
   |                 ^^^^ `str` cannot be indexed by `{integer}`
   |
   = help: the trait `std::ops::Index<{integer}>` is not implemented for `str`
   = note: you can use `.chars().nth()` or `.bytes().nth()`
           see chapter in The Book <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>

error: aborting due to previous error

For more information about this error, try `rustc --explain E0277`.
```

`x.py test src/test/ui` succeeded and I've also tested output manually by compiling the following code:
```rust
fn _f() {
    let s = std::string::String::from("hello");
    let _c = s[0];

    let s = std::string::String::from("hello");
    let mut _c = s[0];

    let s = "hello";
    let _c = s[0];

    let s = "hello";
    let mut _c = &s[0];
}
```

Not sure if some docs should be changed too. I will also fix error message in the [Book :: Indexing into Strings](https://github.com/rust-lang/book/blob/db53e2e3cdf77beac853df6f29db4b3b86ea598c/src/ch08-02-strings.md#indexing-into-strings) if that PR will get approved :)