### PR TITLE
librustc_borrowck => 2018

### DIFF
--- a/src/librustc_borrowck/Cargo.toml
+++ b/src/librustc_borrowck/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_borrowck"
 version = "0.0.0"
+edition = "2018"
 
 [lib]
 name = "rustc_borrowck"
@@ -13,8 +14,10 @@ test = false
 log = "0.4"
 syntax = { path = "../libsyntax" }
 syntax_pos = { path = "../libsyntax_pos" }
-graphviz = { path = "../libgraphviz" }
+# for "clarity", rename the graphviz crate to dot; graphviz within `borrowck`
+# refers to the borrowck-specific graphviz adapter traits.
+dot = { path = "../libgraphviz", package = "graphviz" }
 rustc = { path = "../librustc" }
 rustc_mir = { path = "../librustc_mir" }
-rustc_errors = { path = "../librustc_errors" }
+errors = { path = "../librustc_errors", package = "rustc_errors" }
 rustc_data_structures = { path = "../librustc_data_structures" }

--- a/src/librustc_borrowck/borrowck/check_loans.rs
+++ b/src/librustc_borrowck/borrowck/check_loans.rs
@@ -7,10 +7,10 @@
 // 3. assignments do not affect things loaned out as immutable
 // 4. moves do not affect things loaned out in any way
 
-use self::UseError::*;
+use UseError::*;
 
-use borrowck::*;
-use borrowck::InteriorKind::{InteriorElement, InteriorField};
+use crate::borrowck::*;
+use crate::borrowck::InteriorKind::{InteriorElement, InteriorField};
 use rustc::middle::expr_use_visitor as euv;
 use rustc::middle::expr_use_visitor::MutateMode;
 use rustc::middle::mem_categorization as mc;
@@ -22,6 +22,7 @@ use syntax_pos::Span;
 use rustc::hir;
 use rustc::hir::Node;
 use rustc_mir::util::borrowck_errors::{BorrowckErrors, Origin};
+use log::debug;
 
 use std::rc::Rc;
 
