### PR TITLE
[WIP] Transition some crates to Rust 2018

### DIFF
--- a/src/libarena/Cargo.toml
+++ b/src/libarena/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "arena"
 version = "0.0.0"
+edition = "2018"
 
 [lib]
 name = "arena"

--- a/src/libarena/lib.rs
+++ b/src/libarena/lib.rs
@@ -13,27 +13,29 @@
        html_root_url = "https://doc.rust-lang.org/nightly/",
        test(no_crate_inject, attr(deny(warnings))))]
 
+#![deny(rust_2018_idioms)]
+
 #![feature(alloc)]
 #![feature(core_intrinsics)]
 #![feature(dropck_eyepatch)]
-#![feature(nll)]
 #![feature(raw_vec_internals)]
 #![cfg_attr(test, feature(test))]
 
 #![allow(deprecated)]
 
 extern crate alloc;
-extern crate rustc_data_structures;
 
 use rustc_data_structures::sync::MTLock;
 
-use std::cell::{Cell, RefCell};
-use std::cmp;
-use std::intrinsics;
-use std::marker::{PhantomData, Send};
-use std::mem;
-use std::ptr;
-use std::slice;
+use std::{
+    cell::{Cell, RefCell},
+    cmp,
+    intrinsics,
+    marker::{PhantomData, Send},
+    mem,
+    ptr,
+    slice,
+};
 
 use alloc::raw_vec::RawVec;
 
@@ -478,7 +480,7 @@ impl SyncDroplessArena {
 #[cfg(test)]
 mod tests {
     extern crate test;
-    use self::test::Bencher;
+    use test::Bencher;
     use super::TypedArena;
     use std::cell::Cell;
 
@@ -611,7 +613,7 @@ mod tests {
         count: &'a Cell<u32>,
     }
 
-    impl<'a> Drop for DropCounter<'a> {
+    impl Drop for DropCounter<'_> {
         fn drop(&mut self) {
             self.count.set(self.count.get() + 1);
         }

--- a/src/libfmt_macros/Cargo.toml
+++ b/src/libfmt_macros/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "fmt_macros"
 version = "0.0.0"
+edition = "2018"
 
 [lib]
 name = "fmt_macros"

--- a/src/libfmt_macros/lib.rs
+++ b/src/libfmt_macros/lib.rs
@@ -10,18 +10,17 @@
        html_playground_url = "https://play.rust-lang.org/",
        test(attr(deny(warnings))))]
 
-#![feature(nll)]
+#![deny(rust_2018_idioms)]
+
 #![feature(rustc_private)]
 
-pub use self::Piece::*;
-pub use self::Position::*;
-pub use self::Alignment::*;
-pub use self::Flag::*;
-pub use self::Count::*;
+pub use Piece::*;
+pub use Position::*;
+pub use Alignment::*;
+pub use Flag::*;
+pub use Count::*;
 
-use std::str;
-use std::string;
-use std::iter;
+use std::{str, string, iter};
 
 /// A piece is a portion of the format string which represents the next part
 /// to emit. These are emitted as a stream by the `Parser` class.

--- a/src/libgraphviz/Cargo.toml
+++ b/src/libgraphviz/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "graphviz"
 version = "0.0.0"
+edition = "2018"
 
 [lib]
 name = "graphviz"

--- a/src/libgraphviz/lib.rs
+++ b/src/libgraphviz/lib.rs
@@ -276,14 +276,13 @@
        html_root_url = "https://doc.rust-lang.org/nightly/",
        test(attr(allow(unused_variables), deny(warnings))))]
 
-#![feature(nll)]
+#![deny(rust_2018_idioms)]
+
 #![feature(str_escape)]
 
-use self::LabelText::*;
+use LabelText::*;
 
-use std::borrow::Cow;
-use std::io::prelude::*;
-use std::io;
+use std::{borrow::Cow, io::{self, prelude::*}};
 
 /// The text for a graphviz label on a node or edge.
 pub enum LabelText<'a> {
@@ -548,12 +547,12 @@ impl<'a> LabelText<'a> {
     }
 
     /// Puts `prefix` on a line above this label, with a blank line separator.
