### PR TITLE
use ignore directives for run-make tests

### DIFF
--- a/src/test/run-make-fulldeps/c-dynamic-dylib/Makefile
+++ b/src/test/run-make-fulldeps/c-dynamic-dylib/Makefile
@@ -1,14 +1,12 @@
 -include ../tools.mk
 
+# ignore-macos
+#
 # This hits an assertion in the linker on older versions of osx apparently
-ifeq ($(shell uname),Darwin)
-all:
-	echo ignored
-else
+
 all: $(call DYLIB,cfoo)
 	$(RUSTC) foo.rs -C prefer-dynamic
 	$(RUSTC) bar.rs
 	$(call RUN,bar)
 	$(call REMOVE_DYLIBS,cfoo)
 	$(call FAIL,bar)
-endif

--- a/src/test/run-make-fulldeps/c-dynamic-rlib/Makefile
+++ b/src/test/run-make-fulldeps/c-dynamic-rlib/Makefile
@@ -1,17 +1,15 @@
 -include ../tools.mk
 
+# ignore-macos
+#
+# This hits an assertion in the linker on older versions of osx apparently
+
 # This overrides the LD_LIBRARY_PATH for RUN
 TARGET_RPATH_DIR:=$(TARGET_RPATH_DIR):$(TMPDIR)
 
-# This hits an assertion in the linker on older versions of osx apparently
-ifeq ($(shell uname),Darwin)
-all:
-	echo ignored
-else
 all: $(call DYLIB,cfoo)
 	$(RUSTC) foo.rs
 	$(RUSTC) bar.rs
 	$(call RUN,bar)
 	$(call REMOVE_DYLIBS,cfoo)
 	$(call FAIL,bar)
-endif

--- a/src/test/run-make-fulldeps/c-link-to-rust-staticlib/Makefile
+++ b/src/test/run-make-fulldeps/c-link-to-rust-staticlib/Makefile
@@ -1,7 +1,8 @@
 -include ../tools.mk
 
-# FIXME: ignore freebsd
-ifneq ($(shell uname),FreeBSD)
+# ignore-freebsd
+# FIXME
+
 all:
 	$(RUSTC) foo.rs
 	$(CC) bar.c $(call STATICLIB,foo) $(call OUT_EXE,bar) \
@@ -9,8 +10,3 @@ all:
 	$(call RUN,bar)
 	rm $(call STATICLIB,foo)
 	$(call RUN,bar)
-
-else
-all:
-
-endif

--- a/src/test/run-make-fulldeps/cdylib-fewer-symbols/Makefile
+++ b/src/test/run-make-fulldeps/cdylib-fewer-symbols/Makefile
@@ -3,13 +3,10 @@
 
 -include ../tools.mk
 
+# ignore-windows
 # FIXME: The __rdl_ and __rust_ symbol still remains, no matter using MSVC or GNU
 # See https://github.com/rust-lang/rust/pull/46207#issuecomment-347561753
-ifdef IS_WINDOWS
-all:
-	true
-else
+
 all:
 	$(RUSTC) foo.rs
 	nm -g "$(call DYLIB,foo)" | $(CGREP) -v __rdl_ __rde_ __rg_ __rust_
-endif

--- a/src/test/run-make-fulldeps/compiler-rt-works-on-mingw/Makefile
+++ b/src/test/run-make-fulldeps/compiler-rt-works-on-mingw/Makefile
@@ -1,17 +1,9 @@
 -include ../tools.mk
 
-ifneq (,$(findstring MINGW,$(UNAME)))
-ifndef IS_MSVC
+# only-mingw
+
 all:
 	$(CXX) foo.cpp -c -o $(TMPDIR)/foo.o
 	$(AR) crus $(TMPDIR)/libfoo.a $(TMPDIR)/foo.o
 	$(RUSTC) foo.rs -lfoo -lstdc++
 	$(call RUN,foo)
-else
-all:
-
-endif
-else
-all:
-
-endif

--- a/src/test/run-make-fulldeps/dep-info-spaces/Makefile
+++ b/src/test/run-make-fulldeps/dep-info-spaces/Makefile
@@ -1,9 +1,9 @@
 -include ../tools.mk
 
-# FIXME: ignore freebsd/windows
-# (windows: see `../dep-info/Makefile`)
-ifneq ($(shell uname),FreeBSD)
-ifndef IS_WINDOWS
+# ignore-windows
+# ignore-freebsd
+# FIXME: (windows: see `../dep-info/Makefile`)
+
 all:
 	cp lib.rs $(TMPDIR)/
 	cp 'foo foo.rs' $(TMPDIR)/
@@ -17,12 +17,3 @@ all:
 	pwd
 	$(MAKE) -drf Makefile.foo
 	rm $(TMPDIR)/done && exit 1 || exit 0
-else
-all:
-
-endif
-
-else
-all:
-
-endif

--- a/src/test/run-make-fulldeps/dep-info/Makefile
+++ b/src/test/run-make-fulldeps/dep-info/Makefile
@@ -1,11 +1,11 @@
 -include ../tools.mk
 
