### PR TITLE
rustc_mir: split qualify_consts' "value qualification" bitflags into separate computations.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2822,7 +2822,6 @@ name = "rustc_mir"
 version = "0.0.0"
 dependencies = [
  "arena 0.0.0",
- "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "graphviz 0.0.0",

--- a/src/librustc_mir/Cargo.toml
+++ b/src/librustc_mir/Cargo.toml
@@ -11,7 +11,6 @@ crate-type = ["dylib"]
 
 [dependencies]
 arena = { path = "../libarena" }
-bitflags = "1.0"
 either = "1.5.0"
 dot = { path = "../libgraphviz", package = "graphviz" }
 log = "0.4"

--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -21,7 +21,7 @@ use rustc::mir::visit::{PlaceContext, Visitor, MutatingUseContext, NonMutatingUs
 use rustc::middle::lang_items;
 use rustc::session::config::nightly_options;
 use syntax::ast::LitKind;
-use syntax::feature_gate::{UnstableFeatures, emit_feature_err, GateIssue};
+use syntax::feature_gate::{emit_feature_err, GateIssue};
 use syntax_pos::{Span, DUMMY_SP};
 
 use std::fmt;
@@ -1062,32 +1062,14 @@ impl<'a, 'tcx> Visitor<'tcx> for Checker<'a, 'tcx> {
                                         err.emit();
                                     }
                                 } else {
-                                    // FIXME(#57563): remove this check when const fn stabilizes.
-                                    let (msg, note) = if let UnstableFeatures::Disallow =
-                                            self.tcx.sess.opts.unstable_features {
-                                        (format!("calls in {}s are limited to \
-                                                tuple structs and tuple variants",
-                                                self.mode),
-                                        Some("a limited form of compile-time function \
-                                            evaluation is available on a nightly \
-                                            compiler via `const fn`"))
-                                    } else {
-                                        (format!("calls in {}s are limited \
-                                                to constant functions, \
-                                                tuple structs and tuple variants",
-                                                self.mode),
-                                        None)
-                                    };
                                     let mut err = struct_span_err!(
                                         self.tcx.sess,
                                         self.span,
                                         E0015,
-                                        "{}",
-                                        msg,
+                                        "calls in {}s are limited to constant functions, \
+                                         tuple structs and tuple variants",
+                                        self.mode,
                                     );
-                                    if let Some(note) = note {
-                                        err.span_note(self.span, note);
-                                    }
                                     err.emit();
                                 }
                             }

--- a/src/test/ui/error-codes/E0017.nll.stderr
+++ b/src/test/ui/error-codes/E0017.nll.stderr
@@ -4,17 +4,17 @@ error[E0017]: references in constants may only refer to immutable values
 LL | const CR: &'static mut i32 = &mut C; //~ ERROR E0017
    |                              ^^^^^^ constants require immutable values
 
-error: cannot mutate statics in the initializer of another static
-  --> $DIR/E0017.rs:5:39
-   |
-LL | static STATIC_REF: &'static mut i32 = &mut X; //~ ERROR E0017
-   |                                       ^^^^^^
-
 error[E0017]: references in statics may only refer to immutable values
   --> $DIR/E0017.rs:5:39
    |
 LL | static STATIC_REF: &'static mut i32 = &mut X; //~ ERROR E0017
    |                                       ^^^^^^ statics require immutable values
+
+error: cannot mutate statics in the initializer of another static
+  --> $DIR/E0017.rs:5:39
+   |
+LL | static STATIC_REF: &'static mut i32 = &mut X; //~ ERROR E0017
+   |                                       ^^^^^^
 
 error[E0596]: cannot borrow immutable static item `X` as mutable
   --> $DIR/E0017.rs:5:39

--- a/src/test/ui/error-codes/E0017.stderr
+++ b/src/test/ui/error-codes/E0017.stderr
@@ -4,17 +4,17 @@ error[E0017]: references in constants may only refer to immutable values
 LL | const CR: &'static mut i32 = &mut C; //~ ERROR E0017
    |                              ^^^^^^ constants require immutable values
 
-error: cannot mutate statics in the initializer of another static
-  --> $DIR/E0017.rs:5:39
-   |
-LL | static STATIC_REF: &'static mut i32 = &mut X; //~ ERROR E0017
-   |                                       ^^^^^^
-
 error[E0017]: references in statics may only refer to immutable values
   --> $DIR/E0017.rs:5:39
    |
 LL | static STATIC_REF: &'static mut i32 = &mut X; //~ ERROR E0017
    |                                       ^^^^^^ statics require immutable values
