### PR TITLE
 multiple substitutions become multiple children in JSON output

### DIFF
--- a/src/test/ui/json_error_format/issue-53934-multiple-parts.rs
+++ b/src/test/ui/json_error_format/issue-53934-multiple-parts.rs
@@ -1,0 +1,8 @@
+// compile-flags: --error-format pretty-json -Zunstable-options
+
+struct Point { x: isize, y: isize }
+
+fn main() {
+    let p = Point { x: 1, y: 2 };
+    let Point { .., y, } = p;
+}

--- a/src/test/ui/json_error_format/issue-53934-multiple-parts.stderr
+++ b/src/test/ui/json_error_format/issue-53934-multiple-parts.stderr
@@ -1,0 +1,126 @@
+{
+  "message": "expected `}`, found `,`",
+  "code": null,
+  "level": "error",
+  "spans": [
+    {
+      "file_name": "$DIR/issue-53934-multiple-parts.rs",
+      "byte_start": 166,
+      "byte_end": 167,
+      "line_start": 7,
+      "line_end": 7,
+      "column_start": 19,
+      "column_end": 20,
+      "is_primary": true,
+      "text": [
+        {
+          "text": "    let Point { .., y, } = p;",
+          "highlight_start": 19,
+          "highlight_end": 20
+        }
+      ],
+      "label": "expected `}`",
+      "suggested_replacement": null,
+      "suggestion_applicability": null,
+      "expansion": null
+    },
+    {
+      "file_name": "$DIR/issue-53934-multiple-parts.rs",
+      "byte_start": 164,
+      "byte_end": 167,
+      "line_start": 7,
+      "line_end": 7,
+      "column_start": 17,
+      "column_end": 20,
+      "is_primary": false,
+      "text": [
+        {
+          "text": "    let Point { .., y, } = p;",
+          "highlight_start": 17,
+          "highlight_end": 20
+        }
+      ],
+      "label": "`..` must be at the end and cannot have a trailing comma",
+      "suggested_replacement": null,
+      "suggestion_applicability": null,
+      "expansion": null
+    }
+  ],
+  "children": [
+    {
+      "message": "move the `..` to the end of the field list",
+      "code": null,
+      "level": "help",
+      "spans": [
+        {
+          "file_name": "$DIR/issue-53934-multiple-parts.rs",
+          "byte_start": 164,
+          "byte_end": 168,
+          "line_start": 7,
+          "line_end": 7,
+          "column_start": 17,
+          "column_end": 21,
+          "is_primary": true,
+          "text": [
+            {
+              "text": "    let Point { .., y, } = p;",
+              "highlight_start": 17,
+              "highlight_end": 21
+            }
+          ],
+          "label": null,
+          "suggested_replacement": "",
+          "suggestion_applicability": "MachineApplicable",
+          "expansion": null
+        },
+        {
+          "file_name": "$DIR/issue-53934-multiple-parts.rs",
+          "byte_start": 171,
+          "byte_end": 172,
+          "line_start": 7,
+          "line_end": 7,
+          "column_start": 24,
+          "column_end": 25,
+          "is_primary": true,
+          "text": [
+            {
+              "text": "    let Point { .., y, } = p;",
+              "highlight_start": 24,
+              "highlight_end": 25
+            }
+          ],
+          "label": null,
+          "suggested_replacement": ".. }",
+          "suggestion_applicability": "MachineApplicable",
+          "expansion": null
+        }
+      ],
+      "children": [],
+      "rendered": null
+    }
+  ],
+  "rendered": "error: expected `}`, found `,`
+  --> $DIR/issue-53934-multiple-parts.rs:7:19
+   |
+LL |     let Point { .., y, } = p;
+   |                 --^
+   |                 | |
+   |                 | expected `}`
+   |                 `..` must be at the end and cannot have a trailing comma
+help: move the `..` to the end of the field list
+   |
+LL |     let Point { y, .. } = p;
+   |                --  ^^^^
+
+"
+}
+{
+  "message": "aborting due to previous error",
+  "code": null,
+  "level": "error",
+  "spans": [],
+  "children": [],
+  "rendered": "error: aborting due to previous error
+
+"
+}

