### PR TITLE
Fix moving text in search tabs headers

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -1195,7 +1195,7 @@ pre.rust {
 	border-top: 2px solid;
 }
 
-#titles > div:not(:last-child):not(.selected) {
+#titles > div:not(:last-child) {
 	margin-right: 1px;
 	width: calc(33.3% - 1px);
 }


### PR DESCRIPTION
Fixes #59005.

Now, the text in the search tabs headers isn't moving anymore.

r? @QuietMisdreavus 