### PR TITLE
Refactor async fn return type lowering

### DIFF
--- a/src/librustc/hir/intravisit.rs
+++ b/src/librustc/hir/intravisit.rs
@@ -490,7 +490,11 @@ pub fn walk_item<'v, V: Visitor<'v>>(visitor: &mut V, item: &'v Item) {
             visitor.visit_ty(ty);
             visitor.visit_generics(generics)
         }
-        ItemKind::Existential(ExistTy { ref generics, ref bounds, impl_trait_fn: _ }) => {
+        ItemKind::Existential(ExistTy {
+            ref generics,
+            ref bounds,
+            ..
+        }) => {
             visitor.visit_id(item.hir_id);
             walk_generics(visitor, generics);
             walk_list!(visitor, visit_param_bound, bounds);

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -1799,6 +1799,18 @@ pub struct ExistTy {
     pub generics: Generics,
     pub bounds: GenericBounds,
     pub impl_trait_fn: Option<DefId>,
+    pub origin: ExistTyOrigin,
+}
+
+/// Where the existential type came from
+#[derive(Copy, Clone, RustcEncodable, RustcDecodable, Debug, HashStable)]
+pub enum ExistTyOrigin {
+    /// `existential type Foo: Trait;`
+    ExistentialType,
+    /// `-> impl Trait`
+    ReturnImplTrait,
+    /// `async fn`
+    AsyncFn,
 }
 
 /// The various kinds of types recognized by the compiler.

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -2891,7 +2891,7 @@ fn insert_late_bound_lifetimes(
     }
 }
 
-fn report_missing_lifetime_specifiers(
+pub fn report_missing_lifetime_specifiers(
     sess: &Session,
     span: Span,
     count: usize,

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1979,6 +1979,7 @@ fn explicit_predicates_of<'a, 'tcx>(
                     ref bounds,
                     impl_trait_fn,
                     ref generics,
+                    origin: _,
                 }) => {
                     let substs = InternalSubsts::identity_for_item(tcx, def_id);
                     let opaque_ty = tcx.mk_opaque(def_id, substs);

--- a/src/test/run-pass/async-await.rs
+++ b/src/test/run-pass/async-await.rs
@@ -79,6 +79,11 @@ async fn async_fn(x: u8) -> u8 {
     x
 }
 
+async fn generic_async_fn<T>(x: T) -> T {
+    await!(wake_and_yield_once());
+    x
+}
+
 async fn async_fn_with_borrow(x: &u8) -> u8 {
     await!(wake_and_yield_once());
     *x
@@ -96,14 +101,21 @@ fn async_fn_with_impl_future_named_lifetime<'a>(x: &'a u8) -> impl Future<Output
     }
 }
 
-async fn async_fn_with_named_lifetime_multiple_args<'a>(x: &'a u8, _y: &'a u8) -> u8 {
+/* FIXME(cramertj) support when `existential type T<'a, 'b>:;` works
+async fn async_fn_multiple_args(x: &u8, _y: &u8) -> u8 {
+    await!(wake_and_yield_once());
+    *x
+}
+*/
+
+async fn async_fn_multiple_args_named_lifetime<'a>(x: &'a u8, _y: &'a u8) -> u8 {
     await!(wake_and_yield_once());
     *x
 }
 
 fn async_fn_with_internal_borrow(y: u8) -> impl Future<Output = u8> {
     async move {
-        await!(async_fn_with_borrow(&y))
+        await!(async_fn_with_borrow_named_lifetime(&y))
     }
 }
 
@@ -162,6 +174,7 @@ fn main() {
         async_nonmove_block,
         async_closure,
         async_fn,
+        generic_async_fn,
         async_fn_with_internal_borrow,
         Foo::async_method,
         |x| {
@@ -170,7 +183,6 @@ fn main() {
             }
         },
     }
-
     test_with_borrow! {
         async_block_with_borrow_named_lifetime,
         async_fn_with_borrow,
@@ -178,7 +190,7 @@ fn main() {
         async_fn_with_impl_future_named_lifetime,
         |x| {
             async move {
-                await!(async_fn_with_named_lifetime_multiple_args(x, x))
+                await!(async_fn_multiple_args_named_lifetime(x, x))
             }
         },
     }

--- a/src/test/ui/async-fn-multiple-lifetimes.rs
+++ b/src/test/ui/async-fn-multiple-lifetimes.rs
@@ -5,7 +5,7 @@
 use std::ops::Add;
 
 async fn multiple_named_lifetimes<'a, 'b>(_: &'a u8, _: &'b u8) {}
-//~^ ERROR multiple different lifetimes used in arguments of `async fn`
+//~^ ERROR ambiguous lifetime bound in `async fn`
 
 async fn multiple_hrtb_and_single_named_lifetime_ok<'c>(
     _: impl for<'a> Add<&'a u8>,
@@ -14,7 +14,6 @@ async fn multiple_hrtb_and_single_named_lifetime_ok<'c>(
 ) {}
 
 async fn multiple_elided_lifetimes(_: &u8, _: &u8) {}
-//~^ ERROR multiple elided lifetimes used
-//~^^ ERROR missing lifetime specifier
+//~^ ambiguous lifetime bound in `async fn`
 
 fn main() {}

