### PR TITLE
use port 80 for retrieving GPG key

### DIFF
--- a/src/ci/docker/dist-various-1/install-x86_64-redox.sh
+++ b/src/ci/docker/dist-various-1/install-x86_64-redox.sh
@@ -6,7 +6,7 @@ set -ex
 apt-get update
 apt-get install -y --no-install-recommends software-properties-common apt-transport-https
 
-apt-key adv --batch --yes --keyserver keyserver.ubuntu.com --recv-keys AA12E97F0881517F
+apt-key adv --batch --yes --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys AA12E97F0881517F
 add-apt-repository -y 'deb https://static.redox-os.org/toolchain/apt /'
 
 apt-get update


### PR DESCRIPTION
This works around firewalls blocking port 11371.

See https://unix.stackexchange.com/questions/75892/keyserver-timed-out-when-trying-to-add-a-gpg-public-key.