### PR TITLE
Unused variable suggestions apply on all patterns.

### DIFF
--- a/src/test/ui/issues/issue-17999.stderr
+++ b/src/test/ui/issues/issue-17999.stderr
@@ -2,7 +2,7 @@ error: unused variable: `x`
   --> $DIR/issue-17999.rs:5:13
    |
 LL |         let x = (); //~ ERROR: unused variable: `x`
-   |             ^ help: consider using `_x` instead
+   |             ^ help: consider prefixing with an underscore: `_x`
    |
 note: lint level defined here
   --> $DIR/issue-17999.rs:1:9
@@ -14,7 +14,7 @@ error: unused variable: `a`
   --> $DIR/issue-17999.rs:7:13
    |
 LL |             a => {} //~ ERROR: unused variable: `a`
-   |             ^ help: consider using `_a` instead
+   |             ^ help: consider prefixing with an underscore: `_a`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-22599.stderr
+++ b/src/test/ui/issues/issue-22599.stderr
@@ -2,7 +2,7 @@ error: unused variable: `a`
   --> $DIR/issue-22599.rs:8:19
    |
 LL |     v = match 0 { a => 0 }; //~ ERROR: unused variable: `a`
-   |                   ^ help: consider using `_a` instead
+   |                   ^ help: consider prefixing with an underscore: `_a`
    |
 note: lint level defined here
   --> $DIR/issue-22599.rs:1:9

--- a/src/test/ui/issues/issue-56685.rs
+++ b/src/test/ui/issues/issue-56685.rs
@@ -1,0 +1,44 @@
+#![allow(dead_code)]
+#![deny(unused_variables)]
+
+// This test aims to check that unused variable suggestions update bindings in all
+// match arms.
+
+fn main() {
+    enum E {
+        A(i32,),
+        B(i32,),
+    }
+
+    match E::A(1) {
+        E::A(x) | E::B(x) => {}
+        //~^ ERROR unused variable: `x`
+    }
+
+    enum F {
+        A(i32, i32,),
+        B(i32, i32,),
+        C(i32, i32,),
+    }
+
+    let _ = match F::A(1, 2) {
+        F::A(x, y) | F::B(x, y) => { y },
+        //~^ ERROR unused variable: `x`
+        F::C(a, b) => { 3 }
+        //~^ ERROR unused variable: `a`
+        //~^^ ERROR unused variable: `b`
+    };
+
+    let _ = if let F::A(x, y) | F::B(x, y) = F::A(1, 2) {
+    //~^ ERROR unused variable: `x`
+        y
+    } else {
+        3
+    };
+
+    while let F::A(x, y) | F::B(x, y) = F::A(1, 2) {
+    //~^ ERROR unused variable: `x`
+        let _ = y;
+        break;
+    }
+}

