### PR TITLE
Fix code block display in portability element in dark theme

### DIFF
--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -189,6 +189,10 @@ a.test-arrow {
 .stab.deprecated { background: #F3DFFF; border-color: #7F0087; color: #2f2f2f; }
 .stab.portability { background: #C4ECFF; border-color: #7BA5DB; color: #2f2f2f; }
 
+.stab > code {
+	color: #ddd;
+}
+
 #help > div {
 	background: #4d4d4d;
 	border-color: #bfbfbf;

--- a/src/librustdoc/html/static/themes/light.css
+++ b/src/librustdoc/html/static/themes/light.css
@@ -190,6 +190,10 @@ a.test-arrow {
 .stab.deprecated { background: #F3DFFF; border-color: #7F0087; }
 .stab.portability { background: #C4ECFF; border-color: #7BA5DB; }
 
+.stab > code {
+	color: #000;
+}
+
 #help > div {
 	background: #e9e9e9;
 	border-color: #bfbfbf;


### PR DESCRIPTION
Fixes #59261.

r? @QuietMisdreavus 

A little screenshot:

<img width="521" alt="Screenshot 2019-03-26 at 00 37 49" src="https://user-images.githubusercontent.com/3050060/54961082-9a41c600-4f5f-11e9-8040-ae6f26d368ff.png">
