### PR TITLE
Improve some compiletest documentation

### DIFF
--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -117,6 +117,7 @@ impl CompareMode {
     }
 }
 
+/// Configuration for compiletest
 #[derive(Clone)]
 pub struct Config {
     /// `true` to to overwrite stderr/stdout files instead of complaining about changes in output.
@@ -254,6 +255,8 @@ pub struct Config {
     pub linker: Option<String>,
     pub llvm_components: String,
     pub llvm_cxxflags: String,
+
+    /// Path to a NodeJS executable. Used for JS doctests, emscripten and WASM tests
     pub nodejs: Option<String>,
 }
 

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -333,7 +333,10 @@ pub struct TestProps {
     pub normalize_stdout: Vec<(String, String)>,
     pub normalize_stderr: Vec<(String, String)>,
     pub failure_status: i32,
+    // Whether or not `rustfix` should apply the `CodeSuggestion`s of this test and compile the
+    // resulting Rust code.
     pub run_rustfix: bool,
+    // If true, `rustfix` will only apply `MachineApplicable` suggestions.
     pub rustfix_only_machine_applicable: bool,
     pub assembly_output: Option<String>,
 }

--- a/src/tools/compiletest/src/json.rs
+++ b/src/tools/compiletest/src/json.rs
@@ -1,11 +1,11 @@
+//! These structs are a subset of the ones found in `syntax::json`.
+//! They are only used for deserialization of JSON output provided by libtest.
+
 use crate::errors::{Error, ErrorKind};
 use crate::runtest::ProcRes;
 use serde_json;
 use std::path::Path;
 use std::str::FromStr;
-
-// These structs are a subset of the ones found in
-// `syntax::json`.
 
 #[derive(Deserialize)]
 struct Diagnostic {

--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -598,6 +598,8 @@ fn collect_tests_from_dir(
     Ok(())
 }
 
+
+/// Returns true if `file_name` looks like a proper test file name.
 pub fn is_test(file_name: &OsString) -> bool {
     let file_name = file_name.to_str().unwrap();
 
@@ -1047,4 +1049,13 @@ fn test_extract_gdb_version() {
         7012000: "GNU gdb (GDB) 7.12.20161027-git",
         7012050: "GNU gdb (GDB) 7.12.50.20161027-git",
     }
+}
+
+#[test]
+fn is_test_test() {
+    assert_eq!(true, is_test(&OsString::from("a_test.rs")));
+    assert_eq!(false, is_test(&OsString::from(".a_test.rs")));
+    assert_eq!(false, is_test(&OsString::from("a_cat.gif")));
+    assert_eq!(false, is_test(&OsString::from("#a_dog_gif")));
+    assert_eq!(false, is_test(&OsString::from("~a_temp_file")));
 }


### PR DESCRIPTION
This adds some missing documentation for rustfix related things and adds
a test for the `is_test` function.