### PR TITLE
librustc_codegen_ssa => 2018

### DIFF
--- a/src/librustc_codegen_ssa/Cargo.toml
+++ b/src/librustc_codegen_ssa/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_codegen_ssa"
 version = "0.0.0"
+edition = "2018"
 
 [lib]
 name = "rustc_codegen_ssa"

--- a/src/librustc_codegen_ssa/back/link.rs
+++ b/src/librustc_codegen_ssa/back/link.rs
@@ -9,7 +9,7 @@ use rustc_target::spec::LinkerFlavor;
 use rustc::hir::def_id::CrateNum;
 
 use super::command::Command;
-use CrateInfo;
+use crate::CrateInfo;
 
 use cc::windows_registry;
 use std::fs;

--- a/src/librustc_codegen_ssa/back/lto.rs
+++ b/src/librustc_codegen_ssa/back/lto.rs
@@ -1,6 +1,6 @@
 use super::write::CodegenContext;
-use traits::*;
-use ModuleCodegen;
+use crate::traits::*;
+use crate::ModuleCodegen;
 
 use rustc::util::time_graph::Timeline;
 use rustc_errors::FatalError;

--- a/src/librustc_codegen_ssa/back/write.rs
+++ b/src/librustc_codegen_ssa/back/write.rs
@@ -1,12 +1,12 @@
-use {ModuleCodegen, ModuleKind, CachedModuleCodegen, CompiledModule, CrateInfo, CodegenResults,
-    RLIB_BYTECODE_EXTENSION};
+use crate::{ModuleCodegen, ModuleKind, CachedModuleCodegen, CompiledModule, CrateInfo,
+    CodegenResults, RLIB_BYTECODE_EXTENSION};
 use super::linker::LinkerInfo;
 use super::lto::{self, SerializedModule};
 use super::link::{self, remove, get_linker};
 use super::command::Command;
 use super::symbol_export::ExportedSymbols;
 
-use memmap;
+use crate::traits::*;
 use rustc_incremental::{copy_cgu_workproducts_to_incr_comp_cache_dir,
                         in_incr_comp_dir, in_incr_comp_dir_sess};
 use rustc::dep_graph::{WorkProduct, WorkProductId, WorkProductFileKind};
