### PR TITLE
error_index_generator => 2018

### DIFF
--- a/src/tools/error_index_generator/Cargo.toml
+++ b/src/tools/error_index_generator/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "error_index_generator"
 version = "0.0.0"
+edition = "2018"
 
 [dependencies]
 rustdoc = { path = "../../librustdoc" }

--- a/src/tools/error_index_generator/main.rs
+++ b/src/tools/error_index_generator/main.rs
@@ -1,8 +1,9 @@
 #![feature(rustc_private)]
 
+#![deny(rust_2018_idioms)]
+
 extern crate env_logger;
 extern crate syntax;
-extern crate rustdoc;
 extern crate serialize as rustc_serialize;
 
 use std::collections::BTreeMap;


### PR DESCRIPTION
Transitions `error_index_generator` to Rust 2018; cc #58099

r? @Centril