### PR TITLE
Rollup of 15 pull requests

### DIFF
--- a/src/etc/lldb_batchmode.py
+++ b/src/etc/lldb_batchmode.py
@@ -18,9 +18,14 @@ import lldb
 import os
 import sys
 import threading
-import thread
 import re
 import time
+
+try:
+    import thread
+except ModuleNotFoundError:
+    # The `thread` module was renamed to `_thread` in Python 3.
+    import _thread as thread
 
 # Set this to True for additional output
 DEBUG_OUTPUT = False

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -1,27 +1,22 @@
 //! Functionality for ordering and comparison.
 //!
-//! This module defines both [`PartialOrd`] and [`PartialEq`] traits which are used
-//! by the compiler to implement comparison operators. Rust programs may
-//! implement [`PartialOrd`] to overload the `<`, `<=`, `>`, and `>=` operators,
-//! and may implement [`PartialEq`] to overload the `==` and `!=` operators.
+//! This module contains various tools for ordering and comparing values. In
+//! summary:
 //!
-//! [`PartialOrd`]: trait.PartialOrd.html
-//! [`PartialEq`]: trait.PartialEq.html
+//! * [`Eq`] and [`PartialEq`] are traits that allow you to define total and
+//!   partial equality between values, respectively. Implementing them overloads
+//!   the `==` and `!=` operators.
+//! * [`Ord`] and [`PartialOrd`] are traits that allow you to define total and
+//!   partial orderings between values, respectively. Implementing them overloads
+//!   the `<`, `<=`, `>`, and `>=` operators.
+//! * [`Ordering`][cmp::Ordering] is an enum returned by the
+//!   main functions of [`Ord`] and [`PartialOrd`], and describes an ordering.
+//! * [`Reverse`][cmp::Reverse] is a struct that allows you to easily reverse
+//!   an ordering.
+//! * [`max`][cmp::max] and [`min`][cmp::min] are functions that build off of
+//!   [`Ord`] and allow you to find the maximum or minimum of two values.
 //!
-//! # Examples
-//!
-//! ```
-//! let x: u32 = 0;
-//! let y: u32 = 1;
-//!
-//! // these two lines are equivalent
-//! assert_eq!(x < y, true);
-//! assert_eq!(x.lt(&y), true);
-//!
-//! // these two lines are also equivalent
-//! assert_eq!(x == y, false);
-//! assert_eq!(x.eq(&y), false);
-//! ```
+//! For more details, see the respective documentation of each item in the list.
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -191,29 +191,8 @@ pub trait Write {
     /// assert_eq!(&buf, "world");
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    fn write_fmt(&mut self, args: Arguments) -> Result {
-        // This Adapter is needed to allow `self` (of type `&mut
-        // Self`) to be cast to a Write (below) without
-        // requiring a `Sized` bound.
-        struct Adapter<'a,T: ?Sized +'a>(&'a mut T);
-
-        impl<T: ?Sized> Write for Adapter<'_, T>
-            where T: Write
-        {
-            fn write_str(&mut self, s: &str) -> Result {
-                self.0.write_str(s)
-            }
-
-            fn write_char(&mut self, c: char) -> Result {
-                self.0.write_char(c)
-            }
-
-            fn write_fmt(&mut self, args: Arguments) -> Result {
-                self.0.write_fmt(args)
-            }
-        }
-
-        write(&mut Adapter(self), args)
+    fn write_fmt(mut self: &mut Self, args: Arguments) -> Result {
+        write(&mut self, args)
     }
 }
 

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -247,7 +247,7 @@ struct Void {
 /// family of functions. It contains a function to format the given value. At
 /// compile time it is ensured that the function and the value have the correct
 /// types, and then this struct is used to canonicalize arguments to one type.
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 #[allow(missing_debug_implementations)]
 #[unstable(feature = "fmt_internals", reason = "internal to format_args!",
            issue = "0")]
@@ -255,14 +255,6 @@ struct Void {
 pub struct ArgumentV1<'a> {
     value: &'a Void,
     formatter: fn(&Void, &mut Formatter) -> Result,
-}
-
-#[unstable(feature = "fmt_internals", reason = "internal to format_args!",
-           issue = "0")]
-impl Clone for ArgumentV1<'_> {
-    fn clone(&self) -> Self {
-        *self
-    }
 }
 
 impl<'a> ArgumentV1<'a> {

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -1076,7 +1076,7 @@ impl<'a> Formatter<'a> {
                 self.args[i].as_usize()
             }
             rt::v1::Count::NextParam => {
-                self.curarg.next().and_then(|arg| arg.as_usize())
+                self.curarg.next()?.as_usize()
             }
         }
     }
@@ -1142,15 +1142,15 @@ impl<'a> Formatter<'a> {
             sign = Some('+'); width += 1;
         }
 
