### PR TITLE
Add a note about 2018e if someone uses `try {` in 2015e

### DIFF
--- a/src/librustc_resolve/error_reporting.rs
+++ b/src/librustc_resolve/error_reporting.rs
@@ -251,6 +251,10 @@ impl<'a> Resolver<'a> {
                     format!("{}!", path_str),
                     Applicability::MaybeIncorrect,
                 );
+                if path_str == "try" && span.rust_2015() {
+                    err.note("if you want the `try` keyword, \
+                        you need to be in the 2018 edition");
+                }
             }
             (Def::TyAlias(..), PathSource::Trait(_)) => {
                 err.span_label(span, "type aliases cannot be used as traits");

--- a/src/test/ui/try-block/try-block-in-edition2015.stderr
+++ b/src/test/ui/try-block/try-block-in-edition2015.stderr
@@ -16,6 +16,8 @@ error[E0574]: expected struct, variant or union type, found macro `try`
    |
 LL |     let try_result: Option<_> = try {
    |                                 ^^^ help: use `!` to invoke the macro: `try!`
+   |
+   = note: if you want the `try` keyword, you need to be in the 2018 edition
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Inspired by https://github.com/rust-lang/rust/issues/58491, where a `try_blocks` example was accidentally run in 2015, which of course produces a bunch of errors.

What's the philosophy about gating for this?  The keyword is stably a keyword in 2018, so I haven't gated it for now but am not mentioning what the keyword _does_.  Let me know if I should do differently.

Resolves #53672