### PR TITLE
htmldocck: don't let HTMLParser convert charrefs

### DIFF
--- a/src/etc/htmldocck.py
+++ b/src/etc/htmldocck.py
@@ -137,6 +137,7 @@ class CustomHTMLParser(HTMLParser):
     attributes."""
     def __init__(self, target=None):
         HTMLParser.__init__(self)
+        self.convert_charrefs = False
         self.__builder = target or ET.TreeBuilder()
 
     def handle_starttag(self, tag, attrs):


### PR DESCRIPTION
With python 3.5, the default value for `convert_charrefs` became True. This broke nbsp conversion for `@matches` XPATH PATTERN tests.

My distro has python 3.7 as `python`, so I came across this failure:

```xpath
12: @matches check failed
        `XPATH PATTERN` did not match
        // @matches issue_32374/struct.T.html '//*[@class="stab unstable"]' '🔬 This is a nightly-only experimental API. \(test #32374\)$'
```

Putting a breakpoint on this method:
```python
    def handle_entityref(self, name):
        self.__builder.data(entitydefs[name])
```
shows that it was not called. I suspect this is due to the change in behaviour between python3.4 and 3.5 documented in the constructor and the method: https://docs.python.org/3/library/html.parser.html#html.parser.HTMLParser.handle_entityref