### PR TITLE
Use normal mutable borrows in matches

### DIFF
--- a/src/librustc/ich/impls_mir.rs
+++ b/src/librustc/ich/impls_mir.rs
@@ -196,7 +196,12 @@ impl_stable_hash_for!(impl<'gcx> for enum mir::StatementKind<'gcx> [ mir::Statem
 });
 
 impl_stable_hash_for!(enum mir::RetagKind { FnEntry, TwoPhase, Raw, Default });
-impl_stable_hash_for!(enum mir::FakeReadCause { ForMatchGuard, ForMatchedPlace, ForLet });
+impl_stable_hash_for!(enum mir::FakeReadCause {
+    ForMatchGuard,
+    ForMatchedPlace,
+    ForGuardBinding,
+    ForLet
+});
 
 impl<'a, 'gcx> HashStable<StableHashingContext<'a>> for mir::Place<'gcx> {
     fn hash_stable<W: StableHasherResult>(&self,

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -1823,16 +1823,21 @@ pub enum RetagKind {
 /// The `FakeReadCause` describes the type of pattern why a `FakeRead` statement exists.
 #[derive(Copy, Clone, RustcEncodable, RustcDecodable, Debug)]
 pub enum FakeReadCause {
-    /// Inject a fake read of the borrowed input at the start of each arm's
-    /// pattern testing code.
+    /// Inject a fake read of the borrowed input at the end of each guards
+    /// code.
     ///
-    /// This should ensure that you cannot change the variant for an enum
-    /// while you are in the midst of matching on it.
+    /// This should ensure that you cannot change the variant for an enum while
+    /// you are in the midst of matching on it.
     ForMatchGuard,
 
     /// `let x: !; match x {}` doesn't generate any read of x so we need to
     /// generate a read of x to check that it is initialized and safe.
     ForMatchedPlace,
+
+    /// A fake read of the RefWithinGuard version of a bind-by-value variable
+    /// in a match guard to ensure that it's value hasn't change by the time
+    /// we create the OutsideGuard version.
+    ForGuardBinding,
 
     /// Officially, the semantics of
     ///

--- a/src/librustc_mir/borrow_check/borrow_set.rs
+++ b/src/librustc_mir/borrow_check/borrow_set.rs
@@ -3,9 +3,7 @@ use crate::borrow_check::nll::ToRegionVid;
 use crate::dataflow::indexes::BorrowIndex;
 use crate::dataflow::move_paths::MoveData;
 use rustc::mir::traversal;
-use rustc::mir::visit::{
-    PlaceContext, Visitor, NonUseContext, MutatingUseContext, NonMutatingUseContext
-};
+use rustc::mir::visit::{PlaceContext, Visitor, NonUseContext, MutatingUseContext};
 use rustc::mir::{self, Location, Mir, Local};
 use rustc::ty::{RegionVid, TyCtxt};
 use rustc::util::nodemap::{FxHashMap, FxHashSet};
@@ -257,31 +255,21 @@ impl<'a, 'gcx, 'tcx> Visitor<'tcx> for GatherBorrows<'a, 'gcx, 'tcx> {
                 );
             }
 
-            // Otherwise, this is the unique later use
-            // that we expect.
-            borrow_data.activation_location = match context {
-                // The use of TMP in a shared borrow does not
-                // count as an actual activation.
-                PlaceContext::NonMutatingUse(NonMutatingUseContext::SharedBorrow(..)) |
-                PlaceContext::NonMutatingUse(NonMutatingUseContext::ShallowBorrow(..)) =>
-                    TwoPhaseActivation::NotActivated,
-                _ => {
-                    // Double check: This borrow is indeed a two-phase borrow (that is,
-                    // we are 'transitioning' from `NotActivated` to `ActivatedAt`) and
-                    // we've not found any other activations (checked above).
-                    assert_eq!(
-                        borrow_data.activation_location,
-                        TwoPhaseActivation::NotActivated,
-                        "never found an activation for this borrow!",
-                    );
+            // Otherwise, this is the unique later use that we expect.
+            // Double check: This borrow is indeed a two-phase borrow (that is,
+            // we are 'transitioning' from `NotActivated` to `ActivatedAt`) and
+            // we've not found any other activations (checked above).
+            assert_eq!(
+                borrow_data.activation_location,
+                TwoPhaseActivation::NotActivated,
+                "never found an activation for this borrow!",
+            );
+            self.activation_map
+                .entry(location)
+                .or_default()
+                .push(borrow_index);
 
-                    self.activation_map
-                        .entry(location)
-                        .or_default()
-                        .push(borrow_index);
-                    TwoPhaseActivation::ActivatedAt(location)
-                }
-            };
+            borrow_data.activation_location = TwoPhaseActivation::ActivatedAt(location);
         }
     }
 

--- a/src/librustc_mir/borrow_check/error_reporting.rs
+++ b/src/librustc_mir/borrow_check/error_reporting.rs
@@ -1330,22 +1330,30 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
         let loan_span = loan_spans.args_or_use();
 
         let tcx = self.infcx.tcx;
-        let mut err = if loan.kind == BorrowKind::Shallow {
-            tcx.cannot_mutate_in_match_guard(
+        if loan.kind == BorrowKind::Shallow {
+            let mut err = tcx.cannot_mutate_in_match_guard(
                 span,
                 loan_span,
                 &self.describe_place(place).unwrap_or_else(|| "_".to_owned()),
                 "assign",
                 Origin::Mir,
-            )
-        } else {
-            tcx.cannot_assign_to_borrowed(
-                span,
-                loan_span,
-                &self.describe_place(place).unwrap_or_else(|| "_".to_owned()),
-                Origin::Mir,
-            )
-        };
+            );
+            loan_spans.var_span_label(
+                &mut err,
+                format!("borrow occurs due to use{}", loan_spans.describe()),
+            );
+
+            err.buffer(&mut self.errors_buffer);
+
+            return;
+        }
+
+        let mut err = tcx.cannot_assign_to_borrowed(
+            span,
+            loan_span,
+            &self.describe_place(place).unwrap_or_else(|| "_".to_owned()),
+            Origin::Mir,
+        );
 
         loan_spans.var_span_label(
             &mut err,

--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -998,7 +998,9 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
                 }
 
                 (Read(_), BorrowKind::Shared) | (Reservation(..), BorrowKind::Shared)
-                | (Read(_), BorrowKind::Shallow) | (Reservation(..), BorrowKind::Shallow) => {
+                | (Read(_), BorrowKind::Shallow) | (Reservation(..), BorrowKind::Shallow)
+                | (Read(ReadKind::Borrow(BorrowKind::Shallow)), BorrowKind::Unique)
+                | (Read(ReadKind::Borrow(BorrowKind::Shallow)), BorrowKind::Mut { .. }) => {
                     Control::Continue
                 }
 

--- a/src/librustc_mir/borrow_check/nll/invalidation.rs
+++ b/src/librustc_mir/borrow_check/nll/invalidation.rs
@@ -78,13 +78,8 @@ impl<'cx, 'tcx, 'gcx> Visitor<'tcx> for InvalidationGenerator<'cx, 'tcx, 'gcx> {
                     JustWrite
                 );
             }
