### PR TITLE
Remove the `connect_timeout_unroutable` test.

### DIFF
--- a/src/libstd/net/tcp.rs
+++ b/src/libstd/net/tcp.rs
@@ -1674,17 +1674,6 @@ mod tests {
     }
 
     #[test]
-    fn connect_timeout_unroutable() {
-        // this IP is unroutable, so connections should always time out,
-        // provided the network is reachable to begin with.
-        let addr = "10.255.255.1:80".parse().unwrap();
-        let e = TcpStream::connect_timeout(&addr, Duration::from_millis(250)).unwrap_err();
-        assert!(e.kind() == io::ErrorKind::TimedOut ||
-                e.kind() == io::ErrorKind::Other,
-                "bad error: {} {:?}", e, e.kind());
-    }
-
-    #[test]
     fn connect_timeout_unbound() {
         // bind and drop a socket to track down a "probably unassigned" port
         let socket = TcpListener::bind("127.0.0.1:0").unwrap();


### PR DESCRIPTION
It requires an unreachable IP address, but there is no such thing, and
this has caused it to fail for multiple people.

Fixes #44698, fixes #50065.

r? @sfackler 