### PR TITLE
Fix copy_from_slice

### DIFF
--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -1968,7 +1968,7 @@ impl<T> [T] {
         assert_eq!(self.len(), src.len(),
                    "destination and source slices have different lengths");
         unsafe {
-            ptr::copy_nonoverlapping(
+            ptr::copy(
                 src.as_ptr(), self.as_mut_ptr(), self.len());
         }
     }


### PR DESCRIPTION
There is no guarantee that the slices are not overlapping.

This was discovered due to https://github.com/rust-lang/rust/pull/58783