### PR TITLE
libsyntax_pos => 2018

### DIFF
--- a/src/libsyntax_pos/Cargo.toml
+++ b/src/libsyntax_pos/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "syntax_pos"
 version = "0.0.0"
+edition = "2018"
 
 [lib]
 name = "syntax_pos"

--- a/src/libsyntax_pos/analyze_source_file.rs
+++ b/src/libsyntax_pos/analyze_source_file.rs
@@ -36,7 +36,7 @@ pub fn analyze_source_file(
     (lines, multi_byte_chars, non_narrow_chars)
 }
 
-cfg_if! {
+cfg_if::cfg_if! {
     if #[cfg(all(any(target_arch = "x86", target_arch = "x86_64")))] {
         fn analyze_source_file_dispatch(src: &str,
                                     source_file_start_pos: BytePos,

--- a/src/libsyntax_pos/edition.rs
+++ b/src/libsyntax_pos/edition.rs
@@ -27,7 +27,7 @@ pub const EDITION_NAME_LIST: &str = "2015|2018";
 pub const DEFAULT_EDITION: Edition = Edition::Edition2015;
 
 impl fmt::Display for Edition {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s = match *self {
             Edition::Edition2015 => "2015",
             Edition::Edition2018 => "2018",

--- a/src/libsyntax_pos/hygiene.rs
+++ b/src/libsyntax_pos/hygiene.rs
@@ -5,10 +5,10 @@
 //! and definition contexts*. J. Funct. Program. 22, 2 (March 2012), 181-216.
 //! DOI=10.1017/S0956796812000093 <https://doi.org/10.1017/S0956796812000093>
 
-use GLOBALS;
-use Span;
-use edition::{Edition, DEFAULT_EDITION};
-use symbol::{keywords, Symbol};
+use crate::GLOBALS;
+use crate::Span;
+use crate::edition::{Edition, DEFAULT_EDITION};
+use crate::symbol::{keywords, Symbol};
 
 use serialize::{Encodable, Decodable, Encoder, Decoder};
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
@@ -525,7 +525,7 @@ impl SyntaxContext {
 }
 
 impl fmt::Debug for SyntaxContext {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "#{}", self.0)
     }
 }

--- a/src/libsyntax_pos/span_encoding.rs
+++ b/src/libsyntax_pos/span_encoding.rs
@@ -4,9 +4,9 @@
 // The encoding format for inline spans were obtained by optimizing over crates in rustc/libstd.
 // See https://internals.rust-lang.org/t/rfc-compiler-refactoring-spans/1357/28
 
-use GLOBALS;
-use {BytePos, SpanData};
-use hygiene::SyntaxContext;
+use crate::GLOBALS;
+use crate::{BytePos, SpanData};
+use crate::hygiene::SyntaxContext;
 
 use rustc_data_structures::fx::FxHashMap;
 use std::hash::{Hash, Hasher};


### PR DESCRIPTION
Transitions `libsyntax_pos` to Rust 2018; cc #58099

r? @Centril