### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -29,6 +29,7 @@ Ariel Ben-Yehuda <arielb1@mail.tau.ac.il> Ariel Ben-Yehuda <ariel.byd@gmail.com>
 Ariel Ben-Yehuda <arielb1@mail.tau.ac.il> arielb1 <arielb1@mail.tau.ac.il>
 Austin Seipp <mad.one@gmail.com> <as@hacks.yi.org>
 Aydin Kim <ladinjin@hanmail.net> aydin.kim <aydin.kim@samsung.com>
+Bastian Kauschke <bastian_kauschke@hotmail.de>
 Barosl Lee <vcs@barosl.com> Barosl LEE <github@barosl.com>
 Ben Alpert <ben@benalpert.com> <spicyjalapeno@gmail.com>
 Ben Sago <ogham@users.noreply.github.com> Ben S <ogham@bsago.me>

--- a/src/ci/docker/dist-powerpc64-linux/build-powerpc64-toolchain.sh
+++ b/src/ci/docker/dist-powerpc64-linux/build-powerpc64-toolchain.sh
@@ -23,7 +23,8 @@ pushd binutils-$TARGET
 curl https://ftp.gnu.org/gnu/binutils/binutils-$BINUTILS.tar.bz2 | tar xjf -
 mkdir binutils-build
 cd binutils-build
-hide_output ../binutils-$BINUTILS/configure --target=$TARGET --prefix=$PREFIX --with-sysroot=$SYSROOT
+hide_output ../binutils-$BINUTILS/configure --target=$TARGET \
+  --prefix=$PREFIX --with-sysroot=$SYSROOT
 hide_output make -j10
 hide_output make install
 popd

--- a/src/ci/docker/dist-powerpc64-linux/build-powerpc64-toolchain.sh
+++ b/src/ci/docker/dist-powerpc64-linux/build-powerpc64-toolchain.sh
@@ -3,9 +3,28 @@ set -ex
 
 source shared.sh
 
+BINUTILS=2.32
+TARGET=powerpc64-unknown-linux-gnu
+PREFIX=/x-tools/$TARGET
+SYSROOT=$PREFIX/$TARGET/sysroot
+
 mkdir build
 cd build
 cp ../powerpc64-linux-gnu.config .config
 hide_output ct-ng build
 cd ..
 rm -rf build
+
+chmod -R u+w $PREFIX
+
+# Next, download and build newer binutils.
+mkdir binutils-$TARGET
+pushd binutils-$TARGET
+curl https://ftp.gnu.org/gnu/binutils/binutils-$BINUTILS.tar.bz2 | tar xjf -
+mkdir binutils-build
+cd binutils-build
+hide_output ../binutils-$BINUTILS/configure --target=$TARGET --prefix=$PREFIX --with-sysroot=$SYSROOT
+hide_output make -j10
+hide_output make install
+popd
+rm -rf binutils-$TARGET

--- a/src/ci/docker/dist-powerpc64le-linux/build-powerpc64le-toolchain.sh
+++ b/src/ci/docker/dist-powerpc64le-linux/build-powerpc64le-toolchain.sh
@@ -4,7 +4,7 @@ set -ex
 
 source shared.sh
 
-BINUTILS=2.25.1
+BINUTILS=2.32
 GCC=5.3.0
 TARGET=powerpc64le-linux-gnu
 SYSROOT=/usr/local/$TARGET/sysroot

--- a/src/librustc/mir/interpret/error.rs
+++ b/src/librustc/mir/interpret/error.rs
@@ -116,7 +116,9 @@ impl<'a, 'gcx, 'tcx> ConstEvalErr<'tcx> {
                     // point to the `const` statement as a secondary span
                     // they don't have any label
                     for sp in primary_spans {
-                        lint.span_label(sp, "");
+                        if sp != span {
+                            lint.span_label(sp, "");
+                        }
                     }
                 }
                 lint.emit();

--- a/src/librustc/mir/interpret/error.rs
+++ b/src/librustc/mir/interpret/error.rs
@@ -100,6 +100,7 @@ impl<'a, 'gcx, 'tcx> ConstEvalErr<'tcx> {
         tcx: TyCtxtAt<'a, 'gcx, 'tcx>,
         message: &str,
         lint_root: hir::HirId,
+        span: Option<Span>,
     ) -> ErrorHandled {
         let lint = self.struct_generic(
             tcx,
@@ -108,6 +109,16 @@ impl<'a, 'gcx, 'tcx> ConstEvalErr<'tcx> {
         );
         match lint {
             Ok(mut lint) => {
+                if let Some(span) = span {
+                    let primary_spans = lint.span.primary_spans().to_vec();
+                    // point at the actual error as the primary span
+                    lint.replace_span_with(span);
+                    // point to the `const` statement as a secondary span
+                    // they don't have any label
+                    for sp in primary_spans {
+                        lint.span_label(sp, "");
+                    }
+                }
                 lint.emit();
                 ErrorHandled::Reported
             },

--- a/src/librustc_driver/pretty.rs
+++ b/src/librustc_driver/pretty.rs
@@ -633,10 +633,20 @@ fn print_flowgraph<'a, 'tcx, W: Write>(variants: Vec<borrowck_dot::Variant>,
     let body = tcx.hir().body(body_id);
     let cfg = cfg::CFG::new(tcx, &body);
     let labelled_edges = mode != PpFlowGraphMode::UnlabelledEdges;
+    let hir_id = code.id();
+    // We have to disassemble the hir_id because name must be ASCII
+    // alphanumeric. This does not appear in the rendered graph, so it does not
+    // have to be user friendly.
+    let name = format!(
+        "hir_id_{}_{}_{}",
+        hir_id.owner.address_space().index(),
+        hir_id.owner.as_array_index(),
+        hir_id.local_id.index(),
+    );
     let lcfg = LabelledCFG {
         tcx,
         cfg: &cfg,
-        name: format!("node_{}", code.id()),
+        name,
         labelled_edges,
     };
 

--- a/src/librustc_errors/diagnostic.rs
+++ b/src/librustc_errors/diagnostic.rs
@@ -366,7 +366,7 @@ impl Diagnostic {
                 }],
             }],
             msg: msg.to_owned(),
-            style: SuggestionStyle::HideCodeInline,
+            style: SuggestionStyle::HideCodeAlways,
             applicability,
         });
         self

