### PR TITLE
Rollup of 17 pull requests

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -90,6 +90,11 @@
 # with clang-cl, so this is special in that it only compiles LLVM with clang-cl
 #clang-cl = '/path/to/clang-cl.exe'
 
+# Pass extra compiler and linker flags to the LLVM CMake build.
+#cflags = "-fextra-flag"
+#cxxflags = "-fextra-flag"
+#ldflags = "-Wl,extra-flag"
+
 # Use libc++ when building LLVM instead of libstdc++. This is the default on
 # platforms already use libc++ as the default C++ library, but this option
 # allows you to use libc++ even on platforms when it's not. You need to ensure

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -82,6 +82,9 @@ pub struct Config {
     pub lldb_enabled: bool,
     pub llvm_tools_enabled: bool,
 
+    pub llvm_cflags: Option<String>,
+    pub llvm_cxxflags: Option<String>,
+    pub llvm_ldflags: Option<String>,
     pub llvm_use_libcxx: bool,
 
     // rust codegen options
@@ -254,6 +257,9 @@ struct Llvm {
     link_shared: Option<bool>,
     version_suffix: Option<String>,
     clang_cl: Option<String>,
+    cflags: Option<String>,
+    cxxflags: Option<String>,
+    ldflags: Option<String>,
     use_libcxx: Option<bool>,
 }
 
@@ -516,6 +522,10 @@ impl Config {
             config.llvm_link_jobs = llvm.link_jobs;
             config.llvm_version_suffix = llvm.version_suffix.clone();
             config.llvm_clang_cl = llvm.clang_cl.clone();
+
+            config.llvm_cflags = llvm.cflags.clone();
+            config.llvm_cxxflags = llvm.cxxflags.clone();
+            config.llvm_ldflags = llvm.ldflags.clone();
             set(&mut config.llvm_use_libcxx, llvm.use_libcxx);
         }
 

--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -64,6 +64,10 @@ o("lldb", "rust.lldb", "build lldb")
 o("missing-tools", "dist.missing-tools", "allow failures when building tools")
 o("use-libcxx", "llvm.use_libcxx", "build LLVM with libc++")
 
+o("cflags", "llvm.cflags", "build LLVM with these extra compiler flags")
+o("cxxflags", "llvm.cxxflags", "build LLVM with these extra compiler flags")
+o("ldflags", "llvm.ldflags", "build LLVM with these extra linker flags")
+
 # Optimization and debugging options. These may be overridden by the release
 # channel, etc.
 o("optimize", "rust.optimize", "build optimized rust code")

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -65,6 +65,7 @@ use self::Ordering::*;
 /// the same book if their ISBN matches, even if the formats differ:
 ///
 /// ```
+/// #[derive(PartialEq)]
 /// enum BookFormat {
 ///     Paperback,
 ///     Hardback,

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -142,33 +142,33 @@ use self::Ordering::*;
 ///     Hardback,
 ///     Ebook,
 /// }
-/// 
+///
 /// struct Book {
 ///     isbn: i32,
 ///     format: BookFormat,
 /// }
-/// 
+///
 /// impl PartialEq<BookFormat> for Book {
 ///     fn eq(&self, other: &BookFormat) -> bool {
 ///         self.format == *other
 ///     }
 /// }
-/// 
+///
 /// impl PartialEq<Book> for BookFormat {
 ///     fn eq(&self, other: &Book) -> bool {
 ///         *self == other.format
 ///     }
 /// }
-/// 
+///
 /// impl PartialEq for Book {
 ///     fn eq(&self, other: &Book) -> bool {
 ///         self.isbn == other.isbn
 ///     }
 /// }
-/// 
+///
 /// let b1 = Book { isbn: 3, format: BookFormat::Paperback };
 /// let b2 = Book { isbn: 3, format: BookFormat::Ebook };
-/// 
+///
 /// assert!(b1 == BookFormat::Paperback);
 /// assert!(b1 != BookFormat::Ebook);
 /// assert!(b1 == b2);

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -170,7 +170,7 @@ use self::Ordering::*;
 /// let b2 = Book { isbn: 3, format: BookFormat::Ebook };
 ///
 /// assert!(b1 == BookFormat::Paperback);
-/// assert!(b1 != BookFormat::Ebook);
+/// assert!(BookFormat::Ebook != b1);
 /// assert!(b1 == b2);
 /// ```
 ///

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -96,6 +96,7 @@ use self::Ordering::*;
 /// For example, let's tweak our previous code a bit:
 ///
 /// ```
+/// // The derive implements <BookFormat> == <BookFormat> comparisons
 /// #[derive(PartialEq)]
 /// enum BookFormat {
 ///     Paperback,

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -65,7 +65,6 @@ use self::Ordering::*;
 /// the same book if their ISBN matches, even if the formats differ:
 ///
 /// ```
-/// #[derive(PartialEq)]
 /// enum BookFormat {
 ///     Paperback,
 ///     Hardback,
@@ -97,6 +96,7 @@ use self::Ordering::*;
 /// For example, let's tweak our previous code a bit:
 ///
 /// ```
+/// #[derive(PartialEq)]
 /// enum BookFormat {
 ///     Paperback,
 ///     Hardback,

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -107,66 +107,28 @@ use self::Ordering::*;
 ///     format: BookFormat,
 /// }
 ///
+/// // Implement <Book> == <BookFormat> comparisons
 /// impl PartialEq<BookFormat> for Book {
 ///     fn eq(&self, other: &BookFormat) -> bool {
-///         match (&self.format, other) {
-///            (BookFormat::Paperback, BookFormat::Paperback) => true,
-///            (BookFormat::Hardback,  BookFormat::Hardback)  => true,
-///            (BookFormat::Ebook,     BookFormat::Ebook)     => true,
-///            (_, _) => false,
-///         }
+///         self.format == *other
+///     }
+/// }
+///
+/// // Implement <BookFormat> == <Book> comparisons
+/// impl PartialEq<Book> for BookFormat {
+///     fn eq(&self, other: &Book) -> bool {
+///         *other == self.format
 ///     }
 /// }
 ///
 /// let b1 = Book { isbn: 3, format: BookFormat::Paperback };
 ///
 /// assert!(b1 == BookFormat::Paperback);
-/// assert!(b1 != BookFormat::Ebook);
+/// assert!(BookFormat::Ebook != b1);
 /// ```
 ///
 /// By changing `impl PartialEq for Book` to `impl PartialEq<BookFormat> for Book`,
-/// we've changed what type we can use on the right side of the `==` operator.
-/// This lets us use it in the `assert!` statements at the bottom.
-///
-/// You can also combine these implementations to let the `==` operator work with
-/// two different types:
-///
-/// ```
-/// enum BookFormat {
-///     Paperback,
-///     Hardback,
-///     Ebook,
-/// }
-///
-/// struct Book {
-///     isbn: i32,
-///     format: BookFormat,
-/// }
-///
-/// impl PartialEq<BookFormat> for Book {
-///     fn eq(&self, other: &BookFormat) -> bool {
-///         match (&self.format, other) {
-///            (&BookFormat::Paperback, &BookFormat::Paperback) => true,
-///            (&BookFormat::Hardback,  &BookFormat::Hardback)  => true,
-///            (&BookFormat::Ebook,     &BookFormat::Ebook)     => true,
-///            (_, _) => false,
-///         }
-///     }
-/// }
-///
-/// impl PartialEq for Book {
-///     fn eq(&self, other: &Book) -> bool {
-///         self.isbn == other.isbn
-///     }
-/// }
-///
-/// let b1 = Book { isbn: 3, format: BookFormat::Paperback };
-/// let b2 = Book { isbn: 3, format: BookFormat::Ebook };
-///
-/// assert!(b1 == BookFormat::Paperback);
-/// assert!(b1 != BookFormat::Ebook);
-/// assert!(b1 == b2);
-/// ```
+/// we allow `BookFormat`s to be compared with `Book`s.
 ///
 /// # Examples
 ///

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -132,6 +132,48 @@ use self::Ordering::*;
 /// By changing `impl PartialEq for Book` to `impl PartialEq<BookFormat> for Book`,
 /// we allow `BookFormat`s to be compared with `Book`s.
 ///
+/// You can also combine these implementations to let the `==` operator work with
+/// two different types:
+///
+/// ```
+/// #[derive(PartialEq)]
+/// enum BookFormat {
+///     Paperback,
+///     Hardback,
+///     Ebook,
+/// }
+/// 
+/// struct Book {
+///     isbn: i32,
+///     format: BookFormat,
+/// }
+/// 
+/// impl PartialEq<BookFormat> for Book {
+///     fn eq(&self, other: &BookFormat) -> bool {
+///         self.format == *other
+///     }
+/// }
+/// 
+/// impl PartialEq<Book> for BookFormat {
+///     fn eq(&self, other: &Book) -> bool {
+///         *self == other.format
+///     }
+/// }
+/// 
+/// impl PartialEq for Book {
+///     fn eq(&self, other: &Book) -> bool {
+///         self.isbn == other.isbn
+///     }
+/// }
+/// 
+/// let b1 = Book { isbn: 3, format: BookFormat::Paperback };
+/// let b2 = Book { isbn: 3, format: BookFormat::Ebook };
+/// 
+/// assert!(b1 == BookFormat::Paperback);
+/// assert!(b1 != BookFormat::Ebook);
+/// assert!(b1 == b2);
+/// ```
+///
 /// # Examples
 ///
 /// ```

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -117,7 +117,7 @@ use self::Ordering::*;
 /// // Implement <BookFormat> == <Book> comparisons
 /// impl PartialEq<Book> for BookFormat {
 ///     fn eq(&self, other: &Book) -> bool {
-///         *other == self.format
+///         *self == other.format
 ///     }
 /// }
 ///

--- a/src/libcore/ffi.rs
+++ b/src/libcore/ffi.rs
@@ -22,16 +22,18 @@ use ::fmt;
 // N.B., for LLVM to recognize the void pointer type and by extension
 //     functions like malloc(), we need to have it represented as i8* in
 //     LLVM bitcode. The enum used here ensures this and prevents misuse
-//     of the "raw" type by only having private variants.. We need two
+//     of the "raw" type by only having private variants. We need two
 //     variants, because the compiler complains about the repr attribute
-//     otherwise.
+//     otherwise and we need at least one variant as otherwise the enum
+//     would be uninhabited and at least dereferencing such pointers would
+//     be UB.
 #[repr(u8)]
 #[stable(feature = "raw_os", since = "1.1.0")]
 pub enum c_void {
-    #[unstable(feature = "c_void_variant", reason = "should not have to exist",
+    #[unstable(feature = "c_void_variant", reason = "temporary implementation detail",
                issue = "0")]
     #[doc(hidden)] __variant1,
