### PR TITLE
Whitelist some rustc attrs

### DIFF
--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -906,7 +906,7 @@ pub const BUILTIN_ATTRIBUTES: &[(&str, AttributeType, AttributeTemplate, Attribu
                                          not currently handle destructors.",
                                         cfg_fn!(thread_local))),
 
-    ("rustc_on_unimplemented", Normal, template!(List:
+    ("rustc_on_unimplemented", Whitelisted, template!(List:
                           r#"/*opt*/ message = "...", /*opt*/ label = "...", /*opt*/ note = "...""#,
                           NameValueStr: "message"),
                                              Gated(Stability::Unstable,

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -962,6 +962,20 @@ pub const BUILTIN_ATTRIBUTES: &[(&str, AttributeType, AttributeTemplate, Attribu
             is just used for rustc unit tests \
             and will never be stable",
            cfg_fn!(rustc_attrs))),
+    ("rustc_layout_scalar_valid_range_start", Whitelisted, template!(List: "value"),
+     Gated(Stability::Unstable,
+           "rustc_attrs",
+           "the `#[rustc_layout_scalar_valid_range_start]` attribute \
+            is just used to enable niche optimizations in libcore \
+            and will never be stable",
+           cfg_fn!(rustc_attrs))),
+    ("rustc_layout_scalar_valid_range_end", Whitelisted, template!(List: "value"),
+     Gated(Stability::Unstable,
+           "rustc_attrs",
+           "the `#[rustc_layout_scalar_valid_range_end]` attribute \
+            is just used to enable niche optimizations in libcore \
+            and will never be stable",
+           cfg_fn!(rustc_attrs))),
     ("rustc_regions", Normal, template!(Word), Gated(Stability::Unstable,
                                     "rustc_attrs",
                                     "the `#[rustc_regions]` attribute \

--- a/src/test/incremental/issue-59523-on-implemented-is-not-unused.rs
+++ b/src/test/incremental/issue-59523-on-implemented-is-not-unused.rs
@@ -1,0 +1,27 @@
+// We should not see the unused_attributes lint fire for
+// rustc_on_unimplemented, but with this bug we are seeing it fire (on
+// subsequent runs) if incremental compilation is enabled.
+
+// revisions: rpass1 rpass2
+// compile-pass
+
+#![feature(on_unimplemented)]
+#![deny(unused_attributes)]
+
+#[rustc_on_unimplemented = "invalid"]
+trait Index<Idx: ?Sized> {
+    type Output: ?Sized;
+    fn index(&self, index: Idx) -> &Self::Output;
+}
+
+#[rustc_on_unimplemented = "a usize is required to index into a slice"]
+impl Index<usize> for [i32] {
+    type Output = i32;
+    fn index(&self, index: usize) -> &i32 {
+        &self[index]
+    }
+}
+
+fn main() {
+    Index::<usize>::index(&[1, 2, 3] as &[i32], 2);
+}

--- a/src/test/incremental/issue-59524-layout-scalar-valid-range-is-not-unused.rs
+++ b/src/test/incremental/issue-59524-layout-scalar-valid-range-is-not-unused.rs
@@ -1,0 +1,19 @@
+// We should not see the unused_attributes lint fire for
+// rustc_layout_scalar_valid_range_start, but with this bug we are
+// seeing it fire (on subsequent runs) if incremental compilation is
+// enabled.
+
+// revisions: rpass1 rpass2
+// compile-pass
+
+#![feature(rustc_attrs)]
+#![deny(unused_attributes)]
+
+#[rustc_layout_scalar_valid_range_start(10)]
+#[rustc_layout_scalar_valid_range_end(30)]
+struct RestrictedRange(u32);
+const OKAY_RANGE: RestrictedRange = unsafe { RestrictedRange(20) };
+
+fn main() {
+    OKAY_RANGE.0;
+}


### PR DESCRIPTION
These rustc attrs are used within libcore, and were causing failures when one mixed incremental compilation with bootstrapping (due to a default of `-D warnings` when bootstrapping).

Fix #59523 
Fix #59524

Cc #58633 