### PR TITLE
Add suggestions to deprecation lints

### DIFF
--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -124,6 +124,7 @@
 #![feature(abi_unadjusted)]
 #![feature(adx_target_feature)]
 #![feature(maybe_uninit)]
+#![feature(unrestricted_attribute_tokens)]
 
 #[prelude_import]
 #[allow(unused)]

--- a/src/libcore/sync/atomic.rs
+++ b/src/libcore/sync/atomic.rs
@@ -290,7 +290,15 @@ pub enum Ordering {
 /// [`AtomicBool`]: struct.AtomicBool.html
 #[cfg(target_has_atomic = "8")]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_deprecated(since = "1.34.0", reason = "the `new` function is now preferred")]
+#[cfg_attr(not(stage0), rustc_deprecated(
+    since = "1.34.0",
+    reason = "the `new` function is now preferred",
+    suggestion = "AtomicBool::new(false)",
+))]
+#[cfg_attr(stage0, rustc_deprecated(
+    since = "1.34.0",
+    reason = "the `new` function is now preferred",
+))]
 pub const ATOMIC_BOOL_INIT: AtomicBool = AtomicBool::new(false);
 
 #[cfg(target_has_atomic = "8")]
@@ -1127,6 +1135,7 @@ macro_rules! atomic_int {
      $extra_feature:expr,
      $min_fn:ident, $max_fn:ident,
      $align:expr,
+     $atomic_new:expr,
      $int_type:ident $atomic_type:ident $atomic_init:ident) => {
         /// An integer type which can be safely shared between threads.
         ///
@@ -1148,7 +1157,15 @@ macro_rules! atomic_int {
 
         /// An atomic integer initialized to `0`.
         #[$stable]
-        #[rustc_deprecated(since = "1.34.0", reason = "the `new` function is now preferred")]
+        #[cfg_attr(stage0, rustc_deprecated(
+            since = "1.34.0",
+            reason = "the `new` function is now preferred",
+        ))]
+        #[cfg_attr(not(stage0), rustc_deprecated(
+            since = "1.34.0",
+            reason = "the `new` function is now preferred",
+            suggestion = $atomic_new,
+        ))]
         pub const $atomic_init: $atomic_type = $atomic_type::new(0);
 
         #[$stable]
@@ -1878,6 +1895,7 @@ atomic_int! {
     "#![feature(integer_atomics)]\n\n",
     atomic_min, atomic_max,
     1,
+    "AtomicI8::new(0)",
     i8 AtomicI8 ATOMIC_I8_INIT
 }
 #[cfg(target_has_atomic = "8")]
@@ -1892,6 +1910,7 @@ atomic_int! {
     "#![feature(integer_atomics)]\n\n",
     atomic_umin, atomic_umax,
     1,
+    "AtomicU8::new(0)",
     u8 AtomicU8 ATOMIC_U8_INIT
 }
 #[cfg(target_has_atomic = "16")]
@@ -1906,6 +1925,7 @@ atomic_int! {
     "#![feature(integer_atomics)]\n\n",
     atomic_min, atomic_max,
     2,
+    "AtomicI16::new(0)",
     i16 AtomicI16 ATOMIC_I16_INIT
 }
 #[cfg(target_has_atomic = "16")]
@@ -1920,6 +1940,7 @@ atomic_int! {
     "#![feature(integer_atomics)]\n\n",
     atomic_umin, atomic_umax,
     2,
+    "AtomicU16::new(0)",
     u16 AtomicU16 ATOMIC_U16_INIT
 }
 #[cfg(target_has_atomic = "32")]
@@ -1934,6 +1955,7 @@ atomic_int! {
     "#![feature(integer_atomics)]\n\n",
     atomic_min, atomic_max,
     4,
+    "AtomicI32::new(0)",
     i32 AtomicI32 ATOMIC_I32_INIT
 }
 #[cfg(target_has_atomic = "32")]
@@ -1948,6 +1970,7 @@ atomic_int! {
     "#![feature(integer_atomics)]\n\n",
     atomic_umin, atomic_umax,
     4,
+    "AtomicU32::new(0)",
     u32 AtomicU32 ATOMIC_U32_INIT
 }
 #[cfg(target_has_atomic = "64")]
@@ -1962,6 +1985,7 @@ atomic_int! {
     "#![feature(integer_atomics)]\n\n",
     atomic_min, atomic_max,
     8,
+    "AtomicI64::new(0)",
     i64 AtomicI64 ATOMIC_I64_INIT
 }
 #[cfg(target_has_atomic = "64")]
