### PR TITLE
Recover from missing comma between enum variants and from bad `pub` kw

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -7713,11 +7713,7 @@ impl<'a> Parser<'a> {
             variants.push(respan(vlo.to(self.prev_span), vr));
 
             if !self.eat(&token::Comma) {
-                if self.token.is_ident() &&
-                    !self.token.is_special_ident() &&
-                    !self.token.is_used_keyword() &&
-                    !self.token.is_unused_keyword()
-                {
+                if self.token.is_ident() && !self.token.is_reserved_ident() {
                     let sp = self.sess.source_map().next_point(self.prev_span);
                     let mut err = self.struct_span_err(sp, "missing comma");
                     err.span_suggestion_short(

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -8623,11 +8623,15 @@ impl<'a> Parser<'a> {
     /// Recover from `pub` keyword in places where it seems _reasonable_ but isn't valid.
     fn eat_bad_pub(&mut self) {
         if self.token.is_keyword(keywords::Pub) {
-            self.bump();
-            let mut err = self.diagnostic()
-                .struct_span_err(self.prev_span, "unnecessary visibility qualifier");
-            err.span_label(self.prev_span, "`pub` not permitted here");
-            err.emit();
+            match self.parse_visibility(false) {
+                Ok(vis) => {
+                    let mut err = self.diagnostic()
+                        .struct_span_err(vis.span, "unnecessary visibility qualifier");
+                    err.span_label(vis.span, "`pub` not permitted here");
+                    err.emit();
+                }
+                Err(mut err) => err.emit(),
+            }
         }
     }
 }

--- a/src/test/ui/issues/issue-28433.rs
+++ b/src/test/ui/issues/issue-28433.rs
@@ -1,13 +1,14 @@
 // compile-flags: -Z continue-parse-after-error
 
-enum bird {
-    pub duck,
-    //~^ ERROR: expected identifier, found keyword `pub`
-    //~| ERROR: expected
-    goose
+enum Bird {
+    pub Duck,
+    //~^ ERROR expected identifier, found keyword `pub`
+    //~| ERROR missing comma
+    //~| WARN variant `pub` should have an upper camel case name
+    Goose
 }
 
 
 fn main() {
-    let y = bird::goose;
+    let y = Bird::Goose;
 }

--- a/src/test/ui/issues/issue-28433.rs
+++ b/src/test/ui/issues/issue-28433.rs
@@ -2,9 +2,7 @@
 
 enum Bird {
     pub Duck,
-    //~^ ERROR expected identifier, found keyword `pub`
-    //~| ERROR missing comma
-    //~| WARN variant `pub` should have an upper camel case name
+    //~^ ERROR unnecessary visibility qualifier
     Goose
 }
 

--- a/src/test/ui/issues/issue-28433.rs
+++ b/src/test/ui/issues/issue-28433.rs
@@ -3,7 +3,9 @@
 enum Bird {
     pub Duck,
     //~^ ERROR unnecessary visibility qualifier
-    Goose
+    Goose,
+    pub(crate) Dove
+    //~^ ERROR unnecessary visibility qualifier
 }
 
 

--- a/src/test/ui/issues/issue-28433.stderr
+++ b/src/test/ui/issues/issue-28433.stderr
@@ -1,26 +1,8 @@
-error: expected identifier, found keyword `pub`
+error: unnecessary visibility qualifier
   --> $DIR/issue-28433.rs:4:5
    |
 LL |     pub Duck,
-   |     ^^^ expected identifier, found keyword
-help: you can escape reserved keywords to use them as identifiers
-   |
-LL |     r#pub Duck,
-   |     ^^^^^
+   |     ^^^ `pub` not permitted here
 
-error: missing comma
-  --> $DIR/issue-28433.rs:4:8
-   |
-LL |     pub Duck,
-   |        ^ help: missing comma
-
-warning: variant `pub` should have an upper camel case name
-  --> $DIR/issue-28433.rs:4:5
-   |
-LL |     pub Duck,
-   |     ^^^ help: convert the identifier to upper camel case: `Pub`
-   |
-   = note: #[warn(non_camel_case_types)] on by default
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-28433.stderr
+++ b/src/test/ui/issues/issue-28433.stderr
@@ -1,18 +1,26 @@
 error: expected identifier, found keyword `pub`
   --> $DIR/issue-28433.rs:4:5
    |
-LL |     pub duck,
+LL |     pub Duck,
    |     ^^^ expected identifier, found keyword
 help: you can escape reserved keywords to use them as identifiers
    |
-LL |     r#pub duck,
+LL |     r#pub Duck,
    |     ^^^^^
 
-error: expected one of `(`, `,`, `=`, `{`, or `}`, found `duck`
-  --> $DIR/issue-28433.rs:4:9
+error: missing comma
+  --> $DIR/issue-28433.rs:4:8
    |
-LL |     pub duck,
-   |         ^^^^ expected one of `(`, `,`, `=`, `{`, or `}` here
+LL |     pub Duck,
+   |        ^ help: missing comma
+
+warning: variant `pub` should have an upper camel case name
+  --> $DIR/issue-28433.rs:4:5
+   |
+LL |     pub Duck,
+   |     ^^^ help: convert the identifier to upper camel case: `Pub`
+   |
+   = note: #[warn(non_camel_case_types)] on by default
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-28433.stderr
+++ b/src/test/ui/issues/issue-28433.stderr
@@ -4,5 +4,11 @@ error: unnecessary visibility qualifier
 LL |     pub Duck,
    |     ^^^ `pub` not permitted here
 
-error: aborting due to previous error
+error: unnecessary visibility qualifier
+  --> $DIR/issue-28433.rs:7:5
+   |
+LL |     pub(crate) Dove
+   |     ^^^^^^^^^^ `pub` not permitted here
+
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/parser/recover-enum.rs
+++ b/src/test/ui/parser/recover-enum.rs
@@ -3,7 +3,11 @@
 fn main() {
     enum Test {
         Very
-        Bad //~ ERROR found `Bad`
-        Stuff
+        //~^ ERROR missing comma
+        Bad(usize)
+        //~^ ERROR missing comma
+        Stuff { a: usize }
+        //~^ ERROR missing comma
+        Here
     }
 }

--- a/src/test/ui/parser/recover-enum.stderr
+++ b/src/test/ui/parser/recover-enum.stderr
@@ -1,10 +1,20 @@
-error: expected one of `(`, `,`, `=`, `{`, or `}`, found `Bad`
-  --> $DIR/recover-enum.rs:6:9
+error: missing comma
+  --> $DIR/recover-enum.rs:5:13
    |
 LL |         Very
-   |             - expected one of `(`, `,`, `=`, `{`, or `}` here
-LL |         Bad
-   |         ^^^ unexpected token
+   |             ^ help: missing comma
 
-error: aborting due to previous error
+error: missing comma
+  --> $DIR/recover-enum.rs:7:19
+   |
+LL |         Bad(usize)
+   |                   ^ help: missing comma
+
+error: missing comma
+  --> $DIR/recover-enum.rs:9:27
+   |
+LL |         Stuff { a: usize }
+   |                           ^ help: missing comma
+
+error: aborting due to 3 previous errors
 

--- a/src/test/ui/parser/trait-pub-assoc-const.rs
+++ b/src/test/ui/parser/trait-pub-assoc-const.rs
@@ -1,6 +1,6 @@
 trait Foo {
     pub const Foo: u32;
-    //~^ ERROR expected one of `async`, `const`, `extern`, `fn`, `type`, `unsafe`, or `}`, found
+    //~^ ERROR unnecessary visibility qualifier
 }
 
 fn main() {}

--- a/src/test/ui/parser/trait-pub-assoc-const.stderr
+++ b/src/test/ui/parser/trait-pub-assoc-const.stderr
@@ -1,10 +1,8 @@
-error: expected one of `async`, `const`, `extern`, `fn`, `type`, `unsafe`, or `}`, found `pub`
+error: unnecessary visibility qualifier
   --> $DIR/trait-pub-assoc-const.rs:2:5
    |
-LL | trait Foo {
-   |            - expected one of 7 possible tokens here
 LL |     pub const Foo: u32;
-   |     ^^^ unexpected token
+   |     ^^^ `pub` not permitted here
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/trait-pub-assoc-ty.rs
+++ b/src/test/ui/parser/trait-pub-assoc-ty.rs
@@ -1,6 +1,6 @@
 trait Foo {
     pub type Foo;
-    //~^ ERROR expected one of `async`, `const`, `extern`, `fn`, `type`, `unsafe`, or `}`, found
+    //~^ ERROR unnecessary visibility qualifier
 }
 
 fn main() {}

--- a/src/test/ui/parser/trait-pub-assoc-ty.stderr
+++ b/src/test/ui/parser/trait-pub-assoc-ty.stderr
@@ -1,10 +1,8 @@
-error: expected one of `async`, `const`, `extern`, `fn`, `type`, `unsafe`, or `}`, found `pub`
+error: unnecessary visibility qualifier
   --> $DIR/trait-pub-assoc-ty.rs:2:5
    |
-LL | trait Foo {
-   |            - expected one of 7 possible tokens here
 LL |     pub type Foo;
-   |     ^^^ unexpected token
+   |     ^^^ `pub` not permitted here
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/trait-pub-method.rs
+++ b/src/test/ui/parser/trait-pub-method.rs
@@ -1,6 +1,6 @@
 trait Foo {
     pub fn foo();
-    //~^ ERROR expected one of `async`, `const`, `extern`, `fn`, `type`, `unsafe`, or `}`, found
+    //~^ ERROR unnecessary visibility qualifier
 }
 
 fn main() {}

--- a/src/test/ui/parser/trait-pub-method.stderr
+++ b/src/test/ui/parser/trait-pub-method.stderr
@@ -1,10 +1,8 @@
-error: expected one of `async`, `const`, `extern`, `fn`, `type`, `unsafe`, or `}`, found `pub`
+error: unnecessary visibility qualifier
   --> $DIR/trait-pub-method.rs:2:5
    |
-LL | trait Foo {
-   |            - expected one of 7 possible tokens here
 LL |     pub fn foo();
-   |     ^^^ unexpected token
+   |     ^^^ `pub` not permitted here
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Fix #56579. Fix #56473.