### PR TITLE
Rollup of 23 pull requests

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -155,6 +155,7 @@ Matt Brubeck <mbrubeck@limpet.net> <mbrubeck@cs.hmc.edu>
 Matthew Auld <matthew.auld@intel.com>
 Matthew McPherrin <matthew@mcpherrin.ca> <matt@mcpherrin.ca>
 Matthijs Hofstra <thiezz@gmail.com>
+Melody Horn <melody@boringcactus.com> <mathphreak@gmail.com>
 Michael Williams <m.t.williams@live.com>
 Michael Woerister <michaelwoerister@posteo> <michaelwoerister@gmail>
 Mickaël Raybaud-Roig <raybaudroigm@gmail.com> m-r-r <raybaudroigm@gmail.com>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -207,7 +207,10 @@ test_script:
   - sh src/ci/init_repo.sh . /c/cache/rustsrc
   - set SRC=.
   - set NO_CCACHE=1
-  - sh src/ci/run.sh
+  # Added this debugging code to try tracking down https://github.com/rust-lang/rust/issues/58160
+  # Replace it with the commented line below after the issue with AppVeyor is fixed
+  - "sh src/ci/run.sh & set ret=%errorlevel% & echo exit code in appveyor.yml: %ret% & exit %ret%"
+#  - sh src/ci/run.sh
 
 on_failure:
   # Dump crash log

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -127,7 +127,7 @@ if [ ! -z "$SCRIPT" ]; then
   set +e
   sh -x -c "$SCRIPT"
   ret=$?
