### PR TITLE
Implement CString::from_reader

### DIFF
--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -1356,20 +1356,6 @@ mod tests {
     }
 
     #[test]
-    fn read_to_cstring1() {
-        let test = "Example\0";
-        let string = CString::from_reader(test.as_bytes()).unwrap();
-        assert_eq!(string.as_bytes(), b"Example");
-    }
-
-    #[test]
-    fn read_to_cstring2() {
-        let test = "Example";
-        let result = CString::from_reader(test.as_bytes());
-        assert_eq!(result.is_err(), true);
-    }
-
-    #[test]
     fn simple() {
         let s = CString::new("1234").unwrap();
         assert_eq!(s.as_bytes(), b"1234");

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -371,7 +371,7 @@ impl CString {
     /// let string = CString::from_reader(test.as_bytes()).unwrap();
     /// ```
     ///
-    #[stable(feature = "cstring_from_reader", since = "1.33.0")]
+    #[stable(feature = "cstring_from_reader", issue = "59229")]
     pub fn from_reader(mut reader: impl io::Read) -> Result<CString, io::Error>
     {
         let mut buffer = Vec::new();

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -371,7 +371,7 @@ impl CString {
     /// let string = CString::from_reader(test.as_bytes()).unwrap();
     /// ```
     ///
-    #[stable(feature = "cstring_from_reader", issue = "#59229")]
+    #[unstable(feature = "cstring_from_reader", issue = "59229")]
     pub fn from_reader(mut reader: impl io::Read) -> Result<CString, io::Error>
     {
         let mut buffer = Vec::new();

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -365,6 +365,7 @@ impl CString {
     /// # Examples
     ///
     /// ```
+    /// #![feature(cstring_from_reader)]
     /// use std::ffi::CString;
     ///
     /// let test = "Example\0";

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -371,7 +371,7 @@ impl CString {
     /// let string = CString::from_reader(test.as_bytes()).unwrap();
     /// ```
     ///
-    #[stable(feature = "cstring_from_reader", issue = "59229")]
+    #[stable(feature = "cstring_from_reader", issue = "#59229")]
     pub fn from_reader(mut reader: impl io::Read) -> Result<CString, io::Error>
     {
         let mut buffer = Vec::new();


### PR DESCRIPTION
# Description

This PR implements the method ```CString::from_reader(impl Read) -> Result<CString, io::Error>```.
Issue #59229 explains why this method should be included in the Standard Library, but it boils down to:
- People are using unsafe code to read a CString without performance overhead.
- There are currently no methods in the Standard Library that allow us to read a CString safely without having to check for intermediate null characters (something is often already proven by the way the code is written).

I still have one open point. Currently I construct a CString by pushing the null character to the buffer and then using:
```
CString { inner: buffer.into_boxed_slice() }
```

I thought that would be better then calling ```CString::from_vec_unchecked``` which results in:
```
v.reserve_exact(1);
v.push(0);
CString { inner: v.into_boxed_slice() }
```
In all cases where the vector still contains space for another null character not using ```CString::from_vec_unchecked``` would be faster because ```v.reserve_exact(1);``` does not have to be called. I believe this occurs far more often then a ```Vec``` having no space left when reading from an object that implements ```Read```.

I do however wonder if the compiler is able eliminate the check that occurs in ```v.push``` when ```v.reserve_exact``` is called just prior to it. If it is able to do that I will change to code to use ```CString::from_vec_unchecked``` because in case of a memory allocation it will try to provide a more exact block without the performance overhead of having to do an extra check. If anyone is able to verify this (Assembly is not my strongest point), please let me know :)

What do you guys think about this?

closes #59229 

EDIT: Oh, and this is my first pull request on Rust! So if I did anything wrong, please let me know! :)