### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/src/libcore/any.rs
+++ b/src/libcore/any.rs
@@ -81,12 +81,10 @@ pub trait Any: 'static {
     /// # Examples
     ///
     /// ```
-    /// #![feature(get_type_id)]
-    ///
     /// use std::any::{Any, TypeId};
     ///
     /// fn is_string(s: &dyn Any) -> bool {
-    ///     TypeId::of::<String>() == s.get_type_id()
+    ///     TypeId::of::<String>() == s.type_id()
     /// }
     ///
     /// fn main() {
@@ -94,15 +92,13 @@ pub trait Any: 'static {
     ///     assert_eq!(is_string(&"cookie monster".to_string()), true);
     /// }
     /// ```
-    #[unstable(feature = "get_type_id",
-               reason = "this method will likely be replaced by an associated static",
-               issue = "27745")]
-    fn get_type_id(&self) -> TypeId;
+    #[stable(feature = "get_type_id", since = "1.34.0")]
+    fn type_id(&self) -> TypeId;
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: 'static + ?Sized > Any for T {
-    fn get_type_id(&self) -> TypeId { TypeId::of::<T>() }
+    fn type_id(&self) -> TypeId { TypeId::of::<T>() }
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -161,10 +157,10 @@ impl dyn Any {
         let t = TypeId::of::<T>();
 
         // Get TypeId of the type in the trait object
-        let boxed = self.get_type_id();
+        let concrete = self.type_id();
 
         // Compare both TypeIds on equality
-        t == boxed
+        t == concrete
     }
 
     /// Returns some reference to the boxed value if it is of type `T`, or

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -1590,6 +1590,153 @@ impl<T> [T] {
         sort::quicksort(self, |a, b| f(a).lt(&f(b)));
     }
 
+    /// Reorder the slice such that the element at `index` is at its final sorted position.
+    ///
+    /// This reordering has the additional property that any value at position `i < index` will be
+    /// less than or equal to any value at a position `j > index`. Additionally, this reordering is
+    /// unstable (i.e. any number of equal elements may end up at position `index`), in-place
+    /// (i.e. does not allocate), and `O(n)` worst-case. This function is also/ known as "kth
+    /// element" in other libraries. It returns a triplet of the following values: all elements less
+    /// than the one at the given index, the value at the given index, and all elements greater than
+    /// the one at the given index.
+    ///
+    /// # Current implementation
+    ///
+    /// The current algorithm is based on the quickselect portion of the same quicksort algorithm
+    /// used for [`sort_unstable`].
+    ///
+    /// [`sort_unstable`]: #method.sort_unstable
+    ///
+    /// # Panics
+    ///
+    /// Panics when `index >= len()`, meaning it always panics on empty slices.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(slice_partition_at_index)]
+    ///
+    /// let mut v = [-5i32, 4, 1, -3, 2];
+    ///
+    /// // Find the median
+    /// v.partition_at_index(2);
+    ///
+    /// // We are only guaranteed the slice will be one of the following, based on the way we sort
+    /// // about the specified index.
+    /// assert!(v == [-3, -5, 1, 2, 4] ||
+    ///         v == [-5, -3, 1, 2, 4] ||
+    ///         v == [-3, -5, 1, 4, 2] ||
+    ///         v == [-5, -3, 1, 4, 2]);
+    /// ```
+    #[unstable(feature = "slice_partition_at_index", issue = "55300")]
+    #[inline]
+    pub fn partition_at_index(&mut self, index: usize) -> (&mut [T], &mut T, &mut [T])
+        where T: Ord
+    {
+        let mut f = |a: &T, b: &T| a.lt(b);
+        sort::partition_at_index(self, index, &mut f)
+    }
+
+    /// Reorder the slice with a comparator function such that the element at `index` is at its
+    /// final sorted position.
+    ///
+    /// This reordering has the additional property that any value at position `i < index` will be
+    /// less than or equal to any value at a position `j > index` using the comparator function.
+    /// Additionally, this reordering is unstable (i.e. any number of equal elements may end up at
+    /// position `index`), in-place (i.e. does not allocate), and `O(n)` worst-case. This function
+    /// is also known as "kth element" in other libraries. It returns a triplet of the following
+    /// values: all elements less than the one at the given index, the value at the given index,
+    /// and all elements greater than the one at the given index, using the provided comparator
+    /// function.
+    ///
+    /// # Current implementation
+    ///
+    /// The current algorithm is based on the quickselect portion of the same quicksort algorithm
+    /// used for [`sort_unstable`].
+    ///
+    /// [`sort_unstable`]: #method.sort_unstable
+    ///
+    /// # Panics
+    ///
+    /// Panics when `index >= len()`, meaning it always panics on empty slices.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(slice_partition_at_index)]
+    ///
+    /// let mut v = [-5i32, 4, 1, -3, 2];
+    ///
+    /// // Find the median as if the slice were sorted in descending order.
+    /// v.partition_at_index_by(2, |a, b| b.cmp(a));
+    ///
+    /// // We are only guaranteed the slice will be one of the following, based on the way we sort
+    /// // about the specified index.
+    /// assert!(v == [2, 4, 1, -5, -3] ||
+    ///         v == [2, 4, 1, -3, -5] ||
+    ///         v == [4, 2, 1, -5, -3] ||
+    ///         v == [4, 2, 1, -3, -5]);
+    /// ```
+    #[unstable(feature = "slice_partition_at_index", issue = "55300")]
+    #[inline]
+    pub fn partition_at_index_by<F>(&mut self, index: usize, mut compare: F)
+                                    -> (&mut [T], &mut T, &mut [T])
+        where F: FnMut(&T, &T) -> Ordering
+    {
+        let mut f = |a: &T, b: &T| compare(a, b) == Less;
+        sort::partition_at_index(self, index, &mut f)
+    }
+
+    /// Reorder the slice with a key extraction function such that the element at `index` is at its
+    /// final sorted position.
+    ///
+    /// This reordering has the additional property that any value at position `i < index` will be
+    /// less than or equal to any value at a position `j > index` using the key extraction function.
+    /// Additionally, this reordering is unstable (i.e. any number of equal elements may end up at
+    /// position `index`), in-place (i.e. does not allocate), and `O(n)` worst-case. This function
+    /// is also known as "kth element" in other libraries. It returns a triplet of the following
+    /// values: all elements less than the one at the given index, the value at the given index, and
+    /// all elements greater than the one at the given index, using the provided key extraction
+    /// function.
+    ///
+    /// # Current implementation
+    ///
+    /// The current algorithm is based on the quickselect portion of the same quicksort algorithm
+    /// used for [`sort_unstable`].
+    ///
+    /// [`sort_unstable`]: #method.sort_unstable
+    ///
+    /// # Panics
+    ///
+    /// Panics when `index >= len()`, meaning it always panics on empty slices.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(slice_partition_at_index)]
+    ///
+    /// let mut v = [-5i32, 4, 1, -3, 2];
+    ///
+    /// // Return the median as if the array were sorted according to absolute value.
+    /// v.partition_at_index_by_key(2, |a| a.abs());
+    ///
+    /// // We are only guaranteed the slice will be one of the following, based on the way we sort
+    /// // about the specified index.
+    /// assert!(v == [1, 2, -3, 4, -5] ||
+    ///         v == [1, 2, -3, -5, 4] ||
+    ///         v == [2, 1, -3, 4, -5] ||
+    ///         v == [2, 1, -3, -5, 4]);
+    /// ```
+    #[unstable(feature = "slice_partition_at_index", issue = "55300")]
+    #[inline]
+    pub fn partition_at_index_by_key<K, F>(&mut self, index: usize, mut f: F)
+                                           -> (&mut [T], &mut T, &mut [T])
+        where F: FnMut(&T) -> K, K: Ord
+    {
+        let mut g = |a: &T, b: &T| f(a).lt(&f(b));
+        sort::partition_at_index(self, index, &mut g)
+    }
+
     /// Moves all consecutive repeated elements to the end of the slice according to the
     /// [`PartialEq`] trait implementation.
     ///

--- a/src/libcore/slice/sort.rs
+++ b/src/libcore/slice/sort.rs
@@ -701,3 +701,92 @@ pub fn quicksort<T, F>(v: &mut [T], mut is_less: F)
 
     recurse(v, &mut is_less, None, limit);
 }
