### PR TITLE
Always calculate glob map but only for glob uses

### DIFF
--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -122,7 +122,7 @@ mod sty;
 /// *on-demand* infrastructure.
 #[derive(Clone)]
 pub struct CrateAnalysis {
-    pub glob_map: Option<hir::GlobMap>,
+    pub glob_map: hir::GlobMap,
 }
 
 #[derive(Clone)]

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -57,7 +57,6 @@ extern crate syntax_pos;
 use driver::CompileController;
 use pretty::{PpMode, UserIdentifiedItem};
 
-use rustc_resolve as resolve;
 use rustc_save_analysis as save;
 use rustc_save_analysis::DumpHandler;
 use rustc_data_structures::sync::{self, Lrc, Ordering::SeqCst};
@@ -950,7 +949,6 @@ pub fn enable_save_analysis(control: &mut CompileController) {
         });
     };
     control.after_analysis.run_callback_on_error = true;
-    control.make_glob_map = resolve::MakeGlobMap::Yes;
 }
 
 impl RustcDefaultCalls {

--- a/src/librustc_driver/test.rs
+++ b/src/librustc_driver/test.rs
@@ -18,7 +18,6 @@ use rustc::ty::{self, Ty, TyCtxt, TypeFoldable};
 use rustc_data_structures::sync::{self, Lrc};
 use rustc_lint;
 use rustc_metadata::cstore::CStore;
-use rustc_resolve::MakeGlobMap;
 use rustc_target::spec::abi::Abi;
 use syntax;
 use syntax::ast;
@@ -134,7 +133,6 @@ fn test_env_with_pool<F>(
             None,
             "test",
             None,
-            MakeGlobMap::No,
             |_| Ok(()),
         ).expect("phase 2 aborted")
     };

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -1536,9 +1536,7 @@ pub struct Resolver<'a> {
     extern_module_map: FxHashMap<(DefId, bool /* MacrosOnly? */), Module<'a>>,
     binding_parent_modules: FxHashMap<PtrKey<'a, NameBinding<'a>>, Module<'a>>,
 
-    pub make_glob_map: bool,
-    /// Maps imports to the names of items actually imported (this actually maps
-    /// all imports, but only glob imports are actually interesting).
+    /// Maps glob imports to the names of items actually imported.
     pub glob_map: GlobMap,
 
     used_imports: FxHashSet<(NodeId, Namespace)>,
@@ -1785,7 +1783,6 @@ impl<'a> Resolver<'a> {
                cstore: &'a CStore,
                krate: &Crate,
                crate_name: &str,
-               make_glob_map: MakeGlobMap,
                crate_loader: &'a mut CrateLoader<'a>,
                arenas: &'a ResolverArenas<'a>)
                -> Resolver<'a> {
@@ -1869,7 +1866,6 @@ impl<'a> Resolver<'a> {
             extern_module_map: FxHashMap::default(),
             binding_parent_modules: FxHashMap::default(),
 
-            make_glob_map: make_glob_map == MakeGlobMap::Yes,
             glob_map: Default::default(),
 
             used_imports: FxHashSet::default(),
@@ -1979,14 +1975,15 @@ impl<'a> Resolver<'a> {
             used.set(true);
             directive.used.set(true);
             self.used_imports.insert((directive.id, ns));
-            self.add_to_glob_map(directive.id, ident);
+            self.add_to_glob_map(&directive, ident);
             self.record_use(ident, ns, binding, false);
         }
     }
 
