### PR TITLE
consistent naming for Rhs type parameter in libcore/ops

### DIFF
--- a/src/libcore/ops/arith.rs
+++ b/src/libcore/ops/arith.rs
@@ -1,6 +1,6 @@
 /// The addition operator `+`.
 ///
-/// Note that `RHS` is `Self` by default, but this is not mandatory. For
+/// Note that `Rhs` is `Self` by default, but this is not mandatory. For
 /// example, [`std::time::SystemTime`] implements `Add<Duration>`, which permits
 /// operations of the form `SystemTime = SystemTime + Duration`.
 ///
@@ -67,18 +67,18 @@
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_on_unimplemented(
     on(
-        all(_Self="{integer}", RHS="{float}"),
+        all(_Self="{integer}", Rhs="{float}"),
         message="cannot add a float to an integer",
     ),
     on(
-        all(_Self="{float}", RHS="{integer}"),
+        all(_Self="{float}", Rhs="{integer}"),
         message="cannot add an integer to a float",
     ),
-    message="cannot add `{RHS}` to `{Self}`",
-    label="no implementation for `{Self} + {RHS}`",
+    message="cannot add `{Rhs}` to `{Self}`",
+    label="no implementation for `{Self} + {Rhs}`",
 )]
 #[doc(alias = "+")]
-pub trait Add<RHS=Self> {
+pub trait Add<Rhs=Self> {
     /// The resulting type after applying the `+` operator.
     #[stable(feature = "rust1", since = "1.0.0")]
     type Output;
@@ -86,7 +86,7 @@ pub trait Add<RHS=Self> {
     /// Performs the `+` operation.
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
-    fn add(self, rhs: RHS) -> Self::Output;
+    fn add(self, rhs: Rhs) -> Self::Output;
 }
 
 macro_rules! add_impl {
@@ -108,7 +108,7 @@ add_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 
 /// The subtraction operator `-`.
 ///
-/// Note that `RHS` is `Self` by default, but this is not mandatory. For
+/// Note that `Rhs` is `Self` by default, but this is not mandatory. For
 /// example, [`std::time::SystemTime`] implements `Sub<Duration>`, which permits
 /// operations of the form `SystemTime = SystemTime - Duration`.
 ///
@@ -173,10 +173,10 @@ add_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 /// ```
 #[lang = "sub"]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_on_unimplemented(message="cannot subtract `{RHS}` from `{Self}`",
-                         label="no implementation for `{Self} - {RHS}`")]
+#[rustc_on_unimplemented(message="cannot subtract `{Rhs}` from `{Self}`",
+                         label="no implementation for `{Self} - {Rhs}`")]
 #[doc(alias = "-")]
-pub trait Sub<RHS=Self> {
+pub trait Sub<Rhs=Self> {
     /// The resulting type after applying the `-` operator.
     #[stable(feature = "rust1", since = "1.0.0")]
     type Output;
@@ -184,7 +184,7 @@ pub trait Sub<RHS=Self> {
     /// Performs the `-` operation.
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
-    fn sub(self, rhs: RHS) -> Self::Output;
+    fn sub(self, rhs: Rhs) -> Self::Output;
 }
 
 macro_rules! sub_impl {
@@ -206,7 +206,7 @@ sub_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 
 /// The multiplication operator `*`.
 ///
-/// Note that `RHS` is `Self` by default, but this is not mandatory.
+/// Note that `Rhs` is `Self` by default, but this is not mandatory.
 ///
 /// # Examples
 ///
@@ -293,10 +293,10 @@ sub_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 /// ```
 #[lang = "mul"]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_on_unimplemented(message="cannot multiply `{RHS}` to `{Self}`",
-                         label="no implementation for `{Self} * {RHS}`")]
+#[rustc_on_unimplemented(message="cannot multiply `{Rhs}` to `{Self}`",
+                         label="no implementation for `{Self} * {Rhs}`")]
 #[doc(alias = "*")]
-pub trait Mul<RHS=Self> {
+pub trait Mul<Rhs=Self> {
     /// The resulting type after applying the `*` operator.
     #[stable(feature = "rust1", since = "1.0.0")]
     type Output;
@@ -304,7 +304,7 @@ pub trait Mul<RHS=Self> {
     /// Performs the `*` operation.
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
-    fn mul(self, rhs: RHS) -> Self::Output;
+    fn mul(self, rhs: Rhs) -> Self::Output;
 }
 
 macro_rules! mul_impl {
@@ -326,7 +326,7 @@ mul_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 
 /// The division operator `/`.
 ///
-/// Note that `RHS` is `Self` by default, but this is not mandatory.
+/// Note that `Rhs` is `Self` by default, but this is not mandatory.
 ///
 /// # Examples
 ///
@@ -417,10 +417,10 @@ mul_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 /// ```
 #[lang = "div"]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_on_unimplemented(message="cannot divide `{Self}` by `{RHS}`",
-                         label="no implementation for `{Self} / {RHS}`")]
+#[rustc_on_unimplemented(message="cannot divide `{Self}` by `{Rhs}`",
+                         label="no implementation for `{Self} / {Rhs}`")]
 #[doc(alias = "/")]
