### PR TITLE
rustc: Update linker flavor inference from filename

### DIFF
--- a/src/librustc_codegen_ssa/back/link.rs
+++ b/src/librustc_codegen_ssa/back/link.rs
@@ -152,17 +152,20 @@ pub fn linker_and_flavor(sess: &Session) -> (PathBuf, LinkerFlavor) {
                 LinkerFlavor::PtxLinker => "rust-ptx-linker",
             }), flavor)),
             (Some(linker), None) => {
-                let stem = if linker.extension().and_then(|ext| ext.to_str()) == Some("exe") {
-                    linker.file_stem().and_then(|stem| stem.to_str())
-                } else {
-                    linker.to_str()
-                }.unwrap_or_else(|| {
-                    sess.fatal("couldn't extract file stem from specified linker");
-                }).to_owned();
+                let stem = linker
+                    .file_stem()
+                    .and_then(|stem| stem.to_str())
+                    .unwrap_or_else(|| {
+                        sess.fatal("couldn't extract file stem from specified linker")
+                    });
 
                 let flavor = if stem == "emcc" {
                     LinkerFlavor::Em
-                } else if stem == "gcc" || stem.ends_with("-gcc") {
+                } else if stem == "gcc"
+                    || stem.ends_with("-gcc")
+                    || stem == "clang"
+                    || stem.ends_with("-clang")
+                {
                     LinkerFlavor::Gcc
                 } else if stem == "ld" || stem == "ld.lld" || stem.ends_with("-ld") {
                     LinkerFlavor::Ld


### PR DESCRIPTION
This commit fixes what is believed to be a preexisting bug in the linker
flavor inference and additionally adds a new features. Previously if the
linker didn't end in `exe` the entire file name was compared to infer
the linker's flavor. This commit fixes the code to instead
unconditionally inspect `file_stem()` which is the relevant part we're
looking at to figure out what the linker flavor is.

Additionally this commit now also adds recognition of `clang` and clang
wrappers that end in `-clang` (which look like gcc wrappers). This
should allow clang-specific wrappers to get correctly inferred to the
`Gcc` linker flavor rather than the default linker flavor configured for
a target.