### PR TITLE
Default to integrated `rust-lld` linker for UEFI targets

### DIFF
--- a/src/librustc_target/spec/uefi_base.rs
+++ b/src/librustc_target/spec/uefi_base.rs
@@ -59,7 +59,7 @@ pub fn opts() -> TargetOptions {
         singlethread: true,
         emit_debug_gdb_scripts: false,
 
-        linker: Some("lld-link".to_string()),
+        linker: Some("rust-lld".to_string()),
         lld_flavor: LldFlavor::Link,
         pre_link_args,
 


### PR DESCRIPTION
The `x86_64-unknown-uefi` target was added in https://github.com/rust-lang/rust/pull/56769 with the linker defaulting to `lld-link`. This means that a system linker with that name is required for linking.

I think defaulting to `rust-lld`, which is shipped with Rust, is a better default for the following reasons:

- Most systems don't have `lld-link` installed, so it forces users to install it first.
- The naming of LLD executables is not standarized, so users often need to create an additional symlink before things work. For example, on Ubuntu `apt install lld` leads to an executable named `lld-link-6.0`.
- We already default to `rust-lld` for [many targets](https://github.com/rust-lang/rust/search?utf8=%E2%9C%93&q=rust-lld&type=), including embedded and WASM targets, so doing the same for UEFI crates seems consistent to me. (It even seems like `x86_64-unknown-uefi` is the [only target](https://github.com/rust-lang/rust/search?q=lld-link&unscoped_q=lld-link) that uses `lld-link`.)

cc @dvdhrm who added the target and @kkk669 who [proposed to use `rust-lld`](https://github.com/rust-lang/rust/pull/56769#issuecomment-461119648).