### PR TITLE
Remove `track_errors` from `check_match`, `typeck_item_bodies` and `register_plugins`

### DIFF
--- a/src/librustc/ty/query/mod.rs
+++ b/src/librustc/ty/query/mod.rs
@@ -272,7 +272,7 @@ rustc_query_append! { [define_queries!][ <'tcx>
 
     TypeChecking {
         [] fn typeck_item_bodies:
-                typeck_item_bodies_dep_node(CrateNum) -> Result<(), ErrorReported>,
+                typeck_item_bodies_dep_node(CrateNum) -> (),
 
         [] fn typeck_tables_of: TypeckTables(DefId) -> &'tcx ty::TypeckTables<'tcx>,
     },
@@ -325,8 +325,7 @@ rustc_query_append! { [define_queries!][ <'tcx>
     },
 
     TypeChecking {
-        [] fn check_match: CheckMatch(DefId)
-            -> Result<(), ErrorReported>,
+        [] fn check_match: CheckMatch(DefId) -> (),
 
         /// Performs part of the privacy check and computes "access levels".
         [] fn privacy_access_levels: PrivacyAccessLevels(CrateNum) -> Lrc<AccessLevels>,

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -323,22 +323,20 @@ pub fn register_plugins<'a>(
         ..
     } = registry;
 
-    sess.track_errors(|| {
-        let mut ls = sess.lint_store.borrow_mut();
-        for pass in early_lint_passes {
-            ls.register_early_pass(Some(sess), true, false, pass);
-        }
-        for pass in late_lint_passes {
-            ls.register_late_pass(Some(sess), true, pass);
-        }
+    let mut ls = sess.lint_store.borrow_mut();
+    for pass in early_lint_passes {
+        ls.register_early_pass(Some(sess), true, false, pass);
+    }
+    for pass in late_lint_passes {
+        ls.register_late_pass(Some(sess), true, pass);
+    }
 
-        for (name, (to, deprecated_name)) in lint_groups {
-            ls.register_group(Some(sess), true, name, deprecated_name, to);
-        }
+    for (name, (to, deprecated_name)) in lint_groups {
+        ls.register_group(Some(sess), true, name, deprecated_name, to);
+    }
 
-        *sess.plugin_llvm_passes.borrow_mut() = llvm_passes;
-        *sess.plugin_attributes.borrow_mut() = attributes.clone();
-    })?;
+    *sess.plugin_llvm_passes.borrow_mut() = llvm_passes;
+    *sess.plugin_attributes.borrow_mut() = attributes.clone();
 
     Ok((krate, PluginInfo {
         syntax_exts,

--- a/src/librustc_mir/build/matches/mod.rs
+++ b/src/librustc_mir/build/matches/mod.rs
@@ -438,7 +438,12 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
         // always convert all match-pairs into bindings.
         self.simplify_candidate(&mut candidate);
 
-        if !candidate.match_pairs.is_empty() {
+        if !candidate.match_pairs.is_empty() && self.hir.tcx().sess.err_count() == 0 {
+            // Only abort compilation if no other errors have been emitted. This used to be a hard
+            // error that wouldn't be reached because `hair::pattern::check_match::check_match`
+            // wouldn't have let the compiler continue. In our tests this is only ever hit by
+            // `ui/consts/const-match-check.rs` with `--cfg eval1`, and that file already generates
+            // a different error before hand.
             span_bug!(
                 candidate.match_pairs[0].pattern.span,
                 "match pairs {:?} remaining after simplifying \

--- a/src/librustc_mir/build/matches/mod.rs
+++ b/src/librustc_mir/build/matches/mod.rs
@@ -438,17 +438,18 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
         // always convert all match-pairs into bindings.
         self.simplify_candidate(&mut candidate);
 
-        if !candidate.match_pairs.is_empty() && self.hir.tcx().sess.err_count() == 0 {
+        if !candidate.match_pairs.is_empty() {
             // Only abort compilation if no other errors have been emitted. This used to be a hard
             // error that wouldn't be reached because `hair::pattern::check_match::check_match`
             // wouldn't have let the compiler continue. In our tests this is only ever hit by
             // `ui/consts/const-match-check.rs` with `--cfg eval1`, and that file already generates
             // a different error before hand.
-            span_bug!(
+            self.hir.tcx().sess.delay_span_bug(
                 candidate.match_pairs[0].pattern.span,
-                "match pairs {:?} remaining after simplifying \
-                 irrefutable pattern",
-                candidate.match_pairs
+                &format!(
+                    "match pairs {:?} remaining after simplifying irrefutable pattern",
+                    candidate.match_pairs,
+                ),
             );
         }
 

--- a/src/librustc_mir/build/matches/mod.rs
+++ b/src/librustc_mir/build/matches/mod.rs
@@ -439,9 +439,9 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
         self.simplify_candidate(&mut candidate);
 
         if !candidate.match_pairs.is_empty() {
-            // Only abort compilation if no other errors have been emitted. This used to be a hard
-            // error that wouldn't be reached because `hair::pattern::check_match::check_match`
-            // wouldn't have let the compiler continue. In our tests this is only ever hit by
+            // ICE if no other errors have been emitted. This used to be a hard error that wouldn't
+            // be reached because `hair::pattern::check_match::check_match` wouldn't have let the
+            // compiler continue. In our tests this is only ever hit by
             // `ui/consts/const-match-check.rs` with `--cfg eval1`, and that file already generates
             // a different error before hand.
             self.hir.tcx().sess.delay_span_bug(

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -15,7 +15,6 @@ use rustc::ty::layout::{self, LayoutOf, VariantIdx};
 use rustc::ty::subst::Subst;
 use rustc::traits::Reveal;
 use rustc_data_structures::fx::FxHashMap;
-use rustc::util::common::ErrorReported;
 
 use syntax::ast::Mutability;
 use syntax::source_map::{Span, DUMMY_SP};
@@ -619,9 +618,7 @@ pub fn const_eval_raw_provider<'a, 'tcx>(
         let tables = tcx.typeck_tables_of(def_id);
 
         // Do match-check before building MIR
-        if let Err(ErrorReported) = tcx.check_match(def_id) {
-            return Err(ErrorHandled::Reported)
-        }
+        tcx.check_match(def_id);
 
         if let hir::BodyOwnerKind::Const = tcx.hir().body_owner_kind_by_hir_id(id) {
             tcx.mir_const_qualif(def_id);

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -618,6 +618,7 @@ pub fn const_eval_raw_provider<'a, 'tcx>(
         let tables = tcx.typeck_tables_of(def_id);
 
         // Do match-check before building MIR
+        // FIXME(#59378) check_match may have errored but we're not checking for that anymore
         tcx.check_match(def_id);
 
         if let hir::BodyOwnerKind::Const = tcx.hir().body_owner_kind_by_hir_id(id) {

--- a/src/librustc_mir/hair/pattern/check_match.rs
+++ b/src/librustc_mir/hair/pattern/check_match.rs
@@ -37,15 +37,14 @@ pub(crate) fn check_match<'a, 'tcx>(
         return Ok(());
     };
 
-    tcx.sess.track_errors(|| {
-        MatchVisitor {
-            tcx,
-            tables: tcx.body_tables(body_id),
-            region_scope_tree: &tcx.region_scope_tree(def_id),
-            param_env: tcx.param_env(def_id),
-            identity_substs: InternalSubsts::identity_for_item(tcx, def_id),
-        }.visit_body(tcx.hir().body(body_id));
-    })
+    MatchVisitor {
+        tcx,
+        tables: tcx.body_tables(body_id),
+        region_scope_tree: &tcx.region_scope_tree(def_id),
+        param_env: tcx.param_env(def_id),
+        identity_substs: InternalSubsts::identity_for_item(tcx, def_id),
+    }.visit_body(tcx.hir().body(body_id));
+    Ok(())
 }
 
 fn create_e0004<'a>(sess: &'a Session, sp: Span, error_message: String) -> DiagnosticBuilder<'a> {

--- a/src/librustc_mir/hair/pattern/check_match.rs
+++ b/src/librustc_mir/hair/pattern/check_match.rs
@@ -14,7 +14,6 @@ use rustc::ty::{self, Ty, TyCtxt, TyKind};
 use rustc::ty::subst::{InternalSubsts, SubstsRef};
 use rustc::lint;
 use rustc_errors::{Applicability, DiagnosticBuilder};
-use rustc::util::common::ErrorReported;
 
 use rustc::hir::def::*;
 use rustc::hir::def_id::DefId;
@@ -27,14 +26,11 @@ use std::slice;
 use syntax::ptr::P;
 use syntax_pos::{Span, DUMMY_SP, MultiSpan};
 
-pub(crate) fn check_match<'a, 'tcx>(
-    tcx: TyCtxt<'a, 'tcx, 'tcx>,
-    def_id: DefId,
-) -> Result<(), ErrorReported> {
+pub(crate) fn check_match<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) {
     let body_id = if let Some(id) = tcx.hir().as_local_hir_id(def_id) {
         tcx.hir().body_owned_by(id)
     } else {
-        return Ok(());
+        return;
     };
 
     MatchVisitor {
@@ -44,7 +40,6 @@ pub(crate) fn check_match<'a, 'tcx>(
         param_env: tcx.param_env(def_id),
         identity_substs: InternalSubsts::identity_for_item(tcx, def_id),
     }.visit_body(tcx.hir().body(body_id));
-    Ok(())
 }
 
 fn create_e0004<'a>(sess: &'a Session, sp: Span, error_message: String) -> DiagnosticBuilder<'a> {

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -702,14 +702,11 @@ fn check_mod_item_types<'tcx>(tcx: TyCtxt<'_, 'tcx, 'tcx>, module_def_id: DefId)
     tcx.hir().visit_item_likes_in_module(module_def_id, &mut CheckItemTypesVisitor { tcx });
 }
 
-fn typeck_item_bodies<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, crate_num: CrateNum)
-                                -> Result<(), ErrorReported>
-{
+fn typeck_item_bodies<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, crate_num: CrateNum) {
     debug_assert!(crate_num == LOCAL_CRATE);
     tcx.par_body_owners(|body_owner_def_id| {
         tcx.ensure().typeck_tables_of(body_owner_def_id);
     });
-    Ok(())
 }
 
 fn check_item_well_formed<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) {

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -706,11 +706,10 @@ fn typeck_item_bodies<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, crate_num: CrateNum
                                 -> Result<(), ErrorReported>
 {
     debug_assert!(crate_num == LOCAL_CRATE);
-    Ok(tcx.sess.track_errors(|| {
-        tcx.par_body_owners(|body_owner_def_id| {
-            tcx.ensure().typeck_tables_of(body_owner_def_id);
-        });
-    })?)
+    tcx.par_body_owners(|body_owner_def_id| {
+        tcx.ensure().typeck_tables_of(body_owner_def_id);
+    });
+    Ok(())
 }
 
 fn check_item_well_formed<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) {

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -363,7 +363,7 @@ pub fn check_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>)
         })
     })?;
 
-    time(tcx.sess, "item-bodies checking", || tcx.typeck_item_bodies(LOCAL_CRATE))?;
+    time(tcx.sess, "item-bodies checking", || tcx.typeck_item_bodies(LOCAL_CRATE));
 
     check_unused::check_crate(tcx);
     check_for_entry_fn(tcx);

--- a/src/test/ui/issues/issue-26217.rs
+++ b/src/test/ui/issues/issue-26217.rs
@@ -1,6 +1,10 @@
 fn foo<T>() where for<'a> T: 'a {}
 
-fn main<'a>() {
+fn bar<'a>() {
     foo::<&'a i32>();
     //~^ ERROR the type `&'a i32` does not fulfill the required lifetime
+}
+
+fn main() {
+    bar();
 }


### PR DESCRIPTION
In the spirit of continuing through errors in type checking (#39275), remove `track_errors` from a couple of locations in the codebase.