-            StatementKind::FakeRead(_, ref place) => {
-                self.access_place(
-                    ContextKind::FakeRead.new(location),
-                    place,
-                    (Deep, Read(ReadKind::Borrow(BorrowKind::Shared))),
-                    LocalMutationIsAllowed::No,
-                );
+            StatementKind::FakeRead(_, _) => {
+                // Only relavent for initialized/liveness/safety checks.
             }
             StatementKind::SetDiscriminant {
                 ref place,
@@ -438,7 +433,9 @@ impl<'cg, 'cx, 'tcx, 'gcx> InvalidationGenerator<'cx, 'tcx, 'gcx> {
                     }
 
                     (Read(_), BorrowKind::Shallow) | (Reservation(..), BorrowKind::Shallow)
-                    | (Read(_), BorrowKind::Shared) | (Reservation(..), BorrowKind::Shared) => {
+                    | (Read(_), BorrowKind::Shared) | (Reservation(..), BorrowKind::Shared)
+                    | (Read(ReadKind::Borrow(BorrowKind::Shallow)), BorrowKind::Unique)
+                    | (Read(ReadKind::Borrow(BorrowKind::Shallow)), BorrowKind::Mut { .. }) => {
                         // Reads/reservations don't invalidate shared or shallow borrows
                     }
 

--- a/src/librustc_mir/build/block.rs
+++ b/src/librustc_mir/build/block.rs
@@ -6,8 +6,6 @@ use rustc::mir::*;
 use rustc::hir;
 use syntax_pos::Span;
 
-use std::slice;
-
 impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
     pub fn ast_block(&mut self,
                      destination: &Place<'tcx>,
@@ -125,7 +123,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                             None,
                             remainder_span,
                             lint_level,
-                            slice::from_ref(&pattern),
+                            &pattern,
                             ArmHasGuard(false),
                             Some((None, initializer_span)),
                         );
@@ -138,7 +136,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                             }));
                     } else {
                         scope = this.declare_bindings(
-                            None, remainder_span, lint_level, slice::from_ref(&pattern),
+                            None, remainder_span, lint_level, &pattern,
                             ArmHasGuard(false), None);
 
                         debug!("ast_block_stmts: pattern={:?}", pattern);

--- a/src/librustc_mir/build/expr/into.rs
+++ b/src/librustc_mir/build/expr/into.rs
@@ -53,8 +53,8 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
             ExprKind::Block { body: ast_block } => {
                 this.ast_block(destination, block, ast_block, source_info)
             }
-            ExprKind::Match { discriminant, arms } => {
-                this.match_expr(destination, expr_span, block, discriminant, arms)
+            ExprKind::Match { scrutinee, arms } => {
+                this.match_expr(destination, expr_span, block, scrutinee, arms)
             }
             ExprKind::NeverToAny { source } => {
                 let source = this.hir.mirror(source);

--- a/src/librustc_mir/build/matches/util.rs
+++ b/src/librustc_mir/build/matches/util.rs
@@ -72,7 +72,6 @@ impl<'pat, 'tcx> MatchPair<'pat, 'tcx> {
         MatchPair {
             place,
             pattern,
-            slice_len_checked: false,
         }
     }
 }

--- a/src/librustc_mir/build/mod.rs
+++ b/src/librustc_mir/build/mod.rs
@@ -459,8 +459,7 @@ enum LocalsForNode {
 
     /// The exceptional case is identifiers in a match arm's pattern
     /// that are referenced in a guard of that match arm. For these,
-    /// we can have `2 + k` Locals, where `k` is the number of candidate
-    /// patterns (separated by `|`) in the arm.
+    /// we have `2` Locals.
     ///
     /// * `for_arm_body` is the Local used in the arm body (which is
     ///   just like the `One` case above),
@@ -468,16 +467,7 @@ enum LocalsForNode {
     /// * `ref_for_guard` is the Local used in the arm's guard (which
     ///   is a reference to a temp that is an alias of
     ///   `for_arm_body`).
-    ///
-    /// * `vals_for_guard` is the `k` Locals; at most one of them will
-    ///   get initialized by the arm's execution, and after it is
-    ///   initialized, `ref_for_guard` will be assigned a reference to
-    ///   it.
-    ///
-    /// There reason we have `k` Locals rather than just 1 is to
-    /// accommodate some restrictions imposed by two-phase borrows,
-    /// which apply when we have a `ref mut` pattern.
-    ForGuard { vals_for_guard: Vec<Local>, ref_for_guard: Local, for_arm_body: Local },
+    ForGuard { ref_for_guard: Local, for_arm_body: Local },
 }
 
 #[derive(Debug)]
@@ -510,16 +500,11 @@ struct GuardFrame {
 }
 
 /// `ForGuard` indicates whether we are talking about:
-///   1. the temp for a local binding used solely within guard expressions,
-///   2. the temp that holds reference to (1.), which is actually what the
-///      guard expressions see, or
-///   3. the temp for use outside of guard expressions.
+///   1. The variable for use outside of guard expressions, or
+///   2. The temp that holds reference to (1.), which is actually what the
+///      guard expressions see.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 enum ForGuard {
-    /// The `usize` identifies for which candidate pattern we want the
-    /// local binding. We keep a temp per-candidate to accommodate
-    /// two-phase borrows (see `LocalsForNode` documentation).
-    ValWithinGuard(usize),
     RefWithinGuard,
     OutsideGuard,
 }
@@ -532,11 +517,6 @@ impl LocalsForNode {
             (&LocalsForNode::ForGuard { for_arm_body: local_id, .. }, ForGuard::OutsideGuard) =>
                 local_id,
 
-            (&LocalsForNode::ForGuard { ref vals_for_guard, .. },
-             ForGuard::ValWithinGuard(pat_idx)) =>
-                vals_for_guard[pat_idx],
-
-            (&LocalsForNode::One(_), ForGuard::ValWithinGuard(_)) |
             (&LocalsForNode::One(_), ForGuard::RefWithinGuard) =>
                 bug!("anything with one local should never be within a guard."),
         }
@@ -941,7 +921,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                     }
                     _ => {
                         scope = self.declare_bindings(scope, ast_body.span,
-                                                      LintLevel::Inherited, &[pattern.clone()],
+                                                      LintLevel::Inherited, &pattern,
                                                       matches::ArmHasGuard(false),
                                                       Some((Some(&place), span)));
                         unpack!(block = self.place_into_pattern(block, pattern, &place, false));

--- a/src/librustc_mir/diagnostics.rs
+++ b/src/librustc_mir/diagnostics.rs
@@ -1978,8 +1978,8 @@ could cause the match to be non-exhaustive:
 let mut x = Some(0);
 match x {
     None => (),
-    Some(v) if { x = None; false } => (),
-    Some(_) => (), // No longer matches
+    Some(_) if { x = None; false } => (),
+    Some(v) => (), // No longer matches
 }
 ```
 

--- a/src/librustc_mir/hair/cx/expr.rs
+++ b/src/librustc_mir/hair/cx/expr.rs
@@ -611,7 +611,7 @@ fn make_mirror_unadjusted<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
         }
         hir::ExprKind::Match(ref discr, ref arms, _) => {
             ExprKind::Match {
-                discriminant: discr.to_ref(),
+                scrutinee: discr.to_ref(),
                 arms: arms.iter().map(|a| convert_arm(cx, a)).collect(),
             }
         }

--- a/src/librustc_mir/hair/mod.rs
+++ b/src/librustc_mir/hair/mod.rs
@@ -203,7 +203,7 @@ pub enum ExprKind<'tcx> {
         body: ExprRef<'tcx>,
     },
     Match {
-        discriminant: ExprRef<'tcx>,
+        scrutinee: ExprRef<'tcx>,
         arms: Vec<Arm<'tcx>>,
     },
     Block {

--- a/src/librustc_mir/transform/cleanup_post_borrowck.rs
+++ b/src/librustc_mir/transform/cleanup_post_borrowck.rs
@@ -1,9 +1,9 @@
-//! This module provides two passes:
+//! This module provides a pass to replacing the following statements with
+//! [`Nop`]s
 //!
-//!   - [`CleanAscribeUserType`], that replaces all [`AscribeUserType`]
-//!     statements with [`Nop`].
-//!   - [`CleanFakeReadsAndBorrows`], that replaces all [`FakeRead`] statements
-//!     and borrows that are read by [`ForMatchGuard`] fake reads with [`Nop`].
+//!   - [`AscribeUserType`]
+//!   - [`FakeRead`]
+//!   - [`Assign`] statements with a [`Shallow`] borrow
 //!
 //! The `CleanFakeReadsAndBorrows` "pass" is actually implemented as two
 //! traversals (aka visits) of the input MIR. The first traversal,
@@ -11,102 +11,41 @@
 //! temporaries read by [`ForMatchGuard`] reads, and [`DeleteFakeBorrows`]
 //! deletes the initialization of those temporaries.
 //!
-//! [`CleanAscribeUserType`]: cleanup_post_borrowck::CleanAscribeUserType
-//! [`CleanFakeReadsAndBorrows`]: cleanup_post_borrowck::CleanFakeReadsAndBorrows
-//! [`DeleteAndRecordFakeReads`]: cleanup_post_borrowck::DeleteAndRecordFakeReads
-//! [`DeleteFakeBorrows`]: cleanup_post_borrowck::DeleteFakeBorrows
 //! [`AscribeUserType`]: rustc::mir::StatementKind::AscribeUserType
-//! [`Nop`]: rustc::mir::StatementKind::Nop
+//! [`Shallow`]: rustc::mir::BorrowKind::Shallow
 //! [`FakeRead`]: rustc::mir::StatementKind::FakeRead
-//! [`ForMatchGuard`]: rustc::mir::FakeReadCause::ForMatchGuard
+//! [`Nop`]: rustc::mir::StatementKind::Nop
 
-use rustc_data_structures::fx::FxHashSet;
-
-use rustc::mir::{BasicBlock, FakeReadCause, Local, Location, Mir, Place};
+use rustc::mir::{BasicBlock, BorrowKind, Rvalue, Location, Mir};
 use rustc::mir::{Statement, StatementKind};
 use rustc::mir::visit::MutVisitor;
 use rustc::ty::TyCtxt;
 use crate::transform::{MirPass, MirSource};
 
-pub struct CleanAscribeUserType;
+pub struct CleanupNonCodegenStatements;
 
-pub struct DeleteAscribeUserType;
+pub struct DeleteNonCodegenStatements;
 
-impl MirPass for CleanAscribeUserType {
+impl MirPass for CleanupNonCodegenStatements {
     fn run_pass<'a, 'tcx>(&self,
                           _tcx: TyCtxt<'a, 'tcx, 'tcx>,
                           _source: MirSource<'tcx>,
                           mir: &mut Mir<'tcx>) {
-        let mut delete = DeleteAscribeUserType;
+        let mut delete = DeleteNonCodegenStatements;
         delete.visit_mir(mir);
     }
 }
 
-impl<'tcx> MutVisitor<'tcx> for DeleteAscribeUserType {
+impl<'tcx> MutVisitor<'tcx> for DeleteNonCodegenStatements {
     fn visit_statement(&mut self,
                        block: BasicBlock,
                        statement: &mut Statement<'tcx>,
                        location: Location) {
-        if let StatementKind::AscribeUserType(..) = statement.kind {
-            statement.make_nop();
-        }
-        self.super_statement(block, statement, location);
-    }
-}
-
-pub struct CleanFakeReadsAndBorrows;
-
-#[derive(Default)]
-pub struct DeleteAndRecordFakeReads {
-    fake_borrow_temporaries: FxHashSet<Local>,
-}
-
-pub struct DeleteFakeBorrows {
-    fake_borrow_temporaries: FxHashSet<Local>,
-}
-
-// Removes any FakeReads from the MIR
-impl MirPass for CleanFakeReadsAndBorrows {
-    fn run_pass<'a, 'tcx>(&self,
-                          _tcx: TyCtxt<'a, 'tcx, 'tcx>,
-                          _source: MirSource<'tcx>,
-                          mir: &mut Mir<'tcx>) {
-        let mut delete_reads = DeleteAndRecordFakeReads::default();
-        delete_reads.visit_mir(mir);
-        let mut delete_borrows = DeleteFakeBorrows {
-            fake_borrow_temporaries: delete_reads.fake_borrow_temporaries,
-        };
-        delete_borrows.visit_mir(mir);
-    }
-}
-
-impl<'tcx> MutVisitor<'tcx> for DeleteAndRecordFakeReads {
-    fn visit_statement(&mut self,
-                       block: BasicBlock,
-                       statement: &mut Statement<'tcx>,
-                       location: Location) {
-        if let StatementKind::FakeRead(cause, ref place) = statement.kind {
-            if let FakeReadCause::ForMatchGuard = cause {
-                match *place {
-                    Place::Local(local) => self.fake_borrow_temporaries.insert(local),
-                    _ => bug!("Fake match guard read of non-local: {:?}", place),
-                };
-            }
-            statement.make_nop();
-        }
-        self.super_statement(block, statement, location);
-    }
-}
-
-impl<'tcx> MutVisitor<'tcx> for DeleteFakeBorrows {
-    fn visit_statement(&mut self,
-                       block: BasicBlock,
-                       statement: &mut Statement<'tcx>,
-                       location: Location) {
-        if let StatementKind::Assign(Place::Local(local), _) = statement.kind {
-            if self.fake_borrow_temporaries.contains(&local) {
-                statement.make_nop();
-            }
+        match statement.kind {
+            StatementKind::AscribeUserType(..)
+            | StatementKind::Assign(_, box Rvalue::Ref(_, BorrowKind::Shallow, _))
+            | StatementKind::FakeRead(..) => statement.make_nop(),
+            _ => (),
         }
         self.super_statement(block, statement, location);
     }

--- a/src/librustc_mir/transform/mod.rs
+++ b/src/librustc_mir/transform/mod.rs
@@ -241,15 +241,11 @@ fn optimized_mir<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) -> &'tcx 
 
     let mut mir = tcx.mir_validated(def_id).steal();
     run_passes(tcx, &mut mir, InstanceDef::Item(def_id), MirPhase::Optimized, &[
-        // Remove all things not needed by analysis
+        // Remove all things only needed by analysis
         &no_landing_pads::NoLandingPads,
         &simplify_branches::SimplifyBranches::new("initial"),
         &remove_noop_landing_pads::RemoveNoopLandingPads,
-        // Remove all `AscribeUserType` statements.
-        &cleanup_post_borrowck::CleanAscribeUserType,
-        // Remove all `FakeRead` statements and the borrows that are only
-        // used for checking matches
-        &cleanup_post_borrowck::CleanFakeReadsAndBorrows,
+        &cleanup_post_borrowck::CleanupNonCodegenStatements,
 
         &simplify::SimplifyCfg::new("early-opt"),
 

--- a/src/test/codegen/match.rs
+++ b/src/test/codegen/match.rs
@@ -14,12 +14,12 @@ pub fn exhaustive_match(e: E, unit: ()) {
 // CHECK-NEXT: i[[TY:[0-9]+]] [[DISCR:[0-9]+]], label %[[A:[a-zA-Z0-9_]+]]
 // CHECK-NEXT: i[[TY:[0-9]+]] [[DISCR:[0-9]+]], label %[[B:[a-zA-Z0-9_]+]]
 // CHECK-NEXT: ]
+// CHECK: [[OTHERWISE]]:
+// CHECK-NEXT: unreachable
 // CHECK: [[A]]:
 // CHECK-NEXT: br label %[[EXIT:[a-zA-Z0-9_]+]]
 // CHECK: [[B]]:
 // CHECK-NEXT: br label %[[EXIT:[a-zA-Z0-9_]+]]
-// CHECK: [[OTHERWISE]]:
-// CHECK-NEXT: unreachable
     match e {
         E::A => unit,
         E::B => unit,

--- a/src/test/mir-opt/issue-49232.rs
+++ b/src/test/mir-opt/issue-49232.rs
@@ -47,10 +47,10 @@ fn main() {
 //         resume;
 //     }
 //     bb5: {
-//         falseEdges -> [real: bb12, imaginary: bb6];
+//         falseEdges -> [real: bb11, imaginary: bb6];
 //     }
 //     bb6: {
-//         falseEdges -> [real: bb14, imaginary: bb7];
+//         falseEdges -> [real: bb13, imaginary: bb7];
 //     }
 //     bb7: {
 //         unreachable;
@@ -62,41 +62,41 @@ fn main() {
 //         goto -> bb5;
 //     }
 //     bb10: {
+//         _2 = const 4i32;
+//         goto -> bb18;
+//     }
+//     bb11: {
+//         goto -> bb10;
+//     }
+//     bb12: {
+//         _0 = ();
+//         goto -> bb14;
+//     }
+//     bb13: {
+//         goto -> bb12;
+//     }
+//     bb14: {
+//         StorageDead(_3);
+//         goto -> bb15;
+//     }
+//     bb15: {
+//         StorageDead(_2);
+//         goto -> bb2;
+//     }
+//     bb16: {
+//         _4 = ();
+//         unreachable;
+//     }
+//     bb17: {
+//         StorageDead(_4);
+//         goto -> bb18;
+//     }
+//     bb18: {
 //         FakeRead(ForLet, _2);
 //         StorageDead(_3);
 //         StorageLive(_6);
 //         _6 = &_2;
 //         _5 = const std::mem::drop(move _6) -> [return: bb19, unwind: bb4];
-//     }
-//     bb11: {
-//         _2 = const 4i32;
-//         goto -> bb10;
-//     }
-//     bb12: {
-//         goto -> bb11;
-//     }
-//     bb13: {
-//         _0 = ();
-//         goto -> bb15;
-//     }
-//     bb14: {
-//         goto -> bb13;
-//     }
-//     bb15: {
-//         StorageDead(_3);
-//         goto -> bb16;
-//     }
-//     bb16: {
-//         StorageDead(_2);
-//         goto -> bb2;
-//     }
-//     bb17: {
-//         _4 = ();
-//         unreachable;
-//     }
-//     bb18: {
-//         StorageDead(_4);
-//         goto -> bb10;
 //     }
 //     bb19: {
 //         StorageDead(_6);

--- a/src/test/mir-opt/issue-49232.rs
+++ b/src/test/mir-opt/issue-49232.rs
@@ -41,46 +41,46 @@ fn main() {
 //         StorageLive(_3);
 //         _3 = const true;
 //         FakeRead(ForMatchedPlace, _3);
-//         switchInt(_3) -> [false: bb11, otherwise: bb10];
+//         switchInt(_3) -> [false: bb9, otherwise: bb8];
 //     }
 //     bb4: {
 //         resume;
 //     }
 //     bb5: {
-//         _2 = const 4i32;
-//         goto -> bb14;
+//         falseEdges -> [real: bb12, imaginary: bb6];
 //     }
 //     bb6: {
-//         _0 = ();
-//         goto -> bb15;
+//         falseEdges -> [real: bb14, imaginary: bb7];
 //     }
 //     bb7: {
-//         falseEdges -> [real: bb12, imaginary: bb8];
-//     }
-//     bb8: {
-//         falseEdges -> [real: bb13, imaginary: bb9];
-//     }
-//     bb9: {
 //         unreachable;
 //     }
-//     bb10: {
-//         goto -> bb8;
-//     }
-//     bb11: {
-//         goto -> bb7;
-//     }
-//     bb12: {
-//         goto -> bb5;
-//     }
-//     bb13: {
+//     bb8: {
 //         goto -> bb6;
 //     }
-//     bb14: {
+//     bb9: {
+//         goto -> bb5;
+//     }
+//     bb10: {
 //         FakeRead(ForLet, _2);
 //         StorageDead(_3);
 //         StorageLive(_6);
 //         _6 = &_2;
 //         _5 = const std::mem::drop(move _6) -> [return: bb19, unwind: bb4];
+//     }
+//     bb11: {
+//         _2 = const 4i32;
+//         goto -> bb10;
+//     }
+//     bb12: {
+//         goto -> bb11;
+//     }
+//     bb13: {
+//         _0 = ();
+//         goto -> bb15;
+//     }
+//     bb14: {
+//         goto -> bb13;
 //     }
 //     bb15: {
 //         StorageDead(_3);
@@ -96,7 +96,7 @@ fn main() {
 //     }
 //     bb18: {
 //         StorageDead(_4);
-//         goto -> bb14;
+//         goto -> bb10;
 //     }
 //     bb19: {
 //         StorageDead(_6);

--- a/src/test/mir-opt/match_false_edges.rs
+++ b/src/test/mir-opt/match_false_edges.rs
@@ -51,13 +51,13 @@ fn main() {
 //      resume;
 //  }
 //  bb2: {
-//      falseEdges -> [real: bb9, imaginary: bb3]; //pre_binding1
+//      falseEdges -> [real: bb8, imaginary: bb3]; //pre_binding1
 //  }
 //  bb3: {
-//      falseEdges -> [real: bb12, imaginary: bb4]; //pre_binding2
+//      falseEdges -> [real: bb11, imaginary: bb4]; //pre_binding2
 //  }
 //  bb4: {
-//      falseEdges -> [real: bb13, imaginary: bb5]; //pre_binding3
+//      falseEdges -> [real: bb12, imaginary: bb5]; //pre_binding3
 //  }
 //  bb5: {
 //      unreachable;
@@ -68,43 +68,43 @@ fn main() {
 //  bb7: {
 //      unreachable;
 //  }
-//  bb8: {
-//      ...
-//      return;
-//  }
-//  bb9: { // binding1 and guard
+//  bb8: { // binding1 and guard
 //      StorageLive(_6);
 //      _6 = &(((promoted[1]: std::option::Option<i32>) as Some).0: i32);
 //      _4 = &shallow (promoted[0]: std::option::Option<i32>);
 //      StorageLive(_7);
-//      _7 = const guard() -> [return: bb10, unwind: bb1];
+//      _7 = const guard() -> [return: bb9, unwind: bb1];
 //  }
-//  bb10: {
+//  bb9: {
 //      FakeRead(ForMatchGuard, _4);
 //      FakeRead(ForGuardBinding, _6);
-//      switchInt(move _7) -> [false: bb6, otherwise: bb11];
+//      switchInt(move _7) -> [false: bb6, otherwise: bb10];
 //  }
-//  bb11: {
+//  bb10: {
 //      StorageLive(_5);
 //      _5 = ((_2 as Some).0: i32);
 //      StorageLive(_8);
 //      _8 = _5;
 //      _1 = (const 1i32, move _8);
 //      StorageDead(_8);
-//      goto -> bb8;
+//      goto -> bb13;
 //  }
-//  bb12: {
+//  bb11: {
 //      StorageLive(_9);
 //      _9 = ((_2 as Some).0: i32);
 //      StorageLive(_10);
 //      _10 = _9;
 //      _1 = (const 2i32, move _10);
 //      StorageDead(_10);
-//      goto -> bb8;
+//      goto -> bb13;
+//  }
+//  bb12: {
+//      _1 = (const 3i32, const 3i32);
+//      goto -> bb13;
 //  }
 //  bb13: {
-//      _1 = (const 3i32, const 3i32);
-//      goto -> bb8;
+//      ...
+//      return;
 //  }
 // END rustc.full_tested_match.QualifyAndPromoteConstants.after.mir
 //
@@ -120,13 +120,13 @@ fn main() {
 //      resume;
 //  }
 //  bb2: {
-//      falseEdges -> [real: bb9, imaginary: bb3];
+//      falseEdges -> [real: bb8, imaginary: bb3];
 //  }
 //  bb3: {
-//      falseEdges -> [real: bb12, imaginary: bb4];
+//      falseEdges -> [real: bb11, imaginary: bb4];
 //  }
 //  bb4: {
-//      falseEdges -> [real: bb13, imaginary: bb5];
+//      falseEdges -> [real: bb12, imaginary: bb5];
 //  }
 //  bb5: {
 //      unreachable;
@@ -137,43 +137,43 @@ fn main() {
 //  bb7: {
 //      unreachable;
 //  }
-//  bb8: {
-//      ...
-//      return;
-//  }
-//  bb9: { // binding1 and guard
+//  bb8: { // binding1 and guard
 //      StorageLive(_6);
 //      _6 = &((_2 as Some).0: i32);
 //      _4 = &shallow _2;
 //      StorageLive(_7);
-//      _7 = const guard() -> [return: bb10, unwind: bb1];
+//      _7 = const guard() -> [return: bb9, unwind: bb1];
 //  }
-//  bb10: { // end of guard
+//  bb9: { // end of guard
 //      FakeRead(ForMatchGuard, _4);
 //      FakeRead(ForGuardBinding, _6);
-//      switchInt(move _7) -> [false: bb6, otherwise: bb11];
+//      switchInt(move _7) -> [false: bb6, otherwise: bb10];
 //  }
-//  bb11: { // arm1
+//  bb10: { // arm1
 //      StorageLive(_5);
 //      _5 = ((_2 as Some).0: i32);
 //      StorageLive(_8);
 //      _8 = _5;
 //      _1 = (const 1i32, move _8);
 //      StorageDead(_8);
-//      goto -> bb8;
+//      goto -> bb13;
 //  }
-//  bb12: { // arm2
+//  bb11: { // arm2
 //      _1 = (const 3i32, const 3i32);
-//      goto -> bb8;
+//      goto -> bb13;
 //  }
-//  bb13: { // binding3 and arm3
+//  bb12: { // binding3 and arm3
 //      StorageLive(_9);
 //      _9 = ((_2 as Some).0: i32);
 //      StorageLive(_10);
 //      _10 = _9;
 //      _1 = (const 2i32, move _10);
 //      StorageDead(_10);
-//      goto -> bb8;
+//      goto -> bb13;
+//  }
+//  bb13: {
+//      ...
+//      return;
 //  }
 // END rustc.full_tested_match2.QualifyAndPromoteConstants.before.mir
 //
@@ -189,79 +189,79 @@ fn main() {
 //      resume;
 //  }
 //  bb2: {
-//      falseEdges -> [real: bb10, imaginary: bb3]; //pre_binding1
+//      falseEdges -> [real: bb9, imaginary: bb3];
 //  }
 //  bb3: {
-//      falseEdges -> [real: bb13, imaginary: bb4]; //pre_binding2
+//      falseEdges -> [real: bb12, imaginary: bb4];
 //  }
 //  bb4: {
-//      falseEdges -> [real: bb14, imaginary: bb5]; //pre_binding3
+//      falseEdges -> [real: bb13, imaginary: bb5];
 //  }
 //  bb5: {
-//      falseEdges -> [real: bb17, imaginary: bb6]; //pre_binding4
+//      falseEdges -> [real: bb16, imaginary: bb6];
 //  }
 //  bb6: {
 //      unreachable;
 //  }
-//  bb7: { // to pre_binding2
+//  bb7: {
 //      falseEdges -> [real: bb3, imaginary: bb3];
 //  }
-//  bb8: { // to pre_binding4
+//  bb8: {
 //      falseEdges -> [real: bb5, imaginary: bb5];
 //  }
-//  bb9: {
-//      ...
-//      return;
-//  }
-//  bb10: { // binding1: Some(w) if guard()
+//  bb9: { // binding1: Some(w) if guard()
 //      StorageLive(_7);
 //      _7 = &((_2 as Some).0: i32);
 //      _5 = &shallow _2;
 //      StorageLive(_8);
-//      _8 = const guard() -> [return: bb11, unwind: bb1];
+//      _8 = const guard() -> [return: bb10, unwind: bb1];
 //  }
-//  bb11: { //end of guard
+//  bb10: { //end of guard
 //      FakeRead(ForMatchGuard, _5);
 //      FakeRead(ForGuardBinding, _7);
-//      switchInt(move _8) -> [false: bb7, otherwise: bb12];
+//      switchInt(move _8) -> [false: bb7, otherwise: bb11];
 //  }
-//  bb12: { // set up bindings for arm1
+//  bb11: { // set up bindings for arm1
 //      StorageLive(_6);
 //      _6 = ((_2 as Some).0: i32);
 //      _1 = const 1i32;
-//      goto -> bb9;
+//      goto -> bb17;
 //  }
-//  bb13: { // binding2 & arm2
+//  bb12: { // binding2 & arm2
 //      StorageLive(_9);
 //      _9 = _2;
 //      _1 = const 2i32;
-//      goto -> bb9;
+//      goto -> bb17;
 //  }
-//  bb14: { // binding3: Some(y) if guard2(y)
+//  bb13: { // binding3: Some(y) if guard2(y)
 //      StorageLive(_11);
 //      _11 = &((_2 as Some).0: i32);
 //      _5 = &shallow _2;
 //      StorageLive(_12);
 //      StorageLive(_13);
 //      _13 = (*_11);
-//      _12 = const guard2(move _13) -> [return: bb15, unwind: bb1];
+//      _12 = const guard2(move _13) -> [return: bb14, unwind: bb1];
 //  }
-//  bb15: { // end of guard2
+//  bb14: { // end of guard2
 //      StorageDead(_13);
 //      FakeRead(ForMatchGuard, _5);
 //      FakeRead(ForGuardBinding, _11);
-//      switchInt(move _12) -> [false: bb8, otherwise: bb16];
+//      switchInt(move _12) -> [false: bb8, otherwise: bb15];
 //  }
-//  bb16: { // binding4 & arm4
+//  bb15: { // binding4 & arm4
 //      StorageLive(_10);
 //      _10 = ((_2 as Some).0: i32);
 //      _1 = const 3i32;
-//      goto -> bb9;
+//      goto -> bb17;
 //  }
-//  bb17: {
+//  bb16: {
 //      StorageLive(_14);
 //      _14 = _2;
 //      _1 = const 4i32;
-//      goto -> bb9;
+//      goto -> bb17;
+//  }
+//  bb17: {
+//      ...
+//      return;
 //  }
 // END rustc.main.QualifyAndPromoteConstants.before.mir

--- a/src/test/mir-opt/match_false_edges.rs
+++ b/src/test/mir-opt/match_false_edges.rs
@@ -73,34 +73,33 @@ fn main() {
 //      return;
 //  }
 //  bb9: { // binding1 and guard
-//      StorageLive(_8);
-//      _8 = &(((promoted[2]: std::option::Option<i32>) as Some).0: i32);
-//      _4 = &shallow (promoted[1]: std::option::Option<i32>);
-//      _5 = &(((promoted[0]: std::option::Option<i32>) as Some).0: i32);
-//      StorageLive(_9);
-//      _9 = const guard() -> [return: bb10, unwind: bb1];
+//      StorageLive(_6);
+//      _6 = &(((promoted[1]: std::option::Option<i32>) as Some).0: i32);
+//      _4 = &shallow (promoted[0]: std::option::Option<i32>);
+//      StorageLive(_7);
+//      _7 = const guard() -> [return: bb10, unwind: bb1];
 //  }
 //  bb10: {
 //      FakeRead(ForMatchGuard, _4);
-//      FakeRead(ForMatchGuard, _5);
-//      switchInt(move _9) -> [false: bb6, otherwise: bb11];
+//      FakeRead(ForGuardBinding, _6);
+//      switchInt(move _7) -> [false: bb6, otherwise: bb11];
 //  }
 //  bb11: {
-//      StorageLive(_6);
-//      _6 = ((_2 as Some).0: i32);
-//      StorageLive(_10);
-//      _10 = _6;
-//      _1 = (const 1i32, move _10);
-//      StorageDead(_10);
+//      StorageLive(_5);
+//      _5 = ((_2 as Some).0: i32);
+//      StorageLive(_8);
+//      _8 = _5;
+//      _1 = (const 1i32, move _8);
+//      StorageDead(_8);
 //      goto -> bb8;
 //  }
 //  bb12: {
-//      StorageLive(_11);
-//      _11 = ((_2 as Some).0: i32);
-//      StorageLive(_12);
-//      _12 = _11;
-//      _1 = (const 2i32, move _12);
-//      StorageDead(_12);
+//      StorageLive(_9);
+//      _9 = ((_2 as Some).0: i32);
+//      StorageLive(_10);
+//      _10 = _9;
+//      _1 = (const 2i32, move _10);
+//      StorageDead(_10);
 //      goto -> bb8;
 //  }
 //  bb13: {
@@ -143,25 +142,24 @@ fn main() {
 //      return;
 //  }
 //  bb9: { // binding1 and guard
-//      StorageLive(_8);
-//      _8 = &((_2 as Some).0: i32);
+//      StorageLive(_6);
+//      _6 = &((_2 as Some).0: i32);
 //      _4 = &shallow _2;
-//      _5 = &((_2 as Some).0: i32);
-//      StorageLive(_9);
-//      _9 = const guard() -> [return: bb10, unwind: bb1];
+//      StorageLive(_7);
+//      _7 = const guard() -> [return: bb10, unwind: bb1];
 //  }
 //  bb10: { // end of guard
 //      FakeRead(ForMatchGuard, _4);
-//      FakeRead(ForMatchGuard, _5);
-//      switchInt(move _9) -> [false: bb6, otherwise: bb11];
+//      FakeRead(ForGuardBinding, _6);
+//      switchInt(move _7) -> [false: bb6, otherwise: bb11];
 //  }
 //  bb11: { // arm1
-//      StorageLive(_6);
-//      _6 = ((_2 as Some).0: i32);
-//      StorageLive(_10);
-//      _10 = _6;
-//      _1 = (const 1i32, move _10);
-//      StorageDead(_10);
+//      StorageLive(_5);
+//      _5 = ((_2 as Some).0: i32);
+//      StorageLive(_8);
+//      _8 = _5;
+//      _1 = (const 1i32, move _8);
+//      StorageDead(_8);
 //      goto -> bb8;
 //  }
 //  bb12: { // arm2
@@ -169,12 +167,12 @@ fn main() {
 //      goto -> bb8;
 //  }
 //  bb13: { // binding3 and arm3
-//      StorageLive(_11);
-//      _11 = ((_2 as Some).0: i32);
-//      StorageLive(_12);
-//      _12 = _11;
-//      _1 = (const 2i32, move _12);
-//      StorageDead(_12);
+//      StorageLive(_9);
+//      _9 = ((_2 as Some).0: i32);
+//      StorageLive(_10);
+//      _10 = _9;
+//      _1 = (const 2i32, move _10);
+//      StorageDead(_10);
 //      goto -> bb8;
 //  }
 // END rustc.full_tested_match2.QualifyAndPromoteConstants.before.mir
@@ -216,55 +214,53 @@ fn main() {
 //      return;
 //  }
 //  bb10: { // binding1: Some(w) if guard()
-//      StorageLive(_9);
-//      _9 = &((_2 as Some).0: i32);
+//      StorageLive(_7);
+//      _7 = &((_2 as Some).0: i32);
 //      _5 = &shallow _2;
-//      _6 = &((_2 as Some).0: i32);
-//      StorageLive(_10);
-//      _10 = const guard() -> [return: bb11, unwind: bb1];
+//      StorageLive(_8);
+//      _8 = const guard() -> [return: bb11, unwind: bb1];
 //  }
 //  bb11: { //end of guard
 //      FakeRead(ForMatchGuard, _5);
-//      FakeRead(ForMatchGuard, _6);
-//      switchInt(move _10) -> [false: bb7, otherwise: bb12];
+//      FakeRead(ForGuardBinding, _7);
+//      switchInt(move _8) -> [false: bb7, otherwise: bb12];
 //  }
 //  bb12: { // set up bindings for arm1
-//      StorageLive(_7);
-//      _7 = ((_2 as Some).0: i32);
+//      StorageLive(_6);
+//      _6 = ((_2 as Some).0: i32);
 //      _1 = const 1i32;
 //      goto -> bb9;
 //  }
 //  bb13: { // binding2 & arm2
-//      StorageLive(_11);
-//      _11 = _2;
+//      StorageLive(_9);
+//      _9 = _2;
 //      _1 = const 2i32;
 //      goto -> bb9;
 //  }
 //  bb14: { // binding3: Some(y) if guard2(y)
-//      StorageLive(_14);
-//      _14 = &((_2 as Some).0: i32);
+//      StorageLive(_11);
+//      _11 = &((_2 as Some).0: i32);
 //      _5 = &shallow _2;
-//      _6 = &((_2 as Some).0: i32);
-//      StorageLive(_15);
-//      StorageLive(_16);
-//      _16 = (*_14);
-//      _15 = const guard2(move _16) -> [return: bb15, unwind: bb1];
+//      StorageLive(_12);
+//      StorageLive(_13);
+//      _13 = (*_11);
+//      _12 = const guard2(move _13) -> [return: bb15, unwind: bb1];
 //  }
 //  bb15: { // end of guard2
-//      StorageDead(_16);
+//      StorageDead(_13);
 //      FakeRead(ForMatchGuard, _5);
-//      FakeRead(ForMatchGuard, _6);
-//      switchInt(move _15) -> [false: bb8, otherwise: bb16];
+//      FakeRead(ForGuardBinding, _11);
+//      switchInt(move _12) -> [false: bb8, otherwise: bb16];
 //  }
 //  bb16: { // binding4 & arm4
-//      StorageLive(_12);
-//      _12 = ((_2 as Some).0: i32);
+//      StorageLive(_10);
+//      _10 = ((_2 as Some).0: i32);
 //      _1 = const 3i32;
 //      goto -> bb9;
 //  }
 //  bb17: {
-//      StorageLive(_17);
-//      _17 = _2;
+//      StorageLive(_14);
+//      _14 = _2;
 //      _1 = const 4i32;
 //      goto -> bb9;
 //  }

--- a/src/test/mir-opt/match_false_edges.rs
+++ b/src/test/mir-opt/match_false_edges.rs
@@ -44,72 +44,68 @@ fn main() {
 //      ...
 //      _2 = std::option::Option<i32>::Some(const 42i32,);
 //      FakeRead(ForMatchedPlace, _2);
-//      _7 = discriminant(_2);
-//      _9 = &shallow (promoted[2]: std::option::Option<i32>);
-//      _10 = &(((promoted[1]: std::option::Option<i32>) as Some).0: i32);
-//      switchInt(move _7) -> [0isize: bb5, 1isize: bb3, otherwise: bb7];
+//      _3 = discriminant(_2);
+//      switchInt(move _3) -> [0isize: bb4, 1isize: bb2, otherwise: bb7];
 //  }
 //  bb1: {
 //      resume;
 //  }
-//  bb2: {  // arm1
-//      _1 = (const 3i32, const 3i32);
-//      goto -> bb13;
+//  bb2: {
+//      falseEdges -> [real: bb9, imaginary: bb3]; //pre_binding1
 //  }
-//  bb3: { // binding3(empty) and arm3
-//      FakeRead(ForMatchGuard, _9);
-//      FakeRead(ForMatchGuard, _10);
-//      falseEdges -> [real: bb8, imaginary: bb4]; //pre_binding1
+//  bb3: {
+//      falseEdges -> [real: bb12, imaginary: bb4]; //pre_binding2
 //  }
 //  bb4: {
-//      FakeRead(ForMatchGuard, _9);
-//      FakeRead(ForMatchGuard, _10);
-//      falseEdges -> [real: bb12, imaginary: bb5]; //pre_binding2
+//      falseEdges -> [real: bb13, imaginary: bb5]; //pre_binding3
 //  }
 //  bb5: {
-//      FakeRead(ForMatchGuard, _9);
-//      FakeRead(ForMatchGuard, _10);
-//      falseEdges -> [real: bb2, imaginary: bb6]; //pre_binding3
-//  }
-//  bb6: {
 //      unreachable;
+//  }
+//  bb6: { // to pre_binding2
+//      falseEdges -> [real: bb3, imaginary: bb3];
 //  }
 //  bb7: {
 //      unreachable;
 //  }
-//  bb8: { // binding1 and guard
-//      StorageLive(_5);
-//      _5 = &(((promoted[0]: std::option::Option<i32>) as Some).0: i32);
-//      StorageLive(_8);
-//      _8 = const guard() -> [return: bb9, unwind: bb1];
-//  }
-//  bb9: {
-//      switchInt(move _8) -> [false: bb10, otherwise: bb11];
-//  }
-//  bb10: { // to pre_binding2
-//      falseEdges -> [real: bb4, imaginary: bb4];
-//  }
-//  bb11: { // bindingNoLandingPads.before.mir2 and arm2
-//      StorageLive(_3);
-//      _3 = ((_2 as Some).0: i32);
-//      StorageLive(_11);
-//      _11 = _3;
-//      _1 = (const 1i32, move _11);
-//      StorageDead(_11);
-//      goto -> bb13;
-//  }
-//  bb12: {
-//      StorageLive(_6);
-//      _6 = ((_2 as Some).0: i32);
-//      StorageLive(_12);
-//      _12 = _6;
-//      _1 = (const 2i32, move_12);
-//      StorageDead(_12);
-//      goto -> bb13;
-//  }
-//  bb13: {
+//  bb8: {
 //      ...
 //      return;
+//  }
+//  bb9: { // binding1 and guard
+//      StorageLive(_8);
+//      _8 = &(((promoted[2]: std::option::Option<i32>) as Some).0: i32);
+//      _4 = &shallow (promoted[1]: std::option::Option<i32>);
+//      _5 = &(((promoted[0]: std::option::Option<i32>) as Some).0: i32);
+//      StorageLive(_9);
+//      _9 = const guard() -> [return: bb10, unwind: bb1];
+//  }
+//  bb10: {
+//      FakeRead(ForMatchGuard, _4);
+//      FakeRead(ForMatchGuard, _5);
+//      switchInt(move _9) -> [false: bb6, otherwise: bb11];
+//  }
+//  bb11: {
+//      StorageLive(_6);
+//      _6 = ((_2 as Some).0: i32);
+//      StorageLive(_10);
+//      _10 = _6;
+//      _1 = (const 1i32, move _10);
+//      StorageDead(_10);
+//      goto -> bb8;
+//  }
+//  bb12: {
+//      StorageLive(_11);
+//      _11 = ((_2 as Some).0: i32);
+//      StorageLive(_12);
+//      _12 = _11;
+//      _1 = (const 2i32, move _12);
+//      StorageDead(_12);
+//      goto -> bb8;
+//  }
+//  bb13: {
+//      _1 = (const 3i32, const 3i32);
+//      goto -> bb8;
 //  }
 // END rustc.full_tested_match.QualifyAndPromoteConstants.after.mir
 //
@@ -118,164 +114,158 @@ fn main() {
 //      ...
 //      _2 = std::option::Option<i32>::Some(const 42i32,);
 //      FakeRead(ForMatchedPlace, _2);
-//      _7 = discriminant(_2);
-//      _9 = &shallow _2;
-//      _10 = &((_2 as Some).0: i32);
-//      switchInt(move _7) -> [0isize: bb4, 1isize: bb3, otherwise: bb7];
+//      _3 = discriminant(_2);
+//      switchInt(move _3) -> [0isize: bb3, 1isize: bb2, otherwise: bb7];
 //  }
 //  bb1: {
 //      resume;
 //  }
-//  bb2: { // arm2
-//      _1 = (const 3i32, const 3i32);
-//      goto -> bb13;
+//  bb2: {
+//      falseEdges -> [real: bb9, imaginary: bb3];
 //  }
 //  bb3: {
-//      FakeRead(ForMatchGuard, _9);
-//      FakeRead(ForMatchGuard, _10);
-//      falseEdges -> [real: bb8, imaginary: bb4]; //pre_binding1
+//      falseEdges -> [real: bb12, imaginary: bb4];
 //  }
 //  bb4: {
-//      FakeRead(ForMatchGuard, _9);
-//      FakeRead(ForMatchGuard, _10);
-//      falseEdges -> [real: bb2, imaginary: bb5]; //pre_binding2
+//      falseEdges -> [real: bb13, imaginary: bb5];
 //  }
 //  bb5: {
-//      FakeRead(ForMatchGuard, _9);
-//      FakeRead(ForMatchGuard, _10);
-//      falseEdges -> [real: bb12, imaginary: bb6]; //pre_binding3
-//  }
-//  bb6: {
 //      unreachable;
+//  }
+//  bb6: { // to pre_binding3 (can skip 2 since this is `Some`)
+//      falseEdges -> [real: bb4, imaginary: bb3];
 //  }
 //  bb7: {
 //      unreachable;
 //  }
-//  bb8: { // binding1 and guard
-//      StorageLive(_5);
-//      _5 = &((_2 as Some).0: i32);
-//      StorageLive(_8);
-//      _8 = const guard() -> [return: bb9, unwind: bb1];
-//  }
-//  bb9: { // end of guard
-//      switchInt(move _8) -> [false: bb10, otherwise: bb11];
-//  }
-//  bb10: { // to pre_binding3 (can skip 2 since this is `Some`)
-//      falseEdges -> [real: bb5, imaginary: bb4];
-//  }
-//  bb11: { // arm1
-//      StorageLive(_3);
-//      _3 = ((_2 as Some).0: i32);
-//      StorageLive(_11);
-//      _11 = _3;
-//      _1 = (const 1i32, move _11);
-//      StorageDead(_11);
-//      goto -> bb13;
-//  }
-//  bb12: { // binding3 and arm3
-//      StorageLive(_6);
-//      _6 = ((_2 as Some).0: i32);
-//      StorageLive(_12);
-//      _12 = _6;
-//      _1 = (const 2i32, move _12);
-//      StorageDead(_12);
-//      goto -> bb13;
-//  }
-//  bb13: {
+//  bb8: {
 //      ...
 //      return;
+//  }
+//  bb9: { // binding1 and guard
+//      StorageLive(_8);
+//      _8 = &((_2 as Some).0: i32);
+//      _4 = &shallow _2;
+//      _5 = &((_2 as Some).0: i32);
+//      StorageLive(_9);
+//      _9 = const guard() -> [return: bb10, unwind: bb1];
+//  }
+//  bb10: { // end of guard
+//      FakeRead(ForMatchGuard, _4);
+//      FakeRead(ForMatchGuard, _5);
+//      switchInt(move _9) -> [false: bb6, otherwise: bb11];
+//  }
+//  bb11: { // arm1
+//      StorageLive(_6);
+//      _6 = ((_2 as Some).0: i32);
+//      StorageLive(_10);
+//      _10 = _6;
+//      _1 = (const 1i32, move _10);
+//      StorageDead(_10);
+//      goto -> bb8;
+//  }
+//  bb12: { // arm2
+//      _1 = (const 3i32, const 3i32);
+//      goto -> bb8;
+//  }
+//  bb13: { // binding3 and arm3
+//      StorageLive(_11);
+//      _11 = ((_2 as Some).0: i32);
+//      StorageLive(_12);
+//      _12 = _11;
+//      _1 = (const 2i32, move _12);
+//      StorageDead(_12);
+//      goto -> bb8;
 //  }
 // END rustc.full_tested_match2.QualifyAndPromoteConstants.before.mir
 //
 // START rustc.main.QualifyAndPromoteConstants.before.mir
 // bb0: {
 //     ...
-//     _2 = std::option::Option<i32>::Some(const 1i32,);
-//     FakeRead(ForMatchedPlace, _2);
-//     _11 = discriminant(_2);
-//    _16 = &shallow _2;
-//    _17 = &((_2 as Some).0: i32);
-//     switchInt(move _11) -> [1isize: bb2, otherwise: bb3];
-// }
-// bb1: {
-//     resume;
-// }
-// bb2: {
-//      FakeRead(ForMatchGuard, _16);
-//      FakeRead(ForMatchGuard, _17);
-//     falseEdges -> [real: bb7, imaginary: bb3]; //pre_binding1
-// }
-// bb3: {
-//      FakeRead(ForMatchGuard, _16);
-//      FakeRead(ForMatchGuard, _17);
-//     falseEdges -> [real: bb11, imaginary: bb4]; //pre_binding2
-// }
-// bb4: {
-//      FakeRead(ForMatchGuard, _16);
-//      FakeRead(ForMatchGuard, _17);
-//     falseEdges -> [real: bb12, imaginary: bb5]; //pre_binding3
-// }
-// bb5: {
-//      FakeRead(ForMatchGuard, _16);
-//      FakeRead(ForMatchGuard, _17);
-//     falseEdges -> [real: bb16, imaginary: bb6]; //pre_binding4
-// }
-// bb6: {
-//     unreachable;
-// }
-// bb7: { // binding1: Some(w) if guard()
-//     StorageLive(_5);
-//     _5 = &((_2 as Some).0: i32);
-//     StorageLive(_12);
-//     _12 = const guard() -> [return: bb8, unwind: bb1];
-// }
-// bb8: { //end of guard
-//     switchInt(move _12) -> [false: bb9, otherwise: bb10];
-// }
-// bb9: { // to pre_binding2
-//     falseEdges -> [real: bb3, imaginary: bb3];
-// }
-// bb10: { // set up bindings for arm1
-//     StorageLive(_3);
-//     _3 = ((_2 as Some).0: i32);
-//     _1 = const 1i32;
-//     goto -> bb17;
-// }
-// bb11: { // binding2 & arm2
-//     StorageLive(_6);
-//     _6 = _2;
-//     _1 = const 2i32;
-//     goto -> bb17;
-// }
-// bb12: { // binding3: Some(y) if guard2(y)
-//     StorageLive(_9);
-//     _9 = &((_2 as Some).0: i32);
-//     StorageLive(_14);
-//     StorageLive(_15);
-//     _15 = (*_9);
-//     _14 = const guard2(move _15) -> [return: bb13, unwind: bb1];
-// }
-// bb13: { // end of guard2
-//     StorageDead(_15);
-//     switchInt(move _14) -> [false: bb14, otherwise: bb15];
-// }
-// bb14: { // to pre_binding4
-//     falseEdges -> [real: bb5, imaginary: bb5];
-// }
-// bb15: { // set up bindings for arm3
-//     StorageLive(_7);
-//     _7 = ((_2 as Some).0: i32);
-//     _1 = const 3i32;
-//     goto -> bb17;
-// }
-// bb16: { // binding4 & arm4
-//     StorageLive(_10);
-//     _10 = _2;
-//     _1 = const 4i32;
-//     goto -> bb17;
-// }
-// bb17: {
-//     ...
-//     return;
-// }
+//      _2 = std::option::Option<i32>::Some(const 1i32,);
+//      FakeRead(ForMatchedPlace, _2);
+//      _3 = discriminant(_2);
+//      switchInt(move _3) -> [1isize: bb2, otherwise: bb3];
+//  }
+//  bb1: {
+//      resume;
+//  }
+//  bb2: {
+//      falseEdges -> [real: bb10, imaginary: bb3]; //pre_binding1
+//  }
+//  bb3: {
+//      falseEdges -> [real: bb13, imaginary: bb4]; //pre_binding2
+//  }
+//  bb4: {
+//      falseEdges -> [real: bb14, imaginary: bb5]; //pre_binding3
+//  }
+//  bb5: {
+//      falseEdges -> [real: bb17, imaginary: bb6]; //pre_binding4
+//  }
+//  bb6: {
+//      unreachable;
+//  }
+//  bb7: { // to pre_binding2
+//      falseEdges -> [real: bb3, imaginary: bb3];
+//  }
+//  bb8: { // to pre_binding4
+//      falseEdges -> [real: bb5, imaginary: bb5];
+//  }
+//  bb9: {
+//      ...
+//      return;
+//  }
+//  bb10: { // binding1: Some(w) if guard()
+//      StorageLive(_9);
+//      _9 = &((_2 as Some).0: i32);
+//      _5 = &shallow _2;
+//      _6 = &((_2 as Some).0: i32);
+//      StorageLive(_10);
+//      _10 = const guard() -> [return: bb11, unwind: bb1];
+//  }
+//  bb11: { //end of guard
+//      FakeRead(ForMatchGuard, _5);
+//      FakeRead(ForMatchGuard, _6);
+//      switchInt(move _10) -> [false: bb7, otherwise: bb12];
+//  }
+//  bb12: { // set up bindings for arm1
+//      StorageLive(_7);
+//      _7 = ((_2 as Some).0: i32);
+//      _1 = const 1i32;
+//      goto -> bb9;
+//  }
+//  bb13: { // binding2 & arm2
+//      StorageLive(_11);
+//      _11 = _2;
+//      _1 = const 2i32;
+//      goto -> bb9;
+//  }
+//  bb14: { // binding3: Some(y) if guard2(y)
+//      StorageLive(_14);
+//      _14 = &((_2 as Some).0: i32);
+//      _5 = &shallow _2;
+//      _6 = &((_2 as Some).0: i32);
+//      StorageLive(_15);
+//      StorageLive(_16);
+//      _16 = (*_14);
+//      _15 = const guard2(move _16) -> [return: bb15, unwind: bb1];
+//  }
+//  bb15: { // end of guard2
+//      StorageDead(_16);
+//      FakeRead(ForMatchGuard, _5);
+//      FakeRead(ForMatchGuard, _6);
+//      switchInt(move _15) -> [false: bb8, otherwise: bb16];
+//  }
+//  bb16: { // binding4 & arm4
+//      StorageLive(_12);
+//      _12 = ((_2 as Some).0: i32);
+//      _1 = const 3i32;
+//      goto -> bb9;
+//  }
+//  bb17: {
+//      StorageLive(_17);
+//      _17 = _2;
+//      _1 = const 4i32;
+//      goto -> bb9;
+//  }
 // END rustc.main.QualifyAndPromoteConstants.before.mir

--- a/src/test/mir-opt/match_test.rs
+++ b/src/test/mir-opt/match_test.rs
@@ -23,16 +23,16 @@ fn main() {
 //        switchInt(move _4) -> [false: bb7, otherwise: bb8];
 //    }
 //    bb1: {
-//        falseEdges -> [real: bb13, imaginary: bb2];
+//        falseEdges -> [real: bb12, imaginary: bb2];
 //    }
 //    bb2: {
-//        falseEdges -> [real: bb14, imaginary: bb3];
+//        falseEdges -> [real: bb13, imaginary: bb3];
 //    }
 //    bb3: {
-//        falseEdges -> [real: bb15, imaginary: bb4];
+//        falseEdges -> [real: bb14, imaginary: bb4];
 //    }
 //    bb4: {
-//        falseEdges -> [real: bb16, imaginary: bb5];
+//        falseEdges -> [real: bb15, imaginary: bb5];
 //    }
 //    bb5: {
 //        unreachable;
@@ -56,31 +56,31 @@ fn main() {
 //        switchInt(move _7) -> [false: bb9, otherwise: bb2];
 //    }
 //    bb11: {
+//        _3 = const 0i32;
+//        goto -> bb16;
+//    }
+//    bb12: {
+//        StorageLive(_8);
+//        _8 = _2;
+//        switchInt(move _8) -> [false: bb6, otherwise: bb11];
+//    }
+//    bb13: {
+//        _3 = const 1i32;
+//        goto -> bb16;
+//    }
+//    bb14: {
+//        _3 = const 2i32;
+//        goto -> bb16;
+//    }
+//    bb15: {
+//        _3 = const 3i32;
+//        goto -> bb16;
+//    }
+//    bb16: {
 //        StorageDead(_8);
 //        _0 = ();
 //        StorageDead(_2);
 //        StorageDead(_1);
 //        return;
-//    }
-//    bb12: {
-//        _3 = const 0i32;
-//        goto -> bb11;
-//    }
-//    bb13: {
-//        StorageLive(_8);
-//        _8 = _2;
-//        switchInt(move _8) -> [false: bb6, otherwise: bb12];
-//    }
-//    bb14: {
-//        _3 = const 1i32;
-//        goto -> bb11;
-//    }
-//    bb15: {
-//        _3 = const 2i32;
-//        goto -> bb11;
-//    }
-//    bb16: {
-//        _3 = const 3i32;
-//        goto -> bb11;
 //    }
 // END rustc.main.SimplifyCfg-initial.after.mir

--- a/src/test/mir-opt/match_test.rs
+++ b/src/test/mir-opt/match_test.rs
@@ -20,66 +20,67 @@ fn main() {
 // START rustc.main.SimplifyCfg-initial.after.mir
 //    bb0: {
 //        ...
-//        _4 = Le(const 0i32, _1);
-//        switchInt(move _4) -> [false: bb10, otherwise: bb11];
+//        switchInt(move _4) -> [false: bb7, otherwise: bb8];
 //    }
 //    bb1: {
-//        _3 = const 0i32;
-//        goto -> bb16;
+//        falseEdges -> [real: bb13, imaginary: bb2];
 //    }
 //    bb2: {
-//        _3 = const 1i32;
-//        goto -> bb16;
+//        falseEdges -> [real: bb14, imaginary: bb3];
 //    }
 //    bb3: {
-//        _3 = const 2i32;
-//        goto -> bb16;
+//        falseEdges -> [real: bb15, imaginary: bb4];
 //    }
 //    bb4: {
-//        _3 = const 3i32;
-//        goto -> bb16;
+//        falseEdges -> [real: bb16, imaginary: bb5];
 //    }
 //    bb5: {
-//        falseEdges -> [real: bb12, imaginary: bb6];
-//    }
-//    bb6: {
-//        falseEdges -> [real: bb2, imaginary: bb7];
-//    }
-//    bb7: {
-//        falseEdges -> [real: bb3, imaginary: bb8];
-//    }
-//    bb8: {
-//        falseEdges -> [real: bb4, imaginary: bb9];
-//    }
-//    bb9: {
 //        unreachable;
 //    }
+//    bb6: {
+//        falseEdges -> [real: bb4, imaginary: bb2];
+//    }
+//    bb7: {
+//        _6 = Le(const 10i32, _1);
+//        switchInt(move _6) -> [false: bb9, otherwise: bb10];
+//    }
+//    bb8: {
+//        _5 = Lt(_1, const 10i32);
+//        switchInt(move _5) -> [false: bb7, otherwise: bb1];
+//    }
+//    bb9: {
+//        switchInt(_1) -> [-1i32: bb3, otherwise: bb4];
+//    }
 //    bb10: {
-//        _7 = Le(const 10i32, _1);
-//        switchInt(move _7) -> [false: bb14, otherwise: bb15];
+//        _7 = Le(_1, const 20i32);
+//        switchInt(move _7) -> [false: bb9, otherwise: bb2];
 //    }
 //    bb11: {
-//        _5 = Lt(_1, const 10i32);
-//        switchInt(move _5) -> [false: bb10, otherwise: bb5];
+//        StorageDead(_8);
+//        _0 = ();
+//        StorageDead(_2);
+//        StorageDead(_1);
+//        return;
 //    }
 //    bb12: {
-//        StorageLive(_6);
-//        _6 = _2;
-//        switchInt(move _6) -> [false: bb13, otherwise: bb1];
+//        _3 = const 0i32;
+//        goto -> bb11;
 //    }
 //    bb13: {
-//        falseEdges -> [real: bb8, imaginary: bb6];
+//        StorageLive(_8);
+//        _8 = _2;
+//        switchInt(move _8) -> [false: bb6, otherwise: bb12];
 //    }
 //    bb14: {
-//        switchInt(_1) -> [-1i32: bb7, otherwise: bb8];
+//        _3 = const 1i32;
+//        goto -> bb11;
 //    }
 //    bb15: {
-//        _8 = Le(_1, const 20i32);
-//        switchInt(move _8) -> [false: bb14, otherwise: bb6];
+//        _3 = const 2i32;
+//        goto -> bb11;
 //    }
 //    bb16: {
-//        StorageDead(_6);
-//        ...
-//        return;
+//        _3 = const 3i32;
+//        goto -> bb11;
 //    }
 // END rustc.main.SimplifyCfg-initial.after.mir

--- a/src/test/mir-opt/remove_fake_borrows.rs
+++ b/src/test/mir-opt/remove_fake_borrows.rs
@@ -24,10 +24,10 @@ fn main() {
 //     switchInt(move _3) -> [1isize: bb5, otherwise: bb2];
 // }
 // bb1: {
-//     goto -> bb8;
+//     goto -> bb7;
 // }
 // bb2: {
-//     goto -> bb9;
+//     goto -> bb8;
 // }
 // bb3: {
 //     unreachable;
@@ -39,14 +39,10 @@ fn main() {
 //     switchInt((*(*((_1 as Some).0: &'<empty> &'<empty> i32)))) -> [0i32: bb1, otherwise: bb2];
 // }
 // bb6: {
-//     StorageDead(_8);
-//     return;
+//     _0 = const 0i32;
+//     goto -> bb9;
 // }
 // bb7: {
-//     _0 = const 0i32;
-//     goto -> bb6;
-// }
-// bb8: {
 //     _4 = &shallow _1;
 //     _5 = &shallow ((_1 as Some).0: &'<empty> &'<empty> i32);
 //     _6 = &shallow (*((_1 as Some).0: &'<empty> &'<empty> i32));
@@ -57,11 +53,15 @@ fn main() {
 //     FakeRead(ForMatchGuard, _5);
 //     FakeRead(ForMatchGuard, _6);
 //     FakeRead(ForMatchGuard, _7);
-//     switchInt(move _8) -> [false: bb4, otherwise: bb7];
+//     switchInt(move _8) -> [false: bb4, otherwise: bb6];
+// }
+// bb8: {
+//     _0 = const 1i32;
+//     goto -> bb9;
 // }
 // bb9: {
-//     _0 = const 1i32;
-//     goto -> bb6;
+//     StorageDead(_8);
+//     return;
 // }
 // bb10: {
 //     resume;
@@ -75,10 +75,10 @@ fn main() {
 //     switchInt(move _3) -> [1isize: bb5, otherwise: bb2];
 // }
 // bb1: {
-//     goto -> bb8;
+//     goto -> bb7;
 // }
 // bb2: {
-//     goto -> bb9;
+//     goto -> bb8;
 // }
 // bb3: {
 //     unreachable;
@@ -90,14 +90,10 @@ fn main() {
 //     switchInt((*(*((_1 as Some).0: &'<empty> &'<empty> i32)))) -> [0i32: bb1, otherwise: bb2];
 // }
 // bb6: {
-//     StorageDead(_8);
-//     return;
+//     _0 = const 0i32;
+//     goto -> bb9;
 // }
 // bb7: {
-//     _0 = const 0i32;
-//     goto -> bb6;
-// }
-// bb8: {
 //     nop;
 //     nop;
 //     nop;
@@ -108,11 +104,15 @@ fn main() {
 //     nop;
 //     nop;
 //     nop;
-//     switchInt(move _8) -> [false: bb4, otherwise: bb7];
+//     switchInt(move _8) -> [false: bb4, otherwise: bb6];
+// }
+// bb8: {
+//     _0 = const 1i32;
+//     goto -> bb9;
 // }
 // bb9: {
-//     _0 = const 1i32;
-//     goto -> bb6;
+//     StorageDead(_8);
+//     return;
 // }
 // bb10: {
 //     resume;

--- a/src/test/mir-opt/remove_fake_borrows.rs
+++ b/src/test/mir-opt/remove_fake_borrows.rs
@@ -17,7 +17,7 @@ fn main() {
 
 // END RUST SOURCE
 
-// START rustc.match_guard.CleanFakeReadsAndBorrows.before.mir
+// START rustc.match_guard.CleanupNonCodegenStatements.before.mir
 // bb0: {
 //     FakeRead(ForMatchedPlace, _1);
 //     _3 = discriminant(_1);
@@ -66,9 +66,9 @@ fn main() {
 // bb10: {
 //     resume;
 // }
-// END rustc.match_guard.CleanFakeReadsAndBorrows.before.mir
+// END rustc.match_guard.CleanupNonCodegenStatements.before.mir
 
-// START rustc.match_guard.CleanFakeReadsAndBorrows.after.mir
+// START rustc.match_guard.CleanupNonCodegenStatements.after.mir
 // bb0: {
 //     nop;
 //     _3 = discriminant(_1);
@@ -116,5 +116,5 @@ fn main() {
 // }
 // bb10: {
 //     resume;
-//    }
-// END rustc.match_guard.CleanFakeReadsAndBorrows.after.mir
+// }
+// END rustc.match_guard.CleanupNonCodegenStatements.after.mir

--- a/src/test/mir-opt/remove_fake_borrows.rs
+++ b/src/test/mir-opt/remove_fake_borrows.rs
@@ -4,15 +4,15 @@
 
 #![feature(nll)]
 
-fn match_guard(x: Option<&&i32>) -> i32 {
+fn match_guard(x: Option<&&i32>, c: bool) -> i32 {
     match x {
-        Some(0) if true => 0,
+        Some(0) if c => 0,
         _ => 1,
     }
 }
 
 fn main() {
-    match_guard(None);
+    match_guard(None, true);
 }
 
 // END RUST SOURCE
@@ -20,49 +20,48 @@ fn main() {
 // START rustc.match_guard.CleanFakeReadsAndBorrows.before.mir
 // bb0: {
 //     FakeRead(ForMatchedPlace, _1);
-//     _2 = discriminant(_1);
-//     _3 = &shallow _1;
-//     _4 = &shallow ((_1 as Some).0: &'<empty> &'<empty> i32);
-//     _5 = &shallow (*((_1 as Some).0: &'<empty> &'<empty> i32));
-//     _6 = &shallow (*(*((_1 as Some).0: &'<empty> &'<empty> i32)));
-//     switchInt(move _2) -> [1isize: bb6, otherwise: bb4];
+//     _3 = discriminant(_1);
+//     switchInt(move _3) -> [1isize: bb5, otherwise: bb2];
 // }
 // bb1: {
-//     _0 = const 0i32;
-//     goto -> bb9;
+//     goto -> bb8;
 // }
 // bb2: {
-//     _0 = const 1i32;
 //     goto -> bb9;
 // }
 // bb3: {
-//     FakeRead(ForMatchGuard, _3);
-//     FakeRead(ForMatchGuard, _4);
-//     FakeRead(ForMatchGuard, _5);
-//     FakeRead(ForMatchGuard, _6);
-//     goto -> bb7;
+//     unreachable;
 // }
 // bb4: {
-//     FakeRead(ForMatchGuard, _3);
-//     FakeRead(ForMatchGuard, _4);
-//     FakeRead(ForMatchGuard, _5);
-//     FakeRead(ForMatchGuard, _6);
 //     goto -> bb2;
 // }
 // bb5: {
-//     unreachable;
+//     switchInt((*(*((_1 as Some).0: &'<empty> &'<empty> i32)))) -> [0i32: bb1, otherwise: bb2];
 // }
 // bb6: {
-//     switchInt((*(*((_1 as Some).0: &'<empty> &'<empty> i32)))) -> [0i32: bb3, otherwise: bb4];
+//     StorageDead(_8);
+//     return;
 // }
 // bb7: {
-//     goto -> bb1;
+//     _0 = const 0i32;
+//     goto -> bb6;
 // }
 // bb8: {
-//     goto -> bb4;
+//     _4 = &shallow _1;
+//     _5 = &shallow ((_1 as Some).0: &'<empty> &'<empty> i32);
+//     _6 = &shallow (*((_1 as Some).0: &'<empty> &'<empty> i32));
+//     _7 = &shallow (*(*((_1 as Some).0: &'<empty> &'<empty> i32)));
+//     StorageLive(_8);
+//     _8 = _2;
+//     FakeRead(ForMatchGuard, _4);
+//     FakeRead(ForMatchGuard, _5);
+//     FakeRead(ForMatchGuard, _6);
+//     FakeRead(ForMatchGuard, _7);
+//     switchInt(move _8) -> [false: bb4, otherwise: bb7];
 // }
 // bb9: {
-//     return;
+//     _0 = const 1i32;
+//     goto -> bb6;
 // }
 // bb10: {
 //     resume;
@@ -72,51 +71,50 @@ fn main() {
 // START rustc.match_guard.CleanFakeReadsAndBorrows.after.mir
 // bb0: {
 //     nop;
-//     _2 = discriminant(_1);
-//     nop;
-//     nop;
-//     nop;
-//     nop;
-//     switchInt(move _2) -> [1isize: bb6, otherwise: bb4];
+//     _3 = discriminant(_1);
+//     switchInt(move _3) -> [1isize: bb5, otherwise: bb2];
 // }
 // bb1: {
-//     _0 = const 0i32;
-//     goto -> bb9;
+//     goto -> bb8;
 // }
 // bb2: {
-//     _0 = const 1i32;
 //     goto -> bb9;
 // }
 // bb3: {
-//     nop;
-//     nop;
-//     nop;
-//     nop;
-//     goto -> bb7;
+//     unreachable;
 // }
 // bb4: {
-//     nop;
-//     nop;
-//     nop;
-//     nop;
 //     goto -> bb2;
 // }
 // bb5: {
-//     unreachable;
+//     switchInt((*(*((_1 as Some).0: &'<empty> &'<empty> i32)))) -> [0i32: bb1, otherwise: bb2];
 // }
 // bb6: {
-//     switchInt((*(*((_1 as Some).0: &'<empty> &'<empty> i32)))) -> [0i32: bb3, otherwise: bb4];
+//     StorageDead(_8);
+//     return;
 // }
 // bb7: {
-//     goto -> bb1;
+//     _0 = const 0i32;
+//     goto -> bb6;
 // }
 // bb8: {
-//     goto -> bb4;
+//     nop;
+//     nop;
+//     nop;
+//     nop;
+//     StorageLive(_8);
+//     _8 = _2;
+//     nop;
+//     nop;
+//     nop;
+//     nop;
+//     switchInt(move _8) -> [false: bb4, otherwise: bb7];
 // }
 // bb9: {
-//     return;
+//     _0 = const 1i32;
+//     goto -> bb6;
 // }
 // bb10: {
 //     resume;
-// }
+//    }
 // END rustc.match_guard.CleanFakeReadsAndBorrows.after.mir

--- a/src/test/ui/match/match-ref-mut-stability.rs
+++ b/src/test/ui/match/match-ref-mut-stability.rs
@@ -1,0 +1,39 @@
+// Check that `ref mut` variables don't change address between the match guard
+// and the arm expression.
+
+// run-pass
+
+#![feature(nll, bind_by_move_pattern_guards)]
+
+// Test that z always point to the same temporary.
+fn referent_stability() {
+    let p;
+    match 0 {
+        ref mut z if { p = z as *const _; true } => assert_eq!(p, z as *const _),
+        _ => unreachable!(),
+    };
+}
+
+// Test that z is always effectively the same variable.
+fn variable_stability() {
+    let p;
+    match 0 {
+        ref mut z if { p = &z as *const _; true } => assert_eq!(p, &z as *const _),
+        _ => unreachable!(),
+    };
+}
+
+// Test that a borrow of *z can cross from the guard to the arm.
+fn persist_borrow() {
+    let r;
+    match 0 {
+        ref mut z if { r = z as &_; true } => assert_eq!(*r, 0),
+        _ => unreachable!(),
+    }
+}
+
+fn main() {
+    referent_stability();
+    variable_stability();
+    persist_borrow();
+}

--- a/src/test/ui/nll/match-cfg-fake-edges.rs
+++ b/src/test/ui/nll/match-cfg-fake-edges.rs
@@ -1,0 +1,58 @@
+// Test that we have enough false edges to avoid exposing the exact matching
+// algorithm in borrow checking.
+
+#![feature(nll, bind_by_move_pattern_guards)]
+
+fn guard_always_precedes_arm(y: i32) {
+    let mut x;
+    // x should always be initialized, as the only way to reach the arm is
+    // through the guard.
+    match y {
+        0 | 2 if { x = 2; true } => x,
+        _ => 2,
+    };
+}
+
+fn guard_may_be_skipped(y: i32) {
+    let x;
+    // Even though x *is* always initialized, we don't want to have borrowck
+    // results be based on whether patterns are exhaustive.
+    match y {
+        _ if { x = 2; true } => 1,
+        _ if {
+            x; //~ ERROR use of possibly uninitialized variable: `x`
+            false
+        } => 2,
+        _ => 3,
+    };
+}
+
+fn guard_may_be_taken(y: bool) {
+    let x = String::new();
+    // Even though x *is* never moved before the use, we don't want to have
+    // borrowck results be based on whether patterns are disjoint.
+    match y {
+        false if { drop(x); true } => 1,
+        true => {
+            x; //~ ERROR use of moved value: `x`
+            2
+        }
+        false => 3,
+    };
+}
+
+fn all_previous_tests_may_be_done(y: &mut (bool, bool)) {
+    let r = &mut y.1;
+    // We don't actually test y.1 to select the second arm, but we don't want
+    // borrowck results to be based on the order we match patterns.
+    match y {
+        (false, true) => 1, //~ ERROR cannot use `y.1` because it was mutably borrowed
+        (true, _) => {
+            r;
+            2
+        }
+        (false, _) => 3,
+    };
+}
+
+fn main() {}

--- a/src/test/ui/nll/match-cfg-fake-edges.stderr
+++ b/src/test/ui/nll/match-cfg-fake-edges.stderr
@@ -1,0 +1,34 @@
+error[E0381]: use of possibly uninitialized variable: `x`
+  --> $DIR/match-cfg-fake-edges.rs:23:13
+   |
+LL |             x; //~ ERROR use of possibly uninitialized variable: `x`
+   |             ^ use of possibly uninitialized `x`
+
+error[E0382]: use of moved value: `x`
+  --> $DIR/match-cfg-fake-edges.rs:37:13
+   |
+LL |     let x = String::new();
+   |         - move occurs because `x` has type `std::string::String`, which does not implement the `Copy` trait
+...
+LL |         false if { drop(x); true } => 1,
+   |                         - value moved here
+LL |         true => {
+LL |             x; //~ ERROR use of moved value: `x`
+   |             ^ value used here after move
+
+error[E0503]: cannot use `y.1` because it was mutably borrowed
+  --> $DIR/match-cfg-fake-edges.rs:49:17
+   |
+LL |     let r = &mut y.1;
+   |             -------- borrow of `y.1` occurs here
+...
+LL |         (false, true) => 1, //~ ERROR cannot use `y.1` because it was mutably borrowed
+   |                 ^^^^ use of borrowed `y.1`
+LL |         (true, _) => {
+LL |             r;
+   |             - borrow later used here
+
+error: aborting due to 3 previous errors
+
+Some errors occurred: E0381, E0382, E0503.
+For more information about an error, try `rustc --explain E0381`.

--- a/src/test/ui/nll/match-guards-partially-borrow.rs
+++ b/src/test/ui/nll/match-guards-partially-borrow.rs
@@ -17,6 +17,30 @@ fn ok_mutation_in_guard(mut q: i32) {
     }
 }
 
+fn ok_mutation_in_guard2(mut u: bool) {
+    // OK value of u is unused before modification
+    match u {
+        _ => (),
+        _ if {
+            u = true;
+            false
+        } => (),
+        x => (),
+    }
+}
+
+fn ok_mutation_in_guard4(mut w: (&mut bool,)) {
+    // OK value of u is unused before modification
+    match w {
+        _ => (),
+        _ if {
+            *w.0 = true;
+            false
+        } => (),
+        x => (),
+    }
+}
+
 fn ok_indirect_mutation_in_guard(mut p: &bool) {
     match *p {
         // OK, mutation doesn't change which patterns s matches
@@ -53,8 +77,8 @@ fn mutation_invalidates_previous_pattern_in_guard(mut r: bool) {
 
 fn match_on_borrowed_early_end(mut s: bool) {
     let h = &mut s;
-    match s { //~ ERROR
-        // s changes value between the start of the match and when its value is checked.
+    // OK value of s is unused before modification.
+    match s {
         _ if {
             *h = !*h;
             false
@@ -75,19 +99,7 @@ fn bad_mutation_in_guard(mut t: bool) {
     }
 }
 
-fn bad_mutation_in_guard2(mut u: bool) {
-    match u {
-        // Guard changes the value bound in the last pattern.
-        _ => (),
-        _ if {
-            u = true; //~ ERROR
-            false
-        } => (),
-        x => (),
-    }
-}
-
-pub fn bad_mutation_in_guard3(mut x: Option<Option<&i32>>) {
+fn bad_mutation_in_guard2(mut x: Option<Option<&i32>>) {
     // Check that nested patterns are checked.
     match x {
         None => (),
@@ -103,20 +115,7 @@ pub fn bad_mutation_in_guard3(mut x: Option<Option<&i32>>) {
     }
 }
 
-
-fn bad_mutation_in_guard4(mut w: (&mut bool,)) {
-    match w {
-        // Guard changes the value bound in the last pattern.
-        _ => (),
-        _ if {
-            *w.0 = true; //~ ERROR
-            false
-        } => (),
-        x => (),
-    }
-}
-
-fn bad_mutation_in_guard5(mut t: bool) {
+fn bad_mutation_in_guard3(mut t: bool) {
     match t {
         s if {
             t = !t; //~ ERROR

--- a/src/test/ui/nll/match-guards-partially-borrow.rs
+++ b/src/test/ui/nll/match-guards-partially-borrow.rs
@@ -30,7 +30,7 @@ fn ok_indirect_mutation_in_guard(mut p: &bool) {
 
 fn mutation_invalidates_pattern_in_guard(mut q: bool) {
     match q {
-        // s doesn't match the pattern with the guard by the end of the guard.
+        // q doesn't match the pattern with the guard by the end of the guard.
         false if {
             q = true; //~ ERROR
             true
@@ -41,7 +41,7 @@ fn mutation_invalidates_pattern_in_guard(mut q: bool) {
 
 fn mutation_invalidates_previous_pattern_in_guard(mut r: bool) {
     match r {
-        // s matches a previous pattern by the end of the guard.
+        // r matches a previous pattern by the end of the guard.
         true => (),
         _ if {
             r = true; //~ ERROR
@@ -113,6 +113,16 @@ fn bad_mutation_in_guard4(mut w: (&mut bool,)) {
             false
         } => (),
         x => (),
+    }
+}
+
+fn bad_mutation_in_guard5(mut t: bool) {
+    match t {
+        s if {
+            t = !t; //~ ERROR
+            false
+        } => (), // What value should `s` have in the arm?
+        _ => (),
     }
 }
 

--- a/src/test/ui/nll/match-guards-partially-borrow.stderr
+++ b/src/test/ui/nll/match-guards-partially-borrow.stderr
@@ -6,9 +6,6 @@ LL |     match q {
 ...
 LL |             q = true; //~ ERROR
    |             ^^^^^^^^ cannot assign
-...
-LL |         _ => (),
-   |         - borrow later used here
 
 error[E0510]: cannot assign `r` in match guard
   --> $DIR/match-guards-partially-borrow.rs:47:13
@@ -18,9 +15,6 @@ LL |     match r {
 ...
 LL |             r = true; //~ ERROR
    |             ^^^^^^^^ cannot assign
-...
-LL |         _ => (),
-   |         - borrow later used here
 
 error[E0503]: cannot use `s` because it was mutably borrowed
   --> $DIR/match-guards-partially-borrow.rs:56:11
@@ -41,9 +35,6 @@ LL |     match t {
 ...
 LL |             t = true; //~ ERROR
    |             ^^^^^^^^ cannot assign
-...
-LL |         false => (),
-   |         ----- borrow later used here
 
 error[E0506]: cannot assign to `u` because it is borrowed
   --> $DIR/match-guards-partially-borrow.rs:83:13
@@ -53,8 +44,8 @@ LL |     match u {
 ...
 LL |             u = true; //~ ERROR
    |             ^^^^^^^^ assignment to borrowed `u` occurs here
-...
-LL |         x => (),
+LL |             false
+LL |         } => (),
    |         - borrow later used here
 
 error[E0510]: cannot mutably borrow `x.0` in match guard
@@ -74,59 +65,59 @@ LL |     match w {
 ...
 LL |             *w.0 = true; //~ ERROR
    |             ^^^^^^^^^^^ assignment to borrowed `*w.0` occurs here
-...
-LL |         x => (),
+LL |             false
+LL |         } => (),
+   |         - borrow later used here
+
+error[E0506]: cannot assign to `t` because it is borrowed
+  --> $DIR/match-guards-partially-borrow.rs:122:13
+   |
+LL |     match t {
+   |           - borrow of `t` occurs here
+LL |         s if {
+LL |             t = !t; //~ ERROR
+   |             ^^^^^^ assignment to borrowed `t` occurs here
+LL |             false
+LL |         } => (), // What value should `s` have in the arm?
    |         - borrow later used here
 
 error[E0510]: cannot assign `y` in match guard
-  --> $DIR/match-guards-partially-borrow.rs:123:13
+  --> $DIR/match-guards-partially-borrow.rs:133:13
    |
 LL |     match *y {
    |           -- value is immutable in match guard
 ...
 LL |             y = &true; //~ ERROR
    |             ^^^^^^^^^ cannot assign
-...
-LL |         false => (),
-   |         ----- borrow later used here
 
 error[E0510]: cannot assign `z` in match guard
-  --> $DIR/match-guards-partially-borrow.rs:134:13
+  --> $DIR/match-guards-partially-borrow.rs:144:13
    |
 LL |     match z {
    |           - value is immutable in match guard
 ...
 LL |             z = &true; //~ ERROR
    |             ^^^^^^^^^ cannot assign
-...
-LL |         &false => (),
-   |         ------ borrow later used here
 
 error[E0510]: cannot assign `a` in match guard
-  --> $DIR/match-guards-partially-borrow.rs:146:13
+  --> $DIR/match-guards-partially-borrow.rs:156:13
    |
 LL |     match a {
    |           - value is immutable in match guard
 ...
 LL |             a = &true; //~ ERROR
    |             ^^^^^^^^^ cannot assign
-...
-LL |         false => (),
-   |         ----- borrow later used here
 
 error[E0510]: cannot assign `b` in match guard
-  --> $DIR/match-guards-partially-borrow.rs:157:13
+  --> $DIR/match-guards-partially-borrow.rs:167:13
    |
 LL |     match b {
    |           - value is immutable in match guard
 ...
 LL |             b = &true; //~ ERROR
    |             ^^^^^^^^^ cannot assign
-...
-LL |         &b => (),
-   |         -- borrow later used here
 
-error: aborting due to 11 previous errors
+error: aborting due to 12 previous errors
 
 Some errors occurred: E0503, E0506, E0510.
 For more information about an error, try `rustc --explain E0503`.

--- a/src/test/ui/nll/match-guards-partially-borrow.stderr
+++ b/src/test/ui/nll/match-guards-partially-borrow.stderr
@@ -1,5 +1,5 @@
 error[E0510]: cannot assign `q` in match guard
-  --> $DIR/match-guards-partially-borrow.rs:35:13
+  --> $DIR/match-guards-partially-borrow.rs:59:13
    |
 LL |     match q {
    |           - value is immutable in match guard
@@ -8,7 +8,7 @@ LL |             q = true; //~ ERROR
    |             ^^^^^^^^ cannot assign
 
 error[E0510]: cannot assign `r` in match guard
-  --> $DIR/match-guards-partially-borrow.rs:47:13
+  --> $DIR/match-guards-partially-borrow.rs:71:13
    |
 LL |     match r {
    |           - value is immutable in match guard
@@ -16,19 +16,8 @@ LL |     match r {
 LL |             r = true; //~ ERROR
    |             ^^^^^^^^ cannot assign
 
-error[E0503]: cannot use `s` because it was mutably borrowed
-  --> $DIR/match-guards-partially-borrow.rs:56:11
-   |
-LL |     let h = &mut s;
-   |             ------ borrow of `s` occurs here
-LL |     match s { //~ ERROR
-   |           ^ use of borrowed `s`
-...
-LL |             *h = !*h;
-   |                   -- borrow later used here
-
 error[E0510]: cannot assign `t` in match guard
-  --> $DIR/match-guards-partially-borrow.rs:71:13
+  --> $DIR/match-guards-partially-borrow.rs:95:13
    |
 LL |     match t {
    |           - value is immutable in match guard
@@ -36,20 +25,8 @@ LL |     match t {
 LL |             t = true; //~ ERROR
    |             ^^^^^^^^ cannot assign
 
-error[E0506]: cannot assign to `u` because it is borrowed
-  --> $DIR/match-guards-partially-borrow.rs:83:13
-   |
-LL |     match u {
-   |           - borrow of `u` occurs here
-...
-LL |             u = true; //~ ERROR
-   |             ^^^^^^^^ assignment to borrowed `u` occurs here
-LL |             false
-LL |         } => (),
-   |         - borrow later used here
-
 error[E0510]: cannot mutably borrow `x.0` in match guard
-  --> $DIR/match-guards-partially-borrow.rs:97:22
+  --> $DIR/match-guards-partially-borrow.rs:109:22
    |
 LL |     match x {
    |           - value is immutable in match guard
@@ -57,24 +34,11 @@ LL |     match x {
 LL |                 Some(ref mut r) => *r = None, //~ ERROR
    |                      ^^^^^^^^^ cannot mutably borrow
 
-error[E0506]: cannot assign to `*w.0` because it is borrowed
-  --> $DIR/match-guards-partially-borrow.rs:112:13
-   |
-LL |     match w {
-   |           - borrow of `*w.0` occurs here
-...
-LL |             *w.0 = true; //~ ERROR
-   |             ^^^^^^^^^^^ assignment to borrowed `*w.0` occurs here
-LL |             false
-LL |         } => (),
-   |         - borrow later used here
-
 error[E0506]: cannot assign to `t` because it is borrowed
-  --> $DIR/match-guards-partially-borrow.rs:122:13
+  --> $DIR/match-guards-partially-borrow.rs:121:13
    |
-LL |     match t {
-   |           - borrow of `t` occurs here
 LL |         s if {
+   |         - borrow of `t` occurs here
 LL |             t = !t; //~ ERROR
    |             ^^^^^^ assignment to borrowed `t` occurs here
 LL |             false
@@ -82,7 +46,7 @@ LL |         } => (), // What value should `s` have in the arm?
    |         - borrow later used here
 
 error[E0510]: cannot assign `y` in match guard
-  --> $DIR/match-guards-partially-borrow.rs:133:13
+  --> $DIR/match-guards-partially-borrow.rs:132:13
    |
 LL |     match *y {
    |           -- value is immutable in match guard
@@ -91,7 +55,7 @@ LL |             y = &true; //~ ERROR
    |             ^^^^^^^^^ cannot assign
 
 error[E0510]: cannot assign `z` in match guard
-  --> $DIR/match-guards-partially-borrow.rs:144:13
+  --> $DIR/match-guards-partially-borrow.rs:143:13
    |
 LL |     match z {
    |           - value is immutable in match guard
@@ -100,7 +64,7 @@ LL |             z = &true; //~ ERROR
    |             ^^^^^^^^^ cannot assign
 
 error[E0510]: cannot assign `a` in match guard
-  --> $DIR/match-guards-partially-borrow.rs:156:13
+  --> $DIR/match-guards-partially-borrow.rs:155:13
    |
 LL |     match a {
    |           - value is immutable in match guard
@@ -109,7 +73,7 @@ LL |             a = &true; //~ ERROR
    |             ^^^^^^^^^ cannot assign
 
 error[E0510]: cannot assign `b` in match guard
-  --> $DIR/match-guards-partially-borrow.rs:167:13
+  --> $DIR/match-guards-partially-borrow.rs:166:13
    |
 LL |     match b {
    |           - value is immutable in match guard
@@ -117,7 +81,7 @@ LL |     match b {
 LL |             b = &true; //~ ERROR
    |             ^^^^^^^^^ cannot assign
 
-error: aborting due to 12 previous errors
+error: aborting due to 9 previous errors
 
-Some errors occurred: E0503, E0506, E0510.
-For more information about an error, try `rustc --explain E0503`.
+Some errors occurred: E0506, E0510.
+For more information about an error, try `rustc --explain E0506`.


### PR DESCRIPTION
`ref mut` borrows are currently two-phase with NLL enabled. This changes them to be proper mutable borrows. To accommodate this, first the position of fake borrows is changed:

```text
[ 1. Pre-match ]
       |
[ (old create fake borrows) ]
[ 2. Discriminant testing -- check discriminants ] <-+
       |                                             |
       | (once a specific arm is chosen)             |
       |                                             |
[ (old read fake borrows) ]                          |
[ 3. Create "guard bindings" for arm ]               |
[ (create fake borrows) ]                            |
       |                                             |
[ 4. Execute guard code ]                            |
[ (read fake borrows) ] --(guard is false)-----------+
       |
       | (guard results in true)
       |
[ 5. Create real bindings and execute arm ]
       |
[ Exit match ]
```

The following additional changes are made to accommodate `ref mut` bindings: 

* We no longer create fake `Shared` borrows. These borrows are no longer needed for soundness, just to avoid some arguably strange cases.
* `Shallow` borrows no longer conflict with existing borrows, avoiding conflicting access between the guard borrow access and the `ref mut` borrow.

There is some further clean up done in this PR:

* Avoid the "later used here" note for Shallow borrows (since it's not relevant with the message provided)
* Make any use of a two-phase borrow activate it.
* Simplify the cleanup_post_borrowck passes into a single pass.

cc #56254

r? @nikomatsakis 