### PR TITLE
Update Cargo.lock to use the latest `compiler_builtins`

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -216,6 +216,12 @@ declare_lint! {
     "detect mut variables which don't need to be mutable"
 }
 
+declare_lint! {
+    pub ELIDED_LIFETIME_IN_PATH,
+    Allow,
+    "hidden lifetime parameters are deprecated, try `Foo<'_>`"
+}
+
 /// Does nothing as a lint pass, but registers some `Lint`s
 /// which are used by other parts of the compiler.
 #[derive(Copy, Clone)]
@@ -256,7 +262,8 @@ impl LintPass for HardwiredLints {
             LATE_BOUND_LIFETIME_ARGUMENTS,
             DEPRECATED,
             UNUSED_UNSAFE,
-            UNUSED_MUT
+            UNUSED_MUT,
+            ELIDED_LIFETIME_IN_PATH
         )
     }
 }

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -530,7 +530,7 @@ impl<'a, 'tcx> Visitor<'tcx> for LifetimeContext<'a, 'tcx> {
 
     fn visit_lifetime(&mut self, lifetime_ref: &'tcx hir::Lifetime) {
         if lifetime_ref.is_elided() {
-            self.resolve_elided_lifetimes(slice::ref_slice(lifetime_ref));
+            self.resolve_elided_lifetimes(slice::ref_slice(lifetime_ref), false);
             return;
         }
         if lifetime_ref.is_static() {
@@ -1114,7 +1114,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
         }
 
         if params.lifetimes.iter().all(|l| l.is_elided()) {
-            self.resolve_elided_lifetimes(&params.lifetimes);
+            self.resolve_elided_lifetimes(&params.lifetimes, true);
         } else {
             for l in &params.lifetimes { self.visit_lifetime(l); }
         }
@@ -1445,7 +1445,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
 
     }
 
-    fn resolve_elided_lifetimes(&mut self, lifetime_refs: &[hir::Lifetime]) {
+    fn resolve_elided_lifetimes(&mut self, lifetime_refs: &[hir::Lifetime], deprecated: bool) {
         if lifetime_refs.is_empty() {
             return;
         }

--- a/src/test/compile-fail/lint-elided-lifetime-in-path.rs
+++ b/src/test/compile-fail/lint-elided-lifetime-in-path.rs
@@ -1,0 +1,15 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![deny(elided_lifetime_in_path)]
+struct Foo<'a> { x: &'a u32 }
+fn foo(x: &Foo) {
+    //~   ^warning: hidden lifetime parameters are deprecated, try `Foo<'_>`
+}


### PR DESCRIPTION
A very tiny PR per the request of @alexcrichton : https://github.com/rust-lang-nursery/compiler-builtins/pull/267#issuecomment-452037536