### PR TITLE
WIP: Add lint for missing Clone impls

### DIFF
--- a/src/doc/rustc/src/lints/listing/allowed-by-default.md
+++ b/src/doc/rustc/src/lints/listing/allowed-by-default.md
@@ -126,54 +126,11 @@ Lifetime elision elides this lifetime, but that is being deprecated.
 
 ## missing-copy-implementations
 
-This lint detects potentially-forgotten implementations of `Copy`. Some
-example code that triggers this lint:
-
-```rust
-pub struct Foo {
-    pub field: i32
-}
-```
-
-When set to 'deny', this will produce:
-
-```text
-error: type could implement `Copy`; consider adding `impl Copy`
- --> src/main.rs:3:1
-  |
-3 | / pub struct Foo { //~ ERROR type could implement `Copy`; consider adding `impl Copy`
-4 | |     pub field: i32
-5 | | }
-  | |_^
-  |
-```
-
-You can fix the lint by deriving `Copy`.
-
-This lint is set to 'allow' because this code isn't bad; it's common to write
-newtypes like this specifically so that a `Copy` type is no longer `Copy`.
+This lint is deprecated and no longer used.
 
 ## missing-debug-implementations
 
-This lint detects missing implementations of `fmt::Debug`. Some example code
-that triggers this lint:
-
-```rust
-pub struct Foo;
-```
-
-When set to 'deny', this will produce:
-
-```text
-error: type does not implement `fmt::Debug`; consider adding #[derive(Debug)] or a manual implementation
- --> src/main.rs:3:1
-  |
-3 | pub struct Foo;
-  | ^^^^^^^^^^^^^^^
-  |
-```
-
-You can fix the lint by deriving `Debug`.
+This lint is deprecated and no longer used.
 
 ## missing-docs
 

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -377,6 +377,10 @@ language_item_table! {
 
     Arc,                         "arc",                arc,                     Target::Struct;
     Rc,                          "rc",                 rc,                      Target::Struct;
+
+    DefaultTraitLangItem,        "default",            default_trait,           Target::Trait;
+    DisplayTraitLangItem,        "display",            display_trait,           Target::Trait;
+    HashTraitLangItem,           "hash",               hash_trait,              Target::Trait;
 }
 
 impl<'a, 'tcx, 'gcx> TyCtxt<'a, 'tcx, 'gcx> {

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -532,7 +532,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MissingDoc {
 declare_lint! {
     pub MISSING_COPY_IMPLEMENTATIONS,
     Allow,
-    "detects potentially-forgotten implementations of `Copy`"
+    "detects potentially-forgotten implementations of `Copy` (deprecated, do not use)"
 }
 
 #[derive(Copy, Clone)]
@@ -596,7 +596,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MissingCopyImplementations {
 declare_lint! {
     MISSING_DEBUG_IMPLEMENTATIONS,
     Allow,
-    "detects missing implementations of fmt::Debug"
+    "detects missing implementations of fmt::Debug (deprecated, do not use)"
 }
 
 pub struct MissingDebugImplementations {


### PR DESCRIPTION
This is a WIP implementation for #58066. I've just implemented a lint for missing `Clone` implementations. For the other traits listed in #58066, I'll add separate commits for the missing ones once I've gotten some feedback here and am sure I'm on the right track.

Closes #58066.