### PR TITLE
Update `vec!` to have the same coercion behavior as arrays

### DIFF
--- a/src/liballoc/macros.rs
+++ b/src/liballoc/macros.rs
@@ -39,9 +39,20 @@ macro_rules! vec {
     ($elem:expr; $n:expr) => (
         $crate::vec::from_elem($elem, $n)
     );
-    ($($x:expr),*) => (
-        <[_]>::into_vec(box [$($x),*])
-    );
+    ($($x:expr),*) => ({
+        // We use a temporary let binding to work around a coercion
+        // bug/strangness with `box [a, b]` syntax. Example:
+        //
+        //     fn foo() {}
+        //     fn bar() {}
+        //
+        //     let _ = [foo, bar]; // works: fn items coerced to fn pointers
+        //     let _ = <[_]>::into_vec(box [foo, bar]);  // doesn't work
+        //
+        // See the `macro_fn_pointer_coercion` test.
+        let tmp = [$($x),*];
+        <[_]>::into_vec(box tmp)
+    });
     ($($x:expr,)*) => (vec![$($x),*])
 }
 

--- a/src/liballoc/tests/vec.rs
+++ b/src/liballoc/tests/vec.rs
@@ -1151,3 +1151,11 @@ fn test_try_reserve_exact() {
     }
 
 }
+
+#[test]
+fn macro_fn_pointer_coercion() {
+    fn foo() {}
+    fn bar() {}
+
+    let _v = vec![foo, bar];
+}


### PR DESCRIPTION
Before this commit, `vec![a, b, c]` had different coercion behavior than the 
array `[a, b, c]`. Example:

```rust
fn foo() {}
fn bar() {}

let arr = [foo, bar];    // works, fn items coerced to fn pointer
let v = vec![foo, bar];  // doesn't work
```

Last line results in:

    error[E0308]: mismatched types
     --> src/main.rs:6:13
      |
    6 |     let v = vec![foo, bar];  // doesn't work
      |             ^^^^^^^^^^^^^^ expected slice, found array of 2 elements
      |
      = note: expected type `std::boxed::Box<[fn() {main::foo}]>`
                 found type `std::boxed::Box<[fn(); 2]>`

This is due to `box [a, b, c]` behaving a bit strangely. A very related
question on StackOverflow: https://stackoverflow.com/q/54632524/2408867

By introducing this temporary let binding, we can fix the coercion
behavior. I'm pretty sure this is not a breaking change as it only 
allows more cases to compile.

---

Another very related question on SO: https://stackoverflow.com/questions/28151073/how-can-i-store-function-pointers-in-an-array

I have to admit that I created this PR only with the GitHub web editor and didn't test anything (CI will notice mistakes, right?). If you think I should extend this PR, just let me know!