### PR TITLE
libsyntax_ext => 2018

### DIFF
--- a/src/libsyntax_ext/Cargo.toml
+++ b/src/libsyntax_ext/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "syntax_ext"
 version = "0.0.0"
+edition = "2018"
 
 [lib]
 name = "syntax_ext"

--- a/src/libsyntax_ext/asm.rs
+++ b/src/libsyntax_ext/asm.rs
@@ -1,13 +1,13 @@
 // Inline assembly support.
 //
-use self::State::*;
+use State::*;
 
 use rustc_data_structures::thin_vec::ThinVec;
 
-use errors::DiagnosticBuilder;
+use crate::errors::DiagnosticBuilder;
+
 use syntax::ast;
-use syntax::ext::base;
-use syntax::ext::base::*;
+use syntax::ext::base::{self, *};
 use syntax::feature_gate;
 use syntax::parse::{self, token};
 use syntax::ptr::P;
@@ -15,6 +15,7 @@ use syntax::symbol::Symbol;
 use syntax::ast::AsmDialect;
 use syntax_pos::Span;
 use syntax::tokenstream;
+use syntax::{span_err, struct_span_err};
 
 enum State {
     Asm,
@@ -40,7 +41,7 @@ impl State {
 
 const OPTIONS: &[&str] = &["volatile", "alignstack", "intel"];
 
-pub fn expand_asm<'cx>(cx: &'cx mut ExtCtxt,
+pub fn expand_asm<'cx>(cx: &'cx mut ExtCtxt<'_>,
                        sp: Span,
                        tts: &[tokenstream::TokenTree])
                        -> Box<dyn base::MacResult + 'cx> {

--- a/src/libsyntax_ext/assert.rs
+++ b/src/libsyntax_ext/assert.rs
@@ -1,4 +1,5 @@
-use errors::DiagnosticBuilder;
+use crate::errors::DiagnosticBuilder;
+
 use syntax::ast::{self, *};
 use syntax::source_map::Spanned;
 use syntax::ext::base::*;
@@ -11,7 +12,7 @@ use syntax::tokenstream::{TokenStream, TokenTree};
 use syntax_pos::{Span, DUMMY_SP};
 
 pub fn expand_assert<'cx>(
-    cx: &'cx mut ExtCtxt,
+    cx: &'cx mut ExtCtxt<'_>,
     sp: Span,
     tts: &[TokenTree],
 ) -> Box<dyn MacResult + 'cx> {

--- a/src/libsyntax_ext/cfg.rs
+++ b/src/libsyntax_ext/cfg.rs
@@ -2,17 +2,17 @@
 /// a literal `true` or `false` based on whether the given cfg matches the
 /// current compilation environment.
 
-use errors::DiagnosticBuilder;
+use crate::errors::DiagnosticBuilder;
+
 use syntax::ast;
-use syntax::ext::base::*;
-use syntax::ext::base;
+use syntax::ext::base::{self, *};
 use syntax::ext::build::AstBuilder;
 use syntax::attr;
 use syntax::tokenstream;
 use syntax::parse::token;
 use syntax_pos::Span;
 
-pub fn expand_cfg<'cx>(cx: &mut ExtCtxt,
+pub fn expand_cfg<'cx>(cx: &mut ExtCtxt<'_>,
                        sp: Span,
                        tts: &[tokenstream::TokenTree])
                        -> Box<dyn base::MacResult + 'static> {

--- a/src/libsyntax_ext/compile_error.rs
+++ b/src/libsyntax_ext/compile_error.rs
@@ -1,11 +1,10 @@
 // The compiler code necessary to support the compile_error! extension.
 
-use syntax::ext::base::*;
-use syntax::ext::base;
+use syntax::ext::base::{self, *};
 use syntax_pos::Span;
 use syntax::tokenstream;
 
-pub fn expand_compile_error<'cx>(cx: &'cx mut ExtCtxt,
+pub fn expand_compile_error<'cx>(cx: &'cx mut ExtCtxt<'_>,
                               sp: Span,
                               tts: &[tokenstream::TokenTree])
                               -> Box<dyn base::MacResult + 'cx> {

--- a/src/libsyntax_ext/concat.rs
+++ b/src/libsyntax_ext/concat.rs
@@ -3,12 +3,11 @@ use syntax::ext::base;
 use syntax::ext::build::AstBuilder;
 use syntax::symbol::Symbol;
 use syntax::tokenstream;
-use syntax_pos;
 
 use std::string::String;
 
 pub fn expand_syntax_ext(
-    cx: &mut base::ExtCtxt,
+    cx: &mut base::ExtCtxt<'_>,
     sp: syntax_pos::Span,
     tts: &[tokenstream::TokenTree],
 ) -> Box<dyn base::MacResult + 'static> {

--- a/src/libsyntax_ext/concat_idents.rs
+++ b/src/libsyntax_ext/concat_idents.rs
@@ -1,8 +1,7 @@
 use rustc_data_structures::thin_vec::ThinVec;
 
 use syntax::ast;
-use syntax::ext::base::*;
-use syntax::ext::base;
+use syntax::ext::base::{self, *};
 use syntax::feature_gate;
 use syntax::parse::token;
 use syntax::ptr::P;
@@ -10,7 +9,7 @@ use syntax_pos::Span;
 use syntax_pos::symbol::Symbol;
 use syntax::tokenstream::TokenTree;
 
-pub fn expand_syntax_ext<'cx>(cx: &'cx mut ExtCtxt,
+pub fn expand_syntax_ext<'cx>(cx: &'cx mut ExtCtxt<'_>,
                               sp: Span,
                               tts: &[TokenTree])
                               -> Box<dyn base::MacResult + 'cx> {

--- a/src/libsyntax_ext/deriving/bounds.rs
+++ b/src/libsyntax_ext/deriving/bounds.rs
@@ -1,11 +1,12 @@
-use deriving::path_std;
-use deriving::generic::*;
-use deriving::generic::ty::*;
+use crate::deriving::path_std;
+use crate::deriving::generic::*;
+use crate::deriving::generic::ty::*;
+
 use syntax::ast::MetaItem;
 use syntax::ext::base::{Annotatable, ExtCtxt};
 use syntax_pos::Span;
 
