### PR TITLE
Update the const fn tracking issue to the new metabug

### DIFF
--- a/src/doc/unstable-book/src/language-features/const-fn.md
+++ b/src/doc/unstable-book/src/language-features/const-fn.md
@@ -1,8 +1,8 @@
 # `const_fn`
 
-The tracking issue for this feature is: [#24111]
+The tracking issue for this feature is: [#57563]
 
-[#24111]: https://github.com/rust-lang/rust/issues/24111
+[#57563]: https://github.com/rust-lang/rust/issues/57563
 
 ------------------------
 

--- a/src/librustc_mir/diagnostics.rs
+++ b/src/librustc_mir/diagnostics.rs
@@ -573,7 +573,7 @@ const Y: i32 = A;
 ```
 "##,
 
-// FIXME(#24111) Change the language here when const fn stabilizes
+// FIXME(#57563) Change the language here when const fn stabilizes
 E0015: r##"
 The only functions that can be called in static or constant expressions are
 `const` functions, and struct/enum constructors. `const` functions are only

--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -901,7 +901,7 @@ impl<'a, 'tcx> Visitor<'tcx> for Qualifier<'a, 'tcx, 'tcx> {
                                         err.emit();
                                     }
                                 } else {
-                                    // FIXME(#24111): remove this check when const fn stabilizes.
+                                    // FIXME(#57563): remove this check when const fn stabilizes.
                                     let (msg, note) = if let UnstableFeatures::Disallow =
                                             self.tcx.sess.opts.unstable_features {
                                         (format!("calls in {}s are limited to \

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -191,7 +191,7 @@ declare_features! (
     (active, slice_patterns, "1.0.0", Some(23121), None),
 
     // Allows the definition of `const` functions with some advanced features.
-    (active, const_fn, "1.2.0", Some(24111), None),
+    (active, const_fn, "1.2.0", Some(57563), None),
 
     // Allows accessing fields of unions inside `const` functions.
     (active, const_fn_union, "1.27.0", Some(51909), None),

--- a/src/test/ui/feature-gates/feature-gate-const_fn.stderr
+++ b/src/test/ui/feature-gates/feature-gate-const_fn.stderr
@@ -16,7 +16,7 @@ error[E0379]: trait fns cannot be declared const
 LL |     const fn foo() -> u32 { 0 } //~ ERROR trait fns cannot be declared const
    |     ^^^^^ trait fns cannot be const
 
-error[E0658]: const fn is unstable (see issue #24111)
+error[E0658]: const fn is unstable (see issue #57563)
   --> $DIR/feature-gate-const_fn.rs:6:5
    |
 LL |     const fn foo() -> u32; //~ ERROR const fn is unstable
@@ -24,7 +24,7 @@ LL |     const fn foo() -> u32; //~ ERROR const fn is unstable
    |
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0658]: const fn is unstable (see issue #24111)
+error[E0658]: const fn is unstable (see issue #57563)
   --> $DIR/feature-gate-const_fn.rs:8:5
    |
 LL |     const fn bar() -> u32 { 0 } //~ ERROR const fn is unstable

--- a/src/test/ui/feature-gates/feature-gate-min_const_fn.stderr
+++ b/src/test/ui/feature-gates/feature-gate-min_const_fn.stderr
@@ -16,7 +16,7 @@ error[E0379]: trait fns cannot be declared const
 LL |     const fn foo() -> u32 { 0 } //~ ERROR trait fns cannot be declared const
    |     ^^^^^ trait fns cannot be const
 
-error[E0658]: const fn is unstable (see issue #24111)
+error[E0658]: const fn is unstable (see issue #57563)
   --> $DIR/feature-gate-min_const_fn.rs:6:5
    |
 LL |     const fn foo() -> u32; //~ ERROR const fn is unstable
@@ -24,7 +24,7 @@ LL |     const fn foo() -> u32; //~ ERROR const fn is unstable
    |
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0658]: const fn is unstable (see issue #24111)
+error[E0658]: const fn is unstable (see issue #57563)
   --> $DIR/feature-gate-min_const_fn.rs:8:5
    |
 LL |     const fn bar() -> u32 { 0 } //~ ERROR const fn is unstable

--- a/src/tools/tidy/src/features.rs
+++ b/src/tools/tidy/src/features.rs
@@ -336,12 +336,11 @@ fn map_lib_features(base_src_path: &Path,
                     level: Status::Unstable,
                     since: "None".to_owned(),
                     has_gate_test: false,
-                    // Whether there is a common tracking issue
-                    // for these feature gates remains an open question
-                    // https://github.com/rust-lang/rust/issues/24111#issuecomment-340283184
-                    // But we take 24111 otherwise they will be shown as
-                    // "internal to the compiler" which they are not.
-                    tracking_issue: Some(24111),
+                    // FIXME(#57563): #57563 is now used as a common tracking issue,
+                    // although we would like to have specific tracking
+                    // issues for each `rustc_const_unstable` in the
+                    // future.
+                    tracking_issue: Some(57563),
                 };
                 mf(Ok((feature_name, feature)), file, i + 1);
                 continue;


### PR DESCRIPTION
The new `const fn` tracking issue is #57563. We don't want to point to a closed issue in the diagnostics (or FIXMEs), so these have been updated (from the old issue, #24111).

r? @Centril