### PR TITLE
Reference tracking issue for inherent associated types in diagnostic

### DIFF
--- a/src/librustc_passes/ast_validation.rs
+++ b/src/librustc_passes/ast_validation.rs
@@ -438,8 +438,9 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
         }
         for predicate in &generics.where_clause.predicates {
             if let WherePredicate::EqPredicate(ref predicate) = *predicate {
-                self.err_handler().span_err(predicate.span, "equality constraints are not yet \
-                                                             supported in where clauses (#20041)");
+                self.err_handler()
+                    .span_err(predicate.span, "equality constraints are not yet \
+                                               supported in where clauses (see #20041)");
             }
         }
         visit::walk_generics(self, generics)

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1107,7 +1107,7 @@ fn report_assoc_ty_on_inherent_impl<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, span:
         tcx.sess,
         span,
         E0202,
-        "associated types are not allowed in inherent impls"
+        "associated types are not yet supported in inherent impls (see #8995)"
     );
 }
 

--- a/src/test/ui/assoc-inherent.rs
+++ b/src/test/ui/assoc-inherent.rs
@@ -1,9 +1,9 @@
-// Test associated types are forbidden in inherent impls.
+// Test associated types are, until #8995 is implemented, forbidden in inherent impls.
 
 struct Foo;
 
 impl Foo {
-    type Bar = isize; //~ERROR associated types are not allowed in inherent impls
+    type Bar = isize; //~ERROR associated types are not yet supported in inherent impls (see #8995)
 }
 
 fn main() {}

--- a/src/test/ui/assoc-inherent.stderr
+++ b/src/test/ui/assoc-inherent.stderr
@@ -1,7 +1,7 @@
-error[E0202]: associated types are not allowed in inherent impls
+error[E0202]: associated types are not yet supported in inherent impls (see #8995)
   --> $DIR/assoc-inherent.rs:6:5
    |
-LL |     type Bar = isize; //~ERROR associated types are not allowed in inherent impls
+LL |     type Bar = isize; //~ERROR associated types are not yet supported in inherent impls (see #8995)
    |     ^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error

--- a/src/test/ui/where-clauses/where-equality-constraints.stderr
+++ b/src/test/ui/where-clauses/where-equality-constraints.stderr
@@ -1,10 +1,10 @@
-error: equality constraints are not yet supported in where clauses (#20041)
+error: equality constraints are not yet supported in where clauses (see #20041)
   --> $DIR/where-equality-constraints.rs:1:14
    |
 LL | fn f() where u8 = u16 {}
    |              ^^^^^^^^
 
-error: equality constraints are not yet supported in where clauses (#20041)
+error: equality constraints are not yet supported in where clauses (see #20041)
   --> $DIR/where-equality-constraints.rs:3:14
    |
 LL | fn g() where for<'a> &'static (u8,) == u16, {}


### PR DESCRIPTION
This makes it clearer that associated types in inherent impls are an intended feature, like the diagnostic for equality constraints in where clauses. (This is more helpful, because the lack of associated types is a confusing omission and it lets users more easily track the state of the feature.)