### PR TITLE
Use more impl header lifetime elision

### DIFF
--- a/src/liballoc/borrow.rs
+++ b/src/liballoc/borrow.rs
@@ -182,8 +182,8 @@ pub enum Cow<'a, B: ?Sized + 'a>
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, B: ?Sized + ToOwned> Clone for Cow<'a, B> {
-    fn clone(&self) -> Cow<'a, B> {
+impl<B: ?Sized + ToOwned> Clone for Cow<'_, B> {
+    fn clone(&self) -> Self {
         match *self {
             Borrowed(b) => Borrowed(b),
             Owned(ref o) => {
@@ -193,7 +193,7 @@ impl<'a, B: ?Sized + ToOwned> Clone for Cow<'a, B> {
         }
     }
 
-    fn clone_from(&mut self, source: &Cow<'a, B>) {
+    fn clone_from(&mut self, source: &Self) {
         if let Owned(ref mut dest) = *self {
             if let Owned(ref o) = *source {
                 o.borrow().clone_into(dest);
@@ -296,11 +296,11 @@ impl<B: ?Sized + ToOwned> Deref for Cow<'_, B> {
 impl<B: ?Sized> Eq for Cow<'_, B> where B: Eq + ToOwned {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, B: ?Sized> Ord for Cow<'a, B>
+impl<B: ?Sized> Ord for Cow<'_, B>
     where B: Ord + ToOwned
 {
     #[inline]
-    fn cmp(&self, other: &Cow<'a, B>) -> Ordering {
+    fn cmp(&self, other: &Self) -> Ordering {
         Ord::cmp(&**self, &**other)
     }
 }
@@ -353,18 +353,18 @@ impl<B: ?Sized> fmt::Display for Cow<'_, B>
 }
 
 #[stable(feature = "default", since = "1.11.0")]
-impl<'a, B: ?Sized> Default for Cow<'a, B>
+impl<B: ?Sized> Default for Cow<'_, B>
     where B: ToOwned,
           <B as ToOwned>::Owned: Default
 {
     /// Creates an owned Cow<'a, B> with the default value for the contained owned value.
-    fn default() -> Cow<'a, B> {
+    fn default() -> Self {
         Owned(<B as ToOwned>::Owned::default())
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, B: ?Sized> Hash for Cow<'a, B>
+impl<B: ?Sized> Hash for Cow<'_, B>
     where B: Hash + ToOwned
 {
     #[inline]

--- a/src/liballoc/collections/binary_heap.rs
+++ b/src/liballoc/collections/binary_heap.rs
@@ -947,8 +947,8 @@ impl<T: fmt::Debug> fmt::Debug for Iter<'_, T> {
 
 // FIXME(#26925) Remove in favor of `#[derive(Clone)]`
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, T> Clone for Iter<'a, T> {
-    fn clone(&self) -> Iter<'a, T> {
+impl<T> Clone for Iter<'_, T> {
+    fn clone(&self) -> Self {
         Iter { iter: self.iter.clone() }
     }
 }

--- a/src/liballoc/collections/btree/map.rs
+++ b/src/liballoc/collections/btree/map.rs
@@ -1218,8 +1218,8 @@ impl<K, V> ExactSizeIterator for Iter<'_, K, V> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, K, V> Clone for Iter<'a, K, V> {
-    fn clone(&self) -> Iter<'a, K, V> {
+impl<K, V> Clone for Iter<'_, K, V> {
+    fn clone(&self) -> Self {
         Iter {
             range: self.range.clone(),
             length: self.length,
@@ -1441,8 +1441,8 @@ impl<K, V> ExactSizeIterator for Keys<'_, K, V> {
 impl<K, V> FusedIterator for Keys<'_, K, V> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, K, V> Clone for Keys<'a, K, V> {
-    fn clone(&self) -> Keys<'a, K, V> {
+impl<K, V> Clone for Keys<'_, K, V> {
+    fn clone(&self) -> Self {
         Keys { inner: self.inner.clone() }
     }
 }
@@ -1478,8 +1478,8 @@ impl<K, V> ExactSizeIterator for Values<'_, K, V> {
 impl<K, V> FusedIterator for Values<'_, K, V> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, K, V> Clone for Values<'a, K, V> {
-    fn clone(&self) -> Values<'a, K, V> {
+impl<K, V> Clone for Values<'_, K, V> {
+    fn clone(&self) -> Self {
         Values { inner: self.inner.clone() }
     }
 }
@@ -1606,8 +1606,8 @@ impl<'a, K, V> Range<'a, K, V> {
 impl<K, V> FusedIterator for Range<'_, K, V> {}
 
 #[stable(feature = "btree_range", since = "1.17.0")]
-impl<'a, K, V> Clone for Range<'a, K, V> {
-    fn clone(&self) -> Range<'a, K, V> {
+impl<K, V> Clone for Range<'_, K, V> {
+    fn clone(&self) -> Self {
         Range {
             front: self.front,
             back: self.back,

--- a/src/liballoc/collections/btree/set.rs
+++ b/src/liballoc/collections/btree/set.rs
@@ -907,8 +907,8 @@ impl<T: Debug> Debug for BTreeSet<T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, T> Clone for Iter<'a, T> {
-    fn clone(&self) -> Iter<'a, T> {
+impl<T> Clone for Iter<'_, T> {
+    fn clone(&self) -> Self {
         Iter { iter: self.iter.clone() }
     }
 }
@@ -963,8 +963,8 @@ impl<T> ExactSizeIterator for IntoIter<T> {
 impl<T> FusedIterator for IntoIter<T> {}
 
 #[stable(feature = "btree_range", since = "1.17.0")]
-impl<'a, T> Clone for Range<'a, T> {
-    fn clone(&self) -> Range<'a, T> {
+impl<T> Clone for Range<'_, T> {
+    fn clone(&self) -> Self {
         Range { iter: self.iter.clone() }
     }
 }
@@ -998,8 +998,8 @@ fn cmp_opt<T: Ord>(x: Option<&T>, y: Option<&T>, short: Ordering, long: Ordering
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, T> Clone for Difference<'a, T> {
-    fn clone(&self) -> Difference<'a, T> {
+impl<T> Clone for Difference<'_, T> {
+    fn clone(&self) -> Self {
         Difference {
             a: self.a.clone(),
             b: self.b.clone(),
@@ -1036,8 +1036,8 @@ impl<'a, T: Ord> Iterator for Difference<'a, T> {
 impl<T: Ord> FusedIterator for Difference<'_, T> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, T> Clone for SymmetricDifference<'a, T> {
-    fn clone(&self) -> SymmetricDifference<'a, T> {
+impl<T> Clone for SymmetricDifference<'_, T> {
+    fn clone(&self) -> Self {
         SymmetricDifference {
             a: self.a.clone(),
             b: self.b.clone(),
@@ -1070,8 +1070,8 @@ impl<'a, T: Ord> Iterator for SymmetricDifference<'a, T> {
 impl<T: Ord> FusedIterator for SymmetricDifference<'_, T> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, T> Clone for Intersection<'a, T> {
-    fn clone(&self) -> Intersection<'a, T> {
+impl<T> Clone for Intersection<'_, T> {
+    fn clone(&self) -> Self {
         Intersection {
             a: self.a.clone(),
             b: self.b.clone(),
@@ -1108,8 +1108,8 @@ impl<'a, T: Ord> Iterator for Intersection<'a, T> {
 impl<T: Ord> FusedIterator for Intersection<'_, T> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, T> Clone for Union<'a, T> {
-    fn clone(&self) -> Union<'a, T> {
+impl<T> Clone for Union<'_, T> {
+    fn clone(&self) -> Self {
         Union {
             a: self.a.clone(),
             b: self.b.clone(),

--- a/src/liballoc/collections/linked_list.rs
+++ b/src/liballoc/collections/linked_list.rs
@@ -1200,16 +1200,16 @@ unsafe impl<T: Send> Send for LinkedList<T> {}
 unsafe impl<T: Sync> Sync for LinkedList<T> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
-unsafe impl<'a, T: Sync> Send for Iter<'a, T> {}
+unsafe impl<T: Sync> Send for Iter<'_, T> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
-unsafe impl<'a, T: Sync> Sync for Iter<'a, T> {}
+unsafe impl<T: Sync> Sync for Iter<'_, T> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
-unsafe impl<'a, T: Send> Send for IterMut<'a, T> {}
+unsafe impl<T: Send> Send for IterMut<'_, T> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
-unsafe impl<'a, T: Sync> Sync for IterMut<'a, T> {}
+unsafe impl<T: Sync> Sync for IterMut<'_, T> {}
 
 #[cfg(test)]
 mod tests {

--- a/src/liballoc/collections/vec_deque.rs
+++ b/src/liballoc/collections/vec_deque.rs
@@ -2132,8 +2132,8 @@ impl<T: fmt::Debug> fmt::Debug for Iter<'_, T> {
 
 // FIXME(#26925) Remove in favor of `#[derive(Clone)]`
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, T> Clone for Iter<'a, T> {
-    fn clone(&self) -> Iter<'a, T> {
+impl<T> Clone for Iter<'_, T> {
+    fn clone(&self) -> Self {
         Iter {
             ring: self.ring,
             tail: self.tail,
@@ -2225,7 +2225,7 @@ pub struct IterMut<'a, T: 'a> {
 }
 
 #[stable(feature = "collection_debug", since = "1.17.0")]
-impl<'a, T: fmt::Debug> fmt::Debug for IterMut<'_, T> {
+impl<T: fmt::Debug> fmt::Debug for IterMut<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let (front, back) = RingSlices::ring_slices(&*self.ring, self.head, self.tail);
         f.debug_tuple("IterMut")

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2455,7 +2455,7 @@ pub struct Drain<'a, T: 'a> {
 }
 
 #[stable(feature = "collection_debug", since = "1.17.0")]
-impl<'a, T: 'a + fmt::Debug> fmt::Debug for Drain<'a, T> {
+impl<T: fmt::Debug> fmt::Debug for Drain<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("Drain")
          .field(&self.iter.as_slice())

--- a/src/libcore/future/future.rs
+++ b/src/libcore/future/future.rs
@@ -100,7 +100,7 @@ pub trait Future {
     fn poll(self: Pin<&mut Self>, lw: &LocalWaker) -> Poll<Self::Output>;
 }
 
-impl<'a, F: ?Sized + Future + Unpin> Future for &'a mut F {
+impl<F: ?Sized + Future + Unpin> Future for &mut F {
     type Output = F::Output;
 
     fn poll(mut self: Pin<&mut Self>, lw: &LocalWaker) -> Poll<Self::Output> {

--- a/src/libcore/internal_macros.rs
+++ b/src/libcore/internal_macros.rs
@@ -7,7 +7,7 @@ macro_rules! forward_ref_unop {
     };
     (impl $imp:ident, $method:ident for $t:ty, #[$attr:meta]) => {
         #[$attr]
-        impl<'a> $imp for &'a $t {
+        impl $imp for &$t {
             type Output = <$t as $imp>::Output;
 
             #[inline]

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -874,7 +874,7 @@ impl<T> Option<T> {
     }
 }
 
-impl<'a, T: Copy> Option<&'a T> {
+impl<T: Copy> Option<&T> {
     /// Maps an `Option<&T>` to an `Option<T>` by copying the contents of the
     /// option.
     ///
@@ -895,7 +895,7 @@ impl<'a, T: Copy> Option<&'a T> {
     }
 }
 
-impl<'a, T: Copy> Option<&'a mut T> {
+impl<T: Copy> Option<&mut T> {
     /// Maps an `Option<&mut T>` to an `Option<T>` by copying the contents of the
     /// option.
     ///
@@ -916,7 +916,7 @@ impl<'a, T: Copy> Option<&'a mut T> {
     }
 }
 
-impl<'a, T: Clone> Option<&'a T> {
+impl<T: Clone> Option<&T> {
     /// Maps an `Option<&T>` to an `Option<T>` by cloning the contents of the
     /// option.
     ///
@@ -935,7 +935,7 @@ impl<'a, T: Clone> Option<&'a T> {
     }
 }
 
-impl<'a, T: Clone> Option<&'a mut T> {
+impl<T: Clone> Option<&mut T> {
     /// Maps an `Option<&mut T>` to an `Option<T>` by cloning the contents of the
     /// option.
     ///

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -2899,7 +2899,7 @@ macro_rules! iterator {
         }
 
         #[stable(feature = "rust1", since = "1.0.0")]
-        impl<'a, T> ExactSizeIterator for $name<'a, T> {
+        impl<T> ExactSizeIterator for $name<'_, T> {
             #[inline(always)]
             fn len(&self) -> usize {
                 len!(self)
@@ -3094,10 +3094,10 @@ macro_rules! iterator {
         }
 
         #[stable(feature = "fused", since = "1.26.0")]
-        impl<'a, T> FusedIterator for $name<'a, T> {}
+        impl<T> FusedIterator for $name<'_, T> {}
 
         #[unstable(feature = "trusted_len", issue = "37572")]
-        unsafe impl<'a, T> TrustedLen for $name<'a, T> {}
+        unsafe impl<T> TrustedLen for $name<'_, T> {}
     }
 }
 
@@ -4361,8 +4361,8 @@ pub struct RChunks<'a, T:'a> {
 
 // FIXME(#26925) Remove in favor of `#[derive(Clone)]`
 #[stable(feature = "rchunks", since = "1.31.0")]
-impl<'a, T> Clone for RChunks<'a, T> {
-    fn clone(&self) -> RChunks<'a, T> {
+impl<T> Clone for RChunks<'_, T> {
+    fn clone(&self) -> Self {
         RChunks {
             v: self.v,
             chunk_size: self.chunk_size,
@@ -4451,13 +4451,13 @@ impl<'a, T> DoubleEndedIterator for RChunks<'a, T> {
 }
 
 #[stable(feature = "rchunks", since = "1.31.0")]
-impl<'a, T> ExactSizeIterator for RChunks<'a, T> {}
+impl<T> ExactSizeIterator for RChunks<'_, T> {}
 
 #[unstable(feature = "trusted_len", issue = "37572")]
-unsafe impl<'a, T> TrustedLen for RChunks<'a, T> {}
+unsafe impl<T> TrustedLen for RChunks<'_, T> {}
 
 #[stable(feature = "rchunks", since = "1.31.0")]
-impl<'a, T> FusedIterator for RChunks<'a, T> {}
+impl<T> FusedIterator for RChunks<'_, T> {}
 
 #[doc(hidden)]
 #[stable(feature = "rchunks", since = "1.31.0")]
@@ -4576,13 +4576,13 @@ impl<'a, T> DoubleEndedIterator for RChunksMut<'a, T> {
 }
 
 #[stable(feature = "rchunks", since = "1.31.0")]
-impl<'a, T> ExactSizeIterator for RChunksMut<'a, T> {}
+impl<T> ExactSizeIterator for RChunksMut<'_, T> {}
 
 #[unstable(feature = "trusted_len", issue = "37572")]
-unsafe impl<'a, T> TrustedLen for RChunksMut<'a, T> {}
+unsafe impl<T> TrustedLen for RChunksMut<'_, T> {}
 
 #[stable(feature = "rchunks", since = "1.31.0")]
-impl<'a, T> FusedIterator for RChunksMut<'a, T> {}
+impl<T> FusedIterator for RChunksMut<'_, T> {}
 
 #[doc(hidden)]
 #[stable(feature = "rchunks", since = "1.31.0")]
@@ -4707,10 +4707,10 @@ impl<'a, T> ExactSizeIterator for RChunksExact<'a, T> {
 }
 
 #[unstable(feature = "trusted_len", issue = "37572")]
-unsafe impl<'a, T> TrustedLen for RChunksExact<'a, T> {}
+unsafe impl<T> TrustedLen for RChunksExact<'_, T> {}
 
 #[stable(feature = "rchunks", since = "1.31.0")]
-impl<'a, T> FusedIterator for RChunksExact<'a, T> {}
+impl<T> FusedIterator for RChunksExact<'_, T> {}
 
 #[doc(hidden)]
 #[stable(feature = "rchunks", since = "1.31.0")]
@@ -4818,17 +4818,17 @@ impl<'a, T> DoubleEndedIterator for RChunksExactMut<'a, T> {
 }
 
 #[stable(feature = "rchunks", since = "1.31.0")]
-impl<'a, T> ExactSizeIterator for RChunksExactMut<'a, T> {
+impl<T> ExactSizeIterator for RChunksExactMut<'_, T> {
     fn is_empty(&self) -> bool {
         self.v.is_empty()
     }
 }
 
 #[unstable(feature = "trusted_len", issue = "37572")]
-unsafe impl<'a, T> TrustedLen for RChunksExactMut<'a, T> {}
+unsafe impl<T> TrustedLen for RChunksExactMut<'_, T> {}
 
 #[stable(feature = "rchunks", since = "1.31.0")]
-impl<'a, T> FusedIterator for RChunksExactMut<'a, T> {}
+impl<T> FusedIterator for RChunksExactMut<'_, T> {}
 
 #[doc(hidden)]
 #[stable(feature = "rchunks", since = "1.31.0")]

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -820,7 +820,7 @@ impl FusedIterator for Bytes<'_> {}
 unsafe impl TrustedLen for Bytes<'_> {}
 
 #[doc(hidden)]
-unsafe impl<'a> TrustedRandomAccess for Bytes<'a> {
+unsafe impl TrustedRandomAccess for Bytes<'_> {
     unsafe fn get_unchecked(&mut self, i: usize) -> u8 {
         self.0.get_unchecked(i)
     }

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -1641,7 +1641,7 @@ impl<K, V, S> Default for HashMap<K, V, S>
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, K, Q: ?Sized, V, S> Index<&'a Q> for HashMap<K, V, S>
+impl<K, Q: ?Sized, V, S> Index<&Q> for HashMap<K, V, S>
     where K: Eq + Hash + Borrow<Q>,
           Q: Eq + Hash,
           S: BuildHasher
@@ -1673,14 +1673,14 @@ pub struct Iter<'a, K: 'a, V: 'a> {
 
 // FIXME(#26925) Remove in favor of `#[derive(Clone)]`
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, K, V> Clone for Iter<'a, K, V> {
-    fn clone(&self) -> Iter<'a, K, V> {
+impl<K, V> Clone for Iter<'_, K, V> {
+    fn clone(&self) -> Self {
         Iter { inner: self.inner.clone() }
     }
 }
 
 #[stable(feature = "std_debug", since = "1.16.0")]
-impl<'a, K: Debug, V: Debug> fmt::Debug for Iter<'a, K, V> {
+impl<K: Debug, V: Debug> fmt::Debug for Iter<'_, K, V> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_list()
             .entries(self.clone())
@@ -1726,14 +1726,14 @@ pub struct Keys<'a, K: 'a, V: 'a> {
 
 // FIXME(#26925) Remove in favor of `#[derive(Clone)]`
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, K, V> Clone for Keys<'a, K, V> {
-    fn clone(&self) -> Keys<'a, K, V> {
+impl<K, V> Clone for Keys<'_, K, V> {
+    fn clone(&self) -> Self {
         Keys { inner: self.inner.clone() }
     }
 }
 
 #[stable(feature = "std_debug", since = "1.16.0")]
-impl<'a, K: Debug, V> fmt::Debug for Keys<'a, K, V> {
+impl<K: Debug, V> fmt::Debug for Keys<'_, K, V> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_list()
             .entries(self.clone())
@@ -1755,14 +1755,14 @@ pub struct Values<'a, K: 'a, V: 'a> {
 
 // FIXME(#26925) Remove in favor of `#[derive(Clone)]`
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, K, V> Clone for Values<'a, K, V> {
-    fn clone(&self) -> Values<'a, K, V> {
+impl<K, V> Clone for Values<'_, K, V> {
+    fn clone(&self) -> Self {
         Values { inner: self.inner.clone() }
     }
 }
 
 #[stable(feature = "std_debug", since = "1.16.0")]
-impl<'a, K, V: Debug> fmt::Debug for Values<'a, K, V> {
+impl<K, V: Debug> fmt::Debug for Values<'_, K, V> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_list()
             .entries(self.clone())
@@ -2241,7 +2241,7 @@ impl<'a, K, V, S> RawVacantEntryMut<'a, K, V, S> {
 }
 
 #[unstable(feature = "hash_raw_entry", issue = "56167")]
-impl<'a, K, V, S> Debug for RawEntryBuilderMut<'a, K, V, S> {
+impl<K, V, S> Debug for RawEntryBuilderMut<'_, K, V, S> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("RawEntryBuilder")
          .finish()
@@ -2249,7 +2249,7 @@ impl<'a, K, V, S> Debug for RawEntryBuilderMut<'a, K, V, S> {
 }
 
 #[unstable(feature = "hash_raw_entry", issue = "56167")]
-impl<'a, K: Debug, V: Debug, S> Debug for RawEntryMut<'a, K, V, S> {
+impl<K: Debug, V: Debug, S> Debug for RawEntryMut<'_, K, V, S> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             RawEntryMut::Vacant(ref v) => {
@@ -2267,7 +2267,7 @@ impl<'a, K: Debug, V: Debug, S> Debug for RawEntryMut<'a, K, V, S> {
 }
 
 #[unstable(feature = "hash_raw_entry", issue = "56167")]
-impl<'a, K: Debug, V: Debug> Debug for RawOccupiedEntryMut<'a, K, V> {
+impl<K: Debug, V: Debug> Debug for RawOccupiedEntryMut<'_, K, V> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("RawOccupiedEntryMut")
          .field("key", self.key())
@@ -2277,7 +2277,7 @@ impl<'a, K: Debug, V: Debug> Debug for RawOccupiedEntryMut<'a, K, V> {
 }
 
 #[unstable(feature = "hash_raw_entry", issue = "56167")]
-impl<'a, K, V, S> Debug for RawVacantEntryMut<'a, K, V, S> {
+impl<K, V, S> Debug for RawVacantEntryMut<'_, K, V, S> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("RawVacantEntryMut")
          .finish()
@@ -2285,7 +2285,7 @@ impl<'a, K, V, S> Debug for RawVacantEntryMut<'a, K, V, S> {
 }
 
 #[unstable(feature = "hash_raw_entry", issue = "56167")]
-impl<'a, K, V, S> Debug for RawEntryBuilder<'a, K, V, S> {
+impl<K, V, S> Debug for RawEntryBuilder<'_, K, V, S> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("RawEntryBuilder")
          .finish()
@@ -2312,7 +2312,7 @@ pub enum Entry<'a, K: 'a, V: 'a> {
 }
 
 #[stable(feature= "debug_hash_map", since = "1.12.0")]
-impl<'a, K: 'a + Debug, V: 'a + Debug> Debug for Entry<'a, K, V> {
+impl<K: Debug, V: Debug> Debug for Entry<'_, K, V> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Vacant(ref v) => {
@@ -2340,7 +2340,7 @@ pub struct OccupiedEntry<'a, K: 'a, V: 'a> {
 }
 
 #[stable(feature= "debug_hash_map", since = "1.12.0")]
-impl<'a, K: 'a + Debug, V: 'a + Debug> Debug for OccupiedEntry<'a, K, V> {
+impl<K: Debug, V: Debug> Debug for OccupiedEntry<'_, K, V> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("OccupiedEntry")
             .field("key", self.key())
@@ -2361,7 +2361,7 @@ pub struct VacantEntry<'a, K: 'a, V: 'a> {
 }
 
 #[stable(feature= "debug_hash_map", since = "1.12.0")]
-impl<'a, K: 'a + Debug, V: 'a> Debug for VacantEntry<'a, K, V> {
+impl<K: Debug, V> Debug for VacantEntry<'_, K, V> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_tuple("VacantEntry")
             .field(self.key())
@@ -2448,7 +2448,7 @@ impl<'a, K, V> Iterator for Iter<'a, K, V> {
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, K, V> ExactSizeIterator for Iter<'a, K, V> {
+impl<K, V> ExactSizeIterator for Iter<'_, K, V> {
     #[inline]
     fn len(&self) -> usize {
         self.inner.len()
@@ -2456,7 +2456,7 @@ impl<'a, K, V> ExactSizeIterator for Iter<'a, K, V> {
 }
 
 #[stable(feature = "fused", since = "1.26.0")]
-impl<'a, K, V> FusedIterator for Iter<'a, K, V> {}
+impl<K, V> FusedIterator for Iter<'_, K, V> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, K, V> Iterator for IterMut<'a, K, V> {
@@ -2472,17 +2472,17 @@ impl<'a, K, V> Iterator for IterMut<'a, K, V> {
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, K, V> ExactSizeIterator for IterMut<'a, K, V> {
+impl<K, V> ExactSizeIterator for IterMut<'_, K, V> {
     #[inline]
     fn len(&self) -> usize {
         self.inner.len()
     }
 }
 #[stable(feature = "fused", since = "1.26.0")]
-impl<'a, K, V> FusedIterator for IterMut<'a, K, V> {}
+impl<K, V> FusedIterator for IterMut<'_, K, V> {}
 
 #[stable(feature = "std_debug", since = "1.16.0")]
-impl<'a, K, V> fmt::Debug for IterMut<'a, K, V>
+impl<K, V> fmt::Debug for IterMut<'_, K, V>
     where K: fmt::Debug,
           V: fmt::Debug,
 {
@@ -2539,14 +2539,14 @@ impl<'a, K, V> Iterator for Keys<'a, K, V> {
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, K, V> ExactSizeIterator for Keys<'a, K, V> {
+impl<K, V> ExactSizeIterator for Keys<'_, K, V> {
     #[inline]
     fn len(&self) -> usize {
         self.inner.len()
     }
 }
 #[stable(feature = "fused", since = "1.26.0")]
-impl<'a, K, V> FusedIterator for Keys<'a, K, V> {}
+impl<K, V> FusedIterator for Keys<'_, K, V> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, K, V> Iterator for Values<'a, K, V> {
@@ -2562,14 +2562,14 @@ impl<'a, K, V> Iterator for Values<'a, K, V> {
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, K, V> ExactSizeIterator for Values<'a, K, V> {
+impl<K, V> ExactSizeIterator for Values<'_, K, V> {
     #[inline]
     fn len(&self) -> usize {
         self.inner.len()
     }
 }
 #[stable(feature = "fused", since = "1.26.0")]
-impl<'a, K, V> FusedIterator for Values<'a, K, V> {}
+impl<K, V> FusedIterator for Values<'_, K, V> {}
 
 #[stable(feature = "map_values_mut", since = "1.10.0")]
 impl<'a, K, V> Iterator for ValuesMut<'a, K, V> {
@@ -2585,17 +2585,17 @@ impl<'a, K, V> Iterator for ValuesMut<'a, K, V> {
     }
 }
 #[stable(feature = "map_values_mut", since = "1.10.0")]
-impl<'a, K, V> ExactSizeIterator for ValuesMut<'a, K, V> {
+impl<K, V> ExactSizeIterator for ValuesMut<'_, K, V> {
     #[inline]
     fn len(&self) -> usize {
         self.inner.len()
     }
 }
 #[stable(feature = "fused", since = "1.26.0")]
-impl<'a, K, V> FusedIterator for ValuesMut<'a, K, V> {}
+impl<K, V> FusedIterator for ValuesMut<'_, K, V> {}
 
 #[stable(feature = "std_debug", since = "1.16.0")]
-impl<'a, K, V> fmt::Debug for ValuesMut<'a, K, V>
+impl<K, V> fmt::Debug for ValuesMut<'_, K, V>
     where K: fmt::Debug,
           V: fmt::Debug,
 {
@@ -2620,17 +2620,17 @@ impl<'a, K, V> Iterator for Drain<'a, K, V> {
     }
 }
 #[stable(feature = "drain", since = "1.6.0")]
-impl<'a, K, V> ExactSizeIterator for Drain<'a, K, V> {
+impl<K, V> ExactSizeIterator for Drain<'_, K, V> {
     #[inline]
     fn len(&self) -> usize {
         self.inner.len()
     }
 }
 #[stable(feature = "fused", since = "1.26.0")]
-impl<'a, K, V> FusedIterator for Drain<'a, K, V> {}
+impl<K, V> FusedIterator for Drain<'_, K, V> {}
 
 #[stable(feature = "std_debug", since = "1.16.0")]
-impl<'a, K, V> fmt::Debug for Drain<'a, K, V>
+impl<K, V> fmt::Debug for Drain<'_, K, V>
     where K: fmt::Debug,
           V: fmt::Debug,
 {

--- a/src/libstd/collections/hash/set.rs
+++ b/src/libstd/collections/hash/set.rs
@@ -1112,8 +1112,8 @@ impl<T, S> IntoIterator for HashSet<T, S>
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, K> Clone for Iter<'a, K> {
-    fn clone(&self) -> Iter<'a, K> {
+impl<K> Clone for Iter<'_, K> {
+    fn clone(&self) -> Self {
         Iter { iter: self.iter.clone() }
     }
 }
@@ -1129,16 +1129,16 @@ impl<'a, K> Iterator for Iter<'a, K> {
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, K> ExactSizeIterator for Iter<'a, K> {
+impl<K> ExactSizeIterator for Iter<'_, K> {
     fn len(&self) -> usize {
         self.iter.len()
     }
 }
 #[stable(feature = "fused", since = "1.26.0")]
-impl<'a, K> FusedIterator for Iter<'a, K> {}
+impl<K> FusedIterator for Iter<'_, K> {}
 
 #[stable(feature = "std_debug", since = "1.16.0")]
-impl<'a, K: fmt::Debug> fmt::Debug for Iter<'a, K> {
+impl<K: fmt::Debug> fmt::Debug for Iter<'_, K> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_list().entries(self.clone()).finish()
     }
@@ -1187,16 +1187,16 @@ impl<'a, K> Iterator for Drain<'a, K> {
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, K> ExactSizeIterator for Drain<'a, K> {
+impl<K> ExactSizeIterator for Drain<'_, K> {
     fn len(&self) -> usize {
         self.iter.len()
     }
 }
 #[stable(feature = "fused", since = "1.26.0")]
-impl<'a, K> FusedIterator for Drain<'a, K> {}
+impl<K> FusedIterator for Drain<'_, K> {}
 
 #[stable(feature = "std_debug", since = "1.16.0")]
-impl<'a, K: fmt::Debug> fmt::Debug for Drain<'a, K> {
+impl<K: fmt::Debug> fmt::Debug for Drain<'_, K> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let entries_iter = self.iter
             .inner
@@ -1207,8 +1207,8 @@ impl<'a, K: fmt::Debug> fmt::Debug for Drain<'a, K> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, T, S> Clone for Intersection<'a, T, S> {
-    fn clone(&self) -> Intersection<'a, T, S> {
+impl<T, S> Clone for Intersection<'_, T, S> {
+    fn clone(&self) -> Self {
         Intersection { iter: self.iter.clone(), ..*self }
     }
 }
@@ -1236,7 +1236,7 @@ impl<'a, T, S> Iterator for Intersection<'a, T, S>
 }
 
 #[stable(feature = "std_debug", since = "1.16.0")]
-impl<'a, T, S> fmt::Debug for Intersection<'a, T, S>
+impl<T, S> fmt::Debug for Intersection<'_, T, S>
     where T: fmt::Debug + Eq + Hash,
           S: BuildHasher
 {
@@ -1246,15 +1246,15 @@ impl<'a, T, S> fmt::Debug for Intersection<'a, T, S>
 }
 
 #[stable(feature = "fused", since = "1.26.0")]
-impl<'a, T, S> FusedIterator for Intersection<'a, T, S>
+impl<T, S> FusedIterator for Intersection<'_, T, S>
     where T: Eq + Hash,
           S: BuildHasher
 {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, T, S> Clone for Difference<'a, T, S> {
-    fn clone(&self) -> Difference<'a, T, S> {
+impl<T, S> Clone for Difference<'_, T, S> {
+    fn clone(&self) -> Self {
         Difference { iter: self.iter.clone(), ..*self }
     }
 }
@@ -1282,14 +1282,14 @@ impl<'a, T, S> Iterator for Difference<'a, T, S>
 }
 
 #[stable(feature = "fused", since = "1.26.0")]
-impl<'a, T, S> FusedIterator for Difference<'a, T, S>
+impl<T, S> FusedIterator for Difference<'_, T, S>
     where T: Eq + Hash,
           S: BuildHasher
 {
 }
 
 #[stable(feature = "std_debug", since = "1.16.0")]
-impl<'a, T, S> fmt::Debug for Difference<'a, T, S>
+impl<T, S> fmt::Debug for Difference<'_, T, S>
     where T: fmt::Debug + Eq + Hash,
           S: BuildHasher
 {
@@ -1299,8 +1299,8 @@ impl<'a, T, S> fmt::Debug for Difference<'a, T, S>
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, T, S> Clone for SymmetricDifference<'a, T, S> {
-    fn clone(&self) -> SymmetricDifference<'a, T, S> {
+impl<T, S> Clone for SymmetricDifference<'_, T, S> {
+    fn clone(&self) -> Self {
         SymmetricDifference { iter: self.iter.clone() }
     }
 }
@@ -1321,14 +1321,14 @@ impl<'a, T, S> Iterator for SymmetricDifference<'a, T, S>
 }
 
 #[stable(feature = "fused", since = "1.26.0")]
-impl<'a, T, S> FusedIterator for SymmetricDifference<'a, T, S>
+impl<T, S> FusedIterator for SymmetricDifference<'_, T, S>
     where T: Eq + Hash,
           S: BuildHasher
 {
 }
 
 #[stable(feature = "std_debug", since = "1.16.0")]
-impl<'a, T, S> fmt::Debug for SymmetricDifference<'a, T, S>
+impl<T, S> fmt::Debug for SymmetricDifference<'_, T, S>
     where T: fmt::Debug + Eq + Hash,
           S: BuildHasher
 {
@@ -1338,21 +1338,21 @@ impl<'a, T, S> fmt::Debug for SymmetricDifference<'a, T, S>
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, T, S> Clone for Union<'a, T, S> {
-    fn clone(&self) -> Union<'a, T, S> {
+impl<T, S> Clone for Union<'_, T, S> {
+    fn clone(&self) -> Self {
         Union { iter: self.iter.clone() }
     }
 }
 
 #[stable(feature = "fused", since = "1.26.0")]
-impl<'a, T, S> FusedIterator for Union<'a, T, S>
+impl<T, S> FusedIterator for Union<'_, T, S>
     where T: Eq + Hash,
           S: BuildHasher
 {
 }
 
 #[stable(feature = "std_debug", since = "1.16.0")]
-impl<'a, T, S> fmt::Debug for Union<'a, T, S>
+impl<T, S> fmt::Debug for Union<'_, T, S>
     where T: fmt::Debug + Eq + Hash,
           S: BuildHasher
 {

--- a/src/libstd/collections/hash/table.rs
+++ b/src/libstd/collections/hash/table.rs
@@ -296,7 +296,7 @@ pub trait Put<K, V> {
 }
 
 
-impl<'t, K, V> Put<K, V> for &'t mut RawTable<K, V> {
+impl<K, V> Put<K, V> for &mut RawTable<K, V> {
     unsafe fn borrow_table_mut(&mut self) -> &mut RawTable<K, V> {
         *self
     }
@@ -865,8 +865,8 @@ struct RawBuckets<'a, K, V> {
 }
 
 // FIXME(#26925) Remove in favor of `#[derive(Clone)]`
-impl<'a, K, V> Clone for RawBuckets<'a, K, V> {
-    fn clone(&self) -> RawBuckets<'a, K, V> {
+impl<K, V> Clone for RawBuckets<'_, K, V> {
+    fn clone(&self) -> Self {
         RawBuckets {
             raw: self.raw,
             elems_left: self.elems_left,
@@ -901,7 +901,7 @@ impl<'a, K, V> Iterator for RawBuckets<'a, K, V> {
     }
 }
 
-impl<'a, K, V> ExactSizeIterator for RawBuckets<'a, K, V> {
+impl<K, V> ExactSizeIterator for RawBuckets<'_, K, V> {
     fn len(&self) -> usize {
         self.elems_left
     }
@@ -912,12 +912,12 @@ pub struct Iter<'a, K: 'a, V: 'a> {
     iter: RawBuckets<'a, K, V>,
 }
 
-unsafe impl<'a, K: Sync, V: Sync> Sync for Iter<'a, K, V> {}
-unsafe impl<'a, K: Sync, V: Sync> Send for Iter<'a, K, V> {}
+unsafe impl<K: Sync, V: Sync> Sync for Iter<'_, K, V> {}
+unsafe impl<K: Sync, V: Sync> Send for Iter<'_, K, V> {}
 
 // FIXME(#26925) Remove in favor of `#[derive(Clone)]`
-impl<'a, K, V> Clone for Iter<'a, K, V> {
-    fn clone(&self) -> Iter<'a, K, V> {
+impl<K, V> Clone for Iter<'_, K, V> {
+    fn clone(&self) -> Self {
         Iter {
             iter: self.iter.clone(),
         }
@@ -931,10 +931,10 @@ pub struct IterMut<'a, K: 'a, V: 'a> {
     _marker: marker::PhantomData<&'a mut V>,
 }
 
-unsafe impl<'a, K: Sync, V: Sync> Sync for IterMut<'a, K, V> {}
+unsafe impl<K: Sync, V: Sync> Sync for IterMut<'_, K, V> {}
 // Both K: Sync and K: Send are correct for IterMut's Send impl,
 // but Send is the more useful bound
-unsafe impl<'a, K: Send, V: Send> Send for IterMut<'a, K, V> {}
+unsafe impl<K: Send, V: Send> Send for IterMut<'_, K, V> {}
 
 impl<'a, K: 'a, V: 'a> IterMut<'a, K, V> {
     pub fn iter(&self) -> Iter<K, V> {
@@ -968,8 +968,8 @@ pub struct Drain<'a, K: 'a, V: 'a> {
     marker: marker::PhantomData<&'a RawTable<K, V>>,
 }
 
-unsafe impl<'a, K: Sync, V: Sync> Sync for Drain<'a, K, V> {}
-unsafe impl<'a, K: Send, V: Send> Send for Drain<'a, K, V> {}
+unsafe impl<K: Sync, V: Sync> Sync for Drain<'_, K, V> {}
+unsafe impl<K: Send, V: Send> Send for Drain<'_, K, V> {}
 
 impl<'a, K, V> Drain<'a, K, V> {
     pub fn iter(&self) -> Iter<K, V> {
@@ -994,7 +994,7 @@ impl<'a, K, V> Iterator for Iter<'a, K, V> {
     }
 }
 
-impl<'a, K, V> ExactSizeIterator for Iter<'a, K, V> {
+impl<K, V> ExactSizeIterator for Iter<'_, K, V> {
     fn len(&self) -> usize {
         self.iter.len()
     }
@@ -1015,7 +1015,7 @@ impl<'a, K, V> Iterator for IterMut<'a, K, V> {
     }
 }
 
-impl<'a, K, V> ExactSizeIterator for IterMut<'a, K, V> {
+impl<K, V> ExactSizeIterator for IterMut<'_, K, V> {
     fn len(&self) -> usize {
         self.iter.len()
     }
@@ -1064,13 +1064,13 @@ impl<'a, K, V> Iterator for Drain<'a, K, V> {
     }
 }
 
-impl<'a, K, V> ExactSizeIterator for Drain<'a, K, V> {
+impl<K, V> ExactSizeIterator for Drain<'_, K, V> {
     fn len(&self) -> usize {
         self.iter.len()
     }
 }
 
-impl<'a, K: 'a, V: 'a> Drop for Drain<'a, K, V> {
+impl<K, V> Drop for Drain<'_, K, V> {
     fn drop(&mut self) {
         self.for_each(drop);
     }

--- a/src/libstd/env.rs
+++ b/src/libstd/env.rs
@@ -399,7 +399,7 @@ impl<'a> Iterator for SplitPaths<'a> {
 }
 
 #[stable(feature = "std_debug", since = "1.16.0")]
-impl<'a> fmt::Debug for SplitPaths<'a> {
+impl fmt::Debug for SplitPaths<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.pad("SplitPaths { .. }")
     }

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -659,8 +659,8 @@ impl fmt::Debug for CStr {
 }
 
 #[stable(feature = "cstr_default", since = "1.10.0")]
-impl<'a> Default for &'a CStr {
-    fn default() -> &'a CStr {
+impl Default for &CStr {
+    fn default() -> Self {
         const SLICE: &[c_char] = &[0];
         unsafe { CStr::from_ptr(SLICE.as_ptr()) }
     }

--- a/src/libstd/ffi/os_str.rs
+++ b/src/libstd/ffi/os_str.rs
@@ -778,10 +778,10 @@ impl Default for Box<OsStr> {
 }
 
 #[stable(feature = "osstring_default", since = "1.9.0")]
-impl<'a> Default for &'a OsStr {
+impl Default for &OsStr {
     /// Creates an empty `OsStr`.
     #[inline]
-    fn default() -> &'a OsStr {
+    fn default() -> Self {
         OsStr::new("")
     }
 }

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -618,7 +618,7 @@ impl Seek for File {
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a> Read for &'a File {
+impl Read for &File {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.inner.read(buf)
     }
@@ -629,14 +629,14 @@ impl<'a> Read for &'a File {
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a> Write for &'a File {
+impl Write for &File {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.inner.write(buf)
     }
     fn flush(&mut self) -> io::Result<()> { self.inner.flush() }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a> Seek for &'a File {
+impl Seek for &File {
     fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
         self.inner.seek(pos)
     }

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -1174,7 +1174,7 @@ mod tests {
         // Issue #32085
         struct FailFlushWriter<'a>(&'a mut Vec<u8>);
 
-        impl<'a> Write for FailFlushWriter<'a> {
+        impl Write for FailFlushWriter<'_> {
             fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
                 self.0.extend_from_slice(buf);
                 Ok(buf.len())

--- a/src/libstd/io/cursor.rs
+++ b/src/libstd/io/cursor.rs
@@ -279,7 +279,7 @@ fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usi
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a> Write for Cursor<&'a mut [u8]> {
+impl Write for Cursor<&mut [u8]> {
     #[inline]
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         slice_write(&mut self.pos, self.inner, buf)
@@ -288,7 +288,7 @@ impl<'a> Write for Cursor<&'a mut [u8]> {
 }
 
 #[stable(feature = "cursor_mut_vec", since = "1.25.0")]
-impl<'a> Write for Cursor<&'a mut Vec<u8>> {
+impl Write for Cursor<&mut Vec<u8>> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         vec_write(&mut self.pos, self.inner, buf)
     }

--- a/src/libstd/io/impls.rs
+++ b/src/libstd/io/impls.rs
@@ -7,7 +7,7 @@ use mem;
 // Forwarding implementations
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, R: Read + ?Sized> Read for &'a mut R {
+impl<R: Read + ?Sized> Read for &mut R {
     #[inline]
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         (**self).read(buf)
@@ -34,7 +34,7 @@ impl<'a, R: Read + ?Sized> Read for &'a mut R {
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, W: Write + ?Sized> Write for &'a mut W {
+impl<W: Write + ?Sized> Write for &mut W {
     #[inline]
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> { (**self).write(buf) }
 
@@ -52,12 +52,12 @@ impl<'a, W: Write + ?Sized> Write for &'a mut W {
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, S: Seek + ?Sized> Seek for &'a mut S {
+impl<S: Seek + ?Sized> Seek for &mut S {
     #[inline]
     fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> { (**self).seek(pos) }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, B: BufRead + ?Sized> BufRead for &'a mut B {
+impl<B: BufRead + ?Sized> BufRead for &mut B {
     #[inline]
     fn fill_buf(&mut self) -> io::Result<&[u8]> { (**self).fill_buf() }
 
@@ -152,7 +152,7 @@ impl<B: BufRead + ?Sized> BufRead for Box<B> {
 /// Note that reading updates the slice to point to the yet unread part.
 /// The slice will be empty when EOF is reached.
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a> Read for &'a [u8] {
+impl Read for &[u8] {
     #[inline]
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let amt = cmp::min(buf.len(), self.len());
@@ -207,7 +207,7 @@ impl<'a> Read for &'a [u8] {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a> BufRead for &'a [u8] {
+impl BufRead for &[u8] {
     #[inline]
     fn fill_buf(&mut self) -> io::Result<&[u8]> { Ok(*self) }
 
@@ -221,7 +221,7 @@ impl<'a> BufRead for &'a [u8] {
 /// Note that writing updates the slice to point to the yet unwritten part.
 /// The slice will be empty when it has been completely overwritten.
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a> Write for &'a mut [u8] {
+impl Write for &mut [u8] {
     #[inline]
     fn write(&mut self, data: &[u8]) -> io::Result<usize> {
         let amt = cmp::min(data.len(), self.len());

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -299,7 +299,7 @@ const DEFAULT_BUF_SIZE: usize = ::sys_common::io::DEFAULT_BUF_SIZE;
 
 struct Guard<'a> { buf: &'a mut Vec<u8>, len: usize }
 
-impl<'a> Drop for Guard<'a> {
+impl Drop for Guard<'_> {
     fn drop(&mut self) {
         unsafe { self.buf.set_len(self.len); }
     }
@@ -1114,7 +1114,7 @@ pub trait Write {
             error: Result<()>,
         }
 
-        impl<'a, T: Write + ?Sized> fmt::Write for Adaptor<'a, T> {
+        impl<T: Write + ?Sized> fmt::Write for Adaptor<'_, T> {
             fn write_str(&mut self, s: &str) -> fmt::Result {
                 match self.inner.write_all(s.as_bytes()) {
                     Ok(()) => Ok(()),

--- a/src/libstd/io/stdio.rs
+++ b/src/libstd/io/stdio.rs
@@ -312,7 +312,7 @@ impl Read for Stdin {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a> Read for StdinLock<'a> {
+impl Read for StdinLock<'_> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.inner.read(buf)
     }
@@ -323,13 +323,13 @@ impl<'a> Read for StdinLock<'a> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a> BufRead for StdinLock<'a> {
+impl BufRead for StdinLock<'_> {
     fn fill_buf(&mut self) -> io::Result<&[u8]> { self.inner.fill_buf() }
     fn consume(&mut self, n: usize) { self.inner.consume(n) }
 }
 
 #[stable(feature = "std_debug", since = "1.16.0")]
-impl<'a> fmt::Debug for StdinLock<'a> {
+impl fmt::Debug for StdinLock<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.pad("StdinLock { .. }")
     }
@@ -485,7 +485,7 @@ impl Write for Stdout {
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a> Write for StdoutLock<'a> {
+impl Write for StdoutLock<'_> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.inner.borrow_mut().write(buf)
     }
@@ -495,7 +495,7 @@ impl<'a> Write for StdoutLock<'a> {
 }
 
 #[stable(feature = "std_debug", since = "1.16.0")]
-impl<'a> fmt::Debug for StdoutLock<'a> {
+impl fmt::Debug for StdoutLock<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.pad("StdoutLock { .. }")
     }
@@ -638,7 +638,7 @@ impl Write for Stderr {
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a> Write for StderrLock<'a> {
+impl Write for StderrLock<'_> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.inner.borrow_mut().write(buf)
     }
@@ -648,7 +648,7 @@ impl<'a> Write for StderrLock<'a> {
 }
 
 #[stable(feature = "std_debug", since = "1.16.0")]
-impl<'a> fmt::Debug for StderrLock<'a> {
+impl fmt::Debug for StderrLock<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.pad("StderrLock { .. }")
     }

--- a/src/libstd/net/addr.rs
+++ b/src/libstd/net/addr.rs
@@ -861,7 +861,7 @@ fn resolve_socket_addr(lh: LookupHost) -> io::Result<vec::IntoIter<SocketAddr>> 
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a> ToSocketAddrs for (&'a str, u16) {
+impl ToSocketAddrs for (&str, u16) {
     type Iter = vec::IntoIter<SocketAddr>;
     fn to_socket_addrs(&self) -> io::Result<vec::IntoIter<SocketAddr>> {
         let (host, port) = *self;
@@ -904,7 +904,7 @@ impl<'a> ToSocketAddrs for &'a [SocketAddr] {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, T: ToSocketAddrs + ?Sized> ToSocketAddrs for &'a T {
+impl<T: ToSocketAddrs + ?Sized> ToSocketAddrs for &T {
     type Iter = T::Iter;
     fn to_socket_addrs(&self) -> io::Result<T::Iter> {
         (**self).to_socket_addrs()

--- a/src/libstd/net/tcp.rs
+++ b/src/libstd/net/tcp.rs
@@ -580,7 +580,7 @@ impl Write for TcpStream {
     fn flush(&mut self) -> io::Result<()> { Ok(()) }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a> Read for &'a TcpStream {
+impl Read for &TcpStream {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> { self.0.read(buf) }
 
     #[inline]
@@ -589,7 +589,7 @@ impl<'a> Read for &'a TcpStream {
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a> Write for &'a TcpStream {
+impl Write for &TcpStream {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> { self.0.write(buf) }
     fn flush(&mut self) -> io::Result<()> { Ok(()) }
 }

--- a/src/libstd/panic.rs
+++ b/src/libstd/panic.rs
@@ -199,9 +199,9 @@ pub struct AssertUnwindSafe<T>(
 // * Our custom AssertUnwindSafe wrapper is indeed unwind safe
 
 #[stable(feature = "catch_unwind", since = "1.9.0")]
-impl<'a, T: ?Sized> !UnwindSafe for &'a mut T {}
+impl<T: ?Sized> !UnwindSafe for &mut T {}
 #[stable(feature = "catch_unwind", since = "1.9.0")]
-impl<'a, T: RefUnwindSafe + ?Sized> UnwindSafe for &'a T {}
+impl<T: RefUnwindSafe + ?Sized> UnwindSafe for &T {}
 #[stable(feature = "catch_unwind", since = "1.9.0")]
 impl<T: RefUnwindSafe + ?Sized> UnwindSafe for *const T {}
 #[stable(feature = "catch_unwind", since = "1.9.0")]
@@ -320,7 +320,7 @@ impl<T: fmt::Debug> fmt::Debug for AssertUnwindSafe<T> {
 }
 
 #[unstable(feature = "futures_api", issue = "50547")]
-impl<'a, F: Future> Future for AssertUnwindSafe<F> {
+impl<F: Future> Future for AssertUnwindSafe<F> {
     type Output = F::Output;
 
     fn poll(self: Pin<&mut Self>, lw: &LocalWaker) -> Poll<Self::Output> {

--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -457,14 +457,14 @@ impl<'a> cmp::PartialOrd for PrefixComponent<'a> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a> cmp::Ord for PrefixComponent<'a> {
-    fn cmp(&self, other: &PrefixComponent<'a>) -> cmp::Ordering {
+impl cmp::Ord for PrefixComponent<'_> {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
         cmp::Ord::cmp(&self.parsed, &other.parsed)
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a> Hash for PrefixComponent<'a> {
+impl Hash for PrefixComponent<'_> {
     fn hash<H: Hasher>(&self, h: &mut H) {
         self.parsed.hash(h);
     }
@@ -561,14 +561,14 @@ impl<'a> Component<'a> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a> AsRef<OsStr> for Component<'a> {
+impl AsRef<OsStr> for Component<'_> {
     fn as_ref(&self) -> &OsStr {
         self.as_os_str()
     }
 }
 
 #[stable(feature = "path_component_asref", since = "1.25.0")]
-impl<'a> AsRef<Path> for Component<'a> {
+impl AsRef<Path> for Component<'_> {
     fn as_ref(&self) -> &Path {
         self.as_os_str().as_ref()
     }
@@ -630,11 +630,11 @@ pub struct Iter<'a> {
 }
 
 #[stable(feature = "path_components_debug", since = "1.13.0")]
-impl<'a> fmt::Debug for Components<'a> {
+impl fmt::Debug for Components<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         struct DebugHelper<'a>(&'a Path);
 
-        impl<'a> fmt::Debug for DebugHelper<'a> {
+        impl fmt::Debug for DebugHelper<'_> {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_list()
                     .entries(self.0.components())
@@ -814,25 +814,25 @@ impl<'a> Components<'a> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a> AsRef<Path> for Components<'a> {
+impl AsRef<Path> for Components<'_> {
     fn as_ref(&self) -> &Path {
         self.as_path()
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a> AsRef<OsStr> for Components<'a> {
+impl AsRef<OsStr> for Components<'_> {
     fn as_ref(&self) -> &OsStr {
         self.as_path().as_os_str()
     }
 }
 
 #[stable(feature = "path_iter_debug", since = "1.13.0")]
-impl<'a> fmt::Debug for Iter<'a> {
+impl fmt::Debug for Iter<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         struct DebugHelper<'a>(&'a Path);
 
-        impl<'a> fmt::Debug for DebugHelper<'a> {
+        impl fmt::Debug for DebugHelper<'_> {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_list()
                     .entries(self.0.iter())
@@ -867,14 +867,14 @@ impl<'a> Iter<'a> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a> AsRef<Path> for Iter<'a> {
+impl AsRef<Path> for Iter<'_> {
     fn as_ref(&self) -> &Path {
         self.as_path()
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a> AsRef<OsStr> for Iter<'a> {
+impl AsRef<OsStr> for Iter<'_> {
     fn as_ref(&self) -> &OsStr {
         self.as_path().as_os_str()
     }
@@ -897,7 +897,7 @@ impl<'a> DoubleEndedIterator for Iter<'a> {
 }
 
 #[stable(feature = "fused", since = "1.26.0")]
-impl<'a> FusedIterator for Iter<'a> {}
+impl FusedIterator for Iter<'_> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a> Iterator for Components<'a> {
@@ -1000,7 +1000,7 @@ impl<'a> DoubleEndedIterator for Components<'a> {
 }
 
 #[stable(feature = "fused", since = "1.26.0")]
-impl<'a> FusedIterator for Components<'a> {}
+impl FusedIterator for Components<'_> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a> cmp::PartialEq for Components<'a> {
@@ -1010,7 +1010,7 @@ impl<'a> cmp::PartialEq for Components<'a> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a> cmp::Eq for Components<'a> {}
+impl cmp::Eq for Components<'_> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a> cmp::PartialOrd for Components<'a> {
@@ -1020,8 +1020,8 @@ impl<'a> cmp::PartialOrd for Components<'a> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a> cmp::Ord for Components<'a> {
-    fn cmp(&self, other: &Components<'a>) -> cmp::Ordering {
+impl cmp::Ord for Components<'_> {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
         Iterator::cmp(self.clone(), other.clone())
     }
 }
@@ -1063,7 +1063,7 @@ impl<'a> Iterator for Ancestors<'a> {
 }
 
 #[stable(feature = "path_ancestors", since = "1.28.0")]
-impl<'a> FusedIterator for Ancestors<'a> {}
+impl FusedIterator for Ancestors<'_> {}
 
 ////////////////////////////////////////////////////////////////////////////////
 // Basic types and traits
@@ -2530,14 +2530,14 @@ pub struct Display<'a> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a> fmt::Debug for Display<'a> {
+impl fmt::Debug for Display<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Debug::fmt(&self.path, f)
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a> fmt::Display for Display<'a> {
+impl fmt::Display for Display<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.path.inner.display(f)
     }
@@ -2591,7 +2591,7 @@ impl AsRef<Path> for OsStr {
 }
 
 #[stable(feature = "cow_os_str_as_ref_path", since = "1.8.0")]
-impl<'a> AsRef<Path> for Cow<'a, OsStr> {
+impl AsRef<Path> for Cow<'_, OsStr> {
     fn as_ref(&self) -> &Path {
         Path::new(self)
     }

--- a/src/libstd/sync/mpsc/select.rs
+++ b/src/libstd/sync/mpsc/select.rs
@@ -321,7 +321,7 @@ impl Drop for Select {
     }
 }
 
-impl<'rx, T: Send> Drop for Handle<'rx, T> {
+impl<T: Send> Drop for Handle<'_, T> {
     fn drop(&mut self) {
         unsafe { self.remove() }
     }
@@ -347,7 +347,7 @@ impl fmt::Debug for Select {
     }
 }
 
-impl<'rx, T:Send+'rx> fmt::Debug for Handle<'rx, T> {
+impl<T: Send> fmt::Debug for Handle<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Handle").finish()
     }

--- a/src/libstd/sync/mutex.rs
+++ b/src/libstd/sync/mutex.rs
@@ -150,9 +150,9 @@ pub struct MutexGuard<'a, T: ?Sized + 'a> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, T: ?Sized> !Send for MutexGuard<'a, T> { }
+impl<T: ?Sized> !Send for MutexGuard<'_, T> { }
 #[stable(feature = "mutexguard", since = "1.19.0")]
-unsafe impl<'a, T: ?Sized + Sync> Sync for MutexGuard<'a, T> { }
+unsafe impl<T: ?Sized + Sync> Sync for MutexGuard<'_, T> { }
 
 impl<T> Mutex<T> {
     /// Creates a new mutex in an unlocked state ready for use.
@@ -421,7 +421,7 @@ impl<'mutex, T: ?Sized> MutexGuard<'mutex, T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'mutex, T: ?Sized> Deref for MutexGuard<'mutex, T> {
+impl<T: ?Sized> Deref for MutexGuard<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &T {
@@ -430,14 +430,14 @@ impl<'mutex, T: ?Sized> Deref for MutexGuard<'mutex, T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'mutex, T: ?Sized> DerefMut for MutexGuard<'mutex, T> {
+impl<T: ?Sized> DerefMut for MutexGuard<'_, T> {
     fn deref_mut(&mut self) -> &mut T {
         unsafe { &mut *self.__lock.data.get() }
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, T: ?Sized> Drop for MutexGuard<'a, T> {
+impl<T: ?Sized> Drop for MutexGuard<'_, T> {
     #[inline]
     fn drop(&mut self) {
         unsafe {
@@ -448,14 +448,14 @@ impl<'a, T: ?Sized> Drop for MutexGuard<'a, T> {
 }
 
 #[stable(feature = "std_debug", since = "1.16.0")]
-impl<'a, T: ?Sized + fmt::Debug> fmt::Debug for MutexGuard<'a, T> {
+impl<T: ?Sized + fmt::Debug> fmt::Debug for MutexGuard<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Debug::fmt(&**self, f)
     }
 }
 
 #[stable(feature = "std_guard_impls", since = "1.20.0")]
-impl<'a, T: ?Sized + fmt::Display> fmt::Display for MutexGuard<'a, T> {
+impl<T: ?Sized + fmt::Display> fmt::Display for MutexGuard<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         (**self).fmt(f)
     }

--- a/src/libstd/sync/once.rs
+++ b/src/libstd/sync/once.rs
@@ -436,7 +436,7 @@ impl fmt::Debug for Once {
     }
 }
 
-impl<'a> Drop for Finish<'a> {
+impl Drop for Finish<'_> {
     fn drop(&mut self) {
         // Swap out our state with however we finished. We should only ever see
         // an old state which was RUNNING.

--- a/src/libstd/sync/rwlock.rs
+++ b/src/libstd/sync/rwlock.rs
@@ -91,10 +91,10 @@ pub struct RwLockReadGuard<'a, T: ?Sized + 'a> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, T: ?Sized> !Send for RwLockReadGuard<'a, T> {}
+impl<T: ?Sized> !Send for RwLockReadGuard<'_, T> {}
 
 #[stable(feature = "rwlock_guard_sync", since = "1.23.0")]
-unsafe impl<'a, T: ?Sized + Sync> Sync for RwLockReadGuard<'a, T> {}
+unsafe impl<T: ?Sized + Sync> Sync for RwLockReadGuard<'_, T> {}
 
 /// RAII structure used to release the exclusive write access of a lock when
 /// dropped.
@@ -113,10 +113,10 @@ pub struct RwLockWriteGuard<'a, T: ?Sized + 'a> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, T: ?Sized> !Send for RwLockWriteGuard<'a, T> {}
+impl<T: ?Sized> !Send for RwLockWriteGuard<'_, T> {}
 
 #[stable(feature = "rwlock_guard_sync", since = "1.23.0")]
-unsafe impl<'a, T: ?Sized + Sync> Sync for RwLockWriteGuard<'a, T> {}
+unsafe impl<T: ?Sized + Sync> Sync for RwLockWriteGuard<'_, T> {}
 
 impl<T> RwLock<T> {
     /// Creates a new instance of an `RwLock<T>` which is unlocked.
@@ -480,7 +480,7 @@ impl<'rwlock, T: ?Sized> RwLockWriteGuard<'rwlock, T> {
 }
 
 #[stable(feature = "std_debug", since = "1.16.0")]
-impl<'a, T: fmt::Debug> fmt::Debug for RwLockReadGuard<'a, T> {
+impl<T: fmt::Debug> fmt::Debug for RwLockReadGuard<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("RwLockReadGuard")
             .field("lock", &self.__lock)
@@ -489,14 +489,14 @@ impl<'a, T: fmt::Debug> fmt::Debug for RwLockReadGuard<'a, T> {
 }
 
 #[stable(feature = "std_guard_impls", since = "1.20.0")]
-impl<'a, T: ?Sized + fmt::Display> fmt::Display for RwLockReadGuard<'a, T> {
+impl<T: ?Sized + fmt::Display> fmt::Display for RwLockReadGuard<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         (**self).fmt(f)
     }
 }
 
 #[stable(feature = "std_debug", since = "1.16.0")]
-impl<'a, T: fmt::Debug> fmt::Debug for RwLockWriteGuard<'a, T> {
+impl<T: fmt::Debug> fmt::Debug for RwLockWriteGuard<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("RwLockWriteGuard")
             .field("lock", &self.__lock)
@@ -505,14 +505,14 @@ impl<'a, T: fmt::Debug> fmt::Debug for RwLockWriteGuard<'a, T> {
 }
 
 #[stable(feature = "std_guard_impls", since = "1.20.0")]
-impl<'a, T: ?Sized + fmt::Display> fmt::Display for RwLockWriteGuard<'a, T> {
+impl<T: ?Sized + fmt::Display> fmt::Display for RwLockWriteGuard<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         (**self).fmt(f)
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'rwlock, T: ?Sized> Deref for RwLockReadGuard<'rwlock, T> {
+impl<T: ?Sized> Deref for RwLockReadGuard<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &T {
@@ -521,7 +521,7 @@ impl<'rwlock, T: ?Sized> Deref for RwLockReadGuard<'rwlock, T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'rwlock, T: ?Sized> Deref for RwLockWriteGuard<'rwlock, T> {
+impl<T: ?Sized> Deref for RwLockWriteGuard<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &T {
@@ -530,21 +530,21 @@ impl<'rwlock, T: ?Sized> Deref for RwLockWriteGuard<'rwlock, T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'rwlock, T: ?Sized> DerefMut for RwLockWriteGuard<'rwlock, T> {
+impl<T: ?Sized> DerefMut for RwLockWriteGuard<'_, T> {
     fn deref_mut(&mut self) -> &mut T {
         unsafe { &mut *self.__lock.data.get() }
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, T: ?Sized> Drop for RwLockReadGuard<'a, T> {
+impl<T: ?Sized> Drop for RwLockReadGuard<'_, T> {
     fn drop(&mut self) {
         unsafe { self.__lock.inner.read_unlock(); }
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, T: ?Sized> Drop for RwLockWriteGuard<'a, T> {
+impl<T: ?Sized> Drop for RwLockWriteGuard<'_, T> {
     fn drop(&mut self) {
         self.__lock.poison.done(&self.__poison);
         unsafe { self.__lock.inner.write_unlock(); }

--- a/src/libstd/sys_common/bytestring.rs
+++ b/src/libstd/sys_common/bytestring.rs
@@ -31,7 +31,7 @@ mod tests {
     fn smoke() {
         struct Helper<'a>(&'a [u8]);
 
-        impl<'a> Debug for Helper<'a> {
+        impl Debug for Helper<'_> {
             fn fmt(&self, f: &mut Formatter) -> Result {
                 debug_fmt_bytestring(self.0, f)
             }

--- a/src/libstd/sys_common/mutex.rs
+++ b/src/libstd/sys_common/mutex.rs
@@ -76,7 +76,7 @@ pub fn raw(mutex: &Mutex) -> &imp::Mutex { &mutex.0 }
 /// A simple RAII utility for the above Mutex without the poisoning semantics.
 pub struct MutexGuard<'a>(&'a imp::Mutex);
 
-impl<'a> Drop for MutexGuard<'a> {
+impl Drop for MutexGuard<'_> {
     #[inline]
     fn drop(&mut self) {
         unsafe { self.0.unlock(); }

--- a/src/libstd/sys_common/remutex.rs
+++ b/src/libstd/sys_common/remutex.rs
@@ -43,7 +43,7 @@ pub struct ReentrantMutexGuard<'a, T: 'a> {
     __poison: poison::Guard,
 }
 
-impl<'a, T> !marker::Send for ReentrantMutexGuard<'a, T> {}
+impl<T> !marker::Send for ReentrantMutexGuard<'_, T> {}
 
 
 impl<T> ReentrantMutex<T> {
@@ -138,7 +138,7 @@ impl<'mutex, T> ReentrantMutexGuard<'mutex, T> {
     }
 }
 
-impl<'mutex, T> Deref for ReentrantMutexGuard<'mutex, T> {
+impl<T> Deref for ReentrantMutexGuard<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &T {
@@ -146,7 +146,7 @@ impl<'mutex, T> Deref for ReentrantMutexGuard<'mutex, T> {
     }
 }
 
-impl<'a, T> Drop for ReentrantMutexGuard<'a, T> {
+impl<T> Drop for ReentrantMutexGuard<'_, T> {
     #[inline]
     fn drop(&mut self) {
         unsafe {
@@ -212,7 +212,7 @@ mod tests {
     }
 
     pub struct Answer<'a>(pub ReentrantMutexGuard<'a, RefCell<u32>>);
-    impl<'a> Drop for Answer<'a> {
+    impl Drop for Answer<'_> {
         fn drop(&mut self) {
             *self.0.borrow_mut() = 42;
         }


### PR DESCRIPTION
Inspired by seeing explicit lifetimes on these two:

- https://doc.rust-lang.org/nightly/std/slice/struct.Iter.html#impl-FusedIterator
- https://doc.rust-lang.org/nightly/std/primitive.u32.html#impl-Not

And a follow-up to https://github.com/rust-lang/rust/pull/54687, that started using IHLE in libcore.

Most of the changes in here fall into two big categories:

- Removing lifetimes from common traits that can essentially never user a lifetime from an input (particularly `Drop`, `Debug`, and `Clone`)

- Forwarding impls that are only possible because the lifetime doesn't matter (like `impl<R: Read + ?Sized> Read for &mut R`)

I omitted things that seemed like they could be more controversial, like the handful of iterators that have a `Item: 'static` despite the iterator having a lifetime or the `PartialEq` implementations [where the flipped one cannot elide the lifetime](https://internals.rust-lang.org/t/impl-type-parameter-aliases/9403/2?u=scottmcm).

I also removed two lifetimes that turned out to be completely unused; see https://github.com/rust-lang/rust/issues/41960#issuecomment-464557423