### PR TITLE
rustdoc: Allow inlining of reexported crates and crate items

### DIFF
--- a/src/test/rustdoc/auxiliary/pub-extern-crate.rs
+++ b/src/test/rustdoc/auxiliary/pub-extern-crate.rs
@@ -1,0 +1,2 @@
+#![crate_name = "inner"]
+pub struct SomeStruct;

--- a/src/test/rustdoc/pub-extern-crate.rs
+++ b/src/test/rustdoc/pub-extern-crate.rs
@@ -1,0 +1,9 @@
+// aux-build:pub-extern-crate.rs
+
+// @has pub_extern_crate/index.html
+// @!has - '//code' 'pub extern crate inner'
+// @has - '//a/@href' 'inner/index.html'
+// @has pub_extern_crate/inner/index.html
+// @has pub_extern_crate/inner/struct.SomeStruct.html
+#[doc(inline)]
+pub extern crate inner;


### PR DESCRIPTION
Fixes #46296 

This PR checks for when a `pub extern crate` statement has a `#[doc(inline)]` attribute & inlines its contents. Code is based off of the inlining statements for `pub use` statements. 