### PR TITLE
Fix Android CI failing to download SDKs

### DIFF
--- a/src/ci/docker/scripts/android-sdk.sh
+++ b/src/ci/docker/scripts/android-sdk.sh
@@ -20,7 +20,7 @@ download_sysimage() {
     # The output from sdkmanager is so noisy that it will occupy all of the 4 MB
     # log extremely quickly. Thus we must silence all output.
     yes | sdkmanager --licenses > /dev/null
-    sdkmanager platform-tools emulator \
+    yes | sdkmanager platform-tools emulator \
         "platforms;android-$api" \
         "system-images;android-$api;default;$abi" > /dev/null
 }


### PR DESCRIPTION
A component of the Android SDK now requires an additional license ([full license text](https://gist.github.com/pietroalbini/28b46a6fed0921d129de58e7aef29f11)) to be accepted before it's possible to use it. The license is dated January 16th 2019, so it's recent.

The weird thing about the license is that it doesn't prompt you to accept it during `sdkmanager --licenses` like all the other ones, but during `sdkmanager platform-tools emulator ...`, and we didn't pipe `yes` to it before this PR.

The PR changes the SDK installation script to accept all the licenses even on the `sdkmanager platform-tools emulator` command.