-# FIXME: ignore freebsd/windows
-# on windows `rustc --dep-info` produces Makefile dependency with
+# ignore-windows
+# ignore-freebsd
+# FIXME: on windows `rustc --dep-info` produces Makefile dependency with
 # windows native paths (e.g. `c:\path\to\libfoo.a`)
 # but msys make seems to fail to recognize such paths, so test fails.
-ifneq ($(shell uname),FreeBSD)
-ifndef IS_WINDOWS
+
 all:
 	cp *.rs $(TMPDIR)
 	$(RUSTC) --emit dep-info,link --crate-type=lib $(TMPDIR)/lib.rs
@@ -23,12 +23,3 @@ all:
 	rm $(TMPDIR)/bar.rs
 	cp $(TMPDIR)/lib2.rs $(TMPDIR)/lib.rs
 	$(MAKE) -drf Makefile.foo
-else
-all:
-
-endif
-
-else
-all:
-
-endif

--- a/src/test/run-make-fulldeps/emit-stack-sizes/Makefile
+++ b/src/test/run-make-fulldeps/emit-stack-sizes/Makefile
@@ -1,31 +1,13 @@
 -include ../tools.mk
 
+# ignore-windows
+# ignore-macos
+# min-llvm-version 6.0
+#
 # This feature only works when the output object format is ELF so we ignore
 # macOS and Windows
-ifdef IS_WINDOWS
-# Do nothing on Windows.
-all:
-	exit 0
-else ifneq (,$(filter $(TARGET),i686-apple-darwin x86_64-apple-darwin))
-# Do nothing on macOS.
-all:
-	exit 0
-else
+
 # check that the .stack_sizes section is generated
-# this test requires LLVM >= 6.0.0
-vers = $(shell $(RUSTC) -Vv)
-ifneq (,$(findstring LLVM version: 3,$(vers)))
-all:
-	exit 0
-else ifneq (,$(findstring LLVM version: 4,$(vers)))
-all:
-	exit 0
-else ifneq (,$(findstring LLVM version: 5,$(vers)))
-all:
-	exit 0
-else
 all:
 	$(RUSTC) -C opt-level=3 -Z emit-stack-sizes --emit=obj foo.rs
 	size -A $(TMPDIR)/foo.o | $(CGREP) .stack_sizes
-endif
-endif

--- a/src/test/run-make-fulldeps/fpic/Makefile
+++ b/src/test/run-make-fulldeps/fpic/Makefile
@@ -1,13 +1,10 @@
 -include ../tools.mk
 
+# ignore-windows
+# ignore-macos
+
 # Test for #39529.
 # `-z text` causes ld to error if there are any non-PIC sections
 
-ifeq ($(UNAME),Darwin)
-all:
-else ifdef IS_WINDOWS
-all:
-else
 all:
 	$(RUSTC) hello.rs -C link-args=-Wl,-z,text
-endif

--- a/src/test/run-make-fulldeps/include_bytes_deps/Makefile
+++ b/src/test/run-make-fulldeps/include_bytes_deps/Makefile
@@ -1,20 +1,11 @@
 -include ../tools.mk
 
-# FIXME: ignore freebsd/windows
-# on windows `rustc --dep-info` produces Makefile dependency with
+# ignore-windows
+# ignore-freebsd
+# FIXME: on windows `rustc --dep-info` produces Makefile dependency with
 # windows native paths (e.g. `c:\path\to\libfoo.a`)
 # but msys make seems to fail to recognize such paths, so test fails.
-ifneq ($(shell uname),FreeBSD)
-ifndef IS_WINDOWS
+
 all:
 	$(RUSTC) --emit dep-info main.rs
 	$(CGREP) "input.txt" "input.bin" "input.md" < $(TMPDIR)/main.d
-else
-all:
-
-endif
-
-else
-all:
-
-endif

--- a/src/test/run-make-fulldeps/intrinsic-unreachable/Makefile
+++ b/src/test/run-make-fulldeps/intrinsic-unreachable/Makefile
@@ -1,15 +1,11 @@
 -include ../tools.mk
 
-ifndef IS_WINDOWS
-# The assembly for exit-unreachable.rs should be shorter because it's missing
-# (at minimum) a return instruction.
+# ignore-windows
+#
+# Because of Windows exception handling, the code is not necessarily any shorter.
+# https://github.com/llvm-mirror/llvm/commit/64b2297786f7fd6f5fa24cdd4db0298fbf211466
 
 all:
 	$(RUSTC) -O --emit asm exit-ret.rs
 	$(RUSTC) -O --emit asm exit-unreachable.rs
 	test `wc -l < $(TMPDIR)/exit-unreachable.s` -lt `wc -l < $(TMPDIR)/exit-ret.s`
-else
-# Because of Windows exception handling, the code is not necessarily any shorter.
-# https://github.com/llvm-mirror/llvm/commit/64b2297786f7fd6f5fa24cdd4db0298fbf211466
-all:
-endif

