### PR TITLE
Fix missed fn rename in #59284

### DIFF
--- a/src/libstd/sys/sgx/rwlock.rs
+++ b/src/libstd/sys/sgx/rwlock.rs
@@ -268,7 +268,7 @@ mod tests {
 
         #[inline(never)]
         unsafe fn rwlock_new(init: &mut MaybeUninit<RWLock>) {
-            init.set(RWLock::new());
+            init.write(RWLock::new());
         }
 
         unsafe {


### PR DESCRIPTION
See https://github.com/rust-lang/rust/pull/59284#issuecomment-477822797