### PR TITLE
Fix LLVM IR generated for C-variadic arguments

### DIFF
--- a/src/test/codegen/issue-58881.rs
+++ b/src/test/codegen/issue-58881.rs
@@ -1,0 +1,21 @@
+// compile-flags: -C no-prepopulate-passes
+//
+// only-x86_64
+// ignore-windows
+
+#![crate_type = "lib"]
+
+extern "C" {
+    fn variadic_fn(_: i32, ...);
+}
+
+#[repr(C)]
+struct Foo(u8);
+#[repr(C)]
+struct Bar(u64, u64, u64);
+
+// Ensure that emit arguments of the correct type.
+pub unsafe fn test_call_variadic() {
+    // CHECK: call void (i32, ...) @variadic_fn(i32 0, i8 {{.*}}, %Bar* {{.*}})
+    variadic_fn(0, Foo(0), Bar(0, 0, 0))
+}


### PR DESCRIPTION
It is possible to create malformed LLVM IR given variadic arguments that
are aggregate types. This occurs due to improper tracking of the current
argument in the functions list of arguments.

Fixes: #58881