### PR TITLE
librustc_target => 2018

### DIFF
--- a/src/librustc_target/Cargo.toml
+++ b/src/librustc_target/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_target"
 version = "0.0.0"
+edition = "2018"
 
 [lib]
 name = "rustc_target"

--- a/src/librustc_target/abi/call/aarch64.rs
+++ b/src/librustc_target/abi/call/aarch64.rs
@@ -1,5 +1,5 @@
-use abi::call::{FnType, ArgType, Reg, RegKind, Uniform};
-use abi::{HasDataLayout, LayoutOf, TyLayout, TyLayoutMethods};
+use crate::abi::call::{FnType, ArgType, Reg, RegKind, Uniform};
+use crate::abi::{HasDataLayout, LayoutOf, TyLayout, TyLayoutMethods};
 
 fn is_homogeneous_aggregate<'a, Ty, C>(cx: &C, arg: &mut ArgType<'a, Ty>)
                                      -> Option<Uniform>

--- a/src/librustc_target/abi/call/amdgpu.rs
+++ b/src/librustc_target/abi/call/amdgpu.rs
@@ -1,5 +1,5 @@
-use abi::call::{ArgType, FnType, };
-use abi::{HasDataLayout, LayoutOf, TyLayout, TyLayoutMethods};
+use crate::abi::call::{ArgType, FnType, };
+use crate::abi::{HasDataLayout, LayoutOf, TyLayout, TyLayoutMethods};
 
 fn classify_ret_ty<'a, Ty, C>(_cx: &C, ret: &mut ArgType<'a, Ty>)
   where Ty: TyLayoutMethods<'a, C> + Copy,

--- a/src/librustc_target/abi/call/arm.rs
+++ b/src/librustc_target/abi/call/arm.rs
@@ -1,6 +1,6 @@
-use abi::call::{Conv, FnType, ArgType, Reg, RegKind, Uniform};
-use abi::{HasDataLayout, LayoutOf, TyLayout, TyLayoutMethods};
-use spec::HasTargetSpec;
+use crate::abi::call::{Conv, FnType, ArgType, Reg, RegKind, Uniform};
+use crate::abi::{HasDataLayout, LayoutOf, TyLayout, TyLayoutMethods};
+use crate::spec::HasTargetSpec;
 
 fn is_homogeneous_aggregate<'a, Ty, C>(cx: &C, arg: &mut ArgType<'a, Ty>)
                                      -> Option<Uniform>

--- a/src/librustc_target/abi/call/asmjs.rs
+++ b/src/librustc_target/abi/call/asmjs.rs
@@ -1,5 +1,5 @@
-use abi::call::{FnType, ArgType, Uniform};
-use abi::{HasDataLayout, LayoutOf, TyLayout, TyLayoutMethods};
+use crate::abi::call::{FnType, ArgType, Uniform};
+use crate::abi::{HasDataLayout, LayoutOf, TyLayout, TyLayoutMethods};
 
 // Data layout: e-p:32:32-i64:64-v128:32:128-n32-S128
 
@@ -26,7 +26,7 @@ fn classify_ret_ty<'a, Ty, C>(cx: &C, ret: &mut ArgType<'a, Ty>)
     }
 }
 
