### PR TITLE
always back `ty::Const` by an `Allocation`

### DIFF
--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -375,11 +375,30 @@ impl_stable_hash_for!(enum ::syntax::ast::Mutability {
     Mutable
 });
 
-impl_stable_hash_for!(struct ty::Const<'tcx> {
-    ty,
-    alloc,
-    val
-});
+
+impl<'a, 'gcx> HashStable<StableHashingContext<'a>> for ty::Const<'gcx> {
+    fn hash_stable<W: StableHasherResult>(
+        &self,
+        hcx: &mut StableHashingContext<'a>,
+        hasher: &mut StableHasher<W>,
+    ) {
+        let ty::Const { ty, val, alloc } = self;
+        ty.hash_stable(hcx, hasher);
+        val.hash_stable(hcx, hasher);
+        // don't hash the memory for `Scalar` and `Slice`. There's nothing to be gained
+        // by it. All the relevant info is contained in the value.
+        if let mir::interpret::ConstValue::ByRef = val {
+            let (alloc, ptr) = alloc.unwrap();
+            // type check for future changes
+            let alloc: &'gcx mir::interpret::Allocation = alloc;
+            alloc.hash_stable(hcx, hasher);
+            ptr.offset.hash_stable(hcx, hasher);
+            // do not hash the alloc id in the pointer. It does not add anything new to the hash.
+            // If the hash of the alloc id is the same, then the hash of the allocation would also
+            // be the same.
+        }
+    }
+}
 
 impl_stable_hash_for!(impl<'tcx> for enum ty::LazyConst<'tcx> [ty::LazyConst] {
     Unevaluated(did, substs),

--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -300,12 +300,13 @@ impl_stable_hash_for!(struct ty::FieldDef {
 });
 
 impl_stable_hash_for!(
-    impl<'tcx> for enum mir::interpret::ConstValue<'tcx> [ mir::interpret::ConstValue ] {
+    impl<'tcx> for enum mir::interpret::ConstValue [ mir::interpret::ConstValue ] {
         Scalar(val),
         Slice(a, b),
-        ByRef(id, alloc, offset),
+        ByRef,
     }
 );
+
 impl_stable_hash_for!(struct crate::mir::interpret::RawConst<'tcx> {
     alloc_id,
     ty,
@@ -374,6 +375,7 @@ impl_stable_hash_for!(enum ::syntax::ast::Mutability {
 
 impl_stable_hash_for!(struct ty::Const<'tcx> {
     ty,
+    alloc,
     val
 });
 

--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -308,8 +308,10 @@ impl_stable_hash_for!(
 );
 
 impl_stable_hash_for!(struct crate::mir::interpret::RawConst<'tcx> {
+    // FIXME(oli-obk): is ignoring the `alloc_id` for perf reasons ok?
     alloc_id,
     ty,
+    alloc,
 });
 
 impl_stable_hash_for! {

--- a/src/librustc/mir/interpret/value.rs
+++ b/src/librustc/mir/interpret/value.rs
@@ -13,6 +13,9 @@ pub struct RawConst<'tcx> {
     pub ty: Ty<'tcx>,
     /// the allocation that would be returned by using
     /// `tcx.alloc_map.lock().unwrap_memory(self.alloc_id)`
+    ///
+    /// This is an optimization so we don't actually have to go fetch said allocation from the
+    /// `alloc_map` at most use sites of the `const_eval_raw` query
     pub alloc: &'tcx Allocation,
 }
 

--- a/src/librustc/mir/interpret/value.rs
+++ b/src/librustc/mir/interpret/value.rs
@@ -2,15 +2,18 @@ use std::fmt;
 
 use crate::ty::{Ty, layout::{HasDataLayout, Size}};
 
-use super::{EvalResult, Pointer, PointerArithmetic, AllocId, sign_extend, truncate};
+use super::{EvalResult, Pointer, PointerArithmetic, AllocId, sign_extend, truncate, Allocation};
 
 /// Represents the result of a raw const operation, pre-validation.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, RustcEncodable, RustcDecodable, Hash)]
 pub struct RawConst<'tcx> {
-    // the value lives here, at offset 0, and that allocation definitely is a `AllocKind::Memory`
-    // (so you can use `AllocMap::unwrap_memory`).
+    /// the value lives here, at offset 0, and the allocation that it refers to is the one in the
+    /// `alloc` field
     pub alloc_id: AllocId,
     pub ty: Ty<'tcx>,
+    /// the allocation that would be returned by using
+    /// `tcx.alloc_map.lock().unwrap_memory(self.alloc_id)`
+    pub alloc: &'tcx Allocation,
 }
 
 /// Represents a constant value in Rust. `Scalar` and `ScalarPair` are optimizations that

--- a/src/librustc/mir/interpret/value.rs
+++ b/src/librustc/mir/interpret/value.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use crate::ty::{Ty, layout::{HasDataLayout, Size}};
 
-use super::{EvalResult, Pointer, PointerArithmetic, Allocation, AllocId, sign_extend, truncate};
+use super::{EvalResult, Pointer, PointerArithmetic, AllocId, sign_extend, truncate};
 
 /// Represents the result of a raw const operation, pre-validation.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, RustcEncodable, RustcDecodable, Hash)]
@@ -16,7 +16,7 @@ pub struct RawConst<'tcx> {
 /// Represents a constant value in Rust. `Scalar` and `ScalarPair` are optimizations that
 /// match the `LocalState` optimizations for easy conversions between `Value` and `ConstValue`.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord, RustcEncodable, RustcDecodable, Hash)]
-pub enum ConstValue<'tcx> {
+pub enum ConstValue {
     /// Used only for types with `layout::abi::Scalar` ABI and ZSTs.
     ///
     /// Not using the enum `Value` to encode that this must not be `Undef`.
@@ -31,19 +31,17 @@ pub enum ConstValue<'tcx> {
     /// it.
     Slice(Scalar, u64),
 
-    /// An allocation together with an offset into the allocation.
-    /// Invariant: the `AllocId` matches the allocation.
-    ByRef(AllocId, &'tcx Allocation, Size),
+    ByRef,
 }
 
 #[cfg(target_arch = "x86_64")]
-static_assert!(CONST_SIZE: ::std::mem::size_of::<ConstValue<'static>>() == 40);
+static_assert!(CONST_SIZE: ::std::mem::size_of::<ConstValue>() == 40);
 
-impl<'tcx> ConstValue<'tcx> {
+impl ConstValue {
     #[inline]
     pub fn try_to_scalar(&self) -> Option<Scalar> {
         match *self {
-            ConstValue::ByRef(..) |
+            ConstValue::ByRef |
             ConstValue::Slice(..) => None,
             ConstValue::Scalar(val) => Some(val),
         }

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -1665,6 +1665,7 @@ impl<'tcx> TerminatorKind<'tcx> {
                                 }.into(),
                             ),
                             ty: switch_ty,
+                            alloc: None,
                         };
                         fmt_const_val(&mut s, c).unwrap();
                         s.into()

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -2132,6 +2132,8 @@ impl<'tcx> Hash for Const<'tcx> {
         let Const { ty, val, alloc } = self;
         ty.hash(hasher);
         val.hash(hasher);
+        // don't hash the memory for `Scalar` and `Slice`. There's nothing to be gained
+        // by it. All the relevant info is contained in the value.
         if let ConstValue::ByRef = val {
             let (alloc, ptr) = alloc.unwrap();
             // type check for future changes

--- a/src/librustc_codegen_llvm/consts.rs
+++ b/src/librustc_codegen_llvm/consts.rs
@@ -1,7 +1,7 @@
 use libc::c_uint;
 use llvm::{self, SetUnnamedAddr, True};
 use rustc::hir::def_id::DefId;
-use rustc::mir::interpret::{ConstValue, Allocation, read_target_uint,
+use rustc::mir::interpret::{Allocation, read_target_uint,
     Pointer, ErrorHandled, GlobalId};
 use rustc::hir::Node;
 use debuginfo;
@@ -69,12 +69,11 @@ pub fn codegen_static_initializer(
     };
     let param_env = ty::ParamEnv::reveal_all();
     let static_ = cx.tcx.const_eval(param_env.and(cid))?;
-    let (alloc, ptr) = static_.alloc.unwrap();
-    assert_eq!(ptr.offset.bytes(), 0);
-    match static_.val {
-        ConstValue::ByRef => {},
+    let (alloc, ptr) = match static_.alloc {
+        Some(alloc) => alloc,
         _ => bug!("static const eval returned {:#?}", static_),
-    }
+    };
+    assert_eq!(ptr.offset.bytes(), 0);
     Ok((const_alloc_to_llvm(cx, alloc), alloc))
 }
 

--- a/src/librustc_codegen_llvm/consts.rs
+++ b/src/librustc_codegen_llvm/consts.rs
@@ -69,11 +69,12 @@ pub fn codegen_static_initializer(
     };
     let param_env = ty::ParamEnv::reveal_all();
     let static_ = cx.tcx.const_eval(param_env.and(cid))?;
-
-    let alloc = match static_.val {
-        ConstValue::ByRef(_, alloc, n) if n.bytes() == 0 => alloc,
+    let (alloc, ptr) = static_.alloc.unwrap();
+    assert_eq!(ptr.offset.bytes(), 0);
+    match static_.val {
+        ConstValue::ByRef => {},
         _ => bug!("static const eval returned {:#?}", static_),
-    };
+    }
     Ok((const_alloc_to_llvm(cx, alloc), alloc))
 }
 

--- a/src/librustc_codegen_ssa/mir/operand.rs
+++ b/src/librustc_codegen_ssa/mir/operand.rs
@@ -101,8 +101,9 @@ impl<'a, 'tcx: 'a, V: CodegenObject> OperandRef<'tcx, V> {
                 let b_llval = bx.cx().const_usize(b);
                 OperandValue::Pair(a_llval, b_llval)
             },
-            ConstValue::ByRef(_, alloc, offset) => {
-                return Ok(bx.load_operand(bx.cx().from_const_alloc(layout, alloc, offset)));
+            ConstValue::ByRef => {
+                let (alloc, ptr) = val.alloc.unwrap();
+                return Ok(bx.load_operand(bx.cx().from_const_alloc(layout, alloc, ptr.offset)));
             },
         };
 

--- a/src/librustc_codegen_ssa/mir/place.rs
+++ b/src/librustc_codegen_ssa/mir/place.rs
@@ -417,8 +417,9 @@ impl<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 let layout = cx.layout_of(self.monomorphize(&ty));
                 match bx.tcx().const_eval(param_env.and(cid)) {
                     Ok(val) => match val.val {
-                        mir::interpret::ConstValue::ByRef(_, alloc, offset) => {
-                            bx.cx().from_const_alloc(layout, alloc, offset)
+                        mir::interpret::ConstValue::ByRef => {
+                            let (alloc, ptr) = val.alloc.unwrap();
+                            bx.cx().from_const_alloc(layout, alloc, ptr.offset)
                         }
                         _ => bug!("promoteds should have an allocation: {:?}", val),
                     },

--- a/src/librustc_codegen_ssa/mir/place.rs
+++ b/src/librustc_codegen_ssa/mir/place.rs
@@ -416,11 +416,8 @@ impl<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 };
                 let layout = cx.layout_of(self.monomorphize(&ty));
                 match bx.tcx().const_eval(param_env.and(cid)) {
-                    Ok(val) => match val.val {
-                        mir::interpret::ConstValue::ByRef => {
-                            let (alloc, ptr) = val.alloc.unwrap();
-                            bx.cx().from_const_alloc(layout, alloc, ptr.offset)
-                        }
+                    Ok(val) => match val.alloc {
+                        Some((alloc, ptr)) => bx.cx().from_const_alloc(layout, alloc, ptr.offset),
                         _ => bug!("promoteds should have an allocation: {:?}", val),
                     },
                     Err(_) => {

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -486,6 +486,9 @@ pub fn const_field<'a, 'tcx>(
     })();
     result.map_err(|error| {
         let err = error_to_const_error(&ecx, error);
+        // FIXME(oli-obk): I believe this is unreachable and we can just ICE here. Since a constant
+        // is checked for validity before being in a place that could pass it to `const_field`,
+        // we can't possibly have errors. All fields have already been checked.
         err.report_as_error(ecx.tcx, "could not access field of constant");
         ErrorHandled::Reported
     })

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -63,7 +63,7 @@ pub(crate) fn eval_promoted<'a, 'mir, 'tcx>(
 }
 
 // FIXME: These two conversion functions are bad hacks.  We should just always use allocations.
-pub fn op_to_const<'tcx>(
+fn op_to_const<'tcx>(
     ecx: &CompileTimeEvalContext<'_, '_, 'tcx>,
     op: OpTy<'tcx>,
 ) -> EvalResult<'tcx, ty::Const<'tcx>> {

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -66,15 +66,13 @@ pub(crate) fn eval_promoted<'a, 'mir, 'tcx>(
 pub fn op_to_const<'tcx>(
     ecx: &CompileTimeEvalContext<'_, '_, 'tcx>,
     op: OpTy<'tcx>,
-    may_normalize: bool,
 ) -> EvalResult<'tcx, ty::Const<'tcx>> {
     // We do not normalize just any data.  Only scalar layout and slices.
-    let normalize = may_normalize
-        && match op.layout.abi {
-            layout::Abi::Scalar(..) => true,
-            layout::Abi::ScalarPair(..) => op.layout.ty.is_slice(),
-            _ => false,
-        };
+    let normalize = match op.layout.abi {
+        layout::Abi::Scalar(..) => true,
+        layout::Abi::ScalarPair(..) => op.layout.ty.is_slice(),
+        _ => false,
+    };
     let normalized_op = if normalize {
         ecx.try_read_immediate(op)?
     } else {
@@ -489,7 +487,7 @@ pub fn const_field<'a, 'tcx>(
         let field = ecx.operand_field(down, field.index() as u64)?;
         // and finally move back to the const world, always normalizing because
         // this is not called for statics.
-        op_to_const(&ecx, field, true)
+        op_to_const(&ecx, field)
     })();
     result.map_err(|error| {
         let err = error_to_const_error(&ecx, error);

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -489,8 +489,12 @@ pub fn const_variant_index<'a, 'tcx>(
 ) -> EvalResult<'tcx, VariantIdx> {
     trace!("const_variant_index: {:?}", val);
     let ecx = mk_eval_cx(tcx, DUMMY_SP, param_env);
-    let op = ecx.lazy_const_to_op(ty::LazyConst::Evaluated(val), val.ty)?;
-    Ok(ecx.read_discriminant(op)?.1)
+    let (_, ptr) = val.alloc.expect(
+        "const_variant_index can only be called on aggregates, which should never be created without
+        a corresponding allocation",
+    );
+    let mplace = MPlaceTy::from_aligned_ptr(ptr, ecx.layout_of(val.ty)?);
+    Ok(ecx.read_discriminant(mplace.into())?.1)
 }
 
 pub fn error_to_const_error<'a, 'mir, 'tcx>(

--- a/src/librustc_mir/hair/constant.rs
+++ b/src/librustc_mir/hair/constant.rs
@@ -42,6 +42,7 @@ crate fn lit_to_const<'a, 'gcx, 'tcx>(
             let id = tcx.allocate_bytes(s.as_bytes());
             return Ok(ty::Const {
                 val: ConstValue::new_slice(Scalar::Ptr(id.into()), s.len() as u64),
+                alloc: None,
                 ty: tcx.types.err,
             });
         },
@@ -72,14 +73,14 @@ crate fn lit_to_const<'a, 'gcx, 'tcx>(
         LitKind::Bool(b) => ConstValue::Scalar(Scalar::from_bool(b)),
         LitKind::Char(c) => ConstValue::Scalar(Scalar::from_char(c)),
     };
-    Ok(ty::Const { val: lit, ty })
+    Ok(ty::Const { val: lit, ty, alloc: None })
 }
 
 fn parse_float<'tcx>(
     num: Symbol,
     fty: ast::FloatTy,
     neg: bool,
-) -> Result<ConstValue<'tcx>, ()> {
+) -> Result<ConstValue, ()> {
     let num = num.as_str();
     use rustc_apfloat::ieee::{Single, Double};
     use rustc_apfloat::Float;

--- a/src/librustc_mir/interpret/memory.rs
+++ b/src/librustc_mir/interpret/memory.rs
@@ -348,10 +348,9 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> Memory<'a, 'mir, 'tcx, M> {
                 ErrorHandled::TooGeneric => EvalErrorKind::TooGeneric.into(),
             }
         }).map(|raw_const| {
-            let allocation = tcx.alloc_map.lock().unwrap_memory(raw_const.alloc_id);
             // We got tcx memory. Let the machine figure out whether and how to
             // turn that into memory with the right pointer tag.
-            M::adjust_static_allocation(allocation, memory_extra)
+            M::adjust_static_allocation(raw_const.alloc, memory_extra)
         })
     }
 

--- a/src/librustc_mir/interpret/memory.rs
+++ b/src/librustc_mir/interpret/memory.rs
@@ -621,7 +621,7 @@ where
         &mut self,
         alloc_id: AllocId,
         mutability: Mutability,
-    ) -> EvalResult<'tcx> {
+    ) -> EvalResult<'tcx, &'tcx Allocation> {
         trace!(
             "mark_static_initialized {:?}, mutability: {:?}",
             alloc_id,
@@ -647,7 +647,7 @@ where
             // does not permit code that would break this!
             if self.alloc_map.contains_key(&alloc) {
                 // Not yet interned, so proceed recursively
-                self.intern_static(alloc, mutability)?;
+                let _alloc = self.intern_static(alloc, mutability)?;
             } else if self.dead_alloc_map.contains_key(&alloc) {
                 // dangling pointer
                 return err!(ValidationFailure(
@@ -655,7 +655,7 @@ where
                 ))
             }
         }
-        Ok(())
+        Ok(alloc)
     }
 }
 

