### PR TITLE
Move some bench tests back from libtest

### DIFF
--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -44,3 +44,28 @@ pub fn black_box<T>(dummy: T) -> T {
 pub fn black_box<T>(dummy: T) -> T {
     dummy
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::Bencher;
+    use libtest::stats::Stats;
+
+    #[bench]
+    pub fn sum_three_items(b: &mut Bencher) {
+        b.iter(|| {
+            [1e20f64, 1.5f64, -1e20f64].sum();
+        })
+    }
+
+    #[bench]
+    pub fn sum_many_f64(b: &mut Bencher) {
+        let nums = [-1e30f64, 1e60, 1e30, 1.0, -1e60];
+        let v = (0..500).map(|i| nums[i % 5]).collect::<Vec<_>>();
+        b.iter(|| {
+            v.sum();
+        })
+    }
+
+    #[bench]
+    pub fn no_iter(_: &mut Bencher) {}
+}


### PR DESCRIPTION
It doesn't make much sense to test these on rust-lang/libtest since they exercise the `#[bench]` macro which is part of rust-lang/rust. 

This PR moves these tests back here.

r? @alexcrichton 