### PR TITLE
[beta] Fix `attempted .def_id() on invalid def: NonMacroAttr(Builtin)`

### DIFF
--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -750,12 +750,11 @@ fn compute_all_traits<'a, 'gcx, 'tcx>(tcx: TyCtxt<'a, 'gcx, 'tcx>) -> Vec<DefId>
                            traits: &mut Vec<DefId>,
                            external_mods: &mut FxHashSet<DefId>,
                            def: Def) {
-        let def_id = def.def_id();
         match def {
-            Def::Trait(..) => {
+            Def::Trait(def_id) => {
                 traits.push(def_id);
             }
-            Def::Mod(..) => {
+            Def::Mod(def_id) => {
                 if !external_mods.insert(def_id) {
                     return;
                 }

--- a/src/librustdoc/visit_lib.rs
+++ b/src/librustdoc/visit_lib.rs
@@ -60,9 +60,11 @@ impl<'a, 'tcx, 'rcx> LibEmbargoVisitor<'a, 'tcx, 'rcx> {
         }
 
         for item in self.cx.tcx.item_children(def_id).iter() {
-            if self.cx.tcx.def_key(item.def.def_id()).parent.map_or(false, |d| d == def_id.index) ||
-                item.vis == Visibility::Public {
-                self.visit_item(item.def);
+            if let Some(def_id) = item.def.opt_def_id() {
+                if self.cx.tcx.def_key(def_id).parent.map_or(false, |d| d == def_id.index) ||
+                    item.vis == Visibility::Public {
+                    self.visit_item(item.def);
+                }
             }
         }
     }


### PR DESCRIPTION
backport of the fix so we can get update the bootstrap compiler to a compiler that has this fix. It's very hard to do development on stage 0/1 since resolve errors often end up with an ICE before outputting any useful diagnostics.

cc @rust-lang/compiler @rust-lang/infra I would like to fast-track this backport as it severly hampers @varkor's and my rustc developments. The ICE never happens for successful compiles, only if there are errors.

Since it is very minimalistic and can easily be reverted if desired I think/hope we can skip the usual beta nomination + beta accepted steps