### PR TITLE
rustdoc: remove blank unstable spans

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -3483,10 +3483,6 @@ fn item_struct(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
                        ns_id = ns_id,
                        name = field.name.as_ref().unwrap(),
                        ty = ty)?;
-                if let Some(stability_class) = field.stability_class() {
-                    write!(w, "<span class='stab {stab}'></span>",
-                        stab = stability_class)?;
-                }
                 document(w, cx, field)?;
             }
         }

--- a/src/test/rustdoc/stability.rs
+++ b/src/test/rustdoc/stability.rs
@@ -1,0 +1,12 @@
+#![feature(staged_api)]
+
+#![unstable(feature = "test", issue = "0")]
+
+pub struct Unstable {
+    // @has stability/struct.Unstable.html \
+    //      '//div[@class="stability"]//div[@class="stab unstable"]' \
+    //      'This is a nightly-only experimental API'
+    // @count stability/struct.Unstable.html '//span[@class="stab unstable"]' 0
+    pub foo: u32,
+    pub bar: u32,
+}


### PR DESCRIPTION
Rustdoc generates blank unstable spans for unstable struct fields: ![screen shot 2019-01-28 at 1 05 04 pm](https://user-images.githubusercontent.com/1372438/51856295-5e8ed500-22fd-11e9-8074-025eddb4ef65.png)

This PR removes them: 
![screen shot 2019-01-28 at 1 07 22 pm](https://user-images.githubusercontent.com/1372438/51856424-aada1500-22fd-11e9-86f0-34e2aa78b8b1.png)

r? @QuietMisdreavus 
