### PR TITLE
Build the standard library for thumbv7neon-unknown-linux-gnueabihf in CI

### DIFF
--- a/src/ci/docker/dist-various-1/Dockerfile
+++ b/src/ci/docker/dist-various-1/Dockerfile
@@ -116,13 +116,17 @@ ENV TARGETS=$TARGETS,armebv7r-none-eabi
 ENV TARGETS=$TARGETS,armebv7r-none-eabihf
 ENV TARGETS=$TARGETS,armv7r-none-eabi
 ENV TARGETS=$TARGETS,armv7r-none-eabihf
+ENV TARGETS=$TARGETS,thumbv7neon-unknown-linux-gnueabihf
 
 ENV CC_mipsel_unknown_linux_musl=mipsel-openwrt-linux-gcc \
     CC_mips_unknown_linux_musl=mips-openwrt-linux-gcc \
     CC_sparc64_unknown_linux_gnu=sparc64-linux-gnu-gcc \
     CC_x86_64_unknown_redox=x86_64-unknown-redox-gcc \
-    CC_armebv7r_none_eabi=arm-none-eabi-gcc
-
+    CC_armebv7r_none_eabi=arm-none-eabi-gcc \
+    CC_thumbv7neon_unknown_linux_gnueabihf=arm-linux-gnueabihf-gcc \
+    AR_thumbv7neon_unknown_linux_gnueabihf=arm-linux-gnueabihf-ar \
+    CXX_thumbv7neon_unknown_linux_gnueabihf=arm-linux-gnueabihf-g++
+    
 ENV RUST_CONFIGURE_ARGS \
       --musl-root-armv5te=/musl-armv5te \
       --musl-root-arm=/musl-arm \


### PR DESCRIPTION
Using the `dist-armv7-linux` image instead of `dist-various-1` in order to use the ARMv7 toolchain available in `dist-armv7-linux`.

Closes #57030.