-  echo "script exited with $ret"
+  echo "exit code in src/ci/run.sh: $ret"
   exit $ret
 else
   do_make() {

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -128,6 +128,12 @@ if [ ! -z "$SCRIPT" ]; then
   sh -x -c "$SCRIPT"
   ret=$?
   echo "exit code in src/ci/run.sh: $ret"
+
+  echo "tasklist:"
+  tasklist
+  echo -n "location of sh: "
+  where sh
+
   exit $ret
 else
   do_make() {

--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -52,6 +52,12 @@ If reading multiple hundreds of pages about a language isn't your style, then
 a lot of words, RBE shows off a bunch of code, and keeps the talking to a
 minimum. It also includes exercises!
 
+## Rustlings
+
+[Rustlings](https://github.com/rust-lang/rustlings) guides you through downloading and setting up the Rust toolchain,
+and teaches you the basics of reading and writing Rust syntax. It's an
+alternative to Rust by Example that works with your own environment.
+
 # Use Rust
 
 Once you've gotten familiar with the language, these resources can help you

--- a/src/libcore/iter/traits/iterator.rs
+++ b/src/libcore/iter/traits/iterator.rs
@@ -952,8 +952,7 @@ pub trait Iterator {
     /// ```
     ///
     /// The `3` is no longer there, because it was consumed in order to see if
-    /// the iteration should stop, but wasn't placed back into the iterator or
-    /// some similar thing.
+    /// the iteration should stop, but wasn't placed back into the iterator.
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     fn take_while<P>(self, predicate: P) -> TakeWhile<Self, P> where

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -2961,8 +2961,8 @@ impl str {
     /// An iterator over substrings of this string slice, separated by
     /// characters matched by a pattern.
     ///
-    /// The pattern can be a `&str`, [`char`], or a closure that determines the
-    /// split.
+    /// The pattern can be any type that implements the Pattern trait. Notable
+    /// examples are `&str`, [`char`], and closures that determines the split.
     ///
     /// # Iterator behavior
     ///
@@ -3078,8 +3078,8 @@ impl str {
     /// An iterator over substrings of the given string slice, separated by
     /// characters matched by a pattern and yielded in reverse order.
     ///
-    /// The pattern can be a `&str`, [`char`], or a closure that determines the
-    /// split.
+    /// The pattern can be any type that implements the Pattern trait. Notable
+    /// examples are `&str`, [`char`], and closures that determines the split.
     ///
     /// # Iterator behavior
     ///
@@ -3128,8 +3128,8 @@ impl str {
     /// An iterator over substrings of the given string slice, separated by
     /// characters matched by a pattern.
     ///
-    /// The pattern can be a `&str`, [`char`], or a closure that determines the
-    /// split.
+    /// The pattern can be any type that implements the Pattern trait. Notable
+    /// examples are `&str`, [`char`], and closures that determines the split.
     ///
     /// Equivalent to [`split`], except that the trailing substring
     /// is skipped if empty.
@@ -3175,8 +3175,8 @@ impl str {
     /// An iterator over substrings of `self`, separated by characters
     /// matched by a pattern and yielded in reverse order.
     ///
-    /// The pattern can be a simple `&str`, [`char`], or a closure that
-    /// determines the split.
+    /// The pattern can be any type that implements the Pattern trait. Notable
+    /// examples are `&str`, [`char`], and closures that determines the split.
     /// Additional libraries might provide more complex patterns like
     /// regular expressions.
     ///
@@ -3222,8 +3222,8 @@ impl str {
     /// If `n` substrings are returned, the last substring (the `n`th substring)
     /// will contain the remainder of the string.
     ///
-    /// The pattern can be a `&str`, [`char`], or a closure that determines the
-    /// split.
+    /// The pattern can be any type that implements the Pattern trait. Notable
+    /// examples are `&str`, [`char`], and closures that determines the split.
     ///
     /// # Iterator behavior
     ///
@@ -3275,8 +3275,8 @@ impl str {
     /// If `n` substrings are returned, the last substring (the `n`th substring)
     /// will contain the remainder of the string.
     ///
-    /// The pattern can be a `&str`, [`char`], or a closure that
-    /// determines the split.
+    /// The pattern can be any type that implements the Pattern trait. Notable
+    /// examples are `&str`, [`char`], and closures that determines the split.
     ///
     /// # Iterator behavior
     ///
@@ -3319,8 +3319,8 @@ impl str {
     /// An iterator over the disjoint matches of a pattern within the given string
     /// slice.
     ///
-    /// The pattern can be a `&str`, [`char`], or a closure that
-    /// determines if a character matches.
+    /// The pattern can be any type that implements the Pattern trait. Notable
+    /// examples are `&str`, [`char`], and closures that determines the split.
     ///
     /// # Iterator behavior
     ///

--- a/src/libcore/task/poll.rs
+++ b/src/libcore/task/poll.rs
@@ -7,6 +7,7 @@ use result::Result;
 
 /// Indicates whether a value is available or if the current task has been
 /// scheduled to receive a wakeup instead.
+#[must_use = "this `Poll` may be a `Pending` variant, which should be handled"]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum Poll<T> {
     /// Represents that a value is immediately ready.

--- a/src/libfmt_macros/Cargo.toml
+++ b/src/libfmt_macros/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "fmt_macros"
 version = "0.0.0"
+edition = "2018"
 
 [lib]
 name = "fmt_macros"

--- a/src/libfmt_macros/lib.rs
+++ b/src/libfmt_macros/lib.rs
@@ -10,14 +10,15 @@
        html_playground_url = "https://play.rust-lang.org/",
        test(attr(deny(warnings))))]
 
-#![feature(nll)]
+#![deny(rust_2018_idioms)]
+
 #![feature(rustc_private)]
 
-pub use self::Piece::*;
-pub use self::Position::*;
-pub use self::Alignment::*;
-pub use self::Flag::*;
-pub use self::Count::*;
+pub use Piece::*;
+pub use Position::*;
+pub use Alignment::*;
+pub use Flag::*;
+pub use Count::*;
 
 use std::str;
 use std::string;

--- a/src/libgraphviz/Cargo.toml
+++ b/src/libgraphviz/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "graphviz"
 version = "0.0.0"
+edition = "2018"
 
 [lib]
 name = "graphviz"

--- a/src/libgraphviz/lib.rs
+++ b/src/libgraphviz/lib.rs
@@ -276,10 +276,11 @@
        html_root_url = "https://doc.rust-lang.org/nightly/",
        test(attr(allow(unused_variables), deny(warnings))))]
 
-#![feature(nll)]
+#![deny(rust_2018_idioms)]
+
 #![feature(str_escape)]
 
-use self::LabelText::*;
+use LabelText::*;
 
 use std::borrow::Cow;
 use std::io::prelude::*;
@@ -548,12 +549,12 @@ impl<'a> LabelText<'a> {
     }
 
     /// Puts `prefix` on a line above this label, with a blank line separator.
-    pub fn prefix_line(self, prefix: LabelText) -> LabelText<'static> {
+    pub fn prefix_line(self, prefix: LabelText<'_>) -> LabelText<'static> {
         prefix.suffix_line(self)
     }
 
     /// Puts `suffix` on a line below this label, with a blank line separator.
-    pub fn suffix_line(self, suffix: LabelText) -> LabelText<'static> {
+    pub fn suffix_line(self, suffix: LabelText<'_>) -> LabelText<'static> {
         let mut prefix = self.pre_escaped_content().into_owned();
         let suffix = suffix.pre_escaped_content();
         prefix.push_str(r"\n\n");
@@ -686,7 +687,7 @@ pub fn render_opts<'a, N, E, G, W>(g: &'a G,
 
 #[cfg(test)]
 mod tests {
-    use self::NodeLabels::*;
+    use NodeLabels::*;
     use super::{Id, Labeller, Nodes, Edges, GraphWalk, render, Style};
     use super::LabelText::{self, LabelStr, EscStr, HtmlStr};
     use std::io;

--- a/src/libpanic_abort/Cargo.toml
+++ b/src/libpanic_abort/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "panic_abort"
 version = "0.0.0"
+edition = "2018"
 
 [lib]
 path = "lib.rs"

--- a/src/libpanic_abort/lib.rs
+++ b/src/libpanic_abort/lib.rs
@@ -10,11 +10,12 @@
        html_root_url = "https://doc.rust-lang.org/nightly/",
        issue_tracker_base_url = "https://github.com/rust-lang/rust/issues/")]
 #![panic_runtime]
+
 #![allow(unused_features)]
+#![deny(rust_2018_idioms)]
 
 #![feature(core_intrinsics)]
 #![feature(libc)]
-#![feature(nll)]
 #![feature(panic_runtime)]
 #![feature(staged_api)]
 #![feature(rustc_attrs)]
@@ -46,7 +47,6 @@ pub unsafe extern fn __rust_start_panic(_payload: usize) -> u32 {
 
     #[cfg(any(unix, target_os = "cloudabi"))]
     unsafe fn abort() -> ! {
-        extern crate libc;
         libc::abort();
     }
 

--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -401,6 +401,12 @@ impl<'hir> Map<'hir> {
         }
     }
 
+    // FIXME(@ljedrz): replace the NodeId variant
+    pub fn describe_def_by_hir_id(&self, hir_id: HirId) -> Option<Def> {
+        let node_id = self.hir_to_node_id(hir_id);
+        self.describe_def(node_id)
+    }
+
     fn entry_count(&self) -> usize {
         self.map.len()
     }
@@ -443,6 +449,12 @@ impl<'hir> Map<'hir> {
         } else {
             bug!("no entry for node_id `{}`", node_id)
         }
+    }
+
+    // FIXME(@ljedrz): replace the NodeId variant
+    pub fn fn_decl_by_hir_id(&self, hir_id: HirId) -> Option<FnDecl> {
+        let node_id = self.hir_to_node_id(hir_id);
+        self.fn_decl(node_id)
     }
 
     /// Returns the `NodeId` that corresponds to the definition of
@@ -855,6 +867,12 @@ impl<'hir> Map<'hir> {
         self.local_def_id(self.get_parent(id))
     }
 
+    // FIXME(@ljedrz): replace the NodeId variant
+    pub fn get_parent_did_by_hir_id(&self, id: HirId) -> DefId {
+        let node_id = self.hir_to_node_id(id);
+        self.get_parent_did(node_id)
+    }
+
     pub fn get_foreign_abi(&self, id: NodeId) -> Abi {
         let parent = self.get_parent(id);
         if let Some(entry) = self.find_entry(parent) {
@@ -866,6 +884,12 @@ impl<'hir> Map<'hir> {
             }
         }
         bug!("expected foreign mod or inlined parent, found {}", self.node_to_string(parent))
+    }
+
+    // FIXME(@ljedrz): replace the NodeId variant
+    pub fn get_foreign_abi_by_hir_id(&self, id: HirId) -> Abi {
+        let node_id = self.hir_to_node_id(id);
+        self.get_foreign_abi(node_id)
     }
 
     pub fn expect_item(&self, id: NodeId) -> &'hir Item {
@@ -886,6 +910,18 @@ impl<'hir> Map<'hir> {
             Some(Node::ImplItem(item)) => item,
             _ => bug!("expected impl item, found {}", self.node_to_string(id))
         }
+    }
+
+    // FIXME(@ljedrz): replace the NodeId variant
+    pub fn expect_impl_item_by_hir_id(&self, id: HirId) -> &'hir ImplItem {
+        let node_id = self.hir_to_node_id(id);
+        self.expect_impl_item(node_id)
+    }
+
+    // FIXME(@ljedrz): replace the NodeId variant
+    pub fn expect_trait_item_by_hir_id(&self, id: HirId) -> &'hir TraitItem {
+        let node_id = self.hir_to_node_id(id);
+        self.expect_trait_item(node_id)
     }
 
     pub fn expect_trait_item(&self, id: NodeId) -> &'hir TraitItem {
@@ -931,6 +967,12 @@ impl<'hir> Map<'hir> {
         }
     }
 
+    // FIXME(@ljedrz): replace the NodeId variant
+    pub fn expect_expr_by_hir_id(&self, id: HirId) -> &'hir Expr {
+        let node_id = self.hir_to_node_id(id);
+        self.expect_expr(node_id)
+    }
+
     /// Returns the name associated with the given NodeId's AST.
     pub fn name(&self, id: NodeId) -> Name {
         match self.get(id) {
@@ -946,6 +988,12 @@ impl<'hir> Map<'hir> {
             Node::StructCtor(_) => self.name(self.get_parent(id)),
             _ => bug!("no name for {}", self.node_to_string(id))
         }
+    }
+
+    // FIXME(@ljedrz): replace the NodeId variant
+    pub fn name_by_hir_id(&self, id: HirId) -> Name {
+        let node_id = self.hir_to_node_id(id);
+        self.name(node_id)
     }
 
     /// Given a node ID, get a list of attributes associated with the AST
@@ -968,6 +1016,12 @@ impl<'hir> Map<'hir> {
             _ => None
         };
         attrs.unwrap_or(&[])
+    }
+
+    // FIXME(@ljedrz): replace the NodeId variant
+    pub fn attrs_by_hir_id(&self, id: HirId) -> &'hir [ast::Attribute] {
+        let node_id = self.hir_to_node_id(id);
+        self.attrs(node_id)
     }
 
     /// Returns an iterator that yields the node id's with paths that
@@ -1017,6 +1071,12 @@ impl<'hir> Map<'hir> {
             Some(Node::Crate) => self.forest.krate.span,
             None => bug!("hir::map::Map::span: id not in map: {:?}", id),
         }
+    }
+
+    // FIXME(@ljedrz): replace the NodeId variant
+    pub fn span_by_hir_id(&self, id: HirId) -> Span {
+        let node_id = self.hir_to_node_id(id);
+        self.span(node_id)
     }
 
     pub fn span_if_local(&self, id: DefId) -> Option<Span> {

--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -765,7 +765,9 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
                 }
             }
             EvalResult::Unmarked => {
-                span_bug!(span, "encountered unmarked API: {:?}", def_id);
+                // The API could be uncallable for other reasons, for example when a private module
+                // was referenced.
+                self.sess.delay_span_bug(span, &format!("encountered unmarked API: {:?}", def_id));
             }
         }
     }

