### PR TITLE
SGX target: Expose thread id function in os module

### DIFF
--- a/src/libstd/os/fortanix_sgx/mod.rs
+++ b/src/libstd/os/fortanix_sgx/mod.rs
@@ -43,3 +43,8 @@ pub mod mem {
 }
 
 pub use crate::sys::ext::{io, arch, ffi};
+
+/// Functions for querying thread-related information.
+pub mod thread {
+    pub use crate::sys::abi::thread::current;
+}

--- a/src/libstd/sys/sgx/abi/thread.rs
+++ b/src/libstd/sys/sgx/abi/thread.rs
@@ -4,6 +4,7 @@ use fortanix_sgx_abi::Tcs;
 /// all currently running threads in the enclave, and it is guaranteed to be
 /// constant for the lifetime of the thread. More specifically for SGX, there
 /// is a one-to-one correspondence of the ID to the address of the TCS.
+#[unstable(feature = "sgx_platform", issue = "56975")]
 pub fn current() -> Tcs {
     extern "C" { fn get_tcs_addr() -> Tcs; }
     unsafe { get_tcs_addr() }


### PR DESCRIPTION
In order to call `std::os::fortanix_sgx::usercalls::send`, you need the thread id. This exposes it through another function in `std::os::fortanix_sgx`.

I looked at how other platforms do this. On Windows and `cfg(unix)` you can get the OS handle from a `thread::JoinHandle`, but that's not sufficient, I need it for a `thread::Thread`. In the future, this functionality could be added to `thread::Thread` and this platform can follow suit.

r? @joshtriplett 