### PR TITLE
CI: Set job names.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,20 +12,27 @@ git:
   depth: 2
   submodules: false
 
+env:
+  global:
+    - CI_JOB_NAME=$TRAVIS_JOB_NAME
+
 matrix:
   fast_finish: true
   include:
     # Images used in testing PR and try-build should be run first.
     - env: IMAGE=x86_64-gnu-llvm-6.0 RUST_BACKTRACE=1
+      name: x86_64-gnu-llvm-6.0
       if: type = pull_request OR branch = auto
 
     - env: IMAGE=dist-x86_64-linux DEPLOY=1
+      name: dist-x86_64-linux
       if: branch = try OR branch = auto
 
     # "alternate" deployments, these are "nightlies" but have LLVM assertions
     # turned on, they're deployed to a different location primarily for
     # additional testing.
-    - env: IMAGE=dist-x86_64-linux DEPLOY_ALT=1 CI_JOB_NAME=dist-x86_64-linux-alt
+    - env: IMAGE=dist-x86_64-linux DEPLOY_ALT=1
+      name: dist-x86_64-linux-alt
       if: branch = try OR branch = auto
 
     - env: >
@@ -37,9 +44,9 @@ matrix:
         MACOSX_DEPLOYMENT_TARGET=10.7
         NO_LLVM_ASSERTIONS=1
         NO_DEBUG_ASSERTIONS=1
-        CI_JOB_NAME=dist-x86_64-apple-alt
       os: osx
       osx_image: xcode9.3-moar
+      name: dist-x86_64-apple-alt
       if: branch = auto
 
     # macOS builders. These are placed near the beginning because they are very
@@ -60,9 +67,9 @@ matrix:
         MACOSX_STD_DEPLOYMENT_TARGET=10.7
         NO_LLVM_ASSERTIONS=1
         NO_DEBUG_ASSERTIONS=1
-        CI_JOB_NAME=x86_64-apple
       os: osx
       osx_image: xcode9.3-moar
+      name: x86_64-apple
       if: branch = auto
 
     - env: >
@@ -74,9 +81,9 @@ matrix:
         MACOSX_STD_DEPLOYMENT_TARGET=10.7
         NO_LLVM_ASSERTIONS=1
         NO_DEBUG_ASSERTIONS=1
-        CI_JOB_NAME=i686-apple
       os: osx
       osx_image: xcode9.3-moar
+      name: i686-apple
       if: branch = auto
 
     # OSX builders producing releases. These do not run the full test suite and
@@ -95,9 +102,9 @@ matrix:
         NO_LLVM_ASSERTIONS=1
         NO_DEBUG_ASSERTIONS=1
         DIST_REQUIRE_ALL_TOOLS=1
-        CI_JOB_NAME=dist-i686-apple
       os: osx
       osx_image: xcode9.3-moar
+      name: dist-i686-apple
       if: branch = auto
 
     - env: >
@@ -110,81 +117,116 @@ matrix:
         NO_LLVM_ASSERTIONS=1
         NO_DEBUG_ASSERTIONS=1
         DIST_REQUIRE_ALL_TOOLS=1
-        CI_JOB_NAME=dist-x86_64-apple
       os: osx
       osx_image: xcode9.3-moar
+      name: dist-x86_64-apple
       if: branch = auto
 
     # Linux builders, remaining docker images
     - env: IMAGE=arm-android
+      name: arm-android
       if: branch = auto
     - env: IMAGE=armhf-gnu
+      name: armhf-gnu
       if: branch = auto
     - env: IMAGE=dist-various-1 DEPLOY=1
+      name: dist-various-1
       if: branch = auto
     - env: IMAGE=dist-various-2 DEPLOY=1
+      name: dist-various-2
       if: branch = auto
     - env: IMAGE=dist-aarch64-linux DEPLOY=1
+      name: dist-aarch64-linux
       if: branch = auto
     - env: IMAGE=dist-android DEPLOY=1
+      name: dist-android
       if: branch = auto
     - env: IMAGE=dist-arm-linux DEPLOY=1
+      name: dist-arm-linux
       if: branch = auto
     - env: IMAGE=dist-armhf-linux DEPLOY=1
+      name: dist-armhf-linux
       if: branch = auto
     - env: IMAGE=dist-armv7-linux DEPLOY=1
+      name: dist-armv7-linux
       if: branch = auto
     - env: IMAGE=dist-i586-gnu-i586-i686-musl DEPLOY=1
+      name: dist-i586-gnu-i586-i686-musl
       if: branch = auto
     - env: IMAGE=dist-i686-freebsd DEPLOY=1
+      name: dist-i686-freebsd
       if: branch = auto
     - env: IMAGE=dist-i686-linux DEPLOY=1
+      name: dist-i686-linux
       if: branch = auto
     - env: IMAGE=dist-mips-linux DEPLOY=1
+      name: dist-mips-linux
       if: branch = auto
     - env: IMAGE=dist-mips64-linux DEPLOY=1
