### PR TITLE
librustc_data_structures => 2018

### DIFF
--- a/src/librustc_data_structures/Cargo.toml
+++ b/src/librustc_data_structures/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_data_structures"
 version = "0.0.0"
+edition = "2018"
 
 [lib]
 name = "rustc_data_structures"
@@ -16,8 +17,8 @@ serialize = { path = "../libserialize" }
 graphviz = { path = "../libgraphviz" }
 cfg-if = "0.1.2"
 stable_deref_trait = "1.0.0"
-rustc-rayon = "0.1.1"
-rustc-rayon-core = "0.1.1"
+rayon = { version = "0.1.1", package = "rustc-rayon" }
+rayon-core = { version = "0.1.1", package = "rustc-rayon-core" }
 rustc-hash = "1.0.1"
 smallvec = { version = "0.6.7", features = ["union", "may_dangle"] }
 

--- a/src/librustc_data_structures/bit_set.rs
+++ b/src/librustc_data_structures/bit_set.rs
@@ -1,4 +1,4 @@
-use indexed_vec::{Idx, IndexVec};
+use crate::indexed_vec::{Idx, IndexVec};
 use smallvec::SmallVec;
 use std::fmt;
 use std::iter;
@@ -208,7 +208,7 @@ impl<T: Idx> SubtractFromBitSet<T> for BitSet<T> {
 }
 
 impl<T: Idx> fmt::Debug for BitSet<T> {
-    fn fmt(&self, w: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, w: &mut fmt::Formatter<'_>) -> fmt::Result {
         w.debug_list()
          .entries(self.iter())
          .finish()
@@ -366,7 +366,7 @@ impl<T: Idx> SparseBitSet<T> {
         dense
     }
 
-    fn iter(&self) -> slice::Iter<T> {
+    fn iter(&self) -> slice::Iter<'_, T> {
         self.elems.iter()
     }
 }
@@ -536,7 +536,7 @@ impl<T: Idx> HybridBitSet<T> {
         }
     }
 
