### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/src/etc/gdb_rust_pretty_printing.py
+++ b/src/etc/gdb_rust_pretty_printing.py
@@ -330,19 +330,20 @@ def children_of_node(boxed_node, height, want_values):
         leaf = node_ptr['data']
     else:
         leaf = node_ptr.dereference()
-    keys = leaf['keys']['value']['value']
+    keys = leaf['keys']
     if want_values:
-        values = leaf['vals']['value']['value']
+        values = leaf['vals']
     length = int(leaf['len'])
     for i in xrange(0, length + 1):
         if height > 0:
-            for child in children_of_node(node_ptr['edges'][i], height - 1, want_values):
+            child_ptr = node_ptr['edges'][i]['value']['value']
+            for child in children_of_node(child_ptr, height - 1, want_values):
                 yield child
         if i < length:
             if want_values:
-                yield (keys[i], values[i])
+                yield (keys[i]['value']['value'], values[i]['value']['value'])
             else:
-                yield keys[i]
+                yield keys[i]['value']['value']
 
 class RustStdBTreeSetPrinter(object):
     def __init__(self, val):

--- a/src/liballoc/borrow.rs
+++ b/src/liballoc/borrow.rs
@@ -380,7 +380,6 @@ impl<'a, B: ?Sized> Hash for Cow<'a, B>
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-#[allow(deprecated)]
 impl<'a, T: ?Sized + ToOwned> AsRef<T> for Cow<'a, T> {
     fn as_ref(&self) -> &T {
         self

--- a/src/liballoc/collections/btree/node.rs
+++ b/src/liballoc/collections/btree/node.rs
@@ -650,7 +650,7 @@ impl<'a, K: 'a, V: 'a, Type> NodeRef<marker::Mut<'a>, K, V, Type> {
         } else {
             unsafe {
                 slice::from_raw_parts_mut(
-                    MaybeUninit::first_mut_ptr(&mut (*self.as_leaf_mut()).keys),
+                    MaybeUninit::first_ptr_mut(&mut (*self.as_leaf_mut()).keys),
                     self.len()
                 )
             }
@@ -661,7 +661,7 @@ impl<'a, K: 'a, V: 'a, Type> NodeRef<marker::Mut<'a>, K, V, Type> {
         debug_assert!(!self.is_shared_root());
         unsafe {
             slice::from_raw_parts_mut(
-                MaybeUninit::first_mut_ptr(&mut (*self.as_leaf_mut()).vals),
+                MaybeUninit::first_ptr_mut(&mut (*self.as_leaf_mut()).vals),
                 self.len()
             )
         }
@@ -749,7 +749,7 @@ impl<'a, K, V> NodeRef<marker::Mut<'a>, K, V, marker::Internal> {
             slice_insert(self.vals_mut(), 0, val);
             slice_insert(
                 slice::from_raw_parts_mut(
-                    MaybeUninit::first_mut_ptr(&mut self.as_internal_mut().edges),
+                    MaybeUninit::first_ptr_mut(&mut self.as_internal_mut().edges),
                     self.len()+1
                 ),
                 0,
@@ -808,7 +808,7 @@ impl<'a, K, V> NodeRef<marker::Mut<'a>, K, V, marker::LeafOrInternal> {
                 ForceResult::Internal(mut internal) => {
                     let edge = slice_remove(
                         slice::from_raw_parts_mut(
-                            MaybeUninit::first_mut_ptr(&mut internal.as_internal_mut().edges),
+                            MaybeUninit::first_ptr_mut(&mut internal.as_internal_mut().edges),
                             old_len+1
                         ),
                         0
@@ -1087,7 +1087,7 @@ impl<'a, K, V> Handle<NodeRef<marker::Mut<'a>, K, V, marker::Internal>, marker::
 
             slice_insert(
                 slice::from_raw_parts_mut(
-                    MaybeUninit::first_mut_ptr(&mut self.node.as_internal_mut().edges),
+                    MaybeUninit::first_ptr_mut(&mut self.node.as_internal_mut().edges),
                     self.node.len()
                 ),
                 self.idx + 1,

--- a/src/liballoc/collections/btree/node.rs
+++ b/src/liballoc/collections/btree/node.rs
@@ -106,11 +106,8 @@ impl<K, V> LeafNode<K, V> {
         LeafNode {
             // As a general policy, we leave fields uninitialized if they can be, as this should
             // be both slightly faster and easier to track in Valgrind.
-            // Creating a `[MaybeUninit; N]` array by first creating a
-            // `MaybeUninit<[MaybeUninit; N]>`; the `into_inner` is safe because the inner
-            // array does not require initialization.
-            keys: MaybeUninit::uninitialized().into_inner(),
-            vals: MaybeUninit::uninitialized().into_inner(),
+            keys: uninitialized_array![_; CAPACITY],
+            vals: uninitialized_array![_; CAPACITY],
             parent: ptr::null(),
             parent_idx: MaybeUninit::uninitialized(),
             len: 0
@@ -162,10 +159,7 @@ impl<K, V> InternalNode<K, V> {
     unsafe fn new() -> Self {
         InternalNode {
             data: LeafNode::new(),
-            // Creating a `[MaybeUninit; N]` array by first creating a
-            // `MaybeUninit<[MaybeUninit; N]>`; the `into_inner` is safe because the inner
-            // array does not require initialization.
-            edges: MaybeUninit::uninitialized().into_inner(),
+            edges: uninitialized_array![_; 2*B],
         }
     }
 }

--- a/src/liballoc/collections/btree/node.rs
+++ b/src/liballoc/collections/btree/node.rs
@@ -145,7 +145,7 @@ struct InternalNode<K, V> {
 
     /// The pointers to the children of this node. `len + 1` of these are considered
     /// initialized and valid.
-    edges: [BoxedNode<K, V>; 2 * B],
+    edges: [MaybeUninit<BoxedNode<K, V>>; 2 * B],
 }
 
 impl<K, V> InternalNode<K, V> {
@@ -159,7 +159,10 @@ impl<K, V> InternalNode<K, V> {
     unsafe fn new() -> Self {
         InternalNode {
             data: LeafNode::new(),
-            edges: mem::uninitialized()
+            // Creating a `[MaybeUninit; N]` array by first creating a
+            // `MaybeUninit<[MaybeUninit; N]>`; the `into_inner` is safe because the inner
+            // array does not require initialization.
+            edges: MaybeUninit::uninitialized().into_inner(),
         }
     }
 }
@@ -261,7 +264,7 @@ impl<K, V> Root<K, V> {
             -> NodeRef<marker::Mut, K, V, marker::Internal> {
         debug_assert!(!self.is_shared_root());
         let mut new_node = Box::new(unsafe { InternalNode::new() });
-        new_node.edges[0] = unsafe { BoxedNode::from_ptr(self.node.as_ptr()) };
+        new_node.edges[0].set(unsafe { BoxedNode::from_ptr(self.node.as_ptr()) });
 
         self.node = BoxedNode::from_internal(new_node);
         self.height += 1;
@@ -718,7 +721,7 @@ impl<'a, K, V> NodeRef<marker::Mut<'a>, K, V, marker::Internal> {
         unsafe {
             ptr::write(self.keys_mut().get_unchecked_mut(idx), key);
             ptr::write(self.vals_mut().get_unchecked_mut(idx), val);
-            ptr::write(self.as_internal_mut().edges.get_unchecked_mut(idx + 1), edge.node);
+            self.as_internal_mut().edges.get_unchecked_mut(idx + 1).set(edge.node);
 
             (*self.as_leaf_mut()).len += 1;
 
@@ -749,7 +752,7 @@ impl<'a, K, V> NodeRef<marker::Mut<'a>, K, V, marker::Internal> {
             slice_insert(self.vals_mut(), 0, val);
             slice_insert(
                 slice::from_raw_parts_mut(
-                    self.as_internal_mut().edges.as_mut_ptr(),
+                    MaybeUninit::first_mut_ptr(&mut self.as_internal_mut().edges),
                     self.len()+1
                 ),
                 0,
@@ -778,7 +781,9 @@ impl<'a, K, V> NodeRef<marker::Mut<'a>, K, V, marker::LeafOrInternal> {
             let edge = match self.reborrow_mut().force() {
                 ForceResult::Leaf(_) => None,
                 ForceResult::Internal(internal) => {
-                    let edge = ptr::read(internal.as_internal().edges.get_unchecked(idx + 1));
+                    let edge = ptr::read(
+                        internal.as_internal().edges.get_unchecked(idx + 1).as_ptr()
+                    );
                     let mut new_root = Root { node: edge, height: internal.height - 1 };
                     (*new_root.as_mut().as_leaf_mut()).parent = ptr::null();
                     Some(new_root)
@@ -806,7 +811,7 @@ impl<'a, K, V> NodeRef<marker::Mut<'a>, K, V, marker::LeafOrInternal> {
                 ForceResult::Internal(mut internal) => {
                     let edge = slice_remove(
                         slice::from_raw_parts_mut(
-                            internal.as_internal_mut().edges.as_mut_ptr(),
+                            MaybeUninit::first_mut_ptr(&mut internal.as_internal_mut().edges),
                             old_len+1
                         ),
                         0
@@ -1085,7 +1090,7 @@ impl<'a, K, V> Handle<NodeRef<marker::Mut<'a>, K, V, marker::Internal>, marker::
 
             slice_insert(
                 slice::from_raw_parts_mut(
-                    self.node.as_internal_mut().edges.as_mut_ptr(),
+                    MaybeUninit::first_mut_ptr(&mut self.node.as_internal_mut().edges),
                     self.node.len()
                 ),
                 self.idx + 1,
@@ -1140,7 +1145,9 @@ impl<BorrowType, K, V>
     pub fn descend(self) -> NodeRef<BorrowType, K, V, marker::LeafOrInternal> {
         NodeRef {
             height: self.node.height - 1,
-            node: unsafe { self.node.as_internal().edges.get_unchecked(self.idx).as_ptr() },
+            node: unsafe {
+                self.node.as_internal().edges.get_unchecked(self.idx).get_ref().as_ptr()
+            },
             root: self.node.root,
             _marker: PhantomData
         }

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -63,6 +63,7 @@
 #![no_std]
 #![needs_allocator]
 
+#![warn(deprecated_in_future)]
 #![deny(intra_doc_link_resolution_failure)]
 #![deny(missing_debug_implementations)]
 

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -64,8 +64,8 @@
 #![needs_allocator]
 
 #![warn(deprecated_in_future)]
-#![deny(intra_doc_link_resolution_failure)]
-#![deny(missing_debug_implementations)]
+#![warn(intra_doc_link_resolution_failure)]
+#![warn(missing_debug_implementations)]
 
 #![cfg_attr(not(test), feature(fn_traits))]
 #![cfg_attr(not(test), feature(generator_trait))]

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)]
-
 //! Single-threaded reference-counting pointers. 'Rc' stands for 'Reference
 //! Counted'.
 //!

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -2048,7 +2048,7 @@ macro_rules! tuple {
     ( $($name:ident,)+ ) => (
         #[stable(feature = "rust1", since = "1.0.0")]
         impl<$($name:Debug),*> Debug for ($($name,)*) where last_type!($($name,)+): ?Sized {
-            #[allow(non_snake_case, unused_assignments, deprecated)]
+            #[allow(non_snake_case, unused_assignments)]
             fn fmt(&self, f: &mut Formatter) -> Result {
                 let mut builder = f.debug_tuple("");
                 let ($(ref $name,)*) = *self;

--- a/src/libcore/fmt/num.rs
+++ b/src/libcore/fmt/num.rs
@@ -1,7 +1,5 @@
 //! Integer and floating-point number formatting
 
-#![allow(deprecated)]
-
 
 use fmt;
 use ops::{Div, Rem, Sub};

--- a/src/libcore/fmt/num.rs
+++ b/src/libcore/fmt/num.rs
@@ -200,7 +200,7 @@ macro_rules! impl_Display {
             };
             let mut buf = uninitialized_array![u8; 39];
             let mut curr = buf.len() as isize;
-            let buf_ptr = MaybeUninit::first_mut_ptr(&mut buf);
+            let buf_ptr = MaybeUninit::first_ptr_mut(&mut buf);
             let lut_ptr = DEC_DIGITS_LUT.as_ptr();
 
             unsafe {

--- a/src/libcore/fmt/num.rs
+++ b/src/libcore/fmt/num.rs
@@ -51,12 +51,7 @@ trait GenericRadix {
         // characters for a base 2 number.
         let zero = T::zero();
         let is_nonnegative = x >= zero;
-        // Creating a `[MaybeUninit; N]` array by first creating a
-        // `MaybeUninit<[MaybeUninit; N]>`; the `into_inner` is safe because the inner
-        // array does not require initialization.
-        let mut buf: [MaybeUninit<u8>; 128] = unsafe {
-            MaybeUninit::uninitialized().into_inner()
-        };
+        let mut buf = uninitialized_array![u8; 128];
         let mut curr = buf.len();
         let base = T::from_u8(Self::BASE);
         if is_nonnegative {
@@ -203,12 +198,7 @@ macro_rules! impl_Display {
                 // convert the negative num to positive by summing 1 to it's 2 complement
                 (!self.$conv_fn()).wrapping_add(1)
             };
-            // Creating a `[MaybeUninit; N]` array by first creating a
-            // `MaybeUninit<[MaybeUninit; N]>`; the `into_inner` is safe because the inner
-            // array does not require initialization.
-            let mut buf: [MaybeUninit<u8>; 39] = unsafe {
-                MaybeUninit::uninitialized().into_inner()
-            };
+            let mut buf = uninitialized_array![u8; 39];
             let mut curr = buf.len() as isize;
             let buf_ptr = MaybeUninit::first_mut_ptr(&mut buf);
             let lut_ptr = DEC_DIGITS_LUT.as_ptr();

--- a/src/libcore/hash/sip.rs
+++ b/src/libcore/hash/sip.rs
@@ -1,6 +1,6 @@
 //! An implementation of SipHash.
 
-#![allow(deprecated)]
+#![allow(deprecated)] // the types in this module are deprecated
 
 use marker::PhantomData;
 use ptr;

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -123,6 +123,7 @@
 #![feature(structural_match)]
 #![feature(abi_unadjusted)]
 #![feature(adx_target_feature)]
+#![feature(maybe_uninit)]
 
 #[prelude_import]
 #[allow(unused)]

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -60,6 +60,7 @@
        test(attr(allow(dead_code, deprecated, unused_variables, unused_mut))))]
 
 #![no_core]
+#![warn(deprecated_in_future)]
 #![deny(missing_docs)]
 #![deny(intra_doc_link_resolution_failure)]
 #![deny(missing_debug_implementations)]

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -58,8 +58,8 @@
        issue_tracker_base_url = "https://github.com/rust-lang/rust/issues/",
        test(no_crate_inject, attr(deny(warnings))),
        test(attr(allow(dead_code, deprecated, unused_variables, unused_mut))))]
-
 #![no_core]
+
 #![warn(deprecated_in_future)]
 #![deny(missing_docs)]
 #![deny(intra_doc_link_resolution_failure)]

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -61,9 +61,9 @@
 #![no_core]
 
 #![warn(deprecated_in_future)]
-#![deny(missing_docs)]
-#![deny(intra_doc_link_resolution_failure)]
-#![deny(missing_debug_implementations)]
+#![warn(missing_docs)]
+#![warn(intra_doc_link_resolution_failure)]
+#![warn(missing_debug_implementations)]
 
 #![feature(allow_internal_unstable)]
 #![feature(arbitrary_self_types)]

--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -547,6 +547,23 @@ macro_rules! unimplemented {
     ($($arg:tt)+) => (panic!("not yet implemented: {}", format_args!($($arg)*)));
 }
 
+/// A macro to create an array of [`MaybeUninit`]
+///
+/// This macro constructs and uninitialized array of the type `[MaybeUninit<K>; N]`.
+///
+/// [`MaybeUninit`]: mem/union.MaybeUninit.html
+#[macro_export]
+#[unstable(feature = "maybe_uninit", issue = "53491")]
+macro_rules! uninitialized_array {
+    // This `into_inner` is safe because an array of `MaybeUninit` does not
+    // require initialization.
+    // FIXME(#49147): Could be replaced by an array initializer, once those can
+    // be any const expression.
+    ($t:ty; $size:expr) => (unsafe {
+        MaybeUninit::<[MaybeUninit<$t>; $size]>::uninitialized().into_inner()
+    });
+}
+
 /// Built-in macros to the compiler itself.
 ///
 /// These macros do not have any corresponding definition with a `macro_rules!`

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -1148,4 +1148,18 @@ impl<T> MaybeUninit<T> {
     pub fn as_mut_ptr(&mut self) -> *mut T {
         unsafe { &mut *self.value as *mut T }
     }
+
+    /// Get a pointer to the first contained values.
+    #[unstable(feature = "maybe_uninit", issue = "53491")]
+    #[inline(always)]
+    pub fn first_ptr(this: &[MaybeUninit<T>]) -> *const T {
+        this as *const [MaybeUninit<T>] as *const T
+    }
+
+    /// Get a mutable pointer to the first contained values.
+    #[unstable(feature = "maybe_uninit", issue = "53491")]
+    #[inline(always)]
+    pub fn first_mut_ptr(this: &mut [MaybeUninit<T>]) -> *mut T {
+        this as *mut [MaybeUninit<T>] as *mut T
+    }
 }

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -1159,7 +1159,7 @@ impl<T> MaybeUninit<T> {
     /// Get a mutable pointer to the first element of the array.
     #[unstable(feature = "maybe_uninit", issue = "53491")]
     #[inline(always)]
-    pub fn first_mut_ptr(this: &mut [MaybeUninit<T>]) -> *mut T {
+    pub fn first_ptr_mut(this: &mut [MaybeUninit<T>]) -> *mut T {
         this as *mut [MaybeUninit<T>] as *mut T
     }
 }

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -1149,14 +1149,14 @@ impl<T> MaybeUninit<T> {
         unsafe { &mut *self.value as *mut T }
     }
 
-    /// Get a pointer to the first contained values.
+    /// Get a pointer to the first element of the array.
     #[unstable(feature = "maybe_uninit", issue = "53491")]
     #[inline(always)]
     pub fn first_ptr(this: &[MaybeUninit<T>]) -> *const T {
         this as *const [MaybeUninit<T>] as *const T
     }
 
-    /// Get a mutable pointer to the first contained values.
+    /// Get a mutable pointer to the first element of the array.
     #[unstable(feature = "maybe_uninit", issue = "53491")]
     #[inline(always)]
     pub fn first_mut_ptr(this: &mut [MaybeUninit<T>]) -> *mut T {

--- a/src/libcore/slice/sort.rs
+++ b/src/libcore/slice/sort.rs
@@ -262,8 +262,8 @@ fn partition_in_blocks<T, F>(v: &mut [T], pivot: &T, is_less: &mut F) -> usize
 
         if start_l == end_l {
             // Trace `block_l` elements from the left side.
-            start_l = MaybeUninit::first_mut_ptr(&mut offsets_l);
-            end_l = MaybeUninit::first_mut_ptr(&mut offsets_l);
+            start_l = MaybeUninit::first_ptr_mut(&mut offsets_l);
+            end_l = MaybeUninit::first_ptr_mut(&mut offsets_l);
             let mut elem = l;
 
             for i in 0..block_l {
@@ -278,8 +278,8 @@ fn partition_in_blocks<T, F>(v: &mut [T], pivot: &T, is_less: &mut F) -> usize
 
         if start_r == end_r {
             // Trace `block_r` elements from the right side.
-            start_r = MaybeUninit::first_mut_ptr(&mut offsets_r);
-            end_r = MaybeUninit::first_mut_ptr(&mut offsets_r);
+            start_r = MaybeUninit::first_ptr_mut(&mut offsets_r);
+            end_r = MaybeUninit::first_ptr_mut(&mut offsets_r);
             let mut elem = r;
 
             for i in 0..block_r {

--- a/src/libcore/slice/sort.rs
+++ b/src/libcore/slice/sort.rs
@@ -216,21 +216,14 @@ fn partition_in_blocks<T, F>(v: &mut [T], pivot: &T, is_less: &mut F) -> usize
     let mut block_l = BLOCK;
     let mut start_l = ptr::null_mut();
     let mut end_l = ptr::null_mut();
-    // Creating a `[MaybeUninit; N]` array by first creating a
-    // `MaybeUninit<[MaybeUninit; N]>`; the `into_inner` is safe because the inner
-    // array does not require initialization.
-    let mut offsets_l: [MaybeUninit<u8>; BLOCK] = unsafe {
-        MaybeUninit::uninitialized().into_inner()
-    };
+    let mut offsets_l: [MaybeUninit<u8>; BLOCK] = uninitialized_array![u8; BLOCK];
 
     // The current block on the right side (from `r.sub(block_r)` to `r`).
     let mut r = unsafe { l.add(v.len()) };
     let mut block_r = BLOCK;
     let mut start_r = ptr::null_mut();
     let mut end_r = ptr::null_mut();
-    let mut offsets_r: [MaybeUninit<u8>; BLOCK] = unsafe {
-        MaybeUninit::uninitialized().into_inner()
-    };
+    let mut offsets_r: [MaybeUninit<u8>; BLOCK] = uninitialized_array![u8; BLOCK];
 
     // FIXME: When we get VLAs, try creating one array of length `min(v.len(), 2 * BLOCK)` rather
     // than two fixed-size arrays of length `BLOCK`. VLAs might be more cache-efficient.

--- a/src/librustc/diagnostics.rs
+++ b/src/librustc/diagnostics.rs
@@ -362,9 +362,9 @@ struct Foo1 { x: &bool }
               // ^ expected lifetime parameter
 struct Foo2<'a> { x: &'a bool } // correct
 
-impl Foo2 { ... }
+impl Foo2 {}
   // ^ expected lifetime parameter
-impl<'a> Foo2<'a> { ... } // correct
+impl<'a> Foo2<'a> {} // correct
 
 struct Bar1 { x: Foo2 }
               // ^^^^ expected lifetime parameter
@@ -777,21 +777,32 @@ struct Foo<'a> {
 }
 ```
 
-Implementations need their own lifetime declarations:
+Impl blocks declare lifetime parameters separately. You need to add lifetime
+parameters to an impl block if you're implementing a type that has a lifetime
+parameter of its own.
+For example:
     
-```
-// error, undeclared lifetime
+```compile_fail,E0261
+// error,  use of undeclared lifetime name `'a`
 impl Foo<'a> {
-    ...
+    fn foo<'a>(x: &'a str) {}
+}
+    
+struct Foo<'a> {
+    x: &'a str,
 }
 ```
 
-Which are declared like this:
+This is fixed by declaring impl block like this:
 
 ```
 // correct
 impl<'a> Foo<'a> {
-    ...
+    fn foo(x: &'a str) {}
+}
+    
+struct Foo<'a> {
+    x: &'a str,
 }
 ```
 "##,

--- a/src/librustc/diagnostics.rs
+++ b/src/librustc/diagnostics.rs
@@ -362,6 +362,10 @@ struct Foo1 { x: &bool }
               // ^ expected lifetime parameter
 struct Foo2<'a> { x: &'a bool } // correct
 
+impl Foo2 { ... }
+  // ^ expected lifetime parameter
+impl<'a> Foo2<'a> { ... } // correct
+
 struct Bar1 { x: Foo2 }
               // ^^^^ expected lifetime parameter
 struct Bar2<'a> { x: Foo2<'a> } // correct
@@ -770,6 +774,24 @@ fn foo<'a>(x: &'a str) {}
 
 struct Foo<'a> {
     x: &'a str,
+}
+```
+
+Implementations need their own lifetime declarations:
+    
+```
+// error, undeclared lifetime
+impl Foo<'a> {
+    ...
+}
+```
+
+Which are declared like this:
+
+```
+// correct
+impl<'a> Foo<'a> {
+    ...
 }
 ```
 "##,

--- a/src/librustc/diagnostics.rs
+++ b/src/librustc/diagnostics.rs
@@ -363,7 +363,7 @@ struct Foo1 { x: &bool }
 struct Foo2<'a> { x: &'a bool } // correct
 
 impl Foo2 {}
-  // ^ expected lifetime parameter
+  // ^^^^ expected lifetime parameter
 impl<'a> Foo2<'a> {} // correct
 
 struct Bar1 { x: Foo2 }
@@ -770,39 +770,39 @@ struct Foo {
 These can be fixed by declaring lifetime parameters:
 
 ```
-fn foo<'a>(x: &'a str) {}
-
 struct Foo<'a> {
     x: &'a str,
 }
+
+fn foo<'a>(x: &'a str) {}
 ```
 
 Impl blocks declare lifetime parameters separately. You need to add lifetime
 parameters to an impl block if you're implementing a type that has a lifetime
 parameter of its own.
 For example:
-    
+
 ```compile_fail,E0261
+struct Foo<'a> {
+    x: &'a str,
+}
+
 // error,  use of undeclared lifetime name `'a`
 impl Foo<'a> {
     fn foo<'a>(x: &'a str) {}
 }
-    
+```
+
+This is fixed by declaring the impl block like this:
+
+```
 struct Foo<'a> {
     x: &'a str,
 }
-```
 
-This is fixed by declaring impl block like this:
-
-```
 // correct
 impl<'a> Foo<'a> {
     fn foo(x: &'a str) {}
-}
-    
-struct Foo<'a> {
-    x: &'a str,
 }
 ```
 "##,

--- a/src/librustc/ty/erase_regions.rs
+++ b/src/librustc/ty/erase_regions.rs
@@ -1,4 +1,4 @@
-use ty::{self, Ty, TyCtxt};
+use ty::{self, Ty, TyCtxt, TypeFlags};
 use ty::fold::{TypeFolder, TypeFoldable};
 
 pub(super) fn provide(providers: &mut ty::query::Providers<'_>) {
@@ -21,6 +21,11 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
     pub fn erase_regions<T>(self, value: &T) -> T
         where T : TypeFoldable<'tcx>
     {
+        // If there's nothing to erase avoid performing the query at all
+        if !value.has_type_flags(TypeFlags::HAS_RE_LATE_BOUND | TypeFlags::HAS_FREE_REGIONS) {
+            return value.clone();
+        }
+
         let value1 = value.fold_with(&mut RegionEraserVisitor { tcx: self });
         debug!("erase_regions({:?}) = {:?}", value, value1);
         value1

--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -19,7 +19,9 @@ use syntax::ext::base::{Annotatable, MacroKind, SyntaxExtension};
 use syntax::ext::expand::{AstFragment, Invocation, InvocationKind};
 use syntax::ext::hygiene::{self, Mark};
 use syntax::ext::tt::macro_rules;
-use syntax::feature_gate::{feature_err, is_builtin_attr_name, GateIssue};
+use syntax::feature_gate::{
+    feature_err, is_builtin_attr_name, AttributeGate, GateIssue, Stability, BUILTIN_ATTRIBUTES,
+};
 use syntax::symbol::{Symbol, keywords};
 use syntax::visit::Visitor;
 use syntax::util::lev_distance::find_best_match_for_name;
@@ -310,15 +312,18 @@ impl<'a> Resolver<'a> {
                             if !features.rustc_attrs {
                                 let msg = "unless otherwise specified, attributes with the prefix \
                                            `rustc_` are reserved for internal compiler diagnostics";
-                                feature_err(&self.session.parse_sess, "rustc_attrs", path.span,
-                                            GateIssue::Language, &msg).emit();
+                                self.report_unknown_attribute(path.span, &name, msg, "rustc_attrs");
                             }
                         } else if !features.custom_attribute {
                             let msg = format!("The attribute `{}` is currently unknown to the \
                                                compiler and may have meaning added to it in the \
                                                future", path);
-                            feature_err(&self.session.parse_sess, "custom_attribute", path.span,
-                                        GateIssue::Language, &msg).emit();
+                            self.report_unknown_attribute(
+                                path.span,
+                                &name,
+                                &msg,
+                                "custom_attribute",
+                            );
                         }
                     }
                 } else {
@@ -337,6 +342,61 @@ impl<'a> Resolver<'a> {
         }
 
         Ok((def, self.get_macro(def)))
+    }
+
+    fn report_unknown_attribute(&self, span: Span, name: &str, msg: &str, feature: &str) {
+        let mut err = feature_err(
+            &self.session.parse_sess,
+            feature,
+            span,
+            GateIssue::Language,
+            &msg,
+        );
+
+        let features = self.session.features_untracked();
+
+        let attr_candidates = BUILTIN_ATTRIBUTES
+            .iter()
+            .filter_map(|(name, _, _, gate)| {
+                if name.starts_with("rustc_") && !features.rustc_attrs {
+                    return None;
+                }
+
+                match gate {
+                    AttributeGate::Gated(Stability::Unstable, ..)
+                        if self.session.opts.unstable_features.is_nightly_build() =>
+                    {
+                        Some(name)
+                    }
+                    AttributeGate::Gated(Stability::Deprecated(..), ..) => Some(name),
+                    AttributeGate::Ungated => Some(name),
+                    _ => None,
+                }
+            })
+            .map(|name| Symbol::intern(name))
+            .chain(
+                // Add built-in macro attributes as well.
+                self.builtin_macros.iter().filter_map(|(name, binding)| {
+                    match binding.macro_kind() {
+                        Some(MacroKind::Attr) => Some(*name),
+                        _ => None,
+                    }
+                }),
+            )
+            .collect::<Vec<_>>();
+
+        let lev_suggestion = find_best_match_for_name(attr_candidates.iter(), &name, None);
+
+        if let Some(suggestion) = lev_suggestion {
+            err.span_suggestion(
+                span,
+                "a built-in attribute with a similar name exists",
+                suggestion.to_string(),
+                Applicability::MaybeIncorrect,
+            );
+        }
+
+        err.emit();
     }
 
     pub fn resolve_macro_to_def_inner(

--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -15,7 +15,7 @@ use syntax::ast::{self, Ident};
 use syntax::attr;
 use syntax::errors::DiagnosticBuilder;
 use syntax::ext::base::{self, Determinacy};
-use syntax::ext::base::{Annotatable, MacroKind, SyntaxExtension};
+use syntax::ext::base::{MacroKind, SyntaxExtension};
 use syntax::ext::expand::{AstFragment, Invocation, InvocationKind};
 use syntax::ext::hygiene::{self, Mark};
 use syntax::ext::tt::macro_rules;
@@ -127,9 +127,9 @@ impl<'a> base::Resolver for Resolver<'a> {
         mark
     }
 
-    fn resolve_dollar_crates(&mut self, annotatable: &Annotatable) {
-        pub struct ResolveDollarCrates<'a, 'b: 'a> {
-            pub resolver: &'a mut Resolver<'b>,
+    fn resolve_dollar_crates(&mut self, fragment: &AstFragment) {
+        struct ResolveDollarCrates<'a, 'b: 'a> {
+            resolver: &'a mut Resolver<'b>
         }
         impl<'a> Visitor<'a> for ResolveDollarCrates<'a, '_> {
             fn visit_ident(&mut self, ident: Ident) {
@@ -144,7 +144,7 @@ impl<'a> base::Resolver for Resolver<'a> {
             fn visit_mac(&mut self, _: &ast::Mac) {}
         }
 
-        annotatable.visit_with(&mut ResolveDollarCrates { resolver: self });
+        fragment.visit_with(&mut ResolveDollarCrates { resolver: self });
     }
 
     fn visit_ast_fragment_with_placeholders(&mut self, mark: Mark, fragment: &AstFragment,

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -537,11 +537,8 @@ impl<'a> Resolver<'a> {
                  primary_binding: &'a NameBinding<'a>, secondary_binding: &'a NameBinding<'a>)
                  -> &'a NameBinding<'a> {
         self.arenas.alloc_name_binding(NameBinding {
-            kind: primary_binding.kind.clone(),
             ambiguity: Some((secondary_binding, kind)),
-            vis: primary_binding.vis,
-            span: primary_binding.span,
-            expansion: primary_binding.expansion,
+            ..primary_binding.clone()
         })
     }
 

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -419,10 +419,6 @@ kbd {
 	color: #ccc;
 }
 
-.impl-items code {
-	background-color: rgba(0, 0, 0, 0);
-}
-
 #sidebar-toggle {
 	background-color: #565656;
 }

--- a/src/librustdoc/html/static/themes/light.css
+++ b/src/librustdoc/html/static/themes/light.css
@@ -414,10 +414,6 @@ kbd {
 	color: #999;
 }
 
-.impl-items code {
-	background-color: rgba(0, 0, 0, 0);
-}
-
 #sidebar-toggle {
 	background-color: #F1F1F1;
 }

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -607,7 +607,7 @@ impl Builder {
 pub fn spawn<F, T>(f: F) -> JoinHandle<T> where
     F: FnOnce() -> T, F: Send + 'static, T: Send + 'static
 {
-    Builder::new().spawn(f).unwrap()
+    Builder::new().spawn(f).expect("failed to spawn thread")
 }
 
 /// Gets a handle to the thread that invokes it.

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -14,7 +14,6 @@ use parse::token;
 use ptr::P;
 use smallvec::SmallVec;
 use symbol::{keywords, Ident, Symbol};
-use visit::Visitor;
 use ThinVec;
 
 use rustc_data_structures::fx::FxHashMap;
@@ -134,17 +133,6 @@ impl Annotatable {
                 _ => false,
             },
             _ => false,
-        }
-    }
-
-    pub fn visit_with<'a, V: Visitor<'a>>(&'a self, visitor: &mut V) {
-        match self {
-            Annotatable::Item(item) => visitor.visit_item(item),
-            Annotatable::TraitItem(trait_item) => visitor.visit_trait_item(trait_item),
-            Annotatable::ImplItem(impl_item) => visitor.visit_impl_item(impl_item),
-            Annotatable::ForeignItem(foreign_item) => visitor.visit_foreign_item(foreign_item),
-            Annotatable::Stmt(stmt) => visitor.visit_stmt(stmt),
-            Annotatable::Expr(expr) => visitor.visit_expr(expr),
         }
     }
 }
@@ -742,7 +730,7 @@ pub trait Resolver {
     fn next_node_id(&mut self) -> ast::NodeId;
     fn get_module_scope(&mut self, id: ast::NodeId) -> Mark;
 
-    fn resolve_dollar_crates(&mut self, annotatable: &Annotatable);
+    fn resolve_dollar_crates(&mut self, fragment: &AstFragment);
     fn visit_ast_fragment_with_placeholders(&mut self, mark: Mark, fragment: &AstFragment,
                                             derives: &[Mark]);
     fn add_builtin(&mut self, ident: ast::Ident, ext: Lrc<SyntaxExtension>);
@@ -776,7 +764,7 @@ impl Resolver for DummyResolver {
     fn next_node_id(&mut self) -> ast::NodeId { ast::DUMMY_NODE_ID }
     fn get_module_scope(&mut self, _id: ast::NodeId) -> Mark { Mark::root() }
 
-    fn resolve_dollar_crates(&mut self, _annotatable: &Annotatable) {}
+    fn resolve_dollar_crates(&mut self, _fragment: &AstFragment) {}
     fn visit_ast_fragment_with_placeholders(&mut self, _invoc: Mark, _fragment: &AstFragment,
                                             _derives: &[Mark]) {}
     fn add_builtin(&mut self, _ident: ast::Ident, _ext: Lrc<SyntaxExtension>) {}

--- a/src/test/pretty/dollar-crate.pp
+++ b/src/test/pretty/dollar-crate.pp
@@ -1,0 +1,18 @@
+#![feature(prelude_import)]
+#![no_std]
+#[prelude_import]
+use ::std::prelude::v1::*;
+#[macro_use]
+extern crate std;
+// pretty-compare-only
+// pretty-mode:expanded
+// pp-exact:dollar-crate.pp
+
+fn main() {
+    {
+        ::std::io::_print(::std::fmt::Arguments::new_v1(&["rust\n"],
+                                                        &match () {
+                                                             () => [],
+                                                         }));
+    };
+}

--- a/src/test/pretty/dollar-crate.rs
+++ b/src/test/pretty/dollar-crate.rs
@@ -1,0 +1,7 @@
+// pretty-compare-only
+// pretty-mode:expanded
+// pp-exact:dollar-crate.pp
+
+fn main() {
+    println!("rust");
+}

--- a/src/test/ui/issues/issue-49074.stderr
+++ b/src/test/ui/issues/issue-49074.stderr
@@ -2,7 +2,7 @@ error[E0658]: The attribute `marco_use` is currently unknown to the compiler and
   --> $DIR/issue-49074.rs:3:3
    |
 LL | #[marco_use] // typo
-   |   ^^^^^^^^^
+   |   ^^^^^^^^^ help: a built-in attribute with a similar name exists: `macro_use`
    |
    = help: add #![feature(custom_attribute)] to the crate attributes to enable
 

--- a/src/test/ui/macros/macro-reexport-removed.stderr
+++ b/src/test/ui/macros/macro-reexport-removed.stderr
@@ -14,7 +14,7 @@ error[E0658]: The attribute `macro_reexport` is currently unknown to the compile
   --> $DIR/macro-reexport-removed.rs:5:3
    |
 LL | #[macro_reexport(macro_one)] //~ ERROR attribute `macro_reexport` is currently unknown
-   |   ^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^ help: a built-in attribute with a similar name exists: `macro_export`
    |
    = help: add #![feature(custom_attribute)] to the crate attributes to enable
 

--- a/src/test/ui/proc-macro/derive-still-gated.stderr
+++ b/src/test/ui/proc-macro/derive-still-gated.stderr
@@ -2,7 +2,7 @@ error[E0658]: The attribute `derive_A` is currently unknown to the compiler and 
   --> $DIR/derive-still-gated.rs:8:3
    |
 LL | #[derive_A] //~ ERROR attribute `derive_A` is currently unknown
-   |   ^^^^^^^^
+   |   ^^^^^^^^ help: a built-in attribute with a similar name exists: `derive`
    |
    = help: add #![feature(custom_attribute)] to the crate attributes to enable
 

--- a/src/test/ui/suggestions/attribute-typos.rs
+++ b/src/test/ui/suggestions/attribute-typos.rs
@@ -1,0 +1,13 @@
+#[deprcated]    //~ ERROR E0658
+fn foo() {}     //~| HELP a built-in attribute with a similar name exists
+                //~| SUGGESTION deprecated
+                //~| HELP add #![feature(custom_attribute)] to the crate attributes to enable
+
+#[tests]        //~ ERROR E0658
+fn bar() {}     //~| HELP a built-in attribute with a similar name exists
+                //~| SUGGESTION test
+                //~| HELP add #![feature(custom_attribute)] to the crate attributes to enable
+
+#[rustc_err]    //~ ERROR E0658
+fn main() {}    //~| HELP add #![feature(rustc_attrs)] to the crate attributes to enable
+                // don't suggest rustc attributes

--- a/src/test/ui/suggestions/attribute-typos.stderr
+++ b/src/test/ui/suggestions/attribute-typos.stderr
@@ -1,0 +1,27 @@
+error[E0658]: unless otherwise specified, attributes with the prefix `rustc_` are reserved for internal compiler diagnostics (see issue #29642)
+  --> $DIR/attribute-typos.rs:11:3
+   |
+LL | #[rustc_err]    //~ ERROR E0658
+   |   ^^^^^^^^^
+   |
+   = help: add #![feature(rustc_attrs)] to the crate attributes to enable
+
+error[E0658]: The attribute `tests` is currently unknown to the compiler and may have meaning added to it in the future (see issue #29642)
+  --> $DIR/attribute-typos.rs:6:3
+   |
+LL | #[tests]        //~ ERROR E0658
+   |   ^^^^^ help: a built-in attribute with a similar name exists: `test`
+   |
+   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+
+error[E0658]: The attribute `deprcated` is currently unknown to the compiler and may have meaning added to it in the future (see issue #29642)
+  --> $DIR/attribute-typos.rs:1:3
+   |
+LL | #[deprcated]    //~ ERROR E0658
+   |   ^^^^^^^^^ help: a built-in attribute with a similar name exists: `deprecated`
+   |
+   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
Successful merges:

 - #57045 (Kill remaining uses of mem::uninitialized in libcore, liballoc)
 - #57674 (Avoid erase_regions_ty queries if there are no regions to erase)
 - #57833 (Print a slightly clearer message when failing to launch a thread)
 - #57859 (Fix invalid background color)
 - #57904 (add typo suggestion to unknown attribute error)
 - #57915 (Pretty print `$crate` as `crate` or `crate_name` in more cases)
 - #57950 (Extend E0106, E0261)

Failed merges:


r? @ghost