### PR TITLE
std: docs: Disable running several Stdio doctests

### DIFF
--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -1015,7 +1015,7 @@ impl From<ChildStdin> for Stdio {
     ///
     /// `ChildStdin` will be converted to `Stdio` using `Stdio::from` under the hood.
     ///
-    /// ```rust
+    /// ```rust,no_run
     /// use std::process::{Command, Stdio};
     ///
     /// let reverse = Command::new("rev")
@@ -1044,7 +1044,7 @@ impl From<ChildStdout> for Stdio {
     ///
     /// `ChildStdout` will be converted to `Stdio` using `Stdio::from` under the hood.
     ///
-    /// ```rust
+    /// ```rust,no_run
     /// use std::process::{Command, Stdio};
     ///
     /// let hello = Command::new("echo")


### PR DESCRIPTION
* A number of `Stdio` related doc examples include running the "rev"
command to illustrate piping commands. The majority of these tests are
marked as `no_run` except for two tests which were not
* Not running these tests is unlikely to cause any negative impact, and
doing so also allows the test suite to pass in environments where the
"rev" command is unavailable