### PR TITLE
Prepare beta 1.33.0, take 2

### DIFF
--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -43,7 +43,7 @@ fi
 #
 # FIXME: need a scheme for changing this `nightly` value to `beta` and `stable`
 #        either automatically or manually.
-export RUST_RELEASE_CHANNEL=nightly
+export RUST_RELEASE_CHANNEL=beta
 if [ "$DEPLOY$DEPLOY_ALT" != "" ]; then
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --release-channel=$RUST_RELEASE_CHANNEL"
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-llvm-static-stdcpp"

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -47,6 +47,8 @@ assert_eq!(size_of::<Option<std::num::", stringify!($Ty), ">>(), size_of::<", st
                 #[stable(feature = "nonzero", since = "1.28.0")]
                 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
                 #[repr(transparent)]
+                // FIXME: the rustc_layout_scalar_valid_range_start attr is marked as unused
+                #[cfg_attr(stage0, allow(unused_attributes))]
                 #[rustc_layout_scalar_valid_range_start(1)]
                 pub struct $Ty($Int);
             }
@@ -68,6 +70,8 @@ assert_eq!(size_of::<Option<std::num::", stringify!($Ty), ">>(), size_of::<", st
                 #[inline]
                 pub fn new(n: $Int) -> Option<Self> {
                     if n != 0 {
+                        // FIXME: this unsafe block is actually needed
+                        #[cfg_attr(stage0, allow(unused_unsafe))]
                         Some(unsafe { $Ty(n) })
                     } else {
                         None

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -2718,6 +2718,8 @@ impl<T: ?Sized> PartialOrd for *mut T {
                      (if you also use #[may_dangle]), Send, and/or Sync")]
 #[doc(hidden)]
 #[repr(transparent)]
+// FIXME: the rustc_layout_scalar_valid_range_start attr is marked as unused
+#[cfg_attr(stage0, allow(unused_attributes))]
 #[rustc_layout_scalar_valid_range_start(1)]
 pub struct Unique<T: ?Sized> {
     pointer: *const T,
@@ -2783,6 +2785,8 @@ impl<T: ?Sized> Unique<T> {
     /// Creates a new `Unique` if `ptr` is non-null.
     pub fn new(ptr: *mut T) -> Option<Self> {
         if !ptr.is_null() {
+            // FIXME: this unsafe block is actually needed
+            #[cfg_attr(stage0, allow(unused_unsafe))]
             Some(unsafe { Unique { pointer: ptr as _, _marker: PhantomData } })
         } else {
             None
@@ -2839,6 +2843,8 @@ impl<T: ?Sized> fmt::Pointer for Unique<T> {
 #[unstable(feature = "ptr_internals", issue = "0")]
 impl<'a, T: ?Sized> From<&'a mut T> for Unique<T> {
     fn from(reference: &'a mut T) -> Self {
+        // FIXME: this unsafe block is actually needed
+        #[cfg_attr(stage0, allow(unused_unsafe))]
         unsafe { Unique { pointer: reference as *mut T, _marker: PhantomData } }
     }
 }
@@ -2846,6 +2852,8 @@ impl<'a, T: ?Sized> From<&'a mut T> for Unique<T> {
 #[unstable(feature = "ptr_internals", issue = "0")]
 impl<'a, T: ?Sized> From<&'a T> for Unique<T> {
     fn from(reference: &'a T) -> Self {
+        // FIXME: this unsafe block is actually needed
+        #[cfg_attr(stage0, allow(unused_unsafe))]
         unsafe { Unique { pointer: reference as *const T, _marker: PhantomData } }
     }
 }
@@ -2853,6 +2861,8 @@ impl<'a, T: ?Sized> From<&'a T> for Unique<T> {
 #[unstable(feature = "ptr_internals", issue = "0")]
 impl<'a, T: ?Sized> From<NonNull<T>> for Unique<T> {
     fn from(p: NonNull<T>) -> Self {
+        // FIXME: this unsafe block is actually needed
+        #[cfg_attr(stage0, allow(unused_unsafe))]
         unsafe { Unique { pointer: p.pointer, _marker: PhantomData } }
     }
 }
@@ -3042,6 +3052,8 @@ impl<T: ?Sized> hash::Hash for NonNull<T> {
 impl<T: ?Sized> From<Unique<T>> for NonNull<T> {
     #[inline]
     fn from(unique: Unique<T>) -> Self {
+        // FIXME: this unsafe block is actually needed
+        #[cfg_attr(stage0, allow(unused_unsafe))]
         unsafe { NonNull { pointer: unique.pointer } }
     }
 }
@@ -3050,6 +3062,8 @@ impl<T: ?Sized> From<Unique<T>> for NonNull<T> {
 impl<'a, T: ?Sized> From<&'a mut T> for NonNull<T> {
     #[inline]
     fn from(reference: &'a mut T) -> Self {
+        // FIXME: this unsafe block is actually needed
+        #[cfg_attr(stage0, allow(unused_unsafe))]
         unsafe { NonNull { pointer: reference as *mut T } }
     }
 }
@@ -3058,6 +3072,8 @@ impl<'a, T: ?Sized> From<&'a mut T> for NonNull<T> {
 impl<'a, T: ?Sized> From<&'a T> for NonNull<T> {
     #[inline]
     fn from(reference: &'a T) -> Self {
+        // FIXME: this unsafe block is actually needed
+        #[cfg_attr(stage0, allow(unused_unsafe))]
         unsafe { NonNull { pointer: reference as *const T } }
     }
 }

--- a/src/stage0.txt
+++ b/src/stage0.txt
@@ -12,9 +12,9 @@
 # source tarball for a stable release you'll likely see `1.x.0` for rustc and
 # `0.x.0` for Cargo where they were released on `date`.
 
-date: 2019-01-04
-rustc: beta
-cargo: beta
+date: 2019-01-16
+rustc: 1.32.0
+cargo: 0.33.0
 
 # When making a stable release the process currently looks like:
 #
@@ -34,4 +34,4 @@ cargo: beta
 # looking at a beta source tarball and it's uncommented we'll shortly comment it
 # out.
 
-#dev: 1
+dev: 1


### PR DESCRIPTION
This PR includes the usual changes for a new beta, and suppresses a few lints on libcore: those lints are false positives caused by an internal attribute (rustc_layout_scalar_valid_range_start) and only happen on stage0.

r? @Mark-Simulacrum 

*Note: recreated to avoid issues with the old PR.*