### PR TITLE
Fix undefined behavior

### DIFF
--- a/src/libstd/sys/sgx/ext/arch.rs
+++ b/src/libstd/sys/sgx/ext/arch.rs
@@ -36,7 +36,7 @@ pub fn egetkey(request: &Align512<[u8; 512]>) -> Result<Align16<[u8; 16]>, u32> 
             : "={eax}"(error)
             : "{eax}"(ENCLU_EGETKEY),
               "{rbx}"(request),
-              "{rcx}"(out.get_mut())
+              "{rcx}"(out.as_mut_ptr())
             : "flags"
         );
 
@@ -66,7 +66,7 @@ pub fn ereport(
             : "{eax}"(ENCLU_EREPORT),
               "{rbx}"(targetinfo),
               "{rcx}"(reportdata),
-              "{rdx}"(report.get_mut())
+              "{rdx}"(report.as_mut_ptr())
         );
 
         report.into_inner()


### PR DESCRIPTION
From the [`MaybeUninit::get_mut` docs](https://doc.rust-lang.org/std/mem/union.MaybeUninit.html):
> It is up to the caller to guarantee that the the MaybeUninit really is in an initialized state, otherwise this will immediately cause undefined behavior.

r? @joshtriplett 