### PR TITLE
librustc_llvm => 2018

### DIFF
--- a/src/librustc_llvm/Cargo.toml
+++ b/src/librustc_llvm/Cargo.toml
@@ -3,6 +3,7 @@ authors = ["The Rust Project Developers"]
 name = "rustc_llvm"
 version = "0.0.0"
 build = "build.rs"
+edition = "2018"
 
 [lib]
 name = "rustc_llvm"

--- a/src/librustc_llvm/build.rs
+++ b/src/librustc_llvm/build.rs
@@ -1,6 +1,3 @@
-extern crate cc;
-extern crate build_helper;
-
 use std::process::Command;
 use std::env;
 use std::path::{PathBuf, Path};

--- a/src/librustc_llvm/lib.rs
+++ b/src/librustc_llvm/lib.rs
@@ -1,4 +1,4 @@
-#![feature(nll)]
+#![deny(rust_2018_idioms)]
 #![feature(static_nobundle)]
 
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",


### PR DESCRIPTION
Transitions `librustc_llvm` to Rust 2018; cc #58099

r? @Centril