### PR TITLE
Transition rustdoc-theme to 2018 edition

### DIFF
--- a/src/tools/rustdoc-themes/Cargo.toml
+++ b/src/tools/rustdoc-themes/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rustdoc-themes"
 version = "0.1.0"
 authors = ["Guillaume Gomez <guillaume1.gomez@gmail.com>"]
+edition = "2018"
 
 [[bin]]
 name = "rustdoc-themes"

--- a/src/tools/rustdoc-themes/main.rs
+++ b/src/tools/rustdoc-themes/main.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 use std::env::args;
 use std::fs::read_dir;
 use std::path::Path;


### PR DESCRIPTION
Transitions rustdoc-theme to Rust 2018; cc #58099