### PR TITLE
Rollup of 10 pull requests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,7 +147,7 @@ of a random person. This is entirely optional.
 After someone has reviewed your pull request, they will leave an annotation
 on the pull request with an `r+`. It will look something like this:
 
-    @bors: r+ 38fe8d2
+    @bors r+
 
 This tells [@bors][bors], our lovable integration bot, that your pull request has
 been approved. The PR then enters the [merge queue][merge-queue], where @bors
@@ -302,7 +302,7 @@ from the source code itself.
 Documentation pull requests function in the same way as other pull requests,
 though you may see a slightly different form of `r+`:
 
-    @bors: r+ 38fe8d2 rollup
+    @bors r+ rollup
 
 That additional `rollup` tells @bors that this change is eligible for a 'rollup'.
 To save @bors some work, and to get small changes through more quickly, when

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ links to the major sections:
 * [Helpful Links and Information](#helpful-links-and-information)
 
 If you have questions, please make a post on [internals.rust-lang.org][internals] or
-hop on [#rust-internals][pound-rust-internals].
+hop on the [Rust Discord server][rust-discord], [Rust Zulip server][rust-zulip] or [#rust-internals][pound-rust-internals].
 
 As a reminder, all contributors are expected to follow our [Code of Conduct][coc].
 
@@ -27,6 +27,8 @@ can give you a good example of how a typical contribution would go.
 
 [pound-rust-internals]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
 [internals]: https://internals.rust-lang.org
+[rust-discord]: http://discord.gg/rust-lang
+[rust-zulip]: https://rust-lang.zulipchat.com
 [coc]: https://www.rust-lang.org/conduct.html
 [rustc-guide]: https://rust-lang.github.io/rustc-guide/
 [walkthrough]: https://rust-lang.github.io/rustc-guide/walkthrough.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,7 @@ can give you a good example of how a typical contribution would go.
 [pound-rust-internals]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
 [internals]: https://internals.rust-lang.org
 [coc]: https://www.rust-lang.org/conduct.html
+[rustc-guide]: https://rust-lang.github.io/rustc-guide/
 [walkthrough]: https://rust-lang.github.io/rustc-guide/walkthrough.html
 
 ## Feature Requests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,12 +136,12 @@ All pull requests are reviewed by another person. We have a bot,
 request.
 
 If you want to request that a specific person reviews your pull request,
-you can add an `r?` to the message. For example, Steve usually reviews
+you can add an `r?` to the message. For example, [Steve][steveklabnik] usually reviews
 documentation changes. So if you were to make a documentation change, add
 
     r? @steveklabnik
 
-to the end of the message, and @rust-highfive will assign @steveklabnik instead
+to the end of the message, and @rust-highfive will assign [@steveklabnik][steveklabnik] instead
 of a random person. This is entirely optional.
 
 After someone has reviewed your pull request, they will leave an annotation
@@ -150,11 +150,12 @@ on the pull request with an `r+`. It will look something like this:
     @bors r+
 
 This tells [@bors][bors], our lovable integration bot, that your pull request has
-been approved. The PR then enters the [merge queue][merge-queue], where @bors
+been approved. The PR then enters the [merge queue][merge-queue], where [@bors][bors]
 will run all the tests on every platform we support. If it all works out,
-@bors will merge your code into `master` and close the pull request.
+[@bors][bors] will merge your code into `master` and close the pull request.
 
 [rust-highfive]: https://github.com/rust-highfive
+[steveklabnik]: https://github.com/steveklabnik
 [bors]: https://github.com/bors
 [merge-queue]: https://buildbot2.rust-lang.org/homu/queue/rust
 
@@ -304,9 +305,9 @@ though you may see a slightly different form of `r+`:
 
     @bors r+ rollup
 
-That additional `rollup` tells @bors that this change is eligible for a 'rollup'.
-To save @bors some work, and to get small changes through more quickly, when
-@bors attempts to merge a commit that's rollup-eligible, it will also merge
+That additional `rollup` tells [@bors][bors] that this change is eligible for a 'rollup'.
+To save [@bors][bors] some work, and to get small changes through more quickly, when
+[@bors][bors] attempts to merge a commit that's rollup-eligible, it will also merge
 the other rollup-eligible patches too, and they'll get tested and merged at
 the same time.
 
@@ -433,7 +434,7 @@ are:
 * Although out of date, [Tom Lee's great blog article][tlgba] is very helpful
 * [rustaceans.org][ro] is helpful, but mostly dedicated to IRC
 * The [Rust Compiler Testing Docs][rctd]
-* For @bors, [this cheat sheet][cheatsheet] is helpful (Remember to replace `@homu` with `@bors` in the commands that you use.)
+* For [@bors][bors], [this cheat sheet][cheatsheet] is helpful (Remember to replace `@homu` with `@bors` in the commands that you use.)
 * **Google!** ([search only in Rust Documentation][gsearchdocs] to find types, traits, etc. quickly)
 * Don't be afraid to ask! The Rust community is friendly and helpful.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -433,7 +433,8 @@ are:
 * Although out of date, [Tom Lee's great blog article][tlgba] is very helpful
 * [rustaceans.org][ro] is helpful, but mostly dedicated to IRC
 * The [Rust Compiler Testing Docs][rctd]
-* For [@bors][bors], [this cheat sheet][cheatsheet] is helpful (Remember to replace `@homu` with `@bors` in the commands that you use.)
+* For [@bors][bors], [this cheat sheet][cheatsheet] is helpful
+(though you'll need to replace `@homu` with `@bors` in any commands)
 * **Google!** ([search only in Rust Documentation][gsearchdocs] to find types, traits, etc. quickly)
 * Don't be afraid to ask! The Rust community is friendly and helpful.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,7 +132,7 @@ request); you can add [git hooks](https://git-scm.com/book/en/v2/Customizing-Git
 before every push to make sure you never forget to make this check.
 
 All pull requests are reviewed by another person. We have a bot,
-@rust-highfive, that will automatically assign a random person to review your
+[@rust-highfive][rust-highfive], that will automatically assign a random person to review your
 request.
 
 If you want to request that a specific person reviews your pull request,
@@ -149,11 +149,13 @@ on the pull request with an `r+`. It will look something like this:
 
     @bors: r+ 38fe8d2
 
-This tells @bors, our lovable integration bot, that your pull request has
+This tells [@bors][bors], our lovable integration bot, that your pull request has
 been approved. The PR then enters the [merge queue][merge-queue], where @bors
 will run all the tests on every platform we support. If it all works out,
 @bors will merge your code into `master` and close the pull request.
 
+[rust-highfive]: https://github.com/rust-highfive
+[bors]: https://github.com/bors
 [merge-queue]: https://buildbot2.rust-lang.org/homu/queue/rust
 
 Speaking of tests, Rust has a comprehensive test suite. More information about

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,6 +154,15 @@ been approved. The PR then enters the [merge queue][merge-queue], where [@bors][
 will run all the tests on every platform we support. If it all works out,
 [@bors][bors] will merge your code into `master` and close the pull request.
 
+Depending on the scale of the change, you may see a slightly different form of `r+`:
+
+    @bors r+ rollup
+
+The additional `rollup` tells [@bors][bors] that this change is eligible for to be
+"rolled up". Changes that are rolled up are tested and merged at the same time, to
+speed the process up. Typically only small changes that are expected not to conflict
+with one another are rolled up.
+
 [rust-highfive]: https://github.com/rust-highfive
 [steveklabnik]: https://github.com/steveklabnik
 [bors]: https://github.com/bors
@@ -298,18 +307,8 @@ the submodule to. Running `./x.py build` should work now.
 
 Documentation improvements are very welcome. The source of `doc.rust-lang.org`
 is located in `src/doc` in the tree, and standard API documentation is generated
-from the source code itself.
-
-Documentation pull requests function in the same way as other pull requests,
-though you may see a slightly different form of `r+`:
-
-    @bors r+ rollup
-
-That additional `rollup` tells [@bors][bors] that this change is eligible for a 'rollup'.
-To save [@bors][bors] some work, and to get small changes through more quickly, when
-[@bors][bors] attempts to merge a commit that's rollup-eligible, it will also merge
-the other rollup-eligible patches too, and they'll get tested and merged at
-the same time.
+from the source code itself. Documentation pull requests function in the same way
+as other pull requests.
 
 To find documentation-related issues, sort by the [T-doc label][tdoc].
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ can give you a good example of how a typical contribution would go.
 [feature-requests]: #feature-requests
 
 To request a change to the way the Rust language works, please head over
-to the [RFCs repository](https://github.com/rust-lang/rfcs) and view the 
+to the [RFCs repository](https://github.com/rust-lang/rfcs) and view the
 [README](https://github.com/rust-lang/rfcs/blob/master/README.md)
 for instructions.
 
@@ -191,7 +191,7 @@ before the PR is merged.
 [breaking-tools-built-with-the-compiler]: #breaking-tools-built-with-the-compiler
 
 Rust's build system builds a number of tools that make use of the
-internals of the compiler. This includes 
+internals of the compiler. This includes
 [Clippy](https://github.com/rust-lang/rust-clippy),
 [RLS](https://github.com/rust-lang/rls) and
 [rustfmt](https://github.com/rust-lang/rustfmt). If these tools

--- a/src/libcore/hint.rs
+++ b/src/libcore/hint.rs
@@ -2,7 +2,7 @@
 
 //! Hints to compiler that affects how code should be emitted or optimized.
 
-use intrinsics;
+use {arch, intrinsics};
 
 /// Informs the compiler that this point in the code is not reachable, enabling
 /// further optimizations.
@@ -62,13 +62,32 @@ pub unsafe fn unreachable_unchecked() -> ! {
 #[inline]
 #[unstable(feature = "renamed_spin_loop", issue = "55002")]
 pub fn spin_loop() {
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    unsafe {
-        asm!("pause" ::: "memory" : "volatile");
+    #[cfg(
+        all(
+            any(target_arch = "x86", target_arch = "x86_64"),
+            target_feature = "sse2"
+        )
+    )] {
+        #[cfg(target_arch = "x86")] {
+            unsafe { arch::x86::_mm_pause() };
+        }
+
+        #[cfg(target_arch = "x86_64")] {
+            unsafe { arch::x86_64::_mm_pause() };
+        }
     }
 
-    #[cfg(target_arch = "aarch64")]
-    unsafe {
-        asm!("yield" ::: "memory" : "volatile");
+    #[cfg(
+        any(
+            target_arch = "aarch64",
+            all(target_arch = "arm", target_feature = "v6")
+        )
+    )] {
+        #[cfg(target_arch = "aarch64")] {
+            unsafe { arch::aarch64::__yield() };
+        }
+        #[cfg(target_arch = "arm")] {
+            unsafe { arch::arm::__yield() };
+        }
     }
 }

--- a/src/librustc/hir/check_attr.rs
+++ b/src/librustc/hir/check_attr.rs
@@ -177,16 +177,8 @@ impl<'a, 'tcx> CheckAttrVisitor<'a, 'tcx> {
         let mut is_transparent = false;
 
         for hint in &hints {
-            let name = if let Some(name) = hint.ident_str() {
-                name
-            } else {
-                // Invalid repr hint like repr(42). We don't check for unrecognized hints here
-                // (libsyntax does that), so just ignore it.
-                continue;
-            };
-
-            let (article, allowed_targets) = match name {
-                "C" | "align" => {
+            let (article, allowed_targets) = match hint.name_or_empty().get() {
+                name @ "C" | name @ "align" => {
                     is_c |= name == "C";
                     if target != Target::Struct &&
                             target != Target::Union &&

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -2672,7 +2672,7 @@ impl<'a> LoweringContext<'a> {
 
     fn lower_variant_data(&mut self, vdata: &VariantData) -> hir::VariantData {
         match *vdata {
-            VariantData::Struct(ref fields, id) => {
+            VariantData::Struct(ref fields, id, recovered) => {
                 let LoweredNodeId { node_id: _, hir_id } = self.lower_node_id(id);
 
                 hir::VariantData::Struct(
@@ -2682,6 +2682,7 @@ impl<'a> LoweringContext<'a> {
                         .map(|f| self.lower_struct_field(f))
                         .collect(),
                     hir_id,
+                    recovered,
                 )
             },
             VariantData::Tuple(ref fields, id) => {

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -2173,7 +2173,7 @@ impl StructField {
 /// Id of the whole struct lives in `Item`.
 #[derive(Clone, RustcEncodable, RustcDecodable, Debug, HashStable)]
 pub enum VariantData {
-    Struct(HirVec<StructField>, HirId, bool),
+    Struct(HirVec<StructField>, HirId, /* recovered */ bool),
     Tuple(HirVec<StructField>, HirId),
     Unit(HirId),
 }

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -2173,7 +2173,7 @@ impl StructField {
 /// Id of the whole struct lives in `Item`.
 #[derive(Clone, RustcEncodable, RustcDecodable, Debug, HashStable)]
 pub enum VariantData {
-    Struct(HirVec<StructField>, HirId),
+    Struct(HirVec<StructField>, HirId, bool),
     Tuple(HirVec<StructField>, HirId),
     Unit(HirId),
 }
@@ -2187,7 +2187,7 @@ impl VariantData {
     }
     pub fn hir_id(&self) -> HirId {
         match *self {
-            VariantData::Struct(_, hir_id)
+            VariantData::Struct(_, hir_id, _)
             | VariantData::Tuple(_, hir_id)
             | VariantData::Unit(hir_id) => hir_id,
         }

--- a/src/librustc/lint/levels.rs
+++ b/src/librustc/lint/levels.rs
@@ -194,7 +194,7 @@ impl<'a> LintLevelsBuilder<'a> {
             struct_span_err!(sess, span, E0452, "malformed lint attribute")
         };
         for attr in attrs {
-            let level = match attr.ident_str().and_then(|name| Level::from_str(name)) {
+            let level = match Level::from_str(&attr.name_or_empty()) {
                 None => continue,
                 Some(lvl) => lvl,
             };

--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -723,12 +723,7 @@ pub fn struct_lint_level<'a>(sess: &'a Session,
 
 pub fn maybe_lint_level_root(tcx: TyCtxt<'_, '_, '_>, id: hir::HirId) -> bool {
     let attrs = tcx.hir().attrs_by_hir_id(id);
-    for attr in attrs {
-        if attr.ident_str().and_then(Level::from_str).is_some() {
-            return true;
-        }
-    }
-    false
+    attrs.iter().any(|attr| Level::from_str(&attr.name_or_empty()).is_some())
 }
 
 fn lint_levels<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, cnum: CrateNum)

--- a/src/librustc/middle/lib_features.rs
+++ b/src/librustc/middle/lib_features.rs
@@ -65,9 +65,9 @@ impl<'a, 'tcx> LibFeatureCollector<'a, 'tcx> {
                 for meta in metas {
                     if let Some(mi) = meta.meta_item() {
                         // Find the `feature = ".."` meta-item.
-                        match (mi.ident_str(), mi.value_str()) {
-                            (Some("feature"), val) => feature = val,
-                            (Some("since"), val) => since = val,
+                        match (mi.name_or_empty().get(), mi.value_str()) {
+                            ("feature", val) => feature = val,
+                            ("since", val) => since = val,
                             _ => {}
                         }
                     }

--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -194,12 +194,11 @@ impl<'a, 'tcx: 'a> Annotator<'a, 'tcx> {
         } else {
             // Emit errors for non-staged-api crates.
             for attr in attrs {
-                if let Some(tag) = attr.ident_str() {
-                    if tag == "unstable" || tag == "stable" || tag == "rustc_deprecated" {
-                        attr::mark_used(attr);
-                        self.tcx.sess.span_err(attr.span, "stability attributes may not be used \
-                                                           outside of the standard library");
-                    }
+                let name = attr.name_or_empty();
+                if ["unstable", "stable", "rustc_deprecated"].contains(&name.get()) {
+                    attr::mark_used(attr);
+                    self.tcx.sess.span_err(attr.span, "stability attributes may not be used \
+                                                        outside of the standard library");
                 }
             }
 

--- a/src/librustc/traits/on_unimplemented.rs
+++ b/src/librustc/traits/on_unimplemented.rs
@@ -177,9 +177,9 @@ impl<'a, 'gcx, 'tcx> OnUnimplementedDirective {
         for command in self.subcommands.iter().chain(Some(self)).rev() {
             if let Some(ref condition) = command.condition {
                 if !attr::eval_condition(condition, &tcx.sess.parse_sess, &mut |c| {
-                    c.ident_str().map_or(false, |name| {
+                    c.ident().map_or(false, |ident| {
                         options.contains(&(
-                            name.to_string(),
+                            ident.to_string(),
                             c.value_str().map(|s| s.as_str().to_string())
                         ))
                     })

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -1811,6 +1811,7 @@ pub struct VariantDef {
     pub fields: Vec<FieldDef>,
     pub ctor_kind: CtorKind,
     flags: VariantFlags,
+    pub recovered: bool,
 }
 
 impl<'a, 'gcx, 'tcx> VariantDef {
@@ -1829,16 +1830,17 @@ impl<'a, 'gcx, 'tcx> VariantDef {
     ///
     /// If someone speeds up attribute loading to not be a performance concern, they can
     /// remove this hack and use the constructor `DefId` everywhere.
-    pub fn new(tcx: TyCtxt<'a, 'gcx, 'tcx>,
-               did: DefId,
-               ident: Ident,
-               discr: VariantDiscr,
-               fields: Vec<FieldDef>,
-               adt_kind: AdtKind,
-               ctor_kind: CtorKind,
-               attribute_def_id: DefId)
-               -> Self
-    {
+    pub fn new(
+        tcx: TyCtxt<'a, 'gcx, 'tcx>,
+        did: DefId,
+        ident: Ident,
+        discr: VariantDiscr,
+        fields: Vec<FieldDef>,
+        adt_kind: AdtKind,
+        ctor_kind: CtorKind,
+        attribute_def_id: DefId,
+        recovered: bool,
+    ) -> Self {
         debug!("VariantDef::new({:?}, {:?}, {:?}, {:?}, {:?}, {:?}, {:?})", did, ident, discr,
                fields, adt_kind, ctor_kind, attribute_def_id);
         let mut flags = VariantFlags::NO_VARIANT_FLAGS;
@@ -1852,7 +1854,8 @@ impl<'a, 'gcx, 'tcx> VariantDef {
             discr,
             fields,
             ctor_kind,
-            flags
+            flags,
+            recovered,
         }
     }
 
@@ -1868,7 +1871,8 @@ impl_stable_hash_for!(struct VariantDef {
     discr,
     fields,
     ctor_kind,
-    flags
+    flags,
+    recovered
 });
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, RustcEncodable, RustcDecodable, HashStable)]

--- a/src/librustc_driver/pretty.rs
+++ b/src/librustc_driver/pretty.rs
@@ -633,10 +633,20 @@ fn print_flowgraph<'a, 'tcx, W: Write>(variants: Vec<borrowck_dot::Variant>,
     let body = tcx.hir().body(body_id);
     let cfg = cfg::CFG::new(tcx, &body);
     let labelled_edges = mode != PpFlowGraphMode::UnlabelledEdges;
+    let hir_id = code.id();
+    // We have to disassemble the hir_id because name must be ASCII
+    // alphanumeric. This does not appear in the rendered graph, so it does not
+    // have to be user friendly.
+    let name = format!(
+        "hir_id_{}_{}_{}",
+        hir_id.owner.address_space().index(),
+        hir_id.owner.as_array_index(),
+        hir_id.local_id.index(),
+    );
     let lcfg = LabelledCFG {
         tcx,
         cfg: &cfg,
-        name: format!("node_{}", code.id()),
+        name,
         labelled_edges,
     };
 

--- a/src/librustc_incremental/persist/dirty_clean.rs
+++ b/src/librustc_incremental/persist/dirty_clean.rs
@@ -576,8 +576,8 @@ fn expect_associated_value(tcx: TyCtxt<'_, '_, '_>, item: &NestedMetaItem) -> as
     if let Some(value) = item.value_str() {
         value
     } else {
-        let msg = if let Some(name) = item.ident_str() {
-            format!("associated value expected for `{}`", name)
+        let msg = if let Some(ident) = item.ident() {
+            format!("associated value expected for `{}`", ident)
         } else {
             "expected an associated value".to_string()
         };

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -759,8 +759,9 @@ impl LintPass for DeprecatedAttr {
 
 impl EarlyLintPass for DeprecatedAttr {
     fn check_attribute(&mut self, cx: &EarlyContext<'_>, attr: &ast::Attribute) {
+        let name = attr.name_or_empty();
         for &&(n, _, _, ref g) in &self.depr_attrs {
-            if attr.ident_str() == Some(n) {
+            if name == n {
                 if let &AttributeGate::Gated(Stability::Deprecated(link, suggestion),
                                              ref name,
                                              ref reason,

--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -267,21 +267,21 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedAttributes {
             }
         }
 
-        let name = attr.ident_str();
+        let name = attr.name_or_empty();
         if !attr::is_used(attr) {
             debug!("Emitting warning for: {:?}", attr);
             cx.span_lint(UNUSED_ATTRIBUTES, attr.span, "unused attribute");
             // Is it a builtin attribute that must be used at the crate level?
             let known_crate = BUILTIN_ATTRIBUTES.iter()
                 .find(|&&(builtin, ty, ..)| {
-                    name == Some(builtin) && ty == AttributeType::CrateLevel
+                    name == builtin && ty == AttributeType::CrateLevel
                 })
                 .is_some();
 
             // Has a plugin registered this attribute as one that must be used at
             // the crate level?
             let plugin_crate = plugin_attributes.iter()
-                .find(|&&(ref x, t)| name == Some(x) && AttributeType::CrateLevel == t)
+                .find(|&&(ref x, t)| name == x.as_str() && AttributeType::CrateLevel == t)
                 .is_some();
             if known_crate || plugin_crate {
                 let msg = match attr.style {

--- a/src/librustc_metadata/decoder.rs
+++ b/src/librustc_metadata/decoder.rs
@@ -576,7 +576,8 @@ impl<'a, 'tcx> CrateMetadata {
             }).collect(),
             adt_kind,
             data.ctor_kind,
-            attribute_def_id
+            attribute_def_id,
+            false,
         )
     }
 

--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -156,7 +156,7 @@ fn do_mir_borrowck<'a, 'gcx, 'tcx>(
     let mut flow_inits = FlowAtLocation::new(do_dataflow(
         tcx,
         mir,
-        id,
+        def_id,
         &attributes,
         &dead_unwinds,
         MaybeInitializedPlaces::new(tcx, mir, &mdpe),
@@ -191,7 +191,7 @@ fn do_mir_borrowck<'a, 'gcx, 'tcx>(
     let flow_borrows = FlowAtLocation::new(do_dataflow(
         tcx,
         mir,
-        id,
+        def_id,
         &attributes,
         &dead_unwinds,
         Borrows::new(tcx, mir, regioncx.clone(), &borrow_set),
@@ -200,7 +200,7 @@ fn do_mir_borrowck<'a, 'gcx, 'tcx>(
     let flow_uninits = FlowAtLocation::new(do_dataflow(
         tcx,
         mir,
-        id,
+        def_id,
         &attributes,
         &dead_unwinds,
         MaybeUninitializedPlaces::new(tcx, mir, &mdpe),
@@ -209,7 +209,7 @@ fn do_mir_borrowck<'a, 'gcx, 'tcx>(
     let flow_ever_inits = FlowAtLocation::new(do_dataflow(
         tcx,
         mir,
-        id,
+        def_id,
         &attributes,
         &dead_unwinds,
         EverInitializedPlaces::new(tcx, mir, &mdpe),

--- a/src/librustc_mir/transform/generator.rs
+++ b/src/librustc_mir/transform/generator.rs
@@ -26,7 +26,7 @@
 //!     }
 //!
 //! This pass computes the meaning of the state field and the MIR locals which are live
-//! across a suspension point. There are however two hardcoded generator states:
+//! across a suspension point. There are however three hardcoded generator states:
 //!     0 - Generator have not been resumed yet
 //!     1 - Generator has returned / is completed
 //!     2 - Generator has been poisoned
@@ -143,6 +143,13 @@ impl<'tcx> MutVisitor<'tcx> for PinArgVisitor<'tcx> {
 fn self_arg() -> Local {
     Local::new(1)
 }
+
+/// Generator have not been resumed yet
+const UNRESUMED: u32 = 0;
+/// Generator has returned / is completed
+const RETURNED: u32 = 1;
+/// Generator has been poisoned
+const POISONED: u32 = 2;
 
 struct SuspensionPoint {
     state: u32,
@@ -278,7 +285,7 @@ impl<'a, 'tcx> MutVisitor<'tcx> for TransformVisitor<'a, 'tcx> {
 
                 state
             } else { // Return
-                 1 // state for returned
+                RETURNED // state for returned
             };
             data.statements.push(self.set_state(state, source_info));
             data.terminator.as_mut().unwrap().kind = TerminatorKind::Return;
@@ -643,10 +650,10 @@ fn create_generator_drop_shim<'a, 'tcx>(
 
     let mut cases = create_cases(&mut mir, transform, |point| point.drop);
 
-    cases.insert(0, (0, drop_clean));
+    cases.insert(0, (UNRESUMED, drop_clean));
 
-    // The returned state (1) and the poisoned state (2) falls through to
-    // the default case which is just to return
+    // The returned state and the poisoned state fall through to the default
+    // case which is just to return
 
     insert_switch(tcx, &mut mir, cases, &transform, TerminatorKind::Return);
 
@@ -762,7 +769,7 @@ fn create_generator_resume_function<'a, 'tcx>(
     for block in mir.basic_blocks_mut() {
         let source_info = block.terminator().source_info;
         if let &TerminatorKind::Resume = &block.terminator().kind {
-            block.statements.push(transform.set_state(1, source_info));
+            block.statements.push(transform.set_state(POISONED, source_info));
         }
     }
 
@@ -773,12 +780,12 @@ fn create_generator_resume_function<'a, 'tcx>(
         GeneratorResumedAfterReturn,
     };
 
-    // Jump to the entry point on the 0 state
-    cases.insert(0, (0, BasicBlock::new(0)));
-    // Panic when resumed on the returned (1) state
-    cases.insert(1, (1, insert_panic_block(tcx, mir, GeneratorResumedAfterReturn)));
-    // Panic when resumed on the poisoned (2) state
-    cases.insert(2, (2, insert_panic_block(tcx, mir, GeneratorResumedAfterPanic)));
+    // Jump to the entry point on the unresumed
+    cases.insert(0, (UNRESUMED, BasicBlock::new(0)));
+    // Panic when resumed on the returned state
+    cases.insert(1, (RETURNED, insert_panic_block(tcx, mir, GeneratorResumedAfterReturn)));
+    // Panic when resumed on the poisoned state
+    cases.insert(2, (POISONED, insert_panic_block(tcx, mir, GeneratorResumedAfterPanic)));
 
     insert_switch(tcx, mir, cases, &transform, TerminatorKind::Unreachable);
 
@@ -942,7 +949,7 @@ impl MirPass for StateTransform {
         mir.generator_layout = Some(layout);
 
         // Insert `drop(generator_struct)` which is used to drop upvars for generators in
-        // the unresumed (0) state.
+        // the unresumed state.
         // This is expanded to a drop ladder in `elaborate_generator_drops`.
         let drop_clean = insert_clean_drop(mir);
 

--- a/src/librustc_mir/transform/generator.rs
+++ b/src/librustc_mir/transform/generator.rs
@@ -383,13 +383,13 @@ fn locals_live_across_suspend_points(
     FxHashMap<BasicBlock, liveness::LiveVarSet>,
 ) {
     let dead_unwinds = BitSet::new_empty(mir.basic_blocks().len());
-    let hir_id = tcx.hir().as_local_hir_id(source.def_id()).unwrap();
+    let def_id = source.def_id();
 
     // Calculate when MIR locals have live storage. This gives us an upper bound of their
     // lifetimes.
     let storage_live_analysis = MaybeStorageLive::new(mir);
     let storage_live =
-        do_dataflow(tcx, mir, hir_id, &[], &dead_unwinds, storage_live_analysis,
+        do_dataflow(tcx, mir, def_id, &[], &dead_unwinds, storage_live_analysis,
                     |bd, p| DebugFormatted::new(&bd.mir().local_decls[p]));
 
     // Find the MIR locals which do not use StorageLive/StorageDead statements.
@@ -403,7 +403,7 @@ fn locals_live_across_suspend_points(
     let borrowed_locals = if !movable {
         let analysis = HaveBeenBorrowedLocals::new(mir);
         let result =
-            do_dataflow(tcx, mir, hir_id, &[], &dead_unwinds, analysis,
+            do_dataflow(tcx, mir, def_id, &[], &dead_unwinds, analysis,
                         |bd, p| DebugFormatted::new(&bd.mir().local_decls[p]));
         Some((analysis, result))
     } else {

--- a/src/librustc_mir/util/graphviz.rs
+++ b/src/librustc_mir/util/graphviz.rs
@@ -1,6 +1,7 @@
 use rustc::hir::def_id::DefId;
 use rustc::mir::*;
 use rustc::ty::TyCtxt;
+use rustc_data_structures::indexed_vec::Idx;
 use std::fmt::Debug;
 use std::io::{self, Write};
 
@@ -20,6 +21,17 @@ pub fn write_mir_graphviz<'tcx, W>(tcx: TyCtxt<'_, '_, 'tcx>,
     Ok(())
 }
 
+// Must match `[0-9A-Za-z_]*`. This does not appear in the rendered graph, so
+// it does not have to be user friendly.
+pub fn graphviz_safe_def_name(def_id: DefId) -> String {
+    format!(
+        "{}_{}_{}",
+        def_id.krate.index(),
+        def_id.index.address_space().index(),
+        def_id.index.as_array_index(),
+    )
+}
+
 /// Write a graphviz DOT graph of the MIR.
 pub fn write_mir_fn_graphviz<'tcx, W>(tcx: TyCtxt<'_, '_, 'tcx>,
                                       def_id: DefId,
@@ -27,7 +39,7 @@ pub fn write_mir_fn_graphviz<'tcx, W>(tcx: TyCtxt<'_, '_, 'tcx>,
                                       w: &mut W) -> io::Result<()>
     where W: Write
 {
-    writeln!(w, "digraph Mir_{} {{", tcx.hir().as_local_hir_id(def_id).unwrap())?;
+    writeln!(w, "digraph Mir_{} {{", graphviz_safe_def_name(def_id))?;
 
     // Global graph properties
     writeln!(w, r#"    graph [fontname="monospace"];"#)?;

--- a/src/librustc_mir/util/mod.rs
+++ b/src/librustc_mir/util/mod.rs
@@ -15,7 +15,7 @@ pub mod collect_writes;
 
 pub use self::alignment::is_disaligned;
 pub use self::pretty::{dump_enabled, dump_mir, write_mir_pretty, PassWhere};
-pub use self::graphviz::{write_mir_graphviz};
+pub use self::graphviz::{graphviz_safe_def_name, write_mir_graphviz};
 pub use self::graphviz::write_node_label as write_graphviz_node_label;
 
 /// If possible, suggest replacing `ref` with `ref mut`.

--- a/src/librustc_mir/util/pretty.rs
+++ b/src/librustc_mir/util/pretty.rs
@@ -317,9 +317,8 @@ where
     let data = &mir[block];
 
     // Basic block label at the top.
-    let cleanup_text = if data.is_cleanup { " // cleanup" } else { "" };
-    let lbl = format!("{}{:?}: {{", INDENT, block);
-    writeln!(w, "{0:1$}{2}", lbl, ALIGN, cleanup_text)?;
+    let cleanup_text = if data.is_cleanup { " (cleanup)" } else { "" };
+    writeln!(w, "{}{:?}{}: {{", INDENT, block, cleanup_text)?;
 
     // List of statements in the middle.
     let mut current_location = Location {

--- a/src/librustc_passes/layout_test.rs
+++ b/src/librustc_passes/layout_test.rs
@@ -53,8 +53,7 @@ impl<'a, 'tcx> VarianceTest<'a, 'tcx> {
                 // The `..` are the names of fields to dump.
                 let meta_items = attr.meta_item_list().unwrap_or_default();
                 for meta_item in meta_items {
-                    let name = meta_item.ident_str().unwrap_or("");
-                    match name {
+                    match meta_item.name_or_empty().get() {
                         "abi" => {
                             self.tcx
                                 .sess
@@ -84,7 +83,7 @@ impl<'a, 'tcx> VarianceTest<'a, 'tcx> {
                             );
                         }
 
-                        _ => {
+                        name => {
                             self.tcx.sess.span_err(
                                 meta_item.span(),
                                 &format!("unrecognized field name `{}`", name),

--- a/src/librustc_plugin/load.rs
+++ b/src/librustc_plugin/load.rs
@@ -56,12 +56,12 @@ pub fn load_plugins(sess: &Session,
 
             for plugin in plugins {
                 // plugins must have a name and can't be key = value
-                match plugin.ident_str() {
-                    Some(name) if !plugin.is_value_str() => {
-                        let args = plugin.meta_item_list().map(ToOwned::to_owned);
-                        loader.load_plugin(plugin.span(), name, args.unwrap_or_default());
-                    },
-                    _ => call_malformed_plugin_attribute(sess, attr.span),
+                let name = plugin.name_or_empty();
+                if !name.is_empty() && !plugin.is_value_str() {
+                    let args = plugin.meta_item_list().map(ToOwned::to_owned);
+                    loader.load_plugin(plugin.span(), &name, args.unwrap_or_default());
+                } else {
+                    call_malformed_plugin_attribute(sess, attr.span);
                 }
             }
         }

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -303,7 +303,7 @@ impl<'a> Resolver<'a> {
                 }
 
                 // Empty groups `a::b::{}` are turned into synthetic `self` imports
-                // `a::b::c::{self as _}`, so that their prefixes are correctly
+                // `a::b::c::{self as __dummy}`, so that their prefixes are correctly
                 // resolved and checked for privacy/stability/etc.
                 if items.is_empty() && !empty_for_self(&prefix) {
                     let new_span = prefix[prefix.len() - 1].ident.span;
@@ -312,7 +312,7 @@ impl<'a> Resolver<'a> {
                             Ident::new(keywords::SelfLower.name(), new_span)
                         ),
                         kind: ast::UseTreeKind::Simple(
-                            Some(Ident::new(keywords::Underscore.name().gensymed(), new_span)),
+                            Some(Ident::new(Name::gensym("__dummy"), new_span)),
                             ast::DUMMY_NODE_ID,
                             ast::DUMMY_NODE_ID,
                         ),

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -1295,9 +1295,11 @@ impl<'a, 'b:'a> ImportResolver<'a, 'b> {
                 None => continue,
             };
 
-            // Filter away "empty import canaries" and ambiguous imports.
+            // Filter away ambiguous and gensymed imports. Gensymed imports
+            // (e.g. implicitly injected `std`) cannot be properly encoded in metadata,
+            // so they can cause name conflict errors downstream.
             let is_good_import = binding.is_import() && !binding.is_ambiguity() &&
-                                 binding.vis != ty::Visibility::Invisible;
+                                 !(ident.name.is_gensymed() && ident.name != "_");
             if is_good_import || binding.is_macro_def() {
                 let def = binding.def();
                 if def != Def::Err {

--- a/src/librustc_save_analysis/dump_visitor.rs
+++ b/src/librustc_save_analysis/dump_visitor.rs
@@ -481,8 +481,8 @@ impl<'l, 'tcx: 'l, 'll, O: DumpOutput + 'll> DumpVisitor<'l, 'tcx, 'll, O> {
         };
 
         let (value, fields) = match item.node {
-            ast::ItemKind::Struct(ast::VariantData::Struct(ref fields, _), _) |
-            ast::ItemKind::Union(ast::VariantData::Struct(ref fields, _), _) => {
+            ast::ItemKind::Struct(ast::VariantData::Struct(ref fields, ..), _) |
+            ast::ItemKind::Union(ast::VariantData::Struct(ref fields, ..), _) => {
                 let include_priv_fields = !self.save_ctxt.config.pub_only;
                 let fields_str = fields
                     .iter()
@@ -560,7 +560,7 @@ impl<'l, 'tcx: 'l, 'll, O: DumpOutput + 'll> DumpVisitor<'l, 'tcx, 'll, O> {
             let name_span = variant.node.ident.span;
 
             match variant.node.data {
-                ast::VariantData::Struct(ref fields, _) => {
+                ast::VariantData::Struct(ref fields, ..) => {
                     let fields_str = fields
                         .iter()
                         .enumerate()

--- a/src/librustc_save_analysis/sig.rs
+++ b/src/librustc_save_analysis/sig.rs
@@ -703,7 +703,7 @@ impl Sig for ast::Variant_ {
     fn make(&self, offset: usize, _parent_id: Option<NodeId>, scx: &SaveContext<'_, '_>) -> Result {
         let mut text = self.ident.to_string();
         match self.data {
-            ast::VariantData::Struct(ref fields, id) => {
+            ast::VariantData::Struct(ref fields, id, r) => {
                 let name_def = SigElement {
                     id: id_from_node_id(id, scx),
                     start: offset,
@@ -712,12 +712,16 @@ impl Sig for ast::Variant_ {
                 text.push_str(" { ");
                 let mut defs = vec![name_def];
                 let mut refs = vec![];
-                for f in fields {
-                    let field_sig = f.make(offset + text.len(), Some(id), scx)?;
-                    text.push_str(&field_sig.text);
-                    text.push_str(", ");
-                    defs.extend(field_sig.defs.into_iter());
-                    refs.extend(field_sig.refs.into_iter());
+                if r {
+                    text.push_str("/* parse error */ ");
+                } else {
+                    for f in fields {
+                        let field_sig = f.make(offset + text.len(), Some(id), scx)?;
+                        text.push_str(&field_sig.text);
+                        text.push_str(", ");
+                        defs.extend(field_sig.defs.into_iter());
+                        refs.extend(field_sig.refs.into_iter());
+                    }
                 }
                 text.push('}');
                 Ok(Signature { text, defs, refs })

--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -918,14 +918,16 @@ https://doc.rust-lang.org/reference/types.html#trait-objects");
         pat_ty
     }
 
-    fn check_struct_pat_fields(&self,
-                               adt_ty: Ty<'tcx>,
-                               pat_id: hir::HirId,
-                               span: Span,
-                               variant: &'tcx ty::VariantDef,
-                               fields: &'gcx [Spanned<hir::FieldPat>],
-                               etc: bool,
-                               def_bm: ty::BindingMode) -> bool {
+    fn check_struct_pat_fields(
+        &self,
+        adt_ty: Ty<'tcx>,
+        pat_id: hir::HirId,
+        span: Span,
+        variant: &'tcx ty::VariantDef,
+        fields: &'gcx [Spanned<hir::FieldPat>],
+        etc: bool,
+        def_bm: ty::BindingMode,
+    ) -> bool {
         let tcx = self.tcx;
 
         let (substs, adt) = match adt_ty.sty {
@@ -985,7 +987,7 @@ https://doc.rust-lang.org/reference/types.html#trait-objects");
                 .map(|field| field.ident.modern())
                 .filter(|ident| !used_fields.contains_key(&ident))
                 .collect::<Vec<_>>();
-        if inexistent_fields.len() > 0 {
+        if inexistent_fields.len() > 0 && !variant.recovered {
             let (field_names, t, plural) = if inexistent_fields.len() == 1 {
                 (format!("a field named `{}`", inexistent_fields[0].1), "this", "")
             } else {

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3689,12 +3689,17 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                            field, expr_t)
     }
 
-    fn report_unknown_field(&self,
-                            ty: Ty<'tcx>,
-                            variant: &'tcx ty::VariantDef,
-                            field: &hir::Field,
-                            skip_fields: &[hir::Field],
-                            kind_name: &str) {
+    fn report_unknown_field(
+        &self,
+        ty: Ty<'tcx>,
+        variant: &'tcx ty::VariantDef,
+        field: &hir::Field,
+        skip_fields: &[hir::Field],
+        kind_name: &str,
+    ) {
+        if variant.recovered {
+            return;
+        }
         let mut err = self.type_error_struct_with_diag(
             field.ident.span,
             |actual| match ty.sty {

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -598,6 +598,10 @@ fn convert_variant<'a, 'tcx>(
             }
         })
         .collect();
+    let recovered = match def {
+        hir::VariantData::Struct(_, _, r) => *r,
+        _ => false,
+    };
     ty::VariantDef::new(tcx,
         did,
         ident,
@@ -605,7 +609,8 @@ fn convert_variant<'a, 'tcx>(
         fields,
         adt_kind,
         CtorKind::from_hir(def),
-        attribute_def_id
+        attribute_def_id,
+        recovered,
     )
 }
 

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -507,6 +507,18 @@ impl Item {
             .as_ref()
             .or_else(|| self.stability.as_ref().and_then(|s| s.deprecation.as_ref()))
     }
+    pub fn is_default(&self) -> bool {
+        match self.inner {
+            ItemEnum::MethodItem(ref meth) => {
+                if let Some(defaultness) = meth.defaultness {
+                    defaultness.has_value() && !defaultness.is_final()
+                } else {
+                    false
+                }
+            }
+            _ => false,
+        }
+    }
 }
 
 #[derive(Clone, RustcEncodable, RustcDecodable, Debug)]
@@ -1699,9 +1711,11 @@ pub struct Method {
     pub generics: Generics,
     pub decl: FnDecl,
     pub header: hir::FnHeader,
+    pub defaultness: Option<hir::Defaultness>,
 }
 
-impl<'a> Clean<Method> for (&'a hir::MethodSig, &'a hir::Generics, hir::BodyId) {
+impl<'a> Clean<Method> for (&'a hir::MethodSig, &'a hir::Generics, hir::BodyId,
+                            Option<hir::Defaultness>) {
     fn clean(&self, cx: &DocContext<'_>) -> Method {
         let (generics, decl) = enter_impl_trait(cx, || {
             (self.1.clean(cx), (&*self.0.decl, self.2).clean(cx))
@@ -1710,6 +1724,7 @@ impl<'a> Clean<Method> for (&'a hir::MethodSig, &'a hir::Generics, hir::BodyId) 
             decl,
             generics,
             header: self.0.header,
+            defaultness: self.3,
         }
     }
 }
@@ -2015,7 +2030,7 @@ impl Clean<Item> for hir::TraitItem {
                                     default.map(|e| print_const_expr(cx, e)))
             }
             hir::TraitItemKind::Method(ref sig, hir::TraitMethod::Provided(body)) => {
-                MethodItem((sig, &self.generics, body).clean(cx))
+                MethodItem((sig, &self.generics, body, None).clean(cx))
             }
             hir::TraitItemKind::Method(ref sig, hir::TraitMethod::Required(ref names)) => {
                 let (generics, decl) = enter_impl_trait(cx, || {
@@ -2053,7 +2068,7 @@ impl Clean<Item> for hir::ImplItem {
                                     Some(print_const_expr(cx, expr)))
             }
             hir::ImplItemKind::Method(ref sig, body) => {
-                MethodItem((sig, &self.generics, body).clean(cx))
+                MethodItem((sig, &self.generics, body, Some(self.defaultness)).clean(cx))
             }
             hir::ImplItemKind::Type(ref ty) => TypedefItem(Typedef {
                 type_: ty.clean(cx),
@@ -2136,7 +2151,8 @@ impl<'tcx> Clean<Item> for ty::AssociatedItem {
                             abi: sig.abi(),
                             constness,
                             asyncness: hir::IsAsync::NotAsync,
-                        }
+                        },
+                        defaultness: Some(self.defaultness),
                     })
                 } else {
                     TyMethodItem(TyMethod {

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -521,21 +521,21 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
             for attr in krate.module.as_ref().unwrap().attrs.lists("doc") {
                 let diag = ctxt.sess().diagnostic();
 
-                let name = attr.ident_str();
+                let name = attr.name_or_empty();
                 if attr.is_word() {
-                    if name == Some("no_default_passes") {
+                    if name == "no_default_passes" {
                         report_deprecated_attr("no_default_passes", diag);
                         if default_passes == passes::DefaultPassOption::Default {
                             default_passes = passes::DefaultPassOption::None;
                         }
                     }
                 } else if let Some(value) = attr.value_str() {
-                    let sink = match name {
-                        Some("passes") => {
+                    let sink = match name.get() {
+                        "passes" => {
                             report_deprecated_attr("passes = \"...\"", diag);
                             &mut manual_passes
                         },
-                        Some("plugins") => {
+                        "plugins" => {
                             report_deprecated_attr("plugins = \"...\"", diag);
                             eprintln!("WARNING: #![doc(plugins = \"...\")] no longer functions; \
                                       see CVE-2018-1000622");
@@ -548,7 +548,7 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
                     }
                 }
 
-                if attr.is_word() && name == Some("document_private_items") {
+                if attr.is_word() && name == "document_private_items" {
                     if default_passes == passes::DefaultPassOption::Default {
                         default_passes = passes::DefaultPassOption::Private;
                     }

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -45,6 +45,7 @@ pub struct GenericBounds<'a>(pub &'a [clean::GenericBound]);
 /// Wrapper struct for emitting a comma-separated list of items
 pub struct CommaSep<'a, T>(pub &'a [T]);
 pub struct AbiSpace(pub Abi);
+pub struct DefaultSpace(pub bool);
 
 /// Wrapper struct for properly emitting a function or method declaration.
 pub struct Function<'a> {
@@ -1054,6 +1055,16 @@ impl fmt::Display for AbiSpace {
         match self.0 {
             Abi::Rust => Ok(()),
             abi => write!(f, "extern {0}{1}{0} ", quot, abi.name()),
+        }
+    }
+}
+
+impl fmt::Display for DefaultSpace {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.0 {
+            write!(f, "default ")
+        } else {
+            Ok(())
         }
     }
 }

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -61,7 +61,7 @@ use crate::doctree;
 use crate::fold::DocFolder;
 use crate::html::escape::Escape;
 use crate::html::format::{AsyncSpace, ConstnessSpace};
-use crate::html::format::{GenericBounds, WhereClause, href, AbiSpace};
+use crate::html::format::{GenericBounds, WhereClause, href, AbiSpace, DefaultSpace};
 use crate::html::format::{VisSpace, Function, UnsafetySpace, MutableSpace};
 use crate::html::format::fmt_impl_for_trait_page;
 use crate::html::item_type::ItemType;
@@ -3434,11 +3434,12 @@ fn render_assoc_item(w: &mut fmt::Formatter<'_>,
             }
         };
         let mut header_len = format!(
-            "{}{}{}{}{:#}fn {}{:#}",
+            "{}{}{}{}{}{:#}fn {}{:#}",
             VisSpace(&meth.visibility),
             ConstnessSpace(header.constness),
             UnsafetySpace(header.unsafety),
             AsyncSpace(header.asyncness),
+            DefaultSpace(meth.is_default()),
             AbiSpace(header.abi),
             name,
             *g
@@ -3450,12 +3451,13 @@ fn render_assoc_item(w: &mut fmt::Formatter<'_>,
             (0, true)
         };
         render_attributes(w, meth)?;
-        write!(w, "{}{}{}{}{}fn <a href='{href}' class='fnname'>{name}</a>\
+        write!(w, "{}{}{}{}{}{}fn <a href='{href}' class='fnname'>{name}</a>\
                    {generics}{decl}{where_clause}",
                VisSpace(&meth.visibility),
                ConstnessSpace(header.constness),
                UnsafetySpace(header.unsafety),
                AsyncSpace(header.asyncness),
+               DefaultSpace(meth.is_default()),
                AbiSpace(header.abi),
                href = href,
                name = name,

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -562,23 +562,23 @@ pub fn run(mut krate: clean::Crate,
     // going to emit HTML
     if let Some(attrs) = krate.module.as_ref().map(|m| &m.attrs) {
         for attr in attrs.lists("doc") {
-            match (attr.ident_str(), attr.value_str()) {
-                (Some("html_favicon_url"), Some(s)) => {
+            match (attr.name_or_empty().get(), attr.value_str()) {
+                ("html_favicon_url", Some(s)) => {
                     scx.layout.favicon = s.to_string();
                 }
-                (Some("html_logo_url"), Some(s)) => {
+                ("html_logo_url", Some(s)) => {
                     scx.layout.logo = s.to_string();
                 }
-                (Some("html_playground_url"), Some(s)) => {
+                ("html_playground_url", Some(s)) => {
                     markdown::PLAYGROUND.with(|slot| {
                         let name = krate.name.clone();
                         *slot.borrow_mut() = Some((Some(name), s.to_string()));
                     });
                 }
-                (Some("issue_tracker_base_url"), Some(s)) => {
+                ("issue_tracker_base_url", Some(s)) => {
                     scx.issue_tracker_base_url = Some(s.to_string());
                 }
-                (Some("html_no_source"), None) if attr.is_word() => {
+                ("html_no_source", None) if attr.is_word() => {
                     scx.include_sources = false;
                 }
                 _ => {}
@@ -3749,7 +3749,7 @@ fn render_attributes(w: &mut fmt::Formatter<'_>, it: &clean::Item) -> fmt::Resul
     let mut attrs = String::new();
 
     for attr in &it.attrs.other_attrs {
-        if !attr.ident_str().map_or(false, |name| ATTRIBUTE_WHITELIST.contains(&name)) {
+        if !ATTRIBUTE_WHITELIST.contains(&attr.name_or_empty().get()) {
             continue;
         }
         if let Some(s) = render_attribute(&attr.meta().unwrap()) {

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -620,7 +620,7 @@ pub enum PatKind {
 
     /// A struct or struct variant pattern (e.g., `Variant {x, y, ..}`).
     /// The `bool` is `true` in the presence of a `..`.
-    Struct(Path, Vec<Spanned<FieldPat>>, bool),
+    Struct(Path, Vec<Spanned<FieldPat>>, /* recovered */ bool),
 
     /// A tuple struct/variant pattern (`Variant(x, y, .., z)`).
     /// If the `..` pattern fragment is present, then `Option<usize>` denotes its position.

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -2133,7 +2133,7 @@ pub enum VariantData {
     /// Struct variant.
     ///
     /// E.g., `Bar { .. }` as in `enum Foo { Bar { .. } }`.
-    Struct(Vec<StructField>, NodeId),
+    Struct(Vec<StructField>, NodeId, bool),
     /// Tuple variant.
     ///
     /// E.g., `Bar(..)` as in `enum Foo { Bar(..) }`.
@@ -2147,13 +2147,13 @@ pub enum VariantData {
 impl VariantData {
     pub fn fields(&self) -> &[StructField] {
         match *self {
-            VariantData::Struct(ref fields, _) | VariantData::Tuple(ref fields, _) => fields,
+            VariantData::Struct(ref fields, ..) | VariantData::Tuple(ref fields, _) => fields,
             _ => &[],
         }
     }
     pub fn id(&self) -> NodeId {
         match *self {
-            VariantData::Struct(_, id) | VariantData::Tuple(_, id) | VariantData::Unit(id) => id,
+            VariantData::Struct(_, id, _) | VariantData::Tuple(_, id) | VariantData::Unit(id) => id,
         }
     }
     pub fn is_struct(&self) -> bool {

--- a/src/libsyntax/attr/builtin.rs
+++ b/src/libsyntax/attr/builtin.rs
@@ -222,9 +222,9 @@ fn find_stability_generic<'a, I>(sess: &ParseSess,
                     )+
                     for meta in metas {
                         if let Some(mi) = meta.meta_item() {
-                            match mi.ident_str() {
+                            match mi.name_or_empty().get() {
                                 $(
-                                    Some(stringify!($name))
+                                    stringify!($name)
                                         => if !get(mi, &mut $name) { continue 'outer },
                                 )+
                                 _ => {
@@ -252,7 +252,7 @@ fn find_stability_generic<'a, I>(sess: &ParseSess,
                 }
             }
 
-            match meta.ident_str().expect("not a stability level") {
+            match meta.name_or_empty().get() {
                 "rustc_deprecated" => {
                     if rustc_depr.is_some() {
                         span_err!(diagnostic, item_sp, E0540,
@@ -306,10 +306,10 @@ fn find_stability_generic<'a, I>(sess: &ParseSess,
                     let mut issue = None;
                     for meta in metas {
                         if let Some(mi) = meta.meta_item() {
-                            match mi.ident_str() {
-                                Some("feature") => if !get(mi, &mut feature) { continue 'outer },
-                                Some("reason") => if !get(mi, &mut reason) { continue 'outer },
-                                Some("issue") => if !get(mi, &mut issue) { continue 'outer },
+                            match mi.name_or_empty().get() {
+                                "feature" => if !get(mi, &mut feature) { continue 'outer },
+                                "reason" => if !get(mi, &mut reason) { continue 'outer },
+                                "issue" => if !get(mi, &mut issue) { continue 'outer },
                                 _ => {
                                     handle_errors(
                                         sess,
@@ -377,10 +377,10 @@ fn find_stability_generic<'a, I>(sess: &ParseSess,
                     for meta in metas {
                         match meta {
                             NestedMetaItem::MetaItem(mi) => {
-                                match mi.ident_str() {
-                                    Some("feature") =>
+                                match mi.name_or_empty().get() {
+                                    "feature" =>
                                         if !get(mi, &mut feature) { continue 'outer },
-                                    Some("since") =>
+                                    "since" =>
                                         if !get(mi, &mut since) { continue 'outer },
                                     _ => {
                                         handle_errors(
@@ -532,14 +532,14 @@ pub fn eval_condition<F>(cfg: &ast::MetaItem, sess: &ParseSess, eval: &mut F)
 
             // The unwraps below may look dangerous, but we've already asserted
             // that they won't fail with the loop above.
-            match cfg.ident_str() {
-                Some("any") => mis.iter().any(|mi| {
+            match cfg.name_or_empty().get() {
+                "any" => mis.iter().any(|mi| {
                     eval_condition(mi.meta_item().unwrap(), sess, eval)
                 }),
-                Some("all") => mis.iter().all(|mi| {
+                "all" => mis.iter().all(|mi| {
                     eval_condition(mi.meta_item().unwrap(), sess, eval)
                 }),
-                Some("not") => {
+                "not" => {
                     if mis.len() != 1 {
                         span_err!(sess.span_diagnostic, cfg.span, E0536, "expected 1 cfg-pattern");
                         return false;
@@ -635,9 +635,9 @@ fn find_deprecation_generic<'a, I>(sess: &ParseSess,
                 for meta in list {
                     match meta {
                         NestedMetaItem::MetaItem(mi) => {
-                            match mi.ident_str() {
-                                Some("since") => if !get(mi, &mut since) { continue 'outer },
-                                Some("note") => if !get(mi, &mut note) { continue 'outer },
+                            match mi.name_or_empty().get() {
+                                "since" => if !get(mi, &mut since) { continue 'outer },
+                                "note" => if !get(mi, &mut note) { continue 'outer },
                                 _ => {
                                     handle_errors(
                                         sess,
@@ -729,12 +729,12 @@ pub fn find_repr_attrs(sess: &ParseSess, attr: &Attribute) -> Vec<ReprAttr> {
 
                 let mut recognised = false;
                 if item.is_word() {
-                    let hint = match item.ident_str() {
-                        Some("C") => Some(ReprC),
-                        Some("packed") => Some(ReprPacked(1)),
-                        Some("simd") => Some(ReprSimd),
-                        Some("transparent") => Some(ReprTransparent),
-                        name => name.and_then(|name| int_type_of_word(name)).map(ReprInt),
+                    let hint = match item.name_or_empty().get() {
+                        "C" => Some(ReprC),
+                        "packed" => Some(ReprPacked(1)),
+                        "simd" => Some(ReprSimd),
+                        "transparent" => Some(ReprTransparent),
+                        name => int_type_of_word(name).map(ReprInt),
                     };
 
                     if let Some(h) = hint {

--- a/src/libsyntax/attr/mod.rs
+++ b/src/libsyntax/attr/mod.rs
@@ -22,7 +22,7 @@ use crate::parse::parser::Parser;
 use crate::parse::{self, ParseSess, PResult};
 use crate::parse::token::{self, Token};
 use crate::ptr::P;
-use crate::symbol::Symbol;
+use crate::symbol::{keywords, LocalInternedString, Symbol};
 use crate::ThinVec;
 use crate::tokenstream::{TokenStream, TokenTree, DelimSpan};
 use crate::GLOBALS;
@@ -89,8 +89,8 @@ impl NestedMetaItem {
     pub fn ident(&self) -> Option<Ident> {
         self.meta_item().and_then(|meta_item| meta_item.ident())
     }
-    pub fn ident_str(&self) -> Option<&str> {
-        self.ident().map(|name| name.as_str().get())
+    pub fn name_or_empty(&self) -> LocalInternedString {
+        self.ident().unwrap_or(keywords::Invalid.ident()).name.as_str()
     }
 
     /// Gets the string value if self is a MetaItem and the MetaItem is a
@@ -167,8 +167,8 @@ impl Attribute {
             None
         }
     }
-    pub fn ident_str(&self) -> Option<&str> {
-        self.ident().map(|name| name.as_str().get())
+    pub fn name_or_empty(&self) -> LocalInternedString {
+        self.ident().unwrap_or(keywords::Invalid.ident()).name.as_str()
     }
 
     pub fn value_str(&self) -> Option<Symbol> {
@@ -205,8 +205,8 @@ impl MetaItem {
             None
         }
     }
-    pub fn ident_str(&self) -> Option<&str> {
-        self.ident().map(|name| name.as_str().get())
+    pub fn name_or_empty(&self) -> LocalInternedString {
+        self.ident().unwrap_or(keywords::Invalid.ident()).name.as_str()
     }
 
     // #[attribute(name = "value")]

--- a/src/libsyntax/config.rs
+++ b/src/libsyntax/config.rs
@@ -225,7 +225,7 @@ impl<'a> StripUnconfigured<'a> {
 
     fn configure_variant_data(&mut self, vdata: &mut ast::VariantData) {
         match vdata {
-            ast::VariantData::Struct(fields, _id) |
+            ast::VariantData::Struct(fields, _id, _) |
             ast::VariantData::Tuple(fields, _id) =>
                 fields.flat_map_in_place(|field| self.configure(field)),
             ast::VariantData::Unit(_id) => {}

--- a/src/libsyntax/mut_visit.rs
+++ b/src/libsyntax/mut_visit.rs
@@ -765,7 +765,7 @@ pub fn noop_visit_where_predicate<T: MutVisitor>(pred: &mut WherePredicate, vis:
 
 pub fn noop_visit_variant_data<T: MutVisitor>(vdata: &mut VariantData, vis: &mut T) {
     match vdata {
-        VariantData::Struct(fields, id) |
+        VariantData::Struct(fields, id, _) |
         VariantData::Tuple(fields, id) => {
             visit_vec(fields, |field| vis.visit_struct_field(field));
             vis.visit_id(id);

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -6902,7 +6902,9 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn parse_record_struct_body(&mut self) -> PResult<'a, (Vec<StructField>, bool)> {
+    fn parse_record_struct_body(
+        &mut self,
+    ) -> PResult<'a, (Vec<StructField>, /* recovered */ bool)> {
         let mut fields = Vec::new();
         let mut recovered = false;
         if self.eat(&token::OpenDelim(token::Brace)) {

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -6829,14 +6829,16 @@ impl<'a> Parser<'a> {
                 VariantData::Unit(ast::DUMMY_NODE_ID)
             } else {
                 // If we see: `struct Foo<T> where T: Copy { ... }`
-                VariantData::Struct(self.parse_record_struct_body()?, ast::DUMMY_NODE_ID)
+                let (fields, recovered) = self.parse_record_struct_body()?;
+                VariantData::Struct(fields, ast::DUMMY_NODE_ID, recovered)
             }
         // No `where` so: `struct Foo<T>;`
         } else if self.eat(&token::Semi) {
             VariantData::Unit(ast::DUMMY_NODE_ID)
         // Record-style struct definition
         } else if self.token == token::OpenDelim(token::Brace) {
-            VariantData::Struct(self.parse_record_struct_body()?, ast::DUMMY_NODE_ID)
+            let (fields, recovered) = self.parse_record_struct_body()?;
+            VariantData::Struct(fields, ast::DUMMY_NODE_ID, recovered)
         // Tuple-style struct definition with optional where-clause.
         } else if self.token == token::OpenDelim(token::Paren) {
             let body = VariantData::Tuple(self.parse_tuple_struct_body()?, ast::DUMMY_NODE_ID);
@@ -6864,9 +6866,11 @@ impl<'a> Parser<'a> {
 
         let vdata = if self.token.is_keyword(keywords::Where) {
             generics.where_clause = self.parse_where_clause()?;
-            VariantData::Struct(self.parse_record_struct_body()?, ast::DUMMY_NODE_ID)
+            let (fields, recovered) = self.parse_record_struct_body()?;
+            VariantData::Struct(fields, ast::DUMMY_NODE_ID, recovered)
         } else if self.token == token::OpenDelim(token::Brace) {
-            VariantData::Struct(self.parse_record_struct_body()?, ast::DUMMY_NODE_ID)
+            let (fields, recovered) = self.parse_record_struct_body()?;
+            VariantData::Struct(fields, ast::DUMMY_NODE_ID, recovered)
         } else {
             let token_str = self.this_token_descr();
             let mut err = self.fatal(&format!(
@@ -6898,12 +6902,14 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn parse_record_struct_body(&mut self) -> PResult<'a, Vec<StructField>> {
+    fn parse_record_struct_body(&mut self) -> PResult<'a, (Vec<StructField>, bool)> {
         let mut fields = Vec::new();
+        let mut recovered = false;
         if self.eat(&token::OpenDelim(token::Brace)) {
             while self.token != token::CloseDelim(token::Brace) {
                 let field = self.parse_struct_decl_field().map_err(|e| {
                     self.recover_stmt();
+                    recovered = true;
                     e
                 });
                 match field {
@@ -6922,7 +6928,7 @@ impl<'a> Parser<'a> {
             return Err(err);
         }
 
-        Ok(fields)
+        Ok((fields, recovered))
     }
 
     fn parse_tuple_struct_body(&mut self) -> PResult<'a, Vec<StructField>> {
@@ -7684,12 +7690,14 @@ impl<'a> Parser<'a> {
             if self.check(&token::OpenDelim(token::Brace)) {
                 // Parse a struct variant.
                 all_nullary = false;
-                struct_def = VariantData::Struct(self.parse_record_struct_body()?,
-                                                 ast::DUMMY_NODE_ID);
+                let (fields, recovered) = self.parse_record_struct_body()?;
+                struct_def = VariantData::Struct(fields, ast::DUMMY_NODE_ID, recovered);
             } else if self.check(&token::OpenDelim(token::Paren)) {
                 all_nullary = false;
-                struct_def = VariantData::Tuple(self.parse_tuple_struct_body()?,
-                                                ast::DUMMY_NODE_ID);
+                struct_def = VariantData::Tuple(
+                    self.parse_tuple_struct_body()?,
+                    ast::DUMMY_NODE_ID,
+                );
             } else if self.eat(&token::Eq) {
                 disr_expr = Some(AnonConst {
                     id: ast::DUMMY_NODE_ID,

--- a/src/libsyntax_ext/deriving/generic/mod.rs
+++ b/src/libsyntax_ext/deriving/generic/mod.rs
@@ -463,9 +463,10 @@ impl<'a> TraitDef<'a> {
                 let mut attrs = newitem.attrs.clone();
                 attrs.extend(item.attrs
                     .iter()
-                    .filter(|a| a.ident_str().map_or(false, |name| {
-                        ["allow", "warn", "deny", "forbid", "stable", "unstable"].contains(&name)
-                    }))
+                    .filter(|a| {
+                        ["allow", "warn", "deny", "forbid", "stable", "unstable"]
+                            .contains(&a.name_or_empty().get())
+                    })
                     .cloned());
                 push(Annotatable::Item(P(ast::Item { attrs: attrs, ..(*newitem).clone() })))
             }

--- a/src/libsyntax_pos/symbol.rs
+++ b/src/libsyntax_pos/symbol.rs
@@ -179,6 +179,10 @@ impl Symbol {
         with_interner(|interner| interner.gensymed(self))
     }
 
+    pub fn is_gensymed(self) -> bool {
+        with_interner(|interner| interner.is_gensymed(self))
+    }
+
     pub fn as_str(self) -> LocalInternedString {
         with_interner(|interner| unsafe {
             LocalInternedString {

--- a/src/test/mir-opt/basic_assignment.rs
+++ b/src/test/mir-opt/basic_assignment.rs
@@ -48,7 +48,7 @@ fn main() {
 //        drop(_6) -> [return: bb6, unwind: bb4];
 //    }
 //    ...
-//    bb5: {
+//    bb5 (cleanup): {
 //        drop(_6) -> bb4;
 //    }
 // END rustc.main.SimplifyCfg-initial.after.mir

--- a/src/test/mir-opt/box_expr.rs
+++ b/src/test/mir-opt/box_expr.rs
@@ -38,7 +38,7 @@ impl Drop for S {
 //         (*_2) = const S::new() -> [return: bb2, unwind: bb3];
 //     }
 //
-//     bb1: {
+//     bb1 (cleanup): {
 //         resume;
 //     }
 //
@@ -47,7 +47,7 @@ impl Drop for S {
 //         drop(_2) -> bb4;
 //     }
 //
-//     bb3: {
+//     bb3 (cleanup): {
 //         drop(_2) -> bb1;
 //     }
 //
@@ -62,11 +62,11 @@ impl Drop for S {
 //         drop(_4) -> [return: bb8, unwind: bb6];
 //     }
 //
-//     bb6: {
+//     bb6 (cleanup): {
 //         drop(_1) -> bb1;
 //     }
 //
-//     bb7: {
+//     bb7 (cleanup): {
 //         drop(_4) -> bb6;
 //     }
 //

--- a/src/test/mir-opt/generator-drop-cleanup.rs
+++ b/src/test/mir-opt/generator-drop-cleanup.rs
@@ -1,0 +1,43 @@
+#![feature(generators, generator_trait)]
+
+// Regression test for #58892, generator drop shims should not have blocks
+// spuriously marked as cleanup
+
+fn main() {
+    let gen = || {
+        yield;
+    };
+}
+
+// END RUST SOURCE
+
+// START rustc.main-{{closure}}.generator_drop.0.mir
+// bb0: {
+//     switchInt(((*_1).0: u32)) -> [0u32: bb4, 3u32: bb7, otherwise: bb8];
+// }
+// bb1: {
+//     goto -> bb5;
+// }
+// bb2: {
+//     return;
+// }
+// bb3: {
+//     return;
+// }
+// bb4: {
+//     goto -> bb6;
+// }
+// bb5: {
+//     goto -> bb2;
+// }
+// bb6: {
+//     goto -> bb3;
+// }
+// bb7: {
+//     StorageLive(_3);
+//     goto -> bb1;
+// }
+// bb8: {
+//     return;
+// }
+// END rustc.main-{{closure}}.generator_drop.0.mir

--- a/src/test/mir-opt/graphviz.rs
+++ b/src/test/mir-opt/graphviz.rs
@@ -1,0 +1,23 @@
+// Test graphviz output
+// compile-flags: -Z dump-mir-graphviz
+
+// ignore-tidy-linelength
+
+fn main() {}
+
+// END RUST SOURCE
+// START rustc.main.mir_map.0.dot
+// digraph Mir_0_0_3 { // The name here MUST be an ASCII identifier.
+//     graph [fontname="monospace"];
+//     node [fontname="monospace"];
+//     edge [fontname="monospace"];
+//     label=<fn main() -&gt; ()<br align="left"/>>;
+//     bb0 [shape="none", label=<<table border="0" cellborder="1" cellspacing="0"><tr><td bgcolor="gray" align="center" colspan="1">0</td></tr><tr><td align="left" balign="left">_0 = ()<br/></td></tr><tr><td align="left">goto</td></tr></table>
+// >];
+//     bb1 [shape="none", label=<<table border="0" cellborder="1" cellspacing="0"><tr><td bgcolor="gray" align="center" colspan="1">1</td></tr><tr><td align="left">resume</td></tr></table>
+// >];
+//     bb2 [shape="none", label=<<table border="0" cellborder="1" cellspacing="0"><tr><td bgcolor="gray" align="center" colspan="1">2</td></tr><tr><td align="left">return</td></tr></table>
+// >];
+//     bb0 -> bb2 [label=""];
+// }
+// END rustc.main.mir_map.0.dot

--- a/src/test/mir-opt/issue-38669.rs
+++ b/src/test/mir-opt/issue-38669.rs
@@ -18,7 +18,7 @@ fn main() {
 //         FakeRead(ForLet, _1);
 //         goto -> bb2;
 //     }
-//     bb1: {
+//     bb1 (cleanup): {
 //         resume;
 //     }
 //     bb2: {

--- a/src/test/mir-opt/issue-49232.rs
+++ b/src/test/mir-opt/issue-49232.rs
@@ -43,7 +43,7 @@ fn main() {
 //         FakeRead(ForMatchedPlace, _3);
 //         switchInt(_3) -> [false: bb9, otherwise: bb8];
 //     }
-//     bb4: {
+//     bb4 (cleanup): {
 //         resume;
 //     }
 //     bb5: {

--- a/src/test/mir-opt/loop_test.rs
+++ b/src/test/mir-opt/loop_test.rs
@@ -18,7 +18,7 @@ fn main() {
 // END RUST SOURCE
 // START rustc.main.SimplifyCfg-qualify-consts.after.mir
 //    ...
-//    bb1: { // The cleanup block
+//    bb1 (cleanup): {
 //        resume;
 //    }
 //    ...

--- a/src/test/mir-opt/match_false_edges.rs
+++ b/src/test/mir-opt/match_false_edges.rs
@@ -47,7 +47,7 @@ fn main() {
 //      _3 = discriminant(_2);
 //      switchInt(move _3) -> [0isize: bb4, 1isize: bb2, otherwise: bb7];
 //  }
-//  bb1: {
+//  bb1 (cleanup): {
 //      resume;
 //  }
 //  bb2: {
@@ -116,7 +116,7 @@ fn main() {
 //      _3 = discriminant(_2);
 //      switchInt(move _3) -> [0isize: bb3, 1isize: bb2, otherwise: bb7];
 //  }
-//  bb1: {
+//  bb1 (cleanup): {
 //      resume;
 //  }
 //  bb2: {
@@ -185,7 +185,7 @@ fn main() {
 //      _3 = discriminant(_2);
 //      switchInt(move _3) -> [1isize: bb2, otherwise: bb3];
 //  }
-//  bb1: {
+//  bb1 (cleanup): {
 //      resume;
 //  }
 //  bb2: {

--- a/src/test/mir-opt/packed-struct-drop-aligned.rs
+++ b/src/test/mir-opt/packed-struct-drop-aligned.rs
@@ -38,14 +38,14 @@ impl Drop for Droppy {
 //         _6 = move (_1.0: Aligned);
 //         drop(_6) -> [return: bb4, unwind: bb3];
 //     }
-//     bb1: {
+//     bb1 (cleanup): {
 //         resume;
 //     }
 //     bb2: {
 //         StorageDead(_1);
 //         return;
 //     }
-//     bb3: {
+//     bb3 (cleanup): {
 //         (_1.0: Aligned) = move _4;
 //         drop(_1) -> bb1;
 //     }

--- a/src/test/mir-opt/remove_fake_borrows.rs
+++ b/src/test/mir-opt/remove_fake_borrows.rs
@@ -63,7 +63,7 @@ fn main() {
 //     StorageDead(_8);
 //     return;
 // }
-// bb10: {
+// bb10 (cleanup): {
 //     resume;
 // }
 // END rustc.match_guard.CleanupNonCodegenStatements.before.mir
@@ -114,7 +114,7 @@ fn main() {
 //     StorageDead(_8);
 //     return;
 // }
-// bb10: {
+// bb10 (cleanup): {
 //     resume;
 // }
 // END rustc.match_guard.CleanupNonCodegenStatements.after.mir

--- a/src/test/mir-opt/unusual-item-types.rs
+++ b/src/test/mir-opt/unusual-item-types.rs
@@ -22,7 +22,7 @@ fn main() {
 //     _0 = const 2i32;
 //     return;
 // }
-// bb1: {
+// bb1 (cleanup): {
 //     resume;
 // }
 // END rustc.{{impl}}-ASSOCIATED_CONSTANT.mir_map.0.mir
@@ -32,7 +32,7 @@ fn main() {
 //     _0 = const 5isize;
 //     return;
 // }
-// bb1: {
+// bb1 (cleanup): {
 //     resume;
 // }
 // END rustc.E-V-{{constant}}.mir_map.0.mir
@@ -44,16 +44,16 @@ fn main() {
 // bb1: {
 //     return;
 // }
-// bb2: {
+// bb2 (cleanup): {
 //     resume;
 // }
 // bb3: {
 //     goto -> bb1;
 // }
-// bb4: {
+// bb4 (cleanup): {
 //     goto -> bb2;
 // }
-// bb5: {
+// bb5 (cleanup): {
 //     drop(((*_1).0: alloc::raw_vec::RawVec<i32>)) -> bb4;
 // }
 // bb6: {

--- a/src/test/run-fail/generator-resume-after-panic.rs
+++ b/src/test/run-fail/generator-resume-after-panic.rs
@@ -1,0 +1,22 @@
+// error-pattern:generator resumed after panicking
+
+// Test that we get the correct message for resuming a panicked generator.
+
+#![feature(generators, generator_trait)]
+
+use std::{
+    ops::Generator,
+    pin::Pin,
+    panic,
+};
+
+fn main() {
+    let mut g = || {
+        panic!();
+        yield;
+    };
+    panic::catch_unwind(panic::AssertUnwindSafe(|| {
+        let x = Pin::new(&mut g).resume();
+    }));
+    Pin::new(&mut g).resume();
+}

--- a/src/test/rustdoc/default_trait_method.rs
+++ b/src/test/rustdoc/default_trait_method.rs
@@ -1,0 +1,15 @@
+#![feature(specialization)]
+
+pub trait Item {
+    fn foo();
+    fn bar();
+}
+
+// @has default_trait_method/trait.Item.html
+// @has - '//*[@id="method.foo"]' 'default fn foo()'
+// @has - '//*[@id="method.bar"]' 'fn bar()'
+// @!has - '//*[@id="method.bar"]' 'default fn bar()'
+impl<T: ?Sized> Item for T {
+    default fn foo() {}
+    fn bar() {}
+}

--- a/src/test/ui/imports/auxiliary/gensymed.rs
+++ b/src/test/ui/imports/auxiliary/gensymed.rs
@@ -1,0 +1,3 @@
+// edition:2018
+
+mod std {}

--- a/src/test/ui/imports/gensymed.rs
+++ b/src/test/ui/imports/gensymed.rs
@@ -1,0 +1,7 @@
+// compile-pass
+// edition:2018
+// aux-build:gensymed.rs
+
+extern crate gensymed;
+
+fn main() {}

--- a/src/test/ui/parser/recovered-struct-variant.rs
+++ b/src/test/ui/parser/recovered-struct-variant.rs
@@ -1,0 +1,13 @@
+enum Foo {
+    A { a, b: usize }
+    //~^ ERROR expected `:`, found `,`
+}
+
+fn main() {
+    // no complaints about non-existing fields
+    let f = Foo::A { a:3, b: 4};
+    match f {
+        // no complaints about non-existing fields
+        Foo::A {a, b} => {}
+    }
+}

--- a/src/test/ui/parser/recovered-struct-variant.stderr
+++ b/src/test/ui/parser/recovered-struct-variant.stderr
@@ -1,0 +1,8 @@
+error: expected `:`, found `,`
+  --> $DIR/recovered-struct-variant.rs:2:10
+   |
+LL |     A { a, b: usize }
+   |          ^ expected `:`
+
+error: aborting due to previous error
+

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -10,7 +10,7 @@ use std::io::{self, Read, Write};
 use std::path::{PathBuf, Path};
 use std::process::{Command, Stdio};
 
-static HOSTS: &'static [&'static str] = &[
+static HOSTS: &[&str] = &[
     "aarch64-unknown-linux-gnu",
     "arm-unknown-linux-gnueabi",
     "arm-unknown-linux-gnueabihf",
@@ -35,7 +35,7 @@ static HOSTS: &'static [&'static str] = &[
     "x86_64-unknown-netbsd",
 ];
 
-static TARGETS: &'static [&'static str] = &[
+static TARGETS: &[&str] = &[
     "aarch64-apple-ios",
     "aarch64-fuchsia",
     "aarch64-linux-android",
@@ -115,7 +115,7 @@ static TARGETS: &'static [&'static str] = &[
     "x86_64-unknown-redox",
 ];
 
-static DOCS_TARGETS: &'static [&'static str] = &[
+static DOCS_TARGETS: &[&str] = &[
     "i686-apple-darwin",
     "i686-pc-windows-gnu",
     "i686-pc-windows-msvc",
@@ -126,7 +126,7 @@ static DOCS_TARGETS: &'static [&'static str] = &[
     "x86_64-unknown-linux-gnu",
 ];
 
-static MINGW: &'static [&'static str] = &[
+static MINGW: &[&str] = &[
     "i686-pc-windows-gnu",
     "x86_64-pc-windows-gnu",
 ];
@@ -153,7 +153,7 @@ struct Rename {
     to: String,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Default)]
 struct Target {
     available: bool,
     url: Option<String>,
@@ -165,23 +165,19 @@ struct Target {
 }
 
 impl Target {
-    fn unavailable() -> Target {
-        Target {
-            available: false,
-            url: None,
-            hash: None,
-            xz_url: None,
-            xz_hash: None,
-            components: None,
-            extensions: None,
-        }
-    }
+    fn unavailable() -> Self { Self::default() }
 }
 
 #[derive(Serialize)]
 struct Component {
     pkg: String,
     target: String,
+}
+
+impl Component {
+    fn from_str(pkg: &str, target: &str) -> Self {
+        Self { pkg: pkg.to_string(), target: target.to_string() }
+    }
 }
 
 macro_rules! t {
@@ -301,6 +297,25 @@ fn main() {
     }.build();
 }
 
+enum PkgType { RustSrc, Cargo, Rls, Clippy, Rustfmt, LlvmTools, Lldb, Miri, Other }
+
+impl PkgType {
+    fn from_component(component: &str) -> Self {
+        use PkgType::*;
+        match component {
+            "rust-src" => RustSrc,
+            "cargo" => Cargo,
+            "rls" | "rls-preview" => Rls,
+            "clippy" | "clippy-preview" => Clippy,
+            "rustfmt" | "rustfmt-preview" => Rustfmt,
+            "llvm-tools" | "llvm-tools-preview" => LlvmTools,
+            "lldb" | "lldb-preview" => Lldb,
+            "miri" | "miri-preview" => Miri,
+            _ => Other,
+        }
+    }
+}
+
 impl Builder {
     fn build(&mut self) {
         self.rust_version = self.version("rust", "x86_64-unknown-linux-gnu");
@@ -349,39 +364,56 @@ impl Builder {
             renames: BTreeMap::new(),
             profiles: BTreeMap::new(),
         };
+        self.add_packages_to(&mut manifest);
+        self.add_profiles_to(&mut manifest);
+        self.add_renames_to(&mut manifest);
+        manifest.pkg.insert("rust".to_string(), self.rust_package(&manifest));
+        manifest
+    }
 
-        self.package("rustc", &mut manifest.pkg, HOSTS);
-        self.package("cargo", &mut manifest.pkg, HOSTS);
-        self.package("rust-mingw", &mut manifest.pkg, MINGW);
-        self.package("rust-std", &mut manifest.pkg, TARGETS);
-        self.package("rust-docs", &mut manifest.pkg, DOCS_TARGETS);
-        self.package("rust-src", &mut manifest.pkg, &["*"]);
-        self.package("rls-preview", &mut manifest.pkg, HOSTS);
-        self.package("clippy-preview", &mut manifest.pkg, HOSTS);
-        self.package("miri", &mut manifest.pkg, HOSTS);
-        self.package("rustfmt-preview", &mut manifest.pkg, HOSTS);
-        self.package("rust-analysis", &mut manifest.pkg, TARGETS);
-        self.package("llvm-tools-preview", &mut manifest.pkg, TARGETS);
-        self.package("lldb-preview", &mut manifest.pkg, TARGETS);
+    fn add_packages_to(&mut self, manifest: &mut Manifest) {
+        let mut package = |name, targets| self.package(name, &mut manifest.pkg, targets);
+        package("rustc", HOSTS);
+        package("cargo", HOSTS);
+        package("rust-mingw", MINGW);
+        package("rust-std", TARGETS);
+        package("rust-docs", DOCS_TARGETS);
+        package("rust-src", &["*"]);
+        package("rls-preview", HOSTS);
+        package("clippy-preview", HOSTS);
+        package("miri", HOSTS);
+        package("rustfmt-preview", HOSTS);
+        package("rust-analysis", TARGETS);
+        package("llvm-tools-preview", TARGETS);
+        package("lldb-preview", TARGETS);
+    }
 
-        self.profile("minimal",
-                     &mut manifest.profiles,
-                     &["rustc", "cargo", "rust-std", "rust-mingw"]);
-        self.profile("default",
-                     &mut manifest.profiles,
-                     &["rustc", "cargo", "rust-std", "rust-mingw",
-                       "rust-docs", "rustfmt-preview", "clippy-preview"]);
-        self.profile("complete",
-                     &mut manifest.profiles,
-                     &["rustc", "cargo", "rust-std", "rust-mingw",
-                       "rust-docs", "rustfmt-preview", "clippy-preview",
-                       "rls-preview", "rust-src", "llvm-tools-preview",
-                       "lldb-preview", "rust-analysis", "miri"]);
+    fn add_profiles_to(&mut self, manifest: &mut Manifest) {
+        let mut profile = |name, pkgs| self.profile(name, &mut manifest.profiles, pkgs);
+        profile("minimal", &["rustc", "cargo", "rust-std", "rust-mingw"]);
+        profile("default", &[
+            "rustc", "cargo", "rust-std", "rust-mingw",
+            "rust-docs", "rustfmt-preview", "clippy-preview"
+        ]);
+        profile("complete", &[
+            "rustc", "cargo", "rust-std", "rust-mingw",
+            "rust-docs", "rustfmt-preview", "clippy-preview",
+            "rls-preview", "rust-src", "llvm-tools-preview",
+            "lldb-preview", "rust-analysis", "miri"
+        ]);
+    }
 
-        manifest.renames.insert("rls".to_owned(), Rename { to: "rls-preview".to_owned() });
-        manifest.renames.insert("rustfmt".to_owned(), Rename { to: "rustfmt-preview".to_owned() });
-        manifest.renames.insert("clippy".to_owned(), Rename { to: "clippy-preview".to_owned() });
+    fn add_renames_to(&self, manifest: &mut Manifest) {
+        let mut rename = |from: &str, to: &str| manifest.renames.insert(
+            from.to_owned(),
+            Rename { to: to.to_owned() }
+        );
+        rename("rls", "rls-preview");
+        rename("rustfmt", "rustfmt-preview");
+        rename("clippy", "clippy-preview");
+    }
 
+    fn rust_package(&mut self, manifest: &Manifest) -> Package {
         let mut pkg = Package {
             version: self.cached_version("rust")
                          .as_ref()
@@ -391,90 +423,82 @@ impl Builder {
             target: BTreeMap::new(),
         };
         for host in HOSTS {
-            let filename = self.filename("rust", host);
-            let digest = match self.digests.remove(&filename) {
-                Some(digest) => digest,
-                None => {
-                    pkg.target.insert(host.to_string(), Target::unavailable());
-                    continue
-                }
-            };
-            let xz_filename = filename.replace(".tar.gz", ".tar.xz");
-            let xz_digest = self.digests.remove(&xz_filename);
-            let mut components = Vec::new();
-            let mut extensions = Vec::new();
-
-            // rustc/rust-std/cargo/docs are all required, and so is rust-mingw
-            // if it's available for the target.
-            components.extend(vec![
-                Component { pkg: "rustc".to_string(), target: host.to_string() },
-                Component { pkg: "rust-std".to_string(), target: host.to_string() },
-                Component { pkg: "cargo".to_string(), target: host.to_string() },
-                Component { pkg: "rust-docs".to_string(), target: host.to_string() },
-            ]);
-            if host.contains("pc-windows-gnu") {
-                components.push(Component {
-                    pkg: "rust-mingw".to_string(),
-                    target: host.to_string(),
-                });
+            if let Some(target) = self.target_host_combination(host, &manifest) {
+                pkg.target.insert(host.to_string(), target);
+            } else {
+                pkg.target.insert(host.to_string(), Target::unavailable());
+                continue
             }
-
-            // Tools are always present in the manifest, but might be marked as unavailable if they
-            // weren't built
-            extensions.extend(vec![
-                Component { pkg: "clippy-preview".to_string(), target: host.to_string() },
-                Component { pkg: "miri".to_string(), target: host.to_string() },
-                Component { pkg: "rls-preview".to_string(), target: host.to_string() },
-                Component { pkg: "rustfmt-preview".to_string(), target: host.to_string() },
-                Component { pkg: "llvm-tools-preview".to_string(), target: host.to_string() },
-                Component { pkg: "lldb-preview".to_string(), target: host.to_string() },
-                Component { pkg: "rust-analysis".to_string(), target: host.to_string() },
-            ]);
-
-            for target in TARGETS {
-                if target != host {
-                    extensions.push(Component {
-                        pkg: "rust-std".to_string(),
-                        target: target.to_string(),
-                    });
-                }
-            }
-            extensions.push(Component {
-                pkg: "rust-src".to_string(),
-                target: "*".to_string(),
-            });
-
-            // If the components/extensions don't actually exist for this
-            // particular host/target combination then nix it entirely from our
-            // lists.
-            {
-                let has_component = |c: &Component| {
-                    if c.target == "*" {
-                        return true
-                    }
-                    let pkg = match manifest.pkg.get(&c.pkg) {
-                        Some(p) => p,
-                        None => return false,
-                    };
-                    pkg.target.get(&c.target).is_some()
-                };
-                extensions.retain(&has_component);
-                components.retain(&has_component);
-            }
-
-            pkg.target.insert(host.to_string(), Target {
-                available: true,
-                url: Some(self.url(&filename)),
-                hash: Some(digest),
-                xz_url: xz_digest.as_ref().map(|_| self.url(&xz_filename)),
-                xz_hash: xz_digest,
-                components: Some(components),
-                extensions: Some(extensions),
-            });
         }
-        manifest.pkg.insert("rust".to_string(), pkg);
+        pkg
+    }
 
-        manifest
+    fn target_host_combination(&mut self, host: &str, manifest: &Manifest) -> Option<Target> {
+        let filename = self.filename("rust", host);
+        let digest = self.digests.remove(&filename)?;
+        let xz_filename = filename.replace(".tar.gz", ".tar.xz");
+        let xz_digest = self.digests.remove(&xz_filename);
+        let mut components = Vec::new();
+        let mut extensions = Vec::new();
+
+        let host_component = |pkg| Component::from_str(pkg, host);
+
+        // rustc/rust-std/cargo/docs are all required,
+        // and so is rust-mingw if it's available for the target.
+        components.extend(vec![
+            host_component("rustc"),
+            host_component("rust-std"),
+            host_component("cargo"),
+            host_component("rust-docs"),
+        ]);
+        if host.contains("pc-windows-gnu") {
+            components.push(host_component("rust-mingw"));
+        }
+
+        // Tools are always present in the manifest,
+        // but might be marked as unavailable if they weren't built.
+        extensions.extend(vec![
+            host_component("clippy-preview"),
+            host_component("miri"),
+            host_component("rls-preview"),
+            host_component("rustfmt-preview"),
+            host_component("llvm-tools-preview"),
+            host_component("lldb-preview"),
+            host_component("rust-analysis"),
+        ]);
+
+        extensions.extend(
+            TARGETS.iter()
+                .filter(|&&target| target != host)
+                .map(|target| Component::from_str("rust-std", target))
+        );
+        extensions.push(Component::from_str("rust-src", "*"));
+
+        // If the components/extensions don't actually exist for this
+        // particular host/target combination then nix it entirely from our
+        // lists.
+        let has_component = |c: &Component| {
+            if c.target == "*" {
+                return true
+            }
+            let pkg = match manifest.pkg.get(&c.pkg) {
+                Some(p) => p,
+                None => return false,
+            };
+            pkg.target.get(&c.target).is_some()
+        };
+        extensions.retain(&has_component);
+        components.retain(&has_component);
+
+        Some(Target {
+            available: true,
+            url: Some(self.url(&filename)),
+            hash: Some(digest),
+            xz_url: xz_digest.as_ref().map(|_| self.url(&xz_filename)),
+            xz_hash: xz_digest,
+            components: Some(components),
+            extensions: Some(extensions),
+        })
     }
 
     fn profile(&mut self,
@@ -488,10 +512,11 @@ impl Builder {
                pkgname: &str,
                dst: &mut BTreeMap<String, Package>,
                targets: &[&str]) {
-        let (version, is_present) = match *self.cached_version(pkgname) {
-            Some(ref version) => (version.clone(), true),
-            None => (String::new(), false),
-        };
+        let (version, is_present) = self.cached_version(pkgname)
+            .as_ref()
+            .cloned()
+            .map(|version| (version, true))
+            .unwrap_or_default();
 
         let targets = targets.iter().map(|name| {
             if is_present {
@@ -515,15 +540,7 @@ impl Builder {
             } else {
                 // If the component is not present for this build add it anyway but mark it as
                 // unavailable -- this way rustup won't allow upgrades without --force
-                (name.to_string(), Target {
-                    available: false,
-                    url: None,
-                    hash: None,
-                    xz_url: None,
-                    xz_hash: None,
-                    components: None,
-                    extensions: None,
-                })
+                (name.to_string(), Target::unavailable())
             }
         }).collect();
 
@@ -542,89 +559,65 @@ impl Builder {
     }
 
     fn filename(&self, component: &str, target: &str) -> String {
-        if component == "rust-src" {
-            format!("rust-src-{}.tar.gz", self.rust_release)
-        } else if component == "cargo" {
-            format!("cargo-{}-{}.tar.gz", self.cargo_release, target)
-        } else if component == "rls" || component == "rls-preview" {
-            format!("rls-{}-{}.tar.gz", self.rls_release, target)
-        } else if component == "clippy" || component == "clippy-preview" {
-            format!("clippy-{}-{}.tar.gz", self.clippy_release, target)
-        } else if component == "rustfmt" || component == "rustfmt-preview" {
-            format!("rustfmt-{}-{}.tar.gz", self.rustfmt_release, target)
-        } else if component == "llvm-tools" || component == "llvm-tools-preview" {
-            format!("llvm-tools-{}-{}.tar.gz", self.llvm_tools_release, target)
-        } else if component == "lldb" || component == "lldb-preview" {
-            format!("lldb-{}-{}.tar.gz", self.lldb_release, target)
-        } else if component == "miri" || component == "miri-preview" {
-            format!("miri-{}-{}.tar.gz", self.miri_release, target)
-        } else {
-            format!("{}-{}-{}.tar.gz", component, self.rust_release, target)
+        use PkgType::*;
+        match PkgType::from_component(component) {
+            RustSrc => format!("rust-src-{}.tar.gz", self.rust_release),
+            Cargo => format!("cargo-{}-{}.tar.gz", self.cargo_release, target),
+            Rls => format!("rls-{}-{}.tar.gz", self.rls_release, target),
+            Clippy => format!("clippy-{}-{}.tar.gz", self.clippy_release, target),
+            Rustfmt => format!("rustfmt-{}-{}.tar.gz", self.rustfmt_release, target),
+            LlvmTools => format!("llvm-tools-{}-{}.tar.gz", self.llvm_tools_release, target),
+            Lldb => format!("lldb-{}-{}.tar.gz", self.lldb_release, target),
+            Miri => format!("miri-{}-{}.tar.gz", self.miri_release, target),
+            Other => format!("{}-{}-{}.tar.gz", component, self.rust_release, target),
         }
     }
 
     fn cached_version(&self, component: &str) -> &Option<String> {
-        if component == "cargo" {
-            &self.cargo_version
-        } else if component == "rls" || component == "rls-preview" {
-            &self.rls_version
-        } else if component == "clippy" || component == "clippy-preview" {
-            &self.clippy_version
-        } else if component == "rustfmt" || component == "rustfmt-preview" {
-            &self.rustfmt_version
-        } else if component == "llvm-tools" || component == "llvm-tools-preview" {
-            &self.llvm_tools_version
-        } else if component == "lldb" || component == "lldb-preview" {
-            &self.lldb_version
-        } else if component == "miri" || component == "miri-preview" {
-            &self.miri_version
-        } else {
-            &self.rust_version
+        use PkgType::*;
+        match PkgType::from_component(component) {
+            Cargo => &self.cargo_version,
+            Rls => &self.rls_version,
+            Clippy => &self.clippy_version,
+            Rustfmt => &self.rustfmt_version,
+            LlvmTools => &self.llvm_tools_version,
+            Lldb => &self.lldb_version,
+            Miri => &self.miri_version,
+            _ => &self.rust_version,
         }
     }
 
     fn cached_git_commit_hash(&self, component: &str) -> &Option<String> {
-        if component == "cargo" {
-            &self.cargo_git_commit_hash
-        } else if component == "rls" || component == "rls-preview" {
-            &self.rls_git_commit_hash
-        } else if component == "clippy" || component == "clippy-preview" {
-            &self.clippy_git_commit_hash
-        } else if component == "rustfmt" || component == "rustfmt-preview" {
-            &self.rustfmt_git_commit_hash
-        } else if component == "llvm-tools" || component == "llvm-tools-preview" {
-            &self.llvm_tools_git_commit_hash
-        } else if component == "lldb" || component == "lldb-preview" {
-            &self.lldb_git_commit_hash
-        } else if component == "miri" || component == "miri-preview" {
-            &self.miri_git_commit_hash
-        } else {
-            &self.rust_git_commit_hash
+        use PkgType::*;
+        match PkgType::from_component(component) {
+            Cargo => &self.cargo_git_commit_hash,
+            Rls => &self.rls_git_commit_hash,
+            Clippy => &self.clippy_git_commit_hash,
+            Rustfmt => &self.rustfmt_git_commit_hash,
+            LlvmTools => &self.llvm_tools_git_commit_hash,
+            Lldb => &self.lldb_git_commit_hash,
+            Miri => &self.miri_git_commit_hash,
+            _ => &self.rust_git_commit_hash,
         }
     }
 
     fn version(&self, component: &str, target: &str) -> Option<String> {
-        let mut cmd = Command::new("tar");
-        let filename = self.filename(component, target);
-        cmd.arg("xf")
-           .arg(self.input.join(&filename))
-           .arg(format!("{}/version", filename.replace(".tar.gz", "")))
-           .arg("-O");
-        let output = t!(cmd.output());
-        if output.status.success() {
-            Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
-        } else {
-            // Perhaps we didn't build this package.
-            None
-        }
+        self.untar(component, target, |filename| format!("{}/version", filename))
     }
 
     fn git_commit_hash(&self, component: &str, target: &str) -> Option<String> {
+        self.untar(component, target, |filename| format!("{}/git-commit-hash", filename))
+    }
+
+    fn untar<F>(&self, component: &str, target: &str, dir: F) -> Option<String>
+    where
+        F: FnOnce(String) -> String
+    {
         let mut cmd = Command::new("tar");
         let filename = self.filename(component, target);
         cmd.arg("xf")
            .arg(self.input.join(&filename))
-           .arg(format!("{}/git-commit-hash", filename.replace(".tar.gz", "")))
+           .arg(dir(filename.replace(".tar.gz", "")))
            .arg("-O");
         let output = t!(cmd.output());
         if output.status.success() {


### PR DESCRIPTION
Successful merges:

 - #58902 (Fixes for the generator transform)
 - #58913 (Add new test case for possible bug in BufReader)
 - #58927 (Add default keyword handling in rustdoc)
 - #58995 (Refactor tools/build-mainfest)
 - #59172 (Update and clean up several parts of CONTRIBUTING.md)
 - #59239 (Remove inline assembly from hint::spin_loop)
 - #59251 (Use a valid name for graphviz graphs)
 - #59256 (Make meta-item API compatible with `LocalInternedString::get` soundness fix)
 - #59266 (Do not complain about non-existing fields after parse recovery)
 - #59296 (Do not encode gensymed imports in metadata)

Failed merges:


r? @ghost