### PR TITLE
librustc_passes => 2018

### DIFF
--- a/src/librustc_passes/Cargo.toml
+++ b/src/librustc_passes/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_passes"
 version = "0.0.0"
+edition = "2018"
 
 [lib]
 name = "rustc_passes"
@@ -16,4 +17,4 @@ rustc_data_structures = { path = "../librustc_data_structures" }
 syntax = { path = "../libsyntax" }
 syntax_ext = { path = "../libsyntax_ext" }
 syntax_pos = { path = "../libsyntax_pos" }
-rustc_errors = { path = "../librustc_errors" }
+errors = { path = "../librustc_errors", package = "rustc_errors" }

--- a/src/librustc_passes/ast_validation.rs
+++ b/src/librustc_passes/ast_validation.rs
@@ -15,10 +15,11 @@ use syntax::source_map::Spanned;
 use syntax::symbol::keywords;
 use syntax::ptr::P;
 use syntax::visit::{self, Visitor};
+use syntax::{span_err, struct_span_err, walk_list};
 use syntax_ext::proc_macro_decls::is_proc_macro_attr;
 use syntax_pos::Span;
-use errors;
 use errors::Applicability;
+use log::debug;
 
 struct AstValidator<'a> {
     session: &'a Session,

--- a/src/librustc_passes/diagnostics.rs
+++ b/src/librustc_passes/diagnostics.rs
@@ -1,5 +1,7 @@
 #![allow(non_snake_case)]
 
+use syntax::{register_diagnostic, register_diagnostics, register_long_diagnostics};
+
 register_long_diagnostics! {
 /*
 E0014: r##"

--- a/src/librustc_passes/hir_stats.rs
+++ b/src/librustc_passes/hir_stats.rs
@@ -61,7 +61,7 @@ impl<'k> StatCollector<'k> {
         });
 
         entry.count += 1;
-        entry.size = ::std::mem::size_of_val(node);
+        entry.size = std::mem::size_of_val(node);
     }
 
     fn print(&self, title: &str) {

--- a/src/librustc_passes/lib.rs
+++ b/src/librustc_passes/lib.rs
@@ -13,18 +13,10 @@
 
 #![recursion_limit="256"]
 
-#[macro_use]
-extern crate rustc;
-extern crate rustc_mir;
-extern crate rustc_data_structures;
+#![deny(rust_2018_idioms)]
 
 #[macro_use]
-extern crate log;
-#[macro_use]
-extern crate syntax;
-extern crate syntax_ext;
-extern crate syntax_pos;
-extern crate rustc_errors as errors;
+extern crate rustc;
 
 use rustc::ty::query::Providers;
 
@@ -38,7 +30,7 @@ pub mod loops;
 
 __build_diagnostic_array! { librustc_passes, DIAGNOSTICS }
 
-pub fn provide(providers: &mut Providers) {
+pub fn provide(providers: &mut Providers<'_>) {
     rvalue_promotion::provide(providers);
     loops::provide(providers);
 }

--- a/src/librustc_passes/loops.rs
+++ b/src/librustc_passes/loops.rs
@@ -1,4 +1,4 @@
-use self::Context::*;
+use Context::*;
 
 use rustc::session::Session;
 
@@ -9,6 +9,7 @@ use rustc::hir::map::Map;
 use rustc::hir::intravisit::{self, Visitor, NestedVisitorMap};
 use rustc::hir::{self, Node, Destination};
 use syntax::ast;
+use syntax::struct_span_err;
 use syntax_pos::Span;
 use errors::Applicability;
 
@@ -59,7 +60,7 @@ fn check_mod_loops<'tcx>(tcx: TyCtxt<'_, 'tcx, 'tcx>, module_def_id: DefId) {
     }.as_deep_visitor());
 }
 
-pub(crate) fn provide(providers: &mut Providers) {
+pub(crate) fn provide(providers: &mut Providers<'_>) {
     *providers = Providers {
         check_mod_loops,
         ..*providers

--- a/src/librustc_passes/rvalue_promotion.rs
+++ b/src/librustc_passes/rvalue_promotion.rs
@@ -28,10 +28,11 @@ use rustc::hir;
 use rustc_data_structures::sync::Lrc;
 use syntax::ast;
 use syntax_pos::{Span, DUMMY_SP};
-use self::Promotability::*;
+use log::debug;
+use Promotability::*;
 use std::ops::{BitAnd, BitAndAssign, BitOr};
 
-pub fn provide(providers: &mut Providers) {
+pub fn provide(providers: &mut Providers<'_>) {
     *providers = Providers {
         rvalue_promotable_map,
         const_is_rvalue_promotable_to_static,
@@ -622,7 +623,7 @@ impl<'a, 'gcx, 'tcx> euv::Delegate<'tcx> for CheckCrateVisitor<'a, 'gcx> {
     fn consume(&mut self,
                _consume_id: ast::NodeId,
                _consume_span: Span,
-               _cmt: &mc::cmt_,
+               _cmt: &mc::cmt_<'_>,
                _mode: euv::ConsumeMode) {}
 
     fn borrow(&mut self,
@@ -681,11 +682,14 @@ impl<'a, 'gcx, 'tcx> euv::Delegate<'tcx> for CheckCrateVisitor<'a, 'gcx> {
     fn mutate(&mut self,
               _assignment_id: ast::NodeId,
               _assignment_span: Span,
-              _assignee_cmt: &mc::cmt_,
+              _assignee_cmt: &mc::cmt_<'_>,
               _mode: euv::MutateMode) {
     }
 
-    fn matched_pat(&mut self, _: &hir::Pat, _: &mc::cmt_, _: euv::MatchMode) {}
+    fn matched_pat(&mut self, _: &hir::Pat, _: &mc::cmt_<'_>, _: euv::MatchMode) {}
 
-    fn consume_pat(&mut self, _consume_pat: &hir::Pat, _cmt: &mc::cmt_, _mode: euv::ConsumeMode) {}
+    fn consume_pat(&mut self,
+                   _consume_pat: &hir::Pat,
+                   _cmt: &mc::cmt_<'_>,
+                   _mode: euv::ConsumeMode) {}
 }


### PR DESCRIPTION
Transitions `librustc_passes` to Rust 2018; cc #58099

r? @Centril