### PR TITLE
Include llvm-ar with llvm-tools component

### DIFF
--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -190,6 +190,7 @@ const LLVM_TOOLS: &[&str] = &[
     "llvm-readobj", // used to get information from ELFs/objects that the other tools don't provide
     "llvm-size", // used to prints the size of the linker sections of a program
     "llvm-strip", // used to discard symbols from binary files to reduce their size
+    "llvm-ar" // used for creating and modifying archive files
 ];
 
 /// A structure representing a Rust compiler.


### PR DESCRIPTION
Adds the `llvm-ar` tool to the `llvm-tools` component. This is useful for [building and linking native code](https://doc.rust-lang.org/cargo/reference/build-scripts.html#case-study-building-some-native-code) in cargo build scripts without needing to use the platform specific `ar`. According to #58663 it is also useful for WASM.

 `llvm-ar` is very small (~82KB), so it does not significantly increase the size of the `llvm-tools` component.

Fixes #58663