### PR TITLE
librustc_codegen_llvm: #![deny(elided_lifetimes_in_paths)]

### DIFF
--- a/src/librustc_codegen_llvm/allocator.rs
+++ b/src/librustc_codegen_llvm/allocator.rs
@@ -9,7 +9,7 @@ use rustc_allocator::{ALLOCATOR_METHODS, AllocatorTy};
 use crate::ModuleLlvm;
 use crate::llvm::{self, False, True};
 
-pub(crate) unsafe fn codegen(tcx: TyCtxt, mods: &mut ModuleLlvm, kind: AllocatorKind) {
+pub(crate) unsafe fn codegen(tcx: TyCtxt<'_, '_, '_>, mods: &mut ModuleLlvm, kind: AllocatorKind) {
     let llcx = &*mods.llcx;
     let llmod = mods.llmod();
     let usize = match &tcx.sess.target.target.target_pointer_width[..] {

--- a/src/librustc_codegen_llvm/attributes.rs
+++ b/src/librustc_codegen_llvm/attributes.rs
@@ -308,7 +308,7 @@ pub fn from_fn_attrs(
     }
 }
 
-pub fn provide(providers: &mut Providers) {
+pub fn provide(providers: &mut Providers<'_>) {
     providers.target_features_whitelist = |tcx, cnum| {
         assert_eq!(cnum, LOCAL_CRATE);
         if tcx.sess.opts.actually_rustdoc {
@@ -328,7 +328,7 @@ pub fn provide(providers: &mut Providers) {
     provide_extern(providers);
 }
 
-pub fn provide_extern(providers: &mut Providers) {
+pub fn provide_extern(providers: &mut Providers<'_>) {
     providers.wasm_import_module_map = |tcx, cnum| {
         // Build up a map from DefId to a `NativeLibrary` structure, where
         // `NativeLibrary` internally contains information about
@@ -362,7 +362,7 @@ pub fn provide_extern(providers: &mut Providers) {
     };
 }
 
-fn wasm_import_module(tcx: TyCtxt, id: DefId) -> Option<CString> {
+fn wasm_import_module(tcx: TyCtxt<'_, '_, '_>, id: DefId) -> Option<CString> {
     tcx.wasm_import_module_map(id.krate)
         .get(&id)
         .map(|s| CString::new(&s[..]).unwrap())

--- a/src/librustc_codegen_llvm/back/archive.rs
+++ b/src/librustc_codegen_llvm/back/archive.rs
@@ -42,7 +42,7 @@ enum Addition {
     },
 }
 
-fn is_relevant_child(c: &Child) -> bool {
+fn is_relevant_child(c: &Child<'_>) -> bool {
     match c.name() {
         Some(name) => !name.contains("SYMDEF"),
         None => false,

--- a/src/librustc_codegen_llvm/back/link.rs
+++ b/src/librustc_codegen_llvm/back/link.rs
@@ -808,7 +808,7 @@ fn exec_linker(sess: &Session, cmd: &mut Command, out_filename: &Path, tmpdir: &
     }
 
     impl<'a> fmt::Display for Escape<'a> {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             if self.is_like_msvc {
                 // This is "documented" at
                 // https://msdn.microsoft.com/en-us/library/4xdcbak7.aspx

--- a/src/librustc_codegen_llvm/back/rpath.rs
+++ b/src/librustc_codegen_llvm/back/rpath.rs
@@ -15,7 +15,7 @@ pub struct RPathConfig<'a> {
     pub get_install_prefix_lib_path: &'a mut dyn FnMut() -> PathBuf,
 }
 
-pub fn get_rpath_flags(config: &mut RPathConfig) -> Vec<String> {
+pub fn get_rpath_flags(config: &mut RPathConfig<'_>) -> Vec<String> {
     // No rpath on windows
     if !config.has_rpath {
         return Vec::new();
@@ -52,7 +52,7 @@ fn rpaths_to_flags(rpaths: &[String]) -> Vec<String> {
     ret
 }
 
-fn get_rpaths(config: &mut RPathConfig, libs: &[PathBuf]) -> Vec<String> {
+fn get_rpaths(config: &mut RPathConfig<'_>, libs: &[PathBuf]) -> Vec<String> {
     debug!("output: {:?}", config.out_filename.display());
     debug!("libs:");
     for libpath in libs {
@@ -86,12 +86,12 @@ fn get_rpaths(config: &mut RPathConfig, libs: &[PathBuf]) -> Vec<String> {
     rpaths
 }
 
-fn get_rpaths_relative_to_output(config: &mut RPathConfig,
+fn get_rpaths_relative_to_output(config: &mut RPathConfig<'_>,
                                  libs: &[PathBuf]) -> Vec<String> {
     libs.iter().map(|a| get_rpath_relative_to_output(config, a)).collect()
 }
 
-fn get_rpath_relative_to_output(config: &mut RPathConfig, lib: &Path) -> String {
+fn get_rpath_relative_to_output(config: &mut RPathConfig<'_>, lib: &Path) -> String {
     // Mac doesn't appear to support $ORIGIN
     let prefix = if config.is_like_osx {
         "@loader_path"
@@ -127,7 +127,7 @@ fn path_relative_from(path: &Path, base: &Path) -> Option<PathBuf> {
     } else {
         let mut ita = path.components();
         let mut itb = base.components();
-        let mut comps: Vec<Component> = vec![];
+        let mut comps: Vec<Component<'_>> = vec![];
         loop {
             match (ita.next(), itb.next()) {
                 (None, None) => break,
@@ -154,7 +154,7 @@ fn path_relative_from(path: &Path, base: &Path) -> Option<PathBuf> {
 }
 
 
-fn get_install_prefix_rpath(config: &mut RPathConfig) -> String {
+fn get_install_prefix_rpath(config: &mut RPathConfig<'_>) -> String {
     let path = (config.get_install_prefix_lib_path)();
     let path = env::current_dir().unwrap().join(&path);
     // FIXME (#9639): This needs to handle non-utf8 paths

--- a/src/librustc_codegen_llvm/back/wasm.rs
+++ b/src/librustc_codegen_llvm/back/wasm.rs
@@ -60,7 +60,7 @@ pub fn rewrite_imports(path: &Path, import_map: &FxHashMap<String, String>) {
     fs::write(path, &ret.data).expect("failed to write wasm output");
 
     fn rewrite_import_section(
-        wasm: &mut WasmDecoder,
+        wasm: &mut WasmDecoder<'_>,
         import_map: &FxHashMap<String, String>,
     )
         -> Vec<u8>
@@ -75,7 +75,7 @@ pub fn rewrite_imports(path: &Path, import_map: &FxHashMap<String, String>) {
         return dst.data
     }
 
-    fn rewrite_import_entry(wasm: &mut WasmDecoder,
+    fn rewrite_import_entry(wasm: &mut WasmDecoder<'_>,
                             dst: &mut WasmEncoder,
                             import_map: &FxHashMap<String, String>) {
         // More info about the binary format here is available at:

--- a/src/librustc_codegen_llvm/back/write.rs
+++ b/src/librustc_codegen_llvm/back/write.rs
@@ -83,7 +83,7 @@ pub fn write_output_file(
 }
 
 pub fn create_target_machine(
-    tcx: TyCtxt,
+    tcx: TyCtxt<'_, '_, '_>,
     find_features: bool,
 ) -> &'static mut llvm::TargetMachine {
     target_machine_factory(tcx.sess, tcx.backend_optimization_level(LOCAL_CRATE), find_features)()

--- a/src/librustc_codegen_llvm/base.rs
+++ b/src/librustc_codegen_llvm/base.rs
@@ -172,17 +172,17 @@ pub fn compile_codegen_unit<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
             let mono_items = cx.codegen_unit
                                .items_in_deterministic_order(cx.tcx);
             for &(mono_item, (linkage, visibility)) in &mono_items {
-                mono_item.predefine::<Builder>(&cx, linkage, visibility);
+                mono_item.predefine::<Builder<'_, '_, '_>>(&cx, linkage, visibility);
             }
 
             // ... and now that we have everything pre-defined, fill out those definitions.
             for &(mono_item, _) in &mono_items {
-                mono_item.define::<Builder>(&cx);
+                mono_item.define::<Builder<'_, '_, '_>>(&cx);
             }
 
             // If this codegen unit contains the main function, also create the
             // wrapper here
-            maybe_create_entry_wrapper::<Builder>(&cx);
+            maybe_create_entry_wrapper::<Builder<'_, '_, '_>>(&cx);
 
             // Run replace-all-uses-with for statics that need it
             for &(old_g, new_g) in cx.statics_to_rauw().borrow().iter() {

--- a/src/librustc_codegen_llvm/builder.rs
+++ b/src/librustc_codegen_llvm/builder.rs
@@ -456,7 +456,7 @@ impl BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
     fn checked_binop(
         &mut self,
         oop: OverflowOp,
-        ty: Ty,
+        ty: Ty<'_>,
         lhs: Self::Value,
         rhs: Self::Value,
     ) -> (Self::Value, Self::Value) {

--- a/src/librustc_codegen_llvm/context.rs
+++ b/src/librustc_codegen_llvm/context.rs
@@ -144,7 +144,7 @@ pub fn is_pie_binary(sess: &Session) -> bool {
 }
 
 pub unsafe fn create_module(
-    tcx: TyCtxt,
+    tcx: TyCtxt<'_, '_, '_>,
     llcx: &'ll llvm::Context,
     mod_name: &str,
 ) -> &'ll llvm::Module {

--- a/src/librustc_codegen_llvm/debuginfo/create_scope_map.rs
+++ b/src/librustc_codegen_llvm/debuginfo/create_scope_map.rs
@@ -20,7 +20,7 @@ use syntax_pos::BytePos;
 /// If debuginfo is disabled, the returned vector is empty.
 pub fn create_mir_scopes(
     cx: &CodegenCx<'ll, '_>,
-    mir: &Mir,
+    mir: &Mir<'_>,
     debug_context: &FunctionDebugContext<&'ll DISubprogram>,
 ) -> IndexVec<SourceScope, MirDebugScope<&'ll DIScope>> {
     let null_scope = MirDebugScope {
@@ -55,7 +55,7 @@ pub fn create_mir_scopes(
 }
 
 fn make_mir_scope(cx: &CodegenCx<'ll, '_>,
-                  mir: &Mir,
+                  mir: &Mir<'_>,
                   has_variables: &BitSet<SourceScope>,
                   debug_context: &FunctionDebugContextData<&'ll DISubprogram>,
                   scope: SourceScope,

--- a/src/librustc_codegen_llvm/debuginfo/gdb.rs
+++ b/src/librustc_codegen_llvm/debuginfo/gdb.rs
@@ -13,7 +13,7 @@ use syntax::attr;
 
 /// Inserts a side-effect free instruction sequence that makes sure that the
 /// .debug_gdb_scripts global is referenced, so it isn't removed by the linker.
-pub fn insert_reference_to_gdb_debug_scripts_section_global(bx: &mut Builder) {
+pub fn insert_reference_to_gdb_debug_scripts_section_global(bx: &mut Builder<'_, '_, '_>) {
     if needs_gdb_debug_scripts_section(bx) {
         let gdb_debug_scripts_section = get_or_insert_gdb_debug_scripts_section_global(bx);
         // Load just the first byte as that's all that's necessary to force
@@ -64,7 +64,7 @@ pub fn get_or_insert_gdb_debug_scripts_section_global(cx: &CodegenCx<'ll, '_>)
     })
 }
 
-pub fn needs_gdb_debug_scripts_section(cx: &CodegenCx) -> bool {
+pub fn needs_gdb_debug_scripts_section(cx: &CodegenCx<'_, '_>) -> bool {
     let omit_gdb_pretty_printer_section =
         attr::contains_name(&cx.tcx.hir().krate_attrs(),
                             "omit_gdb_pretty_printer_section");

--- a/src/librustc_codegen_llvm/debuginfo/metadata.rs
+++ b/src/librustc_codegen_llvm/debuginfo/metadata.rs
@@ -60,7 +60,7 @@ impl Hash for llvm::Metadata {
 }
 
 impl fmt::Debug for llvm::Metadata {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         (self as *const Self).fmt(f)
     }
 }
@@ -817,7 +817,7 @@ fn pointer_type_metadata(
     }
 }
 
-pub fn compile_unit_metadata(tcx: TyCtxt,
+pub fn compile_unit_metadata(tcx: TyCtxt<'_, '_, '_>,
                              codegen_unit_name: &str,
                              debug_context: &CrateDebugContext<'ll, '_>)
                              -> &'ll DIDescriptor {
@@ -1162,7 +1162,7 @@ fn prepare_union_metadata(
 // sometimes emit the old style rather than emit something completely
 // useless when rust is compiled against LLVM 6 or older.  This
 // function decides which representation will be emitted.
-fn use_enum_fallback(cx: &CodegenCx) -> bool {
+fn use_enum_fallback(cx: &CodegenCx<'_, '_>) -> bool {
     // On MSVC we have to use the fallback mode, because LLVM doesn't
     // lower variant parts to PDB.
     return cx.sess().target.target.options.is_like_msvc
@@ -1736,7 +1736,7 @@ fn prepare_enum_metadata(
         }),
     );
 
-    fn get_enum_discriminant_name(cx: &CodegenCx,
+    fn get_enum_discriminant_name(cx: &CodegenCx<'_, '_>,
                                   def_id: DefId)
                                   -> InternedString {
         cx.tcx.item_name(def_id)
@@ -1863,7 +1863,7 @@ fn compute_type_parameters(cx: &CodegenCx<'ll, 'tcx>, ty: Ty<'tcx>) -> Option<&'
     }
     return Some(create_DIArray(DIB(cx), &[]));
 
-    fn get_parameter_names(cx: &CodegenCx,
+    fn get_parameter_names(cx: &CodegenCx<'_, '_>,
                            generics: &ty::Generics)
                            -> Vec<InternedString> {
         let mut names = generics.parent.map_or(vec![], |def_id| {

--- a/src/librustc_codegen_llvm/debuginfo/mod.rs
+++ b/src/librustc_codegen_llvm/debuginfo/mod.rs
@@ -103,7 +103,7 @@ impl<'a, 'tcx> CrateDebugContext<'a, 'tcx> {
 }
 
 /// Creates any deferred debug metadata nodes
-pub fn finalize(cx: &CodegenCx) {
+pub fn finalize(cx: &CodegenCx<'_, '_>) {
     if cx.dbg_cx.is_none() {
         return;
     }
@@ -233,7 +233,7 @@ impl DebugInfoMethods<'tcx> for CodegenCx<'ll, 'tcx> {
         instance: Instance<'tcx>,
         sig: ty::FnSig<'tcx>,
         llfn: &'ll Value,
-        mir: &mir::Mir,
+        mir: &mir::Mir<'_>,
     ) -> FunctionDebugContext<&'ll DISubprogram> {
         if self.sess().opts.debuginfo == DebugInfo::None {
             return FunctionDebugContext::DebugInfoDisabled;
@@ -455,7 +455,7 @@ impl DebugInfoMethods<'tcx> for CodegenCx<'ll, 'tcx> {
             return create_DIArray(DIB(cx), &template_params[..]);
         }
 
-        fn get_parameter_names(cx: &CodegenCx,
+        fn get_parameter_names(cx: &CodegenCx<'_, '_>,
                                generics: &ty::Generics)
                                -> Vec<InternedString> {
             let mut names = generics.parent.map_or(vec![], |def_id| {
@@ -518,7 +518,7 @@ impl DebugInfoMethods<'tcx> for CodegenCx<'ll, 'tcx> {
 
     fn create_mir_scopes(
         &self,
-        mir: &mir::Mir,
+        mir: &mir::Mir<'_>,
         debug_context: &FunctionDebugContext<&'ll DISubprogram>,
     ) -> IndexVec<mir::SourceScope, MirDebugScope<&'ll DIScope>> {
         create_scope_map::create_mir_scopes(self, mir, debug_context)

--- a/src/librustc_codegen_llvm/debuginfo/type_names.rs
+++ b/src/librustc_codegen_llvm/debuginfo/type_names.rs
@@ -178,7 +178,7 @@ pub fn push_debuginfo_type_name<'a, 'tcx>(cx: &CodegenCx<'a, 'tcx>,
         }
     }
 
-    fn push_item_name(cx: &CodegenCx,
+    fn push_item_name(cx: &CodegenCx<'_, '_>,
                       def_id: DefId,
                       qualified: bool,
                       output: &mut String) {

--- a/src/librustc_codegen_llvm/debuginfo/utils.rs
+++ b/src/librustc_codegen_llvm/debuginfo/utils.rs
@@ -13,7 +13,7 @@ use rustc_codegen_ssa::traits::*;
 
 use syntax_pos::Span;
 
-pub fn is_node_local_to_unit(cx: &CodegenCx, def_id: DefId) -> bool
+pub fn is_node_local_to_unit(cx: &CodegenCx<'_, '_>, def_id: DefId) -> bool
 {
     // The is_local_to_unit flag indicates whether a function is local to the
     // current compilation unit (i.e., if it is *static* in the C-sense). The
@@ -37,7 +37,7 @@ pub fn create_DIArray(
 }
 
 /// Returns syntax_pos::Loc corresponding to the beginning of the span
-pub fn span_start(cx: &CodegenCx, span: Span) -> syntax_pos::Loc {
+pub fn span_start(cx: &CodegenCx<'_, '_>, span: Span) -> syntax_pos::Loc {
     cx.sess().source_map().lookup_char_pos(span.lo())
 }
 

--- a/src/librustc_codegen_llvm/intrinsic.rs
+++ b/src/librustc_codegen_llvm/intrinsic.rs
@@ -1251,8 +1251,8 @@ fn generic_simd_intrinsic(
 
     fn simd_simple_float_intrinsic(
         name: &str,
-        in_elem: &::rustc::ty::TyS,
-        in_ty: &::rustc::ty::TyS,
+        in_elem: &::rustc::ty::TyS<'_>,
+        in_ty: &::rustc::ty::TyS<'_>,
         in_len: usize,
         bx: &mut Builder<'a, 'll, 'tcx>,
         span: Span,
@@ -1362,7 +1362,7 @@ fn generic_simd_intrinsic(
     // FIXME: use:
     //  https://github.com/llvm-mirror/llvm/blob/master/include/llvm/IR/Function.h#L182
     //  https://github.com/llvm-mirror/llvm/blob/master/include/llvm/IR/Intrinsics.h#L81
-    fn llvm_vector_str(elem_ty: ty::Ty, vec_len: usize, no_pointers: usize) -> String {
+    fn llvm_vector_str(elem_ty: ty::Ty<'_>, vec_len: usize, no_pointers: usize) -> String {
         let p0s: String = "p0".repeat(no_pointers);
         match elem_ty.sty {
             ty::Int(v) => format!("v{}{}i{}", vec_len, p0s, v.bit_width().unwrap()),
@@ -1372,7 +1372,7 @@ fn generic_simd_intrinsic(
         }
     }
 
-    fn llvm_vector_ty(cx: &CodegenCx<'ll, '_>, elem_ty: ty::Ty, vec_len: usize,
+    fn llvm_vector_ty(cx: &CodegenCx<'ll, '_>, elem_ty: ty::Ty<'_>, vec_len: usize,
                       mut no_pointers: usize) -> &'ll Type {
         // FIXME: use cx.layout_of(ty).llvm_type() ?
         let mut elem_ty = match elem_ty.sty {
@@ -1418,7 +1418,7 @@ fn generic_simd_intrinsic(
                  in_ty, ret_ty);
 
         // This counts how many pointers
-        fn ptr_count(t: ty::Ty) -> usize {
+        fn ptr_count(t: ty::Ty<'_>) -> usize {
             match t.sty {
                 ty::RawPtr(p) => 1 + ptr_count(p.ty),
                 _ => 0,
@@ -1426,7 +1426,7 @@ fn generic_simd_intrinsic(
         }
 
         // Non-ptr type
-        fn non_ptr(t: ty::Ty) -> ty::Ty {
+        fn non_ptr(t: ty::Ty<'_>) -> ty::Ty<'_> {
             match t.sty {
                 ty::RawPtr(p) => non_ptr(p.ty),
                 _ => t,
@@ -1517,7 +1517,7 @@ fn generic_simd_intrinsic(
                  arg_tys[2].simd_size(tcx));
 
         // This counts how many pointers
-        fn ptr_count(t: ty::Ty) -> usize {
+        fn ptr_count(t: ty::Ty<'_>) -> usize {
             match t.sty {
                 ty::RawPtr(p) => 1 + ptr_count(p.ty),
                 _ => 0,
@@ -1525,7 +1525,7 @@ fn generic_simd_intrinsic(
         }
 
         // Non-ptr type
-        fn non_ptr(t: ty::Ty) -> ty::Ty {
+        fn non_ptr(t: ty::Ty<'_>) -> ty::Ty<'_> {
             match t.sty {
                 ty::RawPtr(p) => non_ptr(p.ty),
                 _ => t,
@@ -1901,7 +1901,7 @@ unsupported {} from `{}` with element `{}` of size `{}` to `{}`"#,
 // Returns None if the type is not an integer
 // FIXME: there’s multiple of this functions, investigate using some of the already existing
 // stuffs.
-fn int_type_width_signed(ty: Ty, cx: &CodegenCx) -> Option<(u64, bool)> {
+fn int_type_width_signed(ty: Ty<'_>, cx: &CodegenCx<'_, '_>) -> Option<(u64, bool)> {
     match ty.sty {
         ty::Int(t) => Some((match t {
             ast::IntTy::Isize => cx.tcx.sess.target.isize_ty.bit_width().unwrap() as u64,

--- a/src/librustc_codegen_llvm/llvm/archive_ro.rs
+++ b/src/librustc_codegen_llvm/llvm/archive_ro.rs
@@ -36,7 +36,7 @@ impl ArchiveRO {
         };
     }
 
-    pub fn iter(&self) -> Iter {
+    pub fn iter(&self) -> Iter<'_> {
         unsafe {
             Iter {
                 raw: super::LLVMRustArchiveIteratorNew(self.raw),

--- a/src/librustc_codegen_llvm/llvm/ffi.rs
+++ b/src/librustc_codegen_llvm/llvm/ffi.rs
@@ -1283,7 +1283,7 @@ extern "C" {
                               SingleThreaded: Bool)
                               -> &'a Value;
 
-    pub fn LLVMRustBuildAtomicFence(B: &Builder,
+    pub fn LLVMRustBuildAtomicFence(B: &Builder<'_>,
                                     Order: AtomicOrdering,
                                     Scope: SynchronizationScope);
 
@@ -1311,17 +1311,17 @@ extern "C" {
     pub fn LLVMPassManagerBuilderUseInlinerWithThreshold(PMB: &PassManagerBuilder,
                                                          threshold: c_uint);
     pub fn LLVMPassManagerBuilderPopulateModulePassManager(PMB: &PassManagerBuilder,
-                                                           PM: &PassManager);
+                                                           PM: &PassManager<'_>);
 
     pub fn LLVMPassManagerBuilderPopulateFunctionPassManager(PMB: &PassManagerBuilder,
-                                                             PM: &PassManager);
+                                                             PM: &PassManager<'_>);
     pub fn LLVMPassManagerBuilderPopulateLTOPassManager(PMB: &PassManagerBuilder,
-                                                        PM: &PassManager,
+                                                        PM: &PassManager<'_>,
                                                         Internalize: Bool,
                                                         RunInliner: Bool);
     pub fn LLVMRustPassManagerBuilderPopulateThinLTOPassManager(
         PMB: &PassManagerBuilder,
-        PM: &PassManager);
+        PM: &PassManager<'_>);
 
     // Stuff that's in rustllvm/ because it's not upstream yet.
 
@@ -1340,11 +1340,11 @@ extern "C" {
     /// list:
     pub fn LLVMIsSectionIteratorAtEnd(ObjFile: &'a ObjectFile, SI: &SectionIterator<'a>) -> Bool;
     /// Moves the section iterator to point to the next section.
-    pub fn LLVMMoveToNextSection(SI: &SectionIterator);
+    pub fn LLVMMoveToNextSection(SI: &SectionIterator<'_>);
     /// Returns the current section size.
-    pub fn LLVMGetSectionSize(SI: &SectionIterator) -> c_ulonglong;
+    pub fn LLVMGetSectionSize(SI: &SectionIterator<'_>) -> c_ulonglong;
     /// Returns the current section contents as a string buffer.
-    pub fn LLVMGetSectionContents(SI: &SectionIterator) -> *const c_char;
+    pub fn LLVMGetSectionContents(SI: &SectionIterator<'_>) -> *const c_char;
 
     /// Reads the given file and returns it as a memory buffer. Use
     /// LLVMDisposeMemoryBuffer() to get rid of it.
@@ -1392,7 +1392,7 @@ extern "C" {
 
     pub fn LLVMRustDIBuilderDispose(Builder: &'a mut DIBuilder<'a>);
 
-    pub fn LLVMRustDIBuilderFinalize(Builder: &DIBuilder);
+    pub fn LLVMRustDIBuilderFinalize(Builder: &DIBuilder<'_>);
 
     pub fn LLVMRustDIBuilderCreateCompileUnit(Builder: &DIBuilder<'a>,
                                               Lang: c_uint,
@@ -1635,7 +1635,7 @@ extern "C" {
 
     pub fn LLVMRustPassKind(Pass: &Pass) -> PassKind;
     pub fn LLVMRustFindAndCreatePass(Pass: *const c_char) -> Option<&'static mut Pass>;
-    pub fn LLVMRustAddPass(PM: &PassManager, Pass: &'static mut Pass);
+    pub fn LLVMRustAddPass(PM: &PassManager<'_>, Pass: &'static mut Pass);
 
     pub fn LLVMRustHasFeature(T: &TargetMachine, s: *const c_char) -> bool;
 
@@ -1700,13 +1700,13 @@ extern "C" {
     pub fn LLVMRustArchiveIteratorNext(
         AIR: &ArchiveIterator<'a>,
     ) -> Option<&'a mut ArchiveChild<'a>>;
-    pub fn LLVMRustArchiveChildName(ACR: &ArchiveChild, size: &mut size_t) -> *const c_char;
-    pub fn LLVMRustArchiveChildData(ACR: &ArchiveChild, size: &mut size_t) -> *const c_char;
+    pub fn LLVMRustArchiveChildName(ACR: &ArchiveChild<'_>, size: &mut size_t) -> *const c_char;
+    pub fn LLVMRustArchiveChildData(ACR: &ArchiveChild<'_>, size: &mut size_t) -> *const c_char;
     pub fn LLVMRustArchiveChildFree(ACR: &'a mut ArchiveChild<'a>);
     pub fn LLVMRustArchiveIteratorFree(AIR: &'a mut ArchiveIterator<'a>);
     pub fn LLVMRustDestroyArchive(AR: &'static mut Archive);
 
-    pub fn LLVMRustGetSectionName(SI: &SectionIterator, data: &mut *const c_char) -> size_t;
+    pub fn LLVMRustGetSectionName(SI: &SectionIterator<'_>, data: &mut *const c_char) -> size_t;
 
     #[allow(improper_ctypes)]
     pub fn LLVMRustWriteTwineToString(T: &Twine, s: &RustString);
@@ -1742,7 +1742,7 @@ extern "C" {
 
     pub fn LLVMRustWriteArchive(Dst: *const c_char,
                                 NumMembers: size_t,
-                                Members: *const &RustArchiveMember,
+                                Members: *const &RustArchiveMember<'_>,
                                 WriteSymbtab: bool,
                                 Kind: ArchiveKind)
                                 -> LLVMRustResult;
@@ -1815,7 +1815,7 @@ extern "C" {
     pub fn LLVMRustThinLTOPatchDICompileUnit(M: &Module, CU: *mut c_void);
 
     pub fn LLVMRustLinkerNew(M: &'a Module) -> &'a mut Linker<'a>;
-    pub fn LLVMRustLinkerAdd(linker: &Linker,
+    pub fn LLVMRustLinkerAdd(linker: &Linker<'_>,
                              bytecode: *const c_char,
                              bytecode_len: usize) -> bool;
     pub fn LLVMRustLinkerFree(linker: &'a mut Linker<'a>);

--- a/src/librustc_codegen_llvm/type_.rs
+++ b/src/librustc_codegen_llvm/type_.rs
@@ -31,7 +31,7 @@ impl PartialEq for Type {
 }
 
 impl fmt::Debug for Type {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&llvm::build_string(|s| unsafe {
             llvm::LLVMRustWriteTypeToString(self, s);
         }).expect("non-UTF8 type description from LLVM"))

--- a/src/librustc_codegen_llvm/value.rs
+++ b/src/librustc_codegen_llvm/value.rs
@@ -22,7 +22,7 @@ impl Hash for Value {
 
 
 impl fmt::Debug for Value {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&llvm::build_string(|s| unsafe {
             llvm::LLVMRustWriteValueToString(self, s);
         }).expect("non-UTF8 value description from LLVM"))


### PR DESCRIPTION
As part of the Rust 2018 transition, remove `#![allow(elided_lifetimes_in_paths)]` from `librustc_codegen_llvm`.

r? @oli-obk 