### PR TITLE
Point at coercion reason for `if` expressions without else clause if caused by return type

### DIFF
--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3472,8 +3472,39 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
             // We won't diverge unless both branches do (or the condition does).
             self.diverges.set(cond_diverges | then_diverges & else_diverges);
         } else {
+            // If this `if` expr is the parent's function return expr, the cause of the type
+            // coercion is the return type, point at it. (#25228)
+            let mut ret_reason = None;
+            if let Node::Block(block) = self.tcx.hir().get_by_hir_id(
+                self.tcx.hir().get_parent_node_by_hir_id(
+                    self.tcx.hir().get_parent_node_by_hir_id(then_expr.hir_id),
+                ),
+            ) {
+                // check that the body's parent is an fn
+                let parent = self.tcx.hir().get_by_hir_id(
+                    self.tcx.hir().get_parent_node_by_hir_id(
+                        self.tcx.hir().get_parent_node_by_hir_id(block.hir_id),
+                    ),
+                );
+                if let (Some(expr), Node::Item(hir::Item {
+                    node: hir::ItemKind::Fn(..), ..
+                })) = (&block.expr, parent) {
+                    // check that the `if` expr without `else` is the fn body's expr
+                    if expr.span == sp {
+                        ret_reason = self.get_fn_decl(then_expr.hir_id).map(|(fn_decl, _)| (
+                            fn_decl.output.span(),
+                            format!("found `{}` because of this return type", fn_decl.output),
+                        ));
+                    }
+                }
+            }
             let else_cause = self.cause(sp, ObligationCauseCode::IfExpressionWithNoElse);
-            coerce.coerce_forced_unit(self, &else_cause, &mut |_| (), true);
+            coerce.coerce_forced_unit(self, &else_cause, &mut |err| {
+                if let Some((sp, msg)) = &ret_reason {
+                    err.span_label(*sp, msg.as_str());
+                }
+                err.note("`if` expressions without `else` must evaluate to `()`");
+            }, true);
 
             // If the condition is false we can't diverge.
             self.diverges.set(cond_diverges);

--- a/src/test/ui/if/if-without-else-as-fn-expr.rs
+++ b/src/test/ui/if/if-without-else-as-fn-expr.rs
@@ -1,0 +1,10 @@
+fn foo(bar: usize) -> usize {
+    if bar % 5 == 0 {
+        return 3;
+    }
+    //~^^^ ERROR if may be missing an else clause
+}
+
+fn main() {
+    let _ = foo(1);
+}

--- a/src/test/ui/if/if-without-else-as-fn-expr.rs
+++ b/src/test/ui/if/if-without-else-as-fn-expr.rs
@@ -5,6 +5,21 @@ fn foo(bar: usize) -> usize {
     //~^^^ ERROR if may be missing an else clause
 }
 
+fn foo2(bar: usize) -> usize {
+    let x: usize = if bar % 5 == 0 {
+        return 3;
+    };
+    //~^^^ ERROR if may be missing an else clause
+    x
+}
+
+fn foo3(bar: usize) -> usize {
+    if bar % 5 == 0 {
+        3
+    }
+    //~^^^ ERROR if may be missing an else clause
+}
+
 fn main() {
     let _ = foo(1);
 }

--- a/src/test/ui/if/if-without-else-as-fn-expr.stderr
+++ b/src/test/ui/if/if-without-else-as-fn-expr.stderr
@@ -1,0 +1,17 @@
+error[E0317]: if may be missing an else clause
+  --> $DIR/if-without-else-as-fn-expr.rs:2:5
+   |
+LL |   fn foo(bar: usize) -> usize {
+   |                         ----- found `usize` because of this return type
+LL | /     if bar % 5 == 0 {
+LL | |         return 3;
+LL | |     }
+   | |_____^ expected (), found usize
+   |
+   = note: expected type `()`
+              found type `usize`
+   = note: `if` expressions without `else` must evaluate to `()`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0317`.

--- a/src/test/ui/if/if-without-else-as-fn-expr.stderr
+++ b/src/test/ui/if/if-without-else-as-fn-expr.stderr
@@ -13,6 +13,37 @@ LL | |     }
    = note: `if` expressions without `else` evaluate to `()`
    = help: consider adding an `else` block that evaluates to the expected type
 
-error: aborting due to previous error
+error[E0317]: if may be missing an else clause
+  --> $DIR/if-without-else-as-fn-expr.rs:9:20
+   |
+LL |       let x: usize = if bar % 5 == 0 {
+   |  _________-__________^
+   | |         |
+   | |         expected because of this assignment
+LL | |         return 3;
+LL | |     };
+   | |_____^ expected usize, found ()
+   |
+   = note: expected type `usize`
+              found type `()`
+   = note: `if` expressions without `else` evaluate to `()`
+   = help: consider adding an `else` block that evaluates to the expected type
+
+error[E0317]: if may be missing an else clause
+  --> $DIR/if-without-else-as-fn-expr.rs:17:5
+   |
+LL |   fn foo3(bar: usize) -> usize {
+   |                          ----- expected `usize` because of this return type
+LL | /     if bar % 5 == 0 {
+LL | |         3
+LL | |     }
+   | |_____^ expected usize, found ()
+   |
+   = note: expected type `usize`
+              found type `()`
+   = note: `if` expressions without `else` evaluate to `()`
+   = help: consider adding an `else` block that evaluates to the expected type
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0317`.

--- a/src/test/ui/if/if-without-else-as-fn-expr.stderr
+++ b/src/test/ui/if/if-without-else-as-fn-expr.stderr
@@ -2,15 +2,16 @@ error[E0317]: if may be missing an else clause
   --> $DIR/if-without-else-as-fn-expr.rs:2:5
    |
 LL |   fn foo(bar: usize) -> usize {
-   |                         ----- found `usize` because of this return type
+   |                         ----- expected `usize` because of this return type
 LL | /     if bar % 5 == 0 {
 LL | |         return 3;
 LL | |     }
-   | |_____^ expected (), found usize
+   | |_____^ expected usize, found ()
    |
-   = note: expected type `()`
-              found type `usize`
-   = note: `if` expressions without `else` must evaluate to `()`
+   = note: expected type `usize`
+              found type `()`
+   = note: `if` expressions without `else` evaluate to `()`
+   = help: consider adding an `else` block that evaluates to the expected type
 
 error: aborting due to previous error
 

--- a/src/test/ui/if/if-without-else-result.stderr
+++ b/src/test/ui/if/if-without-else-result.stderr
@@ -6,7 +6,8 @@ LL |     let a = if true { true };
    |
    = note: expected type `()`
               found type `bool`
-   = note: `if` expressions without `else` must evaluate to `()`
+   = note: `if` expressions without `else` evaluate to `()`
+   = help: consider adding an `else` block that evaluates to the expected type
 
 error: aborting due to previous error
 

--- a/src/test/ui/if/if-without-else-result.stderr
+++ b/src/test/ui/if/if-without-else-result.stderr
@@ -6,6 +6,7 @@ LL |     let a = if true { true };
    |
    = note: expected type `()`
               found type `bool`
+   = note: `if` expressions without `else` must evaluate to `()`
 
 error: aborting due to previous error
 

--- a/src/test/ui/if/if-without-else-result.stderr
+++ b/src/test/ui/if/if-without-else-result.stderr
@@ -2,7 +2,10 @@ error[E0317]: if may be missing an else clause
   --> $DIR/if-without-else-result.rs:2:13
    |
 LL |     let a = if true { true };
-   |             ^^^^^^^^^^^^^^^^ expected (), found bool
+   |             ^^^^^^^^^^----^^
+   |             |         |
+   |             |         found here
+   |             expected (), found bool
    |
    = note: expected type `()`
               found type `bool`

--- a/src/test/ui/issues/issue-4201.stderr
+++ b/src/test/ui/issues/issue-4201.stderr
@@ -13,6 +13,7 @@ LL | |     };
    |
    = note: expected type `()`
               found type `{integer}`
+   = note: `if` expressions without `else` must evaluate to `()`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-4201.stderr
+++ b/src/test/ui/issues/issue-4201.stderr
@@ -13,7 +13,8 @@ LL | |     };
    |
    = note: expected type `()`
               found type `{integer}`
-   = note: `if` expressions without `else` must evaluate to `()`
+   = note: `if` expressions without `else` evaluate to `()`
+   = help: consider adding an `else` block that evaluates to the expected type
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-4201.stderr
+++ b/src/test/ui/issues/issue-4201.stderr
@@ -8,6 +8,7 @@ LL | | //~| expected type `()`
 LL | | //~| found type `{integer}`
 LL | | //~| expected (), found integer
 LL | |         1
+   | |         - found here
 LL | |     };
    | |_____^ expected (), found integer
    |

