### PR TITLE
Do not emit incorrect borrow suggestion involving macros and fix overlapping multiline spans

### DIFF
--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -314,8 +314,13 @@ impl EmitterWriter {
                 //  | |______foo
                 //  |        baz
                 add_annotation_to_file(&mut output, file.clone(), ann.line_start, ann.as_start());
+                // 4 is the minimum vertical length of a multiline span when presented: two lines
+                // of code and two lines of underline. This is not true for the special case where
+                // the beginning doesn't have an underline, but the current logic seems to be
+                // working correctly.
                 let middle = min(ann.line_start + 4, ann.line_end);
                 for line in ann.line_start + 1..middle {
+                    // Every `|` that joins the beginning of the span (`___^`) to the end (`|__^`).
                     add_annotation_to_file(&mut output, file.clone(), line, ann.as_line());
                 }
                 if middle < ann.line_end - 1 {

--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -243,7 +243,7 @@ impl EmitterWriter {
                         end_col: hi.col_display,
                         is_primary: span_label.is_primary,
                         label: span_label.label.clone(),
-                        overlaps: false,
+                        overlaps_exactly: false,
                     };
                     multiline_annotations.push((lo.file.clone(), ml.clone()));
                     AnnotationType::Multiline(ml)
@@ -277,7 +277,7 @@ impl EmitterWriter {
                 {
                     a.increase_depth();
                 } else if ann.same_span(a) && &ann != a {
-                    a.overlaps = true;
+                    a.overlaps_exactly = true;
                 } else {
                     break;
                 }
@@ -290,7 +290,7 @@ impl EmitterWriter {
                 max_depth = ann.depth;
             }
             let mut end_ann = ann.as_end();
-            if !ann.overlaps {
+            if !ann.overlaps_exactly {
                 // avoid output like
                 //
                 //  |        foo(

--- a/src/librustc_errors/snippet.rs
+++ b/src/librustc_errors/snippet.rs
@@ -18,11 +18,18 @@ pub struct MultilineAnnotation {
     pub end_col: usize,
     pub is_primary: bool,
     pub label: Option<String>,
+    pub overlaps: bool,
 }
 
 impl MultilineAnnotation {
     pub fn increase_depth(&mut self) {
         self.depth += 1;
+    }
+
+    /// Compare two `MultilineAnnotation`s considering only the `Span` they cover.
+    pub fn same_span(&self, other: &MultilineAnnotation) -> bool {
+        self.line_start == other.line_start && self.line_end == other.line_end
+            && self.start_col == other.start_col && self.end_col == other.end_col
     }
 
     pub fn as_start(&self) -> Annotation {

--- a/src/librustc_errors/snippet.rs
+++ b/src/librustc_errors/snippet.rs
@@ -18,7 +18,7 @@ pub struct MultilineAnnotation {
     pub end_col: usize,
     pub is_primary: bool,
     pub label: Option<String>,
-    pub overlaps: bool,
+    pub overlaps_exactly: bool,
 }
 
 impl MultilineAnnotation {

--- a/src/librustc_typeck/check/demand.rs
+++ b/src/librustc_typeck/check/demand.rs
@@ -10,7 +10,7 @@ use rustc::hir::Node;
 use rustc::hir::{Item, ItemKind, print};
 use rustc::ty::{self, Ty, AssociatedItem};
 use rustc::ty::adjustment::AllowTwoPhase;
-use errors::{Applicability, DiagnosticBuilder, SourceMapper};
+use errors::{Applicability, DiagnosticBuilder};
 
 use super::method::probe;
 
@@ -271,9 +271,10 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                  expected: Ty<'tcx>)
                  -> Option<(Span, &'static str, String)> {
         let cm = self.sess().source_map();
-        // Use the callsite's span if this is a macro call. #41858
-        let sp = cm.call_span_if_macro(expr.span);
+        let sp = expr.span;
         if !cm.span_to_filename(sp).is_real() {
+            // Ignore if span is from within a macro #41858, #58298. We previously used the macro
+            // call span, but that breaks down when the type error comes from multiple calls down.
             return None;
         }
 

--- a/src/libsyntax/test_snippet.rs
+++ b/src/libsyntax/test_snippet.rs
@@ -375,6 +375,66 @@ error: foo
 }
 
 #[test]
+fn triple_exact_overlap() {
+    test_harness(r#"
+fn foo() {
+  X0 Y0 Z0
+  X1 Y1 Z1
+  X2 Y2 Z2
+}
+"#,
+    vec![
+        SpanLabel {
+            start: Position {
+                string: "X0",
+                count: 1,
+            },
+            end: Position {
+                string: "X2",
+                count: 1,
+            },
+            label: "`X` is a good letter",
+        },
+        SpanLabel {
+            start: Position {
+                string: "X0",
+                count: 1,
+            },
+            end: Position {
+                string: "X2",
+                count: 1,
+            },
+            label: "`Y` is a good letter too",
+        },
+        SpanLabel {
+            start: Position {
+                string: "X0",
+                count: 1,
+            },
+            end: Position {
+                string: "X2",
+                count: 1,
+            },
+            label: "`Z` label",
+        },
+    ],
+    r#"
+error: foo
+ --> test.rs:3:3
+  |
+3 | /   X0 Y0 Z0
+4 | |   X1 Y1 Z1
+5 | |   X2 Y2 Z2
+  | |    ^
+  | |    |
+  | |    `X` is a good letter
+  | |____`Y` is a good letter too
+  |      `Z` label
+
+"#);
+}
+
+#[test]
 fn minimum_depth() {
     test_harness(r#"
 fn foo() {

--- a/src/test/ui/span/coerce-suggestions.stderr
+++ b/src/test/ui/span/coerce-suggestions.stderr
@@ -50,10 +50,7 @@ error[E0308]: mismatched types
   --> $DIR/coerce-suggestions.rs:21:9
    |
 LL |     s = format!("foo");
-   |         ^^^^^^^^^^^^^^
-   |         |
-   |         expected mutable reference, found struct `std::string::String`
-   |         help: consider mutably borrowing here: `&mut format!("foo")`
+   |         ^^^^^^^^^^^^^^ expected mutable reference, found struct `std::string::String`
    |
    = note: expected type `&mut std::string::String`
               found type `std::string::String`

--- a/src/test/ui/suggestions/dont-suggest-deref-inside-macro-issue-58298.rs
+++ b/src/test/ui/suggestions/dont-suggest-deref-inside-macro-issue-58298.rs
@@ -3,7 +3,7 @@ fn warn(_: &str) {}
 macro_rules! intrinsic_match {
     ($intrinsic:expr) => {
         warn(format!("unsupported intrinsic {}", $intrinsic));
-        //^~ ERROR mismatched types
+        //~^ ERROR mismatched types
     };
 }
 

--- a/src/test/ui/suggestions/dont-suggest-deref-inside-macro-issue-58298.rs
+++ b/src/test/ui/suggestions/dont-suggest-deref-inside-macro-issue-58298.rs
@@ -1,0 +1,14 @@
+fn warn(_: &str) {}
+
+macro_rules! intrinsic_match {
+    ($intrinsic:expr) => {
+        warn(format!("unsupported intrinsic {}", $intrinsic));
+        //^~ ERROR mismatched types
+    };
+}
+
+fn main() {
+    intrinsic_match! {
+        "abc"
+    };
+}

--- a/src/test/ui/suggestions/dont-suggest-deref-inside-macro-issue-58298.stderr
+++ b/src/test/ui/suggestions/dont-suggest-deref-inside-macro-issue-58298.stderr
@@ -1,16 +1,13 @@
 error[E0308]: mismatched types
-  --> $DIR/dont-suggest-deref-inside-macro-issue-58298.rs:10:5
+  --> $DIR/dont-suggest-deref-inside-macro-issue-58298.rs:11:5
    |
-LL |        intrinsic_match! {
-   |   _____^
-   |  |_____|
-   | ||
-LL | ||         "abc"
-LL | ||     };
-   | ||      ^
-   | ||______|
-   | |_______expected &str, found struct `std::string::String`
-   |         in this macro invocation
+LL | /     intrinsic_match! {
+LL | |         "abc"
+LL | |     };
+   | |      ^
+   | |      |
+   | |______expected &str, found struct `std::string::String`
+   |        in this macro invocation
    |
    = note: expected type `&str`
               found type `std::string::String`

--- a/src/test/ui/suggestions/dont-suggest-deref-inside-macro-issue-58298.stderr
+++ b/src/test/ui/suggestions/dont-suggest-deref-inside-macro-issue-58298.stderr
@@ -1,0 +1,21 @@
+error[E0308]: mismatched types
+  --> $DIR/dont-suggest-deref-inside-macro-issue-58298.rs:10:5
+   |
+LL |        intrinsic_match! {
+   |   _____^
+   |  |_____|
+   | ||
+LL | ||         "abc"
+LL | ||     };
+   | ||      ^
+   | ||______|
+   | |_______expected &str, found struct `std::string::String`
+   |         in this macro invocation
+   |
+   = note: expected type `&str`
+              found type `std::string::String`
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fix #58298.