+
+fn partition_at_index_loop<'a, T, F>( mut v: &'a mut [T], mut index: usize, is_less: &mut F
+                                    , mut pred: Option<&'a T>) where F: FnMut(&T, &T) -> bool
+{
+    loop {
+        // For slices of up to this length it's probably faster to simply sort them.
+        const MAX_INSERTION: usize = 10;
+        if v.len() <= MAX_INSERTION {
+            insertion_sort(v, is_less);
+            return;
+        }
+
+        // Choose a pivot
+        let (pivot, _) = choose_pivot(v, is_less);
+
+        // If the chosen pivot is equal to the predecessor, then it's the smallest element in the
+        // slice. Partition the slice into elements equal to and elements greater than the pivot.
+        // This case is usually hit when the slice contains many duplicate elements.
+        if let Some(p) = pred {
+            if !is_less(p, &v[pivot]) {
+                let mid = partition_equal(v, pivot, is_less);
+
+                // If we've passed our index, then we're good.
+                if mid > index {
+                    return;
+                }
+
+                // Otherwise, continue sorting elements greater than the pivot.
+                v = &mut v[mid..];
+                index = index - mid;
+                pred = None;
+                continue;
+            }
+        }
+
+        let (mid, _) = partition(v, pivot, is_less);
+
+        // Split the slice into `left`, `pivot`, and `right`.
+        let (left, right) = {v}.split_at_mut(mid);
+        let (pivot, right) = right.split_at_mut(1);
+        let pivot = &pivot[0];
+
+        if mid < index {
+            v = right;
+            index = index - mid - 1;
+            pred = Some(pivot);
+        } else if mid > index {
+            v = left;
+        } else {
+            // If mid == index, then we're done, since partition() guaranteed that all elements
+            // after mid are greater than or equal to mid.
+            return;
+        }
+    }
+}
+
+pub fn partition_at_index<T, F>(v: &mut [T], index: usize, mut is_less: F)
+                                -> (&mut [T], &mut T, &mut [T]) where F: FnMut(&T, &T) -> bool
+{
+    use cmp::Ordering::Less;
+    use cmp::Ordering::Greater;
+
+    if index >= v.len() {
+        panic!("partition_at_index index {} greater than length of slice {}", index, v.len());
+    }
+
+    if mem::size_of::<T>() == 0 {
+        // Sorting has no meaningful behavior on zero-sized types. Do nothing.
+    } else if index == v.len() - 1 {
+        // Find max element and place it in the last position of the array. We're free to use
+        // `unwrap()` here because we know v must not be empty.
+        let (max_index, _) = v.iter().enumerate().max_by(
+            |&(_, x), &(_, y)| if is_less(x, y) { Less } else { Greater }).unwrap();
+        v.swap(max_index, index);
+    } else if index == 0 {
+        // Find min element and place it in the first position of the array. We're free to use
+        // `unwrap()` here because we know v must not be empty.
+        let (min_index, _) = v.iter().enumerate().min_by(
+            |&(_, x), &(_, y)| if is_less(x, y) { Less } else { Greater }).unwrap();
+        v.swap(min_index, index);
+    } else {
+        partition_at_index_loop(v, index, &mut is_less, None);
+    }
+
+    let (left, right) = v.split_at_mut(index);
+    let (pivot, right) = right.split_at_mut(1);
+    let pivot = &mut pivot[0];
+    (left, pivot, right)
+}

--- a/src/libcore/tests/lib.rs
+++ b/src/libcore/tests/lib.rs
@@ -27,6 +27,7 @@
 #![feature(refcell_replace_swap)]
 #![feature(slice_patterns)]
 #![feature(sort_internals)]
+#![feature(slice_partition_at_index)]
 #![feature(specialization)]
 #![feature(step_trait)]
 #![feature(str_internals)]

--- a/src/libcore/tests/slice.rs
+++ b/src/libcore/tests/slice.rs
@@ -1089,6 +1089,122 @@ fn sort_unstable() {
     assert!(v == [0xDEADBEEF]);
 }
 
