### PR TITLE
Fix memory leak in P::filter_map

### DIFF
--- a/src/libsyntax/ptr.rs
+++ b/src/libsyntax/ptr.rs
@@ -101,6 +101,7 @@ impl<T: 'static> P<T> {
                 // Recreate self from the raw pointer.
                 Some(P { ptr: Box::from_raw(p) })
             } else {
+                drop(Box::from_raw(p));
                 None
             }
         }


### PR DESCRIPTION
Probably this function isn't widely used, but anyway this wasn't working as intended.

r? @eddyb 

Do not rollup if you want to see if max-rss change in perf.