### PR TITLE
[wg-async-await] Add regression test for #55809.

### DIFF
--- a/src/test/run-pass/issue-55809.rs
+++ b/src/test/run-pass/issue-55809.rs
@@ -1,0 +1,30 @@
+// edition:2018
+// run-pass
+
+#![feature(async_await, await_macro, futures_api)]
+
+trait Foo { }
+
+impl Foo for () { }
+
+impl<'a, T> Foo for &'a mut T where T: Foo { }
+
+async fn foo_async<T>(_v: T) -> u8 where T: Foo {
+    0
+}
+
+async fn bad<T>(v: T) -> u8 where T: Foo {
+    await!(foo_async(v))
+}
+
+async fn async_main() {
+    let mut v = ();
+
+    let _ = await!(bad(&mut v));
+    let _ = await!(foo_async(&mut v));
+    let _ = await!(bad(v));
+}
+
+fn main() {
+    let _ = async_main();
+}


### PR DESCRIPTION
Fixes #55809.

This PR adds a regression test for #55809 which checks that a
overflow does not occur when evaluating a requirement for async
functions and `&mut` arguments in some specific circumstances.