### PR TITLE
[beta] Rollup backports

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,10 +4,10 @@ Version 1.33.0 (2019-02-28)
 Language
 --------
 - [You can now use the `cfg(target_vendor)` attribute.][57465] E.g.
-  `#[cfg(target_vendor="linux")] fn main() { println!("Hello Linux!"); }`
+  `#[cfg(target_vendor="apple")] fn main() { println!("Hello Apple!"); }`
 - [Integer patterns such as in a match expression can now be exhaustive.][56362]
   E.g. You can have match statement on a `u8` that covers `0..=255` and
-  you would no longer be required to have a `_ => unreachable!()` case. 
+  you would no longer be required to have a `_ => unreachable!()` case.
 - [You can now have multiple patterns in `if let` and `while let`
   expressions.][57532] You can do this with the same syntax as a `match`
   expression. E.g.
@@ -51,8 +51,7 @@ Language
   // Allowed as there is only one `Read` in the module.
   pub trait Read {}
   ```
-- [`extern` functions will now abort by default when panicking.][55982]
-  This was previously undefined behaviour.
+- [You may now use `Rc`, `Arc`, and `Pin` as method receivers][56805].
 
 Compiler
 --------
@@ -109,27 +108,30 @@ Compatibility Notes
   are now deprecated in the standard library, and their usage will now produce a warning.
   Please use the `str::{trim_start, trim_end, trim_start_matches, trim_end_matches}`
   methods instead.
+- The `Error::cause` method has been deprecated in favor of `Error::source` which supports
+  downcasting.
 
-[57615]: https://github.com/rust-lang/rust/pull/57615/
-[57465]: https://github.com/rust-lang/rust/pull/57465/
-[57532]: https://github.com/rust-lang/rust/pull/57532/
-[57535]: https://github.com/rust-lang/rust/pull/57535/
-[57566]: https://github.com/rust-lang/rust/pull/57566/
+[55982]: https://github.com/rust-lang/rust/pull/55982/
+[56303]: https://github.com/rust-lang/rust/pull/56303/
+[56351]: https://github.com/rust-lang/rust/pull/56351/
+[56362]: https://github.com/rust-lang/rust/pull/56362
+[56642]: https://github.com/rust-lang/rust/pull/56642/
+[56769]: https://github.com/rust-lang/rust/pull/56769/
+[56805]: https://github.com/rust-lang/rust/pull/56805
+[56947]: https://github.com/rust-lang/rust/pull/56947/
+[57049]: https://github.com/rust-lang/rust/pull/57049/
+[57067]: https://github.com/rust-lang/rust/pull/57067/
+[57105]: https://github.com/rust-lang/rust/pull/57105
 [57130]: https://github.com/rust-lang/rust/pull/57130/
 [57167]: https://github.com/rust-lang/rust/pull/57167/
 [57175]: https://github.com/rust-lang/rust/pull/57175/
 [57234]: https://github.com/rust-lang/rust/pull/57234/
 [57332]: https://github.com/rust-lang/rust/pull/57332/
-[56947]: https://github.com/rust-lang/rust/pull/56947/
-[57049]: https://github.com/rust-lang/rust/pull/57049/
-[57067]: https://github.com/rust-lang/rust/pull/57067/
-[56769]: https://github.com/rust-lang/rust/pull/56769/
-[56642]: https://github.com/rust-lang/rust/pull/56642/
-[56303]: https://github.com/rust-lang/rust/pull/56303/
-[56351]: https://github.com/rust-lang/rust/pull/56351/
-[55982]: https://github.com/rust-lang/rust/pull/55982/
-[56362]: https://github.com/rust-lang/rust/pull/56362
-[57105]: https://github.com/rust-lang/rust/pull/57105
+[57465]: https://github.com/rust-lang/rust/pull/57465/
+[57532]: https://github.com/rust-lang/rust/pull/57532/
+[57535]: https://github.com/rust-lang/rust/pull/57535/
+[57566]: https://github.com/rust-lang/rust/pull/57566/
+[57615]: https://github.com/rust-lang/rust/pull/57615/
 [cargo/6484]: https://github.com/rust-lang/cargo/pull/6484/
 [`unix::FileExt::read_exact_at`]: https://doc.rust-lang.org/std/os/unix/fs/trait.FileExt.html#method.read_exact_at
 [`unix::FileExt::write_all_at`]: https://doc.rust-lang.org/std/os/unix/fs/trait.FileExt.html#method.write_all_at
@@ -170,7 +172,7 @@ Language
 - [You can now match against literals in macros with the `literal`
   specifier.][56072] This will match against a literal of any type.
   E.g. `1`, `'A'`, `"Hello World"`
-- [Self can now be used as a constructor and pattern for unit and tuple structs.][56365] E.g. 
+- [Self can now be used as a constructor and pattern for unit and tuple structs.][56365] E.g.
   ```rust
   struct Point(i32, i32);
 
