### PR TITLE
rustc-workspace-hack => 2018

### DIFF
--- a/src/tools/rustc-workspace-hack/Cargo.toml
+++ b/src/tools/rustc-workspace-hack/Cargo.toml
@@ -6,6 +6,7 @@ license = 'MIT/Apache-2.0'
 description = """
 Hack for the compiler's own build system
 """
+edition = "2018"
 
 [lib]
 path = "lib.rs"


### PR DESCRIPTION
Transitions `rustc-workspace-hack` to Rust 2018; cc #58099

r? @alexcrichton