### PR TITLE
appveyor: Try using a different `sh.exe`

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -209,7 +209,7 @@ test_script:
   - set NO_CCACHE=1
   # Try specifically using git's `sh.exe` instead of the one in PATH which is
   # the msys64 sh.exe. Trying to debug rust-lang/rust#58160
-  - "C:\Program Files\Git\usr\bin\sh.exe" src/ci/run.sh
+  - "\"C:\\Program Files\\Git\\usr\\bin\\sh.exe\" src/ci/run.sh"
 
 on_failure:
   # Dump crash log

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -207,7 +207,9 @@ test_script:
   - sh src/ci/init_repo.sh . /c/cache/rustsrc
   - set SRC=.
   - set NO_CCACHE=1
-  - sh src/ci/run.sh
+  # Try specifically using git's `sh.exe` instead of the one in PATH which is
+  # the msys64 sh.exe. Trying to debug rust-lang/rust#58160
+  - "C:\Program Files\Git\usr\bin\sh.exe" src/ci/run.sh
 
 on_failure:
   # Dump crash log


### PR DESCRIPTION
On a suggestions from AppVeyor let's try using a different `sh.exe` and
see what happens...

cc https://github.com/rust-lang/rust/issues/58160