### PR TITLE
librustc_fs_util => 2018

### DIFF
--- a/src/librustc_fs_util/Cargo.toml
+++ b/src/librustc_fs_util/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_fs_util"
 version = "0.0.0"
+edition = "2018"
 
 [lib]
 name = "rustc_fs_util"

--- a/src/librustc_fs_util/lib.rs
+++ b/src/librustc_fs_util/lib.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 use std::path::{Path, PathBuf};
 use std::ffi::CString;
 use std::fs;


### PR DESCRIPTION
Transitions `librustc_fs_util` to Rust 2018; cc #58099

r? @Centril