### PR TITLE
Provide the option to use libc++ even on all platforms

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -90,6 +90,12 @@
 # with clang-cl, so this is special in that it only compiles LLVM with clang-cl
 #clang-cl = '/path/to/clang-cl.exe'
 
+# Use libc++ when building LLVM instead of libstdc++. This is the default on
+# platforms already use libc++ as the default C++ library, but this option
+# allows you to use libc++ even on platforms when it's not. You need to ensure
+# that your host compiler ships with libc++.
+#use-libcxx = true
+
 # =============================================================================
 # General build configuration options
 # =============================================================================

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -752,6 +752,9 @@ pub fn build_codegen_backend(builder: &Builder,
             if builder.config.llvm_link_shared {
                 cargo.env("LLVM_LINK_SHARED", "1");
             }
+            if builder.config.llvm_use_libcxx {
+                cargo.env("LLVM_USE_LIBCXX", "1");
+            }
         }
         _ => panic!("unknown backend: {}", backend),
     }

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -82,6 +82,8 @@ pub struct Config {
     pub lldb_enabled: bool,
     pub llvm_tools_enabled: bool,
 
+    pub llvm_use_libcxx: bool,
+
     // rust codegen options
     pub rust_optimize: bool,
     pub rust_codegen_units: Option<u32>,
@@ -252,6 +254,7 @@ struct Llvm {
     link_shared: Option<bool>,
     version_suffix: Option<String>,
     clang_cl: Option<String>,
+    use_libcxx: Option<bool>,
 }
 
 #[derive(Deserialize, Default, Clone)]
@@ -513,6 +516,7 @@ impl Config {
             config.llvm_link_jobs = llvm.link_jobs;
             config.llvm_version_suffix = llvm.version_suffix.clone();
             config.llvm_clang_cl = llvm.clang_cl.clone();
+            set(&mut config.llvm_use_libcxx, llvm.use_libcxx);
         }
 
         if let Some(ref rust) = toml.rust {

--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -62,6 +62,7 @@ o("full-tools", None, "enable all tools")
 o("lld", "rust.lld", "build lld")
 o("lldb", "rust.lldb", "build lldb")
 o("missing-tools", "dist.missing-tools", "allow failures when building tools")
+o("use-libcxx", "llvm.use_libcxx", "build LLVM with libc++")
 
 # Optimization and debugging options. These may be overridden by the release
 # channel, etc.

--- a/src/librustc_llvm/build.rs
+++ b/src/librustc_llvm/build.rs
@@ -232,6 +232,7 @@ fn main() {
     }
 
     let llvm_static_stdcpp = env::var_os("LLVM_STATIC_STDCPP");
+    let llvm_use_libcxx = env::var_os("LLVM_USE_LIBCXX");
 
     let stdcppname = if target.contains("openbsd") {
         // llvm-config on OpenBSD doesn't mention stdlib=libc++
@@ -241,6 +242,8 @@ fn main() {
     } else if target.contains("netbsd") && llvm_static_stdcpp.is_some() {
         // NetBSD uses a separate library when relocation is required
         "stdc++_pic"
+    } else if llvm_use_libcxx.is_some() {
+        "c++"
     } else {
         "stdc++"
     };


### PR DESCRIPTION
This is the default on platforms which use libc++ as the default C++
library but this option allows using libc++ on others as well.