### PR TITLE
librustc_apfloat => 2018

### DIFF
--- a/src/librustc_apfloat/Cargo.toml
+++ b/src/librustc_apfloat/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_apfloat"
 version = "0.0.0"
+edition = "2018"
 
 [lib]
 name = "rustc_apfloat"

--- a/src/librustc_apfloat/ieee.rs
+++ b/src/librustc_apfloat/ieee.rs
@@ -1,5 +1,5 @@
-use {Category, ExpInt, IEK_INF, IEK_NAN, IEK_ZERO};
-use {Float, FloatConvert, ParseError, Round, Status, StatusAnd};
+use crate::{Category, ExpInt, IEK_INF, IEK_NAN, IEK_ZERO};
+use crate::{Float, FloatConvert, ParseError, Round, Status, StatusAnd};
 
 use smallvec::{SmallVec, smallvec};
 use std::cmp::{self, Ordering};
@@ -325,7 +325,7 @@ impl<S> Neg for IeeeFloat<S> {
 /// 1.01E-2              4        2       0.0101
 /// 1.01E-2              4        1       1.01E-2
 impl<S: Semantics> fmt::Display for IeeeFloat<S> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let width = f.width().unwrap_or(3);
         let alternate = f.alternate();
 
@@ -614,7 +614,7 @@ impl<S: Semantics> fmt::Display for IeeeFloat<S> {
 }
 
 impl<S: Semantics> fmt::Debug for IeeeFloat<S> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}({:?} | {}{:?} * 2^{})",
                self, self.category,
                if self.sign { "-" } else { "+" },

--- a/src/librustc_apfloat/lib.rs
+++ b/src/librustc_apfloat/lib.rs
@@ -34,16 +34,12 @@
       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
       html_root_url = "https://doc.rust-lang.org/nightly/")]
 #![forbid(unsafe_code)]
+#![deny(rust_2018_idioms)]
 
-#![feature(nll)]
 #![feature(try_from)]
 // See librustc_cratesio_shim/Cargo.toml for a comment explaining this.
 #[allow(unused_extern_crates)]
 extern crate rustc_cratesio_shim;
-
-#[macro_use]
-extern crate bitflags;
-extern crate smallvec;
 
 use std::cmp::Ordering;
 use std::fmt;
@@ -51,7 +47,7 @@ use std::ops::{Neg, Add, Sub, Mul, Div, Rem};
 use std::ops::{AddAssign, SubAssign, MulAssign, DivAssign, RemAssign};
 use std::str::FromStr;
 
-bitflags! {
+bitflags::bitflags! {
     /// IEEE-754R 7: Default exception handling.
     ///
     /// UNDERFLOW or OVERFLOW are always returned or-ed with INEXACT.

--- a/src/librustc_apfloat/ppc.rs
+++ b/src/librustc_apfloat/ppc.rs
@@ -1,5 +1,5 @@
-use {Category, ExpInt, Float, FloatConvert, Round, ParseError, Status, StatusAnd};
-use ieee;
+use crate::{Category, ExpInt, Float, FloatConvert, Round, ParseError, Status, StatusAnd};
+use crate::ieee;
 
 use std::cmp::Ordering;
 use std::fmt;
@@ -124,7 +124,7 @@ impl<F: Float> Neg for DoubleFloat<F> {
 }
 
 impl<F: FloatConvert<Fallback<F>>> fmt::Display for DoubleFloat<F> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&Fallback::from(*self), f)
     }
 }

--- a/src/librustc_apfloat/tests/ieee.rs
+++ b/src/librustc_apfloat/tests/ieee.rs
@@ -1,9 +1,7 @@
-#[macro_use]
-extern crate rustc_apfloat;
-
 use rustc_apfloat::{Category, ExpInt, IEK_INF, IEK_NAN, IEK_ZERO};
 use rustc_apfloat::{Float, FloatConvert, ParseError, Round, Status};
 use rustc_apfloat::ieee::{Half, Single, Double, Quad, X87DoubleExtended};
+use rustc_apfloat::unpack;
 
 trait SingleExt {
     fn from_f32(input: f32) -> Self;

--- a/src/librustc_apfloat/tests/ppc.rs
+++ b/src/librustc_apfloat/tests/ppc.rs
@@ -1,5 +1,3 @@
-extern crate rustc_apfloat;
-
 use rustc_apfloat::{Category, Float, Round};
 use rustc_apfloat::ppc::DoubleDouble;
 


### PR DESCRIPTION
Transitions `librustc_apfloat` to Rust 2018; cc #58099

r? @Centril