### PR TITLE
publish_toolstate.py: further fix the runtime errors

### DIFF
--- a/src/tools/publish_toolstate.py
+++ b/src/tools/publish_toolstate.py
@@ -171,7 +171,7 @@ if __name__ == '__main__':
 
     # assume that PR authors are also owners of the repo where the branch lives
     relevant_pr_match = re.search(
-        'Auto merge of #([0-9]+) - ([^:]+):[^,]+ r=([^\s]+)',
+        r'Auto merge of #([0-9]+) - ([^:]+):[^,]+, r=(\S+)',
         cur_commit_msg,
     )
     if relevant_pr_match:
@@ -182,10 +182,10 @@ if __name__ == '__main__':
         pr_reviewer = relevant_pr_match.group(3)
     else:
         number = '-1'
-        relevant_pr_user = '<unknown user>'
+        relevant_pr_user = 'ghost'
         relevant_pr_number = '<unknown PR>'
         relevant_pr_url = '<unknown>'
-        pr_reviewer = '<unknown reviewer>'
+        pr_reviewer = 'ghost'
 
     message = update_latest(
         cur_commit,


### PR DESCRIPTION
The regex was missing a `,`, causing `relevant_pr_match` to become None and set the PR number to -1 and assigned the new issue to `@<unknown user>`. This causes the 422 error when creating the issue due to invalid assignee and unable to leave the tool-is-broken comment since PR -1 does not exist.

The default user names are now also changed to @ghost to prevent the 422 error in case anything goes wrong again.