### PR TITLE
Remove TrustedRandomAccess specialization for Cloned<T: Copy>

### DIFF
--- a/src/libcore/iter/adapters/mod.rs
+++ b/src/libcore/iter/adapters/mod.rs
@@ -315,26 +315,12 @@ impl<'a, I, T: 'a> FusedIterator for Cloned<I>
 unsafe impl<'a, I, T: 'a> TrustedRandomAccess for Cloned<I>
     where I: TrustedRandomAccess<Item=&'a T>, T: Clone
 {
-    default unsafe fn get_unchecked(&mut self, i: usize) -> Self::Item {
+    unsafe fn get_unchecked(&mut self, i: usize) -> Self::Item {
         self.it.get_unchecked(i).clone()
     }
 
     #[inline]
-    default fn may_have_side_effect() -> bool { true }
-}
-
-#[doc(hidden)]
-unsafe impl<'a, I, T: 'a> TrustedRandomAccess for Cloned<I>
-    where I: TrustedRandomAccess<Item=&'a T>, T: Copy
-{
-    unsafe fn get_unchecked(&mut self, i: usize) -> Self::Item {
-        *self.it.get_unchecked(i)
-    }
-
-    #[inline]
-    fn may_have_side_effect() -> bool {
-        I::may_have_side_effect()
-    }
+    fn may_have_side_effect() -> bool { true }
 }
 
 #[unstable(feature = "trusted_len", issue = "37572")]


### PR DESCRIPTION
For incorrect Clone implementations, this exposes specialization.