### PR TITLE
rustdoc: fix ICE from loading proc-macro stubs

### DIFF
--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -431,8 +431,12 @@ fn macro_resolve(cx: &DocContext, path_str: &str) -> Option<Def> {
     let parent_scope = resolver.dummy_parent_scope();
     if let Ok(def) = resolver.resolve_macro_to_def_inner(&path, MacroKind::Bang,
                                                          &parent_scope, false, false) {
-        if let SyntaxExtension::DeclMacro { .. } = *resolver.get_macro(def) {
-            return Some(def);
+        if let Def::Macro(_, MacroKind::ProcMacroStub) = def {
+            // skip proc-macro stubs, they'll cause `get_macro` to crash
+        } else {
+            if let SyntaxExtension::DeclMacro { .. } = *resolver.get_macro(def) {
+                return Some(def);
+            }
         }
     }
     if let Some(def) = resolver.all_macros.get(&Symbol::intern(path_str)) {

--- a/src/test/rustdoc/proc-macro.rs
+++ b/src/test/rustdoc/proc-macro.rs
@@ -4,6 +4,11 @@
 #![crate_type="proc-macro"]
 #![crate_name="some_macros"]
 
+// @has some_macros/index.html
+// @has - '//a/[@href="attr.some_proc_attr.html"]' 'some_proc_attr'
+
+//! include a link to [some_proc_attr] to make sure it works.
+
 extern crate proc_macro;
 
 use proc_macro::TokenStream;


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/55399, fixes https://github.com/rust-lang/rust/issues/54100

When trying to resolve a macro, rustdoc first tries to load it from the resolver to see whether it's a Macros 2.0 macro, so it can return that Def before looking for any other kind of macro. However, this becomes a problem when you try to load proc-macros: since you can't use a proc-macro inside its own crate, this lookup also fails when attempting to link to it.

However, we have a hint that this lookup will fail: Macros which are actually `ProcMacroStub`s will fail the lookup, so we can use that information to skip loading the macro. Rustdoc will then happily check `resolve.all_macros`, which will return a usable Def that we can link to.