### PR TITLE
ci: fix docker cache hash collision

### DIFF
--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -20,9 +20,9 @@ travis_time_start
 if [ -f "$docker_dir/$image/Dockerfile" ]; then
     if [ "$CI" != "" ]; then
       hash_key=/tmp/.docker-hash-key.txt
-      find $docker_dir/$image $docker_dir/scripts -type f | \
-        sort | \
-        xargs cat >> $hash_key
+      rm -f "${hash_key}"
+      echo $image >> $hash_key
+      find $docker_dir -type f | sort | xargs cat >> $hash_key
       docker --version >> $hash_key
       cksum=$(sha512sum $hash_key | \
         awk '{print $1}')


### PR DESCRIPTION
#58416 uncovered a bug in our caching for docker images: if the image `foo` pulls files from the image `bar` and a file in `bar` changed, the hash of `foo` will be the same even though it should be different. In that PR's case, `dist-i686-linux` pulls scripts from `dist-x86_64-linux`, and the PR only changed those scripts, causing an hash collision for `dist-i686-linux`.

We have to fix this, since the image will be rebuilt every time bors switches from testing master to testing beta/stable (and when it switches back), making CI way more painful than it currently is.

The approach used by this PR is to just include all the files in `src/ci/docker` in the hash. It's a bit heavy-handed and it will cause a rebuild of all the images every time a single image changes, but it's the best I can think of.

r? @Mark-Simulacrum 
cc @alexcrichton @kennytm 