### PR TITLE
Simplify resolve_lifetimes

### DIFF
--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -713,7 +713,7 @@ impl<'a> LoweringContext<'a> {
         let params = lifetimes_to_define
             .into_iter()
             .map(|(span, hir_name)| {
-                let def_node_id = self.next_id().node_id;
+                let LoweredNodeId { node_id, hir_id } = self.next_id();
 
                 // Get the name we'll use to make the def-path. Note
                 // that collisions are ok here and this shouldn't
@@ -1477,8 +1477,11 @@ impl<'a> LoweringContext<'a> {
                     && !self.already_defined_lifetimes.contains(&name) {
                     self.already_defined_lifetimes.insert(name);
 
+                    let LoweredNodeId { node_id, hir_id } = self.context.next_id();
+
                     self.output_lifetimes.push(hir::GenericArg::Lifetime(hir::Lifetime {
-                        id: self.context.next_id().node_id,
+                        id: node_id,
+                        hir_id,
                         span: lifetime.span,
                         name,
                     }));
@@ -2282,8 +2285,10 @@ impl<'a> LoweringContext<'a> {
             ];
 
             if let Some((name, span)) = bound_lifetime {
+                let LoweredNodeId { node_id, hir_id } = this.next_id();
+
                 bounds.push(hir::GenericBound::Outlives(
-                    hir::Lifetime { id: this.next_id().node_id, name, span }));
+                    hir::Lifetime { id: node_id, hir_id, name, span }));
             }
 
             hir::HirVec::from(bounds)
@@ -2350,8 +2355,11 @@ impl<'a> LoweringContext<'a> {
         span: Span,
         name: hir::LifetimeName,
     ) -> hir::Lifetime {
+        let LoweredNodeId { node_id, hir_id } = self.lower_node_id(id);
+
         hir::Lifetime {
-            id: self.lower_node_id(id).node_id,
+            id: node_id,
+            hir_id,
             span,
             name: name,
         }
@@ -4957,8 +4965,11 @@ impl<'a> LoweringContext<'a> {
             // `'f`.
             AnonymousLifetimeMode::CreateParameter => {
                 let fresh_name = self.collect_fresh_in_band_lifetime(span);
+                let LoweredNodeId { node_id, hir_id } = self.next_id();
+
                 hir::Lifetime {
-                    id: self.next_id().node_id,
+                    id: node_id,
+                    hir_id,
                     span,
                     name: hir::LifetimeName::Param(fresh_name),
                 }
@@ -5058,8 +5069,11 @@ impl<'a> LoweringContext<'a> {
     }
 
     fn new_implicit_lifetime(&mut self, span: Span) -> hir::Lifetime {
+        let LoweredNodeId { node_id, hir_id } = self.next_id();
+
         hir::Lifetime {
-            id: self.next_id().node_id,
+            id: node_id,
+            hir_id,
             span,
             name: hir::LifetimeName::Implicit,
         }

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -156,6 +156,7 @@ impl fmt::Debug for Label {
 #[derive(Clone, RustcEncodable, RustcDecodable, Copy)]
 pub struct Lifetime {
     pub id: NodeId,
+    pub hir_id: HirId,
     pub span: Span,
 
     /// Either "'a", referring to a named lifetime definition,

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -539,6 +539,7 @@ pub enum GenericParamKind {
 #[derive(Clone, RustcEncodable, RustcDecodable, Debug)]
 pub struct GenericParam {
     pub id: NodeId,
+    pub hir_id: HirId,
     pub name: ParamName,
     pub attrs: HirVec<Attribute>,
     pub bounds: GenericBounds,

--- a/src/librustc/ich/impls_hir.rs
+++ b/src/librustc/ich/impls_hir.rs
@@ -159,6 +159,7 @@ impl_stable_hash_for!(struct hir::Label {
 
 impl_stable_hash_for!(struct hir::Lifetime {
     id,
+    hir_id,
     span,
     name
 });

--- a/src/librustc/ich/impls_hir.rs
+++ b/src/librustc/ich/impls_hir.rs
@@ -201,6 +201,7 @@ impl_stable_hash_for!(enum hir::TraitBoundModifier {
 
 impl_stable_hash_for!(struct hir::GenericParam {
     id,
+    hir_id,
     name,
     pure_wrt_drop,
     attrs,

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -8,7 +8,7 @@
 use hir::def::Def;
 use hir::def_id::{CrateNum, DefId, LocalDefId, LOCAL_CRATE};
 use hir::map::Map;
-use hir::{GenericArg, GenericParam, ItemLocalId, LifetimeName, Node, ParamName};
+use hir::{GenericArg, GenericParam, LifetimeName, Node, ParamName};
 use ty::{self, DefIdTree, GenericParamDefKind, TyCtxt};
 
 use errors::{Applicability, DiagnosticBuilder};
@@ -23,7 +23,7 @@ use syntax::attr;
 use syntax::ptr::P;
 use syntax::symbol::keywords;
 use syntax_pos::Span;
-use util::nodemap::{DefIdMap, FxHashMap, FxHashSet, HirIdMap, HirIdSet};
+use util::nodemap::{DefIdMap, FxHashMap, FxHashSet, HirIdMap, HirIdSet, ItemLocalMap, ItemLocalSet};
 
 use hir::intravisit::{self, NestedVisitorMap, Visitor};
 use hir::{self, GenericParamKind, LifetimeParamKind};
@@ -210,10 +210,10 @@ struct NamedRegionMap {
 /// See `NamedRegionMap`.
 #[derive(Default)]
 pub struct ResolveLifetimes {
-    defs: FxHashMap<LocalDefId, Lrc<FxHashMap<ItemLocalId, Region>>>,
-    late_bound: FxHashMap<LocalDefId, Lrc<FxHashSet<ItemLocalId>>>,
+    defs: FxHashMap<LocalDefId, Lrc<ItemLocalMap<Region>>>,
+    late_bound: FxHashMap<LocalDefId, Lrc<ItemLocalSet>>,
     object_lifetime_defaults:
-        FxHashMap<LocalDefId, Lrc<FxHashMap<ItemLocalId, Lrc<Vec<ObjectLifetimeDefault>>>>>,
+        FxHashMap<LocalDefId, Lrc<ItemLocalMap<Lrc<Vec<ObjectLifetimeDefault>>>>>,
 }
 
 impl_stable_hash_for!(struct ::middle::resolve_lifetime::ResolveLifetimes {

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -209,6 +209,7 @@ impl<'a, 'tcx, 'rcx> DocContext<'a, 'tcx, 'rcx> {
 
                     args.push(hir::GenericArg::Lifetime(hir::Lifetime {
                         id: ast::DUMMY_NODE_ID,
+                        hir_id: hir::DUMMY_HIR_ID,
                         span: DUMMY_SP,
                         name: hir::LifetimeName::Param(name),
                     }));


### PR DESCRIPTION
Obtaining `hir_id` is free during lowering, so I thought it might be a good idea to save it while creating `hir::Lifetime` and `hir::GenericParam` so that `resolve_lifetimes` can do less work.

I'm *pretty sure* `resolve_lifetimes` can be simplified further (I'd like to squash `NamedRegionMap` with `ResolveLifetimes`), but I need to sleep on it; this seems like a step in the right direction.

As an added bonus this should be a step forward for https://github.com/rust-lang/rust/issues/50928.

r? @varkor 