### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/src/libcore/benches/fmt.rs
+++ b/src/libcore/benches/fmt.rs
@@ -1,0 +1,110 @@
+use std::io::{self, Write as IoWrite};
+use std::fmt::{self, Write as FmtWrite};
+use test::Bencher;
+
+#[bench]
+fn write_vec_value(bh: &mut Bencher) {
+    bh.iter(|| {
+        let mut mem = Vec::new();
+        for _ in 0..1000 {
+            mem.write_all("abc".as_bytes()).unwrap();
+        }
+    });
+}
+
+#[bench]
+fn write_vec_ref(bh: &mut Bencher) {
+    bh.iter(|| {
+        let mut mem = Vec::new();
+        let wr = &mut mem as &mut dyn io::Write;
+        for _ in 0..1000 {
+            wr.write_all("abc".as_bytes()).unwrap();
+        }
+    });
+}
+
+#[bench]
+fn write_vec_macro1(bh: &mut Bencher) {
+    bh.iter(|| {
+        let mut mem = Vec::new();
+        let wr = &mut mem as &mut dyn io::Write;
+        for _ in 0..1000 {
+            write!(wr, "abc").unwrap();
+        }
+    });
+}
+
+#[bench]
+fn write_vec_macro2(bh: &mut Bencher) {
+    bh.iter(|| {
+        let mut mem = Vec::new();
+        let wr = &mut mem as &mut dyn io::Write;
+        for _ in 0..1000 {
+            write!(wr, "{}", "abc").unwrap();
+        }
+    });
+}
+
+#[bench]
+fn write_vec_macro_debug(bh: &mut Bencher) {
+    bh.iter(|| {
+        let mut mem = Vec::new();
+        let wr = &mut mem as &mut dyn io::Write;
+        for _ in 0..1000 {
+            write!(wr, "{:?}", "☃").unwrap();
+        }
+    });
+}
+
+#[bench]
+fn write_str_value(bh: &mut Bencher) {
+    bh.iter(|| {
+        let mut mem = String::new();
+        for _ in 0..1000 {
+            mem.write_str("abc").unwrap();
+        }
+    });
+}
+
+#[bench]
+fn write_str_ref(bh: &mut Bencher) {
+    bh.iter(|| {
+        let mut mem = String::new();
+        let wr = &mut mem as &mut dyn fmt::Write;
+        for _ in 0..1000 {
+            wr.write_str("abc").unwrap();
+        }
+    });
+}
+
+#[bench]
+fn write_str_macro1(bh: &mut Bencher) {
+    bh.iter(|| {
+        let mut mem = String::new();
+        for _ in 0..1000 {
+            write!(mem, "abc").unwrap();
+        }
+    });
+}
+
+#[bench]
+fn write_str_macro2(bh: &mut Bencher) {
+    bh.iter(|| {
+        let mut mem = String::new();
+        let wr = &mut mem as &mut dyn fmt::Write;
+        for _ in 0..1000 {
+            write!(wr, "{}", "abc").unwrap();
+        }
+    });
+}
+
+#[bench]
+fn write_str_macro_debug(bh: &mut Bencher) {
+    bh.iter(|| {
+        let mut mem = String::new();
+        let wr = &mut mem as &mut dyn fmt::Write;
+        for _ in 0..1000 {
+            write!(wr, "{:?}", "☃").unwrap();
+        }
+    });
+}

--- a/src/libcore/benches/lib.rs
+++ b/src/libcore/benches/lib.rs
@@ -11,3 +11,4 @@ mod iter;
 mod num;
 mod ops;
 mod slice;
+mod fmt;

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -1026,28 +1026,30 @@ pub fn write(output: &mut dyn Write, args: Arguments) -> Result {
         curarg: args.args.iter(),
     };
 
