### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/src/doc/rustc/src/lints/listing/deny-by-default.md
+++ b/src/doc/rustc/src/lints/listing/deny-by-default.md
@@ -149,6 +149,26 @@ error: const items should never be #[no_mangle]
   |
 ```
 
+## overflowing-literals
+
+This lint detects literal out of range for its type. Some
+example code that triggers this lint:
+
+```rust,compile_fail
+let x: u8 = 1000;
+```
+
+This will produce:
+
+```text
+error: literal out of range for u8
+ --> src/main.rs:2:17
+  |
+2 |     let x: u8 = 1000;
+  |                 ^^^^
+  |
+```
+
 ## parenthesized-params-in-types-and-modules
 
 This lint detects incorrect parentheses. Some example code that triggers this

--- a/src/doc/rustc/src/lints/listing/warn-by-default.md
+++ b/src/doc/rustc/src/lints/listing/warn-by-default.md
@@ -285,26 +285,6 @@ warning: functions generic over types must be mangled
   |
 ```
 
-## overflowing-literals
-
-This lint detects literal out of range for its type. Some
-example code that triggers this lint:
-
-```rust
-let x: u8 = 1000;
-```
-
-This will produce:
-
-```text
-warning: literal out of range for u8
- --> src/main.rs:2:17
-  |
-2 |     let x: u8 = 1000;
-  |                 ^^^^
-  |
-```
-
 ## path-statements
 
 This lint detects path statements with no effect. Some example code that