--- a/src/test/ui/json_error_format/issue-53934-multiple-substitutions.rs
+++ b/src/test/ui/json_error_format/issue-53934-multiple-substitutions.rs
@@ -1,0 +1,7 @@
+// compile-flags: --error-format pretty-json -Zunstable-options
+
+fn main() {
+    let xs = vec![String::from("foo")];
+    let d: &Display = &xs;
+    println!("{}", d);
+}

--- a/src/test/ui/json_error_format/issue-53934-multiple-substitutions.stderr
+++ b/src/test/ui/json_error_format/issue-53934-multiple-substitutions.stderr
@@ -1,0 +1,185 @@
+{
+  "message": "cannot find type `Display` in this scope",
+  "code": {
+    "code": "E0412",
+    "explanation": "
+The type name used is not in scope.
+
+Erroneous code examples:
+
+```compile_fail,E0412
+impl Something {} // error: type name `Something` is not in scope
+
+// or:
+
+trait Foo {
+    fn bar(N); // error: type name `N` is not in scope
+}
+
+// or:
+
+fn foo(x: T) {} // type name `T` is not in scope
+```
+
+To fix this error, please verify you didn't misspell the type name, you did
+declare it or imported it into the scope. Examples:
+
+```
+struct Something;
+
+impl Something {} // ok!
+
+// or:
+
+trait Foo {
+    type N;
+
+    fn bar(_: Self::N); // ok!
+}
+
+// or:
+
+fn foo<T>(x: T) {} // ok!
+```
+
+Another case that causes this error is when a type is imported into a parent
+module. To fix this, you can follow the suggestion and use File directly or
+`use super::File;` which will import the types from the parent namespace. An
+example that causes this error is below:
+
+```compile_fail,E0412
+use std::fs::File;
+
+mod foo {
+    fn some_function(f: File) {}
+}
+```
+
+```
+use std::fs::File;
+
+mod foo {
+    // either
+    use super::File;
+    // or
+    // use std::fs::File;
+    fn foo(f: File) {}
+}
+# fn main() {} // don't insert it for us; that'll break imports
+```
+"
+  },
+  "level": "error",
+  "spans": [
+    {
+      "file_name": "$DIR/issue-53934-multiple-substitutions.rs",
+      "byte_start": 129,
+      "byte_end": 136,
+      "line_start": 5,
+      "line_end": 5,
+      "column_start": 13,
+      "column_end": 20,
+      "is_primary": true,
+      "text": [
+        {
+          "text": "    let d: &Display = &xs;",
+          "highlight_start": 13,
+          "highlight_end": 20
+        }
+      ],
+      "label": "not found in this scope",
+      "suggested_replacement": null,
+      "suggestion_applicability": null,
+      "expansion": null
+    }
+  ],
+  "children": [
+    {
+      "message": "possible candidates are found in other modules, you can import them into scope",
+      "code": null,
+      "level": "help",
+      "spans": [
+        {
+          "file_name": "$DIR/issue-53934-multiple-substitutions.rs",
+          "byte_start": 65,
+          "byte_end": 65,
+          "line_start": 3,
+          "line_end": 3,
+          "column_start": 1,
+          "column_end": 1,
+          "is_primary": true,
+          "text": [
+            {
+              "text": "fn main() {",
+              "highlight_start": 1,
+              "highlight_end": 1
+            }
+          ],
+          "label": null,
+          "suggested_replacement": "use std::fmt::Display;
+
+",
+          "suggestion_applicability": "Unspecified",
+          "expansion": null
+        },
+        {
+          "file_name": "$DIR/issue-53934-multiple-substitutions.rs",
+          "byte_start": 65,
+          "byte_end": 65,
+          "line_start": 3,
+          "line_end": 3,
+          "column_start": 1,
+          "column_end": 1,
+          "is_primary": true,
+          "text": [
+            {
+              "text": "fn main() {",
+              "highlight_start": 1,
+              "highlight_end": 1
+            }
+          ],
+          "label": null,
+          "suggested_replacement": "use std::path::Display;
+
+",
+          "suggestion_applicability": "Unspecified",
+          "expansion": null
+        }
+      ],
+      "children": [],
+      "rendered": null
+    }
+  ],
+  "rendered": "error[E0412]: cannot find type `Display` in this scope
+  --> $DIR/issue-53934-multiple-substitutions.rs:5:13
+   |
+LL |     let d: &Display = &xs;
+   |             ^^^^^^^ not found in this scope
+help: possible candidates are found in other modules, you can import them into scope
+   |
+LL | use std::fmt::Display;
+   |
+LL | use std::path::Display;
+   |
+
+"
+}
+{
+  "message": "aborting due to previous error",
+  "code": null,
+  "level": "error",
+  "spans": [],
+  "children": [],
+  "rendered": "error: aborting due to previous error
+
+"
+}
+{
+  "message": "For more information about this error, try `rustc --explain E0412`.",
+  "code": null,
+  "level": "",
+  "spans": [],
+  "children": [],
+  "rendered": "For more information about this error, try `rustc --explain E0412`.
+"
+}

