### PR TITLE
libpanic_abort => 2018

### DIFF
--- a/src/libpanic_abort/Cargo.toml
+++ b/src/libpanic_abort/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "panic_abort"
 version = "0.0.0"
+edition = "2018"
 
 [lib]
 path = "lib.rs"

--- a/src/libpanic_abort/lib.rs
+++ b/src/libpanic_abort/lib.rs
@@ -10,11 +10,12 @@
        html_root_url = "https://doc.rust-lang.org/nightly/",
        issue_tracker_base_url = "https://github.com/rust-lang/rust/issues/")]
 #![panic_runtime]
+
 #![allow(unused_features)]
+#![deny(rust_2018_idioms)]
 
 #![feature(core_intrinsics)]
 #![feature(libc)]
-#![feature(nll)]
 #![feature(panic_runtime)]
 #![feature(staged_api)]
 #![feature(rustc_attrs)]
@@ -46,7 +47,6 @@ pub unsafe extern fn __rust_start_panic(_payload: usize) -> u32 {
 
     #[cfg(any(unix, target_os = "cloudabi"))]
     unsafe fn abort() -> ! {
-        extern crate libc;
         libc::abort();
     }
 


### PR DESCRIPTION
Transitions `libpanic_abort` to Rust 2018; cc #58099 

r? @oli-obk