### PR TITLE
Remove `CrateNum::Invalid`.

### DIFF
--- a/src/librustc/hir/def_id.rs
+++ b/src/librustc/hir/def_id.rs
@@ -17,8 +17,6 @@ pub enum CrateNum {
     // FIXME(jseyfried): this is also used for custom derives until proc-macro crates get
     // `CrateNum`s.
     BuiltinMacros,
-    /// A CrateNum value that indicates that something is wrong.
-    Invalid,
     /// A special CrateNum that we use for the tcx.rcache when decoding from
     /// the incr. comp. cache.
     ReservedForIncrCompCache,
@@ -29,7 +27,6 @@ impl ::std::fmt::Debug for CrateNum {
     fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
             CrateNum::Index(id) => write!(fmt, "crate{}", id.private),
-            CrateNum::Invalid => write!(fmt, "invalid crate"),
             CrateNum::BuiltinMacros => write!(fmt, "builtin macros crate"),
             CrateNum::ReservedForIncrCompCache => write!(fmt, "crate for decoding incr comp cache"),
         }
@@ -90,7 +87,6 @@ impl fmt::Display for CrateNum {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             CrateNum::Index(id) => fmt::Display::fmt(&id.private, f),
-            CrateNum::Invalid => write!(f, "invalid crate"),
             CrateNum::BuiltinMacros => write!(f, "builtin macros crate"),
             CrateNum::ReservedForIncrCompCache => write!(f, "crate for decoding incr comp cache"),
         }


### PR DESCRIPTION
It's unused.