### PR TITLE
std: Render large exit codes as hex on Windows

### DIFF
--- a/src/libstd/sys/windows/process.rs
+++ b/src/libstd/sys/windows/process.rs
@@ -393,7 +393,16 @@ impl From<c::DWORD> for ExitStatus {
 
 impl fmt::Display for ExitStatus {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "exit code: {}", self.0)
+        // Windows exit codes with the high bit set typically mean some form of
+        // unhandled exception or warning. In this scenario printing the exit
+        // code in decimal doesn't always make sense because it's a very large
+        // and somewhat gibberish number. The hex code is a bit more
+        // recognizable and easier to search for, so print that.
+        if self.0 & 0x80000000 != 0 {
+            write!(f, "exit code: {:#x}", self.0)
+        } else {
+            write!(f, "exit code: {}", self.0)
+        }
     }
 }
 


### PR DESCRIPTION
On Windows process exit codes are never signals but rather always 32-bit
integers. Most faults like segfaults and such end up having large
integers used to represent them, like STATUS_ACCESS_VIOLATION being
0xC0000005. Currently, however, when an `ExitStatus` is printed this
ends up getting rendered as 3221225477 which is somewhat more difficult
to debug.

This commit adds a branch in `Display for ExitStatus` on Windows which
handles exit statuses where the high bit is set and prints those exit
statuses as hex instead of with decimals. This will hopefully preserve
the current display for small exit statuses (like `exit code: 22`), but
assist in quickly debugging segfaults/access violations/etc. I've
found at least that the hex codes are easier to search for than decimal.

I wasn't able to find any official documentation saying that all system
exit codes have the high bit set, but I figure it's a good enough
heuristic for now.