### PR TITLE
Introduce RefCell::try_borrow_unguarded

### DIFF
--- a/src/doc/unstable-book/src/library-features/borrow-state.md
+++ b/src/doc/unstable-book/src/library-features/borrow-state.md
@@ -1,0 +1,7 @@
+# `borrow_state`
+
+The tracking issue for this feature is: [#27733]
+
+[#27733]: https://github.com/rust-lang/rust/issues/27733
+
+------------------------

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -765,10 +765,14 @@ impl<T> RefCell<T> {
 }
 
 impl<T: ?Sized> RefCell<T> {
-    /// Query the current state of this `RefCell`
+    /// Queries the current state of this `RefCell`.
     ///
-    /// The returned value can be dispatched on to determine if a call to
-    /// `borrow` or `borrow_mut` would succeed.
+    /// A return value of `BorrowState::Writing` signals that this `RefCell`
+    /// is currently mutably borrowed, while `BorrowState::Reading` signals
+    /// that it is immutably borrowed.
+    ///
+    /// This is mostly useful in rare use cases with `RefCell::as_ptr` to
+    /// access the data without changing its borrow state, use with care.
     ///
     /// # Examples
     ///
@@ -780,9 +784,9 @@ impl<T: ?Sized> RefCell<T> {
     /// let c = RefCell::new(5);
     ///
     /// match c.borrow_state() {
-    ///     BorrowState::Writing => println!("Cannot be borrowed"),
-    ///     BorrowState::Reading => println!("Cannot be borrowed mutably"),
-    ///     BorrowState::Unused => println!("Can be borrowed (mutably as well)"),
+    ///     BorrowState::Writing => println!("currently borrowed mutably"),
+    ///     BorrowState::Reading => println!("currently borrowed immutably"),
+    ///     BorrowState::Unused => println!("not borrowed"),
     /// }
     /// ```
     #[unstable(feature = "borrow_state", issue = "27733")]

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -572,8 +572,6 @@ pub struct RefCell<T: ?Sized> {
 /// An enumeration of values returned from the `state` method on a `RefCell<T>`.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[unstable(feature = "borrow_state", issue = "27733")]
-#[rustc_deprecated(since = "1.15.0", reason = "use `try_borrow` instead")]
-#[allow(deprecated)]
 pub enum BorrowState {
     /// The cell is currently being read, there is at least one active `borrow`.
     Reading,
@@ -788,8 +786,6 @@ impl<T: ?Sized> RefCell<T> {
     /// }
     /// ```
     #[unstable(feature = "borrow_state", issue = "27733")]
-    #[rustc_deprecated(since = "1.15.0", reason = "use `try_borrow` instead")]
-    #[allow(deprecated)]
     #[inline]
     pub fn borrow_state(&self) -> BorrowState {
         let borrow = self.borrow.get();


### PR DESCRIPTION
*Come sit next to the fireplace with me, this is going to be a long story.*

So, you may already be aware that Servo has weird design constraints that forces us developers working on it to do weird things. The thing that interests us today is that we do layout on a separate thread with its own thread pool to do some things in parallel, whereas the data it uses comes from the script thread, which implements the entire DOM and related pieces, with `!Sync` data types such as `RefCell<T>`.

The invariant we maintain is that script does not do anything ever with the DOM data as long as layout is doing its job. That's all nice and all, but one thing we don't ensure is that we don't actually know if script was currently mutably borrowing some `RefCell<T>` prior to starting layout, which may lead to aliasing mutable memory and obviously undefined behaviour.

This PR reinstates `RefCell::borrow_state` so that [this method](https://github.com/servo/servo/blob/master/components/script/dom/bindings/cell.rs#L23-L30) can make use of it and return `None` if the cell was mutably borrowed.

Cc @SimonSapin 