### PR TITLE
On incorrect cfg literal/identifier, point at the right span

### DIFF
--- a/src/libsyntax/parse/attr.rs
+++ b/src/libsyntax/parse/attr.rs
@@ -285,7 +285,7 @@ impl<'a> Parser<'a> {
         }
 
         let found = self.this_token_to_string();
-        let msg = format!("expected unsuffixed literal or identifier, found {}", found);
+        let msg = format!("expected unsuffixed literal or identifier, found `{}`", found);
         Err(self.diagnostic().struct_span_err(self.span, &msg))
     }
 

--- a/src/libsyntax/parse/attr.rs
+++ b/src/libsyntax/parse/attr.rs
@@ -286,7 +286,7 @@ impl<'a> Parser<'a> {
 
         let found = self.this_token_to_string();
         let msg = format!("expected unsuffixed literal or identifier, found {}", found);
-        Err(self.diagnostic().struct_span_err(lo, &msg))
+        Err(self.diagnostic().struct_span_err(self.span, &msg))
     }
 
     /// matches meta_seq = ( COMMASEP(meta_item_inner) )

--- a/src/test/ui/conditional-compilation/cfg-attr-syntax-validation.rs
+++ b/src/test/ui/conditional-compilation/cfg-attr-syntax-validation.rs
@@ -28,7 +28,7 @@ struct S9;
 macro_rules! generate_s10 {
     ($expr: expr) => {
         #[cfg(feature = $expr)]
-        //~^ ERROR expected unsuffixed literal or identifier, found concat!("nonexistent")
+        //~^ ERROR expected unsuffixed literal or identifier, found `concat!("nonexistent")`
         struct S10;
     }
 }

--- a/src/test/ui/conditional-compilation/cfg-attr-syntax-validation.stderr
+++ b/src/test/ui/conditional-compilation/cfg-attr-syntax-validation.stderr
@@ -52,7 +52,7 @@ error[E0565]: literal in `cfg` predicate value must be a string
 LL | #[cfg(a = b"hi")]  //~ ERROR literal in `cfg` predicate value must be a string
    |           ^^^^^ help: consider removing the prefix: `"hi"`
 
-error: expected unsuffixed literal or identifier, found concat!("nonexistent")
+error: expected unsuffixed literal or identifier, found `concat!("nonexistent")`
   --> $DIR/cfg-attr-syntax-validation.rs:30:25
    |
 LL |         #[cfg(feature = $expr)]

--- a/src/test/ui/conditional-compilation/cfg-attr-syntax-validation.stderr
+++ b/src/test/ui/conditional-compilation/cfg-attr-syntax-validation.stderr
@@ -53,10 +53,10 @@ LL | #[cfg(a = b"hi")]  //~ ERROR literal in `cfg` predicate value must be a str
    |           ^^^^^ help: consider removing the prefix: `"hi"`
 
 error: expected unsuffixed literal or identifier, found concat!("nonexistent")
-  --> $DIR/cfg-attr-syntax-validation.rs:30:15
+  --> $DIR/cfg-attr-syntax-validation.rs:30:25
    |
 LL |         #[cfg(feature = $expr)]
-   |               ^^^^^^^
+   |                         ^^^^^
 ...
 LL | generate_s10!(concat!("nonexistent"));
    | -------------------------------------- in this macro invocation


### PR DESCRIPTION
CC #58462