### PR TITLE
Add embedded book to test such that checktools works

### DIFF
--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1383,6 +1383,7 @@ test_book!(
     RustdocBook, "src/doc/rustdoc", "rustdoc", default=true;
     RustcBook, "src/doc/rustc", "rustc", default=true;
     RustByExample, "src/doc/rust-by-example", "rust-by-example", default=false;
+    EmbeddedBook, "src/doc/embedded-book", "embedded-book", default=false;
     TheBook, "src/doc/book", "book", default=false;
     UnstableBook, "src/doc/unstable-book", "unstable-book", default=true;
 );


### PR DESCRIPTION
r? @alexcrichton 

FWIW this doesn't attempt to make sure we don't break check tools again -- we intentionally make the bash script not exit when x.py fails so we'd need some special case handling so for now I'm just fixing the bug itself, not its cause.