### PR TITLE
Unify E0109, E0110 and E0111

### DIFF
--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -1290,45 +1290,34 @@ fn main() {
 "##,
 
 E0109: r##"
-You tried to give a type parameter to a type which doesn't need it. Erroneous
-code example:
+You tried to provide a generic argument to a type which doesn't need it.
+Erroneous code example:
 
 ```compile_fail,E0109
-type X = u32<i32>; // error: type arguments are not allowed on this entity
+type X = u32<i32>; // error: type arguments are not allowed for this type
+type Y = bool<'static>; // error: lifetime parameters are not allowed on
+                        //        this type
 ```
 
-Please check that you used the correct type and recheck its definition. Perhaps
-it doesn't need the type parameter.
+Check that you used the correct argument and that the definition is correct.
 
 Example:
 
 ```
-type X = u32; // this compiles
+type X = u32; // ok!
+type Y = bool; // ok!
 ```
 
-Note that type parameters for enum-variant constructors go after the variant,
-not after the enum (`Option::None::<u32>`, not `Option::<u32>::None`).
+Note that generic arguments for enum variant constructors go after the variant,
+not after the enum. For example, you would write `Option::None::<u32>`,
+rather than `Option::<u32>::None`.
 "##,
 
 E0110: r##"
-You tried to give a lifetime parameter to a type which doesn't need it.
-Erroneous code example:
+#### Note: this error code is no longer emitted by the compiler.
 
-```compile_fail,E0110
-type X = u32<'static>; // error: lifetime parameters are not allowed on
-                       //        this type
-```
-
-Please check that the correct type was used and recheck its definition; perhaps
-it doesn't need the lifetime parameter. Example:
-
-```
-type X = u32; // ok!
-```
-"##,
-
-E0111: r##"
-You tried to give a const parameter to a type which doesn't need it.
+You tried to provide a lifetime to a type which doesn't need it.
+See `E0109` for more details.
 "##,
 
 E0116: r##"

--- a/src/test/ui/enum-variant-generic-args.rs
+++ b/src/test/ui/enum-variant-generic-args.rs
@@ -9,27 +9,27 @@ impl<T> Enum<T> {
         Self::TSVariant(());
         //~^ ERROR mismatched types [E0308]
         Self::TSVariant::<()>(());
-        //~^ ERROR type arguments are not allowed on this entity [E0109]
+        //~^ ERROR type arguments are not allowed for this type [E0109]
         Self::<()>::TSVariant(());
-        //~^ ERROR type arguments are not allowed on this entity [E0109]
+        //~^ ERROR type arguments are not allowed for this type [E0109]
         //~^^ ERROR mismatched types [E0308]
         Self::<()>::TSVariant::<()>(());
-        //~^ ERROR type arguments are not allowed on this entity [E0109]
-        //~^^ ERROR type arguments are not allowed on this entity [E0109]
+        //~^ ERROR type arguments are not allowed for this type [E0109]
+        //~^^ ERROR type arguments are not allowed for this type [E0109]
     }
 
     fn s_variant() {
         Self::SVariant { v: () };
         //~^ ERROR mismatched types [E0308]
         Self::SVariant::<()> { v: () };
-        //~^ ERROR type arguments are not allowed on this entity [E0109]
+        //~^ ERROR type arguments are not allowed for this type [E0109]
         //~^^ ERROR mismatched types [E0308]
         Self::<()>::SVariant { v: () };
-        //~^ ERROR type arguments are not allowed on this entity [E0109]
+        //~^ ERROR type arguments are not allowed for this type [E0109]
         //~^^ ERROR mismatched types [E0308]
         Self::<()>::SVariant::<()> { v: () };
-        //~^ ERROR type arguments are not allowed on this entity [E0109]
-        //~^^ ERROR type arguments are not allowed on this entity [E0109]
+        //~^ ERROR type arguments are not allowed for this type [E0109]
+        //~^^ ERROR type arguments are not allowed for this type [E0109]
         //~^^^ ERROR mismatched types [E0308]
     }
 }
@@ -38,36 +38,36 @@ fn main() {
     // Tuple struct variant
 
     Enum::<()>::TSVariant::<()>(());
-    //~^ ERROR type arguments are not allowed on this entity [E0109]
+    //~^ ERROR type arguments are not allowed for this type [E0109]
 
     Alias::TSVariant::<()>(());
-    //~^ ERROR type arguments are not allowed on this entity [E0109]
+    //~^ ERROR type arguments are not allowed for this type [E0109]
     Alias::<()>::TSVariant::<()>(());
-    //~^ ERROR type arguments are not allowed on this entity [E0109]
+    //~^ ERROR type arguments are not allowed for this type [E0109]
 
     AliasFixed::TSVariant::<()>(());
-    //~^ ERROR type arguments are not allowed on this entity [E0109]
+    //~^ ERROR type arguments are not allowed for this type [E0109]
     AliasFixed::<()>::TSVariant(());
     //~^ ERROR wrong number of type arguments: expected 0, found 1 [E0107]
     AliasFixed::<()>::TSVariant::<()>(());
-    //~^ ERROR type arguments are not allowed on this entity [E0109]
+    //~^ ERROR type arguments are not allowed for this type [E0109]
     //~^^ ERROR wrong number of type arguments: expected 0, found 1 [E0107]
 
     // Struct variant
 
     Enum::<()>::SVariant::<()> { v: () };
-    //~^ ERROR type arguments are not allowed on this entity [E0109]
+    //~^ ERROR type arguments are not allowed for this type [E0109]
 
     Alias::SVariant::<()> { v: () };
-    //~^ ERROR type arguments are not allowed on this entity [E0109]
+    //~^ ERROR type arguments are not allowed for this type [E0109]
     Alias::<()>::SVariant::<()> { v: () };
-    //~^ ERROR type arguments are not allowed on this entity [E0109]
+    //~^ ERROR type arguments are not allowed for this type [E0109]
 
     AliasFixed::SVariant::<()> { v: () };
-    //~^ ERROR type arguments are not allowed on this entity [E0109]
+    //~^ ERROR type arguments are not allowed for this type [E0109]
     AliasFixed::<()>::SVariant { v: () };
     //~^ ERROR wrong number of type arguments: expected 0, found 1 [E0107]
     AliasFixed::<()>::SVariant::<()> { v: () };
-    //~^ ERROR type arguments are not allowed on this entity [E0109]
+    //~^ ERROR type arguments are not allowed for this type [E0109]
     //~^^ ERROR wrong number of type arguments: expected 0, found 1 [E0107]
 }

