### PR TITLE
Reborrow Pin<P> using &mut in `Pin::set`

### DIFF
--- a/src/libcore/pin.rs
+++ b/src/libcore/pin.rs
@@ -175,11 +175,11 @@ impl<P: DerefMut> Pin<P> {
     /// Assign a new value to the memory behind the pinned reference.
     #[stable(feature = "pin", since = "1.33.0")]
     #[inline(always)]
-    pub fn set(mut self: Pin<P>, value: P::Target)
+    pub fn set(self: &mut Pin<P>, value: P::Target)
     where
         P::Target: Sized,
     {
-        *self.pointer = value;
+        *(self.pointer) = value;
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/57339.

This makes it possible to call `.set` multiple times without
using `.as_mut()` first to reborrow the pointer.

r? @withoutboats 
cc @rust-lang/libs 