### PR TITLE
Continue parsing after parent type args and suggest using angle brackets

### DIFF
--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -1826,7 +1826,7 @@ impl<'a> LoweringContext<'a> {
                         struct_span_err!(self.sess, data.span, E0214, "{}", msg)
                             .span_label(data.span, "only traits may use parentheses")
                             .emit();
-                        (hir::GenericArgs::none(), true)
+                        (hir::GenericArgs::none(), false)
                     }
                 },
             }

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -1826,7 +1826,11 @@ impl<'a> LoweringContext<'a> {
                         struct_span_err!(self.sess, data.span, E0214, "{}", msg)
                             .span_label(data.span, "only traits may use parentheses")
                             .emit();
-                        (hir::GenericArgs::none(), false)
+                        (self.lower_angle_bracketed_parameter_data(
+                            &data.as_angle_bracketed_args(),
+                            param_mode,
+                            itctx).0,
+                         false)
                     }
                 },
             }

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -192,6 +192,16 @@ pub struct ParenthesisedArgs {
     pub output: Option<P<Ty>>,
 }
 
+impl ParenthesisedArgs {
+    pub fn as_angle_bracketed_args(&self) -> AngleBracketedArgs {
+        AngleBracketedArgs {
+            span: self.span,
+            args: self.inputs.iter().cloned().map(|input| GenericArg::Type(input)).collect(),
+            bindings: vec![],
+        }
+    }
+}
+
 // hack to ensure that we don't try to access the private parts of `NodeId` in this module
 mod node_id_inner {
     use rustc_data_structures::indexed_vec::Idx;

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2176,11 +2176,11 @@ impl<'a> Parser<'a> {
               style != PathStyle::Mod && self.check(&token::ModSep)
                                       && self.look_ahead(1, |t| is_args_start(t)) {
             // Generic arguments are found - `<`, `(`, `::<` or `::(`.
-            let lo = self.span;
             if self.eat(&token::ModSep) && style == PathStyle::Type && enable_warning {
                 self.diagnostic().struct_span_warn(self.prev_span, "unnecessary path disambiguator")
                                  .span_label(self.prev_span, "try removing `::`").emit();
             }
+            let lo = self.span;
 
             let args = if self.eat_lt() {
                 // `<'a, T, A = U>`

--- a/src/test/ui/error-codes/E0214.stderr
+++ b/src/test/ui/error-codes/E0214.stderr
@@ -4,13 +4,6 @@ error[E0214]: parenthesized parameters may only be used with a trait
 LL |     let v: Vec(&str) = vec!["foo"];
    |               ^^^^^^ only traits may use parentheses
 
-error[E0107]: wrong number of type arguments: expected 1, found 0
-  --> $DIR/E0214.rs:2:12
-   |
-LL |     let v: Vec(&str) = vec!["foo"];
-   |            ^^^^^^^^^ expected 1 type argument
+error: aborting due to previous error
 
-error: aborting due to 2 previous errors
-
-Some errors occurred: E0107, E0214.
-For more information about an error, try `rustc --explain E0107`.
+For more information about this error, try `rustc --explain E0214`.

--- a/src/test/ui/error-codes/E0214.stderr
+++ b/src/test/ui/error-codes/E0214.stderr
@@ -4,6 +4,13 @@ error[E0214]: parenthesized parameters may only be used with a trait
 LL |     let v: Vec(&str) = vec!["foo"];
    |               ^^^^^^ only traits may use parentheses
 
-error: aborting due to previous error
+error[E0107]: wrong number of type arguments: expected 1, found 0
+  --> $DIR/E0214.rs:2:12
+   |
+LL |     let v: Vec(&str) = vec!["foo"];
+   |            ^^^^^^^^^ expected 1 type argument
 
-For more information about this error, try `rustc --explain E0214`.
+error: aborting due to 2 previous errors
+
+Some errors occurred: E0107, E0214.
+For more information about an error, try `rustc --explain E0107`.

--- a/src/test/ui/error-codes/E0214.stderr
+++ b/src/test/ui/error-codes/E0214.stderr
@@ -2,7 +2,10 @@ error[E0214]: parenthesized parameters may only be used with a trait
   --> $DIR/E0214.rs:2:15
    |
 LL |     let v: Vec(&str) = vec!["foo"];
-   |               ^^^^^^ only traits may use parentheses
+   |               ^^^^^^
+   |               |
+   |               only traits may use parentheses
+   |               help: use angle brackets instead: `<&str>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0214.stderr
+++ b/src/test/ui/error-codes/E0214.stderr
@@ -1,10 +1,10 @@
-error[E0214]: parenthesized parameters may only be used with a trait
+error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
   --> $DIR/E0214.rs:2:15
    |
 LL |     let v: Vec(&str) = vec!["foo"];
    |               ^^^^^^
    |               |
-   |               only traits may use parentheses
+   |               only `Fn` traits may use parentheses
    |               help: use angle brackets instead: `<&str>`
 
 error: aborting due to previous error

--- a/src/test/ui/issues/issue-23589.rs
+++ b/src/test/ui/issues/issue-23589.rs
@@ -1,5 +1,5 @@
 fn main() {
     let v: Vec(&str) = vec!['1', '2'];
-    //~^ ERROR parenthesized parameters may only be used with a trait
+    //~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
     //~| ERROR mismatched types
 }

--- a/src/test/ui/issues/issue-23589.rs
+++ b/src/test/ui/issues/issue-23589.rs
@@ -1,4 +1,5 @@
 fn main() {
     let v: Vec(&str) = vec!['1', '2'];
     //~^ ERROR parenthesized parameters may only be used with a trait
+    //~| ERROR mismatched types
 }

--- a/src/test/ui/issues/issue-23589.stderr
+++ b/src/test/ui/issues/issue-23589.stderr
@@ -4,6 +4,13 @@ error[E0214]: parenthesized parameters may only be used with a trait
 LL |     let v: Vec(&str) = vec!['1', '2'];
    |               ^^^^^^ only traits may use parentheses
 
-error: aborting due to previous error
+error[E0107]: wrong number of type arguments: expected 1, found 0
+  --> $DIR/issue-23589.rs:2:12
+   |
+LL |     let v: Vec(&str) = vec!['1', '2'];
+   |            ^^^^^^^^^ expected 1 type argument
 
-For more information about this error, try `rustc --explain E0214`.
+error: aborting due to 2 previous errors
+
+Some errors occurred: E0107, E0214.
+For more information about an error, try `rustc --explain E0107`.

--- a/src/test/ui/issues/issue-23589.stderr
+++ b/src/test/ui/issues/issue-23589.stderr
@@ -4,13 +4,16 @@ error[E0214]: parenthesized parameters may only be used with a trait
 LL |     let v: Vec(&str) = vec!['1', '2'];
    |               ^^^^^^ only traits may use parentheses
 
-error[E0107]: wrong number of type arguments: expected 1, found 0
-  --> $DIR/issue-23589.rs:2:12
+error[E0308]: mismatched types
+  --> $DIR/issue-23589.rs:2:29
    |
 LL |     let v: Vec(&str) = vec!['1', '2'];
-   |            ^^^^^^^^^ expected 1 type argument
+   |                             ^^^ expected &str, found char
+   |
+   = note: expected type `&str`
+              found type `char`
 
 error: aborting due to 2 previous errors
 
-Some errors occurred: E0107, E0214.
-For more information about an error, try `rustc --explain E0107`.
+Some errors occurred: E0214, E0308.
+For more information about an error, try `rustc --explain E0214`.

--- a/src/test/ui/issues/issue-23589.stderr
+++ b/src/test/ui/issues/issue-23589.stderr
@@ -2,7 +2,10 @@ error[E0214]: parenthesized parameters may only be used with a trait
   --> $DIR/issue-23589.rs:2:15
    |
 LL |     let v: Vec(&str) = vec!['1', '2'];
-   |               ^^^^^^ only traits may use parentheses
+   |               ^^^^^^
+   |               |
+   |               only traits may use parentheses
+   |               help: use angle brackets instead: `<&str>`
 
 error[E0308]: mismatched types
   --> $DIR/issue-23589.rs:2:29

--- a/src/test/ui/issues/issue-23589.stderr
+++ b/src/test/ui/issues/issue-23589.stderr
@@ -1,10 +1,10 @@
-error[E0214]: parenthesized parameters may only be used with a trait
+error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
   --> $DIR/issue-23589.rs:2:15
    |
 LL |     let v: Vec(&str) = vec!['1', '2'];
    |               ^^^^^^
    |               |
-   |               only traits may use parentheses
+   |               only `Fn` traits may use parentheses
    |               help: use angle brackets instead: `<&str>`
 
 error[E0308]: mismatched types

--- a/src/test/ui/issues/issue-32995-2.rs
+++ b/src/test/ui/issues/issue-32995-2.rs
@@ -2,11 +2,11 @@
 
 fn main() {
     { fn f<X: ::std::marker()::Send>() {} }
-    //~^ ERROR parenthesized parameters may only be used with a trait
+    //~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
     //~| WARN previously accepted
 
     { fn f() -> impl ::std::marker()::Send { } }
-    //~^ ERROR parenthesized parameters may only be used with a trait
+    //~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
     //~| WARN previously accepted
 }
 
@@ -14,5 +14,5 @@ fn main() {
 struct X;
 
 impl ::std::marker()::Copy for X {}
-//~^ ERROR parenthesized parameters may only be used with a trait
+//~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
 //~| WARN previously accepted

--- a/src/test/ui/issues/issue-32995-2.stderr
+++ b/src/test/ui/issues/issue-32995-2.stderr
@@ -1,4 +1,4 @@
-error: parenthesized parameters may only be used with a trait
+error: parenthesized type parameters may only be used with a `Fn` trait
   --> $DIR/issue-32995-2.rs:4:28
    |
 LL |     { fn f<X: ::std::marker()::Send>() {} }
@@ -8,7 +8,7 @@ LL |     { fn f<X: ::std::marker()::Send>() {} }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #42238 <https://github.com/rust-lang/rust/issues/42238>
 
-error: parenthesized parameters may only be used with a trait
+error: parenthesized type parameters may only be used with a `Fn` trait
   --> $DIR/issue-32995-2.rs:8:35
    |
 LL |     { fn f() -> impl ::std::marker()::Send { } }
@@ -17,7 +17,7 @@ LL |     { fn f() -> impl ::std::marker()::Send { } }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #42238 <https://github.com/rust-lang/rust/issues/42238>
 
-error: parenthesized parameters may only be used with a trait
+error: parenthesized type parameters may only be used with a `Fn` trait
   --> $DIR/issue-32995-2.rs:16:19
    |
 LL | impl ::std::marker()::Copy for X {}

--- a/src/test/ui/issues/issue-32995.rs
+++ b/src/test/ui/issues/issue-32995.rs
@@ -2,32 +2,32 @@
 
 fn main() {
     let x: usize() = 1;
-    //~^ ERROR parenthesized parameters may only be used with a trait
+    //~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
     //~| WARN previously accepted
 
     let b: ::std::boxed()::Box<_> = Box::new(1);
-    //~^ ERROR parenthesized parameters may only be used with a trait
+    //~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
     //~| WARN previously accepted
 
     let p = ::std::str::()::from_utf8(b"foo").unwrap();
-    //~^ ERROR parenthesized parameters may only be used with a trait
+    //~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
     //~| WARN previously accepted
 
     let p = ::std::str::from_utf8::()(b"foo").unwrap();
-    //~^ ERROR parenthesized parameters may only be used with a trait
+    //~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
     //~| WARN previously accepted
 
     let o : Box<::std::marker()::Send> = Box::new(1);
-    //~^ ERROR parenthesized parameters may only be used with a trait
+    //~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
     //~| WARN previously accepted
 
     let o : Box<Send + ::std::marker()::Sync> = Box::new(1);
-    //~^ ERROR parenthesized parameters may only be used with a trait
+    //~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
     //~| WARN previously accepted
 }
 
 fn foo<X:Default>() {
     let d : X() = Default::default();
-    //~^ ERROR parenthesized parameters may only be used with a trait
+    //~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
     //~| WARN previously accepted
 }

--- a/src/test/ui/issues/issue-32995.stderr
+++ b/src/test/ui/issues/issue-32995.stderr
@@ -1,4 +1,4 @@
-error: parenthesized parameters may only be used with a trait
+error: parenthesized type parameters may only be used with a `Fn` trait
   --> $DIR/issue-32995.rs:4:17
    |
 LL |     let x: usize() = 1;
@@ -8,7 +8,7 @@ LL |     let x: usize() = 1;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #42238 <https://github.com/rust-lang/rust/issues/42238>
 
-error: parenthesized parameters may only be used with a trait
+error: parenthesized type parameters may only be used with a `Fn` trait
   --> $DIR/issue-32995.rs:8:24
    |
 LL |     let b: ::std::boxed()::Box<_> = Box::new(1);
@@ -17,7 +17,7 @@ LL |     let b: ::std::boxed()::Box<_> = Box::new(1);
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #42238 <https://github.com/rust-lang/rust/issues/42238>
 
-error: parenthesized parameters may only be used with a trait
+error: parenthesized type parameters may only be used with a `Fn` trait
   --> $DIR/issue-32995.rs:12:25
    |
 LL |     let p = ::std::str::()::from_utf8(b"foo").unwrap();
@@ -26,7 +26,7 @@ LL |     let p = ::std::str::()::from_utf8(b"foo").unwrap();
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #42238 <https://github.com/rust-lang/rust/issues/42238>
 
-error: parenthesized parameters may only be used with a trait
+error: parenthesized type parameters may only be used with a `Fn` trait
   --> $DIR/issue-32995.rs:16:36
    |
 LL |     let p = ::std::str::from_utf8::()(b"foo").unwrap();
@@ -35,7 +35,7 @@ LL |     let p = ::std::str::from_utf8::()(b"foo").unwrap();
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #42238 <https://github.com/rust-lang/rust/issues/42238>
 
-error: parenthesized parameters may only be used with a trait
+error: parenthesized type parameters may only be used with a `Fn` trait
   --> $DIR/issue-32995.rs:20:30
    |
 LL |     let o : Box<::std::marker()::Send> = Box::new(1);
@@ -44,7 +44,7 @@ LL |     let o : Box<::std::marker()::Send> = Box::new(1);
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #42238 <https://github.com/rust-lang/rust/issues/42238>
 
-error: parenthesized parameters may only be used with a trait
+error: parenthesized type parameters may only be used with a `Fn` trait
   --> $DIR/issue-32995.rs:24:37
    |
 LL |     let o : Box<Send + ::std::marker()::Sync> = Box::new(1);
@@ -53,7 +53,7 @@ LL |     let o : Box<Send + ::std::marker()::Sync> = Box::new(1);
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #42238 <https://github.com/rust-lang/rust/issues/42238>
 
-error: parenthesized parameters may only be used with a trait
+error: parenthesized type parameters may only be used with a `Fn` trait
   --> $DIR/issue-32995.rs:30:14
    |
 LL |     let d : X() = Default::default();

--- a/src/test/ui/issues/issue-32995.stderr
+++ b/src/test/ui/issues/issue-32995.stderr
@@ -18,19 +18,19 @@ LL |     let b: ::std::boxed()::Box<_> = Box::new(1);
    = note: for more information, see issue #42238 <https://github.com/rust-lang/rust/issues/42238>
 
 error: parenthesized parameters may only be used with a trait
-  --> $DIR/issue-32995.rs:12:23
+  --> $DIR/issue-32995.rs:12:25
    |
 LL |     let p = ::std::str::()::from_utf8(b"foo").unwrap();
-   |                       ^^^^
+   |                         ^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #42238 <https://github.com/rust-lang/rust/issues/42238>
 
 error: parenthesized parameters may only be used with a trait
-  --> $DIR/issue-32995.rs:16:34
+  --> $DIR/issue-32995.rs:16:36
    |
 LL |     let p = ::std::str::from_utf8::()(b"foo").unwrap();
-   |                                  ^^^^
+   |                                    ^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #42238 <https://github.com/rust-lang/rust/issues/42238>

--- a/src/test/ui/parser/type-parameters-in-field-exprs.stderr
+++ b/src/test/ui/parser/type-parameters-in-field-exprs.stderr
@@ -1,20 +1,20 @@
 error: field expressions may not have generic arguments
-  --> $DIR/type-parameters-in-field-exprs.rs:13:8
+  --> $DIR/type-parameters-in-field-exprs.rs:13:10
    |
 LL |     f.x::<isize>;
-   |        ^^^^^^^^^
+   |          ^^^^^^^
 
 error: field expressions may not have generic arguments
-  --> $DIR/type-parameters-in-field-exprs.rs:15:8
+  --> $DIR/type-parameters-in-field-exprs.rs:15:10
    |
 LL |     f.x::<>;
-   |        ^^^^
+   |          ^^
 
 error: field expressions may not have generic arguments
-  --> $DIR/type-parameters-in-field-exprs.rs:17:8
+  --> $DIR/type-parameters-in-field-exprs.rs:17:10
    |
 LL |     f.x::();
-   |        ^^^^
+   |          ^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/span/macro-ty-params.stderr
+++ b/src/test/ui/span/macro-ty-params.stderr
@@ -1,14 +1,14 @@
 error: generic arguments in macro path
-  --> $DIR/macro-ty-params.rs:10:8
+  --> $DIR/macro-ty-params.rs:10:10
    |
 LL |     foo::<T>!(); //~ ERROR generic arguments in macro path
-   |        ^^^^^
+   |          ^^^
 
 error: generic arguments in macro path
-  --> $DIR/macro-ty-params.rs:11:8
+  --> $DIR/macro-ty-params.rs:11:10
    |
 LL |     foo::<>!(); //~ ERROR generic arguments in macro path
-   |        ^^^^
+   |          ^^
 
 error: unexpected generic arguments in path
   --> $DIR/macro-ty-params.rs:12:8

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-1.rs
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-1.rs
@@ -6,7 +6,7 @@ struct Bar<A> {
 
 fn bar() {
     let x: Box<Bar()> = panic!();
-    //~^ ERROR parenthesized parameters may only be used with a trait
+    //~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
     //~| ERROR wrong number of type arguments: expected 1, found 0
 }
 

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-1.rs
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-1.rs
@@ -7,6 +7,7 @@ struct Bar<A> {
 fn bar() {
     let x: Box<Bar()> = panic!();
     //~^ ERROR parenthesized parameters may only be used with a trait
+    //~| ERROR wrong number of type arguments: expected 1, found 0
 }
 
 fn main() { }

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-1.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-1.stderr
@@ -1,11 +1,8 @@
-error[E0214]: parenthesized parameters may only be used with a trait
+error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
   --> $DIR/unboxed-closure-sugar-used-on-struct-1.rs:8:19
    |
 LL |     let x: Box<Bar()> = panic!();
-   |                   ^^
-   |                   |
-   |                   only traits may use parentheses
-   |                   help: use angle brackets instead: `<>`
+   |                   ^^ only `Fn` traits may use parentheses
 
 error[E0107]: wrong number of type arguments: expected 1, found 0
   --> $DIR/unboxed-closure-sugar-used-on-struct-1.rs:8:16

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-1.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-1.stderr
@@ -2,7 +2,10 @@ error[E0214]: parenthesized parameters may only be used with a trait
   --> $DIR/unboxed-closure-sugar-used-on-struct-1.rs:8:19
    |
 LL |     let x: Box<Bar()> = panic!();
-   |                   ^^ only traits may use parentheses
+   |                   ^^
+   |                   |
+   |                   only traits may use parentheses
+   |                   help: use angle brackets instead: `<>`
 
 error[E0107]: wrong number of type arguments: expected 1, found 0
   --> $DIR/unboxed-closure-sugar-used-on-struct-1.rs:8:16

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-1.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-1.stderr
@@ -4,6 +4,13 @@ error[E0214]: parenthesized parameters may only be used with a trait
 LL |     let x: Box<Bar()> = panic!();
    |                   ^^ only traits may use parentheses
 
-error: aborting due to previous error
+error[E0107]: wrong number of type arguments: expected 1, found 0
+  --> $DIR/unboxed-closure-sugar-used-on-struct-1.rs:8:16
+   |
+LL |     let x: Box<Bar()> = panic!();
+   |                ^^^^^ expected 1 type argument
 
-For more information about this error, try `rustc --explain E0214`.
+error: aborting due to 2 previous errors
+
+Some errors occurred: E0107, E0214.
+For more information about an error, try `rustc --explain E0107`.

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-3.rs
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-3.rs
@@ -12,7 +12,7 @@ fn bar() {
     let b = Bar::<isize, usize>::new(); // OK
 
     let b = Bar::(isize, usize)::new(); // OK too (for the parser)
-    //~^ ERROR parenthesized parameters may only be used with a trait
+    //~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
 }
 
 fn main() {}

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-3.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-3.stderr
@@ -4,6 +4,13 @@ error[E0214]: parenthesized parameters may only be used with a trait
 LL |     let b = Bar::(isize, usize)::new(); // OK too (for the parser)
    |                ^^^^^^^^^^^^^^^^ only traits may use parentheses
 
-error: aborting due to previous error
+error[E0107]: wrong number of type arguments: expected 2, found 0
+  --> $DIR/unboxed-closure-sugar-used-on-struct-3.rs:14:13
+   |
+LL |     let b = Bar::(isize, usize)::new(); // OK too (for the parser)
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^ expected 2 type arguments
 
-For more information about this error, try `rustc --explain E0214`.
+error: aborting due to 2 previous errors
+
+Some errors occurred: E0107, E0214.
+For more information about an error, try `rustc --explain E0107`.

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-3.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-3.stderr
@@ -4,13 +4,6 @@ error[E0214]: parenthesized parameters may only be used with a trait
 LL |     let b = Bar::(isize, usize)::new(); // OK too (for the parser)
    |                ^^^^^^^^^^^^^^^^ only traits may use parentheses
 
-error[E0107]: wrong number of type arguments: expected 2, found 0
-  --> $DIR/unboxed-closure-sugar-used-on-struct-3.rs:14:13
-   |
-LL |     let b = Bar::(isize, usize)::new(); // OK too (for the parser)
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^ expected 2 type arguments
+error: aborting due to previous error
 
-error: aborting due to 2 previous errors
-
-Some errors occurred: E0107, E0214.
-For more information about an error, try `rustc --explain E0107`.
+For more information about this error, try `rustc --explain E0214`.

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-3.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-3.stderr
@@ -1,8 +1,11 @@
 error[E0214]: parenthesized parameters may only be used with a trait
-  --> $DIR/unboxed-closure-sugar-used-on-struct-3.rs:14:16
+  --> $DIR/unboxed-closure-sugar-used-on-struct-3.rs:14:18
    |
 LL |     let b = Bar::(isize, usize)::new(); // OK too (for the parser)
-   |                ^^^^^^^^^^^^^^^^ only traits may use parentheses
+   |                  ^^^^^^^^^^^^^^
+   |                  |
+   |                  only traits may use parentheses
+   |                  help: use angle brackets instead: `<isize, usize>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-3.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-3.stderr
@@ -1,10 +1,10 @@
-error[E0214]: parenthesized parameters may only be used with a trait
+error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
   --> $DIR/unboxed-closure-sugar-used-on-struct-3.rs:14:18
    |
 LL |     let b = Bar::(isize, usize)::new(); // OK too (for the parser)
    |                  ^^^^^^^^^^^^^^
    |                  |
-   |                  only traits may use parentheses
+   |                  only `Fn` traits may use parentheses
    |                  help: use angle brackets instead: `<isize, usize>`
 
 error: aborting due to previous error

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct.rs
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct.rs
@@ -5,7 +5,7 @@ struct Bar<A> {
 }
 
 fn foo(b: Box<Bar()>) {
-    //~^ ERROR parenthesized parameters may only be used with a trait
+    //~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
     //~| ERROR wrong number of type arguments: expected 1, found 0
 }
 

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct.rs
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct.rs
@@ -6,7 +6,7 @@ struct Bar<A> {
 
 fn foo(b: Box<Bar()>) {
     //~^ ERROR parenthesized parameters may only be used with a trait
-    //~| ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~| ERROR wrong number of type arguments: expected 1, found 0
 }
 
 fn main() { }

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct.stderr
@@ -2,7 +2,10 @@ error[E0214]: parenthesized parameters may only be used with a trait
   --> $DIR/unboxed-closure-sugar-used-on-struct.rs:7:18
    |
 LL | fn foo(b: Box<Bar()>) {
-   |                  ^^ only traits may use parentheses
+   |                  ^^
+   |                  |
+   |                  only traits may use parentheses
+   |                  help: use angle brackets instead: `<>`
 
 error[E0107]: wrong number of type arguments: expected 1, found 0
   --> $DIR/unboxed-closure-sugar-used-on-struct.rs:7:15

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct.stderr
@@ -4,13 +4,13 @@ error[E0214]: parenthesized parameters may only be used with a trait
 LL | fn foo(b: Box<Bar()>) {
    |                  ^^ only traits may use parentheses
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0107]: wrong number of type arguments: expected 1, found 0
   --> $DIR/unboxed-closure-sugar-used-on-struct.rs:7:15
    |
 LL | fn foo(b: Box<Bar()>) {
-   |               ^^^^^ not allowed in type signatures
+   |               ^^^^^ expected 1 type argument
 
 error: aborting due to 2 previous errors
 
-Some errors occurred: E0121, E0214.
-For more information about an error, try `rustc --explain E0121`.
+Some errors occurred: E0107, E0214.
+For more information about an error, try `rustc --explain E0107`.

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct.stderr
@@ -1,11 +1,8 @@
-error[E0214]: parenthesized parameters may only be used with a trait
+error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
   --> $DIR/unboxed-closure-sugar-used-on-struct.rs:7:18
    |
 LL | fn foo(b: Box<Bar()>) {
-   |                  ^^
-   |                  |
-   |                  only traits may use parentheses
-   |                  help: use angle brackets instead: `<>`
+   |                  ^^ only `Fn` traits may use parentheses
 
 error[E0107]: wrong number of type arguments: expected 1, found 0
   --> $DIR/unboxed-closure-sugar-used-on-struct.rs:7:15


### PR DESCRIPTION
```
error[E0214]: parenthesized parameters may only be used with a trait
--> $DIR/E0214.rs:2:15
   |
LL |     let v: Vec(&str) = vec!["foo"];
   |               ^^^^^^
   |               |
   |               only traits may use parentheses
   |               help: use angle brackets instead: `<&str>`
```

r? @zackmdavis 