### PR TITLE
[WIP] Internal lints

### DIFF
--- a/src/librustc/hir/def_id.rs
+++ b/src/librustc/hir/def_id.rs
@@ -1,5 +1,5 @@
-use ty::{self, TyCtxt};
-use hir::map::definitions::FIRST_FREE_HIGH_DEF_INDEX;
+use crate::ty::{self, TyCtxt};
+use crate::hir::map::definitions::FIRST_FREE_HIGH_DEF_INDEX;
 use rustc_data_structures::indexed_vec::Idx;
 use serialize;
 use std::fmt;

--- a/src/librustc/lint/internal.rs
+++ b/src/librustc/lint/internal.rs
@@ -1,21 +1,11 @@
-// Copyright 2012-2018 The Rust Project Developers. See the COPYRIGHT
-// file at the top-level directory of this distribution and at
-// http://rust-lang.org/COPYRIGHT.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 //! Some lints that are only useful in the compiler or crates that use compiler internals, such as
 //! Clippy.
 
-use errors::Applicability;
-use hir::{Expr, ExprKind, PatKind, Path, QPath, Ty, TyKind};
-use lint::{
+use crate::hir::{Expr, ExprKind, PatKind, Path, QPath, Ty, TyKind};
+use crate::lint::{
     EarlyContext, EarlyLintPass, LateContext, LateLintPass, LintArray, LintContext, LintPass,
 };
+use errors::Applicability;
 use rustc_data_structures::fx::FxHashMap;
 use syntax::ast::Ident;
 
@@ -42,6 +32,10 @@ impl LintPass for DefaultHashTypes {
     fn get_lints(&self) -> LintArray {
         lint_array!(DEFAULT_HASH_TYPES)
     }
+
+    fn name(&self) -> &'static str {
+        "DefaultHashTypes"
+    }
 }
 
 impl EarlyLintPass for DefaultHashTypes {
@@ -53,7 +47,7 @@ impl EarlyLintPass for DefaultHashTypes {
                 replace, ident_string
             );
             let mut db = cx.struct_span_lint(DEFAULT_HASH_TYPES, ident.span, &msg);
-            db.span_suggestion_with_applicability(
+            db.span_suggestion(
                 ident.span,
                 "use",
                 replace.to_string(),
@@ -79,6 +73,10 @@ pub struct TyKindUsage;
 impl LintPass for TyKindUsage {
     fn get_lints(&self) -> LintArray {
         lint_array!(USAGE_OF_TY_TYKIND)
+    }
+
+    fn name(&self) -> &'static str {
+        "TyKindUsage"
     }
 }
 
@@ -124,12 +122,13 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TyKindUsage {
                                     path.span,
                                     "usage of `ty::TyKind::<kind>`",
                                 )
-                                .span_suggestion_with_applicability(
+                                .span_suggestion(
                                     path.span,
                                     "try using ty::<kind> directly",
                                     "ty".to_string(),
                                     Applicability::MaybeIncorrect, // ty maybe needs an import
-                                ).emit();
+                                )
+                                .emit();
                             }
                         }
                     }

