### PR TITLE
librustc_tsan => 2018

### DIFF
--- a/src/librustc_tsan/Cargo.toml
+++ b/src/librustc_tsan/Cargo.toml
@@ -3,6 +3,7 @@ authors = ["The Rust Project Developers"]
 build = "build.rs"
 name = "rustc_tsan"
 version = "0.0.0"
+edition = "2018"
 
 [lib]
 name = "rustc_tsan"

--- a/src/librustc_tsan/build.rs
+++ b/src/librustc_tsan/build.rs
@@ -1,6 +1,3 @@
-extern crate build_helper;
-extern crate cmake;
-
 use std::env;
 use build_helper::sanitizer_lib_boilerplate;
 

--- a/src/librustc_tsan/lib.rs
+++ b/src/librustc_tsan/lib.rs
@@ -1,8 +1,9 @@
 #![sanitizer_runtime]
-#![feature(nll)]
 #![feature(sanitizer_runtime)]
 #![feature(staged_api)]
 #![no_std]
 #![unstable(feature = "sanitizer_runtime_lib",
             reason = "internal implementation detail of sanitizers",
             issue = "0")]
+
+#![deny(rust_2018_idioms)]


### PR DESCRIPTION
Transitions `librustc_tsan` to Rust 2018; cc #58099

r? @Centril