### PR TITLE
Stabilize iter::successors and iter::from_fn

### DIFF
--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -327,7 +327,9 @@ pub use self::sources::{Once, once};
 #[unstable(feature = "iter_once_with", issue = "57581")]
 pub use self::sources::{OnceWith, once_with};
 #[unstable(feature = "iter_unfold", issue = "55977")]
-pub use self::sources::{FromFn, from_fn, Successors, successors};
+pub use self::sources::{FromFn, from_fn};
+#[stable(feature = "iter_successors", since = "1.34.0")]
+pub use self::sources::{Successors, successors};
 
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::traits::{FromIterator, IntoIterator, DoubleEndedIterator, Extend};

--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -326,7 +326,7 @@ pub use self::sources::{Empty, empty};
 pub use self::sources::{Once, once};
 #[unstable(feature = "iter_once_with", issue = "57581")]
 pub use self::sources::{OnceWith, once_with};
-#[unstable(feature = "iter_unfold", issue = "55977")]
+#[stable(feature = "iter_from_fn", since = "1.34.0")]
 pub use self::sources::{FromFn, from_fn};
 #[stable(feature = "iter_successors", since = "1.34.0")]
 pub use self::sources::{Successors, successors};

--- a/src/libcore/iter/sources.rs
+++ b/src/libcore/iter/sources.rs
@@ -572,13 +572,12 @@ impl<F> fmt::Debug for FromFn<F> {
 /// and calls the given `FnMut(&T) -> Option<T>` closure to compute each item’s successor.
 ///
 /// ```
-/// #![feature(iter_unfold)]
 /// use std::iter::successors;
 ///
 /// let powers_of_10 = successors(Some(1_u16), |n| n.checked_mul(10));
 /// assert_eq!(powers_of_10.collect::<Vec<_>>(), &[1, 10, 100, 1_000, 10_000]);
 /// ```
-#[unstable(feature = "iter_unfold", issue = "55977")]
+#[stable(feature = "iter_successors", since = "1.34.0")]
 pub fn successors<T, F>(first: Option<T>, succ: F) -> Successors<T, F>
     where F: FnMut(&T) -> Option<T>
 {
@@ -598,13 +597,13 @@ pub fn successors<T, F>(first: Option<T>, succ: F) -> Successors<T, F>
 ///
 /// [`successors`]: fn.successors.html
 #[derive(Clone)]
-#[unstable(feature = "iter_unfold", issue = "55977")]
+#[stable(feature = "iter_successors", since = "1.34.0")]
 pub struct Successors<T, F> {
     next: Option<T>,
     succ: F,
 }
 
-#[unstable(feature = "iter_unfold", issue = "55977")]
+#[stable(feature = "iter_successors", since = "1.34.0")]
 impl<T, F> Iterator for Successors<T, F>
     where F: FnMut(&T) -> Option<T>
 {
@@ -628,12 +627,12 @@ impl<T, F> Iterator for Successors<T, F>
     }
 }
 
-#[unstable(feature = "iter_unfold", issue = "55977")]
+#[stable(feature = "iter_successors", since = "1.34.0")]
 impl<T, F> FusedIterator for Successors<T, F>
     where F: FnMut(&T) -> Option<T>
 {}
 
-#[unstable(feature = "iter_unfold", issue = "55977")]
+#[stable(feature = "iter_successors", since = "1.34.0")]
 impl<T: fmt::Debug, F> fmt::Debug for Successors<T, F> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Successors")

--- a/src/libcore/iter/sources.rs
+++ b/src/libcore/iter/sources.rs
@@ -514,7 +514,6 @@ pub fn once_with<A, F: FnOnce() -> A>(gen: F) -> OnceWith<F> {
 /// [module-level documentation]: index.html
 ///
 /// ```
-/// #![feature(iter_unfold)]
 /// let mut count = 0;
 /// let counter = std::iter::from_fn(move || {
 ///     // Increment our count. This is why we started at zero.
@@ -530,7 +529,7 @@ pub fn once_with<A, F: FnOnce() -> A>(gen: F) -> OnceWith<F> {
 /// assert_eq!(counter.collect::<Vec<_>>(), &[1, 2, 3, 4, 5]);
 /// ```
 #[inline]
-#[unstable(feature = "iter_unfold", issue = "55977")]
+#[stable(feature = "iter_from_fn", since = "1.34.0")]
 pub fn from_fn<T, F>(f: F) -> FromFn<F>
     where F: FnMut() -> Option<T>
 {
@@ -544,10 +543,10 @@ pub fn from_fn<T, F>(f: F) -> FromFn<F>
 ///
 /// [`iter::from_fn`]: fn.from_fn.html
 #[derive(Clone)]
-#[unstable(feature = "iter_unfold", issue = "55977")]
+#[stable(feature = "iter_from_fn", since = "1.34.0")]
 pub struct FromFn<F>(F);
 
-#[unstable(feature = "iter_unfold", issue = "55977")]
+#[stable(feature = "iter_from_fn", since = "1.34.0")]
 impl<T, F> Iterator for FromFn<F>
     where F: FnMut() -> Option<T>
 {
@@ -559,7 +558,7 @@ impl<T, F> Iterator for FromFn<F>
     }
 }
 
-#[unstable(feature = "iter_unfold", issue = "55977")]
+#[stable(feature = "iter_from_fn", since = "1.34.0")]
 impl<F> fmt::Debug for FromFn<F> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("FromFn").finish()

--- a/src/libcore/tests/lib.rs
+++ b/src/libcore/tests/lib.rs
@@ -14,7 +14,6 @@
 #![feature(iter_copied)]
 #![feature(iter_nth_back)]
 #![feature(iter_once_with)]
-#![feature(iter_unfold)]
 #![feature(pattern)]
 #![feature(range_is_empty)]
 #![feature(raw)]


### PR DESCRIPTION
FCP: https://github.com/rust-lang/rust/issues/58045#issuecomment-464674773, https://github.com/rust-lang/rust/issues/55977#issuecomment-463964234