### PR TITLE
Cleanup PartialEq docs.

### DIFF
--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -65,6 +65,7 @@ use self::Ordering::*;
 /// the same book if their ISBN matches, even if the formats differ:
 ///
 /// ```
+/// #[derive(PartialEq)]
 /// enum BookFormat {
 ///     Paperback,
 ///     Hardback,

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -142,33 +142,33 @@ use self::Ordering::*;
 ///     Hardback,
 ///     Ebook,
 /// }
-/// 
+///
 /// struct Book {
 ///     isbn: i32,
 ///     format: BookFormat,
 /// }
-/// 
+///
 /// impl PartialEq<BookFormat> for Book {
 ///     fn eq(&self, other: &BookFormat) -> bool {
 ///         self.format == *other
 ///     }
 /// }
-/// 
+///
 /// impl PartialEq<Book> for BookFormat {
 ///     fn eq(&self, other: &Book) -> bool {
 ///         *self == other.format
 ///     }
 /// }
-/// 
+///
 /// impl PartialEq for Book {
 ///     fn eq(&self, other: &Book) -> bool {
 ///         self.isbn == other.isbn
 ///     }
 /// }
-/// 
+///
 /// let b1 = Book { isbn: 3, format: BookFormat::Paperback };
 /// let b2 = Book { isbn: 3, format: BookFormat::Ebook };
-/// 
+///
 /// assert!(b1 == BookFormat::Paperback);
 /// assert!(b1 != BookFormat::Ebook);
 /// assert!(b1 == b2);

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -170,7 +170,7 @@ use self::Ordering::*;
 /// let b2 = Book { isbn: 3, format: BookFormat::Ebook };
 ///
 /// assert!(b1 == BookFormat::Paperback);
-/// assert!(b1 != BookFormat::Ebook);
+/// assert!(BookFormat::Ebook != b1);
 /// assert!(b1 == b2);
 /// ```
 ///

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -96,6 +96,7 @@ use self::Ordering::*;
 /// For example, let's tweak our previous code a bit:
 ///
 /// ```
+/// // The derive implements <BookFormat> == <BookFormat> comparisons
 /// #[derive(PartialEq)]
 /// enum BookFormat {
 ///     Paperback,

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -65,7 +65,6 @@ use self::Ordering::*;
 /// the same book if their ISBN matches, even if the formats differ:
 ///
 /// ```
-/// #[derive(PartialEq)]
 /// enum BookFormat {
 ///     Paperback,
 ///     Hardback,
@@ -97,6 +96,7 @@ use self::Ordering::*;
 /// For example, let's tweak our previous code a bit:
 ///
 /// ```
+/// #[derive(PartialEq)]
 /// enum BookFormat {
 ///     Paperback,
 ///     Hardback,

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -107,66 +107,28 @@ use self::Ordering::*;
 ///     format: BookFormat,
 /// }
 ///
+/// // Implement <Book> == <BookFormat> comparisons
 /// impl PartialEq<BookFormat> for Book {
 ///     fn eq(&self, other: &BookFormat) -> bool {
-///         match (&self.format, other) {
-///            (BookFormat::Paperback, BookFormat::Paperback) => true,
-///            (BookFormat::Hardback,  BookFormat::Hardback)  => true,
-///            (BookFormat::Ebook,     BookFormat::Ebook)     => true,
-///            (_, _) => false,
-///         }
+///         self.format == *other
+///     }
+/// }
+///
+/// // Implement <BookFormat> == <Book> comparisons
+/// impl PartialEq<Book> for BookFormat {
+///     fn eq(&self, other: &Book) -> bool {
+///         *other == self.format
 ///     }
 /// }
 ///
 /// let b1 = Book { isbn: 3, format: BookFormat::Paperback };
 ///
 /// assert!(b1 == BookFormat::Paperback);
