### PR TITLE
compiletest: Support opt-in Clang-based run-make tests and use them for testing xLTO.

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -96,6 +96,10 @@
 # that your host compiler ships with libc++.
 #use-libcxx = true
 
+# The value specified here will be passed as `-DLLVM_USE_LINKER` to CMake.
+#use-linker = "lld"
+
+
 # =============================================================================
 # General build configuration options
 # =============================================================================

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -77,6 +77,7 @@ pub struct Config {
     pub llvm_experimental_targets: String,
     pub llvm_link_jobs: Option<u32>,
     pub llvm_version_suffix: Option<String>,
+    pub llvm_use_linker: Option<String>,
 
     pub lld_enabled: bool,
     pub lldb_enabled: bool,
@@ -255,6 +256,7 @@ struct Llvm {
     version_suffix: Option<String>,
     clang_cl: Option<String>,
     use_libcxx: Option<bool>,
+    use_linker: Option<String>,
 }
 
 #[derive(Deserialize, Default, Clone)]
@@ -517,6 +519,7 @@ impl Config {
             config.llvm_version_suffix = llvm.version_suffix.clone();
             config.llvm_clang_cl = llvm.clang_cl.clone();
             set(&mut config.llvm_use_libcxx, llvm.use_libcxx);
+            config.llvm_use_linker = llvm.use_linker.clone();
         }
 
         if let Some(ref rust) = toml.rust {

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -231,6 +231,10 @@ impl Step for Llvm {
             cfg.define("LLVM_VERSION_SUFFIX", suffix);
         }
 
+        if let Some(ref linker) = builder.config.llvm_use_linker {
+            cfg.define("LLVM_USE_LINKER", linker);
+        }
+
         if let Some(ref python) = builder.config.python {
             cfg.define("PYTHON_EXECUTABLE", python);
         }

--- a/src/ci/docker/x86_64-gnu-debug/Dockerfile
+++ b/src/ci/docker/x86_64-gnu-debug/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.10
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
   g++ \
@@ -17,7 +17,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   cmake \
   sudo \
   gdb \
-  xz-utils
+  xz-utils \
+  lld \
+  clang
 
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
@@ -30,7 +32,11 @@ ENV RUST_CONFIGURE_ARGS \
       --enable-debug \
       --enable-lld \
       --enable-lldb \
-      --enable-optimize
+      --enable-optimize \
+      --set target.x86_64-unknown-linux-gnu.linker=clang \
+      --set target.x86_64-unknown-linux-gnu.cc=clang \
+      --set target.x86_64-unknown-linux-gnu.cxx=clang++
+
 ENV SCRIPT \
   python2.7 ../x.py build && \
   python2.7 ../x.py test src/test/run-make-fulldeps --test-args clang

--- a/src/ci/docker/x86_64-gnu-debug/Dockerfile
+++ b/src/ci/docker/x86_64-gnu-debug/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   curl \
   ca-certificates \
   python2.7 \
+  python2.7-dev \
   git \
   cmake \
   sudo \
@@ -16,9 +17,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
+ENV RUSTBUILD_FORCE_CLANG_BASED_TESTS 1
 ENV RUN_CHECK_WITH_PARALLEL_QUERIES 1
+
 ENV RUST_CONFIGURE_ARGS \
       --build=x86_64-unknown-linux-gnu \
       --enable-debug \
+      --enable-lld \
+      --enable-lldb \
       --enable-optimize
-ENV SCRIPT python2.7 ../x.py build
+ENV SCRIPT \
+  python2.7 ../x.py build && \
+  python2.7 ../x.py test src/test/run-make-fulldeps --test-args clang

--- a/src/ci/docker/x86_64-gnu-debug/Dockerfile
+++ b/src/ci/docker/x86_64-gnu-debug/Dockerfile
@@ -8,6 +8,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   ca-certificates \
   python2.7 \
   python2.7-dev \
+  libxml2-dev \
+  libncurses-dev \
+  libedit-dev \
+  swig \
+  doxygen \
   git \
   cmake \
   sudo \

--- a/src/ci/docker/x86_64-gnu-debug/Dockerfile
+++ b/src/ci/docker/x86_64-gnu-debug/Dockerfile
@@ -33,6 +33,7 @@ ENV RUST_CONFIGURE_ARGS \
       --enable-lld \
       --enable-lldb \
       --enable-optimize \
+      --set llvm.use-linker=lld \
       --set target.x86_64-unknown-linux-gnu.linker=clang \
       --set target.x86_64-unknown-linux-gnu.cc=clang \
       --set target.x86_64-unknown-linux-gnu.cxx=clang++

--- a/src/test/run-make-fulldeps/cross-lang-lto-clang/Makefile
+++ b/src/test/run-make-fulldeps/cross-lang-lto-clang/Makefile
@@ -9,7 +9,7 @@ all: cpp-executable rust-executable
 
 cpp-executable:
 	$(RUSTC) -Zcross-lang-lto=on -o $(TMPDIR)/librustlib-xlto.a -Copt-level=2 -Ccodegen-units=1 ./rustlib.rs
-	clang -flto=thin -fuse-ld=lld -L $(TMPDIR) -lrustlib-xlto -o $(TMPDIR)/cmain ./cmain.c -O3
+	$(CLANG) -flto=thin -fuse-ld=lld -L $(TMPDIR) -lrustlib-xlto -o $(TMPDIR)/cmain ./cmain.c -O3
 	# Make sure we don't find a call instruction to the function we expect to
 	# always be inlined.
 	llvm-objdump -d $(TMPDIR)/cmain | $(CGREP) -v -e "call.*rust_always_inlined"
@@ -18,8 +18,8 @@ cpp-executable:
 	llvm-objdump -d $(TMPDIR)/cmain | $(CGREP) -e "call.*rust_never_inlined"
 
 rust-executable:
-	clang ./clib.c -flto=thin -c -o $(TMPDIR)/clib.o -O2
+	$(CLANG) ./clib.c -flto=thin -c -o $(TMPDIR)/clib.o -O2
 	(cd $(TMPDIR); $(AR) crus ./libxyz.a ./clib.o)
-	$(RUSTC) -Zcross-lang-lto=on -L$(TMPDIR) -Copt-level=2 -Clinker=clang -Clink-arg=-fuse-ld=lld ./main.rs -o $(TMPDIR)/rsmain
+	$(RUSTC) -Zcross-lang-lto=on -L$(TMPDIR) -Copt-level=2 -Clinker=$(CLANG) -Clink-arg=-fuse-ld=lld ./main.rs -o $(TMPDIR)/rsmain
 	llvm-objdump -d $(TMPDIR)/rsmain | $(CGREP) -e "call.*c_never_inlined"
 	llvm-objdump -d $(TMPDIR)/rsmain | $(CGREP) -v -e "call.*c_always_inlined"

--- a/src/test/run-make-fulldeps/cross-lang-lto-clang/Makefile
+++ b/src/test/run-make-fulldeps/cross-lang-lto-clang/Makefile
@@ -1,0 +1,25 @@
+# needs-matching-clang
+
+# This test makes sure that cross-language inlining actually works by checking
+# the generated machine code.
+
+-include ../tools.mk
+
+all: cpp-executable rust-executable
+
+cpp-executable:
+	$(RUSTC) -Zcross-lang-lto=on -o $(TMPDIR)/librustlib-xlto.a -Copt-level=2 -Ccodegen-units=1 ./rustlib.rs
+	clang -flto=thin -fuse-ld=lld -L $(TMPDIR) -lrustlib-xlto -o $(TMPDIR)/cmain ./cmain.c -O3
+	# Make sure we don't find a call instruction to the function we expect to
+	# always be inlined.
+	llvm-objdump -d $(TMPDIR)/cmain | $(CGREP) -v -e "call.*rust_always_inlined"
+	# As a sanity check, make sure we do find a call instruction to a
+	# non-inlined function
+	llvm-objdump -d $(TMPDIR)/cmain | $(CGREP) -e "call.*rust_never_inlined"
+
+rust-executable:
+	clang ./clib.c -flto=thin -c -o $(TMPDIR)/clib.o -O2
+	(cd $(TMPDIR); $(AR) crus ./libxyz.a ./clib.o)
+	$(RUSTC) -Zcross-lang-lto=on -L$(TMPDIR) -Copt-level=2 -Clinker=clang -Clink-arg=-fuse-ld=lld ./main.rs -o $(TMPDIR)/rsmain
+	llvm-objdump -d $(TMPDIR)/rsmain | $(CGREP) -e "call.*c_never_inlined"
+	llvm-objdump -d $(TMPDIR)/rsmain | $(CGREP) -v -e "call.*c_always_inlined"

--- a/src/test/run-make-fulldeps/cross-lang-lto-clang/clib.c
+++ b/src/test/run-make-fulldeps/cross-lang-lto-clang/clib.c
@@ -1,0 +1,9 @@
+#include <stdint.h>
+
+uint32_t c_always_inlined() {
+    return 1234;
+}
+
+__attribute__((noinline)) uint32_t c_never_inlined() {
+    return 12345;
+}

--- a/src/test/run-make-fulldeps/cross-lang-lto-clang/cmain.c
+++ b/src/test/run-make-fulldeps/cross-lang-lto-clang/cmain.c
@@ -1,0 +1,12 @@
+#include <stdint.h>
+
+// A trivial function defined in Rust, returning a constant value. This should
+// always be inlined.
+uint32_t rust_always_inlined();
+
+
+uint32_t rust_never_inlined();
+
+int main(int argc, char** argv) {
+    return rust_never_inlined() + rust_always_inlined();
+}

--- a/src/test/run-make-fulldeps/cross-lang-lto-clang/main.rs
+++ b/src/test/run-make-fulldeps/cross-lang-lto-clang/main.rs
@@ -1,0 +1,11 @@
+#[link(name = "xyz")]
+extern "C" {
+    fn c_always_inlined() -> u32;
+    fn c_never_inlined() -> u32;
+}
+
+fn main() {
+    unsafe {
+        println!("blub: {}", c_always_inlined() + c_never_inlined());
+    }
+}

--- a/src/test/run-make-fulldeps/cross-lang-lto-clang/rustlib.rs
+++ b/src/test/run-make-fulldeps/cross-lang-lto-clang/rustlib.rs
@@ -1,0 +1,12 @@
+#![crate_type="staticlib"]
+
+#[no_mangle]
+pub extern "C" fn rust_always_inlined() -> u32 {
+    42
+}
+
+#[no_mangle]
+#[inline(never)]
+pub extern "C" fn rust_never_inlined() -> u32 {
+    421
+}

--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -144,6 +144,10 @@ pub struct Config {
     /// (or, alternatively, to silently run them like regular run-pass tests).
     pub force_valgrind: bool,
 
+    /// Whether to fail if we don't have a clang version available that matches
+    /// rustc's LLVM version.
+    pub force_clang_based_tests: bool,
+
     /// The directory containing the tests to run
     pub src_base: PathBuf,
 
@@ -204,6 +208,9 @@ pub struct Config {
 
     /// Is LLVM a system LLVM
     pub system_llvm: bool,
+
+    /// The version of Clang available to run-make tests (if any).
+    pub clang_version: Option<String>,
 
     /// Path to the android tools
     pub android_cross_path: PathBuf,

--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -144,9 +144,9 @@ pub struct Config {
     /// (or, alternatively, to silently run them like regular run-pass tests).
     pub force_valgrind: bool,
 
-    /// Whether to fail if we don't have a clang version available that matches
-    /// rustc's LLVM version.
-    pub force_clang_based_tests: bool,
+    /// The path to the Clang executable to run Clang-based tests with. If
+    /// `None` then these tests will be ignored.
+    pub run_clang_based_tests_with: Option<String>,
 
     /// The directory containing the tests to run
     pub src_base: PathBuf,
@@ -208,9 +208,6 @@ pub struct Config {
 
     /// Is LLVM a system LLVM
     pub system_llvm: bool,
-
-    /// The version of Clang available to run-make tests (if any).
-    pub clang_version: Option<String>,
 
     /// Path to the android tools
     pub android_cross_path: PathBuf,

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -111,6 +111,11 @@ impl EarlyProps {
                 if ignore_llvm(config, ln) {
                     props.ignore = Ignore::Ignore;
                 }
+
+                if !config.force_clang_based_tests &&
+                   config.parse_needs_matching_clang(ln) {
+                    props.ignore = Ignore::Ignore;
+                }
             }
 
             if (config.mode == common::DebugInfoGdb || config.mode == common::DebugInfoBoth) &&
@@ -703,6 +708,10 @@ impl Config {
         } else {
             None
         }
+    }
+
+    fn parse_needs_matching_clang(&self, line: &str) -> bool {
+        self.parse_name_directive(line, "needs-matching-clang")
     }
 
     /// Parses a name-value directive which contains config-specific information, e.g., `ignore-x86`

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -112,7 +112,7 @@ impl EarlyProps {
                     props.ignore = Ignore::Ignore;
                 }
 
-                if !config.force_clang_based_tests &&
+                if config.run_clang_based_tests_with.is_none() &&
                    config.parse_needs_matching_clang(ln) {
                     props.ignore = Ignore::Ignore;
                 }

--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -50,10 +50,30 @@ pub mod util;
 fn main() {
     env_logger::init();
 
-    let config = parse_config(env::args().collect());
+    let mut config = parse_config(env::args().collect());
 
     if config.valgrind_path.is_none() && config.force_valgrind {
         panic!("Can't find Valgrind to run Valgrind tests");
+    }
+
+    // Some run-make tests need a version of Clang available that matches
+    // rustc's LLVM version. Since this isn't always the case, these tests are
+    // opt-in.
+    let clang_based_tests_possible = check_clang_based_tests_possible(&config);
+    match (clang_based_tests_possible, config.force_clang_based_tests) {
+        (Ok(_), true) |
+        (Err(_), false) => {
+            // Nothing to do
+        }
+        (Ok(_), false) => {
+            // If a valid clang version is available, run the tests even if
+            // they are not forced.
+            config.force_clang_based_tests = true;
+        }
+        (Err(msg), true) => {
+            // Tests are forced but we don't have a valid version of Clang.
+            panic!("{}", msg)
+        }
     }
 
     log_config(&config);
@@ -107,6 +127,11 @@ pub fn parse_config(args: Vec<String>) -> Config {
             "",
             "force-valgrind",
             "fail if Valgrind tests cannot be run under Valgrind",
+        )
+        .optflag(
+            "",
+            "force-clang-based-tests",
+            "fail if Clang-based run-make tests can't be run for some reason",
         )
         .optopt(
             "",
@@ -189,6 +214,12 @@ pub fn parse_config(args: Vec<String>) -> Config {
             "VERSION STRING",
         )
         .optflag("", "system-llvm", "is LLVM the system LLVM")
+        .optopt(
+            "",
+            "clang-version",
+            "the version of Clang available to run-make tests",
+            "VERSION STRING",
+        )
         .optopt(
             "",
             "android-cross-path",
@@ -298,6 +329,7 @@ pub fn parse_config(args: Vec<String>) -> Config {
         docck_python: matches.opt_str("docck-python").unwrap(),
         valgrind_path: matches.opt_str("valgrind-path"),
         force_valgrind: matches.opt_present("force-valgrind"),
+        force_clang_based_tests: matches.opt_present("force-clang-based-tests"),
         llvm_filecheck: matches.opt_str("llvm-filecheck").map(|s| PathBuf::from(&s)),
         src_base,
         build_base: opt_path(matches, "build-base"),
@@ -323,6 +355,7 @@ pub fn parse_config(args: Vec<String>) -> Config {
         lldb_native_rust,
         llvm_version: matches.opt_str("llvm-version"),
         system_llvm: matches.opt_present("system-llvm"),
+        clang_version: matches.opt_str("clang-version"),
         android_cross_path: android_cross_path,
         adb_path: opt_str2(matches.opt_str("adb-path")),
         adb_test_dir: opt_str2(matches.opt_str("adb-test-dir")),
@@ -1029,5 +1062,56 @@ fn test_extract_gdb_version() {
         7012000: "GNU gdb (GDB) 7.12",
         7012000: "GNU gdb (GDB) 7.12.20161027-git",
         7012050: "GNU gdb (GDB) 7.12.50.20161027-git",
+    }
+}
+
+
+fn check_clang_based_tests_possible(config: &Config) -> Result<(), String> {
+
+    let llvm_version = if let Some(llvm_version) = config.llvm_version.as_ref() {
+        llvm_version
+    } else {
+        return Err(format!("Running `compiletest` with `--force-clang-based-tests` \
+                            requires `--llvm-version` to be specified."));
+    };
+
+    let clang_major_version = if let Some(ref version_string) = config.clang_version {
+        major_version_from_clang_version_string(version_string)?
+    } else {
+        return Err(format!("Clang is required for running tests \
+                            (because of --force-clang-based-tests) \
+                            but it does not seem to be available."));
+    };
+
+    let rustc_llvm_major_version = major_version_from_llvm_version_string(&llvm_version)?;
+
+    return if clang_major_version != rustc_llvm_major_version {
+        Err(format!("`--force-clang-based-tests` needs the major version of Clang \
+                     and rustc's LLVM to be the same. Clang version is: {}, \
+                     Rustc LLVM is: {}",
+                     config.clang_version.clone().unwrap(),
+                     llvm_version))
+    } else {
+        Ok(())
+    };
+
+    fn major_version_from_clang_version_string(clang_version: &str) -> Result<&str, String> {
+        let re = regex::Regex::new(r"clang version (\d)\.\d").unwrap();
+        if let Some(captures) = re.captures(clang_version) {
+            Ok(captures.get(1).unwrap().as_str())
+        } else {
+            Err(format!("Failed to parse major version from Clang version \
+                         string '{}'.", clang_version))
+        }
+    }
+
+    fn major_version_from_llvm_version_string(llvm_version: &str) -> Result<&str, String> {
+        let re = regex::Regex::new(r"(\d)\.\d").unwrap();
+        if let Some(captures) = re.captures(llvm_version) {
+            Ok(captures.get(1).unwrap().as_str())
+        } else {
+            Err(format!("Failed to parse major version from LLVM version \
+                         string '{}'.", llvm_version))
+        }
     }
 }

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2587,6 +2587,10 @@ impl<'test> TestCx<'test> {
             cmd.env("RUSTC_LINKER", linker);
         }
 
+        if let Some(ref clang) = self.config.run_clang_based_tests_with {
+            cmd.env("CLANG", clang);
+        }
+
         // We don't want RUSTFLAGS set from the outside to interfere with
         // compiler flags set in the test cases:
         cmd.env_remove("RUSTFLAGS");


### PR DESCRIPTION
Some cross-language run-make tests need a Clang compiler that matches the LLVM version of `rustc`. Since such a compiler usually isn't available these tests (marked with the `needs-matching-clang`
directive) are ignored by default.

For some CI jobs we do need these tests to run unconditionally though. In order to support this a `--force-clang-based-tests` flag is added to compiletest. If this flag is specified, `compiletest` will fail if it can't detect an appropriate version of Clang.

@rust-lang/infra The PR doesn't yet enable the tests yet. Do you have any recommendation for which jobs to enable them?

cc #57438

r? @alexcrichton 