### PR TITLE
Fix span for closure return type when annotated.

### DIFF
--- a/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/region_name.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/region_name.rs
@@ -681,10 +681,13 @@ impl<'tcx> RegionInferenceContext<'tcx> {
 
         let (return_span, mir_description) = match tcx.hir().get(mir_node_id) {
             hir::Node::Expr(hir::Expr {
-                node: hir::ExprKind::Closure(_, _, _, span, gen_move),
+                node: hir::ExprKind::Closure(_, return_ty, _, span, gen_move),
                 ..
             }) => (
-                tcx.sess.source_map().end_point(*span),
+                match return_ty.output {
+                    hir::FunctionRetTy::DefaultReturn(_) => tcx.sess.source_map().end_point(*span),
+                    hir::FunctionRetTy::Return(_) => return_ty.output.span(),
+                },
                 if gen_move.is_some() {
                     " of generator"
                 } else {

--- a/src/test/ui/nll/issue-58053.rs
+++ b/src/test/ui/nll/issue-58053.rs
@@ -1,0 +1,14 @@
+#![allow(warnings)]
+#![feature(nll)]
+
+fn main() {
+    let i = &3;
+
+    let f = |x: &i32| -> &i32 { x };
+    //~^ ERROR lifetime may not live long enough
+    let j = f(i);
+
+    let g = |x: &i32| { x };
+    //~^ ERROR lifetime may not live long enough
+    let k = g(i);
+}

--- a/src/test/ui/nll/issue-58053.stderr
+++ b/src/test/ui/nll/issue-58053.stderr
@@ -1,0 +1,20 @@
+error: lifetime may not live long enough
+  --> $DIR/issue-58053.rs:7:33
+   |
+LL |     let f = |x: &i32| -> &i32 { x };
+   |                 -        ----   ^ returning this value requires that `'1` must outlive `'2`
+   |                 |        |
+   |                 |        return type of closure is &'2 i32
+   |                 let's call the lifetime of this reference `'1`
+
+error: lifetime may not live long enough
+  --> $DIR/issue-58053.rs:11:25
+   |
+LL |     let g = |x: &i32| { x };
+   |                 -   -   ^ returning this value requires that `'1` must outlive `'2`
+   |                 |   |
+   |                 |   return type of closure is &'2 i32
+   |                 let's call the lifetime of this reference `'1`
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes #58053.

This PR adjusts the span used to label closure return types so that
if the user specifies the return type, i.e. `|_| -> X {}` instead of
`|_| {}`, we correctly highlight all of it and not just the last
character.

r? @pnkfelix 