### PR TITLE
MaybeUninit: add read_initialized, add examples

### DIFF
--- a/src/libcore/fmt/float.rs
+++ b/src/libcore/fmt/float.rs
@@ -15,6 +15,7 @@ fn float_to_decimal_common_exact<T>(fmt: &mut Formatter, num: &T,
         // FIXME(#53491): Technically, this is calling `get_mut` on an uninitialized
         // `MaybeUninit` (here and elsewhere in this file).  Revisit this once
         // we decided whether that is valid or not.
+        // Using `freeze` is *not enough*; `flt2dec::Part` is an enum!
         let formatted = flt2dec::to_exact_fixed_str(flt2dec::strategy::grisu::format_exact,
                                                     *num, sign, precision,
                                                     false, buf.get_mut(), parts.get_mut());
@@ -33,6 +34,7 @@ fn float_to_decimal_common_shortest<T>(fmt: &mut Formatter, num: &T,
         // enough for f32 and f64
         let mut buf = MaybeUninit::<[u8; flt2dec::MAX_SIG_DIGITS]>::uninitialized();
         let mut parts = MaybeUninit::<[flt2dec::Part; 4]>::uninitialized();
+        // FIXME(#53491)
         let formatted = flt2dec::to_shortest_str(flt2dec::strategy::grisu::format_shortest, *num,
                                                  sign, precision, false, buf.get_mut(),
                                                  parts.get_mut());
@@ -71,6 +73,7 @@ fn float_to_exponential_common_exact<T>(fmt: &mut Formatter, num: &T,
     unsafe {
         let mut buf = MaybeUninit::<[u8; 1024]>::uninitialized(); // enough for f32 and f64
         let mut parts = MaybeUninit::<[flt2dec::Part; 6]>::uninitialized();
+        // FIXME(#53491)
         let formatted = flt2dec::to_exact_exp_str(flt2dec::strategy::grisu::format_exact,
                                                   *num, sign, precision,
                                                   upper, buf.get_mut(), parts.get_mut());
@@ -90,6 +93,7 @@ fn float_to_exponential_common_shortest<T>(fmt: &mut Formatter,
         // enough for f32 and f64
         let mut buf = MaybeUninit::<[u8; flt2dec::MAX_SIG_DIGITS]>::uninitialized();
         let mut parts = MaybeUninit::<[flt2dec::Part; 6]>::uninitialized();
+        // FIXME(#53491)
         let formatted = flt2dec::to_shortest_exp_str(flt2dec::strategy::grisu::format_shortest,
                                                      *num, sign, (0, 0), upper,
                                                      buf.get_mut(), parts.get_mut());

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -1165,6 +1165,32 @@ impl<T> MaybeUninit<T> {
 
     /// Gets a pointer to the contained value. Reading from this pointer or turning it
     /// into a reference is undefined behavior unless the `MaybeUninit` is initialized.
+    ///
+    /// # Examples
+    ///
+    /// Correct usage of this method:
+    ///
+    /// ```rust
+    /// #![feature(maybe_uninit)]
+    /// use std::mem::MaybeUninit;
+    ///
+    /// let mut x = MaybeUninit::<Vec<u32>>::uninitialized();
+    /// x.set(vec![0,1,2]);
+    /// // Create a reference into the `MaybeUninit`. This is okay because we initialized it.
+    /// let x_vec = unsafe { &*x.as_ptr() };
+    /// assert_eq!(x_vec.len(), 3);
+    /// ```
+    ///
+    /// *Incorrect* usage of this method:
+    ///
+    /// ```rust,no_run
+    /// #![feature(maybe_uninit)]
+    /// use std::mem::MaybeUninit;
+    ///
+    /// let x = MaybeUninit::<Vec<u32>>::uninitialized();
+    /// let x_vec = unsafe { &*x.as_ptr() };
+    /// // We have created a reference to an uninitialized vector! This is undefined behavior.
+    /// ```
     #[unstable(feature = "maybe_uninit", issue = "53491")]
     #[inline(always)]
     pub fn as_ptr(&self) -> *const T {
@@ -1173,6 +1199,33 @@ impl<T> MaybeUninit<T> {
 
     /// Gets a mutable pointer to the contained value. Reading from this pointer or turning it
     /// into a reference is undefined behavior unless the `MaybeUninit` is initialized.
+    ///
+    /// # Examples
+    ///
+    /// Correct usage of this method:
+    ///
+    /// ```rust
+    /// #![feature(maybe_uninit)]
+    /// use std::mem::MaybeUninit;
+    ///
+    /// let mut x = MaybeUninit::<Vec<u32>>::uninitialized();
+    /// x.set(vec![0,1,2]);
+    /// // Create a reference into the `MaybeUninit`. This is okay because we initialized it.
+    /// let x_vec = unsafe { &mut *x.as_mut_ptr() };
+    /// x_vec.push(3);
+    /// assert_eq!(x_vec.len(), 4);
+    /// ```
+    ///
+    /// *Incorrect* usage of this method:
+    ///
+    /// ```rust,no_run
+    /// #![feature(maybe_uninit)]
+    /// use std::mem::MaybeUninit;
+    ///
+    /// let mut x = MaybeUninit::<Vec<u32>>::uninitialized();
+    /// let x_vec = unsafe { &mut *x.as_mut_ptr() };
+    /// // We have created a reference to an uninitialized vector! This is undefined behavior.
+    /// ```
     #[unstable(feature = "maybe_uninit", issue = "53491")]
     #[inline(always)]
     pub fn as_mut_ptr(&mut self) -> *mut T {

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -1327,6 +1327,8 @@ impl<T> MaybeUninit<T> {
     /// calling `read_initialized` and then [`into_initialized`]), it is your responsibility
     /// to ensure that that data may indeed be duplicated.
     ///
+    /// [`into_initialized`]: #method.into_initialized
+    ///
     /// # Examples
     ///
     /// Correct usage of this method:

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -1064,13 +1064,13 @@ impl<T: ?Sized> DerefMut for ManuallyDrop<T> {
 /// use std::mem::{self, MaybeUninit};
 ///
 /// let b: bool = unsafe { mem::uninitialized() }; // undefined behavior!
-/// // equivalent code with `MaybeUninit`
+/// // The equivalent code with `MaybeUninit`:
 /// let b: bool = unsafe { MaybeUninit::uninitialized().into_initialized() }; // undefined behavior!
 /// ```
 ///
 /// Moreover, uninitialized memory is special in that the compiler knows that
 /// it does not have a fixed value. This makes it undefined behavior to have
-/// uninitialized data in a variable even if that variable has integer type,
+/// uninitialized data in a variable even if that variable has an integer type,
 /// which otherwise can hold any bit pattern:
 ///
 /// ```rust,no_run
@@ -1084,7 +1084,7 @@ impl<T: ?Sized> DerefMut for ManuallyDrop<T> {
 /// (Notice that the rules around uninitialized integers are not finalized yet, but
 /// until they are, it is advisable to avoid them.)
 ///
-/// `MaybeUninit` serves to enable unsafe code to deal with uninitialized data.
+/// `MaybeUninit<T>` serves to enable unsafe code to deal with uninitialized data.
 /// It is a signal to the compiler indicating that the data here might *not*
 /// be initialized:
 ///
@@ -1107,7 +1107,7 @@ impl<T: ?Sized> DerefMut for ManuallyDrop<T> {
 #[allow(missing_debug_implementations)]
 #[unstable(feature = "maybe_uninit", issue = "53491")]
 #[derive(Copy)]
-// NOTE after stabilizing `MaybeUninit` proceed to deprecate `mem::uninitialized`
+// NOTE after stabilizing `MaybeUninit` proceed to deprecate `mem::uninitialized`.
 pub union MaybeUninit<T> {
     uninit: (),
     value: ManuallyDrop<T>,
@@ -1123,7 +1123,7 @@ impl<T: Copy> Clone for MaybeUninit<T> {
 }
 
 impl<T> MaybeUninit<T> {
-    /// Create a new `MaybeUninit` initialized with the given value.
+    /// Create a new `MaybeUninit<T>` initialized with the given value.
     ///
     /// Note that dropping a `MaybeUninit` will never call `T`'s drop code.
     /// It is your responsibility to make sure `T` gets dropped if it got initialized.
@@ -1149,13 +1149,13 @@ impl<T> MaybeUninit<T> {
     /// but `MaybeUninit<&'static i32>::zeroed()` is not because references must not
     /// be null.
     ///
-    /// Note that dropping a `MaybeUninit` will never call `T`'s drop code.
+    /// Note that dropping a `MaybeUninit<T>` will never call `T`'s drop code.
     /// It is your responsibility to make sure `T` gets dropped if it got initialized.
     ///
     /// # Example
     ///
-    /// Correct usage of this method: initializing a struct with zero, where all
-    /// fields of the struct can hold 0 as a valid value.
+    /// Correct usage of this function: initializing a struct with zero, where all
+    /// fields of the struct can hold the bit-pattern 0 as a valid value.
     ///
     /// ```rust
     /// #![feature(maybe_uninit)]
@@ -1166,7 +1166,7 @@ impl<T> MaybeUninit<T> {
     /// assert_eq!(x, (0, false));
     /// ```
     ///
-    /// *Incorrect* usage of this method: initializing a struct with zero, where some fields
+    /// *Incorrect* usage of this function: initializing a struct with zero, where some fields
     /// cannot hold 0 as a valid value.
     ///
     /// ```rust,no_run
@@ -1177,7 +1177,7 @@ impl<T> MaybeUninit<T> {
     ///
     /// let x = MaybeUninit::<(u8, NotZero)>::zeroed();
     /// let x = unsafe { x.into_initialized() };
-    /// // We create a `NotZero` (inside a pair) that does not have a valid discriminant.
+    /// // Inside a pair, we create a `NotZero` that does not have a valid discriminant.
     /// // This is undefined behavior.
     /// ```
     #[unstable(feature = "maybe_uninit", issue = "53491")]
@@ -1203,7 +1203,7 @@ impl<T> MaybeUninit<T> {
     }
 
     /// Gets a pointer to the contained value. Reading from this pointer or turning it
-    /// into a reference is undefined behavior unless the `MaybeUninit` is initialized.
+    /// into a reference is undefined behavior unless the `MaybeUninit<T>` is initialized.
     ///
     /// # Examples
     ///
@@ -1237,7 +1237,7 @@ impl<T> MaybeUninit<T> {
     }
 
     /// Gets a mutable pointer to the contained value. Reading from this pointer or turning it
-    /// into a reference is undefined behavior unless the `MaybeUninit` is initialized.
+    /// into a reference is undefined behavior unless the `MaybeUninit<T>` is initialized.
     ///
     /// # Examples
     ///
@@ -1249,7 +1249,8 @@ impl<T> MaybeUninit<T> {
     ///
     /// let mut x = MaybeUninit::<Vec<u32>>::uninitialized();
     /// x.set(vec![0,1,2]);
-    /// // Create a reference into the `MaybeUninit`. This is okay because we initialized it.
+    /// // Create a reference into the `MaybeUninit<Vec<u32>>`.
+    /// // This is okay because we initialized it.
     /// let x_vec = unsafe { &mut *x.as_mut_ptr() };
     /// x_vec.push(3);
     /// assert_eq!(x_vec.len(), 4);
@@ -1303,7 +1304,7 @@ impl<T> MaybeUninit<T> {
     ///
     /// let x = MaybeUninit::<Vec<u32>>::uninitialized();
     /// let x_init = unsafe { x.into_initialized() };
-    /// // `x` had not been initialized yet, so this last line causes undefined behavior.
+    /// // `x` had not been initialized yet, so this last line caused undefined behavior.
     /// ```
     #[unstable(feature = "maybe_uninit", issue = "53491")]
     #[inline(always)]
@@ -1312,16 +1313,16 @@ impl<T> MaybeUninit<T> {
         ManuallyDrop::into_inner(self.value)
     }
 
-    /// Reads the value from the `MaybeUninit` container. The resulting `T` is subject
+    /// Reads the value from the `MaybeUninit<T>` container. The resulting `T` is subject
     /// to the usual drop handling.
     ///
-    /// # Unsafety
+    /// # Safety
     ///
-    /// It is up to the caller to guarantee that the `MaybeUninit` really is in an initialized
+    /// It is up to the caller to guarantee that the `MaybeUninit<T>` really is in an initialized
     /// state. Calling this when the content is not yet fully initialized causes undefined
     /// behavior.
     ///
-    /// Moreover, this leaves a copy of the same data behind in the `MaybeUninit`. When using
+    /// Moreover, this leaves a copy of the same data behind in the `MaybeUninit<T>`. When using
     /// multiple copies of the data (by calling `read_initialized` multiple times, or first
     /// calling `read_initialized` and then [`into_initialized`]), it is your responsibility
     /// to ensure that that data may indeed be duplicated.

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -1321,6 +1321,9 @@ impl<T> MaybeUninit<T> {
     /// Reads the value from the `MaybeUninit<T>` container. The resulting `T` is subject
     /// to the usual drop handling.
     ///
+    /// Whenever possible, it is preferrable to use [`into_initialized`] instead, which
+    /// prevents duplicating the content of the `MaybeUninit<T>`.
+    ///
     /// # Safety
     ///
     /// It is up to the caller to guarantee that the `MaybeUninit<T>` really is in an initialized

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -1106,10 +1106,20 @@ impl<T: ?Sized> DerefMut for ManuallyDrop<T> {
 // FIXME before stabilizing, explain how to initialize a struct field-by-field.
 #[allow(missing_debug_implementations)]
 #[unstable(feature = "maybe_uninit", issue = "53491")]
+#[derive(Copy)]
 // NOTE after stabilizing `MaybeUninit` proceed to deprecate `mem::uninitialized`
 pub union MaybeUninit<T> {
     uninit: (),
     value: ManuallyDrop<T>,
+}
+
+#[unstable(feature = "maybe_uninit", issue = "53491")]
+impl<T: Copy> Clone for MaybeUninit<T> {
+    #[inline(always)]
+    fn clone(&self) -> Self {
+        // Not calling T::clone(), we cannot know if we are initialized enough for that.
+        *self
+    }
 }
 
 impl<T> MaybeUninit<T> {

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -1049,7 +1049,7 @@ impl<T: ?Sized> DerefMut for ManuallyDrop<T> {
 /// use std::mem::{self, MaybeUninit};
 ///
 /// let x: &i32 = unsafe { mem::zeroed() }; // undefined behavior!
-/// // equivalent code with `MaybeUninit<&i32>`
+/// // The equivalent code with `MaybeUninit<&i32>`:
 /// let x: &i32 = unsafe { MaybeUninit::zeroed().into_initialized() }; // undefined behavior!
 /// ```
 ///
@@ -1078,7 +1078,7 @@ impl<T: ?Sized> DerefMut for ManuallyDrop<T> {
 /// use std::mem::{self, MaybeUninit};
 ///
 /// let x: i32 = unsafe { mem::uninitialized() }; // undefined behavior!
-/// // equivalent code with `MaybeUninit<i32>`
+/// // The equivalent code with `MaybeUninit<i32>`:
 /// let x: i32 = unsafe { MaybeUninit::uninitialized().into_initialized() }; // undefined behavior!
 /// ```
 /// (Notice that the rules around uninitialized integers are not finalized yet, but
@@ -1231,7 +1231,7 @@ impl<T> MaybeUninit<T> {
     /// let x_vec = unsafe { &*x.as_ptr() };
     /// // We have created a reference to an uninitialized vector! This is undefined behavior.
     /// ```
-    /// (Notice that the rules around referenced to uninitialized data are not finalized yet, but
+    /// (Notice that the rules around references to uninitialized data are not finalized yet, but
     /// until they are, it is advisable to avoid them.)
     #[unstable(feature = "maybe_uninit", issue = "53491")]
     #[inline(always)]

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -1178,6 +1178,31 @@ impl<T> MaybeUninit<T> {
     /// It is up to the caller to guarantee that the `MaybeUninit` really is in an initialized
     /// state. Calling this when the content is not yet fully initialized causes undefined
     /// behavior.
+    ///
+    /// # Examples
+    ///
+    /// Correct usage of this method:
+    ///
+    /// ```rust
+    /// #![feature(maybe_uninit)]
+    /// use std::mem::MaybeUninit;
+    ///
+    /// let mut x = MaybeUninit::<bool>::uninitialized();
+    /// x.set(true);
+    /// let x_init = unsafe { x.into_initialized() };
+    /// assert_eq!(x_init, true);
+    /// ```
+    ///
+    /// *Incorrect* usage of this method:
+    ///
+    /// ```rust,no_run
+    /// #![feature(maybe_uninit)]
+    /// use std::mem::MaybeUninit;
+    ///
+    /// let x = MaybeUninit::<Vec<u32>>::uninitialized();
+    /// let x_init = unsafe { x.into_initialized() };
+    /// // `x` had not been initialized yet, so this last line causes undefined behavior.
+    /// ```
     #[unstable(feature = "maybe_uninit", issue = "53491")]
     #[inline(always)]
     pub unsafe fn into_initialized(self) -> T {
@@ -1212,15 +1237,17 @@ impl<T> MaybeUninit<T> {
     /// let x1 = unsafe { x.read_initialized() };
     /// // `u32` is `Copy`, so we may read multiple times.
     /// let x2 = unsafe { x.read_initialized() };
+    /// assert_eq!(x1, x2);
     ///
     /// let mut x = MaybeUninit::<Option<Vec<u32>>>::uninitialized();
     /// x.set(None);
     /// let x1 = unsafe { x.read_initialized() };
     /// // Duplicating a `None` value is okay, so we may read multiple times.
     /// let x2 = unsafe { x.read_initialized() };
+    /// assert_eq!(x1, x2);
     /// ```
     ///
-    /// *Incorrect* usafe of this method:
+    /// *Incorrect* usage of this method:
     ///
     /// ```rust,no_run
     /// #![feature(maybe_uninit)]

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -1141,6 +1141,35 @@ impl<T> MaybeUninit<T> {
     ///
     /// Note that dropping a `MaybeUninit` will never call `T`'s drop code.
     /// It is your responsibility to make sure `T` gets dropped if it got initialized.
+    ///
+    /// # Example
+    ///
+    /// Correct usage of this method: initializing a struct with zero, where all
+    /// fields of the struct can hold 0 as a valid value.
+    ///
+    /// ```rust
+    /// #![feature(maybe_uninit)]
+    /// use std::mem::MaybeUninit;
+    ///
+    /// let x = MaybeUninit::<(u8, bool)>::zeroed();
+    /// let x = unsafe { x.into_initialized() };
+    /// assert_eq!(x, (0, false));
+    /// ```
+    ///
+    /// *Incorrect* usage of this method: initializing a struct with zero, where some fields
+    /// cannot hold 0 as a valid value.
+    ///
+    /// ```rust,no_run
+    /// #![feature(maybe_uninit)]
+    /// use std::mem::MaybeUninit;
+    ///
+    /// enum NotZero { One = 1, Two = 2 };
+    ///
+    /// let x = MaybeUninit::<(u8, NotZero)>::zeroed();
+    /// let x = unsafe { x.into_initialized() };
+    /// // We create a `NotZero` (inside a pair) that does not have a valid discriminant.
+    /// // This is undefined behavior.
+    /// ```
     #[unstable(feature = "maybe_uninit", issue = "53491")]
     #[inline]
     pub fn zeroed() -> MaybeUninit<T> {

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -1269,7 +1269,7 @@ impl<T> MaybeUninit<T> {
     /// let x_vec = unsafe { &mut *x.as_mut_ptr() };
     /// // We have created a reference to an uninitialized vector! This is undefined behavior.
     /// ```
-    /// (Notice that the rules around referenced to uninitialized data are not finalized yet, but
+    /// (Notice that the rules around references to uninitialized data are not finalized yet, but
     /// until they are, it is advisable to avoid them.)
     #[unstable(feature = "maybe_uninit", issue = "53491")]
     #[inline(always)]

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -1191,7 +1191,8 @@ impl<T> MaybeUninit<T> {
     }
 
     /// Sets the value of the `MaybeUninit<T>`. This overwrites any previous value
-    /// without dropping it. For your convenience, this also returns a mutable
+    /// without dropping it, so be careful not to use this twice unless you want to
+    /// skip running the destructor. For your convenience, this also returns a mutable
     /// reference to the (now safely initialized) contents of `self`.
     #[unstable(feature = "maybe_uninit", issue = "53491")]
     #[inline(always)]
@@ -1214,7 +1215,7 @@ impl<T> MaybeUninit<T> {
     /// use std::mem::MaybeUninit;
     ///
     /// let mut x = MaybeUninit::<Vec<u32>>::uninitialized();
-    /// x.set(vec![0,1,2]);
+    /// unsafe { x.as_mut_ptr().write(vec![0,1,2]); }
     /// // Create a reference into the `MaybeUninit<T>`. This is okay because we initialized it.
     /// let x_vec = unsafe { &*x.as_ptr() };
     /// assert_eq!(x_vec.len(), 3);
@@ -1250,7 +1251,7 @@ impl<T> MaybeUninit<T> {
     /// use std::mem::MaybeUninit;
     ///
     /// let mut x = MaybeUninit::<Vec<u32>>::uninitialized();
-    /// x.set(vec![0,1,2]);
+    /// unsafe { x.as_mut_ptr().write(vec![0,1,2]); }
     /// // Create a reference into the `MaybeUninit<Vec<u32>>`.
     /// // This is okay because we initialized it.
     /// let x_vec = unsafe { &mut *x.as_mut_ptr() };
@@ -1295,7 +1296,7 @@ impl<T> MaybeUninit<T> {
     /// use std::mem::MaybeUninit;
     ///
     /// let mut x = MaybeUninit::<bool>::uninitialized();
-    /// x.set(true);
+    /// unsafe { x.as_mut_ptr().write(true); }
     /// let x_init = unsafe { x.into_initialized() };
     /// assert_eq!(x_init, true);
     /// ```

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -1230,6 +1230,8 @@ impl<T> MaybeUninit<T> {
     /// let x_vec = unsafe { &*x.as_ptr() };
     /// // We have created a reference to an uninitialized vector! This is undefined behavior.
     /// ```
+    /// (Notice that the rules around referenced to uninitialized data are not finalized yet, but
+    /// until they are, it is advisable to avoid them.)
     #[unstable(feature = "maybe_uninit", issue = "53491")]
     #[inline(always)]
     pub fn as_ptr(&self) -> *const T {
@@ -1266,6 +1268,8 @@ impl<T> MaybeUninit<T> {
     /// let x_vec = unsafe { &mut *x.as_mut_ptr() };
     /// // We have created a reference to an uninitialized vector! This is undefined behavior.
     /// ```
+    /// (Notice that the rules around referenced to uninitialized data are not finalized yet, but
+    /// until they are, it is advisable to avoid them.)
     #[unstable(feature = "maybe_uninit", issue = "53491")]
     #[inline(always)]
     pub fn as_mut_ptr(&mut self) -> *mut T {

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -301,7 +301,7 @@ pub unsafe fn swap<T>(x: *mut T, y: *mut T) {
     // Perform the swap
     copy_nonoverlapping(x, tmp.as_mut_ptr(), 1);
     copy(y, x, 1); // `x` and `y` may overlap
-    copy_nonoverlapping(tmp.get_ref(), y, 1);
+    copy_nonoverlapping(tmp.as_ptr(), y, 1);
 }
 
 /// Swaps `count * size_of::<T>()` bytes between the two regions of memory


### PR DESCRIPTION
This adds a new `read_initialized` method, similar to suggestions by @Amanieu and @shepmaster. I also added examples to this and other methods.