### PR TITLE
Rollup of 11 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1407,7 +1407,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "minifier"
-version = "0.0.26"
+version = "0.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "macro-utils 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2853,7 +2853,7 @@ dependencies = [
 name = "rustdoc"
 version = "0.0.0"
 dependencies = [
- "minifier 0.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "minifier 0.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "pulldown-cmark 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3890,7 +3890,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum memchr 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0a3eb002f0535929f1199681417029ebea04aadc0c7a4224b46be99c7f5d6a16"
 "checksum memmap 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e2ffa2c986de11a9df78620c01eeaaf27d94d3ff02bf81bfcca953102dd0c6ff"
 "checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
-"checksum minifier 0.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "f299df45afd73332044ea9f717c816a84fc90c8b631409abf339ba93642a7985"
+"checksum minifier 0.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "3a2898502751dcc9d66b6fff57f3cf63cc91605e83e1a33515396f5027f8e4ca"
 "checksum miniz-sys 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "0300eafb20369952951699b68243ab4334f4b10a88f411c221d444b36c40e649"
 "checksum miniz_oxide 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5ad30a47319c16cde58d0314f5d98202a80c9083b5f61178457403dfb14e509c"
 "checksum miniz_oxide_c_api 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "28edaef377517fd9fe3e085c37d892ce7acd1fbeab9239c5a36eec352d8a8b7e"

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -55,9 +55,7 @@
             reason = "this library is unlikely to be stabilized in its current \
                       form or name",
             issue = "27783")]
-#![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/",
+#![doc(html_root_url = "https://doc.rust-lang.org/nightly/",
        issue_tracker_base_url = "https://github.com/rust-lang/rust/issues/",
        test(no_crate_inject, attr(allow(unused_variables), deny(warnings))))]
 #![no_std]

--- a/src/libarena/lib.rs
+++ b/src/libarena/lib.rs
@@ -8,9 +8,7 @@
 //! This crate implements `TypedArena`, a simple arena that can only hold
 //! objects of a single type.
 
-#![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/",
+#![doc(html_root_url = "https://doc.rust-lang.org/nightly/",
        test(no_crate_inject, attr(deny(warnings))))]
 
 #![feature(alloc)]

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -729,6 +729,10 @@ extern "rust-intrinsic" {
     /// cause [undefined behavior][ub] with this function. `transmute` should be
     /// the absolute last resort.
     ///
+    /// `transmute` is re-exported by [core::mem](../mem/index.html) as
+    /// `core::mem::transmute`, which may be used without the `core_intrinsics`
+    /// feature flag.
+    ///
     /// The [nomicon](../../nomicon/transmutes.html) has additional
     /// documentation.
     ///

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -729,10 +729,6 @@ extern "rust-intrinsic" {
     /// cause [undefined behavior][ub] with this function. `transmute` should be
     /// the absolute last resort.
     ///
-    /// `transmute` is re-exported by [core::mem](../mem/index.html) as
-    /// `core::mem::transmute`, which may be used without the `core_intrinsics`
-    /// feature flag.
-    ///
     /// The [nomicon](../../nomicon/transmutes.html) has additional
     /// documentation.
     ///

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -51,9 +51,7 @@
 #![cfg(not(test))]
 
 #![stable(feature = "core", since = "1.6.0")]
-#![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/",
+#![doc(html_root_url = "https://doc.rust-lang.org/nightly/",
        html_playground_url = "https://play.rust-lang.org/",
        issue_tracker_base_url = "https://github.com/rust-lang/rust/issues/",
        test(no_crate_inject, attr(deny(warnings))),

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -15,6 +15,7 @@ use ptr;
 use ops::{Deref, DerefMut};
 
 #[stable(feature = "rust1", since = "1.0.0")]
+#[doc(inline)]
 pub use intrinsics::transmute;
 
 /// Takes ownership and "forgets" about the value **without running its destructor**.

--- a/src/libfmt_macros/lib.rs
+++ b/src/libfmt_macros/lib.rs
@@ -4,9 +4,7 @@
 //! Parsing does not happen at runtime: structures of `std::fmt::rt` are
 //! generated instead.
 
-#![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/",
+#![doc(html_root_url = "https://doc.rust-lang.org/nightly/",
        html_playground_url = "https://play.rust-lang.org/",
        test(attr(deny(warnings))))]
 

--- a/src/libgraphviz/lib.rs
+++ b/src/libgraphviz/lib.rs
@@ -271,9 +271,7 @@
 //!
 //! * [DOT language](http://www.graphviz.org/doc/info/lang.html)
 
-#![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/",
+#![doc(html_root_url = "https://doc.rust-lang.org/nightly/",
        test(attr(allow(unused_variables), deny(warnings))))]
 
 #![deny(rust_2018_idioms)]

--- a/src/libpanic_abort/lib.rs
+++ b/src/libpanic_abort/lib.rs
@@ -5,9 +5,7 @@
 
 #![no_std]
 #![unstable(feature = "panic_abort", issue = "32837")]
