### PR TITLE
Add x86_64 musl host to the manifest

### DIFF
--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -32,6 +32,7 @@ static HOSTS: &'static [&'static str] = &[
     "x86_64-pc-windows-msvc",
     "x86_64-unknown-freebsd",
     "x86_64-unknown-linux-gnu",
+    "x86_64-unknown-linux-musl",
     "x86_64-unknown-netbsd",
 ];
 


### PR DESCRIPTION
@alexcrichton r?

Probably too late for https://github.com/rust-lang/rust/pull/59207