### PR TITLE
SGX target: handle empty user buffers correctly

### DIFF
--- a/src/libstd/os/fortanix_sgx/mod.rs
+++ b/src/libstd/os/fortanix_sgx/mod.rs
@@ -16,7 +16,7 @@ pub mod usercalls {
     /// Primitives for allocating memory in userspace as well as copying data
     /// to and from user memory.
     pub mod alloc {
-        pub use sys::abi::usercalls::alloc;
+        pub use sys::abi::usercalls::alloc::*;
     }
 
     /// Lowest-level interfaces to usercalls and usercall ABI type definitions.

--- a/src/libstd/sys/sgx/abi/usercalls/alloc.rs
+++ b/src/libstd/sys/sgx/abi/usercalls/alloc.rs
@@ -537,7 +537,12 @@ impl UserRef<super::raw::ByteBuffer> {
     pub fn copy_user_buffer(&self) -> Vec<u8> {
         unsafe {
             let buf = self.to_enclave();
-            User::from_raw_parts(buf.data as _, buf.len).to_enclave()
+            if buf.len > 0 {
+                User::from_raw_parts(buf.data as _, buf.len).to_enclave()
+            } else {
+                // Mustn't look at `data` or call `free` if `len` is `0`.
+                Vec::with_capacity(0)
+            }
         }
     }
 }

--- a/src/libstd/sys/sgx/abi/usercalls/mod.rs
+++ b/src/libstd/sys/sgx/abi/usercalls/mod.rs
@@ -22,7 +22,8 @@ pub fn read(fd: Fd, buf: &mut [u8]) -> IoResult<usize> {
 #[unstable(feature = "sgx_platform", issue = "56975")]
 pub fn read_alloc(fd: Fd) -> IoResult<Vec<u8>> {
     unsafe {
-        let mut userbuf = alloc::User::<ByteBuffer>::uninitialized();
+        let userbuf = ByteBuffer { data: ::ptr::null_mut(), len: 0 };
+        let mut userbuf = alloc::User::new_from_enclave(&userbuf);
         raw::read_alloc(fd, userbuf.as_raw_mut_ptr()).from_sgx_result()?;
         Ok(userbuf.copy_user_buffer())
     }


### PR DESCRIPTION
Also, expose correct items in `os::fortanix_sgx::usercalls::alloc`

* [read_alloc documentation](https://edp.fortanix.com/docs/api/fortanix_sgx_abi/struct.Usercalls.html#method.read_alloc)
* [Clarified ByteBuffer documentation](https://github.com/fortanix/rust-sgx/pull/94/files#diff-ca843ad9e25cacd63a80579c0f7efa56)

r? @joshtriplett 