### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2066,7 +2066,7 @@ name = "rand_chacha"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2088,7 +2088,7 @@ name = "rand_hc"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2113,7 +2113,7 @@ name = "rand_xorshift"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2252,7 +2252,7 @@ dependencies = [
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-workspace-hack 1.0.0",
  "rustc_tools_util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustfmt-nightly 1.1.0",
+ "rustfmt-nightly 1.2.0",
  "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.81 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_ignored 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3048,7 +3048,7 @@ dependencies = [
 
 [[package]]
 name = "rustfmt-nightly"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytecount 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1195,7 +1195,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "jemalloc-sys"
-version = "0.1.8"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2066,7 +2066,7 @@ name = "rand_chacha"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2088,7 +2088,7 @@ name = "rand_hc"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2113,7 +2113,7 @@ name = "rand_xorshift"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2492,7 +2492,7 @@ dependencies = [
 name = "rustc-main"
 version = "0.0.0"
 dependencies = [
- "jemalloc-sys 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jemalloc-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_codegen_ssa 0.0.0",
  "rustc_driver 0.0.0",
  "rustc_target 0.0.0",
@@ -4086,7 +4086,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "f58856976b776fedd95533137617a02fb25719f40e7d9b01c7043cd65474f450"
 "checksum itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
-"checksum jemalloc-sys 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "bfc62c8e50e381768ce8ee0428ee53741929f7ebd73e4d83f669bcf7693e00ae"
+"checksum jemalloc-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7bef0d4ce37578dfd80b466e3d8324bd9de788e249f1accebb0c472ea4b52bdc"
 "checksum jobserver 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "dd80e58f77e0cdea53ba96acc5e04479e5ffc5d869626a6beafe50fed867eace"
 "checksum json 0.11.13 (registry+https://github.com/rust-lang/crates.io-index)" = "9ad0485404155f45cce53a40d4b2d6ac356418300daed05273d9e26f91c390be"
 "checksum jsonrpc-core 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a5152c3fda235dfd68341b3edf4121bc4428642c93acbd6de88c26bf95fc5d7"

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -402,6 +402,7 @@ impl<'a> Builder<'a> {
                 test::UnstableBook,
                 test::RustcBook,
                 test::EmbeddedBook,
+                test::EditionGuide,
                 test::Rustfmt,
                 test::Miri,
                 test::Clippy,

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1421,6 +1421,7 @@ test_book!(
     EmbeddedBook, "src/doc/embedded-book", "embedded-book", default=false;
     TheBook, "src/doc/book", "book", default=false;
     UnstableBook, "src/doc/unstable-book", "unstable-book", default=true;
+    EditionGuide, "src/doc/edition-guide", "edition-guide", default=false;
 );
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]

--- a/src/ci/docker/x86_64-gnu-tools/checktools.sh
+++ b/src/ci/docker/x86_64-gnu-tools/checktools.sh
@@ -24,6 +24,7 @@ python2.7 "$X_PY" test --no-fail-fast \
     src/doc/reference \
     src/doc/rust-by-example \
     src/doc/embedded-book \
+    src/doc/edition-guide \
     src/tools/clippy \
     src/tools/rls \
     src/tools/rustfmt \
@@ -73,6 +74,7 @@ status_check() {
     check_dispatch $1 beta nomicon src/doc/nomicon
     check_dispatch $1 beta reference src/doc/reference
     check_dispatch $1 beta rust-by-example src/doc/rust-by-example
+    check_dispatch $1 beta edition-guide src/doc/edition-guide
     check_dispatch $1 beta rls src/tools/rls
     check_dispatch $1 beta rustfmt src/tools/rustfmt
     check_dispatch $1 beta clippy-driver src/tools/clippy

--- a/src/doc/unstable-book/src/language-features/plugin.md
+++ b/src/doc/unstable-book/src/language-features/plugin.md
@@ -130,7 +130,7 @@ The advantages over a simple `fn(&str) -> u32` are:
   a way to define new literal syntax for any data type.
 
 In addition to procedural macros, you can define new
-[`derive`](../reference/attributes.html#derive)-like attributes and other kinds
+[`derive`](../reference/attributes/derive.html)-like attributes and other kinds
 of extensions.  See `Registry::register_syntax_extension` and the
 `SyntaxExtension` enum.  For a more involved macro example, see
 [`regex_macros`](https://github.com/rust-lang/regex/blob/master/regex_macros/src/lib.rs).
@@ -174,7 +174,7 @@ quasiquote as an ordinary plugin library.
 # Lint plugins
 
 Plugins can extend [Rust's lint
-infrastructure](../reference/attributes.html#lint-check-attributes) with
+infrastructure](../reference/attributes/diagnostics.html#lint-check-attributes) with
 additional checks for code style, safety, etc. Now let's write a plugin
 [`lint_plugin_test.rs`](https://github.com/rust-lang/rust/blob/master/src/test/ui-fulldeps/auxiliary/lint_plugin_test.rs)
 that warns about any item named `lintme`.
@@ -253,7 +253,7 @@ mostly use the same infrastructure as lint plugins, and provide examples of how
 to access type information.
 
 Lints defined by plugins are controlled by the usual [attributes and compiler
-flags](../reference/attributes.html#lint-check-attributes), e.g.
+flags](../reference/attributes/diagnostics.html#lint-check-attributes), e.g.
 `#[allow(test_lint)]` or `-A test-lint`. These identifiers are derived from the
 first argument to `declare_lint!`, with appropriate case and punctuation
 conversion.

--- a/src/librustc/hir/intravisit.rs
+++ b/src/librustc/hir/intravisit.rs
@@ -485,30 +485,30 @@ pub fn walk_item<'v, V: Visitor<'v>>(visitor: &mut V, item: &'v Item) {
         ItemKind::GlobalAsm(_) => {
             visitor.visit_id(item.hir_id);
         }
-        ItemKind::Ty(ref typ, ref type_parameters) => {
+        ItemKind::Ty(ref ty, ref generics) => {
             visitor.visit_id(item.hir_id);
-            visitor.visit_ty(typ);
-            visitor.visit_generics(type_parameters)
+            visitor.visit_ty(ty);
+            visitor.visit_generics(generics)
         }
         ItemKind::Existential(ExistTy { ref generics, ref bounds, impl_trait_fn: _ }) => {
             visitor.visit_id(item.hir_id);
             walk_generics(visitor, generics);
             walk_list!(visitor, visit_param_bound, bounds);
         }
-        ItemKind::Enum(ref enum_definition, ref type_parameters) => {
-            visitor.visit_generics(type_parameters);
+        ItemKind::Enum(ref enum_definition, ref generics) => {
+            visitor.visit_generics(generics);
             // `visit_enum_def()` takes care of visiting the `Item`'s `HirId`.
-            visitor.visit_enum_def(enum_definition, type_parameters, item.hir_id, item.span)
+            visitor.visit_enum_def(enum_definition, generics, item.hir_id, item.span)
         }
         ItemKind::Impl(
             ..,
-            ref type_parameters,
+            ref generics,
             ref opt_trait_reference,
             ref typ,
             ref impl_item_refs
         ) => {
             visitor.visit_id(item.hir_id);
-            visitor.visit_generics(type_parameters);
+            visitor.visit_generics(generics);
             walk_list!(visitor, visit_trait_ref, opt_trait_reference);
             visitor.visit_ty(typ);
             walk_list!(visitor, visit_impl_item_ref, impl_item_refs);

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -172,6 +172,7 @@ impl<'a, 'tcx> MarkSymbolVisitor<'a, 'tcx> {
                     | hir::ItemKind::Ty(..)
                     | hir::ItemKind::Static(..)
                     | hir::ItemKind::Existential(..)
+                    | hir::ItemKind::Impl(..)
                     | hir::ItemKind::Const(..) => {
                         intravisit::walk_item(self, &item);
                     }

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -73,7 +73,7 @@ impl<'a, 'tcx> MarkSymbolVisitor<'a, 'tcx> {
             Def::Const(_) | Def::AssociatedConst(..) | Def::TyAlias(_) => {
                 self.check_def_id(def.def_id());
             }
-            _ if self.in_pat => (),
+            _ if self.in_pat => {},
             Def::PrimTy(..) | Def::SelfTy(..) | Def::SelfCtor(..) |
             Def::Local(..) | Def::Upvar(..) => {}
             Def::Ctor(ctor_def_id, CtorOf::Variant, ..) => {
@@ -91,6 +91,7 @@ impl<'a, 'tcx> MarkSymbolVisitor<'a, 'tcx> {
                     self.check_def_id(variant_id);
                 }
             }
+            Def::ToolMod | Def::NonMacroAttr(..) | Def::Err => {}
             _ => {
                 self.check_def_id(def.def_id());
             }
@@ -166,17 +167,13 @@ impl<'a, 'tcx> MarkSymbolVisitor<'a, 'tcx> {
                     }
                     hir::ItemKind::Enum(..) => {
                         self.inherited_pub_visibility = item.vis.node.is_pub();
+
                         intravisit::walk_item(self, &item);
                     }
-                    hir::ItemKind::Fn(..)
-                    | hir::ItemKind::Ty(..)
-                    | hir::ItemKind::Static(..)
-                    | hir::ItemKind::Existential(..)
-                    | hir::ItemKind::Impl(..)
-                    | hir::ItemKind::Const(..) => {
+                    hir::ItemKind::ForeignMod(..) => {}
+                    _ => {
                         intravisit::walk_item(self, &item);
                     }
-                    _ => ()
                 }
             }
             Node::TraitItem(trait_item) => {
@@ -188,7 +185,7 @@ impl<'a, 'tcx> MarkSymbolVisitor<'a, 'tcx> {
             Node::ForeignItem(foreign_item) => {
                 intravisit::walk_foreign_item(self, &foreign_item);
             }
-            _ => ()
+            _ => {}
         }
         self.repr_has_repr_c = had_repr_c;
         self.inherited_pub_visibility = had_inherited_pub_visibility;

--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -314,8 +314,13 @@ impl EmitterWriter {
                 //  | |______foo
                 //  |        baz
                 add_annotation_to_file(&mut output, file.clone(), ann.line_start, ann.as_start());
+                // 4 is the minimum vertical length of a multiline span when presented: two lines
+                // of code and two lines of underline. This is not true for the special case where
+                // the beginning doesn't have an underline, but the current logic seems to be
+                // working correctly.
                 let middle = min(ann.line_start + 4, ann.line_end);
                 for line in ann.line_start + 1..middle {
+                    // Every `|` that joins the beginning of the span (`___^`) to the end (`|__^`).
                     add_annotation_to_file(&mut output, file.clone(), line, ann.as_line());
                 }
                 if middle < ann.line_end - 1 {

--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -243,7 +243,7 @@ impl EmitterWriter {
                         end_col: hi.col_display,
                         is_primary: span_label.is_primary,
                         label: span_label.label.clone(),
-                        overlaps: false,
+                        overlaps_exactly: false,
                     };
                     multiline_annotations.push((lo.file.clone(), ml.clone()));
                     AnnotationType::Multiline(ml)
@@ -277,7 +277,7 @@ impl EmitterWriter {
                 {
                     a.increase_depth();
                 } else if ann.same_span(a) && &ann != a {
-                    a.overlaps = true;
+                    a.overlaps_exactly = true;
                 } else {
                     break;
                 }
@@ -290,7 +290,7 @@ impl EmitterWriter {
                 max_depth = ann.depth;
             }
             let mut end_ann = ann.as_end();
-            if !ann.overlaps {
+            if !ann.overlaps_exactly {
                 // avoid output like
                 //
                 //  |        foo(

--- a/src/librustc_errors/snippet.rs
+++ b/src/librustc_errors/snippet.rs
@@ -18,11 +18,18 @@ pub struct MultilineAnnotation {
     pub end_col: usize,
     pub is_primary: bool,
     pub label: Option<String>,
+    pub overlaps: bool,
 }
 
 impl MultilineAnnotation {
     pub fn increase_depth(&mut self) {
         self.depth += 1;
+    }
+
+    /// Compare two `MultilineAnnotation`s considering only the `Span` they cover.
+    pub fn same_span(&self, other: &MultilineAnnotation) -> bool {
+        self.line_start == other.line_start && self.line_end == other.line_end
+            && self.start_col == other.start_col && self.end_col == other.end_col
     }
 
     pub fn as_start(&self) -> Annotation {

--- a/src/librustc_errors/snippet.rs
+++ b/src/librustc_errors/snippet.rs
@@ -18,7 +18,7 @@ pub struct MultilineAnnotation {
     pub end_col: usize,
     pub is_primary: bool,
     pub label: Option<String>,
-    pub overlaps: bool,
+    pub overlaps_exactly: bool,
 }
 
 impl MultilineAnnotation {

--- a/src/librustc_mir/monomorphize/collector.rs
+++ b/src/librustc_mir/monomorphize/collector.rs
@@ -1040,7 +1040,7 @@ impl<'b, 'a, 'v> ItemLikeVisitor<'v> for RootCollector<'b, 'a, 'v> {
 
 impl<'b, 'a, 'v> RootCollector<'b, 'a, 'v> {
     fn is_root(&self, def_id: DefId) -> bool {
-        !item_has_type_parameters(self.tcx, def_id) && match self.mode {
+        !item_requires_monomorphization(self.tcx, def_id) && match self.mode {
             MonoItemCollectionMode::Eager => {
                 true
             }
@@ -1101,7 +1101,7 @@ impl<'b, 'a, 'v> RootCollector<'b, 'a, 'v> {
     }
 }
 
-fn item_has_type_parameters<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) -> bool {
+fn item_requires_monomorphization<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) -> bool {
     let generics = tcx.generics_of(def_id);
     generics.requires_monomorphization(tcx)
 }

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -1697,7 +1697,12 @@ impl<'a> hir::lowering::Resolver for Resolver<'a> {
         components: &[&str],
         is_value: bool
     ) -> hir::Path {
-        let segments = iter::once(keywords::PathRoot.ident())
+        let root = if crate_root.is_some() {
+            keywords::PathRoot
+        } else {
+            keywords::Crate
+        };
+        let segments = iter::once(root.ident())
             .chain(
                 crate_root.into_iter()
                     .chain(components.iter().cloned())

--- a/src/librustc_save_analysis/dump_visitor.rs
+++ b/src/librustc_save_analysis/dump_visitor.rs
@@ -659,7 +659,7 @@ impl<'l, 'tcx: 'l, 'll, O: DumpOutput + 'll> DumpVisitor<'l, 'tcx, 'll, O> {
     fn process_impl(
         &mut self,
         item: &'l ast::Item,
-        type_parameters: &'l ast::Generics,
+        generics: &'l ast::Generics,
         trait_ref: &'l Option<ast::TraitRef>,
         typ: &'l ast::Ty,
         impl_items: &'l [ast::ImplItem],
@@ -678,7 +678,7 @@ impl<'l, 'tcx: 'l, 'll, O: DumpOutput + 'll> DumpVisitor<'l, 'tcx, 'll, O> {
         if let &Some(ref trait_ref) = trait_ref {
             self.process_path(trait_ref.ref_id, &trait_ref.path);
         }
-        self.process_generic_params(type_parameters, "", item.id);
+        self.process_generic_params(generics, "", item.id);
         for impl_item in impl_items {
             let map = &self.tcx.hir();
             self.process_impl_item(impl_item, map.local_def_id(item.id));

--- a/src/librustc_typeck/check/demand.rs
+++ b/src/librustc_typeck/check/demand.rs
@@ -10,7 +10,7 @@ use rustc::hir::Node;
 use rustc::hir::{Item, ItemKind, print};
 use rustc::ty::{self, Ty, AssociatedItem};
 use rustc::ty::adjustment::AllowTwoPhase;
-use errors::{Applicability, DiagnosticBuilder, SourceMapper};
+use errors::{Applicability, DiagnosticBuilder};
 
 use super::method::probe;
 
@@ -271,9 +271,10 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                  expected: Ty<'tcx>)
                  -> Option<(Span, &'static str, String)> {
         let cm = self.sess().source_map();
-        // Use the callsite's span if this is a macro call. #41858
-        let sp = cm.call_span_if_macro(expr.span);
+        let sp = expr.span;
         if !cm.span_to_filename(sp).is_real() {
+            // Ignore if span is from within a macro #41858, #58298. We previously used the macro
+            // call span, but that breaks down when the type error comes from multiple calls down.
             return None;
         }
 

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -2550,7 +2550,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
             Neither if self.type_var_diverges(ty) => self.tcx.mk_diverging_default(),
             Neither => return false,
         };
-        debug!("default_type_parameters: defaulting `{:?}` to `{:?}`", ty, fallback);
+        debug!("fallback_if_possible: defaulting `{:?}` to `{:?}`", ty, fallback);
         self.demand_eqtype(syntax_pos::DUMMY_SP, ty, fallback);
         true
     }

--- a/src/librustc_typeck/check/op.rs
+++ b/src/librustc_typeck/check/op.rs
@@ -306,7 +306,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                             if let Some(missing_trait) = missing_trait {
                                 if op.node == hir::BinOpKind::Add &&
                                     self.check_str_addition(expr, lhs_expr, rhs_expr, lhs_ty,
-                                                            rhs_ty, &mut err, true) {
+                                                            rhs_ty, &mut err, true, op) {
                                     // This has nothing here because it means we did string
                                     // concatenation (e.g., "Hello " += "World!"). This means
                                     // we don't want the note in the else clause to be emitted
@@ -332,8 +332,10 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                 op.node.as_str(),
                                 lhs_ty);
 
-                            err.span_label(lhs_expr.span, lhs_ty.to_string());
-                            err.span_label(rhs_expr.span, rhs_ty.to_string());
+                            if !lhs_expr.span.eq(&rhs_expr.span) {
+                                err.span_label(lhs_expr.span, lhs_ty.to_string());
+                                err.span_label(rhs_expr.span, rhs_ty.to_string());
+                            }
 
                             let mut suggested_deref = false;
                             if let Ref(_, mut rty, _) = lhs_ty.sty {
@@ -384,7 +386,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                             if let Some(missing_trait) = missing_trait {
                                 if op.node == hir::BinOpKind::Add &&
                                     self.check_str_addition(expr, lhs_expr, rhs_expr, lhs_ty,
-                                                            rhs_ty, &mut err, false) {
+                                                            rhs_ty, &mut err, false, op) {
                                     // This has nothing here because it means we did string
                                     // concatenation (e.g., "Hello " + "World!"). This means
                                     // we don't want the note in the else clause to be emitted
@@ -422,6 +424,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         rhs_ty: Ty<'tcx>,
         err: &mut errors::DiagnosticBuilder<'_>,
         is_assign: bool,
+        op: hir::BinOp,
     ) -> bool {
         let source_map = self.tcx.sess.source_map();
         let msg = "`to_owned()` can be used to create an owned `String` \
@@ -435,7 +438,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
             (&Ref(_, l_ty, _), &Ref(_, r_ty, _))
             if l_ty.sty == Str && r_ty.sty == Str => {
                 if !is_assign {
-                    err.span_label(expr.span,
+                    err.span_label(op.span,
                                    "`+` can't be used to concatenate two `&str` strings");
                     match source_map.span_to_snippet(lhs_expr.span) {
                         Ok(lstring) => err.span_suggestion(

--- a/src/librustc_typeck/check/op.rs
+++ b/src/librustc_typeck/check/op.rs
@@ -327,10 +327,14 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                             err.emit();
                         }
                         IsAssign::No => {
-                            let mut err = struct_span_err!(self.tcx.sess, expr.span, E0369,
+                            let mut err = struct_span_err!(self.tcx.sess, op.span, E0369,
                                 "binary operation `{}` cannot be applied to type `{}`",
                                 op.node.as_str(),
                                 lhs_ty);
+
+                            err.span_label(lhs_expr.span, lhs_ty.to_string());
+                            err.span_label(rhs_expr.span, rhs_ty.to_string());
+
                             let mut suggested_deref = false;
                             if let Ref(_, mut rty, _) = lhs_ty.sty {
                                 if {

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -1,5 +1,5 @@
 use crate::check::{Inherited, FnCtxt};
-use crate::constrained_type_params::{identify_constrained_type_params, Parameter};
+use crate::constrained_generic_params::{identify_constrained_generic_params, Parameter};
 
 use crate::hir::def_id::DefId;
 use rustc::traits::{self, ObligationCauseCode};
@@ -941,7 +941,7 @@ fn check_variances_for_type_defn<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                         .map(|(index, _)| Parameter(index as u32))
                         .collect();
 
-    identify_constrained_type_params(tcx,
+    identify_constrained_generic_params(tcx,
                                      &ty_predicates,
                                      None,
                                      &mut constrained_parameters);

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -15,7 +15,7 @@
 //! crate as a kind of pass. This should eventually be factored away.
 
 use crate::astconv::{AstConv, Bounds};
-use crate::constrained_type_params as ctp;
+use crate::constrained_generic_params as ctp;
 use crate::check::intrinsic::intrisic_operation_unsafety;
 use crate::lint;
 use crate::middle::lang_items::SizedTraitLangItem;

--- a/src/librustc_typeck/constrained_generic_params.rs
+++ b/src/librustc_typeck/constrained_generic_params.rs
@@ -86,7 +86,7 @@ impl<'tcx> TypeVisitor<'tcx> for ParameterCollector {
     }
 }
 
-pub fn identify_constrained_type_params<'tcx>(tcx: TyCtxt<'_, 'tcx, 'tcx>,
+pub fn identify_constrained_generic_params<'tcx>(tcx: TyCtxt<'_, 'tcx, 'tcx>,
                                               predicates: &ty::GenericPredicates<'tcx>,
                                               impl_trait_ref: Option<ty::TraitRef<'tcx>>,
                                               input_parameters: &mut FxHashSet<Parameter>)

--- a/src/librustc_typeck/impl_wf_check.rs
+++ b/src/librustc_typeck/impl_wf_check.rs
@@ -8,7 +8,7 @@
 //! specialization errors. These things can (and probably should) be
 //! fixed, but for the moment it's easier to do these checks early.
 
-use crate::constrained_type_params as ctp;
+use crate::constrained_generic_params as ctp;
 use rustc::hir;
 use rustc::hir::itemlikevisit::ItemLikeVisitor;
 use rustc::hir::def_id::DefId;
@@ -103,7 +103,7 @@ fn enforce_impl_params_are_constrained<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     let impl_trait_ref = tcx.impl_trait_ref(impl_def_id);
 
     let mut input_parameters = ctp::parameters_for_impl(impl_self_ty, impl_trait_ref);
-    ctp::identify_constrained_type_params(
+    ctp::identify_constrained_generic_params(
         tcx, &impl_predicates, impl_trait_ref, &mut input_parameters);
 
     // Disallow unconstrained lifetimes, but only if they appear in assoc types.

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -88,7 +88,7 @@ mod check;
 mod check_unused;
 mod coherence;
 mod collect;
-mod constrained_type_params;
+mod constrained_generic_params;
 mod structured_errors;
 mod impl_wf_check;
 mod namespace;

--- a/src/libsyntax/test_snippet.rs
+++ b/src/libsyntax/test_snippet.rs
@@ -375,6 +375,66 @@ error: foo
 }
 
 #[test]
+fn triple_exact_overlap() {
+    test_harness(r#"
+fn foo() {
+  X0 Y0 Z0
+  X1 Y1 Z1
+  X2 Y2 Z2
+}
+"#,
+    vec![
+        SpanLabel {
+            start: Position {
+                string: "X0",
+                count: 1,
+            },
+            end: Position {
+                string: "X2",
+                count: 1,
+            },
+            label: "`X` is a good letter",
+        },
+        SpanLabel {
+            start: Position {
+                string: "X0",
+                count: 1,
+            },
+            end: Position {
+                string: "X2",
+                count: 1,
+            },
+            label: "`Y` is a good letter too",
+        },
+        SpanLabel {
+            start: Position {
+                string: "X0",
+                count: 1,
+            },
+            end: Position {
+                string: "X2",
+                count: 1,
+            },
+            label: "`Z` label",
+        },
+    ],
+    r#"
+error: foo
+ --> test.rs:3:3
+  |
+3 | /   X0 Y0 Z0
+4 | |   X1 Y1 Z1
+5 | |   X2 Y2 Z2
+  | |    ^
+  | |    |
+  | |    `X` is a good letter
+  | |____`Y` is a good letter too
+  |      `Z` label
+
+"#);
+}
+
+#[test]
 fn minimum_depth() {
     test_harness(r#"
 fn foo() {

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -244,24 +244,24 @@ pub fn walk_item<'a, V: Visitor<'a>>(visitor: &mut V, item: &'a Item) {
             walk_list!(visitor, visit_foreign_item, &foreign_module.items);
         }
         ItemKind::GlobalAsm(ref ga) => visitor.visit_global_asm(ga),
-        ItemKind::Ty(ref typ, ref type_parameters) => {
+        ItemKind::Ty(ref typ, ref generics) => {
             visitor.visit_ty(typ);
-            visitor.visit_generics(type_parameters)
+            visitor.visit_generics(generics)
         }
-        ItemKind::Existential(ref bounds, ref type_parameters) => {
+        ItemKind::Existential(ref bounds, ref generics) => {
             walk_list!(visitor, visit_param_bound, bounds);
-            visitor.visit_generics(type_parameters)
+            visitor.visit_generics(generics)
         }
-        ItemKind::Enum(ref enum_definition, ref type_parameters) => {
-            visitor.visit_generics(type_parameters);
-            visitor.visit_enum_def(enum_definition, type_parameters, item.id, item.span)
+        ItemKind::Enum(ref enum_definition, ref generics) => {
+            visitor.visit_generics(generics);
+            visitor.visit_enum_def(enum_definition, generics, item.id, item.span)
         }
         ItemKind::Impl(_, _, _,
-                 ref type_parameters,
+                 ref generics,
                  ref opt_trait_reference,
                  ref typ,
                  ref impl_items) => {
-            visitor.visit_generics(type_parameters);
+            visitor.visit_generics(generics);
             walk_list!(visitor, visit_trait_ref, opt_trait_reference);
             visitor.visit_ty(typ);
             walk_list!(visitor, visit_impl_item, impl_items);

--- a/src/rustc/Cargo.toml
+++ b/src/rustc/Cargo.toml
@@ -17,7 +17,7 @@ rustc_driver = { path = "../librustc_driver" }
 rustc_codegen_ssa = { path = "../librustc_codegen_ssa" }
 
 [dependencies.jemalloc-sys]
-version = '0.1.8'
+version = '0.3.0'
 optional = true
 features = ['unprefixed_malloc_on_supported_platforms']
 

--- a/src/test/run-pass/no-core-2.rs
+++ b/src/test/run-pass/no-core-2.rs
@@ -1,0 +1,18 @@
+#![allow(dead_code, unused_imports)]
+#![feature(no_core)]
+#![no_core]
+// edition:2018
+
+extern crate std;
+extern crate core;
+use core::{prelude::v1::*, *};
+
+fn foo() {
+    for _ in &[()] {}
+}
+
+fn bar() -> Option<()> {
+    None?
+}
+
+fn main() {}

--- a/src/test/ui/autoderef-full-lval.stderr
+++ b/src/test/ui/autoderef-full-lval.stderr
@@ -1,16 +1,20 @@
 error[E0369]: binary operation `+` cannot be applied to type `std::boxed::Box<isize>`
-  --> $DIR/autoderef-full-lval.rs:15:20
+  --> $DIR/autoderef-full-lval.rs:15:24
    |
 LL |     let z: isize = a.x + b.y;
-   |                    ^^^^^^^^^
+   |                    --- ^ --- std::boxed::Box<isize>
+   |                    |
+   |                    std::boxed::Box<isize>
    |
    = note: an implementation of `std::ops::Add` might be missing for `std::boxed::Box<isize>`
 
 error[E0369]: binary operation `+` cannot be applied to type `std::boxed::Box<isize>`
-  --> $DIR/autoderef-full-lval.rs:21:25
+  --> $DIR/autoderef-full-lval.rs:21:33
    |
 LL |     let answer: isize = forty.a + two.a;
-   |                         ^^^^^^^^^^^^^^^
+   |                         ------- ^ ----- std::boxed::Box<isize>
+   |                         |
+   |                         std::boxed::Box<isize>
    |
    = note: an implementation of `std::ops::Add` might be missing for `std::boxed::Box<isize>`
 

--- a/src/test/ui/binary-op-on-double-ref.stderr
+++ b/src/test/ui/binary-op-on-double-ref.stderr
@@ -1,8 +1,10 @@
 error[E0369]: binary operation `%` cannot be applied to type `&&{integer}`
-  --> $DIR/binary-op-on-double-ref.rs:4:9
+  --> $DIR/binary-op-on-double-ref.rs:4:11
    |
 LL |         x % 2 == 0
-   |         ^^^^^
+   |         - ^ - {integer}
+   |         |
+   |         &&{integer}
    |
    = help: `%` can be used on '{integer}', you can dereference `x`: `*x`
 

--- a/src/test/ui/binop/binop-bitxor-str.stderr
+++ b/src/test/ui/binop/binop-bitxor-str.stderr
@@ -1,8 +1,10 @@
 error[E0369]: binary operation `^` cannot be applied to type `std::string::String`
-  --> $DIR/binop-bitxor-str.rs:3:21
+  --> $DIR/binop-bitxor-str.rs:3:37
    |
 LL | fn main() { let x = "a".to_string() ^ "b".to_string(); }
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                     --------------- ^ --------------- std::string::String
+   |                     |
+   |                     std::string::String
    |
    = note: an implementation of `std::ops::BitXor` might be missing for `std::string::String`
 

--- a/src/test/ui/binop/binop-mul-bool.stderr
+++ b/src/test/ui/binop/binop-mul-bool.stderr
@@ -1,8 +1,10 @@
 error[E0369]: binary operation `*` cannot be applied to type `bool`
-  --> $DIR/binop-mul-bool.rs:3:21
+  --> $DIR/binop-mul-bool.rs:3:26
    |
 LL | fn main() { let x = true * false; }
-   |                     ^^^^^^^^^^^^
+   |                     ---- ^ ----- bool
+   |                     |
+   |                     bool
    |
    = note: an implementation of `std::ops::Mul` might be missing for `bool`
 

--- a/src/test/ui/binop/binop-typeck.stderr
+++ b/src/test/ui/binop/binop-typeck.stderr
@@ -1,8 +1,10 @@
 error[E0369]: binary operation `+` cannot be applied to type `bool`
-  --> $DIR/binop-typeck.rs:6:13
+  --> $DIR/binop-typeck.rs:6:15
    |
 LL |     let z = x + y;
-   |             ^^^^^
+   |             - ^ - {integer}
+   |             |
+   |             bool
    |
    = note: an implementation of `std::ops::Add` might be missing for `bool`
 

--- a/src/test/ui/dead-code-impl.rs
+++ b/src/test/ui/dead-code-impl.rs
@@ -1,0 +1,17 @@
+// run-pass
+
+#![deny(dead_code)]
+
+pub struct GenericFoo<T>(T);
+
+type Foo = GenericFoo<u32>;
+
+impl Foo {
+    fn bar(self) -> u8 {
+        0
+    }
+}
+
+fn main() {
+    println!("{}", GenericFoo(0).bar());
+}

--- a/src/test/ui/derives/derives-span-PartialEq-enum-struct-variant.stderr
+++ b/src/test/ui/derives/derives-span-PartialEq-enum-struct-variant.stderr
@@ -3,6 +3,9 @@ error[E0369]: binary operation `==` cannot be applied to type `Error`
    |
 LL |      x: Error
    |      ^^^^^^^^
+   |      |
+   |      Error
+   |      Error
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `Error`
 
@@ -11,6 +14,9 @@ error[E0369]: binary operation `!=` cannot be applied to type `Error`
    |
 LL |      x: Error
    |      ^^^^^^^^
+   |      |
+   |      Error
+   |      Error
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `Error`
 

--- a/src/test/ui/derives/derives-span-PartialEq-enum-struct-variant.stderr
+++ b/src/test/ui/derives/derives-span-PartialEq-enum-struct-variant.stderr
@@ -3,9 +3,6 @@ error[E0369]: binary operation `==` cannot be applied to type `Error`
    |
 LL |      x: Error
    |      ^^^^^^^^
-   |      |
-   |      Error
-   |      Error
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `Error`
 
@@ -14,9 +11,6 @@ error[E0369]: binary operation `!=` cannot be applied to type `Error`
    |
 LL |      x: Error
    |      ^^^^^^^^
-   |      |
-   |      Error
-   |      Error
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `Error`
 

--- a/src/test/ui/derives/derives-span-PartialEq-enum.stderr
+++ b/src/test/ui/derives/derives-span-PartialEq-enum.stderr
@@ -3,9 +3,6 @@ error[E0369]: binary operation `==` cannot be applied to type `Error`
    |
 LL |      Error
    |      ^^^^^
-   |      |
-   |      Error
-   |      Error
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `Error`
 
@@ -14,9 +11,6 @@ error[E0369]: binary operation `!=` cannot be applied to type `Error`
    |
 LL |      Error
    |      ^^^^^
-   |      |
-   |      Error
-   |      Error
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `Error`
 

--- a/src/test/ui/derives/derives-span-PartialEq-enum.stderr
+++ b/src/test/ui/derives/derives-span-PartialEq-enum.stderr
@@ -3,6 +3,9 @@ error[E0369]: binary operation `==` cannot be applied to type `Error`
    |
 LL |      Error
    |      ^^^^^
+   |      |
+   |      Error
+   |      Error
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `Error`
 
@@ -11,6 +14,9 @@ error[E0369]: binary operation `!=` cannot be applied to type `Error`
    |
 LL |      Error
    |      ^^^^^
+   |      |
+   |      Error
+   |      Error
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `Error`
 

--- a/src/test/ui/derives/derives-span-PartialEq-struct.stderr
+++ b/src/test/ui/derives/derives-span-PartialEq-struct.stderr
@@ -3,6 +3,9 @@ error[E0369]: binary operation `==` cannot be applied to type `Error`
    |
 LL |     x: Error
    |     ^^^^^^^^
+   |     |
+   |     Error
+   |     Error
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `Error`
 
@@ -11,6 +14,9 @@ error[E0369]: binary operation `!=` cannot be applied to type `Error`
    |
 LL |     x: Error
    |     ^^^^^^^^
+   |     |
+   |     Error
+   |     Error
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `Error`
 

--- a/src/test/ui/derives/derives-span-PartialEq-struct.stderr
+++ b/src/test/ui/derives/derives-span-PartialEq-struct.stderr
@@ -3,9 +3,6 @@ error[E0369]: binary operation `==` cannot be applied to type `Error`
    |
 LL |     x: Error
    |     ^^^^^^^^
-   |     |
-   |     Error
-   |     Error
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `Error`
 
@@ -14,9 +11,6 @@ error[E0369]: binary operation `!=` cannot be applied to type `Error`
    |
 LL |     x: Error
    |     ^^^^^^^^
-   |     |
-   |     Error
-   |     Error
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `Error`
 

--- a/src/test/ui/derives/derives-span-PartialEq-tuple-struct.stderr
+++ b/src/test/ui/derives/derives-span-PartialEq-tuple-struct.stderr
@@ -3,6 +3,9 @@ error[E0369]: binary operation `==` cannot be applied to type `Error`
    |
 LL |     Error
    |     ^^^^^
+   |     |
+   |     Error
+   |     Error
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `Error`
 
@@ -11,6 +14,9 @@ error[E0369]: binary operation `!=` cannot be applied to type `Error`
    |
 LL |     Error
    |     ^^^^^
+   |     |
+   |     Error
+   |     Error
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `Error`
 

--- a/src/test/ui/derives/derives-span-PartialEq-tuple-struct.stderr
+++ b/src/test/ui/derives/derives-span-PartialEq-tuple-struct.stderr
@@ -3,9 +3,6 @@ error[E0369]: binary operation `==` cannot be applied to type `Error`
    |
 LL |     Error
    |     ^^^^^
-   |     |
-   |     Error
-   |     Error
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `Error`
 
@@ -14,9 +11,6 @@ error[E0369]: binary operation `!=` cannot be applied to type `Error`
    |
 LL |     Error
    |     ^^^^^
-   |     |
-   |     Error
-   |     Error
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `Error`
 

--- a/src/test/ui/derives/deriving-no-inner-impl-error-message.stderr
+++ b/src/test/ui/derives/deriving-no-inner-impl-error-message.stderr
@@ -3,9 +3,6 @@ error[E0369]: binary operation `==` cannot be applied to type `NoCloneOrEq`
    |
 LL |     x: NoCloneOrEq
    |     ^^^^^^^^^^^^^^
-   |     |
-   |     NoCloneOrEq
-   |     NoCloneOrEq
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `NoCloneOrEq`
 
@@ -14,9 +11,6 @@ error[E0369]: binary operation `!=` cannot be applied to type `NoCloneOrEq`
    |
 LL |     x: NoCloneOrEq
    |     ^^^^^^^^^^^^^^
-   |     |
-   |     NoCloneOrEq
-   |     NoCloneOrEq
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `NoCloneOrEq`
 

--- a/src/test/ui/derives/deriving-no-inner-impl-error-message.stderr
+++ b/src/test/ui/derives/deriving-no-inner-impl-error-message.stderr
@@ -3,6 +3,9 @@ error[E0369]: binary operation `==` cannot be applied to type `NoCloneOrEq`
    |
 LL |     x: NoCloneOrEq
    |     ^^^^^^^^^^^^^^
+   |     |
+   |     NoCloneOrEq
+   |     NoCloneOrEq
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `NoCloneOrEq`
 
@@ -11,6 +14,9 @@ error[E0369]: binary operation `!=` cannot be applied to type `NoCloneOrEq`
    |
 LL |     x: NoCloneOrEq
    |     ^^^^^^^^^^^^^^
+   |     |
+   |     NoCloneOrEq
+   |     NoCloneOrEq
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `NoCloneOrEq`
 

--- a/src/test/ui/fn/fn-compare-mismatch.stderr
+++ b/src/test/ui/fn/fn-compare-mismatch.stderr
@@ -1,8 +1,10 @@
 error[E0369]: binary operation `==` cannot be applied to type `fn() {main::f}`
-  --> $DIR/fn-compare-mismatch.rs:4:13
+  --> $DIR/fn-compare-mismatch.rs:4:15
    |
 LL |     let x = f == g;
-   |             ^^^^^^
+   |             - ^^ - fn() {main::g}
+   |             |
+   |             fn() {main::f}
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `fn() {main::f}`
 

--- a/src/test/ui/for/for-loop-type-error.stderr
+++ b/src/test/ui/for/for-loop-type-error.stderr
@@ -1,8 +1,10 @@
 error[E0369]: binary operation `+` cannot be applied to type `()`
-  --> $DIR/for-loop-type-error.rs:2:13
+  --> $DIR/for-loop-type-error.rs:2:16
    |
 LL |     let x = () + ();
-   |             ^^^^^^^
+   |             -- ^ -- ()
+   |             |
+   |             ()
    |
    = note: an implementation of `std::ops::Add` might be missing for `()`
 

--- a/src/test/ui/issues/issue-14915.stderr
+++ b/src/test/ui/issues/issue-14915.stderr
@@ -1,8 +1,10 @@
 error[E0369]: binary operation `+` cannot be applied to type `std::boxed::Box<isize>`
-  --> $DIR/issue-14915.rs:6:20
+  --> $DIR/issue-14915.rs:6:22
    |
 LL |     println!("{}", x + 1);
-   |                    ^^^^^
+   |                    - ^ - {integer}
+   |                    |
+   |                    std::boxed::Box<isize>
    |
    = note: an implementation of `std::ops::Add` might be missing for `std::boxed::Box<isize>`
 

--- a/src/test/ui/issues/issue-24363.stderr
+++ b/src/test/ui/issues/issue-24363.stderr
@@ -5,10 +5,12 @@ LL |     1.create_a_type_error[
    |       ^^^^^^^^^^^^^^^^^^^
 
 error[E0369]: binary operation `+` cannot be applied to type `()`
-  --> $DIR/issue-24363.rs:3:9
+  --> $DIR/issue-24363.rs:3:11
    |
 LL |         ()+()
-   |         ^^^^^
+   |         --^-- ()
+   |         |
+   |         ()
    |
    = note: an implementation of `std::ops::Add` might be missing for `()`
 

--- a/src/test/ui/issues/issue-28837.stderr
+++ b/src/test/ui/issues/issue-28837.stderr
@@ -1,120 +1,150 @@
 error[E0369]: binary operation `+` cannot be applied to type `A`
-  --> $DIR/issue-28837.rs:6:5
+  --> $DIR/issue-28837.rs:6:7
    |
 LL |     a + a;
-   |     ^^^^^
+   |     - ^ - A
+   |     |
+   |     A
    |
    = note: an implementation of `std::ops::Add` might be missing for `A`
 
 error[E0369]: binary operation `-` cannot be applied to type `A`
-  --> $DIR/issue-28837.rs:8:5
+  --> $DIR/issue-28837.rs:8:7
    |
 LL |     a - a;
-   |     ^^^^^
+   |     - ^ - A
+   |     |
+   |     A
    |
    = note: an implementation of `std::ops::Sub` might be missing for `A`
 
 error[E0369]: binary operation `*` cannot be applied to type `A`
-  --> $DIR/issue-28837.rs:10:5
+  --> $DIR/issue-28837.rs:10:7
    |
 LL |     a * a;
-   |     ^^^^^
+   |     - ^ - A
+   |     |
+   |     A
    |
    = note: an implementation of `std::ops::Mul` might be missing for `A`
 
 error[E0369]: binary operation `/` cannot be applied to type `A`
-  --> $DIR/issue-28837.rs:12:5
+  --> $DIR/issue-28837.rs:12:7
    |
 LL |     a / a;
-   |     ^^^^^
+   |     - ^ - A
+   |     |
+   |     A
    |
    = note: an implementation of `std::ops::Div` might be missing for `A`
 
 error[E0369]: binary operation `%` cannot be applied to type `A`
-  --> $DIR/issue-28837.rs:14:5
+  --> $DIR/issue-28837.rs:14:7
    |
 LL |     a % a;
-   |     ^^^^^
+   |     - ^ - A
+   |     |
+   |     A
    |
    = note: an implementation of `std::ops::Rem` might be missing for `A`
 
 error[E0369]: binary operation `&` cannot be applied to type `A`
-  --> $DIR/issue-28837.rs:16:5
+  --> $DIR/issue-28837.rs:16:7
    |
 LL |     a & a;
-   |     ^^^^^
+   |     - ^ - A
+   |     |
+   |     A
    |
    = note: an implementation of `std::ops::BitAnd` might be missing for `A`
 
 error[E0369]: binary operation `|` cannot be applied to type `A`
-  --> $DIR/issue-28837.rs:18:5
+  --> $DIR/issue-28837.rs:18:7
    |
 LL |     a | a;
-   |     ^^^^^
+   |     - ^ - A
+   |     |
+   |     A
    |
    = note: an implementation of `std::ops::BitOr` might be missing for `A`
 
 error[E0369]: binary operation `<<` cannot be applied to type `A`
-  --> $DIR/issue-28837.rs:20:5
+  --> $DIR/issue-28837.rs:20:7
    |
 LL |     a << a;
-   |     ^^^^^^
+   |     - ^^ - A
+   |     |
+   |     A
    |
    = note: an implementation of `std::ops::Shl` might be missing for `A`
 
 error[E0369]: binary operation `>>` cannot be applied to type `A`
-  --> $DIR/issue-28837.rs:22:5
+  --> $DIR/issue-28837.rs:22:7
    |
 LL |     a >> a;
-   |     ^^^^^^
+   |     - ^^ - A
+   |     |
+   |     A
    |
    = note: an implementation of `std::ops::Shr` might be missing for `A`
 
 error[E0369]: binary operation `==` cannot be applied to type `A`
-  --> $DIR/issue-28837.rs:24:5
+  --> $DIR/issue-28837.rs:24:7
    |
 LL |     a == a;
-   |     ^^^^^^
+   |     - ^^ - A
+   |     |
+   |     A
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `A`
 
 error[E0369]: binary operation `!=` cannot be applied to type `A`
-  --> $DIR/issue-28837.rs:26:5
+  --> $DIR/issue-28837.rs:26:7
    |
 LL |     a != a;
-   |     ^^^^^^
+   |     - ^^ - A
+   |     |
+   |     A
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `A`
 
 error[E0369]: binary operation `<` cannot be applied to type `A`
-  --> $DIR/issue-28837.rs:28:5
+  --> $DIR/issue-28837.rs:28:7
    |
 LL |     a < a;
-   |     ^^^^^
+   |     - ^ - A
+   |     |
+   |     A
    |
    = note: an implementation of `std::cmp::PartialOrd` might be missing for `A`
 
 error[E0369]: binary operation `<=` cannot be applied to type `A`
-  --> $DIR/issue-28837.rs:30:5
+  --> $DIR/issue-28837.rs:30:7
    |
 LL |     a <= a;
-   |     ^^^^^^
+   |     - ^^ - A
+   |     |
+   |     A
    |
    = note: an implementation of `std::cmp::PartialOrd` might be missing for `A`
 
 error[E0369]: binary operation `>` cannot be applied to type `A`
-  --> $DIR/issue-28837.rs:32:5
+  --> $DIR/issue-28837.rs:32:7
    |
 LL |     a > a;
-   |     ^^^^^
+   |     - ^ - A
+   |     |
+   |     A
    |
    = note: an implementation of `std::cmp::PartialOrd` might be missing for `A`
 
 error[E0369]: binary operation `>=` cannot be applied to type `A`
-  --> $DIR/issue-28837.rs:34:5
+  --> $DIR/issue-28837.rs:34:7
    |
 LL |     a >= a;
-   |     ^^^^^^
+   |     - ^^ - A
+   |     |
+   |     A
    |
    = note: an implementation of `std::cmp::PartialOrd` might be missing for `A`
 

--- a/src/test/ui/issues/issue-31076.stderr
+++ b/src/test/ui/issues/issue-31076.stderr
@@ -1,16 +1,20 @@
 error[E0369]: binary operation `+` cannot be applied to type `{integer}`
-  --> $DIR/issue-31076.rs:13:13
+  --> $DIR/issue-31076.rs:13:15
    |
 LL |     let x = 5 + 6;
-   |             ^^^^^
+   |             - ^ - {integer}
+   |             |
+   |             {integer}
    |
    = note: an implementation of `std::ops::Add` might be missing for `{integer}`
 
 error[E0369]: binary operation `+` cannot be applied to type `i32`
-  --> $DIR/issue-31076.rs:15:13
+  --> $DIR/issue-31076.rs:15:18
    |
 LL |     let y = 5i32 + 6i32;
-   |             ^^^^^^^^^^^
+   |             ---- ^ ---- i32
+   |             |
+   |             i32
    |
    = note: an implementation of `std::ops::Add` might be missing for `i32`
 

--- a/src/test/ui/issues/issue-35668.stderr
+++ b/src/test/ui/issues/issue-35668.stderr
@@ -1,8 +1,10 @@
 error[E0369]: binary operation `*` cannot be applied to type `&T`
-  --> $DIR/issue-35668.rs:2:22
+  --> $DIR/issue-35668.rs:2:23
    |
 LL |     a.iter().map(|a| a*a)
-   |                      ^^^
+   |                      -^- &T
+   |                      |
+   |                      &T
    |
    = note: an implementation of `std::ops::Mul` might be missing for `&T`
 

--- a/src/test/ui/issues/issue-3820.stderr
+++ b/src/test/ui/issues/issue-3820.stderr
@@ -1,8 +1,10 @@
 error[E0369]: binary operation `*` cannot be applied to type `Thing`
-  --> $DIR/issue-3820.rs:14:13
+  --> $DIR/issue-3820.rs:14:15
    |
 LL |     let w = u * 3;
-   |             ^^^^^
+   |             - ^ - {integer}
+   |             |
+   |             Thing
    |
    = note: an implementation of `std::ops::Mul` might be missing for `Thing`
 

--- a/src/test/ui/issues/issue-40610.stderr
+++ b/src/test/ui/issues/issue-40610.stderr
@@ -1,8 +1,10 @@
 error[E0369]: binary operation `+` cannot be applied to type `()`
-  --> $DIR/issue-40610.rs:4:5
+  --> $DIR/issue-40610.rs:4:8
    |
 LL |     () + f(&[1.0]);
-   |     ^^^^^^^^^^^^^^
+   |     -- ^ --------- ()
+   |     |
+   |     ()
    |
    = note: an implementation of `std::ops::Add` might be missing for `()`
 

--- a/src/test/ui/issues/issue-41394.stderr
+++ b/src/test/ui/issues/issue-41394.stderr
@@ -1,8 +1,10 @@
 error[E0369]: binary operation `+` cannot be applied to type `&str`
-  --> $DIR/issue-41394.rs:2:9
+  --> $DIR/issue-41394.rs:2:12
    |
 LL |     A = "" + 1
-   |         ^^^^^^
+   |         -- ^ - {integer}
+   |         |
+   |         &str
    |
    = note: an implementation of `std::ops::Add` might be missing for `&str`
 

--- a/src/test/ui/issues/issue-47377.stderr
+++ b/src/test/ui/issues/issue-47377.stderr
@@ -1,8 +1,12 @@
 error[E0369]: binary operation `+` cannot be applied to type `&str`
-  --> $DIR/issue-47377.rs:4:12
+  --> $DIR/issue-47377.rs:4:14
    |
 LL |      let _a = b + ", World!";
-   |               ^^^^^^^^^^^^^^ `+` can't be used to concatenate two `&str` strings
+   |               --^-----------
+   |               |   |
+   |               |   &str
+   |               &str
+   |               `+` can't be used to concatenate two `&str` strings
 help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
    |
 LL |      let _a = b.to_owned() + ", World!";

--- a/src/test/ui/issues/issue-47377.stderr
+++ b/src/test/ui/issues/issue-47377.stderr
@@ -2,11 +2,10 @@ error[E0369]: binary operation `+` cannot be applied to type `&str`
   --> $DIR/issue-47377.rs:4:14
    |
 LL |      let _a = b + ", World!";
-   |               --^-----------
-   |               |   |
-   |               |   &str
+   |               - ^ ---------- &str
+   |               | |
+   |               | `+` can't be used to concatenate two `&str` strings
    |               &str
-   |               `+` can't be used to concatenate two `&str` strings
 help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
    |
 LL |      let _a = b.to_owned() + ", World!";

--- a/src/test/ui/issues/issue-47380.stderr
+++ b/src/test/ui/issues/issue-47380.stderr
@@ -2,11 +2,10 @@ error[E0369]: binary operation `+` cannot be applied to type `&str`
   --> $DIR/issue-47380.rs:3:35
    |
 LL |     println!("🦀🦀🦀🦀🦀"); let _a = b + ", World!";
-   |                                      --^-----------
-   |                                      |   |
-   |                                      |   &str
+   |                                      - ^ ---------- &str
+   |                                      | |
+   |                                      | `+` can't be used to concatenate two `&str` strings
    |                                      &str
-   |                                      `+` can't be used to concatenate two `&str` strings
 help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
    |
 LL |     println!("🦀🦀🦀🦀🦀"); let _a = b.to_owned() + ", World!";

--- a/src/test/ui/issues/issue-47380.stderr
+++ b/src/test/ui/issues/issue-47380.stderr
@@ -1,8 +1,12 @@
 error[E0369]: binary operation `+` cannot be applied to type `&str`
-  --> $DIR/issue-47380.rs:3:33
+  --> $DIR/issue-47380.rs:3:35
    |
 LL |     println!("🦀🦀🦀🦀🦀"); let _a = b + ", World!";
-   |                                      ^^^^^^^^^^^^^^ `+` can't be used to concatenate two `&str` strings
+   |                                      --^-----------
+   |                                      |   |
+   |                                      |   &str
+   |                                      &str
+   |                                      `+` can't be used to concatenate two `&str` strings
 help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
    |
 LL |     println!("🦀🦀🦀🦀🦀"); let _a = b.to_owned() + ", World!";

--- a/src/test/ui/parser/require-parens-for-chained-comparison.stderr
+++ b/src/test/ui/parser/require-parens-for-chained-comparison.stderr
@@ -38,10 +38,12 @@ LL |     false == 0 < 2;
               found type `{integer}`
 
 error[E0369]: binary operation `<` cannot be applied to type `fn() {f::<_>}`
-  --> $DIR/require-parens-for-chained-comparison.rs:13:5
+  --> $DIR/require-parens-for-chained-comparison.rs:13:6
    |
 LL |     f<X>();
-   |     ^^^
+   |     -^- X
+   |     |
+   |     fn() {f::<_>}
    |
    = note: an implementation of `std::cmp::PartialOrd` might be missing for `fn() {f::<_>}`
 

--- a/src/test/ui/pattern/pattern-tyvar-2.stderr
+++ b/src/test/ui/pattern/pattern-tyvar-2.stderr
@@ -1,8 +1,10 @@
 error[E0369]: binary operation `*` cannot be applied to type `std::vec::Vec<isize>`
-  --> $DIR/pattern-tyvar-2.rs:3:69
+  --> $DIR/pattern-tyvar-2.rs:3:71
    |
 LL | fn foo(t: Bar) -> isize { match t { Bar::T1(_, Some(x)) => { return x * 3; } _ => { panic!(); } } }
-   |                                                                     ^^^^^
+   |                                                                     - ^ - {integer}
+   |                                                                     |
+   |                                                                     std::vec::Vec<isize>
    |
    = note: an implementation of `std::ops::Mul` might be missing for `std::vec::Vec<isize>`
 

--- a/src/test/ui/span/coerce-suggestions.stderr
+++ b/src/test/ui/span/coerce-suggestions.stderr
@@ -50,10 +50,7 @@ error[E0308]: mismatched types
   --> $DIR/coerce-suggestions.rs:21:9
    |
 LL |     s = format!("foo");
-   |         ^^^^^^^^^^^^^^
-   |         |
-   |         expected mutable reference, found struct `std::string::String`
-   |         help: consider mutably borrowing here: `&mut format!("foo")`
+   |         ^^^^^^^^^^^^^^ expected mutable reference, found struct `std::string::String`
    |
    = note: expected type `&mut std::string::String`
               found type `std::string::String`

--- a/src/test/ui/span/issue-39018.stderr
+++ b/src/test/ui/span/issue-39018.stderr
@@ -1,26 +1,36 @@
 error[E0369]: binary operation `+` cannot be applied to type `&str`
-  --> $DIR/issue-39018.rs:2:13
+  --> $DIR/issue-39018.rs:2:22
    |
 LL |     let x = "Hello " + "World!";
-   |             ^^^^^^^^^^^^^^^^^^^ `+` can't be used to concatenate two `&str` strings
+   |             ---------^---------
+   |             |          |
+   |             |          &str
+   |             &str
+   |             `+` can't be used to concatenate two `&str` strings
 help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
    |
 LL |     let x = "Hello ".to_owned() + "World!";
    |             ^^^^^^^^^^^^^^^^^^^
 
 error[E0369]: binary operation `+` cannot be applied to type `World`
-  --> $DIR/issue-39018.rs:8:13
+  --> $DIR/issue-39018.rs:8:26
    |
 LL |     let y = World::Hello + World::Goodbye;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |             ------------ ^ -------------- World
+   |             |
+   |             World
    |
    = note: an implementation of `std::ops::Add` might be missing for `World`
 
 error[E0369]: binary operation `+` cannot be applied to type `&str`
-  --> $DIR/issue-39018.rs:11:13
+  --> $DIR/issue-39018.rs:11:22
    |
 LL |     let x = "Hello " + "World!".to_owned();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `+` can't be used to concatenate a `&str` with a `String`
+   |             ---------^--------------------
+   |             |          |
+   |             |          std::string::String
+   |             &str
+   |             `+` can't be used to concatenate a `&str` with a `String`
 help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
    |
 LL |     let x = "Hello ".to_owned() + &"World!".to_owned();

--- a/src/test/ui/span/issue-39018.stderr
+++ b/src/test/ui/span/issue-39018.stderr
@@ -2,11 +2,10 @@ error[E0369]: binary operation `+` cannot be applied to type `&str`
   --> $DIR/issue-39018.rs:2:22
    |
 LL |     let x = "Hello " + "World!";
-   |             ---------^---------
-   |             |          |
-   |             |          &str
+   |             -------- ^ -------- &str
+   |             |        |
+   |             |        `+` can't be used to concatenate two `&str` strings
    |             &str
-   |             `+` can't be used to concatenate two `&str` strings
 help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
    |
 LL |     let x = "Hello ".to_owned() + "World!";

--- a/src/test/ui/str/str-concat-on-double-ref.stderr
+++ b/src/test/ui/str/str-concat-on-double-ref.stderr
@@ -1,8 +1,10 @@
 error[E0369]: binary operation `+` cannot be applied to type `&std::string::String`
-  --> $DIR/str-concat-on-double-ref.rs:4:13
+  --> $DIR/str-concat-on-double-ref.rs:4:15
    |
 LL |     let c = a + b;
-   |             ^^^^^
+   |             - ^ - &str
+   |             |
+   |             &std::string::String
    |
    = note: an implementation of `std::ops::Add` might be missing for `&std::string::String`
 

--- a/src/test/ui/suggestions/dont-suggest-deref-inside-macro-issue-58298.rs
+++ b/src/test/ui/suggestions/dont-suggest-deref-inside-macro-issue-58298.rs
@@ -3,7 +3,7 @@ fn warn(_: &str) {}
 macro_rules! intrinsic_match {
     ($intrinsic:expr) => {
         warn(format!("unsupported intrinsic {}", $intrinsic));
-        //^~ ERROR mismatched types
+        //~^ ERROR mismatched types
     };
 }
 

--- a/src/test/ui/suggestions/dont-suggest-deref-inside-macro-issue-58298.rs
+++ b/src/test/ui/suggestions/dont-suggest-deref-inside-macro-issue-58298.rs
@@ -1,0 +1,14 @@
+fn warn(_: &str) {}
+
+macro_rules! intrinsic_match {
+    ($intrinsic:expr) => {
+        warn(format!("unsupported intrinsic {}", $intrinsic));
+        //^~ ERROR mismatched types
+    };
+}
+
+fn main() {
+    intrinsic_match! {
+        "abc"
+    };
+}

--- a/src/test/ui/suggestions/dont-suggest-deref-inside-macro-issue-58298.stderr
+++ b/src/test/ui/suggestions/dont-suggest-deref-inside-macro-issue-58298.stderr
@@ -1,16 +1,13 @@
 error[E0308]: mismatched types
-  --> $DIR/dont-suggest-deref-inside-macro-issue-58298.rs:10:5
+  --> $DIR/dont-suggest-deref-inside-macro-issue-58298.rs:11:5
    |
-LL |        intrinsic_match! {
-   |   _____^
-   |  |_____|
-   | ||
-LL | ||         "abc"
-LL | ||     };
-   | ||      ^
-   | ||______|
-   | |_______expected &str, found struct `std::string::String`
-   |         in this macro invocation
+LL | /     intrinsic_match! {
+LL | |         "abc"
+LL | |     };
+   | |      ^
+   | |      |
+   | |______expected &str, found struct `std::string::String`
+   |        in this macro invocation
    |
    = note: expected type `&str`
               found type `std::string::String`

--- a/src/test/ui/suggestions/dont-suggest-deref-inside-macro-issue-58298.stderr
+++ b/src/test/ui/suggestions/dont-suggest-deref-inside-macro-issue-58298.stderr
@@ -1,0 +1,21 @@
+error[E0308]: mismatched types
+  --> $DIR/dont-suggest-deref-inside-macro-issue-58298.rs:10:5
+   |
+LL |        intrinsic_match! {
+   |   _____^
+   |  |_____|
+   | ||
+LL | ||         "abc"
+LL | ||     };
+   | ||      ^
+   | ||______|
+   | |_______expected &str, found struct `std::string::String`
+   |         in this macro invocation
+   |
+   = note: expected type `&str`
+              found type `std::string::String`
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/traits/trait-resolution-in-overloaded-op.stderr
+++ b/src/test/ui/traits/trait-resolution-in-overloaded-op.stderr
@@ -1,8 +1,10 @@
 error[E0369]: binary operation `*` cannot be applied to type `&T`
-  --> $DIR/trait-resolution-in-overloaded-op.rs:8:5
+  --> $DIR/trait-resolution-in-overloaded-op.rs:8:7
    |
 LL |     a * b
-   |     ^^^^^
+   |     - ^ - f64
+   |     |
+   |     &T
    |
    = note: an implementation of `std::ops::Mul` might be missing for `&T`
 

--- a/src/test/ui/type/type-check/missing_trait_impl.stderr
+++ b/src/test/ui/type/type-check/missing_trait_impl.stderr
@@ -1,8 +1,10 @@
 error[E0369]: binary operation `+` cannot be applied to type `T`
-  --> $DIR/missing_trait_impl.rs:5:13
+  --> $DIR/missing_trait_impl.rs:5:15
    |
 LL |     let z = x + y;
-   |             ^^^^^
+   |             - ^ - T
+   |             |
+   |             T
    |
    = note: `T` might need a bound for `std::ops::Add`
 

--- a/src/test/ui/vec/vec-res-add.stderr
+++ b/src/test/ui/vec/vec-res-add.stderr
@@ -1,8 +1,10 @@
 error[E0369]: binary operation `+` cannot be applied to type `std::vec::Vec<R>`
-  --> $DIR/vec-res-add.rs:16:13
+  --> $DIR/vec-res-add.rs:16:15
    |
 LL |     let k = i + j;
-   |             ^^^^^
+   |             - ^ - std::vec::Vec<R>
+   |             |
+   |             std::vec::Vec<R>
    |
    = note: an implementation of `std::ops::Add` might be missing for `std::vec::Vec<R>`
 

--- a/src/tools/publish_toolstate.py
+++ b/src/tools/publish_toolstate.py
@@ -20,12 +20,13 @@ MAINTAINERS = {
     'rustfmt': '@nrc @topecongiro',
     'book': '@carols10cents @steveklabnik',
     'nomicon': '@frewsxcv @Gankro',
-    'reference': '@steveklabnik @Havvy @matthewjasper @alercah',
+    'reference': '@steveklabnik @Havvy @matthewjasper @ehuss',
     'rust-by-example': '@steveklabnik @marioidival @projektir',
     'embedded-book': (
         '@adamgreig @andre-richter @jamesmunns @korken89 '
         '@ryankurte @thejpster @therealprof'
     ),
+    'edition-guide': '@ehuss @Centril @steveklabnik',
 }
 
 REPOS = {
@@ -38,6 +39,7 @@ REPOS = {
     'reference': 'https://github.com/rust-lang-nursery/reference',
     'rust-by-example': 'https://github.com/rust-lang/rust-by-example',
     'embedded-book': 'https://github.com/rust-embedded/book',
+    'edition-guide': 'https://github.com/rust-lang-nursery/edition-guide',
 }
 
 


### PR DESCRIPTION
Successful merges:

 - #59366 (Update books)
 - #59436 (Update jemalloc-sys to version 0.3.0)
 - #59454 (Update rustfmt to 1.2.0)
 - #59462 (Fix error in Rust 2018 + no_core environment)
 - #59467 (Better diagnostic for binary operation on BoxedValues)
 - #59473 (Do not emit incorrect borrow suggestion involving macros and fix overlapping multiline spans)
 - #59480 (Update stdsimd)
 - #59486 (Visit `ImplItem` in `dead_code` lint)
 - #59510 (Rename `type_parameters` to `generics` and so on)

Failed merges:

 - #59516 (Update cargo)

r? @ghost