### PR TITLE
specify "upper camel case" in style lint

### DIFF
--- a/src/librustc_lint/Cargo.toml
+++ b/src/librustc_lint/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 name = "rustc_lint"
 path = "lib.rs"
 crate-type = ["dylib"]
-test = false
 
 [dependencies]
 log = "0.4"

--- a/src/test/ui/lint/lint-group-nonstandard-style.rs
+++ b/src/test/ui/lint/lint-group-nonstandard-style.rs
@@ -19,7 +19,7 @@ mod test {
 
         fn CamelCase() {} //~ WARN should have a snake
 
-        struct snake_case; //~ WARN should have a camel
+        struct snake_case; //~ WARN should have an upper camel
     }
 }
 

--- a/src/test/ui/lint/lint-group-nonstandard-style.stderr
+++ b/src/test/ui/lint/lint-group-nonstandard-style.stderr
@@ -1,8 +1,8 @@
-warning: type `snake_case` should have a camel case name
+warning: type `snake_case` should have an upper camel case name
   --> $DIR/lint-group-nonstandard-style.rs:22:16
    |
-LL |         struct snake_case; //~ WARN should have a camel
-   |                ^^^^^^^^^^ help: convert the identifier to camel case: `SnakeCase`
+LL |         struct snake_case; //~ WARN should have an upper camel
+   |                ^^^^^^^^^^ help: convert the identifier to upper camel case: `SnakeCase`
    |
 note: lint level defined here
   --> $DIR/lint-group-nonstandard-style.rs:18:17

--- a/src/test/ui/lint/lint-non-camel-case-types.rs
+++ b/src/test/ui/lint/lint-non-camel-case-types.rs
@@ -2,43 +2,35 @@
 #![allow(dead_code)]
 
 struct ONE_TWO_THREE;
-//~^ ERROR type `ONE_TWO_THREE` should have a camel case name
+//~^ ERROR type `ONE_TWO_THREE` should have an upper camel case name
 
