### PR TITLE
[WIP] BARE_TRAIT_OBJECTS -> Deny

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -261,7 +261,7 @@ declare_lint! {
 
 declare_lint! {
     pub BARE_TRAIT_OBJECTS,
-    Allow,
+    Deny,
     "suggest using `dyn Trait` for trait objects"
 }
 


### PR DESCRIPTION
Based on https://github.com/rust-lang/rfcs/blob/master/text/2113-dyn-trait-syntax.md#migration.

Let's first crater this for both editions to see what the fallout is. (I expect it will be large)
I suspect the likely outcome will be `Warn` on at least Rust 2015 for a start.

r? @oli-obk 