### PR TITLE
Document the one TyKind that isn't documented

### DIFF
--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -107,6 +107,7 @@ pub enum TyKind<'tcx> {
     /// definition and not a concrete use of it.
     Adt(&'tcx AdtDef, &'tcx Substs<'tcx>),
 
+    /// An unsized FFI type that is opaque to Rust. Written as `extern type T`.
     Foreign(DefId),
 
     /// The pointee of a string slice. Written as `str`.


### PR DESCRIPTION
This is especially confusing since the name `Foreign` and the name `extern type` are so different. I deduced that they're the same by consulting git-blame.