### PR TITLE
Improve the dbg! macro docs 

### DIFF
--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -231,10 +231,13 @@ macro_rules! eprintln {
 /// to give up ownership, you can instead borrow with `dbg!(&expr)`
 /// for some expression `expr`.
 ///
+/// The `dbg!` macro works exactly the same in release builds. This is useful when debugging issues
+/// that only occur in release builds or when debugging in release mode is significantly faster.
+///
 /// Note that the macro is intended as a debugging tool and therefore you
 /// should avoid having uses of it in version control for longer periods.
 /// Use cases involving debug output that should be added to version control
-/// may be better served by macros such as `debug!` from the `log` crate.
+/// are better served by macros such as [`debug!`][debug-log] from the [`log`][log] crate.
 ///
 /// # Stability
 ///
@@ -306,6 +309,8 @@ macro_rules! eprintln {
 /// ```
 ///
 /// [stderr]: https://en.wikipedia.org/wiki/Standard_streams#Standard_error_(stderr)
+/// [debug-log]: https://docs.rs/log/*/log/macro.debug.html
+/// [log]: https://docs.rs/log/
 #[macro_export]
 #[stable(feature = "dbg_macro", since = "1.32.0")]
 macro_rules! dbg {

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -232,7 +232,8 @@ macro_rules! eprintln {
 /// for some expression `expr`.
 ///
 /// The `dbg!` macro works exactly the same in release builds.
-/// This is useful when debugging issues that only occur in release builds or when debugging in
+/// This is useful when debugging issues that only occur in release
+/// builds or when debugging in release mode is significantly faster.
 /// release mode is significantly faster.
 ///
 /// Note that the macro is intended as a debugging tool and therefore you

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -234,7 +234,6 @@ macro_rules! eprintln {
 /// The `dbg!` macro works exactly the same in release builds.
 /// This is useful when debugging issues that only occur in release
 /// builds or when debugging in release mode is significantly faster.
-/// release mode is significantly faster.
 ///
 /// Note that the macro is intended as a debugging tool and therefore you
 /// should avoid having uses of it in version control for longer periods.

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -231,8 +231,9 @@ macro_rules! eprintln {
 /// to give up ownership, you can instead borrow with `dbg!(&expr)`
 /// for some expression `expr`.
 ///
-/// The `dbg!` macro works exactly the same in release builds. This is useful when debugging issues
-/// that only occur in release builds or when debugging in release mode is significantly faster.
+/// The `dbg!` macro works exactly the same in release builds.
+/// This is useful when debugging issues that only occur in release builds or when debugging in
+/// release mode is significantly faster.
 ///
 /// Note that the macro is intended as a debugging tool and therefore you
 /// should avoid having uses of it in version control for longer periods.

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -239,7 +239,7 @@ macro_rules! eprintln {
 /// Note that the macro is intended as a debugging tool and therefore you
 /// should avoid having uses of it in version control for longer periods.
 /// Use cases involving debug output that should be added to version control
-/// are better served by macros such as [`debug!`][debug-log] from the [`log`][log] crate.
+/// are better served by macros such as [`debug!`] from the [`log`] crate.
 ///
 /// # Stability
 ///
@@ -311,8 +311,8 @@ macro_rules! eprintln {
 /// ```
 ///
 /// [stderr]: https://en.wikipedia.org/wiki/Standard_streams#Standard_error_(stderr)
-/// [debug-log]: https://docs.rs/log/*/log/macro.debug.html
-/// [log]: https://docs.rs/log/
+/// [`debug!`]: https://docs.rs/log/*/log/macro.debug.html
+/// [`log`]: https://crates.io/crates/log
 #[macro_export]
 #[stable(feature = "dbg_macro", since = "1.32.0")]
 macro_rules! dbg {


### PR DESCRIPTION
# Description

As stated has been discussed in #58383 the docs do not clearly state why it is useful to have the option to use `dbg!` in release builds as well. This PR should change that.

closes #58383