### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/src/etc/generate-deriving-span-tests.py
+++ b/src/etc/generate-deriving-span-tests.py
@@ -13,7 +13,7 @@ import os, stat
 TEST_DIR = os.path.abspath(
     os.path.join(os.path.dirname(__file__), '../test/ui/derives/'))
 
-TEMPLATE = """
+TEMPLATE = """\
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
 {error_deriving}

--- a/src/etc/generate-deriving-span-tests.py
+++ b/src/etc/generate-deriving-span-tests.py
@@ -8,12 +8,10 @@ derives have spans that point to the fields, rather than the
 sample usage: src/etc/generate-deriving-span-tests.py
 """
 
-import os, datetime, stat, re
+import os, stat
 
 TEST_DIR = os.path.abspath(
     os.path.join(os.path.dirname(__file__), '../test/ui/derives/'))
-
-YEAR = datetime.datetime.now().year
 
 TEMPLATE = """
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
@@ -63,18 +61,10 @@ def create_test_case(type, trait, super_traits, error_count):
 
     errors = '\n'.join('//~%s ERROR' % ('^' * n) for n in range(error_count))
     code = string.format(traits = all_traits, errors = errors)
-    return TEMPLATE.format(year = YEAR, error_deriving=error_deriving, code = code)
+    return TEMPLATE.format(error_deriving=error_deriving, code = code)
 
 def write_file(name, string):
     test_file = os.path.join(TEST_DIR, 'derives-span-%s.rs' % name)
-
-    with open(test_file) as f:
-        old_str = f.read()
-        old_str_ignoring_date = re.sub(r'^// Copyright \d+',
-                                        '// Copyright {year}'.format(year = YEAR), old_str)
-        if old_str_ignoring_date == string:
-            # if all we're doing is updating the copyright year, ignore it
-            return 0
 
     # set write permission if file exists, so it can be changed
     if os.path.exists(test_file):
@@ -85,8 +75,6 @@ def write_file(name, string):
 
     # mark file read-only
     os.chmod(test_file, stat.S_IRUSR|stat.S_IRGRP|stat.S_IROTH)
-
-    return 1
 
 
 ENUM = 1
@@ -110,15 +98,11 @@ for (trait, supers, errs) in [('Clone', [], 1),
                               ('Hash', [], 1)]:
     traits[trait] = (ALL, supers, errs)
 
-files = 0
-
 for (trait, (types, super_traits, error_count)) in traits.items():
     mk = lambda ty: create_test_case(ty, trait, super_traits, error_count)
     if types & ENUM:
-        files += write_file(trait + '-enum', mk(ENUM_TUPLE))
-        files += write_file(trait + '-enum-struct-variant', mk(ENUM_STRUCT))
+        write_file(trait + '-enum', mk(ENUM_TUPLE))
+        write_file(trait + '-enum-struct-variant', mk(ENUM_STRUCT))
     if types & STRUCT:
