### PR TITLE
Explicitly pass strong ref as raw pointer to prevent UB in Arc::drop

### DIFF
--- a/src/libcore/sync/atomic.rs
+++ b/src/libcore/sync/atomic.rs
@@ -1576,6 +1576,41 @@ assert_eq!(foo.load(Ordering::SeqCst), 10);
             }
 
             doc_comment! {
+                concat!("Subtracts from the given atomic value, returning the previous value.
+
+This operation wraps around on overflow.
+
+`fetch_sub_explicit` takes ", stringify!($atomic_type), " which will be substracted by given value
+in respect to [`Ordering`] argument which describes the memory ordering
+of this operation. All ordering modes are possible. Note that using
+[`Acquire`] makes the store part of this operation [`Relaxed`], and
+using [`Release`] makes the load part [`Relaxed`].
+
+[`Ordering`]: enum.Ordering.html
+[`Relaxed`]: enum.Ordering.html#variant.Relaxed
+[`Release`]: enum.Ordering.html#variant.Release
+[`Acquire`]: enum.Ordering.html#variant.Acquire
+
+# Examples
+
+```
+", $extra_feature, "use std::sync::atomic::{", stringify!($atomic_type), ", Ordering};
+
+let foo = ", stringify!($atomic_type), "::new(20);
+assert_eq!(", stringify!($atomic_type), ".fetch_sub_explicit(foo, Ordering::SeqCst), 20);
+assert_eq!(foo.load(Ordering::SeqCst), 10);
+            ```"),
+                #[inline]
+                #[$stable]
+                #[cfg(target_has_atomic = "cas")]
+                pub fn fetch_sub_explicit(f: *const $atomic_type,
+                                             val: $int_type,
+                                             order: Ordering) -> $int_type {
+                    unsafe { atomic_sub((*f).v.get(), val, order) }
+                }
+            }
+
+            doc_comment! {
                 concat!("Bitwise \"and\" with the current value.
 
 Performs a bitwise \"and\" operation on the current value and the argument `val`, and


### PR DESCRIPTION
As stated out in https://github.com/rust-lang/rust/issues/55005 I try to apply the first solution stated by @RalfJung . Which is:
> * Provide a version of `fetch_sub` that takes a raw pointer, and use that.

I want to add couple of questions and notes about PR:
* I am unsure how this can be done without extending the public api of `Atomic*`.
* mutable borrows can't be done over the `ArcInner<T>` so while using the `fetch_*` of strong ref. how we can pass a raw pointer of strong ref? Is it correct way of doing it?
* how can we test this spooky case? Spawning threads that will lurk behind the `Arc::drop`? I have no idea.