### PR TITLE
Deprecate Read::initializer in favor of ptr::freeze

### DIFF
--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -1523,4 +1523,7 @@ extern "rust-intrinsic" {
     /// Emits a `!nontemporal` store according to LLVM (see their docs).
     /// Probably will never become stable.
     pub fn nontemporal_store<T>(ptr: *mut T, val: T);
+
+    #[cfg(not(stage0))]
+    pub fn freeze<T>(ptr: *mut T, count: usize);
 }

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -1524,7 +1524,9 @@ extern "rust-intrinsic" {
     /// Probably will never become stable.
     pub fn nontemporal_store<T>(ptr: *mut T, val: T);
 
-    /// Freezes undefined data. Exposed as ptr::freeze.
+    /// Freezes undefined data.
+    ///
+    /// Exposed as [`std::ptr::freeze`](../../std/ptr/fn.freeze.html).
     #[cfg(not(stage0))]
     pub fn freeze<T>(ptr: *mut T, count: usize);
 }

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -1524,6 +1524,7 @@ extern "rust-intrinsic" {
     /// Probably will never become stable.
     pub fn nontemporal_store<T>(ptr: *mut T, val: T);
 
+    /// Freezes undefined data. Exposed as ptr::freeze.
     #[cfg(not(stage0))]
     pub fn freeze<T>(ptr: *mut T, count: usize);
 }

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -956,7 +956,7 @@ pub unsafe fn write_volatile<T>(dst: *mut T, src: T) {
 ///
 /// While this function does not actually physically write to memory, it acts as if it
 /// does. For example, calling this method on data which is concurrently accessible
-/// elsewhere is undefined behavior just as it would be to `ptr::write`.
+/// elsewhere is undefined behavior just as it would be to use `ptr::write`.
 ///
 /// # Warning
 ///

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -952,7 +952,7 @@ pub unsafe fn write_volatile<T>(dst: *mut T, src: T) {
 /// Uninitialized memory has undefined contents, and interation with that data
 /// can easily cause undefined behavior. This function "freezes" memory
 /// contents, converting uninitialized memory to initialized memory with
-/// arbitrary conents so that use of it is well defined.
+/// arbitrary contents so that use of it is well defined.
 ///
 /// This function has no runtime effect; it is purely an instruction to the
 /// compiler. In particular, it does not actually write anything to the memory.

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -991,7 +991,7 @@ pub unsafe fn write_volatile<T>(dst: *mut T, src: T) {
 ///         // We're passing this buffer to an arbitrary reader and aren't
 ///         // guaranteed they won't read from it, so freeze to avoid UB.
 ///         let mut buf: [u8; 4] = mem::uninitialized();
-///         ptr::freeze(&mut buf, 1);
+///         ptr::freeze(buf.as_mut_ptr(), buf.len());
 ///         reader.read_exact(&mut buf)?;
 ///
 ///         Ok(u32::from_le_bytes(buf))

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -1010,7 +1010,7 @@ pub unsafe fn freeze<T>(dst: *mut T, count: usize) {
 #[cfg(stage0)]
 pub unsafe fn freeze<T>(dst: *mut T, count: usize) {
     let _ = count;
-    asm!("" : "=*m"(dst) : );
+    asm!("" :: "r"(dst) : "memory" : "volatile");
 }
 
 #[lang = "const_ptr"]

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -949,7 +949,7 @@ pub unsafe fn write_volatile<T>(dst: *mut T, src: T) {
 /// Freezes `count * size_of::<T>()` bytes of memory, converting uninitialized data into
 /// arbitrary but fixed data.
 ///
-/// Uninitialized memory has undefined contents, and interation with those contents
+/// Uninitialized memory has undefined contents, and interaction with those contents
 /// can easily cause undefined behavior. Freezing the memory avoids those issues by
 /// converting the memory to an initialized state without actually needing to write to
 /// all of it. This function has no effect on memory which is already initialized.

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -947,7 +947,7 @@ pub unsafe fn write_volatile<T>(dst: *mut T, src: T) {
 }
 
 /// Freezes `count * size_of::<T>()` bytes of memory, converting undefined data into
-/// defined-but-arbitrary data.
+/// arbitrary but fixed data.
 ///
 /// Uninitialized memory has undefined contents, and interation with that data
 /// can easily cause undefined behavior. This function "freezes" memory
@@ -961,7 +961,9 @@ pub unsafe fn write_volatile<T>(dst: *mut T, src: T) {
 ///
 /// Behavior is undefined if any of the following conditions are violated:
 ///
-/// * `dst` must be [valid] for reads.
+/// * `dst` must be [valid] for writes.
+///
+/// * Every bit representation of `T` must be a valid value.
 ///
 /// Note that even if `T` has size `0`, the pointer must be non-NULL and properly aligned.
 ///

--- a/src/librustc_typeck/check/intrinsic.rs
+++ b/src/librustc_typeck/check/intrinsic.rs
@@ -379,6 +379,18 @@ pub fn check_intrinsic_type<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                 (1, vec![ tcx.mk_mut_ptr(param(0)), param(0) ], tcx.mk_unit())
             }
 
+            "freeze" => {
+                (1,
+                 vec![
+                     tcx.mk_ptr(ty::TypeAndMut {
+                         ty: param(0),
+                         mutbl: hir::MutMutable
+                     }),
+                     tcx.types.usize,
+                 ],
+                 tcx.mk_unit())
+            }
+
             ref other => {
                 struct_span_err!(tcx.sess, it.span, E0093,
                                  "unrecognized intrinsic function: `{}`",

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -9,7 +9,9 @@
 
 use fmt;
 use ffi::OsString;
-use io::{self, SeekFrom, Seek, Read, Initializer, Write};
+use io::{self, SeekFrom, Seek, Read, Write};
+#[allow(deprecated)]
+use io::Initializer;
 use path::{Path, PathBuf};
 use sys::fs as fs_imp;
 use sys_common::{AsInnerMut, FromInner, AsInner, IntoInner};
@@ -600,6 +602,7 @@ impl Read for File {
     }
 
     #[inline]
+    #[allow(deprecated)]
     unsafe fn initializer(&self) -> Initializer {
         Initializer::nop()
     }
@@ -624,6 +627,7 @@ impl<'a> Read for &'a File {
     }
 
     #[inline]
+    #[allow(deprecated)]
     unsafe fn initializer(&self) -> Initializer {
         Initializer::nop()
     }

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -5,8 +5,11 @@ use io::prelude::*;
 use cmp;
 use error;
 use fmt;
-use io::{self, Initializer, DEFAULT_BUF_SIZE, Error, ErrorKind, SeekFrom};
+use io::{self, DEFAULT_BUF_SIZE, Error, ErrorKind, SeekFrom};
+#[allow(deprecated)]
+use io::Initializer;
 use memchr;
+use ptr;
 
 /// The `BufReader` struct adds buffering to any reader.
 ///
@@ -92,7 +95,7 @@ impl<R: Read> BufReader<R> {
         unsafe {
             let mut buffer = Vec::with_capacity(cap);
             buffer.set_len(cap);
-            inner.initializer().initialize(&mut buffer);
+            ptr::freeze(buffer.as_mut_ptr(), cap);
             BufReader {
                 inner,
                 buf: buffer.into_boxed_slice(),
@@ -236,6 +239,7 @@ impl<R: Read> Read for BufReader<R> {
     }
 
     // we can't skip unconditionally because of the large buffer case in read.
+    #[allow(deprecated)]
     unsafe fn initializer(&self) -> Initializer {
         self.inner.initializer()
     }

--- a/src/libstd/io/cursor.rs
+++ b/src/libstd/io/cursor.rs
@@ -2,7 +2,9 @@ use io::prelude::*;
 
 use core::convert::TryInto;
 use cmp;
-use io::{self, Initializer, SeekFrom, Error, ErrorKind};
+use io::{self, SeekFrom, Error, ErrorKind};
+#[allow(deprecated)]
+use io::Initializer;
 
 /// A `Cursor` wraps an in-memory buffer and provides it with a
 /// [`Seek`] implementation.
@@ -229,6 +231,7 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
     }
 
     #[inline]
+    #[allow(deprecated)]
     unsafe fn initializer(&self) -> Initializer {
         Initializer::nop()
     }

--- a/src/libstd/io/impls.rs
+++ b/src/libstd/io/impls.rs
@@ -1,5 +1,7 @@
 use cmp;
-use io::{self, SeekFrom, Read, Initializer, Write, Seek, BufRead, Error, ErrorKind};
+use io::{self, SeekFrom, Read, Write, Seek, BufRead, Error, ErrorKind};
+#[allow(deprecated)]
+use io::Initializer;
 use fmt;
 use mem;
 
@@ -14,6 +16,7 @@ impl<'a, R: Read + ?Sized> Read for &'a mut R {
     }
 
     #[inline]
+    #[allow(deprecated)]
     unsafe fn initializer(&self) -> Initializer {
         (**self).initializer()
     }
@@ -83,6 +86,7 @@ impl<R: Read + ?Sized> Read for Box<R> {
     }
 
     #[inline]
+    #[allow(deprecated)]
     unsafe fn initializer(&self) -> Initializer {
         (**self).initializer()
     }
@@ -172,6 +176,7 @@ impl<'a> Read for &'a [u8] {
     }
 
     #[inline]
+    #[allow(deprecated)]
     unsafe fn initializer(&self) -> Initializer {
         Initializer::nop()
     }

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -367,7 +367,7 @@ fn read_to_end_with_reservation<R: Read + ?Sized>(r: &mut R,
                 g.buf.reserve(reservation_size);
                 let capacity = g.buf.capacity();
                 g.buf.set_len(capacity);
-                r.initializer().initialize(&mut g.buf[g.len..]);
+                ptr::freeze(g.buf.as_mut_ptr().add(g.len), g.buf.len() - g.len);
             }
         }
 
@@ -543,6 +543,8 @@ pub trait Read {
     /// [`Initializer::nop()`]: ../../std/io/struct.Initializer.html#method.nop
     /// [`Initializer`]: ../../std/io/struct.Initializer.html
     #[unstable(feature = "read_initializer", issue = "42788")]
+    #[rustc_deprecated(since = "1.33.0", reason = "use std::ptr::freeze instead")]
+    #[allow(deprecated)]
     #[inline]
     unsafe fn initializer(&self) -> Initializer {
         Initializer::zeroing()
@@ -869,12 +871,22 @@ pub trait Read {
 
 /// A type used to conditionally initialize buffers passed to `Read` methods.
 #[unstable(feature = "read_initializer", issue = "42788")]
-#[derive(Debug)]
+#[rustc_deprecated(since = "1.33.0", reason = "use std::ptr::freeze instead")]
 pub struct Initializer(bool);
 
+#[allow(deprecated)]
+#[unstable(feature = "read_initializer", issue = "42788")]
+impl fmt::Debug for Initializer {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.debug_tuple("Initializer").field(&self.0).finish()
+    }
+}
+
+#[allow(deprecated)]
 impl Initializer {
     /// Returns a new `Initializer` which will zero out buffers.
     #[unstable(feature = "read_initializer", issue = "42788")]
+    #[rustc_deprecated(since = "1.33.0", reason = "use std::ptr::freeze instead")]
     #[inline]
     pub fn zeroing() -> Initializer {
         Initializer(true)
@@ -889,6 +901,7 @@ impl Initializer {
     /// the method accurately reflects the number of bytes that have been
     /// written to the head of the buffer.
     #[unstable(feature = "read_initializer", issue = "42788")]
+    #[rustc_deprecated(since = "1.33.0", reason = "use std::ptr::freeze instead")]
     #[inline]
     pub unsafe fn nop() -> Initializer {
         Initializer(false)
@@ -896,6 +909,7 @@ impl Initializer {
 
     /// Indicates if a buffer should be initialized.
     #[unstable(feature = "read_initializer", issue = "42788")]
+    #[rustc_deprecated(since = "1.33.0", reason = "use std::ptr::freeze instead")]
     #[inline]
     pub fn should_initialize(&self) -> bool {
         self.0
@@ -903,6 +917,7 @@ impl Initializer {
 
     /// Initializes a buffer if necessary.
     #[unstable(feature = "read_initializer", issue = "42788")]
+    #[rustc_deprecated(since = "1.33.0", reason = "use std::ptr::freeze instead")]
     #[inline]
     pub fn initialize(&self, buf: &mut [u8]) {
         if self.should_initialize() {
@@ -1698,6 +1713,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
         self.second.read(buf)
     }
 
+    #[allow(deprecated)]
     unsafe fn initializer(&self) -> Initializer {
         let initializer = self.first.initializer();
         if initializer.should_initialize() {
@@ -1895,6 +1911,7 @@ impl<T: Read> Read for Take<T> {
         Ok(n)
     }
 
+    #[allow(deprecated)]
     unsafe fn initializer(&self) -> Initializer {
         self.inner.initializer()
     }

--- a/src/libstd/io/stdio.rs
+++ b/src/libstd/io/stdio.rs
@@ -3,7 +3,9 @@ use io::prelude::*;
 use cell::RefCell;
 use fmt;
 use io::lazy::Lazy;
-use io::{self, Initializer, BufReader, LineWriter};
+use io::{self, BufReader, LineWriter};
+#[allow(deprecated)]
+use io::Initializer;
 use sync::{Arc, Mutex, MutexGuard};
 use sys::stdio;
 use sys_common::remutex::{ReentrantMutex, ReentrantMutexGuard};
@@ -67,6 +69,7 @@ impl Read for StdinRaw {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> { self.0.read(buf) }
 
     #[inline]
+    #[allow(deprecated)]
     unsafe fn initializer(&self) -> Initializer {
         Initializer::nop()
     }
@@ -297,6 +300,7 @@ impl Read for Stdin {
         self.lock().read(buf)
     }
     #[inline]
+    #[allow(deprecated)]
     unsafe fn initializer(&self) -> Initializer {
         Initializer::nop()
     }
@@ -317,6 +321,7 @@ impl<'a> Read for StdinLock<'a> {
         self.inner.read(buf)
     }
     #[inline]
+    #[allow(deprecated)]
     unsafe fn initializer(&self) -> Initializer {
         Initializer::nop()
     }

--- a/src/libstd/io/util.rs
+++ b/src/libstd/io/util.rs
@@ -1,8 +1,11 @@
 #![allow(missing_copy_implementations)]
 
 use fmt;
-use io::{self, Read, Initializer, Write, ErrorKind, BufRead};
+use io::{self, Read, Write, ErrorKind, BufRead};
+#[allow(deprecated)]
+use io::Initializer;
 use mem;
+use ptr;
 
 /// Copies the entire contents of a reader into a writer.
 ///
@@ -45,7 +48,7 @@ pub fn copy<R: ?Sized, W: ?Sized>(reader: &mut R, writer: &mut W) -> io::Result<
 {
     let mut buf = unsafe {
         let mut buf: [u8; super::DEFAULT_BUF_SIZE] = mem::uninitialized();
-        reader.initializer().initialize(&mut buf);
+        ptr::freeze(&mut buf, 1);
         buf
     };
 
@@ -97,6 +100,7 @@ impl Read for Empty {
     fn read(&mut self, _buf: &mut [u8]) -> io::Result<usize> { Ok(0) }
 
     #[inline]
+    #[allow(deprecated)]
     unsafe fn initializer(&self) -> Initializer {
         Initializer::nop()
     }
@@ -153,6 +157,7 @@ impl Read for Repeat {
     }
 
     #[inline]
+    #[allow(deprecated)]
     unsafe fn initializer(&self) -> Initializer {
         Initializer::nop()
     }

--- a/src/libstd/io/util.rs
+++ b/src/libstd/io/util.rs
@@ -48,7 +48,7 @@ pub fn copy<R: ?Sized, W: ?Sized>(reader: &mut R, writer: &mut W) -> io::Result<
 {
     let mut buf = unsafe {
         let mut buf: [u8; super::DEFAULT_BUF_SIZE] = mem::uninitialized();
-        ptr::freeze(&mut buf, 1);
+        ptr::freeze(buf.as_mut_ptr(), buf.len());
         buf
     };
 

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -264,6 +264,7 @@
 #![feature(panic_unwind)]
 #![feature(prelude_import)]
 #![feature(ptr_internals)]
+#![feature(ptr_freeze)]
 #![feature(raw)]
 #![feature(hash_raw_entry)]
 #![feature(rustc_attrs)]

--- a/src/libstd/net/tcp.rs
+++ b/src/libstd/net/tcp.rs
@@ -1,7 +1,9 @@
 use io::prelude::*;
 
 use fmt;
-use io::{self, Initializer};
+use io;
+#[allow(deprecated)]
+use io::Initializer;
 use net::{ToSocketAddrs, SocketAddr, Shutdown};
 use sys_common::net as net_imp;
 use sys_common::{AsInner, FromInner, IntoInner};
@@ -570,6 +572,7 @@ impl Read for TcpStream {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> { self.0.read(buf) }
 
     #[inline]
+    #[allow(deprecated)]
     unsafe fn initializer(&self) -> Initializer {
         Initializer::nop()
     }
@@ -584,6 +587,7 @@ impl<'a> Read for &'a TcpStream {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> { self.0.read(buf) }
 
     #[inline]
+    #[allow(deprecated)]
     unsafe fn initializer(&self) -> Initializer {
         Initializer::nop()
     }

--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -111,7 +111,9 @@ use io::prelude::*;
 use ffi::OsStr;
 use fmt;
 use fs;
-use io::{self, Initializer};
+use io;
+#[allow(deprecated)]
+use io::Initializer;
 use path::Path;
 use str;
 use sys::pipe::{read2, AnonPipe};
@@ -272,6 +274,7 @@ impl Read for ChildStdout {
         self.inner.read(buf)
     }
     #[inline]
+    #[allow(deprecated)]
     unsafe fn initializer(&self) -> Initializer {
         Initializer::nop()
     }
@@ -319,6 +322,7 @@ impl Read for ChildStderr {
         self.inner.read(buf)
     }
     #[inline]
+    #[allow(deprecated)]
     unsafe fn initializer(&self) -> Initializer {
         Initializer::nop()
     }

--- a/src/libstd/sys/redox/ext/net.rs
+++ b/src/libstd/sys/redox/ext/net.rs
@@ -3,7 +3,9 @@
 //! Unix-specific networking functionality
 
 use fmt;
-use io::{self, Error, ErrorKind, Initializer};
+use io::{self, Error, ErrorKind};
+#[allow(deprecated)]
+use io::Initializer;
 use net::Shutdown;
 use os::unix::io::{RawFd, AsRawFd, FromRawFd, IntoRawFd};
 use path::Path;
@@ -410,6 +412,7 @@ impl io::Read for UnixStream {
     }
 
     #[inline]
+    #[allow(deprecated)]
     unsafe fn initializer(&self) -> Initializer {
         Initializer::nop()
     }
@@ -422,6 +425,7 @@ impl<'a> io::Read for &'a UnixStream {
     }
 
     #[inline]
+    #[allow(deprecated)]
     unsafe fn initializer(&self) -> Initializer {
         Initializer::nop()
     }

--- a/src/libstd/sys/unix/ext/net.rs
+++ b/src/libstd/sys/unix/ext/net.rs
@@ -18,7 +18,9 @@ mod libc {
 use ascii;
 use ffi::OsStr;
 use fmt;
-use io::{self, Initializer};
+use io;
+#[allow(deprecated)]
+use io::Initializer;
 use mem;
 use net::{self, Shutdown};
 use os::unix::ffi::OsStrExt;
@@ -552,6 +554,7 @@ impl io::Read for UnixStream {
     }
 
     #[inline]
+    #[allow(deprecated)]
     unsafe fn initializer(&self) -> Initializer {
         Initializer::nop()
     }
@@ -564,6 +567,7 @@ impl<'a> io::Read for &'a UnixStream {
     }
 
     #[inline]
+    #[allow(deprecated)]
     unsafe fn initializer(&self) -> Initializer {
         Initializer::nop()
     }

--- a/src/libstd/sys/unix/fd.rs
+++ b/src/libstd/sys/unix/fd.rs
@@ -1,7 +1,9 @@
 #![unstable(reason = "not public", issue = "0", feature = "fd")]
 
 use cmp;
-use io::{self, Read, Initializer};
+use io::{self, Read};
+#[allow(deprecated)]
+use io::Initializer;
 use libc::{self, c_int, c_void, ssize_t};
 use mem;
 use sync::atomic::{AtomicBool, Ordering};
@@ -262,6 +264,7 @@ impl<'a> Read for &'a FileDesc {
     }
 
     #[inline]
+    #[allow(deprecated)]
     unsafe fn initializer(&self) -> Initializer {
         Initializer::nop()
     }

--- a/src/test/codegen/freeze.rs
+++ b/src/test/codegen/freeze.rs
@@ -1,0 +1,18 @@
+// compile-flags: -O
+#![crate_type="lib"]
+#![feature(ptr_freeze)]
+
+use std::ptr;
+use std::mem;
+
+// freeze should prevent reads of uninitialized memory from being UB
+#[no_mangle]
+pub fn read_uninitialized() -> u8 {
+    // CHECK-LABEL: @read_uninitialized
+    // CHECK-NOT: undef
+    unsafe {
+        let mut v: u8 = mem::uninitialized();
+        ptr::freeze(&mut v, 1);
+        v
+    }
+}


### PR DESCRIPTION
Read implementations should only write into the buffer passed to them,
but have the ability to read from it. Access of uninitialized memory can
easily cause UB, so there's then a question of what a user of a reader
should do to initialize buffers.

Previously, we allowed a Read implementation to promise it wouldn't look
at the contents of the buffer, which allows the user to pass
uninitialized memory to it.

Instead, this PR adds a method to "freeze" undefined bytes into
arbitrary-but-defined bytes. This is currently done via an inline
assembly directive noting the address as an output, so LLVM no longer
knows it's uninitialized. There is a proposed "freeze" operation in LLVM
itself that would do this directly, but it hasn't been fully
implemented.

Some targets don't support inline assembly, so there we instead pass the
pointer to an extern "C" function, which is similarly opaque to LLVM.

The current approach is very low level. If we stabilize, we'll probably
want to add something like `slice.freeze()` to make this easier to use.

r? @alexcrichton 