### PR TITLE
librustc: deny(elided_lifetimes_in_paths)

### DIFF
--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -62,8 +62,6 @@
 
 #![recursion_limit="512"]
 
-#![warn(elided_lifetimes_in_paths)]
-
 #[macro_use] extern crate bitflags;
 extern crate getopts;
 #[macro_use] extern crate lazy_static;


### PR DESCRIPTION
As part of the Rust 2018 transition, remove `#![allow(elided_lifetimes_in_paths)]` from `librustc`.

r? @oli-obk 