-    pub fn prefix_line(self, prefix: LabelText) -> LabelText<'static> {
+    pub fn prefix_line(self, prefix: LabelText<'_>) -> LabelText<'static> {
         prefix.suffix_line(self)
     }
 
     /// Puts `suffix` on a line below this label, with a blank line separator.
-    pub fn suffix_line(self, suffix: LabelText) -> LabelText<'static> {
+    pub fn suffix_line(self, suffix: LabelText<'_>) -> LabelText<'static> {
         let mut prefix = self.pre_escaped_content().into_owned();
         let suffix = suffix.pre_escaped_content();
         prefix.push_str(r"\n\n");
@@ -686,11 +685,12 @@ pub fn render_opts<'a, N, E, G, W>(g: &'a G,
 
 #[cfg(test)]
 mod tests {
-    use self::NodeLabels::*;
-    use super::{Id, Labeller, Nodes, Edges, GraphWalk, render, Style};
-    use super::LabelText::{self, LabelStr, EscStr, HtmlStr};
-    use std::io;
-    use std::io::prelude::*;
+    use NodeLabels::*;
+    use super::{
+        Id, Labeller, Nodes, Edges, GraphWalk, render, Style,
+        LabelText::{self, LabelStr, EscStr, HtmlStr},
+    };
+    use std::io::{self, prelude::*};
 
     /// each node is an index in a vector in the graph.
     type Node = usize;

--- a/src/libpanic_abort/Cargo.toml
+++ b/src/libpanic_abort/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "panic_abort"
 version = "0.0.0"
+edition = "2018"
 
 [lib]
 path = "lib.rs"

--- a/src/libpanic_abort/lib.rs
+++ b/src/libpanic_abort/lib.rs
@@ -10,11 +10,12 @@
        html_root_url = "https://doc.rust-lang.org/nightly/",
        issue_tracker_base_url = "https://github.com/rust-lang/rust/issues/")]
 #![panic_runtime]
+
 #![allow(unused_features)]
+#![deny(rust_2018_idioms)]
 
 #![feature(core_intrinsics)]
 #![feature(libc)]
-#![feature(nll)]
 #![feature(panic_runtime)]
 #![feature(staged_api)]
 #![feature(rustc_attrs)]
@@ -46,7 +47,6 @@ pub unsafe extern fn __rust_start_panic(_payload: usize) -> u32 {
 
     #[cfg(any(unix, target_os = "cloudabi"))]
     unsafe fn abort() -> ! {
-        extern crate libc;
         libc::abort();
     }
 

--- a/src/libpanic_unwind/Cargo.toml
+++ b/src/libpanic_unwind/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "panic_unwind"
 version = "0.0.0"
+edition = "2018"
 
 [lib]
 path = "lib.rs"

--- a/src/libpanic_unwind/dwarf/eh.rs
+++ b/src/libpanic_unwind/dwarf/eh.rs
@@ -11,7 +11,7 @@
 #![allow(non_upper_case_globals)]
 #![allow(unused)]
 
-use dwarf::DwarfReader;
+use crate::dwarf::DwarfReader;
 use core::mem;
 
 pub const DW_EH_PE_omit: u8 = 0xFF;
@@ -51,7 +51,7 @@ pub enum EHAction {
 
 pub const USING_SJLJ_EXCEPTIONS: bool = cfg!(all(target_os = "ios", target_arch = "arm"));
 
-pub unsafe fn find_eh_action(lsda: *const u8, context: &EHContext)
+pub unsafe fn find_eh_action(lsda: *const u8, context: &EHContext<'_>)
     -> Result<EHAction, ()>
 {
     if lsda.is_null() {
@@ -145,7 +145,7 @@ fn round_up(unrounded: usize, align: usize) -> Result<usize, ()> {
 }
 
 unsafe fn read_encoded_pointer(reader: &mut DwarfReader,
-                               context: &EHContext,
+                               context: &EHContext<'_>,
                                encoding: u8)
                                -> Result<usize, ()> {
     if encoding == DW_EH_PE_omit {

--- a/src/libpanic_unwind/emcc.rs
+++ b/src/libpanic_unwind/emcc.rs
@@ -10,10 +10,10 @@
 
 use core::any::Any;
 use core::ptr;
+use core::mem;
 use alloc::boxed::Box;
 use libc::{self, c_int};
 use unwind as uw;
-use core::mem;
 
 pub fn payload() -> *mut u8 {
     ptr::null_mut()

--- a/src/libpanic_unwind/gcc.rs
+++ b/src/libpanic_unwind/gcc.rs
@@ -52,7 +52,7 @@ use alloc::boxed::Box;
 
 use unwind as uw;
 use libc::{c_int, uintptr_t};
-use dwarf::eh::{self, EHContext, EHAction};
+use crate::dwarf::eh::{self, EHContext, EHAction};
 
 #[repr(C)]
 struct Exception {

--- a/src/libpanic_unwind/lib.rs
+++ b/src/libpanic_unwind/lib.rs
@@ -19,6 +19,8 @@
        html_root_url = "https://doc.rust-lang.org/nightly/",
        issue_tracker_base_url = "https://github.com/rust-lang/rust/issues/")]
 
+#![deny(rust_2018_idioms)]
+
 #![feature(allocator_api)]
 #![feature(alloc)]
 #![feature(core_intrinsics)]
@@ -34,8 +36,6 @@
 #![panic_runtime]
 #![feature(panic_runtime)]
 
-extern crate alloc;
-extern crate libc;
 #[cfg(not(any(target_env = "msvc", all(windows, target_arch = "x86_64", target_env = "gnu"))))]
 extern crate unwind;
 
@@ -89,7 +89,7 @@ pub unsafe extern "C" fn __rust_maybe_catch_panic(f: fn(*mut u8),
                                                   vtable_ptr: *mut usize)
                                                   -> u32 {
     let mut payload = imp::payload();
-    if intrinsics::try(f, data, &mut payload as *mut _ as *mut _) == 0 {
+    if intrinsics::r#try(f, data, &mut payload as *mut _ as *mut _) == 0 {
         0
     } else {
         let obj = mem::transmute::<_, raw::TraitObject>(imp::cleanup(payload));

--- a/src/libpanic_unwind/seh.rs
+++ b/src/libpanic_unwind/seh.rs
@@ -52,7 +52,7 @@ use core::any::Any;
 use core::mem;
 use core::raw;
 
-use windows as c;
+use crate::windows as c;
 use libc::{c_int, c_uint};
 
 // First up, a whole bunch of type definitions. There's a few platform-specific
@@ -301,5 +301,5 @@ pub unsafe fn cleanup(payload: [u64; 2]) -> Box<dyn Any + Send> {
 #[lang = "eh_personality"]
 #[cfg(not(test))]
 fn rust_eh_personality() {
-    unsafe { ::core::intrinsics::abort() }
+    unsafe { core::intrinsics::abort() }
 }

--- a/src/libpanic_unwind/seh64_gnu.rs
+++ b/src/libpanic_unwind/seh64_gnu.rs
@@ -9,8 +9,8 @@ use alloc::boxed::Box;
 use core::any::Any;
 use core::intrinsics;
 use core::ptr;
-use dwarf::eh::{EHContext, EHAction, find_eh_action};
-use windows as c;
+use crate::dwarf::eh::{EHContext, EHAction, find_eh_action};
+use crate::windows as c;
 
 // Define our exception codes:
 // according to http://msdn.microsoft.com/en-us/library/het71c37(v=VS.80).aspx,

--- a/src/librustc_privacy/Cargo.toml
+++ b/src/librustc_privacy/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_privacy"
 version = "0.0.0"
+edition = "2018"
 
 [lib]
 name = "rustc_privacy"

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -2,18 +2,15 @@
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
        html_root_url = "https://doc.rust-lang.org/nightly/")]
 
-#![feature(nll)]
+#![deny(rust_2018_idioms)]
+
 #![feature(rustc_diagnostic_macros)]
 
 #![recursion_limit="256"]
 
-#[macro_use] extern crate rustc;
 #[macro_use] extern crate syntax;
-#[macro_use] extern crate log;
-extern crate rustc_typeck;
-extern crate syntax_pos;
-extern crate rustc_data_structures;
 
+use rustc::bug;
 use rustc::hir::{self, Node, PatKind, AssociatedItemKind};
 use rustc::hir::def::Def;
 use rustc::hir::def_id::{CRATE_DEF_INDEX, LOCAL_CRATE, CrateNum, DefId};
@@ -1541,7 +1538,7 @@ impl<'a, 'tcx: 'a> SearchInterfaceForPrivateItemsVisitor<'a, 'tcx> {
         let ret = self.required_visibility == ty::Visibility::Public &&
             self.private_crates.contains(&item_id.krate);
 
-        debug!("leaks_private_dep(item_id={:?})={}", item_id, ret);
+        log::debug!("leaks_private_dep(item_id={:?})={}", item_id, ret);
         return ret;
     }
 }
@@ -1705,7 +1702,7 @@ impl<'a, 'tcx> Visitor<'tcx> for PrivateItemsInPublicInterfacesVisitor<'a, 'tcx>
     }
 }
 
-pub fn provide(providers: &mut Providers) {
+pub fn provide(providers: &mut Providers<'_>) {
     *providers = Providers {
         privacy_access_levels,
         check_mod_privacy,

--- a/src/libterm/Cargo.toml
+++ b/src/libterm/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "term"
 version = "0.0.0"
+edition = "2018"
 
 [lib]
 name = "term"

--- a/src/libterm/lib.rs
+++ b/src/libterm/lib.rs
@@ -37,19 +37,18 @@
        test(attr(deny(warnings))))]
 #![deny(missing_docs)]
 
+#![deny(rust_2018_idioms)]
+
 #![cfg_attr(windows, feature(libc))]
 // Handle rustfmt skips
 #![feature(custom_attribute)]
-#![feature(nll)]
 #![allow(unused_attributes)]
 
-use std::io::prelude::*;
+use std::io::{self, prelude::*, Stdout, Stderr};
 
 pub use terminfo::TerminfoTerminal;
 #[cfg(windows)]
 pub use win::WinConsole;
-
-use std::io::{self, Stdout, Stderr};
 
 pub mod terminfo;
 

--- a/src/libterm/terminfo/mod.rs
+++ b/src/libterm/terminfo/mod.rs
@@ -5,18 +5,13 @@ use std::env;
 use std::error;
 use std::fmt;
 use std::fs::File;
-use std::io::prelude::*;
-use std::io;
-use std::io::BufReader;
+use std::io::{self, prelude::*, BufReader};
 use std::path::Path;
 
-use Attr;
-use color;
-use Terminal;
+use crate::{Attr, color, Terminal};
 use self::searcher::get_dbpath_for_term;
 use self::parser::compiled::{parse, msys_terminfo};
 use self::parm::{expand, Variables, Param};
-
 
 /// A parsed terminfo database entry.
 #[derive(Debug)]
@@ -58,7 +53,7 @@ impl error::Error for Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use self::Error::*;
         match *self {
             TermUnset => Ok(()),

--- a/src/libterm/terminfo/parm.rs
+++ b/src/libterm/terminfo/parm.rs
@@ -40,23 +40,27 @@ pub enum Param {
 /// Container for static and dynamic variable arrays
 pub struct Variables {
     /// Static variables A-Z
-    sta: [Param; 26],
+    sta_va: [Param; 26],
     /// Dynamic variables a-z
-    dyn: [Param; 26],
+    dyn_va: [Param; 26],
 }
 
 impl Variables {
     /// Return a new zero-initialized Variables
     pub fn new() -> Variables {
         Variables {
-            sta: [Number(0), Number(0), Number(0), Number(0), Number(0), Number(0), Number(0),
-                  Number(0), Number(0), Number(0), Number(0), Number(0), Number(0), Number(0),
-                  Number(0), Number(0), Number(0), Number(0), Number(0), Number(0), Number(0),
-                  Number(0), Number(0), Number(0), Number(0), Number(0)],
-            dyn: [Number(0), Number(0), Number(0), Number(0), Number(0), Number(0), Number(0),
-                  Number(0), Number(0), Number(0), Number(0), Number(0), Number(0), Number(0),
-                  Number(0), Number(0), Number(0), Number(0), Number(0), Number(0), Number(0),
-                  Number(0), Number(0), Number(0), Number(0), Number(0)],
+            sta_va: [
+                Number(0), Number(0), Number(0), Number(0), Number(0), Number(0), Number(0),
+                Number(0), Number(0), Number(0), Number(0), Number(0), Number(0), Number(0),
+                Number(0), Number(0), Number(0), Number(0), Number(0), Number(0), Number(0),
+                Number(0), Number(0), Number(0), Number(0), Number(0)
+            ],
+            dyn_va: [
+                Number(0), Number(0), Number(0), Number(0), Number(0), Number(0), Number(0),
+                Number(0), Number(0), Number(0), Number(0), Number(0), Number(0), Number(0),
+                Number(0), Number(0), Number(0), Number(0), Number(0), Number(0), Number(0),
+                Number(0), Number(0), Number(0), Number(0), Number(0)
+            ],
         }
     }
 }
@@ -249,14 +253,14 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables) -> Result<Vec<
                 if cur >= 'A' && cur <= 'Z' {
                     if let Some(arg) = stack.pop() {
                         let idx = (cur as u8) - b'A';
-                        vars.sta[idx as usize] = arg;
+                        vars.sta_va[idx as usize] = arg;
                     } else {
                         return Err("stack is empty".to_string());
                     }
                 } else if cur >= 'a' && cur <= 'z' {
                     if let Some(arg) = stack.pop() {
                         let idx = (cur as u8) - b'a';
-                        vars.dyn[idx as usize] = arg;
+                        vars.dyn_va[idx as usize] = arg;
                     } else {
                         return Err("stack is empty".to_string());
                     }
@@ -267,10 +271,10 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables) -> Result<Vec<
             GetVar => {
                 if cur >= 'A' && cur <= 'Z' {
                     let idx = (cur as u8) - b'A';
-                    stack.push(vars.sta[idx as usize].clone());
+                    stack.push(vars.sta_va[idx as usize].clone());
                 } else if cur >= 'a' && cur <= 'z' {
                     let idx = (cur as u8) - b'a';
-                    stack.push(vars.dyn[idx as usize].clone());
+                    stack.push(vars.dyn_va[idx as usize].clone());
                 } else {
                     return Err("bad variable name in %g".to_string());
                 }

--- a/src/libterm/terminfo/parser/compiled.rs
+++ b/src/libterm/terminfo/parser/compiled.rs
@@ -3,14 +3,13 @@
 //! ncurses-compatible compiled terminfo format parsing (term(5))
 
 use std::collections::HashMap;
-use std::io::prelude::*;
-use std::io;
+use std::io::{self, prelude::*};
 use super::super::TermInfo;
 
 // These are the orders ncurses uses in its compiled format (as of 5.9). Not sure if portable.
 
 #[rustfmt_skip]
-pub static boolfnames: &'static[&'static str] = &["auto_left_margin", "auto_right_margin",
+pub static boolfnames: &[&str] = &["auto_left_margin", "auto_right_margin",
     "no_esc_ctlc", "ceol_standout_glitch", "eat_newline_glitch", "erase_overstrike", "generic_type",
     "hard_copy", "has_meta_key", "has_status_line", "insert_null_glitch", "memory_above",
     "memory_below", "move_insert_mode", "move_standout_mode", "over_strike", "status_line_esc_ok",
@@ -23,13 +22,13 @@ pub static boolfnames: &'static[&'static str] = &["auto_left_margin", "auto_righ
     "return_does_clr_eol"];
 
 #[rustfmt_skip]
-pub static boolnames: &'static[&'static str] = &["bw", "am", "xsb", "xhp", "xenl", "eo",
+pub static boolnames: &[&str] = &["bw", "am", "xsb", "xhp", "xenl", "eo",
     "gn", "hc", "km", "hs", "in", "db", "da", "mir", "msgr", "os", "eslok", "xt", "hz", "ul", "xon",
     "nxon", "mc5i", "chts", "nrrmc", "npc", "ndscr", "ccc", "bce", "hls", "xhpa", "crxm", "daisy",
     "xvpa", "sam", "cpix", "lpix", "OTbs", "OTns", "OTnc", "OTMT", "OTNL", "OTpt", "OTxr"];
 
 #[rustfmt_skip]
-pub static numfnames: &'static[&'static str] = &[ "columns", "init_tabs", "lines",
+pub static numfnames: &[&str] = &[ "columns", "init_tabs", "lines",
     "lines_of_memory", "magic_cookie_glitch", "padding_baud_rate", "virtual_terminal",
     "width_status_line", "num_labels", "label_height", "label_width", "max_attributes",
     "maximum_windows", "max_colors", "max_pairs", "no_color_video", "buffer_capacity",
@@ -40,13 +39,13 @@ pub static numfnames: &'static[&'static str] = &[ "columns", "init_tabs", "lines
     "new_line_delay", "backspace_delay", "horizontal_tab_delay", "number_of_function_keys"];
 
 #[rustfmt_skip]
-pub static numnames: &'static[&'static str] = &[ "cols", "it", "lines", "lm", "xmc", "pb",
+pub static numnames: &[&str] = &[ "cols", "it", "lines", "lm", "xmc", "pb",
     "vt", "wsl", "nlab", "lh", "lw", "ma", "wnum", "colors", "pairs", "ncv", "bufsz", "spinv",
     "spinh", "maddr", "mjump", "mcs", "mls", "npins", "orc", "orl", "orhi", "orvi", "cps", "widcs",
     "btns", "bitwin", "bitype", "UTug", "OTdC", "OTdN", "OTdB", "OTdT", "OTkn"];
 
 #[rustfmt_skip]
-pub static stringfnames: &'static[&'static str] = &[ "back_tab", "bell", "carriage_return",
+pub static stringfnames: &[&str] = &[ "back_tab", "bell", "carriage_return",
     "change_scroll_region", "clear_all_tabs", "clear_screen", "clr_eol", "clr_eos",
     "column_address", "command_character", "cursor_address", "cursor_down", "cursor_home",
     "cursor_invisible", "cursor_left", "cursor_mem_address", "cursor_normal", "cursor_right",
@@ -120,7 +119,7 @@ pub static stringfnames: &'static[&'static str] = &[ "back_tab", "bell", "carria
     "acs_plus", "memory_lock", "memory_unlock", "box_chars_1"];
 
 #[rustfmt_skip]
-pub static stringnames: &'static[&'static str] = &[ "cbt", "_", "cr", "csr", "tbc", "clear",
+pub static stringnames: &[&str] = &[ "cbt", "_", "cr", "csr", "tbc", "clear",
     "_", "_", "hpa", "cmdch", "cup", "cud1", "home", "civis", "cub1", "mrcup", "cnorm", "cuf1",
     "ll", "cuu1", "cvvis", "dch1", "dl1", "dsl", "hd", "smacs", "blink", "bold", "smcup", "smdc",
     "dim", "smir", "invis", "prot", "rev", "smso", "smul", "ech", "rmacs", "sgr0", "rmcup", "rmdc",

--- a/src/libterm/win.rs
+++ b/src/libterm/win.rs
@@ -2,14 +2,9 @@
 
 // FIXME (#13400): this is only a tiny fraction of the Windows console api
 
-extern crate libc;
+use std::io::{self, prelude::*};
 
-use std::io;
-use std::io::prelude::*;
-
-use Attr;
-use color;
-use Terminal;
+use crate::{Attr, color, Terminal};
 
 /// A Terminal implementation which uses the Win32 Console API.
 pub struct WinConsole<T> {


### PR DESCRIPTION
r? @Mark-Simulacrum 

Transition these crates to Rust 2018:
+ libarena
+ libfmt_macros
+ libgraphviz
+ libpanic_abort
+ libpanic_unwind
+ libterm
+ librustc_privacy