### PR TITLE
Add a debug_assert to Vec::set_len

### DIFF
--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -819,6 +819,8 @@ impl<T> Vec<T> {
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub unsafe fn set_len(&mut self, new_len: usize) {
+        debug_assert!(new_len <= self.capacity());
+
         self.len = new_len;
     }
 


### PR DESCRIPTION
Following the precedent of https://github.com/rust-lang/rust/pull/52972, which found https://github.com/llogiq/bytecount/pull/42.

(This may well make a test fail; let's see what Travis says.)