### PR TITLE
[WIP] ELLIPSIS_INCLUSIVE_RANGE_PATTERNS -> Deny

### DIFF
--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1477,10 +1477,9 @@ impl LintPass for SoftLints {
 
 declare_lint! {
     pub ELLIPSIS_INCLUSIVE_RANGE_PATTERNS,
-    Allow,
+    Deny,
     "`...` range patterns are deprecated"
 }
-
 
 pub struct EllipsisInclusiveRangePatterns;
 


### PR DESCRIPTION
Continuing on from #59482 and https://github.com/rust-lang/rust/pull/59483 with the `rust_2018_idioms` group, we have `ellipsis_inclusive_range_patterns` to progress.

r? @oli-obk 