### PR TITLE
libarena => 2018

### DIFF
--- a/src/libarena/Cargo.toml
+++ b/src/libarena/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "arena"
 version = "0.0.0"
+edition = "2018"
 
 [lib]
 name = "arena"


### PR DESCRIPTION
Transitions `libarena` to Rust 2018; cc https://github.com/rust-lang/rust/issues/58099

r? @oli-obk 