### PR TITLE
Introduce the assert_matches! macro family

### DIFF
--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -243,7 +243,7 @@ macro_rules! debug_assert_ne {
 ///
 /// # Examples
 ///
-/// ```
+/// ```rust
 /// #![feature(assert_matches)]
 ///
 /// assert_matches!(Some(3), Some(3) | None | Some(2));
@@ -284,7 +284,7 @@ macro_rules! assert_matches {
 ///
 /// # Examples
 ///
-/// ```
+/// ```rust
 /// #![feature(assert_matches)]
 ///
 /// debug_assert_matches!(Some(3), Some(_));

--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -236,6 +236,70 @@ macro_rules! debug_assert_ne {
     ($($arg:tt)*) => (if cfg!(debug_assertions) { assert_ne!($($arg)*); })
 }
 
+/// Asserts that an expression matches a certain pattern.
+///
+/// On panic, this macro will print the debug representation of the expression
+/// with the given pattern.
+///
+/// # Examples
+///
+/// ```
+/// #![feature(assert_matches)]
+///
+/// assert_matches!(Some(3), Some(3) | None | Some(2));
+/// assert_matches!(Err(3), Ok(x) | Err(x) if x >= 3);
+/// ```
+#[macro_export]
+#[unstable(feature = "assert_matches", issue = "0")]
+macro_rules! assert_matches {
+    ($e:expr, $($pat:pat)|+) => {
+        match $e {
+            $($pat)|+ => (),
+            ref e => panic!("assertion failed: `{:?}` does not match `{}`",
+                            e, stringify!($($pat)|+))
+        }
+    };
+    ($e:expr, $($pat:pat)|+ if $cond:expr) => {
+        match $e {
+            $($pat)|+ if $cond => (),
+            ref e => panic!("assertion failed: `{:?}` does not match `{}`",
+                            e, stringify!($($pat)|+ if $cond))
+        }
+    };
+}
+
+/// Asserts that an expression matches a certain pattern.
+///
+/// On panic, this macro will print the debug representation of the expression
+/// with the given pattern.
+///
+/// Unlike [`assert_matches!`], `debug_assert_matches!` statements are only enabled in
+/// non optimized builds by default. An optimized build will omit all
+/// `debug_assert_matches!` statements unless `-C debug-assertions` is passed to the
+/// compiler. This makes `debug_assert_matches!` useful for checks that are too
+/// expensive to be present in a release build but may be helpful during
+/// development.
+///
+/// [`assert_matches!`]: ../std/macro.assert_matches.html
+///
+/// # Examples
+///
+/// ```
+/// #![feature(assert_matches)]
+///
+/// debug_assert_matches!(Some(3), Some(_));
+/// debug_assert_matches!(Err(3), Ok(x) | Err(x) if x >= 3);
+/// ```
+#[macro_export]
+#[unstable(feature = "assert_matches", issue = "0")]
+macro_rules! debug_assert_matches {
+    ($($tt:tt)*) => {{
+        if cfg!(debug_assertions) {
+            assert_matches!($($tt)*);
+        }
+    }}
+}
+
 /// Helper macro for reducing boilerplate code for matching `Result` together
 /// with converting downstream errors.
 ///


### PR DESCRIPTION
This pull request introduce two new macros, the `assert_matches!` and `debug_assert_matches!`.
A new family is born 🎉 

These macros can be very helpful when doing tests, more practical than doing a match and a panic by hand. It could be classified into the same category of tools than the `dgb!` macro or the `std::convert::identity` function:
> [Too small to be a crate. Used often enough to make it into std](https://twitter.com/yoshuawuyts/status/1105833696312074240).

If you wanted to know why I did not use the `?` macro operator it is because it seems that the libcore crate is not under 2018 edition therefore this operator is not available. As a workaround I used a macro that can have two different inputs: one with the `if` guard and the other without it.

[You can test it in the playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=189a909c2026073325a9647ddd5a0df6).

```rust
assert_matches!(Some(3), Some(_));
assert_matches!(Some(3), Some(3) | None | Some(2));

assert_matches!(Err(3), Ok(x) | Err(x) if x >= 3);

assert_matches!(&[3, 4][..], &[3, x] | &[x, 3] if x >= 4);

assert_matches!(3, e @ 0..=3 if e >= 3);
```