### PR TITLE
HirId-ify intravisit

### DIFF
--- a/src/librustc/hir/intravisit.rs
+++ b/src/librustc/hir/intravisit.rs
@@ -31,7 +31,7 @@
 //! This order consistency is required in a few places in rustc, for
 //! example generator inference, and possibly also HIR borrowck.
 
-use syntax::ast::{NodeId, CRATE_NODE_ID, Ident, Name, Attribute};
+use syntax::ast::{Ident, Name, Attribute};
 use syntax_pos::Span;
 use crate::hir::*;
 use crate::hir::def::Def;
@@ -225,7 +225,7 @@ pub trait Visitor<'v> : Sized {
 
     ///////////////////////////////////////////////////////////////////////////
 
-    fn visit_id(&mut self, _node_id: NodeId) {
+    fn visit_id(&mut self, _hir_id: HirId) {
         // Nothing to do.
     }
     fn visit_def_mention(&mut self, _def: Def) {
@@ -237,7 +237,7 @@ pub trait Visitor<'v> : Sized {
     fn visit_ident(&mut self, ident: Ident) {
         walk_ident(self, ident)
     }
-    fn visit_mod(&mut self, m: &'v Mod, _s: Span, n: NodeId) {
+    fn visit_mod(&mut self, m: &'v Mod, _s: Span, n: HirId) {
         walk_mod(self, m, n)
     }
     fn visit_foreign_item(&mut self, i: &'v ForeignItem) {
@@ -279,11 +279,11 @@ pub trait Visitor<'v> : Sized {
     fn visit_fn_decl(&mut self, fd: &'v FnDecl) {
         walk_fn_decl(self, fd)
     }
-    fn visit_fn(&mut self, fk: FnKind<'v>, fd: &'v FnDecl, b: BodyId, s: Span, id: NodeId) {
+    fn visit_fn(&mut self, fk: FnKind<'v>, fd: &'v FnDecl, b: BodyId, s: Span, id: HirId) {
         walk_fn(self, fk, fd, b, s, id)
     }
-    fn visit_use(&mut self, path: &'v Path, id: NodeId, hir_id: HirId) {
-        walk_use(self, path, id, hir_id)
+    fn visit_use(&mut self, path: &'v Path, hir_id: HirId) {
+        walk_use(self, path, hir_id)
     }
     fn visit_trait_item(&mut self, ti: &'v TraitItem) {
         walk_trait_item(self, ti)
@@ -310,7 +310,7 @@ pub trait Visitor<'v> : Sized {
                           s: &'v VariantData,
                           _: Name,
                           _: &'v Generics,
-                          _parent_id: NodeId,
+                          _parent_id: HirId,
                           _: Span) {
         walk_struct_def(self, s)
     }
@@ -320,11 +320,11 @@ pub trait Visitor<'v> : Sized {
     fn visit_enum_def(&mut self,
                       enum_definition: &'v EnumDef,
                       generics: &'v Generics,
-                      item_id: NodeId,
+                      item_id: HirId,
                       _: Span) {
         walk_enum_def(self, enum_definition, generics, item_id)
     }
-    fn visit_variant(&mut self, v: &'v Variant, g: &'v Generics, item_id: NodeId) {
+    fn visit_variant(&mut self, v: &'v Variant, g: &'v Generics, item_id: HirId) {
         walk_variant(self, v, g, item_id)
     }
     fn visit_label(&mut self, label: &'v Label) {
@@ -373,19 +373,19 @@ pub trait Visitor<'v> : Sized {
 
 /// Walks the contents of a crate. See also `Crate::visit_all_items`.
 pub fn walk_crate<'v, V: Visitor<'v>>(visitor: &mut V, krate: &'v Crate) {
-    visitor.visit_mod(&krate.module, krate.span, CRATE_NODE_ID);
+    visitor.visit_mod(&krate.module, krate.span, CRATE_HIR_ID);
     walk_list!(visitor, visit_attribute, &krate.attrs);
     walk_list!(visitor, visit_macro_def, &krate.exported_macros);
 }
 
 pub fn walk_macro_def<'v, V: Visitor<'v>>(visitor: &mut V, macro_def: &'v MacroDef) {
-    visitor.visit_id(macro_def.id);
+    visitor.visit_id(macro_def.hir_id);
     visitor.visit_name(macro_def.span, macro_def.name);
     walk_list!(visitor, visit_attribute, &macro_def.attrs);
 }
 
-pub fn walk_mod<'v, V: Visitor<'v>>(visitor: &mut V, module: &'v Mod, mod_node_id: NodeId) {
-    visitor.visit_id(mod_node_id);
+pub fn walk_mod<'v, V: Visitor<'v>>(visitor: &mut V, module: &'v Mod, mod_hir_id: HirId) {
+    visitor.visit_id(mod_hir_id);
     for &item_id in &module.item_ids {
         visitor.visit_nested_item(item_id);
     }
@@ -393,7 +393,7 @@ pub fn walk_mod<'v, V: Visitor<'v>>(visitor: &mut V, module: &'v Mod, mod_node_i
 
 pub fn walk_body<'v, V: Visitor<'v>>(visitor: &mut V, body: &'v Body) {
     for argument in &body.arguments {
-        visitor.visit_id(argument.id);
+        visitor.visit_id(argument.hir_id);
         visitor.visit_pat(&argument.pat);
     }
     visitor.visit_expr(&body.value);
@@ -404,7 +404,7 @@ pub fn walk_local<'v, V: Visitor<'v>>(visitor: &mut V, local: &'v Local) {
     // dominates the local's definition.
     walk_list!(visitor, visit_expr, &local.init);
     walk_list!(visitor, visit_attribute, local.attrs.iter());
-    visitor.visit_id(local.id);
+    visitor.visit_id(local.hir_id);
     visitor.visit_pat(&local.pat);
     walk_list!(visitor, visit_ty, &local.ty);
 }
@@ -418,7 +418,7 @@ pub fn walk_label<'v, V: Visitor<'v>>(visitor: &mut V, label: &'v Label) {
 }
 
 pub fn walk_lifetime<'v, V: Visitor<'v>>(visitor: &mut V, lifetime: &'v Lifetime) {
-    visitor.visit_id(lifetime.id);
+    visitor.visit_id(lifetime.hir_id);
     match lifetime.name {
         LifetimeName::Param(ParamName::Plain(ident)) => {
             visitor.visit_ident(ident);
@@ -444,7 +444,7 @@ pub fn walk_poly_trait_ref<'v, V>(visitor: &mut V,
 pub fn walk_trait_ref<'v, V>(visitor: &mut V, trait_ref: &'v TraitRef)
     where V: Visitor<'v>
 {
-    visitor.visit_id(trait_ref.ref_id);
+    visitor.visit_id(trait_ref.hir_ref_id);
     visitor.visit_path(&trait_ref.path, trait_ref.hir_ref_id)
 }
 
@@ -453,17 +453,17 @@ pub fn walk_item<'v, V: Visitor<'v>>(visitor: &mut V, item: &'v Item) {
     visitor.visit_ident(item.ident);
     match item.node {
         ItemKind::ExternCrate(orig_name) => {
-            visitor.visit_id(item.id);
+            visitor.visit_id(item.hir_id);
             if let Some(orig_name) = orig_name {
                 visitor.visit_name(item.span, orig_name);
             }
         }
         ItemKind::Use(ref path, _) => {
-            visitor.visit_use(path, item.id, item.hir_id);
+            visitor.visit_use(path, item.hir_id);
         }
         ItemKind::Static(ref typ, _, body) |
         ItemKind::Const(ref typ, body) => {
-            visitor.visit_id(item.id);
+            visitor.visit_id(item.hir_id);
             visitor.visit_ty(typ);
             visitor.visit_nested_body(body);
         }
@@ -476,26 +476,26 @@ pub fn walk_item<'v, V: Visitor<'v>>(visitor: &mut V, item: &'v Item) {
                              declaration,
                              body_id,
                              item.span,
-                             item.id)
+                             item.hir_id)
         }
         ItemKind::Mod(ref module) => {
-            // `visit_mod()` takes care of visiting the `Item`'s `NodeId`.
-            visitor.visit_mod(module, item.span, item.id)
+            // `visit_mod()` takes care of visiting the `Item`'s `HirId`.
+            visitor.visit_mod(module, item.span, item.hir_id)
         }
         ItemKind::ForeignMod(ref foreign_module) => {
-            visitor.visit_id(item.id);
+            visitor.visit_id(item.hir_id);
             walk_list!(visitor, visit_foreign_item, &foreign_module.items);
         }
         ItemKind::GlobalAsm(_) => {
-            visitor.visit_id(item.id);
+            visitor.visit_id(item.hir_id);
         }
         ItemKind::Ty(ref typ, ref type_parameters) => {
-            visitor.visit_id(item.id);
+            visitor.visit_id(item.hir_id);
             visitor.visit_ty(typ);
             visitor.visit_generics(type_parameters)
         }
         ItemKind::Existential(ExistTy {ref generics, ref bounds, impl_trait_fn}) => {
-            visitor.visit_id(item.id);
+            visitor.visit_id(item.hir_id);
             walk_generics(visitor, generics);
             walk_list!(visitor, visit_param_bound, bounds);
             if let Some(impl_trait_fn) = impl_trait_fn {
@@ -504,8 +504,8 @@ pub fn walk_item<'v, V: Visitor<'v>>(visitor: &mut V, item: &'v Item) {
         }
         ItemKind::Enum(ref enum_definition, ref type_parameters) => {
             visitor.visit_generics(type_parameters);
-            // `visit_enum_def()` takes care of visiting the `Item`'s `NodeId`.
-            visitor.visit_enum_def(enum_definition, type_parameters, item.id, item.span)
+            // `visit_enum_def()` takes care of visiting the `Item`'s `HirId`.
+            visitor.visit_enum_def(enum_definition, type_parameters, item.hir_id, item.span)
         }
         ItemKind::Impl(
             ..,
@@ -514,7 +514,7 @@ pub fn walk_item<'v, V: Visitor<'v>>(visitor: &mut V, item: &'v Item) {
             ref typ,
             ref impl_item_refs
         ) => {
-            visitor.visit_id(item.id);
+            visitor.visit_id(item.hir_id);
             visitor.visit_generics(type_parameters);
             walk_list!(visitor, visit_trait_ref, opt_trait_reference);
             visitor.visit_ty(typ);
@@ -523,18 +523,18 @@ pub fn walk_item<'v, V: Visitor<'v>>(visitor: &mut V, item: &'v Item) {
         ItemKind::Struct(ref struct_definition, ref generics) |
         ItemKind::Union(ref struct_definition, ref generics) => {
             visitor.visit_generics(generics);
-            visitor.visit_id(item.id);
-            visitor.visit_variant_data(struct_definition, item.ident.name, generics, item.id,
+            visitor.visit_id(item.hir_id);
+            visitor.visit_variant_data(struct_definition, item.ident.name, generics, item.hir_id,
                                        item.span);
         }
         ItemKind::Trait(.., ref generics, ref bounds, ref trait_item_refs) => {
-            visitor.visit_id(item.id);
+            visitor.visit_id(item.hir_id);
             visitor.visit_generics(generics);
             walk_list!(visitor, visit_param_bound, bounds);
             walk_list!(visitor, visit_trait_item_ref, trait_item_refs);
         }
         ItemKind::TraitAlias(ref generics, ref bounds) => {
-            visitor.visit_id(item.id);
+            visitor.visit_id(item.hir_id);
             visitor.visit_generics(generics);
             walk_list!(visitor, visit_param_bound, bounds);
         }
@@ -544,16 +544,15 @@ pub fn walk_item<'v, V: Visitor<'v>>(visitor: &mut V, item: &'v Item) {
 
 pub fn walk_use<'v, V: Visitor<'v>>(visitor: &mut V,
                                     path: &'v Path,
-                                    item_id: NodeId,
                                     hir_id: HirId) {
-    visitor.visit_id(item_id);
+    visitor.visit_id(hir_id);
     visitor.visit_path(path, hir_id);
 }
 
 pub fn walk_enum_def<'v, V: Visitor<'v>>(visitor: &mut V,
                                          enum_definition: &'v EnumDef,
                                          generics: &'v Generics,
-                                         item_id: NodeId) {
+                                         item_id: HirId) {
     visitor.visit_id(item_id);
     walk_list!(visitor,
                visit_variant,
@@ -565,7 +564,7 @@ pub fn walk_enum_def<'v, V: Visitor<'v>>(visitor: &mut V,
 pub fn walk_variant<'v, V: Visitor<'v>>(visitor: &mut V,
                                         variant: &'v Variant,
                                         generics: &'v Generics,
-                                        parent_item_id: NodeId) {
+                                        parent_item_id: HirId) {
     visitor.visit_ident(variant.node.ident);
     visitor.visit_variant_data(&variant.node.data,
                                variant.node.ident.name,
@@ -577,7 +576,7 @@ pub fn walk_variant<'v, V: Visitor<'v>>(visitor: &mut V,
 }
 
 pub fn walk_ty<'v, V: Visitor<'v>>(visitor: &mut V, typ: &'v Ty) {
-    visitor.visit_id(typ.id);
+    visitor.visit_id(typ.hir_id);
 
     match typ.node {
         TyKind::Slice(ref ty) => {
@@ -648,7 +647,7 @@ pub fn walk_path_segment<'v, V: Visitor<'v>>(visitor: &mut V,
                                              path_span: Span,
                                              segment: &'v PathSegment) {
     visitor.visit_ident(segment.ident);
-    if let Some(id) = segment.id {
+    if let Some(id) = segment.hir_id {
         visitor.visit_id(id);
     }
     if let Some(ref args) = segment.args {
@@ -665,13 +664,13 @@ pub fn walk_generic_args<'v, V: Visitor<'v>>(visitor: &mut V,
 
 pub fn walk_assoc_type_binding<'v, V: Visitor<'v>>(visitor: &mut V,
                                                    type_binding: &'v TypeBinding) {
-    visitor.visit_id(type_binding.id);
+    visitor.visit_id(type_binding.hir_id);
     visitor.visit_ident(type_binding.ident);
     visitor.visit_ty(&type_binding.ty);
 }
 
 pub fn walk_pat<'v, V: Visitor<'v>>(visitor: &mut V, pattern: &'v Pat) {
-    visitor.visit_id(pattern.id);
+    visitor.visit_id(pattern.hir_id);
     match pattern.node {
         PatKind::TupleStruct(ref qpath, ref children, _) => {
             visitor.visit_qpath(qpath, pattern.hir_id, pattern.span);
@@ -683,7 +682,7 @@ pub fn walk_pat<'v, V: Visitor<'v>>(visitor: &mut V, pattern: &'v Pat) {
         PatKind::Struct(ref qpath, ref fields, _) => {
             visitor.visit_qpath(qpath, pattern.hir_id, pattern.span);
             for field in fields {
-                visitor.visit_id(field.node.id);
+                visitor.visit_id(field.node.hir_id);
                 visitor.visit_ident(field.node.ident);
                 visitor.visit_pat(&field.node.pat)
             }
@@ -715,7 +714,7 @@ pub fn walk_pat<'v, V: Visitor<'v>>(visitor: &mut V, pattern: &'v Pat) {
 }
 
 pub fn walk_foreign_item<'v, V: Visitor<'v>>(visitor: &mut V, foreign_item: &'v ForeignItem) {
-    visitor.visit_id(foreign_item.id);
+    visitor.visit_id(foreign_item.hir_id);
     visitor.visit_vis(&foreign_item.vis);
     visitor.visit_ident(foreign_item.ident);
 
@@ -744,7 +743,7 @@ pub fn walk_param_bound<'v, V: Visitor<'v>>(visitor: &mut V, bound: &'v GenericB
 }
 
 pub fn walk_generic_param<'v, V: Visitor<'v>>(visitor: &mut V, param: &'v GenericParam) {
-    visitor.visit_id(param.id);
+    visitor.visit_id(param.hir_id);
     walk_list!(visitor, visit_attribute, &param.attrs);
     match param.name {
         ParamName::Plain(ident) => visitor.visit_ident(ident),
@@ -760,7 +759,7 @@ pub fn walk_generic_param<'v, V: Visitor<'v>>(visitor: &mut V, param: &'v Generi
 
 pub fn walk_generics<'v, V: Visitor<'v>>(visitor: &mut V, generics: &'v Generics) {
     walk_list!(visitor, visit_generic_param, &generics.params);
-    visitor.visit_id(generics.where_clause.id);
+    visitor.visit_id(generics.where_clause.hir_id);
     walk_list!(visitor, visit_where_predicate, &generics.where_clause.predicates);
 }
 
@@ -783,11 +782,11 @@ pub fn walk_where_predicate<'v, V: Visitor<'v>>(
             visitor.visit_lifetime(lifetime);
             walk_list!(visitor, visit_param_bound, bounds);
         }
-        &WherePredicate::EqPredicate(WhereEqPredicate{id,
+        &WherePredicate::EqPredicate(WhereEqPredicate{hir_id,
                                                       ref lhs_ty,
                                                       ref rhs_ty,
                                                       ..}) => {
-            visitor.visit_id(id);
+            visitor.visit_id(hir_id);
             visitor.visit_ty(lhs_ty);
             visitor.visit_ty(rhs_ty);
         }
@@ -822,7 +821,7 @@ pub fn walk_fn<'v, V: Visitor<'v>>(visitor: &mut V,
                                    function_declaration: &'v FnDecl,
                                    body_id: BodyId,
                                    _span: Span,
-                                   id: NodeId) {
+                                   id: HirId) {
     visitor.visit_id(id);
     visitor.visit_fn_decl(function_declaration);
     walk_fn_kind(visitor, function_kind);
@@ -835,12 +834,12 @@ pub fn walk_trait_item<'v, V: Visitor<'v>>(visitor: &mut V, trait_item: &'v Trai
     visitor.visit_generics(&trait_item.generics);
     match trait_item.node {
         TraitItemKind::Const(ref ty, default) => {
-            visitor.visit_id(trait_item.id);
+            visitor.visit_id(trait_item.hir_id);
             visitor.visit_ty(ty);
             walk_list!(visitor, visit_nested_body, default);
         }
         TraitItemKind::Method(ref sig, TraitMethod::Required(ref param_names)) => {
-            visitor.visit_id(trait_item.id);
+            visitor.visit_id(trait_item.hir_id);
             visitor.visit_fn_decl(&sig.decl);
             for &param_name in param_names {
                 visitor.visit_ident(param_name);
@@ -854,10 +853,10 @@ pub fn walk_trait_item<'v, V: Visitor<'v>>(visitor: &mut V, trait_item: &'v Trai
                              &sig.decl,
                              body_id,
                              trait_item.span,
-                             trait_item.id);
+                             trait_item.hir_id);
         }
         TraitItemKind::Type(ref bounds, ref default) => {
-            visitor.visit_id(trait_item.id);
+            visitor.visit_id(trait_item.hir_id);
             walk_list!(visitor, visit_param_bound, bounds);
             walk_list!(visitor, visit_ty, default);
         }
@@ -894,7 +893,7 @@ pub fn walk_impl_item<'v, V: Visitor<'v>>(visitor: &mut V, impl_item: &'v ImplIt
     visitor.visit_generics(generics);
     match *node {
         ImplItemKind::Const(ref ty, body) => {
-            visitor.visit_id(impl_item.id);
+            visitor.visit_id(impl_item.hir_id);
             visitor.visit_ty(ty);
             visitor.visit_nested_body(body);
         }
@@ -906,14 +905,14 @@ pub fn walk_impl_item<'v, V: Visitor<'v>>(visitor: &mut V, impl_item: &'v ImplIt
                              &sig.decl,
                              body_id,
                              impl_item.span,
-                             impl_item.id);
+                             impl_item.hir_id);
         }
         ImplItemKind::Type(ref ty) => {
-            visitor.visit_id(impl_item.id);
+            visitor.visit_id(impl_item.hir_id);
             visitor.visit_ty(ty);
         }
         ImplItemKind::Existential(ref bounds) => {
-            visitor.visit_id(impl_item.id);
+            visitor.visit_id(impl_item.hir_id);
             walk_list!(visitor, visit_param_bound, bounds);
         }
     }
@@ -931,12 +930,12 @@ pub fn walk_impl_item_ref<'v, V: Visitor<'v>>(visitor: &mut V, impl_item_ref: &'
 
 
 pub fn walk_struct_def<'v, V: Visitor<'v>>(visitor: &mut V, struct_definition: &'v VariantData) {
-    visitor.visit_id(struct_definition.id());
+    visitor.visit_id(struct_definition.hir_id());
     walk_list!(visitor, visit_struct_field, struct_definition.fields());
 }
 
 pub fn walk_struct_field<'v, V: Visitor<'v>>(visitor: &mut V, struct_field: &'v StructField) {
-    visitor.visit_id(struct_field.id);
+    visitor.visit_id(struct_field.hir_id);
     visitor.visit_vis(&struct_field.vis);
     visitor.visit_ident(struct_field.ident);
     visitor.visit_ty(&struct_field.ty);
@@ -944,13 +943,13 @@ pub fn walk_struct_field<'v, V: Visitor<'v>>(visitor: &mut V, struct_field: &'v 
 }
 
 pub fn walk_block<'v, V: Visitor<'v>>(visitor: &mut V, block: &'v Block) {
-    visitor.visit_id(block.id);
+    visitor.visit_id(block.hir_id);
     walk_list!(visitor, visit_stmt, &block.stmts);
     walk_list!(visitor, visit_expr, &block.expr);
 }
 
 pub fn walk_stmt<'v, V: Visitor<'v>>(visitor: &mut V, statement: &'v Stmt) {
-    visitor.visit_id(statement.id);
+    visitor.visit_id(statement.hir_id);
     match statement.node {
         StmtKind::Local(ref local) => visitor.visit_local(local),
         StmtKind::Item(ref item) => visitor.visit_nested_item(**item),
@@ -962,12 +961,12 @@ pub fn walk_stmt<'v, V: Visitor<'v>>(visitor: &mut V, statement: &'v Stmt) {
 }
 
 pub fn walk_anon_const<'v, V: Visitor<'v>>(visitor: &mut V, constant: &'v AnonConst) {
-    visitor.visit_id(constant.id);
+    visitor.visit_id(constant.hir_id);
     visitor.visit_nested_body(constant.body);
 }
 
 pub fn walk_expr<'v, V: Visitor<'v>>(visitor: &mut V, expression: &'v Expr) {
-    visitor.visit_id(expression.id);
+    visitor.visit_id(expression.hir_id);
     walk_list!(visitor, visit_attribute, expression.attrs.iter());
     match expression.node {
         ExprKind::Box(ref subexpression) => {
@@ -983,7 +982,7 @@ pub fn walk_expr<'v, V: Visitor<'v>>(visitor: &mut V, expression: &'v Expr) {
         ExprKind::Struct(ref qpath, ref fields, ref optional_base) => {
             visitor.visit_qpath(qpath, expression.hir_id, expression.span);
             for field in fields {
-                visitor.visit_id(field.id);
+                visitor.visit_id(field.hir_id);
                 visitor.visit_ident(field.ident);
                 visitor.visit_expr(&field.expr)
             }
@@ -1035,7 +1034,7 @@ pub fn walk_expr<'v, V: Visitor<'v>>(visitor: &mut V, expression: &'v Expr) {
                              function_declaration,
                              body,
                              expression.span,
-                             expression.id)
+                             expression.hir_id)
         }
         ExprKind::Block(ref block, ref opt_label) => {
             walk_list!(visitor, visit_label, opt_label);
@@ -1104,8 +1103,8 @@ pub fn walk_arm<'v, V: Visitor<'v>>(visitor: &mut V, arm: &'v Arm) {
 }
 
 pub fn walk_vis<'v, V: Visitor<'v>>(visitor: &mut V, vis: &'v Visibility) {
-    if let VisibilityKind::Restricted { ref path, id, hir_id } = vis.node {
-        visitor.visit_id(id);
+    if let VisibilityKind::Restricted { ref path, id: _, hir_id } = vis.node {
+        visitor.visit_id(hir_id);
         visitor.visit_path(path, hir_id)
     }
 }

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -3301,7 +3301,9 @@ impl<'a> LoweringContext<'a> {
         let mut path = path.clone();
         for seg in path.segments.iter_mut() {
             if seg.id.is_some() {
-                seg.id = Some(self.next_id().node_id);
+                let next_id = self.next_id();
+                seg.id = Some(next_id.node_id);
+                seg.hir_id = Some(next_id.hir_id);
             }
         }
         path

--- a/src/librustc/hir/map/collector.rs
+++ b/src/librustc/hir/map/collector.rs
@@ -228,7 +228,8 @@ impl<'a, 'hir> NodeCollector<'a, 'hir> {
         self.map[id.as_usize()] = Some(entry);
     }
 
-    fn insert(&mut self, span: Span, id: NodeId, node: Node<'hir>) {
+    // FIXME(ljedrz): devise a way to get rid of this NodeId
+    fn insert(&mut self, span: Span, node_id: NodeId, hir_id: HirId, node: Node<'hir>) {
         let entry = Entry {
             parent: self.parent_node,
             parent_hir: self.parent_hir,
@@ -243,10 +244,10 @@ impl<'a, 'hir> NodeCollector<'a, 'hir> {
         // Make sure that the DepNode of some node coincides with the HirId
         // owner of that node.
         if cfg!(debug_assertions) {
-            let hir_id = self.definitions.node_to_hir_id(id);
+           assert_eq!(self.definitions.node_to_hir_id(node_id), hir_id);
 
             if hir_id.owner != self.current_dep_node_owner {
-                let node_str = match self.definitions.opt_def_index(id) {
+                let node_str = match self.definitions.opt_def_index(node_id) {
                     Some(def_index) => {
                         self.definitions.def_path(def_index).to_string_no_crate()
                     }
@@ -254,7 +255,7 @@ impl<'a, 'hir> NodeCollector<'a, 'hir> {
                 };
 
                 let forgot_str = if hir_id == crate::hir::DUMMY_HIR_ID {
-                    format!("\nMaybe you forgot to lower the node id {:?}?", id)
+                    format!("\nMaybe you forgot to lower the node id {:?}?", node_id)
                 } else {
                     String::new()
                 };
@@ -276,13 +277,21 @@ impl<'a, 'hir> NodeCollector<'a, 'hir> {
             }
         }
 
-        self.insert_entry(id, entry);
+        self.insert_entry(node_id, entry);
     }
 
-    fn with_parent<F: FnOnce(&mut Self)>(&mut self, parent_id: NodeId, f: F) {
+    fn with_parent<F: FnOnce(&mut Self)>(
+        &mut self,
+        parent_node_id: NodeId,
+        parent_hir_id: HirId,
+        f: F,
+    ) {
         let parent_node = self.parent_node;
-        self.parent_node = parent_id;
+        self.parent_node = parent_node_id;
+        let parent_hir = self.parent_hir;
+        self.parent_hir = parent_hir_id;
         f(self);
+        self.parent_hir = parent_hir;
         self.parent_node = parent_node;
     }
 
@@ -352,12 +361,13 @@ impl<'a, 'hir> Visitor<'hir> for NodeCollector<'a, 'hir> {
         debug_assert_eq!(i.hir_id.owner,
                          self.definitions.opt_def_index(i.id).unwrap());
         self.with_dep_node_owner(i.hir_id.owner, i, |this| {
-            this.insert(i.span, i.id, Node::Item(i));
-            this.with_parent(i.id, |this| {
+            this.insert(i.span, i.id, i.hir_id, Node::Item(i));
+            this.with_parent(i.id, i.hir_id, |this| {
                 if let ItemKind::Struct(ref struct_def, _) = i.node {
                     // If this is a tuple-like struct, register the constructor.
                     if !struct_def.is_struct() {
-                        this.insert(i.span, struct_def.id(), Node::StructCtor(struct_def));
+                        this.insert(i.span, struct_def.id(), struct_def.hir_id(),
+                            Node::StructCtor(struct_def));
                     }
                 }
                 intravisit::walk_item(this, i);
@@ -366,15 +376,16 @@ impl<'a, 'hir> Visitor<'hir> for NodeCollector<'a, 'hir> {
     }
 
     fn visit_foreign_item(&mut self, foreign_item: &'hir ForeignItem) {
-        self.insert(foreign_item.span, foreign_item.id, Node::ForeignItem(foreign_item));
+        self.insert(foreign_item.span, foreign_item.id, foreign_item.hir_id,
+            Node::ForeignItem(foreign_item));
 
-        self.with_parent(foreign_item.id, |this| {
+        self.with_parent(foreign_item.id, foreign_item.hir_id, |this| {
             intravisit::walk_foreign_item(this, foreign_item);
         });
     }
 
     fn visit_generic_param(&mut self, param: &'hir GenericParam) {
-        self.insert(param.span, param.id, Node::GenericParam(param));
+        self.insert(param.span, param.id, param.hir_id, Node::GenericParam(param));
         intravisit::walk_generic_param(self, param);
     }
 
@@ -382,9 +393,9 @@ impl<'a, 'hir> Visitor<'hir> for NodeCollector<'a, 'hir> {
         debug_assert_eq!(ti.hir_id.owner,
                          self.definitions.opt_def_index(ti.id).unwrap());
         self.with_dep_node_owner(ti.hir_id.owner, ti, |this| {
-            this.insert(ti.span, ti.id, Node::TraitItem(ti));
+            this.insert(ti.span, ti.id, ti.hir_id, Node::TraitItem(ti));
 
-            this.with_parent(ti.id, |this| {
+            this.with_parent(ti.id, ti.hir_id, |this| {
                 intravisit::walk_trait_item(this, ti);
             });
         });
@@ -394,9 +405,9 @@ impl<'a, 'hir> Visitor<'hir> for NodeCollector<'a, 'hir> {
         debug_assert_eq!(ii.hir_id.owner,
                          self.definitions.opt_def_index(ii.id).unwrap());
         self.with_dep_node_owner(ii.hir_id.owner, ii, |this| {
-            this.insert(ii.span, ii.id, Node::ImplItem(ii));
+            this.insert(ii.span, ii.id, ii.hir_id, Node::ImplItem(ii));
 
-            this.with_parent(ii.id, |this| {
+            this.with_parent(ii.id, ii.hir_id, |this| {
                 intravisit::walk_impl_item(this, ii);
             });
         });
@@ -408,83 +419,83 @@ impl<'a, 'hir> Visitor<'hir> for NodeCollector<'a, 'hir> {
         } else {
             Node::Pat(pat)
         };
-        self.insert(pat.span, pat.id, node);
+        self.insert(pat.span, pat.id, pat.hir_id, node);
 
-        self.with_parent(pat.id, |this| {
+        self.with_parent(pat.id, pat.hir_id, |this| {
             intravisit::walk_pat(this, pat);
         });
     }
 
     fn visit_anon_const(&mut self, constant: &'hir AnonConst) {
-        self.insert(DUMMY_SP, constant.id, Node::AnonConst(constant));
+        self.insert(DUMMY_SP, constant.id, constant.hir_id, Node::AnonConst(constant));
 
-        self.with_parent(constant.id, |this| {
+        self.with_parent(constant.id, constant.hir_id, |this| {
             intravisit::walk_anon_const(this, constant);
         });
     }
 
     fn visit_expr(&mut self, expr: &'hir Expr) {
-        self.insert(expr.span, expr.id, Node::Expr(expr));
+        self.insert(expr.span, expr.id, expr.hir_id, Node::Expr(expr));
 
-        self.with_parent(expr.id, |this| {
+        self.with_parent(expr.id, expr.hir_id, |this| {
             intravisit::walk_expr(this, expr);
         });
     }
 
     fn visit_stmt(&mut self, stmt: &'hir Stmt) {
-        let id = stmt.id;
-        self.insert(stmt.span, id, Node::Stmt(stmt));
+        self.insert(stmt.span, stmt.id, stmt.hir_id, Node::Stmt(stmt));
 
-        self.with_parent(id, |this| {
+        self.with_parent(stmt.id, stmt.hir_id, |this| {
             intravisit::walk_stmt(this, stmt);
         });
     }
 
     fn visit_path_segment(&mut self, path_span: Span, path_segment: &'hir PathSegment) {
-        if let Some(id) = path_segment.id {
-            self.insert(path_span, id, Node::PathSegment(path_segment));
+        if let Some(node_id) = path_segment.id {
+            let hir_id = path_segment.hir_id.unwrap();
+            self.insert(path_span, node_id, hir_id, Node::PathSegment(path_segment));
         }
         intravisit::walk_path_segment(self, path_span, path_segment);
     }
 
     fn visit_ty(&mut self, ty: &'hir Ty) {
-        self.insert(ty.span, ty.id, Node::Ty(ty));
+        self.insert(ty.span, ty.id, ty.hir_id, Node::Ty(ty));
 
-        self.with_parent(ty.id, |this| {
+        self.with_parent(ty.id, ty.hir_id, |this| {
             intravisit::walk_ty(this, ty);
         });
     }
 
     fn visit_trait_ref(&mut self, tr: &'hir TraitRef) {
-        self.insert(tr.path.span, tr.ref_id, Node::TraitRef(tr));
+        self.insert(tr.path.span, tr.ref_id, tr.hir_ref_id, Node::TraitRef(tr));
 
-        self.with_parent(tr.ref_id, |this| {
+        self.with_parent(tr.ref_id, tr.hir_ref_id, |this| {
             intravisit::walk_trait_ref(this, tr);
         });
     }
 
     fn visit_fn(&mut self, fk: intravisit::FnKind<'hir>, fd: &'hir FnDecl,
-                b: BodyId, s: Span, id: NodeId) {
-        assert_eq!(self.parent_node, id);
+                b: BodyId, s: Span, id: HirId) {
+        assert_eq!(self.parent_hir, id);
         intravisit::walk_fn(self, fk, fd, b, s, id);
     }
 
     fn visit_block(&mut self, block: &'hir Block) {
-        self.insert(block.span, block.id, Node::Block(block));
-        self.with_parent(block.id, |this| {
+        self.insert(block.span, block.id, block.hir_id, Node::Block(block));
+        self.with_parent(block.id, block.hir_id, |this| {
             intravisit::walk_block(this, block);
         });
     }
 
     fn visit_local(&mut self, l: &'hir Local) {
-        self.insert(l.span, l.id, Node::Local(l));
-        self.with_parent(l.id, |this| {
+        self.insert(l.span, l.id, l.hir_id, Node::Local(l));
+        self.with_parent(l.id, l.hir_id, |this| {
             intravisit::walk_local(this, l)
         })
     }
 
     fn visit_lifetime(&mut self, lifetime: &'hir Lifetime) {
-        self.insert(lifetime.span, lifetime.id, Node::Lifetime(lifetime));
+        self.insert(lifetime.span, lifetime.id, lifetime.hir_id, Node::Lifetime(lifetime));
     }
 
     fn visit_vis(&mut self, visibility: &'hir Visibility) {
@@ -492,9 +503,9 @@ impl<'a, 'hir> Visitor<'hir> for NodeCollector<'a, 'hir> {
             VisibilityKind::Public |
             VisibilityKind::Crate(_) |
             VisibilityKind::Inherited => {}
-            VisibilityKind::Restricted { id, .. } => {
-                self.insert(visibility.span, id, Node::Visibility(visibility));
-                self.with_parent(id, |this| {
+            VisibilityKind::Restricted { id, hir_id, .. } => {
+                self.insert(visibility.span, id, hir_id, Node::Visibility(visibility));
+                self.with_parent(id, hir_id, |this| {
                     intravisit::walk_vis(this, visibility);
                 });
             }
@@ -505,21 +516,20 @@ impl<'a, 'hir> Visitor<'hir> for NodeCollector<'a, 'hir> {
         let def_index = self.definitions.opt_def_index(macro_def.id).unwrap();
 
         self.with_dep_node_owner(def_index, macro_def, |this| {
-            this.insert(macro_def.span, macro_def.id, Node::MacroDef(macro_def));
+            this.insert(macro_def.span, macro_def.id, macro_def.hir_id, Node::MacroDef(macro_def));
         });
     }
 
-    fn visit_variant(&mut self, v: &'hir Variant, g: &'hir Generics, item_id: NodeId) {
-        let id = v.node.data.id();
-        self.insert(v.span, id, Node::Variant(v));
-        self.with_parent(id, |this| {
+    fn visit_variant(&mut self, v: &'hir Variant, g: &'hir Generics, item_id: HirId) {
+        self.insert(v.span, v.node.data.id(), v.node.data.hir_id(), Node::Variant(v));
+        self.with_parent(v.node.data.id(), v.node.data.hir_id(), |this| {
             intravisit::walk_variant(this, v, g, item_id);
         });
     }
 
     fn visit_struct_field(&mut self, field: &'hir StructField) {
-        self.insert(field.span, field.id, Node::Field(field));
-        self.with_parent(field.id, |this| {
+        self.insert(field.span, field.id, field.hir_id, Node::Field(field));
+        self.with_parent(field.id, field.hir_id, |this| {
             intravisit::walk_struct_field(this, field);
         });
     }

--- a/src/librustc/hir/map/hir_id_validator.rs
+++ b/src/librustc/hir/map/hir_id_validator.rs
@@ -98,11 +98,8 @@ impl<'a, 'hir: 'a> HirIdValidator<'a, 'hir> {
         if max != self.hir_ids_seen.len() - 1 {
             // Collect the missing ItemLocalIds
             let missing: Vec<_> = (0 ..= max as u32)
-              .filter(|&i| !self.hir_ids_seen
-                                .iter()
-                                .find(|&local_id| local_id == &ItemLocalId::from_u32(i))
-                                .is_some()
-            ).collect();
+              .filter(|&i| !self.hir_ids_seen.contains(&ItemLocalId::from_u32(i)))
+              .collect();
 
             // Try to map those to something more useful
             let mut missing_items = Vec::with_capacity(missing.len());

--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -11,7 +11,6 @@ use crate::middle::cstore::CrateStoreDyn;
 
 use rustc_target::spec::abi::Abi;
 use rustc_data_structures::svh::Svh;
-use rustc_data_structures::sync::join;
 use syntax::ast::{self, Name, NodeId, CRATE_NODE_ID};
 use syntax::source_map::Spanned;
 use syntax::ext::base::MacroKind;
@@ -1242,13 +1241,18 @@ pub fn map_crate<'hir>(sess: &crate::session::Session,
                        forest: &'hir Forest,
                        definitions: &'hir Definitions)
                        -> Map<'hir> {
-    let ((map, crate_hash), hir_to_node_id) = join(|| {
+    // Build the reverse mapping of `node_to_hir_id`.
+    let hir_to_node_id = definitions.node_to_hir_id.iter_enumerated()
+        .map(|(node_id, &hir_id)| (hir_id, node_id)).collect();
+
+    let (map, crate_hash) = {
         let hcx = crate::ich::StableHashingContext::new(sess, &forest.krate, definitions, cstore);
 
         let mut collector = NodeCollector::root(sess,
                                                 &forest.krate,
                                                 &forest.dep_graph,
                                                 &definitions,
+                                                &hir_to_node_id,
                                                 hcx);
         intravisit::walk_crate(&mut collector, &forest.krate);
 
@@ -1259,11 +1263,7 @@ pub fn map_crate<'hir>(sess: &crate::session::Session,
             cstore,
             cmdline_args
         )
-    }, || {
-        // Build the reverse mapping of `node_to_hir_id`.
-        definitions.node_to_hir_id.iter_enumerated()
-                    .map(|(node_id, &hir_id)| (hir_id, node_id)).collect()
-    });
+    };
 
     if log_enabled!(::log::Level::Debug) {
         // This only makes sense for ordered stores; note the

--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -182,8 +182,8 @@ macro_rules! late_lint_methods {
             fn check_name(a: Span, b: ast::Name);
             fn check_crate(a: &$hir hir::Crate);
             fn check_crate_post(a: &$hir hir::Crate);
-            fn check_mod(a: &$hir hir::Mod, b: Span, c: ast::NodeId);
-            fn check_mod_post(a: &$hir hir::Mod, b: Span, c: ast::NodeId);
+            fn check_mod(a: &$hir hir::Mod, b: Span, c: hir::HirId);
+            fn check_mod_post(a: &$hir hir::Mod, b: Span, c: hir::HirId);
             fn check_foreign_item(a: &$hir hir::ForeignItem);
             fn check_foreign_item_post(a: &$hir hir::ForeignItem);
             fn check_item(a: &$hir hir::Item);
@@ -206,13 +206,13 @@ macro_rules! late_lint_methods {
                 b: &$hir hir::FnDecl,
                 c: &$hir hir::Body,
                 d: Span,
-                e: ast::NodeId);
+                e: hir::HirId);
             fn check_fn_post(
                 a: hir::intravisit::FnKind<$hir>,
                 b: &$hir hir::FnDecl,
                 c: &$hir hir::Body,
                 d: Span,
-                e: ast::NodeId
+                e: hir::HirId
             );
             fn check_trait_item(a: &$hir hir::TraitItem);
             fn check_trait_item_post(a: &$hir hir::TraitItem);
@@ -222,13 +222,13 @@ macro_rules! late_lint_methods {
                 a: &$hir hir::VariantData,
                 b: ast::Name,
                 c: &$hir hir::Generics,
-                d: ast::NodeId
+                d: hir::HirId
             );
             fn check_struct_def_post(
                 a: &$hir hir::VariantData,
                 b: ast::Name,
                 c: &$hir hir::Generics,
-                d: ast::NodeId
+                d: hir::HirId
             );
             fn check_struct_field(a: &$hir hir::StructField);
             fn check_variant(a: &$hir hir::Variant, b: &$hir hir::Generics);
@@ -781,7 +781,7 @@ impl<'a, 'tcx> intravisit::Visitor<'tcx> for LintLevelMapBuilder<'a, 'tcx> {
     fn visit_variant(&mut self,
                      v: &'tcx hir::Variant,
                      g: &'tcx hir::Generics,
-                     item_id: ast::NodeId) {
+                     item_id: hir::HirId) {
         self.with_lint_attrs(v.node.data.id(), &v.node.attrs, |builder| {
             intravisit::walk_variant(builder, v, g, item_id);
         })

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -211,7 +211,7 @@ impl<'a, 'tcx> Visitor<'tcx> for MarkSymbolVisitor<'a, 'tcx> {
     }
 
     fn visit_variant_data(&mut self, def: &'tcx hir::VariantData, _: ast::Name,
-                          _: &hir::Generics, _: ast::NodeId, _: syntax_pos::Span) {
+                          _: &hir::Generics, _: hir::HirId, _: syntax_pos::Span) {
         let has_repr_c = self.repr_has_repr_c;
         let inherited_pub_visibility = self.inherited_pub_visibility;
         let live_fields = def.fields().iter().filter(|f| {
@@ -570,7 +570,7 @@ impl<'a, 'tcx> Visitor<'tcx> for DeadVisitor<'a, 'tcx> {
     fn visit_variant(&mut self,
                      variant: &'tcx hir::Variant,
                      g: &'tcx hir::Generics,
-                     id: ast::NodeId) {
+                     id: hir::HirId) {
         if self.should_warn_about_variant(&variant.node) {
             self.warn_dead_code(variant.node.data.id(), variant.span, variant.node.ident.name,
                                 "variant", "constructed");

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -172,7 +172,7 @@ impl<'a, 'tcx> Visitor<'tcx> for IrMaps<'a, 'tcx> {
     }
 
     fn visit_fn(&mut self, fk: FnKind<'tcx>, fd: &'tcx hir::FnDecl,
-                b: hir::BodyId, s: Span, id: NodeId) {
+                b: hir::BodyId, s: Span, id: HirId) {
         visit_fn(self, fk, fd, b, s, id);
     }
 
@@ -358,7 +358,7 @@ fn visit_fn<'a, 'tcx: 'a>(ir: &mut IrMaps<'a, 'tcx>,
                           decl: &'tcx hir::FnDecl,
                           body_id: hir::BodyId,
                           sp: Span,
-                          id: ast::NodeId) {
+                          id: hir::HirId) {
     debug!("visit_fn");
 
     // swap in a new set of IR maps for this function body:
@@ -366,8 +366,8 @@ fn visit_fn<'a, 'tcx: 'a>(ir: &mut IrMaps<'a, 'tcx>,
 
     // Don't run unused pass for #[derive()]
     if let FnKind::Method(..) = fk {
-        let parent = ir.tcx.hir().get_parent(id);
-        if let Some(Node::Item(i)) = ir.tcx.hir().find(parent) {
+        let parent = ir.tcx.hir().get_parent_item(id);
+        if let Some(Node::Item(i)) = ir.tcx.hir().find_by_hir_id(parent) {
             if i.attrs.iter().any(|a| a.check_name("automatically_derived")) {
                 return;
             }

--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -293,7 +293,7 @@ impl<'a, 'tcx> Visitor<'tcx> for Annotator<'a, 'tcx> {
         });
     }
 
-    fn visit_variant(&mut self, var: &'tcx Variant, g: &'tcx Generics, item_id: NodeId) {
+    fn visit_variant(&mut self, var: &'tcx Variant, g: &'tcx Generics, item_id: HirId) {
         self.annotate(var.node.data.id(), &var.node.attrs, var.span, AnnotationKind::Required, |v| {
             intravisit::walk_variant(v, var, g, item_id);
         })
@@ -369,7 +369,7 @@ impl<'a, 'tcx> Visitor<'tcx> for MissingStabilityAnnotations<'a, 'tcx> {
         intravisit::walk_impl_item(self, ii);
     }
 
-    fn visit_variant(&mut self, var: &'tcx Variant, g: &'tcx Generics, item_id: NodeId) {
+    fn visit_variant(&mut self, var: &'tcx Variant, g: &'tcx Generics, item_id: HirId) {
         self.check_missing_stability(var.node.data.id(), var.span, "variant");
         intravisit::walk_variant(self, var, g, item_id);
     }

--- a/src/librustc_borrowck/borrowck/gather_loans/move_error.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/move_error.rs
@@ -88,8 +88,7 @@ fn report_move_errors<'a, 'tcx>(bccx: &BorrowckCtxt<'a, 'tcx>, errors: &[MoveErr
             }
         }
         if let NoteClosureEnv(upvar_id) = error.move_from.note {
-            let var_node_id = bccx.tcx.hir().hir_to_node_id(upvar_id.var_path.hir_id);
-            err.span_label(bccx.tcx.hir().span(var_node_id),
+            err.span_label(bccx.tcx.hir().span_by_hir_id(upvar_id.var_path.hir_id),
                            "captured outer variable");
         }
         err.emit();

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -499,7 +499,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MissingDoc {
 
     fn check_impl_item(&mut self, cx: &LateContext<'_, '_>, impl_item: &hir::ImplItem) {
         // If the method is an impl for a trait, don't doc.
-        if method_context(cx, impl_item.id) == MethodLateContext::TraitImpl {
+        if method_context(cx, impl_item.hir_id) == MethodLateContext::TraitImpl {
             return;
         }
 

--- a/src/librustc_lint/nonstandard_style.rs
+++ b/src/librustc_lint/nonstandard_style.rs
@@ -18,8 +18,8 @@ pub enum MethodLateContext {
     PlainImpl,
 }
 
-pub fn method_context(cx: &LateContext<'_, '_>, id: ast::NodeId) -> MethodLateContext {
-    let def_id = cx.tcx.hir().local_def_id(id);
+pub fn method_context(cx: &LateContext<'_, '_>, id: hir::HirId) -> MethodLateContext {
+    let def_id = cx.tcx.hir().local_def_id_from_hir_id(id);
     let item = cx.tcx.associated_item(def_id);
     match item.container {
         ty::TraitContainer(..) => MethodLateContext::TraitAutoImpl,
@@ -317,7 +317,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NonSnakeCase {
         _: &hir::FnDecl,
         _: &hir::Body,
         _: Span,
-        id: ast::NodeId,
+        id: hir::HirId,
     ) {
         match &fk {
             FnKind::Method(ident, ..) => {
@@ -369,7 +369,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NonSnakeCase {
         s: &hir::VariantData,
         _: ast::Name,
         _: &hir::Generics,
-        _: ast::NodeId,
+        _: hir::HirId,
     ) {
         for sf in s.fields() {
             self.check_snake_case(cx, "structure field", &sf.ident);

--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -1663,7 +1663,7 @@ impl<'a, 'b, 'tcx> Visitor<'tcx> for EncodeVisitor<'a, 'b, 'tcx> {
     fn visit_variant(&mut self,
                      v: &'tcx hir::Variant,
                      g: &'tcx hir::Generics,
-                     id: ast::NodeId) {
+                     id: hir::HirId) {
         intravisit::walk_variant(self, v, g, id);
 
         if let Some(ref discr) = v.node.disr_expr {

--- a/src/librustc_mir/transform/mod.rs
+++ b/src/librustc_mir/transform/mod.rs
@@ -78,7 +78,7 @@ fn mir_keys<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, krate: CrateNum)
                               v: &'tcx hir::VariantData,
                               _: ast::Name,
                               _: &'tcx hir::Generics,
-                              _: ast::NodeId,
+                              _: hir::HirId,
                               _: Span) {
             if let hir::VariantData::Tuple(_, node_id, _) = *v {
                 self.set.insert(self.tcx.hir().local_def_id(node_id));

--- a/src/librustc_passes/hir_stats.rs
+++ b/src/librustc_passes/hir_stats.rs
@@ -123,7 +123,7 @@ impl<'v> hir_visit::Visitor<'v> for StatCollector<'v> {
         hir_visit::walk_item(self, i)
     }
 
-    fn visit_mod(&mut self, m: &'v hir::Mod, _s: Span, n: NodeId) {
+    fn visit_mod(&mut self, m: &'v hir::Mod, _s: Span, n: hir::HirId) {
         self.record("Mod", Id::None, m);
         hir_visit::walk_mod(self, m, n)
     }
@@ -173,7 +173,7 @@ impl<'v> hir_visit::Visitor<'v> for StatCollector<'v> {
                 fd: &'v hir::FnDecl,
                 b: hir::BodyId,
                 s: Span,
-                id: NodeId) {
+                id: hir::HirId) {
         self.record("FnDecl", Id::None, fd);
         hir_visit::walk_fn(self, fk, fd, b, s, id)
     }
@@ -206,7 +206,7 @@ impl<'v> hir_visit::Visitor<'v> for StatCollector<'v> {
     fn visit_variant(&mut self,
                      v: &'v hir::Variant,
                      g: &'v hir::Generics,
-                     item_id: NodeId) {
+                     item_id: hir::HirId) {
         self.record("Variant", Id::None, v);
         hir_visit::walk_variant(self, v, g, item_id)
     }

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -454,8 +454,8 @@ impl<'a, 'tcx> EmbargoVisitor<'a, 'tcx> {
         if let Some([module, segment]) = segments.rchunks_exact(2).next() {
             if let Some(item) = module.def
                 .and_then(|def| def.mod_def_id())
-                .and_then(|def_id| self.tcx.hir().as_local_node_id(def_id))
-                .map(|module_node_id| self.tcx.hir().expect_item(module_node_id))
+                .and_then(|def_id| self.tcx.hir().as_local_hir_id(def_id))
+                .map(|module_hir_id| self.tcx.hir().expect_item_by_hir_id(module_hir_id))
              {
                 if let hir::ItemKind::Mod(m) = &item.node {
                     for item_id in m.item_ids.as_ref() {

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -673,11 +673,11 @@ impl<'a, 'tcx> Visitor<'tcx> for EmbargoVisitor<'a, 'tcx> {
         self.prev_level = orig_level;
     }
 
-    fn visit_mod(&mut self, m: &'tcx hir::Mod, _sp: Span, id: ast::NodeId) {
+    fn visit_mod(&mut self, m: &'tcx hir::Mod, _sp: Span, id: hir::HirId) {
         // This code is here instead of in visit_item so that the
         // crate module gets processed as well.
         if self.prev_level.is_some() {
-            let def_id = self.tcx.hir().local_def_id(id);
+            let def_id = self.tcx.hir().local_def_id_from_hir_id(id);
             if let Some(exports) = self.tcx.module_exports(def_id) {
                 for export in exports.iter() {
                     if export.vis == ty::Visibility::Public {
@@ -823,7 +823,7 @@ impl<'a, 'tcx> Visitor<'tcx> for NamePrivacyVisitor<'a, 'tcx> {
         NestedVisitorMap::All(&self.tcx.hir())
     }
 
-    fn visit_mod(&mut self, _m: &'tcx hir::Mod, _s: Span, _n: ast::NodeId) {
+    fn visit_mod(&mut self, _m: &'tcx hir::Mod, _s: Span, _n: hir::HirId) {
         // Don't visit nested modules, since we run a separate visitor walk
         // for each module in `privacy_access_levels`
     }
@@ -963,7 +963,7 @@ impl<'a, 'tcx> Visitor<'tcx> for TypePrivacyVisitor<'a, 'tcx> {
         NestedVisitorMap::All(&self.tcx.hir())
     }
 
-    fn visit_mod(&mut self, _m: &'tcx hir::Mod, _s: Span, _n: ast::NodeId) {
+    fn visit_mod(&mut self, _m: &'tcx hir::Mod, _s: Span, _n: hir::HirId) {
         // Don't visit nested modules, since we run a separate visitor walk
         // for each module in `privacy_access_levels`
     }
@@ -1461,7 +1461,7 @@ impl<'a, 'tcx> Visitor<'tcx> for ObsoleteVisiblePrivateTypesVisitor<'a, 'tcx> {
     fn visit_variant(&mut self,
                      v: &'tcx hir::Variant,
                      g: &'tcx hir::Generics,
-                     item_id: ast::NodeId) {
+                     item_id: hir::HirId) {
         if self.access_levels.is_reachable(v.node.data.id()) {
             self.in_variant = true;
             intravisit::walk_variant(self, v, g, item_id);
@@ -1769,7 +1769,8 @@ fn check_mod_privacy<'tcx>(tcx: TyCtxt<'_, 'tcx, 'tcx>, module_def_id: DefId) {
         empty_tables: &empty_tables,
     };
     let (module, span, node_id) = tcx.hir().get_module(module_def_id);
-    intravisit::walk_mod(&mut visitor, module, node_id);
+    let hir_id = tcx.hir().node_to_hir_id(node_id);
+    intravisit::walk_mod(&mut visitor, module, hir_id);
 
     // Check privacy of explicitly written types and traits as well as
     // inferred types of expressions and patterns.
@@ -1781,7 +1782,7 @@ fn check_mod_privacy<'tcx>(tcx: TyCtxt<'_, 'tcx, 'tcx>, module_def_id: DefId) {
         span,
         empty_tables: &empty_tables,
     };
-    intravisit::walk_mod(&mut visitor, module, node_id);
+    intravisit::walk_mod(&mut visitor, module, hir_id);
 }
 
 fn privacy_access_levels<'tcx>(

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -501,7 +501,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                               mut msg: String,
                               candidates: Vec<DefId>) {
         let module_did = self.tcx.hir().get_module_parent_by_hir_id(self.body_id);
-        let module_id = self.tcx.hir().as_local_node_id(module_did).unwrap();
+        let module_id = self.tcx.hir().as_local_hir_id(module_did).unwrap();
         let krate = self.tcx.hir().krate();
         let (span, found_use) = UsePlacementFinder::check(self.tcx, krate, module_id);
         if let Some(span) = span {
@@ -787,7 +787,7 @@ pub fn provide(providers: &mut ty::query::Providers) {
 }
 
 struct UsePlacementFinder<'a, 'tcx: 'a, 'gcx: 'tcx> {
-    target_module: ast::NodeId,
+    target_module: hir::HirId,
     span: Option<Span>,
     found_use: bool,
     tcx: TyCtxt<'a, 'gcx, 'tcx>
@@ -797,7 +797,7 @@ impl<'a, 'tcx, 'gcx> UsePlacementFinder<'a, 'tcx, 'gcx> {
     fn check(
         tcx: TyCtxt<'a, 'gcx, 'tcx>,
         krate: &'tcx hir::Crate,
-        target_module: ast::NodeId,
+        target_module: hir::HirId,
     ) -> (Option<Span>, bool) {
         let mut finder = UsePlacementFinder {
             target_module,
@@ -815,13 +815,13 @@ impl<'a, 'tcx, 'gcx> hir::intravisit::Visitor<'tcx> for UsePlacementFinder<'a, '
         &mut self,
         module: &'tcx hir::Mod,
         _: Span,
-        node_id: ast::NodeId,
+        hir_id: hir::HirId,
     ) {
         if self.span.is_some() {
             return;
         }
-        if node_id != self.target_module {
-            hir::intravisit::walk_mod(self, module, node_id);
+        if hir_id != self.target_module {
+            hir::intravisit::walk_mod(self, module, hir_id);
             return;
         }
         // Find a `use` statement.

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1024,7 +1024,7 @@ impl<'a, 'gcx, 'tcx> Visitor<'gcx> for GatherLocalsVisitor<'a, 'gcx, 'tcx> {
 
     // Don't descend into the bodies of nested closures
     fn visit_fn(&mut self, _: intravisit::FnKind<'gcx>, _: &'gcx hir::FnDecl,
-                _: hir::BodyId, _: Span, _: ast::NodeId) { }
+                _: hir::BodyId, _: Span, _: hir::HirId) { }
 }
 
 /// When `check_fn` is invoked on a generator (i.e., a body that

--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -456,7 +456,7 @@ impl<'a, 'gcx, 'tcx> Visitor<'gcx> for RegionCtxt<'a, 'gcx, 'tcx> {
         _: &'gcx hir::FnDecl,
         body_id: hir::BodyId,
         span: Span,
-        id: ast::NodeId,
+        hir_id: hir::HirId,
     ) {
         assert!(
             match fk {
@@ -473,7 +473,6 @@ impl<'a, 'gcx, 'tcx> Visitor<'gcx> for RegionCtxt<'a, 'gcx, 'tcx> {
         let env_snapshot = self.outlives_environment.push_snapshot_pre_closure();
 
         let body = self.tcx.hir().body(body_id);
-        let hir_id = self.tcx.hir().node_to_hir_id(id);
         self.visit_fn_body(hir_id, body, span);
 
         // Restore state from previous function.

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -296,8 +296,8 @@ pub fn build_impl(cx: &DocContext, did: DefId, ret: &mut Vec<clean::Item>) {
         }
     }
 
-    let for_ = if let Some(nodeid) = tcx.hir().as_local_node_id(did) {
-        match tcx.hir().expect_item(nodeid).node {
+    let for_ = if let Some(hir_id) = tcx.hir().as_local_hir_id(did) {
+        match tcx.hir().expect_item_by_hir_id(hir_id).node {
             hir::ItemKind::Impl(.., ref t, _) => {
                 t.clean(cx)
             }
@@ -318,8 +318,8 @@ pub fn build_impl(cx: &DocContext, did: DefId, ret: &mut Vec<clean::Item>) {
     }
 
     let predicates = tcx.predicates_of(did);
-    let (trait_items, generics) = if let Some(nodeid) = tcx.hir().as_local_node_id(did) {
-        match tcx.hir().expect_item(nodeid).node {
+    let (trait_items, generics) = if let Some(hir_id) = tcx.hir().as_local_hir_id(did) {
+        match tcx.hir().expect_item_by_hir_id(hir_id).node {
             hir::ItemKind::Impl(.., ref gen, _, _, ref item_ids) => {
                 (
                     item_ids.iter()

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2562,9 +2562,9 @@ impl Clean<Type> for hir::Ty {
                 let mut alias = None;
                 if let Def::TyAlias(def_id) = path.def {
                     // Substitute private type aliases
-                    if let Some(node_id) = cx.tcx.hir().as_local_node_id(def_id) {
+                    if let Some(hir_id) = cx.tcx.hir().as_local_hir_id(def_id) {
                         if !cx.renderinfo.borrow().access_levels.is_exported(def_id) {
-                            alias = Some(&cx.tcx.hir().expect_item(node_id).node);
+                            alias = Some(&cx.tcx.hir().expect_item_by_hir_id(hir_id).node);
                         }
                     }
                 };

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -893,7 +893,7 @@ impl<'a, 'hir> intravisit::Visitor<'hir> for HirCollector<'a, 'hir> {
     fn visit_variant(&mut self,
                      v: &'hir hir::Variant,
                      g: &'hir hir::Generics,
-                     item_id: ast::NodeId) {
+                     item_id: hir::HirId) {
         self.visit_testable(v.node.ident.to_string(), &v.node.attrs, |this| {
             intravisit::walk_variant(this, v, g, item_id);
         });

--- a/src/test/run-pass-fulldeps/auxiliary/issue-40001-plugin.rs
+++ b/src/test/run-pass-fulldeps/auxiliary/issue-40001-plugin.rs
@@ -48,11 +48,11 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MissingWhitelistedAttrPass {
                 _: &'tcx hir::FnDecl,
                 _: &'tcx hir::Body,
                 span: source_map::Span,
-                id: ast::NodeId) {
+                id: hir::HirId) {
 
-        let item = match cx.tcx.hir().get(id) {
+        let item = match cx.tcx.hir().get_by_hir_id(id) {
             Node::Item(item) => item,
-            _ => cx.tcx.hir().expect_item(cx.tcx.hir().get_parent(id)),
+            _ => cx.tcx.hir().expect_item_by_hir_id(cx.tcx.hir().get_parent_item(id)),
         };
 
         if !attr::contains_name(&item.attrs, "whitelisted_attr") {


### PR DESCRIPTION
A big step towards https://github.com/rust-lang/rust/pull/57578.

This affects mostly `hir::{collector, intravisit}` and `rustc::lint`.