### PR TITLE
Add 'rustc-env:RUST_BACKTRACE=0' to const-pat-ice test

### DIFF
--- a/src/test/ui/pattern/const-pat-ice.rs
+++ b/src/test/ui/pattern/const-pat-ice.rs
@@ -1,4 +1,5 @@
 // failure-status: 101
+// rustc-env:RUST_BACKTRACE=0
 
 // This is a repro test for an ICE in our pattern handling of constants.
 


### PR DESCRIPTION
This ensures that the test passes, regardless of what the user has set
RUST_BACKTRACE to.