### PR TITLE
rustdoc: wrap stability tags in colored spans

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -2798,9 +2798,13 @@ fn item_module(w: &mut fmt::Formatter, cx: &Context,
 fn stability_tags(item: &clean::Item) -> String {
     let mut tags = String::new();
 
+    fn tag_html(class: &str, contents: &str) -> String {
+        format!(r#"<span class="stab {}">{}</span>"#, class, contents)
+    }
+
     // The trailing space after each tag is to space it properly against the rest of the docs.
     if item.deprecation().is_some() {
-        tags.push_str("[<div class='stab deprecated'>Deprecated</div>] ");
+        tags += &tag_html("deprecated", "Deprecated");
     }
 
     if let Some(stab) = item
@@ -2809,17 +2813,14 @@ fn stability_tags(item: &clean::Item) -> String {
         .filter(|s| s.level == stability::Unstable)
     {
         if stab.feature.as_ref().map(|s| &**s) == Some("rustc_private") {
-            tags.push_str("[<div class='stab internal'>Internal</div>] ");
+            tags += &tag_html("internal", "Internal");
         } else {
-            tags.push_str("[<div class='stab unstable'>Experimental</div>] ");
+            tags += &tag_html("unstable", "Experimental");
         }
     }
 
     if let Some(ref cfg) = item.attrs.cfg {
-        tags.push_str(&format!(
-            "[<div class='stab portability'>{}</div>] ",
-            cfg.render_short_html()
-        ));
+        tags += &tag_html("portability", &cfg.render_short_html());
     }
 
     tags

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -767,11 +767,14 @@ body.blur > :not(#help) {
 }
 
 .module-item .stab {
-	display: inline;
-	border-width: 0;
-	padding: 0;
-	margin: 0;
-	background: inherit !important;
+	border-radius: 3px;
+	display: inline-block;
+	font-size: 80%;
+	line-height: 1.2;
+	margin-bottom: 0;
+	margin-right: .3em;
+	padding: 2px;
+	vertical-align: text-bottom;
 }
 
 .module-item.unstable {

--- a/src/test/rustdoc/deprecated.rs
+++ b/src/test/rustdoc/deprecated.rs
@@ -1,7 +1,9 @@
 #![feature(deprecated)]
 
-// @matches deprecated/index.html '//*[@class="docblock-short"]' \
-//      '^\[Deprecated\] Deprecated docs'
+// @has deprecated/index.html '//*[@class="docblock-short"]/span[@class="stab deprecated"]' \
+//      'Deprecated'
+// @has - '//*[@class="docblock-short"]' 'Deprecated docs'
+
 // @has deprecated/struct.S.html '//*[@class="stab deprecated"]' \
 //      'Deprecated since 1.0.0: text'
 /// Deprecated docs

--- a/src/test/rustdoc/inline_cross/macros.rs
+++ b/src/test/rustdoc/inline_cross/macros.rs
@@ -7,7 +7,8 @@
 
 extern crate macros;
 
-// @has foo/index.html '//*[@class="docblock-short"]' '[Deprecated] [Experimental]'
+// @has foo/index.html '//*[@class="docblock-short"]/span[@class="stab deprecated"]' Deprecated
+// @has - '//*[@class="docblock-short"]/span[@class="stab unstable"]' Experimental
 
 // @has foo/macro.my_macro.html
 // @has - '//*[@class="docblock"]' 'docs for my_macro'

--- a/src/test/rustdoc/internal.rs
+++ b/src/test/rustdoc/internal.rs
@@ -1,7 +1,9 @@
 // compile-flags: -Z force-unstable-if-unmarked
 
-// @matches internal/index.html '//*[@class="docblock-short"]' \
-//      '^\[Internal\] Docs'
+// @matches internal/index.html '//*[@class="docblock-short"]/span[@class="stab internal"]' \
+//      'Internal'
+// @matches - '//*[@class="docblock-short"]' 'Docs'
+
 // @has internal/struct.S.html '//*[@class="stab internal"]' \
 //      'This is an internal compiler API. (rustc_private)'
 /// Docs

--- a/src/test/rustdoc/issue-32374.rs
+++ b/src/test/rustdoc/issue-32374.rs
@@ -3,8 +3,11 @@
 
 #![unstable(feature="test", issue = "32374")]
 
-// @matches issue_32374/index.html '//*[@class="docblock-short"]' \
-//      '^\[Deprecated\] \[Experimental\] Docs'
+// @matches issue_32374/index.html '//*[@class="docblock-short"]/span[@class="stab deprecated"]' \
+//      'Deprecated'
+// @matches issue_32374/index.html '//*[@class="docblock-short"]/span[@class="stab unstable"]' \
+//      'Experimental'
+// @matches issue_32374/index.html '//*[@class="docblock-short"]/text()' 'Docs'
 
 // @has issue_32374/struct.T.html '//*[@class="stab deprecated"]' \
 //      'Deprecated since 1.0.0: text'


### PR DESCRIPTION
A cosmetic change to make the stability tags stand out a bit against the docs. Opening for discussion.

Before: 

![screen shot 2019-01-31 at 3 29 36 pm](https://user-images.githubusercontent.com/1372438/52083406-54730d80-256d-11e9-8e61-b8caff569434.png)
![screen shot 2019-01-31 at 3 31 32 pm](https://user-images.githubusercontent.com/1372438/52083408-54730d80-256d-11e9-97b7-43e808448f65.png)

After:
![screen shot 2019-01-31 at 3 29 18 pm](https://user-images.githubusercontent.com/1372438/52083405-54730d80-256d-11e9-9983-19d9519b2ed8.png)
![screen shot 2019-01-31 at 3 29 46 pm](https://user-images.githubusercontent.com/1372438/52083407-54730d80-256d-11e9-8c32-11a1ad7d3f34.png)

r? @QuietMisdreavus 