--- a/src/librustc_privacy/Cargo.toml
+++ b/src/librustc_privacy/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_privacy"
 version = "0.0.0"
+edition = "2018"
 
 [lib]
 name = "rustc_privacy"

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -2,18 +2,15 @@
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
        html_root_url = "https://doc.rust-lang.org/nightly/")]
 
-#![feature(nll)]
+#![deny(rust_2018_idioms)]
+
 #![feature(rustc_diagnostic_macros)]
 
 #![recursion_limit="256"]
 
-#[macro_use] extern crate rustc;
 #[macro_use] extern crate syntax;
-#[macro_use] extern crate log;
-extern crate rustc_typeck;
-extern crate syntax_pos;
-extern crate rustc_data_structures;
 
+use rustc::bug;
 use rustc::hir::{self, Node, PatKind, AssociatedItemKind};
 use rustc::hir::def::Def;
 use rustc::hir::def_id::{CRATE_DEF_INDEX, LOCAL_CRATE, CrateNum, DefId};
@@ -1541,7 +1538,7 @@ impl<'a, 'tcx: 'a> SearchInterfaceForPrivateItemsVisitor<'a, 'tcx> {
         let ret = self.required_visibility == ty::Visibility::Public &&
             self.private_crates.contains(&item_id.krate);
 
