### PR TITLE
Fix ICE in MIR pretty printing

### DIFF
--- a/src/librustc_mir/util/pretty.rs
+++ b/src/librustc_mir/util/pretty.rs
@@ -1,4 +1,5 @@
 use rustc::hir::def_id::{DefId, LOCAL_CRATE};
+use rustc::hir::def::CtorKind;
 use rustc::mir::*;
 use rustc::mir::visit::Visitor;
 use rustc::ty::{self, TyCtxt};
@@ -597,7 +598,8 @@ fn write_mir_sig(
     trace!("write_mir_sig: {:?}", src.instance);
     let descr = tcx.describe_def(src.def_id());
     let is_function = match descr {
-        Some(Def::Fn(_)) | Some(Def::Method(_)) | Some(Def::StructCtor(..)) => true,
+        Some(Def::Fn(_)) | Some(Def::Method(_)) | Some(Def::Variant(..)) |
+        Some(Def::StructCtor(_, CtorKind::Fn)) => true,
         _ => tcx.is_closure(src.def_id()),
     };
     match (descr, src.promoted) {

--- a/src/test/mir-opt/unusual-item-types.rs
+++ b/src/test/mir-opt/unusual-item-types.rs
@@ -7,11 +7,18 @@ impl A {
     const ASSOCIATED_CONSTANT: i32 = 2;
 }
 
+// See #59021
+enum Test {
+    X(usize),
+    Y { a: usize },
+}
+
 enum E {
     V = 5,
 }
 
 fn main() {
+    let f = Test::X as fn(usize) -> Test;
     let v = Vec::<i32>::new();
 }
 
@@ -64,3 +71,14 @@ fn main() {
 //     _3 = const std::ops::Drop::drop(move _2) -> [return: bb6, unwind: bb5];
 // }
 // END rustc.ptr-real_drop_in_place.std__vec__Vec_i32_.AddMovesForPackedDrops.before.mir
+
+// START rustc.Test-X.mir_map.0.mir
+// fn Test::X(_1: usize) -> Test {
+//     let mut _0: Test;
+//
+//     bb0: {
+//         _0 = Test::X(move _1,);
+//         return;
+//     }
+// }
+// END rustc.Test-X.mir_map.0.mir


### PR DESCRIPTION
A `Def::Variant` should be considered as a function in mir pretty
printing. Each variant has a constructor that we must print.

Given the following enum definition:

```rust
pub enum TestMe {
    X(usize),
}
```

We will need to generate a constructor for the variant `X` with a
signature that looks something like the following:

```
fn TestMe::X(_1: usize) -> TestMe;
```

Fixes: #59021 