### PR TITLE
Misc refactorings to rustc_codegen_ssa

### DIFF
--- a/src/librustc_codegen_llvm/abi.rs
+++ b/src/librustc_codegen_llvm/abi.rs
@@ -859,4 +859,8 @@ impl AbiBuilderMethods<'tcx> for Builder<'a, 'll, 'tcx> {
     ) {
         ty.apply_attrs_callsite(self, callsite)
     }
+
+    fn get_param(&self, index: usize) -> Self::Value {
+        llvm::get_param(self.llfn(), index as c_uint)
+    }
 }

--- a/src/librustc_codegen_llvm/builder.rs
+++ b/src/librustc_codegen_llvm/builder.rs
@@ -1471,7 +1471,7 @@ impl BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
 }
 
 impl StaticBuilderMethods<'tcx> for Builder<'a, 'll, 'tcx> {
-    fn get_static(&self, def_id: DefId) -> &'ll Value {
+    fn get_static(&mut self, def_id: DefId) -> &'ll Value {
         // Forward to the `get_static` method of `CodegenCx`
         self.cx().get_static(def_id)
     }

--- a/src/librustc_codegen_llvm/builder.rs
+++ b/src/librustc_codegen_llvm/builder.rs
@@ -21,6 +21,7 @@ use rustc_codegen_ssa::mir::place::PlaceRef;
 use std::borrow::Cow;
 use std::ops::{Deref, Range};
 use std::ptr;
+use std::iter::TrustedLen;
 
 // All Builders must have an llfn associated with them
 #[must_use]
@@ -169,11 +170,10 @@ impl BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
         &mut self,
         v: &'ll Value,
         else_llbb: &'ll BasicBlock,
-        num_cases: usize,
-        cases: impl Iterator<Item = (u128, &'ll BasicBlock)>,
+        cases: impl ExactSizeIterator<Item = (u128, &'ll BasicBlock)> + TrustedLen,
     ) {
         let switch = unsafe {
-            llvm::LLVMBuildSwitch(self.llbuilder, v, else_llbb, num_cases as c_uint)
+            llvm::LLVMBuildSwitch(self.llbuilder, v, else_llbb, cases.len() as c_uint)
         };
         for (on_val, dest) in cases {
             let on_val = self.const_uint_big(self.val_ty(v), on_val);

--- a/src/librustc_codegen_llvm/builder.rs
+++ b/src/librustc_codegen_llvm/builder.rs
@@ -616,7 +616,7 @@ impl BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
         assert_eq!(place.llextra.is_some(), place.layout.is_unsized());
 
         if place.layout.is_zst() {
-            return OperandRef::new_zst(self.cx(), place.layout);
+            return OperandRef::new_zst(self, place.layout);
         }
 
         fn scalar_load_metadata<'a, 'll, 'tcx>(

--- a/src/librustc_codegen_llvm/builder.rs
+++ b/src/librustc_codegen_llvm/builder.rs
@@ -1472,6 +1472,7 @@ impl BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
 
 impl StaticBuilderMethods<'tcx> for Builder<'a, 'll, 'tcx> {
     fn get_static(&self, def_id: DefId) -> &'ll Value {
+        // Forward to the `get_static` method of `CodegenCx`
         self.cx().get_static(def_id)
     }
 }

--- a/src/librustc_codegen_llvm/builder.rs
+++ b/src/librustc_codegen_llvm/builder.rs
@@ -170,9 +170,16 @@ impl BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
         v: &'ll Value,
         else_llbb: &'ll BasicBlock,
         num_cases: usize,
-    ) -> &'ll Value {
-        unsafe {
+        cases: impl Iterator<Item = (u128, &'ll BasicBlock)>,
+    ) {
+        let switch = unsafe {
             llvm::LLVMBuildSwitch(self.llbuilder, v, else_llbb, num_cases as c_uint)
+        };
+        for (on_val, dest) in cases {
+            let on_val = self.const_uint_big(self.val_ty(v), on_val);
+            unsafe {
+                llvm::LLVMAddCase(switch, on_val, dest)
+            }
         }
     }
 
@@ -1155,12 +1162,6 @@ impl BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
                 AtomicOrdering::from_generic(order),
                 SynchronizationScope::from_generic(scope)
             );
-        }
-    }
-
-    fn add_case(&mut self, s: &'ll Value, on_val: &'ll Value, dest: &'ll BasicBlock) {
-        unsafe {
-            llvm::LLVMAddCase(s, on_val, dest)
         }
     }
 

--- a/src/librustc_codegen_llvm/common.rs
+++ b/src/librustc_codegen_llvm/common.rs
@@ -119,6 +119,72 @@ impl CodegenCx<'ll, 'tcx> {
     pub fn const_bytes(&self, bytes: &[u8]) -> &'ll Value {
         bytes_in_context(self.llcx, bytes)
     }
+
+    fn const_cstr(
+        &self,
+        s: LocalInternedString,
+        null_terminated: bool,
+    ) -> &'ll Value {
+        unsafe {
+            if let Some(&llval) = self.const_cstr_cache.borrow().get(&s) {
+                return llval;
+            }
+
+            let sc = llvm::LLVMConstStringInContext(self.llcx,
+                                                    s.as_ptr() as *const c_char,
+                                                    s.len() as c_uint,
+                                                    !null_terminated as Bool);
+            let sym = self.generate_local_symbol_name("str");
+            let g = self.define_global(&sym[..], self.val_ty(sc)).unwrap_or_else(||{
+                bug!("symbol `{}` is already defined", sym);
+            });
+            llvm::LLVMSetInitializer(g, sc);
+            llvm::LLVMSetGlobalConstant(g, True);
+            llvm::LLVMRustSetLinkage(g, llvm::Linkage::InternalLinkage);
+
+            self.const_cstr_cache.borrow_mut().insert(s, g);
+            g
+        }
+    }
+
+    pub fn const_str_slice(&self, s: LocalInternedString) -> &'ll Value {
+        let len = s.len();
+        let cs = consts::ptrcast(self.const_cstr(s, false),
+            self.type_ptr_to(self.layout_of(self.tcx.mk_str()).llvm_type(self)));
+        self.const_fat_ptr(cs, self.const_usize(len as u64))
+    }
+
+    pub fn const_get_elt(&self, v: &'ll Value, idx: u64) -> &'ll Value {
+        unsafe {
+            assert_eq!(idx as c_uint as u64, idx);
+            let us = &[idx as c_uint];
+            let r = llvm::LLVMConstExtractValue(v, us.as_ptr(), us.len() as c_uint);
+
+            debug!("const_get_elt(v={:?}, idx={}, r={:?})",
+                   v, idx, r);
+
+            r
+        }
+    }
+
+    pub fn const_get_real(&self, v: &'ll Value) -> Option<(f64, bool)> {
+        unsafe {
+            if self.is_const_real(v) {
+                let mut loses_info: llvm::Bool = ::std::mem::uninitialized();
+                let r = llvm::LLVMConstRealGetDouble(v, &mut loses_info);
+                let loses_info = if loses_info == 1 { true } else { false };
+                Some((r, loses_info))
+            } else {
+                None
+            }
+        }
+    }
+
+    fn is_const_real(&self, v: &'ll Value) -> bool {
+        unsafe {
+            llvm::LLVMIsAConstantFP(v).is_some()
+        }
+    }
 }
 
 impl ConstMethods<'tcx> for CodegenCx<'ll, 'tcx> {
@@ -183,72 +249,12 @@ impl ConstMethods<'tcx> for CodegenCx<'ll, 'tcx> {
         self.const_uint(self.type_i8(), i as u64)
     }
 