--- a/src/test/ui/issues/issue-50577.stderr
+++ b/src/test/ui/issues/issue-50577.stderr
@@ -6,7 +6,8 @@ LL |         Drop = assert_eq!(1, 1)
    |
    = note: expected type `()`
               found type `isize`
-   = note: `if` expressions without `else` must evaluate to `()`
+   = note: `if` expressions without `else` evaluate to `()`
+   = help: consider adding an `else` block that evaluates to the expected type
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/issues/issue-50577.stderr
+++ b/src/test/ui/issues/issue-50577.stderr
@@ -2,7 +2,10 @@ error[E0317]: if may be missing an else clause
   --> $DIR/issue-50577.rs:3:16
    |
 LL |         Drop = assert_eq!(1, 1)
-   |                ^^^^^^^^^^^^^^^^ expected (), found isize
+   |                ^^^^^^^^^^^^^^^^
+   |                |
+   |                expected (), found isize
+   |                found here
    |
    = note: expected type `()`
               found type `isize`

--- a/src/test/ui/issues/issue-50577.stderr
+++ b/src/test/ui/issues/issue-50577.stderr
@@ -6,6 +6,7 @@ LL |         Drop = assert_eq!(1, 1)
    |
    = note: expected type `()`
               found type `isize`
+   = note: `if` expressions without `else` must evaluate to `()`
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to previous error


### PR DESCRIPTION
```
error[E0317]: if may be missing an else clause
  --> $DIR/if-without-else-as-fn-expr.rs:2:5
   |
LL |   fn foo(bar: usize) -> usize {
   |                         ----- found `usize` because of this return type
LL | /     if bar % 5 == 0 {
LL | |         return 3;
LL | |     }
   | |_____^ expected (), found usize
   |
   = note: expected type `()`
              found type `usize`
   = note: `if` expressions without `else` must evaluate to `()`
```

Fix #25228.