### PR TITLE
When encountering `||{}()`, suggest the likely intended `(||{})()`

### DIFF
--- a/src/test/ui/suggestions/suggest-on-bare-closure-call.rs
+++ b/src/test/ui/suggestions/suggest-on-bare-closure-call.rs
@@ -1,0 +1,4 @@
+fn main() {
+    let _ = ||{}();
+    //~^ ERROR expected function, found `()`
+}

--- a/src/test/ui/suggestions/suggest-on-bare-closure-call.stderr
+++ b/src/test/ui/suggestions/suggest-on-bare-closure-call.stderr
@@ -1,0 +1,15 @@
+error[E0618]: expected function, found `()`
+  --> $DIR/suggest-on-bare-closure-call.rs:2:15
+   |
+LL |     let _ = ||{}();
+   |               ^^--
+   |               |
+   |               call expression requires function
+help: if you meant to create this closure and immediately call it, surround the closure with parenthesis
+   |
+LL |     let _ = (||{})();
+   |             ^    ^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0618`.


### PR DESCRIPTION
Fix #55851.