--- a/src/test/run-make-fulldeps/issue-24445/Makefile
+++ b/src/test/run-make-fulldeps/issue-24445/Makefile
@@ -1,12 +1,10 @@
 -include ../tools.mk
 
-ifeq ($(UNAME),Linux)
+# only-linux
+
 all:
 	$(RUSTC) foo.rs
 	$(CC) foo.c -lfoo -L $(TMPDIR) -Wl,--gc-sections -lpthread -ldl -o $(TMPDIR)/foo
 	$(call RUN,foo)
 	$(CC) foo.c -lfoo -L $(TMPDIR) -Wl,--gc-sections -lpthread -ldl -pie -fPIC -o $(TMPDIR)/foo
 	$(call RUN,foo)
-else
-all:
-endif

--- a/src/test/run-make-fulldeps/issue-26006/Makefile
+++ b/src/test/run-make-fulldeps/issue-26006/Makefile
@@ -1,8 +1,9 @@
 -include ../tools.mk
 
+# ignore-windows
+
 OUT := $(TMPDIR)/out
 
-ifndef IS_WINDOWS
 all: time
 
 time: libc
@@ -13,6 +14,3 @@ time: libc
 libc:
 	mkdir -p $(OUT)/libc
 	$(RUSTC) in/libc/lib.rs --crate-name=libc -Cmetadata=foo -o $(OUT)/libc/liblibc.rlib
-else
-all:
-endif

--- a/src/test/run-make-fulldeps/issue-36710/Makefile
+++ b/src/test/run-make-fulldeps/issue-36710/Makefile
@@ -1,21 +1,12 @@
 -include ../tools.mk
 
-ifeq (musl,$(findstring musl,$(TARGET)))
-all: skip
-else
-all: test
-endif
+# ignore-musl
 
-test: foo
+all: foo
 	$(call RUN,foo)
-
-skip:
-	echo "expected failure"
 
 foo: foo.rs $(call NATIVE_STATICLIB,foo)
 	$(RUSTC) $< -lfoo $(EXTRACXXFLAGS)
 
 $(TMPDIR)/libfoo.o: foo.cpp
 	$(call COMPILE_OBJ_CXX,$@,$<)
-
-.PHONY: all test skip

--- a/src/test/run-make-fulldeps/issue-37839/Makefile
+++ b/src/test/run-make-fulldeps/issue-37839/Makefile
@@ -1,12 +1,8 @@
 -include ../tools.mk
 
-ifeq ($(findstring stage1,$(RUST_BUILD_STAGE)),stage1)
-# ignore stage1
-all:
+# ignore-stage1
 
-else
 all:
 	$(RUSTC) a.rs && $(RUSTC) b.rs
 	$(BARE_RUSTC) c.rs -L dependency=$(TMPDIR) --extern b=$(TMPDIR)/libb.rlib \
 		--out-dir=$(TMPDIR)
-endif

--- a/src/test/run-make-fulldeps/issue-37893/Makefile
+++ b/src/test/run-make-fulldeps/issue-37893/Makefile
@@ -1,10 +1,6 @@
 -include ../tools.mk
 
-ifeq ($(findstring stage1,$(RUST_BUILD_STAGE)),stage1)
-# ignore stage1
-all:
+# ignore-stage1
 
-else
 all:
 	$(RUSTC) a.rs && $(RUSTC) b.rs && $(RUSTC) c.rs
-endif

--- a/src/test/run-make-fulldeps/issue-51671/Makefile
+++ b/src/test/run-make-fulldeps/issue-51671/Makefile
@@ -1,13 +1,9 @@
 -include ../tools.mk
 
-ifdef IS_WINDOWS
-# Do nothing on MSVC.
-all:
-	exit 0
-else
+# ignore-windows
+
 all:
 	$(RUSTC) --emit=obj app.rs
 	nm $(TMPDIR)/app.o | $(CGREP) rust_begin_unwind
 	nm $(TMPDIR)/app.o | $(CGREP) rust_eh_personality
 	nm $(TMPDIR)/app.o | $(CGREP) rust_oom
-endif

--- a/src/test/run-make-fulldeps/libs-search-path/Makefile
+++ b/src/test/run-make-fulldeps/libs-search-path/Makefile
@@ -1,6 +1,6 @@
 -include ../tools.mk
 
-ifeq ($(if $(IS_WINDOWS),$(IS_MSVC),no),)
+# only-mingw
 
 all: empty.rs
 	cp -r $(shell cygpath -u $(shell $(RUSTC) --print sysroot)) $(TMPDIR)/sysroot
@@ -8,9 +8,3 @@ all: empty.rs
 	mkdir -p $(TMPDIR)/obj
 	mv $(TMPDIR)/sysroot/lib/rustlib/$(TARGET)/lib/crt2.o $(TMPDIR)/obj/crt2.o
 	$(RUSTC) --target $(TARGET) --sysroot $(TMPDIR)/sysroot -L$(TMPDIR)/obj -Z print-link-args empty.rs | $(CGREP) 'obj\\crt2.o'
-
-else
-
-all:
-
-endif

