### PR TITLE
Update edition-guide

### DIFF
--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -60,7 +60,7 @@ macro_rules! book {
 // NOTE: When adding a book here, make sure to ALSO build the book by
 // adding a build step in `src/bootstrap/builder.rs`!
 book!(
-    EditionGuide, "src/doc/edition-guide", "edition-guide", RustbookVersion::MdBook1;
+    EditionGuide, "src/doc/edition-guide", "edition-guide", RustbookVersion::MdBook2;
     EmbeddedBook, "src/doc/embedded-book", "embedded-book", RustbookVersion::MdBook2;
     Nomicon, "src/doc/nomicon", "nomicon", RustbookVersion::MdBook1;
     Reference, "src/doc/reference", "reference", RustbookVersion::MdBook1;


### PR DESCRIPTION
15 commits in 419edb885ec1a98c0747b3907003d79e3e6b93a9..5f3cc2a5618700efcde3bc00799744f21fa9ad2e
2018-12-04 16:43:38 -0500 to 2019-02-27 20:11:50 -0800
- Migrate to mdbook 0.2. (rust-lang-nursery/edition-guide#152)
- Remove automatic deployment. (rust-lang-nursery/edition-guide#151)
- Fix issue with rust's linkchecker and mdbook. (rust-lang-nursery/edition-guide#147)
- Fix test now that overflowing_literals is rejected in all editions. (rust-lang-nursery/edition-guide#148)
- overflowing_literals is deny on all editions (rust-lang-nursery/edition-guide#146)
- Update for uniform_path stabilization. (rust-lang-nursery/edition-guide#141)
- Add example to rustup to show overriding to specific version (rust-lang-nursery/edition-guide#144)
- Update for anonymous-lifetime stabilization. (rust-lang-nursery/edition-guide#142)
- Add minimum Rust version for Kleene operator (rust-lang-nursery/edition-guide#137)
- Add 2018-specific changes. (rust-lang-nursery/edition-guide#130)
- aborting-on-panic.md: Typo in example config (rust-lang-nursery/edition-guide#125)
- Clarify uniform paths are not yet in Rust 2018 (rust-lang-nursery/edition-guide#124)
- update several version numbers
- Fixes outdated link (rust-lang-nursery/edition-guide#131)
- Fixed typo in transitioning page. (rust-lang-nursery/edition-guide#127)