### PR TITLE
Fix C-variadic function printing

### DIFF
--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -2814,9 +2814,6 @@ impl<'a> State<'a> {
         -> io::Result<()> {
         self.popen()?;
         self.commasep(Inconsistent, &decl.inputs, |s, arg| s.print_arg(arg, false))?;
-        if decl.c_variadic {
-            self.s.word(", ...")?;
-        }
         self.pclose()?;
 
         self.print_fn_output(decl)

--- a/src/test/pretty/fn-variadic.rs
+++ b/src/test/pretty/fn-variadic.rs
@@ -1,0 +1,15 @@
+// Check that `fn foo(x: i32, ...)` does not print as `fn foo(x: i32, ..., ...)`.
+// See issue #58853.
+//
+// pp-exact
+#![feature(c_variadic)]
+
+extern "C" {
+    pub fn foo(x: i32, ...);
+}
+
+pub unsafe extern "C" fn bar(_: i32, mut ap: ...) -> usize {
+    ap.arg::<usize>()
+}
+
+fn main() { }

--- a/src/test/pretty/fn-variadic.rs
+++ b/src/test/pretty/fn-variadic.rs
@@ -1,6 +1,6 @@
 // Check that `fn foo(x: i32, ...)` does not print as `fn foo(x: i32, ..., ...)`.
 // See issue #58853.
-//
+
 // pp-exact
 #![feature(c_variadic)]
 


### PR DESCRIPTION
There is no longer a need to append the string `", ..."` to a functions
args as `...` is parsed as an argument and will appear in the functions
arguments.

r? @alexreg 
cc @alexcrichton 
Fixes: #58853