### PR TITLE
High priority resolutions for associated variants

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -368,6 +368,12 @@ declare_lint! {
     report_in_external_macro: true
 }
 
+declare_lint! {
+    pub AMBIGUOUS_ASSOCIATED_ITEMS,
+    Warn,
+    "ambiguous associated items"
+}
+
 /// Does nothing as a lint pass, but registers some `Lint`s
 /// that are used by other parts of the compiler.
 #[derive(Copy, Clone)]
@@ -433,6 +439,7 @@ impl LintPass for HardwiredLints {
             parser::QUESTION_MARK_MACRO_SEP,
             parser::ILL_FORMED_ATTRIBUTE_INPUT,
             DEPRECATED_IN_FUTURE,
+            AMBIGUOUS_ASSOCIATED_ITEMS,
         )
     }
 }

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -341,6 +341,11 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
             reference: "issue #57571 <https://github.com/rust-lang/rust/issues/57571>",
             edition: None,
         },
+        FutureIncompatibleInfo {
+            id: LintId::of(AMBIGUOUS_ASSOCIATED_ITEMS),
+            reference: "issue #57644 <https://github.com/rust-lang/rust/issues/57644>",
+            edition: None,
+        },
         ]);
 
     // Register renamed and removed lints.

--- a/src/librustc_typeck/check/method/mod.rs
+++ b/src/librustc_typeck/check/method/mod.rs
@@ -408,45 +408,36 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
 
         let tcx = self.tcx;
 
