### PR TITLE
Make iter::Empty<T> Send and Sync for any T

### DIFF
--- a/src/libcore/iter/sources.rs
+++ b/src/libcore/iter/sources.rs
@@ -198,7 +198,10 @@ pub fn repeat_with<A, F: FnMut() -> A>(repeater: F) -> RepeatWith<F> {
 ///
 /// [`empty`]: fn.empty.html
 #[stable(feature = "iter_empty", since = "1.2.0")]
-pub struct Empty<T>(marker::PhantomData<T>);
+pub struct Empty<T>(marker::PhantomData<PhantomFnWorkaround<T>>);
+
+// Workaround for PhantomData<fn() -> T> not being allowed in const fn.
+struct PhantomFnWorkaround<T>(fn() -> T);
 
 #[stable(feature = "core_impl_debug", since = "1.9.0")]
 impl<T> fmt::Debug for Empty<T> {

--- a/src/test/run-pass/threads-sendsync/sync-send-iterators-in-libcore.rs
+++ b/src/test/run-pass/threads-sendsync/sync-send-iterators-in-libcore.rs
@@ -91,6 +91,7 @@ fn main() {
     is_sync_send!((1..));
     is_sync_send!(repeat(1));
     is_sync_send!(empty::<usize>());
+    is_sync_send!(empty::<*mut i32>());
     is_sync_send!(once(1));
 
     // for option.rs


### PR DESCRIPTION
Just because it can be. Likely nobody will be using that property of `iter::empty`, but at the same time, there is no reason to not allow it.