### PR TITLE
librustc_lint => 2018

### DIFF
--- a/src/librustc_lint/Cargo.toml
+++ b/src/librustc_lint/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_lint"
 version = "0.0.0"
+edition = "2018"
 
 [lib]
 name = "rustc_lint"

--- a/src/librustc_lint/diagnostics.rs
+++ b/src/librustc_lint/diagnostics.rs
@@ -1,3 +1,5 @@
+use syntax::{register_diagnostic, register_diagnostics};
+
 register_diagnostics! {
     E0721, // `await` keyword
 }

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -21,15 +21,10 @@
 
 #![recursion_limit="256"]
 
-#[macro_use]
-extern crate syntax;
+#![deny(rust_2018_idioms)]
+
 #[macro_use]
 extern crate rustc;
-#[macro_use]
-extern crate log;
-extern crate rustc_target;
-extern crate syntax_pos;
-extern crate rustc_data_structures;
 
 mod diagnostics;
 mod nonstandard_style;
@@ -51,7 +46,6 @@ use rustc::lint::builtin::{
     parser::ILL_FORMED_ATTRIBUTE_INPUT,
 };
 use rustc::session;
-use rustc::util;
 use rustc::hir;
 
 use syntax::ast;

--- a/src/librustc_lint/nonstandard_style.rs
+++ b/src/librustc_lint/nonstandard_style.rs
@@ -1,6 +1,7 @@
 use rustc::hir::{self, GenericParamKind, PatKind};
 use rustc::hir::def::Def;
 use rustc::hir::intravisit::FnKind;
+use rustc::lint;
 use rustc::ty;
 use rustc_target::spec::abi::Abi;
 use lint::{EarlyContext, LateContext, LintContext, LintArray};
@@ -17,7 +18,7 @@ pub enum MethodLateContext {
     PlainImpl,
 }
 