--- a/src/test/ui/async-fn-multiple-lifetimes.stderr
+++ b/src/test/ui/async-fn-multiple-lifetimes.stderr
@@ -1,32 +1,20 @@
-error[E0709]: multiple different lifetimes used in arguments of `async fn`
-  --> $DIR/async-fn-multiple-lifetimes.rs:7:47
+error: ambiguous lifetime bound in `async fn`
+  --> $DIR/async-fn-multiple-lifetimes.rs:7:65
    |
 LL | async fn multiple_named_lifetimes<'a, 'b>(_: &'a u8, _: &'b u8) {}
-   |                                               ^^         ^^ different lifetime here
-   |                                               |
-   |                                               first lifetime here
+   |                                                                 ^ neither `'a` nor `'b` outlives the other
    |
-   = help: `async fn` can only accept borrowed values with identical lifetimes
+   = note: multiple unrelated lifetimes are not allowed in `async fn`.
+   = note: if you're using argument-position elided lifetimes, consider switching to a single named lifetime.
 
-error[E0707]: multiple elided lifetimes used in arguments of `async fn`
-  --> $DIR/async-fn-multiple-lifetimes.rs:16:39
+error: ambiguous lifetime bound in `async fn`
+  --> $DIR/async-fn-multiple-lifetimes.rs:16:52
    |
 LL | async fn multiple_elided_lifetimes(_: &u8, _: &u8) {}
-   |                                       ^       ^ different lifetime here
-   |                                       |
-   |                                       first lifetime here
+   |                                                    ^ the elided lifetimes here do not outlive one another
    |
-   = help: consider giving these arguments named lifetimes
+   = note: multiple unrelated lifetimes are not allowed in `async fn`.
+   = note: if you're using argument-position elided lifetimes, consider switching to a single named lifetime.
 
-error[E0106]: missing lifetime specifier
-  --> $DIR/async-fn-multiple-lifetimes.rs:16:39
-   |
-LL | async fn multiple_elided_lifetimes(_: &u8, _: &u8) {}
-   |                                       ^ expected lifetime parameter
-   |
-   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `_` or `_`
+error: aborting due to 2 previous errors
 
-error: aborting due to 3 previous errors
-
-Some errors occurred: E0106, E0707, E0709.
-For more information about an error, try `rustc --explain E0106`.

--- a/src/test/ui/issues/issue-54974.rs
+++ b/src/test/ui/issues/issue-54974.rs
@@ -1,0 +1,16 @@
+// compile-pass
+// edition:2018
+
+#![feature(async_await, await_macro, futures_api)]
+
+use std::sync::Arc;
+
+trait SomeTrait: Send + Sync + 'static {
+    fn do_something(&self);
+}
+
+async fn my_task(obj: Arc<SomeTrait>) {
+    unimplemented!()
+}
+
+fn main() {}

--- a/src/test/ui/issues/issue-55324.rs
+++ b/src/test/ui/issues/issue-55324.rs
@@ -1,0 +1,14 @@
+// compile-pass
+// edition:2018
+
+#![feature(async_await, await_macro, futures_api)]
+
+use std::future::Future;
+
+#[allow(unused)]
+async fn foo<F: Future<Output = i32>>(x: &i32, future: F) -> i32 {
+    let y = await!(future);
+    *x + y
+}
+
+fn main() {}

--- a/src/test/ui/issues/issue-58885.rs
+++ b/src/test/ui/issues/issue-58885.rs
@@ -1,0 +1,21 @@
+// compile-pass
+// edition:2018
+
+#![feature(async_await, await_macro, futures_api)]
+
+struct Xyz {
+    a: u64,
+}
+
+trait Foo {}
+
+impl Xyz {
+    async fn do_sth<'a>(
+        &'a self, foo: &'a dyn Foo
+    ) -> bool
+    {
+        true
+    }
+}
+
+fn main() {}

--- a/src/test/ui/issues/issue-59001.rs
+++ b/src/test/ui/issues/issue-59001.rs
@@ -1,0 +1,17 @@
+// compile-pass
+// edition:2018
+
+#![feature(async_await, await_macro, futures_api)]
+
+use std::future::Future;
+
+#[allow(unused)]
+async fn enter<'a, F, R>(mut callback: F)
+where
+    F: FnMut(&'a mut i32) -> R,
+    R: Future<Output = ()> + 'a,
+{
+    unimplemented!()
+}
+
+fn main() {}


### PR DESCRIPTION
async fn now lowers directly to an existential type declaration
rather than reusing the `impl Trait` return type lowering.

As part of this, it lowers all argument-position elided lifetimes
using the in-band-lifetimes machinery, creating fresh parameter
names for each of them, using each lifetime parameter as a generic
argument to the generated existential type.

This doesn't currently successfully allow multiple
argument-position elided lifetimes since `existential type`
doesn't yet support multiple lifetimes where neither outlive
the other:
```rust
existential type Foo<'a, 'b>:; // error: ambiguous lifetime bound in `impl Trait`
fn foo<'a, 'b>(_: &'a u8, _: &'b u8) -> Foo<'a, 'b> { () } 
```

This requires a separate fix.

Fix #59001
Fix #58885
Fix #55324
Fix #54974
Progress on #56238

r? @nikomatsakis