### PR TITLE
Apply docs convention: Replace # Unsafety with # Safety in docs

### DIFF
--- a/src/libcore/alloc.rs
+++ b/src/libcore/alloc.rs
@@ -420,7 +420,7 @@ impl fmt::Display for CannotReallocInPlace {
 /// }
 /// ```
 ///
-/// # Unsafety
+/// # Safety
 ///
 /// The `GlobalAlloc` trait is an `unsafe` trait for a number of reasons, and
 /// implementors must ensure that they adhere to these contracts:
@@ -643,7 +643,7 @@ pub unsafe trait GlobalAlloc {
 ///    currently allocated via an allocator `a`, then it is legal to
 ///    use that layout to deallocate it, i.e., `a.dealloc(ptr, k);`.
 ///
-/// # Unsafety
+/// # Safety
 ///
 /// The `Alloc` trait is an `unsafe` trait for a number of reasons, and
 /// implementors must ensure that they adhere to these contracts:

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -1173,7 +1173,7 @@ impl<T> MaybeUninit<T> {
     /// to ensure that the data will get dropped, because the resulting `T` is
     /// subject to the usual drop handling.
     ///
-    /// # Unsafety
+    /// # Safety
     ///
     /// It is up to the caller to guarantee that the `MaybeUninit` really is in an initialized
     /// state. Calling this when the content is not yet fully initialized causes undefined
@@ -1187,7 +1187,7 @@ impl<T> MaybeUninit<T> {
 
     /// Gets a reference to the contained value.
     ///
-    /// # Unsafety
+    /// # Safety
     ///
     /// It is up to the caller to guarantee that the `MaybeUninit` really is in an initialized
     /// state. Calling this when the content is not yet fully initialized causes undefined
@@ -1200,7 +1200,7 @@ impl<T> MaybeUninit<T> {
 
     /// Gets a mutable reference to the contained value.
     ///
-    /// # Unsafety
+    /// # Safety
     ///
     /// It is up to the caller to guarantee that the `MaybeUninit` really is in an initialized
     /// state. Calling this when the content is not yet fully initialized causes undefined

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -2158,7 +2158,7 @@ impl<T> [T] {
     /// This method has no purpose when either input element `T` or output element `U` are
     /// zero-sized and will return the original slice without splitting anything.
     ///
-    /// # Unsafety
+    /// # Safety
     ///
     /// This method is essentially a `transmute` with respect to the elements in the returned
     /// middle slice, so all the usual caveats pertaining to `transmute::<T, U>` also apply here.
@@ -2211,7 +2211,7 @@ impl<T> [T] {
     /// This method has no purpose when either input element `T` or output element `U` are
     /// zero-sized and will return the original slice without splitting anything.
     ///
-    /// # Unsafety
+    /// # Safety
     ///
     /// This method is essentially a `transmute` with respect to the elements in the returned
     /// middle slice, so all the usual caveats pertaining to `transmute::<T, U>` also apply here.


### PR DESCRIPTION
As used in RFC 1574: https://github.com/rust-lang/rfcs/blob/master/text/1574-more-api-documentation-conventions.md#using-markdown

"Safety" is used many times more than "Unsafety" is within existing docs.

@bors rollup

r? @RalfJung 