-        files += write_file(trait + '-struct', mk(STRUCT_FIELDS))
-        files += write_file(trait + '-tuple-struct', mk(STRUCT_TUPLE))
-
-print('Generated {files} deriving span test{}.'.format('s' if files != 1 else '', files = files))
+        write_file(trait + '-struct', mk(STRUCT_FIELDS))
+        write_file(trait + '-tuple-struct', mk(STRUCT_TUPLE))

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -202,10 +202,15 @@ impl<T: ?Sized> Box<T> {
     #[unstable(feature = "ptr_internals", issue = "0", reason = "use into_raw_non_null instead")]
     #[inline]
     #[doc(hidden)]
-    pub fn into_unique(b: Box<T>) -> Unique<T> {
-        let unique = b.0;
+    pub fn into_unique(mut b: Box<T>) -> Unique<T> {
+        // Box is kind-of a library type, but recognized as a "unique pointer" by
+        // Stacked Borrows.  This function here corresponds to "reborrowing to
+        // a raw pointer", but there is no actual reborrow here -- so
+        // without some care, the pointer we are returning here still carries
+        // the `Uniq` tag.  We round-trip through a mutable reference to avoid that.
+        let unique = unsafe { b.0.as_mut() as *mut T };
         mem::forget(b);
-        unique
+        unsafe { Unique::new_unchecked(unique) }
     }
 
     /// Consumes and leaks the `Box`, returning a mutable reference,

--- a/src/liballoc/tests/arc.rs
+++ b/src/liballoc/tests/arc.rs
@@ -1,5 +1,3 @@
-#![cfg(not(miri))]
-
 use std::any::Any;
 use std::sync::{Arc, Weak};
 use std::cell::RefCell;

--- a/src/liballoc/tests/binary_heap.rs
+++ b/src/liballoc/tests/binary_heap.rs
@@ -282,7 +282,7 @@ fn assert_covariance() {
 //
 // Destructors must be called exactly once per element.
 #[test]
-#[cfg(not(miri))]
+#[cfg(not(miri))] // Miri does not support panics
 fn panic_safe() {
     static DROP_COUNTER: AtomicUsize = AtomicUsize::new(0);
 

--- a/src/liballoc/tests/btree/map.rs
+++ b/src/liballoc/tests/btree/map.rs
@@ -7,6 +7,7 @@ use std::iter::FromIterator;
 use super::DeterministicRng;
 
 #[test]
+#[cfg(not(miri))] // Miri is too slow
 fn test_basic_large() {
     let mut map = BTreeMap::new();
     let size = 10000;
@@ -69,7 +70,10 @@ fn test_basic_small() {
 
 #[test]
 fn test_iter() {
+    #[cfg(not(miri))] // Miri is too slow
     let size = 10000;
+    #[cfg(miri)]
+    let size = 100;
 
     // Forwards
     let mut map: BTreeMap<_, _> = (0..size).map(|i| (i, i)).collect();
@@ -91,7 +95,10 @@ fn test_iter() {
 
 #[test]
 fn test_iter_rev() {
+    #[cfg(not(miri))] // Miri is too slow
     let size = 10000;
+    #[cfg(miri)]
+    let size = 100;
 
     // Forwards
     let mut map: BTreeMap<_, _> = (0..size).map(|i| (i, i)).collect();
@@ -127,7 +134,10 @@ fn test_values_mut() {
 
 #[test]
 fn test_iter_mixed() {
+    #[cfg(not(miri))] // Miri is too slow
     let size = 10000;
+    #[cfg(miri)]
+    let size = 100;
 
     // Forwards
     let mut map: BTreeMap<_, _> = (0..size).map(|i| (i, i)).collect();
@@ -214,6 +224,7 @@ fn test_range_equal_empty_cases() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_range_equal_excluded() {
     let map: BTreeMap<_, _> = (0..5).map(|i| (i, i)).collect();
     map.range((Excluded(2), Excluded(2)));
@@ -221,6 +232,7 @@ fn test_range_equal_excluded() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_range_backwards_1() {
     let map: BTreeMap<_, _> = (0..5).map(|i| (i, i)).collect();
     map.range((Included(3), Included(2)));
@@ -228,6 +240,7 @@ fn test_range_backwards_1() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_range_backwards_2() {
     let map: BTreeMap<_, _> = (0..5).map(|i| (i, i)).collect();
     map.range((Included(3), Excluded(2)));
@@ -235,6 +248,7 @@ fn test_range_backwards_2() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_range_backwards_3() {
     let map: BTreeMap<_, _> = (0..5).map(|i| (i, i)).collect();
     map.range((Excluded(3), Included(2)));
@@ -242,6 +256,7 @@ fn test_range_backwards_3() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_range_backwards_4() {
     let map: BTreeMap<_, _> = (0..5).map(|i| (i, i)).collect();
     map.range((Excluded(3), Excluded(2)));
@@ -249,7 +264,10 @@ fn test_range_backwards_4() {
 
 #[test]
 fn test_range_1000() {
+    #[cfg(not(miri))] // Miri is too slow
     let size = 1000;
+    #[cfg(miri)]
+    let size = 100;
     let map: BTreeMap<_, _> = (0..size).map(|i| (i, i)).collect();
 
     fn test(map: &BTreeMap<u32, u32>, size: u32, min: Bound<&u32>, max: Bound<&u32>) {
@@ -286,7 +304,10 @@ fn test_range_borrowed_key() {
 
 #[test]
 fn test_range() {
+    #[cfg(not(miri))] // Miri is too slow
     let size = 200;
+    #[cfg(miri)]
+    let size = 20;
     let map: BTreeMap<_, _> = (0..size).map(|i| (i, i)).collect();
 
     for i in 0..size {
@@ -305,7 +326,10 @@ fn test_range() {
 
 #[test]
 fn test_range_mut() {
+    #[cfg(not(miri))] // Miri is too slow
     let size = 200;
+    #[cfg(miri)]
+    let size = 20;
     let mut map: BTreeMap<_, _> = (0..size).map(|i| (i, i)).collect();
 
     for i in 0..size {
@@ -479,7 +503,10 @@ fn test_bad_zst() {
 #[test]
 fn test_clone() {
     let mut map = BTreeMap::new();
+    #[cfg(not(miri))] // Miri is too slow
     let size = 100;
+    #[cfg(miri)]
+    let size = 20;
     assert_eq!(map.len(), 0);
 
     for i in 0..size {
@@ -631,6 +658,7 @@ create_append_test!(test_append_145, 145);
 create_append_test!(test_append_170, 170);
 create_append_test!(test_append_181, 181);
 create_append_test!(test_append_239, 239);
+#[cfg(not(miri))] // Miri is too slow
 create_append_test!(test_append_1700, 1700);
 
 fn rand_data(len: usize) -> Vec<(u32, u32)> {

--- a/src/liballoc/tests/btree/map.rs
+++ b/src/liballoc/tests/btree/map.rs
@@ -7,10 +7,12 @@ use std::iter::FromIterator;
 use super::DeterministicRng;
 
 #[test]
-#[cfg(not(miri))] // Miri is too slow
 fn test_basic_large() {
     let mut map = BTreeMap::new();
+    #[cfg(not(miri))] // Miri is too slow
     let size = 10000;
+    #[cfg(miri)]
+    let size = 200;
     assert_eq!(map.len(), 0);
 
     for i in 0..size {
@@ -73,7 +75,7 @@ fn test_iter() {
     #[cfg(not(miri))] // Miri is too slow
     let size = 10000;
     #[cfg(miri)]
-    let size = 100;
+    let size = 200;
 
     // Forwards
     let mut map: BTreeMap<_, _> = (0..size).map(|i| (i, i)).collect();
@@ -98,7 +100,7 @@ fn test_iter_rev() {
     #[cfg(not(miri))] // Miri is too slow
     let size = 10000;
     #[cfg(miri)]
-    let size = 100;
+    let size = 200;
 
     // Forwards
     let mut map: BTreeMap<_, _> = (0..size).map(|i| (i, i)).collect();
@@ -137,7 +139,7 @@ fn test_iter_mixed() {
     #[cfg(not(miri))] // Miri is too slow
     let size = 10000;
     #[cfg(miri)]
-    let size = 100;
+    let size = 200;
 
     // Forwards
     let mut map: BTreeMap<_, _> = (0..size).map(|i| (i, i)).collect();
@@ -267,7 +269,7 @@ fn test_range_1000() {
     #[cfg(not(miri))] // Miri is too slow
     let size = 1000;
     #[cfg(miri)]
-    let size = 100;
+    let size = 200;
     let map: BTreeMap<_, _> = (0..size).map(|i| (i, i)).collect();
 
     fn test(map: &BTreeMap<u32, u32>, size: u32, min: Bound<&u32>, max: Bound<&u32>) {
@@ -307,7 +309,7 @@ fn test_range() {
     #[cfg(not(miri))] // Miri is too slow
     let size = 200;
     #[cfg(miri)]
-    let size = 20;
+    let size = 30;
     let map: BTreeMap<_, _> = (0..size).map(|i| (i, i)).collect();
 
     for i in 0..size {
@@ -329,7 +331,7 @@ fn test_range_mut() {
     #[cfg(not(miri))] // Miri is too slow
     let size = 200;
     #[cfg(miri)]
-    let size = 20;
+    let size = 30;
     let mut map: BTreeMap<_, _> = (0..size).map(|i| (i, i)).collect();
 
     for i in 0..size {
@@ -506,7 +508,7 @@ fn test_clone() {
     #[cfg(not(miri))] // Miri is too slow
     let size = 100;
     #[cfg(miri)]
-    let size = 20;
+    let size = 30;
     assert_eq!(map.len(), 0);
 
     for i in 0..size {

--- a/src/liballoc/tests/btree/mod.rs
+++ b/src/liballoc/tests/btree/mod.rs
@@ -1,5 +1,3 @@
-#![cfg(not(miri))]
-
 mod map;
 mod set;
 

--- a/src/liballoc/tests/heap.rs
+++ b/src/liballoc/tests/heap.rs
@@ -1,5 +1,3 @@
-#![cfg(not(miri))]
-
 use std::alloc::{Global, Alloc, Layout, System};
 
 /// Issue #45955.

--- a/src/liballoc/tests/rc.rs
+++ b/src/liballoc/tests/rc.rs
@@ -1,5 +1,3 @@
-#![cfg(not(miri))]
-
 use std::any::Any;
 use std::rc::{Rc, Weak};
 use std::cell::RefCell;

--- a/src/liballoc/tests/slice.rs
+++ b/src/liballoc/tests/slice.rs
@@ -1,5 +1,3 @@
-#![cfg(not(miri))]
-
 use std::cell::Cell;
 use std::cmp::Ordering::{self, Equal, Greater, Less};
 use std::mem;
@@ -260,6 +258,7 @@ fn test_swap_remove() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_swap_remove_fail() {
     let mut v = vec![1];
     let _ = v.swap_remove(0);
@@ -391,6 +390,7 @@ fn test_reverse() {
 }
 
 #[test]
+#[cfg(not(miri))] // Miri does not support entropy
 fn test_sort() {
     let mut rng = thread_rng();
 
@@ -467,6 +467,7 @@ fn test_sort() {
 }
 
 #[test]
+#[cfg(not(miri))] // Miri does not support entropy
 fn test_sort_stability() {
     for len in (2..25).chain(500..510) {
         for _ in 0..10 {
@@ -631,6 +632,7 @@ fn test_insert() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_insert_oob() {
     let mut a = vec![1, 2, 3];
     a.insert(4, 5);
@@ -655,6 +657,7 @@ fn test_remove() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_remove_fail() {
     let mut a = vec![1];
     let _ = a.remove(0);
@@ -936,6 +939,7 @@ fn test_windowsator() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_windowsator_0() {
     let v = &[1, 2, 3, 4];
     let _it = v.windows(0);
@@ -960,6 +964,7 @@ fn test_chunksator() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_chunksator_0() {
     let v = &[1, 2, 3, 4];
     let _it = v.chunks(0);
@@ -984,6 +989,7 @@ fn test_chunks_exactator() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_chunks_exactator_0() {
     let v = &[1, 2, 3, 4];
     let _it = v.chunks_exact(0);
@@ -1008,6 +1014,7 @@ fn test_rchunksator() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_rchunksator_0() {
     let v = &[1, 2, 3, 4];
     let _it = v.rchunks(0);
@@ -1032,6 +1039,7 @@ fn test_rchunks_exactator() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_rchunks_exactator_0() {
     let v = &[1, 2, 3, 4];
     let _it = v.rchunks_exact(0);
@@ -1084,6 +1092,7 @@ fn test_vec_default() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_overflow_does_not_cause_segfault() {
     let mut v = vec![];
     v.reserve_exact(!0);
@@ -1093,6 +1102,7 @@ fn test_overflow_does_not_cause_segfault() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_overflow_does_not_cause_segfault_managed() {
     let mut v = vec![Rc::new(1)];
     v.reserve_exact(!0);
@@ -1268,6 +1278,7 @@ fn test_mut_chunks_rev() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_mut_chunks_0() {
     let mut v = [1, 2, 3, 4];
     let _it = v.chunks_mut(0);
@@ -1300,6 +1311,7 @@ fn test_mut_chunks_exact_rev() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_mut_chunks_exact_0() {
     let mut v = [1, 2, 3, 4];
     let _it = v.chunks_exact_mut(0);
@@ -1332,6 +1344,7 @@ fn test_mut_rchunks_rev() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_mut_rchunks_0() {
     let mut v = [1, 2, 3, 4];
     let _it = v.rchunks_mut(0);
@@ -1364,6 +1377,7 @@ fn test_mut_rchunks_exact_rev() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_mut_rchunks_exact_0() {
     let mut v = [1, 2, 3, 4];
     let _it = v.rchunks_exact_mut(0);
@@ -1397,6 +1411,7 @@ fn test_box_slice_clone() {
 #[test]
 #[allow(unused_must_use)] // here, we care about the side effects of `.clone()`
 #[cfg_attr(target_os = "emscripten", ignore)]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_box_slice_clone_panics() {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -1461,6 +1476,7 @@ fn test_copy_from_slice() {
 
 #[test]
 #[should_panic(expected = "destination and source slices have different lengths")]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_copy_from_slice_dst_longer() {
     let src = [0, 1, 2, 3];
     let mut dst = [0; 5];
@@ -1469,6 +1485,7 @@ fn test_copy_from_slice_dst_longer() {
 
 #[test]
 #[should_panic(expected = "destination and source slices have different lengths")]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_copy_from_slice_dst_shorter() {
     let src = [0, 1, 2, 3];
     let mut dst = [0; 3];
@@ -1588,6 +1605,7 @@ thread_local!(static SILENCE_PANIC: Cell<bool> = Cell::new(false));
 
 #[test]
 #[cfg_attr(target_os = "emscripten", ignore)] // no threads
+#[cfg(not(miri))] // Miri does not support panics
 fn panic_safe() {
     let prev = panic::take_hook();
     panic::set_hook(Box::new(move |info| {

--- a/src/liballoc/tests/str.rs
+++ b/src/liballoc/tests/str.rs
@@ -31,7 +31,6 @@ fn test_rfind() {
 }
 
 #[test]
-#[cfg(not(miri))]
 fn test_collect() {
     let empty = "";
     let s: String = empty.chars().collect();
@@ -119,7 +118,6 @@ fn test_concat_for_different_types() {
 #[test]
 fn test_concat_for_different_lengths() {
     let empty: &[&str] = &[];
-    #[cfg(not(miri))]
     test_concat!("", empty);
     test_concat!("a", ["a"]);
     test_concat!("ab", ["a", "b"]);
@@ -148,7 +146,6 @@ fn test_join_for_different_types() {
 #[test]
 fn test_join_for_different_lengths() {
     let empty: &[&str] = &[];
-    #[cfg(not(miri))]
     test_join!("", empty, "-");
     test_join!("a", ["a"], "-");
     test_join!("a-b", ["a", "b"], "-");
@@ -162,7 +159,6 @@ fn test_join_for_different_lengths_with_long_separator() {
     assert_eq!("～～～～～".len(), 15);
 
     let empty: &[&str] = &[];
-    #[cfg(not(miri))]
     test_join!("", empty, "～～～～～");
     test_join!("a", ["a"], "～～～～～");
     test_join!("a～～～～～b", ["a", "b"], "～～～～～");
@@ -170,7 +166,7 @@ fn test_join_for_different_lengths_with_long_separator() {
 }
 
 #[test]
-#[cfg(not(miri))]
+#[cfg(not(miri))] // Miri is too slow
 fn test_unsafe_slice() {
     assert_eq!("ab", unsafe {"abc".get_unchecked(0..2)});
     assert_eq!("bc", unsafe {"abc".get_unchecked(1..3)});
@@ -243,7 +239,6 @@ fn test_replacen() {
 #[test]
 fn test_replace() {
     let a = "a";
-    #[cfg(not(miri))]
     assert_eq!("".replace(a, "b"), "");
     assert_eq!("a".replace(a, "b"), "b");
     assert_eq!("ab".replace(a, "b"), "bb");
@@ -303,7 +298,6 @@ fn test_replace_pattern() {
 // The current implementation of SliceIndex fails to handle methods
 // orthogonally from range types; therefore, it is worth testing
 // all of the indexing operations on each input.
-#[cfg(not(miri))]
 mod slice_index {
     // Test a slicing operation **that should succeed,**
     // testing it on all of the indexing methods.
@@ -357,6 +351,7 @@ mod slice_index {
     //  to be used in `should_panic`)
     #[test]
     #[should_panic(expected = "out of bounds")]
+    #[cfg(not(miri))] // Miri does not support panics
     fn assert_range_eq_can_fail_by_panic() {
         assert_range_eq!("abc", 0..5, "abc");
     }
@@ -366,6 +361,7 @@ mod slice_index {
     //  to be used in `should_panic`)
     #[test]
     #[should_panic(expected = "==")]
+    #[cfg(not(miri))] // Miri does not support panics
     fn assert_range_eq_can_fail_by_inequality() {
         assert_range_eq!("abc", 0..2, "abc");
     }
@@ -413,6 +409,7 @@ mod slice_index {
 
                 #[test]
                 #[should_panic(expected = $expect_msg)]
+                #[cfg(not(miri))] // Miri does not support panics
                 fn index_fail() {
                     let v: String = $data.into();
                     let v: &str = &v;
@@ -421,6 +418,7 @@ mod slice_index {
 
                 #[test]
                 #[should_panic(expected = $expect_msg)]
+                #[cfg(not(miri))] // Miri does not support panics
                 fn index_mut_fail() {
                     let mut v: String = $data.into();
                     let v: &mut str = &mut v;
@@ -490,6 +488,7 @@ mod slice_index {
 
     #[test]
     #[cfg(not(target_arch = "asmjs"))] // hits an OOM
+    #[cfg(not(miri))] // Miri is too slow
     fn simple_big() {
         fn a_million_letter_x() -> String {
             let mut i = 0;
@@ -515,6 +514,7 @@ mod slice_index {
 
     #[test]
     #[should_panic]
+    #[cfg(not(miri))] // Miri does not support panics
     fn test_slice_fail() {
         &"中华Việt Nam"[0..2];
     }
@@ -666,12 +666,14 @@ mod slice_index {
     // check the panic includes the prefix of the sliced string
     #[test]
     #[should_panic(expected="byte index 1024 is out of bounds of `Lorem ipsum dolor sit amet")]
+    #[cfg(not(miri))] // Miri does not support panics
     fn test_slice_fail_truncated_1() {
         &LOREM_PARAGRAPH[..1024];
     }
     // check the truncation in the panic message
     #[test]
     #[should_panic(expected="luctus, im`[...]")]
+    #[cfg(not(miri))] // Miri does not support panics
     fn test_slice_fail_truncated_2() {
         &LOREM_PARAGRAPH[..1024];
     }
@@ -686,7 +688,7 @@ fn test_str_slice_rangetoinclusive_ok() {
 
 #[test]
 #[should_panic]
-#[cfg(not(miri))]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_str_slice_rangetoinclusive_notok() {
     let s = "abcαβγ";
     &s[..=3];
@@ -702,7 +704,7 @@ fn test_str_slicemut_rangetoinclusive_ok() {
 
 #[test]
 #[should_panic]
-#[cfg(not(miri))]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_str_slicemut_rangetoinclusive_notok() {
     let mut s = "abcαβγ".to_owned();
     let s: &mut str = &mut s;
@@ -892,7 +894,7 @@ fn test_as_bytes() {
 
 #[test]
 #[should_panic]
-#[cfg(not(miri))]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_as_bytes_fail() {
     // Don't double free. (I'm not sure if this exercises the
     // original problem code path anymore.)
@@ -982,7 +984,7 @@ fn test_split_at_mut() {
 
 #[test]
 #[should_panic]
-#[cfg(not(miri))]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_split_at_boundscheck() {
     let s = "ศไทย中华Việt Nam";
     s.split_at(1);
@@ -1078,7 +1080,7 @@ fn test_rev_iterator() {
 }
 
 #[test]
-#[cfg(not(miri))]
+#[cfg(not(miri))] // Miri is too slow
 fn test_chars_decoding() {
     let mut bytes = [0; 4];
     for c in (0..0x110000).filter_map(std::char::from_u32) {
@@ -1090,7 +1092,7 @@ fn test_chars_decoding() {
 }
 
 #[test]
-#[cfg(not(miri))]
+#[cfg(not(miri))] // Miri is too slow
 fn test_chars_rev_decoding() {
     let mut bytes = [0; 4];
     for c in (0..0x110000).filter_map(std::char::from_u32) {
@@ -1320,7 +1322,6 @@ fn test_splitator() {
 }
 
 #[test]
-#[cfg(not(miri))]
 fn test_str_default() {
     use std::default::Default;
 
@@ -1380,7 +1381,7 @@ fn test_bool_from_str() {
     assert_eq!("not even a boolean".parse::<bool>().ok(), None);
 }
 
-#[cfg(not(miri))]
+#[cfg(not(miri))] // Miri is too slow
 fn check_contains_all_substrings(s: &str) {
     assert!(s.contains(""));
     for i in 0..s.len() {
@@ -1391,7 +1392,7 @@ fn check_contains_all_substrings(s: &str) {
 }
 
 #[test]
-#[cfg(not(miri))]
+#[cfg(not(miri))] // Miri is too slow
 fn strslice_issue_16589() {
     assert!("bananas".contains("nana"));
 
@@ -1401,7 +1402,6 @@ fn strslice_issue_16589() {
 }
 
 #[test]
-#[cfg(not(miri))]
 fn strslice_issue_16878() {
     assert!(!"1234567ah012345678901ah".contains("hah"));
     assert!(!"00abc01234567890123456789abc".contains("bcabc"));
@@ -1409,7 +1409,7 @@ fn strslice_issue_16878() {
 
 
 #[test]
-#[cfg(not(miri))]
+#[cfg(not(miri))] // Miri is too slow
 fn test_strslice_contains() {
     let x = "There are moments, Jeeves, when one asks oneself, 'Do trousers matter?'";
     check_contains_all_substrings(x);
@@ -1547,7 +1547,6 @@ fn trim_ws() {
 
 #[test]
 fn to_lowercase() {
-    #[cfg(not(miri))]
     assert_eq!("".to_lowercase(), "");
     assert_eq!("AÉǅaé ".to_lowercase(), "aéǆaé ");
 
@@ -1581,7 +1580,6 @@ fn to_lowercase() {
 
 #[test]
 fn to_uppercase() {
-    #[cfg(not(miri))]
     assert_eq!("".to_uppercase(), "");
     assert_eq!("aéǅßﬁᾀ".to_uppercase(), "AÉǄSSFIἈΙ");
 }
@@ -1613,7 +1611,6 @@ fn test_cow_from() {
 }
 
 #[test]
-#[cfg(not(miri))]
 fn test_repeat() {
     assert_eq!("".repeat(3), "");
     assert_eq!("abc".repeat(0), "");

--- a/src/liballoc/tests/string.rs
+++ b/src/liballoc/tests/string.rs
@@ -1,5 +1,3 @@
-#![cfg(not(miri))]
-
 use std::borrow::Cow;
 use std::collections::CollectionAllocErr::*;
 use std::mem::size_of;
@@ -233,6 +231,7 @@ fn test_split_off_empty() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_split_off_past_end() {
     let orig = "Hello, world!";
     let mut split = String::from(orig);
@@ -241,6 +240,7 @@ fn test_split_off_past_end() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_split_off_mid_char() {
     let mut orig = String::from("山");
     orig.split_off(1);
@@ -289,6 +289,7 @@ fn test_str_truncate_invalid_len() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_str_truncate_split_codepoint() {
     let mut s = String::from("\u{FC}"); // ü
     s.truncate(1);
@@ -323,6 +324,7 @@ fn remove() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn remove_bad() {
     "ศ".to_string().remove(1);
 }
@@ -358,11 +360,13 @@ fn insert() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn insert_bad1() {
     "".to_string().insert(1, 't');
 }
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn insert_bad2() {
     "ệ".to_string().insert(1, 't');
 }
@@ -443,6 +447,7 @@ fn test_replace_range() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_replace_range_char_boundary() {
     let mut s = "Hello, 世界!".to_owned();
     s.replace_range(..8, "");
@@ -459,6 +464,7 @@ fn test_replace_range_inclusive_range() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_replace_range_out_of_bounds() {
     let mut s = String::from("12345");
     s.replace_range(5..6, "789");
@@ -466,6 +472,7 @@ fn test_replace_range_out_of_bounds() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_replace_range_inclusive_out_of_bounds() {
     let mut s = String::from("12345");
     s.replace_range(5..=5, "789");
@@ -525,6 +532,7 @@ fn test_reserve_exact() {
 }
 
 #[test]
+#[cfg(not(miri))] // Miri does not support signalling OOM
 fn test_try_reserve() {
 
     // These are the interesting cases:
@@ -602,6 +610,7 @@ fn test_try_reserve() {
 }
 
 #[test]
+#[cfg(not(miri))] // Miri does not support signalling OOM
 fn test_try_reserve_exact() {
 
     // This is exactly the same as test_try_reserve with the method changed.

--- a/src/liballoc/tests/vec.rs
+++ b/src/liballoc/tests/vec.rs
@@ -368,6 +368,7 @@ fn test_vec_truncate_drop() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_vec_truncate_fail() {
     struct BadElem(i32);
     impl Drop for BadElem {
@@ -391,6 +392,7 @@ fn test_index() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_index_out_of_bounds() {
     let vec = vec![1, 2, 3];
     let _ = vec[3];
@@ -398,6 +400,7 @@ fn test_index_out_of_bounds() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_slice_out_of_bounds_1() {
     let x = vec![1, 2, 3, 4, 5];
     &x[!0..];
@@ -405,6 +408,7 @@ fn test_slice_out_of_bounds_1() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_slice_out_of_bounds_2() {
     let x = vec![1, 2, 3, 4, 5];
     &x[..6];
@@ -412,6 +416,7 @@ fn test_slice_out_of_bounds_2() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_slice_out_of_bounds_3() {
     let x = vec![1, 2, 3, 4, 5];
     &x[!0..4];
@@ -419,6 +424,7 @@ fn test_slice_out_of_bounds_3() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_slice_out_of_bounds_4() {
     let x = vec![1, 2, 3, 4, 5];
     &x[1..6];
@@ -426,6 +432,7 @@ fn test_slice_out_of_bounds_4() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_slice_out_of_bounds_5() {
     let x = vec![1, 2, 3, 4, 5];
     &x[3..2];
@@ -433,6 +440,7 @@ fn test_slice_out_of_bounds_5() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_swap_remove_empty() {
     let mut vec = Vec::<i32>::new();
     vec.swap_remove(0);
@@ -503,6 +511,7 @@ fn test_drain_items_zero_sized() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_drain_out_of_bounds() {
     let mut v = vec![1, 2, 3, 4, 5];
     v.drain(5..6);
@@ -576,6 +585,7 @@ fn test_drain_max_vec_size() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_drain_inclusive_out_of_bounds() {
     let mut v = vec![1, 2, 3, 4, 5];
     v.drain(5..=5);
@@ -605,6 +615,7 @@ fn test_splice_inclusive_range() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_splice_out_of_bounds() {
     let mut v = vec![1, 2, 3, 4, 5];
     let a = [10, 11, 12];
@@ -613,6 +624,7 @@ fn test_splice_out_of_bounds() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_splice_inclusive_out_of_bounds() {
     let mut v = vec![1, 2, 3, 4, 5];
     let a = [10, 11, 12];

--- a/src/liballoc/tests/vec_deque.rs
+++ b/src/liballoc/tests/vec_deque.rs
@@ -108,7 +108,7 @@ fn test_index() {
 
 #[test]
 #[should_panic]
-#[cfg(not(miri))]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_index_out_of_bounds() {
     let mut deq = VecDeque::new();
     for i in 1..4 {
@@ -907,24 +907,21 @@ fn test_append() {
     // normal append
     a.append(&mut b);
     assert_eq!(a.iter().cloned().collect::<Vec<_>>(), [1, 2, 3, 4, 5, 6]);
-    #[cfg(not(miri))]
     assert_eq!(b.iter().cloned().collect::<Vec<_>>(), []);
 
     // append nothing to something
     a.append(&mut b);
     assert_eq!(a.iter().cloned().collect::<Vec<_>>(), [1, 2, 3, 4, 5, 6]);
-    #[cfg(not(miri))]
     assert_eq!(b.iter().cloned().collect::<Vec<_>>(), []);
 
     // append something to nothing
     b.append(&mut a);
     assert_eq!(b.iter().cloned().collect::<Vec<_>>(), [1, 2, 3, 4, 5, 6]);
-    #[cfg(not(miri))]
     assert_eq!(a.iter().cloned().collect::<Vec<_>>(), []);
 }
 
 #[test]
-#[cfg(not(miri))]
+#[cfg(not(miri))] // Miri is too slow
 fn test_append_permutations() {
     fn construct_vec_deque(
         push_back: usize,
@@ -1125,7 +1122,7 @@ fn test_reserve_exact_2() {
 }
 
 #[test]
-#[cfg(not(miri))]
+#[cfg(not(miri))] // Miri does not support signalling OOM
 fn test_try_reserve() {
 
     // These are the interesting cases:
@@ -1227,7 +1224,7 @@ fn test_try_reserve() {
 }
 
 #[test]
-#[cfg(not(miri))]
+#[cfg(not(miri))] // Miri does not support signalling OOM
 fn test_try_reserve_exact() {
 
     // This is exactly the same as test_try_reserve with the method changed.

--- a/src/liballoc/tests/vec_deque.rs
+++ b/src/liballoc/tests/vec_deque.rs
@@ -921,7 +921,6 @@ fn test_append() {
 }
 
 #[test]
-#[cfg(not(miri))] // Miri is too slow
 fn test_append_permutations() {
     fn construct_vec_deque(
         push_back: usize,
@@ -945,7 +944,10 @@ fn test_append_permutations() {
         out
     }
 
+    #[cfg(not(miri))] // Miri is too slow
     const MAX: usize = 5;
+    #[cfg(miri)]
+    const MAX: usize = 3;
 
     // Many different permutations of both the `VecDeque` getting appended to
     // and the one getting appended are generated to check `append`.

--- a/src/libcore/tests/cell.rs
+++ b/src/libcore/tests/cell.rs
@@ -1,5 +1,3 @@
-#![cfg(not(miri))]
-
 use core::cell::*;
 use core::default::Default;
 use std::mem::drop;
@@ -111,6 +109,7 @@ fn double_borrow_single_release_no_borrow_mut() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn discard_doesnt_unborrow() {
     let x = RefCell::new(0);
     let _b = x.borrow();
@@ -351,6 +350,7 @@ fn refcell_ref_coercion() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn refcell_swap_borrows() {
     let x = RefCell::new(0);
     let _b = x.borrow();
@@ -360,6 +360,7 @@ fn refcell_swap_borrows() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn refcell_replace_borrows() {
     let x = RefCell::new(0);
     let _b = x.borrow();

--- a/src/libcore/tests/fmt/builders.rs
+++ b/src/libcore/tests/fmt/builders.rs
@@ -488,7 +488,6 @@ mod debug_list {
 }
 
 #[test]
-#[cfg(not(miri))] // FIXME uses code in liballoc, investigate Stacked Borrows failure
 fn test_formatting_parameters_are_forwarded() {
     use std::collections::{BTreeMap, BTreeSet};
     #[derive(Debug)]

--- a/src/libcore/tests/fmt/builders.rs
+++ b/src/libcore/tests/fmt/builders.rs
@@ -488,6 +488,7 @@ mod debug_list {
 }
 
 #[test]
+#[cfg(not(miri))] // FIXME uses code in liballoc, investigate Stacked Borrows failure
 fn test_formatting_parameters_are_forwarded() {
     use std::collections::{BTreeMap, BTreeSet};
     #[derive(Debug)]

--- a/src/libcore/tests/fmt/mod.rs
+++ b/src/libcore/tests/fmt/mod.rs
@@ -1,4 +1,4 @@
-#![cfg(not(miri))]
+#![cfg(not(miri))] // FIXME: A bug in Miri breaks padding in string formatting
 
 mod builders;
 mod float;

--- a/src/libcore/tests/fmt/mod.rs
+++ b/src/libcore/tests/fmt/mod.rs
@@ -1,10 +1,9 @@
-#![cfg(not(miri))] // FIXME: A bug in Miri breaks padding in string formatting
-
 mod builders;
 mod float;
 mod num;
 
 #[test]
+#[cfg(not(miri))] // Miri cannot print pointers
 fn test_format_flags() {
     // No residual flags left by pointer formatting
     let p = "".as_ptr();
@@ -14,6 +13,7 @@ fn test_format_flags() {
 }
 
 #[test]
+#[cfg(not(miri))] // Miri cannot print pointers
 fn test_pointer_formats_data_pointer() {
     let b: &[u8] = b"";
     let s: &str = "";

--- a/src/libcore/tests/hash/mod.rs
+++ b/src/libcore/tests/hash/mod.rs
@@ -1,5 +1,3 @@
-#![cfg(not(miri))]
-
 mod sip;
 
 use std::hash::{Hash, Hasher};
@@ -75,9 +73,11 @@ fn test_writer_hasher() {
     let cs: &mut [u8] = &mut [1, 2, 3];
     let ptr = cs.as_ptr();
     let slice_ptr = cs as *const [u8];
+    #[cfg(not(miri))] // Miri cannot hash pointers
     assert_eq!(hash(&slice_ptr), hash(&ptr) + cs.len() as u64);
 
     let slice_ptr = cs as *mut [u8];
+    #[cfg(not(miri))] // Miri cannot hash pointers
     assert_eq!(hash(&slice_ptr), hash(&ptr) + cs.len() as u64);
 }
 

--- a/src/libcore/tests/iter.rs
+++ b/src/libcore/tests/iter.rs
@@ -1661,9 +1661,7 @@ fn test_range_step() {
     assert_eq!((1..21).rev().step_by(5).collect::<Vec<isize>>(), [20, 15, 10, 5]);
     assert_eq!((1..21).rev().step_by(6).collect::<Vec<isize>>(), [20, 14, 8, 2]);
     assert_eq!((200..255).step_by(50).collect::<Vec<u8>>(), [200, 250]);
-    #[cfg(not(miri))] // Miri cannot compare empty slices
     assert_eq!((200..-5).step_by(1).collect::<Vec<isize>>(), []);
-    #[cfg(not(miri))] // Miri cannot compare empty slices
     assert_eq!((200..200).step_by(1).collect::<Vec<isize>>(), []);
 
     assert_eq!((0..20).step_by(1).size_hint(), (20, Some(20)));

--- a/src/libcore/tests/iter.rs
+++ b/src/libcore/tests/iter.rs
@@ -190,7 +190,6 @@ fn test_iterator_step_by() {
 }
 
 #[test]
-#[cfg(not(miri))]
 fn test_iterator_step_by_nth() {
     let mut it = (0..16).step_by(5);
     assert_eq!(it.nth(0), Some(0));
@@ -209,7 +208,6 @@ fn test_iterator_step_by_nth() {
 }
 
 #[test]
-#[cfg(not(miri))]
 fn test_iterator_step_by_nth_overflow() {
     #[cfg(target_pointer_width = "8")]
     type Bigger = u16;
@@ -262,7 +260,6 @@ fn test_iterator_step_by_zero() {
 }
 
 #[test]
-#[cfg(not(miri))]
 fn test_iterator_step_by_size_hint() {
     struct StubSizeHint(usize, Option<usize>);
     impl Iterator for StubSizeHint {
@@ -1657,7 +1654,6 @@ fn test_range_inclusive_nth() {
 }
 
 #[test]
-#[cfg(not(miri))]
 fn test_range_step() {
     #![allow(deprecated)]
 
@@ -1665,7 +1661,9 @@ fn test_range_step() {
     assert_eq!((1..21).rev().step_by(5).collect::<Vec<isize>>(), [20, 15, 10, 5]);
     assert_eq!((1..21).rev().step_by(6).collect::<Vec<isize>>(), [20, 14, 8, 2]);
     assert_eq!((200..255).step_by(50).collect::<Vec<u8>>(), [200, 250]);
+    #[cfg(not(miri))] // Miri cannot compare empty slices
     assert_eq!((200..-5).step_by(1).collect::<Vec<isize>>(), []);
+    #[cfg(not(miri))] // Miri cannot compare empty slices
     assert_eq!((200..200).step_by(1).collect::<Vec<isize>>(), []);
 
     assert_eq!((0..20).step_by(1).size_hint(), (20, Some(20)));
@@ -1681,7 +1679,6 @@ fn test_range_step() {
 }
 
 #[test]
-#[cfg(not(miri))]
 fn test_step_by_skip() {
     assert_eq!((0..640).step_by(128).skip(1).collect::<Vec<_>>(), [128, 256, 384, 512]);
     assert_eq!((0..=50).step_by(10).nth(3), Some(30));
@@ -1689,7 +1686,6 @@ fn test_step_by_skip() {
 }
 
 #[test]
-#[cfg(not(miri))]
 fn test_range_inclusive_step() {
     assert_eq!((0..=50).step_by(10).collect::<Vec<_>>(), [0, 10, 20, 30, 40, 50]);
     assert_eq!((0..=5).step_by(1).collect::<Vec<_>>(), [0, 1, 2, 3, 4, 5]);

--- a/src/libcore/tests/iter.rs
+++ b/src/libcore/tests/iter.rs
@@ -255,7 +255,7 @@ fn test_iterator_step_by_nth_overflow() {
 
 #[test]
 #[should_panic]
-#[cfg(not(miri))]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_iterator_step_by_zero() {
     let mut it = (0..).step_by(0);
     it.next();
@@ -1417,7 +1417,7 @@ fn test_rposition() {
 
 #[test]
 #[should_panic]
-#[cfg(not(miri))]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_rposition_panic() {
     let v: [(Box<_>, Box<_>); 4] =
         [(box 0, box 0), (box 0, box 0),

--- a/src/libcore/tests/num/bignum.rs
+++ b/src/libcore/tests/num/bignum.rs
@@ -3,6 +3,7 @@ use core::num::bignum::tests::Big8x3 as Big;
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_from_u64_overflow() {
     Big::from_u64(0x1000000);
 }
@@ -19,12 +20,14 @@ fn test_add() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_add_overflow_1() {
     Big::from_small(1).add(&Big::from_u64(0xffffff));
 }
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_add_overflow_2() {
     Big::from_u64(0xffffff).add(&Big::from_small(1));
 }
@@ -42,6 +45,7 @@ fn test_add_small() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_add_small_overflow() {
     Big::from_u64(0xffffff).add_small(1);
 }
@@ -57,12 +61,14 @@ fn test_sub() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_sub_underflow_1() {
     Big::from_u64(0x10665).sub(&Big::from_u64(0x10666));
 }
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_sub_underflow_2() {
     Big::from_small(0).sub(&Big::from_u64(0x123456));
 }
@@ -76,6 +82,7 @@ fn test_mul_small() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_mul_small_overflow() {
     Big::from_u64(0x800000).mul_small(2);
 }
@@ -94,12 +101,14 @@ fn test_mul_pow2() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_mul_pow2_overflow_1() {
     Big::from_u64(0x1).mul_pow2(24);
 }
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_mul_pow2_overflow_2() {
     Big::from_u64(0x123).mul_pow2(16);
 }
@@ -118,12 +127,14 @@ fn test_mul_pow5() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_mul_pow5_overflow_1() {
     Big::from_small(1).mul_pow5(12);
 }
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_mul_pow5_overflow_2() {
     Big::from_small(230).mul_pow5(8);
 }
@@ -141,12 +152,14 @@ fn test_mul_digits() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_mul_digits_overflow_1() {
     Big::from_u64(0x800000).mul_digits(&[2]);
 }
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_mul_digits_overflow_2() {
     Big::from_u64(0x1000).mul_digits(&[0, 0x10]);
 }
@@ -206,6 +219,7 @@ fn test_get_bit() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_get_bit_out_of_range() {
     Big::from_small(42).get_bit(24);
 }

--- a/src/libcore/tests/num/dec2flt/mod.rs
+++ b/src/libcore/tests/num/dec2flt/mod.rs
@@ -52,6 +52,7 @@ fn large() {
 }
 
 #[test]
+#[cfg(not(miri))] // Miri is too slow
 fn subnormals() {
     test_literal!(5e-324);
     test_literal!(91e-324);
@@ -63,6 +64,7 @@ fn subnormals() {
 }
 
 #[test]
+#[cfg(not(miri))] // Miri is too slow
 fn infinity() {
     test_literal!(1e400);
     test_literal!(1e309);

--- a/src/libcore/tests/num/flt2dec/mod.rs
+++ b/src/libcore/tests/num/flt2dec/mod.rs
@@ -1,3 +1,5 @@
+#![cfg(not(miri))] // Miri does not implement ldexp, which most tests here need
+
 use std::prelude::v1::*;
 use std::{str, i16, f32, f64, fmt};
 

--- a/src/libcore/tests/num/mod.rs
+++ b/src/libcore/tests/num/mod.rs
@@ -1,5 +1,3 @@
-#![cfg(not(miri))]
-
 use core::convert::{TryFrom, TryInto};
 use core::cmp::PartialEq;
 use core::fmt::Debug;

--- a/src/libcore/tests/option.rs
+++ b/src/libcore/tests/option.rs
@@ -69,7 +69,7 @@ fn test_option_dance() {
 }
 
 #[test] #[should_panic]
-#[cfg(not(miri))]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_option_too_much_dance() {
     struct A;
     let mut y = Some(A);
@@ -130,7 +130,7 @@ fn test_unwrap() {
 
 #[test]
 #[should_panic]
-#[cfg(not(miri))]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_unwrap_panic1() {
     let x: Option<isize> = None;
     x.unwrap();
@@ -138,7 +138,7 @@ fn test_unwrap_panic1() {
 
 #[test]
 #[should_panic]
-#[cfg(not(miri))]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_unwrap_panic2() {
     let x: Option<String> = None;
     x.unwrap();

--- a/src/libcore/tests/ptr.rs
+++ b/src/libcore/tests/ptr.rs
@@ -1,5 +1,3 @@
-#![cfg(not(miri))]
-
 use core::ptr::*;
 use core::cell::RefCell;
 
@@ -42,6 +40,7 @@ fn test() {
 }
 
 #[test]
+#[cfg(not(miri))] // This test performs invalid OOB pointer arithmetic
 fn test_is_null() {
     let p: *const isize = null();
     assert!(p.is_null());
@@ -147,6 +146,7 @@ fn test_as_ref() {
 }
 
 #[test]
+#[cfg(not(miri))] // This test is UB according to Stacked Borrows
 fn test_as_mut() {
     unsafe {
         let p: *mut isize = null_mut();
@@ -208,6 +208,7 @@ fn test_ptr_addition() {
 }
 
 #[test]
+#[cfg(not(miri))] // This test performs invalid OOB pointer arithmetic
 fn test_ptr_subtraction() {
     unsafe {
         let xs = vec![0,1,2,3,4,5,6,7,8,9];
@@ -251,6 +252,7 @@ fn test_unsized_nonnull() {
 
 #[test]
 #[allow(warnings)]
+#[cfg(not(miri))] // Miri cannot hash pointers
 // Have a symbol for the test below. It doesn’t need to be an actual variadic function, match the
 // ABI, or even point to an actual executable code, because the function itself is never invoked.
 #[no_mangle]
@@ -290,6 +292,7 @@ fn write_unaligned_drop() {
 }
 
 #[test]
+#[cfg(not(miri))] // Miri cannot compute actual alignment of an allocation
 fn align_offset_zst() {
     // For pointers of stride = 0, the pointer is already aligned or it cannot be aligned at
     // all, because no amount of elements will align the pointer.
@@ -304,6 +307,7 @@ fn align_offset_zst() {
 }
 
 #[test]
+#[cfg(not(miri))] // Miri cannot compute actual alignment of an allocation
 fn align_offset_stride1() {
     // For pointers of stride = 1, the pointer can always be aligned. The offset is equal to
     // number of bytes.
@@ -320,6 +324,7 @@ fn align_offset_stride1() {
 }
 
 #[test]
+#[cfg(not(miri))] // Miri is too slow
 fn align_offset_weird_strides() {
     #[repr(packed)]
     struct A3(u16, u8);

--- a/src/libcore/tests/result.rs
+++ b/src/libcore/tests/result.rs
@@ -117,7 +117,7 @@ fn test_unwrap_or_else() {
 
 #[test]
 #[should_panic]
-#[cfg(not(miri))]
+#[cfg(not(miri))] // Miri does not support panics
 pub fn test_unwrap_or_else_panic() {
     fn handler(msg: &'static str) -> isize {
         if msg == "I got this." {
@@ -139,7 +139,7 @@ pub fn test_expect_ok() {
 }
 #[test]
 #[should_panic(expected="Got expected error: \"All good\"")]
-#[cfg(not(miri))]
+#[cfg(not(miri))] // Miri does not support panics
 pub fn test_expect_err() {
     let err: Result<isize, &'static str> = Err("All good");
     err.expect("Got expected error");
@@ -153,7 +153,7 @@ pub fn test_expect_err_err() {
 }
 #[test]
 #[should_panic(expected="Got expected ok: \"All good\"")]
-#[cfg(not(miri))]
+#[cfg(not(miri))] // Miri does not support panics
 pub fn test_expect_err_ok() {
     let err: Result<&'static str, isize> = Ok("All good");
     err.expect_err("Got expected ok");

--- a/src/libcore/tests/slice.rs
+++ b/src/libcore/tests/slice.rs
@@ -782,7 +782,7 @@ mod slice_index {
     //  to be used in `should_panic`)
     #[test]
     #[should_panic(expected = "out of range")]
-    #[cfg(not(miri))]
+    #[cfg(not(miri))] // Miri does not support panics
     fn assert_range_eq_can_fail_by_panic() {
         assert_range_eq!([0, 1, 2], 0..5, [0, 1, 2]);
     }
@@ -792,7 +792,7 @@ mod slice_index {
     //  to be used in `should_panic`)
     #[test]
     #[should_panic(expected = "==")]
-    #[cfg(not(miri))]
+    #[cfg(not(miri))] // Miri does not support panics
     fn assert_range_eq_can_fail_by_inequality() {
         assert_range_eq!([0, 1, 2], 0..2, [0, 1, 2]);
     }
@@ -842,7 +842,7 @@ mod slice_index {
 
                 #[test]
                 #[should_panic(expected = $expect_msg)]
-                #[cfg(not(miri))]
+                #[cfg(not(miri))] // Miri does not support panics
                 fn index_fail() {
                     let v = $data;
                     let v: &[_] = &v;
@@ -851,7 +851,7 @@ mod slice_index {
 
                 #[test]
                 #[should_panic(expected = $expect_msg)]
-                #[cfg(not(miri))]
+                #[cfg(not(miri))] // Miri does not support panics
                 fn index_mut_fail() {
                     let mut v = $data;
                     let v: &mut [_] = &mut v;
@@ -1306,7 +1306,7 @@ fn test_copy_within() {
 
 #[test]
 #[should_panic(expected = "src is out of bounds")]
-#[cfg(not(miri))]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_copy_within_panics_src_too_long() {
     let mut bytes = *b"Hello, World!";
     // The length is only 13, so 14 is out of bounds.
@@ -1315,7 +1315,7 @@ fn test_copy_within_panics_src_too_long() {
 
 #[test]
 #[should_panic(expected = "dest is out of bounds")]
-#[cfg(not(miri))]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_copy_within_panics_dest_too_long() {
     let mut bytes = *b"Hello, World!";
     // The length is only 13, so a slice of length 4 starting at index 10 is out of bounds.
@@ -1323,7 +1323,7 @@ fn test_copy_within_panics_dest_too_long() {
 }
 #[test]
 #[should_panic(expected = "src end is before src start")]
-#[cfg(not(miri))]
+#[cfg(not(miri))] // Miri does not support panics
 fn test_copy_within_panics_src_inverted() {
     let mut bytes = *b"Hello, World!";
     // 2 is greater than 1, so this range is invalid.

--- a/src/libcore/tests/slice.rs
+++ b/src/libcore/tests/slice.rs
@@ -1015,7 +1015,7 @@ fn test_rotate_right() {
 
 #[test]
 #[cfg(not(target_arch = "wasm32"))]
-#[cfg(not(miri))]
+#[cfg(not(miri))] // Miri does not support entropy
 fn sort_unstable() {
     use core::cmp::Ordering::{Equal, Greater, Less};
     use core::slice::heapsort;
@@ -1171,7 +1171,7 @@ pub mod memchr {
 }
 
 #[test]
-#[cfg(not(miri))]
+#[cfg(not(miri))] // Miri cannot compute actual alignment of an allocation
 fn test_align_to_simple() {
     let bytes = [1u8, 2, 3, 4, 5, 6, 7];
     let (prefix, aligned, suffix) = unsafe { bytes.align_to::<u16>() };
@@ -1187,7 +1187,6 @@ fn test_align_to_simple() {
 }
 
 #[test]
-#[cfg(not(miri))]
 fn test_align_to_zst() {
     let bytes = [1, 2, 3, 4, 5, 6, 7];
     let (prefix, aligned, suffix) = unsafe { bytes.align_to::<()>() };
@@ -1196,7 +1195,7 @@ fn test_align_to_zst() {
 }
 
 #[test]
-#[cfg(not(miri))]
+#[cfg(not(miri))] // Miri cannot compute actual alignment of an allocation
 fn test_align_to_non_trivial() {
     #[repr(align(8))] struct U64(u64, u64);
     #[repr(align(8))] struct U64U64U32(u64, u64, u32);
@@ -1208,7 +1207,6 @@ fn test_align_to_non_trivial() {
 }
 
 #[test]
-#[cfg(not(miri))]
 fn test_align_to_empty_mid() {
     use core::mem;
 

--- a/src/libcore/tests/time.rs
+++ b/src/libcore/tests/time.rs
@@ -1,5 +1,3 @@
-#![cfg(not(miri))]
-
 use core::time::Duration;
 
 #[test]
@@ -109,12 +107,14 @@ fn checked_sub() {
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn sub_bad1() {
     let _ = Duration::new(0, 0) - Duration::new(0, 1);
 }
 
 #[test]
 #[should_panic]
+#[cfg(not(miri))] // Miri does not support panics
 fn sub_bad2() {
     let _ = Duration::new(0, 0) - Duration::new(1, 0);
 }
@@ -287,6 +287,7 @@ fn debug_formatting_precision_two() {
 }
 
 #[test]
+#[cfg(not(miri))] // FIXME: A bug in Miri breaks padding in string formatting
 fn debug_formatting_precision_high() {
     assert_eq!(format!("{:.5?}",  Duration::new(0, 23_678)), "23.67800µs");
 

--- a/src/libcore/tests/time.rs
+++ b/src/libcore/tests/time.rs
@@ -287,7 +287,6 @@ fn debug_formatting_precision_two() {
 }
 
 #[test]
-#[cfg(not(miri))] // FIXME: A bug in Miri breaks padding in string formatting
 fn debug_formatting_precision_high() {
     assert_eq!(format!("{:.5?}",  Duration::new(0, 23_678)), "23.67800µs");
 

--- a/src/librustc_mir/diagnostics.rs
+++ b/src/librustc_mir/diagnostics.rs
@@ -2370,6 +2370,37 @@ let value = (&foo(), &foo());
 ```
 "##,
 
+E0723: r##"
+An feature unstable in `const` contexts was used.
+
+Erroneous code example:
+
+```compile_fail,E0723
+trait T {}
+
+impl T for () {}
+
+const fn foo() -> impl T { // error: `impl Trait` in const fn is unstable
+    ()
+}
+```
+
+To enable this feature on a nightly version of rustc, add the `const_fn`
+feature flag:
+
+```compile_fail,E0723
+#![feature(const_fn)]
+
+trait T {}
+
+impl T for () {}
+
+const fn foo() -> impl T { // error: `impl Trait` in const fn is unstable
+    ()
+}
+```
+"##,
+
 }
 
 register_diagnostics! {

--- a/src/librustc_mir/diagnostics.rs
+++ b/src/librustc_mir/diagnostics.rs
@@ -2388,14 +2388,14 @@ const fn foo() -> impl T { // error: `impl Trait` in const fn is unstable
 To enable this feature on a nightly version of rustc, add the `const_fn`
 feature flag:
 
-```compile_fail,E0723
+```
 #![feature(const_fn)]
 
 trait T {}
 
 impl T for () {}
 
-const fn foo() -> impl T { // error: `impl Trait` in const fn is unstable
+const fn foo() -> impl T {
     ()
 }
 ```

--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -1206,7 +1206,17 @@ impl MirPass for QualifyAndPromoteConstants {
                         // enforce `min_const_fn` for stable const fns
                         use super::qualify_min_const_fn::is_min_const_fn;
                         if let Err((span, err)) = is_min_const_fn(tcx, def_id, mir) {
-                            tcx.sess.span_err(span, &err);
+                            let mut diag = struct_span_err!(
+                                tcx.sess,
+                                span,
+                                E0723,
+                                "{} (see issue #57563)",
+                                err,
+                            );
+                            diag.help(
+                                "add #![feature(const_fn)] to the crate attributes to enable",
+                            );
+                            diag.emit();
                         } else {
                             // this should not produce any errors, but better safe than sorry
                             // FIXME(#53819)

--- a/src/librustc_passes/ast_validation.rs
+++ b/src/librustc_passes/ast_validation.rs
@@ -519,7 +519,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                 if let Some(ref type_) = data.output {
                     // `-> Foo` syntax is essentially an associated type binding,
                     // so it is also allowed to contain nested `impl Trait`.
-                    self.with_impl_trait(None, |this| visit::walk_ty(this, type_));
+                    self.with_impl_trait(None, |this| this.visit_ty(type_));
                 }
             }
         }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -2236,7 +2236,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
             hir_id, def_id, substs, user_self_ty, self.tag(),
         );
 
-        if !substs.is_noop() {
+        if Self::can_contain_user_lifetime_bounds((substs, user_self_ty)) {
             let canonicalized = self.infcx.canonicalize_user_type_annotation(
                 &UserType::TypeOf(def_id, UserSubsts {
                     substs,
@@ -2431,21 +2431,27 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         let ty = self.to_ty(ast_ty);
         debug!("to_ty_saving_user_provided_ty: ty={:?}", ty);
 
-        // If the type given by the user has free regions, save it for
-        // later, since NLL would like to enforce those. Also pass in
-        // types that involve projections, since those can resolve to
-        // `'static` bounds (modulo #54940, which hopefully will be
-        // fixed by the time you see this comment, dear reader,
-        // although I have my doubts). Also pass in types with inference
-        // types, because they may be repeated. Other sorts of things
-        // are already sufficiently enforced with erased regions. =)
-        if ty.has_free_regions() || ty.has_projections() || ty.has_infer_types() {
+        if Self::can_contain_user_lifetime_bounds(ty) {
             let c_ty = self.infcx.canonicalize_response(&UserType::Ty(ty));
             debug!("to_ty_saving_user_provided_ty: c_ty={:?}", c_ty);
             self.tables.borrow_mut().user_provided_types_mut().insert(ast_ty.hir_id, c_ty);
         }
 
         ty
+    }
+
+    // If the type given by the user has free regions, save it for later, since
+    // NLL would like to enforce those. Also pass in types that involve
+    // projections, since those can resolve to `'static` bounds (modulo #54940,
+    // which hopefully will be fixed by the time you see this comment, dear
+    // reader, although I have my doubts). Also pass in types with inference
+    // types, because they may be repeated. Other sorts of things are already
+    // sufficiently enforced with erased regions. =)
+    fn can_contain_user_lifetime_bounds<T>(t: T) -> bool
+    where
+        T: TypeFoldable<'tcx>
+    {
+        t.has_free_regions() || t.has_projections() || t.has_infer_types()
     }
 
     pub fn node_ty(&self, id: hir::HirId) -> Ty<'tcx> {

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -165,7 +165,12 @@ impl<'a, 'tcx, 'rcx> Clean<Crate> for visit_ast::RustdocVisitor<'a, 'tcx, 'rcx> 
         match module.inner {
             ModuleItem(ref module) => {
                 for it in &module.items {
-                    if it.is_extern_crate() && it.attrs.has_doc_flag("masked") {
+                    // `compiler_builtins` should be masked too, but we can't apply
+                    // `#[doc(masked)]` to the injected `extern crate` because it's unstable.
+                    if it.is_extern_crate()
+                        && (it.attrs.has_doc_flag("masked")
+                            || self.cx.tcx.is_compiler_builtins(it.def_id.krate))
+                    {
                         masked_crates.insert(it.def_id.krate);
                     }
                 }

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -1598,7 +1598,7 @@ if (!DOMTokenList.prototype.remove) {
                 clearTimeout(searchTimeout);
                 if (search_input.value.length === 0) {
                     if (browserSupportsHistoryApi()) {
-                        history.replaceState("", "std - Rust", "?search=");
+                        history.replaceState("", window.currentCrate + " - Rust", "?search=");
                     }
                     if (hasClass(main, "content")) {
                         removeClass(main, "hidden");

--- a/src/test/ui/consts/min_const_fn/bad_const_fn_body_ice.stderr
+++ b/src/test/ui/consts/min_const_fn/bad_const_fn_body_ice.stderr
@@ -1,10 +1,12 @@
-error: heap allocations are not allowed in const fn
+error[E0723]: heap allocations are not allowed in const fn (see issue #57563)
   --> $DIR/bad_const_fn_body_ice.rs:2:5
    |
 LL |     vec![1, 2, 3] //~ ERROR heap allocations are not allowed in const fn
    |     ^^^^^^^^^^^^^
    |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0723`.

--- a/src/test/ui/consts/min_const_fn/cast_errors.stderr
+++ b/src/test/ui/consts/min_const_fn/cast_errors.stderr
@@ -1,32 +1,43 @@
-error: unsizing casts are not allowed in const fn
+error[E0723]: unsizing casts are not allowed in const fn (see issue #57563)
   --> $DIR/cast_errors.rs:3:41
    |
 LL | const fn unsize(x: &[u8; 3]) -> &[u8] { x }
    |                                         ^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: function pointers in const fn are unstable
+error[E0723]: function pointers in const fn are unstable (see issue #57563)
   --> $DIR/cast_errors.rs:5:23
    |
 LL | const fn closure() -> fn() { || {} }
    |                       ^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: function pointers in const fn are unstable
+error[E0723]: function pointers in const fn are unstable (see issue #57563)
   --> $DIR/cast_errors.rs:8:5
    |
 LL |     (|| {}) as fn();
    |     ^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: function pointers in const fn are unstable
+error[E0723]: function pointers in const fn are unstable (see issue #57563)
   --> $DIR/cast_errors.rs:11:28
    |
 LL | const fn reify(f: fn()) -> unsafe fn() { f }
    |                            ^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: function pointers in const fn are unstable
+error[E0723]: function pointers in const fn are unstable (see issue #57563)
   --> $DIR/cast_errors.rs:13:21
    |
 LL | const fn reify2() { main as unsafe fn(); }
    |                     ^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error: aborting due to 5 previous errors
 
+For more information about this error, try `rustc --explain E0723`.

--- a/src/test/ui/consts/min_const_fn/cmp_fn_pointers.stderr
+++ b/src/test/ui/consts/min_const_fn/cmp_fn_pointers.stderr
@@ -1,8 +1,11 @@
-error: function pointers in const fn are unstable
+error[E0723]: function pointers in const fn are unstable (see issue #57563)
   --> $DIR/cmp_fn_pointers.rs:1:14
    |
 LL | const fn cmp(x: fn(), y: fn()) -> bool { //~ ERROR function pointers in const fn are unstable
    |              ^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0723`.

--- a/src/test/ui/consts/min_const_fn/loop_ice.stderr
+++ b/src/test/ui/consts/min_const_fn/loop_ice.stderr
@@ -1,8 +1,11 @@
-error: loops are not allowed in const fn
+error[E0723]: loops are not allowed in const fn (see issue #57563)
   --> $DIR/loop_ice.rs:2:5
    |
 LL |     loop {} //~ ERROR loops are not allowed in const fn
    |     ^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0723`.

--- a/src/test/ui/consts/min_const_fn/min_const_fn.nll.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn.nll.stderr
@@ -4,11 +4,13 @@ error[E0493]: destructors cannot be evaluated at compile-time
 LL |     const fn into_inner(self) -> T { self.0 } //~ destructors cannot be evaluated
    |                         ^^^^ constant functions cannot evaluate destructors
 
-error: mutable references in const fn are unstable
+error[E0723]: mutable references in const fn are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:39:36
    |
 LL |     const fn get_mut(&mut self) -> &mut T { &mut self.0 }
    |                                    ^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error[E0493]: destructors cannot be evaluated at compile-time
   --> $DIR/min_const_fn.rs:44:28
@@ -16,11 +18,13 @@ error[E0493]: destructors cannot be evaluated at compile-time
 LL |     const fn into_inner_lt(self) -> T { self.0 } //~ destructors cannot be evaluated
    |                            ^^^^ constant functions cannot evaluate destructors
 
-error: mutable references in const fn are unstable
+error[E0723]: mutable references in const fn are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:46:42
    |
 LL |     const fn get_mut_lt(&'a mut self) -> &mut T { &mut self.0 }
    |                                          ^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error[E0493]: destructors cannot be evaluated at compile-time
   --> $DIR/min_const_fn.rs:51:27
@@ -28,173 +32,229 @@ error[E0493]: destructors cannot be evaluated at compile-time
 LL |     const fn into_inner_s(self) -> T { self.0 } //~ ERROR destructors
    |                           ^^^^ constant functions cannot evaluate destructors
 
-error: mutable references in const fn are unstable
+error[E0723]: mutable references in const fn are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:53:38
    |
 LL |     const fn get_mut_s(&mut self) -> &mut T { &mut self.0 }
    |                                      ^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: mutable references in const fn are unstable
+error[E0723]: mutable references in const fn are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:58:39
    |
 LL |     const fn get_mut_sq(&mut self) -> &mut T { &mut self.0 }
    |                                       ^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:76:16
    |
 LL | const fn foo11<T: std::fmt::Display>(t: T) -> T { t }
    |                ^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:78:18
    |
 LL | const fn foo11_2<T: Send>(t: T) -> T { t }
    |                  ^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: only int, `bool` and `char` operations are stable in const fn
+error[E0723]: only int, `bool` and `char` operations are stable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:80:33
    |
 LL | const fn foo19(f: f32) -> f32 { f * 2.0 }
    |                                 ^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: only int, `bool` and `char` operations are stable in const fn
+error[E0723]: only int, `bool` and `char` operations are stable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:82:35
    |
 LL | const fn foo19_2(f: f32) -> f32 { 2.0 - f }
    |                                   ^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: only int and `bool` operations are stable in const fn
+error[E0723]: only int and `bool` operations are stable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:84:35
    |
 LL | const fn foo19_3(f: f32) -> f32 { -f }
    |                                   ^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: only int, `bool` and `char` operations are stable in const fn
+error[E0723]: only int, `bool` and `char` operations are stable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:86:43
    |
 LL | const fn foo19_4(f: f32, g: f32) -> f32 { f / g }
    |                                           ^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: cannot access `static` items in const fn
+error[E0723]: cannot access `static` items in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:90:27
    |
 LL | const fn foo25() -> u32 { BAR } //~ ERROR cannot access `static` items in const fn
    |                           ^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: cannot access `static` items in const fn
+error[E0723]: cannot access `static` items in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:91:36
    |
 LL | const fn foo26() -> &'static u32 { &BAR } //~ ERROR cannot access `static` items
    |                                    ^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: casting pointers to ints is unstable in const fn
+error[E0723]: casting pointers to ints is unstable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:92:42
    |
 LL | const fn foo30(x: *const u32) -> usize { x as usize }
    |                                          ^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: casting pointers to ints is unstable in const fn
+error[E0723]: casting pointers to ints is unstable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:94:63
    |
 LL | const fn foo30_with_unsafe(x: *const u32) -> usize { unsafe { x as usize } }
    |                                                               ^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: casting pointers to ints is unstable in const fn
+error[E0723]: casting pointers to ints is unstable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:96:42
    |
 LL | const fn foo30_2(x: *mut u32) -> usize { x as usize }
    |                                          ^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: casting pointers to ints is unstable in const fn
+error[E0723]: casting pointers to ints is unstable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:98:63
    |
 LL | const fn foo30_2_with_unsafe(x: *mut u32) -> usize { unsafe { x as usize } }
    |                                                               ^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: `if`, `match`, `&&` and `||` are not stable in const fn
+error[E0723]: `if`, `match`, `&&` and `||` are not stable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:100:38
    |
 LL | const fn foo30_4(b: bool) -> usize { if b { 1 } else { 42 } }
    |                                      ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: `if`, `match`, `&&` and `||` are not stable in const fn
+error[E0723]: `if`, `match`, `&&` and `||` are not stable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:102:29
    |
 LL | const fn foo30_5(b: bool) { while b { } } //~ ERROR not stable in const fn
    |                             ^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: `if`, `match`, `&&` and `||` are not stable in const fn
+error[E0723]: `if`, `match`, `&&` and `||` are not stable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:104:44
    |
 LL | const fn foo36(a: bool, b: bool) -> bool { a && b }
    |                                            ^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: `if`, `match`, `&&` and `||` are not stable in const fn
+error[E0723]: `if`, `match`, `&&` and `||` are not stable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:106:44
    |
 LL | const fn foo37(a: bool, b: bool) -> bool { a || b }
    |                                            ^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: mutable references in const fn are unstable
+error[E0723]: mutable references in const fn are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:108:14
    |
 LL | const fn inc(x: &mut i32) { *x += 1 }
    |              ^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:113:6
    |
 LL | impl<T: std::fmt::Debug> Foo<T> {
    |      ^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:118:6
    |
 LL | impl<T: std::fmt::Debug + Sized> Foo<T> {
    |      ^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:123:6
    |
 LL | impl<T: Sync + Sized> Foo<T> {
    |      ^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: `impl Trait` in const fn is unstable
+error[E0723]: `impl Trait` in const fn is unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:129:24
    |
 LL | const fn no_rpit2() -> AlanTuring<impl std::fmt::Debug> { AlanTuring(0) }
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:131:34
    |
 LL | const fn no_apit2(_x: AlanTuring<impl std::fmt::Debug>) {}
    |                                  ^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:133:22
    |
 LL | const fn no_apit(_x: impl std::fmt::Debug) {} //~ ERROR trait bounds other than `Sized`
    |                      ^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: `impl Trait` in const fn is unstable
+error[E0723]: `impl Trait` in const fn is unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:134:23
    |
 LL | const fn no_rpit() -> impl std::fmt::Debug {} //~ ERROR `impl Trait` in const fn is unstable
    |                       ^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:135:23
    |
 LL | const fn no_dyn_trait(_x: &dyn std::fmt::Debug) {} //~ ERROR trait bounds other than `Sized`
    |                       ^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:136:32
    |
 LL | const fn no_dyn_trait_ret() -> &'static dyn std::fmt::Debug { &() }
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
 warning[E0515]: cannot return reference to temporary value
   --> $DIR/min_const_fn.rs:136:63
@@ -208,25 +268,31 @@ LL | const fn no_dyn_trait_ret() -> &'static dyn std::fmt::Debug { &() }
    = warning: this error has been downgraded to a warning for backwards compatibility with previous releases
    = warning: this represents potential undefined behavior in your code and this warning will become a hard error in the future
 
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:141:41
    |
 LL | const fn really_no_traits_i_mean_it() { (&() as &std::fmt::Debug, ()).1 }
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: function pointers in const fn are unstable
+error[E0723]: function pointers in const fn are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:144:21
    |
 LL | const fn no_fn_ptrs(_x: fn()) {}
    |                     ^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: function pointers in const fn are unstable
+error[E0723]: function pointers in const fn are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:146:27
    |
 LL | const fn no_fn_ptrs2() -> fn() { fn foo() {} foo }
    |                           ^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error: aborting due to 36 previous errors
 
-Some errors occurred: E0493, E0515.
+Some errors occurred: E0493, E0515, E0723.
 For more information about an error, try `rustc --explain E0493`.

--- a/src/test/ui/consts/min_const_fn/min_const_fn.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn.stderr
@@ -4,11 +4,13 @@ error[E0493]: destructors cannot be evaluated at compile-time
 LL |     const fn into_inner(self) -> T { self.0 } //~ destructors cannot be evaluated
    |                         ^^^^ constant functions cannot evaluate destructors
 
-error: mutable references in const fn are unstable
+error[E0723]: mutable references in const fn are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:39:36
    |
 LL |     const fn get_mut(&mut self) -> &mut T { &mut self.0 }
    |                                    ^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error[E0493]: destructors cannot be evaluated at compile-time
   --> $DIR/min_const_fn.rs:44:28
@@ -16,11 +18,13 @@ error[E0493]: destructors cannot be evaluated at compile-time
 LL |     const fn into_inner_lt(self) -> T { self.0 } //~ destructors cannot be evaluated
    |                            ^^^^ constant functions cannot evaluate destructors
 
-error: mutable references in const fn are unstable
+error[E0723]: mutable references in const fn are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:46:42
    |
 LL |     const fn get_mut_lt(&'a mut self) -> &mut T { &mut self.0 }
    |                                          ^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error[E0493]: destructors cannot be evaluated at compile-time
   --> $DIR/min_const_fn.rs:51:27
@@ -28,192 +32,255 @@ error[E0493]: destructors cannot be evaluated at compile-time
 LL |     const fn into_inner_s(self) -> T { self.0 } //~ ERROR destructors
    |                           ^^^^ constant functions cannot evaluate destructors
 
-error: mutable references in const fn are unstable
+error[E0723]: mutable references in const fn are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:53:38
    |
 LL |     const fn get_mut_s(&mut self) -> &mut T { &mut self.0 }
    |                                      ^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: mutable references in const fn are unstable
+error[E0723]: mutable references in const fn are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:58:39
    |
 LL |     const fn get_mut_sq(&mut self) -> &mut T { &mut self.0 }
    |                                       ^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:76:16
    |
 LL | const fn foo11<T: std::fmt::Display>(t: T) -> T { t }
    |                ^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:78:18
    |
 LL | const fn foo11_2<T: Send>(t: T) -> T { t }
    |                  ^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: only int, `bool` and `char` operations are stable in const fn
+error[E0723]: only int, `bool` and `char` operations are stable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:80:33
    |
 LL | const fn foo19(f: f32) -> f32 { f * 2.0 }
    |                                 ^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: only int, `bool` and `char` operations are stable in const fn
+error[E0723]: only int, `bool` and `char` operations are stable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:82:35
    |
 LL | const fn foo19_2(f: f32) -> f32 { 2.0 - f }
    |                                   ^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: only int and `bool` operations are stable in const fn
+error[E0723]: only int and `bool` operations are stable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:84:35
    |
 LL | const fn foo19_3(f: f32) -> f32 { -f }
    |                                   ^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: only int, `bool` and `char` operations are stable in const fn
+error[E0723]: only int, `bool` and `char` operations are stable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:86:43
    |
 LL | const fn foo19_4(f: f32, g: f32) -> f32 { f / g }
    |                                           ^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: cannot access `static` items in const fn
+error[E0723]: cannot access `static` items in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:90:27
    |
 LL | const fn foo25() -> u32 { BAR } //~ ERROR cannot access `static` items in const fn
    |                           ^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: cannot access `static` items in const fn
+error[E0723]: cannot access `static` items in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:91:36
    |
 LL | const fn foo26() -> &'static u32 { &BAR } //~ ERROR cannot access `static` items
    |                                    ^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: casting pointers to ints is unstable in const fn
+error[E0723]: casting pointers to ints is unstable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:92:42
    |
 LL | const fn foo30(x: *const u32) -> usize { x as usize }
    |                                          ^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: casting pointers to ints is unstable in const fn
+error[E0723]: casting pointers to ints is unstable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:94:63
    |
 LL | const fn foo30_with_unsafe(x: *const u32) -> usize { unsafe { x as usize } }
    |                                                               ^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: casting pointers to ints is unstable in const fn
+error[E0723]: casting pointers to ints is unstable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:96:42
    |
 LL | const fn foo30_2(x: *mut u32) -> usize { x as usize }
    |                                          ^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: casting pointers to ints is unstable in const fn
+error[E0723]: casting pointers to ints is unstable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:98:63
    |
 LL | const fn foo30_2_with_unsafe(x: *mut u32) -> usize { unsafe { x as usize } }
    |                                                               ^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: `if`, `match`, `&&` and `||` are not stable in const fn
+error[E0723]: `if`, `match`, `&&` and `||` are not stable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:100:38
    |
 LL | const fn foo30_4(b: bool) -> usize { if b { 1 } else { 42 } }
    |                                      ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: `if`, `match`, `&&` and `||` are not stable in const fn
+error[E0723]: `if`, `match`, `&&` and `||` are not stable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:102:29
    |
 LL | const fn foo30_5(b: bool) { while b { } } //~ ERROR not stable in const fn
    |                             ^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: `if`, `match`, `&&` and `||` are not stable in const fn
+error[E0723]: `if`, `match`, `&&` and `||` are not stable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:104:44
    |
 LL | const fn foo36(a: bool, b: bool) -> bool { a && b }
    |                                            ^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: `if`, `match`, `&&` and `||` are not stable in const fn
+error[E0723]: `if`, `match`, `&&` and `||` are not stable in const fn (see issue #57563)
   --> $DIR/min_const_fn.rs:106:44
    |
 LL | const fn foo37(a: bool, b: bool) -> bool { a || b }
    |                                            ^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: mutable references in const fn are unstable
+error[E0723]: mutable references in const fn are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:108:14
    |
 LL | const fn inc(x: &mut i32) { *x += 1 }
    |              ^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:113:6
    |
 LL | impl<T: std::fmt::Debug> Foo<T> {
    |      ^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:118:6
    |
 LL | impl<T: std::fmt::Debug + Sized> Foo<T> {
    |      ^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:123:6
    |
 LL | impl<T: Sync + Sized> Foo<T> {
    |      ^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: `impl Trait` in const fn is unstable
+error[E0723]: `impl Trait` in const fn is unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:129:24
    |
 LL | const fn no_rpit2() -> AlanTuring<impl std::fmt::Debug> { AlanTuring(0) }
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:131:34
    |
 LL | const fn no_apit2(_x: AlanTuring<impl std::fmt::Debug>) {}
    |                                  ^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:133:22
    |
 LL | const fn no_apit(_x: impl std::fmt::Debug) {} //~ ERROR trait bounds other than `Sized`
    |                      ^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: `impl Trait` in const fn is unstable
+error[E0723]: `impl Trait` in const fn is unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:134:23
    |
 LL | const fn no_rpit() -> impl std::fmt::Debug {} //~ ERROR `impl Trait` in const fn is unstable
    |                       ^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:135:23
    |
 LL | const fn no_dyn_trait(_x: &dyn std::fmt::Debug) {} //~ ERROR trait bounds other than `Sized`
    |                       ^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:136:32
    |
 LL | const fn no_dyn_trait_ret() -> &'static dyn std::fmt::Debug { &() }
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:141:41
    |
 LL | const fn really_no_traits_i_mean_it() { (&() as &std::fmt::Debug, ()).1 }
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: function pointers in const fn are unstable
+error[E0723]: function pointers in const fn are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:144:21
    |
 LL | const fn no_fn_ptrs(_x: fn()) {}
    |                     ^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: function pointers in const fn are unstable
+error[E0723]: function pointers in const fn are unstable (see issue #57563)
   --> $DIR/min_const_fn.rs:146:27
    |
 LL | const fn no_fn_ptrs2() -> fn() { fn foo() {} foo }
    |                           ^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error: aborting due to 36 previous errors
 
-For more information about this error, try `rustc --explain E0493`.
+Some errors occurred: E0493, E0723.
+For more information about an error, try `rustc --explain E0493`.

--- a/src/test/ui/consts/min_const_fn/min_const_fn_dyn.nll.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn_dyn.nll.stderr
@@ -1,14 +1,18 @@
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn_dyn.rs:9:5
    |
 LL |     x.0.field;
    |     ^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn_dyn.rs:12:66
    |
 LL | const fn no_inner_dyn_trait_ret() -> Hide { Hide(HasDyn { field: &0 }) }
    |                                                                  ^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
 warning[E0716]: temporary value dropped while borrowed
   --> $DIR/min_const_fn_dyn.rs:12:67
@@ -24,4 +28,5 @@ LL | const fn no_inner_dyn_trait_ret() -> Hide { Hide(HasDyn { field: &0 }) }
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0716`.
+Some errors occurred: E0716, E0723.
+For more information about an error, try `rustc --explain E0716`.

--- a/src/test/ui/consts/min_const_fn/min_const_fn_dyn.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn_dyn.stderr
@@ -1,14 +1,19 @@
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn_dyn.rs:9:5
    |
 LL |     x.0.field;
    |     ^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: trait bounds other than `Sized` on const fn parameters are unstable
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> $DIR/min_const_fn_dyn.rs:12:66
    |
 LL | const fn no_inner_dyn_trait_ret() -> Hide { Hide(HasDyn { field: &0 }) }
    |                                                                  ^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0723`.

--- a/src/test/ui/consts/min_const_fn/min_const_fn_fn_ptr.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn_fn_ptr.stderr
@@ -1,14 +1,19 @@
-error: function pointers in const fn are unstable
+error[E0723]: function pointers in const fn are unstable (see issue #57563)
   --> $DIR/min_const_fn_fn_ptr.rs:11:5
    |
 LL |     x.0.field;
    |     ^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: function pointers in const fn are unstable
+error[E0723]: function pointers in const fn are unstable (see issue #57563)
   --> $DIR/min_const_fn_fn_ptr.rs:14:59
    |
 LL | const fn no_inner_dyn_trait_ret() -> Hide { Hide(HasPtr { field }) }
    |                                                           ^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0723`.

--- a/src/test/ui/consts/min_const_fn/min_const_fn_libstd_stability.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn_libstd_stability.stderr
@@ -1,26 +1,35 @@
-error: can only call other `min_const_fn` within a `min_const_fn`
+error[E0723]: can only call other `min_const_fn` within a `min_const_fn` (see issue #57563)
   --> $DIR/min_const_fn_libstd_stability.rs:15:25
    |
 LL | const fn bar() -> u32 { foo() } //~ ERROR can only call other `min_const_fn`
    |                         ^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: can only call other `min_const_fn` within a `min_const_fn`
+error[E0723]: can only call other `min_const_fn` within a `min_const_fn` (see issue #57563)
   --> $DIR/min_const_fn_libstd_stability.rs:22:26
    |
 LL | const fn bar2() -> u32 { foo2() } //~ ERROR can only call other `min_const_fn`
    |                          ^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: only int, `bool` and `char` operations are stable in const fn
+error[E0723]: only int, `bool` and `char` operations are stable in const fn (see issue #57563)
   --> $DIR/min_const_fn_libstd_stability.rs:26:26
    |
 LL | const fn bar3() -> u32 { (5f32 + 6f32) as u32 } //~ ERROR only int, `bool` and `char` operations
    |                          ^^^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: can only call other `min_const_fn` within a `min_const_fn`
+error[E0723]: can only call other `min_const_fn` within a `min_const_fn` (see issue #57563)
   --> $DIR/min_const_fn_libstd_stability.rs:34:32
    |
 LL | const fn bar2_gated() -> u32 { foo2_gated() } //~ ERROR can only call other `min_const_fn`
    |                                ^^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error: aborting due to 4 previous errors
 
+For more information about this error, try `rustc --explain E0723`.

--- a/src/test/ui/consts/min_const_fn/min_const_unsafe_fn_libstd_stability.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_unsafe_fn_libstd_stability.stderr
@@ -1,26 +1,35 @@
-error: can only call other `min_const_fn` within a `min_const_fn`
+error[E0723]: can only call other `min_const_fn` within a `min_const_fn` (see issue #57563)
   --> $DIR/min_const_unsafe_fn_libstd_stability.rs:15:41
    |
 LL | const unsafe fn bar() -> u32 { unsafe { foo() } } //~ ERROR can only call other `min_const_fn`
    |                                         ^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: can only call other `min_const_fn` within a `min_const_fn`
+error[E0723]: can only call other `min_const_fn` within a `min_const_fn` (see issue #57563)
   --> $DIR/min_const_unsafe_fn_libstd_stability.rs:22:42
    |
 LL | const unsafe fn bar2() -> u32 { unsafe { foo2() } } //~ ERROR can only call other `min_const_fn`
    |                                          ^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: only int, `bool` and `char` operations are stable in const fn
+error[E0723]: only int, `bool` and `char` operations are stable in const fn (see issue #57563)
   --> $DIR/min_const_unsafe_fn_libstd_stability.rs:26:33
    |
 LL | const unsafe fn bar3() -> u32 { (5f32 + 6f32) as u32 } //~ ERROR only int, `bool` and `char` op
    |                                 ^^^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: can only call other `min_const_fn` within a `min_const_fn`
+error[E0723]: can only call other `min_const_fn` within a `min_const_fn` (see issue #57563)
   --> $DIR/min_const_unsafe_fn_libstd_stability.rs:34:48
    |
 LL | const unsafe fn bar2_gated() -> u32 { unsafe { foo2_gated() } } //~ ERROR can only call other
    |                                                ^^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error: aborting due to 4 previous errors
 
+For more information about this error, try `rustc --explain E0723`.

--- a/src/test/ui/consts/min_const_fn/min_const_unsafe_fn_libstd_stability2.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_unsafe_fn_libstd_stability2.stderr
@@ -1,20 +1,27 @@
-error: can only call other `min_const_fn` within a `min_const_fn`
+error[E0723]: can only call other `min_const_fn` within a `min_const_fn` (see issue #57563)
   --> $DIR/min_const_unsafe_fn_libstd_stability2.rs:15:32
    |
 LL | const unsafe fn bar() -> u32 { foo() } //~ ERROR can only call other `min_const_fn`
    |                                ^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: can only call other `min_const_fn` within a `min_const_fn`
+error[E0723]: can only call other `min_const_fn` within a `min_const_fn` (see issue #57563)
   --> $DIR/min_const_unsafe_fn_libstd_stability2.rs:22:33
    |
 LL | const unsafe fn bar2() -> u32 { foo2() } //~ ERROR can only call other `min_const_fn`
    |                                 ^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: can only call other `min_const_fn` within a `min_const_fn`
+error[E0723]: can only call other `min_const_fn` within a `min_const_fn` (see issue #57563)
   --> $DIR/min_const_unsafe_fn_libstd_stability2.rs:30:39
    |
 LL | const unsafe fn bar2_gated() -> u32 { foo2_gated() } //~ ERROR can only call other `min_const_fn`
    |                                       ^^^^^^^^^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error: aborting due to 3 previous errors
 
+For more information about this error, try `rustc --explain E0723`.

--- a/src/test/ui/consts/min_const_fn/mutable_borrow.stderr
+++ b/src/test/ui/consts/min_const_fn/mutable_borrow.stderr
@@ -1,14 +1,19 @@
-error: mutable references in const fn are unstable
+error[E0723]: mutable references in const fn are unstable (see issue #57563)
   --> $DIR/mutable_borrow.rs:3:9
    |
 LL |     let b = &mut a; //~ ERROR mutable references in const fn
    |         ^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: mutable references in const fn are unstable
+error[E0723]: mutable references in const fn are unstable (see issue #57563)
   --> $DIR/mutable_borrow.rs:12:13
    |
 LL |         let b = &mut a; //~ ERROR mutable references in const fn
    |             ^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0723`.

--- a/src/test/ui/consts/single_variant_match_ice.stderr
+++ b/src/test/ui/consts/single_variant_match_ice.stderr
@@ -10,12 +10,15 @@ error[E0019]: constant contains unimplemented expression type
 LL |     x => 42, //~ ERROR unimplemented expression type
    |     ^
 
-error: `if`, `match`, `&&` and `||` are not stable in const fn
+error[E0723]: `if`, `match`, `&&` and `||` are not stable in const fn (see issue #57563)
   --> $DIR/single_variant_match_ice.rs:18:13
    |
 LL |             Prob => 0x1, //~ ERROR `if`, `match`, `&&` and `||` are not stable in const fn
    |             ^^^^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error: aborting due to 3 previous errors
 
-For more information about this error, try `rustc --explain E0019`.
+Some errors occurred: E0019, E0723.
+For more information about an error, try `rustc --explain E0019`.

--- a/src/test/ui/issues/issue-37550.stderr
+++ b/src/test/ui/issues/issue-37550.stderr
@@ -1,8 +1,11 @@
-error: function pointers in const fn are unstable
+error[E0723]: function pointers in const fn are unstable (see issue #57563)
   --> $DIR/issue-37550.rs:3:9
    |
 LL |     let x = || t; //~ ERROR function pointers in const fn are unstable
    |         ^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0723`.

--- a/src/test/ui/issues/issue-57979.rs
+++ b/src/test/ui/issues/issue-57979.rs
@@ -1,0 +1,42 @@
+// Regression test for #57979. This situation is meant to be an error.
+// As noted in the issue thread, we decided to forbid nested impl
+// trait of this kind:
+//
+// ```rust
+// fn foo() -> impl Foo<impl Bar> { .. }
+// ```
+//
+// Basically there are two hidden variables here, let's call them `X`
+// and `Y`, and we must prove that:
+//
+// ```
+// X: Foo<Y>
+// Y: Bar
+// ```
+//
+// However, the user is only giving us the return type `X`. It's true
+// that in some cases, we can infer `Y` from `X`, because `X` only
+// implements `Foo` for one type (and indeed the compiler does
+// inference of this kind), but I do recall that we intended to forbid
+// this -- in part because such inference is fragile, and there is not
+// necessarily a way for the user to be more explicit should the
+// inference fail (so you could get stuck with no way to port your
+// code forward if, for example, more impls are added to an existing
+// type).
+//
+// The same seems to apply in this situation. Here there are three impl traits, so we have
+//
+// ```
+// X: IntoIterator<Item = Y>
+// Y: Borrow<Data<Z>>
+// Z: AsRef<[u8]>
+// ```
+
+use std::borrow::Borrow;
+
+pub struct Data<TBody>(TBody);
+
+pub fn collect(_: impl IntoIterator<Item = impl Borrow<Data<impl AsRef<[u8]>>>>) {
+    //~^ ERROR
+    unimplemented!()
+}

--- a/src/test/ui/issues/issue-57979.stderr
+++ b/src/test/ui/issues/issue-57979.stderr
@@ -1,0 +1,17 @@
+error[E0666]: nested `impl Trait` is not allowed
+  --> $DIR/issue-57979.rs:39:61
+   |
+LL | pub fn collect(_: impl IntoIterator<Item = impl Borrow<Data<impl AsRef<[u8]>>>>) {
+   |                                            -----------------^^^^^^^^^^^^^^^^--
+   |                                            |                |
+   |                                            |                nested `impl Trait` here
+   |                                            outer `impl Trait`
+
+error[E0601]: `main` function not found in crate `issue_57979`
+   |
+   = note: consider adding a `main` function to `$DIR/issue-57979.rs`
+
+error: aborting due to 2 previous errors
+
+Some errors occurred: E0601, E0666.
+For more information about an error, try `rustc --explain E0601`.

--- a/src/test/ui/nll/user-annotations/dump-adt-brace-struct.rs
+++ b/src/test/ui/nll/user-annotations/dump-adt-brace-struct.rs
@@ -15,5 +15,7 @@ fn main() {
 
     SomeStruct::<_> { t: 22 }; // Nothing interesting given, no annotation.
 
-    SomeStruct::<u32> { t: 22 }; //~ ERROR [u32]
+    SomeStruct::<u32> { t: 22 }; // No lifetime bounds given.
+
+    SomeStruct::<&'static u32> { t: &22 }; //~ ERROR [&ReStatic u32]
 }

--- a/src/test/ui/nll/user-annotations/dump-adt-brace-struct.stderr
+++ b/src/test/ui/nll/user-annotations/dump-adt-brace-struct.stderr
@@ -1,8 +1,8 @@
-error: user substs: UserSubsts { substs: [u32], user_self_ty: None }
-  --> $DIR/dump-adt-brace-struct.rs:18:5
+error: user substs: UserSubsts { substs: [&ReStatic u32], user_self_ty: None }
+  --> $DIR/dump-adt-brace-struct.rs:20:5
    |
-LL |     SomeStruct::<u32> { t: 22 }; //~ ERROR [u32]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     SomeStruct::<&'static u32> { t: &22 }; //~ ERROR [&ReStatic u32]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/user-annotations/dump-fn-method.stderr
+++ b/src/test/ui/nll/user-annotations/dump-fn-method.stderr
@@ -1,23 +1,23 @@
-error: user substs: UserSubsts { substs: [u32], user_self_ty: None }
-  --> $DIR/dump-fn-method.rs:26:13
+error: user substs: UserSubsts { substs: [&ReStatic u32], user_self_ty: None }
+  --> $DIR/dump-fn-method.rs:30:13
    |
-LL |     let x = foo::<u32>; //~ ERROR [u32]
-   |             ^^^^^^^^^^
+LL |     let x = foo::<&'static u32>; //~ ERROR [&ReStatic u32]
+   |             ^^^^^^^^^^^^^^^^^^^
 
 error: user substs: UserSubsts { substs: [^0, u32, ^1], user_self_ty: None }
-  --> $DIR/dump-fn-method.rs:32:13
+  --> $DIR/dump-fn-method.rs:36:13
    |
 LL |     let x = <_ as Bazoom<u32>>::method::<_>; //~ ERROR [^0, u32, ^1]
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: user substs: UserSubsts { substs: [u8, u16, u32], user_self_ty: None }
-  --> $DIR/dump-fn-method.rs:36:13
+error: user substs: UserSubsts { substs: [u8, &ReStatic u16, u32], user_self_ty: None }
+  --> $DIR/dump-fn-method.rs:45:13
    |
-LL |     let x = <u8 as Bazoom<u16>>::method::<u32>; //~ ERROR [u8, u16, u32]
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     let x = <u8 as Bazoom<&'static u16>>::method::<u32>; //~ ERROR [u8, &ReStatic u16, u32]
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: user substs: UserSubsts { substs: [^0, ^1, u32], user_self_ty: None }
-  --> $DIR/dump-fn-method.rs:44:5
+  --> $DIR/dump-fn-method.rs:53:5
    |
 LL |     y.method::<u32>(44, 66); //~ ERROR [^0, ^1, u32]
    |     ^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/nll/user-annotations/inherent-associated-constants.rs
+++ b/src/test/ui/nll/user-annotations/inherent-associated-constants.rs
@@ -1,0 +1,17 @@
+#![feature(nll)]
+
+struct A<'a>(&'a ());
+
+impl A<'static> {
+    const IC: i32 = 10;
+}
+
+fn non_wf_associated_const<'a>(x: i32) {
+    A::<'a>::IC; //~ ERROR lifetime may not live long enough
+}
+
+fn wf_associated_const<'a>(x: i32) {
+    A::<'static>::IC;
+}
+
+fn main() {}

--- a/src/test/ui/nll/user-annotations/inherent-associated-constants.stderr
+++ b/src/test/ui/nll/user-annotations/inherent-associated-constants.stderr
@@ -1,0 +1,10 @@
+error: lifetime may not live long enough
+  --> $DIR/inherent-associated-constants.rs:10:5
+   |
+LL | fn non_wf_associated_const<'a>(x: i32) {
+   |                            -- lifetime `'a` defined here
+LL |     A::<'a>::IC; //~ ERROR lifetime may not live long enough
+   |     ^^^^^^^^^^^ requires that `'a` must outlive `'static`
+
+error: aborting due to previous error
+

--- a/src/test/ui/unsafe/ranged_ints2_const.stderr
+++ b/src/test/ui/unsafe/ranged_ints2_const.stderr
@@ -1,14 +1,18 @@
-error: mutable references in const fn are unstable
+error[E0723]: mutable references in const fn are unstable (see issue #57563)
   --> $DIR/ranged_ints2_const.rs:11:9
    |
 LL |     let y = &mut x.0; //~ ERROR references in const fn are unstable
    |         ^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error: mutable references in const fn are unstable
+error[E0723]: mutable references in const fn are unstable (see issue #57563)
   --> $DIR/ranged_ints2_const.rs:18:9
    |
 LL |     let y = unsafe { &mut x.0 }; //~ ERROR mutable references in const fn are unstable
    |         ^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error[E0133]: mutation of layout constrained field is unsafe and requires unsafe function or block
   --> $DIR/ranged_ints2_const.rs:11:13
@@ -20,4 +24,5 @@ LL |     let y = &mut x.0; //~ ERROR references in const fn are unstable
 
 error: aborting due to 3 previous errors
 
-For more information about this error, try `rustc --explain E0133`.
+Some errors occurred: E0133, E0723.
+For more information about an error, try `rustc --explain E0133`.


### PR DESCRIPTION
Successful merges:

 - #57981 (Fix #57730)
 - #58196 (Add specific feature gate error for const-unstable features)
 - #58293 (Remove code for updating copyright years in generate-deriving-span-tests)
 - #58306 (Don't default on std crate when manipulating browser history)
 - #58353 (Check the Self-type of inherent associated constants)
 - #58429 (fix Box::into_unique effecitvely transmuting to a raw ptr)
 - #58433 (Update which libcore/liballoc tests Miri ignores, and document why)
 - #58438 (Use posix_spawn_file_actions_addchdir_np when possible)
 - #58448 (rustdoc: mask `compiler_builtins` docs)

Failed merges:


r? @ghost