--- a/src/test/ui/enum-variant-generic-args.stderr
+++ b/src/test/ui/enum-variant-generic-args.stderr
@@ -7,13 +7,13 @@ LL |         Self::TSVariant(());
    = note: expected type `T`
               found type `()`
 
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/enum-variant-generic-args.rs:11:27
    |
 LL |         Self::TSVariant::<()>(());
    |                           ^^ type argument not allowed
 
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/enum-variant-generic-args.rs:13:16
    |
 LL |         Self::<()>::TSVariant(());
@@ -28,13 +28,13 @@ LL |         Self::<()>::TSVariant(());
    = note: expected type `T`
               found type `()`
 
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/enum-variant-generic-args.rs:16:16
    |
 LL |         Self::<()>::TSVariant::<()>(());
    |                ^^ type argument not allowed
 
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/enum-variant-generic-args.rs:16:33
    |
 LL |         Self::<()>::TSVariant::<()>(());
@@ -49,7 +49,7 @@ LL |         Self::SVariant { v: () };
    = note: expected type `T`
               found type `()`
 
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/enum-variant-generic-args.rs:24:26
    |
 LL |         Self::SVariant::<()> { v: () };
@@ -64,7 +64,7 @@ LL |         Self::SVariant::<()> { v: () };
    = note: expected type `T`
               found type `()`
 
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/enum-variant-generic-args.rs:27:16
    |
 LL |         Self::<()>::SVariant { v: () };
@@ -79,13 +79,13 @@ LL |         Self::<()>::SVariant { v: () };
    = note: expected type `T`
               found type `()`
 
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/enum-variant-generic-args.rs:30:16
    |
 LL |         Self::<()>::SVariant::<()> { v: () };
    |                ^^ type argument not allowed
 
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/enum-variant-generic-args.rs:30:32
    |
 LL |         Self::<()>::SVariant::<()> { v: () };
@@ -100,25 +100,25 @@ LL |         Self::<()>::SVariant::<()> { v: () };
    = note: expected type `T`
               found type `()`
 
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/enum-variant-generic-args.rs:40:29
    |
 LL |     Enum::<()>::TSVariant::<()>(());
    |                             ^^ type argument not allowed
 
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/enum-variant-generic-args.rs:43:24
    |
 LL |     Alias::TSVariant::<()>(());
    |                        ^^ type argument not allowed
 
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/enum-variant-generic-args.rs:45:30
    |
 LL |     Alias::<()>::TSVariant::<()>(());
    |                              ^^ type argument not allowed
 
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/enum-variant-generic-args.rs:48:29
    |
 LL |     AliasFixed::TSVariant::<()>(());
@@ -136,31 +136,31 @@ error[E0107]: wrong number of type arguments: expected 0, found 1
 LL |     AliasFixed::<()>::TSVariant::<()>(());
    |                  ^^ unexpected type argument
 
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/enum-variant-generic-args.rs:52:35
    |
 LL |     AliasFixed::<()>::TSVariant::<()>(());
    |                                   ^^ type argument not allowed
 
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/enum-variant-generic-args.rs:58:28
    |
 LL |     Enum::<()>::SVariant::<()> { v: () };
    |                            ^^ type argument not allowed
 
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/enum-variant-generic-args.rs:61:23
    |
 LL |     Alias::SVariant::<()> { v: () };
    |                       ^^ type argument not allowed
 
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/enum-variant-generic-args.rs:63:29
    |
 LL |     Alias::<()>::SVariant::<()> { v: () };
    |                             ^^ type argument not allowed
 
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/enum-variant-generic-args.rs:66:28
    |
 LL |     AliasFixed::SVariant::<()> { v: () };
@@ -178,7 +178,7 @@ error[E0107]: wrong number of type arguments: expected 0, found 1
 LL |     AliasFixed::<()>::SVariant::<()> { v: () };
    |                  ^^ unexpected type argument
 
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/enum-variant-generic-args.rs:70:34
    |
 LL |     AliasFixed::<()>::SVariant::<()> { v: () };

--- a/src/test/ui/error-codes/E0109.stderr
+++ b/src/test/ui/error-codes/E0109.stderr
@@ -1,4 +1,4 @@
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/E0109.rs:1:14
    |
 LL | type X = u32<i32>;

--- a/src/test/ui/error-codes/E0110.rs
+++ b/src/test/ui/error-codes/E0110.rs
@@ -1,3 +1,3 @@
-type X = u32<'static>; //~ ERROR E0110
+type X = u32<'static>; //~ ERROR E0109
 
 fn main() {}

--- a/src/test/ui/error-codes/E0110.stderr
+++ b/src/test/ui/error-codes/E0110.stderr
@@ -1,4 +1,4 @@
-error[E0110]: lifetime arguments are not allowed on this entity
+error[E0109]: lifetime arguments are not allowed for this type
   --> $DIR/E0110.rs:1:14
    |
 LL | type X = u32<'static>;