@@ -460,7 +462,7 @@ Version 1.31.0 (2018-12-06)
 
 Language
 --------
-- 🎉 [This version marks the release of the 2018 edition of Rust.][54057] 🎉 
+- 🎉 [This version marks the release of the 2018 edition of Rust.][54057] 🎉
 - [New lifetime elision rules now allow for eliding lifetimes in functions and
   impl headers.][54778] E.g. `impl<'a> Reader for BufReader<'a> {}` can now be
   `impl Reader for BufReader<'_> {}`. Lifetimes are still required to be defined

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -110,8 +110,11 @@ Compatibility Notes
   methods instead.
 - The `Error::cause` method has been deprecated in favor of `Error::source` which supports
   downcasting.
+- [Libtest no longer creates a new thread for each test when
+  `--test-threads=1`.  It also runs the tests in deterministic order][56243]
 
 [55982]: https://github.com/rust-lang/rust/pull/55982/
+[56243]: https://github.com/rust-lang/rust/pull/56243
 [56303]: https://github.com/rust-lang/rust/pull/56303/
 [56351]: https://github.com/rust-lang/rust/pull/56351/
 [56362]: https://github.com/rust-lang/rust/pull/56362

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -241,6 +241,8 @@ pub struct Build {
     clippy_info: channel::GitInfo,
     miri_info: channel::GitInfo,
     rustfmt_info: channel::GitInfo,
+    in_tree_llvm_info: channel::GitInfo,
+    emscripten_llvm_info: channel::GitInfo,
     local_rebuild: bool,
     fail_fast: bool,
     doc_tests: DocTests,
@@ -363,6 +365,8 @@ impl Build {
         let clippy_info = channel::GitInfo::new(&config, &src.join("src/tools/clippy"));
         let miri_info = channel::GitInfo::new(&config, &src.join("src/tools/miri"));
         let rustfmt_info = channel::GitInfo::new(&config, &src.join("src/tools/rustfmt"));
+        let in_tree_llvm_info = channel::GitInfo::new(&config, &src.join("src/llvm-project"));
+        let emscripten_llvm_info = channel::GitInfo::new(&config, &src.join("src/llvm-emscripten"));
 
         let mut build = Build {
             initial_rustc: config.initial_rustc.clone(),
@@ -386,6 +390,8 @@ impl Build {
             clippy_info,
             miri_info,
             rustfmt_info,
+            in_tree_llvm_info,
+            emscripten_llvm_info,
             cc: HashMap::new(),
             cxx: HashMap::new(),
             ar: HashMap::new(),

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -639,10 +639,9 @@ impl<'a> Resolver<'a> {
         // but metadata cannot encode gensyms currently, so we create it here.
         // This is only a guess, two equivalent idents may incorrectly get different gensyms here.
         let ident = ident.gensym_if_underscore();
-        let def_id = def.def_id();
         let expansion = Mark::root(); // FIXME(jseyfried) intercrate hygiene
         match def {
-            Def::Mod(..) | Def::Enum(..) => {
+            Def::Mod(def_id) | Def::Enum(def_id) => {
                 let module = self.new_module(parent,
                                              ModuleKind::Def(def, ident.name),
                                              def_id,
@@ -650,13 +649,14 @@ impl<'a> Resolver<'a> {
                                              span);
                 self.define(parent, ident, TypeNS, (module, vis, DUMMY_SP, expansion));
             }
-            Def::Variant(..) | Def::TyAlias(..) | Def::ForeignTy(..) => {
+            Def::Variant(..) | Def::TyAlias(..) | Def::ForeignTy(..) | Def::Existential(..) |
+            Def::TraitAlias(..) | Def::PrimTy(..) | Def::ToolMod => {
                 self.define(parent, ident, TypeNS, (def, vis, DUMMY_SP, expansion));
             }
             Def::Fn(..) | Def::Static(..) | Def::Const(..) | Def::VariantCtor(..) => {
                 self.define(parent, ident, ValueNS, (def, vis, DUMMY_SP, expansion));
             }
-            Def::StructCtor(..) => {
+            Def::StructCtor(def_id, ..) => {
                 self.define(parent, ident, ValueNS, (def, vis, DUMMY_SP, expansion));
 
                 if let Some(struct_def_id) =
@@ -665,7 +665,7 @@ impl<'a> Resolver<'a> {
                     self.struct_constructors.insert(struct_def_id, (def, vis));
                 }
             }
-            Def::Trait(..) => {
+            Def::Trait(def_id) => {
                 let module_kind = ModuleKind::Def(def, ident.name);
                 let module = self.new_module(parent,
                                              module_kind,
@@ -686,18 +686,14 @@ impl<'a> Resolver<'a> {
                 }
                 module.populated.set(true);
             }
-            Def::Existential(..) |
-            Def::TraitAlias(..) => {
-                self.define(parent, ident, TypeNS, (def, vis, DUMMY_SP, expansion));
-            }
-            Def::Struct(..) | Def::Union(..) => {
+            Def::Struct(def_id) | Def::Union(def_id) => {
                 self.define(parent, ident, TypeNS, (def, vis, DUMMY_SP, expansion));
 
                 // Record field names for error reporting.
                 let field_names = self.cstore.struct_field_names_untracked(def_id);
                 self.insert_field_names(def_id, field_names);
             }
-            Def::Macro(..) => {
+            Def::Macro(..) | Def::NonMacroAttr(..) => {
                 self.define(parent, ident, MacroNS, (def, vis, DUMMY_SP, expansion));
             }
             _ => bug!("unexpected definition: {:?}", def)

--- a/src/stage0.txt
+++ b/src/stage0.txt
@@ -12,7 +12,7 @@
 # source tarball for a stable release you'll likely see `1.x.0` for rustc and
 # `0.x.0` for Cargo where they were released on `date`.
 
-date: 2019-02-25
+date: 2019-02-28
 rustc: 1.33.0
 cargo: 0.34.0
 
@@ -34,4 +34,4 @@ cargo: 0.34.0
 # looking at a beta source tarball and it's uncommented we'll shortly comment it
 # out.
 
-dev: 1
+#dev: 1

--- a/src/test/ui/rust-2018/uniform-paths/auxiliary/cross-crate.rs
+++ b/src/test/ui/rust-2018/uniform-paths/auxiliary/cross-crate.rs
@@ -1,0 +1,5 @@
+// edition:2018
+
+pub use ignore as built_in_attr;
+pub use u8 as built_in_type;
+pub use rustfmt as tool_mod;

--- a/src/test/ui/rust-2018/uniform-paths/cross-crate.rs
+++ b/src/test/ui/rust-2018/uniform-paths/cross-crate.rs
@@ -1,0 +1,11 @@
+// edition:2018
+// aux-build:cross-crate.rs
+
+extern crate cross_crate;
+use cross_crate::*;
+
+#[built_in_attr] //~ ERROR cannot use a built-in attribute through an import
+#[tool_mod::skip] //~ ERROR cannot use a tool module through an import
+fn main() {
+    let _: built_in_type; // OK
+}

--- a/src/test/ui/rust-2018/uniform-paths/cross-crate.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/cross-crate.stderr
@@ -1,0 +1,26 @@
+error: cannot use a built-in attribute through an import
+  --> $DIR/cross-crate.rs:7:3
+   |
+LL | #[built_in_attr]
+   |   ^^^^^^^^^^^^^
+   |
+note: the built-in attribute imported here
+  --> $DIR/cross-crate.rs:5:5
+   |
+LL | use cross_crate::*;
+   |     ^^^^^^^^^^^^^^
+
+error: cannot use a tool module through an import
+  --> $DIR/cross-crate.rs:8:3
+   |
+LL | #[tool_mod::skip]
+   |   ^^^^^^^^
+   |
+note: the tool module imported here
+  --> $DIR/cross-crate.rs:5:5
+   |
+LL | use cross_crate::*;
+   |     ^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/rust-2018/uniform-paths/cross-crate.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/cross-crate.stderr
@@ -1,7 +1,7 @@
 error: cannot use a built-in attribute through an import
   --> $DIR/cross-crate.rs:7:3
    |
-LL | #[built_in_attr]
+LL | #[built_in_attr] //~ ERROR cannot use a built-in attribute through an import
    |   ^^^^^^^^^^^^^
    |
 note: the built-in attribute imported here
@@ -13,7 +13,7 @@ LL | use cross_crate::*;
 error: cannot use a tool module through an import
   --> $DIR/cross-crate.rs:8:3
    |
-LL | #[tool_mod::skip]
+LL | #[tool_mod::skip] //~ ERROR cannot use a tool module through an import
    |   ^^^^^^^^
    |
 note: the tool module imported here


### PR DESCRIPTION
Rolled up:

* [beta] Move to static.r-l.o stable release #58896 

Cherry-picked:

* Add release notes for PR #56243 #58959 
* resolve: Account for new importable entities #59047 
* bootstrap: Default to a sensible llvm-suffix. #59173 

r? @ghost