### PR TITLE
CI: Trim some tests from i686-gnu

### DIFF
--- a/src/ci/docker/i686-gnu/Dockerfile
+++ b/src/ci/docker/i686-gnu/Dockerfile
@@ -18,4 +18,10 @@ COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
 ENV RUST_CONFIGURE_ARGS --build=i686-unknown-linux-gnu
-ENV SCRIPT python2.7 ../x.py test
+# Exclude some tests that are unlikely to be platform specific, to speed up
+# this slow job.
+ENV SCRIPT python2.7 ../x.py test \
+  --exclude src/bootstrap \
+  --exclude src/test/rustdoc-js \
+  --exclude src/tools/error_index_generator \
+  --exclude src/tools/linkchecker


### PR DESCRIPTION
This removes some tests from the i686-gnu job. This job clocks in at 2hr 56min, and removing these should cut about 10 to 15 minutes, giving a little more breathing room. I suspect these don't need to be tested on every platform.