--- a/src/librustc_mir/interpret/operand.rs
+++ b/src/librustc_mir/interpret/operand.rs
@@ -585,11 +585,14 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
             ty::LazyConst::Evaluated(c) => c,
         };
         match val.val {
-            ConstValue::ByRef(id, alloc, offset) => {
+            ConstValue::ByRef => {
+                let (alloc, ptr) = val.alloc.expect(
+                    "ByRef ty::Const must have corresponding Some alloc field",
+                );
                 // We rely on mutability being set correctly in that allocation to prevent writes
                 // where none should happen -- and for `static mut`, we copy on demand anyway.
                 Ok(Operand::Indirect(
-                    MemPlace::from_ptr(Pointer::new(id, offset), alloc.align)
+                    MemPlace::from_ptr(ptr, alloc.align)
                 ).with_default_tag())
             },
             ConstValue::Slice(a, b) =>

--- a/src/librustc_mir/interpret/operand.rs
+++ b/src/librustc_mir/interpret/operand.rs
@@ -269,7 +269,7 @@ pub(super) fn from_known_layout<'tcx>(
 impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> {
     /// Try reading an immediate in memory; this is interesting particularly for ScalarPair.
     /// Returns `None` if the layout does not permit loading this as a value.
-    pub(super) fn try_read_immediate_from_mplace(
+    crate fn try_read_immediate_from_mplace(
         &self,
         mplace: MPlaceTy<'tcx, M::PointerTag>,
     ) -> EvalResult<'tcx, Option<Immediate<M::PointerTag>>> {

--- a/src/librustc_mir/interpret/operand.rs
+++ b/src/librustc_mir/interpret/operand.rs
@@ -508,7 +508,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
 
     // Evaluate a place with the goal of reading from it.  This lets us sometimes
     // avoid allocations.
-    fn eval_place_to_op(
+    pub(super) fn eval_place_to_op(
         &self,
         mir_place: &mir::Place<'tcx>,
         layout: Option<TyLayout<'tcx>>,
@@ -522,7 +522,8 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
                 let op = self.eval_place_to_op(&proj.base, None)?;
                 self.operand_projection(op, &proj.elem)?
             }
-
+            // FIXME(oli-obk): statics and promoteds have preevaluated `val` fields nowadays
+            // add nonallocating variants here
             _ => self.eval_place_to_mplace(mir_place)?.into(),
         };
 

--- a/src/librustc_mir/interpret/operand.rs
+++ b/src/librustc_mir/interpret/operand.rs
@@ -548,7 +548,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
 
             Constant(ref constant) => {
                 let layout = from_known_layout(layout, || {
-                    let ty = self.monomorphize(mir_op.ty(self.mir(), *self.tcx))?;
+                    let ty = self.monomorphize(constant.ty)?;
                     self.layout_of(ty)
                 })?;
                 let op = self.const_value_to_op(*constant.literal)?;

--- a/src/librustc_mir/interpret/operand.rs
+++ b/src/librustc_mir/interpret/operand.rs
@@ -713,7 +713,7 @@ where
     M::MemoryMap: AllocMap<AllocId, (MemoryKind<M::MemoryKinds>, Allocation<(), M::AllocExtra>)>,
     M::AllocExtra: AllocationExtra<(), M::MemoryExtra>,
 {
-    // FIXME: CTFE should use allocations, then we can remove this.
+    /// FIXME: still used by const propagation, do not add new uses of this!
     pub(crate) fn lazy_const_to_op(
         &self,
         cnst: ty::LazyConst<'tcx>,

--- a/src/librustc_mir/interpret/operand.rs
+++ b/src/librustc_mir/interpret/operand.rs
@@ -12,7 +12,7 @@ use rustc::mir::interpret::{
     EvalResult, EvalErrorKind,
 };
 use super::{
-    EvalContext, Machine, AllocMap, Allocation, AllocationExtra,
+    EvalContext, Machine,
     MemPlace, MPlaceTy, PlaceTy, Place, MemoryKind,
 };
 pub use rustc::mir::interpret::ScalarMaybeUndef;
@@ -704,22 +704,4 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
         })
     }
 
-}
-
-impl<'a, 'mir, 'tcx, M> EvalContext<'a, 'mir, 'tcx, M>
-where
-    M: Machine<'a, 'mir, 'tcx, PointerTag=()>,
-    // FIXME: Working around https://github.com/rust-lang/rust/issues/24159
-    M::MemoryMap: AllocMap<AllocId, (MemoryKind<M::MemoryKinds>, Allocation<(), M::AllocExtra>)>,
-    M::AllocExtra: AllocationExtra<(), M::MemoryExtra>,
-{
-    /// FIXME: still used by const propagation, do not add new uses of this!
-    pub(crate) fn lazy_const_to_op(
-        &self,
-        cnst: ty::LazyConst<'tcx>,
-        ty: ty::Ty<'tcx>,
-    ) -> EvalResult<'tcx, OpTy<'tcx>> {
-        let op = self.const_value_to_op(cnst)?;
-        Ok(OpTy { op, layout: self.layout_of(ty)? })
-    }
 }

--- a/src/librustc_mir/interpret/operand.rs
+++ b/src/librustc_mir/interpret/operand.rs
@@ -569,7 +569,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
             .collect()
     }
 
-    // Used when Miri runs into a constant, and (indirectly through lazy_const_to_op) by CTFE.
+    // Used when Miri runs into a constant.
     fn const_value_to_op(
         &self,
         val: ty::LazyConst<'tcx>,

--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -58,7 +58,7 @@ impl<'tcx, Tag> ::std::ops::Deref for PlaceTy<'tcx, Tag> {
 }
 
 /// A MemPlace with its layout. Constructing it is only possible in this module.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 pub struct MPlaceTy<'tcx, Tag=()> {
     mplace: MemPlace<Tag>,
     pub layout: TyLayout<'tcx>,

--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -995,11 +995,14 @@ where
         &self,
         raw: RawConst<'tcx>,
     ) -> EvalResult<'tcx, MPlaceTy<'tcx, M::PointerTag>> {
-        // This must be an allocation in `tcx`
-        assert!(self.tcx.alloc_map.lock().get(raw.alloc_id).is_some());
+        // This must be an allocation in `tcx` and match the `alloc` field
+        debug_assert_eq!(
+            self.tcx.alloc_map.lock().unwrap_memory(raw.alloc_id) as *const _,
+            raw.alloc as *const _,
+        );
         let layout = self.layout_of(raw.ty)?;
         Ok(MPlaceTy::from_aligned_ptr(
-            Pointer::new(raw.alloc_id, Size::ZERO).with_default_tag(),
+            Pointer::from(raw.alloc_id).with_default_tag(),
             layout,
         ))
     }

--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -611,7 +611,7 @@ where
     }
 
     /// Computes a place. You should only use this if you intend to write into this
-    /// place; for reading, a more efficient alternative is `eval_place_for_read`.
+    /// place; for reading, a more efficient alternative is `eval_place_to_op`.
     pub fn eval_place(
         &mut self,
         mir_place: &mir::Place<'tcx>

--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -212,7 +212,7 @@ impl<'tcx, Tag> MPlaceTy<'tcx, Tag> {
     }
 
     #[inline]
-    fn from_aligned_ptr(ptr: Pointer<Tag>, layout: TyLayout<'tcx>) -> Self {
+    crate fn from_aligned_ptr(ptr: Pointer<Tag>, layout: TyLayout<'tcx>) -> Self {
         MPlaceTy { mplace: MemPlace::from_ptr(ptr, layout.align.abi), layout }
     }
 

--- a/src/librustc_mir/interpret/step.rs
+++ b/src/librustc_mir/interpret/step.rs
@@ -266,8 +266,8 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
             }
 
             Discriminant(ref place) => {
-                let place = self.eval_place(place)?;
-                let discr_val = self.read_discriminant(self.place_to_op(place)?)?.0;
+                let op = self.eval_place_to_op(place, None)?;
+                let discr_val = self.read_discriminant(op)?.0;
                 let size = dest.layout.size;
                 self.write_scalar(Scalar::from_uint(discr_val, size), dest)?;
             }

--- a/src/librustc_mir/interpret/validity.rs
+++ b/src/librustc_mir/interpret/validity.rs
@@ -11,7 +11,7 @@ use rustc::mir::interpret::{
 };
 
 use super::{
-    OpTy, Machine, EvalContext, ValueVisitor,
+    OpTy, Machine, EvalContext, ValueVisitor, MPlaceTy,
 };
 
 macro_rules! validation_failure {
@@ -74,13 +74,13 @@ pub enum PathElem {
 }
 
 /// State for tracking recursive validation of references
-pub struct RefTracking<'tcx, Tag> {
-    pub seen: FxHashSet<(OpTy<'tcx, Tag>)>,
-    pub todo: Vec<(OpTy<'tcx, Tag>, Vec<PathElem>)>,
+pub struct RefTracking<T> {
+    pub seen: FxHashSet<T>,
+    pub todo: Vec<(T, Vec<PathElem>)>,
 }
 
-impl<'tcx, Tag: Copy+Eq+Hash> RefTracking<'tcx, Tag> {
-    pub fn new(op: OpTy<'tcx, Tag>) -> Self {
+impl<'tcx, T: Copy + Eq + Hash> RefTracking<T> {
+    pub fn new(op: T) -> Self {
         let mut ref_tracking = RefTracking {
             seen: FxHashSet::default(),
             todo: vec![(op, Vec::new())],
@@ -151,7 +151,7 @@ struct ValidityVisitor<'rt, 'a: 'rt, 'mir: 'rt, 'tcx: 'a+'rt+'mir, M: Machine<'a
     /// starts must not be changed!  `visit_fields` and `visit_array` rely on
     /// this stack discipline.
     path: Vec<PathElem>,
-    ref_tracking: Option<&'rt mut RefTracking<'tcx, M::PointerTag>>,
+    ref_tracking: Option<&'rt mut RefTracking<MPlaceTy<'tcx, M::PointerTag>>>,
     const_mode: bool,
     ecx: &'rt EvalContext<'a, 'mir, 'tcx, M>,
 }
@@ -399,16 +399,15 @@ impl<'rt, 'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>>
                     // before.  Proceed recursively even for integer pointers, no
                     // reason to skip them! They are (recursively) valid for some ZST,
                     // but not for others (e.g., `!` is a ZST).
-                    let op = place.into();
-                    if ref_tracking.seen.insert(op) {
-                        trace!("Recursing below ptr {:#?}", *op);
+                    if ref_tracking.seen.insert(place) {
+                        trace!("Recursing below ptr {:#?}", *place);
                         // We need to clone the path anyway, make sure it gets created
                         // with enough space for the additional `Deref`.
                         let mut new_path = Vec::with_capacity(self.path.len()+1);
                         new_path.clone_from(&self.path);
                         new_path.push(PathElem::Deref);
                         // Remember to come back to this later.
-                        ref_tracking.todo.push((op, new_path));
+                        ref_tracking.todo.push((place, new_path));
                     }
                 }
             }
@@ -598,7 +597,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> EvalContext<'a, 'mir, 'tcx, M> 
         &self,
         op: OpTy<'tcx, M::PointerTag>,
         path: Vec<PathElem>,
-        ref_tracking: Option<&mut RefTracking<'tcx, M::PointerTag>>,
+        ref_tracking: Option<&mut RefTracking<MPlaceTy<'tcx, M::PointerTag>>>,
         const_mode: bool,
     ) -> EvalResult<'tcx> {
         trace!("validate_operand: {:?}, {:?}", *op, op.layout.ty);

--- a/src/librustc_mir/monomorphize/collector.rs
+++ b/src/librustc_mir/monomorphize/collector.rs
@@ -1257,11 +1257,12 @@ fn collect_const<'a, 'tcx>(
         ConstValue::Slice(Scalar::Ptr(ptr), _) |
         ConstValue::Scalar(Scalar::Ptr(ptr)) =>
             collect_miri(tcx, ptr.alloc_id, output),
-        ConstValue::ByRef(_id, alloc, _offset) => {
-            for &((), id) in alloc.relocations.values() {
-                collect_miri(tcx, id, output);
-            }
-        }
+        ConstValue::ByRef => {}
         _ => {},
+    }
+    if let Some((alloc, _)) = constant.alloc {
+        for &((), id) in alloc.relocations.values() {
+            collect_miri(tcx, id, output);
+        }
     }
 }

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -296,7 +296,7 @@ impl<'a, 'mir, 'tcx> ConstPropagator<'a, 'mir, 'tcx> {
                 };
                 // cannot use `const_eval` here, because that would require having the MIR
                 // for the current function available, but we're producing said MIR right now
-                let res = self.use_ecx(source_info, |this| {
+                let (res, _) = self.use_ecx(source_info, |this| {
                     eval_promoted(this.tcx, cid, this.mir, this.param_env)
                 })?;
                 trace!("evaluated promoted {:?} to {:?}", promoted, res);

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1464,8 +1464,8 @@ fn maybe_check_static_with_link_section(tcx: TyCtxt, id: DefId, span: Span) {
     };
     let param_env = ty::ParamEnv::reveal_all();
     if let Ok(static_) = tcx.const_eval(param_env.and(cid)) {
-        let alloc = if let ConstValue::ByRef(_, allocation, _) = static_.val {
-            allocation
+        let alloc = if let ConstValue::ByRef = static_.val {
+            static_.alloc.unwrap().0
         } else {
             bug!("Matching on non-ByRef static")
         };


### PR DESCRIPTION
This reduces the number of conversion between `Allocation` and `Value` by caching both.

r? @RalfJung 