### PR TITLE
rustdoc: support methods on primitives in intra-doc links

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -976,11 +976,13 @@ impl Attributes {
                                 "https://doc.rust-lang.org/nightly",
                         };
                         // This is a primitive so the url is done "by hand".
+                        let tail = fragment.find('#').unwrap_or_else(|| fragment.len());
                         Some((s.clone(),
-                              format!("{}{}std/primitive.{}.html",
+                              format!("{}{}std/primitive.{}.html{}",
                                       url,
                                       if !url.ends_with('/') { "/" } else { "" },
-                                      fragment)))
+                                      &fragment[..tail],
+                                      &fragment[tail..])))
                     } else {
                         panic!("This isn't a primitive?!");
                     }

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -1,6 +1,7 @@
 use rustc::lint as lint;
 use rustc::hir;
 use rustc::hir::def::Def;
+use rustc::hir::def_id::DefId;
 use rustc::ty;
 use syntax;
 use syntax::ast::{self, Ident, NodeId};
@@ -125,6 +126,17 @@ impl<'a, 'tcx, 'rcx> LinkCollector<'a, 'tcx, 'rcx> {
                 if let Some(name) = current_item.as_ref() {
                     path = name.clone();
                 }
+            }
+            if let Some(prim) = is_primitive(&path, false) {
+                let did = primitive_impl(cx, &path).ok_or(())?;
+                return cx.tcx.associated_items(did)
+                    .find(|item| item.ident.name == item_name)
+                    .and_then(|item| match item.kind {
+                        ty::AssociatedKind::Method => Some("method"),
+                        _ => None,
+                    })
+                    .map(|out| (prim, Some(format!("{}#{}.{}", path, out, item_name))))
+                    .ok_or(());
             }
 
             // FIXME: `with_scope` requires the `NodeId` of a module.
@@ -587,5 +599,28 @@ fn is_primitive(path_str: &str, is_val: bool) -> Option<Def> {
         None
     } else {
         PRIMITIVES.iter().find(|x| x.0 == path_str).map(|x| x.1)
+    }
+}
+
+fn primitive_impl(cx: &DocContext, path_str: &str) -> Option<DefId> {
+    let tcx = cx.tcx;
+    match path_str {
+        "u8" => tcx.lang_items().u8_impl(),
+        "u16" => tcx.lang_items().u16_impl(),
+        "u32" => tcx.lang_items().u32_impl(),
+        "u64" => tcx.lang_items().u64_impl(),
+        "u128" => tcx.lang_items().u128_impl(),
+        "usize" => tcx.lang_items().usize_impl(),
+        "i8" => tcx.lang_items().i8_impl(),
+        "i16" => tcx.lang_items().i16_impl(),
+        "i32" => tcx.lang_items().i32_impl(),
+        "i64" => tcx.lang_items().i64_impl(),
+        "i128" => tcx.lang_items().i128_impl(),
+        "isize" => tcx.lang_items().isize_impl(),
+        "f32" => tcx.lang_items().f32_impl(),
+        "f64" => tcx.lang_items().f64_impl(),
+        "str" => tcx.lang_items().str_impl(),
+        "char" => tcx.lang_items().char_impl(),
+        _ => None,
     }
 }

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -602,7 +602,7 @@ fn is_primitive(path_str: &str, is_val: bool) -> Option<Def> {
     }
 }
 
-fn primitive_impl(cx: &DocContext, path_str: &str) -> Option<DefId> {
+fn primitive_impl(cx: &DocContext<'_, '_, '_>, path_str: &str) -> Option<DefId> {
     let tcx = cx.tcx;
     match path_str {
         "u8" => tcx.lang_items().u8_impl(),

--- a/src/test/rustdoc/intra-link-prim-methods.rs
+++ b/src/test/rustdoc/intra-link-prim-methods.rs
@@ -1,0 +1,3 @@
+#![deny(intra_doc_link_resolution_failure)]
+
+//! A [`char`] and its [`char::len_utf8`].


### PR DESCRIPTION
Fixes #58598.