### PR TITLE
Use `track_errors` instead of hand rolling

### DIFF
--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -14,6 +14,7 @@ use rustc::ty::{self, TyCtxt, query::TyCtxtAt};
 use rustc::ty::layout::{self, LayoutOf, VariantIdx};
 use rustc::ty::subst::Subst;
 use rustc::traits::Reveal;
+use rustc::util::common::ErrorReported;
 use rustc_data_structures::fx::FxHashMap;
 
 use syntax::ast::Mutability;
@@ -654,7 +655,7 @@ pub fn const_eval_raw_provider<'a, 'tcx>(
                                         v));
                     v
                 },
-                Err(_) => ErrorHandled::Reported,
+                Err(ErrorReported) => ErrorHandled::Reported,
             }
         } else if def_id.is_local() {
             // constant defined in this crate, we can figure out a lint level!

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -645,15 +645,17 @@ pub fn const_eval_raw_provider<'a, 'tcx>(
             // an error must be reported.
             let reported_err = tcx.sess.track_errors(|| {
                 err.report_as_error(ecx.tcx,
-                                    "could not evaluate static initializer");
+                                    "could not evaluate static initializer")
             });
             match reported_err {
-                Ok(v) => tcx.sess.delay_span_bug(err.span,
+                Ok(v) => {
+                    tcx.sess.delay_span_bug(err.span,
                                         &format!("static eval failure did not emit an error: {:#?}",
-                                        v)),
-                Err(err) => err,
+                                        v));
+                    v
+                },
+                Err(ErrorReported) => ErrorHandled::Reported,
             }
-            reported_err
         } else if def_id.is_local() {
             // constant defined in this crate, we can figure out a lint level!
             match tcx.describe_def(def_id) {

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -650,9 +650,9 @@ pub fn const_eval_raw_provider<'a, 'tcx>(
                                     "could not evaluate static initializer");
             });
             match tracked_err {
-                Ok(_) => tcx.sess.delay_span_bug(err.span,
+                Ok(reported_err) => tcx.sess.delay_span_bug(err.span,
                                         &format!("static eval failure did not emit an error: {:#?}",
-                                        tracked_err)),
+                                        reported_err)),
                 Err(_) => (),
             }
             reported_err

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -641,19 +641,17 @@ pub fn const_eval_raw_provider<'a, 'tcx>(
         let err = error_to_const_error(&ecx, error);
         // errors in statics are always emitted as fatal errors
         if tcx.is_static(def_id).is_some() {
-            let reported_err = err.report_as_error(ecx.tcx,
-                                                   "could not evaluate static initializer");
             // Ensure that if the above error was either `TooGeneric` or `Reported`
             // an error must be reported.
-            let tracked_err = tcx.sess.track_errors(|| {
+            let reported_err = tcx.sess.track_errors(|| {
                 err.report_as_error(ecx.tcx,
                                     "could not evaluate static initializer");
             });
-            match tracked_err {
-                Ok(reported_err) => tcx.sess.delay_span_bug(err.span,
+            match reported_err {
+                Ok(v) => tcx.sess.delay_span_bug(err.span,
                                         &format!("static eval failure did not emit an error: {:#?}",
-                                        reported_err)),
-                Err(_) => (),
+                                        v)),
+                Err(err) => err,
             }
             reported_err
         } else if def_id.is_local() {

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -645,13 +645,14 @@ pub fn const_eval_raw_provider<'a, 'tcx>(
                                                    "could not evaluate static initializer");
             // Ensure that if the above error was either `TooGeneric` or `Reported`
             // an error must be reported.
-            let errs = tcx.sess.track_errors(|| {
-                tcx.sess.err_count();
+            let tracked_err = tcx.sess.track_errors(|| {
+                err.report_as_error(ecx.tcx,
+                                    "could not evaluate static initializer");
             });
-            match errs {
+            match tracked_err {
                 Ok(_) => tcx.sess.delay_span_bug(err.span,
                                         &format!("static eval failure did not emit an error: {:#?}",
-                                        reported_err)),
+                                        tracked_err)),
                 Err(_) => (),
             }
             reported_err

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -645,10 +645,14 @@ pub fn const_eval_raw_provider<'a, 'tcx>(
                                                    "could not evaluate static initializer");
             // Ensure that if the above error was either `TooGeneric` or `Reported`
             // an error must be reported.
-            if tcx.sess.err_count() == 0 {
-                tcx.sess.delay_span_bug(err.span,
+            let errs = tcx.sess.track_errors(|| {
+                tcx.sess.err_count();
+            });
+            match errs {
+                Ok(_) => tcx.sess.delay_span_bug(err.span,
                                         &format!("static eval failure did not emit an error: {:#?}",
-                                                 reported_err));
+                                        reported_err)),
+                Err(_) => (),
             }
             reported_err
         } else if def_id.is_local() {

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -654,7 +654,7 @@ pub fn const_eval_raw_provider<'a, 'tcx>(
                                         v));
                     v
                 },
-                Err(ErrorReported) => ErrorHandled::Reported,
+                Err(_) => ErrorHandled::Reported,
             }
         } else if def_id.is_local() {
             // constant defined in this crate, we can figure out a lint level!


### PR DESCRIPTION
Fixes #59215 

r? @oli-obk 