### PR TITLE
[WIP] Lint duplicate trait and lifetime bounds

### DIFF
--- a/src/libcore/array.rs
+++ b/src/libcore/array.rs
@@ -9,6 +9,8 @@
                       integer constants",
             issue = "27778")]
 
+#![cfg_attr(not(stage0), allow(duplicate_bounds))]
+
 use borrow::{Borrow, BorrowMut};
 use cmp::Ordering;
 use convert::TryFrom;

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -346,6 +346,19 @@ declare_lint! {
     "outlives requirements can be inferred"
 }
 
+declare_lint! {
+    pub DEPRECATED_IN_FUTURE,
+    Allow,
+    "detects use of items that will be deprecated in a future version",
+    report_in_external_macro: true
+}
+
+declare_lint! {
+    pub DUPLICATE_BOUNDS,
+    Warn,
+    "detects duplicate bounds on type parameters, lifetime parameters, and projections"
+}
+
 /// Some lints that are buffered from `libsyntax`. See `syntax::early_buffered_lints`.
 pub mod parser {
     declare_lint! {
@@ -440,6 +453,8 @@ impl LintPass for HardwiredLints {
             parser::ILL_FORMED_ATTRIBUTE_INPUT,
             DEPRECATED_IN_FUTURE,
             AMBIGUOUS_ASSOCIATED_ITEMS,
+            DUPLICATE_BOUNDS,
+            parser::QUESTION_MARK_MACRO_SEP,
         )
     }
 }

--- a/src/librustc/traits/util.rs
+++ b/src/librustc/traits/util.rs
@@ -1,3 +1,4 @@
+use errors::DiagnosticBuilder;
 use hir;
 use hir::def_id::DefId;
 use traits::specialize::specialization_graph::NodeItem;

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -47,7 +47,7 @@ use rustc::hir::{self, GenericParamKind, PatKind};
 
 use nonstandard_style::{MethodLateContext, method_context};
 
-// hardwired lints from librustc
+// Hardwired lints from librustc.
 pub use lint::builtin::*;
 
 declare_lint! {

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -345,7 +345,7 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
             reference: "issue #57644 <https://github.com/rust-lang/rust/issues/57644>",
             edition: None,
         },
-        ]);
+    ]);
 
     // Register renamed and removed lints.
     store.register_renamed("single_use_lifetime", "single_use_lifetimes");

--- a/src/test/ui/lint/lint-incoherent-auto-trait-objects.rs
+++ b/src/test/ui/lint/lint-incoherent-auto-trait-objects.rs
@@ -7,6 +7,7 @@ impl Foo for dyn Send {}
 impl Foo for dyn Send + Send {}
 //~^ ERROR conflicting implementations
 //~| hard error
+//~^^^ WARNING duplicate auto trait `Send` found in type parameter bounds [duplicate_auto_traits_in_bounds]
 
 impl Foo for dyn Send + Sync {}
 
@@ -17,5 +18,6 @@ impl Foo for dyn Sync + Send {}
 impl Foo for dyn Send + Sync + Send {}
 //~^ ERROR conflicting implementations
 //~| hard error
+//~^^^ WARNING duplicate auto trait `Send` found in type parameter bounds [duplicate_auto_traits_in_bounds]
 
 fn main() {}

--- a/src/test/ui/lint/lint-incoherent-auto-trait-objects.stderr
+++ b/src/test/ui/lint/lint-incoherent-auto-trait-objects.stderr
@@ -1,3 +1,21 @@
+warning: duplicate auto trait `Send` found in type parameter bounds
+  --> $DIR/lint-incoherent-auto-trait-objects.rs:7:18
+   |
+LL | impl Foo for dyn Send + Send {}
+   |                  ^^^^   ^^^^ subsequent use of auto trait
+   |                  |
+   |                  first use of auto trait
+   |
+   = note: #[warn(duplicate_auto_traits_in_bounds)] on by default
+
+warning: duplicate auto trait `Send` found in type parameter bounds
+  --> $DIR/lint-incoherent-auto-trait-objects.rs:18:18
+   |
+LL | impl Foo for dyn Send + Sync + Send {}
+   |                  ^^^^          ^^^^ subsequent use of auto trait
+   |                  |
+   |                  first use of auto trait
+
 error: conflicting implementations of trait `Foo` for type `(dyn std::marker::Send + 'static)`: (E0119)
   --> $DIR/lint-incoherent-auto-trait-objects.rs:7:1
    |

