### PR TITLE
Generate a documentation page for core::mem::transmute.

### DIFF
--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -729,6 +729,10 @@ extern "rust-intrinsic" {
     /// cause [undefined behavior][ub] with this function. `transmute` should be
     /// the absolute last resort.
     ///
+    /// `transmute` is re-exported by [core::mem](../mem/index.html) as
+    /// `core::mem::transmute`, which may be used without the `core_intrinsics`
+    /// feature flag.
+    ///
     /// The [nomicon](../../nomicon/transmutes.html) has additional
     /// documentation.
     ///

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -729,10 +729,6 @@ extern "rust-intrinsic" {
     /// cause [undefined behavior][ub] with this function. `transmute` should be
     /// the absolute last resort.
     ///
-    /// `transmute` is re-exported by [core::mem](../mem/index.html) as
-    /// `core::mem::transmute`, which may be used without the `core_intrinsics`
-    /// feature flag.
-    ///
     /// The [nomicon](../../nomicon/transmutes.html) has additional
     /// documentation.
     ///

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -15,6 +15,7 @@ use ptr;
 use ops::{Deref, DerefMut};
 
 #[stable(feature = "rust1", since = "1.0.0")]
+#[doc(inline)]
 pub use intrinsics::transmute;
 
 /// Takes ownership and "forgets" about the value **without running its destructor**.


### PR DESCRIPTION
In `#[no_std]` environments, `std::mem::transmute` is unavailable. Searching for "core transmute" online only pulls up `core::intrinsics::transmute`, which is behind the (unstable) `core_intrinsics` feature flag. Users wishing to use transmute in `#[no_std]` environments typically should use `core::mem::transmute` instead, as it is stable. This documentation makes `core::mem::transmute` discoverable.