--- a/src/test/run-make-fulldeps/libs-through-symlinks/Makefile
+++ b/src/test/run-make-fulldeps/libs-through-symlinks/Makefile
@@ -1,8 +1,6 @@
 -include ../tools.mk
 
-ifdef IS_WINDOWS
-all:
-else
+# ignore-windows
 
 NAME := $(shell $(RUSTC) --print file-names foo.rs)
 
@@ -11,4 +9,3 @@ all:
 	$(RUSTC) foo.rs -o $(TMPDIR)/outdir/$(NAME)
 	ln -nsf outdir/$(NAME) $(TMPDIR)
 	RUST_LOG=rustc_metadata::loader $(RUSTC) bar.rs
-endif

--- a/src/test/run-make-fulldeps/linker-output-non-utf8/Makefile
+++ b/src/test/run-make-fulldeps/linker-output-non-utf8/Makefile
@@ -2,16 +2,16 @@
 
 # Make sure we don't ICE if the linker prints a non-UTF-8 error message.
 
-# Ignore Windows and Apple
-
+# ignore-windows
+#
 # This does not work in its current form on windows, possibly due to
 # gcc bugs or something about valid Windows paths.  See issue #29151
 # for more information.
-ifndef IS_WINDOWS
 
+# ignore-macos
+#
 # This also does not work on Apple APFS due to the filesystem requiring
 # valid UTF-8 paths.
-ifneq ($(shell uname),Darwin)
 
 # The zzz it to allow humans to tab complete or glob this thing.
 bad_dir := $(TMPDIR)/zzz$$'\xff'
@@ -21,12 +21,3 @@ all:
 	mkdir $(bad_dir)
 	mv $(TMPDIR)/liblibrary.a $(bad_dir)
 	LIBRARY_PATH=$(bad_dir) $(RUSTC) exec.rs 2>&1 | $(CGREP) this_symbol_not_defined
-else
-all:
-
-endif
-
-else
-all:
-
-endif

--- a/src/test/run-make-fulldeps/min-global-align/Makefile
+++ b/src/test/run-make-fulldeps/min-global-align/Makefile
@@ -1,5 +1,7 @@
 -include ../tools.mk
 
+# only-linux
+
 # This tests ensure that global variables respect the target minimum alignment.
 # The three bools `STATIC_BOOL`, `STATIC_MUT_BOOL`, and `CONST_BOOL` all have
 # type-alignment of 1, but some targets require greater global alignment.
@@ -8,7 +10,6 @@ SRC = min_global_align.rs
 LL = $(TMPDIR)/min_global_align.ll
 
 all:
-ifeq ($(UNAME),Linux)
 # Most targets are happy with default alignment -- take i686 for example.
 ifeq ($(filter x86,$(LLVM_COMPONENTS)),x86)
 	$(RUSTC) --target=i686-unknown-linux-gnu --emit=llvm-ir $(SRC)
@@ -18,5 +19,4 @@ endif
 ifeq ($(filter systemz,$(LLVM_COMPONENTS)),systemz)
 	$(RUSTC) --target=s390x-unknown-linux-gnu --emit=llvm-ir $(SRC)
 	[ "$$(grep -c 'align 2' "$(LL)")" -eq "3" ]
-endif
 endif

--- a/src/test/run-make-fulldeps/no-integrated-as/Makefile
+++ b/src/test/run-make-fulldeps/no-integrated-as/Makefile
@@ -1,7 +1,8 @@
 -include ../tools.mk
 
+# only-linux
+# only-x86_64
+
 all:
-ifeq ($(TARGET),x86_64-unknown-linux-gnu)
 	$(RUSTC) hello.rs -C no_integrated_as
 	$(call RUN,hello)
-endif

--- a/src/test/run-make-fulldeps/pgo-gen-lto/Makefile
+++ b/src/test/run-make-fulldeps/pgo-gen-lto/Makefile
@@ -1,10 +1,10 @@
 -include ../tools.mk
 
+# ignore-windows
+
 all:
 ifeq ($(PROFILER_SUPPORT),1)
-ifndef IS_WINDOWS
 	$(RUSTC) -Copt-level=3 -Clto=fat -Z pgo-gen="$(TMPDIR)/test.profraw" test.rs
 	$(call RUN,test) || exit 1
 	[ -e "$(TMPDIR)/test.profraw" ] || (echo "No .profraw file"; exit 1)
-endif
 endif

--- a/src/test/run-make-fulldeps/pgo-gen/Makefile
+++ b/src/test/run-make-fulldeps/pgo-gen/Makefile
@@ -1,10 +1,10 @@
 -include ../tools.mk
 
+# ignore-windows
+
 all:
 ifeq ($(PROFILER_SUPPORT),1)
-ifndef IS_WINDOWS
 	$(RUSTC) -g -Z pgo-gen="$(TMPDIR)/test.profraw" test.rs
 	$(call RUN,test) || exit 1
 	[ -e "$(TMPDIR)/test.profraw" ] || (echo "No .profraw file"; exit 1)
-endif
 endif

