### PR TITLE
Fix weird behavior when panicking inside synchronization primitives

### DIFF
--- a/src/libstd/sync/mpsc/oneshot.rs
+++ b/src/libstd/sync/mpsc/oneshot.rs
@@ -255,8 +255,11 @@ impl<T> Packet<T> {
             // to stay valid while we take the data).
             DATA => unsafe { (&mut *self.data.get()).take().unwrap(); },
 
-            // We're the only ones that can block on this port
-            _ => unreachable!()
+            // We're the only ones that can block on this port, but we may be
+            // unwinding
+            ptr => unsafe {
+                drop(SignalToken::cast_from_usize(ptr));
+            }
         }
     }
 

--- a/src/libstd/sync/mpsc/sync.rs
+++ b/src/libstd/sync/mpsc/sync.rs
@@ -399,7 +399,12 @@ impl<T> Packet<T> {
                 *guard.canceled.take().unwrap() = true;
                 Some(token)
             }
-            BlockedReceiver(..) => unreachable!(),
+            // We're the only ones that can block on this port, but we may be
+            // unwinding
+            BlockedReceiver(token) => {
+                drop(token);
+                None
+            }
         };
         mem::drop(guard);
 

--- a/src/test/run-fail/mpsc-recv-unwind/common.rs
+++ b/src/test/run-fail/mpsc-recv-unwind/common.rs
@@ -1,0 +1,27 @@
+// ignore-test
+
+// Common code used by the other tests in this directory
+
+extern crate libc;
+
+use std::sync::{Arc, Barrier, mpsc};
+use std::time::Duration;
+use std::{env, thread, process};
+
+pub fn panic_inside_mpsc_recv(r: mpsc::Receiver<()>) {
+    env::set_var("LIBC_FATAL_STDERR_", "1");
+    let barrier = Arc::new(Barrier::new(2));
+    let main_thread = unsafe { libc::pthread_self() };
+    let barrier2 = barrier.clone();
+    thread::spawn(move || {
+        barrier2.wait();
+        // try to make sure main thread proceeds into recv
+        thread::sleep(Duration::from_millis(100));
+        unsafe { libc::pthread_cancel(main_thread); }
+        thread::sleep(Duration::from_millis(2000));
+        println!("Deadlock detected");
+        process::exit(1);
+    });
+    barrier.wait();
+    r.recv().unwrap()
+}

--- a/src/test/run-fail/mpsc-recv-unwind/oneshot.rs
+++ b/src/test/run-fail/mpsc-recv-unwind/oneshot.rs
@@ -1,0 +1,22 @@
+// Test that unwinding while an MPSC channel receiver is blocking doesn't panic
+// or deadlock inside the MPSC implementation.
+//
+// Various platforms may trigger unwinding while a thread is blocked, due to an
+// error condition. It can be tricky to trigger such unwinding. The test here
+// uses pthread_cancel on Linux. If at some point in the future, pthread_cancel
+// no longer unwinds through the MPSC code, that doesn't mean this test should
+// be removed. Instead, another way should be found to trigger unwinding in a
+// blocked MPSC channel receiver.
+
+// only-linux
+// error-pattern:FATAL: exception not rethrown
+// failure-status:signal:6
+
+#![feature(rustc_private)]
+
+mod common;
+
+fn main() {
+    let (_s, r) = std::sync::mpsc::channel();
+    common::panic_inside_mpsc_recv(r);
+}

--- a/src/test/run-fail/mpsc-recv-unwind/shared.rs
+++ b/src/test/run-fail/mpsc-recv-unwind/shared.rs
@@ -1,0 +1,23 @@
+// Test that unwinding while an MPSC channel receiver is blocking doesn't panic
+// or deadlock inside the MPSC implementation.
+//
+// Various platforms may trigger unwinding while a thread is blocked, due to an
+// error condition. It can be tricky to trigger such unwinding. The test here
+// uses pthread_cancel on Linux. If at some point in the future, pthread_cancel
+// no longer unwinds through the MPSC code, that doesn't mean this test should
+// be removed. Instead, another way should be found to trigger unwinding in a
+// blocked MPSC channel receiver.
+
+// only-linux
+// error-pattern:FATAL: exception not rethrown
+// failure-status:signal:6
+
+#![feature(rustc_private)]
+
+mod common;
+
+fn main() {
+    let (s, r) = std::sync::mpsc::channel();
+    s.clone();
+    common::panic_inside_mpsc_recv(r);
+}

--- a/src/test/run-fail/mpsc-recv-unwind/stream.rs
+++ b/src/test/run-fail/mpsc-recv-unwind/stream.rs
@@ -1,0 +1,26 @@
+// Test that unwinding while an MPSC channel receiver is blocking doesn't panic
+// or deadlock inside the MPSC implementation.
+//
+// Various platforms may trigger unwinding while a thread is blocked, due to an
+// error condition. It can be tricky to trigger such unwinding. The test here
+// uses pthread_cancel on Linux. If at some point in the future, pthread_cancel
+// no longer unwinds through the MPSC code, that doesn't mean this test should
+// be removed. Instead, another way should be found to trigger unwinding in a
+// blocked MPSC channel receiver.
+
+// only-linux
+// error-pattern:FATAL: exception not rethrown
+// failure-status:signal:6
+
+#![feature(rustc_private)]
+
+mod common;
+
+fn main() {
+    let (s, r) = std::sync::mpsc::channel();
+    s.send(()).unwrap();
+    r.recv().unwrap();
+    s.send(()).unwrap();
+    r.recv().unwrap();
+    common::panic_inside_mpsc_recv(r);
+}

--- a/src/test/run-fail/mpsc-recv-unwind/sync.rs
+++ b/src/test/run-fail/mpsc-recv-unwind/sync.rs
@@ -1,0 +1,22 @@
+// Test that unwinding while an MPSC channel receiver is blocking doesn't panic
+// or deadlock inside the MPSC implementation.
+//
+// Various platforms may trigger unwinding while a thread is blocked, due to an
+// error condition. It can be tricky to trigger such unwinding. The test here
+// uses pthread_cancel on Linux. If at some point in the future, pthread_cancel
+// no longer unwinds through the MPSC code, that doesn't mean this test should
+// be removed. Instead, another way should be found to trigger unwinding in a
+// blocked MPSC channel receiver.
+
+// only-linux
+// error-pattern:FATAL: exception not rethrown
+// failure-status:signal:6
+
+#![feature(rustc_private)]
+
+mod common;
+
+fn main() {
+    let (_s, r) = std::sync::mpsc::sync_channel(0);
+    common::panic_inside_mpsc_recv(r);
+}


### PR DESCRIPTION
Currently, when the stack is unwound while an MPSC channel receiver is blocking on a receive, this will result in the execution of `unreachable!()` or a deadlock. Various platforms may trigger unwinding while a thread is blocked, due to an error condition.

This PR changes the MPSC drop logic so that unwinding works properly. It also adds tests for all MPSC variants. It can be tricky to trigger unwinding while a thread is blocked. Here I've used pthread_cancel on Linux.

Fixes https://github.com/fortanix/rust-sgx/issues/86

* [x] MPSC oneshot
* [x] MPSC sync
* [ ] MPSC shared
* [ ] MPSC stream
* [ ] Condvar (#58461)
* [ ] thread::park_timeout (https://github.com/rust-lang/rust/pull/58461#issuecomment-471787169)