### PR TITLE
Refactor InferenceFudger (née RegionFudger)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -781,6 +781,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ena"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2662,7 +2670,7 @@ name = "rustc_data_structures"
 version = "0.0.0"
 dependencies = [
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "ena 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ena 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "graphviz 0.0.0",
  "jobserver 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4043,6 +4051,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum elasticlunr-rs 2.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a99a310cd1f9770e7bf8e48810c7bcbb0e078c8fb23a8c7bcf0da4c2bf61a455"
 "checksum ena 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f56c93cc076508c549d9bb747f79aa9b4eb098be7b8cad8830c3137ef52d1e00"
+"checksum ena 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1bc0780a33d340b98e80725a927ff9c3fe30eac92b414725968faeb49458df17"
 "checksum env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)" = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
 "checksum env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "afb070faf94c85d17d50ca44f6ad076bce18ae92f0037d350947240a36e9d42e"
 "checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "ena"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2670,7 +2670,7 @@ name = "rustc_data_structures"
 version = "0.0.0"
 dependencies = [
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "ena 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ena 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "graphviz 0.0.0",
  "jobserver 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4051,7 +4051,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum elasticlunr-rs 2.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a99a310cd1f9770e7bf8e48810c7bcbb0e078c8fb23a8c7bcf0da4c2bf61a455"
 "checksum ena 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f56c93cc076508c549d9bb747f79aa9b4eb098be7b8cad8830c3137ef52d1e00"
-"checksum ena 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1bc0780a33d340b98e80725a927ff9c3fe30eac92b414725968faeb49458df17"
+"checksum ena 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3dc01d68e08ca384955a3aeba9217102ca1aa85b6e168639bf27739f1d749d87"
 "checksum env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)" = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
 "checksum env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "afb070faf94c85d17d50ca44f6ad076bce18ae92f0037d350947240a36e9d42e"
 "checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"

--- a/src/librustc/infer/canonical/mod.rs
+++ b/src/librustc/infer/canonical/mod.rs
@@ -360,9 +360,9 @@ impl<'cx, 'gcx, 'tcx> InferCtxt<'cx, 'gcx, 'tcx> {
                         )
                     }
 
-                    CanonicalTyVarKind::Int => self.tcx.mk_int_var(self.next_int_var_id()),
+                    CanonicalTyVarKind::Int => self.next_int_var(),
 
-                    CanonicalTyVarKind::Float => self.tcx.mk_float_var(self.next_float_var_id()),
+                    CanonicalTyVarKind::Float => self.next_float_var(),
                 };
                 ty.into()
             }

--- a/src/librustc/infer/fudge.rs
+++ b/src/librustc/infer/fudge.rs
@@ -64,12 +64,12 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                     // going to be popped, so we will have to
                     // eliminate any references to them.
 
-                    let type_variables =
-                        self.type_variables.borrow_mut().types_created_since_snapshot(
-                            &snapshot.type_snapshot);
-                    let region_vars =
-                        self.borrow_region_constraints().vars_created_since_snapshot(
-                            &snapshot.region_constraints_snapshot);
+                    let type_variables = self.type_variables.borrow_mut().vars_since_snapshot(
+                        &snapshot.type_snapshot,
+                    );
+                    let region_vars = self.borrow_region_constraints().vars_since_snapshot(
+                        &snapshot.region_constraints_snapshot,
+                    );
 
                     Ok((type_variables, region_vars, value))
                 }

--- a/src/librustc/infer/fudge.rs
+++ b/src/librustc/infer/fudge.rs
@@ -62,7 +62,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                     let value = self.resolve_type_vars_if_possible(&value);
 
                     // At this point, `value` could in principle refer
-                    // to types/regions that have been created during
+                    // to inference variables that have been created during
                     // the snapshot. Once we exit `probe()`, those are
                     // going to be popped, so we will have to
                     // eliminate any references to them.
