### PR TITLE
Keep sccache alive for 10 hours, not 3

### DIFF
--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -79,7 +79,7 @@ fi
 # server (#48192) which causes Cargo to erroneously think that a build script
 # hasn't finished yet. Try to solve that problem by starting a very long-lived
 # sccache server at the start of the build, but no need to worry if this fails.
-SCCACHE_IDLE_TIMEOUT=10800 sccache --start-server || true
+SCCACHE_IDLE_TIMEOUT=36000 sccache --start-server || true
 
 if [ "$RUN_CHECK_WITH_PARALLEL_QUERIES" != "" ]; then
   $SRC/configure --enable-parallel-compiler


### PR DESCRIPTION
We're currently praying that sccache dying after 3 hrs somehow causes
the "exited with 259" errors on appveyor, but this is a complete shot in
the dark. In any case it should be harmless to keep sccache alive!

cc #58160