### PR TITLE
Simplify io::Lazy

### DIFF
--- a/src/libstd/io/lazy.rs
+++ b/src/libstd/io/lazy.rs
@@ -1,13 +1,20 @@
 use crate::cell::UnsafeCell;
+use crate::sync::Arc;
 use crate::sync::atomic::AtomicUsize;
 use crate::sync::atomic::Ordering;
 use crate::sys_common;
 use crate::sys_common::mutex::Mutex;
 
-/// Helper for lazy initialization of a static, with a destructor that runs when the main (Rust)
-/// thread exits.
+/// Helper for lazy initialization of a static, with a destructor that attempts to run when the main
+/// (Rust) thread exits.
 ///
 /// Currently used only inside the standard library, by the stdio types.
+///
+/// If there are still child threads around when the main thread exits, they get terminated. But
+/// there is a small window where they are not yet terminated and may hold a reference to the
+/// the data. We therefore store the data in an `Arc<T>`, keep one of the `Arc`'s in the static, and
+/// hand out clones. When the `Arc` in the static gets dropped by the `at_exit` handler, the
+/// contents will only be dropped if there where no childs threads holding a reference.
 ///
 /// # Safety
 /// - `UnsafeCell`: We only create a mutable reference during initialization and during the shutdown
@@ -22,7 +29,7 @@ use crate::sys_common::mutex::Mutex;
 pub struct Lazy<T> {
     guard: Mutex, // Only used to protect initialization.
     status: AtomicUsize,
-    data: UnsafeCell<Option<T>>,
+    data: UnsafeCell<Option<Arc<T>>>,
 }
 
 unsafe impl<T> Sync for Lazy<T> {}
@@ -42,36 +49,32 @@ impl<T> Lazy<T> {
 }
 
 impl<T: Send + Sync + 'static> Lazy<T> {
