### PR TITLE
bootstrap: deny(rust_2018_idioms)

### DIFF
--- a/src/bootstrap/cache.rs
+++ b/src/bootstrap/cache.rs
@@ -68,20 +68,20 @@ unsafe impl<T> Send for Interned<T> {}
 unsafe impl<T> Sync for Interned<T> {}
 
 impl fmt::Display for Interned<String> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s: &str = &*self;
         f.write_str(s)
     }
 }
 
 impl fmt::Debug for Interned<String> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s: &str = &*self;
         f.write_fmt(format_args!("{:?}", s))
     }
 }
 impl fmt::Debug for Interned<PathBuf> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s: &Path = &*self;
         f.write_fmt(format_args!("{:?}", s))
     }

--- a/src/bootstrap/cc_detect.rs
+++ b/src/bootstrap/cc_detect.rs
@@ -27,7 +27,6 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use build_helper::output;
-use cc;
 
 use crate::{Build, GitRepo};
 use crate::config::Target;
@@ -157,7 +156,7 @@ fn set_compiler(cfg: &mut cc::Build,
                 None => return,
             };
             match output[i + 3..].chars().next().unwrap() {
-                '0' ... '6' => {}
+                '0' ..= '6' => {}
                 _ => return,
             }
             let alternative = format!("e{}", gnu_compiler);

--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -17,17 +17,17 @@ impl Step for Std {
     type Output = ();
     const DEFAULT: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.all_krates("std")
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Std {
             target: run.target,
         });
     }
 