@@ -1976,6 +2000,7 @@ atomic_int! {
     "#![feature(integer_atomics)]\n\n",
     atomic_umin, atomic_umax,
     8,
+    "AtomicU64::new(0)",
     u64 AtomicU64 ATOMIC_U64_INIT
 }
 #[cfg(target_has_atomic = "128")]
@@ -1990,6 +2015,7 @@ atomic_int! {
     "#![feature(integer_atomics)]\n\n",
     atomic_min, atomic_max,
     16,
+    "AtomicI128::new(0)",
     i128 AtomicI128 ATOMIC_I128_INIT
 }
 #[cfg(target_has_atomic = "128")]
@@ -2004,6 +2030,7 @@ atomic_int! {
     "#![feature(integer_atomics)]\n\n",
     atomic_umin, atomic_umax,
     16,
+    "AtomicU128::new(0)",
     u128 AtomicU128 ATOMIC_U128_INIT
 }
 #[cfg(target_pointer_width = "16")]
@@ -2030,6 +2057,7 @@ atomic_int!{
     "",
     atomic_min, atomic_max,
     ptr_width!(),
+    "AtomicIsize::new(0)",
     isize AtomicIsize ATOMIC_ISIZE_INIT
 }
 #[cfg(target_has_atomic = "ptr")]
@@ -2044,6 +2072,7 @@ atomic_int!{
     "",
     atomic_umin, atomic_umax,
     ptr_width!(),
+    "AtomicUsize::new(0)",
     usize AtomicUsize ATOMIC_USIZE_INIT
 }
 

--- a/src/librustc/ich/impls_syntax.rs
+++ b/src/librustc/ich/impls_syntax.rs
@@ -147,7 +147,7 @@ for ::syntax::attr::StabilityLevel {
     }
 }
 
