### PR TITLE
Change `String` to `&'static str` in `ParseResult::Failure`.

### DIFF
--- a/src/libsyntax/ext/tt/macro_parser.rs
+++ b/src/libsyntax/ext/tt/macro_parser.rs
@@ -271,7 +271,7 @@ pub enum ParseResult<T> {
     Success(T),
     /// Arm failed to match. If the second parameter is `token::Eof`, it indicates an unexpected
     /// end of macro invocation. Otherwise, it indicates that no rules expected the given token.
-    Failure(syntax_pos::Span, Token, String),
+    Failure(syntax_pos::Span, Token, &'static str),
     /// Fatal error (malformed macro?). Abort compilation.
     Error(syntax_pos::Span, String),
 }
@@ -721,7 +721,7 @@ pub fn parse(
                         sess.source_map().next_point(parser.span)
                     },
                     token::Eof,
-                    "missing tokens in macro arguments".to_string(),
+                    "missing tokens in macro arguments",
                 );
             }
         }
@@ -760,7 +760,7 @@ pub fn parse(
             return Failure(
                 parser.span,
                 parser.token,
-                "no rules expected this token in macro call".to_string(),
+                "no rules expected this token in macro call",
             );
         }
         // Dump all possible `next_items` into `cur_items` for the next iteration.

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -202,7 +202,7 @@ fn generic_extension<'cx>(cx: &'cx mut ExtCtxt,
     let best_fail_msg = parse_failure_msg(best_fail_tok.expect("ran no matchers"));
     let span = best_fail_spot.substitute_dummy(sp);
     let mut err = cx.struct_span_err(span, &best_fail_msg);
-    err.span_label(span, best_fail_text.unwrap_or(best_fail_msg));
+    err.span_label(span, best_fail_text.unwrap_or(&best_fail_msg));
     if let Some(sp) = def_span {
         if cx.source_map().span_to_filename(sp).is_real() && !sp.is_dummy() {
             err.span_label(cx.source_map().def_span(sp), "when calling this macro");


### PR DESCRIPTION
This avoids 770,000 allocations when compiling the `html5ever`
benchmark, reducing instruction counts by up to 2%.