### PR TITLE
Print a slightly clearer message when failing to launch a thread

### DIFF
--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -607,7 +607,7 @@ impl Builder {
 pub fn spawn<F, T>(f: F) -> JoinHandle<T> where
     F: FnOnce() -> T, F: Send + 'static, T: Send + 'static
 {
-    Builder::new().spawn(f).unwrap()
+    Builder::new().spawn(f).expect("failed to spawn thread")
 }
 
 /// Gets a handle to the thread that invokes it.


### PR DESCRIPTION
As discussed in #46345, the `io::Error` you get when a thread fails to launch is of type `io::ErrorKind::WouldBlock`. This is super uninformative when an arbitrary `thread::spawn` fails somewhere in your code:

```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 11,
kind: WouldBlock, message: "operation would block" }', src/libcore/result.rs:997:5
```

This PR improves the situation a little bit by using `expect` instead of `unwrap`. I don't consider this a complete fix for #46345 though.