### PR TITLE
Refactor how opaque::Decoder represents its contents

### DIFF
--- a/src/librustc_incremental/persist/load.rs
+++ b/src/librustc_incremental/persist/load.rs
@@ -200,7 +200,7 @@ pub fn load_query_result_cache<'sess>(sess: &'sess Session) -> OnDiskCache<'sess
     }
 
     match load_data(sess.opts.debugging_opts.incremental_info, &query_cache_path(sess)) {
-        LoadResult::Ok{ data: (bytes, start_pos) } => OnDiskCache::new(sess, bytes, start_pos),
+        LoadResult::Ok{ data: (bytes, _) } => OnDiskCache::new(sess, bytes),
         _ => OnDiskCache::new_empty(sess.source_map())
     }
 }

--- a/src/librustc_metadata/decoder.rs
+++ b/src/librustc_metadata/decoder.rs
@@ -179,7 +179,7 @@ impl<'a, 'tcx: 'a> TyDecoder<'a, 'tcx> for DecodeContext<'a, 'tcx> {
 
     #[inline]
     fn peek_byte(&self) -> u8 {
-        self.opaque.data[self.opaque.position()]
+        self.opaque.data()[0]
     }
 
     #[inline]
@@ -212,7 +212,7 @@ impl<'a, 'tcx: 'a> TyDecoder<'a, 'tcx> for DecodeContext<'a, 'tcx> {
     fn with_position<F, R>(&mut self, pos: usize, f: F) -> R
         where F: FnOnce(&mut Self) -> R
     {
-        let new_opaque = opaque::Decoder::new(self.opaque.data, pos);
+        let new_opaque = opaque::Decoder::new(self.opaque.original_data, pos);
         let old_opaque = mem::replace(&mut self.opaque, new_opaque);
         let old_state = mem::replace(&mut self.lazy_state, LazyState::NoNode);
         let r = f(self);

--- a/src/libserialize/leb128.rs
+++ b/src/libserialize/leb128.rs
@@ -114,10 +114,10 @@ pub fn write_signed_leb128(out: &mut Vec<u8>, value: i128) {
 }
 
 #[inline]
-pub fn read_signed_leb128(data: &[u8], start_position: usize) -> (i128, usize) {
+pub fn read_signed_leb128(data: &[u8]) -> (i128, usize) {
     let mut result = 0;
     let mut shift = 0;
-    let mut position = start_position;
+    let mut position = 0;
     let mut byte;
 
     loop {
@@ -136,7 +136,7 @@ pub fn read_signed_leb128(data: &[u8], start_position: usize) -> (i128, usize) {
         result |= -(1 << shift);
     }
 
-    (result, position - start_position)
+    (result, position)
 }
 
 macro_rules! impl_test_unsigned_leb128 {
@@ -176,7 +176,7 @@ fn test_signed_leb128() {
     }
     let mut pos = 0;
     for &x in &values {
-        let (value, bytes_read) = read_signed_leb128(&mut stream, pos);
+        let (value, bytes_read) = read_signed_leb128(&mut stream[pos..]);
         pos += bytes_read;
         assert_eq!(x, value);
     }

--- a/src/libserialize/lib.rs
+++ b/src/libserialize/lib.rs
@@ -15,6 +15,7 @@ Core encoding and decoding interfaces.
 #![feature(specialization)]
 #![feature(never_type)]
 #![feature(nll)]
+#![feature(ptr_wrapping_offset_from)]
 #![cfg_attr(test, feature(test))]
 
 pub use self::serialize::{Decoder, Encoder, Decodable, Encodable};


### PR DESCRIPTION
Instead of (&[u8], position) simply store the &[u8] and reslice.

This was originally written for #58475, to see if removing the arithmetic helped with avoiding integer overflow checks, however I think the result is slightly more readable in general -- specifically the removal of set_position is a nice win. I think this might be a hair faster even without the changes in #58475, but I haven't measured that.