@@ -6,4 +6,4 @@ LL | type X = u32<'static>;
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0110`.
+For more information about this error, try `rustc --explain E0109`.

--- a/src/test/ui/issues/issue-22706.rs
+++ b/src/test/ui/issues/issue-22706.rs
@@ -1,3 +1,3 @@
 fn is_copy<T: ::std::marker<i32>::Copy>() {}
-//~^ ERROR type arguments are not allowed on this entity [E0109]
+//~^ ERROR type arguments are not allowed for this type [E0109]
 fn main() {}

--- a/src/test/ui/issues/issue-22706.stderr
+++ b/src/test/ui/issues/issue-22706.stderr
@@ -1,4 +1,4 @@
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/issue-22706.rs:1:29
    |
 LL | fn is_copy<T: ::std::marker<i32>::Copy>() {}

--- a/src/test/ui/mod-subitem-as-enum-variant.rs
+++ b/src/test/ui/mod-subitem-as-enum-variant.rs
@@ -6,5 +6,5 @@ mod Mod {
 fn main() {
     Mod::FakeVariant::<i32>(0);
     Mod::<i32>::FakeVariant(0);
-    //~^ ERROR type arguments are not allowed on this entity [E0109]
+    //~^ ERROR type arguments are not allowed for this type [E0109]
 }

--- a/src/test/ui/mod-subitem-as-enum-variant.stderr
+++ b/src/test/ui/mod-subitem-as-enum-variant.stderr
@@ -1,4 +1,4 @@
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/mod-subitem-as-enum-variant.rs:8:11
    |
 LL |     Mod::<i32>::FakeVariant(0);

--- a/src/test/ui/prim-with-args.rs
+++ b/src/test/ui/prim-with-args.rs
@@ -1,27 +1,27 @@
 fn main() {
 
-let x: isize<isize>; //~ ERROR type arguments are not allowed on this entity
-let x: i8<isize>; //~ ERROR type arguments are not allowed on this entity
-let x: i16<isize>; //~ ERROR type arguments are not allowed on this entity
-let x: i32<isize>; //~ ERROR type arguments are not allowed on this entity
-let x: i64<isize>; //~ ERROR type arguments are not allowed on this entity
-let x: usize<isize>; //~ ERROR type arguments are not allowed on this entity
-let x: u8<isize>; //~ ERROR type arguments are not allowed on this entity
-let x: u16<isize>; //~ ERROR type arguments are not allowed on this entity
-let x: u32<isize>; //~ ERROR type arguments are not allowed on this entity
-let x: u64<isize>; //~ ERROR type arguments are not allowed on this entity
-let x: char<isize>; //~ ERROR type arguments are not allowed on this entity
+let x: isize<isize>; //~ ERROR type arguments are not allowed for this type
+let x: i8<isize>; //~ ERROR type arguments are not allowed for this type
+let x: i16<isize>; //~ ERROR type arguments are not allowed for this type
+let x: i32<isize>; //~ ERROR type arguments are not allowed for this type
+let x: i64<isize>; //~ ERROR type arguments are not allowed for this type
+let x: usize<isize>; //~ ERROR type arguments are not allowed for this type
+let x: u8<isize>; //~ ERROR type arguments are not allowed for this type
+let x: u16<isize>; //~ ERROR type arguments are not allowed for this type
+let x: u32<isize>; //~ ERROR type arguments are not allowed for this type
+let x: u64<isize>; //~ ERROR type arguments are not allowed for this type
+let x: char<isize>; //~ ERROR type arguments are not allowed for this type
 
-let x: isize<'static>; //~ ERROR lifetime arguments are not allowed on this entity
-let x: i8<'static>; //~ ERROR lifetime arguments are not allowed on this entity
-let x: i16<'static>; //~ ERROR lifetime arguments are not allowed on this entity
-let x: i32<'static>; //~ ERROR lifetime arguments are not allowed on this entity
-let x: i64<'static>; //~ ERROR lifetime arguments are not allowed on this entity
-let x: usize<'static>; //~ ERROR lifetime arguments are not allowed on this entity
-let x: u8<'static>; //~ ERROR lifetime arguments are not allowed on this entity
-let x: u16<'static>; //~ ERROR lifetime arguments are not allowed on this entity
-let x: u32<'static>; //~ ERROR lifetime arguments are not allowed on this entity
-let x: u64<'static>; //~ ERROR lifetime arguments are not allowed on this entity
-let x: char<'static>; //~ ERROR lifetime arguments are not allowed on this entity
+let x: isize<'static>; //~ ERROR lifetime arguments are not allowed for this type
+let x: i8<'static>; //~ ERROR lifetime arguments are not allowed for this type
+let x: i16<'static>; //~ ERROR lifetime arguments are not allowed for this type
+let x: i32<'static>; //~ ERROR lifetime arguments are not allowed for this type
+let x: i64<'static>; //~ ERROR lifetime arguments are not allowed for this type
+let x: usize<'static>; //~ ERROR lifetime arguments are not allowed for this type
+let x: u8<'static>; //~ ERROR lifetime arguments are not allowed for this type
+let x: u16<'static>; //~ ERROR lifetime arguments are not allowed for this type
+let x: u32<'static>; //~ ERROR lifetime arguments are not allowed for this type
+let x: u64<'static>; //~ ERROR lifetime arguments are not allowed for this type
+let x: char<'static>; //~ ERROR lifetime arguments are not allowed for this type
 
 }

--- a/src/test/ui/prim-with-args.stderr
+++ b/src/test/ui/prim-with-args.stderr
@@ -1,130 +1,130 @@
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/prim-with-args.rs:3:14
    |
 LL | let x: isize<isize>;
    |              ^^^^^ type argument not allowed
 
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/prim-with-args.rs:4:11
    |
 LL | let x: i8<isize>;
    |           ^^^^^ type argument not allowed
 
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/prim-with-args.rs:5:12
    |
 LL | let x: i16<isize>;
    |            ^^^^^ type argument not allowed
 
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/prim-with-args.rs:6:12
    |
 LL | let x: i32<isize>;
    |            ^^^^^ type argument not allowed
 
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/prim-with-args.rs:7:12
    |
 LL | let x: i64<isize>;
    |            ^^^^^ type argument not allowed
 
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/prim-with-args.rs:8:14
    |
 LL | let x: usize<isize>;
    |              ^^^^^ type argument not allowed
 
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/prim-with-args.rs:9:11
    |
 LL | let x: u8<isize>;
    |           ^^^^^ type argument not allowed
 
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/prim-with-args.rs:10:12
    |
 LL | let x: u16<isize>;
    |            ^^^^^ type argument not allowed
 
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/prim-with-args.rs:11:12
    |
 LL | let x: u32<isize>;
    |            ^^^^^ type argument not allowed
 
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/prim-with-args.rs:12:12
    |
 LL | let x: u64<isize>;
    |            ^^^^^ type argument not allowed
 
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/prim-with-args.rs:13:13
    |
 LL | let x: char<isize>;
    |             ^^^^^ type argument not allowed
 
-error[E0110]: lifetime arguments are not allowed on this entity
+error[E0109]: lifetime arguments are not allowed for this type
   --> $DIR/prim-with-args.rs:15:14
    |
 LL | let x: isize<'static>;
    |              ^^^^^^^ lifetime argument not allowed
 
-error[E0110]: lifetime arguments are not allowed on this entity
+error[E0109]: lifetime arguments are not allowed for this type
   --> $DIR/prim-with-args.rs:16:11
    |
 LL | let x: i8<'static>;
    |           ^^^^^^^ lifetime argument not allowed
 
-error[E0110]: lifetime arguments are not allowed on this entity
+error[E0109]: lifetime arguments are not allowed for this type
   --> $DIR/prim-with-args.rs:17:12
    |
 LL | let x: i16<'static>;
    |            ^^^^^^^ lifetime argument not allowed
 
-error[E0110]: lifetime arguments are not allowed on this entity
+error[E0109]: lifetime arguments are not allowed for this type
   --> $DIR/prim-with-args.rs:18:12
    |
 LL | let x: i32<'static>;
    |            ^^^^^^^ lifetime argument not allowed
 
-error[E0110]: lifetime arguments are not allowed on this entity
+error[E0109]: lifetime arguments are not allowed for this type
   --> $DIR/prim-with-args.rs:19:12
    |
 LL | let x: i64<'static>;
    |            ^^^^^^^ lifetime argument not allowed
 
-error[E0110]: lifetime arguments are not allowed on this entity
+error[E0109]: lifetime arguments are not allowed for this type
   --> $DIR/prim-with-args.rs:20:14
    |
 LL | let x: usize<'static>;
    |              ^^^^^^^ lifetime argument not allowed
 
-error[E0110]: lifetime arguments are not allowed on this entity
+error[E0109]: lifetime arguments are not allowed for this type
   --> $DIR/prim-with-args.rs:21:11
    |
 LL | let x: u8<'static>;
    |           ^^^^^^^ lifetime argument not allowed
 
-error[E0110]: lifetime arguments are not allowed on this entity
+error[E0109]: lifetime arguments are not allowed for this type
   --> $DIR/prim-with-args.rs:22:12
    |
 LL | let x: u16<'static>;
    |            ^^^^^^^ lifetime argument not allowed
 
-error[E0110]: lifetime arguments are not allowed on this entity
+error[E0109]: lifetime arguments are not allowed for this type
   --> $DIR/prim-with-args.rs:23:12
    |
 LL | let x: u32<'static>;
    |            ^^^^^^^ lifetime argument not allowed
 
-error[E0110]: lifetime arguments are not allowed on this entity
+error[E0109]: lifetime arguments are not allowed for this type
   --> $DIR/prim-with-args.rs:24:12
    |
 LL | let x: u64<'static>;
    |            ^^^^^^^ lifetime argument not allowed
 
-error[E0110]: lifetime arguments are not allowed on this entity
+error[E0109]: lifetime arguments are not allowed for this type
   --> $DIR/prim-with-args.rs:25:13
    |
 LL | let x: char<'static>;
@@ -132,5 +132,4 @@ LL | let x: char<'static>;
 
 error: aborting due to 22 previous errors
 
-Some errors occurred: E0109, E0110.
-For more information about an error, try `rustc --explain E0109`.
+For more information about this error, try `rustc --explain E0109`.

--- a/src/test/ui/qualified/qualified-path-params-2.rs
+++ b/src/test/ui/qualified/qualified-path-params-2.rs
@@ -16,7 +16,7 @@ impl S {
 }
 
 type A = <S as Tr>::A::f<u8>;
-//~^ ERROR type arguments are not allowed on this entity
+//~^ ERROR type arguments are not allowed for this type
 //~| ERROR ambiguous associated type
 
 fn main() {}

--- a/src/test/ui/qualified/qualified-path-params-2.stderr
+++ b/src/test/ui/qualified/qualified-path-params-2.stderr
@@ -1,4 +1,4 @@
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/qualified-path-params-2.rs:18:26
    |
 LL | type A = <S as Tr>::A::f<u8>;

--- a/src/test/ui/rfc1598-generic-associated-types/collections.rs
+++ b/src/test/ui/rfc1598-generic-associated-types/collections.rs
@@ -2,7 +2,7 @@
 //~^ WARNING the feature `generic_associated_types` is incomplete
 #![feature(associated_type_defaults)]
 
-// FIXME(#44265): "lifetime arguments are not allowed on this entity" errors will be addressed in a
+// FIXME(#44265): "lifetime arguments are not allowed for this type" errors will be addressed in a
 // follow-up PR.
 
 // A Collection trait and collection families. Based on
@@ -15,14 +15,14 @@ trait Collection<T> {
     // Test associated type defaults with parameters
     type Sibling<U>: Collection<U> =
         <<Self as Collection<T>>::Family as CollectionFamily>::Member<U>;
-    //~^ ERROR type arguments are not allowed on this entity [E0109]
+    //~^ ERROR type arguments are not allowed for this type [E0109]
 
     fn empty() -> Self;
 
     fn add(&mut self, value: T);
 
     fn iterate<'iter>(&'iter self) -> Self::Iter<'iter>;
-    //~^ ERROR lifetime arguments are not allowed on this entity [E0110]
+    //~^ ERROR lifetime arguments are not allowed for this type [E0109]
 }
 
 trait CollectionFamily {
@@ -48,13 +48,13 @@ impl<T> Collection<T> for Vec<T> {
     }
 
     fn iterate<'iter>(&'iter self) -> Self::Iter<'iter> {
-    //~^ ERROR lifetime arguments are not allowed on this entity [E0110]
+    //~^ ERROR lifetime arguments are not allowed for this type [E0109]
         self.iter()
     }
 }
 
 fn floatify<C>(ints: &C) -> <<C as Collection<i32>>::Family as CollectionFamily>::Member<f32>
-//~^ ERROR type arguments are not allowed on this entity [E0109]
+//~^ ERROR type arguments are not allowed for this type [E0109]
 where
     C: Collection<i32>,
 {
@@ -66,7 +66,7 @@ where
 }
 
 fn floatify_sibling<C>(ints: &C) -> <C as Collection<i32>>::Sibling<f32>
-//~^ ERROR type arguments are not allowed on this entity [E0109]
+//~^ ERROR type arguments are not allowed for this type [E0109]
 where
     C: Collection<i32>,
 {

--- a/src/test/ui/rfc1598-generic-associated-types/collections.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/collections.stderr
@@ -4,31 +4,31 @@ warning: the feature `generic_associated_types` is incomplete and may cause the 
 LL | #![feature(generic_associated_types)]
    |            ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/collections.rs:56:90
    |
 LL | fn floatify<C>(ints: &C) -> <<C as Collection<i32>>::Family as CollectionFamily>::Member<f32>
    |                                                                                          ^^^ type argument not allowed
 
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/collections.rs:68:69
    |
 LL | fn floatify_sibling<C>(ints: &C) -> <C as Collection<i32>>::Sibling<f32>
    |                                                                     ^^^ type argument not allowed
 
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/collections.rs:17:71
    |
 LL |         <<Self as Collection<T>>::Family as CollectionFamily>::Member<U>;
    |                                                                       ^ type argument not allowed
 
-error[E0110]: lifetime arguments are not allowed on this entity
+error[E0109]: lifetime arguments are not allowed for this type
   --> $DIR/collections.rs:24:50
    |
 LL |     fn iterate<'iter>(&'iter self) -> Self::Iter<'iter>;
    |                                                  ^^^^^ lifetime argument not allowed
 
-error[E0110]: lifetime arguments are not allowed on this entity
+error[E0109]: lifetime arguments are not allowed for this type
   --> $DIR/collections.rs:50:50
    |
 LL |     fn iterate<'iter>(&'iter self) -> Self::Iter<'iter> {
@@ -36,5 +36,4 @@ LL |     fn iterate<'iter>(&'iter self) -> Self::Iter<'iter> {
 
 error: aborting due to 5 previous errors
 
-Some errors occurred: E0109, E0110.
-For more information about an error, try `rustc --explain E0109`.
+For more information about this error, try `rustc --explain E0109`.

--- a/src/test/ui/rfc1598-generic-associated-types/construct_with_other_type.rs
+++ b/src/test/ui/rfc1598-generic-associated-types/construct_with_other_type.rs
@@ -3,7 +3,7 @@
 
 use std::ops::Deref;
 
-// FIXME(#44265): "lifetime arguments are not allowed on this entity" errors will be addressed in a
+// FIXME(#44265): "lifetime arguments are not allowed for this type" errors will be addressed in a
 // follow-up PR.
 
 trait Foo {
@@ -15,15 +15,15 @@ trait Baz {
 
     // This weird type tests that we can use universal function call syntax to access the Item on
     type Baa<'a>: Deref<Target = <Self::Quux<'a> as Foo>::Bar<'a, 'static>>;
-    //~^ ERROR lifetime arguments are not allowed on this entity [E0110]
-    //~| ERROR lifetime arguments are not allowed on this entity [E0110]
+    //~^ ERROR lifetime arguments are not allowed for this type [E0109]
+    //~| ERROR lifetime arguments are not allowed for this type [E0109]
 }
 
 impl<T> Baz for T where T: Foo {
     type Quux<'a> = T;
 
     type Baa<'a> = &'a <T as Foo>::Bar<'a, 'static>;
-    //~^ ERROR lifetime arguments are not allowed on this entity [E0110]
+    //~^ ERROR lifetime arguments are not allowed for this type [E0109]
 }
 
 fn main() {}

--- a/src/test/ui/rfc1598-generic-associated-types/construct_with_other_type.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/construct_with_other_type.stderr
@@ -4,19 +4,19 @@ warning: the feature `generic_associated_types` is incomplete and may cause the 
 LL | #![feature(generic_associated_types)]
    |            ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0110]: lifetime arguments are not allowed on this entity
+error[E0109]: lifetime arguments are not allowed for this type
   --> $DIR/construct_with_other_type.rs:17:46
    |
 LL |     type Baa<'a>: Deref<Target = <Self::Quux<'a> as Foo>::Bar<'a, 'static>>;
    |                                              ^^ lifetime argument not allowed
 
-error[E0110]: lifetime arguments are not allowed on this entity
+error[E0109]: lifetime arguments are not allowed for this type
   --> $DIR/construct_with_other_type.rs:17:63
    |
 LL |     type Baa<'a>: Deref<Target = <Self::Quux<'a> as Foo>::Bar<'a, 'static>>;
    |                                                               ^^ lifetime argument not allowed
 
-error[E0110]: lifetime arguments are not allowed on this entity
+error[E0109]: lifetime arguments are not allowed for this type
   --> $DIR/construct_with_other_type.rs:25:40
    |
 LL |     type Baa<'a> = &'a <T as Foo>::Bar<'a, 'static>;
@@ -24,4 +24,4 @@ LL |     type Baa<'a> = &'a <T as Foo>::Bar<'a, 'static>;
 
 error: aborting due to 3 previous errors
 
-For more information about this error, try `rustc --explain E0110`.
+For more information about this error, try `rustc --explain E0109`.

--- a/src/test/ui/rfc1598-generic-associated-types/generic_associated_type_undeclared_lifetimes.rs
+++ b/src/test/ui/rfc1598-generic-associated-types/generic_associated_type_undeclared_lifetimes.rs
@@ -3,20 +3,20 @@
 
 use std::ops::Deref;
 
-// FIXME(#44265): "lifetime arguments are not allowed on this entity" errors will be addressed in a
+// FIXME(#44265): "lifetime arguments are not allowed for this type" errors will be addressed in a
 // follow-up PR.
 
 trait Iterable {
     type Item<'a>;
     type Iter<'a>: Iterator<Item = Self::Item<'a>>
-    //~^ ERROR lifetime arguments are not allowed on this entity [E0110]
+    //~^ ERROR lifetime arguments are not allowed for this type [E0109]
         + Deref<Target = Self::Item<'b>>;
     //~^ ERROR undeclared lifetime
-    //~| ERROR lifetime arguments are not allowed on this entity [E0110]
+    //~| ERROR lifetime arguments are not allowed for this type [E0109]
 
     fn iter<'a>(&'a self) -> Self::Iter<'undeclared>;
     //~^ ERROR undeclared lifetime
-    //~| ERROR lifetime arguments are not allowed on this entity [E0110]
+    //~| ERROR lifetime arguments are not allowed for this type [E0109]
 }
 
 fn main() {}

--- a/src/test/ui/rfc1598-generic-associated-types/generic_associated_type_undeclared_lifetimes.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/generic_associated_type_undeclared_lifetimes.stderr
@@ -16,19 +16,19 @@ error[E0261]: use of undeclared lifetime name `'undeclared`
 LL |     fn iter<'a>(&'a self) -> Self::Iter<'undeclared>;
    |                                         ^^^^^^^^^^^ undeclared lifetime
 