-        let mode = probe::Mode::Path;
-        match self.probe_for_name(span, mode, method_name, IsSuggestion(false),
-                                  self_ty, expr_id, ProbeScope::TraitsInScope) {
-            Ok(pick) => {
-                debug!("resolve_ufcs: pick={:?}", pick);
-                if let Some(import_id) = pick.import_id {
-                    let import_def_id = tcx.hir().local_def_id(import_id);
-                    debug!("resolve_ufcs: used_trait_import: {:?}", import_def_id);
-                    Lrc::get_mut(&mut self.tables.borrow_mut().used_trait_imports)
-                                                .unwrap().insert(import_def_id);
+        // Check if we have an enum variant.
+        if let ty::Adt(adt_def, _) = self_ty.sty {
+            if adt_def.is_enum() {
+                let variant_def = adt_def.variants.iter().find(|vd| {
+                    tcx.hygienic_eq(method_name, vd.ident, adt_def.did)
+                });
+                if let Some(variant_def) = variant_def {
+                    check_type_alias_enum_variants_enabled(tcx, span);
+
+                    let def = Def::VariantCtor(variant_def.did, variant_def.ctor_kind);
+                    tcx.check_stability(def.def_id(), Some(expr_id), span);
+                    return Ok(def);
                 }
-
-                let def = pick.item.def();
-                debug!("resolve_ufcs: def={:?}", def);
-                tcx.check_stability(def.def_id(), Some(expr_id), span);
-
-                Ok(def)
-            }
-            Err(err) => {
-                // Check if we have an enum variant.
-                match self_ty.sty {
-                    ty::Adt(adt_def, _) if adt_def.is_enum() => {
-                        let variant_def = adt_def.variants.iter().find(|vd| {
-                            tcx.hygienic_eq(method_name, vd.ident, adt_def.did)
-                        });
-                        if let Some(variant_def) = variant_def {
-                            check_type_alias_enum_variants_enabled(tcx, span);
-
-                            let def = Def::VariantCtor(variant_def.did, variant_def.ctor_kind);
-                            tcx.check_stability(def.def_id(), Some(expr_id), span);
-                            return Ok(def);
-                        }
-                    },
-                    _ => (),
-                }
-
-                Err(err)
             }
         }
+
+        let pick = self.probe_for_name(span, probe::Mode::Path, method_name, IsSuggestion(false),
+                                       self_ty, expr_id, ProbeScope::TraitsInScope)?;
+        debug!("resolve_ufcs: pick={:?}", pick);
+        if let Some(import_id) = pick.import_id {
+            let import_def_id = tcx.hir().local_def_id(import_id);
+            debug!("resolve_ufcs: used_trait_import: {:?}", import_def_id);
+            Lrc::get_mut(&mut self.tables.borrow_mut().used_trait_imports)
+                .unwrap().insert(import_def_id);
+        }
+
+        let def = pick.item.def();
+        debug!("resolve_ufcs: def={:?}", def);
+        tcx.check_stability(def.def_id(), Some(expr_id), span);
+        Ok(def)
     }
 
     /// Find item with name `item_name` defined in impl/trait `def_id`

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -4724,8 +4724,8 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 } else {
                     Def::Err
                 };
-                let (ty, def) = AstConv::associated_path_def_to_ty(self, node_id, path_span,
-                                                                   ty, def, segment);
+                let (ty, def) = AstConv::associated_path_to_ty(self, node_id, path_span,
+                                                               ty, def, segment, true);
 
                 // Write back the new resolution.
                 let hir_id = self.tcx.hir().node_to_hir_id(node_id);

--- a/src/test/ui/type-alias-enum-variants-priority-2.rs
+++ b/src/test/ui/type-alias-enum-variants-priority-2.rs
@@ -1,0 +1,13 @@
+#![feature(type_alias_enum_variants)]
+
+enum E {
+    V(u8)
+}
+
+impl E {
+    fn V() {}
+}
+
+fn main() {
+    <E>::V(); //~ ERROR this function takes 1 parameter but 0 parameters were supplied
+}

--- a/src/test/ui/type-alias-enum-variants-priority-2.stderr
+++ b/src/test/ui/type-alias-enum-variants-priority-2.stderr
@@ -1,0 +1,12 @@
+error[E0061]: this function takes 1 parameter but 0 parameters were supplied
+  --> $DIR/type-alias-enum-variants-priority-2.rs:12:5
+   |
+LL |     V(u8)
+   |     ----- defined here
+...
+LL |     <E>::V(); //~ ERROR this function takes 1 parameter but 0 parameters were supplied
+   |     ^^^^^^^^ expected 1 parameter
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0061`.

--- a/src/test/ui/type-alias-enum-variants-priority-3.rs
+++ b/src/test/ui/type-alias-enum-variants-priority-3.rs
@@ -1,0 +1,10 @@
+#![feature(type_alias_enum_variants)]
+
+enum E {
+    V
+}
+
+fn check() -> <E>::V {}
+//~^ ERROR expected type, found variant `V`
+
+fn main() {}

--- a/src/test/ui/type-alias-enum-variants-priority-3.stderr
+++ b/src/test/ui/type-alias-enum-variants-priority-3.stderr
@@ -1,0 +1,8 @@
+error: expected type, found variant `V`
+  --> $DIR/type-alias-enum-variants-priority-3.rs:7:15
+   |
+LL | fn check() -> <E>::V {}
+   |               ^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/type-alias-enum-variants-priority.rs
+++ b/src/test/ui/type-alias-enum-variants-priority.rs
@@ -1,0 +1,20 @@
+#![feature(type_alias_enum_variants)]
+#![deny(ambiguous_associated_items)]
+
+enum E {
+    V
+}
+
+trait Tr {
+    type V;
+    fn f() -> Self::V;
+}
+
+impl Tr for E {
+    type V = u8;
+    fn f() -> Self::V { 0 }
+    //~^ ERROR ambiguous associated item
+    //~| WARN this was previously accepted
+}
+
+fn main() {}

--- a/src/test/ui/type-alias-enum-variants-priority.stderr
+++ b/src/test/ui/type-alias-enum-variants-priority.stderr
@@ -1,0 +1,26 @@
+error: ambiguous associated item
+  --> $DIR/type-alias-enum-variants-priority.rs:15:15
+   |
+LL |     fn f() -> Self::V { 0 }
+   |               ^^^^^^^ help: use fully-qualified syntax: `<E as Trait>::V`
+   |
+note: lint level defined here
+  --> $DIR/type-alias-enum-variants-priority.rs:2:9
+   |
+LL | #![deny(ambiguous_associated_items)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #57644 <https://github.com/rust-lang/rust/issues/57644>
+note: `V` could refer to variant defined here
+  --> $DIR/type-alias-enum-variants-priority.rs:5:5
+   |
+LL |     V
+   |     ^
+note: `V` could also refer to associated type defined here
+  --> $DIR/type-alias-enum-variants-priority.rs:9:5
+   |
+LL |     type V;
+   |     ^^^^^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
In https://github.com/rust-lang/rust/pull/56225 variants were assigned lowest priority during name resolution to avoid crater run and potential breakage.

This PR changes the rules to give variants highest priority instead.
Some motivation:
- If variants (and their constructors) are treated as associated items, then they are obviously *inherent* associated items since they don't come from traits.
- Inherent associated items have higher priority during resolution than associated items from traits.
- The reason is that there is a way to disambiguate in favor of trait items (`<Type as Trait>::Ambiguous`), but there's no way to disambiguate in favor of inherent items, so they become unusable in case of ambiguities if they have low priority.
- It's technically problematic to fallback from associated types to anything until lazy normalization (?) is implemented.

Crater found some regressions from this change, but they are all in type positions, e.g.
```rust
fn f() -> Self::Ambiguos { ... } // Variant `Ambiguous` or associated type `Ambiguous`?
```
, so variants are not usable there right now, but they may become usable in the future if https://github.com/rust-lang/rfcs/pull/2593 is accepted.
This PR keeps code like this successfully resolving, but introduces a future-compatibility lint `ambiguous_associated_items` that recommends rewriting it as `<Self as Trait>::Ambiguous`.