### PR TITLE
remove deprecated suggestion functions

### DIFF
--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -1829,7 +1829,7 @@ impl<'a> LoweringContext<'a> {
                         if let Ok(snippet) = self.sess.source_map().span_to_snippet(data.span) {
                             // Do not suggest going from `Trait()` to `Trait<>`
                             if data.inputs.len() > 0 {
-                                err.span_suggestion_with_applicability(
+                                err.span_suggestion(
                                     data.span,
                                     "use angle brackets instead",
                                     format!("<{}>", &snippet[1..snippet.len() - 1]),

--- a/src/librustc/infer/error_reporting/mod.rs
+++ b/src/librustc/infer/error_reporting/mod.rs
@@ -499,7 +499,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                 if let Some(ty::error::ExpectedFound { found, .. }) = exp_found {
                     if ty.is_box() && ty.boxed_ty() == found {
                         if let Ok(snippet) = self.tcx.sess.source_map().span_to_snippet(span) {
-                            err.span_suggestion_with_applicability(
+                            err.span_suggestion(
                                 span,
                                 "consider dereferencing the boxed value",
                                 format!("*{}", snippet),
@@ -532,7 +532,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                 err.span_label(then, "expected because of this");
                 outer.map(|sp| err.span_label(sp, "if and else have incompatible types"));
                 if let Some(sp) = semicolon {
-                    err.span_suggestion_short_with_applicability(
+                    err.span_suggestion_short(
                         sp,
                         "consider removing this semicolon",
                         String::new(),
@@ -1084,7 +1084,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                                 self.tcx.sess.source_map().span_to_snippet(span),
                                 show_suggestion,
                             ) {
-                                diag.span_suggestion_with_applicability(
+                                diag.span_suggestion(
                                     span,
                                     msg,
                                     format!("{}.as_ref()", snippet),
@@ -1273,7 +1273,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                     let tail = if has_lifetimes { " + " } else { "" };
                     format!("{}: {}{}", bound_kind, sub, tail)
                 };
-                err.span_suggestion_short_with_applicability(
+                err.span_suggestion_short(
                     sp,
                     &consider,
                     suggestion,

--- a/src/librustc/infer/error_reporting/nice_region_error/named_anon_conflict.rs
+++ b/src/librustc/infer/error_reporting/nice_region_error/named_anon_conflict.rs
@@ -102,7 +102,7 @@ impl<'a, 'gcx, 'tcx> NiceRegionError<'a, 'gcx, 'tcx> {
             E0621,
             "explicit lifetime required in {}",
             error_var
-        ).span_suggestion_with_applicability(
+        ).span_suggestion(
             new_ty_span,
             &format!("add explicit lifetime `{}` to {}", named, span_label_var),
             new_ty.to_string(),

--- a/src/librustc/infer/error_reporting/nice_region_error/static_impl_trait.rs
+++ b/src/librustc/infer/error_reporting/nice_region_error/static_impl_trait.rs
@@ -53,7 +53,7 @@ impl<'a, 'gcx, 'tcx> NiceRegionError<'a, 'gcx, 'tcx> {
                         _ => "'_".to_owned(),
                     };
                     if let Ok(snippet) = self.tcx.sess.source_map().span_to_snippet(return_sp) {
-                        err.span_suggestion_with_applicability(
+                        err.span_suggestion(
                             return_sp,
                             &format!(
                                 "you can add a constraint to the return type to make it last \

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -473,7 +473,7 @@ impl BuiltinLintDiagnostics {
                     Ok(s) => (format!("dyn {}", s), Applicability::MachineApplicable),
                     Err(_) => ("dyn <type>".to_string(), Applicability::HasPlaceholders)
                 };
-                db.span_suggestion_with_applicability(span, "use `dyn`", sugg, app);
+                db.span_suggestion(span, "use `dyn`", sugg, app);
             }
             BuiltinLintDiagnostics::AbsPathWithModule(span) => {
                 let (sugg, app) = match sess.source_map().span_to_snippet(span) {
@@ -490,7 +490,7 @@ impl BuiltinLintDiagnostics {
                     }
                     Err(_) => ("crate::<path>".to_string(), Applicability::HasPlaceholders)
                 };
-                db.span_suggestion_with_applicability(span, "use `crate`", sugg, app);
+                db.span_suggestion(span, "use `crate`", sugg, app);
             }
             BuiltinLintDiagnostics::DuplicatedMacroExports(ident, earlier_span, later_span) => {
                 db.span_label(later_span, format!("`{}` already exported", ident));
@@ -531,7 +531,7 @@ impl BuiltinLintDiagnostics {
                         (insertion_span, anon_lts)
                     }
                 };
-                db.span_suggestion_with_applicability(
+                db.span_suggestion(
                     replace_span,
                     &format!("indicate the anonymous lifetime{}", if n >= 2 { "s" } else { "" }),
                     suggestion,
@@ -539,12 +539,7 @@ impl BuiltinLintDiagnostics {
                 );
             }
             BuiltinLintDiagnostics::UnknownCrateTypes(span, note, sugg) => {
-                db.span_suggestion_with_applicability(
-                    span,
-                    &note,
-                    sugg,
-                    Applicability::MaybeIncorrect
-                );
+                db.span_suggestion(span, &note, sugg, Applicability::MaybeIncorrect);
             }
         }
     }

--- a/src/librustc/lint/levels.rs
+++ b/src/librustc/lint/levels.rs
@@ -324,7 +324,7 @@ impl<'a> LintLevelsBuilder<'a> {
                                     Some(li.span.into()),
                                     &msg,
                                 );
-                                err.span_suggestion_with_applicability(
+                                err.span_suggestion(
                                     li.span,
                                     "change it to",
                                     new_lint_name.to_string(),
@@ -362,7 +362,7 @@ impl<'a> LintLevelsBuilder<'a> {
                                                               Some(li.span.into()),
                                                               &msg);
                         if let Some(new_name) = renamed {
-                            err.span_suggestion_with_applicability(
+                            err.span_suggestion(
                                 li.span,
                                 "use the new name",
                                 new_name,
@@ -386,7 +386,7 @@ impl<'a> LintLevelsBuilder<'a> {
                                                 &msg);
 
                         if let Some(suggestion) = suggestion {
-                            db.span_suggestion_with_applicability(
+                            db.span_suggestion(
                                 li.span,
                                 "did you mean",
                                 suggestion.to_string(),

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -1600,12 +1600,16 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
                     let mut err = self.ir.tcx
                         .struct_span_lint_hir(lint::builtin::UNUSED_VARIABLES, hir_id, sp, &msg);
                     if self.ir.variable_is_shorthand(var) {
-                        err.span_suggestion_with_applicability(sp, "try ignoring the field",
-                                                               format!("{}: _", name),
-                                                               Applicability::MachineApplicable);
+                        err.span_suggestion(
+                            sp,
+                            "try ignoring the field",
+                            format!("{}: _", name),
+                            Applicability::MachineApplicable,
+                        );
                     } else {
-                        err.span_suggestion_short_with_applicability(
-                            sp, &suggest_underscore_msg,
+                        err.span_suggestion_short(
+                            sp,
+                            &suggest_underscore_msg,
                             format!("_{}", name),
                             Applicability::MachineApplicable,
                         );

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -1526,14 +1526,14 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
             // place ("start at" because the latter includes trailing
             // whitespace), then this is an in-band lifetime
             if decl_span.shrink_to_lo() == use_span.shrink_to_lo() {
-                err.span_suggestion_with_applicability(
+                err.span_suggestion(
                     use_span,
                     "elide the single-use lifetime",
                     String::new(),
                     Applicability::MachineApplicable,
                 );
             } else {
-                err.multipart_suggestion_with_applicability(
+                err.multipart_suggestion(
                     "elide the single-use lifetime",
                     vec![(decl_span, String::new()), (use_span, String::new())],
                     Applicability::MachineApplicable,
@@ -1644,7 +1644,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
                             if let Some(generics) = self.tcx.hir().get_generics(parent_def_id) {
                                 let unused_lt_span = self.lifetime_deletion_span(name, generics);
                                 if let Some(span) = unused_lt_span {
-                                    err.span_suggestion_with_applicability(
+                                    err.span_suggestion(
                                         span,
                                         "elide the unused lifetime",
                                         String::new(),
@@ -2350,7 +2350,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
                 } else {
                     (format!("{} + 'static", snippet), Applicability::MaybeIncorrect)
                 };
-                db.span_suggestion_with_applicability(span, msg, sugg, applicability);
+                db.span_suggestion(span, msg, sugg, applicability);
                 false
             }
             Err(_) => {

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -435,7 +435,7 @@ impl Session {
                 }
                 DiagnosticBuilderMethod::SpanSuggestion(suggestion) => {
                     let span = span_maybe.expect("span_suggestion_* needs a span");
-                    diag_builder.span_suggestion_with_applicability(
+                    diag_builder.span_suggestion(
                         span,
                         message,
                         suggestion,

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -904,7 +904,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                 if let Some(ref expr) = local.init {
                     if let hir::ExprKind::Index(_, _) = expr.node {
                         if let Ok(snippet) = self.tcx.sess.source_map().span_to_snippet(expr.span) {
-                            err.span_suggestion_with_applicability(
+                            err.span_suggestion(
                                 expr.span,
                                 "consider borrowing here",
                                 format!("&{}", snippet),
@@ -952,7 +952,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                         let format_str = format!("consider removing {} leading `&`-references",
                                                  remove_refs);
 
-                        err.span_suggestion_short_with_applicability(
+                        err.span_suggestion_short(
                             sp, &format_str, String::new(), Applicability::MachineApplicable
                         );
                         break;
@@ -1109,7 +1109,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
             // For example, if `expected_args_length` is 2, suggest `|_, _|`.
             if found_args.is_empty() && is_closure {
                 let underscores = vec!["_"; expected_args.len()].join(", ");
-                err.span_suggestion_with_applicability(
+                err.span_suggestion(
                     pipe_span,
                     &format!(
                         "consider changing the closure to take and ignore the expected argument{}",
@@ -1130,11 +1130,12 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                         .map(|(name, _)| name.to_owned())
                         .collect::<Vec<String>>()
                         .join(", ");
-                    err.span_suggestion_with_applicability(found_span,
-                                                           "change the closure to take multiple \
-                                                            arguments instead of a single tuple",
-                                                           format!("|{}|", sugg),
-                                                           Applicability::MachineApplicable);
+                    err.span_suggestion(
+                        found_span,
+                        "change the closure to take multiple arguments instead of a single tuple",
+                        format!("|{}|", sugg),
+                        Applicability::MachineApplicable,
+                    );
                 }
             }
             if let &[ArgKind::Tuple(_, ref fields)] = &expected_args[..] {
@@ -1162,12 +1163,11 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                             String::new()
                         },
                     );
-                    err.span_suggestion_with_applicability(
+                    err.span_suggestion(
                         found_span,
-                        "change the closure to accept a tuple instead of \
-                         individual arguments",
+                        "change the closure to accept a tuple instead of individual arguments",
                         sugg,
-                        Applicability::MachineApplicable
+                        Applicability::MachineApplicable,
                     );
                 }
             }

--- a/src/librustc/ty/error.rs
+++ b/src/librustc/ty/error.rs
@@ -237,7 +237,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
                 {
                     if let Ok(snippet) = self.sess.source_map().span_to_snippet(sp) {
                         if snippet.chars().all(|c| c.is_digit(10) || c == '-' || c == '_') {
-                            db.span_suggestion_with_applicability(
+                            db.span_suggestion(
                                 sp,
                                 "use a float literal",
                                 format!("{}.0", snippet),

--- a/src/librustc_borrowck/borrowck/gather_loans/move_error.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/move_error.rs
@@ -70,7 +70,7 @@ fn report_move_errors<'a, 'tcx>(bccx: &BorrowckCtxt<'a, 'tcx>, errors: &[MoveErr
                 let initializer =
                     e.init.as_ref().expect("should have an initializer to get an error");
                 if let Ok(snippet) = bccx.tcx.sess.source_map().span_to_snippet(initializer.span) {
-                    err.span_suggestion_with_applicability(
+                    err.span_suggestion(
                         initializer.span,
                         "consider using a reference instead",
                         format!("&{}", snippet),

--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -850,7 +850,7 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
                                         }) = cmt.cat {
                                             db.note(fn_closure_msg);
                                         } else {
-                                            db.span_suggestion_with_applicability(
+                                            db.span_suggestion(
                                                 sp,
                                                 msg,
                                                 suggestion,
@@ -858,7 +858,7 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
                                             );
                                         }
                                     } else {
-                                        db.span_suggestion_with_applicability(
+                                        db.span_suggestion(
                                             sp,
                                             msg,
                                             suggestion,
@@ -1229,7 +1229,7 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
                         let let_span = self.tcx.hir().span(node_id);
                         let suggestion = suggest_ref_mut(self.tcx, let_span);
                         if let Some(replace_str) = suggestion {
-                            db.span_suggestion_with_applicability(
+                            db.span_suggestion(
                                 let_span,
                                 "use a mutable reference instead",
                                 replace_str,
@@ -1291,7 +1291,7 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
                 )) = ty.map(|t| &t.node)
                 {
                     let borrow_expr_id = self.tcx.hir().get_parent_node(borrowed_node_id);
-                    db.span_suggestion_with_applicability(
+                    db.span_suggestion(
                         self.tcx.hir().span(borrow_expr_id),
                         "consider removing the `&mut`, as it is an \
                         immutable binding to a mutable reference",
@@ -1299,7 +1299,7 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
                         Applicability::MachineApplicable,
                     );
                 } else {
-                    db.span_suggestion_with_applicability(
+                    db.span_suggestion(
                         let_span,
                         "make this binding mutable",
                         format!("mut {}", snippet),
@@ -1326,7 +1326,7 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
                                                   &cmt_path_or_string,
                                                   capture_span,
                                                   Origin::Ast)
-            .span_suggestion_with_applicability(
+            .span_suggestion(
                  err.span,
                  &format!("to force the closure to take ownership of {} \
                            (and any other referenced variables), \

--- a/src/librustc_borrowck/borrowck/unused.rs
+++ b/src/librustc_borrowck/borrowck/unused.rs
@@ -78,11 +78,12 @@ impl<'a, 'tcx> UnusedMutCx<'a, 'tcx> {
                                      hir_id,
                                      span,
                                      "variable does not need to be mutable")
-                .span_suggestion_short_with_applicability(
+                .span_suggestion_short(
                     mut_span,
                     "remove this `mut`",
                     String::new(),
-                    Applicability::MachineApplicable)
+                    Applicability::MachineApplicable,
+                )
                 .emit();
         }
     }

--- a/src/librustc_errors/diagnostic.rs
+++ b/src/librustc_errors/diagnostic.rs
@@ -229,59 +229,7 @@ impl Diagnostic {
         self
     }
 
-    /// Prints out a message with a suggested edit of the code. If the suggestion is presented
-    /// inline it will only show the text message and not the text.
-    ///
-    /// See `CodeSuggestion` for more information.
-    #[deprecated(note = "Use `span_suggestion_short_with_applicability`")]
-    pub fn span_suggestion_short(&mut self, sp: Span, msg: &str, suggestion: String) -> &mut Self {
-        self.suggestions.push(CodeSuggestion {
-            substitutions: vec![Substitution {
-                parts: vec![SubstitutionPart {
-                    snippet: suggestion,
-                    span: sp,
-                }],
-            }],
-            msg: msg.to_owned(),
-            show_code_when_inline: false,
-            applicability: Applicability::Unspecified,
-        });
-        self
-    }
-
-    /// Prints out a message with a suggested edit of the code.
-    ///
-    /// In case of short messages and a simple suggestion,
-    /// rustc displays it as a label like
-    ///
-    /// "try adding parentheses: `(tup.0).1`"
-    ///
-    /// The message
-    ///
-    /// * should not end in any punctuation (a `:` is added automatically)
-    /// * should not be a question
-    /// * should not contain any parts like "the following", "as shown"
-    /// * may look like "to do xyz, use" or "to do xyz, use abc"
-    /// * may contain a name of a function, variable or type, but not whole expressions
-    ///
-    /// See `CodeSuggestion` for more information.
-    #[deprecated(note = "Use `span_suggestion_with_applicability`")]
-    pub fn span_suggestion(&mut self, sp: Span, msg: &str, suggestion: String) -> &mut Self {
-        self.suggestions.push(CodeSuggestion {
-            substitutions: vec![Substitution {
-                parts: vec![SubstitutionPart {
-                    snippet: suggestion,
-                    span: sp,
-                }],
-            }],
-            msg: msg.to_owned(),
-            show_code_when_inline: true,
-            applicability: Applicability::Unspecified,
-        });
-        self
-    }
-
-    pub fn multipart_suggestion_with_applicability(
+    pub fn multipart_suggestion(
         &mut self,
         msg: &str,
         suggestion: Vec<(Span, String)>,
@@ -301,39 +249,24 @@ impl Diagnostic {
         self
     }
 
-    #[deprecated(note = "Use `multipart_suggestion_with_applicability`")]
-    pub fn multipart_suggestion(
-        &mut self,
-        msg: &str,
-        suggestion: Vec<(Span, String)>,
-    ) -> &mut Self {
-        self.multipart_suggestion_with_applicability(
-            msg,
-            suggestion,
-            Applicability::Unspecified,
-        )
-    }
-
-    /// Prints out a message with multiple suggested edits of the code.
-    #[deprecated(note = "Use `span_suggestions_with_applicability`")]
-    pub fn span_suggestions(&mut self, sp: Span, msg: &str, suggestions: Vec<String>) -> &mut Self {
-        self.suggestions.push(CodeSuggestion {
-            substitutions: suggestions.into_iter().map(|snippet| Substitution {
-                parts: vec![SubstitutionPart {
-                    snippet,
-                    span: sp,
-                }],
-            }).collect(),
-            msg: msg.to_owned(),
-            show_code_when_inline: true,
-            applicability: Applicability::Unspecified,
-        });
-        self
-    }
-
-    /// This is a suggestion that may contain mistakes or fillers and should
-    /// be read and understood by a human.
-    pub fn span_suggestion_with_applicability(&mut self, sp: Span, msg: &str,
+    /// Prints out a message with a suggested edit of the code.
+    ///
+    /// In case of short messages and a simple suggestion, rustc displays it as a label:
+    ///
+    /// ```text
+    /// try adding parentheses: `(tup.0).1`
+    /// ```
+    ///
+    /// The message
+    ///
+    /// * should not end in any punctuation (a `:` is added automatically)
+    /// * should not be a question (avoid language like "did you mean")
+    /// * should not contain any phrases like "the following", "as shown", etc.
+    /// * may look like "to do xyz, use" or "to do xyz, use abc"
+    /// * may contain a name of a function, variable, or type, but not whole expressions
+    ///
+    /// See `CodeSuggestion` for more information.
+    pub fn span_suggestion(&mut self, sp: Span, msg: &str,
                                        suggestion: String,
                                        applicability: Applicability) -> &mut Self {
         self.suggestions.push(CodeSuggestion {
@@ -350,7 +283,8 @@ impl Diagnostic {
         self
     }
 
-    pub fn span_suggestions_with_applicability(&mut self, sp: Span, msg: &str,
+    /// Prints out a message with multiple suggested edits of the code.
+    pub fn span_suggestions(&mut self, sp: Span, msg: &str,
         suggestions: impl Iterator<Item = String>, applicability: Applicability) -> &mut Self
     {
         self.suggestions.push(CodeSuggestion {
@@ -367,7 +301,11 @@ impl Diagnostic {
         self
     }
 
-    pub fn span_suggestion_short_with_applicability(
+    /// Prints out a message with a suggested edit of the code. If the suggestion is presented
+    /// inline, it will only show the message and not the suggestion.
+    ///
+    /// See `CodeSuggestion` for more information.
+    pub fn span_suggestion_short(
         &mut self, sp: Span, msg: &str, suggestion: String, applicability: Applicability
     ) -> &mut Self {
         self.suggestions.push(CodeSuggestion {

--- a/src/librustc_errors/diagnostic_builder.rs
+++ b/src/librustc_errors/diagnostic_builder.rs
@@ -39,7 +39,6 @@ macro_rules! forward {
     ) => {
         $(#[$attrs])*
         pub fn $n(&self, $($name: $ty),*) -> &Self {
-            #[allow(deprecated)]
             self.diagnostic.$n($($name),*);
             self
         }
@@ -52,7 +51,6 @@ macro_rules! forward {
     ) => {
         $(#[$attrs])*
         pub fn $n(&mut self, $($name: $ty),*) -> &mut Self {
-            #[allow(deprecated)]
             self.diagnostic.$n($($name),*);
             self
         }
@@ -70,7 +68,6 @@ macro_rules! forward {
     ) => {
         $(#[$attrs])*
         pub fn $n<S: Into<MultiSpan>>(&mut self, $($name: $ty),*) -> &mut Self {
-            #[allow(deprecated)]
             self.diagnostic.$n($($name),*);
             self
         }
@@ -190,53 +187,16 @@ impl<'a> DiagnosticBuilder<'a> {
                                                   msg: &str,
                                                   ) -> &mut Self);
 
-    forward!(
-        #[deprecated(note = "Use `span_suggestion_short_with_applicability`")]
-        pub fn span_suggestion_short(
-            &mut self,
-            sp: Span,
-            msg: &str,
-            suggestion: String,
-        ) -> &mut Self
-    );
-
-    forward!(
-        #[deprecated(note = "Use `multipart_suggestion_with_applicability`")]
-        pub fn multipart_suggestion(
-            &mut self,
-            msg: &str,
-            suggestion: Vec<(Span, String)>,
-        ) -> &mut Self
-    );
-
-    forward!(
-        #[deprecated(note = "Use `span_suggestion_with_applicability`")]
-        pub fn span_suggestion(
-            &mut self,
-            sp: Span,
-            msg: &str,
-            suggestion: String,
-        ) -> &mut Self
-    );
-
-    forward!(
-        #[deprecated(note = "Use `span_suggestions_with_applicability`")]
-        pub fn span_suggestions(&mut self,
-            sp: Span,
-            msg: &str,
-            suggestions: Vec<String>,
-        ) -> &mut Self
-    );
-
-    pub fn multipart_suggestion_with_applicability(&mut self,
-                                              msg: &str,
-                                              suggestion: Vec<(Span, String)>,
-                                              applicability: Applicability,
-                                              ) -> &mut Self {
+    pub fn multipart_suggestion(
+        &mut self,
+        msg: &str,
+        suggestion: Vec<(Span, String)>,
+        applicability: Applicability,
+    ) -> &mut Self {
         if !self.allow_suggestions {
             return self
         }
-        self.diagnostic.multipart_suggestion_with_applicability(
+        self.diagnostic.multipart_suggestion(
             msg,
             suggestion,
             applicability,
@@ -244,16 +204,17 @@ impl<'a> DiagnosticBuilder<'a> {
         self
     }
 
-    pub fn span_suggestion_with_applicability(&mut self,
-                                              sp: Span,
-                                              msg: &str,
-                                              suggestion: String,
-                                              applicability: Applicability)
-                                              -> &mut Self {
+    pub fn span_suggestion(
+        &mut self,
+        sp: Span,
+        msg: &str,
+        suggestion: String,
+        applicability: Applicability,
+    ) -> &mut Self {
         if !self.allow_suggestions {
             return self
         }
-        self.diagnostic.span_suggestion_with_applicability(
+        self.diagnostic.span_suggestion(
             sp,
             msg,
             suggestion,
@@ -262,16 +223,17 @@ impl<'a> DiagnosticBuilder<'a> {
         self
     }
 
-    pub fn span_suggestions_with_applicability(&mut self,
-                                               sp: Span,
-                                               msg: &str,
-                                               suggestions: impl Iterator<Item = String>,
-                                               applicability: Applicability)
-                                               -> &mut Self {
+    pub fn span_suggestions(
+        &mut self,
+        sp: Span,
+        msg: &str,
+        suggestions: impl Iterator<Item = String>,
+        applicability: Applicability,
+    ) -> &mut Self {
         if !self.allow_suggestions {
             return self
         }
-        self.diagnostic.span_suggestions_with_applicability(
+        self.diagnostic.span_suggestions(
             sp,
             msg,
             suggestions,
@@ -280,16 +242,17 @@ impl<'a> DiagnosticBuilder<'a> {
         self
     }
 
-    pub fn span_suggestion_short_with_applicability(&mut self,
-                                                    sp: Span,
-                                                    msg: &str,
-                                                    suggestion: String,
-                                                    applicability: Applicability)
-                                                    -> &mut Self {
+    pub fn span_suggestion_short(
+        &mut self,
+        sp: Span,
+        msg: &str,
+        suggestion: String,
+        applicability: Applicability,
+    ) -> &mut Self {
         if !self.allow_suggestions {
             return self
         }
-        self.diagnostic.span_suggestion_short_with_applicability(
+        self.diagnostic.span_suggestion_short(
             sp,
             msg,
             suggestion,

--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -54,12 +54,28 @@ use syntax_pos::{BytePos,
                  Span,
                  NO_EXPANSION};
 
+/// Indicates the confidence in the correctness of a suggestion.
+///
+/// All suggestions are marked with an `Applicability`. Tools use the applicability of a suggestion
+/// to determine whether it should be automatically applied or if the user should be consulted
+/// before applying the suggestion.
 #[derive(Copy, Clone, Debug, PartialEq, Hash, RustcEncodable, RustcDecodable)]
 pub enum Applicability {
+    /// The suggestion is definitely what the user intended. This suggestion should be
+    /// automatically applied.
     MachineApplicable,
-    HasPlaceholders,
+
+    /// The suggestion may be what the user intended, but it is uncertain. The suggestion should
+    /// result in valid Rust code if it is applied.
     MaybeIncorrect,
-    Unspecified
+
+    /// The suggestion contains placeholders like `(...)` or `{ /* fields */ }`. The suggestion
+    /// cannot be applied automatically because it will not result in valid Rust code. The user
+    /// will need to fill in the placeholders.
+    HasPlaceholders,
+
+    /// The applicability of the suggestion is unknown.
+    Unspecified,
 }
 
 #[derive(Clone, Debug, PartialEq, Hash, RustcEncodable, RustcDecodable)]

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -78,7 +78,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for WhileTrue {
                         let msg = "denote infinite loops with `loop { ... }`";
                         let condition_span = cx.tcx.sess.source_map().def_span(e.span);
                         let mut err = cx.struct_span_lint(WHILE_TRUE, condition_span, msg);
-                        err.span_suggestion_short_with_applicability(
+                        err.span_suggestion_short(
                             condition_span,
                             "use `loop`",
                             "loop".to_owned(),
@@ -199,7 +199,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NonShorthandFieldPatterns {
                                      &format!("the `{}:` in this pattern is redundant", ident));
                         let subspan = cx.tcx.sess.source_map().span_through_char(fieldpat.span,
                                                                                  ':');
-                        err.span_suggestion_short_with_applicability(
+                        err.span_suggestion_short(
                             subspan,
                             "remove this",
                             ident.to_string(),
@@ -704,7 +704,7 @@ impl EarlyLintPass for AnonymousParameters {
                                     arg.pat.span,
                                     "anonymous parameters are deprecated and will be \
                                      removed in the next edition."
-                                ).span_suggestion_with_applicability(
+                                ).span_suggestion(
                                     arg.pat.span,
                                     "Try naming the parameter or explicitly \
                                     ignoring it",
@@ -759,7 +759,7 @@ impl EarlyLintPass for DeprecatedAttr {
                     let msg = format!("use of deprecated attribute `{}`: {}. See {}",
                                       name, reason, link);
                     let mut err = cx.struct_span_lint(DEPRECATED, attr.span, &msg);
-                    err.span_suggestion_short_with_applicability(
+                    err.span_suggestion_short(
                         attr.span,
                         suggestion.unwrap_or("remove this attribute"),
                         String::new(),
@@ -906,7 +906,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for InvalidNoMangleItems {
                                                                   it.span,
                                                                   "functions generic over \
                                                                    types must be mangled");
-                                err.span_suggestion_short_with_applicability(
+                                err.span_suggestion_short(
                                     no_mangle_attr.span,
                                     "remove this attribute",
                                     String::new(),
@@ -934,7 +934,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for InvalidNoMangleItems {
                         .unwrap_or(0) as u32;
                     // `const` is 5 chars
                     let const_span = it.span.with_hi(BytePos(it.span.lo().0 + start + 5));
-                    err.span_suggestion_with_applicability(
+                    err.span_suggestion(
                         const_span,
                         "try a static value",
                         "pub static".to_owned(),
@@ -1116,10 +1116,12 @@ impl UnreachablePub {
                     "pub(crate)"
                 }.to_owned();
 
-                err.span_suggestion_with_applicability(vis.span,
-                                                       "consider restricting its visibility",
-                                                       replacement,
-                                                       applicability);
+                err.span_suggestion(
+                    vis.span,
+                    "consider restricting its visibility",
+                    replacement,
+                    applicability,
+                );
                 if exportable {
                     err.help("or consider exporting it for use by other crates");
                 }
@@ -1452,7 +1454,7 @@ impl EarlyLintPass for EllipsisInclusiveRangePatterns {
             if parenthesise {
                 *visit_subpats = false;
                 let mut err = cx.struct_span_lint(ELLIPSIS_INCLUSIVE_RANGE_PATTERNS, pat.span, msg);
-                err.span_suggestion_with_applicability(
+                err.span_suggestion(
                     pat.span,
                     suggestion,
                     format!("&({}..={})", expr_to_string(&start), expr_to_string(&end)),
@@ -1461,7 +1463,7 @@ impl EarlyLintPass for EllipsisInclusiveRangePatterns {
                 err.emit();
             } else {
                 let mut err = cx.struct_span_lint(ELLIPSIS_INCLUSIVE_RANGE_PATTERNS, join, msg);
-                err.span_suggestion_short_with_applicability(
+                err.span_suggestion_short(
                     join,
                     suggestion,
                     "..=".to_owned(),
@@ -1613,7 +1615,7 @@ impl EarlyLintPass for KeywordIdents {
                         E0721,
                         "`await` is a keyword in the {} edition", cur_edition,
                     );
-                    err.span_suggestion_with_applicability(
+                    err.span_suggestion(
                         ident.span,
                         "you can use a raw identifier to stay compatible",
                         "r#await".to_string(),
@@ -1637,7 +1639,7 @@ impl EarlyLintPass for KeywordIdents {
                      ident.as_str(),
                      next_edition),
         );
-        lint.span_suggestion_with_applicability(
+        lint.span_suggestion(
             ident.span,
             "you can use a raw identifier to stay compatible",
             format!("r#{}", ident.as_str()),
@@ -1865,7 +1867,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ExplicitOutlivesRequirements {
                     lint_spans.clone(),
                     "outlives requirements can be inferred"
                 );
-                err.multipart_suggestion_with_applicability(
+                err.multipart_suggestion(
                     if bound_count == 1 {
                         "remove this bound"
                     } else {

--- a/src/librustc_lint/nonstandard_style.rs
+++ b/src/librustc_lint/nonstandard_style.rs
@@ -93,7 +93,7 @@ impl NonCamelCaseTypes {
 
             let msg = format!("{} `{}` should have a camel case name", sort, name);
             cx.struct_span_lint(NON_CAMEL_CASE_TYPES, ident.span, &msg)
-                .span_suggestion_with_applicability(
+                .span_suggestion(
                     ident.span,
                     "convert the identifier to camel case",
                     c,
@@ -223,7 +223,7 @@ impl NonSnakeCase {
             // We have a valid span in almost all cases, but we don't have one when linting a crate
             // name provided via the command line.
             if !ident.span.is_dummy() {
-                err.span_suggestion_with_applicability(
+                err.span_suggestion(
                     ident.span,
                     "convert the identifier to snake case",
                     sc,
@@ -377,7 +377,7 @@ impl NonUpperCaseGlobals {
 
             let msg = format!("{} `{}` should have an upper case name", sort, name);
             cx.struct_span_lint(NON_UPPER_CASE_GLOBALS, ident.span, &msg)
-                .span_suggestion_with_applicability(
+                .span_suggestion(
                     ident.span,
                     "convert the identifier to upper case",
                     uc,

--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -143,7 +143,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TypeLimits {
                                                              OVERFLOWING_LITERALS,
                                                              parent_expr.span,
                                                              "only u8 can be cast into char");
-                                        err.span_suggestion_with_applicability(
+                                        err.span_suggestion(
                                             parent_expr.span,
                                             &"use a char literal instead",
                                             format!("'\\u{{{:X}}}'", lit_val),
@@ -401,7 +401,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TypeLimits {
             {
                 if let Some(pos) = repr_str.chars().position(|c| c == 'i' || c == 'u') {
                     let (sans_suffix, _) = repr_str.split_at(pos);
-                    err.span_suggestion_with_applicability(
+                    err.span_suggestion(
                         expr.span,
                         &format!("consider using `{}` instead", sugg_ty),
                         format!("{}{}", sans_suffix, sugg_ty),

--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -366,12 +366,12 @@ impl UnusedParens {
                     _ => false,
                 }
             }).to_owned();
-        err.span_suggestion_short_with_applicability(
-                span,
-                "remove these parentheses",
-                parens_removed,
-                Applicability::MachineApplicable
-            );
+        err.span_suggestion_short(
+            span,
+            "remove these parentheses",
+            parens_removed,
+            Applicability::MachineApplicable,
+        );
         err.emit();
     }
 }

--- a/src/librustc_mir/borrow_check/error_reporting.rs
+++ b/src/librustc_mir/borrow_check/error_reporting.rs
@@ -1139,7 +1139,7 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
             Err(_) => "move |<args>| <body>".to_string()
         };
 
-        err.span_suggestion_with_applicability(
+        err.span_suggestion(
             args_span,
             &format!("to force the closure to take ownership of {} (and any \
                       other referenced variables), use the `move` keyword",
@@ -1428,7 +1428,7 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
         if let Some(decl) = local_decl {
             if let Some(name) = decl.name {
                 if decl.can_be_made_mutable() {
-                    err.span_suggestion_with_applicability(
+                    err.span_suggestion(
                         decl.source_info.span,
                         "make this binding mutable",
                         format!("mut {}", name),

--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -307,7 +307,7 @@ fn do_mir_borrowck<'a, 'gcx, 'tcx>(
                 span,
                 "variable does not need to be mutable",
             )
-            .span_suggestion_short_with_applicability(
+            .span_suggestion_short(
                 mut_span,
                 "remove this `mut`",
                 String::new(),

--- a/src/librustc_mir/borrow_check/move_errors.rs
+++ b/src/librustc_mir/borrow_check/move_errors.rs
@@ -368,14 +368,14 @@ impl<'a, 'gcx, 'tcx> MirBorrowckCtxt<'a, 'gcx, 'tcx> {
                     // expressions `a[b]`, which roughly desugar to
                     // `*Index::index(&a, b)` or
                     // `*IndexMut::index_mut(&mut a, b)`.
-                    err.span_suggestion_with_applicability(
+                    err.span_suggestion(
                         span,
                         "consider removing the `*`",
                         snippet[1..].to_owned(),
                         Applicability::Unspecified,
                     );
                 } else {
-                    err.span_suggestion_with_applicability(
+                    err.span_suggestion(
                         span,
                         "consider borrowing here",
                         format!("&{}", snippet),
@@ -439,7 +439,7 @@ impl<'a, 'gcx, 'tcx> MirBorrowckCtxt<'a, 'gcx, 'tcx> {
         suggestions.sort_unstable_by_key(|&(span, _, _)| span);
         suggestions.dedup_by_key(|&mut (span, _, _)| span);
         for (span, to_remove, suggestion) in suggestions {
-            err.span_suggestion_with_applicability(
+            err.span_suggestion(
                 span,
                 &format!("consider removing the `{}`", to_remove),
                 suggestion,

--- a/src/librustc_mir/borrow_check/mutability_errors.rs
+++ b/src/librustc_mir/borrow_check/mutability_errors.rs
@@ -231,7 +231,7 @@ impl<'a, 'gcx, 'tcx> MirBorrowckCtxt<'a, 'gcx, 'tcx> {
                     base.ty(self.mir, self.infcx.tcx).to_ty(self.infcx.tcx),
                     field,
                 ) {
-                    err.span_suggestion_with_applicability(
+                    err.span_suggestion(
                         span,
                         "consider changing this to be mutable",
                         message,
@@ -285,7 +285,7 @@ impl<'a, 'gcx, 'tcx> MirBorrowckCtxt<'a, 'gcx, 'tcx> {
                 assert_eq!(local_decl.mutability, Mutability::Not);
 
                 err.span_label(span, format!("cannot {ACT}", ACT = act));
-                err.span_suggestion_with_applicability(
+                err.span_suggestion(
                     local_decl.source_info.span,
                     "consider changing this to be mutable",
                     format!("mut {}", local_decl.name.unwrap()),
@@ -316,7 +316,7 @@ impl<'a, 'gcx, 'tcx> MirBorrowckCtxt<'a, 'gcx, 'tcx> {
                         _,
                     ) = pat.node
                     {
-                        err.span_suggestion_with_applicability(
+                        err.span_suggestion(
                             upvar_ident.span,
                             "consider changing this to be mutable",
                             format!("mut {}", upvar_ident.name),
@@ -410,7 +410,7 @@ impl<'a, 'gcx, 'tcx> MirBorrowckCtxt<'a, 'gcx, 'tcx> {
                 };
 
                 if let Some((err_help_span, suggested_code)) = suggestion {
-                    err.span_suggestion_with_applicability(
+                    err.span_suggestion(
                         err_help_span,
                         &format!("consider changing this to be a mutable {}", pointer_desc),
                         suggested_code,

--- a/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/mod.rs
@@ -626,7 +626,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                             "'_".to_string()
                         };
 
-                        diag.span_suggestion_with_applicability(
+                        diag.span_suggestion(
                             span,
                             &format!(
                                 "to allow this impl Trait to capture borrowed data with lifetime \

--- a/src/librustc_mir/hair/pattern/check_match.rs
+++ b/src/librustc_mir/hair/pattern/check_match.rs
@@ -313,7 +313,7 @@ fn check_for_bindings_named_same_as_variants(cx: &MatchVisitor, pat: &Pat) {
                             "pattern binding `{}` is named the same as one \
                             of the variants of the type `{}`",
                             ident, ty_path);
-                        err.span_suggestion_with_applicability(
+                        err.span_suggestion(
                             p.span,
                             "to match on the variant, qualify the path",
                             format!("{}::{}", ty_path, ident),

--- a/src/librustc_passes/ast_validation.rs
+++ b/src/librustc_passes/ast_validation.rs
@@ -237,7 +237,7 @@ impl<'a> AstValidator<'a> {
             );
 
             if let Ok(snippet) = self.session.source_map().span_to_snippet(span) {
-                err.span_suggestion_with_applicability(
+                err.span_suggestion(
                     span, "consider adding parentheses", format!("({})", snippet),
                     Applicability::MachineApplicable,
                 );
@@ -290,7 +290,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                 );
                 match val.node {
                     ExprKind::Lit(ref v) if v.node.is_numeric() => {
-                        err.span_suggestion_with_applicability(
+                        err.span_suggestion(
                             place.span.between(val.span),
                             "if you meant to write a comparison against a negative value, add a \
                              space in between `<` and `-`",

--- a/src/librustc_passes/loops.rs
+++ b/src/librustc_passes/loops.rs
@@ -140,7 +140,7 @@ impl<'a, 'hir> Visitor<'hir> for CheckLoopVisitor<'a, 'hir> {
                                 .span_label(e.span,
                                             "can only break with a value inside \
                                             `loop` or breakable block")
-                                .span_suggestion_with_applicability(
+                                .span_suggestion(
                                     e.span,
                                     &format!(
                                         "instead, use `break` on its own \

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -347,7 +347,7 @@ impl<'a> Resolver<'a> {
                 let module = if orig_name.is_none() && ident.name == keywords::SelfLower.name() {
                     self.session
                         .struct_span_err(item.span, "`extern crate self;` requires renaming")
-                        .span_suggestion_with_applicability(
+                        .span_suggestion(
                             item.span,
                             "try",
                             "extern crate self as name;".into(),

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -247,7 +247,7 @@ fn resolve_struct_error<'sess, 'a>(resolver: &'sess Resolver,
             let sugg_msg = "try using a local type parameter instead";
             if let Some((sugg_span, new_snippet)) = cm.generate_local_type_param_snippet(span) {
                 // Suggest the modification to the user
-                err.span_suggestion_with_applicability(
+                err.span_suggestion(
                     sugg_span,
                     sugg_msg,
                     new_snippet,
@@ -3175,7 +3175,7 @@ impl<'a> Resolver<'a> {
             // Emit help message for fake-self from other languages like `this`(javascript)
             if ["this", "my"].contains(&&*item_str.as_str())
                 && this.self_value_is_available(path[0].ident.span, span) {
-                err.span_suggestion_with_applicability(
+                err.span_suggestion(
                     span,
                     "did you mean",
                     "self".to_string(),
@@ -3239,7 +3239,7 @@ impl<'a> Resolver<'a> {
                     };
                     let msg = format!("{}try using the variant's enum", preamble);
 
-                    err.span_suggestions_with_applicability(
+                    err.span_suggestions(
                         span,
                         &msg,
                         enum_candidates.into_iter()
@@ -3262,7 +3262,7 @@ impl<'a> Resolver<'a> {
                     let self_is_available = this.self_value_is_available(path[0].ident.span, span);
                     match candidate {
                         AssocSuggestion::Field => {
-                            err.span_suggestion_with_applicability(
+                            err.span_suggestion(
                                 span,
                                 "try",
                                 format!("self.{}", path_str),
@@ -3275,7 +3275,7 @@ impl<'a> Resolver<'a> {
                             }
                         }
                         AssocSuggestion::MethodWithSelf if self_is_available => {
-                            err.span_suggestion_with_applicability(
+                            err.span_suggestion(
                                 span,
                                 "try",
                                 format!("self.{}", path_str),
@@ -3283,7 +3283,7 @@ impl<'a> Resolver<'a> {
                             );
                         }
                         AssocSuggestion::MethodWithSelf | AssocSuggestion::AssocItem => {
-                            err.span_suggestion_with_applicability(
+                            err.span_suggestion(
                                 span,
                                 "try",
                                 format!("Self::{}", path_str),
@@ -3304,7 +3304,7 @@ impl<'a> Resolver<'a> {
                     "{} {} with a similar name exists",
                     suggestion.article, suggestion.kind
                 );
-                err.span_suggestion_with_applicability(
+                err.span_suggestion(
                     ident_span,
                     &msg,
                     suggestion.candidate.to_string(),
@@ -3318,7 +3318,7 @@ impl<'a> Resolver<'a> {
             if let Some(def) = def {
                 match (def, source) {
                     (Def::Macro(..), _) => {
-                        err.span_suggestion_with_applicability(
+                        err.span_suggestion(
                             span,
                             "use `!` to invoke the macro",
                             format!("{}!", path_str),
@@ -3335,7 +3335,7 @@ impl<'a> Resolver<'a> {
                     }
                     (Def::Mod(..), PathSource::Expr(Some(parent))) => match parent.node {
                         ExprKind::Field(_, ident) => {
-                            err.span_suggestion_with_applicability(
+                            err.span_suggestion(
                                 parent.span,
                                 "use the path separator to refer to an item",
                                 format!("{}::{}", path_str, ident),
@@ -3345,7 +3345,7 @@ impl<'a> Resolver<'a> {
                         }
                         ExprKind::MethodCall(ref segment, ..) => {
                             let span = parent.span.with_hi(segment.ident.span.hi());
-                            err.span_suggestion_with_applicability(
+                            err.span_suggestion(
                                 span,
                                 "use the path separator to refer to an item",
                                 format!("{}::{}", path_str, segment.ident),
@@ -3428,7 +3428,7 @@ impl<'a> Resolver<'a> {
                                 PathSource::Expr(Some(parent)) => {
                                     match parent.node {
                                         ExprKind::MethodCall(ref path_assignment, _)  => {
-                                            err.span_suggestion_with_applicability(
+                                            err.span_suggestion(
                                                 sm.start_point(parent.span)
                                                   .to(path_assignment.ident.span),
                                                 "use `::` to access an associated function",
@@ -3451,7 +3451,7 @@ impl<'a> Resolver<'a> {
                                 },
                                 PathSource::Expr(None) if followed_by_brace == true => {
                                     if let Some((sp, snippet)) = closing_brace {
-                                        err.span_suggestion_with_applicability(
+                                        err.span_suggestion(
                                             sp,
                                             "surround the struct literal with parenthesis",
                                             format!("({})", snippet),
@@ -3589,7 +3589,7 @@ impl<'a> Resolver<'a> {
                         err.span_label(base_span,
                                        "expecting a type here because of type ascription");
                         if line_sp != line_base_sp {
-                            err.span_suggestion_short_with_applicability(
+                            err.span_suggestion_short(
                                 sp,
                                 "did you mean to use `;` here instead?",
                                 ";".to_string(),
@@ -4866,7 +4866,7 @@ impl<'a> Resolver<'a> {
                 } else if ident.span.rust_2018() {
                     let msg = "relative paths are not supported in visibilities on 2018 edition";
                     self.session.struct_span_err(ident.span, msg)
-                        .span_suggestion_with_applicability(
+                        .span_suggestion(
                             path.span,
                             "try",
                             format!("crate::{}", path),
@@ -5179,7 +5179,7 @@ impl<'a> Resolver<'a> {
 
             let rename_msg = "you can use `as` to change the binding name of the import";
             if let Some(suggestion) = suggestion {
-                err.span_suggestion_with_applicability(
+                err.span_suggestion(
                     binding_span,
                     rename_msg,
                     suggestion,
@@ -5302,7 +5302,7 @@ fn show_candidates(err: &mut DiagnosticBuilder,
             *candidate = format!("use {};\n{}", candidate, additional_newline);
         }
 
-        err.span_suggestions_with_applicability(
+        err.span_suggestions(
             span,
             &msg,
             path_strings.into_iter(),

--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -1021,14 +1021,14 @@ impl<'a> Resolver<'a> {
         if let Some(suggestion) = suggestion {
             if suggestion != name {
                 if let MacroKind::Bang = kind {
-                    err.span_suggestion_with_applicability(
+                    err.span_suggestion(
                         span,
                         "you could try the macro",
                         suggestion.to_string(),
                         Applicability::MaybeIncorrect
                     );
                 } else {
-                    err.span_suggestion_with_applicability(
+                    err.span_suggestion(
                         span,
                         "try",
                         suggestion.to_string(),

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1096,7 +1096,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> dyn AstConv<'gcx, 'tcx> + 'o {
             if !suggestions.is_empty() {
                 let msg = format!("if you meant to specify the associated {}, write",
                     if suggestions.len() == 1 { "type" } else { "types" });
-                err.multipart_suggestion_with_applicability(
+                err.multipart_suggestion(
                     &msg,
                     suggestions,
                     Applicability::MaybeIncorrect,
@@ -1172,7 +1172,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> dyn AstConv<'gcx, 'tcx> + 'o {
                                         trait_str: &str,
                                         name: &str) {
         struct_span_err!(self.tcx().sess, span, E0223, "ambiguous associated type")
-            .span_suggestion_with_applicability(
+            .span_suggestion(
                 span,
                 "use fully-qualified syntax",
                 format!("<{} as {}>::{}", type_str, trait_str, name),
@@ -1353,7 +1353,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> dyn AstConv<'gcx, 'tcx> + 'o {
                         &assoc_ident.as_str(),
                         None,
                     ) {
-                        err.span_suggestion_with_applicability(
+                        err.span_suggestion(
                             span,
                             "did you mean",
                             format!("{}::{}", qself_ty, suggested_name),
@@ -1407,7 +1407,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> dyn AstConv<'gcx, 'tcx> + 'o {
             could_refer_to(variant_def, "");
             could_refer_to(def, " also");
 
-            err.span_suggestion_with_applicability(
+            err.span_suggestion(
                 span,
                 "use fully-qualified syntax",
                 format!("<{} as {}>::{}", qself_ty, "Trait", assoc_ident),

--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -990,7 +990,7 @@ https://doc.rust-lang.org/reference/types.html#trait-objects");
                     let suggested_name =
                         find_best_match_for_name(input, &ident.as_str(), None);
                     if let Some(suggested_name) = suggested_name {
-                        err.span_suggestion_with_applicability(
+                        err.span_suggestion(
                             *span,
                             "did you mean",
                             suggested_name.to_string(),

--- a/src/librustc_typeck/check/callee.rs
+++ b/src/librustc_typeck/check/callee.rs
@@ -269,7 +269,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                     );
 
                     if let Some(ref path) = unit_variant {
-                        err.span_suggestion_with_applicability(
+                        err.span_suggestion(
                             call_expr.span,
                             &format!(
                                 "`{}` is a unit variant, you need to write it \
@@ -294,7 +294,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                 self.tcx.sess.source_map().is_multiline(call_expr.span);
                             if call_is_multiline {
                                 let span = self.tcx.sess.source_map().next_point(callee.span);
-                                err.span_suggestion_with_applicability(
+                                err.span_suggestion(
                                     span,
                                     "try adding a semicolon",
                                     ";".to_owned(),

--- a/src/librustc_typeck/check/cast.rs
+++ b/src/librustc_typeck/check/cast.rs
@@ -213,7 +213,7 @@ impl<'a, 'gcx, 'tcx> CastCheck<'tcx> {
                                        fcx.ty_to_string(self.expr_ty),
                                        cast_ty));
                 if let Ok(snippet) = fcx.sess().source_map().span_to_snippet(self.expr.span) {
-                    err.span_suggestion_with_applicability(
+                    err.span_suggestion(
                         self.expr.span,
                         "dereference the expression",
                         format!("*{}", snippet),
@@ -263,7 +263,7 @@ impl<'a, 'gcx, 'tcx> CastCheck<'tcx> {
                 if self.expr_ty.is_numeric() {
                     match fcx.tcx.sess.source_map().span_to_snippet(self.expr.span) {
                         Ok(snippet) => {
-                            err.span_suggestion_with_applicability(
+                            err.span_suggestion(
                                 self.span,
                                 "compare with zero instead",
                                 format!("{} != 0", snippet),
@@ -314,7 +314,7 @@ impl<'a, 'gcx, 'tcx> CastCheck<'tcx> {
                 err.note("The type information given here is insufficient to check whether \
                           the pointer cast is valid");
                 if unknown_cast_to {
-                    err.span_suggestion_short_with_applicability(
+                    err.span_suggestion_short(
                         self.cast_span,
                         "consider giving more type information",
                         String::new(),
@@ -345,7 +345,7 @@ impl<'a, 'gcx, 'tcx> CastCheck<'tcx> {
                 if self.cast_ty.is_trait() {
                     match fcx.tcx.sess.source_map().span_to_snippet(self.cast_span) {
                         Ok(s) => {
-                            err.span_suggestion_with_applicability(
+                            err.span_suggestion(
                                 self.cast_span,
                                 "try casting to a reference instead",
                                 format!("&{}{}", mtstr, s),
@@ -367,7 +367,7 @@ impl<'a, 'gcx, 'tcx> CastCheck<'tcx> {
             ty::Adt(def, ..) if def.is_box() => {
                 match fcx.tcx.sess.source_map().span_to_snippet(self.cast_span) {
                     Ok(s) => {
-                        err.span_suggestion_with_applicability(
+                        err.span_suggestion(
                             self.cast_span,
                             "try casting to a `Box` instead",
                             format!("Box<{}>", s),

--- a/src/librustc_typeck/check/compare_method.rs
+++ b/src/librustc_typeck/check/compare_method.rs
@@ -316,7 +316,7 @@ fn compare_predicate_entailment<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                 if let Some(trait_err_span) = trait_err_span {
                     if let Ok(trait_err_str) = tcx.sess.source_map()
                                                        .span_to_snippet(trait_err_span) {
-                        diag.span_suggestion_with_applicability(
+                        diag.span_suggestion(
                             impl_err_span,
                             "consider change the type to match the mutability in trait",
                             trait_err_str,
@@ -784,7 +784,7 @@ fn compare_synthetic_generics<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                             .span_to_snippet(trait_m.generics.span)
                             .ok()?;
 
-                        err.multipart_suggestion_with_applicability(
+                        err.multipart_suggestion(
                             "try changing the `impl Trait` argument to a generic parameter",
                             vec![
                                 // replace `impl Trait` with `T`
@@ -855,7 +855,7 @@ fn compare_synthetic_generics<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                             .span_to_snippet(bounds)
                             .ok()?;
 
-                        err.multipart_suggestion_with_applicability(
+                        err.multipart_suggestion(
                             "try removing the generic parameter and using `impl Trait` instead",
                             vec![
                                 // delete generic parameters

--- a/src/librustc_typeck/check/demand.rs
+++ b/src/librustc_typeck/check/demand.rs
@@ -143,7 +143,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                     let expr_text = print::to_string(print::NO_ANN, |s| s.print_expr(expr));
                     let suggestions = compatible_variants
                         .map(|v| format!("{}({})", v, expr_text));
-                    err.span_suggestions_with_applicability(
+                    err.span_suggestions(
                         expr.span,
                         "try using a variant of the expected type",
                         suggestions,
@@ -558,7 +558,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                     if needs_paren { ")" } else { "" },
                 );
 
-                err.span_suggestion_with_applicability(
+                err.span_suggestion(
                     expr.span,
                     &suggest_msg,
                     if literal_is_ty_suffixed(expr) {
@@ -575,7 +575,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                     match (found.bit_width(), exp.bit_width()) {
                         (Some(found), Some(exp)) if found > exp => {
                             if can_cast {
-                                err.span_suggestion_with_applicability(
+                                err.span_suggestion(
                                     expr.span,
                                     &format!("{}, which {}", msg, will_truncate),
                                     cast_suggestion,
@@ -585,7 +585,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                         }
                         (None, _) | (_, None) => {
                             if can_cast {
-                                err.span_suggestion_with_applicability(
+                                err.span_suggestion(
                                     expr.span,
                                     &format!("{}, which {}", msg, depending_on_isize),
                                     cast_suggestion,
@@ -606,7 +606,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                     match (found.bit_width(), exp.bit_width()) {
                         (Some(found), Some(exp)) if found > exp => {
                             if can_cast {
-                                err.span_suggestion_with_applicability(
+                                err.span_suggestion(
                                     expr.span,
                                     &format!("{}, which {}", msg, will_truncate),
                                     cast_suggestion,
@@ -616,7 +616,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                         }
                         (None, _) | (_, None) => {
                             if can_cast {
-                                err.span_suggestion_with_applicability(
+                                err.span_suggestion(
                                     expr.span,
                                     &format!("{}, which {}", msg, depending_on_usize),
                                     cast_suggestion,
@@ -637,7 +637,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                     if can_cast {
                         match (found.bit_width(), exp.bit_width()) {
                             (Some(found), Some(exp)) if found > exp - 1 => {
-                                err.span_suggestion_with_applicability(
+                                err.span_suggestion(
                                     expr.span,
                                     &format!("{}, which {}", msg, will_truncate),
                                     cast_suggestion,
@@ -645,7 +645,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                 );
                             }
                             (None, None) => {
-                                err.span_suggestion_with_applicability(
+                                err.span_suggestion(
                                     expr.span,
                                     &format!("{}, which {}", msg, will_truncate),
                                     cast_suggestion,
@@ -653,7 +653,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                 );
                             }
                             (None, _) => {
-                                err.span_suggestion_with_applicability(
+                                err.span_suggestion(
                                     expr.span,
                                     &format!("{}, which {}", msg, depending_on_isize),
                                     cast_suggestion,
@@ -661,7 +661,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                 );
                             }
                             (_, None) => {
-                                err.span_suggestion_with_applicability(
+                                err.span_suggestion(
                                     expr.span,
                                     &format!("{}, which {}", msg, depending_on_usize),
                                     cast_suggestion,
@@ -669,7 +669,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                 );
                             }
                             _ => {
-                                err.span_suggestion_with_applicability(
+                                err.span_suggestion(
                                     expr.span,
                                     &format!("{}, which {}", msg, will_zero_extend),
                                     cast_suggestion,
@@ -684,7 +684,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                     if can_cast {
                         match (found.bit_width(), exp.bit_width()) {
                             (Some(found), Some(exp)) if found - 1 > exp => {
-                                err.span_suggestion_with_applicability(
+                                err.span_suggestion(
                                     expr.span,
                                     &format!("{}, which {}", msg, will_truncate),
                                     cast_suggestion,
@@ -692,7 +692,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                 );
                             }
                             (None, None) => {
-                                err.span_suggestion_with_applicability(
+                                err.span_suggestion(
                                     expr.span,
                                     &format!("{}, which {}", msg, will_sign_extend),
                                     cast_suggestion,
@@ -700,7 +700,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                 );
                             }
                             (None, _) => {
-                                err.span_suggestion_with_applicability(
+                                err.span_suggestion(
                                     expr.span,
                                     &format!("{}, which {}", msg, depending_on_usize),
                                     cast_suggestion,
@@ -708,7 +708,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                 );
                             }
                             (_, None) => {
-                                err.span_suggestion_with_applicability(
+                                err.span_suggestion(
                                     expr.span,
                                     &format!("{}, which {}", msg, depending_on_isize),
                                     cast_suggestion,
@@ -716,7 +716,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                 );
                             }
                             _ => {
-                                err.span_suggestion_with_applicability(
+                                err.span_suggestion(
                                     expr.span,
                                     &format!("{}, which {}", msg, will_sign_extend),
                                     cast_suggestion,
@@ -734,7 +734,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                            None,
                        );
                     } else if can_cast {
-                        err.span_suggestion_with_applicability(
+                        err.span_suggestion(
                             expr.span,
                             &format!("{}, producing the closest possible value", msg),
                             cast_suggestion,
@@ -745,7 +745,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 }
                 (&ty::Uint(_), &ty::Float(_)) | (&ty::Int(_), &ty::Float(_)) => {
                     if can_cast {
-                        err.span_suggestion_with_applicability(
+                        err.span_suggestion(
                             expr.span,
                             &format!("{}, rounding the float towards zero", msg),
                             cast_suggestion,
@@ -760,7 +760,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 (&ty::Float(ref exp), &ty::Uint(ref found)) => {
                     // if `found` is `None` (meaning found is `usize`), don't suggest `.into()`
                     if exp.bit_width() > found.bit_width().unwrap_or(256) {
-                        err.span_suggestion_with_applicability(
+                        err.span_suggestion(
                             expr.span,
                             &format!("{}, producing the floating point representation of the \
                                       integer",
@@ -769,7 +769,8 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                             Applicability::MachineApplicable
                         );
                     } else if can_cast {
-                        err.span_suggestion_with_applicability(expr.span,
+                        err.span_suggestion(
+                            expr.span,
                             &format!("{}, producing the floating point representation of the \
                                       integer, rounded if necessary",
                                      msg),
@@ -782,7 +783,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 (&ty::Float(ref exp), &ty::Int(ref found)) => {
                     // if `found` is `None` (meaning found is `isize`), don't suggest `.into()`
                     if exp.bit_width() > found.bit_width().unwrap_or(256) {
-                        err.span_suggestion_with_applicability(
+                        err.span_suggestion(
                             expr.span,
                             &format!("{}, producing the floating point representation of the \
                                       integer",
@@ -791,7 +792,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                             Applicability::MachineApplicable
                         );
                     } else if can_cast {
-                        err.span_suggestion_with_applicability(
+                        err.span_suggestion(
                             expr.span,
                             &format!("{}, producing the floating point representation of the \
                                       integer, rounded if necessary",

--- a/src/librustc_typeck/check/method/mod.rs
+++ b/src/librustc_typeck/check/method/mod.rs
@@ -157,7 +157,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
             (format!("{}()", method_name), Applicability::MaybeIncorrect)
         };
 
-        err.span_suggestion_with_applicability(method_name.span, msg, suggestion, applicability);
+        err.span_suggestion(method_name.span, msg, suggestion, applicability);
     }
 
     /// Performs method lookup. If lookup is successful, it will return the callee

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -1144,7 +1144,7 @@ impl<'a, 'gcx, 'tcx> ProbeContext<'a, 'gcx, 'tcx> {
             "a method with this name may be added to the standard library in the future",
         );
 
-        // FIXME: This should be a `span_suggestion_with_applicability` instead of `help`
+        // FIXME: This should be a `span_suggestion` instead of `help`
         // However `self.span` only
         // highlights the method name, so we can't use it. Also consider reusing the code from
         // `report_method_error()`.

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -237,15 +237,12 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                 let snippet = tcx.sess.source_map().span_to_snippet(lit.span)
                                     .unwrap_or_else(|_| "<numeric literal>".to_owned());
 
-                                err.span_suggestion_with_applicability(
-                                                    lit.span,
-                                                    &format!("you must specify a concrete type for \
-                                                              this numeric value, like `{}`",
-                                                             concrete_type),
-                                                    format!("{}_{}",
-                                                            snippet,
-                                                            concrete_type),
-                                                    Applicability::MaybeIncorrect,
+                                err.span_suggestion(
+                                    lit.span,
+                                    &format!("you must specify a concrete type for \
+                                              this numeric value, like `{}`", concrete_type),
+                                    format!("{}_{}", snippet, concrete_type),
+                                    Applicability::MaybeIncorrect,
                                 );
                             }
                             ExprKind::Path(ref qpath) => {
@@ -271,7 +268,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                                 ty,
                                                 ..
                                             })) => {
-                                                err.span_suggestion_with_applicability(
+                                                err.span_suggestion(
                                                     // account for `let x: _ = 42;`
                                                     //                  ^^^^
                                                     span.to(ty.as_ref().map(|ty| ty.span)
@@ -304,7 +301,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                         );
                         if let Some(suggestion) = suggestion {
                             // enum variant
-                            err.span_suggestion_with_applicability(
+                            err.span_suggestion(
                                 item_name.span,
                                 "did you mean",
                                 suggestion.to_string(),
@@ -404,7 +401,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 }
                 if static_sources.len() == 1 {
                     if let SelfSource::MethodCall(expr) = source {
-                        err.span_suggestion_with_applicability(expr.span.to(span),
+                        err.span_suggestion(expr.span.to(span),
                                             "use associated function syntax instead",
                                             format!("{}::{}",
                                                     self.ty_to_string(actual),
@@ -445,7 +442,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 }
 
                 if let Some(lev_candidate) = lev_candidate {
-                    err.span_suggestion_with_applicability(
+                    err.span_suggestion(
                         span,
                         "did you mean",
                         lev_candidate.ident.to_string(),
@@ -522,12 +519,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 )
             });
 
-            err.span_suggestions_with_applicability(
-                                                    span,
-                                                    &msg,
-                                                    path_strings,
-                                                    Applicability::MaybeIncorrect,
-            );
+            err.span_suggestions(span, &msg, path_strings, Applicability::MaybeIncorrect);
         } else {
             let limit = if candidates.len() == 5 { 5 } else { 4 };
             for (i, trait_did) in candidates.iter().take(limit).enumerate() {

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -2903,7 +2903,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 let sugg_span = tcx.sess.source_map().end_point(expr_sp);
                 // remove closing `)` from the span
                 let sugg_span = sugg_span.shrink_to_lo();
-                err.span_suggestion_with_applicability(
+                err.span_suggestion(
                     sugg_span,
                     "expected the unit value `()`; create it with empty parentheses",
                     String::from("()"),
@@ -3170,7 +3170,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                     self.tcx.sess.source_map().span_to_snippet(lhs.span),
                     self.tcx.sess.source_map().span_to_snippet(rhs.span))
                 {
-                    err.span_suggestion_with_applicability(
+                    err.span_suggestion(
                         expr.span,
                         msg,
                         format!("{} == {}", left, right),
@@ -3587,7 +3587,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                         if let Some(suggested_field_name) =
                             Self::suggest_field_name(def.non_enum_variant(),
                                                      &field.as_str(), vec![]) {
-                                err.span_suggestion_with_applicability(
+                                err.span_suggestion(
                                     field.span,
                                     "a field with a similar name exists",
                                     suggested_field_name.to_string(),
@@ -3618,7 +3618,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                             } else {
                                 Applicability::MaybeIncorrect
                             };
-                            err.span_suggestion_with_applicability(
+                            err.span_suggestion(
                                 expr.span, help, suggestion, applicability
                             );
                         }
@@ -3629,7 +3629,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                             .unwrap_or_else(|_| self.tcx.hir().node_to_pretty_string(base.id));
                         let msg = format!("`{}` is a raw pointer; try dereferencing it", base);
                         let suggestion = format!("(*{}).{}", base, field);
-                        err.span_suggestion_with_applicability(
+                        err.span_suggestion(
                             expr.span,
                             &msg,
                             suggestion,
@@ -3719,12 +3719,12 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         if let Some(field_name) = Self::suggest_field_name(variant,
                                                            &field.ident.as_str(),
                                                            skip_fields.collect()) {
-            err.span_suggestion_with_applicability(
-                    field.ident.span,
-                    "a field with a similar name exists",
-                    field_name.to_string(),
-                    Applicability::MaybeIncorrect,
-                );
+            err.span_suggestion(
+                field.ident.span,
+                "a field with a similar name exists",
+                field_name.to_string(),
+                Applicability::MaybeIncorrect,
+            );
         } else {
             match ty.sty {
                 ty::Adt(adt, ..) => {
@@ -4670,11 +4670,12 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                             ast::LitIntType::Unsuffixed) = lit.node {
                                         let snip = tcx.sess.source_map().span_to_snippet(base.span);
                                         if let Ok(snip) = snip {
-                                            err.span_suggestion_with_applicability(
+                                            err.span_suggestion(
                                                 expr.span,
                                                 "to access tuple elements, use",
                                                 format!("{}.{}", snip, i),
-                                                Applicability::MachineApplicable);
+                                                Applicability::MachineApplicable,
+                                            );
                                             needs_note = false;
                                         }
                                     }
@@ -5106,7 +5107,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         found: Ty<'tcx>,
     ) {
         if let Some((sp, msg, suggestion)) = self.check_ref(expr, found, expected) {
-            err.span_suggestion_with_applicability(
+            err.span_suggestion(
                 sp,
                 msg,
                 suggestion,
@@ -5133,7 +5134,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                         }
                     }).peekable();
                 if suggestions.peek().is_some() {
-                    err.span_suggestions_with_applicability(
+                    err.span_suggestions(
                         expr.span,
                         "try using a conversion method",
                         suggestions,
@@ -5172,7 +5173,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 ExprKind::Match(..) |
                 ExprKind::Block(..) => {
                     let sp = self.tcx.sess.source_map().next_point(cause_span);
-                    err.span_suggestion_with_applicability(
+                    err.span_suggestion(
                         sp,
                         "try adding a semicolon",
                         ";".to_string(),
@@ -5206,7 +5207,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         // haven't set a return type at all (and aren't `fn main()` or an impl).
         match (&fn_decl.output, found.is_suggestable(), can_suggest, expected.is_unit()) {
             (&hir::FunctionRetTy::DefaultReturn(span), true, true, true) => {
-                err.span_suggestion_with_applicability(
+                err.span_suggestion(
                     span,
                     "try adding a return type",
                     format!("-> {} ", self.resolve_type_vars_with_obligations(found)),
@@ -5260,7 +5261,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         err: &mut DiagnosticBuilder,
     ) {
         if let Some(span_semi) = self.could_remove_semicolon(blk, expected_ty) {
-            err.span_suggestion_with_applicability(
+            err.span_suggestion(
                 span_semi,
                 "consider removing this semicolon",
                 String::new(),
@@ -5436,7 +5437,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                 },
                                 AdtKind::Struct |
                                 AdtKind::Union => {
-                                    err.span_suggestion_with_applicability(
+                                    err.span_suggestion(
                                         span,
                                         "use curly brackets",
                                         String::from("Self { /* fields */ }"),

--- a/src/librustc_typeck/check/op.rs
+++ b/src/librustc_typeck/check/op.rs
@@ -280,7 +280,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                             rty,
                                             lstring,
                                         );
-                                        err.span_suggestion_with_applicability(
+                                        err.span_suggestion(
                                             lhs_expr.span,
                                             msg,
                                             format!("*{}", lstring),
@@ -434,7 +434,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                     err.span_label(expr.span,
                                    "`+` can't be used to concatenate two `&str` strings");
                     match source_map.span_to_snippet(lhs_expr.span) {
-                        Ok(lstring) => err.span_suggestion_with_applicability(
+                        Ok(lstring) => err.span_suggestion(
                             lhs_expr.span,
                             msg,
                             format!("{}.to_owned()", lstring),
@@ -455,7 +455,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                     is_assign,
                 ) {
                     (Ok(l), Ok(r), false) => {
-                        err.multipart_suggestion_with_applicability(
+                        err.multipart_suggestion(
                             msg,
                             vec![
                                 (lhs_expr.span, format!("{}.to_owned()", l)),

--- a/src/librustc_typeck/check_unused.rs
+++ b/src/librustc_typeck/check_unused.rs
@@ -136,7 +136,7 @@ fn unused_crates_lint<'tcx>(tcx: TyCtxt<'_, 'tcx, 'tcx>) {
                     .fold(span, |acc, attr_span| acc.to(attr_span));
 
                 tcx.struct_span_lint_node(lint, id, span, msg)
-                    .span_suggestion_short_with_applicability(
+                    .span_suggestion_short(
                         span_with_attrs,
                         "remove it",
                         String::new(),
@@ -178,7 +178,7 @@ fn unused_crates_lint<'tcx>(tcx: TyCtxt<'_, 'tcx, 'tcx>) {
         };
         let replacement = visibility_qualified(&item.vis, base_replacement);
         tcx.struct_span_lint_node(lint, id, extern_crate.span, msg)
-            .span_suggestion_short_with_applicability(
+            .span_suggestion_short(
                 extern_crate.span,
                 &help,
                 replacement,

--- a/src/librustc_typeck/structured_errors.rs
+++ b/src/librustc_typeck/structured_errors.rs
@@ -63,7 +63,7 @@ impl<'tcx> StructuredDiagnostic<'tcx> for VariadicError<'tcx> {
             )
         };
         if let Ok(snippet) = self.sess.source_map().span_to_snippet(self.span) {
-            err.span_suggestion_with_applicability(
+            err.span_suggestion(
                 self.span,
                 &format!("cast the value to `{}`", self.cast_ty),
                 format!("{} as {}", snippet, self.cast_ty),

--- a/src/librustdoc/passes/check_code_block_syntax.rs
+++ b/src/librustdoc/passes/check_code_block_syntax.rs
@@ -62,7 +62,7 @@ impl<'a, 'tcx, 'rcx> SyntaxChecker<'a, 'tcx, 'rcx> {
 
                 if code_block.syntax.is_none() && code_block.is_fenced {
                     let sp = sp.from_inner_byte_pos(0, 3);
-                    diag.span_suggestion_with_applicability(
+                    diag.span_suggestion(
                         sp,
                         "mark blocks that do not contain Rust code as text",
                         String::from("```text"),

--- a/src/libsyntax/attr/builtin.rs
+++ b/src/libsyntax/attr/builtin.rs
@@ -42,7 +42,7 @@ fn handle_errors(sess: &ParseSess, span: Span, error: AttrError) {
             let mut err = struct_span_err!(diag, span, E0565, "{}", msg);
             if is_bytestr {
                 if let Ok(lint_str) = sess.source_map().span_to_snippet(span) {
-                    err.span_suggestion_with_applicability(
+                    err.span_suggestion(
                         span,
                         "consider removing the prefix",
                         format!("{}", &lint_str[1..]),
@@ -794,7 +794,7 @@ pub fn find_repr_attrs(sess: &ParseSess, attr: &Attribute) -> Vec<ReprAttr> {
                                     "incorrect `repr(align)` attribute format");
                                 match value.node {
                                     ast::LitKind::Int(int, ast::LitIntType::Unsuffixed) => {
-                                        err.span_suggestion_with_applicability(
+                                        err.span_suggestion(
                                             item.span,
                                             "use parentheses instead",
                                             format!("align({})", int),
@@ -802,7 +802,7 @@ pub fn find_repr_attrs(sess: &ParseSess, attr: &Attribute) -> Vec<ReprAttr> {
                                         );
                                     }
                                     ast::LitKind::Str(s, _) => {
-                                        err.span_suggestion_with_applicability(
+                                        err.span_suggestion(
                                             item.span,
                                             "use parentheses instead",
                                             format!("align({})", s),

--- a/src/libsyntax/config.rs
+++ b/src/libsyntax/config.rs
@@ -155,7 +155,7 @@ impl<'a> StripUnconfigured<'a> {
             let error = |span, msg, suggestion: &str| {
                 let mut err = self.sess.span_diagnostic.struct_span_err(span, msg);
                 if !suggestion.is_empty() {
-                    err.span_suggestion_with_applicability(
+                    err.span_suggestion(
                         span,
                         "expected syntax is",
                         suggestion.into(),

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -361,7 +361,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                             let trait_list = traits.iter()
                                 .map(|t| t.to_string()).collect::<Vec<_>>();
                             let suggestion = format!("#[derive({})]", trait_list.join(", "));
-                            err.span_suggestion_with_applicability(
+                            err.span_suggestion(
                                 span, "try an outer attribute", suggestion,
                                 // We don't 𝑘𝑛𝑜𝑤 that the following item is an ADT
                                 Applicability::MaybeIncorrect
@@ -1043,7 +1043,7 @@ impl<'a> Parser<'a> {
             let semi_full_span = semi_span.to(self.sess.source_map().next_point(semi_span));
             match self.sess.source_map().span_to_snippet(semi_full_span) {
                 Ok(ref snippet) if &snippet[..] != ";" && kind_name == "expression" => {
-                    err.span_suggestion_with_applicability(
+                    err.span_suggestion(
                         semi_span,
                         "you might be missing a semicolon here",
                         ";".to_owned(),
@@ -1574,7 +1574,7 @@ impl<'a, 'b> Folder for InvocationCollector<'a, 'b> {
                         _ => (String::from("<path>"), Applicability::HasPlaceholders),
                     };
 
-                    err.span_suggestion_with_applicability(
+                    err.span_suggestion(
                         it.span,
                         "provide a file path with `=`",
                         format!("include = \"{}\"", path),

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -221,7 +221,7 @@ fn generic_extension<'cx>(cx: &'cx mut ExtCtxt,
                     if comma_span.is_dummy() {
                         err.note("you might be missing a comma");
                     } else {
-                        err.span_suggestion_short_with_applicability(
+                        err.span_suggestion_short(
                             comma_span,
                             "missing comma here",
                             ", ".to_string(),

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -949,7 +949,7 @@ impl<'a> StringReader<'a> {
                                     }
                                     if i != 0 {
                                         suggestion.push('}');
-                                        err.span_suggestion_with_applicability(
+                                        err.span_suggestion(
                                             self.mk_sp(start, self.pos),
                                             "format of unicode escape sequences uses braces",
                                             suggestion,
@@ -1427,7 +1427,7 @@ impl<'a> StringReader<'a> {
                             self.sess.span_diagnostic
                                 .struct_span_err(span,
                                                  "character literal may only contain one codepoint")
-                                .span_suggestion_with_applicability(
+                                .span_suggestion(
                                     span,
                                     "if you meant to write a `str` literal, use double quotes",
                                     format!("\"{}\"", &self.src[start..end]),

--- a/src/libsyntax/parse/lexer/unicode_chars.rs
+++ b/src/libsyntax/parse/lexer/unicode_chars.rs
@@ -336,7 +336,7 @@ crate fn check_for_substitution<'a>(reader: &StringReader<'a>,
                 let msg =
                     format!("Unicode character '{}' ({}) looks like '{}' ({}), but it is not",
                             ch, u_name, ascii_char, ascii_name);
-                err.span_suggestion_with_applicability(
+                err.span_suggestion(
                     span,
                     &msg,
                     ascii_char.to_string(),

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -736,7 +736,7 @@ impl<'a> Parser<'a> {
             };
             let mut err = self.fatal(&msg_exp);
             if self.token.is_ident_named("and") {
-                err.span_suggestion_short_with_applicability(
+                err.span_suggestion_short(
                     self.span,
                     "use `&&` instead of `and` for the boolean operator",
                     "&&".to_string(),
@@ -744,7 +744,7 @@ impl<'a> Parser<'a> {
                 );
             }
             if self.token.is_ident_named("or") {
-                err.span_suggestion_short_with_applicability(
+                err.span_suggestion_short(
                     self.span,
                     "use `||` instead of `or` for the boolean operator",
                     "||".to_string(),
@@ -810,7 +810,7 @@ impl<'a> Parser<'a> {
             if ident.is_reserved() && !ident.is_path_segment_keyword() &&
                 ident.name != keywords::Underscore.name()
             {
-                err.span_suggestion_with_applicability(
+                err.span_suggestion(
                     self.span,
                     "you can escape reserved keywords to use them as identifiers",
                     format!("r#{}", ident),
@@ -823,7 +823,7 @@ impl<'a> Parser<'a> {
         } else {
             err.span_label(self.span, "expected identifier");
             if self.token == token::Comma && self.look_ahead(1, |t| t.is_ident()) {
-                err.span_suggestion_with_applicability(
+                err.span_suggestion(
                     self.span,
                     "remove this comma",
                     String::new(),
@@ -1696,7 +1696,7 @@ impl<'a> Parser<'a> {
         if !allow_plus && impl_dyn_multi {
             let sum_with_parens = format!("({})", pprust::ty_to_string(&ty));
             self.struct_span_err(ty.span, "ambiguous `+` in a type")
-                .span_suggestion_with_applicability(
+                .span_suggestion(
                     ty.span,
                     "use parentheses to disambiguate",
                     sum_with_parens,
@@ -1731,7 +1731,7 @@ impl<'a> Parser<'a> {
                     s.print_type_bounds(" +", &bounds)?;
                     s.pclose()
                 });
-                err.span_suggestion_with_applicability(
+                err.span_suggestion(
                     sum_span,
                     "try adding parentheses",
                     sum_with_parens,
@@ -1774,7 +1774,7 @@ impl<'a> Parser<'a> {
 
         self.diagnostic()
             .struct_span_err(span, "missing angle brackets in associated item path")
-            .span_suggestion_with_applicability( // this is a best-effort recovery
+            .span_suggestion( // this is a best-effort recovery
                 span, "try", recovered.to_string(), Applicability::MaybeIncorrect
             ).emit();
 
@@ -1878,7 +1878,7 @@ impl<'a> Parser<'a> {
                     let ident = self.parse_ident().unwrap();
                     let span = pat.span.with_hi(ident.span.hi());
 
-                    err.span_suggestion_with_applicability(
+                    err.span_suggestion(
                         span,
                         "declare the type after the parameter binding",
                         String::from("<identifier>: <type>"),
@@ -1886,7 +1886,7 @@ impl<'a> Parser<'a> {
                     );
                 } else if require_name && is_trait_item {
                     if let PatKind::Ident(_, ident, _) = pat.node {
-                        err.span_suggestion_with_applicability(
+                        err.span_suggestion(
                             pat.span,
                             "explicitly ignore parameter",
                             format!("_: {}", ident),
@@ -1937,7 +1937,7 @@ impl<'a> Parser<'a> {
                         "patterns aren't allowed in methods without bodies",
                         DiagnosticId::Error("E0642".into()),
                     );
-                    err.span_suggestion_short_with_applicability(
+                    err.span_suggestion_short(
                         pat.span,
                         "give this argument a name or use an underscore to ignore it",
                         "_".to_owned(),
@@ -2034,7 +2034,7 @@ impl<'a> Parser<'a> {
                     let sp = lo.to(self.prev_span);
                     let mut err = self.diagnostic()
                         .struct_span_err(sp, "float literals must have an integer part");
-                    err.span_suggestion_with_applicability(
+                    err.span_suggestion(
                         sp,
                         "must have an integer part",
                         format!("0.{}{}", val, suffix),
@@ -2365,7 +2365,7 @@ impl<'a> Parser<'a> {
             if self.token == token::Eq {
                 self.diagnostic()
                     .struct_span_err(self.span, "expected `:`, found `=`")
-                    .span_suggestion_with_applicability(
+                    .span_suggestion(
                         fieldname.span.shrink_to_hi().to(self.span),
                         "replace equals symbol with a colon",
                         ":".to_string(),
@@ -2751,7 +2751,7 @@ impl<'a> Parser<'a> {
                         exp_span.to(self.prev_span),
                         "cannot use a comma after the base struct",
                     );
-                    err.span_suggestion_short_with_applicability(
+                    err.span_suggestion_short(
                         self.span,
                         "remove this comma",
                         String::new(),
@@ -3019,7 +3019,7 @@ impl<'a> Parser<'a> {
                     span,
                     &format!("unmatched angle bracket{}", if plural { "s" } else { "" }),
                 )
-                .span_suggestion_with_applicability(
+                .span_suggestion(
                     span,
                     &format!("remove extra angle bracket{}", if plural { "s" } else { "" }),
                     String::new(),
@@ -3072,7 +3072,7 @@ impl<'a> Parser<'a> {
                             s.s.word(".")?;
                             s.s.word(fstr.splitn(2, ".").last().unwrap().to_string())
                         });
-                        err.span_suggestion_with_applicability(
+                        err.span_suggestion(
                             lo.to(self.prev_span),
                             "try parenthesizing the first index",
                             sugg,
@@ -3219,7 +3219,7 @@ impl<'a> Parser<'a> {
                 let span_of_tilde = lo;
                 let mut err = self.diagnostic()
                     .struct_span_err(span_of_tilde, "`~` cannot be used as a unary operator");
-                err.span_suggestion_short_with_applicability(
+                err.span_suggestion_short(
                     span_of_tilde,
                     "use `!` to perform bitwise negation",
                     "!".to_owned(),
@@ -3292,7 +3292,7 @@ impl<'a> Parser<'a> {
                     // trailing whitespace after the `!` in our suggestion
                     let to_replace = self.sess.source_map()
                         .span_until_non_whitespace(lo.to(self.span));
-                    err.span_suggestion_short_with_applicability(
+                    err.span_suggestion_short(
                         to_replace,
                         "use `!` to perform logical negation",
                         "!".to_owned(),
@@ -3393,7 +3393,7 @@ impl<'a> Parser<'a> {
                         let cur_pos = cm.lookup_char_pos(self.span.lo());
                         let op_pos = cm.lookup_char_pos(cur_op_span.hi());
                         if cur_pos.line != op_pos.line {
-                            err.span_suggestion_with_applicability(
+                            err.span_suggestion(
                                 cur_op_span,
                                 "try using a semicolon",
                                 ";".to_string(),
@@ -3552,7 +3552,7 @@ impl<'a> Parser<'a> {
 
                         let expr_str = self.sess.source_map().span_to_snippet(expr.span)
                                                 .unwrap_or_else(|_| pprust::expr_to_string(&expr));
-                        err.span_suggestion_with_applicability(
+                        err.span_suggestion(
                             expr.span,
                             &format!("try {} the cast value", op_verb),
                             format!("({})", expr_str),
@@ -3768,7 +3768,7 @@ impl<'a> Parser<'a> {
             let in_span = self.prev_span.between(self.span);
             let mut err = self.sess.span_diagnostic
                 .struct_span_err(in_span, "missing `in` in `for` loop");
-            err.span_suggestion_short_with_applicability(
+            err.span_suggestion_short(
                 in_span, "try adding `in` here", " in ".into(),
                 // has been misleading, at least in the past (closed Issue #48492)
                 Applicability::MaybeIncorrect
@@ -3782,7 +3782,7 @@ impl<'a> Parser<'a> {
                 self.prev_span,
                 "expected iterable, found keyword `in`",
             );
-            err.span_suggestion_short_with_applicability(
+            err.span_suggestion_short(
                 in_span.until(self.prev_span),
                 "remove the duplicated `in`",
                 String::new(),
@@ -3874,7 +3874,7 @@ impl<'a> Parser<'a> {
                                                None)?;
         if let Err(mut e) = self.expect(&token::OpenDelim(token::Brace)) {
             if self.token == token::Token::Semi {
-                e.span_suggestion_short_with_applicability(
+                e.span_suggestion_short(
                     match_span,
                     "try removing this `match`",
                     String::new(),
@@ -3949,7 +3949,7 @@ impl<'a> Parser<'a> {
                             //   |      - ^^ self.span
                             //   |      |
                             //   |      parsed until here as `"y" & X`
-                            err.span_suggestion_short_with_applicability(
+                            err.span_suggestion_short(
                                 cm.next_point(arm_start_span),
                                 "missing a comma here to end this `match` arm",
                                 ",".to_owned(),
@@ -4026,7 +4026,7 @@ impl<'a> Parser<'a> {
             if self.token == token::OrOr {
                 let mut err = self.struct_span_err(self.span,
                                                    "unexpected token `||` after pattern");
-                err.span_suggestion_with_applicability(
+                err.span_suggestion(
                     self.span,
                     "use a single `|` to specify multiple patterns",
                     "|".to_owned(),
@@ -4234,7 +4234,7 @@ impl<'a> Parser<'a> {
                     // Accept `...` as if it were `..` to avoid further errors
                     let mut err = self.struct_span_err(self.span,
                                                        "expected field pattern, found `...`");
-                    err.span_suggestion_with_applicability(
+                    err.span_suggestion(
                         self.span,
                         "to omit remaining fields, use one fewer `.`",
                         "..".to_owned(),
@@ -4266,7 +4266,7 @@ impl<'a> Parser<'a> {
                 if self.token == token::CloseDelim(token::Brace) {
                     // If the struct looks otherwise well formed, recover and continue.
                     if let Some(sp) = comma_sp {
-                        err.span_suggestion_short_with_applicability(
+                        err.span_suggestion_short(
                             sp,
                             "remove this comma",
                             String::new(),
@@ -4308,7 +4308,7 @@ impl<'a> Parser<'a> {
 
         if let Some(mut err) = delayed_err {
             if let Some(etc_span) = etc_span {
-                err.multipart_suggestion_with_applicability(
+                err.multipart_suggestion(
                     "move the `..` to the end of the field list",
                     vec![
                         (etc_span, String::new()),
@@ -4379,7 +4379,7 @@ impl<'a> Parser<'a> {
             let mut err = self.struct_span_err(comma_span,
                                                "unexpected `,` in pattern");
             if let Ok(seq_snippet) = self.sess.source_map().span_to_snippet(seq_span) {
-                err.span_suggestion_with_applicability(
+                err.span_suggestion(
                     seq_span,
                     "try adding parentheses",
                     format!("({})", seq_snippet),
@@ -4447,7 +4447,7 @@ impl<'a> Parser<'a> {
                 let binding_mode = if self.eat_keyword(keywords::Ref) {
                     self.diagnostic()
                         .struct_span_err(mutref_span, "the order of `mut` and `ref` is incorrect")
-                        .span_suggestion_with_applicability(
+                        .span_suggestion(
                             mutref_span,
                             "try switching the order",
                             "ref mut".into(),
@@ -4591,7 +4591,7 @@ impl<'a> Parser<'a> {
                         pat.span,
                         "the range pattern here has ambiguous interpretation",
                     );
-                    err.span_suggestion_with_applicability(
+                    err.span_suggestion(
                         pat.span,
                         "add parentheses to clarify the precedence",
                         format!("({})", pprust::pat_to_string(&pat)),
@@ -4667,7 +4667,7 @@ impl<'a> Parser<'a> {
             (Ok(init), Some((_, colon_sp, mut err))) => {  // init parsed, ty error
                 // Could parse the type as if it were the initializer, it is likely there was a
                 // typo in the code: `:` instead of `=`. Add suggestion and emit the error.
-                err.span_suggestion_short_with_applicability(
+                err.span_suggestion_short(
                     colon_sp,
                     "use `=` if you meant to assign",
                     "=".to_string(),
@@ -5170,7 +5170,7 @@ impl<'a> Parser<'a> {
                 self.token.is_keyword(keywords::In) || self.token == token::Colon;
 
             if self.token.is_ident_named("and") {
-                e.span_suggestion_short_with_applicability(
+                e.span_suggestion_short(
                     self.span,
                     "use `&&` instead of `and` for the boolean operator",
                     "&&".to_string(),
@@ -5178,7 +5178,7 @@ impl<'a> Parser<'a> {
                 );
             }
             if self.token.is_ident_named("or") {
-                e.span_suggestion_short_with_applicability(
+                e.span_suggestion_short(
                     self.span,
                     "use `||` instead of `or` for the boolean operator",
                     "||".to_string(),
@@ -5213,7 +5213,7 @@ impl<'a> Parser<'a> {
                         s.print_stmt(&stmt)?;
                         s.bclose_maybe_open(stmt.span, INDENT_UNIT, false)
                     });
-                    e.span_suggestion_with_applicability(
+                    e.span_suggestion(
                         stmt_span,
                         "try placing this code inside a block",
                         sugg,
@@ -5331,10 +5331,10 @@ impl<'a> Parser<'a> {
     fn err_dotdotdot_syntax(&self, span: Span) {
         self.diagnostic().struct_span_err(span, {
             "unexpected token: `...`"
-        }).span_suggestion_with_applicability(
+        }).span_suggestion(
             span, "use `..` for an exclusive range", "..".to_owned(),
             Applicability::MaybeIncorrect
-        ).span_suggestion_with_applicability(
+        ).span_suggestion(
             span, "or `..=` for an inclusive range", "..=".to_owned(),
             Applicability::MaybeIncorrect
         ).emit();
@@ -5534,7 +5534,7 @@ impl<'a> Parser<'a> {
                 "lifetime parameters must be declared prior to type parameters",
             );
             if !suggestions.is_empty() {
-                err.multipart_suggestion_with_applicability(
+                err.multipart_suggestion(
                     "move the lifetime parameter prior to the first type parameter",
                     suggestions,
                     Applicability::MachineApplicable,
@@ -5702,7 +5702,7 @@ impl<'a> Parser<'a> {
                             if plural { "s" } else { "" }
                         ),
                     )
-                    .span_suggestion_with_applicability(
+                    .span_suggestion(
                         span,
                         &format!(
                             "remove extra angle bracket{}",
@@ -5863,7 +5863,7 @@ impl<'a> Parser<'a> {
             suggestions.extend_from_slice(&type_suggestions);
 
             let plural = bad_lifetime_pos.len() + bad_type_pos.len() > 1;
-            err.multipart_suggestion_with_applicability(
+            err.multipart_suggestion(
                 &format!(
                     "move the parameter{}",
                     if plural { "s" } else { "" },
@@ -5872,7 +5872,7 @@ impl<'a> Parser<'a> {
                 Applicability::MachineApplicable,
             );
         } else if !lifetime_suggestions.is_empty() {
-            err.multipart_suggestion_with_applicability(
+            err.multipart_suggestion(
                 &format!(
                     "move the lifetime parameter{} prior to the first type parameter",
                     if bad_lifetime_pos.len() > 1 { "s" } else { "" },
@@ -5881,7 +5881,7 @@ impl<'a> Parser<'a> {
                 Applicability::MachineApplicable,
             );
         } else if !type_suggestions.is_empty() {
-            err.multipart_suggestion_with_applicability(
+            err.multipart_suggestion(
                 &format!(
                     "move the type parameter{} prior to the first associated type binding",
                     if bad_type_pos.len() > 1 { "s" } else { "" },
@@ -6385,7 +6385,7 @@ impl<'a> Parser<'a> {
                 let mut err = if is_macro_rules {
                     let mut err = self.diagnostic()
                         .struct_span_err(sp, "can't qualify macro_rules invocation with `pub`");
-                    err.span_suggestion_with_applicability(
+                    err.span_suggestion(
                         sp,
                         "try exporting the macro",
                         "#[macro_export]".to_owned(),
@@ -6593,7 +6593,7 @@ impl<'a> Parser<'a> {
                 // impl Trait for Type
                 if !has_for {
                     self.struct_span_err(missing_for_span, "missing `for` in a trait impl")
-                        .span_suggestion_short_with_applicability(
+                        .span_suggestion_short(
                             missing_for_span,
                             "add `for` here",
                             " for ".to_string(),
@@ -6817,7 +6817,7 @@ impl<'a> Parser<'a> {
                 } else {
                     if seen_comma == false {
                         let sp = self.sess.source_map().next_point(previous_span);
-                        err.span_suggestion_with_applicability(
+                        err.span_suggestion(
                             sp,
                             "missing comma here",
                             ",".into(),
@@ -6833,7 +6833,7 @@ impl<'a> Parser<'a> {
                                                                 self.this_token_descr()));
                 if self.token.is_ident() {
                     // This is likely another field; emit the diagnostic and keep going
-                    err.span_suggestion_with_applicability(
+                    err.span_suggestion(
                         sp,
                         "try adding a comma",
                         ",".into(),
@@ -6931,7 +6931,7 @@ impl<'a> Parser<'a> {
                 self.expect(&token::CloseDelim(token::Paren))?;  // `)`
                 let mut err = struct_span_err!(self.sess.span_diagnostic, sp, E0704, "{}", msg);
                 err.help(suggestion);
-                err.span_suggestion_with_applicability(
+                err.span_suggestion(
                     sp, &help_msg, format!("in {}", path), Applicability::MachineApplicable
                 );
                 err.emit();  // emit diagnostic, but continue with public visibility
@@ -6962,7 +6962,7 @@ impl<'a> Parser<'a> {
     fn maybe_consume_incorrect_semicolon(&mut self, items: &[P<Item>]) -> bool {
         if self.eat(&token::Semi) {
             let mut err = self.struct_span_err(self.prev_span, "expected item, found `;`");
-            err.span_suggestion_short_with_applicability(
+            err.span_suggestion_short(
                 self.prev_span,
                 "remove this semicolon",
                 String::new(),
@@ -7390,7 +7390,7 @@ impl<'a> Parser<'a> {
 
             let mut err = self.struct_span_err(fixed_name_sp, error_msg);
             err.span_label(fixed_name_sp, "dash-separated idents are not valid");
-            err.multipart_suggestion_with_applicability(
+            err.multipart_suggestion(
                 suggestion_msg,
                 replacement,
                 Applicability::MachineApplicable,
@@ -7759,7 +7759,7 @@ impl<'a> Parser<'a> {
                 let mut err = self.diagnostic()
                     .struct_span_err(prev_span, "const globals cannot be mutable");
                 err.span_label(prev_span, "cannot be mutable");
-                err.span_suggestion_with_applicability(
+                err.span_suggestion(
                     const_span,
                     "you might want to declare a static instead",
                     "static".to_owned(),
@@ -7996,7 +7996,7 @@ impl<'a> Parser<'a> {
                                   ident);
                 let mut err = self.diagnostic()
                     .struct_span_err(sp, "missing `struct` for struct definition");
-                err.span_suggestion_short_with_applicability(
+                err.span_suggestion_short(
                     sp, &msg, " struct ".into(), Applicability::MaybeIncorrect // speculative
                 );
                 return Err(err);
@@ -8031,12 +8031,12 @@ impl<'a> Parser<'a> {
                                              kw,
                                              ident,
                                              kw_name);
-                    err.span_suggestion_short_with_applicability(
+                    err.span_suggestion_short(
                         sp, &suggestion, format!(" {} ", kw), Applicability::MachineApplicable
                     );
                 } else {
                     if let Ok(snippet) = self.sess.source_map().span_to_snippet(ident_sp) {
-                        err.span_suggestion_with_applicability(
+                        err.span_suggestion(
                             full_sp,
                             "if you meant to call a macro, try",
                             format!("{}!", snippet),
@@ -8067,7 +8067,7 @@ impl<'a> Parser<'a> {
                 let msg = format!("missing `{}` for {} definition", kw, kw_name);
                 let mut err = self.diagnostic().struct_span_err(sp, &msg);
                 if !ambiguous {
-                    err.span_suggestion_short_with_applicability(
+                    err.span_suggestion_short(
                         sp,
                         &format!("add `{}` here to parse `{}` as a public {}", kw, ident, kw_name),
                         format!(" {} ", kw),
@@ -8094,7 +8094,7 @@ impl<'a> Parser<'a> {
             if self.token.is_keyword(keywords::Const) {
                 self.diagnostic()
                     .struct_span_err(self.span, "extern items cannot be `const`")
-                    .span_suggestion_with_applicability(
+                    .span_suggestion(
                         self.span,
                         "try using a static value",
                         "static".to_owned(),

--- a/src/libsyntax_ext/format.rs
+++ b/src/libsyntax_ext/format.rs
@@ -763,7 +763,7 @@ pub fn expand_preparsed_format_args(ecx: &mut ExtCtxt,
                     0 => "{}".to_string(),
                     _ => format!("{}{{}}", "{} ".repeat(args.len())),
                 };
-                err.span_suggestion_with_applicability(
+                err.span_suggestion(
                     fmt_sp.shrink_to_lo(),
                     "you might be missing a string literal to format with",
                     format!("\"{}\", ", sugg_fmt),
@@ -1080,7 +1080,7 @@ pub fn expand_preparsed_format_args(ecx: &mut ExtCtxt,
                         ));
                     }
                     if suggestions.len() > 0 {
-                        diag.multipart_suggestion_with_applicability(
+                        diag.multipart_suggestion(
                             "format specifiers use curly braces",
                             suggestions,
                             Applicability::MachineApplicable,


### PR DESCRIPTION
This PR removes the (now unused) deprecated suggestion functions and removes `_with_applicability` from their replacements' names.

This PR will break clippy, but I'll open a clippy PR once this is merged.