### PR TITLE
make asm diagnostic instruction optional

### DIFF
--- a/src/librustc_codegen_llvm/llvm/diagnostic.rs
+++ b/src/librustc_codegen_llvm/llvm/diagnostic.rs
@@ -88,7 +88,7 @@ impl OptimizationDiagnostic<'ll> {
 pub struct InlineAsmDiagnostic<'ll> {
     pub cookie: c_uint,
     pub message: &'ll Twine,
-    pub instruction: &'ll Value,
+    pub instruction: Option<&'ll Value>,
 }
 
 impl InlineAsmDiagnostic<'ll> {
@@ -107,7 +107,7 @@ impl InlineAsmDiagnostic<'ll> {
         InlineAsmDiagnostic {
             cookie,
             message: message.unwrap(),
-            instruction: instruction.unwrap(),
+            instruction,
         }
     }
 }

--- a/src/test/ui/issues/issue-23458.rs
+++ b/src/test/ui/issues/issue-23458.rs
@@ -1,0 +1,10 @@
+#![feature(asm)]
+
+// only-x86_64
+
+fn main() {
+    unsafe {
+        asm!("int $3"); //~ ERROR too few operands for instruction
+                        //~| ERROR invalid operand in inline asm
+    }
+}

--- a/src/test/ui/issues/issue-23458.stderr
+++ b/src/test/ui/issues/issue-23458.stderr
@@ -1,0 +1,17 @@
+error: invalid operand in inline asm: 'int $3'
+  --> $DIR/issue-23458.rs:7:9
+   |
+LL |         asm!("int $3");
+   |         ^^^^^^^^^^^^^^^
+
+error: <inline asm>:1:2: error: too few operands for instruction
+        int 
+        ^
+
+  --> $DIR/issue-23458.rs:7:9
+   |
+LL |         asm!("int $3");
+   |         ^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
`DiagnosticInfoInlineAsm::getInstruction` may return a null pointer, so
the instruction shouldn't be blindly unwrapped.

Reopening from #55193. I was unable to trigger the assertion on Windows after rebasing.

Fixes #23458.
Fixes #55216.
