### PR TITLE
split MaybeUninit into several features, expand docs a bit

### DIFF
--- a/src/liballoc/collections/btree/node.rs
+++ b/src/liballoc/collections/btree/node.rs
@@ -453,7 +453,7 @@ impl<BorrowType, K, V, Type> NodeRef<BorrowType, K, V, Type> {
                     root: self.root,
                     _marker: PhantomData
                 },
-                idx: unsafe { usize::from(*self.as_header().parent_idx.get_ref()) },
+                idx: unsafe { usize::from(*self.as_header().parent_idx.as_ptr()) },
                 _marker: PhantomData
             })
         } else {
@@ -1143,7 +1143,7 @@ impl<BorrowType, K, V>
         NodeRef {
             height: self.node.height - 1,
             node: unsafe {
-                self.node.as_internal().edges.get_unchecked(self.idx).get_ref().as_ptr()
+                (&*self.node.as_internal().edges.get_unchecked(self.idx).as_ptr()).as_ptr()
             },
             root: self.node.root,
             _marker: PhantomData

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -112,7 +112,7 @@
 #![feature(rustc_const_unstable)]
 #![feature(const_vec_new)]
 #![feature(slice_partition_dedup)]
-#![feature(maybe_uninit)]
+#![feature(maybe_uninit, maybe_uninit_slice)]
 #![feature(alloc_layout_extra)]
 #![feature(try_trait)]
 

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -112,7 +112,7 @@
 #![feature(rustc_const_unstable)]
 #![feature(const_vec_new)]
 #![feature(slice_partition_dedup)]
-#![feature(maybe_uninit, maybe_uninit_slice)]
+#![feature(maybe_uninit, maybe_uninit_slice, maybe_uninit_array)]
 #![feature(alloc_layout_extra)]
 #![feature(try_trait)]
 

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -122,7 +122,7 @@
 #![feature(structural_match)]
 #![feature(abi_unadjusted)]
 #![feature(adx_target_feature)]
-#![feature(maybe_uninit, maybe_uninit_slice)]
+#![feature(maybe_uninit, maybe_uninit_slice, maybe_uninit_array)]
 #![feature(unrestricted_attribute_tokens)]
 
 #[prelude_import]

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -122,7 +122,7 @@
 #![feature(structural_match)]
 #![feature(abi_unadjusted)]
 #![feature(adx_target_feature)]
-#![feature(maybe_uninit)]
+#![feature(maybe_uninit, maybe_uninit_slice)]
 #![feature(unrestricted_attribute_tokens)]
 
 #[prelude_import]

--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -567,7 +567,7 @@ macro_rules! unimplemented {
 ///
 /// [`MaybeUninit`]: mem/union.MaybeUninit.html
 #[macro_export]
-#[unstable(feature = "maybe_uninit_slice", issue = "53491")]
+#[unstable(feature = "maybe_uninit_array", issue = "53491")]
 macro_rules! uninitialized_array {
     // This `into_initialized` is safe because an array of `MaybeUninit` does not
     // require initialization.

--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -563,11 +563,11 @@ macro_rules! unimplemented {
 
 /// A macro to create an array of [`MaybeUninit`]
 ///
-/// This macro constructs and uninitialized array of the type `[MaybeUninit<K>; N]`.
+/// This macro constructs an uninitialized array of the type `[MaybeUninit<K>; N]`.
 ///
 /// [`MaybeUninit`]: mem/union.MaybeUninit.html
 #[macro_export]
-#[unstable(feature = "maybe_uninit", issue = "53491")]
+#[unstable(feature = "maybe_uninit_slice", issue = "53491")]
 macro_rules! uninitialized_array {
     // This `into_initialized` is safe because an array of `MaybeUninit` does not
     // require initialization.


### PR DESCRIPTION
This splits the `maybe_uninit` feature gate into several:

* `maybe_uninit` for what we will hopefully stabilize soon-ish.
* `maybe_uninit_ref` for creating references into `MaybeUninit`, for which the rules are not yet clear.
* `maybe_uninit_slice` for handling slices of `MaybeUninit`, which needs more API design work.
* `maybe_uninit_array` for creating arrays of `MaybeUninit` using a macro (because we don't have https://github.com/rust-lang/rust/issues/49147 yet).

Is that an okay thing to do? The goal is to help people avoid APIs we do not want to stabilize yet. I used this to make sure rustc itself does not use `get_ref` and `get_mut`.

I also extended the docs to advise against uninitialized integers -- again this is something for which the rules are still being discussed.