### PR TITLE
Rollup of 10 pull requests

### DIFF
--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -1036,6 +1036,32 @@ pub fn write(output: &mut dyn Write, args: Arguments) -> Result {
     Ok(())
 }
 
+/// Padding after the end of something. Returned by `Formatter::padding`.
+#[must_use = "don't forget to write the post padding"]
+struct PostPadding {
+    fill: [u8; 4],
+    fill_len: u32,
+    padding: usize,
+}
+
+impl PostPadding {
+    /// Safety relies on `fill[..fill_len]` being a valid UTF-8 char.
+    unsafe fn new(fill: [u8; 4], fill_len: u32, padding: usize) -> PostPadding {
+        PostPadding { fill, fill_len, padding }
+    }
+
+    /// Write this post padding.
+    fn write(self, buf: &mut dyn Write) -> Result {
+        let fill = unsafe {
+            str::from_utf8_unchecked(&self.fill.get_unchecked(..self.fill_len as usize))
+        };
+        for _ in 0..self.padding {
+            buf.write_str(fill)?;
+        }
+        Ok(())
+    }
+}
+
 impl<'a> Formatter<'a> {
     fn wrap_buf<'b, 'c, F>(&'b mut self, wrap: F) -> Formatter<'c>
         where 'b: 'c, F: FnOnce(&'b mut (dyn Write+'b)) -> &'c mut (dyn Write+'c)
@@ -1193,16 +1219,16 @@ impl<'a> Formatter<'a> {
                 self.fill = '0';
                 self.align = rt::v1::Alignment::Right;
                 write_prefix(self, sign, prefix)?;
-                self.with_padding(min - width, rt::v1::Alignment::Right, |f| {
-                    f.buf.write_str(buf)
-                })
+                let post_padding = self.padding(min - width, rt::v1::Alignment::Right)?;
+                self.buf.write_str(buf)?;
+                post_padding.write(self.buf)
             }
             // Otherwise, the sign and prefix goes after the padding
             Some(min) => {
-                self.with_padding(min - width, rt::v1::Alignment::Right, |f| {
-                    write_prefix(f, sign, prefix)?;
-                    f.buf.write_str(buf)
-                })
+                let post_padding = self.padding(min - width, rt::v1::Alignment::Right)?;
+                write_prefix(self, sign, prefix)?;
+                self.buf.write_str(buf)?;
+                post_padding.write(self.buf)
             }
         }
     }
@@ -1273,19 +1299,21 @@ impl<'a> Formatter<'a> {
             // up the minimum width with the specified string + some alignment.
             Some(width) => {
                 let align = rt::v1::Alignment::Left;
-                self.with_padding(width - s.chars().count(), align, |me| {
-                    me.buf.write_str(s)
-                })
+                let post_padding = self.padding(width - s.chars().count(), align)?;
+                self.buf.write_str(s)?;
+                post_padding.write(self.buf)
             }
         }
     }
 