-        let mut prefixed = false;
-        if self.alternate() {
-            prefixed = true; width += prefix.chars().count();
+        let prefixed = self.alternate();
+        if prefixed {
+            width += prefix.chars().count();
         }
 
         // Writes the sign if it exists, and then the prefix if it was requested
         let write_prefix = |f: &mut Formatter| {
             if let Some(c) = sign {
-                f.buf.write_str(c.encode_utf8(&mut [0; 4]))?;
+                f.buf.write_char(c)?;
             }
             if prefixed { f.buf.write_str(prefix) }
             else { Ok(()) }
@@ -1312,7 +1312,7 @@ impl<'a> Formatter<'a> {
 
                 // remove the sign from the formatted parts
                 formatted.sign = b"";
-                width = if width < sign.len() { 0 } else { width - sign.len() };
+                width = width.saturating_sub(sign.len());
                 align = rt::v1::Alignment::Right;
                 self.fill = '0';
                 self.align = rt::v1::Alignment::Right;

--- a/src/libcore/num/f32.rs
+++ b/src/libcore/num/f32.rs
@@ -161,6 +161,14 @@ impl f32 {
         self != self
     }
 
+    // FIXME(#50145): `abs` is publicly unavailable in libcore due to
+    // concerns about portability, so this implementation is for
+    // private use internally.
+    #[inline]
+    fn abs_private(self) -> f32 {
+        f32::from_bits(self.to_bits() & 0x7fff_ffff)
+    }
+
     /// Returns `true` if this value is positive infinity or negative infinity and
     /// false otherwise.
     ///
@@ -181,7 +189,7 @@ impl f32 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn is_infinite(self) -> bool {
-        self == INFINITY || self == NEG_INFINITY
+        self.abs_private() == INFINITY
     }
 
     /// Returns `true` if this number is neither infinite nor `NaN`.
@@ -203,7 +211,9 @@ impl f32 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn is_finite(self) -> bool {
-        !(self.is_nan() || self.is_infinite())
+        // There's no need to handle NaN separately: if self is NaN,
+        // the comparison is not true, exactly as desired.
+        self.abs_private() < INFINITY
     }
 
     /// Returns `true` if the number is neither zero, infinite,

--- a/src/libcore/num/f64.rs
+++ b/src/libcore/num/f64.rs
@@ -161,6 +161,14 @@ impl f64 {
         self != self
     }
 
+    // FIXME(#50145): `abs` is publicly unavailable in libcore due to
+    // concerns about portability, so this implementation is for
+    // private use internally.
+    #[inline]
+    fn abs_private(self) -> f64 {
+        f64::from_bits(self.to_bits() & 0x7fff_ffff_ffff_ffff)
+    }
+
     /// Returns `true` if this value is positive infinity or negative infinity and
     /// false otherwise.
     ///
@@ -181,7 +189,7 @@ impl f64 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn is_infinite(self) -> bool {
-        self == INFINITY || self == NEG_INFINITY
+        self.abs_private() == INFINITY
     }
 
     /// Returns `true` if this number is neither infinite nor `NaN`.
@@ -203,7 +211,9 @@ impl f64 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn is_finite(self) -> bool {
-        !(self.is_nan() || self.is_infinite())
+        // There's no need to handle NaN separately: if self is NaN,
+        // the comparison is not true, exactly as desired.
+        self.abs_private() < INFINITY
     }
 
     /// Returns `true` if the number is neither zero, infinite,

--- a/src/libcore/str/pattern.rs
+++ b/src/libcore/str/pattern.rs
@@ -425,8 +425,7 @@ impl<'a> Pattern<'a> for char {
     #[inline]
     fn into_searcher(self, haystack: &'a str) -> Self::Searcher {
         let mut utf8_encoded = [0; 4];
-        self.encode_utf8(&mut utf8_encoded);
-        let utf8_size = self.len_utf8();
+        let utf8_size = self.encode_utf8(&mut utf8_encoded).len();
         CharSearcher {
             haystack,
             finger: 0,

--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -302,7 +302,7 @@ impl_stable_hash_for!(struct ty::FieldDef {
 impl_stable_hash_for!(
     impl<'tcx> for enum mir::interpret::ConstValue<'tcx> [ mir::interpret::ConstValue ] {
         Scalar(val),
-        ScalarPair(a, b),
+        Slice(a, b),
         ByRef(id, alloc, offset),
     }
 );

--- a/src/librustc/infer/lexical_region_resolve/mod.rs
+++ b/src/librustc/infer/lexical_region_resolve/mod.rs
@@ -13,6 +13,7 @@ use rustc_data_structures::graph::implementation::{
     Direction, Graph, NodeIndex, INCOMING, OUTGOING,
 };
 use rustc_data_structures::indexed_vec::{Idx, IndexVec};
+use smallvec::SmallVec;
 use std::fmt;
 use std::u32;
 use ty::fold::TypeFoldable;
@@ -190,19 +191,24 @@ impl<'cx, 'gcx, 'tcx> LexicalResolver<'cx, 'gcx, 'tcx> {
             match *constraint {
                 Constraint::RegSubVar(a_region, b_vid) => {
                     let b_data = var_values.value_mut(b_vid);
-                    self.expand_node(a_region, b_vid, b_data)
+                    (self.expand_node(a_region, b_vid, b_data), false)
                 }
                 Constraint::VarSubVar(a_vid, b_vid) => match *var_values.value(a_vid) {
-                    VarValue::ErrorValue => false,
+                    VarValue::ErrorValue => (false, false),
                     VarValue::Value(a_region) => {
                         let b_node = var_values.value_mut(b_vid);
-                        self.expand_node(a_region, b_vid, b_node)
+                        let changed = self.expand_node(a_region, b_vid, b_node);
+                        let retain = match *b_node {
+                            VarValue::Value(ReStatic) | VarValue::ErrorValue => false,
+                            _ => true
+                        };
+                        (changed, retain)
                     }
                 },
                 Constraint::RegSubReg(..) | Constraint::VarSubReg(..) => {
                     // These constraints are checked after expansion
                     // is done, in `collect_errors`.
-                    false
+                    (false, false)
                 }
             }
         })
@@ -710,21 +716,23 @@ impl<'cx, 'gcx, 'tcx> LexicalResolver<'cx, 'gcx, 'tcx> {
 
     fn iterate_until_fixed_point<F>(&self, tag: &str, mut body: F)
     where
-        F: FnMut(&Constraint<'tcx>, &SubregionOrigin<'tcx>) -> bool,
+        F: FnMut(&Constraint<'tcx>, &SubregionOrigin<'tcx>) -> (bool, bool),
     {
+        let mut constraints: SmallVec<[_; 16]> = self.data.constraints.iter().collect();
         let mut iteration = 0;
         let mut changed = true;
         while changed {
             changed = false;
             iteration += 1;
             debug!("---- {} Iteration {}{}", "#", tag, iteration);
-            for (constraint, origin) in &self.data.constraints {
-                let edge_changed = body(constraint, origin);
+            constraints.retain(|(constraint, origin)| {
+                let (edge_changed, retain) = body(constraint, origin);
                 if edge_changed {
                     debug!("Updated due to constraint {:?}", constraint);
                     changed = true;
                 }
-            }
+                retain
+            });
         }
         debug!("---- {} Complete after {} iteration(s)", tag, iteration);
     }

--- a/src/librustc/infer/lexical_region_resolve/mod.rs
+++ b/src/librustc/infer/lexical_region_resolve/mod.rs
@@ -274,6 +274,13 @@ impl<'cx, 'gcx, 'tcx> LexicalResolver<'cx, 'gcx, 'tcx> {
 
     fn lub_concrete_regions(&self, a: Region<'tcx>, b: Region<'tcx>) -> Region<'tcx> {
         let tcx = self.tcx();
+
+        // Equal scopes can show up quite often, if the fixed point
+        // iteration converges slowly, skip them
+        if a == b {
+            return a;
+        }
+
         match (a, b) {
             (&ty::ReClosureBound(..), _)
             | (_, &ty::ReClosureBound(..))

--- a/src/librustc/mir/interpret/pointer.rs
+++ b/src/librustc/mir/interpret/pointer.rs
@@ -76,6 +76,8 @@ pub struct Pointer<Tag=(),Id=AllocId> {
     pub tag: Tag,
 }
 
+static_assert!(POINTER_SIZE: ::std::mem::size_of::<Pointer>() == 16);
+
 /// Produces a `Pointer` which points to the beginning of the Allocation
 impl From<AllocId> for Pointer {
     #[inline(always)]

--- a/src/librustc/mir/interpret/value.rs
+++ b/src/librustc/mir/interpret/value.rs
@@ -32,6 +32,9 @@ pub enum ConstValue<'tcx> {
     ByRef(AllocId, &'tcx Allocation, Size),
 }
 
+#[cfg(target_arch = "x86_64")]
+static_assert!(CONST_SIZE: ::std::mem::size_of::<ConstValue<'static>>() == 56);
+
 impl<'tcx> ConstValue<'tcx> {
     #[inline]
     pub fn try_to_scalar(&self) -> Option<Scalar> {
@@ -89,6 +92,8 @@ pub enum Scalar<Tag=(), Id=AllocId> {
     /// relocation and its associated offset together as a `Pointer` here.
     Ptr(Pointer<Tag, Id>),
 }
+
+static_assert!(SCALAR_SIZE: ::std::mem::size_of::<Scalar>() == 24);
 
 impl<Tag> fmt::Display for Scalar<Tag> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/librustc/mir/interpret/value.rs
+++ b/src/librustc/mir/interpret/value.rs
@@ -23,6 +23,11 @@ pub enum ConstValue<'tcx> {
     Scalar(Scalar),
 
     /// Used only for slices and strings (`&[T]`, `&str`, `*const [T]`, `*mut str`, `Box<str>`, ...)
+    ///
+    /// Empty slices don't necessarily have an address backed by an `AllocId`, thus we also need to
+    /// enable integer pointers. The `Scalar` type covers exactly those two cases. While we could
+    /// create dummy-`AllocId`s, the additional code effort for the conversions doesn't seem worth
+    /// it.
     Slice(Scalar, u64),
 
     /// An allocation + offset into the allocation.

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -59,6 +59,7 @@ use std::hash::{Hash, Hasher};
 use std::fmt;
 use std::mem;
 use std::ops::{Deref, Bound};
+use std::ptr;
 use std::iter;
 use std::sync::mpsc;
 use std::sync::Arc;
@@ -168,7 +169,7 @@ impl<'gcx: 'tcx, 'tcx> CtxtInterners<'tcx> {
 
                 // Make sure we don't end up with inference
                 // types/regions in the global interner
-                if local as *const _ as usize == global as *const _ as usize {
+                if ptr::eq(local, global) {
                     bug!("Attempted to intern `{:?}` which contains \
                         inference types/regions in the global type context",
                         &ty_struct);
@@ -1125,9 +1126,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
 
     /// Returns true if self is the same as self.global_tcx().
     fn is_global(self) -> bool {
-        let local = self.interners as *const _;
-        let global = &self.global_interners as *const _;
-        local as usize == global as usize
+        ptr::eq(self.interners, &self.global_interners)
     }
 
     /// Create a type context and call the closure with a `TyCtxt` reference
@@ -1777,6 +1776,7 @@ pub mod tls {
     use std::fmt;
     use std::mem;
     use std::marker::PhantomData;
+    use std::ptr;
     use syntax_pos;
     use ty::query;
     use errors::{Diagnostic, TRACK_DIAGNOSTICS};
@@ -2011,8 +2011,7 @@ pub mod tls {
     {
         with_context(|context| {
             unsafe {
-                let gcx = tcx.gcx as *const _ as usize;
-                assert!(context.tcx.gcx as *const _ as usize == gcx);
+                assert!(ptr::eq(context.tcx.gcx, tcx.gcx));
                 let context: &ImplicitCtxt<'_, '_, '_> = mem::transmute(context);
                 f(context)
             }
@@ -2030,10 +2029,8 @@ pub mod tls {
     {
         with_context(|context| {
             unsafe {
-                let gcx = tcx.gcx as *const _ as usize;
-                let interners = tcx.interners as *const _ as usize;
-                assert!(context.tcx.gcx as *const _ as usize == gcx);
-                assert!(context.tcx.interners as *const _ as usize == interners);
+                assert!(ptr::eq(context.tcx.gcx, tcx.gcx));
+                assert!(ptr::eq(context.tcx.interners, tcx.interners));
                 let context: &ImplicitCtxt<'_, '_, '_> = mem::transmute(context);
                 f(context)
             }

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -1730,7 +1730,7 @@ macro_rules! nop_list_lift {
         impl<'a, 'tcx> Lift<'tcx> for &'a List<$ty> {
             type Lifted = &'tcx List<$lifted>;
             fn lift_to_tcx<'b, 'gcx>(&self, tcx: TyCtxt<'b, 'gcx, 'tcx>) -> Option<Self::Lifted> {
-                        if self.is_empty() {
+                if self.is_empty() {
                     return Some(List::empty());
                 }
                 if tcx.interners.arena.in_arena(*self as *const _) {

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -122,7 +122,7 @@ mod sty;
 /// *on-demand* infrastructure.
 #[derive(Clone)]
 pub struct CrateAnalysis {
-    pub glob_map: Option<hir::GlobMap>,
+    pub glob_map: hir::GlobMap,
 }
 
 #[derive(Clone)]

--- a/src/librustc/ty/structural_impls.rs
+++ b/src/librustc/ty/structural_impls.rs
@@ -498,7 +498,7 @@ impl<'a, 'tcx> Lift<'tcx> for ConstValue<'a> {
     fn lift_to_tcx<'b, 'gcx>(&self, tcx: TyCtxt<'b, 'gcx, 'tcx>) -> Option<Self::Lifted> {
         match *self {
             ConstValue::Scalar(x) => Some(ConstValue::Scalar(x)),
-            ConstValue::ScalarPair(x, y) => Some(ConstValue::ScalarPair(x, y)),
+            ConstValue::Slice(x, y) => Some(ConstValue::Slice(x, y)),
             ConstValue::ByRef(x, alloc, z) => Some(ConstValue::ByRef(
                 x, alloc.lift_to_tcx(tcx)?, z,
             )),

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -2063,6 +2063,9 @@ pub enum LazyConst<'tcx> {
     Evaluated(Const<'tcx>),
 }
 
+#[cfg(target_arch = "x86_64")]
+static_assert!(LAZY_CONST_SIZE: ::std::mem::size_of::<LazyConst<'static>>() == 72);
+
 impl<'tcx> LazyConst<'tcx> {
     pub fn map_evaluated<R>(self, f: impl FnOnce(Const<'tcx>) -> Option<R>) -> Option<R> {
         match self {
@@ -2088,6 +2091,9 @@ pub struct Const<'tcx> {
 
     pub val: ConstValue<'tcx>,
 }
+
+#[cfg(target_arch = "x86_64")]
+static_assert!(CONST_SIZE: ::std::mem::size_of::<Const<'static>>() == 64);
 
 impl<'tcx> Const<'tcx> {
     #[inline]

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -2064,7 +2064,7 @@ pub enum LazyConst<'tcx> {
 }
 
 #[cfg(target_arch = "x86_64")]
-static_assert!(LAZY_CONST_SIZE: ::std::mem::size_of::<LazyConst<'static>>() == 72);
+static_assert!(LAZY_CONST_SIZE: ::std::mem::size_of::<LazyConst<'static>>() == 56);
 
 impl<'tcx> LazyConst<'tcx> {
     pub fn map_evaluated<R>(self, f: impl FnOnce(Const<'tcx>) -> Option<R>) -> Option<R> {
@@ -2093,7 +2093,7 @@ pub struct Const<'tcx> {
 }
 
 #[cfg(target_arch = "x86_64")]
-static_assert!(CONST_SIZE: ::std::mem::size_of::<Const<'static>>() == 64);
+static_assert!(CONST_SIZE: ::std::mem::size_of::<Const<'static>>() == 48);
 
 impl<'tcx> Const<'tcx> {
     #[inline]

--- a/src/librustc_codegen_llvm/debuginfo/metadata.rs
+++ b/src/librustc_codegen_llvm/debuginfo/metadata.rs
@@ -47,7 +47,7 @@ use syntax_pos::{self, Span, FileName};
 
 impl PartialEq for llvm::Metadata {
     fn eq(&self, other: &Self) -> bool {
-        self as *const _ == other as *const _
+        ptr::eq(self, other)
     }
 }
 

--- a/src/librustc_codegen_llvm/type_.rs
+++ b/src/librustc_codegen_llvm/type_.rs
@@ -20,12 +20,13 @@ use abi::{LlvmType, FnTypeExt};
 
 use std::fmt;
 use std::cell::RefCell;
+use std::ptr;
 
 use libc::c_uint;
 
 impl PartialEq for Type {
     fn eq(&self, other: &Self) -> bool {
-        self as *const _ == other as *const _
+        ptr::eq(self, other)
     }
 }
 

--- a/src/librustc_codegen_llvm/value.rs
+++ b/src/librustc_codegen_llvm/value.rs
@@ -4,10 +4,11 @@ use llvm;
 
 use std::fmt;
 use std::hash::{Hash, Hasher};
+use std::ptr;
 
 impl PartialEq for Value {
     fn eq(&self, other: &Self) -> bool {
-        self as *const _ == other as *const _
+        ptr::eq(self, other)
     }
 }
 

--- a/src/librustc_codegen_ssa/mir/operand.rs
+++ b/src/librustc_codegen_ssa/mir/operand.rs
@@ -88,9 +88,9 @@ impl<'a, 'tcx: 'a, V: CodegenObject> OperandRef<'tcx, V> {
                 );
                 OperandValue::Immediate(llval)
             },
-            ConstValue::ScalarPair(a, b) => {
-                let (a_scalar, b_scalar) = match layout.abi {
-                    layout::Abi::ScalarPair(ref a, ref b) => (a, b),
+            ConstValue::Slice(a, b) => {
+                let a_scalar = match layout.abi {
+                    layout::Abi::ScalarPair(ref a, _) => a,
                     _ => bug!("from_const: invalid ScalarPair layout: {:#?}", layout)
                 };
                 let a_llval = bx.cx().scalar_to_backend(
@@ -98,11 +98,7 @@ impl<'a, 'tcx: 'a, V: CodegenObject> OperandRef<'tcx, V> {
                     a_scalar,
                     bx.cx().scalar_pair_element_backend_type(layout, 0, true),
                 );
-                let b_llval = bx.cx().scalar_to_backend(
-                    b,
-                    b_scalar,
-                    bx.cx().scalar_pair_element_backend_type(layout, 1, true),
-                );
+                let b_llval = bx.cx().const_usize(b);
                 OperandValue::Pair(a_llval, b_llval)
             },
             ConstValue::ByRef(_, alloc, offset) => {

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -26,7 +26,7 @@ use rustc_passes::{self, ast_validation, hir_stats, loops, rvalue_promotion};
 use rustc_plugin as plugin;
 use rustc_plugin::registry::Registry;
 use rustc_privacy;
-use rustc_resolve::{MakeGlobMap, Resolver, ResolverArenas};
+use rustc_resolve::{Resolver, ResolverArenas};
 use rustc_traits;
 use rustc_typeck as typeck;
 use syntax::{self, ast, attr, diagnostics, visit};
@@ -179,7 +179,6 @@ pub fn compile_input(
                 registry,
                 &crate_name,
                 addl_plugins,
-                control.make_glob_map,
                 |expanded_crate| {
                     let mut state = CompileState::state_after_expand(
                         input,
@@ -394,7 +393,6 @@ pub struct CompileController<'a> {
 
     // FIXME we probably want to group the below options together and offer a
     // better API, rather than this ad-hoc approach.
-    pub make_glob_map: MakeGlobMap,
     // Whether the compiler should keep the ast beyond parsing.
     pub keep_ast: bool,
     // -Zcontinue-parse-after-error
@@ -416,7 +414,6 @@ impl<'a> CompileController<'a> {
             after_hir_lowering: PhaseController::basic(),
             after_analysis: PhaseController::basic(),
             compilation_done: PhaseController::basic(),
-            make_glob_map: MakeGlobMap::No,
             keep_ast: false,
             continue_parse_after_error: false,
             provide: box |_| {},
@@ -738,7 +735,6 @@ pub fn phase_2_configure_and_expand<F>(
     registry: Option<Registry>,
     crate_name: &str,
     addl_plugins: Option<Vec<String>>,
-    make_glob_map: MakeGlobMap,
     after_expand: F,
 ) -> Result<ExpansionResult, CompileIncomplete>
 where
@@ -758,7 +754,6 @@ where
         registry,
         crate_name,
         addl_plugins,
-        make_glob_map,
         &resolver_arenas,
         &mut crate_loader,
         after_expand,
@@ -784,11 +779,7 @@ where
             },
 
             analysis: ty::CrateAnalysis {
-                glob_map: if resolver.make_glob_map {
-                    Some(resolver.glob_map)
-                } else {
-                    None
-                },
+                glob_map: resolver.glob_map
             },
         }),
         Err(x) => Err(x),
@@ -804,7 +795,6 @@ pub fn phase_2_configure_and_expand_inner<'a, F>(
     registry: Option<Registry>,
     crate_name: &str,
     addl_plugins: Option<Vec<String>>,
-    make_glob_map: MakeGlobMap,
     resolver_arenas: &'a ResolverArenas<'a>,
     crate_loader: &'a mut CrateLoader<'a>,
     after_expand: F,
@@ -936,7 +926,6 @@ where
         cstore,
         &krate,
         crate_name,
-        make_glob_map,
         crate_loader,
         &resolver_arenas,
     );

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -56,7 +56,6 @@ extern crate syntax_pos;
 use driver::CompileController;
 use pretty::{PpMode, UserIdentifiedItem};
 
-use rustc_resolve as resolve;
 use rustc_save_analysis as save;
 use rustc_save_analysis::DumpHandler;
 use rustc_data_structures::sync::{self, Lrc};
@@ -954,7 +953,6 @@ pub fn enable_save_analysis(control: &mut CompileController) {
         });
     };
     control.after_analysis.run_callback_on_error = true;
-    control.make_glob_map = resolve::MakeGlobMap::Yes;
 }
 
 impl RustcDefaultCalls {

--- a/src/librustc_driver/test.rs
+++ b/src/librustc_driver/test.rs
@@ -18,7 +18,6 @@ use rustc::ty::{self, Ty, TyCtxt, TypeFoldable};
 use rustc_data_structures::sync::{self, Lrc};
 use rustc_lint;
 use rustc_metadata::cstore::CStore;
-use rustc_resolve::MakeGlobMap;
 use rustc_target::spec::abi::Abi;
 use syntax;
 use syntax::ast;
@@ -134,7 +133,6 @@ fn test_env_with_pool<F>(
             None,
             "test",
             None,
-            MakeGlobMap::No,
             |_| Ok(()),
         ).expect("phase 2 aborted")
     };

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -70,7 +70,7 @@ fn mk_eval_cx_inner<'a, 'mir, 'tcx>(
     Ok(ecx)
 }
 
-pub fn mk_eval_cx<'a, 'tcx>(
+fn mk_eval_cx<'a, 'tcx>(
     tcx: TyCtxt<'a, 'tcx, 'tcx>,
     instance: Instance<'tcx>,
     param_env: ty::ParamEnv<'tcx>,

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -90,7 +90,7 @@ fn mk_eval_cx_inner<'a, 'mir, 'tcx>(
 /// The function containing the `match` that is currently being analyzed may have generic bounds
 /// that inform us about the generic bounds of the constant. E.g. using an associated constant
 /// of a function's generic parameter will require knowledge about the bounds on the generic
-/// parameter.
+/// parameter. These bounds are passed to `mk_eval_cx` via the `ParamEnv` argument.
 fn mk_eval_cx<'a, 'tcx>(
     tcx: TyCtxt<'a, 'tcx, 'tcx>,
     instance: Instance<'tcx>,

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -96,7 +96,7 @@ pub fn op_to_const<'tcx>(
     op: OpTy<'tcx>,
     may_normalize: bool,
 ) -> EvalResult<'tcx, ty::Const<'tcx>> {
-    // We do not normalize just any data.  Only scalar layout and fat pointers.
+    // We do not normalize just any data.  Only scalar layout and slices.
     let normalize = may_normalize
         && match op.layout.abi {
             layout::Abi::Scalar(..) => true,

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -100,10 +100,7 @@ pub fn op_to_const<'tcx>(
     let normalize = may_normalize
         && match op.layout.abi {
             layout::Abi::Scalar(..) => true,
-            layout::Abi::ScalarPair(..) => {
-                // Must be a fat pointer
-                op.layout.ty.builtin_deref(true).is_some()
-            },
+            layout::Abi::ScalarPair(..) => op.layout.ty.is_slice(),
             _ => false,
         };
     let normalized_op = if normalize {
@@ -132,7 +129,7 @@ pub fn op_to_const<'tcx>(
         Ok(Immediate::Scalar(x)) =>
             ConstValue::Scalar(x.not_undef()?),
         Ok(Immediate::ScalarPair(a, b)) =>
-            ConstValue::ScalarPair(a.not_undef()?, b.not_undef()?),
+            ConstValue::Slice(a.not_undef()?, b.to_usize(ecx)?),
     };
     Ok(ty::Const { val, ty: op.layout.ty })
 }

--- a/src/librustc_mir/hair/constant.rs
+++ b/src/librustc_mir/hair/constant.rs
@@ -35,7 +35,7 @@ crate fn lit_to_const<'a, 'gcx, 'tcx>(
         LitKind::Str(ref s, _) => {
             let s = s.as_str();
             let id = tcx.allocate_bytes(s.as_bytes());
-            ConstValue::new_slice(Scalar::Ptr(id.into()), s.len() as u64, &tcx)
+            ConstValue::new_slice(Scalar::Ptr(id.into()), s.len() as u64)
         },
         LitKind::ByteStr(ref data) => {
             let id = tcx.allocate_bytes(data);

--- a/src/librustc_mir/hair/pattern/_match.rs
+++ b/src/librustc_mir/hair/pattern/_match.rs
@@ -221,13 +221,16 @@ impl<'a, 'tcx> LiteralExpander<'a, 'tcx> {
             // unsize array to slice if pattern is array but match value or other patterns are slice
             (ConstValue::Scalar(Scalar::Ptr(p)), ty::Array(t, n), ty::Slice(u)) => {
                 assert_eq!(t, u);
-                ConstValue::ScalarPair(
+                ConstValue::Slice(
                     Scalar::Ptr(p),
-                    n.map_evaluated(|val| val.val.try_to_scalar()).unwrap(),
+                    n.map_evaluated(|val| val.val.try_to_scalar())
+                        .unwrap()
+                        .to_usize(&self.tcx)
+                        .unwrap(),
                 )
             },
             // fat pointers stay the same
-            (ConstValue::ScalarPair(..), _, _) => val,
+            (ConstValue::Slice(..), _, _) => val,
             // FIXME(oli-obk): this is reachable for `const FOO: &&&u32 = &&&42;` being used
             _ => bug!("cannot deref {:#?}, {} -> {}", val, crty, rty),
         }
@@ -777,9 +780,9 @@ fn max_slice_length<'p, 'a: 'p, 'tcx: 'a, I>(
                         max_fixed_len,
                         n.unwrap_usize(cx.tcx),
                     ),
-                    (ConstValue::ScalarPair(_, n), ty::Slice(_)) => max_fixed_len = cmp::max(
+                    (ConstValue::Slice(_, n), ty::Slice(_)) => max_fixed_len = cmp::max(
                         max_fixed_len,
-                        n.to_usize(&cx.tcx).unwrap(),
+                        n,
                     ),
                     _ => {},
                 }
@@ -1414,7 +1417,7 @@ fn slice_pat_covered_by_const<'tcx>(
             alloc.get_bytes(&tcx, ptr, Size::from_bytes(n)).unwrap()
         },
         // a slice fat pointer to a zero length slice
-        (ConstValue::ScalarPair(Scalar::Bits { .. }, n), ty::Slice(t)) => {
+        (ConstValue::Slice(Scalar::Bits { .. }, 0), ty::Slice(t)) => {
             if *t != tcx.types.u8 {
                 // FIXME(oli-obk): can't mix const patterns with slice patterns and get
                 // any sort of exhaustiveness/unreachable check yet
@@ -1422,11 +1425,10 @@ fn slice_pat_covered_by_const<'tcx>(
                 // are definitely unreachable.
                 return Ok(false);
             }
-            assert_eq!(n.to_usize(&tcx).unwrap(), 0);
             &[]
         },
         //
-        (ConstValue::ScalarPair(Scalar::Ptr(ptr), n), ty::Slice(t)) => {
+        (ConstValue::Slice(Scalar::Ptr(ptr), n), ty::Slice(t)) => {
             if *t != tcx.types.u8 {
                 // FIXME(oli-obk): can't mix const patterns with slice patterns and get
                 // any sort of exhaustiveness/unreachable check yet
@@ -1434,7 +1436,6 @@ fn slice_pat_covered_by_const<'tcx>(
                 // are definitely unreachable.
                 return Ok(false);
             }
-            let n = n.to_usize(&tcx).unwrap();
             tcx.alloc_map
                 .lock()
                 .unwrap_memory(ptr.alloc_id)
@@ -1766,12 +1767,12 @@ fn specialize<'p, 'a: 'p, 'tcx: 'a>(
                         },
                         ty::TyKind::Slice(t) => {
                             match value.val {
-                                ConstValue::ScalarPair(ptr, n) => (
+                                ConstValue::Slice(ptr, n) => (
                                     ptr.to_ptr().ok().map(|ptr| (
                                         ptr,
                                         cx.tcx.alloc_map.lock().unwrap_memory(ptr.alloc_id),
                                     )),
-                                    n.to_bits(cx.tcx.data_layout.pointer_size).unwrap() as u64,
+                                    n,
                                     t,
                                 ),
                                 _ => span_bug!(

--- a/src/librustc_mir/hair/pattern/mod.rs
+++ b/src/librustc_mir/hair/pattern/mod.rs
@@ -1218,25 +1218,21 @@ pub fn compare_const_vals<'a, 'gcx, 'tcx>(
     if let ty::Str = ty.value.sty {
         match (a.val, b.val) {
             (
-                ConstValue::ScalarPair(
+                ConstValue::Slice(
                     Scalar::Ptr(ptr_a),
                     len_a,
                 ),
-                ConstValue::ScalarPair(
+                ConstValue::Slice(
                     Scalar::Ptr(ptr_b),
                     len_b,
                 ),
             ) if ptr_a.offset.bytes() == 0 && ptr_b.offset.bytes() == 0 => {
-                if let Ok(len_a) = len_a.to_bits(tcx.data_layout.pointer_size) {
-                    if let Ok(len_b) = len_b.to_bits(tcx.data_layout.pointer_size) {
-                        if len_a == len_b {
-                            let map = tcx.alloc_map.lock();
-                            let alloc_a = map.unwrap_memory(ptr_a.alloc_id);
-                            let alloc_b = map.unwrap_memory(ptr_b.alloc_id);
-                            if alloc_a.bytes.len() as u128 == len_a {
-                                return from_bool(alloc_a == alloc_b);
-                            }
-                        }
+                if len_a == len_b {
+                    let map = tcx.alloc_map.lock();
+                    let alloc_a = map.unwrap_memory(ptr_a.alloc_id);
+                    let alloc_b = map.unwrap_memory(ptr_b.alloc_id);
+                    if alloc_a.bytes.len() as u64 == len_a {
+                        return from_bool(alloc_a == alloc_b);
                     }
                 }
             }

--- a/src/librustc_mir/interpret/operand.rs
+++ b/src/librustc_mir/interpret/operand.rs
@@ -561,10 +561,10 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
                     MemPlace::from_ptr(Pointer::new(id, offset), alloc.align)
                 ).with_default_tag())
             },
-            ConstValue::ScalarPair(a, b) =>
+            ConstValue::Slice(a, b) =>
                 Ok(Operand::Immediate(Immediate::ScalarPair(
                     a.into(),
-                    b.into(),
+                    Scalar::from_uint(b, self.tcx.data_layout.pointer_size).into(),
                 )).with_default_tag()),
             ConstValue::Scalar(x) =>
                 Ok(Operand::Immediate(Immediate::Scalar(x.into())).with_default_tag()),

--- a/src/librustc_mir/monomorphize/collector.rs
+++ b/src/librustc_mir/monomorphize/collector.rs
@@ -1261,12 +1261,7 @@ fn collect_const<'a, 'tcx>(
     debug!("visiting const {:?}", constant);
 
     match constant.val {
-        ConstValue::ScalarPair(Scalar::Ptr(a), Scalar::Ptr(b)) => {
-            collect_miri(tcx, a.alloc_id, output);
-            collect_miri(tcx, b.alloc_id, output);
-        }
-        ConstValue::ScalarPair(_, Scalar::Ptr(ptr)) |
-        ConstValue::ScalarPair(Scalar::Ptr(ptr), _) |
+        ConstValue::Slice(Scalar::Ptr(ptr), _) |
         ConstValue::Scalar(Scalar::Ptr(ptr)) =>
             collect_miri(tcx, ptr.alloc_id, output),
         ConstValue::ByRef(_id, alloc, _offset) => {

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -1536,9 +1536,7 @@ pub struct Resolver<'a> {
     extern_module_map: FxHashMap<(DefId, bool /* MacrosOnly? */), Module<'a>>,
     binding_parent_modules: FxHashMap<PtrKey<'a, NameBinding<'a>>, Module<'a>>,
 
-    pub make_glob_map: bool,
-    /// Maps imports to the names of items actually imported (this actually maps
-    /// all imports, but only glob imports are actually interesting).
+    /// Maps glob imports to the names of items actually imported.
     pub glob_map: GlobMap,
 
     used_imports: FxHashSet<(NodeId, Namespace)>,
@@ -1785,7 +1783,6 @@ impl<'a> Resolver<'a> {
                cstore: &'a CStore,
                krate: &Crate,
                crate_name: &str,
-               make_glob_map: MakeGlobMap,
                crate_loader: &'a mut CrateLoader<'a>,
                arenas: &'a ResolverArenas<'a>)
                -> Resolver<'a> {
@@ -1869,7 +1866,6 @@ impl<'a> Resolver<'a> {
             extern_module_map: FxHashMap::default(),
             binding_parent_modules: FxHashMap::default(),
 
-            make_glob_map: make_glob_map == MakeGlobMap::Yes,
             glob_map: Default::default(),
 
             used_imports: FxHashSet::default(),
@@ -1979,14 +1975,15 @@ impl<'a> Resolver<'a> {
             used.set(true);
             directive.used.set(true);
             self.used_imports.insert((directive.id, ns));
-            self.add_to_glob_map(directive.id, ident);
+            self.add_to_glob_map(&directive, ident);
             self.record_use(ident, ns, binding, false);
         }
     }
 
-    fn add_to_glob_map(&mut self, id: NodeId, ident: Ident) {
-        if self.make_glob_map {
-            self.glob_map.entry(id).or_default().insert(ident.name);
+    #[inline]
+    fn add_to_glob_map(&mut self, directive: &ImportDirective<'_>, ident: Ident) {
+        if directive.is_glob() {
+            self.glob_map.entry(directive.id).or_default().insert(ident.name);
         }
     }
 
@@ -4528,7 +4525,7 @@ impl<'a> Resolver<'a> {
                 let import_id = match binding.kind {
                     NameBindingKind::Import { directive, .. } => {
                         self.maybe_unused_trait_imports.insert(directive.id);
-                        self.add_to_glob_map(directive.id, trait_name);
+                        self.add_to_glob_map(&directive, trait_name);
                         Some(directive.id)
                     }
                     _ => None,
@@ -5230,12 +5227,6 @@ fn module_to_string(module: Module) -> Option<String> {
 
 fn err_path_resolution() -> PathResolution {
     PathResolution::new(Def::Err)
-}
-
-#[derive(PartialEq,Copy, Clone)]
-pub enum MakeGlobMap {
-    Yes,
-    No,
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/src/librustc_save_analysis/dump_visitor.rs
+++ b/src/librustc_save_analysis/dump_visitor.rs
@@ -14,7 +14,7 @@
 //! recording the output.
 
 use rustc::hir::def::Def as HirDef;
-use rustc::hir::def_id::{DefId, LOCAL_CRATE};
+use rustc::hir::def_id::DefId;
 use rustc::session::config::Input;
 use rustc::ty::{self, TyCtxt};
 use rustc_data_structures::fx::FxHashSet;
@@ -56,14 +56,14 @@ macro_rules! access_from {
     ($save_ctxt:expr, $vis:expr, $id:expr) => {
         Access {
             public: $vis.node.is_pub(),
-            reachable: $save_ctxt.tcx.privacy_access_levels(LOCAL_CRATE).is_reachable($id),
+            reachable: $save_ctxt.access_levels.is_reachable($id),
         }
     };
 
     ($save_ctxt:expr, $item:expr) => {
         Access {
             public: $item.vis.node.is_pub(),
-            reachable: $save_ctxt.tcx.privacy_access_levels(LOCAL_CRATE).is_reachable($item.id),
+            reachable: $save_ctxt.access_levels.is_reachable($item.id),
         }
     };
 }

--- a/src/librustc_save_analysis/dump_visitor.rs
+++ b/src/librustc_save_analysis/dump_visitor.rs
@@ -1239,7 +1239,6 @@ impl<'l, 'tcx: 'l, 'll, O: DumpOutput + 'll> DumpVisitor<'l, 'tcx, 'll, O> {
 
                 // Make a comma-separated list of names of imported modules.
                 let glob_map = &self.save_ctxt.analysis.glob_map;
-                let glob_map = glob_map.as_ref().unwrap();
                 let names = if glob_map.contains_key(&id) {
                     glob_map.get(&id).unwrap().iter().map(|n| n.to_string()).collect()
                 } else {

--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -1122,8 +1122,6 @@ pub fn process_crate<'l, 'tcx, H: SaveHandler>(
     mut handler: H,
 ) {
     tcx.dep_graph.with_ignore(|| {
-        assert!(analysis.glob_map.is_some());
-
         info!("Dumping crate {}", cratename);
 
         let save_ctxt = SaveContext {

--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -622,9 +622,11 @@ impl<'l, 'tcx: 'l> SaveContext<'l, 'tcx> {
             Node::Visibility(&Spanned {
                 node: hir::VisibilityKind::Restricted { ref path, .. }, .. }) => path.def,
 
-            Node::PathSegment(seg) => match seg.def {
-                Some(def) => def,
-                None => HirDef::Err,
+            Node::PathSegment(seg) => {
+                match seg.def {
+                    Some(def) if def != HirDef::Err => def,
+                    _ => self.get_path_def(self.tcx.hir().get_parent_node(id)),
+                }
             },
             Node::Expr(&hir::Expr {
                 node: hir::ExprKind::Struct(ref qpath, ..),

--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -35,11 +35,13 @@ use rustc::hir;
 use rustc::hir::def::Def as HirDef;
 use rustc::hir::Node;
 use rustc::hir::def_id::{DefId, LOCAL_CRATE};
+use rustc::middle::privacy::AccessLevels;
 use rustc::middle::cstore::ExternCrate;
 use rustc::session::config::{CrateType, Input, OutputType};
 use rustc::ty::{self, TyCtxt};
 use rustc_typeck::hir_ty_to_ty;
 use rustc_codegen_utils::link::{filename_for_metadata, out_filename};
+use rustc_data_structures::sync::Lrc;
 
 use std::cell::Cell;
 use std::default::Default;
@@ -68,6 +70,7 @@ use rls_data::config::Config;
 pub struct SaveContext<'l, 'tcx: 'l> {
     tcx: TyCtxt<'l, 'tcx, 'tcx>,
     tables: &'l ty::TypeckTables<'tcx>,
+    access_levels: &'l AccessLevels,
     analysis: &'l ty::CrateAnalysis,
     span_utils: SpanUtils<'tcx>,
     config: Config,
@@ -1126,10 +1129,18 @@ pub fn process_crate<'l, 'tcx, H: SaveHandler>(
 
         info!("Dumping crate {}", cratename);
 
+        // Privacy checking requires and is done after type checking; use a
+        // fallback in case the access levels couldn't have been correctly computed.
+        let access_levels = match tcx.sess.compile_status() {
+            Ok(..) => tcx.privacy_access_levels(LOCAL_CRATE),
+            Err(..) => Lrc::new(AccessLevels::default()),
+        };
+
         let save_ctxt = SaveContext {
             tcx,
             tables: &ty::TypeckTables::empty(None),
             analysis,
+            access_levels: &access_levels,
             span_utils: SpanUtils::new(&tcx.sess),
             config: find_config(config),
             impl_counter: Cell::new(0),

--- a/src/librustc_typeck/coherence/orphan.rs
+++ b/src/librustc_typeck/coherence/orphan.rs
@@ -40,7 +40,7 @@ impl<'cx, 'tcx, 'v> ItemLikeVisitor<'v> for OrphanChecker<'cx, 'tcx> {
                                      "only traits defined in the current crate can be \
                                       implemented for arbitrary types")
                         .span_label(sp, "impl doesn't use types inside crate")
-                        .note("the impl does not reference any types defined in this crate")
+                        .note("the impl does not reference only types defined in this crate")
                         .note("define and implement a trait or new type instead")
                         .emit();
                     return;

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -451,7 +451,6 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
                                                         None,
                                                         &name,
                                                         None,
-                                                        resolve::MakeGlobMap::No,
                                                         &resolver_arenas,
                                                         &mut crate_loader,
                                                         |_| Ok(()));
@@ -476,7 +475,7 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
             }).collect(),
         };
         let analysis = ty::CrateAnalysis {
-            glob_map: if resolver.make_glob_map { Some(resolver.glob_map.clone()) } else { None },
+            glob_map: resolver.glob_map.clone(),
         };
 
         let mut arenas = AllArenas::new();

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -6,7 +6,6 @@ use rustc_driver::{self, driver, target_features, Compilation};
 use rustc_driver::driver::phase_2_configure_and_expand;
 use rustc_metadata::cstore::CStore;
 use rustc_metadata::dynamic_lib::DynamicLibrary;
-use rustc_resolve::MakeGlobMap;
 use rustc::hir;
 use rustc::hir::intravisit;
 use rustc::session::{self, CompileIncomplete, config};
@@ -100,7 +99,6 @@ pub fn run(mut options: Options) -> isize {
                 None,
                 "rustdoc-test",
                 None,
-                MakeGlobMap::No,
                 |_| Ok(()),
             ).expect("phase_2_configure_and_expand aborted in rustdoc!")
         };

--- a/src/libstd/sys/windows/process.rs
+++ b/src/libstd/sys/windows/process.rs
@@ -393,7 +393,16 @@ impl From<c::DWORD> for ExitStatus {
 
 impl fmt::Display for ExitStatus {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "exit code: {}", self.0)
+        // Windows exit codes with the high bit set typically mean some form of
+        // unhandled exception or warning. In this scenario printing the exit
+        // code in decimal doesn't always make sense because it's a very large
+        // and somewhat gibberish number. The hex code is a bit more
+        // recognizable and easier to search for, so print that.
+        if self.0 & 0x80000000 != 0 {
+            write!(f, "exit code: {:#x}", self.0)
+        } else {
+            write!(f, "exit code: {}", self.0)
+        }
     }
 }
 

--- a/src/libsyntax/ext/tt/macro_parser.rs
+++ b/src/libsyntax/ext/tt/macro_parser.rs
@@ -271,7 +271,7 @@ pub enum ParseResult<T> {
     Success(T),
     /// Arm failed to match. If the second parameter is `token::Eof`, it indicates an unexpected
     /// end of macro invocation. Otherwise, it indicates that no rules expected the given token.
-    Failure(syntax_pos::Span, Token, String),
+    Failure(syntax_pos::Span, Token, &'static str),
     /// Fatal error (malformed macro?). Abort compilation.
     Error(syntax_pos::Span, String),
 }
@@ -721,7 +721,7 @@ pub fn parse(
                         sess.source_map().next_point(parser.span)
                     },
                     token::Eof,
-                    "missing tokens in macro arguments".to_string(),
+                    "missing tokens in macro arguments",
                 );
             }
         }
@@ -760,7 +760,7 @@ pub fn parse(
             return Failure(
                 parser.span,
                 parser.token,
-                "no rules expected this token in macro call".to_string(),
+                "no rules expected this token in macro call",
             );
         }
         // Dump all possible `next_items` into `cur_items` for the next iteration.

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -202,7 +202,7 @@ fn generic_extension<'cx>(cx: &'cx mut ExtCtxt,
     let best_fail_msg = parse_failure_msg(best_fail_tok.expect("ran no matchers"));
     let span = best_fail_spot.substitute_dummy(sp);
     let mut err = cx.struct_span_err(span, &best_fail_msg);
-    err.span_label(span, best_fail_text.unwrap_or(best_fail_msg));
+    err.span_label(span, best_fail_text.unwrap_or(&best_fail_msg));
     if let Some(sp) = def_span {
         if cx.source_map().span_to_filename(sp).is_real() && !sp.is_dummy() {
             err.span_label(cx.source_map().def_span(sp), "when calling this macro");

--- a/src/test/rustdoc-ui/failed-doctest-output.stdout
+++ b/src/test/rustdoc-ui/failed-doctest-output.stdout
@@ -12,7 +12,7 @@ error[E0425]: cannot find value `no` in this scope
 3 | no
   | ^^ not found in this scope
 
-thread '$DIR/failed-doctest-output.rs - OtherStruct (line 17)' panicked at 'couldn't compile the test', src/librustdoc/test.rs:321:13
+thread '$DIR/failed-doctest-output.rs - OtherStruct (line 17)' panicked at 'couldn't compile the test', src/librustdoc/test.rs:319:13
 note: Run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
 
 ---- $DIR/failed-doctest-output.rs - SomeStruct (line 11) stdout ----
@@ -21,7 +21,7 @@ thread '$DIR/failed-doctest-output.rs - SomeStruct (line 11)' panicked at 'test 
 thread 'main' panicked at 'oh no', $DIR/failed-doctest-output.rs:3:1
 note: Run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
 
-', src/librustdoc/test.rs:356:17
+', src/librustdoc/test.rs:354:17
 
 
 failures:

--- a/src/test/rustdoc/auxiliary/pub-extern-crate.rs
+++ b/src/test/rustdoc/auxiliary/pub-extern-crate.rs
@@ -1,0 +1,2 @@
+#![crate_name = "inner"]
+pub struct SomeStruct;

--- a/src/test/rustdoc/pub-extern-crate.rs
+++ b/src/test/rustdoc/pub-extern-crate.rs
@@ -1,0 +1,9 @@
+// aux-build:pub-extern-crate.rs
+
+// @has pub_extern_crate/index.html
+// @!has - '//code' 'pub extern crate inner'
+// @has - '//a/@href' 'inner/index.html'
+// @has pub_extern_crate/inner/index.html
+// @has pub_extern_crate/inner/struct.SomeStruct.html
+#[doc(inline)]
+pub extern crate inner;

--- a/src/test/ui/coherence/coherence-cow.re_a.stderr
+++ b/src/test/ui/coherence/coherence-cow.re_a.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl<T> Remote for Pair<T,Cover<T>> { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence-cow.re_b.stderr
+++ b/src/test/ui/coherence/coherence-cow.re_b.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl<T> Remote for Pair<Cover<T>,T> { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence-cow.re_c.stderr
+++ b/src/test/ui/coherence/coherence-cow.re_c.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl<T,U> Remote for Pair<Cover<T>,U> { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence-fundamental-trait-objects.old.stderr
+++ b/src/test/ui/coherence/coherence-fundamental-trait-objects.old.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Misc for dyn Fundamental<Local> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence-fundamental-trait-objects.re.stderr
+++ b/src/test/ui/coherence/coherence-fundamental-trait-objects.re.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Misc for dyn Fundamental<Local> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence-impls-copy.old.stderr
+++ b/src/test/ui/coherence/coherence-impls-copy.old.stderr
@@ -51,7 +51,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Copy for i32 {}
    | ^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
@@ -60,7 +60,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Copy for (MyType, MyType) {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
@@ -69,7 +69,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Copy for [MyType] {}
    | ^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
@@ -78,7 +78,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Copy for &'static [NotSync] {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error: aborting due to 10 previous errors

--- a/src/test/ui/coherence/coherence-impls-copy.re.stderr
+++ b/src/test/ui/coherence/coherence-impls-copy.re.stderr
@@ -51,7 +51,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Copy for i32 {}
    | ^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
@@ -60,7 +60,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Copy for (MyType, MyType) {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
@@ -69,7 +69,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Copy for [MyType] {}
    | ^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
@@ -78,7 +78,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Copy for &'static [NotSync] {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error: aborting due to 10 previous errors

--- a/src/test/ui/coherence/coherence-impls-send.old.stderr
+++ b/src/test/ui/coherence/coherence-impls-send.old.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | unsafe impl Send for (MyType, MyType) {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error[E0321]: cross-crate traits with a default impl, like `std::marker::Send`, can only be implemented for a struct/enum type, not `&'static NotSync`
@@ -19,7 +19,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | unsafe impl Send for [MyType] {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
@@ -28,7 +28,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | unsafe impl Send for &'static [NotSync] {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error: aborting due to 4 previous errors

--- a/src/test/ui/coherence/coherence-impls-send.re.stderr
+++ b/src/test/ui/coherence/coherence-impls-send.re.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | unsafe impl Send for (MyType, MyType) {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error[E0321]: cross-crate traits with a default impl, like `std::marker::Send`, can only be implemented for a struct/enum type, not `&'static NotSync`
@@ -19,7 +19,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | unsafe impl Send for [MyType] {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
@@ -28,7 +28,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | unsafe impl Send for &'static [NotSync] {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error: aborting due to 4 previous errors

--- a/src/test/ui/coherence/coherence-impls-sized.old.stderr
+++ b/src/test/ui/coherence/coherence-impls-sized.old.stderr
@@ -40,7 +40,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Sized for (MyType, MyType) {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
@@ -49,7 +49,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Sized for [MyType] {}
    | ^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
@@ -58,7 +58,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Sized for &'static [NotSync] {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error: aborting due to 9 previous errors

--- a/src/test/ui/coherence/coherence-impls-sized.re.stderr
+++ b/src/test/ui/coherence/coherence-impls-sized.re.stderr
@@ -40,7 +40,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Sized for (MyType, MyType) {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
@@ -49,7 +49,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Sized for [MyType] {}
    | ^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
@@ -58,7 +58,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Sized for &'static [NotSync] {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error: aborting due to 9 previous errors

--- a/src/test/ui/coherence/coherence-orphan.old.stderr
+++ b/src/test/ui/coherence/coherence-orphan.old.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl TheTrait<usize> for isize { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
@@ -13,7 +13,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl !Send for Vec<isize> { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/coherence/coherence-orphan.re.stderr
+++ b/src/test/ui/coherence/coherence-orphan.re.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl TheTrait<usize> for isize { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
@@ -13,7 +13,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl !Send for Vec<isize> { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/coherence/coherence-overlapping-pairs.re.stderr
+++ b/src/test/ui/coherence/coherence-overlapping-pairs.re.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl<T> Remote for lib::Pair<T,Foo> { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence-pair-covered-uncovered-1.re.stderr
+++ b/src/test/ui/coherence/coherence-pair-covered-uncovered-1.re.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl<T, U> Remote1<Pair<T, Local<U>>> for i32 { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence-pair-covered-uncovered.re.stderr
+++ b/src/test/ui/coherence/coherence-pair-covered-uncovered.re.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl<T,U> Remote for Pair<T,Local<U>> { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence-vec-local-2.re.stderr
+++ b/src/test/ui/coherence/coherence-vec-local-2.re.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl<T> Remote for Vec<Local<T>> { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence-vec-local.old.stderr
+++ b/src/test/ui/coherence/coherence-vec-local.old.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Remote for Vec<Local> { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence-vec-local.re.stderr
+++ b/src/test/ui/coherence/coherence-vec-local.re.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Remote for Vec<Local> { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence_local_err_struct.old.stderr
+++ b/src/test/ui/coherence/coherence_local_err_struct.old.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl lib::MyCopy for lib::MyStruct<MyType> { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence_local_err_struct.re.stderr
+++ b/src/test/ui/coherence/coherence_local_err_struct.re.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl lib::MyCopy for lib::MyStruct<MyType> { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence_local_err_tuple.old.stderr
+++ b/src/test/ui/coherence/coherence_local_err_tuple.old.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl lib::MyCopy for (MyType,) { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence_local_err_tuple.re.stderr
+++ b/src/test/ui/coherence/coherence_local_err_tuple.re.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl lib::MyCopy for (MyType,) { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/dropck/drop-on-non-struct.stderr
+++ b/src/test/ui/dropck/drop-on-non-struct.stderr
@@ -10,7 +10,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl<'a> Drop for &'a mut isize {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/error-codes/E0117.stderr
+++ b/src/test/ui/error-codes/E0117.stderr
@@ -10,7 +10,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Drop for u32 {} //~ ERROR E0117
    | ^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/error-codes/E0206.stderr
+++ b/src/test/ui/error-codes/E0206.stderr
@@ -16,7 +16,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Copy for Foo { }
    | ^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/typeck/typeck-default-trait-impl-cross-crate-coherence.stderr
+++ b/src/test/ui/typeck/typeck-default-trait-impl-cross-crate-coherence.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl DefaultedTrait for (A,) { } //~ ERROR E0117
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
@@ -13,7 +13,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl !DefaultedTrait for (B,) { } //~ ERROR E0117
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error[E0321]: cross-crate traits with a default impl, like `lib::DefaultedTrait`, can only be implemented for a struct/enum type defined in the current crate
@@ -28,7 +28,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl DefaultedTrait for lib::Something<C> { } //~ ERROR E0117
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error: aborting due to 4 previous errors


### PR DESCRIPTION
Successful merges:

 - #57351 (Don't actually create a full MIR stack frame when not needed)
 - #57353 (Optimise floating point `is_finite` (2x) and `is_infinite` (1.6x).)
 - #57392 (Always calculate glob map but only for glob uses)
 - #57412 (Improve the wording)
 - #57436 (save-analysis: use a fallback when access levels couldn't be computed)
 - #57442 (Simplify `ConstValue::ScalarPair`)
 - #57453 (lldb_batchmode.py: try `import _thread` for Python 3)
 - #57454 (Some cleanups for core::fmt)
 - #57461 (Change `String` to `&'static str` in `ParseResult::Failure`.)
 - #57473 (std: Render large exit codes as hex on Windows)
 - #57474 (save-analysis: Get path def from parent in case there's no def for the path itself.)
 - #57494 (Speed up item_bodies for large match statements involving regions)
 - #57496 (re-do docs for core::cmp)
 - #57508 (rustdoc: Allow inlining of reexported crates and crate items)
 - #57547 (Use `ptr::eq` where applicable)

Failed merges:


r? @ghost