-error[E0110]: lifetime arguments are not allowed on this entity
+error[E0109]: lifetime arguments are not allowed for this type
   --> $DIR/generic_associated_type_undeclared_lifetimes.rs:11:47
    |
 LL |     type Iter<'a>: Iterator<Item = Self::Item<'a>>
    |                                               ^^ lifetime argument not allowed
 
-error[E0110]: lifetime arguments are not allowed on this entity
+error[E0109]: lifetime arguments are not allowed for this type
   --> $DIR/generic_associated_type_undeclared_lifetimes.rs:13:37
    |
 LL |         + Deref<Target = Self::Item<'b>>;
    |                                     ^^ lifetime argument not allowed
 
-error[E0110]: lifetime arguments are not allowed on this entity
+error[E0109]: lifetime arguments are not allowed for this type
   --> $DIR/generic_associated_type_undeclared_lifetimes.rs:17:41
    |
 LL |     fn iter<'a>(&'a self) -> Self::Iter<'undeclared>;
@@ -36,5 +36,5 @@ LL |     fn iter<'a>(&'a self) -> Self::Iter<'undeclared>;
 
 error: aborting due to 5 previous errors
 
-Some errors occurred: E0110, E0261.
-For more information about an error, try `rustc --explain E0110`.
+Some errors occurred: E0109, E0261.
+For more information about an error, try `rustc --explain E0109`.