--- a/src/test/run-make-fulldeps/prune-link-args/Makefile
+++ b/src/test/run-make-fulldeps/prune-link-args/Makefile
@@ -1,11 +1,9 @@
 -include ../tools.mk
-ifdef IS_WINDOWS
-# ignore windows
-RUSTC_FLAGS =
-else
+
+# ignore-windows
+
 # Notice the space in the end, this emulates the output of pkg-config
 RUSTC_FLAGS = -C link-args="-lc "
-endif
 
 all:
 	$(RUSTC) $(RUSTC_FLAGS) empty.rs

--- a/src/test/run-make-fulldeps/relro-levels/Makefile
+++ b/src/test/run-make-fulldeps/relro-levels/Makefile
@@ -1,9 +1,10 @@
 -include ../tools.mk
 
+# only-linux
+#
 # This tests the different -Zrelro-level values, and makes sure that they work properly.
 
 all:
-ifeq ($(UNAME),Linux)
 	# Ensure that binaries built with the full relro level links them with both
 	# RELRO and BIND_NOW for doing eager symbol resolving.
 	$(RUSTC) -Zrelro-level=full hello.rs
@@ -18,4 +19,3 @@ ifeq ($(UNAME),Linux)
 	# enabled by default.
 	$(RUSTC) -Zrelro-level=off hello.rs
 	! readelf -l $(TMPDIR)/hello | grep -q GNU_RELRO
-endif

--- a/src/test/run-make-fulldeps/rustdoc-io-error/Makefile
+++ b/src/test/run-make-fulldeps/rustdoc-io-error/Makefile
@@ -4,10 +4,10 @@
 # while generating files. Ideally this would be a rustdoc-ui test, so we could
 # verify the error message as well.
 
-OUTPUT_DIR := "$(TMPDIR)/rustdoc-io-error"
+# ignore-windows
+# The test uses `chmod`.
 
-# Ignore Windows: the test uses `chmod`.
-ifndef IS_WINDOWS
+OUTPUT_DIR := "$(TMPDIR)/rustdoc-io-error"
 
 # This test operates by creating a temporary directory and modifying its
 # permissions so that it is not writable. We have to take special care to set
@@ -18,8 +18,3 @@ all:
 	-$(shell $(RUSTDOC) -o $(OUTPUT_DIR) foo.rs)
 	chmod u+w $(OUTPUT_DIR)
 	exit $($(.SHELLSTATUS) -eq 1)
-
-else
-all:
-
-endif

--- a/src/test/run-make-fulldeps/sanitizer-leak/Makefile
+++ b/src/test/run-make-fulldeps/sanitizer-leak/Makefile
@@ -1,16 +1,12 @@
 -include ../tools.mk
 
+# only-linux
+# only-x86_64
+# ignore-test
 # FIXME(#46126) ThinLTO for libstd broke this test
-ifeq (1,0)
+
 all:
-ifeq ($(TARGET),x86_64-unknown-linux-gnu)
 ifdef SANITIZER_SUPPORT
 	$(RUSTC) -C opt-level=1 -g -Z sanitizer=leak -Z print-link-args leak.rs | $(CGREP) librustc_lsan
 	$(TMPDIR)/leak 2>&1 | $(CGREP) 'detected memory leaks'
 endif
-endif
-
-else
-all:
-endif
-

--- a/src/test/run-make-fulldeps/sanitizer-memory/Makefile
+++ b/src/test/run-make-fulldeps/sanitizer-memory/Makefile
@@ -1,10 +1,10 @@
 -include ../tools.mk
 
+# only-linux
+# only-x86_64
+
 all:
-ifeq ($(TARGET),x86_64-unknown-linux-gnu)
 ifdef SANITIZER_SUPPORT
 	$(RUSTC) -g -Z sanitizer=memory -Z print-link-args uninit.rs | $(CGREP) librustc_msan
 	$(TMPDIR)/uninit 2>&1 | $(CGREP) use-of-uninitialized-value
 endif
-endif
-

--- a/src/test/run-make-fulldeps/symbol-visibility/Makefile
+++ b/src/test/run-make-fulldeps/symbol-visibility/Makefile
@@ -1,12 +1,9 @@
 include ../tools.mk
 
-ifdef IS_WINDOWS
-# Do nothing on MSVC.
+# ignore-windows
+#
 # On MINGW the --version-script, --dynamic-list, and --retain-symbol args don't
 # seem to work reliably.
-all:
-	exit 0
-else
 
 NM=nm -D
 CDYLIB_NAME=liba_cdylib.so
@@ -89,4 +86,3 @@ all:
 	# Check that an executable does not export any dynamic symbols
 	[ "$$($(NM) $(TMPDIR)/$(EXE_NAME) | grep -c public_c_function_from_rlib)" -eq "0" ]
 	[ "$$($(NM) $(TMPDIR)/$(EXE_NAME) | grep -c public_rust_function_from_exe)" -eq "0" ]
-endif

