### PR TITLE
Ignore aarch64 in simd-intrinsic-generic-reduction

### DIFF
--- a/src/test/run-pass/simd/simd-intrinsic-generic-reduction.rs
+++ b/src/test/run-pass/simd/simd-intrinsic-generic-reduction.rs
@@ -2,6 +2,7 @@
 #![allow(non_camel_case_types)]
 
 // ignore-emscripten
+// ignore-aarch64 FIXME: https://github.com/rust-lang/rust/issues/54510
 
 // Test that the simd_reduce_{op} intrinsics produce the correct results.
 


### PR DESCRIPTION
This fails on AArch64 see https://github.com/rust-lang/rust/issues/54510

Disabling it for now until it's fixed/implemented in LLVM

cc @gnzlbg 