### PR TITLE
Include the span of attributes of the lhs to the span of the assignment expression

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3455,6 +3455,14 @@ impl<'a> Parser<'a> {
                 }),
             }?;
 
+            // Make sure that the span of the parent node is larger than the span of lhs and rhs,
+            // including the attributes.
+            let lhs_span = lhs
+                .attrs
+                .iter()
+                .filter(|a| a.style == AttrStyle::Outer)
+                .next()
+                .map_or(lhs_span, |a| a.span);
             let span = lhs_span.to(rhs.span);
             lhs = match op {
                 AssocOp::Add | AssocOp::Subtract | AssocOp::Multiply | AssocOp::Divide |


### PR DESCRIPTION
This PR adds the span of attributes of the lhs to the span of the assignment expression. Currently with the following code, `#[attr]` is not included to the span of the assignment (`foo = true`).

```rust
#[attr]
foo = true;
```
The rational behind this change is that as libsyntax user I expect the span of the parent node includes every span of child nodes.

cc https://github.com/rust-lang/rustfmt/issues/3313, https://github.com/rust-lang/rust/issues/15701.

