### PR TITLE
rustdoc: respect alternate flag when formatting impl trait

### DIFF
--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -49,8 +49,11 @@ pub struct AbiSpace(pub Abi);
 pub struct Function<'a> {
     /// The declaration to emit.
     pub decl: &'a clean::FnDecl,
-    /// The length of the function's "name", used to determine line-wrapping.
-    pub name_len: usize,
+    /// The length of the function header and name. In other words, the number of characters in the
+    /// function declaration up to but not including the parentheses.
+    ///
+    /// Used to determine line-wrapping.
+    pub header_len: usize,
     /// The number of spaces to indent each successive line with, if line-wrapping is necessary.
     pub indent: usize,
     /// Whether the function is async or not.
@@ -665,7 +668,11 @@ fn fmt_type(t: &clean::Type, f: &mut fmt::Formatter, use_absolute: bool) -> fmt:
             }
         }
         clean::ImplTrait(ref bounds) => {
-            write!(f, "impl {}", GenericBounds(bounds))
+            if f.alternate() {
+                write!(f, "impl {:#}", GenericBounds(bounds))
+            } else {
+                write!(f, "impl {}", GenericBounds(bounds))
+            }
         }
         clean::QPath { ref name, ref self_type, ref trait_ } => {
             let should_show_cast = match *trait_ {
@@ -834,7 +841,7 @@ impl fmt::Display for clean::FnDecl {
 
 impl<'a> fmt::Display for Function<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let &Function { decl, name_len, indent, asyncness } = self;
+        let &Function { decl, header_len, indent, asyncness } = self;
         let amp = if f.alternate() { "&" } else { "&amp;" };
         let mut args = String::new();
         let mut args_plain = String::new();
@@ -889,6 +896,8 @@ impl<'a> fmt::Display for Function<'a> {
             }
         }
 
+        let mut args_plain = format!("({})", args_plain);
+
         if decl.variadic {
             args.push_str(",<br> ...");
             args_plain.push_str(", ...");
@@ -907,13 +916,8 @@ impl<'a> fmt::Display for Function<'a> {
             output.to_string()
         };
 
-        let pad = " ".repeat(name_len);
-        let plain = format!("{pad}({args}){arrow}",
-                        pad = pad,
-                        args = args_plain,
-                        arrow = arrow_plain);
-
-        let output = if plain.len() > 80 {
+        let declaration_len = header_len + args_plain.len() + arrow_plain.len();
+        let output = if declaration_len > 80 {
             let full_pad = format!("<br>{}", "&nbsp;".repeat(indent + 4));
             let close_pad = format!("<br>{}", "&nbsp;".repeat(indent));
             format!("({args}{close}){arrow}",

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -2962,14 +2962,16 @@ fn item_static(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
 
 fn item_function(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
                  f: &clean::Function) -> fmt::Result {
-    let name_len = format!("{}{}{}{}{:#}fn {}{:#}",
-                           VisSpace(&it.visibility),
-                           ConstnessSpace(f.header.constness),
-                           UnsafetySpace(f.header.unsafety),
-                           AsyncSpace(f.header.asyncness),
-                           AbiSpace(f.header.abi),
-                           it.name.as_ref().unwrap(),
-                           f.generics).len();
+    let header_len = format!(
+        "{}{}{}{}{:#}fn {}{:#}",
+        VisSpace(&it.visibility),
+        ConstnessSpace(f.header.constness),
+        UnsafetySpace(f.header.unsafety),
+        AsyncSpace(f.header.asyncness),
+        AbiSpace(f.header.abi),
+        it.name.as_ref().unwrap(),
+        f.generics
+    ).len();
     write!(w, "{}<pre class='rust fn'>", render_spotlight_traits(it)?)?;
     render_attributes(w, it)?;
     write!(w,
@@ -2985,7 +2987,7 @@ fn item_function(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
            where_clause = WhereClause { gens: &f.generics, indent: 0, end_newline: true },
            decl = Function {
               decl: &f.decl,
-              name_len,
+              header_len,
               indent: 0,
               asyncness: f.header.asyncness,
            })?;
@@ -3400,16 +3402,18 @@ fn render_assoc_item(w: &mut fmt::Formatter,
                 href(did).map(|p| format!("{}#{}.{}", p.0, ty, name)).unwrap_or(anchor)
             }
         };
-        let mut head_len = format!("{}{}{}{}{:#}fn {}{:#}",
-                                   VisSpace(&meth.visibility),
-                                   ConstnessSpace(header.constness),
-                                   UnsafetySpace(header.unsafety),
-                                   AsyncSpace(header.asyncness),
-                                   AbiSpace(header.abi),
-                                   name,
-                                   *g).len();
+        let mut header_len = format!(
+            "{}{}{}{}{:#}fn {}{:#}",
+            VisSpace(&meth.visibility),
+            ConstnessSpace(header.constness),
+            UnsafetySpace(header.unsafety),
+            AsyncSpace(header.asyncness),
+            AbiSpace(header.abi),
+            name,
+            *g
+        ).len();
         let (indent, end_newline) = if parent == ItemType::Trait {
-            head_len += 4;
+            header_len += 4;
             (4, false)
         } else {
             (0, true)
@@ -3427,7 +3431,7 @@ fn render_assoc_item(w: &mut fmt::Formatter,
                generics = *g,
                decl = Function {
                    decl: d,
-                   name_len: head_len,
+                   header_len,
                    indent,
                    asyncness: header.asyncness,
                },

--- a/src/test/rustdoc/wrapping.rs
+++ b/src/test/rustdoc/wrapping.rs
@@ -1,0 +1,5 @@
+use std::fmt::Debug;
+
+// @has 'wrapping/fn.foo.html' '//pre[@class="rust fn"]' 'pub fn foo() -> impl Debug'
+// @count - '//pre[@class="rust fn"]/br' 0
+pub fn foo() -> impl Debug {}


### PR DESCRIPTION
Fixes #58226.

Before:
<img width="963" alt="screen shot 2019-02-12 at 3 23 30 pm" src="https://user-images.githubusercontent.com/1372438/52665732-4496ea00-2eda-11e9-9e29-efffe43b2abf.png">

After:
<img width="964" alt="screen shot 2019-02-12 at 3 23 51 pm" src="https://user-images.githubusercontent.com/1372438/52665733-452f8080-2eda-11e9-999a-dd1fb28dee16.png">