### PR TITLE
filter suggestions from extern prelude

### DIFF
--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -4046,13 +4046,27 @@ impl<'a> Resolver<'a> {
                     } else {
                         // Items from the prelude
                         if !module.no_implicit_prelude {
-                            names.extend(self.extern_prelude.iter().map(|(ident, _)| {
-                                TypoSuggestion {
-                                    candidate: ident.name,
-                                    article: "a",
-                                    kind: "crate",
-                                }
+                            names.extend(self.extern_prelude.clone().iter().flat_map(|(ident, _)| {
+                                self.crate_loader
+                                    .maybe_process_path_extern(ident.name, ident.span)
+                                    .and_then(|crate_id| {
+                                        let crate_mod = Def::Mod(DefId {
+                                            krate: crate_id,
+                                            index: CRATE_DEF_INDEX,
+                                        });
+
+                                        if filter_fn(crate_mod) {
+                                            Some(TypoSuggestion {
+                                                candidate: ident.name,
+                                                article: "a",
+                                                kind: "crate",
+                                            })
+                                        } else {
+                                            None
+                                        }
+                                    })
                             }));
+
                             if let Some(prelude) = self.prelude {
                                 add_module_candidates(prelude, &mut names);
                             }

--- a/src/test/ui/proc-macro/resolve-error.stderr
+++ b/src/test/ui/proc-macro/resolve-error.stderr
@@ -20,7 +20,7 @@ error: cannot find derive macro `attr_proc_macra` in this scope
   --> $DIR/resolve-error.rs:44:10
    |
 LL | #[derive(attr_proc_macra)]
-   |          ^^^^^^^^^^^^^^^ help: try: `attr_proc_macro`
+   |          ^^^^^^^^^^^^^^^
 
 error: cannot find macro `FooWithLongNama!` in this scope
   --> $DIR/resolve-error.rs:49:5

--- a/src/test/ui/suggestions/auxiliary/foo.rs
+++ b/src/test/ui/suggestions/auxiliary/foo.rs
@@ -1,0 +1,3 @@
+//! Contains a struct with almost the same name as itself, to trigger Levenshtein suggestions.
+
+pub struct Foo;

--- a/src/test/ui/suggestions/no-extern-crate-in-type.rs
+++ b/src/test/ui/suggestions/no-extern-crate-in-type.rs
@@ -1,0 +1,7 @@
+// aux-build:foo.rs
+
+extern crate foo;
+
+type Output = Option<Foo>; //~ ERROR cannot find type `Foo`
+
+fn main() {}

--- a/src/test/ui/suggestions/no-extern-crate-in-type.stderr
+++ b/src/test/ui/suggestions/no-extern-crate-in-type.stderr
@@ -1,0 +1,13 @@
+error[E0412]: cannot find type `Foo` in this scope
+  --> $DIR/no-extern-crate-in-type.rs:5:22
+   |
+LL | type Output = Option<Foo>;
+   |                      ^^^ not found in this scope
+help: possible candidate is found in another module, you can import it into scope
+   |
+LL | use foo::Foo;
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0412`.


### PR DESCRIPTION
Fixes #59027.

Modifies the candidate gathering code to call `filter_fn` on extern crates, which causes them to be filtered out when looking for a type.