### PR TITLE
rustdoc: mask `compiler_builtins` docs

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -165,7 +165,12 @@ impl<'a, 'tcx, 'rcx> Clean<Crate> for visit_ast::RustdocVisitor<'a, 'tcx, 'rcx> 
         match module.inner {
             ModuleItem(ref module) => {
                 for it in &module.items {
-                    if it.is_extern_crate() && it.attrs.has_doc_flag("masked") {
+                    // `compiler_builtins` should be masked too, but we can't apply
+                    // `#[doc(masked)]` to the injected `extern crate` because it's unstable.
+                    if it.is_extern_crate()
+                        && (it.attrs.has_doc_flag("masked")
+                            || self.cx.tcx.is_compiler_builtins(it.def_id.krate))
+                    {
                         masked_crates.insert(it.def_id.krate);
                     }
                 }


### PR DESCRIPTION
Fixes #46783.

I wasn't able to fully confirm the underlying cause, but my theory is that functions in `compiler_builtins` were overwriting functions with the same names in libcore in the search index. Since the functions in `compiler_builtins` didn't have docs, that's why they weren't appearing in the results.

Masking the `compiler_builtins` crate fixes the search results. It appears that this crate was accidentally unmasked in #49503.