### PR TITLE
Allow lang and lib features to share names

### DIFF
--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -403,10 +403,14 @@ impl<'a, 'tcx> Index<'tcx> {
             active_features: Default::default(),
         };
 
-        let ref active_lib_features = tcx.features().declared_lib_features;
+        let active_lib_features = &tcx.features().declared_lib_features;
+        let active_lang_features = &tcx.features().declared_lang_features;
 
-        // Put the active features into a map for quick lookup
-        index.active_features = active_lib_features.iter().map(|&(ref s, _)| s.clone()).collect();
+        // Put the active features into a map for quick lookup.
+        index.active_features =
+            active_lib_features.iter().map(|&(ref s, ..)| s.clone())
+            .chain(active_lang_features.iter().map(|&(ref s, ..)| s.clone()))
+            .collect();
 
         {
             let krate = tcx.hir().krate();


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/58715.

I didn't add a test, because there's currently no standard lang test feature and I felt apprehensive about adding a permanently unstable feature. Instead, a shared lang/lib feature will be used in https://github.com/rust-lang/rust/pull/57760 and will essentially provide an immediately test.