--- a/src/test/ui/rfc1598-generic-associated-types/iterable.rs
+++ b/src/test/ui/rfc1598-generic-associated-types/iterable.rs
@@ -3,16 +3,16 @@
 
 use std::ops::Deref;
 
-// FIXME(#44265): "lifetime arguments are not allowed on this entity" errors will be addressed in a
+// FIXME(#44265): "lifetime arguments are not allowed for this type" errors will be addressed in a
 // follow-up PR.
 
 trait Iterable {
     type Item<'a>;
     type Iter<'a>: Iterator<Item = Self::Item<'a>>;
-    //~^ ERROR lifetime arguments are not allowed on this entity [E0110]
+    //~^ ERROR lifetime arguments are not allowed for this type [E0109]
 
     fn iter<'a>(&'a self) -> Self::Iter<'a>;
-    //~^ ERROR lifetime arguments are not allowed on this entity [E0110]
+    //~^ ERROR lifetime arguments are not allowed for this type [E0109]
 }
 
 // Impl for struct type
@@ -21,7 +21,7 @@ impl<T> Iterable for Vec<T> {
     type Iter<'a> = std::slice::Iter<'a, T>;
 
     fn iter<'a>(&'a self) -> Self::Iter<'a> {
-    //~^ ERROR lifetime arguments are not allowed on this entity [E0110]
+    //~^ ERROR lifetime arguments are not allowed for this type [E0109]
         self.iter()
     }
 }
