### PR TITLE
Internal lints take 2

### DIFF
--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -316,6 +316,11 @@ fn main() {
         }
     }
 
+    // This is required for internal lints.
+    if stage != "0" {
+        cmd.arg("-Zunstable-options");
+    }
+
     // Force all crates compiled by this compiler to (a) be unstable and (b)
     // allow the `rustc_private` feature to link to other unstable crates
     // also in the sysroot. We also do this for host crates, since those

--- a/src/libarena/lib.rs
+++ b/src/libarena/lib.rs
@@ -12,6 +12,7 @@
        test(no_crate_inject, attr(deny(warnings))))]
 
 #![deny(rust_2018_idioms)]
+#![cfg_attr(not(stage0), deny(internal))]
 
 #![feature(alloc)]
 #![feature(core_intrinsics)]

--- a/src/libfmt_macros/lib.rs
+++ b/src/libfmt_macros/lib.rs
@@ -9,6 +9,7 @@
        test(attr(deny(warnings))))]
 
 #![deny(rust_2018_idioms)]
+#![cfg_attr(not(stage0), deny(internal))]
 
 #![feature(nll)]
 #![feature(rustc_private)]

--- a/src/librustc/ich/hcx.rs
+++ b/src/librustc/ich/hcx.rs
@@ -9,7 +9,6 @@ use crate::session::Session;
 
 use std::cmp::Ord;
 use std::hash as std_hash;
-use std::collections::HashMap;
 use std::cell::RefCell;
 
 use syntax::ast;
@@ -394,13 +393,12 @@ impl<'a> HashStable<StableHashingContext<'a>> for DelimSpan {
     }
 }
 
