### PR TITLE
Special suggestion for illegal unicode curly quote pairs

### DIFF
--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -125,6 +125,28 @@ impl<'a> StringReader<'a> {
         Ok(ret_val)
     }
 
+    /// Immutably extract string if found at current position with given delimiters
+    pub fn peek_delimited(&self, from_ch: char, to_ch: char) -> Option<String> {
+        let mut pos = self.pos;
+        let mut idx = self.src_index(pos);
+        let mut ch = char_at(&self.src, idx);
+        if ch != from_ch {
+            return None;
+        }
+        pos = pos + Pos::from_usize(ch.len_utf8());
+        let start_pos = pos;
+        idx = self.src_index(pos);
+        while idx < self.end_src_index {
+            ch = char_at(&self.src, idx);
+            if ch == to_ch {
+                return Some(self.src[self.src_index(start_pos)..self.src_index(pos)].to_string());
+            }
+            pos = pos + Pos::from_usize(ch.len_utf8());
+            idx = self.src_index(pos);
+        }
+        return None;
+    }
+
     fn try_real_token(&mut self) -> Result<TokenAndSpan, ()> {
         let mut t = self.try_next_token()?;
         loop {

--- a/src/test/ui/parser/unicode-quote-chars.rs
+++ b/src/test/ui/parser/unicode-quote-chars.rs
@@ -1,0 +1,7 @@
+// ignore-tidy-linelength
+
+fn main() {
+    println!(“hello world”);
+    //~^ ERROR unknown start of token: \u{201c}
+    //~^^ HELP Unicode characters '“' (Left Double Quotation Mark) and '”' (Right Double Quotation Mark) look like '"' (Quotation Mark), but are not
+}

--- a/src/test/ui/parser/unicode-quote-chars.stderr
+++ b/src/test/ui/parser/unicode-quote-chars.stderr
@@ -1,0 +1,12 @@
+error: unknown start of token: /u{201c}
+  --> $DIR/unicode-quote-chars.rs:4:14
+   |
+LL |     println!(“hello world”);
+   |              ^
+help: Unicode characters '“' (Left Double Quotation Mark) and '”' (Right Double Quotation Mark) look like '"' (Quotation Mark), but are not
+   |
+LL |     println!("hello world");
+   |              ^^^^^^^^^^^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fixes #58436 

Did not end up expanding the error message span to include the full string literal since I figured the start of the token was the issue, while the help suggestion span would include up to the closing quotation mark.

The look ahead logic does not affect the reader position, not sure if that is an issue (if eg it should still continue to parse after the closing quote without erroring out).