### PR TITLE
Don't export table by default in wasm

### DIFF
--- a/src/librustc_codegen_ssa/back/linker.rs
+++ b/src/librustc_codegen_ssa/back/linker.rs
@@ -911,9 +911,6 @@ impl<'a> WasmLd<'a> {
         // For now we just never have an entry symbol
         cmd.arg("--no-entry");
 
-        // Make the default table accessible
-        cmd.arg("--export-table");
-
         // Rust code should never have warnings, and warnings are often
         // indicative of bugs, let's prevent them.
         cmd.arg("--fatal-warnings");


### PR DESCRIPTION
Revert of https://github.com/rust-lang/rust/pull/53237
As per discussion here https://github.com/rustwasm/team/issues/251