### PR TITLE
libcore, liballoc: disable tests in Miri

### DIFF
--- a/src/liballoc/tests/arc.rs
+++ b/src/liballoc/tests/arc.rs
@@ -1,3 +1,5 @@
+#![cfg(not(miri))]
+
 use std::any::Any;
 use std::sync::{Arc, Weak};
 use std::cell::RefCell;

--- a/src/liballoc/tests/binary_heap.rs
+++ b/src/liballoc/tests/binary_heap.rs
@@ -282,6 +282,7 @@ fn assert_covariance() {
 //
 // Destructors must be called exactly once per element.
 #[test]
+#[cfg(not(miri))]
 fn panic_safe() {
     static DROP_COUNTER: AtomicUsize = AtomicUsize::new(0);
 

--- a/src/liballoc/tests/btree/mod.rs
+++ b/src/liballoc/tests/btree/mod.rs
@@ -1,3 +1,5 @@
+#![cfg(not(miri))]
+
 mod map;
 mod set;
 

--- a/src/liballoc/tests/heap.rs
+++ b/src/liballoc/tests/heap.rs
@@ -1,3 +1,5 @@
+#![cfg(not(miri))]
+
 use std::alloc::{Global, Alloc, Layout, System};
 
 /// https://github.com/rust-lang/rust/issues/45955

--- a/src/liballoc/tests/rc.rs
+++ b/src/liballoc/tests/rc.rs
@@ -1,3 +1,5 @@
+#![cfg(not(miri))]
+
 use std::any::Any;
 use std::rc::{Rc, Weak};
 use std::cell::RefCell;

--- a/src/liballoc/tests/slice.rs
+++ b/src/liballoc/tests/slice.rs
@@ -1,3 +1,5 @@
+#![cfg(not(miri))]
+
 use std::cell::Cell;
 use std::cmp::Ordering::{Equal, Greater, Less};
 use std::cmp::Ordering;

--- a/src/liballoc/tests/str.rs
+++ b/src/liballoc/tests/str.rs
@@ -31,6 +31,7 @@ fn test_rfind() {
 }
 
 #[test]
+#[cfg(not(miri))]
 fn test_collect() {
     let empty = "";
     let s: String = empty.chars().collect();
@@ -118,6 +119,7 @@ fn test_concat_for_different_types() {
 #[test]
 fn test_concat_for_different_lengths() {
     let empty: &[&str] = &[];
+    #[cfg(not(miri))]
     test_concat!("", empty);
     test_concat!("a", ["a"]);
     test_concat!("ab", ["a", "b"]);
@@ -146,6 +148,7 @@ fn test_join_for_different_types() {
 #[test]
 fn test_join_for_different_lengths() {
     let empty: &[&str] = &[];
+    #[cfg(not(miri))]
     test_join!("", empty, "-");
     test_join!("a", ["a"], "-");
     test_join!("a-b", ["a", "b"], "-");
@@ -159,6 +162,7 @@ fn test_join_for_different_lengths_with_long_separator() {
     assert_eq!("～～～～～".len(), 15);
 
     let empty: &[&str] = &[];
+    #[cfg(not(miri))]
     test_join!("", empty, "～～～～～");
     test_join!("a", ["a"], "～～～～～");
     test_join!("a～～～～～b", ["a", "b"], "～～～～～");
@@ -166,6 +170,7 @@ fn test_join_for_different_lengths_with_long_separator() {
 }
 
 #[test]
+#[cfg(not(miri))]
 fn test_unsafe_slice() {
     assert_eq!("ab", unsafe {"abc".get_unchecked(0..2)});
     assert_eq!("bc", unsafe {"abc".get_unchecked(1..3)});
@@ -238,6 +243,7 @@ fn test_replacen() {
 #[test]
 fn test_replace() {
     let a = "a";
+    #[cfg(not(miri))]
     assert_eq!("".replace(a, "b"), "");
     assert_eq!("a".replace(a, "b"), "b");
     assert_eq!("ab".replace(a, "b"), "bb");
@@ -297,6 +303,7 @@ fn test_replace_pattern() {
 // The current implementation of SliceIndex fails to handle methods
 // orthogonally from range types; therefore, it is worth testing
 // all of the indexing operations on each input.
+#[cfg(not(miri))]
 mod slice_index {
     // Test a slicing operation **that should succeed,**
     // testing it on all of the indexing methods.
@@ -679,6 +686,7 @@ fn test_str_slice_rangetoinclusive_ok() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))]
 fn test_str_slice_rangetoinclusive_notok() {
     let s = "abcαβγ";
     &s[..=3];
@@ -694,6 +702,7 @@ fn test_str_slicemut_rangetoinclusive_ok() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))]
 fn test_str_slicemut_rangetoinclusive_notok() {
     let mut s = "abcαβγ".to_owned();
     let s: &mut str = &mut s;
@@ -883,6 +892,7 @@ fn test_as_bytes() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))]
 fn test_as_bytes_fail() {
     // Don't double free. (I'm not sure if this exercises the
     // original problem code path anymore.)
@@ -972,6 +982,7 @@ fn test_split_at_mut() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))]
 fn test_split_at_boundscheck() {
     let s = "ศไทย中华Việt Nam";
     s.split_at(1);
@@ -1066,6 +1077,7 @@ fn test_rev_iterator() {
 }
 
 #[test]
+#[cfg(not(miri))]
 fn test_chars_decoding() {
     let mut bytes = [0; 4];
     for c in (0..0x110000).filter_map(::std::char::from_u32) {
@@ -1077,6 +1089,7 @@ fn test_chars_decoding() {
 }
 
 #[test]
+#[cfg(not(miri))]
 fn test_chars_rev_decoding() {
     let mut bytes = [0; 4];
     for c in (0..0x110000).filter_map(::std::char::from_u32) {
@@ -1306,6 +1319,7 @@ fn test_splitator() {
 }
 
 #[test]
+#[cfg(not(miri))]
 fn test_str_default() {
     use std::default::Default;
 
@@ -1365,6 +1379,7 @@ fn test_bool_from_str() {
     assert_eq!("not even a boolean".parse::<bool>().ok(), None);
 }
 
+#[cfg(not(miri))]
 fn check_contains_all_substrings(s: &str) {
     assert!(s.contains(""));
     for i in 0..s.len() {
@@ -1375,6 +1390,7 @@ fn check_contains_all_substrings(s: &str) {
 }
 
 #[test]
+#[cfg(not(miri))]
 fn strslice_issue_16589() {
     assert!("bananas".contains("nana"));
 
@@ -1384,6 +1400,7 @@ fn strslice_issue_16589() {
 }
 
 #[test]
+#[cfg(not(miri))]
 fn strslice_issue_16878() {
     assert!(!"1234567ah012345678901ah".contains("hah"));
     assert!(!"00abc01234567890123456789abc".contains("bcabc"));
@@ -1391,6 +1408,7 @@ fn strslice_issue_16878() {
 
 
 #[test]
+#[cfg(not(miri))]
 fn test_strslice_contains() {
     let x = "There are moments, Jeeves, when one asks oneself, 'Do trousers matter?'";
     check_contains_all_substrings(x);
@@ -1528,6 +1546,7 @@ fn trim_ws() {
 
 #[test]
 fn to_lowercase() {
+    #[cfg(not(miri))]
     assert_eq!("".to_lowercase(), "");
     assert_eq!("AÉǅaé ".to_lowercase(), "aéǆaé ");
 
@@ -1561,6 +1580,7 @@ fn to_lowercase() {
 
 #[test]
 fn to_uppercase() {
+    #[cfg(not(miri))]
     assert_eq!("".to_uppercase(), "");
     assert_eq!("aéǅßﬁᾀ".to_uppercase(), "AÉǄSSFIἈΙ");
 }
@@ -1592,6 +1612,7 @@ fn test_cow_from() {
 }
 
 #[test]
+#[cfg(not(miri))]
 fn test_repeat() {
     assert_eq!("".repeat(3), "");
     assert_eq!("abc".repeat(0), "");

--- a/src/liballoc/tests/string.rs
+++ b/src/liballoc/tests/string.rs
@@ -1,3 +1,5 @@
+#![cfg(not(miri))]
+
 use std::borrow::Cow;
 use std::collections::CollectionAllocErr::*;
 use std::mem::size_of;

--- a/src/liballoc/tests/vec.rs
+++ b/src/liballoc/tests/vec.rs
@@ -1,3 +1,5 @@
+#![cfg(not(miri))]
+
 use std::borrow::Cow;
 use std::mem::size_of;
 use std::{usize, isize};

--- a/src/liballoc/tests/vec_deque.rs
+++ b/src/liballoc/tests/vec_deque.rs
@@ -107,6 +107,7 @@ fn test_index() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))]
 fn test_index_out_of_bounds() {
     let mut deq = VecDeque::new();
     for i in 1..4 {
@@ -905,20 +906,24 @@ fn test_append() {
     // normal append
     a.append(&mut b);
     assert_eq!(a.iter().cloned().collect::<Vec<_>>(), [1, 2, 3, 4, 5, 6]);
+    #[cfg(not(miri))]
     assert_eq!(b.iter().cloned().collect::<Vec<_>>(), []);
 
     // append nothing to something
     a.append(&mut b);
     assert_eq!(a.iter().cloned().collect::<Vec<_>>(), [1, 2, 3, 4, 5, 6]);
+    #[cfg(not(miri))]
     assert_eq!(b.iter().cloned().collect::<Vec<_>>(), []);
 
     // append something to nothing
     b.append(&mut a);
     assert_eq!(b.iter().cloned().collect::<Vec<_>>(), [1, 2, 3, 4, 5, 6]);
+    #[cfg(not(miri))]
     assert_eq!(a.iter().cloned().collect::<Vec<_>>(), []);
 }
 
 #[test]
+#[cfg(not(miri))]
 fn test_append_permutations() {
     fn construct_vec_deque(
         push_back: usize,
@@ -1119,6 +1124,7 @@ fn test_reserve_exact_2() {
 }
 
 #[test]
+#[cfg(not(miri))]
 fn test_try_reserve() {
 
     // These are the interesting cases:
@@ -1220,6 +1226,7 @@ fn test_try_reserve() {
 }
 
 #[test]
+#[cfg(not(miri))]
 fn test_try_reserve_exact() {
 
     // This is exactly the same as test_try_reserve with the method changed.

--- a/src/libcore/tests/cell.rs
+++ b/src/libcore/tests/cell.rs
@@ -1,3 +1,5 @@
+#![cfg(not(miri))]
+
 use core::cell::*;
 use core::default::Default;
 use std::mem::drop;

--- a/src/libcore/tests/fmt/mod.rs
+++ b/src/libcore/tests/fmt/mod.rs
@@ -1,3 +1,5 @@
+#![cfg(not(miri))]
+
 mod builders;
 mod float;
 mod num;

--- a/src/libcore/tests/hash/mod.rs
+++ b/src/libcore/tests/hash/mod.rs
@@ -1,3 +1,5 @@
+#![cfg(not(miri))]
+
 mod sip;
 
 use std::hash::{Hash, Hasher};

--- a/src/libcore/tests/iter.rs
+++ b/src/libcore/tests/iter.rs
@@ -190,6 +190,7 @@ fn test_iterator_step_by() {
 }
 
 #[test]
+#[cfg(not(miri))]
 fn test_iterator_step_by_nth() {
     let mut it = (0..16).step_by(5);
     assert_eq!(it.nth(0), Some(0));
@@ -208,6 +209,7 @@ fn test_iterator_step_by_nth() {
 }
 
 #[test]
+#[cfg(not(miri))]
 fn test_iterator_step_by_nth_overflow() {
     #[cfg(target_pointer_width = "8")]
     type Bigger = u16;
@@ -253,12 +255,14 @@ fn test_iterator_step_by_nth_overflow() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))]
 fn test_iterator_step_by_zero() {
     let mut it = (0..).step_by(0);
     it.next();
 }
 
 #[test]
+#[cfg(not(miri))]
 fn test_iterator_step_by_size_hint() {
     struct StubSizeHint(usize, Option<usize>);
     impl Iterator for StubSizeHint {
@@ -1413,6 +1417,7 @@ fn test_rposition() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))]
 fn test_rposition_panic() {
     let v: [(Box<_>, Box<_>); 4] =
         [(box 0, box 0), (box 0, box 0),
@@ -1652,6 +1657,7 @@ fn test_range_inclusive_nth() {
 }
 
 #[test]
+#[cfg(not(miri))]
 fn test_range_step() {
     #![allow(deprecated)]
 
@@ -1675,6 +1681,7 @@ fn test_range_step() {
 }
 
 #[test]
+#[cfg(not(miri))]
 fn test_step_by_skip() {
     assert_eq!((0..640).step_by(128).skip(1).collect::<Vec<_>>(), [128, 256, 384, 512]);
     assert_eq!((0..=50).step_by(10).nth(3), Some(30));
@@ -1682,6 +1689,7 @@ fn test_step_by_skip() {
 }
 
 #[test]
+#[cfg(not(miri))]
 fn test_range_inclusive_step() {
     assert_eq!((0..=50).step_by(10).collect::<Vec<_>>(), [0, 10, 20, 30, 40, 50]);
     assert_eq!((0..=5).step_by(1).collect::<Vec<_>>(), [0, 1, 2, 3, 4, 5]);

--- a/src/libcore/tests/num/mod.rs
+++ b/src/libcore/tests/num/mod.rs
@@ -1,3 +1,5 @@
+#![cfg(not(miri))]
+
 use core::convert::{TryFrom, TryInto};
 use core::cmp::PartialEq;
 use core::fmt::Debug;

--- a/src/libcore/tests/option.rs
+++ b/src/libcore/tests/option.rs
@@ -69,6 +69,7 @@ fn test_option_dance() {
 }
 
 #[test] #[should_panic]
+#[cfg(not(miri))]
 fn test_option_too_much_dance() {
     struct A;
     let mut y = Some(A);
@@ -129,6 +130,7 @@ fn test_unwrap() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))]
 fn test_unwrap_panic1() {
     let x: Option<isize> = None;
     x.unwrap();
@@ -136,6 +138,7 @@ fn test_unwrap_panic1() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))]
 fn test_unwrap_panic2() {
     let x: Option<String> = None;
     x.unwrap();

--- a/src/libcore/tests/ptr.rs
+++ b/src/libcore/tests/ptr.rs
@@ -1,3 +1,5 @@
+#![cfg(not(miri))]
+
 use core::ptr::*;
 use core::cell::RefCell;
 

--- a/src/libcore/tests/result.rs
+++ b/src/libcore/tests/result.rs
@@ -117,6 +117,7 @@ fn test_unwrap_or_else() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))]
 pub fn test_unwrap_or_else_panic() {
     fn handler(msg: &'static str) -> isize {
         if msg == "I got this." {
@@ -138,6 +139,7 @@ pub fn test_expect_ok() {
 }
 #[test]
 #[should_panic(expected="Got expected error: \"All good\"")]
+#[cfg(not(miri))]
 pub fn test_expect_err() {
     let err: Result<isize, &'static str> = Err("All good");
     err.expect("Got expected error");
@@ -151,6 +153,7 @@ pub fn test_expect_err_err() {
 }
 #[test]
 #[should_panic(expected="Got expected ok: \"All good\"")]
+#[cfg(not(miri))]
 pub fn test_expect_err_ok() {
     let err: Result<&'static str, isize> = Ok("All good");
     err.expect_err("Got expected ok");

--- a/src/libcore/tests/slice.rs
+++ b/src/libcore/tests/slice.rs
@@ -782,6 +782,7 @@ mod slice_index {
     //  to be used in `should_panic`)
     #[test]
     #[should_panic(expected = "out of range")]
+    #[cfg(not(miri))]
     fn assert_range_eq_can_fail_by_panic() {
         assert_range_eq!([0, 1, 2], 0..5, [0, 1, 2]);
     }
@@ -791,6 +792,7 @@ mod slice_index {
     //  to be used in `should_panic`)
     #[test]
     #[should_panic(expected = "==")]
+    #[cfg(not(miri))]
     fn assert_range_eq_can_fail_by_inequality() {
         assert_range_eq!([0, 1, 2], 0..2, [0, 1, 2]);
     }
@@ -840,6 +842,7 @@ mod slice_index {
 
                 #[test]
                 #[should_panic(expected = $expect_msg)]
+                #[cfg(not(miri))]
                 fn index_fail() {
                     let v = $data;
                     let v: &[_] = &v;
@@ -848,6 +851,7 @@ mod slice_index {
 
                 #[test]
                 #[should_panic(expected = $expect_msg)]
+                #[cfg(not(miri))]
                 fn index_mut_fail() {
                     let mut v = $data;
                     let v: &mut [_] = &mut v;
@@ -1011,6 +1015,7 @@ fn test_rotate_right() {
 
 #[test]
 #[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(miri))]
 fn sort_unstable() {
     use core::cmp::Ordering::{Equal, Greater, Less};
     use core::slice::heapsort;
@@ -1166,6 +1171,7 @@ pub mod memchr {
 }
 
 #[test]
+#[cfg(not(miri))]
 fn test_align_to_simple() {
     let bytes = [1u8, 2, 3, 4, 5, 6, 7];
     let (prefix, aligned, suffix) = unsafe { bytes.align_to::<u16>() };
@@ -1181,6 +1187,7 @@ fn test_align_to_simple() {
 }
 
 #[test]
+#[cfg(not(miri))]
 fn test_align_to_zst() {
     let bytes = [1, 2, 3, 4, 5, 6, 7];
     let (prefix, aligned, suffix) = unsafe { bytes.align_to::<()>() };
@@ -1189,6 +1196,7 @@ fn test_align_to_zst() {
 }
 
 #[test]
+#[cfg(not(miri))]
 fn test_align_to_non_trivial() {
     #[repr(align(8))] struct U64(u64, u64);
     #[repr(align(8))] struct U64U64U32(u64, u64, u32);
@@ -1200,6 +1208,7 @@ fn test_align_to_non_trivial() {
 }
 
 #[test]
+#[cfg(not(miri))]
 fn test_align_to_empty_mid() {
     use core::mem;
 
@@ -1297,6 +1306,7 @@ fn test_copy_within() {
 
 #[test]
 #[should_panic(expected = "src is out of bounds")]
+#[cfg(not(miri))]
 fn test_copy_within_panics_src_too_long() {
     let mut bytes = *b"Hello, World!";
     // The length is only 13, so 14 is out of bounds.
@@ -1305,6 +1315,7 @@ fn test_copy_within_panics_src_too_long() {
 
 #[test]
 #[should_panic(expected = "dest is out of bounds")]
+#[cfg(not(miri))]
 fn test_copy_within_panics_dest_too_long() {
     let mut bytes = *b"Hello, World!";
     // The length is only 13, so a slice of length 4 starting at index 10 is out of bounds.
@@ -1312,6 +1323,7 @@ fn test_copy_within_panics_dest_too_long() {
 }
 #[test]
 #[should_panic(expected = "src end is before src start")]
+#[cfg(not(miri))]
 fn test_copy_within_panics_src_inverted() {
     let mut bytes = *b"Hello, World!";
     // 2 is greater than 1, so this range is invalid.

--- a/src/libcore/tests/time.rs
+++ b/src/libcore/tests/time.rs
@@ -1,3 +1,5 @@
+#![cfg(not(miri))]
+
 use core::time::Duration;
 
 #[test]


### PR DESCRIPTION
I am going to run the libcore and liballoc unit test suites in Miri.  Not all tests pass.  This PR disables a whole bunch of tests when running in Miri, to get us to a baseline from which I can investigate failures.

Cc @SimonSapin @alexcrichton 