-/// assert!(b1 != BookFormat::Ebook);
+/// assert!(BookFormat::Ebook != b1);
 /// ```
 ///
 /// By changing `impl PartialEq for Book` to `impl PartialEq<BookFormat> for Book`,
-/// we've changed what type we can use on the right side of the `==` operator.
-/// This lets us use it in the `assert!` statements at the bottom.
-///
-/// You can also combine these implementations to let the `==` operator work with
-/// two different types:
-///
-/// ```
-/// enum BookFormat {
-///     Paperback,
-///     Hardback,
-///     Ebook,
-/// }
-///
-/// struct Book {
-///     isbn: i32,
-///     format: BookFormat,
-/// }
-///
-/// impl PartialEq<BookFormat> for Book {
-///     fn eq(&self, other: &BookFormat) -> bool {
-///         match (&self.format, other) {
-///            (&BookFormat::Paperback, &BookFormat::Paperback) => true,
-///            (&BookFormat::Hardback,  &BookFormat::Hardback)  => true,
-///            (&BookFormat::Ebook,     &BookFormat::Ebook)     => true,
-///            (_, _) => false,
-///         }
-///     }
-/// }
-///
-/// impl PartialEq for Book {
-///     fn eq(&self, other: &Book) -> bool {
-///         self.isbn == other.isbn
-///     }
-/// }
-///
-/// let b1 = Book { isbn: 3, format: BookFormat::Paperback };
-/// let b2 = Book { isbn: 3, format: BookFormat::Ebook };
-///
-/// assert!(b1 == BookFormat::Paperback);
-/// assert!(b1 != BookFormat::Ebook);
-/// assert!(b1 == b2);
-/// ```
+/// we allow `BookFormat`s to be compared with `Book`s.
 ///
 /// # Examples
 ///

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -132,6 +132,48 @@ use self::Ordering::*;
 /// By changing `impl PartialEq for Book` to `impl PartialEq<BookFormat> for Book`,
 /// we allow `BookFormat`s to be compared with `Book`s.
 ///
+/// You can also combine these implementations to let the `==` operator work with
+/// two different types:
+///
+/// ```
+/// #[derive(PartialEq)]
+/// enum BookFormat {
+///     Paperback,
+///     Hardback,
+///     Ebook,
+/// }
+/// 
+/// struct Book {
+///     isbn: i32,
+///     format: BookFormat,
+/// }
+/// 
+/// impl PartialEq<BookFormat> for Book {
+///     fn eq(&self, other: &BookFormat) -> bool {
+///         self.format == *other
+///     }
+/// }
+/// 
+/// impl PartialEq<Book> for BookFormat {
+///     fn eq(&self, other: &Book) -> bool {
+///         *self == other.format
+///     }
+/// }
+/// 
+/// impl PartialEq for Book {
+///     fn eq(&self, other: &Book) -> bool {
+///         self.isbn == other.isbn
+///     }
+/// }
+/// 
+/// let b1 = Book { isbn: 3, format: BookFormat::Paperback };
+/// let b2 = Book { isbn: 3, format: BookFormat::Ebook };
+/// 
+/// assert!(b1 == BookFormat::Paperback);
+/// assert!(b1 != BookFormat::Ebook);
+/// assert!(b1 == b2);
+/// ```
+///
 /// # Examples
 ///
 /// ```

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -117,7 +117,7 @@ use self::Ordering::*;
 /// // Implement <BookFormat> == <Book> comparisons
 /// impl PartialEq<Book> for BookFormat {
 ///     fn eq(&self, other: &Book) -> bool {
-///         *other == self.format
+///         *self == other.format
 ///     }
 /// }
 ///


### PR DESCRIPTION
- Cleanup the `impl PartialEq<BookFormat> for Book` implementation
- Implement `impl PartialEq<Book> for BookFormat` so it’s symmetric
  - Fixes https://github.com/rust-lang/rust/issues/53844.
- Removes the last example since it appears to be redundant with the
  previous two examples.