-    fn add_to_glob_map(&mut self, id: NodeId, ident: Ident) {
-        if self.make_glob_map {
-            self.glob_map.entry(id).or_default().insert(ident.name);
+    #[inline]
+    fn add_to_glob_map(&mut self, directive: &ImportDirective<'_>, ident: Ident) {
+        if directive.is_glob() {
+            self.glob_map.entry(directive.id).or_default().insert(ident.name);
         }
     }
 
@@ -4551,7 +4548,7 @@ impl<'a> Resolver<'a> {
                 let import_id = match binding.kind {
                     NameBindingKind::Import { directive, .. } => {
                         self.maybe_unused_trait_imports.insert(directive.id);
-                        self.add_to_glob_map(directive.id, trait_name);
+                        self.add_to_glob_map(&directive, trait_name);
                         Some(directive.id)
                     }
                     _ => None,
@@ -5253,12 +5250,6 @@ fn module_to_string(module: Module) -> Option<String> {
 
 fn err_path_resolution() -> PathResolution {
     PathResolution::new(Def::Err)
-}
-
-#[derive(PartialEq,Copy, Clone)]
-pub enum MakeGlobMap {
-    Yes,
-    No,
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/src/librustc_save_analysis/dump_visitor.rs
+++ b/src/librustc_save_analysis/dump_visitor.rs
@@ -1239,7 +1239,6 @@ impl<'l, 'tcx: 'l, 'll, O: DumpOutput + 'll> DumpVisitor<'l, 'tcx, 'll, O> {
 
                 // Make a comma-separated list of names of imported modules.
                 let glob_map = &self.save_ctxt.analysis.glob_map;
-                let glob_map = glob_map.as_ref().unwrap();
                 let names = if glob_map.contains_key(&id) {
                     glob_map.get(&id).unwrap().iter().map(|n| n.to_string()).collect()
                 } else {

--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -1122,8 +1122,6 @@ pub fn process_crate<'l, 'tcx, H: SaveHandler>(
     mut handler: H,
 ) {
     tcx.dep_graph.with_ignore(|| {
-        assert!(analysis.glob_map.is_some());
-
         info!("Dumping crate {}", cratename);
 
         let save_ctxt = SaveContext {

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -451,7 +451,6 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
                                                         None,
                                                         &name,
                                                         None,
-                                                        resolve::MakeGlobMap::No,
                                                         &resolver_arenas,
                                                         &mut crate_loader,
                                                         |_| Ok(()));
@@ -476,7 +475,7 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
             }).collect(),
         };
         let analysis = ty::CrateAnalysis {
-            glob_map: if resolver.make_glob_map { Some(resolver.glob_map.clone()) } else { None },
+            glob_map: resolver.glob_map.clone(),
         };
 
         let mut arenas = AllArenas::new();

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -6,7 +6,6 @@ use rustc_driver::{self, driver, target_features, Compilation};
 use rustc_driver::driver::phase_2_configure_and_expand;
 use rustc_metadata::cstore::CStore;
 use rustc_metadata::dynamic_lib::DynamicLibrary;
-use rustc_resolve::MakeGlobMap;
 use rustc::hir;
 use rustc::hir::intravisit;
 use rustc::session::{self, CompileIncomplete, config};
@@ -100,7 +99,6 @@ pub fn run(mut options: Options) -> isize {
                 None,
                 "rustdoc-test",
                 None,
-                MakeGlobMap::No,
                 |_| Ok(()),
             ).expect("phase_2_configure_and_expand aborted in rustdoc!")
         };

--- a/src/test/rustdoc-ui/failed-doctest-output.stdout
+++ b/src/test/rustdoc-ui/failed-doctest-output.stdout
@@ -12,7 +12,7 @@ error[E0425]: cannot find value `no` in this scope
 3 | no
   | ^^ not found in this scope
 
-thread '$DIR/failed-doctest-output.rs - OtherStruct (line 17)' panicked at 'couldn't compile the test', src/librustdoc/test.rs:321:13
+thread '$DIR/failed-doctest-output.rs - OtherStruct (line 17)' panicked at 'couldn't compile the test', src/librustdoc/test.rs:319:13
 note: Run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
 
 ---- $DIR/failed-doctest-output.rs - SomeStruct (line 11) stdout ----
@@ -21,7 +21,7 @@ thread '$DIR/failed-doctest-output.rs - SomeStruct (line 11)' panicked at 'test 
 thread 'main' panicked at 'oh no', $DIR/failed-doctest-output.rs:3:1
 note: Run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
 
-', src/librustdoc/test.rs:356:17
+', src/librustdoc/test.rs:354:17
 
 
 failures:


### PR DESCRIPTION
Previously calculating glob map was *opt-in*, however it did record node id -> ident use for every use directive. This aims to see if we can unconditionally calculate the glob map and not regress performance.

Main motivation is to get rid of some of the moving pieces and simplify the compilation interface - this would allow us to entirely remove `CrateAnalysis`. Later, we could easily expose a relevant query, similar to the likes of `maybe_unused_trait_import` (so using precomputed data from the resolver, but which could be rewritten to be on-demand).

r? @nikomatsakis 

Local perf run showed mostly noise (except `ctfe-stress-*`) but I'd appreciate if we could do a perf run run here and double-check that this won't regress performance.