### PR TITLE
tidy: Accept CC0-1.0 license

### DIFF
--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -16,6 +16,7 @@ const LICENSES: &[&str] = &[
     "MIT",
     "Unlicense/MIT",
     "Unlicense OR MIT",
+    "CC0-1.0",
 ];
 
 /// These are exceptions to Rust's permissive licensing policy, and


### PR DESCRIPTION
It's very permissive license.

CC https://github.com/rust-lang/rust/pull/58337