-struct foo { //~ ERROR type `foo` should have a camel case name
+struct foo { //~ ERROR type `foo` should have an upper camel case name
     bar: isize,
 }
 
-enum foo2 { //~ ERROR type `foo2` should have a camel case name
+enum foo2 { //~ ERROR type `foo2` should have an upper camel case name
     Bar
 }
 
-struct foo3 { //~ ERROR type `foo3` should have a camel case name
+struct foo3 { //~ ERROR type `foo3` should have an upper camel case name
     bar: isize
 }
 
-type foo4 = isize; //~ ERROR type `foo4` should have a camel case name
+type foo4 = isize; //~ ERROR type `foo4` should have an upper camel case name
 
 enum Foo5 {
-    bar //~ ERROR variant `bar` should have a camel case name
+    bar //~ ERROR variant `bar` should have an upper camel case name
 }
 
-trait foo6 { //~ ERROR trait `foo6` should have a camel case name
+trait foo6 { //~ ERROR trait `foo6` should have an upper camel case name
     fn dummy(&self) { }
 }
 
-fn f<ty>(_: ty) {} //~ ERROR type parameter `ty` should have a camel case name
+fn f<ty>(_: ty) {} //~ ERROR type parameter `ty` should have an upper camel case name
 
 #[repr(C)]
 struct foo7 {
     bar: isize,
 }
-
-struct X86_64;
-
-struct X86__64; //~ ERROR type `X86__64` should have a camel case name
-
-struct Abc_123; //~ ERROR type `Abc_123` should have a camel case name
-
-struct A1_b2_c3; //~ ERROR type `A1_b2_c3` should have a camel case name
 
 fn main() { }

--- a/src/test/ui/lint/lint-non-camel-case-types.stderr
+++ b/src/test/ui/lint/lint-non-camel-case-types.stderr
@@ -1,8 +1,8 @@
-error: type `ONE_TWO_THREE` should have a camel case name
+error: type `ONE_TWO_THREE` should have an upper camel case name
   --> $DIR/lint-non-camel-case-types.rs:4:8
    |
 LL | struct ONE_TWO_THREE;
-   |        ^^^^^^^^^^^^^ help: convert the identifier to camel case: `OneTwoThree`
+   |        ^^^^^^^^^^^^^ help: convert the identifier to upper camel case: `OneTwoThree`
    |
 note: lint level defined here
   --> $DIR/lint-non-camel-case-types.rs:1:11
@@ -10,65 +10,47 @@ note: lint level defined here
 LL | #![forbid(non_camel_case_types)]
    |           ^^^^^^^^^^^^^^^^^^^^
 
-error: type `foo` should have a camel case name
+error: type `foo` should have an upper camel case name
   --> $DIR/lint-non-camel-case-types.rs:7:8
    |
-LL | struct foo { //~ ERROR type `foo` should have a camel case name
-   |        ^^^ help: convert the identifier to camel case: `Foo`
+LL | struct foo { //~ ERROR type `foo` should have an upper camel case name
+   |        ^^^ help: convert the identifier to upper camel case: `Foo`
 
-error: type `foo2` should have a camel case name
+error: type `foo2` should have an upper camel case name
   --> $DIR/lint-non-camel-case-types.rs:11:6
    |
-LL | enum foo2 { //~ ERROR type `foo2` should have a camel case name
-   |      ^^^^ help: convert the identifier to camel case: `Foo2`
+LL | enum foo2 { //~ ERROR type `foo2` should have an upper camel case name
+   |      ^^^^ help: convert the identifier to upper camel case: `Foo2`
 
-error: type `foo3` should have a camel case name
+error: type `foo3` should have an upper camel case name
   --> $DIR/lint-non-camel-case-types.rs:15:8
    |
-LL | struct foo3 { //~ ERROR type `foo3` should have a camel case name
-   |        ^^^^ help: convert the identifier to camel case: `Foo3`
+LL | struct foo3 { //~ ERROR type `foo3` should have an upper camel case name
+   |        ^^^^ help: convert the identifier to upper camel case: `Foo3`
 
-error: type `foo4` should have a camel case name
+error: type `foo4` should have an upper camel case name
   --> $DIR/lint-non-camel-case-types.rs:19:6
    |
-LL | type foo4 = isize; //~ ERROR type `foo4` should have a camel case name
-   |      ^^^^ help: convert the identifier to camel case: `Foo4`
+LL | type foo4 = isize; //~ ERROR type `foo4` should have an upper camel case name
+   |      ^^^^ help: convert the identifier to upper camel case: `Foo4`
 
-error: variant `bar` should have a camel case name
+error: variant `bar` should have an upper camel case name
   --> $DIR/lint-non-camel-case-types.rs:22:5
    |
-LL |     bar //~ ERROR variant `bar` should have a camel case name
-   |     ^^^ help: convert the identifier to camel case: `Bar`
+LL |     bar //~ ERROR variant `bar` should have an upper camel case name
+   |     ^^^ help: convert the identifier to upper camel case: `Bar`
 
-error: trait `foo6` should have a camel case name
+error: trait `foo6` should have an upper camel case name
   --> $DIR/lint-non-camel-case-types.rs:25:7
    |
-LL | trait foo6 { //~ ERROR trait `foo6` should have a camel case name
-   |       ^^^^ help: convert the identifier to camel case: `Foo6`
+LL | trait foo6 { //~ ERROR trait `foo6` should have an upper camel case name
+   |       ^^^^ help: convert the identifier to upper camel case: `Foo6`
 
-error: type parameter `ty` should have a camel case name
+error: type parameter `ty` should have an upper camel case name
   --> $DIR/lint-non-camel-case-types.rs:29:6
    |
-LL | fn f<ty>(_: ty) {} //~ ERROR type parameter `ty` should have a camel case name
-   |      ^^ help: convert the identifier to camel case: `Ty`
+LL | fn f<ty>(_: ty) {} //~ ERROR type parameter `ty` should have an upper camel case name
+   |      ^^ help: convert the identifier to upper camel case: `Ty`
 
-error: type `X86__64` should have a camel case name
-  --> $DIR/lint-non-camel-case-types.rs:38:8
-   |
-LL | struct X86__64; //~ ERROR type `X86__64` should have a camel case name
-   |        ^^^^^^^ help: convert the identifier to camel case: `X86_64`
-
-error: type `Abc_123` should have a camel case name
-  --> $DIR/lint-non-camel-case-types.rs:40:8
-   |
-LL | struct Abc_123; //~ ERROR type `Abc_123` should have a camel case name
-   |        ^^^^^^^ help: convert the identifier to camel case: `Abc123`
-
-error: type `A1_b2_c3` should have a camel case name
-  --> $DIR/lint-non-camel-case-types.rs:42:8
-   |
-LL | struct A1_b2_c3; //~ ERROR type `A1_b2_c3` should have a camel case name
-   |        ^^^^^^^^ help: convert the identifier to camel case: `A1B2C3`
-
-error: aborting due to 11 previous errors
+error: aborting due to 8 previous errors
 

--- a/src/test/ui/utf8_idents.rs
+++ b/src/test/ui/utf8_idents.rs
@@ -1,9 +1,7 @@
-//
-
 fn foo<
     'β, //~ ERROR non-ascii idents are not fully supported
     γ  //~ ERROR non-ascii idents are not fully supported
-       //~^ WARN type parameter `γ` should have a camel case name
+       //~^ WARN type parameter `γ` should have an upper camel case name
 >() {}
 
 struct X {

--- a/src/test/ui/utf8_idents.stderr
+++ b/src/test/ui/utf8_idents.stderr
@@ -1,5 +1,5 @@
 error[E0658]: non-ascii idents are not fully supported. (see issue #55467)
-  --> $DIR/utf8_idents.rs:4:5
+  --> $DIR/utf8_idents.rs:2:5
    |
 LL |     'β, //~ ERROR non-ascii idents are not fully supported
    |     ^^
@@ -7,7 +7,7 @@ LL |     'β, //~ ERROR non-ascii idents are not fully supported
    = help: add #![feature(non_ascii_idents)] to the crate attributes to enable
 
 error[E0658]: non-ascii idents are not fully supported. (see issue #55467)
-  --> $DIR/utf8_idents.rs:5:5
+  --> $DIR/utf8_idents.rs:3:5
    |
 LL |     γ  //~ ERROR non-ascii idents are not fully supported
    |     ^
@@ -15,7 +15,7 @@ LL |     γ  //~ ERROR non-ascii idents are not fully supported
    = help: add #![feature(non_ascii_idents)] to the crate attributes to enable
 
 error[E0658]: non-ascii idents are not fully supported. (see issue #55467)
-  --> $DIR/utf8_idents.rs:10:5
+  --> $DIR/utf8_idents.rs:8:5
    |
 LL |     δ: usize //~ ERROR non-ascii idents are not fully supported
    |     ^
@@ -23,18 +23,18 @@ LL |     δ: usize //~ ERROR non-ascii idents are not fully supported
    = help: add #![feature(non_ascii_idents)] to the crate attributes to enable
 
 error[E0658]: non-ascii idents are not fully supported. (see issue #55467)
-  --> $DIR/utf8_idents.rs:14:9
+  --> $DIR/utf8_idents.rs:12:9
    |
 LL |     let α = 0.00001f64; //~ ERROR non-ascii idents are not fully supported
    |         ^
    |
    = help: add #![feature(non_ascii_idents)] to the crate attributes to enable
 
-warning: type parameter `γ` should have a camel case name
-  --> $DIR/utf8_idents.rs:5:5
+warning: type parameter `γ` should have an upper camel case name
+  --> $DIR/utf8_idents.rs:3:5
    |
 LL |     γ  //~ ERROR non-ascii idents are not fully supported
-   |     ^ help: convert the identifier to camel case: `Γ`
+   |     ^ help: convert the identifier to upper camel case: `Γ`
    |
    = note: #[warn(non_camel_case_types)] on by default
 


### PR DESCRIPTION
Also, fix an issue where internal upper case letters were converted to
lower case.

Fixes #57319.