### PR TITLE
Transition libserialize to 2018 edition

### DIFF
--- a/src/libserialize/Cargo.toml
+++ b/src/libserialize/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "serialize"
 version = "0.0.0"
+edition = "2018"
 
 [lib]
 name = "serialize"

--- a/src/libserialize/collection_impls.rs
+++ b/src/libserialize/collection_impls.rs
@@ -2,7 +2,7 @@
 
 use std::hash::{Hash, BuildHasher};
 
-use {Decodable, Encodable, Decoder, Encoder};
+use crate::{Decodable, Encodable, Decoder, Encoder};
 use std::collections::{LinkedList, VecDeque, BTreeMap, BTreeSet, HashMap, HashSet};
 use std::rc::Rc;
 use std::sync::Arc;

--- a/src/libserialize/hex.rs
+++ b/src/libserialize/hex.rs
@@ -60,7 +60,7 @@ pub enum FromHexError {
 }
 
 impl fmt::Display for FromHexError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             InvalidHexCharacter(ch, idx) =>
                 write!(f, "Invalid character '{}' at position {}", ch, idx),
@@ -146,7 +146,7 @@ impl FromHex for str {
 mod tests {
     extern crate test;
     use self::test::Bencher;
-    use hex::{FromHex, ToHex};
+    use crate::hex::{FromHex, ToHex};
 
     #[test]
     pub fn test_to_hex() {

--- a/src/libserialize/lib.rs
+++ b/src/libserialize/lib.rs
@@ -10,6 +10,8 @@ Core encoding and decoding interfaces.
        html_playground_url = "https://play.rust-lang.org/",
        test(attr(allow(unused_variables), deny(warnings))))]
 
+#![deny(rust_2018_idioms)]
+
 #![feature(box_syntax)]
 #![feature(core_intrinsics)]
 #![feature(specialization)]
@@ -22,8 +24,6 @@ pub use self::serialize::{Decoder, Encoder, Decodable, Encodable};
 pub use self::serialize::{SpecializationError, SpecializedEncoder, SpecializedDecoder};
 pub use self::serialize::{UseSpecializedEncodable, UseSpecializedDecodable};
 
-extern crate smallvec;
-
 mod serialize;
 mod collection_impls;
 
@@ -34,5 +34,5 @@ pub mod opaque;
 pub mod leb128;
 
 mod rustc_serialize {
-    pub use serialize::*;
+    pub use crate::serialize::*;
 }

--- a/src/libserialize/opaque.rs
+++ b/src/libserialize/opaque.rs
@@ -1,6 +1,6 @@
-use leb128::{self, read_signed_leb128, write_signed_leb128};
+use crate::leb128::{self, read_signed_leb128, write_signed_leb128};
 use std::borrow::Cow;
-use serialize;
+use crate::serialize;
 
 // -----------------------------------------------------------------------------
 // Encoder
@@ -312,7 +312,7 @@ impl<'a> serialize::Decoder for Decoder<'a> {
     }
 
     #[inline]
-    fn read_str(&mut self) -> Result<Cow<str>, Self::Error> {
+    fn read_str(&mut self) -> Result<Cow<'_, str>, Self::Error> {
         let len = self.read_usize()?;
         let s = ::std::str::from_utf8(&self.data[self.position..self.position + len]).unwrap();
         self.position += len;
@@ -328,7 +328,7 @@ impl<'a> serialize::Decoder for Decoder<'a> {
 
 #[cfg(test)]
 mod tests {
-    use serialize::{Encodable, Decodable};
+    use crate::serialize::{Encodable, Decodable};
     use std::fmt::Debug;
     use super::{Encoder, Decoder};
 

--- a/src/libserialize/serialize.rs
+++ b/src/libserialize/serialize.rs
@@ -175,7 +175,7 @@ pub trait Decoder {
     fn read_f64(&mut self) -> Result<f64, Self::Error>;
     fn read_f32(&mut self) -> Result<f32, Self::Error>;
     fn read_char(&mut self) -> Result<char, Self::Error>;
-    fn read_str(&mut self) -> Result<Cow<str>, Self::Error>;
+    fn read_str(&mut self) -> Result<Cow<'_, str>, Self::Error>;
 
     // Compound types:
     fn read_enum<T, F>(&mut self, _name: &str, f: F) -> Result<T, Self::Error>


### PR DESCRIPTION
Transitions libserialize to Rust 2018; cc #58099
r? @Centril