--- a/src/libcore/alloc.rs
+++ b/src/libcore/alloc.rs
@@ -420,7 +420,7 @@ impl fmt::Display for CannotReallocInPlace {
 /// }
 /// ```
 ///
-/// # Unsafety
+/// # Safety
 ///
 /// The `GlobalAlloc` trait is an `unsafe` trait for a number of reasons, and
 /// implementors must ensure that they adhere to these contracts:
@@ -643,7 +643,7 @@ pub unsafe trait GlobalAlloc {
 ///    currently allocated via an allocator `a`, then it is legal to
 ///    use that layout to deallocate it, i.e., `a.dealloc(ptr, k);`.
 ///
-/// # Unsafety
+/// # Safety
 ///
 /// The `Alloc` trait is an `unsafe` trait for a number of reasons, and
 /// implementors must ensure that they adhere to these contracts:

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -1173,7 +1173,7 @@ impl<T> MaybeUninit<T> {
     /// to ensure that the data will get dropped, because the resulting `T` is
     /// subject to the usual drop handling.
     ///
-    /// # Unsafety
+    /// # Safety
     ///
     /// It is up to the caller to guarantee that the `MaybeUninit` really is in an initialized
     /// state. Calling this when the content is not yet fully initialized causes undefined
@@ -1187,7 +1187,7 @@ impl<T> MaybeUninit<T> {
 
     /// Gets a reference to the contained value.
     ///
-    /// # Unsafety
+    /// # Safety
     ///
     /// It is up to the caller to guarantee that the `MaybeUninit` really is in an initialized
     /// state. Calling this when the content is not yet fully initialized causes undefined
@@ -1200,7 +1200,7 @@ impl<T> MaybeUninit<T> {
 
     /// Gets a mutable reference to the contained value.
     ///
-    /// # Unsafety
+    /// # Safety
     ///
     /// It is up to the caller to guarantee that the `MaybeUninit` really is in an initialized
     /// state. Calling this when the content is not yet fully initialized causes undefined

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -2158,7 +2158,7 @@ impl<T> [T] {
     /// This method has no purpose when either input element `T` or output element `U` are
     /// zero-sized and will return the original slice without splitting anything.
     ///
-    /// # Unsafety
+    /// # Safety
     ///
     /// This method is essentially a `transmute` with respect to the elements in the returned
     /// middle slice, so all the usual caveats pertaining to `transmute::<T, U>` also apply here.
@@ -2211,7 +2211,7 @@ impl<T> [T] {
     /// This method has no purpose when either input element `T` or output element `U` are
     /// zero-sized and will return the original slice without splitting anything.
     ///
-    /// # Unsafety
+    /// # Safety
     ///
     /// This method is essentially a `transmute` with respect to the elements in the returned
     /// middle slice, so all the usual caveats pertaining to `transmute::<T, U>` also apply here.

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -62,8 +62,6 @@
 
 #![recursion_limit="512"]
 
-#![warn(elided_lifetimes_in_paths)]
-
 #[macro_use] extern crate bitflags;
 extern crate getopts;
 #[macro_use] extern crate lazy_static;

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -3,7 +3,7 @@
 use crate::hir;
 use crate::hir::def_id::DefId;
 use crate::infer::canonical::Canonical;
-use crate::mir::interpret::ConstValue;
+use crate::mir::interpret::{ConstValue, truncate};
 use crate::middle::region;
 use polonius_engine::Atom;
 use rustc_data_structures::indexed_vec::Idx;
@@ -2118,8 +2118,7 @@ impl<'tcx> Const<'tcx> {
         let size = tcx.layout_of(ty).unwrap_or_else(|e| {
             panic!("could not compute layout for {:?}: {:?}", ty, e)
         }).size;
-        let shift = 128 - size.bits();
-        let truncated = (bits << shift) >> shift;
+        let truncated = truncate(bits, size);
         assert_eq!(truncated, bits, "from_bits called with untruncated value");
         Self::from_scalar(Scalar::Bits { bits, size: size.bytes() as u8 }, ty.value)
     }

--- a/src/librustc_codegen_llvm/allocator.rs
+++ b/src/librustc_codegen_llvm/allocator.rs
@@ -9,7 +9,7 @@ use rustc_allocator::{ALLOCATOR_METHODS, AllocatorTy};
 use crate::ModuleLlvm;
 use crate::llvm::{self, False, True};
 
-pub(crate) unsafe fn codegen(tcx: TyCtxt, mods: &mut ModuleLlvm, kind: AllocatorKind) {
+pub(crate) unsafe fn codegen(tcx: TyCtxt<'_, '_, '_>, mods: &mut ModuleLlvm, kind: AllocatorKind) {
     let llcx = &*mods.llcx;
     let llmod = mods.llmod();
     let usize = match &tcx.sess.target.target.target_pointer_width[..] {

--- a/src/librustc_codegen_llvm/attributes.rs
+++ b/src/librustc_codegen_llvm/attributes.rs
@@ -308,7 +308,7 @@ pub fn from_fn_attrs(
     }
 }
 
-pub fn provide(providers: &mut Providers) {
+pub fn provide(providers: &mut Providers<'_>) {
     providers.target_features_whitelist = |tcx, cnum| {
         assert_eq!(cnum, LOCAL_CRATE);
         if tcx.sess.opts.actually_rustdoc {
@@ -328,7 +328,7 @@ pub fn provide(providers: &mut Providers) {
     provide_extern(providers);
 }
 
-pub fn provide_extern(providers: &mut Providers) {
+pub fn provide_extern(providers: &mut Providers<'_>) {
     providers.wasm_import_module_map = |tcx, cnum| {
         // Build up a map from DefId to a `NativeLibrary` structure, where
         // `NativeLibrary` internally contains information about
@@ -362,7 +362,7 @@ pub fn provide_extern(providers: &mut Providers) {
     };
 }
 
-fn wasm_import_module(tcx: TyCtxt, id: DefId) -> Option<CString> {
+fn wasm_import_module(tcx: TyCtxt<'_, '_, '_>, id: DefId) -> Option<CString> {
     tcx.wasm_import_module_map(id.krate)
         .get(&id)
         .map(|s| CString::new(&s[..]).unwrap())

--- a/src/librustc_codegen_llvm/back/archive.rs
+++ b/src/librustc_codegen_llvm/back/archive.rs
@@ -42,7 +42,7 @@ enum Addition {
     },
 }
 
-fn is_relevant_child(c: &Child) -> bool {
+fn is_relevant_child(c: &Child<'_>) -> bool {
     match c.name() {
         Some(name) => !name.contains("SYMDEF"),
         None => false,

--- a/src/librustc_codegen_llvm/back/link.rs
+++ b/src/librustc_codegen_llvm/back/link.rs
@@ -808,7 +808,7 @@ fn exec_linker(sess: &Session, cmd: &mut Command, out_filename: &Path, tmpdir: &
     }
 
     impl<'a> fmt::Display for Escape<'a> {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             if self.is_like_msvc {
                 // This is "documented" at
                 // https://msdn.microsoft.com/en-us/library/4xdcbak7.aspx

--- a/src/librustc_codegen_llvm/back/rpath.rs
+++ b/src/librustc_codegen_llvm/back/rpath.rs
@@ -15,7 +15,7 @@ pub struct RPathConfig<'a> {
     pub get_install_prefix_lib_path: &'a mut dyn FnMut() -> PathBuf,
 }
 
-pub fn get_rpath_flags(config: &mut RPathConfig) -> Vec<String> {
+pub fn get_rpath_flags(config: &mut RPathConfig<'_>) -> Vec<String> {
     // No rpath on windows
     if !config.has_rpath {
         return Vec::new();
@@ -52,7 +52,7 @@ fn rpaths_to_flags(rpaths: &[String]) -> Vec<String> {
     ret
 }
 
-fn get_rpaths(config: &mut RPathConfig, libs: &[PathBuf]) -> Vec<String> {
+fn get_rpaths(config: &mut RPathConfig<'_>, libs: &[PathBuf]) -> Vec<String> {
     debug!("output: {:?}", config.out_filename.display());
     debug!("libs:");
     for libpath in libs {
@@ -86,12 +86,12 @@ fn get_rpaths(config: &mut RPathConfig, libs: &[PathBuf]) -> Vec<String> {
     rpaths
 }
 
-fn get_rpaths_relative_to_output(config: &mut RPathConfig,
+fn get_rpaths_relative_to_output(config: &mut RPathConfig<'_>,
                                  libs: &[PathBuf]) -> Vec<String> {
     libs.iter().map(|a| get_rpath_relative_to_output(config, a)).collect()
 }
 
-fn get_rpath_relative_to_output(config: &mut RPathConfig, lib: &Path) -> String {
+fn get_rpath_relative_to_output(config: &mut RPathConfig<'_>, lib: &Path) -> String {
     // Mac doesn't appear to support $ORIGIN
     let prefix = if config.is_like_osx {
         "@loader_path"
@@ -127,7 +127,7 @@ fn path_relative_from(path: &Path, base: &Path) -> Option<PathBuf> {
     } else {
         let mut ita = path.components();
         let mut itb = base.components();
-        let mut comps: Vec<Component> = vec![];
+        let mut comps: Vec<Component<'_>> = vec![];
         loop {
             match (ita.next(), itb.next()) {
                 (None, None) => break,
@@ -154,7 +154,7 @@ fn path_relative_from(path: &Path, base: &Path) -> Option<PathBuf> {
 }
 
 
-fn get_install_prefix_rpath(config: &mut RPathConfig) -> String {
+fn get_install_prefix_rpath(config: &mut RPathConfig<'_>) -> String {
     let path = (config.get_install_prefix_lib_path)();
     let path = env::current_dir().unwrap().join(&path);
     // FIXME (#9639): This needs to handle non-utf8 paths

--- a/src/librustc_codegen_llvm/back/wasm.rs
+++ b/src/librustc_codegen_llvm/back/wasm.rs
@@ -60,7 +60,7 @@ pub fn rewrite_imports(path: &Path, import_map: &FxHashMap<String, String>) {
     fs::write(path, &ret.data).expect("failed to write wasm output");
 
     fn rewrite_import_section(
-        wasm: &mut WasmDecoder,
+        wasm: &mut WasmDecoder<'_>,
         import_map: &FxHashMap<String, String>,
     )
         -> Vec<u8>
@@ -75,7 +75,7 @@ pub fn rewrite_imports(path: &Path, import_map: &FxHashMap<String, String>) {
         return dst.data
     }
 
-    fn rewrite_import_entry(wasm: &mut WasmDecoder,
+    fn rewrite_import_entry(wasm: &mut WasmDecoder<'_>,
                             dst: &mut WasmEncoder,
                             import_map: &FxHashMap<String, String>) {
         // More info about the binary format here is available at:

--- a/src/librustc_codegen_llvm/back/write.rs
+++ b/src/librustc_codegen_llvm/back/write.rs
@@ -83,7 +83,7 @@ pub fn write_output_file(
 }
 
 pub fn create_target_machine(
-    tcx: TyCtxt,
+    tcx: TyCtxt<'_, '_, '_>,
     find_features: bool,
 ) -> &'static mut llvm::TargetMachine {
     target_machine_factory(tcx.sess, tcx.backend_optimization_level(LOCAL_CRATE), find_features)()

--- a/src/librustc_codegen_llvm/base.rs
+++ b/src/librustc_codegen_llvm/base.rs
@@ -172,17 +172,17 @@ pub fn compile_codegen_unit<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
             let mono_items = cx.codegen_unit
                                .items_in_deterministic_order(cx.tcx);
             for &(mono_item, (linkage, visibility)) in &mono_items {
-                mono_item.predefine::<Builder>(&cx, linkage, visibility);
+                mono_item.predefine::<Builder<'_, '_, '_>>(&cx, linkage, visibility);
             }
 
             // ... and now that we have everything pre-defined, fill out those definitions.
             for &(mono_item, _) in &mono_items {
-                mono_item.define::<Builder>(&cx);
+                mono_item.define::<Builder<'_, '_, '_>>(&cx);
             }
 
             // If this codegen unit contains the main function, also create the
             // wrapper here
-            maybe_create_entry_wrapper::<Builder>(&cx);
+            maybe_create_entry_wrapper::<Builder<'_, '_, '_>>(&cx);
 
             // Run replace-all-uses-with for statics that need it
             for &(old_g, new_g) in cx.statics_to_rauw().borrow().iter() {

--- a/src/librustc_codegen_llvm/builder.rs
+++ b/src/librustc_codegen_llvm/builder.rs
@@ -456,7 +456,7 @@ impl BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
     fn checked_binop(
         &mut self,
         oop: OverflowOp,
-        ty: Ty,
+        ty: Ty<'_>,
         lhs: Self::Value,
         rhs: Self::Value,
     ) -> (Self::Value, Self::Value) {

--- a/src/librustc_codegen_llvm/context.rs
+++ b/src/librustc_codegen_llvm/context.rs
@@ -144,7 +144,7 @@ pub fn is_pie_binary(sess: &Session) -> bool {
 }
 
 pub unsafe fn create_module(
-    tcx: TyCtxt,
+    tcx: TyCtxt<'_, '_, '_>,
     llcx: &'ll llvm::Context,
     mod_name: &str,
 ) -> &'ll llvm::Module {

--- a/src/librustc_codegen_llvm/debuginfo/create_scope_map.rs
+++ b/src/librustc_codegen_llvm/debuginfo/create_scope_map.rs
@@ -20,7 +20,7 @@ use syntax_pos::BytePos;
 /// If debuginfo is disabled, the returned vector is empty.
 pub fn create_mir_scopes(
     cx: &CodegenCx<'ll, '_>,
-    mir: &Mir,
+    mir: &Mir<'_>,
     debug_context: &FunctionDebugContext<&'ll DISubprogram>,
 ) -> IndexVec<SourceScope, MirDebugScope<&'ll DIScope>> {
     let null_scope = MirDebugScope {
@@ -55,7 +55,7 @@ pub fn create_mir_scopes(
 }
 
 fn make_mir_scope(cx: &CodegenCx<'ll, '_>,
-                  mir: &Mir,
+                  mir: &Mir<'_>,
                   has_variables: &BitSet<SourceScope>,
                   debug_context: &FunctionDebugContextData<&'ll DISubprogram>,
                   scope: SourceScope,

--- a/src/librustc_codegen_llvm/debuginfo/gdb.rs
+++ b/src/librustc_codegen_llvm/debuginfo/gdb.rs
@@ -13,7 +13,7 @@ use syntax::attr;
 
 /// Inserts a side-effect free instruction sequence that makes sure that the
 /// .debug_gdb_scripts global is referenced, so it isn't removed by the linker.
-pub fn insert_reference_to_gdb_debug_scripts_section_global(bx: &mut Builder) {
+pub fn insert_reference_to_gdb_debug_scripts_section_global(bx: &mut Builder<'_, '_, '_>) {
     if needs_gdb_debug_scripts_section(bx) {
         let gdb_debug_scripts_section = get_or_insert_gdb_debug_scripts_section_global(bx);
         // Load just the first byte as that's all that's necessary to force
@@ -64,7 +64,7 @@ pub fn get_or_insert_gdb_debug_scripts_section_global(cx: &CodegenCx<'ll, '_>)
     })
 }
 
-pub fn needs_gdb_debug_scripts_section(cx: &CodegenCx) -> bool {
+pub fn needs_gdb_debug_scripts_section(cx: &CodegenCx<'_, '_>) -> bool {
     let omit_gdb_pretty_printer_section =
         attr::contains_name(&cx.tcx.hir().krate_attrs(),
                             "omit_gdb_pretty_printer_section");

--- a/src/librustc_codegen_llvm/debuginfo/metadata.rs
+++ b/src/librustc_codegen_llvm/debuginfo/metadata.rs
@@ -60,7 +60,7 @@ impl Hash for llvm::Metadata {
 }
 
 impl fmt::Debug for llvm::Metadata {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         (self as *const Self).fmt(f)
     }
 }
@@ -817,7 +817,7 @@ fn pointer_type_metadata(
     }
 }
 
-pub fn compile_unit_metadata(tcx: TyCtxt,
+pub fn compile_unit_metadata(tcx: TyCtxt<'_, '_, '_>,
                              codegen_unit_name: &str,
                              debug_context: &CrateDebugContext<'ll, '_>)
                              -> &'ll DIDescriptor {
@@ -1162,7 +1162,7 @@ fn prepare_union_metadata(
 // sometimes emit the old style rather than emit something completely
 // useless when rust is compiled against LLVM 6 or older.  This
 // function decides which representation will be emitted.
-fn use_enum_fallback(cx: &CodegenCx) -> bool {
+fn use_enum_fallback(cx: &CodegenCx<'_, '_>) -> bool {
     // On MSVC we have to use the fallback mode, because LLVM doesn't
     // lower variant parts to PDB.
     return cx.sess().target.target.options.is_like_msvc
@@ -1736,7 +1736,7 @@ fn prepare_enum_metadata(
         }),
     );
 
-    fn get_enum_discriminant_name(cx: &CodegenCx,
+    fn get_enum_discriminant_name(cx: &CodegenCx<'_, '_>,
                                   def_id: DefId)
                                   -> InternedString {
         cx.tcx.item_name(def_id)
@@ -1863,7 +1863,7 @@ fn compute_type_parameters(cx: &CodegenCx<'ll, 'tcx>, ty: Ty<'tcx>) -> Option<&'
     }
     return Some(create_DIArray(DIB(cx), &[]));
 
-    fn get_parameter_names(cx: &CodegenCx,
+    fn get_parameter_names(cx: &CodegenCx<'_, '_>,
                            generics: &ty::Generics)
                            -> Vec<InternedString> {
         let mut names = generics.parent.map_or(vec![], |def_id| {

--- a/src/librustc_codegen_llvm/debuginfo/mod.rs
+++ b/src/librustc_codegen_llvm/debuginfo/mod.rs
@@ -103,7 +103,7 @@ impl<'a, 'tcx> CrateDebugContext<'a, 'tcx> {
 }
 
 /// Creates any deferred debug metadata nodes
-pub fn finalize(cx: &CodegenCx) {
+pub fn finalize(cx: &CodegenCx<'_, '_>) {
     if cx.dbg_cx.is_none() {
         return;
     }
@@ -233,7 +233,7 @@ impl DebugInfoMethods<'tcx> for CodegenCx<'ll, 'tcx> {
         instance: Instance<'tcx>,
         sig: ty::FnSig<'tcx>,
         llfn: &'ll Value,
-        mir: &mir::Mir,
+        mir: &mir::Mir<'_>,
     ) -> FunctionDebugContext<&'ll DISubprogram> {
         if self.sess().opts.debuginfo == DebugInfo::None {
             return FunctionDebugContext::DebugInfoDisabled;
@@ -455,7 +455,7 @@ impl DebugInfoMethods<'tcx> for CodegenCx<'ll, 'tcx> {
             return create_DIArray(DIB(cx), &template_params[..]);
         }
 
-        fn get_parameter_names(cx: &CodegenCx,
+        fn get_parameter_names(cx: &CodegenCx<'_, '_>,
                                generics: &ty::Generics)
                                -> Vec<InternedString> {
             let mut names = generics.parent.map_or(vec![], |def_id| {
@@ -518,7 +518,7 @@ impl DebugInfoMethods<'tcx> for CodegenCx<'ll, 'tcx> {
 
     fn create_mir_scopes(
         &self,
-        mir: &mir::Mir,
+        mir: &mir::Mir<'_>,
         debug_context: &FunctionDebugContext<&'ll DISubprogram>,
     ) -> IndexVec<mir::SourceScope, MirDebugScope<&'ll DIScope>> {
         create_scope_map::create_mir_scopes(self, mir, debug_context)

--- a/src/librustc_codegen_llvm/debuginfo/type_names.rs
+++ b/src/librustc_codegen_llvm/debuginfo/type_names.rs
@@ -178,7 +178,7 @@ pub fn push_debuginfo_type_name<'a, 'tcx>(cx: &CodegenCx<'a, 'tcx>,
         }
     }
 
-    fn push_item_name(cx: &CodegenCx,
+    fn push_item_name(cx: &CodegenCx<'_, '_>,
                       def_id: DefId,
                       qualified: bool,
                       output: &mut String) {

--- a/src/librustc_codegen_llvm/debuginfo/utils.rs
+++ b/src/librustc_codegen_llvm/debuginfo/utils.rs
@@ -13,7 +13,7 @@ use rustc_codegen_ssa::traits::*;
 
 use syntax_pos::Span;
 
-pub fn is_node_local_to_unit(cx: &CodegenCx, def_id: DefId) -> bool
+pub fn is_node_local_to_unit(cx: &CodegenCx<'_, '_>, def_id: DefId) -> bool
 {
     // The is_local_to_unit flag indicates whether a function is local to the
     // current compilation unit (i.e., if it is *static* in the C-sense). The
@@ -37,7 +37,7 @@ pub fn create_DIArray(
 }
 
 /// Returns syntax_pos::Loc corresponding to the beginning of the span
-pub fn span_start(cx: &CodegenCx, span: Span) -> syntax_pos::Loc {
+pub fn span_start(cx: &CodegenCx<'_, '_>, span: Span) -> syntax_pos::Loc {
     cx.sess().source_map().lookup_char_pos(span.lo())
 }
 

--- a/src/librustc_codegen_llvm/intrinsic.rs
+++ b/src/librustc_codegen_llvm/intrinsic.rs
@@ -1251,8 +1251,8 @@ fn generic_simd_intrinsic(
 
     fn simd_simple_float_intrinsic(
         name: &str,
-        in_elem: &::rustc::ty::TyS,
-        in_ty: &::rustc::ty::TyS,
+        in_elem: &::rustc::ty::TyS<'_>,
+        in_ty: &::rustc::ty::TyS<'_>,
         in_len: usize,
         bx: &mut Builder<'a, 'll, 'tcx>,
         span: Span,
@@ -1362,7 +1362,7 @@ fn generic_simd_intrinsic(
     // FIXME: use:
     //  https://github.com/llvm-mirror/llvm/blob/master/include/llvm/IR/Function.h#L182
     //  https://github.com/llvm-mirror/llvm/blob/master/include/llvm/IR/Intrinsics.h#L81
-    fn llvm_vector_str(elem_ty: ty::Ty, vec_len: usize, no_pointers: usize) -> String {
+    fn llvm_vector_str(elem_ty: ty::Ty<'_>, vec_len: usize, no_pointers: usize) -> String {
         let p0s: String = "p0".repeat(no_pointers);
         match elem_ty.sty {
             ty::Int(v) => format!("v{}{}i{}", vec_len, p0s, v.bit_width().unwrap()),
@@ -1372,7 +1372,7 @@ fn generic_simd_intrinsic(
         }
     }
 
-    fn llvm_vector_ty(cx: &CodegenCx<'ll, '_>, elem_ty: ty::Ty, vec_len: usize,
+    fn llvm_vector_ty(cx: &CodegenCx<'ll, '_>, elem_ty: ty::Ty<'_>, vec_len: usize,
                       mut no_pointers: usize) -> &'ll Type {
         // FIXME: use cx.layout_of(ty).llvm_type() ?
         let mut elem_ty = match elem_ty.sty {
@@ -1418,7 +1418,7 @@ fn generic_simd_intrinsic(
                  in_ty, ret_ty);
 
         // This counts how many pointers
-        fn ptr_count(t: ty::Ty) -> usize {
+        fn ptr_count(t: ty::Ty<'_>) -> usize {
             match t.sty {
                 ty::RawPtr(p) => 1 + ptr_count(p.ty),
                 _ => 0,
@@ -1426,7 +1426,7 @@ fn generic_simd_intrinsic(
         }
 
         // Non-ptr type
-        fn non_ptr(t: ty::Ty) -> ty::Ty {
+        fn non_ptr(t: ty::Ty<'_>) -> ty::Ty<'_> {
             match t.sty {
                 ty::RawPtr(p) => non_ptr(p.ty),
                 _ => t,
@@ -1517,7 +1517,7 @@ fn generic_simd_intrinsic(
                  arg_tys[2].simd_size(tcx));
 
         // This counts how many pointers
-        fn ptr_count(t: ty::Ty) -> usize {
+        fn ptr_count(t: ty::Ty<'_>) -> usize {
             match t.sty {
                 ty::RawPtr(p) => 1 + ptr_count(p.ty),
                 _ => 0,
@@ -1525,7 +1525,7 @@ fn generic_simd_intrinsic(
         }
 
         // Non-ptr type
-        fn non_ptr(t: ty::Ty) -> ty::Ty {
+        fn non_ptr(t: ty::Ty<'_>) -> ty::Ty<'_> {
             match t.sty {
                 ty::RawPtr(p) => non_ptr(p.ty),
                 _ => t,
@@ -1901,7 +1901,7 @@ unsupported {} from `{}` with element `{}` of size `{}` to `{}`"#,
 // Returns None if the type is not an integer
 // FIXME: there’s multiple of this functions, investigate using some of the already existing
 // stuffs.
-fn int_type_width_signed(ty: Ty, cx: &CodegenCx) -> Option<(u64, bool)> {
+fn int_type_width_signed(ty: Ty<'_>, cx: &CodegenCx<'_, '_>) -> Option<(u64, bool)> {
     match ty.sty {
         ty::Int(t) => Some((match t {
             ast::IntTy::Isize => cx.tcx.sess.target.isize_ty.bit_width().unwrap() as u64,

--- a/src/librustc_codegen_llvm/llvm/archive_ro.rs
+++ b/src/librustc_codegen_llvm/llvm/archive_ro.rs
@@ -36,7 +36,7 @@ impl ArchiveRO {
         };
     }
 
-    pub fn iter(&self) -> Iter {
+    pub fn iter(&self) -> Iter<'_> {
         unsafe {
             Iter {
                 raw: super::LLVMRustArchiveIteratorNew(self.raw),

--- a/src/librustc_codegen_llvm/llvm/ffi.rs
+++ b/src/librustc_codegen_llvm/llvm/ffi.rs
@@ -1283,7 +1283,7 @@ extern "C" {
                               SingleThreaded: Bool)
                               -> &'a Value;
 
-    pub fn LLVMRustBuildAtomicFence(B: &Builder,
+    pub fn LLVMRustBuildAtomicFence(B: &Builder<'_>,
                                     Order: AtomicOrdering,
                                     Scope: SynchronizationScope);
 
@@ -1311,17 +1311,17 @@ extern "C" {
     pub fn LLVMPassManagerBuilderUseInlinerWithThreshold(PMB: &PassManagerBuilder,
                                                          threshold: c_uint);
     pub fn LLVMPassManagerBuilderPopulateModulePassManager(PMB: &PassManagerBuilder,
-                                                           PM: &PassManager);
+                                                           PM: &PassManager<'_>);
 
     pub fn LLVMPassManagerBuilderPopulateFunctionPassManager(PMB: &PassManagerBuilder,
-                                                             PM: &PassManager);
+                                                             PM: &PassManager<'_>);
     pub fn LLVMPassManagerBuilderPopulateLTOPassManager(PMB: &PassManagerBuilder,
-                                                        PM: &PassManager,
+                                                        PM: &PassManager<'_>,
                                                         Internalize: Bool,
                                                         RunInliner: Bool);
     pub fn LLVMRustPassManagerBuilderPopulateThinLTOPassManager(
         PMB: &PassManagerBuilder,
-        PM: &PassManager);
+        PM: &PassManager<'_>);
 
     // Stuff that's in rustllvm/ because it's not upstream yet.
 
@@ -1340,11 +1340,11 @@ extern "C" {
     /// list:
     pub fn LLVMIsSectionIteratorAtEnd(ObjFile: &'a ObjectFile, SI: &SectionIterator<'a>) -> Bool;
     /// Moves the section iterator to point to the next section.
-    pub fn LLVMMoveToNextSection(SI: &SectionIterator);
+    pub fn LLVMMoveToNextSection(SI: &SectionIterator<'_>);
     /// Returns the current section size.
-    pub fn LLVMGetSectionSize(SI: &SectionIterator) -> c_ulonglong;
+    pub fn LLVMGetSectionSize(SI: &SectionIterator<'_>) -> c_ulonglong;
     /// Returns the current section contents as a string buffer.
-    pub fn LLVMGetSectionContents(SI: &SectionIterator) -> *const c_char;
+    pub fn LLVMGetSectionContents(SI: &SectionIterator<'_>) -> *const c_char;
 
     /// Reads the given file and returns it as a memory buffer. Use
     /// LLVMDisposeMemoryBuffer() to get rid of it.
@@ -1392,7 +1392,7 @@ extern "C" {
 
     pub fn LLVMRustDIBuilderDispose(Builder: &'a mut DIBuilder<'a>);
 
-    pub fn LLVMRustDIBuilderFinalize(Builder: &DIBuilder);
+    pub fn LLVMRustDIBuilderFinalize(Builder: &DIBuilder<'_>);
 
     pub fn LLVMRustDIBuilderCreateCompileUnit(Builder: &DIBuilder<'a>,
                                               Lang: c_uint,
@@ -1635,7 +1635,7 @@ extern "C" {
 
     pub fn LLVMRustPassKind(Pass: &Pass) -> PassKind;
     pub fn LLVMRustFindAndCreatePass(Pass: *const c_char) -> Option<&'static mut Pass>;
-    pub fn LLVMRustAddPass(PM: &PassManager, Pass: &'static mut Pass);
+    pub fn LLVMRustAddPass(PM: &PassManager<'_>, Pass: &'static mut Pass);
 
     pub fn LLVMRustHasFeature(T: &TargetMachine, s: *const c_char) -> bool;
 
@@ -1700,13 +1700,13 @@ extern "C" {
     pub fn LLVMRustArchiveIteratorNext(
         AIR: &ArchiveIterator<'a>,
     ) -> Option<&'a mut ArchiveChild<'a>>;
-    pub fn LLVMRustArchiveChildName(ACR: &ArchiveChild, size: &mut size_t) -> *const c_char;
-    pub fn LLVMRustArchiveChildData(ACR: &ArchiveChild, size: &mut size_t) -> *const c_char;
+    pub fn LLVMRustArchiveChildName(ACR: &ArchiveChild<'_>, size: &mut size_t) -> *const c_char;
+    pub fn LLVMRustArchiveChildData(ACR: &ArchiveChild<'_>, size: &mut size_t) -> *const c_char;
     pub fn LLVMRustArchiveChildFree(ACR: &'a mut ArchiveChild<'a>);
     pub fn LLVMRustArchiveIteratorFree(AIR: &'a mut ArchiveIterator<'a>);
     pub fn LLVMRustDestroyArchive(AR: &'static mut Archive);
 
-    pub fn LLVMRustGetSectionName(SI: &SectionIterator, data: &mut *const c_char) -> size_t;
+    pub fn LLVMRustGetSectionName(SI: &SectionIterator<'_>, data: &mut *const c_char) -> size_t;
 
     #[allow(improper_ctypes)]
     pub fn LLVMRustWriteTwineToString(T: &Twine, s: &RustString);
@@ -1742,7 +1742,7 @@ extern "C" {
 
     pub fn LLVMRustWriteArchive(Dst: *const c_char,
                                 NumMembers: size_t,
-                                Members: *const &RustArchiveMember,
+                                Members: *const &RustArchiveMember<'_>,
                                 WriteSymbtab: bool,
                                 Kind: ArchiveKind)
                                 -> LLVMRustResult;
@@ -1815,7 +1815,7 @@ extern "C" {
     pub fn LLVMRustThinLTOPatchDICompileUnit(M: &Module, CU: *mut c_void);
 
     pub fn LLVMRustLinkerNew(M: &'a Module) -> &'a mut Linker<'a>;
-    pub fn LLVMRustLinkerAdd(linker: &Linker,
+    pub fn LLVMRustLinkerAdd(linker: &Linker<'_>,
                              bytecode: *const c_char,
                              bytecode_len: usize) -> bool;
     pub fn LLVMRustLinkerFree(linker: &'a mut Linker<'a>);

--- a/src/librustc_codegen_llvm/type_.rs
+++ b/src/librustc_codegen_llvm/type_.rs
@@ -31,7 +31,7 @@ impl PartialEq for Type {
 }
 
 impl fmt::Debug for Type {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&llvm::build_string(|s| unsafe {
             llvm::LLVMRustWriteTypeToString(self, s);
         }).expect("non-UTF8 type description from LLVM"))

--- a/src/librustc_codegen_llvm/value.rs
+++ b/src/librustc_codegen_llvm/value.rs
@@ -22,7 +22,7 @@ impl Hash for Value {
 
 
 impl fmt::Debug for Value {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&llvm::build_string(|s| unsafe {
             llvm::LLVMRustWriteValueToString(self, s);
         }).expect("non-UTF8 value description from LLVM"))

--- a/src/librustc_codegen_ssa/back/command.rs
+++ b/src/librustc_codegen_ssa/back/command.rs
@@ -159,7 +159,7 @@ impl Command {
 }
 
 impl fmt::Debug for Command {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.command().fmt(f)
     }
 }

--- a/src/librustc_codegen_ssa/back/linker.rs
+++ b/src/librustc_codegen_ssa/back/linker.rs
@@ -25,7 +25,7 @@ pub struct LinkerInfo {
 }
 
 impl LinkerInfo {
-    pub fn new(tcx: TyCtxt) -> LinkerInfo {
+    pub fn new(tcx: TyCtxt<'_, '_, '_>) -> LinkerInfo {
         LinkerInfo {
             exports: tcx.sess.crate_types.borrow().iter().map(|&c| {
                 (c, exported_symbols(tcx, c))
@@ -1052,7 +1052,7 @@ impl<'a> Linker for WasmLd<'a> {
     }
 }
 
-fn exported_symbols(tcx: TyCtxt, crate_type: CrateType) -> Vec<String> {
+fn exported_symbols(tcx: TyCtxt<'_, '_, '_>, crate_type: CrateType) -> Vec<String> {
     if let Some(ref exports) = tcx.sess.target.target.options.override_export_symbols {
         return exports.clone()
     }

--- a/src/librustc_codegen_ssa/back/symbol_export.rs
+++ b/src/librustc_codegen_ssa/back/symbol_export.rs
@@ -22,7 +22,7 @@ pub type ExportedSymbols = FxHashMap<
     Arc<Vec<(String, SymbolExportLevel)>>,
 >;
 
-pub fn threshold(tcx: TyCtxt) -> SymbolExportLevel {
+pub fn threshold(tcx: TyCtxt<'_, '_, '_>) -> SymbolExportLevel {
     crates_export_threshold(&tcx.sess.crate_types.borrow())
 }
 
@@ -342,7 +342,7 @@ fn upstream_monomorphizations_for_provider<'a, 'tcx>(
        .cloned()
 }
 
-fn is_unreachable_local_definition_provider(tcx: TyCtxt, def_id: DefId) -> bool {
+fn is_unreachable_local_definition_provider(tcx: TyCtxt<'_, '_, '_>, def_id: DefId) -> bool {
     if let Some(node_id) = tcx.hir().as_local_node_id(def_id) {
         !tcx.reachable_set(LOCAL_CRATE).0.contains(&node_id)
     } else {
@@ -351,7 +351,7 @@ fn is_unreachable_local_definition_provider(tcx: TyCtxt, def_id: DefId) -> bool 
     }
 }
 
-pub fn provide(providers: &mut Providers) {
+pub fn provide(providers: &mut Providers<'_>) {
     providers.reachable_non_generics = reachable_non_generics_provider;
     providers.is_reachable_non_generic = is_reachable_non_generic_provider_local;
     providers.exported_symbols = exported_symbols_provider_local;
@@ -359,12 +359,12 @@ pub fn provide(providers: &mut Providers) {
     providers.is_unreachable_local_definition = is_unreachable_local_definition_provider;
 }
 
-pub fn provide_extern(providers: &mut Providers) {
+pub fn provide_extern(providers: &mut Providers<'_>) {
     providers.is_reachable_non_generic = is_reachable_non_generic_provider_extern;
     providers.upstream_monomorphizations_for = upstream_monomorphizations_for_provider;
 }
 
-fn symbol_export_level(tcx: TyCtxt, sym_def_id: DefId) -> SymbolExportLevel {
+fn symbol_export_level(tcx: TyCtxt<'_, '_, '_>, sym_def_id: DefId) -> SymbolExportLevel {
     // We export anything that's not mangled at the "C" layer as it probably has
     // to do with ABI concerns. We do not, however, apply such treatment to
     // special symbols in the standard library for various plumbing between

--- a/src/librustc_codegen_ssa/base.rs
+++ b/src/librustc_codegen_ssa/base.rs
@@ -370,7 +370,7 @@ pub fn from_immediate<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>>(
 pub fn to_immediate<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>>(
     bx: &mut Bx,
     val: Bx::Value,
-    layout: layout::TyLayout,
+    layout: layout::TyLayout<'_>,
 ) -> Bx::Value {
     if let layout::Abi::Scalar(ref scalar) = layout.abi {
         return to_immediate_scalar(bx, val, scalar);
@@ -802,7 +802,7 @@ fn assert_and_save_dep_graph<'ll, 'tcx>(tcx: TyCtxt<'ll, 'tcx, 'tcx>) {
 }
 
 impl CrateInfo {
-    pub fn new(tcx: TyCtxt) -> CrateInfo {
+    pub fn new(tcx: TyCtxt<'_, '_, '_>) -> CrateInfo {
         let mut info = CrateInfo {
             panic_runtime: None,
             compiler_builtins: None,
@@ -880,7 +880,7 @@ impl CrateInfo {
         return info
     }
 
-    fn load_wasm_imports(&mut self, tcx: TyCtxt, cnum: CrateNum) {
+    fn load_wasm_imports(&mut self, tcx: TyCtxt<'_, '_, '_>, cnum: CrateNum) {
         self.wasm_imports.extend(tcx.wasm_import_module_map(cnum).iter().map(|(&id, module)| {
             let instance = Instance::mono(tcx, id);
             let import_name = tcx.symbol_name(instance);
@@ -890,13 +890,13 @@ impl CrateInfo {
     }
 }
 
-fn is_codegened_item(tcx: TyCtxt, id: DefId) -> bool {
+fn is_codegened_item(tcx: TyCtxt<'_, '_, '_>, id: DefId) -> bool {
     let (all_mono_items, _) =
         tcx.collect_and_partition_mono_items(LOCAL_CRATE);
     all_mono_items.contains(&id)
 }
 
-pub fn provide_both(providers: &mut Providers) {
+pub fn provide_both(providers: &mut Providers<'_>) {
     providers.backend_optimization_level = |tcx, cratenum| {
         let for_speed = match tcx.sess.opts.optimize {
             // If globally no optimisation is done, #[optimize] has no effect.

--- a/src/librustc_codegen_ssa/common.rs
+++ b/src/librustc_codegen_ssa/common.rs
@@ -134,7 +134,7 @@ mod temp_stable_hash_impls {
     }
 }
 
-pub fn langcall(tcx: TyCtxt,
+pub fn langcall(tcx: TyCtxt<'_, '_, '_>,
                 span: Option<Span>,
                 msg: &str,
                 li: LangItem)

--- a/src/librustc_codegen_ssa/lib.rs
+++ b/src/librustc_codegen_ssa/lib.rs
@@ -11,7 +11,6 @@
 #![allow(dead_code)]
 #![deny(rust_2018_idioms)]
 #![allow(explicit_outlives_requirements)]
-#![allow(elided_lifetimes_in_paths)]
 
 #![recursion_limit="256"]
 

--- a/src/librustc_codegen_ssa/mir/operand.rs
+++ b/src/librustc_codegen_ssa/mir/operand.rs
@@ -48,7 +48,7 @@ pub struct OperandRef<'tcx, V> {
 }
 
 impl<V: CodegenObject> fmt::Debug for OperandRef<'tcx, V> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "OperandRef({:?} @ {:?})", self.val, self.layout)
     }
 }

--- a/src/librustc_codegen_ssa/traits/backend.rs
+++ b/src/librustc_codegen_ssa/traits/backend.rs
@@ -32,13 +32,18 @@ impl<'tcx, T> Backend<'tcx> for T where
 }
 
 pub trait ExtraBackendMethods: CodegenBackend + WriteBackendMethods + Sized + Send {
-    fn new_metadata(&self, sess: TyCtxt, mod_name: &str) -> Self::Module;
+    fn new_metadata(&self, sess: TyCtxt<'_, '_, '_>, mod_name: &str) -> Self::Module;
     fn write_metadata<'b, 'gcx>(
         &self,
         tcx: TyCtxt<'b, 'gcx, 'gcx>,
         metadata: &mut Self::Module,
     ) -> EncodedMetadata;
-    fn codegen_allocator(&self, tcx: TyCtxt, mods: &mut Self::Module, kind: AllocatorKind);
+    fn codegen_allocator(
+        &self,
+        tcx: TyCtxt<'_, '_, '_>,
+        mods: &mut Self::Module,
+        kind: AllocatorKind
+    );
     fn compile_codegen_unit<'a, 'tcx: 'a>(
         &self,
         tcx: TyCtxt<'a, 'tcx, 'tcx>,

--- a/src/librustc_codegen_ssa/traits/builder.rs
+++ b/src/librustc_codegen_ssa/traits/builder.rs
@@ -100,7 +100,7 @@ pub trait BuilderMethods<'a, 'tcx: 'a>:
     fn checked_binop(
         &mut self,
         oop: OverflowOp,
-        ty: Ty,
+        ty: Ty<'_>,
         lhs: Self::Value,
         rhs: Self::Value,
     ) -> (Self::Value, Self::Value);

--- a/src/librustc_codegen_ssa/traits/debuginfo.rs
+++ b/src/librustc_codegen_ssa/traits/debuginfo.rs
@@ -22,12 +22,12 @@ pub trait DebugInfoMethods<'tcx>: BackendTypes {
         instance: Instance<'tcx>,
         sig: ty::FnSig<'tcx>,
         llfn: Self::Value,
-        mir: &mir::Mir,
+        mir: &mir::Mir<'_>,
     ) -> FunctionDebugContext<Self::DIScope>;
 
     fn create_mir_scopes(
         &self,
-        mir: &mir::Mir,
+        mir: &mir::Mir<'_>,
         debug_context: &FunctionDebugContext<Self::DIScope>,
     ) -> IndexVec<mir::SourceScope, MirDebugScope<Self::DIScope>>;
     fn extend_scope_to_file(

--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -15,7 +15,6 @@ use std::{i8, i16, i32, i64, u8, u16, u32, u64, f32, f64};
 use syntax::{ast, attr};
 use syntax::errors::Applicability;
 use rustc_target::spec::abi::Abi;
-use syntax::edition::Edition;
 use syntax_pos::Span;
 use syntax::source_map;
 
@@ -29,9 +28,8 @@ declare_lint! {
 
 declare_lint! {
     OVERFLOWING_LITERALS,
-    Warn,
-    "literal out of range for its type",
-    Edition::Edition2018 => Deny
+    Deny,
+    "literal out of range for its type"
 }
 
 declare_lint! {

--- a/src/librustc_mir/hair/constant.rs
+++ b/src/librustc_mir/hair/constant.rs
@@ -21,8 +21,7 @@ crate fn lit_to_const<'a, 'gcx, 'tcx>(
         let param_ty = ParamEnv::reveal_all().and(tcx.lift_to_global(&ty).unwrap());
         let width = tcx.layout_of(param_ty).map_err(|_| LitToConstError::Reported)?.size;
         trace!("trunc {} with size {} and shift {}", n, width.bits(), 128 - width.bits());
-        let shift = 128 - width.bits();
-        let result = (n << shift) >> shift;
+        let result = truncate(n, width);
         trace!("trunc result: {}", result);
         Ok(ConstValue::Scalar(Scalar::Bits {
             bits: result,

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -196,7 +196,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> dyn AstConv<'gcx, 'tcx> + 'o {
 
     /// Report error if there is an explicit type parameter when using `impl Trait`.
     fn check_impl_trait(
-        tcx: TyCtxt,
+        tcx: TyCtxt<'_, '_, '_>,
         span: Span,
         seg: &hir::PathSegment,
         generics: &ty::Generics,
@@ -227,7 +227,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> dyn AstConv<'gcx, 'tcx> + 'o {
     /// Checks that the correct number of generic arguments have been provided.
     /// Used specifically for function calls.
     pub fn check_generic_arg_count_for_call(
-        tcx: TyCtxt,
+        tcx: TyCtxt<'_, '_, '_>,
         span: Span,
         def: &ty::Generics,
         seg: &hir::PathSegment,
@@ -259,7 +259,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> dyn AstConv<'gcx, 'tcx> + 'o {
     /// Checks that the correct number of generic arguments have been provided.
     /// This is used both for datatypes and function calls.
     fn check_generic_arg_count(
-        tcx: TyCtxt,
+        tcx: TyCtxt<'_, '_, '_>,
         span: Span,
         def: &ty::Generics,
         args: &hir::GenericArgs,
@@ -1502,7 +1502,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> dyn AstConv<'gcx, 'tcx> + 'o {
         has_err
     }
 
-    pub fn prohibit_assoc_ty_binding(tcx: TyCtxt, span: Span) {
+    pub fn prohibit_assoc_ty_binding(tcx: TyCtxt<'_, '_, '_>, span: Span) {
         let mut err = struct_span_err!(tcx.sess, span, E0229,
                                        "associated type bindings are not allowed here");
         err.span_label(span, "associated type not allowed here").emit();

--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -183,7 +183,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 let rhs_ty = self.check_expr(end);
 
                 // Check that both end-points are of numeric or char type.
-                let numeric_or_char = |ty: Ty| ty.is_numeric() || ty.is_char();
+                let numeric_or_char = |ty: Ty<'_>| ty.is_numeric() || ty.is_char();
                 let lhs_compat = numeric_or_char(lhs_ty);
                 let rhs_compat = numeric_or_char(rhs_ty);
 

--- a/src/librustc_typeck/check/callee.rs
+++ b/src/librustc_typeck/check/callee.rs
@@ -18,7 +18,7 @@ use rustc::hir;
 /// Checks that it is legal to call methods of the trait corresponding
 /// to `trait_id` (this only cares about the trait, not the specific
 /// method that is called).
-pub fn check_legal_trait_for_method_call(tcx: TyCtxt, span: Span, trait_id: DefId) {
+pub fn check_legal_trait_for_method_call(tcx: TyCtxt<'_, '_, '_>, span: Span, trait_id: DefId) {
     if tcx.lang_items().drop_trait() == Some(trait_id) {
         struct_span_err!(tcx.sess, span, E0040, "explicit use of destructor method")
             .span_label(span, "explicit destructor calls not allowed")

--- a/src/librustc_typeck/check/closure.rs
+++ b/src/librustc_typeck/check/closure.rs
@@ -574,7 +574,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         expr_def_id: DefId,
         decl: &hir::FnDecl,
     ) -> ty::PolyFnSig<'tcx> {
-        let astconv: &dyn AstConv = self;
+        let astconv: &dyn AstConv<'_, '_> = self;
 
         // First, convert the types that the user supplied (if any).
         let supplied_arguments = decl.inputs.iter().map(|a| astconv.ast_ty_to_ty(a));
@@ -606,7 +606,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
     /// so should yield an error, but returns back a signature where
     /// all parameters are of type `TyErr`.
     fn error_sig_of_closure(&self, decl: &hir::FnDecl) -> ty::PolyFnSig<'tcx> {
-        let astconv: &dyn AstConv = self;
+        let astconv: &dyn AstConv<'_, '_> = self;
 
         let supplied_arguments = decl.inputs.iter().map(|a| {
             // Convert the types that the user supplied (if any), but ignore them.

--- a/src/librustc_typeck/check/coercion.rs
+++ b/src/librustc_typeck/check/coercion.rs
@@ -101,7 +101,7 @@ fn coerce_mutbls<'tcx>(from_mutbl: hir::Mutability,
     }
 }
 
-fn identity(_: Ty) -> Vec<Adjustment> { vec![] }
+fn identity(_: Ty<'_>) -> Vec<Adjustment<'_>> { vec![] }
 
 fn simple<'tcx>(kind: Adjust<'tcx>) -> impl FnOnce(Ty<'tcx>) -> Vec<Adjustment<'tcx>> {
     move |target| vec![Adjustment { kind, target }]
@@ -1084,7 +1084,7 @@ impl<'gcx, 'tcx, 'exprs, E> CoerceMany<'gcx, 'tcx, 'exprs, E>
     pub fn coerce_forced_unit<'a>(&mut self,
                                   fcx: &FnCtxt<'a, 'gcx, 'tcx>,
                                   cause: &ObligationCause<'tcx>,
-                                  augment_error: &mut dyn FnMut(&mut DiagnosticBuilder),
+                                  augment_error: &mut dyn FnMut(&mut DiagnosticBuilder<'_>),
                                   label_unit_as_expected: bool)
     {
         self.coerce_inner(fcx,
@@ -1103,7 +1103,7 @@ impl<'gcx, 'tcx, 'exprs, E> CoerceMany<'gcx, 'tcx, 'exprs, E>
                         cause: &ObligationCause<'tcx>,
                         expression: Option<&'gcx hir::Expr>,
                         mut expression_ty: Ty<'tcx>,
-                        augment_error: Option<&mut dyn FnMut(&mut DiagnosticBuilder)>,
+                        augment_error: Option<&mut dyn FnMut(&mut DiagnosticBuilder<'_>)>,
                         label_expression_as_expected: bool)
     {
         // Incorporate whatever type inference information we have

--- a/src/librustc_typeck/check/compare_method.rs
+++ b/src/librustc_typeck/check/compare_method.rs
@@ -408,7 +408,7 @@ fn check_region_bounds_on_impl_method<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 
 fn extract_spans_for_error_reporting<'a, 'gcx, 'tcx>(infcx: &infer::InferCtxt<'a, 'gcx, 'tcx>,
                                                      param_env: ty::ParamEnv<'tcx>,
-                                                     terr: &TypeError,
+                                                     terr: &TypeError<'_>,
                                                      cause: &ObligationCause<'tcx>,
                                                      impl_m: &ty::AssociatedItem,
                                                      impl_sig: ty::FnSig<'tcx>,

--- a/src/librustc_typeck/check/demand.rs
+++ b/src/librustc_typeck/check/demand.rs
@@ -544,7 +544,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
             };
 
             let into_sugg = into_suggestion.clone();
-            let suggest_to_change_suffix_or_into = |err: &mut DiagnosticBuilder,
+            let suggest_to_change_suffix_or_into = |err: &mut DiagnosticBuilder<'_>,
                                                     note: Option<&str>| {
                 let suggest_msg = if literal_is_ty_suffixed(expr) {
                     format!(

--- a/src/librustc_typeck/check/method/confirm.rs
+++ b/src/librustc_typeck/check/method/confirm.rs
@@ -598,7 +598,7 @@ impl<'a, 'gcx, 'tcx> ConfirmContext<'a, 'gcx, 'tcx> {
             })
     }
 
-    fn enforce_illegal_method_limitations(&self, pick: &probe::Pick) {
+    fn enforce_illegal_method_limitations(&self, pick: &probe::Pick<'_>) {
         // Disallow calls to the method `drop` defined in the `Drop` trait.
         match pick.item.container {
             ty::TraitContainer(trait_def_id) => {

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -388,7 +388,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
     }
 }
 
-pub fn provide(providers: &mut ty::query::Providers) {
+pub fn provide(providers: &mut ty::query::Providers<'_>) {
     providers.method_autoderef_steps = method_autoderef_steps;
 }
 
@@ -1180,7 +1180,7 @@ impl<'a, 'gcx, 'tcx> ProbeContext<'a, 'gcx, 'tcx> {
 
     fn emit_unstable_name_collision_hint(
         &self,
-        stable_pick: &Pick,
+        stable_pick: &Pick<'_>,
         unstable_candidates: &[(&Candidate<'tcx>, Symbol)],
     ) {
         let mut diag = self.tcx.struct_span_lint_hir(

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -72,7 +72,8 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
             return;
         }
 
-        let report_candidates = |err: &mut DiagnosticBuilder, mut sources: Vec<CandidateSource>| {
+        let report_candidates = |err: &mut DiagnosticBuilder<'_>,
+                                 mut sources: Vec<CandidateSource>| {
             sources.sort();
             sources.dedup();
             // Dynamic limit to avoid hiding just one candidate, which is silly.
@@ -497,7 +498,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
     }
 
     fn suggest_use_candidates(&self,
-                              err: &mut DiagnosticBuilder,
+                              err: &mut DiagnosticBuilder<'_>,
                               mut msg: String,
                               candidates: Vec<DefId>) {
         let module_did = self.tcx.hir().get_module_parent_by_hir_id(self.body_id);
@@ -549,7 +550,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
     }
 
     fn suggest_valid_traits(&self,
-                            err: &mut DiagnosticBuilder,
+                            err: &mut DiagnosticBuilder<'_>,
                             valid_out_of_scope_traits: Vec<DefId>) -> bool {
         if !valid_out_of_scope_traits.is_empty() {
             let mut candidates = valid_out_of_scope_traits;
@@ -577,7 +578,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
     }
 
     fn suggest_traits_to_import<'b>(&self,
-                                    err: &mut DiagnosticBuilder,
+                                    err: &mut DiagnosticBuilder<'_>,
                                     span: Span,
                                     rcvr_ty: Ty<'tcx>,
                                     item_name: ast::Ident,
@@ -648,8 +649,8 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
     fn type_derefs_to_local(&self,
                             span: Span,
                             rcvr_ty: Ty<'tcx>,
-                            source: SelfSource) -> bool {
-        fn is_local(ty: Ty) -> bool {
+                            source: SelfSource<'_>) -> bool {
+        fn is_local(ty: Ty<'_>) -> bool {
             match ty.sty {
                 ty::Adt(def, _) => def.did.is_local(),
                 ty::Foreign(did) => did.is_local(),
@@ -749,7 +750,7 @@ fn compute_all_traits<'a, 'gcx, 'tcx>(tcx: TyCtxt<'a, 'gcx, 'tcx>) -> Vec<DefId>
     // Cross-crate:
 
     let mut external_mods = FxHashSet::default();
-    fn handle_external_def(tcx: TyCtxt,
+    fn handle_external_def(tcx: TyCtxt<'_, '_, '_>,
                            traits: &mut Vec<DefId>,
                            external_mods: &mut FxHashSet<DefId>,
                            def: Def) {
@@ -779,7 +780,7 @@ fn compute_all_traits<'a, 'gcx, 'tcx>(tcx: TyCtxt<'a, 'gcx, 'tcx>) -> Vec<DefId>
     traits
 }
 
-pub fn provide(providers: &mut ty::query::Providers) {
+pub fn provide(providers: &mut ty::query::Providers<'_>) {
     providers.all_traits = |tcx, cnum| {
         assert_eq!(cnum, LOCAL_CRATE);
         Lrc::new(compute_all_traits(tcx))

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -738,7 +738,7 @@ fn check_impl_item_well_formed<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: De
     wfcheck::check_impl_item(tcx, def_id);
 }
 
-pub fn provide(providers: &mut Providers) {
+pub fn provide(providers: &mut Providers<'_>) {
     method::provide(providers);
     *providers = Providers {
         typeck_item_bodies,
@@ -1437,7 +1437,7 @@ pub fn check_item_type<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, it: &'tcx hir::Ite
     }
 }
 
-fn maybe_check_static_with_link_section(tcx: TyCtxt, id: DefId, span: Span) {
+fn maybe_check_static_with_link_section(tcx: TyCtxt<'_, '_, '_>, id: DefId, span: Span) {
     // Only restricted on wasm32 target for now
     if !tcx.sess.opts.target_triple.triple().starts_with("wasm32") {
         return
@@ -2122,7 +2122,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
     }
 
     pub fn tag(&self) -> String {
-        let self_ptr: *const FnCtxt = self;
+        let self_ptr: *const FnCtxt<'_, '_, '_> = self;
         format!("{:?}", self_ptr)
     }
 
@@ -3369,7 +3369,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         // (`only_has_type`); otherwise, we just go with a
         // fresh type variable.
         let coerce_to_ty = expected.coercion_target_type(self, sp);
-        let mut coerce: DynamicCoerceMany = CoerceMany::new(coerce_to_ty);
+        let mut coerce: DynamicCoerceMany<'_, '_> = CoerceMany::new(coerce_to_ty);
 
         coerce.coerce(self, &self.misc(sp), then_expr, then_ty);
 
@@ -5043,7 +5043,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
     }
 
     /// Given a function `Node`, return its `FnDecl` if it exists, or `None` otherwise.
-    fn get_node_fn_decl(&self, node: Node) -> Option<(hir::FnDecl, ast::Ident, bool)> {
+    fn get_node_fn_decl(&self, node: Node<'_>) -> Option<(hir::FnDecl, ast::Ident, bool)> {
         match node {
             Node::Item(&hir::Item {
                 ident, node: hir::ItemKind::Fn(ref decl, ..), ..

--- a/src/librustc_typeck/check/op.rs
+++ b/src/librustc_typeck/check/op.rs
@@ -416,7 +416,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         rhs_expr: &'gcx hir::Expr,
         lhs_ty: Ty<'tcx>,
         rhs_ty: Ty<'tcx>,
-        err: &mut errors::DiagnosticBuilder,
+        err: &mut errors::DiagnosticBuilder<'_>,
         is_assign: bool,
     ) -> bool {
         let source_map = self.tcx.sess.source_map();
@@ -688,7 +688,7 @@ enum Op {
 /// Reason #2 is the killer. I tried for a while to always use
 /// overloaded logic and just check the types in constants/codegen after
 /// the fact, and it worked fine, except for SIMD types. -nmatsakis
-fn is_builtin_binop(lhs: Ty, rhs: Ty, op: hir::BinOp) -> bool {
+fn is_builtin_binop(lhs: Ty<'_>, rhs: Ty<'_>, op: hir::BinOp) -> bool {
     match BinOpCategory::from(op) {
         BinOpCategory::Shortcircuit => {
             true

--- a/src/librustc_typeck/check/upvar.rs
+++ b/src/librustc_typeck/check/upvar.rs
@@ -649,6 +649,6 @@ impl<'a, 'gcx, 'tcx> euv::Delegate<'tcx> for InferBorrowKind<'a, 'gcx, 'tcx> {
     }
 }
 
-fn var_name(tcx: TyCtxt, var_hir_id: hir::HirId) -> ast::Name {
+fn var_name(tcx: TyCtxt<'_, '_, '_>, var_hir_id: hir::HirId) -> ast::Name {
     tcx.hir().name_by_hir_id(var_hir_id)
 }

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -938,7 +938,7 @@ fn report_bivariance<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     err.emit();
 }
 
-fn reject_shadowing_parameters(tcx: TyCtxt, def_id: DefId) {
+fn reject_shadowing_parameters(tcx: TyCtxt<'_, '_, '_>, def_id: DefId) {
     let generics = tcx.generics_of(def_id);
     let parent = tcx.generics_of(generics.parent.unwrap());
     let impl_params: FxHashMap<_, _> = parent.params.iter().flat_map(|param| match param.kind {
@@ -1093,7 +1093,7 @@ fn error_392<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, span: Span, param_name: ast:
     err
 }
 
-fn error_194(tcx: TyCtxt, span: Span, trait_decl_span: Span, name: &str) {
+fn error_194(tcx: TyCtxt<'_, '_, '_>, span: Span, trait_decl_span: Span, name: &str) {
     struct_span_err!(tcx.sess, span, E0194,
                      "type parameter `{}` shadows another type parameter of the same name",
                      name)

--- a/src/librustc_typeck/check/writeback.rs
+++ b/src/librustc_typeck/check/writeback.rs
@@ -729,30 +729,30 @@ impl<'cx, 'gcx, 'tcx> WritebackCx<'cx, 'gcx, 'tcx> {
 }
 
 trait Locatable {
-    fn to_span(&self, tcx: &TyCtxt) -> Span;
+    fn to_span(&self, tcx: &TyCtxt<'_, '_, '_>) -> Span;
 }
 
 impl Locatable for Span {
-    fn to_span(&self, _: &TyCtxt) -> Span {
+    fn to_span(&self, _: &TyCtxt<'_, '_, '_>) -> Span {
         *self
     }
 }
 
 impl Locatable for ast::NodeId {
-    fn to_span(&self, tcx: &TyCtxt) -> Span {
+    fn to_span(&self, tcx: &TyCtxt<'_, '_, '_>) -> Span {
         tcx.hir().span(*self)
     }
 }
 
 impl Locatable for DefIndex {
-    fn to_span(&self, tcx: &TyCtxt) -> Span {
+    fn to_span(&self, tcx: &TyCtxt<'_, '_, '_>) -> Span {
         let hir_id = tcx.hir().def_index_to_hir_id(*self);
         tcx.hir().span_by_hir_id(hir_id)
     }
 }
 
 impl Locatable for hir::HirId {
-    fn to_span(&self, tcx: &TyCtxt) -> Span {
+    fn to_span(&self, tcx: &TyCtxt<'_, '_, '_>) -> Span {
         tcx.hir().span_by_hir_id(*self)
     }
 }

--- a/src/librustc_typeck/coherence/inherent_impls_overlap.rs
+++ b/src/librustc_typeck/coherence/inherent_impls_overlap.rs
@@ -20,7 +20,7 @@ struct InherentOverlapChecker<'a, 'tcx: 'a> {
 
 impl<'a, 'tcx> InherentOverlapChecker<'a, 'tcx> {
     fn check_for_common_items_in_impls(&self, impl1: DefId, impl2: DefId,
-                                       overlap: traits::OverlapResult,
+                                       overlap: traits::OverlapResult<'_>,
                                        used_to_be_allowed: bool) {
 
         let name_and_namespace = |def_id| {

--- a/src/librustc_typeck/coherence/mod.rs
+++ b/src/librustc_typeck/coherence/mod.rs
@@ -41,7 +41,11 @@ fn check_impl<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, node_id: ast::NodeId) {
     }
 }
 
-fn enforce_trait_manually_implementable(tcx: TyCtxt, impl_def_id: DefId, trait_def_id: DefId) {
+fn enforce_trait_manually_implementable(
+    tcx: TyCtxt<'_, '_, '_>,
+    impl_def_id: DefId,
+    trait_def_id: DefId
+) {
     let did = Some(trait_def_id);
     let li = tcx.lang_items();
     let span = tcx.sess.source_map().def_span(tcx.span_of_impl(impl_def_id).unwrap());
@@ -93,7 +97,11 @@ fn enforce_trait_manually_implementable(tcx: TyCtxt, impl_def_id: DefId, trait_d
 
 /// We allow impls of marker traits to overlap, so they can't override impls
 /// as that could make it ambiguous which associated item to use.
-fn enforce_empty_impls_for_marker_traits(tcx: TyCtxt, impl_def_id: DefId, trait_def_id: DefId) {
+fn enforce_empty_impls_for_marker_traits(
+    tcx: TyCtxt<'_, '_, '_>,
+    impl_def_id: DefId,
+    trait_def_id: DefId
+) {
     if !tcx.trait_def(trait_def_id).is_marker {
         return;
     }
@@ -110,7 +118,7 @@ fn enforce_empty_impls_for_marker_traits(tcx: TyCtxt, impl_def_id: DefId, trait_
         .emit();
 }
 
-pub fn provide(providers: &mut Providers) {
+pub fn provide(providers: &mut Providers<'_>) {
     use self::builtin::coerce_unsized_info;
     use self::inherent_impls::{crate_inherent_impls, inherent_impls};
     use self::inherent_impls_overlap::crate_inherent_impls_overlap_check;

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1406,7 +1406,7 @@ fn find_existential_constraints<'a, 'tcx>(
                         ty::Param(p) => Some(*index_map.get(p).unwrap()),
                         _ => None,
                     }).collect();
-                let is_param = |ty: ty::Ty| match ty.sty {
+                let is_param = |ty: ty::Ty<'_>| match ty.sty {
                     ty::Param(_) => true,
                     _ => false,
                 };
@@ -2216,7 +2216,7 @@ fn compute_sig_of_foreign_fn_decl<'a, 'tcx>(
         && abi != abi::Abi::PlatformIntrinsic
         && !tcx.features().simd_ffi
     {
-        let check = |ast_ty: &hir::Ty, ty: Ty| {
+        let check = |ast_ty: &hir::Ty, ty: Ty<'_>| {
             if ty.is_simd() {
                 tcx.sess
                    .struct_span_err(
@@ -2251,7 +2251,7 @@ fn is_foreign_item<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) -> bool
 }
 
 fn from_target_feature(
-    tcx: TyCtxt,
+    tcx: TyCtxt<'_, '_, '_>,
     id: DefId,
     attr: &ast::Attribute,
     whitelist: &FxHashMap<String, Option<String>>,

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -2865,8 +2865,8 @@ E0370: r##"
 The maximum value of an enum was reached, so it cannot be automatically
 set in the next enum value. Erroneous code example:
 
-```compile_fail
-#[deny(overflowing_literals)]
+```compile_fail,E0370
+#[repr(i64)]
 enum Foo {
     X = 0x7fffffffffffffff,
     Y, // error: enum discriminant overflowed on value after
@@ -2879,6 +2879,7 @@ To fix this, please set manually the next enum value or put the enum variant
 with the maximum value at the end of the enum. Examples:
 
 ```
+#[repr(i64)]
 enum Foo {
     X = 0x7fffffffffffffff,
     Y = 0, // ok!
@@ -2888,6 +2889,7 @@ enum Foo {
 Or:
 
 ```
+#[repr(i64)]
 enum Foo {
     Y = 0, // ok!
     X = 0x7fffffffffffffff,

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -74,8 +74,6 @@ This API is completely unstable and subject to change.
 #![deny(rust_2018_idioms)]
 #![allow(explicit_outlives_requirements)]
 
-#![allow(elided_lifetimes_in_paths)] // WIP
-
 #[macro_use] extern crate log;
 #[macro_use] extern crate syntax;
 

--- a/src/librustc_typeck/variance/mod.rs
+++ b/src/librustc_typeck/variance/mod.rs
@@ -27,7 +27,7 @@ pub mod test;
 /// Code for transforming variances.
 mod xform;
 
-pub fn provide(providers: &mut Providers) {
+pub fn provide(providers: &mut Providers<'_>) {
     *providers = Providers {
         variances_of,
         crate_variances,
@@ -91,4 +91,3 @@ fn variances_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, item_def_id: DefId)
                        .unwrap_or(&crate_map.empty_variance)
                        .clone()
 }
-

--- a/src/librustc_typeck/variance/solve.rs
+++ b/src/librustc_typeck/variance/solve.rs
@@ -23,7 +23,7 @@ struct SolveContext<'a, 'tcx: 'a> {
     solutions: Vec<ty::Variance>,
 }
 
-pub fn solve_constraints(constraints_cx: ConstraintContext) -> ty::CrateVariancesMap {
+pub fn solve_constraints(constraints_cx: ConstraintContext<'_, '_>) -> ty::CrateVariancesMap {
     let ConstraintContext { terms_cx, constraints, .. } = constraints_cx;
 
     let mut solutions = vec![ty::Bivariant; terms_cx.inferred_terms.len()];

--- a/src/librustc_typeck/variance/terms.rs
+++ b/src/librustc_typeck/variance/terms.rs
@@ -32,7 +32,7 @@ pub enum VarianceTerm<'a> {
 }
 
 impl<'a> fmt::Debug for VarianceTerm<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             ConstantTerm(c1) => write!(f, "{:?}", c1),
             TransformTerm(v1, v2) => write!(f, "({:?} \u{00D7} {:?})", v1, v2),
@@ -86,7 +86,7 @@ pub fn determine_parameters_to_be_inferred<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>
     terms_cx
 }
 
-fn lang_items(tcx: TyCtxt) -> Vec<(ast::NodeId, Vec<ty::Variance>)> {
+fn lang_items(tcx: TyCtxt<'_, '_, '_>) -> Vec<(ast::NodeId, Vec<ty::Variance>)> {
     let lang_items = tcx.lang_items();
     let all = vec![
         (lang_items.phantom_data(), vec![ty::Covariant]),

--- a/src/test/run-pass/issues/issue-27949.rs
+++ b/src/test/run-pass/issues/issue-27949.rs
@@ -1,0 +1,41 @@
+// run-pass
+//
+// At one time, the `==` operator (and other binary operators) did not
+// support subtyping during type checking, and would therefore require
+// LHS and RHS to be exactly identical--i.e. to have the same lifetimes.
+//
+// This was fixed in 1a7fb7dc78439a704f024609ce3dc0beb1386552.
+
+#[derive(Copy, Clone)]
+struct Input<'a> {
+    foo: &'a u32
+}
+
+impl <'a> std::cmp::PartialEq<Input<'a>> for Input<'a> {
+    fn eq(&self, other: &Input<'a>) -> bool {
+        self.foo == other.foo
+    }
+
+    fn ne(&self, other: &Input<'a>) -> bool {
+        self.foo != other.foo
+    }
+}
+
+
+fn check_equal<'a, 'b>(x: Input<'a>, y: Input<'b>) -> bool {
+    // Type checking error due to 'a != 'b prior to 1a7fb7dc78
+    x == y
+}
+
+fn main() {
+    let i = 1u32;
+    let j = 1u32;
+    let k = 2u32;
+
+    let input_i = Input { foo: &i };
+    let input_j = Input { foo: &j };
+    let input_k = Input { foo: &k };
+    assert!(check_equal(input_i, input_i));
+    assert!(check_equal(input_i, input_j));
+    assert!(!check_equal(input_i, input_k));
+}

--- a/src/test/ui/lint/deny-overflowing-literals.rs
+++ b/src/test/ui/lint/deny-overflowing-literals.rs
@@ -1,5 +1,3 @@
-// edition:2018
-
 fn main() {
     let x: u8 = 256;
     //~^ error: literal out of range for u8

--- a/src/test/ui/lint/deny-overflowing-literals.stderr
+++ b/src/test/ui/lint/deny-overflowing-literals.stderr
@@ -1,5 +1,5 @@
 error: literal out of range for u8
-  --> $DIR/edition-deny-overflowing-literals-2018.rs:4:17
+  --> $DIR/deny-overflowing-literals.rs:2:17
    |
 LL |     let x: u8 = 256;
    |                 ^^^

--- a/src/test/ui/lint/lint-type-limits2.rs
+++ b/src/test/ui/lint/lint-type-limits2.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+#![warn(overflowing_literals)]
 
 // compile-flags: -D unused-comparisons
 fn main() { }

--- a/src/test/ui/lint/lint-type-limits2.stderr
+++ b/src/test/ui/lint/lint-type-limits2.stderr
@@ -1,5 +1,5 @@
 error: comparison is useless due to type limits
-  --> $DIR/lint-type-limits2.rs:12:5
+  --> $DIR/lint-type-limits2.rs:13:5
    |
 LL |     128 > bar() //~ ERROR comparison is useless due to type limits
    |     ^^^^^^^^^^^
@@ -7,12 +7,16 @@ LL |     128 > bar() //~ ERROR comparison is useless due to type limits
    = note: requested on the command line with `-D unused-comparisons`
 
 warning: literal out of range for i8
-  --> $DIR/lint-type-limits2.rs:12:5
+  --> $DIR/lint-type-limits2.rs:13:5
    |
 LL |     128 > bar() //~ ERROR comparison is useless due to type limits
    |     ^^^
    |
-   = note: #[warn(overflowing_literals)] on by default
+note: lint level defined here
+  --> $DIR/lint-type-limits2.rs:2:9
+   |
+LL | #![warn(overflowing_literals)]
+   |         ^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/lint/lint-type-limits3.rs
+++ b/src/test/ui/lint/lint-type-limits3.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+#![warn(overflowing_literals)]
 
 // compile-flags: -D unused-comparisons
 fn main() { }

--- a/src/test/ui/lint/lint-type-limits3.stderr
+++ b/src/test/ui/lint/lint-type-limits3.stderr
@@ -1,5 +1,5 @@
 error: comparison is useless due to type limits
-  --> $DIR/lint-type-limits3.rs:8:11
+  --> $DIR/lint-type-limits3.rs:9:11
    |
 LL |     while 200 != i { //~ ERROR comparison is useless due to type limits
    |           ^^^^^^^^
@@ -7,12 +7,16 @@ LL |     while 200 != i { //~ ERROR comparison is useless due to type limits
    = note: requested on the command line with `-D unused-comparisons`
 
 warning: literal out of range for i8
-  --> $DIR/lint-type-limits3.rs:8:11
+  --> $DIR/lint-type-limits3.rs:9:11
    |
 LL |     while 200 != i { //~ ERROR comparison is useless due to type limits
    |           ^^^
    |
-   = note: #[warn(overflowing_literals)] on by default
+note: lint level defined here
+  --> $DIR/lint-type-limits3.rs:2:9
+   |
+LL | #![warn(overflowing_literals)]
+   |         ^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/lint/type-overflow.rs
+++ b/src/test/ui/lint/type-overflow.rs
@@ -1,4 +1,5 @@
 // compile-pass
+#![warn(overflowing_literals)]
 
 fn main() {
     let error = 255i8; //~WARNING literal out of range for i8

--- a/src/test/ui/lint/type-overflow.stderr
+++ b/src/test/ui/lint/type-overflow.stderr
@@ -1,13 +1,17 @@
 warning: literal out of range for i8
-  --> $DIR/type-overflow.rs:4:17
+  --> $DIR/type-overflow.rs:5:17
    |
 LL |     let error = 255i8; //~WARNING literal out of range for i8
    |                 ^^^^^
    |
-   = note: #[warn(overflowing_literals)] on by default
+note: lint level defined here
+  --> $DIR/type-overflow.rs:2:9
+   |
+LL | #![warn(overflowing_literals)]
+   |         ^^^^^^^^^^^^^^^^^^^^
 
 warning: literal out of range for i8
-  --> $DIR/type-overflow.rs:9:16
+  --> $DIR/type-overflow.rs:10:16
    |
 LL |     let fail = 0b1000_0001i8; //~WARNING literal out of range for i8
    |                ^^^^^^^^^^^^^ help: consider using `u8` instead: `0b1000_0001u8`
@@ -15,7 +19,7 @@ LL |     let fail = 0b1000_0001i8; //~WARNING literal out of range for i8
    = note: the literal `0b1000_0001i8` (decimal `129`) does not fit into an `i8` and will become `-127i8`
 
 warning: literal out of range for i64
-  --> $DIR/type-overflow.rs:11:16
+  --> $DIR/type-overflow.rs:12:16
    |
 LL |     let fail = 0x8000_0000_0000_0000i64; //~WARNING literal out of range for i64
    |                ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `u64` instead: `0x8000_0000_0000_0000u64`
@@ -23,7 +27,7 @@ LL |     let fail = 0x8000_0000_0000_0000i64; //~WARNING literal out of range fo
    = note: the literal `0x8000_0000_0000_0000i64` (decimal `9223372036854775808`) does not fit into an `i64` and will become `-9223372036854775808i64`
 
 warning: literal out of range for u32
-  --> $DIR/type-overflow.rs:13:16
+  --> $DIR/type-overflow.rs:14:16
    |
 LL |     let fail = 0x1_FFFF_FFFFu32; //~WARNING literal out of range for u32
    |                ^^^^^^^^^^^^^^^^ help: consider using `u64` instead: `0x1_FFFF_FFFFu64`
@@ -31,7 +35,7 @@ LL |     let fail = 0x1_FFFF_FFFFu32; //~WARNING literal out of range for u32
    = note: the literal `0x1_FFFF_FFFFu32` (decimal `8589934591`) does not fit into an `u32` and will become `4294967295u32`
 
 warning: literal out of range for i128
-  --> $DIR/type-overflow.rs:15:22
+  --> $DIR/type-overflow.rs:16:22
    |
 LL |     let fail: i128 = 0x8000_0000_0000_0000_0000_0000_0000_0000;
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -40,7 +44,7 @@ LL |     let fail: i128 = 0x8000_0000_0000_0000_0000_0000_0000_0000;
    = help: consider using `u128` instead
 
 warning: literal out of range for i32
-  --> $DIR/type-overflow.rs:18:16
+  --> $DIR/type-overflow.rs:19:16
    |
 LL |     let fail = 0x8FFF_FFFF_FFFF_FFFE; //~WARNING literal out of range for i32
    |                ^^^^^^^^^^^^^^^^^^^^^
@@ -49,7 +53,7 @@ LL |     let fail = 0x8FFF_FFFF_FFFF_FFFE; //~WARNING literal out of range for i
    = help: consider using `i128` instead
 
 warning: literal out of range for i8
-  --> $DIR/type-overflow.rs:20:17
+  --> $DIR/type-overflow.rs:21:17
    |
 LL |     let fail = -0b1111_1111i8; //~WARNING literal out of range for i8
    |                 ^^^^^^^^^^^^^ help: consider using `i16` instead: `0b1111_1111i16`


### PR DESCRIPTION
Successful merges:

 - #55632 (Deny the `overflowing_literals` lint for all editions)
 - #58687 (Reduce Miri Code Repetition like `(n << amt) >> amt`)
 - #58690 (Reduce a Code Repetition like `(n << amt) >> amt`)
 - #58718 (Apply docs convention: Replace # Unsafety with # Safety in docs)
 - #58719 (librustc_codegen_llvm: #![deny(elided_lifetimes_in_paths)])
 - #58720 (librustc_codegen_ssa: #![deny(elided_lifetimes_in_paths)])
 - #58722 (librustc_typeck: deny(elided_lifetimes_in_paths))
 - #58723 (librustc: deny(elided_lifetimes_in_paths))
 - #58725 (Test that binop subtyping in rustc_typeck fixes #27949)

Failed merges:


r? @ghost