### PR TITLE
Associate an allocator to boxes

### DIFF
--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -88,6 +88,7 @@ use core::ops::{
 use core::ptr::{self, NonNull, Unique};
 use core::task::{Context, Poll};
 
+use crate::alloc::{Alloc, Global, Layout, handle_alloc_error};
 use crate::vec::Vec;
 use crate::raw_vec::RawVec;
 use crate::str::from_boxed_utf8_unchecked;
@@ -98,7 +99,7 @@ use crate::str::from_boxed_utf8_unchecked;
 #[lang = "owned_box"]
 #[fundamental]
 #[stable(feature = "rust1", since = "1.0.0")]
-pub struct Box<T: ?Sized>(Unique<T>);
+pub struct Box<T: ?Sized, A = Global>(Unique<T>, pub(crate) A);
 
 impl<T> Box<T> {
     /// Allocates memory on the heap and then places `x` into it.
@@ -122,6 +123,49 @@ impl<T> Box<T> {
     #[inline(always)]
     pub fn pin(x: T) -> Pin<Box<T>> {
         (box x).into()
+    }
+}
+
+impl<T, A: Alloc> Box<T, A> {
+    /// Allocates memory in the given allocator and then places `x` into it.
+    ///
+    /// This doesn't actually allocate if `T` is zero-sized.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #![feature(allocator_api)]
+    /// use std::alloc::Global;
+    /// let five = Box::new_in(5, Global);
+    /// ```
+    #[unstable(feature = "allocator_api", issue = "32838")]
+    #[inline(always)]
+    pub fn new_in(x: T, a: A) -> Box<T, A> {
+        let mut a = a;
+        let layout = Layout::for_value(&x);
+        let size = layout.size();
+        let ptr = if size == 0 {
+            Unique::empty()
+        } else {
+            unsafe {
+                let ptr = a.alloc(layout).unwrap_or_else(|_| handle_alloc_error(layout));
+                ptr.cast().into()
+            }
+        };
+        // Move x into the location allocated above. This needs to happen
+        // for any size so that x is not dropped in some cases.
+        unsafe {
+            ptr::write(ptr.as_ptr() as *mut T, x);
+        }
+        Box(ptr, a)
+    }
+
+    /// Constructs a new `Pin<Box<T>>`. If `T` does not implement `Unpin`, then
+    /// `x` will be pinned in memory and unable to be moved.
+    #[unstable(feature = "allocator_api", issue = "32838")]
+    #[inline(always)]
+    pub fn pin_in(x: T, a: A) -> Pin<Box<T, A>> {
+        Box::new_in(x, a).into()
     }
 }
 
@@ -165,9 +209,48 @@ impl<T: ?Sized> Box<T> {
     #[stable(feature = "box_raw", since = "1.4.0")]
     #[inline]
     pub unsafe fn from_raw(raw: *mut T) -> Self {
-        Box(Unique::new_unchecked(raw))
+        Box(Unique::new_unchecked(raw), Global)
+    }
+}
+
+impl<T: ?Sized, A: Alloc> Box<T, A> {
+    /// Constructs a box from a raw pointer in the given allocator.
+    ///
+    /// This is similar to the [`Box::from_raw`] function, but assumes
+    /// the pointer was allocated with the given allocator.
+    ///
+    /// This function is unsafe because improper use may lead to
+    /// memory problems. For example, specifying the wrong allocator
+    /// may corrupt the allocator state.
+    ///
+    /// [`Box::from_raw`]: struct.Box.html#method.from_raw
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #![feature(allocator_api)]
+    /// use std::alloc::Global;
+    /// let x = Box::new_in(5, Global);
+    /// let ptr = Box::into_raw(x);
+    /// let x = unsafe { Box::from_raw_in(ptr, Global) };
+    /// ```
+    #[unstable(feature = "allocator_api", issue = "32838")]
+    #[inline]
+    pub unsafe fn from_raw_in(raw: *mut T, a: A) -> Self {
+        Box(Unique::new_unchecked(raw), a)
     }
 
+    /// Maps a `Box<T, A>` to `Box<U, A>` by applying a function to the
+    /// raw pointer.
+    #[unstable(feature = "allocator_api", issue = "32838")]
+    #[inline]
+    pub unsafe fn map_raw<U: ?Sized, F: FnOnce(*mut T) -> *mut U>(b: Box<T, A>, f: F) -> Box<U, A> {
+        let a = ptr::read(&b.1);
+        Box::from_raw_in(f(Box::into_raw(b)), a)
+    }
+}
+
+impl<T: ?Sized, A> Box<T, A> {
     /// Consumes the `Box`, returning a wrapped raw pointer.
     ///
     /// The pointer will be properly aligned and non-null.
@@ -210,7 +293,7 @@ impl<T: ?Sized> Box<T> {
     /// [`Box::from_raw`]: struct.Box.html#method.from_raw
     #[stable(feature = "box_raw", since = "1.4.0")]
     #[inline]
-    pub fn into_raw(b: Box<T>) -> *mut T {
+    pub fn into_raw(b: Box<T, A>) -> *mut T {
         Box::into_raw_non_null(b).as_ptr()
     }
 
@@ -246,14 +329,14 @@ impl<T: ?Sized> Box<T> {
     /// ```
     #[unstable(feature = "box_into_raw_non_null", issue = "47336")]
     #[inline]
-    pub fn into_raw_non_null(b: Box<T>) -> NonNull<T> {
+    pub fn into_raw_non_null(b: Box<T, A>) -> NonNull<T> {
         Box::into_unique(b).into()
     }
 
     #[unstable(feature = "ptr_internals", issue = "0", reason = "use into_raw_non_null instead")]
     #[inline]
     #[doc(hidden)]
-    pub fn into_unique(b: Box<T>) -> Unique<T> {
+    pub fn into_unique(b: Box<T, A>) -> Unique<T> {
         let mut unique = b.0;
         mem::forget(b);
         // Box is kind-of a library type, but recognized as a "unique pointer" by
@@ -308,7 +391,7 @@ impl<T: ?Sized> Box<T> {
     /// ```
     #[stable(feature = "box_leak", since = "1.26.0")]
     #[inline]
-    pub fn leak<'a>(b: Box<T>) -> &'a mut T
+    pub fn leak<'a>(b: Box<T, A>) -> &'a mut T
     where
         T: 'a // Technically not needed, but kept to be explicit.
     {
@@ -321,7 +404,7 @@ impl<T: ?Sized> Box<T> {
     ///
     /// This is also available via [`From`].
     #[unstable(feature = "box_into_pin", issue = "0")]
-    pub fn into_pin(boxed: Box<T>) -> Pin<Box<T>> {
+    pub fn into_pin(boxed: Box<T, A>) -> Pin<Box<T, A>> {
         // It's not possible to move or replace the insides of a `Pin<Box<T>>`
         // when `T: !Unpin`,  so it's safe to pin it directly without any
         // additional requirements.
@@ -330,36 +413,36 @@ impl<T: ?Sized> Box<T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-unsafe impl<#[may_dangle] T: ?Sized> Drop for Box<T> {
+unsafe impl<#[may_dangle] T: ?Sized, A> Drop for Box<T, A> {
     fn drop(&mut self) {
         // FIXME: Do nothing, drop is currently performed by compiler.
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: Default> Default for Box<T> {
-    /// Creates a `Box<T>`, with the `Default` value for T.
-    fn default() -> Box<T> {
-        box Default::default()
+impl<T: Default, A: Alloc + Default> Default for Box<T, A> {
+    /// Creates a `Box<T, A>`, with the `Default` value for T.
+    fn default() -> Box<T, A> {
+        Box::new_in(Default::default(), A::default())
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T> Default for Box<[T]> {
-    fn default() -> Box<[T]> {
-        Box::<[T; 0]>::new([])
+impl<T, A: Alloc + Default> Default for Box<[T], A> {
+    fn default() -> Box<[T], A> {
+        Box::<[T; 0], A>::new_in([], A::default())
     }
 }
 
 #[stable(feature = "default_box_extra", since = "1.17.0")]
-impl Default for Box<str> {
-    fn default() -> Box<str> {
+impl<A: Alloc + Default> Default for Box<str, A> {
+    fn default() -> Box<str, A> {
         unsafe { from_boxed_utf8_unchecked(Default::default()) }
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: Clone> Clone for Box<T> {
+impl<T: Clone, A: Alloc + Clone> Clone for Box<T, A> {
     /// Returns a new box with a `clone()` of this box's contents.
     ///
     /// # Examples
@@ -370,8 +453,8 @@ impl<T: Clone> Clone for Box<T> {
     /// ```
     #[rustfmt::skip]
     #[inline]
-    fn clone(&self) -> Box<T> {
-        box { (**self).clone() }
+    fn clone(&self) -> Box<T, A> {
+        Box::new_in((**self).clone(), self.1.clone())
     }
     /// Copies `source`'s contents into `self` without creating a new allocation.
     ///
@@ -386,17 +469,17 @@ impl<T: Clone> Clone for Box<T> {
     /// assert_eq!(*y, 5);
     /// ```
     #[inline]
-    fn clone_from(&mut self, source: &Box<T>) {
+    fn clone_from(&mut self, source: &Box<T, A>) {
         (**self).clone_from(&(**source));
     }
 }
 
 
 #[stable(feature = "box_slice_clone", since = "1.3.0")]
-impl Clone for Box<str> {
+impl<A: Alloc + Clone> Clone for Box<str, A> {
     fn clone(&self) -> Self {
         // this makes a copy of the data
-        let buf: Box<[u8]> = self.as_bytes().into();
+        let buf = Box::<[u8], A>::from_slice_in(self.as_bytes(), self.1.clone());
         unsafe {
             from_boxed_utf8_unchecked(buf)
         }
@@ -404,58 +487,58 @@ impl Clone for Box<str> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized + PartialEq> PartialEq for Box<T> {
+impl<T: ?Sized + PartialEq, A> PartialEq for Box<T, A> {
     #[inline]
-    fn eq(&self, other: &Box<T>) -> bool {
+    fn eq(&self, other: &Box<T, A>) -> bool {
         PartialEq::eq(&**self, &**other)
     }
     #[inline]
-    fn ne(&self, other: &Box<T>) -> bool {
+    fn ne(&self, other: &Box<T, A>) -> bool {
         PartialEq::ne(&**self, &**other)
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized + PartialOrd> PartialOrd for Box<T> {
+impl<T: ?Sized + PartialOrd, A> PartialOrd for Box<T, A> {
     #[inline]
-    fn partial_cmp(&self, other: &Box<T>) -> Option<Ordering> {
+    fn partial_cmp(&self, other: &Box<T, A>) -> Option<Ordering> {
         PartialOrd::partial_cmp(&**self, &**other)
     }
     #[inline]
-    fn lt(&self, other: &Box<T>) -> bool {
+    fn lt(&self, other: &Box<T, A>) -> bool {
         PartialOrd::lt(&**self, &**other)
     }
     #[inline]
-    fn le(&self, other: &Box<T>) -> bool {
+    fn le(&self, other: &Box<T, A>) -> bool {
         PartialOrd::le(&**self, &**other)
     }
     #[inline]
-    fn ge(&self, other: &Box<T>) -> bool {
+    fn ge(&self, other: &Box<T, A>) -> bool {
         PartialOrd::ge(&**self, &**other)
     }
     #[inline]
-    fn gt(&self, other: &Box<T>) -> bool {
+    fn gt(&self, other: &Box<T, A>) -> bool {
         PartialOrd::gt(&**self, &**other)
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized + Ord> Ord for Box<T> {
+impl<T: ?Sized + Ord, A> Ord for Box<T, A> {
     #[inline]
-    fn cmp(&self, other: &Box<T>) -> Ordering {
+    fn cmp(&self, other: &Box<T, A>) -> Ordering {
         Ord::cmp(&**self, &**other)
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized + Eq> Eq for Box<T> {}
+impl<T: ?Sized + Eq, A> Eq for Box<T, A> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized + Hash> Hash for Box<T> {
+impl<T: ?Sized + Hash, A> Hash for Box<T, A> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         (**self).hash(state);
     }
 }
 
 #[stable(feature = "indirect_hasher_impl", since = "1.22.0")]
-impl<T: ?Sized + Hasher> Hasher for Box<T> {
+impl<T: ?Sized + Hasher, A> Hasher for Box<T, A> {
     fn finish(&self) -> u64 {
         (**self).finish()
     }
@@ -501,7 +584,7 @@ impl<T: ?Sized + Hasher> Hasher for Box<T> {
 }
 
 #[stable(feature = "from_for_ptrs", since = "1.6.0")]
-impl<T> From<T> for Box<T> {
+impl<T, A: Alloc + Default> From<T> for Box<T, A> {
     /// Converts a generic type `T` into a `Box<T>`
     ///
     /// The conversion allocates on the heap and moves `t`
@@ -515,22 +598,33 @@ impl<T> From<T> for Box<T> {
     /// assert_eq!(Box::from(x), boxed);
     /// ```
     fn from(t: T) -> Self {
-        Box::new(t)
+        Box::new_in(t, A::default())
     }
 }
 
 #[stable(feature = "pin", since = "1.33.0")]
-impl<T: ?Sized> From<Box<T>> for Pin<Box<T>> {
+impl<T: ?Sized, A> From<Box<T, A>> for Pin<Box<T, A>> {
     /// Converts a `Box<T>` into a `Pin<Box<T>>`
     ///
     /// This conversion does not allocate on the heap and happens in place.
-    fn from(boxed: Box<T>) -> Self {
+    fn from(boxed: Box<T, A>) -> Self {
         Box::into_pin(boxed)
     }
 }
 
+impl<T: Copy, A: Alloc> Box<[T], A> {
+    fn from_slice_in(slice: &[T], a: A) -> Box<[T], A> {
+        let len = slice.len();
+        let buf = RawVec::with_capacity_in(len, a);
+        unsafe {
+            ptr::copy_nonoverlapping(slice.as_ptr(), buf.ptr(), len);
+            buf.into_box()
+        }
+    }
+}
+
 #[stable(feature = "box_from_slice", since = "1.17.0")]
-impl<T: Copy> From<&[T]> for Box<[T]> {
+impl<T: Copy, A: Alloc + Default> From<&[T]> for Box<[T], A> {
     /// Converts a `&[T]` into a `Box<[T]>`
     ///
     /// This conversion allocates on the heap
@@ -544,18 +638,13 @@ impl<T: Copy> From<&[T]> for Box<[T]> {
     ///
     /// println!("{:?}", boxed_slice);
     /// ```
-    fn from(slice: &[T]) -> Box<[T]> {
-        let len = slice.len();
-        let buf = RawVec::with_capacity(len);
-        unsafe {
-            ptr::copy_nonoverlapping(slice.as_ptr(), buf.ptr(), len);
-            buf.into_box()
-        }
+    fn from(slice: &[T]) -> Box<[T], A> {
+        Box::<_, _>::from_slice_in(slice, A::default())
     }
 }
 
 #[stable(feature = "box_from_slice", since = "1.17.0")]
-impl From<&str> for Box<str> {
+impl<A: Alloc + Default> From<&str> for Box<str, A> {
     /// Converts a `&str` into a `Box<str>`
     ///
     /// This conversion allocates on the heap
@@ -567,13 +656,13 @@ impl From<&str> for Box<str> {
     /// println!("{}", boxed);
     /// ```
     #[inline]
-    fn from(s: &str) -> Box<str> {
+    fn from(s: &str) -> Box<str, A> {
         unsafe { from_boxed_utf8_unchecked(Box::from(s.as_bytes())) }
     }
 }
 
 #[stable(feature = "boxed_str_conv", since = "1.19.0")]
-impl From<Box<str>> for Box<[u8]> {
+impl<A: Alloc> From<Box<str, A>> for Box<[u8], A> {
     /// Converts a `Box<str>>` into a `Box<[u8]>`
     ///
     /// This conversion does not allocate on the heap and happens in place.
@@ -591,12 +680,12 @@ impl From<Box<str>> for Box<[u8]> {
     /// assert_eq!(boxed_slice, boxed_str);
     /// ```
     #[inline]
-    fn from(s: Box<str>) -> Self {
-        unsafe { Box::from_raw(Box::into_raw(s) as *mut [u8]) }
+    fn from(s: Box<str, A>) -> Self {
+        unsafe { Box::map_raw(s, |p| p as *mut [u8]) }
     }
 }
 
-impl Box<dyn Any> {
+impl<A: Alloc> Box<dyn Any, A> {
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     /// Attempt to downcast the box to a concrete type.
@@ -618,19 +707,16 @@ impl Box<dyn Any> {
     ///     print_if_string(Box::new(0i8));
     /// }
     /// ```
-    pub fn downcast<T: Any>(self) -> Result<Box<T>, Box<dyn Any>> {
+    pub fn downcast<T: Any>(self) -> Result<Box<T, A>, Box<dyn Any, A>> {
         if self.is::<T>() {
-            unsafe {
-                let raw: *mut dyn Any = Box::into_raw(self);
-                Ok(Box::from_raw(raw as *mut T))
-            }
+            unsafe { Ok(Box::map_raw(self, |p| p as *mut T)) }
         } else {
             Err(self)
         }
     }
 }
 
-impl Box<dyn Any + Send> {
+impl<A: Alloc> Box<dyn Any + Send, A> {
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     /// Attempt to downcast the box to a concrete type.
@@ -652,30 +738,30 @@ impl Box<dyn Any + Send> {
     ///     print_if_string(Box::new(0i8));
     /// }
     /// ```
-    pub fn downcast<T: Any>(self) -> Result<Box<T>, Box<dyn Any + Send>> {
-        <Box<dyn Any>>::downcast(self).map_err(|s| unsafe {
+    pub fn downcast<T: Any>(self) -> Result<Box<T, A>, Box<dyn Any + Send, A>> {
+        <Box<dyn Any, A>>::downcast(self).map_err(|s| unsafe {
             // reapply the Send marker
-            Box::from_raw(Box::into_raw(s) as *mut (dyn Any + Send))
+            Box::map_raw(s, |p| p as *mut (dyn Any + Send))
         })
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: fmt::Display + ?Sized> fmt::Display for Box<T> {
+impl<T: fmt::Display + ?Sized, A> fmt::Display for Box<T, A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&**self, f)
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: fmt::Debug + ?Sized> fmt::Debug for Box<T> {
+impl<T: fmt::Debug + ?Sized, A> fmt::Debug for Box<T, A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&**self, f)
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized> fmt::Pointer for Box<T> {
+impl<T: ?Sized, A> fmt::Pointer for Box<T, A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // It's not possible to extract the inner Uniq directly from the Box,
         // instead we cast it to a *const which aliases the Unique
@@ -685,7 +771,7 @@ impl<T: ?Sized> fmt::Pointer for Box<T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized> Deref for Box<T> {
+impl<T: ?Sized, A> Deref for Box<T, A> {
     type Target = T;
 
     fn deref(&self) -> &T {
@@ -694,17 +780,17 @@ impl<T: ?Sized> Deref for Box<T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized> DerefMut for Box<T> {
+impl<T: ?Sized, A> DerefMut for Box<T, A> {
     fn deref_mut(&mut self) -> &mut T {
         &mut **self
     }
 }
 
 #[unstable(feature = "receiver_trait", issue = "0")]
-impl<T: ?Sized> Receiver for Box<T> {}
+impl<T: ?Sized, A> Receiver for Box<T, A> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<I: Iterator + ?Sized> Iterator for Box<I> {
+impl<I: Iterator + ?Sized, A> Iterator for Box<I, A> {
     type Item = I::Item;
     fn next(&mut self) -> Option<I::Item> {
         (**self).next()
@@ -717,7 +803,7 @@ impl<I: Iterator + ?Sized> Iterator for Box<I> {
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<I: DoubleEndedIterator + ?Sized> DoubleEndedIterator for Box<I> {
+impl<I: DoubleEndedIterator + ?Sized, A> DoubleEndedIterator for Box<I, A> {
     fn next_back(&mut self) -> Option<I::Item> {
         (**self).next_back()
     }
@@ -726,7 +812,7 @@ impl<I: DoubleEndedIterator + ?Sized> DoubleEndedIterator for Box<I> {
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<I: ExactSizeIterator + ?Sized> ExactSizeIterator for Box<I> {
+impl<I: ExactSizeIterator + ?Sized, A> ExactSizeIterator for Box<I, A> {
     fn len(&self) -> usize {
         (**self).len()
     }
@@ -736,10 +822,10 @@ impl<I: ExactSizeIterator + ?Sized> ExactSizeIterator for Box<I> {
 }
 
 #[stable(feature = "fused", since = "1.26.0")]
-impl<I: FusedIterator + ?Sized> FusedIterator for Box<I> {}
+impl<I: FusedIterator + ?Sized, A> FusedIterator for Box<I, A> {}
 
 #[stable(feature = "boxed_closure_impls", since = "1.35.0")]
-impl<A, F: FnOnce<A> + ?Sized> FnOnce<A> for Box<F> {
+impl<A, F: FnOnce<A> + ?Sized, Alloc> FnOnce<A> for Box<F, Alloc> {
     type Output = <F as FnOnce<A>>::Output;
 
     extern "rust-call" fn call_once(self, args: A) -> Self::Output {
@@ -748,14 +834,14 @@ impl<A, F: FnOnce<A> + ?Sized> FnOnce<A> for Box<F> {
 }
 
 #[stable(feature = "boxed_closure_impls", since = "1.35.0")]
-impl<A, F: FnMut<A> + ?Sized> FnMut<A> for Box<F> {
+impl<A, F: FnMut<A> + ?Sized, Alloc> FnMut<A> for Box<F, Alloc> {
     extern "rust-call" fn call_mut(&mut self, args: A) -> Self::Output {
         <F as FnMut<A>>::call_mut(self, args)
     }
 }
 
 #[stable(feature = "boxed_closure_impls", since = "1.35.0")]
-impl<A, F: Fn<A> + ?Sized> Fn<A> for Box<F> {
+impl<A, F: Fn<A> + ?Sized, Alloc> Fn<A> for Box<F, Alloc> {
     extern "rust-call" fn call(&self, args: A) -> Self::Output {
         <F as Fn<A>>::call(self, args)
     }
@@ -841,8 +927,9 @@ impl<A, F> FnBox<A> for F
 }
 
 #[unstable(feature = "coerce_unsized", issue = "27732")]
-impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<Box<U>> for Box<T> {}
+impl<T: ?Sized + Unsize<U>, U: ?Sized, A> CoerceUnsized<Box<U, A>> for Box<T, A> {}
 
+//FIXME: Make generic over A when the compiler supports it.
 #[unstable(feature = "dispatch_from_dyn", issue = "0")]
 impl<T: ?Sized + Unsize<U>, U: ?Sized> DispatchFromDyn<Box<U>> for Box<T> {}
 
@@ -854,10 +941,10 @@ impl<A> FromIterator<A> for Box<[A]> {
 }
 
 #[stable(feature = "box_slice_clone", since = "1.3.0")]
-impl<T: Clone> Clone for Box<[T]> {
+impl<T: Clone, A: Alloc + Clone> Clone for Box<[T], A> {
     fn clone(&self) -> Self {
         let mut new = BoxBuilder {
-            data: RawVec::with_capacity(self.len()),
+            data: RawVec::with_capacity_in(self.len(), self.1.clone()),
             len: 0,
         };
 
@@ -875,20 +962,20 @@ impl<T: Clone> Clone for Box<[T]> {
         return unsafe { new.into_box() };
 
         // Helper type for responding to panics correctly.
-        struct BoxBuilder<T> {
-            data: RawVec<T>,
+        struct BoxBuilder<T, A: Alloc> {
+            data: RawVec<T, A>,
             len: usize,
         }
 
-        impl<T> BoxBuilder<T> {
-            unsafe fn into_box(self) -> Box<[T]> {
+        impl<T, A: Alloc> BoxBuilder<T, A> {
+            unsafe fn into_box(self) -> Box<[T], A> {
                 let raw = ptr::read(&self.data);
                 mem::forget(self);
                 raw.into_box()
             }
         }
 
-        impl<T> Drop for BoxBuilder<T> {
+        impl<T, A: Alloc> Drop for BoxBuilder<T, A> {
             fn drop(&mut self) {
                 let mut data = self.data.ptr();
                 let max = unsafe { data.add(self.len) };
@@ -905,28 +992,28 @@ impl<T: Clone> Clone for Box<[T]> {
 }
 
 #[stable(feature = "box_borrow", since = "1.1.0")]
-impl<T: ?Sized> borrow::Borrow<T> for Box<T> {
+impl<T: ?Sized, A> borrow::Borrow<T> for Box<T, A> {
     fn borrow(&self) -> &T {
         &**self
     }
 }
 
 #[stable(feature = "box_borrow", since = "1.1.0")]
-impl<T: ?Sized> borrow::BorrowMut<T> for Box<T> {
+impl<T: ?Sized, A> borrow::BorrowMut<T> for Box<T, A> {
     fn borrow_mut(&mut self) -> &mut T {
         &mut **self
     }
 }
 
 #[stable(since = "1.5.0", feature = "smart_ptr_as_ref")]
-impl<T: ?Sized> AsRef<T> for Box<T> {
+impl<T: ?Sized, A> AsRef<T> for Box<T, A> {
     fn as_ref(&self) -> &T {
         &**self
     }
 }
 
 #[stable(since = "1.5.0", feature = "smart_ptr_as_ref")]
-impl<T: ?Sized> AsMut<T> for Box<T> {
+impl<T: ?Sized, A> AsMut<T> for Box<T, A> {
     fn as_mut(&mut self) -> &mut T {
         &mut **self
     }
@@ -955,10 +1042,10 @@ impl<T: ?Sized> AsMut<T> for Box<T> {
  *  could have a method to project a Pin<T> from it.
  */
 #[stable(feature = "pin", since = "1.33.0")]
-impl<T: ?Sized> Unpin for Box<T> { }
+impl<T: ?Sized, A> Unpin for Box<T, A> { }
 
 #[unstable(feature = "generator_trait", issue = "43122")]
-impl<G: ?Sized + Generator + Unpin> Generator for Box<G> {
+impl<G: ?Sized + Generator + Unpin, A> Generator for Box<G, A> {
     type Yield = G::Yield;
     type Return = G::Return;
 
@@ -968,7 +1055,7 @@ impl<G: ?Sized + Generator + Unpin> Generator for Box<G> {
 }
 
 #[unstable(feature = "generator_trait", issue = "43122")]
-impl<G: ?Sized + Generator> Generator for Pin<Box<G>> {
+impl<G: ?Sized + Generator, A> Generator for Pin<Box<G, A>> {
     type Yield = G::Yield;
     type Return = G::Return;
 
@@ -978,7 +1065,7 @@ impl<G: ?Sized + Generator> Generator for Pin<Box<G>> {
 }
 
 #[stable(feature = "futures_api", since = "1.36.0")]
-impl<F: ?Sized + Future + Unpin> Future for Box<F> {
+impl<F: ?Sized + Future + Unpin, A> Future for Box<F, A> {
     type Output = F::Output;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {

--- a/src/liballoc/raw_vec.rs
+++ b/src/liballoc/raw_vec.rs
@@ -682,8 +682,8 @@ impl<T, A: Alloc> RawVec<T, A> {
 
 }
 
-impl<T> RawVec<T, Global> {
-    /// Converts the entire buffer into `Box<[T]>`.
+impl<T, A: Alloc> RawVec<T, A> {
+    /// Converts the entire buffer into `Box<[T], A>`.
     ///
     /// Note that this will correctly reconstitute any `cap` changes
     /// that may have been performed. (see description of type for details)
@@ -693,10 +693,11 @@ impl<T> RawVec<T, Global> {
     /// All elements of `RawVec<T, Global>` must be initialized. Notice that
     /// the rules around uninitialized boxed values are not finalized yet,
     /// but until they are, it is advisable to avoid them.
-    pub unsafe fn into_box(self) -> Box<[T]> {
+    pub unsafe fn into_box(self) -> Box<[T], A> {
         // NOTE: not calling `cap()` here, actually using the real `cap` field!
         let slice = slice::from_raw_parts_mut(self.ptr(), self.cap);
-        let output: Box<[T]> = Box::from_raw(slice);
+        let a = ptr::read(&self.a);
+        let output: Box<[T], A> = Box::from_raw_in(slice, a);
         mem::forget(self);
         output
     }

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -729,7 +729,7 @@ impl<T: ?Sized> Rc<T> {
                 value_size);
 
             // Free the allocation without dropping its contents
-            box_free(box_unique);
+            box_free::<_, Global>(box_unique, Global);
 
             Rc { ptr: NonNull::new_unchecked(ptr), phantom: PhantomData }
         }

--- a/src/liballoc/str.rs
+++ b/src/liballoc/str.rs
@@ -35,6 +35,7 @@ use core::ptr;
 use core::iter::FusedIterator;
 use core::unicode::conversions;
 
+use crate::alloc::Alloc;
 use crate::borrow::ToOwned;
 use crate::boxed::Box;
 use crate::slice::{SliceConcatExt, SliceIndex};
@@ -585,6 +586,6 @@ impl str {
 /// ```
 #[stable(feature = "str_box_extras", since = "1.20.0")]
 #[inline]
-pub unsafe fn from_boxed_utf8_unchecked(v: Box<[u8]>) -> Box<str> {
-    Box::from_raw(Box::into_raw(v) as *mut str)
+pub unsafe fn from_boxed_utf8_unchecked<A: Alloc>(v: Box<[u8], A>) -> Box<str, A> {
+    Box::map_raw(v, |p| p as *mut str)
 }

--- a/src/liballoc/sync.rs
+++ b/src/liballoc/sync.rs
@@ -615,7 +615,7 @@ impl<T: ?Sized> Arc<T> {
                 value_size);
 
             // Free the allocation without dropping its contents
-            box_free(box_unique);
+            box_free::<_, Global>(box_unique, Global);
 
             Arc { ptr: NonNull::new_unchecked(ptr), phantom: PhantomData }
         }

--- a/src/liballoc/tests/heap.rs
+++ b/src/liballoc/tests/heap.rs
@@ -1,4 +1,4 @@
-use std::alloc::{Global, Alloc, Layout, System};
+use std::alloc::{GlobalAlloc, Layout, System};
 
 /// Issue #45955.
 #[test]
@@ -6,21 +6,16 @@ fn alloc_system_overaligned_request() {
     check_overalign_requests(System)
 }
 
-#[test]
-fn std_heap_overaligned_request() {
-    check_overalign_requests(Global)
-}
-
-fn check_overalign_requests<T: Alloc>(mut allocator: T) {
+fn check_overalign_requests<T: GlobalAlloc>(allocator: T) {
     let size = 8;
     let align = 16; // greater than size
     let iterations = 100;
     unsafe {
         let pointers: Vec<_> = (0..iterations).map(|_| {
-            allocator.alloc(Layout::from_size_align(size, align).unwrap()).unwrap()
+            allocator.alloc(Layout::from_size_align(size, align).unwrap())
         }).collect();
         for &ptr in &pointers {
-            assert_eq!((ptr.as_ptr() as usize) % align, 0,
+            assert_eq!((ptr as usize) % align, 0,
                        "Got a pointer less aligned than requested")
         }
 

--- a/src/libstd/alloc.rs
+++ b/src/libstd/alloc.rs
@@ -63,7 +63,6 @@
 
 use core::sync::atomic::{AtomicPtr, Ordering};
 use core::{mem, ptr};
-use core::ptr::NonNull;
 
 use crate::sys_common::util::dumb_print;
 
@@ -132,33 +131,6 @@ pub use alloc_crate::alloc::*;
 #[stable(feature = "alloc_system_type", since = "1.28.0")]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct System;
-
-// The Alloc impl just forwards to the GlobalAlloc impl, which is in `std::sys::*::alloc`.
-#[unstable(feature = "allocator_api", issue = "32838")]
-unsafe impl Alloc for System {
-    #[inline]
-    unsafe fn alloc(&mut self, layout: Layout) -> Result<NonNull<u8>, AllocErr> {
-        NonNull::new(GlobalAlloc::alloc(self, layout)).ok_or(AllocErr)
-    }
-
-    #[inline]
-    unsafe fn alloc_zeroed(&mut self, layout: Layout) -> Result<NonNull<u8>, AllocErr> {
-        NonNull::new(GlobalAlloc::alloc_zeroed(self, layout)).ok_or(AllocErr)
-    }
-
-    #[inline]
-    unsafe fn dealloc(&mut self, ptr: NonNull<u8>, layout: Layout) {
-        GlobalAlloc::dealloc(self, ptr.as_ptr(), layout)
-    }
-
-    #[inline]
-    unsafe fn realloc(&mut self,
-                      ptr: NonNull<u8>,
-                      layout: Layout,
-                      new_size: usize) -> Result<NonNull<u8>, AllocErr> {
-        NonNull::new(GlobalAlloc::realloc(self, ptr.as_ptr(), layout, new_size)).ok_or(AllocErr)
-    }
-}
 
 static HOOK: AtomicPtr<()> = AtomicPtr::new(ptr::null_mut());
 

--- a/src/test/run-pass/allocator/custom.rs
+++ b/src/test/run-pass/allocator/custom.rs
@@ -7,14 +7,14 @@
 
 extern crate helper;
 
-use std::alloc::{self, Global, Alloc, System, Layout};
+use std::alloc::{Global, Alloc, GlobalAlloc, System, Layout};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 static HITS: AtomicUsize = AtomicUsize::new(0);
 
 struct A;
 
-unsafe impl alloc::GlobalAlloc for A {
+unsafe impl GlobalAlloc for A {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         HITS.fetch_add(1, Ordering::SeqCst);
         System.alloc(layout)
@@ -49,7 +49,7 @@ fn main() {
         drop(s);
         assert_eq!(HITS.load(Ordering::SeqCst), n + 4);
 
-        let ptr = System.alloc(layout.clone()).unwrap();
+        let ptr = System.alloc(layout.clone());
         assert_eq!(HITS.load(Ordering::SeqCst), n + 4);
         helper::work_with(&ptr);
         System.dealloc(ptr, layout);

--- a/src/test/run-pass/allocator/xcrate-use.rs
+++ b/src/test/run-pass/allocator/xcrate-use.rs
@@ -9,7 +9,7 @@
 extern crate custom;
 extern crate helper;
 
-use std::alloc::{Global, Alloc, System, Layout};
+use std::alloc::{Global, Alloc, GlobalAlloc, System, Layout};
 use std::sync::atomic::{Ordering, AtomicUsize};
 
 #[global_allocator]
@@ -26,7 +26,7 @@ fn main() {
         Global.dealloc(ptr, layout.clone());
         assert_eq!(GLOBAL.0.load(Ordering::SeqCst), n + 2);
 
-        let ptr = System.alloc(layout.clone()).unwrap();
+        let ptr = System.alloc(layout.clone());
         assert_eq!(GLOBAL.0.load(Ordering::SeqCst), n + 2);
         helper::work_with(&ptr);
         System.dealloc(ptr, layout);

--- a/src/test/ui/error-codes/e0119/conflict-with-std.stderr
+++ b/src/test/ui/error-codes/e0119/conflict-with-std.stderr
@@ -5,7 +5,7 @@ LL | impl AsRef<Q> for Box<Q> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: conflicting implementation in crate `alloc`:
-           - impl<T> std::convert::AsRef<T> for std::boxed::Box<T>
+           - impl<T, A> std::convert::AsRef<T> for std::boxed::Box<T, A>
              where T: ?Sized;
 
 error[E0119]: conflicting implementations of trait `std::convert::From<S>` for type `S`:

--- a/src/test/ui/issues/issue-14092.rs
+++ b/src/test/ui/issues/issue-14092.rs
@@ -1,4 +1,4 @@
 fn fn1(0: Box) {}
-        //~^ ERROR wrong number of type arguments: expected 1, found 0 [E0107]
+        //~^ ERROR wrong number of type arguments: expected at least 1, found 0 [E0107]
 
 fn main() {}

--- a/src/test/ui/issues/issue-14092.stderr
+++ b/src/test/ui/issues/issue-14092.stderr
@@ -1,8 +1,8 @@
-error[E0107]: wrong number of type arguments: expected 1, found 0
+error[E0107]: wrong number of type arguments: expected at least 1, found 0
   --> $DIR/issue-14092.rs:1:11
    |
 LL | fn fn1(0: Box) {}
-   |           ^^^ expected 1 type argument
+   |           ^^^ expected at least 1 type argument
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-41974.stderr
+++ b/src/test/ui/issues/issue-41974.stderr
@@ -1,13 +1,13 @@
-error[E0119]: conflicting implementations of trait `std::ops::Drop` for type `std::boxed::Box<_>`:
+error[E0119]: conflicting implementations of trait `std::ops::Drop` for type `std::boxed::Box<_, _>`:
   --> $DIR/issue-41974.rs:7:1
    |
 LL | impl<T> Drop for T where T: A {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: conflicting implementation in crate `alloc`:
-           - impl<T> std::ops::Drop for std::boxed::Box<T>
+           - impl<T, A> std::ops::Drop for std::boxed::Box<T, A>
              where T: ?Sized;
-   = note: downstream crates may implement trait `A` for type `std::boxed::Box<_>`
+   = note: downstream crates may implement trait `A` for type `std::boxed::Box<_, _>`
 
 error[E0120]: the Drop trait may only be implemented on structures
   --> $DIR/issue-41974.rs:7:18


### PR DESCRIPTION
This turns `Box<T>` into `Box<T, A = Global>`, with a `A: Alloc` bound
for impls.

Ideally, inherent methods like `Box::new` would be applied to
`Box<T, A: Alloc + Default>`, but as of now, that would be backwards
incompatible because it would require type annotations in places where
they currently aren't required.

`impl FromIterator` is not covered because it relies on `Vec`, which
would need allocator awareness.

`DispatchFromDyn` is left out or being generic over `A` because there
is no bound that would make it work currently. `FnBox` is left out
because it's related to `DispatchFromDyn`.