@@ -16,7 +16,6 @@ use rustc::session::config::{self, OutputFilenames, OutputType, Passes, Sanitize
 use rustc::session::Session;
 use rustc::util::nodemap::FxHashMap;
 use rustc::util::time_graph::{self, TimeGraph, Timeline};
-use traits::*;
 use rustc::hir::def_id::{CrateNum, LOCAL_CRATE};
 use rustc::ty::TyCtxt;
 use rustc::util::common::{time_depth, set_time_depth, print_time_passes_entry};

--- a/src/librustc_codegen_ssa/base.rs
+++ b/src/librustc_codegen_ssa/base.rs
@@ -13,7 +13,7 @@
 //!     but one llvm::Type corresponds to many `Ty`s; for instance, tup(int, int,
 //!     int) and rec(x=int, y=int, z=int) will have the same llvm::Type.
 
-use {ModuleCodegen, ModuleKind, CachedModuleCodegen};
+use crate::{ModuleCodegen, ModuleKind, CachedModuleCodegen};
 
 use rustc::dep_graph::cgu_reuse_tracker::CguReuse;
 use rustc::hir::def_id::{CrateNum, DefId, LOCAL_CRATE};
@@ -28,26 +28,26 @@ use rustc::util::common::{time, print_time_passes_entry};
 use rustc::util::profiling::ProfileCategory;
 use rustc::session::config::{self, EntryFnType, Lto};
 use rustc::session::Session;
-use mir::place::PlaceRef;
-use back::write::{OngoingCodegen, start_async_codegen, submit_pre_lto_module_to_llvm,
-    submit_post_lto_module_to_llvm};
-use {MemFlags, CrateInfo};
-use callee;
 use rustc_mir::monomorphize::item::DefPathBasedNames;
-use common::{RealPredicate, TypeKind, IntPredicate};
-use meth;
-use mir;
 use rustc::util::time_graph;
 use rustc_mir::monomorphize::Instance;
 use rustc_mir::monomorphize::partitioning::{CodegenUnit, CodegenUnitExt};
-use mono_item::MonoItem;
 use rustc::util::nodemap::FxHashMap;
 use rustc_data_structures::indexed_vec::Idx;
 use rustc_data_structures::sync::Lrc;
 use rustc_codegen_utils::{symbol_names_test, check_for_rustc_errors_attr};
 use rustc::ty::layout::{FAT_PTR_ADDR, FAT_PTR_EXTRA};
+use crate::mir::place::PlaceRef;
+use crate::back::write::{OngoingCodegen, start_async_codegen, submit_pre_lto_module_to_llvm,
+    submit_post_lto_module_to_llvm};
+use crate::{MemFlags, CrateInfo};
+use crate::callee;
+use crate::common::{RealPredicate, TypeKind, IntPredicate};
+use crate::meth;
+use crate::mir;
+use crate::mono_item::MonoItem;
 
-use traits::*;
+use crate::traits::*;
 
 use std::any::Any;
 use std::cmp;
@@ -58,7 +58,7 @@ use syntax_pos::Span;
 use syntax::attr;
 use rustc::hir;
 
-use mir::operand::OperandValue;
+use crate::mir::operand::OperandValue;
 
 use std::marker::PhantomData;
 

--- a/src/librustc_codegen_ssa/callee.rs
+++ b/src/librustc_codegen_ssa/callee.rs
@@ -1,4 +1,4 @@
-use traits::*;
+use crate::traits::*;
 use rustc::ty;
 use rustc::ty::subst::Substs;
 use rustc::hir::def_id::DefId;

--- a/src/librustc_codegen_ssa/common.rs
+++ b/src/librustc_codegen_ssa/common.rs
@@ -5,11 +5,11 @@ use syntax_pos::{DUMMY_SP, Span};
 
 use rustc::hir::def_id::DefId;
 use rustc::middle::lang_items::LangItem;
-use base;
-use traits::*;
+use crate::base;
+use crate::traits::*;
 
 use rustc::hir;
-use traits::BuilderMethods;
+use crate::traits::BuilderMethods;
 
 pub fn type_needs_drop<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, ty: Ty<'tcx>) -> bool {
     ty.needs_drop(tcx, ty::ParamEnv::reveal_all())
@@ -123,7 +123,7 @@ pub enum TypeKind {
 mod temp_stable_hash_impls {
     use rustc_data_structures::stable_hasher::{StableHasherResult, StableHasher,
                                                HashStable};
-    use ModuleCodegen;
+    use crate::ModuleCodegen;
 
     impl<HCX, M> HashStable<HCX> for ModuleCodegen<M> {
         fn hash_stable<W: StableHasherResult>(&self,

--- a/src/librustc_codegen_ssa/glue.rs
+++ b/src/librustc_codegen_ssa/glue.rs
@@ -2,12 +2,10 @@
 //
 // Code relating to drop glue.
 
-use std;
-
-use common::IntPredicate;
-use meth;
 use rustc::ty::{self, Ty};
-use traits::*;
+use crate::common::IntPredicate;
+use crate::meth;
+use crate::traits::*;
 
 pub fn size_and_align_of_dst<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>>(
     bx: &mut Bx,

--- a/src/librustc_codegen_ssa/lib.rs
+++ b/src/librustc_codegen_ssa/lib.rs
@@ -10,6 +10,9 @@
 #![feature(nll)]
 #![allow(unused_attributes)]
 #![allow(dead_code)]
+#![deny(rust_2018_idioms)]
+#![allow(explicit_outlives_requirements)]
+#![allow(elided_lifetimes_in_paths)]
 
 #![recursion_limit="256"]
 
@@ -17,27 +20,9 @@
 //! The backend-agnostic functions of this crate use functions defined in various traits that
 //! have to be implemented by each backends.
 
-#[macro_use] extern crate bitflags;
 #[macro_use] extern crate log;
-extern crate rustc_apfloat;
-#[macro_use]  extern crate rustc;
-extern crate rustc_target;
-extern crate rustc_mir;
+#[macro_use] extern crate rustc;
 #[macro_use] extern crate syntax;
-extern crate syntax_pos;
-extern crate rustc_incremental;
-extern crate rustc_codegen_utils;
-extern crate rustc_data_structures;
-extern crate rustc_allocator;
-extern crate rustc_fs_util;
-extern crate serialize;
-extern crate rustc_errors;
-extern crate rustc_demangle;
-extern crate cc;
-extern crate libc;
-extern crate jobserver;
-extern crate memmap;
-extern crate num_cpus;
 
 use std::path::PathBuf;
 use rustc::dep_graph::WorkProduct;
@@ -133,7 +118,7 @@ pub enum ModuleKind {
     Allocator,
 }
 
-bitflags! {
+bitflags::bitflags! {
     pub struct MemFlags: u8 {
         const VOLATILE = 1 << 0;
         const NONTEMPORAL = 1 << 1;

--- a/src/librustc_codegen_ssa/meth.rs
+++ b/src/librustc_codegen_ssa/meth.rs
@@ -1,8 +1,8 @@
 use rustc_target::abi::call::FnType;
-use callee;
 use rustc_mir::monomorphize;
 
-use traits::*;
+use crate::callee;
+use crate::traits::*;
 
 use rustc::ty::{self, Ty};
 

--- a/src/librustc_codegen_ssa/mir/analyze.rs
+++ b/src/librustc_codegen_ssa/mir/analyze.rs
@@ -10,7 +10,7 @@ use rustc::mir::traversal;
 use rustc::ty;
 use rustc::ty::layout::{LayoutOf, HasTyCtxt};
 use super::FunctionCx;
-use traits::*;
+use crate::traits::*;
 
 pub fn non_ssa_locals<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>>(
     fx: &FunctionCx<'a, 'tcx, Bx>

--- a/src/librustc_codegen_ssa/mir/block.rs
+++ b/src/librustc_codegen_ssa/mir/block.rs
@@ -5,13 +5,13 @@ use rustc::mir;
 use rustc::mir::interpret::EvalErrorKind;
 use rustc_target::abi::call::{ArgType, FnType, PassMode};
 use rustc_target::spec::abi::Abi;
-use base;
-use MemFlags;
-use common::{self, IntPredicate};
-use meth;
 use rustc_mir::monomorphize;
+use crate::base;
+use crate::MemFlags;
+use crate::common::{self, IntPredicate};
+use crate::meth;
 
-use traits::*;
+use crate::traits::*;
 
 use syntax::symbol::Symbol;
 use syntax_pos::Pos;

--- a/src/librustc_codegen_ssa/mir/constant.rs
+++ b/src/librustc_codegen_ssa/mir/constant.rs
@@ -6,7 +6,7 @@ use rustc::mir::interpret::GlobalId;
 use rustc::ty::{self, Ty};
 use rustc::ty::layout;
 use syntax::source_map::Span;
-use traits::*;
+use crate::traits::*;
 
 use super::FunctionCx;
 

--- a/src/librustc_codegen_ssa/mir/mod.rs
+++ b/src/librustc_codegen_ssa/mir/mod.rs
@@ -4,11 +4,11 @@ use rustc::ty::layout::{TyLayout, HasTyCtxt};
 use rustc::mir::{self, Mir};
 use rustc::ty::subst::Substs;
 use rustc::session::config::DebugInfo;
-use base;
-use debuginfo::{self, VariableAccess, VariableKind, FunctionDebugContext};
 use rustc_mir::monomorphize::Instance;
 use rustc_target::abi::call::{FnType, PassMode};
-use traits::*;
+use crate::base;
+use crate::debuginfo::{self, VariableAccess, VariableKind, FunctionDebugContext};
+use crate::traits::*;
 
 use syntax_pos::{DUMMY_SP, NO_EXPANSION, BytePos, Span};
 use syntax::symbol::keywords;

--- a/src/librustc_codegen_ssa/mir/operand.rs
+++ b/src/librustc_codegen_ssa/mir/operand.rs
@@ -3,11 +3,11 @@ use rustc::mir;
 use rustc::ty;
 use rustc::ty::layout::{self, Align, LayoutOf, TyLayout};
 
-use base;
-use MemFlags;
-use glue;
+use crate::base;
+use crate::MemFlags;
+use crate::glue;
 
-use traits::*;
+use crate::traits::*;
 
 use std::fmt;
 

--- a/src/librustc_codegen_ssa/mir/place.rs
+++ b/src/librustc_codegen_ssa/mir/place.rs
@@ -2,11 +2,11 @@ use rustc::ty::{self, Ty};
 use rustc::ty::layout::{self, Align, TyLayout, LayoutOf, VariantIdx, HasTyCtxt};
 use rustc::mir;
 use rustc::mir::tcx::PlaceTy;
-use MemFlags;
-use common::IntPredicate;
-use glue;
+use crate::MemFlags;
+use crate::common::IntPredicate;
+use crate::glue;
 
-use traits::*;
+use crate::traits::*;
 
 use super::{FunctionCx, LocalRef};
 use super::operand::OperandValue;

--- a/src/librustc_codegen_ssa/mir/rvalue.rs
+++ b/src/librustc_codegen_ssa/mir/rvalue.rs
@@ -6,13 +6,13 @@ use rustc::middle::lang_items::ExchangeMallocFnLangItem;
 use rustc_apfloat::{ieee, Float, Status, Round};
 use std::{u128, i128};
 
-use base;
-use MemFlags;
-use callee;
-use common::{self, RealPredicate, IntPredicate};
+use crate::base;
+use crate::MemFlags;
+use crate::callee;
+use crate::common::{self, RealPredicate, IntPredicate};
 use rustc_mir::monomorphize;
 
-use traits::*;
+use crate::traits::*;
 
 use super::{FunctionCx, LocalRef};
 use super::operand::{OperandRef, OperandValue};

--- a/src/librustc_codegen_ssa/mir/statement.rs
+++ b/src/librustc_codegen_ssa/mir/statement.rs
@@ -1,10 +1,10 @@
 use rustc::mir;
 
-use traits::BuilderMethods;
+use crate::traits::BuilderMethods;
 use super::FunctionCx;
 use super::LocalRef;
 use super::OperandValue;
-use traits::*;
+use crate::traits::*;
 
 impl<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
     pub fn codegen_statement(

--- a/src/librustc_codegen_ssa/mono_item.rs
+++ b/src/librustc_codegen_ssa/mono_item.rs
@@ -1,10 +1,10 @@
-use base;
 use rustc::hir;
 use rustc::hir::def::Def;
 use rustc::mir::mono::{Linkage, Visibility};
 use rustc::ty::layout::HasTyCtxt;
 use std::fmt;
-use traits::*;
+use crate::base;
+use crate::traits::*;
 
 pub use rustc::mir::mono::MonoItem;
 

--- a/src/librustc_codegen_ssa/traits/asm.rs
+++ b/src/librustc_codegen_ssa/traits/asm.rs
@@ -1,5 +1,5 @@
 use super::BackendTypes;
-use mir::place::PlaceRef;
+use crate::mir::place::PlaceRef;
 use rustc::hir::{GlobalAsm, InlineAsm};
 
 pub trait AsmBuilderMethods<'tcx>: BackendTypes {

--- a/src/librustc_codegen_ssa/traits/builder.rs
+++ b/src/librustc_codegen_ssa/traits/builder.rs
@@ -4,13 +4,14 @@ use super::debuginfo::DebugInfoBuilderMethods;
 use super::intrinsic::IntrinsicCallMethods;
 use super::type_::ArgTypeMethods;
 use super::{HasCodegen, StaticBuilderMethods};
-use common::{AtomicOrdering, AtomicRmwBinOp, IntPredicate, RealPredicate, SynchronizationScope};
-use mir::operand::OperandRef;
-use mir::place::PlaceRef;
+use crate::common::{AtomicOrdering, AtomicRmwBinOp, IntPredicate, RealPredicate,
+    SynchronizationScope};
+use crate::mir::operand::OperandRef;
+use crate::mir::place::PlaceRef;
+use crate::MemFlags;
 use rustc::ty::Ty;
 use rustc::ty::layout::{Align, Size};
 use std::ffi::CStr;
-use MemFlags;
 
 use std::borrow::Cow;
 use std::ops::Range;

--- a/src/librustc_codegen_ssa/traits/consts.rs
+++ b/src/librustc_codegen_ssa/traits/consts.rs
@@ -1,5 +1,5 @@
 use super::BackendTypes;
-use mir::place::PlaceRef;
+use crate::mir::place::PlaceRef;
 use rustc::mir::interpret::Allocation;
 use rustc::mir::interpret::Scalar;
 use rustc::ty::layout;

--- a/src/librustc_codegen_ssa/traits/debuginfo.rs
+++ b/src/librustc_codegen_ssa/traits/debuginfo.rs
@@ -1,5 +1,5 @@
 use super::BackendTypes;
-use debuginfo::{FunctionDebugContext, MirDebugScope, VariableAccess, VariableKind};
+use crate::debuginfo::{FunctionDebugContext, MirDebugScope, VariableAccess, VariableKind};
 use rustc::hir::def_id::CrateNum;
 use rustc::mir;
 use rustc::ty::{self, Ty};

--- a/src/librustc_codegen_ssa/traits/intrinsic.rs
+++ b/src/librustc_codegen_ssa/traits/intrinsic.rs
@@ -1,5 +1,5 @@
 use super::BackendTypes;
-use mir::operand::OperandRef;
+use crate::mir::operand::OperandRef;
 use rustc::ty::Ty;
 use rustc_target::abi::call::FnType;
 use syntax_pos::Span;

--- a/src/librustc_codegen_ssa/traits/type_.rs
+++ b/src/librustc_codegen_ssa/traits/type_.rs
@@ -1,8 +1,8 @@
 use super::misc::MiscMethods;
 use super::Backend;
 use super::HasCodegen;
-use common::{self, TypeKind};
-use mir::place::PlaceRef;
+use crate::common::{self, TypeKind};
+use crate::mir::place::PlaceRef;
 use rustc::ty::layout::{self, Align, Size, TyLayout};
 use rustc::ty::{self, Ty};
 use rustc::util::nodemap::FxHashMap;

--- a/src/librustc_codegen_ssa/traits/write.rs
+++ b/src/librustc_codegen_ssa/traits/write.rs
@@ -1,6 +1,6 @@
-use back::lto::{LtoModuleCodegen, SerializedModule, ThinModule};
-use back::write::{CodegenContext, ModuleConfig};
-use {CompiledModule, ModuleCodegen};
+use crate::back::lto::{LtoModuleCodegen, SerializedModule, ThinModule};
+use crate::back::write::{CodegenContext, ModuleConfig};
+use crate::{CompiledModule, ModuleCodegen};
 
 use rustc::dep_graph::WorkProduct;
 use rustc::util::time_graph::Timeline;


### PR DESCRIPTION
Transitions `librustc_codegen_ssa` to Rust 2018; cc #58099

r? @petrochenkov