-#![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/",
+#![doc(html_root_url = "https://doc.rust-lang.org/nightly/",
        issue_tracker_base_url = "https://github.com/rust-lang/rust/issues/")]
 #![panic_runtime]
 

--- a/src/libpanic_unwind/lib.rs
+++ b/src/libpanic_unwind/lib.rs
@@ -14,9 +14,7 @@
 
 #![no_std]
 #![unstable(feature = "panic_unwind", issue = "32837")]
-#![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/",
+#![doc(html_root_url = "https://doc.rust-lang.org/nightly/",
        issue_tracker_base_url = "https://github.com/rust-lang/rust/issues/")]
 
 #![feature(allocator_api)]

--- a/src/libproc_macro/lib.rs
+++ b/src/libproc_macro/lib.rs
@@ -9,9 +9,7 @@
 
 #![stable(feature = "proc_macro_lib", since = "1.15.0")]
 #![deny(missing_docs)]
-#![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/",
+#![doc(html_root_url = "https://doc.rust-lang.org/nightly/",
        html_playground_url = "https://play.rust-lang.org/",
        issue_tracker_base_url = "https://github.com/rust-lang/rust/issues/",
        test(no_crate_inject, attr(deny(warnings))),

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -26,9 +26,7 @@
 //!
 //! This API is completely unstable and subject to change.
 
-#![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/")]
+#![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
 
 #![deny(rust_2018_idioms)]
 #![allow(explicit_outlives_requirements)]

--- a/src/librustc_apfloat/lib.rs
+++ b/src/librustc_apfloat/lib.rs
@@ -30,9 +30,7 @@
 //!
 //! This API is completely unstable and subject to change.
 
-#![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-      html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-      html_root_url = "https://doc.rust-lang.org/nightly/")]
+#![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
 #![forbid(unsafe_code)]
 #![deny(rust_2018_idioms)]
 

--- a/src/librustc_borrowck/lib.rs
+++ b/src/librustc_borrowck/lib.rs
@@ -1,6 +1,4 @@
-#![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-      html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-      html_root_url = "https://doc.rust-lang.org/nightly/")]
+#![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
 
 #![allow(non_camel_case_types)]
 

--- a/src/librustc_codegen_llvm/lib.rs
+++ b/src/librustc_codegen_llvm/lib.rs
@@ -4,9 +4,7 @@
 //!
 //! This API is completely unstable and subject to change.
 
-#![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-      html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-      html_root_url = "https://doc.rust-lang.org/nightly/")]
+#![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
 
 #![feature(box_patterns)]
 #![feature(box_syntax)]

--- a/src/librustc_codegen_ssa/lib.rs
+++ b/src/librustc_codegen_ssa/lib.rs
@@ -1,6 +1,4 @@
-#![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-      html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-      html_root_url = "https://doc.rust-lang.org/nightly/")]
+#![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
 
 #![feature(box_patterns)]
 #![feature(box_syntax)]

--- a/src/librustc_codegen_utils/codegen_backend.rs
+++ b/src/librustc_codegen_utils/codegen_backend.rs
@@ -4,9 +4,7 @@
 //!
 //! This API is completely unstable and subject to change.
 
-#![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-      html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-      html_root_url = "https://doc.rust-lang.org/nightly/")]
+#![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
 #![deny(warnings)]
 
 #![feature(box_syntax)]

--- a/src/librustc_codegen_utils/lib.rs
+++ b/src/librustc_codegen_utils/lib.rs
@@ -2,9 +2,7 @@
 //!
 //! This API is completely unstable and subject to change.
 
-#![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-      html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-      html_root_url = "https://doc.rust-lang.org/nightly/")]
+#![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
 
 #![feature(box_patterns)]
 #![feature(box_syntax)]

--- a/src/librustc_data_structures/lib.rs
+++ b/src/librustc_data_structures/lib.rs
@@ -6,9 +6,7 @@
 //!
 //! This API is completely unstable and subject to change.
 
-#![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-      html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-      html_root_url = "https://doc.rust-lang.org/nightly/")]
+#![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
 
 #![feature(in_band_lifetimes)]
 #![feature(unboxed_closures)]

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -4,9 +4,7 @@
 //!
 //! This API is completely unstable and subject to change.
 
-#![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-      html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-      html_root_url = "https://doc.rust-lang.org/nightly/")]
+#![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
 
 #![feature(box_syntax)]
 #![cfg_attr(unix, feature(libc))]

--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -1,6 +1,4 @@
-#![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-      html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-      html_root_url = "https://doc.rust-lang.org/nightly/")]
+#![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
 
 #![feature(custom_attribute)]
 #![allow(unused_attributes)]

--- a/src/librustc_incremental/lib.rs
+++ b/src/librustc_incremental/lib.rs
@@ -1,8 +1,6 @@
 //! Support for serializing the dep-graph and reloading it.
 
-#![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-      html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-      html_root_url = "https://doc.rust-lang.org/nightly/")]
+#![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
 
 #![feature(nll)]
 #![feature(specialization)]

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -9,9 +9,7 @@
 //!
 //! This API is completely unstable and subject to change.
 
