### PR TITLE
Pretty print `$crate` as `crate` or `crate_name` in more cases

### DIFF
--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -15,7 +15,7 @@ use syntax::ast::{self, Ident};
 use syntax::attr;
 use syntax::errors::DiagnosticBuilder;
 use syntax::ext::base::{self, Determinacy};
-use syntax::ext::base::{Annotatable, MacroKind, SyntaxExtension};
+use syntax::ext::base::{MacroKind, SyntaxExtension};
 use syntax::ext::expand::{AstFragment, Invocation, InvocationKind};
 use syntax::ext::hygiene::{self, Mark};
 use syntax::ext::tt::macro_rules;
@@ -127,9 +127,9 @@ impl<'a> base::Resolver for Resolver<'a> {
         mark
     }
 
-    fn resolve_dollar_crates(&mut self, annotatable: &Annotatable) {
-        pub struct ResolveDollarCrates<'a, 'b: 'a> {
-            pub resolver: &'a mut Resolver<'b>,
+    fn resolve_dollar_crates(&mut self, fragment: &AstFragment) {
+        struct ResolveDollarCrates<'a, 'b: 'a> {
+            resolver: &'a mut Resolver<'b>
         }
         impl<'a> Visitor<'a> for ResolveDollarCrates<'a, '_> {
             fn visit_ident(&mut self, ident: Ident) {
@@ -144,7 +144,7 @@ impl<'a> base::Resolver for Resolver<'a> {
             fn visit_mac(&mut self, _: &ast::Mac) {}
         }
 
-        annotatable.visit_with(&mut ResolveDollarCrates { resolver: self });
+        fragment.visit_with(&mut ResolveDollarCrates { resolver: self });
     }
 
     fn visit_ast_fragment_with_placeholders(&mut self, mark: Mark, fragment: &AstFragment,

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -537,11 +537,8 @@ impl<'a> Resolver<'a> {
                  primary_binding: &'a NameBinding<'a>, secondary_binding: &'a NameBinding<'a>)
                  -> &'a NameBinding<'a> {
         self.arenas.alloc_name_binding(NameBinding {
-            kind: primary_binding.kind.clone(),
             ambiguity: Some((secondary_binding, kind)),
-            vis: primary_binding.vis,
-            span: primary_binding.span,
-            expansion: primary_binding.expansion,
+            ..primary_binding.clone()
         })
     }
 

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -14,7 +14,6 @@ use parse::token;
 use ptr::P;
 use smallvec::SmallVec;
 use symbol::{keywords, Ident, Symbol};
-use visit::Visitor;
 use ThinVec;
 
 use rustc_data_structures::fx::FxHashMap;
@@ -134,17 +133,6 @@ impl Annotatable {
                 _ => false,
             },
             _ => false,
-        }
-    }
-
-    pub fn visit_with<'a, V: Visitor<'a>>(&'a self, visitor: &mut V) {
-        match self {
-            Annotatable::Item(item) => visitor.visit_item(item),
-            Annotatable::TraitItem(trait_item) => visitor.visit_trait_item(trait_item),
-            Annotatable::ImplItem(impl_item) => visitor.visit_impl_item(impl_item),
-            Annotatable::ForeignItem(foreign_item) => visitor.visit_foreign_item(foreign_item),
-            Annotatable::Stmt(stmt) => visitor.visit_stmt(stmt),
-            Annotatable::Expr(expr) => visitor.visit_expr(expr),
         }
     }
 }
@@ -742,7 +730,7 @@ pub trait Resolver {
     fn next_node_id(&mut self) -> ast::NodeId;
     fn get_module_scope(&mut self, id: ast::NodeId) -> Mark;
 
-    fn resolve_dollar_crates(&mut self, annotatable: &Annotatable);
+    fn resolve_dollar_crates(&mut self, fragment: &AstFragment);
     fn visit_ast_fragment_with_placeholders(&mut self, mark: Mark, fragment: &AstFragment,
                                             derives: &[Mark]);
     fn add_builtin(&mut self, ident: ast::Ident, ext: Lrc<SyntaxExtension>);
@@ -776,7 +764,7 @@ impl Resolver for DummyResolver {
     fn next_node_id(&mut self) -> ast::NodeId { ast::DUMMY_NODE_ID }
     fn get_module_scope(&mut self, _id: ast::NodeId) -> Mark { Mark::root() }
 
-    fn resolve_dollar_crates(&mut self, _annotatable: &Annotatable) {}
+    fn resolve_dollar_crates(&mut self, _fragment: &AstFragment) {}
     fn visit_ast_fragment_with_placeholders(&mut self, _invoc: Mark, _fragment: &AstFragment,
                                             _derives: &[Mark]) {}
     fn add_builtin(&mut self, _ident: ast::Ident, _ext: Lrc<SyntaxExtension>) {}

--- a/src/test/pretty/dollar-crate.pp
+++ b/src/test/pretty/dollar-crate.pp
@@ -1,0 +1,18 @@
+#![feature(prelude_import)]
+#![no_std]
+#[prelude_import]
+use ::std::prelude::v1::*;
+#[macro_use]
+extern crate std;
+// pretty-compare-only
+// pretty-mode:expanded
+// pp-exact:dollar-crate.pp
+
+fn main() {
+    {
+        ::std::io::_print(::std::fmt::Arguments::new_v1(&["rust\n"],
+                                                        &match () {
+                                                             () => [],
+                                                         }));
+    };
+}

--- a/src/test/pretty/dollar-crate.rs
+++ b/src/test/pretty/dollar-crate.rs
@@ -1,0 +1,7 @@
+// pretty-compare-only
+// pretty-mode:expanded
+// pp-exact:dollar-crate.pp
+
+fn main() {
+    println!("rust");
+}


### PR DESCRIPTION
So, people do parse output of `--pretty=expanded` (sigh), so covering only the legacy proc-macro case (like it was done in https://github.com/rust-lang/rust/pull/57155) is not enough.

This PRs resolves all `$crate`s produced by macros, so they are all printed in the parseable form `$crate::foo` -> `crate::foo` or `crate_name::foo`.

Fixes https://github.com/rust-lang/rust/issues/38016#issuecomment-455851334
Fixes https://github.com/rust-lang/rust/pull/57155#issuecomment-455807195