### PR TITLE
librustc_errors => 2018

### DIFF
--- a/src/librustc_errors/Cargo.toml
+++ b/src/librustc_errors/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_errors"
 version = "0.0.0"
+edition = "2018"
 
 [lib]
 name = "rustc_errors"

--- a/src/librustc_errors/diagnostic.rs
+++ b/src/librustc_errors/diagnostic.rs
@@ -1,11 +1,11 @@
-use CodeSuggestion;
-use SubstitutionPart;
-use Substitution;
-use Applicability;
-use Level;
+use crate::CodeSuggestion;
+use crate::SubstitutionPart;
+use crate::Substitution;
+use crate::Applicability;
+use crate::Level;
+use crate::snippet::Style;
 use std::fmt;
 use syntax_pos::{MultiSpan, Span};
-use snippet::Style;
 
 #[must_use]
 #[derive(Clone, Debug, PartialEq, Hash, RustcEncodable, RustcDecodable)]

--- a/src/librustc_errors/diagnostic_builder.rs
+++ b/src/librustc_errors/diagnostic_builder.rs
@@ -1,14 +1,15 @@
-use Diagnostic;
-use DiagnosticId;
-use DiagnosticStyledString;
-use Applicability;
+use crate::Diagnostic;
+use crate::DiagnosticId;
+use crate::DiagnosticStyledString;
+use crate::Applicability;
 
-use Level;
-use Handler;
+use crate::Level;
+use crate::Handler;
 use std::fmt::{self, Debug};
 use std::ops::{Deref, DerefMut};
 use std::thread::panicking;
 use syntax_pos::{MultiSpan, Span};
+use log::debug;
 
 /// Used for emitting structured error messages and other diagnostic information.
 ///
@@ -111,8 +112,8 @@ impl<'a> DiagnosticBuilder<'a> {
         // implements `Drop`.
         let diagnostic;
         unsafe {
-            diagnostic = ::std::ptr::read(&self.diagnostic);
-            ::std::mem::forget(self);
+            diagnostic = std::ptr::read(&self.diagnostic);
+            std::mem::forget(self);
         };
         // Logging here is useful to help track down where in logs an error was
         // actually emitted.
@@ -298,7 +299,7 @@ impl<'a> DiagnosticBuilder<'a> {
 }
 
 impl<'a> Debug for DiagnosticBuilder<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.diagnostic.fmt(f)
     }
 }

--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -1,28 +1,26 @@
-use self::Destination::*;
+use Destination::*;
 
 use syntax_pos::{SourceFile, Span, MultiSpan};
 
-use {Level, CodeSuggestion, DiagnosticBuilder, SubDiagnostic, SourceMapperDyn, DiagnosticId};
-use snippet::{Annotation, AnnotationType, Line, MultilineAnnotation, StyledString, Style};
-use styled_buffer::StyledBuffer;
+use crate::{Level, CodeSuggestion, DiagnosticBuilder, SubDiagnostic, SourceMapperDyn, DiagnosticId};
+use crate::snippet::{Annotation, AnnotationType, Line, MultilineAnnotation, StyledString, Style};
+use crate::styled_buffer::StyledBuffer;
 
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::sync::Lrc;
-use atty;
 use std::borrow::Cow;
 use std::io::prelude::*;
 use std::io;
 use std::cmp::{min, Reverse};
 use termcolor::{StandardStream, ColorChoice, ColorSpec, BufferWriter};
 use termcolor::{WriteColor, Color, Buffer};
