### PR TITLE
Ignore future deprecations in #[deprecated]

### DIFF
--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -598,37 +598,11 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         // Deprecated attributes apply in-crate and cross-crate.
         if let Some(id) = id {
             if let Some(depr_entry) = self.lookup_deprecation_entry(def_id) {
-                // If the deprecation is scheduled for a future Rust
-                // version, then we should display no warning message.
-                let deprecated_in_future_version = if let Some(sym) = depr_entry.attr.since {
-                    let since = sym.as_str();
-                    if !deprecation_in_effect(&since) {
-                        Some(since)
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                };
-
                 let parent_def_id = self.hir().local_def_id(self.hir().get_parent(id));
                 let skip = self.lookup_deprecation_entry(parent_def_id)
                                .map_or(false, |parent_depr| parent_depr.same_origin(&depr_entry));
 
-                if let Some(since) = deprecated_in_future_version {
-                    let path = self.item_path_str(def_id);
-                    let message = format!("use of item '{}' \
-                                           that will be deprecated in future version {}",
-                                          path,
-                                          since);
-
-                    lint_deprecated(def_id,
-                                    id,
-                                    depr_entry.attr.note,
-                                    None,
-                                    &message,
-                                    lint::builtin::DEPRECATED_IN_FUTURE);
-                } else if !skip {
+                if !skip {
                     let path = self.item_path_str(def_id);
                     let message = format!("use of deprecated item '{}'", path);
                     lint_deprecated(def_id,

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -2845,8 +2845,10 @@ fn short_stability(item: &clean::Item, cx: &Context) -> Vec<String> {
     let mut stability = vec![];
     let error_codes = ErrorCodes::from(UnstableFeatures::from_environment().is_nightly_build());
 
-    if let Some(Deprecation { since, note }) = &item.deprecation() {
-        let mut message = if let Some(since) = since {
+    if let Some(Deprecation { note, .. }) = &item.deprecation() {
+        // We display deprecation messages for #[deprecated] and #[rustc_deprecated]
+        // but only display the future-deprecation messages for #[rustc_deprecated].
+        let mut message = if let Some(since) = item.stability.deprecation.since {
             if stability::deprecation_in_effect(since) {
                 format!("Deprecated since {}", Escape(since))
             } else {

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -2855,16 +2855,18 @@ fn short_stability(item: &clean::Item, cx: &Context) -> Vec<String> {
     let mut stability = vec![];
     let error_codes = ErrorCodes::from(UnstableFeatures::from_environment().is_nightly_build());
 
-    if let Some(Deprecation { note, .. }) = &item.deprecation() {
+    if let Some(Deprecation { note, since }) = &item.deprecation() {
         // We display deprecation messages for #[deprecated] and #[rustc_deprecated]
         // but only display the future-deprecation messages for #[rustc_deprecated].
-        let mut message = String::from("Deprecated");
+        let mut message = if let Some(since) = since {
+            format!("Deprecated since {}", Escape(since))
+        } else {
+            String::from("Deprecated")
+        };
         if let Some(ref stab) = item.stability {
             if let Some(ref depr) = stab.deprecation {
                 if let Some(ref since) = depr.since {
-                    if stability::deprecation_in_effect(&since) {
-                        message = format!("Deprecated since {}", Escape(&since));
-                    } else {
+                    if !stability::deprecation_in_effect(&since) {
                         message = format!("Deprecating in {}", Escape(&since));
                     }
                 }

--- a/src/test/rustdoc/deprecated-future.rs
+++ b/src/test/rustdoc/deprecated-future.rs
@@ -1,5 +1,7 @@
 #![feature(deprecated)]
 
+// @has deprecated_future/index.html '//*[@class="stab deprecated"]' \
+//      'Deprecated'
 // @has deprecated_future/struct.S.html '//*[@class="stab deprecated"]' \
 //      'Deprecated since 99.99.99: effectively never'
 #[deprecated(since = "99.99.99", note = "effectively never")]

--- a/src/test/rustdoc/deprecated-future.rs
+++ b/src/test/rustdoc/deprecated-future.rs
@@ -1,6 +1,6 @@
 #![feature(deprecated)]
 
 // @has deprecated_future/struct.S.html '//*[@class="stab deprecated"]' \
-//      'Deprecating in 99.99.99: effectively never'
+//      'Deprecated since 99.99.99: effectively never'
 #[deprecated(since = "99.99.99", note = "effectively never")]
 pub struct S;

--- a/src/test/rustdoc/rustc_deprecated-future.rs
+++ b/src/test/rustdoc/rustc_deprecated-future.rs
@@ -1,0 +1,11 @@
+#![feature(staged_api)]
+
+#![stable(feature = "rustc_deprecated-future-test", since = "1.0.0")]
+
+// @has rustc_deprecated_future/index.html '//*[@class="stab deprecated"]' \
+//      'Deprecation planned'
+// @has rustc_deprecated_future/struct.S.html '//*[@class="stab deprecated"]' \
+//      'Deprecating in 99.99.99: effectively never'
+#[rustc_deprecated(since = "99.99.99", reason = "effectively never")]
+#[stable(feature = "rustc_deprecated-future-test", since = "1.0.0")]
+pub struct S;

--- a/src/test/ui/deprecation/deprecation-in-future.rs
+++ b/src/test/ui/deprecation/deprecation-in-future.rs
@@ -1,12 +1,14 @@
 // ignore-tidy-linelength
 
+// run-pass
+
 #![deny(deprecated_in_future)]
 
 #[deprecated(since = "99.99.99", note = "text")]
 pub fn deprecated_future() {}
 
 fn test() {
-    deprecated_future(); //~ ERROR use of item 'deprecated_future' that will be deprecated in future version 99.99.99: text
+    deprecated_future(); // ok; deprecated_in_future only applies to rustc_deprecated
 }
 
 fn main() {}

--- a/src/test/ui/deprecation/deprecation-in-future.stderr
+++ b/src/test/ui/deprecation/deprecation-in-future.stderr
@@ -1,14 +1,8 @@
-error: use of item 'deprecated_future' that will be deprecated in future version 99.99.99: text
-  --> $DIR/deprecation-in-future.rs:9:5
+warning: use of deprecated item 'deprecated_future': text
+  --> $DIR/deprecation-in-future.rs:11:5
    |
-LL |     deprecated_future(); //~ ERROR use of item 'deprecated_future' that will be deprecated in future version 99.99.99: text
+LL |     deprecated_future(); // ok; deprecated_in_future only applies to rustc_deprecated
    |     ^^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
-  --> $DIR/deprecation-in-future.rs:3:9
-   |
-LL | #![deny(deprecated_in_future)]
-   |         ^^^^^^^^^^^^^^^^^^^^
-
-error: aborting due to previous error
+   = note: #[warn(deprecated)] on by default
 

--- a/src/test/ui/deprecation/deprecation-lint.rs
+++ b/src/test/ui/deprecation/deprecation-lint.rs
@@ -261,8 +261,9 @@ mod this_crate {
         <Foo>::trait_deprecated_text(&foo); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
         <Foo as Trait>::trait_deprecated_text(&foo); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
 
-        deprecated_future(); // Fine; no error.
-        deprecated_future_text(); // Fine; no error.
+        // Future deprecations are only permitted for rustc_deprecated.
+        deprecated_future(); //~ ERROR use of deprecated item
+        deprecated_future_text(); //~ ERROR use of deprecated item
 
         let _ = DeprecatedStruct {
             //~^ ERROR use of deprecated item 'this_crate::DeprecatedStruct': text

--- a/src/test/ui/deprecation/deprecation-lint.stderr
+++ b/src/test/ui/deprecation/deprecation-lint.stderr
@@ -214,128 +214,140 @@ error: use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
 LL |         <Foo as Trait>::trait_deprecated_text(&foo); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+error: use of deprecated item 'this_crate::deprecated_future': text
+  --> $DIR/deprecation-lint.rs:265:9
+   |
+LL |         deprecated_future(); //~ ERROR use of deprecated item
+   |         ^^^^^^^^^^^^^^^^^
+
+error: use of deprecated item 'this_crate::deprecated_future_text': text
+  --> $DIR/deprecation-lint.rs:266:9
+   |
+LL |         deprecated_future_text(); //~ ERROR use of deprecated item
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+
 error: use of deprecated item 'this_crate::DeprecatedStruct': text
-  --> $DIR/deprecation-lint.rs:267:17
+  --> $DIR/deprecation-lint.rs:268:17
    |
 LL |         let _ = DeprecatedStruct {
    |                 ^^^^^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate::DeprecatedUnitStruct': text
-  --> $DIR/deprecation-lint.rs:272:17
+  --> $DIR/deprecation-lint.rs:273:17
    |
 LL |         let _ = DeprecatedUnitStruct; //~ ERROR use of deprecated item 'this_crate::DeprecatedUnitStruct': text
    |                 ^^^^^^^^^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate::Enum::DeprecatedVariant': text
-  --> $DIR/deprecation-lint.rs:274:17
+  --> $DIR/deprecation-lint.rs:275:17
    |
 LL |         let _ = Enum::DeprecatedVariant; //~ ERROR use of deprecated item 'this_crate::Enum::DeprecatedVariant': text
    |                 ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate::DeprecatedTupleStruct': text
-  --> $DIR/deprecation-lint.rs:276:17
+  --> $DIR/deprecation-lint.rs:277:17
    |
 LL |         let _ = DeprecatedTupleStruct (1); //~ ERROR use of deprecated item 'this_crate::DeprecatedTupleStruct': text
    |                 ^^^^^^^^^^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate::nested::DeprecatedStruct': text
-  --> $DIR/deprecation-lint.rs:278:17
+  --> $DIR/deprecation-lint.rs:279:17
    |
 LL |         let _ = nested::DeprecatedStruct {
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate::nested::DeprecatedUnitStruct': text
-  --> $DIR/deprecation-lint.rs:283:17
+  --> $DIR/deprecation-lint.rs:284:17
    |
 LL |         let _ = nested::DeprecatedUnitStruct; //~ ERROR use of deprecated item 'this_crate::nested::DeprecatedUnitStruct': text
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate::nested::Enum::DeprecatedVariant': text
-  --> $DIR/deprecation-lint.rs:285:17
+  --> $DIR/deprecation-lint.rs:286:17
    |
 LL |         let _ = nested::Enum::DeprecatedVariant; //~ ERROR use of deprecated item 'this_crate::nested::Enum::DeprecatedVariant': text
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate::nested::DeprecatedTupleStruct': text
-  --> $DIR/deprecation-lint.rs:287:17
+  --> $DIR/deprecation-lint.rs:288:17
    |
 LL |         let _ = nested::DeprecatedTupleStruct (1); //~ ERROR use of deprecated item 'this_crate::nested::DeprecatedTupleStruct': text
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate::Trait::trait_deprecated': text
-  --> $DIR/deprecation-lint.rs:292:9
+  --> $DIR/deprecation-lint.rs:293:9
    |
 LL |         Trait::trait_deprecated(&foo); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated'
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate::Trait::trait_deprecated': text
-  --> $DIR/deprecation-lint.rs:294:9
+  --> $DIR/deprecation-lint.rs:295:9
    |
 LL |         <Foo as Trait>::trait_deprecated(&foo); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated'
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
-  --> $DIR/deprecation-lint.rs:296:9
+  --> $DIR/deprecation-lint.rs:297:9
    |
 LL |         Trait::trait_deprecated_text(&foo); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
-  --> $DIR/deprecation-lint.rs:298:9
+  --> $DIR/deprecation-lint.rs:299:9
    |
 LL |         <Foo as Trait>::trait_deprecated_text(&foo); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate::test_fn_closure_body::{{closure}}::bar'
-  --> $DIR/deprecation-lint.rs:316:13
+  --> $DIR/deprecation-lint.rs:317:13
    |
 LL |             bar(); //~ ERROR use of deprecated item 'this_crate::test_fn_closure_body::{{closure}}::bar'
    |             ^^^
 
 error: use of deprecated item 'this_crate::DeprecatedTrait': text
-  --> $DIR/deprecation-lint.rs:335:10
+  --> $DIR/deprecation-lint.rs:336:10
    |
 LL |     impl DeprecatedTrait for S { } //~ ERROR use of deprecated item 'this_crate::DeprecatedTrait': text
    |          ^^^^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate::DeprecatedTrait': text
-  --> $DIR/deprecation-lint.rs:337:24
+  --> $DIR/deprecation-lint.rs:338:24
    |
 LL |     trait LocalTrait : DeprecatedTrait { } //~ ERROR use of deprecated item 'this_crate::DeprecatedTrait': text
    |                        ^^^^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate2::Deprecated': text
-  --> $DIR/deprecation-lint.rs:389:17
+  --> $DIR/deprecation-lint.rs:390:17
    |
 LL |         let x = Deprecated {
    |                 ^^^^^^^^^^
 
 error: use of deprecated item 'this_crate2::Deprecated': text
-  --> $DIR/deprecation-lint.rs:398:13
+  --> $DIR/deprecation-lint.rs:399:13
    |
 LL |         let Deprecated {
    |             ^^^^^^^^^^
 
 error: use of deprecated item 'this_crate2::Deprecated': text
-  --> $DIR/deprecation-lint.rs:404:13
+  --> $DIR/deprecation-lint.rs:405:13
    |
 LL |         let Deprecated
    |             ^^^^^^^^^^
 
 error: use of deprecated item 'this_crate2::Deprecated2': text
-  --> $DIR/deprecation-lint.rs:409:17
+  --> $DIR/deprecation-lint.rs:410:17
    |
 LL |         let x = Deprecated2(1, 2, 3);
    |                 ^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate2::Deprecated2': text
-  --> $DIR/deprecation-lint.rs:419:13
+  --> $DIR/deprecation-lint.rs:420:13
    |
 LL |         let Deprecated2
    |             ^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate2::Deprecated2': text
-  --> $DIR/deprecation-lint.rs:428:13
+  --> $DIR/deprecation-lint.rs:429:13
    |
 LL |         let Deprecated2
    |             ^^^^^^^^^^^
@@ -593,136 +605,136 @@ LL |         <Foo>::trait_deprecated_text(&foo); //~ ERROR use of deprecated ite
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate::DeprecatedStruct::i': text
-  --> $DIR/deprecation-lint.rs:269:13
+  --> $DIR/deprecation-lint.rs:270:13
    |
 LL |             i: 0 //~ ERROR use of deprecated item 'this_crate::DeprecatedStruct::i': text
    |             ^^^^
 
 error: use of deprecated item 'this_crate::nested::DeprecatedStruct::i': text
-  --> $DIR/deprecation-lint.rs:280:13
+  --> $DIR/deprecation-lint.rs:281:13
    |
 LL |             i: 0 //~ ERROR use of deprecated item 'this_crate::nested::DeprecatedStruct::i': text
    |             ^^^^
 
 error: use of deprecated item 'this_crate::Trait::trait_deprecated': text
-  --> $DIR/deprecation-lint.rs:291:13
+  --> $DIR/deprecation-lint.rs:292:13
    |
 LL |         foo.trait_deprecated(); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated'
    |             ^^^^^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate::Trait::trait_deprecated': text
-  --> $DIR/deprecation-lint.rs:293:9
+  --> $DIR/deprecation-lint.rs:294:9
    |
 LL |         <Foo>::trait_deprecated(&foo); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated'
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
-  --> $DIR/deprecation-lint.rs:295:13
+  --> $DIR/deprecation-lint.rs:296:13
    |
 LL |         foo.trait_deprecated_text(); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
    |             ^^^^^^^^^^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
-  --> $DIR/deprecation-lint.rs:297:9
+  --> $DIR/deprecation-lint.rs:298:9
    |
 LL |         <Foo>::trait_deprecated_text(&foo); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate::Trait::trait_deprecated': text
-  --> $DIR/deprecation-lint.rs:302:13
+  --> $DIR/deprecation-lint.rs:303:13
    |
 LL |         foo.trait_deprecated(); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated'
    |             ^^^^^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
-  --> $DIR/deprecation-lint.rs:303:13
+  --> $DIR/deprecation-lint.rs:304:13
    |
 LL |         foo.trait_deprecated_text(); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
    |             ^^^^^^^^^^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate2::Stable::override2': text
-  --> $DIR/deprecation-lint.rs:362:13
+  --> $DIR/deprecation-lint.rs:363:13
    |
 LL |             override2: 3,
    |             ^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate2::Stable::override2': text
-  --> $DIR/deprecation-lint.rs:366:17
+  --> $DIR/deprecation-lint.rs:367:17
    |
 LL |         let _ = x.override2;
    |                 ^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate2::Stable::override2': text
-  --> $DIR/deprecation-lint.rs:370:13
+  --> $DIR/deprecation-lint.rs:371:13
    |
 LL |             override2: _
    |             ^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate2::Stable2::2': text
-  --> $DIR/deprecation-lint.rs:378:17
+  --> $DIR/deprecation-lint.rs:379:17
    |
 LL |         let _ = x.2;
    |                 ^^^
 
 error: use of deprecated item 'this_crate2::Stable2::2': text
-  --> $DIR/deprecation-lint.rs:383:20
+  --> $DIR/deprecation-lint.rs:384:20
    |
 LL |                    _)
    |                    ^
 
 error: use of deprecated item 'this_crate2::Deprecated::inherit': text
-  --> $DIR/deprecation-lint.rs:391:13
+  --> $DIR/deprecation-lint.rs:392:13
    |
 LL |             inherit: 1,
    |             ^^^^^^^^^^
 
 error: use of deprecated item 'this_crate2::Deprecated::inherit': text
-  --> $DIR/deprecation-lint.rs:395:17
+  --> $DIR/deprecation-lint.rs:396:17
    |
 LL |         let _ = x.inherit;
    |                 ^^^^^^^^^
 
 error: use of deprecated item 'this_crate2::Deprecated::inherit': text
-  --> $DIR/deprecation-lint.rs:400:13
+  --> $DIR/deprecation-lint.rs:401:13
    |
 LL |             inherit: _,
    |             ^^^^^^^^^^
 
 error: use of deprecated item 'this_crate2::Deprecated2::0': text
-  --> $DIR/deprecation-lint.rs:412:17
+  --> $DIR/deprecation-lint.rs:413:17
    |
 LL |         let _ = x.0;
    |                 ^^^
 
 error: use of deprecated item 'this_crate2::Deprecated2::1': text
-  --> $DIR/deprecation-lint.rs:414:17
+  --> $DIR/deprecation-lint.rs:415:17
    |
 LL |         let _ = x.1;
    |                 ^^^
 
 error: use of deprecated item 'this_crate2::Deprecated2::2': text
-  --> $DIR/deprecation-lint.rs:416:17
+  --> $DIR/deprecation-lint.rs:417:17
    |
 LL |         let _ = x.2;
    |                 ^^^
 
 error: use of deprecated item 'this_crate2::Deprecated2::0': text
-  --> $DIR/deprecation-lint.rs:421:14
+  --> $DIR/deprecation-lint.rs:422:14
    |
 LL |             (_,
    |              ^
 
 error: use of deprecated item 'this_crate2::Deprecated2::1': text
-  --> $DIR/deprecation-lint.rs:423:14
+  --> $DIR/deprecation-lint.rs:424:14
    |
 LL |              _,
    |              ^
 
 error: use of deprecated item 'this_crate2::Deprecated2::2': text
-  --> $DIR/deprecation-lint.rs:425:14
+  --> $DIR/deprecation-lint.rs:426:14
    |
 LL |              _)
    |              ^
 
-error: aborting due to 120 previous errors
+error: aborting due to 122 previous errors
 

--- a/src/test/ui/deprecation/rustc_deprecation-in-future.rs
+++ b/src/test/ui/deprecation/rustc_deprecation-in-future.rs
@@ -1,0 +1,15 @@
+// ignore-tidy-linelength
+
+#![deny(deprecated_in_future)]
+
+#![feature(staged_api)]
+
+#![stable(feature = "rustc_deprecation-in-future-test", since = "1.0.0")]
+
+#[rustc_deprecated(since = "99.99.99", reason = "effectively never")]
+#[stable(feature = "rustc_deprecation-in-future-test", since = "1.0.0")]
+pub struct S;
+
+fn main() {
+    let _ = S; //~ ERROR use of item 'S' that will be deprecated in future version 99.99.99: effectively never
+}

--- a/src/test/ui/deprecation/rustc_deprecation-in-future.stderr
+++ b/src/test/ui/deprecation/rustc_deprecation-in-future.stderr
@@ -1,0 +1,14 @@
+error: use of item 'S' that will be deprecated in future version 99.99.99: effectively never
+  --> $DIR/rustc_deprecation-in-future.rs:14:13
+   |
+LL |     let _ = S; //~ ERROR use of item 'S' that will be deprecated in future version 99.99.99: effectively never
+   |             ^
+   |
+note: lint level defined here
+  --> $DIR/rustc_deprecation-in-future.rs:3:9
+   |
+LL | #![deny(deprecated_in_future)]
+   |         ^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
The future deprecation warnings should only apply to `#[rustc_deprecated]` as they take into account rustc's version. Fixes #57952.

I've also slightly modified rustdoc's display of future deprecation notices to make it more consistent, so I'm assigning a rustdoc team member for review to make sure this is okay.

r? @GuillaumeGomez