@@ -106,10 +106,10 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
             fudger.int_vars.is_empty() &&
             fudger.float_vars.is_empty() &&
             fudger.region_vars.is_empty() {
-            return Ok(value);
+            Ok(value)
+        } else {
+            Ok(value.fold_with(&mut fudger))
         }
-
-        Ok(value.fold_with(&mut fudger))
     }
 }
 
@@ -137,7 +137,7 @@ impl<'a, 'gcx, 'tcx> TypeFolder<'gcx, 'tcx> for InferenceFudger<'a, 'gcx, 'tcx> 
                     self.infcx.next_ty_var(origin)
                 } else {
                     // This variable was created before the
-                    // "fudging".  Since we refresh all type
+                    // "fudging". Since we refresh all type
                     // variables to their binding anyhow, we know
                     // that it is unbound, so we can just return
                     // it.

--- a/src/librustc/infer/fudge.rs
+++ b/src/librustc/infer/fudge.rs
@@ -149,14 +149,14 @@ impl<'a, 'gcx, 'tcx> TypeFolder<'gcx, 'tcx> for InferenceFudger<'a, 'gcx, 'tcx> 
             }
             ty::Infer(ty::InferTy::IntVar(vid)) => {
                 if self.int_vars.contains(&vid) {
-                    self.infcx.tcx.mk_int_var(self.infcx.next_int_var_id())
+                    self.infcx.next_int_var()
                 } else {
                     ty
                 }
             }
             ty::Infer(ty::InferTy::FloatVar(vid)) => {
                 if self.float_vars.contains(&vid) {
-                    self.infcx.tcx.mk_float_var(self.infcx.next_float_var_id())
+                    self.infcx.next_float_var()
                 } else {
                     ty
                 }

--- a/src/librustc/infer/mod.rs
+++ b/src/librustc/infer/mod.rs
@@ -999,12 +999,20 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
         self.tcx.mk_ty_var(self.next_ty_var_id(true, origin))
     }
 
-    pub fn next_int_var_id(&self) -> IntVid {
+    fn next_int_var_id(&self) -> IntVid {
         self.int_unification_table.borrow_mut().new_key(None)
     }
 
-    pub fn next_float_var_id(&self) -> FloatVid {
+    pub fn next_int_var(&self) -> Ty<'tcx> {
+        self.tcx.mk_int_var(self.next_int_var_id())
+    }
+
+    fn next_float_var_id(&self) -> FloatVid {
         self.float_unification_table.borrow_mut().new_key(None)
+    }
+
+    pub fn next_float_var(&self) -> Ty<'tcx> {
+        self.tcx.mk_float_var(self.next_float_var_id())
     }
 
     /// Creates a fresh region variable with the next available index.

--- a/src/librustc/infer/region_constraints/mod.rs
+++ b/src/librustc/infer/region_constraints/mod.rs
@@ -16,6 +16,7 @@ use crate::ty::{Region, RegionVid};
 
 use std::collections::BTreeMap;
 use std::{cmp, fmt, mem, u32};
+use std::ops::Range;
 
 mod leak_check;
 
@@ -840,8 +841,8 @@ impl<'tcx> RegionConstraintCollector<'tcx> {
         }
     }
 
-    pub fn vars_since_snapshot(&self, mark: &RegionSnapshot) -> Vec<RegionVid> {
-        self.unification_table.vars_since_snapshot(&mark.region_snapshot).collect()
+    pub fn vars_since_snapshot(&self, mark: &RegionSnapshot) -> Range<RegionVid> {
+        self.unification_table.vars_since_snapshot(&mark.region_snapshot)
     }
 
     /// See [`RegionInference::region_constraints_added_in_snapshot`].

--- a/src/librustc/infer/region_constraints/mod.rs
+++ b/src/librustc/infer/region_constraints/mod.rs
@@ -840,7 +840,7 @@ impl<'tcx> RegionConstraintCollector<'tcx> {
         }
     }
 