@@ -32,18 +32,18 @@ impl<T> Iterable for [T] {
     type Iter<'a> = std::slice::Iter<'a, T>;
 
     fn iter<'a>(&'a self) -> Self::Iter<'a> {
-    //~^ ERROR lifetime arguments are not allowed on this entity [E0110]
+    //~^ ERROR lifetime arguments are not allowed for this type [E0109]
         self.iter()
     }
 }
 
 fn make_iter<'a, I: Iterable>(it: &'a I) -> I::Iter<'a> {
-    //~^ ERROR lifetime arguments are not allowed on this entity [E0110]
+    //~^ ERROR lifetime arguments are not allowed for this type [E0109]
     it.iter()
 }
 
 fn get_first<'a, I: Iterable>(it: &'a I) -> Option<I::Item<'a>> {
-    //~^ ERROR lifetime arguments are not allowed on this entity [E0110]
+    //~^ ERROR lifetime arguments are not allowed for this type [E0109]
     it.iter().next()
 }
 

--- a/src/test/ui/rfc1598-generic-associated-types/iterable.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/iterable.stderr
@@ -4,37 +4,37 @@ warning: the feature `generic_associated_types` is incomplete and may cause the 
 LL | #![feature(generic_associated_types)]
    |            ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0110]: lifetime arguments are not allowed on this entity
+error[E0109]: lifetime arguments are not allowed for this type
   --> $DIR/iterable.rs:11:47
    |
 LL |     type Iter<'a>: Iterator<Item = Self::Item<'a>>;
    |                                               ^^ lifetime argument not allowed
 
-error[E0110]: lifetime arguments are not allowed on this entity
+error[E0109]: lifetime arguments are not allowed for this type
   --> $DIR/iterable.rs:40:53
    |
 LL | fn make_iter<'a, I: Iterable>(it: &'a I) -> I::Iter<'a> {
    |                                                     ^^ lifetime argument not allowed
 
-error[E0110]: lifetime arguments are not allowed on this entity
+error[E0109]: lifetime arguments are not allowed for this type
   --> $DIR/iterable.rs:45:60
    |
 LL | fn get_first<'a, I: Iterable>(it: &'a I) -> Option<I::Item<'a>> {
    |                                                            ^^ lifetime argument not allowed
 
-error[E0110]: lifetime arguments are not allowed on this entity
+error[E0109]: lifetime arguments are not allowed for this type
   --> $DIR/iterable.rs:14:41
    |
 LL |     fn iter<'a>(&'a self) -> Self::Iter<'a>;
    |                                         ^^ lifetime argument not allowed
 
-error[E0110]: lifetime arguments are not allowed on this entity
+error[E0109]: lifetime arguments are not allowed for this type
   --> $DIR/iterable.rs:23:41
    |
 LL |     fn iter<'a>(&'a self) -> Self::Iter<'a> {
    |                                         ^^ lifetime argument not allowed
 
-error[E0110]: lifetime arguments are not allowed on this entity
+error[E0109]: lifetime arguments are not allowed for this type
   --> $DIR/iterable.rs:34:41
    |
 LL |     fn iter<'a>(&'a self) -> Self::Iter<'a> {
@@ -42,4 +42,4 @@ LL |     fn iter<'a>(&'a self) -> Self::Iter<'a> {
 
 error: aborting due to 6 previous errors
 
-For more information about this error, try `rustc --explain E0110`.
+For more information about this error, try `rustc --explain E0109`.

--- a/src/test/ui/rfc1598-generic-associated-types/parameter_number_and_kind.rs
+++ b/src/test/ui/rfc1598-generic-associated-types/parameter_number_and_kind.rs
@@ -2,7 +2,7 @@
 //~^ WARNING the feature `generic_associated_types` is incomplete
 #![feature(associated_type_defaults)]
 
-// FIXME(#44265): "lifetime arguments are not allowed on this entity" errors will be addressed in a
+// FIXME(#44265): "lifetime arguments are not allowed for this type" errors will be addressed in a
 // follow-up PR.
 
 // FIXME(#44265): Update expected errors once E110 is resolved, now does not get past `trait Foo`.
@@ -15,13 +15,13 @@ trait Foo {
     type E<'a, T>;
     // Test parameters in default values
     type FOk<T> = Self::E<'static, T>;
-    //~^ ERROR type arguments are not allowed on this entity [E0109]
-    //~| ERROR lifetime arguments are not allowed on this entity [E0110]
+    //~^ ERROR type arguments are not allowed for this type [E0109]
+    //~| ERROR lifetime arguments are not allowed for this type [E0109]
     type FErr1 = Self::E<'static, 'static>; // Error
-    //~^ ERROR lifetime arguments are not allowed on this entity [E0110]
+    //~^ ERROR lifetime arguments are not allowed for this type [E0109]
     type FErr2<T> = Self::E<'static, T, u32>; // Error
-    //~^ ERROR type arguments are not allowed on this entity [E0109]
-    //~| ERROR lifetime arguments are not allowed on this entity [E0110]
+    //~^ ERROR type arguments are not allowed for this type [E0109]
+    //~| ERROR lifetime arguments are not allowed for this type [E0109]
 }
 
 struct Fooy;

--- a/src/test/ui/rfc1598-generic-associated-types/parameter_number_and_kind.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/parameter_number_and_kind.stderr
@@ -4,31 +4,31 @@ warning: the feature `generic_associated_types` is incomplete and may cause the 
 LL | #![feature(generic_associated_types)]
    |            ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0110]: lifetime arguments are not allowed on this entity
+error[E0109]: lifetime arguments are not allowed for this type
   --> $DIR/parameter_number_and_kind.rs:17:27
    |
 LL |     type FOk<T> = Self::E<'static, T>;
    |                           ^^^^^^^ lifetime argument not allowed
 
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/parameter_number_and_kind.rs:17:36
    |
 LL |     type FOk<T> = Self::E<'static, T>;
    |                                    ^ type argument not allowed
 
