### PR TITLE
Mention `unwind(aborts)` in diagnostics for `#[unwind]`

### DIFF
--- a/src/librustc_mir/build/mod.rs
+++ b/src/librustc_mir/build/mod.rs
@@ -581,6 +581,10 @@ fn should_abort_on_panic<'a, 'gcx, 'tcx>(tcx: TyCtxt<'a, 'gcx, 'tcx>,
     // Not callable from C, so we can safely unwind through these
     if abi == Abi::Rust || abi == Abi::RustCall { return false; }
 
+    // Validate `#[unwind]` syntax regardless of platform-specific panic strategy
+    let attrs = &tcx.get_attrs(fn_def_id);
+    let unwind_attr = attr::find_unwind_attr(Some(tcx.sess.diagnostic()), attrs);
+
     // We never unwind, so it's not relevant to stop an unwind
     if tcx.sess.panic_strategy() != PanicStrategy::Unwind { return false; }
 
@@ -589,8 +593,7 @@ fn should_abort_on_panic<'a, 'gcx, 'tcx>(tcx: TyCtxt<'a, 'gcx, 'tcx>,
 
     // This is a special case: some functions have a C abi but are meant to
     // unwind anyway. Don't stop them.
-    let attrs = &tcx.get_attrs(fn_def_id);
-    match attr::find_unwind_attr(Some(tcx.sess.diagnostic()), attrs) {
+    match unwind_attr {
         None => true,
         Some(UnwindAttr::Allowed) => false,
         Some(UnwindAttr::Aborts) => true,

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -1173,7 +1173,7 @@ pub const BUILTIN_ATTRIBUTES: &[(&str, AttributeType, AttributeTemplate, Attribu
            "dropck_eyepatch",
            "may_dangle has unstable semantics and may be removed in the future",
            cfg_fn!(dropck_eyepatch))),
-    ("unwind", Whitelisted, template!(List: "allowed"), Gated(Stability::Unstable,
+    ("unwind", Whitelisted, template!(List: "allowed|aborts"), Gated(Stability::Unstable,
                                   "unwind_attributes",
                                   "#[unwind] is experimental",
                                   cfg_fn!(unwind_attributes))),

--- a/src/test/ui/malformed/malformed-unwind-1.rs
+++ b/src/test/ui/malformed/malformed-unwind-1.rs
@@ -1,0 +1,11 @@
+#![feature(unwind_attributes)]
+
+#[unwind]
+//~^ ERROR attribute must be of the form
+extern "C" fn f1() {}
+
+#[unwind = ""]
+//~^ ERROR attribute must be of the form
+extern "C" fn f2() {}
+
+fn main() {}

--- a/src/test/ui/malformed/malformed-unwind-1.stderr
+++ b/src/test/ui/malformed/malformed-unwind-1.stderr
@@ -1,0 +1,14 @@
+error: attribute must be of the form `#[unwind(allowed|aborts)]`
+  --> $DIR/malformed-unwind-1.rs:3:1
+   |
+LL | #[unwind]
+   | ^^^^^^^^^
+
+error: attribute must be of the form `#[unwind(allowed|aborts)]`
+  --> $DIR/malformed-unwind-1.rs:7:1
+   |
+LL | #[unwind = ""]
+   | ^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/malformed/malformed-unwind-2.rs
+++ b/src/test/ui/malformed/malformed-unwind-2.rs
@@ -1,0 +1,11 @@
+#![feature(unwind_attributes)]
+
+#[unwind(allowed, aborts)]
+//~^ ERROR malformed `#[unwind]` attribute
+extern "C" fn f1() {}
+
+#[unwind(unsupported)]
+//~^ ERROR malformed `#[unwind]` attribute
+extern "C" fn f2() {}
+
+fn main() {}

--- a/src/test/ui/malformed/malformed-unwind-2.stderr
+++ b/src/test/ui/malformed/malformed-unwind-2.stderr
@@ -1,0 +1,15 @@
+error[E0633]: malformed `#[unwind]` attribute
+  --> $DIR/malformed-unwind-2.rs:3:1
+   |
+LL | #[unwind(allowed, aborts)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0633]: malformed `#[unwind]` attribute
+  --> $DIR/malformed-unwind-2.rs:7:1
+   |
+LL | #[unwind(unsupported)]
+   | ^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0633`.


### PR DESCRIPTION
Simplify input validation for `#[unwind]`, add tests

cc https://github.com/rust-lang/rust/issues/58760
r? @Mark-Simulacrum 