### PR TITLE
Add unstable option to ignore should_panic tests

### DIFF
--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -366,6 +366,7 @@ pub struct TestOpts {
     pub list: bool,
     pub filter: Option<String>,
     pub filter_exact: bool,
+    pub exclude_should_panic: bool,
     pub run_ignored: RunIgnored,
     pub run_tests: bool,
     pub bench_benchmarks: bool,
@@ -385,6 +386,7 @@ impl TestOpts {
             list: false,
             filter: None,
             filter_exact: false,
+            exclude_should_panic: false,
             run_ignored: RunIgnored::No,
             run_tests: false,
             bench_benchmarks: false,
@@ -406,6 +408,7 @@ fn optgroups() -> getopts::Options {
     let mut opts = getopts::Options::new();
     opts.optflag("", "include-ignored", "Run ignored and not ignored tests")
         .optflag("", "ignored", "Run only ignored tests")
+        .optflag("", "exclude-should-panic", "Sets #[should_panic] tests to imply #[ignore]")
         .optflag("", "test", "Run tests and not benchmarks")
         .optflag("", "bench", "Run benchmarks instead of tests")
         .optflag("", "list", "List all tests and benchmarks")
@@ -558,6 +561,13 @@ pub fn parse_opts(args: &[String]) -> Option<OptRes> {
         None
     };
 
+    let exclude_should_panic = matches.opt_present("exclude-should-panic");
+    if !allow_unstable && exclude_should_panic {
+        return Some(Err(
+            "The \"exclude-should-panic\" flag is only accepted on the nightly compiler".into(),
+        ));
+    }
+
     let include_ignored = matches.opt_present("include-ignored");
     if !allow_unstable && include_ignored {
         return Some(Err(
@@ -648,6 +658,7 @@ pub fn parse_opts(args: &[String]) -> Option<OptRes> {
         list,
         filter,
         filter_exact: exact,
+        exclude_should_panic,
         run_ignored,
         run_tests,
         bench_benchmarks,
@@ -1365,6 +1376,14 @@ pub fn filter_tests(opts: &TestOpts, tests: Vec<TestDescAndFn>) -> Vec<TestDescA
     // Skip tests that match any of the skip filters
     filtered.retain(|test| !opts.skip.iter().any(|sf| matches_filter(test, sf)));
 
+    // Set #[should_panic] tests to ignore
+    if opts.exclude_should_panic {
+        filtered
+            .iter_mut()
+            .filter(|test| test.desc.should_panic != ShouldPanic::No)
+            .for_each(|test| test.desc.ignore = true);
+    }
+
     // maybe unignore tests
     match opts.run_ignored {
         RunIgnored::Yes => {
@@ -1981,6 +2000,32 @@ mod tests {
         assert_eq!(filtered.len(), 2);
         assert!(!filtered[0].desc.ignore);
         assert!(!filtered[1].desc.ignore);
+    }
+
+    #[test]
+    pub fn exclude_should_panic_option() {
+        let mut opts = TestOpts::new();
+        opts.run_tests = true;
+        opts.exclude_should_panic = true;
+
+        let mut tests = one_ignored_one_unignored_test();
+
+        tests.push(TestDescAndFn {
+            desc: TestDesc {
+                name: StaticTestName("3"),
+                ignore: false,
+                should_panic: ShouldPanic::YesWithMessage("should panic with message"),
+                allow_fail: false,
+            },
+            testfn: DynTestFn(Box::new(move || {})),
+        });
+
+        let filtered = filter_tests(&opts, tests);
+
+        assert_eq!(filtered.len(), 3);
+        assert!(filtered[0].desc.ignore);
+        assert!(!filtered[1].desc.ignore);
+        assert!(filtered[2].desc.ignore);
     }
 
     #[test]


### PR DESCRIPTION
Add an unstable option `--exclude-should-panic` to libtest to workaround https://github.com/rust-lang/miri/issues/636

?r @oli-obk 
cc @RalfJung 