### PR TITLE
librustc_codegen_utils => 2018

### DIFF
--- a/src/librustc_codegen_utils/Cargo.toml
+++ b/src/librustc_codegen_utils/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_codegen_utils"
 version = "0.0.0"
+edition = "2018"
 
 [lib]
 name = "rustc_codegen_utils"

--- a/src/librustc_codegen_utils/lib.rs
+++ b/src/librustc_codegen_utils/lib.rs
@@ -16,18 +16,10 @@
 
 #![recursion_limit="256"]
 
-extern crate flate2;
-#[macro_use]
-extern crate log;
+#![deny(rust_2018_idioms)]
 
 #[macro_use]
 extern crate rustc;
-extern crate rustc_target;
-extern crate rustc_metadata;
-extern crate rustc_mir;
-extern crate rustc_incremental;
-extern crate syntax;
-extern crate syntax_pos;
 #[macro_use] extern crate rustc_data_structures;
 
 use rustc::ty::TyCtxt;
@@ -42,7 +34,7 @@ pub mod symbol_names_test;
 /// error in codegen. This is used to write compile-fail tests
 /// that actually test that compilation succeeds without
 /// reporting an error.
-pub fn check_for_rustc_errors_attr(tcx: TyCtxt) {
+pub fn check_for_rustc_errors_attr(tcx: TyCtxt<'_, '_, '_>) {
     if let Some((def_id, _)) = tcx.entry_fn(LOCAL_CRATE) {
         if tcx.has_attr(def_id, "rustc_error") {
             tcx.sess.span_fatal(tcx.def_span(def_id), "compilation successful");

--- a/src/librustc_codegen_utils/link.rs
+++ b/src/librustc_codegen_utils/link.rs
@@ -41,7 +41,7 @@ pub fn find_crate_name(sess: Option<&Session>,
                        attrs: &[ast::Attribute],
                        input: &Input) -> String {
     let validate = |s: String, span: Option<Span>| {
-        ::rustc_metadata::validate_crate_name(sess, &s, span);
+        rustc_metadata::validate_crate_name(sess, &s, span);
         s
     };
 

--- a/src/librustc_codegen_utils/symbol_names.rs
+++ b/src/librustc_codegen_utils/symbol_names.rs
@@ -103,10 +103,12 @@ use rustc_mir::monomorphize::Instance;
 
 use syntax_pos::symbol::Symbol;
 
+use log::debug;
+
 use std::fmt::Write;
 use std::mem::discriminant;
 
-pub fn provide(providers: &mut Providers) {
+pub fn provide(providers: &mut Providers<'_>) {
     *providers = Providers {
         def_symbol_name,
         symbol_name,


### PR DESCRIPTION
Transitions `librustc_codegen_utils` to Rust 2018; cc #58099

r? @Centril