### PR TITLE
Move alloc::prelude::* to alloc::prelude::v1, make alloc a subset of std

### DIFF
--- a/src/liballoc/prelude/mod.rs
+++ b/src/liballoc/prelude/mod.rs
@@ -6,10 +6,11 @@
 //! ```
 //! # #![allow(unused_imports)]
 //! # #![feature(alloc)]
+//! #![feature(alloc_prelude)]
 //! extern crate alloc;
 //! use alloc::prelude::v1::*;
 //! ```
 
-#![unstable(feature = "alloc", issue = "27783")]
+#![unstable(feature = "alloc_prelude", issue = "58935")]
 
 pub mod v1;

--- a/src/liballoc/prelude/mod.rs
+++ b/src/liballoc/prelude/mod.rs
@@ -1,0 +1,15 @@
+//! The alloc Prelude
+//!
+//! The purpose of this module is to alleviate imports of commonly-used
+//! items of the `alloc` crate by adding a glob import to the top of modules:
+//!
+//! ```
+//! # #![allow(unused_imports)]
+//! # #![feature(alloc)]
+//! extern crate alloc;
+//! use alloc::prelude::v1::*;
+//! ```
+
+#![unstable(feature = "alloc", issue = "27783")]
+
+pub mod v1;

--- a/src/liballoc/prelude/v1.rs
+++ b/src/liballoc/prelude/v1.rs
@@ -1,14 +1,6 @@
-//! The alloc Prelude
+//! The first version of the prelude of `alloc` crate.
 //!
-//! The purpose of this module is to alleviate imports of commonly-used
-//! items of the `alloc` crate by adding a glob import to the top of modules:
-//!
-//! ```
-//! # #![allow(unused_imports)]
-//! # #![feature(alloc)]
-//! extern crate alloc;
-//! use alloc::prelude::*;
-//! ```
+//! See the [module-level documentation](../index.html) for more.
 
 #![unstable(feature = "alloc", issue = "27783")]
 

--- a/src/liballoc/prelude/v1.rs
+++ b/src/liballoc/prelude/v1.rs
@@ -2,10 +2,10 @@
 //!
 //! See the [module-level documentation](../index.html) for more.
 
-#![unstable(feature = "alloc", issue = "27783")]
+#![unstable(feature = "alloc_prelude", issue = "58935")]
 
-#[unstable(feature = "alloc", issue = "27783")] pub use crate::borrow::ToOwned;
-#[unstable(feature = "alloc", issue = "27783")] pub use crate::boxed::Box;
-#[unstable(feature = "alloc", issue = "27783")] pub use crate::slice::SliceConcatExt;
-#[unstable(feature = "alloc", issue = "27783")] pub use crate::string::{String, ToString};
-#[unstable(feature = "alloc", issue = "27783")] pub use crate::vec::Vec;
+#[unstable(feature = "alloc_prelude", issue = "58935")] pub use crate::borrow::ToOwned;
+#[unstable(feature = "alloc_prelude", issue = "58935")] pub use crate::boxed::Box;
+#[unstable(feature = "alloc_prelude", issue = "58935")] pub use crate::slice::SliceConcatExt;
+#[unstable(feature = "alloc_prelude", issue = "58935")] pub use crate::string::{String, ToString};
+#[unstable(feature = "alloc_prelude", issue = "58935")] pub use crate::vec::Vec;


### PR DESCRIPTION
This was one of the unresolved questions of https://github.com/rust-lang/rfcs/pull/2480. As the RFC says this is maybe not useful in the sense that we are unlikely to ever have a second version, but making the crate a true subset makes one less issue to think about if we stabilize it and later want to merge standard library crates and have Cargo feature flags to enable or disable parts of the `std` crate.

See also discussion in https://github.com/rust-lang/rust/pull/58175.

Also rename the feature gate and point to a dedicated tracking issue: https://github.com/rust-lang/rust/issues/58935