### PR TITLE
match match match match match

### DIFF
--- a/src/test/run-pass/weird-exprs.rs
+++ b/src/test/run-pass/weird-exprs.rs
@@ -127,6 +127,21 @@ fn punch_card() -> impl std::fmt::Debug {
     ..=.. ..=..    .. ..=..=..    ..=..=.. ..    .. ..=.. ..
 }
 
+fn r#match() {
+    let val = match match match match match () {
+        () => ()
+    } {
+        () => ()
+    } {
+        () => ()
+    } {
+        () => ()
+    } {
+        () => ()
+    };
+    assert_eq!(val, ());
+}
+
 pub fn main() {
     strange();
     funny();
@@ -142,4 +157,5 @@ pub fn main() {
     union();
     special_characters();
     punch_card();
+    r#match();
 }


### PR DESCRIPTION
The `match` keyword can be chained as long as there are enough body-blocks following, and the output of one match will be the input of the next match.

I accidentally wrote something among the lines of this:

```rust
match match Ok(Some(1337)) {
    Ok(val) => val,
    Err(err) => handle_err(err),
} {
    Some(foo) => handle_foo(foo),
    None => {},
}
```