### PR TITLE
Suggest removal of `&` when borrowing macro and appropriate

### DIFF
--- a/src/librustc_typeck/check/demand.rs
+++ b/src/librustc_typeck/check/demand.rs
@@ -367,6 +367,15 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                         // Maybe remove `&`?
                         hir::ExprKind::AddrOf(_, ref expr) => {
                             if !cm.span_to_filename(expr.span).is_real() {
+                                if let Ok(code) = cm.span_to_snippet(sp) {
+                                    if code.chars().next() == Some('&') {
+                                        return Some((
+                                            sp,
+                                            "consider removing the borrow",
+                                            code[1..].to_string()),
+                                        );
+                                    }
+                                }
                                 return None;
                             }
                             if let Ok(code) = cm.span_to_snippet(expr.span) {

--- a/src/test/ui/block-result/issue-5500.stderr
+++ b/src/test/ui/block-result/issue-5500.stderr
@@ -4,7 +4,10 @@ error[E0308]: mismatched types
 LL | fn main() {
    |           - expected `()` because of default return type
 LL |     &panic!()
-   |     ^^^^^^^^^ expected (), found reference
+   |     ^^^^^^^^^
+   |     |
+   |     expected (), found reference
+   |     help: consider removing the borrow: `panic!()`
    |
    = note: expected type `()`
               found type `&_`

--- a/src/test/ui/diverging-tuple-parts-39485.stderr
+++ b/src/test/ui/diverging-tuple-parts-39485.stderr
@@ -1,13 +1,19 @@
 error[E0308]: mismatched types
   --> $DIR/diverging-tuple-parts-39485.rs:8:5
    |
-LL | fn g() {
-   |        - help: try adding a return type: `-> &_`
 LL |     &panic!() //~ ERROR mismatched types
    |     ^^^^^^^^^ expected (), found reference
    |
    = note: expected type `()`
               found type `&_`
+help: try adding a return type
+   |
+LL | fn g() -> &_ {
+   |        ^^^^^
+help: consider removing the borrow
+   |
+LL |     panic!() //~ ERROR mismatched types
+   |     ^^^^^^^^
 
 error[E0308]: mismatched types
   --> $DIR/diverging-tuple-parts-39485.rs:12:5

--- a/src/test/ui/suggestions/format-borrow.rs
+++ b/src/test/ui/suggestions/format-borrow.rs
@@ -1,0 +1,6 @@
+fn main() {
+    let a: String = &String::from("a");
+    //~^ ERROR mismatched types
+    let b: String = &format!("b");
+    //~^ ERROR mismatched types
+}

--- a/src/test/ui/suggestions/format-borrow.stderr
+++ b/src/test/ui/suggestions/format-borrow.stderr
@@ -1,0 +1,27 @@
+error[E0308]: mismatched types
+  --> $DIR/format-borrow.rs:2:21
+   |
+LL |     let a: String = &String::from("a");
+   |                     ^^^^^^^^^^^^^^^^^^
+   |                     |
+   |                     expected struct `std::string::String`, found reference
+   |                     help: consider removing the borrow: `String::from("a")`
+   |
+   = note: expected type `std::string::String`
+              found type `&std::string::String`
+
+error[E0308]: mismatched types
+  --> $DIR/format-borrow.rs:4:21
+   |
+LL |     let b: String = &format!("b");
+   |                     ^^^^^^^^^^^^^
+   |                     |
+   |                     expected struct `std::string::String`, found reference
+   |                     help: consider removing the borrow: `format!("b")`
+   |
+   = note: expected type `std::string::String`
+              found type `&std::string::String`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fix #58815.