### PR TITLE
Transition tidy and unstable-book-gen to 2018 edition

### DIFF
--- a/src/tools/tidy/src/main.rs
+++ b/src/tools/tidy/src/main.rs
@@ -4,6 +4,7 @@
 //! etc. This is run by default on `make check` and as part of the auto
 //! builders.
 
+#![deny(rust_2018_idioms)]
 #![deny(warnings)]
 
 extern crate tidy;

--- a/src/tools/tidy/src/unstable_book.rs
+++ b/src/tools/tidy/src/unstable_book.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 use std::fs;
 use std::path;
-use features::{collect_lang_features, collect_lib_features, Features, Status};
+use crate::features::{collect_lang_features, collect_lib_features, Features, Status};
 
 pub const PATH_STR: &str = "doc/unstable-book/src";
 

--- a/src/tools/unstable-book-gen/Cargo.toml
+++ b/src/tools/unstable-book-gen/Cargo.toml
@@ -4,6 +4,7 @@ authors = ["est31 <MTest31@outlook.com>",
 name = "unstable-book-gen"
 version = "0.1.0"
 license = "MIT/Apache-2.0"
+edition = "2018"
 
 [dependencies]
 tidy = { path = "../tidy" }

--- a/src/tools/unstable-book-gen/src/main.rs
+++ b/src/tools/unstable-book-gen/src/main.rs
@@ -1,8 +1,9 @@
 //! Auto-generate stub docs for the unstable book
 
+#![deny(rust_2018_idioms)]
 #![deny(warnings)]
 
-extern crate tidy;
+
 
 use tidy::features::{Feature, Features, collect_lib_features, collect_lang_features};
 use tidy::unstable_book::{collect_unstable_feature_names, collect_unstable_book_section_file_names,


### PR DESCRIPTION
Transitions tidy and unstable-book-gen to Rust 2018; cc #58099