### PR TITLE
Fix issue 57762

### DIFF
--- a/src/librustc_codegen_llvm/debuginfo/metadata.rs
+++ b/src/librustc_codegen_llvm/debuginfo/metadata.rs
@@ -1164,11 +1164,10 @@ fn use_enum_fallback(cx: &CodegenCx) -> bool {
     // On MSVC we have to use the fallback mode, because LLVM doesn't
     // lower variant parts to PDB.
     return cx.sess().target.target.options.is_like_msvc
-        || llvm_util::get_major_version() < 7
         // LLVM version 7 did not release with an important bug fix;
-        // but the required patch is in the equivalent Rust LLVM.
-        // See https://github.com/rust-lang/rust/issues/57762.
-        || (llvm_util::get_major_version() == 7 && unsafe { !llvm::LLVMRustIsRustLLVM() });
+        // but the required patch is in the LLVM 8.  Rust LLVM reports
+        // 8 as well.
+        || llvm_util::get_major_version() < 8;
 }
 
 // Describes the members of an enum value: An enum is described as a union of

--- a/src/librustc_codegen_llvm/debuginfo/metadata.rs
+++ b/src/librustc_codegen_llvm/debuginfo/metadata.rs
@@ -1164,7 +1164,11 @@ fn use_enum_fallback(cx: &CodegenCx) -> bool {
     // On MSVC we have to use the fallback mode, because LLVM doesn't
     // lower variant parts to PDB.
     return cx.sess().target.target.options.is_like_msvc
-        || llvm_util::get_major_version() < 7;
+        || llvm_util::get_major_version() < 7
+        // LLVM version 7 did not release with an important bug fix;
+        // but the required patch is in the equivalent Rust LLVM.
+        // See https://github.com/rust-lang/rust/issues/57762.
+        || (llvm_util::get_major_version() == 7 && unsafe { !llvm::LLVMRustIsRustLLVM() });
 }
 
 // Describes the members of an enum value: An enum is described as a union of


### PR DESCRIPTION
against a stock LLVM 7.  LLVM 7 was released without a necessary fix
for a bug in the DWARF discriminant code.

This patch changes rustc to use the fallback mode on (non-Rust) LLVM 7.

Closes #57762