### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/src/doc/robots.txt
+++ b/src/doc/robots.txt
@@ -1,0 +1,19 @@
+# NB: This file is not automatically deployed. After changes, it needs to be uploaded manually to doc.rust-lang.org
+User-agent: *
+Disallow: /0.3/
+Disallow: /0.4/
+Disallow: /0.5/
+Disallow: /0.6/
+Disallow: /0.7/
+Disallow: /0.8/
+Disallow: /0.9/
+Disallow: /0.10/
+Disallow: /0.11.0/
+Disallow: /0.12.0/
+Disallow: /1.0.0-alpha/
+Disallow: /1.0.0-alpha.2/
+Disallow: /1.0.0-beta/
+Disallow: /1.0.0-beta.2/
+Disallow: /1.0.0-beta.3/
+Disallow: /1.0.0-beta.4/
+Disallow: /1.0.0-beta.5/

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -662,6 +662,9 @@ impl<I: DoubleEndedIterator + ?Sized> DoubleEndedIterator for Box<I> {
     fn next_back(&mut self) -> Option<I::Item> {
         (**self).next_back()
     }
+    fn nth_back(&mut self, n: usize) -> Option<I::Item> {
+        (**self).nth_back(n)
+    }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<I: ExactSizeIterator + ?Sized> ExactSizeIterator for Box<I> {

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -115,6 +115,7 @@
 #![feature(maybe_uninit)]
 #![feature(alloc_layout_extra)]
 #![feature(try_trait)]
+#![feature(iter_nth_back)]
 
 // Allow testing this library
 

--- a/src/libcore/hint.rs
+++ b/src/libcore/hint.rs
@@ -62,13 +62,32 @@ pub unsafe fn unreachable_unchecked() -> ! {
 #[inline]
 #[unstable(feature = "renamed_spin_loop", issue = "55002")]
 pub fn spin_loop() {
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    unsafe {
-        asm!("pause" ::: "memory" : "volatile");
+    #[cfg(
+        all(
+            any(target_arch = "x86", target_arch = "x86_64"),
+            target_feature = "sse2"
+        )
+    )] {
+        #[cfg(target_arch = "x86")] {
+            unsafe { crate::arch::x86::_mm_pause() };
+        }
+
+        #[cfg(target_arch = "x86_64")] {
+            unsafe { crate::arch::x86_64::_mm_pause() };
+        }
     }
 
-    #[cfg(target_arch = "aarch64")]
-    unsafe {
-        asm!("yield" ::: "memory" : "volatile");
+    #[cfg(
+        any(
+            target_arch = "aarch64",
+            all(target_arch = "arm", target_feature = "v6")
+        )
+    )] {
+        #[cfg(target_arch = "aarch64")] {
+            unsafe { crate::arch::aarch64::__yield() };
+        }
+        #[cfg(target_arch = "arm")] {
+            unsafe { crate::arch::arm::__yield() };
+        }
     }
 }

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -3835,6 +3835,19 @@ impl<'a, T> DoubleEndedIterator for Windows<'a, T> {
             ret
         }
     }
+
+    #[inline]
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        let (end, overflow) = self.v.len().overflowing_sub(n);
+        if end < self.size || overflow {
+            self.v = &[];
+            None
+        } else {
+            let ret = &self.v[end-self.size..end];
+            self.v = &self.v[..end-1];
+            Some(ret)
+        }
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcore/tests/slice.rs
+++ b/src/libcore/tests/slice.rs
@@ -579,6 +579,19 @@ fn test_windows_nth() {
 }
 
 #[test]