-    pub fn vars_created_since_snapshot(&self, mark: &RegionSnapshot) -> Vec<RegionVid> {
+    pub fn vars_since_snapshot(&self, mark: &RegionSnapshot) -> Vec<RegionVid> {
         self.undo_log[mark.length..]
             .iter()
             .filter_map(|&elt| match elt {

--- a/src/librustc/infer/region_constraints/mod.rs
+++ b/src/librustc/infer/region_constraints/mod.rs
@@ -841,12 +841,7 @@ impl<'tcx> RegionConstraintCollector<'tcx> {
     }
 
     pub fn vars_since_snapshot(&self, mark: &RegionSnapshot) -> Vec<RegionVid> {
-        self.undo_log[mark.length..]
-            .iter()
-            .filter_map(|&elt| match elt {
-                AddVar(vid) => Some(vid),
-                _ => None,
-            }).collect()
+        self.unification_table.vars_since_snapshot(&mark.region_snapshot).collect()
     }
 
     /// See [`RegionInference::region_constraints_added_in_snapshot`].

--- a/src/librustc/infer/region_constraints/mod.rs
+++ b/src/librustc/infer/region_constraints/mod.rs
@@ -16,6 +16,7 @@ use crate::ty::{Region, RegionVid};
 
 use std::collections::BTreeMap;
 use std::{cmp, fmt, mem, u32};
+use std::ops::Range;
 
 mod leak_check;
 
@@ -843,13 +844,11 @@ impl<'tcx> RegionConstraintCollector<'tcx> {
     pub fn vars_since_snapshot(
         &self,
         mark: &RegionSnapshot,
-    ) -> FxHashMap<RegionVid, RegionVariableOrigin> {
+    ) -> (Range<RegionVid>, Vec<RegionVariableOrigin>) {
         let range = self.unification_table.vars_since_snapshot(&mark.region_snapshot);
-        (range.start.index()..range.end.index()).map(|index| {
-            let vid = ty::RegionVid::from(index);
-            let origin = self.var_infos[vid].origin.clone();
-            (vid, origin)
-        }).collect()
+        (range.clone(), (range.start.index()..range.end.index()).map(|index| {
+            self.var_infos[ty::RegionVid::from(index)].origin.clone()
+        }).collect())
     }
 
     /// See [`RegionInference::region_constraints_added_in_snapshot`].

--- a/src/librustc/infer/type_variable.rs
+++ b/src/librustc/infer/type_variable.rs
@@ -60,8 +60,6 @@ pub enum TypeVariableOrigin {
     Generalized(ty::TyVid),
 }
 
-pub type TypeVariableMap = FxHashMap<ty::TyVid, TypeVariableOrigin>;
-
 struct TypeVariableData {
     origin: TypeVariableOrigin,
     diverging: bool,

--- a/src/librustc/infer/type_variable.rs
+++ b/src/librustc/infer/type_variable.rs
@@ -292,11 +292,9 @@ impl<'tcx> TypeVariableTable<'tcx> {
         self.sub_relations.commit(sub_snapshot);
     }
 
-    /// Returns a map `{V1 -> V2}`, where the keys `{V1}` are
-    /// ty-variables created during the snapshot, and the values
-    /// `{V2}` are the root variables that they were unified with,
-    /// along with their origin.
-    pub fn types_created_since_snapshot(&mut self, s: &Snapshot<'tcx>) -> TypeVariableMap {
+    /// Returns a map from the type variables created during the
+    /// snapshot to the origin of the type variable.
+    pub fn vars_since_snapshot(&mut self, s: &Snapshot<'tcx>) -> TypeVariableMap {
         let actions_since_snapshot = self.values.actions_since_snapshot(&s.snapshot);
 
         actions_since_snapshot

--- a/src/librustc/infer/type_variable.rs
+++ b/src/librustc/infer/type_variable.rs
@@ -295,19 +295,10 @@ impl<'tcx> TypeVariableTable<'tcx> {
     /// Returns a map from the type variables created during the
     /// snapshot to the origin of the type variable.
     pub fn vars_since_snapshot(&mut self, s: &Snapshot<'tcx>) -> TypeVariableMap {
-        let actions_since_snapshot = self.values.actions_since_snapshot(&s.snapshot);
-
-        actions_since_snapshot
-            .iter()
-            .filter_map(|action| match action {
-                &sv::UndoLog::NewElem(index) => Some(ty::TyVid { index: index as u32 }),
-                _ => None,
-            })
-            .map(|vid| {
-                let origin = self.values.get(vid.index as usize).origin.clone();
-                (vid, origin)
-            })
-            .collect()
+        self.values.values_since_snapshot(&s.snapshot).map(|idx| {
+            let origin = self.values.get(idx).origin.clone();
+            (ty::TyVid { index: idx as u32 }, origin)
+        }).collect()
     }
 
     /// Finds the set of type variables that existed *before* `s`

--- a/src/librustc/infer/type_variable.rs
+++ b/src/librustc/infer/type_variable.rs
@@ -6,7 +6,6 @@ use std::cmp;
 use std::marker::PhantomData;
 use std::ops::Range;
 use std::u32;
-use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::snapshot_vec as sv;
 use rustc_data_structures::unify as ut;
 use ut::UnifyKey;

--- a/src/librustc/infer/type_variable.rs
+++ b/src/librustc/infer/type_variable.rs
@@ -5,7 +5,7 @@ use crate::ty::{self, Ty, TyVid};
 use std::cmp;
 use std::marker::PhantomData;
 use std::u32;
-use rustc_data_structures::fx::FxHashMap;
+use std::ops::Range;
 use rustc_data_structures::snapshot_vec as sv;
 use rustc_data_structures::unify as ut;
 
@@ -294,12 +294,11 @@ impl<'tcx> TypeVariableTable<'tcx> {
     pub fn vars_since_snapshot(
         &mut self,
         s: &Snapshot<'tcx>,
-    ) -> FxHashMap<TyVid, TypeVariableOrigin> {
+    ) -> (Range<TyVid>, Vec<TypeVariableOrigin>) {
         let range = self.eq_relations.vars_since_snapshot(&s.eq_snapshot);
-        (range.start.vid.index..range.end.vid.index).map(|index| {
-            let origin = self.values.get(index as usize).origin.clone();
-            (TyVid { index }, origin)
-        }).collect()
+        (range.start.vid..range.end.vid, (range.start.vid.index..range.end.vid.index).map(|index| {
+            self.values.get(index as usize).origin.clone()
+        }).collect())
     }
 
     /// Finds the set of type variables that existed *before* `s`

--- a/src/librustc/infer/type_variable.rs
+++ b/src/librustc/infer/type_variable.rs
@@ -8,7 +8,6 @@ use std::ops::Range;
 use std::u32;
 use rustc_data_structures::snapshot_vec as sv;
 use rustc_data_structures::unify as ut;
-use ut::UnifyKey;
 
 pub struct TypeVariableTable<'tcx> {
     values: sv::SnapshotVec<Delegate>,
@@ -291,11 +290,10 @@ impl<'tcx> TypeVariableTable<'tcx> {
         self.sub_relations.commit(sub_snapshot);
     }
 
-    /// Returns a map from the type variables created during the
-    /// snapshot to the origin of the type variable.
+    /// Returns a range of the type variables created during the snapshot.
     pub fn vars_since_snapshot(&mut self, s: &Snapshot<'tcx>) -> Range<TyVid> {
-        let range = self.values.values_since_snapshot(&s.snapshot);
-        TyVid::from_index(range.start as u32)..TyVid::from_index(range.end as u32)
+        let range = self.eq_relations.vars_since_snapshot(&s.eq_snapshot);
+        range.start.vid..range.end.vid
     }
 
     /// Finds the set of type variables that existed *before* `s`

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -44,6 +44,7 @@
 #![feature(non_exhaustive)]
 #![feature(proc_macro_internals)]
 #![feature(optin_builtin_traits)]
+#![feature(range_is_empty)]
 #![feature(refcell_replace_swap)]
 #![feature(rustc_diagnostic_macros)]
 #![feature(rustc_attrs)]

--- a/src/librustc_data_structures/Cargo.toml
+++ b/src/librustc_data_structures/Cargo.toml
@@ -10,7 +10,7 @@ path = "lib.rs"
 crate-type = ["dylib"]
 
 [dependencies]
-ena = "0.12"
+ena = "0.13"
 log = "0.4"
 jobserver_crate = { version = "0.1", package = "jobserver" }
 lazy_static = "1"

--- a/src/librustc_data_structures/Cargo.toml
+++ b/src/librustc_data_structures/Cargo.toml
@@ -10,7 +10,7 @@ path = "lib.rs"
 crate-type = ["dylib"]
 
 [dependencies]
-ena = "0.11"
+ena = "0.12"
 log = "0.4"
 jobserver_crate = { version = "0.1", package = "jobserver" }
 lazy_static = "1"

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3097,8 +3097,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                         _ => None
                     }
                 });
-                opt_ty.unwrap_or_else(
-                    || tcx.mk_int_var(self.next_int_var_id()))
+                opt_ty.unwrap_or_else(|| self.next_int_var())
             }
             ast::LitKind::Float(_, t) => tcx.mk_mach_float(t),
             ast::LitKind::FloatUnsuffixed(_) => {
@@ -3108,8 +3107,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                         _ => None
                     }
                 });
-                opt_ty.unwrap_or_else(
-                    || tcx.mk_float_var(self.next_float_var_id()))
+                opt_ty.unwrap_or_else(|| self.next_float_var())
             }
             ast::LitKind::Bool(_) => tcx.types.bool,
             ast::LitKind::Err(_) => tcx.types.err,

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3229,7 +3229,8 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
             Some(ret) => ret,
             None => return Vec::new()
         };
-        let expect_args = self.fudge_inference_if_ok(&RegionVariableOrigin::Coercion(call_span), || {
+        let origin = RegionVariableOrigin::Coercion(call_span);
+        let expect_args = self.fudge_inference_if_ok(&origin, || {
             // Attempt to apply a subtyping relationship between the formal
             // return type (likely containing type variables if the function
             // is polymorphic) and the expected return type.

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3231,7 +3231,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
             Some(ret) => ret,
             None => return Vec::new()
         };
-        let expect_args = self.fudge_regions_if_ok(&RegionVariableOrigin::Coercion(call_span), || {
+        let expect_args = self.fudge_inference_if_ok(&RegionVariableOrigin::Coercion(call_span), || {
             // Attempt to apply a subtyping relationship between the formal
             // return type (likely containing type variables if the function
             // is polymorphic) and the expected return type.

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -92,7 +92,7 @@ use rustc::hir::intravisit::{self, Visitor, NestedVisitorMap};
 use rustc::hir::itemlikevisit::ItemLikeVisitor;
 use crate::middle::lang_items;
 use crate::namespace::Namespace;
-use rustc::infer::{self, InferCtxt, InferOk, InferResult, RegionVariableOrigin};
+use rustc::infer::{self, InferCtxt, InferOk, InferResult};
 use rustc::infer::canonical::{Canonical, OriginalQueryValues, QueryResponse};
 use rustc_data_structures::indexed_vec::Idx;
 use rustc_data_structures::sync::Lrc;
@@ -3229,8 +3229,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
             Some(ret) => ret,
             None => return Vec::new()
         };
-        let origin = RegionVariableOrigin::Coercion(call_span);
-        let expect_args = self.fudge_inference_if_ok(&origin, || {
+        let expect_args = self.fudge_inference_if_ok(|| {
             // Attempt to apply a subtyping relationship between the formal
             // return type (likely containing type variables if the function
             // is polymorphic) and the expected return type.


### PR DESCRIPTION
- Rename `RegionFudger` (and related methods) to `InferenceFudger`.
- Take integer and float inference variables into account.
- Refactor `types_created_since_snapshot` and `vars_created_since_snapshot` with the [new version of ena](https://github.com/rust-lang-nursery/ena/pull/21).
- Some other refactoring in the area.

r? @eddyb 