### PR TITLE
Rollup of 12 pull requests

### DIFF
--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -71,6 +71,10 @@ accomplishing various tasks.
   </form>
 </div>
 
+## The Edition Guide
+
+[The Edition Guide](edition-guide/index.html) describes the Rust editions.
+
 ## The Rustc Book
 
 [The Rustc Book](rustc/index.html) describes the Rust compiler, `rustc`.

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -435,6 +435,27 @@ impl<T: ?Sized> Rc<T> {
         }
     }
 
+    /// Consumes the `Rc`, returning the wrapped pointer as `NonNull<T>`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(rc_into_raw_non_null)]
+    ///
+    /// use std::rc::Rc;
+    ///
+    /// let x = Rc::new(10);
+    /// let ptr = Rc::into_raw_non_null(x);
+    /// let deref = unsafe { *ptr.as_ref() };
+    /// assert_eq!(deref, 10);
+    /// ```
+    #[unstable(feature = "rc_into_raw_non_null", issue = "47336")]
+    #[inline]
+    pub fn into_raw_non_null(this: Self) -> NonNull<T> {
+        // safe because Rc guarantees its pointer is non-null
+        unsafe { NonNull::new_unchecked(Rc::into_raw(this) as *mut _) }
+    }
+
     /// Creates a new [`Weak`][weak] pointer to this value.
     ///
     /// [weak]: struct.Weak.html

--- a/src/liballoc/sync.rs
+++ b/src/liballoc/sync.rs
@@ -413,6 +413,27 @@ impl<T: ?Sized> Arc<T> {
         }
     }
 
