### PR TITLE
Run branch cleanup after copy prop

### DIFF
--- a/src/librustc_mir/transform/mod.rs
+++ b/src/librustc_mir/transform/mod.rs
@@ -285,6 +285,7 @@ fn optimized_mir<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) -> &'tcx 
         &simplify_branches::SimplifyBranches::new("after-const-prop"),
         &deaggregator::Deaggregator,
         &copy_prop::CopyPropagation,
+        &simplify_branches::SimplifyBranches::new("after-copy-prop"),
         &remove_noop_landing_pads::RemoveNoopLandingPads,
         &simplify::SimplifyCfg::new("final"),
         &simplify::SimplifyLocals,

--- a/src/test/mir-opt/simplify_match.rs
+++ b/src/test/mir-opt/simplify_match.rs
@@ -1,0 +1,22 @@
+fn main() {
+    match { let x = false; x } {
+        true => println!("hello world!"),
+        false => {},
+    }
+}
+
+// END RUST SOURCE
+// START rustc.main.SimplifyBranches-after-copy-prop.before.mir
+// bb0: {
+//     ...
+//     switchInt(const false) -> [false: bb3, otherwise: bb1];
+// }
+// bb1: {
+// END rustc.main.SimplifyBranches-after-copy-prop.before.mir
+// START rustc.main.SimplifyBranches-after-copy-prop.after.mir
+// bb0: {
+//     ...
+//     goto -> bb3;
+// }
+// bb1: {
+// END rustc.main.SimplifyBranches-after-copy-prop.after.mir


### PR DESCRIPTION
This is preliminary work for https://github.com/rust-lang/rust/pull/59288#issuecomment-474277172 which gets rid of `if` in the HIR.

cc @rust-lang/wg-mir-opt 	@Centril 	