### PR TITLE
Stabilize refcell_replace_swap feature

### DIFF
--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -711,7 +711,6 @@ impl<T> RefCell<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(refcell_replace_swap)]
     /// use std::cell::RefCell;
     /// let cell = RefCell::new(5);
     /// let old_value = cell.replace_with(|&mut old| old + 1);
@@ -719,7 +718,7 @@ impl<T> RefCell<T> {
     /// assert_eq!(cell, RefCell::new(6));
     /// ```
     #[inline]
-    #[unstable(feature = "refcell_replace_swap", issue="43570")]
+    #[stable(feature = "refcell_replace_swap", since="1.35.0")]
     pub fn replace_with<F: FnOnce(&mut T) -> T>(&self, f: F) -> T {
         let mut_borrow = &mut *self.borrow_mut();
         let replacement = f(mut_borrow);

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -702,8 +702,6 @@ impl<T> RefCell<T> {
     /// Replaces the wrapped value with a new one computed from `f`, returning
     /// the old value, without deinitializing either one.
     ///
-    /// This function corresponds to [`std::mem::replace`](../mem/fn.replace.html).
-    ///
     /// # Panics
     ///
     /// Panics if the value is currently borrowed.

--- a/src/libcore/tests/lib.rs
+++ b/src/libcore/tests/lib.rs
@@ -16,7 +16,6 @@
 #![feature(pattern)]
 #![feature(range_is_empty)]
 #![feature(raw)]
-#![feature(refcell_replace_swap)]
 #![feature(slice_patterns)]
 #![feature(sort_internals)]
 #![feature(specialization)]

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -45,7 +45,6 @@
 #![feature(proc_macro_internals)]
 #![feature(optin_builtin_traits)]
 #![feature(range_is_empty)]
-#![feature(refcell_replace_swap)]
 #![feature(rustc_diagnostic_macros)]
 #![feature(rustc_attrs)]
 #![feature(slice_patterns)]

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -64,7 +64,6 @@ This API is completely unstable and subject to change.
 #![feature(crate_visibility_modifier)]
 #![feature(exhaustive_patterns)]
 #![feature(nll)]
-#![feature(refcell_replace_swap)]
 #![feature(rustc_diagnostic_macros)]
 #![feature(slice_patterns)]
 #![feature(never_type)]

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -703,8 +703,6 @@ declare_features! (
     (accepted, extern_crate_self, "1.34.0", Some(56409), None),
     // support for arbitrary delimited token streams in non-macro attributes
     (accepted, unrestricted_attribute_tokens, "1.34.0", Some(55208), None),
-    // add replace and swap functions to RefCell
-    (accepted, refcell_replace_swap, "1.35.0", Some(43570), None),
 );
 
 // If you change this, please modify `src/doc/unstable-book` as well. You must

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -703,6 +703,8 @@ declare_features! (
     (accepted, extern_crate_self, "1.34.0", Some(56409), None),
     // support for arbitrary delimited token streams in non-macro attributes
     (accepted, unrestricted_attribute_tokens, "1.34.0", Some(55208), None),
+    // add replace and swap functions to RefCell
+    (accepted, refcell_replace_swap, "1.35.0", Some(43570), None),
 );
 
 // If you change this, please modify `src/doc/unstable-book` as well. You must


### PR DESCRIPTION
Please be kind, this is my first time contributing. :smile: 

I noticed #43570 only needs stabilizing (and I need it for a side project I'm working on), so I followed the [guide](https://rust-lang.github.io/rustc-guide/stabilization_guide.html#stabilization-pr) to move things forward.

I'm happy to amend things if needed, let me know!