### PR TITLE
Transition rustdoc to 2018 edition

### DIFF
--- a/src/tools/rustdoc/Cargo.toml
+++ b/src/tools/rustdoc/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rustdoc-tool"
 version = "0.0.0"
 authors = ["The Rust Project Developers"]
+edition = "2018"
 
 # Cargo adds a number of paths to the dylib search path on windows, which results in
 # the wrong rustdoc being executed. To avoid the conflicting rustdocs, we name the "tool"

--- a/src/tools/rustdoc/main.rs
+++ b/src/tools/rustdoc/main.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 #![feature(link_args)]
 
 #[allow(unused_attributes)]
@@ -9,7 +11,5 @@
 #[cfg_attr(all(windows, not(target_env = "msvc")), link_args = "-Wl,--stack,16777216")]
 // See src/rustc/rustc.rs for the corresponding rustc settings.
 extern {}
-
-extern crate rustdoc;
 
 fn main() { rustdoc::main() }


### PR DESCRIPTION
Transitions rustdoc to Rust 2018; cc #58099