### PR TITLE
Moves test::black_box to core::hint and fix black_box on wasm32 and asm.js

### DIFF
--- a/src/libcore/hint.rs
+++ b/src/libcore/hint.rs
@@ -97,7 +97,6 @@ pub fn spin_loop() {
 /// elimination.
 ///
 /// This function is a no-op, and does not even read from `dummy`.
-#[cfg_attr(any(target_arch = "asmjs", target_arch = "wasm32"), inline(never))]
 #[unstable(feature = "test", issue = "27812")]
 pub fn black_box<T>(dummy: T) -> T {
     #[cfg(not(any(target_arch = "asmjs", target_arch = "wasm32")))] {
@@ -107,6 +106,7 @@ pub fn black_box<T>(dummy: T) -> T {
         dummy
     }
     #[cfg(any(target_arch = "asmjs", target_arch = "wasm32"))] {
-        dummy
+        #[inline(never)] fn black_box_(x: T) -> T { x }
+        black_box_(dummy)
     }
 }

--- a/src/libcore/hint.rs
+++ b/src/libcore/hint.rs
@@ -99,13 +99,29 @@ pub fn spin_loop() {
 /// This function is a no-op, and does not even read from `dummy`.
 #[unstable(feature = "test", issue = "27812")]
 pub fn black_box<T>(dummy: T) -> T {
-    #[cfg(not(target_arch = "asmjs"))] {
+    #[cfg(not(
+        any(
+            target_arch = "asmjs",
+            all(
+                target_arch = "wasm32",
+                target_os = "emscripten"
+            )
+        )
+    ))] {
         // we need to "use" the argument in some way LLVM can't
         // introspect.
         unsafe { asm!("" : : "r"(&dummy)) }
         dummy
     }
-    #[cfg(target_arch = "asmjs")] {
+    #[cfg(
+        any(
+            target_arch = "asmjs",
+            all(
+                target_arch = "wasm32",
+                target_os = "emscripten"
+            )
+        )
+    )] {
         unsafe {
             let ret = crate::ptr::read_volatile(&dummy);
             crate::mem::forget(dummy);

--- a/src/libcore/hint.rs
+++ b/src/libcore/hint.rs
@@ -99,17 +99,17 @@ pub fn spin_loop() {
 /// This function is a no-op, and does not even read from `dummy`.
 #[unstable(feature = "test", issue = "27812")]
 pub fn black_box<T>(dummy: T) -> T {
-    #[cfg(not(any(target_arch = "asmjs", target_arch = "wasm32")))] {
+    #[cfg(not(target_arch = "asmjs"))] {
         // we need to "use" the argument in some way LLVM can't
         // introspect.
         unsafe { asm!("" : : "r"(&dummy)) }
         dummy
     }
-    #[cfg(any(target_arch = "asmjs", target_arch = "wasm32"))] {
+    #[cfg(target_arch = "asmjs")] {
         unsafe {
             let ret = crate::ptr::read_volatile(&dummy);
             crate::mem::forget(dummy);
             ret
         }
-   }
+    }
 }

--- a/src/libcore/hint.rs
+++ b/src/libcore/hint.rs
@@ -91,3 +91,22 @@ pub fn spin_loop() {
         }
     }
 }
+
+/// A function that is opaque to the optimizer, to allow benchmarks to
+/// pretend to use outputs to assist in avoiding dead-code
+/// elimination.
+///
+/// This function is a no-op, and does not even read from `dummy`.
+#[cfg_attr(any(target_arch = "asmjs", target_arch = "wasm32"), inline(never))]
+#[unstable(feature = "test", issue = "27812")]
+pub fn black_box<T>(dummy: T) -> T {
+    #[cfg(not(any(target_arch = "asmjs", target_arch = "wasm32")))] {
+        // we need to "use" the argument in some way LLVM can't
+        // introspect.
+        unsafe { asm!("" : : "r"(&dummy)) }
+        dummy
+    }
+    #[cfg(any(target_arch = "asmjs", target_arch = "wasm32"))] {
+        dummy
+    }
+}

--- a/src/libcore/hint.rs
+++ b/src/libcore/hint.rs
@@ -106,7 +106,10 @@ pub fn black_box<T>(dummy: T) -> T {
         dummy
     }
     #[cfg(any(target_arch = "asmjs", target_arch = "wasm32"))] {
-        #[inline(never)] fn black_box_(x: T) -> T { x }
-        black_box_(dummy)
-    }
+        unsafe {
+            let ret = crate::ptr::read_volatile(&dummy);
+            crate::mem::forget(dummy);
+            ret
+        }
+   }
 }

--- a/src/libcore/hint.rs
+++ b/src/libcore/hint.rs
@@ -122,6 +122,7 @@ pub fn black_box<T>(dummy: T) -> T {
             )
         )
     )] {
+        // asm.js and emscripten do not support inline assembly
         unsafe {
             let ret = crate::ptr::read_volatile(&dummy);
             crate::mem::forget(dummy);

--- a/src/libcore/internal_macros.rs
+++ b/src/libcore/internal_macros.rs
@@ -119,3 +119,84 @@ macro_rules! impl_fn_for_zst {
         )+
     }
 }
