### PR TITLE
manifest: only include miri on the nightly channel

### DIFF
--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -522,11 +522,17 @@ impl Builder {
                pkgname: &str,
                dst: &mut BTreeMap<String, Package>,
                targets: &[&str]) {
-        let (version, is_present) = self.cached_version(pkgname)
+        let (version, mut is_present) = self.cached_version(pkgname)
             .as_ref()
             .cloned()
             .map(|version| (version, true))
             .unwrap_or_default();
+
+        // miri needs to build std with xargo, which doesn't allow stable/beta:
+        // <https://github.com/japaric/xargo/pull/204#issuecomment-374888868>
+        if pkgname == "miri-preview" && self.rust_release != "nightly" {
+            is_present = false; // ignore it
+        }
 
         let targets = targets.iter().map(|name| {
             if is_present {


### PR DESCRIPTION
miri needs to build std with xargo, which doesn't allow stable/beta:
<https://github.com/japaric/xargo/pull/204#issuecomment-374888868>

Therefore, at this time there's no point in making miri available on any
but the nightly channel.  If we get a stable way to build `std`, like
[RFC 2663], then we can re-evaluate whether to start including miri,
perhaps still as `miri-preview`.

[RFC 2663]: https://github.com/rust-lang/rfcs/pull/2663