### PR TITLE
[DO NOT MERGE] syntax: try ref-counting the AST.

### DIFF
--- a/src/libsyntax/attr/mod.rs
+++ b/src/libsyntax/attr/mod.rs
@@ -735,7 +735,7 @@ impl HasAttrs for ThinVec<Attribute> {
     }
 }
 
-impl<T: HasAttrs + 'static> HasAttrs for P<T> {
+impl<T: Clone + HasAttrs + 'static> HasAttrs for P<T> {
     fn attrs(&self) -> &[Attribute] {
         (**self).attrs()
     }


### PR DESCRIPTION
This an exploratory change, mainly to see what the costs around manipulating ASTs are.
Trying out an arena would be harder, as lifetimes would have to be added everywhere.
Also, AFAIK we don't have a "memory/time graph" of any sort, so it might be hard to profile.

cc @michaelwoerister @Mark-Simulacrum @Zoxc 