### PR TITLE
Fix `std::os::fortanix_sgx::usercalls::raw::UsercallNrs`

### DIFF
--- a/src/libstd/os/fortanix_sgx/mod.rs
+++ b/src/libstd/os/fortanix_sgx/mod.rs
@@ -21,25 +21,10 @@ pub mod usercalls {
 
     /// Lowest-level interfaces to usercalls and usercall ABI type definitions.
     pub mod raw {
-        use sys::abi::usercalls::raw::invoke_with_usercalls;
-        pub use sys::abi::usercalls::raw::do_usercall;
+        pub use sys::abi::usercalls::raw::{do_usercall, Usercalls as UsercallNrs};
         pub use sys::abi::usercalls::raw::{accept_stream, alloc, async_queues, bind_stream, close,
                                            connect_stream, exit, flush, free, insecure_time,
                                            launch_thread, read, read_alloc, send, wait, write};
-
-        macro_rules! define_usercallnrs {
-            ($(fn $f:ident($($n:ident: $t:ty),*) $(-> $r:ty)*; )*) => {
-                /// Usercall numbers as per the ABI.
-                #[repr(C)]
-                #[unstable(feature = "sgx_platform", issue = "56975")]
-                #[derive(Copy, Clone, Hash, PartialEq, Eq, Debug)]
-                #[allow(missing_docs)]
-                pub enum UsercallNrs {
-                    $($f,)*
-                }
-            };
-        }
-        invoke_with_usercalls!(define_usercallnrs);
 
         // fortanix-sgx-abi re-exports
         pub use sys::abi::usercalls::raw::{ByteBuffer, FifoDescriptor, Return, Usercall};

--- a/src/libstd/sys/sgx/abi/usercalls/raw.rs
+++ b/src/libstd/sys/sgx/abi/usercalls/raw.rs
@@ -41,10 +41,15 @@ trait ReturnValue {
 macro_rules! define_usercalls {
     // Using `$r:tt` because `$r:ty` doesn't match ! in `clobber_diverging`
     ($(fn $f:ident($($n:ident: $t:ty),*) $(-> $r:tt)*; )*) => {
-        #[repr(C)]
-        #[allow(non_camel_case_types)]
-        enum Usercalls {
-            __enclave_usercalls_invalid,
+        /// Usercall numbers as per the ABI.
+        #[repr(u64)]
+        #[unstable(feature = "sgx_platform", issue = "56975")]
+        #[derive(Copy, Clone, Hash, PartialEq, Eq, Debug)]
+        #[allow(missing_docs, non_camel_case_types)]
+        #[non_exhaustive]
+        pub enum Usercalls {
+            #[doc(hidden)]
+            __enclave_usercalls_invalid = 0,
             $($f,)*
         }
 


### PR DESCRIPTION
It was 0-indexed but should be 1-indexed. This PR just removes the duplicate code and re-exports the internal enum.

Fixes https://github.com/fortanix/rust-sgx/issues/88

r? @joshtriplett 