### PR TITLE
Fix some minor warnings

### DIFF
--- a/src/libfmt_macros/lib.rs
+++ b/src/libfmt_macros/lib.rs
@@ -11,6 +11,7 @@
        test(attr(deny(warnings))))]
 
 #![feature(nll)]
+#![feature(rustc_private)]
 
 pub use self::Piece::*;
 pub use self::Position::*;

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -25,7 +25,7 @@
 #![feature(asm)]
 #![cfg_attr(stage0, feature(cfg_target_vendor))]
 #![feature(fnbox)]
-#![cfg_attr(any(unix, target_os = "cloudabi"), feature(libc))]
+#![cfg_attr(any(unix, target_os = "cloudabi"), feature(libc, rustc_private))]
 #![feature(nll)]
 #![feature(set_stdio)]
 #![feature(panic_unwind)]

--- a/src/tools/linkchecker/main.rs
+++ b/src/tools/linkchecker/main.rs
@@ -78,7 +78,7 @@ impl FileEntry {
     fn parse_ids(&mut self, file: &Path, contents: &str, errors: &mut bool) {
         if self.ids.is_empty() {
             with_attrs_in_source(contents, " id", |fragment, i, _| {
-                let frag = fragment.trim_left_matches("#").to_owned();
+                let frag = fragment.trim_start_matches("#").to_owned();
                 let encoded = small_url_encode(&frag);
                 if !self.ids.insert(frag) {
                     *errors = true;
@@ -343,7 +343,7 @@ fn with_attrs_in_source<F: FnMut(&str, usize, &str)>(contents: &str, attr: &str,
                 Some(i) => i,
                 None => continue,
             };
-            if rest[..pos_equals].trim_left_matches(" ") != "" {
+            if rest[..pos_equals].trim_start_matches(" ") != "" {
                 continue;
             }
 
@@ -355,7 +355,7 @@ fn with_attrs_in_source<F: FnMut(&str, usize, &str)>(contents: &str, attr: &str,
             };
             let quote_delim = rest.as_bytes()[pos_quote] as char;
 
-            if rest[..pos_quote].trim_left_matches(" ") != "" {
+            if rest[..pos_quote].trim_start_matches(" ") != "" {
                 continue;
             }
             let rest = &rest[pos_quote + 1..];


### PR DESCRIPTION
Since apparently RLS works when initialized in the root repository (:tada:) I decided to fix some of the issues it caught.

There are a lot of unused attribute warnings left on `rustc_on_unimplemented` and `rustc_layout_scalar_valid_range_start` but I imagine we can't do much about it due to 2-stage compilation?