### PR TITLE
Correctly set filetime for copied LLVM

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1998,7 +1998,8 @@ impl<'test> TestCx<'test> {
 
     fn fatal(&self, err: &str) -> ! {
         self.error(err);
-        panic!();
+        error!("fatal error, panic: {:?}", err);
+        panic!("fatal error");
     }
 
     fn fatal_proc_rec(&self, err: &str, proc_res: &ProcRes) -> ! {


### PR DESCRIPTION
This also makes compiletest no longer always retest everything.

Fixes #57864