### PR TITLE
appveyor: Use VS2017 for all our images

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,7 @@
 environment:
+  # This is required for at least an AArch64 compiler in one image, and is also
+  # going to soon be required for compiling LLVM.
+  APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017 Preview
 
   # By default schannel checks revocation of certificates unlike some other SSL
   # backends, but we've historically had problems on CI where a revocation
@@ -86,7 +89,6 @@ environment:
     DIST_REQUIRE_ALL_TOOLS: 1
     DEPLOY: 1
     CI_JOB_NAME: dist-x86_64-msvc
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017 Preview
   - RUST_CONFIGURE_ARGS: >
       --build=i686-pc-windows-msvc
       --target=i586-pc-windows-msvc


### PR DESCRIPTION
Originally added in #55935 to test build times, this was reverted
in #56201 due to a belief that it caused the exit code 259 spurious
errors. We've since learned, however, that the 259 exit code is likely
not related to this image update as we're getting it in a number of
locations now.

VS2017 looks like it may be required to compile LLVm in the near future,
notably discovered by #58408 where we attempted to update LLVM.