### PR TITLE
Transition librustc_traits to 2018 edition

### DIFF
--- a/src/librustc_traits/Cargo.toml
+++ b/src/librustc_traits/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_traits"
 version = "0.0.0"
+edition = "2018"
 
 [lib]
 name = "rustc_traits"

--- a/src/librustc_traits/chalk_context/mod.rs
+++ b/src/librustc_traits/chalk_context/mod.rs
@@ -502,13 +502,13 @@ type ChalkHhGoal<'tcx> = HhGoal<ChalkArenas<'tcx>>;
 type ChalkExClause<'tcx> = ExClause<ChalkArenas<'tcx>>;
 
 impl Debug for ChalkContext<'cx, 'gcx> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "ChalkContext")
     }
 }
 
 impl Debug for ChalkInferenceContext<'cx, 'gcx, 'tcx> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "ChalkInferenceContext")
     }
 }
@@ -658,7 +658,7 @@ impl<'tcx, 'gcx: 'tcx, T> Upcast<'tcx, 'gcx> for Canonical<'gcx, T>
     }
 }
 
-crate fn provide(p: &mut Providers) {
+crate fn provide(p: &mut Providers<'_>) {
     *p = Providers {
         evaluate_goal,
         ..*p

--- a/src/librustc_traits/chalk_context/program_clauses.rs
+++ b/src/librustc_traits/chalk_context/program_clauses.rs
@@ -220,7 +220,7 @@ fn wf_clause_for_slice<'tcx>(tcx: ty::TyCtxt<'_, '_, 'tcx>) -> Clauses<'tcx> {
         def_id: sized_trait,
         substs: tcx.mk_substs_trait(ty, ty::List::empty()),
     };
-    let sized_implemented: DomainGoal = ty::TraitPredicate {
+    let sized_implemented: DomainGoal<'_> = ty::TraitPredicate {
         trait_ref: sized_implemented
     }.lower();
 
@@ -252,7 +252,7 @@ fn wf_clause_for_array<'tcx>(
         def_id: sized_trait,
         substs: tcx.mk_substs_trait(ty, ty::List::empty()),
     };
-    let sized_implemented: DomainGoal = ty::TraitPredicate {
+    let sized_implemented: DomainGoal<'_> = ty::TraitPredicate {
         trait_ref: sized_implemented
     }.lower();
 
@@ -326,7 +326,7 @@ fn wf_clause_for_ref<'tcx>(
         mutbl,
     });
 