+    /// Consumes the `Arc`, returning the wrapped pointer as `NonNull<T>`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(rc_into_raw_non_null)]
+    ///
+    /// use std::sync::Arc;
+    ///
+    /// let x = Arc::new(10);
+    /// let ptr = Arc::into_raw_non_null(x);
+    /// let deref = unsafe { *ptr.as_ref() };
+    /// assert_eq!(deref, 10);
+    /// ```
+    #[unstable(feature = "rc_into_raw_non_null", issue = "47336")]
+    #[inline]
+    pub fn into_raw_non_null(this: Self) -> NonNull<T> {
+        // safe because Arc guarantees its pointer is non-null
+        unsafe { NonNull::new_unchecked(Arc::into_raw(this) as *mut _) }
+    }
+
     /// Creates a new [`Weak`][weak] pointer to this value.
     ///
     /// [weak]: struct.Weak.html

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -3544,6 +3544,8 @@ impl str {
     ///
     /// assert_eq!("Hello\tworld", s.trim());
     /// ```
+    #[must_use = "this returns the trimmed string as a new allocation, \
+                  without modifying the original"]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn trim(&self) -> &str {
         self.trim_matches(|c: char| c.is_whitespace())
@@ -3579,6 +3581,8 @@ impl str {
     /// let s = "  עברית  ";
     /// assert!(Some('ע') == s.trim_start().chars().next());
     /// ```
+    #[must_use = "this returns the trimmed string as a new allocation, \
+                  without modifying the original"]
     #[stable(feature = "trim_direction", since = "1.30.0")]
     pub fn trim_start(&self) -> &str {
         self.trim_start_matches(|c: char| c.is_whitespace())
@@ -3614,6 +3618,8 @@ impl str {
     /// let s = "  עברית  ";
     /// assert!(Some('ת') == s.trim_end().chars().rev().next());
     /// ```
+    #[must_use = "this returns the trimmed string as a new allocation, \
+                  without modifying the original"]
     #[stable(feature = "trim_direction", since = "1.30.0")]
     pub fn trim_end(&self) -> &str {
         self.trim_end_matches(|c: char| c.is_whitespace())
@@ -3716,6 +3722,8 @@ impl str {
     /// ```
     /// assert_eq!("1foo1barXX".trim_matches(|c| c == '1' || c == 'X'), "foo1bar");
     /// ```
+    #[must_use = "this returns the trimmed string as a new allocation, \
+                  without modifying the original"]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn trim_matches<'a, P: Pattern<'a>>(&'a self, pat: P) -> &'a str
         where P::Searcher: DoubleEndedSearcher<'a>
@@ -3761,6 +3769,8 @@ impl str {
     /// let x: &[_] = &['1', '2'];
     /// assert_eq!("12foo1bar12".trim_start_matches(x), "foo1bar12");
     /// ```
+    #[must_use = "this returns the trimmed string as a new allocation, \
+                  without modifying the original"]
     #[stable(feature = "trim_direction", since = "1.30.0")]
     pub fn trim_start_matches<'a, P: Pattern<'a>>(&'a self, pat: P) -> &'a str {
         let mut i = self.len();
@@ -3804,6 +3814,8 @@ impl str {
     /// ```
     /// assert_eq!("1fooX".trim_end_matches(|c| c == '1' || c == 'X'), "1foo");
     /// ```
+    #[must_use = "this returns the trimmed string as a new allocation, \
+                  without modifying the original"]
     #[stable(feature = "trim_direction", since = "1.30.0")]
     pub fn trim_end_matches<'a, P: Pattern<'a>>(&'a self, pat: P) -> &'a str
         where P::Searcher: ReverseSearcher<'a>

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -3544,7 +3544,7 @@ impl str {
     ///
     /// assert_eq!("Hello\tworld", s.trim());
     /// ```
-    #[must_use = "this returns the trimmed string as a new allocation, \
+    #[must_use = "this returns the trimmed string as a slice, \
                   without modifying the original"]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn trim(&self) -> &str {

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -3774,10 +3774,10 @@ impl str {
     ///
     /// # Text directionality
     ///
-    /// A string is a sequence of bytes. 'Left' in this context means the first
-    /// position of that byte string; for a language like Arabic or Hebrew
-    /// which are 'right to left' rather than 'left to right', this will be
-    /// the _right_ side, not the left.
+    /// A string is a sequence of bytes. `start` in this context means the first
+    /// position of that byte string; for a left-to-right language like English or
+    /// Russian, this will be left side; and for right-to-left languages like
+    /// like Arabic or Hebrew, this will be the right side.
     ///
     /// # Examples
     ///
@@ -3806,10 +3806,10 @@ impl str {
     ///
     /// # Text directionality
     ///
-    /// A string is a sequence of bytes. 'Right' in this context means the last
-    /// position of that byte string; for a language like Arabic or Hebrew
-    /// which are 'right to left' rather than 'left to right', this will be
-    /// the _left_ side, not the right.
+    /// A string is a sequence of bytes. `end` in this context means the last
+    /// position of that byte string; for a left-to-right language like English or
+    /// Russian, this will be right side; and for right-to-left languages like
+    /// like Arabic or Hebrew, this will be the left side.
     ///
     /// # Examples
     ///

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -3581,7 +3581,7 @@ impl str {
     /// let s = "  עברית  ";
     /// assert!(Some('ע') == s.trim_start().chars().next());
     /// ```
-    #[must_use = "this returns the trimmed string as a new allocation, \
+    #[must_use = "this returns the trimmed string as a new slice, \
                   without modifying the original"]
     #[stable(feature = "trim_direction", since = "1.30.0")]
     pub fn trim_start(&self) -> &str {
@@ -3618,7 +3618,7 @@ impl str {
     /// let s = "  עברית  ";
     /// assert!(Some('ת') == s.trim_end().chars().rev().next());
     /// ```
-    #[must_use = "this returns the trimmed string as a new allocation, \
+    #[must_use = "this returns the trimmed string as a new slice, \
                   without modifying the original"]
     #[stable(feature = "trim_direction", since = "1.30.0")]
     pub fn trim_end(&self) -> &str {
@@ -3722,7 +3722,7 @@ impl str {
     /// ```
     /// assert_eq!("1foo1barXX".trim_matches(|c| c == '1' || c == 'X'), "foo1bar");
     /// ```
-    #[must_use = "this returns the trimmed string as a new allocation, \
+    #[must_use = "this returns the trimmed string as a new slice, \
                   without modifying the original"]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn trim_matches<'a, P: Pattern<'a>>(&'a self, pat: P) -> &'a str
@@ -3769,7 +3769,7 @@ impl str {
     /// let x: &[_] = &['1', '2'];
     /// assert_eq!("12foo1bar12".trim_start_matches(x), "foo1bar12");
     /// ```
-    #[must_use = "this returns the trimmed string as a new allocation, \
+    #[must_use = "this returns the trimmed string as a new slice, \
                   without modifying the original"]
     #[stable(feature = "trim_direction", since = "1.30.0")]
     pub fn trim_start_matches<'a, P: Pattern<'a>>(&'a self, pat: P) -> &'a str {
@@ -3814,7 +3814,7 @@ impl str {
     /// ```
     /// assert_eq!("1fooX".trim_end_matches(|c| c == '1' || c == 'X'), "1foo");
     /// ```
-    #[must_use = "this returns the trimmed string as a new allocation, \
+    #[must_use = "this returns the trimmed string as a new slice, \
                   without modifying the original"]
     #[stable(feature = "trim_direction", since = "1.30.0")]
     pub fn trim_end_matches<'a, P: Pattern<'a>>(&'a self, pat: P) -> &'a str

--- a/src/librustc/mir/interpret/value.rs
+++ b/src/librustc/mir/interpret/value.rs
@@ -14,7 +14,7 @@ pub struct RawConst<'tcx> {
 }
 
 /// Represents a constant value in Rust. Scalar and ScalarPair are optimizations which
-/// matches the LocalValue optimizations for easy conversions between Value and ConstValue.
+/// matches the LocalState optimizations for easy conversions between Value and ConstValue.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord, RustcEncodable, RustcDecodable, Hash)]
 pub enum ConstValue<'tcx> {
     /// Used only for types with layout::abi::Scalar ABI and ZSTs

--- a/src/librustc_codegen_llvm/llvm_util.rs
+++ b/src/librustc_codegen_llvm/llvm_util.rs
@@ -147,6 +147,7 @@ const X86_WHITELIST: &[(&str, Option<&str>)] = &[
     ("fxsr", None),
     ("lzcnt", None),
     ("mmx", Some("mmx_target_feature")),
+    ("movbe", Some("movbe_target_feature")),
     ("pclmulqdq", None),
     ("popcnt", None),
     ("rdrand", None),

--- a/src/librustc_mir/dataflow/impls/borrows.rs
+++ b/src/librustc_mir/dataflow/impls/borrows.rs
@@ -215,8 +215,8 @@ impl<'a, 'gcx, 'tcx> Borrows<'a, 'gcx, 'tcx> {
             if places_conflict::places_conflict(
                 self.tcx,
                 self.mir,
-                place,
                 &borrow_data.borrowed_place,
+                place,
                 places_conflict::PlaceConflictBias::NoOverlap,
             ) {
                 debug!(

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -323,8 +323,8 @@ impl<'a, 'mir, 'tcx: 'mir, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tc
         let cell = &frame.locals[local].layout;
         if cell.get().is_none() {
             let layout = ::interpret::operand::from_known_layout(layout, || {
-            let local_ty = frame.mir.local_decls[local].ty;
-            let local_ty = self.monomorphize_with_substs(local_ty, frame.instance.substs);
+                let local_ty = frame.mir.local_decls[local].ty;
+                let local_ty = self.monomorphize_with_substs(local_ty, frame.instance.substs);
                 self.layout_of(local_ty)
             })?;
             cell.set(Some(layout));

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -510,7 +510,8 @@ impl<'a, 'mir, 'tcx: 'mir, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tc
                 match local.state {
                     LocalState::Live(_) => {
                         // This needs to be properly initialized.
-                        let layout = self.layout_of(mir.local_decls[idx].ty)?;
+                        let ty = self.monomorphize(mir.local_decls[idx].ty)?;
+                        let layout = self.layout_of(ty)?;
                         local.state = LocalState::Live(self.uninit_operand(layout)?);
                         local.layout = Cell::new(Some(layout));
                     }

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -509,9 +509,10 @@ impl<'a, 'mir, 'tcx: 'mir, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tc
             for (idx, local) in locals.iter_enumerated_mut() {
                 match local.state {
                     LocalState::Live(_) => {
-                        // This needs to be peoperly initialized.
-                        let layout = self.layout_of_local(self.frame(), idx, None)?;
+                        // This needs to be properly initialized.
+                        let layout = self.layout_of(mir.local_decls[idx].ty)?;
                         local.state = LocalState::Live(self.uninit_operand(layout)?);
+                        local.layout = Cell::new(Some(layout));
                     }
                     LocalState::Dead => {
                         // Nothing to do

--- a/src/librustc_mir/interpret/mod.rs
+++ b/src/librustc_mir/interpret/mod.rs
@@ -18,7 +18,7 @@ mod visitor;
 pub use rustc::mir::interpret::*; // have all the `interpret` symbols in one place: here
 
 pub use self::eval_context::{
-    EvalContext, Frame, StackPopCleanup, LocalValue, LocalState,
+    EvalContext, Frame, StackPopCleanup, LocalState, LocalValue,
 };
 
 pub use self::place::{Place, PlaceTy, MemPlace, MPlaceTy};

--- a/src/librustc_mir/interpret/mod.rs
+++ b/src/librustc_mir/interpret/mod.rs
@@ -18,7 +18,7 @@ mod visitor;
 pub use rustc::mir::interpret::*; // have all the `interpret` symbols in one place: here
 
 pub use self::eval_context::{
-    EvalContext, Frame, StackPopCleanup, LocalValue,
+    EvalContext, Frame, StackPopCleanup, LocalValue, LocalState,
 };
 
 pub use self::place::{Place, PlaceTy, MemPlace, MPlaceTy};

--- a/src/librustc_mir/interpret/operand.rs
+++ b/src/librustc_mir/interpret/operand.rs
@@ -227,7 +227,7 @@ impl<'tcx, Tag> OpTy<'tcx, Tag>
 // Use the existing layout if given (but sanity check in debug mode),
 // or compute the layout.
 #[inline(always)]
-fn from_known_layout<'tcx>(
+pub(super) fn from_known_layout<'tcx>(
     layout: Option<TyLayout<'tcx>>,
     compute: impl FnOnce() -> EvalResult<'tcx, TyLayout<'tcx>>
 ) -> EvalResult<'tcx, TyLayout<'tcx>> {
@@ -461,10 +461,11 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
         &self,
         frame: &super::Frame<'mir, 'tcx, M::PointerTag, M::FrameExtra>,
         local: mir::Local,
+        layout: Option<TyLayout<'tcx>>,
     ) -> EvalResult<'tcx, OpTy<'tcx, M::PointerTag>> {
         assert_ne!(local, mir::RETURN_PLACE);
         let op = *frame.locals[local].access()?;
-        let layout = self.layout_of_local(frame, local)?;
+        let layout = self.layout_of_local(frame, local, layout)?;
         Ok(OpTy { op, layout })
     }
 
@@ -473,14 +474,15 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
     fn eval_place_to_op(
         &self,
         mir_place: &mir::Place<'tcx>,
+        layout: Option<TyLayout<'tcx>>,
     ) -> EvalResult<'tcx, OpTy<'tcx, M::PointerTag>> {
         use rustc::mir::Place::*;
         let op = match *mir_place {
             Local(mir::RETURN_PLACE) => return err!(ReadFromReturnPointer),
-            Local(local) => self.access_local(self.frame(), local)?,
+            Local(local) => self.access_local(self.frame(), local, layout)?,
 
             Projection(ref proj) => {
-                let op = self.eval_place_to_op(&proj.base)?;
+                let op = self.eval_place_to_op(&proj.base, None)?;
                 self.operand_projection(op, &proj.elem)?
             }
 
@@ -504,7 +506,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
             // FIXME: do some more logic on `move` to invalidate the old location
             Copy(ref place) |
             Move(ref place) =>
-                self.eval_place_to_op(place)?,
+                self.eval_place_to_op(place, layout)?,
 
             Constant(ref constant) => {
                 let layout = from_known_layout(layout, || {

--- a/src/librustc_mir/interpret/operand.rs
+++ b/src/librustc_mir/interpret/operand.rs
@@ -457,7 +457,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
     }
 
     /// This is used by [priroda](https://github.com/oli-obk/priroda) to get an OpTy from a local
-    fn access_local(
+    pub fn access_local(
         &self,
         frame: &super::Frame<'mir, 'tcx, M::PointerTag, M::FrameExtra>,
         local: mir::Local,

--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -624,7 +624,7 @@ where
                     // their layout on return.
                     PlaceTy {
                         place: *return_place,
-                        layout: self.layout_of(self.frame().mir.return_ty())?,
+                        layout: self.layout_of(self.monomorphize(self.frame().mir.return_ty())?)?,
                     },
                 None => return err!(InvalidNullPointerUsage),
             },

--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -624,7 +624,7 @@ where
                     // their layout on return.
                     PlaceTy {
                         place: *return_place,
-                        layout: self.layout_of_local(self.frame(), mir::RETURN_PLACE, None)?,
+                        layout: self.layout_of(self.frame().mir.return_ty())?,
                     },
                 None => return err!(InvalidNullPointerUsage),
             },

--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -624,7 +624,7 @@ where
                     // their layout on return.
                     PlaceTy {
                         place: *return_place,
-                        layout: self.layout_of_local(self.frame(), mir::RETURN_PLACE)?,
+                        layout: self.layout_of_local(self.frame(), mir::RETURN_PLACE, None)?,
                     },
                 None => return err!(InvalidNullPointerUsage),
             },
@@ -633,7 +633,7 @@ where
                     frame: self.cur_frame(),
                     local,
                 },
-                layout: self.layout_of_local(self.frame(), local)?,
+                layout: self.layout_of_local(self.frame(), local, None)?,
             },
 
             Projection(ref proj) => {
@@ -901,7 +901,7 @@ where
                         // We need the layout of the local.  We can NOT use the layout we got,
                         // that might e.g., be an inner field of a struct with `Scalar` layout,
                         // that has different alignment than the outer field.
-                        let local_layout = self.layout_of_local(&self.stack[frame], local)?;
+                        let local_layout = self.layout_of_local(&self.stack[frame], local, None)?;
                         let ptr = self.allocate(local_layout, MemoryKind::Stack);
                         // We don't have to validate as we can assume the local
                         // was already valid for its type.

--- a/src/librustc_mir/interpret/snapshot.rs
+++ b/src/librustc_mir/interpret/snapshot.rs
@@ -23,8 +23,8 @@ use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use syntax::ast::Mutability;
 use syntax::source_map::Span;
 
-use super::eval_context::{LocalValue, StackPopCleanup};
-use super::{Frame, Memory, Operand, MemPlace, Place, Immediate, ScalarMaybeUndef, LocalState};
+use super::eval_context::{LocalState, StackPopCleanup};
+use super::{Frame, Memory, Operand, MemPlace, Place, Immediate, ScalarMaybeUndef, LocalValue};
 use const_eval::CompileTimeInterpreter;
 
 #[derive(Default)]
@@ -250,11 +250,11 @@ impl_snapshot_for!(enum Operand {
     Indirect(m),
 });
 
-impl_stable_hash_for!(enum ::interpret::LocalState {
+impl_stable_hash_for!(enum ::interpret::LocalValue {
     Dead,
     Live(x),
 });
-impl_snapshot_for!(enum LocalState {
+impl_snapshot_for!(enum LocalValue {
     Live(v),
     Dead,
 });
@@ -309,7 +309,7 @@ struct FrameSnapshot<'a, 'tcx: 'a> {
     span: &'a Span,
     return_to_block: &'a StackPopCleanup,
     return_place: Option<Place<(), AllocIdSnapshot<'a>>>,
-    locals: IndexVec<mir::Local, LocalState<(), AllocIdSnapshot<'a>>>,
+    locals: IndexVec<mir::Local, LocalValue<(), AllocIdSnapshot<'a>>>,
     block: &'a mir::BasicBlock,
     stmt: usize,
 }
@@ -356,17 +356,17 @@ impl<'a, 'mir, 'tcx, Ctx> Snapshot<'a, Ctx> for &'a Frame<'mir, 'tcx>
     }
 }
 
-impl<'a, 'tcx, Ctx> Snapshot<'a, Ctx> for &'a LocalValue<'tcx>
+impl<'a, 'tcx, Ctx> Snapshot<'a, Ctx> for &'a LocalState<'tcx>
     where Ctx: SnapshotContext<'a>,
 {
-    type Item = LocalState<(), AllocIdSnapshot<'a>>;
+    type Item = LocalValue<(), AllocIdSnapshot<'a>>;
 
     fn snapshot(&self, ctx: &'a Ctx) -> Self::Item {
         self.state.snapshot(ctx)
     }
 }
 
-impl_stable_hash_for!(struct LocalValue<'tcx> {
+impl_stable_hash_for!(struct LocalState<'tcx> {
     state,
     layout -> _,
 });

--- a/src/librustc_mir/interpret/snapshot.rs
+++ b/src/librustc_mir/interpret/snapshot.rs
@@ -362,7 +362,8 @@ impl<'a, 'tcx, Ctx> Snapshot<'a, Ctx> for &'a LocalState<'tcx>
     type Item = LocalValue<(), AllocIdSnapshot<'a>>;
 
     fn snapshot(&self, ctx: &'a Ctx) -> Self::Item {
-        self.state.snapshot(ctx)
+        let LocalState { state, layout: _ } = self;
+        state.snapshot(ctx)
     }
 }
 

--- a/src/librustc_mir/interpret/snapshot.rs
+++ b/src/librustc_mir/interpret/snapshot.rs
@@ -7,7 +7,7 @@
 
 use std::hash::{Hash, Hasher};
 
-use rustc::ich::{StableHashingContextProvider, StableHashingContext};
+use rustc::ich::StableHashingContextProvider;
 use rustc::mir;
 use rustc::mir::interpret::{
     AllocId, Pointer, Scalar,
@@ -19,7 +19,7 @@ use rustc::ty::{self, TyCtxt};
 use rustc::ty::layout::Align;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_data_structures::indexed_vec::IndexVec;
-use rustc_data_structures::stable_hasher::{HashStable, StableHasher, StableHasherResult};
+use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use syntax::ast::Mutability;
 use syntax::source_map::Span;
 
@@ -366,16 +366,10 @@ impl<'a, 'tcx, Ctx> Snapshot<'a, Ctx> for &'a LocalValue<'tcx>
     }
 }
 
-
-impl<'a, 'gcx> HashStable<StableHashingContext<'a>> for LocalValue<'gcx> {
-    fn hash_stable<W: StableHasherResult>(
-        &self,
-        hcx: &mut StableHashingContext<'a>,
-        hasher: &mut StableHasher<W>,
-    ) {
-        self.state.hash_stable(hcx, hasher);
-    }
-}
+impl_stable_hash_for!(struct LocalValue<'tcx> {
+    state,
+    layout -> _,
+});
 
 impl<'a, 'b, 'mir, 'tcx: 'a+'mir> SnapshotContext<'b>
     for Memory<'a, 'mir, 'tcx, CompileTimeInterpreter<'a, 'mir, 'tcx>>

--- a/src/librustc_mir/interpret/terminator.rs
+++ b/src/librustc_mir/interpret/terminator.rs
@@ -309,7 +309,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
                         mir.spread_arg,
                         mir.args_iter()
                             .map(|local|
-                                (local, self.layout_of_local(self.frame(), local).unwrap().ty)
+                                (local, self.layout_of_local(self.frame(), local, None).unwrap().ty)
                             )
                             .collect::<Vec<_>>()
                     );
@@ -383,7 +383,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
                         }
                     } else {
                         let callee_layout =
-                            self.layout_of_local(self.frame(), mir::RETURN_PLACE)?;
+                            self.layout_of_local(self.frame(), mir::RETURN_PLACE, None)?;
                         if !callee_layout.abi.is_uninhabited() {
                             return err!(FunctionRetMismatch(
                                 self.tcx.types.never, callee_layout.ty

--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -784,7 +784,8 @@ https://doc.rust-lang.org/reference/types.html#trait-objects");
                 report_unexpected_variant_def(tcx, &def, pat.span, qpath);
                 return tcx.types.err;
             }
-            Def::VariantCtor(_, CtorKind::Fictive) => {
+            Def::VariantCtor(_, CtorKind::Fictive) |
+            Def::VariantCtor(_, CtorKind::Fn) => {
                 report_unexpected_variant_def(tcx, &def, pat.span, qpath);
                 return tcx.types.err;
             }

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -2205,6 +2205,7 @@ fn from_target_feature(
                 Some("wasm_target_feature") => rust_features.wasm_target_feature,
                 Some("cmpxchg16b_target_feature") => rust_features.cmpxchg16b_target_feature,
                 Some("adx_target_feature") => rust_features.adx_target_feature,
+                Some("movbe_target_feature") => rust_features.movbe_target_feature,
                 Some(name) => bug!("unknown target feature gate {}", name),
                 None => true,
             };

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1303,12 +1303,12 @@ fn type_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) -> Ty<'tcx> {
             }
         },
 
-        Node::GenericParam(param) => match param.kind {
+        Node::GenericParam(param) => match &param.kind {
             hir::GenericParamKind::Type {
                 default: Some(ref ty),
                 ..
             } => icx.to_ty(ty),
-            _ => bug!("unexpected non-type NodeGenericParam"),
+            x => bug!("unexpected non-type Node::GenericParam: {:?}", x),
         },
 
         x => {

--- a/src/libstd/sys/sgx/abi/entry.S
+++ b/src/libstd/sys/sgx/abi/entry.S
@@ -66,7 +66,7 @@ IMAGE_BASE:
     globvar EH_FRM_HDR_SIZE 8
 
 .Lreentry_panic_msg:
-    .asciz "Re-entered panicked enclave!"
+    .asciz "Re-entered aborted enclave!"
 .Lreentry_panic_msg_end:
 
 .Lusercall_panic_msg:
@@ -80,7 +80,7 @@ IMAGE_BASE:
     .org .+48 /*  reserved bits */
 
 .data
-.Lpanicked:
+.Laborted:
     .byte 0
 
 /*  TCS local storage section */
@@ -134,6 +134,9 @@ sgx_entry:
     jz .Lskip_debug_init
     mov %r10,%gs:tcsls_debug_panic_buf_ptr
 .Lskip_debug_init:
+/*  check for abort */
+    bt $0,.Laborted(%rip)
+    jc .Lreentry_panic
 /*  check if returning from usercall */
     mov %gs:tcsls_last_rsp,%r11
     test %r11,%r11
@@ -164,9 +167,6 @@ sgx_entry:
     mov %r14,%r8
     mov %r15,%r9
 .Lskip_init:
-/*  check for panic */
-    bt $0,.Lpanicked(%rip)
-    jc .Lreentry_panic
 /*  call into main entry point */
     load_tcsls_flag_secondary_bool cx /* RCX = entry() argument: secondary: bool */
     call entry /* RDI, RSI, RDX, R8, R9 passed in from userspace */
@@ -237,18 +237,18 @@ sgx_entry:
     stmxcsr (%rsp)
 .endm
 
-.global panic_exit
-panic_exit:
+.global usercall_exit
+usercall_exit:
 /* save registers in DEBUG mode, so that debugger can reconstruct the stack */
     testb $0xff,DEBUG(%rip)
     jz .Lskip_save_registers
     push_callee_saved_registers
     movq %rsp,%gs:tcsls_panic_last_rsp
 .Lskip_save_registers:
-/* set panicked bit */
-    movb $1,.Lpanicked(%rip)
+/* set aborted bit */
+    movb $1,.Laborted(%rip)
 /* call usercall exit(true) */
-    mov $1,%esi   /*  RSI = usercall() argument: panic = true */
+    /* NOP: mov %rsi,%rsi */ /*  RSI = usercall() argument: panic */
     xor %rdx,%rdx /*  RDX cleared */
     movq $usercall_nr_exit,%rdi /*  RDI = usercall exit */
     jmp .Lexit

--- a/src/libstd/sys/sgx/abi/usercalls/mod.rs
+++ b/src/libstd/sys/sgx/abi/usercalls/mod.rs
@@ -119,7 +119,7 @@ pub unsafe fn launch_thread() -> IoResult<()> {
 /// Usercall `exit`. See the ABI documentation for more information.
 #[unstable(feature = "sgx_platform", issue = "56975")]
 pub fn exit(panic: bool) -> ! {
-    unsafe { raw::exit(panic) }
+    unsafe { super::panic::usercall_exit(panic) }
 }
 
 /// Usercall `wait`. See the ABI documentation for more information.

--- a/src/libstd/sys/sgx/mod.rs
+++ b/src/libstd/sys/sgx/mod.rs
@@ -125,7 +125,7 @@ pub unsafe fn strlen(mut s: *const c_char) -> usize {
 }
 
 pub unsafe fn abort_internal() -> ! {
-    abi::panic::panic_exit()
+    abi::panic::usercall_exit(true)
 }
 
 pub fn hashmap_random_keys() -> (u64, u64) {

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -394,6 +394,7 @@ declare_features! (
     (active, wasm_target_feature, "1.30.0", Some(44839), None),
     (active, adx_target_feature, "1.32.0", Some(44839), None),
     (active, cmpxchg16b_target_feature, "1.32.0", Some(44839), None),
+    (active, movbe_target_feature, "1.34.0", Some(44839), None),
 
     // Allows macro invocations on modules expressions and statements and
     // procedural macros to expand to non-items.

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4381,8 +4381,13 @@ impl<'a> Parser<'a> {
             if let Ok(seq_snippet) = self.sess.source_map().span_to_snippet(seq_span) {
                 err.span_suggestion(
                     seq_span,
-                    "try adding parentheses",
+                    "try adding parentheses to match on a tuple..",
                     format!("({})", seq_snippet),
+                    Applicability::MachineApplicable
+                ).span_suggestion(
+                    seq_span,
+                    "..or a vertical bar to match on multiple alternatives",
+                    format!("{}", seq_snippet.replace(",", " |")),
                     Applicability::MachineApplicable
                 );
             }

--- a/src/test/ui/did_you_mean/issue-48492-tuple-destructure-missing-parens.stderr
+++ b/src/test/ui/did_you_mean/issue-48492-tuple-destructure-missing-parens.stderr
@@ -2,37 +2,85 @@ error: unexpected `,` in pattern
   --> $DIR/issue-48492-tuple-destructure-missing-parens.rs:38:17
    |
 LL |     while let b1, b2, b3 = reading_frame.next().expect("there should be a start codon") {
-   |               --^------- help: try adding parentheses: `(b1, b2, b3)`
+   |                 ^
+help: try adding parentheses to match on a tuple..
+   |
+LL |     while let (b1, b2, b3) = reading_frame.next().expect("there should be a start codon") {
+   |               ^^^^^^^^^^^^
+help: ..or a vertical bar to match on multiple alternatives
+   |
+LL |     while let b1 | b2 | b3 = reading_frame.next().expect("there should be a start codon") {
+   |               ^^^^^^^^^^^^
 
 error: unexpected `,` in pattern
   --> $DIR/issue-48492-tuple-destructure-missing-parens.rs:49:14
    |
 LL |     if let b1, b2, b3 = reading_frame.next().unwrap() {
-   |            --^------- help: try adding parentheses: `(b1, b2, b3)`
+   |              ^
+help: try adding parentheses to match on a tuple..
+   |
+LL |     if let (b1, b2, b3) = reading_frame.next().unwrap() {
+   |            ^^^^^^^^^^^^
+help: ..or a vertical bar to match on multiple alternatives
+   |
+LL |     if let b1 | b2 | b3 = reading_frame.next().unwrap() {
+   |            ^^^^^^^^^^^^
 
 error: unexpected `,` in pattern
   --> $DIR/issue-48492-tuple-destructure-missing-parens.rs:59:28
    |
 LL |         Nucleotide::Adenine, Nucleotide::Cytosine, _ => true
-   |         -------------------^------------------------ help: try adding parentheses: `(Nucleotide::Adenine, Nucleotide::Cytosine, _)`
+   |                            ^
+help: try adding parentheses to match on a tuple..
+   |
+LL |         (Nucleotide::Adenine, Nucleotide::Cytosine, _) => true
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: ..or a vertical bar to match on multiple alternatives
+   |
+LL |         Nucleotide::Adenine | Nucleotide::Cytosine | _ => true
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: unexpected `,` in pattern
   --> $DIR/issue-48492-tuple-destructure-missing-parens.rs:67:10
    |
 LL |     for x, _barr_body in women.iter().map(|woman| woman.allosomes.clone()) {
-   |         -^----------- help: try adding parentheses: `(x, _barr_body)`
+   |          ^
+help: try adding parentheses to match on a tuple..
+   |
+LL |     for (x, _barr_body) in women.iter().map(|woman| woman.allosomes.clone()) {
+   |         ^^^^^^^^^^^^^^^
+help: ..or a vertical bar to match on multiple alternatives
+   |
+LL |     for x | _barr_body in women.iter().map(|woman| woman.allosomes.clone()) {
+   |         ^^^^^^^^^^^^^^
 
 error: unexpected `,` in pattern
   --> $DIR/issue-48492-tuple-destructure-missing-parens.rs:75:10
    |
 LL |     for x, y @ Allosome::Y(_) in men.iter().map(|man| man.allosomes.clone()) {
-   |         -^------------------- help: try adding parentheses: `(x, y @ Allosome::Y(_))`
+   |          ^
+help: try adding parentheses to match on a tuple..
+   |
+LL |     for (x, y @ Allosome::Y(_)) in men.iter().map(|man| man.allosomes.clone()) {
+   |         ^^^^^^^^^^^^^^^^^^^^^^^
+help: ..or a vertical bar to match on multiple alternatives
+   |
+LL |     for x | y @ Allosome::Y(_) in men.iter().map(|man| man.allosomes.clone()) {
+   |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: unexpected `,` in pattern
   --> $DIR/issue-48492-tuple-destructure-missing-parens.rs:84:14
    |
 LL |     let women, men: (Vec<Genome>, Vec<Genome>) = genomes.iter().cloned()
-   |         -----^---- help: try adding parentheses: `(women, men)`
+   |              ^
+help: try adding parentheses to match on a tuple..
+   |
+LL |     let (women, men): (Vec<Genome>, Vec<Genome>) = genomes.iter().cloned()
+   |         ^^^^^^^^^^^^
+help: ..or a vertical bar to match on multiple alternatives
+   |
+LL |     let women | men: (Vec<Genome>, Vec<Genome>) = genomes.iter().cloned()
+   |         ^^^^^^^^^^^
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/issues/issue-58006.rs
+++ b/src/test/ui/issues/issue-58006.rs
@@ -1,0 +1,15 @@
+#![feature(type_alias_enum_variants)]
+pub enum Enum {
+    A(usize),
+}
+
+impl Enum {
+    fn foo(&self) -> () {
+        match self {
+            Self::A => (),
+            //~^ ERROR expected unit struct/variant or constant, found tuple variant
+        }
+    }
+}
+
+fn main() {}

--- a/src/test/ui/issues/issue-58006.stderr
+++ b/src/test/ui/issues/issue-58006.stderr
@@ -1,0 +1,9 @@
+error[E0533]: expected unit struct/variant or constant, found tuple variant `<Self>::A`
+  --> $DIR/issue-58006.rs:9:13
+   |
+LL |             Self::A => (),
+   |             ^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0533`.

--- a/src/test/ui/nll/issue-57989.rs
+++ b/src/test/ui/nll/issue-57989.rs
@@ -1,0 +1,12 @@
+// Test for ICE from issue 57989
+
+#![feature(nll)]
+
+fn f(x: &i32) {
+    let g = &x;
+    *x = 0;     //~ ERROR cannot assign to `*x` which is behind a `&` reference
+                //~| ERROR cannot assign to `*x` because it is borrowed
+    g;
+}
+
+fn main() {}

--- a/src/test/ui/nll/issue-57989.stderr
+++ b/src/test/ui/nll/issue-57989.stderr
@@ -1,0 +1,24 @@
+error[E0594]: cannot assign to `*x` which is behind a `&` reference
+  --> $DIR/issue-57989.rs:7:5
+   |
+LL | fn f(x: &i32) {
+   |         ---- help: consider changing this to be a mutable reference: `&mut i32`
+LL |     let g = &x;
+LL |     *x = 0;     //~ ERROR cannot assign to `*x` which is behind a `&` reference
+   |     ^^^^^^ `x` is a `&` reference, so the data it refers to cannot be written
+
+error[E0506]: cannot assign to `*x` because it is borrowed
+  --> $DIR/issue-57989.rs:7:5
+   |
+LL |     let g = &x;
+   |             -- borrow of `*x` occurs here
+LL |     *x = 0;     //~ ERROR cannot assign to `*x` which is behind a `&` reference
+   |     ^^^^^^ assignment to borrowed `*x` occurs here
+LL |                 //~| ERROR cannot assign to `*x` because it is borrowed
+LL |     g;
+   |     - borrow later used here
+
+error: aborting due to 2 previous errors
+
+Some errors occurred: E0506, E0594.
+For more information about an error, try `rustc --explain E0506`.

--- a/src/test/ui/target-feature-gate.rs
+++ b/src/test/ui/target-feature-gate.rs
@@ -22,6 +22,7 @@
 // gate-test-wasm_target_feature
 // gate-test-adx_target_feature
 // gate-test-cmpxchg16b_target_feature
+// gate-test-movbe_target_feature
 // min-llvm-version 6.0
 
 #[target_feature(enable = "avx512bw")]

--- a/src/test/ui/target-feature-gate.stderr
+++ b/src/test/ui/target-feature-gate.stderr
@@ -1,5 +1,5 @@
 error[E0658]: the target feature `avx512bw` is currently unstable (see issue #44839)
-  --> $DIR/target-feature-gate.rs:27:18
+  --> $DIR/target-feature-gate.rs:28:18
    |
 LL | #[target_feature(enable = "avx512bw")]
    |                  ^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Successful merges:

 - #57008 (suggest `|` when `,` founds in invalid match value)
 - #57106 (Mark str::trim.* functions as #[must_use].)
 - #57920 (use `SOURCE_DATE_EPOCH` for man page time if set)
 - #57934 (Introduce into_raw_non_null on Rc and Arc)
 - #57971 (SGX target: improve panic & exit handling)
 - #57980 (Add the edition guide to the bookshelf)
 - #57984 (Improve bug message in check_ty)
 - #57999 (Add MOVBE x86 CPU feature)
 - #58000 (Fixes and cleanups)
 - #58005 (update docs for fix_start/end_matches)
 - #58007 (Don't panic when accessing enum variant ctor using `Self` in match)
 - #58008 (Pass correct arguments to places_conflict)

Failed merges:


r? @ghost