### PR TITLE
Correct minimum system LLVM version in tests

### DIFF
--- a/src/librustc_codegen_llvm/debuginfo/metadata.rs
+++ b/src/librustc_codegen_llvm/debuginfo/metadata.rs
@@ -1156,12 +1156,14 @@ fn prepare_union_metadata(
 // Enums
 //=-----------------------------------------------------------------------------
 
-// DWARF variant support is only available starting in LLVM 7.
+// DWARF variant support is only available starting in LLVM 8.
 // Although the earlier enum debug info output did not work properly
 // in all situations, it is better for the time being to continue to
 // sometimes emit the old style rather than emit something completely
-// useless when rust is compiled against LLVM 6 or older.  This
-// function decides which representation will be emitted.
+// useless when rust is compiled against LLVM 6 or older. LLVM 7
+// contains an early version of the DWARF variant support, and will
+// crash when handling the new debug info format. This function
+// decides which representation will be emitted.
 fn use_enum_fallback(cx: &CodegenCx<'_, '_>) -> bool {
     // On MSVC we have to use the fallback mode, because LLVM doesn't
     // lower variant parts to PDB.

--- a/src/test/codegen/enum-debug-clike.rs
+++ b/src/test/codegen/enum-debug-clike.rs
@@ -4,7 +4,7 @@
 
 // ignore-tidy-linelength
 // ignore-windows
-// min-system-llvm-version 7.0
+// min-system-llvm-version 8.0
 
 // compile-flags: -g -C no-prepopulate-passes
 

--- a/src/test/codegen/enum-debug-niche-2.rs
+++ b/src/test/codegen/enum-debug-niche-2.rs
@@ -4,7 +4,7 @@
 
 // ignore-tidy-linelength
 // ignore-windows
-// min-system-llvm-version 7.0
+// min-system-llvm-version 8.0
 
 // compile-flags: -g -C no-prepopulate-passes
 

--- a/src/test/codegen/enum-debug-niche.rs
+++ b/src/test/codegen/enum-debug-niche.rs
@@ -4,7 +4,7 @@
 
 // ignore-tidy-linelength
 // ignore-windows
-// min-system-llvm-version 7.0
+// min-system-llvm-version 8.0
 
 // compile-flags: -g -C no-prepopulate-passes
 

--- a/src/test/codegen/enum-debug-tagged.rs
+++ b/src/test/codegen/enum-debug-tagged.rs
@@ -4,7 +4,7 @@
 
 // ignore-tidy-linelength
 // ignore-windows
-// min-system-llvm-version 7.0
+// min-system-llvm-version 8.0
 
 // compile-flags: -g -C no-prepopulate-passes
 

--- a/src/test/debuginfo/borrowed-enum.rs
+++ b/src/test/debuginfo/borrowed-enum.rs
@@ -1,7 +1,7 @@
 // ignore-tidy-linelength
 
 // Require LLVM with DW_TAG_variant_part and a gdb or lldb that can read it.
-// min-system-llvm-version: 7.0
+// min-system-llvm-version: 8.0
 // min-gdb-version: 8.2
 // rust-lldb
 

--- a/src/test/debuginfo/generic-enum-with-different-disr-sizes.rs
+++ b/src/test/debuginfo/generic-enum-with-different-disr-sizes.rs
@@ -3,7 +3,7 @@
 // min-lldb-version: 310
 
 // Require LLVM with DW_TAG_variant_part and a gdb that can read it.
-// min-system-llvm-version: 7.0
+// min-system-llvm-version: 8.0
 // min-gdb-version: 8.2
 
 // compile-flags:-g

--- a/src/test/debuginfo/generic-struct-style-enum.rs
+++ b/src/test/debuginfo/generic-struct-style-enum.rs
@@ -2,7 +2,7 @@
 // min-lldb-version: 310
 
 // Require LLVM with DW_TAG_variant_part and a gdb that can read it.
-// min-system-llvm-version: 7.0
+// min-system-llvm-version: 8.0
 // min-gdb-version: 8.2
 
 // compile-flags:-g

--- a/src/test/debuginfo/generic-tuple-style-enum.rs
+++ b/src/test/debuginfo/generic-tuple-style-enum.rs
@@ -2,7 +2,7 @@
 
 // Require LLVM with DW_TAG_variant_part and a gdb and lldb that can
 // read it.
-// min-system-llvm-version: 7.0
+// min-system-llvm-version: 8.0
 // min-gdb-version: 8.2
 // rust-lldb
 

--- a/src/test/debuginfo/recursive-struct.rs
+++ b/src/test/debuginfo/recursive-struct.rs
@@ -2,7 +2,7 @@
 // ignore-lldb
 
 // Require LLVM with DW_TAG_variant_part and a gdb that can read it.
-// min-system-llvm-version: 7.0
+// min-system-llvm-version: 8.0
 // min-gdb-version: 8.2
 
 // compile-flags:-g

--- a/src/test/debuginfo/struct-style-enum.rs
+++ b/src/test/debuginfo/struct-style-enum.rs
@@ -2,7 +2,7 @@
 
 // Require LLVM with DW_TAG_variant_part and a gdb and lldb that can
 // read it.
-// min-system-llvm-version: 7.0
+// min-system-llvm-version: 8.0
 // min-gdb-version: 8.2
 // rust-lldb
 

--- a/src/test/debuginfo/tuple-style-enum.rs
+++ b/src/test/debuginfo/tuple-style-enum.rs
@@ -2,7 +2,7 @@
 
 // Require LLVM with DW_TAG_variant_part and a gdb and lldb that can
 // read it.
-// min-system-llvm-version: 7.0
+// min-system-llvm-version: 8.0
 // min-gdb-version: 8.2
 // rust-lldb
 

--- a/src/test/debuginfo/unique-enum.rs
+++ b/src/test/debuginfo/unique-enum.rs
@@ -2,7 +2,7 @@
 
 // Require LLVM with DW_TAG_variant_part and a gdb and lldb that can
 // read it.
-// min-system-llvm-version: 7.0
+// min-system-llvm-version: 8.0
 // min-gdb-version: 8.2
 // rust-lldb
 


### PR DESCRIPTION
Since commit 9452a8dfa3ba, the new debug info format is only generated
for LLVM 8 and newer versions. However, the tests still assume that LLVM
7 will use the new debug info format. Fix the tests (and a comment in
the code) to match the actual version check.