--- a/src/librustc_metadata/native_libs.rs
+++ b/src/librustc_metadata/native_libs.rs
@@ -74,7 +74,7 @@ impl<'a, 'tcx> ItemLikeVisitor<'tcx> for Collector<'a, 'tcx> {
                         "dylib" => cstore::NativeUnknown,
                         "framework" => cstore::NativeFramework,
                         k => {
-                            struct_span_err!(self.tcx.sess, item.span, E0458,
+                            struct_span_err!(self.tcx.sess, item.span(), E0458,
                                       "unknown kind: `{}`", k)
                                 .span_label(item.span(), "unknown kind")
                                 .span_label(m.span, "").emit();

--- a/src/librustc_metadata/native_libs.rs
+++ b/src/librustc_metadata/native_libs.rs
@@ -74,9 +74,10 @@ impl<'a, 'tcx> ItemLikeVisitor<'tcx> for Collector<'a, 'tcx> {
                         "dylib" => cstore::NativeUnknown,
                         "framework" => cstore::NativeFramework,
                         k => {
-                            struct_span_err!(self.tcx.sess, m.span, E0458,
+                            struct_span_err!(self.tcx.sess, item.span, E0458,
                                       "unknown kind: `{}`", k)
-                                .span_label(item.span(), "unknown kind").emit();
+                                .span_label(item.span(), "unknown kind")
+                                .span_label(m.span, "").emit();
                             cstore::NativeUnknown
                         }
                     };

--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -156,7 +156,7 @@ fn do_mir_borrowck<'a, 'gcx, 'tcx>(
     let mut flow_inits = FlowAtLocation::new(do_dataflow(
         tcx,
         mir,
-        id,
+        def_id,
         &attributes,
         &dead_unwinds,
         MaybeInitializedPlaces::new(tcx, mir, &mdpe),
@@ -191,7 +191,7 @@ fn do_mir_borrowck<'a, 'gcx, 'tcx>(
     let flow_borrows = FlowAtLocation::new(do_dataflow(
         tcx,
         mir,
-        id,
+        def_id,
         &attributes,
         &dead_unwinds,
         Borrows::new(tcx, mir, regioncx.clone(), &borrow_set),
@@ -200,7 +200,7 @@ fn do_mir_borrowck<'a, 'gcx, 'tcx>(
     let flow_uninits = FlowAtLocation::new(do_dataflow(
         tcx,
         mir,
-        id,
+        def_id,
         &attributes,
         &dead_unwinds,
         MaybeUninitializedPlaces::new(tcx, mir, &mdpe),
@@ -209,7 +209,7 @@ fn do_mir_borrowck<'a, 'gcx, 'tcx>(
     let flow_ever_inits = FlowAtLocation::new(do_dataflow(
         tcx,
         mir,
-        id,
+        def_id,
         &attributes,
         &dead_unwinds,
         EverInitializedPlaces::new(tcx, mir, &mdpe),

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -668,6 +668,7 @@ pub fn const_eval_raw_provider<'a, 'tcx>(
                         tcx.at(tcx.def_span(def_id)),
                         "any use of this value will cause an error",
                         hir_id,
+                        Some(err.span),
                     )
                 },
                 // promoting runtime code is only allowed to error if it references broken constants
@@ -684,6 +685,7 @@ pub fn const_eval_raw_provider<'a, 'tcx>(
                             tcx.at(span),
                             "reaching this expression at runtime will panic or abort",
                             tcx.hir().as_local_hir_id(def_id).unwrap(),
+                            Some(err.span),
                         )
                     }
                 // anything else (array lengths, enum initializers, constant patterns) are reported

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -237,6 +237,7 @@ impl<'a, 'mir, 'tcx> ConstPropagator<'a, 'mir, 'tcx> {
                             self.ecx.tcx,
                             "this expression will panic at runtime",
                             lint_root,
+                            None,
                         );
                     }
                 }

--- a/src/librustc_mir/transform/generator.rs
+++ b/src/librustc_mir/transform/generator.rs
@@ -383,13 +383,13 @@ fn locals_live_across_suspend_points(
     FxHashMap<BasicBlock, liveness::LiveVarSet>,
 ) {
     let dead_unwinds = BitSet::new_empty(mir.basic_blocks().len());
-    let hir_id = tcx.hir().as_local_hir_id(source.def_id()).unwrap();
+    let def_id = source.def_id();
 
     // Calculate when MIR locals have live storage. This gives us an upper bound of their
     // lifetimes.
     let storage_live_analysis = MaybeStorageLive::new(mir);
     let storage_live =
-        do_dataflow(tcx, mir, hir_id, &[], &dead_unwinds, storage_live_analysis,
+        do_dataflow(tcx, mir, def_id, &[], &dead_unwinds, storage_live_analysis,
                     |bd, p| DebugFormatted::new(&bd.mir().local_decls[p]));
 
     // Find the MIR locals which do not use StorageLive/StorageDead statements.
@@ -403,7 +403,7 @@ fn locals_live_across_suspend_points(
     let borrowed_locals = if !movable {
         let analysis = HaveBeenBorrowedLocals::new(mir);
         let result =
-            do_dataflow(tcx, mir, hir_id, &[], &dead_unwinds, analysis,
+            do_dataflow(tcx, mir, def_id, &[], &dead_unwinds, analysis,
                         |bd, p| DebugFormatted::new(&bd.mir().local_decls[p]));
         Some((analysis, result))
     } else {

--- a/src/librustc_mir/util/graphviz.rs
+++ b/src/librustc_mir/util/graphviz.rs
@@ -1,6 +1,7 @@
 use rustc::hir::def_id::DefId;
 use rustc::mir::*;
 use rustc::ty::TyCtxt;
+use rustc_data_structures::indexed_vec::Idx;
 use std::fmt::Debug;
 use std::io::{self, Write};
 
@@ -20,6 +21,17 @@ pub fn write_mir_graphviz<'tcx, W>(tcx: TyCtxt<'_, '_, 'tcx>,
     Ok(())
 }
 
+// Must match `[0-9A-Za-z_]*`. This does not appear in the rendered graph, so
+// it does not have to be user friendly.
+pub fn graphviz_safe_def_name(def_id: DefId) -> String {
+    format!(
+        "{}_{}_{}",
+        def_id.krate.index(),
+        def_id.index.address_space().index(),
+        def_id.index.as_array_index(),
+    )
+}
+
 /// Write a graphviz DOT graph of the MIR.
 pub fn write_mir_fn_graphviz<'tcx, W>(tcx: TyCtxt<'_, '_, 'tcx>,
                                       def_id: DefId,
@@ -27,7 +39,7 @@ pub fn write_mir_fn_graphviz<'tcx, W>(tcx: TyCtxt<'_, '_, 'tcx>,
                                       w: &mut W) -> io::Result<()>
     where W: Write
 {
-    writeln!(w, "digraph Mir_{} {{", tcx.hir().as_local_hir_id(def_id).unwrap())?;
+    writeln!(w, "digraph Mir_{} {{", graphviz_safe_def_name(def_id))?;
 
     // Global graph properties
     writeln!(w, r#"    graph [fontname="monospace"];"#)?;

--- a/src/librustc_mir/util/mod.rs
+++ b/src/librustc_mir/util/mod.rs
@@ -15,7 +15,7 @@ pub mod collect_writes;
 
 pub use self::alignment::is_disaligned;
 pub use self::pretty::{dump_enabled, dump_mir, write_mir_pretty, PassWhere};
-pub use self::graphviz::{write_mir_graphviz};
+pub use self::graphviz::{graphviz_safe_def_name, write_mir_graphviz};
 pub use self::graphviz::write_node_label as write_graphviz_node_label;
 
 /// If possible, suggest replacing `ref` with `ref mut`.

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -5112,7 +5112,7 @@ impl<'a> Resolver<'a> {
                         // extra for the comma.
                         span.lo().0 - (prev_comma.as_bytes().len() as u32) - 1
                     ));
-                    err.span_suggestion(
+                    err.tool_only_span_suggestion(
                         span, message, String::new(), Applicability::MaybeIncorrect,
                     );
                     return;

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -4932,7 +4932,7 @@ impl<'a> Resolver<'a> {
             Some((directive, _, true)) if should_remove_import && !directive.is_glob() => {
                 // Simple case - remove the entire import. Due to the above match arm, this can
                 // only be a single use so just remove it entirely.
-                err.span_suggestion_hidden(
+                err.tool_only_span_suggestion(
                     directive.use_span_with_attributes,
                     "remove unnecessary import",
                     String::new(),

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -4932,7 +4932,7 @@ impl<'a> Resolver<'a> {
             Some((directive, _, true)) if should_remove_import && !directive.is_glob() => {
                 // Simple case - remove the entire import. Due to the above match arm, this can
                 // only be a single use so just remove it entirely.
-                err.span_suggestion(
+                err.span_suggestion_hidden(
                     directive.use_span_with_attributes,
                     "remove unnecessary import",
                     String::new(),

--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -971,7 +971,7 @@ https://doc.rust-lang.org/reference/types.html#trait-objects");
                             self.field_ty(span, f, substs)
                         })
                         .unwrap_or_else(|| {
-                            inexistent_fields.push((span, field.ident));
+                            inexistent_fields.push(field.ident);
                             no_field_errors = false;
                             tcx.types.err
                         })
@@ -987,15 +987,15 @@ https://doc.rust-lang.org/reference/types.html#trait-objects");
                 .collect::<Vec<_>>();
         if inexistent_fields.len() > 0 {
             let (field_names, t, plural) = if inexistent_fields.len() == 1 {
-                (format!("a field named `{}`", inexistent_fields[0].1), "this", "")
+                (format!("a field named `{}`", inexistent_fields[0]), "this", "")
             } else {
                 (format!("fields named {}",
                          inexistent_fields.iter()
-                            .map(|(_, name)| format!("`{}`", name))
+                            .map(|ident| format!("`{}`", ident))
                             .collect::<Vec<String>>()
                             .join(", ")), "these", "s")
             };
-            let spans = inexistent_fields.iter().map(|(span, _)| *span).collect::<Vec<_>>();
+            let spans = inexistent_fields.iter().map(|ident| ident.span).collect::<Vec<_>>();
             let mut err = struct_span_err!(tcx.sess,
                                            spans,
                                            E0026,
@@ -1003,8 +1003,8 @@ https://doc.rust-lang.org/reference/types.html#trait-objects");
                                            kind_name,
                                            tcx.item_path_str(variant.did),
                                            field_names);
-            if let Some((span, ident)) = inexistent_fields.last() {
-                err.span_label(*span,
+            if let Some(ident) = inexistent_fields.last() {
+                err.span_label(ident.span,
                                format!("{} `{}` does not have {} field{}",
                                        kind_name,
                                        tcx.item_path_str(variant.did),
@@ -1016,8 +1016,8 @@ https://doc.rust-lang.org/reference/types.html#trait-objects");
                         find_best_match_for_name(input, &ident.as_str(), None);
                     if let Some(suggested_name) = suggested_name {
                         err.span_suggestion(
-                            *span,
-                            "did you mean",
+                            ident.span,
+                            "a field with a similar name exists",
                             suggested_name.to_string(),
                             Applicability::MaybeIncorrect,
                         );

--- a/src/libstd/net/udp.rs
+++ b/src/libstd/net/udp.rs
@@ -904,6 +904,16 @@ mod tests {
     }
 
     #[test]
+    fn socket_peer_ip4() {
+        each_ip(&mut |addr1, addr2| {
+            let server = t!(UdpSocket::bind(&addr1));
+            assert_eq!(server.peer_addr().unwrap_err().kind(), ErrorKind::NotConnected);
+            t!(server.connect(&addr2));
+            assert_eq!(addr2, t!(server.peer_addr()));
+        })
+    }
+
+    #[test]
     fn udp_clone_smoke() {
         each_ip(&mut |addr1, addr2| {
             let sock1 = t!(UdpSocket::bind(&addr1));

--- a/src/libstd/net/udp.rs
+++ b/src/libstd/net/udp.rs
@@ -193,6 +193,19 @@ impl UdpSocket {
     /// assert_eq!(socket.peer_addr().unwrap(),
     ///            SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(192, 168, 0, 1), 41203)));
     /// ```
+    ///
+    /// If the socket isn't connected, it will return a [`NotConnected`] error.
+    ///
+    /// [`NotConnected`]: ../../std/io/enum.ErrorKind.html#variant.NotConnected
+    ///
+    /// ```no_run
+    /// #![feature(udp_peer_addr)]
+    /// use std::net::UdpSocket;
+    ///
+    /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("couldn't bind to address");
+    /// assert_eq!(socket.peer_addr().unwrap_err().kind(),
+    ///            ::std::io::ErrorKind::NotConnected);
+    /// ```
     #[unstable(feature = "udp_peer_addr", issue = "59127")]
     pub fn peer_addr(&self) -> io::Result<SocketAddr> {
         self.0.peer_addr()

--- a/src/libstd/net/udp.rs
+++ b/src/libstd/net/udp.rs
@@ -896,7 +896,7 @@ mod tests {
     }
 
     #[test]
-    fn socket_name_ip4() {
+    fn socket_name() {
         each_ip(&mut |addr, _| {
             let server = t!(UdpSocket::bind(&addr));
             assert_eq!(addr, t!(server.local_addr()));
@@ -904,7 +904,7 @@ mod tests {
     }
 
     #[test]
-    fn socket_peer_ip4() {
+    fn socket_peer() {
         each_ip(&mut |addr1, addr2| {
             let server = t!(UdpSocket::bind(&addr1));
             assert_eq!(server.peer_addr().unwrap_err().kind(), ErrorKind::NotConnected);

--- a/src/libstd/net/udp.rs
+++ b/src/libstd/net/udp.rs
@@ -180,6 +180,23 @@ impl UdpSocket {
         }
     }
 
+    /// Returns the socket address of the remote peer this socket was connected to.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4, UdpSocket};
+    ///
+    /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("couldn't bind to address");
+    /// socket.connect("192.168.0.1:41203").expect("couldn't connect to address");
+    /// assert_eq!(socket.peer_addr().unwrap(),
+    ///            SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(192, 168, 0, 1), 41203)));
+    /// ```
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub fn peer_addr(&self) -> io::Result<SocketAddr> {
+        self.0.peer_addr()
+    }
+
     /// Returns the socket address that this socket was created from.
     ///
     /// # Examples

--- a/src/libstd/net/udp.rs
+++ b/src/libstd/net/udp.rs
@@ -185,6 +185,7 @@ impl UdpSocket {
     /// # Examples
     ///
     /// ```no_run
+    /// #![feature(udp_peer_addr)]
     /// use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4, UdpSocket};
     ///
     /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("couldn't bind to address");
@@ -192,7 +193,7 @@ impl UdpSocket {
     /// assert_eq!(socket.peer_addr().unwrap(),
     ///            SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(192, 168, 0, 1), 41203)));
     /// ```
-    #[stable(feature = "rust1", since = "1.0.0")]
+    #[unstable(feature = "udp_peer_addr", issue = "59127")]
     pub fn peer_addr(&self) -> io::Result<SocketAddr> {
         self.0.peer_addr()
     }

--- a/src/libstd/sys/cloudabi/shims/net.rs
+++ b/src/libstd/sys/cloudabi/shims/net.rs
@@ -159,6 +159,10 @@ impl UdpSocket {
         unsupported()
     }
 
+    pub fn peer_addr(&self) -> io::Result<SocketAddr> {
+        match self.0 {}
+    }
+
     pub fn socket_addr(&self) -> io::Result<SocketAddr> {
         match self.0 {}
     }

--- a/src/libstd/sys/redox/net/udp.rs
+++ b/src/libstd/sys/redox/net/udp.rs
@@ -72,6 +72,11 @@ impl UdpSocket {
         Ok(None)
     }
 
+    pub fn peer_addr(&self) -> Result<SocketAddr> {
+        let path = self.0.path()?;
+        Ok(path_to_peer_addr(path.to_str().unwrap_or("")))
+    }
+
     pub fn socket_addr(&self) -> Result<SocketAddr> {
         let path = self.0.path()?;
         Ok(path_to_local_addr(path.to_str().unwrap_or("")))

--- a/src/libstd/sys/sgx/net.rs
+++ b/src/libstd/sys/sgx/net.rs
@@ -257,6 +257,10 @@ impl UdpSocket {
         unsupported()
     }
 
+    pub fn peer_addr(&self) -> io::Result<SocketAddr> {
+        match self.0 {}
+    }
+
     pub fn socket_addr(&self) -> io::Result<SocketAddr> {
         match self.0 {}
     }

--- a/src/libstd/sys/unix/l4re.rs
+++ b/src/libstd/sys/unix/l4re.rs
@@ -292,6 +292,10 @@ pub mod net {
 
         pub fn into_socket(self) -> Socket { self.inner }
 
+        pub fn peer_addr(&self) -> io::Result<SocketAddr> {
+            unimpl!();
+        }
+
         pub fn socket_addr(&self) -> io::Result<SocketAddr> {
             unimpl!();
         }
@@ -463,4 +467,3 @@ pub mod net {
         }
     }
 }
-

--- a/src/libstd/sys/wasm/net.rs
+++ b/src/libstd/sys/wasm/net.rs
@@ -156,6 +156,10 @@ impl UdpSocket {
         unsupported()
     }
 
+    pub fn peer_addr(&self) -> io::Result<SocketAddr> {
+        match self.0 {}
+    }
+
     pub fn socket_addr(&self) -> io::Result<SocketAddr> {
         match self.0 {}
     }

--- a/src/libstd/sys_common/net.rs
+++ b/src/libstd/sys_common/net.rs
@@ -472,6 +472,12 @@ impl UdpSocket {
 
     pub fn into_socket(self) -> Socket { self.inner }
 
+    pub fn peer_addr(&self) -> io::Result<SocketAddr> {
+        sockname(|buf, len| unsafe {
+            c::getpeername(*self.inner.as_inner(), buf, len)
+        })
+    }
+
     pub fn socket_addr(&self) -> io::Result<SocketAddr> {
         sockname(|buf, len| unsafe {
             c::getsockname(*self.inner.as_inner(), buf, len)

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -5599,8 +5599,14 @@ impl<'a> Parser<'a> {
 
         if !negative_bounds.is_empty() || was_negative {
             let plural = negative_bounds.len() > 1;
-            let mut err = self.struct_span_err(negative_bounds,
-                                               "negative trait bounds are not supported");
+            let last_span = negative_bounds.last().map(|sp| *sp);
+            let mut err = self.struct_span_err(
+                negative_bounds,
+                "negative trait bounds are not supported",
+            );
+            if let Some(sp) = last_span {
+                err.span_label(sp, "negative trait bounds are not supported");
+            }
             if let Some(bound_list) = colon_span {
                 let bound_list = bound_list.to(self.prev_span);
                 let mut new_bound_list = String::new();
@@ -5613,11 +5619,12 @@ impl<'a> Parser<'a> {
                     }
                     new_bound_list = new_bound_list.replacen(" +", ":", 1);
                 }
-                err.span_suggestion_short(bound_list,
-                                        &format!("remove the trait bound{}",
-                                                if plural { "s" } else { "" }),
-                                        new_bound_list,
-                                        Applicability::MachineApplicable);
+                err.span_suggestion_hidden(
+                    bound_list,
+                    &format!("remove the trait bound{}", if plural { "s" } else { "" }),
+                    new_bound_list,
+                    Applicability::MachineApplicable,
+                );
             }
             err.emit();
         }

--- a/src/libsyntax/tokenstream.rs
+++ b/src/libsyntax/tokenstream.rs
@@ -181,8 +181,8 @@ impl TokenStream {
                         (_, (TokenTree::Token(_, token::Token::Comma), _)) => continue,
                         ((TokenTree::Token(sp, token_left), NonJoint),
                          (TokenTree::Token(_, token_right), _))
-                        if token_left.is_ident() || token_left.is_lit() &&
-                            token_right.is_ident() || token_right.is_lit() => *sp,
+                        if (token_left.is_ident() || token_left.is_lit()) &&
+                            (token_right.is_ident() || token_right.is_lit()) => *sp,
                         ((TokenTree::Delimited(sp, ..), NonJoint), _) => sp.entire(),
                         _ => continue,
                     };

--- a/src/libsyntax/tokenstream.rs
+++ b/src/libsyntax/tokenstream.rs
@@ -178,9 +178,11 @@ impl TokenStream {
             while let Some((pos, ts)) = iter.next() {
                 if let Some((_, next)) = iter.peek() {
                     let sp = match (&ts, &next) {
-                        ((TokenTree::Token(_, token::Token::Comma), NonJoint), _) |
-                        (_, (TokenTree::Token(_, token::Token::Comma), NonJoint)) => continue,
-                        ((TokenTree::Token(sp, _), NonJoint), _) => *sp,
+                        (_, (TokenTree::Token(_, token::Token::Comma), _)) => continue,
+                        ((TokenTree::Token(sp, token_left), NonJoint),
+                         (TokenTree::Token(_, token_right), _))
+                        if token_left.is_ident() || token_left.is_lit() &&
+                            token_right.is_ident() || token_right.is_lit() => *sp,
                         ((TokenTree::Delimited(sp, ..), NonJoint), _) => sp.entire(),
                         _ => continue,
                     };

--- a/src/test/mir-opt/graphviz.rs
+++ b/src/test/mir-opt/graphviz.rs
@@ -1,0 +1,23 @@
+// Test graphviz output
+// compile-flags: -Z dump-mir-graphviz
+
+// ignore-tidy-linelength
+
+fn main() {}
+
+// END RUST SOURCE
+// START rustc.main.mir_map.0.dot
+// digraph Mir_0_0_3 { // The name here MUST be an ASCII identifier.
+//     graph [fontname="monospace"];
+//     node [fontname="monospace"];
+//     edge [fontname="monospace"];
+//     label=<fn main() -&gt; ()<br align="left"/>>;
+//     bb0 [shape="none", label=<<table border="0" cellborder="1" cellspacing="0"><tr><td bgcolor="gray" align="center" colspan="1">0</td></tr><tr><td align="left" balign="left">_0 = ()<br/></td></tr><tr><td align="left">goto</td></tr></table>
+// >];
+//     bb1 [shape="none", label=<<table border="0" cellborder="1" cellspacing="0"><tr><td bgcolor="gray" align="center" colspan="1">1</td></tr><tr><td align="left">resume</td></tr></table>
+// >];
+//     bb2 [shape="none", label=<<table border="0" cellborder="1" cellspacing="0"><tr><td bgcolor="gray" align="center" colspan="1">2</td></tr><tr><td align="left">return</td></tr></table>
+// >];
+//     bb0 -> bb2 [label=""];
+// }
+// END rustc.main.mir_map.0.dot

--- a/src/test/ui/array_const_index-0.stderr
+++ b/src/test/ui/array_const_index-0.stderr
@@ -1,8 +1,8 @@
 error: any use of this value will cause an error
-  --> $DIR/array_const_index-0.rs:2:1
+  --> $DIR/array_const_index-0.rs:2:16
    |
 LL | const B: i32 = (&A)[1];
-   | ^^^^^^^^^^^^^^^-------^
+   | ---------------^^^^^^^-
    |                |
    |                index out of bounds: the len is 0 but the index is 1
    |

--- a/src/test/ui/array_const_index-1.stderr
+++ b/src/test/ui/array_const_index-1.stderr
@@ -1,8 +1,8 @@
 error: any use of this value will cause an error
-  --> $DIR/array_const_index-1.rs:2:1
+  --> $DIR/array_const_index-1.rs:2:16
    |
 LL | const B: i32 = A[1];
-   | ^^^^^^^^^^^^^^^----^
+   | ---------------^^^^-
    |                |
    |                index out of bounds: the len is 0 but the index is 1
    |

--- a/src/test/ui/associated-const/associated-const-no-item.stderr
+++ b/src/test/ui/associated-const/associated-const-no-item.stderr
@@ -2,9 +2,7 @@ error[E0599]: no associated item named `ID` found for type `i32` in the current 
   --> $DIR/associated-const-no-item.rs:5:23
    |
 LL | const X: i32 = <i32>::ID;
-   |                -------^^
-   |                |
-   |                associated item not found in `i32`
+   |                       ^^ associated item not found in `i32`
    |
    = help: items from traits can only be used if the trait is implemented and in scope
    = note: the following trait defines an item `ID`, perhaps you need to implement it:

--- a/src/test/ui/bad/bad-extern-link-attrs.stderr
+++ b/src/test/ui/bad/bad-extern-link-attrs.stderr
@@ -11,10 +11,10 @@ LL | #[link(name = "")]
    | ^^^^^^^^^^^^^^^^^^ empty name given
 
 error[E0458]: unknown kind: `bar`
-  --> $DIR/bad-extern-link-attrs.rs:4:1
+  --> $DIR/bad-extern-link-attrs.rs:4:22
    |
 LL | #[link(name = "foo", kind = "bar")]
-   | ^^^^^^^^^^^^^^^^^^^^^------------^^
+   | ---------------------^^^^^^^^^^^^--
    |                      |
    |                      unknown kind
 

--- a/src/test/ui/bogus-tag.stderr
+++ b/src/test/ui/bogus-tag.stderr
@@ -5,7 +5,7 @@ LL | enum Color { Rgb(isize, isize, isize), Rgba(isize, isize, isize, isize), }
    | ---------- variant `Hsl` not found here
 ...
 LL |         Color::Hsl(h, s, l) => { println!("hsl"); }
-   |         -------^^^--------- variant not found in `Color`
+   |                ^^^ variant not found in `Color`
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-err-early.stderr
+++ b/src/test/ui/consts/const-err-early.stderr
@@ -1,8 +1,8 @@
 error: any use of this value will cause an error
-  --> $DIR/const-err-early.rs:3:1
+  --> $DIR/const-err-early.rs:3:19
    |
 LL | pub const A: i8 = -std::i8::MIN;
-   | ^^^^^^^^^^^^^^^^^^-------------^
+   | ------------------^^^^^^^^^^^^^-
    |                   |
    |                   attempt to negate with overflow
    |
@@ -13,34 +13,34 @@ LL | #![deny(const_err)]
    |         ^^^^^^^^^
 
 error: any use of this value will cause an error
-  --> $DIR/const-err-early.rs:4:1
+  --> $DIR/const-err-early.rs:4:19
    |
 LL | pub const B: u8 = 200u8 + 200u8;
-   | ^^^^^^^^^^^^^^^^^^-------------^
+   | ------------------^^^^^^^^^^^^^-
    |                   |
    |                   attempt to add with overflow
 
 error: any use of this value will cause an error
-  --> $DIR/const-err-early.rs:5:1
+  --> $DIR/const-err-early.rs:5:19
    |
 LL | pub const C: u8 = 200u8 * 4;
-   | ^^^^^^^^^^^^^^^^^^---------^
+   | ------------------^^^^^^^^^-
    |                   |
    |                   attempt to multiply with overflow
 
 error: any use of this value will cause an error
-  --> $DIR/const-err-early.rs:6:1
+  --> $DIR/const-err-early.rs:6:19
    |
 LL | pub const D: u8 = 42u8 - (42u8 + 1);
-   | ^^^^^^^^^^^^^^^^^^-----------------^
+   | ------------------^^^^^^^^^^^^^^^^^-
    |                   |
    |                   attempt to subtract with overflow
 
 error: any use of this value will cause an error
-  --> $DIR/const-err-early.rs:7:1
+  --> $DIR/const-err-early.rs:7:19
    |
 LL | pub const E: u8 = [5u8][1];
-   | ^^^^^^^^^^^^^^^^^^--------^
+   | ------------------^^^^^^^^-
    |                   |
    |                   index out of bounds: the len is 1 but the index is 1
 

--- a/src/test/ui/consts/const-err-multi.stderr
+++ b/src/test/ui/consts/const-err-multi.stderr
@@ -1,8 +1,8 @@
 error: any use of this value will cause an error
-  --> $DIR/const-err-multi.rs:3:1
+  --> $DIR/const-err-multi.rs:3:19
    |
 LL | pub const A: i8 = -std::i8::MIN;
-   | ^^^^^^^^^^^^^^^^^^-------------^
+   | ------------------^^^^^^^^^^^^^-
    |                   |
    |                   attempt to negate with overflow
    |
@@ -13,26 +13,26 @@ LL | #![deny(const_err)]
    |         ^^^^^^^^^
 
 error: any use of this value will cause an error
-  --> $DIR/const-err-multi.rs:5:1
+  --> $DIR/const-err-multi.rs:5:19
    |
 LL | pub const B: i8 = A;
-   | ^^^^^^^^^^^^^^^^^^-^
+   | ------------------^-
    |                   |
    |                   referenced constant has errors
 
 error: any use of this value will cause an error
-  --> $DIR/const-err-multi.rs:7:1
+  --> $DIR/const-err-multi.rs:7:19
    |
 LL | pub const C: u8 = A as u8;
-   | ^^^^^^^^^^^^^^^^^^-------^
+   | ------------------^^^^^^^-
    |                   |
    |                   referenced constant has errors
 
 error: any use of this value will cause an error
-  --> $DIR/const-err-multi.rs:9:1
+  --> $DIR/const-err-multi.rs:9:19
    |
 LL | pub const D: i8 = 50 - A;
-   | ^^^^^^^^^^^^^^^^^^------^
+   | ------------------^^^^^^-
    |                   |
    |                   referenced constant has errors
 

--- a/src/test/ui/consts/const-err.stderr
+++ b/src/test/ui/consts/const-err.stderr
@@ -1,8 +1,8 @@
 warning: any use of this value will cause an error
-  --> $DIR/const-err.rs:10:1
+  --> $DIR/const-err.rs:10:17
    |
 LL | const FOO: u8 = [5u8][1];
-   | ^^^^^^^^^^^^^^^^--------^
+   | ----------------^^^^^^^^-
    |                 |
    |                 index out of bounds: the len is 1 but the index is 1
    |

--- a/src/test/ui/consts/const-eval/conditional_array_execution.stderr
+++ b/src/test/ui/consts/const-eval/conditional_array_execution.stderr
@@ -1,8 +1,8 @@
 warning: any use of this value will cause an error
-  --> $DIR/conditional_array_execution.rs:5:1
+  --> $DIR/conditional_array_execution.rs:5:19
    |
 LL | const FOO: u32 = [X - Y, Y - X][(X < Y) as usize];
-   | ^^^^^^^^^^^^^^^^^^-----^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ------------------^^^^^---------------------------
    |                   |
    |                   attempt to subtract with overflow
    |

--- a/src/test/ui/consts/const-eval/const-eval-overflow2.rs
+++ b/src/test/ui/consts/const-eval/const-eval-overflow2.rs
@@ -11,43 +11,51 @@ use std::fmt;
 use std::{i8, i16, i32, i64, isize};
 use std::{u8, u16, u32, u64, usize};
 
-const VALS_I8: (i8,) = //~ ERROR any use of this value will cause an error
+const VALS_I8: (i8,) =
     (
      i8::MIN - 1,
      );
+ //~^^ ERROR any use of this value will cause an error
 
-const VALS_I16: (i16,) = //~ ERROR any use of this value will cause an error
+const VALS_I16: (i16,) =
     (
      i16::MIN - 1,
      );
+ //~^^ ERROR any use of this value will cause an error
 
-const VALS_I32: (i32,) = //~ ERROR any use of this value will cause an error
+const VALS_I32: (i32,) =
     (
      i32::MIN - 1,
      );
+ //~^^ ERROR any use of this value will cause an error
 
-const VALS_I64: (i64,) = //~ ERROR any use of this value will cause an error
+const VALS_I64: (i64,) =
     (
      i64::MIN - 1,
      );
+ //~^^ ERROR any use of this value will cause an error
 
-const VALS_U8: (u8,) = //~ ERROR any use of this value will cause an error
+const VALS_U8: (u8,) =
     (
      u8::MIN - 1,
      );
+ //~^^ ERROR any use of this value will cause an error
 
-const VALS_U16: (u16,) = ( //~ ERROR any use of this value will cause an error
+const VALS_U16: (u16,) = (
      u16::MIN - 1,
      );
+ //~^^ ERROR any use of this value will cause an error
 
-const VALS_U32: (u32,) = ( //~ ERROR any use of this value will cause an error
+const VALS_U32: (u32,) = (
      u32::MIN - 1,
      );
+ //~^^ ERROR any use of this value will cause an error
 
-const VALS_U64: (u64,) = //~ ERROR any use of this value will cause an error
+const VALS_U64: (u64,) =
     (
      u64::MIN - 1,
      );
+ //~^^ ERROR any use of this value will cause an error
 
 fn main() {
     foo(VALS_I8);

--- a/src/test/ui/consts/const-eval/const-eval-overflow2.stderr
+++ b/src/test/ui/consts/const-eval/const-eval-overflow2.stderr
@@ -1,12 +1,12 @@
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2.rs:14:1
+  --> $DIR/const-eval-overflow2.rs:16:6
    |
 LL | / const VALS_I8: (i8,) =
 LL | |     (
 LL | |      i8::MIN - 1,
-   | |      ----------- attempt to subtract with overflow
+   | |      ^^^^^^^^^^^ attempt to subtract with overflow
 LL | |      );
-   | |_______^
+   | |_______-
    |
 note: lint level defined here
   --> $DIR/const-eval-overflow2.rs:8:9
@@ -15,72 +15,72 @@ LL | #![deny(const_err)]
    |         ^^^^^^^^^
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2.rs:19:1
+  --> $DIR/const-eval-overflow2.rs:22:6
    |
 LL | / const VALS_I16: (i16,) =
 LL | |     (
 LL | |      i16::MIN - 1,
-   | |      ------------ attempt to subtract with overflow
+   | |      ^^^^^^^^^^^^ attempt to subtract with overflow
 LL | |      );
-   | |_______^
+   | |_______-
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2.rs:24:1
+  --> $DIR/const-eval-overflow2.rs:28:6
    |
 LL | / const VALS_I32: (i32,) =
 LL | |     (
 LL | |      i32::MIN - 1,
-   | |      ------------ attempt to subtract with overflow
+   | |      ^^^^^^^^^^^^ attempt to subtract with overflow
 LL | |      );
-   | |_______^
+   | |_______-
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2.rs:29:1
+  --> $DIR/const-eval-overflow2.rs:34:6
    |
 LL | / const VALS_I64: (i64,) =
 LL | |     (
 LL | |      i64::MIN - 1,
-   | |      ------------ attempt to subtract with overflow
+   | |      ^^^^^^^^^^^^ attempt to subtract with overflow
 LL | |      );
-   | |_______^
+   | |_______-
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2.rs:34:1
+  --> $DIR/const-eval-overflow2.rs:40:6
    |
 LL | / const VALS_U8: (u8,) =
 LL | |     (
 LL | |      u8::MIN - 1,
-   | |      ----------- attempt to subtract with overflow
+   | |      ^^^^^^^^^^^ attempt to subtract with overflow
 LL | |      );
-   | |_______^
+   | |_______-
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2.rs:39:1
+  --> $DIR/const-eval-overflow2.rs:45:6
    |
 LL | / const VALS_U16: (u16,) = (
 LL | |      u16::MIN - 1,
-   | |      ------------ attempt to subtract with overflow
+   | |      ^^^^^^^^^^^^ attempt to subtract with overflow
 LL | |      );
-   | |_______^
+   | |_______-
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2.rs:43:1
+  --> $DIR/const-eval-overflow2.rs:50:6
    |
 LL | / const VALS_U32: (u32,) = (
 LL | |      u32::MIN - 1,
-   | |      ------------ attempt to subtract with overflow
+   | |      ^^^^^^^^^^^^ attempt to subtract with overflow
 LL | |      );
-   | |_______^
+   | |_______-
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2.rs:47:1
+  --> $DIR/const-eval-overflow2.rs:56:6
    |
 LL | / const VALS_U64: (u64,) =
 LL | |     (
 LL | |      u64::MIN - 1,
-   | |      ------------ attempt to subtract with overflow
+   | |      ^^^^^^^^^^^^ attempt to subtract with overflow
 LL | |      );
-   | |_______^
+   | |_______-
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/consts/const-eval/const-eval-overflow2b.rs
+++ b/src/test/ui/consts/const-eval/const-eval-overflow2b.rs
@@ -11,43 +11,51 @@ use std::fmt;
 use std::{i8, i16, i32, i64, isize};
 use std::{u8, u16, u32, u64, usize};
 
-const VALS_I8: (i8,) = //~ ERROR any use of this value will cause an error
+const VALS_I8: (i8,) =
     (
      i8::MAX + 1,
      );
+ //~^^ ERROR any use of this value will cause an error
 
-const VALS_I16: (i16,) = //~ ERROR any use of this value will cause an error
+const VALS_I16: (i16,) =
     (
      i16::MAX + 1,
      );
+ //~^^ ERROR any use of this value will cause an error
 
-const VALS_I32: (i32,) = //~ ERROR any use of this value will cause an error
+const VALS_I32: (i32,) =
     (
      i32::MAX + 1,
      );
+ //~^^ ERROR any use of this value will cause an error
 
-const VALS_I64: (i64,) = //~ ERROR any use of this value will cause an error
+const VALS_I64: (i64,) =
     (
      i64::MAX + 1,
      );
+ //~^^ ERROR any use of this value will cause an error
 
-const VALS_U8: (u8,) = //~ ERROR any use of this value will cause an error
+const VALS_U8: (u8,) =
     (
      u8::MAX + 1,
      );
+ //~^^ ERROR any use of this value will cause an error
 
-const VALS_U16: (u16,) = ( //~ ERROR any use of this value will cause an error
+const VALS_U16: (u16,) = (
      u16::MAX + 1,
      );
+ //~^^ ERROR any use of this value will cause an error
 
-const VALS_U32: (u32,) = ( //~ ERROR any use of this value will cause an error
+const VALS_U32: (u32,) = (
      u32::MAX + 1,
      );
+ //~^^ ERROR any use of this value will cause an error
 
-const VALS_U64: (u64,) = //~ ERROR any use of this value will cause an error
+const VALS_U64: (u64,) =
     (
      u64::MAX + 1,
      );
+ //~^^ ERROR any use of this value will cause an error
 
 fn main() {
     foo(VALS_I8);

--- a/src/test/ui/consts/const-eval/const-eval-overflow2b.stderr
+++ b/src/test/ui/consts/const-eval/const-eval-overflow2b.stderr
@@ -1,12 +1,12 @@
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2b.rs:14:1
+  --> $DIR/const-eval-overflow2b.rs:16:6
    |
 LL | / const VALS_I8: (i8,) =
 LL | |     (
 LL | |      i8::MAX + 1,
-   | |      ----------- attempt to add with overflow
+   | |      ^^^^^^^^^^^ attempt to add with overflow
 LL | |      );
-   | |_______^
+   | |_______-
    |
 note: lint level defined here
   --> $DIR/const-eval-overflow2b.rs:8:9
@@ -15,72 +15,72 @@ LL | #![deny(const_err)]
    |         ^^^^^^^^^
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2b.rs:19:1
+  --> $DIR/const-eval-overflow2b.rs:22:6
    |
 LL | / const VALS_I16: (i16,) =
 LL | |     (
 LL | |      i16::MAX + 1,
-   | |      ------------ attempt to add with overflow
+   | |      ^^^^^^^^^^^^ attempt to add with overflow
 LL | |      );
-   | |_______^
+   | |_______-
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2b.rs:24:1
+  --> $DIR/const-eval-overflow2b.rs:28:6
    |
 LL | / const VALS_I32: (i32,) =
 LL | |     (
 LL | |      i32::MAX + 1,
-   | |      ------------ attempt to add with overflow
+   | |      ^^^^^^^^^^^^ attempt to add with overflow
 LL | |      );
-   | |_______^
+   | |_______-
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2b.rs:29:1
+  --> $DIR/const-eval-overflow2b.rs:34:6
    |
 LL | / const VALS_I64: (i64,) =
 LL | |     (
 LL | |      i64::MAX + 1,
-   | |      ------------ attempt to add with overflow
+   | |      ^^^^^^^^^^^^ attempt to add with overflow
 LL | |      );
-   | |_______^
+   | |_______-
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2b.rs:34:1
+  --> $DIR/const-eval-overflow2b.rs:40:6
    |
 LL | / const VALS_U8: (u8,) =
 LL | |     (
 LL | |      u8::MAX + 1,
-   | |      ----------- attempt to add with overflow
+   | |      ^^^^^^^^^^^ attempt to add with overflow
 LL | |      );
-   | |_______^
+   | |_______-
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2b.rs:39:1
+  --> $DIR/const-eval-overflow2b.rs:45:6
    |
 LL | / const VALS_U16: (u16,) = (
 LL | |      u16::MAX + 1,
-   | |      ------------ attempt to add with overflow
+   | |      ^^^^^^^^^^^^ attempt to add with overflow
 LL | |      );
-   | |_______^
+   | |_______-
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2b.rs:43:1
+  --> $DIR/const-eval-overflow2b.rs:50:6
    |
 LL | / const VALS_U32: (u32,) = (
 LL | |      u32::MAX + 1,
-   | |      ------------ attempt to add with overflow
+   | |      ^^^^^^^^^^^^ attempt to add with overflow
 LL | |      );
-   | |_______^
+   | |_______-
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2b.rs:47:1
+  --> $DIR/const-eval-overflow2b.rs:56:6
    |
 LL | / const VALS_U64: (u64,) =
 LL | |     (
 LL | |      u64::MAX + 1,
-   | |      ------------ attempt to add with overflow
+   | |      ^^^^^^^^^^^^ attempt to add with overflow
 LL | |      );
-   | |_______^
+   | |_______-
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/consts/const-eval/const-eval-overflow2c.rs
+++ b/src/test/ui/consts/const-eval/const-eval-overflow2c.rs
@@ -11,43 +11,51 @@ use std::fmt;
 use std::{i8, i16, i32, i64, isize};
 use std::{u8, u16, u32, u64, usize};
 
-const VALS_I8: (i8,) = //~ ERROR any use of this value will cause an error
+const VALS_I8: (i8,) =
     (
      i8::MIN * 2,
      );
+ //~^^ ERROR any use of this value will cause an error
 
-const VALS_I16: (i16,) = //~ ERROR any use of this value will cause an error
+const VALS_I16: (i16,) =
     (
      i16::MIN * 2,
      );
+ //~^^ ERROR any use of this value will cause an error
 
-const VALS_I32: (i32,) = //~ ERROR any use of this value will cause an error
+const VALS_I32: (i32,) =
     (
      i32::MIN * 2,
      );
+ //~^^ ERROR any use of this value will cause an error
 
-const VALS_I64: (i64,) = //~ ERROR any use of this value will cause an error
+const VALS_I64: (i64,) =
     (
      i64::MIN * 2,
      );
+ //~^^ ERROR any use of this value will cause an error
 
-const VALS_U8: (u8,) = //~ ERROR any use of this value will cause an error
+const VALS_U8: (u8,) =
     (
      u8::MAX * 2,
      );
+ //~^^ ERROR any use of this value will cause an error
 
-const VALS_U16: (u16,) = ( //~ ERROR any use of this value will cause an error
+const VALS_U16: (u16,) = (
      u16::MAX * 2,
      );
+ //~^^ ERROR any use of this value will cause an error
 
-const VALS_U32: (u32,) = ( //~ ERROR any use of this value will cause an error
+const VALS_U32: (u32,) = (
      u32::MAX * 2,
      );
+ //~^^ ERROR any use of this value will cause an error
 
-const VALS_U64: (u64,) = //~ ERROR any use of this value will cause an error
+const VALS_U64: (u64,) =
     (
      u64::MAX * 2,
      );
+ //~^^ ERROR any use of this value will cause an error
 
 fn main() {
     foo(VALS_I8);

--- a/src/test/ui/consts/const-eval/const-eval-overflow2c.stderr
+++ b/src/test/ui/consts/const-eval/const-eval-overflow2c.stderr
@@ -1,12 +1,12 @@
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2c.rs:14:1
+  --> $DIR/const-eval-overflow2c.rs:16:6
    |
 LL | / const VALS_I8: (i8,) =
 LL | |     (
 LL | |      i8::MIN * 2,
-   | |      ----------- attempt to multiply with overflow
+   | |      ^^^^^^^^^^^ attempt to multiply with overflow
 LL | |      );
-   | |_______^
+   | |_______-
    |
 note: lint level defined here
   --> $DIR/const-eval-overflow2c.rs:8:9
@@ -15,72 +15,72 @@ LL | #![deny(const_err)]
    |         ^^^^^^^^^
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2c.rs:19:1
+  --> $DIR/const-eval-overflow2c.rs:22:6
    |
 LL | / const VALS_I16: (i16,) =
 LL | |     (
 LL | |      i16::MIN * 2,
-   | |      ------------ attempt to multiply with overflow
+   | |      ^^^^^^^^^^^^ attempt to multiply with overflow
 LL | |      );
-   | |_______^
+   | |_______-
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2c.rs:24:1
+  --> $DIR/const-eval-overflow2c.rs:28:6
    |
 LL | / const VALS_I32: (i32,) =
 LL | |     (
 LL | |      i32::MIN * 2,
-   | |      ------------ attempt to multiply with overflow
+   | |      ^^^^^^^^^^^^ attempt to multiply with overflow
 LL | |      );
-   | |_______^
+   | |_______-
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2c.rs:29:1
+  --> $DIR/const-eval-overflow2c.rs:34:6
    |
 LL | / const VALS_I64: (i64,) =
 LL | |     (
 LL | |      i64::MIN * 2,
-   | |      ------------ attempt to multiply with overflow
+   | |      ^^^^^^^^^^^^ attempt to multiply with overflow
 LL | |      );
-   | |_______^
+   | |_______-
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2c.rs:34:1
+  --> $DIR/const-eval-overflow2c.rs:40:6
    |
 LL | / const VALS_U8: (u8,) =
 LL | |     (
 LL | |      u8::MAX * 2,
-   | |      ----------- attempt to multiply with overflow
+   | |      ^^^^^^^^^^^ attempt to multiply with overflow
 LL | |      );
-   | |_______^
+   | |_______-
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2c.rs:39:1
+  --> $DIR/const-eval-overflow2c.rs:45:6
    |
 LL | / const VALS_U16: (u16,) = (
 LL | |      u16::MAX * 2,
-   | |      ------------ attempt to multiply with overflow
+   | |      ^^^^^^^^^^^^ attempt to multiply with overflow
 LL | |      );
-   | |_______^
+   | |_______-
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2c.rs:43:1
+  --> $DIR/const-eval-overflow2c.rs:50:6
    |
 LL | / const VALS_U32: (u32,) = (
 LL | |      u32::MAX * 2,
-   | |      ------------ attempt to multiply with overflow
+   | |      ^^^^^^^^^^^^ attempt to multiply with overflow
 LL | |      );
-   | |_______^
+   | |_______-
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2c.rs:47:1
+  --> $DIR/const-eval-overflow2c.rs:56:6
    |
 LL | / const VALS_U64: (u64,) =
 LL | |     (
 LL | |      u64::MAX * 2,
-   | |      ------------ attempt to multiply with overflow
+   | |      ^^^^^^^^^^^^ attempt to multiply with overflow
 LL | |      );
-   | |_______^
+   | |_______-
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/consts/const-eval/const-pointer-values-in-various-types.stderr
+++ b/src/test/ui/consts/const-eval/const-pointer-values-in-various-types.stderr
@@ -7,28 +7,28 @@ LL |     const I32_REF_USIZE_UNION: usize = unsafe { Nonsense { int_32_ref: &3 }
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 
 error: any use of this value will cause an error
-  --> $DIR/const-pointer-values-in-various-types.rs:27:5
+  --> $DIR/const-pointer-values-in-various-types.rs:27:43
    |
 LL |     const I32_REF_U8_UNION: u8 = unsafe { Nonsense { int_32_ref: &3 }.uint_8 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^----------------------------------^^^
+   |     --------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                           |
    |                                           a raw memory access tried to access part of a pointer value as raw bytes
    |
    = note: #[deny(const_err)] on by default
 
 error: any use of this value will cause an error
-  --> $DIR/const-pointer-values-in-various-types.rs:30:5
+  --> $DIR/const-pointer-values-in-various-types.rs:30:45
    |
 LL |     const I32_REF_U16_UNION: u16 = unsafe { Nonsense { int_32_ref: &3 }.uint_16 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------------------------------^^^
+   |     ----------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                             |
    |                                             a raw memory access tried to access part of a pointer value as raw bytes
 
 error: any use of this value will cause an error
-  --> $DIR/const-pointer-values-in-various-types.rs:33:5
+  --> $DIR/const-pointer-values-in-various-types.rs:33:45
    |
 LL |     const I32_REF_U32_UNION: u32 = unsafe { Nonsense { int_32_ref: &3 }.uint_32 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------------------------------^^^
+   |     ----------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                             |
    |                                             a raw memory access tried to access part of a pointer value as raw bytes
 
@@ -49,26 +49,26 @@ LL |     const I32_REF_U128_UNION: u128 = unsafe { Nonsense { int_32_ref: &3 }.u
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 
 error: any use of this value will cause an error
-  --> $DIR/const-pointer-values-in-various-types.rs:42:5
+  --> $DIR/const-pointer-values-in-various-types.rs:42:43
    |
 LL |     const I32_REF_I8_UNION: i8 = unsafe { Nonsense { int_32_ref: &3 }.int_8 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---------------------------------^^^
+   |     --------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                           |
    |                                           a raw memory access tried to access part of a pointer value as raw bytes
 
 error: any use of this value will cause an error
-  --> $DIR/const-pointer-values-in-various-types.rs:45:5
+  --> $DIR/const-pointer-values-in-various-types.rs:45:45
    |
 LL |     const I32_REF_I16_UNION: i16 = unsafe { Nonsense { int_32_ref: &3 }.int_16 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^----------------------------------^^^
+   |     ----------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                             |
    |                                             a raw memory access tried to access part of a pointer value as raw bytes
 
 error: any use of this value will cause an error
-  --> $DIR/const-pointer-values-in-various-types.rs:48:5
+  --> $DIR/const-pointer-values-in-various-types.rs:48:45
    |
 LL |     const I32_REF_I32_UNION: i32 = unsafe { Nonsense { int_32_ref: &3 }.int_32 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^----------------------------------^^^
+   |     ----------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                             |
    |                                             a raw memory access tried to access part of a pointer value as raw bytes
 
@@ -89,10 +89,10 @@ LL |     const I32_REF_I128_UNION: i128 = unsafe { Nonsense { int_32_ref: &3 }.i
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 
 error: any use of this value will cause an error
-  --> $DIR/const-pointer-values-in-various-types.rs:57:5
+  --> $DIR/const-pointer-values-in-various-types.rs:57:45
    |
 LL |     const I32_REF_F32_UNION: f32 = unsafe { Nonsense { int_32_ref: &3 }.float_32 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   |     ----------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                             |
    |                                             a raw memory access tried to access part of a pointer value as raw bytes
 
@@ -105,42 +105,42 @@ LL |     const I32_REF_F64_UNION: f64 = unsafe { Nonsense { int_32_ref: &3 }.flo
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 
 error: any use of this value will cause an error
-  --> $DIR/const-pointer-values-in-various-types.rs:63:5
+  --> $DIR/const-pointer-values-in-various-types.rs:63:47
    |
 LL |     const I32_REF_BOOL_UNION: bool = unsafe { Nonsense { int_32_ref: &3 }.truthy_falsey };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------------------------------------^^^
+   |     ------------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                               |
    |                                               a raw memory access tried to access part of a pointer value as raw bytes
 
 error: any use of this value will cause an error
-  --> $DIR/const-pointer-values-in-various-types.rs:66:5
+  --> $DIR/const-pointer-values-in-various-types.rs:66:47
    |
 LL |     const I32_REF_CHAR_UNION: char = unsafe { Nonsense { int_32_ref: &3 }.character };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------------------------------------^^^
+   |     ------------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                               |
    |                                               a raw memory access tried to access part of a pointer value as raw bytes
 
 error: any use of this value will cause an error
-  --> $DIR/const-pointer-values-in-various-types.rs:69:5
+  --> $DIR/const-pointer-values-in-various-types.rs:69:39
    |
 LL |     const STR_U8_UNION: u8 = unsafe { Nonsense { stringy: "3" }.uint_8 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^--------------------------------^^^
+   |     ----------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                       |
    |                                       a raw memory access tried to access part of a pointer value as raw bytes
 
 error: any use of this value will cause an error
-  --> $DIR/const-pointer-values-in-various-types.rs:72:5
+  --> $DIR/const-pointer-values-in-various-types.rs:72:41
    |
 LL |     const STR_U16_UNION: u16 = unsafe { Nonsense { stringy: "3" }.uint_16 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---------------------------------^^^
+   |     ------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                         |
    |                                         a raw memory access tried to access part of a pointer value as raw bytes
 
 error: any use of this value will cause an error
-  --> $DIR/const-pointer-values-in-various-types.rs:75:5
+  --> $DIR/const-pointer-values-in-various-types.rs:75:41
    |
 LL |     const STR_U32_UNION: u32 = unsafe { Nonsense { stringy: "3" }.uint_32 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---------------------------------^^^
+   |     ------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                         |
    |                                         a raw memory access tried to access part of a pointer value as raw bytes
 
@@ -153,34 +153,34 @@ LL |     const STR_U64_UNION: u64 = unsafe { Nonsense { stringy: "3" }.uint_64 }
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 
 error: any use of this value will cause an error
-  --> $DIR/const-pointer-values-in-various-types.rs:81:5
+  --> $DIR/const-pointer-values-in-various-types.rs:81:43
    |
 LL |     const STR_U128_UNION: u128 = unsafe { Nonsense { stringy: "3" }.uint_128 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^----------------------------------^^^
+   |     --------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                           |
    |                                           a raw memory access tried to access part of a pointer value as raw bytes
 
 error: any use of this value will cause an error
-  --> $DIR/const-pointer-values-in-various-types.rs:84:5
+  --> $DIR/const-pointer-values-in-various-types.rs:84:39
    |
 LL |     const STR_I8_UNION: i8 = unsafe { Nonsense { stringy: "3" }.int_8 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------------------------------^^^
+   |     ----------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                       |
    |                                       a raw memory access tried to access part of a pointer value as raw bytes
 
 error: any use of this value will cause an error
-  --> $DIR/const-pointer-values-in-various-types.rs:87:5
+  --> $DIR/const-pointer-values-in-various-types.rs:87:41
    |
 LL |     const STR_I16_UNION: i16 = unsafe { Nonsense { stringy: "3" }.int_16 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^--------------------------------^^^
+   |     ------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                         |
    |                                         a raw memory access tried to access part of a pointer value as raw bytes
 
 error: any use of this value will cause an error
-  --> $DIR/const-pointer-values-in-various-types.rs:90:5
+  --> $DIR/const-pointer-values-in-various-types.rs:90:41
    |
 LL |     const STR_I32_UNION: i32 = unsafe { Nonsense { stringy: "3" }.int_32 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^--------------------------------^^^
+   |     ------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                         |
    |                                         a raw memory access tried to access part of a pointer value as raw bytes
 
@@ -193,18 +193,18 @@ LL |     const STR_I64_UNION: i64 = unsafe { Nonsense { stringy: "3" }.int_64 };
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 
 error: any use of this value will cause an error
-  --> $DIR/const-pointer-values-in-various-types.rs:96:5
+  --> $DIR/const-pointer-values-in-various-types.rs:96:43
    |
 LL |     const STR_I128_UNION: i128 = unsafe { Nonsense { stringy: "3" }.int_128 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---------------------------------^^^
+   |     --------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                           |
    |                                           a raw memory access tried to access part of a pointer value as raw bytes
 
 error: any use of this value will cause an error
-  --> $DIR/const-pointer-values-in-various-types.rs:99:5
+  --> $DIR/const-pointer-values-in-various-types.rs:99:41
    |
 LL |     const STR_F32_UNION: f32 = unsafe { Nonsense { stringy: "3" }.float_32 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^----------------------------------^^^
+   |     ------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                         |
    |                                         a raw memory access tried to access part of a pointer value as raw bytes
 
@@ -217,18 +217,18 @@ LL |     const STR_F64_UNION: f64 = unsafe { Nonsense { stringy: "3" }.float_64 
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 
 error: any use of this value will cause an error
-  --> $DIR/const-pointer-values-in-various-types.rs:105:5
+  --> $DIR/const-pointer-values-in-various-types.rs:105:43
    |
 LL |     const STR_BOOL_UNION: bool = unsafe { Nonsense { stringy: "3" }.truthy_falsey };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---------------------------------------^^^
+   |     --------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                           |
    |                                           a raw memory access tried to access part of a pointer value as raw bytes
 
 error: any use of this value will cause an error
-  --> $DIR/const-pointer-values-in-various-types.rs:108:5
+  --> $DIR/const-pointer-values-in-various-types.rs:108:43
    |
 LL |     const STR_CHAR_UNION: char = unsafe { Nonsense { stringy: "3" }.character };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------------------------------^^^
+   |     --------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                           |
    |                                           a raw memory access tried to access part of a pointer value as raw bytes
 

--- a/src/test/ui/consts/const-eval/const_panic.stderr
+++ b/src/test/ui/consts/const-eval/const_panic.stderr
@@ -1,8 +1,8 @@
 error: any use of this value will cause an error
-  --> $DIR/const_panic.rs:4:1
+  --> $DIR/const_panic.rs:4:19
    |
 LL | pub const Z: () = panic!("cheese");
-   | ^^^^^^^^^^^^^^^^^^----------------^
+   | ------------------^^^^^^^^^^^^^^^^-
    |                   |
    |                   the evaluated program panicked at 'cheese', $DIR/const_panic.rs:4:19
    |
@@ -10,20 +10,20 @@ LL | pub const Z: () = panic!("cheese");
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: any use of this value will cause an error
-  --> $DIR/const_panic.rs:7:1
+  --> $DIR/const_panic.rs:7:19
    |
 LL | pub const Y: () = unreachable!();
-   | ^^^^^^^^^^^^^^^^^^--------------^
+   | ------------------^^^^^^^^^^^^^^-
    |                   |
    |                   the evaluated program panicked at 'internal error: entered unreachable code', $DIR/const_panic.rs:7:19
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: any use of this value will cause an error
-  --> $DIR/const_panic.rs:10:1
+  --> $DIR/const_panic.rs:10:19
    |
 LL | pub const X: () = unimplemented!();
-   | ^^^^^^^^^^^^^^^^^^----------------^
+   | ------------------^^^^^^^^^^^^^^^^-
    |                   |
    |                   the evaluated program panicked at 'not yet implemented', $DIR/const_panic.rs:10:19
    |

--- a/src/test/ui/consts/const-eval/const_panic_libcore.stderr
+++ b/src/test/ui/consts/const-eval/const_panic_libcore.stderr
@@ -1,8 +1,8 @@
 error: any use of this value will cause an error
-  --> $DIR/const_panic_libcore.rs:5:1
+  --> $DIR/const_panic_libcore.rs:5:15
    |
 LL | const Z: () = panic!("cheese");
-   | ^^^^^^^^^^^^^^----------------^
+   | --------------^^^^^^^^^^^^^^^^-
    |               |
    |               the evaluated program panicked at 'cheese', $DIR/const_panic_libcore.rs:5:15
    |
@@ -10,20 +10,20 @@ LL | const Z: () = panic!("cheese");
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: any use of this value will cause an error
-  --> $DIR/const_panic_libcore.rs:8:1
+  --> $DIR/const_panic_libcore.rs:8:15
    |
 LL | const Y: () = unreachable!();
-   | ^^^^^^^^^^^^^^--------------^
+   | --------------^^^^^^^^^^^^^^-
    |               |
    |               the evaluated program panicked at 'internal error: entered unreachable code', $DIR/const_panic_libcore.rs:8:15
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: any use of this value will cause an error
-  --> $DIR/const_panic_libcore.rs:11:1
+  --> $DIR/const_panic_libcore.rs:11:15
    |
 LL | const X: () = unimplemented!();
-   | ^^^^^^^^^^^^^^----------------^
+   | --------------^^^^^^^^^^^^^^^^-
    |               |
    |               the evaluated program panicked at 'not yet implemented', $DIR/const_panic_libcore.rs:11:15
    |

--- a/src/test/ui/consts/const-eval/const_panic_libcore_main.stderr
+++ b/src/test/ui/consts/const-eval/const_panic_libcore_main.stderr
@@ -1,8 +1,8 @@
 error: any use of this value will cause an error
-  --> $DIR/const_panic_libcore_main.rs:9:1
+  --> $DIR/const_panic_libcore_main.rs:9:15
    |
 LL | const Z: () = panic!("cheese");
-   | ^^^^^^^^^^^^^^----------------^
+   | --------------^^^^^^^^^^^^^^^^-
    |               |
    |               the evaluated program panicked at 'cheese', $DIR/const_panic_libcore_main.rs:9:15
    |
@@ -10,20 +10,20 @@ LL | const Z: () = panic!("cheese");
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: any use of this value will cause an error
-  --> $DIR/const_panic_libcore_main.rs:12:1
+  --> $DIR/const_panic_libcore_main.rs:12:15
    |
 LL | const Y: () = unreachable!();
-   | ^^^^^^^^^^^^^^--------------^
+   | --------------^^^^^^^^^^^^^^-
    |               |
    |               the evaluated program panicked at 'internal error: entered unreachable code', $DIR/const_panic_libcore_main.rs:12:15
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: any use of this value will cause an error
-  --> $DIR/const_panic_libcore_main.rs:15:1
+  --> $DIR/const_panic_libcore_main.rs:15:15
    |
 LL | const X: () = unimplemented!();
-   | ^^^^^^^^^^^^^^----------------^
+   | --------------^^^^^^^^^^^^^^^^-
    |               |
    |               the evaluated program panicked at 'not yet implemented', $DIR/const_panic_libcore_main.rs:15:15
    |

--- a/src/test/ui/consts/const-eval/const_raw_ptr_ops.stderr
+++ b/src/test/ui/consts/const-eval/const_raw_ptr_ops.stderr
@@ -1,34 +1,34 @@
 error: any use of this value will cause an error
-  --> $DIR/const_raw_ptr_ops.rs:6:1
+  --> $DIR/const_raw_ptr_ops.rs:6:26
    |
 LL | const X: bool = unsafe { &1 as *const i32 == &2 as *const i32 };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   | -------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                          |
    |                          "pointer arithmetic or comparison" needs an rfc before being allowed inside constants
    |
    = note: #[deny(const_err)] on by default
 
 error: any use of this value will cause an error
-  --> $DIR/const_raw_ptr_ops.rs:12:1
+  --> $DIR/const_raw_ptr_ops.rs:12:28
    |
 LL | const Y2: usize = unsafe { &1 as *const i32 as usize + 1 };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------------------------^^^
+   | ---------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                            |
    |                            "pointer arithmetic or comparison" needs an rfc before being allowed inside constants
 
 error: any use of this value will cause an error
-  --> $DIR/const_raw_ptr_ops.rs:16:1
+  --> $DIR/const_raw_ptr_ops.rs:16:26
    |
 LL | const Z2: i32 = unsafe { *(42 as *const i32) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^-------------------^^^
+   | -------------------------^^^^^^^^^^^^^^^^^^^---
    |                          |
    |                          a memory access tried to interpret some bytes as a pointer
 
 error: any use of this value will cause an error
-  --> $DIR/const_raw_ptr_ops.rs:17:1
+  --> $DIR/const_raw_ptr_ops.rs:17:26
    |
 LL | const Z3: i32 = unsafe { *(44 as *const i32) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^-------------------^^^
+   | -------------------------^^^^^^^^^^^^^^^^^^^---
    |                          |
    |                          a memory access tried to interpret some bytes as a pointer
 

--- a/src/test/ui/consts/const-eval/issue-43197.stderr
+++ b/src/test/ui/consts/const-eval/issue-43197.stderr
@@ -1,8 +1,8 @@
 warning: any use of this value will cause an error
-  --> $DIR/issue-43197.rs:8:5
+  --> $DIR/issue-43197.rs:8:20
    |
 LL |     const X: u32 = 0-1;
-   |     ^^^^^^^^^^^^^^^---^
+   |     ---------------^^^-
    |                    |
    |                    attempt to subtract with overflow
    |
@@ -13,10 +13,10 @@ LL | #![warn(const_err)]
    |         ^^^^^^^^^
 
 warning: any use of this value will cause an error
-  --> $DIR/issue-43197.rs:10:5
+  --> $DIR/issue-43197.rs:10:24
    |
 LL |     const Y: u32 = foo(0-1);
-   |     ^^^^^^^^^^^^^^^^^^^---^^
+   |     -------------------^^^--
    |                        |
    |                        attempt to subtract with overflow
 

--- a/src/test/ui/consts/const-eval/issue-49296.stderr
+++ b/src/test/ui/consts/const-eval/issue-49296.stderr
@@ -1,8 +1,8 @@
 error: any use of this value will cause an error
-  --> $DIR/issue-49296.rs:18:1
+  --> $DIR/issue-49296.rs:18:16
    |
 LL | const X: u64 = *wat(42);
-   | ^^^^^^^^^^^^^^^--------^
+   | ---------------^^^^^^^^-
    |                |
    |                dangling pointer was dereferenced
    |

--- a/src/test/ui/consts/const-eval/issue-50814-2.stderr
+++ b/src/test/ui/consts/const-eval/issue-50814-2.stderr
@@ -1,8 +1,8 @@
 error: any use of this value will cause an error
-  --> $DIR/issue-50814-2.rs:12:5
+  --> $DIR/issue-50814-2.rs:12:24
    |
 LL |     const BAR: usize = [5, 6, 7][T::BOO];
-   |     ^^^^^^^^^^^^^^^^^^^-----------------^
+   |     -------------------^^^^^^^^^^^^^^^^^-
    |                        |
    |                        index out of bounds: the len is 3 but the index is 42
    |

--- a/src/test/ui/consts/const-eval/issue-50814.stderr
+++ b/src/test/ui/consts/const-eval/issue-50814.stderr
@@ -1,8 +1,8 @@
 error: any use of this value will cause an error
-  --> $DIR/issue-50814.rs:13:5
+  --> $DIR/issue-50814.rs:13:21
    |
 LL |     const MAX: u8 = A::MAX + B::MAX;
-   |     ^^^^^^^^^^^^^^^^---------------^
+   |     ----------------^^^^^^^^^^^^^^^-
    |                     |
    |                     attempt to add with overflow
    |

--- a/src/test/ui/consts/const-eval/promoted_errors.stderr
+++ b/src/test/ui/consts/const-eval/promoted_errors.stderr
@@ -50,11 +50,15 @@ warning: reaching this expression at runtime will panic or abort
   --> $DIR/promoted_errors.rs:14:20
    |
 LL |     println!("{}", 1/(false as u32));
-   |                    ^^^^^^^^^^^^^^^^ attempt to divide by zero
+   |                    ^^^^^^^^^^^^^^^^
+   |                    |
+   |                    attempt to divide by zero
 
 warning: reaching this expression at runtime will panic or abort
   --> $DIR/promoted_errors.rs:9:20
    |
 LL |     println!("{}", 1/(1-1));
-   |                    ^^^^^^^ attempt to divide by zero
+   |                    ^^^^^^^
+   |                    |
+   |                    attempt to divide by zero
 

--- a/src/test/ui/consts/const-eval/promoted_errors.stderr
+++ b/src/test/ui/consts/const-eval/promoted_errors.stderr
@@ -50,15 +50,11 @@ warning: reaching this expression at runtime will panic or abort
   --> $DIR/promoted_errors.rs:14:20
    |
 LL |     println!("{}", 1/(false as u32));
-   |                    ^^^^^^^^^^^^^^^^
-   |                    |
-   |                    attempt to divide by zero
+   |                    ^^^^^^^^^^^^^^^^ attempt to divide by zero
 
 warning: reaching this expression at runtime will panic or abort
   --> $DIR/promoted_errors.rs:9:20
    |
 LL |     println!("{}", 1/(1-1));
-   |                    ^^^^^^^
-   |                    |
-   |                    attempt to divide by zero
+   |                    ^^^^^^^ attempt to divide by zero
 

--- a/src/test/ui/consts/const-eval/pub_const_err.stderr
+++ b/src/test/ui/consts/const-eval/pub_const_err.stderr
@@ -1,8 +1,8 @@
 warning: any use of this value will cause an error
-  --> $DIR/pub_const_err.rs:6:1
+  --> $DIR/pub_const_err.rs:6:20
    |
 LL | pub const Z: u32 = 0 - 1;
-   | ^^^^^^^^^^^^^^^^^^^-----^
+   | -------------------^^^^^-
    |                    |
    |                    attempt to subtract with overflow
    |

--- a/src/test/ui/consts/const-eval/pub_const_err_bin.stderr
+++ b/src/test/ui/consts/const-eval/pub_const_err_bin.stderr
@@ -1,8 +1,8 @@
 warning: any use of this value will cause an error
-  --> $DIR/pub_const_err_bin.rs:4:1
+  --> $DIR/pub_const_err_bin.rs:4:20
    |
 LL | pub const Z: u32 = 0 - 1;
-   | ^^^^^^^^^^^^^^^^^^^-----^
+   | -------------------^^^^^-
    |                    |
    |                    attempt to subtract with overflow
    |

--- a/src/test/ui/consts/const-eval/unused-broken-const.stderr
+++ b/src/test/ui/consts/const-eval/unused-broken-const.stderr
@@ -1,10 +1,10 @@
 warning: due to multiple output types requested, the explicitly specified output file name will be adapted for each output type
 
 error: any use of this value will cause an error
-  --> $DIR/unused-broken-const.rs:5:1
+  --> $DIR/unused-broken-const.rs:5:18
    |
 LL | const FOO: i32 = [][0];
-   | ^^^^^^^^^^^^^^^^^-----^
+   | -----------------^^^^^-
    |                  |
    |                  index out of bounds: the len is 0 but the index is 0
    |

--- a/src/test/ui/consts/const-int-unchecked.stderr
+++ b/src/test/ui/consts/const-int-unchecked.stderr
@@ -1,322 +1,322 @@
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:14:1
+  --> $DIR/const-int-unchecked.rs:14:29
    |
 LL | const SHL_U8: u8 = unsafe { intrinsics::unchecked_shl(5_u8, 8) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^----------------------------------^^^
+   | ----------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                             |
    |                             Overflowing shift by 8 in unchecked_shl
    |
    = note: #[deny(const_err)] on by default
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:16:1
+  --> $DIR/const-int-unchecked.rs:16:31
    |
 LL | const SHL_U16: u16 = unsafe { intrinsics::unchecked_shl(5_u16, 16) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                               |
    |                               Overflowing shift by 16 in unchecked_shl
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:18:1
+  --> $DIR/const-int-unchecked.rs:18:31
    |
 LL | const SHL_U32: u32 = unsafe { intrinsics::unchecked_shl(5_u32, 32) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                               |
    |                               Overflowing shift by 32 in unchecked_shl
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:20:1
+  --> $DIR/const-int-unchecked.rs:20:31
    |
 LL | const SHL_U64: u64 = unsafe { intrinsics::unchecked_shl(5_u64, 64) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                               |
    |                               Overflowing shift by 64 in unchecked_shl
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:22:1
+  --> $DIR/const-int-unchecked.rs:22:33
    |
 LL | const SHL_U128: u128 = unsafe { intrinsics::unchecked_shl(5_u128, 128) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^--------------------------------------^^^
+   | --------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                 |
    |                                 Overflowing shift by 128 in unchecked_shl
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:27:1
+  --> $DIR/const-int-unchecked.rs:27:29
    |
 LL | const SHL_I8: i8 = unsafe { intrinsics::unchecked_shl(5_i8, 8) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^----------------------------------^^^
+   | ----------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                             |
    |                             Overflowing shift by 8 in unchecked_shl
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:29:1
+  --> $DIR/const-int-unchecked.rs:29:31
    |
 LL | const SHL_I16: i16 = unsafe { intrinsics::unchecked_shl(5_16, 16) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------------------------------^^^
+   | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                               |
    |                               Overflowing shift by 16 in unchecked_shl
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:31:1
+  --> $DIR/const-int-unchecked.rs:31:31
    |
 LL | const SHL_I32: i32 = unsafe { intrinsics::unchecked_shl(5_i32, 32) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                               |
    |                               Overflowing shift by 32 in unchecked_shl
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:33:1
+  --> $DIR/const-int-unchecked.rs:33:31
    |
 LL | const SHL_I64: i64 = unsafe { intrinsics::unchecked_shl(5_i64, 64) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                               |
    |                               Overflowing shift by 64 in unchecked_shl
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:35:1
+  --> $DIR/const-int-unchecked.rs:35:33
    |
 LL | const SHL_I128: i128 = unsafe { intrinsics::unchecked_shl(5_i128, 128) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^--------------------------------------^^^
+   | --------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                 |
    |                                 Overflowing shift by 128 in unchecked_shl
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:40:1
+  --> $DIR/const-int-unchecked.rs:40:33
    |
 LL | const SHL_I8_NEG: i8 = unsafe { intrinsics::unchecked_shl(5_i8, -1) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------------------------------^^^
+   | --------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                 |
    |                                 Overflowing shift by 255 in unchecked_shl
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:42:1
+  --> $DIR/const-int-unchecked.rs:42:35
    |
 LL | const SHL_I16_NEG: i16 = unsafe { intrinsics::unchecked_shl(5_16, -1) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------------------------------^^^
+   | ----------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                   |
    |                                   Overflowing shift by 65535 in unchecked_shl
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:44:1
+  --> $DIR/const-int-unchecked.rs:44:35
    |
 LL | const SHL_I32_NEG: i32 = unsafe { intrinsics::unchecked_shl(5_i32, -1) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   | ----------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                   |
    |                                   Overflowing shift by 4294967295 in unchecked_shl
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:46:1
+  --> $DIR/const-int-unchecked.rs:46:35
    |
 LL | const SHL_I64_NEG: i64 = unsafe { intrinsics::unchecked_shl(5_i64, -1) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   | ----------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                   |
    |                                   Overflowing shift by 18446744073709551615 in unchecked_shl
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:48:1
+  --> $DIR/const-int-unchecked.rs:48:37
    |
 LL | const SHL_I128_NEG: i128 = unsafe { intrinsics::unchecked_shl(5_i128, -1) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------------------------------------^^^
+   | ------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                     |
    |                                     Overflowing shift by 340282366920938463463374607431768211455 in unchecked_shl
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:54:1
+  --> $DIR/const-int-unchecked.rs:54:40
    |
 LL | const SHL_I8_NEG_RANDOM: i8 = unsafe { intrinsics::unchecked_shl(5_i8, -6) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------------------------------^^^
+   | ---------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                        |
    |                                        Overflowing shift by 250 in unchecked_shl
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:56:1
+  --> $DIR/const-int-unchecked.rs:56:42
    |
 LL | const SHL_I16_NEG_RANDOM: i16 = unsafe { intrinsics::unchecked_shl(5_16, -13) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   | -----------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                          |
    |                                          Overflowing shift by 65523 in unchecked_shl
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:58:1
+  --> $DIR/const-int-unchecked.rs:58:42
    |
 LL | const SHL_I32_NEG_RANDOM: i32 = unsafe { intrinsics::unchecked_shl(5_i32, -25) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------------------------------------^^^
+   | -----------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                          |
    |                                          Overflowing shift by 4294967271 in unchecked_shl
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:60:1
+  --> $DIR/const-int-unchecked.rs:60:42
    |
 LL | const SHL_I64_NEG_RANDOM: i64 = unsafe { intrinsics::unchecked_shl(5_i64, -30) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------------------------------------^^^
+   | -----------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                          |
    |                                          Overflowing shift by 18446744073709551586 in unchecked_shl
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:62:1
+  --> $DIR/const-int-unchecked.rs:62:44
    |
 LL | const SHL_I128_NEG_RANDOM: i128 = unsafe { intrinsics::unchecked_shl(5_i128, -93) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^--------------------------------------^^^
+   | -------------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                            |
    |                                            Overflowing shift by 340282366920938463463374607431768211363 in unchecked_shl
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:69:1
+  --> $DIR/const-int-unchecked.rs:69:29
    |
 LL | const SHR_U8: u8 = unsafe { intrinsics::unchecked_shr(5_u8, 8) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^----------------------------------^^^
+   | ----------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                             |
    |                             Overflowing shift by 8 in unchecked_shr
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:71:1
+  --> $DIR/const-int-unchecked.rs:71:31
    |
 LL | const SHR_U16: u16 = unsafe { intrinsics::unchecked_shr(5_u16, 16) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                               |
    |                               Overflowing shift by 16 in unchecked_shr
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:73:1
+  --> $DIR/const-int-unchecked.rs:73:31
    |
 LL | const SHR_U32: u32 = unsafe { intrinsics::unchecked_shr(5_u32, 32) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                               |
    |                               Overflowing shift by 32 in unchecked_shr
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:75:1
+  --> $DIR/const-int-unchecked.rs:75:31
    |
 LL | const SHR_U64: u64 = unsafe { intrinsics::unchecked_shr(5_u64, 64) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                               |
    |                               Overflowing shift by 64 in unchecked_shr
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:77:1
+  --> $DIR/const-int-unchecked.rs:77:33
    |
 LL | const SHR_U128: u128 = unsafe { intrinsics::unchecked_shr(5_u128, 128) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^--------------------------------------^^^
+   | --------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                 |
    |                                 Overflowing shift by 128 in unchecked_shr
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:82:1
+  --> $DIR/const-int-unchecked.rs:82:29
    |
 LL | const SHR_I8: i8 = unsafe { intrinsics::unchecked_shr(5_i8, 8) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^----------------------------------^^^
+   | ----------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                             |
    |                             Overflowing shift by 8 in unchecked_shr
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:84:1
+  --> $DIR/const-int-unchecked.rs:84:31
    |
 LL | const SHR_I16: i16 = unsafe { intrinsics::unchecked_shr(5_16, 16) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------------------------------^^^
+   | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                               |
    |                               Overflowing shift by 16 in unchecked_shr
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:86:1
+  --> $DIR/const-int-unchecked.rs:86:31
    |
 LL | const SHR_I32: i32 = unsafe { intrinsics::unchecked_shr(5_i32, 32) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                               |
    |                               Overflowing shift by 32 in unchecked_shr
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:88:1
+  --> $DIR/const-int-unchecked.rs:88:31
    |
 LL | const SHR_I64: i64 = unsafe { intrinsics::unchecked_shr(5_i64, 64) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                               |
    |                               Overflowing shift by 64 in unchecked_shr
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:90:1
+  --> $DIR/const-int-unchecked.rs:90:33
    |
 LL | const SHR_I128: i128 = unsafe { intrinsics::unchecked_shr(5_i128, 128) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^--------------------------------------^^^
+   | --------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                 |
    |                                 Overflowing shift by 128 in unchecked_shr
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:95:1
+  --> $DIR/const-int-unchecked.rs:95:33
    |
 LL | const SHR_I8_NEG: i8 = unsafe { intrinsics::unchecked_shr(5_i8, -1) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------------------------------^^^
+   | --------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                 |
    |                                 Overflowing shift by 255 in unchecked_shr
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:97:1
+  --> $DIR/const-int-unchecked.rs:97:35
    |
 LL | const SHR_I16_NEG: i16 = unsafe { intrinsics::unchecked_shr(5_16, -1) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------------------------------^^^
+   | ----------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                   |
    |                                   Overflowing shift by 65535 in unchecked_shr
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:99:1
+  --> $DIR/const-int-unchecked.rs:99:35
    |
 LL | const SHR_I32_NEG: i32 = unsafe { intrinsics::unchecked_shr(5_i32, -1) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   | ----------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                   |
    |                                   Overflowing shift by 4294967295 in unchecked_shr
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:101:1
+  --> $DIR/const-int-unchecked.rs:101:35
    |
 LL | const SHR_I64_NEG: i64 = unsafe { intrinsics::unchecked_shr(5_i64, -1) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   | ----------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                   |
    |                                   Overflowing shift by 18446744073709551615 in unchecked_shr
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:103:1
+  --> $DIR/const-int-unchecked.rs:103:37
    |
 LL | const SHR_I128_NEG: i128 = unsafe { intrinsics::unchecked_shr(5_i128, -1) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------------------------------------^^^
+   | ------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                     |
    |                                     Overflowing shift by 340282366920938463463374607431768211455 in unchecked_shr
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:109:1
+  --> $DIR/const-int-unchecked.rs:109:40
    |
 LL | const SHR_I8_NEG_RANDOM: i8 = unsafe { intrinsics::unchecked_shr(5_i8, -6) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------------------------------^^^
+   | ---------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                        |
    |                                        Overflowing shift by 250 in unchecked_shr
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:111:1
+  --> $DIR/const-int-unchecked.rs:111:42
    |
 LL | const SHR_I16_NEG_RANDOM: i16 = unsafe { intrinsics::unchecked_shr(5_16, -13) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^
+   | -----------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                          |
    |                                          Overflowing shift by 65523 in unchecked_shr
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:113:1
+  --> $DIR/const-int-unchecked.rs:113:42
    |
 LL | const SHR_I32_NEG_RANDOM: i32 = unsafe { intrinsics::unchecked_shr(5_i32, -25) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------------------------------------^^^
+   | -----------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                          |
    |                                          Overflowing shift by 4294967271 in unchecked_shr
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:115:1
+  --> $DIR/const-int-unchecked.rs:115:42
    |
 LL | const SHR_I64_NEG_RANDOM: i64 = unsafe { intrinsics::unchecked_shr(5_i64, -30) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------------------------------------^^^
+   | -----------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                          |
    |                                          Overflowing shift by 18446744073709551586 in unchecked_shr
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:117:1
+  --> $DIR/const-int-unchecked.rs:117:44
    |
 LL | const SHR_I128_NEG_RANDOM: i128 = unsafe { intrinsics::unchecked_shr(5_i128, -93) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^--------------------------------------^^^
+   | -------------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                            |
    |                                            Overflowing shift by 340282366920938463463374607431768211363 in unchecked_shr
 

--- a/src/test/ui/consts/const-len-underflow-separate-spans.stderr
+++ b/src/test/ui/consts/const-len-underflow-separate-spans.stderr
@@ -1,8 +1,8 @@
 error: any use of this value will cause an error
-  --> $DIR/const-len-underflow-separate-spans.rs:7:1
+  --> $DIR/const-len-underflow-separate-spans.rs:7:20
    |
 LL | const LEN: usize = ONE - TWO;
-   | ^^^^^^^^^^^^^^^^^^^---------^
+   | -------------------^^^^^^^^^-
    |                    |
    |                    attempt to subtract with overflow
    |

--- a/src/test/ui/consts/const-slice-oob.stderr
+++ b/src/test/ui/consts/const-slice-oob.stderr
@@ -1,8 +1,8 @@
 error: any use of this value will cause an error
-  --> $DIR/const-slice-oob.rs:4:1
+  --> $DIR/const-slice-oob.rs:4:18
    |
 LL | const BAR: u32 = FOO[5];
-   | ^^^^^^^^^^^^^^^^^------^
+   | -----------------^^^^^^-
    |                  |
    |                  index out of bounds: the len is 3 but the index is 5
    |

--- a/src/test/ui/consts/dangling-alloc-id-ice.stderr
+++ b/src/test/ui/consts/dangling-alloc-id-ice.stderr
@@ -1,11 +1,17 @@
 error: any use of this value will cause an error
   --> $DIR/dangling-alloc-id-ice.rs:8:1
    |
-LL | / const FOO: &() = {
-LL | |     let y = ();
-LL | |     unsafe { Foo { y: &y }.long_live_the_unit }
-LL | | };
-   | |__^ type validation failed: encountered dangling pointer in final constant
+LL |    const FOO: &() = {
+   |   _^
+   |  |_|
+   | ||
+LL | ||     let y = ();
+LL | ||     unsafe { Foo { y: &y }.long_live_the_unit }
+LL | || };
+   | ||  ^
+   | ||__|
+   | |___type validation failed: encountered dangling pointer in final constant
+   | 
    |
    = note: #[deny(const_err)] on by default
 

--- a/src/test/ui/consts/dangling-alloc-id-ice.stderr
+++ b/src/test/ui/consts/dangling-alloc-id-ice.stderr
@@ -1,17 +1,11 @@
 error: any use of this value will cause an error
   --> $DIR/dangling-alloc-id-ice.rs:8:1
    |
-LL |    const FOO: &() = {
-   |   _^
-   |  |_|
-   | ||
-LL | ||     let y = ();
-LL | ||     unsafe { Foo { y: &y }.long_live_the_unit }
-LL | || };
-   | ||  ^
-   | ||__|
-   | |___type validation failed: encountered dangling pointer in final constant
-   | 
+LL | / const FOO: &() = {
+LL | |     let y = ();
+LL | |     unsafe { Foo { y: &y }.long_live_the_unit }
+LL | | };
+   | |__^ type validation failed: encountered dangling pointer in final constant
    |
    = note: #[deny(const_err)] on by default
 

--- a/src/test/ui/consts/dangling_raw_ptr.stderr
+++ b/src/test/ui/consts/dangling_raw_ptr.stderr
@@ -1,11 +1,17 @@
 error: any use of this value will cause an error
   --> $DIR/dangling_raw_ptr.rs:1:1
    |
-LL | / const FOO: *const u32 = {
-LL | |     let x = 42;
-LL | |     &x
-LL | | };
-   | |__^ type validation failed: encountered dangling pointer in final constant
+LL |    const FOO: *const u32 = {
+   |   _^
+   |  |_|
+   | ||
+LL | ||     let x = 42;
+LL | ||     &x
+LL | || };
+   | ||  ^
+   | ||__|
+   | |___type validation failed: encountered dangling pointer in final constant
+   | 
    |
    = note: #[deny(const_err)] on by default
 

--- a/src/test/ui/consts/dangling_raw_ptr.stderr
+++ b/src/test/ui/consts/dangling_raw_ptr.stderr
@@ -1,17 +1,11 @@
 error: any use of this value will cause an error
   --> $DIR/dangling_raw_ptr.rs:1:1
    |
-LL |    const FOO: *const u32 = {
-   |   _^
-   |  |_|
-   | ||
-LL | ||     let x = 42;
-LL | ||     &x
-LL | || };
-   | ||  ^
-   | ||__|
-   | |___type validation failed: encountered dangling pointer in final constant
-   | 
+LL | / const FOO: *const u32 = {
+LL | |     let x = 42;
+LL | |     &x
+LL | | };
+   | |__^ type validation failed: encountered dangling pointer in final constant
    |
    = note: #[deny(const_err)] on by default
 

--- a/src/test/ui/did_you_mean/bad-assoc-pat.stderr
+++ b/src/test/ui/did_you_mean/bad-assoc-pat.stderr
@@ -26,33 +26,25 @@ error[E0599]: no associated item named `AssocItem` found for type `[u8]` in the 
   --> $DIR/bad-assoc-pat.rs:3:15
    |
 LL |         [u8]::AssocItem => {}
-   |         ------^^^^^^^^^
-   |         |
-   |         associated item not found in `[u8]`
+   |               ^^^^^^^^^ associated item not found in `[u8]`
 
 error[E0599]: no associated item named `AssocItem` found for type `(u8, u8)` in the current scope
   --> $DIR/bad-assoc-pat.rs:6:19
    |
 LL |         (u8, u8)::AssocItem => {}
-   |         ----------^^^^^^^^^
-   |         |
-   |         associated item not found in `(u8, u8)`
+   |                   ^^^^^^^^^ associated item not found in `(u8, u8)`
 
 error[E0599]: no associated item named `AssocItem` found for type `_` in the current scope
   --> $DIR/bad-assoc-pat.rs:9:12
    |
 LL |         _::AssocItem => {}
-   |         ---^^^^^^^^^
-   |         |
-   |         associated item not found in `_`
+   |            ^^^^^^^^^ associated item not found in `_`
 
 error[E0599]: no associated item named `AssocItem` found for type `(u8,)` in the current scope
   --> $DIR/bad-assoc-pat.rs:14:17
    |
 LL |         &(u8,)::AssocItem => {}
-   |          -------^^^^^^^^^
-   |          |
-   |          associated item not found in `(u8,)`
+   |                 ^^^^^^^^^ associated item not found in `(u8,)`
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/dont-suggest-private-trait-method.stderr
+++ b/src/test/ui/dont-suggest-private-trait-method.stderr
@@ -5,9 +5,7 @@ LL | struct T;
    | --------- function or associated item `new` not found for this
 ...
 LL |     T::new();
-   |     ---^^^
-   |     |
-   |     function or associated item not found in `T`
+   |        ^^^ function or associated item not found in `T`
 
 error: aborting due to previous error
 

--- a/src/test/ui/double-type-import.stderr
+++ b/src/test/ui/double-type-import.stderr
@@ -4,12 +4,10 @@ error[E0252]: the name `X` is defined multiple times
 LL |     pub use self::bar::X;
    |             ------------ previous import of the type `X` here
 LL |     use self::bar::X;
-   |     ----^^^^^^^^^^^^-
-   |     |   |
-   |     |   `X` reimported here
-   |     help: remove unnecessary import
+   |         ^^^^^^^^^^^^ `X` reimported here
    |
    = note: `X` must be defined only once in the type namespace of this module
+   = help: remove unnecessary import
 
 error: aborting due to previous error
 

--- a/src/test/ui/double-type-import.stderr
+++ b/src/test/ui/double-type-import.stderr
@@ -7,7 +7,6 @@ LL |     use self::bar::X;
    |         ^^^^^^^^^^^^ `X` reimported here
    |
    = note: `X` must be defined only once in the type namespace of this module
-   = help: remove unnecessary import
 
 error: aborting due to previous error
 

--- a/src/test/ui/empty/empty-struct-braces-expr.stderr
+++ b/src/test/ui/empty/empty-struct-braces-expr.stderr
@@ -50,19 +50,19 @@ error[E0599]: no variant named `Empty3` found for type `empty_struct::XE` in the
   --> $DIR/empty-struct-braces-expr.rs:22:19
    |
 LL |     let xe3 = XE::Empty3;
-   |               ----^^^^^^
-   |               |   |
-   |               |   help: did you mean: `XEmpty3`
-   |               variant not found in `empty_struct::XE`
+   |                   ^^^^^^
+   |                   |
+   |                   variant not found in `empty_struct::XE`
+   |                   help: did you mean: `XEmpty3`
 
 error[E0599]: no variant named `Empty3` found for type `empty_struct::XE` in the current scope
   --> $DIR/empty-struct-braces-expr.rs:23:19
    |
 LL |     let xe3 = XE::Empty3();
-   |               ----^^^^^^
-   |               |   |
-   |               |   help: did you mean: `XEmpty3`
-   |               variant not found in `empty_struct::XE`
+   |                   ^^^^^^
+   |                   |
+   |                   variant not found in `empty_struct::XE`
+   |                   help: did you mean: `XEmpty3`
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/error-codes/E0396-fixed.stderr
+++ b/src/test/ui/error-codes/E0396-fixed.stderr
@@ -1,8 +1,8 @@
 error: any use of this value will cause an error
-  --> $DIR/E0396-fixed.rs:5:1
+  --> $DIR/E0396-fixed.rs:5:28
    |
 LL | const VALUE: u8 = unsafe { *REG_ADDR };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^---------^^^
+   | ---------------------------^^^^^^^^^---
    |                            |
    |                            a memory access tried to interpret some bytes as a pointer
    |

--- a/src/test/ui/error-codes/E0430.stderr
+++ b/src/test/ui/error-codes/E0430.stderr
@@ -10,10 +10,8 @@ error[E0252]: the name `fmt` is defined multiple times
   --> $DIR/E0430.rs:1:22
    |
 LL | use std::fmt::{self, self};
-   |                ------^^^^
-   |                |   | |
-   |                |   | `fmt` reimported here
-   |                |   help: remove unnecessary import
+   |                ----  ^^^^ `fmt` reimported here
+   |                |
    |                previous import of the module `fmt` here
    |
    = note: `fmt` must be defined only once in the type namespace of this module

--- a/src/test/ui/error-codes/E0458.stderr
+++ b/src/test/ui/error-codes/E0458.stderr
@@ -1,8 +1,8 @@
 error[E0458]: unknown kind: `wonderful_unicorn`
-  --> $DIR/E0458.rs:1:1
+  --> $DIR/E0458.rs:1:8
    |
 LL | #[link(kind = "wonderful_unicorn")] extern {}
-   | ^^^^^^^--------------------------^^
+   | -------^^^^^^^^^^^^^^^^^^^^^^^^^^--
    |        |
    |        unknown kind
 

--- a/src/test/ui/error-codes/E0599.stderr
+++ b/src/test/ui/error-codes/E0599.stderr
@@ -5,7 +5,7 @@ LL | struct Foo;
    | ----------- associated item `NotEvenReal` not found for this
 ...
 LL |     || if let Foo::NotEvenReal() = Foo {};
-   |               -----^^^^^^^^^^^-- associated item not found in `Foo`
+   |                    ^^^^^^^^^^^ associated item not found in `Foo`
 
 error: aborting due to previous error
 

--- a/src/test/ui/imports/duplicate.stderr
+++ b/src/test/ui/imports/duplicate.stderr
@@ -4,12 +4,10 @@ error[E0252]: the name `foo` is defined multiple times
 LL |     use a::foo;
    |         ------ previous import of the value `foo` here
 LL |     use a::foo;
-   |     ----^^^^^^-
-   |     |   |
-   |     |   `foo` reimported here
-   |     help: remove unnecessary import
+   |         ^^^^^^ `foo` reimported here
    |
    = note: `foo` must be defined only once in the value namespace of this module
+   = help: remove unnecessary import
 
 error[E0659]: `foo` is ambiguous (glob import vs glob import in the same module)
   --> $DIR/duplicate.rs:46:15

--- a/src/test/ui/imports/duplicate.stderr
+++ b/src/test/ui/imports/duplicate.stderr
@@ -7,7 +7,6 @@ LL |     use a::foo;
    |         ^^^^^^ `foo` reimported here
    |
    = note: `foo` must be defined only once in the value namespace of this module
-   = help: remove unnecessary import
 
 error[E0659]: `foo` is ambiguous (glob import vs glob import in the same module)
   --> $DIR/duplicate.rs:46:15

--- a/src/test/ui/invalid/invalid-path-in-const.stderr
+++ b/src/test/ui/invalid/invalid-path-in-const.stderr
@@ -2,9 +2,7 @@ error[E0599]: no associated item named `DOESNOTEXIST` found for type `u32` in th
   --> $DIR/invalid-path-in-const.rs:2:23
    |
 LL |     fn f(a: [u8; u32::DOESNOTEXIST]) {}
-   |                  -----^^^^^^^^^^^^
-   |                  |
-   |                  associated item not found in `u32`
+   |                       ^^^^^^^^^^^^ associated item not found in `u32`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-17800.stderr
+++ b/src/test/ui/issues/issue-17800.stderr
@@ -2,10 +2,10 @@ error[E0026]: variant `MyOption::MySome` does not have a field named `x`
   --> $DIR/issue-17800.rs:8:28
    |
 LL |         MyOption::MySome { x: 42 } => (),
-   |                            ^^^^^
+   |                            ^
    |                            |
    |                            variant `MyOption::MySome` does not have this field
-   |                            help: did you mean: `0`
+   |                            help: a field with a similar name exists: `0`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-22933-2.stderr
+++ b/src/test/ui/issues/issue-22933-2.stderr
@@ -5,9 +5,7 @@ LL | enum Delicious {
    | -------------- variant `PIE` not found here
 ...
 LL |     ApplePie = Delicious::Apple as isize | Delicious::PIE as isize,
-   |                                            -----------^^^
-   |                                            |
-   |                                            variant not found in `Delicious`
+   |                                                       ^^^ variant not found in `Delicious`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-22933-3.stderr
+++ b/src/test/ui/issues/issue-22933-3.stderr
@@ -2,9 +2,7 @@ error[E0599]: no associated item named `MIN` found for type `u8` in the current 
   --> $DIR/issue-22933-3.rs:1:22
    |
 LL | const FOO: [u32; u8::MIN as usize] = [];
-   |                  ----^^^
-   |                  |
-   |                  associated item not found in `u8`
+   |                      ^^^ associated item not found in `u8`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-23173.stderr
+++ b/src/test/ui/issues/issue-23173.stderr
@@ -5,9 +5,7 @@ LL | enum Token { LeftParen, RightParen, Plus, Minus, /* etc */ }
    | ---------- variant `Homura` not found here
 ...
 LL |     use_token(&Token::Homura);
-   |                -------^^^^^^
-   |                |
-   |                variant not found in `Token`
+   |                       ^^^^^^ variant not found in `Token`
 
 error[E0599]: no function or associated item named `method` found for type `Struct` in the current scope
   --> $DIR/issue-23173.rs:11:13
@@ -16,9 +14,7 @@ LL | struct Struct {
    | ------------- function or associated item `method` not found for this
 ...
 LL |     Struct::method();
-   |     --------^^^^^^
-   |     |
-   |     function or associated item not found in `Struct`
+   |             ^^^^^^ function or associated item not found in `Struct`
 
 error[E0599]: no function or associated item named `method` found for type `Struct` in the current scope
   --> $DIR/issue-23173.rs:13:13
@@ -27,9 +23,7 @@ LL | struct Struct {
    | ------------- function or associated item `method` not found for this
 ...
 LL |     Struct::method;
-   |     --------^^^^^^
-   |     |
-   |     function or associated item not found in `Struct`
+   |             ^^^^^^ function or associated item not found in `Struct`
 
 error[E0599]: no associated item named `Assoc` found for type `Struct` in the current scope
   --> $DIR/issue-23173.rs:15:13
@@ -38,9 +32,7 @@ LL | struct Struct {
    | ------------- associated item `Assoc` not found for this
 ...
 LL |     Struct::Assoc;
-   |     --------^^^^^
-   |     |
-   |     associated item not found in `Struct`
+   |             ^^^^^ associated item not found in `Struct`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/issues/issue-23217.stderr
+++ b/src/test/ui/issues/issue-23217.stderr
@@ -4,10 +4,10 @@ error[E0599]: no variant named `A` found for type `SomeEnum` in the current scop
 LL | pub enum SomeEnum {
    | ----------------- variant `A` not found here
 LL |     B = SomeEnum::A,
-   |         ----------^
-   |         |         |
-   |         |         help: did you mean: `B`
-   |         variant not found in `SomeEnum`
+   |                   ^
+   |                   |
+   |                   variant not found in `SomeEnum`
+   |                   help: did you mean: `B`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-26886.stderr
+++ b/src/test/ui/issues/issue-26886.stderr
@@ -4,12 +4,10 @@ error[E0252]: the name `Arc` is defined multiple times
 LL | use std::sync::{self, Arc};
    |                       --- previous import of the type `Arc` here
 LL | use std::sync::Arc;
-   | ----^^^^^^^^^^^^^^-
-   | |   |
-   | |   `Arc` reimported here
-   | help: remove unnecessary import
+   |     ^^^^^^^^^^^^^^ `Arc` reimported here
    |
    = note: `Arc` must be defined only once in the type namespace of this module
+   = help: remove unnecessary import
 
 error[E0252]: the name `sync` is defined multiple times
   --> $DIR/issue-26886.rs:4:5
@@ -18,12 +16,10 @@ LL | use std::sync::{self, Arc};
    |                 ---- previous import of the module `sync` here
 ...
 LL | use std::sync;
-   | ----^^^^^^^^^-
-   | |   |
-   | |   `sync` reimported here
-   | help: remove unnecessary import
+   |     ^^^^^^^^^ `sync` reimported here
    |
    = note: `sync` must be defined only once in the type namespace of this module
+   = help: remove unnecessary import
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-26886.stderr
+++ b/src/test/ui/issues/issue-26886.stderr
@@ -7,7 +7,6 @@ LL | use std::sync::Arc;
    |     ^^^^^^^^^^^^^^ `Arc` reimported here
    |
    = note: `Arc` must be defined only once in the type namespace of this module
-   = help: remove unnecessary import
 
 error[E0252]: the name `sync` is defined multiple times
   --> $DIR/issue-26886.rs:4:5
@@ -19,7 +18,6 @@ LL | use std::sync;
    |     ^^^^^^^^^ `sync` reimported here
    |
    = note: `sync` must be defined only once in the type namespace of this module
-   = help: remove unnecessary import
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-28344.stderr
+++ b/src/test/ui/issues/issue-28344.stderr
@@ -8,10 +8,10 @@ error[E0599]: no function or associated item named `bitor` found for type `dyn s
   --> $DIR/issue-28344.rs:4:25
    |
 LL |     let x: u8 = BitXor::bitor(0 as u8, 0 as u8);
-   |                 --------^^^^^
-   |                 |
-   |                 function or associated item not found in `dyn std::ops::BitXor<_>`
-   |                 help: did you mean: `bitxor`
+   |                         ^^^^^
+   |                         |
+   |                         function or associated item not found in `dyn std::ops::BitXor<_>`
+   |                         help: did you mean: `bitxor`
 
 error[E0191]: the value of the associated type `Output` (from the trait `std::ops::BitXor`) must be specified
   --> $DIR/issue-28344.rs:8:13
@@ -23,10 +23,10 @@ error[E0599]: no function or associated item named `bitor` found for type `dyn s
   --> $DIR/issue-28344.rs:8:21
    |
 LL |     let g = BitXor::bitor;
-   |             --------^^^^^
-   |             |
-   |             function or associated item not found in `dyn std::ops::BitXor<_>`
-   |             help: did you mean: `bitxor`
+   |                     ^^^^^
+   |                     |
+   |                     function or associated item not found in `dyn std::ops::BitXor<_>`
+   |                     help: did you mean: `bitxor`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/issues/issue-28586.stderr
+++ b/src/test/ui/issues/issue-28586.stderr
@@ -2,9 +2,7 @@ error[E0599]: no associated item named `BYTES` found for type `usize` in the cur
   --> $DIR/issue-28586.rs:4:26
    |
 LL | impl Foo for [u8; usize::BYTES] {}
-   |                   -------^^^^^
-   |                   |
-   |                   associated item not found in `usize`
+   |                          ^^^^^ associated item not found in `usize`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-28971.stderr
+++ b/src/test/ui/issues/issue-28971.stderr
@@ -5,10 +5,10 @@ LL | enum Foo {
    | -------- variant `Baz` not found here
 ...
 LL |             Foo::Baz(..) => (),
-   |             -----^^^----
-   |             |    |
-   |             |    help: did you mean: `Bar`
-   |             variant not found in `Foo`
+   |                  ^^^
+   |                  |
+   |                  variant not found in `Foo`
+   |                  help: did you mean: `Bar`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-30123.stderr
+++ b/src/test/ui/issues/issue-30123.stderr
@@ -2,9 +2,7 @@ error[E0599]: no function or associated item named `new_undirected` found for ty
   --> $DIR/issue-30123.rs:7:33
    |
 LL |     let ug = Graph::<i32, i32>::new_undirected();
-   |              -------------------^^^^^^^^^^^^^^
-   |              |
-   |              function or associated item not found in `issue_30123_aux::Graph<i32, i32>`
+   |                                 ^^^^^^^^^^^^^^ function or associated item not found in `issue_30123_aux::Graph<i32, i32>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-38919.stderr
+++ b/src/test/ui/issues/issue-38919.stderr
@@ -2,9 +2,7 @@ error[E0599]: no associated item named `Item` found for type `T` in the current 
   --> $DIR/issue-38919.rs:2:8
    |
 LL |     T::Item;
-   |     ---^^^^
-   |     |
-   |     associated item not found in `T`
+   |        ^^^^ associated item not found in `T`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-39559.stderr
+++ b/src/test/ui/issues/issue-39559.stderr
@@ -2,9 +2,7 @@ error[E0599]: no function or associated item named `dim` found for type `D` in t
   --> $DIR/issue-39559.rs:14:21
    |
 LL |     entries: [T; D::dim()],
-   |                  ---^^^
-   |                  |
-   |                  function or associated item not found in `D`
+   |                     ^^^ function or associated item not found in `D`
    |
    = help: items from traits can only be used if the trait is implemented and in scope
    = note: the following trait defines an item `dim`, perhaps you need to implement it:

--- a/src/test/ui/issues/issue-3973.stderr
+++ b/src/test/ui/issues/issue-3973.stderr
@@ -14,9 +14,7 @@ LL | struct Point {
    | ------------ function or associated item `new` not found for this
 ...
 LL |     let p = Point::new(0.0, 0.0);
-   |             -------^^^
-   |             |
-   |             function or associated item not found in `Point`
+   |                    ^^^ function or associated item not found in `Point`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-42880.stderr
+++ b/src/test/ui/issues/issue-42880.stderr
@@ -2,7 +2,7 @@ error[E0599]: no associated item named `String` found for type `std::string::Str
   --> $DIR/issue-42880.rs:4:22
    |
 LL |     let f = |&Value::String(_)| ();
-   |               -------^^^^^^--- associated item not found in `std::string::String`
+   |                      ^^^^^^ associated item not found in `std::string::String`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-43105.stderr
+++ b/src/test/ui/issues/issue-43105.stderr
@@ -5,10 +5,10 @@ LL | const NUM: u8 = xyz();
    |                 ^^^^^
 
 error: any use of this value will cause an error
-  --> $DIR/issue-43105.rs:3:1
+  --> $DIR/issue-43105.rs:3:17
    |
 LL | const NUM: u8 = xyz();
-   | ^^^^^^^^^^^^^^^^-----^
+   | ----------------^^^^^-
    |                 |
    |                 calling non-const function `xyz`
    |

--- a/src/test/ui/issues/issue-45829/import-twice.stderr
+++ b/src/test/ui/issues/issue-45829/import-twice.stderr
@@ -2,10 +2,8 @@ error[E0252]: the name `A` is defined multiple times
   --> $DIR/import-twice.rs:6:14
    |
 LL | use foo::{A, A};
-   |           ---^
-   |           || |
-   |           || `A` reimported here
-   |           |help: remove unnecessary import
+   |           -  ^ `A` reimported here
+   |           |
    |           previous import of the type `A` here
    |
    = note: `A` must be defined only once in the type namespace of this module

--- a/src/test/ui/issues/issue-51102.stderr
+++ b/src/test/ui/issues/issue-51102.stderr
@@ -2,7 +2,7 @@ error[E0026]: struct `SimpleStruct` does not have a field named `state`
   --> $DIR/issue-51102.rs:13:17
    |
 LL |                 state: 0,
-   |                 ^^^^^^^^ struct `SimpleStruct` does not have this field
+   |                 ^^^^^ struct `SimpleStruct` does not have this field
 
 error[E0025]: field `no_state_here` bound multiple times in the pattern
   --> $DIR/issue-51102.rs:24:17
@@ -16,7 +16,7 @@ error[E0026]: variant `SimpleEnum::NoState` does not have a field named `state`
   --> $DIR/issue-51102.rs:33:17
    |
 LL |                 state: 0
-   |                 ^^^^^^^^ variant `SimpleEnum::NoState` does not have this field
+   |                 ^^^^^ variant `SimpleEnum::NoState` does not have this field
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/issues/issue-52717.stderr
+++ b/src/test/ui/issues/issue-52717.stderr
@@ -5,7 +5,7 @@ LL |     A::A { fob } => { println!("{}", fob); }
    |            ^^^
    |            |
    |            variant `A::A` does not have this field
-   |            help: did you mean: `foo`
+   |            help: a field with a similar name exists: `foo`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-52891.stderr
+++ b/src/test/ui/issues/issue-52891.stderr
@@ -7,7 +7,6 @@ LL | use issue_52891::a;
    |     ^^^^^^^^^^^^^^ `a` reimported here
    |
    = note: `a` must be defined only once in the type namespace of this module
-   = help: remove unnecessary import
 
 error[E0252]: the name `a` is defined multiple times
   --> $DIR/issue-52891.rs:14:19
@@ -125,7 +124,6 @@ LL | use issue_52891::n;
    |     ^^^^^^^^^^^^^^ `n` reimported here
    |
    = note: `n` must be defined only once in the type namespace of this module
-   = help: remove unnecessary import
 
 error: aborting due to 10 previous errors
 

--- a/src/test/ui/issues/issue-52891.stderr
+++ b/src/test/ui/issues/issue-52891.stderr
@@ -4,12 +4,10 @@ error[E0252]: the name `a` is defined multiple times
 LL | use issue_52891::a;
    |     -------------- previous import of the module `a` here
 LL | use issue_52891::a;
-   | ----^^^^^^^^^^^^^^-
-   | |   |
-   | |   `a` reimported here
-   | help: remove unnecessary import
+   |     ^^^^^^^^^^^^^^ `a` reimported here
    |
    = note: `a` must be defined only once in the type namespace of this module
+   = help: remove unnecessary import
 
 error[E0252]: the name `a` is defined multiple times
   --> $DIR/issue-52891.rs:14:19
@@ -129,15 +127,13 @@ error[E0252]: the name `n` is defined multiple times
   --> $DIR/issue-52891.rs:36:5
    |
 LL | use issue_52891::n;
-   | -------------------
-   | |   |
-   | |   previous import of the module `n` here
-   | help: remove unnecessary import
+   |     -------------- previous import of the module `n` here
 LL | #[macro_use]
 LL | use issue_52891::n;
    |     ^^^^^^^^^^^^^^ `n` reimported here
    |
    = note: `n` must be defined only once in the type namespace of this module
+   = help: remove unnecessary import
 
 error: aborting due to 10 previous errors
 

--- a/src/test/ui/issues/issue-52891.stderr
+++ b/src/test/ui/issues/issue-52891.stderr
@@ -44,10 +44,7 @@ LL | use issue_52891::a;
    |     -------------- previous import of the module `a` here
 ...
 LL | use issue_52891::{f, g, a};
-   |                       --^
-   |                       | |
-   |                       | `a` reimported here
-   |                       help: remove unnecessary import
+   |                         ^ `a` reimported here
    |
    = note: `a` must be defined only once in the type namespace of this module
 
@@ -82,16 +79,11 @@ LL |     a,
 error[E0252]: the name `a` is defined multiple times
   --> $DIR/issue-52891.rs:26:5
    |
-LL |   use issue_52891::a;
-   |       -------------- previous import of the module `a` here
+LL | use issue_52891::a;
+   |     -------------- previous import of the module `a` here
 ...
-LL |       m,
-   |  ______-
-LL | |     a};
-   | |     ^
-   | |     |
-   | |_____`a` reimported here
-   |       help: remove unnecessary import
+LL |     a};
+   |     ^ `a` reimported here
    |
    = note: `a` must be defined only once in the type namespace of this module
 

--- a/src/test/ui/issues/issue-57362-2.stderr
+++ b/src/test/ui/issues/issue-57362-2.stderr
@@ -2,9 +2,7 @@ error[E0599]: no function or associated item named `make_g` found for type `for<
   --> $DIR/issue-57362-2.rs:22:25
    |
 LL |     let x = <fn (&())>::make_g();
-   |             ------------^^^^^^
-   |             |
-   |             function or associated item not found in `for<'r> fn(&'r ())`
+   |                         ^^^^^^ function or associated item not found in `for<'r> fn(&'r ())`
    |
    = help: items from traits can only be used if the trait is implemented and in scope
    = note: the following trait defines an item `make_g`, perhaps you need to implement it:

--- a/src/test/ui/issues/issue-58857.stderr
+++ b/src/test/ui/issues/issue-58857.stderr
@@ -2,7 +2,8 @@ error: negative trait bounds are not supported
   --> $DIR/issue-58857.rs:4:7
    |
 LL | impl<A: !Valid> Conj<A>{}
-   |       ^^^^^^^^ help: remove the trait bound
+   |       ^^^^^^^^ negative trait bounds are not supported
+   = help: remove the trait bound
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-7950.stderr
+++ b/src/test/ui/issues/issue-7950.stderr
@@ -5,9 +5,7 @@ LL | struct Foo;
    | ----------- function or associated item `bar` not found for this
 ...
 LL |     Foo::bar();
-   |     -----^^^
-   |     |
-   |     function or associated item not found in `Foo`
+   |          ^^^ function or associated item not found in `Foo`
 
 error: aborting due to previous error
 

--- a/src/test/ui/lexical-scopes.stderr
+++ b/src/test/ui/lexical-scopes.stderr
@@ -12,9 +12,7 @@ error[E0599]: no function or associated item named `f` found for type `Foo` in t
   --> $DIR/lexical-scopes.rs:10:10
    |
 LL |     Foo::f();
-   |     -----^
-   |     |
-   |     function or associated item not found in `Foo`
+   |          ^ function or associated item not found in `Foo`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/macros/missing-comma.rs
+++ b/src/test/ui/macros/missing-comma.rs
@@ -6,6 +6,11 @@ macro_rules! foo {
     ($a:ident, $b:ident, $c:ident, $d:ident, $e:ident) => ();
 }
 
+macro_rules! bar {
+    ($lvl:expr, $($arg:tt)+) => {}
+}
+
+
 fn main() {
     println!("{}" a);
     //~^ ERROR expected token: `,`
@@ -17,4 +22,6 @@ fn main() {
     //~^ ERROR no rules expected the token `d`
     foo!(a, b, c d e);
     //~^ ERROR no rules expected the token `d`
+    bar!(Level::Error, );
+    //~^ ERROR unexpected end of macro invocation
 }

--- a/src/test/ui/macros/missing-comma.stderr
+++ b/src/test/ui/macros/missing-comma.stderr
@@ -1,11 +1,11 @@
 error: expected token: `,`
-  --> $DIR/missing-comma.rs:10:19
+  --> $DIR/missing-comma.rs:15:19
    |
 LL |     println!("{}" a);
    |                   ^
 
 error: no rules expected the token `b`
-  --> $DIR/missing-comma.rs:12:12
+  --> $DIR/missing-comma.rs:17:12
    |
 LL | macro_rules! foo {
    | ---------------- when calling this macro
@@ -16,7 +16,7 @@ LL |     foo!(a b);
    |           help: missing comma here
 
 error: no rules expected the token `e`
-  --> $DIR/missing-comma.rs:14:21
+  --> $DIR/missing-comma.rs:19:21
    |
 LL | macro_rules! foo {
    | ---------------- when calling this macro
@@ -27,7 +27,7 @@ LL |     foo!(a, b, c, d e);
    |                    help: missing comma here
 
 error: no rules expected the token `d`
-  --> $DIR/missing-comma.rs:16:18
+  --> $DIR/missing-comma.rs:21:18
    |
 LL | macro_rules! foo {
    | ---------------- when calling this macro
@@ -38,7 +38,7 @@ LL |     foo!(a, b, c d, e);
    |                 help: missing comma here
 
 error: no rules expected the token `d`
-  --> $DIR/missing-comma.rs:18:18
+  --> $DIR/missing-comma.rs:23:18
    |
 LL | macro_rules! foo {
    | ---------------- when calling this macro
@@ -46,5 +46,14 @@ LL | macro_rules! foo {
 LL |     foo!(a, b, c d e);
    |                  ^ no rules expected this token in macro call
 
-error: aborting due to 5 previous errors
+error: unexpected end of macro invocation
+  --> $DIR/missing-comma.rs:25:23
+   |
+LL | macro_rules! bar {
+   | ---------------- when calling this macro
+...
+LL |     bar!(Level::Error, );
+   |                       ^ missing tokens in macro arguments
+
+error: aborting due to 6 previous errors
 

--- a/src/test/ui/nll/user-annotations/issue-55748-pat-types-constrain-bindings.rs
+++ b/src/test/ui/nll/user-annotations/issue-55748-pat-types-constrain-bindings.rs
@@ -1,0 +1,70 @@
+// This test is ensuring that type ascriptions on let bindings
+// constrain both:
+//
+// 1. the input expression on the right-hand side (after any potential
+//    coercion, and allowing for covariance), *and*
+//
+// 2. the bindings (if any) nested within the pattern on the left-hand
+//    side (and here, the type-constraint is *invariant*).
+
+#![feature(nll)]
+
+#![allow(dead_code, unused_mut)]
+type PairUncoupled<'a, 'b, T> = (&'a T, &'b T);
+type PairCoupledRegions<'a, T> = (&'a T, &'a T);
+type PairCoupledTypes<T> = (T, T);
+
+fn uncoupled_lhs<'a>(_x: &'a u32, s: &'static u32) -> &'static u32 {
+    let ((mut y, mut _z),): (PairUncoupled<u32>,) = ((s, &_x),); // ok
+    // Above compiling does *not* imply below would compile.
+    // ::std::mem::swap(&mut y, &mut _z);
+    y
+}
+
+fn swap_regions((mut y, mut _z): PairCoupledRegions<u32>) {
+    ::std::mem::swap(&mut y, &mut _z);
+}
+
+fn coupled_regions_lhs<'a>(_x: &'a u32, s: &'static u32) -> &'static u32 {
+    let ((y, _z),): (PairCoupledRegions<u32>,) = ((s, &_x),);
+    // If above line compiled, so should line below ...
+
+    // swap_regions((y, _z));
+
+    // ... but the ascribed type also invalidates this use of `y`
+    y //~ ERROR lifetime may not live long enough
+}
+
+fn swap_types((mut y, mut _z): PairCoupledTypes<&u32>) {
+    ::std::mem::swap(&mut y, &mut _z);
+}
+
+fn coupled_types_lhs<'a>(_x: &'a u32, s: &'static u32) -> &'static u32 {
+    let ((y, _z),): (PairCoupledTypes<&u32>,) = ((s, &_x),);
+    // If above line compiled, so should line below ...
+
+    // swap_types((y, _z));
+
+    // ... but the ascribed type also invalidates this use of `y`
+    y //~ ERROR lifetime may not live long enough
+}
+
+fn swap_wilds((mut y, mut _z): PairCoupledTypes<&u32>) {
+    ::std::mem::swap(&mut y, &mut _z);
+}
+
+fn coupled_wilds_lhs<'a>(_x: &'a u32, s: &'static u32) -> &'static u32 {
+    let ((y, _z),): (PairCoupledTypes<_>,) = ((s, &_x),);
+    // If above line compiled, so should line below
+    // swap_wilds((y, _z));
+
+    // ... but the ascribed type also invalidates this use of `y`
+    y //~ ERROR lifetime may not live long enough
+}
+
+fn main() {
+    uncoupled_lhs(&3, &4);
+    coupled_regions_lhs(&3, &4);
+    coupled_types_lhs(&3, &4);
+    coupled_wilds_lhs(&3, &4);
+}

--- a/src/test/ui/nll/user-annotations/issue-55748-pat-types-constrain-bindings.stderr
+++ b/src/test/ui/nll/user-annotations/issue-55748-pat-types-constrain-bindings.stderr
@@ -1,0 +1,29 @@
+error: lifetime may not live long enough
+  --> $DIR/issue-55748-pat-types-constrain-bindings.rs:35:5
+   |
+LL | fn coupled_regions_lhs<'a>(_x: &'a u32, s: &'static u32) -> &'static u32 {
+   |                        -- lifetime `'a` defined here
+...
+LL |     y
+   |     ^ returning this value requires that `'a` must outlive `'static`
+
+error: lifetime may not live long enough
+  --> $DIR/issue-55748-pat-types-constrain-bindings.rs:49:5
+   |
+LL | fn coupled_types_lhs<'a>(_x: &'a u32, s: &'static u32) -> &'static u32 {
+   |                      -- lifetime `'a` defined here
+...
+LL |     y
+   |     ^ returning this value requires that `'a` must outlive `'static`
+
+error: lifetime may not live long enough
+  --> $DIR/issue-55748-pat-types-constrain-bindings.rs:62:5
+   |
+LL | fn coupled_wilds_lhs<'a>(_x: &'a u32, s: &'static u32) -> &'static u32 {
+   |                      -- lifetime `'a` defined here
+...
+LL |     y
+   |     ^ returning this value requires that `'a` must outlive `'static`
+
+error: aborting due to 3 previous errors
+

--- a/src/test/ui/numeric/numeric-fields.stderr
+++ b/src/test/ui/numeric/numeric-fields.stderr
@@ -10,7 +10,7 @@ error[E0026]: struct `S` does not have a field named `0x1`
   --> $DIR/numeric-fields.rs:7:17
    |
 LL |         S{0: a, 0x1: b, ..} => {}
-   |                 ^^^^^^ struct `S` does not have this field
+   |                 ^^^ struct `S` does not have this field
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/parser/issue-33418.fixed
+++ b/src/test/ui/parser/issue-33418.fixed
@@ -1,10 +1,15 @@
 // run-rustfix
 
-trait Tr {} //~ ERROR negative trait bounds are not supported
-trait Tr2: SuperA {} //~ ERROR negative trait bounds are not supported
-trait Tr3: SuperB {} //~ ERROR negative trait bounds are not supported
+trait Tr {}
+//~^ ERROR negative trait bounds are not supported
+trait Tr2: SuperA {}
+//~^ ERROR negative trait bounds are not supported
+trait Tr3: SuperB {}
+//~^ ERROR negative trait bounds are not supported
 trait Tr4: SuperB + SuperD {}
+//~^ ERROR negative trait bounds are not supported
 trait Tr5 {}
+//~^ ERROR negative trait bounds are not supported
 
 trait SuperA {}
 trait SuperB {}

--- a/src/test/ui/parser/issue-33418.rs
+++ b/src/test/ui/parser/issue-33418.rs
@@ -1,12 +1,17 @@
 // run-rustfix
 
-trait Tr: !SuperA {} //~ ERROR negative trait bounds are not supported
-trait Tr2: SuperA + !SuperB {} //~ ERROR negative trait bounds are not supported
-trait Tr3: !SuperA + SuperB {} //~ ERROR negative trait bounds are not supported
-trait Tr4: !SuperA + SuperB //~ ERROR negative trait bounds are not supported
+trait Tr: !SuperA {}
+//~^ ERROR negative trait bounds are not supported
+trait Tr2: SuperA + !SuperB {}
+//~^ ERROR negative trait bounds are not supported
+trait Tr3: !SuperA + SuperB {}
+//~^ ERROR negative trait bounds are not supported
+trait Tr4: !SuperA + SuperB
     + !SuperC + SuperD {}
-trait Tr5: !SuperA //~ ERROR negative trait bounds are not supported
+//~^ ERROR negative trait bounds are not supported
+trait Tr5: !SuperA
     + !SuperB {}
+//~^ ERROR negative trait bounds are not supported
 
 trait SuperA {}
 trait SuperB {}

--- a/src/test/ui/parser/issue-33418.stderr
+++ b/src/test/ui/parser/issue-33418.stderr
@@ -2,41 +2,40 @@ error: negative trait bounds are not supported
   --> $DIR/issue-33418.rs:3:9
    |
 LL | trait Tr: !SuperA {}
-   |         ^^^^^^^^^ help: remove the trait bound
+   |         ^^^^^^^^^ negative trait bounds are not supported
+   = help: remove the trait bound
 
 error: negative trait bounds are not supported
-  --> $DIR/issue-33418.rs:4:19
+  --> $DIR/issue-33418.rs:5:19
    |
 LL | trait Tr2: SuperA + !SuperB {}
-   |          ---------^^^^^^^^^
-   |          |
-   |          help: remove the trait bound
+   |                   ^^^^^^^^^ negative trait bounds are not supported
+   = help: remove the trait bound
 
 error: negative trait bounds are not supported
-  --> $DIR/issue-33418.rs:5:10
+  --> $DIR/issue-33418.rs:7:10
    |
 LL | trait Tr3: !SuperA + SuperB {}
-   |          ^^^^^^^^^---------
-   |          |
-   |          help: remove the trait bound
+   |          ^^^^^^^^^ negative trait bounds are not supported
+   = help: remove the trait bound
 
 error: negative trait bounds are not supported
-  --> $DIR/issue-33418.rs:6:10
+  --> $DIR/issue-33418.rs:9:10
    |
-LL |   trait Tr4: !SuperA + SuperB
-   |  __________-^^^^^^^^
-LL | |     + !SuperC + SuperD {}
-   | |_____^^^^^^^^^________- help: remove the trait bounds
+LL | trait Tr4: !SuperA + SuperB
+   |          ^^^^^^^^^
+LL |     + !SuperC + SuperD {}
+   |     ^^^^^^^^^ negative trait bounds are not supported
+   = help: remove the trait bounds
 
 error: negative trait bounds are not supported
-  --> $DIR/issue-33418.rs:8:10
+  --> $DIR/issue-33418.rs:12:10
    |
-LL |   trait Tr5: !SuperA
-   |  __________-^^^^^^^^
-LL | |     + !SuperB {}
-   | |     ^^^^^^^^-
-   | |_____________|
-   |               help: remove the trait bounds
+LL | trait Tr5: !SuperA
+   |          ^^^^^^^^^
+LL |     + !SuperB {}
+   |     ^^^^^^^^^ negative trait bounds are not supported
+   = help: remove the trait bounds
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/proc-macro/shadow.stderr
+++ b/src/test/ui/proc-macro/shadow.stderr
@@ -1,16 +1,14 @@
 error[E0259]: the name `derive_a` is defined multiple times
   --> $DIR/shadow.rs:6:1
    |
-LL |   extern crate derive_a;
-   |   ---------------------- previous import of the extern crate `derive_a` here
-LL | / #[macro_use]
-LL | | extern crate derive_a;
-   | | ^^^^^^^^^^^^^^^^^^^^^-
-   | |_|____________________|
-   |   |                    help: remove unnecessary import
-   |   `derive_a` reimported here
+LL | extern crate derive_a;
+   | ---------------------- previous import of the extern crate `derive_a` here
+LL | #[macro_use]
+LL | extern crate derive_a;
+   | ^^^^^^^^^^^^^^^^^^^^^^ `derive_a` reimported here
    |
    = note: `derive_a` must be defined only once in the type namespace of this module
+   = help: remove unnecessary import
 
 error: aborting due to previous error
 

--- a/src/test/ui/proc-macro/shadow.stderr
+++ b/src/test/ui/proc-macro/shadow.stderr
@@ -8,7 +8,6 @@ LL | extern crate derive_a;
    | ^^^^^^^^^^^^^^^^^^^^^^ `derive_a` reimported here
    |
    = note: `derive_a` must be defined only once in the type namespace of this module
-   = help: remove unnecessary import
 
 error: aborting due to previous error
 

--- a/src/test/ui/resolve/resolve-conflict-import-vs-import.stderr
+++ b/src/test/ui/resolve/resolve-conflict-import-vs-import.stderr
@@ -4,12 +4,10 @@ error[E0252]: the name `transmute` is defined multiple times
 LL | use std::mem::transmute;
    |     ------------------- previous import of the value `transmute` here
 LL | use std::mem::transmute;
-   | ----^^^^^^^^^^^^^^^^^^^-
-   | |   |
-   | |   `transmute` reimported here
-   | help: remove unnecessary import
+   |     ^^^^^^^^^^^^^^^^^^^ `transmute` reimported here
    |
    = note: `transmute` must be defined only once in the value namespace of this module
+   = help: remove unnecessary import
 
 error: aborting due to previous error
 

--- a/src/test/ui/resolve/resolve-conflict-import-vs-import.stderr
+++ b/src/test/ui/resolve/resolve-conflict-import-vs-import.stderr
@@ -7,7 +7,6 @@ LL | use std::mem::transmute;
    |     ^^^^^^^^^^^^^^^^^^^ `transmute` reimported here
    |
    = note: `transmute` must be defined only once in the value namespace of this module
-   = help: remove unnecessary import
 
 error: aborting due to previous error
 

--- a/src/test/ui/rfc-2005-default-binding-mode/no-double-error.stderr
+++ b/src/test/ui/rfc-2005-default-binding-mode/no-double-error.stderr
@@ -2,9 +2,7 @@ error[E0599]: no associated item named `XXX` found for type `u32` in the current
   --> $DIR/no-double-error.rs:8:14
    |
 LL |         u32::XXX => { }
-   |         -----^^^
-   |         |
-   |         associated item not found in `u32`
+   |              ^^^ associated item not found in `u32`
 
 error: aborting due to previous error
 

--- a/src/test/ui/rust-2018/trait-import-suggestions.stderr
+++ b/src/test/ui/rust-2018/trait-import-suggestions.stderr
@@ -30,9 +30,7 @@ error[E0599]: no function or associated item named `from_str` found for type `u3
   --> $DIR/trait-import-suggestions.rs:30:18
    |
 LL |     let y = u32::from_str("33");
-   |             -----^^^^^^^^
-   |             |
-   |             function or associated item not found in `u32`
+   |                  ^^^^^^^^ function or associated item not found in `u32`
    |
    = help: items from traits can only be used if the trait is in scope
 help: the following trait is implemented but not in scope, perhaps add a `use` for it:

--- a/src/test/ui/structs/struct-field-cfg.stderr
+++ b/src/test/ui/structs/struct-field-cfg.stderr
@@ -22,7 +22,7 @@ error[E0026]: struct `Foo` does not have a field named `absent`
   --> $DIR/struct-field-cfg.rs:16:42
    |
 LL |     let Foo { present: (), #[cfg(all())] absent: () } = foo;
-   |                                          ^^^^^^^^^^ struct `Foo` does not have this field
+   |                                          ^^^^^^ struct `Foo` does not have this field
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/traits/trait-item-privacy.stderr
+++ b/src/test/ui/traits/trait-item-privacy.stderr
@@ -39,9 +39,7 @@ LL | struct S;
    | --------- function or associated item `a` not found for this
 ...
 LL |     S::a(&S);
-   |     ---^
-   |     |
-   |     function or associated item not found in `S`
+   |        ^ function or associated item not found in `S`
    |
    = help: items from traits can only be used if the trait is implemented and in scope
    = note: the following trait defines an item `a`, perhaps you need to implement it:
@@ -54,9 +52,7 @@ LL | struct S;
    | --------- function or associated item `b` not found for this
 ...
 LL |     S::b(&S);
-   |     ---^
-   |     |
-   |     function or associated item not found in `S`
+   |        ^ function or associated item not found in `S`
    |
    = help: items from traits can only be used if the trait is in scope
 help: the following trait is implemented but not in scope, perhaps add a `use` for it:
@@ -77,9 +73,7 @@ LL | struct S;
    | --------- associated item `A` not found for this
 ...
 LL |     S::A;
-   |     ---^
-   |     |
-   |     associated item not found in `S`
+   |        ^ associated item not found in `S`
    |
    = help: items from traits can only be used if the trait is implemented and in scope
    = note: the following trait defines an item `A`, perhaps you need to implement it:
@@ -92,9 +86,7 @@ LL | struct S;
    | --------- associated item `B` not found for this
 ...
 LL |     S::B;
-   |     ---^
-   |     |
-   |     associated item not found in `S`
+   |        ^ associated item not found in `S`
    |
    = help: items from traits can only be used if the trait is in scope
 help: the following trait is implemented but not in scope, perhaps add a `use` for it:

--- a/src/test/ui/ufcs/ufcs-partially-resolved.stderr
+++ b/src/test/ui/ufcs/ufcs-partially-resolved.stderr
@@ -190,17 +190,13 @@ error[E0599]: no associated item named `NN` found for type `<u8 as Tr>::Y` in th
   --> $DIR/ufcs-partially-resolved.rs:38:20
    |
 LL |     <u8 as Tr>::Y::NN;
-   |     ---------------^^
-   |     |
-   |     associated item not found in `<u8 as Tr>::Y`
+   |                    ^^ associated item not found in `<u8 as Tr>::Y`
 
 error[E0599]: no associated item named `N` found for type `<u8 as Dr>::X` in the current scope
   --> $DIR/ufcs-partially-resolved.rs:55:20
    |
 LL |     <u8 as Dr>::X::N;
-   |     ---------------^
-   |     |
-   |     associated item not found in `<u8 as Dr>::X`
+   |                    ^ associated item not found in `<u8 as Dr>::X`
 
 error: aborting due to 32 previous errors
 

--- a/src/test/ui/unresolved/unresolved-extern-mod-suggestion.stderr
+++ b/src/test/ui/unresolved/unresolved-extern-mod-suggestion.stderr
@@ -7,7 +7,6 @@ LL | use core;
    |     ^^^^ `core` reimported here
    |
    = note: `core` must be defined only once in the type namespace of this module
-   = help: remove unnecessary import
 
 error: aborting due to previous error
 

--- a/src/test/ui/unresolved/unresolved-extern-mod-suggestion.stderr
+++ b/src/test/ui/unresolved/unresolved-extern-mod-suggestion.stderr
@@ -4,12 +4,10 @@ error[E0254]: the name `core` is defined multiple times
 LL | extern crate core;
    | ------------------ previous import of the extern crate `core` here
 LL | use core;
-   | ----^^^^-
-   | |   |
-   | |   `core` reimported here
-   | help: remove unnecessary import
+   |     ^^^^ `core` reimported here
    |
    = note: `core` must be defined only once in the type namespace of this module
+   = help: remove unnecessary import
 
 error: aborting due to previous error
 

--- a/src/test/ui/unspecified-self-in-trait-ref.stderr
+++ b/src/test/ui/unspecified-self-in-trait-ref.stderr
@@ -2,33 +2,25 @@ error[E0599]: no function or associated item named `lol` found for type `dyn Foo
   --> $DIR/unspecified-self-in-trait-ref.rs:10:18
    |
 LL |     let a = Foo::lol();
-   |             -----^^^
-   |             |
-   |             function or associated item not found in `dyn Foo<_>`
+   |                  ^^^ function or associated item not found in `dyn Foo<_>`
 
 error[E0599]: no function or associated item named `lol` found for type `dyn Foo<_>` in the current scope
   --> $DIR/unspecified-self-in-trait-ref.rs:12:23
    |
 LL |     let b = Foo::<_>::lol();
-   |             ----------^^^
-   |             |
-   |             function or associated item not found in `dyn Foo<_>`
+   |                       ^^^ function or associated item not found in `dyn Foo<_>`
 
 error[E0599]: no function or associated item named `lol` found for type `dyn Bar<_, _>` in the current scope
   --> $DIR/unspecified-self-in-trait-ref.rs:14:18
    |
 LL |     let c = Bar::lol();
-   |             -----^^^
-   |             |
-   |             function or associated item not found in `dyn Bar<_, _>`
+   |                  ^^^ function or associated item not found in `dyn Bar<_, _>`
 
 error[E0599]: no function or associated item named `lol` found for type `dyn Bar<usize, _>` in the current scope
   --> $DIR/unspecified-self-in-trait-ref.rs:16:30
    |
 LL |     let d = Bar::<usize, _>::lol();
-   |             -----------------^^^
-   |             |
-   |             function or associated item not found in `dyn Bar<usize, _>`
+   |                              ^^^ function or associated item not found in `dyn Bar<usize, _>`
 
 error[E0393]: the type parameter `A` must be explicitly specified
   --> $DIR/unspecified-self-in-trait-ref.rs:18:13

--- a/src/test/ui/use/use-paths-as-items.stderr
+++ b/src/test/ui/use/use-paths-as-items.stderr
@@ -7,7 +7,6 @@ LL | use std::mem;
    |     ^^^^^^^^ `mem` reimported here
    |
    = note: `mem` must be defined only once in the type namespace of this module
-   = help: remove unnecessary import
 
 error: aborting due to previous error
 

--- a/src/test/ui/use/use-paths-as-items.stderr
+++ b/src/test/ui/use/use-paths-as-items.stderr
@@ -4,12 +4,10 @@ error[E0252]: the name `mem` is defined multiple times
 LL | use std::{mem, ptr};
    |           --- previous import of the module `mem` here
 LL | use std::mem;
-   | ----^^^^^^^^-
-   | |   |
-   | |   `mem` reimported here
-   | help: remove unnecessary import
+   |     ^^^^^^^^ `mem` reimported here
    |
    = note: `mem` must be defined only once in the type namespace of this module
+   = help: remove unnecessary import
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Successful merges:

 - #57729 (extra testing of how NLL handles wildcard type `_`)
 - #58986 ([CI] Update binutils for powerpc64 and powerpc64le)
 - #59084 (Tweak some diagnostic spans)
 - #59106 (Add peer_addr function to UdpSocket)
 - #59116 (Be more discerning on when to attempt suggesting a comma in a macro invocation)
 - #59240 (use the identifier span for missing struct field)
 - #59251 (Use a valid name for graphviz graphs)
 - #59252 (add self to mailmap)

Failed merges:


r? @ghost