### PR TITLE
Add error for trailing angle brackets.

### DIFF
--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -140,6 +140,20 @@ pub enum GenericArgs {
 }
 
 impl GenericArgs {
+    pub fn is_parenthesized(&self) -> bool {
+        match *self {
+            Parenthesized(..) => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_angle_bracketed(&self) -> bool {
+        match *self {
+            AngleBracketed(..) => true,
+            _ => false,
+        }
+    }
+
     pub fn span(&self) -> Span {
         match *self {
             AngleBracketed(ref data) => data.span,

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2869,11 +2869,18 @@ impl<'a> Parser<'a> {
             self.eat_to_tokens(&[&token::OpenDelim(token::Paren)]);
             let span = lo.until(self.span);
 
+            // We needn't check `encountered_gt` to determine if we should pluralize "bracket".
+            // `encountered_gt` can only represent a single `>` character, if `number_of_shr >= 1`
+            // then there is either `>>` or `>>>` - in either case a plural is warranted.
+            let plural = number_of_shr >= 1;
             self.diagnostic()
-                .struct_span_err(span, "unmatched angle bracket")
+                .struct_span_err(
+                    span,
+                    &format!("unmatched angle bracket{}", if plural { "s" } else { "" }),
+                )
                 .span_suggestion_with_applicability(
                     span,
-                    "remove extra angle bracket",
+                    &format!("remove extra angle bracket{}", if plural { "s" } else { "" }),
                     String::new(),
                     Applicability::MachineApplicable,
                 )

--- a/src/test/ui/issues/issue-54521-1.rs
+++ b/src/test/ui/issues/issue-54521-1.rs
@@ -1,0 +1,16 @@
+// compile-pass
+
+// This test checks that the `remove extra angle brackets` error doesn't happen for some
+// potential edge-cases..
+
+struct X {
+    len: u32,
+}
+
+fn main() {
+    let x = X { len: 3 };
+
+    let _ = x.len > (3);
+
+    let _ = x.len >> (3);
+}

--- a/src/test/ui/issues/issue-54521-2.fixed
+++ b/src/test/ui/issues/issue-54521-2.fixed
@@ -1,0 +1,22 @@
+// run-rustfix
+
+// This test checks that the following error is emitted and the suggestion works:
+//
+// ```
+// let _ = Vec::<usize>>>::new();
+//                     ^^ help: remove extra angle brackets
+// ```
+
+fn main() {
+    let _ = Vec::<usize>::new();
+    //~^ ERROR unmatched angle bracket
+
+    let _ = Vec::<usize>::new();
+    //~^ ERROR unmatched angle bracket
+
+    let _ = Vec::<usize>::new();
+    //~^ ERROR unmatched angle bracket
+
+    let _ = Vec::<usize>::new();
+    //~^ ERROR unmatched angle bracket
+}

--- a/src/test/ui/issues/issue-54521-2.rs
+++ b/src/test/ui/issues/issue-54521-2.rs
@@ -1,0 +1,22 @@
+// run-rustfix
+
+// This test checks that the following error is emitted and the suggestion works:
+//
+// ```
+// let _ = Vec::<usize>>>::new();
+//                     ^^ help: remove extra angle brackets
+// ```
+
+fn main() {
+    let _ = Vec::<usize>>>>>::new();
+    //~^ ERROR unmatched angle bracket
+
+    let _ = Vec::<usize>>>>::new();
+    //~^ ERROR unmatched angle bracket
+
+    let _ = Vec::<usize>>>::new();
+    //~^ ERROR unmatched angle bracket
+
+    let _ = Vec::<usize>>::new();
+    //~^ ERROR unmatched angle bracket
+}

--- a/src/test/ui/issues/issue-54521-2.stderr
+++ b/src/test/ui/issues/issue-54521-2.stderr
@@ -1,0 +1,26 @@
+error: unmatched angle brackets
+  --> $DIR/issue-54521-2.rs:11:25
+   |
+LL |     let _ = Vec::<usize>>>>>::new();
+   |                         ^^^^ help: remove extra angle brackets
+
+error: unmatched angle brackets
+  --> $DIR/issue-54521-2.rs:14:25
+   |
+LL |     let _ = Vec::<usize>>>>::new();
+   |                         ^^^ help: remove extra angle brackets
+
+error: unmatched angle brackets
+  --> $DIR/issue-54521-2.rs:17:25
+   |
+LL |     let _ = Vec::<usize>>>::new();
+   |                         ^^ help: remove extra angle brackets
+
+error: unmatched angle bracket
+  --> $DIR/issue-54521-2.rs:20:25
+   |
+LL |     let _ = Vec::<usize>>::new();
+   |                         ^ help: remove extra angle bracket
+
+error: aborting due to 4 previous errors
+

--- a/src/test/ui/issues/issue-54521.fixed
+++ b/src/test/ui/issues/issue-54521.fixed
@@ -1,0 +1,22 @@
+// run-rustfix
+
+// This test checks that the following error is emitted and the suggestion works:
+//
+// ```
+// let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>>>();
+//                                                        ^^ help: remove extra angle brackets
+// ```
+
+fn main() {
+    let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>();
+    //~^ ERROR unmatched angle bracket
+
+    let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>();
+    //~^ ERROR unmatched angle bracket
+
+    let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>();
+    //~^ ERROR unmatched angle bracket
+
+    let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>();
+    //~^ ERROR unmatched angle bracket
+}

--- a/src/test/ui/issues/issue-54521.rs
+++ b/src/test/ui/issues/issue-54521.rs
@@ -1,0 +1,22 @@
+// run-rustfix
+
+// This test checks that the following error is emitted and the suggestion works:
+//
+// ```
+// let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>>>();
+//                                                        ^^ help: remove extra angle brackets
+// ```
+
+fn main() {
+    let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>>>>>();
+    //~^ ERROR unmatched angle bracket
+
+    let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>>>>();
+    //~^ ERROR unmatched angle bracket
+
+    let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>>>();
+    //~^ ERROR unmatched angle bracket
+
+    let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>>();
+    //~^ ERROR unmatched angle bracket
+}

--- a/src/test/ui/issues/issue-54521.stderr
+++ b/src/test/ui/issues/issue-54521.stderr
@@ -1,0 +1,26 @@
+error: unmatched angle bracket
+  --> $DIR/issue-54521.rs:11:60
+   |
+LL |     let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>>>>>();
+   |                                                            ^^^^ help: remove extra angle bracket
+
+error: unmatched angle bracket
+  --> $DIR/issue-54521.rs:14:60
+   |
+LL |     let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>>>>();
+   |                                                            ^^^ help: remove extra angle bracket
+
+error: unmatched angle bracket
+  --> $DIR/issue-54521.rs:17:60
+   |
+LL |     let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>>>();
+   |                                                            ^^ help: remove extra angle bracket
+
+error: unmatched angle bracket
+  --> $DIR/issue-54521.rs:20:60
+   |
+LL |     let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>>();
+   |                                                            ^ help: remove extra angle bracket
+
+error: aborting due to 4 previous errors
+

--- a/src/test/ui/issues/issue-54521.stderr
+++ b/src/test/ui/issues/issue-54521.stderr
@@ -1,20 +1,20 @@
-error: unmatched angle bracket
+error: unmatched angle brackets
   --> $DIR/issue-54521.rs:11:60
    |
 LL |     let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>>>>>();
-   |                                                            ^^^^ help: remove extra angle bracket
+   |                                                            ^^^^ help: remove extra angle brackets
 
-error: unmatched angle bracket
+error: unmatched angle brackets
   --> $DIR/issue-54521.rs:14:60
    |
 LL |     let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>>>>();
-   |                                                            ^^^ help: remove extra angle bracket
+   |                                                            ^^^ help: remove extra angle brackets
 
-error: unmatched angle bracket
+error: unmatched angle brackets
   --> $DIR/issue-54521.rs:17:60
    |
 LL |     let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>>>();
-   |                                                            ^^ help: remove extra angle bracket
+   |                                                            ^^ help: remove extra angle brackets
 
 error: unmatched angle bracket
   --> $DIR/issue-54521.rs:20:60


### PR DESCRIPTION
Fixes #54521.

This PR adds a error (and accompanying machine applicable
suggestion) for trailing angle brackets on function calls with a
turbofish.

r? @estebank 