### PR TITLE
Make an assert debug-only in `find_constraint_paths_between_regions`.

### DIFF
--- a/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/mod.rs
@@ -205,7 +205,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             for constraint in self.constraint_graph
                 .outgoing_edges(r, &self.constraints, fr_static)
             {
-                assert_eq!(constraint.sup, r);
+                debug_assert_eq!(constraint.sup, r);
                 let sub_region = constraint.sub;
                 if let Trace::NotVisited = context[sub_region] {
                     context[sub_region] = Trace::FromOutlivesConstraint(constraint);


### PR DESCRIPTION
This reduces instruction counts for NLL builds of `wg-grammar` by over
20%.

r? @nikomatsakis