### PR TITLE
Remove stray FIXME

### DIFF
--- a/src/libstd/sys/sgx/rwlock.rs
+++ b/src/libstd/sys/sgx/rwlock.rs
@@ -19,9 +19,6 @@ unsafe fn rw_lock_size_assert(r: RWLock) {
     mem::transmute::<RWLock, [u8; 128]>(r);
 }
 
-//unsafe impl Send for RWLock {}
-//unsafe impl Sync for RWLock {} // FIXME
-
 impl RWLock {
     pub const fn new() -> RWLock {
         RWLock {


### PR DESCRIPTION
These were copied from the WebAssembly implementation, and later commented. There is nothing to be fixed, RWLock is Send/Sync because all member fields are Send/Sync.

r? @joshtriplett 