### PR TITLE
Fix a tiny error in documentation of std::pin.

### DIFF
--- a/src/libcore/pin.rs
+++ b/src/libcore/pin.rs
@@ -109,7 +109,7 @@
 //! assert_eq!(still_unmoved.slice, NonNull::from(&still_unmoved.data));
 //!
 //! // Since our type doesn't implement Unpin, this will fail to compile:
-//! // let new_unmoved = Unmovable::new("world".to_string());
+//! // let mut new_unmoved = Unmovable::new("world".to_string());
 //! // std::mem::swap(&mut *still_unmoved, &mut *new_unmoved);
 //! ```
 //!


### PR DESCRIPTION
`new_unmoved` must be `mut` for passing to `std::mem::swap`.