### PR TITLE
librustc_cratesio_shim => 2018

### DIFF
--- a/src/librustc_cratesio_shim/Cargo.toml
+++ b/src/librustc_cratesio_shim/Cargo.toml
@@ -15,6 +15,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_cratesio_shim"
 version = "0.0.0"
+edition = "2018"
 
 [lib]
 crate-type = ["dylib"]

--- a/src/librustc_cratesio_shim/src/lib.rs
+++ b/src/librustc_cratesio_shim/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 // See Cargo.toml for a comment explaining this crate.
 #![allow(unused_extern_crates)]
 


### PR DESCRIPTION
Transitions `librustc_cratesio_shim` to Rust 2018; cc #58099

r? @Centril