-    /// Runs a callback, emitting the correct padding either before or
-    /// afterwards depending on whether right or left alignment is requested.
-    fn with_padding<F>(&mut self, padding: usize, default: rt::v1::Alignment,
-                       f: F) -> Result
-        where F: FnOnce(&mut Formatter) -> Result,
-    {
+    /// Write the pre-padding and return the unwritten post-padding. Callers are
+    /// responsible for ensuring post-padding is written after the thing that is
+    /// being padded.
+    fn padding(
+        &mut self,
+        padding: usize,
+        default: rt::v1::Alignment
+    ) -> result::Result<PostPadding, Error> {
         let align = match self.align {
             rt::v1::Alignment::Unknown => default,
             _ => self.align
@@ -1299,19 +1327,19 @@ impl<'a> Formatter<'a> {
         };
 
         let mut fill = [0; 4];
-        let fill = self.fill.encode_utf8(&mut fill);
+        let fill_len = {
+            let fill = self.fill.encode_utf8(&mut fill);
 
-        for _ in 0..pre_pad {
-            self.buf.write_str(fill)?;
-        }
+            for _ in 0..pre_pad {
+                self.buf.write_str(fill)?;
+            }
 
-        f(self)?;
+            fill.len()
+        };
 
-        for _ in 0..post_pad {
-            self.buf.write_str(fill)?;
-        }
-
-        Ok(())
+        Ok(unsafe {
+            PostPadding::new(fill, fill_len as u32, post_pad)
+        })
     }
 
     /// Takes the formatted parts and applies the padding.
@@ -1343,9 +1371,9 @@ impl<'a> Formatter<'a> {
             let ret = if width <= len { // no padding
                 self.write_formatted_parts(&formatted)
             } else {
-                self.with_padding(width - len, align, |f| {
-                    f.write_formatted_parts(&formatted)
-                })
+                let post_padding = self.padding(width - len, align)?;
+                self.write_formatted_parts(&formatted)?;
+                post_padding.write(self.buf)
             };
             self.fill = old_fill;
             self.align = old_align;

--- a/src/libcore/fmt/num.rs
+++ b/src/libcore/fmt/num.rs
@@ -257,12 +257,22 @@ macro_rules! impl_Display {
     };
 }
 
-impl_Display!(i8, u8, i16, u16, i32, u32 as u32 via to_u32 named fmt_u32);
-impl_Display!(i64, u64 as u64 via to_u64 named fmt_u64);
+// Include wasm32 in here since it doesn't reflect the native pointer size, and
+// often cares strongly about getting a smaller code size.
+#[cfg(any(target_pointer_width = "64", target_arch = "wasm32"))]
+mod imp {
+    use super::*;
+    impl_Display!(
+        i8, u8, i16, u16, i32, u32, i64, u64, usize, isize
+            as u64 via to_u64 named fmt_u64
+    );
+}
+
+#[cfg(not(any(target_pointer_width = "64", target_arch = "wasm32")))]
+mod imp {
+    use super::*;
+    impl_Display!(i8, u8, i16, u16, i32, u32, isize, usize as u32 via to_u32 named fmt_u32);
+    impl_Display!(i64, u64 as u64 via to_u64 named fmt_u64);
+}
+
 impl_Display!(i128, u128 as u128 via to_u128 named fmt_u128);
-#[cfg(target_pointer_width = "16")]
-impl_Display!(isize, usize as u16 via to_u16 named fmt_usize);
-#[cfg(target_pointer_width = "32")]
-impl_Display!(isize, usize as u32 via to_u32 named fmt_usize);
-#[cfg(target_pointer_width = "64")]
-impl_Display!(isize, usize as u64 via to_u64 named fmt_usize);

--- a/src/libcore/fmt/num.rs
+++ b/src/libcore/fmt/num.rs
@@ -178,7 +178,8 @@ integer! { i32, u32 }
 integer! { i64, u64 }
 integer! { i128, u128 }
 
-const DEC_DIGITS_LUT: &'static[u8] =
+
+static DEC_DIGITS_LUT: &[u8; 200] =
     b"0001020304050607080910111213141516171819\
       2021222324252627282930313233343536373839\
       4041424344454647484950515253545556575859\
@@ -186,18 +187,8 @@ const DEC_DIGITS_LUT: &'static[u8] =
       8081828384858687888990919293949596979899";
 
 macro_rules! impl_Display {
-    ($($t:ident),*: $conv_fn:ident) => ($(
-    #[stable(feature = "rust1", since = "1.0.0")]
-    impl fmt::Display for $t {
-        #[allow(unused_comparisons)]
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            let is_nonnegative = *self >= 0;
-            let mut n = if is_nonnegative {
-                self.$conv_fn()
-            } else {
-                // convert the negative num to positive by summing 1 to it's 2 complement
-                (!self.$conv_fn()).wrapping_add(1)
-            };
+    ($($t:ident),* as $u:ident via $conv_fn:ident named $name:ident) => {
+        fn $name(mut n: $u, is_nonnegative: bool, f: &mut fmt::Formatter) -> fmt::Result {
             let mut buf = uninitialized_array![u8; 39];
             let mut curr = buf.len() as isize;
             let buf_ptr = MaybeUninit::first_ptr_mut(&mut buf);
@@ -205,18 +196,18 @@ macro_rules! impl_Display {
 
             unsafe {
                 // need at least 16 bits for the 4-characters-at-a-time to work.
-                if ::mem::size_of::<$t>() >= 2 {
-                    // eagerly decode 4 characters at a time
-                    while n >= 10000 {
-                        let rem = (n % 10000) as isize;
-                        n /= 10000;
+                assert!(::mem::size_of::<$u>() >= 2);
 
-                        let d1 = (rem / 100) << 1;
-                        let d2 = (rem % 100) << 1;
-                        curr -= 4;
-                        ptr::copy_nonoverlapping(lut_ptr.offset(d1), buf_ptr.offset(curr), 2);
-                        ptr::copy_nonoverlapping(lut_ptr.offset(d2), buf_ptr.offset(curr + 2), 2);
-                    }
+                // eagerly decode 4 characters at a time
+                while n >= 10000 {
+                    let rem = (n % 10000) as isize;
+                    n /= 10000;
+
+                    let d1 = (rem / 100) << 1;
+                    let d2 = (rem % 100) << 1;
+                    curr -= 4;
+                    ptr::copy_nonoverlapping(lut_ptr.offset(d1), buf_ptr.offset(curr), 2);
+                    ptr::copy_nonoverlapping(lut_ptr.offset(d2), buf_ptr.offset(curr + 2), 2);
                 }
 
                 // if we reach here numbers are <= 9999, so at most 4 chars long
@@ -247,15 +238,31 @@ macro_rules! impl_Display {
             };
             f.pad_integral(is_nonnegative, "", buf_slice)
         }
-    })*);
+
+        $(
+            #[stable(feature = "rust1", since = "1.0.0")]
+            impl fmt::Display for $t {
+                #[allow(unused_comparisons)]
+                fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                    let is_nonnegative = *self >= 0;
+                    let n = if is_nonnegative {
+                        self.$conv_fn()
+                    } else {
+                        // convert the negative num to positive by summing 1 to it's 2 complement
+                        (!self.$conv_fn()).wrapping_add(1)
+                    };
+                    $name(n, is_nonnegative, f)
+                }
+            })*
+    };
 }
 
-impl_Display!(i8, u8, i16, u16, i32, u32: to_u32);
-impl_Display!(i64, u64: to_u64);
-impl_Display!(i128, u128: to_u128);
+impl_Display!(i8, u8, i16, u16, i32, u32 as u32 via to_u32 named fmt_u32);
+impl_Display!(i64, u64 as u64 via to_u64 named fmt_u64);
+impl_Display!(i128, u128 as u128 via to_u128 named fmt_u128);
 #[cfg(target_pointer_width = "16")]
-impl_Display!(isize, usize: to_u16);
+impl_Display!(isize, usize as u16 via to_u16 named fmt_usize);
 #[cfg(target_pointer_width = "32")]
-impl_Display!(isize, usize: to_u32);
+impl_Display!(isize, usize as u32 via to_u32 named fmt_usize);
 #[cfg(target_pointer_width = "64")]
-impl_Display!(isize, usize: to_u64);
+impl_Display!(isize, usize as u64 via to_u64 named fmt_usize);

--- a/src/libpanic_unwind/Cargo.toml
+++ b/src/libpanic_unwind/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "panic_unwind"
 version = "0.0.0"
+edition = "2018"
 
 [lib]
 path = "lib.rs"

--- a/src/libpanic_unwind/dwarf/eh.rs
+++ b/src/libpanic_unwind/dwarf/eh.rs
@@ -11,7 +11,7 @@
 #![allow(non_upper_case_globals)]
 #![allow(unused)]
 
-use dwarf::DwarfReader;
+use crate::dwarf::DwarfReader;
 use core::mem;
 
 pub const DW_EH_PE_omit: u8 = 0xFF;
@@ -51,7 +51,7 @@ pub enum EHAction {
 
 pub const USING_SJLJ_EXCEPTIONS: bool = cfg!(all(target_os = "ios", target_arch = "arm"));
 
-pub unsafe fn find_eh_action(lsda: *const u8, context: &EHContext)
+pub unsafe fn find_eh_action(lsda: *const u8, context: &EHContext<'_>)
     -> Result<EHAction, ()>
 {
     if lsda.is_null() {
@@ -145,7 +145,7 @@ fn round_up(unrounded: usize, align: usize) -> Result<usize, ()> {
 }
 
 unsafe fn read_encoded_pointer(reader: &mut DwarfReader,
-                               context: &EHContext,
+                               context: &EHContext<'_>,
                                encoding: u8)
                                -> Result<usize, ()> {
     if encoding == DW_EH_PE_omit {

--- a/src/libpanic_unwind/emcc.rs
+++ b/src/libpanic_unwind/emcc.rs
@@ -10,10 +10,10 @@
 
 use core::any::Any;
 use core::ptr;
+use core::mem;
 use alloc::boxed::Box;
 use libc::{self, c_int};
 use unwind as uw;
-use core::mem;
 
 pub fn payload() -> *mut u8 {
     ptr::null_mut()

--- a/src/libpanic_unwind/gcc.rs
+++ b/src/libpanic_unwind/gcc.rs
@@ -52,7 +52,7 @@ use alloc::boxed::Box;
 
 use unwind as uw;
 use libc::{c_int, uintptr_t};
-use dwarf::eh::{self, EHContext, EHAction};
+use crate::dwarf::eh::{self, EHContext, EHAction};
 
 #[repr(C)]
 struct Exception {

--- a/src/libpanic_unwind/lib.rs
+++ b/src/libpanic_unwind/lib.rs
@@ -17,6 +17,8 @@
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/",
        issue_tracker_base_url = "https://github.com/rust-lang/rust/issues/")]
 
+#![deny(rust_2018_idioms)]
+
 #![feature(allocator_api)]
 #![feature(alloc)]
 #![feature(core_intrinsics)]
@@ -32,8 +34,6 @@
 #![panic_runtime]
 #![feature(panic_runtime)]
 
-extern crate alloc;
-extern crate libc;
 #[cfg(not(any(target_env = "msvc", all(windows, target_arch = "x86_64", target_env = "gnu"))))]
 extern crate unwind;
 
@@ -87,7 +87,7 @@ pub unsafe extern "C" fn __rust_maybe_catch_panic(f: fn(*mut u8),
                                                   vtable_ptr: *mut usize)
                                                   -> u32 {
     let mut payload = imp::payload();
-    if intrinsics::try(f, data, &mut payload as *mut _ as *mut _) == 0 {
+    if intrinsics::r#try(f, data, &mut payload as *mut _ as *mut _) == 0 {
         0
     } else {
         let obj = mem::transmute::<_, raw::TraitObject>(imp::cleanup(payload));

--- a/src/libpanic_unwind/seh.rs
+++ b/src/libpanic_unwind/seh.rs
@@ -52,7 +52,7 @@ use core::any::Any;
 use core::mem;
 use core::raw;
 
-use windows as c;
+use crate::windows as c;
 use libc::{c_int, c_uint};
 
 // First up, a whole bunch of type definitions. There's a few platform-specific
@@ -301,5 +301,5 @@ pub unsafe fn cleanup(payload: [u64; 2]) -> Box<dyn Any + Send> {
 #[lang = "eh_personality"]
 #[cfg(not(test))]
 fn rust_eh_personality() {
-    unsafe { ::core::intrinsics::abort() }
+    unsafe { core::intrinsics::abort() }
 }

--- a/src/libpanic_unwind/seh64_gnu.rs
+++ b/src/libpanic_unwind/seh64_gnu.rs
@@ -9,8 +9,8 @@ use alloc::boxed::Box;
 use core::any::Any;
 use core::intrinsics;
 use core::ptr;
-use dwarf::eh::{EHContext, EHAction, find_eh_action};
-use windows as c;
+use crate::dwarf::eh::{EHContext, EHAction, find_eh_action};
+use crate::windows as c;
 
 // Define our exception codes:
 // according to http://msdn.microsoft.com/en-us/library/het71c37(v=VS.80).aspx,

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -2288,7 +2288,7 @@ impl ItemKind {
             ItemKind::Union(..) => "union",
             ItemKind::Trait(..) => "trait",
             ItemKind::TraitAlias(..) => "trait alias",
-            ItemKind::Impl(..) => "item",
+            ItemKind::Impl(..) => "impl",
         }
     }
 

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -72,7 +72,7 @@ pub mod print;
 /// the `local_id` part of the `HirId` changing, which is a very useful property in
 /// incremental compilation where we have to persist things through changes to
 /// the code base.
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, PartialOrd, Ord)]
 pub struct HirId {
     pub owner: DefIndex,
     pub local_id: ItemLocalId,
@@ -1234,7 +1234,7 @@ pub enum UnsafeSource {
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, RustcEncodable, RustcDecodable, Hash, Debug)]
 pub struct BodyId {
-    pub node_id: NodeId,
+    pub hir_id: HirId,
 }
 
 /// The body of a function, closure, or constant value. In the case of
@@ -1268,7 +1268,7 @@ pub struct Body {
 impl Body {
     pub fn id(&self) -> BodyId {
         BodyId {
-            node_id: self.value.id
+            hir_id: self.value.hir_id,
         }
     }
 }

--- a/src/librustc/ich/impls_hir.rs
+++ b/src/librustc/ich/impls_hir.rs
@@ -989,8 +989,8 @@ impl<'a> ToStableHashKey<StableHashingContext<'a>> for hir::BodyId {
     fn to_stable_hash_key(&self,
                           hcx: &StableHashingContext<'a>)
                           -> (DefPathHash, hir::ItemLocalId) {
-        let hir::BodyId { node_id } = *self;
-        node_id.to_stable_hash_key(hcx)
+        let hir::BodyId { hir_id } = *self;
+        hir_id.to_stable_hash_key(hcx)
     }
 }
 

--- a/src/librustc/infer/error_reporting/need_type_info.rs
+++ b/src/librustc/infer/error_reporting/need_type_info.rs
@@ -105,7 +105,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
         };
 
         if let Some(body_id) = body_id {
-            let expr = self.tcx.hir().expect_expr(body_id.node_id);
+            let expr = self.tcx.hir().expect_expr_by_hir_id(body_id.hir_id);
             local_visitor.visit_expr(expr);
         }
 

--- a/src/librustc/infer/mod.rs
+++ b/src/librustc/infer/mod.rs
@@ -7,6 +7,7 @@ pub use self::SubregionOrigin::*;
 pub use self::ValuePairs::*;
 pub use crate::ty::IntVarValue;
 
+use crate::hir;
 use crate::hir::def_id::DefId;
 use crate::infer::canonical::{Canonical, CanonicalVarValues};
 use crate::middle::free_region::RegionRelations;
@@ -203,7 +204,7 @@ pub struct InferCtxt<'a, 'gcx: 'a + 'tcx, 'tcx: 'a> {
     // for each body-id in this map, which will process the
     // obligations within. This is expected to be done 'late enough'
     // that all type inference variables have been bound and so forth.
-    pub region_obligations: RefCell<Vec<(ast::NodeId, RegionObligation<'tcx>)>>,
+    pub region_obligations: RefCell<Vec<(hir::HirId, RegionObligation<'tcx>)>>,
 
     /// What is the innermost universe we have created? Starts out as
     /// `UniverseIndex::root()` but grows from there as we enter
@@ -1433,7 +1434,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
     pub fn partially_normalize_associated_types_in<T>(
         &self,
         span: Span,
-        body_id: ast::NodeId,
+        body_id: hir::HirId,
         param_env: ty::ParamEnv<'tcx>,
         value: &T,
     ) -> InferOk<'tcx, T>

--- a/src/librustc/infer/opaque_types/mod.rs
+++ b/src/librustc/infer/opaque_types/mod.rs
@@ -98,7 +98,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
     pub fn instantiate_opaque_types<T: TypeFoldable<'tcx>>(
         &self,
         parent_def_id: DefId,
-        body_id: ast::NodeId,
+        body_id: hir::HirId,
         param_env: ty::ParamEnv<'tcx>,
         value: &T,
     ) -> InferOk<'tcx, (T, OpaqueTypeMap<'tcx>)> {
@@ -632,7 +632,7 @@ impl<'cx, 'gcx, 'tcx> TypeFolder<'gcx, 'tcx> for ReverseMapper<'cx, 'gcx, 'tcx> 
 struct Instantiator<'a, 'gcx: 'tcx, 'tcx: 'a> {
     infcx: &'a InferCtxt<'a, 'gcx, 'tcx>,
     parent_def_id: DefId,
-    body_id: ast::NodeId,
+    body_id: hir::HirId,
     param_env: ty::ParamEnv<'tcx>,
     opaque_types: OpaqueTypeMap<'tcx>,
     obligations: Vec<PredicateObligation<'tcx>>,

--- a/src/librustc/infer/outlives/env.rs
+++ b/src/librustc/infer/outlives/env.rs
@@ -1,7 +1,7 @@
 use crate::infer::outlives::free_region_map::FreeRegionMap;
 use crate::infer::{GenericKind, InferCtxt};
+use crate::hir;
 use rustc_data_structures::fx::FxHashMap;
-use syntax::ast;
 use syntax_pos::Span;
 use crate::traits::query::outlives_bounds::{self, OutlivesBound};
 use crate::ty::{self, Ty};
@@ -55,7 +55,7 @@ pub struct OutlivesEnvironment<'tcx> {
     // results when proving outlives obligations like `T: 'x` later
     // (e.g., if `T: 'x` must be proven within the body B1, then we
     // know it is true if either `'a: 'x` or `'b: 'x`).
-    region_bound_pairs_map: FxHashMap<ast::NodeId, RegionBoundPairs<'tcx>>,
+    region_bound_pairs_map: FxHashMap<hir::HirId, RegionBoundPairs<'tcx>>,
 
     // Used to compute `region_bound_pairs_map`: contains the set of
     // in-scope region-bound pairs thus far.
@@ -87,7 +87,7 @@ impl<'a, 'gcx: 'tcx, 'tcx: 'a> OutlivesEnvironment<'tcx> {
     }
 
     /// Borrows current value of the `region_bound_pairs`.
-    pub fn region_bound_pairs_map(&self) -> &FxHashMap<ast::NodeId, RegionBoundPairs<'tcx>> {
+    pub fn region_bound_pairs_map(&self) -> &FxHashMap<hir::HirId, RegionBoundPairs<'tcx>> {
         &self.region_bound_pairs_map
     }
 
@@ -162,7 +162,7 @@ impl<'a, 'gcx: 'tcx, 'tcx: 'a> OutlivesEnvironment<'tcx> {
         &mut self,
         infcx: &InferCtxt<'a, 'gcx, 'tcx>,
         fn_sig_tys: &[Ty<'tcx>],
-        body_id: ast::NodeId,
+        body_id: hir::HirId,
         span: Span,
     ) {
         debug!("add_implied_bounds()");
@@ -176,7 +176,7 @@ impl<'a, 'gcx: 'tcx, 'tcx: 'a> OutlivesEnvironment<'tcx> {
     }
 
     /// Save the current set of region-bound pairs under the given `body_id`.
-    pub fn save_implied_bounds(&mut self, body_id: ast::NodeId) {
+    pub fn save_implied_bounds(&mut self, body_id: hir::HirId) {
         let old = self.region_bound_pairs_map.insert(
             body_id,
             self.region_bound_pairs_accum.clone(),

--- a/src/librustc/infer/outlives/obligations.rs
+++ b/src/librustc/infer/outlives/obligations.rs
@@ -63,7 +63,7 @@ use crate::infer::outlives::env::RegionBoundPairs;
 use crate::infer::outlives::verify::VerifyBoundCx;
 use crate::infer::{self, GenericKind, InferCtxt, RegionObligation, SubregionOrigin, VerifyBound};
 use rustc_data_structures::fx::FxHashMap;
-use syntax::ast;
+use crate::hir;
 use crate::traits::ObligationCause;
 use crate::ty::outlives::Component;
 use crate::ty::{self, Region, Ty, TyCtxt, TypeFoldable};
@@ -76,7 +76,7 @@ impl<'cx, 'gcx, 'tcx> InferCtxt<'cx, 'gcx, 'tcx> {
     /// information).
     pub fn register_region_obligation(
         &self,
-        body_id: ast::NodeId,
+        body_id: hir::HirId,
         obligation: RegionObligation<'tcx>,
     ) {
         debug!(
@@ -110,7 +110,7 @@ impl<'cx, 'gcx, 'tcx> InferCtxt<'cx, 'gcx, 'tcx> {
     }
 
     /// Trait queries just want to pass back type obligations "as is"
-    pub fn take_registered_region_obligations(&self) -> Vec<(ast::NodeId, RegionObligation<'tcx>)> {
+    pub fn take_registered_region_obligations(&self) -> Vec<(hir::HirId, RegionObligation<'tcx>)> {
         ::std::mem::replace(&mut *self.region_obligations.borrow_mut(), vec![])
     }
 
@@ -149,7 +149,7 @@ impl<'cx, 'gcx, 'tcx> InferCtxt<'cx, 'gcx, 'tcx> {
     /// processed.
     pub fn process_registered_region_obligations(
         &self,
-        region_bound_pairs_map: &FxHashMap<ast::NodeId, RegionBoundPairs<'tcx>>,
+        region_bound_pairs_map: &FxHashMap<hir::HirId, RegionBoundPairs<'tcx>>,
         implicit_region_bound: Option<ty::Region<'tcx>>,
         param_env: ty::ParamEnv<'tcx>,
     ) {

--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -350,8 +350,6 @@ impl<'a, 'tcx> Visitor<'tcx> for MissingStabilityAnnotations<'a, 'tcx> {
             // optional. They inherit stability from their parents when unannotated.
             hir::ItemKind::Impl(.., None, _, _) | hir::ItemKind::ForeignMod(..) => {}
 
-            hir::ItemKind::Mod(..) => self.check_missing_stability(i.id, i.span, "module"),
-
             _ => self.check_missing_stability(i.id, i.span, i.node.descriptive_variant())
         }
 
@@ -359,14 +357,14 @@ impl<'a, 'tcx> Visitor<'tcx> for MissingStabilityAnnotations<'a, 'tcx> {
     }
 
     fn visit_trait_item(&mut self, ti: &'tcx hir::TraitItem) {
-        self.check_missing_stability(ti.id, ti.span, "node");
+        self.check_missing_stability(ti.id, ti.span, "item");
         intravisit::walk_trait_item(self, ti);
     }
 
     fn visit_impl_item(&mut self, ii: &'tcx hir::ImplItem) {
         let impl_def_id = self.tcx.hir().local_def_id(self.tcx.hir().get_parent(ii.id));
         if self.tcx.impl_trait_ref(impl_def_id).is_none() {
-            self.check_missing_stability(ii.id, ii.span, "node");
+            self.check_missing_stability(ii.id, ii.span, "item");
         }
         intravisit::walk_impl_item(self, ii);
     }

--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -352,7 +352,7 @@ impl<'a, 'tcx> Visitor<'tcx> for MissingStabilityAnnotations<'a, 'tcx> {
 
             hir::ItemKind::Mod(..) => self.check_missing_stability(i.id, i.span, "module"),
 
-            _ => self.check_missing_stability(i.id, i.span, "node")
+            _ => self.check_missing_stability(i.id, i.span, i.node.descriptive_variant())
         }
 
         intravisit::walk_item(self, i)
@@ -382,7 +382,7 @@ impl<'a, 'tcx> Visitor<'tcx> for MissingStabilityAnnotations<'a, 'tcx> {
     }
 
     fn visit_foreign_item(&mut self, i: &'tcx hir::ForeignItem) {
-        self.check_missing_stability(i.id, i.span, "node");
+        self.check_missing_stability(i.id, i.span, i.node.descriptive_variant());
         intravisit::walk_foreign_item(self, i);
     }
 

--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -598,37 +598,11 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         // Deprecated attributes apply in-crate and cross-crate.
         if let Some(id) = id {
             if let Some(depr_entry) = self.lookup_deprecation_entry(def_id) {
-                // If the deprecation is scheduled for a future Rust
-                // version, then we should display no warning message.
-                let deprecated_in_future_version = if let Some(sym) = depr_entry.attr.since {
-                    let since = sym.as_str();
-                    if !deprecation_in_effect(&since) {
-                        Some(since)
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                };
-
                 let parent_def_id = self.hir().local_def_id(self.hir().get_parent(id));
                 let skip = self.lookup_deprecation_entry(parent_def_id)
                                .map_or(false, |parent_depr| parent_depr.same_origin(&depr_entry));
 
-                if let Some(since) = deprecated_in_future_version {
-                    let path = self.item_path_str(def_id);
-                    let message = format!("use of item '{}' \
-                                           that will be deprecated in future version {}",
-                                          path,
-                                          since);
-
-                    lint_deprecated(def_id,
-                                    id,
-                                    depr_entry.attr.note,
-                                    None,
-                                    &message,
-                                    lint::builtin::DEPRECATED_IN_FUTURE);
-                } else if !skip {
+                if !skip {
                     let path = self.item_path_str(def_id);
                     let message = format!("use of deprecated item '{}'", path);
                     lint_deprecated(def_id,

--- a/src/librustc/traits/auto_trait.rs
+++ b/src/librustc/traits/auto_trait.rs
@@ -202,7 +202,7 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
                 full_env,
                 ty,
                 trait_did,
-                ObligationCause::misc(DUMMY_SP, ast::DUMMY_NODE_ID),
+                ObligationCause::misc(DUMMY_SP, hir::DUMMY_HIR_ID),
             );
             fulfill.select_all_or_error(&infcx).unwrap_or_else(|e| {
                 panic!(
@@ -315,7 +315,7 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
             user_env.caller_bounds.iter().cloned().collect();
 
         let mut new_env = param_env.clone();
-        let dummy_cause = ObligationCause::misc(DUMMY_SP, ast::DUMMY_NODE_ID);
+        let dummy_cause = ObligationCause::misc(DUMMY_SP, hir::DUMMY_HIR_ID);
 
         while let Some(pred) = predicates.pop_front() {
             infcx.clear_caches();
@@ -669,7 +669,7 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
         select: &mut SelectionContext<'c, 'd, 'cx>,
         only_projections: bool,
     ) -> bool {
-        let dummy_cause = ObligationCause::misc(DUMMY_SP, ast::DUMMY_NODE_ID);
+        let dummy_cause = ObligationCause::misc(DUMMY_SP, hir::DUMMY_HIR_ID);
 
         for (obligation, mut predicate) in nested
             .map(|o| (o.clone(), o.predicate.clone()))

--- a/src/librustc/traits/mod.rs
+++ b/src/librustc/traits/mod.rs
@@ -132,7 +132,7 @@ pub struct ObligationCause<'tcx> {
     /// (in particular, closures can add new assumptions). See the
     /// field `region_obligations` of the `FulfillmentContext` for more
     /// information.
-    pub body_id: ast::NodeId,
+    pub body_id: hir::HirId,
 
     pub code: ObligationCauseCode<'tcx>
 }
@@ -654,7 +654,7 @@ pub fn type_known_to_meet_bound_modulo_regions<'a, 'gcx, 'tcx>(
     };
     let obligation = Obligation {
         param_env,
-        cause: ObligationCause::misc(span, ast::DUMMY_NODE_ID),
+        cause: ObligationCause::misc(span, hir::DUMMY_HIR_ID),
         recursion_depth: 0,
         predicate: trait_ref.to_predicate(),
     };
@@ -677,7 +677,7 @@ pub fn type_known_to_meet_bound_modulo_regions<'a, 'gcx, 'tcx>(
         // We can use a dummy node-id here because we won't pay any mind
         // to region obligations that arise (there shouldn't really be any
         // anyhow).
-        let cause = ObligationCause::misc(span, ast::DUMMY_NODE_ID);
+        let cause = ObligationCause::misc(span, hir::DUMMY_HIR_ID);
 
         fulfill_cx.register_bound(infcx, param_env, ty, def_id, cause);
 
@@ -1057,7 +1057,7 @@ impl<'tcx,O> Obligation<'tcx,O> {
     }
 
     pub fn misc(span: Span,
-                body_id: ast::NodeId,
+                body_id: hir::HirId,
                 param_env: ty::ParamEnv<'tcx>,
                 trait_ref: O)
                 -> Obligation<'tcx, O> {
@@ -1075,18 +1075,18 @@ impl<'tcx,O> Obligation<'tcx,O> {
 impl<'tcx> ObligationCause<'tcx> {
     #[inline]
     pub fn new(span: Span,
-               body_id: ast::NodeId,
+               body_id: hir::HirId,
                code: ObligationCauseCode<'tcx>)
                -> ObligationCause<'tcx> {
-        ObligationCause { span: span, body_id: body_id, code: code }
+        ObligationCause { span, body_id, code }
     }
 
-    pub fn misc(span: Span, body_id: ast::NodeId) -> ObligationCause<'tcx> {
-        ObligationCause { span: span, body_id: body_id, code: MiscObligation }
+    pub fn misc(span: Span, body_id: hir::HirId) -> ObligationCause<'tcx> {
+        ObligationCause { span, body_id, code: MiscObligation }
     }
 
     pub fn dummy() -> ObligationCause<'tcx> {
-        ObligationCause { span: DUMMY_SP, body_id: ast::CRATE_NODE_ID, code: MiscObligation }
+        ObligationCause { span: DUMMY_SP, body_id: hir::CRATE_HIR_ID, code: MiscObligation }
     }
 }
 

--- a/src/librustc/traits/query/outlives_bounds.rs
+++ b/src/librustc/traits/query/outlives_bounds.rs
@@ -1,6 +1,6 @@
 use crate::infer::InferCtxt;
 use crate::infer::canonical::OriginalQueryValues;
-use syntax::ast;
+use crate::hir;
 use syntax::source_map::Span;
 use crate::traits::{FulfillmentContext, ObligationCause, TraitEngine, TraitEngineExt};
 use crate::traits::query::NoSolution;
@@ -89,7 +89,7 @@ impl<'cx, 'gcx, 'tcx> InferCtxt<'cx, 'gcx, 'tcx> {
     pub fn implied_outlives_bounds(
         &self,
         param_env: ty::ParamEnv<'tcx>,
-        body_id: ast::NodeId,
+        body_id: hir::HirId,
         ty: Ty<'tcx>,
         span: Span,
     ) -> Vec<OutlivesBound<'tcx>> {

--- a/src/librustc/ty/wf.rs
+++ b/src/librustc/ty/wf.rs
@@ -1,10 +1,10 @@
+use crate::hir;
 use crate::hir::def_id::DefId;
 use crate::infer::InferCtxt;
 use crate::ty::subst::Substs;
 use crate::traits;
 use crate::ty::{self, ToPredicate, Ty, TyCtxt, TypeFoldable};
 use std::iter::once;
-use syntax::ast;
 use syntax_pos::Span;
 use crate::middle::lang_items;
 
@@ -16,7 +16,7 @@ use crate::middle::lang_items;
 /// say "$0 is WF if $0 is WF".
 pub fn obligations<'a, 'gcx, 'tcx>(infcx: &InferCtxt<'a, 'gcx, 'tcx>,
                                    param_env: ty::ParamEnv<'tcx>,
-                                   body_id: ast::NodeId,
+                                   body_id: hir::HirId,
                                    ty: Ty<'tcx>,
                                    span: Span)
                                    -> Option<Vec<traits::PredicateObligation<'tcx>>>
@@ -42,7 +42,7 @@ pub fn obligations<'a, 'gcx, 'tcx>(infcx: &InferCtxt<'a, 'gcx, 'tcx>,
 /// if `Bar: Eq`.
 pub fn trait_obligations<'a, 'gcx, 'tcx>(infcx: &InferCtxt<'a, 'gcx, 'tcx>,
                                          param_env: ty::ParamEnv<'tcx>,
-                                         body_id: ast::NodeId,
+                                         body_id: hir::HirId,
                                          trait_ref: &ty::TraitRef<'tcx>,
                                          span: Span)
                                          -> Vec<traits::PredicateObligation<'tcx>>
@@ -54,7 +54,7 @@ pub fn trait_obligations<'a, 'gcx, 'tcx>(infcx: &InferCtxt<'a, 'gcx, 'tcx>,
 
 pub fn predicate_obligations<'a, 'gcx, 'tcx>(infcx: &InferCtxt<'a, 'gcx, 'tcx>,
                                              param_env: ty::ParamEnv<'tcx>,
-                                             body_id: ast::NodeId,
+                                             body_id: hir::HirId,
                                              predicate: &ty::Predicate<'tcx>,
                                              span: Span)
                                              -> Vec<traits::PredicateObligation<'tcx>>
@@ -103,7 +103,7 @@ pub fn predicate_obligations<'a, 'gcx, 'tcx>(infcx: &InferCtxt<'a, 'gcx, 'tcx>,
 struct WfPredicates<'a, 'gcx: 'a+'tcx, 'tcx: 'a> {
     infcx: &'a InferCtxt<'a, 'gcx, 'tcx>,
     param_env: ty::ParamEnv<'tcx>,
-    body_id: ast::NodeId,
+    body_id: hir::HirId,
     span: Span,
     out: Vec<traits::PredicateObligation<'tcx>>,
 }

--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -404,7 +404,7 @@ fn closure_to_block(closure_id: LocalDefId,
     match tcx.hir().get(closure_id) {
         Node::Expr(expr) => match expr.node {
             hir::ExprKind::Closure(.., body_id, _, _) => {
-                body_id.node_id
+                tcx.hir().hir_to_node_id(body_id.hir_id)
             }
             _ => {
                 bug!("encountered non-closure id: {}", closure_id)

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -296,6 +296,11 @@ pub fn compile_input(
                         (control.after_analysis.callback)(&mut state);
                     });
 
+                    // Plugins like clippy and rust-semverver stop the analysis early,
+                    // but want to still return an error if errors during the analysis
+                    // happened:
+                    tcx.sess.compile_status()?;
+
                     if control.after_analysis.stop == Compilation::Stop {
                         return result.and_then(|_| Err(CompileIncomplete::Stopped));
                     }

--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -1174,9 +1174,9 @@ impl MirPass for QualifyAndPromoteConstants {
         }
 
         let def_id = src.def_id();
-        let id = tcx.hir().as_local_node_id(def_id).unwrap();
+        let id = tcx.hir().as_local_hir_id(def_id).unwrap();
         let mut const_promoted_temps = None;
-        let mode = match tcx.hir().body_owner_kind(id) {
+        let mode = match tcx.hir().body_owner_kind_by_hir_id(id) {
             hir::BodyOwnerKind::Closure => Mode::Fn,
             hir::BodyOwnerKind::Fn => {
                 if tcx.is_const_fn(def_id) {

--- a/src/librustc_mir/util/pretty.rs
+++ b/src/librustc_mir/util/pretty.rs
@@ -197,7 +197,7 @@ fn dump_path(
                 .chars()
                 .filter_map(|c| match c {
                     ' ' => None,
-                    ':' => Some('_'),
+                    ':' | '<' | '>' => Some('_'),
                     c => Some(c)
                 }));
             s
@@ -603,7 +603,8 @@ fn write_mir_sig(
     match (descr, src.promoted) {
         (_, Some(i)) => write!(w, "{:?} in ", i)?,
         (Some(Def::StructCtor(..)), _) => write!(w, "struct ")?,
-        (Some(Def::Const(_)), _) => write!(w, "const ")?,
+        (Some(Def::Const(_)), _)
+        | (Some(Def::AssociatedConst(_)), _) => write!(w, "const ")?,
         (Some(Def::Static(_, /*is_mutbl*/false)), _) => write!(w, "static ")?,
         (Some(Def::Static(_, /*is_mutbl*/true)), _) => write!(w, "static mut ")?,
         (_, _) if is_function => write!(w, "fn ")?,

--- a/src/librustc_passes/rvalue_promotion.rs
+++ b/src/librustc_passes/rvalue_promotion.rs
@@ -56,8 +56,7 @@ fn const_is_rvalue_promotable_to_static<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     let node_id = tcx.hir().as_local_node_id(def_id)
         .expect("rvalue_promotable_map invoked with non-local def-id");
     let body_id = tcx.hir().body_owned_by(node_id);
-    let body_hir_id = tcx.hir().node_to_hir_id(body_id.node_id);
-    tcx.rvalue_promotable_map(def_id).contains(&body_hir_id.local_id)
+    tcx.rvalue_promotable_map(def_id).contains(&body_id.hir_id.local_id)
 }
 
 fn rvalue_promotable_map<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -805,7 +805,8 @@ impl<'a, 'tcx> NamePrivacyVisitor<'a, 'tcx> {
                    def: &'tcx ty::AdtDef, // definition of the struct or enum
                    field: &'tcx ty::FieldDef) { // definition of the field
         let ident = Ident::new(keywords::Invalid.name(), use_ctxt);
-        let def_id = self.tcx.adjust_ident(ident, def.did, self.current_item).1;
+        let current_hir = self.tcx.hir().node_to_hir_id(self.current_item);
+        let def_id = self.tcx.adjust_ident(ident, def.did, current_hir).1;
         if !def.is_enum() && !field.vis.is_accessible_from(def_id, self.tcx) {
             struct_span_err!(self.tcx.sess, span, E0451, "field `{}` of {} `{}` is private",
                              field.ident, def.variant_descr(), self.tcx.item_path_str(def.did))

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -25,7 +25,7 @@ use rustc::hir::def::*;
 use rustc::hir::def::Namespace::*;
 use rustc::hir::def_id::{CRATE_DEF_INDEX, LOCAL_CRATE, DefId};
 use rustc::hir::{Freevar, FreevarMap, TraitCandidate, TraitMap, GlobMap};
-use rustc::ty;
+use rustc::ty::{self, DefIdTree};
 use rustc::util::nodemap::{NodeMap, NodeSet, FxHashMap, FxHashSet, DefIdMap};
 use rustc::{bug, span_bug};
 
@@ -93,6 +93,7 @@ enum ScopeSet {
 
 /// A free importable items suggested in case of resolution failure.
 struct ImportSuggestion {
+    did: Option<DefId>,
     path: Path,
 }
 
@@ -4392,7 +4393,8 @@ impl<'a> Resolver<'a> {
 
                 // collect results based on the filter function
                 if ident.name == lookup_ident.name && ns == namespace {
-                    if filter_fn(name_binding.def()) {
+                    let def = name_binding.def();
+                    if filter_fn(def) {
                         // create the path
                         let mut segms = path_segments.clone();
                         if lookup_ident.span.rust_2018() {
@@ -4416,7 +4418,12 @@ impl<'a> Resolver<'a> {
                         // declared as public (due to pruning, we don't explore
                         // outside crate private modules => no need to check this)
                         if !in_module_is_extern || name_binding.vis == ty::Visibility::Public {
-                            candidates.push(ImportSuggestion { path });
+                            let did = match def {
+                                Def::StructCtor(did, _) | Def::VariantCtor(did, _) =>
+                                    self.parent(did),
+                                _ => def.opt_def_id(),
+                            };
+                            candidates.push(ImportSuggestion { did, path });
                         }
                     }
                 }
@@ -4513,7 +4520,8 @@ impl<'a> Resolver<'a> {
                             span: name_binding.span,
                             segments: path_segments,
                         };
-                        result = Some((module, ImportSuggestion { path }));
+                        let did = module.def().and_then(|def| def.opt_def_id());
+                        result = Some((module, ImportSuggestion { did, path }));
                     } else {
                         // add the module to the lookup
                         if seen_modules.insert(module.def_id().unwrap()) {

--- a/src/librustc_target/spec/uefi_base.rs
+++ b/src/librustc_target/spec/uefi_base.rs
@@ -5,7 +5,7 @@
 // UEFI uses COFF/PE32+ format for binaries. All binaries must be statically linked. No dynamic
 // linker is supported. As native to COFF, binaries are position-dependent, but will be relocated
 // by the loader if the pre-chosen memory location is already in use.
-// UEFI forbids running code on anything but the boot-CPU. Not interrupts are allowed other than
+// UEFI forbids running code on anything but the boot-CPU. No interrupts are allowed other than
 // the timer-interrupt. Device-drivers are required to use polling-based models. Furthermore, all
 // code runs in the same environment, no process separation is supported.
 
@@ -21,7 +21,10 @@ pub fn opts() -> TargetOptions {
             "/NOLOGO".to_string(),
 
             // UEFI is fully compatible to non-executable data pages. Tell the compiler that
-            // non-code sections can be marked as non-executable, including stack pages.
+            // non-code sections can be marked as non-executable, including stack pages. In fact,
+            // firmware might enforce this, so we better let the linker know about this, so it
+            // will fail if the compiler ever tries placing code on the stack (e.g., trampoline
+            // constructs and alike).
             "/NXCOMPAT".to_string(),
 
             // There is no runtime for UEFI targets, prevent them from being linked. UEFI targets

--- a/src/librustc_traits/implied_outlives_bounds.rs
+++ b/src/librustc_traits/implied_outlives_bounds.rs
@@ -1,6 +1,7 @@
 //! Provider for the `implied_outlives_bounds` query.
 //! Do not call this query directory. See [`rustc::traits::query::implied_outlives_bounds`].
 
+use rustc::hir;
 use rustc::infer::InferCtxt;
 use rustc::infer::canonical::{self, Canonical};
 use rustc::traits::{TraitEngine, TraitEngineExt};
@@ -11,7 +12,6 @@ use rustc::ty::outlives::Component;
 use rustc::ty::query::Providers;
 use rustc::ty::wf;
 use smallvec::{SmallVec, smallvec};
-use syntax::ast::DUMMY_NODE_ID;
 use syntax::source_map::DUMMY_SP;
 use rustc::traits::FulfillmentContext;
 
@@ -65,7 +65,7 @@ fn compute_implied_outlives_bounds<'tcx>(
         // unresolved inference variables here anyway, but there might be
         // during typeck under some circumstances.)
         let obligations =
-            wf::obligations(infcx, param_env, DUMMY_NODE_ID, ty, DUMMY_SP).unwrap_or(vec![]);
+            wf::obligations(infcx, param_env, hir::DUMMY_HIR_ID, ty, DUMMY_SP).unwrap_or(vec![]);
 
         // N.B., all of these predicates *ought* to be easily proven
         // true. In fact, their correctness is (mostly) implied by

--- a/src/librustc_traits/normalize_projection_ty.rs
+++ b/src/librustc_traits/normalize_projection_ty.rs
@@ -1,3 +1,4 @@
+use rustc::hir;
 use rustc::infer::canonical::{Canonical, QueryResponse};
 use rustc::traits::query::{normalize::NormalizationResult, CanonicalProjectionGoal, NoSolution};
 use rustc::traits::{self, ObligationCause, SelectionContext, TraitEngineExt};
@@ -5,7 +6,6 @@ use rustc::ty::query::Providers;
 use rustc::ty::{ParamEnvAnd, TyCtxt};
 use rustc_data_structures::sync::Lrc;
 use std::sync::atomic::Ordering;
-use syntax::ast::DUMMY_NODE_ID;
 use syntax_pos::DUMMY_SP;
 
 crate fn provide(p: &mut Providers<'_>) {
@@ -34,7 +34,7 @@ fn normalize_projection_ty<'tcx>(
              value: goal,
          }| {
             let selcx = &mut SelectionContext::new(infcx);
-            let cause = ObligationCause::misc(DUMMY_SP, DUMMY_NODE_ID);
+            let cause = ObligationCause::misc(DUMMY_SP, hir::DUMMY_HIR_ID);
             let mut obligations = vec![];
             let answer = traits::normalize_projection_type(
                 selcx,

--- a/src/librustc_traits/type_op.rs
+++ b/src/librustc_traits/type_op.rs
@@ -1,6 +1,7 @@
 use rustc::infer::at::ToTrace;
 use rustc::infer::canonical::{Canonical, QueryResponse};
 use rustc::infer::InferCtxt;
+use rustc::hir;
 use rustc::hir::def_id::DefId;
 use rustc::traits::query::type_op::ascribe_user_type::AscribeUserType;
 use rustc::traits::query::type_op::eq::Eq;
@@ -18,7 +19,6 @@ use rustc::ty::{
 };
 use rustc_data_structures::sync::Lrc;
 use std::fmt;
-use syntax::ast;
 use syntax_pos::DUMMY_SP;
 
 crate fn provide(p: &mut Providers<'_>) {
@@ -71,7 +71,7 @@ impl AscribeUserTypeCx<'me, 'gcx, 'tcx> {
         self.infcx
             .partially_normalize_associated_types_in(
                 DUMMY_SP,
-                ast::CRATE_NODE_ID,
+                hir::CRATE_HIR_ID,
                 self.param_env,
                 &value,
             )

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -878,8 +878,9 @@ impl<'o, 'gcx: 'tcx, 'tcx> dyn AstConv<'gcx, 'tcx> + 'o {
                                           binding.item_name, binding.span)
         }?;
 
+        let hir_ref_id = self.tcx().hir().node_to_hir_id(ref_id);
         let (assoc_ident, def_scope) =
-            tcx.adjust_ident(binding.item_name, candidate.def_id(), ref_id);
+            tcx.adjust_ident(binding.item_name, candidate.def_id(), hir_ref_id);
         let assoc_ty = tcx.associated_items(candidate.def_id()).find(|i| {
             i.kind == ty::AssociatedKind::Type && i.ident.modern() == assoc_ident
         }).expect("missing associated type");
@@ -1373,7 +1374,8 @@ impl<'o, 'gcx: 'tcx, 'tcx> dyn AstConv<'gcx, 'tcx> + 'o {
         };
 
         let trait_did = bound.def_id();
-        let (assoc_ident, def_scope) = tcx.adjust_ident(assoc_ident, trait_did, ref_id);
+        let hir_ref_id = self.tcx().hir().node_to_hir_id(ref_id);
+        let (assoc_ident, def_scope) = tcx.adjust_ident(assoc_ident, trait_did, hir_ref_id);
         let item = tcx.associated_items(trait_did).find(|i| {
             Namespace::from(i.kind) == Namespace::Type &&
                 i.ident.modern() == assoc_ident

--- a/src/librustc_typeck/check/autoderef.rs
+++ b/src/librustc_typeck/check/autoderef.rs
@@ -1,6 +1,7 @@
 use super::{FnCtxt, PlaceOp, Needs};
 use super::method::MethodCallee;
 
+use rustc::hir;
 use rustc::infer::{InferCtxt, InferOk};
 use rustc::session::DiagnosticMessageId;
 use rustc::traits::{self, TraitEngine};
@@ -9,7 +10,7 @@ use rustc::ty::{ToPredicate, TypeFoldable};
 use rustc::ty::adjustment::{Adjustment, Adjust, OverloadedDeref};
 
 use syntax_pos::Span;
-use syntax::ast::{self, Ident};
+use syntax::ast::Ident;
 
 use std::iter;
 
@@ -21,7 +22,7 @@ enum AutoderefKind {
 
 pub struct Autoderef<'a, 'gcx: 'tcx, 'tcx: 'a> {
     infcx: &'a InferCtxt<'a, 'gcx, 'tcx>,
-    body_id: ast::NodeId,
+    body_id: hir::HirId,
     param_env: ty::ParamEnv<'tcx>,
     steps: Vec<(Ty<'tcx>, AutoderefKind)>,
     cur_ty: Ty<'tcx>,
@@ -87,7 +88,7 @@ impl<'a, 'gcx, 'tcx> Iterator for Autoderef<'a, 'gcx, 'tcx> {
 impl<'a, 'gcx, 'tcx> Autoderef<'a, 'gcx, 'tcx> {
     pub fn new(infcx: &'a InferCtxt<'a, 'gcx, 'tcx>,
                param_env: ty::ParamEnv<'tcx>,
-               body_id: ast::NodeId,
+               body_id: hir::HirId,
                span: Span,
                base_ty: Ty<'tcx>)
                -> Autoderef<'a, 'gcx, 'tcx>

--- a/src/librustc_typeck/check/closure.rs
+++ b/src/librustc_typeck/check/closure.rs
@@ -641,7 +641,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
             .liberate_late_bound_regions(expr_def_id, &bound_sig);
         let liberated_sig = self.inh.normalize_associated_types_in(
             body.value.span,
-            body.value.id,
+            body.value.hir_id,
             self.param_env,
             &liberated_sig,
         );

--- a/src/librustc_typeck/check/intrinsic.rs
+++ b/src/librustc_typeck/check/intrinsic.rs
@@ -58,7 +58,7 @@ fn equate_intrinsic_type<'a, 'tcx>(
         safety,
         abi
     )));
-    let cause = ObligationCause::new(it.span, it.id, ObligationCauseCode::IntrinsicType);
+    let cause = ObligationCause::new(it.span, it.hir_id, ObligationCauseCode::IntrinsicType);
     require_same_types(tcx, &cause, tcx.mk_fn_ptr(tcx.fn_sig(def_id)), fty);
 }
 

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -401,7 +401,7 @@ fn method_autoderef_steps<'a, 'gcx, 'tcx>(tcx: TyCtxt<'a, 'gcx, 'gcx>,
     tcx.infer_ctxt().enter_with_canonical(DUMMY_SP, &goal, |ref infcx, goal, inference_vars| {
         let ParamEnvAnd { param_env, value: self_ty } = goal;
 
-        let mut autoderef = Autoderef::new(infcx, param_env, ast::DUMMY_NODE_ID, DUMMY_SP, self_ty)
+        let mut autoderef = Autoderef::new(infcx, param_env, hir::DUMMY_HIR_ID, DUMMY_SP, self_ty)
             .include_raw_pointers()
             .silence_errors();
         let mut reached_raw_pointer = false;
@@ -1183,7 +1183,7 @@ impl<'a, 'gcx, 'tcx> ProbeContext<'a, 'gcx, 'tcx> {
         stable_pick: &Pick,
         unstable_candidates: &[(&Candidate<'tcx>, Symbol)],
     ) {
-        let mut diag = self.tcx.struct_span_lint_node(
+        let mut diag = self.tcx.struct_span_lint_hir(
             lint::builtin::UNSTABLE_NAME_COLLISIONS,
             self.fcx.body_id,
             self.span,

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -346,7 +346,8 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                     };
 
                                     let field_ty = field.ty(tcx, substs);
-                                    let scope = self.tcx.hir().get_module_parent(self.body_id);
+                                    let scope = self.tcx.hir().get_module_parent_by_hir_id(
+                                        self.body_id);
                                     if field.vis.is_accessible_from(scope, self.tcx) {
                                         if self.is_fn_ty(&field_ty, span) {
                                             err.help(&format!("use `({0}.{1})(...)` if you \
@@ -499,7 +500,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                               err: &mut DiagnosticBuilder,
                               mut msg: String,
                               candidates: Vec<DefId>) {
-        let module_did = self.tcx.hir().get_module_parent(self.body_id);
+        let module_did = self.tcx.hir().get_module_parent_by_hir_id(self.body_id);
         let module_id = self.tcx.hir().as_local_node_id(module_did).unwrap();
         let krate = self.tcx.hir().krate();
         let (span, found_use) = UsePlacementFinder::check(self.tcx, krate, module_id);

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -752,12 +752,11 @@ fn compute_all_traits<'a, 'gcx, 'tcx>(tcx: TyCtxt<'a, 'gcx, 'tcx>) -> Vec<DefId>
                            traits: &mut Vec<DefId>,
                            external_mods: &mut FxHashSet<DefId>,
                            def: Def) {
-        let def_id = def.def_id();
         match def {
-            Def::Trait(..) => {
+            Def::Trait(def_id) => {
                 traits.push(def_id);
             }
-            Def::Mod(..) => {
+            Def::Mod(def_id) => {
                 if !external_mods.insert(def_id) {
                     return;
                 }

--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -112,7 +112,7 @@ macro_rules! ignore_err {
 impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
     pub fn regionck_expr(&self, body: &'gcx hir::Body) {
         let subject = self.tcx.hir().body_owner_def_id(body.id());
-        let id = body.value.id;
+        let id = body.value.hir_id;
         let mut rcx = RegionCtxt::new(
             self,
             RepeatingScope(id),
@@ -138,9 +138,9 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
 
     /// Region checking during the WF phase for items. `wf_tys` are the
     /// types from which we should derive implied bounds, if any.
-    pub fn regionck_item(&self, item_id: ast::NodeId, span: Span, wf_tys: &[Ty<'tcx>]) {
+    pub fn regionck_item(&self, item_id: hir::HirId, span: Span, wf_tys: &[Ty<'tcx>]) {
         debug!("regionck_item(item.id={:?}, wf_tys={:?})", item_id, wf_tys);
-        let subject = self.tcx.hir().local_def_id(item_id);
+        let subject = self.tcx.hir().local_def_id_from_hir_id(item_id);
         let mut rcx = RegionCtxt::new(
             self,
             RepeatingScope(item_id),
@@ -166,18 +166,19 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
     pub fn regionck_fn(&self, fn_id: ast::NodeId, body: &'gcx hir::Body) {
         debug!("regionck_fn(id={})", fn_id);
         let subject = self.tcx.hir().body_owner_def_id(body.id());
-        let node_id = body.value.id;
+        let hir_id = body.value.hir_id;
         let mut rcx = RegionCtxt::new(
             self,
-            RepeatingScope(node_id),
-            node_id,
+            RepeatingScope(hir_id),
+            hir_id,
             Subject(subject),
             self.param_env,
         );
 
         if self.err_count_since_creation() == 0 {
+            let fn_hir_id = self.tcx.hir().node_to_hir_id(fn_id);
             // regionck assumes typeck succeeded
-            rcx.visit_fn_body(fn_id, body, self.tcx.hir().span(fn_id));
+            rcx.visit_fn_body(fn_hir_id, body, self.tcx.hir().span_by_hir_id(fn_hir_id));
         }
 
         rcx.resolve_regions_and_report_errors(SuppressRegionErrors::when_nll_is_enabled(self.tcx));
@@ -201,13 +202,13 @@ pub struct RegionCtxt<'a, 'gcx: 'a + 'tcx, 'tcx: 'a> {
     outlives_environment: OutlivesEnvironment<'tcx>,
 
     // id of innermost fn body id
-    body_id: ast::NodeId,
+    body_id: hir::HirId,
 
     // call_site scope of innermost fn
     call_site_scope: Option<region::Scope>,
 
     // id of innermost fn or loop
-    repeating_scope: ast::NodeId,
+    repeating_scope: hir::HirId,
 
     // id of AST node being analyzed (the subject of the analysis).
     subject_def_id: DefId,
@@ -220,14 +221,14 @@ impl<'a, 'gcx, 'tcx> Deref for RegionCtxt<'a, 'gcx, 'tcx> {
     }
 }
 
-pub struct RepeatingScope(ast::NodeId);
+pub struct RepeatingScope(hir::HirId);
 pub struct Subject(DefId);
 
 impl<'a, 'gcx, 'tcx> RegionCtxt<'a, 'gcx, 'tcx> {
     pub fn new(
         fcx: &'a FnCtxt<'a, 'gcx, 'tcx>,
         RepeatingScope(initial_repeating_scope): RepeatingScope,
-        initial_body_id: ast::NodeId,
+        initial_body_id: hir::HirId,
         Subject(subject): Subject,
         param_env: ty::ParamEnv<'tcx>,
     ) -> RegionCtxt<'a, 'gcx, 'tcx> {
@@ -244,7 +245,7 @@ impl<'a, 'gcx, 'tcx> RegionCtxt<'a, 'gcx, 'tcx> {
         }
     }
 
-    fn set_repeating_scope(&mut self, scope: ast::NodeId) -> ast::NodeId {
+    fn set_repeating_scope(&mut self, scope: hir::HirId) -> hir::HirId {
         mem::replace(&mut self.repeating_scope, scope)
     }
 
@@ -301,15 +302,15 @@ impl<'a, 'gcx, 'tcx> RegionCtxt<'a, 'gcx, 'tcx> {
     /// `intravisit::Visitor` impl below.)
     fn visit_fn_body(
         &mut self,
-        id: ast::NodeId, // the id of the fn itself
+        id: hir::HirId, // the id of the fn itself
         body: &'gcx hir::Body,
         span: Span,
     ) {
         // When we enter a function, we can derive
-        debug!("visit_fn_body(id={})", id);
+        debug!("visit_fn_body(id={:?})", id);
 
         let body_id = body.id();
-        self.body_id = body_id.node_id;
+        self.body_id = body_id.hir_id;
 
         let call_site = region::Scope {
             id: body.value.hir_id.local_id,
@@ -318,11 +319,10 @@ impl<'a, 'gcx, 'tcx> RegionCtxt<'a, 'gcx, 'tcx> {
         self.call_site_scope = Some(call_site);
 
         let fn_sig = {
-            let fn_hir_id = self.tcx.hir().node_to_hir_id(id);
-            match self.tables.borrow().liberated_fn_sigs().get(fn_hir_id) {
+            match self.tables.borrow().liberated_fn_sigs().get(id) {
                 Some(f) => f.clone(),
                 None => {
-                    bug!("No fn-sig entry for id={}", id);
+                    bug!("No fn-sig entry for id={:?}", id);
                 }
             }
         };
@@ -342,11 +342,11 @@ impl<'a, 'gcx, 'tcx> RegionCtxt<'a, 'gcx, 'tcx> {
         self.outlives_environment.add_implied_bounds(
             self.fcx,
             &fn_sig_tys[..],
-            body_id.node_id,
+            body_id.hir_id,
             span,
         );
         self.outlives_environment
-            .save_implied_bounds(body_id.node_id);
+            .save_implied_bounds(body_id.hir_id);
         self.link_fn_args(
             region::Scope {
                 id: body.value.hir_id.local_id,
@@ -355,7 +355,7 @@ impl<'a, 'gcx, 'tcx> RegionCtxt<'a, 'gcx, 'tcx> {
             &body.arguments,
         );
         self.visit_body(body);
-        self.visit_region_obligations(body_id.node_id);
+        self.visit_region_obligations(body_id.hir_id);
 
         let call_site_scope = self.call_site_scope.unwrap();
         debug!(
@@ -365,8 +365,7 @@ impl<'a, 'gcx, 'tcx> RegionCtxt<'a, 'gcx, 'tcx> {
         );
         let call_site_region = self.tcx.mk_region(ty::ReScope(call_site_scope));
 
-        let body_hir_id = self.tcx.hir().node_to_hir_id(body_id.node_id);
-        self.type_of_node_must_outlive(infer::CallReturn(span), body_hir_id, call_site_region);
+        self.type_of_node_must_outlive(infer::CallReturn(span), body_id.hir_id, call_site_region);
 
         self.constrain_opaque_types(
             &self.fcx.opaque_types.borrow(),
@@ -374,8 +373,8 @@ impl<'a, 'gcx, 'tcx> RegionCtxt<'a, 'gcx, 'tcx> {
         );
     }
 
-    fn visit_region_obligations(&mut self, node_id: ast::NodeId) {
-        debug!("visit_region_obligations: node_id={}", node_id);
+    fn visit_region_obligations(&mut self, hir_id: hir::HirId) {
+        debug!("visit_region_obligations: hir_id={:?}", hir_id);
 
         // region checking can introduce new pending obligations
         // which, when processed, might generate new region
@@ -474,7 +473,8 @@ impl<'a, 'gcx, 'tcx> Visitor<'gcx> for RegionCtxt<'a, 'gcx, 'tcx> {
         let env_snapshot = self.outlives_environment.push_snapshot_pre_closure();
 
         let body = self.tcx.hir().body(body_id);
-        self.visit_fn_body(id, body, span);
+        let hir_id = self.tcx.hir().node_to_hir_id(id);
+        self.visit_fn_body(hir_id, body, span);
 
         // Restore state from previous function.
         self.outlives_environment
@@ -502,7 +502,7 @@ impl<'a, 'gcx, 'tcx> Visitor<'gcx> for RegionCtxt<'a, 'gcx, 'tcx> {
 
     fn visit_expr(&mut self, expr: &'gcx hir::Expr) {
         debug!(
-            "regionck::visit_expr(e={:?}, repeating_scope={})",
+            "regionck::visit_expr(e={:?}, repeating_scope={:?})",
             expr, self.repeating_scope
         );
 
@@ -555,7 +555,7 @@ impl<'a, 'gcx, 'tcx> Visitor<'gcx> for RegionCtxt<'a, 'gcx, 'tcx> {
         }
 
         debug!(
-            "regionck::visit_expr(e={:?}, repeating_scope={}) - visiting subexprs",
+            "regionck::visit_expr(e={:?}, repeating_scope={:?}) - visiting subexprs",
             expr, self.repeating_scope
         );
         match expr.node {
@@ -679,16 +679,16 @@ impl<'a, 'gcx, 'tcx> Visitor<'gcx> for RegionCtxt<'a, 'gcx, 'tcx> {
             }
 
             hir::ExprKind::Loop(ref body, _, _) => {
-                let repeating_scope = self.set_repeating_scope(body.id);
+                let repeating_scope = self.set_repeating_scope(body.hir_id);
                 intravisit::walk_expr(self, expr);
                 self.set_repeating_scope(repeating_scope);
             }
 
             hir::ExprKind::While(ref cond, ref body, _) => {
-                let repeating_scope = self.set_repeating_scope(cond.id);
+                let repeating_scope = self.set_repeating_scope(cond.hir_id);
                 self.visit_expr(&cond);
 
-                self.set_repeating_scope(body.id);
+                self.set_repeating_scope(body.hir_id);
                 self.visit_block(&body);
 
                 self.set_repeating_scope(repeating_scope);
@@ -758,7 +758,7 @@ impl<'a, 'gcx, 'tcx> RegionCtxt<'a, 'gcx, 'tcx> {
     }
 
     fn check_expr_fn_block(&mut self, expr: &'gcx hir::Expr, body_id: hir::BodyId) {
-        let repeating_scope = self.set_repeating_scope(body_id.node_id);
+        let repeating_scope = self.set_repeating_scope(body_id.hir_id);
         intravisit::walk_expr(self, expr);
         self.set_repeating_scope(repeating_scope);
     }

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -22,7 +22,7 @@ use rustc::hir;
 /// `F: for<'b, 'tcx> where 'gcx: 'tcx FnOnce(FnCtxt<'b, 'gcx, 'tcx>)`.
 struct CheckWfFcxBuilder<'a, 'gcx: 'a+'tcx, 'tcx: 'a> {
     inherited: super::InheritedBuilder<'a, 'gcx, 'tcx>,
-    id: ast::NodeId,
+    id: hir::HirId,
     span: Span,
     param_env: ty::ParamEnv<'tcx>,
 }
@@ -226,9 +226,10 @@ fn for_item<'a, 'gcx, 'tcx>(tcx: TyCtxt<'a, 'gcx, 'gcx>, item: &hir::Item)
 fn for_id<'a, 'gcx, 'tcx>(tcx: TyCtxt<'a, 'gcx, 'gcx>, id: ast::NodeId, span: Span)
                           -> CheckWfFcxBuilder<'a, 'gcx, 'tcx> {
     let def_id = tcx.hir().local_def_id(id);
+    let hir_id = tcx.hir().node_to_hir_id(id);
     CheckWfFcxBuilder {
         inherited: Inherited::build(tcx, def_id),
-        id,
+        id: hir_id,
         span,
         param_env: tcx.param_env(def_id),
     }
@@ -968,13 +969,13 @@ fn reject_shadowing_parameters(tcx: TyCtxt, def_id: DefId) {
 fn check_false_global_bounds<'a, 'gcx, 'tcx>(
     fcx: &FnCtxt<'a, 'gcx, 'tcx>,
     span: Span,
-    id: ast::NodeId)
+    id: hir::HirId)
 {
     use rustc::ty::TypeFoldable;
 
     let empty_env = ty::ParamEnv::empty();
 
-    let def_id = fcx.tcx.hir().local_def_id(id);
+    let def_id = fcx.tcx.hir().local_def_id_from_hir_id(id);
     let predicates = fcx.tcx.predicates_of(def_id).predicates
         .iter()
         .map(|(p, _)| *p)

--- a/src/librustc_typeck/check/writeback.rs
+++ b/src/librustc_typeck/check/writeback.rs
@@ -100,7 +100,7 @@ impl<'cx, 'gcx, 'tcx> WritebackCx<'cx, 'gcx, 'tcx> {
         body: &'gcx hir::Body,
         rustc_dump_user_substs: bool,
     ) -> WritebackCx<'cx, 'gcx, 'tcx> {
-        let owner = fcx.tcx.hir().definitions().node_to_hir_id(body.id().node_id);
+        let owner = body.id().hir_id;
 
         WritebackCx {
             fcx,

--- a/src/librustc_typeck/coherence/builtin.rs
+++ b/src/librustc_typeck/coherence/builtin.rs
@@ -162,8 +162,8 @@ fn visit_implementation_of_dispatch_from_dyn<'a, 'tcx>(
     if impl_did.is_local() {
         let dispatch_from_dyn_trait = tcx.lang_items().dispatch_from_dyn_trait().unwrap();
 
-        let impl_node_id = tcx.hir().as_local_node_id(impl_did).unwrap();
-        let span = tcx.hir().span(impl_node_id);
+        let impl_hir_id = tcx.hir().as_local_hir_id(impl_did).unwrap();
+        let span = tcx.hir().span_by_hir_id(impl_hir_id);
 
         let source = tcx.type_of(impl_did);
         assert!(!source.has_escaping_bound_vars());
@@ -185,7 +185,7 @@ fn visit_implementation_of_dispatch_from_dyn<'a, 'tcx>(
         };
 
         tcx.infer_ctxt().enter(|infcx| {
-            let cause = ObligationCause::misc(span, impl_node_id);
+            let cause = ObligationCause::misc(span, impl_hir_id);
 
             use ty::TyKind::*;
             match (&source.sty, &target.sty) {
@@ -332,7 +332,7 @@ pub fn coerce_unsized_info<'a, 'gcx>(gcx: TyCtxt<'a, 'gcx, 'gcx>,
     });
 
     // this provider should only get invoked for local def-ids
-    let impl_node_id = gcx.hir().as_local_node_id(impl_did).unwrap_or_else(|| {
+    let impl_hir_id = gcx.hir().as_local_hir_id(impl_did).unwrap_or_else(|| {
         bug!("coerce_unsized_info: invoked for non-local def-id {:?}", impl_did)
     });
 
@@ -344,7 +344,7 @@ pub fn coerce_unsized_info<'a, 'gcx>(gcx: TyCtxt<'a, 'gcx, 'gcx>,
            source,
            target);
 
-    let span = gcx.hir().span(impl_node_id);
+    let span = gcx.hir().span_by_hir_id(impl_hir_id);
     let param_env = gcx.param_env(impl_did);
     assert!(!source.has_escaping_bound_vars());
 
@@ -355,7 +355,7 @@ pub fn coerce_unsized_info<'a, 'gcx>(gcx: TyCtxt<'a, 'gcx, 'gcx>,
            target);
 
     gcx.infer_ctxt().enter(|infcx| {
-        let cause = ObligationCause::misc(span, impl_node_id);
+        let cause = ObligationCause::misc(span, impl_hir_id);
         let check_mutbl = |mt_a: ty::TypeAndMut<'gcx>,
                            mt_b: ty::TypeAndMut<'gcx>,
                            mk_ptr: &dyn Fn(Ty<'gcx>) -> Ty<'gcx>| {
@@ -481,11 +481,11 @@ pub fn coerce_unsized_info<'a, 'gcx>(gcx: TyCtxt<'a, 'gcx, 'gcx>,
                                being coerced, none found");
                     return err_info;
                 } else if diff_fields.len() > 1 {
-                    let item = gcx.hir().expect_item(impl_node_id);
+                    let item = gcx.hir().expect_item_by_hir_id(impl_hir_id);
                     let span = if let ItemKind::Impl(.., Some(ref t), _, _) = item.node {
                         t.path.span
                     } else {
-                        gcx.hir().span(impl_node_id)
+                        gcx.hir().span_by_hir_id(impl_hir_id)
                     };
 
                     let mut err = struct_span_err!(gcx.sess,
@@ -527,7 +527,7 @@ pub fn coerce_unsized_info<'a, 'gcx>(gcx: TyCtxt<'a, 'gcx, 'gcx>,
         let mut fulfill_cx = TraitEngine::new(infcx.tcx);
 
         // Register an obligation for `A: Trait<B>`.
-        let cause = traits::ObligationCause::misc(span, impl_node_id);
+        let cause = traits::ObligationCause::misc(span, impl_hir_id);
         let predicate = gcx.predicate_for_trait_def(param_env,
                                                     cause,
                                                     trait_def_id,

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -179,12 +179,12 @@ fn require_same_types<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 }
 
 fn check_main_fn_ty<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, main_def_id: DefId) {
-    let main_id = tcx.hir().as_local_node_id(main_def_id).unwrap();
+    let main_id = tcx.hir().as_local_hir_id(main_def_id).unwrap();
     let main_span = tcx.def_span(main_def_id);
     let main_t = tcx.type_of(main_def_id);
     match main_t.sty {
         ty::FnDef(..) => {
-            if let Some(Node::Item(it)) = tcx.hir().find(main_id) {
+            if let Some(Node::Item(it)) = tcx.hir().find_by_hir_id(main_id) {
                 if let hir::ItemKind::Fn(.., ref generics, _) = it.node {
                     let mut error = false;
                     if !generics.params.is_empty() {
@@ -244,12 +244,12 @@ fn check_main_fn_ty<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, main_def_id: DefId) {
 }
 
 fn check_start_fn_ty<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, start_def_id: DefId) {
-    let start_id = tcx.hir().as_local_node_id(start_def_id).unwrap();
+    let start_id = tcx.hir().as_local_hir_id(start_def_id).unwrap();
     let start_span = tcx.def_span(start_def_id);
     let start_t = tcx.type_of(start_def_id);
     match start_t.sty {
         ty::FnDef(..) => {
-            if let Some(Node::Item(it)) = tcx.hir().find(start_id) {
+            if let Some(Node::Item(it)) = tcx.hir().find_by_hir_id(start_id) {
                 if let hir::ItemKind::Fn(.., ref generics, _) = it.node {
                     let mut error = false;
                     if !generics.params.is_empty() {

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -3830,7 +3830,7 @@ fn print_const(cx: &DocContext, n: ty::LazyConst) -> String {
 }
 
 fn print_const_expr(cx: &DocContext, body: hir::BodyId) -> String {
-    cx.tcx.hir().node_to_pretty_string(body.node_id)
+    cx.tcx.hir().hir_to_pretty_string(body.hir_id)
 }
 
 /// Given a type Path, resolve it to a Type using the TyCtxt

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -2845,8 +2845,10 @@ fn short_stability(item: &clean::Item, cx: &Context) -> Vec<String> {
     let mut stability = vec![];
     let error_codes = ErrorCodes::from(UnstableFeatures::from_environment().is_nightly_build());
 
-    if let Some(Deprecation { since, note }) = &item.deprecation() {
-        let mut message = if let Some(since) = since {
+    if let Some(Deprecation { note, .. }) = &item.deprecation() {
+        // We display deprecation messages for #[deprecated] and #[rustc_deprecated]
+        // but only display the future-deprecation messages for #[rustc_deprecated].
+        let mut message = if let Some(since) = item.stability.deprecation.since {
             if stability::deprecation_in_effect(since) {
                 format!("Deprecated since {}", Escape(since))
             } else {

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -2855,16 +2855,18 @@ fn short_stability(item: &clean::Item, cx: &Context) -> Vec<String> {
     let mut stability = vec![];
     let error_codes = ErrorCodes::from(UnstableFeatures::from_environment().is_nightly_build());
 
-    if let Some(Deprecation { note, .. }) = &item.deprecation() {
+    if let Some(Deprecation { note, since }) = &item.deprecation() {
         // We display deprecation messages for #[deprecated] and #[rustc_deprecated]
         // but only display the future-deprecation messages for #[rustc_deprecated].
-        let mut message = String::from("Deprecated");
+        let mut message = if let Some(since) = since {
+            format!("Deprecated since {}", Escape(since))
+        } else {
+            String::from("Deprecated")
+        };
         if let Some(ref stab) = item.stability {
             if let Some(ref depr) = stab.deprecation {
                 if let Some(ref since) = depr.since {
-                    if stability::deprecation_in_effect(&since) {
-                        message = format!("Deprecated since {}", Escape(&since));
-                    } else {
+                    if !stability::deprecation_in_effect(&since) {
                         message = format!("Deprecating in {}", Escape(&since));
                     }
                 }

--- a/src/librustdoc/visit_lib.rs
+++ b/src/librustdoc/visit_lib.rs
@@ -60,9 +60,11 @@ impl<'a, 'tcx, 'rcx> LibEmbargoVisitor<'a, 'tcx, 'rcx> {
         }
 
         for item in self.cx.tcx.item_children(def_id).iter() {
-            if self.cx.tcx.def_key(item.def.def_id()).parent.map_or(false, |d| d == def_id.index) ||
-                item.vis == Visibility::Public {
-                self.visit_item(item.def);
+            if let Some(def_id) = item.def.opt_def_id() {
+                if self.cx.tcx.def_key(def_id).parent.map_or(false, |d| d == def_id.index) ||
+                    item.vis == Visibility::Public {
+                    self.visit_item(item.def);
+                }
             }
         }
     }

--- a/src/test/incremental/issue-54242.rs
+++ b/src/test/incremental/issue-54242.rs
@@ -1,0 +1,17 @@
+// revisions: rpass cfail
+
+trait Tr {
+    type Arr;
+
+    const C: usize = 0;
+}
+
+impl Tr for str {
+    #[cfg(rpass)]
+    type Arr = [u8; 8];
+    #[cfg(cfail)]
+    type Arr = [u8; Self::C];
+    //[cfail]~^ ERROR cycle detected when const-evaluating
+}
+
+fn main() {}

--- a/src/test/mir-opt/unusual-item-types.rs
+++ b/src/test/mir-opt/unusual-item-types.rs
@@ -1,0 +1,66 @@
+// Test that we don't ICE when trying to dump MIR for unusual item types and
+// that we don't create filenames containing `<` and `>`
+
+struct A;
+
+impl A {
+    const ASSOCIATED_CONSTANT: i32 = 2;
+}
+
+enum E {
+    V = 5,
+}
+
+fn main() {
+    let v = Vec::<i32>::new();
+}
+
+// END RUST SOURCE
+
+// START rustc.{{impl}}-ASSOCIATED_CONSTANT.mir_map.0.mir
+// bb0: {
+//     _0 = const 2i32;
+//     return;
+// }
+// bb1: {
+//     resume;
+// }
+// END rustc.{{impl}}-ASSOCIATED_CONSTANT.mir_map.0.mir
+
+// START rustc.E-V-{{constant}}.mir_map.0.mir
+// bb0: {
+//     _0 = const 5isize;
+//     return;
+// }
+// bb1: {
+//     resume;
+// }
+// END rustc.E-V-{{constant}}.mir_map.0.mir
+
+// START rustc.ptr-real_drop_in_place.std__vec__Vec_i32_.AddMovesForPackedDrops.before.mir
+//     bb0: {
+//     goto -> bb7;
+// }
+// bb1: {
+//     return;
+// }
+// bb2: {
+//     resume;
+// }
+// bb3: {
+//     goto -> bb1;
+// }
+// bb4: {
+//     goto -> bb2;
+// }
+// bb5: {
+//     drop(((*_1).0: alloc::raw_vec::RawVec<i32>)) -> bb4;
+// }
+// bb6: {
+//     drop(((*_1).0: alloc::raw_vec::RawVec<i32>)) -> [return: bb3, unwind: bb4];
+// }
+// bb7: {
+//     _2 = &mut (*_1);
+//     _3 = const std::ops::Drop::drop(move _2) -> [return: bb6, unwind: bb5];
+// }
+// END rustc.ptr-real_drop_in_place.std__vec__Vec_i32_.AddMovesForPackedDrops.before.mir

--- a/src/test/run-make/wasm-stringify-ints-small/Makefile
+++ b/src/test/run-make/wasm-stringify-ints-small/Makefile
@@ -4,7 +4,7 @@ ifeq ($(TARGET),wasm32-unknown-unknown)
 all:
 	$(RUSTC) foo.rs -C lto -O --target wasm32-unknown-unknown
 	wc -c < $(TMPDIR)/foo.wasm
-	[ "`wc -c < $(TMPDIR)/foo.wasm`" -lt "21000" ]
+	[ "`wc -c < $(TMPDIR)/foo.wasm`" -lt "20500" ]
 else
 all:
 endif

--- a/src/test/run-make/wasm-stringify-ints-small/Makefile
+++ b/src/test/run-make/wasm-stringify-ints-small/Makefile
@@ -1,0 +1,10 @@
+-include ../../run-make-fulldeps/tools.mk
+
+ifeq ($(TARGET),wasm32-unknown-unknown)
+all:
+	$(RUSTC) foo.rs -C lto -O --target wasm32-unknown-unknown
+	wc -c < $(TMPDIR)/foo.wasm
+	[ "`wc -c < $(TMPDIR)/foo.wasm`" -lt "21000" ]
+else
+all:
+endif

--- a/src/test/run-make/wasm-stringify-ints-small/foo.rs
+++ b/src/test/run-make/wasm-stringify-ints-small/foo.rs
@@ -1,0 +1,39 @@
+#![crate_type = "cdylib"]
+
+extern "C" {
+    fn observe(ptr: *const u8, len: usize);
+
+    fn get_u8() -> u8;
+    fn get_i8() -> i8;
+    fn get_u16() -> u16;
+    fn get_i16() -> i16;
+    fn get_u32() -> u32;
+    fn get_i32() -> i32;
+    fn get_u64() -> u64;
+    fn get_i64() -> i64;
+    fn get_usize() -> usize;
+    fn get_isize() -> isize;
+}
+
+macro_rules! stringify {
+    ( $($f:ident)* ) => {
+        $(
+            let s = $f().to_string();
+            observe(s.as_ptr(), s.len());
+        )*
+    };
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn foo() {
+    stringify!(get_u8);
+    stringify!(get_i8);
+    stringify!(get_u16);
+    stringify!(get_i16);
+    stringify!(get_u32);
+    stringify!(get_i32);
+    stringify!(get_u64);
+    stringify!(get_i64);
+    stringify!(get_usize);
+    stringify!(get_isize);
+}

--- a/src/test/run-make/wasm-stringify-ints-small/foo.rs
+++ b/src/test/run-make/wasm-stringify-ints-small/foo.rs
@@ -2,22 +2,14 @@
 
 extern "C" {
     fn observe(ptr: *const u8, len: usize);
-
-    fn get_u8() -> u8;
-    fn get_i8() -> i8;
-    fn get_u16() -> u16;
-    fn get_i16() -> i16;
-    fn get_u32() -> u32;
-    fn get_i32() -> i32;
-    fn get_u64() -> u64;
-    fn get_i64() -> i64;
-    fn get_usize() -> usize;
-    fn get_isize() -> isize;
 }
 
-macro_rules! stringify {
-    ( $($f:ident)* ) => {
+macro_rules! s {
+    ( $( $f:ident -> $t:ty );* $(;)* ) => {
         $(
+            extern "C" {
+                fn $f() -> $t;
+            }
             let s = $f().to_string();
             observe(s.as_ptr(), s.len());
         )*
@@ -26,14 +18,16 @@ macro_rules! stringify {
 
 #[no_mangle]
 pub unsafe extern "C" fn foo() {
-    stringify!(get_u8);
-    stringify!(get_i8);
-    stringify!(get_u16);
-    stringify!(get_i16);
-    stringify!(get_u32);
-    stringify!(get_i32);
-    stringify!(get_u64);
-    stringify!(get_i64);
-    stringify!(get_usize);
-    stringify!(get_isize);
+    s! {
+        get_u8 -> u8;
+        get_i8 -> i8;
+        get_u16 -> u16;
+        get_i16 -> i16;
+        get_u32 -> u32;
+        get_i32 -> i32;
+        get_u64 -> u64;
+        get_i64 -> i64;
+        get_usize -> usize;
+        get_isize -> isize;
+    }
 }

--- a/src/test/rustdoc/deprecated-future.rs
+++ b/src/test/rustdoc/deprecated-future.rs
@@ -1,5 +1,7 @@
 #![feature(deprecated)]
 
+// @has deprecated_future/index.html '//*[@class="stab deprecated"]' \
+//      'Deprecated'
 // @has deprecated_future/struct.S.html '//*[@class="stab deprecated"]' \
 //      'Deprecated since 99.99.99: effectively never'
 #[deprecated(since = "99.99.99", note = "effectively never")]

--- a/src/test/rustdoc/deprecated-future.rs
+++ b/src/test/rustdoc/deprecated-future.rs
@@ -1,6 +1,6 @@
 #![feature(deprecated)]
 
 // @has deprecated_future/struct.S.html '//*[@class="stab deprecated"]' \
-//      'Deprecating in 99.99.99: effectively never'
+//      'Deprecated since 99.99.99: effectively never'
 #[deprecated(since = "99.99.99", note = "effectively never")]
 pub struct S;

--- a/src/test/rustdoc/rustc_deprecated-future.rs
+++ b/src/test/rustdoc/rustc_deprecated-future.rs
@@ -1,0 +1,11 @@
+#![feature(staged_api)]
+
+#![stable(feature = "rustc_deprecated-future-test", since = "1.0.0")]
+
+// @has rustc_deprecated_future/index.html '//*[@class="stab deprecated"]' \
+//      'Deprecation planned'
+// @has rustc_deprecated_future/struct.S.html '//*[@class="stab deprecated"]' \
+//      'Deprecating in 99.99.99: effectively never'
+#[rustc_deprecated(since = "99.99.99", reason = "effectively never")]
+#[stable(feature = "rustc_deprecated-future-test", since = "1.0.0")]
+pub struct S;

--- a/src/test/ui/deprecation/deprecation-in-future.rs
+++ b/src/test/ui/deprecation/deprecation-in-future.rs
@@ -1,12 +1,14 @@
 // ignore-tidy-linelength
 
+// run-pass
+
 #![deny(deprecated_in_future)]
 
 #[deprecated(since = "99.99.99", note = "text")]
 pub fn deprecated_future() {}
 
 fn test() {
-    deprecated_future(); //~ ERROR use of item 'deprecated_future' that will be deprecated in future version 99.99.99: text
+    deprecated_future(); // ok; deprecated_in_future only applies to rustc_deprecated
 }
 
 fn main() {}

--- a/src/test/ui/deprecation/deprecation-in-future.stderr
+++ b/src/test/ui/deprecation/deprecation-in-future.stderr
@@ -1,14 +1,8 @@
-error: use of item 'deprecated_future' that will be deprecated in future version 99.99.99: text
-  --> $DIR/deprecation-in-future.rs:9:5
+warning: use of deprecated item 'deprecated_future': text
+  --> $DIR/deprecation-in-future.rs:11:5
    |
-LL |     deprecated_future(); //~ ERROR use of item 'deprecated_future' that will be deprecated in future version 99.99.99: text
+LL |     deprecated_future(); // ok; deprecated_in_future only applies to rustc_deprecated
    |     ^^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
-  --> $DIR/deprecation-in-future.rs:3:9
-   |
-LL | #![deny(deprecated_in_future)]
-   |         ^^^^^^^^^^^^^^^^^^^^
-
-error: aborting due to previous error
+   = note: #[warn(deprecated)] on by default
 

--- a/src/test/ui/deprecation/deprecation-lint.rs
+++ b/src/test/ui/deprecation/deprecation-lint.rs
@@ -261,8 +261,9 @@ mod this_crate {
         <Foo>::trait_deprecated_text(&foo); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
         <Foo as Trait>::trait_deprecated_text(&foo); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
 
-        deprecated_future(); // Fine; no error.
-        deprecated_future_text(); // Fine; no error.
+        // Future deprecations are only permitted for rustc_deprecated.
+        deprecated_future(); //~ ERROR use of deprecated item
+        deprecated_future_text(); //~ ERROR use of deprecated item
 
         let _ = DeprecatedStruct {
             //~^ ERROR use of deprecated item 'this_crate::DeprecatedStruct': text

--- a/src/test/ui/deprecation/deprecation-lint.stderr
+++ b/src/test/ui/deprecation/deprecation-lint.stderr
@@ -214,128 +214,140 @@ error: use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
 LL |         <Foo as Trait>::trait_deprecated_text(&foo); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+error: use of deprecated item 'this_crate::deprecated_future': text
+  --> $DIR/deprecation-lint.rs:265:9
+   |
+LL |         deprecated_future(); //~ ERROR use of deprecated item
+   |         ^^^^^^^^^^^^^^^^^
+
+error: use of deprecated item 'this_crate::deprecated_future_text': text
+  --> $DIR/deprecation-lint.rs:266:9
+   |
+LL |         deprecated_future_text(); //~ ERROR use of deprecated item
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+
 error: use of deprecated item 'this_crate::DeprecatedStruct': text
-  --> $DIR/deprecation-lint.rs:267:17
+  --> $DIR/deprecation-lint.rs:268:17
    |
 LL |         let _ = DeprecatedStruct {
    |                 ^^^^^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate::DeprecatedUnitStruct': text
-  --> $DIR/deprecation-lint.rs:272:17
+  --> $DIR/deprecation-lint.rs:273:17
    |
 LL |         let _ = DeprecatedUnitStruct; //~ ERROR use of deprecated item 'this_crate::DeprecatedUnitStruct': text
    |                 ^^^^^^^^^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate::Enum::DeprecatedVariant': text
-  --> $DIR/deprecation-lint.rs:274:17
+  --> $DIR/deprecation-lint.rs:275:17
    |
 LL |         let _ = Enum::DeprecatedVariant; //~ ERROR use of deprecated item 'this_crate::Enum::DeprecatedVariant': text
    |                 ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate::DeprecatedTupleStruct': text
-  --> $DIR/deprecation-lint.rs:276:17
+  --> $DIR/deprecation-lint.rs:277:17
    |
 LL |         let _ = DeprecatedTupleStruct (1); //~ ERROR use of deprecated item 'this_crate::DeprecatedTupleStruct': text
    |                 ^^^^^^^^^^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate::nested::DeprecatedStruct': text
-  --> $DIR/deprecation-lint.rs:278:17
+  --> $DIR/deprecation-lint.rs:279:17
    |
 LL |         let _ = nested::DeprecatedStruct {
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate::nested::DeprecatedUnitStruct': text
-  --> $DIR/deprecation-lint.rs:283:17
+  --> $DIR/deprecation-lint.rs:284:17
    |
 LL |         let _ = nested::DeprecatedUnitStruct; //~ ERROR use of deprecated item 'this_crate::nested::DeprecatedUnitStruct': text
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate::nested::Enum::DeprecatedVariant': text
-  --> $DIR/deprecation-lint.rs:285:17
+  --> $DIR/deprecation-lint.rs:286:17
    |
 LL |         let _ = nested::Enum::DeprecatedVariant; //~ ERROR use of deprecated item 'this_crate::nested::Enum::DeprecatedVariant': text
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate::nested::DeprecatedTupleStruct': text
-  --> $DIR/deprecation-lint.rs:287:17
+  --> $DIR/deprecation-lint.rs:288:17
    |
 LL |         let _ = nested::DeprecatedTupleStruct (1); //~ ERROR use of deprecated item 'this_crate::nested::DeprecatedTupleStruct': text
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate::Trait::trait_deprecated': text
-  --> $DIR/deprecation-lint.rs:292:9
+  --> $DIR/deprecation-lint.rs:293:9
    |
 LL |         Trait::trait_deprecated(&foo); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated'
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate::Trait::trait_deprecated': text
-  --> $DIR/deprecation-lint.rs:294:9
+  --> $DIR/deprecation-lint.rs:295:9
    |
 LL |         <Foo as Trait>::trait_deprecated(&foo); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated'
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
-  --> $DIR/deprecation-lint.rs:296:9
+  --> $DIR/deprecation-lint.rs:297:9
    |
 LL |         Trait::trait_deprecated_text(&foo); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
-  --> $DIR/deprecation-lint.rs:298:9
+  --> $DIR/deprecation-lint.rs:299:9
    |
 LL |         <Foo as Trait>::trait_deprecated_text(&foo); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate::test_fn_closure_body::{{closure}}::bar'
-  --> $DIR/deprecation-lint.rs:316:13
+  --> $DIR/deprecation-lint.rs:317:13
    |
 LL |             bar(); //~ ERROR use of deprecated item 'this_crate::test_fn_closure_body::{{closure}}::bar'
    |             ^^^
 
 error: use of deprecated item 'this_crate::DeprecatedTrait': text
-  --> $DIR/deprecation-lint.rs:335:10
+  --> $DIR/deprecation-lint.rs:336:10
    |
 LL |     impl DeprecatedTrait for S { } //~ ERROR use of deprecated item 'this_crate::DeprecatedTrait': text
    |          ^^^^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate::DeprecatedTrait': text
-  --> $DIR/deprecation-lint.rs:337:24
+  --> $DIR/deprecation-lint.rs:338:24
    |
 LL |     trait LocalTrait : DeprecatedTrait { } //~ ERROR use of deprecated item 'this_crate::DeprecatedTrait': text
    |                        ^^^^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate2::Deprecated': text
-  --> $DIR/deprecation-lint.rs:389:17
+  --> $DIR/deprecation-lint.rs:390:17
    |
 LL |         let x = Deprecated {
    |                 ^^^^^^^^^^
 
 error: use of deprecated item 'this_crate2::Deprecated': text
-  --> $DIR/deprecation-lint.rs:398:13
+  --> $DIR/deprecation-lint.rs:399:13
    |
 LL |         let Deprecated {
    |             ^^^^^^^^^^
 
 error: use of deprecated item 'this_crate2::Deprecated': text
-  --> $DIR/deprecation-lint.rs:404:13
+  --> $DIR/deprecation-lint.rs:405:13
    |
 LL |         let Deprecated
    |             ^^^^^^^^^^
 
 error: use of deprecated item 'this_crate2::Deprecated2': text
-  --> $DIR/deprecation-lint.rs:409:17
+  --> $DIR/deprecation-lint.rs:410:17
    |
 LL |         let x = Deprecated2(1, 2, 3);
    |                 ^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate2::Deprecated2': text
-  --> $DIR/deprecation-lint.rs:419:13
+  --> $DIR/deprecation-lint.rs:420:13
    |
 LL |         let Deprecated2
    |             ^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate2::Deprecated2': text
-  --> $DIR/deprecation-lint.rs:428:13
+  --> $DIR/deprecation-lint.rs:429:13
    |
 LL |         let Deprecated2
    |             ^^^^^^^^^^^
@@ -593,136 +605,136 @@ LL |         <Foo>::trait_deprecated_text(&foo); //~ ERROR use of deprecated ite
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate::DeprecatedStruct::i': text
-  --> $DIR/deprecation-lint.rs:269:13
+  --> $DIR/deprecation-lint.rs:270:13
    |
 LL |             i: 0 //~ ERROR use of deprecated item 'this_crate::DeprecatedStruct::i': text
    |             ^^^^
 
 error: use of deprecated item 'this_crate::nested::DeprecatedStruct::i': text
-  --> $DIR/deprecation-lint.rs:280:13
+  --> $DIR/deprecation-lint.rs:281:13
    |
 LL |             i: 0 //~ ERROR use of deprecated item 'this_crate::nested::DeprecatedStruct::i': text
    |             ^^^^
 
 error: use of deprecated item 'this_crate::Trait::trait_deprecated': text
-  --> $DIR/deprecation-lint.rs:291:13
+  --> $DIR/deprecation-lint.rs:292:13
    |
 LL |         foo.trait_deprecated(); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated'
    |             ^^^^^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate::Trait::trait_deprecated': text
-  --> $DIR/deprecation-lint.rs:293:9
+  --> $DIR/deprecation-lint.rs:294:9
    |
 LL |         <Foo>::trait_deprecated(&foo); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated'
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
-  --> $DIR/deprecation-lint.rs:295:13
+  --> $DIR/deprecation-lint.rs:296:13
    |
 LL |         foo.trait_deprecated_text(); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
    |             ^^^^^^^^^^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
-  --> $DIR/deprecation-lint.rs:297:9
+  --> $DIR/deprecation-lint.rs:298:9
    |
 LL |         <Foo>::trait_deprecated_text(&foo); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate::Trait::trait_deprecated': text
-  --> $DIR/deprecation-lint.rs:302:13
+  --> $DIR/deprecation-lint.rs:303:13
    |
 LL |         foo.trait_deprecated(); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated'
    |             ^^^^^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
-  --> $DIR/deprecation-lint.rs:303:13
+  --> $DIR/deprecation-lint.rs:304:13
    |
 LL |         foo.trait_deprecated_text(); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
    |             ^^^^^^^^^^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate2::Stable::override2': text
-  --> $DIR/deprecation-lint.rs:362:13
+  --> $DIR/deprecation-lint.rs:363:13
    |
 LL |             override2: 3,
    |             ^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate2::Stable::override2': text
-  --> $DIR/deprecation-lint.rs:366:17
+  --> $DIR/deprecation-lint.rs:367:17
    |
 LL |         let _ = x.override2;
    |                 ^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate2::Stable::override2': text
-  --> $DIR/deprecation-lint.rs:370:13
+  --> $DIR/deprecation-lint.rs:371:13
    |
 LL |             override2: _
    |             ^^^^^^^^^^^^
 
 error: use of deprecated item 'this_crate2::Stable2::2': text
-  --> $DIR/deprecation-lint.rs:378:17
+  --> $DIR/deprecation-lint.rs:379:17
    |
 LL |         let _ = x.2;
    |                 ^^^
 
 error: use of deprecated item 'this_crate2::Stable2::2': text
-  --> $DIR/deprecation-lint.rs:383:20
+  --> $DIR/deprecation-lint.rs:384:20
    |
 LL |                    _)
    |                    ^
 
 error: use of deprecated item 'this_crate2::Deprecated::inherit': text
-  --> $DIR/deprecation-lint.rs:391:13
+  --> $DIR/deprecation-lint.rs:392:13
    |
 LL |             inherit: 1,
    |             ^^^^^^^^^^
 
 error: use of deprecated item 'this_crate2::Deprecated::inherit': text
-  --> $DIR/deprecation-lint.rs:395:17
+  --> $DIR/deprecation-lint.rs:396:17
    |
 LL |         let _ = x.inherit;
    |                 ^^^^^^^^^
 
 error: use of deprecated item 'this_crate2::Deprecated::inherit': text
-  --> $DIR/deprecation-lint.rs:400:13
+  --> $DIR/deprecation-lint.rs:401:13
    |
 LL |             inherit: _,
    |             ^^^^^^^^^^
 
 error: use of deprecated item 'this_crate2::Deprecated2::0': text
-  --> $DIR/deprecation-lint.rs:412:17
+  --> $DIR/deprecation-lint.rs:413:17
    |
 LL |         let _ = x.0;
    |                 ^^^
 
 error: use of deprecated item 'this_crate2::Deprecated2::1': text
-  --> $DIR/deprecation-lint.rs:414:17
+  --> $DIR/deprecation-lint.rs:415:17
    |
 LL |         let _ = x.1;
    |                 ^^^
 
 error: use of deprecated item 'this_crate2::Deprecated2::2': text
-  --> $DIR/deprecation-lint.rs:416:17
+  --> $DIR/deprecation-lint.rs:417:17
    |
 LL |         let _ = x.2;
    |                 ^^^
 
 error: use of deprecated item 'this_crate2::Deprecated2::0': text
-  --> $DIR/deprecation-lint.rs:421:14
+  --> $DIR/deprecation-lint.rs:422:14
    |
 LL |             (_,
    |              ^
 
 error: use of deprecated item 'this_crate2::Deprecated2::1': text
-  --> $DIR/deprecation-lint.rs:423:14
+  --> $DIR/deprecation-lint.rs:424:14
    |
 LL |              _,
    |              ^
 
 error: use of deprecated item 'this_crate2::Deprecated2::2': text
-  --> $DIR/deprecation-lint.rs:425:14
+  --> $DIR/deprecation-lint.rs:426:14
    |
 LL |              _)
    |              ^
 
-error: aborting due to 120 previous errors
+error: aborting due to 122 previous errors
 

--- a/src/test/ui/deprecation/rustc_deprecation-in-future.rs
+++ b/src/test/ui/deprecation/rustc_deprecation-in-future.rs
@@ -1,0 +1,15 @@
+// ignore-tidy-linelength
+
+#![deny(deprecated_in_future)]
+
+#![feature(staged_api)]
+
+#![stable(feature = "rustc_deprecation-in-future-test", since = "1.0.0")]
+
+#[rustc_deprecated(since = "99.99.99", reason = "effectively never")]
+#[stable(feature = "rustc_deprecation-in-future-test", since = "1.0.0")]
+pub struct S;
+
+fn main() {
+    let _ = S; //~ ERROR use of item 'S' that will be deprecated in future version 99.99.99: effectively never
+}

--- a/src/test/ui/deprecation/rustc_deprecation-in-future.stderr
+++ b/src/test/ui/deprecation/rustc_deprecation-in-future.stderr
@@ -1,0 +1,14 @@
+error: use of item 'S' that will be deprecated in future version 99.99.99: effectively never
+  --> $DIR/rustc_deprecation-in-future.rs:14:13
+   |
+LL |     let _ = S; //~ ERROR use of item 'S' that will be deprecated in future version 99.99.99: effectively never
+   |             ^
+   |
+note: lint level defined here
+  --> $DIR/rustc_deprecation-in-future.rs:3:9
+   |
+LL | #![deny(deprecated_in_future)]
+   |         ^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/issue-42944.rs
+++ b/src/test/ui/issue-42944.rs
@@ -1,0 +1,19 @@
+mod foo {
+    pub struct B(());
+}
+
+mod bar {
+    use foo::B;
+
+    fn foo() {
+        B(()); //~ ERROR expected function, found struct `B` [E0423]
+    }
+}
+
+mod baz {
+    fn foo() {
+        B(()); //~ ERROR cannot find function `B` in this scope [E0425]
+    }
+}
+
+fn main() {}

--- a/src/test/ui/issue-42944.stderr
+++ b/src/test/ui/issue-42944.stderr
@@ -1,0 +1,20 @@
+error[E0423]: expected function, found struct `B`
+  --> $DIR/issue-42944.rs:9:9
+   |
+LL |         B(()); //~ ERROR expected function, found struct `B` [E0423]
+   |         ^ constructor is not visible here due to private fields
+
+error[E0425]: cannot find function `B` in this scope
+  --> $DIR/issue-42944.rs:15:9
+   |
+LL |         B(()); //~ ERROR cannot find function `B` in this scope [E0425]
+   |         ^ not found in this scope
+help: possible candidate is found in another module, you can import it into scope
+   |
+LL |     use foo::B;
+   |
+
+error: aborting due to 2 previous errors
+
+Some errors occurred: E0423, E0425.
+For more information about an error, try `rustc --explain E0423`.

--- a/src/test/ui/missing/missing-stability.rs
+++ b/src/test/ui/missing/missing-stability.rs
@@ -6,7 +6,7 @@
 #![stable(feature = "stable_test_feature", since = "1.0.0")]
 
 pub fn unmarked() {
-    //~^ ERROR This node does not have a stability attribute
+    //~^ ERROR node has missing stability attribute
     ()
 }
 
@@ -20,5 +20,5 @@ pub mod foo {
 pub mod bar {
     // #[stable] is not inherited
     pub fn unmarked() {}
-    //~^ ERROR This node does not have a stability attribute
+    //~^ ERROR node has missing stability attribute
 }

--- a/src/test/ui/missing/missing-stability.rs
+++ b/src/test/ui/missing/missing-stability.rs
@@ -6,7 +6,7 @@
 #![stable(feature = "stable_test_feature", since = "1.0.0")]
 
 pub fn unmarked() {
-    //~^ ERROR node has missing stability attribute
+    //~^ ERROR function has missing stability attribute
     ()
 }
 
@@ -20,5 +20,5 @@ pub mod foo {
 pub mod bar {
     // #[stable] is not inherited
     pub fn unmarked() {}
-    //~^ ERROR node has missing stability attribute
+    //~^ ERROR function has missing stability attribute
 }

--- a/src/test/ui/missing/missing-stability.stderr
+++ b/src/test/ui/missing/missing-stability.stderr
@@ -1,13 +1,13 @@
-error: This node does not have a stability attribute
+error: node has missing stability attribute
   --> $DIR/missing-stability.rs:8:1
    |
 LL | / pub fn unmarked() {
-LL | |     //~^ ERROR This node does not have a stability attribute
+LL | |     //~^ ERROR node has missing stability attribute
 LL | |     ()
 LL | | }
    | |_^
 
-error: This node does not have a stability attribute
+error: node has missing stability attribute
   --> $DIR/missing-stability.rs:22:5
    |
 LL |     pub fn unmarked() {}

--- a/src/test/ui/missing/missing-stability.stderr
+++ b/src/test/ui/missing/missing-stability.stderr
@@ -1,13 +1,13 @@
-error: node has missing stability attribute
+error: function has missing stability attribute
   --> $DIR/missing-stability.rs:8:1
    |
 LL | / pub fn unmarked() {
-LL | |     //~^ ERROR node has missing stability attribute
+LL | |     //~^ ERROR function has missing stability attribute
 LL | |     ()
 LL | | }
    | |_^
 
-error: node has missing stability attribute
+error: function has missing stability attribute
   --> $DIR/missing-stability.rs:22:5
    |
 LL |     pub fn unmarked() {}

--- a/src/test/ui/resolve/privacy-struct-ctor.stderr
+++ b/src/test/ui/resolve/privacy-struct-ctor.stderr
@@ -2,25 +2,16 @@ error[E0423]: expected value, found struct `Z`
   --> $DIR/privacy-struct-ctor.rs:20:9
    |
 LL |         Z;
-   |         ^ constructor is not visible here due to private fields
-help: a tuple struct with a similar name exists
-   |
-LL |         S;
    |         ^
-help: possible better candidate is found in another module, you can import it into scope
-   |
-LL |     use m::n::Z;
-   |
+   |         |
+   |         constructor is not visible here due to private fields
+   |         help: a tuple struct with a similar name exists: `S`
 
 error[E0423]: expected value, found struct `S`
   --> $DIR/privacy-struct-ctor.rs:33:5
    |
 LL |     S;
    |     ^ constructor is not visible here due to private fields
-help: possible better candidate is found in another module, you can import it into scope
-   |
-LL | use m::S;
-   |
 
 error[E0423]: expected value, found struct `S2`
   --> $DIR/privacy-struct-ctor.rs:38:5

--- a/src/test/ui/stability-attribute/missing-stability-attr-at-top-level.rs
+++ b/src/test/ui/stability-attribute/missing-stability-attr-at-top-level.rs
@@ -1,0 +1,4 @@
+#![feature(staged_api)]
+//~^ ERROR crate has missing stability attribute
+
+fn main() {}

--- a/src/test/ui/stability-attribute/missing-stability-attr-at-top-level.stderr
+++ b/src/test/ui/stability-attribute/missing-stability-attr-at-top-level.stderr
@@ -1,0 +1,11 @@
+error: crate has missing stability attribute
+  --> $DIR/missing-stability-attr-at-top-level.rs:1:1
+   |
+LL | / #![feature(staged_api)]
+LL | | //~^ ERROR crate has missing stability attribute
+LL | |
+LL | | fn main() {}
+   | |____________^
+
+error: aborting due to previous error
+

--- a/src/test/ui/stability-attribute/stability-attribute-issue-43027.rs
+++ b/src/test/ui/stability-attribute/stability-attribute-issue-43027.rs
@@ -2,7 +2,7 @@
 #![stable(feature = "test", since = "0")]
 
 #[stable(feature = "test", since = "0")]
-pub struct Reverse<T>(pub T); //~ ERROR This node does not have a stability attribute
+pub struct Reverse<T>(pub T); //~ ERROR field has missing stability attribute
 
 fn main() {
     // Make sure the field is used to fill the stability cache

--- a/src/test/ui/stability-attribute/stability-attribute-issue-43027.stderr
+++ b/src/test/ui/stability-attribute/stability-attribute-issue-43027.stderr
@@ -1,7 +1,7 @@
-error: This node does not have a stability attribute
+error: field has missing stability attribute
   --> $DIR/stability-attribute-issue-43027.rs:5:23
    |
-LL | pub struct Reverse<T>(pub T); //~ ERROR This node does not have a stability attribute
+LL | pub struct Reverse<T>(pub T); //~ ERROR field has missing stability attribute
    |                       ^^^^^
 
 error: aborting due to previous error

--- a/src/test/ui/stability-attribute/stability-attribute-sanity-3.rs
+++ b/src/test/ui/stability-attribute/stability-attribute-sanity-3.rs
@@ -5,7 +5,7 @@
 #![stable(feature = "stable_test_feature", since = "1.0.0")]
 
 #[macro_export]
-macro_rules! mac { //~ ERROR This node does not have a stability attribute
+macro_rules! mac { //~ ERROR macro has missing stability attribute
     () => ()
 }
 

--- a/src/test/ui/stability-attribute/stability-attribute-sanity-3.stderr
+++ b/src/test/ui/stability-attribute/stability-attribute-sanity-3.stderr
@@ -1,7 +1,7 @@
-error: This node does not have a stability attribute
+error: macro has missing stability attribute
   --> $DIR/stability-attribute-sanity-3.rs:8:1
    |
-LL | / macro_rules! mac { //~ ERROR This node does not have a stability attribute
+LL | / macro_rules! mac { //~ ERROR macro has missing stability attribute
 LL | |     () => ()
 LL | | }
    | |_^


### PR DESCRIPTION
Successful merges:

 - #58110 (libpanic_unwind => 2018)
 - #58167 (HirId-ify hir::BodyId)
 - #58202 (Ignore future deprecations in #[deprecated])
 - #58272 (Cut down on number formating code size)
 - #58276 (Improve the error messages for missing stability attributes)
 - #58354 (Fix ICE and invalid filenames in MIR printing code)
 - #58381 (Only suggest imports if not imported.)
 - #58386 (Fix #54242)
 - #58400 (Fix rustc_driver swallowing errors when compilation is stopped)
 - #58420 (target/uefi: clarify documentation)

Failed merges:


r? @ghost