-    #[unstable(feature = "c_void_variant", reason = "should not have to exist",
+    #[unstable(feature = "c_void_variant", reason = "temporary implementation detail",
                issue = "0")]
     #[doc(hidden)] __variant2,
 }

--- a/src/libcore/ffi.rs
+++ b/src/libcore/ffi.rs
@@ -13,11 +13,12 @@ use ::fmt;
 /// and `*mut c_void` is equivalent to C's `void*`. That said, this is
 /// *not* the same as C's `void` return type, which is Rust's `()` type.
 ///
-/// Ideally, this type would be equivalent to [`!`], but currently it may
-/// be more ideal to use `c_void` for FFI purposes.
+/// To model pointers to opaque types in FFI, until `extern type` is
+/// stabilized, it is recommended to use a newtype wrapper around an empty
+/// byte array. See the [Nomicon] for details.
 ///
-/// [`!`]: ../../std/primitive.never.html
 /// [pointer]: ../../std/primitive.pointer.html
+/// [Nomicon]: https://doc.rust-lang.org/nomicon/ffi.html#representing-opaque-structs
 // N.B., for LLVM to recognize the void pointer type and by extension
 //     functions like malloc(), we need to have it represented as i8* in
 //     LLVM bitcode. The enum used here ensures this and prevents misuse

