### PR TITLE
rustdoc: collapse blanket impls in the same way as normal impls

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -2071,6 +2071,14 @@ if (!DOMTokenList.prototype.remove) {
                     collapser(e, collapse);
                 });
             }
+
+            var blanket_list = document.getElementById("blanket-implementations-list");
+
+            if (blanket_list !== null) {
+                onEachLazy(blanket_list.getElementsByClassName("collapse-toggle"), function(e) {
+                    collapser(e, collapse);
+                });
+            }
         }
     }
 


### PR DESCRIPTION
If the rustdoc setting _Auto-hide trait implementations documentation_ is activated (on by default), normal trait implementations are collapsed by default. 

Blanket impls on the other hand are not collapsed. I'm not sure whether this is intended, but considering that the blanket impls for `From`, `Into`, `TryFrom`, ... are on every type, it would reduce the documentation bloat if these would also be collapsed when the setting is active.

(I'm not really familiar with the codebase and therefore just copied the code for the normal impl collapsing, but I could deduplicate it into a method, of course, too.)