-fn classify_arg_ty<Ty>(arg: &mut ArgType<Ty>) {
+fn classify_arg_ty<Ty>(arg: &mut ArgType<'_, Ty>) {
     if arg.layout.is_aggregate() {
         arg.make_indirect_byval();
     }

--- a/src/librustc_target/abi/call/hexagon.rs
+++ b/src/librustc_target/abi/call/hexagon.rs
@@ -1,8 +1,8 @@
 #![allow(non_upper_case_globals)]
 
-use abi::call::{FnType, ArgType};
+use crate::abi::call::{FnType, ArgType};
 
-fn classify_ret_ty<Ty>(ret: &mut ArgType<Ty>) {
+fn classify_ret_ty<Ty>(ret: &mut ArgType<'_, Ty>) {
     if ret.layout.is_aggregate() && ret.layout.size.bits() > 64 {
         ret.make_indirect();
     } else {
@@ -10,7 +10,7 @@ fn classify_ret_ty<Ty>(ret: &mut ArgType<Ty>) {
     }
 }
 
-fn classify_arg_ty<Ty>(arg: &mut ArgType<Ty>) {
+fn classify_arg_ty<Ty>(arg: &mut ArgType<'_, Ty>) {
     if arg.layout.is_aggregate() && arg.layout.size.bits() > 64 {
         arg.make_indirect();
     } else {
@@ -18,7 +18,7 @@ fn classify_arg_ty<Ty>(arg: &mut ArgType<Ty>) {
     }
 }
 
-pub fn compute_abi_info<Ty>(fty: &mut FnType<Ty>) {
+pub fn compute_abi_info<Ty>(fty: &mut FnType<'_,Ty>) {
     if !fty.ret.is_ignore() {
         classify_ret_ty(&mut fty.ret);
     }

--- a/src/librustc_target/abi/call/mips.rs
+++ b/src/librustc_target/abi/call/mips.rs
@@ -1,7 +1,7 @@
-use abi::call::{ArgType, FnType, Reg, Uniform};
-use abi::{HasDataLayout, LayoutOf, Size, TyLayoutMethods};
+use crate::abi::call::{ArgType, FnType, Reg, Uniform};
+use crate::abi::{HasDataLayout, LayoutOf, Size, TyLayoutMethods};
 
-fn classify_ret_ty<'a, Ty, C>(cx: &C, ret: &mut ArgType<Ty>, offset: &mut Size)
+fn classify_ret_ty<'a, Ty, C>(cx: &C, ret: &mut ArgType<'_, Ty>, offset: &mut Size)
     where Ty: TyLayoutMethods<'a, C>, C: LayoutOf<Ty = Ty> + HasDataLayout
 {
     if !ret.layout.is_aggregate() {
@@ -12,7 +12,7 @@ fn classify_ret_ty<'a, Ty, C>(cx: &C, ret: &mut ArgType<Ty>, offset: &mut Size)
     }
 }
 
-fn classify_arg_ty<'a, Ty, C>(cx: &C, arg: &mut ArgType<Ty>, offset: &mut Size)
+fn classify_arg_ty<'a, Ty, C>(cx: &C, arg: &mut ArgType<'_, Ty>, offset: &mut Size)
     where Ty: TyLayoutMethods<'a, C>, C: LayoutOf<Ty = Ty> + HasDataLayout
 {
     let dl = cx.data_layout();
@@ -34,7 +34,7 @@ fn classify_arg_ty<'a, Ty, C>(cx: &C, arg: &mut ArgType<Ty>, offset: &mut Size)
     *offset = offset.align_to(align) + size.align_to(align);
 }
 
-pub fn compute_abi_info<'a, Ty, C>(cx: &C, fty: &mut FnType<Ty>)
+pub fn compute_abi_info<'a, Ty, C>(cx: &C, fty: &mut FnType<'_, Ty>)
     where Ty: TyLayoutMethods<'a, C>, C: LayoutOf<Ty = Ty> + HasDataLayout
 {
     let mut offset = Size::ZERO;

--- a/src/librustc_target/abi/call/mips64.rs
+++ b/src/librustc_target/abi/call/mips64.rs
@@ -1,7 +1,7 @@
-use abi::call::{ArgAttribute, ArgType, CastTarget, FnType, PassMode, Reg, RegKind, Uniform};
-use abi::{self, HasDataLayout, LayoutOf, Size, TyLayout, TyLayoutMethods};
+use crate::abi::call::{ArgAttribute, ArgType, CastTarget, FnType, PassMode, Reg, RegKind, Uniform};
+use crate::abi::{self, HasDataLayout, LayoutOf, Size, TyLayout, TyLayoutMethods};
 
-fn extend_integer_width_mips<Ty>(arg: &mut ArgType<Ty>, bits: u64) {
+fn extend_integer_width_mips<Ty>(arg: &mut ArgType<'_, Ty>, bits: u64) {
     // Always sign extend u32 values on 64-bit mips
     if let abi::Abi::Scalar(ref scalar) = arg.layout.abi {
         if let abi::Int(i, signed) = scalar.value {

--- a/src/librustc_target/abi/call/mod.rs
+++ b/src/librustc_target/abi/call/mod.rs
@@ -1,6 +1,6 @@
-use abi::{self, Abi, Align, FieldPlacement, Size};
-use abi::{HasDataLayout, LayoutOf, TyLayout, TyLayoutMethods};
-use spec::HasTargetSpec;
+use crate::abi::{self, Abi, Align, FieldPlacement, Size};
+use crate::abi::{HasDataLayout, LayoutOf, TyLayout, TyLayoutMethods};
+use crate::spec::{self, HasTargetSpec};
 
 mod aarch64;
 mod amdgpu;
@@ -42,13 +42,13 @@ pub enum PassMode {
 
 // Hack to disable non_upper_case_globals only for the bitflags! and not for the rest
 // of this module
-pub use self::attr_impl::ArgAttribute;
+pub use attr_impl::ArgAttribute;
 
 #[allow(non_upper_case_globals)]
 #[allow(unused)]
 mod attr_impl {
     // The subset of llvm::Attribute needed for arguments, packed into a bitfield.
-    bitflags! {
+    bitflags::bitflags! {
         #[derive(Default)]
         pub struct ArgAttribute: u16 {
             const ByVal     = 1 << 0;
@@ -526,22 +526,22 @@ pub struct FnType<'a, Ty> {
 }
 
 impl<'a, Ty> FnType<'a, Ty> {
-    pub fn adjust_for_cabi<C>(&mut self, cx: &C, abi: ::spec::abi::Abi) -> Result<(), String>
+    pub fn adjust_for_cabi<C>(&mut self, cx: &C, abi: spec::abi::Abi) -> Result<(), String>
         where Ty: TyLayoutMethods<'a, C> + Copy,
               C: LayoutOf<Ty = Ty, TyLayout = TyLayout<'a, Ty>> + HasDataLayout + HasTargetSpec
     {
         match &cx.target_spec().arch[..] {
             "x86" => {
-                let flavor = if abi == ::spec::abi::Abi::Fastcall {
+                let flavor = if abi == spec::abi::Abi::Fastcall {
                     x86::Flavor::Fastcall
                 } else {
                     x86::Flavor::General
                 };
                 x86::compute_abi_info(cx, self, flavor);
             },
-            "x86_64" => if abi == ::spec::abi::Abi::SysV64 {
+            "x86_64" => if abi == spec::abi::Abi::SysV64 {
                 x86_64::compute_abi_info(cx, self);
-            } else if abi == ::spec::abi::Abi::Win64 || cx.target_spec().options.is_like_windows {
+            } else if abi == spec::abi::Abi::Win64 || cx.target_spec().options.is_like_windows {
                 x86_win64::compute_abi_info(self);
             } else {
                 x86_64::compute_abi_info(cx, self);

--- a/src/librustc_target/abi/call/msp430.rs
+++ b/src/librustc_target/abi/call/msp430.rs
@@ -1,7 +1,7 @@
 // Reference: MSP430 Embedded Application Binary Interface
 // http://www.ti.com/lit/an/slaa534/slaa534.pdf
 
-use abi::call::{ArgType, FnType};
+use crate::abi::call::{ArgType, FnType};
 
 // 3.5 Structures or Unions Passed and Returned by Reference
 //
@@ -9,7 +9,7 @@ use abi::call::{ArgType, FnType};
 // returned by reference. To pass a structure or union by reference, the caller
 // places its address in the appropriate location: either in a register or on
 // the stack, according to its position in the argument list. (..)"
-fn classify_ret_ty<Ty>(ret: &mut ArgType<Ty>) {
+fn classify_ret_ty<Ty>(ret: &mut ArgType<'_, Ty>) {
     if ret.layout.is_aggregate() && ret.layout.size.bits() > 32 {
         ret.make_indirect();
     } else {
@@ -17,7 +17,7 @@ fn classify_ret_ty<Ty>(ret: &mut ArgType<Ty>) {
     }
 }
 
-fn classify_arg_ty<Ty>(arg: &mut ArgType<Ty>) {
+fn classify_arg_ty<Ty>(arg: &mut ArgType<'_, Ty>) {
     if arg.layout.is_aggregate() && arg.layout.size.bits() > 32 {
         arg.make_indirect();
     } else {
@@ -25,7 +25,7 @@ fn classify_arg_ty<Ty>(arg: &mut ArgType<Ty>) {
     }
 }
 
-pub fn compute_abi_info<Ty>(fty: &mut FnType<Ty>) {
+pub fn compute_abi_info<Ty>(fty: &mut FnType<'_, Ty>) {
     if !fty.ret.is_ignore() {
         classify_ret_ty(&mut fty.ret);
     }

--- a/src/librustc_target/abi/call/nvptx.rs
+++ b/src/librustc_target/abi/call/nvptx.rs
@@ -1,9 +1,9 @@
 // Reference: PTX Writer's Guide to Interoperability
 // http://docs.nvidia.com/cuda/ptx-writers-guide-to-interoperability
 
-use abi::call::{ArgType, FnType};
+use crate::abi::call::{ArgType, FnType};
 
-fn classify_ret_ty<Ty>(ret: &mut ArgType<Ty>) {
+fn classify_ret_ty<Ty>(ret: &mut ArgType<'_, Ty>) {
     if ret.layout.is_aggregate() && ret.layout.size.bits() > 32 {
         ret.make_indirect();
     } else {
@@ -11,7 +11,7 @@ fn classify_ret_ty<Ty>(ret: &mut ArgType<Ty>) {
     }
 }
 
-fn classify_arg_ty<Ty>(arg: &mut ArgType<Ty>) {
+fn classify_arg_ty<Ty>(arg: &mut ArgType<'_, Ty>) {
     if arg.layout.is_aggregate() && arg.layout.size.bits() > 32 {
         arg.make_indirect();
     } else {
@@ -19,7 +19,7 @@ fn classify_arg_ty<Ty>(arg: &mut ArgType<Ty>) {
     }
 }
 
-pub fn compute_abi_info<Ty>(fty: &mut FnType<Ty>) {
+pub fn compute_abi_info<Ty>(fty: &mut FnType<'_, Ty>) {
     if !fty.ret.is_ignore() {
         classify_ret_ty(&mut fty.ret);
     }

--- a/src/librustc_target/abi/call/nvptx64.rs
+++ b/src/librustc_target/abi/call/nvptx64.rs
@@ -1,9 +1,9 @@
 // Reference: PTX Writer's Guide to Interoperability
 // http://docs.nvidia.com/cuda/ptx-writers-guide-to-interoperability
 
-use abi::call::{ArgType, FnType};
+use crate::abi::call::{ArgType, FnType};
 
-fn classify_ret_ty<Ty>(ret: &mut ArgType<Ty>) {
+fn classify_ret_ty<Ty>(ret: &mut ArgType<'_, Ty>) {
     if ret.layout.is_aggregate() && ret.layout.size.bits() > 64 {
         ret.make_indirect();
     } else {
@@ -11,7 +11,7 @@ fn classify_ret_ty<Ty>(ret: &mut ArgType<Ty>) {
     }
 }
 
-fn classify_arg_ty<Ty>(arg: &mut ArgType<Ty>) {
+fn classify_arg_ty<Ty>(arg: &mut ArgType<'_, Ty>) {
     if arg.layout.is_aggregate() && arg.layout.size.bits() > 64 {
         arg.make_indirect();
     } else {
@@ -19,7 +19,7 @@ fn classify_arg_ty<Ty>(arg: &mut ArgType<Ty>) {
     }
 }
 
-pub fn compute_abi_info<Ty>(fty: &mut FnType<Ty>) {
+pub fn compute_abi_info<Ty>(fty: &mut FnType<'_, Ty>) {
     if !fty.ret.is_ignore() {
         classify_ret_ty(&mut fty.ret);
     }

--- a/src/librustc_target/abi/call/powerpc.rs
+++ b/src/librustc_target/abi/call/powerpc.rs
@@ -1,7 +1,7 @@
-use abi::call::{ArgType, FnType, Reg, Uniform};
-use abi::{HasDataLayout, LayoutOf, Size, TyLayoutMethods};
+use crate::abi::call::{ArgType, FnType, Reg, Uniform};
+use crate::abi::{HasDataLayout, LayoutOf, Size, TyLayoutMethods};
 
-fn classify_ret_ty<'a, Ty, C>(cx: &C, ret: &mut ArgType<Ty>, offset: &mut Size)
+fn classify_ret_ty<'a, Ty, C>(cx: &C, ret: &mut ArgType<'_, Ty>, offset: &mut Size)
     where Ty: TyLayoutMethods<'a, C>, C: LayoutOf<Ty = Ty> + HasDataLayout
 {
     if !ret.layout.is_aggregate() {
@@ -12,7 +12,7 @@ fn classify_ret_ty<'a, Ty, C>(cx: &C, ret: &mut ArgType<Ty>, offset: &mut Size)
     }
 }
 
-fn classify_arg_ty<'a, Ty, C>(cx: &C, arg: &mut ArgType<Ty>, offset: &mut Size)
+fn classify_arg_ty<'a, Ty, C>(cx: &C, arg: &mut ArgType<'_, Ty>, offset: &mut Size)
     where Ty: TyLayoutMethods<'a, C>, C: LayoutOf<Ty = Ty> + HasDataLayout
 {
     let dl = cx.data_layout();
@@ -34,7 +34,7 @@ fn classify_arg_ty<'a, Ty, C>(cx: &C, arg: &mut ArgType<Ty>, offset: &mut Size)
     *offset = offset.align_to(align) + size.align_to(align);
 }
 
-pub fn compute_abi_info<'a, Ty, C>(cx: &C, fty: &mut FnType<Ty>)
+pub fn compute_abi_info<'a, Ty, C>(cx: &C, fty: &mut FnType<'_, Ty>)
     where Ty: TyLayoutMethods<'a, C>, C: LayoutOf<Ty = Ty> + HasDataLayout
 {
     let mut offset = Size::ZERO;

--- a/src/librustc_target/abi/call/powerpc64.rs
+++ b/src/librustc_target/abi/call/powerpc64.rs
@@ -2,16 +2,16 @@
 // Alignment of 128 bit types is not currently handled, this will
 // need to be fixed when PowerPC vector support is added.
 
-use abi::call::{FnType, ArgType, Reg, RegKind, Uniform};
-use abi::{Endian, HasDataLayout, LayoutOf, TyLayout, TyLayoutMethods};
-use spec::HasTargetSpec;
+use crate::abi::call::{FnType, ArgType, Reg, RegKind, Uniform};
+use crate::abi::{Endian, HasDataLayout, LayoutOf, TyLayout, TyLayoutMethods};
+use crate::spec::HasTargetSpec;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum ABI {
     ELFv1, // original ABI used for powerpc64 (big-endian)
     ELFv2, // newer ABI used for powerpc64le and musl (both endians)
 }
-use self::ABI::*;
+use ABI::*;
 
 fn is_homogeneous_aggregate<'a, Ty, C>(cx: &C, arg: &mut ArgType<'a, Ty>, abi: ABI)
                                        -> Option<Uniform>

--- a/src/librustc_target/abi/call/riscv.rs
+++ b/src/librustc_target/abi/call/riscv.rs
@@ -1,9 +1,9 @@
 // Reference: RISC-V ELF psABI specification
 // https://github.com/riscv/riscv-elf-psabi-doc
 
-use abi::call::{ArgType, FnType};
+use crate::abi::call::{ArgType, FnType};
 
-fn classify_ret_ty<Ty>(arg: &mut ArgType<Ty>, xlen: u64) {
+fn classify_ret_ty<Ty>(arg: &mut ArgType<'_, Ty>, xlen: u64) {
     // "Scalars wider than 2✕XLEN are passed by reference and are replaced in
     // the argument list with the address."
     // "Aggregates larger than 2✕XLEN bits are passed by reference and are
@@ -19,7 +19,7 @@ fn classify_ret_ty<Ty>(arg: &mut ArgType<Ty>, xlen: u64) {
     arg.extend_integer_width_to(xlen); // this method only affects integer scalars
 }
 
-fn classify_arg_ty<Ty>(arg: &mut ArgType<Ty>, xlen: u64) {
+fn classify_arg_ty<Ty>(arg: &mut ArgType<'_, Ty>, xlen: u64) {
     // "Scalars wider than 2✕XLEN are passed by reference and are replaced in
     // the argument list with the address."
     // "Aggregates larger than 2✕XLEN bits are passed by reference and are
@@ -35,7 +35,7 @@ fn classify_arg_ty<Ty>(arg: &mut ArgType<Ty>, xlen: u64) {
     arg.extend_integer_width_to(xlen); // this method only affects integer scalars
 }
 
-pub fn compute_abi_info<Ty>(fty: &mut FnType<Ty>, xlen: u64) {
+pub fn compute_abi_info<Ty>(fty: &mut FnType<'_, Ty>, xlen: u64) {
     if !fty.ret.is_ignore() {
         classify_ret_ty(&mut fty.ret, xlen);
     }

--- a/src/librustc_target/abi/call/s390x.rs
+++ b/src/librustc_target/abi/call/s390x.rs
@@ -1,10 +1,10 @@
 // FIXME: The assumes we're using the non-vector ABI, i.e., compiling
 // for a pre-z13 machine or using -mno-vx.
 
-use abi::call::{FnType, ArgType, Reg};
-use abi::{self, HasDataLayout, LayoutOf, TyLayout, TyLayoutMethods};
+use crate::abi::call::{FnType, ArgType, Reg};
+use crate::abi::{self, HasDataLayout, LayoutOf, TyLayout, TyLayoutMethods};
 
-fn classify_ret_ty<'a, Ty, C>(ret: &mut ArgType<Ty>)
+fn classify_ret_ty<'a, Ty, C>(ret: &mut ArgType<'_, Ty>)
     where Ty: TyLayoutMethods<'a, C>, C: LayoutOf<Ty = Ty> + HasDataLayout
 {
     if !ret.layout.is_aggregate() && ret.layout.size.bits() <= 64 {

--- a/src/librustc_target/abi/call/sparc.rs
+++ b/src/librustc_target/abi/call/sparc.rs
@@ -1,7 +1,7 @@
-use abi::call::{ArgType, FnType, Reg, Uniform};
-use abi::{HasDataLayout, LayoutOf, Size, TyLayoutMethods};
+use crate::abi::call::{ArgType, FnType, Reg, Uniform};
+use crate::abi::{HasDataLayout, LayoutOf, Size, TyLayoutMethods};
 
-fn classify_ret_ty<'a, Ty, C>(cx: &C, ret: &mut ArgType<Ty>, offset: &mut Size)
+fn classify_ret_ty<'a, Ty, C>(cx: &C, ret: &mut ArgType<'_, Ty>, offset: &mut Size)
     where Ty: TyLayoutMethods<'a, C>, C: LayoutOf<Ty = Ty> + HasDataLayout
 {
     if !ret.layout.is_aggregate() {
@@ -12,7 +12,7 @@ fn classify_ret_ty<'a, Ty, C>(cx: &C, ret: &mut ArgType<Ty>, offset: &mut Size)
     }
 }
 
-fn classify_arg_ty<'a, Ty, C>(cx: &C, arg: &mut ArgType<Ty>, offset: &mut Size)
+fn classify_arg_ty<'a, Ty, C>(cx: &C, arg: &mut ArgType<'_, Ty>, offset: &mut Size)
     where Ty: TyLayoutMethods<'a, C>, C: LayoutOf<Ty = Ty> + HasDataLayout
 {
     let dl = cx.data_layout();
@@ -34,7 +34,7 @@ fn classify_arg_ty<'a, Ty, C>(cx: &C, arg: &mut ArgType<Ty>, offset: &mut Size)
     *offset = offset.align_to(align) + size.align_to(align);
 }
 
-pub fn compute_abi_info<'a, Ty, C>(cx: &C, fty: &mut FnType<Ty>)
+pub fn compute_abi_info<'a, Ty, C>(cx: &C, fty: &mut FnType<'_, Ty>)
     where Ty: TyLayoutMethods<'a, C>, C: LayoutOf<Ty = Ty> + HasDataLayout
 {
     let mut offset = Size::ZERO;

--- a/src/librustc_target/abi/call/sparc64.rs
+++ b/src/librustc_target/abi/call/sparc64.rs
@@ -1,7 +1,7 @@
 // FIXME: This needs an audit for correctness and completeness.
 
-use abi::call::{FnType, ArgType, Reg, RegKind, Uniform};
-use abi::{HasDataLayout, LayoutOf, TyLayout, TyLayoutMethods};
+use crate::abi::call::{FnType, ArgType, Reg, RegKind, Uniform};
+use crate::abi::{HasDataLayout, LayoutOf, TyLayout, TyLayoutMethods};
 
 fn is_homogeneous_aggregate<'a, Ty, C>(cx: &C, arg: &mut ArgType<'a, Ty>)
                                      -> Option<Uniform>

--- a/src/librustc_target/abi/call/wasm32.rs
+++ b/src/librustc_target/abi/call/wasm32.rs
@@ -1,14 +1,14 @@
-use abi::call::{FnType, ArgType};
+use crate::abi::call::{FnType, ArgType};
 
-fn classify_ret_ty<Ty>(ret: &mut ArgType<Ty>) {
+fn classify_ret_ty<Ty>(ret: &mut ArgType<'_, Ty>) {
     ret.extend_integer_width_to(32);
 }
 
-fn classify_arg_ty<Ty>(arg: &mut ArgType<Ty>) {
+fn classify_arg_ty<Ty>(arg: &mut ArgType<'_, Ty>) {
     arg.extend_integer_width_to(32);
 }
 
-pub fn compute_abi_info<Ty>(fty: &mut FnType<Ty>) {
+pub fn compute_abi_info<Ty>(fty: &mut FnType<'_, Ty>) {
     if !fty.ret.is_ignore() {
         classify_ret_ty(&mut fty.ret);
     }

--- a/src/librustc_target/abi/call/x86.rs
+++ b/src/librustc_target/abi/call/x86.rs
@@ -1,6 +1,6 @@
-use abi::call::{ArgAttribute, FnType, PassMode, Reg, RegKind};
-use abi::{self, HasDataLayout, LayoutOf, TyLayout, TyLayoutMethods};
-use spec::HasTargetSpec;
+use crate::abi::call::{ArgAttribute, FnType, PassMode, Reg, RegKind};
+use crate::abi::{self, HasDataLayout, LayoutOf, TyLayout, TyLayoutMethods};
+use crate::spec::HasTargetSpec;
 
 #[derive(PartialEq)]
 pub enum Flavor {

--- a/src/librustc_target/abi/call/x86_64.rs
+++ b/src/librustc_target/abi/call/x86_64.rs
@@ -1,8 +1,8 @@
 // The classification code for the x86_64 ABI is taken from the clay language
 // https://github.com/jckarter/clay/blob/master/compiler/src/externals.cpp
 
-use abi::call::{ArgType, CastTarget, FnType, Reg, RegKind};
-use abi::{self, Abi, HasDataLayout, LayoutOf, Size, TyLayout, TyLayoutMethods};
+use crate::abi::call::{ArgType, CastTarget, FnType, Reg, RegKind};
+use crate::abi::{self, Abi, HasDataLayout, LayoutOf, Size, TyLayout, TyLayoutMethods};
 
 /// Classification of "eightbyte" components.
 // N.B., the order of the variants is from general to specific,

--- a/src/librustc_target/abi/call/x86_win64.rs
+++ b/src/librustc_target/abi/call/x86_win64.rs
@@ -1,10 +1,10 @@
-use abi::call::{ArgType, FnType, Reg};
-use abi::Abi;
+use crate::abi::call::{ArgType, FnType, Reg};
+use crate::abi::Abi;
 
 // Win64 ABI: http://msdn.microsoft.com/en-us/library/zthk2dkh.aspx
 
-pub fn compute_abi_info<Ty>(fty: &mut FnType<Ty>) {
-    let fixup = |a: &mut ArgType<Ty>| {
+pub fn compute_abi_info<Ty>(fty: &mut FnType<'_, Ty>) {
+    let fixup = |a: &mut ArgType<'_, Ty>| {
         match a.layout.abi {
             Abi::Uninhabited => {}
             Abi::ScalarPair(..) |

--- a/src/librustc_target/abi/mod.rs
+++ b/src/librustc_target/abi/mod.rs
@@ -1,7 +1,7 @@
-pub use self::Integer::*;
-pub use self::Primitive::*;
+pub use Integer::*;
+pub use Primitive::*;
 
-use spec::Target;
+use crate::spec::Target;
 
 use std::fmt;
 use std::ops::{Add, Deref, Sub, Mul, AddAssign, Range, RangeInclusive};
@@ -533,13 +533,13 @@ pub enum FloatTy {
 }
 
 impl fmt::Debug for FloatTy {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(self, f)
     }
 }
 
 impl fmt::Display for FloatTy {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.ty_to_string())
     }
 }

--- a/src/librustc_target/lib.rs
+++ b/src/librustc_target/lib.rs
@@ -17,11 +17,11 @@
 #![feature(slice_patterns)]
 #![feature(step_trait)]
 
-#[macro_use]
-extern crate bitflags;
-extern crate serialize;
+#![deny(rust_2018_idioms)]
+
 #[macro_use] extern crate log;
 
+#[allow(unused_extern_crates)]
 extern crate serialize as rustc_serialize; // used by deriving
 
 // See librustc_cratesio_shim/Cargo.toml for a comment explaining this.

--- a/src/librustc_target/spec/aarch64_apple_ios.rs
+++ b/src/librustc_target/spec/aarch64_apple_ios.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
 use super::apple_ios_base::{opts, Arch};
 
 pub fn target() -> TargetResult {

--- a/src/librustc_target/spec/aarch64_fuchsia.rs
+++ b/src/librustc_target/spec/aarch64_fuchsia.rs
@@ -1,4 +1,4 @@
-use spec::{LldFlavor, LinkerFlavor, Target, TargetOptions, TargetResult};
+use crate::spec::{LldFlavor, LinkerFlavor, Target, TargetOptions, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::fuchsia_base::opts();

--- a/src/librustc_target/spec/aarch64_linux_android.rs
+++ b/src/librustc_target/spec/aarch64_linux_android.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
 
 // See https://developer.android.com/ndk/guides/abis.html#arm64-v8a
 // for target ABI requirements.

--- a/src/librustc_target/spec/aarch64_pc_windows_msvc.rs
+++ b/src/librustc_target/spec/aarch64_pc_windows_msvc.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult, PanicStrategy};
+use crate::spec::{LinkerFlavor, Target, TargetResult, PanicStrategy};
 
 pub fn target() -> TargetResult {
     let mut base = super::windows_msvc_base::opts();

--- a/src/librustc_target/spec/aarch64_unknown_cloudabi.rs
+++ b/src/librustc_target/spec/aarch64_unknown_cloudabi.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::cloudabi_base::opts();

--- a/src/librustc_target/spec/aarch64_unknown_freebsd.rs
+++ b/src/librustc_target/spec/aarch64_unknown_freebsd.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::freebsd_base::opts();

--- a/src/librustc_target/spec/aarch64_unknown_hermit.rs
+++ b/src/librustc_target/spec/aarch64_unknown_hermit.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::hermit_base::opts();

--- a/src/librustc_target/spec/aarch64_unknown_linux_gnu.rs
+++ b/src/librustc_target/spec/aarch64_unknown_linux_gnu.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::linux_base::opts();

--- a/src/librustc_target/spec/aarch64_unknown_linux_musl.rs
+++ b/src/librustc_target/spec/aarch64_unknown_linux_musl.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::linux_musl_base::opts();

--- a/src/librustc_target/spec/aarch64_unknown_netbsd.rs
+++ b/src/librustc_target/spec/aarch64_unknown_netbsd.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::netbsd_base::opts();

--- a/src/librustc_target/spec/aarch64_unknown_openbsd.rs
+++ b/src/librustc_target/spec/aarch64_unknown_openbsd.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::openbsd_base::opts();

--- a/src/librustc_target/spec/abi.rs
+++ b/src/librustc_target/spec/abi.rs
@@ -96,7 +96,7 @@ impl Abi {
 }
 
 impl fmt::Display for Abi {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "\"{}\"", self.name())
     }
 }

--- a/src/librustc_target/spec/android_base.rs
+++ b/src/librustc_target/spec/android_base.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, TargetOptions};
+use crate::spec::{LinkerFlavor, TargetOptions};
 
 pub fn opts() -> TargetOptions {
     let mut base = super::linux_base::opts();

--- a/src/librustc_target/spec/apple_base.rs
+++ b/src/librustc_target/spec/apple_base.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use spec::{LinkArgs, TargetOptions};
+use crate::spec::{LinkArgs, TargetOptions};
 
 pub fn opts() -> TargetOptions {
     // ELF TLS is only available in macOS 10.7+. If you try to compile for 10.6

--- a/src/librustc_target/spec/apple_ios_base.rs
+++ b/src/librustc_target/spec/apple_ios_base.rs
@@ -1,8 +1,8 @@
 use std::io;
 use std::process::Command;
-use spec::{LinkArgs, LinkerFlavor, TargetOptions};
+use crate::spec::{LinkArgs, LinkerFlavor, TargetOptions};
 
-use self::Arch::*;
+use Arch::*;
 
 #[allow(non_camel_case_types)]
 #[derive(Copy, Clone)]

--- a/src/librustc_target/spec/arm_base.rs
+++ b/src/librustc_target/spec/arm_base.rs
@@ -1,4 +1,4 @@
-use spec::abi::Abi;
+use crate::spec::abi::Abi;
 
 // All the calling conventions trigger an assertion(Unsupported calling convention) in llvm on arm
 pub fn abi_blacklist() -> Vec<Abi> {

--- a/src/librustc_target/spec/arm_linux_androideabi.rs
+++ b/src/librustc_target/spec/arm_linux_androideabi.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::android_base::opts();

--- a/src/librustc_target/spec/arm_unknown_linux_gnueabi.rs
+++ b/src/librustc_target/spec/arm_unknown_linux_gnueabi.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::linux_base::opts();

--- a/src/librustc_target/spec/arm_unknown_linux_gnueabihf.rs
+++ b/src/librustc_target/spec/arm_unknown_linux_gnueabihf.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::linux_base::opts();

--- a/src/librustc_target/spec/arm_unknown_linux_musleabi.rs
+++ b/src/librustc_target/spec/arm_unknown_linux_musleabi.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::linux_musl_base::opts();

--- a/src/librustc_target/spec/arm_unknown_linux_musleabihf.rs
+++ b/src/librustc_target/spec/arm_unknown_linux_musleabihf.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::linux_musl_base::opts();

--- a/src/librustc_target/spec/armebv7r_none_eabi.rs
+++ b/src/librustc_target/spec/armebv7r_none_eabi.rs
@@ -1,7 +1,7 @@
 // Targets the Big endian Cortex-R4/R5 processor (ARMv7-R)
 
 use std::default::Default;
-use spec::{LinkerFlavor, LldFlavor, PanicStrategy, Target, TargetOptions, TargetResult};
+use crate::spec::{LinkerFlavor, LldFlavor, PanicStrategy, Target, TargetOptions, TargetResult};
 
 pub fn target() -> TargetResult {
     Ok(Target {

--- a/src/librustc_target/spec/armebv7r_none_eabihf.rs
+++ b/src/librustc_target/spec/armebv7r_none_eabihf.rs
@@ -1,7 +1,7 @@
 // Targets the Cortex-R4F/R5F processor (ARMv7-R)
 
 use std::default::Default;
-use spec::{LinkerFlavor, LldFlavor, PanicStrategy, Target, TargetOptions, TargetResult};
+use crate::spec::{LinkerFlavor, LldFlavor, PanicStrategy, Target, TargetOptions, TargetResult};
 
 pub fn target() -> TargetResult {
     Ok(Target {

--- a/src/librustc_target/spec/armv4t_unknown_linux_gnueabi.rs
+++ b/src/librustc_target/spec/armv4t_unknown_linux_gnueabi.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
 
 pub fn target() -> TargetResult {
     let base = super::linux_base::opts();

--- a/src/librustc_target/spec/armv5te_unknown_linux_gnueabi.rs
+++ b/src/librustc_target/spec/armv5te_unknown_linux_gnueabi.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
 
 pub fn target() -> TargetResult {
     let base = super::linux_base::opts();

--- a/src/librustc_target/spec/armv5te_unknown_linux_musleabi.rs
+++ b/src/librustc_target/spec/armv5te_unknown_linux_musleabi.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
 
 pub fn target() -> TargetResult {
     let base = super::linux_musl_base::opts();

--- a/src/librustc_target/spec/armv6_unknown_netbsd_eabihf.rs
+++ b/src/librustc_target/spec/armv6_unknown_netbsd_eabihf.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::netbsd_base::opts();

--- a/src/librustc_target/spec/armv7_apple_ios.rs
+++ b/src/librustc_target/spec/armv7_apple_ios.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
 use super::apple_ios_base::{opts, Arch};
 
 pub fn target() -> TargetResult {

--- a/src/librustc_target/spec/armv7_linux_androideabi.rs
+++ b/src/librustc_target/spec/armv7_linux_androideabi.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
 
 // This target if is for the baseline of the Android v7a ABI
 // in thumb mode. It's named armv7-* instead of thumbv7-*

--- a/src/librustc_target/spec/armv7_unknown_cloudabi_eabihf.rs
+++ b/src/librustc_target/spec/armv7_unknown_cloudabi_eabihf.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::cloudabi_base::opts();

--- a/src/librustc_target/spec/armv7_unknown_linux_gnueabihf.rs
+++ b/src/librustc_target/spec/armv7_unknown_linux_gnueabihf.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
 
 // This target is for glibc Linux on ARMv7 without NEON or
 // thumb-mode. See the thumbv7neon variant for enabling both.

--- a/src/librustc_target/spec/armv7_unknown_linux_musleabihf.rs
+++ b/src/librustc_target/spec/armv7_unknown_linux_musleabihf.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
 
 // This target is for musl Linux on ARMv7 without thumb-mode or NEON.
 

--- a/src/librustc_target/spec/armv7_unknown_netbsd_eabihf.rs
+++ b/src/librustc_target/spec/armv7_unknown_netbsd_eabihf.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
 
 pub fn target() -> TargetResult {
     let base = super::netbsd_base::opts();

--- a/src/librustc_target/spec/armv7r_none_eabi.rs
+++ b/src/librustc_target/spec/armv7r_none_eabi.rs
@@ -1,7 +1,7 @@
 // Targets the Little-endian Cortex-R4/R5 processor (ARMv7-R)
 
 use std::default::Default;
-use spec::{LinkerFlavor, LldFlavor, PanicStrategy, Target, TargetOptions, TargetResult};
+use crate::spec::{LinkerFlavor, LldFlavor, PanicStrategy, Target, TargetOptions, TargetResult};
 
 pub fn target() -> TargetResult {
     Ok(Target {

--- a/src/librustc_target/spec/armv7r_none_eabihf.rs
+++ b/src/librustc_target/spec/armv7r_none_eabihf.rs
@@ -1,7 +1,7 @@
 // Targets the Little-endian Cortex-R4F/R5F processor (ARMv7-R)
 
 use std::default::Default;
-use spec::{LinkerFlavor, LldFlavor, PanicStrategy, Target, TargetOptions, TargetResult};
+use crate::spec::{LinkerFlavor, LldFlavor, PanicStrategy, Target, TargetOptions, TargetResult};
 
 pub fn target() -> TargetResult {
     Ok(Target {

--- a/src/librustc_target/spec/armv7s_apple_ios.rs
+++ b/src/librustc_target/spec/armv7s_apple_ios.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
 use super::apple_ios_base::{opts, Arch};
 
 pub fn target() -> TargetResult {

--- a/src/librustc_target/spec/bitrig_base.rs
+++ b/src/librustc_target/spec/bitrig_base.rs
@@ -1,4 +1,4 @@
-use spec::{TargetOptions, RelroLevel};
+use crate::spec::{TargetOptions, RelroLevel};
 use std::default::Default;
 
 pub fn opts() -> TargetOptions {

--- a/src/librustc_target/spec/cloudabi_base.rs
+++ b/src/librustc_target/spec/cloudabi_base.rs
@@ -1,4 +1,4 @@
-use spec::{LinkArgs, LinkerFlavor, TargetOptions, RelroLevel};
+use crate::spec::{LinkArgs, LinkerFlavor, TargetOptions, RelroLevel};
 
 pub fn opts() -> TargetOptions {
     let mut args = LinkArgs::new();

--- a/src/librustc_target/spec/dragonfly_base.rs
+++ b/src/librustc_target/spec/dragonfly_base.rs
@@ -1,4 +1,4 @@
-use spec::{LinkArgs, LinkerFlavor, TargetOptions, RelroLevel};
+use crate::spec::{LinkArgs, LinkerFlavor, TargetOptions, RelroLevel};
 use std::default::Default;
 
 pub fn opts() -> TargetOptions {

--- a/src/librustc_target/spec/freebsd_base.rs
+++ b/src/librustc_target/spec/freebsd_base.rs
@@ -1,4 +1,4 @@
-use spec::{LinkArgs, LinkerFlavor, TargetOptions, RelroLevel};
+use crate::spec::{LinkArgs, LinkerFlavor, TargetOptions, RelroLevel};
 use std::default::Default;
 
 pub fn opts() -> TargetOptions {

--- a/src/librustc_target/spec/fuchsia_base.rs
+++ b/src/librustc_target/spec/fuchsia_base.rs
@@ -1,4 +1,4 @@
-use spec::{LldFlavor, LinkArgs, LinkerFlavor, TargetOptions};
+use crate::spec::{LldFlavor, LinkArgs, LinkerFlavor, TargetOptions};
 use std::default::Default;
 
 pub fn opts() -> TargetOptions {

--- a/src/librustc_target/spec/haiku_base.rs
+++ b/src/librustc_target/spec/haiku_base.rs
@@ -1,4 +1,4 @@
-use spec::{TargetOptions, RelroLevel};
+use crate::spec::{TargetOptions, RelroLevel};
 use std::default::Default;
 
 pub fn opts() -> TargetOptions {

--- a/src/librustc_target/spec/hermit_base.rs
+++ b/src/librustc_target/spec/hermit_base.rs
@@ -1,4 +1,4 @@
-use spec::{LinkArgs, LinkerFlavor, PanicStrategy, TargetOptions};
+use crate::spec::{LinkArgs, LinkerFlavor, PanicStrategy, TargetOptions};
 use std::default::Default;
 
 pub fn opts() -> TargetOptions {

--- a/src/librustc_target/spec/i386_apple_ios.rs
+++ b/src/librustc_target/spec/i386_apple_ios.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
 use super::apple_ios_base::{opts, Arch};
 
 pub fn target() -> TargetResult {

--- a/src/librustc_target/spec/i586_pc_windows_msvc.rs
+++ b/src/librustc_target/spec/i586_pc_windows_msvc.rs
@@ -1,4 +1,4 @@
-use spec::TargetResult;
+use crate::spec::TargetResult;
 
 pub fn target() -> TargetResult {
     let mut base = super::i686_pc_windows_msvc::target()?;

--- a/src/librustc_target/spec/i586_unknown_linux_gnu.rs
+++ b/src/librustc_target/spec/i586_unknown_linux_gnu.rs
@@ -1,4 +1,4 @@
-use spec::TargetResult;
+use crate::spec::TargetResult;
 
 pub fn target() -> TargetResult {
     let mut base = super::i686_unknown_linux_gnu::target()?;

--- a/src/librustc_target/spec/i586_unknown_linux_musl.rs
+++ b/src/librustc_target/spec/i586_unknown_linux_musl.rs
@@ -1,4 +1,4 @@
-use spec::TargetResult;
+use crate::spec::TargetResult;
 
 pub fn target() -> TargetResult {
     let mut base = super::i686_unknown_linux_musl::target()?;

--- a/src/librustc_target/spec/i686_apple_darwin.rs
+++ b/src/librustc_target/spec/i686_apple_darwin.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::apple_base::opts();

--- a/src/librustc_target/spec/i686_linux_android.rs
+++ b/src/librustc_target/spec/i686_linux_android.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 // See https://developer.android.com/ndk/guides/abis.html#x86
 // for target ABI requirements.

--- a/src/librustc_target/spec/i686_pc_windows_gnu.rs
+++ b/src/librustc_target/spec/i686_pc_windows_gnu.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::windows_base::opts();

--- a/src/librustc_target/spec/i686_pc_windows_msvc.rs
+++ b/src/librustc_target/spec/i686_pc_windows_msvc.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::windows_msvc_base::opts();

--- a/src/librustc_target/spec/i686_unknown_cloudabi.rs
+++ b/src/librustc_target/spec/i686_unknown_cloudabi.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::cloudabi_base::opts();

--- a/src/librustc_target/spec/i686_unknown_dragonfly.rs
+++ b/src/librustc_target/spec/i686_unknown_dragonfly.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::dragonfly_base::opts();

--- a/src/librustc_target/spec/i686_unknown_freebsd.rs
+++ b/src/librustc_target/spec/i686_unknown_freebsd.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::freebsd_base::opts();

--- a/src/librustc_target/spec/i686_unknown_haiku.rs
+++ b/src/librustc_target/spec/i686_unknown_haiku.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::haiku_base::opts();

--- a/src/librustc_target/spec/i686_unknown_linux_gnu.rs
+++ b/src/librustc_target/spec/i686_unknown_linux_gnu.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::linux_base::opts();

--- a/src/librustc_target/spec/i686_unknown_linux_musl.rs
+++ b/src/librustc_target/spec/i686_unknown_linux_musl.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::linux_musl_base::opts();

--- a/src/librustc_target/spec/i686_unknown_netbsd.rs
+++ b/src/librustc_target/spec/i686_unknown_netbsd.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::netbsd_base::opts();

--- a/src/librustc_target/spec/i686_unknown_openbsd.rs
+++ b/src/librustc_target/spec/i686_unknown_openbsd.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::openbsd_base::opts();

--- a/src/librustc_target/spec/l4re_base.rs
+++ b/src/librustc_target/spec/l4re_base.rs
@@ -1,4 +1,4 @@
-use spec::{LinkArgs, LinkerFlavor, PanicStrategy, TargetOptions};
+use crate::spec::{LinkArgs, LinkerFlavor, PanicStrategy, TargetOptions};
 use std::default::Default;
 //use std::process::Command;
 

--- a/src/librustc_target/spec/linux_base.rs
+++ b/src/librustc_target/spec/linux_base.rs
@@ -1,4 +1,4 @@
-use spec::{LinkArgs, LinkerFlavor, TargetOptions, RelroLevel};
+use crate::spec::{LinkArgs, LinkerFlavor, TargetOptions, RelroLevel};
 use std::default::Default;
 
 pub fn opts() -> TargetOptions {

--- a/src/librustc_target/spec/linux_musl_base.rs
+++ b/src/librustc_target/spec/linux_musl_base.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, TargetOptions};
+use crate::spec::{LinkerFlavor, TargetOptions};
 
 pub fn opts() -> TargetOptions {
     let mut base = super::linux_base::opts();

--- a/src/librustc_target/spec/mips64_unknown_linux_gnuabi64.rs
+++ b/src/librustc_target/spec/mips64_unknown_linux_gnuabi64.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
 
 pub fn target() -> TargetResult {
     Ok(Target {

--- a/src/librustc_target/spec/mips64el_unknown_linux_gnuabi64.rs
+++ b/src/librustc_target/spec/mips64el_unknown_linux_gnuabi64.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
 
 pub fn target() -> TargetResult {
     Ok(Target {

--- a/src/librustc_target/spec/mips_unknown_linux_gnu.rs
+++ b/src/librustc_target/spec/mips_unknown_linux_gnu.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
 
 pub fn target() -> TargetResult {
     Ok(Target {

--- a/src/librustc_target/spec/mips_unknown_linux_musl.rs
+++ b/src/librustc_target/spec/mips_unknown_linux_musl.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::linux_musl_base::opts();

--- a/src/librustc_target/spec/mips_unknown_linux_uclibc.rs
+++ b/src/librustc_target/spec/mips_unknown_linux_uclibc.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
 
 pub fn target() -> TargetResult {
     Ok(Target {

--- a/src/librustc_target/spec/mipsel_unknown_linux_gnu.rs
+++ b/src/librustc_target/spec/mipsel_unknown_linux_gnu.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
 
 pub fn target() -> TargetResult {
     Ok(Target {

--- a/src/librustc_target/spec/mipsel_unknown_linux_musl.rs
+++ b/src/librustc_target/spec/mipsel_unknown_linux_musl.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::linux_musl_base::opts();

--- a/src/librustc_target/spec/mipsel_unknown_linux_uclibc.rs
+++ b/src/librustc_target/spec/mipsel_unknown_linux_uclibc.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
 
 pub fn target() -> TargetResult {
     Ok(Target {

--- a/src/librustc_target/spec/mod.rs
+++ b/src/librustc_target/spec/mod.rs
@@ -40,7 +40,7 @@ use std::default::Default;
 use std::{fmt, io};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
-use spec::abi::{Abi, lookup as lookup_abi};
+use crate::spec::abi::{Abi, lookup as lookup_abi};
 
 pub mod abi;
 mod android_base;
@@ -1408,7 +1408,7 @@ impl TargetTriple {
 }
 
 impl fmt::Display for TargetTriple {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.debug_triple())
     }
 }

--- a/src/librustc_target/spec/msp430_none_elf.rs
+++ b/src/librustc_target/spec/msp430_none_elf.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, PanicStrategy, Target, TargetOptions, TargetResult};
+use crate::spec::{LinkerFlavor, PanicStrategy, Target, TargetOptions, TargetResult};
 
 pub fn target() -> TargetResult {
     Ok(Target {

--- a/src/librustc_target/spec/netbsd_base.rs
+++ b/src/librustc_target/spec/netbsd_base.rs
@@ -1,4 +1,4 @@
-use spec::{LinkArgs, LinkerFlavor, TargetOptions, RelroLevel};
+use crate::spec::{LinkArgs, LinkerFlavor, TargetOptions, RelroLevel};
 use std::default::Default;
 
 pub fn opts() -> TargetOptions {

--- a/src/librustc_target/spec/nvptx64_nvidia_cuda.rs
+++ b/src/librustc_target/spec/nvptx64_nvidia_cuda.rs
@@ -1,5 +1,5 @@
-use spec::{LinkerFlavor, Target, TargetOptions, TargetResult, PanicStrategy, MergeFunctions};
-use spec::abi::Abi;
+use crate::spec::{LinkerFlavor, Target, TargetOptions, TargetResult, PanicStrategy, MergeFunctions};
+use crate::spec::abi::Abi;
 
 pub fn target() -> TargetResult {
     Ok(Target {

--- a/src/librustc_target/spec/openbsd_base.rs
+++ b/src/librustc_target/spec/openbsd_base.rs
@@ -1,4 +1,4 @@
-use spec::{LinkArgs, LinkerFlavor, TargetOptions, RelroLevel};
+use crate::spec::{LinkArgs, LinkerFlavor, TargetOptions, RelroLevel};
 use std::default::Default;
 
 pub fn opts() -> TargetOptions {

--- a/src/librustc_target/spec/powerpc64_unknown_freebsd.rs
+++ b/src/librustc_target/spec/powerpc64_unknown_freebsd.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::freebsd_base::opts();

--- a/src/librustc_target/spec/powerpc64_unknown_linux_gnu.rs
+++ b/src/librustc_target/spec/powerpc64_unknown_linux_gnu.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult, RelroLevel};
+use crate::spec::{LinkerFlavor, Target, TargetResult, RelroLevel};
 
 pub fn target() -> TargetResult {
     let mut base = super::linux_base::opts();

--- a/src/librustc_target/spec/powerpc64_unknown_linux_musl.rs
+++ b/src/librustc_target/spec/powerpc64_unknown_linux_musl.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::linux_musl_base::opts();

--- a/src/librustc_target/spec/powerpc64le_unknown_linux_gnu.rs
+++ b/src/librustc_target/spec/powerpc64le_unknown_linux_gnu.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::linux_base::opts();

--- a/src/librustc_target/spec/powerpc64le_unknown_linux_musl.rs
+++ b/src/librustc_target/spec/powerpc64le_unknown_linux_musl.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::linux_musl_base::opts();

--- a/src/librustc_target/spec/powerpc_unknown_linux_gnu.rs
+++ b/src/librustc_target/spec/powerpc_unknown_linux_gnu.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::linux_base::opts();

--- a/src/librustc_target/spec/powerpc_unknown_linux_gnuspe.rs
+++ b/src/librustc_target/spec/powerpc_unknown_linux_gnuspe.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::linux_base::opts();

--- a/src/librustc_target/spec/powerpc_unknown_linux_musl.rs
+++ b/src/librustc_target/spec/powerpc_unknown_linux_musl.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::linux_musl_base::opts();

--- a/src/librustc_target/spec/powerpc_unknown_netbsd.rs
+++ b/src/librustc_target/spec/powerpc_unknown_netbsd.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::netbsd_base::opts();

--- a/src/librustc_target/spec/redox_base.rs
+++ b/src/librustc_target/spec/redox_base.rs
@@ -1,4 +1,4 @@
-use spec::{LinkArgs, LinkerFlavor, TargetOptions};
+use crate::spec::{LinkArgs, LinkerFlavor, TargetOptions};
 use std::default::Default;
 
 pub fn opts() -> TargetOptions {

--- a/src/librustc_target/spec/riscv32imac_unknown_none_elf.rs
+++ b/src/librustc_target/spec/riscv32imac_unknown_none_elf.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, LldFlavor, PanicStrategy,
+use crate::spec::{LinkerFlavor, LldFlavor, PanicStrategy,
            Target, TargetOptions, TargetResult};
 
 pub fn target() -> TargetResult {

--- a/src/librustc_target/spec/riscv32imc_unknown_none_elf.rs
+++ b/src/librustc_target/spec/riscv32imc_unknown_none_elf.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, LldFlavor, PanicStrategy,
+use crate::spec::{LinkerFlavor, LldFlavor, PanicStrategy,
            Target, TargetOptions, TargetResult};
 
 pub fn target() -> TargetResult {

--- a/src/librustc_target/spec/riscv_base.rs
+++ b/src/librustc_target/spec/riscv_base.rs
@@ -1,4 +1,4 @@
-use spec::abi::Abi;
+use crate::spec::abi::Abi;
 
 // All the calling conventions trigger an assertion(Unsupported calling
 // convention) in llvm on RISCV

--- a/src/librustc_target/spec/s390x_unknown_linux_gnu.rs
+++ b/src/librustc_target/spec/s390x_unknown_linux_gnu.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::linux_base::opts();

--- a/src/librustc_target/spec/solaris_base.rs
+++ b/src/librustc_target/spec/solaris_base.rs
@@ -1,4 +1,4 @@
-use spec::TargetOptions;
+use crate::spec::TargetOptions;
 use std::default::Default;
 
 pub fn opts() -> TargetOptions {

--- a/src/librustc_target/spec/sparc64_unknown_linux_gnu.rs
+++ b/src/librustc_target/spec/sparc64_unknown_linux_gnu.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::linux_base::opts();

--- a/src/librustc_target/spec/sparc64_unknown_netbsd.rs
+++ b/src/librustc_target/spec/sparc64_unknown_netbsd.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::netbsd_base::opts();

--- a/src/librustc_target/spec/sparc_unknown_linux_gnu.rs
+++ b/src/librustc_target/spec/sparc_unknown_linux_gnu.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::linux_base::opts();

--- a/src/librustc_target/spec/sparcv9_sun_solaris.rs
+++ b/src/librustc_target/spec/sparcv9_sun_solaris.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::solaris_base::opts();

--- a/src/librustc_target/spec/thumb_base.rs
+++ b/src/librustc_target/spec/thumb_base.rs
@@ -28,7 +28,7 @@
 // build scripts / gcc flags.
 
 use std::default::Default;
-use spec::{PanicStrategy, TargetOptions};
+use crate::spec::{PanicStrategy, TargetOptions};
 
 pub fn opts() -> TargetOptions {
     // See rust-lang/rfcs#1645 for a discussion about these defaults

--- a/src/librustc_target/spec/thumbv6m_none_eabi.rs
+++ b/src/librustc_target/spec/thumbv6m_none_eabi.rs
@@ -1,6 +1,6 @@
 // Targets the Cortex-M0, Cortex-M0+ and Cortex-M1 processors (ARMv6-M architecture)
 
-use spec::{LinkerFlavor, LldFlavor, Target, TargetOptions, TargetResult};
+use crate::spec::{LinkerFlavor, LldFlavor, Target, TargetOptions, TargetResult};
 
 pub fn target() -> TargetResult {
     Ok(Target {

--- a/src/librustc_target/spec/thumbv7a_pc_windows_msvc.rs
+++ b/src/librustc_target/spec/thumbv7a_pc_windows_msvc.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetOptions, TargetResult, PanicStrategy};
+use crate::spec::{LinkerFlavor, Target, TargetOptions, TargetResult, PanicStrategy};
 
 pub fn target() -> TargetResult {
     let mut base = super::windows_msvc_base::opts();

--- a/src/librustc_target/spec/thumbv7em_none_eabi.rs
+++ b/src/librustc_target/spec/thumbv7em_none_eabi.rs
@@ -9,7 +9,7 @@
 // To opt-in to hardware accelerated floating point operations, you can use, for example,
 // `-C target-feature=+vfp4` or `-C target-cpu=cortex-m4`.
 
-use spec::{LinkerFlavor, LldFlavor, Target, TargetOptions, TargetResult};
+use crate::spec::{LinkerFlavor, LldFlavor, Target, TargetOptions, TargetResult};
 
 pub fn target() -> TargetResult {
     Ok(Target {

--- a/src/librustc_target/spec/thumbv7em_none_eabihf.rs
+++ b/src/librustc_target/spec/thumbv7em_none_eabihf.rs
@@ -8,7 +8,7 @@
 //
 // To opt into double precision hardware support, use the `-C target-feature=-fp-only-sp` flag.
 
-use spec::{LinkerFlavor, LldFlavor, Target, TargetOptions, TargetResult};
+use crate::spec::{LinkerFlavor, LldFlavor, Target, TargetOptions, TargetResult};
 
 pub fn target() -> TargetResult {
     Ok(Target {

--- a/src/librustc_target/spec/thumbv7m_none_eabi.rs
+++ b/src/librustc_target/spec/thumbv7m_none_eabi.rs
@@ -1,6 +1,6 @@
 // Targets the Cortex-M3 processor (ARMv7-M)
 
-use spec::{LinkerFlavor, LldFlavor, Target, TargetOptions, TargetResult};
+use crate::spec::{LinkerFlavor, LldFlavor, Target, TargetOptions, TargetResult};
 
 pub fn target() -> TargetResult {
     Ok(Target {

--- a/src/librustc_target/spec/thumbv7neon_linux_androideabi.rs
+++ b/src/librustc_target/spec/thumbv7neon_linux_androideabi.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
 
 // This target if is for the Android v7a ABI in thumb mode with
 // NEON unconditionally enabled and, therefore, with 32 FPU registers

--- a/src/librustc_target/spec/thumbv7neon_unknown_linux_gnueabihf.rs
+++ b/src/librustc_target/spec/thumbv7neon_unknown_linux_gnueabihf.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
 
 // This target is for glibc Linux on ARMv7 with thumb mode enabled
 // (for consistency with Android and Debian-based distributions)

--- a/src/librustc_target/spec/thumbv8m_base_none_eabi.rs
+++ b/src/librustc_target/spec/thumbv8m_base_none_eabi.rs
@@ -1,6 +1,6 @@
 // Targets the Cortex-M23 processor (Baseline ARMv8-M)
 
-use spec::{LinkerFlavor, LldFlavor, Target, TargetOptions, TargetResult};
+use crate::spec::{LinkerFlavor, LldFlavor, Target, TargetOptions, TargetResult};
 
 pub fn target() -> TargetResult {
     Ok(Target {

--- a/src/librustc_target/spec/thumbv8m_main_none_eabi.rs
+++ b/src/librustc_target/spec/thumbv8m_main_none_eabi.rs
@@ -1,7 +1,7 @@
 // Targets the Cortex-M33 processor (Armv8-M Mainline architecture profile),
 // without the Floating Point extension.
 
-use spec::{LinkerFlavor, LldFlavor, Target, TargetOptions, TargetResult};
+use crate::spec::{LinkerFlavor, LldFlavor, Target, TargetOptions, TargetResult};
 
 pub fn target() -> TargetResult {
     Ok(Target {

--- a/src/librustc_target/spec/thumbv8m_main_none_eabihf.rs
+++ b/src/librustc_target/spec/thumbv8m_main_none_eabihf.rs
@@ -1,7 +1,7 @@
 // Targets the Cortex-M33 processor (Armv8-M Mainline architecture profile),
 // with the Floating Point extension.
 
-use spec::{LinkerFlavor, LldFlavor, Target, TargetOptions, TargetResult};
+use crate::spec::{LinkerFlavor, LldFlavor, Target, TargetOptions, TargetResult};
 
 pub fn target() -> TargetResult {
     Ok(Target {

--- a/src/librustc_target/spec/uefi_base.rs
+++ b/src/librustc_target/spec/uefi_base.rs
@@ -9,7 +9,7 @@
 // the timer-interrupt. Device-drivers are required to use polling-based models. Furthermore, all
 // code runs in the same environment, no process separation is supported.
 
-use spec::{LinkArgs, LinkerFlavor, LldFlavor, PanicStrategy, TargetOptions};
+use crate::spec::{LinkArgs, LinkerFlavor, LldFlavor, PanicStrategy, TargetOptions};
 use std::default::Default;
 
 pub fn opts() -> TargetOptions {

--- a/src/librustc_target/spec/windows_base.rs
+++ b/src/librustc_target/spec/windows_base.rs
@@ -1,4 +1,4 @@
-use spec::{LinkArgs, LinkerFlavor, TargetOptions};
+use crate::spec::{LinkArgs, LinkerFlavor, TargetOptions};
 use std::default::Default;
 
 pub fn opts() -> TargetOptions {

--- a/src/librustc_target/spec/windows_msvc_base.rs
+++ b/src/librustc_target/spec/windows_msvc_base.rs
@@ -1,4 +1,4 @@
-use spec::{LinkArgs, LinkerFlavor, TargetOptions};
+use crate::spec::{LinkArgs, LinkerFlavor, TargetOptions};
 use std::default::Default;
 
 pub fn opts() -> TargetOptions {

--- a/src/librustc_target/spec/x86_64_apple_darwin.rs
+++ b/src/librustc_target/spec/x86_64_apple_darwin.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::apple_base::opts();

--- a/src/librustc_target/spec/x86_64_apple_ios.rs
+++ b/src/librustc_target/spec/x86_64_apple_ios.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
 use super::apple_ios_base::{opts, Arch};
 
 pub fn target() -> TargetResult {

--- a/src/librustc_target/spec/x86_64_fuchsia.rs
+++ b/src/librustc_target/spec/x86_64_fuchsia.rs
@@ -1,4 +1,4 @@
-use spec::{LldFlavor, LinkerFlavor, Target, TargetResult};
+use crate::spec::{LldFlavor, LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::fuchsia_base::opts();

--- a/src/librustc_target/spec/x86_64_linux_android.rs
+++ b/src/librustc_target/spec/x86_64_linux_android.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::android_base::opts();

--- a/src/librustc_target/spec/x86_64_pc_windows_gnu.rs
+++ b/src/librustc_target/spec/x86_64_pc_windows_gnu.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::windows_base::opts();

--- a/src/librustc_target/spec/x86_64_pc_windows_msvc.rs
+++ b/src/librustc_target/spec/x86_64_pc_windows_msvc.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::windows_msvc_base::opts();

--- a/src/librustc_target/spec/x86_64_rumprun_netbsd.rs
+++ b/src/librustc_target/spec/x86_64_rumprun_netbsd.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::netbsd_base::opts();

--- a/src/librustc_target/spec/x86_64_sun_solaris.rs
+++ b/src/librustc_target/spec/x86_64_sun_solaris.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::solaris_base::opts();

--- a/src/librustc_target/spec/x86_64_unknown_bitrig.rs
+++ b/src/librustc_target/spec/x86_64_unknown_bitrig.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::bitrig_base::opts();

--- a/src/librustc_target/spec/x86_64_unknown_cloudabi.rs
+++ b/src/librustc_target/spec/x86_64_unknown_cloudabi.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::cloudabi_base::opts();

--- a/src/librustc_target/spec/x86_64_unknown_dragonfly.rs
+++ b/src/librustc_target/spec/x86_64_unknown_dragonfly.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::dragonfly_base::opts();

--- a/src/librustc_target/spec/x86_64_unknown_freebsd.rs
+++ b/src/librustc_target/spec/x86_64_unknown_freebsd.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::freebsd_base::opts();

--- a/src/librustc_target/spec/x86_64_unknown_haiku.rs
+++ b/src/librustc_target/spec/x86_64_unknown_haiku.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::haiku_base::opts();

--- a/src/librustc_target/spec/x86_64_unknown_hermit.rs
+++ b/src/librustc_target/spec/x86_64_unknown_hermit.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::hermit_base::opts();

--- a/src/librustc_target/spec/x86_64_unknown_l4re_uclibc.rs
+++ b/src/librustc_target/spec/x86_64_unknown_l4re_uclibc.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::l4re_base::opts();

--- a/src/librustc_target/spec/x86_64_unknown_linux_gnu.rs
+++ b/src/librustc_target/spec/x86_64_unknown_linux_gnu.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::linux_base::opts();

--- a/src/librustc_target/spec/x86_64_unknown_linux_gnux32.rs
+++ b/src/librustc_target/spec/x86_64_unknown_linux_gnux32.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::linux_base::opts();

--- a/src/librustc_target/spec/x86_64_unknown_linux_musl.rs
+++ b/src/librustc_target/spec/x86_64_unknown_linux_musl.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::linux_musl_base::opts();

--- a/src/librustc_target/spec/x86_64_unknown_netbsd.rs
+++ b/src/librustc_target/spec/x86_64_unknown_netbsd.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::netbsd_base::opts();

--- a/src/librustc_target/spec/x86_64_unknown_openbsd.rs
+++ b/src/librustc_target/spec/x86_64_unknown_openbsd.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::openbsd_base::opts();

--- a/src/librustc_target/spec/x86_64_unknown_redox.rs
+++ b/src/librustc_target/spec/x86_64_unknown_redox.rs
@@ -1,4 +1,4 @@
-use spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::redox_base::opts();

--- a/src/librustc_target/spec/x86_64_unknown_uefi.rs
+++ b/src/librustc_target/spec/x86_64_unknown_uefi.rs
@@ -5,7 +5,7 @@
 // The win64 ABI is used. It differs from the sysv64 ABI, so we must use a windows target with
 // LLVM. "x86_64-unknown-windows" is used to get the minimal subset of windows-specific features.
 
-use spec::{LinkerFlavor, LldFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, LldFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::uefi_base::opts();


### PR DESCRIPTION
Transitions `librustc_target` to Rust 2018; cc #58099

r? @Centril