### PR TITLE
Fix typo in std::future::Future docs

### DIFF
--- a/src/libcore/future/future.rs
+++ b/src/libcore/future/future.rs
@@ -81,7 +81,7 @@ pub trait Future {
     ///
     /// Once a future has completed (returned `Ready` from `poll`),
     /// then any future calls to `poll` may panic, block forever, or otherwise
-    /// cause any kind of bad behavior expect causing memory unsafety.
+    /// cause any kind of bad behavior except causing memory unsafety.
     /// The `Future` trait itself provides no guarantees about the behavior
     /// of `poll` after a future has completed.
     ///


### PR DESCRIPTION
I am not quite sure if this is actually a typo but

1. to me the sentence doesn't make sense if it says "expect"
2. I hope that `Future`s are not really allowed to cause memory unsafety if they are polled after completion.