### PR TITLE
Stabilize `transpose_result` in 1.33

### DIFF
--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -1013,8 +1013,6 @@ impl<T, E> Option<Result<T, E>> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(transpose_result)]
-    ///
     /// #[derive(Debug, Eq, PartialEq)]
     /// struct SomeErr;
     ///
@@ -1023,7 +1021,7 @@ impl<T, E> Option<Result<T, E>> {
     /// assert_eq!(x, y.transpose());
     /// ```
     #[inline]
-    #[unstable(feature = "transpose_result", issue = "47338")]
+    #[stable(feature = "transpose_result", since = "1.33.0")]
     pub fn transpose(self) -> Result<Option<T>, E> {
         match self {
             Some(Ok(x)) => Ok(Some(x)),

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -972,8 +972,6 @@ impl<T, E> Result<Option<T>, E> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(transpose_result)]
-    ///
     /// #[derive(Debug, Eq, PartialEq)]
     /// struct SomeErr;
     ///
@@ -982,7 +980,7 @@ impl<T, E> Result<Option<T>, E> {
     /// assert_eq!(x.transpose(), y);
     /// ```
     #[inline]
-    #[unstable(feature = "transpose_result", issue = "47338")]
+    #[stable(feature = "transpose_result", since = "1.33.0")]
     pub fn transpose(self) -> Option<Result<T, E>> {
         match self {
             Ok(Some(x)) => Some(Ok(x)),

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -60,7 +60,6 @@
 #![feature(test)]
 #![feature(in_band_lifetimes)]
 #![feature(crate_visibility_modifier)]
-#![feature(transpose_result)]
 
 #![recursion_limit="512"]
 

--- a/src/test/run-pass/result-opt-conversions.rs
+++ b/src/test/run-pass/result-opt-conversions.rs
@@ -1,5 +1,3 @@
-#![feature(transpose_result)]
-
 #[derive(Copy, Clone, Debug, PartialEq)]
 struct BadNumErr;
 


### PR DESCRIPTION
fixes https://github.com/rust-lang/rust/issues/47338.

FCP completed: https://github.com/rust-lang/rust/issues/47338#issuecomment-453762236

r? @alexreg 