### PR TITLE
submodules: update clippy from f1753522 to 6ce78d12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,6 +273,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo_metadata"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.81 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cargotest2"
 version = "0.1.0"
 
@@ -332,7 +344,7 @@ dependencies = [
 name = "clippy"
 version = "0.0.212"
 dependencies = [
- "cargo_metadata 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cargo_metadata 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy-mini-macro-test 0.2.0",
  "clippy_dev 0.0.1",
  "clippy_lints 0.0.212",
@@ -356,7 +368,7 @@ name = "clippy_dev"
 version = "0.0.1"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -366,9 +378,9 @@ dependencies = [
 name = "clippy_lints"
 version = "0.0.212"
 dependencies = [
- "cargo_metadata 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cargo_metadata 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "if_chain 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "pulldown-cmark 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1969,7 +1981,7 @@ name = "rand_chacha"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1991,7 +2003,7 @@ name = "rand_hc"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2016,7 +2028,7 @@ name = "rand_xorshift"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3782,6 +3794,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "40ade3d27603c2cb345eb0912aec461a6dec7e06a4ae48589904e808335c7afa"
 "checksum bytesize 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "716960a18f978640f25101b5cbf1c6f6b0d3192fab36a2d98ca96f0ecbe41010"
 "checksum cargo_metadata 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7d8dfe3adeb30f7938e6c1dd5327f29235d8ada3e898aeb08c343005ec2915a2"
+"checksum cargo_metadata 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "585784cac9b05c93a53b17a0b24a5cdd1dfdda5256f030e089b549d2390cc720"
 "checksum cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4a8b715cb4597106ea87c7c84b2f1d452c7492033765df7f32651e66fcf749"
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
 "checksum chalk-engine 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17ec698a6f053a23bfbe646d9f2fde4b02abc19125595270a99e6f44ae0bdd1a"


### PR DESCRIPTION
Should fix clippy toolstate

Changes:
````
wildcard_match_arm: Update lint count.
wildcard_match_arm: add nesting issue to known.
wildcard_match_arm: lint only enum matches.
wildcard_match_arm: update ui test stderr
wildcard_match_arm: format test.
wilcard_match_arm: run rustfmt.
wildcard_match_arm: add lint properly.
wildcard_match_arm: rename function.
wildcard_match_arm: add simple ui test.
wildcard_match_arm: expand lint scope.
Change match_wild lint name to WILDCARD_MATCH_ARM.
Add match_wild lint (#3649).
fetch_prs_between: add .sh file ending
cargo fmt
Update various docs
Use built-in entry_fn detection over self-built
cargo fmt
Reorganize conditionals: Run faster checks first
Maybe fix ICE?
Add initial version of const_fn lint
Fix `unit_arg` false positive
Rustfmt
Check hypothetically failing conversion
Remove tests for deprecated items
Update more changed iterator paths
Atomics constants are now handled by the deprecation lint
Update changed iterator paths
Update const slice processing
update test stderr
run cargo fmt
rustup https://github.com/rust-lang/rust/pull/57907/
Fix documentation for `slow_vector_initialization`
rustup https://github.com/rust-lang/rust/pull/57726
Remove unsafe_vector_initialization from added lints
Prevent incorrect cast_lossless suggestion in const_fn
Incorporate review suggestions
Fix dogfood tests on Appveyor
test(versioncheck): Use .no_deps()
test(versioncheck): Fix version equality check
chore(cargo/dependencies/cargo-metadata): Upgrade to 0.7.1
dependencies: update itertools from 0.7 to 0.8
Add script to fetch GitHub PRs between two commits
gitattributes: Treat .fixed files as rust files
Update changelog with all changes since 0.0.212
Fix `expect_fun_call` lint suggestions
````

r? @oli-obk 