### PR TITLE
Change privacy checks, particularly for tuple structs

### DIFF
--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -2242,13 +2242,20 @@ impl<'a, 'gcx, 'tcx> AdtDef {
             .0
     }
 
-    pub fn variant_of_def(&self, def: Def) -> &VariantDef {
+    pub fn opt_variant_of_def(&self, def: Def) -> Option<&VariantDef> {
         match def {
-            Def::Variant(vid) | Def::VariantCtor(vid, ..) => self.variant_with_id(vid),
+            Def::Variant(vid) | Def::VariantCtor(vid, ..) => Some(self.variant_with_id(vid)),
             Def::Struct(..) | Def::StructCtor(..) | Def::Union(..) |
             Def::TyAlias(..) | Def::AssociatedTy(..) | Def::SelfTy(..) |
-            Def::SelfCtor(..) => self.non_enum_variant(),
-            _ => bug!("unexpected def {:?} in variant_of_def", def)
+            Def::SelfCtor(..) => Some(self.non_enum_variant()),
+            _ => None,
+        }
+    }
+
+    pub fn variant_of_def(&self, def: Def) -> &VariantDef {
+        match self.opt_variant_of_def(def) {
+            Some(vd) => vd,
+            None => bug!("unexpected def {:?} in variant_of_def", def),
         }
     }
 

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -268,9 +268,11 @@ impl<'a> Resolver<'a> {
                         }
                     }
 
-                    if !self.is_accessible(binding.vis) &&
+                    let is_accessible = self.is_accessible(binding.vis);
+                    if !is_accessible &&
                        // Remove this together with `PUB_USE_OF_PRIVATE_EXTERN_CRATE`
-                       !(self.last_import_segment && binding.is_extern_crate()) {
+                       !(self.last_import_segment && binding.is_extern_crate())
+                    {
                         self.privacy_errors.push(PrivacyError(path_span, ident, binding));
                     }
 

--- a/src/test/ui/error-codes/E0451.stderr
+++ b/src/test/ui/error-codes/E0451.stderr
@@ -1,14 +1,32 @@
 error[E0451]: field `b` of struct `Bar::Foo` is private
   --> $DIR/E0451.rs:14:23
    |
-LL |     let Bar::Foo{a:a, b:b} = foo; //~ ERROR E0451
-   |                       ^^^ field `b` is private
+LL | /     pub struct Foo {
+LL | |         pub a: isize,
+LL | |         b: isize,
+LL | |     }
+   | |_____- `Bar::Foo` defined here
+...
+LL |       let Bar::Foo{a:a, b:b} = foo; //~ ERROR E0451
+   |           --------------^^^-
+   |           |             |
+   |           |             private field
+   |           `Bar::Foo` cannot be destructured due to private field
 
 error[E0451]: field `b` of struct `Bar::Foo` is private
   --> $DIR/E0451.rs:18:29
    |
-LL |     let f = Bar::Foo{ a: 0, b: 0 }; //~ ERROR E0451
-   |                             ^^^^ field `b` is private
+LL | /     pub struct Foo {
+LL | |         pub a: isize,
+LL | |         b: isize,
+LL | |     }
+   | |_____- `Bar::Foo` defined here
+...
+LL |       let f = Bar::Foo{ a: 0, b: 0 }; //~ ERROR E0451
+   |               ----------------^^^^--
+   |               |               |
+   |               |               private field
+   |               `Bar::Foo` cannot be built due to private field
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/functional-struct-update/functional-struct-update-respects-privacy.stderr
+++ b/src/test/ui/functional-struct-update/functional-struct-update-respects-privacy.stderr
@@ -1,8 +1,14 @@
 error[E0451]: field `secret_uid` of struct `foo::S` is private
   --> $DIR/functional-struct-update-respects-privacy.rs:28:49
    |
+LL |     pub struct S { pub a: u8, pub b: String, secret_uid: u64 }
+   |     ---------------------------------------------------------- `foo::S` defined here
+...
 LL |     let s_2 = foo::S { b: format!("ess two"), ..s_1 }; // FRU ...
-   |                                                 ^^^ field `secret_uid` is private
+   |               ----------------------------------^^^--
+   |               |                                 |
+   |               |                                 private field
+   |               `foo::S` cannot be built due to private field
 
 error: aborting due to previous error
 

--- a/src/test/ui/hygiene/fields.rs
+++ b/src/test/ui/hygiene/fields.rs
@@ -12,11 +12,15 @@ mod foo {
             x: i32,
         }
 
-        let s = S { x: 0 }; //~ ERROR type `foo::S` is private
-        let _ = s.x; //~ ERROR type `foo::S` is private
+        let s = S { x: 0 };
+        //~^ ERROR struct `foo::S` is private
+        let _ = s.x;
+        //~^ ERROR struct `foo::S` is private
 
-        let t = T(0); //~ ERROR type `foo::T` is private
-        let _ = t.0; //~ ERROR type `foo::T` is private
+        let t = T(0);
+        //~^ ERROR struct `foo::T` is private
+        let _ = t.0;
+        //~^ ERROR struct `foo::T` is private
 
         let s = $S { $x: 0, x: 1 };
         assert_eq!((s.$x, s.x), (0, 1));

--- a/src/test/ui/hygiene/fields.stderr
+++ b/src/test/ui/hygiene/fields.stderr
@@ -1,35 +1,35 @@
-error: type `foo::S` is private
+error: struct `foo::S` is private
   --> $DIR/fields.rs:15:17
    |
-LL |         let s = S { x: 0 }; //~ ERROR type `foo::S` is private
-   |                 ^^^^^^^^^^
+LL |         let s = S { x: 0 };
+   |                 ^^^^^^^^^^ private
 ...
 LL |     let s = foo::m!(S, x);
    |             ------------- in this macro invocation
 
-error: type `foo::S` is private
-  --> $DIR/fields.rs:16:17
+error: struct `foo::S` is private
+  --> $DIR/fields.rs:17:17
    |
-LL |         let _ = s.x; //~ ERROR type `foo::S` is private
-   |                 ^
+LL |         let _ = s.x;
+   |                 ^ private
 ...
 LL |     let s = foo::m!(S, x);
    |             ------------- in this macro invocation
 
-error: type `foo::T` is private
-  --> $DIR/fields.rs:18:17
+error: struct `foo::T` is private
+  --> $DIR/fields.rs:20:17
    |
-LL |         let t = T(0); //~ ERROR type `foo::T` is private
-   |                 ^^^^
+LL |         let t = T(0);
+   |                 ^^^^ private
 ...
 LL |     let s = foo::m!(S, x);
    |             ------------- in this macro invocation
 
-error: type `foo::T` is private
-  --> $DIR/fields.rs:19:17
+error: struct `foo::T` is private
+  --> $DIR/fields.rs:22:17
    |
-LL |         let _ = t.0; //~ ERROR type `foo::T` is private
-   |                 ^
+LL |         let _ = t.0;
+   |                 ^ private
 ...
 LL |     let s = foo::m!(S, x);
    |             ------------- in this macro invocation

--- a/src/test/ui/hygiene/impl_items.rs
+++ b/src/test/ui/hygiene/impl_items.rs
@@ -9,7 +9,8 @@ mod foo {
     }
 
     pub macro m() {
-        let _: () = S.f(); //~ ERROR type `for<'r> fn(&'r foo::S) {foo::S::f}` is private
+        let _: () = S.f();
+        //~^ ERROR method `foo::S::f` is private
     }
 }
 

--- a/src/test/ui/hygiene/impl_items.stderr
+++ b/src/test/ui/hygiene/impl_items.stderr
@@ -1,8 +1,8 @@
-error: type `for<'r> fn(&'r foo::S) {foo::S::f}` is private
+error: method `foo::S::f` is private
   --> $DIR/impl_items.rs:12:23
    |
-LL |         let _: () = S.f(); //~ ERROR type `for<'r> fn(&'r foo::S) {foo::S::f}` is private
-   |                       ^
+LL |         let _: () = S.f();
+   |                       ^ private
 ...
 LL |     foo::m!();
    |     ---------- in this macro invocation

--- a/src/test/ui/hygiene/intercrate.rs
+++ b/src/test/ui/hygiene/intercrate.rs
@@ -8,5 +8,5 @@ extern crate intercrate;
 
 fn main() {
     assert_eq!(intercrate::foo::m!(), 1);
-    //~^ ERROR type `fn() -> u32 {intercrate::foo::bar::f}` is private
+    //~^ ERROR function `intercrate::foo::bar::f` is private
 }

--- a/src/test/ui/hygiene/intercrate.stderr
+++ b/src/test/ui/hygiene/intercrate.stderr
@@ -1,8 +1,8 @@
-error: type `fn() -> u32 {intercrate::foo::bar::f}` is private
+error: function `intercrate::foo::bar::f` is private
   --> $DIR/intercrate.rs:10:16
    |
 LL |     assert_eq!(intercrate::foo::m!(), 1);
-   |                ^^^^^^^^^^^^^^^^^^^^^
+   |                ^^^^^^^^^^^^^^^^^^^^^ private
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 

