### PR TITLE
libprofiler_builtins => 2018

### DIFF
--- a/src/libprofiler_builtins/Cargo.toml
+++ b/src/libprofiler_builtins/Cargo.toml
@@ -3,6 +3,7 @@ authors = ["The Rust Project Developers"]
 build = "build.rs"
 name = "profiler_builtins"
 version = "0.0.0"
+edition = "2018"
 
 [lib]
 name = "profiler_builtins"

--- a/src/libprofiler_builtins/build.rs
+++ b/src/libprofiler_builtins/build.rs
@@ -2,8 +2,6 @@
 //!
 //! See the build.rs for libcompiler_builtins crate for details.
 
-extern crate cc;
-
 use std::env;
 use std::path::Path;
 

--- a/src/libprofiler_builtins/lib.rs
+++ b/src/libprofiler_builtins/lib.rs
@@ -5,5 +5,5 @@
             reason = "internal implementation detail of rustc right now",
             issue = "0")]
 #![allow(unused_features)]
-#![feature(nll)]
 #![feature(staged_api)]
+#![deny(rust_2018_idioms)]


### PR DESCRIPTION
Transitions `libprofiler_builtins` to Rust 2018; cc #58099

r? @Centril