-pub fn hash_stable_trait_impls<'a, 'gcx, W, R>(
+pub fn hash_stable_trait_impls<'a, 'gcx, W>(
     hcx: &mut StableHashingContext<'a>,
     hasher: &mut StableHasher<W>,
     blanket_impls: &[DefId],
-    non_blanket_impls: &HashMap<fast_reject::SimplifiedType, Vec<DefId>, R>)
-    where W: StableHasherResult,
-          R: std_hash::BuildHasher,
+    non_blanket_impls: &FxHashMap<fast_reject::SimplifiedType, Vec<DefId>>)
+    where W: StableHasherResult
 {
     {
         let mut blanket_impls: SmallVec<[_; 8]> = blanket_impls

--- a/src/librustc/infer/error_reporting/mod.rs
+++ b/src/librustc/infer/error_reporting/mod.rs
@@ -56,7 +56,7 @@ use crate::hir::Node;
 use crate::middle::region;
 use crate::traits::{ObligationCause, ObligationCauseCode};
 use crate::ty::error::TypeError;
-use crate::ty::{self, subst::{Subst, SubstsRef}, Region, Ty, TyCtxt, TyKind, TypeFoldable};
+use crate::ty::{self, subst::{Subst, SubstsRef}, Region, Ty, TyCtxt, TypeFoldable};
 use errors::{Applicability, DiagnosticBuilder, DiagnosticStyledString};
 use std::{cmp, fmt};
 use syntax_pos::{Pos, Span};
@@ -1094,14 +1094,14 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                 (_, false, _) => {
                     if let Some(exp_found) = exp_found {
                         let (def_id, ret_ty) = match exp_found.found.sty {
-                            TyKind::FnDef(def, _) => {
+                            ty::FnDef(def, _) => {
                                 (Some(def), Some(self.tcx.fn_sig(def).output()))
                             }
                             _ => (None, None),
                         };
 
                         let exp_is_struct = match exp_found.expected.sty {
-                            TyKind::Adt(def, _) => def.is_struct(),
+                            ty::Adt(def, _) => def.is_struct(),
                             _ => false,
                         };
 
@@ -1140,8 +1140,8 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
         diag: &mut DiagnosticBuilder<'tcx>,
     ) {
         match (&exp_found.expected.sty, &exp_found.found.sty) {
-            (TyKind::Adt(exp_def, exp_substs), TyKind::Ref(_, found_ty, _)) => {
-                if let TyKind::Adt(found_def, found_substs) = found_ty.sty {
+            (ty::Adt(exp_def, exp_substs), ty::Ref(_, found_ty, _)) => {
+                if let ty::Adt(found_def, found_substs) = found_ty.sty {
                     let path_str = format!("{:?}", exp_def);
                     if exp_def == &found_def {
                         let opt_msg = "you can convert from `&Option<T>` to `Option<&T>` using \
@@ -1164,17 +1164,17 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                             let mut show_suggestion = true;
                             for (exp_ty, found_ty) in exp_substs.types().zip(found_substs.types()) {
                                 match exp_ty.sty {
-                                    TyKind::Ref(_, exp_ty, _) => {
+                                    ty::Ref(_, exp_ty, _) => {
                                         match (&exp_ty.sty, &found_ty.sty) {
-                                            (_, TyKind::Param(_)) |
-                                            (_, TyKind::Infer(_)) |
-                                            (TyKind::Param(_), _) |
-                                            (TyKind::Infer(_), _) => {}
+                                            (_, ty::Param(_)) |
+                                            (_, ty::Infer(_)) |
+                                            (ty::Param(_), _) |
+                                            (ty::Infer(_), _) => {}
                                             _ if ty::TyS::same_type(exp_ty, found_ty) => {}
                                             _ => show_suggestion = false,
                                         };
                                     }
-                                    TyKind::Param(_) | TyKind::Infer(_) => {}
+                                    ty::Param(_) | ty::Infer(_) => {}
                                     _ => show_suggestion = false,
                                 }
                             }

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -29,6 +29,7 @@
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
 
 #![deny(rust_2018_idioms)]
+#![cfg_attr(not(stage0), deny(internal))]
 #![allow(explicit_outlives_requirements)]
 
 #![feature(arbitrary_self_types)]

--- a/src/librustc/lint/internal.rs
+++ b/src/librustc/lint/internal.rs
@@ -1,21 +1,11 @@
-// Copyright 2012-2018 The Rust Project Developers. See the COPYRIGHT
-// file at the top-level directory of this distribution and at
-// http://rust-lang.org/COPYRIGHT.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 //! Some lints that are only useful in the compiler or crates that use compiler internals, such as
 //! Clippy.
 
-use errors::Applicability;
-use hir::{Expr, ExprKind, PatKind, Path, QPath, Ty, TyKind};
-use lint::{
+use crate::hir::{Expr, ExprKind, PatKind, Path, QPath, Ty, TyKind};
+use crate::lint::{
     EarlyContext, EarlyLintPass, LateContext, LateLintPass, LintArray, LintContext, LintPass,
 };
+use errors::Applicability;
 use rustc_data_structures::fx::FxHashMap;
 use syntax::ast::Ident;
 
@@ -42,6 +32,10 @@ impl LintPass for DefaultHashTypes {
     fn get_lints(&self) -> LintArray {
         lint_array!(DEFAULT_HASH_TYPES)
     }
+
+    fn name(&self) -> &'static str {
+        "DefaultHashTypes"
+    }
 }
 
 impl EarlyLintPass for DefaultHashTypes {
@@ -53,7 +47,7 @@ impl EarlyLintPass for DefaultHashTypes {
                 replace, ident_string
             );
             let mut db = cx.struct_span_lint(DEFAULT_HASH_TYPES, ident.span, &msg);
-            db.span_suggestion_with_applicability(
+            db.span_suggestion(
                 ident.span,
                 "use",
                 replace.to_string(),
@@ -79,6 +73,10 @@ pub struct TyKindUsage;
 impl LintPass for TyKindUsage {
     fn get_lints(&self) -> LintArray {
         lint_array!(USAGE_OF_TY_TYKIND)
+    }
+
+    fn name(&self) -> &'static str {
+        "TyKindUsage"
     }
 }
 
@@ -124,12 +122,13 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TyKindUsage {
                                     path.span,
                                     "usage of `ty::TyKind::<kind>`",
                                 )
-                                .span_suggestion_with_applicability(
+                                .span_suggestion(
                                     path.span,
                                     "try using ty::<kind> directly",
                                     "ty".to_string(),
                                     Applicability::MaybeIncorrect, // ty maybe needs an import
-                                ).emit();
+                                )
+                                .emit();
                             }
                         }
                     }

--- a/src/librustc/lint/internal.rs
+++ b/src/librustc/lint/internal.rs
@@ -11,7 +11,7 @@ use syntax::ast::Ident;
 
 declare_lint! {
     pub DEFAULT_HASH_TYPES,
-    Warn,
+    Allow,
     "forbid HashMap and HashSet and suggest the FxHash* variants"
 }
 
@@ -64,7 +64,7 @@ impl EarlyLintPass for DefaultHashTypes {
 
 declare_lint! {
     pub USAGE_OF_TY_TYKIND,
-    Warn,
+    Allow,
     "Usage of `ty::TyKind` outside of the `ty::sty` module"
 }
 

--- a/src/librustc/lint/internal.rs
+++ b/src/librustc/lint/internal.rs
@@ -1,0 +1,165 @@
+// Copyright 2012-2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Some lints that are only useful in the compiler or crates that use compiler internals, such as
+//! Clippy.
+
+use errors::Applicability;
+use hir::{Expr, ExprKind, PatKind, Path, QPath, Ty, TyKind};
+use lint::{
+    EarlyContext, EarlyLintPass, LateContext, LateLintPass, LintArray, LintContext, LintPass,
+};
+use rustc_data_structures::fx::FxHashMap;
+use syntax::ast::Ident;
+
+declare_lint! {
+    pub DEFAULT_HASH_TYPES,
+    Warn,
+    "forbid HashMap and HashSet and suggest the FxHash* variants"
+}
+
+pub struct DefaultHashTypes {
+    map: FxHashMap<String, String>,
+}
+
+impl DefaultHashTypes {
+    pub fn new() -> Self {
+        let mut map = FxHashMap::default();
+        map.insert("HashMap".to_string(), "FxHashMap".to_string());
+        map.insert("HashSet".to_string(), "FxHashSet".to_string());
+        Self { map }
+    }
+}
+
+impl LintPass for DefaultHashTypes {
+    fn get_lints(&self) -> LintArray {
+        lint_array!(DEFAULT_HASH_TYPES)
+    }
+}
+
+impl EarlyLintPass for DefaultHashTypes {
+    fn check_ident(&mut self, cx: &EarlyContext<'_>, ident: Ident) {
+        let ident_string = ident.to_string();
+        if let Some(replace) = self.map.get(&ident_string) {
+            let msg = format!(
+                "Prefer {} over {}, it has better performance",
+                replace, ident_string
+            );
+            let mut db = cx.struct_span_lint(DEFAULT_HASH_TYPES, ident.span, &msg);
+            db.span_suggestion_with_applicability(
+                ident.span,
+                "use",
+                replace.to_string(),
+                Applicability::MaybeIncorrect, // FxHashMap, ... needs another import
+            );
+            db.note(&format!(
+                "a `use rustc_data_structures::fx::{}` may be necessary",
+                replace
+            ))
+            .emit();
+        }
+    }
+}
+
+declare_lint! {
+    pub USAGE_OF_TY_TYKIND,
+    Warn,
+    "Usage of `ty::TyKind` outside of the `ty::sty` module"
+}
+
+pub struct TyKindUsage;
+
+impl LintPass for TyKindUsage {
+    fn get_lints(&self) -> LintArray {
+        lint_array!(USAGE_OF_TY_TYKIND)
+    }
+}
+
+impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TyKindUsage {
+    fn check_expr(&mut self, cx: &LateContext<'_, '_>, expr: &'tcx Expr) {
+        let qpaths = match &expr.node {
+            ExprKind::Match(_, arms, _) => {
+                let mut qpaths = vec![];
+                for arm in arms {
+                    for pat in &arm.pats {
+                        match &pat.node {
+                            PatKind::Path(qpath) | PatKind::TupleStruct(qpath, ..) => {
+                                qpaths.push(qpath)
+                            }
+                            _ => (),
+                        }
+                    }
+                }
+                qpaths
+            }
+            ExprKind::Path(qpath) => vec![qpath],
+            _ => vec![],
+        };
+        for qpath in qpaths {
+            if let QPath::Resolved(_, path) = qpath {
+                let segments_iter = path.segments.iter().rev().skip(1).rev();
+
+                if let Some(last) = segments_iter.clone().last() {
+                    if last.ident.as_str() == "TyKind" {
+                        let path = Path {
+                            span: path.span.with_hi(last.ident.span.hi()),
+                            def: path.def,
+                            segments: segments_iter.cloned().collect(),
+                        };
+
+                        if let Some(def) = last.def {
+                            if def
+                                .def_id()
+                                .match_path(cx.tcx, &["rustc", "ty", "sty", "TyKind"])
+                            {
+                                cx.struct_span_lint(
+                                    USAGE_OF_TY_TYKIND,
+                                    path.span,
+                                    "usage of `ty::TyKind::<kind>`",
+                                )
+                                .span_suggestion_with_applicability(
+                                    path.span,
+                                    "try using ty::<kind> directly",
+                                    "ty".to_string(),
+                                    Applicability::MaybeIncorrect, // ty maybe needs an import
+                                ).emit();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn check_ty(&mut self, cx: &LateContext<'_, '_>, ty: &'tcx Ty) {
+        if let TyKind::Path(qpath) = &ty.node {
+            if let QPath::Resolved(_, path) = qpath {
+                if let Some(last) = path.segments.iter().last() {
+                    if last.ident.as_str() == "TyKind" {
+                        if let Some(def) = last.def {
+                            if def
+                                .def_id()
+                                .match_path(cx.tcx, &["rustc", "ty", "sty", "TyKind"])
+                            {
+                                cx.struct_span_lint(
+                                    USAGE_OF_TY_TYKIND,
+                                    path.span,
+                                    "usage of `ty::TyKind`",
+                                )
+                                .help("try using `ty::Ty` instead")
+                                .emit();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/librustc/lint/internal.rs
+++ b/src/librustc/lint/internal.rs
@@ -1,7 +1,7 @@
 //! Some lints that are only useful in the compiler or crates that use compiler internals, such as
 //! Clippy.
 
-use crate::hir::{HirId, Path, QPath, Ty, TyKind};
+use crate::hir::{def::Def, HirId, Path, QPath, Ty, TyKind};
 use crate::lint::{
     EarlyContext, EarlyLintPass, LateContext, LateLintPass, LintArray, LintContext, LintPass,
 };
@@ -92,10 +92,12 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TyKindUsage {
                     segments: segments_iter.cloned().collect(),
                 };
 
-                if let Some(def) = last.def {
-                    if def
-                        .def_id()
-                        .match_path(cx.tcx, &["rustc", "ty", "sty", "TyKind"])
+                match last.def {
+                    Some(Def::Err) => (),
+                    Some(def)
+                        if def
+                            .def_id()
+                            .match_path(cx.tcx, &["rustc", "ty", "sty", "TyKind"]) =>
                     {
                         cx.struct_span_lint(
                             USAGE_OF_TY_TYKIND,
@@ -110,6 +112,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TyKindUsage {
                         )
                         .emit();
                     }
+                    _ => (),
                 }
             }
         }

--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -574,6 +574,7 @@ impl_stable_hash_for!(enum self::LintSource {
 pub type LevelSource = (Level, LintSource);
 
 pub mod builtin;
+pub mod internal;
 mod context;
 mod levels;
 

--- a/src/librustc/mir/tcx.rs
+++ b/src/librustc/mir/tcx.rs
@@ -36,7 +36,7 @@ impl<'a, 'gcx, 'tcx> PlaceTy<'tcx> {
     pub fn field_ty(self, tcx: TyCtxt<'a, 'gcx, 'tcx>, f: &Field) -> Ty<'tcx>
     {
         let answer = match self.ty.sty {
-            ty::TyKind::Adt(adt_def, substs) => {
+            ty::Adt(adt_def, substs) => {
                 let variant_def = match self.variant_index {
                     None => adt_def.non_enum_variant(),
                     Some(variant_index) => {

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -219,6 +219,11 @@ pub struct CommonTypes<'tcx> {
     pub never: Ty<'tcx>,
     pub err: Ty<'tcx>,
 
+    /// Dummy type used for the `Self` of a `TraitRef` created for converting
+    /// a trait object, and which gets removed in `ExistentialTraitRef`.
+    /// This type must not appear anywhere in other converted types.
+    pub trait_object_dummy_self: Ty<'tcx>,
+
     pub re_empty: Region<'tcx>,
     pub re_static: Region<'tcx>,
     pub re_erased: Region<'tcx>,
@@ -954,6 +959,8 @@ impl<'tcx> CommonTypes<'tcx> {
             u128: mk(Uint(ast::UintTy::U128)),
             f32: mk(Float(ast::FloatTy::F32)),
             f64: mk(Float(ast::FloatTy::F64)),
+
+            trait_object_dummy_self: mk(Infer(ty::FreshTy(0))),
 
             re_empty: mk_region(RegionKind::ReEmpty),
             re_static: mk_region(RegionKind::ReStatic),

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(stage0), allow(usage_of_ty_tykind))]
+
 pub use self::Variance::*;
 pub use self::AssociatedItemContainer::*;
 pub use self::BorrowKind::*;

--- a/src/librustc/util/common.rs
+++ b/src/librustc/util/common.rs
@@ -1,11 +1,10 @@
 #![allow(non_camel_case_types)]
 
-use rustc_data_structures::sync::Lock;
+use rustc_data_structures::{fx::FxHashMap, sync::Lock};
 
 use std::cell::{RefCell, Cell};
-use std::collections::HashMap;
 use std::fmt::Debug;
-use std::hash::{Hash, BuildHasher};
+use std::hash::Hash;
 use std::panic;
 use std::env;
 use std::time::{Duration, Instant};
@@ -341,8 +340,8 @@ pub trait MemoizationMap {
         where OP: FnOnce() -> Self::Value;
 }
 
-impl<K, V, S> MemoizationMap for RefCell<HashMap<K,V,S>>
-    where K: Hash+Eq+Clone, V: Clone, S: BuildHasher
+impl<K, V> MemoizationMap for RefCell<FxHashMap<K,V>>
+    where K: Hash+Eq+Clone, V: Clone
 {
     type Key = K;
     type Value = V;

--- a/src/librustc_allocator/lib.rs
+++ b/src/librustc_allocator/lib.rs
@@ -2,6 +2,7 @@
 #![feature(rustc_private)]
 
 #![deny(rust_2018_idioms)]
+#![cfg_attr(not(stage0), deny(internal))]
 
 pub mod expand;
 

--- a/src/librustc_borrowck/lib.rs
+++ b/src/librustc_borrowck/lib.rs
@@ -2,6 +2,7 @@
 
 #![allow(non_camel_case_types)]
 #![deny(rust_2018_idioms)]
+#![cfg_attr(not(stage0), deny(internal))]
 
 #![feature(nll)]
 

--- a/src/librustc_codegen_ssa/lib.rs
+++ b/src/librustc_codegen_ssa/lib.rs
@@ -14,6 +14,7 @@
 #![allow(unused_attributes)]
 #![allow(dead_code)]
 #![deny(rust_2018_idioms)]
+#![cfg_attr(not(stage0), deny(internal))]
 #![allow(explicit_outlives_requirements)]
 
 #![recursion_limit="256"]

--- a/src/librustc_codegen_utils/lib.rs
+++ b/src/librustc_codegen_utils/lib.rs
@@ -16,6 +16,7 @@
 #![recursion_limit="256"]
 
 #![deny(rust_2018_idioms)]
+#![cfg_attr(not(stage0), deny(internal))]
 
 #[macro_use]
 extern crate rustc;

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -17,6 +17,7 @@
 #![recursion_limit="256"]
 
 #![deny(rust_2018_idioms)]
+#![cfg_attr(not(stage0), deny(internal))]
 
 pub extern crate getopts;
 #[cfg(unix)]

--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -6,6 +6,7 @@
 #![feature(nll)]
 #![feature(optin_builtin_traits)]
 #![deny(rust_2018_idioms)]
+#![cfg_attr(not(stage0), deny(internal))]
 
 #[allow(unused_extern_crates)]
 extern crate serialize as rustc_serialize; // used by deriving

--- a/src/librustc_incremental/lib.rs
+++ b/src/librustc_incremental/lib.rs
@@ -8,6 +8,7 @@
 #![recursion_limit="256"]
 
 #![deny(rust_2018_idioms)]
+#![cfg_attr(not(stage0), deny(internal))]
 
 #[macro_use] extern crate rustc;
 #[allow(unused_extern_crates)]

--- a/src/librustc_interface/interface.rs
+++ b/src/librustc_interface/interface.rs
@@ -12,7 +12,6 @@ use rustc_data_structures::OnDrop;
 use rustc_data_structures::sync::Lrc;
 use rustc_data_structures::fx::{FxHashSet, FxHashMap};
 use rustc_metadata::cstore::CStore;
-use std::collections::HashSet;
 use std::io::Write;
 use std::path::PathBuf;
 use std::result;

--- a/src/librustc_interface/lib.rs
+++ b/src/librustc_interface/lib.rs
@@ -7,6 +7,7 @@
 #![cfg_attr(unix, feature(libc))]
 
 #![deny(rust_2018_idioms)]
+#![cfg_attr(not(stage0), deny(internal))]
 
 #![allow(unused_imports)]
 

--- a/src/librustc_interface/util.rs
+++ b/src/librustc_interface/util.rs
@@ -109,6 +109,7 @@ pub fn create_session(
     let codegen_backend = get_codegen_backend(&sess);
 
     rustc_lint::register_builtins(&mut sess.lint_store.borrow_mut(), Some(&sess));
+    rustc_lint::register_internals(&mut sess.lint_store.borrow_mut(), Some(&sess));
 
     let mut cfg = config::build_configuration(&sess, config::to_crate_config(cfg));
     add_configuration(&mut cfg, &sess, &*codegen_backend);

--- a/src/librustc_interface/util.rs
+++ b/src/librustc_interface/util.rs
@@ -109,7 +109,9 @@ pub fn create_session(
     let codegen_backend = get_codegen_backend(&sess);
 
     rustc_lint::register_builtins(&mut sess.lint_store.borrow_mut(), Some(&sess));
-    rustc_lint::register_internals(&mut sess.lint_store.borrow_mut(), Some(&sess));
+    if sess.unstable_options() {
+        rustc_lint::register_internals(&mut sess.lint_store.borrow_mut(), Some(&sess));
+    }
 
     let mut cfg = config::build_configuration(&sess, config::to_crate_config(cfg));
     add_configuration(&mut cfg, &sess, &*codegen_backend);

--- a/src/librustc_interface/util.rs
+++ b/src/librustc_interface/util.rs
@@ -21,7 +21,6 @@ use rustc_plugin;
 use rustc_privacy;
 use rustc_resolve;
 use rustc_typeck;
-use std::collections::HashSet;
 use std::env;
 use std::env::consts::{DLL_PREFIX, DLL_SUFFIX};
 use std::io::{self, Write};

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -20,6 +20,7 @@
 #![recursion_limit="256"]
 
 #![deny(rust_2018_idioms)]
+#![cfg_attr(not(stage0), deny(internal))]
 
 #[macro_use]
 extern crate rustc;

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -61,6 +61,7 @@ use nonstandard_style::*;
 use builtin::*;
 use types::*;
 use unused::*;
+use rustc::lint::internal::*;
 
 /// Useful for other parts of the compiler.
 pub use builtin::SoftLints;
@@ -487,4 +488,19 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
         "no longer a warning, #[no_mangle] statics always exported");
     store.register_removed("bad_repr",
         "replaced with a generic attribute input check");
+}
+
+pub fn register_internals(store: &mut lint::LintStore, sess: Option<&Session>) {
+    store.register_early_pass(sess, false, false, box DefaultHashTypes::new());
+    store.register_late_pass(sess, false, false, false, box TyKindUsage);
+    store.register_group(
+        sess,
+        false,
+        "internal",
+        None,
+        vec![
+            LintId::of(DEFAULT_HASH_TYPES),
+            LintId::of(USAGE_OF_TY_TYKIND),
+        ],
+    );
 }

--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -321,7 +321,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TypeLimits {
         //
         // No suggestion for: `isize`, `usize`.
         fn get_type_suggestion<'a>(
-            t: &ty::TyKind<'_>,
+            t: Ty<'_>,
             val: u128,
             negative: bool,
         ) -> Option<String> {
@@ -347,14 +347,14 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TypeLimits {
                     }
                 }
             }
-            match t {
-                &ty::Int(i) => find_fit!(i, val, negative,
+            match t.sty {
+                ty::Int(i) => find_fit!(i, val, negative,
                               I8 => [U8] => [I16, I32, I64, I128],
                               I16 => [U16] => [I32, I64, I128],
                               I32 => [U32] => [I64, I128],
                               I64 => [U64] => [I128],
                               I128 => [U128] => []),
-                &ty::Uint(u) => find_fit!(u, val, negative,
+                ty::Uint(u) => find_fit!(u, val, negative,
                               U8 => [U8, U16, U32, U64, U128] => [],
                               U16 => [U16, U32, U64, U128] => [],
                               U32 => [U32, U64, U128] => [],
@@ -364,6 +364,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TypeLimits {
             }
         }
 
+        #[cfg_attr(not(stage0), allow(usage_of_ty_tykind))]
         fn report_bin_hex_error(
             cx: &LateContext<'_, '_>,
             expr: &hir::Expr,
@@ -398,7 +399,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TypeLimits {
                 repr_str, val, t, actually, t
             ));
             if let Some(sugg_ty) =
-                get_type_suggestion(&cx.tables.node_type(expr.hir_id).sty, val, negative)
+                get_type_suggestion(&cx.tables.node_type(expr.hir_id), val, negative)
             {
                 if let Some(pos) = repr_str.chars().position(|c| c == 'i' || c == 'u') {
                     let (sans_suffix, _) = repr_str.split_at(pos);

--- a/src/librustc_metadata/lib.rs
+++ b/src/librustc_metadata/lib.rs
@@ -14,6 +14,7 @@
 #![recursion_limit="256"]
 
 #![deny(rust_2018_idioms)]
+#![cfg_attr(not(stage0), deny(internal))]
 
 extern crate libc;
 #[allow(unused_extern_crates)]

--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -1741,7 +1741,7 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
                 // no move out from an earlier location) then this is an attempt at initialization
                 // of the union - we should error in that case.
                 let tcx = this.infcx.tcx;
-                if let ty::TyKind::Adt(def, _) = base.ty(this.mir, tcx).ty.sty {
+                if let ty::Adt(def, _) = base.ty(this.mir, tcx).ty.sty {
                     if def.is_union() {
                         if this.move_data.path_map[mpi].iter().any(|moi| {
                             this.move_data.moves[*moi].source.is_predecessor_of(

--- a/src/librustc_mir/borrow_check/move_errors.rs
+++ b/src/librustc_mir/borrow_check/move_errors.rs
@@ -532,7 +532,7 @@ impl<'a, 'gcx, 'tcx> MirBorrowckCtxt<'a, 'gcx, 'tcx> {
                     if let StatementKind::Assign(_, box Rvalue::Ref(_, _, source)) = &stmt.kind {
                         let ty = source.ty(self.mir, self.infcx.tcx).ty;
                         let ty = match ty.sty {
-                            ty::TyKind::Ref(_, ty, _) => ty,
+                            ty::Ref(_, ty, _) => ty,
                             _ => ty,
                         };
                         debug!("borrowed_content_source: ty={:?}", ty);
@@ -557,7 +557,7 @@ impl<'a, 'gcx, 'tcx> MirBorrowckCtxt<'a, 'gcx, 'tcx> {
 
                         let ty = source.ty(self.mir, self.infcx.tcx).ty;
                         let ty = match ty.sty {
-                            ty::TyKind::Ref(_, ty, _) => ty,
+                            ty::Ref(_, ty, _) => ty,
                             _ => ty,
                         };
                         debug!("borrowed_content_source: ty={:?}", ty);

--- a/src/librustc_mir/borrow_check/mutability_errors.rs
+++ b/src/librustc_mir/borrow_check/mutability_errors.rs
@@ -5,7 +5,7 @@ use rustc::mir::{
     Mutability, Operand, Place, PlaceBase, Projection, ProjectionElem, Static, StaticKind,
 };
 use rustc::mir::{Terminator, TerminatorKind};
-use rustc::ty::{self, Const, DefIdTree, TyS, TyKind, TyCtxt};
+use rustc::ty::{self, Const, DefIdTree, TyS, TyCtxt};
 use rustc_data_structures::indexed_vec::Idx;
 use syntax_pos::Span;
 use syntax_pos::symbol::keywords;
@@ -261,7 +261,7 @@ impl<'a, 'gcx, 'tcx> MirBorrowckCtxt<'a, 'gcx, 'tcx> {
                             // Otherwise, check if the name is the self kewyord - in which case
                             // we have an explicit self. Do the same thing in this case and check
                             // for a `self: &mut Self` to suggest removing the `&mut`.
-                            if let ty::TyKind::Ref(
+                            if let ty::Ref(
                                 _, _, hir::Mutability::MutMutable
                             ) = local_decl.ty.sty {
                                 true
@@ -476,7 +476,7 @@ impl<'a, 'gcx, 'tcx> MirBorrowckCtxt<'a, 'gcx, 'tcx> {
                                     func: Operand::Constant(box Constant {
                                         literal: Const {
                                             ty: &TyS {
-                                                sty: TyKind::FnDef(id, substs),
+                                                sty: ty::FnDef(id, substs),
                                                 ..
                                             },
                                             ..
@@ -633,8 +633,8 @@ fn annotate_struct_field(
     field: &mir::Field,
 ) -> Option<(Span, String)> {
     // Expect our local to be a reference to a struct of some kind.
-    if let ty::TyKind::Ref(_, ty, _) = ty.sty {
-        if let ty::TyKind::Adt(def, _) = ty.sty {
+    if let ty::Ref(_, ty, _) = ty.sty {
+        if let ty::Adt(def, _) = ty.sty {
             let field = def.all_fields().nth(field.index())?;
             // Use the HIR types to construct the diagnostic message.
             let hir_id = tcx.hir().as_local_hir_id(field.did)?;

--- a/src/librustc_mir/borrow_check/nll/explain_borrow/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/explain_borrow/mod.rs
@@ -589,7 +589,7 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
                                 // Check the type for a trait object.
                                 return match ty.sty {
                                     // `&dyn Trait`
-                                    ty::TyKind::Ref(_, ty, _) if ty.is_trait() => true,
+                                    ty::Ref(_, ty, _) if ty.is_trait() => true,
                                     // `Box<dyn Trait>`
                                     _ if ty.is_box() && ty.boxed_ty().is_trait() => true,
                                     // `dyn Trait`

--- a/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/mod.rs
@@ -583,7 +583,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             (self.to_error_region(fr), self.to_error_region(outlived_fr))
         {
             if let Some(ty::TyS {
-                sty: ty::TyKind::Opaque(did, substs),
+                sty: ty::Opaque(did, substs),
                 ..
             }) = infcx
                 .tcx

--- a/src/librustc_mir/borrow_check/nll/type_check/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/mod.rs
@@ -39,7 +39,7 @@ use rustc::traits::{ObligationCause, PredicateObligations};
 use rustc::ty::fold::TypeFoldable;
 use rustc::ty::subst::{Subst, SubstsRef, UnpackedKind, UserSubsts};
 use rustc::ty::{
-    self, RegionVid, ToPolyTraitRef, Ty, TyCtxt, TyKind, UserType,
+    self, RegionVid, ToPolyTraitRef, Ty, TyCtxt, UserType,
     CanonicalUserTypeAnnotation, CanonicalUserTypeAnnotations,
     UserTypeAnnotationIndex,
 };
@@ -746,7 +746,7 @@ impl<'a, 'b, 'gcx, 'tcx> TypeVerifier<'a, 'b, 'gcx, 'tcx> {
         let (variant, substs) = match base_ty {
             PlaceTy { ty, variant_index: Some(variant_index) } => {
                 match ty.sty {
-                    ty::TyKind::Adt(adt_def, substs) => (&adt_def.variants[variant_index], substs),
+                    ty::Adt(adt_def, substs) => (&adt_def.variants[variant_index], substs),
                     _ => bug!("can't have downcast of non-adt type"),
                 }
             }
@@ -1136,7 +1136,7 @@ impl<'a, 'gcx, 'tcx> TypeChecker<'a, 'gcx, 'tcx> {
         category: ConstraintCategory,
     ) -> Fallible<()> {
         if let Err(terr) = self.sub_types(sub, sup, locations, category) {
-            if let TyKind::Opaque(..) = sup.sty {
+            if let ty::Opaque(..) = sup.sty {
                 // When you have `let x: impl Foo = ...` in a closure,
                 // the resulting inferend values are stored with the
                 // def-id of the base function.
@@ -1389,7 +1389,7 @@ impl<'a, 'gcx, 'tcx> TypeChecker<'a, 'gcx, 'tcx> {
             } => {
                 let place_type = place.ty(mir, tcx).ty;
                 let adt = match place_type.sty {
-                    TyKind::Adt(adt, _) if adt.is_enum() => adt,
+                    ty::Adt(adt, _) if adt.is_enum() => adt,
                     _ => {
                         span_bug!(
                             stmt.source_info.span,

--- a/src/librustc_mir/dataflow/move_paths/builder.rs
+++ b/src/librustc_mir/dataflow/move_paths/builder.rs
@@ -425,7 +425,7 @@ impl<'b, 'a, 'gcx, 'tcx> Gatherer<'b, 'a, 'gcx, 'tcx> {
                 base,
                 elem: ProjectionElem::Field(_, _),
             }) if match base.ty(self.builder.mir, self.builder.tcx).ty.sty {
-                    ty::TyKind::Adt(def, _) if def.is_union() => true,
+                    ty::Adt(def, _) if def.is_union() => true,
                     _ => false,
             } => base,
             // Otherwise, lookup the place.

--- a/src/librustc_mir/hair/pattern/_match.rs
+++ b/src/librustc_mir/hair/pattern/_match.rs
@@ -1754,7 +1754,7 @@ fn specialize<'p, 'a: 'p, 'tcx: 'a>(
                     // they should be pointing to memory is when they are subslices of nonzero
                     // slices
                     let (opt_ptr, n, ty) = match value.ty.sty {
-                        ty::TyKind::Array(t, n) => {
+                        ty::Array(t, n) => {
                             match value.val {
                                 ConstValue::ByRef(ptr, alloc) => (
                                     Some((ptr, alloc)),
@@ -1767,7 +1767,7 @@ fn specialize<'p, 'a: 'p, 'tcx: 'a>(
                                 ),
                             }
                         },
-                        ty::TyKind::Slice(t) => {
+                        ty::Slice(t) => {
                             match value.val {
                                 ConstValue::Slice(ptr, n) => (
                                     ptr.to_ptr().ok().map(|ptr| (

--- a/src/librustc_mir/lib.rs
+++ b/src/librustc_mir/lib.rs
@@ -28,6 +28,7 @@ Rust MIR: a lowered representation of Rust. Also: an experiment!
 #![recursion_limit="256"]
 
 #![deny(rust_2018_idioms)]
+#![cfg_attr(not(stage0), deny(internal))]
 #![allow(explicit_outlives_requirements)]
 
 #[macro_use] extern crate log;

--- a/src/librustc_mir/lints.rs
+++ b/src/librustc_mir/lints.rs
@@ -4,7 +4,7 @@ use rustc::hir::intravisit::FnKind;
 use rustc::hir::map::blocks::FnLikeNode;
 use rustc::lint::builtin::UNCONDITIONAL_RECURSION;
 use rustc::mir::{self, Mir, TerminatorKind};
-use rustc::ty::{AssociatedItem, AssociatedItemContainer, Instance, TyCtxt, TyKind};
+use rustc::ty::{self, AssociatedItem, AssociatedItemContainer, Instance, TyCtxt};
 use rustc::ty::subst::InternalSubsts;
 
 pub fn check(tcx: TyCtxt<'a, 'tcx, 'tcx>,
@@ -86,7 +86,7 @@ fn check_fn_for_unconditional_recursion(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                 TerminatorKind::Call { ref func, .. } => {
                     let func_ty = func.ty(mir, tcx);
 
-                    if let TyKind::FnDef(fn_def_id, substs) = func_ty.sty {
+                    if let ty::FnDef(fn_def_id, substs) = func_ty.sty {
                         let (call_fn_id, call_substs) =
                             if let Some(instance) = Instance::resolve(tcx,
                                                                         param_env,

--- a/src/librustc_mir/transform/instcombine.rs
+++ b/src/librustc_mir/transform/instcombine.rs
@@ -2,7 +2,7 @@
 
 use rustc::mir::{Constant, Location, Place, PlaceBase, Mir, Operand, ProjectionElem, Rvalue, Local};
 use rustc::mir::visit::{MutVisitor, Visitor};
-use rustc::ty::{TyCtxt, TyKind};
+use rustc::ty::{self, TyCtxt};
 use rustc::util::nodemap::{FxHashMap, FxHashSet};
 use rustc_data_structures::indexed_vec::Idx;
 use std::mem;
@@ -90,7 +90,7 @@ impl<'b, 'a, 'tcx> Visitor<'tcx> for OptimizationFinder<'b, 'a, 'tcx> {
 
         if let Rvalue::Len(ref place) = *rvalue {
             let place_ty = place.ty(&self.mir.local_decls, self.tcx).ty;
-            if let TyKind::Array(_, len) = place_ty.sty {
+            if let ty::Array(_, len) = place_ty.sty {
                 let span = self.mir.source_info(location).span;
                 let ty = self.tcx.types.usize;
                 let constant = Constant { span, ty, literal: len, user_ty: None };

--- a/src/librustc_mir/transform/lower_128bit.rs
+++ b/src/librustc_mir/transform/lower_128bit.rs
@@ -3,7 +3,7 @@
 use rustc::hir::def_id::DefId;
 use rustc::middle::lang_items::LangItem;
 use rustc::mir::*;
-use rustc::ty::{List, Ty, TyCtxt, TyKind};
+use rustc::ty::{self, List, Ty, TyCtxt};
 use rustc_data_structures::indexed_vec::{Idx};
 use crate::transform::{MirPass, MirSource};
 
@@ -183,8 +183,8 @@ impl RhsKind {
 
 fn sign_of_128bit(ty: Ty<'_>) -> Option<bool> {
     match ty.sty {
-        TyKind::Int(syntax::ast::IntTy::I128) => Some(true),
-        TyKind::Uint(syntax::ast::UintTy::U128) => Some(false),
+        ty::Int(syntax::ast::IntTy::I128) => Some(true),
+        ty::Uint(syntax::ast::UintTy::U128) => Some(false),
         _ => None,
     }
 }

--- a/src/librustc_passes/lib.rs
+++ b/src/librustc_passes/lib.rs
@@ -12,6 +12,7 @@
 #![recursion_limit="256"]
 
 #![deny(rust_2018_idioms)]
+#![cfg_attr(not(stage0), deny(internal))]
 
 #[macro_use]
 extern crate rustc;

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -1,6 +1,7 @@
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
 
 #![deny(rust_2018_idioms)]
+#![cfg_attr(not(stage0), deny(internal))]
 
 #![feature(nll)]
 #![feature(rustc_diagnostic_macros)]

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -8,6 +8,7 @@
 #![recursion_limit="256"]
 
 #![deny(rust_2018_idioms)]
+#![cfg_attr(not(stage0), deny(internal))]
 
 pub use rustc::hir::def::{Namespace, PerNS};
 

--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -2,6 +2,7 @@
 #![feature(custom_attribute)]
 #![feature(nll)]
 #![deny(rust_2018_idioms)]
+#![cfg_attr(not(stage0), deny(internal))]
 #![allow(unused_attributes)]
 
 #![recursion_limit="256"]

--- a/src/librustc_target/lib.rs
+++ b/src/librustc_target/lib.rs
@@ -16,6 +16,7 @@
 #![feature(step_trait)]
 
 #![deny(rust_2018_idioms)]
+#![cfg_attr(not(stage0), deny(internal))]
 
 #[macro_use] extern crate log;
 

--- a/src/librustc_traits/lib.rs
+++ b/src/librustc_traits/lib.rs
@@ -2,6 +2,7 @@
 //! the guts are broken up into modules; see the comments in those modules.
 
 #![deny(rust_2018_idioms)]
+#![cfg_attr(not(stage0), deny(internal))]
 
 #![feature(crate_visibility_modifier)]
 #![feature(in_band_lifetimes)]

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -99,12 +99,6 @@ enum GenericArgPosition {
     MethodCall,
 }
 
-/// Dummy type used for the `Self` of a `TraitRef` created for converting
-/// a trait object, and which gets removed in `ExistentialTraitRef`.
-/// This type must not appear anywhere in other converted types.
-#[cfg_attr(not(stage0), allow(usage_of_ty_tykind))]
-const TRAIT_OBJECT_DUMMY_SELF: ty::TyKind<'static> = ty::Infer(ty::FreshTy(0));
-
 impl<'o, 'gcx: 'tcx, 'tcx> dyn AstConv<'gcx, 'tcx> + 'o {
     pub fn ast_region_to_region(&self,
         lifetime: &hir::Lifetime,
@@ -596,7 +590,9 @@ impl<'o, 'gcx: 'tcx, 'tcx> dyn AstConv<'gcx, 'tcx> + 'o {
             infer_types,
         );
 
-        let is_object = self_ty.map_or(false, |ty| ty.sty == TRAIT_OBJECT_DUMMY_SELF);
+        let is_object = self_ty.map_or(false, |ty| {
+            ty.sty == self.tcx().types.trait_object_dummy_self.sty
+        });
         let default_needs_object_self = |param: &ty::GenericParamDef| {
             if let GenericParamDefKind::Type { has_default, .. } = param.kind {
                 if is_object && has_default {
@@ -957,10 +953,10 @@ impl<'o, 'gcx: 'tcx, 'tcx> dyn AstConv<'gcx, 'tcx> + 'o {
     }
 
     /// Transform a `PolyTraitRef` into a `PolyExistentialTraitRef` by
-    /// removing the dummy `Self` type (`TRAIT_OBJECT_DUMMY_SELF`).
+    /// removing the dummy `Self` type (`trait_object_dummy_self`).
     fn trait_ref_to_existential(&self, trait_ref: ty::TraitRef<'tcx>)
                                 -> ty::ExistentialTraitRef<'tcx> {
-        if trait_ref.self_ty().sty != TRAIT_OBJECT_DUMMY_SELF {
+        if trait_ref.self_ty().sty != self.tcx().types.trait_object_dummy_self.sty {
             bug!("trait_ref_to_existential called on {:?} with non-dummy Self", trait_ref);
         }
         ty::ExistentialTraitRef::erase_self_ty(self.tcx(), trait_ref)
@@ -981,7 +977,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> dyn AstConv<'gcx, 'tcx> + 'o {
         }
 
         let mut projection_bounds = Vec::new();
-        let dummy_self = tcx.mk_ty(TRAIT_OBJECT_DUMMY_SELF);
+        let dummy_self = self.tcx().types.trait_object_dummy_self;
         let (principal, potential_assoc_types) = self.instantiate_poly_trait_ref(
             &trait_bounds[0],
             dummy_self,
@@ -1031,7 +1027,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> dyn AstConv<'gcx, 'tcx> + 'o {
                 }
                 ty::Predicate::Projection(pred) => {
                     // A `Self` within the original bound will be substituted with a
-                    // `TRAIT_OBJECT_DUMMY_SELF`, so check for that.
+                    // `trait_object_dummy_self`, so check for that.
                     let references_self =
                         pred.skip_binder().ty.walk().any(|t| t == dummy_self);
 
@@ -1131,7 +1127,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> dyn AstConv<'gcx, 'tcx> + 'o {
             err.emit();
         }
 
-        // Erase the `dummy_self` (`TRAIT_OBJECT_DUMMY_SELF`) used above.
+        // Erase the `dummy_self` (`trait_object_dummy_self`) used above.
         let existential_principal = principal.map_bound(|trait_ref| {
             self.trait_ref_to_existential(trait_ref)
         });

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -591,7 +591,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> dyn AstConv<'gcx, 'tcx> + 'o {
         );
 
         let is_object = self_ty.map_or(false, |ty| {
-            ty.sty == self.tcx().types.trait_object_dummy_self.sty
+            ty == self.tcx().types.trait_object_dummy_self
         });
         let default_needs_object_self = |param: &ty::GenericParamDef| {
             if let GenericParamDefKind::Type { has_default, .. } = param.kind {
@@ -956,7 +956,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> dyn AstConv<'gcx, 'tcx> + 'o {
     /// removing the dummy `Self` type (`trait_object_dummy_self`).
     fn trait_ref_to_existential(&self, trait_ref: ty::TraitRef<'tcx>)
                                 -> ty::ExistentialTraitRef<'tcx> {
-        if trait_ref.self_ty().sty != self.tcx().types.trait_object_dummy_self.sty {
+        if trait_ref.self_ty() != self.tcx().types.trait_object_dummy_self {
             bug!("trait_ref_to_existential called on {:?} with non-dummy Self", trait_ref);
         }
         ty::ExistentialTraitRef::erase_self_ty(self.tcx(), trait_ref)

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -102,6 +102,7 @@ enum GenericArgPosition {
 /// Dummy type used for the `Self` of a `TraitRef` created for converting
 /// a trait object, and which gets removed in `ExistentialTraitRef`.
 /// This type must not appear anywhere in other converted types.
+#[cfg_attr(not(stage0), allow(usage_of_ty_tykind))]
 const TRAIT_OBJECT_DUMMY_SELF: ty::TyKind<'static> = ty::Infer(ty::FreshTy(0));
 
 impl<'o, 'gcx: 'tcx, 'tcx> dyn AstConv<'gcx, 'tcx> + 'o {

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -3,7 +3,7 @@ use crate::constrained_generic_params::{identify_constrained_generic_params, Par
 
 use crate::hir::def_id::DefId;
 use rustc::traits::{self, ObligationCauseCode};
-use rustc::ty::{self, Lift, Ty, TyCtxt, TyKind, GenericParamDefKind, TypeFoldable, ToPredicate};
+use rustc::ty::{self, Lift, Ty, TyCtxt, GenericParamDefKind, TypeFoldable, ToPredicate};
 use rustc::ty::subst::{Subst, InternalSubsts};
 use rustc::util::nodemap::{FxHashSet, FxHashMap};
 use rustc::mir::interpret::ConstValue;
@@ -354,7 +354,7 @@ fn check_item_type<'a, 'tcx>(
 
         let mut forbid_unsized = true;
         if allow_foreign_ty {
-            if let TyKind::Foreign(_) = fcx.tcx.struct_tail(item_ty).sty {
+            if let ty::Foreign(_) = fcx.tcx.struct_tail(item_ty).sty {
                 forbid_unsized = false;
             }
         }

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -71,6 +71,7 @@ This API is completely unstable and subject to change.
 #![recursion_limit="256"]
 
 #![deny(rust_2018_idioms)]
+#![cfg_attr(not(stage0), deny(internal))]
 #![allow(explicit_outlives_requirements)]
 
 #[macro_use] extern crate log;

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -1,4 +1,5 @@
 #![deny(rust_2018_idioms)]
+#![cfg_attr(not(stage0), deny(internal))]
 
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/",
        html_playground_url = "https://play.rust-lang.org/")]

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -8,6 +8,7 @@
        test(attr(deny(warnings))))]
 
 #![deny(rust_2018_idioms)]
+#![cfg_attr(not(stage0), deny(internal))]
 
 #![feature(crate_visibility_modifier)]
 #![feature(label_break_value)]

--- a/src/libsyntax_ext/lib.rs
+++ b/src/libsyntax_ext/lib.rs
@@ -3,6 +3,7 @@
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
 
 #![deny(rust_2018_idioms)]
+#![cfg_attr(not(stage0), deny(internal))]
 
 #![feature(in_band_lifetimes)]
 #![feature(proc_macro_diagnostic)]

--- a/src/libsyntax_pos/lib.rs
+++ b/src/libsyntax_pos/lib.rs
@@ -7,6 +7,7 @@
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
 
 #![deny(rust_2018_idioms)]
+#![cfg_attr(not(stage0), deny(internal))]
 
 #![feature(const_fn)]
 #![feature(crate_visibility_modifier)]

--- a/src/test/ui-fulldeps/internal-lints/default_hash_types.rs
+++ b/src/test/ui-fulldeps/internal-lints/default_hash_types.rs
@@ -1,13 +1,3 @@
-// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
-// file at the top-level directory of this distribution and at
-// http://rust-lang.org/COPYRIGHT.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 // compile-flags: -Z internal-lints
 
 #![feature(rustc_private)]

--- a/src/test/ui-fulldeps/internal-lints/default_hash_types.rs
+++ b/src/test/ui-fulldeps/internal-lints/default_hash_types.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Z internal-lints
+// compile-flags: -Z unstable-options
 
 #![feature(rustc_private)]
 
@@ -6,8 +6,6 @@ extern crate rustc_data_structures;
 
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use std::collections::{HashMap, HashSet};
-//~^ WARNING Prefer FxHashMap over HashMap, it has better performance
-//~^^ WARNING Prefer FxHashSet over HashSet, it has better performance
 
 #[deny(default_hash_types)]
 fn main() {

--- a/src/test/ui-fulldeps/internal-lints/default_hash_types.rs
+++ b/src/test/ui-fulldeps/internal-lints/default_hash_types.rs
@@ -1,0 +1,34 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Z internal-lints
+
+#![feature(rustc_private)]
+
+extern crate rustc_data_structures;
+
+use rustc_data_structures::fx::{FxHashMap, FxHashSet};
+use std::collections::{HashMap, HashSet};
+//~^ WARNING Prefer FxHashMap over HashMap, it has better performance
+//~^^ WARNING Prefer FxHashSet over HashSet, it has better performance
+
+#[deny(default_hash_types)]
+fn main() {
+    let _map: HashMap<String, String> = HashMap::default();
+    //~^ ERROR Prefer FxHashMap over HashMap, it has better performance
+    //~^^ ERROR Prefer FxHashMap over HashMap, it has better performance
+    let _set: HashSet<String> = HashSet::default();
+    //~^ ERROR Prefer FxHashSet over HashSet, it has better performance
+    //~^^ ERROR Prefer FxHashSet over HashSet, it has better performance
+
+    // test that the lint doesn't also match the Fx variants themselves
+    let _fx_map: FxHashMap<String, String> = FxHashMap::default();
+    let _fx_set: FxHashSet<String> = FxHashSet::default();
+}

--- a/src/test/ui-fulldeps/internal-lints/default_hash_types.stderr
+++ b/src/test/ui-fulldeps/internal-lints/default_hash_types.stderr
@@ -1,35 +1,18 @@
-warning: Prefer FxHashMap over HashMap, it has better performance
-  --> $DIR/default_hash_types.rs:8:24
-   |
-LL | use std::collections::{HashMap, HashSet};
-   |                        ^^^^^^^ help: use: `FxHashMap`
-   |
-   = note: #[warn(default_hash_types)] on by default
-   = note: a `use rustc_data_structures::fx::FxHashMap` may be necessary
-
-warning: Prefer FxHashSet over HashSet, it has better performance
-  --> $DIR/default_hash_types.rs:8:33
-   |
-LL | use std::collections::{HashMap, HashSet};
-   |                                 ^^^^^^^ help: use: `FxHashSet`
-   |
-   = note: a `use rustc_data_structures::fx::FxHashSet` may be necessary
-
 error: Prefer FxHashMap over HashMap, it has better performance
-  --> $DIR/default_hash_types.rs:14:15
+  --> $DIR/default_hash_types.rs:12:15
    |
 LL |     let _map: HashMap<String, String> = HashMap::default();
    |               ^^^^^^^ help: use: `FxHashMap`
    |
 note: lint level defined here
-  --> $DIR/default_hash_types.rs:12:8
+  --> $DIR/default_hash_types.rs:10:8
    |
 LL | #[deny(default_hash_types)]
    |        ^^^^^^^^^^^^^^^^^^
    = note: a `use rustc_data_structures::fx::FxHashMap` may be necessary
 
 error: Prefer FxHashMap over HashMap, it has better performance
-  --> $DIR/default_hash_types.rs:14:41
+  --> $DIR/default_hash_types.rs:12:41
    |
 LL |     let _map: HashMap<String, String> = HashMap::default();
    |                                         ^^^^^^^ help: use: `FxHashMap`
@@ -37,7 +20,7 @@ LL |     let _map: HashMap<String, String> = HashMap::default();
    = note: a `use rustc_data_structures::fx::FxHashMap` may be necessary
 
 error: Prefer FxHashSet over HashSet, it has better performance
-  --> $DIR/default_hash_types.rs:17:15
+  --> $DIR/default_hash_types.rs:15:15
    |
 LL |     let _set: HashSet<String> = HashSet::default();
    |               ^^^^^^^ help: use: `FxHashSet`
@@ -45,7 +28,7 @@ LL |     let _set: HashSet<String> = HashSet::default();
    = note: a `use rustc_data_structures::fx::FxHashSet` may be necessary
 
 error: Prefer FxHashSet over HashSet, it has better performance
-  --> $DIR/default_hash_types.rs:17:33
+  --> $DIR/default_hash_types.rs:15:33
    |
 LL |     let _set: HashSet<String> = HashSet::default();
    |                                 ^^^^^^^ help: use: `FxHashSet`

--- a/src/test/ui-fulldeps/internal-lints/default_hash_types.stderr
+++ b/src/test/ui-fulldeps/internal-lints/default_hash_types.stderr
@@ -1,5 +1,5 @@
 warning: Prefer FxHashMap over HashMap, it has better performance
-  --> $DIR/default_hash_types.rs:18:24
+  --> $DIR/default_hash_types.rs:8:24
    |
 LL | use std::collections::{HashMap, HashSet};
    |                        ^^^^^^^ help: use: `FxHashMap`
@@ -8,7 +8,7 @@ LL | use std::collections::{HashMap, HashSet};
    = note: a `use rustc_data_structures::fx::FxHashMap` may be necessary
 
 warning: Prefer FxHashSet over HashSet, it has better performance
-  --> $DIR/default_hash_types.rs:18:33
+  --> $DIR/default_hash_types.rs:8:33
    |
 LL | use std::collections::{HashMap, HashSet};
    |                                 ^^^^^^^ help: use: `FxHashSet`
@@ -16,20 +16,20 @@ LL | use std::collections::{HashMap, HashSet};
    = note: a `use rustc_data_structures::fx::FxHashSet` may be necessary
 
 error: Prefer FxHashMap over HashMap, it has better performance
-  --> $DIR/default_hash_types.rs:24:15
+  --> $DIR/default_hash_types.rs:14:15
    |
 LL |     let _map: HashMap<String, String> = HashMap::default();
    |               ^^^^^^^ help: use: `FxHashMap`
    |
 note: lint level defined here
-  --> $DIR/default_hash_types.rs:22:8
+  --> $DIR/default_hash_types.rs:12:8
    |
 LL | #[deny(default_hash_types)]
    |        ^^^^^^^^^^^^^^^^^^
    = note: a `use rustc_data_structures::fx::FxHashMap` may be necessary
 
 error: Prefer FxHashMap over HashMap, it has better performance
-  --> $DIR/default_hash_types.rs:24:41
+  --> $DIR/default_hash_types.rs:14:41
    |
 LL |     let _map: HashMap<String, String> = HashMap::default();
    |                                         ^^^^^^^ help: use: `FxHashMap`
@@ -37,7 +37,7 @@ LL |     let _map: HashMap<String, String> = HashMap::default();
    = note: a `use rustc_data_structures::fx::FxHashMap` may be necessary
 
 error: Prefer FxHashSet over HashSet, it has better performance
-  --> $DIR/default_hash_types.rs:27:15
+  --> $DIR/default_hash_types.rs:17:15
    |
 LL |     let _set: HashSet<String> = HashSet::default();
    |               ^^^^^^^ help: use: `FxHashSet`
@@ -45,7 +45,7 @@ LL |     let _set: HashSet<String> = HashSet::default();
    = note: a `use rustc_data_structures::fx::FxHashSet` may be necessary
 
 error: Prefer FxHashSet over HashSet, it has better performance
-  --> $DIR/default_hash_types.rs:27:33
+  --> $DIR/default_hash_types.rs:17:33
    |
 LL |     let _set: HashSet<String> = HashSet::default();
    |                                 ^^^^^^^ help: use: `FxHashSet`

--- a/src/test/ui-fulldeps/internal-lints/default_hash_types.stderr
+++ b/src/test/ui-fulldeps/internal-lints/default_hash_types.stderr
@@ -1,0 +1,56 @@
+warning: Prefer FxHashMap over HashMap, it has better performance
+  --> $DIR/default_hash_types.rs:18:24
+   |
+LL | use std::collections::{HashMap, HashSet};
+   |                        ^^^^^^^ help: use: `FxHashMap`
+   |
+   = note: #[warn(default_hash_types)] on by default
+   = note: a `use rustc_data_structures::fx::FxHashMap` may be necessary
+
+warning: Prefer FxHashSet over HashSet, it has better performance
+  --> $DIR/default_hash_types.rs:18:33
+   |
+LL | use std::collections::{HashMap, HashSet};
+   |                                 ^^^^^^^ help: use: `FxHashSet`
+   |
+   = note: a `use rustc_data_structures::fx::FxHashSet` may be necessary
+
+error: Prefer FxHashMap over HashMap, it has better performance
+  --> $DIR/default_hash_types.rs:24:15
+   |
+LL |     let _map: HashMap<String, String> = HashMap::default();
+   |               ^^^^^^^ help: use: `FxHashMap`
+   |
+note: lint level defined here
+  --> $DIR/default_hash_types.rs:22:8
+   |
+LL | #[deny(default_hash_types)]
+   |        ^^^^^^^^^^^^^^^^^^
+   = note: a `use rustc_data_structures::fx::FxHashMap` may be necessary
+
+error: Prefer FxHashMap over HashMap, it has better performance
+  --> $DIR/default_hash_types.rs:24:41
+   |
+LL |     let _map: HashMap<String, String> = HashMap::default();
+   |                                         ^^^^^^^ help: use: `FxHashMap`
+   |
+   = note: a `use rustc_data_structures::fx::FxHashMap` may be necessary
+
+error: Prefer FxHashSet over HashSet, it has better performance
+  --> $DIR/default_hash_types.rs:27:15
+   |
+LL |     let _set: HashSet<String> = HashSet::default();
+   |               ^^^^^^^ help: use: `FxHashSet`
+   |
+   = note: a `use rustc_data_structures::fx::FxHashSet` may be necessary
+
+error: Prefer FxHashSet over HashSet, it has better performance
+  --> $DIR/default_hash_types.rs:27:33
+   |
+LL |     let _set: HashSet<String> = HashSet::default();
+   |                                 ^^^^^^^ help: use: `FxHashSet`
+   |
+   = note: a `use rustc_data_structures::fx::FxHashSet` may be necessary
+
+error: aborting due to 4 previous errors
+

--- a/src/test/ui-fulldeps/internal-lints/ty_tykind_usage.rs
+++ b/src/test/ui-fulldeps/internal-lints/ty_tykind_usage.rs
@@ -1,13 +1,3 @@
-// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
-// file at the top-level directory of this distribution and at
-// http://rust-lang.org/COPYRIGHT.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 // compile-flags: -Z internal-lints
 
 #![feature(rustc_private)]

--- a/src/test/ui-fulldeps/internal-lints/ty_tykind_usage.rs
+++ b/src/test/ui-fulldeps/internal-lints/ty_tykind_usage.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Z internal-lints
+// compile-flags: -Z unstable-options
 
 #![feature(rustc_private)]
 

--- a/src/test/ui-fulldeps/internal-lints/ty_tykind_usage.rs
+++ b/src/test/ui-fulldeps/internal-lints/ty_tykind_usage.rs
@@ -1,0 +1,59 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Z internal-lints
+
+#![feature(rustc_private)]
+
+extern crate rustc;
+
+use rustc::ty::{self, Ty, TyKind};
+
+#[deny(usage_of_ty_tykind)]
+fn main() {
+    let sty = TyKind::Bool; //~ ERROR usage of `ty::TyKind::<kind>`
+
+    match sty {
+        TyKind::Bool => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::Char => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::Int(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::Uint(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::Float(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::Adt(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::Foreign(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::Str => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::Array(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::Slice(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::RawPtr(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::Ref(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::FnDef(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::FnPtr(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::Dynamic(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::Closure(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::Generator(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::GeneratorWitness(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::Never => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::Tuple(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::Projection(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::UnnormalizedProjection(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::Opaque(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::Param(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::Bound(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::Placeholder(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::Infer(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+        TyKind::Error => (), //~ ERROR usage of `ty::TyKind::<kind>`
+    }
+
+    if let ty::Int(int_ty) = sty {}
+
+    if let TyKind::Int(int_ty) = sty {} //~ ERROR usage of `ty::TyKind::<kind>`
+
+    fn ty_kind(ty_bad: TyKind<'_>, ty_good: Ty<'_>) {} //~ ERROR usage of `ty::TyKind`
+}

--- a/src/test/ui-fulldeps/internal-lints/ty_tykind_usage.stderr
+++ b/src/test/ui-fulldeps/internal-lints/ty_tykind_usage.stderr
@@ -1,7 +1,7 @@
 error: usage of `ty::TyKind::<kind>`
   --> $DIR/ty_tykind_usage.rs:11:15
    |
-LL |     let sty = TyKind::Bool; //~ ERROR usage of `ty::TyKind::<kind>`
+LL |     let sty = TyKind::Bool;
    |               ^^^^^^ help: try using ty::<kind> directly: `ty`
    |
 note: lint level defined here
@@ -13,181 +13,181 @@ LL | #[deny(usage_of_ty_tykind)]
 error: usage of `ty::TyKind::<kind>`
   --> $DIR/ty_tykind_usage.rs:14:9
    |
-LL |         TyKind::Bool => (), //~ ERROR usage of `ty::TyKind::<kind>`
+LL |         TyKind::Bool => (),
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
   --> $DIR/ty_tykind_usage.rs:15:9
    |
-LL |         TyKind::Char => (), //~ ERROR usage of `ty::TyKind::<kind>`
+LL |         TyKind::Char => (),
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
   --> $DIR/ty_tykind_usage.rs:16:9
    |
-LL |         TyKind::Int(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+LL |         TyKind::Int(..) => (),
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
   --> $DIR/ty_tykind_usage.rs:17:9
    |
-LL |         TyKind::Uint(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+LL |         TyKind::Uint(..) => (),
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
   --> $DIR/ty_tykind_usage.rs:18:9
    |
-LL |         TyKind::Float(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+LL |         TyKind::Float(..) => (),
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
   --> $DIR/ty_tykind_usage.rs:19:9
    |
-LL |         TyKind::Adt(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+LL |         TyKind::Adt(..) => (),
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
   --> $DIR/ty_tykind_usage.rs:20:9
    |
-LL |         TyKind::Foreign(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+LL |         TyKind::Foreign(..) => (),
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
   --> $DIR/ty_tykind_usage.rs:21:9
    |
-LL |         TyKind::Str => (), //~ ERROR usage of `ty::TyKind::<kind>`
+LL |         TyKind::Str => (),
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
   --> $DIR/ty_tykind_usage.rs:22:9
    |
-LL |         TyKind::Array(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+LL |         TyKind::Array(..) => (),
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
   --> $DIR/ty_tykind_usage.rs:23:9
    |
-LL |         TyKind::Slice(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+LL |         TyKind::Slice(..) => (),
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
   --> $DIR/ty_tykind_usage.rs:24:9
    |
-LL |         TyKind::RawPtr(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+LL |         TyKind::RawPtr(..) => (),
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
   --> $DIR/ty_tykind_usage.rs:25:9
    |
-LL |         TyKind::Ref(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+LL |         TyKind::Ref(..) => (),
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
   --> $DIR/ty_tykind_usage.rs:26:9
    |
-LL |         TyKind::FnDef(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+LL |         TyKind::FnDef(..) => (),
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
   --> $DIR/ty_tykind_usage.rs:27:9
    |
-LL |         TyKind::FnPtr(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+LL |         TyKind::FnPtr(..) => (),
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
   --> $DIR/ty_tykind_usage.rs:28:9
    |
-LL |         TyKind::Dynamic(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+LL |         TyKind::Dynamic(..) => (),
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
   --> $DIR/ty_tykind_usage.rs:29:9
    |
-LL |         TyKind::Closure(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+LL |         TyKind::Closure(..) => (),
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
   --> $DIR/ty_tykind_usage.rs:30:9
    |
-LL |         TyKind::Generator(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+LL |         TyKind::Generator(..) => (),
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
   --> $DIR/ty_tykind_usage.rs:31:9
    |
-LL |         TyKind::GeneratorWitness(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+LL |         TyKind::GeneratorWitness(..) => (),
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
   --> $DIR/ty_tykind_usage.rs:32:9
    |
-LL |         TyKind::Never => (), //~ ERROR usage of `ty::TyKind::<kind>`
+LL |         TyKind::Never => (),
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
   --> $DIR/ty_tykind_usage.rs:33:9
    |
-LL |         TyKind::Tuple(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+LL |         TyKind::Tuple(..) => (),
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
   --> $DIR/ty_tykind_usage.rs:34:9
    |
-LL |         TyKind::Projection(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+LL |         TyKind::Projection(..) => (),
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
   --> $DIR/ty_tykind_usage.rs:35:9
    |
-LL |         TyKind::UnnormalizedProjection(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+LL |         TyKind::UnnormalizedProjection(..) => (),
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
   --> $DIR/ty_tykind_usage.rs:36:9
    |
-LL |         TyKind::Opaque(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+LL |         TyKind::Opaque(..) => (),
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
   --> $DIR/ty_tykind_usage.rs:37:9
    |
-LL |         TyKind::Param(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+LL |         TyKind::Param(..) => (),
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
   --> $DIR/ty_tykind_usage.rs:38:9
    |
-LL |         TyKind::Bound(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+LL |         TyKind::Bound(..) => (),
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
   --> $DIR/ty_tykind_usage.rs:39:9
    |
-LL |         TyKind::Placeholder(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+LL |         TyKind::Placeholder(..) => (),
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
   --> $DIR/ty_tykind_usage.rs:40:9
    |
-LL |         TyKind::Infer(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+LL |         TyKind::Infer(..) => (),
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
   --> $DIR/ty_tykind_usage.rs:41:9
    |
-LL |         TyKind::Error => (), //~ ERROR usage of `ty::TyKind::<kind>`
+LL |         TyKind::Error => (),
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
   --> $DIR/ty_tykind_usage.rs:46:12
    |
-LL |     if let TyKind::Int(int_ty) = sty {} //~ ERROR usage of `ty::TyKind::<kind>`
+LL |     if let TyKind::Int(int_ty) = sty {}
    |            ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind`
   --> $DIR/ty_tykind_usage.rs:48:24
    |
-LL |     fn ty_kind(ty_bad: TyKind<'_>, ty_good: Ty<'_>) {} //~ ERROR usage of `ty::TyKind`
+LL |     fn ty_kind(ty_bad: TyKind<'_>, ty_good: Ty<'_>) {}
    |                        ^^^^^^^^^^
    |
    = help: try using `ty::Ty` instead

--- a/src/test/ui-fulldeps/internal-lints/ty_tykind_usage.stderr
+++ b/src/test/ui-fulldeps/internal-lints/ty_tykind_usage.stderr
@@ -1,191 +1,191 @@
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:21:15
+  --> $DIR/ty_tykind_usage.rs:11:15
    |
 LL |     let sty = TyKind::Bool; //~ ERROR usage of `ty::TyKind::<kind>`
    |               ^^^^^^ help: try using ty::<kind> directly: `ty`
    |
 note: lint level defined here
-  --> $DIR/ty_tykind_usage.rs:19:8
+  --> $DIR/ty_tykind_usage.rs:9:8
    |
 LL | #[deny(usage_of_ty_tykind)]
    |        ^^^^^^^^^^^^^^^^^^
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:24:9
+  --> $DIR/ty_tykind_usage.rs:14:9
    |
 LL |         TyKind::Bool => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:25:9
+  --> $DIR/ty_tykind_usage.rs:15:9
    |
 LL |         TyKind::Char => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:26:9
+  --> $DIR/ty_tykind_usage.rs:16:9
    |
 LL |         TyKind::Int(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:27:9
+  --> $DIR/ty_tykind_usage.rs:17:9
    |
 LL |         TyKind::Uint(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:28:9
+  --> $DIR/ty_tykind_usage.rs:18:9
    |
 LL |         TyKind::Float(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:29:9
+  --> $DIR/ty_tykind_usage.rs:19:9
    |
 LL |         TyKind::Adt(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:30:9
+  --> $DIR/ty_tykind_usage.rs:20:9
    |
 LL |         TyKind::Foreign(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:31:9
+  --> $DIR/ty_tykind_usage.rs:21:9
    |
 LL |         TyKind::Str => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:32:9
+  --> $DIR/ty_tykind_usage.rs:22:9
    |
 LL |         TyKind::Array(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:33:9
+  --> $DIR/ty_tykind_usage.rs:23:9
    |
 LL |         TyKind::Slice(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:34:9
+  --> $DIR/ty_tykind_usage.rs:24:9
    |
 LL |         TyKind::RawPtr(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:35:9
+  --> $DIR/ty_tykind_usage.rs:25:9
    |
 LL |         TyKind::Ref(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:36:9
+  --> $DIR/ty_tykind_usage.rs:26:9
    |
 LL |         TyKind::FnDef(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:37:9
+  --> $DIR/ty_tykind_usage.rs:27:9
    |
 LL |         TyKind::FnPtr(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:38:9
+  --> $DIR/ty_tykind_usage.rs:28:9
    |
 LL |         TyKind::Dynamic(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:39:9
+  --> $DIR/ty_tykind_usage.rs:29:9
    |
 LL |         TyKind::Closure(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:40:9
+  --> $DIR/ty_tykind_usage.rs:30:9
    |
 LL |         TyKind::Generator(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:41:9
+  --> $DIR/ty_tykind_usage.rs:31:9
    |
 LL |         TyKind::GeneratorWitness(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:42:9
+  --> $DIR/ty_tykind_usage.rs:32:9
    |
 LL |         TyKind::Never => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:43:9
+  --> $DIR/ty_tykind_usage.rs:33:9
    |
 LL |         TyKind::Tuple(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:44:9
+  --> $DIR/ty_tykind_usage.rs:34:9
    |
 LL |         TyKind::Projection(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:45:9
+  --> $DIR/ty_tykind_usage.rs:35:9
    |
 LL |         TyKind::UnnormalizedProjection(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:46:9
+  --> $DIR/ty_tykind_usage.rs:36:9
    |
 LL |         TyKind::Opaque(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:47:9
+  --> $DIR/ty_tykind_usage.rs:37:9
    |
 LL |         TyKind::Param(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:48:9
+  --> $DIR/ty_tykind_usage.rs:38:9
    |
 LL |         TyKind::Bound(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:49:9
+  --> $DIR/ty_tykind_usage.rs:39:9
    |
 LL |         TyKind::Placeholder(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:50:9
+  --> $DIR/ty_tykind_usage.rs:40:9
    |
 LL |         TyKind::Infer(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:51:9
+  --> $DIR/ty_tykind_usage.rs:41:9
    |
 LL |         TyKind::Error => (), //~ ERROR usage of `ty::TyKind::<kind>`
    |         ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind::<kind>`
-  --> $DIR/ty_tykind_usage.rs:56:12
+  --> $DIR/ty_tykind_usage.rs:46:12
    |
 LL |     if let TyKind::Int(int_ty) = sty {} //~ ERROR usage of `ty::TyKind::<kind>`
    |            ^^^^^^ help: try using ty::<kind> directly: `ty`
 
 error: usage of `ty::TyKind`
-  --> $DIR/ty_tykind_usage.rs:58:24
+  --> $DIR/ty_tykind_usage.rs:48:24
    |
 LL |     fn ty_kind(ty_bad: TyKind<'_>, ty_good: Ty<'_>) {} //~ ERROR usage of `ty::TyKind`
    |                        ^^^^^^^^^^

--- a/src/test/ui-fulldeps/internal-lints/ty_tykind_usage.stderr
+++ b/src/test/ui-fulldeps/internal-lints/ty_tykind_usage.stderr
@@ -1,0 +1,196 @@
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:21:15
+   |
+LL |     let sty = TyKind::Bool; //~ ERROR usage of `ty::TyKind::<kind>`
+   |               ^^^^^^ help: try using ty::<kind> directly: `ty`
+   |
+note: lint level defined here
+  --> $DIR/ty_tykind_usage.rs:19:8
+   |
+LL | #[deny(usage_of_ty_tykind)]
+   |        ^^^^^^^^^^^^^^^^^^
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:24:9
+   |
+LL |         TyKind::Bool => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:25:9
+   |
+LL |         TyKind::Char => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:26:9
+   |
+LL |         TyKind::Int(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:27:9
+   |
+LL |         TyKind::Uint(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:28:9
+   |
+LL |         TyKind::Float(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:29:9
+   |
+LL |         TyKind::Adt(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:30:9
+   |
+LL |         TyKind::Foreign(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:31:9
+   |
+LL |         TyKind::Str => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:32:9
+   |
+LL |         TyKind::Array(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:33:9
+   |
+LL |         TyKind::Slice(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:34:9
+   |
+LL |         TyKind::RawPtr(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:35:9
+   |
+LL |         TyKind::Ref(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:36:9
+   |
+LL |         TyKind::FnDef(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:37:9
+   |
+LL |         TyKind::FnPtr(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:38:9
+   |
+LL |         TyKind::Dynamic(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:39:9
+   |
+LL |         TyKind::Closure(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:40:9
+   |
+LL |         TyKind::Generator(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:41:9
+   |
+LL |         TyKind::GeneratorWitness(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:42:9
+   |
+LL |         TyKind::Never => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:43:9
+   |
+LL |         TyKind::Tuple(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:44:9
+   |
+LL |         TyKind::Projection(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:45:9
+   |
+LL |         TyKind::UnnormalizedProjection(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:46:9
+   |
+LL |         TyKind::Opaque(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:47:9
+   |
+LL |         TyKind::Param(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:48:9
+   |
+LL |         TyKind::Bound(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:49:9
+   |
+LL |         TyKind::Placeholder(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:50:9
+   |
+LL |         TyKind::Infer(..) => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:51:9
+   |
+LL |         TyKind::Error => (), //~ ERROR usage of `ty::TyKind::<kind>`
+   |         ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind::<kind>`
+  --> $DIR/ty_tykind_usage.rs:56:12
+   |
+LL |     if let TyKind::Int(int_ty) = sty {} //~ ERROR usage of `ty::TyKind::<kind>`
+   |            ^^^^^^ help: try using ty::<kind> directly: `ty`
+
+error: usage of `ty::TyKind`
+  --> $DIR/ty_tykind_usage.rs:58:24
+   |
+LL |     fn ty_kind(ty_bad: TyKind<'_>, ty_good: Ty<'_>) {} //~ ERROR usage of `ty::TyKind`
+   |                        ^^^^^^^^^^
+   |
+   = help: try using `ty::Ty` instead
+
+error: aborting due to 31 previous errors
+


### PR DESCRIPTION
cc #58701 
cc #49509

TODO: Add `#![warn(internal)]` to crates (and fix violations)

Crates depending on `rustc_data_structures`

- [x] librustc_resolve
- [x] librustc_driver
- [x] librustc_passes
- [x] librustc_metadata
- [x] librustc_interface
- [x] librustc_save_analysis
- [x] librustc_lint
- [x] librustc
- [x] librustc_incremental
- [x] librustc_codegen_utils
- [x] libarena
- [x] librustc_target
- [x] librustc_allocator
- [x] librustc_privacy
- [x] librustc_traits
- [x] librustc_borrowck
- [x] libsyntax
- [x] librustc_codegen_ssa
- [x] libsyntax_ext
- [x] librustc_errors
- [x] librustc_mir
- [x] libsyntax_pos
- [x] librustc_typeck

Crates with `feature(rustc_private)`
Excluding crates, which are already in the list above. Also excluding tools and tests.

- [ ] ~~libstd~~
- [x] libfmt_macros
- [x] librustdoc

r? @oli-obk 