--- a/src/test/ui/privacy/associated-item-privacy-inherent.rs
+++ b/src/test/ui/privacy/associated-item-privacy-inherent.rs
@@ -11,11 +11,11 @@ mod priv_nominal {
 
     pub macro mac() {
         let value = Pub::method;
-        //~^ ERROR type `for<'r> fn(&'r priv_nominal::Pub) {priv_nominal::Pub::method}` is private
+        //~^ ERROR method `priv_nominal::Pub::method` is private
         value;
-        //~^ ERROR type `for<'r> fn(&'r priv_nominal::Pub) {priv_nominal::Pub::method}` is private
+        //~^ ERROR method `priv_nominal::Pub::method` is private
         Pub.method();
-        //~^ ERROR type `for<'r> fn(&'r priv_nominal::Pub) {priv_nominal::Pub::method}` is private
+        //~^ ERROR method `priv_nominal::Pub::method` is private
         Pub::CONST;
         //~^ ERROR associated constant `CONST` is private
         // let _: Pub::AssocTy;
@@ -35,11 +35,11 @@ mod priv_signature {
 
     pub macro mac() {
         let value = Pub::method;
-        //~^ ERROR type `priv_signature::Priv` is private
+        //~^ ERROR struct `priv_signature::Priv` is private
         value;
-        //~^ ERROR type `priv_signature::Priv` is private
+        //~^ ERROR struct `priv_signature::Priv` is private
         Pub.method(loop {});
-        //~^ ERROR type `priv_signature::Priv` is private
+        //~^ ERROR struct `priv_signature::Priv` is private
     }
 }
 fn priv_signature() {
@@ -55,11 +55,11 @@ mod priv_substs {
 
     pub macro mac() {
         let value = Pub::method::<Priv>;
-        //~^ ERROR type `priv_substs::Priv` is private
+        //~^ ERROR struct `priv_substs::Priv` is private
         value;
-        //~^ ERROR type `priv_substs::Priv` is private
+        //~^ ERROR struct `priv_substs::Priv` is private
         Pub.method::<Priv>();
-        //~^ ERROR type `priv_substs::Priv` is private
+        //~^ ERROR struct `priv_substs::Priv` is private
     }
 }
 fn priv_substs() {
@@ -78,28 +78,28 @@ mod priv_parent_substs {
 
     pub macro mac() {
         let value = <Pub>::method;
-        //~^ ERROR type `priv_parent_substs::Priv` is private
+        //~^ ERROR struct `priv_parent_substs::Priv` is private
         value;
-        //~^ ERROR type `priv_parent_substs::Priv` is private
+        //~^ ERROR struct `priv_parent_substs::Priv` is private
         let value = Pub::method;
-        //~^ ERROR type `priv_parent_substs::Priv` is private
+        //~^ ERROR struct `priv_parent_substs::Priv` is private
         value;
-        //~^ ERROR type `priv_parent_substs::Priv` is private
+        //~^ ERROR struct `priv_parent_substs::Priv` is private
         let value = <Pub>::static_method;
-        //~^ ERROR type `priv_parent_substs::Priv` is private
+        //~^ ERROR struct `priv_parent_substs::Priv` is private
         value;
-        //~^ ERROR type `priv_parent_substs::Priv` is private
+        //~^ ERROR struct `priv_parent_substs::Priv` is private
         let value = Pub::static_method;
-        //~^ ERROR type `priv_parent_substs::Priv` is private
+        //~^ ERROR struct `priv_parent_substs::Priv` is private
         value;
-        //~^ ERROR type `priv_parent_substs::Priv` is private
+        //~^ ERROR struct `priv_parent_substs::Priv` is private
         Pub(Priv).method();
-        //~^ ERROR type `priv_parent_substs::Priv` is private
+        //~^ ERROR struct `priv_parent_substs::Priv` is private
 
         <Pub>::CONST;
-        //~^ ERROR type `priv_parent_substs::Priv` is private
+        //~^ ERROR struct `priv_parent_substs::Priv` is private
         Pub::CONST;
-        //~^ ERROR type `priv_parent_substs::Priv` is private
+        //~^ ERROR struct `priv_parent_substs::Priv` is private
 
         // let _: Pub::AssocTy;
         // pub type InSignatureTy = Pub::AssocTy;

--- a/src/test/ui/privacy/associated-item-privacy-inherent.stderr
+++ b/src/test/ui/privacy/associated-item-privacy-inherent.stderr
@@ -1,26 +1,26 @@
-error: type `for<'r> fn(&'r priv_nominal::Pub) {priv_nominal::Pub::method}` is private
+error: method `priv_nominal::Pub::method` is private
   --> $DIR/associated-item-privacy-inherent.rs:13:21
    |
 LL |         let value = Pub::method;
-   |                     ^^^^^^^^^^^
+   |                     ^^^^^^^^^^^ private
 ...
 LL |     priv_nominal::mac!();
    |     --------------------- in this macro invocation
 
-error: type `for<'r> fn(&'r priv_nominal::Pub) {priv_nominal::Pub::method}` is private
+error: method `priv_nominal::Pub::method` is private
   --> $DIR/associated-item-privacy-inherent.rs:15:9
    |
 LL |         value;
-   |         ^^^^^
+   |         ^^^^^ private
 ...
 LL |     priv_nominal::mac!();
    |     --------------------- in this macro invocation
 
-error: type `for<'r> fn(&'r priv_nominal::Pub) {priv_nominal::Pub::method}` is private
+error: method `priv_nominal::Pub::method` is private
   --> $DIR/associated-item-privacy-inherent.rs:17:13
    |
 LL |         Pub.method();
-   |             ^^^^^^
+   |             ^^^^^^ private
 ...
 LL |     priv_nominal::mac!();
    |     --------------------- in this macro invocation
@@ -29,160 +29,160 @@ error: associated constant `CONST` is private
   --> $DIR/associated-item-privacy-inherent.rs:19:9
    |
 LL |         Pub::CONST;
-   |         ^^^^^^^^^^
+   |         ^^^^^^^^^^ associated constant not accessible from here
 ...
 LL |     priv_nominal::mac!();
    |     --------------------- in this macro invocation
 
-error: type `priv_signature::Priv` is private
+error: struct `priv_signature::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:37:21
    |
 LL |         let value = Pub::method;
-   |                     ^^^^^^^^^^^
+   |                     ^^^^^^^^^^^ private
 ...
 LL |     priv_signature::mac!();
    |     ----------------------- in this macro invocation
 
-error: type `priv_signature::Priv` is private
+error: struct `priv_signature::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:39:9
    |
 LL |         value;
-   |         ^^^^^
+   |         ^^^^^ private
 ...
 LL |     priv_signature::mac!();
    |     ----------------------- in this macro invocation
 
-error: type `priv_signature::Priv` is private
+error: struct `priv_signature::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:41:13
    |
 LL |         Pub.method(loop {});
-   |             ^^^^^^
+   |             ^^^^^^ private
 ...
 LL |     priv_signature::mac!();
    |     ----------------------- in this macro invocation
 
-error: type `priv_substs::Priv` is private
+error: struct `priv_substs::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:57:21
    |
 LL |         let value = Pub::method::<Priv>;
-   |                     ^^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^^^^^^^^^^^^^ private
 ...
 LL |     priv_substs::mac!();
    |     -------------------- in this macro invocation
 
-error: type `priv_substs::Priv` is private
+error: struct `priv_substs::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:59:9
    |
 LL |         value;
-   |         ^^^^^
+   |         ^^^^^ private
 ...
 LL |     priv_substs::mac!();
    |     -------------------- in this macro invocation
 
-error: type `priv_substs::Priv` is private
+error: struct `priv_substs::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:61:9
    |
 LL |         Pub.method::<Priv>();
-   |         ^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^ private
 ...
 LL |     priv_substs::mac!();
    |     -------------------- in this macro invocation
 
-error: type `priv_parent_substs::Priv` is private
+error: struct `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:80:21
    |
 LL |         let value = <Pub>::method;
-   |                     ^^^^^^^^^^^^^
+   |                     ^^^^^^^^^^^^^ private
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
 
-error: type `priv_parent_substs::Priv` is private
+error: struct `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:82:9
    |
 LL |         value;
-   |         ^^^^^
+   |         ^^^^^ private
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
 
-error: type `priv_parent_substs::Priv` is private
+error: struct `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:84:21
    |
 LL |         let value = Pub::method;
-   |                     ^^^^^^^^^^^
+   |                     ^^^^^^^^^^^ private
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
 
-error: type `priv_parent_substs::Priv` is private
+error: struct `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:86:9
    |
 LL |         value;
-   |         ^^^^^
+   |         ^^^^^ private
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
 
-error: type `priv_parent_substs::Priv` is private
+error: struct `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:88:21
    |
 LL |         let value = <Pub>::static_method;
-   |                     ^^^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^^^^^^^^^^^^^^ private
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
 
-error: type `priv_parent_substs::Priv` is private
+error: struct `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:90:9
    |
 LL |         value;
-   |         ^^^^^
+   |         ^^^^^ private
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
 
-error: type `priv_parent_substs::Priv` is private
+error: struct `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:92:21
    |
 LL |         let value = Pub::static_method;
-   |                     ^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^^^^^^^^^^^^ private
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
 
-error: type `priv_parent_substs::Priv` is private
+error: struct `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:94:9
    |
 LL |         value;
-   |         ^^^^^
+   |         ^^^^^ private
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
 
-error: type `priv_parent_substs::Priv` is private
+error: struct `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:96:19
    |
 LL |         Pub(Priv).method();
-   |                   ^^^^^^
+   |                   ^^^^^^ private
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
 
-error: type `priv_parent_substs::Priv` is private
+error: struct `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:99:10
    |
 LL |         <Pub>::CONST;
-   |          ^^^
+   |          ^^^ private
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
 
-error: type `priv_parent_substs::Priv` is private
+error: struct `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:101:9
    |
 LL |         Pub::CONST;
-   |         ^^^^^^^^^^
+   |         ^^^^^^^^^^ private
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation

--- a/src/test/ui/privacy/associated-item-privacy-trait.rs
+++ b/src/test/ui/privacy/associated-item-privacy-trait.rs
@@ -15,11 +15,11 @@ mod priv_trait {
 
     pub macro mac() {
         let value = <Pub as PrivTr>::method;
-        //~^ ERROR type `for<'r> fn(&'r priv_trait::Pub) {<priv_trait::Pub as priv_trait::PrivTr>::method}` is private
+        //~^ ERROR method `priv_trait::PrivTr::method` is private
         value;
-        //~^ ERROR type `for<'r> fn(&'r priv_trait::Pub) {<priv_trait::Pub as priv_trait::PrivTr>::method}` is private
+        //~^ ERROR method `priv_trait::PrivTr::method` is private
         Pub.method();
-        //~^ ERROR type `for<'r> fn(&'r Self) {<Self as priv_trait::PrivTr>::method}` is private
+        //~^ ERROR method `priv_trait::PrivTr::method` is private
         <Pub as PrivTr>::CONST;
         //~^ ERROR associated constant `PrivTr::CONST` is private
         let _: <Pub as PrivTr>::AssocTy;
@@ -47,11 +47,11 @@ mod priv_signature {
 
     pub macro mac() {
         let value = <Pub as PubTr>::method;
-        //~^ ERROR type `priv_signature::Priv` is private
+        //~^ ERROR struct `priv_signature::Priv` is private
         value;
-        //~^ ERROR type `priv_signature::Priv` is private
+        //~^ ERROR struct `priv_signature::Priv` is private
         Pub.method(loop {});
-        //~^ ERROR type `priv_signature::Priv` is private
+        //~^ ERROR struct `priv_signature::Priv` is private
     }
 }
 fn priv_signature() {
@@ -68,11 +68,11 @@ mod priv_substs {
 
     pub macro mac() {
         let value = <Pub as PubTr>::method::<Priv>;
-        //~^ ERROR type `priv_substs::Priv` is private
+        //~^ ERROR struct `priv_substs::Priv` is private
         value;
-        //~^ ERROR type `priv_substs::Priv` is private
+        //~^ ERROR struct `priv_substs::Priv` is private
         Pub.method::<Priv>();
-        //~^ ERROR type `priv_substs::Priv` is private
+        //~^ ERROR struct `priv_substs::Priv` is private
     }
 }
 fn priv_substs() {
@@ -92,46 +92,46 @@ mod priv_parent_substs {
 
     pub macro mac() {
         let value = <Pub as PubTr>::method;
-        //~^ ERROR type `priv_parent_substs::Priv` is private
+        //~^ ERROR struct `priv_parent_substs::Priv` is private
         value;
-        //~^ ERROR type `priv_parent_substs::Priv` is private
+        //~^ ERROR struct `priv_parent_substs::Priv` is private
         let value = <Pub as PubTr<_>>::method;
-        //~^ ERROR type `priv_parent_substs::Priv` is private
+        //~^ ERROR struct `priv_parent_substs::Priv` is private
         value;
-        //~^ ERROR type `priv_parent_substs::Priv` is private
+        //~^ ERROR struct `priv_parent_substs::Priv` is private
         Pub.method();
-        //~^ ERROR type `priv_parent_substs::Priv` is private
+        //~^ ERROR struct `priv_parent_substs::Priv` is private
 
         let value = <Priv as PubTr<_>>::method;
-        //~^ ERROR type `priv_parent_substs::Priv` is private
+        //~^ ERROR struct `priv_parent_substs::Priv` is private
         value;
-        //~^ ERROR type `priv_parent_substs::Priv` is private
+        //~^ ERROR struct `priv_parent_substs::Priv` is private
         Priv.method();
-        //~^ ERROR type `priv_parent_substs::Priv` is private
+        //~^ ERROR struct `priv_parent_substs::Priv` is private
 
         <Pub as PubTr>::CONST;
-        //~^ ERROR type `priv_parent_substs::Priv` is private
+        //~^ ERROR struct `priv_parent_substs::Priv` is private
         <Pub as PubTr<_>>::CONST;
-        //~^ ERROR type `priv_parent_substs::Priv` is private
+        //~^ ERROR struct `priv_parent_substs::Priv` is private
         <Priv as PubTr<_>>::CONST;
-        //~^ ERROR type `priv_parent_substs::Priv` is private
+        //~^ ERROR struct `priv_parent_substs::Priv` is private
 
         let _: <Pub as PubTr>::AssocTy;
-        //~^ ERROR type `priv_parent_substs::Priv` is private
-        //~| ERROR type `priv_parent_substs::Priv` is private
+        //~^ ERROR struct `priv_parent_substs::Priv` is private
+        //~| ERROR struct `priv_parent_substs::Priv` is private
         let _: <Pub as PubTr<_>>::AssocTy;
-        //~^ ERROR type `priv_parent_substs::Priv` is private
-        //~| ERROR type `priv_parent_substs::Priv` is private
+        //~^ ERROR struct `priv_parent_substs::Priv` is private
+        //~| ERROR struct `priv_parent_substs::Priv` is private
         let _: <Priv as PubTr<_>>::AssocTy;
-        //~^ ERROR type `priv_parent_substs::Priv` is private
-        //~| ERROR type `priv_parent_substs::Priv` is private
+        //~^ ERROR struct `priv_parent_substs::Priv` is private
+        //~| ERROR struct `priv_parent_substs::Priv` is private
 
         pub type InSignatureTy1 = <Pub as PubTr>::AssocTy;
-        //~^ ERROR type `priv_parent_substs::Priv` is private
+        //~^ ERROR struct `priv_parent_substs::Priv` is private
         pub type InSignatureTy2 = <Priv as PubTr<Pub>>::AssocTy;
-        //~^ ERROR type `priv_parent_substs::Priv` is private
+        //~^ ERROR struct `priv_parent_substs::Priv` is private
         impl PubTr for u8 {}
-        //~^ ERROR type `priv_parent_substs::Priv` is private
+        //~^ ERROR struct `priv_parent_substs::Priv` is private
     }
 }
 fn priv_parent_substs() {

--- a/src/test/ui/privacy/associated-item-privacy-trait.stderr
+++ b/src/test/ui/privacy/associated-item-privacy-trait.stderr
@@ -1,26 +1,26 @@
-error: type `for<'r> fn(&'r priv_trait::Pub) {<priv_trait::Pub as priv_trait::PrivTr>::method}` is private
+error: method `priv_trait::PrivTr::method` is private
   --> $DIR/associated-item-privacy-trait.rs:17:21
    |
 LL |         let value = <Pub as PrivTr>::method;
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^ private
 ...
 LL |     priv_trait::mac!();
    |     ------------------- in this macro invocation
 
-error: type `for<'r> fn(&'r priv_trait::Pub) {<priv_trait::Pub as priv_trait::PrivTr>::method}` is private
+error: method `priv_trait::PrivTr::method` is private
   --> $DIR/associated-item-privacy-trait.rs:19:9
    |
 LL |         value;
-   |         ^^^^^
+   |         ^^^^^ private
 ...
 LL |     priv_trait::mac!();
    |     ------------------- in this macro invocation
 
-error: type `for<'r> fn(&'r Self) {<Self as priv_trait::PrivTr>::method}` is private
+error: method `priv_trait::PrivTr::method` is private
   --> $DIR/associated-item-privacy-trait.rs:21:13
    |
 LL |         Pub.method();
-   |             ^^^^^^
+   |             ^^^^^^ private
 ...
 LL |     priv_trait::mac!();
    |     ------------------- in this macro invocation
@@ -29,7 +29,7 @@ error: associated constant `PrivTr::CONST` is private
   --> $DIR/associated-item-privacy-trait.rs:23:9
    |
 LL |         <Pub as PrivTr>::CONST;
-   |         ^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^ associated constant not accessible from here
 ...
 LL |     priv_trait::mac!();
    |     ------------------- in this macro invocation
@@ -38,7 +38,7 @@ error: trait `priv_trait::PrivTr` is private
   --> $DIR/associated-item-privacy-trait.rs:25:13
    |
 LL |         let _: <Pub as PrivTr>::AssocTy;
-   |             ^
+   |             ^ private
 ...
 LL |     priv_trait::mac!();
    |     ------------------- in this macro invocation
@@ -47,7 +47,7 @@ error: trait `priv_trait::PrivTr` is private
   --> $DIR/associated-item-privacy-trait.rs:25:16
    |
 LL |         let _: <Pub as PrivTr>::AssocTy;
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^ private
 ...
 LL |     priv_trait::mac!();
    |     ------------------- in this macro invocation
@@ -56,7 +56,7 @@ error: trait `priv_trait::PrivTr` is private
   --> $DIR/associated-item-privacy-trait.rs:28:34
    |
 LL |         pub type InSignatureTy = <Pub as PrivTr>::AssocTy;
-   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^ private
 ...
 LL |     priv_trait::mac!();
    |     ------------------- in this macro invocation
@@ -65,7 +65,7 @@ error: trait `priv_trait::PrivTr` is private
   --> $DIR/associated-item-privacy-trait.rs:30:34
    |
 LL |         pub trait InSignatureTr: PrivTr {}
-   |                                  ^^^^^^
+   |                                  ^^^^^^ private
 ...
 LL |     priv_trait::mac!();
    |     ------------------- in this macro invocation
@@ -74,241 +74,241 @@ error: trait `priv_trait::PrivTr` is private
   --> $DIR/associated-item-privacy-trait.rs:32:14
    |
 LL |         impl PrivTr for u8 {}
-   |              ^^^^^^
+   |              ^^^^^^ private
 ...
 LL |     priv_trait::mac!();
    |     ------------------- in this macro invocation
 
-error: type `priv_signature::Priv` is private
+error: struct `priv_signature::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:49:21
    |
 LL |         let value = <Pub as PubTr>::method;
-   |                     ^^^^^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^^^^^^^^^^^^^^^^ private
 ...
 LL |     priv_signature::mac!();
    |     ----------------------- in this macro invocation
 
-error: type `priv_signature::Priv` is private
+error: struct `priv_signature::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:51:9
    |
 LL |         value;
-   |         ^^^^^
+   |         ^^^^^ private
 ...
 LL |     priv_signature::mac!();
    |     ----------------------- in this macro invocation
 
-error: type `priv_signature::Priv` is private
+error: struct `priv_signature::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:53:13
    |
 LL |         Pub.method(loop {});
-   |             ^^^^^^
+   |             ^^^^^^ private
 ...
 LL |     priv_signature::mac!();
    |     ----------------------- in this macro invocation
 
-error: type `priv_substs::Priv` is private
+error: struct `priv_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:70:21
    |
 LL |         let value = <Pub as PubTr>::method::<Priv>;
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private
 ...
 LL |     priv_substs::mac!();
    |     -------------------- in this macro invocation
 
-error: type `priv_substs::Priv` is private
+error: struct `priv_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:72:9
    |
 LL |         value;
-   |         ^^^^^
+   |         ^^^^^ private
 ...
 LL |     priv_substs::mac!();
    |     -------------------- in this macro invocation
 
-error: type `priv_substs::Priv` is private
+error: struct `priv_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:74:9
    |
 LL |         Pub.method::<Priv>();
-   |         ^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^ private
 ...
 LL |     priv_substs::mac!();
    |     -------------------- in this macro invocation
 
-error: type `priv_parent_substs::Priv` is private
+error: struct `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:94:21
    |
 LL |         let value = <Pub as PubTr>::method;
-   |                     ^^^^^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^^^^^^^^^^^^^^^^ private
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
 
-error: type `priv_parent_substs::Priv` is private
+error: struct `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:96:9
    |
 LL |         value;
-   |         ^^^^^
+   |         ^^^^^ private
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
 
-error: type `priv_parent_substs::Priv` is private
+error: struct `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:98:21
    |
 LL |         let value = <Pub as PubTr<_>>::method;
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^ private
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
 
-error: type `priv_parent_substs::Priv` is private
+error: struct `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:100:9
    |
 LL |         value;
-   |         ^^^^^
+   |         ^^^^^ private
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
 
-error: type `priv_parent_substs::Priv` is private
+error: struct `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:102:9
    |
 LL |         Pub.method();
-   |         ^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^ private
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
 
-error: type `priv_parent_substs::Priv` is private
+error: struct `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:105:21
    |
 LL |         let value = <Priv as PubTr<_>>::method;
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^ private
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
 
-error: type `priv_parent_substs::Priv` is private
+error: struct `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:107:9
    |
 LL |         value;
-   |         ^^^^^
+   |         ^^^^^ private
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
 
-error: type `priv_parent_substs::Priv` is private
+error: struct `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:109:9
    |
 LL |         Priv.method();
-   |         ^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^ private
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
 
-error: type `priv_parent_substs::Priv` is private
+error: struct `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:112:9
    |
 LL |         <Pub as PubTr>::CONST;
-   |         ^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^ private
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
 
-error: type `priv_parent_substs::Priv` is private
+error: struct `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:114:9
    |
 LL |         <Pub as PubTr<_>>::CONST;
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^ private
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
 
-error: type `priv_parent_substs::Priv` is private
+error: struct `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:116:9
    |
 LL |         <Priv as PubTr<_>>::CONST;
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^ private
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
 
-error: type `priv_parent_substs::Priv` is private
+error: struct `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:119:13
    |
 LL |         let _: <Pub as PubTr>::AssocTy;
-   |             ^
+   |             ^ private
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
 
-error: type `priv_parent_substs::Priv` is private
+error: struct `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:119:16
    |
 LL |         let _: <Pub as PubTr>::AssocTy;
-   |                ^^^^^^^^^^^^^^^^^^^^^^^
+   |                ^^^^^^^^^^^^^^^^^^^^^^^ private
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
 