+      name: dist-mips64-linux
       if: branch = auto
     - env: IMAGE=dist-mips64el-linux DEPLOY=1
+      name: dist-mips64el-linux
       if: branch = auto
     - env: IMAGE=dist-mipsel-linux DEPLOY=1
+      name: dist-mipsel-linux
       if: branch = auto
     - env: IMAGE=dist-powerpc-linux DEPLOY=1
+      name: dist-powerpc-linux
       if: branch = auto
     - env: IMAGE=dist-powerpc64-linux DEPLOY=1
+      name: dist-powerpc64-linux
       if: branch = auto
     - env: IMAGE=dist-powerpc64le-linux DEPLOY=1
+      name: dist-powerpc64le-linux
       if: branch = auto
     - env: IMAGE=dist-s390x-linux DEPLOY=1
+      name: dist-s390x-linux
       if: branch = auto
     - env: IMAGE=dist-x86_64-freebsd DEPLOY=1
+      name: dist-x86_64-freebsd
       if: branch = auto
     - env: IMAGE=dist-x86_64-musl DEPLOY=1
+      name: dist-x86_64-musl
       if: branch = auto
     - env: IMAGE=dist-x86_64-netbsd DEPLOY=1
+      name: dist-x86_64-netbsd
       if: branch = auto
     - env: IMAGE=asmjs
+      name: asmjs
       if: branch = auto
     - env: IMAGE=i686-gnu
+      name: i686-gnu
       if: branch = auto
     - env: IMAGE=i686-gnu-nopt
+      name: i686-gnu-nopt
       if: branch = auto
     - env: IMAGE=test-various
+      name: test-various
       if: branch = auto
     - env: IMAGE=x86_64-gnu
+      name: x86_64-gnu
       if: branch = auto
     - env: IMAGE=x86_64-gnu-full-bootstrap
+      name: x86_64-gnu-full-bootstrap
       if: branch = auto
     - env: IMAGE=x86_64-gnu-aux
+      name: x86_64-gnu-aux
       if: branch = auto
     - env: IMAGE=x86_64-gnu-tools
+      name: x86_64-gnu-tools
       if: branch = auto OR (type = pull_request AND commit_message =~ /(?i:^update.*\b(rls|rustfmt|clippy|miri|cargo)\b)/)
     - env: IMAGE=x86_64-gnu-debug
+      name: x86_64-gnu-debug
       if: branch = auto
     - env: IMAGE=x86_64-gnu-nopt
+      name: x86_64-gnu-nopt
       if: branch = auto
     - env: IMAGE=x86_64-gnu-distcheck
+      name: x86_64-gnu-distcheck
       if: branch = auto
     - env: IMAGE=mingw-check
+      name: mingw-check
       if: type = pull_request OR branch = auto
 
     - stage: publish toolstate

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,34 +10,34 @@ environment:
 
   matrix:
   # 32/64 bit MSVC tests
-  - MSYS_BITS: 64
+  - CI_JOB_NAME: x86_64-msvc
+    MSYS_BITS: 64
     RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-profiler
     SCRIPT: python x.py test
-    CI_JOB_NAME: x86_64-msvc
-  - MSYS_BITS: 32
+  - CI_JOB_NAME: i686-msvc-1
+    MSYS_BITS: 32
     RUST_CONFIGURE_ARGS: --build=i686-pc-windows-msvc
     SCRIPT: make appveyor-subset-1
-    CI_JOB_NAME: i686-msvc-1
-  - MSYS_BITS: 32
+  - CI_JOB_NAME: i686-msvc-2
+    MSYS_BITS: 32
     RUST_CONFIGURE_ARGS: --build=i686-pc-windows-msvc
     SCRIPT: make appveyor-subset-2
-    CI_JOB_NAME: i686-msvc-2
 
   # MSVC aux tests
-  - MSYS_BITS: 64
+  - CI_JOB_NAME: x86_64-msvc-aux
+    MSYS_BITS: 64
     RUST_CHECK_TARGET: check-aux EXCLUDE_CARGO=1
     RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc
-    CI_JOB_NAME: x86_64-msvc-aux
-  - MSYS_BITS: 64
+  - CI_JOB_NAME: x86_64-msvc-cargo
+    MSYS_BITS: 64
     SCRIPT: python x.py test src/tools/cargotest src/tools/cargo
     RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc
-    CI_JOB_NAME: x86_64-msvc-cargo
 
   # MSVC tools tests
-  - MSYS_BITS: 64
+  - CI_JOB_NAME: x86_64-msvc-tools
+    MSYS_BITS: 64
     SCRIPT: src/ci/docker/x86_64-gnu-tools/checktools.sh x.py /tmp/toolstates.json windows
     RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --save-toolstates=/tmp/toolstates.json --enable-test-miri
-    CI_JOB_NAME: x86_64-msvc-tools
 
   # 32/64-bit MinGW builds.
   #
