### PR TITLE
Use normal newtype_index macro for MIR dataflows

### DIFF
--- a/src/librustc_mir/borrow_check/error_reporting.rs
+++ b/src/librustc_mir/borrow_check/error_reporting.rs
@@ -25,8 +25,7 @@ use super::borrow_set::BorrowData;
 use super::{Context, MirBorrowckCtxt};
 use super::{InitializationRequiringAction, PrefixSet};
 use crate::dataflow::drop_flag_effects;
-use crate::dataflow::move_paths::indexes::MoveOutIndex;
-use crate::dataflow::move_paths::MovePathIndex;
+use crate::dataflow::indexes::{MovePathIndex, MoveOutIndex};
 use crate::util::borrowck_errors::{BorrowckErrors, Origin};
 
 #[derive(Debug)]

--- a/src/librustc_mir/borrow_check/flows.rs
+++ b/src/librustc_mir/borrow_check/flows.rs
@@ -11,7 +11,7 @@ use crate::borrow_check::location::LocationIndex;
 
 use polonius_engine::Output;
 
-use crate::dataflow::move_paths::indexes::BorrowIndex;
+use crate::dataflow::indexes::BorrowIndex;
 use crate::dataflow::move_paths::HasMoveData;
 use crate::dataflow::Borrows;
 use crate::dataflow::EverInitializedPlaces;

--- a/src/librustc_mir/borrow_check/nll/facts.rs
+++ b/src/librustc_mir/borrow_check/nll/facts.rs
@@ -72,18 +72,6 @@ impl Atom for BorrowIndex {
     }
 }
 
-impl From<usize> for BorrowIndex {
-    fn from(i: usize) -> BorrowIndex {
-        BorrowIndex::new(i)
-    }
-}
-
-impl From<BorrowIndex> for usize {
-    fn from(vid: BorrowIndex) -> usize {
-        Idx::index(vid)
-    }
-}
-
 impl Atom for LocationIndex {
     fn index(self) -> usize {
         Idx::index(self)

--- a/src/librustc_mir/borrow_check/nll/invalidation.rs
+++ b/src/librustc_mir/borrow_check/nll/invalidation.rs
@@ -9,7 +9,7 @@ use crate::borrow_check::ArtificialField;
 use crate::borrow_check::{ReadKind, WriteKind};
 use crate::borrow_check::nll::facts::AllFacts;
 use crate::borrow_check::path_utils::*;
-use crate::dataflow::move_paths::indexes::BorrowIndex;
+use crate::dataflow::indexes::BorrowIndex;
 use rustc::ty::TyCtxt;
 use rustc::mir::visit::Visitor;
 use rustc::mir::{BasicBlock, Location, Mir, Place, PlaceBase, Rvalue};

--- a/src/librustc_mir/borrow_check/nll/type_check/liveness/trace.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/liveness/trace.rs
@@ -3,7 +3,7 @@ use crate::borrow_check::nll::region_infer::values::{self, PointIndex, RegionVal
 use crate::borrow_check::nll::type_check::liveness::local_use_map::LocalUseMap;
 use crate::borrow_check::nll::type_check::NormalizeLocation;
 use crate::borrow_check::nll::type_check::TypeChecker;
-use crate::dataflow::move_paths::indexes::MovePathIndex;
+use crate::dataflow::indexes::MovePathIndex;
 use crate::dataflow::move_paths::MoveData;
 use crate::dataflow::{FlowAtLocation, FlowsAtLocation, MaybeInitializedPlaces};
 use rustc::infer::canonical::QueryRegionConstraint;

--- a/src/librustc_mir/dataflow/impls/borrows.rs
+++ b/src/librustc_mir/dataflow/impls/borrows.rs
@@ -10,12 +10,17 @@ use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::indexed_vec::{Idx, IndexVec};
 
 use crate::dataflow::{BitDenotation, BlockSets, InitialFlow};
-pub use crate::dataflow::indexes::BorrowIndex;
 use crate::borrow_check::nll::region_infer::RegionInferenceContext;
 use crate::borrow_check::nll::ToRegionVid;
 use crate::borrow_check::places_conflict;
 
 use std::rc::Rc;
+
+newtype_index! {
+    pub struct BorrowIndex {
+        DEBUG_FORMAT = "bw{}"
+    }
+}
 
 /// `Borrows` stores the data used in the analyses that track the flow
 /// of borrows.

--- a/src/librustc_mir/dataflow/mod.rs
+++ b/src/librustc_mir/dataflow/mod.rs
@@ -33,7 +33,12 @@ mod graphviz;
 mod impls;
 pub mod move_paths;
 
-pub(crate) use self::move_paths::indexes;
+pub(crate) mod indexes {
+    pub(crate) use super::{
+        move_paths::{MovePathIndex, MoveOutIndex, InitIndex},
+        impls::borrows::BorrowIndex,
+    };
+}
 
 pub(crate) struct DataflowBuilder<'a, 'tcx: 'a, BD>
 where


### PR DESCRIPTION
* Makes the definition of these structs contain `struct IndexName`
* Avoids having an offset by removing high values, rather than 0
* Implements some traits for us.