### PR TITLE
Add vectored read and write support

### DIFF
--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -236,7 +236,7 @@ impl<R: Read> Read for BufReader<R> {
     }
 
     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-        let total_len = bufs.iter().map(|b| b.as_slice().len()).sum::<usize>();
+        let total_len = bufs.iter().map(|b| b.len()).sum::<usize>();
         if self.pos == self.cap && total_len >= self.buf.len() {
             return self.inner.read_vectored(bufs);
         }
@@ -595,7 +595,7 @@ impl<W: Write> Write for BufWriter<W> {
     }
 
     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-        let total_len = bufs.iter().map(|b| b.as_slice().len()).sum::<usize>();
+        let total_len = bufs.iter().map(|b| b.len()).sum::<usize>();
         if self.buf.len() + total_len > self.buf.capacity() {
             self.flush_buf()?;
         }

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -5,7 +5,7 @@ use io::prelude::*;
 use cmp;
 use error;
 use fmt;
-use io::{self, Initializer, DEFAULT_BUF_SIZE, Error, ErrorKind, SeekFrom};
+use io::{self, Initializer, DEFAULT_BUF_SIZE, Error, ErrorKind, SeekFrom, IoVec, IoVecMut};
 use memchr;
 
 /// The `BufReader` struct adds buffering to any reader.
@@ -230,6 +230,19 @@ impl<R: Read> Read for BufReader<R> {
         let nread = {
             let mut rem = self.fill_buf()?;
             rem.read(buf)?
+        };
+        self.consume(nread);
+        Ok(nread)
+    }
+
+    fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+        let total_len = bufs.iter().map(|b| b.as_slice().len()).sum::<usize>();
+        if self.pos == self.cap && total_len >= self.buf.len() {
+            return self.inner.read_vectored(bufs);
+        }
+        let nread = {
+            let mut rem = self.fill_buf()?;
+            rem.read_vectored(bufs)?
         };
         self.consume(nread);
         Ok(nread)
@@ -577,9 +590,25 @@ impl<W: Write> Write for BufWriter<W> {
             self.panicked = false;
             r
         } else {
-            Write::write(&mut self.buf, buf)
+            self.buf.write(buf)
         }
     }
+
+    fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+        let total_len = bufs.iter().map(|b| b.as_slice().len()).sum::<usize>();
+        if self.buf.len() + total_len > self.buf.capacity() {
+            self.flush_buf()?;
+        }
+        if total_len >= self.buf.capacity() {
+            self.panicked = true;
+            let r = self.inner.as_mut().unwrap().write_vectored(bufs);
+            self.panicked = false;
+            r
+        } else {
+            self.buf.write_vectored(bufs)
+        }
+    }
+
     fn flush(&mut self) -> io::Result<()> {
         self.flush_buf().and_then(|()| self.get_mut().flush())
     }

--- a/src/libstd/io/cursor.rs
+++ b/src/libstd/io/cursor.rs
@@ -224,7 +224,6 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
         let mut nread = 0;
         for buf in bufs {
-            let buf = buf.as_mut_slice();
             let n = self.read(buf)?;
             nread += n;
             if n < buf.len() {
@@ -272,7 +271,6 @@ fn slice_write_vectored(
 {
     let mut nwritten = 0;
     for buf in bufs {
-        let buf = buf.as_slice();
         let n = slice_write(pos_mut, slice, buf)?;
         nwritten += n;
         if n < buf.len() {
@@ -317,7 +315,7 @@ fn vec_write_vectored(
 {
     let mut nwritten = 0;
     for buf in bufs {
-        nwritten += vec_write(pos_mut, vec, buf.as_slice())?;
+        nwritten += vec_write(pos_mut, vec, buf)?;
     }
     Ok(nwritten)
 }

--- a/src/libstd/io/cursor.rs
+++ b/src/libstd/io/cursor.rs
@@ -2,7 +2,7 @@ use io::prelude::*;
 
 use core::convert::TryInto;
 use cmp;
-use io::{self, Initializer, SeekFrom, Error, ErrorKind};
+use io::{self, Initializer, SeekFrom, Error, ErrorKind, IoVec, IoVecMut};
 
 /// A `Cursor` wraps an in-memory buffer and provides it with a
 /// [`Seek`] implementation.
@@ -221,6 +221,19 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
         Ok(n)
     }
 
+    fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+        let mut nread = 0;
+        for buf in bufs {
+            let buf = buf.as_mut_slice();
+            let n = self.read(buf)?;
+            nread += n;
+            if n < buf.len() {
+                break;
+            }
+        }
+        Ok(nread)
+    }
+
     fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
         let n = buf.len();
         Read::read_exact(&mut self.fill_buf()?, buf)?;
@@ -251,6 +264,24 @@ fn slice_write(pos_mut: &mut u64, slice: &mut [u8], buf: &[u8]) -> io::Result<us
     Ok(amt)
 }
 
+fn slice_write_vectored(
+    pos_mut: &mut u64,
+    slice: &mut [u8],
+    bufs: &[IoVec<'_>],
+) -> io::Result<usize>
+{
+    let mut nwritten = 0;
+    for buf in bufs {
+        let buf = buf.as_slice();
+        let n = slice_write(pos_mut, slice, buf)?;
+        nwritten += n;
+        if n < buf.len() {
+            break;
+        }
+    }
+    Ok(nwritten)
+}
+
 // Resizing write implementation
 fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usize> {
     let pos: usize = (*pos_mut).try_into().map_err(|_| {
@@ -278,12 +309,31 @@ fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usi
     Ok(buf.len())
 }
 
+fn vec_write_vectored(
+    pos_mut: &mut u64,
+    vec: &mut Vec<u8>,
+    bufs: &[IoVec<'_>],
+) -> io::Result<usize>
+{
+    let mut nwritten = 0;
+    for buf in bufs {
+        nwritten += vec_write(pos_mut, vec, buf.as_slice())?;
+    }
+    Ok(nwritten)
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a> Write for Cursor<&'a mut [u8]> {
     #[inline]
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         slice_write(&mut self.pos, self.inner, buf)
     }
+
+    #[inline]
+    fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+        slice_write_vectored(&mut self.pos, self.inner, bufs)
+    }
+
     fn flush(&mut self) -> io::Result<()> { Ok(()) }
 }
 
@@ -292,6 +342,11 @@ impl<'a> Write for Cursor<&'a mut Vec<u8>> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         vec_write(&mut self.pos, self.inner, buf)
     }
+
+    fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+        vec_write_vectored(&mut self.pos, self.inner, bufs)
+    }
+
     fn flush(&mut self) -> io::Result<()> { Ok(()) }
 }
 
@@ -300,6 +355,11 @@ impl Write for Cursor<Vec<u8>> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         vec_write(&mut self.pos, &mut self.inner, buf)
     }
+
+    fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+        vec_write_vectored(&mut self.pos, &mut self.inner, bufs)
+    }
+
     fn flush(&mut self) -> io::Result<()> { Ok(()) }
 }
 
@@ -309,13 +369,19 @@ impl Write for Cursor<Box<[u8]>> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         slice_write(&mut self.pos, &mut self.inner, buf)
     }
