### PR TITLE
Add suggestion to use `&*var` when `&str: From<String>` is expected

### DIFF
--- a/src/doc/unstable-book/src/language-features/on-unimplemented.md
+++ b/src/doc/unstable-book/src/language-features/on-unimplemented.md
@@ -138,3 +138,15 @@ error[E0277]: `&str` is not an iterator
   = help: the trait `std::iter::Iterator` is not implemented for `&str`
   = note: required by `std::iter::IntoIterator::into_iter`
 ```
+
+If you need to filter on multiple attributes, you can use `all` in the following way:
+
+```rust,compile_fail
+#[rustc_on_unimplemented(
+    on(
+        all(_Self="&str", T="std::string::String"),
+        note="you can coerce a `{T}` into a `{Self}` by writing `&*variable`"
+    )
+)]
+pub trait From<T>: Sized { /* ... */ }
+```

--- a/src/doc/unstable-book/src/language-features/on-unimplemented.md
+++ b/src/doc/unstable-book/src/language-features/on-unimplemented.md
@@ -139,7 +139,8 @@ error[E0277]: `&str` is not an iterator
   = note: required by `std::iter::IntoIterator::into_iter`
 ```
 
-If you need to filter on multiple attributes, you can use `all` in the following way:
+If you need to filter on multiple attributes, you can use `all`, `any` or
+`not` in the following way:
 
 ```rust,compile_fail
 #[rustc_on_unimplemented(

--- a/src/libcore/convert.rs
+++ b/src/libcore/convert.rs
@@ -355,7 +355,7 @@ pub trait Into<T>: Sized {
 #[rustc_on_unimplemented(
     on(
         all(_Self="&str", T="std::string::String"),
-        note="you can coerce a `{T}` into a `{Self}` by writing `&*variable`"
+        note="to coerce a `{T}` into a `{Self}`, use `&*` as a prefix",
     )
 )]
 pub trait From<T>: Sized {

--- a/src/libcore/convert.rs
+++ b/src/libcore/convert.rs
@@ -352,6 +352,12 @@ pub trait Into<T>: Sized {
 /// [`from`]: trait.From.html#tymethod.from
 /// [book]: ../../book/ch09-00-error-handling.html
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_on_unimplemented(
+    on(
+        all(_Self="&str", T="std::string::String"),
+        note="you can coerce a `{T}` into a `{Self}` by writing `&*variable`"
+    )
+)]
 pub trait From<T>: Sized {
     /// Performs the conversion.
     #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/test/ui/suggestions/into-str.rs
+++ b/src/test/ui/suggestions/into-str.rs
@@ -1,0 +1,6 @@
+fn foo<'a, T>(_t: T) where T: Into<&'a str> {}
+
+fn main() {
+    foo(String::new());
+    //~^ ERROR the trait bound `&str: std::convert::From<std::string::String>` is not satisfied
+}

--- a/src/test/ui/suggestions/into-str.stderr
+++ b/src/test/ui/suggestions/into-str.stderr
@@ -1,0 +1,17 @@
+error[E0277]: the trait bound `&str: std::convert::From<std::string::String>` is not satisfied
+  --> $DIR/into-str.rs:4:5
+   |
+LL |     foo(String::new());
+   |     ^^^ the trait `std::convert::From<std::string::String>` is not implemented for `&str`
+   |
+   = note: you can coerce a `std::string::String` into a `&str` by writing `&*variable`
+   = note: required because of the requirements on the impl of `std::convert::Into<&str>` for `std::string::String`
+note: required by `foo`
+  --> $DIR/into-str.rs:1:1
+   |
+LL | fn foo<'a, T>(_t: T) where T: Into<&'a str> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/suggestions/into-str.stderr
+++ b/src/test/ui/suggestions/into-str.stderr
@@ -4,7 +4,7 @@ error[E0277]: the trait bound `&str: std::convert::From<std::string::String>` is
 LL |     foo(String::new());
    |     ^^^ the trait `std::convert::From<std::string::String>` is not implemented for `&str`
    |
-   = note: you can coerce a `std::string::String` into a `&str` by writing `&*variable`
+   = note: to coerce a `std::string::String` into a `&str`, use `&*` as a prefix
    = note: required because of the requirements on the impl of `std::convert::Into<&str>` for `std::string::String`
 note: required by `foo`
   --> $DIR/into-str.rs:1:1


### PR DESCRIPTION
Fix #53879.