-    let _outlives: DomainGoal = ty::OutlivesPredicate(ty, region).lower();
+    let _outlives: DomainGoal<'_> = ty::OutlivesPredicate(ty, region).lower();
     let wf_clause = ProgramClause {
         goal: DomainGoal::WellFormed(WellFormed::Ty(ref_ty)),
         hypotheses: ty::List::empty(),

--- a/src/librustc_traits/dropck_outlives.rs
+++ b/src/librustc_traits/dropck_outlives.rs
@@ -10,7 +10,7 @@ use rustc::util::nodemap::FxHashSet;
 use rustc_data_structures::sync::Lrc;
 use syntax::source_map::{Span, DUMMY_SP};
 
-crate fn provide(p: &mut Providers) {
+crate fn provide(p: &mut Providers<'_>) {
     *p = Providers {
         dropck_outlives,
         adt_dtorck_constraint,
@@ -305,7 +305,7 @@ crate fn adt_dtorck_constraint<'a, 'tcx>(
     let mut result = def.all_fields()
         .map(|field| tcx.type_of(field.did))
         .map(|fty| dtorck_constraint_for_ty(tcx, span, fty, 0, fty))
-        .collect::<Result<DtorckConstraint, NoSolution>>()?;
+        .collect::<Result<DtorckConstraint<'_>, NoSolution>>()?;
     result.outlives.extend(tcx.destructor_constraints(def));
     dedup_dtorck_constraint(&mut result);
 

--- a/src/librustc_traits/evaluate_obligation.rs
+++ b/src/librustc_traits/evaluate_obligation.rs
@@ -6,7 +6,7 @@ use rustc::ty::query::Providers;
 use rustc::ty::{ParamEnvAnd, TyCtxt};
 use syntax::source_map::DUMMY_SP;
 
-crate fn provide(p: &mut Providers) {
+crate fn provide(p: &mut Providers<'_>) {
     *p = Providers {
         evaluate_obligation,
         ..*p

--- a/src/librustc_traits/implied_outlives_bounds.rs
+++ b/src/librustc_traits/implied_outlives_bounds.rs
@@ -17,7 +17,7 @@ use rustc::traits::FulfillmentContext;
 
 use rustc_data_structures::sync::Lrc;
 
-crate fn provide(p: &mut Providers) {
+crate fn provide(p: &mut Providers<'_>) {
     *p = Providers {
         implied_outlives_bounds,
         ..*p

--- a/src/librustc_traits/lib.rs
+++ b/src/librustc_traits/lib.rs
@@ -1,22 +1,18 @@
 //! New recursive solver modeled on Chalk's recursive solver. Most of
 //! the guts are broken up into modules; see the comments in those modules.
 
+#![deny(rust_2018_idioms)]
+
 #![feature(crate_visibility_modifier)]
 #![feature(in_band_lifetimes)]
 #![feature(nll)]
 
 #![recursion_limit="256"]
 
-extern crate chalk_engine;
 #[macro_use]
 extern crate log;
 #[macro_use]
 extern crate rustc;
-extern crate rustc_data_structures;
-extern crate rustc_target;
-extern crate syntax;
-extern crate syntax_pos;
-extern crate smallvec;
 
 mod chalk_context;
 mod dropck_outlives;
@@ -30,7 +26,7 @@ mod type_op;
 
 use rustc::ty::query::Providers;
 
-pub fn provide(p: &mut Providers) {
+pub fn provide(p: &mut Providers<'_>) {
     dropck_outlives::provide(p);
     evaluate_obligation::provide(p);
     implied_outlives_bounds::provide(p);

--- a/src/librustc_traits/lowering/mod.rs
+++ b/src/librustc_traits/lowering/mod.rs
@@ -23,7 +23,7 @@ use syntax::ast;
 
 use std::iter;
 
-crate fn provide(p: &mut Providers) {
+crate fn provide(p: &mut Providers<'_>) {
     *p = Providers {
         program_clauses_for,
         program_clauses_for_env: environment::program_clauses_for_env,
@@ -193,7 +193,7 @@ fn program_clauses_for_trait<'a, 'tcx>(
     };
 
     // `Implemented(Self: Trait<P1..Pn>)`
-    let impl_trait: DomainGoal = trait_pred.lower();
+    let impl_trait: DomainGoal<'_> = trait_pred.lower();
 
     // `FromEnv(Self: Trait<P1..Pn>)`
     let from_env_goal = tcx.mk_goal(impl_trait.into_from_env_goal().into_goal());
@@ -575,7 +575,7 @@ pub fn program_clauses_for_associated_type_value<'a, 'tcx>(
     let ty = tcx.type_of(item_id);
 
     // `Implemented(A0: Trait<A1..An>)`
-    let trait_implemented: DomainGoal = ty::TraitPredicate { trait_ref }.lower();
+    let trait_implemented: DomainGoal<'_> = ty::TraitPredicate { trait_ref }.lower();
 
     // `<A0 as Trait<A1..An>>::AssocType<Pn+1..Pm>`
     let projection_ty = ty::ProjectionTy::from_ref_and_name(tcx, trait_ref, item.ident);

--- a/src/librustc_traits/normalize_erasing_regions.rs
+++ b/src/librustc_traits/normalize_erasing_regions.rs
@@ -4,7 +4,7 @@ use rustc::ty::query::Providers;
 use rustc::ty::{self, ParamEnvAnd, Ty, TyCtxt};
 use std::sync::atomic::Ordering;
 
-crate fn provide(p: &mut Providers) {
+crate fn provide(p: &mut Providers<'_>) {
     *p = Providers {
         normalize_ty_after_erasing_regions,
         ..*p

--- a/src/librustc_traits/normalize_projection_ty.rs
+++ b/src/librustc_traits/normalize_projection_ty.rs
@@ -8,7 +8,7 @@ use std::sync::atomic::Ordering;
 use syntax::ast::DUMMY_NODE_ID;
 use syntax_pos::DUMMY_SP;
 
-crate fn provide(p: &mut Providers) {
+crate fn provide(p: &mut Providers<'_>) {
     *p = Providers {
         normalize_projection_ty,
         ..*p

--- a/src/librustc_traits/type_op.rs
+++ b/src/librustc_traits/type_op.rs
@@ -21,7 +21,7 @@ use std::fmt;
 use syntax::ast;
 use syntax_pos::DUMMY_SP;
 
-crate fn provide(p: &mut Providers) {
+crate fn provide(p: &mut Providers<'_>) {
     *p = Providers {
         type_op_ascribe_user_type,
         type_op_eq,


### PR DESCRIPTION
Transitions librustc_traits to Rust 2018; cc #58099
r? @Centril