### PR TITLE
Add NVPTX target to a build manifest

### DIFF
--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -78,6 +78,7 @@ static TARGETS: &'static [&'static str] = &[
     "mips64el-unknown-linux-gnuabi64",
     "mipsel-unknown-linux-gnu",
     "mipsel-unknown-linux-musl",
+    "nvptx64-nvidia-cuda",
     "powerpc-unknown-linux-gnu",
     "powerpc64-unknown-linux-gnu",
     "powerpc64le-unknown-linux-gnu",


### PR DESCRIPTION
Include `nvptx64-nvidia-cuda` target to a build manifest. I forgot this step at my first take on adding the target (#57937). 

Hopefully, this is the only reason why `rustup target add nvptx64-nvidia-cuda` doesn't work :slightly_frowning_face:

r? @alexcrichton 