### PR TITLE
Fix search results interactions

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -1197,7 +1197,7 @@ if (!DOMTokenList.prototype.remove) {
                 var actives = [[], [], []];
                 // "current" is used to know which tab we're looking into.
                 var current = 0;
-                onEachLazy(document.getElementsByClassName("search-results"), function(e) {
+                onEachLazy(document.getElementById("results").childNodes, function(e) {
                     onEachLazy(e.getElementsByClassName("highlighted"), function(e) {
                         actives[current].push(e);
                     });
@@ -1214,7 +1214,7 @@ if (!DOMTokenList.prototype.remove) {
                     removeClass(actives[currentTab][0], "highlighted");
                 } else if (e.which === 40) { // down
                     if (!actives[currentTab].length) {
-                        var results = document.getElementsByClassName("search-results");
+                        var results = document.getElementById("results").childNodes;
                         if (results.length > 0) {
                             var res = results[currentTab].getElementsByClassName("result");
                             if (res.length > 0) {


### PR DESCRIPTION
The bug is visible when you search for "none": the second tab is empty and therefore it messes with the classes. Then when you try to use arrows on the third tab, it just crashes (because only 2 "search-results" are present and you're on tab 3).

r? @QuietMisdreavus 