-    fn const_cstr(
-        &self,
-        s: LocalInternedString,
-        null_terminated: bool,
-    ) -> &'ll Value {
-        unsafe {
-            if let Some(&llval) = self.const_cstr_cache.borrow().get(&s) {
-                return llval;
-            }
-
-            let sc = llvm::LLVMConstStringInContext(self.llcx,
-                                                    s.as_ptr() as *const c_char,
-                                                    s.len() as c_uint,
-                                                    !null_terminated as Bool);
-            let sym = self.generate_local_symbol_name("str");
-            let g = self.define_global(&sym[..], self.val_ty(sc)).unwrap_or_else(||{
-                bug!("symbol `{}` is already defined", sym);
-            });
-            llvm::LLVMSetInitializer(g, sc);
-            llvm::LLVMSetGlobalConstant(g, True);
-            llvm::LLVMRustSetLinkage(g, llvm::Linkage::InternalLinkage);
-
-            self.const_cstr_cache.borrow_mut().insert(s, g);
-            g
-        }
-    }
-
-    fn const_str_slice(&self, s: LocalInternedString) -> &'ll Value {
-        let len = s.len();
-        let cs = consts::ptrcast(self.const_cstr(s, false),
-            self.type_ptr_to(self.layout_of(self.tcx.mk_str()).llvm_type(self)));
-        self.const_fat_ptr(cs, self.const_usize(len as u64))
-    }
-
     fn const_struct(
         &self,
         elts: &[&'ll Value],
         packed: bool
     ) -> &'ll Value {
         struct_in_context(self.llcx, elts, packed)
-    }
-
-    fn const_get_elt(&self, v: &'ll Value, idx: u64) -> &'ll Value {
-        unsafe {
-            assert_eq!(idx as c_uint as u64, idx);
-            let us = &[idx as c_uint];
-            let r = llvm::LLVMConstExtractValue(v, us.as_ptr(), us.len() as c_uint);
-
-            debug!("const_get_elt(v={:?}, idx={}, r={:?})",
-                   v, idx, r);
-
-            r
-        }
-    }
-
-    fn const_get_real(&self, v: &'ll Value) -> Option<(f64, bool)> {
-        unsafe {
-            if self.is_const_real(v) {
-                let mut loses_info: llvm::Bool = ::std::mem::uninitialized();
-                let r = llvm::LLVMConstRealGetDouble(v, &mut loses_info);
-                let loses_info = if loses_info == 1 { true } else { false };
-                Some((r, loses_info))
-            } else {
-                None
-            }
-        }
     }
 
     fn const_to_uint(&self, v: &'ll Value) -> u64 {
@@ -260,12 +266,6 @@ impl ConstMethods<'tcx> for CodegenCx<'ll, 'tcx> {
     fn is_const_integral(&self, v: &'ll Value) -> bool {
         unsafe {
             llvm::LLVMIsAConstantInt(v).is_some()
-        }
-    }
-
-    fn is_const_real(&self, v: &'ll Value) -> bool {
-        unsafe {
-            llvm::LLVMIsAConstantFP(v).is_some()
         }
     }
 

--- a/src/librustc_codegen_llvm/context.rs
+++ b/src/librustc_codegen_llvm/context.rs
@@ -10,7 +10,6 @@ use crate::monomorphize::partitioning::CodegenUnit;
 use crate::type_::Type;
 use crate::type_of::PointeeInfo;
 use rustc_codegen_ssa::traits::*;
-use libc::c_uint;
 
 use rustc_data_structures::base_n;
 use rustc_data_structures::small_c_str::SmallCStr;
@@ -324,10 +323,6 @@ impl MiscMethods<'tcx> for CodegenCx<'ll, 'tcx> {
 
     fn get_fn(&self, instance: Instance<'tcx>) -> &'ll Value {
         get_fn(self, instance)
-    }
-
-    fn get_param(&self, llfn: &'ll Value, index: usize) -> &'ll Value {
-        llvm::get_param(llfn, index as c_uint)
     }
 
     fn eh_personality(&self) -> &'ll Value {

--- a/src/librustc_codegen_llvm/context.rs
+++ b/src/librustc_codegen_llvm/context.rs
@@ -326,8 +326,8 @@ impl MiscMethods<'tcx> for CodegenCx<'ll, 'tcx> {
         get_fn(self, instance)
     }
 
-    fn get_param(&self, llfn: &'ll Value, index: c_uint) -> &'ll Value {
-        llvm::get_param(llfn, index)
+    fn get_param(&self, llfn: &'ll Value, index: usize) -> &'ll Value {
+        llvm::get_param(llfn, index as c_uint)
     }
 
     fn eh_personality(&self) -> &'ll Value {

--- a/src/librustc_codegen_llvm/debuginfo/mod.rs
+++ b/src/librustc_codegen_llvm/debuginfo/mod.rs
@@ -32,7 +32,7 @@ use rustc_codegen_ssa::debuginfo::{FunctionDebugContext, MirDebugScope, Variable
     VariableKind, FunctionDebugContextData};
 
 use libc::c_uint;
-use std::cell::{Cell, RefCell};
+use std::cell::RefCell;
 use std::ffi::CString;
 
 use syntax_pos::{self, Span, Pos};
@@ -158,7 +158,7 @@ impl DebugInfoBuilderMethods<'tcx> for Builder<'a, 'll, 'tcx> {
         variable_kind: VariableKind,
         span: Span,
     ) {
-        assert!(!dbg_context.get_ref(span).source_locations_enabled.get());
+        assert!(!dbg_context.get_ref(span).source_locations_enabled);
         let cx = self.cx();
 
         let file = span_start(cx, span).file;
@@ -327,7 +327,7 @@ impl DebugInfoMethods<'tcx> for CodegenCx<'ll, 'tcx> {
         // Initialize fn debug context (including scope map and namespace map)
         let fn_debug_context = FunctionDebugContextData {
             fn_metadata,
-            source_locations_enabled: Cell::new(false),
+            source_locations_enabled: false,
             defining_crate: def_id.krate,
         };
 

--- a/src/librustc_codegen_llvm/debuginfo/mod.rs
+++ b/src/librustc_codegen_llvm/debuginfo/mod.rs
@@ -216,7 +216,7 @@ impl DebugInfoBuilderMethods<'tcx> for Builder<'a, 'll, 'tcx> {
 
     fn set_source_location(
         &mut self,
-        debug_context: &FunctionDebugContext<&'ll DISubprogram>,
+        debug_context: &mut FunctionDebugContext<&'ll DISubprogram>,
         scope: Option<&'ll DIScope>,
         span: Span,
     ) {
@@ -519,7 +519,7 @@ impl DebugInfoMethods<'tcx> for CodegenCx<'ll, 'tcx> {
     fn create_mir_scopes(
         &self,
         mir: &mir::Mir<'_>,
-        debug_context: &FunctionDebugContext<&'ll DISubprogram>,
+        debug_context: &mut FunctionDebugContext<&'ll DISubprogram>,
     ) -> IndexVec<mir::SourceScope, MirDebugScope<&'ll DIScope>> {
         create_scope_map::create_mir_scopes(self, mir, debug_context)
     }

--- a/src/librustc_codegen_llvm/debuginfo/mod.rs
+++ b/src/librustc_codegen_llvm/debuginfo/mod.rs
@@ -225,6 +225,13 @@ impl DebugInfoBuilderMethods<'tcx> for Builder<'a, 'll, 'tcx> {
     fn insert_reference_to_gdb_debug_scripts_section_global(&mut self) {
         gdb::insert_reference_to_gdb_debug_scripts_section_global(self)
     }
+
+    fn set_value_name(&mut self, value: &'ll Value, name: &str) {
+        let cname = SmallCStr::new(name);
+        unsafe {
+            llvm::LLVMSetValueName(value, cname.as_ptr());
+        }
+    }
 }
 
 impl DebugInfoMethods<'tcx> for CodegenCx<'ll, 'tcx> {

--- a/src/librustc_codegen_llvm/debuginfo/source_loc.rs
+++ b/src/librustc_codegen_llvm/debuginfo/source_loc.rs
@@ -30,7 +30,7 @@ pub fn set_source_location<D>(
         FunctionDebugContext::RegularContext(ref data) => data
     };
 
-    let dbg_loc = if function_debug_context.source_locations_enabled.get() {
+    let dbg_loc = if function_debug_context.source_locations_enabled {
         debug!("set_source_location: {}", bx.sess().source_map().span_to_string(span));
         let loc = span_start(bx.cx(), span);
         InternalDebugLocation::new(scope.unwrap(), loc.line, loc.col.to_usize())

--- a/src/librustc_codegen_llvm/lib.rs
+++ b/src/librustc_codegen_llvm/lib.rs
@@ -20,6 +20,7 @@
 #![feature(concat_idents)]
 #![feature(link_args)]
 #![feature(static_nobundle)]
+#![feature(trusted_len)]
 #![deny(rust_2018_idioms)]
 #![allow(explicit_outlives_requirements)]
 

--- a/src/librustc_codegen_llvm/type_.rs
+++ b/src/librustc_codegen_llvm/type_.rs
@@ -11,7 +11,6 @@ use rustc_codegen_ssa::traits::*;
 use crate::common;
 use crate::type_of::LayoutLlvmExt;
 use crate::abi::{LlvmType, FnTypeExt};
-use rustc::util::nodemap::FxHashMap;
 use rustc::ty::Ty;
 use rustc::ty::layout::TyLayout;
 use rustc_target::abi::call::{CastTarget, FnType, Reg};
@@ -19,7 +18,6 @@ use rustc_data_structures::small_c_str::SmallCStr;
 use rustc_codegen_ssa::common::TypeKind;
 
 use std::fmt;
-use std::cell::RefCell;
 use std::ptr;
 
 use libc::c_uint;
@@ -231,10 +229,6 @@ impl BaseTypeMethods<'tcx> for CodegenCx<'ll, 'tcx> {
 
     fn val_ty(&self, v: &'ll Value) -> &'ll Type {
         common::val_ty(v)
-    }
-
-    fn scalar_lltypes(&self) -> &RefCell<FxHashMap<Ty<'tcx>, Self::Type>> {
-        &self.scalar_lltypes
     }
 }
 

--- a/src/librustc_codegen_llvm/type_.rs
+++ b/src/librustc_codegen_llvm/type_.rs
@@ -141,6 +141,23 @@ impl CodegenCx<'ll, 'tcx> {
         assert_eq!(size % unit_size, 0);
         self.type_array(self.type_from_integer(unit), size / unit_size)
     }
+
+    crate fn type_variadic_func(
+        &self,
+        args: &[&'ll Type],
+        ret: &'ll Type
+    ) -> &'ll Type {
+        unsafe {
+            llvm::LLVMFunctionType(ret, args.as_ptr(),
+                                   args.len() as c_uint, True)
+        }
+    }
+
+    crate fn type_array(&self, ty: &'ll Type, len: u64) -> &'ll Type {
+        unsafe {
+            llvm::LLVMRustArrayType(ty, len)
+        }
+    }
 }
 
 impl BaseTypeMethods<'tcx> for CodegenCx<'ll, 'tcx> {
@@ -208,17 +225,6 @@ impl BaseTypeMethods<'tcx> for CodegenCx<'ll, 'tcx> {
         }
     }
 
-    fn type_variadic_func(
-        &self,
-        args: &[&'ll Type],
-        ret: &'ll Type
-    ) -> &'ll Type {
-        unsafe {
-            llvm::LLVMFunctionType(ret, args.as_ptr(),
-                                   args.len() as c_uint, True)
-        }
-    }
-
     fn type_struct(
         &self,
         els: &[&'ll Type],
@@ -228,13 +234,6 @@ impl BaseTypeMethods<'tcx> for CodegenCx<'ll, 'tcx> {
             llvm::LLVMStructTypeInContext(self.llcx, els.as_ptr(),
                                           els.len() as c_uint,
                                           packed as Bool)
-        }
-    }
-
-
-    fn type_array(&self, ty: &'ll Type, len: u64) -> &'ll Type {
-        unsafe {
-            llvm::LLVMRustArrayType(ty, len)
         }
     }
 

--- a/src/librustc_codegen_ssa/base.rs
+++ b/src/librustc_codegen_ssa/base.rs
@@ -501,8 +501,8 @@ pub fn maybe_create_entry_wrapper<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>>(
         bx.insert_reference_to_gdb_debug_scripts_section_global();
 
         // Params from native main() used as args for rust start function
-        let param_argc = cx.get_param(llfn, 0);
-        let param_argv = cx.get_param(llfn, 1);
+        let param_argc = bx.get_param(0);
+        let param_argv = bx.get_param(1);
         let arg_argc = bx.intcast(param_argc, cx.type_isize(), true);
         let arg_argv = param_argv;
 

--- a/src/librustc_codegen_ssa/common.rs
+++ b/src/librustc_codegen_ssa/common.rs
@@ -1,7 +1,7 @@
 #![allow(non_camel_case_types, non_snake_case)]
 
-use rustc::ty::{self, Ty, TyCtxt};
-use syntax_pos::{DUMMY_SP, Span};
+use rustc::ty::{Ty, TyCtxt};
+use syntax_pos::Span;
 
 use rustc::hir::def_id::DefId;
 use rustc::middle::lang_items::LangItem;
@@ -10,18 +10,6 @@ use crate::traits::*;
 
 use rustc::hir;
 use crate::traits::BuilderMethods;
-
-pub fn type_needs_drop<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, ty: Ty<'tcx>) -> bool {
-    ty.needs_drop(tcx, ty::ParamEnv::reveal_all())
-}
-
-pub fn type_is_sized<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, ty: Ty<'tcx>) -> bool {
-    ty.is_sized(tcx.at(DUMMY_SP), ty::ParamEnv::reveal_all())
-}
-
-pub fn type_is_freeze<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, ty: Ty<'tcx>) -> bool {
-    ty.is_freeze(tcx, ty::ParamEnv::reveal_all(), DUMMY_SP)
-}
 
 pub enum IntPredicate {
     IntEQ,

--- a/src/librustc_codegen_ssa/debuginfo.rs
+++ b/src/librustc_codegen_ssa/debuginfo.rs
@@ -1,6 +1,5 @@
 use syntax_pos::{BytePos, Span};
 use rustc::hir::def_id::CrateNum;
-use std::cell::Cell;
 
 pub enum FunctionDebugContext<D> {
     RegularContext(FunctionDebugContextData<D>),
@@ -36,10 +35,10 @@ impl<D> FunctionDebugContext<D> {
 /// they are disabled when beginning to codegen a new function. This functions
 /// switches source location emitting on and must therefore be called before the
 /// first real statement/expression of the function is codegened.
-pub fn start_emitting_source_locations<D>(dbg_context: &FunctionDebugContext<D>) {
+pub fn start_emitting_source_locations<D>(dbg_context: &mut FunctionDebugContext<D>) {
     match *dbg_context {
-        FunctionDebugContext::RegularContext(ref data) => {
-            data.source_locations_enabled.set(true)
+        FunctionDebugContext::RegularContext(ref mut data) => {
+            data.source_locations_enabled = true;
         },
         _ => { /* safe to ignore */ }
     }
@@ -47,7 +46,7 @@ pub fn start_emitting_source_locations<D>(dbg_context: &FunctionDebugContext<D>)
 
 pub struct FunctionDebugContextData<D> {
     pub fn_metadata: D,
-    pub source_locations_enabled: Cell<bool>,
+    pub source_locations_enabled: bool,
     pub defining_crate: CrateNum,
 }
 

--- a/src/librustc_codegen_ssa/lib.rs
+++ b/src/librustc_codegen_ssa/lib.rs
@@ -10,6 +10,7 @@
 #![feature(try_blocks)]
 #![feature(in_band_lifetimes)]
 #![feature(nll)]
+#![feature(trusted_len)]
 #![allow(unused_attributes)]
 #![allow(dead_code)]
 #![deny(rust_2018_idioms)]

--- a/src/librustc_codegen_ssa/mir/block.rs
+++ b/src/librustc_codegen_ssa/mir/block.rs
@@ -657,7 +657,7 @@ impl<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                             span_bug!(span, "shuffle indices must be constant");
                         }
                         mir::Operand::Constant(ref constant) => {
-                            let c = self.eval_mir_constant(&bx, constant);
+                            let c = self.eval_mir_constant(constant);
                             let (llval, ty) = self.simd_shuffle_indices(
                                 &bx,
                                 constant.span,

--- a/src/librustc_codegen_ssa/mir/block.rs
+++ b/src/librustc_codegen_ssa/mir/block.rs
@@ -399,12 +399,8 @@ impl<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         // Get the location information.
         let loc = bx.sess().source_map().lookup_char_pos(span.lo());
         let filename = Symbol::intern(&loc.file.name.to_string()).as_str();
-        let filename = bx.const_str_slice(filename);
         let line = bx.const_u32(loc.line as u32);
         let col = bx.const_u32(loc.col.to_usize() as u32 + 1);
-        let align = self.cx.tcx().data_layout.aggregate_align.abi
-            .max(self.cx.tcx().data_layout.i32_align.abi)
-            .max(self.cx.tcx().data_layout.pointer_align.abi);
 
         // Put together the arguments to the panic entry point.
         let (lang_item, args) = match *msg {
@@ -412,30 +408,28 @@ impl<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 let len = self.codegen_operand(&mut bx, len).immediate();
                 let index = self.codegen_operand(&mut bx, index).immediate();
 
-                let file_line_col = bx.const_struct(&[filename, line, col], false);
-                let file_line_col = bx.static_addr_of(
-                    file_line_col,
-                    align,
-                    Some("panic_bounds_check_loc")
+                let file_line_col = bx.static_panic_msg(
+                    None,
+                    filename,
+                    line,
+                    col,
+                    "panic_bounds_check_loc",
                 );
                 (lang_items::PanicBoundsCheckFnLangItem,
-                 vec![file_line_col, index, len])
+                    vec![file_line_col, index, len])
             }
             _ => {
                 let str = msg.description();
                 let msg_str = Symbol::intern(str).as_str();
-                let msg_str = bx.const_str_slice(msg_str);
-                let msg_file_line_col = bx.const_struct(
-                    &[msg_str, filename, line, col],
-                    false
-                );
-                let msg_file_line_col = bx.static_addr_of(
-                    msg_file_line_col,
-                    align,
-                    Some("panic_loc")
+                let msg_file_line_col = bx.static_panic_msg(
+                    Some(msg_str),
+                    filename,
+                    line,
+                    col,
+                    "panic_loc",
                 );
                 (lang_items::PanicFnLangItem,
-                 vec![msg_file_line_col])
+                    vec![msg_file_line_col])
             }
         };
 
@@ -539,27 +533,20 @@ impl<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             if layout.abi.is_uninhabited() {
                 let loc = bx.sess().source_map().lookup_char_pos(span.lo());
                 let filename = Symbol::intern(&loc.file.name.to_string()).as_str();
-                let filename = bx.const_str_slice(filename);
                 let line = bx.const_u32(loc.line as u32);
                 let col = bx.const_u32(loc.col.to_usize() as u32 + 1);
-                let align = self.cx.tcx().data_layout.aggregate_align.abi
-                    .max(self.cx.tcx().data_layout.i32_align.abi)
-                    .max(self.cx.tcx().data_layout.pointer_align.abi);
 
                 let str = format!(
                     "Attempted to instantiate uninhabited type {}",
                     ty
                 );
                 let msg_str = Symbol::intern(&str).as_str();
-                let msg_str = bx.const_str_slice(msg_str);
-                let msg_file_line_col = bx.const_struct(
-                    &[msg_str, filename, line, col],
-                    false,
-                );
-                let msg_file_line_col = bx.static_addr_of(
-                    msg_file_line_col,
-                    align,
-                    Some("panic_loc"),
+                let msg_file_line_col = bx.static_panic_msg(
+                    Some(msg_str),
+                    filename,
+                    line,
+                    col,
+                    "panic_loc",
                 );
 
                 // Obtain the panic entry point.

--- a/src/librustc_codegen_ssa/mir/block.rs
+++ b/src/librustc_codegen_ssa/mir/block.rs
@@ -217,7 +217,6 @@ impl<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             bx.switch(
                 discr.immediate(),
                 helper.llblock(self, *otherwise),
-                values.len(),
                 values.iter().zip(targets).map(|(&value, target)| {
                     (value, helper.llblock(self, *target))
                 })

--- a/src/librustc_codegen_ssa/mir/block.rs
+++ b/src/librustc_codegen_ssa/mir/block.rs
@@ -214,17 +214,14 @@ impl<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             }
         } else {
             let (otherwise, targets) = targets.split_last().unwrap();
-            let switch = bx.switch(discr.immediate(),
-                                   helper.llblock(self, *otherwise),
-                                   values.len());
-            let switch_llty = bx.immediate_backend_type(
-                bx.layout_of(switch_ty)
+            bx.switch(
+                discr.immediate(),
+                helper.llblock(self, *otherwise),
+                values.len(),
+                values.iter().zip(targets).map(|(&value, target)| {
+                    (value, helper.llblock(self, *target))
+                })
             );
-            for (&value, target) in values.iter().zip(targets) {
-                let llval = bx.const_uint_big(switch_llty, value);
-                let llbb = helper.llblock(self, *target);
-                bx.add_case(switch, llval, llbb)
-            }
         }
     }
 

--- a/src/librustc_codegen_ssa/mir/mod.rs
+++ b/src/librustc_codegen_ssa/mir/mod.rs
@@ -334,7 +334,7 @@ pub fn codegen_mir<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>>(
     // Up until here, IR instructions for this function have explicitly not been annotated with
     // source code location, so we don't step into call setup code. From here on, source location
     // emitting should be enabled.
-    debuginfo::start_emitting_source_locations(&fx.debug_context);
+    debuginfo::start_emitting_source_locations(&mut fx.debug_context);
 
     let rpo = traversal::reverse_postorder(&mir);
     let mut visited = BitSet::new_empty(mir.basic_blocks().len());

--- a/src/librustc_codegen_ssa/mir/mod.rs
+++ b/src/librustc_codegen_ssa/mir/mod.rs
@@ -295,7 +295,7 @@ pub fn codegen_mir<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>>(
                 // Temporary or return place
                 if local == mir::RETURN_PLACE && fx.fn_ty.ret.is_indirect() {
                     debug!("alloc: {:?} (return place) -> place", local);
-                    let llretptr = fx.cx.get_param(llfn, 0);
+                    let llretptr = bx.get_param(0);
                     LocalRef::Place(PlaceRef::new_sized(llretptr, layout, layout.align.abi))
                 } else if memory_locals.contains(local) {
                     debug!("alloc: {:?} -> place", local);
@@ -523,18 +523,18 @@ fn arg_local_refs<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>>(
                 }
                 PassMode::Ignore(IgnoreMode::CVarArgs) => {}
                 PassMode::Direct(_) => {
-                    let llarg = bx.get_param(bx.llfn(), llarg_idx);
+                    let llarg = bx.get_param(llarg_idx);
                     bx.set_value_name(llarg, &name);
                     llarg_idx += 1;
                     return local(
                         OperandRef::from_immediate_or_packed_pair(bx, llarg, arg.layout));
                 }
                 PassMode::Pair(..) => {
-                    let a = bx.get_param(bx.llfn(), llarg_idx);
+                    let a = bx.get_param(llarg_idx);
                     bx.set_value_name(a, &(name.clone() + ".0"));
                     llarg_idx += 1;
 
-                    let b = bx.get_param(bx.llfn(), llarg_idx);
+                    let b = bx.get_param(llarg_idx);
                     bx.set_value_name(b, &(name + ".1"));
                     llarg_idx += 1;
 
@@ -551,16 +551,16 @@ fn arg_local_refs<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>>(
             // Don't copy an indirect argument to an alloca, the caller
             // already put it in a temporary alloca and gave it up.
             // FIXME: lifetimes
-            let llarg = bx.get_param(bx.llfn(), llarg_idx);
+            let llarg = bx.get_param(llarg_idx);
             bx.set_value_name(llarg, &name);
             llarg_idx += 1;
             PlaceRef::new_sized(llarg, arg.layout, arg.layout.align.abi)
         } else if arg.is_unsized_indirect() {
             // As the storage for the indirect argument lives during
             // the whole function call, we just copy the fat pointer.
-            let llarg = bx.get_param(bx.llfn(), llarg_idx);
+            let llarg = bx.get_param(llarg_idx);
             llarg_idx += 1;
-            let llextra = bx.get_param(bx.llfn(), llarg_idx);
+            let llextra = bx.get_param(llarg_idx);
             llarg_idx += 1;
             let indirect_operand = OperandValue::Pair(llarg, llextra);
 

--- a/src/librustc_codegen_ssa/mir/mod.rs
+++ b/src/librustc_codegen_ssa/mir/mod.rs
@@ -1,4 +1,3 @@
-use libc::c_uint;
 use rustc::ty::{self, Ty, TypeFoldable, UpvarSubsts};
 use rustc::ty::layout::{TyLayout, HasTyCtxt};
 use rustc::mir::{self, Mir};
@@ -534,18 +533,18 @@ fn arg_local_refs<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>>(
                 }
                 PassMode::Ignore(IgnoreMode::CVarArgs) => {}
                 PassMode::Direct(_) => {
-                    let llarg = bx.get_param(bx.llfn(), llarg_idx as c_uint);
+                    let llarg = bx.get_param(bx.llfn(), llarg_idx);
                     bx.set_value_name(llarg, &name);
                     llarg_idx += 1;
                     return local(
                         OperandRef::from_immediate_or_packed_pair(bx, llarg, arg.layout));
                 }
                 PassMode::Pair(..) => {
-                    let a = bx.get_param(bx.llfn(), llarg_idx as c_uint);
+                    let a = bx.get_param(bx.llfn(), llarg_idx);
                     bx.set_value_name(a, &(name.clone() + ".0"));
                     llarg_idx += 1;
 
-                    let b = bx.get_param(bx.llfn(), llarg_idx as c_uint);
+                    let b = bx.get_param(bx.llfn(), llarg_idx);
                     bx.set_value_name(b, &(name + ".1"));
                     llarg_idx += 1;
 
@@ -562,16 +561,16 @@ fn arg_local_refs<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>>(
             // Don't copy an indirect argument to an alloca, the caller
             // already put it in a temporary alloca and gave it up.
             // FIXME: lifetimes
-            let llarg = bx.get_param(bx.llfn(), llarg_idx as c_uint);
+            let llarg = bx.get_param(bx.llfn(), llarg_idx);
             bx.set_value_name(llarg, &name);
             llarg_idx += 1;
             PlaceRef::new_sized(llarg, arg.layout, arg.layout.align.abi)
         } else if arg.is_unsized_indirect() {
             // As the storage for the indirect argument lives during
             // the whole function call, we just copy the fat pointer.
-            let llarg = bx.get_param(bx.llfn(), llarg_idx as c_uint);
+            let llarg = bx.get_param(bx.llfn(), llarg_idx);
             llarg_idx += 1;
-            let llextra = bx.get_param(bx.llfn(), llarg_idx as c_uint);
+            let llextra = bx.get_param(bx.llfn(), llarg_idx);
             llarg_idx += 1;
             let indirect_operand = OperandValue::Pair(llarg, llextra);
 

--- a/src/librustc_codegen_ssa/mir/operand.rs
+++ b/src/librustc_codegen_ssa/mir/operand.rs
@@ -54,13 +54,13 @@ impl<V: CodegenObject> fmt::Debug for OperandRef<'tcx, V> {
 }
 
 impl<'a, 'tcx: 'a, V: CodegenObject> OperandRef<'tcx, V> {
-    pub fn new_zst<Cx: CodegenMethods<'tcx, Value = V>>(
-        cx: &Cx,
+    pub fn new_zst<Bx: BuilderMethods<'a, 'tcx, Value = V>>(
+        bx: &mut Bx,
         layout: TyLayout<'tcx>
     ) -> OperandRef<'tcx, V> {
         assert!(layout.is_zst());
         OperandRef {
-            val: OperandValue::Immediate(cx.const_undef(cx.immediate_backend_type(layout))),
+            val: OperandValue::Immediate(bx.const_undef(bx.immediate_backend_type(layout))),
             layout
         }
     }
@@ -69,10 +69,10 @@ impl<'a, 'tcx: 'a, V: CodegenObject> OperandRef<'tcx, V> {
         bx: &mut Bx,
         val: ty::Const<'tcx>
     ) -> Result<Self, ErrorHandled> {
-        let layout = bx.cx().layout_of(val.ty);
+        let layout = bx.layout_of(val.ty);
 
         if layout.is_zst() {
-            return Ok(OperandRef::new_zst(bx.cx(), layout));
+            return Ok(OperandRef::new_zst(bx, layout));
         }
 
         let val = match val.val {
@@ -84,10 +84,10 @@ impl<'a, 'tcx: 'a, V: CodegenObject> OperandRef<'tcx, V> {
                     layout::Abi::Scalar(ref x) => x,
                     _ => bug!("from_const: invalid ByVal layout: {:#?}", layout)
                 };
-                let llval = bx.cx().scalar_to_backend(
+                let llval = bx.scalar_to_backend(
                     x,
                     scalar,
-                    bx.cx().immediate_backend_type(layout),
+                    bx.immediate_backend_type(layout),
                 );
                 OperandValue::Immediate(llval)
             },
@@ -96,16 +96,16 @@ impl<'a, 'tcx: 'a, V: CodegenObject> OperandRef<'tcx, V> {
                     layout::Abi::ScalarPair(ref a, _) => a,
                     _ => bug!("from_const: invalid ScalarPair layout: {:#?}", layout)
                 };
-                let a_llval = bx.cx().scalar_to_backend(
+                let a_llval = bx.scalar_to_backend(
                     a,
                     a_scalar,
-                    bx.cx().scalar_pair_element_backend_type(layout, 0, true),
+                    bx.scalar_pair_element_backend_type(layout, 0, true),
                 );
-                let b_llval = bx.cx().const_usize(b);
+                let b_llval = bx.const_usize(b);
                 OperandValue::Pair(a_llval, b_llval)
             },
             ConstValue::ByRef(ptr, alloc) => {
-                return Ok(bx.load_operand(bx.cx().from_const_alloc(layout, alloc, ptr.offset)));
+                return Ok(bx.load_operand(bx.from_const_alloc(layout, alloc, ptr.offset)));
             },
         };
 
@@ -124,7 +124,7 @@ impl<'a, 'tcx: 'a, V: CodegenObject> OperandRef<'tcx, V> {
         }
     }
 
-    pub fn deref<Cx: CodegenMethods<'tcx, Value = V>>(
+    pub fn deref<Cx: LayoutTypeMethods<'tcx>>(
         self,
         cx: &Cx
     ) -> PlaceRef<'tcx, V> {
@@ -199,7 +199,7 @@ impl<'a, 'tcx: 'a, V: CodegenObject> OperandRef<'tcx, V> {
         let mut val = match (self.val, &self.layout.abi) {
             // If the field is ZST, it has no data.
             _ if field.is_zst() => {
-                return OperandRef::new_zst(bx.cx(), field);
+                return OperandRef::new_zst(bx, field);
             }
 
             // Newtype of a scalar, scalar pair or vector.
@@ -409,7 +409,7 @@ impl<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                         // checks in `codegen_consume` and `extract_field`.
                         let elem = o.layout.field(bx.cx(), 0);
                         if elem.is_zst() {
-                            return Some(OperandRef::new_zst(bx.cx(), elem));
+                            return Some(OperandRef::new_zst(bx, elem));
                         }
                     }
                     _ => {}
@@ -432,7 +432,7 @@ impl<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
 
         // ZSTs don't require any actual memory access.
         if layout.is_zst() {
-            return OperandRef::new_zst(bx.cx(), layout);
+            return OperandRef::new_zst(bx, layout);
         }
 
         if let Some(o) = self.maybe_codegen_consume_direct(bx, place) {

--- a/src/librustc_codegen_ssa/mir/operand.rs
+++ b/src/librustc_codegen_ssa/mir/operand.rs
@@ -460,7 +460,7 @@ impl<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
 
             mir::Operand::Constant(ref constant) => {
                 let ty = self.monomorphize(&constant.ty);
-                self.eval_mir_constant(bx, constant)
+                self.eval_mir_constant(constant)
                     .and_then(|c| OperandRef::from_const(bx, c))
                     .unwrap_or_else(|err| {
                         match err {

--- a/src/librustc_codegen_ssa/mir/place.rs
+++ b/src/librustc_codegen_ssa/mir/place.rs
@@ -80,7 +80,7 @@ impl<'a, 'tcx: 'a, V: CodegenObject> PlaceRef<'tcx, V> {
         Self::alloca(bx, ptr_layout, name)
     }
 
-    pub fn len<Cx: CodegenMethods<'tcx, Value = V>>(
+    pub fn len<Cx: ConstMethods<'tcx, Value = V>>(
         &self,
         cx: &Cx
     ) -> V {
@@ -447,7 +447,8 @@ impl<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 // NB: The layout of a static may be unsized as is the case when working
                 // with a static that is an extern_type.
                 let layout = cx.layout_of(self.monomorphize(&ty));
-                PlaceRef::new_thin_place(bx, bx.get_static(def_id), layout, layout.align.abi)
+                let static_ = bx.get_static(def_id);
+                PlaceRef::new_thin_place(bx, static_, layout, layout.align.abi)
             },
             mir::Place::Projection(box mir::Projection {
                 ref base,

--- a/src/librustc_codegen_ssa/mir/rvalue.rs
+++ b/src/librustc_codegen_ssa/mir/rvalue.rs
@@ -523,8 +523,11 @@ impl<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 // According to `rvalue_creates_operand`, only ZST
                 // aggregate rvalues are allowed to be operands.
                 let ty = rvalue.ty(self.mir, self.cx.tcx());
-                (bx, OperandRef::new_zst(self.cx,
-                    self.cx.layout_of(self.monomorphize(&ty))))
+                let operand = OperandRef::new_zst(
+                    &mut bx,
+                    self.cx.layout_of(self.monomorphize(&ty)),
+                );
+                (bx, operand)
             }
         }
     }

--- a/src/librustc_codegen_ssa/mir/rvalue.rs
+++ b/src/librustc_codegen_ssa/mir/rvalue.rs
@@ -87,11 +87,11 @@ impl<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 if dest.layout.is_zst() {
                     return bx;
                 }
-                let zero = bx.cx().const_usize(0);
-                let start = dest.project_index(&mut bx, zero).llval;
 
                 if let OperandValue::Immediate(v) = cg_elem.val {
-                    let size = bx.cx().const_usize(dest.layout.size.bytes());
+                    let zero = bx.const_usize(0);
+                    let start = dest.project_index(&mut bx, zero).llval;
+                    let size = bx.const_usize(dest.layout.size.bytes());
 
                     // Use llvm.memset.p0i8.* to initialize all zero arrays
                     if bx.cx().is_const_integral(v) && bx.cx().const_to_uint(v) == 0 {
@@ -108,28 +108,7 @@ impl<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                     }
                 }
 
-                let count = bx.cx().const_usize(count);
-                let end = dest.project_index(&mut bx, count).llval;
-
-                let mut header_bx = bx.build_sibling_block("repeat_loop_header");
-                let mut body_bx = bx.build_sibling_block("repeat_loop_body");
-                let next_bx = bx.build_sibling_block("repeat_loop_next");
-
-                bx.br(header_bx.llbb());
-                let current = header_bx.phi(bx.cx().val_ty(start), &[start], &[bx.llbb()]);
-
-                let keep_going = header_bx.icmp(IntPredicate::IntNE, current, end);
-                header_bx.cond_br(keep_going, body_bx.llbb(), next_bx.llbb());
-
-                let align = dest.align.restrict_for_offset(dest.layout.field(bx.cx(), 0).size);
-                cg_elem.val.store(&mut body_bx,
-                    PlaceRef::new_sized(current, cg_elem.layout, align));
-
-                let next = body_bx.inbounds_gep(current, &[bx.cx().const_usize(1)]);
-                body_bx.br(header_bx.llbb());
-                header_bx.add_incoming_to_phi(current, next, body_bx.llbb());
-
-                next_bx
+                bx.write_operand_repeatedly(cg_elem, count, dest)
             }
 
             mir::Rvalue::Aggregate(ref kind, ref operands) => {

--- a/src/librustc_codegen_ssa/traits/abi.rs
+++ b/src/librustc_codegen_ssa/traits/abi.rs
@@ -10,4 +10,5 @@ pub trait AbiMethods<'tcx> {
 
 pub trait AbiBuilderMethods<'tcx>: BackendTypes {
     fn apply_attrs_callsite(&mut self, ty: &FnType<'tcx, Ty<'tcx>>, callsite: Self::Value);
+    fn get_param(&self, index: usize) -> Self::Value;
 }

--- a/src/librustc_codegen_ssa/traits/builder.rs
+++ b/src/librustc_codegen_ssa/traits/builder.rs
@@ -36,10 +36,8 @@ pub trait BuilderMethods<'a, 'tcx: 'a>:
     fn with_cx(cx: &'a Self::CodegenCx) -> Self;
     fn build_sibling_block<'b>(&self, name: &'b str) -> Self;
     fn cx(&self) -> &Self::CodegenCx;
-    fn llfn(&self) -> Self::Value;
     fn llbb(&self) -> Self::BasicBlock;
 
-    fn set_value_name(&mut self, value: Self::Value, name: &str);
     fn position_at_end(&mut self, llbb: Self::BasicBlock);
     fn ret_void(&mut self);
     fn ret(&mut self, v: Self::Value);
@@ -209,6 +207,7 @@ pub trait BuilderMethods<'a, 'tcx: 'a>:
         else_val: Self::Value,
     ) -> Self::Value;
 
+    fn va_arg(&mut self, list: Self::Value, ty: Self::Type) -> Self::Value;
     fn extract_element(&mut self, vec: Self::Value, idx: Self::Value) -> Self::Value;
     fn vector_splat(&mut self, num_elts: usize, elt: Self::Value) -> Self::Value;
     fn extract_value(&mut self, agg_val: Self::Value, idx: u64) -> Self::Value;

--- a/src/librustc_codegen_ssa/traits/builder.rs
+++ b/src/librustc_codegen_ssa/traits/builder.rs
@@ -116,6 +116,14 @@ pub trait BuilderMethods<'a, 'tcx: 'a>:
     fn load_operand(&mut self, place: PlaceRef<'tcx, Self::Value>)
         -> OperandRef<'tcx, Self::Value>;
 
+        /// Called for Rvalue::Repeat when the elem is neither a ZST nor optimizable using memset.
+    fn write_operand_repeatedly(
+        self,
+        elem: OperandRef<'tcx, Self::Value>,
+        count: u64,
+        dest: PlaceRef<'tcx, Self::Value>,
+    ) -> Self;
+
     fn range_metadata(&mut self, load: Self::Value, range: Range<u128>);
     fn nonnull_metadata(&mut self, load: Self::Value);
 
@@ -156,12 +164,6 @@ pub trait BuilderMethods<'a, 'tcx: 'a>:
     fn icmp(&mut self, op: IntPredicate, lhs: Self::Value, rhs: Self::Value) -> Self::Value;
     fn fcmp(&mut self, op: RealPredicate, lhs: Self::Value, rhs: Self::Value) -> Self::Value;
 
-    fn phi(
-        &mut self,
-        ty: Self::Type,
-        vals: &[Self::Value],
-        bbs: &[Self::BasicBlock],
-    ) -> Self::Value;
     fn inline_asm_call(
         &mut self,
         asm: &CStr,
@@ -255,7 +257,6 @@ pub trait BuilderMethods<'a, 'tcx: 'a>:
     ) -> Self::Value;
     fn atomic_fence(&mut self, order: AtomicOrdering, scope: SynchronizationScope);
     fn add_case(&mut self, s: Self::Value, on_val: Self::Value, dest: Self::BasicBlock);
-    fn add_incoming_to_phi(&mut self, phi: Self::Value, val: Self::Value, bb: Self::BasicBlock);
     fn set_invariant_load(&mut self, load: Self::Value);
 
     /// Called for `StorageLive`

--- a/src/librustc_codegen_ssa/traits/builder.rs
+++ b/src/librustc_codegen_ssa/traits/builder.rs
@@ -11,10 +11,7 @@ use crate::mir::place::PlaceRef;
 use crate::MemFlags;
 use rustc::ty::Ty;
 use rustc::ty::layout::{Align, Size};
-use std::ffi::CStr;
-
 use std::ops::Range;
-use syntax::ast::AsmDialect;
 
 #[derive(Copy, Clone)]
 pub enum OverflowOp {
@@ -163,17 +160,6 @@ pub trait BuilderMethods<'a, 'tcx: 'a>:
 
     fn icmp(&mut self, op: IntPredicate, lhs: Self::Value, rhs: Self::Value) -> Self::Value;
     fn fcmp(&mut self, op: RealPredicate, lhs: Self::Value, rhs: Self::Value) -> Self::Value;
-
-    fn inline_asm_call(
-        &mut self,
-        asm: &CStr,
-        cons: &CStr,
-        inputs: &[Self::Value],
-        output: Self::Type,
-        volatile: bool,
-        alignstack: bool,
-        dia: AsmDialect,
-    ) -> Option<Self::Value>;
 
     fn memcpy(
         &mut self,

--- a/src/librustc_codegen_ssa/traits/builder.rs
+++ b/src/librustc_codegen_ssa/traits/builder.rs
@@ -13,7 +13,6 @@ use rustc::ty::Ty;
 use rustc::ty::layout::{Align, Size};
 use std::ffi::CStr;
 
-use std::borrow::Cow;
 use std::ops::Range;
 use syntax::ast::AsmDialect;
 
@@ -39,11 +38,9 @@ pub trait BuilderMethods<'a, 'tcx: 'a>:
     fn cx(&self) -> &Self::CodegenCx;
     fn llfn(&self) -> Self::Value;
     fn llbb(&self) -> Self::BasicBlock;
-    fn count_insn(&self, category: &str);
 
     fn set_value_name(&mut self, value: Self::Value, name: &str);
     fn position_at_end(&mut self, llbb: Self::BasicBlock);
-    fn position_at_start(&mut self, llbb: Self::BasicBlock);
     fn ret_void(&mut self);
     fn ret(&mut self, v: Self::Value);
     fn br(&mut self, dest: Self::BasicBlock);
@@ -161,7 +158,6 @@ pub trait BuilderMethods<'a, 'tcx: 'a>:
     fn icmp(&mut self, op: IntPredicate, lhs: Self::Value, rhs: Self::Value) -> Self::Value;
     fn fcmp(&mut self, op: RealPredicate, lhs: Self::Value, rhs: Self::Value) -> Self::Value;
 
-    fn empty_phi(&mut self, ty: Self::Type) -> Self::Value;
     fn phi(
         &mut self,
         ty: Self::Type,
@@ -206,8 +202,6 @@ pub trait BuilderMethods<'a, 'tcx: 'a>:
         flags: MemFlags,
     );
 
-    fn minnum(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value;
-    fn maxnum(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value;
     fn select(
         &mut self,
         cond: Self::Value,
@@ -215,34 +209,8 @@ pub trait BuilderMethods<'a, 'tcx: 'a>:
         else_val: Self::Value,
     ) -> Self::Value;
 
-    fn va_arg(&mut self, list: Self::Value, ty: Self::Type) -> Self::Value;
     fn extract_element(&mut self, vec: Self::Value, idx: Self::Value) -> Self::Value;
-    fn insert_element(
-        &mut self,
-        vec: Self::Value,
-        elt: Self::Value,
-        idx: Self::Value,
-    ) -> Self::Value;
-    fn shuffle_vector(
-        &mut self,
-        v1: Self::Value,
-        v2: Self::Value,
-        mask: Self::Value,
-    ) -> Self::Value;
     fn vector_splat(&mut self, num_elts: usize, elt: Self::Value) -> Self::Value;
-    fn vector_reduce_fadd_fast(&mut self, acc: Self::Value, src: Self::Value) -> Self::Value;
-    fn vector_reduce_fmul_fast(&mut self, acc: Self::Value, src: Self::Value) -> Self::Value;
-    fn vector_reduce_add(&mut self, src: Self::Value) -> Self::Value;
-    fn vector_reduce_mul(&mut self, src: Self::Value) -> Self::Value;
-    fn vector_reduce_and(&mut self, src: Self::Value) -> Self::Value;
-    fn vector_reduce_or(&mut self, src: Self::Value) -> Self::Value;
-    fn vector_reduce_xor(&mut self, src: Self::Value) -> Self::Value;
-    fn vector_reduce_fmin(&mut self, src: Self::Value) -> Self::Value;
-    fn vector_reduce_fmax(&mut self, src: Self::Value) -> Self::Value;
-    fn vector_reduce_fmin_fast(&mut self, src: Self::Value) -> Self::Value;
-    fn vector_reduce_fmax_fast(&mut self, src: Self::Value) -> Self::Value;
-    fn vector_reduce_min(&mut self, src: Self::Value, is_signed: bool) -> Self::Value;
-    fn vector_reduce_max(&mut self, src: Self::Value, is_signed: bool) -> Self::Value;
     fn extract_value(&mut self, agg_val: Self::Value, idx: u64) -> Self::Value;
     fn insert_value(&mut self, agg_val: Self::Value, elt: Self::Value, idx: u64) -> Self::Value;
 
@@ -252,7 +220,6 @@ pub trait BuilderMethods<'a, 'tcx: 'a>:
         pers_fn: Self::Value,
         num_clauses: usize,
     ) -> Self::Value;
-    fn add_clause(&mut self, landing_pad: Self::Value, clause: Self::Value);
     fn set_cleanup(&mut self, landing_pad: Self::Value);
     fn resume(&mut self, exn: Self::Value) -> Self::Value;
     fn cleanup_pad(&mut self, parent: Option<Self::Value>, args: &[Self::Value]) -> Self::Funclet;
@@ -262,7 +229,6 @@ pub trait BuilderMethods<'a, 'tcx: 'a>:
         unwind: Option<Self::BasicBlock>,
     ) -> Self::Value;
     fn catch_pad(&mut self, parent: Self::Value, args: &[Self::Value]) -> Self::Funclet;
-    fn catch_ret(&mut self, funclet: &Self::Funclet, unwind: Self::BasicBlock) -> Self::Value;
     fn catch_switch(
         &mut self,
         parent: Option<Self::Value>,
@@ -292,19 +258,6 @@ pub trait BuilderMethods<'a, 'tcx: 'a>:
     fn add_case(&mut self, s: Self::Value, on_val: Self::Value, dest: Self::BasicBlock);
     fn add_incoming_to_phi(&mut self, phi: Self::Value, val: Self::Value, bb: Self::BasicBlock);
     fn set_invariant_load(&mut self, load: Self::Value);
-
-    /// Returns the ptr value that should be used for storing `val`.
-    fn check_store(&mut self, val: Self::Value, ptr: Self::Value) -> Self::Value;
-
-    /// Returns the args that should be used for a call to `llfn`.
-    fn check_call<'b>(
-        &mut self,
-        typ: &str,
-        llfn: Self::Value,
-        args: &'b [Self::Value],
-    ) -> Cow<'b, [Self::Value]>
-    where
-        [Self::Value]: ToOwned;
 
     /// Called for `StorageLive`
     fn lifetime_start(&mut self, ptr: Self::Value, size: Size);

--- a/src/librustc_codegen_ssa/traits/builder.rs
+++ b/src/librustc_codegen_ssa/traits/builder.rs
@@ -50,7 +50,8 @@ pub trait BuilderMethods<'a, 'tcx: 'a>:
         v: Self::Value,
         else_llbb: Self::BasicBlock,
         num_cases: usize,
-    ) -> Self::Value;
+        cases: impl Iterator<Item = (u128, Self::BasicBlock)>,
+    );
     fn invoke(
         &mut self,
         llfn: Self::Value,
@@ -60,6 +61,7 @@ pub trait BuilderMethods<'a, 'tcx: 'a>:
         funclet: Option<&Self::Funclet>,
     ) -> Self::Value;
     fn unreachable(&mut self);
+
     fn add(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value;
     fn fadd(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value;
     fn fadd_fast(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value;
@@ -242,7 +244,6 @@ pub trait BuilderMethods<'a, 'tcx: 'a>:
         order: AtomicOrdering,
     ) -> Self::Value;
     fn atomic_fence(&mut self, order: AtomicOrdering, scope: SynchronizationScope);
-    fn add_case(&mut self, s: Self::Value, on_val: Self::Value, dest: Self::BasicBlock);
     fn set_invariant_load(&mut self, load: Self::Value);
 
     /// Called for `StorageLive`

--- a/src/librustc_codegen_ssa/traits/builder.rs
+++ b/src/librustc_codegen_ssa/traits/builder.rs
@@ -12,6 +12,7 @@ use crate::MemFlags;
 use rustc::ty::Ty;
 use rustc::ty::layout::{Align, Size};
 use std::ops::Range;
+use std::iter::TrustedLen;
 
 #[derive(Copy, Clone)]
 pub enum OverflowOp {
@@ -49,8 +50,7 @@ pub trait BuilderMethods<'a, 'tcx: 'a>:
         &mut self,
         v: Self::Value,
         else_llbb: Self::BasicBlock,
-        num_cases: usize,
-        cases: impl Iterator<Item = (u128, Self::BasicBlock)>,
+        cases: impl ExactSizeIterator<Item = (u128, Self::BasicBlock)> + TrustedLen,
     );
     fn invoke(
         &mut self,

--- a/src/librustc_codegen_ssa/traits/consts.rs
+++ b/src/librustc_codegen_ssa/traits/consts.rs
@@ -3,7 +3,6 @@ use crate::mir::place::PlaceRef;
 use rustc::mir::interpret::Allocation;
 use rustc::mir::interpret::Scalar;
 use rustc::ty::layout;
-use syntax::symbol::LocalInternedString;
 
 pub trait ConstMethods<'tcx>: BackendTypes {
     // Constant constructors
@@ -19,20 +18,12 @@ pub trait ConstMethods<'tcx>: BackendTypes {
     fn const_usize(&self, i: u64) -> Self::Value;
     fn const_u8(&self, i: u8) -> Self::Value;
 
-    // This is a 'c-like' raw string, which differs from
-    // our boxed-and-length-annotated strings.
-    fn const_cstr(&self, s: LocalInternedString, null_terminated: bool) -> Self::Value;
-
-    fn const_str_slice(&self, s: LocalInternedString) -> Self::Value;
     fn const_struct(&self, elts: &[Self::Value], packed: bool) -> Self::Value;
 
-    fn const_get_elt(&self, v: Self::Value, idx: u64) -> Self::Value;
-    fn const_get_real(&self, v: Self::Value) -> Option<(f64, bool)>;
     fn const_to_uint(&self, v: Self::Value) -> u64;
     fn const_to_opt_u128(&self, v: Self::Value, sign_ext: bool) -> Option<u128>;
 
     fn is_const_integral(&self, v: Self::Value) -> bool;
-    fn is_const_real(&self, v: Self::Value) -> bool;
 
     fn scalar_to_backend(
         &self,

--- a/src/librustc_codegen_ssa/traits/consts.rs
+++ b/src/librustc_codegen_ssa/traits/consts.rs
@@ -24,11 +24,7 @@ pub trait ConstMethods<'tcx>: BackendTypes {
     fn const_cstr(&self, s: LocalInternedString, null_terminated: bool) -> Self::Value;
 
     fn const_str_slice(&self, s: LocalInternedString) -> Self::Value;
-    fn const_fat_ptr(&self, ptr: Self::Value, meta: Self::Value) -> Self::Value;
     fn const_struct(&self, elts: &[Self::Value], packed: bool) -> Self::Value;
-    fn const_array(&self, ty: Self::Type, elts: &[Self::Value]) -> Self::Value;
-    fn const_vector(&self, elts: &[Self::Value]) -> Self::Value;
-    fn const_bytes(&self, bytes: &[u8]) -> Self::Value;
 
     fn const_get_elt(&self, v: Self::Value, idx: u64) -> Self::Value;
     fn const_get_real(&self, v: Self::Value) -> Option<(f64, bool)>;

--- a/src/librustc_codegen_ssa/traits/debuginfo.rs
+++ b/src/librustc_codegen_ssa/traits/debuginfo.rs
@@ -58,4 +58,5 @@ pub trait DebugInfoBuilderMethods<'tcx>: BackendTypes {
         span: Span,
     );
     fn insert_reference_to_gdb_debug_scripts_section_global(&mut self);
+    fn set_value_name(&mut self, value: Self::Value, name: &str);
 }

--- a/src/librustc_codegen_ssa/traits/debuginfo.rs
+++ b/src/librustc_codegen_ssa/traits/debuginfo.rs
@@ -28,7 +28,7 @@ pub trait DebugInfoMethods<'tcx>: BackendTypes {
     fn create_mir_scopes(
         &self,
         mir: &mir::Mir<'_>,
-        debug_context: &FunctionDebugContext<Self::DIScope>,
+        debug_context: &mut FunctionDebugContext<Self::DIScope>,
     ) -> IndexVec<mir::SourceScope, MirDebugScope<Self::DIScope>>;
     fn extend_scope_to_file(
         &self,
@@ -53,7 +53,7 @@ pub trait DebugInfoBuilderMethods<'tcx>: BackendTypes {
     );
     fn set_source_location(
         &mut self,
-        debug_context: &FunctionDebugContext<Self::DIScope>,
+        debug_context: &mut FunctionDebugContext<Self::DIScope>,
         scope: Option<Self::DIScope>,
         span: Span,
     );

--- a/src/librustc_codegen_ssa/traits/misc.rs
+++ b/src/librustc_codegen_ssa/traits/misc.rs
@@ -14,7 +14,6 @@ pub trait MiscMethods<'tcx>: BackendTypes {
     fn check_overflow(&self) -> bool;
     fn instances(&self) -> &RefCell<FxHashMap<Instance<'tcx>, Self::Value>>;
     fn get_fn(&self, instance: Instance<'tcx>) -> Self::Value;
-    fn get_param(&self, llfn: Self::Value, index: usize) -> Self::Value;
     fn eh_personality(&self) -> Self::Value;
     fn eh_unwind_resume(&self) -> Self::Value;
     fn sess(&self) -> &Session;

--- a/src/librustc_codegen_ssa/traits/misc.rs
+++ b/src/librustc_codegen_ssa/traits/misc.rs
@@ -1,5 +1,4 @@
 use super::BackendTypes;
-use libc::c_uint;
 use rustc::mir::mono::Stats;
 use rustc::session::Session;
 use rustc::ty::{self, Instance, Ty};
@@ -15,7 +14,7 @@ pub trait MiscMethods<'tcx>: BackendTypes {
     fn check_overflow(&self) -> bool;
     fn instances(&self) -> &RefCell<FxHashMap<Instance<'tcx>, Self::Value>>;
     fn get_fn(&self, instance: Instance<'tcx>) -> Self::Value;
-    fn get_param(&self, llfn: Self::Value, index: c_uint) -> Self::Value;
+    fn get_param(&self, llfn: Self::Value, index: usize) -> Self::Value;
     fn eh_personality(&self) -> Self::Value;
     fn eh_unwind_resume(&self) -> Self::Value;
     fn sess(&self) -> &Session;

--- a/src/librustc_codegen_ssa/traits/statics.rs
+++ b/src/librustc_codegen_ssa/traits/statics.rs
@@ -8,5 +8,5 @@ pub trait StaticMethods: BackendTypes {
 }
 
 pub trait StaticBuilderMethods<'tcx>: BackendTypes {
-    fn get_static(&self, def_id: DefId) -> Self::Value;
+    fn get_static(&mut self, def_id: DefId) -> Self::Value;
 }

--- a/src/librustc_codegen_ssa/traits/statics.rs
+++ b/src/librustc_codegen_ssa/traits/statics.rs
@@ -1,4 +1,5 @@
 use super::BackendTypes;
+use syntax_pos::symbol::LocalInternedString;
 use rustc::hir::def_id::DefId;
 use rustc::ty::layout::Align;
 
@@ -9,4 +10,12 @@ pub trait StaticMethods: BackendTypes {
 
 pub trait StaticBuilderMethods<'tcx>: BackendTypes {
     fn get_static(&mut self, def_id: DefId) -> Self::Value;
+    fn static_panic_msg(
+        &mut self,
+        msg: Option<LocalInternedString>,
+        filename: LocalInternedString,
+        line: Self::Value,
+        col: Self::Value,
+        kind: &str,
+    ) -> Self::Value;
 }

--- a/src/librustc_codegen_ssa/traits/type_.rs
+++ b/src/librustc_codegen_ssa/traits/type_.rs
@@ -5,9 +5,7 @@ use crate::common::{self, TypeKind};
 use crate::mir::place::PlaceRef;
 use rustc::ty::layout::{self, Align, Size, TyLayout};
 use rustc::ty::{self, Ty};
-use rustc::util::nodemap::FxHashMap;
 use rustc_target::abi::call::{ArgType, CastTarget, FnType, Reg};
-use std::cell::RefCell;
 use syntax::ast;
 
 // This depends on `Backend` and not `BackendTypes`, because consumers will probably want to use
@@ -49,7 +47,6 @@ pub trait BaseTypeMethods<'tcx>: Backend<'tcx> {
     fn int_width(&self, ty: Self::Type) -> u64;
 
     fn val_ty(&self, v: Self::Value) -> Self::Type;
-    fn scalar_lltypes(&self) -> &RefCell<FxHashMap<Ty<'tcx>, Self::Type>>;
 }
 
 pub trait DerivedTypeMethods<'tcx>: BaseTypeMethods<'tcx> + MiscMethods<'tcx> {

--- a/src/librustc_codegen_ssa/traits/type_.rs
+++ b/src/librustc_codegen_ssa/traits/type_.rs
@@ -23,9 +23,7 @@ pub trait BaseTypeMethods<'tcx>: Backend<'tcx> {
     fn type_f64(&self) -> Self::Type;
 
     fn type_func(&self, args: &[Self::Type], ret: Self::Type) -> Self::Type;
-    fn type_variadic_func(&self, args: &[Self::Type], ret: Self::Type) -> Self::Type;
     fn type_struct(&self, els: &[Self::Type], packed: bool) -> Self::Type;
-    fn type_array(&self, ty: Self::Type, len: u64) -> Self::Type;
     fn type_kind(&self, ty: Self::Type) -> TypeKind;
     fn type_ptr_to(&self, ty: Self::Type) -> Self::Type;
     fn element_type(&self, ty: Self::Type) -> Self::Type;

--- a/src/librustc_codegen_ssa/traits/type_.rs
+++ b/src/librustc_codegen_ssa/traits/type_.rs
@@ -1,38 +1,31 @@
 use super::misc::MiscMethods;
 use super::Backend;
 use super::HasCodegen;
-use crate::common::{self, TypeKind};
+use crate::common::TypeKind;
 use crate::mir::place::PlaceRef;
-use rustc::ty::layout::{self, Align, Size, TyLayout};
 use rustc::ty::{self, Ty};
+use rustc::ty::layout::{self, TyLayout};
 use rustc_target::abi::call::{ArgType, CastTarget, FnType, Reg};
-use syntax::ast;
+use syntax_pos::DUMMY_SP;
 
 // This depends on `Backend` and not `BackendTypes`, because consumers will probably want to use
 // `LayoutOf` or `HasTyCtxt`. This way, they don't have to add a constraint on it themselves.
 pub trait BaseTypeMethods<'tcx>: Backend<'tcx> {
-    fn type_void(&self) -> Self::Type;
-    fn type_metadata(&self) -> Self::Type;
     fn type_i1(&self) -> Self::Type;
     fn type_i8(&self) -> Self::Type;
     fn type_i16(&self) -> Self::Type;
     fn type_i32(&self) -> Self::Type;
     fn type_i64(&self) -> Self::Type;
     fn type_i128(&self) -> Self::Type;
-
-    // Creates an integer type with the given number of bits, e.g., i24
-    fn type_ix(&self, num_bits: u64) -> Self::Type;
     fn type_isize(&self) -> Self::Type;
 
     fn type_f32(&self) -> Self::Type;
     fn type_f64(&self) -> Self::Type;
-    fn type_x86_mmx(&self) -> Self::Type;
 
     fn type_func(&self, args: &[Self::Type], ret: Self::Type) -> Self::Type;
     fn type_variadic_func(&self, args: &[Self::Type], ret: Self::Type) -> Self::Type;
     fn type_struct(&self, els: &[Self::Type], packed: bool) -> Self::Type;
     fn type_array(&self, ty: Self::Type, len: u64) -> Self::Type;
-    fn type_vector(&self, ty: Self::Type, len: u64) -> Self::Type;
     fn type_kind(&self, ty: Self::Type) -> TypeKind;
     fn type_ptr_to(&self, ty: Self::Type) -> Self::Type;
     fn element_type(&self, ty: Self::Type) -> Self::Type;
@@ -40,7 +33,6 @@ pub trait BaseTypeMethods<'tcx>: Backend<'tcx> {
     /// Returns the number of elements in `self` if it is a LLVM vector type.
     fn vector_length(&self, ty: Self::Type) -> usize;
 
-    fn func_params_types(&self, ty: Self::Type) -> Vec<Self::Type>;
     fn float_width(&self, ty: Self::Type) -> usize;
 
     /// Retrieves the bit width of the integer type `self`.
@@ -50,10 +42,6 @@ pub trait BaseTypeMethods<'tcx>: Backend<'tcx> {
 }
 
 pub trait DerivedTypeMethods<'tcx>: BaseTypeMethods<'tcx> + MiscMethods<'tcx> {
-    fn type_bool(&self) -> Self::Type {
-        self.type_i8()
-    }
-
     fn type_i8p(&self) -> Self::Type {
         self.type_ptr_to(self.type_i8())
     }
@@ -64,35 +52,6 @@ pub trait DerivedTypeMethods<'tcx>: BaseTypeMethods<'tcx> + MiscMethods<'tcx> {
             "32" => self.type_i32(),
             "64" => self.type_i64(),
             width => bug!("Unsupported target_c_int_width: {}", width),
-        }
-    }
-
-    fn type_int_from_ty(&self, t: ast::IntTy) -> Self::Type {
-        match t {
-            ast::IntTy::Isize => self.type_isize(),
-            ast::IntTy::I8 => self.type_i8(),
-            ast::IntTy::I16 => self.type_i16(),
-            ast::IntTy::I32 => self.type_i32(),
-            ast::IntTy::I64 => self.type_i64(),
-            ast::IntTy::I128 => self.type_i128(),
-        }
-    }
-
-    fn type_uint_from_ty(&self, t: ast::UintTy) -> Self::Type {
-        match t {
-            ast::UintTy::Usize => self.type_isize(),
-            ast::UintTy::U8 => self.type_i8(),
-            ast::UintTy::U16 => self.type_i16(),
-            ast::UintTy::U32 => self.type_i32(),
-            ast::UintTy::U64 => self.type_i64(),
-            ast::UintTy::U128 => self.type_i128(),
-        }
-    }
-
-    fn type_float_from_ty(&self, t: ast::FloatTy) -> Self::Type {
-        match t {
-            ast::FloatTy::F32 => self.type_f32(),
-            ast::FloatTy::F64 => self.type_f64(),
         }
     }
 
@@ -107,32 +66,16 @@ pub trait DerivedTypeMethods<'tcx>: BaseTypeMethods<'tcx> + MiscMethods<'tcx> {
         }
     }
 
-    fn type_pointee_for_align(&self, align: Align) -> Self::Type {
-        // FIXME(eddyb) We could find a better approximation if ity.align < align.
-        let ity = layout::Integer::approximate_align(self, align);
-        self.type_from_integer(ity)
-    }
-
-    /// Return a LLVM type that has at most the required alignment,
-    /// and exactly the required size, as a best-effort padding array.
-    fn type_padding_filler(&self, size: Size, align: Align) -> Self::Type {
-        let unit = layout::Integer::approximate_align(self, align);
-        let size = size.bytes();
-        let unit_size = unit.size().bytes();
-        assert_eq!(size % unit_size, 0);
-        self.type_array(self.type_from_integer(unit), size / unit_size)
-    }
-
     fn type_needs_drop(&self, ty: Ty<'tcx>) -> bool {
-        common::type_needs_drop(self.tcx(), ty)
+        ty.needs_drop(self.tcx(), ty::ParamEnv::reveal_all())
     }
 
     fn type_is_sized(&self, ty: Ty<'tcx>) -> bool {
-        common::type_is_sized(self.tcx(), ty)
+        ty.is_sized(self.tcx().at(DUMMY_SP), ty::ParamEnv::reveal_all())
     }
 
     fn type_is_freeze(&self, ty: Ty<'tcx>) -> bool {
-        common::type_is_freeze(self.tcx(), ty)
+        ty.is_freeze(self.tcx(), ty::ParamEnv::reveal_all(), DUMMY_SP)
     }
 
     fn type_has_metadata(&self, ty: Ty<'tcx>) -> bool {
@@ -155,7 +98,6 @@ impl<T> DerivedTypeMethods<'tcx> for T where Self: BaseTypeMethods<'tcx> + MiscM
 pub trait LayoutTypeMethods<'tcx>: Backend<'tcx> {
     fn backend_type(&self, layout: TyLayout<'tcx>) -> Self::Type;
     fn cast_backend_type(&self, ty: &CastTarget) -> Self::Type;
-    fn fn_backend_type(&self, ty: &FnType<'tcx, Ty<'tcx>>) -> Self::Type;
     fn fn_ptr_backend_type(&self, ty: &FnType<'tcx, Ty<'tcx>>) -> Self::Type;
     fn reg_backend_type(&self, ty: &Reg) -> Self::Type;
     fn immediate_backend_type(&self, layout: TyLayout<'tcx>) -> Self::Type;


### PR DESCRIPTION
Unlike #56636 this doesn't split `BuilderMethods` into a lot of traits. That makes this PR twice as small and the split turned out to not be very useful anyway.

r? @eddyb