### PR TITLE
libfmt_macros => 2018

### DIFF
--- a/src/libfmt_macros/Cargo.toml
+++ b/src/libfmt_macros/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "fmt_macros"
 version = "0.0.0"
+edition = "2018"
 
 [lib]
 name = "fmt_macros"

--- a/src/libfmt_macros/lib.rs
+++ b/src/libfmt_macros/lib.rs
@@ -10,14 +10,15 @@
        html_playground_url = "https://play.rust-lang.org/",
        test(attr(deny(warnings))))]
 
-#![feature(nll)]
+#![deny(rust_2018_idioms)]
+
 #![feature(rustc_private)]
 
-pub use self::Piece::*;
-pub use self::Position::*;
-pub use self::Alignment::*;
-pub use self::Flag::*;
-pub use self::Count::*;
+pub use Piece::*;
+pub use Position::*;
+pub use Alignment::*;
+pub use Flag::*;
+pub use Count::*;
 
 use std::str;
 use std::string;


### PR DESCRIPTION
Transitions `libfmt_macros` to Rust 2018; cc https://github.com/rust-lang/rust/issues/58099

r? @oli-obk 