### PR TITLE
typeck: remove leaky nested probe during trait object method resolution

### DIFF
--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -506,15 +506,13 @@ impl<'a, 'gcx, 'tcx> ProbeContext<'a, 'gcx, 'tcx> {
         match self_ty.value.value.sty {
             ty::Dynamic(ref data, ..) => {
                 if let Some(p) = data.principal() {
-                    self.fcx.probe(|_| {
-                        let InferOk { value: self_ty, obligations: _ } =
-                            self.fcx.probe_instantiate_query_response(
-                                self.span, &self.orig_steps_var_values, self_ty)
-                            .unwrap_or_else(|_| {
-                                span_bug!(self.span, "{:?} was applicable but now isn't?", self_ty)
-                            });
-                        self.assemble_inherent_candidates_from_object(self_ty);
-                    });
+                    let InferOk { value: instantiated_self_ty, obligations: _ } =
+                        self.fcx.probe_instantiate_query_response(
+                            self.span, &self.orig_steps_var_values, self_ty)
+                        .unwrap_or_else(|_| {
+                            span_bug!(self.span, "{:?} was applicable but now isn't?", self_ty)
+                        });
+                    self.assemble_inherent_candidates_from_object(instantiated_self_ty);
                     self.assemble_inherent_impl_candidates_for_type(p.def_id());
                 }
             }

--- a/src/test/ui/typeck/issue-57673-ice-on-deref-of-boxed-trait.rs
+++ b/src/test/ui/typeck/issue-57673-ice-on-deref-of-boxed-trait.rs
@@ -1,0 +1,7 @@
+//extern crate has_assoc_type;
+
+//fn ice(x: Box<dyn has_assoc_type::Foo<Assoc=()>>) {
+fn ice(x: Box<dyn Iterator<Item=()>>) {
+    *x //~ ERROR mismatched types [E0308]
+}
+fn main() {}

--- a/src/test/ui/typeck/issue-57673-ice-on-deref-of-boxed-trait.stderr
+++ b/src/test/ui/typeck/issue-57673-ice-on-deref-of-boxed-trait.stderr
@@ -1,0 +1,14 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-57673-ice-on-deref-of-boxed-trait.rs:5:5
+   |
+LL | fn ice(x: Box<dyn Iterator<Item=()>>) {
+   |                                       - possibly return type missing here?
+LL |     *x //~ ERROR mismatched types [E0308]
+   |     ^^ expected (), found trait std::iter::Iterator
+   |
+   = note: expected type `()`
+              found type `(dyn std::iter::Iterator<Item=()> + 'static)`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
addresses #57673  (but not marking with f-x because thats now afflicting beta channel).

Fix #57216 