### PR TITLE
replace llvm-rebuild-trigger with submodule commit hash

### DIFF
--- a/src/rustllvm/llvm-rebuild-trigger
+++ b/src/rustllvm/llvm-rebuild-trigger
@@ -1,4 +1,0 @@
-# If this file is modified, then llvm will be (optionally) cleaned and then rebuilt.
-# The actual contents of this file do not matter, but to trigger a change on the
-# build bots then the contents should be changed so git updates the mtime.
-2019-03-18


### PR DESCRIPTION
As mentioned in #59285.

This PR removes the need to update the `llvm-rebuild-trigger` file. Instead, the latest commit hash of the appropriate LLVM submodule will be stored in the stamp file and used to detect if a build is required.

Fixes #42405.
Fixes #54959.
Fixes #55537.