### PR TITLE
Don't panic when accessing enum variant ctor using `Self` in match

### DIFF
--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -784,7 +784,8 @@ https://doc.rust-lang.org/reference/types.html#trait-objects");
                 report_unexpected_variant_def(tcx, &def, pat.span, qpath);
                 return tcx.types.err;
             }
-            Def::VariantCtor(_, CtorKind::Fictive) => {
+            Def::VariantCtor(_, CtorKind::Fictive) |
+            Def::VariantCtor(_, CtorKind::Fn) => {
                 report_unexpected_variant_def(tcx, &def, pat.span, qpath);
                 return tcx.types.err;
             }

--- a/src/test/ui/issues/issue-58006.rs
+++ b/src/test/ui/issues/issue-58006.rs
@@ -1,0 +1,15 @@
+#![feature(type_alias_enum_variants)]
+pub enum Enum {
+    A(usize),
+}
+
+impl Enum {
+    fn foo(&self) -> () {
+        match self {
+            Self::A => (),
+            //~^ ERROR expected unit struct/variant or constant, found tuple variant
+        }
+    }
+}
+
+fn main() {}

--- a/src/test/ui/issues/issue-58006.stderr
+++ b/src/test/ui/issues/issue-58006.stderr
@@ -1,0 +1,9 @@
+error[E0533]: expected unit struct/variant or constant, found tuple variant `<Self>::A`
+  --> $DIR/issue-58006.rs:9:13
+   |
+LL |             Self::A => (),
+   |             ^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0533`.


### PR DESCRIPTION
Fix #58006.

r? @petrochenkov 