@@ -52,30 +52,31 @@ environment:
   # bucket, but they cleraly didn't originate there! The downloads originally
   # came from the mingw-w64 SourceForge download site. Unfortunately
   # SourceForge is notoriously flaky, so we mirror it on our own infrastructure.
-  - MSYS_BITS: 32
+  - CI_JOB_NAME: i686-mingw-1
+    MSYS_BITS: 32
     RUST_CONFIGURE_ARGS: --build=i686-pc-windows-gnu
     SCRIPT: make appveyor-subset-1
     MINGW_URL: https://s3-us-west-1.amazonaws.com/rust-lang-ci2/rust-ci-mirror
     MINGW_ARCHIVE: i686-6.3.0-release-posix-dwarf-rt_v5-rev2.7z
     MINGW_DIR: mingw32
-    CI_JOB_NAME: i686-mingw-1
-  - MSYS_BITS: 32
+  - CI_JOB_NAME: i686-mingw-2
+    MSYS_BITS: 32
     RUST_CONFIGURE_ARGS: --build=i686-pc-windows-gnu
     SCRIPT: make appveyor-subset-2
     MINGW_URL: https://s3-us-west-1.amazonaws.com/rust-lang-ci2/rust-ci-mirror
     MINGW_ARCHIVE: i686-6.3.0-release-posix-dwarf-rt_v5-rev2.7z
     MINGW_DIR: mingw32
-    CI_JOB_NAME: i686-mingw-2
-  - MSYS_BITS: 64
+  - CI_JOB_NAME: x86_64-mingw
+    MSYS_BITS: 64
     SCRIPT: python x.py test
     RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-gnu
     MINGW_URL: https://s3-us-west-1.amazonaws.com/rust-lang-ci2/rust-ci-mirror
     MINGW_ARCHIVE: x86_64-6.3.0-release-posix-seh-rt_v5-rev2.7z
     MINGW_DIR: mingw64
-    CI_JOB_NAME: x86_64-mingw
 
   # 32/64 bit MSVC and GNU deployment
-  - RUST_CONFIGURE_ARGS: >
+  - CI_JOB_NAME: dist-x86_64-msvc
+    RUST_CONFIGURE_ARGS: >
       --build=x86_64-pc-windows-msvc
       --target=x86_64-pc-windows-msvc,aarch64-pc-windows-msvc
       --enable-full-tools
@@ -83,8 +84,8 @@ environment:
     SCRIPT: python x.py dist
     DIST_REQUIRE_ALL_TOOLS: 1
     DEPLOY: 1
-    CI_JOB_NAME: dist-x86_64-msvc
-  - RUST_CONFIGURE_ARGS: >
+  - CI_JOB_NAME: dist-i686-msvc
+    RUST_CONFIGURE_ARGS: >
       --build=i686-pc-windows-msvc
       --target=i586-pc-windows-msvc
       --enable-full-tools
@@ -92,8 +93,8 @@ environment:
     SCRIPT: python x.py dist
     DIST_REQUIRE_ALL_TOOLS: 1
     DEPLOY: 1
-    CI_JOB_NAME: dist-i686-msvc
-  - MSYS_BITS: 32
+  - CI_JOB_NAME: dist-i686-mingw
+    MSYS_BITS: 32
     RUST_CONFIGURE_ARGS: --build=i686-pc-windows-gnu --enable-full-tools
     SCRIPT: python x.py dist
     MINGW_URL: https://s3-us-west-1.amazonaws.com/rust-lang-ci2/rust-ci-mirror
@@ -101,8 +102,8 @@ environment:
     MINGW_DIR: mingw32
     DIST_REQUIRE_ALL_TOOLS: 1
     DEPLOY: 1
-    CI_JOB_NAME: dist-i686-mingw
-  - MSYS_BITS: 64
+  - CI_JOB_NAME: dist-x86_64-mingw
+    MSYS_BITS: 64
     SCRIPT: python x.py dist
     RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-gnu --enable-full-tools
     MINGW_URL: https://s3-us-west-1.amazonaws.com/rust-lang-ci2/rust-ci-mirror
@@ -110,14 +111,13 @@ environment:
     MINGW_DIR: mingw64
     DIST_REQUIRE_ALL_TOOLS: 1
     DEPLOY: 1
-    CI_JOB_NAME: dist-x86_64-mingw
 
   # "alternate" deployment, see .travis.yml for more info
-  - MSYS_BITS: 64
+  - CI_JOB_NAME: dist-x86_64-msvc-alt
+    MSYS_BITS: 64
     RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-extended --enable-profiler
     SCRIPT: python x.py dist
     DEPLOY_ALT: 1
-    CI_JOB_NAME: dist-x86_64-msvc-alt
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
This should make it easier to identify what each job is doing when looking at the Travis or Appveyor UI.

- Set `name` for each job in Travis.
- Move `CI_JOB_NAME` to the front in Appveyor so that it appears first in the UI.