### PR TITLE
[rustdoc] Fix crates filtering box not being filled

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -2422,7 +2422,7 @@ if (!DOMTokenList.prototype.remove) {
             return;
         }
         var crates_text = [];
-        if (crates.length > 1) {
+        if (Object.keys(crates).length > 1) {
             for (var crate in crates) {
                 if (crates.hasOwnProperty(crate)) {
                     crates_text.push(crate);


### PR DESCRIPTION
Currently, the filter crate box (at the left of the search input) is always empty. To get the number of keys of dictionary in JS, you need to call `Object.keys()` on it.

r? @QuietMisdreavus 