### PR TITLE
Properly parse '--extern-private' with name and path

### DIFF
--- a/src/librustc/middle/cstore.rs
+++ b/src/librustc/middle/cstore.rs
@@ -199,6 +199,7 @@ pub trait CrateStore {
 
     // "queries" used in resolve that aren't tracked for incremental compilation
     fn crate_name_untracked(&self, cnum: CrateNum) -> Symbol;
+    fn crate_is_private_dep_untracked(&self, cnum: CrateNum) -> bool;
     fn crate_disambiguator_untracked(&self, cnum: CrateNum) -> CrateDisambiguator;
     fn crate_hash_untracked(&self, cnum: CrateNum) -> Svh;
     fn extern_mod_stmt_cnum_untracked(&self, emod_id: ast::NodeId) -> Option<CrateNum>;

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -2686,9 +2686,11 @@ mod tests {
     use super::Options;
 
     impl ExternEntry {
-        fn new_public(location: Option<String>) -> ExternEntry {
-            let mut locations = BTreeSet::new();
-            locations.insert(location);
+        fn new_public<S: Into<String>,
+                      I: IntoIterator<Item = Option<S>>>(locations: I) -> ExternEntry {
+            let locations: BTreeSet<_> = locations.into_iter().map(|o| o.map(|s| s.into()))
+                .collect();
+
             ExternEntry {
                 locations,
                 is_private_dep: false
@@ -2706,10 +2708,6 @@ mod tests {
 
     fn mk_map<K: Ord, V>(entries: Vec<(K, V)>) -> BTreeMap<K, V> {
         BTreeMap::from_iter(entries.into_iter())
-    }
-
-    fn mk_set<V: Ord>(entries: Vec<V>) -> BTreeSet<V> {
-        BTreeSet::from_iter(entries.into_iter())
     }
 
     // When the user supplies --test we should implicitly supply --cfg test
@@ -2829,45 +2827,33 @@ mod tests {
         v1.externs = Externs::new(mk_map(vec![
             (
                 String::from("a"),
-                mk_set(vec![ExternEntry::new_public(Some(String::from("b"))),
-                            ExternEntry::new_public(Some(String::from("c")))
-                            ]),
+                ExternEntry::new_public(vec![Some("b"), Some("c")])
             ),
             (
                 String::from("d"),
-                mk_set(vec![ExternEntry::new_public(Some(String::from("e"))),
-                            ExternEntry::new_public(Some(String::from("f")))
-                            ]),
+                ExternEntry::new_public(vec![Some("e"), Some("f")])
             ),
         ]));
 
         v2.externs = Externs::new(mk_map(vec![
             (
                 String::from("d"),
-                mk_set(vec![ExternEntry::new_public(Some(String::from("e"))),
-                            ExternEntry::new_public(Some(String::from("f")))
-                            ]),
+                ExternEntry::new_public(vec![Some("e"), Some("f")])
             ),
             (
                 String::from("a"),
-                mk_set(vec![ExternEntry::new_public(Some(String::from("b"))),
-                            ExternEntry::new_public(Some(String::from("c")))
-                            ]),
+                ExternEntry::new_public(vec![Some("b"), Some("c")])
             ),
         ]));
 
         v3.externs = Externs::new(mk_map(vec![
             (
                 String::from("a"),
-                mk_set(vec![ExternEntry::new_public(Some(String::from("b"))),
-                            ExternEntry::new_public(Some(String::from("c")))
-                            ]),
+                ExternEntry::new_public(vec![Some("b"), Some("c")])
             ),
             (
                 String::from("d"),
-                mk_set(vec![ExternEntry::new_public(Some(String::from("f"))),
-                            ExternEntry::new_public(Some(String::from("e")))
-                            ]),
+                ExternEntry::new_public(vec![Some("f"), Some("e")])
             ),
         ]));
 

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -285,7 +285,7 @@ impl OutputTypes {
 #[derive(Clone, Hash)]
 pub struct Externs(BTreeMap<String, ExternEntry>);
 
-#[derive(Clone, Hash, Eq, PartialEq, Ord, PartialOrd, Debug)]
+#[derive(Clone, Hash, Eq, PartialEq, Ord, PartialOrd, Debug, Default)]
 pub struct ExternEntry {
     pub locations: BTreeSet<Option<String>>,
     pub is_private_dep: bool
@@ -2337,26 +2337,17 @@ pub fn build_session_options_and_crate_config(
             );
         };
 
-
-        externs
+        let entry = externs
             .entry(name.to_owned())
-            .and_modify(|e| {
-                e.locations.insert(location.clone());
+            .or_default();
 
-                // Crates start out being not private,
-                // and go to being private if we see an '--extern-private'
-                // flag
-                e.is_private_dep |= private;
-            })
-            .or_insert_with(|| {
-                let mut locations = BTreeSet::new();
-                locations.insert(location);
 
-                ExternEntry {
-                    locations: locations,
-                    is_private_dep: private
-                }
-            });
+        entry.locations.insert(location.clone());
+
+        // Crates start out being not private,
+        // and go to being private if we see an '--extern-private'
+        // flag
+        entry.is_private_dep |= private;
     }
 
     let crate_name = matches.opt_str("crate-name");

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -291,6 +291,15 @@ pub struct ExternEntry {
     pub public: bool
 }
 
+impl ExternEntry {
+    pub fn new_public(location: Option<String>) -> ExternEntry {
+        ExternEntry {
+            location,
+            public: true
+        }
+    }
+}
+
 impl Externs {
     pub fn new(data: BTreeMap<String, BTreeSet<ExternEntry>>) -> Externs {
         Externs(data)
@@ -2705,7 +2714,7 @@ mod tests {
         build_session_options_and_crate_config,
         to_crate_config
     };
-    use crate::session::config::{LtoCli, LinkerPluginLto, PgoGenerate};
+    use crate::session::config::{LtoCli, LinkerPluginLto, PgoGenerate, ExternEntry};
     use crate::session::build_session;
     use crate::session::search_paths::SearchPath;
     use std::collections::{BTreeMap, BTreeSet};
@@ -2851,33 +2860,45 @@ mod tests {
         v1.externs = Externs::new(mk_map(vec![
             (
                 String::from("a"),
-                mk_set(vec![Some(String::from("b")), Some(String::from("c"))]),
+                mk_set(vec![ExternEntry::new_public(Some(String::from("b"))),
+                            ExternEntry::new_public(Some(String::from("c")))
+                            ]),
             ),
             (
                 String::from("d"),
-                mk_set(vec![Some(String::from("e")), Some(String::from("f"))]),
+                mk_set(vec![ExternEntry::new_public(Some(String::from("e"))),
+                            ExternEntry::new_public(Some(String::from("f")))
+                            ]),
             ),
         ]));
 
         v2.externs = Externs::new(mk_map(vec![
             (
                 String::from("d"),
-                mk_set(vec![Some(String::from("e")), Some(String::from("f"))]),
+                mk_set(vec![ExternEntry::new_public(Some(String::from("e"))),
+                            ExternEntry::new_public(Some(String::from("f")))
+                            ]),
             ),
             (
                 String::from("a"),
-                mk_set(vec![Some(String::from("b")), Some(String::from("c"))]),
+                mk_set(vec![ExternEntry::new_public(Some(String::from("b"))),
+                            ExternEntry::new_public(Some(String::from("c")))
+                            ]),
             ),
         ]));
 
         v3.externs = Externs::new(mk_map(vec![
             (
                 String::from("a"),
-                mk_set(vec![Some(String::from("b")), Some(String::from("c"))]),
+                mk_set(vec![ExternEntry::new_public(Some(String::from("b"))),
+                            ExternEntry::new_public(Some(String::from("c")))
+                            ]),
             ),
             (
                 String::from("d"),
-                mk_set(vec![Some(String::from("f")), Some(String::from("e"))]),
+                mk_set(vec![ExternEntry::new_public(Some(String::from("f"))),
+                            ExternEntry::new_public(Some(String::from("e")))
+                            ]),
             ),
         ]));
 

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -291,14 +291,7 @@ pub struct ExternEntry {
     pub public: bool
 }
 
-impl ExternEntry {
-    pub fn new_public(location: Option<String>) -> ExternEntry {
-        ExternEntry {
-            location,
-            public: true
-        }
-    }
-}
+
 
 impl Externs {
     pub fn new(data: BTreeMap<String, BTreeSet<ExternEntry>>) -> Externs {
@@ -2703,6 +2696,15 @@ mod tests {
     use syntax::edition::{Edition, DEFAULT_EDITION};
     use syntax;
     use super::Options;
+
+    impl ExternEntry {
+        fn new_public(location: Option<String>) -> ExternEntry {
+            ExternEntry {
+                location,
+                public: true
+            }
+        }
+    }
 
     fn optgroups() -> getopts::Options {
         let mut opts = getopts::Options::new();

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -2388,7 +2388,7 @@ pub fn build_session_options_and_crate_config(
             (k, values)
         })
         .collect();
-        
+
 
 
     let crate_name = matches.opt_str("crate-name");

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -443,10 +443,6 @@ top_level_options!(
         remap_path_prefix: Vec<(PathBuf, PathBuf)> [UNTRACKED],
 
         edition: Edition [TRACKED],
-
-        // The crates to consider private when
-        // checking leaked private dependency types in public interfaces
-        //extern_private: ExternPrivates [UNTRACKED],
     }
 );
 
@@ -649,7 +645,6 @@ impl Default for Options {
             cli_forced_thinlto_off: false,
             remap_path_prefix: Vec::new(),
             edition: DEFAULT_EDITION,
-            //extern_private: ExternPrivates(BTreeMap::new())
         }
     }
 }
@@ -2331,23 +2326,6 @@ pub fn build_session_options_and_crate_config(
         )
     }
 
-    /*let mut extern_private: BTreeMap<_, BTreeSet<_>> = BTreeMap::new();
-
-    for arg in matches.opt_strs("extern-private").into_iter() {
-        let mut parts = arg.splitn(2, '=');
-        let name = parts.next().unwrap_or_else(||
-            early_error(error_format, "--extern-private value must not be empty"));
-        let location = parts.next().map(|s| s.to_string()).unwrap_or_else(||
-            early_error(error_format, "--extern-private value must include a location"));
-
-
-        extern_private
-            .entry(name.to_owned())
-            .or_default()
-            .insert(location);
-
-    }*/
-
     // We start out with a Vec<(Option<String>, bool)>>,
     // and later convert it into a BTreeSet<(Option<String>, bool)>
     // This allows to modify entries in-place to set their correct
@@ -2369,7 +2347,7 @@ pub fn build_session_options_and_crate_config(
         };
 
 
-        // Externsl crates start out public,
+        // Extern crates start out public,
         // and become private if we later see
         // an '--extern-private' key. They never
         // go back to being public once we've seen
@@ -2449,7 +2427,6 @@ pub fn build_session_options_and_crate_config(
             cli_forced_thinlto_off: disable_thinlto,
             remap_path_prefix,
             edition,
-            //extern_private: ExternPrivates(extern_private)
         },
         cfg,
     )

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -1391,6 +1391,16 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         }
     }
 
+    /// Returns whether or not the crate with CrateNum 'cnum'
+    /// is marked as a private dependency
+    pub fn is_private_dep(self, cnum: CrateNum) -> bool {
+        if cnum == LOCAL_CRATE {
+            false
+        } else {
+            self.cstore.crate_is_private_dep_untracked(cnum)
+        }
+    }
+
     #[inline]
     pub fn def_path_hash(self, def_id: DefId) -> hir_map::DefPathHash {
         if def_id.is_local() {

--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -131,9 +131,9 @@ impl<'a> CrateLoader<'a> {
             // `source` stores paths which are normalized which may be different
             // from the strings on the command line.
             let source = &self.cstore.get_crate_data(cnum).source;
-            if let Some(locs) = self.sess.opts.externs.get(&*name.as_str()) {
+            if let Some(entry) = self.sess.opts.externs.get(&*name.as_str()) {
                 // Only use `--extern crate_name=path` here, not `--extern crate_name`.
-                let found = locs.iter().filter_map(|l| l.location.as_ref()).any(|l| {
+                let found = entry.locations.iter().filter_map(|l| l.as_ref()).any(|l| {
                     let l = fs::canonicalize(l).ok();
                     source.dylib.as_ref().map(|p| &p.0) == l.as_ref() ||
                     source.rlib.as_ref().map(|p| &p.0) == l.as_ref()
@@ -201,19 +201,9 @@ impl<'a> CrateLoader<'a> {
         let crate_root = lib.metadata.get_root();
         self.verify_no_symbol_conflicts(span, &crate_root);
 
-        let mut private_dep = false;
-        if let Some(s) = self.sess.opts.externs.get(&name.as_str()) {
-            for entry in s {
-                let p = entry.location.as_ref().map(|s| s.as_str());
-                if p == lib.dylib.as_ref().and_then(|r| r.0.to_str()) ||
-                    p == lib.rlib.as_ref().and_then(|r| r.0.to_str()) {
-
-                    private_dep = !entry.public;
-                    break;
-                }
-            }
-        }
-
+        let private_dep = self.sess.opts.externs.get(&name.as_str())
+            .map(|e| e.is_private_dep)
+            .unwrap_or(false);
 
         info!("register crate `extern crate {} as {}` (private_dep = {})",
             crate_root.name, ident, private_dep);

--- a/src/librustc_metadata/cstore.rs
+++ b/src/librustc_metadata/cstore.rs
@@ -79,6 +79,10 @@ pub struct CrateMetadata {
     pub source: CrateSource,
 
     pub proc_macros: Option<Vec<(ast::Name, Lrc<SyntaxExtension>)>>,
+
+    /// Whether or not this crate should be consider a private dependency
+    /// for purposes of the 'exported_private_dependencies' lint
+    pub private_dep: bool
 }
 
 pub struct CStore {
@@ -114,7 +118,8 @@ impl CStore {
     }
 
     pub(super) fn get_crate_data(&self, cnum: CrateNum) -> Lrc<CrateMetadata> {
-        self.metas.borrow()[cnum].clone().unwrap()
+        self.metas.borrow()[cnum].clone()
+            .unwrap_or_else(|| panic!("Failed to get crate data for {:?}", cnum))
     }
 
     pub(super) fn set_crate_data(&self, cnum: CrateNum, data: Lrc<CrateMetadata>) {

--- a/src/librustc_metadata/cstore_impl.rs
+++ b/src/librustc_metadata/cstore_impl.rs
@@ -399,7 +399,6 @@ impl cstore::CStore {
         r
     }
 
-
     pub fn crate_edition_untracked(&self, cnum: CrateNum) -> Edition {
         self.get_crate_data(cnum).root.edition
     }

--- a/src/librustc_metadata/cstore_impl.rs
+++ b/src/librustc_metadata/cstore_impl.rs
@@ -399,6 +399,7 @@ impl cstore::CStore {
         r
     }
 
+
     pub fn crate_edition_untracked(&self, cnum: CrateNum) -> Edition {
         self.get_crate_data(cnum).root.edition
     }
@@ -492,6 +493,10 @@ impl CrateStore for cstore::CStore {
     fn crate_name_untracked(&self, cnum: CrateNum) -> Symbol
     {
         self.get_crate_data(cnum).name
+    }
+
+    fn crate_is_private_dep_untracked(&self, cnum: CrateNum) -> bool {
+        self.get_crate_data(cnum).private_dep
     }
 
     fn crate_disambiguator_untracked(&self, cnum: CrateNum) -> CrateDisambiguator

--- a/src/librustc_metadata/locator.rs
+++ b/src/librustc_metadata/locator.rs
@@ -442,11 +442,11 @@ impl<'a> Context<'a> {
         // must be loaded via -L plus some filtering.
         if self.hash.is_none() {
             self.should_match_name = false;
-            if let Some(s) = self.sess.opts.externs.get(&self.crate_name.as_str()) {
+            if let Some(entry) = self.sess.opts.externs.get(&self.crate_name.as_str()) {
                 // Only use `--extern crate_name=path` here, not `--extern crate_name`.
-                if s.iter().any(|l| l.location.is_some()) {
+                if entry.locations.iter().any(|l| l.is_some()) {
                     return self.find_commandline_library(
-                        s.iter().filter_map(|l| l.location.as_ref()),
+                        entry.locations.iter().filter_map(|l| l.as_ref()),
                     );
                 }
             }

--- a/src/librustc_metadata/locator.rs
+++ b/src/librustc_metadata/locator.rs
@@ -444,9 +444,9 @@ impl<'a> Context<'a> {
             self.should_match_name = false;
             if let Some(s) = self.sess.opts.externs.get(&self.crate_name.as_str()) {
                 // Only use `--extern crate_name=path` here, not `--extern crate_name`.
-                if s.iter().any(|l| l.is_some()) {
+                if s.iter().any(|l| l.location.is_some()) {
                     return self.find_commandline_library(
-                        s.iter().filter_map(|l| l.as_ref()),
+                        s.iter().filter_map(|l| l.location.as_ref()),
                     );
                 }
             }

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -176,7 +176,7 @@ fn require_same_types<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     })
 }
 
-pub fn check_main_fn_ty<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, main_def_id: DefId) {
+fn check_main_fn_ty<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, main_def_id: DefId) {
     let main_id = tcx.hir().as_local_hir_id(main_def_id).unwrap();
     let main_span = tcx.def_span(main_def_id);
     let main_t = tcx.type_of(main_def_id);
@@ -241,7 +241,7 @@ pub fn check_main_fn_ty<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, main_def_id: DefI
     }
 }
 
-pub fn check_start_fn_ty<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, start_def_id: DefId) {
+fn check_start_fn_ty<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, start_def_id: DefId) {
     let start_id = tcx.hir().as_local_hir_id(start_def_id).unwrap();
     let start_span = tcx.def_span(start_def_id);
     let start_t = tcx.type_of(start_def_id);
@@ -298,7 +298,7 @@ pub fn check_start_fn_ty<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, start_def_id: De
     }
 }
 
-pub fn check_for_entry_fn<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
+fn check_for_entry_fn<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
     match tcx.entry_fn(LOCAL_CRATE) {
         Some((def_id, EntryFnType::Main)) => check_main_fn_ty(tcx, def_id),
         Some((def_id, EntryFnType::Start)) => check_start_fn_ty(tcx, def_id),

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -176,7 +176,7 @@ fn require_same_types<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     })
 }
 
-fn check_main_fn_ty<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, main_def_id: DefId) {
+pub fn check_main_fn_ty<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, main_def_id: DefId) {
     let main_id = tcx.hir().as_local_hir_id(main_def_id).unwrap();
     let main_span = tcx.def_span(main_def_id);
     let main_t = tcx.type_of(main_def_id);
@@ -241,7 +241,7 @@ fn check_main_fn_ty<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, main_def_id: DefId) {
     }
 }
 
-fn check_start_fn_ty<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, start_def_id: DefId) {
+pub fn check_start_fn_ty<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, start_def_id: DefId) {
     let start_id = tcx.hir().as_local_hir_id(start_def_id).unwrap();
     let start_span = tcx.def_span(start_def_id);
     let start_t = tcx.type_of(start_def_id);
@@ -298,7 +298,7 @@ fn check_start_fn_ty<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, start_def_id: DefId)
     }
 }
 
-fn check_for_entry_fn<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
+pub fn check_for_entry_fn<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
     match tcx.entry_fn(LOCAL_CRATE) {
         Some((def_id, EntryFnType::Main)) => check_main_fn_ty(tcx, def_id),
         Some((def_id, EntryFnType::Start)) => check_start_fn_ty(tcx, def_id),

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::fmt;
 use std::path::PathBuf;
 
@@ -590,12 +590,8 @@ fn parse_externs(matches: &getopts::Matches) -> Result<Externs, String> {
         let name = name.to_string();
         // For Rustdoc purposes, we can treat all externs as public
         externs.entry(name)
-            .and_modify(|e| { e.locations.insert(location.clone()); } )
-            .or_insert_with(|| {
-                let mut locations = BTreeSet::new();
-                locations.insert(location);
-                ExternEntry { locations, is_private_dep: false }
-            });
+            .or_default()
+            .locations.insert(location.clone());
     }
     Ok(Externs::new(externs))
 }

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -7,7 +7,7 @@ use errors::emitter::ColorConfig;
 use getopts;
 use rustc::lint::Level;
 use rustc::session::early_error;
-use rustc::session::config::{CodegenOptions, DebuggingOptions, ErrorOutputType, Externs};
+use rustc::session::config::{CodegenOptions, DebuggingOptions, ErrorOutputType, Externs, ExternEntry};
 use rustc::session::config::{nightly_options, build_codegen_options, build_debugging_options,
                              get_cmd_lint_options};
 use rustc::session::search_paths::SearchPath;
@@ -588,7 +588,8 @@ fn parse_externs(matches: &getopts::Matches) -> Result<Externs, String> {
                         enable `--extern crate_name` without `=path`".to_string());
         }
         let name = name.to_string();
-        externs.entry(name).or_default().insert(location);
+        // For Rustdoc purposes, we can treat all externs as public
+        externs.entry(name).or_default().insert(ExternEntry { location, public: true });
     }
     Ok(Externs::new(externs))
 }

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -7,9 +7,9 @@ use errors::emitter::ColorConfig;
 use getopts;
 use rustc::lint::Level;
 use rustc::session::early_error;
-use rustc::session::config::{CodegenOptions, DebuggingOptions, ErrorOutputType, Externs, ExternEntry};
+use rustc::session::config::{CodegenOptions, DebuggingOptions, ErrorOutputType, Externs};
 use rustc::session::config::{nightly_options, build_codegen_options, build_debugging_options,
-                             get_cmd_lint_options};
+                             get_cmd_lint_options, ExternEntry};
 use rustc::session::search_paths::SearchPath;
 use rustc_driver;
 use rustc_target::spec::TargetTriple;

--- a/src/test/ui/privacy/pub-priv-dep/pub-priv1.rs
+++ b/src/test/ui/privacy/pub-priv-dep/pub-priv1.rs
@@ -1,6 +1,6 @@
  // aux-build:priv_dep.rs
  // aux-build:pub_dep.rs
- // compile-flags: --extern-private priv_dep
+ // extern-private:priv_dep
 #![deny(exported_private_dependencies)]
 
 // This crate is a private dependency

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -286,6 +286,9 @@ pub struct TestProps {
     // directory as the test, but for backwards compatibility reasons
     // we also check the auxiliary directory)
     pub aux_builds: Vec<String>,
+    // A list of crates to pass '--extern-private name:PATH' flags for
+    // This should be a subset of 'aux_build'
+    pub extern_private: Vec<String>,
     // Environment settings to use for compiling
     pub rustc_env: Vec<(String, String)>,
     // Environment settings to use during execution
@@ -353,6 +356,7 @@ impl TestProps {
             run_flags: None,
             pp_exact: None,
             aux_builds: vec![],
+            extern_private: vec![],
             revisions: vec![],
             rustc_env: vec![],
             exec_env: vec![],
@@ -467,6 +471,10 @@ impl TestProps {
 
             if let Some(ab) = config.parse_aux_build(ln) {
                 self.aux_builds.push(ab);
+            }
+
+            if let Some(ep) = config.parse_extern_private(ln) {
+                self.extern_private.push(ep);
             }
 
             if let Some(ee) = config.parse_env(ln, "exec-env") {
@@ -608,6 +616,10 @@ impl Config {
     fn parse_aux_build(&self, line: &str) -> Option<String> {
         self.parse_name_value_directive(line, "aux-build")
             .map(|r| r.trim().to_string())
+    }
+
+    fn parse_extern_private(&self, line: &str) -> Option<String> {
+        self.parse_name_value_directive(line, "extern-private")
     }
 
     fn parse_compile_flags(&self, line: &str) -> Option<String> {

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -288,6 +288,7 @@ pub struct TestProps {
     pub aux_builds: Vec<String>,
     // A list of crates to pass '--extern-private name:PATH' flags for
     // This should be a subset of 'aux_build'
+    // FIXME: Replace this with a better solution: https://github.com/rust-lang/rust/pull/54020
     pub extern_private: Vec<String>,
     // Environment settings to use for compiling
     pub rustc_env: Vec<(String, String)>,

--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -1,5 +1,6 @@
 #![crate_name = "compiletest"]
 #![feature(test)]
+#![feature(vec_remove_item)]
 #![deny(warnings, rust_2018_idioms)]
 
 #[cfg(unix)]

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1684,7 +1684,7 @@ impl<'test> TestCx<'test> {
             }
         }
 
-        // Add any '--extenr-private' entries without a matching
+        // Add any '--extern-private' entries without a matching
         // 'aux-build'
         for private_lib in extern_priv {
             add_extern_priv(&private_lib, true);

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -75,7 +75,15 @@ pub fn dylib_env_var() -> &'static str {
 }
 
 /// The platform-specific library file extension
-pub fn lib_extension() -> &'static str {
+pub fn lib_extension(dylib: bool) -> &'static str {
+    // In some casess (e.g. MUSL), we build a static
+    // library, rather than a dynamic library.
+    // In this case, the only path we can pass
+    // with '--extern-meta' is the '.lib' file
+    if !dylib {
+        return ".rlib"
+    }
+
     if cfg!(windows) {
         ".dll"
     } else if cfg!(target_os = "macos") {
@@ -1596,12 +1604,15 @@ impl<'test> TestCx<'test> {
             create_dir_all(&aux_dir).unwrap();
         }
 
-        for priv_dep in &self.props.extern_private {
-            let lib_name = format!("lib{}{}", priv_dep, lib_extension());
+        // Use a Vec instead of a HashMap to preserve original order
+        let mut extern_priv = self.props.extern_private.clone();
+
+        let mut add_extern_priv = |priv_dep: &str, dylib: bool| {
+            let lib_name = format!("lib{}{}", priv_dep, lib_extension(dylib));
             rustc
                 .arg("--extern-private")
                 .arg(format!("{}={}", priv_dep, aux_dir.join(lib_name).to_str().unwrap()));
-        }
+        };
 
         for rel_ab in &self.props.aux_builds {
             let aux_testpaths = self.compute_aux_test_paths(rel_ab);
@@ -1619,8 +1630,8 @@ impl<'test> TestCx<'test> {
             create_dir_all(aux_cx.output_base_dir()).unwrap();
             let mut aux_rustc = aux_cx.make_compile_args(&aux_testpaths.file, aux_output);
 
-            let crate_type = if aux_props.no_prefer_dynamic {
-                None
+            let (dylib, crate_type) = if aux_props.no_prefer_dynamic {
+                (true, None)
             } else if self.config.target.contains("cloudabi")
                 || self.config.target.contains("emscripten")
                 || (self.config.target.contains("musl") && !aux_props.force_host)
@@ -1636,10 +1647,19 @@ impl<'test> TestCx<'test> {
                 // dynamic libraries so we just go back to building a normal library. Note,
                 // however, that for MUSL if the library is built with `force_host` then
                 // it's ok to be a dylib as the host should always support dylibs.
-                Some("lib")
+                (false, Some("lib"))
             } else {
-                Some("dylib")
+                (true, Some("dylib"))
             };
+
+            let trimmed = rel_ab.trim_end_matches(".rs").to_string();
+
+            // Normally, every 'extern-private' has a correspodning 'aux-build'
+            // entry. If so, we remove it from our list of private crates,
+            // and add an '--extern-private' flag to rustc
+            if extern_priv.remove_item(&trimmed).is_some() {
+                add_extern_priv(&trimmed, dylib);
+            }
 
             if let Some(crate_type) = crate_type {
                 aux_rustc.args(&["--crate-type", crate_type]);
@@ -1662,6 +1682,12 @@ impl<'test> TestCx<'test> {
                     &auxres,
                 );
             }
+        }
+
+        // Add any '--extenr-private' entries without a matching
+        // 'aux-build'
+        for private_lib in extern_priv {
+            add_extern_priv(&private_lib, true);
         }
 
         rustc.envs(self.props.rustc_env.clone());

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -74,22 +74,22 @@ pub fn dylib_env_var() -> &'static str {
     }
 }
 
-/// The platform-specific library file extension
-pub fn lib_extension(dylib: bool) -> &'static str {
+/// The platform-specific library name
+pub fn get_lib_name(lib: &str, dylib: bool) -> String {
     // In some casess (e.g. MUSL), we build a static
     // library, rather than a dynamic library.
     // In this case, the only path we can pass
     // with '--extern-meta' is the '.lib' file
     if !dylib {
-        return ".rlib"
+        return format!("lib{}.rlib", lib);
     }
 
     if cfg!(windows) {
-        ".dll"
+        format!("{}.dll", lib)
     } else if cfg!(target_os = "macos") {
-        ".dylib"
+        format!("lib{}.dylib", lib)
     } else {
-        ".so"
+        format!("lib{}.so", lib)
     }
 }
 
@@ -1608,7 +1608,7 @@ impl<'test> TestCx<'test> {
         let mut extern_priv = self.props.extern_private.clone();
 
         let mut add_extern_priv = |priv_dep: &str, dylib: bool| {
-            let lib_name = format!("lib{}{}", priv_dep, lib_extension(dylib));
+            let lib_name = get_lib_name(priv_dep, dylib);
             rustc
                 .arg("--extern-private")
                 .arg(format!("{}={}", priv_dep, aux_dir.join(lib_name).to_str().unwrap()));


### PR DESCRIPTION
It turns out that https://github.com/rust-lang/rust/pull/57586 didn't properly parse `--extern-private name=path`.

This PR properly implements the `--extern-private` option. I've added a new `extern-private` option to `compiletest`, which causes an `--extern-private` option to be passed to the compiler with the proper path.

Part of https://github.com/rust-lang/rust/issues/44663