--- a/src/test/ui/traits/trait-object-auto-dedup-in-impl.rs
+++ b/src/test/ui/traits/trait-object-auto-dedup-in-impl.rs
@@ -1,19 +1,30 @@
+// ignore-tidy-linelength
+
 // Checks to make sure that `dyn Trait + Send` and `dyn Trait + Send + Send` are the same type.
 // Issue: #47010
 
 struct Struct;
+
 impl Trait for Struct {}
+
 trait Trait {}
 
 type Send1 = Trait + Send;
 type Send2 = Trait + Send + Send;
+//~^ WARNING duplicate auto trait `Send` found in type parameter bounds [duplicate_auto_traits_in_bounds]
 
 fn main () {}
 
 impl Trait + Send {
-    fn test(&self) { println!("one"); } //~ ERROR duplicate definitions with name `test`
+    fn test(&self) {
+    //~^ ERROR duplicate definitions with name `test`
+        println!("one");
+    }
 }
 
 impl Trait + Send + Send {
-    fn test(&self) { println!("two"); }
+//~^ WARNING duplicate auto trait `Send` found in type parameter bounds [duplicate_auto_traits_in_bounds]
+    fn test(&self) {
+        println!("two");
+    }
 }

--- a/src/test/ui/traits/trait-object-auto-dedup-in-impl.stderr
+++ b/src/test/ui/traits/trait-object-auto-dedup-in-impl.stderr
@@ -1,11 +1,37 @@
-error[E0592]: duplicate definitions with name `test`
-  --> $DIR/trait-object-auto-dedup-in-impl.rs:14:5
+warning: duplicate auto trait `Send` found in type parameter bounds
+  --> $DIR/trait-object-auto-dedup-in-impl.rs:13:22
    |
-LL |     fn test(&self) { println!("one"); } //~ ERROR duplicate definitions with name `test`
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `test`
+LL | type Send2 = Trait + Send + Send;
+   |                      ^^^^   ^^^^ subsequent use of auto trait
+   |                      |
+   |                      first use of auto trait
+   |
+   = note: #[warn(duplicate_auto_traits_in_bounds)] on by default
+
+warning: duplicate auto trait `Send` found in type parameter bounds
+  --> $DIR/trait-object-auto-dedup-in-impl.rs:25:14
+   |
+LL | impl Trait + Send + Send {
+   |              ^^^^   ^^^^ subsequent use of auto trait
+   |              |
+   |              first use of auto trait
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #56522 <https://github.com/rust-lang/rust/issues/56522>
+
+error[E0592]: duplicate definitions with name `test`
+  --> $DIR/trait-object-auto-dedup-in-impl.rs:20:5
+   |
+LL | /     fn test(&self) {
+LL | |     //~^ ERROR duplicate definitions with name `test`
+LL | |         println!("one");
+LL | |     }
+   | |_____^ duplicate definitions for `test`
 ...
-LL |     fn test(&self) { println!("two"); }
-   |     ----------------------------------- other definition for `test`
+LL | /     fn test(&self) {
+LL | |         println!("two");
+LL | |     }
+   | |_____- other definition for `test`
 
 error: aborting due to previous error
 


### PR DESCRIPTION
For example, `T: Foo + Foo`, `'a: 'b + 'b`, or in-band `T: Foo` together with `where T: Foo`, etc.

I ran into a brick wall with htis one, as it's a lot trickier than it first seems, though I should have a fair bit of boilerplate in place here. Leaving this for someone else to pick up hopefully (ideally before it bitrots into oblivion!).

CC @nikomatsakis