### PR TITLE
Elide object safety errors on non-existent trait function

### DIFF
--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -164,6 +164,9 @@ pub struct Session {
 
     /// Cap lint level specified by a driver specifically.
     pub driver_lint_caps: FxHashMap<lint::LintId, lint::Level>,
+
+    /// `Span`s of trait methods that weren't found to avoid emitting object safety errors
+    pub trait_methods_not_found: OneThread<RefCell<FxHashSet<Span>>>,
 }
 
 pub struct PerfStats {
@@ -1230,6 +1233,7 @@ fn build_session_(
         has_global_allocator: Once::new(),
         has_panic_handler: Once::new(),
         driver_lint_caps,
+        trait_methods_not_found: OneThread::new(RefCell::new(Default::default())),
     };
 
     validate_commandline_args_with_session_available(&sess);

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1012,9 +1012,8 @@ impl<'o, 'gcx: 'tcx, 'tcx> dyn AstConv<'gcx, 'tcx> + 'o {
         let object_safety_violations =
             tcx.global_tcx().astconv_object_safety_violations(principal.def_id());
         if !object_safety_violations.is_empty() {
-            tcx.report_object_safety_error(
-                span, principal.def_id(), object_safety_violations)
-               .emit();
+            tcx.report_object_safety_error(span, principal.def_id(), object_safety_violations)
+                .map(|mut err| err.emit());
             return tcx.types.err;
         }
 

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -60,13 +60,15 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         }
     }
 
-    pub fn report_method_error<'b>(&self,
-                                   span: Span,
-                                   rcvr_ty: Ty<'tcx>,
-                                   item_name: ast::Ident,
-                                   source: SelfSource<'b>,
-                                   error: MethodError<'tcx>,
-                                   args: Option<&'gcx [hir::Expr]>) {
+    pub fn report_method_error<'b>(
+        &self,
+        span: Span,
+        rcvr_ty: Ty<'tcx>,
+        item_name: ast::Ident,
+        source: SelfSource<'b>,
+        error: MethodError<'tcx>,
+        args: Option<&'gcx [hir::Expr]>,
+    ) {
         // Avoid suggestions when we don't know what's going on.
         if rcvr_ty.references_error() {
             return;
@@ -373,6 +375,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                     }
                 } else {
                     err.span_label(span, format!("{} not found in `{}`", item_kind, ty_str));
+                    self.tcx.sess.trait_methods_not_found.borrow_mut().insert(span);
                 }
 
                 if self.is_fn_ty(&rcvr_ty, span) {

--- a/src/test/ui/issues/issue-58734.rs
+++ b/src/test/ui/issues/issue-58734.rs
@@ -1,0 +1,22 @@
+trait Trait {
+    fn exists(self) -> ();
+
+    fn not_object_safe() -> Self;
+}
+
+impl Trait for () {
+    fn exists(self) -> () {
+    }
+
+    fn not_object_safe() -> Self {
+        ()
+    }
+}
+
+fn main() {
+    // object-safe or not, this call is OK
+    Trait::exists(());
+    // no object safety error
+    Trait::nonexistent(());
+    //~^ ERROR no function or associated item named `nonexistent` found for type `dyn Trait`
+}

--- a/src/test/ui/issues/issue-58734.stderr
+++ b/src/test/ui/issues/issue-58734.stderr
@@ -1,0 +1,11 @@
+error[E0599]: no function or associated item named `nonexistent` found for type `dyn Trait` in the current scope
+  --> $DIR/issue-58734.rs:20:12
+   |
+LL |     Trait::nonexistent(());
+   |     -------^^^^^^^^^^^
+   |     |
+   |     function or associated item not found in `dyn Trait`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0599`.


### PR DESCRIPTION
Fix #58734.

r? @zackmdavis 