+#[test]
+fn partition_at_index() {
+    use core::cmp::Ordering::{Equal, Greater, Less};
+    use rand::rngs::SmallRng;
+    use rand::seq::SliceRandom;
+    use rand::{FromEntropy, Rng};
+
+    let mut rng = SmallRng::from_entropy();
+
+    for len in (2..21).chain(500..501) {
+        let mut orig = vec![0; len];
+
+        for &modulus in &[5, 10, 1000] {
+            for _ in 0..10 {
+                for i in 0..len {
+                    orig[i] = rng.gen::<i32>() % modulus;
+                }
+
+                let v_sorted = {
+                    let mut v = orig.clone();
+                    v.sort();
+                    v
+                };
+
+                // Sort in default order.
+                for pivot in 0..len {
+                    let mut v = orig.clone();
+                    v.partition_at_index(pivot);
+
+                    assert_eq!(v_sorted[pivot], v[pivot]);
+                    for i in 0..pivot {
+                        for j in pivot..len {
+                            assert!(v[i] <= v[j]);
+                        }
+                    }
+                }
+
+                // Sort in ascending order.
+                for pivot in 0..len {
+                    let mut v = orig.clone();
+                    let (left, pivot, right) = v.partition_at_index_by(pivot, |a, b| a.cmp(b));
+
+                    assert_eq!(left.len() + right.len(), len - 1);
+
+                    for l in left {
+                        assert!(l <= pivot);
+                        for r in right.iter_mut() {
+                            assert!(l <= r);
+                            assert!(pivot <= r);
+                        }
+                    }
+                }
+
+                // Sort in descending order.
+                let sort_descending_comparator = |a: &i32, b: &i32| b.cmp(a);
+                let v_sorted_descending = {
+                    let mut v = orig.clone();
+                    v.sort_by(sort_descending_comparator);
+                    v
+                };
+
+                for pivot in 0..len {
+                    let mut v = orig.clone();
+                    v.partition_at_index_by(pivot, sort_descending_comparator);
+
+                    assert_eq!(v_sorted_descending[pivot], v[pivot]);
+                    for i in 0..pivot {
+                        for j in pivot..len {
+                            assert!(v[j] <= v[i]);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Sort at index using a completely random comparison function.
+    // This will reorder the elements *somehow*, but won't panic.
+    let mut v = [0; 500];
+    for i in 0..v.len() {
+        v[i] = i as i32;
+    }
+
+    for pivot in 0..v.len() {
+        v.partition_at_index_by(pivot, |_, _| *[Less, Equal, Greater].choose(&mut rng).unwrap());
+        v.sort();
+        for i in 0..v.len() {
+            assert_eq!(v[i], i as i32);
+        }
+    }
+
+    // Should not panic.
+    [(); 10].partition_at_index(0);
+    [(); 10].partition_at_index(5);
+    [(); 10].partition_at_index(9);
+    [(); 100].partition_at_index(0);
+    [(); 100].partition_at_index(50);
+    [(); 100].partition_at_index(99);
+
+    let mut v = [0xDEADBEEFu64];
+    v.partition_at_index(0);
+    assert!(v == [0xDEADBEEF]);
+}
+
+#[test]
+#[should_panic(expected = "index 0 greater than length of slice")]
+fn partition_at_index_zero_length() {
+    [0i32; 0].partition_at_index(0);
+}
+
+#[test]
+#[should_panic(expected = "index 20 greater than length of slice")]
+fn partition_at_index_past_length() {
+    [0i32; 10].partition_at_index(20);
+}
+
 pub mod memchr {
     use core::slice::memchr::{memchr, memrchr};
 

--- a/src/librustc_passes/ast_validation.rs
+++ b/src/librustc_passes/ast_validation.rs
@@ -20,9 +20,79 @@ use errors::Applicability;
 
 struct AstValidator<'a> {
     session: &'a Session,
+
+    // Used to ban nested `impl Trait`, e.g., `impl Into<impl Debug>`.
+    // Nested `impl Trait` _is_ allowed in associated type position,
+    // e.g `impl Iterator<Item=impl Debug>`
+    outer_impl_trait: Option<Span>,
+
+    // Used to ban `impl Trait` in path projections like `<impl Iterator>::Item`
+    // or `Foo::Bar<impl Trait>`
+    is_impl_trait_banned: bool,
 }
 
 impl<'a> AstValidator<'a> {
+    fn with_banned_impl_trait<F>(&mut self, f: F)
+        where F: FnOnce(&mut Self)
+    {
+        let old_is_impl_trait_banned = self.is_impl_trait_banned;
+        self.is_impl_trait_banned = true;
+        f(self);
+        self.is_impl_trait_banned = old_is_impl_trait_banned;
+    }
+
+    fn with_impl_trait<F>(&mut self, outer_impl_trait: Option<Span>, f: F)
+        where F: FnOnce(&mut Self)
+    {
+        let old_outer_impl_trait = self.outer_impl_trait;
+        self.outer_impl_trait = outer_impl_trait;
+        f(self);
+        self.outer_impl_trait = old_outer_impl_trait;
+    }
+
+    // Mirrors visit::walk_ty, but tracks relevant state
+    fn walk_ty(&mut self, t: &'a Ty) {
+        match t.node {
+            TyKind::ImplTrait(..) => {
+                self.with_impl_trait(Some(t.span), |this| visit::walk_ty(this, t))
+            }
+            TyKind::Path(ref qself, ref path) => {
+                // We allow these:
+                //  - `Option<impl Trait>`
+                //  - `option::Option<impl Trait>`
+                //  - `option::Option<T>::Foo<impl Trait>
+                //
+                // But not these:
+                //  - `<impl Trait>::Foo`
+                //  - `option::Option<impl Trait>::Foo`.
+                //
+                // To implement this, we disallow `impl Trait` from `qself`
+                // (for cases like `<impl Trait>::Foo>`)
+                // but we allow `impl Trait` in `GenericArgs`
+                // iff there are no more PathSegments.
+                if let Some(ref qself) = *qself {
+                    // `impl Trait` in `qself` is always illegal
+                    self.with_banned_impl_trait(|this| this.visit_ty(&qself.ty));
+                }
+
+                // Note that there should be a call to visit_path here,
+                // so if any logic is added to process `Path`s a call to it should be
+                // added both in visit_path and here. This code mirrors visit::walk_path.
+                for (i, segment) in path.segments.iter().enumerate() {
+                    // Allow `impl Trait` iff we're on the final path segment
+                    if i == path.segments.len() - 1 {
+                        self.visit_path_segment(path.span, segment);
+                    } else {
+                        self.with_banned_impl_trait(|this| {
+                            this.visit_path_segment(path.span, segment)
+                        });
+                    }
+                }
+            }
+            _ => visit::walk_ty(self, t),
+        }
+    }
+
     fn err_handler(&self) -> &errors::Handler {
         &self.session.diagnostic()
     }
@@ -267,6 +337,19 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                 self.no_questions_in_bounds(bounds, "trait object types", false);
             }
             TyKind::ImplTrait(_, ref bounds) => {
+                if self.is_impl_trait_banned {
+                    struct_span_err!(self.session, ty.span, E0667,
+                        "`impl Trait` is not allowed in path parameters").emit();
+                }
+
+                if let Some(outer_impl_trait) = self.outer_impl_trait {
+                    struct_span_err!(self.session, ty.span, E0666,
+                                    "nested `impl Trait` is not allowed")
+                        .span_label(outer_impl_trait, "outer `impl Trait`")
+                        .span_label(ty.span, "nested `impl Trait` here")
+                        .emit();
+
+                }
                 if !bounds.iter()
                           .any(|b| if let GenericBound::Trait(..) = *b { true } else { false }) {
                     self.err_handler().span_err(ty.span, "at least one trait must be specified");
@@ -275,7 +358,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
             _ => {}
         }
 
-        visit::walk_ty(self, ty)
+        self.walk_ty(ty)
     }
 
     fn visit_label(&mut self, label: &'a Label) {
@@ -414,6 +497,28 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
         visit::walk_foreign_item(self, fi)
     }
 
+    // Mirrors visit::walk_generic_args, but tracks relevant state
+    fn visit_generic_args(&mut self, _: Span, generic_args: &'a GenericArgs) {
+        match *generic_args {
+            GenericArgs::AngleBracketed(ref data) => {
+                walk_list!(self, visit_generic_arg, &data.args);
+                // Type bindings such as `Item=impl Debug` in `Iterator<Item=Debug>`
+                // are allowed to contain nested `impl Trait`.
+                self.with_impl_trait(None, |this| {
+                    walk_list!(this, visit_assoc_type_binding, &data.bindings);
+                });
+            }
+            GenericArgs::Parenthesized(ref data) => {
+                walk_list!(self, visit_ty, &data.inputs);
+                if let Some(ref type_) = data.output {
+                    // `-> Foo` syntax is essentially an associated type binding,
+                    // so it is also allowed to contain nested `impl Trait`.
+                    self.with_impl_trait(None, |this| visit::walk_ty(this, type_));
+                }
+            }
+        }
+    }
+
     fn visit_generics(&mut self, generics: &'a Generics) {
         let mut seen_non_lifetime_param = false;
         let mut seen_default = None;
@@ -490,148 +595,10 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
     }
 }
 
-// Bans nested `impl Trait`, e.g., `impl Into<impl Debug>`.
-// Nested `impl Trait` _is_ allowed in associated type position,
-// e.g `impl Iterator<Item=impl Debug>`
-struct NestedImplTraitVisitor<'a> {
-    session: &'a Session,
-    outer_impl_trait: Option<Span>,
-}
-
-impl<'a> NestedImplTraitVisitor<'a> {
-    fn with_impl_trait<F>(&mut self, outer_impl_trait: Option<Span>, f: F)
-        where F: FnOnce(&mut NestedImplTraitVisitor<'a>)
-    {
-        let old_outer_impl_trait = self.outer_impl_trait;
-        self.outer_impl_trait = outer_impl_trait;
-        f(self);
-        self.outer_impl_trait = old_outer_impl_trait;
-    }
-}
-
-
-impl<'a> Visitor<'a> for NestedImplTraitVisitor<'a> {
-    fn visit_ty(&mut self, t: &'a Ty) {
-        if let TyKind::ImplTrait(..) = t.node {
-            if let Some(outer_impl_trait) = self.outer_impl_trait {
-                struct_span_err!(self.session, t.span, E0666,
-                                 "nested `impl Trait` is not allowed")
-                    .span_label(outer_impl_trait, "outer `impl Trait`")
-                    .span_label(t.span, "nested `impl Trait` here")
-                    .emit();
-
-            }
-            self.with_impl_trait(Some(t.span), |this| visit::walk_ty(this, t));
-        } else {
-            visit::walk_ty(self, t);
-        }
-    }
-    fn visit_generic_args(&mut self, _: Span, generic_args: &'a GenericArgs) {
-        match *generic_args {
-            GenericArgs::AngleBracketed(ref data) => {
-                for arg in &data.args {
-                    self.visit_generic_arg(arg)
-                }
-                for type_binding in &data.bindings {
-                    // Type bindings such as `Item=impl Debug` in `Iterator<Item=Debug>`
-                    // are allowed to contain nested `impl Trait`.
-                    self.with_impl_trait(None, |this| visit::walk_ty(this, &type_binding.ty));
-                }
-            }
-            GenericArgs::Parenthesized(ref data) => {
-                for type_ in &data.inputs {
-                    self.visit_ty(type_);
-                }
-                if let Some(ref type_) = data.output {
-                    // `-> Foo` syntax is essentially an associated type binding,
-                    // so it is also allowed to contain nested `impl Trait`.
-                    self.with_impl_trait(None, |this| visit::walk_ty(this, type_));
-                }
-            }
-        }
-    }
-
-    fn visit_mac(&mut self, _mac: &Spanned<Mac_>) {
-        // covered in AstValidator
-    }
-}
-
-// Bans `impl Trait` in path projections like `<impl Iterator>::Item` or `Foo::Bar<impl Trait>`.
-struct ImplTraitProjectionVisitor<'a> {
-    session: &'a Session,
-    is_banned: bool,
-}
-
-impl<'a> ImplTraitProjectionVisitor<'a> {
-    fn with_ban<F>(&mut self, f: F)
-        where F: FnOnce(&mut ImplTraitProjectionVisitor<'a>)
-    {
-        let old_is_banned = self.is_banned;
-        self.is_banned = true;
-        f(self);
-        self.is_banned = old_is_banned;
-    }
-}
-
-impl<'a> Visitor<'a> for ImplTraitProjectionVisitor<'a> {
-    fn visit_ty(&mut self, t: &'a Ty) {
-        match t.node {
-            TyKind::ImplTrait(..) => {
-                if self.is_banned {
-                    struct_span_err!(self.session, t.span, E0667,
-                        "`impl Trait` is not allowed in path parameters").emit();
-                }
-            }
-            TyKind::Path(ref qself, ref path) => {
-                // We allow these:
-                //  - `Option<impl Trait>`
-                //  - `option::Option<impl Trait>`
-                //  - `option::Option<T>::Foo<impl Trait>
-                //
-                // But not these:
-                //  - `<impl Trait>::Foo`
-                //  - `option::Option<impl Trait>::Foo`.
-                //
-                // To implement this, we disallow `impl Trait` from `qself`
-                // (for cases like `<impl Trait>::Foo>`)
-                // but we allow `impl Trait` in `GenericArgs`
-                // iff there are no more PathSegments.
-                if let Some(ref qself) = *qself {
-                    // `impl Trait` in `qself` is always illegal
-                    self.with_ban(|this| this.visit_ty(&qself.ty));
-                }
-
-                for (i, segment) in path.segments.iter().enumerate() {
-                    // Allow `impl Trait` iff we're on the final path segment
-                    if i == path.segments.len() - 1 {
-                        visit::walk_path_segment(self, path.span, segment);
-                    } else {
-                        self.with_ban(|this|
-                            visit::walk_path_segment(this, path.span, segment));
-                    }
-                }
-            }
-            _ => visit::walk_ty(self, t),
-        }
-    }
-
-    fn visit_mac(&mut self, _mac: &Spanned<Mac_>) {
-        // covered in AstValidator
-    }
-}
-
 pub fn check_crate(session: &Session, krate: &Crate) {
-    visit::walk_crate(
-        &mut NestedImplTraitVisitor {
-            session,
-            outer_impl_trait: None,
-        }, krate);
-
-    visit::walk_crate(
-        &mut ImplTraitProjectionVisitor {
-            session,
-            is_banned: false,
-        }, krate);
-
-    visit::walk_crate(&mut AstValidator { session }, krate)
+    visit::walk_crate(&mut AstValidator {
+        session,
+        outer_impl_trait: None,
+        is_impl_trait_banned: false,
+    }, krate)
 }

--- a/src/librustc_typeck/check/coercion.rs
+++ b/src/librustc_typeck/check/coercion.rs
@@ -1208,83 +1208,20 @@ impl<'gcx, 'tcx, 'exprs, E> CoerceMany<'gcx, 'tcx, 'exprs, E>
                         db.span_label(cause.span, "return type is not `()`");
                     }
                     ObligationCauseCode::BlockTailExpression(blk_id) => {
-                        db = fcx.report_mismatched_types(cause, expected, found, err);
-
-                        let expr = expression.unwrap_or_else(|| {
-                            span_bug!(cause.span,
-                                      "supposed to be part of a block tail expression, but the \
-                                       expression is empty");
-                        });
-                        let pointing_at_return_type = fcx.suggest_mismatched_types_on_tail(
-                            &mut db,
-                            expr,
+                        let parent_id = fcx.tcx.hir().get_parent_node(blk_id);
+                        db = self.report_return_mismatched_types(
+                            cause,
                             expected,
                             found,
-                            cause.span,
-                            blk_id,
+                            err,
+                            fcx,
+                            parent_id,
+                            expression.map(|expr| (expr, blk_id)),
                         );
-                        // FIXME: replace with navigating up the chain until hitting an fn or
-                        // bailing if no "pass-through" Node is found, in order to provide a
-                        // suggestion when encountering something like:
-                        // ```
-                        // fn foo(a: bool) -> impl Debug {
-                        //     if a {
-                        //         bar()?;
-                        //     }
-                        //     {
-                        //         let x = unsafe { bar() };
-                        //         x
-                        //     }
-                        // }
-                        // ```
-                        //
-                        // Verify that this is a tail expression of a function, otherwise the
-                        // label pointing out the cause for the type coercion will be wrong
-                        // as prior return coercions would not be relevant (#57664).
-                        let parent_id = fcx.tcx.hir().get_parent_node(blk_id);
-                        let parent = fcx.tcx.hir().get(fcx.tcx.hir().get_parent_node(parent_id));
-                        if let (Some((fn_decl, _, _)), false) = (
-                            fcx.get_node_fn_decl(parent),
-                            pointing_at_return_type,
-                        ) {
-                            if let Some(sp) = fcx.ret_coercion_span.borrow().as_ref() {
-                                db.span_label(
-                                    fn_decl.output.span(),
-                                    "expected because this return type...",
-                                );
-                                db.span_label(*sp, format!(
-                                    "...is found to be `{}` here",
-                                    fcx.resolve_type_vars_with_obligations(expected),
-                                ));
-                            }
-                        }
                     }
-                    ObligationCauseCode::ReturnType(_id) => {
-                        db = fcx.report_mismatched_types(cause, expected, found, err);
-                        let _id = fcx.tcx.hir().get_parent_node(_id);
-                        let mut pointing_at_return_type = false;
-                        let mut return_sp = None;
-                        if let Some((fn_decl, can_suggest)) = fcx.get_fn_decl(_id) {
-                            pointing_at_return_type = fcx.suggest_missing_return_type(
-                                &mut db, &fn_decl, expected, found, can_suggest);
-                            if !pointing_at_return_type {
-                                return_sp = Some(fn_decl.output.span()); // `impl Trait` return type
-                            }
-                        }
-                        if let (Some(sp), false) = (
-                            fcx.ret_coercion_span.borrow().as_ref(),
-                            pointing_at_return_type,
-                        ) {
-                            if let Some(return_sp) = return_sp {
-                                db.span_label(return_sp, "expected because this return type...");
-                                db.span_label( *sp, format!(
-                                    "...is found to be `{}` here",
-                                    fcx.resolve_type_vars_with_obligations(expected),
-                                ));
-                            } else if !sp.overlaps(cause.span) {
-                                db.span_label(*sp, "expected because of this statement");
-                            }
-                        }
+                    ObligationCauseCode::ReturnType(id) => {
+                        db = self.report_return_mismatched_types(
+                            cause, expected, found, err, fcx, id, None);
                     }
                     _ => {
                         db = fcx.report_mismatched_types(cause, expected, found, err);
@@ -1300,6 +1237,59 @@ impl<'gcx, 'tcx, 'exprs, E> CoerceMany<'gcx, 'tcx, 'exprs, E>
                 self.final_ty = Some(fcx.tcx.types.err);
             }
         }
+    }
+
+    fn report_return_mismatched_types<'a>(
+        &self,
+        cause: &ObligationCause<'tcx>,
+        expected: Ty<'tcx>,
+        found: Ty<'tcx>,
+        err: TypeError<'tcx>,
+        fcx: &FnCtxt<'a, 'gcx, 'tcx>,
+        id: syntax::ast::NodeId,
+        expression: Option<(&'gcx hir::Expr, syntax::ast::NodeId)>,
+    ) -> DiagnosticBuilder<'a> {
+        let mut db = fcx.report_mismatched_types(cause, expected, found, err);
+
+        let mut pointing_at_return_type = false;
+        let mut return_sp = None;
+
+        // Verify that this is a tail expression of a function, otherwise the
+        // label pointing out the cause for the type coercion will be wrong
+        // as prior return coercions would not be relevant (#57664).
+        let parent_id = fcx.tcx.hir().get_parent_node(id);
+        let fn_decl = if let Some((expr, blk_id)) = expression {
+            pointing_at_return_type = fcx.suggest_mismatched_types_on_tail(
+                &mut db,
+                expr,
+                expected,
+                found,
+                cause.span,
+                blk_id,
+            );
+            let parent = fcx.tcx.hir().get(parent_id);
+            fcx.get_node_fn_decl(parent).map(|(fn_decl, _, is_main)| (fn_decl, is_main))
+        } else {
+            fcx.get_fn_decl(parent_id)
+        };
+
+        if let (Some((fn_decl, can_suggest)), _) = (fn_decl, pointing_at_return_type) {
+            if expression.is_none() {
+                pointing_at_return_type |= fcx.suggest_missing_return_type(
+                    &mut db, &fn_decl, expected, found, can_suggest);
+            }
+            if !pointing_at_return_type {
+                return_sp = Some(fn_decl.output.span()); // `impl Trait` return type
+            }
+        }
+        if let (Some(sp), Some(return_sp)) = (fcx.ret_coercion_span.borrow().as_ref(), return_sp) {
+            db.span_label(return_sp, "expected because this return type...");
+            db.span_label( *sp, format!(
+                "...is found to be `{}` here",
+                fcx.resolve_type_vars_with_obligations(expected),
+            ));
+        }
+        db
     }
 
     pub fn complete<'a>(self, fcx: &FnCtxt<'a, 'gcx, 'tcx>) -> Ty<'tcx> {

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -304,7 +304,12 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                         );
                         if let Some(suggestion) = suggestion {
                             // enum variant
-                            err.help(&format!("did you mean `{}`?", suggestion));
+                            err.span_suggestion_with_applicability(
+                                item_name.span,
+                                "did you mean",
+                                suggestion.to_string(),
+                                Applicability::MaybeIncorrect,
+                            );
                         }
                         err
                     }
