### PR TITLE
Add Iterator::max_size_hint

### DIFF
--- a/src/libcore/iter/traits/iterator.rs
+++ b/src/libcore/iter/traits/iterator.rs
@@ -199,6 +199,15 @@ pub trait Iterator {
     #[stable(feature = "rust1", since = "1.0.0")]
     fn size_hint(&self) -> (usize, Option<usize>) { (0, None) }
 
+    /// An estimate of the maximum size of iterators of this type.
+    ///
+    /// This is similar to [`size_hint`], with the exception that it applies to all
+    /// iterators of this type. It can be used to optimize adapters like [`flatten`]
+    /// and provide better size hints.
+    #[inline]
+    #[unstable(feature = "max_size_hint", issue = "0")]
+    fn max_size_hint() -> Option<usize> where Self: Sized { None }
+
     /// Consumes the iterator, counting the number of iterations and returning it.
     ///
     /// This method will evaluate the iterator until its [`next`] returns

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -1172,6 +1172,8 @@ impl<'a, A> Iterator for Iter<'a, A> {
     fn next(&mut self) -> Option<&'a A> { self.inner.next() }
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) { self.inner.size_hint() }
+    #[inline]
+    fn max_size_hint() -> Option<usize> { Some(1) }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -1218,6 +1220,8 @@ impl<'a, A> Iterator for IterMut<'a, A> {
     fn next(&mut self) -> Option<&'a mut A> { self.inner.next() }
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) { self.inner.size_hint() }
+    #[inline]
+    fn max_size_hint() -> Option<usize> { Some(1) }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -1255,6 +1259,8 @@ impl<A> Iterator for IntoIter<A> {
     fn next(&mut self) -> Option<A> { self.inner.next() }
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) { self.inner.size_hint() }
+    #[inline]
+    fn max_size_hint() -> Option<usize> { Some(1) }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -1077,6 +1077,8 @@ impl<'a, T> Iterator for Iter<'a, T> {
         let n = if self.inner.is_some() {1} else {0};
         (n, Some(n))
     }
+    #[inline]
+    fn max_size_hint() -> Option<usize> { Some(1) }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -1122,6 +1124,8 @@ impl<'a, T> Iterator for IterMut<'a, T> {
         let n = if self.inner.is_some() {1} else {0};
         (n, Some(n))
     }
+    #[inline]
+    fn max_size_hint() -> Option<usize> { Some(1) }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -1165,6 +1169,8 @@ impl<T> Iterator for IntoIter<T> {
         let n = if self.inner.is_some() {1} else {0};
         (n, Some(n))
     }
+    #[inline]
+    fn max_size_hint() -> Option<usize> { Some(1) }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]


### PR DESCRIPTION
This is an alternative to #48544 (since closed) which adds a `max_size_hint` method to `Iterator`. It should be merged after #56932, and the actual change is in commit 21348899c7c3068028d6c490edd3482f5e6392bb.

The idea of a "minimum size" is confusing for iterators and iterables, because it's unclear where this should exactly be described. However, the maximum size is unambiguous and will improve the upper bound hints for `flatten` and `flat_map`.

I figured that I'd create a PR here so that people can discuss the change, even though it probably won't be added immediately.