### PR TITLE
Add spin_loop_hint intrinsic

### DIFF
--- a/src/libcore/hint.rs
+++ b/src/libcore/hint.rs
@@ -62,13 +62,6 @@ pub unsafe fn unreachable_unchecked() -> ! {
 #[inline]
 #[unstable(feature = "renamed_spin_loop", issue = "55002")]
 pub fn spin_loop() {
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    unsafe {
-        asm!("pause" ::: "memory" : "volatile");
-    }
-
-    #[cfg(target_arch = "aarch64")]
-    unsafe {
-        asm!("yield" ::: "memory" : "volatile");
-    }
+    #[cfg(not(stage0))]
+    intrinsics::spin_loop_hint();
 }

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -1308,6 +1308,9 @@ extern "rust-intrinsic" {
     /// Emits a `!nontemporal` store according to LLVM (see their docs).
     /// Probably will never become stable.
     pub fn nontemporal_store<T>(ptr: *mut T, val: T);
+
+    #[cfg(not(stage0))]
+    pub fn spin_loop_hint();
 }
 
 mod real_intrinsics {

--- a/src/librustc_typeck/check/intrinsic.rs
+++ b/src/librustc_typeck/check/intrinsic.rs
@@ -70,7 +70,8 @@ pub fn intrisic_operation_unsafety(intrinsic: &str) -> hir::Unsafety {
         "overflowing_add" | "overflowing_sub" | "overflowing_mul" |
         "saturating_add" | "saturating_sub" |
         "rotate_left" | "rotate_right" |
-        "ctpop" | "ctlz" | "cttz" | "bswap" | "bitreverse"
+        "ctpop" | "ctlz" | "cttz" | "bswap" | "bitreverse" |
+        "spin_loop_hint"
         => hir::Unsafety::Normal,
         _ => hir::Unsafety::Unsafe,
     }
@@ -378,6 +379,8 @@ pub fn check_intrinsic_type<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
             "nontemporal_store" => {
                 (1, vec![ tcx.mk_mut_ptr(param(0)), param(0) ], tcx.mk_unit())
             }
+
+            "spin_loop_hint" => (0, vec![], tcx.mk_unit()),
 
             ref other => {
                 struct_span_err!(tcx.sess, it.span, E0093,


### PR DESCRIPTION
This removes one occurrence of inline assembly in libcore, leaving only:

```
src/libcore/num/dec2flt/algorithm.rs
61:        unsafe { asm!("fldcw $0" :: "m" (cw) :: "volatile") }
77:        unsafe { asm!("fnstcw $0" : "=*m" (&cw) ::: "volatile") }
```

This makes life easier for alternative codegen backends which don't (yet) support inline asm by not needing to patch libcore to remove it.

cc https://github.com/bjorn3/rustc_codegen_cranelift/issues/337