-error[E0110]: lifetime arguments are not allowed on this entity
+error[E0109]: lifetime arguments are not allowed for this type
   --> $DIR/parameter_number_and_kind.rs:20:26
    |
 LL |     type FErr1 = Self::E<'static, 'static>; // Error
    |                          ^^^^^^^ lifetime argument not allowed
 
-error[E0110]: lifetime arguments are not allowed on this entity
+error[E0109]: lifetime arguments are not allowed for this type
   --> $DIR/parameter_number_and_kind.rs:22:29
    |
 LL |     type FErr2<T> = Self::E<'static, T, u32>; // Error
    |                             ^^^^^^^ lifetime argument not allowed
 
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/parameter_number_and_kind.rs:22:38
    |
 LL |     type FErr2<T> = Self::E<'static, T, u32>; // Error
@@ -36,5 +36,4 @@ LL |     type FErr2<T> = Self::E<'static, T, u32>; // Error
 
 error: aborting due to 5 previous errors
 
-Some errors occurred: E0109, E0110.
-For more information about an error, try `rustc --explain E0109`.
+For more information about this error, try `rustc --explain E0109`.

--- a/src/test/ui/rfc1598-generic-associated-types/pointer_family.rs
+++ b/src/test/ui/rfc1598-generic-associated-types/pointer_family.rs
@@ -10,7 +10,7 @@ use std::ops::Deref;
 trait PointerFamily {
     type Pointer<T>: Deref<Target = T>;
     fn new<T>(value: T) -> Self::Pointer<T>;
-    //~^ ERROR type arguments are not allowed on this entity [E0109]
+    //~^ ERROR type arguments are not allowed for this type [E0109]
 }
 
 struct ArcFamily;
@@ -18,7 +18,7 @@ struct ArcFamily;
 impl PointerFamily for ArcFamily {
     type Pointer<T> = Arc<T>;
     fn new<T>(value: T) -> Self::Pointer<T> {
-    //~^ ERROR type arguments are not allowed on this entity [E0109]
+    //~^ ERROR type arguments are not allowed for this type [E0109]
         Arc::new(value)
     }
 }
@@ -28,14 +28,14 @@ struct RcFamily;
 impl PointerFamily for RcFamily {
     type Pointer<T> = Rc<T>;
     fn new<T>(value: T) -> Self::Pointer<T> {
-    //~^ ERROR type arguments are not allowed on this entity [E0109]
+    //~^ ERROR type arguments are not allowed for this type [E0109]
         Rc::new(value)
     }
 }
 
 struct Foo<P: PointerFamily> {
     bar: P::Pointer<String>,
-    //~^ ERROR type arguments are not allowed on this entity [E0109]
+    //~^ ERROR type arguments are not allowed for this type [E0109]
 }
 
 fn main() {}

--- a/src/test/ui/rfc1598-generic-associated-types/pointer_family.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/pointer_family.stderr
@@ -4,25 +4,25 @@ warning: the feature `generic_associated_types` is incomplete and may cause the 
 LL | #![feature(generic_associated_types)]
    |            ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/pointer_family.rs:37:21
    |
 LL |     bar: P::Pointer<String>,
    |                     ^^^^^^ type argument not allowed
 
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/pointer_family.rs:12:42
    |
 LL |     fn new<T>(value: T) -> Self::Pointer<T>;
    |                                          ^ type argument not allowed
 
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/pointer_family.rs:20:42
    |
 LL |     fn new<T>(value: T) -> Self::Pointer<T> {
    |                                          ^ type argument not allowed
 
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/pointer_family.rs:30:42
    |
 LL |     fn new<T>(value: T) -> Self::Pointer<T> {

--- a/src/test/ui/rfc1598-generic-associated-types/streaming_iterator.rs
+++ b/src/test/ui/rfc1598-generic-associated-types/streaming_iterator.rs
@@ -10,13 +10,13 @@ trait StreamingIterator {
     type Item<'a>;
     // Applying the lifetime parameter `'a` to `Self::Item` inside the trait.
     fn next<'a>(&'a self) -> Option<Self::Item<'a>>;
-    //~^ ERROR lifetime arguments are not allowed on this entity [E0110]
+    //~^ ERROR lifetime arguments are not allowed for this type [E0109]
 }
 
 struct Foo<T: StreamingIterator> {
     // Applying a concrete lifetime to the constructor outside the trait.
     bar: <T as StreamingIterator>::Item<'static>,
-    //~^ ERROR lifetime arguments are not allowed on this entity [E0110]
+    //~^ ERROR lifetime arguments are not allowed for this type [E0109]
 }
 
 // Users can bound parameters by the type constructed by that trait's associated type constructor
@@ -24,7 +24,7 @@ struct Foo<T: StreamingIterator> {
 //FIXME(sunjay): This next line should parse and be valid
 //fn foo<T: for<'a> StreamingIterator<Item<'a>=&'a [i32]>>(iter: T) { /* ... */ }
 fn foo<T>(iter: T) where T: StreamingIterator, for<'a> T::Item<'a>: Display { /* ... */ }
-//~^ ERROR lifetime arguments are not allowed on this entity [E0110]
+//~^ ERROR lifetime arguments are not allowed for this type [E0109]
 
 // Full example of enumerate iterator
 
@@ -36,9 +36,9 @@ struct StreamEnumerate<I> {
 
 impl<I: StreamingIterator> StreamingIterator for StreamEnumerate<I> {
     type Item<'a> = (usize, I::Item<'a>);
-    //~^ ERROR lifetime arguments are not allowed on this entity [E0110]
+    //~^ ERROR lifetime arguments are not allowed for this type [E0109]
     fn next<'a>(&'a self) -> Option<Self::Item<'a>> {
-        //~^ ERROR lifetime arguments are not allowed on this entity [E0110]
+        //~^ ERROR lifetime arguments are not allowed for this type [E0109]
         match self.iter.next() {
             None => None,
             Some(val) => {

--- a/src/test/ui/rfc1598-generic-associated-types/streaming_iterator.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/streaming_iterator.stderr
@@ -4,31 +4,31 @@ warning: the feature `generic_associated_types` is incomplete and may cause the 
 LL | #![feature(generic_associated_types)]
    |            ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0110]: lifetime arguments are not allowed on this entity
+error[E0109]: lifetime arguments are not allowed for this type
   --> $DIR/streaming_iterator.rs:18:41
    |
 LL |     bar: <T as StreamingIterator>::Item<'static>,
    |                                         ^^^^^^^ lifetime argument not allowed
 
-error[E0110]: lifetime arguments are not allowed on this entity
+error[E0109]: lifetime arguments are not allowed for this type
   --> $DIR/streaming_iterator.rs:26:64
    |
 LL | fn foo<T>(iter: T) where T: StreamingIterator, for<'a> T::Item<'a>: Display { /* ... */ }
    |                                                                ^^ lifetime argument not allowed
 
-error[E0110]: lifetime arguments are not allowed on this entity
+error[E0109]: lifetime arguments are not allowed for this type
   --> $DIR/streaming_iterator.rs:12:48
    |
 LL |     fn next<'a>(&'a self) -> Option<Self::Item<'a>>;
    |                                                ^^ lifetime argument not allowed
 
-error[E0110]: lifetime arguments are not allowed on this entity
+error[E0109]: lifetime arguments are not allowed for this type
   --> $DIR/streaming_iterator.rs:38:37
    |
 LL |     type Item<'a> = (usize, I::Item<'a>);
    |                                     ^^ lifetime argument not allowed
 
-error[E0110]: lifetime arguments are not allowed on this entity
+error[E0109]: lifetime arguments are not allowed for this type
   --> $DIR/streaming_iterator.rs:40:48
    |
 LL |     fn next<'a>(&'a self) -> Option<Self::Item<'a>> {