--- a/src/librustc/lint/internal.rs
+++ b/src/librustc/lint/internal.rs
@@ -1,0 +1,165 @@
+// Copyright 2012-2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Some lints that are only useful in the compiler or crates that use compiler internals, such as
+//! Clippy.
+
+use errors::Applicability;
+use hir::{Expr, ExprKind, PatKind, Path, QPath, Ty, TyKind};
+use lint::{
+    EarlyContext, EarlyLintPass, LateContext, LateLintPass, LintArray, LintContext, LintPass,
+};
+use rustc_data_structures::fx::FxHashMap;
+use syntax::ast::Ident;
+
+declare_lint! {
+    pub DEFAULT_HASH_TYPES,
+    Warn,
+    "forbid HashMap and HashSet and suggest the FxHash* variants"
+}
+
+pub struct DefaultHashTypes {
+    map: FxHashMap<String, String>,
+}
+
+impl DefaultHashTypes {
+    pub fn new() -> Self {
+        let mut map = FxHashMap::default();
+        map.insert("HashMap".to_string(), "FxHashMap".to_string());
+        map.insert("HashSet".to_string(), "FxHashSet".to_string());
+        Self { map }
+    }
+}
+
+impl LintPass for DefaultHashTypes {
+    fn get_lints(&self) -> LintArray {
+        lint_array!(DEFAULT_HASH_TYPES)
+    }
+}
+
+impl EarlyLintPass for DefaultHashTypes {
+    fn check_ident(&mut self, cx: &EarlyContext<'_>, ident: Ident) {
+        let ident_string = ident.to_string();
+        if let Some(replace) = self.map.get(&ident_string) {
+            let msg = format!(
+                "Prefer {} over {}, it has better performance",
+                replace, ident_string
+            );
+            let mut db = cx.struct_span_lint(DEFAULT_HASH_TYPES, ident.span, &msg);
+            db.span_suggestion_with_applicability(
+                ident.span,
+                "use",
+                replace.to_string(),
+                Applicability::MaybeIncorrect, // FxHashMap, ... needs another import
+            );
+            db.note(&format!(
+                "a `use rustc_data_structures::fx::{}` may be necessary",
+                replace
+            ))
+            .emit();
+        }
+    }
+}
+
+declare_lint! {
+    pub USAGE_OF_TY_TYKIND,
+    Warn,
+    "Usage of `ty::TyKind` outside of the `ty::sty` module"
+}
+
+pub struct TyKindUsage;
+
+impl LintPass for TyKindUsage {
+    fn get_lints(&self) -> LintArray {
+        lint_array!(USAGE_OF_TY_TYKIND)
+    }
+}
+
+impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TyKindUsage {
+    fn check_expr(&mut self, cx: &LateContext<'_, '_>, expr: &'tcx Expr) {
+        let qpaths = match &expr.node {
+            ExprKind::Match(_, arms, _) => {
+                let mut qpaths = vec![];
+                for arm in arms {
+                    for pat in &arm.pats {
+                        match &pat.node {
+                            PatKind::Path(qpath) | PatKind::TupleStruct(qpath, ..) => {
+                                qpaths.push(qpath)
+                            }
+                            _ => (),
+                        }
+                    }
+                }
+                qpaths
+            }
+            ExprKind::Path(qpath) => vec![qpath],
+            _ => vec![],
+        };
+        for qpath in qpaths {
+            if let QPath::Resolved(_, path) = qpath {
+                let segments_iter = path.segments.iter().rev().skip(1).rev();
+
+                if let Some(last) = segments_iter.clone().last() {
+                    if last.ident.as_str() == "TyKind" {
+                        let path = Path {
+                            span: path.span.with_hi(last.ident.span.hi()),
+                            def: path.def,
+                            segments: segments_iter.cloned().collect(),
+                        };
+
+                        if let Some(def) = last.def {
+                            if def
+                                .def_id()
+                                .match_path(cx.tcx, &["rustc", "ty", "sty", "TyKind"])
+                            {
+                                cx.struct_span_lint(
+                                    USAGE_OF_TY_TYKIND,
+                                    path.span,
+                                    "usage of `ty::TyKind::<kind>`",
+                                )
+                                .span_suggestion_with_applicability(
+                                    path.span,
+                                    "try using ty::<kind> directly",
+                                    "ty".to_string(),
+                                    Applicability::MaybeIncorrect, // ty maybe needs an import
+                                ).emit();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn check_ty(&mut self, cx: &LateContext<'_, '_>, ty: &'tcx Ty) {
+        if let TyKind::Path(qpath) = &ty.node {
+            if let QPath::Resolved(_, path) = qpath {
+                if let Some(last) = path.segments.iter().last() {
+                    if last.ident.as_str() == "TyKind" {
+                        if let Some(def) = last.def {
+                            if def
+                                .def_id()
+                                .match_path(cx.tcx, &["rustc", "ty", "sty", "TyKind"])
+                            {
+                                cx.struct_span_lint(
+                                    USAGE_OF_TY_TYKIND,
+                                    path.span,
+                                    "usage of `ty::TyKind`",
+                                )
+                                .help("try using `ty::Ty` instead")
+                                .emit();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -563,6 +563,7 @@ impl_stable_hash_for!(enum self::LintSource {
 pub type LevelSource = (Level, LintSource);
 
 pub mod builtin;
+pub mod internal;
 mod context;
 mod levels;
 

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -1410,6 +1410,9 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
     merge_functions: Option<MergeFunctions> = (None, parse_merge_functions, [TRACKED],
         "control the operation of the MergeFunctions LLVM pass, taking
          the same values as the target option of the same name"),
+    internal_lints: bool = (false, parse_bool, [UNTRACKED],
+        "allow internal rustc lints. These lints are probably only useful in the
+        compiler directly or in crates, that use rustc internals, such as Clippy."),
 }
 
 pub fn default_lib_output() -> CrateType {

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -498,6 +498,9 @@ fn run_compiler_with_pool<'a>(
     let codegen_backend = get_codegen_backend(&sess);
 
     rustc_lint::register_builtins(&mut sess.lint_store.borrow_mut(), Some(&sess));
+    if sess.opts.debugging_opts.internal_lints {
+        rustc_lint::register_internals(&mut sess.lint_store.borrow_mut(), Some(&sess));
+    }
 
     let mut cfg = config::build_configuration(&sess, cfg);
     target_features::add_configuration(&mut cfg, &sess, &*codegen_backend);
@@ -815,10 +818,16 @@ impl<'a> CompilerCalls<'a> for RustcDefaultCalls {
                 if sopts.describe_lints {
                     let mut ls = lint::LintStore::new();
                     rustc_lint::register_builtins(&mut ls, Some(&sess));
+                    if sess.opts.debugging_opts.internal_lints {
+                        rustc_lint::register_internals(&mut ls, Some(&sess));
+                    }
                     describe_lints(&sess, &ls, false);
                     return None;
                 }
                 rustc_lint::register_builtins(&mut sess.lint_store.borrow_mut(), Some(&sess));
+                if sess.opts.debugging_opts.internal_lints {
+                    rustc_lint::register_internals(&mut sess.lint_store.borrow_mut(), Some(&sess));
+                }
                 let mut cfg = config::build_configuration(&sess, cfg.clone());
                 let codegen_backend = get_codegen_backend(&sess);
                 target_features::add_configuration(&mut cfg, &sess, &*codegen_backend);

--- a/src/librustc_driver/test.rs
+++ b/src/librustc_driver/test.rs
@@ -114,6 +114,9 @@ fn test_env_with_pool<F>(
     );
     let cstore = CStore::new(::get_codegen_backend(&sess).metadata_loader());
     rustc_lint::register_builtins(&mut sess.lint_store.borrow_mut(), Some(&sess));
+    if sess.opts.debugging_opts.internal_lints {
+        rustc_lint::register_internals(&mut sess.lint_store.borrow_mut(), Some(&sess));
+    }
     let input = config::Input::Str {
         name: FileName::anon_source_code(&source_string),
         input: source_string.to_string(),

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -58,6 +58,7 @@ use nonstandard_style::*;
 use builtin::*;
 use types::*;
 use unused::*;
+use rustc::lint::internal::*;
 
 /// Useful for other parts of the compiler.
 pub use builtin::SoftLints;
@@ -404,4 +405,19 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
         "no longer a warning, #[no_mangle] statics always exported");
     store.register_removed("bad_repr",
         "replaced with a generic attribute input check");
+}
+
+pub fn register_internals(store: &mut lint::LintStore, sess: Option<&Session>) {
+    store.register_early_pass(sess, false, box DefaultHashTypes::new());
+    store.register_late_pass(sess, false, box TyKindUsage);
+    store.register_group(
+        sess,
+        false,
+        "internal",
+        None,
+        vec![
+            LintId::of(DEFAULT_HASH_TYPES),
+            LintId::of(USAGE_OF_TY_TYKIND),
+        ],
+    );
 }

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -408,7 +408,7 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
 }
 
 pub fn register_internals(store: &mut lint::LintStore, sess: Option<&Session>) {
-    store.register_early_pass(sess, false, box DefaultHashTypes::new());
+    store.register_early_pass(sess, false, false, box DefaultHashTypes::new());
     store.register_late_pass(sess, false, box TyKindUsage);
     store.register_group(
         sess,

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -428,6 +428,9 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
         let codegen_backend = rustc_driver::get_codegen_backend(&sess);
         let cstore = Rc::new(CStore::new(codegen_backend.metadata_loader()));
         rustc_lint::register_builtins(&mut sess.lint_store.borrow_mut(), Some(&sess));
+        if sess.opts.debugging_opts.internal_lints {
+            rustc_lint::register_internals(&mut sess.lint_store.borrow_mut(), Some(&sess));
+        }
 
         let mut cfg = config::build_configuration(&sess, config::parse_cfgspecs(cfgs));
         target_features::add_configuration(&mut cfg, &sess, &*codegen_backend);

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -75,6 +75,9 @@ pub fn run(mut options: Options) -> isize {
         let codegen_backend = rustc_driver::get_codegen_backend(&sess);
         let cstore = CStore::new(codegen_backend.metadata_loader());
         rustc_lint::register_builtins(&mut sess.lint_store.borrow_mut(), Some(&sess));
+        if sess.opts.debugging_opts.internal_lints {
+            rustc_lint::register_internals(&mut sess.lint_store.borrow_mut(), Some(&sess));
+        }
 
         let mut cfg = config::build_configuration(&sess,
                                                   config::parse_cfgspecs(options.cfgs.clone()));
@@ -279,6 +282,9 @@ fn run_test(test: &str, cratename: &str, filename: &FileName, line: usize,
         let codegen_backend = rustc_driver::get_codegen_backend(&sess);
         let cstore = CStore::new(codegen_backend.metadata_loader());
         rustc_lint::register_builtins(&mut sess.lint_store.borrow_mut(), Some(&sess));
+        if sess.opts.debugging_opts.internal_lints {
+            rustc_lint::register_internals(&mut sess.lint_store.borrow_mut(), Some(&sess));
+        }
 
         let outdir = Mutex::new(
             if let Some(mut path) = persist_doctests {

--- a/src/test/rustdoc-ui/failed-doctest-output.stdout
+++ b/src/test/rustdoc-ui/failed-doctest-output.stdout
@@ -12,7 +12,7 @@ error[E0425]: cannot find value `no` in this scope
 3 | no
   | ^^ not found in this scope
 
-thread '$DIR/failed-doctest-output.rs - OtherStruct (line 17)' panicked at 'couldn't compile the test', src/librustdoc/test.rs:351:13
+thread '$DIR/failed-doctest-output.rs - OtherStruct (line 17)' panicked at 'couldn't compile the test', src/librustdoc/test.rs:357:13
 note: Run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
 
 ---- $DIR/failed-doctest-output.rs - SomeStruct (line 11) stdout ----
@@ -21,7 +21,7 @@ thread '$DIR/failed-doctest-output.rs - SomeStruct (line 11)' panicked at 'test 
 thread 'main' panicked at 'oh no', $DIR/failed-doctest-output.rs:3:1
 note: Run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
 
-', src/librustdoc/test.rs:372:17
+', src/librustdoc/test.rs:378:17
 
 
 failures:

--- a/src/test/ui-fulldeps/internal-lints/default_hash_types.rs
+++ b/src/test/ui-fulldeps/internal-lints/default_hash_types.rs
@@ -1,13 +1,3 @@
-// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
-// file at the top-level directory of this distribution and at
-// http://rust-lang.org/COPYRIGHT.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 // compile-flags: -Z internal-lints
 
 #![feature(rustc_private)]

--- a/src/test/ui-fulldeps/internal-lints/default_hash_types.rs
+++ b/src/test/ui-fulldeps/internal-lints/default_hash_types.rs
@@ -1,0 +1,34 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Z internal-lints
+
+#![feature(rustc_private)]
+
+extern crate rustc_data_structures;
+
+use rustc_data_structures::fx::{FxHashMap, FxHashSet};
+use std::collections::{HashMap, HashSet};
+//~^ WARNING Prefer FxHashMap over HashMap, it has better performance
+//~^^ WARNING Prefer FxHashSet over HashSet, it has better performance
+
+#[deny(default_hash_types)]
+fn main() {
+    let _map: HashMap<String, String> = HashMap::default();
+    //~^ ERROR Prefer FxHashMap over HashMap, it has better performance
+    //~^^ ERROR Prefer FxHashMap over HashMap, it has better performance
+    let _set: HashSet<String> = HashSet::default();
+    //~^ ERROR Prefer FxHashSet over HashSet, it has better performance
+    //~^^ ERROR Prefer FxHashSet over HashSet, it has better performance
+
+    // test that the lint doesn't also match the Fx variants themselves
+    let _fx_map: FxHashMap<String, String> = FxHashMap::default();
+    let _fx_set: FxHashSet<String> = FxHashSet::default();
+}

--- a/src/test/ui-fulldeps/internal-lints/default_hash_types.stderr
+++ b/src/test/ui-fulldeps/internal-lints/default_hash_types.stderr
@@ -1,5 +1,5 @@
 warning: Prefer FxHashMap over HashMap, it has better performance
-  --> $DIR/default_hash_types.rs:18:24
+  --> $DIR/default_hash_types.rs:8:24
    |
 LL | use std::collections::{HashMap, HashSet};
    |                        ^^^^^^^ help: use: `FxHashMap`
@@ -8,7 +8,7 @@ LL | use std::collections::{HashMap, HashSet};
    = note: a `use rustc_data_structures::fx::FxHashMap` may be necessary
 
 warning: Prefer FxHashSet over HashSet, it has better performance
-  --> $DIR/default_hash_types.rs:18:33
+  --> $DIR/default_hash_types.rs:8:33
    |
 LL | use std::collections::{HashMap, HashSet};
    |                                 ^^^^^^^ help: use: `FxHashSet`
@@ -16,20 +16,20 @@ LL | use std::collections::{HashMap, HashSet};
    = note: a `use rustc_data_structures::fx::FxHashSet` may be necessary
 
 error: Prefer FxHashMap over HashMap, it has better performance
-  --> $DIR/default_hash_types.rs:24:15
+  --> $DIR/default_hash_types.rs:14:15
    |
 LL |     let _map: HashMap<String, String> = HashMap::default();
    |               ^^^^^^^ help: use: `FxHashMap`
    |
 note: lint level defined here
-  --> $DIR/default_hash_types.rs:22:8
+  --> $DIR/default_hash_types.rs:12:8
    |
 LL | #[deny(default_hash_types)]
    |        ^^^^^^^^^^^^^^^^^^
    = note: a `use rustc_data_structures::fx::FxHashMap` may be necessary
 
 error: Prefer FxHashMap over HashMap, it has better performance
-  --> $DIR/default_hash_types.rs:24:41
+  --> $DIR/default_hash_types.rs:14:41
    |
 LL |     let _map: HashMap<String, String> = HashMap::default();
    |                                         ^^^^^^^ help: use: `FxHashMap`
@@ -37,7 +37,7 @@ LL |     let _map: HashMap<String, String> = HashMap::default();
    = note: a `use rustc_data_structures::fx::FxHashMap` may be necessary
 
 error: Prefer FxHashSet over HashSet, it has better performance
-  --> $DIR/default_hash_types.rs:27:15
+  --> $DIR/default_hash_types.rs:17:15
    |
 LL |     let _set: HashSet<String> = HashSet::default();
    |               ^^^^^^^ help: use: `FxHashSet`
@@ -45,7 +45,7 @@ LL |     let _set: HashSet<String> = HashSet::default();
    = note: a `use rustc_data_structures::fx::FxHashSet` may be necessary
 
 error: Prefer FxHashSet over HashSet, it has better performance
-  --> $DIR/default_hash_types.rs:27:33
+  --> $DIR/default_hash_types.rs:17:33
    |
 LL |     let _set: HashSet<String> = HashSet::default();
    |                                 ^^^^^^^ help: use: `FxHashSet`

--- a/src/test/ui-fulldeps/internal-lints/default_hash_types.stderr
+++ b/src/test/ui-fulldeps/internal-lints/default_hash_types.stderr
@@ -1,0 +1,56 @@
+warning: Prefer FxHashMap over HashMap, it has better performance
+  --> $DIR/default_hash_types.rs:18:24
+   |
+LL | use std::collections::{HashMap, HashSet};
+   |                        ^^^^^^^ help: use: `FxHashMap`
+   |
+   = note: #[warn(default_hash_types)] on by default
+   = note: a `use rustc_data_structures::fx::FxHashMap` may be necessary
+
+warning: Prefer FxHashSet over HashSet, it has better performance
+  --> $DIR/default_hash_types.rs:18:33
+   |
+LL | use std::collections::{HashMap, HashSet};
+   |                                 ^^^^^^^ help: use: `FxHashSet`
+   |
+   = note: a `use rustc_data_structures::fx::FxHashSet` may be necessary
+
+error: Prefer FxHashMap over HashMap, it has better performance
+  --> $DIR/default_hash_types.rs:24:15
+   |
+LL |     let _map: HashMap<String, String> = HashMap::default();
+   |               ^^^^^^^ help: use: `FxHashMap`
+   |
+note: lint level defined here
+  --> $DIR/default_hash_types.rs:22:8
+   |
+LL | #[deny(default_hash_types)]
+   |        ^^^^^^^^^^^^^^^^^^
+   = note: a `use rustc_data_structures::fx::FxHashMap` may be necessary
+
+error: Prefer FxHashMap over HashMap, it has better performance
+  --> $DIR/default_hash_types.rs:24:41
+   |
+LL |     let _map: HashMap<String, String> = HashMap::default();
+   |                                         ^^^^^^^ help: use: `FxHashMap`
+   |
+   = note: a `use rustc_data_structures::fx::FxHashMap` may be necessary
+
+error: Prefer FxHashSet over HashSet, it has better performance
+  --> $DIR/default_hash_types.rs:27:15
+   |
+LL |     let _set: HashSet<String> = HashSet::default();
+   |               ^^^^^^^ help: use: `FxHashSet`
+   |
+   = note: a `use rustc_data_structures::fx::FxHashSet` may be necessary
+
+error: Prefer FxHashSet over HashSet, it has better performance
+  --> $DIR/default_hash_types.rs:27:33
+   |
+LL |     let _set: HashSet<String> = HashSet::default();
+   |                                 ^^^^^^^ help: use: `FxHashSet`
+   |
+   = note: a `use rustc_data_structures::fx::FxHashSet` may be necessary
+
+error: aborting due to 4 previous errors
+

--- a/src/test/ui-fulldeps/internal-lints/ty_tykind_usage.rs
+++ b/src/test/ui-fulldeps/internal-lints/ty_tykind_usage.rs
@@ -1,13 +1,3 @@
-// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
-// file at the top-level directory of this distribution and at
-// http://rust-lang.org/COPYRIGHT.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 // compile-flags: -Z internal-lints
 
 #![feature(rustc_private)]

--- a/src/test/ui-fulldeps/internal-lints/ty_tykind_usage.rs
+++ b/src/test/ui-fulldeps/internal-lints/ty_tykind_usage.rs
@@ -1,0 +1,59 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Z internal-lints
+
+#![feature(rustc_private)]
+
+extern crate rustc;
+
+use rustc::ty::{self, Ty, TyKind};
+
+#[deny(usage_of_ty_tykind)]
+fn main() {
+    let sty = TyKind::Bool; //~ ERROR usage of `ty::TyKind::<kind>`
+
+    match sty {
+        TyKind::Bool => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::Char => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::Int(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::Uint(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::Float(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::Adt(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::Foreign(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::Str => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::Array(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::Slice(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::RawPtr(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::Ref(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::FnDef(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::FnPtr(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::Dynamic(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::Closure(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::Generator(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::GeneratorWitness(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::Never => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::Tuple(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::Projection(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::UnnormalizedProjection(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::Opaque(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::Param(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::Bound(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::Placeholder(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::Infer(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::Error => (), //~ ERROR usage of `ty::TyKind::<kind>`
+    }
+
+    if let ty::Int(int_ty) = sty {}
+
+    if let TyKind::Int(int_ty) = sty {} //~ ERROR usage of `ty::TyKind::<kind>`
+
+    fn ty_kind(ty_bad: TyKind<'_>, ty_good: Ty<'_>) {} //~ ERROR usage of `ty::TyKind`
+}

--- a/src/test/ui-fulldeps/internal-lints/ty_tykind_usage.stderr
+++ b/src/test/ui-fulldeps/internal-lints/ty_tykind_usage.stderr
@@ -1,191 +1,191 @@
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:21:15
+  --> $DIR/ty_tykind_usage.rs:11:15
    |
 LL |     let sty = TyKind::Bool; //~ ERROR usage of `ty::TyKind::<kind>`
    |               ^^^^^^ help: try using ty::<kind> directly: `ty`
    |
 note: lint level defined here
-  --> $DIR/ty_tykind_usage.rs:19:8
+  --> $DIR/ty_tykind_usage.rs:9:8
    |
 LL | #[deny(usage_of_ty_tykind)]
    |        ^^^^^^^^^^^^^^^^^^
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:24:9
+  --> $DIR/ty_tykind_usage.rs:14:9
    |
 LL |         TyKind::Bool => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:25:9
+  --> $DIR/ty_tykind_usage.rs:15:9
    |
 LL |         TyKind::Char => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:26:9
+  --> $DIR/ty_tykind_usage.rs:16:9
    |
 LL |         TyKind::Int(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:27:9
+  --> $DIR/ty_tykind_usage.rs:17:9
    |
 LL |         TyKind::Uint(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:28:9
+  --> $DIR/ty_tykind_usage.rs:18:9
    |
 LL |         TyKind::Float(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:29:9
+  --> $DIR/ty_tykind_usage.rs:19:9
    |
 LL |         TyKind::Adt(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:30:9
+  --> $DIR/ty_tykind_usage.rs:20:9
    |
 LL |         TyKind::Foreign(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:31:9
+  --> $DIR/ty_tykind_usage.rs:21:9
    |
 LL |         TyKind::Str => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:32:9
+  --> $DIR/ty_tykind_usage.rs:22:9
    |
 LL |         TyKind::Array(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:33:9
+  --> $DIR/ty_tykind_usage.rs:23:9
    |
 LL |         TyKind::Slice(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:34:9
+  --> $DIR/ty_tykind_usage.rs:24:9
    |
 LL |         TyKind::RawPtr(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:35:9
+  --> $DIR/ty_tykind_usage.rs:25:9
    |
 LL |         TyKind::Ref(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:36:9
+  --> $DIR/ty_tykind_usage.rs:26:9
    |
 LL |         TyKind::FnDef(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:37:9
+  --> $DIR/ty_tykind_usage.rs:27:9
    |
 LL |         TyKind::FnPtr(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:38:9
+  --> $DIR/ty_tykind_usage.rs:28:9
    |
 LL |         TyKind::Dynamic(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:39:9
+  --> $DIR/ty_tykind_usage.rs:29:9
    |
 LL |         TyKind::Closure(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:40:9
+  --> $DIR/ty_tykind_usage.rs:30:9
    |
 LL |         TyKind::Generator(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:41:9
+  --> $DIR/ty_tykind_usage.rs:31:9
    |
 LL |         TyKind::GeneratorWitness(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:42:9
+  --> $DIR/ty_tykind_usage.rs:32:9
    |
 LL |         TyKind::Never => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:43:9
+  --> $DIR/ty_tykind_usage.rs:33:9
    |
 LL |         TyKind::Tuple(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:44:9
+  --> $DIR/ty_tykind_usage.rs:34:9
    |
 LL |         TyKind::Projection(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:45:9
+  --> $DIR/ty_tykind_usage.rs:35:9
    |
 LL |         TyKind::UnnormalizedProjection(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:46:9
+  --> $DIR/ty_tykind_usage.rs:36:9
    |
 LL |         TyKind::Opaque(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:47:9
+  --> $DIR/ty_tykind_usage.rs:37:9
    |
 LL |         TyKind::Param(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:48:9
+  --> $DIR/ty_tykind_usage.rs:38:9
    |
 LL |         TyKind::Bound(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:49:9
+  --> $DIR/ty_tykind_usage.rs:39:9
    |
 LL |         TyKind::Placeholder(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:50:9
+  --> $DIR/ty_tykind_usage.rs:40:9
    |
 LL |         TyKind::Infer(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:51:9
+  --> $DIR/ty_tykind_usage.rs:41:9
    |
 LL |         TyKind::Error => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:56:12
+  --> $DIR/ty_tykind_usage.rs:46:12
    |
 LL |     if let TyKind::Int(int_ty) = sty {} //~ ERROR usage of `ty::TyKind::<kind>`
    |            ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind`
-  --> $DIR/ty_tykind_usage.rs:58:24
+  --> $DIR/ty_tykind_usage.rs:48:24
    |
 LL |     fn ty_kind(ty_bad: TyKind<'_>, ty_good: Ty<'_>) {} //~ ERROR usage of `ty::TyKind`
    |                        ^^^^^^^^^^

--- a/src/test/ui-fulldeps/internal-lints/ty_tykind_usage.stderr
+++ b/src/test/ui-fulldeps/internal-lints/ty_tykind_usage.stderr
@@ -1,0 +1,196 @@
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:21:15
+   |
+LL |     let sty = TyKind::Bool; //~ ERROR usage of `ty::TyKind::<kind>`
+   |               ^^^^^^ help: try using ty::<kind> directly: `ty`
+   |
+note: lint level defined here
+  --> $DIR/ty_tykind_usage.rs:19:8
+   |
+LL | #[deny(usage_of_ty_tykind)]
+   |        ^^^^^^^^^^^^^^^^^^
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:24:9
+   |
+LL |         TyKind::Bool => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:25:9
+   |
+LL |         TyKind::Char => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:26:9
+   |
+LL |         TyKind::Int(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:27:9
+   |
+LL |         TyKind::Uint(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:28:9
+   |
+LL |         TyKind::Float(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:29:9
+   |
+LL |         TyKind::Adt(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:30:9
+   |
+LL |         TyKind::Foreign(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:31:9
+   |
+LL |         TyKind::Str => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:32:9
+   |
+LL |         TyKind::Array(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:33:9
+   |
+LL |         TyKind::Slice(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:34:9
+   |
+LL |         TyKind::RawPtr(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:35:9
+   |
+LL |         TyKind::Ref(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:36:9
+   |
+LL |         TyKind::FnDef(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:37:9
+   |
+LL |         TyKind::FnPtr(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:38:9
+   |
+LL |         TyKind::Dynamic(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:39:9
+   |
+LL |         TyKind::Closure(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:40:9
+   |
+LL |         TyKind::Generator(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:41:9
+   |
+LL |         TyKind::GeneratorWitness(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:42:9
+   |
+LL |         TyKind::Never => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:43:9
+   |
+LL |         TyKind::Tuple(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:44:9
+   |
+LL |         TyKind::Projection(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:45:9
+   |
+LL |         TyKind::UnnormalizedProjection(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:46:9
+   |
+LL |         TyKind::Opaque(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:47:9
+   |
+LL |         TyKind::Param(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:48:9
+   |
+LL |         TyKind::Bound(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:49:9
+   |
+LL |         TyKind::Placeholder(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:50:9
+   |
+LL |         TyKind::Infer(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:51:9
+   |
+LL |         TyKind::Error => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:56:12
+   |
+LL |     if let TyKind::Int(int_ty) = sty {} //~ ERROR usage of `ty::TyKind::<kind>`
+   |            ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind`
+  --> $DIR/ty_tykind_usage.rs:58:24
+   |
+LL |     fn ty_kind(ty_bad: TyKind<'_>, ty_good: Ty<'_>) {} //~ ERROR usage of `ty::TyKind`
+   |                        ^^^^^^^^^^
+   |
+   = help: try using `ty::Ty` instead
+
+error: aborting due to 31 previous errors
+

--- a/src/test/ui-fulldeps/internal-lints/without_compile_flag.rs
+++ b/src/test/ui-fulldeps/internal-lints/without_compile_flag.rs
@@ -1,13 +1,3 @@
-// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
-// file at the top-level directory of this distribution and at
-// http://rust-lang.org/COPYRIGHT.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 // compile-pass
 
 #![allow(unused)]

--- a/src/test/ui-fulldeps/internal-lints/without_compile_flag.rs
+++ b/src/test/ui-fulldeps/internal-lints/without_compile_flag.rs
@@ -1,0 +1,18 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-pass
+
+#![allow(unused)]
+
+use std::collections::HashMap;
+
+#[deny(default_hash_types)] //~ WARNING unknown lint: `default_hash_types`
+fn main() {}

--- a/src/test/ui-fulldeps/internal-lints/without_compile_flag.stderr
+++ b/src/test/ui-fulldeps/internal-lints/without_compile_flag.stderr
@@ -1,0 +1,8 @@
+warning: unknown lint: `default_hash_types`
+  --> $DIR/without_compile_flag.rs:17:8
+   |
+LL | #[deny(default_hash_types)] //~ WARNING unknown lint: `default_hash_types`
+   |        ^^^^^^^^^^^^^^^^^^
+   |
+   = note: #[warn(unknown_lints)] on by default
+

--- a/src/test/ui-fulldeps/internal-lints/without_compile_flag.stderr
+++ b/src/test/ui-fulldeps/internal-lints/without_compile_flag.stderr
@@ -1,5 +1,5 @@
 warning: unknown lint: `default_hash_types`
-  --> $DIR/without_compile_flag.rs:17:8
+  --> $DIR/without_compile_flag.rs:7:8
    |
 LL | #[deny(default_hash_types)] //~ WARNING unknown lint: `default_hash_types`
    |        ^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
cc #49509

I just implemented rust-lang/rust-clippy#3787 and wanted to replace the manual `filter*()` calls with the new iterators. Then I remembered that I still had this in the pipeline.

I will need some help how to add the `-Z internal_lints` flag to the bootstrap script. Especially if it is possible to enable the flag for all subcrates but `libstd` (and maybe some other subcrates).

r? @oli-obk