### PR TITLE
Add test checking that Index<T: ?Sized> works

### DIFF
--- a/src/test/ui/unsized-locals/unsized-index.rs
+++ b/src/test/ui/unsized-locals/unsized-index.rs
@@ -1,0 +1,23 @@
+// compile-pass
+
+// `std::ops::Index` has an `: ?Sized` bound on the `Idx` type param. This is
+// an accidental left-over from the times when it `Index` was by-reference.
+// Tightening the bound now could be a breaking change. Although no crater
+// regression were observed (https://github.com/rust-lang/rust/pull/59527),
+// let's be conservative and just add a test for this.
+#![feature(unsized_locals)]
+
+use std::ops;
+
+pub struct A;
+
+impl ops::Index<str> for A {
+    type Output = ();
+    fn index(&self, _: str) -> &Self::Output { panic!() }
+}
+
+impl ops::IndexMut<str> for A {
+    fn index_mut(&mut self, _: str) -> &mut Self::Output { panic!() }
+}
+
+fn main() {}


### PR DESCRIPTION
I've noticed that we have an `Idx: ?Sized` bound on the **index** in the `Index`, which seems strange given that we accept index by value. My guess is that it was meant to be removed in https://github.com/rust-lang/rust/pull/23601, but was overlooked. 

If I remove this bound, `./x.py src/libstd/ src/libcore/` passes, which means at least that this is not covered by test.

I think there's three things we can do here:

* run crater with the bound removed to check if there are any regressions, and merge this, to be consistent with other operator traits
* run crater, get regressions, write a test for this with a note that "hey, we tried to fix it, its unfixable"
* decide, in the light of by-value DSTs, that this is a feature rather than a bug, and add a test

cc @rust-lang/libs

EDIT: the forth alternative is that there exist a genuine reason why this is the case, but I failed to see it :D