-        debug!("leaks_private_dep(item_id={:?})={}", item_id, ret);
+        log::debug!("leaks_private_dep(item_id={:?})={}", item_id, ret);
         return ret;
     }
 }
@@ -1705,7 +1702,7 @@ impl<'a, 'tcx> Visitor<'tcx> for PrivateItemsInPublicInterfacesVisitor<'a, 'tcx>
     }
 }
 
-pub fn provide(providers: &mut Providers) {
+pub fn provide(providers: &mut Providers<'_>) {
     *providers = Providers {
         privacy_access_levels,
         check_mod_privacy,

--- a/src/libstd/os/fortanix_sgx/mod.rs
+++ b/src/libstd/os/fortanix_sgx/mod.rs
@@ -16,7 +16,7 @@ pub mod usercalls {
     /// Primitives for allocating memory in userspace as well as copying data
     /// to and from user memory.
     pub mod alloc {
-        pub use sys::abi::usercalls::alloc;
+        pub use sys::abi::usercalls::alloc::*;
     }
 
     /// Lowest-level interfaces to usercalls and usercall ABI type definitions.

--- a/src/libstd/sys/sgx/abi/usercalls/alloc.rs
+++ b/src/libstd/sys/sgx/abi/usercalls/alloc.rs
@@ -537,7 +537,12 @@ impl UserRef<super::raw::ByteBuffer> {
     pub fn copy_user_buffer(&self) -> Vec<u8> {
         unsafe {
             let buf = self.to_enclave();
-            User::from_raw_parts(buf.data as _, buf.len).to_enclave()
+            if buf.len > 0 {
+                User::from_raw_parts(buf.data as _, buf.len).to_enclave()
+            } else {
+                // Mustn't look at `data` or call `free` if `len` is `0`.
+                Vec::with_capacity(0)
+            }
         }
     }
 }

--- a/src/libstd/sys/sgx/abi/usercalls/mod.rs
+++ b/src/libstd/sys/sgx/abi/usercalls/mod.rs
@@ -22,7 +22,8 @@ pub fn read(fd: Fd, buf: &mut [u8]) -> IoResult<usize> {
 #[unstable(feature = "sgx_platform", issue = "56975")]
 pub fn read_alloc(fd: Fd) -> IoResult<Vec<u8>> {
     unsafe {
-        let mut userbuf = alloc::User::<ByteBuffer>::uninitialized();
+        let userbuf = ByteBuffer { data: ::ptr::null_mut(), len: 0 };
+        let mut userbuf = alloc::User::new_from_enclave(&userbuf);
         raw::read_alloc(fd, userbuf.as_raw_mut_ptr()).from_sgx_result()?;
         Ok(userbuf.copy_user_buffer())
     }

--- a/src/libstd/sys/sgx/rwlock.rs
+++ b/src/libstd/sys/sgx/rwlock.rs
@@ -19,9 +19,6 @@ unsafe fn rw_lock_size_assert(r: RWLock) {
     mem::transmute::<RWLock, [u8; 128]>(r);
 }
 
-//unsafe impl Send for RWLock {}
-//unsafe impl Sync for RWLock {} // FIXME
-
 impl RWLock {
     pub const fn new() -> RWLock {
         RWLock {

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3455,6 +3455,14 @@ impl<'a> Parser<'a> {
                 }),
             }?;
 
+            // Make sure that the span of the parent node is larger than the span of lhs and rhs,
+            // including the attributes.
+            let lhs_span = lhs
+                .attrs
+                .iter()
+                .filter(|a| a.style == AttrStyle::Outer)
+                .next()
+                .map_or(lhs_span, |a| a.span);
             let span = lhs_span.to(rhs.span);
             lhs = match op {
                 AssocOp::Add | AssocOp::Subtract | AssocOp::Multiply | AssocOp::Divide |

--- a/src/libsyntax/tokenstream.rs
+++ b/src/libsyntax/tokenstream.rs
@@ -255,7 +255,13 @@ impl TokenStream {
             0 => TokenStream::empty(),
             1 => streams.pop().unwrap(),
             _ => {
-                let mut vec = vec![];
+                // rust-lang/rust#57735: pre-allocate vector to avoid
+                // quadratic blow-up due to on-the-fly reallocations.
+                let tree_count = streams.iter()
+                    .map(|ts| match &ts.0 { None => 0, Some(s) => s.len() })
+                    .sum();
+                let mut vec = Vec::with_capacity(tree_count);
+
                 for stream in streams {
                     match stream.0 {
                         None => {},

--- a/src/libunwind/Cargo.toml
+++ b/src/libunwind/Cargo.toml
@@ -3,6 +3,7 @@ authors = ["The Rust Project Developers"]
 name = "unwind"
 version = "0.0.0"
 build = "build.rs"
+edition = "2018"
 
 [lib]
 name = "unwind"

--- a/src/libunwind/lib.rs
+++ b/src/libunwind/lib.rs
@@ -1,8 +1,9 @@
 #![no_std]
 #![unstable(feature = "panic_unwind", issue = "32837")]
 
+#![deny(rust_2018_idioms)]
+
 #![feature(link_cfg)]
-#![feature(nll)]
 #![feature(staged_api)]
 #![feature(unwind_attributes)]
 #![feature(static_nobundle)]
@@ -18,7 +19,6 @@ cfg_if! {
     } else if #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))] {
         // no unwinder on the system!
     } else {
-        extern crate libc;
         mod libunwind;
         pub use libunwind::*;
     }

--- a/src/libunwind/libunwind.rs
+++ b/src/libunwind/libunwind.rs
@@ -21,7 +21,7 @@ pub enum _Unwind_Reason_Code {
     _URC_CONTINUE_UNWIND = 8,
     _URC_FAILURE = 9, // used only by ARM EHABI
 }
-pub use self::_Unwind_Reason_Code::*;
+pub use _Unwind_Reason_Code::*;
 
 pub type _Unwind_Exception_Class = u64;
 pub type _Unwind_Word = uintptr_t;
@@ -94,7 +94,7 @@ if #[cfg(all(any(target_os = "ios", target_os = "netbsd", not(target_arch = "arm
         _UA_FORCE_UNWIND = 8,
         _UA_END_OF_STACK = 16,
     }
-    pub use self::_Unwind_Action::*;
+    pub use _Unwind_Action::*;
 
     extern "C" {
         pub fn _Unwind_GetGR(ctx: *mut _Unwind_Context, reg_index: c_int) -> _Unwind_Word;
@@ -118,7 +118,7 @@ if #[cfg(all(any(target_os = "ios", target_os = "netbsd", not(target_arch = "arm
         _US_FORCE_UNWIND = 8,
         _US_END_OF_STACK = 16,
     }
-    pub use self::_Unwind_State::*;
+    pub use _Unwind_State::*;
 
     #[repr(C)]
     enum _Unwind_VRS_Result {
@@ -134,7 +134,7 @@ if #[cfg(all(any(target_os = "ios", target_os = "netbsd", not(target_arch = "arm
         _UVRSC_WMMXD = 3,
         _UVRSC_WMMXC = 4,
     }
-    use self::_Unwind_VRS_RegClass::*;
+    use _Unwind_VRS_RegClass::*;
     #[repr(C)]
     enum _Unwind_VRS_DataRepresentation {
         _UVRSD_UINT32 = 0,
@@ -144,7 +144,7 @@ if #[cfg(all(any(target_os = "ios", target_os = "netbsd", not(target_arch = "arm
         _UVRSD_FLOAT = 4,
         _UVRSD_DOUBLE = 5,
     }
-    use self::_Unwind_VRS_DataRepresentation::*;
+    use _Unwind_VRS_DataRepresentation::*;
 
     pub const UNWIND_POINTER_REG: c_int = 12;
     pub const UNWIND_IP_REG: c_int = 15;

--- a/src/test/ui/stability-in-private-module.rs
+++ b/src/test/ui/stability-in-private-module.rs
@@ -1,0 +1,4 @@
+fn main() {
+    let _ = std::thread::thread_info::current_thread();
+    //~^ERROR module `thread_info` is private
+}

--- a/src/test/ui/stability-in-private-module.stderr
+++ b/src/test/ui/stability-in-private-module.stderr
@@ -1,0 +1,9 @@
+error[E0603]: module `thread_info` is private
+  --> $DIR/stability-in-private-module.rs:2:26
+   |
+LL |     let _ = std::thread::thread_info::current_thread();
+   |                          ^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0603`.

--- a/src/tools/build-manifest/Cargo.toml
+++ b/src/tools/build-manifest/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 
 [dependencies]
 toml = "0.4"
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"

--- a/src/tools/build-manifest/Cargo.toml
+++ b/src/tools/build-manifest/Cargo.toml
@@ -2,6 +2,7 @@
 name = "build-manifest"
 version = "0.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
+edition = "2018"
 
 [dependencies]
 toml = "0.4"

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -1,4 +1,6 @@
-extern crate toml;
+#![deny(rust_2018_idioms)]
+
+use toml;
 #[macro_use]
 extern crate serde_derive;
 

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -469,7 +469,7 @@ impl Builder {
         }
         manifest.pkg.insert("rust".to_string(), pkg);
 
-        return manifest;
+        manifest
     }
 
     fn profile(&mut self,

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -78,6 +78,7 @@ static TARGETS: &'static [&'static str] = &[
     "mips64el-unknown-linux-gnuabi64",
     "mipsel-unknown-linux-gnu",
     "mipsel-unknown-linux-musl",
+    "nvptx64-nvidia-cuda",
     "powerpc-unknown-linux-gnu",
     "powerpc64-unknown-linux-gnu",
     "powerpc64le-unknown-linux-gnu",

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -1,8 +1,7 @@
 #![deny(rust_2018_idioms)]
 
 use toml;
-#[macro_use]
-extern crate serde_derive;
+use serde_derive::Serialize;
 
 use std::collections::BTreeMap;
 use std::env;

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -1,7 +1,7 @@
 #![deny(rust_2018_idioms)]
 
 use toml;
-use serde_derive::Serialize;
+use serde::Serialize;
 
 use std::collections::BTreeMap;
 use std::env;

--- a/src/tools/linkchecker/Cargo.toml
+++ b/src/tools/linkchecker/Cargo.toml
@@ -2,6 +2,7 @@
 name = "linkchecker"
 version = "0.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
+edition = "2018"
 
 [[bin]]
 name = "linkchecker"

--- a/src/tools/linkchecker/main.rs
+++ b/src/tools/linkchecker/main.rs
@@ -14,6 +14,8 @@
 //! A few whitelisted exceptions are allowed as there's known bugs in rustdoc,
 //! but this should catch the majority of "broken link" cases.
 
+#![deny(rust_2018_idioms)]
+
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::env;
@@ -21,7 +23,7 @@ use std::fs;
 use std::path::{Path, PathBuf, Component};
 use std::rc::Rc;
 
-use Redirect::*;
+use crate::Redirect::*;
 
 macro_rules! t {
     ($e:expr) => (match $e {

--- a/src/tools/remote-test-client/Cargo.toml
+++ b/src/tools/remote-test-client/Cargo.toml
@@ -2,5 +2,6 @@
 name = "remote-test-client"
 version = "0.1.0"
 authors = ["The Rust Project Developers"]
+edition = "2018"
 
 [dependencies]

--- a/src/tools/remote-test-server/Cargo.toml
+++ b/src/tools/remote-test-server/Cargo.toml
@@ -2,5 +2,6 @@
 name = "remote-test-server"
 version = "0.1.0"
 authors = ["The Rust Project Developers"]
+edition = "2018"
 
 [dependencies]

--- a/src/tools/rustdoc-themes/Cargo.toml
+++ b/src/tools/rustdoc-themes/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rustdoc-themes"
 version = "0.1.0"
 authors = ["Guillaume Gomez <guillaume1.gomez@gmail.com>"]
+edition = "2018"
 
 [[bin]]
 name = "rustdoc-themes"

--- a/src/tools/rustdoc-themes/main.rs
+++ b/src/tools/rustdoc-themes/main.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 use std::env::args;
 use std::fs::read_dir;
 use std::path::Path;

--- a/src/tools/tidy/src/main.rs
+++ b/src/tools/tidy/src/main.rs
@@ -4,6 +4,7 @@
 //! etc. This is run by default on `make check` and as part of the auto
 //! builders.
 
+#![deny(rust_2018_idioms)]
 #![deny(warnings)]
 
 extern crate tidy;

--- a/src/tools/tidy/src/unstable_book.rs
+++ b/src/tools/tidy/src/unstable_book.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 use std::fs;
 use std::path;
-use features::{collect_lang_features, collect_lib_features, Features, Status};
+use crate::features::{collect_lang_features, collect_lib_features, Features, Status};
 
 pub const PATH_STR: &str = "doc/unstable-book/src";
 

--- a/src/tools/unstable-book-gen/Cargo.toml
+++ b/src/tools/unstable-book-gen/Cargo.toml
@@ -4,6 +4,7 @@ authors = ["est31 <MTest31@outlook.com>",
 name = "unstable-book-gen"
 version = "0.1.0"
 license = "MIT/Apache-2.0"
+edition = "2018"
 
 [dependencies]
 tidy = { path = "../tidy" }

--- a/src/tools/unstable-book-gen/src/main.rs
+++ b/src/tools/unstable-book-gen/src/main.rs
@@ -1,8 +1,9 @@
 //! Auto-generate stub docs for the unstable book
 
+#![deny(rust_2018_idioms)]
 #![deny(warnings)]
 
-extern crate tidy;
+
 
 use tidy::features::{Feature, Features, collect_lib_features, collect_lang_features};
 use tidy::unstable_book::{collect_unstable_feature_names, collect_unstable_book_section_file_names,


### PR DESCRIPTION
Successful merges:

 - #58001 (proc_macro: make `TokenStream::from_streams` pre-allocate its vector.)
 - #58096 (Transition linkchecker to 2018 edition)
 - #58097 (Transition remote test to Rust 2018)
 - #58106 (libfmt_macros => 2018)
 - #58107 (libgraphviz => 2018)
 - #58108 (Add NVPTX target to a build manifest)
 - #58109 (librustc_privacy => 2018)
 - #58112 (libpanic_abort => 2018)
 - #58113 (Transition build-manifest to 2018 edition)
 - #58114 (Transition tidy and unstable-book-gen to 2018 edition)
 - #58116 (Include the span of attributes of the lhs to the span of the assignment expression)
 - #58117 (Transition rustdoc-theme to 2018 edition)
 - #58128 (libunwind => 2018)
 - #58138 (Fix #58101)
 - #58139 (hir: add more HirId methods)
 - #58141 (Remove weasel word in docs for iter's take_while())
 - #58142 (Remove stray FIXME)
 - #58145 (Add #[must_use] to core::task::Poll)
 - #58162 (Add more debugging code to track down appveyor 259 exit code)
 - #58169 (Update contributor name in .mailmap)
 - #58172 (update split docs)
 - #58182 (SGX target: handle empty user buffers correctly)
 - #58186 (Add Rustlings to the doc index)

Failed merges:


r? @ghost