+
+/// A macro for defining `#[cfg]` if-else statements.
+///
+/// The macro provided by this crate, `cfg_if`, is similar to the `if/elif` C
+/// preprocessor macro by allowing definition of a cascade of `#[cfg]` cases,
+/// emitting the implementation which matches first.
+///
+/// This allows you to conveniently provide a long list `#[cfg]`'d blocks of code
+/// without having to rewrite each clause multiple times.
+///
+/// # Example
+///
+/// ```
+/// #[macro_use]
+/// extern crate cfg_if;
+///
+/// cfg_if! {
+///     if #[cfg(unix)] {
+///         fn foo() { /* unix specific functionality */ }
+///     } else if #[cfg(target_pointer_width = "32")] {
+///         fn foo() { /* non-unix, 32-bit functionality */ }
+///     } else {
+///         fn foo() { /* fallback implementation */ }
+///     }
+/// }
+///
+/// # fn main() {}
+/// ```
+macro_rules! cfg_if {
+    // match if/else chains with a final `else`
+    ($(
+        if #[cfg($($meta:meta),*)] { $($it:item)* }
+    ) else * else {
+        $($it2:item)*
+    }) => {
+        cfg_if! {
+            @__items
+            () ;
+            $( ( ($($meta),*) ($($it)*) ), )*
+            ( () ($($it2)*) ),
+        }
+    };
+
+    // match if/else chains lacking a final `else`
+    (
+        if #[cfg($($i_met:meta),*)] { $($i_it:item)* }
+        $(
+            else if #[cfg($($e_met:meta),*)] { $($e_it:item)* }
+        )*
+    ) => {
+        cfg_if! {
+            @__items
+            () ;
+            ( ($($i_met),*) ($($i_it)*) ),
+            $( ( ($($e_met),*) ($($e_it)*) ), )*
+            ( () () ),
+        }
+    };
+
+    // Internal and recursive macro to emit all the items
+    //
+    // Collects all the negated cfgs in a list at the beginning and after the
+    // semicolon is all the remaining items
+    (@__items ($($not:meta,)*) ; ) => {};
+    (@__items ($($not:meta,)*) ; ( ($($m:meta),*) ($($it:item)*) ), $($rest:tt)*) => {
+        // Emit all items within one block, applying an approprate #[cfg]. The
+        // #[cfg] will require all `$m` matchers specified and must also negate
+        // all previous matchers.
+        cfg_if! { @__apply cfg(all($($m,)* not(any($($not),*)))), $($it)* }
+
+        // Recurse to emit all other items in `$rest`, and when we do so add all
+        // our `$m` matchers to the list of `$not` matchers as future emissions
+        // will have to negate everything we just matched as well.
+        cfg_if! { @__items ($($not,)* $($m,)*) ; $($rest)* }
+    };
+
+    // Internal macro to Apply a cfg attribute to a list of items
+    (@__apply $m:meta, $($it:item)*) => {
+        $(#[$m] $it)*
+    };
+}

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -27,23 +27,7 @@ pub use libtest::{
     TestResult, TrFailed, TrFailedMsg, TrIgnored, TrOk, stats::Summary
 };
 
-/// A function that is opaque to the optimizer, to allow benchmarks to
-/// pretend to use outputs to assist in avoiding dead-code
-/// elimination.
-///
-/// This function is a no-op, and does not even read from `dummy`.
-#[cfg(not(any(target_arch = "asmjs", target_arch = "wasm32")))]
-pub fn black_box<T>(dummy: T) -> T {
-    // we need to "use" the argument in some way LLVM can't
-    // introspect.
-    unsafe { asm!("" : : "r"(&dummy)) }
-    dummy
-}
-#[cfg(any(target_arch = "asmjs", target_arch = "wasm32"))]
-#[inline(never)]
-pub fn black_box<T>(dummy: T) -> T {
-    dummy
-}
+pub use std::hint::black_box;
 
 #[cfg(test)]
 mod tests {

--- a/src/tools/tidy/src/pal.rs
+++ b/src/tools/tidy/src/pal.rs
@@ -42,6 +42,10 @@ const EXCEPTION_PATHS: &[&str] = &[
     "src/libpanic_abort",
     "src/libpanic_unwind",
     "src/libunwind",
+    // black_box implementation is LLVM-version specific and it uses
+    // target_os to tell targets with different LLVM-versions appart
+    // (e.g. `wasm32-unknown-emscripten` vs `wasm32-unknown-unknown`):
+    "src/libcore/hint.rs",
     "src/libstd/sys/", // Platform-specific code for std lives here.
                        // This has the trailing slash so that sys_common is not excepted.
     "src/libstd/os", // Platform-specific public interfaces


### PR DESCRIPTION
This changes removes a cyclic dependency between the "test" and "libtest"
crates, where "libtest" depends on "test" for "black_box", but "test" depends on
"libtest" for everything else.

I've chosen the "hint" module because there seems to be enough consensus in the
discussion of RFC2360 that this module is where such an intrinsic would belong,
but this PR does not implement that RFC! If that RFC ever gets merged, the API, docs, 
etc. of this API will need to change. This PR just move the implementation of the 
already existing API.

For backwards compatibility reasons I've chosen to also keep the "test" feature
gate for these instead of adding a new feature gate. If we change the feature
gate, we'll potentially all benchmarks, and while that's something that we could
do, it seems unnecessary to do that now - if RFC2360 gets merged, we'll need to
do that anyways. Backwards compatibility is also why we continue to re-export
"black_box" from the "test" crate.

This PR also fixes black_box on the wasm32 target, which now supports inline assembly, and uses volatile loads on the asm.js target.

r? @Amanieu (cc @rust-lang/libs)