### PR TITLE
Querify local `plugin_registrar_fn` and `proc_macro_decls_static`

### DIFF
--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -70,7 +70,6 @@ pub struct Session {
     /// For a library crate, this is always none
     pub entry_fn: Once<Option<(NodeId, Span, config::EntryFnType)>>,
     pub plugin_registrar_fn: Once<Option<ast::NodeId>>,
-    pub proc_macro_decls_static: Once<Option<ast::NodeId>>,
     pub sysroot: PathBuf,
     /// The name of the root source file of the crate, in the local file system.
     /// `None` means that there is no source file.
@@ -1175,7 +1174,6 @@ pub fn build_session_(
         // For a library crate, this is always none
         entry_fn: Once::new(),
         plugin_registrar_fn: Once::new(),
-        proc_macro_decls_static: Once::new(),
         sysroot,
         local_crate_source_file,
         working_dir,

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -69,7 +69,6 @@ pub struct Session {
     pub parse_sess: ParseSess,
     /// For a library crate, this is always none
     pub entry_fn: Once<Option<(NodeId, Span, config::EntryFnType)>>,
-    pub plugin_registrar_fn: Once<Option<ast::NodeId>>,
     pub sysroot: PathBuf,
     /// The name of the root source file of the crate, in the local file system.
     /// `None` means that there is no source file.
@@ -1173,7 +1172,6 @@ pub fn build_session_(
         parse_sess: p_s,
         // For a library crate, this is always none
         entry_fn: Once::new(),
-        plugin_registrar_fn: Once::new(),
         sysroot,
         local_crate_source_file,
         working_dir,

--- a/src/librustc_codegen_ssa/back/symbol_export.rs
+++ b/src/librustc_codegen_ssa/back/symbol_export.rs
@@ -147,9 +147,8 @@ fn reachable_non_generics_provider<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         })
         .collect();
 
-    if let Some(id) = *tcx.sess.proc_macro_decls_static.get() {
-        let def_id = tcx.hir().local_def_id(id);
-        reachable_non_generics.insert(def_id, SymbolExportLevel::C);
+    if let Some(id) = tcx.proc_macro_decls_static(LOCAL_CRATE) {
+        reachable_non_generics.insert(id, SymbolExportLevel::C);
     }
 
     if let Some(id) = *tcx.sess.plugin_registrar_fn.get() {

--- a/src/librustc_codegen_ssa/back/symbol_export.rs
+++ b/src/librustc_codegen_ssa/back/symbol_export.rs
@@ -151,9 +151,8 @@ fn reachable_non_generics_provider<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         reachable_non_generics.insert(id, SymbolExportLevel::C);
     }
 
-    if let Some(id) = *tcx.sess.plugin_registrar_fn.get() {
-        let def_id = tcx.hir().local_def_id(id);
-        reachable_non_generics.insert(def_id, SymbolExportLevel::C);
+    if let Some(id) = tcx.plugin_registrar_fn(LOCAL_CRATE) {
+        reachable_non_generics.insert(id, SymbolExportLevel::C);
     }
 
     Lrc::new(reachable_non_generics)

--- a/src/librustc_codegen_utils/symbol_names.rs
+++ b/src/librustc_codegen_utils/symbol_names.rs
@@ -247,7 +247,7 @@ fn compute_symbol_name<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, instance: Instance
             let disambiguator = tcx.sess.local_crate_disambiguator();
             return tcx.sess.generate_plugin_registrar_symbol(disambiguator);
         }
-        if *tcx.sess.proc_macro_decls_static.get() == Some(id) {
+        if tcx.proc_macro_decls_static(LOCAL_CRATE) == Some(def_id) {
             let disambiguator = tcx.sess.local_crate_disambiguator();
             return tcx.sess.generate_proc_macro_decls_symbol(disambiguator);
         }

--- a/src/librustc_codegen_utils/symbol_names.rs
+++ b/src/librustc_codegen_utils/symbol_names.rs
@@ -242,8 +242,8 @@ fn compute_symbol_name<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, instance: Instance
 
     let node_id = tcx.hir().as_local_node_id(def_id);
 
-    if let Some(id) = node_id {
-        if *tcx.sess.plugin_registrar_fn.get() == Some(id) {
+    if def_id.is_local() {
+        if tcx.plugin_registrar_fn(LOCAL_CRATE) == Some(def_id) {
             let disambiguator = tcx.sess.local_crate_disambiguator();
             return tcx.sess.generate_plugin_registrar_symbol(disambiguator);
         }

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -1158,6 +1158,7 @@ where
 }
 
 pub fn default_provide(providers: &mut ty::query::Providers) {
+    proc_macro_decls::provide(providers);
     hir::provide(providers);
     borrowck::provide(providers);
     mir::provide(providers);
@@ -1216,8 +1217,6 @@ where
         .set(time(sess, "looking for plugin registrar", || {
             plugin::build::find_plugin_registrar(sess.diagnostic(), &hir_map)
         }));
-    sess.proc_macro_decls_static
-        .set(proc_macro_decls::find(&hir_map));
 
     let mut local_providers = ty::query::Providers::default();
     default_provide(&mut local_providers);
@@ -1249,6 +1248,10 @@ where
             time(sess, "dep graph tcx init", || rustc_incremental::dep_graph_tcx_init(tcx));
 
             time(sess, "loop checking", || loops::check_crate(tcx));
+
+            time(sess, "looking for derive registrar", || {
+                proc_macro_decls::find(tcx)
+            });
 
             time(sess, "attribute checking", || {
                 hir::check_attr::check_crate(tcx)

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -1243,8 +1243,6 @@ where
             // tcx available.
             time(sess, "dep graph tcx init", || rustc_incremental::dep_graph_tcx_init(tcx));
 
-            time(sess, "loop checking", || loops::check_crate(tcx));
-
             time(sess, "looking for plugin registrar", || {
                 plugin::build::find_plugin_registrar(tcx)
             });
@@ -1252,6 +1250,8 @@ where
             time(sess, "looking for derive registrar", || {
                 proc_macro_decls::find(tcx)
             });
+
+            time(sess, "loop checking", || loops::check_crate(tcx));
 
             time(sess, "attribute checking", || {
                 hir::check_attr::check_crate(tcx)

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -19,7 +19,7 @@
 //! a `pub fn new()`.
 
 use rustc::hir::def::Def;
-use rustc::hir::def_id::DefId;
+use rustc::hir::def_id::{DefId, LOCAL_CRATE};
 use rustc::ty::{self, Ty};
 use hir::Node;
 use util::nodemap::NodeSet;
@@ -860,7 +860,7 @@ impl LintPass for PluginAsLibrary {
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for PluginAsLibrary {
     fn check_item(&mut self, cx: &LateContext, it: &hir::Item) {
-        if cx.sess().plugin_registrar_fn.get().is_some() {
+        if cx.tcx.plugin_registrar_fn(LOCAL_CRATE).is_some() {
             // We're compiling a plugin; it's fine to link other plugins.
             return;
         }

--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -482,10 +482,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
             has_global_allocator: has_global_allocator,
             has_panic_handler: has_panic_handler,
             has_default_lib_allocator: has_default_lib_allocator,
-            plugin_registrar_fn: tcx.sess
-                .plugin_registrar_fn
-                .get()
-                .map(|id| tcx.hir().local_def_id(id).index),
+            plugin_registrar_fn: tcx.plugin_registrar_fn(LOCAL_CRATE).map(|id| id.index),
             proc_macro_decls_static: if is_proc_macro {
                 let id = tcx.proc_macro_decls_static(LOCAL_CRATE).unwrap();
                 Some(id.index)

--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -487,8 +487,8 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
                 .get()
                 .map(|id| tcx.hir().local_def_id(id).index),
             proc_macro_decls_static: if is_proc_macro {
-                let id = tcx.sess.proc_macro_decls_static.get().unwrap();
-                Some(tcx.hir().local_def_id(id).index)
+                let id = tcx.proc_macro_decls_static(LOCAL_CRATE).unwrap();
+                Some(id.index)
             } else {
                 None
             },


### PR DESCRIPTION
Instead of calculating them as part of the `Session`, we do that in the query system.
It's also nice that these queries are already defined for external crates - here, we provide the queries for the local crate.

r? @nikomatsakis 