### PR TITLE
race condition in thread local storage example

### DIFF
--- a/src/libstd/thread/local.rs
+++ b/src/libstd/thread/local.rs
@@ -40,12 +40,15 @@ use crate::mem;
 /// });
 ///
 /// // each thread starts out with the initial value of 1
-/// thread::spawn(move|| {
+/// let t = thread::spawn(move|| {
 ///     FOO.with(|f| {
 ///         assert_eq!(*f.borrow(), 1);
 ///         *f.borrow_mut() = 3;
 ///     });
 /// });
+///
+/// // wait for the thread to complete and bail out on panic
+/// t.join().unwrap();
 ///
 /// // we retain our original value of 2 despite the child thread
 /// FOO.with(|f| {


### PR DESCRIPTION
The example had a potential race condition that would still pass the test.
If the thread which was supposed to modify it's own thread local was slower than the instruction to
modify in the main thread, then the test would pass even in case of a failure.
This is would be minor if the child thread was waited for since it check using an `assert_eq` for the
same thing, but vice versa.
However, if the `assert_eq` failed this would trigger a panic, which is not at all caught by the
example since the thread is not waited on.

Signed-off-by: benaryorg <binary@benary.org>