### PR TITLE
Don't try to clean predicates involving ReErased

### DIFF
--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -574,6 +574,10 @@ impl<'a, 'tcx, 'rcx> AutoTraitFinder<'a, 'tcx, 'rcx> {
         let mut ty_to_fn: FxHashMap<Type, (Option<PolyTrait>, Option<Type>)> = Default::default();
 
         for (orig_p, p) in clean_where_predicates {
+            if p.is_none() {
+                continue;
+            }
+            let p = p.unwrap();
             match p {
                 WherePredicate::BoundPredicate { ty, mut bounds } => {
                     // Writing a projection trait bound of the form

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1271,7 +1271,10 @@ impl Clean<Option<Lifetime>> for ty::RegionKind {
             ty::RePlaceholder(..) |
             ty::ReEmpty |
             ty::ReClosureBound(_) |
-            ty::ReErased => None
+            ty::ReErased => {
+                debug!("Cannot clean region {:?}", self);
+                None
+            }
         }
     }
 }
@@ -1310,16 +1313,16 @@ impl Clean<WherePredicate> for hir::WherePredicate {
     }
 }
 
-impl<'a> Clean<WherePredicate> for ty::Predicate<'a> {
-    fn clean(&self, cx: &DocContext) -> WherePredicate {
+impl<'a> Clean<Option<WherePredicate>> for ty::Predicate<'a> {
+    fn clean(&self, cx: &DocContext) -> Option<WherePredicate> {
         use rustc::ty::Predicate;
 
         match *self {
-            Predicate::Trait(ref pred) => pred.clean(cx),
-            Predicate::Subtype(ref pred) => pred.clean(cx),
+            Predicate::Trait(ref pred) => Some(pred.clean(cx)),
+            Predicate::Subtype(ref pred) => Some(pred.clean(cx)),
             Predicate::RegionOutlives(ref pred) => pred.clean(cx),
             Predicate::TypeOutlives(ref pred) => pred.clean(cx),
-            Predicate::Projection(ref pred) => pred.clean(cx),
+            Predicate::Projection(ref pred) => Some(pred.clean(cx)),
 
             Predicate::WellFormed(..) |
             Predicate::ObjectSafe(..) |
@@ -1345,24 +1348,39 @@ impl<'tcx> Clean<WherePredicate> for ty::SubtypePredicate<'tcx> {
     }
 }
 
-impl<'tcx> Clean<WherePredicate> for ty::OutlivesPredicate<ty::Region<'tcx>, ty::Region<'tcx>> {
-    fn clean(&self, cx: &DocContext) -> WherePredicate {
+impl<'tcx> Clean<Option<WherePredicate>> for
+    ty::OutlivesPredicate<ty::Region<'tcx>,ty::Region<'tcx>> {
+
+    fn clean(&self, cx: &DocContext) -> Option<WherePredicate> {
         let ty::OutlivesPredicate(ref a, ref b) = *self;
-        WherePredicate::RegionPredicate {
+
+        match (a, b) {
+            (ty::ReEmpty, ty::ReEmpty) => {
+                return None;
+            },
+            _ => {}
+        }
+
+        Some(WherePredicate::RegionPredicate {
             lifetime: a.clean(cx).expect("failed to clean lifetime"),
             bounds: vec![GenericBound::Outlives(b.clean(cx).expect("failed to clean bounds"))]
-        }
+        })
     }
 }
 
-impl<'tcx> Clean<WherePredicate> for ty::OutlivesPredicate<Ty<'tcx>, ty::Region<'tcx>> {
-    fn clean(&self, cx: &DocContext) -> WherePredicate {
+impl<'tcx> Clean<Option<WherePredicate>> for ty::OutlivesPredicate<Ty<'tcx>, ty::Region<'tcx>> {
+    fn clean(&self, cx: &DocContext) -> Option<WherePredicate> {
         let ty::OutlivesPredicate(ref ty, ref lt) = *self;
 
-        WherePredicate::BoundPredicate {
+        match lt {
+            ty::ReEmpty => return None,
+            _ => {}
+        }
+
+        Some(WherePredicate::BoundPredicate {
             ty: ty.clean(cx),
             bounds: vec![GenericBound::Outlives(lt.clean(cx).expect("failed to clean lifetimes"))]
-        }
+        })
     }
 }
 
@@ -1579,7 +1597,7 @@ impl<'a, 'tcx> Clean<Generics> for (&'a ty::Generics,
         }).collect::<Vec<GenericParamDef>>();
 
         let mut where_predicates = preds.predicates.iter()
-            .map(|(p, _)| p.clean(cx))
+            .flat_map(|(p, _)| p.clean(cx))
             .collect::<Vec<_>>();
 
         // Type parameters and have a Sized bound by default unless removed with


### PR DESCRIPTION
There's nothing to render when we have a bound involving ReErased (either
a type or region outliving it), so we don't attempt to generate a clean
WherePredicate

Fixes #57806

I haven't been able to come up with a minimized reproduction for the issue, but I've confirmed that this allows the docs to build for `parqet-rs`