### PR TITLE
[WIP] impl FromIterator for Option/Result via scan

### DIFF
--- a/src/libcore/benches/iter.rs
+++ b/src/libcore/benches/iter.rs
@@ -344,3 +344,15 @@ fn bench_partial_cmp(b: &mut Bencher) {
 fn bench_lt(b: &mut Bencher) {
     b.iter(|| (0..100000).map(black_box).lt((0..100000).map(black_box)))
 }
+
+// rust-lang/rust#11084: benchmark how built-in `FromIterator` for
+// `Result` performs, to avoid unknowingly regressing its performance.
+#[bench]
+fn bench_result_from_iter_into_vec(b: &mut Bencher) {
+    let expected = vec![1; 1000];
+    let v: Vec<Result<isize, String>> = vec![Ok(1); 1000];
+    b.iter(|| {
+        let result: Result<Vec<isize>, String> = FromIterator::from_iter(v.iter().cloned());
+        assert_eq!(result.unwrap(), expected);
+    });
+}

--- a/src/libcore/iter/adapters/mod.rs
+++ b/src/libcore/iter/adapters/mod.rs
@@ -1672,6 +1672,21 @@ impl<B, I, St, F> Iterator for Scan<I, St, F> where
             }
         }).into_try()
     }
+
+    #[inline]
+    fn fold<C, G>(mut self, init: C, mut g: G) -> C where
+        Self: Sized, G: FnMut(C, Self::Item) -> C,
+    {
+        // self.try_fold(init, move |acc, x| Ok::<C, !>(g(acc, x))).unwrap()
+        let state = &mut self.state;
+        let f = &mut self.f;
+        self.iter.fold(init, move |acc, x| {
+            match f(state, x) {
+                None => acc,
+                Some(x) => g(acc, x),
+            }
+        })
+    }
 }
 
 /// An iterator that yields `None` forever after the underlying iterator


### PR DESCRIPTION
This PR consists of three main things: 
 * It swaps in a simpler (at least in terms of lines-of-code) implementation of `FromIterator` for `Option` and `Result` that uses the `scan` method to do the bulk of the work rather than the specialized adapter struct that the old implementation used.
 * It adds a micro-benchmark of `FromIterator for Result` in order to measure the performance of this operation, in order to ensure that this change (or other future changes) do not cause this operation to slow down significantly.
 * It revises the implementations of `Vec::extend` and `Iterator::scan` in order to address performance issues uncovered by above micro-benchmark.

cc #11084 

Some (lightly edited) notes from the original PR post follow, but I have removed three of the four original benchmarks (you can find more about them in #11084).

----

The PR was initially marked WIP, because in my experiments on my Linux desktop machine, even when I compile with `optimize=true`, `debug=false`, `codegen-units=1` and `incremental=false`, I still see performance regression on this particular micro-benchmark.
 * I have a bunch of notes and data about this in the comment thread [here](https://github.com/rust-lang/rust/issues/11084#issuecomment-475572382); it has an LTO off/on comparison. Compare the lines that say "using_baseline" (or "using_adapter", which should be roughly equivalent) with the lines that say "with_scan", to get an idea of the effect of this PR in various contexts.
 * The only way I have seen to reliably bring the performance back in line with expectations is to enable LTO in some form.
 * In particular, if you have codegen-units=1, you need to explicitly enable `-C lto=thin` in order to get competitive performance out of the "with_scan" implementation. The default with codegen-units=1 is suboptimal; `-C lto=thin` gives you "whole crate graph" LTO.
 * And if you have codegen-units > 1, then the default (which corresponds to something called "local Thin LTO") will yield the "best" performance. 
   * I put "best" in quotes, because the performance for codegen-units > 1 here is far worse than codegen-units = 1.

Anyway, the micro-benchmarks added here include an explicit encoding of the adapter-based implementation of `FromIterator for Result`, so that one can see how the new implementation compares out of the box (that is, without enabling ThinLTO for codegen-units=1 on the bootstrapped benchmark build).