### PR TITLE
look for python2 symlinks before bootstrap python

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -162,6 +162,9 @@
 # Python interpreter to use for various tasks throughout the build, notably
 # rustdoc tests, the lldb python interpreter, and some dist bits and pieces.
 # Note that Python 2 is currently required.
+#
+# Defaults to python2.7, then python2. If neither executable can be found, then
+# it defaults to the Python interpreter used to execute x.py.
 #python = "python2.7"
 
 # Force Cargo to check that Cargo.lock describes the precise dependency

--- a/src/bootstrap/sanity.rs
+++ b/src/bootstrap/sanity.rs
@@ -34,15 +34,17 @@ impl Finder {
 
     fn maybe_have<S: AsRef<OsStr>>(&mut self, cmd: S) -> Option<PathBuf> {
         let cmd: OsString = cmd.as_ref().into();
-        let path = self.path.clone();
+        let path = &self.path;
         self.cache.entry(cmd.clone()).or_insert_with(|| {
-            for path in env::split_paths(&path) {
+            for path in env::split_paths(path) {
                 let target = path.join(&cmd);
-                let mut cmd_alt = cmd.clone();
-                cmd_alt.push(".exe");
-                if target.is_file() || // some/path/git
-                target.with_extension("exe").exists() || // some/path/git.exe
-                target.join(&cmd_alt).exists() { // some/path/git/git.exe
+                let mut cmd_exe = cmd.clone();
+                cmd_exe.push(".exe");
+
+                if target.is_file()                   // some/path/git
+                    || path.join(&cmd_exe).exists()   // some/path/git.exe
+                    || target.join(&cmd_exe).exists() // some/path/git/git.exe
+                {
                     return Some(target);
                 }
             }

--- a/src/bootstrap/sanity.rs
+++ b/src/bootstrap/sanity.rs
@@ -109,9 +109,9 @@ pub fn check(build: &mut Build) {
     }
 
     build.config.python = build.config.python.take().map(|p| cmd_finder.must_have(p))
-        .or_else(|| env::var_os("BOOTSTRAP_PYTHON").map(PathBuf::from)) // set by bootstrap.py
         .or_else(|| cmd_finder.maybe_have("python2.7"))
         .or_else(|| cmd_finder.maybe_have("python2"))
+        .or_else(|| env::var_os("BOOTSTRAP_PYTHON").map(PathBuf::from)) // set by bootstrap.py
         .or_else(|| Some(cmd_finder.must_have("python")));
 
     build.config.nodejs = build.config.nodejs.take().map(|p| cmd_finder.must_have(p))


### PR DESCRIPTION
Before this commit, if you're running x.py directly on a system where
`python` is symlinked to Python 3, then the `python` config option will
default to a Python 3 interpreter. This causes debuginfo tests to fail
with an opaque error message, since they have a hard requirement on
Python 2.

This commit modifies the Python probe behavior to look for python2.7 and
python2 *before* using the interpreter used to execute `x.py`.