### PR TITLE
Fixes #58586: Make E0505 erronous example fail for the 2018 edition

### DIFF
--- a/src/librustc_mir/diagnostics.rs
+++ b/src/librustc_mir/diagnostics.rs
@@ -1551,11 +1551,9 @@ fn eat(val: Value) {}
 
 fn main() {
     let x = Value{};
-    {
-        let _ref_to_val: &Value = &x;
-        eat(x);
-        borrow(_ref_to_val);
-    }
+    let _ref_to_val: &Value = &x;
+    eat(x);
+    borrow(_ref_to_val);
 }
 ```
 
@@ -1579,11 +1577,9 @@ fn eat(val: &Value) {}
 
 fn main() {
     let x = Value{};
-    {
-        let _ref_to_val: &Value = &x;
-        eat(&x); // pass by reference, if it's possible
-        borrow(_ref_to_val);
-    }
+    let _ref_to_val: &Value = &x;
+    eat(&x); // pass by reference, if it's possible
+    borrow(_ref_to_val);
 }
 ```
 
@@ -1618,11 +1614,9 @@ fn eat(val: Value) {}
 
 fn main() {
     let x = Value{};
-    {
-        let _ref_to_val: &Value = &x;
-        eat(x); // it will be copied here.
-        borrow(_ref_to_val);
-    }
+    let _ref_to_val: &Value = &x;
+    eat(x); // it will be copied here.
+    borrow(_ref_to_val);
 }
 ```
 

--- a/src/librustc_mir/diagnostics.rs
+++ b/src/librustc_mir/diagnostics.rs
@@ -1545,6 +1545,8 @@ Erroneous code example:
 ```compile_fail,E0505
 struct Value {}
 
+fn borrow(val: &Value) {}
+
 fn eat(val: Value) {}
 
 fn main() {
@@ -1552,13 +1554,15 @@ fn main() {
     {
         let _ref_to_val: &Value = &x;
         eat(x);
+        borrow(_ref_to_val);
     }
 }
 ```
 
-Here, the function `eat` takes the ownership of `x`. However,
-`x` cannot be moved because it was borrowed to `_ref_to_val`.
-To fix that you can do few different things:
+Here, the function `eat` takes ownership of `x`. However,
+`x` cannot be moved because the borrow to `_ref_to_val`
+needs to last till the function `borrow`.
+To fix that you can do a few different things:
 
 * Try to avoid moving the variable.
 * Release borrow before move.
@@ -1569,6 +1573,8 @@ Examples:
 ```
 struct Value {}
 
+fn borrow(val: &Value) {}
+
 fn eat(val: &Value) {}
 
 fn main() {
@@ -1576,6 +1582,7 @@ fn main() {
     {
         let _ref_to_val: &Value = &x;
         eat(&x); // pass by reference, if it's possible
+        borrow(_ref_to_val);
     }
 }
 ```
@@ -1585,12 +1592,15 @@ Or:
 ```
 struct Value {}
 
+fn borrow(val: &Value) {}
+
 fn eat(val: Value) {}
 
 fn main() {
     let x = Value{};
     {
         let _ref_to_val: &Value = &x;
+        borrow(_ref_to_val);
     }
     eat(x); // release borrow and then move it.
 }
@@ -1602,6 +1612,8 @@ Or:
 #[derive(Clone, Copy)] // implement Copy trait
 struct Value {}
 
+fn borrow(val: &Value) {}
+
 fn eat(val: Value) {}
 
 fn main() {
@@ -1609,6 +1621,7 @@ fn main() {
     {
         let _ref_to_val: &Value = &x;
         eat(x); // it will be copied here.
+        borrow(_ref_to_val);
     }
 }
 ```


### PR DESCRIPTION
The original example worked for 2015, but not the 2018 edition of Rust.

Borrowing the moved value after ownership is transferred seems required for 2018.

[this](https://github.com/rust-lang/rust/compare/rust-lang:f66e469...gurgalex:b2a02c8#diff-4ca866aea4a6efecd732f1975faaad88R1564) line though is correct for 2018, but not for the 2015 edition.

Fix #58586 