--- a/src/test/ui/issues/issue-56685.stderr
+++ b/src/test/ui/issues/issue-56685.stderr
@@ -1,0 +1,60 @@
+error: unused variable: `x`
+  --> $DIR/issue-56685.rs:14:14
+   |
+LL |         E::A(x) | E::B(x) => {}
+   |              ^         ^
+   |
+note: lint level defined here
+  --> $DIR/issue-56685.rs:2:9
+   |
+LL | #![deny(unused_variables)]
+   |         ^^^^^^^^^^^^^^^^
+help: consider prefixing with an underscore
+   |
+LL |         E::A(_x) | E::B(_x) => {}
+   |              ^^         ^^
+
+error: unused variable: `x`
+  --> $DIR/issue-56685.rs:25:14
+   |
+LL |         F::A(x, y) | F::B(x, y) => { y },
+   |              ^            ^
+help: consider prefixing with an underscore
+   |
+LL |         F::A(_x, y) | F::B(_x, y) => { y },
+   |              ^^            ^^
+
+error: unused variable: `a`
+  --> $DIR/issue-56685.rs:27:14
+   |
+LL |         F::C(a, b) => { 3 }
+   |              ^ help: consider prefixing with an underscore: `_a`
+
+error: unused variable: `b`
+  --> $DIR/issue-56685.rs:27:17
+   |
+LL |         F::C(a, b) => { 3 }
+   |                 ^ help: consider prefixing with an underscore: `_b`
+
+error: unused variable: `x`
+  --> $DIR/issue-56685.rs:32:25
+   |
+LL |     let _ = if let F::A(x, y) | F::B(x, y) = F::A(1, 2) {
+   |                         ^            ^
+help: consider prefixing with an underscore
+   |
+LL |     let _ = if let F::A(_x, y) | F::B(_x, y) = F::A(1, 2) {
+   |                         ^^            ^^
+
+error: unused variable: `x`
+  --> $DIR/issue-56685.rs:39:20
+   |
+LL |     while let F::A(x, y) | F::B(x, y) = F::A(1, 2) {
+   |                    ^            ^
+help: consider prefixing with an underscore
+   |
+LL |     while let F::A(_x, y) | F::B(_x, y) = F::A(1, 2) {
+   |                    ^^            ^^
+
+error: aborting due to 6 previous errors
+

--- a/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.stderr
+++ b/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.stderr
@@ -2,7 +2,7 @@ warning: unused variable: `i_think_continually`
   --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:26:9
    |
 LL |     let i_think_continually = 2;
-   |         ^^^^^^^^^^^^^^^^^^^ help: consider using `_i_think_continually` instead
+   |         ^^^^^^^^^^^^^^^^^^^ help: consider prefixing with an underscore: `_i_think_continually`
    |
 note: lint level defined here
   --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:5:9
@@ -15,19 +15,19 @@ warning: unused variable: `mut_unused_var`
   --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:33:13
    |
 LL |     let mut mut_unused_var = 1;
-   |             ^^^^^^^^^^^^^^ help: consider using `_mut_unused_var` instead
+   |             ^^^^^^^^^^^^^^ help: consider prefixing with an underscore: `_mut_unused_var`
 
 warning: unused variable: `var`
   --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:35:14
    |
 LL |     let (mut var, unused_var) = (1, 2);
-   |              ^^^ help: consider using `_var` instead
+   |              ^^^ help: consider prefixing with an underscore: `_var`
 
 warning: unused variable: `unused_var`
   --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:35:19
    |
 LL |     let (mut var, unused_var) = (1, 2);
-   |                   ^^^^^^^^^^ help: consider using `_unused_var` instead
+   |                   ^^^^^^^^^^ help: consider prefixing with an underscore: `_unused_var`
 
 warning: unused variable: `corridors_of_light`
   --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:37:26

--- a/src/test/ui/lint/lint-removed-allow.stderr
+++ b/src/test/ui/lint/lint-removed-allow.stderr
@@ -2,7 +2,7 @@ error: unused variable: `unused`
   --> $DIR/lint-removed-allow.rs:8:17
    |
 LL | fn main() { let unused = (); } //~ ERROR unused
-   |                 ^^^^^^ help: consider using `_unused` instead
+   |                 ^^^^^^ help: consider prefixing with an underscore: `_unused`
    |
 note: lint level defined here
   --> $DIR/lint-removed-allow.rs:7:8

--- a/src/test/ui/lint/lint-removed-cmdline.stderr
+++ b/src/test/ui/lint/lint-removed-cmdline.stderr
@@ -6,7 +6,7 @@ error: unused variable: `unused`
   --> $DIR/lint-removed-cmdline.rs:12:17
    |
 LL | fn main() { let unused = (); }
-   |                 ^^^^^^ help: consider using `_unused` instead
+   |                 ^^^^^^ help: consider prefixing with an underscore: `_unused`
    |
 note: lint level defined here
   --> $DIR/lint-removed-cmdline.rs:11:8

--- a/src/test/ui/lint/lint-removed.stderr
+++ b/src/test/ui/lint/lint-removed.stderr
@@ -10,7 +10,7 @@ error: unused variable: `unused`
   --> $DIR/lint-removed.rs:8:17
    |
 LL | fn main() { let unused = (); } //~ ERROR unused
-   |                 ^^^^^^ help: consider using `_unused` instead
+   |                 ^^^^^^ help: consider prefixing with an underscore: `_unused`
    |
 note: lint level defined here
   --> $DIR/lint-removed.rs:7:8

--- a/src/test/ui/lint/lint-renamed-allow.stderr
+++ b/src/test/ui/lint/lint-renamed-allow.stderr
@@ -2,7 +2,7 @@ error: unused variable: `unused`
   --> $DIR/lint-renamed-allow.rs:8:17
    |
 LL | fn main() { let unused = (); } //~ ERROR unused
-   |                 ^^^^^^ help: consider using `_unused` instead
+   |                 ^^^^^^ help: consider prefixing with an underscore: `_unused`
    |
 note: lint level defined here
   --> $DIR/lint-renamed-allow.rs:7:8

--- a/src/test/ui/lint/lint-renamed-cmdline.stderr
+++ b/src/test/ui/lint/lint-renamed-cmdline.stderr
@@ -6,7 +6,7 @@ error: unused variable: `unused`
   --> $DIR/lint-renamed-cmdline.rs:8:17
    |
 LL | fn main() { let unused = (); }
-   |                 ^^^^^^ help: consider using `_unused` instead
+   |                 ^^^^^^ help: consider prefixing with an underscore: `_unused`
    |
 note: lint level defined here
   --> $DIR/lint-renamed-cmdline.rs:7:8

--- a/src/test/ui/lint/lint-renamed.stderr
+++ b/src/test/ui/lint/lint-renamed.stderr
@@ -10,7 +10,7 @@ error: unused variable: `unused`
   --> $DIR/lint-renamed.rs:4:17
    |
 LL | fn main() { let unused = (); } //~ ERROR unused
-   |                 ^^^^^^ help: consider using `_unused` instead
+   |                 ^^^^^^ help: consider prefixing with an underscore: `_unused`
    |
 note: lint level defined here
   --> $DIR/lint-renamed.rs:3:8

--- a/src/test/ui/lint/lint-uppercase-variables.stderr
+++ b/src/test/ui/lint/lint-uppercase-variables.stderr
@@ -8,7 +8,7 @@ warning: unused variable: `Foo`
   --> $DIR/lint-uppercase-variables.rs:22:9
    |
 LL |         Foo => {}
-   |         ^^^ help: consider using `_Foo` instead
+   |         ^^^ help: consider prefixing with an underscore: `_Foo`
    |
 note: lint level defined here
   --> $DIR/lint-uppercase-variables.rs:1:9

--- a/src/test/ui/liveness/liveness-unused.stderr
+++ b/src/test/ui/liveness/liveness-unused.stderr
@@ -15,7 +15,7 @@ error: unused variable: `x`
   --> $DIR/liveness-unused.rs:8:7
    |
 LL | fn f1(x: isize) {
-   |       ^ help: consider using `_x` instead
+   |       ^ help: consider prefixing with an underscore: `_x`
    |
 note: lint level defined here
   --> $DIR/liveness-unused.rs:2:9
@@ -27,19 +27,19 @@ error: unused variable: `x`
   --> $DIR/liveness-unused.rs:12:8
    |
 LL | fn f1b(x: &mut isize) {
-   |        ^ help: consider using `_x` instead
+   |        ^ help: consider prefixing with an underscore: `_x`
 
 error: unused variable: `x`
   --> $DIR/liveness-unused.rs:20:9
    |
 LL |     let x: isize;
-   |         ^ help: consider using `_x` instead
+   |         ^ help: consider prefixing with an underscore: `_x`
 
 error: unused variable: `x`
   --> $DIR/liveness-unused.rs:25:9
    |
 LL |     let x = 3;
-   |         ^ help: consider using `_x` instead
+   |         ^ help: consider prefixing with an underscore: `_x`
 
 error: variable `x` is assigned to, but never used
   --> $DIR/liveness-unused.rs:30:13
@@ -74,25 +74,25 @@ error: unused variable: `i`
   --> $DIR/liveness-unused.rs:59:12
    |
 LL |       Some(i) => {
-   |            ^ help: consider using `_i` instead
+   |            ^ help: consider prefixing with an underscore: `_i`
 
 error: unused variable: `x`
   --> $DIR/liveness-unused.rs:79:9
    |
 LL |     for x in 1..10 { }
-   |         ^ help: consider using `_x` instead
+   |         ^ help: consider prefixing with an underscore: `_x`
 
 error: unused variable: `x`
   --> $DIR/liveness-unused.rs:84:10
    |
 LL |     for (x, _) in [1, 2, 3].iter().enumerate() { }
-   |          ^ help: consider using `_x` instead
+   |          ^ help: consider prefixing with an underscore: `_x`
 
 error: unused variable: `x`
   --> $DIR/liveness-unused.rs:89:13
    |
 LL |     for (_, x) in [1, 2, 3].iter().enumerate() {
-   |             ^ help: consider using `_x` instead
+   |             ^ help: consider prefixing with an underscore: `_x`
 
 error: variable `x` is assigned to, but never used
   --> $DIR/liveness-unused.rs:112:9

--- a/src/test/ui/never-assign-dead-code.stderr
+++ b/src/test/ui/never-assign-dead-code.stderr
@@ -21,7 +21,7 @@ warning: unused variable: `x`
   --> $DIR/never-assign-dead-code.rs:9:9
    |
 LL |     let x: ! = panic!("aah"); //~ WARN unused
-   |         ^ help: consider using `_x` instead
+   |         ^ help: consider prefixing with an underscore: `_x`
    |
 note: lint level defined here
   --> $DIR/never-assign-dead-code.rs:5:9

--- a/src/test/ui/proc-macro/attributes-included.stderr
+++ b/src/test/ui/proc-macro/attributes-included.stderr
@@ -2,7 +2,7 @@ warning: unused variable: `a`
   --> $DIR/attributes-included.rs:17:9
    |
 LL |     let a: i32 = "foo"; //~ WARN: unused variable
-   |         ^ help: consider using `_a` instead
+   |         ^ help: consider prefixing with an underscore: `_a`
    |
 note: lint level defined here
   --> $DIR/attributes-included.rs:4:9

--- a/src/test/ui/span/issue-24690.stderr
+++ b/src/test/ui/span/issue-24690.stderr
@@ -2,7 +2,7 @@ warning: unused variable: `theOtherTwo`
   --> $DIR/issue-24690.rs:13:9
    |
 LL |     let theOtherTwo = 2; //~ WARN should have a snake case name
-   |         ^^^^^^^^^^^ help: consider using `_theOtherTwo` instead
+   |         ^^^^^^^^^^^ help: consider prefixing with an underscore: `_theOtherTwo`
    |
 note: lint level defined here
   --> $DIR/issue-24690.rs:8:9


### PR DESCRIPTION
Fixes #56685.

This PR extends existing suggestions to prefix unused variable bindings in match arms with an underscore so that it applies to all patterns in a match arm.

r? @estebank 
cc @alexcrichton (since you filed the issue)