### PR TITLE
Update Clippy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,6 +379,7 @@ dependencies = [
  "compiletest_rs 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive-new 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libtest 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-workspace-hack 1.0.0",
  "rustc_tools_util 0.1.1",


### PR DESCRIPTION
cc rust-lang/rust-clippy#3905
cc rust-lang/rust-clippy#3913
cc #59396 

This should make Clippy appear to be test-pass. This introduces 3 Bugs to Clippy, which are tracked. 

r? @Manishearth @oli-obk 