### PR TITLE
Improve stability tags display

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -2775,8 +2775,7 @@ fn item_module(w: &mut fmt::Formatter, cx: &Context,
                        <tr class='{stab}{add}module-item'>\
                            <td><a class=\"{class}\" href=\"{href}\" \
                                   title='{title}'>{name}</a>{unsafety_flag}</td>\
-                           <td class='docblock-short'>{stab_tags}{docs}\
-                           </td>\
+                           <td class='docblock-short'>{stab_tags}{docs}</td>\
                        </tr>",
                        name = *myitem.name.as_ref().unwrap(),
                        stab_tags = stability_tags(myitem),

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -188,14 +188,14 @@ a.test-arrow {
 	box-shadow: 1px 0 0 1px #000, 0 0 0 2px transparent;
 }
 
-.stab.unstable { background: #FFF5D6; border-color: #FFC600; color: #404040; }
-.stab.internal { background: #FFB9B3; border-color: #B71C1C; color: #404040; }
-.stab.deprecated { background: #F3DFFF; border-color: #7F0087;  color: #404040; }
-.stab.portability { background: #C4ECFF; border-color: #7BA5DB;  color: #404040; }
-
 .module-item .stab {
 	color: #ddd;
 }
+
+.stab.unstable {background: #FFF5D6; border-color: #FFC600; color: #2f2f2f; }
+.stab.internal { background: #FFB9B3; border-color: #B71C1C; color: #2f2f2f; }
+.stab.deprecated { background: #F3DFFF; border-color: #7F0087; color: #2f2f2f; }
+.stab.portability { background: #C4ECFF; border-color: #7BA5DB; color: #2f2f2f; }
 
 #help > div {
 	background: #4d4d4d;

--- a/src/librustdoc/html/static/themes/light.css
+++ b/src/librustdoc/html/static/themes/light.css
@@ -189,14 +189,14 @@ a.test-arrow {
 	box-shadow: 1px 0 0 1px #e0e0e0, 0 0 0 2px transparent;
 }
 
+.module-item .stab {
+	color: #000;
+}
+
 .stab.unstable { background: #FFF5D6; border-color: #FFC600; }
 .stab.internal { background: #FFB9B3; border-color: #B71C1C; }
 .stab.deprecated { background: #F3DFFF; border-color: #7F0087; }
 .stab.portability { background: #C4ECFF; border-color: #7BA5DB; }
-
-.module-item .stab {
-	color: #000;
-}
 
 #help > div {
 	background: #e9e9e9;


### PR DESCRIPTION
The issue was the font color on dark theme. Fixed now:

<img width="352" alt="screenshot 2019-02-08 at 14 15 24" src="https://user-images.githubusercontent.com/3050060/52483276-bd810380-2bb3-11e9-8d46-95368569ac85.png">

r? @QuietMisdreavus 