### PR TITLE
Add more profiler events

### DIFF
--- a/src/librustc/ty/query/plumbing.rs
+++ b/src/librustc/ty/query/plumbing.rs
@@ -436,7 +436,9 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         // First we try to load the result from the on-disk cache
         let result = if Q::cache_on_disk(self.global_tcx(), key.clone()) &&
                         self.sess.opts.debugging_opts.incremental_queries {
+            self.sess.profiler(|p| p.incremental_load_result_start(Q::NAME));
             let result = Q::try_load_from_disk(self.global_tcx(), prev_dep_node_index);
+            self.sess.profiler(|p| p.incremental_load_result_end(Q::NAME));
 
             // We always expect to find a cached result for things that
             // can be forced from DepNode.

--- a/src/librustc/util/profiling.rs
+++ b/src/librustc/util/profiling.rs
@@ -69,12 +69,7 @@ impl CategoryResultData {
     }
 
     fn total_time(&self) -> u64 {
-        let mut total = 0;
-        for (_, time) in &self.query_times {
-            total += time;
-        }
-
-        total
+        self.query_times.iter().map(|(_, time)| time).sum()
     }
 
     fn total_cache_data(&self) -> (u64, u64) {
@@ -133,13 +128,7 @@ impl CalculatedResults {
     }
 
     fn total_time(&self) -> u64 {
-        let mut total = 0;
-
-        for (_, data) in &self.categories {
-            total += data.total_time();
-        }
-
-        total
+        self.categories.iter().map(|(_, data)| data.total_time()).sum()
     }
 
     fn with_options(mut self, opts: &Options) -> CalculatedResults {
@@ -411,9 +400,9 @@ impl SelfProfiler {
             .unwrap();
 
         let mut categories: Vec<_> = results.categories.iter().collect();
-        categories.sort_by(|(_, data1), (_, data2)| data2.total_time().cmp(&data1.total_time()));
+        categories.sort_by_cached_key(|(_, d)| d.total_time());
 
-        for (category, data) in categories {
+        for (category, data) in categories.iter().rev() {
             let (category_hits, category_total) = data.total_cache_data();
             let category_hit_percent = calculate_percent(category_hits, category_total);
 


### PR DESCRIPTION
- Adds Start\Stop events for time spent loading incremental query results from disk.

- Adds Start\Stop events for time spent blocked waiting for queries to complete (when parallel queries are enabled).

r? @michaelwoerister 