### PR TITLE
Bump rustfmt to 1.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2252,7 +2252,7 @@ dependencies = [
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-workspace-hack 1.0.0",
  "rustc_tools_util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustfmt-nightly 1.1.0",
+ "rustfmt-nightly 1.1.1",
  "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.81 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_ignored 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3047,7 +3047,7 @@ dependencies = [
 
 [[package]]
 name = "rustfmt-nightly"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytecount 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
Includes some bug fixes.

https://github.com/rust-lang/rustfmt/compare/1427e4c20ba5cdc80a338347585c9de71a0dea4d...b6dac248ec2f5580b2f4deab931efa8992ece40d