### PR TITLE
Add as_slice() to slice::IterMut and vec::Drain

### DIFF
--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2481,7 +2481,7 @@ impl<'a, T> Drain<'a, T> {
     /// let _ = drain.next().unwrap();
     /// assert_eq!(drain.as_slice(), &['b', 'c']);
     /// ```
-    #[unstable(feature = "vec_drain_as_slice", reason = "recently added", issue = "0")]
+    #[unstable(feature = "vec_drain_as_slice", reason = "recently added", issue = "58957")]
     pub fn as_slice(&self) -> &[T] {
         self.iter.as_slice()
     }

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2468,6 +2468,25 @@ impl<T: fmt::Debug> fmt::Debug for Drain<'_, T> {
     }
 }
 
+impl<'a, T> Drain<'a, T> {
+    /// Returns the remaining items of this iterator as a slice.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #![feature(vec_drain_as_slice)]
+    /// let mut vec = vec!['a', 'b', 'c'];
+    /// let mut drain = vec.drain(..);
+    /// assert_eq!(drain.as_slice(), &['a', 'b', 'c']);
+    /// let _ = drain.next().unwrap();
+    /// assert_eq!(drain.as_slice(), &['b', 'c']);
+    /// ```
+    #[unstable(feature = "vec_drain_as_slice", reason = "recently added", issue = "0")]
+    pub fn as_slice(&self) -> &[T] {
+        self.iter.as_slice()
+    }
+}
+
 #[stable(feature = "drain", since = "1.6.0")]
 unsafe impl<T: Sync> Sync for Drain<'_, T> {}
 #[stable(feature = "drain", since = "1.6.0")]

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -3312,7 +3312,7 @@ impl<'a, T> IterMut<'a, T> {
     /// // Now `as_slice` returns "[2, 3]":
     /// assert_eq!(iter.as_slice(), &[2, 3]);
     /// ```
-    #[unstable(feature = "slice_iter_mut_as_slice", reason = "recently added", issue = "0")]
+    #[unstable(feature = "slice_iter_mut_as_slice", reason = "recently added", issue = "58957")]
     pub fn as_slice(&self) -> &[T] {
         self.make_slice()
     }

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -3291,8 +3291,8 @@ impl<'a, T> IterMut<'a, T> {
 
     /// Views the underlying data as a subslice of the original data.
     ///
-    /// To avoid creating `&mut` references that alias, this has a
-    /// borrowed lifetime from the iterator.
+    /// To avoid creating `&mut [T]` references that alias, the returned slice
+    /// borrows its lifetime from the iterator the method is applied on.
     ///
     /// # Examples
     ///
@@ -3302,11 +3302,11 @@ impl<'a, T> IterMut<'a, T> {
     /// # #![feature(slice_iter_mut_as_slice)]
     /// // First, we declare a type which has `iter_mut` method to get the `IterMut`
     /// // struct (&[usize here]):
-    /// let mut slice = &mut [1, 2, 3];
+    /// let mut slice: &mut [usize] = &mut [1, 2, 3];
     ///
     /// // Then, we get the iterator:
     /// let mut iter = slice.iter_mut();
-    /// // So if we print what `as_slice` method returns here, we have "[1, 2, 3]":
+    /// // So if we print what the `as_slice` method returns here, we have "[1, 2, 3]":
     /// println!("{:?}", iter.as_slice());
     /// assert_eq!(iter.as_slice(), &[1, 2, 3]);
     ///

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -3300,20 +3300,16 @@ impl<'a, T> IterMut<'a, T> {
     ///
     /// ```
     /// # #![feature(slice_iter_mut_as_slice)]
-    /// // First, we declare a type which has `iter_mut` method to get the `IterMut`
-    /// // struct (&[usize here]):
     /// let mut slice: &mut [usize] = &mut [1, 2, 3];
     ///
-    /// // Then, we get the iterator:
+    /// // First, we get the iterator:
     /// let mut iter = slice.iter_mut();
-    /// // So if we print what the `as_slice` method returns here, we have "[1, 2, 3]":
-    /// println!("{:?}", iter.as_slice());
+    /// // So if we check what the `as_slice` method returns here, we have "[1, 2, 3]":
     /// assert_eq!(iter.as_slice(), &[1, 2, 3]);
     ///
     /// // Next, we move to the second element of the slice:
     /// iter.next();
     /// // Now `as_slice` returns "[2, 3]":
-    /// println!("{:?}", iter.as_slice());
     /// assert_eq!(iter.as_slice(), &[2, 3]);
     /// ```
     #[unstable(feature = "slice_iter_mut_as_slice", reason = "recently added", issue = "0")]

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -3288,6 +3288,38 @@ impl<'a, T> IterMut<'a, T> {
     pub fn into_slice(self) -> &'a mut [T] {
         unsafe { from_raw_parts_mut(self.ptr, len!(self)) }
     }
+
+    /// Views the underlying data as a subslice of the original data.
+    ///
+    /// To avoid creating `&mut` references that alias, this has a
+    /// borrowed lifetime from the iterator.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// # #![feature(slice_iter_mut_as_slice)]
+    /// // First, we declare a type which has `iter_mut` method to get the `IterMut`
+    /// // struct (&[usize here]):
+    /// let mut slice = &mut [1, 2, 3];
+    ///
+    /// // Then, we get the iterator:
+    /// let mut iter = slice.iter_mut();
+    /// // So if we print what `as_slice` method returns here, we have "[1, 2, 3]":
+    /// println!("{:?}", iter.as_slice());
+    /// assert_eq!(iter.as_slice(), &[1, 2, 3]);
+    ///
+    /// // Next, we move to the second element of the slice:
+    /// iter.next();
+    /// // Now `as_slice` returns "[2, 3]":
+    /// println!("{:?}", iter.as_slice());
+    /// assert_eq!(iter.as_slice(), &[2, 3]);
+    /// ```
+    #[unstable(feature = "slice_iter_mut_as_slice", reason = "recently added", issue = "0")]
+    pub fn as_slice(&self) -> &[T] {
+        self.make_slice()
+    }
 }
 
 iterator!{struct IterMut -> *mut T, &'a mut T, mut, {mut}, {}}


### PR DESCRIPTION
In bluss/indexmap#88, we found that there was no easy way to implement
`Debug` for our `IterMut` and `Drain` iterators. Those are built on
`slice::IterMut` and `vec::Drain`, which implement `Debug` themselves,
but have no other way to access their data. With a new `as_slice()`
method, we can read the data and customize its presentation.