### PR TITLE
Bump bootstrap compiler to 2019-03-20

### DIFF
--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -2913,7 +2913,7 @@ impl<T: Sized> NonNull<T> {
     /// some other means.
     #[stable(feature = "nonnull", since = "1.25.0")]
     #[inline]
-    #[cfg_attr(not(stage0), rustc_const_unstable(feature = "const_ptr_nonnull"))]
+    #[rustc_const_unstable(feature = "const_ptr_nonnull")]
     pub const fn dangling() -> Self {
         unsafe {
             let ptr = mem::align_of::<T>() as *mut T;
@@ -2977,7 +2977,7 @@ impl<T: ?Sized> NonNull<T> {
     /// Cast to a pointer of another type
     #[stable(feature = "nonnull_cast", since = "1.27.0")]
     #[inline]
-    #[cfg_attr(not(stage0), rustc_const_unstable(feature = "const_ptr_nonnull"))]
+    #[rustc_const_unstable(feature = "const_ptr_nonnull")]
     pub const fn cast<U>(self) -> NonNull<U> {
         unsafe {
             NonNull::new_unchecked(self.as_ptr() as *mut U)

--- a/src/libsyntax_pos/lib.rs
+++ b/src/libsyntax_pos/lib.rs
@@ -17,7 +17,6 @@
 #![feature(rustc_attrs)]
 #![feature(specialization)]
 #![feature(step_trait)]
-#![cfg_attr(not(stage0), feature(stdsimd))]
 
 use serialize::{Encodable, Decodable, Encoder, Decoder};
 

--- a/src/stage0.txt
+++ b/src/stage0.txt
@@ -12,7 +12,7 @@
 # source tarball for a stable release you'll likely see `1.x.0` for rustc and
 # `0.x.0` for Cargo where they were released on `date`.
 
-date: 2019-02-27
+date: 2019-03-20
 rustc: beta
 cargo: beta
 


### PR DESCRIPTION
Includes https://github.com/rust-lang/rust/pull/59295 and by extension https://github.com/rust-lang/rust/pull/59047, which unblocks https://github.com/rust-lang/rust/pull/58253, https://github.com/rust-lang/rust/pull/58837, and possibly https://github.com/rust-lang/rust/pull/59336, and so therefore:

@bors p=50

r? @Mark-Simulacrum 

cc @pietroalbini 