-    pub fn iter(&self) -> HybridIter<T> {
+    pub fn iter(&self) -> HybridIter<'_, T> {
         match self {
             HybridBitSet::Sparse(sparse) => HybridIter::Sparse(sparse.iter()),
             HybridBitSet::Dense(dense) => HybridIter::Dense(dense.iter()),

--- a/src/librustc_data_structures/fingerprint.rs
+++ b/src/librustc_data_structures/fingerprint.rs
@@ -1,5 +1,5 @@
+use crate::stable_hasher;
 use std::mem;
-use stable_hasher;
 use serialize;
 use serialize::opaque::{EncodeResult, Encoder, Decoder};
 
@@ -70,7 +70,7 @@ impl Fingerprint {
 }
 
 impl ::std::fmt::Display for Fingerprint {
-    fn fmt(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, formatter: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         write!(formatter, "{:x}-{:x}", self.0, self.1)
     }
 }

--- a/src/librustc_data_structures/flock.rs
+++ b/src/librustc_data_structures/flock.rs
@@ -14,12 +14,9 @@ cfg_if! {
     if #[cfg(unix)] {
         use std::ffi::{CString, OsStr};
         use std::os::unix::prelude::*;
-        use libc;
 
         #[cfg(any(target_os = "linux", target_os = "android"))]
         mod os {
-            use libc;
-
             #[repr(C)]
             pub struct flock {
                 pub l_type: libc::c_short,
@@ -35,8 +32,6 @@ cfg_if! {
 
         #[cfg(target_os = "freebsd")]
         mod os {
-            use libc;
-
             #[repr(C)]
             pub struct flock {
                 pub l_start: libc::off_t,
@@ -53,8 +48,6 @@ cfg_if! {
                   target_os = "netbsd",
                   target_os = "openbsd"))]
         mod os {
-            use libc;
-
             #[repr(C)]
             pub struct flock {
                 pub l_start: libc::off_t,
@@ -70,8 +63,6 @@ cfg_if! {
 
         #[cfg(target_os = "haiku")]
         mod os {
-            use libc;
-
             #[repr(C)]
             pub struct flock {
                 pub l_type: libc::c_short,
@@ -87,8 +78,6 @@ cfg_if! {
 
         #[cfg(any(target_os = "macos", target_os = "ios"))]
         mod os {
-            use libc;
-
             #[repr(C)]
             pub struct flock {
                 pub l_start: libc::off_t,
@@ -104,8 +93,6 @@ cfg_if! {
 
         #[cfg(target_os = "solaris")]
         mod os {
-            use libc;
-
             #[repr(C)]
             pub struct flock {
                 pub l_type: libc::c_short,

--- a/src/librustc_data_structures/graph/dominators/mod.rs
+++ b/src/librustc_data_structures/graph/dominators/mod.rs
@@ -117,7 +117,7 @@ impl<Node: Idx> Dominators<Node> {
         self.immediate_dominators[node].unwrap()
     }
 
-    pub fn dominators(&self, node: Node) -> Iter<Node> {
+    pub fn dominators(&self, node: Node) -> Iter<'_, Node> {
         assert!(self.is_reachable(node), "node {:?} is not reachable", node);
         Iter {
             dominators: self,
@@ -136,7 +136,7 @@ impl<Node: Idx> Dominators<Node> {
     }
 }
 
-pub struct Iter<'dom, Node: Idx + 'dom> {
+pub struct Iter<'dom, Node: Idx> {
     dominators: &'dom Dominators<Node>,
     node: Option<Node>,
 }
@@ -171,7 +171,7 @@ impl<Node: Idx> DominatorTree<Node> {
 }
 
 impl<Node: Idx> fmt::Debug for DominatorTree<Node> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(
             &DominatorTreeNode {
                 tree: self,
@@ -188,7 +188,7 @@ struct DominatorTreeNode<'tree, Node: Idx> {
 }
 
 impl<'tree, Node: Idx> fmt::Debug for DominatorTreeNode<'tree, Node> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         let subtrees: Vec<_> = self.tree
             .children(self.node)
             .iter()

--- a/src/librustc_data_structures/graph/implementation/mod.rs
+++ b/src/librustc_data_structures/graph/implementation/mod.rs
@@ -20,10 +20,10 @@
 //! the field `next_edge`). Each of those fields is an array that should
 //! be indexed by the direction (see the type `Direction`).
 
-use bit_set::BitSet;
+use crate::bit_set::BitSet;
+use crate::snapshot_vec::{SnapshotVec, SnapshotVecDelegate};
 use std::fmt::Debug;
 use std::usize;
-use snapshot_vec::{SnapshotVec, SnapshotVecDelegate};
 
 #[cfg(test)]
 mod tests;
@@ -212,15 +212,19 @@ impl<N: Debug, E: Debug> Graph<N, E> {
             .all(|(edge_idx, edge)| f(edge_idx, edge))
     }
 
-    pub fn outgoing_edges(&self, source: NodeIndex) -> AdjacentEdges<N, E> {
+    pub fn outgoing_edges(&self, source: NodeIndex) -> AdjacentEdges<'_, N, E> {
         self.adjacent_edges(source, OUTGOING)
     }
 
-    pub fn incoming_edges(&self, source: NodeIndex) -> AdjacentEdges<N, E> {
+    pub fn incoming_edges(&self, source: NodeIndex) -> AdjacentEdges<'_, N, E> {
         self.adjacent_edges(source, INCOMING)
     }
 
-    pub fn adjacent_edges(&self, source: NodeIndex, direction: Direction) -> AdjacentEdges<N, E> {
+    pub fn adjacent_edges(
+        &self,
+        source: NodeIndex,
+        direction: Direction
+    ) -> AdjacentEdges<'_, N, E> {
         let first_edge = self.node(source).first_edge[direction.repr];
         AdjacentEdges {
             graph: self,
@@ -291,11 +295,7 @@ impl<N: Debug, E: Debug> Graph<N, E> {
 
 // # Iterators
 
-pub struct AdjacentEdges<'g, N, E>
-where
-    N: 'g,
-    E: 'g,
-{
+pub struct AdjacentEdges<'g, N, E> {
     graph: &'g Graph<N, E>,
     direction: Direction,
     next: EdgeIndex,
@@ -331,11 +331,7 @@ impl<'g, N: Debug, E: Debug> Iterator for AdjacentEdges<'g, N, E> {
     }
 }
 
-pub struct DepthFirstTraversal<'g, N, E>
-where
-    N: 'g,
-    E: 'g,
-{
+pub struct DepthFirstTraversal<'g, N, E> {
     graph: &'g Graph<N, E>,
     stack: Vec<NodeIndex>,
     visited: BitSet<usize>,

--- a/src/librustc_data_structures/graph/implementation/tests.rs
+++ b/src/librustc_data_structures/graph/implementation/tests.rs
@@ -1,4 +1,4 @@
-use graph::implementation::*;
+use crate::graph::implementation::*;
 use std::fmt::Debug;
 
 type TestGraph = Graph<&'static str, &'static str>;

--- a/src/librustc_data_structures/graph/scc/mod.rs
+++ b/src/librustc_data_structures/graph/scc/mod.rs
@@ -3,9 +3,9 @@
 //! node in the graph. This uses Tarjan's algorithm that completes in
 //! O(n) time.
 
-use fx::FxHashSet;
-use graph::{DirectedGraph, WithNumNodes, WithSuccessors};
-use indexed_vec::{Idx, IndexVec};
+use crate::fx::FxHashSet;
+use crate::graph::{DirectedGraph, WithNumNodes, WithSuccessors};
+use crate::indexed_vec::{Idx, IndexVec};
 use std::ops::Range;
 
 mod test;
@@ -93,7 +93,7 @@ impl<S: Idx> SccData<S> {
     }
 }
 
-struct SccsConstruction<'c, G: DirectedGraph + WithNumNodes + WithSuccessors + 'c, S: Idx> {
+struct SccsConstruction<'c, G: DirectedGraph + WithNumNodes + WithSuccessors, S: Idx> {
     graph: &'c G,
 
     /// The state of each node; used during walk to record the stack

--- a/src/librustc_data_structures/graph/scc/test.rs
+++ b/src/librustc_data_structures/graph/scc/test.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-use graph::test::TestGraph;
+use crate::graph::test::TestGraph;
 use super::*;
 
 #[test]

--- a/src/librustc_data_structures/graph/test.rs
+++ b/src/librustc_data_structures/graph/test.rs
@@ -1,4 +1,4 @@
-use fx::FxHashMap;
+use crate::fx::FxHashMap;
 use std::cmp::max;
 use std::slice;
 use std::iter;

--- a/src/librustc_data_structures/indexed_vec.rs
+++ b/src/librustc_data_structures/indexed_vec.rs
@@ -257,7 +257,7 @@ macro_rules! newtype_index {
      @type         [$type:ident]
      @debug_format [$debug_format:tt]) => (
         impl ::std::fmt::Debug for $type {
-            fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+            fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
                 write!(fmt, $debug_format, self.as_u32())
             }
         }
@@ -495,7 +495,7 @@ impl<I: Idx, T: serialize::Decodable> serialize::Decodable for IndexVec<I, T> {
 }
 
 impl<I: Idx, T: fmt::Debug> fmt::Debug for IndexVec<I, T> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&self.raw, fmt)
     }
 }
@@ -573,7 +573,7 @@ impl<I: Idx, T> IndexVec<I, T> {
     }
 
     #[inline]
-    pub fn iter(&self) -> slice::Iter<T> {
+    pub fn iter(&self) -> slice::Iter<'_, T> {
         self.raw.iter()
     }
 
@@ -589,7 +589,7 @@ impl<I: Idx, T> IndexVec<I, T> {
     }
 
     #[inline]
-    pub fn iter_mut(&mut self) -> slice::IterMut<T> {
+    pub fn iter_mut(&mut self) -> slice::IterMut<'_, T> {
         self.raw.iter_mut()
     }
 

--- a/src/librustc_data_structures/lib.rs
+++ b/src/librustc_data_structures/lib.rs
@@ -24,23 +24,16 @@
 #![cfg_attr(unix, feature(libc))]
 #![cfg_attr(test, feature(test))]
 
-extern crate core;
-extern crate ena;
+#![deny(rust_2018_idioms)]
+
 #[macro_use]
 extern crate log;
+#[allow(unused_extern_crates)]
 extern crate serialize as rustc_serialize; // used by deriving
 #[cfg(unix)]
 extern crate libc;
-extern crate parking_lot;
 #[macro_use]
 extern crate cfg_if;
-extern crate stable_deref_trait;
-extern crate rustc_rayon as rayon;
-extern crate rustc_rayon_core as rayon_core;
-extern crate rustc_hash;
-extern crate serialize;
-extern crate graphviz;
-extern crate smallvec;
 
 // See librustc_cratesio_shim/Cargo.toml for a comment explaining this.
 #[allow(unused_extern_crates)]

--- a/src/librustc_data_structures/obligation_forest/graphviz.rs
+++ b/src/librustc_data_structures/obligation_forest/graphviz.rs
@@ -1,5 +1,5 @@
+use crate::obligation_forest::{ForestObligation, ObligationForest};
 use graphviz as dot;
-use obligation_forest::{ForestObligation, ObligationForest};
 use std::env::var_os;
 use std::fs::File;
 use std::path::Path;
@@ -41,22 +41,22 @@ impl<'a, O: ForestObligation + 'a> dot::Labeller<'a> for &'a ObligationForest<O>
     type Node = usize;
     type Edge = (usize, usize);
 
-    fn graph_id(&self) -> dot::Id {
+    fn graph_id(&self) -> dot::Id<'_> {
         dot::Id::new("trait_obligation_forest").unwrap()
     }
 
-    fn node_id(&self, index: &Self::Node) -> dot::Id {
+    fn node_id(&self, index: &Self::Node) -> dot::Id<'_> {
         dot::Id::new(format!("obligation_{}", index)).unwrap()
     }
 
-    fn node_label(&self, index: &Self::Node) -> dot::LabelText {
+    fn node_label(&self, index: &Self::Node) -> dot::LabelText<'_> {
         let node = &self.nodes[*index];
         let label = format!("{:?} ({:?})", node.obligation.as_predicate(), node.state.get());
 
         dot::LabelText::LabelStr(label.into())
     }
 
-    fn edge_label(&self, (_index_source, _index_target): &Self::Edge) -> dot::LabelText {
+    fn edge_label(&self, (_index_source, _index_target): &Self::Edge) -> dot::LabelText<'_> {
         dot::LabelText::LabelStr("".into())
     }
 }
@@ -65,11 +65,11 @@ impl<'a, O: ForestObligation + 'a> dot::GraphWalk<'a> for &'a ObligationForest<O
     type Node = usize;
     type Edge = (usize, usize);
 
-    fn nodes(&self) -> dot::Nodes<Self::Node> {
+    fn nodes(&self) -> dot::Nodes<'_, Self::Node> {
         (0..self.nodes.len()).collect()
     }
 
-    fn edges(&self) -> dot::Edges<Self::Edge> {
+    fn edges(&self) -> dot::Edges<'_, Self::Edge> {
         (0..self.nodes.len())
             .flat_map(|i| {
                 let node = &self.nodes[i];

--- a/src/librustc_data_structures/obligation_forest/mod.rs
+++ b/src/librustc_data_structures/obligation_forest/mod.rs
@@ -80,7 +80,7 @@
 //! processing step, we compress the vector to remove completed and error
 //! nodes, which aren't needed anymore.
 
-use fx::{FxHashMap, FxHashSet};
+use crate::fx::{FxHashMap, FxHashSet};
 
 use std::cell::Cell;
 use std::collections::hash_map::Entry;
@@ -733,7 +733,7 @@ impl<O> Node<O> {
 
 // I need a Clone closure
 #[derive(Clone)]
-struct GetObligation<'a, O: 'a>(&'a [Node<O>]);
+struct GetObligation<'a, O>(&'a [Node<O>]);
 
 impl<'a, 'b, O> FnOnce<(&'b usize,)> for GetObligation<'a, O> {
     type Output = &'a O;

--- a/src/librustc_data_structures/owning_ref/mod.rs
+++ b/src/librustc_data_structures/owning_ref/mod.rs
@@ -1002,7 +1002,7 @@ impl<O, T: ?Sized> Debug for OwningRef<O, T>
     where O: Debug,
           T: Debug,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f,
                "OwningRef {{ owner: {:?}, reference: {:?} }}",
                self.owner(),
@@ -1014,7 +1014,7 @@ impl<O, T: ?Sized> Debug for OwningRefMut<O, T>
     where O: Debug,
           T: Debug,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f,
                "OwningRefMut {{ owner: {:?}, reference: {:?} }}",
                self.owner(),
@@ -1047,7 +1047,7 @@ unsafe impl<O, T: ?Sized> Sync for OwningRefMut<O, T>
     where O: Sync, for<'a> (&'a mut T): Sync {}
 
 impl Debug for dyn Erased {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "<Erased>",)
     }
 }

--- a/src/librustc_data_structures/ptr_key.rs
+++ b/src/librustc_data_structures/ptr_key.rs
@@ -4,7 +4,7 @@ use std::ops::Deref;
 /// A wrapper around reference that compares and hashes like a pointer.
 /// Can be used as a key in sets/maps indexed by pointers to avoid `unsafe`.
 #[derive(Debug)]
-pub struct PtrKey<'a, T: 'a>(pub &'a T);
+pub struct PtrKey<'a, T>(pub &'a T);
 
 impl<'a, T> Clone for PtrKey<'a, T> {
     fn clone(&self) -> Self { *self }

--- a/src/librustc_data_structures/snapshot_map/mod.rs
+++ b/src/librustc_data_structures/snapshot_map/mod.rs
@@ -1,4 +1,4 @@
-use fx::FxHashMap;
+use crate::fx::FxHashMap;
 use std::hash::Hash;
 use std::ops;
 use std::mem;

--- a/src/librustc_data_structures/sorted_map.rs
+++ b/src/librustc_data_structures/sorted_map.rs
@@ -111,7 +111,7 @@ impl<K: Ord, V> SortedMap<K, V> {
 
     /// Iterate over elements, sorted by key
     #[inline]
-    pub fn iter(&self) -> ::std::slice::Iter<(K, V)> {
+    pub fn iter(&self) -> ::std::slice::Iter<'_, (K, V)> {
         self.data.iter()
     }
 

--- a/src/librustc_data_structures/stable_hasher.rs
+++ b/src/librustc_data_structures/stable_hasher.rs
@@ -1,7 +1,9 @@
 use std::hash::{Hash, Hasher, BuildHasher};
 use std::marker::PhantomData;
 use std::mem;
-use sip128::SipHasher128;
+use crate::sip128::SipHasher128;
+use crate::indexed_vec;
+use crate::bit_set;
 
 /// When hashing something that ends up affecting properties like symbol names,
 /// we want these symbol names to be calculated independently of other factors
@@ -17,7 +19,7 @@ pub struct StableHasher<W> {
 }
 
 impl<W: StableHasherResult> ::std::fmt::Debug for StableHasher<W> {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         write!(f, "{:?}", self.state)
     }
 }
@@ -433,7 +435,7 @@ impl<T, CTX> HashStable<CTX> for ::std::mem::Discriminant<T> {
     }
 }
 
-impl<I: ::indexed_vec::Idx, T, CTX> HashStable<CTX> for ::indexed_vec::IndexVec<I, T>
+impl<I: indexed_vec::Idx, T, CTX> HashStable<CTX> for indexed_vec::IndexVec<I, T>
     where T: HashStable<CTX>,
 {
     fn hash_stable<W: StableHasherResult>(&self,
@@ -447,7 +449,7 @@ impl<I: ::indexed_vec::Idx, T, CTX> HashStable<CTX> for ::indexed_vec::IndexVec<
 }
 
 
-impl<I: ::indexed_vec::Idx, CTX> HashStable<CTX> for ::bit_set::BitSet<I>
+impl<I: indexed_vec::Idx, CTX> HashStable<CTX> for bit_set::BitSet<I>
 {
     fn hash_stable<W: StableHasherResult>(&self,
                                           ctx: &mut CTX,

--- a/src/librustc_data_structures/svh.rs
+++ b/src/librustc_data_structures/svh.rs
@@ -9,7 +9,7 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 use serialize::{Encodable, Decodable, Encoder, Decoder};
 
-use stable_hasher;
+use crate::stable_hasher;
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub struct Svh {
@@ -40,7 +40,7 @@ impl Hash for Svh {
 }
 
 impl fmt::Display for Svh {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad(&self.to_string())
     }
 }

--- a/src/librustc_data_structures/sync.rs
+++ b/src/librustc_data_structures/sync.rs
@@ -21,7 +21,7 @@ use std::collections::HashMap;
 use std::hash::{Hash, BuildHasher};
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
-use owning_ref::{Erased, OwningRef};
+use crate::owning_ref::{Erased, OwningRef};
 
 pub fn serial_join<A, B, RA, RB>(oper_a: A, oper_b: B) -> (RA, RB)
     where A: FnOnce() -> RA,
@@ -261,12 +261,12 @@ cfg_if! {
             }
 
             #[inline(always)]
-            pub fn lock(&self) -> LockGuard<T> {
+            pub fn lock(&self) -> LockGuard<'_, T> {
                 self.0.lock()
             }
 
             #[inline(always)]
-            pub fn lock_mut(&self) -> LockGuard<T> {
+            pub fn lock_mut(&self) -> LockGuard<'_, T> {
                 self.lock()
             }
         }
@@ -490,19 +490,19 @@ impl<T> Lock<T> {
 
     #[cfg(parallel_compiler)]
     #[inline(always)]
-    pub fn try_lock(&self) -> Option<LockGuard<T>> {
+    pub fn try_lock(&self) -> Option<LockGuard<'_, T>> {
         self.0.try_lock()
     }
 
     #[cfg(not(parallel_compiler))]
     #[inline(always)]
-    pub fn try_lock(&self) -> Option<LockGuard<T>> {
+    pub fn try_lock(&self) -> Option<LockGuard<'_, T>> {
         self.0.try_borrow_mut().ok()
     }
 
     #[cfg(parallel_compiler)]
     #[inline(always)]
-    pub fn lock(&self) -> LockGuard<T> {
+    pub fn lock(&self) -> LockGuard<'_, T> {
         if ERROR_CHECKING {
             self.0.try_lock().expect("lock was already held")
         } else {
@@ -512,7 +512,7 @@ impl<T> Lock<T> {
 
     #[cfg(not(parallel_compiler))]
     #[inline(always)]
-    pub fn lock(&self) -> LockGuard<T> {
+    pub fn lock(&self) -> LockGuard<'_, T> {
         self.0.borrow_mut()
     }
 
@@ -522,12 +522,12 @@ impl<T> Lock<T> {
     }
 
     #[inline(always)]
-    pub fn borrow(&self) -> LockGuard<T> {
+    pub fn borrow(&self) -> LockGuard<'_, T> {
         self.lock()
     }
 
     #[inline(always)]
-    pub fn borrow_mut(&self) -> LockGuard<T> {
+    pub fn borrow_mut(&self) -> LockGuard<'_, T> {
         self.lock()
     }
 }
@@ -568,13 +568,13 @@ impl<T> RwLock<T> {
 
     #[cfg(not(parallel_compiler))]
     #[inline(always)]
-    pub fn read(&self) -> ReadGuard<T> {
+    pub fn read(&self) -> ReadGuard<'_, T> {
         self.0.borrow()
     }
 
     #[cfg(parallel_compiler)]
     #[inline(always)]
-    pub fn read(&self) -> ReadGuard<T> {
+    pub fn read(&self) -> ReadGuard<'_, T> {
         if ERROR_CHECKING {
             self.0.try_read().expect("lock was already held")
         } else {
@@ -589,25 +589,25 @@ impl<T> RwLock<T> {
 
     #[cfg(not(parallel_compiler))]
     #[inline(always)]
-    pub fn try_write(&self) -> Result<WriteGuard<T>, ()> {
+    pub fn try_write(&self) -> Result<WriteGuard<'_, T>, ()> {
         self.0.try_borrow_mut().map_err(|_| ())
     }
 
     #[cfg(parallel_compiler)]
     #[inline(always)]
-    pub fn try_write(&self) -> Result<WriteGuard<T>, ()> {
+    pub fn try_write(&self) -> Result<WriteGuard<'_, T>, ()> {
         self.0.try_write().ok_or(())
     }
 
     #[cfg(not(parallel_compiler))]
     #[inline(always)]
-    pub fn write(&self) -> WriteGuard<T> {
+    pub fn write(&self) -> WriteGuard<'_, T> {
         self.0.borrow_mut()
     }
 
     #[cfg(parallel_compiler)]
     #[inline(always)]
-    pub fn write(&self) -> WriteGuard<T> {
+    pub fn write(&self) -> WriteGuard<'_, T> {
         if ERROR_CHECKING {
             self.0.try_write().expect("lock was already held")
         } else {
@@ -621,12 +621,12 @@ impl<T> RwLock<T> {
     }
 
     #[inline(always)]
-    pub fn borrow(&self) -> ReadGuard<T> {
+    pub fn borrow(&self) -> ReadGuard<'_, T> {
         self.read()
     }
 
     #[inline(always)]
-    pub fn borrow_mut(&self) -> WriteGuard<T> {
+    pub fn borrow_mut(&self) -> WriteGuard<'_, T> {
         self.write()
     }
 }

--- a/src/librustc_data_structures/tiny_list.rs
+++ b/src/librustc_data_structures/tiny_list.rs
@@ -123,7 +123,7 @@ impl<T: PartialEq> Element<T> {
 mod test {
     use super::*;
     extern crate test;
-    use self::test::Bencher;
+    use test::Bencher;
 
     #[test]
     fn test_contains_and_insert() {

--- a/src/librustc_data_structures/transitive_relation.rs
+++ b/src/librustc_data_structures/transitive_relation.rs
@@ -1,8 +1,8 @@
-use bit_set::BitMatrix;
-use fx::FxHashMap;
-use sync::Lock;
+use crate::bit_set::BitMatrix;
+use crate::fx::FxHashMap;
+use crate::stable_hasher::{HashStable, StableHasher, StableHasherResult};
+use crate::sync::Lock;
 use rustc_serialize::{Encodable, Encoder, Decodable, Decoder};
-use stable_hasher::{HashStable, StableHasher, StableHasherResult};
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::mem;

--- a/src/librustc_data_structures/vec_linked_list.rs
+++ b/src/librustc_data_structures/vec_linked_list.rs
@@ -1,4 +1,4 @@
-use indexed_vec::{Idx, IndexVec};
+use crate::indexed_vec::{Idx, IndexVec};
 
 pub fn iter<Ls>(
     first: Option<Ls::LinkIndex>,

--- a/src/librustc_data_structures/work_queue.rs
+++ b/src/librustc_data_structures/work_queue.rs
@@ -1,5 +1,5 @@
-use bit_set::BitSet;
-use indexed_vec::Idx;
+use crate::bit_set::BitSet;
+use crate::indexed_vec::Idx;
 use std::collections::VecDeque;
 
 /// A work queue is a handy data structure for tracking work left to


### PR DESCRIPTION
Transitions `librustc_data_structures` to Rust 2018; cc #58099

r? @Centril