-pub trait Div<RHS=Self> {
+pub trait Div<Rhs=Self> {
     /// The resulting type after applying the `/` operator.
     #[stable(feature = "rust1", since = "1.0.0")]
     type Output;
@@ -428,7 +428,7 @@ pub trait Div<RHS=Self> {
     /// Performs the `/` operation.
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
-    fn div(self, rhs: RHS) -> Self::Output;
+    fn div(self, rhs: Rhs) -> Self::Output;
 }
 
 macro_rules! div_impl_integer {
@@ -467,7 +467,7 @@ div_impl_float! { f32 f64 }
 
 /// The remainder operator `%`.
 ///
-/// Note that `RHS` is `Self` by default, but this is not mandatory.
+/// Note that `Rhs` is `Self` by default, but this is not mandatory.
 ///
 /// # Examples
 ///
@@ -502,10 +502,10 @@ div_impl_float! { f32 f64 }
 /// ```
 #[lang = "rem"]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_on_unimplemented(message="cannot mod `{Self}` by `{RHS}`",
-                         label="no implementation for `{Self} % {RHS}`")]
+#[rustc_on_unimplemented(message="cannot mod `{Self}` by `{Rhs}`",
+                         label="no implementation for `{Self} % {Rhs}`")]
 #[doc(alias = "%")]
