### PR TITLE
Fix typo in todo()! comment

### DIFF
--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -562,7 +562,7 @@ macro_rules! unimplemented {
 /// A standardized placeholder for marking unfinished code.
 ///
 /// This can be useful if you are prototyping and are just looking to have your
-/// code typecheck. `todo!` works exactly like `unimplemented!`, there only
+/// code typecheck. `todo!` works exactly like `unimplemented!`, the only
 /// difference between the two macros is the name.
 ///
 /// # Panics

--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -562,7 +562,7 @@ macro_rules! unimplemented {
 /// A standardized placeholder for marking unfinished code.
 ///
 /// This can be useful if you are prototyping and are just looking to have your
-/// code typecheck. `todo!` works exactly like `unimplemented!`, the only
+/// code typecheck. `todo!` works exactly like `unimplemented!`; the only
 /// difference between the two macros is the name.
 ///
 /// # Panics


### PR DESCRIPTION
After #56348 got mentioned in [This Week In Rust](https://this-week-in-rust.org/blog/2019/03/26/this-week-in-rust-279/), I took a look—and spotted a typo. Here's a fix.

It doesn't look like this needs an issue; if I'm wrong, let me know and I'll make one.