### PR TITLE
Exclude old book redirect stubs from search engines

### DIFF
--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -331,7 +331,7 @@ fn invoke_rustdoc(
 
     let path = builder.src.join("src/doc").join(markdown);
 
-    let favicon = builder.src.join("src/doc/favicon.inc");
+    let header = builder.src.join("src/doc/redirect.inc");
     let footer = builder.src.join("src/doc/footer.inc");
     let version_info = out.join("version_info.html");
 
@@ -341,7 +341,7 @@ fn invoke_rustdoc(
 
     cmd.arg("--html-after-content").arg(&footer)
         .arg("--html-before-content").arg(&version_info)
-        .arg("--html-in-header").arg(&favicon)
+        .arg("--html-in-header").arg(&header)
         .arg("--markdown-no-toc")
         .arg("--markdown-playground-url")
         .arg("https://play.rust-lang.org/")

--- a/src/doc/redirect.inc
+++ b/src/doc/redirect.inc
@@ -1,0 +1,2 @@
+<meta name="robots" content="noindex,follow">
+<link rel="shortcut icon" href="https://www.rust-lang.org/favicon.ico">


### PR DESCRIPTION
Adds `<meta name="robots" content="noindex,follow">` to the `<head>` of old stub pages pointing to the second edition of the book.

This is continuation of https://github.com/rust-lang/book/pull/1788