-    let mut pieces = args.pieces.iter();
+    let mut idx = 0;
 
     match args.fmt {
         None => {
             // We can use default formatting parameters for all arguments.
-            for (arg, piece) in args.args.iter().zip(pieces.by_ref()) {
+            for (arg, piece) in args.args.iter().zip(args.pieces.iter()) {
                 formatter.buf.write_str(*piece)?;
                 (arg.formatter)(arg.value, &mut formatter)?;
+                idx += 1;
             }
         }
         Some(fmt) => {
             // Every spec has a corresponding argument that is preceded by
             // a string piece.
-            for (arg, piece) in fmt.iter().zip(pieces.by_ref()) {
+            for (arg, piece) in fmt.iter().zip(args.pieces.iter()) {
                 formatter.buf.write_str(*piece)?;
                 formatter.run(arg)?;
+                idx += 1;
             }
         }
     }
 
     // There can be only one trailing string piece left.
-    if let Some(piece) = pieces.next() {
+    if let Some(piece) = args.pieces.get(idx) {
         formatter.buf.write_str(*piece)?;
     }
 

--- a/src/libcore/iter/iterator.rs
+++ b/src/libcore/iter/iterator.rs
@@ -2358,7 +2358,7 @@ pub trait Iterator {
     ///
     /// ```
     /// fn factorial(n: u32) -> u32 {
-    ///     (1..).take_while(|&i| i <= n).product()
+    ///     (1..=n).product()
     /// }
     /// assert_eq!(factorial(0), 1);
     /// assert_eq!(factorial(1), 1);

--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -329,6 +329,8 @@ pub use self::sources::{RepeatWith, repeat_with};
 pub use self::sources::{Empty, empty};
 #[stable(feature = "iter_once", since = "1.2.0")]
 pub use self::sources::{Once, once};
+#[unstable(feature = "iter_once_with", issue = "0")]
+pub use self::sources::{OnceWith, once_with};
 #[unstable(feature = "iter_unfold", issue = "55977")]
 pub use self::sources::{Unfold, unfold, Successors, successors};
 

--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -329,7 +329,7 @@ pub use self::sources::{RepeatWith, repeat_with};
 pub use self::sources::{Empty, empty};
 #[stable(feature = "iter_once", since = "1.2.0")]
 pub use self::sources::{Once, once};
-#[unstable(feature = "iter_once_with", issue = "0")]
+#[unstable(feature = "iter_once_with", issue = "57581")]
 pub use self::sources::{OnceWith, once_with};
 #[unstable(feature = "iter_unfold", issue = "55977")]
 pub use self::sources::{Unfold, unfold, Successors, successors};

--- a/src/libcore/iter/sources.rs
+++ b/src/libcore/iter/sources.rs
@@ -385,12 +385,12 @@ pub fn once<T>(value: T) -> Once<T> {
 ///
 /// [`once_with`]: fn.once_with.html
 #[derive(Copy, Clone, Debug)]
-#[unstable(feature = "iter_once_with", issue = "0")]
+#[unstable(feature = "iter_once_with", issue = "57581")]
 pub struct OnceWith<F> {
     gen: Option<F>,
 }
 
-#[unstable(feature = "iter_once_with", issue = "0")]
+#[unstable(feature = "iter_once_with", issue = "57581")]
 impl<A, F: FnOnce() -> A> Iterator for OnceWith<F> {
     type Item = A;
 
@@ -405,24 +405,24 @@ impl<A, F: FnOnce() -> A> Iterator for OnceWith<F> {
     }
 }
 
-#[unstable(feature = "iter_once_with", issue = "0")]
+#[unstable(feature = "iter_once_with", issue = "57581")]
 impl<A, F: FnOnce() -> A> DoubleEndedIterator for OnceWith<F> {
     fn next_back(&mut self) -> Option<A> {
         self.next()
     }
 }
 
-#[unstable(feature = "iter_once_with", issue = "0")]
+#[unstable(feature = "iter_once_with", issue = "57581")]
 impl<A, F: FnOnce() -> A> ExactSizeIterator for OnceWith<F> {
     fn len(&self) -> usize {
         self.gen.iter().len()
     }
 }
 
-#[unstable(feature = "iter_once_with", issue = "0")]
+#[unstable(feature = "iter_once_with", issue = "57581")]
 impl<A, F: FnOnce() -> A> FusedIterator for OnceWith<F> {}
 
-#[unstable(feature = "iter_once_with", issue = "0")]
+#[unstable(feature = "iter_once_with", issue = "57581")]
 unsafe impl<A, F: FnOnce() -> A> TrustedLen for OnceWith<F> {}
 
 /// Creates an iterator that lazily generates a value exactly once by invoking
@@ -436,6 +436,7 @@ unsafe impl<A, F: FnOnce() -> A> TrustedLen for OnceWith<F> {}
 /// Unlike [`once`], this function will lazily generate the value on request.
 ///
 /// [`once`]: fn.once.html
+/// [`chain`]: trait.Iterator.html#method.chain
 ///
 /// # Examples
 ///
@@ -480,7 +481,7 @@ unsafe impl<A, F: FnOnce() -> A> TrustedLen for OnceWith<F> {}
 /// }
 /// ```
 #[inline]
-#[unstable(feature = "iter_once_with", issue = "0")]
+#[unstable(feature = "iter_once_with", issue = "57581")]
 pub fn once_with<A, F: FnOnce() -> A>(gen: F) -> OnceWith<F> {
     OnceWith { gen: Some(gen) }
 }

--- a/src/libcore/iter/sources.rs
+++ b/src/libcore/iter/sources.rs
@@ -443,6 +443,8 @@ unsafe impl<A, F: FnOnce() -> A> TrustedLen for OnceWith<F> {}
 /// Basic usage:
 ///
 /// ```
+/// #![feature(iter_once_with)]
+///
 /// use std::iter;
 ///
 /// // one is the loneliest number

--- a/src/libcore/iter/sources.rs
+++ b/src/libcore/iter/sources.rs
@@ -461,6 +461,8 @@ unsafe impl<A, F: FnOnce() -> A> TrustedLen for OnceWith<F> {}
 /// `.foorc`:
 ///
 /// ```no_run
+/// #![feature(iter_once_with)]
+///
 /// use std::iter;
 /// use std::fs;
 /// use std::path::PathBuf;

--- a/src/libcore/iter/sources.rs
+++ b/src/libcore/iter/sources.rs
@@ -377,6 +377,114 @@ pub fn once<T>(value: T) -> Once<T> {
     Once { inner: Some(value).into_iter() }
 }
 
+/// An iterator that repeats elements of type `A` endlessly by
+/// applying the provided closure `F: FnMut() -> A`.
+///
+/// This `struct` is created by the [`once_with`] function.
+/// See its documentation for more.
+///
+/// [`once_with`]: fn.once_with.html
+#[derive(Copy, Clone, Debug)]
+#[unstable(feature = "iter_once_with", issue = "0")]
+pub struct OnceWith<F> {
+    gen: Option<F>,
+}
+
+#[unstable(feature = "iter_once_with", issue = "0")]
+impl<A, F: FnOnce() -> A> Iterator for OnceWith<F> {
+    type Item = A;
+
+    #[inline]
+    fn next(&mut self) -> Option<A> {
+        self.gen.take().map(|f| f())
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.gen.iter().size_hint()
+    }
+}
+
+#[unstable(feature = "iter_once_with", issue = "0")]
+impl<A, F: FnOnce() -> A> DoubleEndedIterator for OnceWith<F> {
+    fn next_back(&mut self) -> Option<A> {
+        self.next()
+    }
+}
+
+#[unstable(feature = "iter_once_with", issue = "0")]
+impl<A, F: FnOnce() -> A> ExactSizeIterator for OnceWith<F> {
+    fn len(&self) -> usize {
+        self.gen.iter().len()
+    }
+}
+
+#[unstable(feature = "iter_once_with", issue = "0")]
+impl<A, F: FnOnce() -> A> FusedIterator for OnceWith<F> {}
+
+#[unstable(feature = "iter_once_with", issue = "0")]
+unsafe impl<A, F: FnOnce() -> A> TrustedLen for OnceWith<F> {}
+
+/// Creates an iterator that lazily generates a value exactly once by invoking
+/// the provided closure.
+///
+/// This is commonly used to adapt a single value generator into a [`chain`] of
+/// other kinds of iteration. Maybe you have an iterator that covers almost
+/// everything, but you need an extra special case. Maybe you have a function
+/// which works on iterators, but you only need to process one value.
+///
+/// Unlike [`once`], this function will lazily generate the value on request.
+///
+/// [`once`]: fn.once.html
+///
+/// # Examples
+///
+/// Basic usage:
+///
+/// ```
+/// use std::iter;
+///
+/// // one is the loneliest number
+/// let mut one = iter::once_with(|| 1);
+///
+/// assert_eq!(Some(1), one.next());
+///
+/// // just one, that's all we get
+/// assert_eq!(None, one.next());
+/// ```
+///
+/// Chaining together with another iterator. Let's say that we want to iterate
+/// over each file of the `.foo` directory, but also a configuration file,
+/// `.foorc`:
+///
+/// ```no_run
+/// use std::iter;
+/// use std::fs;
+/// use std::path::PathBuf;
+///
+/// let dirs = fs::read_dir(".foo").unwrap();
+///
+/// // we need to convert from an iterator of DirEntry-s to an iterator of
+/// // PathBufs, so we use map
+/// let dirs = dirs.map(|file| file.unwrap().path());
+///
+/// // now, our iterator just for our config file
+/// let config = iter::once_with(|| PathBuf::from(".foorc"));
+///
+/// // chain the two iterators together into one big iterator
+/// let files = dirs.chain(config);
+///
+/// // this will give us all of the files in .foo as well as .foorc
+/// for f in files {
+///     println!("{:?}", f);
+/// }
+/// ```
+#[inline]
+#[unstable(feature = "iter_once_with", issue = "0")]
+pub fn once_with<A, F: FnOnce() -> A>(gen: F) -> OnceWith<F> {
+    OnceWith { gen: Some(gen) }
+}
+
 /// Creates a new iterator where each iteration calls the provided closure
 /// `F: FnMut(&mut St) -> Option<T>`.
 ///

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -79,6 +79,7 @@
 #![feature(extern_types)]
 #![feature(fundamental)]
 #![feature(intrinsics)]
+#![feature(iter_once_with)]
 #![feature(lang_items)]
 #![feature(link_llvm_intrinsics)]
 #![feature(never_type)]

--- a/src/libcore/tests/iter.rs
+++ b/src/libcore/tests/iter.rs
@@ -1909,7 +1909,7 @@ fn test_once() {
 
 #[test]
 fn test_once_with() {
-    let mut count = Cell::new(0);
+    let count = Cell::new(0);
     let mut it = once_with(|| {
         count.set(count.get() + 1);
         42

--- a/src/libcore/tests/iter.rs
+++ b/src/libcore/tests/iter.rs
@@ -1907,6 +1907,23 @@ fn test_once() {
 }
 
 #[test]
+fn test_once_with() {
+    let mut count = 0;
+    let mut it = once_with(|| {
+        count += 1;
+        42
+    });
+
+    assert_eq!(count, 0);
+    assert_eq!(it.next(), Some(42));
+    assert_eq!(count, 1);
+    assert_eq!(it.next(), None);
+    assert_eq!(count, 1);
+    assert_eq!(it.next(), None);
+    assert_eq!(count, 1);
+}
+
+#[test]
 fn test_empty() {
     let mut it = empty::<i32>();
     assert_eq!(it.next(), None);

--- a/src/libcore/tests/iter.rs
+++ b/src/libcore/tests/iter.rs
@@ -1,3 +1,4 @@
+use core::cell::Cell;
 use core::iter::*;
 use core::{i8, i16, isize};
 use core::usize;
@@ -1908,19 +1909,19 @@ fn test_once() {
 
 #[test]
 fn test_once_with() {
-    let mut count = 0;
+    let mut count = Cell::new(0);
     let mut it = once_with(|| {
-        count += 1;
+        count.set(count.get() + 1);
         42
     });
 
-    assert_eq!(count, 0);
+    assert_eq!(count.get(), 0);
     assert_eq!(it.next(), Some(42));
-    assert_eq!(count, 1);
+    assert_eq!(count.get(), 1);
     assert_eq!(it.next(), None);
-    assert_eq!(count, 1);
+    assert_eq!(count.get(), 1);
     assert_eq!(it.next(), None);
-    assert_eq!(count, 1);
+    assert_eq!(count.get(), 1);
 }
 
 #[test]

--- a/src/libcore/tests/lib.rs
+++ b/src/libcore/tests/lib.rs
@@ -12,6 +12,7 @@
 #![feature(hashmap_internals)]
 #![feature(iter_copied)]
 #![feature(iter_nth_back)]
+#![feature(iter_once_with)]
 #![feature(iter_unfold)]
 #![feature(pattern)]
 #![feature(range_is_empty)]

--- a/src/libfmt_macros/lib.rs
+++ b/src/libfmt_macros/lib.rs
@@ -72,6 +72,15 @@ pub enum Position<'a> {
     ArgumentNamed(&'a str),
 }
 
+impl Position<'_> {
+    pub fn index(&self) -> Option<usize> {
+        match self {
+            ArgumentIs(i) | ArgumentImplicitlyIs(i) => Some(*i),
+            _ => None,
+        }
+    }
+}
+
 /// Enum of alignments which are supported.
 #[derive(Copy, Clone, PartialEq)]
 pub enum Alignment {

--- a/src/librustc/dep_graph/dep_node.rs
+++ b/src/librustc/dep_graph/dep_node.rs
@@ -476,6 +476,9 @@ define_dep_nodes!( <'tcx>
     [] CheckModLoops(DefId),
     [] CheckModUnstableApiUsage(DefId),
     [] CheckModItemTypes(DefId),
+    [] CheckModPrivacy(DefId),
+    [] CheckModIntrinsics(DefId),
+    [] CheckModLiveness(DefId),
     [] CollectModItemTypes(DefId),
 
     [] Reachability,

--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -507,6 +507,21 @@ impl<'hir> Map<'hir> {
         &self.forest.krate.attrs
     }
 
+    pub fn get_module(&self, module: DefId) -> (&'hir Mod, Span, NodeId)
+    {
+        let node_id = self.as_local_node_id(module).unwrap();
+        self.read(node_id);
+        match self.find_entry(node_id).unwrap().node {
+            Node::Item(&Item {
+                span,
+                node: ItemKind::Mod(ref m),
+                ..
+            }) => (m, span, node_id),
+            Node::Crate => (&self.forest.krate.module, self.forest.krate.span, node_id),
+            _ => panic!("not a module")
+        }
+    }
+
     pub fn visit_item_likes_in_module<V>(&self, module: DefId, visitor: &mut V)
         where V: ItemLikeVisitor<'hir>
     {

--- a/src/librustc/ich/impls_syntax.rs
+++ b/src/librustc/ich/impls_syntax.rs
@@ -258,7 +258,7 @@ for tokenstream::TokenTree {
             tokenstream::TokenTree::Delimited(span, delim, ref tts) => {
                 span.hash_stable(hcx, hasher);
                 std_hash::Hash::hash(&delim, hasher);
-                for sub_tt in tts.stream().trees() {
+                for sub_tt in tts.trees() {
                     sub_tt.hash_stable(hcx, hasher);
                 }
             }

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -100,6 +100,7 @@ use self::VarKind::*;
 use hir::def::*;
 use hir::Node;
 use ty::{self, TyCtxt};
+use ty::query::{Providers, queries};
 use lint;
 use errors::Applicability;
 use util::nodemap::{NodeMap, HirIdMap, HirIdSet};
@@ -114,8 +115,9 @@ use syntax::ptr::P;
 use syntax::symbol::keywords;
 use syntax_pos::Span;
 
-use hir::{Expr, HirId};
 use hir;
+use hir::{Expr, HirId};
+use hir::def_id::DefId;
 use hir::intravisit::{self, Visitor, FnKind, NestedVisitorMap};
 
 /// For use with `propagate_through_loop`.
@@ -179,9 +181,22 @@ impl<'a, 'tcx> Visitor<'tcx> for IrMaps<'a, 'tcx> {
     fn visit_arm(&mut self, a: &'tcx hir::Arm) { visit_arm(self, a); }
 }
 
+fn check_mod_liveness<'tcx>(tcx: TyCtxt<'_, 'tcx, 'tcx>, module_def_id: DefId) {
+    tcx.hir().visit_item_likes_in_module(module_def_id, &mut IrMaps::new(tcx).as_deep_visitor());
+}
+
 pub fn check_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
-    tcx.hir().krate().visit_all_item_likes(&mut IrMaps::new(tcx).as_deep_visitor());
+    for &module in tcx.hir().krate().modules.keys() {
+        queries::check_mod_liveness::ensure(tcx, tcx.hir().local_def_id(module));
+    }
     tcx.sess.abort_if_errors();
+}
+
+pub fn provide(providers: &mut Providers<'_>) {
+    *providers = Providers {
+        check_mod_liveness,
+        ..*providers
+    };
 }
 
 impl fmt::Debug for LiveNode {

--- a/src/librustc/ty/query/config.rs
+++ b/src/librustc/ty/query/config.rs
@@ -109,6 +109,33 @@ impl<'tcx> QueryDescription<'tcx> for queries::check_mod_item_types<'tcx> {
     }
 }
 
+impl<'tcx> QueryDescription<'tcx> for queries::check_mod_privacy<'tcx> {
+    fn describe(
+        tcx: TyCtxt<'_, '_, '_>,
+        key: DefId,
+    ) -> Cow<'static, str> {
+        format!("checking privacy in {}", key.describe_as_module(tcx)).into()
+    }
+}
+
+impl<'tcx> QueryDescription<'tcx> for queries::check_mod_intrinsics<'tcx> {
+    fn describe(
+        tcx: TyCtxt<'_, '_, '_>,
+        key: DefId,
+    ) -> Cow<'static, str> {
+        format!("checking intrinsics in {}", key.describe_as_module(tcx)).into()
+    }
+}
+
+impl<'tcx> QueryDescription<'tcx> for queries::check_mod_liveness<'tcx> {
+    fn describe(
+        tcx: TyCtxt<'_, '_, '_>,
+        key: DefId,
+    ) -> Cow<'static, str> {
+        format!("checking liveness of variables in {}", key.describe_as_module(tcx)).into()
+    }
+}
+
 impl<'tcx> QueryDescription<'tcx> for queries::collect_mod_item_types<'tcx> {
     fn describe(
         tcx: TyCtxt<'_, '_, '_>,

--- a/src/librustc/ty/query/mod.rs
+++ b/src/librustc/ty/query/mod.rs
@@ -264,6 +264,12 @@ define_queries! { <'tcx>
 
         [] fn check_mod_item_types: CheckModItemTypes(DefId) -> (),
 
+        [] fn check_mod_privacy: CheckModPrivacy(DefId) -> (),
+
+        [] fn check_mod_intrinsics: CheckModIntrinsics(DefId) -> (),
+
+        [] fn check_mod_liveness: CheckModLiveness(DefId) -> (),
+
         [] fn collect_mod_item_types: CollectModItemTypes(DefId) -> (),
 
         /// Caches CoerceUnsized kinds for impls on custom types.

--- a/src/librustc/ty/query/plumbing.rs
+++ b/src/librustc/ty/query/plumbing.rs
@@ -1266,6 +1266,9 @@ pub fn force_from_dep_node<'a, 'gcx, 'lcx>(tcx: TyCtxt<'a, 'gcx, 'lcx>,
         DepKind::CheckModLoops => { force!(check_mod_loops, def_id!()); }
         DepKind::CheckModUnstableApiUsage => { force!(check_mod_unstable_api_usage, def_id!()); }
         DepKind::CheckModItemTypes => { force!(check_mod_item_types, def_id!()); }
+        DepKind::CheckModPrivacy => { force!(check_mod_privacy, def_id!()); }
+        DepKind::CheckModIntrinsics => { force!(check_mod_intrinsics, def_id!()); }
+        DepKind::CheckModLiveness => { force!(check_mod_liveness, def_id!()); }
         DepKind::CollectModItemTypes => { force!(collect_mod_item_types, def_id!()); }
         DepKind::Reachability => { force!(reachable_set, LOCAL_CRATE); }
         DepKind::MirKeys => { force!(mir_keys, LOCAL_CRATE); }

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -1168,6 +1168,8 @@ pub fn default_provide(providers: &mut ty::query::Providers) {
     ty::provide(providers);
     traits::provide(providers);
     stability::provide(providers);
+    middle::intrinsicck::provide(providers);
+    middle::liveness::provide(providers);
     reachable::provide(providers);
     rustc_passes::provide(providers);
     rustc_traits::provide(providers);

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1540,7 +1540,7 @@ impl KeywordIdents {
                     _ => {},
                 }
                 TokenTree::Delimited(_, _, tts) => {
-                    self.check_tokens(cx, tts.stream())
+                    self.check_tokens(cx, tts)
                 },
             }
         }

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -22,12 +22,12 @@ use rustc::lint;
 use rustc::middle::privacy::{AccessLevel, AccessLevels};
 use rustc::ty::{self, TyCtxt, Ty, TraitRef, TypeFoldable, GenericParamDefKind};
 use rustc::ty::fold::TypeVisitor;
-use rustc::ty::query::Providers;
+use rustc::ty::query::{Providers, queries};
 use rustc::ty::subst::Substs;
 use rustc::util::nodemap::NodeSet;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_data_structures::sync::Lrc;
-use syntax::ast::{self, CRATE_NODE_ID, Ident};
+use syntax::ast::{self, DUMMY_NODE_ID, Ident};
 use syntax::attr;
 use syntax::symbol::keywords;
 use syntax_pos::Span;
@@ -782,6 +782,10 @@ impl<'a, 'tcx> Visitor<'tcx> for NamePrivacyVisitor<'a, 'tcx> {
         NestedVisitorMap::All(&self.tcx.hir())
     }
 
+    fn visit_mod(&mut self, _m: &'tcx hir::Mod, _s: Span, _n: ast::NodeId) {
+        // Don't visit modules inside
+    }
+
     fn visit_nested_body(&mut self, body: hir::BodyId) {
         let orig_tables = mem::replace(&mut self.tables, self.tcx.body_tables(body));
         let body = self.tcx.hir().body(body);
@@ -915,6 +919,10 @@ impl<'a, 'tcx> Visitor<'tcx> for TypePrivacyVisitor<'a, 'tcx> {
     /// module and so forth, so supply a crate for doing a deep walk.
     fn nested_visit_map<'this>(&'this mut self) -> NestedVisitorMap<'this, 'tcx> {
         NestedVisitorMap::All(&self.tcx.hir())
+    }
+
+    fn visit_mod(&mut self, _m: &'tcx hir::Mod, _s: Span, _n: ast::NodeId) {
+        // Don't visit modules inside
     }
 
     fn visit_nested_body(&mut self, body: hir::BodyId) {
@@ -1654,6 +1662,7 @@ impl<'a, 'tcx> Visitor<'tcx> for PrivateItemsInPublicInterfacesVisitor<'a, 'tcx>
 pub fn provide(providers: &mut Providers) {
     *providers = Providers {
         privacy_access_levels,
+        check_mod_privacy,
         ..*providers
     };
 }
@@ -1662,34 +1671,43 @@ pub fn check_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) -> Lrc<AccessLevels> {
     tcx.privacy_access_levels(LOCAL_CRATE)
 }
 
-fn privacy_access_levels<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
-                                   krate: CrateNum)
-                                   -> Lrc<AccessLevels> {
-    assert_eq!(krate, LOCAL_CRATE);
-
-    let krate = tcx.hir().krate();
+fn check_mod_privacy<'tcx>(tcx: TyCtxt<'_, 'tcx, 'tcx>, module_def_id: DefId) {
     let empty_tables = ty::TypeckTables::empty(None);
 
     // Check privacy of names not checked in previous compilation stages.
     let mut visitor = NamePrivacyVisitor {
         tcx,
         tables: &empty_tables,
-        current_item: CRATE_NODE_ID,
+        current_item: DUMMY_NODE_ID,
         empty_tables: &empty_tables,
     };
-    intravisit::walk_crate(&mut visitor, krate);
+    let (module, span, node_id) = tcx.hir().get_module(module_def_id);
+    intravisit::walk_mod(&mut visitor, module, node_id);
 
     // Check privacy of explicitly written types and traits as well as
     // inferred types of expressions and patterns.
     let mut visitor = TypePrivacyVisitor {
         tcx,
         tables: &empty_tables,
-        current_item: DefId::local(CRATE_DEF_INDEX),
+        current_item: module_def_id,
         in_body: false,
-        span: krate.span,
+        span,
         empty_tables: &empty_tables,
     };
-    intravisit::walk_crate(&mut visitor, krate);
+    intravisit::walk_mod(&mut visitor, module, node_id);
+}
+
+fn privacy_access_levels<'tcx>(
+    tcx: TyCtxt<'_, 'tcx, 'tcx>,
+    krate: CrateNum,
+) -> Lrc<AccessLevels> {
+    assert_eq!(krate, LOCAL_CRATE);
+
+    let krate = tcx.hir().krate();
+
+    for &module in tcx.hir().krate().modules.keys() {
+        queries::check_mod_privacy::ensure(tcx, tcx.hir().local_def_id(module));
+    }
 
     // Build up a set of all exported items in the AST. This is a set of all
     // items which are reachable from external crates based on visibility.

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -2422,7 +2422,7 @@ if (!DOMTokenList.prototype.remove) {
             return;
         }
         var crates_text = [];
-        if (crates.length > 1) {
+        if (Object.keys(crates).length > 1) {
             for (var crate in crates) {
                 if (crates.hasOwnProperty(crate)) {
                     crates_text.push(crate);

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -15,7 +15,7 @@ use rustc_target::spec::abi::Abi;
 use source_map::{dummy_spanned, respan, Spanned};
 use symbol::{keywords, Symbol};
 use syntax_pos::{Span, DUMMY_SP};
-use tokenstream::{ThinTokenStream, TokenStream};
+use tokenstream::TokenStream;
 use ThinVec;
 
 use rustc_data_structures::fx::FxHashSet;
@@ -1216,7 +1216,7 @@ pub type Mac = Spanned<Mac_>;
 pub struct Mac_ {
     pub path: Path,
     pub delim: MacDelimiter,
-    pub tts: ThinTokenStream,
+    pub tts: TokenStream,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Debug)]
@@ -1228,13 +1228,13 @@ pub enum MacDelimiter {
 
 impl Mac_ {
     pub fn stream(&self) -> TokenStream {
-        self.tts.stream()
+        self.tts.clone()
     }
 }
 
 #[derive(Clone, RustcEncodable, RustcDecodable, Debug)]
 pub struct MacroDef {
-    pub tokens: ThinTokenStream,
+    pub tokens: TokenStream,
     pub legacy: bool,
 }
 

--- a/src/libsyntax/attr/mod.rs
+++ b/src/libsyntax/attr/mod.rs
@@ -565,7 +565,7 @@ impl MetaItemKind {
             }
             Some(TokenTree::Delimited(_, delim, ref tts)) if delim == token::Paren => {
                 tokens.next();
-                tts.stream()
+                tts.clone()
             }
             _ => return Some(MetaItemKind::Word),
         };

--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -748,7 +748,7 @@ fn statements_mk_tt(cx: &ExtCtxt, tt: &TokenTree, quoted: bool) -> Vec<ast::Stmt
         },
         TokenTree::Delimited(span, delim, ref tts) => {
             let mut stmts = statements_mk_tt(cx, &TokenTree::open_tt(span.open, delim), false);
-            stmts.extend(statements_mk_tts(cx, tts.stream()));
+            stmts.extend(statements_mk_tts(cx, tts.clone()));
             stmts.extend(statements_mk_tt(cx, &TokenTree::close_tt(span.close, delim), false));
             stmts
         }

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -598,7 +598,7 @@ pub fn noop_fold_tt<T: Folder>(tt: TokenTree, fld: &mut T) -> TokenTree {
         TokenTree::Delimited(span, delim, tts) => TokenTree::Delimited(
             DelimSpan::from_pair(fld.new_span(span.open), fld.new_span(span.close)),
             delim,
-            fld.fold_tts(tts.stream()).into(),
+            fld.fold_tts(tts).into(),
         ),
     }
 }

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -811,7 +811,7 @@ mod tests {
                 )
                 if name_macro_rules.name == "macro_rules"
                 && name_zip.name == "zip" => {
-                    let tts = &macro_tts.stream().trees().collect::<Vec<_>>();
+                    let tts = &macro_tts.trees().collect::<Vec<_>>();
                     match (tts.len(), tts.get(0), tts.get(1), tts.get(2)) {
                         (
                             3,
@@ -820,7 +820,7 @@ mod tests {
                             Some(&TokenTree::Delimited(_, second_delim, ref second_tts)),
                         )
                         if macro_delim == token::Paren => {
-                            let tts = &first_tts.stream().trees().collect::<Vec<_>>();
+                            let tts = &first_tts.trees().collect::<Vec<_>>();
                             match (tts.len(), tts.get(0), tts.get(1)) {
                                 (
                                     2,
@@ -830,7 +830,7 @@ mod tests {
                                 if first_delim == token::Paren && ident.name == "a" => {},
                                 _ => panic!("value 3: {:?} {:?}", first_delim, first_tts),
                             }
-                            let tts = &second_tts.stream().trees().collect::<Vec<_>>();
+                            let tts = &second_tts.trees().collect::<Vec<_>>();
                             match (tts.len(), tts.get(0), tts.get(1)) {
                                 (
                                     2,

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -807,7 +807,7 @@ pub trait PrintState<'a> {
             TokenTree::Delimited(_, delim, tts) => {
                 self.writer().word(token_to_string(&token::OpenDelim(delim)))?;
                 self.writer().space()?;
-                self.print_tts(tts.stream())?;
+                self.print_tts(tts)?;
                 self.writer().space()?;
                 self.writer().word(token_to_string(&token::CloseDelim(delim)))
             },

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -832,7 +832,7 @@ pub fn walk_attribute<'a, V: Visitor<'a>>(visitor: &mut V, attr: &'a Attribute) 
 pub fn walk_tt<'a, V: Visitor<'a>>(visitor: &mut V, tt: TokenTree) {
     match tt {
         TokenTree::Token(_, tok) => visitor.visit_token(tok),
-        TokenTree::Delimited(_, _, tts) => visitor.visit_tts(tts.stream()),
+        TokenTree::Delimited(_, _, tts) => visitor.visit_tts(tts),
     }
 }
 

--- a/src/libsyntax_ext/format.rs
+++ b/src/libsyntax_ext/format.rs
@@ -493,7 +493,10 @@ impl<'a, 'b> Context<'a, 'b> {
 
                 let fill = arg.format.fill.unwrap_or(' ');
 
-                if *arg != simple_arg || fill != ' ' {
+                let pos_simple =
+                    arg.position.index() == simple_arg.position.index();
+
+                if !pos_simple || arg.format != simple_arg.format || fill != ' ' {
                     self.all_pieces_simple = false;
                 }
 

--- a/src/libsyntax_ext/proc_macro_server.rs
+++ b/src/libsyntax_ext/proc_macro_server.rs
@@ -269,7 +269,7 @@ impl ToInternal<TokenStream> for TokenTree<Group, Punct, Ident, Literal> {
         };
 
         let tree = tokenstream::TokenTree::Token(span, token);
-        TokenStream::Tree(tree, if joint { Joint } else { NonJoint })
+        TokenStream::new(vec![(tree, if joint { Joint } else { NonJoint })])
     }
 }
 

--- a/src/test/ui/coherence/coherence-impl-trait-for-marker-trait-negative.rs
+++ b/src/test/ui/coherence/coherence-impl-trait-for-marker-trait-negative.rs
@@ -1,0 +1,29 @@
+#![feature(optin_builtin_traits)]
+
+// Test for issue #56934 - that it is impossible to redundantly
+// implement an auto-trait for a trait object type that contains it.
+
+// Negative impl variant.
+
+auto trait Marker1 {}
+auto trait Marker2 {}
+
+trait Object: Marker1 {}
+
+// A supertrait marker is illegal...
+impl !Marker1 for dyn Object + Marker2 { }   //~ ERROR E0371
+// ...and also a direct component.
+impl !Marker2 for dyn Object + Marker2 { }   //~ ERROR E0371
+
+// But implementing a marker if it is not present is OK.
+impl !Marker2 for dyn Object {} // OK
+
+// A non-principal trait-object type is orphan even in its crate.
+impl !Send for dyn Marker2 {} //~ ERROR E0117
+
+// And impl'ing a remote marker for a local trait object is forbidden
+// by one of these special orphan-like rules.
+impl !Send for dyn Object {} //~ ERROR E0321
+impl !Send for dyn Object + Marker2 {} //~ ERROR E0321
+
+fn main() { }

--- a/src/test/ui/coherence/coherence-impl-trait-for-marker-trait-negative.stderr
+++ b/src/test/ui/coherence/coherence-impl-trait-for-marker-trait-negative.stderr
@@ -1,0 +1,37 @@
+error[E0371]: the object type `(dyn Object + Marker2 + 'static)` automatically implements the trait `Marker1`
+  --> $DIR/coherence-impl-trait-for-marker-trait-negative.rs:14:1
+   |
+LL | impl !Marker1 for dyn Object + Marker2 { }   //~ ERROR E0371
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Object + Marker2 + 'static)` automatically implements trait `Marker1`
+
+error[E0371]: the object type `(dyn Object + Marker2 + 'static)` automatically implements the trait `Marker2`
+  --> $DIR/coherence-impl-trait-for-marker-trait-negative.rs:16:1
+   |
+LL | impl !Marker2 for dyn Object + Marker2 { }   //~ ERROR E0371
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Object + Marker2 + 'static)` automatically implements trait `Marker2`
+
+error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
+  --> $DIR/coherence-impl-trait-for-marker-trait-negative.rs:22:1
+   |
+LL | impl !Send for dyn Marker2 {} //~ ERROR E0117
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   |
+   = note: the impl does not reference any types defined in this crate
+   = note: define and implement a trait or new type instead
+
+error[E0321]: cross-crate traits with a default impl, like `std::marker::Send`, can only be implemented for a struct/enum type, not `(dyn Object + 'static)`
+  --> $DIR/coherence-impl-trait-for-marker-trait-negative.rs:26:1
+   |
+LL | impl !Send for dyn Object {} //~ ERROR E0321
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^ can't implement cross-crate trait with a default impl for non-struct/enum type
+
+error[E0321]: cross-crate traits with a default impl, like `std::marker::Send`, can only be implemented for a struct/enum type, not `(dyn Object + Marker2 + 'static)`
+  --> $DIR/coherence-impl-trait-for-marker-trait-negative.rs:27:1
+   |
+LL | impl !Send for dyn Object + Marker2 {} //~ ERROR E0321
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't implement cross-crate trait with a default impl for non-struct/enum type
+
+error: aborting due to 5 previous errors
+
+Some errors occurred: E0117, E0321, E0371.
+For more information about an error, try `rustc --explain E0117`.

--- a/src/test/ui/coherence/coherence-impl-trait-for-marker-trait-negative.stderr
+++ b/src/test/ui/coherence/coherence-impl-trait-for-marker-trait-negative.stderr
@@ -16,7 +16,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl !Send for dyn Marker2 {} //~ ERROR E0117
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error[E0321]: cross-crate traits with a default impl, like `std::marker::Send`, can only be implemented for a struct/enum type, not `(dyn Object + 'static)`

--- a/src/test/ui/coherence/coherence-impl-trait-for-marker-trait-positive.rs
+++ b/src/test/ui/coherence/coherence-impl-trait-for-marker-trait-positive.rs
@@ -1,0 +1,29 @@
+#![feature(optin_builtin_traits)]
+
+// Test for issue #56934 - that it is impossible to redundantly
+// implement an auto-trait for a trait object type that contains it.
+
+// Positive impl variant.
+
+auto trait Marker1 {}
+auto trait Marker2 {}
+
+trait Object: Marker1 {}
+
+// A supertrait marker is illegal...
+impl Marker1 for dyn Object + Marker2 { }   //~ ERROR E0371
+// ...and also a direct component.
+impl Marker2 for dyn Object + Marker2 { }   //~ ERROR E0371
+
+// But implementing a marker if it is not present is OK.
+impl Marker2 for dyn Object {} // OK
+
+// A non-principal trait-object type is orphan even in its crate.
+unsafe impl Send for dyn Marker2 {} //~ ERROR E0117
+
+// And impl'ing a remote marker for a local trait object is forbidden
+// by one of these special orphan-like rules.
+unsafe impl Send for dyn Object {} //~ ERROR E0321
+unsafe impl Send for dyn Object + Marker2 {} //~ ERROR E0321
+
+fn main() { }

--- a/src/test/ui/coherence/coherence-impl-trait-for-marker-trait-positive.stderr
+++ b/src/test/ui/coherence/coherence-impl-trait-for-marker-trait-positive.stderr
@@ -1,0 +1,37 @@
+error[E0371]: the object type `(dyn Object + Marker2 + 'static)` automatically implements the trait `Marker1`
+  --> $DIR/coherence-impl-trait-for-marker-trait-positive.rs:14:1
+   |
+LL | impl Marker1 for dyn Object + Marker2 { }   //~ ERROR E0371
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Object + Marker2 + 'static)` automatically implements trait `Marker1`
+
+error[E0371]: the object type `(dyn Object + Marker2 + 'static)` automatically implements the trait `Marker2`
+  --> $DIR/coherence-impl-trait-for-marker-trait-positive.rs:16:1
+   |
+LL | impl Marker2 for dyn Object + Marker2 { }   //~ ERROR E0371
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Object + Marker2 + 'static)` automatically implements trait `Marker2`
+
+error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
+  --> $DIR/coherence-impl-trait-for-marker-trait-positive.rs:22:1
+   |
+LL | unsafe impl Send for dyn Marker2 {} //~ ERROR E0117
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   |
+   = note: the impl does not reference any types defined in this crate
+   = note: define and implement a trait or new type instead
+
+error[E0321]: cross-crate traits with a default impl, like `std::marker::Send`, can only be implemented for a struct/enum type, not `(dyn Object + 'static)`
+  --> $DIR/coherence-impl-trait-for-marker-trait-positive.rs:26:1
+   |
+LL | unsafe impl Send for dyn Object {} //~ ERROR E0321
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't implement cross-crate trait with a default impl for non-struct/enum type
+
+error[E0321]: cross-crate traits with a default impl, like `std::marker::Send`, can only be implemented for a struct/enum type, not `(dyn Object + Marker2 + 'static)`
+  --> $DIR/coherence-impl-trait-for-marker-trait-positive.rs:27:1
+   |
+LL | unsafe impl Send for dyn Object + Marker2 {} //~ ERROR E0321
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't implement cross-crate trait with a default impl for non-struct/enum type
+
+error: aborting due to 5 previous errors
+
+Some errors occurred: E0117, E0321, E0371.
+For more information about an error, try `rustc --explain E0117`.

--- a/src/test/ui/coherence/coherence-impl-trait-for-marker-trait-positive.stderr
+++ b/src/test/ui/coherence/coherence-impl-trait-for-marker-trait-positive.stderr
@@ -16,7 +16,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | unsafe impl Send for dyn Marker2 {} //~ ERROR E0117
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference any types defined in this crate
+   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error[E0321]: cross-crate traits with a default impl, like `std::marker::Send`, can only be implemented for a struct/enum type, not `(dyn Object + 'static)`

--- a/src/test/ui/pattern/const-pat-ice.rs
+++ b/src/test/ui/pattern/const-pat-ice.rs
@@ -1,4 +1,5 @@
 // failure-status: 101
+// rustc-env:RUST_BACKTRACE=0
 
 // This is a repro test for an ICE in our pattern handling of constants.
 


### PR DESCRIPTION
Successful merges:

 - #57253 (Make privacy checking, intrinsic checking and liveness checking incremental)
 - #57352 (forbid manually impl'ing one of an object type's marker traits)
 - #57486 (Simplify `TokenStream` some more)
 - #57537 (Small perf improvement for fmt)
 - #57579 (Add core::iter::once_with())
 - #57587 (Add 'rustc-env:RUST_BACKTRACE=0' to const-pat-ice test)
 - #57608 (Simplify 'product' factorial example)
 - #57614 ([rustdoc] Fix crates filtering box not being filled)

Failed merges:


r? @ghost