### PR TITLE
[wg-async-await] Drop `async fn` arguments in async block

### DIFF
--- a/src/librustc/hir/intravisit.rs
+++ b/src/librustc/hir/intravisit.rs
@@ -254,6 +254,9 @@ pub trait Visitor<'v> : Sized {
     fn visit_pat(&mut self, p: &'v Pat) {
         walk_pat(self, p)
     }
+    fn visit_argument_source(&mut self, s: &'v ArgSource) {
+        walk_argument_source(self, s)
+    }
     fn visit_anon_const(&mut self, c: &'v AnonConst) {
         walk_anon_const(self, c)
     }
@@ -391,8 +394,15 @@ pub fn walk_body<'v, V: Visitor<'v>>(visitor: &mut V, body: &'v Body) {
     for argument in &body.arguments {
         visitor.visit_id(argument.hir_id);
         visitor.visit_pat(&argument.pat);
+        visitor.visit_argument_source(&argument.source);
     }
     visitor.visit_expr(&body.value);
+}
+
+pub fn walk_argument_source<'v, V: Visitor<'v>>(visitor: &mut V, source: &'v ArgSource) {
+    if let ArgSource::AsyncFn(pat) = source {
+        visitor.visit_pat(pat);
+    }
 }
 
 pub fn walk_local<'v, V: Visitor<'v>>(visitor: &mut V, local: &'v Local) {

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -2048,6 +2048,14 @@ impl<'a> LoweringContext<'a> {
         hir::Arg {
             hir_id,
             pat: self.lower_pat(&arg.pat),
+            source: self.lower_arg_source(&arg.source),
+        }
+    }
+
+    fn lower_arg_source(&mut self, source: &ArgSource) -> hir::ArgSource {
+        match source {
+            ArgSource::Normal => hir::ArgSource::Normal,
+            ArgSource::AsyncFn(pat) => hir::ArgSource::AsyncFn(self.lower_pat(pat)),
         }
     }
 

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -3413,15 +3413,33 @@ impl<'a> LoweringContext<'a> {
                 )
             }
             ImplItemKind::Method(ref sig, ref body) => {
-                let body_id = self.lower_async_body(&sig.decl, &sig.header.asyncness.node, body);
-                let impl_trait_return_allow = !self.is_in_trait_impl;
-                let (generics, sig) = self.lower_method_sig(
-                    &i.generics,
-                    sig,
-                    impl_item_def_id,
-                    impl_trait_return_allow,
-                    sig.header.asyncness.node.opt_return_id(),
-                );
+                let mut lower_method = |sig: &MethodSig| {
+                    let body_id = self.lower_async_body(
+                        &sig.decl, &sig.header.asyncness.node, body
+                    );
+                    let impl_trait_return_allow = !self.is_in_trait_impl;
+                    let (generics, sig) = self.lower_method_sig(
+                        &i.generics,
+                        sig,
+                        impl_item_def_id,
+                        impl_trait_return_allow,
+                        sig.header.asyncness.node.opt_return_id(),
+                    );
+                    (body_id, generics, sig)
+                };
+
+                let (body_id, generics, sig) = if let IsAsync::Async {
+                    ref arguments, ..
+                } = sig.header.asyncness.node {
+                    let mut sig = sig.clone();
+                    // Replace the arguments of this async function with the generated
+                    // arguments that will be moved into the closure.
+                    sig.decl.inputs = arguments.clone().drain(..).map(|a| a.arg).collect();
+                    lower_method(&sig)
+                } else {
+                    lower_method(sig)
+                };
+
                 (generics, hir::ImplItemKind::Method(sig, body_id))
             }
             ImplItemKind::Type(ref ty) => (

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -2025,8 +2025,15 @@ impl<'a> LoweringContext<'a> {
             init: l.init.as_ref().map(|e| P(self.lower_expr(e))),
             span: l.span,
             attrs: l.attrs.clone(),
-            source: hir::LocalSource::Normal,
+            source: self.lower_local_source(l.source),
         }, ids)
