### PR TITLE
Don't promote function calls to nonpromotable things

### DIFF
--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -507,7 +507,7 @@ impl Qualif for IsNotPromotable {
     fn in_call(
         cx: &ConstCx<'_, 'tcx>,
         callee: &Operand<'tcx>,
-        _args: &[Operand<'tcx>],
+        args: &[Operand<'tcx>],
         _return_ty: Ty<'tcx>,
     ) -> bool {
         if cx.mode == Mode::Fn {
@@ -520,10 +520,7 @@ impl Qualif for IsNotPromotable {
             }
         }
 
-        // FIXME(eddyb) do we need "not promotable" in anything
-        // other than `Mode::Fn` by any chance?
-
-        false
+        Self::in_operand(cx, callee) || args.iter().any(|arg| Self::in_operand(cx, arg))
     }
 }
 

--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -499,6 +499,8 @@ impl Qualif for IsNotConst {
 
 // Refers to temporaries which cannot be promoted as
 // promote_consts decided they weren't simple enough.
+// FIXME(oli-obk,eddyb): Remove this flag entirely and
+// solely process this information via `IsNotConst`.
 struct IsNotPromotable;
 
 impl Qualif for IsNotPromotable {

--- a/src/test/ui/consts/invalid_promotion.rs
+++ b/src/test/ui/consts/invalid_promotion.rs
@@ -1,0 +1,18 @@
+// compile-pass
+// note this was only reproducible with lib crates
+// compile-flags: --crate-type=lib
+
+pub struct Hz;
+
+impl Hz {
+    pub const fn num(&self) -> u32 {
+        42
+    }
+    pub const fn normalized(&self) -> Hz {
+        Hz
+    }
+
+    pub const fn as_u32(&self) -> u32 {
+        self.normalized().num() // this used to promote the `self.normalized()`
+    }
+}


### PR DESCRIPTION
fixes https://github.com/rust-lang/rust/issues/58767 and fixes https://github.com/rust-lang/rust/issues/58634

r? @eddyb 

should we additionally check the function call return type? It might be a promotable function (or any `const fn` inside a `const fn`), but its return type might contain interior mutability.