### PR TITLE
Fix doc for rustc "-g" flag

### DIFF
--- a/src/doc/rustc/src/command-line-arguments.md
+++ b/src/doc/rustc/src/command-line-arguments.md
@@ -42,11 +42,11 @@ This flag prints out various information about the compiler.
 
 ## `-g`: include debug information
 
-A synonym for `-C debuginfo=2`.
+A synonym for `-C debuginfo=2`, for more see [here](codegen-options/index.html#debuginfo).
 
 ## `-O`: optimize your code
 
-A synonym for `-C opt-level=2`.
+A synonym for `-C opt-level=2`, for more see [here](codegen-options/index.html#opt-level).
 
 ## `-o`: filename of the output
 

--- a/src/doc/rustc/src/command-line-arguments.md
+++ b/src/doc/rustc/src/command-line-arguments.md
@@ -42,7 +42,7 @@ This flag prints out various information about the compiler.
 
 ## `-g`: include debug information
 
-A synonym for `-C debug-level=2`.
+A synonym for `-C debuginfo=2`.
 
 ## `-O`: optimize your code
 


### PR DESCRIPTION
The rustc `-g` CLI flag was miss documented to be a synonym of `-C debug-level=2` and not `-C debuglevel=2`. Also add links to the codegen docs for each synonym.

I am unsure of this will conflict with work on #52938