### PR TITLE
Install missing 'rust-gdbui''

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -602,7 +602,7 @@ impl Step for DebuggerScripts {
             // gdb debugger scripts
             builder.install(&builder.src.join("src/etc/rust-gdb"), &sysroot.join("bin"),
                     0o755);
-            builder.install(&builder.src.join("src/etc/rust-gdbui"), &sysroot.join("bin"),
+            builder.install(&builder.src.join("src/etc/rust-gdbgui"), &sysroot.join("bin"),
                     0o755);
 
             cp_debugger_script("gdb_load_rust_pretty_printers.py");

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -602,6 +602,8 @@ impl Step for DebuggerScripts {
             // gdb debugger scripts
             builder.install(&builder.src.join("src/etc/rust-gdb"), &sysroot.join("bin"),
                     0o755);
+            builder.install(&builder.src.join("src/etc/rust-gdbui"), &sysroot.join("bin"),
+                    0o755);
 
             cp_debugger_script("gdb_load_rust_pretty_printers.py");
             cp_debugger_script("gdb_rust_pretty_printing.py");


### PR DESCRIPTION
PR #53774 added `rust-gdbui` as wrapper to launch [gdbui](https://gdbgui.com/), similar to `rust-gdb`.

Unfortunately I've never seen the script in my local installation (from rustup, using rust 1.31.1). @tromey on the PR [suggested it might be missing](https://github.com/rust-lang/rust/pull/53774#issuecomment-419704939) from the installation process.

This PR simply adds a line for `rust-gdbui` too.