### PR TITLE
Disallow `auto` trait alias syntax

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -6534,8 +6534,14 @@ impl<'a> Parser<'a> {
             let bounds = self.parse_generic_bounds()?;
             tps.where_clause = self.parse_where_clause()?;
             self.expect(&token::Semi)?;
+            if is_auto == IsAuto::Yes {
+                let msg = "trait aliases cannot be `auto`";
+                self.struct_span_err(self.prev_span, msg)
+                    .span_label(self.prev_span, msg)
+                    .emit();
+            }
             if unsafety != Unsafety::Normal {
-                let msg = "trait aliases cannot be unsafe";
+                let msg = "trait aliases cannot be `unsafe`";
                 self.struct_span_err(self.prev_span, msg)
                     .span_label(self.prev_span, msg)
                     .emit();

--- a/src/test/ui/traits/trait-alias-syntax.rs
+++ b/src/test/ui/traits/trait-alias-syntax.rs
@@ -1,0 +1,7 @@
+#![feature(trait_alias)]
+
+trait Foo {}
+auto trait A = Foo; //~ ERROR trait aliases cannot be `auto`
+unsafe trait B = Foo; //~ ERROR trait aliases cannot be `unsafe`
+
+fn main() {}

--- a/src/test/ui/traits/trait-alias-syntax.stderr
+++ b/src/test/ui/traits/trait-alias-syntax.stderr
@@ -1,0 +1,14 @@
+error: trait aliases cannot be `auto`
+  --> $DIR/trait-alias-syntax.rs:4:19
+   |
+LL | auto trait A = Foo; //~ ERROR trait aliases cannot be `auto`
+   |                   ^ trait aliases cannot be `auto`
+
+error: trait aliases cannot be `unsafe`
+  --> $DIR/trait-alias-syntax.rs:5:21
+   |
+LL | unsafe trait B = Foo; //~ ERROR trait aliases cannot be `unsafe`
+   |                     ^ trait aliases cannot be `unsafe`
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
See https://github.com/rust-lang/rust/issues/41517#issuecomment-462567679.

r? @Centril

CC @topecongiro @nikomatsakis 
