### PR TITLE
Remove restriction on isize/usize in repr(simd)

### DIFF
--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -1910,7 +1910,6 @@ impl<'a, 'gcx, 'tcx> TyS<'tcx> {
 
     pub fn is_machine(&self) -> bool {
         match self.sty {
-            Int(ast::IntTy::Isize) | Uint(ast::UintTy::Usize) => false,
             Int(..) | Uint(..) | Float(..) => true,
             _ => false,
         }

--- a/src/test/run-pass/simd/simd-size-align.rs
+++ b/src/test/run-pass/simd/simd-size-align.rs
@@ -37,6 +37,22 @@ fn main() {
     check::<f32x6>();
     check::<f32x7>();
     check::<f32x8>();
+
+    check::<usizex2>();
+    check::<usizex3>();
+    check::<usizex4>();
+    check::<usizex5>();
+    check::<usizex6>();
+    check::<usizex7>();
+    check::<usizex8>();
+
+    check::<isizex2>();
+    check::<isizex3>();
+    check::<isizex4>();
+    check::<isizex5>();
+    check::<isizex6>();
+    check::<isizex7>();
+    check::<isizex8>();
 }
 
 #[repr(simd)] struct u8x2(u8, u8);
@@ -62,3 +78,19 @@ fn main() {
 #[repr(simd)] struct f32x6(f32, f32, f32, f32, f32, f32);
 #[repr(simd)] struct f32x7(f32, f32, f32, f32, f32, f32, f32);
 #[repr(simd)] struct f32x8(f32, f32, f32, f32, f32, f32, f32, f32);
+
+#[repr(simd)] struct usizex2(usize, usize);
+#[repr(simd)] struct usizex3(usize, usize, usize);
+#[repr(simd)] struct usizex4(usize, usize, usize, usize);
+#[repr(simd)] struct usizex5(usize, usize, usize, usize, usize);
+#[repr(simd)] struct usizex6(usize, usize, usize, usize, usize, usize);
+#[repr(simd)] struct usizex7(usize, usize, usize, usize, usize, usize, usize);
+#[repr(simd)] struct usizex8(usize, usize, usize, usize, usize, usize, usize, usize);
+
+#[repr(simd)] struct isizex2(isize, isize);
+#[repr(simd)] struct isizex3(isize, isize, isize);
+#[repr(simd)] struct isizex4(isize, isize, isize, isize);
+#[repr(simd)] struct isizex5(isize, isize, isize, isize, isize);
+#[repr(simd)] struct isizex6(isize, isize, isize, isize, isize, isize);
+#[repr(simd)] struct isizex7(isize, isize, isize, isize, isize, isize, isize);
+#[repr(simd)] struct isizex8(isize, isize, isize, isize, isize, isize, isize, isize);

--- a/src/test/ui/simd-type.rs
+++ b/src/test/ui/simd-type.rs
@@ -7,7 +7,4 @@ struct empty; //~ ERROR SIMD vector cannot be empty
 #[repr(simd)]
 struct i64f64(i64, f64); //~ ERROR SIMD vector should be homogeneous
 
-#[repr(simd)]
-struct int4(isize, isize, isize, isize); //~ ERROR SIMD vector element type should be machine type
-
 fn main() {}

--- a/src/test/ui/simd-type.stderr
+++ b/src/test/ui/simd-type.stderr
@@ -10,13 +10,7 @@ error[E0076]: SIMD vector should be homogeneous
 LL | struct i64f64(i64, f64);
    | ^^^^^^^^^^^^^^^^^^^^^^^^ SIMD elements must have the same type
 
-error[E0077]: SIMD vector element type should be machine type
-  --> $DIR/simd-type.rs:11:1
-   |
-LL | struct int4(isize, isize, isize, isize);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+error: aborting due to 2 previous errors
 
-error: aborting due to 3 previous errors
-
-Some errors occurred: E0075, E0076, E0077.
+Some errors occurred: E0075, E0076.
 For more information about an error, try `rustc --explain E0075`.


### PR DESCRIPTION
As discussed in #55078, there's no known reason for this restriction.

It's unlikely that repr(simd) will be stabilized in its current form, but
might as well remove some restrictions on it.

This removes the branch in `is_machine` which returns false for these types.
`is_machine` is only used for the repr(simd) type validation check.