### PR TITLE
[DO NOT MERGE] Deny borrows of unaligned fields

### DIFF
--- a/src/doc/rustc/src/lints/listing/warn-by-default.md
+++ b/src/doc/rustc/src/lints/listing/warn-by-default.md
@@ -492,7 +492,7 @@ To fix this, either remove the lint or use the new name.
 This lint detects borrowing a field in the interior of a packed structure
 with alignment other than 1. Some example code that triggers this lint:
 
-```rust
+```rust,ignore
 #[repr(packed)]
 pub struct Unaligned<T>(pub T);
 

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -168,6 +168,7 @@ pub use intrinsics::write_bytes;
 /// }
 ///
 /// let mut p = Packed { _padding: 0, unaligned: vec![42] };
+/// #[allow(safe_packed_borrows)]
 /// unsafe {
 ///     drop_after_copy(&mut p.unaligned as *mut _);
 ///     mem::forget(p);
@@ -617,6 +618,7 @@ pub unsafe fn read<T>(src: *const T) -> T {
 ///     unaligned: 0x01020304,
 /// };
 ///
+/// #[allow(safe_packed_borrows)]
 /// let v = unsafe {
 ///     // Take the address of a 32-bit integer which is not aligned.
 ///     // This must be done as a raw pointer; unaligned references are invalid.
@@ -780,6 +782,7 @@ pub unsafe fn write<T>(dst: *mut T, src: T) {
 /// let v = 0x01020304;
 /// let mut x: Packed = unsafe { mem::zeroed() };
 ///
+/// #[allow(safe_packed_borrows)]
 /// unsafe {
 ///     // Take a reference to a 32-bit integer which is not aligned.
 ///     let unaligned = &mut x.unaligned as *mut u32;

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -157,8 +157,8 @@ declare_lint! {
 
 declare_lint! {
     pub SAFE_PACKED_BORROWS,
-    Warn,
-    "safe borrows of fields of packed structs were was erroneously allowed"
+    Deny,
+    "borrows of fields of packed structs were was erroneously allowed"
 }
 
 declare_lint! {

--- a/src/librustc_mir/transform/check_unsafety.rs
+++ b/src/librustc_mir/transform/check_unsafety.rs
@@ -374,7 +374,16 @@ impl<'a, 'tcx> UnsafetyChecker<'a, 'tcx> {
                 false
             }
             // `unsafe` function bodies allow unsafe without additional unsafe blocks
-            Safety::BuiltinUnsafe | Safety::FnUnsafe => true,
+            Safety::BuiltinUnsafe | Safety::FnUnsafe => {
+                for violation in violations {
+                    if let UnsafetyViolationKind::BorrowPacked(_) = violation.kind {
+                        if !self.violations.contains(violation) {
+                            self.violations.push(*violation)
+                        }
+                    }
+                }
+                true
+            },
             Safety::ExplicitUnsafe(node_id) => {
                 // mark unsafe block as used if there are any unsafe operations inside
                 if !violations.is_empty() {
@@ -399,6 +408,14 @@ impl<'a, 'tcx> UnsafetyChecker<'a, 'tcx> {
                                     self.violations.push(violation)
                                 }
                             },
+                        }
+                    }
+                } else {
+                    for violation in violations {
+                        if let UnsafetyViolationKind::BorrowPacked(_) = violation.kind {
+                            if !self.violations.contains(violation) {
+                                self.violations.push(*violation)
+                            }
                         }
                     }
                 }

--- a/src/test/run-pass/packed/packed-struct-borrow-element.rs
+++ b/src/test/run-pass/packed/packed-struct-borrow-element.rs
@@ -1,6 +1,6 @@
 // run-pass
 #![allow(dead_code)]
-// ignore-emscripten weird assertion?
+// ignore-test
 
 #[repr(packed)]
 struct Foo1 {

--- a/src/test/ui/issues/issue-27060.rs
+++ b/src/test/ui/issues/issue-27060.rs
@@ -19,8 +19,10 @@ fn main() {
     };
 
     unsafe {
-        let _ = &good.data; // ok
-        let _ = &good.data2[0]; // ok
+        let _ = &good.data; //~ ERROR borrow of packed field is unsafe
+                            //~| hard error
+        let _ = &good.data2[0]; //~ ERROR borrow of packed field is unsafe
+                                //~| hard error
     }
 
     let _ = &good.data; //~ ERROR borrow of packed field is unsafe

--- a/src/test/ui/issues/issue-27060.stderr
+++ b/src/test/ui/issues/issue-27060.stderr
@@ -1,8 +1,8 @@
 error: borrow of packed field is unsafe and requires unsafe function or block (error E0133)
-  --> $DIR/issue-27060.rs:26:13
+  --> $DIR/issue-27060.rs:22:17
    |
-LL |     let _ = &good.data; //~ ERROR borrow of packed field is unsafe
-   |             ^^^^^^^^^^
+LL |         let _ = &good.data; //~ ERROR borrow of packed field is unsafe
+   |                 ^^^^^^^^^^
    |
 note: lint level defined here
   --> $DIR/issue-27060.rs:13:8
@@ -14,7 +14,27 @@ LL | #[deny(safe_packed_borrows)]
    = note: fields of packed structs might be misaligned: dereferencing a misaligned pointer or even just creating a misaligned reference is undefined behavior
 
 error: borrow of packed field is unsafe and requires unsafe function or block (error E0133)
+  --> $DIR/issue-27060.rs:24:17
+   |
+LL |         let _ = &good.data2[0]; //~ ERROR borrow of packed field is unsafe
+   |                 ^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #46043 <https://github.com/rust-lang/rust/issues/46043>
+   = note: fields of packed structs might be misaligned: dereferencing a misaligned pointer or even just creating a misaligned reference is undefined behavior
+
+error: borrow of packed field is unsafe and requires unsafe function or block (error E0133)
   --> $DIR/issue-27060.rs:28:13
+   |
+LL |     let _ = &good.data; //~ ERROR borrow of packed field is unsafe
+   |             ^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #46043 <https://github.com/rust-lang/rust/issues/46043>
+   = note: fields of packed structs might be misaligned: dereferencing a misaligned pointer or even just creating a misaligned reference is undefined behavior
+
+error: borrow of packed field is unsafe and requires unsafe function or block (error E0133)
+  --> $DIR/issue-27060.rs:30:13
    |
 LL |     let _ = &good.data2[0]; //~ ERROR borrow of packed field is unsafe
    |             ^^^^^^^^^^^^^^
@@ -23,5 +43,5 @@ LL |     let _ = &good.data2[0]; //~ ERROR borrow of packed field is unsafe
    = note: for more information, see issue #46043 <https://github.com/rust-lang/rust/issues/46043>
    = note: fields of packed structs might be misaligned: dereferencing a misaligned pointer or even just creating a misaligned reference is undefined behavior
 
-error: aborting due to 2 previous errors
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Just for a crater run (for rust-lang/rfcs#2582)

cc @RalfJung @Centril 
r? @ghost