### PR TITLE
Update visibility of intermediate use items.

### DIFF
--- a/src/libcore/iter/adapters/mod.rs
+++ b/src/libcore/iter/adapters/mod.rs
@@ -11,6 +11,7 @@ mod flatten;
 mod zip;
 
 pub use self::chain::Chain;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::flatten::{FlatMap, Flatten};
 pub use self::zip::Zip;
 pub(crate) use self::zip::TrustedRandomAccess;

--- a/src/libcore/iter/traits/mod.rs
+++ b/src/libcore/iter/traits/mod.rs
@@ -5,9 +5,11 @@ mod collect;
 mod accum;
 mod marker;
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::iterator::Iterator;
 pub use self::double_ended::DoubleEndedIterator;
 pub use self::exact_size::ExactSizeIterator;
 pub use self::collect::{FromIterator, IntoIterator, Extend};
 pub use self::accum::{Sum, Product};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::marker::{FusedIterator, TrustedLen};

--- a/src/librustc/hir/def.rs
+++ b/src/librustc/hir/def.rs
@@ -252,12 +252,14 @@ impl NonMacroAttrKind {
 }
 
 impl Def {
+    /// Return the `DefId` of this `Def` if it has an id, else panic.
     pub fn def_id(&self) -> DefId {
         self.opt_def_id().unwrap_or_else(|| {
             bug!("attempted .def_id() on invalid def: {:?}", self)
         })
     }
 
+    /// Return `Some(..)` with the `DefId` of this `Def` if it has a id, else `None`.
     pub fn opt_def_id(&self) -> Option<DefId> {
         match *self {
             Def::Fn(id) | Def::Mod(id) | Def::Static(id, _) |
@@ -281,6 +283,14 @@ impl Def {
             Def::Err => {
                 None
             }
+        }
+    }
+
+    /// Return the `DefId` of this `Def` if it represents a module.
+    pub fn mod_def_id(&self) -> Option<DefId> {
+        match *self {
+            Def::Mod(id) => Some(id),
+            _ => None,
         }
     }
 

--- a/src/librustc/middle/privacy.rs
+++ b/src/librustc/middle/privacy.rs
@@ -11,16 +11,16 @@ use syntax::ast::NodeId;
 // Accessibility levels, sorted in ascending order
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum AccessLevel {
-    // Superset of Reachable used to mark impl Trait items.
+    /// Superset of `AccessLevel::Reachable` used to mark impl Trait items.
     ReachableFromImplTrait,
-    // Exported items + items participating in various kinds of public interfaces,
-    // but not directly nameable. For example, if function `fn f() -> T {...}` is
-    // public, then type `T` is reachable. Its values can be obtained by other crates
-    // even if the type itself is not nameable.
+    /// Exported items + items participating in various kinds of public interfaces,
+    /// but not directly nameable. For example, if function `fn f() -> T {...}` is
+    /// public, then type `T` is reachable. Its values can be obtained by other crates
+    /// even if the type itself is not nameable.
     Reachable,
-    // Public items + items accessible to other crates with help of `pub use` re-exports
+    /// Public items + items accessible to other crates with help of `pub use` re-exports
     Exported,
-    // Items accessible to other crates directly, without help of re-exports
+    /// Items accessible to other crates directly, without help of re-exports
     Public,
 }
 
@@ -31,12 +31,17 @@ pub struct AccessLevels<Id = NodeId> {
 }
 
 impl<Id: Hash + Eq> AccessLevels<Id> {
+    /// See `AccessLevel::Reachable`.
     pub fn is_reachable(&self, id: Id) -> bool {
         self.map.get(&id) >= Some(&AccessLevel::Reachable)
     }
+
+    /// See `AccessLevel::Exported`.
     pub fn is_exported(&self, id: Id) -> bool {
         self.map.get(&id) >= Some(&AccessLevel::Exported)
     }
+
+    /// See `AccessLevel::Public`.
     pub fn is_public(&self, id: Id) -> bool {
         self.map.get(&id) >= Some(&AccessLevel::Public)
     }

--- a/src/libstd/sys/mod.rs
+++ b/src/libstd/sys/mod.rs
@@ -54,6 +54,7 @@ cfg_if! {
 cfg_if! {
     if #[cfg(any(unix, target_os = "redox"))] {
         // On unix we'll document what's already available
+        #[stable(feature = "rust1", since = "1.0.0")]
         pub use self::ext as unix_ext;
     } else if #[cfg(any(target_os = "cloudabi",
                         target_arch = "wasm32",
@@ -77,6 +78,7 @@ cfg_if! {
     if #[cfg(windows)] {
         // On windows we'll just be documenting what's already available
         #[allow(missing_docs)]
+        #[stable(feature = "rust1", since = "1.0.0")]
         pub use self::ext as windows_ext;
     } else if #[cfg(any(target_os = "cloudabi",
                         target_arch = "wasm32",

--- a/src/test/ui/issues/issue-57410-1.rs
+++ b/src/test/ui/issues/issue-57410-1.rs
@@ -1,0 +1,18 @@
+// compile-pass
+
+// Originally from #53925.
+// Tests that the `unreachable_pub` lint doesn't fire for `pub self::bar::Bar`.
+
+#![deny(unreachable_pub)]
+
+mod foo {
+    mod bar {
+        pub struct Bar;
+    }
+
+    pub use self::bar::Bar;
+}
+
+pub use foo::Bar;
+
+fn main() {}

--- a/src/test/ui/issues/issue-57410.rs
+++ b/src/test/ui/issues/issue-57410.rs
@@ -1,0 +1,17 @@
+// compile-pass
+
+// Tests that the `unreachable_pub` lint doesn't fire for `pub self::imp::f`.
+
+#![deny(unreachable_pub)]
+
+mod m {
+    mod imp {
+        pub fn f() {}
+    }
+
+    pub use self::imp::f;
+}
+
+pub use self::m::f;
+
+fn main() {}


### PR DESCRIPTION
Fixes #57410 and fixes #53925 and fixes #47816.

Currently, the target of a use statement will be updated with
the visibility of the use statement itself (if the use statement was
visible).

This PR ensures that if the path to the target item is via another
use statement then that intermediate use statement will also have the
visibility updated like the target. This silences incorrect
`unreachable_pub` lints with inactionable suggestions.