### PR TITLE
Fix documentation of from_ne_bytes and from_le_bytes

### DIFF
--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -1979,10 +1979,10 @@ When starting from a slice rather than an array, fallible conversion APIs can be
 ```
 use std::convert::TryInto;
 
-fn read_be_", stringify!($SelfT), "(input: &mut &[u8]) -> ", stringify!($SelfT), " {
+fn read_le_", stringify!($SelfT), "(input: &mut &[u8]) -> ", stringify!($SelfT), " {
     let (int_bytes, rest) = input.split_at(std::mem::size_of::<", stringify!($SelfT), ">());
     *input = rest;
-    ", stringify!($SelfT), "::from_be_bytes(int_bytes.try_into().unwrap())
+    ", stringify!($SelfT), "::from_le_bytes(int_bytes.try_into().unwrap())
 }
 ```"),
             #[stable(feature = "int_to_from_bytes", since = "1.32.0")]
@@ -2020,10 +2020,10 @@ When starting from a slice rather than an array, fallible conversion APIs can be
 ```
 use std::convert::TryInto;
 
-fn read_be_", stringify!($SelfT), "(input: &mut &[u8]) -> ", stringify!($SelfT), " {
+fn read_ne_", stringify!($SelfT), "(input: &mut &[u8]) -> ", stringify!($SelfT), " {
     let (int_bytes, rest) = input.split_at(std::mem::size_of::<", stringify!($SelfT), ">());
     *input = rest;
-    ", stringify!($SelfT), "::from_be_bytes(int_bytes.try_into().unwrap())
+    ", stringify!($SelfT), "::from_ne_bytes(int_bytes.try_into().unwrap())
 }
 ```"),
             #[stable(feature = "int_to_from_bytes", since = "1.32.0")]
@@ -3695,10 +3695,10 @@ When starting from a slice rather than an array, fallible conversion APIs can be
 ```
 use std::convert::TryInto;
 
-fn read_be_", stringify!($SelfT), "(input: &mut &[u8]) -> ", stringify!($SelfT), " {
+fn read_le_", stringify!($SelfT), "(input: &mut &[u8]) -> ", stringify!($SelfT), " {
     let (int_bytes, rest) = input.split_at(std::mem::size_of::<", stringify!($SelfT), ">());
     *input = rest;
-    ", stringify!($SelfT), "::from_be_bytes(int_bytes.try_into().unwrap())
+    ", stringify!($SelfT), "::from_le_bytes(int_bytes.try_into().unwrap())
 }
 ```"),
             #[stable(feature = "int_to_from_bytes", since = "1.32.0")]
@@ -3736,10 +3736,10 @@ When starting from a slice rather than an array, fallible conversion APIs can be
 ```
 use std::convert::TryInto;
 
-fn read_be_", stringify!($SelfT), "(input: &mut &[u8]) -> ", stringify!($SelfT), " {
+fn read_ne_", stringify!($SelfT), "(input: &mut &[u8]) -> ", stringify!($SelfT), " {
     let (int_bytes, rest) = input.split_at(std::mem::size_of::<", stringify!($SelfT), ">());
     *input = rest;
-    ", stringify!($SelfT), "::from_be_bytes(int_bytes.try_into().unwrap())
+    ", stringify!($SelfT), "::from_ne_bytes(int_bytes.try_into().unwrap())
 }
 ```"),
             #[stable(feature = "int_to_from_bytes", since = "1.32.0")]


### PR DESCRIPTION
Copypasta mistake, the documentation of `from_ne_bytes` and `from_le_bytes` used the big-endian variant in the example snippets.