### PR TITLE
Print visible name for types as well as modules.

### DIFF
--- a/src/test/ui/issues/auxiliary/issue-56943.rs
+++ b/src/test/ui/issues/auxiliary/issue-56943.rs
@@ -1,0 +1,3 @@
+pub struct S;
+mod m { pub struct S; }
+pub use crate::m::S as S2;

--- a/src/test/ui/issues/issue-56943.rs
+++ b/src/test/ui/issues/issue-56943.rs
@@ -1,0 +1,8 @@
+// aux-build:issue-56943.rs
+
+extern crate issue_56943;
+
+fn main() {
+    let _: issue_56943::S = issue_56943::S2;
+    //~^ ERROR mismatched types [E0308]
+}

--- a/src/test/ui/issues/issue-56943.stderr
+++ b/src/test/ui/issues/issue-56943.stderr
@@ -1,0 +1,12 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-56943.rs:6:29
+   |
+LL |     let _: issue_56943::S = issue_56943::S2;
+   |                             ^^^^^^^^^^^^^^^ expected struct `issue_56943::S`, found struct `issue_56943::S2`
+   |
+   = note: expected type `issue_56943::S`
+              found type `issue_56943::S2`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes #56943 and fixes #57713.

This commit extends previous work in #55007 where the name from the
visible parent was used for modules. Now, we also print the name from
the visible parent for types.

r? @estebank 