### PR TITLE
Update book submodule

### DIFF
--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -187,7 +187,7 @@
 //! [`sync`]: sync/index.html
 //! [`thread`]: thread/index.html
 //! [`use std::env`]: env/index.html
-//! [`use`]: ../book/ch07-02-modules-and-use-to-control-scope-and-privacy.html#the-use-keyword-to-bring-paths-into-a-scope
+//! [`use`]: ../book/ch07-02-defining-modules-to-control-scope-and-privacy.html
 //! [crates.io]: https://crates.io
 //! [deref-coercions]: ../book/ch15-02-deref.html#implicit-deref-coercions-with-functions-and-methods
 //! [files]: fs/struct.File.html


### PR DESCRIPTION
Updates the book to the latest commit

This is to include [documentation SEO fix](https://github.com/rust-lang/book/pull/1788) ASAP.