### PR TITLE
ignore higher-ranked object bound conditions created by WF

### DIFF
--- a/src/librustc/traits/fulfill.rs
+++ b/src/librustc/traits/fulfill.rs
@@ -275,6 +275,8 @@ impl<'a, 'b, 'gcx, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'b, 'gcx, 
                 self.selcx.infcx().resolve_type_vars_if_possible(&obligation.predicate);
         }
 
+        debug!("process_obligation: obligation = {:?}", obligation);
+
         match obligation.predicate {
             ty::Predicate::Trait(ref data) => {
                 let trait_obligation = obligation.with(data.clone());

--- a/src/librustc/ty/wf.rs
+++ b/src/librustc/ty/wf.rs
@@ -482,8 +482,7 @@ impl<'a, 'gcx, 'tcx> WfPredicates<'a, 'gcx, 'tcx> {
         //
         // Note: in fact we only permit builtin traits, not `Bar<'d>`, I
         // am looking forward to the future here.
-
-        if !data.has_escaping_bound_vars() {
+        if !data.has_escaping_bound_vars() && !region.has_escaping_bound_vars() {
             let implicit_bounds =
                 object_region_bounds(self.infcx.tcx, data);
 

--- a/src/test/ui/generator/issue-53548-1.rs
+++ b/src/test/ui/generator/issue-53548-1.rs
@@ -1,0 +1,20 @@
+// A variant of #53548 that does not actually require generators,
+// but which encountered the same ICE/error. See `issue-53548.rs`
+// for details.
+//
+// compile-pass
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+trait Trait: 'static {}
+
+struct Store<C> {
+    inner: Rc<RefCell<Option<C>>>,
+}
+
+fn main() {
+    let store = Store::<Box<for<'a> fn(&(dyn Trait + 'a))>> {
+        inner: Default::default(),
+    };
+}

--- a/src/test/ui/generator/issue-53548.rs
+++ b/src/test/ui/generator/issue-53548.rs
@@ -1,0 +1,39 @@
+// Regression test for #53548. The `Box<dyn Trait>` type below is
+// expanded to `Box<dyn Trait + 'static>`, but the generator "witness"
+// that results is `for<'r> { Box<dyn Trait + 'r> }`. The WF code was
+// encountering an ICE (when debug-assertions were enabled) and an
+// unexpected compilation error (without debug-asserions) when trying
+// to process this `'r` region bound. In particular, to be WF, the
+// region bound must meet the requirements of the trait, and hence we
+// got `for<'r> { 'r: 'static }`. This would ICE because the `Binder`
+// constructor we were using was assering that no higher-ranked
+// regions were involved (because the WF code is supposed to skip
+// those). The error (if debug-asserions were disabled) came because
+// we obviously cannot prove that `'r: 'static` for any region `'r`.
+// Pursuant with our "lazy WF" strategy for higher-ranked regions, the
+// fix is not to require that `for<'r> { 'r: 'static }` holds (this is
+// also analogous to what we would do for higher-ranked regions
+// appearing within the trait in other positions).
+//
+// compile-pass
+
+#![feature(generators)]
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+trait Trait: 'static {}
+
+struct Store<C> {
+    inner: Rc<RefCell<Option<C>>>,
+}
+
+fn main() {
+    Box::new(static move || {
+        let store = Store::<Box<dyn Trait>> {
+            inner: Default::default(),
+        };
+        yield ();
+    });
+}
+


### PR DESCRIPTION
In the `issue-53548` test added in this PR, the `Box<dyn Trait>` type is expanded to `Box<dyn Trait + 'static>`, but the generator "witness" that results is `for<'r> { Box<dyn Trait + 'r> }`. The WF code was encountering an ICE (when debug-assertions were enabled) and an unexpected compilation error (without debug-asserions) when trying to process this `'r` region bound. In particular, to be WF, the region bound must meet the requirements of the trait, and hence we got `for<'r> { 'r: 'static }`. This would ICE because the `Binder` constructor we were using was assering that no higher-ranked regions were involved (because the WF code is supposed to skip those). The error (if debug-asserions were disabled) came because we obviously cannot prove that `'r: 'static` for any region `'r`.  Pursuant with
our "lazy WF" strategy for higher-ranked regions, the fix is not to require that `for<'r> { 'r: 'static }` holds (this is also analogous to what we would do for higher-ranked regions appearing within the trait in other positions).

Fixes #53548

r? @pnkfelix 