### PR TITLE
librustc_plugin => 2018

### DIFF
--- a/src/librustc_plugin/Cargo.toml
+++ b/src/librustc_plugin/Cargo.toml
@@ -3,6 +3,7 @@ authors = ["The Rust Project Developers"]
 name = "rustc_plugin"
 version = "0.0.0"
 build = false
+edition = "2018"
 
 [lib]
 name = "rustc_plugin"

--- a/src/librustc_plugin/diagnostics.rs
+++ b/src/librustc_plugin/diagnostics.rs
@@ -1,5 +1,7 @@
 #![allow(non_snake_case)]
 
+use syntax::{register_diagnostic, register_diagnostics, register_long_diagnostics};
+
 register_long_diagnostics! {
 
 }

--- a/src/librustc_plugin/lib.rs
+++ b/src/librustc_plugin/lib.rs
@@ -54,19 +54,13 @@
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
        html_root_url = "https://doc.rust-lang.org/nightly/")]
 
-#![feature(nll)]
 #![feature(rustc_diagnostic_macros)]
 
 #![recursion_limit="256"]
 
-#[macro_use] extern crate syntax;
+#![deny(rust_2018_idioms)]
 
-extern crate rustc;
-extern crate rustc_metadata;
-extern crate syntax_pos;
-extern crate rustc_errors as errors;
-
-pub use self::registry::Registry;
+pub use registry::Registry;
 
 mod diagnostics;
 pub mod registry;

--- a/src/librustc_plugin/load.rs
+++ b/src/librustc_plugin/load.rs
@@ -3,18 +3,19 @@
 use rustc::session::Session;
 use rustc_metadata::creader::CrateLoader;
 use rustc_metadata::cstore::CStore;
-use registry::Registry;
+use crate::registry::Registry;
 
 use std::borrow::ToOwned;
 use std::env;
 use std::mem;
 use std::path::PathBuf;
 use syntax::ast;
+use syntax::span_err;
 use syntax_pos::{Span, DUMMY_SP};
 
 /// Pointer to a registrar function.
 pub type PluginRegistrarFun =
-    fn(&mut Registry);
+    fn(&mut Registry<'_>);
 
 pub struct PluginRegistrar {
     pub fun: PluginRegistrarFun,


### PR DESCRIPTION
Transitions `librustc_plugin` to Rust 2018; cc #58099

r? @Centril