### PR TITLE
Added documentation on the remainder (Rem) operator for floating points.

### DIFF
--- a/src/libcore/ops/arith.rs
+++ b/src/libcore/ops/arith.rs
@@ -540,7 +540,17 @@ macro_rules! rem_impl_float {
 
         /// The remainder from the division of two floats.
         ///
-        /// The remainder has the same sign as the dividend. For example: `-5.0 % 2.0 = -1.0`.
+        /// The remainder has the same sign as the dividend and is computed as:
+        /// `x - (x / y).trunc() * y`.
+        ///
+        /// # Examples
+        /// ```
+        /// let x: f32 = 4.0;
+        /// let y: f32 = 2.5;
+        /// let remainder = x - (x / y).trunc() * y;
+        ///
+        /// assert_eq!(x % y, remainder);
+        /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         impl Rem for $t {
             type Output = $t;

--- a/src/libcore/ops/arith.rs
+++ b/src/libcore/ops/arith.rs
@@ -545,10 +545,11 @@ macro_rules! rem_impl_float {
         ///
         /// # Examples
         /// ```
-        /// let x: f32 = 4.0;
-        /// let y: f32 = 2.5;
+        /// let x: f32 = 50.50;
+        /// let y: f32 = 8.125;
         /// let remainder = x - (x / y).trunc() * y;
         ///
+        /// // The answer to both operations is 1.75
         /// assert_eq!(x % y, remainder);
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcore/ops/arith.rs
+++ b/src/libcore/ops/arith.rs
@@ -537,6 +537,10 @@ rem_impl_integer! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
 
 macro_rules! rem_impl_float {
     ($($t:ty)*) => ($(
+
+        /// The remainder from the division of two floats.
+        ///
+        /// The remainder has the same sign as the dividend. For example: `-5.0 % 2.0 = -1.0`.
         #[stable(feature = "rust1", since = "1.0.0")]
         impl Rem for $t {
             type Output = $t;


### PR DESCRIPTION
# Description

As has been explained in #57738 the remainder operator on floating points is not clear.
This PR requests adds some information on how the `Rem` / remainder operator on floating points works.

Note also that this description is for both `Rem<f32> for f32` and `Rem<f64> for f64` implementations.

Ps. I wasn't really sure on how to formulate things. So please suggest changes if you have better idea's!

closes #57738