### PR TITLE
HirIdification: add key HirId methods

### DIFF
--- a/src/librustc/cfg/construct.rs
+++ b/src/librustc/cfg/construct.rs
@@ -99,7 +99,6 @@ impl<'a, 'tcx> CFGBuilder<'a, 'tcx> {
     }
 
     fn stmt(&mut self, stmt: &hir::Stmt, pred: CFGIndex) -> CFGIndex {
-        let hir_id = self.tcx.hir().node_to_hir_id(stmt.id);
         let exit = match stmt.node {
             hir::StmtKind::Local(ref local) => {
                 let init_exit = self.opt_expr(&local.init, pred);
@@ -113,7 +112,7 @@ impl<'a, 'tcx> CFGBuilder<'a, 'tcx> {
                 self.expr(&expr, pred)
             }
         };
-        self.add_ast_node(hir_id.local_id, &[exit])
+        self.add_ast_node(stmt.hir_id.local_id, &[exit])
     }
 
     fn pat(&mut self, pat: &hir::Pat, pred: CFGIndex) -> CFGIndex {

--- a/src/librustc/hir/map/definitions.rs
+++ b/src/librustc/hir/map/definitions.rs
@@ -20,7 +20,7 @@ use syntax::ast;
 use syntax::ext::hygiene::Mark;
 use syntax::symbol::{Symbol, InternedString};
 use syntax_pos::{Span, DUMMY_SP};
-use util::nodemap::NodeMap;
+use util::nodemap::{HirIdMap, NodeMap};
 
 /// The DefPathTable maps DefIndexes to DefKeys and vice versa.
 /// Internally the DefPathTable holds a tree of DefKeys, where each DefKey
@@ -147,6 +147,7 @@ impl Decodable for DefPathTable {
 pub struct Definitions {
     table: DefPathTable,
     node_to_def_index: NodeMap<DefIndex>,
+    hir_to_def_index: HirIdMap<DefIndex>,
     def_index_to_node: [Vec<ast::NodeId>; 2],
     pub(super) node_to_hir_id: IndexVec<ast::NodeId, hir::HirId>,
     /// If `Mark` is an ID of some macro expansion,
@@ -441,14 +442,32 @@ impl Definitions {
         self.node_to_def_index.get(&node).cloned()
     }
 
+    // FIXME(@ljedrz): replace the NodeId variant
+    #[inline]
+    pub fn opt_def_index_from_hir_id(&self, hir: hir::HirId) -> Option<DefIndex> {
+        self.hir_to_def_index.get(&hir).cloned()
+    }
+
     #[inline]
     pub fn opt_local_def_id(&self, node: ast::NodeId) -> Option<DefId> {
         self.opt_def_index(node).map(DefId::local)
     }
 
+    // FIXME(@ljedrz): replace the NodeId variant
+    #[inline]
+    pub fn opt_local_def_id_from_hir_id(&self, hir: hir::HirId) -> Option<DefId> {
+        self.opt_def_index_from_hir_id(hir).map(DefId::local)
+    }
+
     #[inline]
     pub fn local_def_id(&self, node: ast::NodeId) -> DefId {
         self.opt_local_def_id(node).unwrap()
+    }
+
+    // FIXME(@ljedrz): replace the NodeId variant
+    #[inline]
+    pub fn local_def_id_from_hir_id(&self, hir: hir::HirId) -> DefId {
+        self.opt_local_def_id_from_hir_id(hir).unwrap()
     }
 
     #[inline]
@@ -459,6 +478,21 @@ impl Definitions {
             let node_id = self.def_index_to_node[space_index][array_index];
             if node_id != ast::DUMMY_NODE_ID {
                 Some(node_id)
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    }
+
+    // FIXME(@ljedrz): replace the NodeId variant
+    #[inline]
+    pub fn as_local_hir_id(&self, def_id: DefId) -> Option<hir::HirId> {
+        if def_id.krate == LOCAL_CRATE {
+            let hir_id = self.def_index_to_hir_id(def_id.index);
+            if hir_id != hir::DUMMY_HIR_ID {
+                Some(hir_id)
             } else {
                 None
             }
@@ -515,6 +549,7 @@ impl Definitions {
         assert!(self.def_index_to_node[address_space.index()].is_empty());
         self.def_index_to_node[address_space.index()].push(ast::CRATE_NODE_ID);
         self.node_to_def_index.insert(ast::CRATE_NODE_ID, root_index);
+        self.hir_to_def_index.insert(hir::CRATE_HIR_ID, root_index);
 
         // Allocate some other DefIndices that always must exist.
         GlobalMetaDataKind::allocate_def_indices(self);
@@ -575,6 +610,9 @@ impl Definitions {
         if node_id != ast::DUMMY_NODE_ID {
             debug!("create_def_with_parent: def_index_to_node[{:?} <-> {:?}", index, node_id);
             self.node_to_def_index.insert(node_id, index);
+            if let Some(hir_id) = self.node_to_hir_id.get(node_id) {
+                self.hir_to_def_index.insert(*hir_id, index);
+            }
         }
 
         if expansion != Mark::root() {

--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -252,8 +252,8 @@ impl<'hir> Map<'hir> {
     // FIXME(@ljedrz): replace the NodeId variant
     #[inline]
     pub fn local_def_id_from_hir_id(&self, hir_id: HirId) -> DefId {
-        self.opt_local_def_id_from_hir_id(hir_id).unwrap_or_else(|| {
-            let node_id = self.hir_to_node_id(hir_id);
+        let node_id = self.hir_to_node_id(hir_id);
+        self.opt_local_def_id(node_id).unwrap_or_else(|| {
             bug!("local_def_id_from_hir_id: no entry for `{:?}`, which has a map of `{:?}`",
                  hir_id, self.find_entry(node_id))
         })
@@ -262,7 +262,8 @@ impl<'hir> Map<'hir> {
     // FIXME(@ljedrz): replace the NodeId variant
     #[inline]
     pub fn opt_local_def_id_from_hir_id(&self, hir_id: HirId) -> Option<DefId> {
-        self.definitions.opt_local_def_id_from_hir_id(hir_id)
+        let node_id = self.hir_to_node_id(hir_id);
+        self.definitions.opt_local_def_id(node_id)
     }
 
     #[inline]

--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -40,6 +40,7 @@ pub const REGULAR_SPACE: DefIndexAddressSpace = DefIndexAddressSpace::High;
 #[derive(Copy, Clone, Debug)]
 pub struct Entry<'hir> {
     parent: NodeId,
+    parent_hir: HirId,
     dep_node: DepNodeIndex,
     node: Node<'hir>,
 }
@@ -208,6 +209,12 @@ impl<'hir> Map<'hir> {
         }
     }
 
+    // FIXME(@ljedrz): replace the NodeId variant
+    pub fn read_by_hir_id(&self, hir_id: HirId) {
+        let node_id = self.hir_to_node_id(hir_id);
+        self.read(node_id);
+    }
+
     #[inline]
     pub fn definitions(&self) -> &'hir Definitions {
         self.definitions
@@ -224,6 +231,11 @@ impl<'hir> Map<'hir> {
         })
     }
 
+    // FIXME(@ljedrz): replace the NodeId variant
+    pub fn def_path_from_hir_id(&self, id: HirId) -> DefPath {
+        self.def_path(self.local_def_id_from_hir_id(id))
+    }
+
     pub fn def_path(&self, def_id: DefId) -> DefPath {
         assert!(def_id.is_local());
         self.definitions.def_path(def_id.index)
@@ -237,6 +249,22 @@ impl<'hir> Map<'hir> {
         })
     }
 
+    // FIXME(@ljedrz): replace the NodeId variant
+    #[inline]
+    pub fn local_def_id_from_hir_id(&self, hir_id: HirId) -> DefId {
+        self.opt_local_def_id_from_hir_id(hir_id).unwrap_or_else(|| {
+            let node_id = self.hir_to_node_id(hir_id);
+            bug!("local_def_id_from_hir_id: no entry for `{:?}`, which has a map of `{:?}`",
+                 hir_id, self.find_entry(node_id))
+        })
+    }
+
+    // FIXME(@ljedrz): replace the NodeId variant
+    #[inline]
+    pub fn opt_local_def_id_from_hir_id(&self, hir_id: HirId) -> Option<DefId> {
+        self.definitions.opt_local_def_id_from_hir_id(hir_id)
+    }
+
     #[inline]
     pub fn opt_local_def_id(&self, node: NodeId) -> Option<DefId> {
         self.definitions.opt_local_def_id(node)
@@ -245,6 +273,12 @@ impl<'hir> Map<'hir> {
     #[inline]
     pub fn as_local_node_id(&self, def_id: DefId) -> Option<NodeId> {
         self.definitions.as_local_node_id(def_id)
+    }
+
+    // FIXME(@ljedrz): replace the NodeId variant
+    #[inline]
+    pub fn as_local_hir_id(&self, def_id: DefId) -> Option<HirId> {
+        self.definitions.as_local_hir_id(def_id)
     }
 
     #[inline]
@@ -566,6 +600,12 @@ impl<'hir> Map<'hir> {
         self.find(id).unwrap_or_else(|| bug!("couldn't find node id {} in the AST map", id))
     }
 
+    // FIXME(@ljedrz): replace the NodeId variant
+    pub fn get_by_hir_id(&self, id: HirId) -> Node<'hir> {
+        let node_id = self.hir_to_node_id(id);
+        self.get(node_id)
+    }
+
     pub fn get_if_local(&self, id: DefId) -> Option<Node<'hir>> {
         self.as_local_node_id(id).map(|id| self.get(id)) // read recorded by `get`
     }
@@ -613,6 +653,12 @@ impl<'hir> Map<'hir> {
         result
     }
 
+    // FIXME(@ljedrz): replace the NodeId variant
+    pub fn find_by_hir_id(&self, hir_id: HirId) -> Option<Node<'hir>> {
+        let node_id = self.hir_to_node_id(hir_id);
+        self.find(node_id)
+    }
+
     /// Similar to `get_parent`; returns the parent node-id, or own `id` if there is
     /// no parent. Note that the parent may be `CRATE_NODE_ID`, which is not itself
     /// present in the map -- so passing the return value of get_parent_node to
@@ -631,6 +677,13 @@ impl<'hir> Map<'hir> {
         }
 
         self.find_entry(id).and_then(|x| x.parent_node()).unwrap_or(id)
+    }
+
+    // FIXME(@ljedrz): replace the NodeId variant
+    pub fn get_parent_node_by_hir_id(&self, id: HirId) -> HirId {
+        let node_id = self.hir_to_node_id(id);
+        let parent_node_id = self.get_parent_node(node_id);
+        self.node_to_hir_id(parent_node_id)
     }
 
     /// Check if the node is an argument. An argument is a local variable whose
@@ -757,6 +810,13 @@ impl<'hir> Map<'hir> {
         }
     }
 
+    // FIXME(@ljedrz): replace the NodeId variant
+    pub fn get_parent_item(&self, id: HirId) -> HirId {
+        let node_id = self.hir_to_node_id(id);
+        let parent_node_id = self.get_parent(node_id);
+        self.node_to_hir_id(parent_node_id)
+    }
+
     /// Returns the `DefId` of `id`'s nearest module parent, or `id` itself if no
     /// module parent is in this map.
     pub fn get_module_parent(&self, id: NodeId) -> DefId {
@@ -812,6 +872,12 @@ impl<'hir> Map<'hir> {
             Some(Node::Item(item)) => item,
             _ => bug!("expected item, found {}", self.node_to_string(id))
         }
+    }
+
+    // FIXME(@ljedrz): replace the NodeId variant
+    pub fn expect_item_by_hir_id(&self, id: HirId) -> &'hir Item {
+        let node_id = self.hir_to_node_id(id);
+        self.expect_item(node_id)
     }
 
     pub fn expect_impl_item(&self, id: NodeId) -> &'hir ImplItem {
@@ -960,12 +1026,27 @@ impl<'hir> Map<'hir> {
         node_id_to_string(self, id, true)
     }
 
+    // FIXME(@ljedrz): replace the NodeId variant
+    pub fn hir_to_string(&self, id: HirId) -> String {
+        hir_id_to_string(self, id, true)
+    }
+
     pub fn node_to_user_string(&self, id: NodeId) -> String {
         node_id_to_string(self, id, false)
     }
 
+    // FIXME(@ljedrz): replace the NodeId variant
+    pub fn hir_to_user_string(&self, id: HirId) -> String {
+        hir_id_to_string(self, id, false)
+    }
+
     pub fn node_to_pretty_string(&self, id: NodeId) -> String {
         print::to_string(self, |s| s.print_node(self.get(id)))
+    }
+
+    // FIXME(@ljedrz): replace the NodeId variant
+    pub fn hir_to_pretty_string(&self, id: HirId) -> String {
+        print::to_string(self, |s| s.print_node(self.get_by_hir_id(id)))
     }
 }
 
@@ -1308,6 +1389,12 @@ fn node_id_to_string(map: &Map<'_>, id: NodeId, include_id: bool) -> String {
         Some(Node::Crate) => String::from("root_crate"),
         None => format!("unknown node{}", id_str),
     }
+}
+
+// FIXME(@ljedrz): replace the NodeId variant
+fn hir_id_to_string(map: &Map<'_>, id: HirId, include_id: bool) -> String {
+    let node_id = map.hir_to_node_id(id);
+    node_id_to_string(map, node_id, include_id)
 }
 
 pub fn describe_def(tcx: TyCtxt<'_, '_, '_>, def_id: DefId) -> Option<Def> {

--- a/src/librustc/infer/error_reporting/nice_region_error/find_anon_type.rs
+++ b/src/librustc/infer/error_reporting/nice_region_error/find_anon_type.rs
@@ -114,7 +114,7 @@ impl<'a, 'gcx, 'tcx> Visitor<'gcx> for FindNestedTypeVisitor<'a, 'gcx, 'tcx> {
 
             hir::TyKind::Rptr(ref lifetime, _) => {
                 // the lifetime of the TyRptr
-                let hir_id = self.tcx.hir().node_to_hir_id(lifetime.id);
+                let hir_id = lifetime.hir_id;
                 match (self.tcx.named_region(hir_id), self.bound_region) {
                     // Find the index of the anonymous region that was part of the
                     // error. We will then search the function parameters for a bound
@@ -221,8 +221,7 @@ impl<'a, 'gcx, 'tcx> Visitor<'gcx> for TyPathVisitor<'a, 'gcx, 'tcx> {
     }
 
     fn visit_lifetime(&mut self, lifetime: &hir::Lifetime) {
-        let hir_id = self.tcx.hir().node_to_hir_id(lifetime.id);
-        match (self.tcx.named_region(hir_id), self.bound_region) {
+        match (self.tcx.named_region(lifetime.hir_id), self.bound_region) {
             // the lifetime of the TyPath!
             (Some(rl::Region::LateBoundAnon(debruijn_index, anon_index)), ty::BrAnon(br_index)) => {
                 if debruijn_index == self.current_index && anon_index == br_index {

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -840,7 +840,7 @@ fn resolve_pat<'a, 'tcx>(visitor: &mut RegionResolutionVisitor<'a, 'tcx>, pat: &
 }
 
 fn resolve_stmt<'a, 'tcx>(visitor: &mut RegionResolutionVisitor<'a, 'tcx>, stmt: &'tcx hir::Stmt) {
-    let stmt_id = visitor.tcx.hir().node_to_hir_id(stmt.id).local_id;
+    let stmt_id = stmt.hir_id.local_id;
     debug!("resolve_stmt(stmt.id={:?})", stmt_id);
 
     // Every statement will clean up the temporaries created during

--- a/src/librustc/ty/item_path.rs
+++ b/src/librustc/ty/item_path.rs
@@ -1,3 +1,4 @@
+use hir;
 use hir::map::DefPathData;
 use hir::def_id::{CrateNum, DefId, CRATE_DEF_INDEX, LOCAL_CRATE};
 use ty::{self, DefIdTree, Ty, TyCtxt};
@@ -74,6 +75,11 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
     /// Returns a string identifying this local node-id.
     pub fn node_path_str(self, id: ast::NodeId) -> String {
         self.item_path_str(self.hir().local_def_id(id))
+    }
+
+    // FIXME(@ljedrz): replace the NodeId variant
+    pub fn hir_path_str(self, id: hir::HirId) -> String {
+        self.item_path_str(self.hir().local_def_id_from_hir_id(id))
     }
 
     /// Returns a string identifying this def-id. This string is

--- a/src/librustc_mir/hair/cx/block.rs
+++ b/src/librustc_mir/hair/cx/block.rs
@@ -46,7 +46,7 @@ fn mirror_stmts<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
                                 -> Vec<StmtRef<'tcx>> {
     let mut result = vec![];
     for (index, stmt) in stmts.iter().enumerate() {
-        let hir_id = cx.tcx.hir().node_to_hir_id(stmt.id);
+        let hir_id = stmt.hir_id;
         let opt_dxn_ext = cx.region_scope_tree.opt_destruction_scope(hir_id.local_id);
         let stmt_span = StatementSpan(cx.tcx.hir().span(stmt.id));
         match stmt.node {

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -114,8 +114,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> dyn AstConv<'gcx, 'tcx> + 'o {
             tcx.hir().name(tcx.hir().as_local_node_id(def_id).unwrap()).as_interned_str()
         };
 
-        let hir_id = tcx.hir().node_to_hir_id(lifetime.id);
-        let r = match tcx.named_region(hir_id) {
+        let r = match tcx.named_region(lifetime.hir_id) {
             Some(rl::Region::Static) => {
                 tcx.types.re_static
             }
@@ -1145,8 +1144,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> dyn AstConv<'gcx, 'tcx> + 'o {
             self.ast_region_to_region(lifetime, None)
         } else {
             self.compute_object_lifetime_bound(span, existential_predicates).unwrap_or_else(|| {
-                let hir_id = tcx.hir().node_to_hir_id(lifetime.id);
-                if tcx.named_region(hir_id).is_some() {
+                if tcx.named_region(lifetime.hir_id).is_some() {
                     self.ast_region_to_region(lifetime, None)
                 } else {
                     self.re_infer(span, None).unwrap_or_else(|| {

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -814,8 +814,7 @@ fn has_late_bound_regions<'a, 'tcx>(
                 return;
             }
 
-            let hir_id = self.tcx.hir().node_to_hir_id(lt.id);
-            match self.tcx.named_region(hir_id) {
+            match self.tcx.named_region(lt.hir_id) {
                 Some(rl::Region::Static) | Some(rl::Region::EarlyBound(..)) => {}
                 Some(rl::Region::LateBound(debruijn, _, _))
                 | Some(rl::Region::LateBoundAnon(debruijn, _)) if debruijn < self.outer_index => {}
@@ -841,8 +840,7 @@ fn has_late_bound_regions<'a, 'tcx>(
         };
         for param in &generics.params {
             if let GenericParamKind::Lifetime { .. } = param.kind {
-                let hir_id = tcx.hir().node_to_hir_id(param.id);
-                if tcx.is_late_bound(hir_id) {
+                if tcx.is_late_bound(param.hir_id) {
                     return Some(param.span);
                 }
             }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1210,8 +1210,7 @@ impl Lifetime {
 impl Clean<Lifetime> for hir::Lifetime {
     fn clean(&self, cx: &DocContext) -> Lifetime {
         if self.id != ast::DUMMY_NODE_ID {
-            let hir_id = cx.tcx.hir().node_to_hir_id(self.id);
-            let def = cx.tcx.named_region(hir_id);
+            let def = cx.tcx.named_region(self.hir_id);
             match def {
                 Some(rl::Region::EarlyBound(_, node_id, _)) |
                 Some(rl::Region::LateBound(_, node_id, _)) |


### PR DESCRIPTION
This is another PR in a series dedicated to `HirId`-ification, i.e. deprecating `ast::NodeId`s after the AST > HIR lowering process. The bigger proof of concept can be seen in #57578.

**Phase 2**: add key `HirId` methods mirroring the `NodeId` ones.

These should be counterparts of the most widely used `Hir` methods using `NodeId`s. Note that this expands `hir::map::Definitions` with an additional `hir_to_def_index` map (with the intention of later removing `node_to_def_index`).

As a bonus there is also a small cleanup commit removing unnecessary calls to `node_to_hir_id` where `HirId` is already available.

r? @Zoxc 
Cc @varkor 