--- a/src/test/run-make-fulldeps/symlinked-extern/Makefile
+++ b/src/test/run-make-fulldeps/symlinked-extern/Makefile
@@ -1,7 +1,7 @@
 -include ../tools.mk
 
-# ignore windows: `ln` is actually `cp` on msys.
-ifndef IS_WINDOWS
+# ignore-windows
+# `ln` is actually `cp` on msys.
 
 all:
 	$(RUSTC) foo.rs
@@ -9,8 +9,3 @@ all:
 	ln -nsf $(TMPDIR)/libfoo.rlib $(TMPDIR)/other
 	$(RUSTC) bar.rs -L $(TMPDIR)
 	$(RUSTC) baz.rs --extern foo=$(TMPDIR)/other/libfoo.rlib  -L $(TMPDIR)
-
-else
-all:
-
-endif

--- a/src/test/run-make-fulldeps/symlinked-libraries/Makefile
+++ b/src/test/run-make-fulldeps/symlinked-libraries/Makefile
@@ -1,15 +1,10 @@
 -include ../tools.mk
 
-# ignore windows: `ln` is actually `cp` on msys.
-ifndef IS_WINDOWS
+# ignore-windows
+# `ln` is actually `cp` on msys.
 
 all:
 	$(RUSTC) foo.rs -C prefer-dynamic
 	mkdir -p $(TMPDIR)/other
 	ln -nsf $(TMPDIR)/$(call DYLIB_GLOB,foo) $(TMPDIR)/other
 	$(RUSTC) bar.rs -L $(TMPDIR)/other
-
-else
-all:
-
-endif

--- a/src/test/run-make-fulldeps/symlinked-rlib/Makefile
+++ b/src/test/run-make-fulldeps/symlinked-rlib/Makefile
@@ -1,14 +1,9 @@
 -include ../tools.mk
 
-# ignore windows: `ln` is actually `cp` on msys.
-ifndef IS_WINDOWS
+# ignore-windows
+# `ln` is actually `cp` on msys.
 
 all:
 	$(RUSTC) foo.rs --crate-type=rlib -o $(TMPDIR)/foo.xxx
 	ln -nsf $(TMPDIR)/foo.xxx $(TMPDIR)/libfoo.rlib
 	$(RUSTC) bar.rs -L $(TMPDIR)
-
-else
-all:
-
-endif

--- a/src/test/run-make-fulldeps/target-cpu-native/Makefile
+++ b/src/test/run-make-fulldeps/target-cpu-native/Makefile
@@ -1,8 +1,11 @@
 -include ../tools.mk
 
+# only-linux
+# only-x86_64
+#
 # I *really* don't want to deal with a cross-platform way to compare file sizes,
 # tests in `make` sort of are awful
-ifeq ($(TARGET),x86_64-unknown-linux-gnu)
+
 all: $(TMPDIR)/out.log
 	# Make sure no warnings about "unknown CPU `native`" were emitted
 	if [ "$$(wc -c $(TMPDIR)/out.log | cut -d' ' -f 1)" = "0" ]; then \
@@ -10,9 +13,6 @@ all: $(TMPDIR)/out.log
 	else \
 	  exit 1; \
 	fi
-else
-all: $(TMPDIR)/out.log
-endif
 
 
 $(TMPDIR)/out.log:

--- a/src/test/run-make-fulldeps/use-extern-for-plugins/Makefile
+++ b/src/test/run-make-fulldeps/use-extern-for-plugins/Makefile
@@ -1,8 +1,9 @@
 -include ../tools.mk
 
-SKIP_OS := 'FreeBSD OpenBSD Bitrig SunOS'
-
-ifneq ($(UNAME),$(findstring $(UNAME),$(SKIP_OS)))
+# ignore-freebsd
+# ignore-openbsd
+# ignore-bitrig
+# ignore-sunos
 
 HOST := $(shell $(RUSTC) -vV | grep 'host:' | sed 's/host: //')
 ifeq ($(findstring i686,$(HOST)),i686)
@@ -15,7 +16,3 @@ all:
 	$(RUSTC) foo.rs -C extra-filename=-host
 	$(RUSTC) bar.rs -C extra-filename=-targ --target $(TARGET)
 	$(RUSTC) baz.rs --extern a=$(TMPDIR)/liba-targ.rlib --target $(TARGET)
-else
-# FreeBSD, OpenBSD, and Bitrig support only x86_64 architecture for now
-all:
-endif

--- a/src/test/run-make-fulldeps/used/Makefile
+++ b/src/test/run-make-fulldeps/used/Makefile
@@ -1,11 +1,7 @@
 -include ../tools.mk
 
-ifdef IS_WINDOWS
-# Do nothing on MSVC.
-all:
-	exit 0
-else
+# ignore-windows
+
 all:
 	$(RUSTC) -C opt-level=3 --emit=obj used.rs
 	nm $(TMPDIR)/used.o | $(CGREP) FOO
-endif

--- a/src/test/run-make-fulldeps/windows-spawn/Makefile
+++ b/src/test/run-make-fulldeps/windows-spawn/Makefile
@@ -1,14 +1,8 @@
 -include ../tools.mk
 
