### PR TITLE
Demo `FromIterator` short-circuiting

### DIFF
--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -1325,7 +1325,7 @@ impl<A, V: FromIterator<A>> FromIterator<Option<A>> for Option<V> {
     ///
     /// let res: Option<Vec<u16>> = items
     ///     .iter()
-    ///     .map(|x| shared += x; x.checked_sub(2))
+    ///     .map(|x| { shared += x; x.checked_sub(2) })
     ///     .collect();
     ///
     /// assert_eq!(res, None);

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -1315,6 +1315,26 @@ impl<A, V: FromIterator<A>> FromIterator<Option<A>> for Option<V> {
     /// Since the last element is zero, it would underflow. Thus, the resulting
     /// value is `None`.
     ///
+    /// Here is a variation on the previous example, showing that no
+    /// further elements are taken from `iter` after the first `None`.
+    ///
+    /// ```
+    /// let items = vec![3_u16, 2, 1, 10];
+    ///
+    /// let mut shared = 0;
+    ///
+    /// let res: Option<Vec<u16>> = items
+    ///     .iter()
+    ///     .map(|x| shared += x; x.checked_sub(2))
+    ///     .collect();
+    ///
+    /// assert_eq!(res, None);
+    /// assert_eq!(shared, 6);
+    /// ```
+    ///
+    /// Since the third element caused an underflow, no further elements were taken,
+    /// so the final value of `shared` is 6 (= `3 + 2 + 1`), not 16.
+    ///
     /// [`Iterator`]: ../iter/trait.Iterator.html
     #[inline]
     fn from_iter<I: IntoIterator<Item=Option<A>>>(iter: I) -> Option<V> {

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -1220,10 +1220,10 @@ impl<A, E, V: FromIterator<A>> FromIterator<Result<A, E>> for Result<V, E> {
     /// ```
     /// let v = vec![3, 2, 1, 10];
     /// let mut shared = 0;
-    /// let res: Result<Vec<u32>, &'static str> = v.iter().map(|x: &u32|
+    /// let res: Result<Vec<u32>, &'static str> = v.iter().map(|x: &u32| {
     ///     shared += x;
     ///     x.checked_sub(2).ok_or("Underflow!")
-    /// ).collect();
+    /// }).collect();
     /// assert_eq!(res, Err("Underflow!"));
     /// assert_eq!(shared, 6);
     /// ```

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -1202,6 +1202,34 @@ impl<A, E, V: FromIterator<A>> FromIterator<Result<A, E>> for Result<V, E> {
     /// ).collect();
     /// assert_eq!(res, Ok(vec![2, 3]));
     /// ```
+    ///
+    /// Here is another example that tries to subtract one from another list
+    /// of integers, this time checking for underflow:
+    ///
+    /// ```
+    /// let v = vec![1, 2, 0];
+    /// let res: Result<Vec<u32>, &'static str> = v.iter().map(|x: &u32|
+    ///     x.checked_sub(1).ok_or("Underflow!")
+    /// ).collect();
+    /// assert_eq!(res, Err("Underflow!"));
+    /// ```
+    ///
+    /// Here is a variation on the previous example, showing that no
+    /// further elements are taken from `iter` after the first `Err`.
+    ///
+    /// ```
+    /// let v = vec![3, 2, 1, 10];
+    /// let mut shared = 0;
+    /// let res: Result<Vec<u32>, &'static str> = v.iter().map(|x: &u32|
+    ///     shared += x;
+    ///     x.checked_sub(2).ok_or("Underflow!")
+    /// ).collect();
+    /// assert_eq!(res, Err("Underflow!"));
+    /// assert_eq!(shared, 6);
+    /// ```
+    ///
+    /// Since the third element caused an underflow, no further elements were taken,
+    /// so the final value of `shared` is 6 (= `3 + 2 + 1`), not 16.
     #[inline]
     fn from_iter<I: IntoIterator<Item=Result<A, E>>>(iter: I) -> Result<V, E> {
         // FIXME(#11084): This could be replaced with Iterator::scan when this


### PR DESCRIPTION
while looking at a FIXME in `FromIterator for Option` and `FromIterator for Result`, I realized that the current documentation does not have example code showing exactly what is meant by "no further elements are taken."

The code snippets provided here are meant to correct that.