### PR TITLE
Forward formatter settings to bounds of `Range<T>` in `fmt::Debug` impl

### DIFF
--- a/src/libcore/ops/range.rs
+++ b/src/libcore/ops/range.rs
@@ -85,7 +85,10 @@ pub struct Range<Idx> {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<Idx: fmt::Debug> fmt::Debug for Range<Idx> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "{:?}..{:?}", self.start, self.end)
+        self.start.fmt(fmt)?;
+        write!(fmt, "..")?;
+        self.end.fmt(fmt)?;
+        Ok(())
     }
 }
 
@@ -184,7 +187,9 @@ pub struct RangeFrom<Idx> {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<Idx: fmt::Debug> fmt::Debug for RangeFrom<Idx> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "{:?}..", self.start)
+        self.start.fmt(fmt)?;
+        write!(fmt, "..")?;
+        Ok(())
     }
 }
 
@@ -266,7 +271,9 @@ pub struct RangeTo<Idx> {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<Idx: fmt::Debug> fmt::Debug for RangeTo<Idx> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "..{:?}", self.end)
+        write!(fmt, "..")?;
+        self.end.fmt(fmt)?;
+        Ok(())
     }
 }
 
@@ -467,7 +474,10 @@ impl<Idx> RangeInclusive<Idx> {
 #[stable(feature = "inclusive_range", since = "1.26.0")]
 impl<Idx: fmt::Debug> fmt::Debug for RangeInclusive<Idx> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "{:?}..={:?}", self.start, self.end)
+        self.start.fmt(fmt)?;
+        write!(fmt, "..=")?;
+        self.end.fmt(fmt)?;
+        Ok(())
     }
 }
 
@@ -602,7 +612,9 @@ pub struct RangeToInclusive<Idx> {
 #[stable(feature = "inclusive_range", since = "1.26.0")]
 impl<Idx: fmt::Debug> fmt::Debug for RangeToInclusive<Idx> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "..={:?}", self.end)
+        write!(fmt, "..=")?;
+        self.end.fmt(fmt)?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Before this change, formatter settings were lost when printing a `Range`. For example, printing a `Range<f32>` with `{:.2?}` would not apply the precision modifier when printing the floats. Now the `Debug` impls look a bit more verbose, but modifier are not lost.

---

I assume the exact output of `Debug` impls in `std` cannot be relied on by users and thus can change, right? 