### PR TITLE
Write generics of trait aliases into metadata.

### DIFF
--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -1213,6 +1213,7 @@ impl<'a, 'b: 'a, 'tcx: 'b> IsolatedEncoder<'a, 'b, 'tcx> {
                 hir::ItemKind::Union(..) |
                 hir::ItemKind::Impl(..) |
                 hir::ItemKind::Existential(..) |
+                hir::ItemKind::TraitAlias(..) |
                 hir::ItemKind::Trait(..) => Some(self.encode_generics(def_id)),
                 _ => None,
             },

--- a/src/test/ui/issues/auxiliary/issue-57676.rs
+++ b/src/test/ui/issues/auxiliary/issue-57676.rs
@@ -1,0 +1,2 @@
+#![feature(trait_alias)]
+trait TestAlias = core::fmt::Debug;

--- a/src/test/ui/issues/issue-57676.rs
+++ b/src/test/ui/issues/issue-57676.rs
@@ -1,0 +1,15 @@
+// aux-build:issue-57676.rs
+
+extern crate issue_57676;
+
+// This tests that when assembling the extension candidates for traits, the presence of a trait
+// alias from another crate will not cause an ICE (the actual errors produced by this once the
+// ICE is fixed aren't interesting).
+
+use std::path::Path;
+
+fn main() {
+    let d: Path = Path::new(".");
+    //~^ ERROR mismatched types [E0308]
+    //~^^ ERROR the size for values of type `[u8]` cannot be known at compilation time [E0277]
+}

--- a/src/test/ui/issues/issue-57676.stderr
+++ b/src/test/ui/issues/issue-57676.stderr
@@ -1,0 +1,25 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-57676.rs:12:19
+   |
+LL |     let d: Path = Path::new(".");
+   |                   ^^^^^^^^^^^^^^ expected struct `std::path::Path`, found reference
+   |
+   = note: expected type `std::path::Path`
+              found type `&std::path::Path`
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> $DIR/issue-57676.rs:12:9
+   |
+LL |     let d: Path = Path::new(".");
+   |         ^ borrow the `Path` instead
+   |
+   = help: within `std::path::Path`, the trait `std::marker::Sized` is not implemented for `[u8]`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
+   = note: required because it appears within the type `std::path::Path`
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
+
+error: aborting due to 2 previous errors
+
+Some errors occurred: E0277, E0308.
+For more information about an error, try `rustc --explain E0277`.


### PR DESCRIPTION
Fixes #57676.

This fixes an ICE where the generics of trait aliases are being read
from metadata when assembling the list of extension candidates and one
such candidate is a trait alias defined in another crate.