-use unicode_width;
 
 const ANONYMIZED_LINE_NUM: &str = "LL";
 
 /// Emitter trait for emitting errors.
 pub trait Emitter {
     /// Emit a structured diagnostic.
-    fn emit(&mut self, db: &DiagnosticBuilder);
+    fn emit(&mut self, db: &DiagnosticBuilder<'_>);
 
     /// Check if should show explanations about "rustc --explain"
     fn should_show_explain(&self) -> bool {
@@ -31,7 +29,7 @@ pub trait Emitter {
 }
 
 impl Emitter for EmitterWriter {
-    fn emit(&mut self, db: &DiagnosticBuilder) {
+    fn emit(&mut self, db: &DiagnosticBuilder<'_>) {
         let mut primary_span = db.span.clone();
         let mut children = db.children.clone();
         let mut suggestions: &[_] = &[];
@@ -1431,7 +1429,7 @@ fn emit_to_destination(rendered_buffer: &[Vec<StyledString>],
                        dst: &mut Destination,
                        short_message: bool)
                        -> io::Result<()> {
-    use lock;
+    use crate::lock;
 
     let mut dst = dst.writable();
 

--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -6,23 +6,15 @@
 #![allow(unused_attributes)]
 #![feature(range_contains)]
 #![cfg_attr(unix, feature(libc))]
-#![feature(nll)]
 #![feature(optin_builtin_traits)]
+#![deny(rust_2018_idioms)]
 
-extern crate atty;
-extern crate termcolor;
-#[cfg(unix)]
-extern crate libc;
-#[macro_use]
-extern crate log;
-extern crate rustc_data_structures;
-extern crate serialize as rustc_serialize;
-extern crate syntax_pos;
-extern crate unicode_width;
+#[allow(unused_extern_crates)]
+extern crate serialize as rustc_serialize; // used by deriving
 
 pub use emitter::ColorConfig;
 
-use self::Level::*;
+use Level::*;
 
 use emitter::{Emitter, EmitterWriter};
 
@@ -144,7 +136,7 @@ impl CodeSuggestion {
         use syntax_pos::{CharPos, Loc, Pos};
 
         fn push_trailing(buf: &mut String,
-                         line_opt: Option<&Cow<str>>,
+                         line_opt: Option<&Cow<'_, str>>,
                          lo: &Loc,
                          hi_opt: Option<&Loc>) {
             let (lo, hi_opt) = (lo.col.to_usize(), hi_opt.map(|hi| hi.col.to_usize()));
@@ -247,7 +239,7 @@ impl FatalError {
 }
 
 impl fmt::Display for FatalError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "parser fatal error")
     }
 }
@@ -264,7 +256,7 @@ impl error::Error for FatalError {
 pub struct ExplicitBug;
 
 impl fmt::Display for ExplicitBug {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "parser internal bug")
     }
 }
@@ -496,7 +488,7 @@ impl Handler {
         DiagnosticBuilder::new(self, Level::Fatal, msg)
     }
 
-    pub fn cancel(&self, err: &mut DiagnosticBuilder) {
+    pub fn cancel(&self, err: &mut DiagnosticBuilder<'_>) {
         err.cancel();
     }
 
@@ -698,12 +690,12 @@ impl Handler {
         self.taught_diagnostics.borrow_mut().insert(code.clone())
     }
 
-    pub fn force_print_db(&self, mut db: DiagnosticBuilder) {
+    pub fn force_print_db(&self, mut db: DiagnosticBuilder<'_>) {
         self.emitter.borrow_mut().emit(&db);
         db.cancel();
     }
 
-    fn emit_db(&self, db: &DiagnosticBuilder) {
+    fn emit_db(&self, db: &DiagnosticBuilder<'_>) {
         let diagnostic = &**db;
 
         TRACK_DIAGNOSTICS.with(|track_diagnostics| {
@@ -749,7 +741,7 @@ pub enum Level {
 }
 
 impl fmt::Display for Level {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.to_str().fmt(f)
     }
 }

--- a/src/librustc_errors/snippet.rs
+++ b/src/librustc_errors/snippet.rs
@@ -1,6 +1,6 @@
 // Code for annotating snippets.
 
-use Level;
+use crate::Level;
 
 #[derive(Clone, Debug, PartialOrd, Ord, PartialEq, Eq)]
 pub struct Line {

--- a/src/librustc_errors/styled_buffer.rs
+++ b/src/librustc_errors/styled_buffer.rs
@@ -1,6 +1,6 @@
 // Code for creating styled buffers
 
-use snippet::{Style, StyledString};
+use crate::snippet::{Style, StyledString};
 
 #[derive(Debug)]
 pub struct StyledBuffer {


### PR DESCRIPTION
Transitions `librustc_errors` to Rust 2018; cc #58099

r? @Centril