### PR TITLE
libcore => 2018

### DIFF
--- a/src/libcore/Cargo.toml
+++ b/src/libcore/Cargo.toml
@@ -4,6 +4,7 @@ name = "core"
 version = "0.0.0"
 autotests = false
 autobenches = false
+edition = "2018"
 
 [lib]
 name = "core"

--- a/src/libcore/alloc.rs
+++ b/src/libcore/alloc.rs
@@ -2,12 +2,12 @@
 
 #![stable(feature = "alloc_module", since = "1.28.0")]
 
-use cmp;
-use fmt;
-use mem;
-use usize;
-use ptr::{self, NonNull};
-use num::NonZeroUsize;
+use crate::cmp;
+use crate::fmt;
+use crate::mem;
+use crate::usize;
+use crate::ptr::{self, NonNull};
+use crate::num::NonZeroUsize;
 
 /// Represents the combination of a starting address and
 /// a total capacity of the returned block.

--- a/src/libcore/any.rs
+++ b/src/libcore/any.rs
@@ -61,8 +61,8 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-use fmt;
-use intrinsics;
+use crate::fmt;
+use crate::intrinsics;
 
 ///////////////////////////////////////////////////////////////////////////////
 // Any trait

--- a/src/libcore/array.rs
+++ b/src/libcore/array.rs
@@ -9,13 +9,13 @@
                       integer constants",
             issue = "27778")]
 
-use borrow::{Borrow, BorrowMut};
-use cmp::Ordering;
-use convert::TryFrom;
-use fmt;
-use hash::{Hash, self};
-use marker::Unsize;
-use slice::{Iter, IterMut};
+use crate::borrow::{Borrow, BorrowMut};
+use crate::cmp::Ordering;
+use crate::convert::TryFrom;
+use crate::fmt;
+use crate::hash::{Hash, self};
+use crate::marker::Unsize;
+use crate::slice::{Iter, IterMut};
 
 /// Utility trait implemented only on arrays of fixed size
 ///

--- a/src/libcore/ascii.rs
+++ b/src/libcore/ascii.rs
@@ -11,9 +11,9 @@
 
 #![stable(feature = "core_ascii", since = "1.26.0")]
 
-use fmt;
-use ops::Range;
-use iter::FusedIterator;
+use crate::fmt;
+use crate::ops::Range;
+use crate::iter::FusedIterator;
 
 /// An iterator over the escaped version of a byte.
 ///

--- a/src/libcore/benches/lib.rs
+++ b/src/libcore/benches/lib.rs
@@ -1,7 +1,6 @@
 #![feature(flt2dec)]
 #![feature(test)]
 
-extern crate core;
 extern crate test;
 
 mod any;

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -186,12 +186,12 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-use cmp::Ordering;
-use fmt::{self, Debug, Display};
-use marker::Unsize;
-use mem;
-use ops::{Deref, DerefMut, CoerceUnsized};
-use ptr;
+use crate::cmp::Ordering;
+use crate::fmt::{self, Debug, Display};
+use crate::marker::Unsize;
+use crate::mem;
+use crate::ops::{Deref, DerefMut, CoerceUnsized};
+use crate::ptr;
 
 /// A mutable memory location.
 ///

--- a/src/libcore/char/convert.rs
+++ b/src/libcore/char/convert.rs
@@ -1,9 +1,10 @@
 //! Character conversions.
 
-use convert::TryFrom;
-use fmt;
-use mem::transmute;
-use str::FromStr;
+use crate::convert::TryFrom;
+use crate::fmt;
+use crate::mem::transmute;
+use crate::str::FromStr;
+
 use super::MAX;
 
 /// Converts a `u32` to a `char`.

--- a/src/libcore/char/decode.rs
+++ b/src/libcore/char/decode.rs
@@ -1,6 +1,7 @@
 //! UTF-8 and UTF-16 decoding iterators
 
-use fmt;
+use crate::fmt;
+
 use super::from_u32_unchecked;
 
 /// An iterator that decodes UTF-16 encoded code points from an iterator of `u16`s.

--- a/src/libcore/char/methods.rs
+++ b/src/libcore/char/methods.rs
@@ -1,10 +1,11 @@
 //! impl char {}
 
-use slice;
-use str::from_utf8_unchecked_mut;
+use crate::slice;
+use crate::str::from_utf8_unchecked_mut;
+use crate::unicode::printable::is_printable;
+use crate::unicode::tables::{conversions, derived_property, general_category, property};
+
 use super::*;
-use unicode::printable::is_printable;
-use unicode::tables::{conversions, derived_property, general_category, property};
 
 #[lang = "char"]
 impl char {

--- a/src/libcore/char/mod.rs
+++ b/src/libcore/char/mod.rs
@@ -37,12 +37,12 @@ pub use self::decode::{decode_utf16, DecodeUtf16, DecodeUtf16Error};
 
 // unstable re-exports
 #[unstable(feature = "unicode_version", issue = "49726")]
-pub use unicode::tables::UNICODE_VERSION;
+pub use crate::unicode::tables::UNICODE_VERSION;
 #[unstable(feature = "unicode_version", issue = "49726")]
-pub use unicode::version::UnicodeVersion;
+pub use crate::unicode::version::UnicodeVersion;
 
-use fmt::{self, Write};
-use iter::FusedIterator;
+use crate::fmt::{self, Write};
+use crate::iter::FusedIterator;
 
 // UTF-8 ranges and tags for encoding characters
 const TAG_CONT: u8     = 0b1000_0000;

--- a/src/libcore/clone.rs
+++ b/src/libcore/clone.rs
@@ -142,13 +142,13 @@ pub trait Clone : Sized {
 #[unstable(feature = "derive_clone_copy",
            reason = "deriving hack, should not be public",
            issue = "0")]
-pub struct AssertParamIsClone<T: Clone + ?Sized> { _field: ::marker::PhantomData<T> }
+pub struct AssertParamIsClone<T: Clone + ?Sized> { _field: crate::marker::PhantomData<T> }
 #[doc(hidden)]
 #[allow(missing_debug_implementations)]
 #[unstable(feature = "derive_clone_copy",
            reason = "deriving hack, should not be public",
            issue = "0")]
-pub struct AssertParamIsCopy<T: Copy + ?Sized> { _field: ::marker::PhantomData<T> }
+pub struct AssertParamIsCopy<T: Copy + ?Sized> { _field: crate::marker::PhantomData<T> }
 
 /// Implementations of `Clone` for primitive types.
 ///

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -265,7 +265,7 @@ pub trait Eq: PartialEq<Self> {
 #[unstable(feature = "derive_eq",
            reason = "deriving hack, should not be public",
            issue = "0")]
-pub struct AssertParamIsEq<T: Eq + ?Sized> { _field: ::marker::PhantomData<T> }
+pub struct AssertParamIsEq<T: Eq + ?Sized> { _field: crate::marker::PhantomData<T> }
 
 /// An `Ordering` is the result of a comparison between two values.
 ///