-#![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-      html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-      html_root_url = "https://doc.rust-lang.org/nightly/")]
+#![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
 
 #![cfg_attr(test, feature(test))]
 #![feature(box_patterns)]

--- a/src/librustc_llvm/lib.rs
+++ b/src/librustc_llvm/lib.rs
@@ -1,9 +1,7 @@
 #![deny(rust_2018_idioms)]
 #![feature(static_nobundle)]
 
-#![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/")]
+#![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
 
 // See librustc_cratesio_shim/Cargo.toml for a comment explaining this.
 #[allow(unused_extern_crates)]

--- a/src/librustc_metadata/lib.rs
+++ b/src/librustc_metadata/lib.rs
@@ -1,6 +1,4 @@
-#![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/")]
+#![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
 
 #![feature(box_patterns)]
 #![feature(libc)]

--- a/src/librustc_passes/lib.rs
+++ b/src/librustc_passes/lib.rs
@@ -4,9 +4,7 @@
 //!
 //! This API is completely unstable and subject to change.
 
-#![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/")]
+#![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
 
 #![feature(nll)]
 #![feature(rustc_diagnostic_macros)]

--- a/src/librustc_plugin/lib.rs
+++ b/src/librustc_plugin/lib.rs
@@ -50,9 +50,7 @@
 //! See the [`plugin` feature](../unstable-book/language-features/plugin.html) of
 //! the Unstable Book for more examples.
 
-#![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/")]
+#![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
 
 #![feature(rustc_diagnostic_macros)]
 

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -1,6 +1,4 @@
-#![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/")]
+#![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
 
 #![deny(rust_2018_idioms)]
 

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -1,6 +1,4 @@
-#![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/")]
+#![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
 
 #![feature(crate_visibility_modifier)]
 #![feature(label_break_value)]

--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -1,6 +1,4 @@
-#![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/")]
+#![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
 #![feature(custom_attribute)]
 #![feature(nll)]
 #![allow(unused_attributes)]

--- a/src/librustc_target/lib.rs
+++ b/src/librustc_target/lib.rs
@@ -7,9 +7,7 @@
 //! more 'stuff' here in the future.  It does not have a dependency on
 //! LLVM.
 
-#![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-      html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-      html_root_url = "https://doc.rust-lang.org/nightly/")]
+#![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
 
 #![feature(box_syntax)]
 #![feature(nll)]

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -55,9 +55,7 @@ This API is completely unstable and subject to change.
 
 */
 
-#![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-      html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-      html_root_url = "https://doc.rust-lang.org/nightly/")]
+#![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
 
 #![allow(non_camel_case_types)]
 

--- a/src/librustdoc/Cargo.toml
+++ b/src/librustdoc/Cargo.toml
@@ -9,6 +9,6 @@ path = "lib.rs"
 
 [dependencies]
 pulldown-cmark = { version = "0.1.2", default-features = false }
-minifier = "0.0.26"
+minifier = "0.0.28"
 tempfile = "3"
 parking_lot = "0.6.4"

--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -4,6 +4,8 @@ use std::path::PathBuf;
 
 use externalfiles::ExternalHtml;
 
+use html::render::SlashChecker;
+
 #[derive(Clone)]
 pub struct Layout {
     pub logo: String,
@@ -176,16 +178,22 @@ pub fn render<T: fmt::Display, S: fmt::Display>(
     static_root_path = static_root_path,
     root_path = page.root_path,
     css_class = page.css_class,
-    logo      = if layout.logo.is_empty() {
-        format!("<a href='{}{}/index.html'>\
-                 <img src='{static_root_path}rust-logo{suffix}.png' alt='logo' width='100'></a>",
-                static_root_path=static_root_path,
-                suffix=page.resource_suffix)
-    } else {
-        format!("<a href='{}{}/index.html'>\
-                 <img src='{}' alt='logo' width='100'></a>",
-                page.root_path, layout.krate,
-                layout.logo)
+    logo      = {
+        let p = format!("{}{}", page.root_path, layout.krate);
+        let p = SlashChecker(&p);
+        if layout.logo.is_empty() {
+            format!("<a href='{path}index.html'>\
+                     <img src='{static_root_path}rust-logo{suffix}.png' \
+                          alt='logo' width='100'></a>",
+                    path=p,
+                    static_root_path=static_root_path,
+                    suffix=page.resource_suffix)
+        } else {
+            format!("<a href='{}index.html'>\
+                     <img src='{}' alt='logo' width='100'></a>",
+                    p,
+                    layout.logo)
+        }
     },
     title     = page.title,
     description = page.description,

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -3483,10 +3483,6 @@ fn item_struct(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
                        ns_id = ns_id,
                        name = field.name.as_ref().unwrap(),
                        ty = ty)?;
-                if let Some(stability_class) = field.stability_class() {
-                    write!(w, "<span class='stab {stab}'></span>",
-                        stab = stability_class)?;
-                }
                 document(w, cx, field)?;
             }
         }

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -73,6 +73,18 @@ use minifier;
 /// A pair of name and its optional document.
 pub type NameDoc = (String, Option<String>);
 
+pub struct SlashChecker<'a>(pub &'a str);
+
+impl<'a> Display for SlashChecker<'a> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        if !self.0.ends_with("/") && !self.0.is_empty() {
+            write!(f, "{}/", self.0)
+        } else {
+            write!(f, "{}", self.0)
+        }
+    }
+}
+
 /// Major driving force in all rustdoc rendering. This contains information
 /// about where in the tree-like hierarchy rendering is occurring and controls
 /// how the current page is being rendered.