-impl_stable_hash_for!(struct ::syntax::attr::RustcDeprecation { since, reason });
+impl_stable_hash_for!(struct ::syntax::attr::RustcDeprecation { since, reason, suggestion });
 
 
 impl_stable_hash_for!(enum ::syntax::attr::IntType {

--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -16,6 +16,7 @@ use syntax::symbol::Symbol;
 use syntax_pos::{Span, MultiSpan};
 use syntax::ast;
 use syntax::ast::{NodeId, Attribute};
+use syntax::errors::Applicability;
 use syntax::feature_gate::{GateIssue, emit_feature_err};
 use syntax::attr::{self, Stability, Deprecation};
 use ty::{self, TyCtxt};
@@ -569,6 +570,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         let lint_deprecated = |def_id: DefId,
                                id: NodeId,
                                note: Option<Symbol>,
+                               suggestion: Option<Symbol>,
                                message: &str,
                                lint: &'static Lint| {
             let msg = if let Some(note) = note {
@@ -577,7 +579,18 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
                 format!("{}", message)
             };
 
-            self.lint_node(lint, id, span, &msg);
+            let mut diag = self.struct_span_lint_node(lint, id, span, &msg);
+            if let Some(suggestion) = suggestion {
+                if let hir::Node::Expr(_) = self.hir().get(id) {
+                    diag.span_suggestion(
+                        span,
+                        &msg,
+                        suggestion.to_string(),
+                        Applicability::MachineApplicable,
+                    );
+                }
+            }
+            diag.emit();
             if id == ast::DUMMY_NODE_ID {
                 span_bug!(span, "emitted a {} lint with dummy node id: {:?}", lint.name, def_id);
             }
@@ -613,6 +626,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
                     lint_deprecated(def_id,
                                     id,
                                     depr_entry.attr.note,
+                                    None,
                                     &message,
                                     lint::builtin::DEPRECATED_IN_FUTURE);
                 } else if !skip {
@@ -621,6 +635,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
                     lint_deprecated(def_id,
                                     id,
                                     depr_entry.attr.note,
+                                    None,
                                     &message,
                                     lint::builtin::DEPRECATED);
                 }
@@ -639,27 +654,30 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         debug!("stability: \
                 inspecting def_id={:?} span={:?} of stability={:?}", def_id, span, stability);
 
-        if let Some(&Stability{rustc_depr: Some(attr::RustcDeprecation { reason, since }), ..})
-                = stability {
-            if let Some(id) = id {
-                let path = self.item_path_str(def_id);
-                if deprecation_in_effect(&since.as_str()) {
-                    let message = format!("use of deprecated item '{}'", path);
-                    lint_deprecated(def_id,
-                                    id,
-                                    Some(reason),
-                                    &message,
-                                    lint::builtin::DEPRECATED);
-                } else {
-                    let message = format!("use of item '{}' \
-                                           that will be deprecated in future version {}",
-                                          path,
-                                          since);
-                    lint_deprecated(def_id,
-                                    id,
-                                    Some(reason),
-                                    &message,
-                                    lint::builtin::DEPRECATED_IN_FUTURE);
+        if let Some(id) = id {
+            if let Some(stability) = stability {
+                if let Some(depr) = &stability.rustc_depr {
+                    let path = self.item_path_str(def_id);
+                    if deprecation_in_effect(&depr.since.as_str()) {
+                        let message = format!("use of deprecated item '{}'", path);
+                        lint_deprecated(def_id,
+                                        id,
+                                        Some(depr.reason),
+                                        depr.suggestion,
+                                        &message,
+                                        lint::builtin::DEPRECATED);
+                    } else {
+                        let message = format!("use of item '{}' \
+                                                that will be deprecated in future version {}",
+                                                path,
+                                                depr.since);
+                        lint_deprecated(def_id,
+                                        id,
+                                        Some(depr.reason),
+                                        depr.suggestion,
+                                        &message,
+                                        lint::builtin::DEPRECATED_IN_FUTURE);
+                    }
                 }
             }
         }

--- a/src/libsyntax/attr/builtin.rs
+++ b/src/libsyntax/attr/builtin.rs
@@ -158,6 +158,8 @@ impl StabilityLevel {
 pub struct RustcDeprecation {
     pub since: Symbol,
     pub reason: Symbol,
+    /// A text snippet used to completely replace any use of the deprecated item in an expression.
+    pub suggestion: Option<Symbol>,
 }
 
 /// Check if `attrs` contains an attribute like `#![feature(feature_name)]`.
@@ -274,13 +276,14 @@ fn find_stability_generic<'a, I>(sess: &ParseSess,
                         continue 'outer
                     }
 
-                    get_meta!(since, reason);
+                    get_meta!(since, reason, suggestion);
 
                     match (since, reason) {
                         (Some(since), Some(reason)) => {
                             rustc_depr = Some(RustcDeprecation {
                                 since,
                                 reason,
+                                suggestion,
                             })
                         }
                         (None, _) => {

--- a/src/test/ui/deprecation/atomic_initializers.fixed
+++ b/src/test/ui/deprecation/atomic_initializers.fixed
@@ -1,0 +1,11 @@
+// run-rustfix
+// compile-pass
+
+#[allow(deprecated, unused_imports)]
+use std::sync::atomic::{AtomicIsize, ATOMIC_ISIZE_INIT};
+
+#[allow(dead_code)]
+static FOO: AtomicIsize = AtomicIsize::new(0);
+//~^ WARN use of deprecated item
+
+fn main() {}

--- a/src/test/ui/deprecation/atomic_initializers.rs
+++ b/src/test/ui/deprecation/atomic_initializers.rs
@@ -1,0 +1,11 @@
+// run-rustfix
+// compile-pass
+
+#[allow(deprecated, unused_imports)]
+use std::sync::atomic::{AtomicIsize, ATOMIC_ISIZE_INIT};
+
+#[allow(dead_code)]
+static FOO: AtomicIsize = ATOMIC_ISIZE_INIT;
+//~^ WARN use of deprecated item
+
+fn main() {}

--- a/src/test/ui/deprecation/atomic_initializers.stderr
+++ b/src/test/ui/deprecation/atomic_initializers.stderr
@@ -1,0 +1,12 @@
+warning: use of deprecated item 'std::sync::atomic::ATOMIC_ISIZE_INIT': the `new` function is now preferred
+  --> $DIR/atomic_initializers.rs:8:27
+   |
+LL | static FOO: AtomicIsize = ATOMIC_ISIZE_INIT;
+   |                           ^^^^^^^^^^^^^^^^^
+   |
+   = note: #[warn(deprecated)] on by default
+help: use of deprecated item 'std::sync::atomic::ATOMIC_ISIZE_INIT': the `new` function is now preferred
+   |
+LL | static FOO: AtomicIsize = AtomicIsize::new(0);
+   |                           ^^^^^^^^^^^^^^^^^^^
+


### PR DESCRIPTION
Clippy used to do this suggestion, but the clippy lints happen after the deprecation lints so we ended up never seeing the structured suggestions.