### PR TITLE
[WIP] UNUSED_EXTERN_CRATES -> Deny

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -30,7 +30,7 @@ declare_lint! {
 
 declare_lint! {
     pub UNUSED_EXTERN_CRATES,
-    Allow,
+    Deny,
     "extern crates that are never used"
 }
 


### PR DESCRIPTION
Continuing on from https://github.com/rust-lang/rust/pull/59482 with the `rust_2018_idioms` group, we have `unused_extern_crates` to progress.

r? @oli-obk
(I'm primarily assigning you because the PR needs a reviewer for the code changes, not for the T-Lang policy questions.. ^^)