-error: type `priv_parent_substs::Priv` is private
+error: struct `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:122:13
    |
 LL |         let _: <Pub as PubTr<_>>::AssocTy;
-   |             ^
+   |             ^ private
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
 
-error: type `priv_parent_substs::Priv` is private
+error: struct `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:122:16
    |
 LL |         let _: <Pub as PubTr<_>>::AssocTy;
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^ private
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
 
-error: type `priv_parent_substs::Priv` is private
+error: struct `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:125:13
    |
 LL |         let _: <Priv as PubTr<_>>::AssocTy;
-   |             ^
+   |             ^ private
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
 
-error: type `priv_parent_substs::Priv` is private
+error: struct `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:125:16
    |
 LL |         let _: <Priv as PubTr<_>>::AssocTy;
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ private
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
 
-error: type `priv_parent_substs::Priv` is private
+error: struct `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:129:35
    |
 LL |         pub type InSignatureTy1 = <Pub as PubTr>::AssocTy;
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^ private
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
 
-error: type `priv_parent_substs::Priv` is private
+error: struct `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:131:35
    |
 LL |         pub type InSignatureTy2 = <Priv as PubTr<Pub>>::AssocTy;
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
 
-error: type `priv_parent_substs::Priv` is private
+error: struct `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:133:14
    |
 LL |         impl PubTr for u8 {}
-   |              ^^^^^
+   |              ^^^^^ private
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation

--- a/src/test/ui/privacy/associated-item-privacy-type-binding.rs
+++ b/src/test/ui/privacy/associated-item-privacy-type-binding.rs
@@ -42,19 +42,19 @@ mod priv_parent_substs {
 
     pub macro mac() {
         let _: Box<PubTrWithParam<AssocTy = u8>>;
-        //~^ ERROR type `priv_parent_substs::Priv` is private
-        //~| ERROR type `priv_parent_substs::Priv` is private
+        //~^ ERROR struct `priv_parent_substs::Priv` is private
+        //~| ERROR struct `priv_parent_substs::Priv` is private
         let _: Box<PubTr<AssocTy = u8>>;
-        //~^ ERROR type `priv_parent_substs::Priv` is private
-        //~| ERROR type `priv_parent_substs::Priv` is private
+        //~^ ERROR struct `priv_parent_substs::Priv` is private
+        //~| ERROR struct `priv_parent_substs::Priv` is private
         pub type InSignatureTy1 = Box<PubTrWithParam<AssocTy = u8>>;
-        //~^ ERROR type `priv_parent_substs::Priv` is private
+        //~^ ERROR struct `priv_parent_substs::Priv` is private
         pub type InSignatureTy2 = Box<PubTr<AssocTy = u8>>;
-        //~^ ERROR type `priv_parent_substs::Priv` is private
+        //~^ ERROR struct `priv_parent_substs::Priv` is private
         trait InSignatureTr1: PubTrWithParam<AssocTy = u8> {}
-        //~^ ERROR type `priv_parent_substs::Priv` is private
+        //~^ ERROR struct `priv_parent_substs::Priv` is private
         trait InSignatureTr2: PubTr<AssocTy = u8> {}
-        //~^ ERROR type `priv_parent_substs::Priv` is private
+        //~^ ERROR struct `priv_parent_substs::Priv` is private
     }
 }
 fn priv_parent_substs() {

--- a/src/test/ui/privacy/associated-item-privacy-type-binding.stderr
+++ b/src/test/ui/privacy/associated-item-privacy-type-binding.stderr
@@ -2,7 +2,7 @@ error: trait `priv_trait::PrivTr` is private
   --> $DIR/associated-item-privacy-type-binding.rs:11:13
    |
 LL |         let _: Box<PubTr<AssocTy = u8>>;
-   |             ^
+   |             ^ private
 ...
 LL |     priv_trait::mac1!();
    |     -------------------- in this macro invocation
@@ -11,7 +11,7 @@ error: trait `priv_trait::PrivTr` is private
   --> $DIR/associated-item-privacy-type-binding.rs:11:16
    |
 LL |         let _: Box<PubTr<AssocTy = u8>>;
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^ private
 ...
 LL |     priv_trait::mac1!();
    |     -------------------- in this macro invocation
@@ -20,7 +20,7 @@ error: trait `priv_trait::PrivTr` is private
   --> $DIR/associated-item-privacy-type-binding.rs:14:31
    |
 LL |         type InSignatureTy2 = Box<PubTr<AssocTy = u8>>;
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^ private
 ...
 LL |     priv_trait::mac1!();
    |     -------------------- in this macro invocation
@@ -29,7 +29,7 @@ error: trait `priv_trait::PrivTr` is private
   --> $DIR/associated-item-privacy-type-binding.rs:16:31
    |
 LL |         trait InSignatureTr2: PubTr<AssocTy = u8> {}
-   |                               ^^^^^^^^^^^^^^^^^^^
+   |                               ^^^^^^^^^^^^^^^^^^^ private
 ...
 LL |     priv_trait::mac1!();
    |     -------------------- in this macro invocation
@@ -38,7 +38,7 @@ error: trait `priv_trait::PrivTr` is private
   --> $DIR/associated-item-privacy-type-binding.rs:20:13
    |
 LL |         let _: Box<PrivTr<AssocTy = u8>>;
-   |             ^
+   |             ^ private
 ...
 LL |     priv_trait::mac2!();
    |     -------------------- in this macro invocation
@@ -47,7 +47,7 @@ error: trait `priv_trait::PrivTr` is private
   --> $DIR/associated-item-privacy-type-binding.rs:20:16
    |
 LL |         let _: Box<PrivTr<AssocTy = u8>>;
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^ private
 ...
 LL |     priv_trait::mac2!();
    |     -------------------- in this macro invocation
@@ -56,7 +56,7 @@ error: trait `priv_trait::PrivTr` is private
   --> $DIR/associated-item-privacy-type-binding.rs:23:31
    |
 LL |         type InSignatureTy1 = Box<PrivTr<AssocTy = u8>>;
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^ private
 ...
 LL |     priv_trait::mac2!();
    |     -------------------- in this macro invocation
@@ -65,79 +65,79 @@ error: trait `priv_trait::PrivTr` is private
   --> $DIR/associated-item-privacy-type-binding.rs:25:31
    |
 LL |         trait InSignatureTr1: PrivTr<AssocTy = u8> {}
-   |                               ^^^^^^^^^^^^^^^^^^^^
+   |                               ^^^^^^^^^^^^^^^^^^^^ private
 ...
 LL |     priv_trait::mac2!();
    |     -------------------- in this macro invocation
 
-error: type `priv_parent_substs::Priv` is private
+error: struct `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-type-binding.rs:44:13
    |
 LL |         let _: Box<PubTrWithParam<AssocTy = u8>>;
-   |             ^
+   |             ^ private
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
 
-error: type `priv_parent_substs::Priv` is private
+error: struct `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-type-binding.rs:44:16
    |
 LL |         let _: Box<PubTrWithParam<AssocTy = u8>>;
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
 
-error: type `priv_parent_substs::Priv` is private
+error: struct `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-type-binding.rs:47:13
    |
 LL |         let _: Box<PubTr<AssocTy = u8>>;
-   |             ^
+   |             ^ private
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
 
-error: type `priv_parent_substs::Priv` is private
+error: struct `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-type-binding.rs:47:16
    |
 LL |         let _: Box<PubTr<AssocTy = u8>>;
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^ private
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
 
-error: type `priv_parent_substs::Priv` is private
+error: struct `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-type-binding.rs:50:35
    |
 LL |         pub type InSignatureTy1 = Box<PubTrWithParam<AssocTy = u8>>;
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
 
-error: type `priv_parent_substs::Priv` is private
+error: struct `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-type-binding.rs:52:35
    |
 LL |         pub type InSignatureTy2 = Box<PubTr<AssocTy = u8>>;
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ private
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
 
-error: type `priv_parent_substs::Priv` is private
+error: struct `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-type-binding.rs:54:31
    |
 LL |         trait InSignatureTr1: PubTrWithParam<AssocTy = u8> {}
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
 
-error: type `priv_parent_substs::Priv` is private
+error: struct `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-type-binding.rs:56:31
    |
 LL |         trait InSignatureTr2: PubTr<AssocTy = u8> {}
-   |                               ^^^^^^^^^^^^^^^^^^^
+   |                               ^^^^^^^^^^^^^^^^^^^ private
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation

--- a/src/test/ui/privacy/multiple-private-fields.rs
+++ b/src/test/ui/privacy/multiple-private-fields.rs
@@ -1,0 +1,17 @@
+mod a {
+    pub struct A(usize, usize);
+    pub struct B {a: usize, b: usize}
+
+}
+
+fn main(){
+    let x = a::A(3, 4);
+    //~^ ERROR fields of struct `a::A` are private
+    let x = a::A;
+    //~^ ERROR tuple struct `a::A` is private
+    let x = a::B {a:1, b:2};
+    //~^ ERROR fields of struct `a::B` are private
+}
+
+fn foo(_x: a::A) {} // ok
+fn bar(_x: a::B) {} // ok

--- a/src/test/ui/privacy/multiple-private-fields.stderr
+++ b/src/test/ui/privacy/multiple-private-fields.stderr
@@ -1,0 +1,34 @@
+error[E0451]: fields of struct `a::A` are private
+  --> $DIR/multiple-private-fields.rs:8:18
+   |
+LL |     pub struct A(usize, usize);
+   |     --------------------------- `a::A` defined here
+...
+LL |     let x = a::A(3, 4);
+   |             ---- ^  ^ private field
+   |             |    |
+   |             |    private field
+   |             `a::A` cannot be built due to private fields
+
+error[E0451]: fields of struct `a::B` are private
+  --> $DIR/multiple-private-fields.rs:12:19
+   |
+LL |     pub struct B {a: usize, b: usize}
+   |     --------------------------------- `a::B` defined here
+...
+LL |     let x = a::B {a:1, b:2};
+   |             ------^^^--^^^-
+   |             |     |    |
+   |             |     |    private field
+   |             |     private field
+   |             `a::B` cannot be built due to private fields
+
+error: tuple struct `a::A` is private
+  --> $DIR/multiple-private-fields.rs:10:13
+   |
+LL |     let x = a::A;
+   |             ^^^^ tuple struct not accesssible from here
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0451`.

