### PR TITLE
rustc_codegen_llvm: support 128-bit discriminants in debuginfo.

### DIFF
--- a/src/test/codegen/enum-debug-niche-2.rs
+++ b/src/test/codegen/enum-debug-niche-2.rs
@@ -9,8 +9,8 @@
 // compile-flags: -g -C no-prepopulate-passes
 
 // CHECK: {{.*}}DICompositeType{{.*}}tag: DW_TAG_variant_part,{{.*}}size: 32,{{.*}}
-// CHECK: {{.*}}DIDerivedType{{.*}}tag: DW_TAG_member,{{.*}}name: "Placeholder",{{.*}}extraData: i64 4294967295{{[,)].*}}
-// CHECK: {{.*}}DIDerivedType{{.*}}tag: DW_TAG_member,{{.*}}name: "Error",{{.*}}extraData: i64 0{{[,)].*}}
+// CHECK: {{.*}}DIDerivedType{{.*}}tag: DW_TAG_member,{{.*}}name: "Placeholder",{{.*}}extraData: i128 4294967295{{[,)].*}}
+// CHECK: {{.*}}DIDerivedType{{.*}}tag: DW_TAG_member,{{.*}}name: "Error",{{.*}}extraData: i128 0{{[,)].*}}
 
 #![feature(never_type)]
 

--- a/src/test/codegen/repr-u128.rs
+++ b/src/test/codegen/repr-u128.rs
@@ -1,0 +1,24 @@
+// ignore-tidy-linelength
+// ignore-windows
+// min-system-llvm-version 8.0
+
+// compile-flags: -g -C no-prepopulate-passes
+
+// CHECK: {{.*}}DIDerivedType{{.*}}tag: DW_TAG_member,{{.*}}name: "None",{{.*}}extraData: i128 18446745000000000124{{[,)].*}}
+
+#![feature(repr128)]
+
+#[repr(u128)]
+pub enum Foo {
+    Lo,
+    Hi = 1 << 64,
+    Bar = 18_446_745_000_000_000_123,
+}
+
+pub fn foo() -> Option<Foo> {
+    None
+}
+
+fn main() {
+    let roa = foo();
+}

--- a/src/test/debuginfo/issue-22656.rs
+++ b/src/test/debuginfo/issue-22656.rs
@@ -15,7 +15,7 @@
 // lldbg-check:[...]$0 = vec![1, 2, 3]
 // lldbr-check:(alloc::vec::Vec<i32>) v = vec![1, 2, 3]
 // lldb-command:print zs
-// lldbg-check:[...]$1 = StructWithZeroSizedField { x: ZeroSizedStruct, y: 123, z: ZeroSizedStruct, w: 456 }
+// lldbg-check:[...]$1 = StructWithZeroSizedField { x: ZeroSizedStruct { }, y: 123, z: ZeroSizedStruct { }, w: 456 }
 // lldbr-check:(issue_22656::StructWithZeroSizedField) zs = StructWithZeroSizedField { x: ZeroSizedStruct { }, y: 123, z: ZeroSizedStruct { }, w: 456 }
 // lldbr-command:continue
 

--- a/src/test/debuginfo/repr-u128.rs
+++ b/src/test/debuginfo/repr-u128.rs
@@ -1,0 +1,37 @@
+// ignore-windows
+// ignore-tidy-linelength
+// min-system-llvm-version 8.0
+
+// compile-flags: -g -C no-prepopulate-passes
+
+// === GDB TESTS ===================================================================================
+
+// gdb-command: run
+
+// gdb-command:print vals
+// gdb-check:$1 = (core::option::Option<repr_u128::Foo>, core::option::Option<repr_u128::Foo>)
+
+// === LLDB TESTS ==================================================================================
+
+// lldb-command:run
+
+// lldb-command:print vals
+// lldbg-check:[...]$0 = (Option<repr_u128::Foo> { }, Option<repr_u128::Foo> { })
+// lldbr-check:((core::option::Option<repr_u128::Foo>, core::option::Option<repr_u128::Foo>)) $0 = (Option<repr_u128::Foo> { }, Option<repr_u128::Foo> { })
+
+#![feature(repr128)]
+
+#[repr(u128)]
+pub enum Foo {
+    Lo,
+    Hi = 1 << 64,
+    Bar = 18_446_745_000_000_000_123,
+}
+
+fn main() {
+    let vals = (Some(Foo::Lo), None::<Foo>);
+
+    zzz(); // #break
+}
+
+fn zzz() {()}


### PR DESCRIPTION
CC: #59509 

> Alternatively, if LLVM and DWARF support it, we should encode the 128-bit discriminant

If we should fix like this issue comment, I'll do.

r? @eddyb 