@@ -440,7 +445,12 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 }
 
                 if let Some(lev_candidate) = lev_candidate {
-                    err.help(&format!("did you mean `{}`?", lev_candidate.ident));
+                    err.span_suggestion_with_applicability(
+                        span,
+                        "did you mean",
+                        lev_candidate.ident.to_string(),
+                        Applicability::MaybeIncorrect,
+                    );
                 }
                 err.emit();
             }

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -7,11 +7,9 @@
 //! primitives](#primitives), [standard macros](#macros), [I/O] and
 //! [multithreading], among [many other things][other].
 //!
-//! `std` is available to all Rust crates by default, just as if each one
-//! contained an `extern crate std;` import at the [crate root]. Therefore the
+//! `std` is available to all Rust crates by default. Therefore the
 //! standard library can be accessed in [`use`] statements through the path
-//! `std`, as in [`use std::env`], or in expressions through the absolute path
-//! `::std`, as in [`::std::env::args`].
+//! `std`, as in [`use std::env`].
 //!
 //! # How to read this documentation
 //!

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -155,7 +155,6 @@
 //! [TCP]: net/struct.TcpStream.html
 //! [The Rust Prelude]: prelude/index.html
 //! [UDP]: net/struct.UdpSocket.html
-//! [`::std::env::args`]: env/fn.args.html
 //! [`Arc`]: sync/struct.Arc.html
 //! [owned slice]: boxed/index.html
 //! [`Cell`]: cell/struct.Cell.html
@@ -189,7 +188,6 @@
 //! [`thread`]: thread/index.html
 //! [`use std::env`]: env/index.html
 //! [`use`]: ../book/ch07-02-modules-and-use-to-control-scope-and-privacy.html#the-use-keyword-to-bring-paths-into-a-scope