+
+    #[inline]
+    fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+        slice_write_vectored(&mut self.pos, &mut self.inner, bufs)
+    }
+
     fn flush(&mut self) -> io::Result<()> { Ok(()) }
 }
 
 #[cfg(test)]
 mod tests {
     use io::prelude::*;
-    use io::{Cursor, SeekFrom};
+    use io::{Cursor, SeekFrom, IoVec, IoVecMut};
 
     #[test]
     fn test_vec_writer() {
@@ -323,7 +389,10 @@ mod tests {
         assert_eq!(writer.write(&[0]).unwrap(), 1);
         assert_eq!(writer.write(&[1, 2, 3]).unwrap(), 3);
         assert_eq!(writer.write(&[4, 5, 6, 7]).unwrap(), 4);
-        let b: &[_] = &[0, 1, 2, 3, 4, 5, 6, 7];
+        assert_eq!(writer.write_vectored(
+            &[IoVec::new(&[]), IoVec::new(&[8, 9]), IoVec::new(&[10])],
+        ).unwrap(), 3);
+        let b: &[_] = &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
         assert_eq!(writer, b);
     }
 
@@ -333,7 +402,10 @@ mod tests {
         assert_eq!(writer.write(&[0]).unwrap(), 1);
         assert_eq!(writer.write(&[1, 2, 3]).unwrap(), 3);
         assert_eq!(writer.write(&[4, 5, 6, 7]).unwrap(), 4);
-        let b: &[_] = &[0, 1, 2, 3, 4, 5, 6, 7];
+        assert_eq!(writer.write_vectored(
+            &[IoVec::new(&[]), IoVec::new(&[8, 9]), IoVec::new(&[10])],
+        ).unwrap(), 3);
+        let b: &[_] = &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
         assert_eq!(&writer.get_ref()[..], b);
     }
 
@@ -344,7 +416,10 @@ mod tests {
         assert_eq!(writer.write(&[0]).unwrap(), 1);
         assert_eq!(writer.write(&[1, 2, 3]).unwrap(), 3);
         assert_eq!(writer.write(&[4, 5, 6, 7]).unwrap(), 4);
-        let b: &[_] = &[0, 1, 2, 3, 4, 5, 6, 7];
+        assert_eq!(writer.write_vectored(
+            &[IoVec::new(&[]), IoVec::new(&[8, 9]), IoVec::new(&[10])],
+        ).unwrap(), 3);
+        let b: &[_] = &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
         assert_eq!(&writer.get_ref()[..], b);
     }
 
@@ -367,6 +442,26 @@ mod tests {
     }
 
     #[test]
+    fn test_box_slice_writer_vectored() {
+        let mut writer = Cursor::new(vec![0u8; 9].into_boxed_slice());
+        assert_eq!(writer.position(), 0);
+        assert_eq!(writer.write_vectored(&[IoVec::new(&[0])]).unwrap(), 1);
+        assert_eq!(writer.position(), 1);
+        assert_eq!(
+            writer.write_vectored(&[IoVec::new(&[1, 2, 3]), IoVec::new(&[4, 5, 6, 7])]).unwrap(),
+            7,
+        );
+        assert_eq!(writer.position(), 8);
+        assert_eq!(writer.write_vectored(&[]).unwrap(), 0);
+        assert_eq!(writer.position(), 8);
+
+        assert_eq!(writer.write_vectored(&[IoVec::new(&[8, 9])]).unwrap(), 1);
+        assert_eq!(writer.write_vectored(&[IoVec::new(&[10])]).unwrap(), 0);
+        let b: &[_] = &[0, 1, 2, 3, 4, 5, 6, 7, 8];
+        assert_eq!(&**writer.get_ref(), b);
+    }
+
+    #[test]
     fn test_buf_writer() {
         let mut buf = [0 as u8; 9];
         {
@@ -382,6 +477,31 @@ mod tests {
 
             assert_eq!(writer.write(&[8, 9]).unwrap(), 1);
             assert_eq!(writer.write(&[10]).unwrap(), 0);
+        }
+        let b: &[_] = &[0, 1, 2, 3, 4, 5, 6, 7, 8];
+        assert_eq!(buf, b);
+    }
+
+    #[test]
+    fn test_buf_writer_vectored() {
+        let mut buf = [0 as u8; 9];
+        {
+            let mut writer = Cursor::new(&mut buf[..]);
+            assert_eq!(writer.position(), 0);
+            assert_eq!(writer.write_vectored(&[IoVec::new(&[0])]).unwrap(), 1);
+            assert_eq!(writer.position(), 1);
+            assert_eq!(
+                writer.write_vectored(
+                    &[IoVec::new(&[1, 2, 3]), IoVec::new(&[4, 5, 6, 7])],
+                ).unwrap(),
+                7,
+            );
+            assert_eq!(writer.position(), 8);
+            assert_eq!(writer.write_vectored(&[]).unwrap(), 0);
+            assert_eq!(writer.position(), 8);
+
+            assert_eq!(writer.write_vectored(&[IoVec::new(&[8, 9])]).unwrap(), 1);
+            assert_eq!(writer.write_vectored(&[IoVec::new(&[10])]).unwrap(), 0);
         }
         let b: &[_] = &[0, 1, 2, 3, 4, 5, 6, 7, 8];
         assert_eq!(buf, b);
@@ -448,6 +568,35 @@ mod tests {
     }
 
     #[test]
+    fn test_mem_reader_vectored() {
+        let mut reader = Cursor::new(vec![0, 1, 2, 3, 4, 5, 6, 7]);
+        let mut buf = [];
+        assert_eq!(reader.read_vectored(&mut [IoVecMut::new(&mut buf)]).unwrap(), 0);
+        assert_eq!(reader.position(), 0);
+        let mut buf = [0];
+        assert_eq!(
+            reader.read_vectored(&mut [IoVecMut::new(&mut []), IoVecMut::new(&mut buf)]).unwrap(),
+            1,
+        );
+        assert_eq!(reader.position(), 1);
+        let b: &[_] = &[0];
+        assert_eq!(buf, b);
+        let mut buf1 = [0; 4];
+        let mut buf2 = [0; 4];
+        assert_eq!(
+            reader.read_vectored(
+                &mut [IoVecMut::new(&mut buf1), IoVecMut::new(&mut buf2)],
+            ).unwrap(),
+            7,
+        );
+        let b1: &[_] = &[1, 2, 3, 4];
+        let b2: &[_] = &[5, 6, 7];
+        assert_eq!(buf1, b1);
+        assert_eq!(&buf2[..3], b2);
+        assert_eq!(reader.read(&mut buf).unwrap(), 0);
+    }
+
+    #[test]
     fn test_boxed_slice_reader() {
         let mut reader = Cursor::new(vec![0, 1, 2, 3, 4, 5, 6, 7].into_boxed_slice());
         let mut buf = [];
@@ -466,6 +615,35 @@ mod tests {
         assert_eq!(reader.read(&mut buf).unwrap(), 3);
         let b: &[_] = &[5, 6, 7];
         assert_eq!(&buf[..3], b);
+        assert_eq!(reader.read(&mut buf).unwrap(), 0);
+    }
+
+    #[test]
+    fn test_boxed_slice_reader_vectored() {
+        let mut reader = Cursor::new(vec![0, 1, 2, 3, 4, 5, 6, 7].into_boxed_slice());
+        let mut buf = [];
+        assert_eq!(reader.read_vectored(&mut [IoVecMut::new(&mut buf)]).unwrap(), 0);
+        assert_eq!(reader.position(), 0);
+        let mut buf = [0];
+        assert_eq!(
+            reader.read_vectored(&mut [IoVecMut::new(&mut []), IoVecMut::new(&mut buf)]).unwrap(),
+            1,
+        );
+        assert_eq!(reader.position(), 1);
+        let b: &[_] = &[0];
+        assert_eq!(buf, b);
+        let mut buf1 = [0; 4];
+        let mut buf2 = [0; 4];
+        assert_eq!(
+            reader.read_vectored(
+                &mut [IoVecMut::new(&mut buf1), IoVecMut::new(&mut buf2)],
+            ).unwrap(),
+            7,
+        );
+        let b1: &[_] = &[1, 2, 3, 4];
+        let b2: &[_] = &[5, 6, 7];
+        assert_eq!(buf1, b1);
+        assert_eq!(&buf2[..3], b2);
         assert_eq!(reader.read(&mut buf).unwrap(), 0);
     }
 
@@ -496,6 +674,35 @@ mod tests {
         assert_eq!(reader.read(&mut buf).unwrap(), 3);
         let b: &[_] = &[5, 6, 7];
         assert_eq!(&buf[..3], b);
+        assert_eq!(reader.read(&mut buf).unwrap(), 0);
+    }
+
+    #[test]
+    fn test_slice_reader_vectored() {
+        let in_buf = vec![0, 1, 2, 3, 4, 5, 6, 7];
+        let reader = &mut &in_buf[..];
+        let mut buf = [];
+        assert_eq!(reader.read_vectored(&mut [IoVecMut::new(&mut buf)]).unwrap(), 0);
+        let mut buf = [0];
+        assert_eq!(
+            reader.read_vectored(&mut [IoVecMut::new(&mut []), IoVecMut::new(&mut buf)]).unwrap(),
+            1,
+        );
+        assert_eq!(reader.len(), 7);
+        let b: &[_] = &[0];
+        assert_eq!(buf, b);
+        let mut buf1 = [0; 4];
+        let mut buf2 = [0; 4];
+        assert_eq!(
+            reader.read_vectored(
+                &mut [IoVecMut::new(&mut buf1), IoVecMut::new(&mut buf2)],
+            ).unwrap(),
+            7,
+        );
+        let b1: &[_] = &[1, 2, 3, 4];
+        let b2: &[_] = &[5, 6, 7];
+        assert_eq!(buf1, b1);
+        assert_eq!(&buf2[..3], b2);
         assert_eq!(reader.read(&mut buf).unwrap(), 0);
     }
 

--- a/src/libstd/io/impls.rs
+++ b/src/libstd/io/impls.rs
@@ -196,7 +196,7 @@ impl<'a> Read for &'a [u8] {
     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
         let mut nread = 0;
         for buf in bufs {
-            nread += self.read(buf.as_mut_slice())?;
+            nread += self.read(buf)?;
             if self.is_empty() {
                 break;
             }
@@ -269,7 +269,7 @@ impl<'a> Write for &'a mut [u8] {
     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
         let mut nwritten = 0;
         for buf in bufs {
-            nwritten += self.write(buf.as_slice())?;
+            nwritten += self.write(buf)?;
             if self.is_empty() {
                 break;
             }
@@ -303,10 +303,10 @@ impl Write for Vec<u8> {
 
     #[inline]
     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-        let len = bufs.iter().map(|b| b.as_slice().len()).sum();
+        let len = bufs.iter().map(|b| b.len()).sum();
         self.reserve(len);
         for buf in bufs {
-            self.extend_from_slice(buf.as_slice());
+            self.extend_from_slice(buf);
         }
         Ok(len)
     }

--- a/src/libstd/io/impls.rs
+++ b/src/libstd/io/impls.rs
@@ -1,5 +1,6 @@
 use cmp;
-use io::{self, SeekFrom, Read, Initializer, Write, Seek, BufRead, Error, ErrorKind};
+use io::{self, SeekFrom, Read, Initializer, Write, Seek, BufRead, Error, ErrorKind, IoVecMut,
+         IoVec};
 use fmt;
 use mem;
 
@@ -11,6 +12,11 @@ impl<'a, R: Read + ?Sized> Read for &'a mut R {
     #[inline]
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         (**self).read(buf)
+    }
+
+    #[inline]
+    fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+        (**self).read_vectored(bufs)
     }
 
     #[inline]
@@ -37,6 +43,11 @@ impl<'a, R: Read + ?Sized> Read for &'a mut R {
 impl<'a, W: Write + ?Sized> Write for &'a mut W {
     #[inline]
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> { (**self).write(buf) }
+
+    #[inline]
+    fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+        (**self).write_vectored(bufs)
+    }
 
     #[inline]
     fn flush(&mut self) -> io::Result<()> { (**self).flush() }
@@ -83,6 +94,11 @@ impl<R: Read + ?Sized> Read for Box<R> {
     }
 
     #[inline]
+    fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+        (**self).read_vectored(bufs)
+    }
+
+    #[inline]
     unsafe fn initializer(&self) -> Initializer {
         (**self).initializer()
     }
@@ -106,6 +122,11 @@ impl<R: Read + ?Sized> Read for Box<R> {
 impl<W: Write + ?Sized> Write for Box<W> {
     #[inline]
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> { (**self).write(buf) }
+
+    #[inline]
+    fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+        (**self).write_vectored(bufs)
+    }
 
     #[inline]
     fn flush(&mut self) -> io::Result<()> { (**self).flush() }
@@ -172,6 +193,19 @@ impl<'a> Read for &'a [u8] {
     }
 
     #[inline]
+    fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+        let mut nread = 0;
+        for buf in bufs {
+            nread += self.read(buf.as_mut_slice())?;
+            if self.is_empty() {
+                break;
+            }
+        }
+
+        Ok(nread)
+    }
+
+    #[inline]
     unsafe fn initializer(&self) -> Initializer {
         Initializer::nop()
     }
@@ -232,6 +266,19 @@ impl<'a> Write for &'a mut [u8] {
     }
 
     #[inline]
+    fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+        let mut nwritten = 0;
+        for buf in bufs {
+            nwritten += self.write(buf.as_slice())?;
+            if self.is_empty() {
+                break;
+            }
+        }
+
+        Ok(nwritten)
+    }
+
+    #[inline]
     fn write_all(&mut self, data: &[u8]) -> io::Result<()> {
         if self.write(data)? == data.len() {
             Ok(())
@@ -252,6 +299,16 @@ impl Write for Vec<u8> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.extend_from_slice(buf);
         Ok(buf.len())
+    }
+
+    #[inline]
+    fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+        let len = bufs.iter().map(|b| b.as_slice().len()).sum();
+        self.reserve(len);
+        for buf in bufs {
+            self.extend_from_slice(buf.as_slice());
+        }
+        Ok(len)
     }
 
     #[inline]

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -530,7 +530,7 @@ pub trait Read {
     ///
     /// The default implementation simply passes the first nonempty buffer to
     /// `read`.
-    #[unstable(feature = "iovec", issue = "0")]
+    #[unstable(feature = "iovec", issue = "58452")]
     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> Result<usize> {
         match bufs.iter_mut().find(|b| !b.is_empty()) {
             Some(buf) => self.read(buf),
@@ -890,11 +890,11 @@ pub trait Read {
 /// It is semantically a wrapper around an `&mut [u8]`, but is guaranteed to be
 /// ABI compatible with the `iovec` type on Unix platforms and `WSABUF` on
 /// Windows.
-#[unstable(feature = "iovec", issue = "0")]
+#[unstable(feature = "iovec", issue = "58452")]
 #[repr(transparent)]
 pub struct IoVecMut<'a>(sys::io::IoVecMut<'a>);
 
-#[unstable(feature = "iovec", issue = "0")]
+#[unstable(feature = "iovec", issue = "58452")]
 impl<'a> fmt::Debug for IoVecMut<'a> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt::Debug::fmt(self.0.as_slice(), fmt)
@@ -907,14 +907,14 @@ impl<'a> IoVecMut<'a> {
     /// # Panics
     ///
     /// Panics on Windows if the slice is larger than 4GB.
-    #[unstable(feature = "iovec", issue = "0")]
+    #[unstable(feature = "iovec", issue = "58452")]
     #[inline]
     pub fn new(buf: &'a mut [u8]) -> IoVecMut<'a> {
         IoVecMut(sys::io::IoVecMut::new(buf))
     }
 }
 
-#[unstable(feature = "iovec", issue = "0")]
+#[unstable(feature = "iovec", issue = "58452")]
 impl<'a> Deref for IoVecMut<'a> {
     type Target = [u8];
 
@@ -924,7 +924,7 @@ impl<'a> Deref for IoVecMut<'a> {
     }
 }
 
-#[unstable(feature = "iovec", issue = "0")]
+#[unstable(feature = "iovec", issue = "58452")]
 impl<'a> DerefMut for IoVecMut<'a> {
     #[inline]
     fn deref_mut(&mut self) -> &mut [u8] {
@@ -937,11 +937,11 @@ impl<'a> DerefMut for IoVecMut<'a> {
 /// It is semantically a wrapper around an `&[u8]`, but is guaranteed to be
 /// ABI compatible with the `iovec` type on Unix platforms and `WSABUF` on
 /// Windows.
-#[unstable(feature = "iovec", issue = "0")]
+#[unstable(feature = "iovec", issue = "58452")]
 #[repr(transparent)]
 pub struct IoVec<'a>(sys::io::IoVec<'a>);
 
-#[unstable(feature = "iovec", issue = "0")]
+#[unstable(feature = "iovec", issue = "58452")]
 impl<'a> fmt::Debug for IoVec<'a> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt::Debug::fmt(self.0.as_slice(), fmt)
@@ -954,14 +954,14 @@ impl<'a> IoVec<'a> {
     /// # Panics
     ///
     /// Panics on Windows if the slice is larger than 4GB.
-    #[unstable(feature = "iovec", issue = "0")]
+    #[unstable(feature = "iovec", issue = "58452")]
     #[inline]
     pub fn new(buf: &'a [u8]) -> IoVec<'a> {
         IoVec(sys::io::IoVec::new(buf))
     }
 }
 
-#[unstable(feature = "iovec", issue = "0")]
+#[unstable(feature = "iovec", issue = "58452")]
 impl<'a> Deref for IoVec<'a> {
     type Target = [u8];
 
@@ -1109,7 +1109,7 @@ pub trait Write {
     ///
     /// The default implementation simply passes the first nonempty buffer to
     /// `write`.
-    #[unstable(feature = "iovec", issue = "0")]
+    #[unstable(feature = "iovec", issue = "58452")]
     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> Result<usize> {
         match bufs.iter().find(|b| !b.is_empty()) {
             Some(buf) => self.write(buf),

--- a/src/libstd/io/util.rs
+++ b/src/libstd/io/util.rs
@@ -1,7 +1,7 @@
 #![allow(missing_copy_implementations)]
 
 use fmt;
-use io::{self, Read, Initializer, Write, ErrorKind, BufRead};
+use io::{self, Read, Initializer, Write, ErrorKind, BufRead, IoVec, IoVecMut};
 use mem;
 
 /// Copies the entire contents of a reader into a writer.
@@ -153,6 +153,15 @@ impl Read for Repeat {
     }
 
     #[inline]
+    fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+        let mut nwritten = 0;
+        for buf in bufs {
+            nwritten += self.read(buf.as_mut_slice())?;
+        }
+        Ok(nwritten)
+    }
+
+    #[inline]
     unsafe fn initializer(&self) -> Initializer {
         Initializer::nop()
     }
@@ -195,6 +204,13 @@ pub fn sink() -> Sink { Sink { _priv: () } }
 impl Write for Sink {
     #[inline]
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> { Ok(buf.len()) }
+
+    #[inline]
+    fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+        let total_len = bufs.iter().map(|b| b.as_slice().len()).sum();
+        Ok(total_len)
+    }
+
     #[inline]
     fn flush(&mut self) -> io::Result<()> { Ok(()) }
 }

--- a/src/libstd/io/util.rs
+++ b/src/libstd/io/util.rs
@@ -156,7 +156,7 @@ impl Read for Repeat {
     fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
         let mut nwritten = 0;
         for buf in bufs {
-            nwritten += self.read(buf.as_mut_slice())?;
+            nwritten += self.read(buf)?;
         }
         Ok(nwritten)
     }
@@ -207,7 +207,7 @@ impl Write for Sink {
 
     #[inline]
     fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-        let total_len = bufs.iter().map(|b| b.as_slice().len()).sum();
+        let total_len = bufs.iter().map(|b| b.len()).sum();
         Ok(total_len)
     }
 

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -228,6 +228,7 @@
 #![feature(arbitrary_self_types)]
 #![feature(array_error_internals)]
 #![feature(asm)]
+#![feature(bind_by_move_pattern_guards)]
 #![feature(box_syntax)]
 #![feature(c_variadic)]
 #![feature(cfg_target_has_atomic)]

--- a/src/libstd/net/tcp.rs
+++ b/src/libstd/net/tcp.rs
@@ -1,7 +1,7 @@
 use io::prelude::*;
 
 use fmt;
-use io::{self, Initializer};
+use io::{self, Initializer, IoVec, IoVecMut};
 use net::{ToSocketAddrs, SocketAddr, Shutdown};
 use sys_common::net as net_imp;
 use sys_common::{AsInner, FromInner, IntoInner};
@@ -569,6 +569,10 @@ impl TcpStream {
 impl Read for TcpStream {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> { self.0.read(buf) }
 
+    fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+        self.0.read_vectored(bufs)
+    }
+
     #[inline]
     unsafe fn initializer(&self) -> Initializer {
         Initializer::nop()
@@ -577,11 +581,20 @@ impl Read for TcpStream {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Write for TcpStream {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> { self.0.write(buf) }
+
+    fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+        self.0.write_vectored(bufs)
+    }
+
     fn flush(&mut self) -> io::Result<()> { Ok(()) }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a> Read for &'a TcpStream {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> { self.0.read(buf) }
+
+    fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+        self.0.read_vectored(bufs)
+    }
 
     #[inline]
     unsafe fn initializer(&self) -> Initializer {
@@ -591,6 +604,11 @@ impl<'a> Read for &'a TcpStream {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a> Write for &'a TcpStream {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> { self.0.write(buf) }
+
+    fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+        self.0.write_vectored(bufs)
+    }
+
     fn flush(&mut self) -> io::Result<()> { Ok(()) }
 }
 
@@ -911,7 +929,7 @@ impl fmt::Debug for TcpListener {
 
 #[cfg(all(test, not(any(target_os = "cloudabi", target_os = "emscripten"))))]
 mod tests {
-    use io::ErrorKind;
+    use io::{ErrorKind, IoVec, IoVecMut};
     use io::prelude::*;
     use net::*;
     use net::test::{next_test_ip4, next_test_ip6};
@@ -1181,6 +1199,53 @@ mod tests {
             assert_eq!(c.read(&mut b).unwrap(), 1);
             t!(c.write(&[1]));
             rx.recv().unwrap();
+        })
+    }
+
+    #[test]
+    fn read_vectored() {
+        each_ip(&mut |addr| {
+            let srv = t!(TcpListener::bind(&addr));
+            let mut s1 = t!(TcpStream::connect(&addr));
+            let mut s2 = t!(srv.accept()).0;
+
+            let len = s1.write(&[10, 11, 12]).unwrap();
+            assert_eq!(len, 3);
+
+            let mut a = [];
+            let mut b = [0];
+            let mut c = [0; 3];
+            let len = t!(s2.read_vectored(
+                &mut [IoVecMut::new(&mut a), IoVecMut::new(&mut b), IoVecMut::new(&mut c)],
+            ));
+            assert!(len > 0);
+            assert_eq!(b, [10]);
+            // some implementations don't support readv, so we may only fill the first buffer
+            assert!(len == 1 || c == [11, 12, 0]);
+        })
+    }
+
+    #[test]
+    fn write_vectored() {
+        each_ip(&mut |addr| {
+            let srv = t!(TcpListener::bind(&addr));
+            let mut s1 = t!(TcpStream::connect(&addr));
+            let mut s2 = t!(srv.accept()).0;
+
+            let a = [];
+            let b = [10];
+            let c = [11, 12];
+            t!(s1.write_vectored(&[IoVec::new(&a), IoVec::new(&b), IoVec::new(&c)]));
+
+            let mut buf = [0; 4];
+            let len = t!(s2.read(&mut buf));
+            // some implementations don't support writev, so we may only write the first buffer
+            if len == 1 {
+                assert_eq!(buf, [10, 0, 0, 0]);
+            } else {
+                assert_eq!(len, 3);
+                assert_eq!(buf, [10, 11, 12, 0]);
+            }
         })
     }
 

--- a/src/libstd/sys/cloudabi/io.rs
+++ b/src/libstd/sys/cloudabi/io.rs
@@ -1,0 +1,32 @@
+pub struct IoVec<'a>(&'a [u8]);
+
+impl<'a> IoVec<'a> {
+    #[inline]
+    pub fn new(buf: &'a [u8]) -> IoVec<'a> {
+        IoVec(buf)
+    }
+
+    #[inline]
+    pub fn as_slice(&self) -> &'a [u8] {
+        self.0
+    }
+}
+
+pub struct IoVecMut<'a>(&'a mut [u8]);
+
+impl<'a> IoVecMut<'a> {
+    #[inline]
+    pub fn new(buf: &'a mut [u8]) -> IoVecMut<'a> {
+        IoVecMut(buf)
+    }
+
+    #[inline]
+    pub fn as_slice(&self) -> &'a [u8] {
+        self.0
+    }
+
+    #[inline]
+    pub fn as_mut_slice(&mut self) -> &'a mut [u8] {
+        self.0
+    }
+}

--- a/src/libstd/sys/cloudabi/io.rs
+++ b/src/libstd/sys/cloudabi/io.rs
@@ -7,7 +7,7 @@ impl<'a> IoVec<'a> {
     }
 
     #[inline]
-    pub fn as_slice(&self) -> &'a [u8] {
+    pub fn as_slice(&self) -> &[u8] {
         self.0
     }
 }
@@ -21,12 +21,12 @@ impl<'a> IoVecMut<'a> {
     }
 
     #[inline]
-    pub fn as_slice(&self) -> &'a [u8] {
+    pub fn as_slice(&self) -> &[u8] {
         self.0
     }
 
     #[inline]
-    pub fn as_mut_slice(&mut self) -> &'a mut [u8] {
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
         self.0
     }
 }

--- a/src/libstd/sys/cloudabi/mod.rs
+++ b/src/libstd/sys/cloudabi/mod.rs
@@ -1,4 +1,3 @@
-use io;
 use libc;
 use mem;
 
@@ -10,6 +9,7 @@ pub mod backtrace;
 #[path = "../unix/cmath.rs"]
 pub mod cmath;
 pub mod condvar;
+pub mod io;
 #[path = "../unix/memchr.rs"]
 pub mod memchr;
 pub mod mutex;
@@ -32,24 +32,24 @@ pub use self::shims::*;
 #[allow(dead_code)]
 pub fn init() {}
 
-pub fn decode_error_kind(errno: i32) -> io::ErrorKind {
+pub fn decode_error_kind(errno: i32) -> ::io::ErrorKind {
     match errno {
-        x if x == abi::errno::ACCES as i32 => io::ErrorKind::PermissionDenied,
-        x if x == abi::errno::ADDRINUSE as i32 => io::ErrorKind::AddrInUse,
-        x if x == abi::errno::ADDRNOTAVAIL as i32 => io::ErrorKind::AddrNotAvailable,
-        x if x == abi::errno::AGAIN as i32 => io::ErrorKind::WouldBlock,
-        x if x == abi::errno::CONNABORTED as i32 => io::ErrorKind::ConnectionAborted,
-        x if x == abi::errno::CONNREFUSED as i32 => io::ErrorKind::ConnectionRefused,
-        x if x == abi::errno::CONNRESET as i32 => io::ErrorKind::ConnectionReset,
-        x if x == abi::errno::EXIST as i32 => io::ErrorKind::AlreadyExists,
-        x if x == abi::errno::INTR as i32 => io::ErrorKind::Interrupted,
-        x if x == abi::errno::INVAL as i32 => io::ErrorKind::InvalidInput,
-        x if x == abi::errno::NOENT as i32 => io::ErrorKind::NotFound,
-        x if x == abi::errno::NOTCONN as i32 => io::ErrorKind::NotConnected,
-        x if x == abi::errno::PERM as i32 => io::ErrorKind::PermissionDenied,
-        x if x == abi::errno::PIPE as i32 => io::ErrorKind::BrokenPipe,
-        x if x == abi::errno::TIMEDOUT as i32 => io::ErrorKind::TimedOut,
-        _ => io::ErrorKind::Other,
+        x if x == abi::errno::ACCES as i32 => ::io::ErrorKind::PermissionDenied,
+        x if x == abi::errno::ADDRINUSE as i32 => ::io::ErrorKind::AddrInUse,
+        x if x == abi::errno::ADDRNOTAVAIL as i32 => ::io::ErrorKind::AddrNotAvailable,
+        x if x == abi::errno::AGAIN as i32 => ::io::ErrorKind::WouldBlock,
+        x if x == abi::errno::CONNABORTED as i32 => ::io::ErrorKind::ConnectionAborted,
+        x if x == abi::errno::CONNREFUSED as i32 => ::io::ErrorKind::ConnectionRefused,
+        x if x == abi::errno::CONNRESET as i32 => ::io::ErrorKind::ConnectionReset,
+        x if x == abi::errno::EXIST as i32 => ::io::ErrorKind::AlreadyExists,
+        x if x == abi::errno::INTR as i32 => ::io::ErrorKind::Interrupted,
+        x if x == abi::errno::INVAL as i32 => ::io::ErrorKind::InvalidInput,
+        x if x == abi::errno::NOENT as i32 => ::io::ErrorKind::NotFound,
+        x if x == abi::errno::NOTCONN as i32 => ::io::ErrorKind::NotConnected,
+        x if x == abi::errno::PERM as i32 => ::io::ErrorKind::PermissionDenied,
+        x if x == abi::errno::PIPE as i32 => ::io::ErrorKind::BrokenPipe,
+        x if x == abi::errno::TIMEDOUT as i32 => ::io::ErrorKind::TimedOut,
+        _ => ::io::ErrorKind::Other,
     }
 }
 

--- a/src/libstd/sys/cloudabi/shims/net.rs
+++ b/src/libstd/sys/cloudabi/shims/net.rs
@@ -1,5 +1,5 @@
 use fmt;
-use io;
+use io::{self, IoVec, IoVecMut};
 use net::{Ipv4Addr, Ipv6Addr, Shutdown, SocketAddr};
 use time::Duration;
 use sys::{unsupported, Void};
@@ -42,7 +42,15 @@ impl TcpStream {
         match self.0 {}
     }
 
+    pub fn read_vectored(&self, _: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+        match self.0 {}
+    }
+
     pub fn write(&self, _: &[u8]) -> io::Result<usize> {
+        match self.0 {}
+    }
+
+    pub fn write_vectored(&self, _: &[IoVec<'_>]) -> io::Result<usize> {
         match self.0 {}
     }
 

--- a/src/libstd/sys/redox/io.rs
+++ b/src/libstd/sys/redox/io.rs
@@ -1,0 +1,32 @@
+pub struct IoVec<'a>(&'a [u8]);
+
+impl<'a> IoVec<'a> {
+    #[inline]
+    pub fn new(buf: &'a [u8]) -> IoVec<'a> {
+        IoVec(buf)
+    }
+
+    #[inline]
+    pub fn as_slice(&self) -> &'a [u8] {
+        self.0
+    }
+}
+
+pub struct IoVecMut<'a>(&'a mut [u8]);
+
+impl<'a> IoVecMut<'a> {
+    #[inline]
+    pub fn new(buf: &'a mut [u8]) -> IoVecMut<'a> {
+        IoVecMut(buf)
+    }
+
+    #[inline]
+    pub fn as_slice(&self) -> &'a [u8] {
+        self.0
+    }
+
+    #[inline]
+    pub fn as_mut_slice(&mut self) -> &'a mut [u8] {
+        self.0
+    }
+}

--- a/src/libstd/sys/redox/io.rs
+++ b/src/libstd/sys/redox/io.rs
@@ -7,7 +7,7 @@ impl<'a> IoVec<'a> {
     }
 
     #[inline]
-    pub fn as_slice(&self) -> &'a [u8] {
+    pub fn as_slice(&self) -> &[u8] {
         self.0
     }
 }
@@ -21,12 +21,12 @@ impl<'a> IoVecMut<'a> {
     }
 
     #[inline]
-    pub fn as_slice(&self) -> &'a [u8] {
+    pub fn as_slice(&self) -> &[u8] {
         self.0
     }
 
     #[inline]
-    pub fn as_mut_slice(&mut self) -> &'a mut [u8] {
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
         self.0
     }
 }

--- a/src/libstd/sys/redox/mod.rs
+++ b/src/libstd/sys/redox/mod.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, missing_docs, nonstandard_style)]
 
-use io::{self, ErrorKind};
+use ::io::{ErrorKind};
 
 pub use libc::strlen;
 pub use self::rand::hashmap_random_keys;
@@ -17,6 +17,7 @@ pub mod ext;
 pub mod fast_thread_local;
 pub mod fd;
 pub mod fs;
+pub mod io;
 pub mod memchr;
 pub mod mutex;
 pub mod net;
@@ -63,8 +64,8 @@ pub fn decode_error_kind(errno: i32) -> ErrorKind {
     }
 }
 
-pub fn cvt(result: Result<usize, syscall::Error>) -> io::Result<usize> {
-    result.map_err(|err| io::Error::from_raw_os_error(err.errno))
+pub fn cvt(result: Result<usize, syscall::Error>) -> ::io::Result<usize> {
+    result.map_err(|err| ::io::Error::from_raw_os_error(err.errno))
 }
 
 #[doc(hidden)]
@@ -82,9 +83,9 @@ macro_rules! impl_is_minus_one {
 
 impl_is_minus_one! { i8 i16 i32 i64 isize }
 
-pub fn cvt_libc<T: IsMinusOne>(t: T) -> io::Result<T> {
+pub fn cvt_libc<T: IsMinusOne>(t: T) -> ::io::Result<T> {
     if t.is_minus_one() {
-        Err(io::Error::last_os_error())
+        Err(::io::Error::last_os_error())
     } else {
         Ok(t)
     }

--- a/src/libstd/sys/redox/net/tcp.rs
+++ b/src/libstd/sys/redox/net/tcp.rs
@@ -1,5 +1,5 @@
 use cmp;
-use io::{self, Error, ErrorKind, Result};
+use io::{self, Error, ErrorKind, Result, IoVec, IoVecMut};
 use mem;
 use net::{SocketAddr, Shutdown};
 use path::Path;
@@ -34,8 +34,22 @@ impl TcpStream {
         self.0.read(buf)
     }
 
+    pub fn read_vectored(&self, buf: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+        match buf.iter_mut().map(|b| b.as_mut_slice()).find(|b| !b.is_empty()) {
+            Some(buf) => self.read(buf),
+            None => Ok(0),
+        }
+    }
+
     pub fn write(&self, buf: &[u8]) -> Result<usize> {
         self.0.write(buf)
+    }
+
+    pub fn write_vectored(&self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+        match buf.iter().map(|b| b.as_slice()).find(|b| !b.is_empty()) {
+            Some(buf) => self.write(buf),
+            None => Ok(0),
+        }
     }
 
     pub fn take_error(&self) -> Result<Option<Error>> {

--- a/src/libstd/sys/redox/net/tcp.rs
+++ b/src/libstd/sys/redox/net/tcp.rs
@@ -35,7 +35,7 @@ impl TcpStream {
     }
 
     pub fn read_vectored(&self, buf: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-        match buf.iter_mut().map(|b| b.as_mut_slice()).find(|b| !b.is_empty()) {
+        match buf.iter_mut().find(|b| !b.is_empty()) {
             Some(buf) => self.read(buf),
             None => Ok(0),
         }
@@ -46,7 +46,7 @@ impl TcpStream {
     }
 
     pub fn write_vectored(&self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-        match buf.iter().map(|b| b.as_slice()).find(|b| !b.is_empty()) {
+        match buf.iter().find(|b| !b.is_empty()) {
             Some(buf) => self.write(buf),
             None => Ok(0),
         }

--- a/src/libstd/sys/redox/net/tcp.rs
+++ b/src/libstd/sys/redox/net/tcp.rs
@@ -34,8 +34,8 @@ impl TcpStream {
         self.0.read(buf)
     }
 
-    pub fn read_vectored(&self, buf: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-        match buf.iter_mut().find(|b| !b.is_empty()) {
+    pub fn read_vectored(&self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+        match bufs.iter_mut().find(|b| !b.is_empty()) {
             Some(buf) => self.read(buf),
             None => Ok(0),
         }
@@ -46,7 +46,7 @@ impl TcpStream {
     }
 
     pub fn write_vectored(&self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
-        match buf.iter().find(|b| !b.is_empty()) {
+        match bufs.iter().find(|b| !b.is_empty()) {
             Some(buf) => self.write(buf),
             None => Ok(0),
         }

--- a/src/libstd/sys/sgx/io.rs
+++ b/src/libstd/sys/sgx/io.rs
@@ -1,0 +1,32 @@
+pub struct IoVec<'a>(&'a [u8]);
+
+impl<'a> IoVec<'a> {
+    #[inline]
+    pub fn new(buf: &'a [u8]) -> IoVec<'a> {
+        IoVec(buf)
+    }
+
+    #[inline]
+    pub fn as_slice(&self) -> &'a [u8] {
+        self.0
+    }
+}
+
+pub struct IoVecMut<'a>(&'a mut [u8]);
+
+impl<'a> IoVecMut<'a> {
+    #[inline]
+    pub fn new(buf: &'a mut [u8]) -> IoVecMut<'a> {
+        IoVecMut(buf)
+    }
+
+    #[inline]
+    pub fn as_slice(&self) -> &'a [u8] {
+        self.0
+    }
+
+    #[inline]
+    pub fn as_mut_slice(&mut self) -> &'a mut [u8] {
+        self.0
+    }
+}

--- a/src/libstd/sys/sgx/io.rs
+++ b/src/libstd/sys/sgx/io.rs
@@ -7,7 +7,7 @@ impl<'a> IoVec<'a> {
     }
 
     #[inline]
-    pub fn as_slice(&self) -> &'a [u8] {
+    pub fn as_slice(&self) -> &[u8] {
         self.0
     }
 }
@@ -21,12 +21,12 @@ impl<'a> IoVecMut<'a> {
     }
 
     #[inline]
-    pub fn as_slice(&self) -> &'a [u8] {
+    pub fn as_slice(&self) -> &[u8] {
         self.0
     }
 
     #[inline]
-    pub fn as_mut_slice(&mut self) -> &'a mut [u8] {
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
         self.0
     }
 }

--- a/src/libstd/sys/sgx/mod.rs
+++ b/src/libstd/sys/sgx/mod.rs
@@ -3,7 +3,6 @@
 //! This module contains the facade (aka platform-specific) implementations of
 //! OS level functionality for Fortanix SGX.
 
-use io;
 use os::raw::c_char;
 use sync::atomic::{AtomicBool, Ordering};
 
@@ -20,6 +19,7 @@ pub mod env;
 pub mod ext;
 pub mod fd;
 pub mod fs;
+pub mod io;
 pub mod memchr;
 pub mod mutex;
 pub mod net;
@@ -41,12 +41,12 @@ pub fn init() {
 
 /// This function is used to implement functionality that simply doesn't exist.
 /// Programs relying on this functionality will need to deal with the error.
-pub fn unsupported<T>() -> io::Result<T> {
+pub fn unsupported<T>() -> ::io::Result<T> {
     Err(unsupported_err())
 }
 
-pub fn unsupported_err() -> io::Error {
-    io::Error::new(io::ErrorKind::Other,
+pub fn unsupported_err() -> ::io::Error {
+    ::io::Error::new(::io::ErrorKind::Other,
                    "operation not supported on SGX yet")
 }
 
@@ -55,58 +55,58 @@ pub fn unsupported_err() -> io::Error {
 /// returned, the program might very well be able to function normally. This is
 /// what happens when `SGX_INEFFECTIVE_ERROR` is set to `true`. If it is
 /// `false`, the behavior is the same as `unsupported`.
-pub fn sgx_ineffective<T>(v: T) -> io::Result<T> {
+pub fn sgx_ineffective<T>(v: T) -> ::io::Result<T> {
     static SGX_INEFFECTIVE_ERROR: AtomicBool = AtomicBool::new(false);
     if SGX_INEFFECTIVE_ERROR.load(Ordering::Relaxed) {
-        Err(io::Error::new(io::ErrorKind::Other,
+        Err(::io::Error::new(::io::ErrorKind::Other,
                        "operation can't be trusted to have any effect on SGX"))
     } else {
         Ok(v)
     }
 }
 
-pub fn decode_error_kind(code: i32) -> io::ErrorKind {
+pub fn decode_error_kind(code: i32) -> ::io::ErrorKind {
     use fortanix_sgx_abi::Error;
 
     // FIXME: not sure how to make sure all variants of Error are covered
     if code == Error::NotFound as _ {
-        io::ErrorKind::NotFound
+        ::io::ErrorKind::NotFound
     } else if code == Error::PermissionDenied as _ {
-        io::ErrorKind::PermissionDenied
+        ::io::ErrorKind::PermissionDenied
     } else if code == Error::ConnectionRefused as _ {
-        io::ErrorKind::ConnectionRefused
+        ::io::ErrorKind::ConnectionRefused
     } else if code == Error::ConnectionReset as _ {
-        io::ErrorKind::ConnectionReset
+        ::io::ErrorKind::ConnectionReset
     } else if code == Error::ConnectionAborted as _ {
-        io::ErrorKind::ConnectionAborted
+        ::io::ErrorKind::ConnectionAborted
     } else if code == Error::NotConnected as _ {
-        io::ErrorKind::NotConnected
+        ::io::ErrorKind::NotConnected
     } else if code == Error::AddrInUse as _ {
-        io::ErrorKind::AddrInUse
+        ::io::ErrorKind::AddrInUse
     } else if code == Error::AddrNotAvailable as _ {
-        io::ErrorKind::AddrNotAvailable
+        ::io::ErrorKind::AddrNotAvailable
     } else if code == Error::BrokenPipe as _ {
-        io::ErrorKind::BrokenPipe
+        ::io::ErrorKind::BrokenPipe
     } else if code == Error::AlreadyExists as _ {
-        io::ErrorKind::AlreadyExists
+        ::io::ErrorKind::AlreadyExists
     } else if code == Error::WouldBlock as _ {
-        io::ErrorKind::WouldBlock
+        ::io::ErrorKind::WouldBlock
     } else if code == Error::InvalidInput as _ {
-        io::ErrorKind::InvalidInput
+        ::io::ErrorKind::InvalidInput
     } else if code == Error::InvalidData as _ {
-        io::ErrorKind::InvalidData
+        ::io::ErrorKind::InvalidData
     } else if code == Error::TimedOut as _ {
-        io::ErrorKind::TimedOut
+        ::io::ErrorKind::TimedOut
     } else if code == Error::WriteZero as _ {
-        io::ErrorKind::WriteZero
+        ::io::ErrorKind::WriteZero
     } else if code == Error::Interrupted as _ {
-        io::ErrorKind::Interrupted
+        ::io::ErrorKind::Interrupted
     } else if code == Error::Other as _ {
-        io::ErrorKind::Other
+        ::io::ErrorKind::Other
     } else if code == Error::UnexpectedEof as _ {
-        io::ErrorKind::UnexpectedEof
+        ::io::ErrorKind::UnexpectedEof
     } else {
-        io::ErrorKind::Other
+        ::io::ErrorKind::Other
     }
 }
 

--- a/src/libstd/sys/sgx/net.rs
+++ b/src/libstd/sys/sgx/net.rs
@@ -1,5 +1,5 @@
 use fmt;
-use io;
+use io::{self, IoVec, IoVecMut};
 use net::{SocketAddr, Shutdown, Ipv4Addr, Ipv6Addr, ToSocketAddrs};
 use time::Duration;
 use sys::{unsupported, Void, sgx_ineffective, AsInner, FromInner, IntoInner, TryIntoInner};
@@ -104,7 +104,7 @@ impl TcpStream {
     }
 
     pub fn read_vectored(&self, buf: &mut [IoVecMut<'_>]) -> io::Result<usize> {
-        let buf = match buf.get(0) {
+        let buf = match buf.get_mut(0) {
             Some(buf) => buf,
             None => return Ok(0),
         };
@@ -120,7 +120,7 @@ impl TcpStream {
             Some(buf) => buf,
             None => return Ok(0),
         };
-        self.read(buf)
+        self.write(buf)
     }
 
     pub fn peer_addr(&self) -> io::Result<SocketAddr> {

--- a/src/libstd/sys/sgx/net.rs
+++ b/src/libstd/sys/sgx/net.rs
@@ -103,8 +103,24 @@ impl TcpStream {
         self.inner.inner.read(buf)
     }
 
+    pub fn read_vectored(&self, buf: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+        let buf = match buf.get(0) {
+            Some(buf) => buf.as_mut_slice(),
+            None => return Ok(0),
+        };
+        self.read(buf)
+    }
+
     pub fn write(&self, buf: &[u8]) -> io::Result<usize> {
         self.inner.inner.write(buf)
+    }
+
+    pub fn write_vectored(&self, buf: &[IoVec<'_>]) -> io::Result<usize> {
+        let buf = match buf.get(0) {
+            Some(buf) => buf.as_slice(),
+            None => return Ok(0),
+        };
+        self.read(buf)
     }
 
     pub fn peer_addr(&self) -> io::Result<SocketAddr> {

--- a/src/libstd/sys/sgx/net.rs
+++ b/src/libstd/sys/sgx/net.rs
@@ -105,7 +105,7 @@ impl TcpStream {
 
     pub fn read_vectored(&self, buf: &mut [IoVecMut<'_>]) -> io::Result<usize> {
         let buf = match buf.get(0) {
-            Some(buf) => buf.as_mut_slice(),
+            Some(buf) => buf,
             None => return Ok(0),
         };
         self.read(buf)
@@ -117,7 +117,7 @@ impl TcpStream {
 
     pub fn write_vectored(&self, buf: &[IoVec<'_>]) -> io::Result<usize> {
         let buf = match buf.get(0) {
-            Some(buf) => buf.as_slice(),
+            Some(buf) => buf,
             None => return Ok(0),
         };
         self.read(buf)

--- a/src/libstd/sys/unix/ext/net.rs
+++ b/src/libstd/sys/unix/ext/net.rs
@@ -18,7 +18,7 @@ mod libc {
 use ascii;
 use ffi::OsStr;
 use fmt;
-use io::{self, Initializer};
+use io::{self, Initializer, IoVec, IoVecMut};
 use mem;
 use net::{self, Shutdown};
 use os::unix::ffi::OsStrExt;
@@ -551,6 +551,10 @@ impl io::Read for UnixStream {
         io::Read::read(&mut &*self, buf)
     }
 
+    fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+        io::Read::read_vectored(&mut &*self, bufs)
+    }
+
     #[inline]
     unsafe fn initializer(&self) -> Initializer {
         Initializer::nop()
@@ -561,6 +565,10 @@ impl io::Read for UnixStream {
 impl<'a> io::Read for &'a UnixStream {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.0.read(buf)
+    }
+
+    fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+        self.0.read_vectored(bufs)
     }
 
     #[inline]
@@ -575,6 +583,10 @@ impl io::Write for UnixStream {
         io::Write::write(&mut &*self, buf)
     }
 
+    fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+        io::Write::write_vectored(&mut &*self, bufs)
+    }
+
     fn flush(&mut self) -> io::Result<()> {
         io::Write::flush(&mut &*self)
     }
@@ -584,6 +596,10 @@ impl io::Write for UnixStream {
 impl<'a> io::Write for &'a UnixStream {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.0.write(buf)
+    }
+
+    fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+        self.0.write_vectored(bufs)
     }
 
     fn flush(&mut self) -> io::Result<()> {
@@ -1508,6 +1524,25 @@ mod test {
         drop(stream);
 
         thread.join().unwrap();
+    }
+
+    #[test]
+    fn vectored() {
+        let (mut s1, mut s2) = or_panic!(UnixStream::pair());
+
+        let len = or_panic!(s1.write_vectored(
+            &[IoVec::new(b"hello"), IoVec::new(b" "), IoVec::new(b"world!")],
+        ));
+        assert_eq!(len, 12);
+
+        let mut buf1 = [0; 6];
+        let mut buf2 = [0; 7];
+        let len = or_panic!(s2.read_vectored(
+            &mut [IoVecMut::new(&mut buf1), IoVecMut::new(&mut buf2)],
+        ));
+        assert_eq!(len, 12);
+        assert_eq!(&buf1, b"hello ");
+        assert_eq!(&buf2, b"world!\0");
     }
 
     #[test]

--- a/src/libstd/sys/unix/io.rs
+++ b/src/libstd/sys/unix/io.rs
@@ -1,0 +1,61 @@
+use marker::PhantomData;
+use libc::{iovec, c_void};
+use slice;
+
+#[repr(transparent)]
+pub struct IoVec<'a> {
+    vec: iovec,
+    _p: PhantomData<&'a [u8]>,
+}
+
+impl<'a> IoVec<'a> {
+    #[inline]
+    pub fn new(buf: &'a [u8]) -> IoVec<'a> {
+        IoVec {
+            vec: iovec {
+                iov_base: buf.as_ptr() as *mut u8 as *mut c_void,
+                iov_len: buf.len()
+            },
+            _p: PhantomData,
+        }
+    }
+
+    #[inline]
+    pub fn as_slice(&self) -> &'a [u8] {
+        unsafe {
+            slice::from_raw_parts(self.vec.iov_base as *mut u8, self.vec.iov_len)
+        }
+    }
+}
+
+pub struct IoVecMut<'a> {
+    vec: iovec,
+    _p: PhantomData<&'a mut [u8]>,
+}
+
+impl<'a> IoVecMut<'a> {
+    #[inline]
+    pub fn new(buf: &'a mut [u8]) -> IoVecMut<'a> {
+        IoVecMut {
+            vec: iovec {
+                iov_base: buf.as_mut_ptr() as *mut c_void,
+                iov_len: buf.len()
+            },
+            _p: PhantomData,
+        }
+    }
+
+    #[inline]
+    pub fn as_slice(&self) -> &'a [u8] {
+        unsafe {
+            slice::from_raw_parts(self.vec.iov_base as *mut u8, self.vec.iov_len)
+        }
+    }
+
+    #[inline]
+    pub fn as_mut_slice(&mut self) -> &'a mut [u8] {
+        unsafe {
+            slice::from_raw_parts_mut(self.vec.iov_base as *mut u8, self.vec.iov_len)
+        }
+    }
+}

--- a/src/libstd/sys/unix/io.rs
+++ b/src/libstd/sys/unix/io.rs
@@ -21,7 +21,7 @@ impl<'a> IoVec<'a> {
     }
 
     #[inline]
-    pub fn as_slice(&self) -> &'a [u8] {
+    pub fn as_slice(&self) -> &[u8] {
         unsafe {
             slice::from_raw_parts(self.vec.iov_base as *mut u8, self.vec.iov_len)
         }
@@ -46,14 +46,14 @@ impl<'a> IoVecMut<'a> {
     }
 
     #[inline]
-    pub fn as_slice(&self) -> &'a [u8] {
+    pub fn as_slice(&self) -> &[u8] {
         unsafe {
             slice::from_raw_parts(self.vec.iov_base as *mut u8, self.vec.iov_len)
         }
     }
 
     #[inline]
-    pub fn as_mut_slice(&mut self) -> &'a mut [u8] {
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
         unsafe {
             slice::from_raw_parts_mut(self.vec.iov_base as *mut u8, self.vec.iov_len)
         }

--- a/src/libstd/sys/unix/l4re.rs
+++ b/src/libstd/sys/unix/l4re.rs
@@ -5,7 +5,7 @@ macro_rules! unimpl {
 pub mod net {
     #![allow(warnings)]
     use fmt;
-    use io;
+    use io::{self, IoVec, IoVecMut};
     use libc;
     use net::{SocketAddr, Shutdown, Ipv4Addr, Ipv6Addr};
     use sys_common::{AsInner, FromInner, IntoInner};
@@ -46,6 +46,10 @@ pub mod net {
             unimpl!();
         }
 
+        pub fn read_vectored(&self, _: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+            unimpl!();
+        }
+
         pub fn peek(&self, _: &mut [u8]) -> io::Result<usize> {
             unimpl!();
         }
@@ -59,6 +63,10 @@ pub mod net {
         }
 
         pub fn write(&self, _: &[u8]) -> io::Result<usize> {
+            unimpl!();
+        }
+
+        pub fn write_vectored(&self, _: &[IoVec<'_>]) -> io::Result<usize> {
             unimpl!();
         }
 
@@ -144,7 +152,15 @@ pub mod net {
             unimpl!();
         }
 
+        pub fn read_vectored(&self, _: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+            unimpl!();
+        }
+
         pub fn write(&self, _: &[u8]) -> io::Result<usize> {
+            unimpl!();
+        }
+
+        pub fn write_vectored(&self, _: &[IoVec<'_>]) -> io::Result<usize> {
             unimpl!();
         }
 

--- a/src/libstd/sys/unix/mod.rs
+++ b/src/libstd/sys/unix/mod.rs
@@ -1,6 +1,6 @@
 #![allow(missing_docs, nonstandard_style)]
 
-use io::{self, ErrorKind};
+use io::ErrorKind;
 use libc;
 
 #[cfg(any(rustdoc, target_os = "linux"))] pub use os::linux as platform;
@@ -39,6 +39,7 @@ pub mod fast_thread_local;
 pub mod fd;
 pub mod fs;
 pub mod memchr;
+pub mod io;
 pub mod mutex;
 #[cfg(not(target_os = "l4re"))]
 pub mod net;
@@ -126,15 +127,15 @@ macro_rules! impl_is_minus_one {
 
 impl_is_minus_one! { i8 i16 i32 i64 isize }
 
-pub fn cvt<T: IsMinusOne>(t: T) -> io::Result<T> {
+pub fn cvt<T: IsMinusOne>(t: T) -> ::io::Result<T> {
     if t.is_minus_one() {
-        Err(io::Error::last_os_error())
+        Err(::io::Error::last_os_error())
     } else {
         Ok(t)
     }
 }
 
-pub fn cvt_r<T, F>(mut f: F) -> io::Result<T>
+pub fn cvt_r<T, F>(mut f: F) -> ::io::Result<T>
     where T: IsMinusOne,
           F: FnMut() -> T
 {

--- a/src/libstd/sys/unix/net.rs
+++ b/src/libstd/sys/unix/net.rs
@@ -1,5 +1,5 @@
 use ffi::CStr;
-use io;
+use io::{self, IoVec, IoVecMut};
 use libc::{self, c_int, c_void, size_t, sockaddr, socklen_t, EAI_SYSTEM, MSG_PEEK};
 use mem;
 use net::{SocketAddr, Shutdown};
@@ -241,6 +241,10 @@ impl Socket {
         self.recv_with_flags(buf, MSG_PEEK)
     }
 
+    pub fn read_vectored(&self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+        self.0.read_vectored(bufs)
+    }
+
     fn recv_from_with_flags(&self, buf: &mut [u8], flags: c_int)
                             -> io::Result<(usize, SocketAddr)> {
         let mut storage: libc::sockaddr_storage = unsafe { mem::zeroed() };
@@ -267,6 +271,10 @@ impl Socket {
 
     pub fn write(&self, buf: &[u8]) -> io::Result<usize> {
         self.0.write(buf)
+    }
+
+    pub fn write_vectored(&self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+        self.0.write_vectored(bufs)
     }
 
     pub fn set_timeout(&self, dur: Option<Duration>, kind: libc::c_int) -> io::Result<()> {

--- a/src/libstd/sys/wasm/io.rs
+++ b/src/libstd/sys/wasm/io.rs
@@ -1,0 +1,32 @@
+pub struct IoVec<'a>(&'a [u8]);
+
+impl<'a> IoVec<'a> {
+    #[inline]
+    pub fn new(buf: &'a [u8]) -> IoVec<'a> {
+        IoVec(buf)
+    }
+
+    #[inline]
+    pub fn as_slice(&self) -> &'a [u8] {
+        self.0
+    }
+}
+
+pub struct IoVecMut<'a>(&'a mut [u8]);
+
+impl<'a> IoVecMut<'a> {
+    #[inline]
+    pub fn new(buf: &'a mut [u8]) -> IoVecMut<'a> {
+        IoVecMut(buf)
+    }
+
+    #[inline]
+    pub fn as_slice(&self) -> &'a [u8] {
+        self.0
+    }
+
+    #[inline]
+    pub fn as_mut_slice(&mut self) -> &'a mut [u8] {
+        self.0
+    }
+}

--- a/src/libstd/sys/wasm/io.rs
+++ b/src/libstd/sys/wasm/io.rs
@@ -7,7 +7,7 @@ impl<'a> IoVec<'a> {
     }
 
     #[inline]
-    pub fn as_slice(&self) -> &'a [u8] {
+    pub fn as_slice(&self) -> &[u8] {
         self.0
     }
 }
@@ -21,12 +21,12 @@ impl<'a> IoVecMut<'a> {
     }
 
     #[inline]
-    pub fn as_slice(&self) -> &'a [u8] {
+    pub fn as_slice(&self) -> &[u8] {
         self.0
     }
 
     #[inline]
-    pub fn as_mut_slice(&mut self) -> &'a mut [u8] {
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
         self.0
     }
 }

--- a/src/libstd/sys/wasm/mod.rs
+++ b/src/libstd/sys/wasm/mod.rs
@@ -14,7 +14,6 @@
 //! compiling for wasm. That way it's a compile time error for something that's
 //! guaranteed to be a runtime error!
 
-use io;
 use os::raw::c_char;
 use ptr;
 use sys::os_str::Buf;
@@ -29,6 +28,7 @@ pub mod backtrace;
 pub mod cmath;
 pub mod env;
 pub mod fs;
+pub mod io;
 pub mod memchr;
 pub mod net;
 pub mod os;
@@ -63,17 +63,17 @@ cfg_if! {
 pub fn init() {
 }
 
-pub fn unsupported<T>() -> io::Result<T> {
+pub fn unsupported<T>() -> ::io::Result<T> {
     Err(unsupported_err())
 }
 
-pub fn unsupported_err() -> io::Error {
-    io::Error::new(io::ErrorKind::Other,
+pub fn unsupported_err() -> ::io::Error {
+    ::io::Error::new(::io::ErrorKind::Other,
                    "operation not supported on wasm yet")
 }
 
-pub fn decode_error_kind(_code: i32) -> io::ErrorKind {
-    io::ErrorKind::Other
+pub fn decode_error_kind(_code: i32) -> ::io::ErrorKind {
+    ::io::ErrorKind::Other
 }
 
 // This enum is used as the storage for a bunch of types which can't actually

--- a/src/libstd/sys/wasm/net.rs
+++ b/src/libstd/sys/wasm/net.rs
@@ -1,5 +1,5 @@
 use fmt;
-use io;
+use io::{self, IoVec, IoVecMut};
 use net::{SocketAddr, Shutdown, Ipv4Addr, Ipv6Addr};
 use time::Duration;
 use sys::{unsupported, Void};
@@ -40,7 +40,15 @@ impl TcpStream {
         match self.0 {}
     }
 
+    pub fn read_vectored(&self, _: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+        match self.0 {}
+    }
+
     pub fn write(&self, _: &[u8]) -> io::Result<usize> {
+        match self.0 {}
+    }
+
+    pub fn write_vectored(&self, _: &[IoVec<'_>]) -> io::Result<usize> {
         match self.0 {}
     }
 

--- a/src/libstd/sys/windows/c.rs
+++ b/src/libstd/sys/windows/c.rs
@@ -57,6 +57,9 @@ pub type LPWSAPROTOCOL_INFO = *mut WSAPROTOCOL_INFO;
 pub type LPSTR = *mut CHAR;
 pub type LPWSTR = *mut WCHAR;
 pub type LPFILETIME = *mut FILETIME;
+pub type LPWSABUF = *mut WSABUF;
+pub type LPWSAOVERLAPPED = *mut c_void;
+pub type LPWSAOVERLAPPED_COMPLETION_ROUTINE = *mut c_void;
 
 pub type PCONDITION_VARIABLE = *mut CONDITION_VARIABLE;
 pub type PLARGE_INTEGER = *mut c_longlong;
@@ -322,6 +325,12 @@ pub struct WSADATA {
     pub lpVendorInfo: *mut u8,
     pub szDescription: [u8; WSADESCRIPTION_LEN + 1],
     pub szSystemStatus: [u8; WSASYS_STATUS_LEN + 1],
+}
+
+#[repr(C)]
+pub struct WSABUF {
+    pub len: ULONG,
+    pub buf: *mut CHAR,
 }
 
 #[repr(C)]
@@ -988,6 +997,22 @@ extern "system" {
                                dwProcessId: DWORD,
                                lpProtocolInfo: LPWSAPROTOCOL_INFO)
                                -> c_int;
+    pub fn WSASend(s: SOCKET,
+                   lpBuffers: LPWSABUF,
+                   dwBufferCount: DWORD,
+                   lpNumberOfBytesSent: LPDWORD,
+                   dwFlags: DWORD,
+                   lpOverlapped: LPWSAOVERLAPPED,
+                   lpCompletionRoutine: LPWSAOVERLAPPED_COMPLETION_ROUTINE)
+                   -> c_int;
+    pub fn WSARecv(s: SOCKET,
+                   lpBuffers: LPWSABUF,
+                   dwBufferCount: DWORD,
+                   lpNumberOfBytesRecvd: LPDWORD,
+                   lpFlags: LPDWORD,
+                   lpOverlapped: LPWSAOVERLAPPED,
+                   lpCompletionRoutine: LPWSAOVERLAPPED_COMPLETION_ROUTINE)
+                   -> c_int;
     pub fn GetCurrentProcessId() -> DWORD;
     pub fn WSASocketW(af: c_int,
                       kind: c_int,

--- a/src/libstd/sys/windows/io.rs
+++ b/src/libstd/sys/windows/io.rs
@@ -22,7 +22,7 @@ impl<'a> IoVec<'a> {
     }
 
     #[inline]
-    pub fn as_slice(&self) -> &'a [u8] {
+    pub fn as_slice(&self) -> &[u8] {
         unsafe {
             slice::from_raw_parts(self.vec.buf as *mut u8, self.vec.len as usize)
         }
@@ -48,14 +48,14 @@ impl<'a> IoVecMut<'a> {
     }
 
     #[inline]
-    pub fn as_slice(&self) -> &'a [u8] {
+    pub fn as_slice(&self) -> &[u8] {
         unsafe {
             slice::from_raw_parts(self.vec.buf as *mut u8, self.vec.len as usize)
         }
     }
 
     #[inline]
-    pub fn as_mut_slice(&mut self) -> &'a mut [u8] {
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
         unsafe {
             slice::from_raw_parts_mut(self.vec.buf as *mut u8, self.vec.len as usize)
         }

--- a/src/libstd/sys/windows/io.rs
+++ b/src/libstd/sys/windows/io.rs
@@ -1,0 +1,63 @@
+use marker::PhantomData;
+use slice;
+use sys::c;
+
+#[repr(transparent)]
+pub struct IoVec<'a> {
+    vec: c::WSABUF,
+    _p: PhantomData<&'a [u8]>,
+}
+
+impl<'a> IoVec<'a> {
+    #[inline]
+    pub fn new(buf: &'a [u8]) -> IoVec<'a> {
+        assert!(buf.len() <= c::ULONG::max_value() as usize);
+        IoVec {
+            vec: c::WSABUF {
+                len: buf.len() as c::ULONG,
+                buf: buf.as_ptr() as *mut u8 as *mut c::CHAR,
+            },
+            _p: PhantomData,
+        }
+    }
+
+    #[inline]
+    pub fn as_slice(&self) -> &'a [u8] {
+        unsafe {
+            slice::from_raw_parts(self.vec.buf as *mut u8, self.vec.len as usize)
+        }
+    }
+}
+
+pub struct IoVecMut<'a> {
+    vec: c::WSABUF,
+    _p: PhantomData<&'a mut [u8]>,
+}
+
+impl<'a> IoVecMut<'a> {
+    #[inline]
+    pub fn new(buf: &'a mut [u8]) -> IoVecMut<'a> {
+        assert!(buf.len() <= c::ULONG::max_value() as usize);
+        IoVecMut {
+            vec: c::WSABUF {
+                len: buf.len() as c::ULONG,
+                buf: buf.as_mut_ptr() as *mut c::CHAR,
+            },
+            _p: PhantomData,
+        }
+    }
+
+    #[inline]
+    pub fn as_slice(&self) -> &'a [u8] {
+        unsafe {
+            slice::from_raw_parts(self.vec.buf as *mut u8, self.vec.len as usize)
+        }
+    }
+
+    #[inline]
+    pub fn as_mut_slice(&mut self) -> &'a mut [u8] {
+        unsafe {
+            slice::from_raw_parts_mut(self.vec.buf as *mut u8, self.vec.len as usize)
+        }
+    }
+}

--- a/src/libstd/sys_common/net.rs
+++ b/src/libstd/sys_common/net.rs
@@ -1,7 +1,7 @@
 use cmp;
 use ffi::CString;
 use fmt;
-use io::{self, Error, ErrorKind};
+use io::{self, Error, ErrorKind, IoVec, IoVecMut};
 use libc::{c_int, c_void};
 use mem;
 use net::{SocketAddr, Shutdown, Ipv4Addr, Ipv6Addr};
@@ -255,6 +255,10 @@ impl TcpStream {
         self.inner.read(buf)
     }
 
+    pub fn read_vectored(&self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+        self.inner.read_vectored(bufs)
+    }
+
     pub fn write(&self, buf: &[u8]) -> io::Result<usize> {
         let len = cmp::min(buf.len(), <wrlen_t>::max_value() as usize) as wrlen_t;
         let ret = cvt(unsafe {
@@ -264,6 +268,10 @@ impl TcpStream {
                     MSG_NOSIGNAL)
         })?;
         Ok(ret as usize)
+    }
+
+    pub fn write_vectored(&self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+        self.inner.write_vectored(bufs)
     }
 
     pub fn peer_addr(&self) -> io::Result<SocketAddr> {

--- a/src/tools/linkchecker/main.rs
+++ b/src/tools/linkchecker/main.rs
@@ -134,7 +134,9 @@ fn check(cache: &mut Cache,
        file.ends_with("log/index.html") ||
        file.ends_with("ty/struct.Slice.html") ||
        file.ends_with("ty/enum.Attributes.html") ||
-       file.ends_with("ty/struct.SymbolName.html") {
+       file.ends_with("ty/struct.SymbolName.html") ||
+       file.ends_with("io/struct.IoVec.html") ||
+       file.ends_with("io/struct.IoVecMut.html") {
         return None;
     }
     // FIXME(#32553)


### PR DESCRIPTION
This functionality has lived for a while in the tokio ecosystem, where
it can improve performance by minimizing copies.

r? @alexcrichton 