-ifdef IS_WINDOWS
+# only-windows
 
 all:
 	$(RUSTC) -o "$(TMPDIR)/hopefullydoesntexist bar.exe" hello.rs
 	$(RUSTC) spawn.rs
 	$(TMPDIR)/spawn.exe
-
-else
-
-all:
-
-endif

--- a/src/test/run-make/thumb-none-cortex-m/Makefile
+++ b/src/test/run-make/thumb-none-cortex-m/Makefile
@@ -10,8 +10,10 @@
 # - thumbv7em-none-eabihf (Bare Cortex-M4F, M7F, FPU, hardfloat)
 # - thumbv7m-none-eabi (Bare Cortex-M3)
 
-# See https://stackoverflow.com/questions/7656425/makefile-ifeq-logical-or
-ifneq (,$(filter $(TARGET),thumbv6m-none-eabi thumbv7em-none-eabi thumbv7em-none-eabihf thumbv7m-none-eabi))
+# only-thumbv6m-none-eabi
+# only-thumbv7em-none-eabi
+# only-thumbv7em-none-eabihf
+# only-thumbv7m-none-eabi
 
 # For cargo setting
 RUSTC := $(RUSTC_ORIGINAL)
@@ -36,8 +38,3 @@ all:
 	# These come from the top-level Rust workspace, that this crate is not a
 	# member of, but Cargo tries to load the workspace `Cargo.toml` anyway.
 	cd $(WORK_DIR) && cd $(CRATE) && env RUSTC_BOOTSTRAP=1 $(CARGO) build --target $(TARGET) -v
-else
-
-all:
-
-endif

--- a/src/test/run-make/thumb-none-qemu/Makefile
+++ b/src/test/run-make/thumb-none-qemu/Makefile
@@ -1,10 +1,11 @@
 -include ../../run-make-fulldeps/tools.mk
 
+# only-thumbv7m-none-eabi
+# only-thumbv6m-none-eabi
+
 # How to run this
 # $ ./x.py clean
 # $ ./x.py test --target thumbv7m-none-eabi src/test/run-make
-
-ifneq (,$(filter $(TARGET),thumbv6m-none-eabi thumbv7m-none-eabi))
 
 # For cargo setting
 export RUSTC := $(RUSTC_ORIGINAL)
@@ -25,6 +26,3 @@ unexport CXX
 
 all:
 	bash script.sh
-else
-all:
-endif

--- a/src/test/run-make/wasm-custom-section/Makefile
+++ b/src/test/run-make/wasm-custom-section/Makefile
@@ -1,10 +1,8 @@
 -include ../../run-make-fulldeps/tools.mk
 
-ifeq ($(TARGET),wasm32-unknown-unknown)
+# only-wasm32
+
 all:
 	$(RUSTC) foo.rs --target wasm32-unknown-unknown
 	$(RUSTC) bar.rs -C lto -O --target wasm32-unknown-unknown
 	$(NODE) foo.js $(TMPDIR)/bar.wasm
-else
-all:
-endif

--- a/src/test/run-make/wasm-custom-sections-opt/Makefile
+++ b/src/test/run-make/wasm-custom-sections-opt/Makefile
@@ -1,9 +1,7 @@
 -include ../../run-make-fulldeps/tools.mk
 
-ifeq ($(TARGET),wasm32-unknown-unknown)
+# only-wasm32
+
 all:
 	$(RUSTC) foo.rs -O --target wasm32-unknown-unknown
 	$(NODE) foo.js $(TMPDIR)/foo.wasm
-else
-all:
-endif

--- a/src/test/run-make/wasm-export-all-symbols/Makefile
+++ b/src/test/run-make/wasm-export-all-symbols/Makefile
@@ -1,6 +1,7 @@
 -include ../../run-make-fulldeps/tools.mk
 
-ifeq ($(TARGET),wasm32-unknown-unknown)
+# only-wasm32
+
 all:
 	$(RUSTC) bar.rs --target wasm32-unknown-unknown
 	$(RUSTC) foo.rs --target wasm32-unknown-unknown
@@ -10,7 +11,3 @@ all:
 	$(NODE) verify.js $(TMPDIR)/foo.wasm
 	$(RUSTC) foo.rs --target wasm32-unknown-unknown -C lto
 	$(NODE) verify.js $(TMPDIR)/foo.wasm
-else
-all:
-endif
-

--- a/src/test/run-make/wasm-import-module/Makefile
+++ b/src/test/run-make/wasm-import-module/Makefile
@@ -1,10 +1,8 @@
 -include ../../run-make-fulldeps/tools.mk
 
-ifeq ($(TARGET),wasm32-unknown-unknown)
+ # only-wasm32
+
 all:
 	$(RUSTC) foo.rs --target wasm32-unknown-unknown
 	$(RUSTC) bar.rs -C lto -O --target wasm32-unknown-unknown
 	$(NODE) foo.js $(TMPDIR)/bar.wasm
-else
-all:
-endif