-//! [crate root]: ../book/ch07-01-packages-and-crates-for-making-libraries-and-executables.html
 //! [crates.io]: https://crates.io
 //! [deref-coercions]: ../book/ch15-02-deref.html#implicit-deref-coercions-with-functions-and-methods
 //! [files]: fs/struct.File.html

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -140,6 +140,20 @@ pub enum GenericArgs {
 }
 
 impl GenericArgs {
+    pub fn is_parenthesized(&self) -> bool {
+        match *self {
+            Parenthesized(..) => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_angle_bracketed(&self) -> bool {
+        match *self {
+            AngleBracketed(..) => true,
+            _ => false,
+        }
+    }
+
     pub fn span(&self) -> Span {
         match *self {
             AngleBracketed(ref data) => data.span,

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -7271,9 +7271,16 @@ impl<'a> Parser<'a> {
             // CONST ITEM
             if self.eat_keyword(keywords::Mut) {
                 let prev_span = self.prev_span;
-                self.diagnostic().struct_span_err(prev_span, "const globals cannot be mutable")
-                                 .help("did you mean to declare a static?")
-                                 .emit();
+                let mut err = self.diagnostic()
+                    .struct_span_err(prev_span, "const globals cannot be mutable");
+                err.span_label(prev_span, "cannot be mutable");
+                err.span_suggestion_with_applicability(
+                    const_span,
+                    "you might want to declare a static instead",
+                    "static".to_owned(),
+                    Applicability::MaybeIncorrect,
+                );
+                err.emit();
             }
             let (ident, item_, extra_attrs) = self.parse_item_const(None)?;
             let prev_span = self.prev_span;

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2002,10 +2002,10 @@ impl<'a> Parser<'a> {
                     self.bump();
                     let sp = lo.to(self.prev_span);
                     let mut err = self.diagnostic()
-                        .struct_span_err(sp, "numeric float literals must have a significant");
+                        .struct_span_err(sp, "float literals must have an integer part");
                     err.span_suggestion_with_applicability(
                         sp,
-                        "numeric float literals must have a significant",
+                        "must have an integer part",
                         format!("0.{}", val),
                         Applicability::MachineApplicable,
                     );

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2869,11 +2869,18 @@ impl<'a> Parser<'a> {
             self.eat_to_tokens(&[&token::OpenDelim(token::Paren)]);
             let span = lo.until(self.span);
 
+            // We needn't check `encountered_gt` to determine if we should pluralize "bracket".
+            // `encountered_gt` can only represent a single `>` character, if `number_of_shr >= 1`
+            // then there is either `>>` or `>>>` - in either case a plural is warranted.
+            let plural = number_of_shr >= 1;
             self.diagnostic()
-                .struct_span_err(span, "unmatched angle bracket")
+                .struct_span_err(
+                    span,
+                    &format!("unmatched angle bracket{}", if plural { "s" } else { "" }),
+                )
                 .span_suggestion_with_applicability(
                     span,
-                    "remove extra angle bracket",
+                    &format!("remove extra angle bracket{}", if plural { "s" } else { "" }),
                     String::new(),
                     Applicability::MachineApplicable,
                 )

--- a/src/test/ui/auto-ref-slice-plus-ref.stderr
+++ b/src/test/ui/auto-ref-slice-plus-ref.stderr
@@ -2,12 +2,11 @@ error[E0599]: no method named `test_mut` found for type `std::vec::Vec<{integer}
   --> $DIR/auto-ref-slice-plus-ref.rs:7:7
    |
 LL |     a.test_mut(); //~ ERROR no method named `test_mut` found
-   |       ^^^^^^^^
+   |       ^^^^^^^^ help: did you mean: `get_mut`
    |
    = help: items from traits can only be used if the trait is implemented and in scope
    = note: the following trait defines an item `test_mut`, perhaps you need to implement it:
            candidate #1: `MyIter`
-   = help: did you mean `get_mut`?
 
 error[E0599]: no method named `test` found for type `std::vec::Vec<{integer}>` in the current scope
   --> $DIR/auto-ref-slice-plus-ref.rs:8:7

--- a/src/test/ui/block-result/issue-3563.stderr
+++ b/src/test/ui/block-result/issue-3563.stderr
@@ -2,9 +2,7 @@ error[E0599]: no method named `b` found for type `&Self` in the current scope
   --> $DIR/issue-3563.rs:3:17
    |
 LL |         || self.b()
-   |                 ^
-   |
-   = help: did you mean `a`?
+   |                 ^ help: did you mean: `a`
 
 error: aborting due to previous error
 

--- a/src/test/ui/empty/empty-struct-braces-expr.stderr
+++ b/src/test/ui/empty/empty-struct-braces-expr.stderr
@@ -51,20 +51,18 @@ error[E0599]: no variant named `Empty3` found for type `empty_struct::XE` in the
    |
 LL |     let xe3 = XE::Empty3; //~ ERROR no variant named `Empty3` found for type
    |               ----^^^^^^
-   |               |
+   |               |   |
+   |               |   help: did you mean: `XEmpty3`
    |               variant not found in `empty_struct::XE`
-   |
-   = help: did you mean `XEmpty3`?
 
 error[E0599]: no variant named `Empty3` found for type `empty_struct::XE` in the current scope
   --> $DIR/empty-struct-braces-expr.rs:23:19
    |
 LL |     let xe3 = XE::Empty3(); //~ ERROR no variant named `Empty3` found for type
    |               ----^^^^^^
-   |               |
+   |               |   |
+   |               |   help: did you mean: `XEmpty3`
    |               variant not found in `empty_struct::XE`
-   |
-   = help: did you mean `XEmpty3`?
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/impl-trait/equality.stderr
+++ b/src/test/ui/impl-trait/equality.stderr
@@ -1,8 +1,11 @@
 error[E0308]: mismatched types
   --> $DIR/equality.rs:15:5
    |
+LL | fn two(x: bool) -> impl Foo {
+   |                    -------- expected because this return type...
+LL |     if x {
 LL |         return 1_i32;
-   |                ----- expected because of this statement
+   |                ----- ...is found to be `i32` here
 LL |     }
 LL |     0_u32
    |     ^^^^^ expected i32, found u32

--- a/src/test/ui/issues/issue-23217.stderr
+++ b/src/test/ui/issues/issue-23217.stderr
@@ -5,10 +5,9 @@ LL | pub enum SomeEnum {
    | ----------------- variant `A` not found here
 LL |     B = SomeEnum::A,
    |         ----------^
-   |         |
+   |         |         |
+   |         |         help: did you mean: `B`
    |         variant not found in `SomeEnum`
-   |
-   = help: did you mean `B`?
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-28344.stderr
+++ b/src/test/ui/issues/issue-28344.stderr
@@ -11,8 +11,7 @@ LL |     let x: u8 = BitXor::bitor(0 as u8, 0 as u8);
    |                 --------^^^^^
    |                 |
    |                 function or associated item not found in `dyn std::ops::BitXor<_>`
-   |
-   = help: did you mean `bitxor`?
+   |                 help: did you mean: `bitxor`
 
 error[E0191]: the value of the associated type `Output` (from the trait `std::ops::BitXor`) must be specified
   --> $DIR/issue-28344.rs:8:13
@@ -27,8 +26,7 @@ LL |     let g = BitXor::bitor;
    |             --------^^^^^
    |             |
    |             function or associated item not found in `dyn std::ops::BitXor<_>`
-   |
-   = help: did you mean `bitxor`?
+   |             help: did you mean: `bitxor`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/issues/issue-28971.stderr
+++ b/src/test/ui/issues/issue-28971.stderr
@@ -5,9 +5,10 @@ LL | enum Foo {
    | -------- variant `Baz` not found here
 ...
 LL |             Foo::Baz(..) => (),
-   |             -----^^^---- variant not found in `Foo`
-   |
-   = help: did you mean `Bar`?
+   |             -----^^^----
+   |             |    |
+   |             |    help: did you mean: `Bar`
+   |             variant not found in `Foo`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-50264-inner-deref-trait/result-deref-err.stderr
+++ b/src/test/ui/issues/issue-50264-inner-deref-trait/result-deref-err.stderr
@@ -2,11 +2,10 @@ error[E0599]: no method named `deref_err` found for type `std::result::Result<_,
   --> $DIR/result-deref-err.rs:4:28
    |
 LL |     let _result = &Err(41).deref_err();
-   |                            ^^^^^^^^^
+   |                            ^^^^^^^^^ help: did you mean: `deref_ok`
    |
    = note: the method `deref_err` exists but the following trait bounds were not satisfied:
            `{integer} : std::ops::Deref`
-   = help: did you mean `deref_ok`?
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-52496.rs
+++ b/src/test/ui/issues/issue-52496.rs
@@ -4,7 +4,6 @@ fn main() {
     let _ = Foo { bar: .5, baz: 42 };
     //~^ ERROR float literals must have an integer part
     //~| ERROR missing field `bat` in initializer of `Foo`
-    //~| ERROR mismatched types
     let bar = 1.5f32;
     let _ = Foo { bar.into(), bat: -1, . };
     //~^ ERROR expected one of

--- a/src/test/ui/issues/issue-52496.rs
+++ b/src/test/ui/issues/issue-52496.rs
@@ -1,0 +1,13 @@
+struct Foo { bar: f64, baz: i64, bat: i64 }
+
+fn main() {
+    let _ = Foo { bar: .5, baz: 42 };
+    //~^ ERROR expected expression
+    //~| ERROR missing field `bat` in initializer of `Foo`
+    let bar = 1.5f32;
+    let _ = Foo { bar.into(), bat: -1, . };
+    //~^ ERROR expected one of
+    //~| ERROR mismatched types
+    //~| ERROR missing field `baz` in initializer of `Foo`
+    //~| ERROR expected identifier, found `.`
+}

--- a/src/test/ui/issues/issue-52496.rs
+++ b/src/test/ui/issues/issue-52496.rs
@@ -2,8 +2,9 @@ struct Foo { bar: f64, baz: i64, bat: i64 }
 
 fn main() {
     let _ = Foo { bar: .5, baz: 42 };
-    //~^ ERROR expected expression
+    //~^ ERROR numeric float literals must have a significant
     //~| ERROR missing field `bat` in initializer of `Foo`
+    //~| ERROR mismatched types
     let bar = 1.5f32;
     let _ = Foo { bar.into(), bat: -1, . };
     //~^ ERROR expected one of

--- a/src/test/ui/issues/issue-52496.rs
+++ b/src/test/ui/issues/issue-52496.rs
@@ -7,7 +7,6 @@ fn main() {
     let bar = 1.5f32;
     let _ = Foo { bar.into(), bat: -1, . };
     //~^ ERROR expected one of
-    //~| ERROR mismatched types
-    //~| ERROR missing field `baz` in initializer of `Foo`
+    //~| ERROR missing fields `bar`, `baz` in initializer of `Foo`
     //~| ERROR expected identifier, found `.`
 }

--- a/src/test/ui/issues/issue-52496.rs
+++ b/src/test/ui/issues/issue-52496.rs
@@ -2,7 +2,7 @@ struct Foo { bar: f64, baz: i64, bat: i64 }
 
 fn main() {
     let _ = Foo { bar: .5, baz: 42 };
-    //~^ ERROR numeric float literals must have a significant
+    //~^ ERROR float literals must have an integer part
     //~| ERROR missing field `bat` in initializer of `Foo`
     //~| ERROR mismatched types
     let bar = 1.5f32;

--- a/src/test/ui/issues/issue-52496.stderr
+++ b/src/test/ui/issues/issue-52496.stderr
@@ -1,8 +1,8 @@
-error: numeric float literals must have a significant
+error: float literals must have an integer part
   --> $DIR/issue-52496.rs:4:24
    |
 LL |     let _ = Foo { bar: .5, baz: 42 };
-   |                        ^^ help: numeric float literals must have a significant: `0.5`
+   |                        ^^ help: must have an integer part: `0.5`
 
 error: expected one of `,` or `}`, found `.`
   --> $DIR/issue-52496.rs:9:22

--- a/src/test/ui/issues/issue-52496.stderr
+++ b/src/test/ui/issues/issue-52496.stderr
@@ -1,0 +1,50 @@
+error: expected expression, found `.`
+  --> $DIR/issue-52496.rs:4:24
+   |
+LL |     let _ = Foo { bar: .5, baz: 42 };
+   |             ---        ^ expected expression
+   |             |
+   |             while parsing this struct
+
+error: expected one of `,` or `}`, found `.`
+  --> $DIR/issue-52496.rs:8:22
+   |
+LL |     let _ = Foo { bar.into(), bat: -1, . };
+   |             ---      ^ expected one of `,` or `}` here
+   |             |
+   |             while parsing this struct
+
+error: expected identifier, found `.`
+  --> $DIR/issue-52496.rs:8:40
+   |
+LL |     let _ = Foo { bar.into(), bat: -1, . };
+   |             ---                        ^ expected identifier
+   |             |
+   |             while parsing this struct
+
+error[E0063]: missing field `bat` in initializer of `Foo`
+  --> $DIR/issue-52496.rs:4:13
+   |
+LL |     let _ = Foo { bar: .5, baz: 42 };
+   |             ^^^ missing `bat`
+
+error[E0308]: mismatched types
+  --> $DIR/issue-52496.rs:8:19
+   |
+LL |     let _ = Foo { bar.into(), bat: -1, . };
+   |                   ^^^ expected f64, found f32
+help: you can cast an `f32` to `f64` in a lossless way
+   |
+LL |     let _ = Foo { bar: bar.into().into(), bat: -1, . };
+   |                   ^^^^^^^^^^^^^^^
+
+error[E0063]: missing field `baz` in initializer of `Foo`
+  --> $DIR/issue-52496.rs:8:13
+   |
+LL |     let _ = Foo { bar.into(), bat: -1, . };
+   |             ^^^ missing `baz`
+
+error: aborting due to 6 previous errors
+
+Some errors occurred: E0063, E0308.
+For more information about an error, try `rustc --explain E0063`.

--- a/src/test/ui/issues/issue-52496.stderr
+++ b/src/test/ui/issues/issue-52496.stderr
@@ -26,23 +26,12 @@ error[E0063]: missing field `bat` in initializer of `Foo`
 LL |     let _ = Foo { bar: .5, baz: 42 };
    |             ^^^ missing `bat`
 
-error[E0308]: mismatched types
-  --> $DIR/issue-52496.rs:8:19
-   |
-LL |     let _ = Foo { bar.into(), bat: -1, . };
-   |                   ^^^ expected f64, found f32
-help: you can cast an `f32` to `f64` in a lossless way
-   |
-LL |     let _ = Foo { bar.into().into(), bat: -1, . };
-   |                   ^^^^^^^^^^
-
-error[E0063]: missing field `baz` in initializer of `Foo`
+error[E0063]: missing fields `bar`, `baz` in initializer of `Foo`
   --> $DIR/issue-52496.rs:8:13
    |
 LL |     let _ = Foo { bar.into(), bat: -1, . };
-   |             ^^^ missing `baz`
+   |             ^^^ missing `bar`, `baz`
 
-error: aborting due to 6 previous errors
+error: aborting due to 5 previous errors
 
-Some errors occurred: E0063, E0308.
-For more information about an error, try `rustc --explain E0063`.
+For more information about this error, try `rustc --explain E0063`.

--- a/src/test/ui/issues/issue-52496.stderr
+++ b/src/test/ui/issues/issue-52496.stderr
@@ -1,13 +1,11 @@
-error: expected expression, found `.`
+error: numeric float literals must have a significant
   --> $DIR/issue-52496.rs:4:24
    |
 LL |     let _ = Foo { bar: .5, baz: 42 };
-   |             ---        ^ expected expression
-   |             |
-   |             while parsing this struct
+   |                        ^^ help: numeric float literals must have a significant: `0.5`
 
 error: expected one of `,` or `}`, found `.`
-  --> $DIR/issue-52496.rs:8:22
+  --> $DIR/issue-52496.rs:9:22
    |
 LL |     let _ = Foo { bar.into(), bat: -1, . };
    |             ---      ^ expected one of `,` or `}` here
@@ -15,12 +13,22 @@ LL |     let _ = Foo { bar.into(), bat: -1, . };
    |             while parsing this struct
 
 error: expected identifier, found `.`
-  --> $DIR/issue-52496.rs:8:40
+  --> $DIR/issue-52496.rs:9:40
    |
 LL |     let _ = Foo { bar.into(), bat: -1, . };
    |             ---                        ^ expected identifier
    |             |
    |             while parsing this struct
+
+error[E0308]: mismatched types
+  --> $DIR/issue-52496.rs:4:24
+   |
+LL |     let _ = Foo { bar: .5, baz: 42 };
+   |                        ^^ expected f64, found f32
+help: change the type of the numeric literal from `f32` to `f64`
+   |
+LL |     let _ = Foo { bar: .5f64, baz: 42 };
+   |                        ^^^^^
 
 error[E0063]: missing field `bat` in initializer of `Foo`
   --> $DIR/issue-52496.rs:4:13
@@ -29,22 +37,22 @@ LL |     let _ = Foo { bar: .5, baz: 42 };
    |             ^^^ missing `bat`
 
 error[E0308]: mismatched types
-  --> $DIR/issue-52496.rs:8:19
+  --> $DIR/issue-52496.rs:9:19
    |
 LL |     let _ = Foo { bar.into(), bat: -1, . };
    |                   ^^^ expected f64, found f32
 help: you can cast an `f32` to `f64` in a lossless way
    |
-LL |     let _ = Foo { bar: bar.into().into(), bat: -1, . };
-   |                   ^^^^^^^^^^^^^^^
+LL |     let _ = Foo { bar.into().into(), bat: -1, . };
+   |                   ^^^^^^^^^^
 
 error[E0063]: missing field `baz` in initializer of `Foo`
-  --> $DIR/issue-52496.rs:8:13
+  --> $DIR/issue-52496.rs:9:13
    |
 LL |     let _ = Foo { bar.into(), bat: -1, . };
    |             ^^^ missing `baz`
 
-error: aborting due to 6 previous errors
+error: aborting due to 7 previous errors
 
 Some errors occurred: E0063, E0308.
 For more information about an error, try `rustc --explain E0063`.

--- a/src/test/ui/issues/issue-52496.stderr
+++ b/src/test/ui/issues/issue-52496.stderr
@@ -5,7 +5,7 @@ LL |     let _ = Foo { bar: .5, baz: 42 };
    |                        ^^ help: must have an integer part: `0.5`
 
 error: expected one of `,` or `}`, found `.`
-  --> $DIR/issue-52496.rs:9:22
+  --> $DIR/issue-52496.rs:8:22
    |
 LL |     let _ = Foo { bar.into(), bat: -1, . };
    |             ---      ^ expected one of `,` or `}` here
@@ -13,22 +13,12 @@ LL |     let _ = Foo { bar.into(), bat: -1, . };
    |             while parsing this struct
 
 error: expected identifier, found `.`
-  --> $DIR/issue-52496.rs:9:40
+  --> $DIR/issue-52496.rs:8:40
    |
 LL |     let _ = Foo { bar.into(), bat: -1, . };
    |             ---                        ^ expected identifier
    |             |
    |             while parsing this struct
-
-error[E0308]: mismatched types
-  --> $DIR/issue-52496.rs:4:24
-   |
-LL |     let _ = Foo { bar: .5, baz: 42 };
-   |                        ^^ expected f64, found f32
-help: change the type of the numeric literal from `f32` to `f64`
-   |
-LL |     let _ = Foo { bar: .5f64, baz: 42 };
-   |                        ^^^^^
 
 error[E0063]: missing field `bat` in initializer of `Foo`
   --> $DIR/issue-52496.rs:4:13
@@ -37,7 +27,7 @@ LL |     let _ = Foo { bar: .5, baz: 42 };
    |             ^^^ missing `bat`
 
 error[E0308]: mismatched types
-  --> $DIR/issue-52496.rs:9:19
+  --> $DIR/issue-52496.rs:8:19
    |
 LL |     let _ = Foo { bar.into(), bat: -1, . };
    |                   ^^^ expected f64, found f32
@@ -47,12 +37,12 @@ LL |     let _ = Foo { bar.into().into(), bat: -1, . };
    |                   ^^^^^^^^^^
 
 error[E0063]: missing field `baz` in initializer of `Foo`
-  --> $DIR/issue-52496.rs:9:13
+  --> $DIR/issue-52496.rs:8:13
    |
 LL |     let _ = Foo { bar.into(), bat: -1, . };
    |             ^^^ missing `baz`
 
-error: aborting due to 7 previous errors
+error: aborting due to 6 previous errors
 
 Some errors occurred: E0063, E0308.
 For more information about an error, try `rustc --explain E0063`.

--- a/src/test/ui/issues/issue-54521-1.rs
+++ b/src/test/ui/issues/issue-54521-1.rs
@@ -1,0 +1,16 @@
+// compile-pass
+
+// This test checks that the `remove extra angle brackets` error doesn't happen for some
+// potential edge-cases..
+
+struct X {
+    len: u32,
+}
+
+fn main() {
+    let x = X { len: 3 };
+
+    let _ = x.len > (3);
+
+    let _ = x.len >> (3);
+}

--- a/src/test/ui/issues/issue-54521-2.fixed
+++ b/src/test/ui/issues/issue-54521-2.fixed
@@ -1,0 +1,22 @@
+// run-rustfix
+
+// This test checks that the following error is emitted and the suggestion works:
+//
+// ```
+// let _ = Vec::<usize>>>::new();
+//                     ^^ help: remove extra angle brackets
+// ```
+
+fn main() {
+    let _ = Vec::<usize>::new();
+    //~^ ERROR unmatched angle bracket
+
+    let _ = Vec::<usize>::new();
+    //~^ ERROR unmatched angle bracket
+
+    let _ = Vec::<usize>::new();
+    //~^ ERROR unmatched angle bracket
+
+    let _ = Vec::<usize>::new();
+    //~^ ERROR unmatched angle bracket
+}

--- a/src/test/ui/issues/issue-54521-2.rs
+++ b/src/test/ui/issues/issue-54521-2.rs
@@ -1,0 +1,22 @@
+// run-rustfix
+
+// This test checks that the following error is emitted and the suggestion works:
+//
+// ```
+// let _ = Vec::<usize>>>::new();
+//                     ^^ help: remove extra angle brackets
+// ```
+
+fn main() {
+    let _ = Vec::<usize>>>>>::new();
+    //~^ ERROR unmatched angle bracket
+
+    let _ = Vec::<usize>>>>::new();
+    //~^ ERROR unmatched angle bracket
+
+    let _ = Vec::<usize>>>::new();
+    //~^ ERROR unmatched angle bracket
+
+    let _ = Vec::<usize>>::new();
+    //~^ ERROR unmatched angle bracket
+}

--- a/src/test/ui/issues/issue-54521-2.stderr
+++ b/src/test/ui/issues/issue-54521-2.stderr
@@ -1,0 +1,26 @@
+error: unmatched angle brackets
+  --> $DIR/issue-54521-2.rs:11:25
+   |
+LL |     let _ = Vec::<usize>>>>>::new();
+   |                         ^^^^ help: remove extra angle brackets
+
+error: unmatched angle brackets
+  --> $DIR/issue-54521-2.rs:14:25
+   |
+LL |     let _ = Vec::<usize>>>>::new();
+   |                         ^^^ help: remove extra angle brackets
+
+error: unmatched angle brackets
+  --> $DIR/issue-54521-2.rs:17:25
+   |
+LL |     let _ = Vec::<usize>>>::new();
+   |                         ^^ help: remove extra angle brackets
+
+error: unmatched angle bracket
+  --> $DIR/issue-54521-2.rs:20:25
+   |
+LL |     let _ = Vec::<usize>>::new();
+   |                         ^ help: remove extra angle bracket
+
+error: aborting due to 4 previous errors
+

--- a/src/test/ui/issues/issue-54521.fixed
+++ b/src/test/ui/issues/issue-54521.fixed
@@ -1,0 +1,22 @@
+// run-rustfix
+
+// This test checks that the following error is emitted and the suggestion works:
+//
+// ```
+// let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>>>();
+//                                                        ^^ help: remove extra angle brackets
+// ```
+
+fn main() {
+    let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>();
+    //~^ ERROR unmatched angle bracket
+
+    let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>();
+    //~^ ERROR unmatched angle bracket
+
+    let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>();
+    //~^ ERROR unmatched angle bracket
+
+    let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>();
+    //~^ ERROR unmatched angle bracket
+}

--- a/src/test/ui/issues/issue-54521.rs
+++ b/src/test/ui/issues/issue-54521.rs
@@ -1,0 +1,22 @@
+// run-rustfix
+
+// This test checks that the following error is emitted and the suggestion works:
+//
+// ```
+// let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>>>();
+//                                                        ^^ help: remove extra angle brackets
+// ```
+
+fn main() {
+    let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>>>>>();
+    //~^ ERROR unmatched angle bracket
+
+    let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>>>>();
+    //~^ ERROR unmatched angle bracket
+
+    let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>>>();
+    //~^ ERROR unmatched angle bracket
+
+    let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>>();
+    //~^ ERROR unmatched angle bracket
+}

--- a/src/test/ui/issues/issue-54521.stderr
+++ b/src/test/ui/issues/issue-54521.stderr
@@ -1,0 +1,26 @@
+error: unmatched angle bracket
+  --> $DIR/issue-54521.rs:11:60
+   |
+LL |     let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>>>>>();
+   |                                                            ^^^^ help: remove extra angle bracket
+
+error: unmatched angle bracket
+  --> $DIR/issue-54521.rs:14:60
+   |
+LL |     let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>>>>();
+   |                                                            ^^^ help: remove extra angle bracket
+
+error: unmatched angle bracket
+  --> $DIR/issue-54521.rs:17:60
+   |
+LL |     let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>>>();
+   |                                                            ^^ help: remove extra angle bracket
+
+error: unmatched angle bracket
+  --> $DIR/issue-54521.rs:20:60
+   |
+LL |     let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>>();
+   |                                                            ^ help: remove extra angle bracket
+
+error: aborting due to 4 previous errors
+

--- a/src/test/ui/issues/issue-54521.stderr
+++ b/src/test/ui/issues/issue-54521.stderr
@@ -1,20 +1,20 @@
-error: unmatched angle bracket
+error: unmatched angle brackets
   --> $DIR/issue-54521.rs:11:60
    |
 LL |     let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>>>>>();
-   |                                                            ^^^^ help: remove extra angle bracket
+   |                                                            ^^^^ help: remove extra angle brackets
 
-error: unmatched angle bracket
+error: unmatched angle brackets
   --> $DIR/issue-54521.rs:14:60
    |
 LL |     let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>>>>();
-   |                                                            ^^^ help: remove extra angle bracket
+   |                                                            ^^^ help: remove extra angle brackets
 
-error: unmatched angle bracket
+error: unmatched angle brackets
   --> $DIR/issue-54521.rs:17:60
    |
 LL |     let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>>>();
-   |                                                            ^^ help: remove extra angle bracket
+   |                                                            ^^ help: remove extra angle brackets
 
 error: unmatched angle bracket
   --> $DIR/issue-54521.rs:20:60

--- a/src/test/ui/parser/issue-17718-const-mut.rs
+++ b/src/test/ui/parser/issue-17718-const-mut.rs
@@ -1,6 +1,6 @@
 const
 mut //~ ERROR: const globals cannot be mutable
-//~^ HELP did you mean to declare a static?
+//~^^ HELP you might want to declare a static instead
 FOO: usize = 3;
 
 fn main() {

--- a/src/test/ui/parser/issue-17718-const-mut.stderr
+++ b/src/test/ui/parser/issue-17718-const-mut.stderr
@@ -1,10 +1,10 @@
 error: const globals cannot be mutable
   --> $DIR/issue-17718-const-mut.rs:2:1
    |
+LL | const
+   | ----- help: you might want to declare a static instead: `static`
 LL | mut //~ ERROR: const globals cannot be mutable
-   | ^^^
-   |
-   = help: did you mean to declare a static?
+   | ^^^ cannot be mutable
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/removed-syntax-with-1.rs
+++ b/src/test/ui/parser/removed-syntax-with-1.rs
@@ -7,5 +7,5 @@ fn main() {
     let a = S { foo: (), bar: () };
     let b = S { foo: () with a };
     //~^ ERROR expected one of `,`, `.`, `?`, `}`, or an operator, found `with`
-    //~| ERROR missing field `bar` in initializer of `main::S`
+    //~| ERROR missing fields `bar`, `foo` in initializer of `main::S`
 }

--- a/src/test/ui/parser/removed-syntax-with-1.rs
+++ b/src/test/ui/parser/removed-syntax-with-1.rs
@@ -5,7 +5,6 @@ fn main() {
     }
 
     let a = S { foo: (), bar: () };
-    let b = S { foo: () with a };
+    let b = S { foo: () with a, bar: () };
     //~^ ERROR expected one of `,`, `.`, `?`, `}`, or an operator, found `with`
-    //~| ERROR missing fields `bar`, `foo` in initializer of `main::S`
 }

--- a/src/test/ui/parser/removed-syntax-with-1.stderr
+++ b/src/test/ui/parser/removed-syntax-with-1.stderr
@@ -2,7 +2,9 @@ error: expected one of `,`, `.`, `?`, `}`, or an operator, found `with`
   --> $DIR/removed-syntax-with-1.rs:8:25
    |
 LL |     let b = S { foo: () with a };
-   |                         ^^^^ expected one of `,`, `.`, `?`, `}`, or an operator here
+   |             -           ^^^^ expected one of `,`, `.`, `?`, `}`, or an operator here
+   |             |
+   |             while parsing this struct
 
 error[E0063]: missing field `bar` in initializer of `main::S`
   --> $DIR/removed-syntax-with-1.rs:8:13

--- a/src/test/ui/parser/removed-syntax-with-1.stderr
+++ b/src/test/ui/parser/removed-syntax-with-1.stderr
@@ -6,11 +6,11 @@ LL |     let b = S { foo: () with a };
    |             |
    |             while parsing this struct
 
-error[E0063]: missing field `bar` in initializer of `main::S`
+error[E0063]: missing fields `bar`, `foo` in initializer of `main::S`
   --> $DIR/removed-syntax-with-1.rs:8:13
    |
 LL |     let b = S { foo: () with a };
-   |             ^ missing `bar`
+   |             ^ missing `bar`, `foo`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/parser/removed-syntax-with-1.stderr
+++ b/src/test/ui/parser/removed-syntax-with-1.stderr
@@ -1,17 +1,10 @@
 error: expected one of `,`, `.`, `?`, `}`, or an operator, found `with`
   --> $DIR/removed-syntax-with-1.rs:8:25
    |
-LL |     let b = S { foo: () with a };
+LL |     let b = S { foo: () with a, bar: () };
    |             -           ^^^^ expected one of `,`, `.`, `?`, `}`, or an operator here
    |             |
    |             while parsing this struct
 
-error[E0063]: missing fields `bar`, `foo` in initializer of `main::S`
-  --> $DIR/removed-syntax-with-1.rs:8:13
-   |
-LL |     let b = S { foo: () with a };
-   |             ^ missing `bar`, `foo`
+error: aborting due to previous error
 
-error: aborting due to 2 previous errors
-
-For more information about this error, try `rustc --explain E0063`.

--- a/src/test/ui/parser/removed-syntax-with-2.rs
+++ b/src/test/ui/parser/removed-syntax-with-2.rs
@@ -7,6 +7,5 @@ fn main() {
     let a = S { foo: (), bar: () };
     let b = S { foo: (), with a };
     //~^ ERROR expected one of `,` or `}`, found `a`
-    //~| ERROR cannot find value `with` in this scope
-    //~| ERROR struct `main::S` has no field named `with`
+    //~| ERROR missing field `bar` in initializer of `main::S`
 }

--- a/src/test/ui/parser/removed-syntax-with-2.stderr
+++ b/src/test/ui/parser/removed-syntax-with-2.stderr
@@ -2,7 +2,9 @@ error: expected one of `,` or `}`, found `a`
   --> $DIR/removed-syntax-with-2.rs:8:31
    |
 LL |     let b = S { foo: (), with a };
-   |                               ^ expected one of `,` or `}` here
+   |             -                 ^ expected one of `,` or `}` here
+   |             |
+   |             while parsing this struct
 
 error[E0425]: cannot find value `with` in this scope
   --> $DIR/removed-syntax-with-2.rs:8:26

--- a/src/test/ui/parser/removed-syntax-with-2.stderr
+++ b/src/test/ui/parser/removed-syntax-with-2.stderr
@@ -6,21 +6,12 @@ LL |     let b = S { foo: (), with a };
    |             |
    |             while parsing this struct
 
-error[E0425]: cannot find value `with` in this scope
-  --> $DIR/removed-syntax-with-2.rs:8:26
+error[E0063]: missing field `bar` in initializer of `main::S`
+  --> $DIR/removed-syntax-with-2.rs:8:13
    |
 LL |     let b = S { foo: (), with a };
-   |                          ^^^^ not found in this scope
+   |             ^ missing `bar`
 
-error[E0560]: struct `main::S` has no field named `with`
-  --> $DIR/removed-syntax-with-2.rs:8:26
-   |
-LL |     let b = S { foo: (), with a };
-   |                          ^^^^ `main::S` does not have this field
-   |
-   = note: available fields are: `foo`, `bar`
+error: aborting due to 2 previous errors
 
-error: aborting due to 3 previous errors
-
-Some errors occurred: E0425, E0560.
-For more information about an error, try `rustc --explain E0425`.
+For more information about this error, try `rustc --explain E0063`.

--- a/src/test/ui/parser/struct-field-numeric-shorthand.rs
+++ b/src/test/ui/parser/struct-field-numeric-shorthand.rs
@@ -1,6 +1,9 @@
 struct Rgb(u8, u8, u8);
 
 fn main() {
-    let _ = Rgb { 0, 1, 2 }; //~ ERROR expected identifier, found `0`
-                             //~| ERROR missing fields `0`, `1`, `2` in initializer of `Rgb`
+    let _ = Rgb { 0, 1, 2 };
+    //~^ ERROR expected identifier, found `0`
+    //~| ERROR expected identifier, found `1`
+    //~| ERROR expected identifier, found `2`
+    //~| ERROR missing fields `0`, `1`, `2` in initializer of `Rgb`
 }

--- a/src/test/ui/parser/struct-field-numeric-shorthand.stderr
+++ b/src/test/ui/parser/struct-field-numeric-shorthand.stderr
@@ -1,17 +1,33 @@
 error: expected identifier, found `0`
   --> $DIR/struct-field-numeric-shorthand.rs:4:19
    |
-LL |     let _ = Rgb { 0, 1, 2 }; //~ ERROR expected identifier, found `0`
+LL |     let _ = Rgb { 0, 1, 2 };
    |             ---   ^ expected identifier
+   |             |
+   |             while parsing this struct
+
+error: expected identifier, found `1`
+  --> $DIR/struct-field-numeric-shorthand.rs:4:22
+   |
+LL |     let _ = Rgb { 0, 1, 2 };
+   |             ---      ^ expected identifier
+   |             |
+   |             while parsing this struct
+
+error: expected identifier, found `2`
+  --> $DIR/struct-field-numeric-shorthand.rs:4:25
+   |
+LL |     let _ = Rgb { 0, 1, 2 };
+   |             ---         ^ expected identifier
    |             |
    |             while parsing this struct
 
 error[E0063]: missing fields `0`, `1`, `2` in initializer of `Rgb`
   --> $DIR/struct-field-numeric-shorthand.rs:4:13
    |
-LL |     let _ = Rgb { 0, 1, 2 }; //~ ERROR expected identifier, found `0`
+LL |     let _ = Rgb { 0, 1, 2 };
    |             ^^^ missing `0`, `1`, `2`
 
-error: aborting due to 2 previous errors
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0063`.

--- a/src/test/ui/point-to-type-err-cause-on-impl-trait-return.stderr
+++ b/src/test/ui/point-to-type-err-cause-on-impl-trait-return.stderr
@@ -1,8 +1,11 @@
 error[E0308]: mismatched types
   --> $DIR/point-to-type-err-cause-on-impl-trait-return.rs:5:5
    |
+LL | fn foo() -> impl std::fmt::Display {
+   |             ---------------------- expected because this return type...
+LL |     if false {
 LL |         return 0i32;
-   |                ---- expected because of this statement
+   |                ---- ...is found to be `i32` here
 LL |     }
 LL |     1u32
    |     ^^^^ expected i32, found u32
@@ -13,8 +16,11 @@ LL |     1u32
 error[E0308]: mismatched types
   --> $DIR/point-to-type-err-cause-on-impl-trait-return.rs:13:16
    |
+LL | fn bar() -> impl std::fmt::Display {
+   |             ---------------------- expected because this return type...
+LL |     if false {
 LL |         return 0i32;
-   |                ---- expected because of this statement
+   |                ---- ...is found to be `i32` here
 LL |     } else {
 LL |         return 1u32;
    |                ^^^^ expected i32, found u32
@@ -25,10 +31,12 @@ LL |         return 1u32;
 error[E0308]: mismatched types
   --> $DIR/point-to-type-err-cause-on-impl-trait-return.rs:19:5
    |
+LL |   fn baz() -> impl std::fmt::Display {
+   |               ---------------------- expected because this return type...
 LL | /     if false {
 LL | |     //~^ ERROR mismatched types
 LL | |         return 0i32;
-   | |                ---- expected because of this statement
+   | |                ---- ...is found to be `i32` here
 LL | |     } else {
 LL | |         1u32
 LL | |     }

--- a/src/test/ui/suggestions/recover-invalid-float.rs
+++ b/src/test/ui/suggestions/recover-invalid-float.rs
@@ -1,0 +1,11 @@
+fn main() {
+    let _: usize = .3;
+    //~^ ERROR float literals must have an integer part
+    //~| ERROR mismatched types
+    let _: usize = .42f32;
+    //~^ ERROR float literals must have an integer part
+    //~| ERROR mismatched types
+    let _: usize = .5f64;
+    //~^ ERROR float literals must have an integer part
+    //~| ERROR mismatched types
+}

--- a/src/test/ui/suggestions/recover-invalid-float.stderr
+++ b/src/test/ui/suggestions/recover-invalid-float.stderr
@@ -1,0 +1,42 @@
+error: float literals must have an integer part
+  --> $DIR/recover-invalid-float.rs:2:20
+   |
+LL |     let _: usize = .3;
+   |                    ^^ help: must have an integer part: `0.3`
+
+error: float literals must have an integer part
+  --> $DIR/recover-invalid-float.rs:5:20
+   |
+LL |     let _: usize = .42f32;
+   |                    ^^^^^^ help: must have an integer part: `0.42f32`
+
+error: float literals must have an integer part
+  --> $DIR/recover-invalid-float.rs:8:20
+   |
+LL |     let _: usize = .5f64;
+   |                    ^^^^^ help: must have an integer part: `0.5f64`
+
+error[E0308]: mismatched types
+  --> $DIR/recover-invalid-float.rs:2:20
+   |
+LL |     let _: usize = .3;
+   |                    ^^ expected usize, found floating-point number
+   |
+   = note: expected type `usize`
+              found type `{float}`
+
+error[E0308]: mismatched types
+  --> $DIR/recover-invalid-float.rs:5:20
+   |
+LL |     let _: usize = .42f32;
+   |                    ^^^^^^ expected usize, found f32
+
+error[E0308]: mismatched types
+  --> $DIR/recover-invalid-float.rs:8:20
+   |
+LL |     let _: usize = .5f64;
+   |                    ^^^^^ expected usize, found f64
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/suggestions/suggest-methods.stderr
+++ b/src/test/ui/suggestions/suggest-methods.stderr
@@ -5,25 +5,19 @@ LL | struct Foo;
    | ----------- method `bat` not found for this
 ...
 LL |     f.bat(1.0); //~ ERROR no method named
-   |       ^^^
-   |
-   = help: did you mean `bar`?
+   |       ^^^ help: did you mean: `bar`
 
 error[E0599]: no method named `is_emtpy` found for type `std::string::String` in the current scope
   --> $DIR/suggest-methods.rs:21:15
    |
 LL |     let _ = s.is_emtpy(); //~ ERROR no method named
-   |               ^^^^^^^^
-   |
-   = help: did you mean `is_empty`?
+   |               ^^^^^^^^ help: did you mean: `is_empty`
 
 error[E0599]: no method named `count_eos` found for type `u32` in the current scope
   --> $DIR/suggest-methods.rs:25:19
    |
 LL |     let _ = 63u32.count_eos(); //~ ERROR no method named
-   |                   ^^^^^^^^^
-   |
-   = help: did you mean `count_zeros`?
+   |                   ^^^^^^^^^ help: did you mean: `count_zeros`
 
 error[E0599]: no method named `count_o` found for type `u32` in the current scope
   --> $DIR/suggest-methods.rs:28:19

--- a/src/test/ui/traits/trait-privacy.rs
+++ b/src/test/ui/traits/trait-privacy.rs
@@ -1,5 +1,4 @@
 // compile-pass
-#![feature(get_type_id)]
 #![allow(dead_code)]
 mod foo {
     pub use self::bar::T;
@@ -18,7 +17,7 @@ fn g() {
 
 fn f() {
     let error = ::std::thread::spawn(|| {}).join().unwrap_err();
-    error.get_type_id(); // Regression test for #21670
+    error.type_id(); // Regression test for #21670
 }
 
 


### PR DESCRIPTION
Successful merges:

 - #55448 (Add 'partition_at_index/_by/_by_key' for slices.)
 - #57179 (Update std/lib.rs docs to reflect Rust 2018 usage)
 - #57730 (Merge visitors in AST validation)
 - #57779 (Recover from parse errors in literal struct fields and incorrect float literals)
 - #57793 (Explain type mismatch cause pointing to return type when it is `impl Trait`)
 - #57795 (Use structured suggestion in stead of notes)
 - #57817 (Add error for trailing angle brackets.)
 - #57834 (Stabilize Any::get_type_id and rename to type_id)

Failed merges:


r? @ghost