--- a/src/libcore/ffi.rs
+++ b/src/libcore/ffi.rs
@@ -49,7 +49,7 @@ impl fmt::Debug for c_void {
 #[unstable(feature = "c_variadic",
            reason = "the `c_variadic` feature has not been properly tested on \
                      all supported platforms",
-           issue = "27745")]
+           issue = "44930")]
 extern {
     type VaListImpl;
 }
@@ -74,7 +74,7 @@ impl fmt::Debug for VaListImpl {
 #[unstable(feature = "c_variadic",
            reason = "the `c_variadic` feature has not been properly tested on \
                      all supported platforms",
-           issue = "27745")]
+           issue = "44930")]
 struct VaListImpl {
     stack: *mut (),
     gr_top: *mut (),
@@ -90,7 +90,7 @@ struct VaListImpl {
 #[unstable(feature = "c_variadic",
            reason = "the `c_variadic` feature has not been properly tested on \
                      all supported platforms",
-           issue = "27745")]
+           issue = "44930")]
 struct VaListImpl {
     gpr: u8,
     fpr: u8,
@@ -106,7 +106,7 @@ struct VaListImpl {
 #[unstable(feature = "c_variadic",
            reason = "the `c_variadic` feature has not been properly tested on \
                      all supported platforms",
-           issue = "27745")]
+           issue = "44930")]
 struct VaListImpl {
     gp_offset: i32,
     fp_offset: i32,
@@ -120,7 +120,7 @@ struct VaListImpl {
 #[unstable(feature = "c_variadic",
            reason = "the `c_variadic` feature has not been properly tested on \
                      all supported platforms",
-           issue = "27745")]
+           issue = "44930")]
 #[repr(transparent)]
 pub struct VaList<'a>(&'a mut VaListImpl);
 
@@ -140,7 +140,7 @@ mod sealed_trait {
     #[unstable(feature = "c_variadic",
                reason = "the `c_variadic` feature has not been properly tested on \
                          all supported platforms",
-               issue = "27745")]
+               issue = "44930")]
     pub trait VaArgSafe {}
 }
 
@@ -150,7 +150,7 @@ macro_rules! impl_va_arg_safe {
             #[unstable(feature = "c_variadic",
                        reason = "the `c_variadic` feature has not been properly tested on \
                                  all supported platforms",
-                       issue = "27745")]
+                       issue = "44930")]
             impl sealed_trait::VaArgSafe for $t {}
         )+
     }
@@ -163,12 +163,12 @@ impl_va_arg_safe!{f64}
 #[unstable(feature = "c_variadic",
            reason = "the `c_variadic` feature has not been properly tested on \
                      all supported platforms",
-           issue = "27745")]
+           issue = "44930")]
 impl<T> sealed_trait::VaArgSafe for *mut T {}
 #[unstable(feature = "c_variadic",
            reason = "the `c_variadic` feature has not been properly tested on \
                      all supported platforms",
-           issue = "27745")]
+           issue = "44930")]
 impl<T> sealed_trait::VaArgSafe for *const T {}
 
 impl<'a> VaList<'a> {
@@ -176,7 +176,7 @@ impl<'a> VaList<'a> {
     #[unstable(feature = "c_variadic",
                reason = "the `c_variadic` feature has not been properly tested on \
                          all supported platforms",
-               issue = "27745")]
+               issue = "44930")]
     pub unsafe fn arg<T: sealed_trait::VaArgSafe>(&mut self) -> T {
         va_arg(self)
     }
