### PR TITLE
Make external_html_url_root takes precedence over local dir

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1355,18 +1355,18 @@ fn clean_srcpath<F>(src_root: &Path, p: &Path, keep_filename: bool, mut f: F) wh
 fn extern_location(e: &clean::ExternalCrate, extern_url: Option<&str>, dst: &Path)
     -> ExternalLocation
 {
-    // See if there's documentation generated into the local directory
-    let local_location = dst.join(&e.name);
-    if local_location.is_dir() {
-        return Local;
-    }
-
     if let Some(url) = extern_url {
         let mut url = url.to_string();
         if !url.ends_with("/") {
             url.push('/');
         }
         return Remote(url);
+    }
+
+    // See if there's documentation generated into the local directory
+    let local_location = dst.join(&e.name);
+    if local_location.is_dir() {
+        return Local;
     }
 
     // Failing that, see if there's an attribute specifying where to find this


### PR DESCRIPTION
Fixes #58472

@QuietMisdreavus the only thing that we did was to check first if there was a local doc build for the external crate before checking anything else and I think this is the issue. Can you double-check please?

r? @QuietMisdreavus 