### PR TITLE
docs: Fix some 'second-edition' links

### DIFF
--- a/src/libcore/ops/deref.rs
+++ b/src/libcore/ops/deref.rs
@@ -27,7 +27,7 @@
 /// [book] as well as the reference sections on [the dereference operator]
 /// [ref-deref-op], [method resolution] and [type coercions].
 ///
-/// [book]: ../../book/second-edition/ch15-02-deref.html
+/// [book]: ../../book/ch15-02-deref.html
 /// [`DerefMut`]: trait.DerefMut.html
 /// [more]: #more-on-deref-coercion
 /// [ref-deref-op]: ../../reference/expressions/operator-expr.html#the-dereference-operator
@@ -117,7 +117,7 @@ impl<T: ?Sized> Deref for &mut T {
 /// [book] as well as the reference sections on [the dereference operator]
 /// [ref-deref-op], [method resolution] and [type coercions].
 ///
-/// [book]: ../../book/second-edition/ch15-02-deref.html
+/// [book]: ../../book/ch15-02-deref.html
 /// [`Deref`]: trait.Deref.html
 /// [more]: #more-on-deref-coercion
 /// [ref-deref-op]: ../../reference/expressions/operator-expr.html#the-dereference-operator

--- a/src/libcore/ops/function.rs
+++ b/src/libcore/ops/function.rs
@@ -27,7 +27,7 @@
 /// `Fn(usize, bool) -> usize`). Those interested in the technical details of
 /// this can refer to [the relevant section in the *Rustonomicon*][nomicon].
 ///
-/// [book]: ../../book/second-edition/ch13-01-closures.html
+/// [book]: ../../book/ch13-01-closures.html
 /// [`FnMut`]: trait.FnMut.html
 /// [`FnOnce`]: trait.FnOnce.html
 /// [function pointers]: ../../std/primitive.fn.html
@@ -95,7 +95,7 @@ pub trait Fn<Args> : FnMut<Args> {
 /// `Fn(usize, bool) -> usize`). Those interested in the technical details of
 /// this can refer to [the relevant section in the *Rustonomicon*][nomicon].
 ///
-/// [book]: ../../book/second-edition/ch13-01-closures.html
+/// [book]: ../../book/ch13-01-closures.html
 /// [`Fn`]: trait.Fn.html
 /// [`FnOnce`]: trait.FnOnce.html
 /// [function pointers]: ../../std/primitive.fn.html
@@ -173,7 +173,7 @@ pub trait FnMut<Args> : FnOnce<Args> {
 /// `Fn(usize, bool) -> usize`). Those interested in the technical details of
 /// this can refer to [the relevant section in the *Rustonomicon*][nomicon].
 ///
-/// [book]: ../../book/second-edition/ch13-01-closures.html
+/// [book]: ../../book/ch13-01-closures.html
 /// [`Fn`]: trait.Fn.html
 /// [`FnMut`]: trait.FnMut.html
 /// [function pointers]: ../../std/primitive.fn.html

--- a/src/libstd/keyword_docs.rs
+++ b/src/libstd/keyword_docs.rs
@@ -169,7 +169,7 @@ mod crate_keyword { }
 ///
 /// [Algebraic Data Types]: https://en.wikipedia.org/wiki/Algebraic_data_type
 /// [`Option`]: option/enum.Option.html
-/// [Rust Book]: https://doc.rust-lang.org/book/second-edition/ch06-01-defining-an-enum.html
+/// [Rust Book]: https://doc.rust-lang.org/book/ch06-01-defining-an-enum.html
 /// [Reference]: https://doc.rust-lang.org/reference/items/enumerations.html
 mod enum_keyword { }
 
@@ -211,7 +211,7 @@ mod enum_keyword { }
 /// For more information on FFI, check the [Rust book] or the [Reference].
 ///
 /// [Rust book]:
-/// https://doc.rust-lang.org/book/second-edition/ch19-01-unsafe-rust.html#using-extern-functions-to-call-external-code
+/// https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#using-extern-functions-to-call-external-code
 /// [Reference]: https://doc.rust-lang.org/reference/items/external-blocks.html
 mod extern_keyword { }
 
@@ -278,7 +278,7 @@ mod extern_keyword { }
 ///
 /// [`impl`]: keyword.impl.html
 /// [`extern`]: keyword.extern.html
-/// [Rust book]: https://doc.rust-lang.org/book/second-edition/ch03-03-how-functions-work.html
+/// [Rust book]: https://doc.rust-lang.org/book/ch03-03-how-functions-work.html
 /// [Reference]: https://doc.rust-lang.org/reference/items/functions.html
 mod fn_keyword { }
 
@@ -705,6 +705,6 @@ mod loop_keyword { }
 /// [Reference][reference].
 ///
 /// [`PhantomData`]: marker/struct.PhantomData.html
-/// [book]: https://doc.rust-lang.org/book/second-edition/ch05-01-defining-structs.html
+/// [book]: https://doc.rust-lang.org/book/ch05-01-defining-structs.html
 /// [reference]: https://doc.rust-lang.org/reference/items/structs.html
 mod struct_keyword { }

--- a/src/libstd/primitive_docs.rs
+++ b/src/libstd/primitive_docs.rs
@@ -923,7 +923,7 @@ mod prim_usize { }
 /// For more information on how to use references, see [the book's section on "References and
 /// Borrowing"][book-refs].
 ///
-/// [book-refs]: ../book/second-edition/ch04-02-references-and-borrowing.html
+/// [book-refs]: ../book/ch04-02-references-and-borrowing.html
 ///
 /// # Trait implementations
 ///


### PR DESCRIPTION
If I understand it correctly, we now want to link to 

    https://doc.rust-lang.org/book/*.html

instead of

    https://doc.rust-lang.org/book/second-edition/*.html

because the second-edition page says that it's no longer distributed with
Rust's docs.

For example: https://doc.rust-lang.org/book/second-edition/ch13-01-closures.html