### PR TITLE
Ignore line ending on older git versions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,7 @@ src/etc/installer/gfx/* binary
 *.woff binary
 src/vendor/** -text
 Cargo.lock -merge linguist-generated=false
+
+# Older git versions try to fix line endings on images, this prevents it.
+*.png binary
+*.ico binary


### PR DESCRIPTION
On Ubuntu 16.04 git 2.7.4 tries to fix the line ending of `.png` and `.ico` files, and obviously it ruins them. This PR adds an attribute to those files to ignore which line ending they use.

r? @GuillaumeGomez 