### PR TITLE
beta: Update RLS version to 1.33

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1955,7 +1955,7 @@ dependencies = [
 
 [[package]]
 name = "rls"
-version = "1.31.6"
+version = "1.33.0"
 dependencies = [
  "cargo 0.34.0",
  "cargo_metadata 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
We missed the 1.32 stable release for version bump, let's make it less confusing and backport a version bump for the current 1.33 beta.

https://github.com/rust-lang/rls/issues/1239

r? @pietroalbini 

cc @nrc