### PR TITLE
libunwind => 2018

### DIFF
--- a/src/libunwind/Cargo.toml
+++ b/src/libunwind/Cargo.toml
@@ -3,6 +3,7 @@ authors = ["The Rust Project Developers"]
 name = "unwind"
 version = "0.0.0"
 build = "build.rs"
+edition = "2018"
 
 [lib]
 name = "unwind"

--- a/src/libunwind/lib.rs
+++ b/src/libunwind/lib.rs
@@ -1,8 +1,9 @@
 #![no_std]
 #![unstable(feature = "panic_unwind", issue = "32837")]
 
+#![deny(rust_2018_idioms)]
+
 #![feature(link_cfg)]
-#![feature(nll)]
 #![feature(staged_api)]
 #![feature(unwind_attributes)]
 #![feature(static_nobundle)]
@@ -18,7 +19,6 @@ cfg_if! {
     } else if #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))] {
         // no unwinder on the system!
     } else {
-        extern crate libc;
         mod libunwind;
         pub use libunwind::*;
     }

--- a/src/libunwind/libunwind.rs
+++ b/src/libunwind/libunwind.rs
@@ -21,7 +21,7 @@ pub enum _Unwind_Reason_Code {
     _URC_CONTINUE_UNWIND = 8,
     _URC_FAILURE = 9, // used only by ARM EHABI
 }
-pub use self::_Unwind_Reason_Code::*;
+pub use _Unwind_Reason_Code::*;
 
 pub type _Unwind_Exception_Class = u64;
 pub type _Unwind_Word = uintptr_t;
@@ -94,7 +94,7 @@ if #[cfg(all(any(target_os = "ios", target_os = "netbsd", not(target_arch = "arm
         _UA_FORCE_UNWIND = 8,
         _UA_END_OF_STACK = 16,
     }
-    pub use self::_Unwind_Action::*;
+    pub use _Unwind_Action::*;
 
     extern "C" {
         pub fn _Unwind_GetGR(ctx: *mut _Unwind_Context, reg_index: c_int) -> _Unwind_Word;
@@ -118,7 +118,7 @@ if #[cfg(all(any(target_os = "ios", target_os = "netbsd", not(target_arch = "arm
         _US_FORCE_UNWIND = 8,
         _US_END_OF_STACK = 16,
     }
-    pub use self::_Unwind_State::*;
+    pub use _Unwind_State::*;
 
     #[repr(C)]
     enum _Unwind_VRS_Result {
@@ -134,7 +134,7 @@ if #[cfg(all(any(target_os = "ios", target_os = "netbsd", not(target_arch = "arm
         _UVRSC_WMMXD = 3,
         _UVRSC_WMMXC = 4,
     }
-    use self::_Unwind_VRS_RegClass::*;
+    use _Unwind_VRS_RegClass::*;
     #[repr(C)]
     enum _Unwind_VRS_DataRepresentation {
         _UVRSD_UINT32 = 0,
@@ -144,7 +144,7 @@ if #[cfg(all(any(target_os = "ios", target_os = "netbsd", not(target_arch = "arm
         _UVRSD_FLOAT = 4,
         _UVRSD_DOUBLE = 5,
     }
-    use self::_Unwind_VRS_DataRepresentation::*;
+    use _Unwind_VRS_DataRepresentation::*;
 
     pub const UNWIND_POINTER_REG: c_int = 12;
     pub const UNWIND_IP_REG: c_int = 15;


### PR DESCRIPTION
Transitions `libunwind` to Rust 2018; cc #58099

r? @Centril