### PR TITLE
warn -> deny duplicate match bindings

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -354,7 +354,7 @@ declare_lint! {
 
 declare_lint! {
     pub DUPLICATE_MATCHER_BINDING_NAME,
-    Warn,
+    Deny,
     "duplicate macro matcher binding name"
 }
 
@@ -464,6 +464,7 @@ impl LintPass for HardwiredLints {
             DEPRECATED_IN_FUTURE,
             AMBIGUOUS_ASSOCIATED_ITEMS,
             NESTED_IMPL_TRAIT,
+            DUPLICATE_MATCHER_BINDING_NAME,
         )
     }
 }

--- a/src/test/ui/macros/macro-multiple-matcher-bindings.rs
+++ b/src/test/ui/macros/macro-multiple-matcher-bindings.rs
@@ -6,6 +6,7 @@
 // compile-pass
 
 #![allow(unused_macros)]
+#![warn(duplicate_matcher_binding_name)]
 
 macro_rules! foo1 {
     ($a:ident, $a:ident) => {}; //~WARNING duplicate matcher binding

--- a/src/test/ui/macros/macro-multiple-matcher-bindings.stderr
+++ b/src/test/ui/macros/macro-multiple-matcher-bindings.stderr
@@ -1,15 +1,19 @@
 warning: duplicate matcher binding
-  --> $DIR/macro-multiple-matcher-bindings.rs:11:6
+  --> $DIR/macro-multiple-matcher-bindings.rs:12:6
    |
 LL |     ($a:ident, $a:ident) => {};
    |      ^^^^^^^^  ^^^^^^^^
    |
-   = note: #[warn(duplicate_matcher_binding_name)] on by default
+note: lint level defined here
+  --> $DIR/macro-multiple-matcher-bindings.rs:9:9
+   |
+LL | #![warn(duplicate_matcher_binding_name)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57593 <https://github.com/rust-lang/rust/issues/57593>
 
 warning: duplicate matcher binding
-  --> $DIR/macro-multiple-matcher-bindings.rs:12:6
+  --> $DIR/macro-multiple-matcher-bindings.rs:13:6
    |
 LL |     ($a:ident, $a:path) => {};
    |      ^^^^^^^^  ^^^^^^^
@@ -18,7 +22,7 @@ LL |     ($a:ident, $a:path) => {};
    = note: for more information, see issue #57593 <https://github.com/rust-lang/rust/issues/57593>
 
 warning: duplicate matcher binding
-  --> $DIR/macro-multiple-matcher-bindings.rs:21:6
+  --> $DIR/macro-multiple-matcher-bindings.rs:22:6
    |
 LL |     ($a:ident, $($a:ident),*) => {};
    |      ^^^^^^^^    ^^^^^^^^
@@ -27,7 +31,7 @@ LL |     ($a:ident, $($a:ident),*) => {};
    = note: for more information, see issue #57593 <https://github.com/rust-lang/rust/issues/57593>
 
 warning: duplicate matcher binding
-  --> $DIR/macro-multiple-matcher-bindings.rs:22:8
+  --> $DIR/macro-multiple-matcher-bindings.rs:23:8
    |
 LL |     ($($a:ident)+ # $($($a:path),+);*) => {};
    |        ^^^^^^^^         ^^^^^^^


### PR DESCRIPTION
This is the next step of https://github.com/rust-lang/rust/issues/57742

r? @Centril 

- [x] Decide whether to go to deny-by-default or hard error.
     - My preference is to make this deny-by-default, rather than going straight to a hard error. The CI should fail because I haven't updated the ui test yet. I'll update it when we decide which to do.
- [x] Update [test](https://github.com/mark-i-m/rust/blob/c25d6b83441e0c060ee0273193ef27b29e1318cd/src/test/ui/macros/macro-multiple-matcher-bindings.rs)
- [ ] ~Crater run~ see https://github.com/rust-lang/rust/pull/59394#issuecomment-477817351