### PR TITLE
Do not ICE in codegen when using a extern_type static

### DIFF
--- a/src/test/run-make-fulldeps/static-extern-type/Makefile
+++ b/src/test/run-make-fulldeps/static-extern-type/Makefile
@@ -1,0 +1,5 @@
+-include ../tools.mk
+
+all: $(call NATIVE_STATICLIB,define-foo)
+	$(RUSTC) -ldefine-foo use-foo.rs
+	$(call RUN,use-foo) || exit 1

--- a/src/test/run-make-fulldeps/static-extern-type/define-foo.c
+++ b/src/test/run-make-fulldeps/static-extern-type/define-foo.c
@@ -1,0 +1,11 @@
+#include <stdint.h>
+
+struct Foo {
+    uint8_t x;
+};
+
+struct Foo FOO = { 42 };
+
+uint8_t bar(const struct Foo* foo) {
+    return foo->x;
+}

--- a/src/test/run-make-fulldeps/static-extern-type/use-foo.rs
+++ b/src/test/run-make-fulldeps/static-extern-type/use-foo.rs
@@ -1,0 +1,14 @@
+#![feature(extern_types)]
+
+extern "C" {
+    type Foo;
+    static FOO: Foo;
+    fn bar(foo: *const Foo) -> u8;
+}
+
+fn main() {
+    unsafe {
+        let foo = &FOO;
+        assert_eq!(bar(foo), 42);
+    }
+}


### PR DESCRIPTION
The layout of a extern_type static is unsized, but may pass the
Well-Formed check in typeck (See #55257).  As a result, we
cannot assume that a static is sized when generating the `Place`
for an r-value.

Fixes: #57876

r? @oli-obk