### PR TITLE
Combine all builtin late lints and make lint checking parallel

### DIFF
--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -42,8 +42,8 @@ use syntax::symbol::Symbol;
 use syntax_pos::Span;
 
 pub use crate::lint::context::{LateContext, EarlyContext, LintContext, LintStore,
-                        check_crate, check_ast_crate, CheckLintNameResult,
-                        FutureIncompatibleInfo, BufferedEarlyLint};
+                        check_crate, check_ast_crate, late_lint_mod, CheckLintNameResult,
+                        FutureIncompatibleInfo, BufferedEarlyLint,};
 
 /// Specification of a single lint.
 #[derive(Copy, Clone, Debug)]
@@ -298,14 +298,14 @@ macro_rules! expand_combined_late_lint_pass_methods {
 
 #[macro_export]
 macro_rules! declare_combined_late_lint_pass {
-    ([$name:ident, [$($passes:ident: $constructor:expr,)*]], [$hir:tt], $methods:tt) => (
+    ([$v:vis $name:ident, [$($passes:ident: $constructor:expr,)*]], [$hir:tt], $methods:tt) => (
         #[allow(non_snake_case)]
-        struct $name {
+        $v struct $name {
             $($passes: $passes,)*
         }
 
         impl $name {
-            fn new() -> Self {
+            $v fn new() -> Self {
                 Self {
                     $($passes: $constructor,)*
                 }
@@ -824,7 +824,6 @@ impl<'a, 'tcx> intravisit::Visitor<'tcx> for LintLevelMapBuilder<'a, 'tcx> {
 
 pub fn provide(providers: &mut Providers<'_>) {
     providers.lint_levels = lint_levels;
-    context::provide(providers);
 }
 
 /// Returns whether `span` originates in a foreign crate's external macro.

--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -273,6 +273,9 @@ macro_rules! expand_lint_pass_methods {
 macro_rules! declare_late_lint_pass {
     ([], [$hir:tt], [$($methods:tt)*]) => (
         pub trait LateLintPass<'a, $hir>: LintPass {
+            fn fresh_late_pass(&self) -> LateLintPassObject {
+                panic!()
+            }
             expand_lint_pass_methods!(&LateContext<'a, $hir>, [$($methods)*]);
         }
     )

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -990,7 +990,7 @@ fn analysis<'tcx>(
                 });
             }, {
                 time(sess, "lint checking", || {
-                    lint::check_crate(tcx, rustc_lint::BuiltinCombinedLateLintPass::new());
+                    lint::check_crate(tcx, || rustc_lint::BuiltinCombinedLateLintPass::new());
                 });
             });
         }, {

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -330,7 +330,7 @@ pub fn register_plugins<'a>(
         ls.register_early_pass(Some(sess), true, false, pass);
     }
     for pass in late_lint_passes {
-        ls.register_late_pass(Some(sess), true, false, pass);
+        ls.register_late_pass(Some(sess), true, false, false, pass);
     }
 
     for (name, (to, deprecated_name)) in lint_groups {
@@ -783,6 +783,7 @@ pub fn default_provide(providers: &mut ty::query::Providers<'_>) {
     middle::entry::provide(providers);
     cstore::provide(providers);
     lint::provide(providers);
+    rustc_lint::provide(providers);
 }
 
 pub fn default_provide_extern(providers: &mut ty::query::Providers<'_>) {
@@ -988,7 +989,9 @@ fn analysis<'tcx>(
                     stability::check_unused_or_stable_features(tcx)
                 });
             }, {
-                time(sess, "lint checking", || lint::check_crate(tcx));
+                time(sess, "lint checking", || {
+                    lint::check_crate(tcx, rustc_lint::BuiltinCombinedLateLintPass::new());
+                });
             });
         }, {
             time(sess, "privacy checking modules", || {


### PR DESCRIPTION
Blocked on https://github.com/rust-lang/rust/pull/57293.

Cuts runtime of late lint checking from 3.222s to 0.546s with 8 threads on `winapi` (@retep998 ;) )

r? @estebank