-pub fn method_context(cx: &LateContext, id: ast::NodeId) -> MethodLateContext {
+pub fn method_context(cx: &LateContext<'_, '_>, id: ast::NodeId) -> MethodLateContext {
     let def_id = cx.tcx.hir().local_def_id(id);
     let item = cx.tcx.associated_item(def_id);
     match item.container {
@@ -41,7 +42,7 @@ declare_lint! {
 pub struct NonCamelCaseTypes;
 
 impl NonCamelCaseTypes {
-    fn check_case(&self, cx: &EarlyContext, sort: &str, ident: &Ident) {
+    fn check_case(&self, cx: &EarlyContext<'_>, sort: &str, ident: &Ident) {
         fn char_has_case(c: char) -> bool {
             c.is_lowercase() || c.is_uppercase()
         }
@@ -115,7 +116,7 @@ impl LintPass for NonCamelCaseTypes {
 }
 
 impl EarlyLintPass for NonCamelCaseTypes {
-    fn check_item(&mut self, cx: &EarlyContext, it: &ast::Item) {
+    fn check_item(&mut self, cx: &EarlyContext<'_>, it: &ast::Item) {
         let has_repr_c = it.attrs
             .iter()
             .any(|attr| {
@@ -138,11 +139,11 @@ impl EarlyLintPass for NonCamelCaseTypes {
         }
     }
 
-    fn check_variant(&mut self, cx: &EarlyContext, v: &ast::Variant, _: &ast::Generics) {
+    fn check_variant(&mut self, cx: &EarlyContext<'_>, v: &ast::Variant, _: &ast::Generics) {
         self.check_case(cx, "variant", &v.node.ident);
     }
 
-    fn check_generic_param(&mut self, cx: &EarlyContext, param: &ast::GenericParam) {
+    fn check_generic_param(&mut self, cx: &EarlyContext<'_>, param: &ast::GenericParam) {
         if let ast::GenericParamKind::Type { .. } = param.kind {
             self.check_case(cx, "type parameter", &param.ident);
         }
@@ -190,7 +191,7 @@ impl NonSnakeCase {
     }
 
     /// Checks if a given identifier is snake case, and reports a diagnostic if not.
-    fn check_snake_case(&self, cx: &LateContext, sort: &str, ident: &Ident) {
+    fn check_snake_case(&self, cx: &LateContext<'_, '_>, sort: &str, ident: &Ident) {
         fn is_snake_case(ident: &str) -> bool {
             if ident.is_empty() {
                 return true;
@@ -249,7 +250,7 @@ impl LintPass for NonSnakeCase {
 }
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NonSnakeCase {
-    fn check_crate(&mut self, cx: &LateContext, cr: &hir::Crate) {
+    fn check_crate(&mut self, cx: &LateContext<'_, '_>, cr: &hir::Crate) {
         let crate_ident = if let Some(name) = &cx.tcx.sess.opts.crate_name {
             Some(Ident::from_str(name))
         } else {
@@ -286,7 +287,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NonSnakeCase {
         }
     }
 
-    fn check_generic_param(&mut self, cx: &LateContext, param: &hir::GenericParam) {
+    fn check_generic_param(&mut self, cx: &LateContext<'_, '_>, param: &hir::GenericParam) {
         if let GenericParamKind::Lifetime { .. } = param.kind {
             self.check_snake_case(cx, "lifetime", &param.name.ident());
         }
@@ -294,8 +295,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NonSnakeCase {
 
     fn check_fn(
         &mut self,
-        cx: &LateContext,
-        fk: FnKind,
+        cx: &LateContext<'_, '_>,
+        fk: FnKind<'_>,
         _: &hir::FnDecl,
         _: &hir::Body,
         _: Span,
@@ -324,13 +325,13 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NonSnakeCase {
         }
     }
 
-    fn check_item(&mut self, cx: &LateContext, it: &hir::Item) {
+    fn check_item(&mut self, cx: &LateContext<'_, '_>, it: &hir::Item) {
         if let hir::ItemKind::Mod(_) = it.node {
             self.check_snake_case(cx, "module", &it.ident);
         }
     }
 
-    fn check_trait_item(&mut self, cx: &LateContext, item: &hir::TraitItem) {
+    fn check_trait_item(&mut self, cx: &LateContext<'_, '_>, item: &hir::TraitItem) {
         if let hir::TraitItemKind::Method(_, hir::TraitMethod::Required(pnames)) = &item.node {
             self.check_snake_case(cx, "trait method", &item.ident);
             for param_name in pnames {
@@ -339,7 +340,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NonSnakeCase {
         }
     }
 
-    fn check_pat(&mut self, cx: &LateContext, p: &hir::Pat) {
+    fn check_pat(&mut self, cx: &LateContext<'_, '_>, p: &hir::Pat) {
         if let &PatKind::Binding(_, _, _, ident, _) = &p.node {
             self.check_snake_case(cx, "variable", &ident);
         }
@@ -347,7 +348,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NonSnakeCase {
 
     fn check_struct_def(
         &mut self,
-        cx: &LateContext,
+        cx: &LateContext<'_, '_>,
         s: &hir::VariantData,
         _: ast::Name,
         _: &hir::Generics,
@@ -369,7 +370,7 @@ declare_lint! {
 pub struct NonUpperCaseGlobals;
 
 impl NonUpperCaseGlobals {
-    fn check_upper_case(cx: &LateContext, sort: &str, ident: &Ident) {
+    fn check_upper_case(cx: &LateContext<'_, '_>, sort: &str, ident: &Ident) {
         let name = &ident.name.as_str();
 
         if name.chars().any(|c| c.is_lowercase()) {
@@ -399,7 +400,7 @@ impl LintPass for NonUpperCaseGlobals {
 }
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NonUpperCaseGlobals {
-    fn check_item(&mut self, cx: &LateContext, it: &hir::Item) {
+    fn check_item(&mut self, cx: &LateContext<'_, '_>, it: &hir::Item) {
         match it.node {
             hir::ItemKind::Static(..) if !attr::contains_name(&it.attrs, "no_mangle") => {
                 NonUpperCaseGlobals::check_upper_case(cx, "static variable", &it.ident);
@@ -411,19 +412,19 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NonUpperCaseGlobals {
         }
     }
 
-    fn check_trait_item(&mut self, cx: &LateContext, ti: &hir::TraitItem) {
+    fn check_trait_item(&mut self, cx: &LateContext<'_, '_>, ti: &hir::TraitItem) {
         if let hir::TraitItemKind::Const(..) = ti.node {
             NonUpperCaseGlobals::check_upper_case(cx, "associated constant", &ti.ident);
         }
     }
 
-    fn check_impl_item(&mut self, cx: &LateContext, ii: &hir::ImplItem) {
+    fn check_impl_item(&mut self, cx: &LateContext<'_, '_>, ii: &hir::ImplItem) {
         if let hir::ImplItemKind::Const(..) = ii.node {
             NonUpperCaseGlobals::check_upper_case(cx, "associated constant", &ii.ident);
         }
     }
 
-    fn check_pat(&mut self, cx: &LateContext, p: &hir::Pat) {
+    fn check_pat(&mut self, cx: &LateContext<'_, '_>, p: &hir::Pat) {
         // Lint for constants that look like binding identifiers (#7526)
         if let PatKind::Path(hir::QPath::Resolved(None, ref path)) = p.node {
             if let Def::Const(..) = path.def {

--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -1,5 +1,6 @@
 use rustc::hir::def::Def;
 use rustc::hir::def_id::DefId;
+use rustc::lint;
 use rustc::ty;
 use rustc::ty::adjustment;
 use lint::{LateContext, EarlyContext, LintContext, LintArray};
@@ -15,6 +16,8 @@ use syntax::util::parser;
 use syntax_pos::Span;
 
 use rustc::hir;
+
+use log::debug;
 
 declare_lint! {
     pub UNUSED_MUST_USE,
@@ -43,7 +46,7 @@ impl LintPass for UnusedResults {
 }
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedResults {
-    fn check_stmt(&mut self, cx: &LateContext, s: &hir::Stmt) {
+    fn check_stmt(&mut self, cx: &LateContext<'_, '_>, s: &hir::Stmt) {
         let expr = match s.node {
             hir::StmtKind::Semi(ref expr) => &**expr,
             _ => return,
@@ -168,7 +171,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedResults {
         }
 
         fn check_must_use(
-            cx: &LateContext,
+            cx: &LateContext<'_, '_>,
             def_id: DefId,
             sp: Span,
             descr_pre_path: &str,
@@ -212,7 +215,7 @@ impl LintPass for PathStatements {
 }
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for PathStatements {
-    fn check_stmt(&mut self, cx: &LateContext, s: &hir::Stmt) {
+    fn check_stmt(&mut self, cx: &LateContext<'_, '_>, s: &hir::Stmt) {
         if let hir::StmtKind::Semi(ref expr) = s.node {
             if let hir::ExprKind::Path(_) = expr.node {
                 cx.span_lint(PATH_STATEMENTS, s.span, "path statement with no effect");
@@ -241,7 +244,7 @@ impl LintPass for UnusedAttributes {
 }
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedAttributes {
-    fn check_attribute(&mut self, cx: &LateContext, attr: &ast::Attribute) {
+    fn check_attribute(&mut self, cx: &LateContext<'_, '_>, attr: &ast::Attribute) {
         debug!("checking attribute: {:?}", attr);
         // Note that check_name() marks the attribute as used if it matches.
         for &(name, ty, ..) in BUILTIN_ATTRIBUTES {
@@ -303,7 +306,7 @@ pub struct UnusedParens;
 
 impl UnusedParens {
     fn check_unused_parens_expr(&self,
-                                cx: &EarlyContext,
+                                cx: &EarlyContext<'_>,
                                 value: &ast::Expr,
                                 msg: &str,
                                 followed_by_block: bool) {
@@ -325,7 +328,7 @@ impl UnusedParens {
     }
 
     fn check_unused_parens_pat(&self,
-                                cx: &EarlyContext,
+                                cx: &EarlyContext<'_>,
                                 value: &ast::Pat,
                                 msg: &str) {
         if let ast::PatKind::Paren(_) = value.node {
@@ -339,7 +342,7 @@ impl UnusedParens {
         }
     }
 
-    fn remove_outer_parens(cx: &EarlyContext, span: Span, pattern: &str, msg: &str) {
+    fn remove_outer_parens(cx: &EarlyContext<'_>, span: Span, pattern: &str, msg: &str) {
         let span_msg = format!("unnecessary parentheses around {}", msg);
         let mut err = cx.struct_span_lint(UNUSED_PARENS, span, &span_msg);
         let mut ate_left_paren = false;
@@ -387,7 +390,7 @@ impl LintPass for UnusedParens {
 }
 
 impl EarlyLintPass for UnusedParens {
-    fn check_expr(&mut self, cx: &EarlyContext, e: &ast::Expr) {
+    fn check_expr(&mut self, cx: &EarlyContext<'_>, e: &ast::Expr) {
         use syntax::ast::ExprKind::*;
         let (value, msg, followed_by_block) = match e.node {
             If(ref cond, ..) => (cond, "`if` condition", true),
@@ -429,7 +432,7 @@ impl EarlyLintPass for UnusedParens {
         self.check_unused_parens_expr(cx, &value, msg, followed_by_block);
     }
 
-    fn check_pat(&mut self, cx: &EarlyContext, p: &ast::Pat, _: &mut bool) {
+    fn check_pat(&mut self, cx: &EarlyContext<'_>, p: &ast::Pat, _: &mut bool) {
         use ast::PatKind::{Paren, Range};
         // The lint visitor will visit each subpattern of `p`. We do not want to lint any range
         // pattern no matter where it occurs in the pattern. For something like `&(a..=b)`, there
@@ -443,7 +446,7 @@ impl EarlyLintPass for UnusedParens {
         }
     }
 
-    fn check_stmt(&mut self, cx: &EarlyContext, s: &ast::Stmt) {
+    fn check_stmt(&mut self, cx: &EarlyContext<'_>, s: &ast::Stmt) {
         if let ast::StmtKind::Local(ref local) = s.node {
             if let Some(ref value) = local.init {
                 self.check_unused_parens_expr(cx, &value, "assigned value", false);
@@ -462,7 +465,7 @@ declare_lint! {
 pub struct UnusedImportBraces;
 
 impl UnusedImportBraces {
-    fn check_use_tree(&self, cx: &EarlyContext, use_tree: &ast::UseTree, item: &ast::Item) {
+    fn check_use_tree(&self, cx: &EarlyContext<'_>, use_tree: &ast::UseTree, item: &ast::Item) {
         if let ast::UseTreeKind::Nested(ref items) = use_tree.kind {
             // Recursively check nested UseTrees
             for &(ref tree, _) in items {
@@ -509,7 +512,7 @@ impl LintPass for UnusedImportBraces {
 }
 
 impl EarlyLintPass for UnusedImportBraces {
-    fn check_item(&mut self, cx: &EarlyContext, item: &ast::Item) {
+    fn check_item(&mut self, cx: &EarlyContext<'_>, item: &ast::Item) {
         if let ast::ItemKind::Use(ref use_tree) = item.node {
             self.check_use_tree(cx, use_tree, item);
         }
@@ -536,7 +539,7 @@ impl LintPass for UnusedAllocation {
 }
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedAllocation {
-    fn check_expr(&mut self, cx: &LateContext, e: &hir::Expr) {
+    fn check_expr(&mut self, cx: &LateContext<'_, '_>, e: &hir::Expr) {
         match e.node {
             hir::ExprKind::Box(_) => {}
             _ => return,


### PR DESCRIPTION
Transitions `librustc_lint` to Rust 2018; cc #58099

r? @Centril