@@ -36,4 +36,4 @@ LL |     fn next<'a>(&'a self) -> Option<Self::Item<'a>> {
 
 error: aborting due to 5 previous errors
 
-For more information about this error, try `rustc --explain E0110`.
+For more information about this error, try `rustc --explain E0109`.

--- a/src/test/ui/structs/struct-path-associated-type.rs
+++ b/src/test/ui/structs/struct-path-associated-type.rs
@@ -13,7 +13,7 @@ fn f<T: Tr>() {
     //~^ ERROR expected struct, variant or union type, found associated type
     let z = T::A::<u8> {};
     //~^ ERROR expected struct, variant or union type, found associated type
-    //~| ERROR type arguments are not allowed on this entity
+    //~| ERROR type arguments are not allowed for this type
     match S {
         T::A {} => {}
         //~^ ERROR expected struct, variant or union type, found associated type
@@ -22,7 +22,7 @@ fn f<T: Tr>() {
 
 fn g<T: Tr<A = S>>() {
     let s = T::A {}; // OK
-    let z = T::A::<u8> {}; //~ ERROR type arguments are not allowed on this entity
+    let z = T::A::<u8> {}; //~ ERROR type arguments are not allowed for this type
     match S {
         T::A {} => {} // OK
     }
@@ -31,7 +31,7 @@ fn g<T: Tr<A = S>>() {
 fn main() {
     let s = S::A {}; //~ ERROR ambiguous associated type
     let z = S::A::<u8> {}; //~ ERROR ambiguous associated type
-    //~^ ERROR type arguments are not allowed on this entity
+    //~^ ERROR type arguments are not allowed for this type
     match S {
         S::A {} => {} //~ ERROR ambiguous associated type
     }

--- a/src/test/ui/structs/struct-path-associated-type.stderr
+++ b/src/test/ui/structs/struct-path-associated-type.stderr
@@ -4,7 +4,7 @@ error[E0071]: expected struct, variant or union type, found associated type
 LL |     let s = T::A {};
    |             ^^^^ not a struct
 
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/struct-path-associated-type.rs:14:20
    |
 LL |     let z = T::A::<u8> {};
@@ -22,7 +22,7 @@ error[E0071]: expected struct, variant or union type, found associated type
 LL |         T::A {} => {}
    |         ^^^^ not a struct
 
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/struct-path-associated-type.rs:25:20
    |
 LL |     let z = T::A::<u8> {};
@@ -34,7 +34,7 @@ error[E0223]: ambiguous associated type
 LL |     let s = S::A {};
    |             ^^^^ help: use fully-qualified syntax: `<S as Trait>::A`
 
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/struct-path-associated-type.rs:33:20
    |
 LL |     let z = S::A::<u8> {};

--- a/src/test/ui/structs/struct-path-self.rs
+++ b/src/test/ui/structs/struct-path-self.rs
@@ -6,7 +6,7 @@ trait Tr {
         //~^ ERROR expected struct, variant or union type, found Self
         let z = Self::<u8> {};
         //~^ ERROR expected struct, variant or union type, found Self
-        //~| ERROR type arguments are not allowed on this entity
+        //~| ERROR type arguments are not allowed for this type
         match s {
             Self { .. } => {}
             //~^ ERROR expected struct, variant or union type, found Self
@@ -17,7 +17,7 @@ trait Tr {
 impl Tr for S {
     fn f() {
         let s = Self {}; // OK
-        let z = Self::<u8> {}; //~ ERROR type arguments are not allowed on this entity
+        let z = Self::<u8> {}; //~ ERROR type arguments are not allowed for this type
         match s {
             Self { .. } => {} // OK
         }
@@ -27,7 +27,7 @@ impl Tr for S {
 impl S {
     fn g() {
         let s = Self {}; // OK
-        let z = Self::<u8> {}; //~ ERROR type arguments are not allowed on this entity
+        let z = Self::<u8> {}; //~ ERROR type arguments are not allowed for this type
         match s {
             Self { .. } => {} // OK
         }

--- a/src/test/ui/structs/struct-path-self.stderr
+++ b/src/test/ui/structs/struct-path-self.stderr
@@ -4,7 +4,7 @@ error[E0071]: expected struct, variant or union type, found Self
 LL |         let s = Self {};
    |                 ^^^^ not a struct
 
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/struct-path-self.rs:7:24
    |
 LL |         let z = Self::<u8> {};
@@ -22,13 +22,13 @@ error[E0071]: expected struct, variant or union type, found Self
 LL |             Self { .. } => {}
    |             ^^^^ not a struct
 
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/struct-path-self.rs:20:24
    |
 LL |         let z = Self::<u8> {};
    |                        ^^ type argument not allowed
 
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/struct-path-self.rs:30:24
    |
 LL |         let z = Self::<u8> {};

--- a/src/test/ui/type-alias-enum-variants.rs
+++ b/src/test/ui/type-alias-enum-variants.rs
@@ -7,5 +7,5 @@ fn main() {
     let _ = Option::None::<u8>; // OK (Lint in future!)
     let _ = Alias::<u8>::None; // OK
     let _ = Alias::None::<u8>; // Error
-    //~^ type arguments are not allowed on this entity
+    //~^ type arguments are not allowed for this type
 }

--- a/src/test/ui/type-alias-enum-variants.stderr
+++ b/src/test/ui/type-alias-enum-variants.stderr
@@ -1,4 +1,4 @@
-error[E0109]: type arguments are not allowed on this entity
+error[E0109]: type arguments are not allowed for this type
   --> $DIR/type-alias-enum-variants.rs:9:27
    |
 LL |     let _ = Alias::None::<u8>; // Error


### PR DESCRIPTION
Error messages should no longer be restricted to specific generic kinds.