### PR TITLE
Avoid some common false positives in intra doc link checking

### DIFF
--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -291,6 +291,12 @@ impl<'a, 'tcx, 'rcx> DocFolder for LinkCollector<'a, 'tcx, 'rcx> {
             if ori_link.contains('/') {
                 continue;
             }
+
+            // [] is mostly likely not supposed to be a link
+            if ori_link.is_empty() {
+                continue;
+            }
+
             let link = ori_link.replace("`", "");
             let (def, fragment) = {
                 let mut kind = PathKind::Unknown;


### PR DESCRIPTION
The empty string case is never going to be a link. The numeric case may be a link, but if it were it would have resolved locally. It's more likely the makeshift markdown footnote notation (`[0]`, etc)

r? @QuietMisdreavus