@@ -185,7 +185,7 @@ impl<'a> VaList<'a> {
     #[unstable(feature = "c_variadic",
                reason = "the `c_variadic` feature has not been properly tested on \
                          all supported platforms",
-               issue = "27745")]
+               issue = "44930")]
     pub unsafe fn copy<F, R>(&self, f: F) -> R
             where F: for<'copy> FnOnce(VaList<'copy>) -> R {
         #[cfg(any(all(not(target_arch = "aarch64"), not(target_arch = "powerpc"),

--- a/src/libcore/pin.rs
+++ b/src/libcore/pin.rs
@@ -99,6 +99,7 @@
 
 use fmt;
 use marker::{Sized, Unpin};
+use cmp::{self, PartialEq, PartialOrd};
 use ops::{Deref, DerefMut, Receiver, CoerceUnsized, DispatchFromDyn};
 
 /// A pinned pointer.
@@ -112,14 +113,57 @@ use ops::{Deref, DerefMut, Receiver, CoerceUnsized, DispatchFromDyn};
 /// [`Unpin`]: ../../std/marker/trait.Unpin.html
 /// [`pin` module]: ../../std/pin/index.html
 //
-// Note: the derives below are allowed because they all only use `&P`, so they
-// cannot move the value behind `pointer`.
+// Note: the derives below, and the explicit `PartialEq` and `PartialOrd`
+// implementations, are allowed because they all only use `&P`, so they cannot move
+// the value behind `pointer`.
 #[stable(feature = "pin", since = "1.33.0")]
 #[fundamental]
 #[repr(transparent)]
-#[derive(Copy, Clone, Hash, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Hash, Eq, Ord)]
 pub struct Pin<P> {
     pointer: P,
+}
+
+#[stable(feature = "pin_partialeq_partialord_impl_applicability", since = "1.34.0")]
+impl<P, Q> PartialEq<Pin<Q>> for Pin<P>
+where
+    P: PartialEq<Q>,
+{
+    
+    fn eq(&self, other: &Pin<Q>) -> bool {
+        self.pointer == other.pointer
+    }
+
+    fn ne(&self, other: &Pin<Q>) -> bool {
+        self.pointer != other.pointer
+    }
+}
+
+#[stable(feature = "pin_partialeq_partialord_impl_applicability", since = "1.34.0")]
+impl<P, Q> PartialOrd<Pin<Q>> for Pin<P>
+where
+    P: PartialOrd<Q>,
+{
+    
+    fn partial_cmp(&self, other: &Pin<Q>) -> Option<cmp::Ordering> {
+        self.pointer.partial_cmp(&other.pointer)
+    }
+
+    fn lt(&self, other: &Pin<Q>) -> bool {
+        self.pointer < other.pointer
+    }
+
+    fn le(&self, other: &Pin<Q>) -> bool {
+        self.pointer <= other.pointer
+    }
+
+    fn gt(&self, other: &Pin<Q>) -> bool {
+        self.pointer > other.pointer
+    }
+
+    fn ge(&self, other: &Pin<Q>) -> bool {
+        self.pointer >= other.pointer
+    }
 }
 
 impl<P: Deref> Pin<P>

--- a/src/libcore/pin.rs
+++ b/src/libcore/pin.rs
@@ -129,7 +129,6 @@ impl<P, Q> PartialEq<Pin<Q>> for Pin<P>
 where
     P: PartialEq<Q>,
 {
-    
     fn eq(&self, other: &Pin<Q>) -> bool {
         self.pointer == other.pointer
     }
@@ -144,7 +143,6 @@ impl<P, Q> PartialOrd<Pin<Q>> for Pin<P>
 where
     P: PartialOrd<Q>,
 {
-    
     fn partial_cmp(&self, other: &Pin<Q>) -> Option<cmp::Ordering> {
         self.pointer.partial_cmp(&other.pointer)
     }

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -3775,7 +3775,7 @@ impl<'a> LoweringContext<'a> {
                 let ohs = P(self.lower_expr(ohs));
                 hir::ExprKind::Unary(op, ohs)
             }
-            ExprKind::Lit(ref l) => hir::ExprKind::Lit(P((*l).clone())),
+            ExprKind::Lit(ref l) => hir::ExprKind::Lit((*l).clone()),
             ExprKind::Cast(ref expr, ref ty) => {
                 let expr = P(self.lower_expr(expr));
                 hir::ExprKind::Cast(expr, self.lower_ty(ty, ImplTraitContext::disallowed()))

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -1466,7 +1466,7 @@ pub enum ExprKind {
     /// A unary operation (For example: `!x`, `*x`)
     Unary(UnOp, P<Expr>),
     /// A literal (For example: `1`, `"foo"`)
-    Lit(P<Lit>),
+    Lit(Lit),
     /// A cast (`foo as f64`)
     Cast(P<Expr>, P<Ty>),
     Type(P<Expr>, P<Ty>),

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -19,7 +19,7 @@ use syntax_pos::{Span, DUMMY_SP, symbol::InternedString};
 use syntax::source_map::{self, Spanned};
 use rustc_target::spec::abi::Abi;
 use syntax::ast::{self, CrateSugar, Ident, Name, NodeId, DUMMY_NODE_ID, AsmDialect};
-use syntax::ast::{Attribute, Lit, StrStyle, FloatTy, IntTy, UintTy};
+use syntax::ast::{Attribute, Label, Lit, StrStyle, FloatTy, IntTy, UintTy};
 use syntax::attr::InlineAttr;
 use syntax::ext::hygiene::SyntaxContext;
 use syntax::ptr::P;
@@ -141,17 +141,6 @@ pub const DUMMY_HIR_ID: HirId = HirId {
 };
 
 pub const DUMMY_ITEM_LOCAL_ID: ItemLocalId = ItemLocalId::MAX;
-
-#[derive(Clone, RustcEncodable, RustcDecodable, Copy)]
-pub struct Label {
-    pub ident: Ident,
-}
-
-impl fmt::Debug for Label {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "label({:?})", self.ident)
-    }
-}
 
 #[derive(Clone, RustcEncodable, RustcDecodable, Copy)]
 pub struct Lifetime {

--- a/src/librustc/ich/impls_hir.rs
+++ b/src/librustc/ich/impls_hir.rs
@@ -153,7 +153,7 @@ impl_stable_hash_for!(enum hir::LifetimeName {
     Error,
 });
 
-impl_stable_hash_for!(struct hir::Label {
+impl_stable_hash_for!(struct ast::Label {
     ident
 });
 

--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -135,10 +135,11 @@ impl CodeSuggestion {
             if let Some(line) = line_opt {
                 if let Some(lo) = line.char_indices().map(|(i, _)| i).nth(lo) {
                     let hi_opt = hi_opt.and_then(|hi| line.char_indices().map(|(i, _)| i).nth(hi));
-                    buf.push_str(match hi_opt {
-                        Some(hi) => &line[lo..hi],
-                        None => &line[lo..],
-                    });
+                    match hi_opt {
+                        Some(hi) if hi > lo => buf.push_str(&line[lo..hi]),
+                        Some(_) => (),
+                        None => buf.push_str(&line[lo..]),
+                    }
                 }
                 if let None = hi_opt {
                     buf.push('\n');

--- a/src/librustc_metadata/native_libs.rs
+++ b/src/librustc_metadata/native_libs.rs
@@ -163,7 +163,7 @@ impl<'a, 'tcx> Collector<'a, 'tcx> {
            !self.tcx.features().static_nobundle {
             feature_gate::emit_feature_err(&self.tcx.sess.parse_sess,
                                            "static_nobundle",
-                                           span.unwrap(),
+                                           span.unwrap_or_else(|| syntax_pos::DUMMY_SP),
                                            GateIssue::Language,
                                            "kind=\"static-nobundle\" is feature gated");
         }

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -3321,7 +3321,12 @@ impl<'a> Resolver<'a> {
             if let Some(def) = def {
                 match (def, source) {
                     (Def::Macro(..), _) => {
-                        err.span_label(span, format!("did you mean `{}!(...)`?", path_str));
+                        err.span_suggestion_with_applicability(
+                            span,
+                            "use `!` to invoke the macro",
+                            format!("{}!", path_str),
+                            Applicability::MaybeIncorrect,
+                        );
                         return (err, candidates);
                     }
                     (Def::TyAlias(..), PathSource::Trait(_)) => {
@@ -3333,13 +3338,22 @@ impl<'a> Resolver<'a> {
                     }
                     (Def::Mod(..), PathSource::Expr(Some(parent))) => match parent.node {
                         ExprKind::Field(_, ident) => {
-                            err.span_label(parent.span, format!("did you mean `{}::{}`?",
-                                                                 path_str, ident));
+                            err.span_suggestion_with_applicability(
+                                parent.span,
+                                "use the path separator to refer to an item",
+                                format!("{}::{}", path_str, ident),
+                                Applicability::MaybeIncorrect,
+                            );
                             return (err, candidates);
                         }
                         ExprKind::MethodCall(ref segment, ..) => {
-                            err.span_label(parent.span, format!("did you mean `{}::{}(...)`?",
-                                                                 path_str, segment.ident));
+                            let span = parent.span.with_hi(segment.ident.span.hi());
+                            err.span_suggestion_with_applicability(
+                                span,
+                                "use the path separator to refer to an item",
+                                format!("{}::{}", path_str, segment.ident),
+                                Applicability::MaybeIncorrect,
+                            );
                             return (err, candidates);
                         }
                         _ => {}

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1042,7 +1042,7 @@ themePicker.onblur = handleThemeButtonsBlur;
         all_sources.sort();
         let mut w = try_err!(File::create(&dst), &dst);
         try_err!(writeln!(&mut w,
-                          "var N = null;var sourcesIndex = {{}};\n{}",
+                          "var N = null;var sourcesIndex = {{}};\n{}\ncreateSourceSidebar();",
                           all_sources.join("\n")),
                  &dst);
     }

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -391,10 +391,6 @@ h4 > code, h3 > code, .invisible > code {
 	display: block;
 }
 
-.in-band, code {
-	z-index: -5;
-}
-
 .invisible {
 	width: 100%;
 	display: inline-block;

--- a/src/librustdoc/html/static/source-script.js
+++ b/src/librustdoc/html/static/source-script.js
@@ -137,5 +137,3 @@ function createSourceSidebar() {
 
     main.insertBefore(sidebar, main.firstChild);
 }
-
-createSourceSidebar();

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -82,12 +82,6 @@ pre {
 	border-bottom-color: #ddd;
 }
 
-:target { background: #494a3d; }
-
-:target > .in-band {
-	background: #494a3d;
-}
-
 .content .method .where,
 .content .fn .where,
 .content .where.fmt-newline {
@@ -252,7 +246,7 @@ a.test-arrow:hover{
 	color: #999;
 }
 
-:target > code {
+:target > code, :target > .in-band {
 	background-color: #494a3d;
 }
 

--- a/src/librustdoc/html/static/themes/light.css
+++ b/src/librustdoc/html/static/themes/light.css
@@ -84,12 +84,6 @@ pre {
 	border-bottom-color: #ddd;
 }
 
-:target { background: #FDFFD3; }
-
-:target > .in-band {
-	background: #FDFFD3;
-}
-
 .content .method .where,
 .content .fn .where,
 .content .where.fmt-newline {
@@ -247,7 +241,7 @@ a.test-arrow:hover{
 	color: #999;
 }
 
-:target > code {
+:target > code, :target > .in-band {
 	background: #FDFFD3;
 }
 

--- a/src/libstd/ffi/mod.rs
+++ b/src/libstd/ffi/mod.rs
@@ -169,7 +169,7 @@ pub use core::ffi::c_void;
 #[unstable(feature = "c_variadic",
            reason = "the `c_variadic` feature has not been properly tested on \
                      all supported platforms",
-           issue = "27745")]
+           issue = "44930")]
 pub use core::ffi::VaList;
 
 mod c_str;

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -1121,7 +1121,9 @@ impl Permissions {
     /// writing.
     ///
     /// This operation does **not** modify the filesystem. To modify the
-    /// filesystem use the `fs::set_permissions` function.
+    /// filesystem use the [`fs::set_permissions`] function.
+    ///
+    /// [`fs::set_permissions`]: fn.set_permissions.html
     ///
     /// # Examples
     ///
@@ -1639,9 +1641,14 @@ pub fn hard_link<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<(
 ///
 /// The `dst` path will be a symbolic link pointing to the `src` path.
 /// On Windows, this will be a file symlink, not a directory symlink;
-/// for this reason, the platform-specific `std::os::unix::fs::symlink`
-/// and `std::os::windows::fs::{symlink_file, symlink_dir}` should be
+/// for this reason, the platform-specific [`std::os::unix::fs::symlink`]
+/// and [`std::os::windows::fs::symlink_file`] or [`symlink_dir`] should be
 /// used instead to make the intent explicit.
+///
+/// [`std::os::unix::fs::symlink`]: ../os/unix/fs/fn.symlink.html
+/// [`std::os::windows::fs::symlink_file`]: ../os/windows/fs/fn.symlink_file.html
+/// [`symlink_dir`]: ../os/windows/fs/fn.symlink_dir.html
+///
 ///
 /// # Examples
 ///
@@ -1795,13 +1802,15 @@ pub fn create_dir<P: AsRef<Path>>(path: P) -> io::Result<()> {
 /// * If any directory in the path specified by `path`
 /// does not already exist and it could not be created otherwise. The specific
 /// error conditions for when a directory is being created (after it is
-/// determined to not exist) are outlined by `fs::create_dir`.
+/// determined to not exist) are outlined by [`fs::create_dir`].
 ///
 /// Notable exception is made for situations where any of the directories
 /// specified in the `path` could not be created as it was being created concurrently.
 /// Such cases are considered to be successful. That is, calling `create_dir_all`
 /// concurrently from multiple threads or processes is guaranteed not to fail
 /// due to a race condition with itself.
+///
+/// [`fs::create_dir`]: fn.create_dir.html
 ///
 /// # Examples
 ///
@@ -1868,7 +1877,10 @@ pub fn remove_dir<P: AsRef<Path>>(path: P) -> io::Result<()> {
 ///
 /// # Errors
 ///
-/// See `file::remove_file` and `fs::remove_dir`.
+/// See [`fs::remove_file`] and [`fs::remove_dir`].
+///
+/// [`fs::remove_file`]:  fn.remove_file.html
+/// [`fs::remove_dir`]: fn.remove_dir.html
 ///
 /// # Examples
 ///

--- a/src/libstd/prelude/mod.rs
+++ b/src/libstd/prelude/mod.rs
@@ -44,8 +44,8 @@
 //! The current version of the prelude (version 1) lives in
 //! [`std::prelude::v1`], and re-exports the following.
 //!
-//! * [`std::marker`]::{[`Copy`], [`Send`], [`Sized`], [`Sync`]}. The marker
-//!   traits indicate fundamental properties of types.
+//! * [`std::marker`]::{[`Copy`], [`Send`], [`Sized`], [`Sync`], [`Unpin`]}. The
+//!   marker traits indicate fundamental properties of types.
 //! * [`std::ops`]::{[`Drop`], [`Fn`], [`FnMut`], [`FnOnce`]}. Various
 //!   operations for both destructors and overloading `()`.
 //! * [`std::mem`]::[`drop`][`mem::drop`], a convenience function for explicitly
@@ -108,6 +108,7 @@
 //! [`Sync`]: ../marker/trait.Sync.html
 //! [`ToOwned`]: ../borrow/trait.ToOwned.html
 //! [`ToString`]: ../string/trait.ToString.html
+//! [`Unpin`]: ../marker/trait.Unpin.html
 //! [`Vec`]: ../vec/struct.Vec.html
 //! [`Clone::clone`]: ../clone/trait.Clone.html#tymethod.clone
 //! [`mem::drop`]: ../mem/fn.drop.html

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -5234,22 +5234,13 @@ impl<'a> Parser<'a> {
                     kind: ast::GenericParamKind::Lifetime,
                 });
                 if let Some(sp) = seen_ty_param {
-                    let param_span = self.prev_span;
-                    let ate_comma = self.eat(&token::Comma);
-                    let remove_sp = if ate_comma {
-                        param_span.until(self.span)
-                    } else {
-                        last_comma_span.unwrap_or(param_span).to(param_span)
-                    };
-                    bad_lifetime_pos.push(param_span);
-
-                    if let Ok(snippet) = self.sess.source_map().span_to_snippet(param_span) {
+                    let remove_sp = last_comma_span.unwrap_or(self.prev_span).to(self.prev_span);
+                    bad_lifetime_pos.push(self.prev_span);
+                    if let Ok(snippet) = self.sess.source_map().span_to_snippet(self.prev_span) {
                         suggestions.push((remove_sp, String::new()));
-                        suggestions.push((sp.shrink_to_lo(), format!("{}, ", snippet)));
-                    }
-                    if ate_comma {
-                        last_comma_span = Some(self.prev_span);
-                        continue
+                        suggestions.push((
+                            sp.shrink_to_lo(),
+                            format!("{}, ", snippet)));
                     }
                 }
             } else if self.check_ident() {

--- a/src/test/ui/error-codes/E0423.stderr
+++ b/src/test/ui/error-codes/E0423.stderr
@@ -29,19 +29,25 @@ error[E0423]: expected value, found struct `S`
   --> $DIR/E0423.rs:12:32
    |
 LL |     if let S { x: _x, y: 2 } = S { x: 1, y: 2 } { println!("Ok"); }
-   |                                ^ did you mean `(S { /* fields */ })`?
+   |                                ^---------------
+   |                                |
+   |                                help: surround the struct literal with parenthesis: `(S { x: 1, y: 2 })`
 
 error[E0423]: expected value, found struct `T`
   --> $DIR/E0423.rs:15:8
    |
 LL |     if T {} == T {} { println!("Ok"); }
-   |        ^ did you mean `(T { /* fields */ })`?
+   |        ^---
+   |        |
+   |        help: surround the struct literal with parenthesis: `(T {})`
 
 error[E0423]: expected value, found struct `std::ops::Range`
   --> $DIR/E0423.rs:21:14
    |
 LL |     for _ in std::ops::Range { start: 0, end: 10 } {}
-   |              ^^^^^^^^^^^^^^^ did you mean `(std::ops::Range { /* fields */ })`?
+   |              ^^^^^^^^^^^^^^^----------------------
+   |              |
+   |              help: surround the struct literal with parenthesis: `(std::ops::Range { start: 0, end: 10 })`
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/feature-gate/feature-gate-static-nobundle-2.rs
+++ b/src/test/ui/feature-gate/feature-gate-static-nobundle-2.rs
@@ -1,0 +1,6 @@
+//~ ERROR kind="static-nobundle" is feature gated
+// Test the behavior of rustc when non-existent library is statically linked
+
+// compile-flags: -l static-nobundle=nonexistent
+
+fn main() {}

--- a/src/test/ui/feature-gate/feature-gate-static-nobundle-2.stderr
+++ b/src/test/ui/feature-gate/feature-gate-static-nobundle-2.stderr
@@ -1,0 +1,7 @@
+error[E0658]: kind="static-nobundle" is feature gated (see issue #37403)
+   |
+   = help: add #![feature(static_nobundle)] to the crate attributes to enable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/imports/issue-57539.rs
+++ b/src/test/ui/imports/issue-57539.rs
@@ -1,0 +1,8 @@
+// edition:2018
+
+mod core {
+    use core; //~ ERROR `core` is ambiguous
+    use crate::*;
+}
+
+fn main() {}

--- a/src/test/ui/imports/issue-57539.stderr
+++ b/src/test/ui/imports/issue-57539.stderr
@@ -1,0 +1,18 @@
+error[E0659]: `core` is ambiguous (name vs any other name during import resolution)
+  --> $DIR/issue-57539.rs:4:9
+   |
+LL |     use core; //~ ERROR `core` is ambiguous
+   |         ^^^^ ambiguous name
+   |
+   = note: `core` could refer to a built-in extern crate
+   = help: use `::core` to refer to this extern crate unambiguously
+note: `core` could also refer to the module imported here
+  --> $DIR/issue-57539.rs:5:9
+   |
+LL |     use crate::*;
+   |         ^^^^^^^^
+   = help: use `self::core` to refer to this module unambiguously
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0659`.

--- a/src/test/ui/lifetime-before-type-params.rs
+++ b/src/test/ui/lifetime-before-type-params.rs
@@ -1,0 +1,9 @@
+#![allow(unused)]
+fn first<T, 'a, 'b>() {}
+//~^ ERROR lifetime parameters must be declared prior to type parameters
+fn second<'a, T, 'b>() {}
+//~^ ERROR lifetime parameters must be declared prior to type parameters
+fn third<T, U, 'a>() {}
+//~^ ERROR lifetime parameters must be declared prior to type parameters
+fn fourth<'a, T, 'b, U, 'c, V>() {}
+//~^ ERROR lifetime parameters must be declared prior to type parameters

--- a/src/test/ui/lifetime-before-type-params.stderr
+++ b/src/test/ui/lifetime-before-type-params.stderr
@@ -1,0 +1,47 @@
+error: lifetime parameters must be declared prior to type parameters
+  --> $DIR/lifetime-before-type-params.rs:2:13
+   |
+LL | fn first<T, 'a, 'b>() {}
+   |             ^^  ^^
+help: move the lifetime parameter prior to the first type parameter
+   |
+LL | fn first<'a, 'b, T>() {}
+   |          ^^^ ^^^ --
+
+error: lifetime parameters must be declared prior to type parameters
+  --> $DIR/lifetime-before-type-params.rs:4:18
+   |
+LL | fn second<'a, T, 'b>() {}
+   |                  ^^
+help: move the lifetime parameter prior to the first type parameter
+   |
+LL | fn second<'a, 'b, T>() {}
+   |               ^^^ --
+
+error: lifetime parameters must be declared prior to type parameters
+  --> $DIR/lifetime-before-type-params.rs:6:16
+   |
+LL | fn third<T, U, 'a>() {}
+   |                ^^
+help: move the lifetime parameter prior to the first type parameter
+   |
+LL | fn third<'a, T, U>() {}
+   |          ^^^    --
+
+error: lifetime parameters must be declared prior to type parameters
+  --> $DIR/lifetime-before-type-params.rs:8:18
+   |
+LL | fn fourth<'a, T, 'b, U, 'c, V>() {}
+   |                  ^^     ^^
+help: move the lifetime parameter prior to the first type parameter
+   |
+LL | fn fourth<'a, 'b, 'c, T, U, V>() {}
+   |               ^^^ ^^^ -- --
+
+error[E0601]: `main` function not found in crate `lifetime_before_type_params`
+   |
+   = note: consider adding a `main` function to `$DIR/lifetime-before-type-params.rs`
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0601`.

--- a/src/test/ui/resolve/resolve-hint-macro.stderr
+++ b/src/test/ui/resolve/resolve-hint-macro.stderr
@@ -2,7 +2,7 @@ error[E0423]: expected function, found macro `assert`
   --> $DIR/resolve-hint-macro.rs:2:5
    |
 LL |     assert(true);
-   |     ^^^^^^ did you mean `assert!(...)`?
+   |     ^^^^^^ help: use `!` to invoke the macro: `assert!`
 
 error: aborting due to previous error
 

--- a/src/test/ui/resolve/suggest-path-instead-of-mod-dot-item.stderr
+++ b/src/test/ui/resolve/suggest-path-instead-of-mod-dot-item.stderr
@@ -4,15 +4,15 @@ error[E0423]: expected value, found module `a`
 LL |     a.I
    |     ^--
    |     |
-   |     did you mean `a::I`?
+   |     help: use the path separator to refer to an item: `a::I`
 
 error[E0423]: expected value, found module `a`
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:22:5
    |
 LL |     a.g()
-   |     ^----
+   |     ^--
    |     |
-   |     did you mean `a::g(...)`?
+   |     help: use the path separator to refer to an item: `a::g`
 
 error[E0423]: expected value, found module `a`
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:27:5
@@ -20,16 +20,21 @@ error[E0423]: expected value, found module `a`
 LL |     a.b.J
    |     ^--
    |     |
-   |     did you mean `a::b`?
+   |     help: use the path separator to refer to an item: `a::b`
 
 error[E0423]: expected value, found module `a::b`
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:32:5
    |
 LL |     a::b.J
-   |     ^^^---
-   |     |  |
-   |     |  help: a constant with a similar name exists: `I`
-   |     did you mean `a::b::J`?
+   |     ^^^^
+help: a constant with a similar name exists
+   |
+LL |     a::I.J
+   |        ^
+help: use the path separator to refer to an item
+   |
+LL |     a::b::J
+   |
 
 error[E0423]: expected value, found module `a`
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:37:5
@@ -37,7 +42,7 @@ error[E0423]: expected value, found module `a`
 LL |     a.b.f();
    |     ^--
    |     |
-   |     did you mean `a::b`?
+   |     help: use the path separator to refer to an item: `a::b`
 
 error[E0423]: expected value, found module `a::b`
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:40:12
@@ -51,10 +56,15 @@ error[E0423]: expected value, found module `a::b`
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:45:5
    |
 LL |     a::b.f()
-   |     ^^^-----
-   |     |  |
-   |     |  help: a constant with a similar name exists: `I`
-   |     did you mean `a::b::f(...)`?
+   |     ^^^^
+help: a constant with a similar name exists
+   |
+LL |     a::I.f()
+   |        ^
+help: use the path separator to refer to an item
+   |
+LL |     a::b::f()
+   |     ^^^^^^^
 
 error[E0423]: expected value, found module `a::b`
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:50:5

--- a/src/test/ui/suggestions/suggest-move-lifetimes.stderr
+++ b/src/test/ui/suggestions/suggest-move-lifetimes.stderr
@@ -16,7 +16,7 @@ LL | struct B<T, 'a, U> { //~ ERROR lifetime parameters must be declared
 help: move the lifetime parameter prior to the first type parameter
    |
 LL | struct B<'a, T, U> { //~ ERROR lifetime parameters must be declared
-   |          ^^^   --
+   |          ^^^ --
 
 error: lifetime parameters must be declared prior to type parameters
   --> $DIR/suggest-move-lifetimes.rs:10:16
@@ -36,7 +36,7 @@ LL | struct D<T, U, 'a, 'b, V, 'c> { //~ ERROR lifetime parameters must be decla
 help: move the lifetime parameter prior to the first type parameter
    |
 LL | struct D<'a, 'b, 'c, T, U, V> { //~ ERROR lifetime parameters must be declared
-   |          ^^^ ^^^ ^^^      ---
+   |          ^^^ ^^^ ^^^    -- --
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/thread-local-mutation.nll.stderr
+++ b/src/test/ui/thread-local-mutation.nll.stderr
@@ -1,0 +1,9 @@
+error[E0594]: cannot assign to immutable static item `S`
+  --> $DIR/thread-local-mutation.rs:11:5
+   |
+LL |     S = "after"; //~ ERROR cannot assign to immutable
+   |     ^^^^^^^^^^^ cannot assign
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0594`.

--- a/src/test/ui/thread-local-mutation.rs
+++ b/src/test/ui/thread-local-mutation.rs
@@ -1,0 +1,18 @@
+// Regression test for #54901: immutable thread locals could be mutated. See:
+// https://github.com/rust-lang/rust/issues/29594#issuecomment-328177697
+// https://github.com/rust-lang/rust/issues/54901
+
+#![feature(thread_local)]
+
+#[thread_local]
+static S: &str = "before";
+
+fn set_s() {
+    S = "after"; //~ ERROR cannot assign to immutable
+}
+
+fn main() {
+    println!("{}", S);
+    set_s();
+    println!("{}", S);
+}

--- a/src/test/ui/thread-local-mutation.stderr
+++ b/src/test/ui/thread-local-mutation.stderr
@@ -1,0 +1,9 @@
+error[E0594]: cannot assign to immutable thread-local static item
+  --> $DIR/thread-local-mutation.rs:11:5
+   |
+LL |     S = "after"; //~ ERROR cannot assign to immutable
+   |     ^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0594`.

--- a/src/test/ui/try-block/try-block-in-edition2015.stderr
+++ b/src/test/ui/try-block/try-block-in-edition2015.stderr
@@ -15,7 +15,7 @@ error[E0574]: expected struct, variant or union type, found macro `try`
   --> $DIR/try-block-in-edition2015.rs:4:33
    |
 LL |     let try_result: Option<_> = try {
-   |                                 ^^^ did you mean `try!(...)`?
+   |                                 ^^^ help: use `!` to invoke the macro: `try!`
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Successful merges:

 - #56594 (Remove confusing comment about ideally using `!` for `c_void`)
 - #57107 (Add a regression test for mutating a non-mut #[thread_local])
 - #57340 (Use correct tracking issue for c_variadic)
 - #57357 (Cleanup PartialEq docs.)
 - #57370 (Support passing cflags/cxxflags/ldflags to LLVM build)
 - #57551 (resolve: Add a test for issue #57539)
 - #57635 (use structured macro and path resolve suggestions)
 - #57636 (Fix sources sidebar not showing up)
 - #57646 (Fixes text becoming invisible when element targetted)
 - #57650 (librustc_metadata: Pass a default value when unwrapping a span)
 - #57654 (Add some links in std::fs.)
 - #57658 (Two HIR tweaks)
 - #57683 (Document Unpin in std::prelude documentation)
 - #57685 (Enhance `Pin` impl applicability for `PartialEq` and `PartialOrd`.)
 - #57710 (Fix non-clickable urls)
 - #57720 (Fix suggestions given mulitple bad lifetimes)
 - #57725 (Use structured suggestion to surround struct literal with parenthesis)

Failed merges:


r? @ghost