### PR TITLE
Use a faster early exit during region expansion

### DIFF
--- a/src/librustc/infer/lexical_region_resolve/mod.rs
+++ b/src/librustc/infer/lexical_region_resolve/mod.rs
@@ -236,6 +236,14 @@ impl<'cx, 'gcx, 'tcx> LexicalResolver<'cx, 'gcx, 'tcx> {
 
         match *b_data {
             VarValue::Value(cur_region) => {
+                // Identical scopes can show up quite often, if the fixed point
+                // iteration converges slowly, skip them
+                if let (ReScope(a_scope), ReScope(cur_scope)) = (a_region, cur_region) {
+                    if a_scope == cur_scope {
+                        return false;
+                    }
+                }
+
                 let mut lub = self.lub_concrete_regions(a_region, cur_region);
                 if lub == cur_region {
                     return false;
@@ -274,12 +282,6 @@ impl<'cx, 'gcx, 'tcx> LexicalResolver<'cx, 'gcx, 'tcx> {
 
     fn lub_concrete_regions(&self, a: Region<'tcx>, b: Region<'tcx>) -> Region<'tcx> {
         let tcx = self.tcx();
-
-        // Equal scopes can show up quite often, if the fixed point
-        // iteration converges slowly, skip them
-        if a == b {
-            return a;
-        }
 
         match (a, b) {
             (&ty::ReClosureBound(..), _)


### PR DESCRIPTION
Turns out that the equality check for regions is rather expensive, and
the current early exit check works in such a way, that the comparison is
even done twice. As we only really care about the case of equal scopes,
we can perform a faster, more specialized check and move it up one
level, so we can eventually skip the additional full comparison as well.