### PR TITLE
Print the appveyor agent version at the start of the build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -126,6 +126,8 @@ clone_depth: 2
 build: false
 
 install:
+  # Print which AppVeyor agent version we're running on.
+  - appveyor version
   # If we need to download a custom MinGW, do so here and set the path
   # appropriately.
   #


### PR DESCRIPTION
[AppVeyor support asked for this.](https://help.appveyor.com/discussions/problems/19657-successful-builds-failing-with-code-259#comment_47132359)

r? @alexcrichton 