### PR TITLE
Lower constant patterns with ascribed types.

### DIFF
--- a/src/test/ui/nll/issue-57960.rs
+++ b/src/test/ui/nll/issue-57960.rs
@@ -1,0 +1,39 @@
+// run-pass
+
+#![allow(dead_code)]
+
+trait Range {
+    const FIRST: u8;
+    const LAST: u8;
+}
+
+struct OneDigit;
+impl Range for OneDigit {
+    const FIRST: u8 = 0;
+    const LAST: u8 = 9;
+}
+
+struct TwoDigits;
+impl Range for TwoDigits {
+    const FIRST: u8 = 10;
+    const LAST: u8 = 99;
+}
+
+struct ThreeDigits;
+impl Range for ThreeDigits {
+    const FIRST: u8 = 100;
+    const LAST: u8 = 255;
+}
+
+fn digits(x: u8) -> u32 {
+    match x {
+        OneDigit::FIRST...OneDigit::LAST => 1,
+        TwoDigits::FIRST...TwoDigits::LAST => 2,
+        ThreeDigits::FIRST...ThreeDigits::LAST => 3,
+        _ => unreachable!(),
+    }
+}
+
+fn main() {
+    assert_eq!(digits(100), 3);
+}


### PR DESCRIPTION
Fixes #57960.

This PR fixes a bug introduced by #55937 which started checking user
type annotations for associated type patterns. Where lowering a
associated constant expression would previously return a
`PatternKind::Constant`, it now returns a `PatternKind::AscribeUserType`
with a `PatternKind::Constant` inside, this PR unwraps that to
access the constant pattern inside and behaves as before.

r? @pnkfelix 