### PR TITLE
Do not complain about unmentioned fields in recovered patterns

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4698,7 +4698,7 @@ impl<'a> Parser<'a> {
                         let (fields, etc) = self.parse_pat_fields().unwrap_or_else(|mut e| {
                             e.emit();
                             self.recover_stmt();
-                            (vec![], false)
+                            (vec![], true)
                         });
                         self.bump();
                         pat = PatKind::Struct(path, fields, etc);

--- a/src/test/ui/parser/bind-struct-early-modifiers.rs
+++ b/src/test/ui/parser/bind-struct-early-modifiers.rs
@@ -2,7 +2,6 @@ fn main() {
     struct Foo { x: isize }
     match (Foo { x: 10 }) {
         Foo { ref x: ref x } => {}, //~ ERROR expected `,`
-                                    //~| ERROR pattern does not mention field `x`
         _ => {}
     }
 }

--- a/src/test/ui/parser/bind-struct-early-modifiers.stderr
+++ b/src/test/ui/parser/bind-struct-early-modifiers.stderr
@@ -4,12 +4,5 @@ error: expected `,`
 LL |         Foo { ref x: ref x } => {},
    |                   ^
 
-error[E0027]: pattern does not mention field `x`
-  --> $DIR/bind-struct-early-modifiers.rs:4:9
-   |
-LL |         Foo { ref x: ref x } => {},
-   |         ^^^^^^^^^^^^^^^^^^^^ missing field `x`
+error: aborting due to previous error
 
-error: aborting due to 2 previous errors
-
-For more information about this error, try `rustc --explain E0027`.

--- a/src/test/ui/parser/issue-10392.rs
+++ b/src/test/ui/parser/issue-10392.rs
@@ -4,5 +4,4 @@ fn a() -> A { panic!() }
 
 fn main() {
     let A { , } = a(); //~ ERROR expected ident
-                       //~| ERROR pattern does not mention field `foo`
 }

--- a/src/test/ui/parser/issue-10392.stderr
+++ b/src/test/ui/parser/issue-10392.stderr
@@ -4,12 +4,5 @@ error: expected identifier, found `,`
 LL |     let A { , } = a();
    |             ^ expected identifier
 
-error[E0027]: pattern does not mention field `foo`
-  --> $DIR/issue-10392.rs:6:9
-   |
-LL |     let A { , } = a();
-   |         ^^^^^^^ missing field `foo`
+error: aborting due to previous error
 
-error: aborting due to 2 previous errors
-
-For more information about this error, try `rustc --explain E0027`.

--- a/src/test/ui/resolve/issue-54379.rs
+++ b/src/test/ui/resolve/issue-54379.rs
@@ -6,7 +6,7 @@ fn main() {
     let thing = MyStruct { s1: None };
 
     match thing {
-        MyStruct { .., Some(_) } => {}, //~ ERROR pattern does not mention field `s1`
+        MyStruct { .., Some(_) } => {},
         //~^ ERROR expected `,`
         //~| ERROR expected `}`, found `,`
         _ => {}

--- a/src/test/ui/resolve/issue-54379.stderr
+++ b/src/test/ui/resolve/issue-54379.stderr
@@ -13,12 +13,5 @@ error: expected `,`
 LL |         MyStruct { .., Some(_) } => {},
    |                        ^^^^
 
-error[E0027]: pattern does not mention field `s1`
-  --> $DIR/issue-54379.rs:9:9
-   |
-LL |         MyStruct { .., Some(_) } => {},
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^ missing field `s1`
+error: aborting due to 2 previous errors
 
-error: aborting due to 3 previous errors
-
-For more information about this error, try `rustc --explain E0027`.


### PR DESCRIPTION
When the parser has to recover from malformed code in a pattern, do not
complain about missing fields.

Fix #59145.