### PR TITLE
librustc_resolve => 2018

### DIFF
--- a/src/librustc_resolve/Cargo.toml
+++ b/src/librustc_resolve/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_resolve"
 version = "0.0.0"
+edition = "2018"
 
 [lib]
 name = "rustc_resolve"

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -3,14 +3,15 @@
 //! Here we build the "reduced graph": the graph of the module tree without
 //! any imports resolved.
 
-use macros::{InvocationData, ParentScope, LegacyScope};
-use resolve_imports::ImportDirective;
-use resolve_imports::ImportDirectiveSubclass::{self, GlobImport, SingleImport};
-use {Module, ModuleData, ModuleKind, NameBinding, NameBindingKind, Segment, ToNameBinding};
-use {ModuleOrUniformRoot, PerNS, Resolver, ResolverArenas, ExternPreludeEntry};
-use Namespace::{self, TypeNS, ValueNS, MacroNS};
-use {resolve_error, resolve_struct_error, ResolutionError};
+use crate::macros::{InvocationData, ParentScope, LegacyScope};
+use crate::resolve_imports::ImportDirective;
+use crate::resolve_imports::ImportDirectiveSubclass::{self, GlobImport, SingleImport};
+use crate::{Module, ModuleData, ModuleKind, NameBinding, NameBindingKind, Segment, ToNameBinding};
+use crate::{ModuleOrUniformRoot, PerNS, Resolver, ResolverArenas, ExternPreludeEntry};
+use crate::Namespace::{self, TypeNS, ValueNS, MacroNS};
+use crate::{resolve_error, resolve_struct_error, ResolutionError};
 
+use rustc::bug;
 use rustc::hir::def::*;
 use rustc::hir::def_id::{CrateNum, CRATE_DEF_INDEX, LOCAL_CRATE, DefId};
 use rustc::ty;
@@ -21,7 +22,7 @@ use std::cell::Cell;
 use std::ptr;
 use rustc_data_structures::sync::Lrc;
 
-use errors::Applicability;
+use crate::errors::Applicability;
 
 use syntax::ast::{Name, Ident};
 use syntax::attr;
@@ -34,11 +35,14 @@ use syntax::ext::hygiene::Mark;
 use syntax::ext::tt::macro_rules;
 use syntax::feature_gate::is_builtin_attr;
 use syntax::parse::token::{self, Token};
+use syntax::span_err;
 use syntax::std_inject::injected_crate_name;
 use syntax::symbol::keywords;
 use syntax::visit::{self, Visitor};
 
 use syntax_pos::{Span, DUMMY_SP};
+
+use log::debug;
 
 impl<'a> ToNameBinding<'a> for (Module<'a>, ty::Visibility, Span, Mark) {
     fn to_name_binding(self, arenas: &'a ResolverArenas<'a>) -> &'a NameBinding<'a> {

--- a/src/librustc_resolve/check_unused.rs
+++ b/src/librustc_resolve/check_unused.rs
@@ -10,8 +10,8 @@
 
 use std::ops::{Deref, DerefMut};
 
-use Resolver;
-use resolve_imports::ImportDirectiveSubclass;
+use crate::Resolver;
+use crate::resolve_imports::ImportDirectiveSubclass;
 
 use rustc::{lint, ty};
 use rustc::util::nodemap::NodeMap;
@@ -113,7 +113,7 @@ impl<'a, 'b> Visitor<'a> for UnusedImportCheckVisitor<'a, 'b> {
     }
 }
 
-pub fn check_crate(resolver: &mut Resolver, krate: &ast::Crate) {
+pub fn check_crate(resolver: &mut Resolver<'_>, krate: &ast::Crate) {
     for directive in resolver.potentially_unused_imports.iter() {
         match directive.subclass {
             _ if directive.used.get() ||

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -1,5 +1,7 @@
 #![allow(non_snake_case)]
 
+use syntax::{register_diagnostic, register_diagnostics, register_long_diagnostics};
+
 // Error messages for EXXXX errors.  Each message should start and end with a
 // new line, and be wrapped to 80 characters.  In vim you can `:set tw=80` and
 // use `gq` to wrap paragraphs. Use `:set tw=0` to disable.

--- a/src/librustc_resolve/error_reporting.rs
+++ b/src/librustc_resolve/error_reporting.rs
@@ -1,10 +1,12 @@
-use {CrateLint, PathResult, Segment};
-use macros::ParentScope;
+use crate::{CrateLint, PathResult, Segment};
+use crate::macros::ParentScope;
+use crate::resolve_imports::ImportResolver;
 
 use syntax::symbol::keywords;
 use syntax_pos::Span;
 
-use resolve_imports::ImportResolver;
+use log::debug;
+
 use std::cmp::Reverse;
 
 impl<'a, 'b:'a> ImportResolver<'a, 'b> {

--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -1,16 +1,17 @@
-use {AmbiguityError, AmbiguityKind, AmbiguityErrorMisc};
-use {CrateLint, Resolver, ResolutionError, ScopeSet, Weak};
-use {Module, ModuleKind, NameBinding, NameBindingKind, PathResult, Segment, ToNameBinding};
-use {is_known_tool, resolve_error};
-use ModuleOrUniformRoot;
-use Namespace::*;
-use build_reduced_graph::{BuildReducedGraphVisitor, IsMacroExport};
-use resolve_imports::ImportResolver;
+use crate::{AmbiguityError, AmbiguityKind, AmbiguityErrorMisc};
+use crate::{CrateLint, Resolver, ResolutionError, ScopeSet, Weak};
+use crate::{Module, ModuleKind, NameBinding, NameBindingKind, PathResult, Segment, ToNameBinding};
+use crate::{is_known_tool, resolve_error};
+use crate::ModuleOrUniformRoot;
+use crate::Namespace::*;
+use crate::build_reduced_graph::{BuildReducedGraphVisitor, IsMacroExport};
+use crate::resolve_imports::ImportResolver;
 use rustc::hir::def_id::{DefId, CRATE_DEF_INDEX, DefIndex,
                          CrateNum, DefIndexAddressSpace};
 use rustc::hir::def::{Def, NonMacroAttrKind};
 use rustc::hir::map::{self, DefCollector};
 use rustc::{ty, lint};
+use rustc::{bug, span_bug};
 use syntax::ast::{self, Ident};
 use syntax::attr;
 use syntax::errors::DiagnosticBuilder;
@@ -26,7 +27,7 @@ use syntax::symbol::{Symbol, keywords};
 use syntax::visit::Visitor;
 use syntax::util::lev_distance::find_best_match_for_name;
 use syntax_pos::{Span, DUMMY_SP};
-use errors::Applicability;
+use crate::errors::Applicability;
 
 use std::cell::Cell;
 use std::{mem, ptr};
@@ -530,7 +531,7 @@ impl<'a> Resolver<'a> {
             BuiltinTypes,
         }
 
-        bitflags! {
+        bitflags::bitflags! {
             struct Flags: u8 {
                 const MACRO_RULES        = 1 << 0;
                 const MODULE             = 1 << 1;
@@ -560,7 +561,7 @@ impl<'a> Resolver<'a> {
         // }
         // So we have to save the innermost solution and continue searching in outer scopes
         // to detect potential ambiguities.
-        let mut innermost_result: Option<(&NameBinding, Flags)> = None;
+        let mut innermost_result: Option<(&NameBinding<'_>, Flags)> = None;
 
         // Go through all the scopes and try to resolve the name.
         let rust_2015 = orig_ident.span.rust_2015();


### PR DESCRIPTION
Transitions `librustc_resolve` to Rust 2018; cc #58099

r? @Centril