### PR TITLE
rustc-std-workspace-core => 2018

### DIFF
--- a/src/tools/rustc-std-workspace-core/Cargo.toml
+++ b/src/tools/rustc-std-workspace-core/Cargo.toml
@@ -6,6 +6,7 @@ license = 'MIT/Apache-2.0'
 description = """
 Hack for the compiler's own build system
 """
+edition = "2018"
 
 [lib]
 path = "lib.rs"

--- a/src/tools/rustc-std-workspace-core/lib.rs
+++ b/src/tools/rustc-std-workspace-core/lib.rs
@@ -1,6 +1,5 @@
 #![feature(no_core)]
 #![no_core]
-
-extern crate core;
+#![deny(rust_2018_idioms)]
 
 pub use core::*;


### PR DESCRIPTION
Transitions `rustc-std-workspace-core` to Rust 2018; cc #58099

r? @alexcrichton