### PR TITLE
Elide invalid method receiver error when it contains TyErr

### DIFF
--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -842,7 +842,9 @@ fn receiver_is_valid<'fcx, 'tcx, 'gcx>(
         } else {
             debug!("receiver_is_valid: type `{:?}` does not deref to `{:?}`",
                 receiver_ty, self_ty);
-            return false
+            // If he receiver already has errors reported due to it, consider it valid to avoid
+            // unecessary errors (#58712).
+            return receiver_ty.references_error();
         }
 
         // without the `arbitrary_self_types` feature, `receiver_ty` must directly deref to

--- a/src/test/ui/issues/issue-58712.rs
+++ b/src/test/ui/issues/issue-58712.rs
@@ -1,0 +1,15 @@
+struct AddrVec<H, A> {
+    h: H,
+    a: A,
+}
+
+impl<H> AddrVec<H, DeviceId> {
+    //~^ ERROR cannot find type `DeviceId` in this scope
+    pub fn device(&self) -> DeviceId {
+    //~^ ERROR cannot find type `DeviceId` in this scope
+        self.tail()
+    }
+}
+
+fn main() {}
+

--- a/src/test/ui/issues/issue-58712.stderr
+++ b/src/test/ui/issues/issue-58712.stderr
@@ -1,0 +1,15 @@
+error[E0412]: cannot find type `DeviceId` in this scope
+  --> $DIR/issue-58712.rs:6:20
+   |
+LL | impl<H> AddrVec<H, DeviceId> {
+   |                    ^^^^^^^^ not found in this scope
+
+error[E0412]: cannot find type `DeviceId` in this scope
+  --> $DIR/issue-58712.rs:8:29
+   |
+LL |     pub fn device(&self) -> DeviceId {
+   |                             ^^^^^^^^ not found in this scope
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0412`.


### PR DESCRIPTION
Fix #58712.