### PR TITLE
un-deprecate mem::zeroed

### DIFF
--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -489,7 +489,6 @@ pub const fn needs_drop<T>() -> bool {
 /// assert_eq!(0, x);
 /// ```
 #[inline]
-#[rustc_deprecated(since = "2.0.0", reason = "use `mem::MaybeUninit::zeroed` instead")]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub unsafe fn zeroed<T>() -> T {
     #[cfg(not(stage0))]


### PR DESCRIPTION
as per the discussion around <https://github.com/rust-lang/rust/issues/53491#issuecomment-451454793>