### PR TITLE
Added a connection timeout and speed threshold when downloading the Docker cache

### DIFF
--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -31,7 +31,7 @@ if [ -f "$docker_dir/$image/Dockerfile" ]; then
       echo "Attempting to download $s3url"
       rm -f /tmp/rustci_docker_cache
       set +e
-      retry curl -f -L -C - -o /tmp/rustci_docker_cache "$url"
+      retry curl -y 30 -Y 10 --connect-timeout 30 -f -L -C - -o /tmp/rustci_docker_cache "$url"
       loaded_images=$(docker load -i /tmp/rustci_docker_cache | sed 's/.* sha/sha/')
       set -e
       echo "Downloaded containers:\n$loaded_images"


### PR DESCRIPTION
This is an attempt to fix one possible cause of #56112. Similar to #52846, this changed the download docker-cache command to fail if it cannot connect or falls below 10 bytes/s after 30 seconds, so it could be retried sooner.