### PR TITLE
PowerShell version of run.sh to work around AppVeyor exit failures

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -207,7 +207,7 @@ test_script:
   - sh src/ci/init_repo.sh . /c/cache/rustsrc
   - set SRC=.
   - set NO_CCACHE=1
-  - sh src/ci/run.sh
+  - ps: ./src/ci/run.ps1
 
 on_failure:
   # Dump crash log

--- a/src/ci/run.ps1
+++ b/src/ci/run.ps1
@@ -1,0 +1,81 @@
+
+if (Test-Path env:\CI_JOB_NAME) {
+    Write-Host "[CI_JOB_NAME=$env:CI_JOB_NAME]"
+}
+
+. $PSScriptRoot/shared.ps1
+
+if (($env:TRAVIS -ne 'true') -or ($env:TRAVIS_BRANCH -eq 'auto')) {
+    $env:RUST_CONFIGURE_ARGS = "$env:RUST_CONFIGURE_ARGS --set build.print-step-timings --enable-verbose-tests"
+}
+
+$env:RUST_CONFIGURE_ARGS = "$env:RUST_CONFIGURE_ARGS --enable-sccache"
+$env:RUST_CONFIGURE_ARGS = "$env:RUST_CONFIGURE_ARGS --disable-manage-submodules"
+$env:RUST_CONFIGURE_ARGS = "$env:RUST_CONFIGURE_ARGS --enable-locked-deps"
+$env:RUST_CONFIGURE_ARGS = "$env:RUST_CONFIGURE_ARGS --enable-cargo-native-static"
+$env:RUST_CONFIGURE_ARGS = "$env:RUST_CONFIGURE_ARGS --set rust.codegen-units-std=1"
+
+if ([string]::IsNullOrEmpty($env:DIST_SRC)) {
+    $env:RUST_CONFIGURE_ARGS = "$env:RUST_CONFIGURE_ARGS --disable-dist-src"
+}
+
+$env:RUST_RELEASE_CHANNEL = 'nightly'
+
+if (-not [string]::IsNullOrEmpty("${env:DEPLOY}${env:DEPLOY_ALT}")) {
+    $env:RUST_CONFIGURE_ARGS = "$env:RUST_CONFIGURE_ARGS --release-channel=$RUST_RELEASE_CHANNEL"
+    $env:RUST_CONFIGURE_ARGS = "$env:RUST_CONFIGURE_ARGS --enable-llvm-static-stdcpp"
+    $env:RUST_CONFIGURE_ARGS = "$env:RUST_CONFIGURE_ARGS --set rust.remap-debuginfo"
+
+    if ($env:NO_LLVM_ASSERTIONS -eq "1") {
+        $env:RUST_CONFIGURE_ARGS = "$env:RUST_CONFIGURE_ARGS --disable-llvm-assertions"
+
+    }
+    elseif ( -not [string]::IsNullOrEmpty($env:DEPLOY_ALT) ) {
+        $env:RUST_CONFIGURE_ARGS = "$env:RUST_CONFIGURE_ARGS --enable-llvm-assertions"
+        $env:RUST_CONFIGURE_ARGS = "$env:RUST_CONFIGURE_ARGS --set rust.verify-llvm-ir"
+    }
+}
+else {
+    if ([string]::IsNullOrEmpty($env:NO_DEBUG_ASSERTIONS)) {
+        $env:RUST_CONFIGURE_ARGS = "$env:RUST_CONFIGURE_ARGS --enable-debug-assertions"
+    }
+
+    # In general we always want to run tests with LLVM assertions enabled, but not
+    # all platforms currently support that, so we have an option to disable.
+    if ([string]::IsNullOrEmpty($env:NO_LLVM_ASSERTIONS)) {
+        RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-llvm-assertions"
+    }
+
+    $env:RUST_CONFIGURE_ARGS = "$env:RUST_CONFIGURE_ARGS --set rust.verify-llvm-ir"
+}
+ 
+if  (($env:RUST_RELEASE_CHANNEL -eq "nightly") -or ([string]::IsNullOrEmpty($env:DIST_REQUIRE_ALL_TOOLS))) {
+    $env:RUST_CONFIGURE_ARGS="$env:RUST_CONFIGURE_ARGS --enable-missing-tools"
+}
+
+$env:SCCACHE_IDLE_TIMEOUT=10800 
+sccache --start-server
+
+if (-not [string]::IsNullOrEmpty($env:RUN_CHECK_WITH_PARALLEL_QUERIES) {
+  $env:SRC/configure --enable-parallel-compiler
+  $env:CARGO_INCREMENTAL=0 
+  python2.7 ../x.py check
+  rm -force config.toml
+  rm -recurse -force build
+}
+
+$env:SRC/configure $env:RUST_CONFIGURE_ARGS
+retry make prepare
+make check-bootstrap
+
+
+$ncpus = (get-wmiobject win32_processor).NumberOfLogicalProcessors
+
+if ((test-path env:\SCRIPT) -and  (-not [string]::IsNullOrEmpty($env:SCRIPT))){
+    & $env:SCRIPT
+} 
+else {
+    make -j $ncpus tidy
+    make -j $ncpus all
+    make -j $ncpus $env:RUST_CHECK_TARGET
+}

--- a/src/ci/shared.ps1
+++ b/src/ci/shared.ps1
@@ -1,0 +1,29 @@
+function retry
+{
+    param (
+    [Parameter(Mandatory=$true)][string]$Command    
+    )
+
+    $retrycount = 1
+    $max = 5
+    $completed = $false
+
+    while ((-not $completed) -and ($retrycount -le 5)) {
+        
+            & { $command }
+
+            if ($LASTEXITCODE -ne 0) {
+                $retrycount += 1
+                start-sleep -Seconds 2
+                Write-host "Command failed.  Attempt $retrycount/$max"
+            }
+            else {
+                $completed = $true
+            }
+    }
+    if (-not $completed) {
+        Write-Host "Failed after $max attempts."
+        throw
+    }
+}
+


### PR DESCRIPTION
In order to work around the challenge with long running processes under msys, (and only as a stop-gap to get builds running again).  [See the support ticket.](https://help.appveyor.com/discussions/problems/19657-successful-builds-failing-with-code-259 )

To that end, I've got a port of the shell script `run.sh` in `run.ps1` (along with a supporting `shared.ps1` for a retry function).

I've got the appveyor config updated to use `run.ps1`.

I can't run this on my own (at least until I've got some time to set up a box that looks like the appveyor builders), but it *should* work. 😄 

I'd be happy to jump in and troubleshoot any problems (via the RDP to build worker) tomorrow.