+
+error: cannot mutate statics in the initializer of another static
+  --> $DIR/E0017.rs:5:39
+   |
+LL | static STATIC_REF: &'static mut i32 = &mut X; //~ ERROR E0017
+   |                                       ^^^^^^
 
 error[E0596]: cannot borrow immutable static item as mutable
   --> $DIR/E0017.rs:5:44

--- a/src/test/ui/error-codes/E0388.nll.stderr
+++ b/src/test/ui/error-codes/E0388.nll.stderr
@@ -4,17 +4,17 @@ error[E0017]: references in constants may only refer to immutable values
 LL | const CR: &'static mut i32 = &mut C; //~ ERROR E0017
    |                              ^^^^^^ constants require immutable values
 
-error: cannot mutate statics in the initializer of another static
-  --> $DIR/E0388.rs:5:39
-   |
-LL | static STATIC_REF: &'static mut i32 = &mut X; //~ ERROR E0017
-   |                                       ^^^^^^
-
 error[E0017]: references in statics may only refer to immutable values
   --> $DIR/E0388.rs:5:39
    |
 LL | static STATIC_REF: &'static mut i32 = &mut X; //~ ERROR E0017
    |                                       ^^^^^^ statics require immutable values
+
+error: cannot mutate statics in the initializer of another static
+  --> $DIR/E0388.rs:5:39
+   |
+LL | static STATIC_REF: &'static mut i32 = &mut X; //~ ERROR E0017
+   |                                       ^^^^^^
 
 error[E0596]: cannot borrow immutable static item `X` as mutable
   --> $DIR/E0388.rs:5:39

--- a/src/test/ui/error-codes/E0388.stderr
+++ b/src/test/ui/error-codes/E0388.stderr
@@ -4,17 +4,17 @@ error[E0017]: references in constants may only refer to immutable values
 LL | const CR: &'static mut i32 = &mut C; //~ ERROR E0017
    |                              ^^^^^^ constants require immutable values
 
-error: cannot mutate statics in the initializer of another static
-  --> $DIR/E0388.rs:5:39
-   |
-LL | static STATIC_REF: &'static mut i32 = &mut X; //~ ERROR E0017
-   |                                       ^^^^^^
-
 error[E0017]: references in statics may only refer to immutable values
   --> $DIR/E0388.rs:5:39
    |
 LL | static STATIC_REF: &'static mut i32 = &mut X; //~ ERROR E0017
    |                                       ^^^^^^ statics require immutable values
+
+error: cannot mutate statics in the initializer of another static
+  --> $DIR/E0388.rs:5:39
+   |
+LL | static STATIC_REF: &'static mut i32 = &mut X; //~ ERROR E0017
+   |                                       ^^^^^^
 
 error[E0596]: cannot borrow immutable static item as mutable
   --> $DIR/E0388.rs:5:44

--- a/src/test/ui/issues/issue-17718-const-bad-values.stderr
+++ b/src/test/ui/issues/issue-17718-const-bad-values.stderr
@@ -4,17 +4,17 @@ error[E0017]: references in constants may only refer to immutable values
 LL | const C1: &'static mut [usize] = &mut [];
    |                                  ^^^^^^^ constants require immutable values
 
-error[E0013]: constants cannot refer to statics, use a constant instead
-  --> $DIR/issue-17718-const-bad-values.rs:5:41
-   |
-LL | const C2: &'static mut usize = unsafe { &mut S };
-   |                                         ^^^^^^
-
 error[E0017]: references in constants may only refer to immutable values
   --> $DIR/issue-17718-const-bad-values.rs:5:41
    |
 LL | const C2: &'static mut usize = unsafe { &mut S };
    |                                         ^^^^^^ constants require immutable values
+
+error[E0013]: constants cannot refer to statics, use a constant instead
+  --> $DIR/issue-17718-const-bad-values.rs:5:41
+   |
+LL | const C2: &'static mut usize = unsafe { &mut S };
+   |                                         ^^^^^^
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
Prerequisite for computing those bits through a dataflow algorithm ~~(which I might do in this PR later)~~.

This PR should not change behavior overall, other than treating `simd_shuffle*` identically to `#[rustc_args_required_const]` (maybe we should just have `#[rustc_args_required_const]` on the intrinsic imports of `simd_shuffle*`? cc @gnzlbg)

cc @oli-obk @alexreg 