### PR TITLE
Re-enable history api on file:// protocol

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -150,8 +150,7 @@ if (!DOMTokenList.prototype.remove) {
     }
 
     function browserSupportsHistoryApi() {
-        return document.location.protocol != "file:" &&
-          window.history && typeof window.history.pushState === "function";
+        return window.history && typeof window.history.pushState === "function";
     }
 
     var main = document.getElementById("main");


### PR DESCRIPTION
Fixes #57135.

I tested locally on chrome (since it was the browser having issues with history management on `file://` protocol) and it worked fine so I guess we can re-enable it.

r? @QuietMisdreavus 