### PR TITLE
Recover from parse errors in literal struct fields and incorrect float literals

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2002,10 +2002,10 @@ impl<'a> Parser<'a> {
                     self.bump();
                     let sp = lo.to(self.prev_span);
                     let mut err = self.diagnostic()
-                        .struct_span_err(sp, "numeric float literals must have a significant");
+                        .struct_span_err(sp, "float literals must have an integer part");
                     err.span_suggestion_with_applicability(
                         sp,
-                        "numeric float literals must have a significant",
+                        "must have an integer part",
                         format!("0.{}", val),
                         Applicability::MachineApplicable,
                     );

--- a/src/test/ui/issues/issue-52496.rs
+++ b/src/test/ui/issues/issue-52496.rs
@@ -4,7 +4,6 @@ fn main() {
     let _ = Foo { bar: .5, baz: 42 };
     //~^ ERROR float literals must have an integer part
     //~| ERROR missing field `bat` in initializer of `Foo`
-    //~| ERROR mismatched types
     let bar = 1.5f32;
     let _ = Foo { bar.into(), bat: -1, . };
     //~^ ERROR expected one of

--- a/src/test/ui/issues/issue-52496.rs
+++ b/src/test/ui/issues/issue-52496.rs
@@ -1,0 +1,13 @@
+struct Foo { bar: f64, baz: i64, bat: i64 }
+
+fn main() {
+    let _ = Foo { bar: .5, baz: 42 };
+    //~^ ERROR expected expression
+    //~| ERROR missing field `bat` in initializer of `Foo`
+    let bar = 1.5f32;
+    let _ = Foo { bar.into(), bat: -1, . };
+    //~^ ERROR expected one of
+    //~| ERROR mismatched types
+    //~| ERROR missing field `baz` in initializer of `Foo`
+    //~| ERROR expected identifier, found `.`
+}

--- a/src/test/ui/issues/issue-52496.rs
+++ b/src/test/ui/issues/issue-52496.rs
@@ -2,8 +2,9 @@ struct Foo { bar: f64, baz: i64, bat: i64 }
 
 fn main() {
     let _ = Foo { bar: .5, baz: 42 };
-    //~^ ERROR expected expression
+    //~^ ERROR numeric float literals must have a significant
     //~| ERROR missing field `bat` in initializer of `Foo`
+    //~| ERROR mismatched types
     let bar = 1.5f32;
     let _ = Foo { bar.into(), bat: -1, . };
     //~^ ERROR expected one of

--- a/src/test/ui/issues/issue-52496.rs
+++ b/src/test/ui/issues/issue-52496.rs
@@ -7,7 +7,6 @@ fn main() {
     let bar = 1.5f32;
     let _ = Foo { bar.into(), bat: -1, . };
     //~^ ERROR expected one of
-    //~| ERROR mismatched types
-    //~| ERROR missing field `baz` in initializer of `Foo`
+    //~| ERROR missing fields `bar`, `baz` in initializer of `Foo`
     //~| ERROR expected identifier, found `.`
 }

--- a/src/test/ui/issues/issue-52496.rs
+++ b/src/test/ui/issues/issue-52496.rs
@@ -2,7 +2,7 @@ struct Foo { bar: f64, baz: i64, bat: i64 }
 
 fn main() {
     let _ = Foo { bar: .5, baz: 42 };
-    //~^ ERROR numeric float literals must have a significant
+    //~^ ERROR float literals must have an integer part
     //~| ERROR missing field `bat` in initializer of `Foo`
     //~| ERROR mismatched types
     let bar = 1.5f32;

--- a/src/test/ui/issues/issue-52496.stderr
+++ b/src/test/ui/issues/issue-52496.stderr
@@ -1,8 +1,8 @@
-error: numeric float literals must have a significant
+error: float literals must have an integer part
   --> $DIR/issue-52496.rs:4:24
    |
 LL |     let _ = Foo { bar: .5, baz: 42 };
-   |                        ^^ help: numeric float literals must have a significant: `0.5`
+   |                        ^^ help: must have an integer part: `0.5`
 
 error: expected one of `,` or `}`, found `.`
   --> $DIR/issue-52496.rs:9:22

--- a/src/test/ui/issues/issue-52496.stderr
+++ b/src/test/ui/issues/issue-52496.stderr
@@ -1,0 +1,50 @@
+error: expected expression, found `.`
+  --> $DIR/issue-52496.rs:4:24
+   |
+LL |     let _ = Foo { bar: .5, baz: 42 };
+   |             ---        ^ expected expression
+   |             |
+   |             while parsing this struct
+
+error: expected one of `,` or `}`, found `.`
+  --> $DIR/issue-52496.rs:8:22
+   |
+LL |     let _ = Foo { bar.into(), bat: -1, . };
+   |             ---      ^ expected one of `,` or `}` here
+   |             |
+   |             while parsing this struct
+
+error: expected identifier, found `.`
+  --> $DIR/issue-52496.rs:8:40
+   |
+LL |     let _ = Foo { bar.into(), bat: -1, . };
+   |             ---                        ^ expected identifier
+   |             |
+   |             while parsing this struct
+
+error[E0063]: missing field `bat` in initializer of `Foo`
+  --> $DIR/issue-52496.rs:4:13
+   |
+LL |     let _ = Foo { bar: .5, baz: 42 };
+   |             ^^^ missing `bat`
+
+error[E0308]: mismatched types
+  --> $DIR/issue-52496.rs:8:19
+   |
+LL |     let _ = Foo { bar.into(), bat: -1, . };
+   |                   ^^^ expected f64, found f32
+help: you can cast an `f32` to `f64` in a lossless way
+   |
+LL |     let _ = Foo { bar: bar.into().into(), bat: -1, . };
+   |                   ^^^^^^^^^^^^^^^
+
+error[E0063]: missing field `baz` in initializer of `Foo`
+  --> $DIR/issue-52496.rs:8:13
+   |
+LL |     let _ = Foo { bar.into(), bat: -1, . };
+   |             ^^^ missing `baz`
+
+error: aborting due to 6 previous errors
+
+Some errors occurred: E0063, E0308.
+For more information about an error, try `rustc --explain E0063`.

--- a/src/test/ui/issues/issue-52496.stderr
+++ b/src/test/ui/issues/issue-52496.stderr
@@ -26,23 +26,12 @@ error[E0063]: missing field `bat` in initializer of `Foo`
 LL |     let _ = Foo { bar: .5, baz: 42 };
    |             ^^^ missing `bat`
 
-error[E0308]: mismatched types
-  --> $DIR/issue-52496.rs:8:19
-   |
-LL |     let _ = Foo { bar.into(), bat: -1, . };
-   |                   ^^^ expected f64, found f32
-help: you can cast an `f32` to `f64` in a lossless way
-   |
-LL |     let _ = Foo { bar.into().into(), bat: -1, . };
-   |                   ^^^^^^^^^^
-
-error[E0063]: missing field `baz` in initializer of `Foo`
+error[E0063]: missing fields `bar`, `baz` in initializer of `Foo`
   --> $DIR/issue-52496.rs:8:13
    |
 LL |     let _ = Foo { bar.into(), bat: -1, . };
-   |             ^^^ missing `baz`
+   |             ^^^ missing `bar`, `baz`
 
-error: aborting due to 6 previous errors
+error: aborting due to 5 previous errors
 
-Some errors occurred: E0063, E0308.
-For more information about an error, try `rustc --explain E0063`.
+For more information about this error, try `rustc --explain E0063`.

--- a/src/test/ui/issues/issue-52496.stderr
+++ b/src/test/ui/issues/issue-52496.stderr
@@ -1,13 +1,11 @@
-error: expected expression, found `.`
+error: numeric float literals must have a significant
   --> $DIR/issue-52496.rs:4:24
    |
 LL |     let _ = Foo { bar: .5, baz: 42 };
-   |             ---        ^ expected expression
-   |             |
-   |             while parsing this struct
+   |                        ^^ help: numeric float literals must have a significant: `0.5`
 
 error: expected one of `,` or `}`, found `.`
-  --> $DIR/issue-52496.rs:8:22
+  --> $DIR/issue-52496.rs:9:22
    |
 LL |     let _ = Foo { bar.into(), bat: -1, . };
    |             ---      ^ expected one of `,` or `}` here
@@ -15,12 +13,22 @@ LL |     let _ = Foo { bar.into(), bat: -1, . };
    |             while parsing this struct
 
 error: expected identifier, found `.`
-  --> $DIR/issue-52496.rs:8:40
+  --> $DIR/issue-52496.rs:9:40
    |
 LL |     let _ = Foo { bar.into(), bat: -1, . };
    |             ---                        ^ expected identifier
    |             |
    |             while parsing this struct
+
+error[E0308]: mismatched types
+  --> $DIR/issue-52496.rs:4:24
+   |
+LL |     let _ = Foo { bar: .5, baz: 42 };
+   |                        ^^ expected f64, found f32
+help: change the type of the numeric literal from `f32` to `f64`
+   |
+LL |     let _ = Foo { bar: .5f64, baz: 42 };
+   |                        ^^^^^
 
 error[E0063]: missing field `bat` in initializer of `Foo`
   --> $DIR/issue-52496.rs:4:13
@@ -29,22 +37,22 @@ LL |     let _ = Foo { bar: .5, baz: 42 };
    |             ^^^ missing `bat`
 
 error[E0308]: mismatched types
-  --> $DIR/issue-52496.rs:8:19
+  --> $DIR/issue-52496.rs:9:19
    |
 LL |     let _ = Foo { bar.into(), bat: -1, . };
    |                   ^^^ expected f64, found f32
 help: you can cast an `f32` to `f64` in a lossless way
    |
-LL |     let _ = Foo { bar: bar.into().into(), bat: -1, . };
-   |                   ^^^^^^^^^^^^^^^
+LL |     let _ = Foo { bar.into().into(), bat: -1, . };
+   |                   ^^^^^^^^^^
 
 error[E0063]: missing field `baz` in initializer of `Foo`
-  --> $DIR/issue-52496.rs:8:13
+  --> $DIR/issue-52496.rs:9:13
    |
 LL |     let _ = Foo { bar.into(), bat: -1, . };
    |             ^^^ missing `baz`
 
-error: aborting due to 6 previous errors
+error: aborting due to 7 previous errors
 
 Some errors occurred: E0063, E0308.
 For more information about an error, try `rustc --explain E0063`.

--- a/src/test/ui/issues/issue-52496.stderr
+++ b/src/test/ui/issues/issue-52496.stderr
@@ -5,7 +5,7 @@ LL |     let _ = Foo { bar: .5, baz: 42 };
    |                        ^^ help: must have an integer part: `0.5`
 
 error: expected one of `,` or `}`, found `.`
-  --> $DIR/issue-52496.rs:9:22
+  --> $DIR/issue-52496.rs:8:22
    |
 LL |     let _ = Foo { bar.into(), bat: -1, . };
    |             ---      ^ expected one of `,` or `}` here
@@ -13,22 +13,12 @@ LL |     let _ = Foo { bar.into(), bat: -1, . };
    |             while parsing this struct
 
 error: expected identifier, found `.`
-  --> $DIR/issue-52496.rs:9:40
+  --> $DIR/issue-52496.rs:8:40
    |
 LL |     let _ = Foo { bar.into(), bat: -1, . };
    |             ---                        ^ expected identifier
    |             |
    |             while parsing this struct
-
-error[E0308]: mismatched types
-  --> $DIR/issue-52496.rs:4:24
-   |
-LL |     let _ = Foo { bar: .5, baz: 42 };
-   |                        ^^ expected f64, found f32
-help: change the type of the numeric literal from `f32` to `f64`
-   |
-LL |     let _ = Foo { bar: .5f64, baz: 42 };
-   |                        ^^^^^
 
 error[E0063]: missing field `bat` in initializer of `Foo`
   --> $DIR/issue-52496.rs:4:13
@@ -37,7 +27,7 @@ LL |     let _ = Foo { bar: .5, baz: 42 };
    |             ^^^ missing `bat`
 
 error[E0308]: mismatched types
-  --> $DIR/issue-52496.rs:9:19
+  --> $DIR/issue-52496.rs:8:19
    |
 LL |     let _ = Foo { bar.into(), bat: -1, . };
    |                   ^^^ expected f64, found f32
@@ -47,12 +37,12 @@ LL |     let _ = Foo { bar.into().into(), bat: -1, . };
    |                   ^^^^^^^^^^
 
 error[E0063]: missing field `baz` in initializer of `Foo`
-  --> $DIR/issue-52496.rs:9:13
+  --> $DIR/issue-52496.rs:8:13
    |
 LL |     let _ = Foo { bar.into(), bat: -1, . };
    |             ^^^ missing `baz`
 
-error: aborting due to 7 previous errors
+error: aborting due to 6 previous errors
 
 Some errors occurred: E0063, E0308.
 For more information about an error, try `rustc --explain E0063`.

--- a/src/test/ui/parser/removed-syntax-with-1.rs
+++ b/src/test/ui/parser/removed-syntax-with-1.rs
@@ -7,5 +7,5 @@ fn main() {
     let a = S { foo: (), bar: () };
     let b = S { foo: () with a };
     //~^ ERROR expected one of `,`, `.`, `?`, `}`, or an operator, found `with`
-    //~| ERROR missing field `bar` in initializer of `main::S`
+    //~| ERROR missing fields `bar`, `foo` in initializer of `main::S`
 }

--- a/src/test/ui/parser/removed-syntax-with-1.rs
+++ b/src/test/ui/parser/removed-syntax-with-1.rs
@@ -5,7 +5,6 @@ fn main() {
     }
 
     let a = S { foo: (), bar: () };
-    let b = S { foo: () with a };
+    let b = S { foo: () with a, bar: () };
     //~^ ERROR expected one of `,`, `.`, `?`, `}`, or an operator, found `with`
-    //~| ERROR missing fields `bar`, `foo` in initializer of `main::S`
 }

--- a/src/test/ui/parser/removed-syntax-with-1.stderr
+++ b/src/test/ui/parser/removed-syntax-with-1.stderr
@@ -2,7 +2,9 @@ error: expected one of `,`, `.`, `?`, `}`, or an operator, found `with`
   --> $DIR/removed-syntax-with-1.rs:8:25
    |
 LL |     let b = S { foo: () with a };
-   |                         ^^^^ expected one of `,`, `.`, `?`, `}`, or an operator here
+   |             -           ^^^^ expected one of `,`, `.`, `?`, `}`, or an operator here
+   |             |
+   |             while parsing this struct
 
 error[E0063]: missing field `bar` in initializer of `main::S`
   --> $DIR/removed-syntax-with-1.rs:8:13

--- a/src/test/ui/parser/removed-syntax-with-1.stderr
+++ b/src/test/ui/parser/removed-syntax-with-1.stderr
@@ -6,11 +6,11 @@ LL |     let b = S { foo: () with a };
    |             |
    |             while parsing this struct
 
-error[E0063]: missing field `bar` in initializer of `main::S`
+error[E0063]: missing fields `bar`, `foo` in initializer of `main::S`
   --> $DIR/removed-syntax-with-1.rs:8:13
    |
 LL |     let b = S { foo: () with a };
-   |             ^ missing `bar`
+   |             ^ missing `bar`, `foo`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/parser/removed-syntax-with-1.stderr
+++ b/src/test/ui/parser/removed-syntax-with-1.stderr
@@ -1,17 +1,10 @@
 error: expected one of `,`, `.`, `?`, `}`, or an operator, found `with`
   --> $DIR/removed-syntax-with-1.rs:8:25
    |
-LL |     let b = S { foo: () with a };
+LL |     let b = S { foo: () with a, bar: () };
    |             -           ^^^^ expected one of `,`, `.`, `?`, `}`, or an operator here
    |             |
    |             while parsing this struct
 
-error[E0063]: missing fields `bar`, `foo` in initializer of `main::S`
-  --> $DIR/removed-syntax-with-1.rs:8:13
-   |
-LL |     let b = S { foo: () with a };
-   |             ^ missing `bar`, `foo`
+error: aborting due to previous error
 
-error: aborting due to 2 previous errors
-
-For more information about this error, try `rustc --explain E0063`.

--- a/src/test/ui/parser/removed-syntax-with-2.rs
+++ b/src/test/ui/parser/removed-syntax-with-2.rs
@@ -7,6 +7,5 @@ fn main() {
     let a = S { foo: (), bar: () };
     let b = S { foo: (), with a };
     //~^ ERROR expected one of `,` or `}`, found `a`
-    //~| ERROR cannot find value `with` in this scope
-    //~| ERROR struct `main::S` has no field named `with`
+    //~| ERROR missing field `bar` in initializer of `main::S`
 }

--- a/src/test/ui/parser/removed-syntax-with-2.stderr
+++ b/src/test/ui/parser/removed-syntax-with-2.stderr
@@ -2,7 +2,9 @@ error: expected one of `,` or `}`, found `a`
   --> $DIR/removed-syntax-with-2.rs:8:31
    |
 LL |     let b = S { foo: (), with a };
-   |                               ^ expected one of `,` or `}` here
+   |             -                 ^ expected one of `,` or `}` here
+   |             |
+   |             while parsing this struct
 
 error[E0425]: cannot find value `with` in this scope
   --> $DIR/removed-syntax-with-2.rs:8:26

--- a/src/test/ui/parser/removed-syntax-with-2.stderr
+++ b/src/test/ui/parser/removed-syntax-with-2.stderr
@@ -6,21 +6,12 @@ LL |     let b = S { foo: (), with a };
    |             |
    |             while parsing this struct
 
-error[E0425]: cannot find value `with` in this scope
-  --> $DIR/removed-syntax-with-2.rs:8:26
+error[E0063]: missing field `bar` in initializer of `main::S`
+  --> $DIR/removed-syntax-with-2.rs:8:13
    |
 LL |     let b = S { foo: (), with a };
-   |                          ^^^^ not found in this scope
+   |             ^ missing `bar`
 
-error[E0560]: struct `main::S` has no field named `with`
-  --> $DIR/removed-syntax-with-2.rs:8:26
-   |
-LL |     let b = S { foo: (), with a };
-   |                          ^^^^ `main::S` does not have this field
-   |
-   = note: available fields are: `foo`, `bar`
+error: aborting due to 2 previous errors
 
-error: aborting due to 3 previous errors
-
-Some errors occurred: E0425, E0560.
-For more information about an error, try `rustc --explain E0425`.
+For more information about this error, try `rustc --explain E0063`.

--- a/src/test/ui/parser/struct-field-numeric-shorthand.rs
+++ b/src/test/ui/parser/struct-field-numeric-shorthand.rs
@@ -1,6 +1,9 @@
 struct Rgb(u8, u8, u8);
 
 fn main() {
-    let _ = Rgb { 0, 1, 2 }; //~ ERROR expected identifier, found `0`
-                             //~| ERROR missing fields `0`, `1`, `2` in initializer of `Rgb`
+    let _ = Rgb { 0, 1, 2 };
+    //~^ ERROR expected identifier, found `0`
+    //~| ERROR expected identifier, found `1`
+    //~| ERROR expected identifier, found `2`
+    //~| ERROR missing fields `0`, `1`, `2` in initializer of `Rgb`
 }

--- a/src/test/ui/parser/struct-field-numeric-shorthand.stderr
+++ b/src/test/ui/parser/struct-field-numeric-shorthand.stderr
@@ -1,17 +1,33 @@
 error: expected identifier, found `0`
   --> $DIR/struct-field-numeric-shorthand.rs:4:19
    |
-LL |     let _ = Rgb { 0, 1, 2 }; //~ ERROR expected identifier, found `0`
+LL |     let _ = Rgb { 0, 1, 2 };
    |             ---   ^ expected identifier
+   |             |
+   |             while parsing this struct
+
+error: expected identifier, found `1`
+  --> $DIR/struct-field-numeric-shorthand.rs:4:22
+   |
+LL |     let _ = Rgb { 0, 1, 2 };
+   |             ---      ^ expected identifier
+   |             |
+   |             while parsing this struct
+
+error: expected identifier, found `2`
+  --> $DIR/struct-field-numeric-shorthand.rs:4:25
+   |
+LL |     let _ = Rgb { 0, 1, 2 };
+   |             ---         ^ expected identifier
    |             |
    |             while parsing this struct
 
 error[E0063]: missing fields `0`, `1`, `2` in initializer of `Rgb`
   --> $DIR/struct-field-numeric-shorthand.rs:4:13
    |
-LL |     let _ = Rgb { 0, 1, 2 }; //~ ERROR expected identifier, found `0`
+LL |     let _ = Rgb { 0, 1, 2 };
    |             ^^^ missing `0`, `1`, `2`
 
-error: aborting due to 2 previous errors
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0063`.

--- a/src/test/ui/suggestions/recover-invalid-float.rs
+++ b/src/test/ui/suggestions/recover-invalid-float.rs
@@ -1,0 +1,11 @@
+fn main() {
+    let _: usize = .3;
+    //~^ ERROR float literals must have an integer part
+    //~| ERROR mismatched types
+    let _: usize = .42f32;
+    //~^ ERROR float literals must have an integer part
+    //~| ERROR mismatched types
+    let _: usize = .5f64;
+    //~^ ERROR float literals must have an integer part
+    //~| ERROR mismatched types
+}

--- a/src/test/ui/suggestions/recover-invalid-float.stderr
+++ b/src/test/ui/suggestions/recover-invalid-float.stderr
@@ -1,0 +1,42 @@
+error: float literals must have an integer part
+  --> $DIR/recover-invalid-float.rs:2:20
+   |
+LL |     let _: usize = .3;
+   |                    ^^ help: must have an integer part: `0.3`
+
+error: float literals must have an integer part
+  --> $DIR/recover-invalid-float.rs:5:20
+   |
+LL |     let _: usize = .42f32;
+   |                    ^^^^^^ help: must have an integer part: `0.42f32`
+
+error: float literals must have an integer part
+  --> $DIR/recover-invalid-float.rs:8:20
+   |
+LL |     let _: usize = .5f64;
+   |                    ^^^^^ help: must have an integer part: `0.5f64`
+
+error[E0308]: mismatched types
+  --> $DIR/recover-invalid-float.rs:2:20
+   |
+LL |     let _: usize = .3;
+   |                    ^^ expected usize, found floating-point number
+   |
+   = note: expected type `usize`
+              found type `{float}`
+
+error[E0308]: mismatched types
+  --> $DIR/recover-invalid-float.rs:5:20
+   |
+LL |     let _: usize = .42f32;
+   |                    ^^^^^^ expected usize, found f32
+
+error[E0308]: mismatched types
+  --> $DIR/recover-invalid-float.rs:8:20
+   |
+LL |     let _: usize = .5f64;
+   |                    ^^^^^ expected usize, found f64
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fix #52496.