+    }
+
+    fn lower_local_source(&mut self, ls: LocalSource) -> hir::LocalSource {
+        match ls {
+            LocalSource::Normal => hir::LocalSource::Normal,
+            LocalSource::AsyncFn => hir::LocalSource::AsyncFn,
+        }
     }
 
     fn lower_mutability(&mut self, m: Mutability) -> hir::Mutability {

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -2816,13 +2816,13 @@ impl<'a> LoweringContext<'a> {
     fn lower_async_body(
         &mut self,
         decl: &FnDecl,
-        asyncness: IsAsync,
+        asyncness: &IsAsync,
         body: &Block,
     ) -> hir::BodyId {
         self.lower_body(Some(decl), |this| {
             if let IsAsync::Async { closure_id, .. } = asyncness {
                 let async_expr = this.make_async_expr(
-                    CaptureBy::Value, closure_id, None,
+                    CaptureBy::Value, *closure_id, None,
                     |this| {
                         let body = this.lower_block(body, false);
                         this.expr_block(body, ThinVec::new())
@@ -2883,14 +2883,14 @@ impl<'a> LoweringContext<'a> {
                     value
                 )
             }
-            ItemKind::Fn(ref decl, header, ref generics, ref body) => {
+            ItemKind::Fn(ref decl, ref header, ref generics, ref body) => {
                 let fn_def_id = self.resolver.definitions().local_def_id(id);
                 self.with_new_scopes(|this| {
                     // Note: we don't need to change the return type from `T` to
                     // `impl Future<Output = T>` here because lower_body
                     // only cares about the input argument patterns in the function
                     // declaration (decl), not the return types.
-                    let body_id = this.lower_async_body(decl, header.asyncness.node, body);
+                    let body_id = this.lower_async_body(decl, &header.asyncness.node, body);
 
                     let (generics, fn_decl) = this.add_in_band_defs(
                         generics,
@@ -3391,7 +3391,7 @@ impl<'a> LoweringContext<'a> {
                 )
             }
             ImplItemKind::Method(ref sig, ref body) => {
-                let body_id = self.lower_async_body(&sig.decl, sig.header.asyncness.node, body);
+                let body_id = self.lower_async_body(&sig.decl, &sig.header.asyncness.node, body);
                 let impl_trait_return_allow = !self.is_in_trait_impl;
                 let (generics, sig) = self.lower_method_sig(
                     &i.generics,
@@ -3589,7 +3589,7 @@ impl<'a> LoweringContext<'a> {
         impl_trait_return_allow: bool,
         is_async: Option<NodeId>,
     ) -> (hir::Generics, hir::MethodSig) {
-        let header = self.lower_fn_header(sig.header);
+        let header = self.lower_fn_header(&sig.header);
         let (generics, decl) = self.add_in_band_defs(
             generics,
             fn_def_id,
@@ -3611,10 +3611,10 @@ impl<'a> LoweringContext<'a> {
         }
     }
 
-    fn lower_fn_header(&mut self, h: FnHeader) -> hir::FnHeader {
+    fn lower_fn_header(&mut self, h: &FnHeader) -> hir::FnHeader {
         hir::FnHeader {
             unsafety: self.lower_unsafety(h.unsafety),
-            asyncness: self.lower_asyncness(h.asyncness.node),
+            asyncness: self.lower_asyncness(&h.asyncness.node),
             constness: self.lower_constness(h.constness),
             abi: h.abi,
         }
@@ -3634,7 +3634,7 @@ impl<'a> LoweringContext<'a> {
         }
     }
 
-    fn lower_asyncness(&mut self, a: IsAsync) -> hir::IsAsync {
+    fn lower_asyncness(&mut self, a: &IsAsync) -> hir::IsAsync {
         match a {
             IsAsync::Async { .. } => hir::IsAsync::Async,
             IsAsync::NotAsync => hir::IsAsync::NotAsync,
@@ -3947,7 +3947,7 @@ impl<'a> LoweringContext<'a> {
                 })
             }
             ExprKind::Closure(
-                capture_clause, asyncness, movability, ref decl, ref body, fn_decl_span
+                capture_clause, ref asyncness, movability, ref decl, ref body, fn_decl_span
             ) => {
                 if let IsAsync::Async { closure_id, .. } = asyncness {
                     let outer_decl = FnDecl {
@@ -3985,7 +3985,7 @@ impl<'a> LoweringContext<'a> {
                                 Some(&**ty)
                             } else { None };
                             let async_body = this.make_async_expr(
-                                capture_clause, closure_id, async_ret_ty,
+                                capture_clause, *closure_id, async_ret_ty,
                                 |this| {
                                     this.with_new_scopes(|this| this.lower_expr(body))
                                 });

--- a/src/librustc/hir/map/def_collector.rs
+++ b/src/librustc/hir/map/def_collector.rs
@@ -68,7 +68,7 @@ impl<'a> DefCollector<'a> {
         id: NodeId,
         name: Name,
         span: Span,
-        header: &FnHeader,
+        header: &'a FnHeader,
         generics: &'a Generics,
         decl: &'a FnDecl,
         body: &'a Block,
@@ -86,12 +86,12 @@ impl<'a> DefCollector<'a> {
         let fn_def_data = DefPathData::ValueNs(name.as_interned_str());
         let fn_def = self.create_def(id, fn_def_data, ITEM_LIKE_SPACE, span);
         return self.with_parent(fn_def, |this| {
-            this.create_def(return_impl_trait_id, DefPathData::ImplTrait, REGULAR_SPACE, span);
+            this.create_def(*return_impl_trait_id, DefPathData::ImplTrait, REGULAR_SPACE, span);
 
             visit::walk_generics(this, generics);
             visit::walk_fn_decl(this, decl);
 
-            let closure_def = this.create_def(closure_id,
+            let closure_def = this.create_def(*closure_id,
                                               DefPathData::ClosureExpr,
                                               REGULAR_SPACE,
                                               span);
@@ -288,7 +288,7 @@ impl<'a> visit::Visitor<'a> for DefCollector<'a> {
 
         match expr.node {
             ExprKind::Mac(..) => return self.visit_macro_invoc(expr.id),
-            ExprKind::Closure(_, asyncness, ..) => {
+            ExprKind::Closure(_, ref asyncness, ..) => {
                 let closure_def = self.create_def(expr.id,
                                           DefPathData::ClosureExpr,
                                           REGULAR_SPACE,
@@ -298,7 +298,7 @@ impl<'a> visit::Visitor<'a> for DefCollector<'a> {
                 // Async closures desugar to closures inside of closures, so
                 // we must create two defs.
                 if let IsAsync::Async { closure_id, .. } = asyncness {
-                    let async_def = self.create_def(closure_id,
+                    let async_def = self.create_def(*closure_id,
                                                     DefPathData::ClosureExpr,
                                                     REGULAR_SPACE,
                                                     expr.span);

--- a/src/librustc/hir/map/def_collector.rs
+++ b/src/librustc/hir/map/def_collector.rs
@@ -73,11 +73,12 @@ impl<'a> DefCollector<'a> {
         decl: &'a FnDecl,
         body: &'a Block,
     ) {
-        let (closure_id, return_impl_trait_id) = match header.asyncness.node {
+        let (closure_id, return_impl_trait_id, arguments) = match &header.asyncness.node {
             IsAsync::Async {
                 closure_id,
                 return_impl_trait_id,
-            } => (closure_id, return_impl_trait_id),
+                arguments,
+            } => (closure_id, return_impl_trait_id, arguments),
             _ => unreachable!(),
         };
 
@@ -89,14 +90,28 @@ impl<'a> DefCollector<'a> {
             this.create_def(*return_impl_trait_id, DefPathData::ImplTrait, REGULAR_SPACE, span);
 
             visit::walk_generics(this, generics);
-            visit::walk_fn_decl(this, decl);
 
-            let closure_def = this.create_def(*closure_id,
-                                              DefPathData::ClosureExpr,
-                                              REGULAR_SPACE,
-                                              span);
+            // Walk the generated arguments for the `async fn`.
+            for a in arguments {
+                use visit::Visitor;
+                this.visit_ty(&a.arg.ty);
+            }
+
+            // We do not invoke `walk_fn_decl` as this will walk the arguments that are being
+            // replaced.
+            visit::walk_fn_ret_ty(this, &decl.output);
+
+            let closure_def = this.create_def(
+                *closure_id, DefPathData::ClosureExpr, REGULAR_SPACE, span,
+            );
             this.with_parent(closure_def, |this| {
-                visit::walk_block(this, body);
+                for a in arguments {
+                    use visit::Visitor;
+                    // Walk each of the generated statements before the regular block body.
+                    this.visit_stmt(&a.stmt);
+                }
+
+                visit::walk_block(this, &body);
             })
         })
     }

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -1583,6 +1583,17 @@ pub enum LocalSource {
     Normal,
     /// A desugared `for _ in _ { .. }` loop.
     ForLoopDesugar,
+    /// When lowering async functions, we create locals within the `async move` so that
+    /// all arguments are dropped after the future is polled.
+    ///
+    /// ```ignore (pseudo-Rust)
+    /// async fn foo(<pattern> @ x: Type) {
+    ///     async move {
+    ///         let <pattern> = x;
+    ///     }
+    /// }
+    /// ```
+    AsyncFn,
 }
 
 /// Hints at the original code for a `match _ { .. }`.

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -1882,6 +1882,26 @@ pub struct InlineAsm {
 pub struct Arg {
     pub pat: P<Pat>,
     pub hir_id: HirId,
+    pub source: ArgSource,
+}
+
+impl Arg {
+    /// Returns the pattern representing the original binding for this argument.
+    pub fn original_pat(&self) -> &P<Pat> {
+        match &self.source {
+            ArgSource::Normal => &self.pat,
+            ArgSource::AsyncFn(pat) => &pat,
+        }
+    }
+}
+
+/// Represents the source of an argument in a function header.
+#[derive(Clone, RustcEncodable, RustcDecodable, Debug, HashStable)]
+pub enum ArgSource {
+    /// Argument as specified by the user.
+    Normal,
+    /// Generated argument from `async fn` lowering, contains the original binding pattern.
+    AsyncFn(P<Pat>),
 }
 
 /// Represents the header (not the body) of a function declaration.

--- a/src/librustc/ich/impls_hir.rs
+++ b/src/librustc/ich/impls_hir.rs
@@ -435,4 +435,3 @@ impl<'hir> HashStable<StableHashingContext<'hir>> for attr::OptimizeAttr {
         mem::discriminant(self).hash_stable(hcx, hasher);
     }
 }
-

--- a/src/librustc/infer/error_reporting/nice_region_error/different_lifetimes.rs
+++ b/src/librustc/infer/error_reporting/nice_region_error/different_lifetimes.rs
@@ -86,18 +86,15 @@ impl<'a, 'gcx, 'tcx> NiceRegionError<'a, 'gcx, 'tcx> {
         let sub_is_ret_type =
             self.is_return_type_anon(scope_def_id_sub, bregion_sub, ty_fndecl_sub);
 
-        let span_label_var1 = if let Some(simple_ident) = anon_arg_sup.pat.simple_ident() {
-            format!(" from `{}`", simple_ident)
-        } else {
-            String::new()
+        let span_label_var1 = match anon_arg_sup.original_pat().simple_ident() {
+            Some(simple_ident) => format!(" from `{}`", simple_ident),
+            None => String::new(),
         };
 
-        let span_label_var2 = if let Some(simple_ident) = anon_arg_sub.pat.simple_ident() {
-            format!(" into `{}`", simple_ident)
-        } else {
-            String::new()
+        let span_label_var2 = match anon_arg_sub.original_pat().simple_ident() {
+            Some(simple_ident) => format!(" into `{}`", simple_ident),
+            None => String::new(),
         };
-
 
         let (span_1, span_2, main_label, span_label) = match (sup_is_ret_type, sub_is_ret_type) {
             (None, None) => {

--- a/src/librustc/infer/error_reporting/nice_region_error/named_anon_conflict.rs
+++ b/src/librustc/infer/error_reporting/nice_region_error/named_anon_conflict.rs
@@ -86,13 +86,12 @@ impl<'a, 'gcx, 'tcx> NiceRegionError<'a, 'gcx, 'tcx> {
             }
         }
 
-        let (error_var, span_label_var) = if let Some(simple_ident) = arg.pat.simple_ident() {
-            (
+        let (error_var, span_label_var) = match arg.original_pat().simple_ident() {
+            Some(simple_ident) => (
                 format!("the type of `{}`", simple_ident),
                 format!("the type of `{}`", simple_ident),
-            )
-        } else {
-            ("parameter type".to_owned(), "type".to_owned())
+            ),
+            None => ("parameter type".to_owned(), "type".to_owned()),
         };
 
         let mut diag = struct_span_err!(

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -2420,7 +2420,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
 
             let help_name = if let Some(body) = parent {
                 let arg = &self.tcx.hir().body(body).arguments[index];
-                format!("`{}`", self.tcx.hir().hir_to_pretty_string(arg.pat.hir_id))
+                format!("`{}`", self.tcx.hir().hir_to_pretty_string(arg.original_pat().hir_id))
             } else {
                 format!("argument {}", index + 1)
             };

--- a/src/librustc_mir/hair/pattern/check_match.rs
+++ b/src/librustc_mir/hair/pattern/check_match.rs
@@ -76,6 +76,7 @@ impl<'a, 'tcx> Visitor<'tcx> for MatchVisitor<'a, 'tcx> {
         self.check_irrefutable(&loc.pat, match loc.source {
             hir::LocalSource::Normal => "local binding",
             hir::LocalSource::ForLoopDesugar => "`for` loop binding",
+            hir::LocalSource::AsyncFn => "async fn binding",
         });
 
         // Check legality of move bindings and `@` patterns.

--- a/src/librustc_passes/ast_validation.rs
+++ b/src/librustc_passes/ast_validation.rs
@@ -230,7 +230,7 @@ impl<'a> AstValidator<'a> {
         }
     }
 
-    fn check_trait_fn_not_async(&self, span: Span, asyncness: IsAsync) {
+    fn check_trait_fn_not_async(&self, span: Span, asyncness: &IsAsync) {
         if asyncness.is_async() {
             struct_span_err!(self.session, span, E0706,
                              "trait fns cannot be declared `async`").emit()
@@ -560,7 +560,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                     self.invalid_visibility(&impl_item.vis, None);
                     if let ImplItemKind::Method(ref sig, _) = impl_item.node {
                         self.check_trait_fn_not_const(sig.header.constness);
-                        self.check_trait_fn_not_async(impl_item.span, sig.header.asyncness.node);
+                        self.check_trait_fn_not_async(impl_item.span, &sig.header.asyncness.node);
                     }
                 }
             }
@@ -633,7 +633,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                 self.no_questions_in_bounds(bounds, "supertraits", true);
                 for trait_item in trait_items {
                     if let TraitItemKind::Method(ref sig, ref block) = trait_item.node {
-                        self.check_trait_fn_not_async(trait_item.span, sig.header.asyncness.node);
+                        self.check_trait_fn_not_async(trait_item.span, &sig.header.asyncness.node);
                         self.check_trait_fn_not_const(sig.header.constness);
                         if block.is_none() {
                             self.check_decl_no_pat(&sig.decl, |span, mut_ident| {

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -831,11 +831,20 @@ impl<'a, 'tcx> Visitor<'tcx> for Resolver<'a> {
 
         // Add each argument to the rib.
         let mut bindings_list = FxHashMap::default();
-        for argument in &declaration.inputs {
+        let mut add_argument = |argument: &ast::Arg| {
             self.resolve_pattern(&argument.pat, PatternSource::FnParam, &mut bindings_list);
             self.visit_ty(&argument.ty);
             debug!("(resolving function) recorded argument");
+        };
+
+        // Walk the generated async arguments if this is an `async fn`, otherwise walk the
+        // normal arguments.
+        if let IsAsync::Async { ref arguments, .. } = asyncness {
+            for a in arguments { add_argument(&a.arg); }
+        } else {
+            for a in &declaration.inputs { add_argument(a); }
         }
+
         visit::walk_fn_ret_ty(self, &declaration.output);
 
         // Resolve the function body, potentially inside the body of an async closure
@@ -846,9 +855,18 @@ impl<'a, 'tcx> Visitor<'tcx> for Resolver<'a> {
         }
 
         match function_kind {
-            FnKind::ItemFn(.., body) |
-            FnKind::Method(.., body) => {
-                self.visit_block(body);
+            FnKind::ItemFn(.., body) | FnKind::Method(.., body) => {
+                if let IsAsync::Async { ref arguments, .. } = asyncness {
+                    let mut body = body.clone();
+                    // Insert the generated statements into the body before attempting to
+                    // resolve names.
+                    for a in arguments {
+                        body.stmts.insert(0, a.stmt.clone());
+                    }
+                    self.visit_block(&body);
+                } else {
+                    self.visit_block(body);
+                }
             }
             FnKind::Closure(body) => {
                 self.visit_expr(body);

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -814,13 +814,13 @@ impl<'a, 'tcx> Visitor<'tcx> for Resolver<'a> {
         debug!("(resolving function) entering function");
         let (rib_kind, asyncness) = match function_kind {
             FnKind::ItemFn(_, ref header, ..) =>
-                (FnItemRibKind, header.asyncness.node),
+                (FnItemRibKind, &header.asyncness.node),
             FnKind::Method(_, ref sig, _, _) =>
-                (TraitOrImplItemRibKind, sig.header.asyncness.node),
+                (TraitOrImplItemRibKind, &sig.header.asyncness.node),
             FnKind::Closure(_) =>
                 // Async closures aren't resolved through `visit_fn`-- they're
                 // processed separately
-                (ClosureRibKind(node_id), IsAsync::NotAsync),
+                (ClosureRibKind(node_id), &IsAsync::NotAsync),
         };
 
         // Create a value rib for the function.
@@ -833,16 +833,14 @@ impl<'a, 'tcx> Visitor<'tcx> for Resolver<'a> {
         let mut bindings_list = FxHashMap::default();
         for argument in &declaration.inputs {
             self.resolve_pattern(&argument.pat, PatternSource::FnParam, &mut bindings_list);
-
             self.visit_ty(&argument.ty);
-
             debug!("(resolving function) recorded argument");
         }
         visit::walk_fn_ret_ty(self, &declaration.output);
 
         // Resolve the function body, potentially inside the body of an async closure
         if let IsAsync::Async { closure_id, .. } = asyncness {
-            let rib_kind = ClosureRibKind(closure_id);
+            let rib_kind = ClosureRibKind(*closure_id);
             self.ribs[ValueNS].push(Rib::new(rib_kind));
             self.label_ribs.push(Rib::new(rib_kind));
         }

--- a/src/librustc_save_analysis/sig.rs
+++ b/src/librustc_save_analysis/sig.rs
@@ -374,7 +374,7 @@ impl Sig for ast::Item {
 
                 Ok(extend_sig(ty, text, defs, vec![]))
             }
-            ast::ItemKind::Fn(ref decl, header, ref generics, _) => {
+            ast::ItemKind::Fn(ref decl, ref header, ref generics, _) => {
                 let mut text = String::new();
                 if header.constness.node == ast::Constness::Const {
                     text.push_str("const ");

--- a/src/librustc_typeck/check/writeback.rs
+++ b/src/librustc_typeck/check/writeback.rs
@@ -297,6 +297,12 @@ impl<'cx, 'gcx, 'tcx> Visitor<'gcx> for WritebackCx<'cx, 'gcx, 'tcx> {
         let ty = self.resolve(&ty, &hir_ty.span);
         self.write_ty_to_tables(hir_ty.hir_id, ty);
     }
+
+    fn visit_argument_source(&mut self, _: &'gcx hir::ArgSource) {
+        // Don't visit the argument source, in `async fn`s it can contain a pattern which has a
+        // `NodeId` w/out a type, as it is only used for getting the name of the original pattern
+        // for diagnostics where only an `hir::Arg` is present.
+    }
 }
 
 impl<'cx, 'gcx, 'tcx> WritebackCx<'cx, 'gcx, 'tcx> {

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1837,18 +1837,35 @@ pub enum Unsafety {
     Normal,
 }
 
-#[derive(Copy, Clone, RustcEncodable, RustcDecodable, Debug)]
+#[derive(Clone, RustcEncodable, RustcDecodable, Debug)]
+pub struct AsyncArgument {
+    /// `__arg0`
+    pub ident: Ident,
+    /// `__arg0: <ty>` argument to replace existing function argument `<pat>: <ty>`.
+    pub arg: Arg,
+    /// `let <pat>: <ty> = __arg0;` statement to be inserted at the start of the block.
+    pub stmt: Stmt,
+}
+
+#[derive(Clone, RustcEncodable, RustcDecodable, Debug)]
 pub enum IsAsync {
     Async {
         closure_id: NodeId,
         return_impl_trait_id: NodeId,
+        /// This field stores the arguments and statements that are used in HIR lowering to
+        /// ensure that `async fn` arguments are dropped at the correct time.
+        ///
+        /// The argument and statements here are generated at parse time as they are required in
+        /// both the hir lowering, def collection and name resolution and this stops them needing
+        /// to be created in each place.
+        arguments: Vec<AsyncArgument>,
     },
     NotAsync,
 }
 
 impl IsAsync {
-    pub fn is_async(self) -> bool {
-        if let IsAsync::Async { .. } = self {
+    pub fn is_async(&self) -> bool {
+        if let IsAsync::Async { .. } = *self {
             true
         } else {
             false
@@ -1856,12 +1873,12 @@ impl IsAsync {
     }
 
     /// In ths case this is an `async` return, the `NodeId` for the generated `impl Trait` item.
-    pub fn opt_return_id(self) -> Option<NodeId> {
+    pub fn opt_return_id(&self) -> Option<NodeId> {
         match self {
             IsAsync::Async {
                 return_impl_trait_id,
                 ..
-            } => Some(return_impl_trait_id),
+            } => Some(*return_impl_trait_id),
             IsAsync::NotAsync => None,
         }
     }
@@ -2223,7 +2240,7 @@ impl Item {
 ///
 /// All the information between the visibility and the name of the function is
 /// included in this struct (e.g., `async unsafe fn` or `const extern "C" fn`).
-#[derive(Clone, Copy, RustcEncodable, RustcDecodable, Debug)]
+#[derive(Clone, RustcEncodable, RustcDecodable, Debug)]
 pub struct FnHeader {
     pub unsafety: Unsafety,
     pub asyncness: Spanned<IsAsync>,

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -876,6 +876,17 @@ pub struct Local {
     pub id: NodeId,
     pub span: Span,
     pub attrs: ThinVec<Attribute>,
+    /// Origin of this local variable.
+    pub source: LocalSource,
+}
+
+#[derive(Clone, Copy, RustcEncodable, RustcDecodable, Debug)]
+pub enum LocalSource {
+    /// Local was parsed from source.
+    Normal,
+    /// Within `ast::IsAsync::Async`, a local is generated that will contain the moved arguments
+    /// of an `async fn`.
+    AsyncFn,
 }
 
 /// An arm of a 'match'.

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1724,6 +1724,16 @@ pub struct Arg {
     pub ty: P<Ty>,
     pub pat: P<Pat>,
     pub id: NodeId,
+    pub source: ArgSource,
+}
+
+/// The source of an argument in a function header.
+#[derive(Clone, RustcEncodable, RustcDecodable, Debug)]
+pub enum ArgSource {
+    /// Argument as written by the user.
+    Normal,
+    /// Argument from `async fn` lowering, contains the original binding pattern.
+    AsyncFn(P<Pat>),
 }
 
 /// Alternative representation for `Arg`s describing `self` parameter of methods.
@@ -1783,6 +1793,7 @@ impl Arg {
             }),
             ty,
             id: DUMMY_NODE_ID,
+            source: ArgSource::Normal,
         };
         match eself.node {
             SelfKind::Explicit(ty, mutbl) => arg(mutbl, ty),

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -979,7 +979,8 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         ast::Arg {
             ty,
             pat: arg_pat,
-            id: ast::DUMMY_NODE_ID
+            id: ast::DUMMY_NODE_ID,
+            source: ast::ArgSource::Normal,
         }
     }
 

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -526,6 +526,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
             id: ast::DUMMY_NODE_ID,
             span: sp,
             attrs: ThinVec::new(),
+            source: ast::LocalSource::Normal,
         });
         ast::Stmt {
             id: ast::DUMMY_NODE_ID,
@@ -554,6 +555,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
             id: ast::DUMMY_NODE_ID,
             span: sp,
             attrs: ThinVec::new(),
+            source: ast::LocalSource::Normal,
         });
         ast::Stmt {
             id: ast::DUMMY_NODE_ID,
@@ -571,6 +573,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
             id: ast::DUMMY_NODE_ID,
             span,
             attrs: ThinVec::new(),
+            source: ast::LocalSource::Normal,
         });
         ast::Stmt {
             id: ast::DUMMY_NODE_ID,

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -1898,7 +1898,7 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                 span: Span,
                 _node_id: NodeId) {
         match fn_kind {
-            FnKind::ItemFn(_, header, _, _) => {
+            FnKind::ItemFn(_, ref header, _, _) => {
                 // Check for const fn and async fn declarations.
                 if header.asyncness.node.is_async() {
                     gate_feature_post!(&self, async_await, span, "async fn is unstable");

--- a/src/libsyntax/mut_visit.rs
+++ b/src/libsyntax/mut_visit.rs
@@ -678,9 +678,17 @@ pub fn noop_visit_interpolated<T: MutVisitor>(nt: &mut token::Nonterminal, vis: 
 
 pub fn noop_visit_asyncness<T: MutVisitor>(asyncness: &mut IsAsync, vis: &mut T) {
     match asyncness {
-        IsAsync::Async { closure_id, return_impl_trait_id } => {
+        IsAsync::Async { closure_id, return_impl_trait_id, ref mut arguments } => {
             vis.visit_id(closure_id);
             vis.visit_id(return_impl_trait_id);
+            for AsyncArgument { ident, arg, stmt } in arguments.iter_mut() {
+                vis.visit_ident(ident);
+                vis.visit_arg(arg);
+                visit_clobber(stmt, |stmt| {
+                    vis.flat_map_stmt(stmt)
+                        .expect_one("expected visitor to produce exactly one item")
+                });
+            }
         }
         IsAsync::NotAsync => {}
     }

--- a/src/libsyntax/mut_visit.rs
+++ b/src/libsyntax/mut_visit.rs
@@ -235,6 +235,10 @@ pub trait MutVisitor: Sized {
         noop_visit_arg(a, self);
     }
 
+    fn visit_arg_source(&mut self, a: &mut ArgSource) {
+        noop_visit_arg_source(a, self);
+    }
+
     fn visit_generics(&mut self, generics: &mut Generics) {
         noop_visit_generics(generics, self);
     }
@@ -563,10 +567,18 @@ pub fn noop_visit_meta_item<T: MutVisitor>(mi: &mut MetaItem, vis: &mut T) {
     vis.visit_span(span);
 }
 
-pub fn noop_visit_arg<T: MutVisitor>(Arg { id, pat, ty }: &mut Arg, vis: &mut T) {
+pub fn noop_visit_arg<T: MutVisitor>(Arg { id, pat, ty, source }: &mut Arg, vis: &mut T) {
     vis.visit_id(id);
     vis.visit_pat(pat);
     vis.visit_ty(ty);
+    vis.visit_arg_source(source);
+}
+
+pub fn noop_visit_arg_source<T: MutVisitor>(source: &mut ArgSource, vis: &mut T) {
+    match source {
+        ArgSource::Normal => {},
+        ArgSource::AsyncFn(pat) => vis.visit_pat(pat),
+    }
 }
 
 pub fn noop_visit_tt<T: MutVisitor>(tt: &mut TokenTree, vis: &mut T) {

--- a/src/libsyntax/mut_visit.rs
+++ b/src/libsyntax/mut_visit.rs
@@ -208,6 +208,10 @@ pub trait MutVisitor: Sized {
         noop_visit_local(l, self);
     }
 
+    fn visit_local_source(&mut self, l: &mut LocalSource) {
+        noop_visit_local_source(l, self);
+    }
+
     fn visit_mac(&mut self, _mac: &mut Mac) {
         panic!("visit_mac disabled by default");
         // N.B., see note about macros above. If you really want a visitor that
@@ -510,13 +514,17 @@ pub fn noop_visit_parenthesized_parameter_data<T: MutVisitor>(args: &mut Parenth
 }
 
 pub fn noop_visit_local<T: MutVisitor>(local: &mut P<Local>, vis: &mut T) {
-    let Local { id, pat, ty, init, span, attrs } = local.deref_mut();
+    let Local { id, pat, ty, init, span, attrs, source } = local.deref_mut();
     vis.visit_id(id);
     vis.visit_pat(pat);
     visit_opt(ty, |ty| vis.visit_ty(ty));
     visit_opt(init, |init| vis.visit_expr(init));
     vis.visit_span(span);
     visit_thin_attrs(attrs, vis);
+    vis.visit_local_source(source);
+}
+
+pub fn noop_visit_local_source<T: MutVisitor>(_local_source: &mut LocalSource, _vis: &mut T) {
 }
 
 pub fn noop_visit_attribute<T: MutVisitor>(attr: &mut Attribute, vis: &mut T) {

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1,7 +1,7 @@
 use crate::ast::{AngleBracketedArgs, AsyncArgument, ParenthesizedArgs, AttrStyle, BareFnTy};
 use crate::ast::{GenericBound, TraitBoundModifier};
 use crate::ast::Unsafety;
-use crate::ast::{Mod, AnonConst, Arg, Arm, Guard, Attribute, BindingMode, TraitItemKind};
+use crate::ast::{Mod, AnonConst, Arg, ArgSource, Arm, Guard, Attribute, BindingMode, TraitItemKind};
 use crate::ast::Block;
 use crate::ast::{BlockCheckMode, CaptureBy, Movability};
 use crate::ast::{Constness, Crate};
@@ -550,7 +550,7 @@ fn dummy_arg(span: Span) -> Arg {
         span,
         id: ast::DUMMY_NODE_ID
     };
-    Arg { ty: P(ty), pat: pat, id: ast::DUMMY_NODE_ID }
+    Arg { ty: P(ty), pat: pat, id: ast::DUMMY_NODE_ID, source: ast::ArgSource::Normal }
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -2101,7 +2101,7 @@ impl<'a> Parser<'a> {
             }
         };
 
-        Ok(Arg { ty, pat, id: ast::DUMMY_NODE_ID })
+        Ok(Arg { ty, pat, id: ast::DUMMY_NODE_ID, source: ast::ArgSource::Normal })
     }
 
     /// Parses a single function argument.
@@ -2124,7 +2124,8 @@ impl<'a> Parser<'a> {
         Ok(Arg {
             ty: t,
             pat,
-            id: ast::DUMMY_NODE_ID
+            id: ast::DUMMY_NODE_ID,
+            source: ast::ArgSource::Normal,
         })
     }
 
@@ -8689,6 +8690,7 @@ impl<'a> Parser<'a> {
                         ),
                         span,
                     }),
+                    source: ArgSource::AsyncFn(input.pat.clone()),
                 };
 
                 // Construct a `let <pat> = __argN;` statement to insert at the top of the

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -14,7 +14,7 @@ use crate::ast::{GenericParam, GenericParamKind};
 use crate::ast::GenericArg;
 use crate::ast::{Ident, ImplItem, IsAsync, IsAuto, Item, ItemKind};
 use crate::ast::{Label, Lifetime, Lit, LitKind};
-use crate::ast::Local;
+use crate::ast::{Local, LocalSource};
 use crate::ast::MacStmtStyle;
 use crate::ast::{Mac, Mac_, MacDelimiter};
 use crate::ast::{MutTy, Mutability};
@@ -4879,6 +4879,7 @@ impl<'a> Parser<'a> {
             id: ast::DUMMY_NODE_ID,
             span: lo.to(hi),
             attrs,
+            source: LocalSource::Normal,
         }))
     }
 

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -8691,15 +8691,16 @@ impl<'a> Parser<'a> {
                     }),
                 };
 
-                // Construct a `let <pat>: <ty> = __argN;` statement to insert at the top of the
+                // Construct a `let <pat> = __argN;` statement to insert at the top of the
                 // async closure.
                 let local = P(Local {
                     pat: input.pat.clone(),
-                    ty: Some(P(Ty {
-                        id,
-                        node: input.ty.node.clone(),
-                        span: input.ty.span,
-                    })),
+                    // We explicitly do not specify the type for this statement. When the user's
+                    // argument type is `impl Trait` then this would require the
+                    // `impl_trait_in_bindings` feature to also be present for that same type to
+                    // be valid in this binding. At the time of writing (13 Mar 19),
+                    // `impl_trait_in_bindings` is not stable.
+                    ty: None,
                     init: Some(P(Expr {
                         id,
                         node: ExprKind::Path(None, ast::Path {

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1,4 +1,4 @@
-use crate::ast::{AngleBracketedArgs, ParenthesizedArgs, AttrStyle, BareFnTy};
+use crate::ast::{AngleBracketedArgs, AsyncArgument, ParenthesizedArgs, AttrStyle, BareFnTy};
 use crate::ast::{GenericBound, TraitBoundModifier};
 use crate::ast::Unsafety;
 use crate::ast::{Mod, AnonConst, Arg, Arm, Guard, Attribute, BindingMode, TraitItemKind};
@@ -1492,6 +1492,7 @@ impl<'a> Parser<'a> {
             IsAsync::Async {
                 closure_id: ast::DUMMY_NODE_ID,
                 return_impl_trait_id: ast::DUMMY_NODE_ID,
+                arguments: Vec::new(),
             }
         } else {
             IsAsync::NotAsync
@@ -1550,7 +1551,7 @@ impl<'a> Parser<'a> {
             // trait item macro.
             (keywords::Invalid.ident(), ast::TraitItemKind::Macro(mac), ast::Generics::default())
         } else {
-            let (constness, unsafety, asyncness, abi) = self.parse_fn_front_matter()?;
+            let (constness, unsafety, mut asyncness, abi) = self.parse_fn_front_matter()?;
 
             let ident = self.parse_ident()?;
             let mut generics = self.parse_generics()?;
@@ -1564,6 +1565,7 @@ impl<'a> Parser<'a> {
                 p.parse_arg_general(p.span.rust_2018(), true, false)
             })?;
             generics.where_clause = self.parse_where_clause()?;
+            self.construct_async_arguments(&mut asyncness, &d);
 
             let sig = ast::MethodSig {
                 header: FnHeader {
@@ -6417,7 +6419,7 @@ impl<'a> Parser<'a> {
     /// Parses an item-position function declaration.
     fn parse_item_fn(&mut self,
                      unsafety: Unsafety,
-                     asyncness: Spanned<IsAsync>,
+                     mut asyncness: Spanned<IsAsync>,
                      constness: Spanned<Constness>,
                      abi: Abi)
                      -> PResult<'a, ItemInfo> {
@@ -6426,6 +6428,7 @@ impl<'a> Parser<'a> {
         let decl = self.parse_fn_decl(allow_c_variadic)?;
         generics.where_clause = self.parse_where_clause()?;
         let (inner_attrs, body) = self.parse_inner_attrs_and_block()?;
+        self.construct_async_arguments(&mut asyncness, &decl);
         let header = FnHeader { unsafety, asyncness, constness, abi };
         Ok((ident, ItemKind::Fn(decl, header, generics, body), Some(inner_attrs)))
     }
@@ -6601,11 +6604,12 @@ impl<'a> Parser<'a> {
             Ok((keywords::Invalid.ident(), vec![], ast::Generics::default(),
                 ast::ImplItemKind::Macro(mac)))
         } else {
-            let (constness, unsafety, asyncness, abi) = self.parse_fn_front_matter()?;
+            let (constness, unsafety, mut asyncness, abi) = self.parse_fn_front_matter()?;
             let ident = self.parse_ident()?;
             let mut generics = self.parse_generics()?;
             let decl = self.parse_fn_decl_with_self(|p| p.parse_arg())?;
             generics.where_clause = self.parse_where_clause()?;
+            self.construct_async_arguments(&mut asyncness, &decl);
             *at_end = true;
             let (inner_attrs, body) = self.parse_inner_attrs_and_block()?;
             let header = ast::FnHeader { abi, unsafety, constness, asyncness };
@@ -8010,6 +8014,7 @@ impl<'a> Parser<'a> {
                                    respan(async_span, IsAsync::Async {
                                        closure_id: ast::DUMMY_NODE_ID,
                                        return_impl_trait_id: ast::DUMMY_NODE_ID,
+                                       arguments: Vec::new(),
                                    }),
                                    respan(fn_span, Constness::NotConst),
                                    Abi::Rust)?;
@@ -8652,6 +8657,66 @@ impl<'a> Parser<'a> {
                     err.emit();
                 }
                 Err(mut err) => err.emit(),
+            }
+        }
+    }
+
+    /// When lowering a `async fn` to the HIR, we need to move all of the arguments of the function
+    /// into the generated closure so that they are dropped when the future is polled and not when
+    /// it is created.
+    ///
+    /// The arguments of the function are replaced in HIR lowering with the arguments created by
+    /// this function and the statements created here are inserted at the top of the closure body.
+    fn construct_async_arguments(&mut self, asyncness: &mut Spanned<IsAsync>, decl: &FnDecl) {
+        if let IsAsync::Async { ref mut arguments, .. } = asyncness.node {
+            for (index, input) in decl.inputs.iter().enumerate() {
+                let id = ast::DUMMY_NODE_ID;
+                let span = input.pat.span;
+
+                // Construct a name for our temporary argument.
+                let name = format!("__arg{}", index);
+                let ident = Ident::from_str(&name);
+
+                // Construct an argument representing `__argN: <ty>` to replace the argument of the
+                // async function.
+                let arg = Arg {
+                    ty: input.ty.clone(),
+                    id,
+                    pat: P(Pat {
+                        id,
+                        node: PatKind::Ident(
+                            BindingMode::ByValue(Mutability::Immutable), ident, None,
+                        ),
+                        span,
+                    }),
+                };
+
+                // Construct a `let <pat>: <ty> = __argN;` statement to insert at the top of the
+                // async closure.
+                let local = P(Local {
+                    pat: input.pat.clone(),
+                    ty: Some(P(Ty {
+                        id,
+                        node: input.ty.node.clone(),
+                        span: input.ty.span,
+                    })),
+                    init: Some(P(Expr {
+                        id,
+                        node: ExprKind::Path(None, ast::Path {
+                            span,
+                            segments: vec![PathSegment { ident, id, args: None }],
+                        }),
+                        span,
+                        attrs: ThinVec::new(),
+                    })),
+                    id,
+                    span,
+                    attrs: ThinVec::new(),
+                    source: LocalSource::AsyncFn,
+                });
+                let stmt = Stmt { id, node: StmtKind::Local(local), span, };
+
+                arguments.push(AsyncArgument { ident, arg, stmt });
             }
         }
     }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -372,7 +372,7 @@ pub fn vis_to_string(v: &ast::Visibility) -> String {
 }
 
 pub fn fun_to_string(decl: &ast::FnDecl,
-                     header: ast::FnHeader,
+                     header: &ast::FnHeader,
                      name: ast::Ident,
                      generics: &ast::Generics)
                      -> String {
@@ -1133,7 +1133,7 @@ impl<'a> State<'a> {
         match item.node {
             ast::ForeignItemKind::Fn(ref decl, ref generics) => {
                 self.head("")?;
-                self.print_fn(decl, ast::FnHeader::default(),
+                self.print_fn(decl, &ast::FnHeader::default(),
                               Some(item.ident),
                               generics, &item.vis)?;
                 self.end()?; // end head-ibox
@@ -1263,7 +1263,7 @@ impl<'a> State<'a> {
                 self.s.word(";")?;
                 self.end()?; // end the outer cbox
             }
-            ast::ItemKind::Fn(ref decl, header, ref param_names, ref body) => {
+            ast::ItemKind::Fn(ref decl, ref header, ref param_names, ref body) => {
                 self.head("")?;
                 self.print_fn(
                     decl,
@@ -1612,7 +1612,7 @@ impl<'a> State<'a> {
                             vis: &ast::Visibility)
                             -> io::Result<()> {
         self.print_fn(&m.decl,
-                      m.header,
+                      &m.header,
                       Some(ident),
                       &generics,
                       vis)
@@ -2210,7 +2210,7 @@ impl<'a> State<'a> {
                 self.bclose_(expr.span, INDENT_UNIT)?;
             }
             ast::ExprKind::Closure(
-                capture_clause, asyncness, movability, ref decl, ref body, _) => {
+                capture_clause, ref asyncness, movability, ref decl, ref body, _) => {
                 self.print_movability(movability)?;
                 self.print_asyncness(asyncness)?;
                 self.print_capture_clause(capture_clause)?;
@@ -2795,7 +2795,7 @@ impl<'a> State<'a> {
 
     pub fn print_fn(&mut self,
                     decl: &ast::FnDecl,
-                    header: ast::FnHeader,
+                    header: &ast::FnHeader,
                     name: Option<ast::Ident>,
                     generics: &ast::Generics,
                     vis: &ast::Visibility) -> io::Result<()> {
@@ -2850,8 +2850,7 @@ impl<'a> State<'a> {
         }
     }
 
-    pub fn print_asyncness(&mut self, asyncness: ast::IsAsync)
-                                -> io::Result<()> {
+    pub fn print_asyncness(&mut self, asyncness: &ast::IsAsync) -> io::Result<()> {
         if asyncness.is_async() {
             self.word_nbsp("async")?;
         }
@@ -3123,7 +3122,7 @@ impl<'a> State<'a> {
             span: syntax_pos::DUMMY_SP,
         };
         self.print_fn(decl,
-                      ast::FnHeader { unsafety, abi, ..ast::FnHeader::default() },
+                      &ast::FnHeader { unsafety, abi, ..ast::FnHeader::default() },
                       name,
                       &generics,
                       &source_map::dummy_spanned(ast::VisibilityKind::Inherited))?;
@@ -3186,7 +3185,7 @@ impl<'a> State<'a> {
     }
 
     pub fn print_fn_header_info(&mut self,
-                                header: ast::FnHeader,
+                                header: &ast::FnHeader,
                                 vis: &ast::Visibility) -> io::Result<()> {
         self.s.word(visibility_qualified(vis, ""))?;
 
@@ -3195,7 +3194,7 @@ impl<'a> State<'a> {
             ast::Constness::Const => self.word_nbsp("const")?
         }
 
-        self.print_asyncness(header.asyncness.node)?;
+        self.print_asyncness(&header.asyncness.node)?;
         self.print_unsafety(header.unsafety)?;
 
         if header.abi != Abi::Rust {

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -534,6 +534,9 @@ pub fn walk_fn_ret_ty<'a, V: Visitor<'a>>(visitor: &mut V, ret_ty: &'a FunctionR
 pub fn walk_fn_decl<'a, V: Visitor<'a>>(visitor: &mut V, function_declaration: &'a FnDecl) {
     for argument in &function_declaration.inputs {
         visitor.visit_pat(&argument.pat);
+        if let ArgSource::AsyncFn(pat) = &argument.source {
+            visitor.visit_pat(pat);
+        }
         visitor.visit_ty(&argument.ty)
     }
     visitor.visit_fn_ret_ty(&function_declaration.output)

--- a/src/libsyntax_ext/deriving/debug.rs
+++ b/src/libsyntax_ext/deriving/debug.rs
@@ -132,6 +132,7 @@ fn stmt_let_undescore(cx: &mut ExtCtxt<'_>, sp: Span, expr: P<ast::Expr>) -> ast
         id: ast::DUMMY_NODE_ID,
         span: sp,
         attrs: ThinVec::new(),
+        source: ast::LocalSource::Normal,
     });
     ast::Stmt {
         id: ast::DUMMY_NODE_ID,

--- a/src/test/run-pass/issue-54716.rs
+++ b/src/test/run-pass/issue-54716.rs
@@ -1,0 +1,87 @@
+// aux-build:arc_wake.rs
+// edition:2018
+// run-pass
+
+#![allow(unused_variables)]
+#![feature(async_await, await_macro, futures_api)]
+
+extern crate arc_wake;
+
+use arc_wake::ArcWake;
+use std::cell::RefCell;
+use std::future::Future;
+use std::sync::Arc;
+
+struct EmptyWaker;
+
+impl ArcWake for EmptyWaker {
+    fn wake(_arc_self: &Arc<Self>) {}
+}
+
+#[derive(Debug, Eq, PartialEq)]
+enum DropOrder {
+    Function,
+    Val(&'static str),
+}
+
+struct D(&'static str, Arc<RefCell<Vec<DropOrder>>>);
+
+impl Drop for D {
+    fn drop(&mut self) {
+        self.1.borrow_mut().push(DropOrder::Val(self.0));
+    }
+}
+
+async fn foo(x: D, _y: D) {
+    x.1.borrow_mut().push(DropOrder::Function);
+}
+
+async fn bar(x: D, _: D) {
+    x.1.borrow_mut().push(DropOrder::Function);
+}
+
+async fn baz((x, _): (D, D)) {
+    x.1.borrow_mut().push(DropOrder::Function);
+}
+
+async fn foobar(x: D, (a, _, _c): (D, D, D), _: D, _y: D) {
+    x.1.borrow_mut().push(DropOrder::Function);
+}
+
+fn main() {
+    let empty = Arc::new(EmptyWaker);
+    let waker = ArcWake::into_waker(empty);
+
+    use DropOrder::*;
+
+    // Currently, the `bar` and `foobar` tests do not output the same order as the equivalent
+    // non-async functions. This is because the drop order of captured variables doesn't match the
+    // drop order of arguments in a function.
+
+    let af = Arc::new(RefCell::new(Vec::new()));
+    let mut fut = Box::pin(foo(D("x", af.clone()), D("_y", af.clone())));
+    let _ = fut.as_mut().poll(&waker);
+    assert_eq!(*af.borrow(), &[Function, Val("_y"), Val("x")]);
+
+    let af = Arc::new(RefCell::new(Vec::new()));
+    let mut fut = Box::pin(bar(D("x", af.clone()), D("_", af.clone())));
+    let _ = fut.as_mut().poll(&waker);
+    assert_eq!(*af.borrow(), &[Function, Val("x"), Val("_")]);
+
+    let af = Arc::new(RefCell::new(Vec::new()));
+    let mut fut = Box::pin(baz((D("x", af.clone()), D("_", af.clone()))));
+    let _ = fut.as_mut().poll(&waker);
+    assert_eq!(*af.borrow(), &[Function, Val("x"), Val("_")]);
+
+    let af = Arc::new(RefCell::new(Vec::new()));
+    let mut fut = Box::pin(foobar(
+        D("x", af.clone()),
+        (D("a", af.clone()), D("_", af.clone()), D("_c", af.clone())),
+        D("_", af.clone()),
+        D("_y", af.clone()),
+    ));
+    let _ = fut.as_mut().poll(&waker);
+    assert_eq!(*af.borrow(), &[
+       Function, Val("_y"), Val("_c"), Val("a"), Val("x"), Val("_"), Val("_"),
+    ]);
+}

--- a/src/test/run-pass/issue-54716.rs
+++ b/src/test/run-pass/issue-54716.rs
@@ -10,6 +10,7 @@ extern crate arc_wake;
 use arc_wake::ArcWake;
 use std::cell::RefCell;
 use std::future::Future;
+use std::marker::PhantomData;
 use std::sync::Arc;
 
 struct EmptyWaker;
@@ -48,6 +49,46 @@ async fn foobar(x: D, (a, _, _c): (D, D, D), _: D, _y: D) {
     x.1.borrow_mut().push(DropOrder::Function);
 }
 
+struct Foo;
+
+impl Foo {
+    async fn foo(x: D, _y: D) {
+        x.1.borrow_mut().push(DropOrder::Function);
+    }
+
+    async fn bar(x: D, _: D) {
+        x.1.borrow_mut().push(DropOrder::Function);
+    }
+
+    async fn baz((x, _): (D, D)) {
+        x.1.borrow_mut().push(DropOrder::Function);
+    }
+
+    async fn foobar(x: D, (a, _, _c): (D, D, D), _: D, _y: D) {
+        x.1.borrow_mut().push(DropOrder::Function);
+    }
+}
+
+struct Bar<'a>(PhantomData<&'a ()>);
+
+impl<'a> Bar<'a> {
+    async fn foo(&'a self, x: D, _y: D) {
+        x.1.borrow_mut().push(DropOrder::Function);
+    }
+
+    async fn bar(&'a self, x: D, _: D) {
+        x.1.borrow_mut().push(DropOrder::Function);
+    }
+
+    async fn baz(&'a self, (x, _): (D, D)) {
+        x.1.borrow_mut().push(DropOrder::Function);
+    }
+
+    async fn foobar(&'a self, x: D, (a, _, _c): (D, D, D), _: D, _y: D) {
+        x.1.borrow_mut().push(DropOrder::Function);
+    }
+}
+
 fn main() {
     let empty = Arc::new(EmptyWaker);
     let waker = ArcWake::into_waker(empty);
@@ -57,6 +98,8 @@ fn main() {
     // Currently, the `bar` and `foobar` tests do not output the same order as the equivalent
     // non-async functions. This is because the drop order of captured variables doesn't match the
     // drop order of arguments in a function.
+
+    // Free functions
 
     let af = Arc::new(RefCell::new(Vec::new()));
     let mut fut = Box::pin(foo(D("x", af.clone()), D("_y", af.clone())));
@@ -75,6 +118,66 @@ fn main() {
 
     let af = Arc::new(RefCell::new(Vec::new()));
     let mut fut = Box::pin(foobar(
+        D("x", af.clone()),
+        (D("a", af.clone()), D("_", af.clone()), D("_c", af.clone())),
+        D("_", af.clone()),
+        D("_y", af.clone()),
+    ));
+    let _ = fut.as_mut().poll(&waker);
+    assert_eq!(*af.borrow(), &[
+       Function, Val("_y"), Val("_c"), Val("a"), Val("x"), Val("_"), Val("_"),
+    ]);
+
+    // Methods w/out self
+
+    let af = Arc::new(RefCell::new(Vec::new()));
+    let mut fut = Box::pin(Foo::foo(D("x", af.clone()), D("_y", af.clone())));
+    let _ = fut.as_mut().poll(&waker);
+    assert_eq!(*af.borrow(), &[Function, Val("_y"), Val("x")]);
+
+    let af = Arc::new(RefCell::new(Vec::new()));
+    let mut fut = Box::pin(Foo::bar(D("x", af.clone()), D("_", af.clone())));
+    let _ = fut.as_mut().poll(&waker);
+    assert_eq!(*af.borrow(), &[Function, Val("x"), Val("_")]);
+
+    let af = Arc::new(RefCell::new(Vec::new()));
+    let mut fut = Box::pin(Foo::baz((D("x", af.clone()), D("_", af.clone()))));
+    let _ = fut.as_mut().poll(&waker);
+    assert_eq!(*af.borrow(), &[Function, Val("x"), Val("_")]);
+
+    let af = Arc::new(RefCell::new(Vec::new()));
+    let mut fut = Box::pin(Foo::foobar(
+        D("x", af.clone()),
+        (D("a", af.clone()), D("_", af.clone()), D("_c", af.clone())),
+        D("_", af.clone()),
+        D("_y", af.clone()),
+    ));
+    let _ = fut.as_mut().poll(&waker);
+    assert_eq!(*af.borrow(), &[
+       Function, Val("_y"), Val("_c"), Val("a"), Val("x"), Val("_"), Val("_"),
+    ]);
+
+    // Methods
+
+    let b = Bar(Default::default());
+
+    let af = Arc::new(RefCell::new(Vec::new()));
+    let mut fut = Box::pin(b.foo(D("x", af.clone()), D("_y", af.clone())));
+    let _ = fut.as_mut().poll(&waker);
+    assert_eq!(*af.borrow(), &[Function, Val("_y"), Val("x")]);
+
+    let af = Arc::new(RefCell::new(Vec::new()));
+    let mut fut = Box::pin(b.bar(D("x", af.clone()), D("_", af.clone())));
+    let _ = fut.as_mut().poll(&waker);
+    assert_eq!(*af.borrow(), &[Function, Val("x"), Val("_")]);
+
+    let af = Arc::new(RefCell::new(Vec::new()));
+    let mut fut = Box::pin(b.baz((D("x", af.clone()), D("_", af.clone()))));
+    let _ = fut.as_mut().poll(&waker);
+    assert_eq!(*af.borrow(), &[Function, Val("x"), Val("_")]);
+
+    let af = Arc::new(RefCell::new(Vec::new()));
+    let mut fut = Box::pin(b.foobar(
         D("x", af.clone()),
         (D("a", af.clone()), D("_", af.clone()), D("_c", af.clone())),
         D("_", af.clone()),


### PR DESCRIPTION
Fixes #54716.

This PR modifies the HIR lowering (and some other places to make this work) so that unused arguments to a async function are always dropped inside the `async move` block and not at the end of the function body.

```
async fn foo(<pattern>: <type>) {
  async move {
  }
} // <-- dropped as you "exit" the fn

// ...becomes...
fn foo(__arg0: <ty>) {
  async move {
    let <pattern>: <ty> = __arg0;
  } // <-- dropped as you "exit" the async block
}
```

However, the exact ordering of drops is not the same as a regular function, [as visible in this playground example](https://play.rust-lang.org/?version=stable&mode=debug&edition=2015&gist=be39af1a58e5d430be1eb3c722cb1ec3) - I believe this to be an unrelated issue. There is a [Zulip topic](https://rust-lang.zulipchat.com/#narrow/stream/187312-t-compiler.2Fwg-async-await/topic/.2354716.20drop.20order) for this.

r? @cramertj 
cc @nikomatsakis 