--- a/src/test/ui/json_error_format/issue-53934-multiple-substitutions.stderr
+++ b/src/test/ui/json_error_format/issue-53934-multiple-substitutions.stderr
@@ -121,7 +121,16 @@ mod foo {
 ",
           "suggestion_applicability": "Unspecified",
           "expansion": null
-        },
+        }
+      ],
+      "children": [],
+      "rendered": null
+    },
+    {
+      "message": "possible candidates are found in other modules, you can import them into scope",
+      "code": null,
+      "level": "help",
+      "spans": [
         {
           "file_name": "$DIR/issue-53934-multiple-substitutions.rs",
           "byte_start": 65,

--- a/src/test/ui/lint/use_suggestion_json.stderr
+++ b/src/test/ui/lint/use_suggestion_json.stderr
@@ -121,7 +121,16 @@ mod foo {
 ",
           "suggestion_applicability": "Unspecified",
           "expansion": null
-        },
+        }
+      ],
+      "children": [],
+      "rendered": null
+    },
+    {
+      "message": "possible candidates are found in other modules, you can import them into scope",
+      "code": null,
+      "level": "help",
+      "spans": [
         {
           "file_name": "$DIR/use_suggestion_json.rs",
           "byte_start": 417,
@@ -144,7 +153,16 @@ mod foo {
 ",
           "suggestion_applicability": "Unspecified",
           "expansion": null
-        },
+        }
+      ],
+      "children": [],
+      "rendered": null
+    },
+    {
+      "message": "possible candidates are found in other modules, you can import them into scope",
+      "code": null,
+      "level": "help",
+      "spans": [
         {
           "file_name": "$DIR/use_suggestion_json.rs",
           "byte_start": 417,
@@ -167,7 +185,16 @@ mod foo {
 ",
           "suggestion_applicability": "Unspecified",
           "expansion": null
-        },
+        }
+      ],
+      "children": [],
+      "rendered": null
+    },
+    {
+      "message": "possible candidates are found in other modules, you can import them into scope",
+      "code": null,
+      "level": "help",
+      "spans": [
         {
           "file_name": "$DIR/use_suggestion_json.rs",
           "byte_start": 417,
@@ -190,7 +217,16 @@ mod foo {
 ",
           "suggestion_applicability": "Unspecified",
           "expansion": null
-        },
+        }
+      ],
+      "children": [],
+      "rendered": null
+    },
+    {
+      "message": "possible candidates are found in other modules, you can import them into scope",
+      "code": null,
+      "level": "help",
+      "spans": [
         {
           "file_name": "$DIR/use_suggestion_json.rs",
           "byte_start": 417,
@@ -213,7 +249,16 @@ mod foo {
 ",
           "suggestion_applicability": "Unspecified",
           "expansion": null
-        },
+        }
+      ],
+      "children": [],
+      "rendered": null
+    },
+    {
+      "message": "possible candidates are found in other modules, you can import them into scope",
+      "code": null,
+      "level": "help",
+      "spans": [
         {
           "file_name": "$DIR/use_suggestion_json.rs",
           "byte_start": 417,
@@ -236,7 +281,16 @@ mod foo {
 ",
           "suggestion_applicability": "Unspecified",
           "expansion": null
-        },
+        }
+      ],
+      "children": [],
+      "rendered": null
+    },
+    {
+      "message": "possible candidates are found in other modules, you can import them into scope",
+      "code": null,
+      "level": "help",
+      "spans": [
         {
           "file_name": "$DIR/use_suggestion_json.rs",
           "byte_start": 417,
@@ -259,7 +313,16 @@ mod foo {
 ",
           "suggestion_applicability": "Unspecified",
           "expansion": null
-        },
+        }
+      ],
+      "children": [],
+      "rendered": null
+    },
+    {
+      "message": "possible candidates are found in other modules, you can import them into scope",
+      "code": null,
+      "level": "help",
+      "spans": [
         {
           "file_name": "$DIR/use_suggestion_json.rs",
           "byte_start": 417,
@@ -282,7 +345,16 @@ mod foo {
 ",
           "suggestion_applicability": "Unspecified",
           "expansion": null
-        },
+        }
+      ],
+      "children": [],
+      "rendered": null
+    },
+    {
+      "message": "possible candidates are found in other modules, you can import them into scope",
+      "code": null,
+      "level": "help",
+      "spans": [
         {
           "file_name": "$DIR/use_suggestion_json.rs",
           "byte_start": 417,
@@ -305,7 +377,16 @@ mod foo {
 ",
           "suggestion_applicability": "Unspecified",
           "expansion": null
-        },
+        }
+      ],
+      "children": [],
+      "rendered": null
+    },
+    {
+      "message": "possible candidates are found in other modules, you can import them into scope",
+      "code": null,
+      "level": "help",
+      "spans": [
         {
           "file_name": "$DIR/use_suggestion_json.rs",
           "byte_start": 417,
@@ -328,7 +409,16 @@ mod foo {
 ",
           "suggestion_applicability": "Unspecified",
           "expansion": null
-        },
+        }
+      ],
+      "children": [],
+      "rendered": null
+    },
+    {
+      "message": "possible candidates are found in other modules, you can import them into scope",
+      "code": null,
+      "level": "help",
+      "spans": [
         {
           "file_name": "$DIR/use_suggestion_json.rs",
           "byte_start": 417,
@@ -351,7 +441,16 @@ mod foo {
 ",
           "suggestion_applicability": "Unspecified",
           "expansion": null
-        },
+        }
+      ],
+      "children": [],
+      "rendered": null
+    },
+    {
+      "message": "possible candidates are found in other modules, you can import them into scope",
+      "code": null,
+      "level": "help",
+      "spans": [
         {
           "file_name": "$DIR/use_suggestion_json.rs",
           "byte_start": 417,


### PR DESCRIPTION
This is a proposed fix for #53934.

The problem being solved is this: in our internal representation of diagnostics, a `CodeSuggestion` can have one or more `Substitutions`, which can in turn have more than one `SubstitutionPart`s. The vast majority of suggestions have just one `Substitution` and one `SubstitutionPart`, but `.span_suggestions` creates multiple `Substitutions` and `.multipart_suggestion` creates multiple `SubstitutionParts`.

Previously, the JSON-emitter was flat-mapping spans into the `children` field of serialized diagnostics, thereby conflating the one-substitution-with-multiple-parts case and the multiple-substitutions-with-one-part-each case, which tools like Rustfix need to be able to distinguish between. Here, we make multiple substitutions appear as multiple children, which is logical. Rustfix was already explicitly bailing out when it found multiple solutions, so there should be no breakage there. Breakage to RLS or third-party tooling may be possible, but is hoped/believed to be acceptable/within-policy (the intent here is to fix outright buggy output, not to constitute an incompatible change to the format).

Look specifically at the diff of the second "multiple substitutions become ..." commit to see the diff in the JSON output. (The first commit introduces some `--error-format json` UI tests specifically to document this.)

https://github.com/rust-lang-nursery/rustfix/pull/162 is the sister pull-request for rustfix.

**Don't merge this yet**; the following items need to be resolved first—

 - [ ] ui/did_you_mean/issue-42764.rs specifically is failing for me locally, which I don't understand?? Presumably Travis will reproduce?
 - [x] check that `cargo fix` can fix a multi-span substitution
 - [ ] look into how other tools cope with multiple substitutions being separate children
     - [ ] `cargo fix` (requires rustfix built with rust-lang-nursery/rustfix#162)
     - [ ] RLS/VSCode
     - [ ] @ehuss [reports having a tool](https://github.com/rust-lang/rust/issues/53934#issuecomment-418403880) that depends on the JSON output

Thanks to @pietroalbini, @estebank, and @killercup for discussion at the 2019 All-Hands meeting.

r? @ghost (attempting to suppress bors autoassignment since this isn't ready yet)