-pub fn expand_deriving_unsafe_bound(cx: &mut ExtCtxt,
+pub fn expand_deriving_unsafe_bound(cx: &mut ExtCtxt<'_>,
                                     span: Span,
                                     _: &MetaItem,
                                     _: &Annotatable,
@@ -13,7 +14,7 @@ pub fn expand_deriving_unsafe_bound(cx: &mut ExtCtxt,
     cx.span_err(span, "this unsafe trait should be implemented explicitly");
 }
 
-pub fn expand_deriving_copy(cx: &mut ExtCtxt,
+pub fn expand_deriving_copy(cx: &mut ExtCtxt<'_>,
                             span: Span,
                             mitem: &MetaItem,
                             item: &Annotatable,

--- a/src/libsyntax_ext/deriving/clone.rs
+++ b/src/libsyntax_ext/deriving/clone.rs
@@ -1,9 +1,8 @@
-use deriving::path_std;
-use deriving::generic::*;
-use deriving::generic::ty::*;
+use crate::deriving::path_std;
+use crate::deriving::generic::*;
+use crate::deriving::generic::ty::*;
 
-use syntax::ast::{self, Expr, Generics, ItemKind, MetaItem, VariantData};
-use syntax::ast::GenericArg;
+use syntax::ast::{self, Expr, GenericArg, Generics, ItemKind, MetaItem, VariantData};
 use syntax::attr;
 use syntax::ext::base::{Annotatable, ExtCtxt};
 use syntax::ext::build::AstBuilder;
@@ -11,7 +10,7 @@ use syntax::ptr::P;
 use syntax::symbol::{Symbol, keywords};
 use syntax_pos::Span;
 
-pub fn expand_deriving_clone(cx: &mut ExtCtxt,
+pub fn expand_deriving_clone(cx: &mut ExtCtxt<'_>,
                              span: Span,
                              mitem: &MetaItem,
                              item: &Annotatable,
@@ -105,12 +104,12 @@ pub fn expand_deriving_clone(cx: &mut ExtCtxt,
 }
 
 fn cs_clone_shallow(name: &str,
-                    cx: &mut ExtCtxt,
+                    cx: &mut ExtCtxt<'_>,
                     trait_span: Span,
-                    substr: &Substructure,
+                    substr: &Substructure<'_>,
                     is_union: bool)
                     -> P<Expr> {
-    fn assert_ty_bounds(cx: &mut ExtCtxt, stmts: &mut Vec<ast::Stmt>,
+    fn assert_ty_bounds(cx: &mut ExtCtxt<'_>, stmts: &mut Vec<ast::Stmt>,
                         ty: P<ast::Ty>, span: Span, helper_name: &str) {
         // Generate statement `let _: helper_name<ty>;`,
         // set the expn ID so we can use the unstable struct.
@@ -120,7 +119,7 @@ fn cs_clone_shallow(name: &str,
                                         vec![GenericArg::Type(ty)], vec![]);
         stmts.push(cx.stmt_let_type_only(span, cx.ty_path(assert_path)));
     }
-    fn process_variant(cx: &mut ExtCtxt, stmts: &mut Vec<ast::Stmt>, variant: &VariantData) {
+    fn process_variant(cx: &mut ExtCtxt<'_>, stmts: &mut Vec<ast::Stmt>, variant: &VariantData) {
         for field in variant.fields() {
             // let _: AssertParamIsClone<FieldTy>;
             assert_ty_bounds(cx, stmts, field.ty.clone(), field.span, "AssertParamIsClone");
@@ -151,14 +150,14 @@ fn cs_clone_shallow(name: &str,
 }
 
 fn cs_clone(name: &str,
-            cx: &mut ExtCtxt,
+            cx: &mut ExtCtxt<'_>,
             trait_span: Span,
-            substr: &Substructure)
+            substr: &Substructure<'_>)
             -> P<Expr> {
     let ctor_path;
     let all_fields;
     let fn_path = cx.std_path(&["clone", "Clone", "clone"]);
-    let subcall = |cx: &mut ExtCtxt, field: &FieldInfo| {
+    let subcall = |cx: &mut ExtCtxt<'_>, field: &FieldInfo<'_>| {
         let args = vec![cx.expr_addr_of(field.span, field.self_.clone())];
         cx.expr_call_global(field.span, fn_path.clone(), args)
     };

--- a/src/libsyntax_ext/deriving/cmp/eq.rs
+++ b/src/libsyntax_ext/deriving/cmp/eq.rs
@@ -1,6 +1,6 @@
-use deriving::path_std;
-use deriving::generic::*;
-use deriving::generic::ty::*;
+use crate::deriving::path_std;
+use crate::deriving::generic::*;
+use crate::deriving::generic::ty::*;
 
 use syntax::ast::{self, Expr, MetaItem, GenericArg};
 use syntax::ext::base::{Annotatable, ExtCtxt};
@@ -9,7 +9,7 @@ use syntax::ptr::P;
 use syntax::symbol::Symbol;
 use syntax_pos::Span;
 
-pub fn expand_deriving_eq(cx: &mut ExtCtxt,
+pub fn expand_deriving_eq(cx: &mut ExtCtxt<'_>,
                           span: Span,
                           mitem: &MetaItem,
                           item: &Annotatable,
@@ -44,8 +44,11 @@ pub fn expand_deriving_eq(cx: &mut ExtCtxt,
     trait_def.expand_ext(cx, mitem, item, push, true)
 }
 
-fn cs_total_eq_assert(cx: &mut ExtCtxt, trait_span: Span, substr: &Substructure) -> P<Expr> {
-    fn assert_ty_bounds(cx: &mut ExtCtxt, stmts: &mut Vec<ast::Stmt>,
+fn cs_total_eq_assert(cx: &mut ExtCtxt<'_>,
+                      trait_span: Span,
+                      substr: &Substructure<'_>)
+                      -> P<Expr> {
+    fn assert_ty_bounds(cx: &mut ExtCtxt<'_>, stmts: &mut Vec<ast::Stmt>,
                         ty: P<ast::Ty>, span: Span, helper_name: &str) {
         // Generate statement `let _: helper_name<ty>;`,
         // set the expn ID so we can use the unstable struct.
@@ -55,7 +58,9 @@ fn cs_total_eq_assert(cx: &mut ExtCtxt, trait_span: Span, substr: &Substructure)
                                         vec![GenericArg::Type(ty)], vec![]);
         stmts.push(cx.stmt_let_type_only(span, cx.ty_path(assert_path)));
     }
-    fn process_variant(cx: &mut ExtCtxt, stmts: &mut Vec<ast::Stmt>, variant: &ast::VariantData) {
+    fn process_variant(cx: &mut ExtCtxt<'_>,
+                       stmts: &mut Vec<ast::Stmt>,
+                       variant: &ast::VariantData) {
         for field in variant.fields() {
             // let _: AssertParamIsEq<FieldTy>;
             assert_ty_bounds(cx, stmts, field.ty.clone(), field.span, "AssertParamIsEq");

--- a/src/libsyntax_ext/deriving/cmp/ord.rs
+++ b/src/libsyntax_ext/deriving/cmp/ord.rs
@@ -1,6 +1,6 @@
-use deriving::path_std;
-use deriving::generic::*;
-use deriving::generic::ty::*;
+use crate::deriving::path_std;
+use crate::deriving::generic::*;
+use crate::deriving::generic::ty::*;
 
 use syntax::ast::{self, Expr, MetaItem};
 use syntax::ext::base::{Annotatable, ExtCtxt};
@@ -9,7 +9,7 @@ use syntax::ptr::P;
 use syntax::symbol::Symbol;
 use syntax_pos::Span;
 
-pub fn expand_deriving_ord(cx: &mut ExtCtxt,
+pub fn expand_deriving_ord(cx: &mut ExtCtxt<'_>,
                            span: Span,
                            mitem: &MetaItem,
                            item: &Annotatable,
@@ -44,7 +44,7 @@ pub fn expand_deriving_ord(cx: &mut ExtCtxt,
 }
 
 
-pub fn ordering_collapsed(cx: &mut ExtCtxt,
+pub fn ordering_collapsed(cx: &mut ExtCtxt<'_>,
                           span: Span,
                           self_arg_tags: &[ast::Ident])
                           -> P<ast::Expr> {
@@ -53,7 +53,7 @@ pub fn ordering_collapsed(cx: &mut ExtCtxt,
     cx.expr_method_call(span, lft, cx.ident_of("cmp"), vec![rgt])
 }
 
-pub fn cs_cmp(cx: &mut ExtCtxt, span: Span, substr: &Substructure) -> P<Expr> {
+pub fn cs_cmp(cx: &mut ExtCtxt<'_>, span: Span, substr: &Substructure<'_>) -> P<Expr> {
     let test_id = cx.ident_of("cmp").gensym();
     let equals_path = cx.path_global(span, cx.std_path(&["cmp", "Ordering", "Equal"]));
 

--- a/src/libsyntax_ext/deriving/cmp/partial_eq.rs
+++ b/src/libsyntax_ext/deriving/cmp/partial_eq.rs
@@ -1,6 +1,6 @@
-use deriving::{path_local, path_std};
-use deriving::generic::*;
-use deriving::generic::ty::*;
+use crate::deriving::{path_local, path_std};
+use crate::deriving::generic::*;
+use crate::deriving::generic::ty::*;
 
 use syntax::ast::{BinOpKind, Expr, MetaItem};
 use syntax::ext::base::{Annotatable, ExtCtxt};
@@ -9,22 +9,22 @@ use syntax::ptr::P;
 use syntax::symbol::Symbol;
 use syntax_pos::Span;
 
-pub fn expand_deriving_partial_eq(cx: &mut ExtCtxt,
+pub fn expand_deriving_partial_eq(cx: &mut ExtCtxt<'_>,
                                   span: Span,
                                   mitem: &MetaItem,
                                   item: &Annotatable,
                                   push: &mut dyn FnMut(Annotatable)) {
     // structures are equal if all fields are equal, and non equal, if
     // any fields are not equal or if the enum variants are different
-    fn cs_op(cx: &mut ExtCtxt,
+    fn cs_op(cx: &mut ExtCtxt<'_>,
              span: Span,
-             substr: &Substructure,
+             substr: &Substructure<'_>,
              op: BinOpKind,
              combiner: BinOpKind,
              base: bool)
              -> P<Expr>
     {
-        let op = |cx: &mut ExtCtxt, span: Span, self_f: P<Expr>, other_fs: &[P<Expr>]| {
+        let op = |cx: &mut ExtCtxt<'_>, span: Span, self_f: P<Expr>, other_fs: &[P<Expr>]| {
             let other_f = match (other_fs.len(), other_fs.get(0)) {
                 (1, Some(o_f)) => o_f,
                 _ => cx.span_bug(span, "not exactly 2 arguments in `derive(PartialEq)`"),
@@ -53,10 +53,10 @@ pub fn expand_deriving_partial_eq(cx: &mut ExtCtxt,
             substr)
     }
 
-    fn cs_eq(cx: &mut ExtCtxt, span: Span, substr: &Substructure) -> P<Expr> {
+    fn cs_eq(cx: &mut ExtCtxt<'_>, span: Span, substr: &Substructure<'_>) -> P<Expr> {
         cs_op(cx, span, substr, BinOpKind::Eq, BinOpKind::And, true)
     }
-    fn cs_ne(cx: &mut ExtCtxt, span: Span, substr: &Substructure) -> P<Expr> {
+    fn cs_ne(cx: &mut ExtCtxt<'_>, span: Span, substr: &Substructure<'_>) -> P<Expr> {
         cs_op(cx, span, substr, BinOpKind::Ne, BinOpKind::Or, false)
     }
 

--- a/src/libsyntax_ext/deriving/cmp/partial_ord.rs
+++ b/src/libsyntax_ext/deriving/cmp/partial_ord.rs
@@ -1,8 +1,8 @@
-pub use self::OrderingOp::*;
+pub use OrderingOp::*;
 
-use deriving::{path_local, pathvec_std, path_std};
-use deriving::generic::*;
-use deriving::generic::ty::*;
+use crate::deriving::{path_local, pathvec_std, path_std};
+use crate::deriving::generic::*;
+use crate::deriving::generic::ty::*;
 
 use syntax::ast::{self, BinOpKind, Expr, MetaItem};
 use syntax::ext::base::{Annotatable, ExtCtxt};
@@ -11,7 +11,7 @@ use syntax::ptr::P;
 use syntax::symbol::Symbol;
 use syntax_pos::Span;
 
-pub fn expand_deriving_partial_ord(cx: &mut ExtCtxt,
+pub fn expand_deriving_partial_ord(cx: &mut ExtCtxt<'_>,
                                    span: Span,
                                    mitem: &MetaItem,
                                    item: &Annotatable,
@@ -95,7 +95,7 @@ pub enum OrderingOp {
     GeOp,
 }
 
-pub fn some_ordering_collapsed(cx: &mut ExtCtxt,
+pub fn some_ordering_collapsed(cx: &mut ExtCtxt<'_>,
                                span: Span,
                                op: OrderingOp,
                                self_arg_tags: &[ast::Ident])
@@ -112,7 +112,7 @@ pub fn some_ordering_collapsed(cx: &mut ExtCtxt,
     cx.expr_method_call(span, lft, cx.ident_of(op_str), vec![rgt])
 }
 
-pub fn cs_partial_cmp(cx: &mut ExtCtxt, span: Span, substr: &Substructure) -> P<Expr> {
+pub fn cs_partial_cmp(cx: &mut ExtCtxt<'_>, span: Span, substr: &Substructure<'_>) -> P<Expr> {
     let test_id = cx.ident_of("cmp").gensym();
     let ordering = cx.path_global(span, cx.std_path(&["cmp", "Ordering", "Equal"]));
     let ordering_expr = cx.expr_path(ordering.clone());
@@ -184,14 +184,14 @@ pub fn cs_partial_cmp(cx: &mut ExtCtxt, span: Span, substr: &Substructure) -> P<
 /// Strict inequality.
 fn cs_op(less: bool,
          inclusive: bool,
-         cx: &mut ExtCtxt,
+         cx: &mut ExtCtxt<'_>,
          span: Span,
-         substr: &Substructure) -> P<Expr> {
-    let ordering_path = |cx: &mut ExtCtxt, name: &str| {
+         substr: &Substructure<'_>) -> P<Expr> {
+    let ordering_path = |cx: &mut ExtCtxt<'_>, name: &str| {
         cx.expr_path(cx.path_global(span, cx.std_path(&["cmp", "Ordering", name])))
     };
 
-    let par_cmp = |cx: &mut ExtCtxt, span, self_f: P<Expr>, other_fs: &[P<Expr>], default| {
+    let par_cmp = |cx: &mut ExtCtxt<'_>, span, self_f: P<Expr>, other_fs: &[P<Expr>], default| {
         let other_f = match (other_fs.len(), other_fs.get(0)) {
             (1, Some(o_f)) => o_f,
             _ => cx.span_bug(span, "not exactly 2 arguments in `derive(PartialOrd)`"),

--- a/src/libsyntax_ext/deriving/debug.rs
+++ b/src/libsyntax_ext/deriving/debug.rs
@@ -1,6 +1,6 @@
-use deriving::path_std;
-use deriving::generic::*;
-use deriving::generic::ty::*;
+use crate::deriving::path_std;
+use crate::deriving::generic::*;
+use crate::deriving::generic::ty::*;
 
 use rustc_data_structures::thin_vec::ThinVec;
 
@@ -11,7 +11,7 @@ use syntax::ext::build::AstBuilder;
 use syntax::ptr::P;
 use syntax_pos::{DUMMY_SP, Span};
 
-pub fn expand_deriving_debug(cx: &mut ExtCtxt,
+pub fn expand_deriving_debug(cx: &mut ExtCtxt<'_>,
                              span: Span,
                              mitem: &MetaItem,
                              item: &Annotatable,
@@ -47,7 +47,7 @@ pub fn expand_deriving_debug(cx: &mut ExtCtxt,
 }
 
 /// We use the debug builders to do the heavy lifting here
-fn show_substructure(cx: &mut ExtCtxt, span: Span, substr: &Substructure) -> P<Expr> {
+fn show_substructure(cx: &mut ExtCtxt<'_>, span: Span, substr: &Substructure<'_>) -> P<Expr> {
     // build fmt.debug_struct(<name>).field(<fieldname>, &<fieldval>)....build()
     // or fmt.debug_tuple(<name>).field(&<fieldval>)....build()
     // based on the "shape".
@@ -124,7 +124,7 @@ fn show_substructure(cx: &mut ExtCtxt, span: Span, substr: &Substructure) -> P<E
     cx.expr_block(block)
 }
 
-fn stmt_let_undescore(cx: &mut ExtCtxt, sp: Span, expr: P<ast::Expr>) -> ast::Stmt {
+fn stmt_let_undescore(cx: &mut ExtCtxt<'_>, sp: Span, expr: P<ast::Expr>) -> ast::Stmt {
     let local = P(ast::Local {
         pat: cx.pat_wild(sp),
         ty: None,

--- a/src/libsyntax_ext/deriving/decodable.rs
+++ b/src/libsyntax_ext/deriving/decodable.rs
@@ -1,9 +1,9 @@
 //! The compiler code necessary for `#[derive(Decodable)]`. See encodable.rs for more.
 
-use deriving::{self, pathvec_std};
-use deriving::generic::*;
-use deriving::generic::ty::*;
-use deriving::warn_if_deprecated;
+use crate::deriving::{self, pathvec_std};
+use crate::deriving::generic::*;
+use crate::deriving::generic::ty::*;
+use crate::deriving::warn_if_deprecated;
 
 use syntax::ast;
 use syntax::ast::{Expr, MetaItem, Mutability};
@@ -13,7 +13,7 @@ use syntax::ptr::P;
 use syntax::symbol::Symbol;
 use syntax_pos::Span;
 
-pub fn expand_deriving_rustc_decodable(cx: &mut ExtCtxt,
+pub fn expand_deriving_rustc_decodable(cx: &mut ExtCtxt<'_>,
                                        span: Span,
                                        mitem: &MetaItem,
                                        item: &Annotatable,
@@ -21,7 +21,7 @@ pub fn expand_deriving_rustc_decodable(cx: &mut ExtCtxt,
     expand_deriving_decodable_imp(cx, span, mitem, item, push, "rustc_serialize")
 }
 
-pub fn expand_deriving_decodable(cx: &mut ExtCtxt,
+pub fn expand_deriving_decodable(cx: &mut ExtCtxt<'_>,
                                  span: Span,
                                  mitem: &MetaItem,
                                  item: &Annotatable,
@@ -30,7 +30,7 @@ pub fn expand_deriving_decodable(cx: &mut ExtCtxt,
     expand_deriving_decodable_imp(cx, span, mitem, item, push, "serialize")
 }
 
-fn expand_deriving_decodable_imp(cx: &mut ExtCtxt,
+fn expand_deriving_decodable_imp(cx: &mut ExtCtxt<'_>,
                                  span: Span,
                                  mitem: &MetaItem,
                                  item: &Annotatable,
@@ -79,9 +79,9 @@ fn expand_deriving_decodable_imp(cx: &mut ExtCtxt,
     trait_def.expand(cx, mitem, item, push)
 }
 
-fn decodable_substructure(cx: &mut ExtCtxt,
+fn decodable_substructure(cx: &mut ExtCtxt<'_>,
                           trait_span: Span,
-                          substr: &Substructure,
+                          substr: &Substructure<'_>,
                           krate: &str)
                           -> P<Expr> {
     let decoder = substr.nonself_args[0].clone();
@@ -168,13 +168,13 @@ fn decodable_substructure(cx: &mut ExtCtxt,
 /// Create a decoder for a single enum variant/struct:
 /// - `outer_pat_path` is the path to this enum variant/struct
 /// - `getarg` should retrieve the `usize`-th field with name `@str`.
-fn decode_static_fields<F>(cx: &mut ExtCtxt,
+fn decode_static_fields<F>(cx: &mut ExtCtxt<'_>,
                            trait_span: Span,
                            outer_pat_path: ast::Path,
                            fields: &StaticFields,
                            mut getarg: F)
                            -> P<Expr>
-    where F: FnMut(&mut ExtCtxt, Span, Symbol, usize) -> P<Expr>
+    where F: FnMut(&mut ExtCtxt<'_>, Span, Symbol, usize) -> P<Expr>
 {
     match *fields {
         Unnamed(ref fields, is_tuple) => {

--- a/src/libsyntax_ext/deriving/default.rs
+++ b/src/libsyntax_ext/deriving/default.rs
@@ -1,15 +1,16 @@
-use deriving::path_std;
-use deriving::generic::*;
-use deriving::generic::ty::*;
+use crate::deriving::path_std;
+use crate::deriving::generic::*;
+use crate::deriving::generic::ty::*;
 
 use syntax::ast::{Expr, MetaItem};
 use syntax::ext::base::{Annotatable, DummyResult, ExtCtxt};
 use syntax::ext::build::AstBuilder;
 use syntax::ptr::P;
 use syntax::symbol::Symbol;
+use syntax::span_err;
 use syntax_pos::Span;
 
-pub fn expand_deriving_default(cx: &mut ExtCtxt,
+pub fn expand_deriving_default(cx: &mut ExtCtxt<'_>,
                                span: Span,
                                mitem: &MetaItem,
                                item: &Annotatable,
@@ -42,7 +43,10 @@ pub fn expand_deriving_default(cx: &mut ExtCtxt,
     trait_def.expand(cx, mitem, item, push)
 }
 
-fn default_substructure(cx: &mut ExtCtxt, trait_span: Span, substr: &Substructure) -> P<Expr> {
+fn default_substructure(cx: &mut ExtCtxt<'_>,
+                        trait_span: Span,
+                        substr: &Substructure<'_>)
+                        -> P<Expr> {
     let default_ident = cx.std_path(&["default", "Default", "default"]);
     let default_call = |span| cx.expr_call_global(span, default_ident.clone(), Vec::new());
 

--- a/src/libsyntax_ext/deriving/encodable.rs
+++ b/src/libsyntax_ext/deriving/encodable.rs
@@ -82,10 +82,10 @@
 //! }
 //! ```
 
-use deriving::{self, pathvec_std};
-use deriving::generic::*;
-use deriving::generic::ty::*;
-use deriving::warn_if_deprecated;
+use crate::deriving::{self, pathvec_std};
+use crate::deriving::generic::*;
+use crate::deriving::generic::ty::*;
+use crate::deriving::warn_if_deprecated;
 
 use syntax::ast::{Expr, ExprKind, MetaItem, Mutability};
 use syntax::ext::base::{Annotatable, ExtCtxt};
@@ -94,7 +94,7 @@ use syntax::ptr::P;
 use syntax::symbol::Symbol;
 use syntax_pos::Span;
 
-pub fn expand_deriving_rustc_encodable(cx: &mut ExtCtxt,
+pub fn expand_deriving_rustc_encodable(cx: &mut ExtCtxt<'_>,
                                        span: Span,
                                        mitem: &MetaItem,
                                        item: &Annotatable,
@@ -102,7 +102,7 @@ pub fn expand_deriving_rustc_encodable(cx: &mut ExtCtxt,
     expand_deriving_encodable_imp(cx, span, mitem, item, push, "rustc_serialize")
 }
 
-pub fn expand_deriving_encodable(cx: &mut ExtCtxt,
+pub fn expand_deriving_encodable(cx: &mut ExtCtxt<'_>,
                                  span: Span,
                                  mitem: &MetaItem,
                                  item: &Annotatable,
@@ -111,7 +111,7 @@ pub fn expand_deriving_encodable(cx: &mut ExtCtxt,
     expand_deriving_encodable_imp(cx, span, mitem, item, push, "serialize")
 }
 
-fn expand_deriving_encodable_imp(cx: &mut ExtCtxt,
+fn expand_deriving_encodable_imp(cx: &mut ExtCtxt<'_>,
                                  span: Span,
                                  mitem: &MetaItem,
                                  item: &Annotatable,
@@ -162,9 +162,9 @@ fn expand_deriving_encodable_imp(cx: &mut ExtCtxt,
     trait_def.expand(cx, mitem, item, push)
 }
 
-fn encodable_substructure(cx: &mut ExtCtxt,
+fn encodable_substructure(cx: &mut ExtCtxt<'_>,
                           trait_span: Span,
-                          substr: &Substructure,
+                          substr: &Substructure<'_>,
                           krate: &'static str)
                           -> P<Expr> {
     let encoder = substr.nonself_args[0].clone();

--- a/src/libsyntax_ext/deriving/generic/ty.rs
+++ b/src/libsyntax_ext/deriving/generic/ty.rs
@@ -1,11 +1,10 @@
 //! A mini version of ast::Ty, which is easier to use, and features an explicit `Self` type to use
 //! when specifying impls to be derived.
 
-pub use self::PtrTy::*;
-pub use self::Ty::*;
+pub use PtrTy::*;
+pub use Ty::*;
 
-use syntax::ast;
-use syntax::ast::{Expr, GenericParamKind, Generics, Ident, SelfKind, GenericArg};
+use syntax::ast::{self, Expr, GenericParamKind, Generics, Ident, SelfKind, GenericArg};
 use syntax::ext::base::ExtCtxt;
 use syntax::ext::build::AstBuilder;
 use syntax::source_map::{respan, DUMMY_SP};
@@ -60,7 +59,7 @@ impl<'a> Path<'a> {
     }
 
     pub fn to_ty(&self,
-                 cx: &ExtCtxt,
+                 cx: &ExtCtxt<'_>,
                  span: Span,
                  self_ty: Ident,
                  self_generics: &Generics)
@@ -68,7 +67,7 @@ impl<'a> Path<'a> {
         cx.ty_path(self.to_path(cx, span, self_ty, self_generics))
     }
     pub fn to_path(&self,
-                   cx: &ExtCtxt,
+                   cx: &ExtCtxt<'_>,
                    span: Span,
                    self_ty: Ident,
                    self_generics: &Generics)
@@ -127,19 +126,19 @@ pub fn nil_ty<'r>() -> Ty<'r> {
     Tuple(Vec::new())
 }
 
-fn mk_lifetime(cx: &ExtCtxt, span: Span, lt: &Option<&str>) -> Option<ast::Lifetime> {
+fn mk_lifetime(cx: &ExtCtxt<'_>, span: Span, lt: &Option<&str>) -> Option<ast::Lifetime> {
     lt.map(|s|
         cx.lifetime(span, Ident::from_str(s))
     )
 }
 
-fn mk_lifetimes(cx: &ExtCtxt, span: Span, lt: &Option<&str>) -> Vec<ast::Lifetime> {
+fn mk_lifetimes(cx: &ExtCtxt<'_>, span: Span, lt: &Option<&str>) -> Vec<ast::Lifetime> {
     mk_lifetime(cx, span, lt).into_iter().collect()
 }
 
 impl<'a> Ty<'a> {
     pub fn to_ty(&self,
-                 cx: &ExtCtxt,
+                 cx: &ExtCtxt<'_>,
                  span: Span,
                  self_ty: Ident,
                  self_generics: &Generics)
@@ -167,7 +166,7 @@ impl<'a> Ty<'a> {
     }
 
     pub fn to_path(&self,
-                   cx: &ExtCtxt,
+                   cx: &ExtCtxt<'_>,
                    span: Span,
                    self_ty: Ident,
                    generics: &Generics)
@@ -193,11 +192,11 @@ impl<'a> Ty<'a> {
 }
 
 
-fn mk_ty_param(cx: &ExtCtxt,
+fn mk_ty_param(cx: &ExtCtxt<'_>,
                span: Span,
                name: &str,
                attrs: &[ast::Attribute],
-               bounds: &[Path],
+               bounds: &[Path<'_>],
                self_ident: Ident,
                self_generics: &Generics)
                -> ast::GenericParam {
@@ -237,7 +236,7 @@ impl<'a> LifetimeBounds<'a> {
         }
     }
     pub fn to_generics(&self,
-                       cx: &ExtCtxt,
+                       cx: &ExtCtxt<'_>,
                        span: Span,
                        self_ty: Ident,
                        self_generics: &Generics)
@@ -262,9 +261,9 @@ impl<'a> LifetimeBounds<'a> {
     }
 }
 
-pub fn get_explicit_self(cx: &ExtCtxt,
+pub fn get_explicit_self(cx: &ExtCtxt<'_>,
                          span: Span,
-                         self_ptr: &Option<PtrTy>)
+                         self_ptr: &Option<PtrTy<'_>>)
                          -> (P<Expr>, ast::ExplicitSelf) {
     // this constructs a fresh `self` path
     let self_path = cx.expr_self(span);

--- a/src/libsyntax_ext/deriving/hash.rs
+++ b/src/libsyntax_ext/deriving/hash.rs
@@ -1,6 +1,6 @@
-use deriving::{self, pathvec_std, path_std};
-use deriving::generic::*;
-use deriving::generic::ty::*;
+use crate::deriving::{self, pathvec_std, path_std};
+use crate::deriving::generic::*;
+use crate::deriving::generic::ty::*;
 
 use syntax::ast::{Expr, MetaItem, Mutability};
 use syntax::ext::base::{Annotatable, ExtCtxt};
@@ -8,7 +8,7 @@ use syntax::ext::build::AstBuilder;
 use syntax::ptr::P;
 use syntax_pos::Span;
 
-pub fn expand_deriving_hash(cx: &mut ExtCtxt,
+pub fn expand_deriving_hash(cx: &mut ExtCtxt<'_>,
                             span: Span,
                             mitem: &MetaItem,
                             item: &Annotatable,
@@ -50,7 +50,7 @@ pub fn expand_deriving_hash(cx: &mut ExtCtxt,
     hash_trait_def.expand(cx, mitem, item, push);
 }
 
-fn hash_substructure(cx: &mut ExtCtxt, trait_span: Span, substr: &Substructure) -> P<Expr> {
+fn hash_substructure(cx: &mut ExtCtxt<'_>, trait_span: Span, substr: &Substructure<'_>) -> P<Expr> {
     let state_expr = match (substr.nonself_args.len(), substr.nonself_args.get(0)) {
         (1, Some(o_f)) => o_f,
         _ => {

--- a/src/libsyntax_ext/deriving/mod.rs
+++ b/src/libsyntax_ext/deriving/mod.rs
@@ -90,7 +90,7 @@ derive_traits! {
 }
 
 #[inline] // because `name` is a compile-time constant
-fn warn_if_deprecated(ecx: &mut ExtCtxt, sp: Span, name: &str) {
+fn warn_if_deprecated(ecx: &mut ExtCtxt<'_>, sp: Span, name: &str) {
     if let Some(replacement) = match name {
         "Encodable" => Some("RustcEncodable"),
         "Decodable" => Some("RustcDecodable"),
@@ -131,7 +131,7 @@ fn hygienic_type_parameter(item: &Annotatable, base: &str) -> String {
 }
 
 /// Constructs an expression that calls an intrinsic
-fn call_intrinsic(cx: &ExtCtxt,
+fn call_intrinsic(cx: &ExtCtxt<'_>,
                   mut span: Span,
                   intrinsic: &str,
                   args: Vec<P<ast::Expr>>)

--- a/src/libsyntax_ext/diagnostics.rs
+++ b/src/libsyntax_ext/diagnostics.rs
@@ -1,5 +1,7 @@
 #![allow(non_snake_case)]
 
+use syntax::{register_diagnostic, register_long_diagnostics};
+
 // Error messages for EXXXX errors.
 // Each message should start and end with a new line, and be wrapped to 80 characters.
 // In vim you can `:set tw=80` and use `gq` to wrap paragraphs. Use `:set tw=0` to disable.

--- a/src/libsyntax_ext/env.rs
+++ b/src/libsyntax_ext/env.rs
@@ -4,8 +4,7 @@
 //
 
 use syntax::ast::{self, Ident, GenericArg};
-use syntax::ext::base::*;
-use syntax::ext::base;
+use syntax::ext::base::{self, *};
 use syntax::ext::build::AstBuilder;
 use syntax::symbol::{keywords, Symbol};
 use syntax_pos::Span;
@@ -13,7 +12,7 @@ use syntax::tokenstream;
 
 use std::env;
 
-pub fn expand_option_env<'cx>(cx: &'cx mut ExtCtxt,
+pub fn expand_option_env<'cx>(cx: &'cx mut ExtCtxt<'_>,
                               sp: Span,
                               tts: &[tokenstream::TokenTree])
                               -> Box<dyn base::MacResult + 'cx> {
@@ -44,7 +43,7 @@ pub fn expand_option_env<'cx>(cx: &'cx mut ExtCtxt,
     MacEager::expr(e)
 }
 
-pub fn expand_env<'cx>(cx: &'cx mut ExtCtxt,
+pub fn expand_env<'cx>(cx: &'cx mut ExtCtxt<'_>,
                        sp: Span,
                        tts: &[tokenstream::TokenTree])
                        -> Box<dyn base::MacResult + 'cx> {

--- a/src/libsyntax_ext/format.rs
+++ b/src/libsyntax_ext/format.rs
@@ -1,9 +1,11 @@
-use self::ArgumentType::*;
-use self::Position::*;
+use ArgumentType::*;
+use Position::*;
 
 use fmt_macros as parse;
 
-use errors::DiagnosticBuilder;
+use crate::errors::DiagnosticBuilder;
+use crate::errors::Applicability;
+
 use syntax::ast;
 use syntax::ext::base::{self, *};
 use syntax::ext::build::AstBuilder;
@@ -13,7 +15,6 @@ use syntax::ptr::P;
 use syntax::symbol::Symbol;
 use syntax::tokenstream;
 use syntax_pos::{MultiSpan, Span, DUMMY_SP};
-use errors::Applicability;
 
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use std::borrow::Cow;
@@ -184,7 +185,7 @@ fn parse_args<'a>(
 }
 
 impl<'a, 'b> Context<'a, 'b> {
-    fn resolve_name_inplace(&self, p: &mut parse::Piece) {
+    fn resolve_name_inplace(&self, p: &mut parse::Piece<'_>) {
         // NOTE: the `unwrap_or` branch is needed in case of invalid format
         // arguments, e.g., `format_args!("{foo}")`.
         let lookup = |s| *self.names.get(s).unwrap_or(&0);
@@ -208,7 +209,7 @@ impl<'a, 'b> Context<'a, 'b> {
     /// Verifies one piece of a parse string, and remembers it if valid.
     /// All errors are not emitted as fatal so we can continue giving errors
     /// about this and possibly other format strings.
-    fn verify_piece(&mut self, p: &parse::Piece) {
+    fn verify_piece(&mut self, p: &parse::Piece<'_>) {
         match *p {
             parse::String(..) => {}
             parse::NextArgument(ref arg) => {
@@ -231,7 +232,7 @@ impl<'a, 'b> Context<'a, 'b> {
         }
     }
 
-    fn verify_count(&mut self, c: parse::Count) {
+    fn verify_count(&mut self, c: parse::Count<'_>) {
         match c {
             parse::CountImplied |
             parse::CountIs(..) => {}
@@ -244,7 +245,7 @@ impl<'a, 'b> Context<'a, 'b> {
         }
     }
 
-    fn describe_num_args(&self) -> Cow<str> {
+    fn describe_num_args(&self) -> Cow<'_, str> {
         match self.args.len() {
             0 => "no arguments were given".into(),
             1 => "there is 1 argument".into(),
@@ -385,11 +386,11 @@ impl<'a, 'b> Context<'a, 'b> {
         self.count_args_index_offset = sofar;
     }
 
-    fn rtpath(ecx: &ExtCtxt, s: &str) -> Vec<ast::Ident> {
+    fn rtpath(ecx: &ExtCtxt<'_>, s: &str) -> Vec<ast::Ident> {
         ecx.std_path(&["fmt", "rt", "v1", s])
     }
 
-    fn build_count(&self, c: parse::Count) -> P<ast::Expr> {
+    fn build_count(&self, c: parse::Count<'_>) -> P<ast::Expr> {
         let sp = self.macsp;
         let count = |c, arg| {
             let mut path = Context::rtpath(self.ecx, "Count");
@@ -426,7 +427,7 @@ impl<'a, 'b> Context<'a, 'b> {
     /// Build a static `rt::Argument` from a `parse::Piece` or append
     /// to the `literal` string.
     fn build_piece(&mut self,
-                   piece: &parse::Piece,
+                   piece: &parse::Piece<'_>,
                    arg_index_consumed: &mut Vec<usize>)
                    -> Option<P<ast::Expr>> {
         let sp = self.macsp;
@@ -647,7 +648,7 @@ impl<'a, 'b> Context<'a, 'b> {
         self.ecx.expr_call_global(self.macsp, path, fn_args)
     }
 
-    fn format_arg(ecx: &ExtCtxt,
+    fn format_arg(ecx: &ExtCtxt<'_>,
                   macsp: Span,
                   mut sp: Span,
                   ty: &ArgumentType,
@@ -686,7 +687,7 @@ impl<'a, 'b> Context<'a, 'b> {
     }
 }
 
-pub fn expand_format_args<'cx>(ecx: &'cx mut ExtCtxt,
+pub fn expand_format_args<'cx>(ecx: &'cx mut ExtCtxt<'_>,
                                mut sp: Span,
                                tts: &[tokenstream::TokenTree])
                                -> Box<dyn base::MacResult + 'cx> {
@@ -703,7 +704,7 @@ pub fn expand_format_args<'cx>(ecx: &'cx mut ExtCtxt,
 }
 
 pub fn expand_format_args_nl<'cx>(
-    ecx: &'cx mut ExtCtxt,
+    ecx: &'cx mut ExtCtxt<'_>,
     mut sp: Span,
     tts: &[tokenstream::TokenTree],
 ) -> Box<dyn base::MacResult + 'cx> {
@@ -734,7 +735,7 @@ pub fn expand_format_args_nl<'cx>(
 
 /// Take the various parts of `format_args!(efmt, args..., name=names...)`
 /// and construct the appropriate formatting expression.
-pub fn expand_preparsed_format_args(ecx: &mut ExtCtxt,
+pub fn expand_preparsed_format_args(ecx: &mut ExtCtxt<'_>,
                                     sp: Span,
                                     efmt: P<ast::Expr>,
                                     args: Vec<P<ast::Expr>>,
@@ -952,7 +953,7 @@ pub fn expand_preparsed_format_args(ecx: &mut ExtCtxt,
         piece
     }).collect::<Vec<_>>();
 
-    let numbered_position_args = pieces.iter().any(|arg: &parse::Piece| {
+    let numbered_position_args = pieces.iter().any(|arg: &parse::Piece<'_>| {
         match *arg {
             parse::String(_) => false,
             parse::NextArgument(arg) => {

--- a/src/libsyntax_ext/format_foreign.rs
+++ b/src/libsyntax_ext/format_foreign.rs
@@ -68,7 +68,7 @@ pub mod printf {
         pub position: (usize, usize),
     }
 
-    impl<'a> Format<'a> {
+    impl Format<'_> {
         /// Translate this directive into an equivalent Rust formatting directive.
         ///
         /// Returns `None` in cases where the `printf` directive does not have an exact Rust
@@ -249,12 +249,12 @@ pub mod printf {
             }
         }
 
-        fn translate(&self, s: &mut String) -> ::std::fmt::Result {
+        fn translate(&self, s: &mut String) -> std::fmt::Result {
             use std::fmt::Write;
             match *self {
                 Num::Num(n) => write!(s, "{}", n),
                 Num::Arg(n) => {
-                    let n = n.checked_sub(1).ok_or(::std::fmt::Error)?;
+                    let n = n.checked_sub(1).ok_or(std::fmt::Error)?;
                     write!(s, "{}$", n)
                 },
                 Num::Next => write!(s, "*"),
@@ -263,7 +263,7 @@ pub mod printf {
     }
 
     /// Returns an iterator over all substitutions in a given string.
-    pub fn iter_subs(s: &str) -> Substitutions {
+    pub fn iter_subs(s: &str) -> Substitutions<'_> {
         Substitutions {
             s,
             pos: 0,
@@ -309,7 +309,7 @@ pub mod printf {
     }
 
     /// Parse the next substitution from the input string.
-    pub fn parse_next_substitution(s: &str) -> Option<(Substitution, &str)> {
+    pub fn parse_next_substitution(s: &str) -> Option<(Substitution<'_>, &str)> {
         use self::State::*;
 
         let at = {
@@ -389,7 +389,7 @@ pub mod printf {
         let mut precision: Option<Num> = None;
         let mut length: Option<&str> = None;
         let mut type_: &str = "";
-        let end: Cur;
+        let end: Cur<'_>;
 
         if let Start = state {
             match c {
@@ -575,7 +575,7 @@ pub mod printf {
         Some((Substitution::Format(f), end.slice_after()))
     }
 
-    fn at_next_cp_while<F>(mut cur: Cur, mut pred: F) -> Cur
+    fn at_next_cp_while<F>(mut cur: Cur<'_>, mut pred: F) -> Cur<'_>
     where F: FnMut(char) -> bool {
         loop {
             match cur.next_cp() {
@@ -769,7 +769,7 @@ pub mod shell {
         Escape((usize, usize)),
     }
 
-    impl<'a> Substitution<'a> {
+    impl Substitution<'_> {
         pub fn as_str(&self) -> String {
             match self {
                 Substitution::Ordinal(n, _) => format!("${}", n),
@@ -804,7 +804,7 @@ pub mod shell {
     }
 
     /// Returns an iterator over all substitutions in a given string.
-    pub fn iter_subs(s: &str) -> Substitutions {
+    pub fn iter_subs(s: &str) -> Substitutions<'_> {
         Substitutions {
             s,
             pos: 0,
@@ -839,7 +839,7 @@ pub mod shell {
     }
 
     /// Parse the next substitution from the input string.
-    pub fn parse_next_substitution(s: &str) -> Option<(Substitution, &str)> {
+    pub fn parse_next_substitution(s: &str) -> Option<(Substitution<'_>, &str)> {
         let at = {
             let start = s.find('$')?;
             match s[start+1..].chars().next()? {
@@ -868,7 +868,7 @@ pub mod shell {
         }
     }
 
-    fn at_next_cp_while<F>(mut cur: Cur, mut pred: F) -> Cur
+    fn at_next_cp_while<F>(mut cur: Cur<'_>, mut pred: F) -> Cur<'_>
     where F: FnMut(char) -> bool {
         loop {
             match cur.next_cp() {
@@ -962,8 +962,6 @@ pub mod shell {
 }
 
 mod strcursor {
-    use std;
-
     pub struct StrCursor<'a> {
         s: &'a str,
         pub at: usize,
@@ -1028,7 +1026,7 @@ mod strcursor {
         }
     }
 
-    impl<'a> Copy for StrCursor<'a> {}
+    impl Copy for StrCursor<'_> {}
 
     impl<'a> Clone for StrCursor<'a> {
         fn clone(&self) -> StrCursor<'a> {
@@ -1036,8 +1034,8 @@ mod strcursor {
         }
     }
 
-    impl<'a> std::fmt::Debug for StrCursor<'a> {
-        fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+    impl std::fmt::Debug for StrCursor<'_> {
+        fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             write!(fmt, "StrCursor({:?} | {:?})", self.slice_before(), self.slice_after())
         }
     }

--- a/src/libsyntax_ext/global_asm.rs
+++ b/src/libsyntax_ext/global_asm.rs
@@ -8,21 +8,22 @@
 /// LLVM's `module asm "some assembly here"`. All of LLVM's caveats
 /// therefore apply.
 
-use errors::DiagnosticBuilder;
+use crate::errors::DiagnosticBuilder;
+
 use syntax::ast;
 use syntax::source_map::respan;
-use syntax::ext::base;
-use syntax::ext::base::*;
+use syntax::ext::base::{self, *};
 use syntax::feature_gate;
 use syntax::parse::token;
 use syntax::ptr::P;
 use syntax::symbol::Symbol;
 use syntax_pos::Span;
 use syntax::tokenstream;
+use smallvec::smallvec;
 
 pub const MACRO: &str = "global_asm";
 
-pub fn expand_global_asm<'cx>(cx: &'cx mut ExtCtxt,
+pub fn expand_global_asm<'cx>(cx: &'cx mut ExtCtxt<'_>,
                               sp: Span,
                               tts: &[tokenstream::TokenTree]) -> Box<dyn base::MacResult + 'cx> {
     if !cx.ecfg.enable_global_asm() {

--- a/src/libsyntax_ext/lib.rs
+++ b/src/libsyntax_ext/lib.rs
@@ -4,29 +4,21 @@
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
        html_root_url = "https://doc.rust-lang.org/nightly/")]
 
+#![deny(rust_2018_idioms)]
+
 #![feature(in_band_lifetimes)]
 #![feature(proc_macro_diagnostic)]
 #![feature(proc_macro_internals)]
 #![feature(proc_macro_span)]
 #![feature(decl_macro)]
-#![feature(nll)]
 #![feature(str_escape)]
 #![feature(rustc_diagnostic_macros)]
 
 #![recursion_limit="256"]
 
-extern crate fmt_macros;
-#[macro_use]
-extern crate syntax;
-extern crate syntax_pos;
 extern crate proc_macro;
-extern crate rustc_data_structures;
-extern crate rustc_errors as errors;
-extern crate rustc_target;
-#[macro_use]
-extern crate smallvec;
-#[macro_use]
-extern crate log;
+
+use rustc_errors as errors;
 
 mod diagnostics;
 

--- a/src/libsyntax_ext/log_syntax.rs
+++ b/src/libsyntax_ext/log_syntax.rs
@@ -4,7 +4,7 @@ use syntax::print;
 use syntax::tokenstream;
 use syntax_pos;
 
-pub fn expand_syntax_ext<'cx>(cx: &'cx mut base::ExtCtxt,
+pub fn expand_syntax_ext<'cx>(cx: &'cx mut base::ExtCtxt<'_>,
                               sp: syntax_pos::Span,
                               tts: &[tokenstream::TokenTree])
                               -> Box<dyn base::MacResult + 'cx> {

--- a/src/libsyntax_ext/proc_macro_decls.rs
+++ b/src/libsyntax_ext/proc_macro_decls.rs
@@ -1,6 +1,7 @@
 use std::mem;
 
-use errors;
+use crate::deriving;
+use crate::errors;
 
 use syntax::ast::{self, Ident};
 use syntax::attr;
@@ -17,8 +18,6 @@ use syntax::symbol::keywords;
 use syntax::visit::{self, Visitor};
 
 use syntax_pos::{Span, DUMMY_SP};
-
-use deriving;
 
 const PROC_MACRO_KINDS: [&str; 3] = ["proc_macro_derive", "proc_macro_attribute", "proc_macro"];
 
@@ -324,7 +323,7 @@ impl<'a> Visitor<'a> for CollectProcMacros<'a> {
 //          ];
 //      }
 fn mk_decls(
-    cx: &mut ExtCtxt,
+    cx: &mut ExtCtxt<'_>,
     custom_derives: &[ProcMacroDerive],
     custom_attrs: &[ProcMacroDef],
     custom_macros: &[ProcMacroDef],

--- a/src/libsyntax_ext/proc_macro_impl.rs
+++ b/src/libsyntax_ext/proc_macro_impl.rs
@@ -1,27 +1,27 @@
-use errors::FatalError;
+use crate::errors::FatalError;
+use crate::proc_macro_server;
 
 use syntax::source_map::Span;
-use syntax::ext::base::*;
+use syntax::ext::base::{self, *};
 use syntax::tokenstream::TokenStream;
-use syntax::ext::base;
 
-pub const EXEC_STRATEGY: ::proc_macro::bridge::server::SameThread =
-    ::proc_macro::bridge::server::SameThread;
+pub const EXEC_STRATEGY: proc_macro::bridge::server::SameThread =
+    proc_macro::bridge::server::SameThread;
 
 pub struct AttrProcMacro {
-    pub client: ::proc_macro::bridge::client::Client<
-        fn(::proc_macro::TokenStream, ::proc_macro::TokenStream) -> ::proc_macro::TokenStream,
+    pub client: proc_macro::bridge::client::Client<
+        fn(proc_macro::TokenStream, proc_macro::TokenStream) -> proc_macro::TokenStream,
     >,
 }
 
 impl base::AttrProcMacro for AttrProcMacro {
     fn expand<'cx>(&self,
-                   ecx: &'cx mut ExtCtxt,
+                   ecx: &'cx mut ExtCtxt<'_>,
                    span: Span,
                    annotation: TokenStream,
                    annotated: TokenStream)
                    -> TokenStream {
-        let server = ::proc_macro_server::Rustc::new(ecx);
+        let server = proc_macro_server::Rustc::new(ecx);
         match self.client.run(&EXEC_STRATEGY, server, annotation, annotated) {
             Ok(stream) => stream,
             Err(e) => {
@@ -39,18 +39,18 @@ impl base::AttrProcMacro for AttrProcMacro {
 }
 
 pub struct BangProcMacro {
-    pub client: ::proc_macro::bridge::client::Client<
-        fn(::proc_macro::TokenStream) -> ::proc_macro::TokenStream,
+    pub client: proc_macro::bridge::client::Client<
+        fn(proc_macro::TokenStream) -> proc_macro::TokenStream,
     >,
 }
 
 impl base::ProcMacro for BangProcMacro {
     fn expand<'cx>(&self,
-                   ecx: &'cx mut ExtCtxt,
+                   ecx: &'cx mut ExtCtxt<'_>,
                    span: Span,
                    input: TokenStream)
                    -> TokenStream {
-        let server = ::proc_macro_server::Rustc::new(ecx);
+        let server = proc_macro_server::Rustc::new(ecx);
         match self.client.run(&EXEC_STRATEGY, server, input) {
             Ok(stream) => stream,
             Err(e) => {

--- a/src/libsyntax_ext/proc_macro_server.rs
+++ b/src/libsyntax_ext/proc_macro_server.rs
@@ -1,4 +1,5 @@
-use errors::{self, Diagnostic, DiagnosticBuilder};
+use crate::errors::{self, Diagnostic, DiagnosticBuilder};
+
 use std::panic;
 
 use proc_macro::bridge::{server, TokenTree};
@@ -369,7 +370,7 @@ pub(crate) struct Rustc<'a> {
 }
 
 impl<'a> Rustc<'a> {
-    pub fn new(cx: &'a ExtCtxt) -> Self {
+    pub fn new(cx: &'a ExtCtxt<'_>) -> Self {
         // No way to determine def location for a proc macro right now, so use call location.
         let location = cx.current_expansion.mark.expn_info().unwrap().call_site;
         let to_span = |transparency| {
@@ -650,7 +651,7 @@ impl server::Literal for Rustc<'_> {
     }
 }
 
-impl<'a> server::SourceFile for Rustc<'a> {
+impl server::SourceFile for Rustc<'_> {
     fn eq(&mut self, file1: &Self::SourceFile, file2: &Self::SourceFile) -> bool {
         Lrc::ptr_eq(file1, file2)
     }

--- a/src/libsyntax_ext/test.rs
+++ b/src/libsyntax_ext/test.rs
@@ -13,7 +13,7 @@ use syntax::source_map::{ExpnInfo, MacroAttribute};
 use std::iter;
 
 pub fn expand_test(
-    cx: &mut ExtCtxt,
+    cx: &mut ExtCtxt<'_>,
     attr_sp: Span,
     _meta_item: &ast::MetaItem,
     item: Annotatable,
@@ -22,7 +22,7 @@ pub fn expand_test(
 }
 
 pub fn expand_bench(
-    cx: &mut ExtCtxt,
+    cx: &mut ExtCtxt<'_>,
     attr_sp: Span,
     _meta_item: &ast::MetaItem,
     item: Annotatable,
@@ -31,7 +31,7 @@ pub fn expand_bench(
 }
 
 pub fn expand_test_or_bench(
-    cx: &mut ExtCtxt,
+    cx: &mut ExtCtxt<'_>,
     attr_sp: Span,
     item: Annotatable,
     is_bench: bool
@@ -180,7 +180,7 @@ pub fn expand_test_or_bench(
         ast::ItemKind::ExternCrate(Some(Symbol::intern("test")))
     );
 
-    debug!("Synthetic test item:\n{}\n", pprust::item_to_string(&test_const));
+    log::debug!("Synthetic test item:\n{}\n", pprust::item_to_string(&test_const));
 
     vec![
         // Access to libtest under a gensymed name
@@ -210,7 +210,7 @@ fn should_fail(i: &ast::Item) -> bool {
     attr::contains_name(&i.attrs, "allow_fail")
 }
 
-fn should_panic(cx: &ExtCtxt, i: &ast::Item) -> ShouldPanic {
+fn should_panic(cx: &ExtCtxt<'_>, i: &ast::Item) -> ShouldPanic {
     match attr::find_by_name(&i.attrs, "should_panic") {
         Some(attr) => {
             let ref sd = cx.parse_sess.span_diagnostic;
@@ -243,7 +243,7 @@ fn should_panic(cx: &ExtCtxt, i: &ast::Item) -> ShouldPanic {
     }
 }
 
-fn has_test_signature(cx: &ExtCtxt, i: &ast::Item) -> bool {
+fn has_test_signature(cx: &ExtCtxt<'_>, i: &ast::Item) -> bool {
     let has_should_panic_attr = attr::contains_name(&i.attrs, "should_panic");
     let ref sd = cx.parse_sess.span_diagnostic;
     if let ast::ItemKind::Fn(ref decl, ref header, ref generics, _) = i.node {
@@ -296,7 +296,7 @@ fn has_test_signature(cx: &ExtCtxt, i: &ast::Item) -> bool {
     }
 }
 
-fn has_bench_signature(cx: &ExtCtxt, i: &ast::Item) -> bool {
+fn has_bench_signature(cx: &ExtCtxt<'_>, i: &ast::Item) -> bool {
     let has_sig = if let ast::ItemKind::Fn(ref decl, _, _, _) = i.node {
         // N.B., inadequate check, but we're running
         // well before resolve, can't get too deep.

--- a/src/libsyntax_ext/test_case.rs
+++ b/src/libsyntax_ext/test_case.rs
@@ -20,7 +20,7 @@ use syntax::source_map::{ExpnInfo, MacroAttribute};
 use syntax::feature_gate;
 
 pub fn expand(
-    ecx: &mut ExtCtxt,
+    ecx: &mut ExtCtxt<'_>,
     attr_sp: Span,
     _meta_item: &ast::MetaItem,
     anno_item: Annotatable

--- a/src/libsyntax_ext/trace_macros.rs
+++ b/src/libsyntax_ext/trace_macros.rs
@@ -1,11 +1,10 @@
-use syntax::ext::base::ExtCtxt;
-use syntax::ext::base;
+use syntax::ext::base::{self, ExtCtxt};
 use syntax::feature_gate;
 use syntax::symbol::keywords;
 use syntax_pos::Span;
 use syntax::tokenstream::TokenTree;
 
-pub fn expand_trace_macros(cx: &mut ExtCtxt,
+pub fn expand_trace_macros(cx: &mut ExtCtxt<'_>,
                            sp: Span,
                            tt: &[TokenTree])
                            -> Box<dyn base::MacResult + 'static> {


### PR DESCRIPTION
Transitions `libsyntax_ext` to Rust 2018; cc #58099

r? @Centril