@@ -1140,7 +1152,8 @@ themePicker.onblur = handleThemeButtonsBlur;
                                   krates
                                     .iter()
                                     .map(|s| {
-                                        format!("<li><a href=\"{}/index.html\">{}</li>", s, s)
+                                        format!("<li><a href=\"{}index.html\">{}</li>",
+                                                SlashChecker(s), s)
                                     })
                                     .collect::<String>());
             try_err!(layout::render(&mut w, &cx.shared.layout,
@@ -2074,8 +2087,7 @@ impl Context {
         let mut themes = self.shared.themes.clone();
         let sidebar = "<p class='location'>Settings</p><div class='sidebar-elems'></div>";
         themes.push(PathBuf::from("settings.css"));
-        let mut layout = self.shared.layout.clone();
-        layout.krate = String::new();
+        let layout = self.shared.layout.clone();
         try_err!(layout::render(&mut w, &layout,
                                 &page, &sidebar, &settings,
                                 self.shared.css_file_extension.is_some(),
@@ -2454,7 +2466,7 @@ impl<'a> fmt::Display for Item<'a> {
 
 fn item_path(ty: ItemType, name: &str) -> String {
     match ty {
-        ItemType::Module => format!("{}/index.html", name),
+        ItemType::Module => format!("{}index.html", SlashChecker(name)),
         _ => format!("{}.{}.html", ty.css_class(), name),
     }
 }

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -939,7 +939,7 @@ themePicker.onblur = handleThemeButtonsBlur;
         if path.exists() {
             for line in BufReader::new(File::open(path)?).lines() {
                 let line = line?;
-                if for_search_index && line.starts_with("var r_") {
+                if for_search_index && line.starts_with("var R") {
                     variables.push(line.clone());
                     // We need to check if the crate name has been put into a variable as well.
                     let tokens = js::simple_minify(&line).apply(js::clean_tokens);
@@ -1299,8 +1299,9 @@ fn write_minify_replacer<W: Write>(
                               })
                               .apply(|f| {
                                   // We add a backline after the newly created variables.
-                                  minifier::js::aggregate_strings_with_separation(
+                                  minifier::js::aggregate_strings_into_array_with_separation(
                                       f,
+                                      "R",
                                       Token::Char(ReservedChar::Backline),
                                   )
                               })

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -4470,15 +4470,17 @@ fn sidebar_assoc_items(it: &clean::Item) -> String {
 
         {
             let used_links_bor = Rc::new(RefCell::new(&mut used_links));
-            let ret = v.iter()
-                       .filter(|i| i.inner_impl().trait_.is_none())
-                       .flat_map(move |i| get_methods(i.inner_impl(),
-                                                      false,
-                                                      &mut used_links_bor.borrow_mut()))
-                       .collect::<String>();
+            let mut ret = v.iter()
+                           .filter(|i| i.inner_impl().trait_.is_none())
+                           .flat_map(move |i| get_methods(i.inner_impl(),
+                                                          false,
+                                                          &mut used_links_bor.borrow_mut()))
+                           .collect::<Vec<_>>();
+            // We want links' order to be reproducible so we don't use unstable sort.
+            ret.sort();
             if !ret.is_empty() {
                 out.push_str(&format!("<a class=\"sidebar-title\" href=\"#methods\">Methods\
-                                       </a><div class=\"sidebar-links\">{}</div>", ret));
+                                       </a><div class=\"sidebar-links\">{}</div>", ret.join("")));
             }
         }
 
@@ -4502,40 +4504,47 @@ fn sidebar_assoc_items(it: &clean::Item) -> String {
                                                      impl_.inner_impl().trait_.as_ref().unwrap())),
                                               Escape(&format!("{:#}", target))));
                         out.push_str("</a>");
-                        let ret = impls.iter()
-                                       .filter(|i| i.inner_impl().trait_.is_none())
-                                       .flat_map(|i| get_methods(i.inner_impl(),
-                                                                 true,
-                                                                 &mut used_links))
-                                       .collect::<String>();
-                        out.push_str(&format!("<div class=\"sidebar-links\">{}</div>", ret));
+                        let mut ret = impls.iter()
+                                           .filter(|i| i.inner_impl().trait_.is_none())
+                                           .flat_map(|i| get_methods(i.inner_impl(),
+                                                                     true,
+                                                                     &mut used_links))
+                                           .collect::<Vec<_>>();
+                        // We want links' order to be reproducible so we don't use unstable sort.
+                        ret.sort();
+                        if !ret.is_empty() {
+                            out.push_str(&format!("<div class=\"sidebar-links\">{}</div>",
+                                                  ret.join("")));
+                        }
                     }
                 }
             }
             let format_impls = |impls: Vec<&Impl>| {
                 let mut links = FxHashSet::default();
 
-                impls.iter()
-                     .filter_map(|i| {
-                         let is_negative_impl = is_negative_impl(i.inner_impl());
-                         if let Some(ref i) = i.inner_impl().trait_ {
-                             let i_display = format!("{:#}", i);
-                             let out = Escape(&i_display);
-                             let encoded = small_url_encode(&format!("{:#}", i));
-                             let generated = format!("<a href=\"#impl-{}\">{}{}</a>",
-                                                     encoded,
-                                                     if is_negative_impl { "!" } else { "" },
-                                                     out);
-                             if links.insert(generated.clone()) {
-                                 Some(generated)
-                             } else {
-                                 None
-                             }
-                         } else {
-                             None
-                         }
-                     })
-                     .collect::<String>()
+                let mut ret = impls.iter()
+                    .filter_map(|i| {
+                        let is_negative_impl = is_negative_impl(i.inner_impl());
+                        if let Some(ref i) = i.inner_impl().trait_ {
+                            let i_display = format!("{:#}", i);
+                            let out = Escape(&i_display);
+                            let encoded = small_url_encode(&format!("{:#}", i));
+                            let generated = format!("<a href=\"#impl-{}\">{}{}</a>",
+                                                    encoded,
+                                                    if is_negative_impl { "!" } else { "" },
+                                                    out);
+                            if links.insert(generated.clone()) {
+                                Some(generated)
+                            } else {
+                                None
+                            }
+                        } else {
+                            None
+                        }
+                    })
+                    .collect::<Vec<String>>();
+                ret.sort();
+                ret.join("")
             };
 
             let (synthetic, concrete): (Vec<&Impl>, Vec<&Impl>) = v
@@ -4637,29 +4646,29 @@ fn sidebar_trait(fmt: &mut fmt::Formatter, it: &clean::Item,
                       }
                   })
                   .collect::<String>();
-    let required = t.items
-                    .iter()
-                    .filter_map(|m| {
-                        match m.name {
-                            Some(ref name) if m.is_ty_method() => {
-                                Some(format!("<a href=\"#tymethod.{name}\">{name}</a>",
-                                             name=name))
+    let mut required = t.items
+                        .iter()
+                        .filter_map(|m| {
+                            match m.name {
+                                Some(ref name) if m.is_ty_method() => {
+                                    Some(format!("<a href=\"#tymethod.{name}\">{name}</a>",
+                                                 name=name))
+                                }
+                                _ => None,
                             }
-                            _ => None,
-                        }
-                    })
-                    .collect::<String>();
-    let provided = t.items
-                    .iter()
-                    .filter_map(|m| {
-                        match m.name {
-                            Some(ref name) if m.is_method() => {
-                                Some(format!("<a href=\"#method.{name}\">{name}</a>", name=name))
+                        })
+                        .collect::<Vec<String>>();
+    let mut provided = t.items
+                        .iter()
+                        .filter_map(|m| {
+                            match m.name {
+                                Some(ref name) if m.is_method() => {
+                                    Some(format!("<a href=\"#method.{0}\">{0}</a>", name))
+                                }
+                                _ => None,
                             }
-                            _ => None,
-                        }
-                    })
-                    .collect::<String>();
+                        })
+                        .collect::<Vec<String>>();
 
     if !types.is_empty() {
         sidebar.push_str(&format!("<a class=\"sidebar-title\" href=\"#associated-types\">\
@@ -4672,38 +4681,41 @@ fn sidebar_trait(fmt: &mut fmt::Formatter, it: &clean::Item,
                                   consts));
     }
     if !required.is_empty() {
+        required.sort();
         sidebar.push_str(&format!("<a class=\"sidebar-title\" href=\"#required-methods\">\
                                    Required Methods</a><div class=\"sidebar-links\">{}</div>",
-                                  required));
+                                  required.join("")));
     }
     if !provided.is_empty() {
+        provided.sort();
         sidebar.push_str(&format!("<a class=\"sidebar-title\" href=\"#provided-methods\">\
                                    Provided Methods</a><div class=\"sidebar-links\">{}</div>",
-                                  provided));
+                                  provided.join("")));
     }
 
     let c = cache();
 
     if let Some(implementors) = c.implementors.get(&it.def_id) {
-        let res = implementors.iter()
-                              .filter(|i| i.inner_impl().for_.def_id()
-                              .map_or(false, |d| !c.paths.contains_key(&d)))
-                              .filter_map(|i| {
-                                  match extract_for_impl_name(&i.impl_item) {
-                                      Some((ref name, ref url)) => {
-                                          Some(format!("<a href=\"#impl-{}\">{}</a>",
-                                                      small_url_encode(url),
-                                                      Escape(name)))
+        let mut res = implementors.iter()
+                                  .filter(|i| i.inner_impl().for_.def_id()
+                                  .map_or(false, |d| !c.paths.contains_key(&d)))
+                                  .filter_map(|i| {
+                                      match extract_for_impl_name(&i.impl_item) {
+                                          Some((ref name, ref url)) => {
+                                              Some(format!("<a href=\"#impl-{}\">{}</a>",
+                                                          small_url_encode(url),
+                                                          Escape(name)))
+                                          }
+                                          _ => None,
                                       }
-                                      _ => None,
-                                  }
-                              })
-                              .collect::<String>();
+                                  })
+                                  .collect::<Vec<String>>();
         if !res.is_empty() {
+            res.sort();
             sidebar.push_str(&format!("<a class=\"sidebar-title\" href=\"#foreign-impls\">\
                                        Implementations on Foreign Types</a><div \
                                        class=\"sidebar-links\">{}</div>",
-                                      res));
+                                      res.join("")));
         }
     }
 

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -2798,9 +2798,13 @@ fn item_module(w: &mut fmt::Formatter, cx: &Context,
 fn stability_tags(item: &clean::Item) -> String {
     let mut tags = String::new();
 
+    fn tag_html(class: &str, contents: &str) -> String {
+        format!(r#"<span class="stab {}">{}</span>"#, class, contents)
+    }
+
     // The trailing space after each tag is to space it properly against the rest of the docs.
     if item.deprecation().is_some() {
-        tags.push_str("[<div class='stab deprecated'>Deprecated</div>] ");
+        tags += &tag_html("deprecated", "Deprecated");
     }
 
     if let Some(stab) = item
@@ -2809,17 +2813,14 @@ fn stability_tags(item: &clean::Item) -> String {
         .filter(|s| s.level == stability::Unstable)
     {
         if stab.feature.as_ref().map(|s| &**s) == Some("rustc_private") {
-            tags.push_str("[<div class='stab internal'>Internal</div>] ");
+            tags += &tag_html("internal", "Internal");
         } else {
-            tags.push_str("[<div class='stab unstable'>Experimental</div>] ");
+            tags += &tag_html("unstable", "Experimental");
         }
     }
 
     if let Some(ref cfg) = item.attrs.cfg {
-        tags.push_str(&format!(
-            "[<div class='stab portability'>{}</div>] ",
-            cfg.render_short_html()
-        ));
+        tags += &tag_html("portability", &cfg.render_short_html());
     }
 
     tags

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -150,8 +150,7 @@ if (!DOMTokenList.prototype.remove) {
     }
 
     function browserSupportsHistoryApi() {
-        return document.location.protocol != "file:" &&
-          window.history && typeof window.history.pushState === "function";
+        return window.history && typeof window.history.pushState === "function";
     }
 
     var main = document.getElementById("main");

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -1918,9 +1918,9 @@ if (!DOMTokenList.prototype.remove) {
             };
         }
 
-        function implHider(addOrRemove) {
+        function implHider(addOrRemove, fullHide) {
             return function(n) {
-                var is_method = hasClass(n, "method");
+                var is_method = hasClass(n, "method") || fullHide;
                 if (is_method || hasClass(n, "type")) {
                     if (is_method === true) {
                         if (addOrRemove) {
@@ -1974,7 +1974,7 @@ if (!DOMTokenList.prototype.remove) {
                 }
             }
         } else {
-            // we are collapsing the impl block
+            // we are collapsing the impl block(s).
 
             var parentElem = toggle.parentNode;
             relatedDoc = parentElem;
@@ -1989,7 +1989,7 @@ if (!DOMTokenList.prototype.remove) {
                 return;
             }
 
-            // Hide all functions, but not associated types/consts
+            // Hide all functions, but not associated types/consts.
 
             if (mode === "toggle") {
                 if (hasClass(relatedDoc, "fns-now-collapsed") ||
@@ -2000,16 +2000,17 @@ if (!DOMTokenList.prototype.remove) {
                 }
             }
 
+            var dontApplyBlockRule = toggle.parentNode.parentNode.id !== "main";
             if (action === "show") {
                 removeClass(relatedDoc, "fns-now-collapsed");
                 removeClass(docblock, "hidden-by-usual-hider");
-                onEachLazy(toggle.childNodes, adjustToggle(false));
-                onEachLazy(relatedDoc.childNodes, implHider(false));
+                onEachLazy(toggle.childNodes, adjustToggle(false, dontApplyBlockRule));
+                onEachLazy(relatedDoc.childNodes, implHider(false, dontApplyBlockRule));
             } else if (action === "hide") {
                 addClass(relatedDoc, "fns-now-collapsed");
                 addClass(docblock, "hidden-by-usual-hider");
-                onEachLazy(toggle.childNodes, adjustToggle(true));
-                onEachLazy(relatedDoc.childNodes, implHider(true));
+                onEachLazy(toggle.childNodes, adjustToggle(true, dontApplyBlockRule);
+                onEachLazy(relatedDoc.childNodes, implHider(true, dontApplyBlockRule));
             }
         }
     }

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -1887,12 +1887,30 @@ if (!DOMTokenList.prototype.remove) {
             updateLocalStorage("rustdoc-collapse", "true");
             addClass(innerToggle, "will-expand");
             onEveryMatchingChild(innerToggle, "inner", function(e) {
-                e.innerHTML = labelForToggleButton(true);
+                var parent = e.parentNode;
+                var superParent = null;
+
+                if (parent) {
+                    superParent = parent.parentNode;
+                }
+                if (!parent || !superParent || superParent.id !== "main" ||
+                    hasClass(parent, "impl") === false) {
+                    e.innerHTML = labelForToggleButton(true);
+                }
             });
             innerToggle.title = "expand all docs";
             if (fromAutoCollapse !== true) {
                 onEachLazy(document.getElementsByClassName("collapse-toggle"), function(e) {
-                    collapseDocs(e, "hide", pageId);
+                    var parent = e.parentNode;
+                    var superParent = null;
+
+                    if (parent) {
+                        superParent = parent.parentNode;
+                    }
+                    if (!parent || !superParent || superParent.id !== "main" ||
+                        hasClass(parent, "impl") === false) {
+                        collapseDocs(e, "hide", pageId);
+                    }
                 });
             }
         }

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -767,11 +767,14 @@ body.blur > :not(#help) {
 }
 
 .module-item .stab {
-	display: inline;
-	border-width: 0;
-	padding: 0;
-	margin: 0;
-	background: inherit !important;
+	border-radius: 3px;
+	display: inline-block;
+	font-size: 80%;
+	line-height: 1.2;
+	margin-bottom: 0;
+	margin-right: .3em;
+	padding: 2px;
+	vertical-align: text-bottom;
 }
 
 .module-item.unstable {

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -1570,5 +1570,6 @@ div.name::before {
 }
 div.name.expand::before {
 	transform: rotate(90deg);
-	left: -14px;
+	left: -15px;
+	top: 2px;
 }

--- a/src/librustdoc/html/static/source-script.js
+++ b/src/librustdoc/html/static/source-script.js
@@ -94,7 +94,7 @@ function createSidebarToggle() {
     inner1.style.position = "relative";
 
     var inner2 = document.createElement("div");
-    inner2.style.marginTop = "-2px";
+    inner2.style.paddingTop = "3px";
     if (getCurrentValue("rustdoc-source-sidebar-show") === "true") {
         inner2.innerText = "<";
     } else {

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -1,6 +1,4 @@
-#![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/",
+#![doc(html_root_url = "https://doc.rust-lang.org/nightly/",
        html_playground_url = "https://play.rust-lang.org/")]
 
 #![feature(bind_by_move_pattern_guards)]

--- a/src/libserialize/lib.rs
+++ b/src/libserialize/lib.rs
@@ -4,9 +4,7 @@
 Core encoding and decoding interfaces.
 */
 
-#![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/",
+#![doc(html_root_url = "https://doc.rust-lang.org/nightly/",
        html_playground_url = "https://play.rust-lang.org/",
        test(attr(allow(unused_variables), deny(warnings))))]
 

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -196,9 +196,7 @@
 //! [primitive types]: ../book/ch03-02-data-types.html
 
 #![stable(feature = "rust1", since = "1.0.0")]
-#![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/",
+#![doc(html_root_url = "https://doc.rust-lang.org/nightly/",
        html_playground_url = "https://play.rust-lang.org/",
        issue_tracker_base_url = "https://github.com/rust-lang/rust/issues/",
        test(no_crate_inject, attr(deny(warnings))),

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -4,9 +4,7 @@
 //!
 //! This API is completely unstable and subject to change.
 
-#![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/",
+#![doc(html_root_url = "https://doc.rust-lang.org/nightly/",
        test(attr(deny(warnings))))]
 
 #![deny(rust_2018_idioms)]

--- a/src/libsyntax_ext/lib.rs
+++ b/src/libsyntax_ext/lib.rs
@@ -1,8 +1,6 @@
 //! Syntax extensions in the Rust compiler.
 
-#![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/")]
+#![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
 
 #![deny(rust_2018_idioms)]
 

--- a/src/libsyntax_pos/lib.rs
+++ b/src/libsyntax_pos/lib.rs
@@ -4,9 +4,7 @@
 //!
 //! This API is completely unstable and subject to change.
 
-#![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-      html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-      html_root_url = "https://doc.rust-lang.org/nightly/")]
+#![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
 
 #![deny(rust_2018_idioms)]
 

--- a/src/libterm/lib.rs
+++ b/src/libterm/lib.rs
@@ -30,9 +30,7 @@
 //! [win]: http://msdn.microsoft.com/en-us/library/windows/desktop/ms682010%28v=vs.85%29.aspx
 //! [ti]: https://en.wikipedia.org/wiki/Terminfo
 
-#![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/",
+#![doc(html_root_url = "https://doc.rust-lang.org/nightly/",
        html_playground_url = "https://play.rust-lang.org/",
        test(attr(deny(warnings))))]
 #![deny(missing_docs)]

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -20,12 +20,7 @@
 #![deny(rust_2018_idioms)]
 #![crate_name = "test"]
 #![unstable(feature = "test", issue = "27812")]
-#![doc(
-    html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-    html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-    html_root_url = "https://doc.rust-lang.org/nightly/",
-    test(attr(deny(warnings)))
-)]
+#![doc(html_root_url = "https://doc.rust-lang.org/nightly/", test(attr(deny(warnings))))]
 #![feature(asm)]
 #![feature(fnbox)]
 #![cfg_attr(any(unix, target_os = "cloudabi"), feature(libc, rustc_private))]

--- a/src/test/rustdoc/deprecated.rs
+++ b/src/test/rustdoc/deprecated.rs
@@ -1,7 +1,9 @@
 #![feature(deprecated)]
 
-// @matches deprecated/index.html '//*[@class="docblock-short"]' \
-//      '^\[Deprecated\] Deprecated docs'
+// @has deprecated/index.html '//*[@class="docblock-short"]/span[@class="stab deprecated"]' \
+//      'Deprecated'
+// @has - '//*[@class="docblock-short"]' 'Deprecated docs'
+
 // @has deprecated/struct.S.html '//*[@class="stab deprecated"]' \
 //      'Deprecated since 1.0.0: text'
 /// Deprecated docs

--- a/src/test/rustdoc/inline_cross/macros.rs
+++ b/src/test/rustdoc/inline_cross/macros.rs
@@ -7,7 +7,8 @@
 
 extern crate macros;
 
-// @has foo/index.html '//*[@class="docblock-short"]' '[Deprecated] [Experimental]'
+// @has foo/index.html '//*[@class="docblock-short"]/span[@class="stab deprecated"]' Deprecated
+// @has - '//*[@class="docblock-short"]/span[@class="stab unstable"]' Experimental
 
 // @has foo/macro.my_macro.html
 // @has - '//*[@class="docblock"]' 'docs for my_macro'

--- a/src/test/rustdoc/internal.rs
+++ b/src/test/rustdoc/internal.rs
@@ -1,7 +1,9 @@
 // compile-flags: -Z force-unstable-if-unmarked
 
-// @matches internal/index.html '//*[@class="docblock-short"]' \
-//      '^\[Internal\] Docs'
+// @matches internal/index.html '//*[@class="docblock-short"]/span[@class="stab internal"]' \
+//      'Internal'
+// @matches - '//*[@class="docblock-short"]' 'Docs'
+
 // @has internal/struct.S.html '//*[@class="stab internal"]' \
 //      'This is an internal compiler API. (rustc_private)'
 /// Docs

--- a/src/test/rustdoc/issue-32374.rs
+++ b/src/test/rustdoc/issue-32374.rs
@@ -3,8 +3,11 @@
 
 #![unstable(feature="test", issue = "32374")]
 
-// @matches issue_32374/index.html '//*[@class="docblock-short"]' \
-//      '^\[Deprecated\] \[Experimental\] Docs'
+// @matches issue_32374/index.html '//*[@class="docblock-short"]/span[@class="stab deprecated"]' \
+//      'Deprecated'
+// @matches issue_32374/index.html '//*[@class="docblock-short"]/span[@class="stab unstable"]' \
+//      'Experimental'
+// @matches issue_32374/index.html '//*[@class="docblock-short"]/text()' 'Docs'
 
 // @has issue_32374/struct.T.html '//*[@class="stab deprecated"]' \
 //      'Deprecated since 1.0.0: text'

--- a/src/test/rustdoc/keyword.rs
+++ b/src/test/rustdoc/keyword.rs
@@ -7,7 +7,7 @@
 // @has foo/keyword.match.html '//a[@class="keyword"]' 'match'
 // @has foo/keyword.match.html '//span[@class="in-band"]' 'Keyword match'
 // @has foo/keyword.match.html '//section[@id="main"]//div[@class="docblock"]//p' 'this is a test!'
-// @!has foo/index.html '//a/@href' 'foo/index.html'
+// @has foo/index.html '//a/@href' '../foo/index.html'
 // @!has foo/foo/index.html
 // @!has-dir foo/foo
 #[doc(keyword = "match")]

--- a/src/test/rustdoc/stability.rs
+++ b/src/test/rustdoc/stability.rs
@@ -1,0 +1,12 @@
+#![feature(staged_api)]
+
+#![unstable(feature = "test", issue = "0")]
+
+pub struct Unstable {
+    // @has stability/struct.Unstable.html \
+    //      '//div[@class="stability"]//div[@class="stab unstable"]' \
+    //      'This is a nightly-only experimental API'
+    // @count stability/struct.Unstable.html '//span[@class="stab unstable"]' 0
+    pub foo: u32,
+    pub bar: u32,
+}


### PR DESCRIPTION
Successful merges:

 - #57504 (Re-enable history api on file:// protocol)
 - #57848 (Generate a documentation page for core::mem::transmute.)
 - #57884 (Update minifier version)
 - #57954 (rustdoc: remove blank unstable spans)
 - #58028 (Fix image link in the settings menu)
 - #58033 (rustdoc: wrap stability tags in colored spans)
 - #58086 ([rustdoc] Improve file list display)
 - #58143 (Sort elements in the sidebar)
 - #58146 (Prevent automatic collapse of methods impl blocks)
 - #58150 (Don't apply impl block collapse rules to trait impls)
 - #58185 (Remove images' url to make it work even without internet connection)

Failed merges:


r? @ghost