### PR TITLE
Fix #54822 and associated faulty tests

### DIFF
--- a/src/librustc_typeck/check/compare_method.rs
+++ b/src/librustc_typeck/check/compare_method.rs
@@ -917,7 +917,7 @@ pub fn compare_const_impl<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     debug!("compare_const_impl(impl_trait_ref={:?})", impl_trait_ref);
 
     tcx.infer_ctxt().enter(|infcx| {
-        let param_env = ty::ParamEnv::empty();
+        let param_env = tcx.param_env(impl_c.def_id);
         let inh = Inherited::new(infcx, impl_c.def_id);
         let infcx = &inh.infcx;
 

--- a/src/test/ui/associated-const/associated-const-generic-obligations.rs
+++ b/src/test/ui/associated-const/associated-const-generic-obligations.rs
@@ -12,7 +12,7 @@ trait Bar: Foo {
 
 impl<T: Foo> Bar for T {
     const FROM: &'static str = "foo";
-    //~^ ERROR the trait bound `T: Foo` is not satisfied [E0277]
+    //~^ ERROR implemented const `FROM` has an incompatible type for trait [E0326]
 }
 
 fn main() {}

--- a/src/test/ui/associated-const/associated-const-generic-obligations.stderr
+++ b/src/test/ui/associated-const/associated-const-generic-obligations.stderr
@@ -1,11 +1,15 @@
-error[E0277]: the trait bound `T: Foo` is not satisfied
-  --> $DIR/associated-const-generic-obligations.rs:14:5
+error[E0326]: implemented const `FROM` has an incompatible type for trait
+  --> $DIR/associated-const-generic-obligations.rs:14:17
    |
+LL |     const FROM: Self::Out;
+   |                 --------- type in trait
+...
 LL |     const FROM: &'static str = "foo";
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `T`
+   |                 ^^^^^^^^^^^^ expected associated type, found reference
    |
-   = help: consider adding a `where T: Foo` bound
+   = note: expected type `<T as Foo>::Out`
+              found type `&'static str`
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0277`.
+For more information about this error, try `rustc --explain E0326`.

--- a/src/test/ui/associated-const/associated-const-trait-bound.rs
+++ b/src/test/ui/associated-const/associated-const-trait-bound.rs
@@ -1,0 +1,21 @@
+// compile-pass
+
+trait ConstDefault {
+    const DEFAULT: Self;
+}
+
+trait Foo: Sized {}
+
+trait FooExt: Foo {
+    type T: ConstDefault;
+}
+
+trait Bar<F: FooExt> {
+    const T: F::T;
+}
+
+impl<F: FooExt> Bar<F> for () {
+    const T: F::T = <F::T as ConstDefault>::DEFAULT;
+}
+
+fn main() {}

--- a/src/test/ui/nll/trait-associated-constant.rs
+++ b/src/test/ui/nll/trait-associated-constant.rs
@@ -26,7 +26,6 @@ struct FailStruct2 { }
 
 impl<'a: 'b, 'b> Anything<'a, 'b> for FailStruct2 {
     const AC: Option<&'a str> = None;
-    //~^ ERROR: mismatched types
 }
 
 fn main() {}

--- a/src/test/ui/nll/trait-associated-constant.rs
+++ b/src/test/ui/nll/trait-associated-constant.rs
@@ -9,22 +9,22 @@ trait Anything<'a: 'b, 'b> {
     const AC: Option<&'b str>;
 }
 
-struct OKStruct { }
+struct OKStruct1 { }
 
-impl<'a: 'b, 'b> Anything<'a, 'b> for OKStruct {
+impl<'a: 'b, 'b> Anything<'a, 'b> for OKStruct1 {
     const AC: Option<&'b str> = None;
 }
 
-struct FailStruct1 { }
+struct FailStruct { }
 
-impl<'a: 'b, 'b, 'c> Anything<'a, 'b> for FailStruct1 {
+impl<'a: 'b, 'b, 'c> Anything<'a, 'b> for FailStruct {
     const AC: Option<&'c str> = None;
     //~^ ERROR: mismatched types
 }
 
-struct FailStruct2 { }
+struct OKStruct2 { }
 
-impl<'a: 'b, 'b> Anything<'a, 'b> for FailStruct2 {
+impl<'a: 'b, 'b> Anything<'a, 'b> for OKStruct2 {
     const AC: Option<&'a str> = None;
 }
 

--- a/src/test/ui/nll/trait-associated-constant.stderr
+++ b/src/test/ui/nll/trait-associated-constant.stderr
@@ -9,12 +9,12 @@ LL |     const AC: Option<&'c str> = None;
 note: the lifetime 'c as defined on the impl at 20:18...
   --> $DIR/trait-associated-constant.rs:20:18
    |
-LL | impl<'a: 'b, 'b, 'c> Anything<'a, 'b> for FailStruct1 {
+LL | impl<'a: 'b, 'b, 'c> Anything<'a, 'b> for FailStruct {
    |                  ^^
 note: ...does not necessarily outlive the lifetime 'b as defined on the impl at 20:14
   --> $DIR/trait-associated-constant.rs:20:14
    |
-LL | impl<'a: 'b, 'b, 'c> Anything<'a, 'b> for FailStruct1 {
+LL | impl<'a: 'b, 'b, 'c> Anything<'a, 'b> for FailStruct {
    |              ^^
 
 error: aborting due to previous error

--- a/src/test/ui/nll/trait-associated-constant.stderr
+++ b/src/test/ui/nll/trait-associated-constant.stderr
@@ -17,25 +17,6 @@ note: ...does not necessarily outlive the lifetime 'b as defined on the impl at 
 LL | impl<'a: 'b, 'b, 'c> Anything<'a, 'b> for FailStruct1 {
    |              ^^
 
-error[E0308]: mismatched types
-  --> $DIR/trait-associated-constant.rs:28:5
-   |
-LL |     const AC: Option<&'a str> = None;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
-   |
-   = note: expected type `std::option::Option<&'b str>`
-              found type `std::option::Option<&'a str>`
-note: the lifetime 'a as defined on the impl at 27:6...
-  --> $DIR/trait-associated-constant.rs:27:6
-   |
-LL | impl<'a: 'b, 'b> Anything<'a, 'b> for FailStruct2 {
-   |      ^^
-note: ...does not necessarily outlive the lifetime 'b as defined on the impl at 27:14
-  --> $DIR/trait-associated-constant.rs:27:14
-   |
-LL | impl<'a: 'b, 'b> Anything<'a, 'b> for FailStruct2 {
-   |              ^^
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Type checking associated constants can require trait bounds, but an empty
parameter environment was provided to the trait solver.  Providing an
appropriate parameter environment seems to fix #54822 and also make one of the
cases in src/test/ui/nll/trait-associated-constant.rs that should compile
successfully do so.  It also (slightly) improves the error message in
src/test/ui/associated-const/associated-const-generic-obligations.rs