### PR TITLE
bootstrap: build crates under libtest with -Z emit-stack-sizes

### DIFF
--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -97,6 +97,8 @@ impl Step for Std {
         let _folder = builder.fold_output(|| format!("stage{}-std", compiler.stage));
         builder.info(&format!("Building stage{} std artifacts ({} -> {})", compiler.stage,
                 &compiler.host, target));
+        // compile with `-Z emit-stack-sizes`; see bootstrap/src/rustc.rs for more details
+        cargo.env("RUSTC_EMIT_STACK_SIZES", "1");
         run_cargo(builder,
                   &mut cargo,
                   &libstd_stamp(builder, compiler, target),
@@ -382,6 +384,8 @@ impl Step for Test {
         let _folder = builder.fold_output(|| format!("stage{}-test", compiler.stage));
         builder.info(&format!("Building stage{} test artifacts ({} -> {})", compiler.stage,
                 &compiler.host, target));
+        // compile with `-Z emit-stack-sizes`; see bootstrap/src/rustc.rs for more details
+        cargo.env("RUSTC_EMIT_STACK_SIZES", "1");
         run_cargo(builder,
                   &mut cargo,
                   &libtest_stamp(builder, compiler, target),


### PR DESCRIPTION
Please see the comment in the diff for the rationale.

This change adds a `.stack_sizes` linker section to `libcompiler_builtins.rlib`
but this section is discarded by the linker by default so it won't affect the
binary size of most programs. It will, however, negatively affect the binary
size of programs that link to a recent release of the `cortex-m-rt` crate
because of the linker script that crate provides, but I have proposed a PR
(rust-embedded/cortex-m-rt#186) to solve the problem (which I originally
introduced :-)).

This change does increase the size of the `libcompiler_builtins.rlib` artifact we
distribute but the increase is in the order of (a few) KBs.

r? @alexcrichton