### PR TITLE
Rollup of 11 pull requests

### DIFF
--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -97,6 +97,8 @@ impl Step for Std {
         let _folder = builder.fold_output(|| format!("stage{}-std", compiler.stage));
         builder.info(&format!("Building stage{} std artifacts ({} -> {})", compiler.stage,
                 &compiler.host, target));
+        // compile with `-Z emit-stack-sizes`; see bootstrap/src/rustc.rs for more details
+        cargo.env("RUSTC_EMIT_STACK_SIZES", "1");
         run_cargo(builder,
                   &mut cargo,
                   &libstd_stamp(builder, compiler, target),
@@ -382,6 +384,8 @@ impl Step for Test {
         let _folder = builder.fold_output(|| format!("stage{}-test", compiler.stage));
         builder.info(&format!("Building stage{} test artifacts ({} -> {})", compiler.stage,
                 &compiler.host, target));
+        // compile with `-Z emit-stack-sizes`; see bootstrap/src/rustc.rs for more details
+        cargo.env("RUSTC_EMIT_STACK_SIZES", "1");
         run_cargo(builder,
                   &mut cargo,
                   &libtest_stamp(builder, compiler, target),

--- a/src/ci/docker/scripts/musl-toolchain.sh
+++ b/src/ci/docker/scripts/musl-toolchain.sh
@@ -29,6 +29,10 @@ TARGET=$ARCH-linux-musl
 OUTPUT=/usr/local
 shift
 
+# Ancient binutils versions don't understand debug symbols produced by more recent tools.
+# Apparently applying `-fPIC` everywhere allows them to link successfully.
+export CFLAGS="-fPIC $CFLAGS"
+
 git clone https://github.com/richfelker/musl-cross-make -b v0.9.7
 cd musl-cross-make
 

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -354,7 +354,7 @@ declare_lint! {
 
 declare_lint! {
     pub DUPLICATE_MATCHER_BINDING_NAME,
-    Warn,
+    Deny,
     "duplicate macro matcher binding name"
 }
 
@@ -464,6 +464,7 @@ impl LintPass for HardwiredLints {
             DEPRECATED_IN_FUTURE,
             AMBIGUOUS_ASSOCIATED_ITEMS,
             NESTED_IMPL_TRAIT,
+            DUPLICATE_MATCHER_BINDING_NAME,
         )
     }
 }

--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -42,8 +42,8 @@ use syntax::symbol::Symbol;
 use syntax_pos::Span;
 
 pub use crate::lint::context::{LateContext, EarlyContext, LintContext, LintStore,
-                        check_crate, check_ast_crate, CheckLintNameResult,
-                        FutureIncompatibleInfo, BufferedEarlyLint};
+                        check_crate, check_ast_crate, late_lint_mod, CheckLintNameResult,
+                        FutureIncompatibleInfo, BufferedEarlyLint,};
 
 /// Specification of a single lint.
 #[derive(Copy, Clone, Debug)]
@@ -298,14 +298,14 @@ macro_rules! expand_combined_late_lint_pass_methods {
 
 #[macro_export]
 macro_rules! declare_combined_late_lint_pass {
-    ([$name:ident, [$($passes:ident: $constructor:expr,)*]], [$hir:tt], $methods:tt) => (
+    ([$v:vis $name:ident, [$($passes:ident: $constructor:expr,)*]], [$hir:tt], $methods:tt) => (
         #[allow(non_snake_case)]
-        struct $name {
+        $v struct $name {
             $($passes: $passes,)*
         }
 
         impl $name {
-            fn new() -> Self {
+            $v fn new() -> Self {
                 Self {
                     $($passes: $constructor,)*
                 }
@@ -824,7 +824,6 @@ impl<'a, 'tcx> intravisit::Visitor<'tcx> for LintLevelMapBuilder<'a, 'tcx> {
 
 pub fn provide(providers: &mut Providers<'_>) {
     providers.lint_levels = lint_levels;
-    context::provide(providers);
 }
 
 /// Returns whether `span` originates in a foreign crate's external macro.

--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -273,6 +273,9 @@ macro_rules! expand_lint_pass_methods {
 macro_rules! declare_late_lint_pass {
     ([], [$hir:tt], [$($methods:tt)*]) => (
         pub trait LateLintPass<'a, $hir>: LintPass {
+            fn fresh_late_pass(&self) -> LateLintPassObject {
+                panic!()
+            }
             expand_lint_pass_methods!(&LateContext<'a, $hir>, [$($methods)*]);
         }
     )

--- a/src/librustc_interface/interface.rs
+++ b/src/librustc_interface/interface.rs
@@ -136,14 +136,12 @@ where
     F: FnOnce(&Compiler) -> R + Send,
     R: Send,
 {
-    syntax::with_globals(move || {
-        let stderr = config.stderr.take();
-        util::spawn_thread_pool(
-            config.opts.debugging_opts.threads,
-            &stderr,
-            || run_compiler_in_existing_thread_pool(config, f),
-        )
-    })
+    let stderr = config.stderr.take();
+    util::spawn_thread_pool(
+        config.opts.debugging_opts.threads,
+        &stderr,
+        || run_compiler_in_existing_thread_pool(config, f),
+    )
 }
 
 pub fn default_thread_pool<F, R>(f: F) -> R

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -990,7 +990,7 @@ fn analysis<'tcx>(
                 });
             }, {
                 time(sess, "lint checking", || {
-                    lint::check_crate(tcx, rustc_lint::BuiltinCombinedLateLintPass::new());
+                    lint::check_crate(tcx, || rustc_lint::BuiltinCombinedLateLintPass::new());
                 });
             });
         }, {

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -330,7 +330,7 @@ pub fn register_plugins<'a>(
         ls.register_early_pass(Some(sess), true, false, pass);
     }
     for pass in late_lint_passes {
-        ls.register_late_pass(Some(sess), true, false, pass);
+        ls.register_late_pass(Some(sess), true, false, false, pass);
     }
 
     for (name, (to, deprecated_name)) in lint_groups {
@@ -783,6 +783,7 @@ pub fn default_provide(providers: &mut ty::query::Providers<'_>) {
     middle::entry::provide(providers);
     cstore::provide(providers);
     lint::provide(providers);
+    rustc_lint::provide(providers);
 }
 
 pub fn default_provide_extern(providers: &mut ty::query::Providers<'_>) {
@@ -988,7 +989,9 @@ fn analysis<'tcx>(
                     stability::check_unused_or_stable_features(tcx)
                 });
             }, {
-                time(sess, "lint checking", || lint::check_crate(tcx));
+                time(sess, "lint checking", || {
+                    lint::check_crate(tcx, rustc_lint::BuiltinCombinedLateLintPass::new());
+                });
             });
         }, {
             time(sess, "privacy checking modules", || {

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -14,6 +14,7 @@ use rustc::ty::{self, TyCtxt, query::TyCtxtAt};
 use rustc::ty::layout::{self, LayoutOf, VariantIdx};
 use rustc::ty::subst::Subst;
 use rustc::traits::Reveal;
+use rustc::util::common::ErrorReported;
 use rustc_data_structures::fx::FxHashMap;
 
 use syntax::ast::Mutability;
@@ -654,7 +655,7 @@ pub fn const_eval_raw_provider<'a, 'tcx>(
                                         v));
                     v
                 },
-                Err(_) => ErrorHandled::Reported,
+                Err(ErrorReported) => ErrorHandled::Reported,
             }
         } else if def_id.is_local() {
             // constant defined in this crate, we can figure out a lint level!

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -645,15 +645,17 @@ pub fn const_eval_raw_provider<'a, 'tcx>(
             // an error must be reported.
             let reported_err = tcx.sess.track_errors(|| {
                 err.report_as_error(ecx.tcx,
-                                    "could not evaluate static initializer");
+                                    "could not evaluate static initializer")
             });
             match reported_err {
-                Ok(v) => tcx.sess.delay_span_bug(err.span,
+                Ok(v) => {
+                    tcx.sess.delay_span_bug(err.span,
                                         &format!("static eval failure did not emit an error: {:#?}",
-                                        v)),
-                Err(err) => err,
+                                        v));
+                    v
+                },
+                Err(ErrorReported) => ErrorHandled::Reported,
             }
-            reported_err
         } else if def_id.is_local() {
             // constant defined in this crate, we can figure out a lint level!
             match tcx.describe_def(def_id) {

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -650,9 +650,9 @@ pub fn const_eval_raw_provider<'a, 'tcx>(
                                     "could not evaluate static initializer");
             });
             match tracked_err {
-                Ok(_) => tcx.sess.delay_span_bug(err.span,
+                Ok(reported_err) => tcx.sess.delay_span_bug(err.span,
                                         &format!("static eval failure did not emit an error: {:#?}",
-                                        tracked_err)),
+                                        reported_err)),
                 Err(_) => (),
             }
             reported_err

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -641,19 +641,17 @@ pub fn const_eval_raw_provider<'a, 'tcx>(
         let err = error_to_const_error(&ecx, error);
         // errors in statics are always emitted as fatal errors
         if tcx.is_static(def_id).is_some() {
-            let reported_err = err.report_as_error(ecx.tcx,
-                                                   "could not evaluate static initializer");
             // Ensure that if the above error was either `TooGeneric` or `Reported`
             // an error must be reported.
-            let tracked_err = tcx.sess.track_errors(|| {
+            let reported_err = tcx.sess.track_errors(|| {
                 err.report_as_error(ecx.tcx,
                                     "could not evaluate static initializer");
             });
-            match tracked_err {
-                Ok(reported_err) => tcx.sess.delay_span_bug(err.span,
+            match reported_err {
+                Ok(v) => tcx.sess.delay_span_bug(err.span,
                                         &format!("static eval failure did not emit an error: {:#?}",
-                                        reported_err)),
-                Err(_) => (),
+                                        v)),
+                Err(err) => err,
             }
             reported_err
         } else if def_id.is_local() {

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -645,13 +645,14 @@ pub fn const_eval_raw_provider<'a, 'tcx>(
                                                    "could not evaluate static initializer");
             // Ensure that if the above error was either `TooGeneric` or `Reported`
             // an error must be reported.
-            let errs = tcx.sess.track_errors(|| {
-                tcx.sess.err_count();
+            let tracked_err = tcx.sess.track_errors(|| {
+                err.report_as_error(ecx.tcx,
+                                    "could not evaluate static initializer");
             });
-            match errs {
+            match tracked_err {
                 Ok(_) => tcx.sess.delay_span_bug(err.span,
                                         &format!("static eval failure did not emit an error: {:#?}",
-                                        reported_err)),
+                                        tracked_err)),
                 Err(_) => (),
             }
             reported_err

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -645,10 +645,14 @@ pub fn const_eval_raw_provider<'a, 'tcx>(
                                                    "could not evaluate static initializer");
             // Ensure that if the above error was either `TooGeneric` or `Reported`
             // an error must be reported.
-            if tcx.sess.err_count() == 0 {
-                tcx.sess.delay_span_bug(err.span,
+            let errs = tcx.sess.track_errors(|| {
+                tcx.sess.err_count();
+            });
+            match errs {
+                Ok(_) => tcx.sess.delay_span_bug(err.span,
                                         &format!("static eval failure did not emit an error: {:#?}",
-                                                 reported_err));
+                                        reported_err)),
+                Err(_) => (),
             }
             reported_err
         } else if def_id.is_local() {

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -654,7 +654,7 @@ pub fn const_eval_raw_provider<'a, 'tcx>(
                                         v));
                     v
                 },
-                Err(ErrorReported) => ErrorHandled::Reported,
+                Err(_) => ErrorHandled::Reported,
             }
         } else if def_id.is_local() {
             // constant defined in this crate, we can figure out a lint level!

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -443,7 +443,7 @@ where R: 'static + Send,
 
     let (tx, rx) = channel();
 
-    let result = rustc_driver::report_ices_to_stderr_if_any(move || syntax::with_globals(move || {
+    let result = rustc_driver::report_ices_to_stderr_if_any(move || {
         let crate_name = options.crate_name.clone();
         let crate_version = options.crate_version.clone();
         let (mut krate, renderinfo, renderopts, passes) = core::run_core(options);
@@ -462,7 +462,7 @@ where R: 'static + Send,
             renderopts,
             passes: passes
         })).unwrap();
-    }));
+    });
 
     match result {
         Ok(()) => rx.recv().unwrap(),

--- a/src/libstd/f32.rs
+++ b/src/libstd/f32.rs
@@ -202,7 +202,6 @@ impl f32 {
     /// # Examples
     ///
     /// ```
-    /// #![feature(copysign)]
     /// use std::f32;
     ///
     /// let f = 3.5_f32;
@@ -216,7 +215,7 @@ impl f32 {
     /// ```
     #[inline]
     #[must_use]
-    #[unstable(feature="copysign", issue="55169")]
+    #[stable(feature = "copysign", since = "1.35.0")]
     pub fn copysign(self, y: f32) -> f32 {
         unsafe { intrinsics::copysignf32(self, y) }
     }

--- a/src/libstd/f64.rs
+++ b/src/libstd/f64.rs
@@ -180,7 +180,6 @@ impl f64 {
     /// # Examples
     ///
     /// ```
-    /// #![feature(copysign)]
     /// use std::f64;
     ///
     /// let f = 3.5_f64;
@@ -194,7 +193,7 @@ impl f64 {
     /// ```
     #[inline]
     #[must_use]
-    #[unstable(feature="copysign", issue="55169")]
+    #[stable(feature = "copysign", since = "1.35.0")]
     pub fn copysign(self, y: f64) -> f64 {
         unsafe { intrinsics::copysignf64(self, y) }
     }

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -1151,7 +1151,7 @@ pub trait Write {
     /// fn main() -> std::io::Result<()> {
     ///     let mut buffer = BufWriter::new(File::create("foo.txt")?);
     ///
-    ///     buffer.write(b"some bytes")?;
+    ///     buffer.write_all(b"some bytes")?;
     ///     buffer.flush()?;
     ///     Ok(())
     /// }

--- a/src/libstd/io/stdio.rs
+++ b/src/libstd/io/stdio.rs
@@ -405,7 +405,7 @@ pub struct StdoutLock<'a> {
 /// use std::io::{self, Write};
 ///
 /// fn main() -> io::Result<()> {
-///     io::stdout().write(b"hello world")?;
+///     io::stdout().write_all(b"hello world")?;
 ///
 ///     Ok(())
 /// }
@@ -420,7 +420,7 @@ pub struct StdoutLock<'a> {
 ///     let stdout = io::stdout();
 ///     let mut handle = stdout.lock();
 ///
-///     handle.write(b"hello world")?;
+///     handle.write_all(b"hello world")?;
 ///
 ///     Ok(())
 /// }
@@ -460,7 +460,7 @@ impl Stdout {
     ///     let stdout = io::stdout();
     ///     let mut handle = stdout.lock();
     ///
-    ///     handle.write(b"hello world")?;
+    ///     handle.write_all(b"hello world")?;
     ///
     ///     Ok(())
     /// }
@@ -558,7 +558,7 @@ pub struct StderrLock<'a> {
 /// use std::io::{self, Write};
 ///
 /// fn main() -> io::Result<()> {
-///     io::stderr().write(b"hello world")?;
+///     io::stderr().write_all(b"hello world")?;
 ///
 ///     Ok(())
 /// }
@@ -573,7 +573,7 @@ pub struct StderrLock<'a> {
 ///     let stderr = io::stderr();
 ///     let mut handle = stderr.lock();
 ///
-///     handle.write(b"hello world")?;
+///     handle.write_all(b"hello world")?;
 ///
 ///     Ok(())
 /// }
@@ -613,7 +613,7 @@ impl Stderr {
     ///     let stderr = io::stderr();
     ///     let mut handle = stderr.lock();
     ///
-    ///     handle.write(b"hello world")?;
+    ///     handle.write_all(b"hello world")?;
     ///
     ///     Ok(())
     /// }

--- a/src/libstd/sys/sgx/rwlock.rs
+++ b/src/libstd/sys/sgx/rwlock.rs
@@ -268,7 +268,7 @@ mod tests {
 
         #[inline(never)]
         unsafe fn rwlock_new(init: &mut MaybeUninit<RWLock>) {
-            init.set(RWLock::new());
+            init.write(RWLock::new());
         }
 
         unsafe {

--- a/src/libsyntax/parse/attr.rs
+++ b/src/libsyntax/parse/attr.rs
@@ -6,6 +6,7 @@ use crate::parse::parser::{Parser, TokenType, PathStyle};
 use crate::tokenstream::{TokenStream, TokenTree};
 
 use log::debug;
+use smallvec::smallvec;
 
 #[derive(Debug)]
 enum InnerAttributeParsePolicy<'a> {
@@ -171,7 +172,7 @@ impl<'a> Parser<'a> {
                 } else {
                     self.parse_unsuffixed_lit()?.tokens()
                 };
-                TokenStream::from_streams(vec![eq.into(), tokens])
+                TokenStream::from_streams(smallvec![eq.into(), tokens])
             } else {
                 TokenStream::empty()
             };

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -647,8 +647,8 @@ pub fn walk_stmt<'a, V: Visitor<'a>>(visitor: &mut V, statement: &'a Stmt) {
     }
 }
 
-pub fn walk_mac<'a, V: Visitor<'a>>(_: &mut V, _: &Mac) {
-    // Empty!
+pub fn walk_mac<'a, V: Visitor<'a>>(visitor: &mut V, mac: &'a Mac) {
+    visitor.visit_path(&mac.node.path, DUMMY_NODE_ID);
 }
 
 pub fn walk_anon_const<'a, V: Visitor<'a>>(visitor: &mut V, constant: &'a AnonConst) {

--- a/src/libsyntax_ext/proc_macro_decls.rs
+++ b/src/libsyntax_ext/proc_macro_decls.rs
@@ -317,7 +317,7 @@ impl<'a> Visitor<'a> for CollectProcMacros<'a> {
         self.in_root = prev_in_root;
     }
 
-    fn visit_mac(&mut self, mac: &ast::Mac) {
+    fn visit_mac(&mut self, mac: &'a ast::Mac) {
         visit::walk_mac(self, mac)
     }
 }

--- a/src/test/ui/macros/macro-multiple-matcher-bindings.rs
+++ b/src/test/ui/macros/macro-multiple-matcher-bindings.rs
@@ -6,6 +6,7 @@
 // compile-pass
 
 #![allow(unused_macros)]
+#![warn(duplicate_matcher_binding_name)]
 
 macro_rules! foo1 {
     ($a:ident, $a:ident) => {}; //~WARNING duplicate matcher binding

--- a/src/test/ui/macros/macro-multiple-matcher-bindings.stderr
+++ b/src/test/ui/macros/macro-multiple-matcher-bindings.stderr
@@ -1,15 +1,19 @@
 warning: duplicate matcher binding
-  --> $DIR/macro-multiple-matcher-bindings.rs:11:6
+  --> $DIR/macro-multiple-matcher-bindings.rs:12:6
    |
 LL |     ($a:ident, $a:ident) => {};
    |      ^^^^^^^^  ^^^^^^^^
    |
-   = note: #[warn(duplicate_matcher_binding_name)] on by default
+note: lint level defined here
+  --> $DIR/macro-multiple-matcher-bindings.rs:9:9
+   |
+LL | #![warn(duplicate_matcher_binding_name)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57593 <https://github.com/rust-lang/rust/issues/57593>
 
 warning: duplicate matcher binding
-  --> $DIR/macro-multiple-matcher-bindings.rs:12:6
+  --> $DIR/macro-multiple-matcher-bindings.rs:13:6
    |
 LL |     ($a:ident, $a:path) => {};
    |      ^^^^^^^^  ^^^^^^^
@@ -18,7 +22,7 @@ LL |     ($a:ident, $a:path) => {};
    = note: for more information, see issue #57593 <https://github.com/rust-lang/rust/issues/57593>
 
 warning: duplicate matcher binding
-  --> $DIR/macro-multiple-matcher-bindings.rs:21:6
+  --> $DIR/macro-multiple-matcher-bindings.rs:22:6
    |
 LL |     ($a:ident, $($a:ident),*) => {};
    |      ^^^^^^^^    ^^^^^^^^
@@ -27,7 +31,7 @@ LL |     ($a:ident, $($a:ident),*) => {};
    = note: for more information, see issue #57593 <https://github.com/rust-lang/rust/issues/57593>
 
 warning: duplicate matcher binding
-  --> $DIR/macro-multiple-matcher-bindings.rs:22:8
+  --> $DIR/macro-multiple-matcher-bindings.rs:23:8
    |
 LL |     ($($a:ident)+ # $($($a:path),+);*) => {};
    |        ^^^^^^^^         ^^^^^^^


### PR DESCRIPTION
Successful merges:

 - #58019 (Combine all builtin late lints and make lint checking parallel)
 - #59358 (Use `track_errors` instead of hand rolling)
 - #59394 (warn -> deny duplicate match bindings)
 - #59401 (bootstrap: build crates under libtest with -Z emit-stack-sizes)
 - #59423 (Visit path in `walk_mac`)
 - #59468 (musl: build toolchain libs with -fPIC)
 - #59476 (Use `SmallVec` in `TokenStreamBuilder`.)
 - #59496 (Remove unnecessary with_globals calls)
 - #59498 (Use 'write_all' instead of 'write' in example code)
 - #59503 (Stablize {f32,f64}::copysign().)
 - #59511 (Fix missed fn rename in #59284)

Failed merges:


r? @ghost