-    pub unsafe fn get(&'static self, init: fn() -> T) -> Option<&T> {
-        match self.status.load(Ordering::Acquire) {
-            UNINITIALIZED => {
-                let _guard = self.guard.lock();
-                // Double-check to make sure this `Lazy` didn't get initialized by another
-                // thread in the small window before we acquired the mutex.
-                if self.status.load(Ordering::Relaxed) != UNINITIALIZED {
-                    return self.get(init);
-                }
+    pub unsafe fn get(&'static self, init: fn() -> T) -> Option<Arc<T>> {
+        if self.status.load(Ordering::Acquire) == UNINITIALIZED {
+            let _guard = self.guard.lock();
+            // Double-check to make sure this `Lazy` didn't get initialized by another
+            // thread in the small window before we acquired the mutex.
+            if self.status.load(Ordering::Relaxed) != UNINITIALIZED {
+                return self.get(init);
+            }
 
-                // Register an `at_exit` handler that drops `data` when the main thread exits.
-                let registered = sys_common::at_exit(move || {
-                    *self.data.get() = None; // `T` gets dropped here
-                    self.status.store(SHUTDOWN, Ordering::Release);
-                });
-                if registered.is_err() {
-                    // Registering the handler will only fail if we are already in the shutdown
-                    // phase. In that case don't attempt to initialize.
-                    self.status.store(SHUTDOWN, Ordering::Release);
-                    return None;
-                }
+            // Register an `at_exit` handler.
+            let registered = sys_common::at_exit(move || {
+                *self.data.get() = None;
+                // The reference to `Arc<T>` gets dropped above. If there are no other references
+                // in child threads `T` will be dropped.
+                self.status.store(SHUTDOWN, Ordering::Release);
+            });
+            if registered.is_err() {
+                // Registering the handler will only fail if we are already in the shutdown
+                // phase. In that case don't attempt to initialize.
+                return None;
+            }
 
-                // Run the initializer of `T`.
-                *self.data.get() = Some(init());
-                self.status.store(AVAILABLE, Ordering::Release);
-
-                (*self.data.get()).as_ref()
-            },
-            SHUTDOWN => None,
-            _ => (*self.data.get()).as_ref(),
+            // Run the initializer of `T`.
+            *self.data.get() = Some(Arc::new(init()));
+            self.status.store(AVAILABLE, Ordering::Release);
         }
+        (*self.data.get()).as_ref().cloned()
     }
 }

--- a/src/libstd/io/stdio.rs
+++ b/src/libstd/io/stdio.rs
@@ -4,7 +4,7 @@ use crate::cell::RefCell;
 use crate::fmt;
 use crate::io::lazy::Lazy;
 use crate::io::{self, Initializer, BufReader, LineWriter};
-use crate::sync::{Mutex, MutexGuard};
+use crate::sync::{Arc, Mutex, MutexGuard};
 use crate::sys::stdio;
 use crate::sys_common::remutex::{ReentrantMutex, ReentrantMutexGuard};
 use crate::thread::LocalKey;
@@ -128,7 +128,7 @@ fn handle_ebadf<T>(r: io::Result<T>, default: T) -> io::Result<T> {
 /// an error.
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Stdin {
-    inner: &'static Mutex<BufReader<Maybe<StdinRaw>>>,
+    inner: Arc<Mutex<BufReader<Maybe<StdinRaw>>>>,
 }
 
 /// A locked reference to the `Stdin` handle.
@@ -339,7 +339,7 @@ pub struct Stdout {
     // FIXME: this should be LineWriter or BufWriter depending on the state of
     //        stdout (tty or not). Note that if this is not line buffered it
     //        should also flush-on-panic or some form of flush-on-abort.
-    inner: &'static ReentrantMutex<RefCell<LineWriter<Maybe<StdoutRaw>>>>,
+    inner: Arc<ReentrantMutex<RefCell<LineWriter<Maybe<StdoutRaw>>>>>,
 }
 
 /// A locked reference to the `Stdout` handle.
@@ -492,7 +492,7 @@ impl fmt::Debug for StdoutLock<'_> {
 /// an error.
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Stderr {
-    inner: &'static ReentrantMutex<RefCell<Maybe<StderrRaw>>>,
+    inner: Arc<ReentrantMutex<RefCell<Maybe<StderrRaw>>>>,
 }
 
 /// A locked reference to the `Stderr` handle.

--- a/src/libstd/sys/cloudabi/stdio.rs
+++ b/src/libstd/sys/cloudabi/stdio.rs
@@ -1,14 +1,12 @@
 use crate::io;
 use crate::sys::cloudabi::abi;
 
-pub struct Stdin(());
-pub struct Stdout(());
-pub struct Stderr(());
+pub struct Stdin;
+pub struct Stdout;
+pub struct Stderr;
 
 impl Stdin {
-    pub fn new() -> io::Result<Stdin> {
-        Ok(Stdin(()))
-    }
+    pub fn new() -> Stdin { Stdin }
 }
 
 impl io::Read for Stdin {
@@ -18,9 +16,7 @@ impl io::Read for Stdin {
 }
 
 impl Stdout {
-    pub fn new() -> io::Result<Stdout> {
-        Ok(Stdout(()))
-    }
+    pub fn new() -> Stdout { Stdout }
 }
 
 impl io::Write for Stdout {
@@ -37,9 +33,7 @@ impl io::Write for Stdout {
 }
 
 impl Stderr {
-    pub fn new() -> io::Result<Stderr> {
-        Ok(Stderr(()))
-    }
+    pub fn new() -> Stderr { Stderr }
 }
 
 impl io::Write for Stderr {
@@ -62,5 +56,5 @@ pub fn is_ebadf(err: &io::Error) -> bool {
 pub const STDIN_BUF_SIZE: usize = crate::sys_common::io::DEFAULT_BUF_SIZE;
 
 pub fn panic_output() -> Option<impl io::Write> {
-    Stderr::new().ok()
+    Some(Stderr::new())
 }

--- a/src/libstd/sys/redox/stdio.rs
+++ b/src/libstd/sys/redox/stdio.rs
@@ -2,12 +2,12 @@ use crate::io;
 use crate::sys::{cvt, syscall};
 use crate::sys::fd::FileDesc;
 
-pub struct Stdin(());
-pub struct Stdout(());
-pub struct Stderr(());
+pub struct Stdin;
+pub struct Stdout;
+pub struct Stderr;
 
 impl Stdin {
-    pub fn new() -> io::Result<Stdin> { Ok(Stdin(())) }
+    pub fn new() -> Stdin { Stdin }
 }
 
 impl io::Read for Stdin {
@@ -20,7 +20,7 @@ impl io::Read for Stdin {
 }
 
 impl Stdout {
-    pub fn new() -> io::Result<Stdout> { Ok(Stdout(())) }
+    pub fn new() -> Stdout { Stdout }
 }
 
 impl io::Write for Stdout {
@@ -37,7 +37,7 @@ impl io::Write for Stdout {
 }
 
 impl Stderr {
-    pub fn new() -> io::Result<Stderr> { Ok(Stderr(())) }
+    pub fn new() -> Stderr { Stderr }
 }
 
 impl io::Write for Stderr {
@@ -60,5 +60,5 @@ pub fn is_ebadf(err: &io::Error) -> bool {
 pub const STDIN_BUF_SIZE: usize = crate::sys_common::io::DEFAULT_BUF_SIZE;
 
 pub fn panic_output() -> Option<impl io::Write> {
-    Stderr::new().ok()
+    Some(Stderr::new())
 }

--- a/src/libstd/sys/sgx/stdio.rs
+++ b/src/libstd/sys/sgx/stdio.rs
@@ -3,9 +3,9 @@ use fortanix_sgx_abi as abi;
 use crate::io;
 use crate::sys::fd::FileDesc;
 
-pub struct Stdin(());
-pub struct Stdout(());
-pub struct Stderr(());
+pub struct Stdin;
+pub struct Stdout;
+pub struct Stderr;
 
 fn with_std_fd<F: FnOnce(&FileDesc) -> R, R>(fd: abi::Fd, f: F) -> R {
     let fd = FileDesc::new(fd);
@@ -15,7 +15,7 @@ fn with_std_fd<F: FnOnce(&FileDesc) -> R, R>(fd: abi::Fd, f: F) -> R {
 }
 
 impl Stdin {
-    pub fn new() -> io::Result<Stdin> { Ok(Stdin(())) }
+    pub fn new() -> Stdin { Stdin }
 }
 
 impl io::Read for Stdin {
@@ -25,7 +25,7 @@ impl io::Read for Stdin {
 }
 
 impl Stdout {
-    pub fn new() -> io::Result<Stdout> { Ok(Stdout(())) }
+    pub fn new() -> Stdout { Stdout }
 }
 
 impl io::Write for Stdout {
@@ -39,7 +39,7 @@ impl io::Write for Stdout {
 }
 
 impl Stderr {
-    pub fn new() -> io::Result<Stderr> { Ok(Stderr(())) }
+    pub fn new() -> Stderr { Stderr }
 }
 
 impl io::Write for Stderr {

--- a/src/libstd/sys/unix/stdio.rs
+++ b/src/libstd/sys/unix/stdio.rs
@@ -1,12 +1,12 @@
 use crate::io;
 use crate::sys::fd::FileDesc;
 
-pub struct Stdin(());
-pub struct Stdout(());
-pub struct Stderr(());
+pub struct Stdin;
+pub struct Stdout;
+pub struct Stderr;
 
 impl Stdin {
-    pub fn new() -> io::Result<Stdin> { Ok(Stdin(())) }
+    pub fn new() -> Stdin { Stdin }
 }
 
 impl io::Read for Stdin {
@@ -19,7 +19,7 @@ impl io::Read for Stdin {
 }
 
 impl Stdout {
-    pub fn new() -> io::Result<Stdout> { Ok(Stdout(())) }
+    pub fn new() -> Stdout { Stdout }
 }
 
 impl io::Write for Stdout {
@@ -36,7 +36,7 @@ impl io::Write for Stdout {
 }
 
 impl Stderr {
-    pub fn new() -> io::Result<Stderr> { Ok(Stderr(())) }
+    pub fn new() -> Stderr { Stderr }
 }
 
 impl io::Write for Stderr {
@@ -59,5 +59,5 @@ pub fn is_ebadf(err: &io::Error) -> bool {
 pub const STDIN_BUF_SIZE: usize = crate::sys_common::io::DEFAULT_BUF_SIZE;
 
 pub fn panic_output() -> Option<impl io::Write> {
-    Stderr::new().ok()
+    Some(Stderr::new())
 }

--- a/src/libstd/sys/wasm/stdio.rs
+++ b/src/libstd/sys/wasm/stdio.rs
@@ -6,9 +6,7 @@ pub struct Stdout;
 pub struct Stderr;
 
 impl Stdin {
-    pub fn new() -> io::Result<Stdin> {
-        Ok(Stdin)
-    }
+    pub fn new() -> Stdin { Stdin }
 }
 
 impl io::Read for Stdin {
@@ -18,9 +16,7 @@ impl io::Read for Stdin {
 }
 
 impl Stdout {
-    pub fn new() -> io::Result<Stdout> {
-        Ok(Stdout)
-    }
+    pub fn new() -> Stdout { Stdout }
 }
 
 impl io::Write for Stdout {
@@ -35,9 +31,7 @@ impl io::Write for Stdout {
 }
 
 impl Stderr {
-    pub fn new() -> io::Result<Stderr> {
-        Ok(Stderr)
-    }
+    pub fn new() -> Stderr { Stderr }
 }
 
 impl io::Write for Stderr {
@@ -59,7 +53,7 @@ pub fn is_ebadf(_err: &io::Error) -> bool {
 
 pub fn panic_output() -> Option<impl io::Write> {
     if cfg!(feature = "wasm_syscall") {
-        Stderr::new().ok()
+        Some(Stderr::new())
     } else {
         None
     }

--- a/src/libstd/sys/windows/stdio.rs
+++ b/src/libstd/sys/windows/stdio.rs
@@ -126,8 +126,8 @@ fn write_u16s(handle: c::HANDLE, data: &[u16]) -> io::Result<usize> {
 }
 
 impl Stdin {
-    pub fn new() -> io::Result<Stdin> {
-        Ok(Stdin { surrogate: 0 })
+    pub fn new() -> Stdin {
+        Stdin { surrogate: 0 }
     }
 }
 
@@ -159,7 +159,6 @@ impl io::Read for Stdin {
         utf16_to_utf8(&utf16_buf[..read], buf)
     }
 }
-
 
 // We assume that if the last `u16` is an unpaired surrogate they got sliced apart by our
 // buffer size, and keep it around for the next read hoping to put them together.
@@ -243,9 +242,7 @@ fn utf16_to_utf8(utf16: &[u16], utf8: &mut [u8]) -> io::Result<usize> {
 }
 
 impl Stdout {
-    pub fn new() -> io::Result<Stdout> {
-        Ok(Stdout)
-    }
+    pub fn new() -> Stdout { Stdout }
 }
 
 impl io::Write for Stdout {
@@ -259,9 +256,7 @@ impl io::Write for Stdout {
 }
 
 impl Stderr {
-    pub fn new() -> io::Result<Stderr> {
-        Ok(Stderr)
-    }
+    pub fn new() -> Stderr { Stderr }
 }
 
 impl io::Write for Stderr {
@@ -279,5 +274,5 @@ pub fn is_ebadf(err: &io::Error) -> bool {
 }
 
 pub fn panic_output() -> Option<impl io::Write> {
-    Stderr::new().ok()
+    Some(Stderr::new())
 }


### PR DESCRIPTION
`io::Lazy` is used inside the standard library by the stdio types as a helper to initialize a global static, and run the destructor at process exit.

The previous code took me some effort to read, as it gets creative with raw pointers to use `Box` inside a static, and with `0` and `1` as special values.

It now uses an atomic to set the current state, only acquires a mutex during initialization instead of every time, and no longer requires the data to be wrapped in an `Arc`.

There is one minor change: if for example `Stdout` were to be used during process exit, which it isn't, three things can happen:
* It may still exist at that point, so no problem in using it;
* It may be cleaned up, in which case `Lazy::get` returns `None`;
* It may not yet be initialized. The old code would hand out an `Arc`, but not initialize the static. Now it also returns `None`.

But since this case doesn't happen in the standard library, it is not really interesting.

Another change is that `stdin_raw()`, `stdout_raw()` and `stderr_raw()` no longer return a result. Since that design the code has changed to be able to pick up changes to the stdio file descriptors / handles. The state at initialization is not the reliable end-state it will have for the duration of the process. As all `sys::stdio` types always return `Ok`, I just removed the needless complexity, including `Maybe::fake`.

r? @alexcrichton

I am still working on changing the `Stdout` buffer strategy and detecting a terminal. That is for another PR.