### PR TITLE
Reject integer suffix when tuple indexing

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3205,14 +3205,7 @@ impl<'a> Parser<'a> {
                         let field = ExprKind::Field(e, Ident::new(name, span));
                         e = self.mk_expr(lo.to(span), field, ThinVec::new());
 
-                        if let Some(suffix) = suffix {
-                            let mut err = self.diagnostic().struct_span_err(
-                                span,
-                                "suffixes on tuple indexes are invalid",
-                            );
-                            err.span_label(span, format!("invalid suffix `{}`", suffix));
-                            err.emit();
-                        }
+                        self.expect_no_suffix(span, "tuple index", suffix);
                     }
                     token::Literal(token::Float(n), _suf) => {
                       self.bump();

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1119,9 +1119,8 @@ impl<'a> Parser<'a> {
                 if text.is_empty() {
                     self.span_bug(sp, "found empty literal suffix in Some")
                 }
-                let msg = format!("{} with a suffix is invalid", kind);
-                self.struct_span_err(sp, &msg)
-                    .span_label(sp, msg)
+                self.struct_span_err(sp, &format!("suffixes on {} are invalid", kind))
+                    .span_label(sp, format!("invalid suffix `{}`", text))
                     .emit();
             }
         }
@@ -2150,7 +2149,7 @@ impl<'a> Parser<'a> {
 
                 if suffix_illegal {
                     let sp = self.span;
-                    self.expect_no_suffix(sp, lit.literal_name(), suf)
+                    self.expect_no_suffix(sp, &format!("a {}", lit.literal_name()), suf)
                 }
 
                 result.unwrap()
@@ -3205,7 +3204,7 @@ impl<'a> Parser<'a> {
                         let field = ExprKind::Field(e, Ident::new(name, span));
                         e = self.mk_expr(lo.to(span), field, ThinVec::new());
 
-                        self.expect_no_suffix(span, "tuple index", suffix);
+                        self.expect_no_suffix(span, "a tuple index", suffix);
                     }
                     token::Literal(token::Float(n), _suf) => {
                       self.bump();
@@ -7791,7 +7790,7 @@ impl<'a> Parser<'a> {
         match self.token {
             token::Literal(token::Str_(s), suf) | token::Literal(token::StrRaw(s, _), suf) => {
                 let sp = self.span;
-                self.expect_no_suffix(sp, "ABI spec", suf);
+                self.expect_no_suffix(sp, "an ABI spec", suf);
                 self.bump();
                 match abi::lookup(&s.as_str()) {
                     Some(abi) => Ok(Some(abi)),
@@ -8612,7 +8611,7 @@ impl<'a> Parser<'a> {
         match self.parse_optional_str() {
             Some((s, style, suf)) => {
                 let sp = self.prev_span;
-                self.expect_no_suffix(sp, "string literal", suf);
+                self.expect_no_suffix(sp, "a string literal", suf);
                 Ok((s, style))
             }
             _ => {

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3208,7 +3208,7 @@ impl<'a> Parser<'a> {
                         if let Some(suffix) = suffix {
                             let mut err = self.diagnostic().struct_span_err(
                                 span,
-                                "tuple index with a suffix is invalid",
+                                "suffixes on tuple indexes are invalid",
                             );
                             err.span_label(span, format!("invalid suffix `{}`", suffix));
                             err.emit();

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2491,7 +2491,8 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_field_name(&mut self) -> PResult<'a, Ident> {
-        if let token::Literal(token::Integer(name), None) = self.token {
+        if let token::Literal(token::Integer(name), suffix) = self.token {
+            self.expect_no_suffix(self.span, "a tuple index", suffix);
             self.bump();
             Ok(Ident::new(name, self.prev_span))
         } else {

--- a/src/test/ui/parser/bad-lit-suffixes.rs
+++ b/src/test/ui/parser/bad-lit-suffixes.rs
@@ -2,20 +2,20 @@
 
 
 extern
-    "C"suffix //~ ERROR ABI spec with a suffix is invalid
+    "C"suffix //~ ERROR suffixes on an ABI spec are invalid
     fn foo() {}
 
 extern
-    "C"suffix //~ ERROR ABI spec with a suffix is invalid
+    "C"suffix //~ ERROR suffixes on an ABI spec are invalid
 {}
 
 fn main() {
-    ""suffix; //~ ERROR string literal with a suffix is invalid
-    b""suffix; //~ ERROR byte string literal with a suffix is invalid
-    r#""#suffix; //~ ERROR string literal with a suffix is invalid
-    br#""#suffix; //~ ERROR byte string literal with a suffix is invalid
-    'a'suffix; //~ ERROR char literal with a suffix is invalid
-    b'a'suffix; //~ ERROR byte literal with a suffix is invalid
+    ""suffix; //~ ERROR suffixes on a string literal are invalid
+    b""suffix; //~ ERROR suffixes on a byte string literal are invalid
+    r#""#suffix; //~ ERROR suffixes on a string literal are invalid
+    br#""#suffix; //~ ERROR suffixes on a byte string literal are invalid
+    'a'suffix; //~ ERROR suffixes on a char literal are invalid
+    b'a'suffix; //~ ERROR suffixes on a byte literal are invalid
 
     1234u1024; //~ ERROR invalid width `1024` for integer literal
     1234i1024; //~ ERROR invalid width `1024` for integer literal

--- a/src/test/ui/parser/bad-lit-suffixes.stderr
+++ b/src/test/ui/parser/bad-lit-suffixes.stderr
@@ -1,50 +1,50 @@
-error: ABI spec with a suffix is invalid
+error: suffixes on an ABI spec are invalid
   --> $DIR/bad-lit-suffixes.rs:5:5
    |
 LL |     "C"suffix
-   |     ^^^^^^^^^ ABI spec with a suffix is invalid
+   |     ^^^^^^^^^ invalid suffix `suffix`
 
-error: ABI spec with a suffix is invalid
+error: suffixes on an ABI spec are invalid
   --> $DIR/bad-lit-suffixes.rs:9:5
    |
 LL |     "C"suffix
-   |     ^^^^^^^^^ ABI spec with a suffix is invalid
+   |     ^^^^^^^^^ invalid suffix `suffix`
 
-error: string literal with a suffix is invalid
+error: suffixes on a string literal are invalid
   --> $DIR/bad-lit-suffixes.rs:13:5
    |
 LL |     ""suffix;
-   |     ^^^^^^^^ string literal with a suffix is invalid
+   |     ^^^^^^^^ invalid suffix `suffix`
 
-error: byte string literal with a suffix is invalid
+error: suffixes on a byte string literal are invalid
   --> $DIR/bad-lit-suffixes.rs:14:5
    |
 LL |     b""suffix;
-   |     ^^^^^^^^^ byte string literal with a suffix is invalid
+   |     ^^^^^^^^^ invalid suffix `suffix`
 
-error: string literal with a suffix is invalid
+error: suffixes on a string literal are invalid
   --> $DIR/bad-lit-suffixes.rs:15:5
    |
 LL |     r#""#suffix;
-   |     ^^^^^^^^^^^ string literal with a suffix is invalid
+   |     ^^^^^^^^^^^ invalid suffix `suffix`
 
-error: byte string literal with a suffix is invalid
+error: suffixes on a byte string literal are invalid
   --> $DIR/bad-lit-suffixes.rs:16:5
    |
 LL |     br#""#suffix;
-   |     ^^^^^^^^^^^^ byte string literal with a suffix is invalid
+   |     ^^^^^^^^^^^^ invalid suffix `suffix`
 
-error: char literal with a suffix is invalid
+error: suffixes on a char literal are invalid
   --> $DIR/bad-lit-suffixes.rs:17:5
    |
 LL |     'a'suffix;
-   |     ^^^^^^^^^ char literal with a suffix is invalid
+   |     ^^^^^^^^^ invalid suffix `suffix`
 
-error: byte literal with a suffix is invalid
+error: suffixes on a byte literal are invalid
   --> $DIR/bad-lit-suffixes.rs:18:5
    |
 LL |     b'a'suffix;
-   |     ^^^^^^^^^^ byte literal with a suffix is invalid
+   |     ^^^^^^^^^^ invalid suffix `suffix`
 
 error: invalid width `1024` for integer literal
   --> $DIR/bad-lit-suffixes.rs:20:5

--- a/src/test/ui/parser/issue-59418.rs
+++ b/src/test/ui/parser/issue-59418.rs
@@ -3,11 +3,10 @@ struct X(i32,i32,i32);
 fn main() {
     let a = X(1, 2, 3);
     let b = a.1suffix;
-    //~^ ERROR suffixes on tuple indexes are invalid
+    //~^ ERROR tuple index with a suffix is invalid
     println!("{}", b);
     let c = (1, 2, 3);
     let d = c.1suffix;
-    //~^ ERROR suffixes on tuple indexes are invalid
+    //~^ ERROR tuple index with a suffix is invalid
     println!("{}", d);
 }
-

--- a/src/test/ui/parser/issue-59418.rs
+++ b/src/test/ui/parser/issue-59418.rs
@@ -3,10 +3,10 @@ struct X(i32,i32,i32);
 fn main() {
     let a = X(1, 2, 3);
     let b = a.1suffix;
-    //~^ ERROR tuple index with a suffix is invalid
+    //~^ ERROR suffixes on a tuple index are invalid
     println!("{}", b);
     let c = (1, 2, 3);
     let d = c.1suffix;
-    //~^ ERROR tuple index with a suffix is invalid
+    //~^ ERROR suffixes on a tuple index are invalid
     println!("{}", d);
 }

--- a/src/test/ui/parser/issue-59418.rs
+++ b/src/test/ui/parser/issue-59418.rs
@@ -9,4 +9,10 @@ fn main() {
     let d = c.1suffix;
     //~^ ERROR suffixes on a tuple index are invalid
     println!("{}", d);
+    let s = X { 0suffix: 0, 1: 1, 2: 2 };
+    //~^ ERROR suffixes on a tuple index are invalid
+    match s {
+        X { 0suffix: _, .. } => {}
+        //~^ ERROR suffixes on a tuple index are invalid
+    }
 }

--- a/src/test/ui/parser/issue-59418.rs
+++ b/src/test/ui/parser/issue-59418.rs
@@ -1,0 +1,9 @@
+struct X(i32,i32,i32);
+
+fn main() {
+    let a = X(1, 2, 3);
+    let b = a.1suffix;
+    //~^ ERROR tuple index with a suffix is invalid
+    println!("{}", b);
+}
+

--- a/src/test/ui/parser/issue-59418.rs
+++ b/src/test/ui/parser/issue-59418.rs
@@ -3,7 +3,11 @@ struct X(i32,i32,i32);
 fn main() {
     let a = X(1, 2, 3);
     let b = a.1suffix;
-    //~^ ERROR tuple index with a suffix is invalid
+    //~^ ERROR suffixes on tuple indexes are invalid
     println!("{}", b);
+    let c = (1, 2, 3);
+    let d = c.1suffix;
+    //~^ ERROR suffixes on tuple indexes are invalid
+    println!("{}", d);
 }
 

--- a/src/test/ui/parser/issue-59418.stderr
+++ b/src/test/ui/parser/issue-59418.stderr
@@ -1,14 +1,14 @@
-error: suffixes on tuple indexes are invalid
+error: tuple index with a suffix is invalid
   --> $DIR/issue-59418.rs:5:15
    |
 LL |     let b = a.1suffix;
-   |               ^^^^^^^ invalid suffix `suffix`
+   |               ^^^^^^^ tuple index with a suffix is invalid
 
-error: suffixes on tuple indexes are invalid
+error: tuple index with a suffix is invalid
   --> $DIR/issue-59418.rs:9:15
    |
 LL |     let d = c.1suffix;
-   |               ^^^^^^^ invalid suffix `suffix`
+   |               ^^^^^^^ tuple index with a suffix is invalid
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/parser/issue-59418.stderr
+++ b/src/test/ui/parser/issue-59418.stderr
@@ -1,14 +1,14 @@
-error: tuple index with a suffix is invalid
+error: suffixes on a tuple index are invalid
   --> $DIR/issue-59418.rs:5:15
    |
 LL |     let b = a.1suffix;
-   |               ^^^^^^^ tuple index with a suffix is invalid
+   |               ^^^^^^^ invalid suffix `suffix`
 
-error: tuple index with a suffix is invalid
+error: suffixes on a tuple index are invalid
   --> $DIR/issue-59418.rs:9:15
    |
 LL |     let d = c.1suffix;
-   |               ^^^^^^^ tuple index with a suffix is invalid
+   |               ^^^^^^^ invalid suffix `suffix`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/parser/issue-59418.stderr
+++ b/src/test/ui/parser/issue-59418.stderr
@@ -1,0 +1,8 @@
+error: tuple index with a suffix is invalid
+  --> $DIR/issue-59418.rs:5:15
+   |
+LL |     let b = a.1suffix;
+   |               ^^^^^^^ invalid suffix `suffix`
+
+error: aborting due to previous error
+

--- a/src/test/ui/parser/issue-59418.stderr
+++ b/src/test/ui/parser/issue-59418.stderr
@@ -1,8 +1,14 @@
-error: tuple index with a suffix is invalid
+error: suffixes on tuple indexes are invalid
   --> $DIR/issue-59418.rs:5:15
    |
 LL |     let b = a.1suffix;
    |               ^^^^^^^ invalid suffix `suffix`
 
-error: aborting due to previous error
+error: suffixes on tuple indexes are invalid
+  --> $DIR/issue-59418.rs:9:15
+   |
+LL |     let d = c.1suffix;
+   |               ^^^^^^^ invalid suffix `suffix`
+
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/parser/issue-59418.stderr
+++ b/src/test/ui/parser/issue-59418.stderr
@@ -10,5 +10,17 @@ error: suffixes on a tuple index are invalid
 LL |     let d = c.1suffix;
    |               ^^^^^^^ invalid suffix `suffix`
 
-error: aborting due to 2 previous errors
+error: suffixes on a tuple index are invalid
+  --> $DIR/issue-59418.rs:12:17
+   |
+LL |     let s = X { 0suffix: 0, 1: 1, 2: 2 };
+   |                 ^^^^^^^ invalid suffix `suffix`
+
+error: suffixes on a tuple index are invalid
+  --> $DIR/issue-59418.rs:15:13
+   |
+LL |         X { 0suffix: _, .. } => {}
+   |             ^^^^^^^ invalid suffix `suffix`
+
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Fix #59418.

r? @varkor 