### PR TITLE
targets: aarch64-unknown-none: Add +strict-align

### DIFF
--- a/src/librustc_target/spec/aarch64_unknown_none.rs
+++ b/src/librustc_target/spec/aarch64_unknown_none.rs
@@ -11,6 +11,7 @@ use super::{LldFlavor, LinkerFlavor, Target, TargetOptions, PanicStrategy};
 pub fn target() -> Result<Target, String> {
     let opts = TargetOptions {
         linker: Some("rust-lld".to_owned()),
+        features: "+strict-align".to_string(),
         executables: true,
         relocation_model: "static".to_string(),
         disable_redzone: true,


### PR DESCRIPTION
On AArch64, an unaligned access causes a synchronous exception. In the current
state of the target, the compiler might generate unaligned accesses, see
https://github.com/rust-embedded/rust-raspi3-tutorial/issues/10.

Since this is a bare-metal target, it is possible that there is no exception
handling in place (yet) to recover from this case, causing a binary to just
silently fail.

Add `+strict-align` to avoid this case.