### PR TITLE
Make the lifetime parameters of tcx consistent.

### DIFF
--- a/src/librustc_codegen_llvm/lib.rs
+++ b/src/librustc_codegen_llvm/lib.rs
@@ -123,9 +123,9 @@ impl ExtraBackendMethods for LlvmCodegenBackend {
     ) -> EncodedMetadata {
         base::write_metadata(tcx, metadata)
     }
-    fn codegen_allocator(
+    fn codegen_allocator<'b, 'gcx>(
         &self,
-        tcx: TyCtxt<'_, '_, '_>,
+        tcx: TyCtxt<'b, 'gcx, 'gcx>,
         mods: &mut ModuleLlvm,
         kind: AllocatorKind
     ) {

--- a/src/librustc_codegen_ssa/traits/backend.rs
+++ b/src/librustc_codegen_ssa/traits/backend.rs
@@ -38,9 +38,9 @@ pub trait ExtraBackendMethods: CodegenBackend + WriteBackendMethods + Sized + Se
         tcx: TyCtxt<'b, 'gcx, 'gcx>,
         metadata: &mut Self::Module,
     ) -> EncodedMetadata;
-    fn codegen_allocator(
+    fn codegen_allocator<'b, 'gcx>(
         &self,
-        tcx: TyCtxt<'_, '_, '_>,
+        tcx: TyCtxt<'b, 'gcx, 'gcx>,
         mods: &mut Self::Module,
         kind: AllocatorKind
     );


### PR DESCRIPTION
I have implemented `codegen_allocator` for my backend, but I've had to make a small change to its signature in `ExtraBackendMethods`. I wonder if this change is justified, or if it is too specific to my use case to be useful to anyone else.

`write_metadata` and `codegen_allocator` are both called from `codegen_crate` (in `librustc_codegen_ssa/base.rs`), and they both receive the same `tcx` as an argument:

https://github.com/rust-lang/rust/blob/c196097e588b05e86b5ce6de992b2a6e6a7027bd/src/librustc_codegen_ssa/base.rs#L555-L557

and:

https://github.com/rust-lang/rust/blob/c196097e588b05e86b5ce6de992b2a6e6a7027bd/src/librustc_codegen_ssa/base.rs#L640-L642

However, `codegen_allocator` accepts a `TyCtxt` with any lifetime parameters (`tcx: TyCtxt<'_, '_, '_>`), while `write_metadata` requires that the `tcx` argument is of type `TyCtxt<'b, 'gcx, 'gcx>`. In my implementation, I've found that it's necessary for `tcx` in `codegen_allocator` to also have the `<'b, 'gcx, 'gcx>` lifetime parameters.

Have I misunderstood the purpose of the parameters of `TyCtxt`? I've read [here](https://rust-lang.github.io/rustc-guide/ty.html) that the last two parameters only need to be distinct if the function needs to be used during type inference, but I don't think that is the case here.