### PR TITLE
hir: add HirId to main Hir nodes

### DIFF
--- a/src/librustc/hir/check_attr.rs
+++ b/src/librustc/hir/check_attr.rs
@@ -362,7 +362,7 @@ fn is_c_like_enum(item: &hir::Item) -> bool {
     if let hir::ItemKind::Enum(ref def, _) = item.node {
         for variant in &def.variants {
             match variant.node.data {
-                hir::VariantData::Unit(_) => { /* continue */ }
+                hir::VariantData::Unit(..) => { /* continue */ }
                 _ => { return false; }
             }
         }

--- a/src/librustc/hir/intravisit.rs
+++ b/src/librustc/hir/intravisit.rs
@@ -694,7 +694,7 @@ pub fn walk_pat<'v, V: Visitor<'v>>(visitor: &mut V, pattern: &'v Pat) {
         PatKind::Ref(ref subpattern, _) => {
             visitor.visit_pat(subpattern)
         }
-        PatKind::Binding(_, canonical_id, ident, ref optional_subpattern) => {
+        PatKind::Binding(_, canonical_id, _hir_id, ident, ref optional_subpattern) => {
             visitor.visit_def_mention(Def::Local(canonical_id));
             visitor.visit_ident(ident);
             walk_list!(visitor, visit_pat, optional_subpattern);

--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -875,7 +875,7 @@ impl<'hir> Map<'hir> {
             Node::Field(f) => f.ident.name,
             Node::Lifetime(lt) => lt.name.ident().name,
             Node::GenericParam(param) => param.name.ident().name,
-            Node::Binding(&Pat { node: PatKind::Binding(_,_,l,_), .. }) => l.name,
+            Node::Binding(&Pat { node: PatKind::Binding(_, _, _, l, _), .. }) => l.name,
             Node::StructCtor(_) => self.name(self.get_parent(id)),
             _ => bug!("no name for {}", self.node_to_string(id))
         }

--- a/src/librustc/hir/pat_util.rs
+++ b/src/librustc/hir/pat_util.rs
@@ -83,7 +83,7 @@ impl hir::Pat {
         where F: FnMut(hir::BindingAnnotation, HirId, Span, ast::Ident),
     {
         self.walk(|p| {
-            if let PatKind::Binding(binding_mode, _, ident, _) = p.node {
+            if let PatKind::Binding(binding_mode, _, _, ident, _) = p.node {
                 f(binding_mode, p.hir_id, p.span, ident);
             }
             true
@@ -123,8 +123,8 @@ impl hir::Pat {
 
     pub fn simple_ident(&self) -> Option<ast::Ident> {
         match self.node {
-            PatKind::Binding(hir::BindingAnnotation::Unannotated, _, ident, None) |
-            PatKind::Binding(hir::BindingAnnotation::Mutable, _, ident, None) => Some(ident),
+            PatKind::Binding(hir::BindingAnnotation::Unannotated, _, _, ident, None) |
+            PatKind::Binding(hir::BindingAnnotation::Mutable, _, _, ident, None) => Some(ident),
             _ => None,
         }
     }

--- a/src/librustc/hir/print.rs
+++ b/src/librustc/hir/print.rs
@@ -1768,7 +1768,7 @@ impl<'a> State<'a> {
         // is that it doesn't matter
         match pat.node {
             PatKind::Wild => self.s.word("_")?,
-            PatKind::Binding(binding_mode, _, ident, ref sub) => {
+            PatKind::Binding(binding_mode, _, _, ident, ref sub) => {
                 match binding_mode {
                     hir::BindingAnnotation::Ref => {
                         self.word_nbsp("ref")?;
@@ -2246,6 +2246,7 @@ impl<'a> State<'a> {
             params: hir::HirVec::new(),
             where_clause: hir::WhereClause {
                 id: ast::DUMMY_NODE_ID,
+                hir_id: hir::DUMMY_HIR_ID,
                 predicates: hir::HirVec::new(),
             },
             span: syntax_pos::DUMMY_SP,

--- a/src/librustc/ich/impls_hir.rs
+++ b/src/librustc/ich/impls_hir.rs
@@ -159,6 +159,7 @@ impl_stable_hash_for!(struct ast::Label {
 
 impl_stable_hash_for!(struct hir::Lifetime {
     id,
+    hir_id,
     span,
     name
 });
@@ -172,6 +173,7 @@ impl_stable_hash_for!(struct hir::Path {
 impl_stable_hash_for!(struct hir::PathSegment {
     ident -> (ident.name),
     id,
+    hir_id,
     def,
     infer_types,
     args
@@ -200,6 +202,7 @@ impl_stable_hash_for!(enum hir::TraitBoundModifier {
 
 impl_stable_hash_for!(struct hir::GenericParam {
     id,
+    hir_id,
     name,
     pure_wrt_drop,
     attrs,
@@ -244,6 +247,7 @@ impl_stable_hash_for!(enum hir::SyntheticTyParamKind {
 
 impl_stable_hash_for!(struct hir::WhereClause {
     id,
+    hir_id,
     predicates
 });
 
@@ -268,6 +272,7 @@ impl_stable_hash_for!(struct hir::WhereRegionPredicate {
 
 impl_stable_hash_for!(struct hir::WhereEqPredicate {
     id,
+    hir_id,
     span,
     lhs_ty,
     rhs_ty
@@ -285,6 +290,7 @@ impl_stable_hash_for!(struct hir::MethodSig {
 
 impl_stable_hash_for!(struct hir::TypeBinding {
     id,
+    hir_id,
     ident -> (ident.name),
     ty,
     span
@@ -397,6 +403,7 @@ impl_stable_hash_for!(struct hir::MacroDef {
     vis,
     attrs,
     id,
+    hir_id,
     span,
     legacy,
     body
@@ -423,6 +430,7 @@ impl_stable_hash_for_spanned!(hir::FieldPat);
 
 impl_stable_hash_for!(struct hir::FieldPat {
     id -> _,
+    hir_id -> _,
     ident -> (ident.name),
     pat,
     is_shorthand,
@@ -442,7 +450,7 @@ impl_stable_hash_for!(enum hir::RangeEnd {
 
 impl_stable_hash_for!(enum hir::PatKind {
     Wild,
-    Binding(binding_mode, var, name, sub),
+    Binding(binding_mode, var, hir_id, name, sub),
     Struct(path, field_pats, dotdot),
     TupleStruct(path, field_pats, dotdot),
     Path(path),
@@ -485,6 +493,7 @@ impl_stable_hash_for!(enum hir::UnOp {
 
 impl_stable_hash_for!(struct hir::Stmt {
     id,
+    hir_id,
     node,
     span,
 });
@@ -514,6 +523,7 @@ impl_stable_hash_for!(enum hir::Guard {
 
 impl_stable_hash_for!(struct hir::Field {
     id -> _,
+    hir_id -> _,
     ident,
     expr,
     span,
@@ -836,14 +846,15 @@ impl_stable_hash_for!(struct hir::StructField {
     ident -> (ident.name),
     vis,
     id,
+    hir_id,
     ty,
     attrs
 });
 
 impl_stable_hash_for!(enum hir::VariantData {
-    Struct(fields, id),
-    Tuple(fields, id),
-    Unit(id)
+    Struct(fields, id, hir_id),
+    Tuple(fields, id, hir_id),
+    Unit(id, hir_id)
 });
 
 impl<'a> HashStable<StableHashingContext<'a>> for hir::Item {
@@ -929,6 +940,7 @@ impl_stable_hash_for!(struct hir::ForeignItem {
     attrs,
     node,
     id,
+    hir_id,
     span,
     vis
 });

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -408,7 +408,7 @@ fn add_from_pat<'a, 'tcx>(ir: &mut IrMaps<'a, 'tcx>, pat: &P<hir::Pat>) {
     while let Some(pat) = pats.pop_front() {
         use hir::PatKind::*;
         match pat.node {
-            Binding(_, _, _, ref inner_pat) => {
+            Binding(_, _, _, _, ref inner_pat) => {
                 pats.extend(inner_pat.iter());
             }
             Struct(_, ref fields, _) => {

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -1024,7 +1024,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
             Node::Variant(&hir::Variant {
                 span,
                 node: hir::VariantKind {
-                    data: hir::VariantData::Tuple(ref fields, _),
+                    data: hir::VariantData::Tuple(ref fields, ..),
                     ..
                 },
                 ..

--- a/src/librustc_borrowck/borrowck/gather_loans/gather_moves.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/gather_moves.rs
@@ -99,7 +99,7 @@ pub fn gather_move_from_pat<'a, 'c, 'tcx: 'c>(bccx: &BorrowckCtxt<'a, 'tcx>,
                                               cmt: &'c mc::cmt_<'tcx>) {
     let source = get_pattern_source(bccx.tcx,move_pat);
     let pat_span_path_opt = match move_pat.node {
-        PatKind::Binding(_, _, ident, _) => {
+        PatKind::Binding(_, _, _, ident, _) => {
             Some(MovePlace {
                      span: move_pat.span,
                      name: ident.name,

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -191,7 +191,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NonShorthandFieldPatterns {
                     // (Issue #49588)
                     continue;
                 }
-                if let PatKind::Binding(_, _, ident, None) = fieldpat.node.pat.node {
+                if let PatKind::Binding(_, _, _, ident, None) = fieldpat.node.pat.node {
                     if cx.tcx.find_field_index(ident, &variant) ==
                        Some(cx.tcx.field_index(fieldpat.node.id, cx.tables)) {
                         let mut err = cx.struct_span_lint(NON_SHORTHAND_FIELD_PATTERNS,

--- a/src/librustc_lint/nonstandard_style.rs
+++ b/src/librustc_lint/nonstandard_style.rs
@@ -340,7 +340,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NonSnakeCase {
     }
 
     fn check_pat(&mut self, cx: &LateContext, p: &hir::Pat) {
-        if let &PatKind::Binding(_, _, ident, _) = &p.node {
+        if let &PatKind::Binding(_, _, _, ident, _) = &p.node {
             self.check_snake_case(cx, "variable", &ident);
         }
     }

--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -977,7 +977,7 @@ impl<'a, 'b: 'a, 'tcx: 'b> IsolatedEncoder<'a, 'b, 'tcx> {
             let body = self.tcx.hir().body(body_id);
             self.lazy_seq(body.arguments.iter().map(|arg| {
                 match arg.pat.node {
-                    PatKind::Binding(_, _, ident, _) => ident.name,
+                    PatKind::Binding(_, _, _, ident, _) => ident.name,
                     _ => keywords::Invalid.name(),
                 }
             }))

--- a/src/librustc_mir/borrow_check/mutability_errors.rs
+++ b/src/librustc_mir/borrow_check/mutability_errors.rs
@@ -312,6 +312,7 @@ impl<'a, 'gcx, 'tcx> MirBorrowckCtxt<'a, 'gcx, 'tcx> {
                     if let hir::PatKind::Binding(
                         hir::BindingAnnotation::Unannotated,
                         _,
+                        _,
                         upvar_ident,
                         _,
                     ) = pat.node

--- a/src/librustc_mir/build/mod.rs
+++ b/src/librustc_mir/build/mod.rs
@@ -229,7 +229,7 @@ fn create_constructor_shim<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                      -> Mir<'tcx>
 {
     let span = tcx.hir().span(ctor_id);
-    if let hir::VariantData::Tuple(ref fields, ctor_id) = *v {
+    if let hir::VariantData::Tuple(ref fields, ctor_id, _) = *v {
         tcx.infer_ctxt().enter(|infcx| {
             let mut mir = shim::build_adt_ctor(&infcx, ctor_id, fields, span);
 
@@ -671,7 +671,7 @@ fn construct_fn<'a, 'gcx, 'tcx, A>(hir: Cx<'a, 'gcx, 'tcx>,
                 mutability: Mutability::Not,
             };
             if let Some(Node::Binding(pat)) = tcx_hir.find(var_node_id) {
-                if let hir::PatKind::Binding(_, _, ident, _) = pat.node {
+                if let hir::PatKind::Binding(_, _, _, ident, _) = pat.node {
                     decl.debug_name = ident.name;
                     if let Some(&bm) = hir.tables.pat_binding_modes().get(pat.hir_id) {
                         if bm == ty::BindByValue(hir::MutMutable) {
@@ -877,8 +877,8 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
             let mut name = None;
             if let Some(pat) = pattern {
                 match pat.node {
-                    hir::PatKind::Binding(hir::BindingAnnotation::Unannotated, _, ident, _)
-                    | hir::PatKind::Binding(hir::BindingAnnotation::Mutable, _, ident, _) => {
+                    hir::PatKind::Binding(hir::BindingAnnotation::Unannotated, _, _, ident, _)
+                    | hir::PatKind::Binding(hir::BindingAnnotation::Mutable, _, _, ident, _) => {
                         name = Some(ident.name);
                     }
                     _ => (),

--- a/src/librustc_mir/hair/pattern/check_match.rs
+++ b/src/librustc_mir/hair/pattern/check_match.rs
@@ -285,7 +285,7 @@ impl<'a, 'tcx> MatchVisitor<'a, 'tcx> {
 
 fn check_for_bindings_named_same_as_variants(cx: &MatchVisitor, pat: &Pat) {
     pat.walk(|p| {
-        if let PatKind::Binding(_, _, ident, None) = p.node {
+        if let PatKind::Binding(_, _, _, ident, None) = p.node {
             if let Some(&bm) = cx.tables.pat_binding_modes().get(p.hir_id) {
                 if bm != ty::BindByValue(hir::MutImmutable) {
                     // Nothing to check.
@@ -503,7 +503,7 @@ fn check_legality_of_move_bindings(cx: &MatchVisitor,
 
     for pat in pats {
         pat.walk(|p| {
-            if let PatKind::Binding(_, _, _, ref sub) = p.node {
+            if let PatKind::Binding(_, _, _, _, ref sub) = p.node {
                 if let Some(&bm) = cx.tables.pat_binding_modes().get(p.hir_id) {
                     match bm {
                         ty::BindByValue(..) => {

--- a/src/librustc_mir/hair/pattern/mod.rs
+++ b/src/librustc_mir/hair/pattern/mod.rs
@@ -513,7 +513,7 @@ impl<'a, 'tcx> PatternContext<'a, 'tcx> {
                 }
             }
 
-            PatKind::Binding(_, id, ident, ref sub) => {
+            PatKind::Binding(_, id, _, ident, ref sub) => {
                 let var_ty = self.tables.node_id_to_type(pat.hir_id);
                 if let ty::Error = var_ty.sty {
                     // Avoid ICE

--- a/src/librustc_mir/transform/mod.rs
+++ b/src/librustc_mir/transform/mod.rs
@@ -80,7 +80,7 @@ fn mir_keys<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, krate: CrateNum)
                               _: &'tcx hir::Generics,
                               _: ast::NodeId,
                               _: Span) {
-            if let hir::VariantData::Tuple(_, node_id) = *v {
+            if let hir::VariantData::Tuple(_, node_id, _) = *v {
                 self.set.insert(self.tcx.hir().local_def_id(node_id));
             }
             intravisit::walk_struct_def(self, v)

--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -227,7 +227,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 self.demand_eqtype_pat(pat.span, expected, rhs_ty, match_discrim_span);
                 common_type
             }
-            PatKind::Binding(ba, var_id, _, ref sub) => {
+            PatKind::Binding(ba, var_id, _, _, ref sub) => {
                 let bm = if ba == hir::BindingAnnotation::Unannotated {
                     def_bm
                 } else {

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1005,7 +1005,7 @@ impl<'a, 'gcx, 'tcx> Visitor<'gcx> for GatherLocalsVisitor<'a, 'gcx, 'tcx> {
 
     // Add pattern bindings.
     fn visit_pat(&mut self, p: &'gcx hir::Pat) {
-        if let PatKind::Binding(_, _, ident, _) = p.node {
+        if let PatKind::Binding(_, _, _, ident, _) = p.node {
             let var_ty = self.assign(p.span, p.id, None);
 
             if !self.fcx.tcx.features().unsized_locals {

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1455,11 +1455,11 @@ fn fn_sig<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) -> ty::PolyFnSig
             compute_sig_of_foreign_fn_decl(tcx, def_id, fn_decl, abi)
         }
 
-        StructCtor(&VariantData::Tuple(ref fields, _))
+        StructCtor(&VariantData::Tuple(ref fields, ..))
         | Variant(&Spanned {
             node:
                 hir::VariantKind {
-                    data: VariantData::Tuple(ref fields, _),
+                    data: VariantData::Tuple(ref fields, ..),
                     ..
                 },
             ..

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -3692,7 +3692,7 @@ fn name_from_pat(p: &hir::Pat) -> String {
 
     match p.node {
         PatKind::Wild => "_".to_string(),
-        PatKind::Binding(_, _, ident, _) => ident.to_string(),
+        PatKind::Binding(_, _, _, ident, _) => ident.to_string(),
         PatKind::TupleStruct(ref p, ..) | PatKind::Path(ref p) => qpath_to_string(p),
         PatKind::Struct(ref name, ref fields, etc) => {
             format!("{} {{ {}{} }}", qpath_to_string(name),
@@ -4071,6 +4071,7 @@ where F: Fn(DefId) -> Def {
         segments: hir::HirVec::from_vec(apb.names.iter().map(|s| hir::PathSegment {
             ident: ast::Ident::from_str(&s),
             id: None,
+            hir_id: None,
             def: None,
             args: None,
             infer_types: false,

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -174,6 +174,7 @@ impl<'a, 'tcx, 'rcx> DocContext<'a, 'tcx, 'rcx> {
             real_name.unwrap_or(last.ident),
             None,
             None,
+            None,
             self.generics_to_path_params(generics.clone()),
             false,
         ));
@@ -206,6 +207,7 @@ impl<'a, 'tcx, 'rcx> DocContext<'a, 'tcx, 'rcx> {
 
                     args.push(hir::GenericArg::Lifetime(hir::Lifetime {
                         id: ast::DUMMY_NODE_ID,
+                        hir_id: hir::DUMMY_HIR_ID,
                         span: DUMMY_SP,
                         name: hir::LifetimeName::Param(name),
                     }));


### PR DESCRIPTION
This is the 1st PR in a series dedicated to `HirId`-ification, i.e. deprecating `ast::NodeId`s after the AST > HIR lowering process. The bigger proof of concept can be seen in https://github.com/rust-lang/rust/pull/57578.

**Phase 1**: store `HirId` in all remaining (some already have it) main HIR nodes (excluding `*Id` objects).

- [x] `Field`
- [x] `FieldPat`
- [x] `ForeignItem`
- [x] `GenericParam`
- [x] `Lifetime`
- [x] `MacroDef`
- [x] `PathSegment`
- [x] `PatKind::Binding`
- [x] `Stmt`
- [x] `StructField`
- [x] `TypeBinding`
- [x] `VariantData`
- [x] `WhereClause`
- [x] `WhereEqPredicate`

r? @Zoxc
Cc @varkor