### PR TITLE
When there are multiple filenames, print what got interpreted as filenames

### DIFF
--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -839,7 +839,15 @@ impl<'a> CompilerCalls<'a> for RustcDefaultCalls {
                 early_error(sopts.error_format, "no input filename given");
             }
             1 => panic!("make_input should have provided valid inputs"),
-            _ => early_error(sopts.error_format, "multiple input filenames provided"),
+            _ =>
+                early_error(
+                    sopts.error_format,
+                    &format!(
+                        "multiple input filenames provided (first two filenames are `{}` and `{}`)",
+                        matches.free[0],
+                        matches.free[1],
+                    ),
+                )
         }
     }
 


### PR DESCRIPTION
I have written code that crafts command lines for rustc, and when I get "multiple input filenames provided" it can be quite hard to figure out where in this long list of arguments the mistake is hiding.  Probably I passed an argument to a flag that does not expect an argument, but which flag would that be?

This changes the error message to print the first two filenames, to make it easier to debug what is going on.