### PR TITLE
rustdoc: don't try to get a DefId for a Def that doesn't have one

### DIFF
--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -37,8 +37,11 @@ use super::Clean;
 /// and `Some` of a vector of items if it was successfully expanded.
 pub fn try_inline(cx: &DocContext, def: Def, name: ast::Name, visited: &mut FxHashSet<DefId>)
                   -> Option<Vec<clean::Item>> {
-    if def == Def::Err { return None }
-    let did = def.def_id();
+    let did = if let Some(did) = def.opt_def_id() {
+        did
+    } else {
+        return None;
+    };
     if did.is_local() { return None }
     let mut ret = Vec::new();
     let inner = match def {

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -3818,7 +3818,7 @@ pub fn register_def(cx: &DocContext, def: Def) -> DefId {
 
 fn resolve_use_source(cx: &DocContext, path: Path) -> ImportSource {
     ImportSource {
-        did: if path.def == Def::Err {
+        did: if path.def.opt_def_id().is_none() {
             None
         } else {
             Some(register_def(cx, path.def))

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -284,10 +284,11 @@ impl<'a, 'tcx, 'rcx> RustdocVisitor<'a, 'tcx, 'rcx> {
         debug!("maybe_inline_local def: {:?}", def);
 
         let tcx = self.cx.tcx;
-        if def == Def::Err {
+        let def_did = if let Some(did) = def.opt_def_id() {
+            did
+        } else {
             return false;
-        }
-        let def_did = def.def_id();
+        };
 
         let use_attrs = tcx.hir().attrs(id);
         // Don't inline `doc(hidden)` imports so they can be stripped at a later stage.

--- a/src/test/rustdoc/use-attr.rs
+++ b/src/test/rustdoc/use-attr.rs
@@ -1,0 +1,8 @@
+// edition:2018
+
+// ICE when rustdoc encountered a use statement of a non-macro attribute (see #58054)
+
+// @has use_attr/index.html
+// @has - '//code' 'pub use proc_macro_attribute'
+pub use proc_macro_attribute;
+use proc_macro_derive;


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/58054

The compiler allows you to write a `use` statement for a built-in non-macro attribute, since `use proc_macro` can apply to both the `proc_macro` crate and the `#[proc_macro]` attribute. However, if you write a use statement for something that *doesn't* have this crossover, rustdoc will try to use it the same way as anything else... which resulted in an ICE because it tried to pull a DefId for something that didn't have one. This PR makes rustdoc skip those lookups when it encounters them, allowing it to properly process and render these imports.