### PR TITLE
Update toolchain to build NetBSD release

### DIFF
--- a/src/ci/docker/dist-x86_64-netbsd/Dockerfile
+++ b/src/ci/docker/dist-x86_64-netbsd/Dockerfile
@@ -3,23 +3,8 @@ FROM ubuntu:16.04
 COPY scripts/cross-apt-packages.sh /scripts/
 RUN sh /scripts/cross-apt-packages.sh
 
-# Ubuntu 16.04 (this container) ships with make 4, but something in the
-# toolchains we build below chokes on that, so go back to make 3
-COPY scripts/make3.sh /scripts/
-RUN sh /scripts/make3.sh
-
-COPY scripts/crosstool-ng.sh /scripts/
-RUN sh /scripts/crosstool-ng.sh
-
-COPY scripts/rustbuild-setup.sh /scripts/
-RUN sh /scripts/rustbuild-setup.sh
-USER rustbuild
-WORKDIR /tmp
-
 COPY dist-x86_64-netbsd/build-netbsd-toolchain.sh /tmp/
-RUN ./build-netbsd-toolchain.sh
-
-USER root
+RUN /tmp/build-netbsd-toolchain.sh
 
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
@@ -33,6 +18,5 @@ ENV \
 
 ENV HOSTS=x86_64-unknown-netbsd
 
-ENV RUST_CONFIGURE_ARGS --enable-extended --disable-docs \
-  --set llvm.allow-old-toolchain
+ENV RUST_CONFIGURE_ARGS --enable-extended --disable-docs
 ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/dist-x86_64-netbsd/build-netbsd-toolchain.sh
+++ b/src/ci/docker/dist-x86_64-netbsd/build-netbsd-toolchain.sh
@@ -28,15 +28,15 @@ mkdir -p /x-tools/x86_64-unknown-netbsd/sysroot
 URL=https://s3-us-west-1.amazonaws.com/rust-lang-ci2/rust-ci-mirror
 
 # Originally from ftp://ftp.netbsd.org/pub/NetBSD/NetBSD-$BSD/source/sets/*.tgz
-curl $URL/2017-03-17-netbsd-src.tgz | tar xzf -
-curl $URL/2017-03-17-netbsd-gnusrc.tgz | tar xzf -
-curl $URL/2017-03-17-netbsd-sharesrc.tgz | tar xzf -
-curl $URL/2017-03-17-netbsd-syssrc.tgz | tar xzf -
+curl $URL/2018-03-01-netbsd-src.tgz | tar xzf -
+curl $URL/2018-03-01-netbsd-gnusrc.tgz | tar xzf -
+curl $URL/2018-03-01-netbsd-sharesrc.tgz | tar xzf -
+curl $URL/2018-03-01-netbsd-syssrc.tgz | tar xzf -
 
 # Originally from ftp://ftp.netbsd.org/pub/NetBSD/NetBSD-$BSD/amd64/binary/sets/*.tgz
-curl $URL/2017-03-17-netbsd-base.tgz | \
+curl $URL/2018-03-01-netbsd-base.tgz | \
   tar xzf - -C /x-tools/x86_64-unknown-netbsd/sysroot ./usr/include ./usr/lib ./lib
-curl $URL/2017-03-17-netbsd-comp.tgz | \
+curl $URL/2018-03-01-netbsd-comp.tgz | \
   tar xzf - -C /x-tools/x86_64-unknown-netbsd/sysroot ./usr/include ./usr/lib
 
 cd usr/src


### PR DESCRIPTION
This allows us to remove the "allow old toolchains" flag we pass to
LLVM, ensuring that we'll be up to date when LLVM needs us to be!

This is a follow-up from https://github.com/rust-lang/rust/pull/58408 where NetBSD was explicitly whitelisted to allow older toolchains.