### PR TITLE
Simplify 'product' factorial example

### DIFF
--- a/src/libcore/iter/iterator.rs
+++ b/src/libcore/iter/iterator.rs
@@ -2358,7 +2358,7 @@ pub trait Iterator {
     ///
     /// ```
     /// fn factorial(n: u32) -> u32 {
-    ///     (1..).take_while(|&i| i <= n).product()
+    ///     (1..=n).product()
     /// }
     /// assert_eq!(factorial(0), 1);
     /// assert_eq!(factorial(1), 1);


### PR DESCRIPTION
This simplifies the [`factorial(n: 32)`](https://doc.rust-lang.org/std/iter/trait.Iterator.html#examples-46) implementation as example for the `Iterator::product()` function.
It currently uses unnecessary additional complexity.

Although very minimal, I do not want to include it in some other irrelevant PR.