--- a/src/test/ui/privacy/privacy5.rs
+++ b/src/test/ui/privacy/privacy5.rs
@@ -48,31 +48,51 @@ mod a {
 }
 
 fn this_crate() {
-    let a = a::A(()); //~ ERROR tuple struct `A` is private
-    let b = a::B(2); //~ ERROR tuple struct `B` is private
-    let c = a::C(2, 3); //~ ERROR tuple struct `C` is private
+    let a = a::A(());
+    //~^ ERROR field `0` of struct `a::A` is private
+    let b = a::B(2);
+    //~^ ERROR field `0` of struct `a::B` is private
+    let c = a::C(2, 3);
+    //~^ ERROR field `1` of struct `a::C` is private
     let d = a::D(4);
 
-    let a::A(()) = a; //~ ERROR tuple struct `A` is private
-    let a::A(_) = a; //~ ERROR tuple struct `A` is private
-    match a { a::A(()) => {} } //~ ERROR tuple struct `A` is private
-    match a { a::A(_) => {} } //~ ERROR tuple struct `A` is private
+    let a::A(()) = a;
+    //~^ ERROR field `0` of struct `a::A` is private
+    let a::A(_) = a;
+    //~^ ERROR field `0` of struct `a::A` is private
+    match a { a::A(()) => {} }
+    //~^ ERROR field `0` of struct `a::A` is private
+    match a { a::A(_) => {} }
+    //~^ ERROR field `0` of struct `a::A` is private
 
-    let a::B(_) = b; //~ ERROR tuple struct `B` is private
-    let a::B(_b) = b; //~ ERROR tuple struct `B` is private
-    match b { a::B(_) => {} } //~ ERROR tuple struct `B` is private
-    match b { a::B(_b) => {} } //~ ERROR tuple struct `B` is private
-    match b { a::B(1) => {} a::B(_) => {} } //~ ERROR tuple struct `B` is private
-                                            //~^ ERROR tuple struct `B` is private
+    let a::B(_) = b;
+    //~^ ERROR field `0` of struct `a::B` is private
+    let a::B(_b) = b;
+    //~^ ERROR field `0` of struct `a::B` is private
+    match b { a::B(_) => {} }
+    //~^ ERROR field `0` of struct `a::B` is private
+    match b { a::B(_b) => {} }
+    //~^ ERROR field `0` of struct `a::B` is private
+    match b { a::B(1) => {} a::B(_) => {} }
+    //~^ ERROR field `0` of struct `a::B` is private
+    //~| ERROR field `0` of struct `a::B` is private
 
-    let a::C(_, _) = c; //~ ERROR tuple struct `C` is private
-    let a::C(_a, _) = c; //~ ERROR tuple struct `C` is private
-    let a::C(_, _b) = c; //~ ERROR tuple struct `C` is private
-    let a::C(_a, _b) = c; //~ ERROR tuple struct `C` is private
-    match c { a::C(_, _) => {} } //~ ERROR tuple struct `C` is private
-    match c { a::C(_a, _) => {} } //~ ERROR tuple struct `C` is private
-    match c { a::C(_, _b) => {} } //~ ERROR tuple struct `C` is private
-    match c { a::C(_a, _b) => {} } //~ ERROR tuple struct `C` is private
+    let a::C(_, _) = c;
+    //~^ ERROR field `1` of struct `a::C` is private
+    let a::C(_a, _) = c;
+    //~^ ERROR field `1` of struct `a::C` is private
+    let a::C(_, _b) = c;
+    //~^ ERROR field `1` of struct `a::C` is private
+    let a::C(_a, _b) = c;
+    //~^ ERROR field `1` of struct `a::C` is private
+    match c { a::C(_, _) => {} }
+    //~^ ERROR field `1` of struct `a::C` is private
+    match c { a::C(_a, _) => {} }
+    //~^ ERROR field `1` of struct `a::C` is private
+    match c { a::C(_, _b) => {} }
+    //~^ ERROR field `1` of struct `a::C` is private
+    match c { a::C(_a, _b) => {} }
+    //~^ ERROR field `1` of struct `a::C` is private
 
     let a::D(_) = d;
     let a::D(_d) = d;
@@ -80,38 +100,61 @@ fn this_crate() {
     match d { a::D(_d) => {} }
     match d { a::D(1) => {} a::D(_) => {} }
 
-    let a2 = a::A; //~ ERROR tuple struct `A` is private
-    let b2 = a::B; //~ ERROR tuple struct `B` is private
-    let c2 = a::C; //~ ERROR tuple struct `C` is private
+    let a2 = a::A;
+    //~^ ERROR tuple struct `a::A` is private
+    let b2 = a::B;
+    //~^ ERROR tuple struct `a::B` is private
+    let c2 = a::C;
+    //~^ ERROR tuple struct `a::C` is private
     let d2 = a::D;
 }
 
 fn xcrate() {
-    let a = other::A(()); //~ ERROR tuple struct `A` is private
-    let b = other::B(2); //~ ERROR tuple struct `B` is private
-    let c = other::C(2, 3); //~ ERROR tuple struct `C` is private
+    let a = other::A(());
+    //~^ ERROR field `0` of struct `other::A` is private
+    let b = other::B(2);
+    //~^ ERROR field `0` of struct `other::B` is private
+    let c = other::C(2, 3);
+    //~^ ERROR field `1` of struct `other::C` is private
     let d = other::D(4);
 
-    let other::A(()) = a; //~ ERROR tuple struct `A` is private
-    let other::A(_) = a; //~ ERROR tuple struct `A` is private
-    match a { other::A(()) => {} } //~ ERROR tuple struct `A` is private
-    match a { other::A(_) => {} } //~ ERROR tuple struct `A` is private
+    let other::A(()) = a;
+    //~^ ERROR field `0` of struct `other::A` is private
+    let other::A(_) = a;
+    //~^ ERROR field `0` of struct `other::A` is private
+    match a { other::A(()) => {} }
+    //~^ ERROR field `0` of struct `other::A` is private
+    match a { other::A(_) => {} }
+    //~^ ERROR field `0` of struct `other::A` is private
 
-    let other::B(_) = b; //~ ERROR tuple struct `B` is private
-    let other::B(_b) = b; //~ ERROR tuple struct `B` is private
-    match b { other::B(_) => {} } //~ ERROR tuple struct `B` is private
-    match b { other::B(_b) => {} } //~ ERROR tuple struct `B` is private
-    match b { other::B(1) => {} other::B(_) => {} } //~ ERROR tuple struct `B` is private
-                                                    //~^ ERROR tuple struct `B` is private
+    let other::B(_) = b;
+    //~^ ERROR field `0` of struct `other::B` is private
+    let other::B(_b) = b;
+    //~^ ERROR field `0` of struct `other::B` is private
+    match b { other::B(_) => {} }
+    //~^ ERROR field `0` of struct `other::B` is private
+    match b { other::B(_b) => {} }
+    //~^ ERROR field `0` of struct `other::B` is private
+    match b { other::B(1) => {} other::B(_) => {} }
+    //~^ ERROR field `0` of struct `other::B` is private
+    //~| ERROR field `0` of struct `other::B` is private
 
-    let other::C(_, _) = c; //~ ERROR tuple struct `C` is private
-    let other::C(_a, _) = c; //~ ERROR tuple struct `C` is private
-    let other::C(_, _b) = c; //~ ERROR tuple struct `C` is private
-    let other::C(_a, _b) = c; //~ ERROR tuple struct `C` is private
-    match c { other::C(_, _) => {} } //~ ERROR tuple struct `C` is private
-    match c { other::C(_a, _) => {} } //~ ERROR tuple struct `C` is private
-    match c { other::C(_, _b) => {} } //~ ERROR tuple struct `C` is private
-    match c { other::C(_a, _b) => {} } //~ ERROR tuple struct `C` is private
+    let other::C(_, _) = c;
+    //~^ ERROR field `1` of struct `other::C` is private
+    let other::C(_a, _) = c;
+    //~^ ERROR field `1` of struct `other::C` is private
+    let other::C(_, _b) = c;
+    //~^ ERROR field `1` of struct `other::C` is private
+    let other::C(_a, _b) = c;
+    //~^ ERROR field `1` of struct `other::C` is private
+    match c { other::C(_, _) => {} }
+    //~^ ERROR field `1` of struct `other::C` is private
+    match c { other::C(_a, _) => {} }
+    //~^ ERROR field `1` of struct `other::C` is private
+    match c { other::C(_, _b) => {} }
+    //~^ ERROR field `1` of struct `other::C` is private
+    match c { other::C(_a, _b) => {} }
+    //~^ ERROR field `1` of struct `other::C` is private
 
     let other::D(_) = d;
     let other::D(_d) = d;
@@ -119,9 +162,12 @@ fn xcrate() {
     match d { other::D(_d) => {} }
     match d { other::D(1) => {} other::D(_) => {} }
 
-    let a2 = other::A; //~ ERROR tuple struct `A` is private
-    let b2 = other::B; //~ ERROR tuple struct `B` is private
-    let c2 = other::C; //~ ERROR tuple struct `C` is private
+    let a2 = other::A;
+    //~^ ERROR struct `other::A` is private
+    let b2 = other::B;
+    //~^ ERROR struct `other::B` is private
+    let c2 = other::C;
+    //~^ ERROR struct `other::C` is private
     let d2 = other::D;
 }
 

--- a/src/test/ui/privacy/privacy5.stderr
+++ b/src/test/ui/privacy/privacy5.stderr
@@ -1,291 +1,579 @@
-error[E0603]: tuple struct `A` is private
-  --> $DIR/privacy5.rs:51:16
+error[E0451]: field `0` of struct `a::A` is private
+  --> $DIR/privacy5.rs:51:18
    |
-LL |     let a = a::A(()); //~ ERROR tuple struct `A` is private
-   |                ^
+LL |     pub struct A(());
+   |     ----------------- `a::A` defined here
+...
+LL |     let a = a::A(());
+   |             ---- ^^ private field
+   |             |
+   |             `a::A` cannot be built due to private field
 
-error[E0603]: tuple struct `B` is private
-  --> $DIR/privacy5.rs:52:16
+error[E0451]: field `0` of struct `a::B` is private
+  --> $DIR/privacy5.rs:53:18
    |
-LL |     let b = a::B(2); //~ ERROR tuple struct `B` is private
-   |                ^
+LL |     pub struct B(isize);
+   |     -------------------- `a::B` defined here
+...
+LL |     let b = a::B(2);
+   |             ---- ^ private field
+   |             |
+   |             `a::B` cannot be built due to private field
 
-error[E0603]: tuple struct `C` is private
-  --> $DIR/privacy5.rs:53:16
+error[E0451]: field `1` of struct `a::C` is private
+  --> $DIR/privacy5.rs:55:21
    |
-LL |     let c = a::C(2, 3); //~ ERROR tuple struct `C` is private
-   |                ^
+LL |     pub struct C(pub isize, isize);
+   |     ------------------------------- `a::C` defined here
+...
+LL |     let c = a::C(2, 3);
+   |             ----    ^ private field
+   |             |
+   |             `a::C` cannot be built due to private field
 
-error[E0603]: tuple struct `A` is private
-  --> $DIR/privacy5.rs:56:12
+error[E0451]: field `0` of struct `a::A` is private
+  --> $DIR/privacy5.rs:59:14
    |
-LL |     let a::A(()) = a; //~ ERROR tuple struct `A` is private
-   |            ^
+LL |     pub struct A(());
+   |     ----------------- `a::A` defined here
+...
+LL |     let a::A(()) = a;
+   |         -----^^-
+   |         |    |
+   |         |    private field
+   |         `a::A` cannot be destructured due to private field
 
-error[E0603]: tuple struct `A` is private
-  --> $DIR/privacy5.rs:57:12
+error[E0451]: field `0` of struct `a::A` is private
+  --> $DIR/privacy5.rs:61:14
    |
-LL |     let a::A(_) = a; //~ ERROR tuple struct `A` is private
-   |            ^
+LL |     pub struct A(());
+   |     ----------------- `a::A` defined here
+...
+LL |     let a::A(_) = a;
+   |         -----^-
+   |         |    |
+   |         |    private field
+   |         `a::A` cannot be destructured due to private field
 
-error[E0603]: tuple struct `A` is private
-  --> $DIR/privacy5.rs:58:18
+error[E0451]: field `0` of struct `a::A` is private
+  --> $DIR/privacy5.rs:63:20
    |
-LL |     match a { a::A(()) => {} } //~ ERROR tuple struct `A` is private
-   |                  ^
+LL |     pub struct A(());
+   |     ----------------- `a::A` defined here
+...
+LL |     match a { a::A(()) => {} }
+   |               -----^^-
+   |               |    |
+   |               |    private field
+   |               `a::A` cannot be destructured due to private field
 
-error[E0603]: tuple struct `A` is private
-  --> $DIR/privacy5.rs:59:18
+error[E0451]: field `0` of struct `a::A` is private
+  --> $DIR/privacy5.rs:65:20
    |
-LL |     match a { a::A(_) => {} } //~ ERROR tuple struct `A` is private
-   |                  ^
+LL |     pub struct A(());
+   |     ----------------- `a::A` defined here
+...
+LL |     match a { a::A(_) => {} }
+   |               -----^-
+   |               |    |
+   |               |    private field
+   |               `a::A` cannot be destructured due to private field
 
-error[E0603]: tuple struct `B` is private
-  --> $DIR/privacy5.rs:61:12
+error[E0451]: field `0` of struct `a::B` is private
+  --> $DIR/privacy5.rs:68:14
    |
-LL |     let a::B(_) = b; //~ ERROR tuple struct `B` is private
-   |            ^
+LL |     pub struct B(isize);
+   |     -------------------- `a::B` defined here
+...
+LL |     let a::B(_) = b;
+   |         -----^-
+   |         |    |
+   |         |    private field
+   |         `a::B` cannot be destructured due to private field
 
-error[E0603]: tuple struct `B` is private
-  --> $DIR/privacy5.rs:62:12
+error[E0451]: field `0` of struct `a::B` is private
+  --> $DIR/privacy5.rs:70:14
    |
-LL |     let a::B(_b) = b; //~ ERROR tuple struct `B` is private
-   |            ^
+LL |     pub struct B(isize);
+   |     -------------------- `a::B` defined here
+...
+LL |     let a::B(_b) = b;
+   |         -----^^-
+   |         |    |
+   |         |    private field
+   |         `a::B` cannot be destructured due to private field
 
-error[E0603]: tuple struct `B` is private
-  --> $DIR/privacy5.rs:63:18
+error[E0451]: field `0` of struct `a::B` is private
+  --> $DIR/privacy5.rs:72:20
    |
-LL |     match b { a::B(_) => {} } //~ ERROR tuple struct `B` is private
-   |                  ^
+LL |     pub struct B(isize);
+   |     -------------------- `a::B` defined here
+...
+LL |     match b { a::B(_) => {} }
+   |               -----^-
+   |               |    |
+   |               |    private field
+   |               `a::B` cannot be destructured due to private field
 
-error[E0603]: tuple struct `B` is private
-  --> $DIR/privacy5.rs:64:18
+error[E0451]: field `0` of struct `a::B` is private
+  --> $DIR/privacy5.rs:74:20
    |
-LL |     match b { a::B(_b) => {} } //~ ERROR tuple struct `B` is private
-   |                  ^
+LL |     pub struct B(isize);
+   |     -------------------- `a::B` defined here
+...
+LL |     match b { a::B(_b) => {} }
+   |               -----^^-
+   |               |    |
+   |               |    private field
+   |               `a::B` cannot be destructured due to private field
 
-error[E0603]: tuple struct `B` is private
-  --> $DIR/privacy5.rs:65:18
+error[E0451]: field `0` of struct `a::B` is private
+  --> $DIR/privacy5.rs:76:20
    |
-LL |     match b { a::B(1) => {} a::B(_) => {} } //~ ERROR tuple struct `B` is private
-   |                  ^
+LL |     pub struct B(isize);
+   |     -------------------- `a::B` defined here
+...
+LL |     match b { a::B(1) => {} a::B(_) => {} }
+   |               -----^-
+   |               |    |
+   |               |    private field
+   |               `a::B` cannot be destructured due to private field
 
-error[E0603]: tuple struct `B` is private
-  --> $DIR/privacy5.rs:65:32
+error[E0451]: field `0` of struct `a::B` is private
+  --> $DIR/privacy5.rs:76:34
    |
-LL |     match b { a::B(1) => {} a::B(_) => {} } //~ ERROR tuple struct `B` is private
-   |                                ^
+LL |     pub struct B(isize);
+   |     -------------------- `a::B` defined here
+...
+LL |     match b { a::B(1) => {} a::B(_) => {} }
+   |                             -----^-
+   |                             |    |
+   |                             |    private field
+   |                             `a::B` cannot be destructured due to private field
 
-error[E0603]: tuple struct `C` is private
-  --> $DIR/privacy5.rs:68:12
+error[E0451]: field `1` of struct `a::C` is private
+  --> $DIR/privacy5.rs:80:17
    |
-LL |     let a::C(_, _) = c; //~ ERROR tuple struct `C` is private
-   |            ^
+LL |     pub struct C(pub isize, isize);
+   |     ------------------------------- `a::C` defined here
+...
+LL |     let a::C(_, _) = c;
+   |         --------^-
+   |         |       |
+   |         |       private field
+   |         `a::C` cannot be destructured due to private field
 
-error[E0603]: tuple struct `C` is private
-  --> $DIR/privacy5.rs:69:12
+error[E0451]: field `1` of struct `a::C` is private
+  --> $DIR/privacy5.rs:82:18
    |
-LL |     let a::C(_a, _) = c; //~ ERROR tuple struct `C` is private
-   |            ^
+LL |     pub struct C(pub isize, isize);
+   |     ------------------------------- `a::C` defined here
+...
+LL |     let a::C(_a, _) = c;
+   |         ---------^-
+   |         |        |
+   |         |        private field
+   |         `a::C` cannot be destructured due to private field
 
-error[E0603]: tuple struct `C` is private
-  --> $DIR/privacy5.rs:70:12
-   |
-LL |     let a::C(_, _b) = c; //~ ERROR tuple struct `C` is private
-   |            ^
-
-error[E0603]: tuple struct `C` is private
-  --> $DIR/privacy5.rs:71:12
-   |
-LL |     let a::C(_a, _b) = c; //~ ERROR tuple struct `C` is private
-   |            ^
-
-error[E0603]: tuple struct `C` is private
-  --> $DIR/privacy5.rs:72:18
-   |
-LL |     match c { a::C(_, _) => {} } //~ ERROR tuple struct `C` is private
-   |                  ^
-
-error[E0603]: tuple struct `C` is private
-  --> $DIR/privacy5.rs:73:18
-   |
-LL |     match c { a::C(_a, _) => {} } //~ ERROR tuple struct `C` is private
-   |                  ^
-
-error[E0603]: tuple struct `C` is private
-  --> $DIR/privacy5.rs:74:18
-   |
-LL |     match c { a::C(_, _b) => {} } //~ ERROR tuple struct `C` is private
-   |                  ^
-
-error[E0603]: tuple struct `C` is private
-  --> $DIR/privacy5.rs:75:18
-   |
-LL |     match c { a::C(_a, _b) => {} } //~ ERROR tuple struct `C` is private
-   |                  ^
-
-error[E0603]: tuple struct `A` is private
-  --> $DIR/privacy5.rs:83:17
-   |
-LL |     let a2 = a::A; //~ ERROR tuple struct `A` is private
-   |                 ^
-
-error[E0603]: tuple struct `B` is private
+error[E0451]: field `1` of struct `a::C` is private
   --> $DIR/privacy5.rs:84:17
    |
-LL |     let b2 = a::B; //~ ERROR tuple struct `B` is private
-   |                 ^
+LL |     pub struct C(pub isize, isize);
+   |     ------------------------------- `a::C` defined here
+...
+LL |     let a::C(_, _b) = c;
+   |         --------^^-
+   |         |       |
+   |         |       private field
+   |         `a::C` cannot be destructured due to private field
 
-error[E0603]: tuple struct `C` is private
-  --> $DIR/privacy5.rs:85:17
+error[E0451]: field `1` of struct `a::C` is private
+  --> $DIR/privacy5.rs:86:18
    |
-LL |     let c2 = a::C; //~ ERROR tuple struct `C` is private
-   |                 ^
+LL |     pub struct C(pub isize, isize);
+   |     ------------------------------- `a::C` defined here
+...
+LL |     let a::C(_a, _b) = c;
+   |         ---------^^-
+   |         |        |
+   |         |        private field
+   |         `a::C` cannot be destructured due to private field
 
-error[E0603]: tuple struct `A` is private
-  --> $DIR/privacy5.rs:90:20
+error[E0451]: field `1` of struct `a::C` is private
+  --> $DIR/privacy5.rs:88:23
    |
-LL |     let a = other::A(()); //~ ERROR tuple struct `A` is private
-   |                    ^
+LL |     pub struct C(pub isize, isize);
+   |     ------------------------------- `a::C` defined here
+...
+LL |     match c { a::C(_, _) => {} }
+   |               --------^-
+   |               |       |
+   |               |       private field
+   |               `a::C` cannot be destructured due to private field
 
-error[E0603]: tuple struct `B` is private
-  --> $DIR/privacy5.rs:91:20
+error[E0451]: field `1` of struct `a::C` is private
+  --> $DIR/privacy5.rs:90:24
    |
-LL |     let b = other::B(2); //~ ERROR tuple struct `B` is private
-   |                    ^
+LL |     pub struct C(pub isize, isize);
+   |     ------------------------------- `a::C` defined here
+...
+LL |     match c { a::C(_a, _) => {} }
+   |               ---------^-
+   |               |        |
+   |               |        private field
+   |               `a::C` cannot be destructured due to private field
 
-error[E0603]: tuple struct `C` is private
-  --> $DIR/privacy5.rs:92:20
+error[E0451]: field `1` of struct `a::C` is private
+  --> $DIR/privacy5.rs:92:23
    |
-LL |     let c = other::C(2, 3); //~ ERROR tuple struct `C` is private
-   |                    ^
+LL |     pub struct C(pub isize, isize);
+   |     ------------------------------- `a::C` defined here
+...
+LL |     match c { a::C(_, _b) => {} }
+   |               --------^^-
+   |               |       |
+   |               |       private field
+   |               `a::C` cannot be destructured due to private field
 
-error[E0603]: tuple struct `A` is private
-  --> $DIR/privacy5.rs:95:16
+error[E0451]: field `1` of struct `a::C` is private
+  --> $DIR/privacy5.rs:94:24
    |
-LL |     let other::A(()) = a; //~ ERROR tuple struct `A` is private
-   |                ^
+LL |     pub struct C(pub isize, isize);
+   |     ------------------------------- `a::C` defined here
+...
+LL |     match c { a::C(_a, _b) => {} }
+   |               ---------^^-
+   |               |        |
+   |               |        private field
+   |               `a::C` cannot be destructured due to private field
 
-error[E0603]: tuple struct `A` is private
-  --> $DIR/privacy5.rs:96:16
-   |
-LL |     let other::A(_) = a; //~ ERROR tuple struct `A` is private
-   |                ^
-
-error[E0603]: tuple struct `A` is private
-  --> $DIR/privacy5.rs:97:22
-   |
-LL |     match a { other::A(()) => {} } //~ ERROR tuple struct `A` is private
-   |                      ^
-
-error[E0603]: tuple struct `A` is private
-  --> $DIR/privacy5.rs:98:22
-   |
-LL |     match a { other::A(_) => {} } //~ ERROR tuple struct `A` is private
-   |                      ^
-
-error[E0603]: tuple struct `B` is private
-  --> $DIR/privacy5.rs:100:16
-   |
-LL |     let other::B(_) = b; //~ ERROR tuple struct `B` is private
-   |                ^
-
-error[E0603]: tuple struct `B` is private
-  --> $DIR/privacy5.rs:101:16
-   |
-LL |     let other::B(_b) = b; //~ ERROR tuple struct `B` is private
-   |                ^
-
-error[E0603]: tuple struct `B` is private
-  --> $DIR/privacy5.rs:102:22
-   |
-LL |     match b { other::B(_) => {} } //~ ERROR tuple struct `B` is private
-   |                      ^
-
-error[E0603]: tuple struct `B` is private
-  --> $DIR/privacy5.rs:103:22
-   |
-LL |     match b { other::B(_b) => {} } //~ ERROR tuple struct `B` is private
-   |                      ^
-
-error[E0603]: tuple struct `B` is private
-  --> $DIR/privacy5.rs:104:22
-   |
-LL |     match b { other::B(1) => {} other::B(_) => {} } //~ ERROR tuple struct `B` is private
-   |                      ^
-
-error[E0603]: tuple struct `B` is private
-  --> $DIR/privacy5.rs:104:40
-   |
-LL |     match b { other::B(1) => {} other::B(_) => {} } //~ ERROR tuple struct `B` is private
-   |                                        ^
-
-error[E0603]: tuple struct `C` is private
-  --> $DIR/privacy5.rs:107:16
-   |
-LL |     let other::C(_, _) = c; //~ ERROR tuple struct `C` is private
-   |                ^
-
-error[E0603]: tuple struct `C` is private
-  --> $DIR/privacy5.rs:108:16
-   |
-LL |     let other::C(_a, _) = c; //~ ERROR tuple struct `C` is private
-   |                ^
-
-error[E0603]: tuple struct `C` is private
-  --> $DIR/privacy5.rs:109:16
-   |
-LL |     let other::C(_, _b) = c; //~ ERROR tuple struct `C` is private
-   |                ^
-
-error[E0603]: tuple struct `C` is private
-  --> $DIR/privacy5.rs:110:16
-   |
-LL |     let other::C(_a, _b) = c; //~ ERROR tuple struct `C` is private
-   |                ^
-
-error[E0603]: tuple struct `C` is private
-  --> $DIR/privacy5.rs:111:22
-   |
-LL |     match c { other::C(_, _) => {} } //~ ERROR tuple struct `C` is private
-   |                      ^
-
-error[E0603]: tuple struct `C` is private
-  --> $DIR/privacy5.rs:112:22
-   |
-LL |     match c { other::C(_a, _) => {} } //~ ERROR tuple struct `C` is private
-   |                      ^
-
-error[E0603]: tuple struct `C` is private
+error[E0451]: field `0` of struct `other::A` is private
   --> $DIR/privacy5.rs:113:22
    |
-LL |     match c { other::C(_, _b) => {} } //~ ERROR tuple struct `C` is private
-   |                      ^
-
-error[E0603]: tuple struct `C` is private
-  --> $DIR/privacy5.rs:114:22
+LL |     let a = other::A(());
+   |             -------- ^^ private field
+   |             |
+   |             `other::A` cannot be built due to private field
+   | 
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:1:1
    |
-LL |     match c { other::C(_a, _b) => {} } //~ ERROR tuple struct `C` is private
-   |                      ^
+LL | pub struct A(());
+   | ----------------- `other::A` defined here
 
-error[E0603]: tuple struct `A` is private
-  --> $DIR/privacy5.rs:122:21
+error[E0451]: field `0` of struct `other::B` is private
+  --> $DIR/privacy5.rs:115:22
    |
-LL |     let a2 = other::A; //~ ERROR tuple struct `A` is private
-   |                     ^
+LL |     let b = other::B(2);
+   |             -------- ^ private field
+   |             |
+   |             `other::B` cannot be built due to private field
+   | 
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:1
+   |
+LL | pub struct B(isize);
+   | -------------------- `other::B` defined here
 
-error[E0603]: tuple struct `B` is private
-  --> $DIR/privacy5.rs:123:21
+error[E0451]: field `1` of struct `other::C` is private
+  --> $DIR/privacy5.rs:117:25
    |
-LL |     let b2 = other::B; //~ ERROR tuple struct `B` is private
-   |                     ^
+LL |     let c = other::C(2, 3);
+   |             --------    ^ private field
+   |             |
+   |             `other::C` cannot be built due to private field
+   | 
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:1
+   |
+LL | pub struct C(pub isize, isize);
+   | ------------------------------- `other::C` defined here
 
-error[E0603]: tuple struct `C` is private
-  --> $DIR/privacy5.rs:124:21
+error[E0451]: field `0` of struct `other::A` is private
+  --> $DIR/privacy5.rs:121:18
    |
-LL |     let c2 = other::C; //~ ERROR tuple struct `C` is private
-   |                     ^
+LL |     let other::A(()) = a;
+   |         ---------^^-
+   |         |        |
+   |         |        private field
+   |         `other::A` cannot be destructured due to private field
+   | 
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:1:1
+   |
+LL | pub struct A(());
+   | ----------------- `other::A` defined here
+
+error[E0451]: field `0` of struct `other::A` is private
+  --> $DIR/privacy5.rs:123:18
+   |
+LL |     let other::A(_) = a;
+   |         ---------^-
+   |         |        |
+   |         |        private field
+   |         `other::A` cannot be destructured due to private field
+   | 
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:1:1
+   |
+LL | pub struct A(());
+   | ----------------- `other::A` defined here
+
+error[E0451]: field `0` of struct `other::A` is private
+  --> $DIR/privacy5.rs:125:24
+   |
+LL |     match a { other::A(()) => {} }
+   |               ---------^^-
+   |               |        |
+   |               |        private field
+   |               `other::A` cannot be destructured due to private field
+   | 
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:1:1
+   |
+LL | pub struct A(());
+   | ----------------- `other::A` defined here
+
+error[E0451]: field `0` of struct `other::A` is private
+  --> $DIR/privacy5.rs:127:24
+   |
+LL |     match a { other::A(_) => {} }
+   |               ---------^-
+   |               |        |
+   |               |        private field
+   |               `other::A` cannot be destructured due to private field
+   | 
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:1:1
+   |
+LL | pub struct A(());
+   | ----------------- `other::A` defined here
+
+error[E0451]: field `0` of struct `other::B` is private
+  --> $DIR/privacy5.rs:130:18
+   |
+LL |     let other::B(_) = b;
+   |         ---------^-
+   |         |        |
+   |         |        private field
+   |         `other::B` cannot be destructured due to private field
+   | 
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:1
+   |
+LL | pub struct B(isize);
+   | -------------------- `other::B` defined here
+
+error[E0451]: field `0` of struct `other::B` is private
+  --> $DIR/privacy5.rs:132:18
+   |
+LL |     let other::B(_b) = b;
+   |         ---------^^-
+   |         |        |
+   |         |        private field
+   |         `other::B` cannot be destructured due to private field
+   | 
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:1
+   |
+LL | pub struct B(isize);
+   | -------------------- `other::B` defined here
+
+error[E0451]: field `0` of struct `other::B` is private
+  --> $DIR/privacy5.rs:134:24
+   |
+LL |     match b { other::B(_) => {} }
+   |               ---------^-
+   |               |        |
+   |               |        private field
+   |               `other::B` cannot be destructured due to private field
+   | 
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:1
+   |
+LL | pub struct B(isize);
+   | -------------------- `other::B` defined here
+
+error[E0451]: field `0` of struct `other::B` is private
+  --> $DIR/privacy5.rs:136:24
+   |
+LL |     match b { other::B(_b) => {} }
+   |               ---------^^-
+   |               |        |
+   |               |        private field
+   |               `other::B` cannot be destructured due to private field
+   | 
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:1
+   |
+LL | pub struct B(isize);
+   | -------------------- `other::B` defined here
+
+error[E0451]: field `0` of struct `other::B` is private
+  --> $DIR/privacy5.rs:138:24
+   |
+LL |     match b { other::B(1) => {} other::B(_) => {} }
+   |               ---------^-
+   |               |        |
+   |               |        private field
+   |               `other::B` cannot be destructured due to private field
+   | 
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:1
+   |
+LL | pub struct B(isize);
+   | -------------------- `other::B` defined here
+
+error[E0451]: field `0` of struct `other::B` is private
+  --> $DIR/privacy5.rs:138:42
+   |
+LL |     match b { other::B(1) => {} other::B(_) => {} }
+   |                                 ---------^-
+   |                                 |        |
+   |                                 |        private field
+   |                                 `other::B` cannot be destructured due to private field
+   | 
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:1
+   |
+LL | pub struct B(isize);
+   | -------------------- `other::B` defined here
+
+error[E0451]: field `1` of struct `other::C` is private
+  --> $DIR/privacy5.rs:142:21
+   |
+LL |     let other::C(_, _) = c;
+   |         ------------^-
+   |         |           |
+   |         |           private field
+   |         `other::C` cannot be destructured due to private field
+   | 
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:1
+   |
+LL | pub struct C(pub isize, isize);
+   | ------------------------------- `other::C` defined here
+
+error[E0451]: field `1` of struct `other::C` is private
+  --> $DIR/privacy5.rs:144:22
+   |
+LL |     let other::C(_a, _) = c;
+   |         -------------^-
+   |         |            |
+   |         |            private field
+   |         `other::C` cannot be destructured due to private field
+   | 
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:1
+   |
+LL | pub struct C(pub isize, isize);
+   | ------------------------------- `other::C` defined here
+
+error[E0451]: field `1` of struct `other::C` is private
+  --> $DIR/privacy5.rs:146:21
+   |
+LL |     let other::C(_, _b) = c;
+   |         ------------^^-
+   |         |           |
+   |         |           private field
+   |         `other::C` cannot be destructured due to private field
+   | 
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:1
+   |
+LL | pub struct C(pub isize, isize);
+   | ------------------------------- `other::C` defined here
+
+error[E0451]: field `1` of struct `other::C` is private
+  --> $DIR/privacy5.rs:148:22
+   |
+LL |     let other::C(_a, _b) = c;
+   |         -------------^^-
+   |         |            |
+   |         |            private field
+   |         `other::C` cannot be destructured due to private field
+   | 
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:1
+   |
+LL | pub struct C(pub isize, isize);
+   | ------------------------------- `other::C` defined here
+
+error[E0451]: field `1` of struct `other::C` is private
+  --> $DIR/privacy5.rs:150:27
+   |
+LL |     match c { other::C(_, _) => {} }
+   |               ------------^-
+   |               |           |
+   |               |           private field
+   |               `other::C` cannot be destructured due to private field
+   | 
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:1
+   |
+LL | pub struct C(pub isize, isize);
+   | ------------------------------- `other::C` defined here
+
+error[E0451]: field `1` of struct `other::C` is private
+  --> $DIR/privacy5.rs:152:28
+   |
+LL |     match c { other::C(_a, _) => {} }
+   |               -------------^-
+   |               |            |
+   |               |            private field
+   |               `other::C` cannot be destructured due to private field
+   | 
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:1
+   |
+LL | pub struct C(pub isize, isize);
+   | ------------------------------- `other::C` defined here
+
+error[E0451]: field `1` of struct `other::C` is private
+  --> $DIR/privacy5.rs:154:27
+   |
+LL |     match c { other::C(_, _b) => {} }
+   |               ------------^^-
+   |               |           |
+   |               |           private field
+   |               `other::C` cannot be destructured due to private field
+   | 
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:1
+   |
+LL | pub struct C(pub isize, isize);
+   | ------------------------------- `other::C` defined here
+
+error[E0451]: field `1` of struct `other::C` is private
+  --> $DIR/privacy5.rs:156:28
+   |
+LL |     match c { other::C(_a, _b) => {} }
+   |               -------------^^-
+   |               |            |
+   |               |            private field
+   |               `other::C` cannot be destructured due to private field
+   | 
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:1
+   |
+LL | pub struct C(pub isize, isize);
+   | ------------------------------- `other::C` defined here
+
+error: tuple struct `a::A` is private
+  --> $DIR/privacy5.rs:103:14
+   |
+LL |     let a2 = a::A;
+   |              ^^^^ tuple struct not accesssible from here
+
+error: tuple struct `a::B` is private
+  --> $DIR/privacy5.rs:105:14
+   |
+LL |     let b2 = a::B;
+   |              ^^^^ tuple struct not accesssible from here
+
+error: tuple struct `a::C` is private
+  --> $DIR/privacy5.rs:107:14
+   |
+LL |     let c2 = a::C;
+   |              ^^^^ tuple struct not accesssible from here
+
+error: struct `other::A` is private
+  --> $DIR/privacy5.rs:165:14
+   |
+LL |     let a2 = other::A;
+   |              ^^^^^^^^ private
+
+error: struct `other::B` is private
+  --> $DIR/privacy5.rs:167:14
+   |
+LL |     let b2 = other::B;
+   |              ^^^^^^^^ private
+
+error: struct `other::C` is private
+  --> $DIR/privacy5.rs:169:14
+   |
+LL |     let c2 = other::C;
+   |              ^^^^^^^^ private
 
 error: aborting due to 48 previous errors
 
-For more information about this error, try `rustc --explain E0603`.
+For more information about this error, try `rustc --explain E0451`.

--- a/src/test/ui/privacy/private-in-public-non-principal-2.stderr
+++ b/src/test/ui/privacy/private-in-public-non-principal-2.stderr
@@ -2,7 +2,7 @@ error: trait `m::PrivNonPrincipal` is private
   --> $DIR/private-in-public-non-principal-2.rs:11:5
    |
 LL |     m::leak_dyn_nonprincipal();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ private
 
 error: aborting due to previous error
 

--- a/src/test/ui/privacy/private-inferred-type-1.rs
+++ b/src/test/ui/privacy/private-inferred-type-1.rs
@@ -13,6 +13,6 @@ mod m {
 }
 
 fn main() {
-    [].arr0_secret(); //~ ERROR type `m::Priv` is private
-    None.ty_param_secret(); //~ ERROR type `m::Priv` is private
+    [].arr0_secret(); //~ ERROR struct `m::Priv` is private
+    None.ty_param_secret(); //~ ERROR struct `m::Priv` is private
 }

--- a/src/test/ui/privacy/private-inferred-type-1.stderr
+++ b/src/test/ui/privacy/private-inferred-type-1.stderr
@@ -1,14 +1,14 @@
-error: type `m::Priv` is private
+error: struct `m::Priv` is private
   --> $DIR/private-inferred-type-1.rs:16:5
    |
-LL |     [].arr0_secret(); //~ ERROR type `m::Priv` is private
-   |     ^^^^^^^^^^^^^^^^
+LL |     [].arr0_secret(); //~ ERROR struct `m::Priv` is private
+   |     ^^^^^^^^^^^^^^^^ private
 
-error: type `m::Priv` is private
+error: struct `m::Priv` is private
   --> $DIR/private-inferred-type-1.rs:17:5
    |
-LL |     None.ty_param_secret(); //~ ERROR type `m::Priv` is private
-   |     ^^^^^^^^^^^^^^^^^^^^^^
+LL |     None.ty_param_secret(); //~ ERROR struct `m::Priv` is private
+   |     ^^^^^^^^^^^^^^^^^^^^^^ private
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/privacy/private-inferred-type-2.rs
+++ b/src/test/ui/privacy/private-inferred-type-2.rs
@@ -13,7 +13,7 @@ mod m {
 }
 
 fn main() {
-    m::Pub::get_priv; //~ ERROR type `m::Priv` is private
-    m::Pub::static_method; //~ ERROR type `m::Priv` is private
-    ext::Pub::static_method; //~ ERROR type `ext::Priv` is private
+    m::Pub::get_priv; //~ ERROR struct `m::Priv` is private
+    m::Pub::static_method; //~ ERROR struct `m::Priv` is private
+    ext::Pub::static_method; //~ ERROR struct `ext::Priv` is private
 }

--- a/src/test/ui/privacy/private-inferred-type-2.stderr
+++ b/src/test/ui/privacy/private-inferred-type-2.stderr
@@ -1,20 +1,20 @@
-error: type `m::Priv` is private
+error: struct `m::Priv` is private
   --> $DIR/private-inferred-type-2.rs:16:5
    |
-LL |     m::Pub::get_priv; //~ ERROR type `m::Priv` is private
-   |     ^^^^^^^^^^^^^^^^
+LL |     m::Pub::get_priv; //~ ERROR struct `m::Priv` is private
+   |     ^^^^^^^^^^^^^^^^ private
 
-error: type `m::Priv` is private
+error: struct `m::Priv` is private
   --> $DIR/private-inferred-type-2.rs:17:5
    |
-LL |     m::Pub::static_method; //~ ERROR type `m::Priv` is private
-   |     ^^^^^^^^^^^^^^^^^^^^^
+LL |     m::Pub::static_method; //~ ERROR struct `m::Priv` is private
+   |     ^^^^^^^^^^^^^^^^^^^^^ private
 
-error: type `ext::Priv` is private
+error: struct `ext::Priv` is private
   --> $DIR/private-inferred-type-2.rs:18:5
    |
-LL |     ext::Pub::static_method; //~ ERROR type `ext::Priv` is private
-   |     ^^^^^^^^^^^^^^^^^^^^^^^
+LL |     ext::Pub::static_method; //~ ERROR struct `ext::Priv` is private
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ private
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/privacy/private-inferred-type-3.rs
+++ b/src/test/ui/privacy/private-inferred-type-3.rs
@@ -1,12 +1,12 @@
 // aux-build:private-inferred-type.rs
 
-// error-pattern:type `fn() {ext::priv_fn}` is private
+// error-pattern:function `ext::priv_fn` is private
 // error-pattern:static `PRIV_STATIC` is private
-// error-pattern:type `ext::PrivEnum` is private
-// error-pattern:type `fn() {<u8 as ext::PrivTrait>::method}` is private
-// error-pattern:type `fn(u8) -> ext::PrivTupleStruct {ext::PrivTupleStruct}` is private
-// error-pattern:type `fn(u8) -> ext::PubTupleStruct {ext::PubTupleStruct}` is private
-// error-pattern:type `for<'r> fn(&'r ext::Pub<u8>) {<ext::Pub<u8>>::priv_method}` is private
+// error-pattern:enum `ext::PrivEnum` is private
+// error-pattern:method `ext::PrivTrait::method` is private
+// error-pattern:struct `ext::PrivTupleStruct` is private
+// error-pattern:struct `ext::PubTupleStruct` is private
+// error-pattern:method `<ext::Pub<u8>>::priv_method` is private
 
 #![feature(decl_macro)]
 

--- a/src/test/ui/privacy/private-inferred-type-3.stderr
+++ b/src/test/ui/privacy/private-inferred-type-3.stderr
@@ -1,8 +1,8 @@
-error: type `fn() {ext::priv_fn}` is private
+error: function `ext::priv_fn` is private
   --> $DIR/private-inferred-type-3.rs:16:5
    |
 LL |     ext::m!();
-   |     ^^^^^^^^^^
+   |     ^^^^^^^^^^ private
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
@@ -10,47 +10,47 @@ error: static `PRIV_STATIC` is private
   --> $DIR/private-inferred-type-3.rs:16:5
    |
 LL |     ext::m!();
-   |     ^^^^^^^^^^
+   |     ^^^^^^^^^^ static not accessible from here
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
-error: type `ext::PrivEnum` is private
+error: enum `ext::PrivEnum` is private
   --> $DIR/private-inferred-type-3.rs:16:5
    |
 LL |     ext::m!();
-   |     ^^^^^^^^^^
+   |     ^^^^^^^^^^ private
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
-error: type `fn() {<u8 as ext::PrivTrait>::method}` is private
+error: method `ext::PrivTrait::method` is private
   --> $DIR/private-inferred-type-3.rs:16:5
    |
 LL |     ext::m!();
-   |     ^^^^^^^^^^
+   |     ^^^^^^^^^^ private
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
-error: type `fn(u8) -> ext::PrivTupleStruct {ext::PrivTupleStruct}` is private
+error: struct `ext::PrivTupleStruct` is private
   --> $DIR/private-inferred-type-3.rs:16:5
    |
 LL |     ext::m!();
-   |     ^^^^^^^^^^
+   |     ^^^^^^^^^^ private
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
-error: type `fn(u8) -> ext::PubTupleStruct {ext::PubTupleStruct}` is private
+error: struct `ext::PubTupleStruct` is private
   --> $DIR/private-inferred-type-3.rs:16:5
    |
 LL |     ext::m!();
-   |     ^^^^^^^^^^
+   |     ^^^^^^^^^^ private
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
-error: type `for<'r> fn(&'r ext::Pub<u8>) {<ext::Pub<u8>>::priv_method}` is private
+error: method `<ext::Pub<u8>>::priv_method` is private
   --> $DIR/private-inferred-type-3.rs:16:5
    |
 LL |     ext::m!();
-   |     ^^^^^^^^^^
+   |     ^^^^^^^^^^ private
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 

--- a/src/test/ui/privacy/private-inferred-type-4.rs
+++ b/src/test/ui/privacy/private-inferred-type-4.rs
@@ -1,0 +1,17 @@
+#![feature(associated_consts)]
+#![feature(decl_macro)]
+#![allow(private_in_public)]
+
+mod m {
+    pub struct PubTupleStruct(u8);
+    impl PubTupleStruct { fn method() {} }
+
+    pub macro m() {
+        PubTupleStruct;
+        //~^ ERROR tuple struct `PubTupleStruct` is private
+    }
+}
+
+fn main() {
+    m::m!();
+}

--- a/src/test/ui/privacy/private-inferred-type-4.stderr
+++ b/src/test/ui/privacy/private-inferred-type-4.stderr
@@ -1,0 +1,11 @@
+error: tuple struct `PubTupleStruct` is private
+  --> $DIR/private-inferred-type-4.rs:10:9
+   |
+LL |         PubTupleStruct;
+   |         ^^^^^^^^^^^^^^ tuple struct not accesssible from here
+...
+LL |     m::m!();
+   |     -------- in this macro invocation
+
+error: aborting due to previous error
+

--- a/src/test/ui/privacy/private-inferred-type.rs
+++ b/src/test/ui/privacy/private-inferred-type.rs
@@ -12,8 +12,6 @@ mod m {
     pub trait PubTrait { fn method() {} }
     impl PubTrait for u8 {}
     struct PrivTupleStruct(u8);
-    pub struct PubTupleStruct(u8);
-    impl PubTupleStruct { fn method() {} }
 
     struct Priv;
     pub type Alias = Priv;
@@ -36,18 +34,16 @@ mod m {
     impl TraitWithAssocTy for Priv { type AssocTy = u8; }
 
     pub macro m() {
-        priv_fn; //~ ERROR type `fn() {m::priv_fn}` is private
+        priv_fn; //~ ERROR function `m::priv_fn` is private
         PRIV_STATIC; // OK, not cross-crate
-        PrivEnum::Variant; //~ ERROR type `m::PrivEnum` is private
+        PrivEnum::Variant; //~ ERROR enum `m::PrivEnum` is private
         PubEnum::Variant; // OK
-        <u8 as PrivTrait>::method; //~ ERROR type `fn() {<u8 as m::PrivTrait>::method}` is private
+        <u8 as PrivTrait>::method; //~ ERROR method `m::PrivTrait::method` is private
         <u8 as PubTrait>::method; // OK
         PrivTupleStruct;
-        //~^ ERROR type `fn(u8) -> m::PrivTupleStruct {m::PrivTupleStruct}` is private
-        PubTupleStruct;
-        //~^ ERROR type `fn(u8) -> m::PubTupleStruct {m::PubTupleStruct}` is private
+        //~^ ERROR struct `m::PrivTupleStruct` is private
         Pub(0u8).priv_method();
-        //~^ ERROR type `for<'r> fn(&'r m::Pub<u8>) {<m::Pub<u8>>::priv_method}` is private
+        //~^ ERROR method `<m::Pub<u8>>::priv_method` is private
     }
 
     trait Trait {}
@@ -94,40 +90,43 @@ mod adjust {
 }
 
 fn main() {
-    let _: m::Alias; //~ ERROR type `m::Priv` is private
-                     //~^ ERROR type `m::Priv` is private
-    let _: <m::Alias as m::TraitWithAssocTy>::AssocTy; //~ ERROR type `m::Priv` is private
-    m::Alias {}; //~ ERROR type `m::Priv` is private
-    m::Pub { 0: m::Alias {} }; //~ ERROR type `m::Priv` is private
+    let _: m::Alias;
+    //~^ ERROR struct `m::Priv` is private
+    //~| ERROR struct `m::Priv` is private
+    let _: <m::Alias as m::TraitWithAssocTy>::AssocTy;
+    //~^ ERROR struct `m::Priv` is private
+    m::Alias {};
+    //~^ ERROR struct `m::Priv` is private
+    m::Pub { 0: m::Alias {} }; //~ ERROR struct `m::Priv` is private
     m::Pub { 0: loop {} }; // OK, `m::Pub` is in value context, so it means Pub<_>, not Pub<Priv>
-    m::Pub::static_method; //~ ERROR type `m::Priv` is private
-    m::Pub::INHERENT_ASSOC_CONST; //~ ERROR type `m::Priv` is private
-    m::Pub(0u8).method_with_substs::<m::Alias>(); //~ ERROR type `m::Priv` is private
-    m::Pub(0u8).method_with_priv_params(loop{}); //~ ERROR type `m::Priv` is private
-    <m::Alias as m::TraitWithAssocConst>::TRAIT_ASSOC_CONST; //~ ERROR type `m::Priv` is private
-    <m::Pub<m::Alias>>::INHERENT_ASSOC_CONST; //~ ERROR type `m::Priv` is private
-    <m::Pub<m::Alias>>::INHERENT_ASSOC_CONST_GENERIC_SELF; //~ ERROR type `m::Priv` is private
-    <m::Pub<m::Alias>>::static_method_generic_self; //~ ERROR type `m::Priv` is private
+    m::Pub::static_method; //~ ERROR struct `m::Priv` is private
+    m::Pub::INHERENT_ASSOC_CONST; //~ ERROR struct `m::Priv` is private
+    m::Pub(0u8).method_with_substs::<m::Alias>(); //~ ERROR struct `m::Priv` is private
+    m::Pub(0u8).method_with_priv_params(loop{}); //~ ERROR struct `m::Priv` is private
+    <m::Alias as m::TraitWithAssocConst>::TRAIT_ASSOC_CONST; //~ ERROR struct `m::Priv` is private
+    <m::Pub<m::Alias>>::INHERENT_ASSOC_CONST; //~ ERROR struct `m::Priv` is private
+    <m::Pub<m::Alias>>::INHERENT_ASSOC_CONST_GENERIC_SELF; //~ ERROR struct `m::Priv` is private
+    <m::Pub<m::Alias>>::static_method_generic_self; //~ ERROR struct `m::Priv` is private
     use m::TraitWithTyParam2;
-    u8::pub_method; //~ ERROR type `m::Priv` is private
+    u8::pub_method; //~ ERROR struct `m::Priv` is private
 
-    adjust::S1.method_s3(); //~ ERROR type `adjust::S2` is private
+    adjust::S1.method_s3(); //~ ERROR struct `adjust::S2` is private
 
     m::m!();
 
     m::leak_anon1(); //~ ERROR trait `m::Trait` is private
-    m::leak_anon2(); //~ ERROR type `m::Priv` is private
-    m::leak_anon3(); //~ ERROR type `m::Priv` is private
+    m::leak_anon2(); //~ ERROR struct `m::Priv` is private
+    m::leak_anon3(); //~ ERROR struct `m::Priv` is private
 
     m::leak_dyn1(); //~ ERROR trait `m::Trait` is private
-    m::leak_dyn2(); //~ ERROR type `m::Priv` is private
-    m::leak_dyn3(); //~ ERROR type `m::Priv` is private
+    m::leak_dyn2(); //~ ERROR struct `m::Priv` is private
+    m::leak_dyn3(); //~ ERROR struct `m::Priv` is private
 
     // Check that messages are not duplicated for various kinds of assignments
-    let a = m::Alias {}; //~ ERROR type `m::Priv` is private
-    let mut b = a; //~ ERROR type `m::Priv` is private
-    b = a; //~ ERROR type `m::Priv` is private
-    match a { //~ ERROR type `m::Priv` is private
+    let a = m::Alias {}; //~ ERROR struct `m::Priv` is private
+    let mut b = a; //~ ERROR struct `m::Priv` is private
+    b = a; //~ ERROR struct `m::Priv` is private
+    match a { //~ ERROR struct `m::Priv` is private
         _ => {}
     }
 }

--- a/src/test/ui/privacy/private-inferred-type.stderr
+++ b/src/test/ui/privacy/private-inferred-type.stderr
@@ -1,209 +1,200 @@
-error: type `m::Priv` is private
-  --> $DIR/private-inferred-type.rs:97:9
+error: struct `m::Priv` is private
+  --> $DIR/private-inferred-type.rs:93:9
    |
-LL |     let _: m::Alias; //~ ERROR type `m::Priv` is private
-   |         ^
+LL |     let _: m::Alias;
+   |         ^ private
 
-error: type `m::Priv` is private
-  --> $DIR/private-inferred-type.rs:97:12
+error: struct `m::Priv` is private
+  --> $DIR/private-inferred-type.rs:93:12
    |
-LL |     let _: m::Alias; //~ ERROR type `m::Priv` is private
-   |            ^^^^^^^^
+LL |     let _: m::Alias;
+   |            ^^^^^^^^ private
 
-error: type `m::Priv` is private
-  --> $DIR/private-inferred-type.rs:99:13
+error: struct `m::Priv` is private
+  --> $DIR/private-inferred-type.rs:96:13
    |
-LL |     let _: <m::Alias as m::TraitWithAssocTy>::AssocTy; //~ ERROR type `m::Priv` is private
-   |             ^^^^^^^^
+LL |     let _: <m::Alias as m::TraitWithAssocTy>::AssocTy;
+   |             ^^^^^^^^ private
 
-error: type `m::Priv` is private
+error: struct `m::Priv` is private
+  --> $DIR/private-inferred-type.rs:98:5
+   |
+LL |     m::Alias {};
+   |     ^^^^^^^^^^^ private
+
+error: struct `m::Priv` is private
   --> $DIR/private-inferred-type.rs:100:5
    |
-LL |     m::Alias {}; //~ ERROR type `m::Priv` is private
-   |     ^^^^^^^^^^^
+LL |     m::Pub { 0: m::Alias {} }; //~ ERROR struct `m::Priv` is private
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ private
 
-error: type `m::Priv` is private
-  --> $DIR/private-inferred-type.rs:101:5
+error: struct `m::Priv` is private
+  --> $DIR/private-inferred-type.rs:102:5
    |
-LL |     m::Pub { 0: m::Alias {} }; //~ ERROR type `m::Priv` is private
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     m::Pub::static_method; //~ ERROR struct `m::Priv` is private
+   |     ^^^^^^^^^^^^^^^^^^^^^ private
 
-error: type `m::Priv` is private
+error: struct `m::Priv` is private
   --> $DIR/private-inferred-type.rs:103:5
    |
-LL |     m::Pub::static_method; //~ ERROR type `m::Priv` is private
-   |     ^^^^^^^^^^^^^^^^^^^^^
+LL |     m::Pub::INHERENT_ASSOC_CONST; //~ ERROR struct `m::Priv` is private
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private
 
-error: type `m::Priv` is private
+error: struct `m::Priv` is private
   --> $DIR/private-inferred-type.rs:104:5
    |
-LL |     m::Pub::INHERENT_ASSOC_CONST; //~ ERROR type `m::Priv` is private
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     m::Pub(0u8).method_with_substs::<m::Alias>(); //~ ERROR struct `m::Priv` is private
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private
 
-error: type `m::Priv` is private
-  --> $DIR/private-inferred-type.rs:105:5
+error: struct `m::Priv` is private
+  --> $DIR/private-inferred-type.rs:105:17
    |
-LL |     m::Pub(0u8).method_with_substs::<m::Alias>(); //~ ERROR type `m::Priv` is private
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     m::Pub(0u8).method_with_priv_params(loop{}); //~ ERROR struct `m::Priv` is private
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^ private
 
-error: type `m::Priv` is private
-  --> $DIR/private-inferred-type.rs:106:17
+error: struct `m::Priv` is private
+  --> $DIR/private-inferred-type.rs:106:5
    |
-LL |     m::Pub(0u8).method_with_priv_params(loop{}); //~ ERROR type `m::Priv` is private
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^
+LL |     <m::Alias as m::TraitWithAssocConst>::TRAIT_ASSOC_CONST; //~ ERROR struct `m::Priv` is private
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private
 
-error: type `m::Priv` is private
-  --> $DIR/private-inferred-type.rs:107:5
+error: struct `m::Priv` is private
+  --> $DIR/private-inferred-type.rs:107:6
    |
-LL |     <m::Alias as m::TraitWithAssocConst>::TRAIT_ASSOC_CONST; //~ ERROR type `m::Priv` is private
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     <m::Pub<m::Alias>>::INHERENT_ASSOC_CONST; //~ ERROR struct `m::Priv` is private
+   |      ^^^^^^^^^^^^^^^^ private
 
-error: type `m::Priv` is private
-  --> $DIR/private-inferred-type.rs:108:6
+error: struct `m::Priv` is private
+  --> $DIR/private-inferred-type.rs:108:5
    |
-LL |     <m::Pub<m::Alias>>::INHERENT_ASSOC_CONST; //~ ERROR type `m::Priv` is private
-   |      ^^^^^^^^^^^^^^^^
+LL |     <m::Pub<m::Alias>>::INHERENT_ASSOC_CONST_GENERIC_SELF; //~ ERROR struct `m::Priv` is private
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private
 
-error: type `m::Priv` is private
+error: struct `m::Priv` is private
   --> $DIR/private-inferred-type.rs:109:5
    |
-LL |     <m::Pub<m::Alias>>::INHERENT_ASSOC_CONST_GENERIC_SELF; //~ ERROR type `m::Priv` is private
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     <m::Pub<m::Alias>>::static_method_generic_self; //~ ERROR struct `m::Priv` is private
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private
 
-error: type `m::Priv` is private
-  --> $DIR/private-inferred-type.rs:110:5
+error: struct `m::Priv` is private
+  --> $DIR/private-inferred-type.rs:111:5
    |
-LL |     <m::Pub<m::Alias>>::static_method_generic_self; //~ ERROR type `m::Priv` is private
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     u8::pub_method; //~ ERROR struct `m::Priv` is private
+   |     ^^^^^^^^^^^^^^ private
 
-error: type `m::Priv` is private
-  --> $DIR/private-inferred-type.rs:112:5
+error: struct `adjust::S2` is private
+  --> $DIR/private-inferred-type.rs:113:5
    |
-LL |     u8::pub_method; //~ ERROR type `m::Priv` is private
-   |     ^^^^^^^^^^^^^^
+LL |     adjust::S1.method_s3(); //~ ERROR struct `adjust::S2` is private
+   |     ^^^^^^^^^^ private
 
-error: type `adjust::S2` is private
-  --> $DIR/private-inferred-type.rs:114:5
+error: function `m::priv_fn` is private
+  --> $DIR/private-inferred-type.rs:37:9
    |
-LL |     adjust::S1.method_s3(); //~ ERROR type `adjust::S2` is private
-   |     ^^^^^^^^^^
+LL |         priv_fn; //~ ERROR function `m::priv_fn` is private
+   |         ^^^^^^^ private
+...
+LL |     m::m!();
+   |     -------- in this macro invocation
 
-error: type `fn() {m::priv_fn}` is private
+error: enum `m::PrivEnum` is private
   --> $DIR/private-inferred-type.rs:39:9
    |
-LL |         priv_fn; //~ ERROR type `fn() {m::priv_fn}` is private
-   |         ^^^^^^^
+LL |         PrivEnum::Variant; //~ ERROR enum `m::PrivEnum` is private
+   |         ^^^^^^^^^^^^^^^^^ private
 ...
 LL |     m::m!();
    |     -------- in this macro invocation
 
-error: type `m::PrivEnum` is private
+error: method `m::PrivTrait::method` is private
   --> $DIR/private-inferred-type.rs:41:9
    |
-LL |         PrivEnum::Variant; //~ ERROR type `m::PrivEnum` is private
-   |         ^^^^^^^^^^^^^^^^^
+LL |         <u8 as PrivTrait>::method; //~ ERROR method `m::PrivTrait::method` is private
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^ private
 ...
 LL |     m::m!();
    |     -------- in this macro invocation
 
-error: type `fn() {<u8 as m::PrivTrait>::method}` is private
+error: struct `m::PrivTupleStruct` is private
   --> $DIR/private-inferred-type.rs:43:9
    |
-LL |         <u8 as PrivTrait>::method; //~ ERROR type `fn() {<u8 as m::PrivTrait>::method}` is private
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
-...
-LL |     m::m!();
-   |     -------- in this macro invocation
-
-error: type `fn(u8) -> m::PrivTupleStruct {m::PrivTupleStruct}` is private
-  --> $DIR/private-inferred-type.rs:45:9
-   |
 LL |         PrivTupleStruct;
-   |         ^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^ private
 ...
 LL |     m::m!();
    |     -------- in this macro invocation
 
-error: type `fn(u8) -> m::PubTupleStruct {m::PubTupleStruct}` is private
-  --> $DIR/private-inferred-type.rs:47:9
-   |
-LL |         PubTupleStruct;
-   |         ^^^^^^^^^^^^^^
-...
-LL |     m::m!();
-   |     -------- in this macro invocation
-
-error: type `for<'r> fn(&'r m::Pub<u8>) {<m::Pub<u8>>::priv_method}` is private
-  --> $DIR/private-inferred-type.rs:49:18
+error: method `<m::Pub<u8>>::priv_method` is private
+  --> $DIR/private-inferred-type.rs:45:18
    |
 LL |         Pub(0u8).priv_method();
-   |                  ^^^^^^^^^^^
+   |                  ^^^^^^^^^^^ private
 ...
 LL |     m::m!();
    |     -------- in this macro invocation
 
 error: trait `m::Trait` is private
-  --> $DIR/private-inferred-type.rs:118:5
+  --> $DIR/private-inferred-type.rs:117:5
    |
 LL |     m::leak_anon1(); //~ ERROR trait `m::Trait` is private
-   |     ^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^ private
 
-error: type `m::Priv` is private
+error: struct `m::Priv` is private
+  --> $DIR/private-inferred-type.rs:118:5
+   |
+LL |     m::leak_anon2(); //~ ERROR struct `m::Priv` is private
+   |     ^^^^^^^^^^^^^^^ private
+
+error: struct `m::Priv` is private
   --> $DIR/private-inferred-type.rs:119:5
    |
-LL |     m::leak_anon2(); //~ ERROR type `m::Priv` is private
-   |     ^^^^^^^^^^^^^^^
-
-error: type `m::Priv` is private
-  --> $DIR/private-inferred-type.rs:120:5
-   |
-LL |     m::leak_anon3(); //~ ERROR type `m::Priv` is private
-   |     ^^^^^^^^^^^^^^^
+LL |     m::leak_anon3(); //~ ERROR struct `m::Priv` is private
+   |     ^^^^^^^^^^^^^^^ private
 
 error: trait `m::Trait` is private
-  --> $DIR/private-inferred-type.rs:122:5
+  --> $DIR/private-inferred-type.rs:121:5
    |
 LL |     m::leak_dyn1(); //~ ERROR trait `m::Trait` is private
-   |     ^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^ private
 
-error: type `m::Priv` is private
+error: struct `m::Priv` is private
+  --> $DIR/private-inferred-type.rs:122:5
+   |
+LL |     m::leak_dyn2(); //~ ERROR struct `m::Priv` is private
+   |     ^^^^^^^^^^^^^^ private
+
+error: struct `m::Priv` is private
   --> $DIR/private-inferred-type.rs:123:5
    |
-LL |     m::leak_dyn2(); //~ ERROR type `m::Priv` is private
-   |     ^^^^^^^^^^^^^^
+LL |     m::leak_dyn3(); //~ ERROR struct `m::Priv` is private
+   |     ^^^^^^^^^^^^^^ private
 
-error: type `m::Priv` is private
-  --> $DIR/private-inferred-type.rs:124:5
+error: struct `m::Priv` is private
+  --> $DIR/private-inferred-type.rs:126:13
    |
-LL |     m::leak_dyn3(); //~ ERROR type `m::Priv` is private
-   |     ^^^^^^^^^^^^^^
+LL |     let a = m::Alias {}; //~ ERROR struct `m::Priv` is private
+   |             ^^^^^^^^^^^ private
 
-error: type `m::Priv` is private
-  --> $DIR/private-inferred-type.rs:127:13
+error: struct `m::Priv` is private
+  --> $DIR/private-inferred-type.rs:127:17
    |
-LL |     let a = m::Alias {}; //~ ERROR type `m::Priv` is private
-   |             ^^^^^^^^^^^
+LL |     let mut b = a; //~ ERROR struct `m::Priv` is private
+   |                 ^ private
 
-error: type `m::Priv` is private
-  --> $DIR/private-inferred-type.rs:128:17
+error: struct `m::Priv` is private
+  --> $DIR/private-inferred-type.rs:128:9
    |
-LL |     let mut b = a; //~ ERROR type `m::Priv` is private
-   |                 ^
+LL |     b = a; //~ ERROR struct `m::Priv` is private
+   |         ^ private
 
-error: type `m::Priv` is private
-  --> $DIR/private-inferred-type.rs:129:9
+error: struct `m::Priv` is private
+  --> $DIR/private-inferred-type.rs:129:11
    |
-LL |     b = a; //~ ERROR type `m::Priv` is private
-   |         ^
-
-error: type `m::Priv` is private
-  --> $DIR/private-inferred-type.rs:130:11
-   |
-LL |     match a { //~ ERROR type `m::Priv` is private
-   |           ^
+LL |     match a { //~ ERROR struct `m::Priv` is private
+   |           ^ private
 
 error[E0446]: private type `m::Priv` in public interface
-  --> $DIR/private-inferred-type.rs:61:36
+  --> $DIR/private-inferred-type.rs:57:36
    |
 LL |     struct Priv;
    |     - `m::Priv` declared as private
@@ -212,7 +203,7 @@ LL |     impl TraitWithAssocTy for u8 { type AssocTy = Priv; }
    |                                    ^^^^^^^^^^^^^^^^^^^^ can't leak private type
 
 error[E0446]: private type `adjust::S2` in public interface
-  --> $DIR/private-inferred-type.rs:83:9
+  --> $DIR/private-inferred-type.rs:79:9
    |
 LL |     struct S2;
    |     - `adjust::S2` declared as private
@@ -220,6 +211,6 @@ LL |     struct S2;
 LL |         type Target = S2Alias; //~ ERROR private type `adjust::S2` in public interface
    |         ^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
 
-error: aborting due to 33 previous errors
+error: aborting due to 32 previous errors
 
 For more information about this error, try `rustc --explain E0446`.

--- a/src/test/ui/privacy/private-struct-field-ctor.stderr
+++ b/src/test/ui/privacy/private-struct-field-ctor.stderr
@@ -1,8 +1,16 @@
 error[E0451]: field `x` of struct `a::Foo` is private
   --> $DIR/private-struct-field-ctor.rs:8:22
    |
-LL |     let s = a::Foo { x: 1 };    //~ ERROR field `x` of struct `a::Foo` is private
-   |                      ^^^^ field `x` is private
+LL | /     pub struct Foo {
+LL | |         x: isize
+LL | |     }
+   | |_____- `a::Foo` defined here
+...
+LL |       let s = a::Foo { x: 1 };    //~ ERROR field `x` of struct `a::Foo` is private
+   |               ---------^^^^--
+   |               |        |
+   |               |        private field
+   |               `a::Foo` cannot be built due to private field
 
 error: aborting due to previous error
 

--- a/src/test/ui/privacy/private-struct-field-pattern.stderr
+++ b/src/test/ui/privacy/private-struct-field-pattern.stderr
@@ -1,8 +1,16 @@
 error[E0451]: field `x` of struct `a::Foo` is private
   --> $DIR/private-struct-field-pattern.rs:15:15
    |
-LL |         Foo { x: _ } => {}  //~ ERROR field `x` of struct `a::Foo` is private
-   |               ^^^^ field `x` is private
+LL | /     pub struct Foo {
+LL | |         x: isize
+LL | |     }
+   | |_____- `a::Foo` defined here
+...
+LL |           Foo { x: _ } => {}  //~ ERROR field `x` of struct `a::Foo` is private
+   |           ------^^^^--
+   |           |     |
+   |           |     private field
+   |           `a::Foo` cannot be destructured due to private field
 
 error: aborting due to previous error
 

--- a/src/test/ui/privacy/private-type-in-interface.rs
+++ b/src/test/ui/privacy/private-type-in-interface.rs
@@ -12,19 +12,26 @@ mod m {
     impl Trait for Priv { type X = u8; }
 }
 
-fn f(_: m::Alias) {} //~ ERROR type `m::Priv` is private
-                     //~^ ERROR type `m::Priv` is private
-fn f_ext(_: ext::Alias) {} //~ ERROR type `ext::Priv` is private
-                           //~^ ERROR type `ext::Priv` is private
+fn f(_: m::Alias) {}
+//~^ ERROR struct `m::Priv` is private
+//~| ERROR struct `m::Priv` is private
+fn f_ext(_: ext::Alias) {}
+//~^ ERROR struct `ext::Priv` is private
+//~| ERROR struct `ext::Priv` is private
 
 trait Tr1 {}
-impl m::Alias {} //~ ERROR type `m::Priv` is private
-impl Tr1 for ext::Alias {} //~ ERROR type `ext::Priv` is private
-type A = <m::Alias as m::Trait>::X; //~ ERROR type `m::Priv` is private
+impl m::Alias {}
+//~^ ERROR struct `m::Priv` is private
+impl Tr1 for ext::Alias {}
+//~^ ERROR struct `ext::Priv` is private
+type A = <m::Alias as m::Trait>::X;
+//~^ ERROR struct `m::Priv` is private
 
 trait Tr2<T> {}
 impl<T> Tr2<T> for u8 {}
-fn g() -> impl Tr2<m::Alias> { 0 } //~ ERROR type `m::Priv` is private
-fn g_ext() -> impl Tr2<ext::Alias> { 0 } //~ ERROR type `ext::Priv` is private
+fn g() -> impl Tr2<m::Alias> { 0 }
+//~^ ERROR struct `m::Priv` is private
+fn g_ext() -> impl Tr2<ext::Alias> { 0 }
+//~^ ERROR struct `ext::Priv` is private
 
 fn main() {}

--- a/src/test/ui/privacy/private-type-in-interface.stderr
+++ b/src/test/ui/privacy/private-type-in-interface.stderr
@@ -1,56 +1,56 @@
-error: type `m::Priv` is private
+error: struct `m::Priv` is private
   --> $DIR/private-type-in-interface.rs:15:9
    |
-LL | fn f(_: m::Alias) {} //~ ERROR type `m::Priv` is private
-   |         ^^^^^^^^
+LL | fn f(_: m::Alias) {}
+   |         ^^^^^^^^ private
 
-error: type `m::Priv` is private
+error: struct `m::Priv` is private
   --> $DIR/private-type-in-interface.rs:15:6
    |
-LL | fn f(_: m::Alias) {} //~ ERROR type `m::Priv` is private
-   |      ^
+LL | fn f(_: m::Alias) {}
+   |      ^ private
 
-error: type `ext::Priv` is private
-  --> $DIR/private-type-in-interface.rs:17:13
+error: struct `ext::Priv` is private
+  --> $DIR/private-type-in-interface.rs:18:13
    |
-LL | fn f_ext(_: ext::Alias) {} //~ ERROR type `ext::Priv` is private
-   |             ^^^^^^^^^^
+LL | fn f_ext(_: ext::Alias) {}
+   |             ^^^^^^^^^^ private
 
-error: type `ext::Priv` is private
-  --> $DIR/private-type-in-interface.rs:17:10
+error: struct `ext::Priv` is private
+  --> $DIR/private-type-in-interface.rs:18:10
    |
-LL | fn f_ext(_: ext::Alias) {} //~ ERROR type `ext::Priv` is private
-   |          ^
+LL | fn f_ext(_: ext::Alias) {}
+   |          ^ private
 
-error: type `m::Priv` is private
-  --> $DIR/private-type-in-interface.rs:21:6
+error: struct `m::Priv` is private
+  --> $DIR/private-type-in-interface.rs:23:6
    |
-LL | impl m::Alias {} //~ ERROR type `m::Priv` is private
-   |      ^^^^^^^^
+LL | impl m::Alias {}
+   |      ^^^^^^^^ private
 
-error: type `ext::Priv` is private
-  --> $DIR/private-type-in-interface.rs:22:14
+error: struct `ext::Priv` is private
+  --> $DIR/private-type-in-interface.rs:25:14
    |
-LL | impl Tr1 for ext::Alias {} //~ ERROR type `ext::Priv` is private
-   |              ^^^^^^^^^^
+LL | impl Tr1 for ext::Alias {}
+   |              ^^^^^^^^^^ private
 
-error: type `m::Priv` is private
-  --> $DIR/private-type-in-interface.rs:23:10
+error: struct `m::Priv` is private
+  --> $DIR/private-type-in-interface.rs:27:10
    |
-LL | type A = <m::Alias as m::Trait>::X; //~ ERROR type `m::Priv` is private
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | type A = <m::Alias as m::Trait>::X;
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^ private
 
-error: type `m::Priv` is private
-  --> $DIR/private-type-in-interface.rs:27:11
+error: struct `m::Priv` is private
+  --> $DIR/private-type-in-interface.rs:32:11
    |
-LL | fn g() -> impl Tr2<m::Alias> { 0 } //~ ERROR type `m::Priv` is private
-   |           ^^^^^^^^^^^^^^^^^^
+LL | fn g() -> impl Tr2<m::Alias> { 0 }
+   |           ^^^^^^^^^^^^^^^^^^ private
 
-error: type `ext::Priv` is private
-  --> $DIR/private-type-in-interface.rs:28:15
+error: struct `ext::Priv` is private
+  --> $DIR/private-type-in-interface.rs:34:15
    |
-LL | fn g_ext() -> impl Tr2<ext::Alias> { 0 } //~ ERROR type `ext::Priv` is private
-   |               ^^^^^^^^^^^^^^^^^^^^
+LL | fn g_ext() -> impl Tr2<ext::Alias> { 0 }
+   |               ^^^^^^^^^^^^^^^^^^^^ private
 
 error: aborting due to 9 previous errors
 

--- a/src/test/ui/privacy/restricted/struct-literal-field.stderr
+++ b/src/test/ui/privacy/restricted/struct-literal-field.stderr
@@ -1,8 +1,16 @@
 error[E0451]: field `x` of struct `foo::bar::S` is private
   --> $DIR/struct-literal-field.rs:18:9
    |
-LL |     S { x: 0 }; //~ ERROR private
-   |         ^^^^ field `x` is private
+LL | /         pub struct S {
+LL | |             pub(in foo) x: i32,
+LL | |         }
+   | |_________- `foo::bar::S` defined here
+...
+LL |       S { x: 0 }; //~ ERROR private
+   |       ----^^^^--
+   |       |   |
+   |       |   private field
+   |       `foo::bar::S` cannot be built due to private field
 
 error: aborting due to previous error
 

--- a/src/test/ui/privacy/union-field-privacy-1.stderr
+++ b/src/test/ui/privacy/union-field-privacy-1.stderr
@@ -1,14 +1,34 @@
 error[E0451]: field `c` of union `m::U` is private
   --> $DIR/union-field-privacy-1.rs:12:20
    |
-LL |     let u = m::U { c: 0 }; //~ ERROR field `c` of union `m::U` is private
-   |                    ^^^^ field `c` is private
+LL | /     pub union U {
+LL | |         pub a: u8,
+LL | |         pub(super) b: u8,
+LL | |         c: u8,
+LL | |     }
+   | |_____- `m::U` defined here
+...
+LL |       let u = m::U { c: 0 }; //~ ERROR field `c` of union `m::U` is private
+   |               -------^^^^--
+   |               |      |
+   |               |      private field
+   |               `m::U` cannot be built due to private field
 
 error[E0451]: field `c` of union `m::U` is private
   --> $DIR/union-field-privacy-1.rs:16:16
    |
-LL |     let m::U { c } = u; //~ ERROR field `c` of union `m::U` is private
-   |                ^ field `c` is private
+LL | /     pub union U {
+LL | |         pub a: u8,
+LL | |         pub(super) b: u8,
+LL | |         c: u8,
+LL | |     }
+   | |_____- `m::U` defined here
+...
+LL |       let m::U { c } = u; //~ ERROR field `c` of union `m::U` is private
+   |           -------^--
+   |           |      |
+   |           |      private field
+   |           `m::U` cannot be destructured due to private field
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/resolve/privacy-struct-ctor-2.rs
+++ b/src/test/ui/resolve/privacy-struct-ctor-2.rs
@@ -15,8 +15,8 @@ mod m {
     use m::n::Z; // OK, only the type is imported
 
     fn f() {
-        Z;
-        //~^ ERROR expected value, found struct `Z`
+        n::Z;
+        //~^ ERROR tuple struct `n::Z` is private
     }
 }
 
@@ -24,12 +24,15 @@ use m::S; // OK, only the type is imported
 use m::S2; // OK, only the type is imported
 
 fn main() {
-    S;
-    //~^ ERROR expected value, found struct `S`
+    m::S;
+    //~^ ERROR tuple struct `m::S` is private
+    let _: S = m::S(2);
+    //~^ ERROR field `0` of struct `m::S` is private
+    m::n::Z;
+    //~^ ERROR struct `m::n::Z` is private
 
-    S2;
-    //~^ ERROR expected value, found struct `S2`
-
-    xcrate::S;
-    //~^ ERROR expected value, found struct `xcrate::S`
+    xcrate::m::S;
+    //~^ ERROR struct `xcrate::S` is private
+    xcrate::m::n::Z;
+    //~^ ERROR struct `xcrate::m::n::Z` is private
 }

--- a/src/test/ui/resolve/privacy-struct-ctor-2.stderr
+++ b/src/test/ui/resolve/privacy-struct-ctor-2.stderr
@@ -1,0 +1,44 @@
+error[E0451]: field `0` of struct `m::S` is private
+  --> $DIR/privacy-struct-ctor-2.rs:29:21
+   |
+LL |     pub struct S(u8);
+   |     ----------------- `m::S` defined here
+...
+LL |     let _: S = m::S(2);
+   |                ---- ^ private field
+   |                |
+   |                `m::S` cannot be built due to private field
+
+error: tuple struct `m::S` is private
+  --> $DIR/privacy-struct-ctor-2.rs:27:5
+   |
+LL |     m::S;
+   |     ^^^^ tuple struct not accesssible from here
+
+error: struct `m::n::Z` is private
+  --> $DIR/privacy-struct-ctor-2.rs:31:5
+   |
+LL |     m::n::Z;
+   |     ^^^^^^^ private
+
+error: struct `xcrate::S` is private
+  --> $DIR/privacy-struct-ctor-2.rs:34:5
+   |
+LL |     xcrate::m::S;
+   |     ^^^^^^^^^^^^ private
+
+error: struct `xcrate::m::n::Z` is private
+  --> $DIR/privacy-struct-ctor-2.rs:36:5
+   |
+LL |     xcrate::m::n::Z;
+   |     ^^^^^^^^^^^^^^^ private
+
+error: tuple struct `n::Z` is private
+  --> $DIR/privacy-struct-ctor-2.rs:18:9
+   |
+LL |         n::Z;
+   |         ^^^^ tuple struct not accesssible from here
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0451`.

--- a/src/test/ui/resolve/privacy-struct-ctor.stderr
+++ b/src/test/ui/resolve/privacy-struct-ctor.stderr
@@ -1,5 +1,5 @@
 error[E0423]: expected value, found struct `Z`
-  --> $DIR/privacy-struct-ctor.rs:20:9
+  --> $DIR/privacy-struct-ctor.rs:18:9
    |
 LL |         Z;
    |         ^ constructor is not visible here due to private fields
@@ -13,7 +13,7 @@ LL |     use m::n::Z;
    |
 
 error[E0423]: expected value, found struct `S`
-  --> $DIR/privacy-struct-ctor.rs:33:5
+  --> $DIR/privacy-struct-ctor.rs:27:5
    |
 LL |     S;
    |     ^ constructor is not visible here due to private fields
@@ -23,13 +23,13 @@ LL | use m::S;
    |
 
 error[E0423]: expected value, found struct `S2`
-  --> $DIR/privacy-struct-ctor.rs:38:5
+  --> $DIR/privacy-struct-ctor.rs:30:5
    |
 LL |     S2;
    |     ^^ did you mean `S2 { /* fields */ }`?
 
 error[E0423]: expected value, found struct `xcrate::S`
-  --> $DIR/privacy-struct-ctor.rs:43:5
+  --> $DIR/privacy-struct-ctor.rs:33:5
    |
 LL |     xcrate::S;
    |     ^^^^^^^^^ constructor is not visible here due to private fields
@@ -38,43 +38,6 @@ help: possible better candidate is found in another module, you can import it in
 LL | use m::S;
    |
 
-error[E0603]: tuple struct `Z` is private
-  --> $DIR/privacy-struct-ctor.rs:18:12
-   |
-LL |         n::Z;
-   |            ^
+error: aborting due to 4 previous errors
 
-error[E0603]: tuple struct `S` is private
-  --> $DIR/privacy-struct-ctor.rs:29:8
-   |
-LL |     m::S;
-   |        ^
-
-error[E0603]: tuple struct `S` is private
-  --> $DIR/privacy-struct-ctor.rs:31:19
-   |
-LL |     let _: S = m::S(2);
-   |                   ^
-
-error[E0603]: tuple struct `Z` is private
-  --> $DIR/privacy-struct-ctor.rs:35:11
-   |
-LL |     m::n::Z;
-   |           ^
-
-error[E0603]: tuple struct `S` is private
-  --> $DIR/privacy-struct-ctor.rs:41:16
-   |
-LL |     xcrate::m::S;
-   |                ^
-
-error[E0603]: tuple struct `Z` is private
-  --> $DIR/privacy-struct-ctor.rs:45:19
-   |
-LL |     xcrate::m::n::Z;
-   |                   ^
-
-error: aborting due to 10 previous errors
-
-Some errors occurred: E0423, E0603.
-For more information about an error, try `rustc --explain E0423`.
+For more information about this error, try `rustc --explain E0423`.

--- a/src/test/ui/rfc-2008-non-exhaustive/structs-2.rs
+++ b/src/test/ui/rfc-2008-non-exhaustive/structs-2.rs
@@ -1,0 +1,9 @@
+// aux-build:structs.rs
+extern crate structs;
+
+use structs::{NormalStruct, UnitStruct, TupleStruct, FunctionalRecord};
+
+fn main() {
+    let ts_explicit = structs::TupleStruct(640, 480);
+    //~^ ERROR struct `structs::TupleStruct` is private
+}

--- a/src/test/ui/rfc-2008-non-exhaustive/structs-2.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/structs-2.stderr
@@ -1,0 +1,8 @@
+error: struct `structs::TupleStruct` is private
+  --> $DIR/structs-2.rs:7:23
+   |
+LL |     let ts_explicit = structs::TupleStruct(640, 480);
+   |                       ^^^^^^^^^^^^^^^^^^^^ private
+
+error: aborting due to previous error
+

--- a/src/test/ui/rfc-2008-non-exhaustive/structs.rs
+++ b/src/test/ui/rfc-2008-non-exhaustive/structs.rs
@@ -20,9 +20,6 @@ fn main() {
     let ts = TupleStruct(640, 480);
     //~^ ERROR expected function, found struct `TupleStruct` [E0423]
 
-    let ts_explicit = structs::TupleStruct(640, 480);
-    //~^ ERROR tuple struct `TupleStruct` is private [E0603]
-
     let TupleStruct { 0: first_field, 1: second_field } = ts;
     //~^ ERROR `..` required with struct marked as non-exhaustive
 

--- a/src/test/ui/rfc-2008-non-exhaustive/structs.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/structs.stderr
@@ -5,19 +5,13 @@ LL |     let ts = TupleStruct(640, 480);
    |              ^^^^^^^^^^^ constructor is not visible here due to private fields
 
 error[E0423]: expected value, found struct `UnitStruct`
-  --> $DIR/structs.rs:29:14
+  --> $DIR/structs.rs:26:14
    |
 LL |     let us = UnitStruct;
    |              ^^^^^^^^^^ constructor is not visible here due to private fields
 
-error[E0603]: tuple struct `TupleStruct` is private
-  --> $DIR/structs.rs:23:32
-   |
-LL |     let ts_explicit = structs::TupleStruct(640, 480);
-   |                                ^^^^^^^^^^^
-
 error[E0603]: unit struct `UnitStruct` is private
-  --> $DIR/structs.rs:32:32
+  --> $DIR/structs.rs:29:32
    |
 LL |     let us_explicit = structs::UnitStruct;
    |                                ^^^^^^^^^^
@@ -47,18 +41,18 @@ LL |     let NormalStruct { first_field, second_field } = ns;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0638]: `..` required with struct marked as non-exhaustive
-  --> $DIR/structs.rs:26:9
+  --> $DIR/structs.rs:23:9
    |
 LL |     let TupleStruct { 0: first_field, 1: second_field } = ts;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0638]: `..` required with struct marked as non-exhaustive
-  --> $DIR/structs.rs:35:9
+  --> $DIR/structs.rs:32:9
    |
 LL |     let UnitStruct { } = us;
    |         ^^^^^^^^^^^^^^
 
-error: aborting due to 9 previous errors
+error: aborting due to 8 previous errors
 
 Some errors occurred: E0423, E0603, E0638, E0639.
 For more information about an error, try `rustc --explain E0423`.


### PR DESCRIPTION
Move tuple struct privacy checks away from `resolve` in order to evaluate
more explicitly point at private tuple struct fields when they are the
cause of the tuple struct being inaccessible.

For structs that are inaccessible, point at the definition span.

Reword privacy messages to be more specific about the ADT kind name.

Group private field errors per struct.

```
error[E0451]: fields of struct `a::A` are private
  --> $DIR/multiple-private-fields.rs:8:18
   |
LL |     pub struct A(usize, usize);
   |     --------------------------- `a::A` defined here
...
LL |     let x = a::A(3, 4);
   |             ---- ^  ^ private field
   |             |    |
   |             |    private field
   |             `a::A` cannot be built due to private fields

 error[E0451]: fields of struct `a::B` are private
  --> $DIR/multiple-private-fields.rs:12:19
   |
LL |     pub struct B {a: usize, b: usize}
   |     --------------------------------- `a::B` defined here
...
LL |     let x = a::B {a:1, b:2};
   |             ------^^^--^^^-
   |             |     |    |
   |             |     |    private field
   |             |     private field
   |             `a::B` cannot be built due to private fields
```

Fix #58017.