### PR TITLE
Add "dereference boxed value" suggestion.

### DIFF
--- a/src/test/ui/issues/issue-57741-1.rs
+++ b/src/test/ui/issues/issue-57741-1.rs
@@ -1,0 +1,18 @@
+#![allow(warnings)]
+
+// This tests that the `help: consider dereferencing the boxed value` suggestion isn't made
+// because the box doesn't deref to the type of the arm.
+
+enum S {
+    A { a: usize },
+    B { b: usize },
+}
+
+fn main() {
+    let x = Box::new(3u32);
+    let y = match x {
+        S::A { a } | S::B { b: a } => a,
+        //~^ ERROR mismatched types [E0308]
+        //~^^ ERROR mismatched types [E0308]
+    };
+}

--- a/src/test/ui/issues/issue-57741-1.stderr
+++ b/src/test/ui/issues/issue-57741-1.stderr
@@ -1,0 +1,25 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-57741-1.rs:14:9
+   |
+LL |     let y = match x {
+   |                   - this match expression has type `std::boxed::Box<u32>`
+LL |         S::A { a } | S::B { b: a } => a,
+   |         ^^^^^^^^^^ expected struct `std::boxed::Box`, found enum `S`
+   |
+   = note: expected type `std::boxed::Box<u32>`
+              found type `S`
+
+error[E0308]: mismatched types
+  --> $DIR/issue-57741-1.rs:14:22
+   |
+LL |     let y = match x {
+   |                   - this match expression has type `std::boxed::Box<u32>`
+LL |         S::A { a } | S::B { b: a } => a,
+   |                      ^^^^^^^^^^^^^ expected struct `std::boxed::Box`, found enum `S`
+   |
+   = note: expected type `std::boxed::Box<u32>`
+              found type `S`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/issues/issue-57741.fixed
+++ b/src/test/ui/issues/issue-57741.fixed
@@ -1,0 +1,31 @@
+// run-rustfix
+
+#![allow(warnings)]
+
+// This tests that the `help: consider dereferencing the boxed value` suggestion is made and works.
+
+enum S {
+    A { a: usize },
+    B { b: usize },
+}
+
+enum T {
+    A(usize),
+    B(usize),
+}
+
+fn main() {
+    let x = Box::new(T::A(3));
+    let y = match *x {
+        T::A(a) | T::B(a) => a,
+        //~^ ERROR mismatched types [E0308]
+        //~^^ ERROR mismatched types [E0308]
+    };
+
+    let x = Box::new(S::A { a: 3 });
+    let y = match *x {
+        S::A { a } | S::B { b: a } => a,
+        //~^ ERROR mismatched types [E0308]
+        //~^^ ERROR mismatched types [E0308]
+    };
+}

--- a/src/test/ui/issues/issue-57741.rs
+++ b/src/test/ui/issues/issue-57741.rs
@@ -1,0 +1,31 @@
+// run-rustfix
+
+#![allow(warnings)]
+
+// This tests that the `help: consider dereferencing the boxed value` suggestion is made and works.
+
+enum S {
+    A { a: usize },
+    B { b: usize },
+}
+
+enum T {
+    A(usize),
+    B(usize),
+}
+
+fn main() {
+    let x = Box::new(T::A(3));
+    let y = match x {
+        T::A(a) | T::B(a) => a,
+        //~^ ERROR mismatched types [E0308]
+        //~^^ ERROR mismatched types [E0308]
+    };
+
+    let x = Box::new(S::A { a: 3 });
+    let y = match x {
+        S::A { a } | S::B { b: a } => a,
+        //~^ ERROR mismatched types [E0308]
+        //~^^ ERROR mismatched types [E0308]
+    };
+}

--- a/src/test/ui/issues/issue-57741.stderr
+++ b/src/test/ui/issues/issue-57741.stderr
@@ -1,0 +1,59 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-57741.rs:20:9
+   |
+LL |     let y = match x {
+   |                   -
+   |                   |
+   |                   this match expression has type `std::boxed::Box<T>`
+   |                   help: consider dereferencing the boxed value: `*x`
+LL |         T::A(a) | T::B(a) => a,
+   |         ^^^^^^^ expected struct `std::boxed::Box`, found enum `T`
+   |
+   = note: expected type `std::boxed::Box<T>`
+              found type `T`
+
+error[E0308]: mismatched types
+  --> $DIR/issue-57741.rs:20:19
+   |
+LL |     let y = match x {
+   |                   -
+   |                   |
+   |                   this match expression has type `std::boxed::Box<T>`
+   |                   help: consider dereferencing the boxed value: `*x`
+LL |         T::A(a) | T::B(a) => a,
+   |                   ^^^^^^^ expected struct `std::boxed::Box`, found enum `T`
+   |
+   = note: expected type `std::boxed::Box<T>`
+              found type `T`
+
+error[E0308]: mismatched types
+  --> $DIR/issue-57741.rs:27:9
+   |
+LL |     let y = match x {
+   |                   -
+   |                   |
+   |                   this match expression has type `std::boxed::Box<S>`
+   |                   help: consider dereferencing the boxed value: `*x`
+LL |         S::A { a } | S::B { b: a } => a,
+   |         ^^^^^^^^^^ expected struct `std::boxed::Box`, found enum `S`
+   |
+   = note: expected type `std::boxed::Box<S>`
+              found type `S`
+
+error[E0308]: mismatched types
+  --> $DIR/issue-57741.rs:27:22
+   |
+LL |     let y = match x {
+   |                   -
+   |                   |
+   |                   this match expression has type `std::boxed::Box<S>`
+   |                   help: consider dereferencing the boxed value: `*x`
+LL |         S::A { a } | S::B { b: a } => a,
+   |                      ^^^^^^^^^^^^^ expected struct `std::boxed::Box`, found enum `S`
+   |
+   = note: expected type `std::boxed::Box<S>`
+              found type `S`
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fix #57741.

This PR adds a `help: consider dereferencing the boxed value` suggestion to discriminants of match statements when the match arms have type `T` and the discriminant has type `Box<T>`.

r? @estebank 