### PR TITLE
Pass correct arguments to places_conflict

### DIFF
--- a/src/librustc_mir/dataflow/impls/borrows.rs
+++ b/src/librustc_mir/dataflow/impls/borrows.rs
@@ -215,8 +215,8 @@ impl<'a, 'gcx, 'tcx> Borrows<'a, 'gcx, 'tcx> {
             if places_conflict::places_conflict(
                 self.tcx,
                 self.mir,
-                place,
                 &borrow_data.borrowed_place,
+                place,
                 places_conflict::PlaceConflictBias::NoOverlap,
             ) {
                 debug!(

--- a/src/test/ui/nll/issue-57989.rs
+++ b/src/test/ui/nll/issue-57989.rs
@@ -1,0 +1,12 @@
+// Test for ICE from issue 57989
+
+#![feature(nll)]
+
+fn f(x: &i32) {
+    let g = &x;
+    *x = 0;     //~ ERROR cannot assign to `*x` which is behind a `&` reference
+                //~| ERROR cannot assign to `*x` because it is borrowed
+    g;
+}
+
+fn main() {}

--- a/src/test/ui/nll/issue-57989.stderr
+++ b/src/test/ui/nll/issue-57989.stderr
@@ -1,0 +1,24 @@
+error[E0594]: cannot assign to `*x` which is behind a `&` reference
+  --> $DIR/issue-57989.rs:7:5
+   |
+LL | fn f(x: &i32) {
+   |         ---- help: consider changing this to be a mutable reference: `&mut i32`
+LL |     let g = &x;
+LL |     *x = 0;     //~ ERROR cannot assign to `*x` which is behind a `&` reference
+   |     ^^^^^^ `x` is a `&` reference, so the data it refers to cannot be written
+
+error[E0506]: cannot assign to `*x` because it is borrowed
+  --> $DIR/issue-57989.rs:7:5
+   |
+LL |     let g = &x;
+   |             -- borrow of `*x` occurs here
+LL |     *x = 0;     //~ ERROR cannot assign to `*x` which is behind a `&` reference
+   |     ^^^^^^ assignment to borrowed `*x` occurs here
+LL |                 //~| ERROR cannot assign to `*x` because it is borrowed
+LL |     g;
+   |     - borrow later used here
+
+error: aborting due to 2 previous errors
+
+Some errors occurred: E0506, E0594.
+For more information about an error, try `rustc --explain E0506`.


### PR DESCRIPTION
The borrow place *must* be a place that we track borrows for, otherwise
we will likely ICE.

Closes #57989