### PR TITLE
Tweak `Span` encoding.

### DIFF
--- a/src/libsyntax_pos/span_encoding.rs
+++ b/src/libsyntax_pos/span_encoding.rs
@@ -74,12 +74,12 @@ const CTXT_INDEX: usize = 2;
 
 // Tag = 0, inline format.
 // -------------------------------------------------------------
-// | base 31:8  | len 7:1  | ctxt (currently 0 bits) | tag 0:0 |
+// | base 31:7  | len 6:1  | ctxt (currently 0 bits) | tag 0:0 |
 // -------------------------------------------------------------
 // Since there are zero bits for ctxt, only SpanData with a 0 SyntaxContext
 // can be inline.
-const INLINE_SIZES: [u32; 3] = [24, 7, 0];
-const INLINE_OFFSETS: [u32; 3] = [8, 1, 1];
+const INLINE_SIZES: [u32; 3] = [25, 6, 0];
+const INLINE_OFFSETS: [u32; 3] = [7, 1, 1];
 
 // Tag = 1, interned format.
 // ------------------------


### PR DESCRIPTION
Failing to fit `base` is more common than failing to fit `len`.