### PR TITLE
Revert "Don't generate minification variable if minification disabled"

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1117,11 +1117,7 @@ themePicker.onblur = handleThemeButtonsBlur;
     // with rustdoc running in parallel.
     all_indexes.sort();
     let mut w = try_err!(File::create(&dst), &dst);
-    if options.enable_minification {
-        try_err!(writeln!(&mut w, "var N=null,E=\"\",T=\"t\",U=\"u\",searchIndex={{}};"), &dst);
-    } else {
-        try_err!(writeln!(&mut w, "var searchIndex={{}};"), &dst);
-    }
+    try_err!(writeln!(&mut w, "var N=null,E=\"\",T=\"t\",U=\"u\",searchIndex={{}};"), &dst);
     try_err!(write_minify_replacer(&mut w,
                                    &format!("{}\n{}", variables.join(""), all_indexes.join("\n")),
                                    options.enable_minification),


### PR DESCRIPTION
Reverts #58643

Fixes #59157

https://github.com/rust-lang/rust/pull/58643 made us stop generating minification variables when minification is disabled, however they may still be needed for parent crates that were generated with minification (this will always be the case for libstd and libcore)

r? @QuietMisdreavus @GuillaumeGomez