@@ -101,7 +102,7 @@ impl<'a, 'tcx> euv::Delegate<'tcx> for CheckLoanCtxt<'a, 'tcx> {
 
     fn matched_pat(&mut self,
                    _matched_pat: &hir::Pat,
-                   _cmt: &mc::cmt_,
+                   _cmt: &mc::cmt_<'_>,
                    _mode: euv::MatchMode) { }
 
     fn consume_pat(&mut self,
@@ -910,7 +911,7 @@ impl<'a, 'tcx> CheckLoanCtxt<'a, 'tcx> {
     pub fn report_illegal_mutation(&self,
                                    span: Span,
                                    loan_path: &LoanPath<'tcx>,
-                                   loan: &Loan) {
+                                   loan: &Loan<'_>) {
         self.bccx.cannot_assign_to_borrowed(
             span, loan.span, &self.bccx.loan_path_to_string(loan_path), Origin::Ast)
             .emit();

--- a/src/librustc_borrowck/borrowck/gather_loans/gather_moves.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/gather_moves.rs
@@ -1,9 +1,9 @@
 //! Computes moves.
 
-use borrowck::*;
-use borrowck::gather_loans::move_error::MovePlace;
-use borrowck::gather_loans::move_error::{MoveError, MoveErrorCollector};
-use borrowck::move_data::*;
+use crate::borrowck::*;
+use crate::borrowck::gather_loans::move_error::MovePlace;
+use crate::borrowck::gather_loans::move_error::{MoveError, MoveErrorCollector};
+use crate::borrowck::move_data::*;
 use rustc::middle::expr_use_visitor as euv;
 use rustc::middle::mem_categorization as mc;
 use rustc::middle::mem_categorization::Categorization;
@@ -15,6 +15,7 @@ use syntax::ast;
 use syntax_pos::Span;
 use rustc::hir::*;
 use rustc::hir::Node;
+use log::debug;
 
 struct GatherMoveInfo<'c, 'tcx: 'c> {
     id: hir::ItemLocalId,

--- a/src/librustc_borrowck/borrowck/gather_loans/lifetime.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/lifetime.rs
@@ -1,7 +1,7 @@
 //! This module implements the check that the lifetime of a borrow
 //! does not exceed the lifetime of the value being borrowed.
 
-use borrowck::*;
+use crate::borrowck::*;
 use rustc::middle::expr_use_visitor as euv;
 use rustc::middle::mem_categorization as mc;
 use rustc::middle::mem_categorization::Categorization;
@@ -10,6 +10,7 @@ use rustc::ty;
 
 use syntax::ast;
 use syntax_pos::Span;
+use log::debug;
 
 type R = Result<(),()>;
 

--- a/src/librustc_borrowck/borrowck/gather_loans/mod.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/mod.rs
@@ -6,8 +6,8 @@
 // their associated scopes.  In phase two, checking loans, we will then make
 // sure that all of these loans are honored.
 
-use borrowck::*;
-use borrowck::move_data::MoveData;
+use crate::borrowck::*;
+use crate::borrowck::move_data::MoveData;
 use rustc::middle::expr_use_visitor as euv;
 use rustc::middle::mem_categorization as mc;
 use rustc::middle::mem_categorization::Categorization;
@@ -17,8 +17,9 @@ use rustc::ty::{self, TyCtxt};
 use syntax::ast;
 use syntax_pos::Span;
 use rustc::hir;
+use log::debug;
 
-use self::restrictions::RestrictionResult;
+use restrictions::RestrictionResult;
 
 mod lifetime;
 mod restrictions;
@@ -427,7 +428,7 @@ impl<'a, 'tcx> GatherLoanCtxt<'a, 'tcx> {
         // }
     }
 
-    pub fn mark_loan_path_as_mutated(&self, loan_path: &LoanPath) {
+    pub fn mark_loan_path_as_mutated(&self, loan_path: &LoanPath<'_>) {
         //! For mutable loans of content whose mutability derives
         //! from a local variable, mark the mutability decl as necessary.
 

--- a/src/librustc_borrowck/borrowck/gather_loans/move_error.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/move_error.rs
@@ -1,4 +1,4 @@
-use borrowck::BorrowckCtxt;
+use crate::borrowck::BorrowckCtxt;
 use rustc::middle::mem_categorization as mc;
 use rustc::middle::mem_categorization::Categorization;
 use rustc::middle::mem_categorization::NoteClosureEnv;
@@ -8,7 +8,8 @@ use rustc_mir::util::borrowck_errors::{BorrowckErrors, Origin};
 use syntax::ast;
 use syntax_pos;
 use errors::{DiagnosticBuilder, Applicability};
-use borrowck::gather_loans::gather_moves::PatternSource;
+use crate::borrowck::gather_loans::gather_moves::PatternSource;
+use log::debug;
 
 pub struct MoveErrorCollector<'tcx> {
     errors: Vec<MoveError<'tcx>>
@@ -167,10 +168,10 @@ fn report_cannot_move_out_of<'a, 'tcx>(bccx: &'a BorrowckCtxt<'a, 'tcx>,
     }
 }
 
-fn note_move_destination(mut err: DiagnosticBuilder,
+fn note_move_destination(mut err: DiagnosticBuilder<'_>,
                          move_to_span: syntax_pos::Span,
                          pat_name: ast::Name,
-                         is_first_note: bool) -> DiagnosticBuilder {
+                         is_first_note: bool) -> DiagnosticBuilder<'_> {
     if is_first_note {
         err.span_label(
             move_to_span,

--- a/src/librustc_borrowck/borrowck/gather_loans/restrictions.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/restrictions.rs
@@ -1,13 +1,14 @@
 //! Computes the restrictions that result from a borrow.
 
-use borrowck::*;
+use crate::borrowck::*;
 use rustc::middle::expr_use_visitor as euv;
 use rustc::middle::mem_categorization as mc;
 use rustc::middle::mem_categorization::Categorization;
 use rustc::ty;
 use syntax_pos::Span;
+use log::debug;
 
-use borrowck::ToInteriorKind;
+use crate::borrowck::ToInteriorKind;
 
 use std::rc::Rc;
 

--- a/src/librustc_borrowck/borrowck/move_data.rs
+++ b/src/librustc_borrowck/borrowck/move_data.rs
@@ -1,11 +1,11 @@
 //! Data structures used for tracking moves. Please see the extensive
 //! comments in the section "Moves and initialization" in `README.md`.
 
-pub use self::MoveKind::*;
+pub use MoveKind::*;
 
-use dataflow::{DataFlowContext, BitwiseOperator, DataFlowOperator, KillFrom};
+use crate::dataflow::{DataFlowContext, BitwiseOperator, DataFlowOperator, KillFrom};
 
-use borrowck::*;
+use crate::borrowck::*;
 use rustc::cfg;
 use rustc::ty::{self, TyCtxt};
 use rustc::util::nodemap::FxHashMap;
@@ -15,6 +15,7 @@ use std::rc::Rc;
 use std::usize;
 use syntax_pos::Span;
 use rustc::hir;
+use log::debug;
 
 #[derive(Default)]
 pub struct MoveData<'tcx> {
@@ -145,7 +146,7 @@ pub struct AssignDataFlowOperator;
 
 pub type AssignDataFlow<'a, 'tcx> = DataFlowContext<'a, 'tcx, AssignDataFlowOperator>;
 
-fn loan_path_is_precise(loan_path: &LoanPath) -> bool {
+fn loan_path_is_precise(loan_path: &LoanPath<'_>) -> bool {
     match loan_path.kind {
         LpVar(_) | LpUpvar(_) => {
             true
@@ -428,8 +429,8 @@ impl<'a, 'tcx> MoveData<'tcx> {
     /// killed by scoping. See `README.md` for more details.
     fn add_gen_kills(&self,
                      bccx: &BorrowckCtxt<'a, 'tcx>,
-                     dfcx_moves: &mut MoveDataFlow,
-                     dfcx_assign: &mut AssignDataFlow) {
+                     dfcx_moves: &mut MoveDataFlow<'_, '_>,
+                     dfcx_assign: &mut AssignDataFlow<'_, '_>) {
         for (i, the_move) in self.moves.borrow().iter().enumerate() {
             dfcx_moves.add_gen(the_move.id, i);
         }
@@ -537,7 +538,7 @@ impl<'a, 'tcx> MoveData<'tcx> {
                   path: MovePathIndex,
                   kill_id: hir::ItemLocalId,
                   kill_kind: KillFrom,
-                  dfcx_moves: &mut MoveDataFlow) {
+                  dfcx_moves: &mut MoveDataFlow<'_, '_>) {
         // We can only perform kills for paths that refer to a unique location,
         // since otherwise we may kill a move from one location with an
         // assignment referring to another location.

--- a/src/librustc_borrowck/borrowck/unused.rs
+++ b/src/librustc_borrowck/borrowck/unused.rs
@@ -7,7 +7,7 @@ use errors::Applicability;
 use std::slice;
 use syntax::ptr::P;
 
-use borrowck::BorrowckCtxt;
+use crate::borrowck::BorrowckCtxt;
 
 pub fn check<'a, 'tcx>(bccx: &BorrowckCtxt<'a, 'tcx>, body: &'tcx hir::Body) {
     let mut used_mut = bccx.used_mut_nodes.borrow().clone();

--- a/src/librustc_borrowck/dataflow.rs
+++ b/src/librustc_borrowck/dataflow.rs
@@ -10,6 +10,7 @@ use std::io;
 use std::mem;
 use std::usize;
 use syntax::print::pprust::PrintState;
+use log::debug;
 
 use rustc_data_structures::graph::implementation::OUTGOING;
 
@@ -80,7 +81,7 @@ pub trait DataFlowOperator : BitwiseOperator {
     fn initial_value(&self) -> bool;
 }
 
-struct PropagationContext<'a, 'b: 'a, 'tcx: 'b, O: 'a> {
+struct PropagationContext<'a, 'b: 'a, 'tcx: 'b, O> {
     dfcx: &'a mut DataFlowContext<'b, 'tcx, O>,
     changed: bool
 }
@@ -99,12 +100,12 @@ impl<'a, 'tcx, O:DataFlowOperator> DataFlowContext<'a, 'tcx, O> {
 }
 
 impl<'a, 'tcx, O:DataFlowOperator> pprust::PpAnn for DataFlowContext<'a, 'tcx, O> {
-    fn nested(&self, state: &mut pprust::State, nested: pprust::Nested) -> io::Result<()> {
+    fn nested(&self, state: &mut pprust::State<'_>, nested: pprust::Nested) -> io::Result<()> {
         pprust::PpAnn::nested(self.tcx.hir(), state, nested)
     }
     fn pre(&self,
-           ps: &mut pprust::State,
-           node: pprust::AnnNode) -> io::Result<()> {
+           ps: &mut pprust::State<'_>,
+           node: pprust::AnnNode<'_>) -> io::Result<()> {
         let id = match node {
             pprust::AnnNode::Name(_) => return Ok(()),
             pprust::AnnNode::Expr(expr) => expr.hir_id.local_id,

--- a/src/librustc_borrowck/graphviz.rs
+++ b/src/librustc_borrowck/graphviz.rs
@@ -2,16 +2,15 @@
 //! libgraphviz traits, specialized to attaching borrowck analysis
 //! data to rendered labels.
 
-pub use self::Variant::*;
+pub use Variant::*;
 
 pub use rustc::cfg::graphviz::{Node, Edge};
 use rustc::cfg::graphviz as cfg_dot;
 
-use borrowck;
-use borrowck::{BorrowckCtxt, LoanPath};
-use dot;
+use crate::borrowck::{self, BorrowckCtxt, LoanPath};
+use crate::dataflow::{DataFlowOperator, DataFlowContext, EntryOrExit};
+use log::debug;
 use rustc::cfg::CFGIndex;
-use dataflow::{DataFlowOperator, DataFlowContext, EntryOrExit};
 use std::rc::Rc;
 
 #[derive(Debug, Copy, Clone)]
@@ -53,7 +52,7 @@ impl<'a, 'tcx> DataflowLabeller<'a, 'tcx> {
         sets
     }
 
-    fn dataflow_for_variant(&self, e: EntryOrExit, n: &Node, v: Variant) -> String {
+    fn dataflow_for_variant(&self, e: EntryOrExit, n: &Node<'_>, v: Variant) -> String {
         let cfgidx = n.0;
         match v {
             Loans   => self.dataflow_loans_for(e, cfgidx),
@@ -89,7 +88,7 @@ impl<'a, 'tcx> DataflowLabeller<'a, 'tcx> {
         let dfcx = &self.analysis_data.loans;
         let loan_index_to_path = |loan_index| {
             let all_loans = &self.analysis_data.all_loans;
-            let l: &borrowck::Loan = &all_loans[loan_index];
+            let l: &borrowck::Loan<'_> = &all_loans[loan_index];
             l.loan_path()
         };
         self.build_set(e, cfgidx, dfcx, loan_index_to_path)

--- a/src/librustc_borrowck/lib.rs
+++ b/src/librustc_borrowck/lib.rs
@@ -3,23 +3,14 @@
       html_root_url = "https://doc.rust-lang.org/nightly/")]
 
 #![allow(non_camel_case_types)]
+#![deny(rust_2018_idioms)]
 
 #![feature(nll)]
 
 #![recursion_limit="256"]
 
-#[macro_use] extern crate log;
-extern crate syntax;
-extern crate syntax_pos;
-extern crate rustc_errors as errors;
-extern crate rustc_data_structures;
-
-// for "clarity", rename the graphviz crate to dot; graphviz within `borrowck`
-// refers to the borrowck-specific graphviz adapter traits.
-extern crate graphviz as dot;
 #[macro_use]
 extern crate rustc;
-extern crate rustc_mir;
 
 pub use borrowck::check_crate;
 pub use borrowck::build_borrowck_dataflow_data_for_fn;


### PR DESCRIPTION
Transitions `librustc_borrowck` to Rust 2018; cc #58099

r? @Centril