### PR TITLE
librustc_allocator => 2018

### DIFF
--- a/src/librustc_allocator/Cargo.toml
+++ b/src/librustc_allocator/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_allocator"
 version = "0.0.0"
+edition = "2018"
 
 [lib]
 path = "lib.rs"

--- a/src/librustc_allocator/expand.rs
+++ b/src/librustc_allocator/expand.rs
@@ -1,6 +1,6 @@
+use log::debug;
 use rustc::middle::allocator::AllocatorKind;
-use rustc_errors;
-use smallvec::SmallVec;
+use smallvec::{smallvec, SmallVec};
 use syntax::{
     ast::{
         self, Arg, Attribute, Crate, Expr, FnHeader, Generics, Ident, Item, ItemKind,
@@ -23,7 +23,7 @@ use syntax::{
 };
 use syntax_pos::Span;
 
-use {AllocatorMethod, AllocatorTy, ALLOCATOR_METHODS};
+use crate::{AllocatorMethod, AllocatorTy, ALLOCATOR_METHODS};
 
 pub fn modify(
     sess: &ParseSess,
@@ -54,7 +54,7 @@ struct ExpandAllocatorDirectives<'a> {
     in_submod: isize,
 }
 
-impl<'a> MutVisitor for ExpandAllocatorDirectives<'a> {
+impl MutVisitor for ExpandAllocatorDirectives<'_> {
     fn flat_map_item(&mut self, item: P<Item>) -> SmallVec<[P<Item>; 1]> {
         debug!("in submodule {}", self.in_submod);
 
@@ -168,7 +168,7 @@ struct AllocFnFactory<'a> {
     cx: ExtCtxt<'a>,
 }
 
-impl<'a> AllocFnFactory<'a> {
+impl AllocFnFactory<'_> {
     fn allocator_fn(&self, method: &AllocatorMethod) -> P<Item> {
         let mut abi_args = Vec::new();
         let mut i = 0;

--- a/src/librustc_allocator/lib.rs
+++ b/src/librustc_allocator/lib.rs
@@ -1,15 +1,6 @@
-#![feature(nll)]
 #![feature(rustc_private)]
 
-#[macro_use] extern crate log;
-extern crate rustc;
-extern crate rustc_data_structures;
-extern crate rustc_errors;
-extern crate rustc_target;
-extern crate syntax;
-extern crate syntax_pos;
-#[macro_use]
-extern crate smallvec;
+#![deny(rust_2018_idioms)]
 
 pub mod expand;
 


### PR DESCRIPTION
Transitions `librustc_allocator` to Rust 2018; cc #58099

r? @Centril