-pub trait Rem<RHS=Self> {
+pub trait Rem<Rhs=Self> {
     /// The resulting type after applying the `%` operator.
     #[stable(feature = "rust1", since = "1.0.0")]
     type Output = Self;
@@ -513,7 +513,7 @@ pub trait Rem<RHS=Self> {
     /// Performs the `%` operation.
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
-    fn rem(self, rhs: RHS) -> Self::Output;
+    fn rem(self, rhs: Rhs) -> Self::Output;
 }
 
 macro_rules! rem_impl_integer {

--- a/src/libcore/ops/bit.rs
+++ b/src/libcore/ops/bit.rs
@@ -59,7 +59,7 @@ not_impl! { bool usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
 
 /// The bitwise AND operator `&`.
 ///
-/// Note that `RHS` is `Self` by default, but this is not mandatory.
+/// Note that `Rhs` is `Self` by default, but this is not mandatory.
 ///
 /// # Examples
 ///
@@ -112,9 +112,9 @@ not_impl! { bool usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
 #[lang = "bitand"]
 #[doc(alias = "&")]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_on_unimplemented(message="no implementation for `{Self} & {RHS}`",
-                         label="no implementation for `{Self} & {RHS}`")]
-pub trait BitAnd<RHS=Self> {
+#[rustc_on_unimplemented(message="no implementation for `{Self} & {Rhs}`",
+                         label="no implementation for `{Self} & {Rhs}`")]
+pub trait BitAnd<Rhs=Self> {
     /// The resulting type after applying the `&` operator.
     #[stable(feature = "rust1", since = "1.0.0")]
     type Output;
@@ -122,7 +122,7 @@ pub trait BitAnd<RHS=Self> {
     /// Performs the `&` operation.
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
-    fn bitand(self, rhs: RHS) -> Self::Output;
+    fn bitand(self, rhs: Rhs) -> Self::Output;
 }
 
 macro_rules! bitand_impl {
@@ -143,7 +143,7 @@ bitand_impl! { bool usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
 
 /// The bitwise OR operator `|`.
 ///
-/// Note that `RHS` is `Self` by default, but this is not mandatory.
+/// Note that `Rhs` is `Self` by default, but this is not mandatory.
 ///
 /// # Examples
 ///
@@ -196,9 +196,9 @@ bitand_impl! { bool usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
 #[lang = "bitor"]
 #[doc(alias = "|")]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_on_unimplemented(message="no implementation for `{Self} | {RHS}`",
-                         label="no implementation for `{Self} | {RHS}`")]
-pub trait BitOr<RHS=Self> {
+#[rustc_on_unimplemented(message="no implementation for `{Self} | {Rhs}`",
+                         label="no implementation for `{Self} | {Rhs}`")]
+pub trait BitOr<Rhs=Self> {
     /// The resulting type after applying the `|` operator.
     #[stable(feature = "rust1", since = "1.0.0")]
     type Output;
@@ -206,7 +206,7 @@ pub trait BitOr<RHS=Self> {
     /// Performs the `|` operation.
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
-    fn bitor(self, rhs: RHS) -> Self::Output;
+    fn bitor(self, rhs: Rhs) -> Self::Output;
 }
 
 macro_rules! bitor_impl {
@@ -227,7 +227,7 @@ bitor_impl! { bool usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
 
 /// The bitwise XOR operator `^`.
 ///
-/// Note that `RHS` is `Self` by default, but this is not mandatory.
+/// Note that `Rhs` is `Self` by default, but this is not mandatory.
 ///
 /// # Examples
 ///
@@ -283,9 +283,9 @@ bitor_impl! { bool usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
 #[lang = "bitxor"]
 #[doc(alias = "^")]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_on_unimplemented(message="no implementation for `{Self} ^ {RHS}`",
-                         label="no implementation for `{Self} ^ {RHS}`")]
-pub trait BitXor<RHS=Self> {
+#[rustc_on_unimplemented(message="no implementation for `{Self} ^ {Rhs}`",
+                         label="no implementation for `{Self} ^ {Rhs}`")]
+pub trait BitXor<Rhs=Self> {
     /// The resulting type after applying the `^` operator.
     #[stable(feature = "rust1", since = "1.0.0")]
     type Output;
@@ -293,7 +293,7 @@ pub trait BitXor<RHS=Self> {
     /// Performs the `^` operation.
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
-    fn bitxor(self, rhs: RHS) -> Self::Output;
+    fn bitxor(self, rhs: Rhs) -> Self::Output;
 }
 
 macro_rules! bitxor_impl {
@@ -371,9 +371,9 @@ bitxor_impl! { bool usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
 #[lang = "shl"]
 #[doc(alias = "<<")]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_on_unimplemented(message="no implementation for `{Self} << {RHS}`",
-                         label="no implementation for `{Self} << {RHS}`")]
-pub trait Shl<RHS=Self> {
+#[rustc_on_unimplemented(message="no implementation for `{Self} << {Rhs}`",
+                         label="no implementation for `{Self} << {Rhs}`")]
+pub trait Shl<Rhs=Self> {
     /// The resulting type after applying the `<<` operator.
     #[stable(feature = "rust1", since = "1.0.0")]
     type Output;
@@ -381,7 +381,7 @@ pub trait Shl<RHS=Self> {
     /// Performs the `<<` operation.
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
-    fn shl(self, rhs: RHS) -> Self::Output;
+    fn shl(self, rhs: Rhs) -> Self::Output;
 }
 
 macro_rules! shl_impl {
@@ -480,9 +480,9 @@ shl_impl_all! { u8 u16 u32 u64 u128 usize i8 i16 i32 i64 isize i128 }
 #[lang = "shr"]
 #[doc(alias = ">>")]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_on_unimplemented(message="no implementation for `{Self} >> {RHS}`",
-                         label="no implementation for `{Self} >> {RHS}`")]
-pub trait Shr<RHS=Self> {
+#[rustc_on_unimplemented(message="no implementation for `{Self} >> {Rhs}`",
+                         label="no implementation for `{Self} >> {Rhs}`")]
+pub trait Shr<Rhs=Self> {
     /// The resulting type after applying the `>>` operator.
     #[stable(feature = "rust1", since = "1.0.0")]
     type Output;
@@ -490,7 +490,7 @@ pub trait Shr<RHS=Self> {
     /// Performs the `>>` operation.
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
-    fn shr(self, rhs: RHS) -> Self::Output;
+    fn shr(self, rhs: Rhs) -> Self::Output;
 }
 
 macro_rules! shr_impl {

--- a/src/test/ui/issues/issue-21950.stderr
+++ b/src/test/ui/issues/issue-21950.stderr
@@ -1,8 +1,8 @@
-error[E0393]: the type parameter `RHS` must be explicitly specified
+error[E0393]: the type parameter `Rhs` must be explicitly specified
   --> $DIR/issue-21950.rs:7:14
    |
 LL |             &Add;
-   |              ^^^ missing reference to `RHS`
+   |              ^^^ missing reference to `Rhs`
    |
    = note: because of the default `Self` reference, type parameters must be specified on object types
 

--- a/src/test/ui/issues/issue-22560.stderr
+++ b/src/test/ui/issues/issue-22560.stderr
@@ -1,16 +1,16 @@
-error[E0393]: the type parameter `RHS` must be explicitly specified
+error[E0393]: the type parameter `Rhs` must be explicitly specified
   --> $DIR/issue-22560.rs:5:13
    |
 LL | type Test = Add +
-   |             ^^^ missing reference to `RHS`
+   |             ^^^ missing reference to `Rhs`
    |
    = note: because of the default `Self` reference, type parameters must be specified on object types
 
-error[E0393]: the type parameter `RHS` must be explicitly specified
+error[E0393]: the type parameter `Rhs` must be explicitly specified
   --> $DIR/issue-22560.rs:8:13
    |
 LL |             Sub;
-   |             ^^^ missing reference to `RHS`
+   |             ^^^ missing reference to `Rhs`
    |
    = note: because of the default `Self` reference, type parameters must be specified on object types
 


### PR DESCRIPTION
Rename RHS type parameter occurrences RHS->Rhs to make it consistent throughout files and follow naming conventions.