-    fn run(self, builder: &Builder) {
+    fn run(self, builder: &Builder<'_>) {
         let target = self.target;
         let compiler = builder.compiler(0, builder.config.build);
 
@@ -56,11 +56,11 @@ impl Step for Rustc {
     const ONLY_HOSTS: bool = true;
     const DEFAULT: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.all_krates("rustc-main")
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Rustc {
             target: run.target,
         });
@@ -71,7 +71,7 @@ impl Step for Rustc {
     /// This will build the compiler for a particular stage of the build using
     /// the `compiler` targeting the `target` architecture. The artifacts
     /// created will also be linked into the sysroot directory.
-    fn run(self, builder: &Builder) {
+    fn run(self, builder: &Builder<'_>) {
         let compiler = builder.compiler(0, builder.config.build);
         let target = self.target;
 
@@ -103,11 +103,11 @@ impl Step for CodegenBackend {
     const ONLY_HOSTS: bool = true;
     const DEFAULT: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.all_krates("rustc_codegen_llvm")
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         let backend = run.builder.config.rust_codegen_backends.get(0);
         let backend = backend.cloned().unwrap_or_else(|| {
             INTERNER.intern_str("llvm")
@@ -118,7 +118,7 @@ impl Step for CodegenBackend {
         });
     }
 
-    fn run(self, builder: &Builder) {
+    fn run(self, builder: &Builder<'_>) {
         let compiler = builder.compiler(0, builder.config.build);
         let target = self.target;
         let backend = self.backend;
@@ -148,17 +148,17 @@ impl Step for Test {
     type Output = ();
     const DEFAULT: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.all_krates("test")
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Test {
             target: run.target,
         });
     }
 
-    fn run(self, builder: &Builder) {
+    fn run(self, builder: &Builder<'_>) {
         let compiler = builder.compiler(0, builder.config.build);
         let target = self.target;
 
@@ -189,17 +189,17 @@ impl Step for Rustdoc {
     const ONLY_HOSTS: bool = true;
     const DEFAULT: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.path("src/tools/rustdoc")
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Rustdoc {
             target: run.target,
         });
     }
 
-    fn run(self, builder: &Builder) {
+    fn run(self, builder: &Builder<'_>) {
         let compiler = builder.compiler(0, builder.config.build);
         let target = self.target;
 
@@ -229,25 +229,37 @@ impl Step for Rustdoc {
 
 /// Cargo's output path for the standard library in a given stage, compiled
 /// by a particular compiler for the specified target.
-pub fn libstd_stamp(builder: &Builder, compiler: Compiler, target: Interned<String>) -> PathBuf {
+pub fn libstd_stamp(
+    builder: &Builder<'_>,
+    compiler: Compiler,
+    target: Interned<String>,
+) -> PathBuf {
     builder.cargo_out(compiler, Mode::Std, target).join(".libstd-check.stamp")
 }
 
 /// Cargo's output path for libtest in a given stage, compiled by a particular
 /// compiler for the specified target.
-pub fn libtest_stamp(builder: &Builder, compiler: Compiler, target: Interned<String>) -> PathBuf {
+pub fn libtest_stamp(
+    builder: &Builder<'_>,
+    compiler: Compiler,
+    target: Interned<String>,
+) -> PathBuf {
     builder.cargo_out(compiler, Mode::Test, target).join(".libtest-check.stamp")
 }
 
 /// Cargo's output path for librustc in a given stage, compiled by a particular
 /// compiler for the specified target.
-pub fn librustc_stamp(builder: &Builder, compiler: Compiler, target: Interned<String>) -> PathBuf {
+pub fn librustc_stamp(
+    builder: &Builder<'_>,
+    compiler: Compiler,
+    target: Interned<String>,
+) -> PathBuf {
     builder.cargo_out(compiler, Mode::Rustc, target).join(".librustc-check.stamp")
 }
 
 /// Cargo's output path for librustc_codegen_llvm in a given stage, compiled by a particular
 /// compiler for the specified target and backend.
-fn codegen_backend_stamp(builder: &Builder,
+fn codegen_backend_stamp(builder: &Builder<'_>,
                          compiler: Compiler,
                          target: Interned<String>,
                          backend: Interned<String>) -> PathBuf {
@@ -257,7 +269,11 @@ fn codegen_backend_stamp(builder: &Builder,
 
 /// Cargo's output path for rustdoc in a given stage, compiled by a particular
 /// compiler for the specified target.
-pub fn rustdoc_stamp(builder: &Builder, compiler: Compiler, target: Interned<String>) -> PathBuf {
+pub fn rustdoc_stamp(
+    builder: &Builder<'_>,
+    compiler: Compiler,
+    target: Interned<String>,
+) -> PathBuf {
     builder.cargo_out(compiler, Mode::ToolRustc, target)
         .join(".rustdoc-check.stamp")
 }

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -25,7 +25,7 @@ use crate::tool::{self, Tool};
 use crate::cache::{INTERNER, Interned};
 use time::{self, Timespec};
 
-pub fn pkgname(builder: &Builder, component: &str) -> String {
+pub fn pkgname(builder: &Builder<'_>, component: &str) -> String {
     if component == "cargo" {
         format!("{}-{}", component, builder.cargo_package_vers())
     } else if component == "rls" {
@@ -46,15 +46,15 @@ pub fn pkgname(builder: &Builder, component: &str) -> String {
     }
 }
 
-fn distdir(builder: &Builder) -> PathBuf {
+fn distdir(builder: &Builder<'_>) -> PathBuf {
     builder.out.join("dist")
 }
 
-pub fn tmpdir(builder: &Builder) -> PathBuf {
+pub fn tmpdir(builder: &Builder<'_>) -> PathBuf {
     builder.out.join("tmp/dist")
 }
 
-fn rust_installer(builder: &Builder) -> Command {
+fn rust_installer(builder: &Builder<'_>) -> Command {
     builder.tool_cmd(Tool::RustInstaller)
 }
 
@@ -76,11 +76,11 @@ impl Step for Docs {
     type Output = PathBuf;
     const DEFAULT: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.path("src/doc")
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Docs {
             stage: run.builder.top_stage,
             host: run.target,
@@ -88,7 +88,7 @@ impl Step for Docs {
     }
 
     /// Builds the `rust-docs` installer component.
-    fn run(self, builder: &Builder) -> PathBuf {
+    fn run(self, builder: &Builder<'_>) -> PathBuf {
         let host = self.host;
 
         let name = pkgname(builder, "rust-docs");
@@ -138,11 +138,11 @@ impl Step for RustcDocs {
     type Output = PathBuf;
     const DEFAULT: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.path("src/librustc")
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(RustcDocs {
             stage: run.builder.top_stage,
             host: run.target,
@@ -150,7 +150,7 @@ impl Step for RustcDocs {
     }
 
     /// Builds the `rustc-docs` installer component.
-    fn run(self, builder: &Builder) -> PathBuf {
+    fn run(self, builder: &Builder<'_>) -> PathBuf {
         let host = self.host;
 
         let name = pkgname(builder, "rustc-docs");
@@ -210,7 +210,7 @@ fn find_files(files: &[&str], path: &[PathBuf]) -> Vec<PathBuf> {
 }
 
 fn make_win_dist(
-    rust_root: &Path, plat_root: &Path, target_triple: Interned<String>, builder: &Builder
+    rust_root: &Path, plat_root: &Path, target_triple: Interned<String>, builder: &Builder<'_>
 ) {
     //Ask gcc where it keeps its stuff
     let mut cmd = Command::new(builder.cc(target_triple));
@@ -334,11 +334,11 @@ impl Step for Mingw {
     type Output = Option<PathBuf>;
     const DEFAULT: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.never()
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Mingw { host: run.target });
     }
 
@@ -346,7 +346,7 @@ impl Step for Mingw {
     ///
     /// This contains all the bits and pieces to run the MinGW Windows targets
     /// without any extra installed software (e.g., we bundle gcc, libraries, etc).
-    fn run(self, builder: &Builder) -> Option<PathBuf> {
+    fn run(self, builder: &Builder<'_>) -> Option<PathBuf> {
         let host = self.host;
 
         if !host.contains("pc-windows-gnu") {
@@ -392,18 +392,18 @@ impl Step for Rustc {
     const DEFAULT: bool = true;
     const ONLY_HOSTS: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.path("src/librustc")
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Rustc {
             compiler: run.builder.compiler(run.builder.top_stage, run.target),
         });
     }
 
     /// Creates the `rustc` installer component.
-    fn run(self, builder: &Builder) -> PathBuf {
+    fn run(self, builder: &Builder<'_>) -> PathBuf {
         let compiler = self.compiler;
         let host = self.compiler.host;
 
@@ -470,7 +470,7 @@ impl Step for Rustc {
 
         return distdir(builder).join(format!("{}-{}.tar.gz", name, host));
 
-        fn prepare_image(builder: &Builder, compiler: Compiler, image: &Path) {
+        fn prepare_image(builder: &Builder<'_>, compiler: Compiler, image: &Path) {
             let host = compiler.host;
             let src = builder.sysroot(compiler);
             let libdir = libdir(&host);
@@ -580,11 +580,11 @@ pub struct DebuggerScripts {
 impl Step for DebuggerScripts {
     type Output = ();
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.path("src/lldb_batchmode.py")
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(DebuggerScripts {
             sysroot: run.builder.sysroot(run.builder.compiler(run.builder.top_stage, run.host)),
             host: run.target,
@@ -592,7 +592,7 @@ impl Step for DebuggerScripts {
     }
 
     /// Copies debugger scripts for `target` into the `sysroot` specified.
-    fn run(self, builder: &Builder) {
+    fn run(self, builder: &Builder<'_>) {
         let host = self.host;
         let sysroot = self.sysroot;
         let dst = sysroot.join("lib/rustlib/etc");
@@ -639,18 +639,18 @@ impl Step for Std {
     type Output = PathBuf;
     const DEFAULT: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.path("src/libstd")
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Std {
             compiler: run.builder.compiler(run.builder.top_stage, run.builder.config.build),
             target: run.target,
         });
     }
 
-    fn run(self, builder: &Builder) -> PathBuf {
+    fn run(self, builder: &Builder<'_>) -> PathBuf {
         let compiler = self.compiler;
         let target = self.target;
 
@@ -728,12 +728,12 @@ impl Step for Analysis {
     type Output = PathBuf;
     const DEFAULT: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         let builder = run.builder;
         run.path("analysis").default_condition(builder.config.extended)
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Analysis {
             compiler: run.builder.compiler(run.builder.top_stage, run.builder.config.build),
             target: run.target,
@@ -741,7 +741,7 @@ impl Step for Analysis {
     }
 
     /// Creates a tarball of save-analysis metadata, if available.
-    fn run(self, builder: &Builder) -> PathBuf {
+    fn run(self, builder: &Builder<'_>) -> PathBuf {
         let compiler = self.compiler;
         let target = self.target;
         assert!(builder.config.extended);
@@ -791,7 +791,7 @@ impl Step for Analysis {
     }
 }
 
-fn copy_src_dirs(builder: &Builder, src_dirs: &[&str], exclude_dirs: &[&str], dst_dir: &Path) {
+fn copy_src_dirs(builder: &Builder<'_>, src_dirs: &[&str], exclude_dirs: &[&str], dst_dir: &Path) {
     fn filter_fn(exclude_dirs: &[&str], dir: &str, path: &Path) -> bool {
         let spath = match path.to_str() {
             Some(path) => path,
@@ -861,16 +861,16 @@ impl Step for Src {
     const DEFAULT: bool = true;
     const ONLY_HOSTS: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.path("src")
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Src);
     }
 
     /// Creates the `rust-src` installer component
-    fn run(self, builder: &Builder) -> PathBuf {
+    fn run(self, builder: &Builder<'_>) -> PathBuf {
         builder.info("Dist src");
 
         let name = pkgname(builder, "rust-src");
@@ -941,17 +941,17 @@ impl Step for PlainSourceTarball {
     const DEFAULT: bool = true;
     const ONLY_HOSTS: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         let builder = run.builder;
         run.path("src").default_condition(builder.config.rust_dist_src)
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(PlainSourceTarball);
     }
 
     /// Creates the plain source tarball
-    fn run(self, builder: &Builder) -> PathBuf {
+    fn run(self, builder: &Builder<'_>) -> PathBuf {
         builder.info("Create plain source tarball");
 
         // Make sure that the root folder of tarball has the correct name
@@ -1069,18 +1069,18 @@ impl Step for Cargo {
     type Output = PathBuf;
     const ONLY_HOSTS: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.path("cargo")
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Cargo {
             stage: run.builder.top_stage,
             target: run.target,
         });
     }
 
-    fn run(self, builder: &Builder) -> PathBuf {
+    fn run(self, builder: &Builder<'_>) -> PathBuf {
         let stage = self.stage;
         let target = self.target;
 
@@ -1155,18 +1155,18 @@ impl Step for Rls {
     type Output = Option<PathBuf>;
     const ONLY_HOSTS: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.path("rls")
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Rls {
             stage: run.builder.top_stage,
             target: run.target,
         });
     }
 
-    fn run(self, builder: &Builder) -> Option<PathBuf> {
+    fn run(self, builder: &Builder<'_>) -> Option<PathBuf> {
         let stage = self.stage;
         let target = self.target;
         assert!(builder.config.extended);
@@ -1234,18 +1234,18 @@ impl Step for Clippy {
     type Output = Option<PathBuf>;
     const ONLY_HOSTS: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.path("clippy")
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Clippy {
             stage: run.builder.top_stage,
             target: run.target,
         });
     }
 
-    fn run(self, builder: &Builder) -> Option<PathBuf> {
+    fn run(self, builder: &Builder<'_>) -> Option<PathBuf> {
         let stage = self.stage;
         let target = self.target;
         assert!(builder.config.extended);
@@ -1318,18 +1318,18 @@ impl Step for Miri {
     type Output = Option<PathBuf>;
     const ONLY_HOSTS: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.path("miri")
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Miri {
             stage: run.builder.top_stage,
             target: run.target,
         });
     }
 
-    fn run(self, builder: &Builder) -> Option<PathBuf> {
+    fn run(self, builder: &Builder<'_>) -> Option<PathBuf> {
         let stage = self.stage;
         let target = self.target;
         assert!(builder.config.extended);
@@ -1402,18 +1402,18 @@ impl Step for Rustfmt {
     type Output = Option<PathBuf>;
     const ONLY_HOSTS: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.path("rustfmt")
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Rustfmt {
             stage: run.builder.top_stage,
             target: run.target,
         });
     }
 
-    fn run(self, builder: &Builder) -> Option<PathBuf> {
+    fn run(self, builder: &Builder<'_>) -> Option<PathBuf> {
         let stage = self.stage;
         let target = self.target;
 
@@ -1485,12 +1485,12 @@ impl Step for Extended {
     const DEFAULT: bool = true;
     const ONLY_HOSTS: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         let builder = run.builder;
         run.path("extended").default_condition(builder.config.extended)
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Extended {
             stage: run.builder.top_stage,
             host: run.builder.config.build,
@@ -1499,7 +1499,7 @@ impl Step for Extended {
     }
 
     /// Creates a combined installer for the specified target in the provided stage.
-    fn run(self, builder: &Builder) {
+    fn run(self, builder: &Builder<'_>) {
         let stage = self.stage;
         let target = self.target;
 
@@ -1949,7 +1949,7 @@ impl Step for Extended {
     }
 }
 
-fn add_env(builder: &Builder, cmd: &mut Command, target: Interned<String>) {
+fn add_env(builder: &Builder<'_>, cmd: &mut Command, target: Interned<String>) {
     let mut parts = channel::CFG_RELEASE_NUM.split('.');
     cmd.env("CFG_RELEASE_INFO", builder.rust_version())
        .env("CFG_RELEASE_NUM", channel::CFG_RELEASE_NUM)
@@ -1985,15 +1985,15 @@ impl Step for HashSign {
     type Output = ();
     const ONLY_HOSTS: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.path("hash-and-sign")
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(HashSign);
     }
 
-    fn run(self, builder: &Builder) {
+    fn run(self, builder: &Builder<'_>) {
         let mut cmd = builder.tool_cmd(Tool::BuildManifest);
         if builder.config.dry_run {
             return;
@@ -2037,7 +2037,7 @@ impl Step for HashSign {
 // LLVM tools are linked dynamically.
 // Note: This function does no yet support Windows but we also don't support
 //       linking LLVM tools dynamically on Windows yet.
-pub fn maybe_install_llvm_dylib(builder: &Builder,
+pub fn maybe_install_llvm_dylib(builder: &Builder<'_>,
                                 target: Interned<String>,
                                 sysroot: &Path) {
     let src_libdir = builder
@@ -2079,18 +2079,18 @@ impl Step for LlvmTools {
     type Output = Option<PathBuf>;
     const ONLY_HOSTS: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.path("llvm-tools")
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(LlvmTools {
             stage: run.builder.top_stage,
             target: run.target,
         });
     }
 
-    fn run(self, builder: &Builder) -> Option<PathBuf> {
+    fn run(self, builder: &Builder<'_>) -> Option<PathBuf> {
         let stage = self.stage;
         let target = self.target;
         assert!(builder.config.extended);
@@ -2163,17 +2163,17 @@ impl Step for Lldb {
     const ONLY_HOSTS: bool = true;
     const DEFAULT: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.path("src/llvm-project/lldb").path("src/tools/lldb")
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Lldb {
             target: run.target,
         });
     }
 
-    fn run(self, builder: &Builder) -> Option<PathBuf> {
+    fn run(self, builder: &Builder<'_>) -> Option<PathBuf> {
         let target = self.target;
 
         if builder.config.dry_run {

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -34,18 +34,18 @@ macro_rules! book {
             type Output = ();
             const DEFAULT: bool = true;
 
-            fn should_run(run: ShouldRun) -> ShouldRun {
+            fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
                 let builder = run.builder;
                 run.path($path).default_condition(builder.config.docs)
             }
 
-            fn make_run(run: RunConfig) {
+            fn make_run(run: RunConfig<'_>) {
                 run.builder.ensure($name {
                     target: run.target,
                 });
             }
 
-            fn run(self, builder: &Builder) {
+            fn run(self, builder: &Builder<'_>) {
                 builder.ensure(Rustbook {
                     target: self.target,
                     name: INTERNER.intern_str($book_name),
@@ -87,7 +87,7 @@ impl Step for Rustbook {
 
     // rustbook is never directly called, and only serves as a shim for the nomicon and the
     // reference.
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.never()
     }
 
@@ -95,7 +95,7 @@ impl Step for Rustbook {
     ///
     /// This will not actually generate any documentation if the documentation has
     /// already been generated.
-    fn run(self, builder: &Builder) {
+    fn run(self, builder: &Builder<'_>) {
         let src = builder.src.join("src/doc");
         builder.ensure(RustbookSrc {
             target: self.target,
@@ -115,18 +115,18 @@ impl Step for UnstableBook {
     type Output = ();
     const DEFAULT: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         let builder = run.builder;
         run.path("src/doc/unstable-book").default_condition(builder.config.docs)
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(UnstableBook {
             target: run.target,
         });
     }
 
-    fn run(self, builder: &Builder) {
+    fn run(self, builder: &Builder<'_>) {
         builder.ensure(UnstableBookGen {
             target: self.target,
         });
@@ -149,19 +149,19 @@ impl Step for CargoBook {
     type Output = ();
     const DEFAULT: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         let builder = run.builder;
         run.path("src/tools/cargo/src/doc/book").default_condition(builder.config.docs)
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(CargoBook {
             target: run.target,
             name: INTERNER.intern_str("cargo"),
         });
     }
 
-    fn run(self, builder: &Builder) {
+    fn run(self, builder: &Builder<'_>) {
         let target = self.target;
         let name = self.name;
         let src = builder.src.join("src/tools/cargo/src/doc");
@@ -194,7 +194,7 @@ struct RustbookSrc {
 impl Step for RustbookSrc {
     type Output = ();
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.never()
     }
 
@@ -202,7 +202,7 @@ impl Step for RustbookSrc {
     ///
     /// This will not actually generate any documentation if the documentation has
     /// already been generated.
-    fn run(self, builder: &Builder) {
+    fn run(self, builder: &Builder<'_>) {
         let target = self.target;
         let name = self.name;
         let src = self.src;
@@ -246,12 +246,12 @@ impl Step for TheBook {
     type Output = ();
     const DEFAULT: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         let builder = run.builder;
         run.path("src/doc/book").default_condition(builder.config.docs)
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(TheBook {
             compiler: run.builder.compiler(run.builder.top_stage, run.builder.config.build),
             target: run.target,
@@ -268,7 +268,7 @@ impl Step for TheBook {
     /// * Version info and CSS
     /// * Index page
     /// * Redirect pages
-    fn run(self, builder: &Builder) {
+    fn run(self, builder: &Builder<'_>) {
         let compiler = self.compiler;
         let target = self.target;
         let name = self.name;
@@ -321,7 +321,12 @@ impl Step for TheBook {
     }
 }
 
-fn invoke_rustdoc(builder: &Builder, compiler: Compiler, target: Interned<String>, markdown: &str) {
+fn invoke_rustdoc(
+    builder: &Builder<'_>,
+    compiler: Compiler,
+    target: Interned<String>,
+    markdown: &str,
+) {
     let out = builder.doc_out(target);
 
     let path = builder.src.join("src/doc").join(markdown);
@@ -358,12 +363,12 @@ impl Step for Standalone {
     type Output = ();
     const DEFAULT: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         let builder = run.builder;
         run.path("src/doc").default_condition(builder.config.docs)
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Standalone {
             compiler: run.builder.compiler(run.builder.top_stage, run.builder.config.build),
             target: run.target,
@@ -378,7 +383,7 @@ impl Step for Standalone {
     /// `STAMP` along with providing the various header/footer HTML we've customized.
     ///
     /// In the end, this is just a glorified wrapper around rustdoc!
-    fn run(self, builder: &Builder) {
+    fn run(self, builder: &Builder<'_>) {
         let target = self.target;
         let compiler = self.compiler;
         builder.info(&format!("Documenting standalone ({})", target));
@@ -452,12 +457,12 @@ impl Step for Std {
     type Output = ();
     const DEFAULT: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         let builder = run.builder;
         run.all_krates("std").default_condition(builder.config.docs)
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Std {
             stage: run.builder.top_stage,
             target: run.target
@@ -468,7 +473,7 @@ impl Step for Std {
     ///
     /// This will generate all documentation for the standard library and its
     /// dependencies. This is largely just a wrapper around `cargo doc`.
-    fn run(self, builder: &Builder) {
+    fn run(self, builder: &Builder<'_>) {
         let stage = self.stage;
         let target = self.target;
         builder.info(&format!("Documenting stage{} std ({})", stage, target));
@@ -539,12 +544,12 @@ impl Step for Test {
     type Output = ();
     const DEFAULT: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         let builder = run.builder;
         run.krate("test").default_condition(builder.config.docs)
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Test {
             stage: run.builder.top_stage,
             target: run.target,
@@ -555,7 +560,7 @@ impl Step for Test {
     ///
     /// This will generate all documentation for libtest and its dependencies. This
     /// is largely just a wrapper around `cargo doc`.
-    fn run(self, builder: &Builder) {
+    fn run(self, builder: &Builder<'_>) {
         let stage = self.stage;
         let target = self.target;
         builder.info(&format!("Documenting stage{} test ({})", stage, target));
@@ -602,12 +607,12 @@ impl Step for WhitelistedRustc {
     const DEFAULT: bool = true;
     const ONLY_HOSTS: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         let builder = run.builder;
         run.krate("rustc-main").default_condition(builder.config.docs)
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(WhitelistedRustc {
             stage: run.builder.top_stage,
             target: run.target,
@@ -623,7 +628,7 @@ impl Step for WhitelistedRustc {
     /// documentation. We don't build other compiler documentation
     /// here as we want to be able to keep it separate from the standard
     /// documentation. This is largely just a wrapper around `cargo doc`.
-    fn run(self, builder: &Builder) {
+    fn run(self, builder: &Builder<'_>) {
         let stage = self.stage;
         let target = self.target;
         builder.info(&format!("Documenting stage{} whitelisted compiler ({})", stage, target));
@@ -674,12 +679,12 @@ impl Step for Rustc {
     const DEFAULT: bool = true;
     const ONLY_HOSTS: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         let builder = run.builder;
         run.krate("rustc-main").default_condition(builder.config.docs)
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Rustc {
             stage: run.builder.top_stage,
             target: run.target,
@@ -692,7 +697,7 @@ impl Step for Rustc {
     /// Compiler documentation is distributed separately, so we make sure
     /// we do not merge it with the other documentation from std, test and
     /// proc_macros. This is largely just a wrapper around `cargo doc`.
-    fn run(self, builder: &Builder) {
+    fn run(self, builder: &Builder<'_>) {
         let stage = self.stage;
         let target = self.target;
         builder.info(&format!("Documenting stage{} compiler ({})", stage, target));
@@ -750,7 +755,7 @@ impl Step for Rustc {
 }
 
 fn find_compiler_crates(
-    builder: &Builder,
+    builder: &Builder<'_>,
     name: &Interned<String>,
     crates: &mut HashSet<Interned<String>>
 ) {
@@ -776,11 +781,11 @@ impl Step for Rustdoc {
     const DEFAULT: bool = true;
     const ONLY_HOSTS: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.krate("rustdoc-tool")
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Rustdoc {
             stage: run.builder.top_stage,
             target: run.target,
@@ -793,7 +798,7 @@ impl Step for Rustdoc {
     /// Compiler documentation is distributed separately, so we make sure
     /// we do not merge it with the other documentation from std, test and
     /// proc_macros. This is largely just a wrapper around `cargo doc`.
-    fn run(self, builder: &Builder) {
+    fn run(self, builder: &Builder<'_>) {
         let stage = self.stage;
         let target = self.target;
         builder.info(&format!("Documenting stage{} rustdoc ({})", stage, target));
@@ -859,12 +864,12 @@ impl Step for ErrorIndex {
     const DEFAULT: bool = true;
     const ONLY_HOSTS: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         let builder = run.builder;
         run.path("src/tools/error_index_generator").default_condition(builder.config.docs)
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(ErrorIndex {
             target: run.target,
         });
@@ -872,7 +877,7 @@ impl Step for ErrorIndex {
 
     /// Generates the HTML rendered error-index by running the
     /// `error_index_generator` tool.
-    fn run(self, builder: &Builder) {
+    fn run(self, builder: &Builder<'_>) {
         let target = self.target;
 
         builder.info(&format!("Documenting error index ({})", target));
@@ -900,18 +905,18 @@ impl Step for UnstableBookGen {
     const DEFAULT: bool = true;
     const ONLY_HOSTS: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         let builder = run.builder;
         run.path("src/tools/unstable-book-gen").default_condition(builder.config.docs)
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(UnstableBookGen {
             target: run.target,
         });
     }
 
-    fn run(self, builder: &Builder) {
+    fn run(self, builder: &Builder<'_>) {
         let target = self.target;
 
         builder.ensure(compile::Std {

--- a/src/bootstrap/install.rs
+++ b/src/bootstrap/install.rs
@@ -14,45 +14,45 @@ use crate::builder::{Builder, RunConfig, ShouldRun, Step};
 use crate::cache::Interned;
 use crate::config::Config;
 
-pub fn install_docs(builder: &Builder, stage: u32, host: Interned<String>) {
+pub fn install_docs(builder: &Builder<'_>, stage: u32, host: Interned<String>) {
     install_sh(builder, "docs", "rust-docs", stage, Some(host));
 }
 
-pub fn install_std(builder: &Builder, stage: u32, target: Interned<String>) {
+pub fn install_std(builder: &Builder<'_>, stage: u32, target: Interned<String>) {
     install_sh(builder, "std", "rust-std", stage, Some(target));
 }
 
-pub fn install_cargo(builder: &Builder, stage: u32, host: Interned<String>) {
+pub fn install_cargo(builder: &Builder<'_>, stage: u32, host: Interned<String>) {
     install_sh(builder, "cargo", "cargo", stage, Some(host));
 }
 
-pub fn install_rls(builder: &Builder, stage: u32, host: Interned<String>) {
+pub fn install_rls(builder: &Builder<'_>, stage: u32, host: Interned<String>) {
     install_sh(builder, "rls", "rls", stage, Some(host));
 }
-pub fn install_clippy(builder: &Builder, stage: u32, host: Interned<String>) {
+pub fn install_clippy(builder: &Builder<'_>, stage: u32, host: Interned<String>) {
     install_sh(builder, "clippy", "clippy", stage, Some(host));
 }
-pub fn install_miri(builder: &Builder, stage: u32, host: Interned<String>) {
+pub fn install_miri(builder: &Builder<'_>, stage: u32, host: Interned<String>) {
     install_sh(builder, "miri", "miri", stage, Some(host));
 }
 
-pub fn install_rustfmt(builder: &Builder, stage: u32, host: Interned<String>) {
+pub fn install_rustfmt(builder: &Builder<'_>, stage: u32, host: Interned<String>) {
     install_sh(builder, "rustfmt", "rustfmt", stage, Some(host));
 }
 
-pub fn install_analysis(builder: &Builder, stage: u32, host: Interned<String>) {
+pub fn install_analysis(builder: &Builder<'_>, stage: u32, host: Interned<String>) {
     install_sh(builder, "analysis", "rust-analysis", stage, Some(host));
 }
 
-pub fn install_src(builder: &Builder, stage: u32) {
+pub fn install_src(builder: &Builder<'_>, stage: u32) {
     install_sh(builder, "src", "rust-src", stage, None);
 }
-pub fn install_rustc(builder: &Builder, stage: u32, host: Interned<String>) {
+pub fn install_rustc(builder: &Builder<'_>, stage: u32, host: Interned<String>) {
     install_sh(builder, "rustc", "rustc", stage, Some(host));
 }
 
 fn install_sh(
-    builder: &Builder,
+    builder: &Builder<'_>,
     package: &str,
     name: &str,
     stage: u32,
@@ -155,7 +155,7 @@ macro_rules! install {
             }
 
             #[allow(dead_code)]
-            fn should_install(builder: &Builder) -> bool {
+            fn should_install(builder: &Builder<'_>) -> bool {
                 builder.config.tools.as_ref().map_or(false, |t| t.contains($path))
             }
         }
@@ -166,12 +166,12 @@ macro_rules! install {
             const ONLY_HOSTS: bool = $only_hosts;
             $(const $c: bool = true;)*
 
-            fn should_run(run: ShouldRun) -> ShouldRun {
+            fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
                 let $_config = &run.builder.config;
                 run.path($path).default_condition($default_cond)
             }
 
-            fn make_run(run: RunConfig) {
+            fn make_run(run: RunConfig<'_>) {
                 run.builder.ensure($name {
                     stage: run.builder.top_stage,
                     target: run.target,
@@ -179,7 +179,7 @@ macro_rules! install {
                 });
             }
 
-            fn run($sel, $builder: &Builder) {
+            fn run($sel, $builder: &Builder<'_>) {
                 $run_item
             }
         })+
@@ -262,20 +262,20 @@ impl Step for Src {
     const DEFAULT: bool = true;
     const ONLY_HOSTS: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         let config = &run.builder.config;
         let cond = config.extended &&
             config.tools.as_ref().map_or(true, |t| t.contains("src"));
         run.path("src").default_condition(cond)
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Src {
             stage: run.builder.top_stage,
         });
     }
 
-    fn run(self, builder: &Builder) {
+    fn run(self, builder: &Builder<'_>) {
         builder.ensure(dist::Src);
         install_src(builder, self.stage);
     }

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -103,7 +103,7 @@
 //! More documentation can be found in each respective module below, and you can
 //! also check out the `src/bootstrap/README.md` file for more information.
 
-#![deny(bare_trait_objects)]
+#![deny(rust_2018_idioms)]
 #![deny(warnings)]
 #![feature(core_intrinsics)]
 #![feature(drain_filter)]
@@ -164,8 +164,6 @@ mod job;
 
 #[cfg(all(unix, not(target_os = "haiku")))]
 mod job {
-    use libc;
-
     pub unsafe fn setup(build: &mut crate::Build) {
         if build.config.low_priority {
             libc::setpriority(libc::PRIO_PGRP as _, 0, 10);

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -35,14 +35,14 @@ impl Step for Llvm {
 
     const ONLY_HOSTS: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.path("src/llvm-project")
             .path("src/llvm-project/llvm")
             .path("src/llvm")
             .path("src/llvm-emscripten")
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         let emscripten = run.path.ends_with("llvm-emscripten");
         run.builder.ensure(Llvm {
             target: run.target,
@@ -51,7 +51,7 @@ impl Step for Llvm {
     }
 
     /// Compile LLVM for `target`.
-    fn run(self, builder: &Builder) -> PathBuf {
+    fn run(self, builder: &Builder<'_>) -> PathBuf {
         let target = self.target;
         let emscripten = self.emscripten;
 
@@ -261,7 +261,7 @@ impl Step for Llvm {
     }
 }
 
-fn check_llvm_version(builder: &Builder, llvm_config: &Path) {
+fn check_llvm_version(builder: &Builder<'_>, llvm_config: &Path) {
     if !builder.config.llvm_version_check {
         return
     }
@@ -282,7 +282,7 @@ fn check_llvm_version(builder: &Builder, llvm_config: &Path) {
     panic!("\n\nbad LLVM version: {}, need >=6.0\n\n", version)
 }
 
-fn configure_cmake(builder: &Builder,
+fn configure_cmake(builder: &Builder<'_>,
                    target: Interned<String>,
                    cfg: &mut cmake::Config) {
     if builder.config.ninja {
@@ -417,16 +417,16 @@ impl Step for Lld {
     type Output = PathBuf;
     const ONLY_HOSTS: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.path("src/llvm-project/lld").path("src/tools/lld")
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Lld { target: run.target });
     }
 
     /// Compile LLVM for `target`.
-    fn run(self, builder: &Builder) -> PathBuf {
+    fn run(self, builder: &Builder<'_>) -> PathBuf {
         if builder.config.dry_run {
             return PathBuf::from("lld-out-dir-test-gen");
         }
@@ -489,17 +489,17 @@ pub struct TestHelpers {
 impl Step for TestHelpers {
     type Output = ();
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.path("src/test/auxiliary/rust_test_helpers.c")
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(TestHelpers { target: run.target })
     }
 
     /// Compiles the `rust_test_helpers.c` library which we used in various
     /// `run-pass` test suites for ABI testing.
-    fn run(self, builder: &Builder) {
+    fn run(self, builder: &Builder<'_>) {
         if builder.config.dry_run {
             return;
         }

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -57,7 +57,7 @@ impl TestKind {
 }
 
 impl fmt::Display for TestKind {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match *self {
             TestKind::Test => "Testing",
             TestKind::Bench => "Benchmarking",
@@ -65,7 +65,7 @@ impl fmt::Display for TestKind {
     }
 }
 
-fn try_run(builder: &Builder, cmd: &mut Command) -> bool {
+fn try_run(builder: &Builder<'_>, cmd: &mut Command) -> bool {
     if !builder.fail_fast {
         if !builder.try_run(cmd) {
             let mut failures = builder.delayed_failures.borrow_mut();
@@ -78,7 +78,7 @@ fn try_run(builder: &Builder, cmd: &mut Command) -> bool {
     true
 }
 
-fn try_run_quiet(builder: &Builder, cmd: &mut Command) -> bool {
+fn try_run_quiet(builder: &Builder<'_>, cmd: &mut Command) -> bool {
     if !builder.fail_fast {
         if !builder.try_run_quiet(cmd) {
             let mut failures = builder.delayed_failures.borrow_mut();
@@ -105,7 +105,7 @@ impl Step for Linkcheck {
     ///
     /// This tool in `src/tools` will verify the validity of all our links in the
     /// documentation to ensure we don't have a bunch of dead ones.
-    fn run(self, builder: &Builder) {
+    fn run(self, builder: &Builder<'_>) {
         let host = self.host;
 
         builder.info(&format!("Linkcheck ({})", host));
@@ -121,13 +121,13 @@ impl Step for Linkcheck {
         );
     }
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         let builder = run.builder;
         run.path("src/tools/linkchecker")
             .default_condition(builder.config.docs)
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Linkcheck { host: run.target });
     }
 }
@@ -142,11 +142,11 @@ impl Step for Cargotest {
     type Output = ();
     const ONLY_HOSTS: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.path("src/tools/cargotest")
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Cargotest {
             stage: run.builder.top_stage,
             host: run.target,
@@ -157,7 +157,7 @@ impl Step for Cargotest {
     ///
     /// This tool in `src/tools` will check out a few Rust projects and run `cargo
     /// test` to ensure that we don't regress the test suites there.
-    fn run(self, builder: &Builder) {
+    fn run(self, builder: &Builder<'_>) {
         let compiler = builder.compiler(self.stage, self.host);
         builder.ensure(compile::Rustc {
             compiler,
@@ -192,11 +192,11 @@ impl Step for Cargo {
     type Output = ();
     const ONLY_HOSTS: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.path("src/tools/cargo")
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Cargo {
             stage: run.builder.top_stage,
             host: run.target,
@@ -204,7 +204,7 @@ impl Step for Cargo {
     }
 
     /// Runs `cargo test` for `cargo` packaged with Rust.
-    fn run(self, builder: &Builder) {
+    fn run(self, builder: &Builder<'_>) {
         let compiler = builder.compiler(self.stage, self.host);
 
         builder.ensure(tool::Cargo {
@@ -247,11 +247,11 @@ impl Step for Rls {
     type Output = ();
     const ONLY_HOSTS: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.path("src/tools/rls")
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Rls {
             stage: run.builder.top_stage,
             host: run.target,
@@ -259,7 +259,7 @@ impl Step for Rls {
     }
 
     /// Runs `cargo test` for the rls.
-    fn run(self, builder: &Builder) {
+    fn run(self, builder: &Builder<'_>) {
         let stage = self.stage;
         let host = self.host;
         let compiler = builder.compiler(stage, host);
@@ -303,11 +303,11 @@ impl Step for Rustfmt {
     type Output = ();
     const ONLY_HOSTS: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.path("src/tools/rustfmt")
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Rustfmt {
             stage: run.builder.top_stage,
             host: run.target,
@@ -315,7 +315,7 @@ impl Step for Rustfmt {
     }
 
     /// Runs `cargo test` for rustfmt.
-    fn run(self, builder: &Builder) {
+    fn run(self, builder: &Builder<'_>) {
         let stage = self.stage;
         let host = self.host;
         let compiler = builder.compiler(stage, host);
@@ -362,12 +362,12 @@ impl Step for Miri {
     const ONLY_HOSTS: bool = true;
     const DEFAULT: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         let test_miri = run.builder.config.test_miri;
         run.path("src/tools/miri").default_condition(test_miri)
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Miri {
             stage: run.builder.top_stage,
             host: run.target,
@@ -375,7 +375,7 @@ impl Step for Miri {
     }
 
     /// Runs `cargo test` for miri.
-    fn run(self, builder: &Builder) {
+    fn run(self, builder: &Builder<'_>) {
         let stage = self.stage;
         let host = self.host;
         let compiler = builder.compiler(stage, host);
@@ -421,11 +421,11 @@ pub struct CompiletestTest {
 impl Step for CompiletestTest {
     type Output = ();
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.path("src/tools/compiletest")
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(CompiletestTest {
             stage: run.builder.top_stage,
             host: run.target,
@@ -433,7 +433,7 @@ impl Step for CompiletestTest {
     }
 
     /// Runs `cargo test` for compiletest.
-    fn run(self, builder: &Builder) {
+    fn run(self, builder: &Builder<'_>) {
         let stage = self.stage;
         let host = self.host;
         let compiler = builder.compiler(stage, host);
@@ -462,11 +462,11 @@ impl Step for Clippy {
     const ONLY_HOSTS: bool = true;
     const DEFAULT: bool = false;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.path("src/tools/clippy")
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Clippy {
             stage: run.builder.top_stage,
             host: run.target,
@@ -474,7 +474,7 @@ impl Step for Clippy {
     }
 
     /// Runs `cargo test` for clippy.
-    fn run(self, builder: &Builder) {
+    fn run(self, builder: &Builder<'_>) {
         let stage = self.stage;
         let host = self.host;
         let compiler = builder.compiler(stage, host);
@@ -516,7 +516,7 @@ impl Step for Clippy {
     }
 }
 
-fn path_for_cargo(builder: &Builder, compiler: Compiler) -> OsString {
+fn path_for_cargo(builder: &Builder<'_>, compiler: Compiler) -> OsString {
     // Configure PATH to find the right rustc. NB. we have to use PATH
     // and not RUSTC because the Cargo test suite has tests that will
     // fail if rustc is not spelled `rustc`.
@@ -535,17 +535,17 @@ impl Step for RustdocTheme {
     const DEFAULT: bool = true;
     const ONLY_HOSTS: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.path("src/tools/rustdoc-themes")
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         let compiler = run.builder.compiler(run.builder.top_stage, run.host);
 
         run.builder.ensure(RustdocTheme { compiler });
     }
 
-    fn run(self, builder: &Builder) {
+    fn run(self, builder: &Builder<'_>) {
         let rustdoc = builder.out.join("bootstrap/debug/rustdoc");
         let mut cmd = builder.tool_cmd(Tool::RustdocTheme);
         cmd.arg(rustdoc.to_str().unwrap())
@@ -584,18 +584,18 @@ impl Step for RustdocJS {
     const DEFAULT: bool = true;
     const ONLY_HOSTS: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.path("src/test/rustdoc-js")
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(RustdocJS {
             host: run.host,
             target: run.target,
         });
     }
 
-    fn run(self, builder: &Builder) {
+    fn run(self, builder: &Builder<'_>) {
         if let Some(ref nodejs) = builder.config.nodejs {
             let mut command = Command::new(nodejs);
             command.args(&["src/tools/rustdoc-js/tester.js", &*self.host]);
@@ -624,11 +624,11 @@ impl Step for RustdocUi {
     const DEFAULT: bool = true;
     const ONLY_HOSTS: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.path("src/test/rustdoc-ui")
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         let compiler = run.builder.compiler(run.builder.top_stage, run.host);
         run.builder.ensure(RustdocUi {
             host: run.host,
@@ -637,7 +637,7 @@ impl Step for RustdocUi {
         });
     }
 
-    fn run(self, builder: &Builder) {
+    fn run(self, builder: &Builder<'_>) {
         builder.ensure(Compiletest {
             compiler: self.compiler,
             target: self.target,
@@ -662,7 +662,7 @@ impl Step for Tidy {
     /// This tool in `src/tools` checks up on various bits and pieces of style and
     /// otherwise just implements a few lint-like checks that are specific to the
     /// compiler itself.
-    fn run(self, builder: &Builder) {
+    fn run(self, builder: &Builder<'_>) {
         let mut cmd = builder.tool_cmd(Tool::Tidy);
         cmd.arg(builder.src.join("src"));
         cmd.arg(&builder.initial_cargo);
@@ -678,16 +678,16 @@ impl Step for Tidy {
         try_run(builder, &mut cmd);
     }
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.path("src/tools/tidy")
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Tidy);
     }
 }
 
-fn testdir(builder: &Builder, host: Interned<String>) -> PathBuf {
+fn testdir(builder: &Builder<'_>, host: Interned<String>) -> PathBuf {
     builder.out.join(host).join("test")
 }
 
@@ -747,11 +747,11 @@ macro_rules! test_definitions {
             const DEFAULT: bool = $default;
             const ONLY_HOSTS: bool = $host;
 
-            fn should_run(run: ShouldRun) -> ShouldRun {
+            fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
                 run.suite_path($path)
             }
 
-            fn make_run(run: RunConfig) {
+            fn make_run(run: RunConfig<'_>) {
                 let compiler = run.builder.compiler(run.builder.top_stage, run.host);
 
                 run.builder.ensure($name {
@@ -760,7 +760,7 @@ macro_rules! test_definitions {
                 });
             }
 
-            fn run(self, builder: &Builder) {
+            fn run(self, builder: &Builder<'_>) {
                 builder.ensure(Compiletest {
                     compiler: self.compiler,
                     target: self.target,
@@ -908,7 +908,7 @@ struct Compiletest {
 impl Step for Compiletest {
     type Output = ();
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.never()
     }
 
@@ -917,7 +917,7 @@ impl Step for Compiletest {
     /// Compiles all tests with `compiler` for `target` with the specified
     /// compiletest `mode` and `suite` arguments. For example `mode` can be
     /// "run-pass" or `suite` can be something like `debuginfo`.
-    fn run(self, builder: &Builder) {
+    fn run(self, builder: &Builder<'_>) {
         let compiler = self.compiler;
         let target = self.target;
         let mode = self.mode;
@@ -1284,7 +1284,7 @@ impl Step for DocTest {
     type Output = ();
     const ONLY_HOSTS: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.never()
     }
 
@@ -1293,7 +1293,7 @@ impl Step for DocTest {
     /// This will run all tests in our markdown documentation (e.g., the book)
     /// located in `src/doc`. The `rustdoc` that's run is the one that sits next to
     /// `compiler`.
-    fn run(self, builder: &Builder) {
+    fn run(self, builder: &Builder<'_>) {
         let compiler = self.compiler;
 
         builder.ensure(compile::Test {
@@ -1354,17 +1354,17 @@ macro_rules! test_book {
                 const DEFAULT: bool = $default;
                 const ONLY_HOSTS: bool = true;
 
-                fn should_run(run: ShouldRun) -> ShouldRun {
+                fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
                     run.path($path)
                 }
 
-                fn make_run(run: RunConfig) {
+                fn make_run(run: RunConfig<'_>) {
                     run.builder.ensure($name {
                         compiler: run.builder.compiler(run.builder.top_stage, run.host),
                     });
                 }
 
-                fn run(self, builder: &Builder) {
+                fn run(self, builder: &Builder<'_>) {
                     builder.ensure(DocTest {
                         compiler: self.compiler,
                         path: $path,
@@ -1398,11 +1398,11 @@ impl Step for ErrorIndex {
     const DEFAULT: bool = true;
     const ONLY_HOSTS: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.path("src/tools/error_index_generator")
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(ErrorIndex {
             compiler: run.builder.compiler(run.builder.top_stage, run.host),
         });
@@ -1414,7 +1414,7 @@ impl Step for ErrorIndex {
     /// The `error_index_generator` tool lives in `src/tools` and is used to
     /// generate a markdown file from the error indexes of the code base which is
     /// then passed to `rustdoc --test`.
-    fn run(self, builder: &Builder) {
+    fn run(self, builder: &Builder<'_>) {
         let compiler = self.compiler;
 
         builder.ensure(compile::Std {
@@ -1440,7 +1440,7 @@ impl Step for ErrorIndex {
     }
 }
 
-fn markdown_test(builder: &Builder, compiler: Compiler, markdown: &Path) -> bool {
+fn markdown_test(builder: &Builder<'_>, compiler: Compiler, markdown: &Path) -> bool {
     match fs::read_to_string(markdown) {
         Ok(contents) => {
             if !contents.contains("```") {
@@ -1480,11 +1480,11 @@ impl Step for CrateLibrustc {
     const DEFAULT: bool = true;
     const ONLY_HOSTS: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.krate("rustc-main")
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         let builder = run.builder;
         let compiler = builder.compiler(builder.top_stage, run.host);
 
@@ -1502,7 +1502,7 @@ impl Step for CrateLibrustc {
         }
     }
 
-    fn run(self, builder: &Builder) {
+    fn run(self, builder: &Builder<'_>) {
         builder.ensure(Crate {
             compiler: self.compiler,
             target: self.target,
@@ -1524,14 +1524,14 @@ pub struct CrateNotDefault {
 impl Step for CrateNotDefault {
     type Output = ();
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.path("src/librustc_asan")
             .path("src/librustc_lsan")
             .path("src/librustc_msan")
             .path("src/librustc_tsan")
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         let builder = run.builder;
         let compiler = builder.compiler(builder.top_stage, run.host);
 
@@ -1551,7 +1551,7 @@ impl Step for CrateNotDefault {
         });
     }
 
-    fn run(self, builder: &Builder) {
+    fn run(self, builder: &Builder<'_>) {
         builder.ensure(Crate {
             compiler: self.compiler,
             target: self.target,
@@ -1575,7 +1575,7 @@ impl Step for Crate {
     type Output = ();
     const DEFAULT: bool = true;
 
-    fn should_run(mut run: ShouldRun) -> ShouldRun {
+    fn should_run(mut run: ShouldRun<'_>) -> ShouldRun<'_> {
         let builder = run.builder;
         run = run.krate("test");
         for krate in run.builder.in_tree_crates("std") {
@@ -1586,7 +1586,7 @@ impl Step for Crate {
         run
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         let builder = run.builder;
         let compiler = builder.compiler(builder.top_stage, run.host);
 
@@ -1622,7 +1622,7 @@ impl Step for Crate {
     ///
     /// Currently this runs all tests for a DAG by passing a bunch of `-p foo`
     /// arguments, and those arguments are discovered from `cargo metadata`.
-    fn run(self, builder: &Builder) {
+    fn run(self, builder: &Builder<'_>) {
         let compiler = self.compiler;
         let target = self.target;
         let mode = self.mode;
@@ -1763,11 +1763,11 @@ impl Step for CrateRustdoc {
     const DEFAULT: bool = true;
     const ONLY_HOSTS: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.paths(&["src/librustdoc", "src/tools/rustdoc"])
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         let builder = run.builder;
 
         let test_kind = builder.kind.into();
@@ -1778,7 +1778,7 @@ impl Step for CrateRustdoc {
         });
     }
 
-    fn run(self, builder: &Builder) {
+    fn run(self, builder: &Builder<'_>) {
         let test_kind = self.test_kind;
 
         let compiler = builder.compiler(builder.top_stage, self.host);
@@ -1846,11 +1846,11 @@ pub struct RemoteCopyLibs {
 impl Step for RemoteCopyLibs {
     type Output = ();
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.never()
     }
 
-    fn run(self, builder: &Builder) {
+    fn run(self, builder: &Builder<'_>) {
         let compiler = self.compiler;
         let target = self.target;
         if !builder.remote_tested(target) {
@@ -1896,16 +1896,16 @@ pub struct Distcheck;
 impl Step for Distcheck {
     type Output = ();
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.path("distcheck")
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Distcheck);
     }
 
     /// Runs "distcheck", a 'make check' from a tarball
-    fn run(self, builder: &Builder) {
+    fn run(self, builder: &Builder<'_>) {
         builder.info("Distcheck");
         let dir = builder.out.join("tmp").join("distcheck");
         let _ = fs::remove_dir_all(&dir);
@@ -1966,7 +1966,7 @@ impl Step for Bootstrap {
     const ONLY_HOSTS: bool = true;
 
     /// Tests the build system itself.
-    fn run(self, builder: &Builder) {
+    fn run(self, builder: &Builder<'_>) {
         let mut cmd = Command::new(&builder.initial_cargo);
         cmd.arg("test")
             .current_dir(builder.src.join("src/bootstrap"))
@@ -1990,11 +1990,11 @@ impl Step for Bootstrap {
         try_run(builder, &mut cmd);
     }
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.path("src/bootstrap")
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Bootstrap);
     }
 }

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -36,7 +36,7 @@ struct ToolBuild {
 impl Step for ToolBuild {
     type Output = Option<PathBuf>;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.never()
     }
 
@@ -44,7 +44,7 @@ impl Step for ToolBuild {
     ///
     /// This will build the specified tool with the specified `host` compiler in
     /// `stage` into the normal cargo output directory.
-    fn run(self, builder: &Builder) -> Option<PathBuf> {
+    fn run(self, builder: &Builder<'_>) -> Option<PathBuf> {
         let compiler = self.compiler;
         let target = self.target;
         let tool = self.tool;
@@ -192,7 +192,7 @@ impl Step for ToolBuild {
 }
 
 pub fn prepare_tool_cargo(
-    builder: &Builder,
+    builder: &Builder<'_>,
     compiler: Compiler,
     mode: Mode,
     target: Interned<String>,
@@ -315,18 +315,18 @@ macro_rules! tool {
         impl Step for $name {
             type Output = PathBuf;
 
-            fn should_run(run: ShouldRun) -> ShouldRun {
+            fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
                 run.path($path)
             }
 
-            fn make_run(run: RunConfig) {
+            fn make_run(run: RunConfig<'_>) {
                 run.builder.ensure($name {
                     compiler: run.builder.compiler(run.builder.top_stage, run.builder.config.build),
                     target: run.target,
                 });
             }
 
-            fn run(self, builder: &Builder) -> PathBuf {
+            fn run(self, builder: &Builder<'_>) -> PathBuf {
                 builder.ensure(ToolBuild {
                     compiler: self.compiler,
                     target: self.target,
@@ -371,18 +371,18 @@ pub struct RemoteTestServer {
 impl Step for RemoteTestServer {
     type Output = PathBuf;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.path("src/tools/remote-test-server")
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(RemoteTestServer {
             compiler: run.builder.compiler(run.builder.top_stage, run.builder.config.build),
             target: run.target,
         });
     }
 
-    fn run(self, builder: &Builder) -> PathBuf {
+    fn run(self, builder: &Builder<'_>) -> PathBuf {
         builder.ensure(ToolBuild {
             compiler: self.compiler,
             target: self.target,
@@ -406,17 +406,17 @@ impl Step for Rustdoc {
     const DEFAULT: bool = true;
     const ONLY_HOSTS: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.path("src/tools/rustdoc")
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Rustdoc {
             host: run.host,
         });
     }
 
-    fn run(self, builder: &Builder) -> PathBuf {
+    fn run(self, builder: &Builder<'_>) -> PathBuf {
         let target_compiler = builder.compiler(builder.top_stage, self.host);
         if target_compiler.stage == 0 {
             if !target_compiler.is_snapshot(builder) {
@@ -490,19 +490,19 @@ impl Step for Cargo {
     const DEFAULT: bool = true;
     const ONLY_HOSTS: bool = true;
 
-    fn should_run(run: ShouldRun) -> ShouldRun {
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         let builder = run.builder;
         run.path("src/tools/cargo").default_condition(builder.config.extended)
     }
 
-    fn make_run(run: RunConfig) {
+    fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Cargo {
             compiler: run.builder.compiler(run.builder.top_stage, run.builder.config.build),
             target: run.target,
         });
     }
 
-    fn run(self, builder: &Builder) -> PathBuf {
+    fn run(self, builder: &Builder<'_>) -> PathBuf {
         // Cargo depends on procedural macros, which requires a full host
         // compiler to be available, so we need to depend on that.
         builder.ensure(compile::Rustc {
@@ -542,12 +542,12 @@ macro_rules! tool_extended {
             const DEFAULT: bool = true;
             const ONLY_HOSTS: bool = true;
 
-            fn should_run(run: ShouldRun) -> ShouldRun {
+            fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
                 let builder = run.builder;
                 run.path($path).default_condition(builder.config.extended)
             }
 
-            fn make_run(run: RunConfig) {
+            fn make_run(run: RunConfig<'_>) {
                 run.builder.ensure($name {
                     compiler: run.builder.compiler(run.builder.top_stage, run.builder.config.build),
                     target: run.target,
@@ -556,7 +556,7 @@ macro_rules! tool_extended {
             }
 
             #[allow(unused_mut)]
-            fn run(mut $sel, $builder: &Builder) -> Option<PathBuf> {
+            fn run(mut $sel, $builder: &Builder<'_>) -> Option<PathBuf> {
                 $extra_deps
                 $builder.ensure(ToolBuild {
                     compiler: $sel.compiler,

--- a/src/bootstrap/util.rs
+++ b/src/bootstrap/util.rs
@@ -95,7 +95,7 @@ pub fn push_exe_path(mut buf: PathBuf, components: &[&str]) -> PathBuf {
 pub struct TimeIt(bool, Instant);
 
 /// Returns an RAII structure that prints out how long it took to drop.
-pub fn timeit(builder: &Builder) -> TimeIt {
+pub fn timeit(builder: &Builder<'_>) -> TimeIt {
     TimeIt(builder.config.dry_run, Instant::now())
 }
 


### PR DESCRIPTION
As part of the Rust 2018 transition, apply `#![deny(rust_2018_idioms)]` to `bootstrap`.

r? @Centril