### PR TITLE
[WIP] HirId-ification

### DIFF
--- a/src/librustc/hir/check_attr.rs
+++ b/src/librustc/hir/check_attr.rs
@@ -95,7 +95,8 @@ impl<'a, 'tcx> CheckAttrVisitor<'a, 'tcx> {
     /// Check any attribute.
     fn check_attributes(&self, item: &hir::Item, target: Target) {
         if target == Target::Fn || target == Target::Const {
-            self.tcx.codegen_fn_attrs(self.tcx.hir().local_def_id(item.id));
+            let def_id = self.tcx.hir().local_def_id_from_hir_id(item.hir_id);
+            self.tcx.codegen_fn_attrs(def_id);
         } else if let Some(a) = item.attrs.iter().find(|a| a.check_name("target_feature")) {
             self.tcx.sess.struct_span_err(a.span, "attribute should be applied to a function")
                 .span_label(item.span, "not a function")
@@ -283,7 +284,7 @@ impl<'a, 'tcx> CheckAttrVisitor<'a, 'tcx> {
 
     fn check_stmt_attributes(&self, stmt: &hir::Stmt) {
         // When checking statements ignore expressions, they will be checked later
-        if let hir::StmtKind::Decl(_, _) = stmt.node {
+        if let hir::StmtKind::Decl(_, ..) = stmt.node {
             for attr in stmt.node.attrs() {
                 if attr.check_name("inline") {
                     self.check_inline(attr, &stmt.span, Target::Statement);

--- a/src/librustc/hir/def.rs
+++ b/src/librustc/hir/def.rs
@@ -65,10 +65,10 @@ pub enum Def {
     Method(DefId),
     AssociatedConst(DefId),
 
-    Local(ast::NodeId),
-    Upvar(ast::NodeId,  // `NodeId` of closed over local
-          usize,        // index in the `freevars` list of the closure
-          ast::NodeId), // expr node that creates the closure
+    Local(hir::HirId),
+    Upvar(hir::HirId,  // `HirId` of closed over local
+          usize,       // index in the `freevars` list of the closure
+          hir::HirId), // expr node that creates the closure
     Label(ast::NodeId),
 
     // Macro namespace

--- a/src/librustc/hir/map/blocks.rs
+++ b/src/librustc/hir/map/blocks.rs
@@ -13,9 +13,9 @@
 
 use hir as ast;
 use hir::map;
-use hir::{Expr, FnDecl, Node};
+use hir::{Expr, FnDecl, HirId, Node};
 use hir::intravisit::FnKind;
-use syntax::ast::{Attribute, Ident, NodeId};
+use syntax::ast::{Attribute, Ident};
 use syntax_pos::Span;
 
 /// An FnLikeNode is a Node that is like a fn, in that it has a decl
@@ -75,16 +75,16 @@ pub enum Code<'a> {
 }
 
 impl<'a> Code<'a> {
-    pub fn id(&self) -> NodeId {
+    pub fn id(&self) -> HirId {
         match *self {
             Code::FnLike(node) => node.id(),
-            Code::Expr(block) => block.id,
+            Code::Expr(block) => block.hir_id,
         }
     }
 
     /// Attempts to construct a Code from presumed FnLike or Expr node input.
-    pub fn from_node(map: &map::Map<'a>, id: NodeId) -> Option<Code<'a>> {
-        match map.get(id) {
+    pub fn from_node(map: &map::Map<'a>, id: HirId) -> Option<Code<'a>> {
+        match map.get_by_hir_id(id) {
             map::Node::Block(_) => {
                 //  Use the parent, hopefully an expression node.
                 Code::from_node(map, map.get_parent_node(id))
@@ -104,7 +104,7 @@ struct ItemFnParts<'a> {
     vis:      &'a ast::Visibility,
     generics: &'a ast::Generics,
     body:     ast::BodyId,
-    id:       NodeId,
+    id:       HirId,
     span:     Span,
     attrs:    &'a [Attribute],
 }
@@ -114,13 +114,13 @@ struct ItemFnParts<'a> {
 struct ClosureParts<'a> {
     decl: &'a FnDecl,
     body: ast::BodyId,
-    id: NodeId,
+    id: HirId,
     span: Span,
     attrs: &'a [Attribute],
 }
 
 impl<'a> ClosureParts<'a> {
-    fn new(d: &'a FnDecl, b: ast::BodyId, id: NodeId, s: Span, attrs: &'a [Attribute]) -> Self {
+    fn new(d: &'a FnDecl, b: ast::BodyId, id: HirId, s: Span, attrs: &'a [Attribute]) -> Self {
         ClosureParts {
             decl: d,
             body: b,
@@ -168,7 +168,7 @@ impl<'a> FnLikeNode<'a> {
                     |c: ClosureParts<'_>| c.span)
     }
 
-    pub fn id(self) -> NodeId {
+    pub fn id(self) -> HirId {
         self.handle(|i: ItemFnParts<'_>| i.id,
                     |id, _, _: &'a ast::MethodSig, _, _, _, _| id,
                     |c: ClosureParts<'_>| c.id)
@@ -213,7 +213,7 @@ impl<'a> FnLikeNode<'a> {
 
     fn handle<A, I, M, C>(self, item_fn: I, method: M, closure: C) -> A where
         I: FnOnce(ItemFnParts<'a>) -> A,
-        M: FnOnce(NodeId,
+        M: FnOnce(HirId,
                   Ident,
                   &'a ast::MethodSig,
                   Option<&'a ast::Visibility>,
@@ -227,7 +227,7 @@ impl<'a> FnLikeNode<'a> {
             map::Node::Item(i) => match i.node {
                 ast::ItemKind::Fn(ref decl, header, ref generics, block) =>
                     item_fn(ItemFnParts {
-                        id: i.id,
+                        id: i.hir_id,
                         ident: i.ident,
                         decl: &decl,
                         body: block,
@@ -241,21 +241,21 @@ impl<'a> FnLikeNode<'a> {
             },
             map::Node::TraitItem(ti) => match ti.node {
                 ast::TraitItemKind::Method(ref sig, ast::TraitMethod::Provided(body)) => {
-                    method(ti.id, ti.ident, sig, None, body, ti.span, &ti.attrs)
+                    method(ti.hir_id, ti.ident, sig, None, body, ti.span, &ti.attrs)
                 }
                 _ => bug!("trait method FnLikeNode that is not fn-like"),
             },
             map::Node::ImplItem(ii) => {
                 match ii.node {
                     ast::ImplItemKind::Method(ref sig, body) => {
-                        method(ii.id, ii.ident, sig, Some(&ii.vis), body, ii.span, &ii.attrs)
+                        method(ii.hir_id, ii.ident, sig, Some(&ii.vis), body, ii.span, &ii.attrs)
                     }
                     _ => bug!("impl method FnLikeNode that is not fn-like")
                 }
             },
             map::Node::Expr(e) => match e.node {
                 ast::ExprKind::Closure(_, ref decl, block, _fn_decl_span, _gen) =>
-                    closure(ClosureParts::new(&decl, block, e.id, e.span, &e.attrs)),
+                    closure(ClosureParts::new(&decl, block, e.hir_id, e.span, &e.attrs)),
                 _ => bug!("expr FnLikeNode that is not fn-like"),
             },
             _ => bug!("other FnLikeNode that is not fn-like"),

--- a/src/librustc/hir/map/definitions.rs
+++ b/src/librustc/hir/map/definitions.rs
@@ -450,6 +450,16 @@ impl Definitions {
     }
 
     #[inline]
+    pub fn local_def_id_from_hir_id(&self, node: hir::HirId) -> DefId {
+        for (node_id, hir_id) in self.node_to_hir_id.iter_enumerated() {
+            if node == *hir_id {
+                return self.local_def_id(node_id);
+            }
+        }
+        unreachable!()
+    }
+
+    #[inline]
     pub fn as_local_node_id(&self, def_id: DefId) -> Option<ast::NodeId> {
         if def_id.krate == LOCAL_CRATE {
             let space_index = def_id.index.address_space().index();
@@ -457,6 +467,20 @@ impl Definitions {
             let node_id = self.def_index_to_node[space_index][array_index];
             if node_id != ast::DUMMY_NODE_ID {
                 Some(node_id)
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    pub fn as_local_hir_id(&self, def_id: DefId) -> Option<hir::HirId> {
+        if def_id.krate == LOCAL_CRATE {
+            let hir_id = self.def_index_to_hir_id(def_id.index);
+            if hir_id != hir::DUMMY_HIR_ID {
+                Some(hir_id)
             } else {
                 None
             }

--- a/src/librustc/hir/map/hir_id_validator.rs
+++ b/src/librustc/hir/map/hir_id_validator.rs
@@ -30,7 +30,7 @@ pub fn check_crate<'hir>(hir_map: &hir::map::Map<'hir>) {
 struct HirIdValidator<'a, 'hir: 'a> {
     hir_map: &'a hir::map::Map<'hir>,
     owner_def_index: Option<DefIndex>,
-    hir_ids_seen: FxHashMap<ItemLocalId, NodeId>,
+    hir_ids_seen: FxHashMap<ItemLocalId, HirId>,
     errors: &'a Lock<Vec<String>>,
 }
 
@@ -55,17 +55,17 @@ impl<'a, 'hir: 'a> OuterVisitor<'a, 'hir> {
 impl<'a, 'hir: 'a> ItemLikeVisitor<'hir> for OuterVisitor<'a, 'hir> {
     fn visit_item(&mut self, i: &'hir hir::Item) {
         let mut inner_visitor = self.new_inner_visitor(self.hir_map);
-        inner_visitor.check(i.id, |this| intravisit::walk_item(this, i));
+        inner_visitor.check(i.hir_id, |this| intravisit::walk_item(this, i));
     }
 
     fn visit_trait_item(&mut self, i: &'hir hir::TraitItem) {
         let mut inner_visitor = self.new_inner_visitor(self.hir_map);
-        inner_visitor.check(i.id, |this| intravisit::walk_trait_item(this, i));
+        inner_visitor.check(i.hir_id, |this| intravisit::walk_trait_item(this, i));
     }
 
     fn visit_impl_item(&mut self, i: &'hir hir::ImplItem) {
         let mut inner_visitor = self.new_inner_visitor(self.hir_map);
-        inner_visitor.check(i.id, |this| intravisit::walk_impl_item(this, i));
+        inner_visitor.check(i.hir_id, |this| intravisit::walk_impl_item(this, i));
     }
 }
 
@@ -77,10 +77,10 @@ impl<'a, 'hir: 'a> HirIdValidator<'a, 'hir> {
     }
 
     fn check<F: FnOnce(&mut HirIdValidator<'a, 'hir>)>(&mut self,
-                                                       node_id: NodeId,
+                                                       hir_id: HirId,
                                                        walk: F) {
         assert!(self.owner_def_index.is_none());
-        let owner_def_index = self.hir_map.local_def_id(node_id).index;
+        let owner_def_index = self.hir_map.local_def_id_from_hir_id(hir_id).index;
         self.owner_def_index = Some(owner_def_index);
         walk(self);
 
@@ -134,7 +134,7 @@ impl<'a, 'hir: 'a> HirIdValidator<'a, 'hir> {
                 missing_items,
                 self.hir_ids_seen
                     .values()
-                    .map(|n| format!("({:?} {})", n, self.hir_map.node_to_string(*n)))
+                    .map(|n| format!("({:?} {})", n, self.hir_map.hir_to_string(*n)))
                     .collect::<Vec<_>>()));
         }
     }
@@ -147,33 +147,31 @@ impl<'a, 'hir: 'a> intravisit::Visitor<'hir> for HirIdValidator<'a, 'hir> {
         intravisit::NestedVisitorMap::OnlyBodies(self.hir_map)
     }
 
-    fn visit_id(&mut self, node_id: NodeId) {
+    fn visit_id(&mut self, hir_id: HirId) {
         let owner = self.owner_def_index.expect("no owner_def_index");
-        let stable_id = self.hir_map.definitions().node_to_hir_id[node_id];
 
-        if stable_id == hir::DUMMY_HIR_ID {
-            self.error(|| format!("HirIdValidator: No HirId assigned for NodeId {}: {:?}",
-                                     node_id,
-                                     self.hir_map.node_to_string(node_id)));
+        if hir_id == hir::DUMMY_HIR_ID {
+            self.error(|| format!("HirIdValidator: HirId {:?} is invalid",
+                                  self.hir_map.hir_to_string(hir_id)));
             return;
         }
 
-        if owner != stable_id.owner {
+        if owner != hir_id.owner {
             self.error(|| format!(
                 "HirIdValidator: The recorded owner of {} is {} instead of {}",
-                self.hir_map.node_to_string(node_id),
-                self.hir_map.def_path(DefId::local(stable_id.owner)).to_string_no_crate(),
+                self.hir_map.hir_to_string(hir_id),
+                self.hir_map.def_path(DefId::local(hir_id.owner)).to_string_no_crate(),
                 self.hir_map.def_path(DefId::local(owner)).to_string_no_crate()));
         }
 
-        if let Some(prev) = self.hir_ids_seen.insert(stable_id.local_id, node_id) {
-            if prev != node_id {
+        if let Some(prev) = self.hir_ids_seen.insert(hir_id.local_id, hir_id) {
+            if prev != hir_id {
                 self.error(|| format!(
                     "HirIdValidator: Same HirId {}/{} assigned for nodes {} and {}",
-                    self.hir_map.def_path(DefId::local(stable_id.owner)).to_string_no_crate(),
-                    stable_id.local_id.as_usize(),
-                    self.hir_map.node_to_string(prev),
-                    self.hir_map.node_to_string(node_id)));
+                    self.hir_map.def_path(DefId::local(hir_id.owner)).to_string_no_crate(),
+                    hir_id.local_id.as_usize(),
+                    self.hir_map.hir_to_string(prev),
+                    self.hir_map.hir_to_string(hir_id)));
             }
         }
     }

--- a/src/librustc/hir/print.rs
+++ b/src/librustc/hir/print.rs
@@ -25,7 +25,7 @@ pub enum AnnNode<'a> {
     Name(&'a ast::Name),
     Block(&'a hir::Block),
     Item(&'a hir::Item),
-    SubItem(ast::NodeId),
+    SubItem(hir::HirId),
     Expr(&'a hir::Expr),
     Pat(&'a hir::Pat),
 }
@@ -924,7 +924,7 @@ impl<'a> State<'a> {
     }
 
     pub fn print_trait_item(&mut self, ti: &hir::TraitItem) -> io::Result<()> {
-        self.ann.pre(self, AnnNode::SubItem(ti.id))?;
+        self.ann.pre(self, AnnNode::SubItem(ti.hir_id))?;
         self.hardbreak_if_not_bol()?;
         self.maybe_print_comment(ti.span.lo())?;
         self.print_outer_attributes(&ti.attrs)?;
@@ -956,11 +956,11 @@ impl<'a> State<'a> {
                                            default.as_ref().map(|ty| &**ty))?;
             }
         }
-        self.ann.post(self, AnnNode::SubItem(ti.id))
+        self.ann.post(self, AnnNode::SubItem(ti.hir_id))
     }
 
     pub fn print_impl_item(&mut self, ii: &hir::ImplItem) -> io::Result<()> {
-        self.ann.pre(self, AnnNode::SubItem(ii.id))?;
+        self.ann.pre(self, AnnNode::SubItem(ii.hir_id))?;
         self.hardbreak_if_not_bol()?;
         self.maybe_print_comment(ii.span.lo())?;
         self.print_outer_attributes(&ii.attrs)?;
@@ -986,7 +986,7 @@ impl<'a> State<'a> {
                 self.print_associated_type(ii.ident, Some(bounds), None)?;
             }
         }
-        self.ann.post(self, AnnNode::SubItem(ii.id))
+        self.ann.post(self, AnnNode::SubItem(ii.hir_id))
     }
 
     pub fn print_stmt(&mut self, st: &hir::Stmt) -> io::Result<()> {
@@ -2254,7 +2254,7 @@ impl<'a> State<'a> {
         let generics = hir::Generics {
             params: hir::HirVec::new(),
             where_clause: hir::WhereClause {
-                id: ast::DUMMY_NODE_ID,
+                hir_id: hir::DUMMY_HIR_ID,
                 predicates: hir::HirVec::new(),
             },
             span: syntax_pos::DUMMY_SP,

--- a/src/librustc/ich/impls_hir.rs
+++ b/src/librustc/ich/impls_hir.rs
@@ -158,7 +158,7 @@ impl_stable_hash_for!(struct hir::Label {
 });
 
 impl_stable_hash_for!(struct hir::Lifetime {
-    id,
+    hir_id,
     span,
     name
 });
@@ -172,6 +172,7 @@ impl_stable_hash_for!(struct hir::Path {
 impl_stable_hash_for!(struct hir::PathSegment {
     ident -> (ident.name),
     id,
+    hir_id,
     def,
     infer_types,
     args
@@ -199,7 +200,7 @@ impl_stable_hash_for!(enum hir::TraitBoundModifier {
 });
 
 impl_stable_hash_for!(struct hir::GenericParam {
-    id,
+    hir_id,
     name,
     pure_wrt_drop,
     attrs,
@@ -243,7 +244,7 @@ impl_stable_hash_for!(enum hir::SyntheticTyParamKind {
 });
 
 impl_stable_hash_for!(struct hir::WhereClause {
-    id,
+    hir_id,
     predicates
 });
 
@@ -267,7 +268,7 @@ impl_stable_hash_for!(struct hir::WhereRegionPredicate {
 });
 
 impl_stable_hash_for!(struct hir::WhereEqPredicate {
-    id,
+    hir_id,
     span,
     lhs_ty,
     rhs_ty
@@ -284,7 +285,7 @@ impl_stable_hash_for!(struct hir::MethodSig {
 });
 
 impl_stable_hash_for!(struct hir::TypeBinding {
-    id,
+    hir_id,
     ident -> (ident.name),
     ty,
     span
@@ -303,7 +304,6 @@ impl<'a> HashStable<StableHashingContext<'a>> for hir::Ty {
                                           hasher: &mut StableHasher<W>) {
         hcx.while_hashing_hir_bodies(true, |hcx| {
             let hir::Ty {
-                id: _,
                 hir_id: _,
                 ref node,
                 ref span,
@@ -375,8 +375,7 @@ impl_stable_hash_for!(enum hir::ImplicitSelfKind {
 });
 
 impl_stable_hash_for!(struct hir::TraitRef {
-    // Don't hash the ref_id. It is tracked via the thing it is used to access
-    ref_id -> _,
+    // Don't hash the hir_ref_id. It is tracked via the thing it is used to access
     hir_ref_id -> _,
     path,
 });
@@ -396,7 +395,7 @@ impl_stable_hash_for!(struct hir::MacroDef {
     name,
     vis,
     attrs,
-    id,
+    hir_id,
     span,
     legacy,
     body
@@ -405,7 +404,6 @@ impl_stable_hash_for!(struct hir::MacroDef {
 impl_stable_hash_for!(struct hir::Block {
     stmts,
     expr,
-    id -> _,
     hir_id -> _,
     rules,
     span,
@@ -413,7 +411,6 @@ impl_stable_hash_for!(struct hir::Block {
 });
 
 impl_stable_hash_for!(struct hir::Pat {
-    id -> _,
     hir_id -> _,
     node,
     span,
@@ -422,7 +419,7 @@ impl_stable_hash_for!(struct hir::Pat {
 impl_stable_hash_for_spanned!(hir::FieldPat);
 
 impl_stable_hash_for!(struct hir::FieldPat {
-    id -> _,
+    hir_id -> _,
     ident -> (ident.name),
     pat,
     is_shorthand,
@@ -489,7 +486,6 @@ impl_stable_hash_for!(struct hir::Local {
     pat,
     ty,
     init,
-    id,
     hir_id,
     span,
     attrs,
@@ -514,7 +510,7 @@ impl_stable_hash_for!(enum hir::Guard {
 });
 
 impl_stable_hash_for!(struct hir::Field {
-    id -> _,
+    hir_id -> _,
     ident,
     expr,
     span,
@@ -537,7 +533,6 @@ impl_stable_hash_for!(enum hir::UnsafeSource {
 });
 
 impl_stable_hash_for!(struct hir::AnonConst {
-    id,
     hir_id,
     body
 });
@@ -548,7 +543,6 @@ impl<'a> HashStable<StableHashingContext<'a>> for hir::Expr {
                                           hasher: &mut StableHasher<W>) {
         hcx.while_hashing_hir_bodies(true, |hcx| {
             let hir::Expr {
-                id: _,
                 hir_id: _,
                 ref span,
                 ref node,
@@ -662,7 +656,6 @@ impl<'a> HashStable<StableHashingContext<'a>> for hir::TraitItem {
                                           hcx: &mut StableHashingContext<'a>,
                                           hasher: &mut StableHasher<W>) {
         let hir::TraitItem {
-            id: _,
             hir_id: _,
             ident,
             ref attrs,
@@ -697,7 +690,6 @@ impl<'a> HashStable<StableHashingContext<'a>> for hir::ImplItem {
                                           hcx: &mut StableHashingContext<'a>,
                                           hasher: &mut StableHasher<W>) {
         let hir::ImplItem {
-            id: _,
             hir_id: _,
             ident,
             ref vis,
@@ -745,9 +737,8 @@ impl<'a> HashStable<StableHashingContext<'a>> for hir::VisibilityKind {
             hir::VisibilityKind::Crate(sugar) => {
                 sugar.hash_stable(hcx, hasher);
             }
-            hir::VisibilityKind::Restricted { ref path, id, hir_id } => {
+            hir::VisibilityKind::Restricted { ref path, hir_id } => {
                 hcx.with_node_id_hashing_mode(NodeIdHashingMode::HashDefPath, |hcx| {
-                    id.hash_stable(hcx, hasher);
                     hir_id.hash_stable(hcx, hasher);
                 });
                 path.hash_stable(hcx, hasher);
@@ -836,15 +827,15 @@ impl_stable_hash_for!(struct hir::StructField {
     span,
     ident -> (ident.name),
     vis,
-    id,
+    hir_id,
     ty,
     attrs
 });
 
 impl_stable_hash_for!(enum hir::VariantData {
-    Struct(fields, id),
-    Tuple(fields, id),
-    Unit(id)
+    Struct(fields, hir_id),
+    Tuple(fields, hir_id),
+    Unit(hir_id)
 });
 
 impl<'a> HashStable<StableHashingContext<'a>> for hir::Item {
@@ -854,7 +845,6 @@ impl<'a> HashStable<StableHashingContext<'a>> for hir::Item {
         let hir::Item {
             ident,
             ref attrs,
-            id: _,
             hir_id: _,
             ref node,
             ref vis,
@@ -929,7 +919,7 @@ impl_stable_hash_for!(struct hir::ForeignItem {
     ident -> (ident.name),
     attrs,
     node,
-    id,
+    hir_id,
     span,
     vis
 });
@@ -941,14 +931,13 @@ impl_stable_hash_for!(enum hir::ForeignItemKind {
 });
 
 impl_stable_hash_for!(enum hir::StmtKind {
-    Decl(decl, id),
-    Expr(expr, id),
-    Semi(expr, id)
+    Decl(decl, hir_id),
+    Expr(expr, hir_id),
+    Semi(expr, hir_id)
 });
 
 impl_stable_hash_for!(struct hir::Arg {
     pat,
-    id,
     hir_id
 });
 
@@ -977,8 +966,8 @@ impl<'a> ToStableHashKey<StableHashingContext<'a>> for hir::BodyId {
     fn to_stable_hash_key(&self,
                           hcx: &StableHashingContext<'a>)
                           -> (DefPathHash, hir::ItemLocalId) {
-        let hir::BodyId { node_id } = *self;
-        node_id.to_stable_hash_key(hcx)
+        let hir::BodyId { hir_id } = *self;
+        hir_id.to_stable_hash_key(hcx)
     }
 }
 

--- a/src/librustc/infer/error_reporting/need_type_info.rs
+++ b/src/librustc/infer/error_reporting/need_type_info.rs
@@ -16,9 +16,9 @@ struct FindLocalByTypeVisitor<'a, 'gcx: 'a + 'tcx, 'tcx: 'a> {
 }
 
 impl<'a, 'gcx, 'tcx> FindLocalByTypeVisitor<'a, 'gcx, 'tcx> {
-    fn node_matches_type(&mut self, node_id: HirId) -> bool {
+    fn node_matches_type(&mut self, hir_id: HirId) -> bool {
         let ty_opt = self.infcx.in_progress_tables.and_then(|tables| {
-            tables.borrow().node_id_to_type_opt(node_id)
+            tables.borrow().hir_id_to_type_opt(hir_id)
         });
         match ty_opt {
             Some(ty) => {
@@ -105,7 +105,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
         };
 
         if let Some(body_id) = body_id {
-            let expr = self.tcx.hir().expect_expr(body_id.node_id);
+            let expr = self.tcx.hir().expect_expr(body_id.hir_id);
             local_visitor.visit_expr(expr);
         }
 

--- a/src/librustc/infer/error_reporting/nice_region_error/different_lifetimes.rs
+++ b/src/librustc/infer/error_reporting/nice_region_error/different_lifetimes.rs
@@ -101,7 +101,7 @@ impl<'a, 'gcx, 'tcx> NiceRegionError<'a, 'gcx, 'tcx> {
 
         let (span_1, span_2, main_label, span_label) = match (sup_is_ret_type, sub_is_ret_type) {
             (None, None) => {
-                let (main_label_1, span_label_1) = if ty_sup.id == ty_sub.id {
+                let (main_label_1, span_label_1) = if ty_sup.hir_id == ty_sub.hir_id {
                     (
                         "this type is declared with multiple lifetimes...".to_owned(),
                         "...but data with one lifetime flows into the other here".to_owned()

--- a/src/librustc/infer/error_reporting/nice_region_error/find_anon_type.rs
+++ b/src/librustc/infer/error_reporting/nice_region_error/find_anon_type.rs
@@ -114,7 +114,7 @@ impl<'a, 'gcx, 'tcx> Visitor<'gcx> for FindNestedTypeVisitor<'a, 'gcx, 'tcx> {
 
             hir::TyKind::Rptr(ref lifetime, _) => {
                 // the lifetime of the TyRptr
-                let hir_id = self.tcx.hir().node_to_hir_id(lifetime.id);
+                let hir_id = lifetime.hir_id;
                 match (self.tcx.named_region(hir_id), self.bound_region) {
                     // Find the index of the anonymous region that was part of the
                     // error. We will then search the function parameters for a bound
@@ -221,7 +221,7 @@ impl<'a, 'gcx, 'tcx> Visitor<'gcx> for TyPathVisitor<'a, 'gcx, 'tcx> {
     }
 
     fn visit_lifetime(&mut self, lifetime: &hir::Lifetime) {
-        let hir_id = self.tcx.hir().node_to_hir_id(lifetime.id);
+        let hir_id = lifetime.hir_id;
         match (self.tcx.named_region(hir_id), self.bound_region) {
             // the lifetime of the TyPath!
             (Some(rl::Region::LateBoundAnon(debruijn_index, anon_index)), ty::BrAnon(br_index)) => {

--- a/src/librustc/infer/error_reporting/nice_region_error/util.rs
+++ b/src/librustc/infer/error_reporting/nice_region_error/util.rs
@@ -51,8 +51,8 @@ impl<'a, 'gcx, 'tcx> NiceRegionError<'a, 'gcx, 'tcx> {
         };
 
         let hir = &self.tcx.hir();
-        if let Some(node_id) = hir.as_local_node_id(id) {
-            if let Some(body_id) = hir.maybe_body_owned_by(node_id) {
+        if let Some(hir_id) = hir.as_local_hir_id(id) {
+            if let Some(body_id) = hir.maybe_body_owned_by(hir_id) {
                 let body = hir.body(body_id);
                 let owner_id = hir.body_owner(body_id);
                 let fn_decl = hir.fn_decl(owner_id).unwrap();
@@ -63,8 +63,8 @@ impl<'a, 'gcx, 'tcx> NiceRegionError<'a, 'gcx, 'tcx> {
                         .filter_map(|(index, arg)| {
                             // May return None; sometimes the tables are not yet populated.
                             let ty_hir_id = fn_decl.inputs[index].hir_id;
-                            let arg_ty_span = hir.span(hir.hir_to_node_id(ty_hir_id));
-                            let ty = tables.node_id_to_type_opt(arg.hir_id)?;
+                            let arg_ty_span = hir.span(ty_hir_id);
+                            let ty = tables.hir_id_to_type_opt(arg.hir_id)?;
                             let mut found_anon_region = false;
                             let new_arg_ty = self.tcx.fold_regions(&ty, &mut false, |r, _| {
                                 if *r == *anon_region {

--- a/src/librustc/infer/error_reporting/note.rs
+++ b/src/librustc/infer/error_reporting/note.rs
@@ -31,8 +31,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                               "...so that reference does not outlive borrowed content");
             }
             infer::ReborrowUpvar(span, ref upvar_id) => {
-                let var_node_id = self.tcx.hir().hir_to_node_id(upvar_id.var_path.hir_id);
-                let var_name = self.tcx.hir().name(var_node_id);
+                let var_name = self.tcx.hir().name(upvar_id.var_path.hir_id);
                 err.span_note(span,
                               &format!("...so that closure can access `{}`", var_name));
             }
@@ -48,10 +47,11 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                               "...so that pointer is not dereferenced outside its lifetime");
             }
             infer::FreeVariable(span, id) => {
+                let hir_id = self.tcx.hir().node_to_hir_id(id);
                 err.span_note(span,
                               &format!("...so that captured variable `{}` does not outlive the \
                                         enclosing closure",
-                                       self.tcx.hir().name(id)));
+                                       self.tcx.hir().name(hir_id)));
             }
             infer::IndexSlice(span) => {
                 err.span_note(span, "...so that slice is not indexed outside the lifetime");
@@ -164,8 +164,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                 err
             }
             infer::ReborrowUpvar(span, ref upvar_id) => {
-                let var_node_id = self.tcx.hir().hir_to_node_id(upvar_id.var_path.hir_id);
-                let var_name = self.tcx.hir().name(var_node_id);
+                let var_name = self.tcx.hir().name(upvar_id.var_path.hir_id);
                 let mut err = struct_span_err!(self.tcx.sess,
                                                span,
                                                E0313,
@@ -217,12 +216,13 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                 err
             }
             infer::FreeVariable(span, id) => {
+                let hir_id = self.tcx.hir().node_to_hir_id(id);
                 let mut err = struct_span_err!(self.tcx.sess,
                                                span,
                                                E0474,
                                                "captured variable `{}` does not outlive the \
                                                 enclosing closure",
-                                               self.tcx.hir().name(id));
+                                               self.tcx.hir().name(hir_id));
                 self.tcx.note_and_explain_region(region_scope_tree, &mut err,
                     "captured variable is valid for ", sup, "");
                 self.tcx.note_and_explain_region(region_scope_tree, &mut err,

--- a/src/librustc/infer/mod.rs
+++ b/src/librustc/infer/mod.rs
@@ -9,6 +9,7 @@ pub use ty::IntVarValue;
 
 use arena::SyncDroplessArena;
 use errors::DiagnosticBuilder;
+use hir;
 use hir::def_id::DefId;
 use infer::canonical::{Canonical, CanonicalVarValues};
 use middle::free_region::RegionRelations;
@@ -202,7 +203,7 @@ pub struct InferCtxt<'a, 'gcx: 'a + 'tcx, 'tcx: 'a> {
     // for each body-id in this map, which will process the
     // obligations within. This is expected to be done 'late enough'
     // that all type inference variables have been bound and so forth.
-    pub region_obligations: RefCell<Vec<(ast::NodeId, RegionObligation<'tcx>)>>,
+    pub region_obligations: RefCell<Vec<(hir::HirId, RegionObligation<'tcx>)>>,
 
     /// What is the innermost universe we have created? Starts out as
     /// `UniverseIndex::root()` but grows from there as we enter
@@ -1440,7 +1441,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
     pub fn partially_normalize_associated_types_in<T>(
         &self,
         span: Span,
-        body_id: ast::NodeId,
+        body_id: hir::HirId,
         param_env: ty::ParamEnv<'tcx>,
         value: &T,
     ) -> InferOk<'tcx, T>

--- a/src/librustc/infer/outlives/env.rs
+++ b/src/librustc/infer/outlives/env.rs
@@ -1,7 +1,7 @@
+use hir;
 use infer::outlives::free_region_map::FreeRegionMap;
 use infer::{GenericKind, InferCtxt};
 use rustc_data_structures::fx::FxHashMap;
-use syntax::ast;
 use syntax_pos::Span;
 use traits::query::outlives_bounds::{self, OutlivesBound};
 use ty::{self, Ty};
@@ -55,7 +55,7 @@ pub struct OutlivesEnvironment<'tcx> {
     // results when proving outlives obligations like `T: 'x` later
     // (e.g., if `T: 'x` must be proven within the body B1, then we
     // know it is true if either `'a: 'x` or `'b: 'x`).
-    region_bound_pairs_map: FxHashMap<ast::NodeId, RegionBoundPairs<'tcx>>,
+    region_bound_pairs_map: FxHashMap<hir::HirId, RegionBoundPairs<'tcx>>,
 
     // Used to compute `region_bound_pairs_map`: contains the set of
     // in-scope region-bound pairs thus far.
@@ -87,7 +87,7 @@ impl<'a, 'gcx: 'tcx, 'tcx: 'a> OutlivesEnvironment<'tcx> {
     }
 
     /// Borrows current value of the `region_bound_pairs`.
-    pub fn region_bound_pairs_map(&self) -> &FxHashMap<ast::NodeId, RegionBoundPairs<'tcx>> {
+    pub fn region_bound_pairs_map(&self) -> &FxHashMap<hir::HirId, RegionBoundPairs<'tcx>> {
         &self.region_bound_pairs_map
     }
 
@@ -162,7 +162,7 @@ impl<'a, 'gcx: 'tcx, 'tcx: 'a> OutlivesEnvironment<'tcx> {
         &mut self,
         infcx: &InferCtxt<'a, 'gcx, 'tcx>,
         fn_sig_tys: &[Ty<'tcx>],
-        body_id: ast::NodeId,
+        body_id: hir::HirId,
         span: Span,
     ) {
         debug!("add_implied_bounds()");
@@ -176,7 +176,7 @@ impl<'a, 'gcx: 'tcx, 'tcx: 'a> OutlivesEnvironment<'tcx> {
     }
 
     /// Save the current set of region-bound pairs under the given `body_id`.
-    pub fn save_implied_bounds(&mut self, body_id: ast::NodeId) {
+    pub fn save_implied_bounds(&mut self, body_id: hir::HirId) {
         let old = self.region_bound_pairs_map.insert(
             body_id,
             self.region_bound_pairs_accum.clone(),

--- a/src/librustc/infer/outlives/obligations.rs
+++ b/src/librustc/infer/outlives/obligations.rs
@@ -63,7 +63,7 @@ use infer::outlives::env::RegionBoundPairs;
 use infer::outlives::verify::VerifyBoundCx;
 use infer::{self, GenericKind, InferCtxt, RegionObligation, SubregionOrigin, VerifyBound};
 use rustc_data_structures::fx::FxHashMap;
-use syntax::ast;
+use hir;
 use traits::ObligationCause;
 use ty::outlives::Component;
 use ty::{self, Region, Ty, TyCtxt, TypeFoldable};
@@ -76,7 +76,7 @@ impl<'cx, 'gcx, 'tcx> InferCtxt<'cx, 'gcx, 'tcx> {
     /// information).
     pub fn register_region_obligation(
         &self,
-        body_id: ast::NodeId,
+        body_id: hir::HirId,
         obligation: RegionObligation<'tcx>,
     ) {
         debug!(
@@ -110,7 +110,7 @@ impl<'cx, 'gcx, 'tcx> InferCtxt<'cx, 'gcx, 'tcx> {
     }
 
     /// Trait queries just want to pass back type obligations "as is"
-    pub fn take_registered_region_obligations(&self) -> Vec<(ast::NodeId, RegionObligation<'tcx>)> {
+    pub fn take_registered_region_obligations(&self) -> Vec<(hir::HirId, RegionObligation<'tcx>)> {
         ::std::mem::replace(&mut *self.region_obligations.borrow_mut(), vec![])
     }
 
@@ -149,7 +149,7 @@ impl<'cx, 'gcx, 'tcx> InferCtxt<'cx, 'gcx, 'tcx> {
     /// processed.
     pub fn process_registered_region_obligations(
         &self,
-        region_bound_pairs_map: &FxHashMap<ast::NodeId, RegionBoundPairs<'tcx>>,
+        region_bound_pairs_map: &FxHashMap<hir::HirId, RegionBoundPairs<'tcx>>,
         implicit_region_bound: Option<ty::Region<'tcx>>,
         param_env: ty::ParamEnv<'tcx>,
     ) {

--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -180,8 +180,8 @@ macro_rules! late_lint_methods {
             fn check_name(a: Span, b: ast::Name);
             fn check_crate(a: &$hir hir::Crate);
             fn check_crate_post(a: &$hir hir::Crate);
-            fn check_mod(a: &$hir hir::Mod, b: Span, c: ast::NodeId);
-            fn check_mod_post(a: &$hir hir::Mod, b: Span, c: ast::NodeId);
+            fn check_mod(a: &$hir hir::Mod, b: Span, c: hir::HirId);
+            fn check_mod_post(a: &$hir hir::Mod, b: Span, c: hir::HirId);
             fn check_foreign_item(a: &$hir hir::ForeignItem);
             fn check_foreign_item_post(a: &$hir hir::ForeignItem);
             fn check_item(a: &$hir hir::Item);
@@ -205,13 +205,13 @@ macro_rules! late_lint_methods {
                 b: &$hir hir::FnDecl,
                 c: &$hir hir::Body,
                 d: Span,
-                e: ast::NodeId);
+                e: hir::HirId);
             fn check_fn_post(
                 a: hir::intravisit::FnKind<$hir>,
                 b: &$hir hir::FnDecl,
                 c: &$hir hir::Body,
                 d: Span,
-                e: ast::NodeId
+                e: hir::HirId
             );
             fn check_trait_item(a: &$hir hir::TraitItem);
             fn check_trait_item_post(a: &$hir hir::TraitItem);
@@ -221,13 +221,13 @@ macro_rules! late_lint_methods {
                 a: &$hir hir::VariantData,
                 b: ast::Name,
                 c: &$hir hir::Generics,
-                d: ast::NodeId
+                d: hir::HirId
             );
             fn check_struct_def_post(
                 a: &$hir hir::VariantData,
                 b: ast::Name,
                 c: &$hir hir::Generics,
-                d: ast::NodeId
+                d: hir::HirId
             );
             fn check_struct_field(a: &$hir hir::StructField);
             fn check_variant(a: &$hir hir::Variant, b: &$hir hir::Generics);
@@ -636,7 +636,7 @@ fn lint_levels<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, cnum: CrateNum)
     };
     let krate = tcx.hir().krate();
 
-    builder.with_lint_attrs(ast::CRATE_NODE_ID, &krate.attrs, |builder| {
+    builder.with_lint_attrs(hir::CRATE_HIR_ID, &krate.attrs, |builder| {
         intravisit::walk_crate(builder, krate);
     });
 
@@ -650,13 +650,13 @@ struct LintLevelMapBuilder<'a, 'tcx: 'a> {
 
 impl<'a, 'tcx> LintLevelMapBuilder<'a, 'tcx> {
     fn with_lint_attrs<F>(&mut self,
-                          id: ast::NodeId,
+                          hir_id: hir::HirId,
                           attrs: &[ast::Attribute],
                           f: F)
         where F: FnOnce(&mut Self)
     {
         let push = self.levels.push(attrs);
-        self.levels.register_id(self.tcx.hir().definitions().node_to_hir_id(id));
+        self.levels.register_id(hir_id);
         f(self);
         self.levels.pop(push);
     }
@@ -668,25 +668,25 @@ impl<'a, 'tcx> intravisit::Visitor<'tcx> for LintLevelMapBuilder<'a, 'tcx> {
     }
 
     fn visit_item(&mut self, it: &'tcx hir::Item) {
-        self.with_lint_attrs(it.id, &it.attrs, |builder| {
+        self.with_lint_attrs(it.hir_id, &it.attrs, |builder| {
             intravisit::walk_item(builder, it);
         });
     }
 
     fn visit_foreign_item(&mut self, it: &'tcx hir::ForeignItem) {
-        self.with_lint_attrs(it.id, &it.attrs, |builder| {
+        self.with_lint_attrs(it.hir_id, &it.attrs, |builder| {
             intravisit::walk_foreign_item(builder, it);
         })
     }
 
     fn visit_expr(&mut self, e: &'tcx hir::Expr) {
-        self.with_lint_attrs(e.id, &e.attrs, |builder| {
+        self.with_lint_attrs(e.hir_id, &e.attrs, |builder| {
             intravisit::walk_expr(builder, e);
         })
     }
 
     fn visit_struct_field(&mut self, s: &'tcx hir::StructField) {
-        self.with_lint_attrs(s.id, &s.attrs, |builder| {
+        self.with_lint_attrs(s.hir_id, &s.attrs, |builder| {
             intravisit::walk_struct_field(builder, s);
         })
     }
@@ -694,26 +694,26 @@ impl<'a, 'tcx> intravisit::Visitor<'tcx> for LintLevelMapBuilder<'a, 'tcx> {
     fn visit_variant(&mut self,
                      v: &'tcx hir::Variant,
                      g: &'tcx hir::Generics,
-                     item_id: ast::NodeId) {
-        self.with_lint_attrs(v.node.data.id(), &v.node.attrs, |builder| {
+                     item_id: hir::HirId) {
+        self.with_lint_attrs(v.node.data.hir_id(), &v.node.attrs, |builder| {
             intravisit::walk_variant(builder, v, g, item_id);
         })
     }
 
     fn visit_local(&mut self, l: &'tcx hir::Local) {
-        self.with_lint_attrs(l.id, &l.attrs, |builder| {
+        self.with_lint_attrs(l.hir_id, &l.attrs, |builder| {
             intravisit::walk_local(builder, l);
         })
     }
 
     fn visit_trait_item(&mut self, trait_item: &'tcx hir::TraitItem) {
-        self.with_lint_attrs(trait_item.id, &trait_item.attrs, |builder| {
+        self.with_lint_attrs(trait_item.hir_id, &trait_item.attrs, |builder| {
             intravisit::walk_trait_item(builder, trait_item);
         });
     }
 
     fn visit_impl_item(&mut self, impl_item: &'tcx hir::ImplItem) {
-        self.with_lint_attrs(impl_item.id, &impl_item.attrs, |builder| {
+        self.with_lint_attrs(impl_item.hir_id, &impl_item.attrs, |builder| {
             intravisit::walk_impl_item(builder, impl_item);
         });
     }

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -26,8 +26,8 @@ use syntax_pos;
 // function, then we should explore its block to check for codes that
 // may need to be marked as live.
 fn should_explore<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
-                            node_id: ast::NodeId) -> bool {
-    match tcx.hir().find(node_id) {
+                            hir_id: hir::HirId) -> bool {
+    match tcx.hir().find_by_hir_id(hir_id) {
         Some(Node::Item(..)) |
         Some(Node::ImplItem(..)) |
         Some(Node::ForeignItem(..)) |
@@ -39,33 +39,33 @@ fn should_explore<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 }
 
 struct MarkSymbolVisitor<'a, 'tcx: 'a> {
-    worklist: Vec<ast::NodeId>,
+    worklist: Vec<hir::HirId>,
     tcx: TyCtxt<'a, 'tcx, 'tcx>,
     tables: &'a ty::TypeckTables<'tcx>,
-    live_symbols: FxHashSet<ast::NodeId>,
+    live_symbols: FxHashSet<hir::HirId>,
     repr_has_repr_c: bool,
     in_pat: bool,
     inherited_pub_visibility: bool,
     ignore_variant_stack: Vec<DefId>,
     // maps from tuple struct constructors to tuple struct items
-    struct_constructors: FxHashMap<ast::NodeId, ast::NodeId>,
+    struct_constructors: FxHashMap<hir::HirId, hir::HirId>,
 }
 
 impl<'a, 'tcx> MarkSymbolVisitor<'a, 'tcx> {
     fn check_def_id(&mut self, def_id: DefId) {
-        if let Some(node_id) = self.tcx.hir().as_local_node_id(def_id) {
-            if should_explore(self.tcx, node_id) ||
-               self.struct_constructors.contains_key(&node_id) {
-                self.worklist.push(node_id);
+        if let Some(hir_id) = self.tcx.hir().as_local_hir_id(def_id) {
+            if should_explore(self.tcx, hir_id) ||
+               self.struct_constructors.contains_key(&hir_id) {
+                self.worklist.push(hir_id);
             }
-            self.live_symbols.insert(node_id);
+            self.live_symbols.insert(hir_id);
         }
     }
 
     fn insert_def_id(&mut self, def_id: DefId) {
-        if let Some(node_id) = self.tcx.hir().as_local_node_id(def_id) {
-            debug_assert!(!should_explore(self.tcx, node_id));
-            self.live_symbols.insert(node_id);
+        if let Some(hir_id) = self.tcx.hir().as_local_hir_id(def_id) {
+            debug_assert!(!should_explore(self.tcx, hir_id));
+            self.live_symbols.insert(hir_id);
         }
     }
 
@@ -99,10 +99,10 @@ impl<'a, 'tcx> MarkSymbolVisitor<'a, 'tcx> {
         }
     }
 
-    fn handle_field_access(&mut self, lhs: &hir::Expr, node_id: ast::NodeId) {
+    fn handle_field_access(&mut self, lhs: &hir::Expr, hir_id: hir::HirId) {
         match self.tables.expr_ty_adjusted(lhs).sty {
             ty::Adt(def, _) => {
-                let index = self.tcx.field_index(node_id, self.tables);
+                let index = self.tcx.field_index(hir_id, self.tables);
                 self.insert_def_id(def.non_enum_variant().fields[index].did);
             }
             ty::Tuple(..) => {}
@@ -112,7 +112,7 @@ impl<'a, 'tcx> MarkSymbolVisitor<'a, 'tcx> {
 
     fn handle_field_pattern_match(&mut self, lhs: &hir::Pat, def: Def,
                                   pats: &[source_map::Spanned<hir::FieldPat>]) {
-        let variant = match self.tables.node_id_to_type(lhs.hir_id).sty {
+        let variant = match self.tables.hir_id_to_type(lhs.hir_id).sty {
             ty::Adt(adt, _) => adt.variant_of_def(def),
             _ => span_bug!(lhs.span, "non-ADT in struct pattern")
         };
@@ -120,7 +120,7 @@ impl<'a, 'tcx> MarkSymbolVisitor<'a, 'tcx> {
             if let PatKind::Wild = pat.node.pat.node {
                 continue;
             }
-            let index = self.tcx.field_index(pat.node.id, self.tables);
+            let index = self.tcx.field_index(pat.node.hir_id, self.tables);
             self.insert_def_id(variant.fields[index].did);
         }
     }
@@ -136,7 +136,7 @@ impl<'a, 'tcx> MarkSymbolVisitor<'a, 'tcx> {
             // tuple struct constructor function
             let id = self.struct_constructors.get(&id).cloned().unwrap_or(id);
 
-            if let Some(node) = self.tcx.hir().find(id) {
+            if let Some(node) = self.tcx.hir().find_by_hir_id(id) {
                 self.live_symbols.insert(id);
                 self.visit_node(node);
             }
@@ -152,7 +152,7 @@ impl<'a, 'tcx> MarkSymbolVisitor<'a, 'tcx> {
             Node::Item(item) => {
                 match item.node {
                     hir::ItemKind::Struct(..) | hir::ItemKind::Union(..) => {
-                        let def_id = self.tcx.hir().local_def_id(item.id);
+                        let def_id = self.tcx.hir().local_def_id_from_hir_id(item.hir_id);
                         let def = self.tcx.adt_def(def_id);
                         self.repr_has_repr_c = def.repr.c();
 
@@ -190,7 +190,7 @@ impl<'a, 'tcx> MarkSymbolVisitor<'a, 'tcx> {
     fn mark_as_used_if_union(&mut self, adt: &ty::AdtDef, fields: &hir::HirVec<hir::Field>) {
         if adt.is_union() && adt.non_enum_variant().fields.len() > 1 && adt.did.is_local() {
             for field in fields {
-                let index = self.tcx.field_index(field.id, self.tables);
+                let index = self.tcx.field_index(field.hir_id, self.tables);
                 self.insert_def_id(adt.non_enum_variant().fields[index].did);
             }
         }
@@ -211,13 +211,13 @@ impl<'a, 'tcx> Visitor<'tcx> for MarkSymbolVisitor<'a, 'tcx> {
     }
 
     fn visit_variant_data(&mut self, def: &'tcx hir::VariantData, _: ast::Name,
-                          _: &hir::Generics, _: ast::NodeId, _: syntax_pos::Span) {
+                          _: &hir::Generics, _: hir::HirId, _: syntax_pos::Span) {
         let has_repr_c = self.repr_has_repr_c;
         let inherited_pub_visibility = self.inherited_pub_visibility;
         let live_fields = def.fields().iter().filter(|f| {
             has_repr_c || inherited_pub_visibility || f.vis.node.is_pub()
         });
-        self.live_symbols.extend(live_fields.map(|f| f.id));
+        self.live_symbols.extend(live_fields.map(|f| f.hir_id));
 
         intravisit::walk_struct_def(self, def);
     }
@@ -232,7 +232,7 @@ impl<'a, 'tcx> Visitor<'tcx> for MarkSymbolVisitor<'a, 'tcx> {
                 self.lookup_and_handle_method(expr.hir_id);
             }
             hir::ExprKind::Field(ref lhs, ..) => {
-                self.handle_field_access(&lhs, expr.id);
+                self.handle_field_access(&lhs, expr.hir_id);
             }
             hir::ExprKind::Struct(_, ref fields, _) => {
                 if let ty::Adt(ref adt, _) = self.tables.expr_ty(expr).sty {
@@ -285,7 +285,7 @@ impl<'a, 'tcx> Visitor<'tcx> for MarkSymbolVisitor<'a, 'tcx> {
 }
 
 fn has_allow_dead_code_or_lang_attr(tcx: TyCtxt<'_, '_, '_>,
-                                    id: ast::NodeId,
+                                    id: hir::HirId,
                                     attrs: &[ast::Attribute]) -> bool {
     if attr::contains_name(attrs, "lang") {
         return true;
@@ -306,7 +306,7 @@ fn has_allow_dead_code_or_lang_attr(tcx: TyCtxt<'_, '_, '_>,
         return true;
     }
 
-    let def_id = tcx.hir().local_def_id(id);
+    let def_id = tcx.hir().local_def_id_from_hir_id(id);
     let cg_attrs = tcx.codegen_fn_attrs(def_id);
 
     // #[used], #[no_mangle], #[export_name], etc also keeps the item alive
@@ -333,25 +333,25 @@ fn has_allow_dead_code_or_lang_attr(tcx: TyCtxt<'_, '_, '_>,
 //   2) We are not sure to be live or not
 //     * Implementation of a trait method
 struct LifeSeeder<'k, 'tcx: 'k> {
-    worklist: Vec<ast::NodeId>,
+    worklist: Vec<hir::HirId>,
     krate: &'k hir::Crate,
     tcx: TyCtxt<'k, 'tcx, 'tcx>,
     // see `MarkSymbolVisitor::struct_constructors`
-    struct_constructors: FxHashMap<ast::NodeId, ast::NodeId>,
+    struct_constructors: FxHashMap<hir::HirId, hir::HirId>,
 }
 
 impl<'v, 'k, 'tcx> ItemLikeVisitor<'v> for LifeSeeder<'k, 'tcx> {
     fn visit_item(&mut self, item: &hir::Item) {
         let allow_dead_code = has_allow_dead_code_or_lang_attr(self.tcx,
-                                                               item.id,
+                                                               item.hir_id,
                                                                &item.attrs);
         if allow_dead_code {
-            self.worklist.push(item.id);
+            self.worklist.push(item.hir_id);
         }
         match item.node {
             hir::ItemKind::Enum(ref enum_def, _) if allow_dead_code => {
                 self.worklist.extend(enum_def.variants.iter()
-                                                      .map(|variant| variant.node.data.id()));
+                                                      .map(|variant| variant.node.data.hir_id()));
             }
             hir::ItemKind::Trait(.., ref trait_item_refs) => {
                 for trait_item_ref in trait_item_refs {
@@ -360,9 +360,9 @@ impl<'v, 'k, 'tcx> ItemLikeVisitor<'v> for LifeSeeder<'k, 'tcx> {
                         hir::TraitItemKind::Const(_, Some(_)) |
                         hir::TraitItemKind::Method(_, hir::TraitMethod::Provided(_)) => {
                             if has_allow_dead_code_or_lang_attr(self.tcx,
-                                                                trait_item.id,
+                                                                trait_item.hir_id,
                                                                 &trait_item.attrs) {
-                                self.worklist.push(trait_item.id);
+                                self.worklist.push(trait_item.hir_id);
                             }
                         }
                         _ => {}
@@ -374,14 +374,14 @@ impl<'v, 'k, 'tcx> ItemLikeVisitor<'v> for LifeSeeder<'k, 'tcx> {
                     let impl_item = self.krate.impl_item(impl_item_ref.id);
                     if opt_trait.is_some() ||
                             has_allow_dead_code_or_lang_attr(self.tcx,
-                                                             impl_item.id,
+                                                             impl_item.hir_id,
                                                              &impl_item.attrs) {
-                        self.worklist.push(impl_item_ref.id.node_id);
+                        self.worklist.push(impl_item.hir_id);
                     }
                 }
             }
             hir::ItemKind::Struct(ref variant_data, _) => {
-                self.struct_constructors.insert(variant_data.id(), item.id);
+                self.struct_constructors.insert(variant_data.hir_id(), item.hir_id);
             }
             _ => ()
         }
@@ -400,10 +400,11 @@ fn create_and_seed_worklist<'a, 'tcx>(
     tcx: TyCtxt<'a, 'tcx, 'tcx>,
     access_levels: &privacy::AccessLevels,
     krate: &hir::Crate,
-) -> (Vec<ast::NodeId>, FxHashMap<ast::NodeId, ast::NodeId>) {
+) -> (Vec<hir::HirId>, FxHashMap<hir::HirId, hir::HirId>) {
     let worklist = access_levels.map.iter().filter_map(|(&id, level)| {
         if level >= &privacy::AccessLevel::Reachable {
-            Some(id)
+            let hir_id = tcx.hir().node_to_hir_id(id);
+            Some(hir_id)
         } else {
             None
         }
@@ -427,7 +428,7 @@ fn create_and_seed_worklist<'a, 'tcx>(
 fn find_live<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                        access_levels: &privacy::AccessLevels,
                        krate: &hir::Crate)
-                       -> FxHashSet<ast::NodeId> {
+                       -> FxHashSet<hir::HirId> {
     let (worklist, struct_constructors) = create_and_seed_worklist(tcx, access_levels, krate);
     let mut symbol_visitor = MarkSymbolVisitor {
         worklist,
@@ -446,7 +447,7 @@ fn find_live<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 
 struct DeadVisitor<'a, 'tcx: 'a> {
     tcx: TyCtxt<'a, 'tcx, 'tcx>,
-    live_symbols: FxHashSet<ast::NodeId>,
+    live_symbols: FxHashSet<hir::HirId>,
 }
 
 impl<'a, 'tcx> DeadVisitor<'a, 'tcx> {
@@ -461,33 +462,33 @@ impl<'a, 'tcx> DeadVisitor<'a, 'tcx> {
             | hir::ItemKind::Union(..) => true,
             _ => false
         };
-        should_warn && !self.symbol_is_live(item.id)
+        should_warn && !self.symbol_is_live(item.hir_id)
     }
 
     fn should_warn_about_field(&mut self, field: &hir::StructField) -> bool {
-        let field_type = self.tcx.type_of(self.tcx.hir().local_def_id(field.id));
+        let field_type = self.tcx.type_of(self.tcx.hir().local_def_id_from_hir_id(field.hir_id));
         !field.is_positional()
-            && !self.symbol_is_live(field.id)
+            && !self.symbol_is_live(field.hir_id)
             && !field_type.is_phantom_data()
-            && !has_allow_dead_code_or_lang_attr(self.tcx, field.id, &field.attrs)
+            && !has_allow_dead_code_or_lang_attr(self.tcx, field.hir_id, &field.attrs)
     }
 
     fn should_warn_about_variant(&mut self, variant: &hir::VariantKind) -> bool {
-        !self.symbol_is_live(variant.data.id())
+        !self.symbol_is_live(variant.data.hir_id())
             && !has_allow_dead_code_or_lang_attr(self.tcx,
-                                                 variant.data.id(),
+                                                 variant.data.hir_id(),
                                                  &variant.attrs)
     }
 
     fn should_warn_about_foreign_item(&mut self, fi: &hir::ForeignItem) -> bool {
-        !self.symbol_is_live(fi.id)
-            && !has_allow_dead_code_or_lang_attr(self.tcx, fi.id, &fi.attrs)
+        !self.symbol_is_live(fi.hir_id)
+            && !has_allow_dead_code_or_lang_attr(self.tcx, fi.hir_id, &fi.attrs)
     }
 
     // id := node id of an item's definition.
     fn symbol_is_live(
         &mut self,
-        id: ast::NodeId,
+        id: hir::HirId,
     ) -> bool {
         if self.live_symbols.contains(&id) {
             return true;
@@ -496,12 +497,12 @@ impl<'a, 'tcx> DeadVisitor<'a, 'tcx> {
         // This is done to handle the case where, for example, the static
         // method of a private type is used, but the type itself is never
         // called directly.
-        let def_id = self.tcx.hir().local_def_id(id);
+        let def_id = self.tcx.hir().local_def_id_from_hir_id(id);
         let inherent_impls = self.tcx.inherent_impls(def_id);
         for &impl_did in inherent_impls.iter() {
             for &item_did in &self.tcx.associated_item_def_ids(impl_did)[..] {
-                if let Some(item_node_id) = self.tcx.hir().as_local_node_id(item_did) {
-                    if self.live_symbols.contains(&item_node_id) {
+                if let Some(item_hir_id) = self.tcx.hir().as_local_hir_id(item_did) {
+                    if self.live_symbols.contains(&item_hir_id) {
                         return true;
                     }
                 }
@@ -511,7 +512,7 @@ impl<'a, 'tcx> DeadVisitor<'a, 'tcx> {
     }
 
     fn warn_dead_code(&mut self,
-                      id: ast::NodeId,
+                      id: hir::HirId,
                       span: syntax_pos::Span,
                       name: ast::Name,
                       node_type: &str,
@@ -555,7 +556,7 @@ impl<'a, 'tcx> Visitor<'tcx> for DeadVisitor<'a, 'tcx> {
                 _ => "used"
             };
             self.warn_dead_code(
-                item.id,
+                item.hir_id,
                 span,
                 item.ident.name,
                 item.node.descriptive_variant(),
@@ -570,9 +571,9 @@ impl<'a, 'tcx> Visitor<'tcx> for DeadVisitor<'a, 'tcx> {
     fn visit_variant(&mut self,
                      variant: &'tcx hir::Variant,
                      g: &'tcx hir::Generics,
-                     id: ast::NodeId) {
+                     id: hir::HirId) {
         if self.should_warn_about_variant(&variant.node) {
-            self.warn_dead_code(variant.node.data.id(), variant.span, variant.node.ident.name,
+            self.warn_dead_code(variant.node.data.hir_id(), variant.span, variant.node.ident.name,
                                 "variant", "constructed");
         } else {
             intravisit::walk_variant(self, variant, g, id);
@@ -581,7 +582,7 @@ impl<'a, 'tcx> Visitor<'tcx> for DeadVisitor<'a, 'tcx> {
 
     fn visit_foreign_item(&mut self, fi: &'tcx hir::ForeignItem) {
         if self.should_warn_about_foreign_item(fi) {
-            self.warn_dead_code(fi.id, fi.span, fi.ident.name,
+            self.warn_dead_code(fi.hir_id, fi.span, fi.ident.name,
                                 fi.node.descriptive_variant(), "used");
         }
         intravisit::walk_foreign_item(self, fi);
@@ -589,7 +590,7 @@ impl<'a, 'tcx> Visitor<'tcx> for DeadVisitor<'a, 'tcx> {
 
     fn visit_struct_field(&mut self, field: &'tcx hir::StructField) {
         if self.should_warn_about_field(&field) {
-            self.warn_dead_code(field.id, field.span, field.ident.name, "field", "used");
+            self.warn_dead_code(field.hir_id, field.span, field.ident.name, "field", "used");
         }
         intravisit::walk_struct_field(self, field);
     }
@@ -597,8 +598,8 @@ impl<'a, 'tcx> Visitor<'tcx> for DeadVisitor<'a, 'tcx> {
     fn visit_impl_item(&mut self, impl_item: &'tcx hir::ImplItem) {
         match impl_item.node {
             hir::ImplItemKind::Const(_, body_id) => {
-                if !self.symbol_is_live(impl_item.id) {
-                    self.warn_dead_code(impl_item.id,
+                if !self.symbol_is_live(impl_item.hir_id) {
+                    self.warn_dead_code(impl_item.hir_id,
                                         impl_item.span,
                                         impl_item.ident.name,
                                         "associated const",
@@ -607,9 +608,10 @@ impl<'a, 'tcx> Visitor<'tcx> for DeadVisitor<'a, 'tcx> {
                 self.visit_nested_body(body_id)
             }
             hir::ImplItemKind::Method(_, body_id) => {
-                if !self.symbol_is_live(impl_item.id) {
+                if !self.symbol_is_live(impl_item.hir_id) {
                     let span = self.tcx.sess.source_map().def_span(impl_item.span);
-                    self.warn_dead_code(impl_item.id, span, impl_item.ident.name, "method", "used");
+                    self.warn_dead_code(impl_item.hir_id, span, impl_item.ident.name, "method",
+                        "used");
                 }
                 self.visit_nested_body(body_id)
             }

--- a/src/librustc/middle/entry.rs
+++ b/src/librustc/middle/entry.rs
@@ -1,8 +1,8 @@
 use hir::map as hir_map;
 use hir::def_id::{CRATE_DEF_INDEX};
+use hir::HirId;
 use session::{config, Session};
 use session::config::EntryFnType;
-use syntax::ast::NodeId;
 use syntax::attr;
 use syntax::entry::EntryPointType;
 use syntax_pos::Span;
@@ -15,22 +15,22 @@ struct EntryContext<'a, 'tcx: 'a> {
     map: &'a hir_map::Map<'tcx>,
 
     // The top-level function called 'main'
-    main_fn: Option<(NodeId, Span)>,
+    main_fn: Option<(HirId, Span)>,
 
     // The function that has attribute named 'main'
-    attr_main_fn: Option<(NodeId, Span)>,
+    attr_main_fn: Option<(HirId, Span)>,
 
     // The function that has the attribute 'start' on it
-    start_fn: Option<(NodeId, Span)>,
+    start_fn: Option<(HirId, Span)>,
 
     // The functions that one might think are 'main' but aren't, e.g.
     // main functions not defined at the top level. For diagnostics.
-    non_main_fns: Vec<(NodeId, Span)> ,
+    non_main_fns: Vec<(HirId, Span)> ,
 }
 
 impl<'a, 'tcx> ItemLikeVisitor<'tcx> for EntryContext<'a, 'tcx> {
     fn visit_item(&mut self, item: &'tcx Item) {
-        let def_id = self.map.local_def_id(item.id);
+        let def_id = self.map.local_def_id_from_hir_id(item.hir_id);
         let def_key = self.map.def_key(def_id);
         let at_root = def_key.parent == Some(CRATE_DEF_INDEX);
         find_item(item, self, at_root);
@@ -106,18 +106,18 @@ fn find_item(item: &Item, ctxt: &mut EntryContext<'_, '_>, at_root: bool) {
     match entry_point_type(item, at_root) {
         EntryPointType::MainNamed => {
             if ctxt.main_fn.is_none() {
-                ctxt.main_fn = Some((item.id, item.span));
+                ctxt.main_fn = Some((item.hir_id, item.span));
             } else {
                 span_err!(ctxt.session, item.span, E0136,
                           "multiple 'main' functions");
             }
         },
         EntryPointType::OtherMain => {
-            ctxt.non_main_fns.push((item.id, item.span));
+            ctxt.non_main_fns.push((item.hir_id, item.span));
         },
         EntryPointType::MainAttr => {
             if ctxt.attr_main_fn.is_none() {
-                ctxt.attr_main_fn = Some((item.id, item.span));
+                ctxt.attr_main_fn = Some((item.hir_id, item.span));
             } else {
                 struct_span_err!(ctxt.session, item.span, E0137,
                                  "multiple functions with a #[main] attribute")
@@ -128,7 +128,7 @@ fn find_item(item: &Item, ctxt: &mut EntryContext<'_, '_>, at_root: bool) {
         },
         EntryPointType::Start => {
             if ctxt.start_fn.is_none() {
-                ctxt.start_fn = Some((item.id, item.span));
+                ctxt.start_fn = Some((item.hir_id, item.span));
             } else {
                 struct_span_err!(ctxt.session, item.span, E0138, "multiple 'start' functions")
                     .span_label(ctxt.start_fn.unwrap().1, "previous `start` function here")

--- a/src/librustc/middle/expr_use_visitor.rs
+++ b/src/librustc/middle/expr_use_visitor.rs
@@ -19,7 +19,6 @@ use ty::{self, TyCtxt, adjustment};
 use hir::{self, PatKind};
 use rustc_data_structures::sync::Lrc;
 use std::rc::Rc;
-use syntax::ast;
 use syntax::ptr::P;
 use syntax_pos::Span;
 use util::nodemap::ItemLocalSet;
@@ -33,7 +32,7 @@ pub trait Delegate<'tcx> {
     // The value found at `cmt` is either copied or moved, depending
     // on mode.
     fn consume(&mut self,
-               consume_id: ast::NodeId,
+               consume_id: hir::HirId,
                consume_span: Span,
                cmt: &mc::cmt_<'tcx>,
                mode: ConsumeMode);
@@ -65,7 +64,7 @@ pub trait Delegate<'tcx> {
     // The value found at `borrow` is being borrowed at the point
     // `borrow_id` for the region `loan_region` with kind `bk`.
     fn borrow(&mut self,
-              borrow_id: ast::NodeId,
+              borrow_id: hir::HirId,
               borrow_span: Span,
               cmt: &mc::cmt_<'tcx>,
               loan_region: ty::Region<'tcx>,
@@ -74,12 +73,12 @@ pub trait Delegate<'tcx> {
 
     // The local variable `id` is declared but not initialized.
     fn decl_without_init(&mut self,
-                         id: ast::NodeId,
+                         id: hir::HirId,
                          span: Span);
 
     // The path at `cmt` is being assigned to.
     fn mutate(&mut self,
-              assignment_id: ast::NodeId,
+              assignment_id: hir::HirId,
               assignment_span: Span,
               assignee_cmt: &mc::cmt_<'tcx>,
               mode: MutateMode);
@@ -329,10 +328,10 @@ impl<'a, 'gcx, 'tcx> ExprUseVisitor<'a, 'gcx, 'tcx> {
     }
 
     fn delegate_consume(&mut self,
-                        consume_id: ast::NodeId,
+                        consume_id: hir::HirId,
                         consume_span: Span,
                         cmt: &mc::cmt_<'tcx>) {
-        debug!("delegate_consume(consume_id={}, cmt={:?})",
+        debug!("delegate_consume(consume_id={:?}, cmt={:?})",
                consume_id, cmt);
 
         let mode = copy_or_move(&self.mc, self.param_env, cmt, DirectRefMove);
@@ -349,7 +348,7 @@ impl<'a, 'gcx, 'tcx> ExprUseVisitor<'a, 'gcx, 'tcx> {
         debug!("consume_expr(expr={:?})", expr);
 
         let cmt = return_if_err!(self.mc.cat_expr(expr));
-        self.delegate_consume(expr.id, expr.span, &cmt);
+        self.delegate_consume(expr.hir_id, expr.span, &cmt);
         self.walk_expr(expr);
     }
 
@@ -359,7 +358,7 @@ impl<'a, 'gcx, 'tcx> ExprUseVisitor<'a, 'gcx, 'tcx> {
                    expr: &hir::Expr,
                    mode: MutateMode) {
         let cmt = return_if_err!(self.mc.cat_expr(expr));
-        self.delegate.mutate(assignment_expr.id, span, &cmt, mode);
+        self.delegate.mutate(assignment_expr.hir_id, span, &cmt, mode);
         self.walk_expr(expr);
     }
 
@@ -372,7 +371,7 @@ impl<'a, 'gcx, 'tcx> ExprUseVisitor<'a, 'gcx, 'tcx> {
                expr, r, bk);
 
         let cmt = return_if_err!(self.mc.cat_expr(expr));
-        self.delegate.borrow(expr.id, expr.span, &cmt, r, bk, cause);
+        self.delegate.borrow(expr.hir_id, expr.span, &cmt, r, bk, cause);
 
         self.walk_expr(expr)
     }
@@ -589,7 +588,7 @@ impl<'a, 'gcx, 'tcx> ExprUseVisitor<'a, 'gcx, 'tcx> {
 
     fn walk_stmt(&mut self, stmt: &hir::Stmt) {
         match stmt.node {
-            hir::StmtKind::Decl(ref decl, _) => {
+            hir::StmtKind::Decl(ref decl, ..) => {
                 match decl.node {
                     hir::DeclKind::Local(ref local) => {
                         self.walk_local(&local);
@@ -602,8 +601,8 @@ impl<'a, 'gcx, 'tcx> ExprUseVisitor<'a, 'gcx, 'tcx> {
                 }
             }
 
-            hir::StmtKind::Expr(ref expr, _) |
-            hir::StmtKind::Semi(ref expr, _) => {
+            hir::StmtKind::Expr(ref expr, ..) |
+            hir::StmtKind::Semi(ref expr, ..) => {
                 self.consume_expr(&expr);
             }
         }
@@ -613,8 +612,7 @@ impl<'a, 'gcx, 'tcx> ExprUseVisitor<'a, 'gcx, 'tcx> {
         match local.init {
             None => {
                 local.pat.each_binding(|_, hir_id, span, _| {
-                    let node_id = self.mc.tcx.hir().hir_to_node_id(hir_id);
-                    self.delegate.decl_without_init(node_id, span);
+                    self.delegate.decl_without_init(hir_id, span);
                 })
             }
 
@@ -633,7 +631,7 @@ impl<'a, 'gcx, 'tcx> ExprUseVisitor<'a, 'gcx, 'tcx> {
     /// Indicates that the value of `blk` will be consumed, meaning either copied or moved
     /// depending on its type.
     fn walk_block(&mut self, blk: &hir::Block) {
-        debug!("walk_block(blk.id={})", blk.id);
+        debug!("walk_block(blk.hir_id={:?})", blk.hir_id);
 
         for stmt in &blk.stmts {
             self.walk_stmt(stmt);
@@ -666,7 +664,7 @@ impl<'a, 'gcx, 'tcx> ExprUseVisitor<'a, 'gcx, 'tcx> {
                 // Consume those fields of the with expression that are needed.
                 for (f_index, with_field) in adt.non_enum_variant().fields.iter().enumerate() {
                     let is_mentioned = fields.iter().any(|f| {
-                        self.tcx().field_index(f.id, self.mc.tables) == f_index
+                        self.tcx().field_index(f.hir_id, self.mc.tables) == f_index
                     });
                     if !is_mentioned {
                         let cmt_field = self.mc.cat_field(
@@ -676,7 +674,7 @@ impl<'a, 'gcx, 'tcx> ExprUseVisitor<'a, 'gcx, 'tcx> {
                             with_field.ident,
                             with_field.ty(self.tcx(), substs)
                         );
-                        self.delegate_consume(with_expr.id, with_expr.span, &cmt_field);
+                        self.delegate_consume(with_expr.hir_id, with_expr.span, &cmt_field);
                     }
                 }
             }
@@ -715,7 +713,7 @@ impl<'a, 'gcx, 'tcx> ExprUseVisitor<'a, 'gcx, 'tcx> {
                 adjustment::Adjust::Unsize => {
                     // Creating a closure/fn-pointer or unsizing consumes
                     // the input and stores it into the resulting rvalue.
-                    self.delegate_consume(expr.id, expr.span, &cmt);
+                    self.delegate_consume(expr.hir_id, expr.span, &cmt);
                 }
 
                 adjustment::Adjust::Deref(None) => {}
@@ -727,7 +725,7 @@ impl<'a, 'gcx, 'tcx> ExprUseVisitor<'a, 'gcx, 'tcx> {
                 // this is an autoref of `x`.
                 adjustment::Adjust::Deref(Some(ref deref)) => {
                     let bk = ty::BorrowKind::from_mutbl(deref.mutbl);
-                    self.delegate.borrow(expr.id, expr.span, &cmt, deref.region, bk, AutoRef);
+                    self.delegate.borrow(expr.hir_id, expr.span, &cmt, deref.region, bk, AutoRef);
                 }
 
                 adjustment::Adjust::Borrow(ref autoref) => {
@@ -745,14 +743,14 @@ impl<'a, 'gcx, 'tcx> ExprUseVisitor<'a, 'gcx, 'tcx> {
                     expr: &hir::Expr,
                     cmt_base: &mc::cmt_<'tcx>,
                     autoref: &adjustment::AutoBorrow<'tcx>) {
-        debug!("walk_autoref(expr.id={} cmt_base={:?} autoref={:?})",
-               expr.id,
+        debug!("walk_autoref(expr.id={:?} cmt_base={:?} autoref={:?})",
+               expr.hir_id,
                cmt_base,
                autoref);
 
         match *autoref {
             adjustment::AutoBorrow::Ref(r, m) => {
-                self.delegate.borrow(expr.id,
+                self.delegate.borrow(expr.hir_id,
                                      expr.span,
                                      cmt_base,
                                      r,
@@ -761,8 +759,8 @@ impl<'a, 'gcx, 'tcx> ExprUseVisitor<'a, 'gcx, 'tcx> {
             }
 
             adjustment::AutoBorrow::RawPtr(m) => {
-                debug!("walk_autoref: expr.id={} cmt_base={:?}",
-                       expr.id,
+                debug!("walk_autoref: expr.id={:?} cmt_base={:?}",
+                       expr.hir_id,
                        cmt_base);
 
                 // Converting from a &T to *T (or &mut T to *mut T) is
@@ -774,7 +772,7 @@ impl<'a, 'gcx, 'tcx> ExprUseVisitor<'a, 'gcx, 'tcx> {
                         data: region::ScopeData::Node
                     }));
 
-                self.delegate.borrow(expr.id,
+                self.delegate.borrow(expr.hir_id,
                                      expr.span,
                                      cmt_base,
                                      r,
@@ -868,7 +866,7 @@ impl<'a, 'gcx, 'tcx> ExprUseVisitor<'a, 'gcx, 'tcx> {
                     // binding being produced.
                     let def = Def::Local(canonical_id);
                     if let Ok(ref binding_cmt) = mc.cat_def(pat.hir_id, pat.span, pat_ty, def) {
-                        delegate.mutate(pat.id, pat.span, binding_cmt, MutateMode::Init);
+                        delegate.mutate(pat.hir_id, pat.span, binding_cmt, MutateMode::Init);
                     }
 
                     // It is also a borrow or copy/move of the value being matched.
@@ -876,7 +874,7 @@ impl<'a, 'gcx, 'tcx> ExprUseVisitor<'a, 'gcx, 'tcx> {
                         ty::BindByReference(m) => {
                             if let ty::Ref(r, _, _) = pat_ty.sty {
                                 let bk = ty::BorrowKind::from_mutbl(m);
-                                delegate.borrow(pat.id, pat.span, &cmt_pat, r, bk, RefBinding);
+                                delegate.borrow(pat.hir_id, pat.span, &cmt_pat, r, bk, RefBinding);
                             }
                         }
                         ty::BindByValue(..) => {
@@ -924,10 +922,10 @@ impl<'a, 'gcx, 'tcx> ExprUseVisitor<'a, 'gcx, 'tcx> {
     fn walk_captures(&mut self, closure_expr: &hir::Expr, fn_decl_span: Span) {
         debug!("walk_captures({:?})", closure_expr);
 
-        self.tcx().with_freevars(closure_expr.id, |freevars| {
+        self.tcx().with_freevars(closure_expr.hir_id, |freevars| {
             for freevar in freevars {
-                let var_hir_id = self.tcx().hir().node_to_hir_id(freevar.var_id());
-                let closure_def_id = self.tcx().hir().local_def_id(closure_expr.id);
+                let var_hir_id = freevar.var_id();
+                let closure_def_id = self.tcx().hir().local_def_id_from_hir_id(closure_expr.hir_id);
                 let upvar_id = ty::UpvarId {
                     var_path: ty::UpvarPath { hir_id: var_hir_id },
                     closure_expr_id: closure_def_id.to_local(),
@@ -942,10 +940,10 @@ impl<'a, 'gcx, 'tcx> ExprUseVisitor<'a, 'gcx, 'tcx> {
                                                 self.param_env,
                                                 &cmt_var,
                                                 CaptureMove);
-                        self.delegate.consume(closure_expr.id, freevar.span, &cmt_var, mode);
+                        self.delegate.consume(closure_expr.hir_id, freevar.span, &cmt_var, mode);
                     }
                     ty::UpvarCapture::ByRef(upvar_borrow) => {
-                        self.delegate.borrow(closure_expr.id,
+                        self.delegate.borrow(closure_expr.hir_id,
                                              fn_decl_span,
                                              &cmt_var,
                                              upvar_borrow.region,
@@ -964,7 +962,7 @@ impl<'a, 'gcx, 'tcx> ExprUseVisitor<'a, 'gcx, 'tcx> {
                         -> mc::McResult<mc::cmt_<'tcx>> {
         // Create the cmt for the variable being borrowed, from the
         // caller's perspective
-        let var_hir_id = self.tcx().hir().node_to_hir_id(upvar.var_id());
+        let var_hir_id = upvar.var_id();
         let var_ty = self.mc.node_ty(var_hir_id)?;
         self.mc.cat_def(closure_hir_id, closure_span, var_ty, upvar.def)
     }

--- a/src/librustc/middle/intrinsicck.rs
+++ b/src/librustc/middle/intrinsicck.rs
@@ -151,7 +151,7 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
         };
         if let Def::Fn(did) = def {
             if self.def_id_is_transmute(did) {
-                let typ = self.tables.node_id_to_type(expr.hir_id);
+                let typ = self.tables.hir_id_to_type(expr.hir_id);
                 let sig = typ.fn_sig(self.tcx);
                 let from = sig.inputs().skip_binder()[0];
                 let to = *sig.output().skip_binder();

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -98,7 +98,7 @@ impl<'a, 'v, 'tcx> ItemLikeVisitor<'v> for LanguageItemCollector<'a, 'tcx> {
             match self.item_refs.get(&*value.as_str()).cloned() {
                 // Known lang item with attribute on correct target.
                 Some((item_index, expected_target)) if actual_target == expected_target => {
-                    let def_id = self.tcx.hir().local_def_id(item.id);
+                    let def_id = self.tcx.hir().local_def_id_from_hir_id(item.hir_id);
                     self.collect_item(item_index, def_id);
                 },
                 // Known lang item with attribute on incorrect target.

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -6,9 +6,9 @@
 //! way. Therefore we break lifetime name resolution into a separate pass.
 
 use hir::def::Def;
-use hir::def_id::{CrateNum, DefId, LocalDefId, LOCAL_CRATE};
 use hir::map::Map;
-use hir::{GenericArg, GenericParam, ItemLocalId, LifetimeName, Node, ParamName};
+use hir::def_id::{CrateNum, DefId, LocalDefId, LOCAL_CRATE};
+use hir::{GenericArg, GenericParam, LifetimeName, Node, ParamName};
 use ty::{self, DefIdTree, GenericParamDefKind, TyCtxt};
 
 use errors::{Applicability, DiagnosticBuilder};
@@ -23,7 +23,7 @@ use syntax::attr;
 use syntax::ptr::P;
 use syntax::symbol::keywords;
 use syntax_pos::Span;
-use util::nodemap::{DefIdMap, FxHashMap, FxHashSet, NodeMap, NodeSet};
+use util::nodemap::{DefIdMap, FxHashMap, FxHashSet, HirIdMap, HirIdSet, ItemLocalMap, ItemLocalSet};
 
 use hir::intravisit::{self, NestedVisitorMap, Visitor};
 use hir::{self, GenericParamKind, LifetimeParamKind};
@@ -83,7 +83,7 @@ impl Region {
     fn early(hir_map: &Map<'_>, index: &mut u32, param: &GenericParam) -> (ParamName, Region) {
         let i = *index;
         *index += 1;
-        let def_id = hir_map.local_def_id(param.id);
+        let def_id = hir_map.local_def_id_from_hir_id(param.hir_id);
         let origin = LifetimeDefOrigin::from_param(param);
         debug!("Region::early: index={} def_id={:?}", i, def_id);
         (param.name.modern(), Region::EarlyBound(i, def_id, origin))
@@ -91,7 +91,7 @@ impl Region {
 
     fn late(hir_map: &Map<'_>, param: &GenericParam) -> (ParamName, Region) {
         let depth = ty::INNERMOST;
-        let def_id = hir_map.local_def_id(param.id);
+        let def_id = hir_map.local_def_id_from_hir_id(param.hir_id);
         let origin = LifetimeDefOrigin::from_param(param);
         debug!(
             "Region::late: param={:?} depth={:?} def_id={:?} origin={:?}",
@@ -151,7 +151,7 @@ impl Region {
         if let Region::EarlyBound(index, _, _) = self {
             params
                 .nth(index as usize)
-                .and_then(|lifetime| map.defs.get(&lifetime.id).cloned())
+                .and_then(|lifetime| map.defs.get(&lifetime.hir_id).cloned())
         } else {
             Some(self)
         }
@@ -195,25 +195,25 @@ pub type ObjectLifetimeDefault = Set1<Region>;
 struct NamedRegionMap {
     // maps from every use of a named (not anonymous) lifetime to a
     // `Region` describing how that region is bound
-    pub defs: NodeMap<Region>,
+    pub defs: HirIdMap<Region>,
 
     // the set of lifetime def ids that are late-bound; a region can
     // be late-bound if (a) it does NOT appear in a where-clause and
     // (b) it DOES appear in the arguments.
-    pub late_bound: NodeSet,
+    pub late_bound: HirIdSet,
 
     // For each type and trait definition, maps type parameters
     // to the trait object lifetime defaults computed from them.
-    pub object_lifetime_defaults: NodeMap<Vec<ObjectLifetimeDefault>>,
+    pub object_lifetime_defaults: HirIdMap<Vec<ObjectLifetimeDefault>>,
 }
 
 /// See `NamedRegionMap`.
 #[derive(Default)]
 pub struct ResolveLifetimes {
-    defs: FxHashMap<LocalDefId, Lrc<FxHashMap<ItemLocalId, Region>>>,
-    late_bound: FxHashMap<LocalDefId, Lrc<FxHashSet<ItemLocalId>>>,
+    defs: FxHashMap<LocalDefId, Lrc<ItemLocalMap<Region>>>,
+    late_bound: FxHashMap<LocalDefId, Lrc<ItemLocalSet>>,
     object_lifetime_defaults:
-        FxHashMap<LocalDefId, Lrc<FxHashMap<ItemLocalId, Lrc<Vec<ObjectLifetimeDefault>>>>>,
+        FxHashMap<LocalDefId, Lrc<ItemLocalMap<Lrc<Vec<ObjectLifetimeDefault>>>>>,
 }
 
 impl_stable_hash_for!(struct ::middle::resolve_lifetime::ResolveLifetimes {
@@ -387,20 +387,17 @@ fn resolve_lifetimes<'tcx>(
 
     let mut rl = ResolveLifetimes::default();
 
-    for (k, v) in named_region_map.defs {
-        let hir_id = tcx.hir().node_to_hir_id(k);
+    for (hir_id, v) in named_region_map.defs {
         let map = rl.defs.entry(hir_id.owner_local_def_id()).or_default();
         Lrc::get_mut(map).unwrap().insert(hir_id.local_id, v);
     }
-    for k in named_region_map.late_bound {
-        let hir_id = tcx.hir().node_to_hir_id(k);
+    for hir_id in named_region_map.late_bound {
         let map = rl.late_bound
             .entry(hir_id.owner_local_def_id())
             .or_default();
         Lrc::get_mut(map).unwrap().insert(hir_id.local_id);
     }
-    for (k, v) in named_region_map.object_lifetime_defaults {
-        let hir_id = tcx.hir().node_to_hir_id(k);
+    for (hir_id, v) in named_region_map.object_lifetime_defaults {
         let map = rl.object_lifetime_defaults
             .entry(hir_id.owner_local_def_id())
             .or_default();
@@ -575,7 +572,7 @@ impl<'a, 'tcx> Visitor<'tcx> for LifetimeContext<'a, 'tcx> {
     }
 
     fn visit_ty(&mut self, ty: &'tcx hir::Ty) {
-        debug!("visit_ty: id={:?} ty={:?}", ty.id, ty);
+        debug!("visit_ty: id={:?} ty={:?}", ty.hir_id, ty);
         match ty.node {
             hir::TyKind::BareFn(ref c) => {
                 let next_early_index = self.next_early_index();
@@ -634,7 +631,7 @@ impl<'a, 'tcx> Visitor<'tcx> for LifetimeContext<'a, 'tcx> {
             hir::TyKind::Rptr(ref lifetime_ref, ref mt) => {
                 self.visit_lifetime(lifetime_ref);
                 let scope = Scope::ObjectLifetimeDefault {
-                    lifetime: self.map.defs.get(&lifetime_ref.id).cloned(),
+                    lifetime: self.map.defs.get(&lifetime_ref.hir_id).cloned(),
                     s: self.scope,
                 };
                 self.with(scope, |_, this| this.visit_ty(&mt.ty));
@@ -677,15 +674,16 @@ impl<'a, 'tcx> Visitor<'tcx> for LifetimeContext<'a, 'tcx> {
                         // and ban them. Type variables instantiated inside binders aren't
                         // well-supported at the moment, so this doesn't work.
                         // In the future, this should be fixed and this error should be removed.
-                        let def = self.map.defs.get(&lifetime.id).cloned();
+                        let def = self.map.defs.get(&lifetime.hir_id).cloned();
                         if let Some(Region::LateBound(_, def_id, _)) = def {
-                            if let Some(node_id) = self.tcx.hir().as_local_node_id(def_id) {
+                            if let Some(hir_id) = self.tcx.hir().as_local_hir_id(def_id) {
                                 // Ensure that the parent of the def is an item, not HRTB
-                                let parent_id = self.tcx.hir().get_parent_node(node_id);
-                                let parent_impl_id = hir::ImplItemId { node_id: parent_id };
-                                let parent_trait_id = hir::TraitItemId { node_id: parent_id };
+                                let parent_id = self.tcx.hir().get_parent_node(hir_id);
+                                let parent_node_id = self.tcx.hir().hir_to_node_id(parent_id);
+                                let parent_impl_id = hir::ImplItemId { node_id: parent_node_id };
+                                let parent_trait_id = hir::TraitItemId { node_id: parent_node_id };
                                 let krate = self.tcx.hir().forest.krate();
-                                if !(krate.items.contains_key(&parent_id)
+                                if !(krate.items.contains_key(&parent_node_id)
                                     || krate.impl_items.contains_key(&parent_impl_id)
                                     || krate.trait_items.contains_key(&parent_trait_id))
                                 {
@@ -780,7 +778,7 @@ impl<'a, 'tcx> Visitor<'tcx> for LifetimeContext<'a, 'tcx> {
             Method(ref sig, _) => {
                 let tcx = self.tcx;
                 self.visit_early_late(
-                    Some(tcx.hir().get_parent(trait_item.id)),
+                    Some(tcx.hir().get_parent(trait_item.hir_id)),
                     &sig.decl,
                     &trait_item.generics,
                     |this| intravisit::walk_trait_item(this, trait_item),
@@ -835,7 +833,7 @@ impl<'a, 'tcx> Visitor<'tcx> for LifetimeContext<'a, 'tcx> {
             Method(ref sig, _) => {
                 let tcx = self.tcx;
                 self.visit_early_late(
-                    Some(tcx.hir().get_parent(impl_item.id)),
+                    Some(tcx.hir().get_parent(impl_item.hir_id)),
                     &sig.decl,
                     &impl_item.generics,
                     |this| intravisit::walk_impl_item(this, impl_item),
@@ -1248,12 +1246,12 @@ fn extract_labels(ctxt: &mut LifetimeContext<'_, '_>, body: &hir::Body) {
                 } => {
                     // FIXME (#24278): non-hygienic comparison
                     if let Some(def) = lifetimes.get(&hir::ParamName::Plain(label.modern())) {
-                        let node_id = tcx.hir().as_local_node_id(def.id().unwrap()).unwrap();
+                        let hir_id = tcx.hir().as_local_hir_id(def.id().unwrap()).unwrap();
 
                         signal_shadowing_problem(
                             tcx,
                             label.name,
-                            original_lifetime(tcx.hir().span(node_id)),
+                            original_lifetime(tcx.hir().span(hir_id)),
                             shadower_label(label.span),
                         );
                         return;
@@ -1267,8 +1265,8 @@ fn extract_labels(ctxt: &mut LifetimeContext<'_, '_>, body: &hir::Body) {
 
 fn compute_object_lifetime_defaults(
     tcx: TyCtxt<'_, '_, '_>,
-) -> NodeMap<Vec<ObjectLifetimeDefault>> {
-    let mut map = NodeMap::default();
+) -> HirIdMap<Vec<ObjectLifetimeDefault>> {
+    let mut map = HirIdMap::default();
     for item in tcx.hir().krate().items.values() {
         match item.node {
             hir::ItemKind::Struct(_, ref generics)
@@ -1312,7 +1310,7 @@ fn compute_object_lifetime_defaults(
                     tcx.sess.span_err(item.span, &object_lifetime_default_reprs);
                 }
 
-                map.insert(item.id, result);
+                map.insert(item.hir_id, result);
             }
             _ => {}
         }
@@ -1345,7 +1343,7 @@ fn object_lifetime_defaults_for_item(
 
                 add_bounds(&mut set, &param.bounds);
 
-                let param_def_id = tcx.hir().local_def_id(param.id);
+                let param_def_id = tcx.hir().local_def_id_from_hir_id(param.hir_id);
                 for predicate in &generics.where_clause.predicates {
                     // Look for `type: ...` where clauses.
                     let data = match *predicate {
@@ -1380,7 +1378,7 @@ fn object_lifetime_defaults_for_item(
                                 .iter()
                                 .filter_map(|param| match param.kind {
                                     GenericParamKind::Lifetime { .. } => Some((
-                                        param.id,
+                                        param.hir_id,
                                         hir::LifetimeName::Param(param.name),
                                         LifetimeDefOrigin::from_param(param),
                                     )),
@@ -1389,7 +1387,7 @@ fn object_lifetime_defaults_for_item(
                                 .enumerate()
                                 .find(|&(_, (_, lt_name, _))| lt_name == name)
                                 .map_or(Set1::Many, |(i, (id, _, origin))| {
-                                    let def_id = tcx.hir().local_def_id(id);
+                                    let def_id = tcx.hir().local_def_id_from_hir_id(id);
                                     Set1::One(Region::EarlyBound(i as u32, def_id, origin))
                                 })
                         }
@@ -1503,8 +1501,10 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
                 }
             }
         };
-        if let Node::Lifetime(hir_lifetime) = self.tcx.hir().get(lifetime.id) {
-            if let Some(parent) = self.tcx.hir().find(self.tcx.hir().get_parent(hir_lifetime.id)) {
+        if let Node::Lifetime(hir_lifetime) = self.tcx.hir().get_by_hir_id(lifetime.hir_id) {
+            if let Some(parent) = self.tcx.hir().find_by_hir_id(
+                self.tcx.hir().get_parent(hir_lifetime.hir_id))
+            {
                 match parent {
                     Node::Item(item) => {
                         if let hir::ItemKind::Fn(decl, _, _, _) = &item.node {
@@ -1581,19 +1581,20 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
             match lifetimeuseset {
                 Some(LifetimeUseSet::One(lifetime)) => {
                     let node_id = self.tcx.hir().as_local_node_id(def_id).unwrap();
-                    debug!("node id first={:?}", node_id);
-                    if let Some((id, span, name)) = match self.tcx.hir().get(node_id) {
+                    let hir_id = self.tcx.hir().node_to_hir_id(node_id);
+                    debug!("node id first={:?}", hir_id);
+                    if let Some((id, span, name)) = match self.tcx.hir().get_by_hir_id(hir_id) {
                         Node::Lifetime(hir_lifetime) => Some((
-                            hir_lifetime.id,
+                            hir_lifetime.hir_id,
                             hir_lifetime.span,
                             hir_lifetime.name.ident(),
                         )),
                         Node::GenericParam(param) => {
-                            Some((param.id, param.span, param.name.ident()))
+                            Some((param.hir_id, param.span, param.name.ident()))
                         }
                         _ => None,
                     } {
-                        debug!("id = {:?} span = {:?} name = {:?}", node_id, span, name);
+                        debug!("id = {:?} span = {:?} name = {:?}", hir_id, span, name);
 
                         if name == keywords::UnderscoreLifetime.ident() {
                             continue;
@@ -1622,18 +1623,19 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
                 }
                 None => {
                     let node_id = self.tcx.hir().as_local_node_id(def_id).unwrap();
-                    if let Some((id, span, name)) = match self.tcx.hir().get(node_id) {
+                    let hir_id = self.tcx.hir().node_to_hir_id(node_id);
+                    if let Some((id, span, name)) = match self.tcx.hir().get_by_hir_id(hir_id) {
                         Node::Lifetime(hir_lifetime) => Some((
-                            hir_lifetime.id,
+                            hir_lifetime.hir_id,
                             hir_lifetime.span,
                             hir_lifetime.name.ident(),
                         )),
                         Node::GenericParam(param) => {
-                            Some((param.id, param.span, param.name.ident()))
+                            Some((param.hir_id, param.span, param.name.ident()))
                         }
                         _ => None,
                     } {
-                        debug!("id ={:?} span = {:?} name = {:?}", node_id, span, name);
+                        debug!("id ={:?} span = {:?} name = {:?}", hir_id, span, name);
                         let mut err = self.tcx.struct_span_lint_node(
                             lint::builtin::UNUSED_LIFETIMES,
                             id,
@@ -1680,7 +1682,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
     /// ordering is not important there.
     fn visit_early_late<F>(
         &mut self,
-        parent_id: Option<ast::NodeId>,
+        parent_id: Option<hir::HirId>,
         decl: &'tcx hir::FnDecl,
         generics: &'tcx hir::Generics,
         walk: F,
@@ -1692,7 +1694,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
         // Find the start of nested early scopes, e.g., in methods.
         let mut index = 0;
         if let Some(parent_id) = parent_id {
-            let parent = self.tcx.hir().expect_item(parent_id);
+            let parent = self.tcx.hir().expect_item_by_hir_id(parent_id);
             if sub_items_have_self_param(&parent.node) {
                 index += 1; // Self comes before lifetimes
             }
@@ -1711,7 +1713,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
             .iter()
             .filter_map(|param| match param.kind {
                 GenericParamKind::Lifetime { .. } => {
-                    if self.map.late_bound.contains(&param.id) {
+                    if self.map.late_bound.contains(&param.hir_id) {
                         Some(Region::late(&self.tcx.hir(), param))
                     } else {
                         Some(Region::early(&self.tcx.hir(), &mut index, param))
@@ -1828,7 +1830,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
                 // Do not free early-bound regions, only late-bound ones.
             } else if let Some(body_id) = outermost_body {
                 let fn_id = self.tcx.hir().body_owner(body_id);
-                match self.tcx.hir().get(fn_id) {
+                match self.tcx.hir().get_by_hir_id(fn_id) {
                     Node::Item(&hir::Item {
                         node: hir::ItemKind::Fn(..),
                         ..
@@ -1841,7 +1843,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
                         node: hir::ImplItemKind::Method(..),
                         ..
                     }) => {
-                        let scope = self.tcx.hir().local_def_id(fn_id);
+                        let scope = self.tcx.hir().local_def_id_from_hir_id(fn_id);
                         def = Region::Free(scope, def.id().unwrap());
                     }
                     _ => {}
@@ -1957,8 +1959,10 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
             };
 
             let map = &self.map;
-            let unsubst = if let Some(id) = self.tcx.hir().as_local_node_id(def_id) {
-                &map.object_lifetime_defaults[&id]
+            let hir = self.tcx.hir();
+            let unsubst = if let Some(node_id) = hir.as_local_node_id(def_id) {
+                let hir_id = hir.definitions().node_to_hir_id(node_id);
+                &map.object_lifetime_defaults[&hir_id]
             } else {
                 let tcx = self.tcx;
                 self.xcrate_object_lifetime_defaults
@@ -2051,8 +2055,8 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
         // and whether there's a `self` argument (treated specially).
         let mut assoc_item_kind = None;
         let mut impl_self = None;
-        let parent = self.tcx.hir().get_parent_node(output.id);
-        let body = match self.tcx.hir().get(parent) {
+        let parent = self.tcx.hir().get_parent_node(output.hir_id);
+        let body = match self.tcx.hir().get_by_hir_id(parent) {
             // `fn` definitions and methods.
             Node::Item(&hir::Item {
                 node: hir::ItemKind::Fn(.., body),
@@ -2065,12 +2069,12 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
             }) => {
                 if let hir::ItemKind::Trait(.., ref trait_items) = self.tcx
                     .hir()
-                    .expect_item(self.tcx.hir().get_parent(parent))
+                    .expect_item_by_hir_id(self.tcx.hir().get_parent(parent))
                     .node
                 {
                     assoc_item_kind = trait_items
                         .iter()
-                        .find(|ti| ti.id.node_id == parent)
+                        .find(|ti| ti.id.node_id == self.tcx.hir().hir_to_node_id(parent))
                         .map(|ti| ti.kind);
                 }
                 match *m {
@@ -2085,13 +2089,13 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
             }) => {
                 if let hir::ItemKind::Impl(.., ref self_ty, ref impl_items) = self.tcx
                     .hir()
-                    .expect_item(self.tcx.hir().get_parent(parent))
+                    .expect_item_by_hir_id(self.tcx.hir().get_parent(parent))
                     .node
                 {
                     impl_self = Some(self_ty);
                     assoc_item_kind = impl_items
                         .iter()
-                        .find(|ii| ii.id.node_id == parent)
+                        .find(|ii| ii.id.node_id == self.tcx.hir().hir_to_node_id(parent))
                         .map(|ii| ii.kind);
                 }
                 Some(body)
@@ -2145,7 +2149,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
             if let hir::TyKind::Rptr(lifetime_ref, ref mt) = inputs[0].node {
                 if let hir::TyKind::Path(hir::QPath::Resolved(None, ref path)) = mt.ty.node {
                     if is_self_ty(path.def) {
-                        if let Some(&lifetime) = self.map.defs.get(&lifetime_ref.id) {
+                        if let Some(&lifetime) = self.map.defs.get(&lifetime_ref.hir_id) {
                             let scope = Scope::Elision {
                                 elide: Elide::Exact(lifetime),
                                 s: self.scope,
@@ -2264,7 +2268,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
             }
 
             fn visit_lifetime(&mut self, lifetime_ref: &hir::Lifetime) {
-                if let Some(&lifetime) = self.map.defs.get(&lifetime_ref.id) {
+                if let Some(&lifetime) = self.map.defs.get(&lifetime_ref.hir_id) {
                     match lifetime {
                         Region::LateBound(debruijn, _, _) | Region::LateBoundAnon(debruijn, _)
                             if debruijn < self.outer_index =>
@@ -2387,7 +2391,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
 
             let help_name = if let Some(body) = parent {
                 let arg = &self.tcx.hir().body(body).arguments[index];
-                format!("`{}`", self.tcx.hir().node_to_pretty_string(arg.pat.id))
+                format!("`{}`", self.tcx.hir().node_to_pretty_string_by_hir_id(arg.pat.hir_id))
             } else {
                 format!("argument {}", index + 1)
             };
@@ -2593,12 +2597,12 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
                     ref lifetimes, s, ..
                 } => {
                     if let Some(&def) = lifetimes.get(&param.name.modern()) {
-                        let node_id = self.tcx.hir().as_local_node_id(def.id().unwrap()).unwrap();
+                        let hir_id = self.tcx.hir().as_local_hir_id(def.id().unwrap()).unwrap();
 
                         signal_shadowing_problem(
                             self.tcx,
                             param.name.ident().name,
-                            original_lifetime(self.tcx.hir().span(node_id)),
+                            original_lifetime(self.tcx.hir().span(hir_id)),
                             shadower_lifetime(&param),
                         );
                         return;
@@ -2655,7 +2659,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
     }
 
     fn insert_lifetime(&mut self, lifetime_ref: &'tcx hir::Lifetime, def: Region) {
-        if lifetime_ref.id == ast::DUMMY_NODE_ID {
+        if lifetime_ref.hir_id == hir::DUMMY_HIR_ID {
             span_bug!(
                 lifetime_ref.span,
                 "lifetime reference not renumbered, \
@@ -2665,11 +2669,11 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
 
         debug!(
             "insert_lifetime: {} resolved to {:?} span={:?}",
-            self.tcx.hir().node_to_string(lifetime_ref.id),
+            self.tcx.hir().hir_to_string(lifetime_ref.hir_id),
             def,
             self.tcx.sess.source_map().span_to_string(lifetime_ref.span)
         );
-        self.map.defs.insert(lifetime_ref.id, def);
+        self.map.defs.insert(lifetime_ref.hir_id, def);
 
         match def {
             Region::LateBoundAnon(..) | Region::Static => {
@@ -2701,7 +2705,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
     /// error (esp. around impl trait). In that case, we remove the
     /// entry into `map.defs` so as not to confuse later code.
     fn uninsert_lifetime_on_error(&mut self, lifetime_ref: &'tcx hir::Lifetime, bad_def: Region) {
-        let old_value = self.map.defs.remove(&lifetime_ref.id);
+        let old_value = self.map.defs.remove(&lifetime_ref.hir_id);
         assert_eq!(old_value, Some(bad_def));
     }
 }
@@ -2790,11 +2794,11 @@ fn insert_late_bound_lifetimes(
         debug!(
             "insert_late_bound_lifetimes: lifetime {:?} with id {:?} is late-bound",
             param.name.ident(),
-            param.id
+            param.hir_id
         );
 
-        let inserted = map.late_bound.insert(param.id);
-        assert!(inserted, "visited lifetime {:?} twice", param.id);
+        let inserted = map.late_bound.insert(param.hir_id);
+        assert!(inserted, "visited lifetime {:?} twice", param.hir_id);
     }
 
     return;

--- a/src/librustc/mir/interpret/error.rs
+++ b/src/librustc/mir/interpret/error.rs
@@ -1,5 +1,6 @@
 use std::{fmt, env};
 
+use hir;
 use hir::map::definitions::DefPathData;
 use mir;
 use ty::{self, Ty, layout};
@@ -14,7 +15,6 @@ use ty::query::TyCtxtAt;
 use errors::DiagnosticBuilder;
 
 use syntax_pos::{Pos, Span};
-use syntax::ast;
 use syntax::symbol::Symbol;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -50,7 +50,7 @@ pub struct ConstEvalErr<'tcx> {
 pub struct FrameInfo<'tcx> {
     pub call_site: Span, // this span is in the caller!
     pub instance: ty::Instance<'tcx>,
-    pub lint_root: Option<ast::NodeId>,
+    pub lint_root: Option<hir::HirId>,
 }
 
 impl<'tcx> fmt::Display for FrameInfo<'tcx> {
@@ -98,7 +98,7 @@ impl<'a, 'gcx, 'tcx> ConstEvalErr<'tcx> {
     pub fn report_as_lint(&self,
         tcx: TyCtxtAt<'a, 'gcx, 'tcx>,
         message: &str,
-        lint_root: ast::NodeId,
+        lint_root: hir::HirId,
     ) -> ErrorHandled {
         let lint = self.struct_generic(
             tcx,
@@ -118,7 +118,7 @@ impl<'a, 'gcx, 'tcx> ConstEvalErr<'tcx> {
         &self,
         tcx: TyCtxtAt<'a, 'gcx, 'tcx>,
         message: &str,
-        lint_root: Option<ast::NodeId>,
+        lint_root: Option<hir::HirId>,
     ) -> Result<DiagnosticBuilder<'tcx>, ErrorHandled> {
         match self.error {
             EvalErrorKind::Layout(LayoutError::Unknown(_)) |
@@ -129,7 +129,7 @@ impl<'a, 'gcx, 'tcx> ConstEvalErr<'tcx> {
         }
         trace!("reporting const eval failure at {:?}", self.span);
         let mut err = if let Some(lint_root) = lint_root {
-            let node_id = self.stacktrace
+            let hir_id = self.stacktrace
                 .iter()
                 .rev()
                 .filter_map(|frame| frame.lint_root)
@@ -137,7 +137,7 @@ impl<'a, 'gcx, 'tcx> ConstEvalErr<'tcx> {
                 .unwrap_or(lint_root);
             tcx.struct_span_lint_node(
                 ::rustc::lint::builtin::CONST_ERR,
-                node_id,
+                hir_id,
                 tcx.span,
                 message,
             )

--- a/src/librustc/mir/mono.rs
+++ b/src/librustc/mir/mono.rs
@@ -1,5 +1,5 @@
+use hir;
 use hir::def_id::{DefId, CrateNum, LOCAL_CRATE};
-use syntax::ast::NodeId;
 use syntax::symbol::{Symbol, InternedString};
 use ty::{Instance, TyCtxt};
 use util::nodemap::FxHashMap;
@@ -14,7 +14,7 @@ use std::hash::Hash;
 pub enum MonoItem<'tcx> {
     Fn(Instance<'tcx>),
     Static(DefId),
-    GlobalAsm(NodeId),
+    GlobalAsm(hir::HirId),
 }
 
 impl<'tcx> MonoItem<'tcx> {

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -3,6 +3,7 @@ use self::code_stats::CodeStats;
 
 use dep_graph::cgu_reuse_tracker::CguReuseTracker;
 use hir::def_id::CrateNum;
+use hir::HirId;
 use rustc_data_structures::fingerprint::Fingerprint;
 
 use lint;
@@ -68,7 +69,7 @@ pub struct Session {
     pub target_tlib_path: Option<SearchPath>,
     pub parse_sess: ParseSess,
     /// For a library crate, this is always none
-    pub entry_fn: Once<Option<(NodeId, Span, config::EntryFnType)>>,
+    pub entry_fn: Once<Option<(HirId, Span, config::EntryFnType)>>,
     pub sysroot: PathBuf,
     /// The name of the root source file of the crate, in the local file system.
     /// `None` means that there is no source file.

--- a/src/librustc/traits/auto_trait.rs
+++ b/src/librustc/traits/auto_trait.rs
@@ -202,7 +202,7 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
                 full_env,
                 ty,
                 trait_did,
-                ObligationCause::misc(DUMMY_SP, ast::DUMMY_NODE_ID),
+                ObligationCause::misc(DUMMY_SP, hir::DUMMY_HIR_ID),
             );
             fulfill.select_all_or_error(&infcx).unwrap_or_else(|e| {
                 panic!(
@@ -315,7 +315,7 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
             user_env.caller_bounds.iter().cloned().collect();
 
         let mut new_env = param_env.clone();
-        let dummy_cause = ObligationCause::misc(DUMMY_SP, ast::DUMMY_NODE_ID);
+        let dummy_cause = ObligationCause::misc(DUMMY_SP, hir::DUMMY_HIR_ID);
 
         while let Some(pred) = predicates.pop_front() {
             infcx.clear_caches();
@@ -669,7 +669,7 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
         select: &mut SelectionContext<'c, 'd, 'cx>,
         only_projections: bool,
     ) -> bool {
-        let dummy_cause = ObligationCause::misc(DUMMY_SP, ast::DUMMY_NODE_ID);
+        let dummy_cause = ObligationCause::misc(DUMMY_SP, hir::DUMMY_HIR_ID);
 
         for (obligation, mut predicate) in nested
             .map(|o| (o.clone(), o.predicate.clone()))

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -894,9 +894,9 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
     fn suggest_borrow_on_unsized_slice(&self,
                                        code: &ObligationCauseCode<'tcx>,
                                        err: &mut DiagnosticBuilder<'tcx>) {
-        if let &ObligationCauseCode::VariableType(node_id) = code {
-            let parent_node = self.tcx.hir().get_parent_node(node_id);
-            if let Some(Node::Local(ref local)) = self.tcx.hir().find(parent_node) {
+        if let &ObligationCauseCode::VariableType(hir_id) = code {
+            let parent_node = self.tcx.hir().get_parent_node(hir_id);
+            if let Some(Node::Local(ref local)) = self.tcx.hir().find_by_hir_id(parent_node) {
                 if let Some(ref expr) = local.init {
                     if let hir::ExprKind::Index(_, _) = expr.node {
                         if let Ok(snippet) = self.tcx.sess.source_map().span_to_snippet(expr.span) {
@@ -1031,7 +1031,8 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                  ).collect::<Vec<_>>())
             }
             Node::StructCtor(ref variant_data) => {
-                (self.tcx.sess.source_map().def_span(self.tcx.hir().span(variant_data.id())),
+                (self.tcx.sess.source_map().def_span(self.tcx.hir().span(
+                    variant_data.hir_id())),
                  vec![ArgKind::empty(); variant_data.fields().len()])
             }
             _ => panic!("non-FnLike node found: {:?}", node),

--- a/src/librustc/traits/mod.rs
+++ b/src/librustc/traits/mod.rs
@@ -132,7 +132,7 @@ pub struct ObligationCause<'tcx> {
     // (in particular, closures can add new assumptions). See the
     // field `region_obligations` of the `FulfillmentContext` for more
     // information.
-    pub body_id: ast::NodeId,
+    pub body_id: hir::HirId,
 
     pub code: ObligationCauseCode<'tcx>
 }
@@ -185,7 +185,7 @@ pub enum ObligationCauseCode<'tcx> {
     /// S { ... } must be Sized
     StructInitializerSized,
     /// Type of each variable must be Sized
-    VariableType(ast::NodeId),
+    VariableType(hir::HirId),
     /// Argument type must be Sized
     SizedArgumentType,
     /// Return type must be Sized
@@ -254,10 +254,10 @@ pub enum ObligationCauseCode<'tcx> {
     ReturnNoExpression,
 
     /// `return` with an expression
-    ReturnType(ast::NodeId),
+    ReturnType(hir::HirId),
 
     /// Block implicit return
-    BlockTailExpression(ast::NodeId),
+    BlockTailExpression(hir::HirId),
 
     /// #[feature(trivial_bounds)] is not enabled
     TrivialBound,
@@ -655,7 +655,7 @@ pub fn type_known_to_meet_bound_modulo_regions<'a, 'gcx, 'tcx>(
     };
     let obligation = Obligation {
         param_env,
-        cause: ObligationCause::misc(span, ast::DUMMY_NODE_ID),
+        cause: ObligationCause::misc(span, hir::DUMMY_HIR_ID),
         recursion_depth: 0,
         predicate: trait_ref.to_predicate(),
     };
@@ -678,7 +678,7 @@ pub fn type_known_to_meet_bound_modulo_regions<'a, 'gcx, 'tcx>(
         // We can use a dummy node-id here because we won't pay any mind
         // to region obligations that arise (there shouldn't really be any
         // anyhow).
-        let cause = ObligationCause::misc(span, ast::DUMMY_NODE_ID);
+        let cause = ObligationCause::misc(span, hir::DUMMY_HIR_ID);
 
         fulfill_cx.register_bound(infcx, param_env, ty, def_id, cause);
 
@@ -1058,7 +1058,7 @@ impl<'tcx,O> Obligation<'tcx,O> {
     }
 
     pub fn misc(span: Span,
-                body_id: ast::NodeId,
+                body_id: hir::HirId,
                 param_env: ty::ParamEnv<'tcx>,
                 trait_ref: O)
                 -> Obligation<'tcx, O> {
@@ -1076,18 +1076,18 @@ impl<'tcx,O> Obligation<'tcx,O> {
 impl<'tcx> ObligationCause<'tcx> {
     #[inline]
     pub fn new(span: Span,
-               body_id: ast::NodeId,
+               body_id: hir::HirId,
                code: ObligationCauseCode<'tcx>)
                -> ObligationCause<'tcx> {
         ObligationCause { span: span, body_id: body_id, code: code }
     }
 
-    pub fn misc(span: Span, body_id: ast::NodeId) -> ObligationCause<'tcx> {
+    pub fn misc(span: Span, body_id: hir::HirId) -> ObligationCause<'tcx> {
         ObligationCause { span: span, body_id: body_id, code: MiscObligation }
     }
 
     pub fn dummy() -> ObligationCause<'tcx> {
-        ObligationCause { span: DUMMY_SP, body_id: ast::CRATE_NODE_ID, code: MiscObligation }
+        ObligationCause { span: DUMMY_SP, body_id: hir::CRATE_HIR_ID, code: MiscObligation }
     }
 }
 

--- a/src/librustc/traits/object_safety.rs
+++ b/src/librustc/traits/object_safety.rs
@@ -10,6 +10,7 @@
 
 use super::elaborate_predicates;
 
+use hir;
 use hir::def_id::DefId;
 use lint;
 use traits::{self, Obligation, ObligationCause};
@@ -129,7 +130,7 @@ impl<'a, 'tcx> TyCtxt<'a, 'tcx, 'tcx> {
                     // It's also hard to get a use site span, so we use the method definition span.
                     self.lint_node_note(
                         lint::builtin::WHERE_CLAUSES_OBJECT_SAFETY,
-                        ast::CRATE_NODE_ID,
+                        hir::CRATE_HIR_ID,
                         *span,
                         &format!("the trait `{}` cannot be made into an object",
                                  self.item_path_str(trait_def_id)),

--- a/src/librustc/traits/query/outlives_bounds.rs
+++ b/src/librustc/traits/query/outlives_bounds.rs
@@ -1,6 +1,6 @@
+use hir;
 use infer::InferCtxt;
 use infer::canonical::OriginalQueryValues;
-use syntax::ast;
 use syntax::source_map::Span;
 use traits::{FulfillmentContext, ObligationCause, TraitEngine, TraitEngineExt};
 use traits::query::NoSolution;
@@ -89,7 +89,7 @@ impl<'cx, 'gcx, 'tcx> InferCtxt<'cx, 'gcx, 'tcx> {
     pub fn implied_outlives_bounds(
         &self,
         param_env: ty::ParamEnv<'tcx>,
-        body_id: ast::NodeId,
+        body_id: hir::HirId,
         ty: Ty<'tcx>,
         span: Span,
     ) -> Vec<OutlivesBound<'tcx>> {

--- a/src/librustc/traits/specialize/mod.rs
+++ b/src/librustc/traits/specialize/mod.rs
@@ -334,9 +334,11 @@ pub(super) fn specialization_graph_provider<'a, 'tcx>(
                         FutureCompatOverlapErrorKind::Issue33140 =>
                             lint::builtin::ORDER_DEPENDENT_TRAIT_OBJECTS,
                     };
+                    let node_id = tcx.hir().as_local_node_id(impl_def_id).unwrap();
+                    let hir_id = tcx.hir().node_to_hir_id(node_id);
                     tcx.struct_span_lint_node(
                         lint,
-                        tcx.hir().as_local_node_id(impl_def_id).unwrap(),
+                        hir_id,
                         impl_span,
                         &msg)
                 } else {

--- a/src/librustc/ty/item_path.rs
+++ b/src/librustc/ty/item_path.rs
@@ -1,3 +1,4 @@
+use hir;
 use hir::map::DefPathData;
 use hir::def_id::{CrateNum, DefId, CRATE_DEF_INDEX, LOCAL_CRATE};
 use ty::{self, DefIdTree, Ty, TyCtxt};
@@ -74,6 +75,10 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
     /// Returns a string identifying this local node-id.
     pub fn node_path_str(self, id: ast::NodeId) -> String {
         self.item_path_str(self.hir().local_def_id(id))
+    }
+
+    pub fn hir_path_str(self, id: hir::HirId) -> String {
+        self.item_path_str(self.hir().local_def_id_from_hir_id(id))
     }
 
     /// Returns a string identifying this def-id. This string is

--- a/src/librustc/ty/query/config.rs
+++ b/src/librustc/ty/query/config.rs
@@ -271,7 +271,7 @@ impl<'tcx> QueryDescription<'tcx> for queries::erase_regions_ty<'tcx> {
 
 impl<'tcx> QueryDescription<'tcx> for queries::type_param_predicates<'tcx> {
     fn describe(tcx: TyCtxt<'_, '_, '_>, (_, def_id): (DefId, DefId)) -> Cow<'static, str> {
-        let id = tcx.hir().as_local_node_id(def_id).unwrap();
+        let id = tcx.hir().as_local_hir_id(def_id).unwrap();
         format!("computing the bounds for type parameter `{}`",
                 tcx.hir().ty_param_name(id)).into()
     }

--- a/src/librustc/ty/wf.rs
+++ b/src/librustc/ty/wf.rs
@@ -1,10 +1,10 @@
+use hir;
 use hir::def_id::DefId;
 use infer::InferCtxt;
 use ty::subst::Substs;
 use traits;
 use ty::{self, ToPredicate, Ty, TyCtxt, TypeFoldable};
 use std::iter::once;
-use syntax::ast;
 use syntax_pos::Span;
 use middle::lang_items;
 
@@ -16,7 +16,7 @@ use middle::lang_items;
 /// say "$0 is WF if $0 is WF".
 pub fn obligations<'a, 'gcx, 'tcx>(infcx: &InferCtxt<'a, 'gcx, 'tcx>,
                                    param_env: ty::ParamEnv<'tcx>,
-                                   body_id: ast::NodeId,
+                                   body_id: hir::HirId,
                                    ty: Ty<'tcx>,
                                    span: Span)
                                    -> Option<Vec<traits::PredicateObligation<'tcx>>>
@@ -42,7 +42,7 @@ pub fn obligations<'a, 'gcx, 'tcx>(infcx: &InferCtxt<'a, 'gcx, 'tcx>,
 /// if `Bar: Eq`.
 pub fn trait_obligations<'a, 'gcx, 'tcx>(infcx: &InferCtxt<'a, 'gcx, 'tcx>,
                                          param_env: ty::ParamEnv<'tcx>,
-                                         body_id: ast::NodeId,
+                                         body_id: hir::HirId,
                                          trait_ref: &ty::TraitRef<'tcx>,
                                          span: Span)
                                          -> Vec<traits::PredicateObligation<'tcx>>
@@ -54,7 +54,7 @@ pub fn trait_obligations<'a, 'gcx, 'tcx>(infcx: &InferCtxt<'a, 'gcx, 'tcx>,
 
 pub fn predicate_obligations<'a, 'gcx, 'tcx>(infcx: &InferCtxt<'a, 'gcx, 'tcx>,
                                              param_env: ty::ParamEnv<'tcx>,
-                                             body_id: ast::NodeId,
+                                             body_id: hir::HirId,
                                              predicate: &ty::Predicate<'tcx>,
                                              span: Span)
                                              -> Vec<traits::PredicateObligation<'tcx>>
@@ -103,7 +103,7 @@ pub fn predicate_obligations<'a, 'gcx, 'tcx>(infcx: &InferCtxt<'a, 'gcx, 'tcx>,
 struct WfPredicates<'a, 'gcx: 'a+'tcx, 'tcx: 'a> {
     infcx: &'a InferCtxt<'a, 'gcx, 'tcx>,
     param_env: ty::ParamEnv<'tcx>,
-    body_id: ast::NodeId,
+    body_id: hir::HirId,
     span: Span,
     out: Vec<traits::PredicateObligation<'tcx>>,
 }

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -800,7 +800,7 @@ impl fmt::Debug for ty::UpvarId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "UpvarId({:?};`{}`;{:?})",
                self.var_path.hir_id,
-               ty::tls::with(|tcx| tcx.hir().name(tcx.hir().hir_to_node_id(self.var_path.hir_id))),
+               ty::tls::with(|tcx| tcx.hir().name(self.var_path.hir_id)),
                self.closure_expr_id)
     }
 }
@@ -1362,15 +1362,16 @@ define_print! {
                         write!(f, "[static generator")?;
                     }
 
-                    if let Some(node_id) = tcx.hir().as_local_node_id(did) {
-                        write!(f, "@{:?}", tcx.hir().span(node_id))?;
+                    if let Some(hir_id) = tcx.hir().as_local_hir_id(did) {
+                        write!(f, "@{:?}", tcx.hir().span(hir_id))?;
                         let mut sep = " ";
-                        tcx.with_freevars(node_id, |freevars| {
+                        tcx.with_freevars(hir_id, |freevars| {
                             for (freevar, upvar_ty) in freevars.iter().zip(upvar_tys) {
+                                let var_hir_id = freevar.var_id();
                                 print!(f, cx,
                                        write("{}{}:",
                                              sep,
-                                             tcx.hir().name(freevar.var_id())),
+                                             tcx.hir().name(var_hir_id)),
                                        print(upvar_ty))?;
                                 sep = ", ";
                             }
@@ -1398,19 +1399,20 @@ define_print! {
                     let upvar_tys = substs.upvar_tys(did, tcx);
                     write!(f, "[closure")?;
 
-                    if let Some(node_id) = tcx.hir().as_local_node_id(did) {
+                    if let Some(hir_id) = tcx.hir().as_local_hir_id(did) {
                         if tcx.sess.opts.debugging_opts.span_free_formats {
-                            write!(f, "@{:?}", node_id)?;
+                            write!(f, "@{:?}", hir_id)?;
                         } else {
-                            write!(f, "@{:?}", tcx.hir().span(node_id))?;
+                            write!(f, "@{:?}", tcx.hir().span(hir_id))?;
                         }
                         let mut sep = " ";
-                        tcx.with_freevars(node_id, |freevars| {
+                        tcx.with_freevars(hir_id, |freevars| {
                             for (freevar, upvar_ty) in freevars.iter().zip(upvar_tys) {
+                                let var_hir_id = freevar.var_id();
                                 print!(f, cx,
                                        write("{}{}:",
                                              sep,
-                                             tcx.hir().name(freevar.var_id())),
+                                             tcx.hir().name(var_hir_id)),
                                        print(upvar_ty))?;
                                 sep = ", ";
                             }

--- a/src/librustc_borrowck/borrowck/gather_loans/gather_moves.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/gather_moves.rs
@@ -11,7 +11,6 @@ use rustc::middle::mem_categorization::InteriorOffsetKind as Kind;
 use rustc::ty::{self, Ty};
 
 use std::rc::Rc;
-use syntax::ast;
 use syntax_pos::Span;
 use rustc::hir::*;
 use rustc::hir::Node;
@@ -47,9 +46,9 @@ pub enum PatternSource<'tcx> {
 /// with a reference to the let
 fn get_pattern_source<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, pat: &Pat) -> PatternSource<'tcx> {
 
-    let parent = tcx.hir().get_parent_node(pat.id);
+    let parent = tcx.hir().get_parent_node(pat.hir_id);
 
-    match tcx.hir().get(parent) {
+    match tcx.hir().get_by_hir_id(parent) {
         Node::Expr(ref e) => {
             // the enclosing expression must be a `match` or something else
             assert!(match e.node {
@@ -66,11 +65,10 @@ fn get_pattern_source<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, pat: &Pat) -> Patte
 
 pub fn gather_decl<'a, 'tcx>(bccx: &BorrowckCtxt<'a, 'tcx>,
                              move_data: &MoveData<'tcx>,
-                             var_id: ast::NodeId,
+                             var_id: hir::HirId,
                              var_ty: Ty<'tcx>) {
     let loan_path = Rc::new(LoanPath::new(LpVar(var_id), var_ty));
-    let hir_id = bccx.tcx.hir().node_to_hir_id(var_id);
-    move_data.add_move(bccx.tcx, loan_path, hir_id.local_id, Declared);
+    move_data.add_move(bccx.tcx, loan_path, var_id.local_id, Declared);
 }
 
 pub fn gather_move_from_expr<'a, 'tcx>(bccx: &BorrowckCtxt<'a, 'tcx>,

--- a/src/librustc_borrowck/borrowck/gather_loans/lifetime.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/lifetime.rs
@@ -103,8 +103,7 @@ impl<'a, 'tcx> GuaranteeLifetimeContext<'a, 'tcx> {
             Categorization::Upvar(..) => {
                 self.bccx.tcx.mk_region(ty::ReScope(self.item_scope))
             }
-            Categorization::Local(local_id) => {
-                let hir_id = self.bccx.tcx.hir().node_to_hir_id(local_id);
+            Categorization::Local(hir_id) => {
                 self.bccx.tcx.mk_region(ty::ReScope(
                     self.bccx.region_scope_tree.var_scope(hir_id.local_id)))
             }

--- a/src/librustc_borrowck/borrowck/gather_loans/move_error.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/move_error.rs
@@ -87,8 +87,7 @@ fn report_move_errors<'a, 'tcx>(bccx: &BorrowckCtxt<'a, 'tcx>, errors: &[MoveErr
             }
         }
         if let NoteClosureEnv(upvar_id) = error.move_from.note {
-            let var_node_id = bccx.tcx.hir().hir_to_node_id(upvar_id.var_path.hir_id);
-            err.span_label(bccx.tcx.hir().span(var_node_id),
+            err.span_label(bccx.tcx.hir().span(upvar_id.var_path.hir_id),
                            "captured outer variable");
         }
         err.emit();

--- a/src/librustc_borrowck/borrowck/gather_loans/restrictions.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/restrictions.rs
@@ -66,9 +66,9 @@ impl<'a, 'tcx> RestrictionsContext<'a, 'tcx> {
                 RestrictionResult::Safe
             }
 
-            Categorization::Local(local_id) => {
+            Categorization::Local(hir_id) => {
                 // R-Variable, locally declared
-                let lp = new_lp(LpVar(local_id));
+                let lp = new_lp(LpVar(hir_id));
                 RestrictionResult::SafeIf(lp.clone(), vec![lp])
             }
 

--- a/src/librustc_codegen_llvm/debuginfo/mod.rs
+++ b/src/librustc_codegen_llvm/debuginfo/mod.rs
@@ -290,7 +290,7 @@ impl DebugInfoMethods<'tcx> for CodegenCx<'ll, 'tcx> {
 
         let mut flags = DIFlags::FlagPrototyped;
 
-        let local_id = self.tcx().hir().as_local_node_id(def_id);
+        let local_id = self.tcx().hir().as_local_hir_id(def_id);
         if let Some((id, _, _)) = *self.sess().entry_fn.borrow() {
             if local_id == Some(id) {
                 flags |= DIFlags::FlagMainSubprogram;

--- a/src/librustc_codegen_ssa/back/symbol_export.rs
+++ b/src/librustc_codegen_ssa/back/symbol_export.rs
@@ -69,7 +69,7 @@ fn reachable_non_generics_provider<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 
     let mut reachable_non_generics: DefIdMap<_> = tcx.reachable_set(LOCAL_CRATE).0
         .iter()
-        .filter_map(|&node_id| {
+        .filter_map(|&hir_id| {
             // We want to ignore some FFI functions that are not exposed from
             // this crate. Reachable FFI functions can be lumped into two
             // categories:
@@ -83,9 +83,9 @@ fn reachable_non_generics_provider<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
             //
             // As a result, if this id is an FFI item (foreign item) then we only
             // let it through if it's included statically.
-            match tcx.hir().get(node_id) {
+            match tcx.hir().get_by_hir_id(hir_id) {
                 Node::ForeignItem(..) => {
-                    let def_id = tcx.hir().local_def_id(node_id);
+                    let def_id = tcx.hir().local_def_id_from_hir_id(hir_id);
                     if tcx.is_statically_included_foreign_item(def_id) {
                         Some(def_id)
                     } else {
@@ -105,7 +105,7 @@ fn reachable_non_generics_provider<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                     node: hir::ImplItemKind::Method(..),
                     ..
                 }) => {
-                    let def_id = tcx.hir().local_def_id(node_id);
+                    let def_id = tcx.hir().local_def_id_from_hir_id(hir_id);
                     let generics = tcx.generics_of(def_id);
                     if !generics.requires_monomorphization(tcx) &&
                         // Functions marked with #[inline] are only ever codegened
@@ -343,8 +343,8 @@ fn upstream_monomorphizations_for_provider<'a, 'tcx>(
 }
 
 fn is_unreachable_local_definition_provider(tcx: TyCtxt, def_id: DefId) -> bool {
-    if let Some(node_id) = tcx.hir().as_local_node_id(def_id) {
-        !tcx.reachable_set(LOCAL_CRATE).0.contains(&node_id)
+    if let Some(hir_id) = tcx.hir().as_local_hir_id(def_id) {
+        !tcx.reachable_set(LOCAL_CRATE).0.contains(&hir_id)
     } else {
         bug!("is_unreachable_local_definition called with non-local DefId: {:?}",
              def_id)

--- a/src/librustc_codegen_ssa/base.rs
+++ b/src/librustc_codegen_ssa/base.rs
@@ -443,7 +443,7 @@ pub fn maybe_create_entry_wrapper<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>>(
 ) {
     let (main_def_id, span) = match *cx.sess().entry_fn.borrow() {
         Some((id, span, _)) => {
-            (cx.tcx().hir().local_def_id(id), span)
+            (cx.tcx().hir().local_def_id_from_hir_id(id), span)
         }
         None => return,
     };

--- a/src/librustc_codegen_ssa/mono_item.rs
+++ b/src/librustc_codegen_ssa/mono_item.rs
@@ -31,8 +31,8 @@ pub trait MonoItemExt<'a, 'tcx: 'a>: fmt::Debug + BaseMonoItemExt<'a, 'tcx> {
                 };
                 cx.codegen_static(def_id, is_mutable);
             }
-            MonoItem::GlobalAsm(node_id) => {
-                let item = cx.tcx().hir().expect_item(node_id);
+            MonoItem::GlobalAsm(hir_id) => {
+                let item = cx.tcx().hir().expect_item_by_hir_id(hir_id);
                 if let hir::ItemKind::GlobalAsm(ref ga) = item.node {
                     cx.codegen_global_asm(ga);
                 } else {

--- a/src/librustc_codegen_utils/lib.rs
+++ b/src/librustc_codegen_utils/lib.rs
@@ -43,7 +43,7 @@ pub mod symbol_names_test;
 /// reporting an error.
 pub fn check_for_rustc_errors_attr(tcx: TyCtxt) {
     if let Some((id, span, _)) = *tcx.sess.entry_fn.borrow() {
-        let main_def_id = tcx.hir().local_def_id(id);
+        let main_def_id = tcx.hir().local_def_id_from_hir_id(id);
 
         if tcx.has_attr(main_def_id, "rustc_error") {
             tcx.sess.span_fatal(span, "compilation successful");

--- a/src/librustc_codegen_utils/symbol_names.rs
+++ b/src/librustc_codegen_utils/symbol_names.rs
@@ -240,7 +240,7 @@ fn compute_symbol_name<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, instance: Instance
 
     debug!("symbol_name(def_id={:?}, substs={:?})", def_id, substs);
 
-    let node_id = tcx.hir().as_local_node_id(def_id);
+    let hir_id = tcx.hir().as_local_hir_id(def_id);
 
     if def_id.is_local() {
         if tcx.plugin_registrar_fn(LOCAL_CRATE) == Some(def_id) {
@@ -254,8 +254,8 @@ fn compute_symbol_name<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, instance: Instance
     }
 
     // FIXME(eddyb) Precompute a custom symbol name based on attributes.
-    let is_foreign = if let Some(id) = node_id {
-        match tcx.hir().get(id) {
+    let is_foreign = if let Some(id) = hir_id {
+        match tcx.hir().get_by_hir_id(id) {
             Node::ForeignItem(_) => true,
             _ => false,
         }

--- a/src/librustc_codegen_utils/symbol_names_test.rs
+++ b/src/librustc_codegen_utils/symbol_names_test.rs
@@ -6,7 +6,6 @@
 
 use rustc::hir;
 use rustc::ty::TyCtxt;
-use syntax::ast;
 
 use rustc_mir::monomorphize::Instance;
 
@@ -33,9 +32,9 @@ struct SymbolNamesTest<'a, 'tcx:'a> {
 
 impl<'a, 'tcx> SymbolNamesTest<'a, 'tcx> {
     fn process_attrs(&mut self,
-                     node_id: ast::NodeId) {
+                     hir_id: hir::HirId) {
         let tcx = self.tcx;
-        let def_id = tcx.hir().local_def_id(node_id);
+        let def_id = self.tcx.hir().local_def_id_from_hir_id(hir_id);
         for attr in tcx.get_attrs(def_id).iter() {
             if attr.check_name(SYMBOL_NAME) {
                 // for now, can only use on monomorphic names
@@ -56,14 +55,14 @@ impl<'a, 'tcx> SymbolNamesTest<'a, 'tcx> {
 
 impl<'a, 'tcx> hir::itemlikevisit::ItemLikeVisitor<'tcx> for SymbolNamesTest<'a, 'tcx> {
     fn visit_item(&mut self, item: &'tcx hir::Item) {
-        self.process_attrs(item.id);
+        self.process_attrs(item.hir_id);
     }
 
     fn visit_trait_item(&mut self, trait_item: &'tcx hir::TraitItem) {
-        self.process_attrs(trait_item.id);
+        self.process_attrs(trait_item.hir_id);
     }
 
     fn visit_impl_item(&mut self, impl_item: &'tcx hir::ImplItem) {
-        self.process_attrs(impl_item.id);
+        self.process_attrs(impl_item.hir_id);
     }
 }

--- a/src/librustc_driver/proc_macro_decls.rs
+++ b/src/librustc_driver/proc_macro_decls.rs
@@ -3,7 +3,6 @@ use rustc::hir::def_id::{CrateNum, DefId, LOCAL_CRATE};
 use rustc::hir;
 use rustc::ty::TyCtxt;
 use rustc::ty::query::Providers;
-use syntax::ast;
 use syntax::attr;
 
 pub fn find<'tcx>(tcx: TyCtxt<'_, 'tcx, 'tcx>) -> Option<DefId> {
@@ -19,17 +18,17 @@ fn proc_macro_decls_static<'tcx>(
     let mut finder = Finder { decls: None };
     tcx.hir().krate().visit_all_item_likes(&mut finder);
 
-    finder.decls.map(|id| tcx.hir().local_def_id(id))
+    finder.decls.map(|id| tcx.hir().local_def_id_from_hir_id(id))
 }
 
 struct Finder {
-    decls: Option<ast::NodeId>,
+    decls: Option<hir::HirId>,
 }
 
 impl<'v> ItemLikeVisitor<'v> for Finder {
     fn visit_item(&mut self, item: &hir::Item) {
         if attr::contains_name(&item.attrs, "rustc_proc_macro_decls") {
-            self.decls = Some(item.id);
+            self.decls = Some(item.hir_id);
         }
     }
 

--- a/src/librustc_incremental/persist/dirty_clean.rs
+++ b/src/librustc_incremental/persist/dirty_clean.rs
@@ -242,7 +242,7 @@ pub struct DirtyCleanVisitor<'a, 'tcx:'a> {
 impl<'a, 'tcx> DirtyCleanVisitor<'a, 'tcx> {
 
     /// Possibly "deserialize" the attribute into a clean/dirty assertion
-    fn assertion_maybe(&mut self, item_id: ast::NodeId, attr: &Attribute)
+    fn assertion_maybe(&mut self, item_id: hir::HirId, attr: &Attribute)
         -> Option<Assertion>
     {
         let is_clean = if attr.check_name(ATTR_DIRTY) {
@@ -270,7 +270,7 @@ impl<'a, 'tcx> DirtyCleanVisitor<'a, 'tcx> {
     }
 
     /// Get the "auto" assertion on pre-validated attr, along with the `except` labels
-    fn assertion_auto(&mut self, item_id: ast::NodeId, attr: &Attribute, is_clean: bool)
+    fn assertion_auto(&mut self, item_id: hir::HirId, attr: &Attribute, is_clean: bool)
         -> Assertion
     {
         let (name, mut auto) = self.auto_labels(item_id, attr);
@@ -322,8 +322,8 @@ impl<'a, 'tcx> DirtyCleanVisitor<'a, 'tcx> {
 
     /// Return all DepNode labels that should be asserted for this item.
     /// index=0 is the "name" used for error messages
-    fn auto_labels(&mut self, item_id: ast::NodeId, attr: &Attribute) -> (&'static str, Labels) {
-        let node = self.tcx.hir().get(item_id);
+    fn auto_labels(&mut self, item_id: hir::HirId, attr: &Attribute) -> (&'static str, Labels) {
+        let node = self.tcx.hir().get_by_hir_id(item_id);
         let (name, labels) = match node {
             HirNode::Item(item) => {
                 match item.node {
@@ -500,8 +500,8 @@ impl<'a, 'tcx> DirtyCleanVisitor<'a, 'tcx> {
         }
     }
 
-    fn check_item(&mut self, item_id: ast::NodeId, item_span: Span) {
-        let def_id = self.tcx.hir().local_def_id(item_id);
+    fn check_item(&mut self, item_id: hir::HirId, item_span: Span) {
+        let def_id = self.tcx.hir().local_def_id_from_hir_id(item_id);
         for attr in self.tcx.get_attrs(def_id).iter() {
             let assertion = match self.assertion_maybe(item_id, attr) {
                 Some(a) => a,
@@ -520,15 +520,15 @@ impl<'a, 'tcx> DirtyCleanVisitor<'a, 'tcx> {
 
 impl<'a, 'tcx> ItemLikeVisitor<'tcx> for DirtyCleanVisitor<'a, 'tcx> {
     fn visit_item(&mut self, item: &'tcx hir::Item) {
-        self.check_item(item.id, item.span);
+        self.check_item(item.hir_id, item.span);
     }
 
     fn visit_trait_item(&mut self, item: &hir::TraitItem) {
-        self.check_item(item.id, item.span);
+        self.check_item(item.hir_id, item.span);
     }
 
     fn visit_impl_item(&mut self, item: &hir::ImplItem) {
-        self.check_item(item.id, item.span);
+        self.check_item(item.hir_id, item.span);
     }
 }
 

--- a/src/librustc_lint/nonstandard_style.rs
+++ b/src/librustc_lint/nonstandard_style.rs
@@ -17,8 +17,8 @@ pub enum MethodLateContext {
     PlainImpl,
 }
 
-pub fn method_context(cx: &LateContext, id: ast::NodeId) -> MethodLateContext {
-    let def_id = cx.tcx.hir().local_def_id(id);
+pub fn method_context(cx: &LateContext, id: hir::HirId) -> MethodLateContext {
+    let def_id = cx.tcx.hir().local_def_id_from_hir_id(id);
     let item = cx.tcx.associated_item(def_id);
     match item.container {
         ty::TraitContainer(..) => MethodLateContext::TraitAutoImpl,
@@ -291,7 +291,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NonSnakeCase {
         _: &hir::FnDecl,
         _: &hir::Body,
         _: Span,
-        id: ast::NodeId,
+        id: hir::HirId
     ) {
         match &fk {
             FnKind::Method(ident, ..) => {
@@ -343,7 +343,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NonSnakeCase {
         s: &hir::VariantData,
         _: ast::Name,
         _: &hir::Generics,
-        _: ast::NodeId,
+        _: hir::HirId
     ) {
         for sf in s.fields() {
             self.check_snake_case(cx, "structure field", &sf.ident);

--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -41,7 +41,7 @@ impl LintPass for UnusedResults {
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedResults {
     fn check_stmt(&mut self, cx: &LateContext, s: &hir::Stmt) {
         let expr = match s.node {
-            hir::StmtKind::Semi(ref expr, _) => &**expr,
+            hir::StmtKind::Semi(ref expr, ..) => &**expr,
             _ => return,
         };
 
@@ -51,7 +51,9 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedResults {
 
         let t = cx.tables.expr_ty(&expr);
         let type_permits_lack_of_use = if t.is_unit()
-            || cx.tcx.is_ty_uninhabited_from(cx.tcx.hir().get_module_parent(expr.id), t) {
+            || cx.tcx.is_ty_uninhabited_from(cx.tcx.hir().get_module_parent(expr.hir_id),
+                                             t)
+        {
             true
         } else {
             match t.sty {
@@ -205,7 +207,7 @@ impl LintPass for PathStatements {
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for PathStatements {
     fn check_stmt(&mut self, cx: &LateContext, s: &hir::Stmt) {
-        if let hir::StmtKind::Semi(ref expr, _) = s.node {
+        if let hir::StmtKind::Semi(ref expr, ..) = s.node {
             if let hir::ExprKind::Path(_) = expr.node {
                 cx.span_lint(PATH_STATEMENTS, s.span, "path statement with no effect");
             }

--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -29,7 +29,7 @@ use std::hash::Hash;
 use std::path::Path;
 use rustc_data_structures::sync::Lrc;
 use std::u32;
-use syntax::ast::{self, CRATE_NODE_ID};
+use syntax::ast;
 use syntax::attr;
 use syntax::source_map::Spanned;
 use syntax::symbol::keywords;
@@ -313,7 +313,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
         let vis = Spanned { span: syntax_pos::DUMMY_SP, node: hir::VisibilityKind::Public };
         index.record(DefId::local(CRATE_DEF_INDEX),
                      IsolatedEncoder::encode_info_for_mod,
-                     FromId(CRATE_NODE_ID, (&krate.module, &krate.attrs, &vis)));
+                     FromId(hir::CRATE_HIR_ID, (&krate.module, &krate.attrs, &vis)));
         let mut visitor = EncodeVisitor { index };
         krate.visit_all_item_likes(&mut visitor.as_deep_visitor());
         for macro_def in &krate.exported_macros {
@@ -587,8 +587,8 @@ impl<'a, 'b: 'a, 'tcx: 'b> IsolatedEncoder<'a, 'b, 'tcx> {
             }
         };
 
-        let enum_id = tcx.hir().as_local_node_id(enum_did).unwrap();
-        let enum_vis = &tcx.hir().expect_item(enum_id).vis;
+        let enum_id = tcx.hir().as_local_hir_id(enum_did).unwrap();
+        let enum_vis = &tcx.hir().expect_item_by_hir_id(enum_id).vis;
 
         Entry {
             kind: EntryKind::Variant(self.lazy(&data)),
@@ -623,7 +623,7 @@ impl<'a, 'b: 'a, 'tcx: 'b> IsolatedEncoder<'a, 'b, 'tcx> {
                                                                  &hir::Visibility)>)
                            -> Entry<'tcx> {
         let tcx = self.tcx;
-        let def_id = tcx.hir().local_def_id(id);
+        let def_id = tcx.hir().local_def_id_from_hir_id(id);
         debug!("IsolatedEncoder::encode_info_for_mod({:?})", def_id);
 
         let data = ModData {
@@ -673,7 +673,7 @@ impl<'a, 'b: 'a, 'tcx: 'b> IsolatedEncoder<'a, 'b, 'tcx> {
         let def_id = field.did;
         debug!("IsolatedEncoder::encode_field({:?})", def_id);
 
-        let variant_id = tcx.hir().as_local_node_id(variant.did).unwrap();
+        let variant_id = tcx.hir().as_local_hir_id(variant.did).unwrap();
         let variant_data = tcx.hir().expect_variant_data(variant_id);
 
         Entry {
@@ -713,8 +713,8 @@ impl<'a, 'b: 'a, 'tcx: 'b> IsolatedEncoder<'a, 'b, 'tcx> {
             }
         };
 
-        let struct_id = tcx.hir().as_local_node_id(adt_def_id).unwrap();
-        let struct_vis = &tcx.hir().expect_item(struct_id).vis;
+        let struct_id = tcx.hir().as_local_hir_id(adt_def_id).unwrap();
+        let struct_vis = &tcx.hir().expect_item_by_hir_id(struct_id).vis;
         let mut ctor_vis = ty::Visibility::from_hir(struct_vis, struct_id, tcx);
         for field in &variant.fields {
             if ctor_vis.is_at_least(field.vis, tcx) {
@@ -778,8 +778,8 @@ impl<'a, 'b: 'a, 'tcx: 'b> IsolatedEncoder<'a, 'b, 'tcx> {
         debug!("IsolatedEncoder::encode_info_for_trait_item({:?})", def_id);
         let tcx = self.tcx;
 
-        let node_id = tcx.hir().as_local_node_id(def_id).unwrap();
-        let ast_item = tcx.hir().expect_trait_item(node_id);
+        let hir_id = tcx.hir().as_local_hir_id(def_id).unwrap();
+        let ast_item = tcx.hir().expect_trait_item_by_hir_id(hir_id);
         let trait_item = tcx.associated_item(def_id);
 
         let container = match trait_item.defaultness {
@@ -888,8 +888,8 @@ impl<'a, 'b: 'a, 'tcx: 'b> IsolatedEncoder<'a, 'b, 'tcx> {
         debug!("IsolatedEncoder::encode_info_for_impl_item({:?})", def_id);
         let tcx = self.tcx;
 
-        let node_id = self.tcx.hir().as_local_node_id(def_id).unwrap();
-        let ast_item = self.tcx.hir().expect_impl_item(node_id);
+        let hir_id = self.tcx.hir().as_local_hir_id(def_id).unwrap();
+        let ast_item = self.tcx.hir().expect_impl_item_by_hir_id(hir_id);
         let impl_item = self.tcx.associated_item(def_id);
 
         let container = match impl_item.defaultness {
@@ -1054,7 +1054,7 @@ impl<'a, 'b: 'a, 'tcx: 'b> IsolatedEncoder<'a, 'b, 'tcx> {
                 EntryKind::Fn(self.lazy(&data))
             }
             hir::ItemKind::Mod(ref m) => {
-                return self.encode_info_for_mod(FromId(item.id, (m, &item.attrs, &item.vis)));
+                return self.encode_info_for_mod(FromId(item.hir_id, (m, &item.attrs, &item.vis)));
             }
             hir::ItemKind::ForeignMod(_) => EntryKind::ForeignMod,
             hir::ItemKind::GlobalAsm(..) => EntryKind::GlobalAsm,
@@ -1068,7 +1068,7 @@ impl<'a, 'b: 'a, 'tcx: 'b> IsolatedEncoder<'a, 'b, 'tcx> {
                 // for methods, write all the stuff get_trait_method
                 // needs to know
                 let struct_ctor = if !struct_def.is_struct() {
-                    Some(tcx.hir().local_def_id(struct_def.id()).index)
+                    Some(tcx.hir().local_def_id_from_hir_id(struct_def.hir_id()).index)
                 } else {
                     None
                 };
@@ -1147,14 +1147,15 @@ impl<'a, 'b: 'a, 'tcx: 'b> IsolatedEncoder<'a, 'b, 'tcx> {
 
         Entry {
             kind,
-            visibility: self.lazy(&ty::Visibility::from_hir(&item.vis, item.id, tcx)),
+            visibility: self.lazy(&ty::Visibility::from_hir(&item.vis, item.hir_id, tcx)),
             span: self.lazy(&item.span),
             attributes: self.encode_attributes(&item.attrs),
             children: match item.node {
                 hir::ItemKind::ForeignMod(ref fm) => {
                     self.lazy_seq(fm.items
                         .iter()
-                        .map(|foreign_item| tcx.hir().local_def_id(foreign_item.id).index))
+                        .map(|foreign_item| tcx.hir()
+                            .local_def_id_from_hir_id(foreign_item.hir_id).index))
                 }
                 hir::ItemKind::Enum(..) => {
                     let def = self.tcx.adt_def(def_id);
@@ -1269,7 +1270,7 @@ impl<'a, 'b: 'a, 'tcx: 'b> IsolatedEncoder<'a, 'b, 'tcx> {
     /// Serialize the text of exported macros
     fn encode_info_for_macro_def(&mut self, macro_def: &hir::MacroDef) -> Entry<'tcx> {
         use syntax::print::pprust;
-        let def_id = self.tcx.hir().local_def_id(macro_def.id);
+        let def_id = self.tcx.hir().local_def_id_from_hir_id(macro_def.hir_id);
         Entry {
             kind: EntryKind::MacroDef(self.lazy(&MacroDef {
                 body: pprust::tts_to_string(&macro_def.body.trees().collect::<Vec<_>>()),
@@ -1326,9 +1327,8 @@ impl<'a, 'b: 'a, 'tcx: 'b> IsolatedEncoder<'a, 'b, 'tcx> {
         let tcx = self.tcx;
 
         let tables = self.tcx.typeck_tables_of(def_id);
-        let node_id = self.tcx.hir().as_local_node_id(def_id).unwrap();
-        let hir_id = self.tcx.hir().node_to_hir_id(node_id);
-        let kind = match tables.node_id_to_type(hir_id).sty {
+        let hir_id = self.tcx.hir().as_local_hir_id(def_id).unwrap();
+        let kind = match tables.hir_id_to_type(hir_id).sty {
             ty::Generator(def_id, ..) => {
                 let layout = self.tcx.generator_layout(def_id);
                 let data = GeneratorData {
@@ -1369,7 +1369,7 @@ impl<'a, 'b: 'a, 'tcx: 'b> IsolatedEncoder<'a, 'b, 'tcx> {
     fn encode_info_for_anon_const(&mut self, def_id: DefId) -> Entry<'tcx> {
         debug!("IsolatedEncoder::encode_info_for_anon_const({:?})", def_id);
         let tcx = self.tcx;
-        let id = tcx.hir().as_local_node_id(def_id).unwrap();
+        let id = tcx.hir().as_local_hir_id(def_id).unwrap();
         let body_id = tcx.hir().body_owned_by(id);
         let const_data = self.encode_rendered_const_for_body(body_id);
         let mir = tcx.mir_const_qualif(def_id).0;
@@ -1576,7 +1576,7 @@ impl<'a, 'b: 'a, 'tcx: 'b> IsolatedEncoder<'a, 'b, 'tcx> {
 
         Entry {
             kind,
-            visibility: self.lazy(&ty::Visibility::from_hir(&nitem.vis, nitem.id, tcx)),
+            visibility: self.lazy(&ty::Visibility::from_hir(&nitem.vis, nitem.hir_id, tcx)),
             span: self.lazy(&nitem.span),
             attributes: self.encode_attributes(&nitem.attrs),
             children: LazySeq::empty(),
@@ -1612,7 +1612,7 @@ impl<'a, 'b, 'tcx> Visitor<'tcx> for EncodeVisitor<'a, 'b, 'tcx> {
     }
     fn visit_item(&mut self, item: &'tcx hir::Item) {
         intravisit::walk_item(self, item);
-        let def_id = self.index.tcx.hir().local_def_id(item.id);
+        let def_id = self.index.tcx.hir().local_def_id_from_hir_id(item.hir_id);
         match item.node {
             hir::ItemKind::ExternCrate(_) |
             hir::ItemKind::Use(..) => (), // ignore these
@@ -1622,7 +1622,7 @@ impl<'a, 'b, 'tcx> Visitor<'tcx> for EncodeVisitor<'a, 'b, 'tcx> {
     }
     fn visit_foreign_item(&mut self, ni: &'tcx hir::ForeignItem) {
         intravisit::walk_foreign_item(self, ni);
-        let def_id = self.index.tcx.hir().local_def_id(ni.id);
+        let def_id = self.index.tcx.hir().local_def_id_from_hir_id(ni.hir_id);
         self.index.record(def_id,
                           IsolatedEncoder::encode_info_for_foreign_item,
                           (def_id, ni));
@@ -1630,11 +1630,11 @@ impl<'a, 'b, 'tcx> Visitor<'tcx> for EncodeVisitor<'a, 'b, 'tcx> {
     fn visit_variant(&mut self,
                      v: &'tcx hir::Variant,
                      g: &'tcx hir::Generics,
-                     id: ast::NodeId) {
+                     id: hir::HirId) {
         intravisit::walk_variant(self, v, g, id);
 
         if let Some(ref discr) = v.node.disr_expr {
-            let def_id = self.index.tcx.hir().local_def_id(discr.id);
+            let def_id = self.index.tcx.hir().local_def_id_from_hir_id(discr.hir_id);;
             self.index.record(def_id, IsolatedEncoder::encode_info_for_anon_const, def_id);
         }
     }
@@ -1647,7 +1647,7 @@ impl<'a, 'b, 'tcx> Visitor<'tcx> for EncodeVisitor<'a, 'b, 'tcx> {
         self.index.encode_info_for_ty(ty);
     }
     fn visit_macro_def(&mut self, macro_def: &'tcx hir::MacroDef) {
-        let def_id = self.index.tcx.hir().local_def_id(macro_def.id);
+        let def_id = self.index.tcx.hir().local_def_id_from_hir_id(macro_def.hir_id);
         self.index.record(def_id, IsolatedEncoder::encode_info_for_macro_def, macro_def);
     }
 }
@@ -1669,7 +1669,7 @@ impl<'a, 'b, 'tcx> IndexBuilder<'a, 'b, 'tcx> {
             match param.kind {
                 hir::GenericParamKind::Lifetime { .. } => {}
                 hir::GenericParamKind::Type { ref default, .. } => {
-                    let def_id = self.tcx.hir().local_def_id(param.id);
+                    let def_id = self.tcx.hir().local_def_id_from_hir_id(param.hir_id);
                     let has_default = Untracked(default.is_some());
                     let encode_info = IsolatedEncoder::encode_info_for_ty_param;
                     self.record(def_id, encode_info, (def_id, has_default));
@@ -1681,7 +1681,7 @@ impl<'a, 'b, 'tcx> IndexBuilder<'a, 'b, 'tcx> {
     fn encode_info_for_ty(&mut self, ty: &hir::Ty) {
         match ty.node {
             hir::TyKind::Array(_, ref length) => {
-                let def_id = self.tcx.hir().local_def_id(length.id);
+                let def_id = self.tcx.hir().local_def_id_from_hir_id(length.hir_id);
                 self.record(def_id, IsolatedEncoder::encode_info_for_anon_const, def_id);
             }
             _ => {}
@@ -1691,7 +1691,7 @@ impl<'a, 'b, 'tcx> IndexBuilder<'a, 'b, 'tcx> {
     fn encode_info_for_expr(&mut self, expr: &hir::Expr) {
         match expr.node {
             hir::ExprKind::Closure(..) => {
-                let def_id = self.tcx.hir().local_def_id(expr.id);
+                let def_id = self.tcx.hir().local_def_id_from_hir_id(expr.hir_id);
                 self.record(def_id, IsolatedEncoder::encode_info_for_closure, def_id);
             }
             _ => {}
@@ -1703,7 +1703,7 @@ impl<'a, 'b, 'tcx> IndexBuilder<'a, 'b, 'tcx> {
     /// so it's easier to do that here then to wait until we would encounter
     /// normally in the visitor walk.
     fn encode_addl_info_for_item(&mut self, item: &hir::Item) {
-        let def_id = self.tcx.hir().local_def_id(item.id);
+        let def_id = self.tcx.hir().local_def_id_from_hir_id(item.hir_id);
         match item.node {
             hir::ItemKind::Static(..) |
             hir::ItemKind::Const(..) |
@@ -1733,7 +1733,7 @@ impl<'a, 'b, 'tcx> IndexBuilder<'a, 'b, 'tcx> {
 
                 // If the struct has a constructor, encode it.
                 if !struct_def.is_struct() {
-                    let ctor_def_id = self.tcx.hir().local_def_id(struct_def.id());
+                    let ctor_def_id = self.tcx.hir().local_def_id_from_hir_id(struct_def.hir_id());
                     self.record(ctor_def_id,
                                 IsolatedEncoder::encode_struct_ctor,
                                 (def_id, ctor_def_id));
@@ -1768,7 +1768,7 @@ struct ImplVisitor<'a, 'tcx: 'a> {
 impl<'a, 'tcx, 'v> ItemLikeVisitor<'v> for ImplVisitor<'a, 'tcx> {
     fn visit_item(&mut self, item: &hir::Item) {
         if let hir::ItemKind::Impl(..) = item.node {
-            let impl_id = self.tcx.hir().local_def_id(item.id);
+            let impl_id = self.tcx.hir().local_def_id_from_hir_id(item.hir_id);
             if let Some(trait_ref) = self.tcx.impl_trait_ref(impl_id) {
                 self.impls
                     .entry(trait_ref.def_id)

--- a/src/librustc_metadata/foreign_modules.rs
+++ b/src/librustc_metadata/foreign_modules.rs
@@ -25,11 +25,11 @@ impl<'a, 'tcx> ItemLikeVisitor<'tcx> for Collector<'a, 'tcx> {
         };
 
         let foreign_items = fm.items.iter()
-            .map(|it| self.tcx.hir().local_def_id(it.id))
+            .map(|it| self.tcx.hir().local_def_id_from_hir_id(it.hir_id))
             .collect();
         self.modules.push(ForeignModule {
             foreign_items,
-            def_id: self.tcx.hir().local_def_id(it.id),
+            def_id: self.tcx.hir().local_def_id_from_hir_id(it.hir_id),
         });
     }
 

--- a/src/librustc_metadata/index_builder.rs
+++ b/src/librustc_metadata/index_builder.rs
@@ -185,7 +185,7 @@ macro_rules! read_hir {
     ($t:ty) => {
         impl<'tcx> DepGraphRead for &'tcx $t {
             fn read(&self, tcx: TyCtxt) {
-                tcx.hir().read(self.id);
+                tcx.hir().read_by_hir_id(self.hir_id);
             }
         }
     }
@@ -215,10 +215,10 @@ impl<T> DepGraphRead for Untracked<T> {
 /// HIR node that doesn't carry its own id. This will allow an
 /// arbitrary `T` to be passed in, but register a read on the given
 /// node-id.
-pub struct FromId<T>(pub ast::NodeId, pub T);
+pub struct FromId<T>(pub hir::HirId, pub T);
 
 impl<T> DepGraphRead for FromId<T> {
     fn read(&self, tcx: TyCtxt) {
-        tcx.hir().read(self.0);
+        tcx.hir().read_by_hir_id(self.0);
     }
 }

--- a/src/librustc_metadata/native_libs.rs
+++ b/src/librustc_metadata/native_libs.rs
@@ -55,7 +55,7 @@ impl<'a, 'tcx> ItemLikeVisitor<'tcx> for Collector<'a, 'tcx> {
                 name: None,
                 kind: cstore::NativeUnknown,
                 cfg: None,
-                foreign_module: Some(self.tcx.hir().local_def_id(it.id)),
+                foreign_module: Some(self.tcx.hir().local_def_id_from_hir_id(it.hir_id)),
                 wasm_import_module: None,
             };
             let mut kind_specified = false;

--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -128,7 +128,7 @@ fn do_mir_borrowck<'a, 'gcx, 'tcx>(
     let param_env = tcx.param_env(def_id);
     let id = tcx
         .hir()
-        .as_local_node_id(def_id)
+        .as_local_hir_id(def_id)
         .expect("do_mir_borrowck: non-local DefId");
 
     // Replace all regions with fresh inference variables. This
@@ -219,7 +219,7 @@ fn do_mir_borrowck<'a, 'gcx, 'tcx>(
         |bd, i| DebugFormatted::new(&bd.move_data().inits[i]),
     ));
 
-    let movable_generator = match tcx.hir().get(id) {
+    let movable_generator = match tcx.hir().get_by_hir_id(id) {
         Node::Expr(&hir::Expr {
             node: hir::ExprKind::Closure(.., Some(hir::GeneratorMovability::Static)),
             ..

--- a/src/librustc_mir/borrow_check/move_errors.rs
+++ b/src/librustc_mir/borrow_check/move_errors.rs
@@ -308,9 +308,7 @@ impl<'a, 'gcx, 'tcx> MirBorrowckCtxt<'a, 'gcx, 'tcx> {
                                         let upvar_decl = &self.mir.upvar_decls[field.index()];
                                         let upvar_hir_id =
                                             upvar_decl.var_hir_id.assert_crate_local();
-                                        let upvar_node_id =
-                                            self.infcx.tcx.hir().hir_to_node_id(upvar_hir_id);
-                                        let upvar_span = self.infcx.tcx.hir().span(upvar_node_id);
+                                        let upvar_span = self.infcx.tcx.hir().span(upvar_hir_id);
                                         diag.span_label(upvar_span, "captured outer variable");
                                         break;
                                     }

--- a/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/region_name.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/region_name.rs
@@ -10,7 +10,7 @@ use rustc::ty::subst::{Substs, UnpackedKind};
 use rustc::ty::{self, RegionKind, RegionVid, Ty, TyCtxt};
 use rustc::util::ppaux::RegionHighlightMode;
 use rustc_errors::DiagnosticBuilder;
-use syntax::ast::{Name, DUMMY_NODE_ID};
+use syntax::ast::Name;
 use syntax::symbol::keywords;
 use syntax_pos::Span;
 use syntax_pos::symbol::InternedString;
@@ -215,14 +215,14 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                 },
 
                 ty::BoundRegion::BrEnv => {
-                    let mir_node_id = tcx.hir()
-                                         .as_local_node_id(mir_def_id)
+                    let mir_hir_id = tcx.hir()
+                                         .as_local_hir_id(mir_def_id)
                                          .expect("non-local mir");
                     let def_ty = self.universal_regions.defining_ty;
 
                     if let DefiningTy::Closure(def_id, substs) = def_ty {
                         let args_span = if let hir::ExprKind::Closure(_, _, _, span, _) =
-                            tcx.hir().expect_expr(mir_node_id).node
+                            tcx.hir().expect_expr(mir_hir_id).node
                         {
                             span
                         } else {
@@ -293,7 +293,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         name: &InternedString,
     ) -> Span {
         let scope = error_region.free_region_binding_scope(tcx);
-        let node = tcx.hir().as_local_node_id(scope).unwrap_or(DUMMY_NODE_ID);
+        let node = tcx.hir().as_local_hir_id(scope).unwrap_or(hir::DUMMY_HIR_ID);
 
         let span = tcx.sess.source_map().def_span(tcx.hir().span(node));
         if let Some(param) = tcx.hir()
@@ -352,8 +352,8 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         argument_index: usize,
         counter: &mut usize,
     ) -> Option<RegionName> {
-        let mir_node_id = infcx.tcx.hir().as_local_node_id(mir_def_id)?;
-        let fn_decl = infcx.tcx.hir().fn_decl(mir_node_id)?;
+        let mir_hir_id = infcx.tcx.hir().as_local_hir_id(mir_def_id)?;
+        let fn_decl = infcx.tcx.hir().fn_decl(mir_hir_id)?;
         let argument_hir_ty: &hir::Ty = &fn_decl.inputs[argument_index];
         match argument_hir_ty.node {
             // This indicates a variable with no type annotation, like

--- a/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/var_name.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/var_name.rs
@@ -71,11 +71,10 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         upvar_index: usize,
     ) -> (Symbol, Span) {
         let upvar_hir_id = mir.upvar_decls[upvar_index].var_hir_id.assert_crate_local();
-        let upvar_node_id = tcx.hir().hir_to_node_id(upvar_hir_id);
-        debug!("get_upvar_name_and_span_for_region: upvar_node_id={:?}", upvar_node_id);
+        debug!("get_upvar_name_and_span_for_region: upvar_hir_id={:?}", upvar_hir_id);
 
-        let upvar_name = tcx.hir().name(upvar_node_id);
-        let upvar_span = tcx.hir().span(upvar_node_id);
+        let upvar_name = tcx.hir().name(upvar_hir_id);
+        let upvar_span = tcx.hir().span(upvar_hir_id);
         debug!("get_upvar_name_and_span_for_region: upvar_name={:?} upvar_span={:?}",
                upvar_name, upvar_span);
 

--- a/src/librustc_mir/build/block.rs
+++ b/src/librustc_mir/build/block.rs
@@ -206,14 +206,14 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
         debug!("update_source_scope_for({:?}, {:?})", span, safety_mode);
         let new_unsafety = match safety_mode {
             BlockSafety::Safe => None,
-            BlockSafety::ExplicitUnsafe(node_id) => {
+            BlockSafety::ExplicitUnsafe(hir_id) => {
                 assert_eq!(self.push_unsafe_count, 0);
                 match self.unpushed_unsafe {
                     Safety::Safe => {}
                     _ => return
                 }
-                self.unpushed_unsafe = Safety::ExplicitUnsafe(node_id);
-                Some(Safety::ExplicitUnsafe(node_id))
+                self.unpushed_unsafe = Safety::ExplicitUnsafe(hir_id);
+                Some(Safety::ExplicitUnsafe(hir_id))
             }
             BlockSafety::PushUnsafe => {
                 self.push_unsafe_count += 1;

--- a/src/librustc_mir/build/scope.rs
+++ b/src/librustc_mir/build/scope.rs
@@ -308,15 +308,11 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
         debug!("in_scope(region_scope={:?}, block={:?})", region_scope, block);
         let source_scope = self.source_scope;
         let tcx = self.hir.tcx();
-        if let LintLevel::Explicit(node_id) = lint_level {
+        if let LintLevel::Explicit(current_hir_id) = lint_level {
             let same_lint_scopes = tcx.dep_graph.with_ignore(|| {
                 let sets = tcx.lint_levels(LOCAL_CRATE);
                 let parent_hir_id =
-                    tcx.hir().definitions().node_to_hir_id(
-                        self.source_scope_local_data[source_scope].lint_root
-                    );
-                let current_hir_id =
-                    tcx.hir().definitions().node_to_hir_id(node_id);
+                    self.source_scope_local_data[source_scope].lint_root;
                 sets.lint_level_set(parent_hir_id) ==
                     sets.lint_level_set(current_hir_id)
             });

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -678,7 +678,7 @@ pub fn const_eval_raw_provider<'a, 'tcx>(
     let cid = key.value;
     let def_id = cid.instance.def.def_id();
 
-    if let Some(id) = tcx.hir().as_local_node_id(def_id) {
+    if let Some(id) = tcx.hir().as_local_hir_id(def_id) {
         let tables = tcx.typeck_tables_of(def_id);
 
         // Do match-check before building MIR
@@ -726,11 +726,11 @@ pub fn const_eval_raw_provider<'a, 'tcx>(
                 // because any code that existed before validation could not have failed validation
                 // thus preventing such a hard error from being a backwards compatibility hazard
                 Some(Def::Const(_)) | Some(Def::AssociatedConst(_)) => {
-                    let node_id = tcx.hir().as_local_node_id(def_id).unwrap();
+                    let hir_id = tcx.hir().as_local_hir_id(def_id).unwrap();
                     err.report_as_lint(
                         tcx.at(tcx.def_span(def_id)),
                         "any use of this value will cause an error",
-                        node_id,
+                        hir_id,
                     )
                 },
                 // promoting runtime code is only allowed to error if it references broken constants
@@ -746,7 +746,7 @@ pub fn const_eval_raw_provider<'a, 'tcx>(
                         err.report_as_lint(
                             tcx.at(span),
                             "reaching this expression at runtime will panic or abort",
-                            tcx.hir().as_local_node_id(def_id).unwrap(),
+                            tcx.hir().as_local_hir_id(def_id).unwrap(),
                         )
                     }
                 // anything else (array lengths, enum initializers, constant patterns) are reported

--- a/src/librustc_mir/dataflow/graphviz.rs
+++ b/src/librustc_mir/dataflow/graphviz.rs
@@ -1,6 +1,6 @@
 //! Hook into libgraphviz for rendering dataflow graphs for MIR.
 
-use syntax::ast::NodeId;
+use rustc::hir::HirId;
 use rustc::mir::{BasicBlock, Mir};
 
 use dot;
@@ -16,7 +16,7 @@ use super::DebugFormatted;
 
 pub trait MirWithFlowState<'tcx> {
     type BD: BitDenotation<'tcx>;
-    fn node_id(&self) -> NodeId;
+    fn hir_id(&self) -> HirId;
     fn mir(&self) -> &Mir<'tcx>;
     fn flow_state(&self) -> &DataflowState<'tcx, Self::BD>;
 }
@@ -25,7 +25,7 @@ impl<'a, 'tcx, BD> MirWithFlowState<'tcx> for DataflowBuilder<'a, 'tcx, BD>
     where BD: BitDenotation<'tcx>
 {
     type BD = BD;
-    fn node_id(&self) -> NodeId { self.node_id }
+    fn hir_id(&self) -> HirId { self.hir_id }
     fn mir(&self) -> &Mir<'tcx> { self.flow_state.mir() }
     fn flow_state(&self) -> &DataflowState<'tcx, Self::BD> { &self.flow_state.flow_state }
 }
@@ -49,8 +49,8 @@ pub(crate) fn print_borrowck_graph_to<'a, 'tcx, BD, P>(
     let g = Graph { mbcx, phantom: PhantomData, render_idx };
     let mut v = Vec::new();
     dot::render(&g, &mut v)?;
-    debug!("print_borrowck_graph_to path: {} node_id: {}",
-           path.display(), mbcx.node_id);
+    debug!("print_borrowck_graph_to path: {} hir_id: {:?}",
+           path.display(), mbcx.hir_id);
     fs::write(path, v)
 }
 
@@ -71,8 +71,8 @@ impl<'a, 'tcx, MWF, P> dot::Labeller<'a> for Graph<'a, 'tcx, MWF, P>
     type Node = Node;
     type Edge = Edge;
     fn graph_id(&self) -> dot::Id {
-        dot::Id::new(format!("graph_for_node_{}",
-                             self.mbcx.node_id()))
+        dot::Id::new(format!("graph_for_hir_{:?}",
+                             self.mbcx.hir_id()))
             .unwrap()
     }
 

--- a/src/librustc_mir/dataflow/mod.rs
+++ b/src/librustc_mir/dataflow/mod.rs
@@ -4,6 +4,7 @@ use rustc_data_structures::bit_set::{BitSet, BitSetOperator, HybridBitSet};
 use rustc_data_structures::indexed_vec::Idx;
 use rustc_data_structures::work_queue::WorkQueue;
 
+use rustc::hir;
 use rustc::ty::{self, TyCtxt};
 use rustc::mir::{self, Mir, BasicBlock, BasicBlockData, Location, Statement, Terminator};
 use rustc::mir::traversal;
@@ -38,7 +39,7 @@ pub(crate) struct DataflowBuilder<'a, 'tcx: 'a, BD>
 where
     BD: BitDenotation<'tcx>
 {
-    node_id: ast::NodeId,
+    hir_id: hir::HirId,
     flow_state: DataflowAnalysis<'a, 'tcx, BD>,
     print_preflow_to: Option<String>,
     print_postflow_to: Option<String>,
@@ -116,7 +117,7 @@ pub struct MoveDataParamEnv<'gcx, 'tcx> {
 
 pub(crate) fn do_dataflow<'a, 'gcx, 'tcx, BD, P>(tcx: TyCtxt<'a, 'gcx, 'tcx>,
                                                  mir: &'a Mir<'tcx>,
-                                                 node_id: ast::NodeId,
+                                                 hir_id: hir::HirId,
                                                  attributes: &[ast::Attribute],
                                                  dead_unwinds: &BitSet<BasicBlock>,
                                                  bd: BD,
@@ -126,14 +127,14 @@ pub(crate) fn do_dataflow<'a, 'gcx, 'tcx, BD, P>(tcx: TyCtxt<'a, 'gcx, 'tcx>,
           P: Fn(&BD, BD::Idx) -> DebugFormatted
 {
     let flow_state = DataflowAnalysis::new(mir, dead_unwinds, bd);
-    flow_state.run(tcx, node_id, attributes, p)
+    flow_state.run(tcx, hir_id, attributes, p)
 }
 
 impl<'a, 'gcx: 'tcx, 'tcx: 'a, BD> DataflowAnalysis<'a, 'tcx, BD> where BD: BitDenotation<'tcx>
 {
     pub(crate) fn run<P>(self,
                          tcx: TyCtxt<'a, 'gcx, 'tcx>,
-                         node_id: ast::NodeId,
+                         hir_id: hir::HirId,
                          attributes: &[ast::Attribute],
                          p: P) -> DataflowResults<'tcx, BD>
         where P: Fn(&BD, BD::Idx) -> DebugFormatted
@@ -158,7 +159,7 @@ impl<'a, 'gcx: 'tcx, 'tcx: 'a, BD> DataflowAnalysis<'a, 'tcx, BD> where BD: BitD
             name_found(tcx.sess, attributes, "borrowck_graphviz_postflow");
 
         let mut mbcx = DataflowBuilder {
-            node_id,
+            hir_id,
             print_preflow_to, print_postflow_to, flow_state: self,
         };
 

--- a/src/librustc_mir/hair/cx/block.rs
+++ b/src/librustc_mir/hair/cx/block.rs
@@ -30,7 +30,7 @@ impl<'tcx> Mirror<'tcx> for &'tcx hir::Block {
                 hir::BlockCheckMode::DefaultBlock =>
                     BlockSafety::Safe,
                 hir::BlockCheckMode::UnsafeBlock(..) =>
-                    BlockSafety::ExplicitUnsafe(self.id),
+                    BlockSafety::ExplicitUnsafe(self.hir_id),
                 hir::BlockCheckMode::PushUnsafeBlock(..) =>
                     BlockSafety::PushUnsafe,
                 hir::BlockCheckMode::PopUnsafeBlock(..) =>
@@ -46,12 +46,12 @@ fn mirror_stmts<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
                                 -> Vec<StmtRef<'tcx>> {
     let mut result = vec![];
     for (index, stmt) in stmts.iter().enumerate() {
-        let hir_id = cx.tcx.hir().node_to_hir_id(stmt.node.id());
+        let hir_id = stmt.node.hir_id();
         let opt_dxn_ext = cx.region_scope_tree.opt_destruction_scope(hir_id.local_id);
-        let stmt_span = StatementSpan(cx.tcx.hir().span(stmt.node.id()));
+        let stmt_span = StatementSpan(cx.tcx.hir().span(stmt.node.hir_id()));
         match stmt.node {
-            hir::StmtKind::Expr(ref expr, _) |
-            hir::StmtKind::Semi(ref expr, _) => {
+            hir::StmtKind::Expr(ref expr, ..) |
+            hir::StmtKind::Semi(ref expr, ..) => {
                 result.push(StmtRef::Mirror(Box::new(Stmt {
                     kind: StmtKind::Expr {
                         scope: region::Scope {
@@ -64,7 +64,7 @@ fn mirror_stmts<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
                     span: stmt_span,
                 })))
             }
-            hir::StmtKind::Decl(ref decl, _) => {
+            hir::StmtKind::Decl(ref decl, ..) => {
                 match decl.node {
                     hir::DeclKind::Item(..) => {
                         // ignore for purposes of the MIR
@@ -103,7 +103,7 @@ fn mirror_stmts<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
                                 },
                                 pattern,
                                 initializer: local.init.to_ref(),
-                                lint_level: cx.lint_level_of(local.id),
+                                lint_level: cx.lint_level_of(local.hir_id),
                             },
                             opt_destruction_scope: opt_dxn_ext,
                             span: stmt_span,
@@ -119,7 +119,7 @@ fn mirror_stmts<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
 pub fn to_expr_ref<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
                                    block: &'tcx hir::Block)
                                    -> ExprRef<'tcx> {
-    let block_ty = cx.tables().node_id_to_type(block.hir_id);
+    let block_ty = cx.tables().hir_id_to_type(block.hir_id);
     let temp_lifetime = cx.region_scope_tree.temporary_scope(block.hir_id.local_id);
     let expr = Expr {
         ty: block_ty,

--- a/src/librustc_mir/hair/cx/mod.rs
+++ b/src/librustc_mir/hair/cx/mod.rs
@@ -28,7 +28,7 @@ pub struct Cx<'a, 'gcx: 'a + 'tcx, 'tcx: 'a> {
     tcx: TyCtxt<'a, 'gcx, 'tcx>,
     infcx: &'a InferCtxt<'a, 'gcx, 'tcx>,
 
-    pub root_lint_level: ast::NodeId,
+    pub root_lint_level: hir::HirId,
     pub param_env: ty::ParamEnv<'gcx>,
 
     /// Identity `Substs` for use with const-evaluation.
@@ -53,9 +53,9 @@ pub struct Cx<'a, 'gcx: 'a + 'tcx, 'tcx: 'a> {
 
 impl<'a, 'gcx, 'tcx> Cx<'a, 'gcx, 'tcx> {
     pub fn new(infcx: &'a InferCtxt<'a, 'gcx, 'tcx>,
-               src_id: ast::NodeId) -> Cx<'a, 'gcx, 'tcx> {
+               src_id: hir::HirId) -> Cx<'a, 'gcx, 'tcx> {
         let tcx = infcx.tcx;
-        let src_def_id = tcx.hir().local_def_id(src_id);
+        let src_def_id = tcx.hir().local_def_id_from_hir_id(src_id);
         let body_owner_kind = tcx.hir().body_owner_kind(src_id);
 
         let constness = match body_owner_kind {
@@ -154,7 +154,7 @@ impl<'a, 'gcx, 'tcx> Cx<'a, 'gcx, 'tcx> {
 
     pub fn pattern_from_hir(&mut self, p: &hir::Pat) -> Pattern<'tcx> {
         let tcx = self.tcx.global_tcx();
-        let p = match tcx.hir().get(p.id) {
+        let p = match tcx.hir().get_by_hir_id(p.hir_id) {
             Node::Pat(p) | Node::Binding(p) => p,
             node => bug!("pattern became {:?}", node)
         };
@@ -198,14 +198,13 @@ impl<'a, 'gcx, 'tcx> Cx<'a, 'gcx, 'tcx> {
         ty.needs_drop(self.tcx.global_tcx(), param_env)
     }
 
-    fn lint_level_of(&self, node_id: ast::NodeId) -> LintLevel {
-        let hir_id = self.tcx.hir().definitions().node_to_hir_id(node_id);
+    fn lint_level_of(&self, hir_id: hir::HirId) -> LintLevel {
         let has_lint_level = self.tcx.dep_graph.with_ignore(|| {
             self.tcx.lint_levels(LOCAL_CRATE).lint_level_set(hir_id).is_some()
         });
 
         if has_lint_level {
-            LintLevel::Explicit(node_id)
+            LintLevel::Explicit(hir_id)
         } else {
             LintLevel::Inherited
         }
@@ -238,7 +237,7 @@ impl UserAnnotatedTyHelpers<'gcx, 'tcx> for Cx<'_, 'gcx, 'tcx> {
     }
 }
 
-fn lint_level_for_hir_id(tcx: TyCtxt, mut id: ast::NodeId) -> ast::NodeId {
+fn lint_level_for_hir_id(tcx: TyCtxt, mut hir_id: hir::HirId) -> hir::HirId {
     // Right now we insert a `with_ignore` node in the dep graph here to
     // ignore the fact that `lint_levels` below depends on the entire crate.
     // For now this'll prevent false positives of recompiling too much when
@@ -250,15 +249,14 @@ fn lint_level_for_hir_id(tcx: TyCtxt, mut id: ast::NodeId) -> ast::NodeId {
     tcx.dep_graph.with_ignore(|| {
         let sets = tcx.lint_levels(LOCAL_CRATE);
         loop {
-            let hir_id = tcx.hir().definitions().node_to_hir_id(id);
             if sets.lint_level_set(hir_id).is_some() {
-                return id
+                return hir_id
             }
-            let next = tcx.hir().get_parent_node(id);
-            if next == id {
+            let next = tcx.hir().get_parent_node(hir_id);
+            if next == hir_id {
                 bug!("lint traversal reached the root of the crate");
             }
-            id = next;
+            hir_id = next;
         }
     })
 }

--- a/src/librustc_mir/hair/mod.rs
+++ b/src/librustc_mir/hair/mod.rs
@@ -12,7 +12,6 @@ use rustc::ty::subst::Substs;
 use rustc::ty::{AdtDef, UpvarSubsts, Ty, Const, LazyConst, UserTypeAnnotation};
 use rustc::ty::layout::VariantIdx;
 use rustc::hir;
-use syntax::ast;
 use syntax_pos::Span;
 use self::cx::Cx;
 
@@ -28,7 +27,7 @@ mod util;
 #[derive(Copy, Clone, Debug)]
 pub enum LintLevel {
     Inherited,
-    Explicit(ast::NodeId)
+    Explicit(hir::HirId)
 }
 
 impl LintLevel {
@@ -54,7 +53,7 @@ pub struct Block<'tcx> {
 #[derive(Copy, Clone, Debug)]
 pub enum BlockSafety {
     Safe,
-    ExplicitUnsafe(ast::NodeId),
+    ExplicitUnsafe(hir::HirId),
     PushUnsafe,
     PopUnsafe
 }
@@ -227,7 +226,7 @@ pub enum ExprKind<'tcx> {
         index: ExprRef<'tcx>,
     },
     VarRef {
-        id: ast::NodeId,
+        id: hir::HirId,
     },
     /// first argument, used for self in a closure
     SelfRef,

--- a/src/librustc_mir/hair/util.rs
+++ b/src/librustc_mir/hair/util.rs
@@ -16,7 +16,7 @@ crate trait UserAnnotatedTyHelpers<'gcx: 'tcx, 'tcx> {
         let user_provided_types = self.tables().user_provided_types();
         let mut user_ty = *user_provided_types.get(hir_id)?;
         debug!("user_subts_applied_to_ty_of_hir_id: user_ty={:?}", user_ty);
-        match &self.tables().node_id_to_type(hir_id).sty {
+        match &self.tables().hir_id_to_type(hir_id).sty {
             ty::Adt(adt_def, ..) => {
                 if let UserTypeAnnotation::TypeOf(ref mut did, _) = &mut user_ty.value {
                     *did = adt_def.did;

--- a/src/librustc_mir/lints.rs
+++ b/src/librustc_mir/lints.rs
@@ -129,10 +129,10 @@ fn check_fn_for_unconditional_recursion(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     // no break */ }`) shouldn't be linted unless it actually
     // recurs.
     if !reached_exit_without_self_call && !self_call_locations.is_empty() {
-        let node_id = tcx.hir().as_local_node_id(def_id).unwrap();
-        let sp = tcx.sess.source_map().def_span(tcx.hir().span(node_id));
+        let hir_id = tcx.hir().as_local_hir_id(def_id).unwrap();
+        let sp = tcx.sess.source_map().def_span(tcx.hir().span(hir_id));
         let mut db = tcx.struct_span_lint_node(UNCONDITIONAL_RECURSION,
-                                                node_id,
+                                                hir_id,
                                                 sp,
                                                 "function cannot return without recursing");
         db.span_label(sp, "cannot return without recursing");

--- a/src/librustc_mir/monomorphize/collector.rs
+++ b/src/librustc_mir/monomorphize/collector.rs
@@ -321,8 +321,8 @@ fn collect_roots<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     let mut roots = Vec::new();
 
     {
-        let entry_fn = tcx.sess.entry_fn.borrow().map(|(node_id, _, _)| {
-            tcx.hir().local_def_id(node_id)
+        let entry_fn = tcx.sess.entry_fn.borrow().map(|(hir_id, _, _)| {
+            tcx.hir().local_def_id_from_hir_id(hir_id)
         });
 
         debug!("collect_roots: entry_fn = {:?}", entry_fn);
@@ -452,8 +452,8 @@ fn check_recursion_limit<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     if recursion_depth > *tcx.sess.recursion_limit.get() {
         let error = format!("reached the recursion limit while instantiating `{}`",
                             instance);
-        if let Some(node_id) = tcx.hir().as_local_node_id(def_id) {
-            tcx.sess.span_fatal(tcx.hir().span(node_id), &error);
+        if let Some(hir_id) = tcx.hir().as_local_hir_id(def_id) {
+            tcx.sess.span_fatal(tcx.hir().span(hir_id), &error);
         } else {
             tcx.sess.fatal(&error);
         }
@@ -484,8 +484,8 @@ fn check_type_length_limit<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         let instance_name = instance.to_string();
         let msg = format!("reached the type-length limit while instantiating `{:.64}...`",
                           instance_name);
-        let mut diag = if let Some(node_id) = tcx.hir().as_local_node_id(instance.def_id()) {
-            tcx.sess.struct_span_fatal(tcx.hir().span(node_id), &msg)
+        let mut diag = if let Some(hir_id) = tcx.hir().as_local_hir_id(instance.def_id()) {
+            tcx.sess.struct_span_fatal(tcx.hir().span(hir_id), &msg)
         } else {
             tcx.sess.struct_fatal(&msg)
         };
@@ -954,7 +954,7 @@ impl<'b, 'a, 'v> ItemLikeVisitor<'v> for RootCollector<'b, 'a, 'v> {
             hir::ItemKind::Union(_, ref generics) => {
                 if generics.params.is_empty() {
                     if self.mode == MonoItemCollectionMode::Eager {
-                        let def_id = self.tcx.hir().local_def_id(item.id);
+                        let def_id = self.tcx.hir().local_def_id_from_hir_id(item.hir_id);
                         debug!("RootCollector: ADT drop-glue for {}",
                                def_id_to_string(self.tcx, def_id));
 
@@ -966,11 +966,11 @@ impl<'b, 'a, 'v> ItemLikeVisitor<'v> for RootCollector<'b, 'a, 'v> {
             hir::ItemKind::GlobalAsm(..) => {
                 debug!("RootCollector: ItemKind::GlobalAsm({})",
                        def_id_to_string(self.tcx,
-                                        self.tcx.hir().local_def_id(item.id)));
-                self.output.push(MonoItem::GlobalAsm(item.id));
+                                        self.tcx.hir().local_def_id_from_hir_id(item.hir_id)));
+                self.output.push(MonoItem::GlobalAsm(item.hir_id));
             }
             hir::ItemKind::Static(..) => {
-                let def_id = self.tcx.hir().local_def_id(item.id);
+                let def_id = self.tcx.hir().local_def_id_from_hir_id(item.hir_id);
                 debug!("RootCollector: ItemKind::Static({})",
                        def_id_to_string(self.tcx, def_id));
                 self.output.push(MonoItem::Static(def_id));
@@ -980,7 +980,7 @@ impl<'b, 'a, 'v> ItemLikeVisitor<'v> for RootCollector<'b, 'a, 'v> {
                 // actually used somewhere. Just declaring them is insufficient.
 
                 // but even just declaring them must collect the items they refer to
-                let def_id = self.tcx.hir().local_def_id(item.id);
+                let def_id = self.tcx.hir().local_def_id_from_hir_id(item.hir_id);
 
                 let instance = Instance::mono(self.tcx, def_id);
                 let cid = GlobalId {
@@ -994,7 +994,7 @@ impl<'b, 'a, 'v> ItemLikeVisitor<'v> for RootCollector<'b, 'a, 'v> {
                 }
             }
             hir::ItemKind::Fn(..) => {
-                let def_id = self.tcx.hir().local_def_id(item.id);
+                let def_id = self.tcx.hir().local_def_id_from_hir_id(item.hir_id);
                 self.push_if_root(def_id);
             }
         }
@@ -1008,7 +1008,7 @@ impl<'b, 'a, 'v> ItemLikeVisitor<'v> for RootCollector<'b, 'a, 'v> {
     fn visit_impl_item(&mut self, ii: &'v hir::ImplItem) {
         match ii.node {
             hir::ImplItemKind::Method(hir::MethodSig { .. }, _) => {
-                let def_id = self.tcx.hir().local_def_id(ii.id);
+                let def_id = self.tcx.hir().local_def_id_from_hir_id(ii.hir_id);
                 self.push_if_root(def_id);
             }
             _ => { /* Nothing to do here */ }
@@ -1101,7 +1101,7 @@ fn create_mono_items_for_default_impls<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                 }
             }
 
-            let impl_def_id = tcx.hir().local_def_id(item.id);
+            let impl_def_id = tcx.hir().local_def_id_from_hir_id(item.hir_id);
 
             debug!("create_mono_items_for_default_impls(item={})",
                    def_id_to_string(tcx, impl_def_id));

--- a/src/librustc_mir/monomorphize/item.rs
+++ b/src/librustc_mir/monomorphize/item.rs
@@ -57,8 +57,8 @@ pub trait MonoItemExt<'a, 'tcx>: fmt::Debug {
             MonoItem::Static(def_id) => {
                 tcx.symbol_name(Instance::mono(tcx, def_id))
             }
-            MonoItem::GlobalAsm(node_id) => {
-                let def_id = tcx.hir().local_def_id(node_id);
+            MonoItem::GlobalAsm(hir_id) => {
+                let def_id = tcx.hir().local_def_id_from_hir_id(hir_id);
                 ty::SymbolName {
                     name: Symbol::intern(&format!("global_asm_{:?}", def_id)).as_interned_str()
                 }
@@ -76,7 +76,8 @@ pub trait MonoItemExt<'a, 'tcx>: fmt::Debug {
         match *self.as_mono_item() {
             MonoItem::Fn(ref instance) => {
                 let entry_def_id =
-                    tcx.sess.entry_fn.borrow().map(|(id, _, _)| tcx.hir().local_def_id(id));
+                    tcx.sess.entry_fn.borrow().map(|(id, _, _)|
+                        tcx.hir().local_def_id_from_hir_id(id));
                 // If this function isn't inlined or otherwise has explicit
                 // linkage, then we'll be creating a globally shared version.
                 if self.explicit_linkage(tcx).is_some() ||
@@ -189,15 +190,15 @@ pub trait MonoItemExt<'a, 'tcx>: fmt::Debug {
     fn local_span(&self, tcx: TyCtxt<'a, 'tcx, 'tcx>) -> Option<Span> {
         match *self.as_mono_item() {
             MonoItem::Fn(Instance { def, .. }) => {
-                tcx.hir().as_local_node_id(def.def_id())
+                tcx.hir().as_local_hir_id(def.def_id())
             }
             MonoItem::Static(def_id) => {
-                tcx.hir().as_local_node_id(def_id)
+                tcx.hir().as_local_hir_id(def_id)
             }
-            MonoItem::GlobalAsm(node_id) => {
-                Some(node_id)
+            MonoItem::GlobalAsm(hir_id) => {
+                Some(hir_id)
             }
-        }.map(|node_id| tcx.hir().span(node_id))
+        }.map(|hir_id| tcx.hir().span(hir_id))
     }
 }
 

--- a/src/librustc_mir/monomorphize/partitioning.rs
+++ b/src/librustc_mir/monomorphize/partitioning.rs
@@ -96,10 +96,9 @@ use std::collections::hash_map::Entry;
 use std::cmp;
 use std::sync::Arc;
 
-use syntax::ast::NodeId;
 use syntax::symbol::InternedString;
 use rustc::dep_graph::{WorkProductId, WorkProduct, DepNode, DepConstructor};
-use rustc::hir::CodegenFnAttrFlags;
+use rustc::hir::{self, CodegenFnAttrFlags};
 use rustc::hir::def_id::{CrateNum, DefId, LOCAL_CRATE, CRATE_DEF_INDEX};
 use rustc::hir::map::DefPathData;
 use rustc::mir::mono::{Linkage, Visibility, CodegenUnitNameBuilder};
@@ -162,7 +161,7 @@ pub trait CodegenUnitExt<'tcx> {
         // The codegen tests rely on items being process in the same order as
         // they appear in the file, so for local items, we sort by node_id first
         #[derive(PartialEq, Eq, PartialOrd, Ord)]
-        pub struct ItemSortKey(Option<NodeId>, ty::SymbolName);
+        pub struct ItemSortKey(Option<hir::HirId>, ty::SymbolName);
 
         fn item_sort_key<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                    item: MonoItem<'tcx>) -> ItemSortKey {
@@ -174,7 +173,7 @@ pub trait CodegenUnitExt<'tcx> {
                         // the codegen tests and can even make item order
                         // unstable.
                         InstanceDef::Item(def_id) => {
-                            tcx.hir().as_local_node_id(def_id)
+                            tcx.hir().as_local_hir_id(def_id)
                         }
                         InstanceDef::VtableShim(..) |
                         InstanceDef::Intrinsic(..) |
@@ -188,10 +187,10 @@ pub trait CodegenUnitExt<'tcx> {
                     }
                 }
                 MonoItem::Static(def_id) => {
-                    tcx.hir().as_local_node_id(def_id)
+                    tcx.hir().as_local_hir_id(def_id)
                 }
-                MonoItem::GlobalAsm(node_id) => {
-                    Some(node_id)
+                MonoItem::GlobalAsm(hir_id) => {
+                    Some(hir_id)
                 }
             }, item.symbol_name(tcx))
         }
@@ -404,8 +403,8 @@ fn mono_item_visibility(
                 Visibility::Hidden
             };
         }
-        MonoItem::GlobalAsm(node_id) => {
-            let def_id = tcx.hir().local_def_id(*node_id);
+        MonoItem::GlobalAsm(hir_id) => {
+            let def_id = tcx.hir().local_def_id_from_hir_id(*hir_id);
             return if tcx.is_reachable_non_generic(def_id) {
                 *can_be_internalized = false;
                 default_visibility(tcx, def_id, false)
@@ -789,7 +788,7 @@ fn characteristic_def_id_of_mono_item<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
             Some(def_id)
         }
         MonoItem::Static(def_id) => Some(def_id),
-        MonoItem::GlobalAsm(node_id) => Some(tcx.hir().local_def_id(node_id)),
+        MonoItem::GlobalAsm(hir_id) => Some(tcx.hir().local_def_id_from_hir_id(hir_id)),
     }
 }
 

--- a/src/librustc_mir/shim.rs
+++ b/src/librustc_mir/shim.rs
@@ -10,7 +10,6 @@ use rustc::ty::query::Providers;
 use rustc_data_structures::indexed_vec::{IndexVec, Idx};
 
 use rustc_target::spec::abi::Abi;
-use syntax::ast;
 use syntax_pos::Span;
 
 use std::fmt;
@@ -846,14 +845,14 @@ fn build_call_shim<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 }
 
 pub fn build_adt_ctor<'a, 'gcx, 'tcx>(infcx: &infer::InferCtxt<'a, 'gcx, 'tcx>,
-                                      ctor_id: ast::NodeId,
+                                      ctor_id: hir::HirId,
                                       fields: &[hir::StructField],
                                       span: Span)
                                       -> Mir<'tcx>
 {
     let tcx = infcx.tcx;
     let gcx = tcx.global_tcx();
-    let def_id = tcx.hir().local_def_id(ctor_id);
+    let def_id = tcx.hir().local_def_id_from_hir_id(ctor_id);
     let param_env = gcx.param_env(def_id);
 
     // Normalize the sig.

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -607,10 +607,10 @@ impl<'b, 'a, 'tcx> Visitor<'tcx> for ConstPropagator<'b, 'a, 'tcx> {
                         .unwrap()
                         .source_info
                         .span;
-                    let node_id = self
+                    let hir_id = self
                         .tcx
                         .hir()
-                        .as_local_node_id(self.source.def_id)
+                        .as_local_hir_id(self.source.def_id)
                         .expect("some part of a failing const eval must be local");
                     use rustc::mir::interpret::EvalErrorKind::*;
                     let msg = match msg {
@@ -649,7 +649,7 @@ impl<'b, 'a, 'tcx> Visitor<'tcx> for ConstPropagator<'b, 'a, 'tcx> {
                     };
                     self.tcx.lint_node(
                         ::rustc::lint::builtin::CONST_ERR,
-                        node_id,
+                        hir_id,
                         span,
                         &msg,
                     );

--- a/src/librustc_mir/transform/elaborate_drops.rs
+++ b/src/librustc_mir/transform/elaborate_drops.rs
@@ -5,13 +5,13 @@ use dataflow::{on_all_children_bits, on_all_drop_children_bits};
 use dataflow::{drop_flag_effects_for_location, on_lookup_result_bits};
 use dataflow::MoveDataParamEnv;
 use dataflow::{self, do_dataflow, DebugFormatted};
+use rustc::hir;
 use rustc::ty::{self, TyCtxt};
 use rustc::ty::layout::VariantIdx;
 use rustc::mir::*;
 use rustc::util::nodemap::FxHashMap;
 use rustc_data_structures::bit_set::BitSet;
 use std::fmt;
-use syntax::ast;
 use syntax_pos::Span;
 use transform::{MirPass, MirSource};
 use util::patch::MirPatch;
@@ -28,7 +28,7 @@ impl MirPass for ElaborateDrops {
     {
         debug!("elaborate_drops({:?} @ {:?})", src, mir.span);
 
-        let id = tcx.hir().as_local_node_id(src.def_id).unwrap();
+        let id = tcx.hir().as_local_hir_id(src.def_id).unwrap();
         let param_env = tcx.param_env(src.def_id).with_reveal_all();
         let move_data = match MoveData::gather_moves(mir, tcx) {
             Ok(move_data) => move_data,
@@ -80,7 +80,7 @@ impl MirPass for ElaborateDrops {
 fn find_dead_unwinds<'a, 'tcx>(
     tcx: TyCtxt<'a, 'tcx, 'tcx>,
     mir: &Mir<'tcx>,
-    id: ast::NodeId,
+    id: hir::HirId,
     env: &MoveDataParamEnv<'tcx, 'tcx>)
     -> BitSet<BasicBlock>
 {

--- a/src/librustc_mir/transform/generator.rs
+++ b/src/librustc_mir/transform/generator.rs
@@ -339,13 +339,13 @@ fn locals_live_across_suspend_points(
     FxHashMap<BasicBlock, liveness::LiveVarSet<Local>>,
 ) {
     let dead_unwinds = BitSet::new_empty(mir.basic_blocks().len());
-    let node_id = tcx.hir().as_local_node_id(source.def_id).unwrap();
+    let hir_id = tcx.hir().as_local_hir_id(source.def_id).unwrap();
 
     // Calculate when MIR locals have live storage. This gives us an upper bound of their
     // lifetimes.
     let storage_live_analysis = MaybeStorageLive::new(mir);
     let storage_live =
-        do_dataflow(tcx, mir, node_id, &[], &dead_unwinds, storage_live_analysis,
+        do_dataflow(tcx, mir, hir_id, &[], &dead_unwinds, storage_live_analysis,
                     |bd, p| DebugFormatted::new(&bd.mir().local_decls[p]));
 
     // Find the MIR locals which do not use StorageLive/StorageDead statements.
@@ -359,7 +359,7 @@ fn locals_live_across_suspend_points(
     let borrowed_locals = if !movable {
         let analysis = HaveBeenBorrowedLocals::new(mir);
         let result =
-            do_dataflow(tcx, mir, node_id, &[], &dead_unwinds, analysis,
+            do_dataflow(tcx, mir, hir_id, &[], &dead_unwinds, analysis,
                         |bd, p| DebugFormatted::new(&bd.mir().local_decls[p]));
         Some((analysis, result))
     } else {

--- a/src/librustc_mir/transform/inline.rs
+++ b/src/librustc_mir/transform/inline.rs
@@ -73,7 +73,7 @@ impl<'a, 'tcx> Inliner<'a, 'tcx> {
         let param_env = self.tcx.param_env(self.source.def_id);
 
         // Only do inlining into fn bodies.
-        let id = self.tcx.hir().as_local_node_id(self.source.def_id).unwrap();
+        let id = self.tcx.hir().as_local_hir_id(self.source.def_id).unwrap();
         let body_owner_kind = self.tcx.hir().body_owner_kind(id);
 
         if let (hir::BodyOwnerKind::Fn, None) = (body_owner_kind, self.source.promoted) {

--- a/src/librustc_mir/transform/mod.rs
+++ b/src/librustc_mir/transform/mod.rs
@@ -78,10 +78,10 @@ fn mir_keys<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, krate: CrateNum)
                               v: &'tcx hir::VariantData,
                               _: ast::Name,
                               _: &'tcx hir::Generics,
-                              _: ast::NodeId,
+                              _: hir::HirId,
                               _: Span) {
-            if let hir::VariantData::Tuple(_, node_id) = *v {
-                self.set.insert(self.tcx.hir().local_def_id(node_id));
+            if let hir::VariantData::Tuple(_, hir_id) = *v {
+                self.set.insert(self.tcx.hir().local_def_id_from_hir_id(hir_id));
             }
             intravisit::walk_struct_def(self, v)
         }
@@ -209,8 +209,8 @@ fn mir_const<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) -> &'tcx Stea
 }
 
 fn mir_validated<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) -> &'tcx Steal<Mir<'tcx>> {
-    let node_id = tcx.hir().as_local_node_id(def_id).unwrap();
-    if let hir::BodyOwnerKind::Const = tcx.hir().body_owner_kind(node_id) {
+    let hir_id = tcx.hir().as_local_hir_id(def_id).unwrap();
+    if let hir::BodyOwnerKind::Const = tcx.hir().body_owner_kind(hir_id) {
         // Ensure that we compute the `mir_const_qualif` for constants at
         // this point, before we steal the mir-const result.
         let _ = tcx.mir_const_qualif(def_id);

--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -1149,7 +1149,7 @@ impl MirPass for QualifyAndPromoteConstants {
         }
 
         let def_id = src.def_id;
-        let id = tcx.hir().as_local_node_id(def_id).unwrap();
+        let id = tcx.hir().as_local_hir_id(def_id).unwrap();
         let mut const_promoted_temps = None;
         let mode = match tcx.hir().body_owner_kind(id) {
             hir::BodyOwnerKind::Fn => {

--- a/src/librustc_mir/transform/rustc_peek.rs
+++ b/src/librustc_mir/transform/rustc_peek.rs
@@ -2,6 +2,7 @@ use rustc_target::spec::abi::{Abi};
 use syntax::ast;
 use syntax_pos::Span;
 
+use rustc::hir;
 use rustc::ty::{self, TyCtxt};
 use rustc::mir::{self, Mir, Location};
 use rustc_data_structures::bit_set::BitSet;
@@ -24,7 +25,7 @@ impl MirPass for SanityCheck {
     fn run_pass<'a, 'tcx>(&self, tcx: TyCtxt<'a, 'tcx, 'tcx>,
                           src: MirSource, mir: &mut Mir<'tcx>) {
         let def_id = src.def_id;
-        let id = tcx.hir().as_local_node_id(def_id).unwrap();
+        let id = tcx.hir().as_local_hir_id(def_id).unwrap();
         if !tcx.has_attr(def_id, "rustc_mir") {
             debug!("skipping rustc_peek::SanityCheck on {}", tcx.item_path_str(def_id));
             return;
@@ -83,7 +84,7 @@ impl MirPass for SanityCheck {
 /// errors are not intended to be used for unit tests.)
 pub fn sanity_check_via_rustc_peek<'a, 'tcx, O>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                                 mir: &Mir<'tcx>,
-                                                id: ast::NodeId,
+                                                id: hir::HirId,
                                                 _attributes: &[ast::Attribute],
                                                 results: &DataflowResults<'tcx, O>)
     where O: BitDenotation<'tcx, Idx=MovePathIndex> + HasMoveData<'tcx>

--- a/src/librustc_mir/util/pretty.rs
+++ b/src/librustc_mir/util/pretty.rs
@@ -569,7 +569,7 @@ pub fn write_mir_intro<'a, 'gcx, 'tcx>(
 }
 
 fn write_mir_sig(tcx: TyCtxt, src: MirSource, mir: &Mir, w: &mut dyn Write) -> io::Result<()> {
-    let id = tcx.hir().as_local_node_id(src.def_id).unwrap();
+    let id = tcx.hir().as_local_hir_id(src.def_id).unwrap();
     let body_owner_kind = tcx.hir().body_owner_kind(id);
     match (body_owner_kind, src.promoted) {
         (_, Some(i)) => write!(w, "{:?} in", i)?,

--- a/src/librustc_passes/hir_stats.rs
+++ b/src/librustc_passes/hir_stats.rs
@@ -2,7 +2,7 @@
 // pieces of AST and HIR. The resulting numbers are good approximations but not
 // completely accurate (some things might be counted twice, others missed).
 
-use rustc::hir;
+use rustc::hir::{self, HirId};
 use rustc::hir::intravisit as hir_visit;
 use rustc::util::common::to_readable_str;
 use rustc::util::nodemap::{FxHashMap, FxHashSet};
@@ -12,7 +12,7 @@ use syntax_pos::Span;
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 enum Id {
-    Node(NodeId),
+    Hir(HirId),
     Attr(AttrId),
     None,
 }
@@ -119,32 +119,32 @@ impl<'v> hir_visit::Visitor<'v> for StatCollector<'v> {
     }
 
     fn visit_item(&mut self, i: &'v hir::Item) {
-        self.record("Item", Id::Node(i.id), i);
+        self.record("Item", Id::Hir(i.hir_id), i);
         hir_visit::walk_item(self, i)
     }
 
-    fn visit_mod(&mut self, m: &'v hir::Mod, _s: Span, n: NodeId) {
+    fn visit_mod(&mut self, m: &'v hir::Mod, _s: Span, h: hir::HirId) {
         self.record("Mod", Id::None, m);
-        hir_visit::walk_mod(self, m, n)
+        hir_visit::walk_mod(self, m, h)
     }
 
     fn visit_foreign_item(&mut self, i: &'v hir::ForeignItem) {
-        self.record("ForeignItem", Id::Node(i.id), i);
+        self.record("ForeignItem", Id::Hir(i.hir_id), i);
         hir_visit::walk_foreign_item(self, i)
     }
 
     fn visit_local(&mut self, l: &'v hir::Local) {
-        self.record("Local", Id::Node(l.id), l);
+        self.record("Local", Id::Hir(l.hir_id), l);
         hir_visit::walk_local(self, l)
     }
 
     fn visit_block(&mut self, b: &'v hir::Block) {
-        self.record("Block", Id::Node(b.id), b);
+        self.record("Block", Id::Hir(b.hir_id), b);
         hir_visit::walk_block(self, b)
     }
 
     fn visit_stmt(&mut self, s: &'v hir::Stmt) {
-        self.record("Stmt", Id::Node(s.node.id()), s);
+        self.record("Stmt", Id::Hir(s.node.hir_id()), s);
         hir_visit::walk_stmt(self, s)
     }
 
@@ -154,7 +154,7 @@ impl<'v> hir_visit::Visitor<'v> for StatCollector<'v> {
     }
 
     fn visit_pat(&mut self, p: &'v hir::Pat) {
-        self.record("Pat", Id::Node(p.id), p);
+        self.record("Pat", Id::Hir(p.hir_id), p);
         hir_visit::walk_pat(self, p)
     }
 
@@ -164,12 +164,12 @@ impl<'v> hir_visit::Visitor<'v> for StatCollector<'v> {
     }
 
     fn visit_expr(&mut self, ex: &'v hir::Expr) {
-        self.record("Expr", Id::Node(ex.id), ex);
+        self.record("Expr", Id::Hir(ex.hir_id), ex);
         hir_visit::walk_expr(self, ex)
     }
 
     fn visit_ty(&mut self, t: &'v hir::Ty) {
-        self.record("Ty", Id::Node(t.id), t);
+        self.record("Ty", Id::Hir(t.hir_id), t);
         hir_visit::walk_ty(self, t)
     }
 
@@ -178,7 +178,7 @@ impl<'v> hir_visit::Visitor<'v> for StatCollector<'v> {
                 fd: &'v hir::FnDecl,
                 b: hir::BodyId,
                 s: Span,
-                id: NodeId) {
+                id: HirId) {
         self.record("FnDecl", Id::None, fd);
         hir_visit::walk_fn(self, fk, fd, b, s, id)
     }
@@ -189,12 +189,12 @@ impl<'v> hir_visit::Visitor<'v> for StatCollector<'v> {
     }
 
     fn visit_trait_item(&mut self, ti: &'v hir::TraitItem) {
-        self.record("TraitItem", Id::Node(ti.id), ti);
+        self.record("TraitItem", Id::Hir(ti.hir_id), ti);
         hir_visit::walk_trait_item(self, ti)
     }
 
     fn visit_impl_item(&mut self, ii: &'v hir::ImplItem) {
-        self.record("ImplItem", Id::Node(ii.id), ii);
+        self.record("ImplItem", Id::Hir(ii.hir_id), ii);
         hir_visit::walk_impl_item(self, ii)
     }
 
@@ -204,20 +204,20 @@ impl<'v> hir_visit::Visitor<'v> for StatCollector<'v> {
     }
 
     fn visit_struct_field(&mut self, s: &'v hir::StructField) {
-        self.record("StructField", Id::Node(s.id), s);
+        self.record("StructField", Id::Hir(s.hir_id), s);
         hir_visit::walk_struct_field(self, s)
     }
 
     fn visit_variant(&mut self,
                      v: &'v hir::Variant,
                      g: &'v hir::Generics,
-                     item_id: NodeId) {
+                     item_id: HirId) {
         self.record("Variant", Id::None, v);
         hir_visit::walk_variant(self, v, g, item_id)
     }
 
     fn visit_lifetime(&mut self, lifetime: &'v hir::Lifetime) {
-        self.record("Lifetime", Id::Node(lifetime.id), lifetime);
+        self.record("Lifetime", Id::Hir(lifetime.hir_id), lifetime);
         hir_visit::walk_lifetime(self, lifetime)
     }
 
@@ -239,7 +239,7 @@ impl<'v> hir_visit::Visitor<'v> for StatCollector<'v> {
     }
 
     fn visit_assoc_type_binding(&mut self, type_binding: &'v hir::TypeBinding) {
-        self.record("TypeBinding", Id::Node(type_binding.id), type_binding);
+        self.record("TypeBinding", Id::Hir(type_binding.hir_id), type_binding);
         hir_visit::walk_assoc_type_binding(self, type_binding)
     }
 
@@ -248,7 +248,7 @@ impl<'v> hir_visit::Visitor<'v> for StatCollector<'v> {
     }
 
     fn visit_macro_def(&mut self, macro_def: &'v hir::MacroDef) {
-        self.record("MacroDef", Id::Node(macro_def.id), macro_def);
+        self.record("MacroDef", Id::Hir(macro_def.hir_id), macro_def);
         hir_visit::walk_macro_def(self, macro_def)
     }
 }

--- a/src/librustc_passes/loops.rs
+++ b/src/librustc_passes/loops.rs
@@ -123,7 +123,8 @@ impl<'a, 'hir> Visitor<'hir> for CheckLoopVisitor<'a, 'hir> {
                     let loop_kind = if loop_id == ast::DUMMY_NODE_ID {
                         None
                     } else {
-                        Some(match self.hir_map.expect_expr(loop_id).node {
+                        let hir_id = self.hir_map.node_to_hir_id(loop_id);
+                        Some(match self.hir_map.expect_expr(hir_id).node {
                             hir::ExprKind::While(..) => LoopKind::WhileLoop,
                             hir::ExprKind::Loop(_, _, source) => LoopKind::Loop(source),
                             ref r => span_bug!(e.span,

--- a/src/librustc_passes/rvalue_promotion.rs
+++ b/src/librustc_passes/rvalue_promotion.rs
@@ -23,10 +23,9 @@ use rustc::middle::mem_categorization::Categorization;
 use rustc::ty::{self, Ty, TyCtxt};
 use rustc::ty::query::Providers;
 use rustc::ty::subst::Substs;
-use rustc::util::nodemap::{ItemLocalSet, NodeSet};
+use rustc::util::nodemap::{ItemLocalSet, HirIdSet};
 use rustc::hir;
 use rustc_data_structures::sync::Lrc;
-use syntax::ast;
 use syntax_pos::{Span, DUMMY_SP};
 use self::Promotability::*;
 use std::ops::{BitAnd, BitAndAssign, BitOr};
@@ -53,11 +52,11 @@ fn const_is_rvalue_promotable_to_static<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 {
     assert!(def_id.is_local());
 
-    let node_id = tcx.hir().as_local_node_id(def_id)
+    let hir_id = tcx.hir().as_local_hir_id(def_id)
         .expect("rvalue_promotable_map invoked with non-local def-id");
-    let body_id = tcx.hir().body_owned_by(node_id);
-    let body_hir_id = tcx.hir().node_to_hir_id(body_id.node_id);
-    tcx.rvalue_promotable_map(def_id).contains(&body_hir_id.local_id)
+    let body_id = tcx.hir().body_owned_by(hir_id);
+
+    tcx.rvalue_promotable_map(def_id).contains(&body_id.hir_id.local_id)
 }
 
 fn rvalue_promotable_map<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
@@ -81,9 +80,9 @@ fn rvalue_promotable_map<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     };
 
     // `def_id` should be a `Body` owner
-    let node_id = tcx.hir().as_local_node_id(def_id)
+    let hir_id = tcx.hir().as_local_hir_id(def_id)
         .expect("rvalue_promotable_map invoked with non-local def-id");
-    let body_id = tcx.hir().body_owned_by(node_id);
+    let body_id = tcx.hir().body_owned_by(hir_id);
     let _ = visitor.check_nested_body(body_id);
 
     Lrc::new(visitor.result)
@@ -93,7 +92,7 @@ struct CheckCrateVisitor<'a, 'tcx: 'a> {
     tcx: TyCtxt<'a, 'tcx, 'tcx>,
     in_fn: bool,
     in_static: bool,
-    mut_rvalue_borrows: NodeSet,
+    mut_rvalue_borrows: HirIdSet,
     param_env: ty::ParamEnv<'tcx>,
     identity_substs: &'tcx Substs<'tcx>,
     tables: &'a ty::TypeckTables<'tcx>,
@@ -170,7 +169,7 @@ impl<'a, 'gcx> CheckCrateVisitor<'a, 'gcx> {
     fn remove_mut_rvalue_borrow(&mut self, pat: &hir::Pat) -> bool {
         let mut any_removed = false;
         pat.walk(|p| {
-            any_removed |= self.mut_rvalue_borrows.remove(&p.id);
+            any_removed |= self.mut_rvalue_borrows.remove(&p.hir_id);
             true
         });
         any_removed
@@ -180,7 +179,7 @@ impl<'a, 'gcx> CheckCrateVisitor<'a, 'gcx> {
 impl<'a, 'tcx> CheckCrateVisitor<'a, 'tcx> {
     fn check_nested_body(&mut self, body_id: hir::BodyId) -> Promotability {
         let item_id = self.tcx.hir().body_owner(body_id);
-        let item_def_id = self.tcx.hir().local_def_id(item_id);
+        let item_def_id = self.tcx.hir().local_def_id_from_hir_id(item_id);
 
         let outer_in_fn = self.in_fn;
         let outer_tables = self.tables;
@@ -220,12 +219,12 @@ impl<'a, 'tcx> CheckCrateVisitor<'a, 'tcx> {
 
     fn check_stmt(&mut self, stmt: &'tcx hir::Stmt) -> Promotability {
         match stmt.node {
-            hir::StmtKind::Decl(ref decl, _node_id) => {
+            hir::StmtKind::Decl(ref decl, ..) => {
                 match &decl.node {
                     hir::DeclKind::Local(local) => {
                         if self.remove_mut_rvalue_borrow(&local.pat) {
                             if let Some(init) = &local.init {
-                                self.mut_rvalue_borrows.insert(init.id);
+                                self.mut_rvalue_borrows.insert(init.hir_id);
                             }
                         }
 
@@ -238,8 +237,8 @@ impl<'a, 'tcx> CheckCrateVisitor<'a, 'tcx> {
                     hir::DeclKind::Item(_) => Promotable
                 }
             }
-            hir::StmtKind::Expr(ref box_expr, _node_id) |
-            hir::StmtKind::Semi(ref box_expr, _node_id) => {
+            hir::StmtKind::Expr(ref box_expr, ..) |
+            hir::StmtKind::Semi(ref box_expr, ..) => {
                 let _ = self.check_expr(box_expr);
                 NotPromotable
             }
@@ -247,12 +246,12 @@ impl<'a, 'tcx> CheckCrateVisitor<'a, 'tcx> {
     }
 
     fn check_expr(&mut self, ex: &'tcx hir::Expr) -> Promotability {
-        let node_ty = self.tables.node_id_to_type(ex.hir_id);
+        let node_ty = self.tables.hir_id_to_type(ex.hir_id);
         let mut outer = check_expr_kind(self, ex, node_ty);
         outer &= check_adjustments(self, ex);
 
         // Handle borrows on (or inside the autorefs of) this expression.
-        if self.mut_rvalue_borrows.remove(&ex.id) {
+        if self.mut_rvalue_borrows.remove(&ex.hir_id) {
             outer = NotPromotable
         }
 
@@ -309,7 +308,7 @@ fn check_expr_kind<'a, 'tcx>(
             if v.tables.is_method_call(e) {
                 return NotPromotable;
             }
-            match v.tables.node_id_to_type(lhs.hir_id).sty {
+            match v.tables.hir_id_to_type(lhs.hir_id).sty {
                 ty::RawPtr(_) | ty::FnPtr(..) => {
                     assert!(op.node == hir::BinOpKind::Eq || op.node == hir::BinOpKind::Ne ||
                             op.node == hir::BinOpKind::Le || op.node == hir::BinOpKind::Lt ||
@@ -322,7 +321,7 @@ fn check_expr_kind<'a, 'tcx>(
         }
         hir::ExprKind::Cast(ref from, _) => {
             let expr_promotability = v.check_expr(from);
-            debug!("Checking const cast(id={})", from.id);
+            debug!("Checking const cast(id={:?})", from.hir_id);
             match v.tables.cast_kinds().get(from.hir_id) {
                 None => {
                     v.tcx.sess.delay_span_bug(e.span, "no kind for cast");
@@ -462,7 +461,7 @@ fn check_expr_kind<'a, 'tcx>(
             let nested_body_promotable = v.check_nested_body(body_id);
             // Paths in constant contexts cannot refer to local variables,
             // as there are none, and thus closures can't have upvars there.
-            if v.tcx.with_freevars(e.id, |fv| !fv.is_empty()) {
+            if v.tcx.with_freevars(e.hir_id, |fv| !fv.is_empty()) {
                 NotPromotable
             } else {
                 nested_body_promotable
@@ -522,7 +521,7 @@ fn check_expr_kind<'a, 'tcx>(
                 mut_borrow = v.remove_mut_rvalue_borrow(pat);
             }
             if mut_borrow {
-                v.mut_rvalue_borrows.insert(expr.id);
+                v.mut_rvalue_borrows.insert(expr.hir_id);
             }
 
             let _ = v.check_expr(expr);
@@ -623,13 +622,13 @@ fn check_adjustments<'a, 'tcx>(
 
 impl<'a, 'gcx, 'tcx> euv::Delegate<'tcx> for CheckCrateVisitor<'a, 'gcx> {
     fn consume(&mut self,
-               _consume_id: ast::NodeId,
+               _consume_id: hir::HirId,
                _consume_span: Span,
                _cmt: &mc::cmt_,
                _mode: euv::ConsumeMode) {}
 
     fn borrow(&mut self,
-              borrow_id: ast::NodeId,
+              borrow_id: hir::HirId,
               _borrow_span: Span,
               cmt: &mc::cmt_<'tcx>,
               _loan_region: ty::Region<'tcx>,
@@ -680,9 +679,9 @@ impl<'a, 'gcx, 'tcx> euv::Delegate<'tcx> for CheckCrateVisitor<'a, 'gcx> {
         }
     }
 
-    fn decl_without_init(&mut self, _id: ast::NodeId, _span: Span) {}
+    fn decl_without_init(&mut self, _id: hir::HirId, _span: Span) {}
     fn mutate(&mut self,
-              _assignment_id: ast::NodeId,
+              _assignment_id: hir::HirId,
               _assignment_span: Span,
               _assignee_cmt: &mc::cmt_,
               _mode: euv::MutateMode) {

--- a/src/librustc_plugin/build.rs
+++ b/src/librustc_plugin/build.rs
@@ -1,6 +1,5 @@
 //! Used by `rustc` when compiling a plugin crate.
 
-use syntax::ast;
 use syntax::attr;
 use syntax_pos::Span;
 use rustc::hir::itemlikevisit::ItemLikeVisitor;
@@ -10,7 +9,7 @@ use rustc::ty::TyCtxt;
 use rustc::ty::query::Providers;
 
 struct RegistrarFinder {
-    registrars: Vec<(ast::NodeId, Span)> ,
+    registrars: Vec<(hir::HirId, Span)> ,
 }
 
 impl<'v> ItemLikeVisitor<'v> for RegistrarFinder {
@@ -18,7 +17,7 @@ impl<'v> ItemLikeVisitor<'v> for RegistrarFinder {
         if let hir::ItemKind::Fn(..) = item.node {
             if attr::contains_name(&item.attrs,
                                    "plugin_registrar") {
-                self.registrars.push((item.id, item.span));
+                self.registrars.push((item.hir_id, item.span));
             }
         }
     }
@@ -47,8 +46,8 @@ fn plugin_registrar_fn<'tcx>(
     match finder.registrars.len() {
         0 => None,
         1 => {
-            let (node_id, _) = finder.registrars.pop().unwrap();
-            Some(tcx.hir().local_def_id(node_id))
+            let (hir_id, _) = finder.registrars.pop().unwrap();
+            Some(tcx.hir().local_def_id_from_hir_id(hir_id))
         },
         _ => {
             let diagnostic = tcx.sess.diagnostic();

--- a/src/librustc_save_analysis/sig.rs
+++ b/src/librustc_save_analysis/sig.rs
@@ -269,7 +269,8 @@ impl Sig for ast::Ty {
                 };
 
                 let name = pprust::path_segment_to_string(path.segments.last().ok_or("Bad path")?);
-                let def = scx.get_path_def(id.ok_or("Missing id for Path")?);
+                let hir_id = scx.tcx.hir().node_to_hir_id(id.ok_or("Missing id for Path")?);
+                let def = scx.get_path_def(hir_id);
                 let id = id_from_def_id(def.def_id());
                 if path.segments.len() - qself.position == 1 {
                     let start = offset + prefix.len();
@@ -572,7 +573,8 @@ impl Sig for ast::Item {
 
 impl Sig for ast::Path {
     fn make(&self, offset: usize, id: Option<NodeId>, scx: &SaveContext) -> Result {
-        let def = scx.get_path_def(id.ok_or("Missing id for Path")?);
+        let hir_id = scx.tcx.hir().node_to_hir_id(id.ok_or("Missing id for Path")?);
+        let def = scx.get_path_def(hir_id);
 
         let (name, start, end) = match def {
             Def::Label(..) | Def::PrimTy(..) | Def::SelfTy(..) | Def::Err => {

--- a/src/librustc_traits/implied_outlives_bounds.rs
+++ b/src/librustc_traits/implied_outlives_bounds.rs
@@ -1,6 +1,7 @@
 //! Provider for the `implied_outlives_bounds` query.
 //! Do not call this query directory. See [`rustc::traits::query::implied_outlives_bounds`].
 
+use rustc::hir;
 use rustc::infer::InferCtxt;
 use rustc::infer::canonical::{self, Canonical};
 use rustc::traits::{TraitEngine, TraitEngineExt};
@@ -11,7 +12,6 @@ use rustc::ty::outlives::Component;
 use rustc::ty::query::Providers;
 use rustc::ty::wf;
 use smallvec::{SmallVec, smallvec};
-use syntax::ast::DUMMY_NODE_ID;
 use syntax::source_map::DUMMY_SP;
 use rustc::traits::FulfillmentContext;
 
@@ -65,7 +65,7 @@ fn compute_implied_outlives_bounds<'tcx>(
         // unresolved inference variables here anyway, but there might be
         // during typeck under some circumstances.)
         let obligations =
-            wf::obligations(infcx, param_env, DUMMY_NODE_ID, ty, DUMMY_SP).unwrap_or(vec![]);
+            wf::obligations(infcx, param_env, hir::DUMMY_HIR_ID, ty, DUMMY_SP).unwrap_or(vec![]);
 
         // N.B., all of these predicates *ought* to be easily proven
         // true. In fact, their correctness is (mostly) implied by

--- a/src/librustc_traits/lowering/mod.rs
+++ b/src/librustc_traits/lowering/mod.rs
@@ -611,8 +611,8 @@ struct ClauseDumper<'a, 'tcx: 'a> {
 }
 
 impl<'a, 'tcx> ClauseDumper<'a, 'tcx> {
-    fn process_attrs(&mut self, node_id: ast::NodeId, attrs: &[ast::Attribute]) {
-        let def_id = self.tcx.hir().local_def_id(node_id);
+    fn process_attrs(&mut self, hir_id: hir::HirId, attrs: &[ast::Attribute]) {
+        let def_id = self.tcx.hir().local_def_id_from_hir_id(hir_id);
         for attr in attrs {
             let mut clauses = None;
 
@@ -654,22 +654,22 @@ impl<'a, 'tcx> Visitor<'tcx> for ClauseDumper<'a, 'tcx> {
     }
 
     fn visit_item(&mut self, item: &'tcx hir::Item) {
-        self.process_attrs(item.id, &item.attrs);
+        self.process_attrs(item.hir_id, &item.attrs);
         intravisit::walk_item(self, item);
     }
 
     fn visit_trait_item(&mut self, trait_item: &'tcx hir::TraitItem) {
-        self.process_attrs(trait_item.id, &trait_item.attrs);
+        self.process_attrs(trait_item.hir_id, &trait_item.attrs);
         intravisit::walk_trait_item(self, trait_item);
     }
 
     fn visit_impl_item(&mut self, impl_item: &'tcx hir::ImplItem) {
-        self.process_attrs(impl_item.id, &impl_item.attrs);
+        self.process_attrs(impl_item.hir_id, &impl_item.attrs);
         intravisit::walk_impl_item(self, impl_item);
     }
 
     fn visit_struct_field(&mut self, s: &'tcx hir::StructField) {
-        self.process_attrs(s.id, &s.attrs);
+        self.process_attrs(s.hir_id, &s.attrs);
         intravisit::walk_struct_field(self, s);
     }
 }

--- a/src/librustc_traits/normalize_projection_ty.rs
+++ b/src/librustc_traits/normalize_projection_ty.rs
@@ -1,3 +1,4 @@
+use rustc::hir;
 use rustc::infer::canonical::{Canonical, QueryResponse};
 use rustc::traits::query::{normalize::NormalizationResult, CanonicalProjectionGoal, NoSolution};
 use rustc::traits::{self, ObligationCause, SelectionContext, TraitEngineExt};
@@ -5,7 +6,6 @@ use rustc::ty::query::Providers;
 use rustc::ty::{ParamEnvAnd, TyCtxt};
 use rustc_data_structures::sync::Lrc;
 use std::sync::atomic::Ordering;
-use syntax::ast::DUMMY_NODE_ID;
 use syntax_pos::DUMMY_SP;
 
 crate fn provide(p: &mut Providers) {
@@ -34,7 +34,7 @@ fn normalize_projection_ty<'tcx>(
              value: goal,
          }| {
             let selcx = &mut SelectionContext::new(infcx);
-            let cause = ObligationCause::misc(DUMMY_SP, DUMMY_NODE_ID);
+            let cause = ObligationCause::misc(DUMMY_SP, hir::DUMMY_HIR_ID);
             let mut obligations = vec![];
             let answer = traits::normalize_projection_type(
                 selcx,

--- a/src/librustc_traits/type_op.rs
+++ b/src/librustc_traits/type_op.rs
@@ -1,6 +1,7 @@
 use rustc::infer::at::ToTrace;
 use rustc::infer::canonical::{Canonical, QueryResponse};
 use rustc::infer::InferCtxt;
+use rustc::hir;
 use rustc::hir::def_id::DefId;
 use rustc::mir::ProjectionKind;
 use rustc::mir::tcx::PlaceTy;
@@ -20,7 +21,6 @@ use rustc::ty::{
 };
 use rustc_data_structures::sync::Lrc;
 use std::fmt;
-use syntax::ast;
 use syntax_pos::DUMMY_SP;
 
 crate fn provide(p: &mut Providers) {
@@ -74,7 +74,7 @@ impl AscribeUserTypeCx<'me, 'gcx, 'tcx> {
         self.infcx
             .partially_normalize_associated_types_in(
                 DUMMY_SP,
-                ast::CRATE_NODE_ID,
+                hir::CRATE_HIR_ID,
                 self.param_env,
                 &value,
             )

--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -63,7 +63,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 }
             }
             PatKind::Path(ref qpath) => {
-                let (def, _, _) = self.resolve_ty_and_def_ufcs(qpath, pat.id, pat.span);
+                let (def, _, _) = self.resolve_ty_and_def_ufcs(qpath, pat.hir_id, pat.span);
                 match def {
                     Def::Const(..) | Def::AssociatedConst(..) => false,
                     _ => true,
@@ -238,7 +238,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                     .pat_binding_modes_mut()
                     .insert(pat.hir_id, bm);
                 debug!("check_pat_walk: pat.hir_id={:?} bm={:?}", pat.hir_id, bm);
-                let local_ty = self.local_ty(pat.span, pat.id).decl_ty;
+                let local_ty = self.local_ty(pat.span, pat.hir_id).decl_ty;
                 match bm {
                     ty::BindByReference(mutbl) => {
                         // if the binding is like
@@ -264,7 +264,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
 
                 // if there are multiple arms, make sure they all agree on
                 // what the type of the binding `x` ought to be
-                if var_id != pat.id {
+                if var_id != pat.hir_id {
                     let vt = self.local_ty(pat.span, var_id).decl_ty;
                     self.demand_eqtype_pat(pat.span, vt, local_ty, match_discrim_span);
                 }
@@ -629,7 +629,7 @@ https://doc.rust-lang.org/reference/types.html#trait-objects");
 
         if self.diverges.get().always() {
             for arm in arms {
-                self.warn_if_unreachable(arm.body.id, arm.body.span, "arm");
+                self.warn_if_unreachable(arm.body.hir_id, arm.body.span, "arm");
             }
         }
 
@@ -739,7 +739,8 @@ https://doc.rust-lang.org/reference/types.html#trait-objects");
     ) -> Ty<'tcx>
     {
         // Resolve the path and check the definition for errors.
-        let (variant, pat_ty) = if let Some(variant_ty) = self.check_struct_path(qpath, pat.id) {
+        let (variant, pat_ty) = if let Some(variant_ty) = self.check_struct_path(qpath, pat.hir_id)
+        {
             variant_ty
         } else {
             for field in fields {
@@ -757,7 +758,8 @@ https://doc.rust-lang.org/reference/types.html#trait-objects");
         self.demand_eqtype_pat(pat.span, expected, pat_ty, match_discrim_span);
 
         // Type-check subpatterns.
-        if self.check_struct_pat_fields(pat_ty, pat.id, pat.span, variant, fields, etc, def_bm) {
+        if self.check_struct_pat_fields(pat_ty, pat.hir_id, pat.span, variant, fields, etc, def_bm)
+        {
             pat_ty
         } else {
             self.tcx.types.err
@@ -773,7 +775,7 @@ https://doc.rust-lang.org/reference/types.html#trait-objects");
         let tcx = self.tcx;
 
         // Resolve the path and check the definition for errors.
-        let (def, opt_ty, segments) = self.resolve_ty_and_def_ufcs(qpath, pat.id, pat.span);
+        let (def, opt_ty, segments) = self.resolve_ty_and_def_ufcs(qpath, pat.hir_id, pat.span);
         match def {
             Def::Err => {
                 self.set_tainted_by_errors();
@@ -795,7 +797,7 @@ https://doc.rust-lang.org/reference/types.html#trait-objects");
         }
 
         // Type-check the path.
-        let pat_ty = self.instantiate_value_path(segments, opt_ty, def, pat.span, pat.id).0;
+        let pat_ty = self.instantiate_value_path(segments, opt_ty, def, pat.span, pat.hir_id).0;
         self.demand_suptype(pat.span, expected, pat_ty);
         pat_ty
     }
@@ -826,7 +828,7 @@ https://doc.rust-lang.org/reference/types.html#trait-objects");
         };
 
         // Resolve the path and check the definition for errors.
-        let (def, opt_ty, segments) = self.resolve_ty_and_def_ufcs(qpath, pat.id, pat.span);
+        let (def, opt_ty, segments) = self.resolve_ty_and_def_ufcs(qpath, pat.hir_id, pat.span);
         if def == Def::Err {
             self.set_tainted_by_errors();
             on_error();
@@ -834,7 +836,8 @@ https://doc.rust-lang.org/reference/types.html#trait-objects");
         }
 
         // Type-check the path.
-        let (pat_ty, def) = self.instantiate_value_path(segments, opt_ty, def, pat.span, pat.id);
+        let (pat_ty, def) = self.instantiate_value_path(
+            segments, opt_ty, def, pat.span, pat.hir_id);
         if !pat_ty.is_fn() {
             report_unexpected_def(def);
             return self.tcx.types.err;
@@ -874,7 +877,7 @@ https://doc.rust-lang.org/reference/types.html#trait-objects");
                 let field_ty = self.field_ty(subpat.span, &variant.fields[i], substs);
                 self.check_pat_walk(&subpat, field_ty, def_bm, match_arm_pat_span);
 
-                self.tcx.check_stability(variant.fields[i].did, Some(pat.id), subpat.span);
+                self.tcx.check_stability(variant.fields[i].did, Some(pat.hir_id), subpat.span);
             }
         } else {
             let subpats_ending = if subpats.len() == 1 { "" } else { "s" };
@@ -894,7 +897,7 @@ https://doc.rust-lang.org/reference/types.html#trait-objects");
 
     fn check_struct_pat_fields(&self,
                                adt_ty: Ty<'tcx>,
-                               pat_id: ast::NodeId,
+                               pat_id: hir::HirId,
                                span: Span,
                                variant: &'tcx ty::VariantDef,
                                fields: &'gcx [Spanned<hir::FieldPat>],
@@ -940,7 +943,7 @@ https://doc.rust-lang.org/reference/types.html#trait-objects");
                     vacant.insert(span);
                     field_map.get(&ident)
                         .map(|(i, f)| {
-                            self.write_field_index(field.id, *i);
+                            self.write_field_index(field.hir_id, *i);
                             self.tcx.check_stability(f.did, Some(pat_id), span);
                             self.field_ty(span, f, substs)
                         })

--- a/src/librustc_typeck/check/autoderef.rs
+++ b/src/librustc_typeck/check/autoderef.rs
@@ -1,6 +1,7 @@
 use super::{FnCtxt, PlaceOp, Needs};
 use super::method::MethodCallee;
 
+use rustc::hir;
 use rustc::infer::{InferCtxt, InferOk};
 use rustc::session::DiagnosticMessageId;
 use rustc::traits::{self, TraitEngine};
@@ -9,7 +10,7 @@ use rustc::ty::{ToPredicate, TypeFoldable};
 use rustc::ty::adjustment::{Adjustment, Adjust, OverloadedDeref};
 
 use syntax_pos::Span;
-use syntax::ast::{self, Ident};
+use syntax::ast::Ident;
 
 use std::iter;
 
@@ -21,7 +22,7 @@ enum AutoderefKind {
 
 pub struct Autoderef<'a, 'gcx: 'tcx, 'tcx: 'a> {
     infcx: &'a InferCtxt<'a, 'gcx, 'tcx>,
-    body_id: ast::NodeId,
+    body_id: hir::HirId,
     param_env: ty::ParamEnv<'tcx>,
     steps: Vec<(Ty<'tcx>, AutoderefKind)>,
     cur_ty: Ty<'tcx>,
@@ -87,7 +88,7 @@ impl<'a, 'gcx, 'tcx> Iterator for Autoderef<'a, 'gcx, 'tcx> {
 impl<'a, 'gcx, 'tcx> Autoderef<'a, 'gcx, 'tcx> {
     pub fn new(infcx: &'a InferCtxt<'a, 'gcx, 'tcx>,
                param_env: ty::ParamEnv<'tcx>,
-               body_id: ast::NodeId,
+               body_id: hir::HirId,
                span: Span,
                base_ty: Ty<'tcx>)
                -> Autoderef<'a, 'gcx, 'tcx>

--- a/src/librustc_typeck/check/callee.rs
+++ b/src/librustc_typeck/check/callee.rs
@@ -250,7 +250,8 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 if let &ty::Adt(adt_def, ..) = t {
                     if adt_def.is_enum() {
                         if let hir::ExprKind::Call(ref expr, _) = call_expr.node {
-                            unit_variant = Some(self.tcx.hir().node_to_pretty_string(expr.id))
+                            unit_variant = Some(
+                                self.tcx.hir().node_to_pretty_string_by_hir_id(expr.hir_id))
                         }
                     }
                 }
@@ -317,7 +318,8 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
 
                     let def_span = match def {
                         Def::Err => None,
-                        Def::Local(id) | Def::Upvar(id, ..) => Some(self.tcx.hir().span(id)),
+                        Def::Local(id)
+                        | Def::Upvar(id, ..) => Some(self.tcx.hir().span(id)),
                         _ => def
                             .opt_def_id()
                             .and_then(|did| self.tcx.hir().span_if_local(did)),

--- a/src/librustc_typeck/check/cast.rs
+++ b/src/librustc_typeck/check/cast.rs
@@ -401,7 +401,7 @@ impl<'a, 'gcx, 'tcx> CastCheck<'tcx> {
         };
         let mut err = fcx.tcx.struct_span_lint_node(
             lint,
-            self.expr.id,
+            self.expr.hir_id,
             self.span,
             &format!("trivial {}cast: `{}` as `{}`",
                      adjective,
@@ -416,8 +416,8 @@ impl<'a, 'gcx, 'tcx> CastCheck<'tcx> {
         self.expr_ty = fcx.structurally_resolved_type(self.span, self.expr_ty);
         self.cast_ty = fcx.structurally_resolved_type(self.span, self.cast_ty);
 
-        debug!("check_cast({}, {:?} as {:?})",
-               self.expr.id,
+        debug!("check_cast({:?}, {:?} as {:?})",
+               self.expr.hir_id,
                self.expr_ty,
                self.cast_ty);
 

--- a/src/librustc_typeck/check/closure.rs
+++ b/src/librustc_typeck/check/closure.rs
@@ -72,7 +72,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
             opt_kind, expected_sig
         );
 
-        let expr_def_id = self.tcx.hir().local_def_id(expr.id);
+        let expr_def_id = self.tcx.hir().local_def_id_from_hir_id(expr.hir_id);
 
         let ClosureSignatures {
             bound_sig,
@@ -86,7 +86,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
             self.param_env,
             liberated_sig,
             decl,
-            expr.id,
+            expr.hir_id,
             body,
             gen,
         ).1;
@@ -132,7 +132,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
 
         debug!(
             "check_closure: expr.id={:?} closure_type={:?}",
-            expr.id, closure_type
+            expr.hir_id, closure_type
         );
 
         // Tuple up the arguments and insert the resulting function type into
@@ -641,7 +641,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
             .liberate_late_bound_regions(expr_def_id, &bound_sig);
         let liberated_sig = self.inh.normalize_associated_types_in(
             body.value.span,
-            body.value.id,
+            body.value.hir_id,
             self.param_env,
             &liberated_sig,
         );

--- a/src/librustc_typeck/check/coercion.rs
+++ b/src/librustc_typeck/check/coercion.rs
@@ -712,9 +712,9 @@ impl<'f, 'gcx, 'tcx> Coerce<'f, 'gcx, 'tcx> {
 
         let b = self.shallow_resolve(b);
 
-        let node_id_a = self.tcx.hir().as_local_node_id(def_id_a).unwrap();
+        let hir_id_a = self.tcx.hir().as_local_hir_id(def_id_a).unwrap();
         match b.sty {
-            ty::FnPtr(_) if self.tcx.with_freevars(node_id_a, |v| v.is_empty()) => {
+            ty::FnPtr(_) if self.tcx.with_freevars(hir_id_a, |v| v.is_empty()) => {
                 // We coerce the closure, which has fn type
                 //     `extern "rust-call" fn((arg0,arg1,...)) -> _`
                 // to
@@ -1177,7 +1177,8 @@ impl<'gcx, 'tcx, 'exprs, E> CoerceMany<'gcx, 'tcx, 'exprs, E>
                         Expressions::UpFront(coercion_sites) => {
                             // if the user gave us an array to validate, check that we got
                             // the next expression in the list, as expected
-                            assert_eq!(coercion_sites[self.pushed].as_coercion_site().id, e.id);
+                            assert_eq!(coercion_sites[self.pushed].as_coercion_site().hir_id,
+                                       e.hir_id);
                         }
                     }
                     self.pushed += 1;

--- a/src/librustc_typeck/check/demand.rs
+++ b/src/librustc_typeck/check/demand.rs
@@ -2,7 +2,6 @@ use check::FnCtxt;
 use rustc::infer::InferOk;
 use rustc::traits::{ObligationCause, ObligationCauseCode};
 
-use syntax::ast;
 use syntax::util::parser::PREC_POSTFIX;
 use syntax_pos::Span;
 use rustc::hir;
@@ -164,7 +163,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                                      probe::Mode::MethodCall,
                                                      expected,
                                                      checked_ty,
-                                                     ast::DUMMY_NODE_ID);
+                                                     hir::DUMMY_HIR_ID);
         methods.retain(|m| {
             self.has_no_input_arg(m) &&
                 self.tcx.get_attrs(m.def_id).iter()
@@ -215,16 +214,15 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
             if let hir::def::Def::Local(id) = path.def {
                 let parent = self.tcx.hir().get_parent_node(id);
                 if let Some(Node::Expr(hir::Expr {
-                    id,
                     node: hir::ExprKind::Closure(_, decl, ..),
                     ..
-                })) = self.tcx.hir().find(parent) {
-                    let parent = self.tcx.hir().get_parent_node(*id);
+                })) = self.tcx.hir().find_by_hir_id(parent) {
+                    let parent = self.tcx.hir().get_parent_node(id);
                     if let (Some(Node::Expr(hir::Expr {
                         node: hir::ExprKind::MethodCall(path, span, expr),
                         ..
-                    })), 1) = (self.tcx.hir().find(parent), decl.inputs.len()) {
-                        let self_ty = self.tables.borrow().node_id_to_type(expr[0].hir_id);
+                    })), 1) = (self.tcx.hir().find_by_hir_id(parent), decl.inputs.len()) {
+                        let self_ty = self.tables.borrow().hir_id_to_type(expr[0].hir_id);
                         let self_ty = format!("{:?}", self_ty);
                         let name = path.ident.as_str();
                         let is_as_ref_able = (
@@ -460,8 +458,8 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                       checked_ty: Ty<'tcx>,
                       expected_ty: Ty<'tcx>)
                       -> bool {
-        let parent_id = self.tcx.hir().get_parent_node(expr.id);
-        if let Some(parent) = self.tcx.hir().find(parent_id) {
+        let parent_id = self.tcx.hir().get_parent_node(expr.hir_id);
+        if let Some(parent) = self.tcx.hir().find_by_hir_id(parent_id) {
             // Shouldn't suggest `.into()` on `const`s.
             if let Node::Item(Item { node: ItemKind::Const(_, _), .. }) = parent {
                 // FIXME(estebank): modify once we decide to suggest `as` casts

--- a/src/librustc_typeck/check/dropck.rs
+++ b/src/librustc_typeck/check/dropck.rs
@@ -1,5 +1,6 @@
 use check::regionck::RegionCtxt;
 
+use hir;
 use hir::def_id::DefId;
 use rustc::infer::outlives::env::OutlivesEnvironment;
 use rustc::infer::{self, InferOk, SuppressRegionErrors};
@@ -9,7 +10,6 @@ use rustc::ty::subst::{Subst, Substs, UnpackedKind};
 use rustc::ty::{self, Ty, TyCtxt};
 use util::common::ErrorReported;
 
-use syntax::ast;
 use syntax_pos::Span;
 
 /// check_drop_impl confirms that the Drop implementation identified by
@@ -70,7 +70,7 @@ fn ensure_drop_params_and_item_params_correspond<'a, 'tcx>(
     drop_impl_ty: Ty<'tcx>,
     self_type_did: DefId,
 ) -> Result<(), ErrorReported> {
-    let drop_impl_node_id = tcx.hir().as_local_node_id(drop_impl_did).unwrap();
+    let drop_impl_hir_id = tcx.hir().as_local_hir_id(drop_impl_did).unwrap();
 
     // check that the impl type can be made to match the trait type.
 
@@ -85,7 +85,7 @@ fn ensure_drop_params_and_item_params_correspond<'a, 'tcx>(
         let fresh_impl_substs = infcx.fresh_substs_for_item(drop_impl_span, drop_impl_did);
         let fresh_impl_self_ty = drop_impl_ty.subst(tcx, fresh_impl_substs);
 
-        let cause = &ObligationCause::misc(drop_impl_span, drop_impl_node_id);
+        let cause = &ObligationCause::misc(drop_impl_span, drop_impl_hir_id);
         match infcx
             .at(cause, impl_param_env)
             .eq(named_type, fresh_impl_self_ty)
@@ -184,7 +184,7 @@ fn ensure_drop_predicates_are_implied_by_item_defn<'a, 'tcx>(
     // absent. So we report an error that the Drop impl injected a
     // predicate that is not present on the struct definition.
 
-    let self_type_node_id = tcx.hir().as_local_node_id(self_type_did).unwrap();
+    let self_type_hir_id = tcx.hir().as_local_hir_id(self_type_did).unwrap();
 
     let drop_impl_span = tcx.def_span(drop_impl_did);
 
@@ -216,7 +216,7 @@ fn ensure_drop_predicates_are_implied_by_item_defn<'a, 'tcx>(
         // repeated `contains` calls.
 
         if !assumptions_in_impl_context.contains(&predicate) {
-            let item_span = tcx.hir().span(self_type_node_id);
+            let item_span = tcx.hir().span(self_type_hir_id);
             struct_span_err!(
                 tcx.sess,
                 drop_impl_span,
@@ -292,7 +292,7 @@ pub fn check_safety_of_destructor_if_necessary<'a, 'gcx, 'tcx>(
     rcx: &mut RegionCtxt<'a, 'gcx, 'tcx>,
     ty: Ty<'tcx>,
     span: Span,
-    body_id: ast::NodeId,
+    body_id: hir::HirId,
     scope: region::Scope,
 ) -> Result<(), ErrorReported> {
     debug!("check_safety_of_destructor_if_necessary typ: {:?} scope: {:?}",

--- a/src/librustc_typeck/check/intrinsic.rs
+++ b/src/librustc_typeck/check/intrinsic.rs
@@ -22,7 +22,7 @@ fn equate_intrinsic_type<'a, 'tcx>(
     inputs: Vec<Ty<'tcx>>,
     output: Ty<'tcx>,
 ) {
-    let def_id = tcx.hir().local_def_id(it.id);
+    let def_id = tcx.hir().local_def_id_from_hir_id(it.hir_id);
 
     match it.node {
         hir::ForeignItemKind::Fn(..) => {}
@@ -58,7 +58,7 @@ fn equate_intrinsic_type<'a, 'tcx>(
         safety,
         abi
     )));
-    let cause = ObligationCause::new(it.span, it.id, ObligationCauseCode::IntrinsicType);
+    let cause = ObligationCause::new(it.span, it.hir_id, ObligationCauseCode::IntrinsicType);
     require_same_types(tcx, &cause, tcx.mk_fn_ptr(tcx.fn_sig(def_id)), fty);
 }
 

--- a/src/librustc_typeck/check/method/mod.rs
+++ b/src/librustc_typeck/check/method/mod.rs
@@ -105,7 +105,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
     pub fn method_exists(&self,
                          method_name: ast::Ident,
                          self_ty: Ty<'tcx>,
-                         call_expr_id: ast::NodeId,
+                         call_expr_id: hir::HirId,
                          allow_private: bool)
                          -> bool {
         let mode = probe::Mode::MethodCall;
@@ -131,7 +131,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         msg: &str,
         method_name: ast::Ident,
         self_ty: Ty<'tcx>,
-        call_expr_id: ast::NodeId,
+        call_expr_id: hir::HirId,
     ) {
         let has_params = self
             .probe_for_name(
@@ -202,7 +202,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 .unwrap().insert(import_def_id);
         }
 
-        self.tcx.check_stability(pick.item.def_id, Some(call_expr.id), span);
+        self.tcx.check_stability(pick.item.def_id, Some(call_expr.hir_id), span);
 
         let result = self.confirm_method(
             span,
@@ -255,7 +255,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         let mode = probe::Mode::MethodCall;
         let self_ty = self.resolve_type_vars_if_possible(&self_ty);
         self.probe_for_name(span, mode, method_name, IsSuggestion(false),
-                            self_ty, call_expr.id, scope)
+                            self_ty, call_expr.hir_id, scope)
     }
 
     /// `lookup_method_in_trait` is used for overloaded operators.
@@ -399,7 +399,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         span: Span,
         method_name: ast::Ident,
         self_ty: Ty<'tcx>,
-        expr_id: ast::NodeId
+        expr_id: hir::HirId
     ) -> Result<Def, MethodError<'tcx>> {
         debug!(
             "resolve_ufcs: method_name={:?} self_ty={:?} expr_id={:?}",

--- a/src/librustc_typeck/check/op.rs
+++ b/src/librustc_typeck/check/op.rs
@@ -51,8 +51,8 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
     {
         let tcx = self.tcx;
 
-        debug!("check_binop(expr.id={}, expr={:?}, op={:?}, lhs_expr={:?}, rhs_expr={:?})",
-               expr.id,
+        debug!("check_binop(expr.hir_id={:?}, expr={:?}, op={:?}, lhs_expr={:?}, rhs_expr={:?})",
+               expr.hir_id,
                expr,
                op,
                lhs_expr,
@@ -150,8 +150,8 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                               is_assign: IsAssign)
                               -> (Ty<'tcx>, Ty<'tcx>, Ty<'tcx>)
     {
-        debug!("check_overloaded_binop(expr.id={}, op={:?}, is_assign={:?})",
-               expr.id,
+        debug!("check_overloaded_binop(expr.hir_id={:?}, op={:?}, is_assign={:?})",
+               expr.hir_id,
                op,
                is_assign);
 

--- a/src/librustc_typeck/coherence/builtin.rs
+++ b/src/librustc_typeck/coherence/builtin.rs
@@ -76,7 +76,7 @@ fn visit_implementation_of_drop<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, impl_did:
 fn visit_implementation_of_copy<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, impl_did: DefId) {
     debug!("visit_implementation_of_copy: impl_did={:?}", impl_did);
 
-    let impl_node_id = if let Some(n) = tcx.hir().as_local_node_id(impl_did) {
+    let impl_hir_id = if let Some(n) = tcx.hir().as_local_hir_id(impl_did) {
         n
     } else {
         debug!("visit_implementation_of_copy(): impl not in this crate");
@@ -87,7 +87,7 @@ fn visit_implementation_of_copy<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, impl_did:
     debug!("visit_implementation_of_copy: self_type={:?} (bound)",
            self_type);
 
-    let span = tcx.hir().span(impl_node_id);
+    let span = tcx.hir().span(impl_hir_id);
     let param_env = tcx.param_env(impl_did);
     assert!(!self_type.has_escaping_bound_vars());
 
@@ -97,7 +97,7 @@ fn visit_implementation_of_copy<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, impl_did:
     match param_env.can_type_implement_copy(tcx, self_type) {
         Ok(()) => {}
         Err(CopyImplementationError::InfrigingFields(fields)) => {
-            let item = tcx.hir().expect_item(impl_node_id);
+            let item = tcx.hir().expect_item_by_hir_id(impl_hir_id);
             let span = if let ItemKind::Impl(.., Some(ref tr), _, _) = item.node {
                 tr.path.span
             } else {
@@ -114,7 +114,7 @@ fn visit_implementation_of_copy<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, impl_did:
             err.emit()
         }
         Err(CopyImplementationError::NotAnAdt) => {
-            let item = tcx.hir().expect_item(impl_node_id);
+            let item = tcx.hir().expect_item_by_hir_id(impl_hir_id);
             let span = if let ItemKind::Impl(.., ref ty, _) = item.node {
                 ty.span
             } else {
@@ -162,8 +162,8 @@ fn visit_implementation_of_dispatch_from_dyn<'a, 'tcx>(
     if impl_did.is_local() {
         let dispatch_from_dyn_trait = tcx.lang_items().dispatch_from_dyn_trait().unwrap();
 
-        let impl_node_id = tcx.hir().as_local_node_id(impl_did).unwrap();
-        let span = tcx.hir().span(impl_node_id);
+        let impl_hir_id = tcx.hir().as_local_hir_id(impl_did).unwrap();
+        let span = tcx.hir().span(impl_hir_id);
 
         let source = tcx.type_of(impl_did);
         assert!(!source.has_escaping_bound_vars());
@@ -185,7 +185,7 @@ fn visit_implementation_of_dispatch_from_dyn<'a, 'tcx>(
         };
 
         tcx.infer_ctxt().enter(|infcx| {
-            let cause = ObligationCause::misc(span, impl_node_id);
+            let cause = ObligationCause::misc(span, impl_hir_id);
 
             use ty::TyKind::*;
             match (&source.sty, &target.sty) {
@@ -332,7 +332,7 @@ pub fn coerce_unsized_info<'a, 'gcx>(gcx: TyCtxt<'a, 'gcx, 'gcx>,
     });
 
     // this provider should only get invoked for local def-ids
-    let impl_node_id = gcx.hir().as_local_node_id(impl_did).unwrap_or_else(|| {
+    let impl_hir_id = gcx.hir().as_local_hir_id(impl_did).unwrap_or_else(|| {
         bug!("coerce_unsized_info: invoked for non-local def-id {:?}", impl_did)
     });
 
@@ -344,7 +344,7 @@ pub fn coerce_unsized_info<'a, 'gcx>(gcx: TyCtxt<'a, 'gcx, 'gcx>,
            source,
            target);
 
-    let span = gcx.hir().span(impl_node_id);
+    let span = gcx.hir().span(impl_hir_id);
     let param_env = gcx.param_env(impl_did);
     assert!(!source.has_escaping_bound_vars());
 
@@ -355,7 +355,7 @@ pub fn coerce_unsized_info<'a, 'gcx>(gcx: TyCtxt<'a, 'gcx, 'gcx>,
            target);
 
     gcx.infer_ctxt().enter(|infcx| {
-        let cause = ObligationCause::misc(span, impl_node_id);
+        let cause = ObligationCause::misc(span, impl_hir_id);
         let check_mutbl = |mt_a: ty::TypeAndMut<'gcx>,
                            mt_b: ty::TypeAndMut<'gcx>,
                            mk_ptr: &dyn Fn(Ty<'gcx>) -> Ty<'gcx>| {
@@ -481,11 +481,11 @@ pub fn coerce_unsized_info<'a, 'gcx>(gcx: TyCtxt<'a, 'gcx, 'gcx>,
                                being coerced, none found");
                     return err_info;
                 } else if diff_fields.len() > 1 {
-                    let item = gcx.hir().expect_item(impl_node_id);
+                    let item = gcx.hir().expect_item_by_hir_id(impl_hir_id);
                     let span = if let ItemKind::Impl(.., Some(ref t), _, _) = item.node {
                         t.path.span
                     } else {
-                        gcx.hir().span(impl_node_id)
+                        gcx.hir().span(impl_hir_id)
                     };
 
                     let mut err = struct_span_err!(gcx.sess,
@@ -527,7 +527,7 @@ pub fn coerce_unsized_info<'a, 'gcx>(gcx: TyCtxt<'a, 'gcx, 'gcx>,
         let mut fulfill_cx = TraitEngine::new(infcx.tcx);
 
         // Register an obligation for `A: Trait<B>`.
-        let cause = traits::ObligationCause::misc(span, impl_node_id);
+        let cause = traits::ObligationCause::misc(span, impl_hir_id);
         let predicate = gcx.predicate_for_trait_def(param_env,
                                                     cause,
                                                     trait_def_id,

--- a/src/librustc_typeck/coherence/inherent_impls.rs
+++ b/src/librustc_typeck/coherence/inherent_impls.rs
@@ -85,7 +85,7 @@ impl<'a, 'tcx, 'v> ItemLikeVisitor<'v> for InherentCollect<'a, 'tcx> {
             _ => return
         };
 
-        let def_id = self.tcx.hir().local_def_id(item.id);
+        let def_id = self.tcx.hir().local_def_id_from_hir_id(item.hir_id);
         let self_ty = self.tcx.type_of(def_id);
         let lang_items = self.tcx.lang_items();
         match self_ty.sty {
@@ -288,7 +288,7 @@ impl<'a, 'tcx> InherentCollect<'a, 'tcx> {
             // Add the implementation to the mapping from implementation to base
             // type def ID, if there is a base type for this implementation and
             // the implementation does not have any associated traits.
-            let impl_def_id = self.tcx.hir().local_def_id(item.id);
+            let impl_def_id = self.tcx.hir().local_def_id_from_hir_id(item.hir_id);
             let mut rc_vec = self.impls_map.inherent_impls
                                            .entry(def_id)
                                            .or_default();

--- a/src/librustc_typeck/coherence/inherent_impls_overlap.rs
+++ b/src/librustc_typeck/coherence/inherent_impls_overlap.rs
@@ -36,11 +36,11 @@ impl<'a, 'tcx> InherentOverlapChecker<'a, 'tcx> {
 
             for &item2 in &impl_items2[..] {
                 if (name, namespace) == name_and_namespace(item2) {
-                    let node_id = self.tcx.hir().as_local_node_id(impl1);
-                    let mut err = if used_to_be_allowed && node_id.is_some() {
+                    let hir_id = self.tcx.hir().as_local_hir_id(impl1);
+                    let mut err = if used_to_be_allowed && hir_id.is_some() {
                         self.tcx.struct_span_lint_node(
                             lint::builtin::INCOHERENT_FUNDAMENTAL_IMPLS,
-                            node_id.unwrap(),
+                            hir_id.unwrap(),
                             self.tcx.span_of_impl(item1).unwrap(),
                             &format!("duplicate definitions with name `{}` (E0592)", name)
                         )
@@ -120,7 +120,7 @@ impl<'a, 'tcx, 'v> ItemLikeVisitor<'v> for InherentOverlapChecker<'a, 'tcx> {
             hir::ItemKind::Struct(..) |
             hir::ItemKind::Trait(..) |
             hir::ItemKind::Union(..) => {
-                let type_def_id = self.tcx.hir().local_def_id(item.id);
+                let type_def_id = self.tcx.hir().local_def_id_from_hir_id(item.hir_id);
                 self.check_for_overlapping_inherent_impls(type_def_id);
             }
             _ => {}

--- a/src/librustc_typeck/coherence/orphan.rs
+++ b/src/librustc_typeck/coherence/orphan.rs
@@ -22,11 +22,11 @@ impl<'cx, 'tcx, 'v> ItemLikeVisitor<'v> for OrphanChecker<'cx, 'tcx> {
     /// to prevent inundating the user with a bunch of similar error
     /// reports.
     fn visit_item(&mut self, item: &hir::Item) {
-        let def_id = self.tcx.hir().local_def_id(item.id);
+        let def_id = self.tcx.hir().local_def_id_from_hir_id(item.hir_id);
         // "Trait" impl
         if let hir::ItemKind::Impl(.., Some(_), _, _) = item.node {
             debug!("coherence2::orphan check: trait impl {}",
-                   self.tcx.hir().node_to_string(item.id));
+                   self.tcx.hir().hir_to_string(item.hir_id));
             let trait_ref = self.tcx.impl_trait_ref(def_id).unwrap();
             let trait_def_id = trait_ref.def_id;
             let cm = self.tcx.sess.source_map();

--- a/src/librustc_typeck/coherence/unsafety.rs
+++ b/src/librustc_typeck/coherence/unsafety.rs
@@ -21,7 +21,7 @@ impl<'cx, 'tcx, 'v> UnsafetyChecker<'cx, 'tcx> {
                                 unsafety: hir::Unsafety,
                                 polarity: hir::ImplPolarity)
     {
-        if let Some(trait_ref) = self.tcx.impl_trait_ref(self.tcx.hir().local_def_id(item.id)) {
+        if let Some(trait_ref) = self.tcx.impl_trait_ref(self.tcx.hir().local_def_id_from_hir_id(item.hir_id)) {
             let trait_def = self.tcx.trait_def(trait_ref.def_id);
             let unsafe_attr = impl_generics.and_then(|generics| {
                 generics.params.iter().find(|p| p.pure_wrt_drop).map(|_| "may_dangle")

--- a/src/librustc_typeck/impl_wf_check.rs
+++ b/src/librustc_typeck/impl_wf_check.rs
@@ -62,7 +62,7 @@ struct ImplWfCheck<'a, 'tcx: 'a> {
 impl<'a, 'tcx> ItemLikeVisitor<'tcx> for ImplWfCheck<'a, 'tcx> {
     fn visit_item(&mut self, item: &'tcx hir::Item) {
         if let hir::ItemKind::Impl(.., ref impl_item_refs) = item.node {
-            let impl_def_id = self.tcx.hir().local_def_id(item.id);
+            let impl_def_id = self.tcx.hir().local_def_id_from_hir_id(item.hir_id);
             enforce_impl_params_are_constrained(self.tcx,
                                                 impl_def_id,
                                                 impl_item_refs);

--- a/src/librustc_typeck/outlives/implicit_infer.rs
+++ b/src/librustc_typeck/outlives/implicit_infer.rs
@@ -53,16 +53,11 @@ pub struct InferVisitor<'cx, 'tcx: 'cx> {
 
 impl<'cx, 'tcx> ItemLikeVisitor<'tcx> for InferVisitor<'cx, 'tcx> {
     fn visit_item(&mut self, item: &hir::Item) {
-        let item_did = self.tcx.hir().local_def_id(item.id);
+        let item_did = self.tcx.hir().local_def_id_from_hir_id(item.hir_id);
 
         debug!("InferVisitor::visit_item(item={:?})", item_did);
 
-        let node_id = self
-            .tcx
-            .hir()
-            .as_local_node_id(item_did)
-            .expect("expected local def-id");
-        let item = match self.tcx.hir().get(node_id) {
+        let item = match self.tcx.hir().get_by_hir_id(item.hir_id) {
             Node::Item(item) => item,
             _ => bug!(),
         };

--- a/src/librustc_typeck/outlives/test.rs
+++ b/src/librustc_typeck/outlives/test.rs
@@ -14,7 +14,7 @@ struct OutlivesTest<'a, 'tcx: 'a> {
 
 impl<'a, 'tcx> ItemLikeVisitor<'tcx> for OutlivesTest<'a, 'tcx> {
     fn visit_item(&mut self, item: &'tcx hir::Item) {
-        let item_def_id = self.tcx.hir().local_def_id(item.id);
+        let item_def_id = self.tcx.hir().local_def_id_from_hir_id(item.hir_id);
 
         // For unit testing: check for a special "rustc_outlives"
         // attribute and report an error with various results if found.

--- a/src/librustc_typeck/variance/constraints.rs
+++ b/src/librustc_typeck/variance/constraints.rs
@@ -6,7 +6,6 @@
 use hir::def_id::DefId;
 use rustc::ty::subst::{Substs, UnpackedKind};
 use rustc::ty::{self, Ty, TyCtxt};
-use syntax::ast;
 use rustc::hir;
 use rustc::hir::itemlikevisit::ItemLikeVisitor;
 
@@ -72,31 +71,31 @@ impl<'a, 'tcx, 'v> ItemLikeVisitor<'v> for ConstraintContext<'a, 'tcx> {
         match item.node {
             hir::ItemKind::Struct(ref struct_def, _) |
             hir::ItemKind::Union(ref struct_def, _) => {
-                self.visit_node_helper(item.id);
+                self.visit_node_helper(item.hir_id);
 
                 if let hir::VariantData::Tuple(..) = *struct_def {
-                    self.visit_node_helper(struct_def.id());
+                    self.visit_node_helper(struct_def.hir_id());
                 }
             }
 
             hir::ItemKind::Enum(ref enum_def, _) => {
-                self.visit_node_helper(item.id);
+                self.visit_node_helper(item.hir_id);
 
                 for variant in &enum_def.variants {
                     if let hir::VariantData::Tuple(..) = variant.node.data {
-                        self.visit_node_helper(variant.node.data.id());
+                        self.visit_node_helper(variant.node.data.hir_id());
                     }
                 }
             }
 
             hir::ItemKind::Fn(..) => {
-                self.visit_node_helper(item.id);
+                self.visit_node_helper(item.hir_id);
             }
 
             hir::ItemKind::ForeignMod(ref foreign_mod) => {
                 for foreign_item in &foreign_mod.items {
                     if let hir::ForeignItemKind::Fn(..) = foreign_item.node {
-                        self.visit_node_helper(foreign_item.id);
+                        self.visit_node_helper(foreign_item.hir_id);
                     }
                 }
             }
@@ -107,21 +106,20 @@ impl<'a, 'tcx, 'v> ItemLikeVisitor<'v> for ConstraintContext<'a, 'tcx> {
 
     fn visit_trait_item(&mut self, trait_item: &hir::TraitItem) {
         if let hir::TraitItemKind::Method(..) = trait_item.node {
-            self.visit_node_helper(trait_item.id);
+            self.visit_node_helper(trait_item.hir_id);
         }
     }
 
     fn visit_impl_item(&mut self, impl_item: &hir::ImplItem) {
         if let hir::ImplItemKind::Method(..) = impl_item.node {
-            self.visit_node_helper(impl_item.id);
+            self.visit_node_helper(impl_item.hir_id);
         }
     }
 }
 
 impl<'a, 'tcx> ConstraintContext<'a, 'tcx> {
-    fn visit_node_helper(&mut self, id: ast::NodeId) {
-        let tcx = self.terms_cx.tcx;
-        let def_id = tcx.hir().local_def_id(id);
+    fn visit_node_helper(&mut self, id: hir::HirId) {
+        let def_id = self.tcx().hir().local_def_id_from_hir_id(id);
         self.build_constraints_for_item(def_id);
     }
 
@@ -138,7 +136,7 @@ impl<'a, 'tcx> ConstraintContext<'a, 'tcx> {
             return;
         }
 
-        let id = tcx.hir().as_local_node_id(def_id).unwrap();
+        let id = tcx.hir().as_local_hir_id(def_id).unwrap();
         let inferred_start = self.terms_cx.inferred_starts[&id];
         let current_item = &CurrentItem { inferred_start };
         match tcx.type_of(def_id).sty {
@@ -356,7 +354,7 @@ impl<'a, 'tcx> ConstraintContext<'a, 'tcx> {
             return;
         }
 
-        let (local, remote) = if let Some(id) = self.tcx().hir().as_local_node_id(def_id) {
+        let (local, remote) = if let Some(id) = self.tcx().hir().as_local_hir_id(def_id) {
             (Some(self.terms_cx.inferred_starts[&id]), None)
         } else {
             (None, Some(self.tcx().variances_of(def_id)))

--- a/src/librustc_typeck/variance/mod.rs
+++ b/src/librustc_typeck/variance/mod.rs
@@ -46,12 +46,12 @@ fn crate_variances<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, crate_num: CrateNum)
 
 fn variances_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, item_def_id: DefId)
                           -> Lrc<Vec<ty::Variance>> {
-    let id = tcx.hir().as_local_node_id(item_def_id).expect("expected local def-id");
+    let id = tcx.hir().as_local_hir_id(item_def_id).expect("expected local def-id");
     let unsupported = || {
         // Variance not relevant.
         span_bug!(tcx.hir().span(id), "asked to compute variance for wrong kind of item")
     };
-    match tcx.hir().get(id) {
+    match tcx.hir().get_by_hir_id(id) {
         Node::Item(item) => match item.node {
             hir::ItemKind::Enum(..) |
             hir::ItemKind::Struct(..) |

--- a/src/librustc_typeck/variance/solve.rs
+++ b/src/librustc_typeck/variance/solve.rs
@@ -83,12 +83,12 @@ impl<'a, 'tcx> SolveContext<'a, 'tcx> {
 
         let solutions = &self.solutions;
         self.terms_cx.inferred_starts.iter().map(|(&id, &InferredIndex(start))| {
-            let def_id = tcx.hir().local_def_id(id);
+            let def_id = tcx.hir().local_def_id_from_hir_id(id);
             let generics = tcx.generics_of(def_id);
 
             let mut variances = solutions[start..start+generics.count()].to_vec();
 
-            debug!("id={} variances={:?}", id, variances);
+            debug!("id={:?} variances={:?}", id, variances);
 
             // Functions can have unused type parameters: make those invariant.
             if let ty::FnDef(..) = tcx.type_of(def_id).sty {

--- a/src/librustc_typeck/variance/terms.rs
+++ b/src/librustc_typeck/variance/terms.rs
@@ -12,10 +12,9 @@
 use arena::TypedArena;
 use rustc::ty::{self, TyCtxt};
 use std::fmt;
-use syntax::ast;
 use rustc::hir;
 use rustc::hir::itemlikevisit::ItemLikeVisitor;
-use util::nodemap::NodeMap;
+use util::nodemap::HirIdMap;
 
 use self::VarianceTerm::*;
 
@@ -55,11 +54,11 @@ pub struct TermsContext<'a, 'tcx: 'a> {
     // For marker types, UnsafeCell, and other lang items where
     // variance is hardcoded, records the item-id and the hardcoded
     // variance.
-    pub lang_items: Vec<(ast::NodeId, Vec<ty::Variance>)>,
+    pub lang_items: Vec<(hir::HirId, Vec<ty::Variance>)>,
 
     // Maps from the node id of an item to the first inferred index
     // used for its type & region parameters.
-    pub inferred_starts: NodeMap<InferredIndex>,
+    pub inferred_starts: HirIdMap<InferredIndex>,
 
     // Maps from an InferredIndex to the term for that variable.
     pub inferred_terms: Vec<VarianceTermPtr<'a>>,
@@ -86,7 +85,7 @@ pub fn determine_parameters_to_be_inferred<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>
     terms_cx
 }
 
-fn lang_items(tcx: TyCtxt) -> Vec<(ast::NodeId, Vec<ty::Variance>)> {
+fn lang_items(tcx: TyCtxt) -> Vec<(hir::HirId, Vec<ty::Variance>)> {
     let lang_items = tcx.lang_items();
     let all = vec![
         (lang_items.phantom_data(), vec![ty::Covariant]),
@@ -96,14 +95,14 @@ fn lang_items(tcx: TyCtxt) -> Vec<(ast::NodeId, Vec<ty::Variance>)> {
     all.into_iter() // iterating over (Option<DefId>, Variance)
        .filter(|&(ref d,_)| d.is_some())
        .map(|(d, v)| (d.unwrap(), v)) // (DefId, Variance)
-       .filter_map(|(d, v)| tcx.hir().as_local_node_id(d).map(|n| (n, v))) // (NodeId, Variance)
+       .filter_map(|(d, v)| tcx.hir().as_local_hir_id(d).map(|n| (n, v))) // (HirId, Variance)
        .collect()
 }
 
 impl<'a, 'tcx> TermsContext<'a, 'tcx> {
-    fn add_inferreds_for_item(&mut self, id: ast::NodeId) {
+    fn add_inferreds_for_item(&mut self, id: hir::HirId) {
         let tcx = self.tcx;
-        let def_id = tcx.hir().local_def_id(id);
+        let def_id = tcx.hir().local_def_id_from_hir_id(id);
         let count = tcx.generics_of(def_id).count();
 
         if count == 0 {
@@ -129,36 +128,36 @@ impl<'a, 'tcx> TermsContext<'a, 'tcx> {
 impl<'a, 'tcx, 'v> ItemLikeVisitor<'v> for TermsContext<'a, 'tcx> {
     fn visit_item(&mut self, item: &hir::Item) {
         debug!("add_inferreds for item {}",
-               self.tcx.hir().node_to_string(item.id));
+               self.tcx.hir().hir_to_string(item.hir_id));
 
         match item.node {
             hir::ItemKind::Struct(ref struct_def, _) |
             hir::ItemKind::Union(ref struct_def, _) => {
-                self.add_inferreds_for_item(item.id);
+                self.add_inferreds_for_item(item.hir_id);
 
                 if let hir::VariantData::Tuple(..) = *struct_def {
-                    self.add_inferreds_for_item(struct_def.id());
+                    self.add_inferreds_for_item(struct_def.hir_id());
                 }
             }
 
             hir::ItemKind::Enum(ref enum_def, _) => {
-                self.add_inferreds_for_item(item.id);
+                self.add_inferreds_for_item(item.hir_id);
 
                 for variant in &enum_def.variants {
                     if let hir::VariantData::Tuple(..) = variant.node.data {
-                        self.add_inferreds_for_item(variant.node.data.id());
+                        self.add_inferreds_for_item(variant.node.data.hir_id());
                     }
                 }
             }
 
             hir::ItemKind::Fn(..) => {
-                self.add_inferreds_for_item(item.id);
+                self.add_inferreds_for_item(item.hir_id);
             }
 
             hir::ItemKind::ForeignMod(ref foreign_mod) => {
                 for foreign_item in &foreign_mod.items {
                     if let hir::ForeignItemKind::Fn(..) = foreign_item.node {
-                        self.add_inferreds_for_item(foreign_item.id);
+                        self.add_inferreds_for_item(foreign_item.hir_id);
                     }
                 }
             }
@@ -169,13 +168,13 @@ impl<'a, 'tcx, 'v> ItemLikeVisitor<'v> for TermsContext<'a, 'tcx> {
 
     fn visit_trait_item(&mut self, trait_item: &hir::TraitItem) {
         if let hir::TraitItemKind::Method(..) = trait_item.node {
-            self.add_inferreds_for_item(trait_item.id);
+            self.add_inferreds_for_item(trait_item.hir_id);
         }
     }
 
     fn visit_impl_item(&mut self, impl_item: &hir::ImplItem) {
         if let hir::ImplItemKind::Method(..) = impl_item.node {
-            self.add_inferreds_for_item(impl_item.id);
+            self.add_inferreds_for_item(impl_item.hir_id);
         }
     }
 }

--- a/src/librustc_typeck/variance/test.rs
+++ b/src/librustc_typeck/variance/test.rs
@@ -12,7 +12,7 @@ struct VarianceTest<'a, 'tcx: 'a> {
 
 impl<'a, 'tcx> ItemLikeVisitor<'tcx> for VarianceTest<'a, 'tcx> {
     fn visit_item(&mut self, item: &'tcx hir::Item) {
-        let item_def_id = self.tcx.hir().local_def_id(item.id);
+        let item_def_id = self.tcx.hir().local_def_id_from_hir_id(item.hir_id);
 
         // For unit testing: check for a special "rustc_variance"
         // attribute and report an error with various results if found.

--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -115,7 +115,6 @@ impl<'a, 'tcx, 'rcx> AutoTraitFinder<'a, 'tcx, 'rcx> {
         if result.is_auto() {
             let trait_ = hir::TraitRef {
                 path: get_path_for_type(self.cx.tcx, trait_def_id, hir::def::Def::Trait),
-                ref_id: ast::DUMMY_NODE_ID,
                 hir_ref_id: hir::DUMMY_HIR_ID,
             };
 

--- a/src/librustdoc/clean/blanket_impl.rs
+++ b/src/librustdoc/clean/blanket_impl.rs
@@ -123,7 +123,6 @@ impl<'a, 'tcx, 'rcx> BlanketImplFinder <'a, 'tcx, 'rcx> {
                             path: get_path_for_type(infcx.tcx,
                                                     trait_def_id,
                                                     hir::def::Def::Trait),
-                            ref_id: ast::DUMMY_NODE_ID,
                             hir_ref_id: hir::DUMMY_HIR_ID,
                         };
                         let provided_trait_methods =

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -162,6 +162,14 @@ impl<'a, 'tcx, 'rcx> DocContext<'a, 'tcx, 'rcx> {
         }
     }
 
+    pub fn as_local_hir_id(&self, def_id: DefId) -> Option<hir::HirId> {
+        if self.all_fake_def_ids.borrow().contains(&def_id) {
+            None
+        } else {
+            self.tcx.hir().as_local_hir_id(def_id)
+        }
+    }
+
     pub fn get_real_ty<F>(&self,
                           def_id: DefId,
                           def_ctor: &F,
@@ -177,6 +185,7 @@ impl<'a, 'tcx, 'rcx> DocContext<'a, 'tcx, 'rcx> {
             real_name.unwrap_or(last.ident),
             None,
             None,
+            None,
             self.generics_to_path_params(generics.clone()),
             false,
         ));
@@ -188,7 +197,6 @@ impl<'a, 'tcx, 'rcx> DocContext<'a, 'tcx, 'rcx> {
         };
 
         hir::Ty {
-            id: ast::DUMMY_NODE_ID,
             node: hir::TyKind::Path(hir::QPath::Resolved(None, P(new_path))),
             span: DUMMY_SP,
             hir_id: hir::DUMMY_HIR_ID,
@@ -208,7 +216,7 @@ impl<'a, 'tcx, 'rcx> DocContext<'a, 'tcx, 'rcx> {
                     };
 
                     args.push(hir::GenericArg::Lifetime(hir::Lifetime {
-                        id: ast::DUMMY_NODE_ID,
+                        hir_id: hir::DUMMY_HIR_ID,
                         span: DUMMY_SP,
                         name: hir::LifetimeName::Param(name),
                     }));
@@ -229,7 +237,6 @@ impl<'a, 'tcx, 'rcx> DocContext<'a, 'tcx, 'rcx> {
     pub fn ty_param_to_ty(&self, param: ty::GenericParamDef) -> hir::Ty {
         debug!("ty_param_to_ty({:?}) {:?}", param, param.def_id);
         hir::Ty {
-            id: ast::DUMMY_NODE_ID,
             node: hir::TyKind::Path(hir::QPath::Resolved(
                 None,
                 P(hir::Path {

--- a/src/librustdoc/doctree.rs
+++ b/src/librustdoc/doctree.rs
@@ -3,7 +3,7 @@
 pub use self::StructType::*;
 
 use syntax::ast;
-use syntax::ast::{Name, NodeId};
+use syntax::ast::Name;
 use syntax::attr;
 use syntax::ext::base::MacroKind;
 use syntax::ptr::P;
@@ -25,7 +25,7 @@ pub struct Module {
     pub enums: Vec<Enum>,
     pub fns: Vec<Function>,
     pub mods: Vec<Module>,
-    pub id: NodeId,
+    pub id: hir::HirId,
     pub typedefs: Vec<Typedef>,
     pub existentials: Vec<Existential>,
     pub statics: Vec<Static>,
@@ -45,7 +45,7 @@ impl Module {
     pub fn new(name: Option<Name>) -> Module {
         Module {
             name       : name,
-            id: ast::CRATE_NODE_ID,
+            id: hir::CRATE_HIR_ID,
             vis: Spanned { span: syntax_pos::DUMMY_SP, node: hir::VisibilityKind::Inherited },
             stab: None,
             depr: None,
@@ -87,7 +87,7 @@ pub struct Struct {
     pub vis: hir::Visibility,
     pub stab: Option<attr::Stability>,
     pub depr: Option<attr::Deprecation>,
-    pub id: NodeId,
+    pub id: hir::HirId,
     pub struct_type: StructType,
     pub name: Name,
     pub generics: hir::Generics,
@@ -100,7 +100,7 @@ pub struct Union {
     pub vis: hir::Visibility,
     pub stab: Option<attr::Stability>,
     pub depr: Option<attr::Deprecation>,
-    pub id: NodeId,
+    pub id: hir::HirId,
     pub struct_type: StructType,
     pub name: Name,
     pub generics: hir::Generics,
@@ -116,7 +116,7 @@ pub struct Enum {
     pub variants: hir::HirVec<Variant>,
     pub generics: hir::Generics,
     pub attrs: hir::HirVec<ast::Attribute>,
-    pub id: NodeId,
+    pub id: hir::HirId,
     pub whence: Span,
     pub name: Name,
 }
@@ -133,7 +133,7 @@ pub struct Variant {
 pub struct Function {
     pub decl: hir::FnDecl,
     pub attrs: hir::HirVec<ast::Attribute>,
-    pub id: NodeId,
+    pub id: hir::HirId,
     pub name: Name,
     pub vis: hir::Visibility,
     pub stab: Option<attr::Stability>,
@@ -148,7 +148,7 @@ pub struct Typedef {
     pub ty: P<hir::Ty>,
     pub gen: hir::Generics,
     pub name: Name,
-    pub id: ast::NodeId,
+    pub id: hir::HirId,
     pub attrs: hir::HirVec<ast::Attribute>,
     pub whence: Span,
     pub vis: hir::Visibility,
@@ -159,7 +159,7 @@ pub struct Typedef {
 pub struct Existential {
     pub exist_ty: hir::ExistTy,
     pub name: Name,
-    pub id: ast::NodeId,
+    pub id: hir::HirId,
     pub attrs: hir::HirVec<ast::Attribute>,
     pub whence: Span,
     pub vis: hir::Visibility,
@@ -177,7 +177,7 @@ pub struct Static {
     pub vis: hir::Visibility,
     pub stab: Option<attr::Stability>,
     pub depr: Option<attr::Deprecation>,
-    pub id: ast::NodeId,
+    pub id: hir::HirId,
     pub whence: Span,
 }
 
@@ -189,7 +189,7 @@ pub struct Constant {
     pub vis: hir::Visibility,
     pub stab: Option<attr::Stability>,
     pub depr: Option<attr::Deprecation>,
-    pub id: ast::NodeId,
+    pub id: hir::HirId,
     pub whence: Span,
 }
 
@@ -201,7 +201,7 @@ pub struct Trait {
     pub generics: hir::Generics,
     pub bounds: hir::HirVec<hir::GenericBound>,
     pub attrs: hir::HirVec<ast::Attribute>,
-    pub id: ast::NodeId,
+    pub id: hir::HirId,
     pub whence: Span,
     pub vis: hir::Visibility,
     pub stab: Option<attr::Stability>,
@@ -222,7 +222,7 @@ pub struct Impl {
     pub vis: hir::Visibility,
     pub stab: Option<attr::Stability>,
     pub depr: Option<attr::Deprecation>,
-    pub id: ast::NodeId,
+    pub id: hir::HirId,
 }
 
 // For Macro we store the DefId instead of the NodeId, since we also create
@@ -249,7 +249,7 @@ pub struct ExternCrate {
 
 pub struct Import {
     pub name: Name,
-    pub id: NodeId,
+    pub id: hir::HirId,
     pub vis: hir::Visibility,
     pub attrs: hir::HirVec<ast::Attribute>,
     pub path: hir::Path,
@@ -259,7 +259,7 @@ pub struct Import {
 
 pub struct ProcMacro {
     pub name: Name,
-    pub id: NodeId,
+    pub id: hir::HirId,
     pub kind: MacroKind,
     pub helpers: Vec<Name>,
     pub attrs: hir::HirVec<ast::Attribute>,

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -3,7 +3,7 @@ use rustc::hir;
 use rustc::hir::def::Def;
 use rustc::ty;
 use syntax;
-use syntax::ast::{self, Ident, NodeId};
+use syntax::ast::{self, Ident};
 use syntax::feature_gate::UnstableFeatures;
 use syntax::symbol::Symbol;
 use syntax_pos::{self, DUMMY_SP};
@@ -45,7 +45,7 @@ enum PathKind {
 
 struct LinkCollector<'a, 'tcx: 'a, 'rcx: 'a> {
     cx: &'a DocContext<'a, 'tcx, 'rcx>,
-    mod_ids: Vec<NodeId>,
+    mod_ids: Vec<hir::HirId>,
     is_nightly_build: bool,
 }
 
@@ -65,7 +65,7 @@ impl<'a, 'tcx, 'rcx> LinkCollector<'a, 'tcx, 'rcx> {
                path_str: &str,
                is_val: bool,
                current_item: &Option<String>,
-               parent_id: Option<NodeId>)
+               parent_id: Option<hir::HirId>)
         -> Result<(Def, Option<String>), ()>
     {
         let cx = self.cx;
@@ -205,8 +205,8 @@ impl<'a, 'tcx, 'rcx> LinkCollector<'a, 'tcx, 'rcx> {
 
 impl<'a, 'tcx, 'rcx> DocFolder for LinkCollector<'a, 'tcx, 'rcx> {
     fn fold_item(&mut self, mut item: Item) -> Option<Item> {
-        let item_node_id = if item.is_mod() {
-            if let Some(id) = self.cx.tcx.hir().as_local_node_id(item.def_id) {
+        let item_hir_id = if item.is_mod() {
+            if let Some(id) = self.cx.tcx.hir().as_local_hir_id(item.def_id) {
                 Some(id)
             } else {
                 debug!("attempting to fold on a non-local item: {:?}", item);
@@ -217,11 +217,11 @@ impl<'a, 'tcx, 'rcx> DocFolder for LinkCollector<'a, 'tcx, 'rcx> {
         };
 
         // FIXME: get the resolver to work with non-local resolve scopes.
-        let parent_node = self.cx.as_local_node_id(item.def_id).and_then(|node_id| {
+        let parent_node = self.cx.as_local_hir_id(item.def_id).and_then(|hir_id| {
             // FIXME: this fails hard for impls in non-module scope, but is necessary for the
             // current `resolve()` implementation.
-            match self.cx.tcx.hir().get_module_parent_node(node_id) {
-                id if id != node_id => Some(id),
+            match self.cx.tcx.hir().get_module_parent_node(hir_id) {
+                id if id != hir_id => Some(id),
                 _ => None,
             }
         });
@@ -233,14 +233,14 @@ impl<'a, 'tcx, 'rcx> DocFolder for LinkCollector<'a, 'tcx, 'rcx> {
         let current_item = match item.inner {
             ModuleItem(..) => {
                 if item.attrs.inner_docs {
-                    if item_node_id.unwrap() != NodeId::from_u32(0) {
+                    if item_hir_id.unwrap() != hir::CRATE_HIR_ID {
                         item.name.clone()
                     } else {
                         None
                     }
                 } else {
                     match parent_node.or(self.mod_ids.last().cloned()) {
-                        Some(parent) if parent != NodeId::from_u32(0) => {
+                        Some(parent) if parent != hir::CRATE_HIR_ID => {
                             // FIXME: can we pull the parent module's name from elsewhere?
                             Some(self.cx.tcx.hir().name(parent).to_string())
                         }
@@ -259,7 +259,7 @@ impl<'a, 'tcx, 'rcx> DocFolder for LinkCollector<'a, 'tcx, 'rcx> {
         };
 
         if item.is_mod() && item.attrs.inner_docs {
-            self.mod_ids.push(item_node_id.unwrap());
+            self.mod_ids.push(item_hir_id.unwrap());
         }
 
         let cx = self.cx;
@@ -406,7 +406,7 @@ impl<'a, 'tcx, 'rcx> DocFolder for LinkCollector<'a, 'tcx, 'rcx> {
         }
 
         if item.is_mod() && !item.attrs.inner_docs {
-            self.mod_ids.push(item_node_id.unwrap());
+            self.mod_ids.push(item_hir_id.unwrap());
         }
 
         if item.is_mod() {
@@ -523,7 +523,7 @@ fn resolution_failure(
 
             let mut diag = cx.tcx.struct_span_lint_node(
                 lint::builtin::INTRA_DOC_LINK_RESOLUTION_FAILURE,
-                NodeId::from_u32(0),
+                hir::CRATE_HIR_ID,
                 sp,
                 &msg,
             );
@@ -532,7 +532,7 @@ fn resolution_failure(
         } else {
             let mut diag = cx.tcx.struct_span_lint_node(
                 lint::builtin::INTRA_DOC_LINK_RESOLUTION_FAILURE,
-                NodeId::from_u32(0),
+                hir::CRATE_HIR_ID,
                 sp,
                 &msg,
             );
@@ -557,7 +557,7 @@ fn resolution_failure(
         }
     } else {
         cx.tcx.struct_span_lint_node(lint::builtin::INTRA_DOC_LINK_RESOLUTION_FAILURE,
-                                     NodeId::from_u32(0),
+                                     hir::CRATE_HIR_ID,
                                      sp,
                                      &msg)
     };

--- a/src/librustdoc/passes/mod.rs
+++ b/src/librustdoc/passes/mod.rs
@@ -1,13 +1,13 @@
 //! Contains information about "passes", used to modify crate information during the documentation
 //! process.
 
+use rustc::hir;
 use rustc::hir::def_id::DefId;
 use rustc::lint as lint;
 use rustc::middle::privacy::AccessLevels;
 use rustc::util::nodemap::DefIdSet;
 use std::mem;
 use std::fmt;
-use syntax::ast::NodeId;
 
 use clean::{self, GetDefId, Item};
 use core::{DocContext, DocAccessLevels};
@@ -380,7 +380,7 @@ pub fn look_for_tests<'a, 'tcx: 'a, 'rcx: 'a>(
         if check_missing_code == true && tests.found_tests == 0 {
             let mut diag = cx.tcx.struct_span_lint_node(
                 lint::builtin::MISSING_DOC_CODE_EXAMPLES,
-                NodeId::from_u32(0),
+                hir::CRATE_HIR_ID,
                 span_of_attrs(&item.attrs),
                 "Missing code example in this documentation");
             diag.emit();
@@ -389,7 +389,7 @@ pub fn look_for_tests<'a, 'tcx: 'a, 'rcx: 'a>(
                   !cx.renderinfo.borrow().access_levels.is_doc_reachable(item.def_id) {
             let mut diag = cx.tcx.struct_span_lint_node(
                 lint::builtin::PRIVATE_DOC_TESTS,
-                NodeId::from_u32(0),
+                hir::CRATE_HIR_ID,
                 span_of_attrs(&item.attrs),
                 "Documentation test in private item");
             diag.emit();

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -838,7 +838,7 @@ impl<'a, 'hir> intravisit::Visitor<'hir> for HirCollector<'a, 'hir> {
 
     fn visit_item(&mut self, item: &'hir hir::Item) {
         let name = if let hir::ItemKind::Impl(.., ref ty, _) = item.node {
-            self.map.node_to_pretty_string(ty.id)
+            self.map.node_to_pretty_string_by_hir_id(ty.hir_id)
         } else {
             item.ident.to_string()
         };
@@ -869,7 +869,7 @@ impl<'a, 'hir> intravisit::Visitor<'hir> for HirCollector<'a, 'hir> {
     fn visit_variant(&mut self,
                      v: &'hir hir::Variant,
                      g: &'hir hir::Generics,
-                     item_id: ast::NodeId) {
+                     item_id: hir::HirId) {
         self.visit_testable(v.node.ident.to_string(), &v.node.attrs, |this| {
             intravisit::walk_variant(this, v, g, item_id);
         });

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -30,7 +30,7 @@ pub struct RustdocVisitor<'a, 'tcx: 'a, 'rcx: 'a> {
     pub module: Module,
     pub attrs: hir::HirVec<ast::Attribute>,
     pub cx: &'a core::DocContext<'a, 'tcx, 'rcx>,
-    view_item_stack: FxHashSet<ast::NodeId>,
+    view_item_stack: FxHashSet<hir::HirId>,
     inlining: bool,
     /// Are the current module and all of its parents public?
     inside_public_path: bool,
@@ -43,7 +43,7 @@ impl<'a, 'tcx, 'rcx> RustdocVisitor<'a, 'tcx, 'rcx> {
     ) -> RustdocVisitor<'a, 'tcx, 'rcx> {
         // If the root is re-exported, terminate all recursion.
         let mut stack = FxHashSet::default();
-        stack.insert(ast::CRATE_NODE_ID);
+        stack.insert(hir::CRATE_HIR_ID);
         RustdocVisitor {
             module: Module::new(None),
             attrs: hir::HirVec::new(),
@@ -65,14 +65,14 @@ impl<'a, 'tcx, 'rcx> RustdocVisitor<'a, 'tcx, 'rcx> {
         }
     }
 
-    fn stability(&self, id: ast::NodeId) -> Option<attr::Stability> {
-        self.cx.tcx.hir().opt_local_def_id(id)
-            .and_then(|def_id| self.cx.tcx.lookup_stability(def_id)).cloned()
+    fn stability(&self, id: hir::HirId) -> Option<attr::Stability> {
+        let def_id = self.cx.tcx.hir().local_def_id_from_hir_id(id);
+        self.cx.tcx.lookup_stability(def_id).cloned()
     }
 
-    fn deprecation(&self, id: ast::NodeId) -> Option<attr::Deprecation> {
-        self.cx.tcx.hir().opt_local_def_id(id)
-            .and_then(|def_id| self.cx.tcx.lookup_deprecation(def_id))
+    fn deprecation(&self, id: hir::HirId) -> Option<attr::Deprecation> {
+        let def_id = self.cx.tcx.hir().local_def_id_from_hir_id(id);
+        self.cx.tcx.lookup_deprecation(def_id)
     }
 
     pub fn visit(&mut self, krate: &hir::Crate) {
@@ -82,7 +82,7 @@ impl<'a, 'tcx, 'rcx> RustdocVisitor<'a, 'tcx, 'rcx> {
                                               krate.attrs.clone(),
                                               Spanned { span: syntax_pos::DUMMY_SP,
                                                         node: hir::VisibilityKind::Public },
-                                              ast::CRATE_NODE_ID,
+                                              hir::CRATE_HIR_ID,
                                               &krate.module,
                                               None);
         // Attach the crate's exported macros to the top-level module:
@@ -100,12 +100,12 @@ impl<'a, 'tcx, 'rcx> RustdocVisitor<'a, 'tcx, 'rcx> {
         debug!("Visiting struct");
         let struct_type = struct_type_from_def(&*sd);
         Struct {
-            id: item.id,
+            id: item.hir_id,
             struct_type,
             name,
             vis: item.vis.clone(),
-            stab: self.stability(item.id),
-            depr: self.deprecation(item.id),
+            stab: self.stability(item.hir_id),
+            depr: self.deprecation(item.hir_id),
             attrs: item.attrs.clone(),
             generics: generics.clone(),
             fields: sd.fields().iter().cloned().collect(),
@@ -119,12 +119,12 @@ impl<'a, 'tcx, 'rcx> RustdocVisitor<'a, 'tcx, 'rcx> {
         debug!("Visiting union");
         let struct_type = struct_type_from_def(&*sd);
         Union {
-            id: item.id,
+            id: item.hir_id,
             struct_type,
             name,
             vis: item.vis.clone(),
-            stab: self.stability(item.id),
-            depr: self.deprecation(item.id),
+            stab: self.stability(item.hir_id),
+            depr: self.deprecation(item.hir_id),
             attrs: item.attrs.clone(),
             generics: generics.clone(),
             fields: sd.fields().iter().cloned().collect(),
@@ -141,17 +141,17 @@ impl<'a, 'tcx, 'rcx> RustdocVisitor<'a, 'tcx, 'rcx> {
             variants: def.variants.iter().map(|v| Variant {
                 name: v.node.ident.name,
                 attrs: v.node.attrs.clone(),
-                stab: self.stability(v.node.data.id()),
-                depr: self.deprecation(v.node.data.id()),
+                stab: self.stability(v.node.data.hir_id()),
+                depr: self.deprecation(v.node.data.hir_id()),
                 def: v.node.data.clone(),
                 whence: v.span,
             }).collect(),
             vis: it.vis.clone(),
-            stab: self.stability(it.id),
-            depr: self.deprecation(it.id),
+            stab: self.stability(it.hir_id),
+            depr: self.deprecation(it.hir_id),
             generics: params.clone(),
             attrs: it.attrs.clone(),
-            id: it.id,
+            id: it.hir_id,
             whence: it.span,
         }
     }
@@ -201,21 +201,21 @@ impl<'a, 'tcx, 'rcx> RustdocVisitor<'a, 'tcx, 'rcx> {
 
                 om.proc_macros.push(ProcMacro {
                     name,
-                    id: item.id,
+                    id: item.hir_id,
                     kind,
                     helpers,
                     attrs: item.attrs.clone(),
                     whence: item.span,
-                    stab: self.stability(item.id),
-                    depr: self.deprecation(item.id),
+                    stab: self.stability(item.hir_id),
+                    depr: self.deprecation(item.hir_id),
                 });
             }
             None => {
                 om.fns.push(Function {
-                    id: item.id,
+                    id: item.hir_id,
                     vis: item.vis.clone(),
-                    stab: self.stability(item.id),
-                    depr: self.deprecation(item.id),
+                    stab: self.stability(item.hir_id),
+                    depr: self.deprecation(item.hir_id),
                     attrs: item.attrs.clone(),
                     decl: fd.clone(),
                     name,
@@ -229,7 +229,7 @@ impl<'a, 'tcx, 'rcx> RustdocVisitor<'a, 'tcx, 'rcx> {
     }
 
     pub fn visit_mod_contents(&mut self, span: Span, attrs: hir::HirVec<ast::Attribute>,
-                              vis: hir::Visibility, id: ast::NodeId,
+                              vis: hir::Visibility, id: hir::HirId,
                               m: &hir::Mod,
                               name: Option<ast::Name>) -> Module {
         let mut om = Module::new(name);
@@ -261,20 +261,20 @@ impl<'a, 'tcx, 'rcx> RustdocVisitor<'a, 'tcx, 'rcx> {
     ///
     /// Returns true if the target has been inlined.
     fn maybe_inline_local(&mut self,
-                          id: ast::NodeId,
+                          id: hir::HirId,
                           def: Def,
                           renamed: Option<ast::Ident>,
                           glob: bool,
                           om: &mut Module,
                           please_inline: bool) -> bool {
 
-        fn inherits_doc_hidden(cx: &core::DocContext, mut node: ast::NodeId) -> bool {
-            while let Some(id) = cx.tcx.hir().get_enclosing_scope(node) {
-                node = id;
-                if cx.tcx.hir().attrs(node).lists("doc").has_word("hidden") {
+        fn inherits_doc_hidden(cx: &core::DocContext, mut hir: hir::HirId) -> bool {
+            while let Some(id) = cx.tcx.hir().get_enclosing_scope(hir) {
+                hir = id;
+                if cx.tcx.hir().attrs(hir).lists("doc").has_word("hidden") {
                     return true;
                 }
-                if node == ast::CRATE_NODE_ID {
+                if hir == hir::CRATE_HIR_ID {
                     break;
                 }
             }
@@ -322,21 +322,21 @@ impl<'a, 'tcx, 'rcx> RustdocVisitor<'a, 'tcx, 'rcx> {
             return false
         }
 
-        let def_node_id = match tcx.hir().as_local_node_id(def_did) {
+        let def_hir_id = match tcx.hir().as_local_hir_id(def_did) {
             Some(n) => n, None => return false
         };
 
         let is_private = !self.cx.renderinfo.borrow().access_levels.is_public(def_did);
-        let is_hidden = inherits_doc_hidden(self.cx, def_node_id);
+        let is_hidden = inherits_doc_hidden(self.cx, def_hir_id);
 
         // Only inline if requested or if the item would otherwise be stripped.
         if (!please_inline && !is_private && !is_hidden) || is_no_inline {
             return false
         }
 
-        if !self.view_item_stack.insert(def_node_id) { return false }
+        if !self.view_item_stack.insert(def_hir_id) { return false }
 
-        let ret = match tcx.hir().get(def_node_id) {
+        let ret = match tcx.hir().get_by_hir_id(def_hir_id) {
             Node::Item(&hir::Item { node: hir::ItemKind::Mod(ref m), .. }) if glob => {
                 let prev = mem::replace(&mut self.inlining, true);
                 for i in &m.item_ids {
@@ -355,7 +355,7 @@ impl<'a, 'tcx, 'rcx> RustdocVisitor<'a, 'tcx, 'rcx> {
             Node::ForeignItem(it) if !glob => {
                 // Generate a fresh `extern {}` block if we want to inline a foreign item.
                 om.foreigns.push(hir::ForeignMod {
-                    abi: tcx.hir().get_foreign_abi(it.id),
+                    abi: tcx.hir().get_foreign_abi(it.hir_id),
                     items: vec![hir::ForeignItem {
                         ident: renamed.unwrap_or(it.ident),
                         .. it.clone()
@@ -369,7 +369,7 @@ impl<'a, 'tcx, 'rcx> RustdocVisitor<'a, 'tcx, 'rcx> {
             }
             _ => false,
         };
-        self.view_item_stack.remove(&def_node_id);
+        self.view_item_stack.remove(&def_hir_id);
         ret
     }
 
@@ -379,7 +379,7 @@ impl<'a, 'tcx, 'rcx> RustdocVisitor<'a, 'tcx, 'rcx> {
         let ident = renamed.unwrap_or(item.ident);
 
         if item.vis.node.is_pub() {
-            let def_id = self.cx.tcx.hir().local_def_id(item.id);
+            let def_id = self.cx.tcx.hir().local_def_id_from_hir_id(item.hir_id);
             self.store_path(def_id);
         }
 
@@ -399,7 +399,7 @@ impl<'a, 'tcx, 'rcx> RustdocVisitor<'a, 'tcx, 'rcx> {
             _ if self.inlining && !item.vis.node.is_pub() => {}
             hir::ItemKind::GlobalAsm(..) => {}
             hir::ItemKind::ExternCrate(orig_name) => {
-                let def_id = self.cx.tcx.hir().local_def_id(item.id);
+                let def_id = self.cx.tcx.hir().local_def_id_from_hir_id(item.hir_id);
                 om.extern_crates.push(ExternCrate {
                     cnum: self.cx.tcx.extern_mod_stmt_cnum(def_id)
                                 .unwrap_or(LOCAL_CRATE),
@@ -434,7 +434,7 @@ impl<'a, 'tcx, 'rcx> RustdocVisitor<'a, 'tcx, 'rcx> {
                         }
                     });
                     let ident = if is_glob { None } else { Some(ident) };
-                    if self.maybe_inline_local(item.id,
+                    if self.maybe_inline_local(item.hir_id,
                                                path.def,
                                                ident,
                                                is_glob,
@@ -446,7 +446,7 @@ impl<'a, 'tcx, 'rcx> RustdocVisitor<'a, 'tcx, 'rcx> {
 
                 om.imports.push(Import {
                     name: ident.name,
-                    id: item.id,
+                    id: item.hir_id,
                     vis: item.vis.clone(),
                     attrs: item.attrs.clone(),
                     path: (**path).clone(),
@@ -458,7 +458,7 @@ impl<'a, 'tcx, 'rcx> RustdocVisitor<'a, 'tcx, 'rcx> {
                 om.mods.push(self.visit_mod_contents(item.span,
                                                      item.attrs.clone(),
                                                      item.vis.clone(),
-                                                     item.id,
+                                                     item.hir_id,
                                                      m,
                                                      Some(ident.name)));
             },
@@ -475,12 +475,12 @@ impl<'a, 'tcx, 'rcx> RustdocVisitor<'a, 'tcx, 'rcx> {
                     ty: ty.clone(),
                     gen: gen.clone(),
                     name: ident.name,
-                    id: item.id,
+                    id: item.hir_id,
                     attrs: item.attrs.clone(),
                     whence: item.span,
                     vis: item.vis.clone(),
-                    stab: self.stability(item.id),
-                    depr: self.deprecation(item.id),
+                    stab: self.stability(item.hir_id),
+                    depr: self.deprecation(item.hir_id),
                 };
                 om.typedefs.push(t);
             },
@@ -488,12 +488,12 @@ impl<'a, 'tcx, 'rcx> RustdocVisitor<'a, 'tcx, 'rcx> {
                 let t = Existential {
                     exist_ty: exist_ty.clone(),
                     name: ident.name,
-                    id: item.id,
+                    id: item.hir_id,
                     attrs: item.attrs.clone(),
                     whence: item.span,
                     vis: item.vis.clone(),
-                    stab: self.stability(item.id),
-                    depr: self.deprecation(item.id),
+                    stab: self.stability(item.hir_id),
+                    depr: self.deprecation(item.hir_id),
                 };
                 om.existentials.push(t);
             },
@@ -502,13 +502,13 @@ impl<'a, 'tcx, 'rcx> RustdocVisitor<'a, 'tcx, 'rcx> {
                     type_: ty.clone(),
                     mutability: mut_.clone(),
                     expr: exp.clone(),
-                    id: item.id,
+                    id: item.hir_id,
                     name: ident.name,
                     attrs: item.attrs.clone(),
                     whence: item.span,
                     vis: item.vis.clone(),
-                    stab: self.stability(item.id),
-                    depr: self.deprecation(item.id),
+                    stab: self.stability(item.hir_id),
+                    depr: self.deprecation(item.hir_id),
                 };
                 om.statics.push(s);
             },
@@ -516,13 +516,13 @@ impl<'a, 'tcx, 'rcx> RustdocVisitor<'a, 'tcx, 'rcx> {
                 let s = Constant {
                     type_: ty.clone(),
                     expr: exp.clone(),
-                    id: item.id,
+                    id: item.hir_id,
                     name: ident.name,
                     attrs: item.attrs.clone(),
                     whence: item.span,
                     vis: item.vis.clone(),
-                    stab: self.stability(item.id),
-                    depr: self.deprecation(item.id),
+                    stab: self.stability(item.hir_id),
+                    depr: self.deprecation(item.hir_id),
                 };
                 om.constants.push(s);
             },
@@ -537,12 +537,12 @@ impl<'a, 'tcx, 'rcx> RustdocVisitor<'a, 'tcx, 'rcx> {
                     items,
                     generics: gen.clone(),
                     bounds: b.iter().cloned().collect(),
-                    id: item.id,
+                    id: item.hir_id,
                     attrs: item.attrs.clone(),
                     whence: item.span,
                     vis: item.vis.clone(),
-                    stab: self.stability(item.id),
-                    depr: self.deprecation(item.id),
+                    stab: self.stability(item.hir_id),
+                    depr: self.deprecation(item.hir_id),
                 };
                 om.traits.push(t);
             },
@@ -572,11 +572,11 @@ impl<'a, 'tcx, 'rcx> RustdocVisitor<'a, 'tcx, 'rcx> {
                         for_: ty.clone(),
                         items,
                         attrs: item.attrs.clone(),
-                        id: item.id,
+                        id: item.hir_id,
                         whence: item.span,
                         vis: item.vis.clone(),
-                        stab: self.stability(item.id),
-                        depr: self.deprecation(item.id),
+                        stab: self.stability(item.hir_id),
+                        depr: self.deprecation(item.hir_id),
                     };
                     om.impls.push(i);
                 }
@@ -596,13 +596,13 @@ impl<'a, 'tcx, 'rcx> RustdocVisitor<'a, 'tcx, 'rcx> {
         let matchers = tts.chunks(4).map(|arm| arm[0].span()).collect();
 
         Macro {
-            def_id: self.cx.tcx.hir().local_def_id(def.id),
+            def_id: self.cx.tcx.hir().local_def_id_from_hir_id(def.hir_id),
             attrs: def.attrs.clone(),
             name: renamed.unwrap_or(def.name),
             whence: def.span,
             matchers,
-            stab: self.stability(def.id),
-            depr: self.deprecation(def.id),
+            stab: self.stability(def.hir_id),
+            depr: self.deprecation(def.hir_id),
             imported_from: None,
         }
     }


### PR DESCRIPTION
This is a WIP attempt at complete `HirId`-ification, i.e. deprecating `ast::NodeId`s after the lowering process.

Sadly this can't be done one-by-one, because everything is connected to each other; I added `HirId` to `Hir` nodes, introduced methods working on `HirId` instead of `NodeId` and I'm gradually removing `NodeId`s.

This PR currently fails to build `stage1` due to some error on my part, probably in `hir::lowering` or `hir::intravisit`; I would like to get some help with that, and also to know if I have made any "design flaws" (e.g. removal of `NodeId` where it will definitely be needed, e.g. by some tool) that haven't revealed themselves just yet.

Current progress on the main hit list (checked ones only have `HirId` now):

- [x] `hir::AnonConst`
- [x] `hir::Arg`
- [x] `hir::Block`
- [x] `hir::BodyId`
- [x] `hir::Destination` - depends on `hir::Def::Label`
- [x] `hir::Expr`
- [x] `hir::Field`
- [x] `hir::FieldPat`
- [x] `hir::ForeignItem`
- [x] `hir::GenericParam`
- [x] `hir::ImplItem`
- [x] `hir::ImplItemId`
- [x] `hir::Item`
- [x] `hir::ItemId` - `NodeId` used by `syntax::visit::Visitor`
- [x] `hir::Lifetime`
- [x] `hir::Local`
- [x] `hir::MacroDef`
- [x] `hir::Pat`
- [x] `hir::PathSegment` - used in `save-analysis`
- [x] `hir::StmtKind`
- [x] `hir::StructField`
- [x] `hir::TraitItem`
- [x] `hir::TraitItemId`
- [x] `hir::TraitRef`
- [x] `hir::Ty`
- [x] `hir::TypeBinding`
- [x] `hir::VariantData`
- [x] `hir::WhereClause`
- [x] `hir::WhereEqPredicate`
- [ ] `hir::def::Def::Label`
- [x] `hir::def::Def::Local`
- [x] `hir::def::Def::Upvar`
- [x] `hir::map::Entry`
- [x] `hir::map::blocks::ItemFnParts`
- [x] `hir::map::blocks::ClosureParts`
- [x] `hir::map::collector::NodeCollector`
- [x] `hir::map::hir_id_validator::HirIdValidator`

Until the HirId-ification is 100% complete the overall code delta will be in plus - this is mostly due to the duplication of some methods working on `NodeId`.

Fixes https://github.com/rust-lang/rust/issues/50928.

r? @varkor 