### PR TITLE
Ignore `Infer` sty when relating MIR and user `Ty`

### DIFF
--- a/src/librustc_mir/borrow_check/nll/type_check/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/mod.rs
@@ -27,7 +27,7 @@ use rustc::infer::canonical::QueryRegionConstraint;
 use rustc::infer::outlives::env::RegionBoundPairs;
 use rustc::infer::{InferCtxt, InferOk, LateBoundRegionConversionTime, NLLRegionVariableOrigin};
 use rustc::mir::interpret::EvalErrorKind::BoundsCheck;
-use rustc::mir::tcx::PlaceTy;
+use rustc::mir::tcx::{PlaceTy, HitTyVar};
 use rustc::mir::visit::{PlaceContext, Visitor, MutatingUseContext, NonMutatingUseContext};
 use rustc::mir::*;
 use rustc::traits::query::type_op;
@@ -1079,7 +1079,6 @@ impl<'a, 'gcx, 'tcx> TypeChecker<'a, 'gcx, 'tcx> {
                 //
                 // if we hit a ty var as we descend, then just skip the
                 // attempt to relate the mir local with any type.
-                #[derive(Debug)] struct HitTyVar;
                 let mut curr_projected_ty: Result<PlaceTy, HitTyVar>;
 
                 curr_projected_ty = Ok(PlaceTy::from_ty(ty));

--- a/src/librustc_traits/type_op.rs
+++ b/src/librustc_traits/type_op.rs
@@ -3,7 +3,7 @@ use rustc::infer::canonical::{Canonical, QueryResponse};
 use rustc::infer::InferCtxt;
 use rustc::hir::def_id::DefId;
 use rustc::mir::ProjectionKind;
-use rustc::mir::tcx::PlaceTy;
+use rustc::mir::tcx::{PlaceTy, HitTyVar};
 use rustc::traits::query::type_op::ascribe_user_type::AscribeUserType;
 use rustc::traits::query::type_op::eq::Eq;
 use rustc::traits::query::type_op::normalize::Normalize;
@@ -133,7 +133,6 @@ impl AscribeUserTypeCx<'me, 'gcx, 'tcx> {
         // if we hit a ty var as we descend, then just skip the
         // attempt to relate the mir local with any type.
 
-        struct HitTyVar;
         let mut curr_projected_ty: Result<PlaceTy, HitTyVar>;
         curr_projected_ty = Ok(PlaceTy::from_ty(ty));
         for proj in projs {

--- a/src/test/ui/issues/issue-57866.rs
+++ b/src/test/ui/issues/issue-57866.rs
@@ -1,0 +1,26 @@
+// run-pass
+
+#![feature(type_alias_enum_variants)]
+
+enum Outer<T> {
+    A(T)
+}
+
+enum Inner {
+    A(i32)
+}
+
+type OuterAlias = Outer<Inner>;
+
+fn ice(x: OuterAlias) {
+    // Fine
+    match x {
+        OuterAlias::A(Inner::A(_)) => (),
+    }
+    // Not fine
+    match x {
+        OuterAlias::A(Inner::A(y)) => (),
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Fix #57866.

r? @petrochenkov 