### PR TITLE
SGX target: fix panic = abort

### DIFF
--- a/src/libpanic_abort/lib.rs
+++ b/src/libpanic_abort/lib.rs
@@ -58,8 +58,9 @@ pub unsafe extern fn __rust_start_panic(_payload: usize) -> u32 {
 
     #[cfg(all(target_vendor="fortanix", target_env="sgx"))]
     unsafe fn abort() -> ! {
-        extern "C" { pub fn panic_exit() -> !; }
-        panic_exit();
+        // call std::sys::abort_internal
+        extern "C" { pub fn __rust_abort() -> !; }
+        __rust_abort();
     }
 }
 

--- a/src/libstd/sys/sgx/rwlock.rs
+++ b/src/libstd/sys/sgx/rwlock.rs
@@ -204,6 +204,7 @@ pub unsafe extern "C" fn __rust_print_err(m: *mut u8, s: i32) {
 }
 
 #[no_mangle]
+// NB. used by both libunwind and libpanic_abort
 pub unsafe extern "C" fn __rust_abort() {
     ::sys::abort_internal();
 }


### PR DESCRIPTION
What is the difference between `no_mangle` and `rustc_std_internal_symbol`?