### PR TITLE
Fix docs rendering

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -392,7 +392,7 @@ h4 > code, h3 > code, .invisible > code {
 }
 
 .in-band, code {
-	z-index: -5;
+	z-index: 5;
 }
 
 .invisible {


### PR DESCRIPTION
Rustdoc seems broken since 34bd2b845b3acd84c5a9bddae3ff8081c19ec5e9. When clicking on links on the left navigation list, the method linked to disappears, covered up by the highlight. On some pages, none of the parameter or return types are clickable. This one line seems to be the culprit.