### PR TITLE
Fix ICE and invalid filenames in MIR printing code

### DIFF
--- a/src/librustc_mir/util/pretty.rs
+++ b/src/librustc_mir/util/pretty.rs
@@ -197,7 +197,7 @@ fn dump_path(
                 .chars()
                 .filter_map(|c| match c {
                     ' ' => None,
-                    ':' => Some('_'),
+                    ':' | '<' | '>' => Some('_'),
                     c => Some(c)
                 }));
             s
@@ -603,7 +603,8 @@ fn write_mir_sig(
     match (descr, src.promoted) {
         (_, Some(i)) => write!(w, "{:?} in ", i)?,
         (Some(Def::StructCtor(..)), _) => write!(w, "struct ")?,
-        (Some(Def::Const(_)), _) => write!(w, "const ")?,
+        (Some(Def::Const(_)), _)
+        | (Some(Def::AssociatedConst(_)), _) => write!(w, "const ")?,
         (Some(Def::Static(_, /*is_mutbl*/false)), _) => write!(w, "static ")?,
         (Some(Def::Static(_, /*is_mutbl*/true)), _) => write!(w, "static mut ")?,
         (_, _) if is_function => write!(w, "fn ")?,

--- a/src/test/mir-opt/unusual-item-types.rs
+++ b/src/test/mir-opt/unusual-item-types.rs
@@ -1,0 +1,66 @@
+// Test that we don't ICE when trying to dump MIR for unusual item types and
+// that we don't create filenames containing `<` and `>`
+
+struct A;
+
+impl A {
+    const ASSOCIATED_CONSTANT: i32 = 2;
+}
+
+enum E {
+    V = 5,
+}
+
+fn main() {
+    let v = Vec::<i32>::new();
+}
+
+// END RUST SOURCE
+
+// START rustc.{{impl}}-ASSOCIATED_CONSTANT.mir_map.0.mir
+// bb0: {
+//     _0 = const 2i32;
+//     return;
+// }
+// bb1: {
+//     resume;
+// }
+// END rustc.{{impl}}-ASSOCIATED_CONSTANT.mir_map.0.mir
+
+// START rustc.E-V-{{constant}}.mir_map.0.mir
+// bb0: {
+//     _0 = const 5isize;
+//     return;
+// }
+// bb1: {
+//     resume;
+// }
+// END rustc.E-V-{{constant}}.mir_map.0.mir
+
+// START rustc.ptr-real_drop_in_place.std__vec__Vec_i32_.AddMovesForPackedDrops.before.mir
+//     bb0: {
+//     goto -> bb7;
+// }
+// bb1: {
+//     return;
+// }
+// bb2: {
+//     resume;
+// }
+// bb3: {
+//     goto -> bb1;
+// }
+// bb4: {
+//     goto -> bb2;
+// }
+// bb5: {
+//     drop(((*_1).0: alloc::raw_vec::RawVec<i32>)) -> bb4;
+// }
+// bb6: {
+//     drop(((*_1).0: alloc::raw_vec::RawVec<i32>)) -> [return: bb3, unwind: bb4];
+// }
+// bb7: {
+//     _2 = &mut (*_1);
+//     _3 = const std::ops::Drop::drop(move _2) -> [return: bb6, unwind: bb5];
+// }
+// END rustc.ptr-real_drop_in_place.std__vec__Vec_i32_.AddMovesForPackedDrops.before.mir


### PR DESCRIPTION
* Don't panic when printing MIR for associated constants
* Don't use `<` and `>` in filenames, since they aren't allowed on Windows.

r? @eddyb 

cc @RalfJung 