### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/src/libcore/convert.rs
+++ b/src/libcore/convert.rs
@@ -476,11 +476,11 @@ impl<T, U> TryInto<U> for T where U: TryFrom<T>
 // Infallible conversions are semantically equivalent to fallible conversions
 // with an uninhabited error type.
 #[unstable(feature = "try_from", issue = "33417")]
-impl<T, U> TryFrom<U> for T where T: From<U> {
+impl<T, U> TryFrom<U> for T where U: Into<T> {
     type Error = !;
 
     fn try_from(value: U) -> Result<Self, Self::Error> {
-        Ok(T::from(value))
+        Ok(U::into(value))
     }
 }
 

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -1826,7 +1826,7 @@ impl<'a> LoweringContext<'a> {
                         struct_span_err!(self.sess, data.span, E0214, "{}", msg)
                             .span_label(data.span, "only traits may use parentheses")
                             .emit();
-                        (hir::GenericArgs::none(), true)
+                        (hir::GenericArgs::none(), false)
                     }
                 },
             }

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -1826,7 +1826,11 @@ impl<'a> LoweringContext<'a> {
                         struct_span_err!(self.sess, data.span, E0214, "{}", msg)
                             .span_label(data.span, "only traits may use parentheses")
                             .emit();
-                        (hir::GenericArgs::none(), false)
+                        (self.lower_angle_bracketed_parameter_data(
+                            &data.as_angle_bracketed_args(),
+                            param_mode,
+                            itctx).0,
+                         false)
                     }
                 },
             }

--- a/src/librustc_typeck/check/demand.rs
+++ b/src/librustc_typeck/check/demand.rs
@@ -454,12 +454,13 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         false
     }
 