+fn test_windows_nth_back() {
+    let v: &[i32] = &[0, 1, 2, 3, 4, 5];
+    let mut c = v.windows(2);
+    assert_eq!(c.nth_back(2).unwrap()[0], 2);
+    assert_eq!(c.next_back().unwrap()[1], 2);
+
+    let v2: &[i32] = &[0, 1, 2, 3, 4];
+    let mut c2 = v2.windows(4);
+    assert_eq!(c2.nth_back(1).unwrap()[1], 1);
+    assert_eq!(c2.next_back(), None);
+}
+
+#[test]
 fn test_windows_last() {
     let v: &[i32] = &[0, 1, 2, 3, 4, 5];
     let c = v.windows(2);

--- a/src/librustc_codegen_llvm/debuginfo/metadata.rs
+++ b/src/librustc_codegen_llvm/debuginfo/metadata.rs
@@ -1156,12 +1156,14 @@ fn prepare_union_metadata(
 // Enums
 //=-----------------------------------------------------------------------------
 
-// DWARF variant support is only available starting in LLVM 7.
+// DWARF variant support is only available starting in LLVM 8.
 // Although the earlier enum debug info output did not work properly
 // in all situations, it is better for the time being to continue to
 // sometimes emit the old style rather than emit something completely
-// useless when rust is compiled against LLVM 6 or older.  This
-// function decides which representation will be emitted.
+// useless when rust is compiled against LLVM 6 or older. LLVM 7
+// contains an early version of the DWARF variant support, and will
+// crash when handling the new debug info format. This function
+// decides which representation will be emitted.
 fn use_enum_fallback(cx: &CodegenCx<'_, '_>) -> bool {
     // On MSVC we have to use the fallback mode, because LLVM doesn't
     // lower variant parts to PDB.

--- a/src/librustc_driver/pretty.rs
+++ b/src/librustc_driver/pretty.rs
@@ -633,10 +633,20 @@ fn print_flowgraph<'a, 'tcx, W: Write>(variants: Vec<borrowck_dot::Variant>,
     let body = tcx.hir().body(body_id);
     let cfg = cfg::CFG::new(tcx, &body);
     let labelled_edges = mode != PpFlowGraphMode::UnlabelledEdges;
+    let hir_id = code.id();
+    // We have to disassemble the hir_id because name must be ASCII
+    // alphanumeric. This does not appear in the rendered graph, so it does not
+    // have to be user friendly.
+    let name = format!(
+        "hir_id_{}_{}_{}",
+        hir_id.owner.address_space().index(),
+        hir_id.owner.as_array_index(),
+        hir_id.local_id.index(),
+    );
     let lcfg = LabelledCFG {
         tcx,
         cfg: &cfg,
-        name: format!("node_{}", code.id()),
+        name,
         labelled_edges,
     };
 

--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -156,7 +156,7 @@ fn do_mir_borrowck<'a, 'gcx, 'tcx>(
     let mut flow_inits = FlowAtLocation::new(do_dataflow(
         tcx,
         mir,
-        id,
+        def_id,
         &attributes,
         &dead_unwinds,
         MaybeInitializedPlaces::new(tcx, mir, &mdpe),
@@ -191,7 +191,7 @@ fn do_mir_borrowck<'a, 'gcx, 'tcx>(
     let flow_borrows = FlowAtLocation::new(do_dataflow(
         tcx,
         mir,
-        id,
+        def_id,
         &attributes,
         &dead_unwinds,
         Borrows::new(tcx, mir, regioncx.clone(), &borrow_set),
@@ -200,7 +200,7 @@ fn do_mir_borrowck<'a, 'gcx, 'tcx>(
     let flow_uninits = FlowAtLocation::new(do_dataflow(
         tcx,
         mir,
-        id,
+        def_id,
         &attributes,
         &dead_unwinds,
         MaybeUninitializedPlaces::new(tcx, mir, &mdpe),
@@ -209,7 +209,7 @@ fn do_mir_borrowck<'a, 'gcx, 'tcx>(
     let flow_ever_inits = FlowAtLocation::new(do_dataflow(
         tcx,
         mir,
-        id,
+        def_id,
         &attributes,
         &dead_unwinds,
         EverInitializedPlaces::new(tcx, mir, &mdpe),

--- a/src/librustc_mir/transform/generator.rs
+++ b/src/librustc_mir/transform/generator.rs
@@ -383,13 +383,13 @@ fn locals_live_across_suspend_points(
     FxHashMap<BasicBlock, liveness::LiveVarSet>,
 ) {
     let dead_unwinds = BitSet::new_empty(mir.basic_blocks().len());
-    let hir_id = tcx.hir().as_local_hir_id(source.def_id()).unwrap();
+    let def_id = source.def_id();
 
     // Calculate when MIR locals have live storage. This gives us an upper bound of their
     // lifetimes.
     let storage_live_analysis = MaybeStorageLive::new(mir);
     let storage_live =
-        do_dataflow(tcx, mir, hir_id, &[], &dead_unwinds, storage_live_analysis,
+        do_dataflow(tcx, mir, def_id, &[], &dead_unwinds, storage_live_analysis,
                     |bd, p| DebugFormatted::new(&bd.mir().local_decls[p]));
 
     // Find the MIR locals which do not use StorageLive/StorageDead statements.
@@ -403,7 +403,7 @@ fn locals_live_across_suspend_points(
     let borrowed_locals = if !movable {
         let analysis = HaveBeenBorrowedLocals::new(mir);
         let result =
-            do_dataflow(tcx, mir, hir_id, &[], &dead_unwinds, analysis,
+            do_dataflow(tcx, mir, def_id, &[], &dead_unwinds, analysis,
                         |bd, p| DebugFormatted::new(&bd.mir().local_decls[p]));
         Some((analysis, result))
     } else {

--- a/src/librustc_mir/util/graphviz.rs
+++ b/src/librustc_mir/util/graphviz.rs
@@ -1,6 +1,7 @@
 use rustc::hir::def_id::DefId;
 use rustc::mir::*;
 use rustc::ty::TyCtxt;
+use rustc_data_structures::indexed_vec::Idx;
 use std::fmt::Debug;
 use std::io::{self, Write};
 
@@ -20,6 +21,17 @@ pub fn write_mir_graphviz<'tcx, W>(tcx: TyCtxt<'_, '_, 'tcx>,
     Ok(())
 }
 
+// Must match `[0-9A-Za-z_]*`. This does not appear in the rendered graph, so
+// it does not have to be user friendly.
+pub fn graphviz_safe_def_name(def_id: DefId) -> String {
+    format!(
+        "{}_{}_{}",
+        def_id.krate.index(),
+        def_id.index.address_space().index(),
+        def_id.index.as_array_index(),
+    )
+}
+
 /// Write a graphviz DOT graph of the MIR.
 pub fn write_mir_fn_graphviz<'tcx, W>(tcx: TyCtxt<'_, '_, 'tcx>,
                                       def_id: DefId,
@@ -27,7 +39,7 @@ pub fn write_mir_fn_graphviz<'tcx, W>(tcx: TyCtxt<'_, '_, 'tcx>,
                                       w: &mut W) -> io::Result<()>
     where W: Write
 {
-    writeln!(w, "digraph Mir_{} {{", tcx.hir().as_local_hir_id(def_id).unwrap())?;
+    writeln!(w, "digraph Mir_{} {{", graphviz_safe_def_name(def_id))?;
 
     // Global graph properties
     writeln!(w, r#"    graph [fontname="monospace"];"#)?;

--- a/src/librustc_mir/util/mod.rs
+++ b/src/librustc_mir/util/mod.rs
@@ -15,7 +15,7 @@ pub mod collect_writes;
 
 pub use self::alignment::is_disaligned;
 pub use self::pretty::{dump_enabled, dump_mir, write_mir_pretty, PassWhere};
-pub use self::graphviz::{write_mir_graphviz};
+pub use self::graphviz::{graphviz_safe_def_name, write_mir_graphviz};
 pub use self::graphviz::write_node_label as write_graphviz_node_label;
 
 /// If possible, suggest replacing `ref` with `ref mut`.

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -303,7 +303,7 @@ impl<'a> Resolver<'a> {
                 }
 
                 // Empty groups `a::b::{}` are turned into synthetic `self` imports
-                // `a::b::c::{self as _}`, so that their prefixes are correctly
+                // `a::b::c::{self as __dummy}`, so that their prefixes are correctly
                 // resolved and checked for privacy/stability/etc.
                 if items.is_empty() && !empty_for_self(&prefix) {
                     let new_span = prefix[prefix.len() - 1].ident.span;
@@ -312,7 +312,7 @@ impl<'a> Resolver<'a> {
                             Ident::new(keywords::SelfLower.name(), new_span)
                         ),
                         kind: ast::UseTreeKind::Simple(
-                            Some(Ident::new(keywords::Underscore.name().gensymed(), new_span)),
+                            Some(Ident::new(Name::gensym("__dummy"), new_span)),
                             ast::DUMMY_NODE_ID,
                             ast::DUMMY_NODE_ID,
                         ),

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -951,7 +951,7 @@ enum RibKind<'a> {
     TraitOrImplItemRibKind,
 
     /// We passed through a function definition. Disallow upvars.
-    /// Permit only those const parameters specified in the function's generics.
+    /// Permit only those const parameters that are specified in the function's generics.
     FnItemRibKind,
 
     /// We passed through an item scope. Disallow upvars.
@@ -3924,19 +3924,16 @@ impl<'a> Resolver<'a> {
                     ribs.next();
                 }
                 for rib in ribs {
-                    match rib.kind {
-                        ItemRibKind | FnItemRibKind => {
-                            // This was an attempt to use a const parameter outside its scope.
-                            if record_used {
-                                resolve_error(
-                                    self,
-                                    span,
-                                    ResolutionError::GenericParamsFromOuterFunction(def),
-                                );
-                            }
-                            return Def::Err;
+                    if let ItemRibKind | FnItemRibKind = rib.kind {
+                        // This was an attempt to use a const parameter outside its scope.
+                        if record_used {
+                            resolve_error(
+                                self,
+                                span,
+                                ResolutionError::GenericParamsFromOuterFunction(def),
+                            );
                         }
-                        _ => {}
+                        return Def::Err;
                     }
                 }
             }

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -814,7 +814,7 @@ impl<'a, 'tcx> Visitor<'tcx> for Resolver<'a> {
         debug!("(resolving function) entering function");
         let (rib_kind, asyncness) = match function_kind {
             FnKind::ItemFn(_, ref header, ..) =>
-                (ItemRibKind, header.asyncness.node),
+                (FnItemRibKind, header.asyncness.node),
             FnKind::Method(_, ref sig, _, _) =>
                 (TraitOrImplItemRibKind, sig.header.asyncness.node),
             FnKind::Closure(_) =>
@@ -949,6 +949,10 @@ enum RibKind<'a> {
     /// binds. Disallow any other upvars (including other ty params that are
     /// upvars).
     TraitOrImplItemRibKind,
+
+    /// We passed through a function definition. Disallow upvars.
+    /// Permit only those const parameters specified in the function's generics.
+    FnItemRibKind,
 
     /// We passed through an item scope. Disallow upvars.
     ItemRibKind,
@@ -3863,7 +3867,7 @@ impl<'a> Resolver<'a> {
                                 seen.insert(node_id, depth);
                             }
                         }
-                        ItemRibKind | TraitOrImplItemRibKind => {
+                        ItemRibKind | FnItemRibKind | TraitOrImplItemRibKind => {
                             // This was an attempt to access an upvar inside a
                             // named function item. This is not allowed, so we
                             // report an error.
@@ -3897,7 +3901,7 @@ impl<'a> Resolver<'a> {
                         ConstantItemRibKind => {
                             // Nothing to do. Continue.
                         }
-                        ItemRibKind => {
+                        ItemRibKind | FnItemRibKind => {
                             // This was an attempt to use a type parameter outside its scope.
                             if record_used {
                                 resolve_error(
@@ -3912,21 +3916,27 @@ impl<'a> Resolver<'a> {
                 }
             }
             Def::ConstParam(..) => {
-                // A const param is always declared in a signature, which is always followed by
-                // some kind of function rib kind (specifically, ItemRibKind in the case of a
-                // normal function), so we can skip the first rib as it will be guaranteed to
-                // (spuriously) conflict with the const param.
-                for rib in &ribs[1..] {
-                    if let ItemRibKind = rib.kind {
-                        // This was an attempt to use a const parameter outside its scope.
-                        if record_used {
-                            resolve_error(
-                                self,
-                                span,
-                                ResolutionError::GenericParamsFromOuterFunction(def),
-                            );
+                let mut ribs = ribs.iter().peekable();
+                if let Some(Rib { kind: FnItemRibKind, .. }) = ribs.peek() {
+                    // When declaring const parameters inside function signatures, the first rib
+                    // is always a `FnItemRibKind`. In this case, we can skip it, to avoid it
+                    // (spuriously) conflicting with the const param.
+                    ribs.next();
+                }
+                for rib in ribs {
+                    match rib.kind {
+                        ItemRibKind | FnItemRibKind => {
+                            // This was an attempt to use a const parameter outside its scope.
+                            if record_used {
+                                resolve_error(
+                                    self,
+                                    span,
+                                    ResolutionError::GenericParamsFromOuterFunction(def),
+                                );
+                            }
+                            return Def::Err;
                         }
-                        return Def::Err;
+                        _ => {}
                     }
                 }
             }

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -1295,9 +1295,11 @@ impl<'a, 'b:'a> ImportResolver<'a, 'b> {
                 None => continue,
             };
 
-            // Filter away "empty import canaries" and ambiguous imports.
+            // Filter away ambiguous and gensymed imports. Gensymed imports
+            // (e.g. implicitly injected `std`) cannot be properly encoded in metadata,
+            // so they can cause name conflict errors downstream.
             let is_good_import = binding.is_import() && !binding.is_ambiguity() &&
-                                 binding.vis != ty::Visibility::Invisible;
+                                 !(ident.name.is_gensymed() && ident.name != "_");
             if is_good_import || binding.is_macro_def() {
                 let def = binding.def();
                 if def != Def::Err {

--- a/src/libsyntax_pos/symbol.rs
+++ b/src/libsyntax_pos/symbol.rs
@@ -179,6 +179,10 @@ impl Symbol {
         with_interner(|interner| interner.gensymed(self))
     }
 
+    pub fn is_gensymed(self) -> bool {
+        with_interner(|interner| interner.is_gensymed(self))
+    }
+
     pub fn as_str(self) -> LocalInternedString {
         with_interner(|interner| unsafe {
             LocalInternedString {

--- a/src/test/codegen/enum-debug-clike.rs
+++ b/src/test/codegen/enum-debug-clike.rs
@@ -4,7 +4,7 @@
 
 // ignore-tidy-linelength
 // ignore-windows
-// min-system-llvm-version 7.0
+// min-system-llvm-version 8.0
 
 // compile-flags: -g -C no-prepopulate-passes
 

--- a/src/test/codegen/enum-debug-niche-2.rs
+++ b/src/test/codegen/enum-debug-niche-2.rs
@@ -4,7 +4,7 @@
 
 // ignore-tidy-linelength
 // ignore-windows
-// min-system-llvm-version 7.0
+// min-system-llvm-version 8.0
 
 // compile-flags: -g -C no-prepopulate-passes
 

--- a/src/test/codegen/enum-debug-niche.rs
+++ b/src/test/codegen/enum-debug-niche.rs
@@ -4,7 +4,7 @@
 
 // ignore-tidy-linelength
 // ignore-windows
-// min-system-llvm-version 7.0
+// min-system-llvm-version 8.0
 
 // compile-flags: -g -C no-prepopulate-passes
 

--- a/src/test/codegen/enum-debug-tagged.rs
+++ b/src/test/codegen/enum-debug-tagged.rs
@@ -4,7 +4,7 @@
 
 // ignore-tidy-linelength
 // ignore-windows
-// min-system-llvm-version 7.0
+// min-system-llvm-version 8.0
 
 // compile-flags: -g -C no-prepopulate-passes
 

--- a/src/test/debuginfo/borrowed-enum.rs
+++ b/src/test/debuginfo/borrowed-enum.rs
@@ -1,7 +1,7 @@
 // ignore-tidy-linelength
 
 // Require LLVM with DW_TAG_variant_part and a gdb or lldb that can read it.
-// min-system-llvm-version: 7.0
+// min-system-llvm-version: 8.0
 // min-gdb-version: 8.2
 // rust-lldb
 

--- a/src/test/debuginfo/generic-enum-with-different-disr-sizes.rs
+++ b/src/test/debuginfo/generic-enum-with-different-disr-sizes.rs
@@ -3,7 +3,7 @@
 // min-lldb-version: 310
 
 // Require LLVM with DW_TAG_variant_part and a gdb that can read it.
-// min-system-llvm-version: 7.0
+// min-system-llvm-version: 8.0
 // min-gdb-version: 8.2
 
 // compile-flags:-g

--- a/src/test/debuginfo/generic-struct-style-enum.rs
+++ b/src/test/debuginfo/generic-struct-style-enum.rs
@@ -2,7 +2,7 @@
 // min-lldb-version: 310
 
 // Require LLVM with DW_TAG_variant_part and a gdb that can read it.
-// min-system-llvm-version: 7.0
+// min-system-llvm-version: 8.0
 // min-gdb-version: 8.2
 
 // compile-flags:-g

--- a/src/test/debuginfo/generic-tuple-style-enum.rs
+++ b/src/test/debuginfo/generic-tuple-style-enum.rs
@@ -2,7 +2,7 @@
 
 // Require LLVM with DW_TAG_variant_part and a gdb and lldb that can
 // read it.
-// min-system-llvm-version: 7.0
+// min-system-llvm-version: 8.0
 // min-gdb-version: 8.2
 // rust-lldb
 

--- a/src/test/debuginfo/recursive-struct.rs
+++ b/src/test/debuginfo/recursive-struct.rs
@@ -2,7 +2,7 @@
 // ignore-lldb
 
 // Require LLVM with DW_TAG_variant_part and a gdb that can read it.
-// min-system-llvm-version: 7.0
+// min-system-llvm-version: 8.0
 // min-gdb-version: 8.2
 
 // compile-flags:-g

--- a/src/test/debuginfo/struct-style-enum.rs
+++ b/src/test/debuginfo/struct-style-enum.rs
@@ -2,7 +2,7 @@
 
 // Require LLVM with DW_TAG_variant_part and a gdb and lldb that can
 // read it.
-// min-system-llvm-version: 7.0
+// min-system-llvm-version: 8.0
 // min-gdb-version: 8.2
 // rust-lldb
 

--- a/src/test/debuginfo/tuple-style-enum.rs
+++ b/src/test/debuginfo/tuple-style-enum.rs
@@ -2,7 +2,7 @@
 
 // Require LLVM with DW_TAG_variant_part and a gdb and lldb that can
 // read it.
-// min-system-llvm-version: 7.0
+// min-system-llvm-version: 8.0
 // min-gdb-version: 8.2
 // rust-lldb
 

--- a/src/test/debuginfo/unique-enum.rs
+++ b/src/test/debuginfo/unique-enum.rs
@@ -2,7 +2,7 @@
 
 // Require LLVM with DW_TAG_variant_part and a gdb and lldb that can
 // read it.
-// min-system-llvm-version: 7.0
+// min-system-llvm-version: 8.0
 // min-gdb-version: 8.2
 // rust-lldb
 

--- a/src/test/mir-opt/graphviz.rs
+++ b/src/test/mir-opt/graphviz.rs
@@ -1,0 +1,23 @@
+// Test graphviz output
+// compile-flags: -Z dump-mir-graphviz
+
+// ignore-tidy-linelength
+
+fn main() {}
+
+// END RUST SOURCE
+// START rustc.main.mir_map.0.dot
+// digraph Mir_0_0_3 { // The name here MUST be an ASCII identifier.
+//     graph [fontname="monospace"];
+//     node [fontname="monospace"];
+//     edge [fontname="monospace"];
+//     label=<fn main() -&gt; ()<br align="left"/>>;
+//     bb0 [shape="none", label=<<table border="0" cellborder="1" cellspacing="0"><tr><td bgcolor="gray" align="center" colspan="1">0</td></tr><tr><td align="left" balign="left">_0 = ()<br/></td></tr><tr><td align="left">goto</td></tr></table>
+// >];
+//     bb1 [shape="none", label=<<table border="0" cellborder="1" cellspacing="0"><tr><td bgcolor="gray" align="center" colspan="1">1</td></tr><tr><td align="left">resume</td></tr></table>
+// >];
+//     bb2 [shape="none", label=<<table border="0" cellborder="1" cellspacing="0"><tr><td bgcolor="gray" align="center" colspan="1">2</td></tr><tr><td align="left">return</td></tr></table>
+// >];
+//     bb0 -> bb2 [label=""];
+// }
+// END rustc.main.mir_map.0.dot

--- a/src/test/ui/const-generics/struct-with-invalid-const-param.rs
+++ b/src/test/ui/const-generics/struct-with-invalid-const-param.rs
@@ -1,0 +1,6 @@
+#![feature(const_generics)]
+//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+
+struct S<const C: u8>(C); //~ ERROR expected type, found const parameter
+
+fn main() {}

--- a/src/test/ui/const-generics/struct-with-invalid-const-param.stderr
+++ b/src/test/ui/const-generics/struct-with-invalid-const-param.stderr
@@ -1,0 +1,15 @@
+warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+  --> $DIR/struct-with-invalid-const-param.rs:1:12
+   |
+LL | #![feature(const_generics)]
+   |            ^^^^^^^^^^^^^^
+
+error[E0573]: expected type, found const parameter `C`
+  --> $DIR/struct-with-invalid-const-param.rs:4:23
+   |
+LL | struct S<const C: u8>(C);
+   |                       ^ help: a struct with a similar name exists: `S`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0573`.

--- a/src/test/ui/imports/auxiliary/gensymed.rs
+++ b/src/test/ui/imports/auxiliary/gensymed.rs
@@ -1,0 +1,3 @@
+// edition:2018
+
+mod std {}

--- a/src/test/ui/imports/gensymed.rs
+++ b/src/test/ui/imports/gensymed.rs
@@ -1,0 +1,7 @@
+// compile-pass
+// edition:2018
+// aux-build:gensymed.rs
+
+extern crate gensymed;
+
+fn main() {}


### PR DESCRIPTION
Successful merges:

 - #59213 (Track changes to robots.txt)
 - #59239 (Remove inline assembly from hint::spin_loop)
 - #59251 (Use a valid name for graphviz graphs)
 - #59296 (Do not encode gensymed imports in metadata)
 - #59328 (Implement specialized nth_back() for Box and Windows.)
 - #59355 (Fix ICE with const generic param in struct)
 - #59377 (Correct minimum system LLVM version in tests)

