### PR TITLE
librustc_metadata => 2018

### DIFF
--- a/src/librustc_metadata/Cargo.toml
+++ b/src/librustc_metadata/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_metadata"
 version = "0.0.0"
+edition = "2018"
 
 [lib]
 name = "rustc_metadata"
@@ -14,7 +15,7 @@ log = "0.4"
 memmap = "0.6"
 rustc = { path = "../librustc" }
 rustc_data_structures = { path = "../librustc_data_structures" }
-rustc_errors = { path = "../librustc_errors" }
+errors = { path = "../librustc_errors", package = "rustc_errors" }
 rustc_target = { path = "../librustc_target" }
 serialize = { path = "../libserialize" }
 stable_deref_trait = "1.0.0"

--- a/src/librustc_metadata/cstore.rs
+++ b/src/librustc_metadata/cstore.rs
@@ -1,7 +1,7 @@
 // The crate store - a central repo for information collected about external
 // crates and libraries
 
-use schema;
+use crate::schema;
 use rustc::hir::def_id::{CrateNum, DefIndex};
 use rustc::hir::map::definitions::DefPathTable;
 use rustc::middle::cstore::{DepKind, ExternCrate, MetadataLoader};
@@ -19,7 +19,7 @@ pub use rustc::middle::cstore::{NativeLibrary, NativeLibraryKind, LinkagePrefere
 pub use rustc::middle::cstore::NativeLibraryKind::*;
 pub use rustc::middle::cstore::{CrateSource, LibSource, ForeignModule};
 
-pub use cstore_impl::{provide, provide_extern};
+pub use crate::cstore_impl::{provide, provide_extern};
 
 // A map from external crate numbers (as decoded from some crate file) to
 // local crate numbers (as generated during this session). Each external

--- a/src/librustc_metadata/cstore_impl.rs
+++ b/src/librustc_metadata/cstore_impl.rs
@@ -1,9 +1,9 @@
-use cstore::{self, LoadedMacro};
-use encoder;
-use link_args;
-use native_libs;
-use foreign_modules;
-use schema;
+use crate::cstore::{self, LoadedMacro};
+use crate::encoder;
+use crate::link_args;
+use crate::native_libs;
+use crate::foreign_modules;
+use crate::schema;
 
 use rustc::ty::query::QueryConfig;
 use rustc::middle::cstore::{CrateStore, DepKind,
@@ -51,7 +51,7 @@ macro_rules! provide {
                     index: CRATE_DEF_INDEX
                 });
                 let dep_node = def_path_hash
-                    .to_dep_node(::rustc::dep_graph::DepKind::CrateMetadata);
+                    .to_dep_node(rustc::dep_graph::DepKind::CrateMetadata);
                 // The DepNodeIndex of the DepNode::CrateMetadata should be
                 // cached somewhere, so that we can use read_index().
                 $tcx.dep_graph.read(dep_node);
@@ -421,7 +421,7 @@ impl cstore::CStore {
             use syntax::ext::base::SyntaxExtension;
             use syntax_ext::proc_macro_impl::BangProcMacro;
 
-            let client = ::proc_macro::bridge::client::Client::expand1(::proc_macro::quote);
+            let client = proc_macro::bridge::client::Client::expand1(proc_macro::quote);
             let ext = SyntaxExtension::ProcMacro {
                 expander: Box::new(BangProcMacro { client }),
                 allow_internal_unstable: true,

--- a/src/librustc_metadata/decoder.rs
+++ b/src/librustc_metadata/decoder.rs
@@ -1,7 +1,7 @@
 // Decoding metadata from a single crate's metadata
 
-use cstore::{self, CrateMetadata, MetadataBlob, NativeLibrary, ForeignModule};
-use schema::*;
+use crate::cstore::{self, CrateMetadata, MetadataBlob, NativeLibrary, ForeignModule};
+use crate::schema::*;
 
 use rustc_data_structures::sync::{Lrc, ReadGuard};
 use rustc::hir::map::{DefKey, DefPath, DefPathData, DefPathHash, Definitions};
@@ -34,6 +34,7 @@ use syntax::symbol::InternedString;
 use syntax::ext::base::{MacroKind, SyntaxExtension};
 use syntax::ext::hygiene::Mark;
 use syntax_pos::{self, Span, BytePos, Pos, DUMMY_SP, NO_EXPANSION};
+use log::debug;
 
 pub struct DecodeContext<'a, 'tcx: 'a> {
     opaque: opaque::Decoder<'a>,
@@ -545,7 +546,7 @@ impl<'a, 'tcx> CrateMetadata {
 
     fn get_variant(&self,
                    tcx: TyCtxt<'a, 'tcx, 'tcx>,
-                   item: &Entry,
+                   item: &Entry<'_>,
                    index: DefIndex,
                    adt_kind: ty::AdtKind)
                    -> ty::VariantDef

--- a/src/librustc_metadata/diagnostics.rs
+++ b/src/librustc_metadata/diagnostics.rs
@@ -1,5 +1,7 @@
 #![allow(non_snake_case)]
 
+use syntax::{register_diagnostic, register_diagnostics, register_long_diagnostics};
+
 register_long_diagnostics! {
 E0454: r##"
 A link name was given with an empty name. Erroneous code example:

--- a/src/librustc_metadata/dynamic_lib.rs
+++ b/src/librustc_metadata/dynamic_lib.rs
@@ -76,7 +76,6 @@ impl DynamicLibrary {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use libc;
     use std::mem;
 
     #[test]
@@ -127,7 +126,6 @@ mod tests {
 
 #[cfg(unix)]
 mod dl {
-    use libc;
     use std::ffi::{CStr, OsStr, CString};
     use std::os::unix::prelude::*;
     use std::ptr;

--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -1,7 +1,7 @@
-use index::Index;
-use index_builder::{FromId, IndexBuilder, Untracked};
-use isolated_encoder::IsolatedEncoder;
-use schema::*;
+use crate::index::Index;
+use crate::index_builder::{FromId, IndexBuilder, Untracked};
+use crate::isolated_encoder::IsolatedEncoder;
+use crate::schema::*;
 
 use rustc::middle::cstore::{LinkagePreference, NativeLibrary,
                             EncodedMetadata, ForeignModule};
@@ -34,6 +34,7 @@ use syntax::attr;
 use syntax::source_map::Spanned;
 use syntax::symbol::keywords;
 use syntax_pos::{self, hygiene, FileName, SourceFile, Span};
+use log::{debug, trace};
 
 use rustc::hir::{self, PatKind};
 use rustc::hir::itemlikevisit::ItemLikeVisitor;
@@ -1521,7 +1522,7 @@ impl<'a, 'b: 'a, 'tcx: 'b> IsolatedEncoder<'a, 'b, 'tcx> {
     // symbol associated with them (they weren't translated) or if they're an FFI
     // definition (as that's not defined in this crate).
     fn encode_exported_symbols(&mut self,
-                               exported_symbols: &[(ExportedSymbol, SymbolExportLevel)])
+                               exported_symbols: &[(ExportedSymbol<'_>, SymbolExportLevel)])
                                -> EncodedExportedSymbols {
         // The metadata symbol name is special. It should not show up in
         // downstream crates.

--- a/src/librustc_metadata/index.rs
+++ b/src/librustc_metadata/index.rs
@@ -1,9 +1,10 @@
-use schema::*;
+use crate::schema::*;
 
 use rustc::hir::def_id::{DefId, DefIndex, DefIndexAddressSpace};
 use rustc_serialize::opaque::Encoder;
 use std::slice;
 use std::u32;
+use log::debug;
 
 /// While we are generating the metadata, we also track the position
 /// of each DefIndex. It is not required that all definitions appear
@@ -24,12 +25,12 @@ impl Index {
         }
     }
 
-    pub fn record(&mut self, def_id: DefId, entry: Lazy<Entry>) {
+    pub fn record(&mut self, def_id: DefId, entry: Lazy<Entry<'_>>) {
         assert!(def_id.is_local());
         self.record_index(def_id.index, entry);
     }
 
-    pub fn record_index(&mut self, item: DefIndex, entry: Lazy<Entry>) {
+    pub fn record_index(&mut self, item: DefIndex, entry: Lazy<Entry<'_>>) {
         assert!(entry.position < (u32::MAX as usize));
         let position = entry.position as u32;
         let space_index = item.address_space().index();

--- a/src/librustc_metadata/isolated_encoder.rs
+++ b/src/librustc_metadata/isolated_encoder.rs
@@ -1,5 +1,5 @@
-use encoder::EncodeContext;
-use schema::{Lazy, LazySeq};
+use crate::encoder::EncodeContext;
+use crate::schema::{Lazy, LazySeq};
 use rustc::ty::TyCtxt;
 use rustc_serialize::Encodable;
 

--- a/src/librustc_metadata/lib.rs
+++ b/src/librustc_metadata/lib.rs
@@ -15,23 +15,15 @@
 
 #![recursion_limit="256"]
 
+#![deny(rust_2018_idioms)]
+
 extern crate libc;
-#[macro_use]
-extern crate log;
-extern crate memmap;
-extern crate stable_deref_trait;
-#[macro_use]
-extern crate syntax;
-extern crate syntax_pos;
-extern crate flate2;
+#[allow(unused_extern_crates)]
 extern crate serialize as rustc_serialize; // used by deriving
-extern crate rustc_errors as errors;
-extern crate syntax_ext;
 extern crate proc_macro;
 
 #[macro_use]
 extern crate rustc;
-extern crate rustc_target;
 #[macro_use]
 extern crate rustc_data_structures;
 

--- a/src/librustc_metadata/locator.rs
+++ b/src/librustc_metadata/locator.rs
@@ -212,9 +212,9 @@
 //! no means all of the necessary details. Take a look at the rest of
 //! metadata::locator or metadata::creader for all the juicy details!
 
-use cstore::{MetadataRef, MetadataBlob};
-use creader::Library;
-use schema::{METADATA_HEADER, rustc_version};
+use crate::cstore::{MetadataRef, MetadataBlob};
+use crate::creader::Library;
+use crate::schema::{METADATA_HEADER, rustc_version};
 
 use rustc_data_structures::fx::FxHashSet;
 use rustc_data_structures::svh::Svh;
@@ -226,6 +226,7 @@ use rustc::util::nodemap::FxHashMap;
 
 use errors::DiagnosticBuilder;
 use syntax::symbol::Symbol;
+use syntax::struct_span_err;
 use syntax_pos::Span;
 use rustc_target::spec::{Target, TargetTriple};
 
@@ -240,6 +241,8 @@ use std::time::Instant;
 use flate2::read::DeflateDecoder;
 
 use rustc_data_structures::owning_ref::OwningRef;
+
+use log::{debug, info, warn};
 
 pub struct CrateMismatch {
     path: PathBuf,
@@ -283,7 +286,7 @@ enum CrateFlavor {
 }
 
 impl fmt::Display for CrateFlavor {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match *self {
             CrateFlavor::Rlib => "rlib",
             CrateFlavor::Rmeta => "rmeta",
@@ -600,7 +603,7 @@ impl<'a> Context<'a> {
             }
         }
 
-        let mut err: Option<DiagnosticBuilder> = None;
+        let mut err: Option<DiagnosticBuilder<'_>> = None;
         for (lib, kind) in m {
             info!("{} reading metadata from: {}", flavor, lib.display());
             let (hash, metadata) =

--- a/src/librustc_metadata/native_libs.rs
+++ b/src/librustc_metadata/native_libs.rs
@@ -9,6 +9,7 @@ use syntax::attr;
 use syntax::source_map::Span;
 use syntax::feature_gate::{self, GateIssue};
 use syntax::symbol::Symbol;
+use syntax::{span_err, struct_span_err};
 
 pub fn collect<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) -> Vec<NativeLibrary> {
     let mut collector = Collector {

--- a/src/librustc_metadata/schema.rs
+++ b/src/librustc_metadata/schema.rs
@@ -1,4 +1,4 @@
-use index;
+use crate::index;
 
 use rustc::hir;
 use rustc::hir::def::{self, CtorKind};
@@ -518,7 +518,7 @@ pub enum AssociatedContainer {
     ImplFinal,
 }
 
-impl_stable_hash_for!(enum ::schema::AssociatedContainer {
+impl_stable_hash_for!(enum crate::schema::AssociatedContainer {
     TraitRequired,
     TraitWithDefault,
     ImplDefault,


### PR DESCRIPTION
Transitions `librustc_metadata` to Rust 2018; cc #58099

r? @Centril