### PR TITLE
ffi: rename VaList::copy to VaList::with_copy

### DIFF
--- a/src/libcore/ffi.rs
+++ b/src/libcore/ffi.rs
@@ -189,7 +189,7 @@ impl<'a> VaList<'a> {
                reason = "the `c_variadic` feature has not been properly tested on \
                          all supported platforms",
                issue = "44930")]
-    pub unsafe fn copy<F, R>(&self, f: F) -> R
+    pub unsafe fn with_copy<F, R>(&self, f: F) -> R
             where F: for<'copy> FnOnce(VaList<'copy>) -> R {
         #[cfg(any(all(not(target_arch = "aarch64"), not(target_arch = "powerpc"),
                       not(target_arch = "x86_64")),

--- a/src/test/run-make-fulldeps/c-link-to-rust-va-list-fn/checkrust.rs
+++ b/src/test/run-make-fulldeps/c-link-to-rust-va-list-fn/checkrust.rs
@@ -62,7 +62,7 @@ pub unsafe extern "C" fn check_list_copy_0(mut ap: VaList) -> usize {
     continue_if!(ap.arg::<c_int>() == 16);
     continue_if!(ap.arg::<c_char>() == 'A' as c_char);
     continue_if!(compare_c_str(ap.arg::<*const c_char>(), "Skip Me!"));
-    ap.copy(|mut ap| {
+    ap.with_copy(|mut ap| {
         if compare_c_str(ap.arg::<*const c_char>(), "Correct") {
             0
         } else {

--- a/src/test/ui/c-variadic/variadic-ffi-4.rs
+++ b/src/test/ui/c-variadic/variadic-ffi-4.rs
@@ -13,7 +13,7 @@ pub unsafe extern "C" fn no_escape1(_: usize, ap: ...) -> VaList<'static> {
 }
 
 pub unsafe extern "C" fn no_escape2(_: usize, ap: ...) {
-    let _ = ap.copy(|ap| { ap }); //~ ERROR: cannot infer an appropriate lifetime
+    let _ = ap.with_copy(|ap| { ap }); //~ ERROR: cannot infer an appropriate lifetime
 }
 
 pub unsafe extern "C" fn no_escape3(_: usize, mut ap0: &mut VaList, mut ap1: ...) {

--- a/src/test/ui/c-variadic/variadic-ffi-4.stderr
+++ b/src/test/ui/c-variadic/variadic-ffi-4.stderr
@@ -15,29 +15,29 @@ LL |     ap
    |     ^^ lifetime `'static` required
 
 error[E0495]: cannot infer an appropriate lifetime due to conflicting requirements
-  --> $DIR/variadic-ffi-4.rs:16:28
+  --> $DIR/variadic-ffi-4.rs:16:33
    |
-LL |     let _ = ap.copy(|ap| { ap });
-   |                            ^^
+LL |     let _ = ap.with_copy(|ap| { ap });
+   |                                 ^^
    |
-note: first, the lifetime cannot outlive the anonymous lifetime #2 defined on the body at 16:21...
-  --> $DIR/variadic-ffi-4.rs:16:21
+note: first, the lifetime cannot outlive the anonymous lifetime #2 defined on the body at 16:26...
+  --> $DIR/variadic-ffi-4.rs:16:26
    |
-LL |     let _ = ap.copy(|ap| { ap });
-   |                     ^^^^^^^^^^^
+LL |     let _ = ap.with_copy(|ap| { ap });
+   |                          ^^^^^^^^^^^
    = note: ...so that the expression is assignable:
            expected core::ffi::VaList<'_>
               found core::ffi::VaList<'_>
 note: but, the lifetime must be valid for the method call at 16:13...
   --> $DIR/variadic-ffi-4.rs:16:13
    |
-LL |     let _ = ap.copy(|ap| { ap });
-   |             ^^^^^^^^^^^^^^^^^^^^
+LL |     let _ = ap.with_copy(|ap| { ap });
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
 note: ...so type `core::ffi::VaList<'_>` of expression is valid during the expression
   --> $DIR/variadic-ffi-4.rs:16:13
    |
-LL |     let _ = ap.copy(|ap| { ap });
-   |             ^^^^^^^^^^^^^^^^^^^^
+LL |     let _ = ap.with_copy(|ap| { ap });
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
   --> $DIR/variadic-ffi-4.rs:20:12

--- a/src/test/ui/c-variadic/variadic-ffi-5.rs
+++ b/src/test/ui/c-variadic/variadic-ffi-5.rs
@@ -16,7 +16,7 @@ pub unsafe extern "C" fn no_escape1(_: usize, ap: ...) -> VaList<'static> {
 }
 
 pub unsafe extern "C" fn no_escape2(_: usize, ap: ...) {
-    let _ = ap.copy(|ap| { ap }); //~ ERROR: lifetime may not live long enough
+    let _ = ap.with_copy(|ap| { ap }); //~ ERROR: lifetime may not live long enough
 }
 
 pub unsafe extern "C" fn no_escape3(_: usize, ap0: &mut VaList, mut ap1: ...) {

--- a/src/test/ui/c-variadic/variadic-ffi-5.stderr
+++ b/src/test/ui/c-variadic/variadic-ffi-5.stderr
@@ -15,13 +15,13 @@ LL |     ap
    |     ^^ lifetime `'static` required
 
 error: lifetime may not live long enough
-  --> $DIR/variadic-ffi-5.rs:19:28
+  --> $DIR/variadic-ffi-5.rs:19:33
    |
-LL |     let _ = ap.copy(|ap| { ap });
-   |                      ---   ^^ returning this value requires that `'1` must outlive `'2`
-   |                      | |
-   |                      | return type of closure is core::ffi::VaList<'2>
-   |                      has type `core::ffi::VaList<'1>`
+LL |     let _ = ap.with_copy(|ap| { ap });
+   |                           ---   ^^ returning this value requires that `'1` must outlive `'2`
+   |                           | |
+   |                           | return type of closure is core::ffi::VaList<'2>
+   |                           has type `core::ffi::VaList<'1>`
 
 error: lifetime may not live long enough
   --> $DIR/variadic-ffi-5.rs:23:5


### PR DESCRIPTION
Rename `VaList::copy` to `VaList::with_copy`

r? @joshtriplett 