--- a/src/test/run-make/wasm-panic-small/Makefile
+++ b/src/test/run-make/wasm-panic-small/Makefile
@@ -1,6 +1,7 @@
 -include ../../run-make-fulldeps/tools.mk
 
-ifeq ($(TARGET),wasm32-unknown-unknown)
+# only-wasm32
+
 all:
 	$(RUSTC) foo.rs -C lto -O --target wasm32-unknown-unknown --cfg a
 	wc -c < $(TMPDIR)/foo.wasm
@@ -14,7 +15,3 @@ all:
 	$(RUSTC) foo.rs -C lto -O --target wasm32-unknown-unknown --cfg d
 	wc -c < $(TMPDIR)/foo.wasm
 	[ "`wc -c < $(TMPDIR)/foo.wasm`" -lt "5120" ]
-else
-all:
-endif
-

--- a/src/test/run-make/wasm-symbols-not-exported/Makefile
+++ b/src/test/run-make/wasm-symbols-not-exported/Makefile
@@ -1,6 +1,7 @@
 -include ../../run-make-fulldeps/tools.mk
 
-ifeq ($(TARGET),wasm32-unknown-unknown)
+# only-wasm32
+
 all:
 	$(RUSTC) foo.rs --target wasm32-unknown-unknown
 	$(NODE) verify-exported-symbols.js $(TMPDIR)/foo.wasm
@@ -10,7 +11,3 @@ all:
 	$(NODE) verify-exported-symbols.js $(TMPDIR)/bar.wasm
 	$(RUSTC) bar.rs --target wasm32-unknown-unknown -O
 	$(NODE) verify-exported-symbols.js $(TMPDIR)/bar.wasm
-else
-all:
-endif
-

--- a/src/test/run-make/wasm-symbols-not-imported/Makefile
+++ b/src/test/run-make/wasm-symbols-not-imported/Makefile
@@ -1,6 +1,7 @@
 -include ../../run-make-fulldeps/tools.mk
 
-ifeq ($(TARGET),wasm32-unknown-unknown)
+# only-wasm32
+
 all:
 	$(RUSTC) foo.rs --target wasm32-unknown-unknown
 	$(NODE) verify-no-imports.js $(TMPDIR)/foo.wasm
@@ -10,7 +11,3 @@ all:
 	$(NODE) verify-no-imports.js $(TMPDIR)/foo.wasm
 	$(RUSTC) foo.rs --target wasm32-unknown-unknown -O -C lto
 	$(NODE) verify-no-imports.js $(TMPDIR)/foo.wasm
-else
-all:
-endif
-

--- a/src/tools/compiletest/src/util.rs
+++ b/src/tools/compiletest/src/util.rs
@@ -9,6 +9,7 @@ const OS_TABLE: &'static [(&'static str, &'static str)] = &[
     ("androideabi", "android"),
     ("bitrig", "bitrig"),
     ("cloudabi", "cloudabi"),
+    ("cuda", "cuda"),
     ("darwin", "macos"),
     ("dragonfly", "dragonfly"),
     ("emscripten", "emscripten"),
@@ -20,9 +21,11 @@ const OS_TABLE: &'static [(&'static str, &'static str)] = &[
     ("l4re", "l4re"),
     ("linux", "linux"),
     ("mingw32", "windows"),
+    ("none", "none"),
     ("netbsd", "netbsd"),
     ("openbsd", "openbsd"),
     ("redox", "redox"),
+    ("sgx", "sgx"),
     ("solaris", "solaris"),
     ("win32", "windows"),
     ("windows", "windows"),
@@ -38,6 +41,7 @@ const ARCH_TABLE: &'static [(&'static str, &'static str)] = &[
     ("armv7", "arm"),
     ("armv7s", "arm"),
     ("asmjs", "asmjs"),
+    ("cuda", "cuda"),
     ("hexagon", "hexagon"),
     ("i386", "x86"),
     ("i586", "x86"),
@@ -154,6 +158,7 @@ fn test_get_arch_failure() {
 fn test_get_arch() {
     assert_eq!("x86_64", get_arch("x86_64-unknown-linux-gnu"));
     assert_eq!("x86_64", get_arch("amd64"));
+    assert_eq!("cuda", get_arch("nvptx64-nvidia-cuda"));
 }
 
 #[test]
@@ -168,4 +173,8 @@ fn test_matches_os() {
     assert!(matches_os("wasm32-unknown-unknown", "emscripten"));
     assert!(matches_os("wasm32-unknown-unknown", "wasm32-bare"));
     assert!(!matches_os("wasm32-unknown-unknown", "windows"));
+    assert!(matches_os("thumbv6m0-none-eabi", "none"));
+    assert!(matches_os("riscv32imc-unknown-none-elf", "none"));
+    assert!(matches_os("nvptx64-nvidia-cuda", "cuda"));
+    assert!(matches_os("x86_64-fortanix-unknown-sgx", "sgx"));
 }


### PR DESCRIPTION
This makes the tests easier to read, and makes it possible to tell which
tests aren't being run on the host platform.

Fixes #56704.