### PR TITLE
Add specific feature gate error for const-unstable features

### DIFF
--- a/src/librustc_mir/diagnostics.rs
+++ b/src/librustc_mir/diagnostics.rs
@@ -2370,6 +2370,37 @@ let value = (&foo(), &foo());
 ```
 "##,
 
+E0723: r##"
+An feature unstable in `const` contexts was used.
+
+Erroneous code example:
+
+```compile_fail,E0723
+trait T {}
+
+impl T for () {}
+
+const fn foo() -> impl T { // error: `impl Trait` in const fn is unstable
+    ()
+}
+```
+
+To enable this feature on a nightly version of rustc, add the `const_fn`
+feature flag:
+
+```compile_fail,E0723
+#![feature(const_fn)]
+
+trait T {}
+
+impl T for () {}
+
+const fn foo() -> impl T { // error: `impl Trait` in const fn is unstable
+    ()
+}
+```
+"##,
+
 }
 
 register_diagnostics! {

--- a/src/librustc_mir/diagnostics.rs
+++ b/src/librustc_mir/diagnostics.rs
@@ -2388,14 +2388,14 @@ const fn foo() -> impl T { // error: `impl Trait` in const fn is unstable
 To enable this feature on a nightly version of rustc, add the `const_fn`
 feature flag:
 
-```compile_fail,E0723
+```
 #![feature(const_fn)]
 
 trait T {}
 
 impl T for () {}
 
-const fn foo() -> impl T { // error: `impl Trait` in const fn is unstable
+const fn foo() -> impl T {
     ()
 }
 ```

