### PR TITLE
Transition build_helper to 2018 edition

### DIFF
--- a/src/build_helper/Cargo.toml
+++ b/src/build_helper/Cargo.toml
@@ -2,6 +2,7 @@
 name = "build_helper"
 version = "0.1.0"
 authors = ["The Rust Project Developers"]
+edition = "2018"
 
 [lib]
 name = "build_helper"

--- a/src/build_helper/lib.rs
+++ b/src/build_helper/lib.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 use std::fs::File;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};


### PR DESCRIPTION
Transitions build_helper to Rust 2018; cc #58099
r? @Centril