### PR TITLE
Notify @topecongiro when the state of rustfmt has changed

### DIFF
--- a/src/tools/publish_toolstate.py
+++ b/src/tools/publish_toolstate.py
@@ -17,7 +17,7 @@ MAINTAINERS = {
     'miri': '@oli-obk @RalfJung @eddyb',
     'clippy-driver': '@Manishearth @llogiq @mcarton @oli-obk',
     'rls': '@nrc @Xanewok',
-    'rustfmt': '@nrc',
+    'rustfmt': '@nrc @topecongiro',
     'book': '@carols10cents @steveklabnik',
     'nomicon': '@frewsxcv @Gankro',
     'reference': '@steveklabnik @Havvy @matthewjasper @alercah',


### PR DESCRIPTION
I would like to get notified when the state of rustfmt has changed.
Context: I am currently a leader of the rustfmt working group.

cc @nrc do you still want to get notified?