### PR TITLE
rustdoc: don't process `Crate::external_traits` when collecting intra-doc links

### DIFF
--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -213,6 +213,7 @@ impl<'a, 'tcx, 'rcx> LinkCollector<'a, 'tcx, 'rcx> {
                 _ => Err(())
             }
         } else {
+            debug!("attempting to resolve item without parent module: {}", path_str);
             Err(())
         }
     }
@@ -433,6 +434,15 @@ impl<'a, 'tcx, 'rcx> DocFolder for LinkCollector<'a, 'tcx, 'rcx> {
         } else {
             self.fold_item_recur(item)
         }
+    }
+
+    // FIXME: if we can resolve intra-doc links from other crates, we can use the stock
+    // `fold_crate`, but until then we should avoid scanning `krate.external_traits` since those
+    // will never resolve properly
+    fn fold_crate(&mut self, mut c: Crate) -> Crate {
+        c.module = c.module.take().and_then(|module| self.fold_item(module));
+
+        c
     }
 }
 

--- a/src/test/rustdoc/auxiliary/intra-links-external-traits.rs
+++ b/src/test/rustdoc/auxiliary/intra-links-external-traits.rs
@@ -1,0 +1,6 @@
+pub trait ThisTrait {
+    fn asdf(&self);
+
+    /// let's link to [`asdf`](ThisTrait::asdf)
+    fn qwop(&self);
+}

--- a/src/test/rustdoc/intra-links-external-traits.rs
+++ b/src/test/rustdoc/intra-links-external-traits.rs
@@ -1,0 +1,12 @@
+// aux-build:intra-links-external-traits.rs
+// ignore-cross-compile
+
+#![crate_name = "outer"]
+#![deny(intra_doc_link_resolution_failure)]
+
+// using a trait that has intra-doc links on it from another crate (whether re-exporting or just
+// implementing it) used to give spurious resolution failure warnings
+
+extern crate intra_links_external_traits;
+
+pub use intra_links_external_traits::ThisTrait;


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust/issues/58745, closes https://github.com/rust-lang/rust/pull/58917

The `collect-intra-doc-links` pass keeps track of the modules it recurses through as it processes items. This is used to know what module to give the resolver when looking up links. When looking through the regular items of the crate, this works fine, but the `DocFolder` trait as written doesn't just process the main crate hierarchy - it also processes the trait items in the `external_traits` map. This is useful for other passes (so they can strip out `#[doc(hidden)]` items, for example), but here it creates a situation where we're processing items "outside" the regular module hierarchy. Since everything in `external_traits` is defined outside the current crate, we can't fall back to finding its module scope like we do with local items.

Skipping this collection saves us from emitting some spurious warnings. We don't even lose anything by skipping it, either - the docs loaded from here are only ever rendered through `html::render::document_short` which strips any links out, so the fact that the links haven't been loaded doesn't matter. Hopefully this removes most of the remaining spurious resolution warnings from intra-doc links.

r? @GuillaumeGomez 