### PR TITLE
[WIP] ELIDED_LIFETIMES_IN_PATHS -> Deny

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -255,7 +255,7 @@ declare_lint! {
 
 declare_lint! {
     pub ELIDED_LIFETIMES_IN_PATHS,
-    Allow,
+    Deny,
     "hidden lifetime parameters in types are deprecated"
 }
 


### PR DESCRIPTION
Continuing on from #59482, https://github.com/rust-lang/rust/pull/59483, and https://github.com/rust-lang/rust/pull/59484 with the `rust_2018_idioms` group, we have `elided_lifetimes_in_paths` to progress.

I won't be opening a PR for `EXPLICIT_OUTLIVES_REQUIREMENTS` as I don't think this should be raised to warn let alone deny.

r? @oli-obk 