### PR TITLE
libproc_macro => 2018

### DIFF
--- a/src/libproc_macro/Cargo.toml
+++ b/src/libproc_macro/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "proc_macro"
 version = "0.0.0"
+edition = "2018"
 
 [lib]
 path = "lib.rs"

--- a/src/libproc_macro/bridge/buffer.rs
+++ b/src/libproc_macro/bridge/buffer.rs
@@ -6,7 +6,7 @@ use std::ops::{Deref, DerefMut};
 use std::slice;
 
 #[repr(C)]
-struct Slice<'a, T: 'a> {
+struct Slice<'a, T> {
     data: &'a [T; 0],
     len: usize,
 }
@@ -42,7 +42,7 @@ pub struct Buffer<T: Copy> {
     data: *mut T,
     len: usize,
     capacity: usize,
-    extend_from_slice: extern "C" fn(Buffer<T>, Slice<T>) -> Buffer<T>,
+    extend_from_slice: extern "C" fn(Buffer<T>, Slice<'_, T>) -> Buffer<T>,
     drop: extern "C" fn(Buffer<T>),
 }
 
@@ -139,7 +139,7 @@ impl<T: Copy> From<Vec<T>> for Buffer<T> {
             }
         }
 
-        extern "C" fn extend_from_slice<T: Copy>(b: Buffer<T>, xs: Slice<T>) -> Buffer<T> {
+        extern "C" fn extend_from_slice<T: Copy>(b: Buffer<T>, xs: Slice<'_, T>) -> Buffer<T> {
             let mut v = to_vec(b);
             v.extend_from_slice(&xs);
             Buffer::from(v)

--- a/src/libproc_macro/bridge/mod.rs
+++ b/src/libproc_macro/bridge/mod.rs
@@ -17,7 +17,7 @@ use std::panic;
 use std::sync::atomic::AtomicUsize;
 use std::sync::Once;
 use std::thread;
-use {Delimiter, Level, LineColumn, Spacing};
+use crate::{Delimiter, Level, LineColumn, Spacing};
 
 /// Higher-order macro describing the server RPC API, allowing automatic
 /// generation of type-safe Rust APIs, both client-side and server-side.
@@ -196,9 +196,9 @@ mod scoped_cell;
 #[forbid(unsafe_code)]
 pub mod server;
 
-use self::buffer::Buffer;
-pub use self::rpc::PanicMessage;
-use self::rpc::{Decode, DecodeMut, Encode, Reader, Writer};
+use buffer::Buffer;
+pub use rpc::PanicMessage;
+use rpc::{Decode, DecodeMut, Encode, Reader, Writer};
 
 /// An active connection between a server and a client.
 /// The server creates the bridge (`Bridge::run_server` in `server.rs`),

--- a/src/libproc_macro/bridge/rpc.rs
+++ b/src/libproc_macro/bridge/rpc.rs
@@ -40,7 +40,7 @@ macro_rules! rpc_encode_decode {
         }
 
         impl<S> DecodeMut<'_, '_, S> for $ty {
-            fn decode(r: &mut Reader, s: &mut S) -> Self {
+            fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
                 let mut byte = 0x80;
                 let mut v = 0;
                 let mut shift = 0;
@@ -61,7 +61,7 @@ macro_rules! rpc_encode_decode {
         }
 
         impl<S> DecodeMut<'_, '_, S> for $name {
-            fn decode(r: &mut Reader, s: &mut S) -> Self {
+            fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
                 $name {
                     $($field: DecodeMut::decode(r, s)),*
                 }
@@ -119,7 +119,7 @@ impl<S> Encode<S> for () {
 }
 
 impl<S> DecodeMut<'_, '_, S> for () {
-    fn decode(_: &mut Reader, _: &mut S) -> Self {}
+    fn decode(_: &mut Reader<'_>, _: &mut S) -> Self {}
 }
 
 impl<S> Encode<S> for u8 {
@@ -129,7 +129,7 @@ impl<S> Encode<S> for u8 {
 }
 
 impl<S> DecodeMut<'_, '_, S> for u8 {
-    fn decode(r: &mut Reader, _: &mut S) -> Self {
+    fn decode(r: &mut Reader<'_>, _: &mut S) -> Self {
         let x = r[0];
         *r = &r[1..];
         x
@@ -146,7 +146,7 @@ impl<S> Encode<S> for bool {
 }
 
 impl<S> DecodeMut<'_, '_, S> for bool {
-    fn decode(r: &mut Reader, s: &mut S) -> Self {
+    fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
         match u8::decode(r, s) {
             0 => false,
             1 => true,
@@ -162,7 +162,7 @@ impl<S> Encode<S> for char {
 }
 
 impl<S> DecodeMut<'_, '_, S> for char {
-    fn decode(r: &mut Reader, s: &mut S) -> Self {
+    fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
         char::from_u32(u32::decode(r, s)).unwrap()
     }
 }
@@ -174,7 +174,7 @@ impl<S> Encode<S> for NonZeroU32 {
 }
 
 impl<S> DecodeMut<'_, '_, S> for NonZeroU32 {
-    fn decode(r: &mut Reader, s: &mut S) -> Self {
+    fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
         Self::new(u32::decode(r, s)).unwrap()
     }
 }
@@ -251,7 +251,7 @@ impl<S> Encode<S> for String {
 }
 
 impl<S> DecodeMut<'_, '_, S> for String {
-    fn decode(r: &mut Reader, s: &mut S) -> Self {
+    fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
         <&str>::decode(r, s).to_string()
     }
 }
@@ -306,7 +306,7 @@ impl<S> Encode<S> for PanicMessage {
 }
 
 impl<S> DecodeMut<'_, '_, S> for PanicMessage {
-    fn decode(r: &mut Reader, s: &mut S) -> Self {
+    fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
         match Option::<String>::decode(r, s) {
             Some(s) => PanicMessage::String(s),
             None => PanicMessage::Unknown,

--- a/src/libproc_macro/bridge/server.rs
+++ b/src/libproc_macro/bridge/server.rs
@@ -131,7 +131,7 @@ pub trait ExecutionStrategy {
         &self,
         dispatcher: &mut impl DispatcherTrait,
         input: Buffer<u8>,
-        run_client: extern "C" fn(Bridge, D) -> Buffer<u8>,
+        run_client: extern "C" fn(Bridge<'_>, D) -> Buffer<u8>,
         client_data: D,
     ) -> Buffer<u8>;
 }
@@ -143,7 +143,7 @@ impl ExecutionStrategy for SameThread {
         &self,
         dispatcher: &mut impl DispatcherTrait,
         input: Buffer<u8>,
-        run_client: extern "C" fn(Bridge, D) -> Buffer<u8>,
+        run_client: extern "C" fn(Bridge<'_>, D) -> Buffer<u8>,
         client_data: D,
     ) -> Buffer<u8> {
         let mut dispatch = |b| dispatcher.dispatch(b);
@@ -168,7 +168,7 @@ impl ExecutionStrategy for CrossThread1 {
         &self,
         dispatcher: &mut impl DispatcherTrait,
         input: Buffer<u8>,
-        run_client: extern "C" fn(Bridge, D) -> Buffer<u8>,
+        run_client: extern "C" fn(Bridge<'_>, D) -> Buffer<u8>,
         client_data: D,
     ) -> Buffer<u8> {
         use std::sync::mpsc::channel;
@@ -206,7 +206,7 @@ impl ExecutionStrategy for CrossThread2 {
         &self,
         dispatcher: &mut impl DispatcherTrait,
         input: Buffer<u8>,
-        run_client: extern "C" fn(Bridge, D) -> Buffer<u8>,
+        run_client: extern "C" fn(Bridge<'_>, D) -> Buffer<u8>,
         client_data: D,
     ) -> Buffer<u8> {
         use std::sync::{Arc, Mutex};
@@ -273,7 +273,7 @@ fn run_server<
     handle_counters: &'static client::HandleCounters,
     server: S,
     input: I,
-    run_client: extern "C" fn(Bridge, D) -> Buffer<u8>,
+    run_client: extern "C" fn(Bridge<'_>, D) -> Buffer<u8>,
     client_data: D,
 ) -> Result<O, PanicMessage> {
     let mut dispatcher = Dispatcher {
@@ -289,7 +289,7 @@ fn run_server<
     Result::decode(&mut &b[..], &mut dispatcher.handle_store)
 }
 
-impl client::Client<fn(::TokenStream) -> ::TokenStream> {
+impl client::Client<fn(crate::TokenStream) -> crate::TokenStream> {
     pub fn run<S: Server>(
         &self,
         strategy: &impl ExecutionStrategy,
@@ -313,7 +313,7 @@ impl client::Client<fn(::TokenStream) -> ::TokenStream> {
     }
 }
 
-impl client::Client<fn(::TokenStream, ::TokenStream) -> ::TokenStream> {
+impl client::Client<fn(crate::TokenStream, crate::TokenStream) -> crate::TokenStream> {
     pub fn run<S: Server>(
         &self,
         strategy: &impl ExecutionStrategy,

--- a/src/libproc_macro/diagnostic.rs
+++ b/src/libproc_macro/diagnostic.rs
@@ -1,4 +1,4 @@
-use Span;
+use crate::Span;
 
 /// An enum representing a diagnostic level.
 #[unstable(feature = "proc_macro_diagnostic", issue = "54140")]
@@ -80,7 +80,7 @@ macro_rules! diagnostic_child_methods {
 /// Iterator over the children diagnostics of a `Diagnostic`.
 #[derive(Debug, Clone)]
 #[unstable(feature = "proc_macro_diagnostic", issue = "54140")]
-pub struct Children<'a>(::std::slice::Iter<'a, Diagnostic>);
+pub struct Children<'a>(std::slice::Iter<'a, Diagnostic>);
 
 #[unstable(feature = "proc_macro_diagnostic", issue = "54140")]
 impl<'a> Iterator for Children<'a> {
@@ -161,22 +161,22 @@ impl Diagnostic {
 
     /// Returns an iterator over the children diagnostics of `self`.
     #[unstable(feature = "proc_macro_diagnostic", issue = "54140")]
-    pub fn children(&self) -> Children {
+    pub fn children(&self) -> Children<'_> {
         Children(self.children.iter())
     }
 
     /// Emit the diagnostic.
     #[unstable(feature = "proc_macro_diagnostic", issue = "54140")]
     pub fn emit(self) {
-        fn to_internal(spans: Vec<Span>) -> ::bridge::client::MultiSpan {
-            let mut multi_span = ::bridge::client::MultiSpan::new();
+        fn to_internal(spans: Vec<Span>) -> crate::bridge::client::MultiSpan {
+            let mut multi_span = crate::bridge::client::MultiSpan::new();
             for span in spans {
                 multi_span.push(span.0);
             }
             multi_span
         }
 
-        let mut diag = ::bridge::client::Diagnostic::new(
+        let mut diag = crate::bridge::client::Diagnostic::new(
             self.level,
             &self.message[..],
             to_internal(self.spans),

--- a/src/libproc_macro/lib.rs
+++ b/src/libproc_macro/lib.rs
@@ -17,7 +17,8 @@
        test(no_crate_inject, attr(deny(warnings))),
        test(attr(allow(dead_code, deprecated, unused_variables, unused_mut))))]
 
-#![feature(nll)]
+#![deny(rust_2018_idioms)]
+
 #![feature(staged_api)]
 #![feature(const_fn)]
 #![feature(extern_types)]
@@ -114,7 +115,7 @@ impl ToString for TokenStream {
 /// with `Delimiter::None` delimiters and negative numeric literals.
 #[stable(feature = "proc_macro_lib", since = "1.15.0")]
 impl fmt::Display for TokenStream {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.to_string())
     }
 }
@@ -122,7 +123,7 @@ impl fmt::Display for TokenStream {
 /// Prints token in a form convenient for debugging.
 #[stable(feature = "proc_macro_lib", since = "1.15.0")]
 impl fmt::Debug for TokenStream {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("TokenStream ")?;
         f.debug_list().entries(self.clone()).finish()
     }
@@ -183,7 +184,7 @@ impl Extend<TokenStream> for TokenStream {
 /// Public implementation details for the `TokenStream` type, such as iterators.
 #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
 pub mod token_stream {
-    use {bridge, Group, Ident, Literal, Punct, TokenTree, TokenStream};
+    use crate::{bridge, Group, Ident, Literal, Punct, TokenTree, TokenStream};
 
     /// An iterator over `TokenStream`'s `TokenTree`s.
     /// The iteration is "shallow", e.g., the iterator doesn't recurse into delimited groups,
@@ -340,7 +341,7 @@ impl Span {
 /// Prints a span in a form convenient for debugging.
 #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
 impl fmt::Debug for Span {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
     }
 }
@@ -398,7 +399,7 @@ impl SourceFile {
 
 #[unstable(feature = "proc_macro_span", issue = "54725")]
 impl fmt::Debug for SourceFile {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SourceFile")
             .field("path", &self.path())
             .field("is_real", &self.is_real())
@@ -483,7 +484,7 @@ impl TokenTree {
 /// Prints token tree in a form convenient for debugging.
 #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
 impl fmt::Debug for TokenTree {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // Each of these has the name in the struct type in the derived debug,
         // so don't bother with an extra layer of indirection
         match *self {
@@ -542,7 +543,7 @@ impl ToString for TokenTree {
 /// with `Delimiter::None` delimiters and negative numeric literals.
 #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
 impl fmt::Display for TokenTree {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.to_string())
     }
 }
@@ -667,14 +668,14 @@ impl ToString for Group {
 /// with `Delimiter::None` delimiters.
 #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
 impl fmt::Display for Group {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.to_string())
     }
 }
 
 #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
 impl fmt::Debug for Group {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Group")
             .field("delimiter", &self.delimiter())
             .field("stream", &self.stream())
@@ -763,14 +764,14 @@ impl ToString for Punct {
 /// back into the same character.
 #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
 impl fmt::Display for Punct {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.to_string())
     }
 }
 
 #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
 impl fmt::Debug for Punct {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Punct")
             .field("ch", &self.as_char())
             .field("spacing", &self.spacing())
@@ -842,14 +843,14 @@ impl ToString for Ident {
 /// back into the same identifier.
 #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
 impl fmt::Display for Ident {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.to_string())
     }
 }
 
 #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
 impl fmt::Debug for Ident {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Ident")
             .field("ident", &self.to_string())
             .field("span", &self.span())
@@ -1092,14 +1093,14 @@ impl ToString for Literal {
 /// back into the same literal (except for possible rounding for floating point literals).
 #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
 impl fmt::Display for Literal {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.to_string())
     }
 }
 
 #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
 impl fmt::Debug for Literal {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // FIXME(eddyb) `Literal` should not expose internal `Debug` impls.
         self.0.fmt(f)
     }

--- a/src/libproc_macro/quote.rs
+++ b/src/libproc_macro/quote.rs
@@ -4,7 +4,7 @@
 //! This quasiquoter uses macros 2.0 hygiene to reliably access
 //! items from `proc_macro`, to build a `proc_macro::TokenStream`.
 
-use {Delimiter, Group, Ident, Literal, Punct, Spacing, Span, TokenStream, TokenTree};
+use crate::{Delimiter, Group, Ident, Literal, Punct, Spacing, Span, TokenStream, TokenTree};
 
 macro_rules! quote_tt {
     (($($t:tt)*)) => { Group::new(Delimiter::Parenthesis, quote!($($t)*)) };
@@ -63,7 +63,7 @@ macro_rules! quote {
 #[unstable(feature = "proc_macro_quote", issue = "54722")]
 pub fn quote(stream: TokenStream) -> TokenStream {
     if stream.is_empty() {
-        return quote!(::TokenStream::new());
+        return quote!(crate::TokenStream::new());
     }
     let mut after_dollar = false;
     let tokens = stream
@@ -73,7 +73,7 @@ pub fn quote(stream: TokenStream) -> TokenStream {
                 after_dollar = false;
                 match tree {
                     TokenTree::Ident(_) => {
-                        return Some(quote!(Into::<::TokenStream>::into(
+                        return Some(quote!(Into::<crate::TokenStream>::into(
                         Clone::clone(&(@ tree))),));
                     }
                     TokenTree::Punct(ref tt) if tt.as_char() == '$' => {}
@@ -86,33 +86,33 @@ pub fn quote(stream: TokenStream) -> TokenStream {
                 }
             }
 
-            Some(quote!(::TokenStream::from((@ match tree {
-                TokenTree::Punct(tt) => quote!(::TokenTree::Punct(::Punct::new(
+            Some(quote!(crate::TokenStream::from((@ match tree {
+                TokenTree::Punct(tt) => quote!(crate::TokenTree::Punct(crate::Punct::new(
                     (@ TokenTree::from(Literal::character(tt.as_char()))),
                     (@ match tt.spacing() {
-                        Spacing::Alone => quote!(::Spacing::Alone),
-                        Spacing::Joint => quote!(::Spacing::Joint),
+                        Spacing::Alone => quote!(crate::Spacing::Alone),
+                        Spacing::Joint => quote!(crate::Spacing::Joint),
                     }),
                 ))),
-                TokenTree::Group(tt) => quote!(::TokenTree::Group(::Group::new(
+                TokenTree::Group(tt) => quote!(crate::TokenTree::Group(crate::Group::new(
                     (@ match tt.delimiter() {
-                        Delimiter::Parenthesis => quote!(::Delimiter::Parenthesis),
-                        Delimiter::Brace => quote!(::Delimiter::Brace),
-                        Delimiter::Bracket => quote!(::Delimiter::Bracket),
-                        Delimiter::None => quote!(::Delimiter::None),
+                        Delimiter::Parenthesis => quote!(crate::Delimiter::Parenthesis),
+                        Delimiter::Brace => quote!(crate::Delimiter::Brace),
+                        Delimiter::Bracket => quote!(crate::Delimiter::Bracket),
+                        Delimiter::None => quote!(crate::Delimiter::None),
                     }),
                     (@ quote(tt.stream())),
                 ))),
-                TokenTree::Ident(tt) => quote!(::TokenTree::Ident(::Ident::new(
+                TokenTree::Ident(tt) => quote!(crate::TokenTree::Ident(crate::Ident::new(
                     (@ TokenTree::from(Literal::string(&tt.to_string()))),
                     (@ quote_span(tt.span())),
                 ))),
-                TokenTree::Literal(tt) => quote!(::TokenTree::Literal({
+                TokenTree::Literal(tt) => quote!(crate::TokenTree::Literal({
                     let mut iter = (@ TokenTree::from(Literal::string(&tt.to_string())))
-                        .parse::<::TokenStream>()
+                        .parse::<crate::TokenStream>()
                         .unwrap()
                         .into_iter();
-                    if let (Some(::TokenTree::Literal(mut lit)), None) =
+                    if let (Some(crate::TokenTree::Literal(mut lit)), None) =
                         (iter.next(), iter.next())
                     {
                         lit.set_span((@ quote_span(tt.span())));
@@ -129,12 +129,12 @@ pub fn quote(stream: TokenStream) -> TokenStream {
         panic!("unexpected trailing `$` in `quote!`");
     }
 
-    quote!([(@ tokens)].iter().cloned().collect::<::TokenStream>())
+    quote!([(@ tokens)].iter().cloned().collect::<crate::TokenStream>())
 }
 
 /// Quote a `Span` into a `TokenStream`.
 /// This is needed to implement a custom quoter.
 #[unstable(feature = "proc_macro_quote", issue = "54722")]
 pub fn quote_span(_: Span) -> TokenStream {
-    quote!(::Span::def_site())
+    quote!(crate::Span::def_site())
 }


### PR DESCRIPTION
Transitions `libproc_macro` to Rust 2018; cc #58099

r? @Centril