--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -1206,7 +1206,17 @@ impl MirPass for QualifyAndPromoteConstants {
                         // enforce `min_const_fn` for stable const fns
                         use super::qualify_min_const_fn::is_min_const_fn;
                         if let Err((span, err)) = is_min_const_fn(tcx, def_id, mir) {
-                            tcx.sess.span_err(span, &err);
+                            let mut diag = struct_span_err!(
+                                tcx.sess,
+                                span,
+                                E0723,
+                                "{} (see issue #57563)",
+                                err,
+                            );
+                            diag.help(
+                                "add #![feature(const_fn)] to the crate attributes to enable",
+                            );
+                            diag.emit();
                         } else {
                             // this should not produce any errors, but better safe than sorry
                             // FIXME(#53819)

--- a/src/test/ui/consts/min_const_fn/bad_const_fn_body_ice.stderr
+++ b/src/test/ui/consts/min_const_fn/bad_const_fn_body_ice.stderr
@@ -1,10 +1,12 @@
-error: heap allocations are not allowed in const fn
+error[E0723]: heap allocations are not allowed in const fn (see issue #57563)
   --> $DIR/bad_const_fn_body_ice.rs:2:5
    |
 LL |     vec![1, 2, 3] //~ ERROR heap allocations are not allowed in const fn
    |     ^^^^^^^^^^^^^
    |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0723`.

--- a/src/test/ui/consts/min_const_fn/cast_errors.stderr
+++ b/src/test/ui/consts/min_const_fn/cast_errors.stderr
@@ -1,32 +1,43 @@
-error: unsizing casts are not allowed in const fn
+error[E0723]: unsizing casts are not allowed in const fn (see issue #57563)
   --> $DIR/cast_errors.rs:3:41
    |
 LL | const fn unsize(x: &[u8; 3]) -> &[u8] { x }
    |                                         ^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: function pointers in const fn are unstable
+error[E0723]: function pointers in const fn are unstable (see issue #57563)
   --> $DIR/cast_errors.rs:5:23
    |
 LL | const fn closure() -> fn() { || {} }
    |                       ^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: function pointers in const fn are unstable
+error[E0723]: function pointers in const fn are unstable (see issue #57563)
   --> $DIR/cast_errors.rs:8:5
    |
 LL |     (|| {}) as fn();
    |     ^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: function pointers in const fn are unstable
+error[E0723]: function pointers in const fn are unstable (see issue #57563)
   --> $DIR/cast_errors.rs:11:28
    |
 LL | const fn reify(f: fn()) -> unsafe fn() { f }
    |                            ^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: function pointers in const fn are unstable
+error[E0723]: function pointers in const fn are unstable (see issue #57563)
   --> $DIR/cast_errors.rs:13:21
    |
 LL | const fn reify2() { main as unsafe fn(); }
    |                     ^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error: aborting due to 5 previous errors
 
+For more information about this error, try `rustc --explain E0723`.

--- a/src/test/ui/consts/min_const_fn/cmp_fn_pointers.stderr
+++ b/src/test/ui/consts/min_const_fn/cmp_fn_pointers.stderr
@@ -1,8 +1,11 @@
-error: function pointers in const fn are unstable
+error[E0723]: function pointers in const fn are unstable (see issue #57563)
   --> $DIR/cmp_fn_pointers.rs:1:14
    |
 LL | const fn cmp(x: fn(), y: fn()) -> bool { //~ ERROR function pointers in const fn are unstable
    |              ^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0723`.

--- a/src/test/ui/consts/min_const_fn/loop_ice.stderr
+++ b/src/test/ui/consts/min_const_fn/loop_ice.stderr
@@ -1,8 +1,11 @@
-error: loops are not allowed in const fn
+error[E0723]: loops are not allowed in const fn (see issue #57563)
   --> $DIR/loop_ice.rs:2:5
    |
 LL |     loop {} //~ ERROR loops are not allowed in const fn
    |     ^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0723`.

--- a/src/test/ui/consts/min_const_fn/min_const_fn.nll.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn.nll.stderr
@@ -4,11 +4,13 @@ error[E0493]: destructors cannot be evaluated at compile-time
 LL |     const fn into_inner(self) -> T { self.0 } //~ destructors cannot be evaluated
    |                         ^^^^ constant functions cannot evaluate destructors
 
-error: mutable references in const fn are unstable
+error[E0723]: mutable references in const fn are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:39:36
    |
 LL |     const fn get_mut(&mut self) -> &mut T { &mut self.0 }
    |                                    ^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error[E0493]: destructors cannot be evaluated at compile-time
   --> $DIR/min_const_fn.rs:44:28
@@ -16,11 +18,13 @@ error[E0493]: destructors cannot be evaluated at compile-time
 LL |     const fn into_inner_lt(self) -> T { self.0 } //~ destructors cannot be evaluated
    |                            ^^^^ constant functions cannot evaluate destructors
 
-error: mutable references in const fn are unstable
+error[E0723]: mutable references in const fn are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:46:42
    |
 LL |     const fn get_mut_lt(&'a mut self) -> &mut T { &mut self.0 }
    |                                          ^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error[E0493]: destructors cannot be evaluated at compile-time
   --> $DIR/min_const_fn.rs:51:27
@@ -28,173 +32,229 @@ error[E0493]: destructors cannot be evaluated at compile-time
 LL |     const fn into_inner_s(self) -> T { self.0 } //~ ERROR destructors
    |                           ^^^^ constant functions cannot evaluate destructors
 
-error: mutable references in const fn are unstable
+error[E0723]: mutable references in const fn are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:53:38
    |
 LL |     const fn get_mut_s(&mut self) -> &mut T { &mut self.0 }
    |                                      ^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: mutable references in const fn are unstable
+error[E0723]: mutable references in const fn are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:58:39
    |
 LL |     const fn get_mut_sq(&mut self) -> &mut T { &mut self.0 }
    |                                       ^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:76:16
    |
 LL | const fn foo11<T: std::fmt::Display>(t: T) -> T { t }
    |                ^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:78:18
    |
 LL | const fn foo11_2<T: Send>(t: T) -> T { t }
    |                  ^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: only int, `bool` and `char` operations are stable in const fn
+error[E0723]: only int, `bool` and `char` operations are stable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:80:33
    |
 LL | const fn foo19(f: f32) -> f32 { f * 2.0 }
    |                                 ^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: only int, `bool` and `char` operations are stable in const fn
+error[E0723]: only int, `bool` and `char` operations are stable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:82:35
    |
 LL | const fn foo19_2(f: f32) -> f32 { 2.0 - f }
    |                                   ^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: only int and `bool` operations are stable in const fn
+error[E0723]: only int and `bool` operations are stable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:84:35
    |
 LL | const fn foo19_3(f: f32) -> f32 { -f }
    |                                   ^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: only int, `bool` and `char` operations are stable in const fn
+error[E0723]: only int, `bool` and `char` operations are stable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:86:43
    |
 LL | const fn foo19_4(f: f32, g: f32) -> f32 { f / g }
    |                                           ^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: cannot access `static` items in const fn
+error[E0723]: cannot access `static` items in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:90:27
    |
 LL | const fn foo25() -> u32 { BAR } //~ ERROR cannot access `static` items in const fn
    |                           ^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: cannot access `static` items in const fn
+error[E0723]: cannot access `static` items in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:91:36
    |
 LL | const fn foo26() -> &'static u32 { &BAR } //~ ERROR cannot access `static` items
    |                                    ^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: casting pointers to ints is unstable in const fn
+error[E0723]: casting pointers to ints is unstable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:92:42
    |
 LL | const fn foo30(x: *const u32) -> usize { x as usize }
    |                                          ^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: casting pointers to ints is unstable in const fn
+error[E0723]: casting pointers to ints is unstable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:94:63
    |
 LL | const fn foo30_with_unsafe(x: *const u32) -> usize { unsafe { x as usize } }
    |                                                               ^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: casting pointers to ints is unstable in const fn
+error[E0723]: casting pointers to ints is unstable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:96:42
    |
 LL | const fn foo30_2(x: *mut u32) -> usize { x as usize }
    |                                          ^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: casting pointers to ints is unstable in const fn
+error[E0723]: casting pointers to ints is unstable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:98:63
    |
 LL | const fn foo30_2_with_unsafe(x: *mut u32) -> usize { unsafe { x as usize } }
    |                                                               ^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: `if`, `match`, `&&` and `||` are not stable in const fn
+error[E0723]: `if`, `match`, `&&` and `||` are not stable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:100:38
    |
 LL | const fn foo30_4(b: bool) -> usize { if b { 1 } else { 42 } }
    |                                      ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: `if`, `match`, `&&` and `||` are not stable in const fn
+error[E0723]: `if`, `match`, `&&` and `||` are not stable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:102:29
    |
 LL | const fn foo30_5(b: bool) { while b { } } //~ ERROR not stable in const fn
    |                             ^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: `if`, `match`, `&&` and `||` are not stable in const fn
+error[E0723]: `if`, `match`, `&&` and `||` are not stable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:104:44
    |
 LL | const fn foo36(a: bool, b: bool) -> bool { a && b }
    |                                            ^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: `if`, `match`, `&&` and `||` are not stable in const fn
+error[E0723]: `if`, `match`, `&&` and `||` are not stable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:106:44
    |
 LL | const fn foo37(a: bool, b: bool) -> bool { a || b }
    |                                            ^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: mutable references in const fn are unstable
+error[E0723]: mutable references in const fn are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:108:14
    |
 LL | const fn inc(x: &mut i32) { *x += 1 }
    |              ^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:113:6
    |
 LL | impl<T: std::fmt::Debug> Foo<T> {
    |      ^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:118:6
    |
 LL | impl<T: std::fmt::Debug + Sized> Foo<T> {
    |      ^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:123:6
    |
 LL | impl<T: Sync + Sized> Foo<T> {
    |      ^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: `impl Trait` in const fn is unstable
+error[E0723]: `impl Trait` in const fn is unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:129:24
    |
 LL | const fn no_rpit2() -> AlanTuring<impl std::fmt::Debug> { AlanTuring(0) }
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:131:34
    |
 LL | const fn no_apit2(_x: AlanTuring<impl std::fmt::Debug>) {}
    |                                  ^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:133:22
    |
 LL | const fn no_apit(_x: impl std::fmt::Debug) {} //~ ERROR trait bounds other than `Sized`
    |                      ^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: `impl Trait` in const fn is unstable
+error[E0723]: `impl Trait` in const fn is unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:134:23
    |
 LL | const fn no_rpit() -> impl std::fmt::Debug {} //~ ERROR `impl Trait` in const fn is unstable
    |                       ^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:135:23
    |
 LL | const fn no_dyn_trait(_x: &dyn std::fmt::Debug) {} //~ ERROR trait bounds other than `Sized`
    |                       ^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:136:32
    |
 LL | const fn no_dyn_trait_ret() -> &'static dyn std::fmt::Debug { &() }
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
 warning[E0515]: cannot return reference to temporary value
   --> $DIR/min_const_fn.rs:136:63
@@ -208,25 +268,31 @@ LL | const fn no_dyn_trait_ret() -> &'static dyn std::fmt::Debug { &() }
    = warning: this error has been downgraded to a warning for backwards compatibility with previous releases
    = warning: this represents potential undefined behavior in your code and this warning will become a hard error in the future
 
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:141:41
    |
 LL | const fn really_no_traits_i_mean_it() { (&() as &std::fmt::Debug, ()).1 }
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: function pointers in const fn are unstable
+error[E0723]: function pointers in const fn are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:144:21
    |
 LL | const fn no_fn_ptrs(_x: fn()) {}
    |                     ^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: function pointers in const fn are unstable
+error[E0723]: function pointers in const fn are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:146:27
    |
 LL | const fn no_fn_ptrs2() -> fn() { fn foo() {} foo }
    |                           ^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error: aborting due to 36 previous errors
 
-Some errors occurred: E0493, E0515.
+Some errors occurred: E0493, E0515, E0723.
 For more information about an error, try `rustc --explain E0493`.

--- a/src/test/ui/consts/min_const_fn/min_const_fn.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn.stderr
@@ -4,11 +4,13 @@ error[E0493]: destructors cannot be evaluated at compile-time
 LL |     const fn into_inner(self) -> T { self.0 } //~ destructors cannot be evaluated
    |                         ^^^^ constant functions cannot evaluate destructors
 
-error: mutable references in const fn are unstable
+error[E0723]: mutable references in const fn are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:39:36
    |
 LL |     const fn get_mut(&mut self) -> &mut T { &mut self.0 }
    |                                    ^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error[E0493]: destructors cannot be evaluated at compile-time
   --> $DIR/min_const_fn.rs:44:28
@@ -16,11 +18,13 @@ error[E0493]: destructors cannot be evaluated at compile-time
 LL |     const fn into_inner_lt(self) -> T { self.0 } //~ destructors cannot be evaluated
    |                            ^^^^ constant functions cannot evaluate destructors
 
-error: mutable references in const fn are unstable
+error[E0723]: mutable references in const fn are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:46:42
    |
 LL |     const fn get_mut_lt(&'a mut self) -> &mut T { &mut self.0 }
    |                                          ^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error[E0493]: destructors cannot be evaluated at compile-time
   --> $DIR/min_const_fn.rs:51:27
@@ -28,192 +32,255 @@ error[E0493]: destructors cannot be evaluated at compile-time
 LL |     const fn into_inner_s(self) -> T { self.0 } //~ ERROR destructors
    |                           ^^^^ constant functions cannot evaluate destructors
 
-error: mutable references in const fn are unstable
+error[E0723]: mutable references in const fn are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:53:38
    |
 LL |     const fn get_mut_s(&mut self) -> &mut T { &mut self.0 }
    |                                      ^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: mutable references in const fn are unstable
+error[E0723]: mutable references in const fn are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:58:39
    |
 LL |     const fn get_mut_sq(&mut self) -> &mut T { &mut self.0 }
    |                                       ^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:76:16
    |
 LL | const fn foo11<T: std::fmt::Display>(t: T) -> T { t }
    |                ^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:78:18
    |
 LL | const fn foo11_2<T: Send>(t: T) -> T { t }
    |                  ^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: only int, `bool` and `char` operations are stable in const fn
+error[E0723]: only int, `bool` and `char` operations are stable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:80:33
    |
 LL | const fn foo19(f: f32) -> f32 { f * 2.0 }
    |                                 ^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: only int, `bool` and `char` operations are stable in const fn
+error[E0723]: only int, `bool` and `char` operations are stable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:82:35
    |
 LL | const fn foo19_2(f: f32) -> f32 { 2.0 - f }
    |                                   ^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: only int and `bool` operations are stable in const fn
+error[E0723]: only int and `bool` operations are stable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:84:35
    |
 LL | const fn foo19_3(f: f32) -> f32 { -f }
    |                                   ^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: only int, `bool` and `char` operations are stable in const fn
+error[E0723]: only int, `bool` and `char` operations are stable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:86:43
    |
 LL | const fn foo19_4(f: f32, g: f32) -> f32 { f / g }
    |                                           ^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: cannot access `static` items in const fn
+error[E0723]: cannot access `static` items in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:90:27
    |
 LL | const fn foo25() -> u32 { BAR } //~ ERROR cannot access `static` items in const fn
    |                           ^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: cannot access `static` items in const fn
+error[E0723]: cannot access `static` items in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:91:36
    |
 LL | const fn foo26() -> &'static u32 { &BAR } //~ ERROR cannot access `static` items
    |                                    ^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: casting pointers to ints is unstable in const fn
+error[E0723]: casting pointers to ints is unstable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:92:42
    |
 LL | const fn foo30(x: *const u32) -> usize { x as usize }
    |                                          ^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: casting pointers to ints is unstable in const fn
+error[E0723]: casting pointers to ints is unstable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:94:63
    |
 LL | const fn foo30_with_unsafe(x: *const u32) -> usize { unsafe { x as usize } }
    |                                                               ^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: casting pointers to ints is unstable in const fn
+error[E0723]: casting pointers to ints is unstable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:96:42
    |
 LL | const fn foo30_2(x: *mut u32) -> usize { x as usize }
    |                                          ^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: casting pointers to ints is unstable in const fn
+error[E0723]: casting pointers to ints is unstable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:98:63
    |
 LL | const fn foo30_2_with_unsafe(x: *mut u32) -> usize { unsafe { x as usize } }
    |                                                               ^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: `if`, `match`, `&&` and `||` are not stable in const fn
+error[E0723]: `if`, `match`, `&&` and `||` are not stable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:100:38
    |
 LL | const fn foo30_4(b: bool) -> usize { if b { 1 } else { 42 } }
    |                                      ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: `if`, `match`, `&&` and `||` are not stable in const fn
+error[E0723]: `if`, `match`, `&&` and `||` are not stable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:102:29
    |
 LL | const fn foo30_5(b: bool) { while b { } } //~ ERROR not stable in const fn
    |                             ^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: `if`, `match`, `&&` and `||` are not stable in const fn
+error[E0723]: `if`, `match`, `&&` and `||` are not stable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:104:44
    |
 LL | const fn foo36(a: bool, b: bool) -> bool { a && b }
    |                                            ^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: `if`, `match`, `&&` and `||` are not stable in const fn
+error[E0723]: `if`, `match`, `&&` and `||` are not stable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:106:44
    |
 LL | const fn foo37(a: bool, b: bool) -> bool { a || b }
    |                                            ^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: mutable references in const fn are unstable
+error[E0723]: mutable references in const fn are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:108:14
    |
 LL | const fn inc(x: &mut i32) { *x += 1 }
    |              ^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:113:6
    |
 LL | impl<T: std::fmt::Debug> Foo<T> {
    |      ^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:118:6
    |
 LL | impl<T: std::fmt::Debug + Sized> Foo<T> {
    |      ^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:123:6
    |
 LL | impl<T: Sync + Sized> Foo<T> {
    |      ^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: `impl Trait` in const fn is unstable
+error[E0723]: `impl Trait` in const fn is unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:129:24
    |
 LL | const fn no_rpit2() -> AlanTuring<impl std::fmt::Debug> { AlanTuring(0) }
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:131:34
    |
 LL | const fn no_apit2(_x: AlanTuring<impl std::fmt::Debug>) {}
    |                                  ^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:133:22
    |
 LL | const fn no_apit(_x: impl std::fmt::Debug) {} //~ ERROR trait bounds other than `Sized`
    |                      ^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: `impl Trait` in const fn is unstable
+error[E0723]: `impl Trait` in const fn is unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:134:23
    |
 LL | const fn no_rpit() -> impl std::fmt::Debug {} //~ ERROR `impl Trait` in const fn is unstable
    |                       ^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:135:23
    |
 LL | const fn no_dyn_trait(_x: &dyn std::fmt::Debug) {} //~ ERROR trait bounds other than `Sized`
    |                       ^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:136:32
    |
 LL | const fn no_dyn_trait_ret() -> &'static dyn std::fmt::Debug { &() }
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:141:41
    |
 LL | const fn really_no_traits_i_mean_it() { (&() as &std::fmt::Debug, ()).1 }
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: function pointers in const fn are unstable
+error[E0723]: function pointers in const fn are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:144:21
    |
 LL | const fn no_fn_ptrs(_x: fn()) {}
    |                     ^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: function pointers in const fn are unstable
+error[E0723]: function pointers in const fn are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:146:27
    |
 LL | const fn no_fn_ptrs2() -> fn() { fn foo() {} foo }
    |                           ^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error: aborting due to 36 previous errors
 
-For more information about this error, try `rustc --explain E0493`.
+Some errors occurred: E0493, E0723.
+For more information about an error, try `rustc --explain E0493`.

--- a/src/test/ui/consts/min_const_fn/min_const_fn_dyn.nll.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn_dyn.nll.stderr
@@ -1,14 +1,18 @@
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn_dyn.rs:9:5
    |
 LL |     x.0.field;
    |     ^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn_dyn.rs:12:66
    |
 LL | const fn no_inner_dyn_trait_ret() -> Hide { Hide(HasDyn { field: &0 }) }
    |                                                                  ^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
 warning[E0716]: temporary value dropped while borrowed
   --> $DIR/min_const_fn_dyn.rs:12:67
@@ -24,4 +28,5 @@ LL | const fn no_inner_dyn_trait_ret() -> Hide { Hide(HasDyn { field: &0 }) }
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0716`.
+Some errors occurred: E0716, E0723.
+For more information about an error, try `rustc --explain E0716`.

--- a/src/test/ui/consts/min_const_fn/min_const_fn_dyn.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn_dyn.stderr
@@ -1,14 +1,19 @@
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn_dyn.rs:9:5
    |
 LL |     x.0.field;
    |     ^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn_dyn.rs:12:66
    |
 LL | const fn no_inner_dyn_trait_ret() -> Hide { Hide(HasDyn { field: &0 }) }
    |                                                                  ^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0723`.

--- a/src/test/ui/consts/min_const_fn/min_const_fn_fn_ptr.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn_fn_ptr.stderr
@@ -1,14 +1,19 @@
-error: function pointers in const fn are unstable
+error[E0723]: function pointers in const fn are unstable (see issue #57563)
   --> $DIR/min_const_fn_fn_ptr.rs:11:5
    |
 LL |     x.0.field;
    |     ^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: function pointers in const fn are unstable
+error[E0723]: function pointers in const fn are unstable (see issue #57563)
   --> $DIR/min_const_fn_fn_ptr.rs:14:59
    |
 LL | const fn no_inner_dyn_trait_ret() -> Hide { Hide(HasPtr { field }) }
    |                                                           ^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0723`.

--- a/src/test/ui/consts/min_const_fn/min_const_fn_libstd_stability.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn_libstd_stability.stderr
@@ -1,26 +1,35 @@
-error: can only call other `min_const_fn` within a `min_const_fn`
+error[E0723]: can only call other `min_const_fn` within a `min_const_fn` (see issue #57563)
   --> $DIR/min_const_fn_libstd_stability.rs:15:25
    |
 LL | const fn bar() -> u32 { foo() } //~ ERROR can only call other `min_const_fn`
    |                         ^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: can only call other `min_const_fn` within a `min_const_fn`
+error[E0723]: can only call other `min_const_fn` within a `min_const_fn` (see issue #57563)
   --> $DIR/min_const_fn_libstd_stability.rs:22:26
    |
 LL | const fn bar2() -> u32 { foo2() } //~ ERROR can only call other `min_const_fn`
    |                          ^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: only int, `bool` and `char` operations are stable in const fn
+error[E0723]: only int, `bool` and `char` operations are stable in const fn (see issue #57563)
   --> $DIR/min_const_fn_libstd_stability.rs:26:26
    |
 LL | const fn bar3() -> u32 { (5f32 + 6f32) as u32 } //~ ERROR only int, `bool` and `char` operations
    |                          ^^^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: can only call other `min_const_fn` within a `min_const_fn`
+error[E0723]: can only call other `min_const_fn` within a `min_const_fn` (see issue #57563)
   --> $DIR/min_const_fn_libstd_stability.rs:34:32
    |
 LL | const fn bar2_gated() -> u32 { foo2_gated() } //~ ERROR can only call other `min_const_fn`
    |                                ^^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error: aborting due to 4 previous errors
 
+For more information about this error, try `rustc --explain E0723`.

--- a/src/test/ui/consts/min_const_fn/min_const_unsafe_fn_libstd_stability.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_unsafe_fn_libstd_stability.stderr
@@ -1,26 +1,35 @@
-error: can only call other `min_const_fn` within a `min_const_fn`
+error[E0723]: can only call other `min_const_fn` within a `min_const_fn` (see issue #57563)
   --> $DIR/min_const_unsafe_fn_libstd_stability.rs:15:41
    |
 LL | const unsafe fn bar() -> u32 { unsafe { foo() } } //~ ERROR can only call other `min_const_fn`
    |                                         ^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: can only call other `min_const_fn` within a `min_const_fn`
+error[E0723]: can only call other `min_const_fn` within a `min_const_fn` (see issue #57563)
   --> $DIR/min_const_unsafe_fn_libstd_stability.rs:22:42
    |
 LL | const unsafe fn bar2() -> u32 { unsafe { foo2() } } //~ ERROR can only call other `min_const_fn`
    |                                          ^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: only int, `bool` and `char` operations are stable in const fn
+error[E0723]: only int, `bool` and `char` operations are stable in const fn (see issue #57563)
   --> $DIR/min_const_unsafe_fn_libstd_stability.rs:26:33
    |
 LL | const unsafe fn bar3() -> u32 { (5f32 + 6f32) as u32 } //~ ERROR only int, `bool` and `char` op
    |                                 ^^^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: can only call other `min_const_fn` within a `min_const_fn`
+error[E0723]: can only call other `min_const_fn` within a `min_const_fn` (see issue #57563)
   --> $DIR/min_const_unsafe_fn_libstd_stability.rs:34:48
    |
 LL | const unsafe fn bar2_gated() -> u32 { unsafe { foo2_gated() } } //~ ERROR can only call other
    |                                                ^^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error: aborting due to 4 previous errors
 
+For more information about this error, try `rustc --explain E0723`.

--- a/src/test/ui/consts/min_const_fn/min_const_unsafe_fn_libstd_stability2.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_unsafe_fn_libstd_stability2.stderr
@@ -1,20 +1,27 @@
-error: can only call other `min_const_fn` within a `min_const_fn`
+error[E0723]: can only call other `min_const_fn` within a `min_const_fn` (see issue #57563)
   --> $DIR/min_const_unsafe_fn_libstd_stability2.rs:15:32
    |
 LL | const unsafe fn bar() -> u32 { foo() } //~ ERROR can only call other `min_const_fn`
    |                                ^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: can only call other `min_const_fn` within a `min_const_fn`
+error[E0723]: can only call other `min_const_fn` within a `min_const_fn` (see issue #57563)
   --> $DIR/min_const_unsafe_fn_libstd_stability2.rs:22:33
    |
 LL | const unsafe fn bar2() -> u32 { foo2() } //~ ERROR can only call other `min_const_fn`
    |                                 ^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: can only call other `min_const_fn` within a `min_const_fn`
+error[E0723]: can only call other `min_const_fn` within a `min_const_fn` (see issue #57563)
   --> $DIR/min_const_unsafe_fn_libstd_stability2.rs:30:39
    |
 LL | const unsafe fn bar2_gated() -> u32 { foo2_gated() } //~ ERROR can only call other `min_const_fn`
    |                                       ^^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error: aborting due to 3 previous errors
 
+For more information about this error, try `rustc --explain E0723`.

--- a/src/test/ui/consts/min_const_fn/mutable_borrow.stderr
+++ b/src/test/ui/consts/min_const_fn/mutable_borrow.stderr
@@ -1,14 +1,19 @@
-error: mutable references in const fn are unstable
+error[E0723]: mutable references in const fn are unstable (see issue #57563)
   --> $DIR/mutable_borrow.rs:3:9
    |
 LL |     let b = &mut a; //~ ERROR mutable references in const fn
    |         ^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: mutable references in const fn are unstable
+error[E0723]: mutable references in const fn are unstable (see issue #57563)
   --> $DIR/mutable_borrow.rs:12:13
    |
 LL |         let b = &mut a; //~ ERROR mutable references in const fn
    |             ^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0723`.

--- a/src/test/ui/consts/single_variant_match_ice.stderr
+++ b/src/test/ui/consts/single_variant_match_ice.stderr
@@ -10,12 +10,15 @@ error[E0019]: constant contains unimplemented expression type
 LL |     x => 42, //~ ERROR unimplemented expression type
    |     ^
 
-error: `if`, `match`, `&&` and `||` are not stable in const fn
+error[E0723]: `if`, `match`, `&&` and `||` are not stable in const fn (see issue #57563)
   --> $DIR/single_variant_match_ice.rs:18:13
    |
 LL |             Prob => 0x1, //~ ERROR `if`, `match`, `&&` and `||` are not stable in const fn
    |             ^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error: aborting due to 3 previous errors
 
-For more information about this error, try `rustc --explain E0019`.
+Some errors occurred: E0019, E0723.
+For more information about an error, try `rustc --explain E0019`.

--- a/src/test/ui/issues/issue-37550.stderr
+++ b/src/test/ui/issues/issue-37550.stderr
@@ -1,8 +1,11 @@
-error: function pointers in const fn are unstable
+error[E0723]: function pointers in const fn are unstable (see issue #57563)
   --> $DIR/issue-37550.rs:3:9
    |
 LL |     let x = || t; //~ ERROR function pointers in const fn are unstable
    |         ^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0723`.

--- a/src/test/ui/unsafe/ranged_ints2_const.stderr
+++ b/src/test/ui/unsafe/ranged_ints2_const.stderr
@@ -1,14 +1,18 @@
-error: mutable references in const fn are unstable
+error[E0723]: mutable references in const fn are unstable (see issue #57563)
   --> $DIR/ranged_ints2_const.rs:11:9
    |
 LL |     let y = &mut x.0; //~ ERROR references in const fn are unstable
    |         ^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: mutable references in const fn are unstable
+error[E0723]: mutable references in const fn are unstable (see issue #57563)
   --> $DIR/ranged_ints2_const.rs:18:9
    |
 LL |     let y = unsafe { &mut x.0 }; //~ ERROR mutable references in const fn are unstable
    |         ^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error[E0133]: mutation of layout constrained field is unsafe and requires unsafe function or block
   --> $DIR/ranged_ints2_const.rs:11:13
@@ -20,4 +24,5 @@ LL |     let y = &mut x.0; //~ ERROR references in const fn are unstable
 
 error: aborting due to 3 previous errors
 
-For more information about this error, try `rustc --explain E0133`.
+Some errors occurred: E0133, E0723.
+For more information about an error, try `rustc --explain E0133`.


### PR DESCRIPTION
Before:
```
error: `impl Trait` in const fn is unstable
 --> src/lib.rs:7:19
  |
7 | const fn foo() -> impl T {
  |                   ^^^^^^

error: aborting due to previous error
```

After:
```
error[E0723]: `impl Trait` in const fn is unstable (see issue #57563)
 --> src/lib.rs:7:19
  |
7 | const fn foo() -> impl T {
  |                   ^^^^^^
  = help: add #![feature(const_fn)] to the crate attributes to enable

error: aborting due to previous error
```

This improves the situation with https://github.com/rust-lang/rust/issues/57563. Fixes https://github.com/rust-lang/rust/issues/57544. Fixes https://github.com/rust-lang/rust/issues/54469.

r? @oli-obk 