@@ -884,7 +884,7 @@ pub fn max<T: Ord>(v1: T, v2: T) -> T {
 
 // Implementation of PartialEq, Eq, PartialOrd and Ord for primitive types
 mod impls {
-    use cmp::Ordering::{self, Less, Greater, Equal};
+    use crate::cmp::Ordering::{self, Less, Greater, Equal};
 
     macro_rules! partial_eq_impl {
         ($($t:ty)*) => ($(

--- a/src/libcore/convert.rs
+++ b/src/libcore/convert.rs
@@ -40,7 +40,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-use fmt;
+use crate::fmt;
 
 /// An identity function.
 ///

--- a/src/libcore/ffi.rs
+++ b/src/libcore/ffi.rs
@@ -4,7 +4,7 @@
 
 //! Utilities related to FFI bindings.
 
-use ::fmt;
+use crate::fmt;
 
 /// Equivalent to C's `void` type when used as a [pointer].
 ///

--- a/src/libcore/fmt/builders.rs
+++ b/src/libcore/fmt/builders.rs
@@ -1,4 +1,4 @@
-use fmt;
+use crate::fmt;
 
 struct PadAdapter<'a> {
     buf: &'a mut (dyn fmt::Write + 'a),

--- a/src/libcore/fmt/float.rs
+++ b/src/libcore/fmt/float.rs
@@ -1,6 +1,6 @@
-use fmt::{Formatter, Result, LowerExp, UpperExp, Display, Debug};
-use mem::MaybeUninit;
-use num::flt2dec;
+use crate::fmt::{Formatter, Result, LowerExp, UpperExp, Display, Debug};
+use crate::mem::MaybeUninit;
+use crate::num::flt2dec;
 
 // Don't inline this so callers don't use the stack space this function
 // requires unless they have to.

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -2,14 +2,14 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-use cell::{UnsafeCell, Cell, RefCell, Ref, RefMut};
-use marker::PhantomData;
-use mem;
-use num::flt2dec;
-use ops::Deref;
-use result;
-use slice;
-use str;
+use crate::cell::{UnsafeCell, Cell, RefCell, Ref, RefMut};
+use crate::marker::PhantomData;
+use crate::mem;
+use crate::num::flt2dec;
+use crate::ops::Deref;
+use crate::result;
+use crate::slice;
+use crate::str;
 
 mod float;
 mod num;

--- a/src/libcore/fmt/num.rs
+++ b/src/libcore/fmt/num.rs
@@ -1,12 +1,12 @@
 //! Integer and floating-point number formatting
 
 
-use fmt;
-use ops::{Div, Rem, Sub};
-use str;
-use slice;
-use ptr;
-use mem::MaybeUninit;
+use crate::fmt;
+use crate::ops::{Div, Rem, Sub};
+use crate::str;
+use crate::slice;
+use crate::ptr;
+use crate::mem::MaybeUninit;
 
 #[doc(hidden)]
 trait Int: PartialEq + PartialOrd + Div<Output=Self> + Rem<Output=Self> +
@@ -196,7 +196,7 @@ macro_rules! impl_Display {
 
             unsafe {
                 // need at least 16 bits for the 4-characters-at-a-time to work.
-                assert!(::mem::size_of::<$u>() >= 2);
+                assert!(crate::mem::size_of::<$u>() >= 2);
 
                 // eagerly decode 4 characters at a time
                 while n >= 10000 {

--- a/src/libcore/future/future.rs
+++ b/src/libcore/future/future.rs
@@ -2,10 +2,10 @@
             reason = "futures in libcore are unstable",
             issue = "50547")]
 
-use marker::Unpin;
-use ops;
-use pin::Pin;
-use task::{Context, Poll};
+use crate::marker::Unpin;
+use crate::ops;
+use crate::pin::Pin;
+use crate::task::{Context, Poll};
 
 /// A future represents an asynchronous computation.
 ///

--- a/src/libcore/hash/mod.rs
+++ b/src/libcore/hash/mod.rs
@@ -81,8 +81,8 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-use fmt;
-use marker;
+use crate::fmt;
+use crate::marker;
 
 #[stable(feature = "rust1", since = "1.0.0")]
 #[allow(deprecated)]
@@ -541,8 +541,9 @@ impl<H> Eq for BuildHasherDefault<H> {}
 //////////////////////////////////////////////////////////////////////////////
 
 mod impls {
-    use mem;
-    use slice;
+    use crate::mem;
+    use crate::slice;
+
     use super::*;
 
     macro_rules! impl_write {

--- a/src/libcore/hash/sip.rs
+++ b/src/libcore/hash/sip.rs
@@ -2,10 +2,10 @@
 
 #![allow(deprecated)] // the types in this module are deprecated
 
-use marker::PhantomData;
-use ptr;
-use cmp;
-use mem;
+use crate::marker::PhantomData;
+use crate::ptr;
+use crate::cmp;
+use crate::mem;
 
 /// An implementation of SipHash 1-3.
 ///
@@ -269,7 +269,7 @@ impl<S: Sip> super::Hasher for Hasher<S> {
     #[inline]
     fn write_usize(&mut self, i: usize) {
         let bytes = unsafe {
-            ::slice::from_raw_parts(&i as *const usize as *const u8, mem::size_of::<usize>())
+            crate::slice::from_raw_parts(&i as *const usize as *const u8, mem::size_of::<usize>())
         };
         self.short_write(bytes);
     }

--- a/src/libcore/hint.rs
+++ b/src/libcore/hint.rs
@@ -2,7 +2,7 @@
 
 //! Hints to compiler that affects how code should be emitted or optimized.
 
-use intrinsics;
+use crate::intrinsics;
 
 /// Informs the compiler that this point in the code is not reachable, enabling
 /// further optimizations.

--- a/src/libcore/internal_macros.rs
+++ b/src/libcore/internal_macros.rs
@@ -81,9 +81,7 @@ macro_rules! forward_ref_op_assign {
 macro_rules! impl_fn_for_zst {
     ($(
         $( #[$attr: meta] )*
-        // FIXME: when libcore is in the 2018 edition, use `?` repetition in
-        // $( <$( $li : lifetime ),+> )?
-        struct $Name: ident impl$( <$( $lifetime : lifetime ),+> )* Fn =
+        struct $Name: ident impl$( <$( $lifetime : lifetime ),+> )? Fn =
             |$( $arg: ident: $ArgTy: ty ),*| -> $ReturnTy: ty
             $body: block;
     )+) => {
@@ -91,14 +89,14 @@ macro_rules! impl_fn_for_zst {
             $( #[$attr] )*
             struct $Name;
 
-            impl $( <$( $lifetime ),+> )* Fn<($( $ArgTy, )*)> for $Name {
+            impl $( <$( $lifetime ),+> )? Fn<($( $ArgTy, )*)> for $Name {
                 #[inline]
                 extern "rust-call" fn call(&self, ($( $arg, )*): ($( $ArgTy, )*)) -> $ReturnTy {
                     $body
                 }
             }
 
-            impl $( <$( $lifetime ),+> )* FnMut<($( $ArgTy, )*)> for $Name {
+            impl $( <$( $lifetime ),+> )? FnMut<($( $ArgTy, )*)> for $Name {
                 #[inline]
                 extern "rust-call" fn call_mut(
                     &mut self,
@@ -108,7 +106,7 @@ macro_rules! impl_fn_for_zst {
                 }
             }
 
-            impl $( <$( $lifetime ),+> )* FnOnce<($( $ArgTy, )*)> for $Name {
+            impl $( <$( $lifetime ),+> )? FnOnce<($( $ArgTy, )*)> for $Name {
                 type Output = $ReturnTy;
 
                 #[inline]

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -39,7 +39,7 @@
 #[stable(feature = "drop_in_place", since = "1.8.0")]
 #[rustc_deprecated(reason = "no longer an intrinsic - use `ptr::drop_in_place` directly",
                    since = "1.18.0")]
-pub use ptr::drop_in_place;
+pub use crate::ptr::drop_in_place;
 
 extern "rust-intrinsic" {
     // N.B., these intrinsics take raw pointers because they mutate aliased
@@ -1291,7 +1291,7 @@ extern "rust-intrinsic" {
     /// platforms this is a `*mut *mut T` which is filled in by the compiler and
     /// on MSVC it's `*mut [usize; 2]`. For more information see the compiler's
     /// source as well as std's catch implementation.
-    pub fn try(f: fn(*mut u8), data: *mut u8, local_ptr: *mut u8) -> i32;
+    pub fn r#try(f: fn(*mut u8), data: *mut u8, local_ptr: *mut u8) -> i32;
 
     /// Emits a `!nontemporal` store according to LLVM (see their docs).
     /// Probably will never become stable.

--- a/src/libcore/iter/adapters/chain.rs
+++ b/src/libcore/iter/adapters/chain.rs
@@ -1,5 +1,6 @@
-use ops::Try;
-use usize;
+use crate::ops::Try;
+use crate::usize;
+
 use super::super::{Iterator, DoubleEndedIterator, FusedIterator, TrustedLen};
 
 /// An iterator that strings two iterators together.

--- a/src/libcore/iter/adapters/flatten.rs
+++ b/src/libcore/iter/adapters/flatten.rs
@@ -1,5 +1,6 @@
-use fmt;
-use ops::Try;
+use crate::fmt;
+use crate::ops::Try;
+
 use super::super::{Iterator, DoubleEndedIterator, FusedIterator};
 use super::Map;
 

--- a/src/libcore/iter/adapters/mod.rs
+++ b/src/libcore/iter/adapters/mod.rs
@@ -1,8 +1,9 @@
-use cmp;
-use fmt;
-use ops::Try;
-use usize;
-use intrinsics;
+use crate::cmp;
+use crate::fmt;
+use crate::ops::Try;
+use crate::usize;
+use crate::intrinsics;
+
 use super::{Iterator, DoubleEndedIterator, ExactSizeIterator, FusedIterator, TrustedLen};
 use super::LoopState;
 

--- a/src/libcore/iter/adapters/zip.rs
+++ b/src/libcore/iter/adapters/zip.rs
@@ -1,4 +1,5 @@
-use cmp;
+use crate::cmp;
+
 use super::super::{Iterator, DoubleEndedIterator, ExactSizeIterator, FusedIterator, TrustedLen};
 
 /// An iterator that iterates two other iterators simultaneously.

--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -306,7 +306,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-use ops::Try;
+use crate::ops::Try;
 
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::traits::Iterator;

--- a/src/libcore/iter/range.rs
+++ b/src/libcore/iter/range.rs
@@ -1,7 +1,7 @@
-use convert::TryFrom;
-use mem;
-use ops::{self, Add, Sub, Try};
-use usize;
+use crate::convert::TryFrom;
+use crate::mem;
+use crate::ops::{self, Add, Sub, Try};
+use crate::usize;
 
 use super::{FusedIterator, TrustedLen};
 
@@ -321,7 +321,7 @@ impl<A: Step> Iterator for ops::RangeInclusive<A> {
         }
 
         if let Some(plus_n) = self.start.add_usize(n) {
-            use cmp::Ordering::*;
+            use crate::cmp::Ordering::*;
 
             match plus_n.partial_cmp(&self.end) {
                 Some(Less) => {

--- a/src/libcore/iter/sources.rs
+++ b/src/libcore/iter/sources.rs
@@ -1,6 +1,6 @@
-use fmt;
-use marker;
-use usize;
+use crate::fmt;
+use crate::marker;
+use crate::usize;
 
 use super::{FusedIterator, TrustedLen};
 
@@ -283,7 +283,7 @@ pub const fn empty<T>() -> Empty<T> {
 #[derive(Clone, Debug)]
 #[stable(feature = "iter_once", since = "1.2.0")]
 pub struct Once<T> {
-    inner: ::option::IntoIter<T>
+    inner: crate::option::IntoIter<T>
 }
 
 #[stable(feature = "iter_once", since = "1.2.0")]

--- a/src/libcore/iter/traits/accum.rs
+++ b/src/libcore/iter/traits/accum.rs
@@ -1,5 +1,5 @@
-use ops::{Mul, Add};
-use num::Wrapping;
+use crate::ops::{Mul, Add};
+use crate::num::Wrapping;
 
 /// Trait to represent types that can be created by summing up an iterator.
 ///

--- a/src/libcore/iter/traits/double_ended.rs
+++ b/src/libcore/iter/traits/double_ended.rs
@@ -1,5 +1,5 @@
-use ops::Try;
-use iter::LoopState;
+use crate::ops::Try;
+use crate::iter::LoopState;
 
 /// An iterator able to yield elements from both ends.
 ///

--- a/src/libcore/iter/traits/iterator.rs
+++ b/src/libcore/iter/traits/iterator.rs
@@ -1,5 +1,5 @@
-use cmp::Ordering;
-use ops::Try;
+use crate::cmp::Ordering;
+use crate::ops::Try;
 
 use super::super::LoopState;
 use super::super::{Chain, Cycle, Copied, Cloned, Enumerate, Filter, FilterMap, Fuse};

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -63,6 +63,10 @@
 #![warn(missing_debug_implementations)]
 #![deny(intra_doc_link_resolution_failure)] // rustdoc is run without -D warnings
 
+#![deny(rust_2018_idioms)]
+#![allow(explicit_outlives_requirements)]
+#![allow(elided_lifetimes_in_paths)]
+
 #![feature(allow_internal_unstable)]
 #![feature(arbitrary_self_types)]
 #![feature(asm)]

--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -6,10 +6,10 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-use cell::UnsafeCell;
-use cmp;
-use hash::Hash;
-use hash::Hasher;
+use crate::cell::UnsafeCell;
+use crate::cmp;
+use crate::hash::Hash;
+use crate::hash::Hasher;
 
 /// Types that can be transferred across thread boundaries.
 ///

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -5,18 +5,18 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-use clone;
-use cmp;
-use fmt;
-use hash;
-use intrinsics;
-use marker::{Copy, PhantomData, Sized};
-use ptr;
-use ops::{Deref, DerefMut};
+use crate::clone;
+use crate::cmp;
+use crate::fmt;
+use crate::hash;
+use crate::intrinsics;
+use crate::marker::{Copy, PhantomData, Sized};
+use crate::ptr;
+use crate::ops::{Deref, DerefMut};
 
 #[stable(feature = "rust1", since = "1.0.0")]
 #[doc(inline)]
-pub use intrinsics::transmute;
+pub use crate::intrinsics::transmute;
 
 /// Takes ownership and "forgets" about the value **without running its destructor**.
 ///

--- a/src/libcore/num/bignum.rs
+++ b/src/libcore/num/bignum.rs
@@ -17,8 +17,8 @@
             issue = "0")]
 #![macro_use]
 
-use mem;
-use intrinsics;
+use crate::mem;
+use crate::intrinsics;
 
 /// Arithmetic operations required by bignums.
 pub trait FullOps: Sized {
@@ -128,7 +128,7 @@ macro_rules! define_bignum {
 
             /// Makes a bignum from `u64` value.
             pub fn from_u64(mut v: u64) -> $name {
-                use mem;
+                use crate::mem;
 
                 let mut base = [0; $n];
                 let mut sz = 0;
@@ -150,7 +150,7 @@ macro_rules! define_bignum {
             /// Returns the `i`-th bit where bit 0 is the least significant one.
             /// In other words, the bit with weight `2^i`.
             pub fn get_bit(&self, i: usize) -> u8 {
-                use mem;
+                use crate::mem;
 
                 let digitbits = mem::size_of::<$ty>() * 8;
                 let d = i / digitbits;
@@ -166,7 +166,7 @@ macro_rules! define_bignum {
             /// Returns the number of bits necessary to represent this value. Note that zero
             /// is considered to need 0 bits.
             pub fn bit_length(&self) -> usize {
-                use mem;
+                use crate::mem;
 
                 // Skip over the most significant digits which are zero.
                 let digits = self.digits();
@@ -190,8 +190,8 @@ macro_rules! define_bignum {
 
             /// Adds `other` to itself and returns its own mutable reference.
             pub fn add<'a>(&'a mut self, other: &$name) -> &'a mut $name {
-                use cmp;
-                use num::bignum::FullOps;
+                use crate::cmp;
+                use crate::num::bignum::FullOps;
 
                 let mut sz = cmp::max(self.size, other.size);
                 let mut carry = false;
@@ -209,7 +209,7 @@ macro_rules! define_bignum {
             }
 
             pub fn add_small(&mut self, other: $ty) -> &mut $name {
-                use num::bignum::FullOps;
+                use crate::num::bignum::FullOps;
 
                 let (mut carry, v) = self.base[0].full_add(other, false);
                 self.base[0] = v;
@@ -228,8 +228,8 @@ macro_rules! define_bignum {
 
             /// Subtracts `other` from itself and returns its own mutable reference.
             pub fn sub<'a>(&'a mut self, other: &$name) -> &'a mut $name {
-                use cmp;
-                use num::bignum::FullOps;
+                use crate::cmp;
+                use crate::num::bignum::FullOps;
 
                 let sz = cmp::max(self.size, other.size);
                 let mut noborrow = true;
@@ -246,7 +246,7 @@ macro_rules! define_bignum {
             /// Multiplies itself by a digit-sized `other` and returns its own
             /// mutable reference.
             pub fn mul_small(&mut self, other: $ty) -> &mut $name {
-                use num::bignum::FullOps;
+                use crate::num::bignum::FullOps;
 
                 let mut sz = self.size;
                 let mut carry = 0;
@@ -265,7 +265,7 @@ macro_rules! define_bignum {
 
             /// Multiplies itself by `2^bits` and returns its own mutable reference.
             pub fn mul_pow2(&mut self, bits: usize) -> &mut $name {
-                use mem;
+                use crate::mem;
 
                 let digitbits = mem::size_of::<$ty>() * 8;
                 let digits = bits / digitbits;
@@ -306,8 +306,8 @@ macro_rules! define_bignum {
 
             /// Multiplies itself by `5^e` and returns its own mutable reference.
             pub fn mul_pow5(&mut self, mut e: usize) -> &mut $name {
-                use mem;
-                use num::bignum::SMALL_POW5;
+                use crate::mem;
+                use crate::num::bignum::SMALL_POW5;
 
                 // There are exactly n trailing zeros on 2^n, and the only relevant digit sizes
                 // are consecutive powers of two, so this is well suited index for the table.
@@ -338,7 +338,7 @@ macro_rules! define_bignum {
             pub fn mul_digits<'a>(&'a mut self, other: &[$ty]) -> &'a mut $name {
                 // the internal routine. works best when aa.len() <= bb.len().
                 fn mul_inner(ret: &mut [$ty; $n], aa: &[$ty], bb: &[$ty]) -> usize {
-                    use num::bignum::FullOps;
+                    use crate::num::bignum::FullOps;
 
                     let mut retsz = 0;
                     for (i, &a) in aa.iter().enumerate() {
@@ -375,7 +375,7 @@ macro_rules! define_bignum {
             /// Divides itself by a digit-sized `other` and returns its own
             /// mutable reference *and* the remainder.
             pub fn div_rem_small(&mut self, other: $ty) -> (&mut $name, $ty) {
-                use num::bignum::FullOps;
+                use crate::num::bignum::FullOps;
 
                 assert!(other > 0);
 
@@ -392,7 +392,7 @@ macro_rules! define_bignum {
             /// Divide self by another bignum, overwriting `q` with the quotient and `r` with the
             /// remainder.
             pub fn div_rem(&self, d: &$name, q: &mut $name, r: &mut $name) {
-                use mem;
+                use crate::mem;
 
                 // Stupid slow base-2 long division taken from
                 // https://en.wikipedia.org/wiki/Division_algorithm
@@ -429,22 +429,22 @@ macro_rules! define_bignum {
             }
         }
 
-        impl ::cmp::PartialEq for $name {
+        impl crate::cmp::PartialEq for $name {
             fn eq(&self, other: &$name) -> bool { self.base[..] == other.base[..] }
         }
 
-        impl ::cmp::Eq for $name {
+        impl crate::cmp::Eq for $name {
         }
 
-        impl ::cmp::PartialOrd for $name {
-            fn partial_cmp(&self, other: &$name) -> ::option::Option<::cmp::Ordering> {
-                ::option::Option::Some(self.cmp(other))
+        impl crate::cmp::PartialOrd for $name {
+            fn partial_cmp(&self, other: &$name) -> crate::option::Option<crate::cmp::Ordering> {
+                crate::option::Option::Some(self.cmp(other))
             }
         }
 
-        impl ::cmp::Ord for $name {
-            fn cmp(&self, other: &$name) -> ::cmp::Ordering {
-                use cmp::max;
+        impl crate::cmp::Ord for $name {
+            fn cmp(&self, other: &$name) -> crate::cmp::Ordering {
+                use crate::cmp::max;
                 let sz = max(self.size, other.size);
                 let lhs = self.base[..sz].iter().cloned().rev();
                 let rhs = other.base[..sz].iter().cloned().rev();
@@ -452,15 +452,15 @@ macro_rules! define_bignum {
             }
         }
 
-        impl ::clone::Clone for $name {
+        impl crate::clone::Clone for $name {
             fn clone(&self) -> $name {
                 $name { size: self.size, base: self.base }
             }
         }
 
-        impl ::fmt::Debug for $name {
-            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
-                use mem;
+        impl crate::fmt::Debug for $name {
+            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+                use crate::mem;
 
                 let sz = if self.size < 1 {1} else {self.size};
                 let digitlen = mem::size_of::<$ty>() * 2;
@@ -469,7 +469,7 @@ macro_rules! define_bignum {
                 for &v in self.base[..sz-1].iter().rev() {
                     write!(f, "_{:01$x}", v, digitlen)?;
                 }
-                ::result::Result::Ok(())
+                crate::result::Result::Ok(())
             }
         }
     )

--- a/src/libcore/num/dec2flt/algorithm.rs
+++ b/src/libcore/num/dec2flt/algorithm.rs
@@ -1,11 +1,11 @@
 //! The various algorithms from the paper.
 
-use cmp::min;
-use cmp::Ordering::{Less, Equal, Greater};
-use num::diy_float::Fp;
-use num::dec2flt::table;
-use num::dec2flt::rawfp::{self, Unpacked, RawFloat, fp_to_float, next_float, prev_float};
-use num::dec2flt::num::{self, Big};
+use crate::cmp::min;
+use crate::cmp::Ordering::{Less, Equal, Greater};
+use crate::num::diy_float::Fp;
+use crate::num::dec2flt::table;
+use crate::num::dec2flt::rawfp::{self, Unpacked, RawFloat, fp_to_float, next_float, prev_float};
+use crate::num::dec2flt::num::{self, Big};
 
 /// Number of significand bits in Fp
 const P: u32 = 64;
@@ -35,7 +35,7 @@ mod fpu_precision {
 // computations are performed in the desired precision.
 #[cfg(all(target_arch="x86", not(target_feature="sse2")))]
 mod fpu_precision {
-    use mem::size_of;
+    use crate::mem::size_of;
 
     /// A structure used to preserve the original value of the FPU control word, so that it can be
     /// restored when the structure is dropped.

--- a/src/libcore/num/dec2flt/mod.rs
+++ b/src/libcore/num/dec2flt/mod.rs
@@ -82,8 +82,8 @@
             reason = "internal routines only exposed for testing",
             issue = "0")]
 
-use fmt;
-use str::FromStr;
+use crate::fmt;
+use crate::str::FromStr;
 
 use self::parse::{parse_decimal, Decimal, Sign, ParseResult};
 use self::num::digits_to_big;

--- a/src/libcore/num/dec2flt/num.rs
+++ b/src/libcore/num/dec2flt/num.rs
@@ -2,9 +2,9 @@
 
 // FIXME This module's name is a bit unfortunate, since other modules also import `core::num`.
 
-use cmp::Ordering::{self, Less, Equal, Greater};
+use crate::cmp::Ordering::{self, Less, Equal, Greater};
 
-pub use num::bignum::Big32x40 as Big;
+pub use crate::num::bignum::Big32x40 as Big;
 
 /// Test whether truncating all bits less significant than `ones_place` introduces
 /// a relative error less, equal, or greater than 0.5 ULP.

--- a/src/libcore/num/dec2flt/rawfp.rs
+++ b/src/libcore/num/dec2flt/rawfp.rs
@@ -17,15 +17,15 @@
 //! Many functions in this module only handle normal numbers. The dec2flt routines conservatively
 //! take the universally-correct slow path (Algorithm M) for very small and very large numbers.
 //! That algorithm needs only next_float() which does handle subnormals and zeros.
-use cmp::Ordering::{Less, Equal, Greater};
-use convert::{TryFrom, TryInto};
-use ops::{Add, Mul, Div, Neg};
-use fmt::{Debug, LowerExp};
-use num::diy_float::Fp;
-use num::FpCategory::{Infinite, Zero, Subnormal, Normal, Nan};
-use num::FpCategory;
-use num::dec2flt::num::{self, Big};
-use num::dec2flt::table;
+use crate::cmp::Ordering::{Less, Equal, Greater};
+use crate::convert::{TryFrom, TryInto};
+use crate::ops::{Add, Mul, Div, Neg};
+use crate::fmt::{Debug, LowerExp};
+use crate::num::diy_float::Fp;
+use crate::num::FpCategory::{Infinite, Zero, Subnormal, Normal, Nan};
+use crate::num::FpCategory;
+use crate::num::dec2flt::num::{self, Big};
+use crate::num::dec2flt::table;
 
 #[derive(Copy, Clone, Debug)]
 pub struct Unpacked {

--- a/src/libcore/num/f32.rs
+++ b/src/libcore/num/f32.rs
@@ -7,8 +7,8 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-use mem;
-use num::FpCategory;
+use crate::mem;
+use crate::num::FpCategory;
 
 /// The radix or base of the internal representation of `f32`.
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcore/num/f64.rs
+++ b/src/libcore/num/f64.rs
@@ -7,8 +7,8 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-use mem;
-use num::FpCategory;
+use crate::mem;
+use crate::num::FpCategory;
 
 /// The radix or base of the internal representation of `f64`.
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcore/num/flt2dec/decoder.rs
+++ b/src/libcore/num/flt2dec/decoder.rs
@@ -1,8 +1,8 @@
 //! Decodes a floating-point value into individual parts and error ranges.
 
-use {f32, f64};
-use num::FpCategory;
-use num::dec2flt::rawfp::RawFloat;
+use crate::{f32, f64};
+use crate::num::FpCategory;
+use crate::num::dec2flt::rawfp::RawFloat;
 
 /// Decoded unsigned finite value, such that:
 ///

--- a/src/libcore/num/flt2dec/mod.rs
+++ b/src/libcore/num/flt2dec/mod.rs
@@ -120,7 +120,7 @@ functions.
             reason = "internal routines only exposed for testing",
             issue = "0")]
 
-use i16;
+use crate::i16;
 pub use self::decoder::{decode, DecodableFloat, FullDecoded, Decoded};
 
 pub mod estimator;

--- a/src/libcore/num/flt2dec/strategy/dragon.rs
+++ b/src/libcore/num/flt2dec/strategy/dragon.rs
@@ -4,12 +4,12 @@
 //! [^1]: Burger, R. G. and Dybvig, R. K. 1996. Printing floating-point numbers
 //!   quickly and accurately. SIGPLAN Not. 31, 5 (May. 1996), 108-116.
 
-use cmp::Ordering;
+use crate::cmp::Ordering;
 
-use num::flt2dec::{Decoded, MAX_SIG_DIGITS, round_up};
-use num::flt2dec::estimator::estimate_scaling_factor;
-use num::bignum::Digit32 as Digit;
-use num::bignum::Big32x40 as Big;
+use crate::num::flt2dec::{Decoded, MAX_SIG_DIGITS, round_up};
+use crate::num::flt2dec::estimator::estimate_scaling_factor;
+use crate::num::bignum::Digit32 as Digit;
+use crate::num::bignum::Big32x40 as Big;
 
 static POW10: [Digit; 10] = [1, 10, 100, 1000, 10000, 100000,
                              1000000, 10000000, 100000000, 1000000000];

--- a/src/libcore/num/flt2dec/strategy/grisu.rs
+++ b/src/libcore/num/flt2dec/strategy/grisu.rs
@@ -5,8 +5,8 @@
 //! [^1]: Florian Loitsch. 2010. Printing floating-point numbers quickly and
 //!   accurately with integers. SIGPLAN Not. 45, 6 (June 2010), 233-243.
 
-use num::diy_float::Fp;
-use num::flt2dec::{Decoded, MAX_SIG_DIGITS, round_up};
+use crate::num::diy_float::Fp;
+use crate::num::flt2dec::{Decoded, MAX_SIG_DIGITS, round_up};
 
 
 // see the comments in `format_shortest_opt` for the rationale.
@@ -418,7 +418,7 @@ pub fn format_shortest_opt(d: &Decoded,
 ///
 /// This should be used for most cases.
 pub fn format_shortest(d: &Decoded, buf: &mut [u8]) -> (/*#digits*/ usize, /*exp*/ i16) {
-    use num::flt2dec::strategy::dragon::format_shortest as fallback;
+    use crate::num::flt2dec::strategy::dragon::format_shortest as fallback;
     match format_shortest_opt(d, buf) {
         Some(ret) => ret,
         None => fallback(d, buf),
@@ -675,7 +675,7 @@ pub fn format_exact_opt(d: &Decoded, buf: &mut [u8], limit: i16)
 ///
 /// This should be used for most cases.
 pub fn format_exact(d: &Decoded, buf: &mut [u8], limit: i16) -> (/*#digits*/ usize, /*exp*/ i16) {
-    use num::flt2dec::strategy::dragon::format_exact as fallback;
+    use crate::num::flt2dec::strategy::dragon::format_exact as fallback;
     match format_exact_opt(d, buf, limit) {
         Some(ret) => ret,
         None => fallback(d, buf, limit),

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -2,12 +2,12 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-use convert::{TryFrom, Infallible};
-use fmt;
-use intrinsics;
-use mem;
-use ops;
-use str::FromStr;
+use crate::convert::{TryFrom, Infallible};
+use crate::fmt;
+use crate::intrinsics;
+use crate::mem;
+use crate::ops;
+use crate::str::FromStr;
 
 macro_rules! impl_nonzero_fmt {
     ( #[$stability: meta] ( $( $Trait: ident ),+ ) for $Ty: ident ) => {
@@ -3939,7 +3939,7 @@ impl u8 {
     #[inline]
     pub fn is_ascii_alphabetic(&self) -> bool {
         match *self {
-            b'A'...b'Z' | b'a'...b'z' => true,
+            b'A'..=b'Z' | b'a'..=b'z' => true,
             _ => false
         }
     }
@@ -3974,7 +3974,7 @@ impl u8 {
     #[inline]
     pub fn is_ascii_uppercase(&self) -> bool {
         match *self {
-            b'A'...b'Z' => true,
+            b'A'..=b'Z' => true,
             _ => false
         }
     }
@@ -4009,7 +4009,7 @@ impl u8 {
     #[inline]
     pub fn is_ascii_lowercase(&self) -> bool {
         match *self {
-            b'a'...b'z' => true,
+            b'a'..=b'z' => true,
             _ => false
         }
     }
@@ -4047,7 +4047,7 @@ impl u8 {
     #[inline]
     pub fn is_ascii_alphanumeric(&self) -> bool {
         match *self {
-            b'0'...b'9' | b'A'...b'Z' | b'a'...b'z' => true,
+            b'0'..=b'9' | b'A'..=b'Z' | b'a'..=b'z' => true,
             _ => false
         }
     }
@@ -4082,7 +4082,7 @@ impl u8 {
     #[inline]
     pub fn is_ascii_digit(&self) -> bool {
         match *self {
-            b'0'...b'9' => true,
+            b'0'..=b'9' => true,
             _ => false
         }
     }
@@ -4120,7 +4120,7 @@ impl u8 {
     #[inline]
     pub fn is_ascii_hexdigit(&self) -> bool {
         match *self {
-            b'0'...b'9' | b'A'...b'F' | b'a'...b'f' => true,
+            b'0'..=b'9' | b'A'..=b'F' | b'a'..=b'f' => true,
             _ => false
         }
     }
@@ -4159,7 +4159,7 @@ impl u8 {
     #[inline]
     pub fn is_ascii_punctuation(&self) -> bool {
         match *self {
-            b'!'...b'/' | b':'...b'@' | b'['...b'`' | b'{'...b'~' => true,
+            b'!'..=b'/' | b':'..=b'@' | b'['..=b'`' | b'{'..=b'~' => true,
             _ => false
         }
     }
@@ -4194,7 +4194,7 @@ impl u8 {
     #[inline]
     pub fn is_ascii_graphic(&self) -> bool {
         match *self {
-            b'!'...b'~' => true,
+            b'!'..=b'~' => true,
             _ => false
         }
     }
@@ -4283,7 +4283,7 @@ impl u8 {
     #[inline]
     pub fn is_ascii_control(&self) -> bool {
         match *self {
-            b'\0'...b'\x1F' | b'\x7F' => true,
+            b'\0'..=b'\x1F' | b'\x7F' => true,
             _ => false
         }
     }
@@ -4573,7 +4573,7 @@ try_from_lower_bounded!(isize, usize);
 #[cfg(target_pointer_width = "16")]
 mod ptr_try_from_impls {
     use super::TryFromIntError;
-    use convert::TryFrom;
+    use crate::convert::TryFrom;
 
     try_from_upper_bounded!(usize, u8);
     try_from_unbounded!(usize, u16, u32, u64, u128);
@@ -4596,7 +4596,7 @@ mod ptr_try_from_impls {
 #[cfg(target_pointer_width = "32")]
 mod ptr_try_from_impls {
     use super::TryFromIntError;
-    use convert::TryFrom;
+    use crate::convert::TryFrom;
 
     try_from_upper_bounded!(usize, u8, u16);
     try_from_unbounded!(usize, u32, u64, u128);
@@ -4622,7 +4622,7 @@ mod ptr_try_from_impls {
 #[cfg(target_pointer_width = "64")]
 mod ptr_try_from_impls {
     use super::TryFromIntError;
-    use convert::TryFrom;
+    use crate::convert::TryFrom;
 
     try_from_upper_bounded!(usize, u8, u16, u32);
     try_from_unbounded!(usize, u64, u128);
@@ -4826,7 +4826,7 @@ impl fmt::Display for ParseIntError {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-pub use num::dec2flt::ParseFloatError;
+pub use crate::num::dec2flt::ParseFloatError;
 
 // Conversion traits for primitive integer and float types
 // Conversions T -> T are covered by a blanket impl and therefore excluded

--- a/src/libcore/num/wrapping.rs
+++ b/src/libcore/num/wrapping.rs
@@ -1,6 +1,6 @@
 use super::Wrapping;
 
-use ops::*;
+use crate::ops::*;
 
 #[allow(unused_macros)]
 macro_rules! sh_impl_signed {

--- a/src/libcore/ops/mod.rs
+++ b/src/libcore/ops/mod.rs
@@ -152,7 +152,7 @@ mod function;
 mod generator;
 mod index;
 mod range;
-mod try;
+mod r#try;
 mod unsize;
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -187,7 +187,7 @@ pub use self::range::{Range, RangeFrom, RangeFull, RangeTo};
 pub use self::range::{RangeInclusive, RangeToInclusive, RangeBounds, Bound};
 
 #[unstable(feature = "try_trait", issue = "42327")]
-pub use self::try::Try;
+pub use self::r#try::Try;
 
 #[unstable(feature = "generator_trait", issue = "43122")]
 pub use self::generator::{Generator, GeneratorState};

--- a/src/libcore/ops/range.rs
+++ b/src/libcore/ops/range.rs
@@ -1,5 +1,5 @@
-use fmt;
-use hash::{Hash, Hasher};
+use crate::fmt;
+use crate::hash::{Hash, Hasher};
 
 /// An unbounded range (`..`).
 ///

--- a/src/libcore/ops/unsize.rs
+++ b/src/libcore/ops/unsize.rs
@@ -1,4 +1,4 @@
-use marker::Unsize;
+use crate::marker::Unsize;
 
 /// Trait that indicates that this is a pointer or a wrapper for one,
 /// where unsizing can be performed on the pointee.

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -135,9 +135,9 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-use iter::{FromIterator, FusedIterator, TrustedLen};
-use {hint, mem, ops::{self, Deref}};
-use pin::Pin;
+use crate::iter::{FromIterator, FusedIterator, TrustedLen};
+use crate::{hint, mem, ops::{self, Deref}};
+use crate::pin::Pin;
 
 // Note that this is not a lang item per se, but it has a hidden dependency on
 // `Iterator`, which is one. The compiler assumes that the `next` method of

--- a/src/libcore/panic.rs
+++ b/src/libcore/panic.rs
@@ -4,8 +4,8 @@
             reason = "newly available in libcore",
             issue = "44489")]
 
-use any::Any;
-use fmt;
+use crate::any::Any;
+use crate::fmt;
 
 /// A struct providing information about a panic.
 ///

--- a/src/libcore/panicking.rs
+++ b/src/libcore/panicking.rs
@@ -26,8 +26,8 @@
                       and related macros",
             issue = "0")]
 
-use fmt;
-use panic::{Location, PanicInfo};
+use crate::fmt;
+use crate::panic::{Location, PanicInfo};
 
 #[cold]
 // never inline unless panic_immediate_abort to avoid code

--- a/src/libcore/pin.rs
+++ b/src/libcore/pin.rs
@@ -263,10 +263,10 @@
 
 #![stable(feature = "pin", since = "1.33.0")]
 
-use fmt;
-use marker::{Sized, Unpin};
-use cmp::{self, PartialEq, PartialOrd};
-use ops::{Deref, DerefMut, Receiver, CoerceUnsized, DispatchFromDyn};
+use crate::fmt;
+use crate::marker::{Sized, Unpin};
+use crate::cmp::{self, PartialEq, PartialOrd};
+use crate::ops::{Deref, DerefMut, Receiver, CoerceUnsized, DispatchFromDyn};
 
 /// A pinned pointer.
 ///

--- a/src/libcore/prelude/v1.rs
+++ b/src/libcore/prelude/v1.rs
@@ -9,38 +9,38 @@
 // Re-exported core operators
 #[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)]
-pub use marker::{Copy, Send, Sized, Sync, Unpin};
+pub use crate::marker::{Copy, Send, Sized, Sync, Unpin};
 #[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)]
-pub use ops::{Drop, Fn, FnMut, FnOnce};
+pub use crate::ops::{Drop, Fn, FnMut, FnOnce};
 
 // Re-exported functions
 #[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)]
-pub use mem::drop;
+pub use crate::mem::drop;
 
 // Re-exported types and traits
 #[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)]
-pub use clone::Clone;
+pub use crate::clone::Clone;
 #[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)]
-pub use cmp::{PartialEq, PartialOrd, Eq, Ord};
+pub use crate::cmp::{PartialEq, PartialOrd, Eq, Ord};
 #[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)]
-pub use convert::{AsRef, AsMut, Into, From};
+pub use crate::convert::{AsRef, AsMut, Into, From};
 #[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)]
-pub use default::Default;
+pub use crate::default::Default;
 #[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)]
-pub use iter::{Iterator, Extend, IntoIterator};
+pub use crate::iter::{Iterator, Extend, IntoIterator};
 #[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)]
-pub use iter::{DoubleEndedIterator, ExactSizeIterator};
+pub use crate::iter::{DoubleEndedIterator, ExactSizeIterator};
 #[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)]
-pub use option::Option::{self, Some, None};
+pub use crate::option::Option::{self, Some, None};
 #[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)]
-pub use result::Result::{self, Ok, Err};
+pub use crate::result::Result::{self, Ok, Err};

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -63,24 +63,24 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-use convert::From;
-use intrinsics;
-use ops::{CoerceUnsized, DispatchFromDyn};
-use fmt;
-use hash;
-use marker::{PhantomData, Unsize};
-use mem::{self, MaybeUninit};
+use crate::convert::From;
+use crate::intrinsics;
+use crate::ops::{CoerceUnsized, DispatchFromDyn};
+use crate::fmt;
+use crate::hash;
+use crate::marker::{PhantomData, Unsize};
+use crate::mem::{self, MaybeUninit};
 
-use cmp::Ordering::{self, Less, Equal, Greater};
-
-#[stable(feature = "rust1", since = "1.0.0")]
-pub use intrinsics::copy_nonoverlapping;
+use crate::cmp::Ordering::{self, Less, Equal, Greater};
 
 #[stable(feature = "rust1", since = "1.0.0")]
-pub use intrinsics::copy;
+pub use crate::intrinsics::copy_nonoverlapping;
 
 #[stable(feature = "rust1", since = "1.0.0")]
-pub use intrinsics::write_bytes;
+pub use crate::intrinsics::copy;
+
+#[stable(feature = "rust1", since = "1.0.0")]
+pub use crate::intrinsics::write_bytes;
 
 /// Executes the destructor (if any) of the pointed-to value.
 ///
@@ -2402,7 +2402,7 @@ pub(crate) unsafe fn align_offset<T: Sized>(p: *const T, a: usize) -> usize {
         }
     }
 
-    let stride = ::mem::size_of::<T>();
+    let stride = mem::size_of::<T>();
     let a_minus_one = a.wrapping_sub(1);
     let pmoda = p as usize & a_minus_one;
 
@@ -2580,7 +2580,7 @@ pub fn eq<T: ?Sized>(a: *const T, b: *const T) -> bool {
 /// ```
 #[stable(feature = "ptr_hash", since = "1.35.0")]
 pub fn hash<T: ?Sized, S: hash::Hasher>(hashee: *const T, into: &mut S) {
-    use hash::Hash;
+    use crate::hash::Hash;
     hashee.hash(into);
 }
 

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -230,9 +230,9 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-use fmt;
-use iter::{FromIterator, FusedIterator, TrustedLen};
-use ops::{self, Deref};
+use crate::fmt;
+use crate::iter::{FromIterator, FusedIterator, TrustedLen};
+use crate::ops::{self, Deref};
 
 /// `Result` is a type that represents either success ([`Ok`]) or failure ([`Err`]).
 ///

--- a/src/libcore/slice/memchr.rs
+++ b/src/libcore/slice/memchr.rs
@@ -1,8 +1,8 @@
 // Original implementation taken from rust-memchr.
 // Copyright 2015 Andrew Gallant, bluss and Nicolas Koch
 
-use cmp;
-use mem;
+use crate::cmp;
+use crate::mem;
 
 const LO_U64: u64 = 0x0101010101010101;
 const HI_U64: u64 = 0x8080808080808080;
@@ -32,7 +32,7 @@ fn repeat_byte(b: u8) -> usize {
 #[cfg(not(target_pointer_width = "16"))]
 #[inline]
 fn repeat_byte(b: u8) -> usize {
-    (b as usize) * (::usize::MAX / 255)
+    (b as usize) * (crate::usize::MAX / 255)
 }
 
 /// Returns the first index matching the byte `x` in `text`.

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -20,20 +20,20 @@
 // * The `raw` and `bytes` submodules.
 // * Boilerplate trait implementations.
 
-use cmp::Ordering::{self, Less, Equal, Greater};
-use cmp;
-use fmt;
-use intrinsics::assume;
-use isize;
-use iter::*;
-use ops::{FnMut, Try, self};
-use option::Option;
-use option::Option::{None, Some};
-use result::Result;
-use result::Result::{Ok, Err};
-use ptr;
-use mem;
-use marker::{Copy, Send, Sync, Sized, self};
+use crate::cmp::Ordering::{self, Less, Equal, Greater};
+use crate::cmp;
+use crate::fmt;
+use crate::intrinsics::assume;
+use crate::isize;
+use crate::iter::*;
+use crate::ops::{FnMut, Try, self};
+use crate::option::Option;
+use crate::option::Option::{None, Some};
+use crate::result::Result;
+use crate::result::Result::{Ok, Err};
+use crate::ptr;
+use crate::mem;
+use crate::marker::{Copy, Send, Sync, Sized, self};
 
 #[unstable(feature = "slice_internals", issue = "0",
            reason = "exposed from core to be reused in std; use the memchr crate")]
@@ -2256,13 +2256,14 @@ impl<T> [T] {
         // Luckily since all this is constant-evaluated... performance here matters not!
         #[inline]
         fn gcd(a: usize, b: usize) -> usize {
+            use crate::intrinsics;
             // iterative stein’s algorithm
             // We should still make this `const fn` (and revert to recursive algorithm if we do)
             // because relying on llvm to consteval all this is… well, it makes me uncomfortable.
             let (ctz_a, mut ctz_b) = unsafe {
                 if a == 0 { return b; }
                 if b == 0 { return a; }
-                (::intrinsics::cttz_nonzero(a), ::intrinsics::cttz_nonzero(b))
+                (intrinsics::cttz_nonzero(a), intrinsics::cttz_nonzero(b))
             };
             let k = ctz_a.min(ctz_b);
             let mut a = a >> ctz_a;
@@ -2271,21 +2272,21 @@ impl<T> [T] {
                 // remove all factors of 2 from b
                 b >>= ctz_b;
                 if a > b {
-                    ::mem::swap(&mut a, &mut b);
+                    mem::swap(&mut a, &mut b);
                 }
                 b = b - a;
                 unsafe {
                     if b == 0 {
                         break;
                     }
-                    ctz_b = ::intrinsics::cttz_nonzero(b);
+                    ctz_b = intrinsics::cttz_nonzero(b);
                 }
             }
             a << k
         }
-        let gcd: usize = gcd(::mem::size_of::<T>(), ::mem::size_of::<U>());
-        let ts: usize = ::mem::size_of::<U>() / gcd;
-        let us: usize = ::mem::size_of::<T>() / gcd;
+        let gcd: usize = gcd(mem::size_of::<T>(), mem::size_of::<U>());
+        let ts: usize = mem::size_of::<U>() / gcd;
+        let us: usize = mem::size_of::<T>() / gcd;
 
         // Armed with this knowledge, we can find how many `U`s we can fit!
         let us_len = self.len() / ts * us;
@@ -2326,7 +2327,7 @@ impl<T> [T] {
     #[stable(feature = "slice_align_to", since = "1.30.0")]
     pub unsafe fn align_to<U>(&self) -> (&[T], &[U], &[T]) {
         // Note that most of this function will be constant-evaluated,
-        if ::mem::size_of::<U>() == 0 || ::mem::size_of::<T>() == 0 {
+        if mem::size_of::<U>() == 0 || mem::size_of::<T>() == 0 {
             // handle ZSTs specially, which is – don't handle them at all.
             return (self, &[], &[]);
         }
@@ -2334,7 +2335,7 @@ impl<T> [T] {
         // First, find at what point do we split between the first and 2nd slice. Easy with
         // ptr.align_offset.
         let ptr = self.as_ptr();
-        let offset = ::ptr::align_offset(ptr, ::mem::align_of::<U>());
+        let offset = crate::ptr::align_offset(ptr, mem::align_of::<U>());
         if offset > self.len() {
             (self, &[], &[])
         } else {
@@ -2379,7 +2380,7 @@ impl<T> [T] {
     #[stable(feature = "slice_align_to", since = "1.30.0")]
     pub unsafe fn align_to_mut<U>(&mut self) -> (&mut [T], &mut [U], &mut [T]) {
         // Note that most of this function will be constant-evaluated,
-        if ::mem::size_of::<U>() == 0 || ::mem::size_of::<T>() == 0 {
+        if mem::size_of::<U>() == 0 || mem::size_of::<T>() == 0 {
             // handle ZSTs specially, which is – don't handle them at all.
             return (self, &mut [], &mut []);
         }
@@ -2387,7 +2388,7 @@ impl<T> [T] {
         // First, find at what point do we split between the first and 2nd slice. Easy with
         // ptr.align_offset.
         let ptr = self.as_ptr();
-        let offset = ::ptr::align_offset(ptr, ::mem::align_of::<U>());
+        let offset = crate::ptr::align_offset(ptr, mem::align_of::<U>());
         if offset > self.len() {
             (self, &mut [], &mut [])
         } else {

--- a/src/libcore/slice/rotate.rs
+++ b/src/libcore/slice/rotate.rs
@@ -1,6 +1,6 @@
-use cmp;
-use mem::{self, MaybeUninit};
-use ptr;
+use crate::cmp;
+use crate::mem::{self, MaybeUninit};
+use crate::ptr;
 
 /// Rotation is much faster if it has access to a little bit of memory. This
 /// union provides a RawVec-like interface, but to a fixed-size stack buffer.

--- a/src/libcore/slice/sort.rs
+++ b/src/libcore/slice/sort.rs
@@ -6,9 +6,9 @@
 //! Unstable sorting is compatible with libcore because it doesn't allocate memory, unlike our
 //! stable sorting implementation.
 
-use cmp;
-use mem::{self, MaybeUninit};
-use ptr;
+use crate::cmp;
+use crate::mem::{self, MaybeUninit};
+use crate::ptr;
 
 /// When dropped, copies from `src` into `dest`.
 struct CopyOnDrop<T> {

--- a/src/libcore/str/lossy.rs
+++ b/src/libcore/str/lossy.rs
@@ -1,8 +1,7 @@
-use char;
-use str as core_str;
-use fmt;
-use fmt::Write;
-use mem;
+use crate::char;
+use crate::str as core_str;
+use crate::fmt::{self, Write};
+use crate::mem;
 
 /// Lossy UTF-8 string.
 #[unstable(feature = "str_internals", issue = "0")]

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -7,14 +7,14 @@
 use self::pattern::Pattern;
 use self::pattern::{Searcher, ReverseSearcher, DoubleEndedSearcher};
 
-use char;
-use fmt::{self, Write};
-use iter::{Map, Cloned, FusedIterator, TrustedLen, TrustedRandomAccess, Filter};
-use iter::{Flatten, FlatMap, Chain};
-use slice::{self, SliceIndex, Split as SliceSplit};
-use mem;
-use ops::Try;
-use option;
+use crate::char;
+use crate::fmt::{self, Write};
+use crate::iter::{Map, Cloned, FusedIterator, TrustedLen, TrustedRandomAccess, Filter};
+use crate::iter::{Flatten, FlatMap, Chain};
+use crate::slice::{self, SliceIndex, Split as SliceSplit};
+use crate::mem;
+use crate::ops::Try;
+use crate::option;
 
 pub mod pattern;
 
@@ -1557,9 +1557,9 @@ Section: Trait implementations
 */
 
 mod traits {
-    use cmp::Ordering;
-    use ops;
-    use slice::{self, SliceIndex};
+    use crate::cmp::Ordering;
+    use crate::ops;
+    use crate::slice::{self, SliceIndex};
 
     /// Implements ordering of strings.
     ///

--- a/src/libcore/str/pattern.rs
+++ b/src/libcore/str/pattern.rs
@@ -7,10 +7,10 @@
             reason = "API not fully fleshed out and ready to be stabilized",
             issue = "27721")]
 
-use cmp;
-use fmt;
-use slice::memchr;
-use usize;
+use crate::cmp;
+use crate::fmt;
+use crate::slice::memchr;
+use crate::usize;
 
 // Pattern
 

--- a/src/libcore/sync/atomic.rs
+++ b/src/libcore/sync/atomic.rs
@@ -118,11 +118,11 @@
 
 use self::Ordering::*;
 
-use intrinsics;
-use cell::UnsafeCell;
-use fmt;
+use crate::intrinsics;
+use crate::cell::UnsafeCell;
+use crate::fmt;
 
-use hint::spin_loop;
+use crate::hint::spin_loop;
 
 /// Signals the processor that it is entering a busy-wait spin-loop.
 ///
@@ -195,7 +195,7 @@ pub struct AtomicPtr<T> {
 impl<T> Default for AtomicPtr<T> {
     /// Creates a null `AtomicPtr<T>`.
     fn default() -> AtomicPtr<T> {
-        AtomicPtr::new(::ptr::null_mut())
+        AtomicPtr::new(crate::ptr::null_mut())
     }
 }
 

--- a/src/libcore/task/poll.rs
+++ b/src/libcore/task/poll.rs
@@ -2,8 +2,8 @@
             reason = "futures in libcore are unstable",
             issue = "50547")]
 
-use ops::Try;
-use result::Result;
+use crate::ops::Try;
+use crate::result::Result;
 
 /// Indicates whether a value is available or if the current task has been
 /// scheduled to receive a wakeup instead.

--- a/src/libcore/task/wake.rs
+++ b/src/libcore/task/wake.rs
@@ -2,8 +2,8 @@
             reason = "futures in libcore are unstable",
             issue = "50547")]
 
-use fmt;
-use marker::{PhantomData, Unpin};
+use crate::fmt;
+use crate::marker::{PhantomData, Unpin};
 
 /// A `RawWaker` allows the implementor of a task executor to create a [`Waker`]
 /// which provides customized wakeup behavior.

--- a/src/libcore/tests/lib.rs
+++ b/src/libcore/tests/lib.rs
@@ -35,7 +35,6 @@
 
 extern crate core;
 extern crate test;
-extern crate rand;
 
 mod any;
 mod array;

--- a/src/libcore/tests/num/int_macros.rs
+++ b/src/libcore/tests/num/int_macros.rs
@@ -6,7 +6,7 @@ mod tests {
     use core::ops::{Shl, Shr, Not, BitXor, BitAnd, BitOr};
     use core::mem;
 
-    use num;
+    use crate::num;
 
     #[test]
     fn test_overflows() {

--- a/src/libcore/tests/num/uint_macros.rs
+++ b/src/libcore/tests/num/uint_macros.rs
@@ -2,10 +2,11 @@ macro_rules! uint_module { ($T:ident, $T_i:ident) => (
 #[cfg(test)]
 mod tests {
     use core::$T_i::*;
-    use num;
     use core::ops::{BitOr, BitAnd, BitXor, Shl, Shr, Not};
     use std::str::FromStr;
     use std::mem;
+
+    use crate::num;
 
     #[test]
     fn test_overflows() {

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -12,9 +12,9 @@
 //! assert_eq!(Duration::new(5, 0), Duration::from_secs(5));
 //! ```
 
-use {fmt, u64};
-use iter::Sum;
-use ops::{Add, Sub, Mul, Div, AddAssign, SubAssign, MulAssign, DivAssign};
+use crate::{fmt, u64};
+use crate::iter::Sum;
+use crate::ops::{Add, Sub, Mul, Div, AddAssign, SubAssign, MulAssign, DivAssign};
 
 const NANOS_PER_SEC: u32 = 1_000_000_000;
 const NANOS_PER_MILLI: u32 = 1_000_000;
@@ -921,7 +921,7 @@ impl fmt::Debug for Duration {
             // Determine the end of the buffer: if precision is set, we just
             // use as many digits from the buffer (capped to 9). If it isn't
             // set, we only use all digits up to the last non-zero one.
-            let end = f.precision().map(|p| ::cmp::min(p, 9)).unwrap_or(pos);
+            let end = f.precision().map(|p| crate::cmp::min(p, 9)).unwrap_or(pos);
 
             // If we haven't emitted a single fractional digit and the precision
             // wasn't set to a non-zero value, we don't print the decimal point.
@@ -931,7 +931,7 @@ impl fmt::Debug for Duration {
                 // We are only writing ASCII digits into the buffer and it was
                 // initialized with '0's, so it contains valid UTF8.
                 let s = unsafe {
-                    ::str::from_utf8_unchecked(&buf[..end])
+                    crate::str::from_utf8_unchecked(&buf[..end])
                 };
 
                 // If the user request a precision > 9, we pad '0's at the end.

--- a/src/libcore/tuple.rs
+++ b/src/libcore/tuple.rs
@@ -1,7 +1,7 @@
 // See src/libstd/primitive_docs.rs for documentation.
 
-use cmp::*;
-use cmp::Ordering::*;
+use crate::cmp::*;
+use crate::cmp::Ordering::*;
 
 // macro for implementing n-ary tuple functions and operations
 macro_rules! tuple_impls {

--- a/src/libcore/unicode/mod.rs
+++ b/src/libcore/unicode/mod.rs
@@ -8,13 +8,13 @@ pub(crate) mod version;
 
 // For use in liballoc, not re-exported in libstd.
 pub mod derived_property {
-    pub use unicode::tables::derived_property::{Case_Ignorable, Cased};
+    pub use crate::unicode::tables::derived_property::{Case_Ignorable, Cased};
 }
 pub mod conversions {
-    pub use unicode::tables::conversions::{to_lower, to_upper};
+    pub use crate::unicode::tables::conversions::{to_lower, to_upper};
 }
 
 // For use in libsyntax
 pub mod property {
-    pub use unicode::tables::property::Pattern_White_Space;
+    pub use crate::unicode::tables::property::Pattern_White_Space;
 }

--- a/src/libcore/unicode/tables.rs
+++ b/src/libcore/unicode/tables.rs
@@ -2,8 +2,8 @@
 
 #![allow(missing_docs, non_upper_case_globals, non_snake_case)]
 
-use unicode::version::UnicodeVersion;
-use unicode::bool_trie::{BoolTrie, SmallBoolTrie};
+use crate::unicode::version::UnicodeVersion;
+use crate::unicode::bool_trie::{BoolTrie, SmallBoolTrie};
 
 /// The version of [Unicode](http://www.unicode.org/) that the Unicode parts of
 /// `char` and `str` methods are based on.

--- a/src/libcore/unit.rs
+++ b/src/libcore/unit.rs
@@ -1,4 +1,4 @@
-use iter::FromIterator;
+use crate::iter::FromIterator;
 
 /// Collapses all unit items from an iterator into one.
 ///


### PR DESCRIPTION
Transitions `libcore` to Rust 2018; cc #58099

r? @Centril