-    pub fn check_for_cast(&self,
-                      err: &mut DiagnosticBuilder<'tcx>,
-                      expr: &hir::Expr,
-                      checked_ty: Ty<'tcx>,
-                      expected_ty: Ty<'tcx>)
-                      -> bool {
+    pub fn check_for_cast(
+        &self,
+        err: &mut DiagnosticBuilder<'tcx>,
+        expr: &hir::Expr,
+        checked_ty: Ty<'tcx>,
+        expected_ty: Ty<'tcx>,
+    ) -> bool {
         let parent_id = self.tcx.hir().get_parent_node(expr.id);
         if let Some(parent) = self.tcx.hir().find(parent_id) {
             // Shouldn't suggest `.into()` on `const`s.
@@ -487,17 +488,40 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         // For now, don't suggest casting with `as`.
         let can_cast = false;
 
+        let mut prefix = String::new();
+        if let Some(hir::Node::Expr(hir::Expr {
+            node: hir::ExprKind::Struct(_, fields, _),
+            ..
+        })) = self.tcx.hir().find(self.tcx.hir().get_parent_node(expr.id)) {
+            // `expr` is a literal field for a struct, only suggest if appropriate
+            for field in fields {
+                if field.expr.id == expr.id {
+                    // This is a field literal
+                    prefix = format!("{}: ", field.ident);
+                    break;
+                }
+            }
+            if &prefix == "" {
+                // Likely a field was meant, but this field wasn't found. Do not suggest anything.
+                return false;
+            }
+        }
+
         let needs_paren = expr.precedence().order() < (PREC_POSTFIX as i8);
 
         if let Ok(src) = self.tcx.sess.source_map().span_to_snippet(expr.span) {
             let msg = format!("you can cast an `{}` to `{}`", checked_ty, expected_ty);
-            let cast_suggestion = format!("{}{}{} as {}",
-                                          if needs_paren { "(" } else { "" },
-                                          src,
-                                          if needs_paren { ")" } else { "" },
-                                          expected_ty);
+            let cast_suggestion = format!(
+                "{}{}{}{} as {}",
+                prefix,
+                if needs_paren { "(" } else { "" },
+                src,
+                if needs_paren { ")" } else { "" },
+                expected_ty,
+            );
             let into_suggestion = format!(
-                "{}{}{}.into()",
+                "{}{}{}{}.into()",
+                prefix,
                 if needs_paren { "(" } else { "" },
                 src,
                 if needs_paren { ")" } else { "" },

--- a/src/librustc_typeck/check/demand.rs
+++ b/src/librustc_typeck/check/demand.rs
@@ -495,7 +495,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         })) = self.tcx.hir().find(self.tcx.hir().get_parent_node(expr.id)) {
             // `expr` is a literal field for a struct, only suggest if appropriate
             for field in fields {
-                if field.expr.id == expr.id {
+                if field.expr.id == expr.id && field.is_shorthand {
                     // This is a field literal
                     prefix = format!("{}: ", field.ident);
                     break;

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -192,6 +192,16 @@ pub struct ParenthesisedArgs {
     pub output: Option<P<Ty>>,
 }
 
+impl ParenthesisedArgs {
+    pub fn as_angle_bracketed_args(&self) -> AngleBracketedArgs {
+        AngleBracketedArgs {
+            span: self.span,
+            args: self.inputs.iter().cloned().map(|input| GenericArg::Type(input)).collect(),
+            bindings: vec![],
+        }
+    }
+}
+
 // hack to ensure that we don't try to access the private parts of `NodeId` in this module
 mod node_id_inner {
     use rustc_data_structures::indexed_vec::Idx;

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4483,13 +4483,17 @@ impl<'a> Parser<'a> {
     }
 
     /// Emit an expected item after attributes error.
-    fn expected_item_err(&self, attrs: &[Attribute]) {
+    fn expected_item_err(&mut self, attrs: &[Attribute]) -> PResult<'a,  ()> {
         let message = match attrs.last() {
             Some(&Attribute { is_sugared_doc: true, .. }) => "expected item after doc comment",
             _ => "expected item after attributes",
         };
 
-        self.span_err(self.prev_span, message);
+        let mut err = self.diagnostic().struct_span_err(self.prev_span, message);
+        if attrs.last().unwrap().is_sugared_doc {
+            err.span_label(self.prev_span, "this doc comment doesn't document anything");
+        }
+        Err(err)
     }
 
     /// Parse a statement. This stops just before trailing semicolons on everything but items.
@@ -7636,7 +7640,7 @@ impl<'a> Parser<'a> {
             }
             None => {
                 if !attrs.is_empty()  {
-                    self.expected_item_err(&attrs);
+                    self.expected_item_err(&attrs)?;
                 }
 
                 self.unexpected()
@@ -7699,7 +7703,7 @@ impl<'a> Parser<'a> {
         }
 
         if !attributes_allowed && !attrs.is_empty() {
-            self.expected_item_err(&attrs);
+            self.expected_item_err(&attrs)?;
         }
         Ok(None)
     }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2176,11 +2176,11 @@ impl<'a> Parser<'a> {
               style != PathStyle::Mod && self.check(&token::ModSep)
                                       && self.look_ahead(1, |t| is_args_start(t)) {
             // Generic arguments are found - `<`, `(`, `::<` or `::(`.
-            let lo = self.span;
             if self.eat(&token::ModSep) && style == PathStyle::Type && enable_warning {
                 self.diagnostic().struct_span_warn(self.prev_span, "unnecessary path disambiguator")
                                  .span_label(self.prev_span, "try removing `::`").emit();
             }
+            let lo = self.span;
 
             let args = if self.eat_lt() {
                 // `<'a, T, A = U>`

--- a/src/test/run-pass/try_from.rs
+++ b/src/test/run-pass/try_from.rs
@@ -1,0 +1,43 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This test relies on `TryFrom` being auto impl for all `T: Into`
+// and `TryInto` being auto impl for all `U: TryFrom`
+
+// This test was added to show the motivation for doing this
+// over `TryFrom` being auto impl for all `T: From`
+
+#![feature(try_from, never_type)]
+
+use std::convert::TryInto;
+
+struct Foo<T> {
+    t: T
+}
+
+/*
+// This fails to compile due to coherence restrictions
+// as of rust version 1.32.x
+impl<T> From<Foo<T>> for Box<T> {
+    fn from(foo: Foo<T>) -> Box<T> {
+        Box::new(foo.t)
+    }
+}
+*/
+
+impl<T> Into<Box<T>> for Foo<T> {
+    fn into(self) -> Box<T> {
+        Box::new(self.t)
+    }
+}
+
+pub fn main() {
+    let _: Result<Box<i32>, !> = Foo { t: 10 }.try_into();
+}

--- a/src/test/run-pass/try_from.rs
+++ b/src/test/run-pass/try_from.rs
@@ -32,12 +32,13 @@ impl<T> From<Foo<T>> for Box<T> {
 }
 */
 
-impl<T> Into<Box<T>> for Foo<T> {
-    fn into(self) -> Box<T> {
-        Box::new(self.t)
+impl<T> Into<Vec<T>> for Foo<T> {
+    fn into(self) -> Vec<T> {
+        vec![self.t]
     }
 }
 
 pub fn main() {
-    let _: Result<Box<i32>, !> = Foo { t: 10 }.try_into();
+    let _: Result<Vec<i32>, !> = Foo { t: 10 }.try_into();
 }
+

--- a/src/test/run-pass/try_from.rs
+++ b/src/test/run-pass/try_from.rs
@@ -1,30 +1,23 @@
-// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
-// file at the top-level directory of this distribution and at
-// http://rust-lang.org/COPYRIGHT.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
-// This test relies on `TryFrom` being auto impl for all `T: Into`
-// and `TryInto` being auto impl for all `U: TryFrom`
+// This test relies on `TryFrom` being blanket impl for all `T: Into`
+// and `TryInto` being blanket impl for all `U: TryFrom`
 
 // This test was added to show the motivation for doing this
-// over `TryFrom` being auto impl for all `T: From`
+// over `TryFrom` being blanket impl for all `T: From`
 
 #![feature(try_from, never_type)]
 
 use std::convert::TryInto;
 
 struct Foo<T> {
-    t: T
+    t: T,
 }
 
-/*
 // This fails to compile due to coherence restrictions
-// as of rust version 1.32.x
+// as of Rust version 1.32.x, therefore it could not be used
+// instead of the `Into` version of the impl, and serves as
+// motivation for a blanket impl for all `T: Into`, instead
+// of a blanket impl for all `T: From`
+/*
 impl<T> From<Foo<T>> for Box<T> {
     fn from(foo: Foo<T>) -> Box<T> {
         Box::new(foo.t)

--- a/src/test/ui/e0119/conflict-with-std.stderr
+++ b/src/test/ui/e0119/conflict-with-std.stderr
@@ -25,7 +25,7 @@ LL | impl TryFrom<X> for X { //~ ERROR conflicting implementations
    |
    = note: conflicting implementation in crate `core`:
            - impl<T, U> std::convert::TryFrom<U> for T
-             where T: std::convert::From<U>;
+             where T: std::convert::Into<U>;
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/e0119/conflict-with-std.stderr
+++ b/src/test/ui/e0119/conflict-with-std.stderr
@@ -25,7 +25,7 @@ LL | impl TryFrom<X> for X { //~ ERROR conflicting implementations
    |
    = note: conflicting implementation in crate `core`:
            - impl<T, U> std::convert::TryFrom<U> for T
-             where T: std::convert::Into<U>;
+             where U: std::convert::Into<T>;
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/error-codes/E0214.stderr
+++ b/src/test/ui/error-codes/E0214.stderr
@@ -4,13 +4,6 @@ error[E0214]: parenthesized parameters may only be used with a trait
 LL |     let v: Vec(&str) = vec!["foo"];
    |               ^^^^^^ only traits may use parentheses
 
-error[E0107]: wrong number of type arguments: expected 1, found 0
-  --> $DIR/E0214.rs:2:12
-   |
-LL |     let v: Vec(&str) = vec!["foo"];
-   |            ^^^^^^^^^ expected 1 type argument
+error: aborting due to previous error
 
-error: aborting due to 2 previous errors
-
-Some errors occurred: E0107, E0214.
-For more information about an error, try `rustc --explain E0107`.
+For more information about this error, try `rustc --explain E0214`.

--- a/src/test/ui/error-codes/E0214.stderr
+++ b/src/test/ui/error-codes/E0214.stderr
@@ -4,6 +4,13 @@ error[E0214]: parenthesized parameters may only be used with a trait
 LL |     let v: Vec(&str) = vec!["foo"];
    |               ^^^^^^ only traits may use parentheses
 
-error: aborting due to previous error
+error[E0107]: wrong number of type arguments: expected 1, found 0
+  --> $DIR/E0214.rs:2:12
+   |
+LL |     let v: Vec(&str) = vec!["foo"];
+   |            ^^^^^^^^^ expected 1 type argument
 
-For more information about this error, try `rustc --explain E0214`.
+error: aborting due to 2 previous errors
+
+Some errors occurred: E0107, E0214.
+For more information about an error, try `rustc --explain E0107`.

--- a/src/test/ui/error-codes/E0214.stderr
+++ b/src/test/ui/error-codes/E0214.stderr
@@ -2,7 +2,10 @@ error[E0214]: parenthesized parameters may only be used with a trait
   --> $DIR/E0214.rs:2:15
    |
 LL |     let v: Vec(&str) = vec!["foo"];
-   |               ^^^^^^ only traits may use parentheses
+   |               ^^^^^^
+   |               |
+   |               only traits may use parentheses
+   |               help: use angle brackets instead: `<&str>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0214.stderr
+++ b/src/test/ui/error-codes/E0214.stderr
@@ -1,10 +1,10 @@
-error[E0214]: parenthesized parameters may only be used with a trait
+error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
   --> $DIR/E0214.rs:2:15
    |
 LL |     let v: Vec(&str) = vec!["foo"];
    |               ^^^^^^
    |               |
-   |               only traits may use parentheses
+   |               only `Fn` traits may use parentheses
    |               help: use angle brackets instead: `<&str>`
 
 error: aborting due to previous error

--- a/src/test/ui/issues/issue-23589.rs
+++ b/src/test/ui/issues/issue-23589.rs
@@ -1,5 +1,5 @@
 fn main() {
     let v: Vec(&str) = vec!['1', '2'];
-    //~^ ERROR parenthesized parameters may only be used with a trait
+    //~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
     //~| ERROR mismatched types
 }

--- a/src/test/ui/issues/issue-23589.rs
+++ b/src/test/ui/issues/issue-23589.rs
@@ -1,4 +1,5 @@
 fn main() {
     let v: Vec(&str) = vec!['1', '2'];
     //~^ ERROR parenthesized parameters may only be used with a trait
+    //~| ERROR mismatched types
 }

--- a/src/test/ui/issues/issue-23589.stderr
+++ b/src/test/ui/issues/issue-23589.stderr
@@ -4,6 +4,13 @@ error[E0214]: parenthesized parameters may only be used with a trait
 LL |     let v: Vec(&str) = vec!['1', '2'];
    |               ^^^^^^ only traits may use parentheses
 
-error: aborting due to previous error
+error[E0107]: wrong number of type arguments: expected 1, found 0
+  --> $DIR/issue-23589.rs:2:12
+   |
+LL |     let v: Vec(&str) = vec!['1', '2'];
+   |            ^^^^^^^^^ expected 1 type argument
 
-For more information about this error, try `rustc --explain E0214`.
+error: aborting due to 2 previous errors
+
+Some errors occurred: E0107, E0214.
+For more information about an error, try `rustc --explain E0107`.

--- a/src/test/ui/issues/issue-23589.stderr
+++ b/src/test/ui/issues/issue-23589.stderr
@@ -4,13 +4,16 @@ error[E0214]: parenthesized parameters may only be used with a trait
 LL |     let v: Vec(&str) = vec!['1', '2'];
    |               ^^^^^^ only traits may use parentheses
 
-error[E0107]: wrong number of type arguments: expected 1, found 0
-  --> $DIR/issue-23589.rs:2:12
+error[E0308]: mismatched types
+  --> $DIR/issue-23589.rs:2:29
    |
 LL |     let v: Vec(&str) = vec!['1', '2'];
-   |            ^^^^^^^^^ expected 1 type argument
+   |                             ^^^ expected &str, found char
+   |
+   = note: expected type `&str`
+              found type `char`
 
 error: aborting due to 2 previous errors
 
-Some errors occurred: E0107, E0214.
-For more information about an error, try `rustc --explain E0107`.
+Some errors occurred: E0214, E0308.
+For more information about an error, try `rustc --explain E0214`.

--- a/src/test/ui/issues/issue-23589.stderr
+++ b/src/test/ui/issues/issue-23589.stderr
@@ -2,7 +2,10 @@ error[E0214]: parenthesized parameters may only be used with a trait
   --> $DIR/issue-23589.rs:2:15
    |
 LL |     let v: Vec(&str) = vec!['1', '2'];
-   |               ^^^^^^ only traits may use parentheses
+   |               ^^^^^^
+   |               |
+   |               only traits may use parentheses
+   |               help: use angle brackets instead: `<&str>`
 
 error[E0308]: mismatched types
   --> $DIR/issue-23589.rs:2:29

--- a/src/test/ui/issues/issue-23589.stderr
+++ b/src/test/ui/issues/issue-23589.stderr
@@ -1,10 +1,10 @@
-error[E0214]: parenthesized parameters may only be used with a trait
+error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
   --> $DIR/issue-23589.rs:2:15
    |
 LL |     let v: Vec(&str) = vec!['1', '2'];
    |               ^^^^^^
    |               |
-   |               only traits may use parentheses
+   |               only `Fn` traits may use parentheses
    |               help: use angle brackets instead: `<&str>`
 
 error[E0308]: mismatched types

--- a/src/test/ui/issues/issue-32995-2.rs
+++ b/src/test/ui/issues/issue-32995-2.rs
@@ -2,11 +2,11 @@
 
 fn main() {
     { fn f<X: ::std::marker()::Send>() {} }
-    //~^ ERROR parenthesized parameters may only be used with a trait
+    //~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
     //~| WARN previously accepted
 
     { fn f() -> impl ::std::marker()::Send { } }
-    //~^ ERROR parenthesized parameters may only be used with a trait
+    //~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
     //~| WARN previously accepted
 }
 
@@ -14,5 +14,5 @@ fn main() {
 struct X;
 
 impl ::std::marker()::Copy for X {}
-//~^ ERROR parenthesized parameters may only be used with a trait
+//~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
 //~| WARN previously accepted

--- a/src/test/ui/issues/issue-32995-2.stderr
+++ b/src/test/ui/issues/issue-32995-2.stderr
@@ -1,4 +1,4 @@
-error: parenthesized parameters may only be used with a trait
+error: parenthesized type parameters may only be used with a `Fn` trait
   --> $DIR/issue-32995-2.rs:4:28
    |
 LL |     { fn f<X: ::std::marker()::Send>() {} }
@@ -8,7 +8,7 @@ LL |     { fn f<X: ::std::marker()::Send>() {} }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #42238 <https://github.com/rust-lang/rust/issues/42238>
 
-error: parenthesized parameters may only be used with a trait
+error: parenthesized type parameters may only be used with a `Fn` trait
   --> $DIR/issue-32995-2.rs:8:35
    |
 LL |     { fn f() -> impl ::std::marker()::Send { } }
@@ -17,7 +17,7 @@ LL |     { fn f() -> impl ::std::marker()::Send { } }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #42238 <https://github.com/rust-lang/rust/issues/42238>
 
-error: parenthesized parameters may only be used with a trait
+error: parenthesized type parameters may only be used with a `Fn` trait
   --> $DIR/issue-32995-2.rs:16:19
    |
 LL | impl ::std::marker()::Copy for X {}

--- a/src/test/ui/issues/issue-32995.rs
+++ b/src/test/ui/issues/issue-32995.rs
@@ -2,32 +2,32 @@
 
 fn main() {
     let x: usize() = 1;
-    //~^ ERROR parenthesized parameters may only be used with a trait
+    //~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
     //~| WARN previously accepted
 
     let b: ::std::boxed()::Box<_> = Box::new(1);
-    //~^ ERROR parenthesized parameters may only be used with a trait
+    //~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
     //~| WARN previously accepted
 
     let p = ::std::str::()::from_utf8(b"foo").unwrap();
-    //~^ ERROR parenthesized parameters may only be used with a trait
+    //~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
     //~| WARN previously accepted
 
     let p = ::std::str::from_utf8::()(b"foo").unwrap();
-    //~^ ERROR parenthesized parameters may only be used with a trait
+    //~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
     //~| WARN previously accepted
 
     let o : Box<::std::marker()::Send> = Box::new(1);
-    //~^ ERROR parenthesized parameters may only be used with a trait
+    //~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
     //~| WARN previously accepted
 
     let o : Box<Send + ::std::marker()::Sync> = Box::new(1);
-    //~^ ERROR parenthesized parameters may only be used with a trait
+    //~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
     //~| WARN previously accepted
 }
 
 fn foo<X:Default>() {
     let d : X() = Default::default();
-    //~^ ERROR parenthesized parameters may only be used with a trait
+    //~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
     //~| WARN previously accepted
 }

--- a/src/test/ui/issues/issue-32995.stderr
+++ b/src/test/ui/issues/issue-32995.stderr
@@ -1,4 +1,4 @@
-error: parenthesized parameters may only be used with a trait
+error: parenthesized type parameters may only be used with a `Fn` trait
   --> $DIR/issue-32995.rs:4:17
    |
 LL |     let x: usize() = 1;
@@ -8,7 +8,7 @@ LL |     let x: usize() = 1;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #42238 <https://github.com/rust-lang/rust/issues/42238>
 
-error: parenthesized parameters may only be used with a trait
+error: parenthesized type parameters may only be used with a `Fn` trait
   --> $DIR/issue-32995.rs:8:24
    |
 LL |     let b: ::std::boxed()::Box<_> = Box::new(1);
@@ -17,7 +17,7 @@ LL |     let b: ::std::boxed()::Box<_> = Box::new(1);
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #42238 <https://github.com/rust-lang/rust/issues/42238>
 
-error: parenthesized parameters may only be used with a trait
+error: parenthesized type parameters may only be used with a `Fn` trait
   --> $DIR/issue-32995.rs:12:25
    |
 LL |     let p = ::std::str::()::from_utf8(b"foo").unwrap();
@@ -26,7 +26,7 @@ LL |     let p = ::std::str::()::from_utf8(b"foo").unwrap();
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #42238 <https://github.com/rust-lang/rust/issues/42238>
 
-error: parenthesized parameters may only be used with a trait
+error: parenthesized type parameters may only be used with a `Fn` trait
   --> $DIR/issue-32995.rs:16:36
    |
 LL |     let p = ::std::str::from_utf8::()(b"foo").unwrap();
@@ -35,7 +35,7 @@ LL |     let p = ::std::str::from_utf8::()(b"foo").unwrap();
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #42238 <https://github.com/rust-lang/rust/issues/42238>
 
-error: parenthesized parameters may only be used with a trait
+error: parenthesized type parameters may only be used with a `Fn` trait
   --> $DIR/issue-32995.rs:20:30
    |
 LL |     let o : Box<::std::marker()::Send> = Box::new(1);
@@ -44,7 +44,7 @@ LL |     let o : Box<::std::marker()::Send> = Box::new(1);
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #42238 <https://github.com/rust-lang/rust/issues/42238>
 
-error: parenthesized parameters may only be used with a trait
+error: parenthesized type parameters may only be used with a `Fn` trait
   --> $DIR/issue-32995.rs:24:37
    |
 LL |     let o : Box<Send + ::std::marker()::Sync> = Box::new(1);
@@ -53,7 +53,7 @@ LL |     let o : Box<Send + ::std::marker()::Sync> = Box::new(1);
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #42238 <https://github.com/rust-lang/rust/issues/42238>
 
-error: parenthesized parameters may only be used with a trait
+error: parenthesized type parameters may only be used with a `Fn` trait
   --> $DIR/issue-32995.rs:30:14
    |
 LL |     let d : X() = Default::default();

--- a/src/test/ui/issues/issue-32995.stderr
+++ b/src/test/ui/issues/issue-32995.stderr
@@ -18,19 +18,19 @@ LL |     let b: ::std::boxed()::Box<_> = Box::new(1);
    = note: for more information, see issue #42238 <https://github.com/rust-lang/rust/issues/42238>
 
 error: parenthesized parameters may only be used with a trait
-  --> $DIR/issue-32995.rs:12:23
+  --> $DIR/issue-32995.rs:12:25
    |
 LL |     let p = ::std::str::()::from_utf8(b"foo").unwrap();
-   |                       ^^^^
+   |                         ^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #42238 <https://github.com/rust-lang/rust/issues/42238>
 
 error: parenthesized parameters may only be used with a trait
-  --> $DIR/issue-32995.rs:16:34
+  --> $DIR/issue-32995.rs:16:36
    |
 LL |     let p = ::std::str::from_utf8::()(b"foo").unwrap();
-   |                                  ^^^^
+   |                                    ^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #42238 <https://github.com/rust-lang/rust/issues/42238>

--- a/src/test/ui/issues/issue-57741-1.rs
+++ b/src/test/ui/issues/issue-57741-1.rs
@@ -1,0 +1,18 @@
+#![allow(warnings)]
+
+// This tests that the `help: consider dereferencing the boxed value` suggestion isn't made
+// because the box doesn't deref to the type of the arm.
+
+enum S {
+    A { a: usize },
+    B { b: usize },
+}
+
+fn main() {
+    let x = Box::new(3u32);
+    let y = match x {
+        S::A { a } | S::B { b: a } => a,
+        //~^ ERROR mismatched types [E0308]
+        //~^^ ERROR mismatched types [E0308]
+    };
+}

--- a/src/test/ui/issues/issue-57741-1.stderr
+++ b/src/test/ui/issues/issue-57741-1.stderr
@@ -1,0 +1,25 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-57741-1.rs:14:9
+   |
+LL |     let y = match x {
+   |                   - this match expression has type `std::boxed::Box<u32>`
+LL |         S::A { a } | S::B { b: a } => a,
+   |         ^^^^^^^^^^ expected struct `std::boxed::Box`, found enum `S`
+   |
+   = note: expected type `std::boxed::Box<u32>`
+              found type `S`
+
+error[E0308]: mismatched types
+  --> $DIR/issue-57741-1.rs:14:22
+   |
+LL |     let y = match x {
+   |                   - this match expression has type `std::boxed::Box<u32>`
+LL |         S::A { a } | S::B { b: a } => a,
+   |                      ^^^^^^^^^^^^^ expected struct `std::boxed::Box`, found enum `S`
+   |
+   = note: expected type `std::boxed::Box<u32>`
+              found type `S`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/issues/issue-57741.fixed
+++ b/src/test/ui/issues/issue-57741.fixed
@@ -1,0 +1,31 @@
+// run-rustfix
+
+#![allow(warnings)]
+
+// This tests that the `help: consider dereferencing the boxed value` suggestion is made and works.
+
+enum S {
+    A { a: usize },
+    B { b: usize },
+}
+
+enum T {
+    A(usize),
+    B(usize),
+}
+
+fn main() {
+    let x = Box::new(T::A(3));
+    let y = match *x {
+        T::A(a) | T::B(a) => a,
+        //~^ ERROR mismatched types [E0308]
+        //~^^ ERROR mismatched types [E0308]
+    };
+
+    let x = Box::new(S::A { a: 3 });
+    let y = match *x {
+        S::A { a } | S::B { b: a } => a,
+        //~^ ERROR mismatched types [E0308]
+        //~^^ ERROR mismatched types [E0308]
+    };
+}

--- a/src/test/ui/issues/issue-57741.rs
+++ b/src/test/ui/issues/issue-57741.rs
@@ -1,0 +1,31 @@
+// run-rustfix
+
+#![allow(warnings)]
+
+// This tests that the `help: consider dereferencing the boxed value` suggestion is made and works.
+
+enum S {
+    A { a: usize },
+    B { b: usize },
+}
+
+enum T {
+    A(usize),
+    B(usize),
+}
+
+fn main() {
+    let x = Box::new(T::A(3));
+    let y = match x {
+        T::A(a) | T::B(a) => a,
+        //~^ ERROR mismatched types [E0308]
+        //~^^ ERROR mismatched types [E0308]
+    };
+
+    let x = Box::new(S::A { a: 3 });
+    let y = match x {
+        S::A { a } | S::B { b: a } => a,
+        //~^ ERROR mismatched types [E0308]
+        //~^^ ERROR mismatched types [E0308]
+    };
+}

--- a/src/test/ui/issues/issue-57741.stderr
+++ b/src/test/ui/issues/issue-57741.stderr
@@ -1,0 +1,59 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-57741.rs:20:9
+   |
+LL |     let y = match x {
+   |                   -
+   |                   |
+   |                   this match expression has type `std::boxed::Box<T>`
+   |                   help: consider dereferencing the boxed value: `*x`
+LL |         T::A(a) | T::B(a) => a,
+   |         ^^^^^^^ expected struct `std::boxed::Box`, found enum `T`
+   |
+   = note: expected type `std::boxed::Box<T>`
+              found type `T`
+
+error[E0308]: mismatched types
+  --> $DIR/issue-57741.rs:20:19
+   |
+LL |     let y = match x {
+   |                   -
+   |                   |
+   |                   this match expression has type `std::boxed::Box<T>`
+   |                   help: consider dereferencing the boxed value: `*x`
+LL |         T::A(a) | T::B(a) => a,
+   |                   ^^^^^^^ expected struct `std::boxed::Box`, found enum `T`
+   |
+   = note: expected type `std::boxed::Box<T>`
+              found type `T`
+
+error[E0308]: mismatched types
+  --> $DIR/issue-57741.rs:27:9
+   |
+LL |     let y = match x {
+   |                   -
+   |                   |
+   |                   this match expression has type `std::boxed::Box<S>`
+   |                   help: consider dereferencing the boxed value: `*x`
+LL |         S::A { a } | S::B { b: a } => a,
+   |         ^^^^^^^^^^ expected struct `std::boxed::Box`, found enum `S`
+   |
+   = note: expected type `std::boxed::Box<S>`
+              found type `S`
+
+error[E0308]: mismatched types
+  --> $DIR/issue-57741.rs:27:22
+   |
+LL |     let y = match x {
+   |                   -
+   |                   |
+   |                   this match expression has type `std::boxed::Box<S>`
+   |                   help: consider dereferencing the boxed value: `*x`
+LL |         S::A { a } | S::B { b: a } => a,
+   |                      ^^^^^^^^^^^^^ expected struct `std::boxed::Box`, found enum `S`
+   |
+   = note: expected type `std::boxed::Box<S>`
+              found type `S`
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/parser/doc-before-eof.stderr
+++ b/src/test/ui/parser/doc-before-eof.stderr
@@ -2,7 +2,7 @@ error: expected item after doc comment
   --> $DIR/doc-before-eof.rs:3:1
    |
 LL | /// hi //~ERROR expected item after doc comment
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this doc comment doesn't document anything
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/doc-before-extern-rbrace.stderr
+++ b/src/test/ui/parser/doc-before-extern-rbrace.stderr
@@ -2,7 +2,7 @@ error: expected item after doc comment
   --> $DIR/doc-before-extern-rbrace.rs:2:5
    |
 LL |     /// hi
-   |     ^^^^^^
+   |     ^^^^^^ this doc comment doesn't document anything
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/doc-before-mod-rbrace.stderr
+++ b/src/test/ui/parser/doc-before-mod-rbrace.stderr
@@ -2,7 +2,7 @@ error: expected item after doc comment
   --> $DIR/doc-before-mod-rbrace.rs:4:5
    |
 LL |     /// document
-   |     ^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^ this doc comment doesn't document anything
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/type-parameters-in-field-exprs.stderr
+++ b/src/test/ui/parser/type-parameters-in-field-exprs.stderr
@@ -1,20 +1,20 @@
 error: field expressions may not have generic arguments
-  --> $DIR/type-parameters-in-field-exprs.rs:13:8
+  --> $DIR/type-parameters-in-field-exprs.rs:13:10
    |
 LL |     f.x::<isize>;
-   |        ^^^^^^^^^
+   |          ^^^^^^^
 
 error: field expressions may not have generic arguments
-  --> $DIR/type-parameters-in-field-exprs.rs:15:8
+  --> $DIR/type-parameters-in-field-exprs.rs:15:10
    |
 LL |     f.x::<>;
-   |        ^^^^
+   |          ^^
 
 error: field expressions may not have generic arguments
-  --> $DIR/type-parameters-in-field-exprs.rs:17:8
+  --> $DIR/type-parameters-in-field-exprs.rs:17:10
    |
 LL |     f.x::();
-   |        ^^^^
+   |          ^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/span/macro-ty-params.stderr
+++ b/src/test/ui/span/macro-ty-params.stderr
@@ -1,14 +1,14 @@
 error: generic arguments in macro path
-  --> $DIR/macro-ty-params.rs:10:8
+  --> $DIR/macro-ty-params.rs:10:10
    |
 LL |     foo::<T>!(); //~ ERROR generic arguments in macro path
-   |        ^^^^^
+   |          ^^^
 
 error: generic arguments in macro path
-  --> $DIR/macro-ty-params.rs:11:8
+  --> $DIR/macro-ty-params.rs:11:10
    |
 LL |     foo::<>!(); //~ ERROR generic arguments in macro path
-   |        ^^^^
+   |          ^^
 
 error: unexpected generic arguments in path
   --> $DIR/macro-ty-params.rs:12:8

--- a/src/test/ui/suggestions/type-mismatch-struct-field-shorthand-2.rs
+++ b/src/test/ui/suggestions/type-mismatch-struct-field-shorthand-2.rs
@@ -1,0 +1,9 @@
+struct RGB { r: f64, g: f64, b: f64 }
+
+fn main() {
+    let (r, g, c): (f32, f32, f32) = (0., 0., 0.);
+    let _ = RGB { r, g, c };
+    //~^ ERROR mismatched types
+    //~| ERROR mismatched types
+    //~| ERROR struct `RGB` has no field named `c`
+}

--- a/src/test/ui/suggestions/type-mismatch-struct-field-shorthand-2.stderr
+++ b/src/test/ui/suggestions/type-mismatch-struct-field-shorthand-2.stderr
@@ -1,0 +1,30 @@
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch-struct-field-shorthand-2.rs:5:19
+   |
+LL |     let _ = RGB { r, g, c };
+   |                   ^ expected f64, found f32
+help: you can cast an `f32` to `f64` in a lossless way
+   |
+LL |     let _ = RGB { r: r.into(), g, c };
+   |                   ^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch-struct-field-shorthand-2.rs:5:22
+   |
+LL |     let _ = RGB { r, g, c };
+   |                      ^ expected f64, found f32
+help: you can cast an `f32` to `f64` in a lossless way
+   |
+LL |     let _ = RGB { r, g: g.into(), c };
+   |                      ^^^^^^^^^^^
+
+error[E0560]: struct `RGB` has no field named `c`
+  --> $DIR/type-mismatch-struct-field-shorthand-2.rs:5:25
+   |
+LL |     let _ = RGB { r, g, c };
+   |                         ^ help: a field with a similar name exists: `b`
+
+error: aborting due to 3 previous errors
+
+Some errors occurred: E0308, E0560.
+For more information about an error, try `rustc --explain E0308`.

--- a/src/test/ui/suggestions/type-mismatch-struct-field-shorthand.fixed
+++ b/src/test/ui/suggestions/type-mismatch-struct-field-shorthand.fixed
@@ -1,0 +1,12 @@
+// run-rustfix
+#![allow(dead_code)]
+
+struct RGB { r: f64, g: f64, b: f64 }
+
+fn main() {
+    let (r, g, b): (f32, f32, f32) = (0., 0., 0.);
+    let _ = RGB { r: r.into(), g: g.into(), b: b.into() };
+    //~^ ERROR mismatched types
+    //~| ERROR mismatched types
+    //~| ERROR mismatched types
+}

--- a/src/test/ui/suggestions/type-mismatch-struct-field-shorthand.rs
+++ b/src/test/ui/suggestions/type-mismatch-struct-field-shorthand.rs
@@ -1,0 +1,12 @@
+// run-rustfix
+#![allow(dead_code)]
+
+struct RGB { r: f64, g: f64, b: f64 }
+
+fn main() {
+    let (r, g, b): (f32, f32, f32) = (0., 0., 0.);
+    let _ = RGB { r, g, b };
+    //~^ ERROR mismatched types
+    //~| ERROR mismatched types
+    //~| ERROR mismatched types
+}

--- a/src/test/ui/suggestions/type-mismatch-struct-field-shorthand.stderr
+++ b/src/test/ui/suggestions/type-mismatch-struct-field-shorthand.stderr
@@ -1,0 +1,33 @@
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch-struct-field-shorthand.rs:8:19
+   |
+LL |     let _ = RGB { r, g, b };
+   |                   ^ expected f64, found f32
+help: you can cast an `f32` to `f64` in a lossless way
+   |
+LL |     let _ = RGB { r: r.into(), g, b };
+   |                   ^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch-struct-field-shorthand.rs:8:22
+   |
+LL |     let _ = RGB { r, g, b };
+   |                      ^ expected f64, found f32
+help: you can cast an `f32` to `f64` in a lossless way
+   |
+LL |     let _ = RGB { r, g: g.into(), b };
+   |                      ^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch-struct-field-shorthand.rs:8:25
+   |
+LL |     let _ = RGB { r, g, b };
+   |                         ^ expected f64, found f32
+help: you can cast an `f32` to `f64` in a lossless way
+   |
+LL |     let _ = RGB { r, g, b: b.into() };
+   |                         ^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-1.rs
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-1.rs
@@ -6,7 +6,7 @@ struct Bar<A> {
 
 fn bar() {
     let x: Box<Bar()> = panic!();
-    //~^ ERROR parenthesized parameters may only be used with a trait
+    //~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
     //~| ERROR wrong number of type arguments: expected 1, found 0
 }
 

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-1.rs
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-1.rs
@@ -7,6 +7,7 @@ struct Bar<A> {
 fn bar() {
     let x: Box<Bar()> = panic!();
     //~^ ERROR parenthesized parameters may only be used with a trait
+    //~| ERROR wrong number of type arguments: expected 1, found 0
 }
 
 fn main() { }

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-1.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-1.stderr
@@ -1,11 +1,8 @@
-error[E0214]: parenthesized parameters may only be used with a trait
+error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
   --> $DIR/unboxed-closure-sugar-used-on-struct-1.rs:8:19
    |
 LL |     let x: Box<Bar()> = panic!();
-   |                   ^^
-   |                   |
-   |                   only traits may use parentheses
-   |                   help: use angle brackets instead: `<>`
+   |                   ^^ only `Fn` traits may use parentheses
 
 error[E0107]: wrong number of type arguments: expected 1, found 0
   --> $DIR/unboxed-closure-sugar-used-on-struct-1.rs:8:16

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-1.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-1.stderr
@@ -2,7 +2,10 @@ error[E0214]: parenthesized parameters may only be used with a trait
   --> $DIR/unboxed-closure-sugar-used-on-struct-1.rs:8:19
    |
 LL |     let x: Box<Bar()> = panic!();
-   |                   ^^ only traits may use parentheses
+   |                   ^^
+   |                   |
+   |                   only traits may use parentheses
+   |                   help: use angle brackets instead: `<>`
 
 error[E0107]: wrong number of type arguments: expected 1, found 0
   --> $DIR/unboxed-closure-sugar-used-on-struct-1.rs:8:16

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-1.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-1.stderr
@@ -4,6 +4,13 @@ error[E0214]: parenthesized parameters may only be used with a trait
 LL |     let x: Box<Bar()> = panic!();
    |                   ^^ only traits may use parentheses
 
-error: aborting due to previous error
+error[E0107]: wrong number of type arguments: expected 1, found 0
+  --> $DIR/unboxed-closure-sugar-used-on-struct-1.rs:8:16
+   |
+LL |     let x: Box<Bar()> = panic!();
+   |                ^^^^^ expected 1 type argument
 
-For more information about this error, try `rustc --explain E0214`.
+error: aborting due to 2 previous errors
+
+Some errors occurred: E0107, E0214.
+For more information about an error, try `rustc --explain E0107`.

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-3.rs
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-3.rs
@@ -12,7 +12,7 @@ fn bar() {
     let b = Bar::<isize, usize>::new(); // OK
 
     let b = Bar::(isize, usize)::new(); // OK too (for the parser)
-    //~^ ERROR parenthesized parameters may only be used with a trait
+    //~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
 }
 
 fn main() {}

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-3.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-3.stderr
@@ -4,6 +4,13 @@ error[E0214]: parenthesized parameters may only be used with a trait
 LL |     let b = Bar::(isize, usize)::new(); // OK too (for the parser)
    |                ^^^^^^^^^^^^^^^^ only traits may use parentheses
 
-error: aborting due to previous error
+error[E0107]: wrong number of type arguments: expected 2, found 0
+  --> $DIR/unboxed-closure-sugar-used-on-struct-3.rs:14:13
+   |
+LL |     let b = Bar::(isize, usize)::new(); // OK too (for the parser)
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^ expected 2 type arguments
 
-For more information about this error, try `rustc --explain E0214`.
+error: aborting due to 2 previous errors
+
+Some errors occurred: E0107, E0214.
+For more information about an error, try `rustc --explain E0107`.

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-3.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-3.stderr
@@ -4,13 +4,6 @@ error[E0214]: parenthesized parameters may only be used with a trait
 LL |     let b = Bar::(isize, usize)::new(); // OK too (for the parser)
    |                ^^^^^^^^^^^^^^^^ only traits may use parentheses
 
-error[E0107]: wrong number of type arguments: expected 2, found 0
-  --> $DIR/unboxed-closure-sugar-used-on-struct-3.rs:14:13
-   |
-LL |     let b = Bar::(isize, usize)::new(); // OK too (for the parser)
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^ expected 2 type arguments
+error: aborting due to previous error
 
-error: aborting due to 2 previous errors
-
-Some errors occurred: E0107, E0214.
-For more information about an error, try `rustc --explain E0107`.
+For more information about this error, try `rustc --explain E0214`.

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-3.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-3.stderr
@@ -1,8 +1,11 @@
 error[E0214]: parenthesized parameters may only be used with a trait
-  --> $DIR/unboxed-closure-sugar-used-on-struct-3.rs:14:16
+  --> $DIR/unboxed-closure-sugar-used-on-struct-3.rs:14:18
    |
 LL |     let b = Bar::(isize, usize)::new(); // OK too (for the parser)
-   |                ^^^^^^^^^^^^^^^^ only traits may use parentheses
+   |                  ^^^^^^^^^^^^^^
+   |                  |
+   |                  only traits may use parentheses
+   |                  help: use angle brackets instead: `<isize, usize>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-3.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-3.stderr
@@ -1,10 +1,10 @@
-error[E0214]: parenthesized parameters may only be used with a trait
+error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
   --> $DIR/unboxed-closure-sugar-used-on-struct-3.rs:14:18
    |
 LL |     let b = Bar::(isize, usize)::new(); // OK too (for the parser)
    |                  ^^^^^^^^^^^^^^
    |                  |
-   |                  only traits may use parentheses
+   |                  only `Fn` traits may use parentheses
    |                  help: use angle brackets instead: `<isize, usize>`
 
 error: aborting due to previous error

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct.rs
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct.rs
@@ -5,7 +5,7 @@ struct Bar<A> {
 }
 
 fn foo(b: Box<Bar()>) {
-    //~^ ERROR parenthesized parameters may only be used with a trait
+    //~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
     //~| ERROR wrong number of type arguments: expected 1, found 0
 }
 

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct.rs
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct.rs
@@ -6,7 +6,7 @@ struct Bar<A> {
 
 fn foo(b: Box<Bar()>) {
     //~^ ERROR parenthesized parameters may only be used with a trait
-    //~| ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~| ERROR wrong number of type arguments: expected 1, found 0
 }
 
 fn main() { }

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct.stderr
@@ -2,7 +2,10 @@ error[E0214]: parenthesized parameters may only be used with a trait
   --> $DIR/unboxed-closure-sugar-used-on-struct.rs:7:18
    |
 LL | fn foo(b: Box<Bar()>) {
-   |                  ^^ only traits may use parentheses
+   |                  ^^
+   |                  |
+   |                  only traits may use parentheses
+   |                  help: use angle brackets instead: `<>`
 
 error[E0107]: wrong number of type arguments: expected 1, found 0
   --> $DIR/unboxed-closure-sugar-used-on-struct.rs:7:15

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct.stderr
@@ -4,13 +4,13 @@ error[E0214]: parenthesized parameters may only be used with a trait
 LL | fn foo(b: Box<Bar()>) {
    |                  ^^ only traits may use parentheses
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0107]: wrong number of type arguments: expected 1, found 0
   --> $DIR/unboxed-closure-sugar-used-on-struct.rs:7:15
    |
 LL | fn foo(b: Box<Bar()>) {
-   |               ^^^^^ not allowed in type signatures
+   |               ^^^^^ expected 1 type argument
 
 error: aborting due to 2 previous errors
 
-Some errors occurred: E0121, E0214.
-For more information about an error, try `rustc --explain E0121`.
+Some errors occurred: E0107, E0214.
+For more information about an error, try `rustc --explain E0107`.

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct.stderr
@@ -1,11 +1,8 @@
-error[E0214]: parenthesized parameters may only be used with a trait
+error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
   --> $DIR/unboxed-closure-sugar-used-on-struct.rs:7:18
    |
 LL | fn foo(b: Box<Bar()>) {
-   |                  ^^
-   |                  |
-   |                  only traits may use parentheses
-   |                  help: use angle brackets instead: `<>`
+   |                  ^^ only `Fn` traits may use parentheses
 
 error[E0107]: wrong number of type arguments: expected 1, found 0
   --> $DIR/unboxed-closure-sugar-used-on-struct.rs:7:15


### PR DESCRIPTION
Successful merges:

 - #56796 (Change bounds on `TryFrom` blanket impl to use `Into` instead of `From`)
 - #57768 (Continue parsing after parent type args and suggest using angle brackets)
 - #57769 (Suggest correct cast for struct fields with shorthand syntax)
 - #57783 (Add "dereference boxed value" suggestion.)
 - #57784 (Add span for bad doc comment)

Failed merges:


r? @ghost