### PR TITLE
Don't default on std crate when manipulating browser history

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -1598,7 +1598,7 @@ if (!DOMTokenList.prototype.remove) {
                 clearTimeout(searchTimeout);
                 if (search_input.value.length === 0) {
                     if (browserSupportsHistoryApi()) {
-                        history.replaceState("", "std - Rust", "?search=");
+                        history.replaceState("", window.currentCrate + " - Rust", "?search=");
                     }
                     if (hasClass(main, "content")) {
                         removeClass(main, "hidden");


### PR DESCRIPTION
Fixes #58263.

r? @QuietMisdreavus 