### PR TITLE
Revert removed #![feature(nll)]

### DIFF
--- a/src/libfmt_macros/lib.rs
+++ b/src/libfmt_macros/lib.rs
@@ -10,6 +10,7 @@
 
 #![deny(rust_2018_idioms)]
 
+#![feature(nll)]
 #![feature(rustc_private)]
 
 pub use Piece::*;

--- a/src/libgraphviz/lib.rs
+++ b/src/libgraphviz/lib.rs
@@ -276,6 +276,7 @@
 
 #![deny(rust_2018_idioms)]
 
+#![feature(nll)]
 #![feature(str_escape)]
 
 use LabelText::*;

--- a/src/libpanic_abort/lib.rs
+++ b/src/libpanic_abort/lib.rs
@@ -14,6 +14,7 @@
 
 #![feature(core_intrinsics)]
 #![feature(libc)]
+#![feature(nll)]
 #![feature(panic_runtime)]
 #![feature(staged_api)]
 #![feature(rustc_attrs)]

--- a/src/libproc_macro/lib.rs
+++ b/src/libproc_macro/lib.rs
@@ -17,6 +17,7 @@
 
 #![deny(rust_2018_idioms)]
 
+#![feature(nll)]
 #![feature(staged_api)]
 #![feature(const_fn)]
 #![feature(extern_types)]

--- a/src/libprofiler_builtins/lib.rs
+++ b/src/libprofiler_builtins/lib.rs
@@ -5,5 +5,6 @@
             reason = "internal implementation detail of rustc right now",
             issue = "0")]
 #![allow(unused_features)]
+#![feature(nll)]
 #![feature(staged_api)]
 #![deny(rust_2018_idioms)]

--- a/src/librustc_allocator/lib.rs
+++ b/src/librustc_allocator/lib.rs
@@ -1,3 +1,4 @@
+#![feature(nll)]
 #![feature(rustc_private)]
 
 #![deny(rust_2018_idioms)]

--- a/src/librustc_apfloat/lib.rs
+++ b/src/librustc_apfloat/lib.rs
@@ -34,6 +34,7 @@
 #![forbid(unsafe_code)]
 #![deny(rust_2018_idioms)]
 
+#![feature(nll)]
 #![feature(try_from)]
 // See librustc_cratesio_shim/Cargo.toml for a comment explaining this.
 #[allow(unused_extern_crates)]

--- a/src/librustc_asan/lib.rs
+++ b/src/librustc_asan/lib.rs
@@ -1,4 +1,5 @@
 #![sanitizer_runtime]
+#![feature(nll)]
 #![feature(sanitizer_runtime)]
 #![feature(staged_api)]
 #![no_std]

--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -4,6 +4,7 @@
 #![allow(unused_attributes)]
 #![feature(range_contains)]
 #![cfg_attr(unix, feature(libc))]
+#![feature(nll)]
 #![feature(optin_builtin_traits)]
 #![deny(rust_2018_idioms)]
 

--- a/src/librustc_llvm/lib.rs
+++ b/src/librustc_llvm/lib.rs
@@ -1,4 +1,5 @@
 #![deny(rust_2018_idioms)]
+#![feature(nll)]
 #![feature(static_nobundle)]
 
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]

--- a/src/librustc_lsan/lib.rs
+++ b/src/librustc_lsan/lib.rs
@@ -1,4 +1,5 @@
 #![sanitizer_runtime]
+#![feature(nll)]
 #![feature(sanitizer_runtime)]
 #![feature(staged_api)]
 #![no_std]

--- a/src/librustc_msan/lib.rs
+++ b/src/librustc_msan/lib.rs
@@ -1,4 +1,5 @@
 #![sanitizer_runtime]
+#![feature(nll)]
 #![feature(sanitizer_runtime)]
 #![feature(staged_api)]
 #![no_std]

--- a/src/librustc_plugin/lib.rs
+++ b/src/librustc_plugin/lib.rs
@@ -52,6 +52,7 @@
 
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
 
+#![feature(nll)]
 #![feature(rustc_diagnostic_macros)]
 
 #![recursion_limit="256"]

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -2,6 +2,7 @@
 
 #![deny(rust_2018_idioms)]
 
+#![feature(nll)]
 #![feature(rustc_diagnostic_macros)]
 
 #![recursion_limit="256"]

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -2,6 +2,7 @@
 
 #![feature(crate_visibility_modifier)]
 #![feature(label_break_value)]
+#![feature(nll)]
 #![feature(rustc_diagnostic_macros)]
 #![feature(slice_sort_by_cached_key)]
 

--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -1,5 +1,6 @@
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
 #![feature(custom_attribute)]
+#![feature(nll)]
 #![deny(rust_2018_idioms)]
 #![allow(unused_attributes)]
 

--- a/src/librustc_tsan/lib.rs
+++ b/src/librustc_tsan/lib.rs
@@ -1,4 +1,5 @@
 #![sanitizer_runtime]
+#![feature(nll)]
 #![feature(sanitizer_runtime)]
 #![feature(staged_api)]
 #![no_std]

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -11,6 +11,7 @@
 
 #![feature(crate_visibility_modifier)]
 #![feature(label_break_value)]
+#![feature(nll)]
 #![feature(rustc_attrs)]
 #![feature(rustc_diagnostic_macros)]
 #![feature(slice_sort_by_cached_key)]

--- a/src/libsyntax_ext/lib.rs
+++ b/src/libsyntax_ext/lib.rs
@@ -9,6 +9,7 @@
 #![feature(proc_macro_internals)]
 #![feature(proc_macro_span)]
 #![feature(decl_macro)]
+#![feature(nll)]
 #![feature(str_escape)]
 #![feature(rustc_diagnostic_macros)]
 

--- a/src/libsyntax_pos/lib.rs
+++ b/src/libsyntax_pos/lib.rs
@@ -11,6 +11,7 @@
 #![feature(const_fn)]
 #![feature(crate_visibility_modifier)]
 #![feature(custom_attribute)]
+#![feature(nll)]
 #![feature(non_exhaustive)]
 #![feature(optin_builtin_traits)]
 #![feature(rustc_attrs)]

--- a/src/libunwind/lib.rs
+++ b/src/libunwind/lib.rs
@@ -4,6 +4,7 @@
 #![deny(rust_2018_idioms)]
 
 #![feature(link_cfg)]
+#![feature(nll)]
 #![feature(staged_api)]
 #![feature(unwind_attributes)]
 #![feature(static_nobundle)]


### PR DESCRIPTION
In PRs related to #58099, `#![feature(nll)]` was removed from several crates.
This PR reverts it.

Related: https://github.com/rust-lang/rust/pull/58265#discussion_r255021244

cc @Centril

r? @matthewjasper