### PR TITLE
Minimum lint levels for C-future-compatibility issues

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -23,6 +23,12 @@ declare_lint! {
 }
 
 declare_lint! {
+    pub UNUSED_ATTRIBUTES,
+    Warn,
+    "detects attributes that were not used by the compiler"
+}
+
+declare_lint! {
     pub UNUSED_IMPORTS,
     Warn,
     "imports that are never used"

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -125,7 +125,7 @@ declare_lint! {
     "detects trivial casts of numeric types which could be removed"
 }
 
-declare_lint! {
+declare_lint! { // FIXME(centril): consider using `declare_unsuppressable_lint`
     pub PRIVATE_IN_PUBLIC,
     Warn,
     "detect private items in public interfaces not caught by the old implementation"
@@ -143,7 +143,7 @@ declare_lint! {
     "detect public re-exports of private extern crates"
 }
 
-declare_lint! {
+declare_lint! { // FIXME(centril): consider using `declare_unsuppressable_lint`
     pub INVALID_TYPE_PARAM_DEFAULT,
     Deny,
     "type parameter default erroneously allowed in invalid location"
@@ -155,62 +155,62 @@ declare_lint! {
     "lints that have been renamed or removed"
 }
 
-declare_lint! {
+declare_lint! { // FIXME(centril): consider using `declare_unsuppressable_lint`
     pub SAFE_EXTERN_STATICS,
     Deny,
     "safe access to extern statics was erroneously allowed"
 }
 
-declare_lint! {
+declare_lint! { // FIXME(centril): consider using `declare_unsuppressable_lint`
     pub SAFE_PACKED_BORROWS,
     Warn,
     "safe borrows of fields of packed structs were was erroneously allowed"
 }
 
-declare_lint! {
+declare_lint! { // FIXME(centril): consider using `declare_unsuppressable_lint`
     pub PATTERNS_IN_FNS_WITHOUT_BODY,
     Warn,
     "patterns in functions without body were erroneously allowed"
 }
 
-declare_lint! {
+declare_lint! { // FIXME(centril): consider using `declare_unsuppressable_lint`
     pub LEGACY_DIRECTORY_OWNERSHIP,
     Deny,
     "non-inline, non-`#[path]` modules (e.g., `mod foo;`) were erroneously allowed in some files \
      not named `mod.rs`"
 }
 
-declare_lint! {
+declare_lint! { // FIXME(centril): consider using `declare_unsuppressable_lint`
     pub LEGACY_CONSTRUCTOR_VISIBILITY,
     Deny,
     "detects use of struct constructors that would be invisible with new visibility rules"
 }
 
-declare_lint! {
+declare_lint! { // FIXME(centril): consider using `declare_unsuppressable_lint`
     pub MISSING_FRAGMENT_SPECIFIER,
     Deny,
     "detects missing fragment specifiers in unused `macro_rules!` patterns"
 }
 
-declare_lint! {
+declare_lint! { // FIXME(centril): consider using `declare_unsuppressable_lint`
     pub PARENTHESIZED_PARAMS_IN_TYPES_AND_MODULES,
     Deny,
     "detects parenthesized generic parameters in type and module names"
 }
 
-declare_lint! {
+declare_lint! { // FIXME(centril): consider using `declare_unsuppressable_lint`
     pub LATE_BOUND_LIFETIME_ARGUMENTS,
     Warn,
     "detects generic lifetime arguments in path segments with late bound lifetime parameters"
 }
 
-declare_lint! {
+declare_lint! { // FIXME(centril): consider using `declare_unsuppressable_lint`
     pub INCOHERENT_FUNDAMENTAL_IMPLS,
     Deny,
     "potentially-conflicting impls were erroneously allowed"
 }
 
-declare_lint! {
+declare_lint! { // FIXME(centril): consider using `declare_unsuppressable_lint`
     pub ORDER_DEPENDENT_TRAIT_OBJECTS,
     Deny,
     "trait-object types were treated as different depending on marker-trait order"
@@ -253,7 +253,7 @@ declare_lint! {
     "detects lifetime parameters that are never used"
 }
 
-declare_lint! {
+declare_lint! { // FIXME(centril): consider using `declare_unsuppressable_lint`
     pub TYVAR_BEHIND_RAW_POINTER,
     Warn,
     "raw pointer to an inference variable"
@@ -278,7 +278,7 @@ declare_lint! {
      instead of `crate`, `self`, or an extern crate name"
 }
 
-declare_lint! {
+declare_unsuppressable_lint! {
     pub ILLEGAL_FLOATING_POINT_LITERAL_PATTERN,
     Warn,
     "floating-point literals cannot be used in patterns"
@@ -326,7 +326,7 @@ declare_lint! {
     "detects code samples in docs of private items not documented by rustdoc"
 }
 
-declare_lint! {
+declare_lint! { // FIXME(centril): consider using `declare_unsuppressable_lint`
     pub WHERE_CLAUSES_OBJECT_SAFETY,
     Warn,
     "checks the object safety of where clauses"
@@ -358,7 +358,7 @@ declare_lint! {
     "outlives requirements can be inferred"
 }
 
-declare_lint! {
+declare_lint! { // FIXME(centril): consider using `declare_unsuppressable_lint`
     pub DUPLICATE_MATCHER_BINDING_NAME,
     Deny,
     "duplicate macro matcher binding name"
@@ -372,7 +372,7 @@ pub mod parser {
         "detects the use of `?` as a macro separator"
     }
 
-    declare_lint! {
+    declare_lint! { // FIXME(centril): consider using `declare_unsuppressable_lint`
         pub ILL_FORMED_ATTRIBUTE_INPUT,
         Warn,
         "ill-formed attribute inputs that were previously accepted and used in practice"
@@ -386,13 +386,13 @@ declare_lint! {
     report_in_external_macro: true
 }
 
-declare_lint! {
+declare_lint! { // FIXME(centril): consider using `declare_unsuppressable_lint`
     pub AMBIGUOUS_ASSOCIATED_ITEMS,
     Warn,
     "ambiguous associated items"
 }
 
-declare_lint! {
+declare_lint! { // FIXME(centril): consider using `declare_unsuppressable_lint`
     pub NESTED_IMPL_TRAIT,
     Warn,
     "nested occurrence of `impl Trait` type"

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1057,7 +1057,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnreachablePub {
     }
 }
 
-declare_lint! {
+declare_lint! { // FIXME(centril): consider using `declare_unsuppressable_lint`
     TYPE_ALIAS_BOUNDS,
     Warn,
     "bounds in type aliases are not enforced"

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -290,11 +290,25 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
     // Guidelines for creating a future incompatibility lint:
     //
     // - Create a lint defaulting to warn as normal, with ideally the same error
-    //   message you would normally give
+    //   message you would normally give.
+    //
     // - Add a suitable reference, typically an RFC or tracking issue. Go ahead
     //   and include the full URL, sort items in ascending order of issue numbers.
-    // - Later, change lint to error
-    // - Eventually, remove lint
+    //
+    // - By default, `declare_lint!` is recommended for use to declare the `Lint`.
+    //
+    //   After at least release cycle, and depending on how things have progressed,
+    //   consider using `declare_unsuppressable_lint!` instead.
+    //   This will turn the minimum level into `Warn` and make sure that `--cap-lints allow`
+    //   won't suppress the lint when it arises in a dependency of the root crate being compiled.
+    //
+    //   Please consult the documentation of `declare_unsuppressable_lint!`
+    //   for more information about it.
+    //
+    // - Later, change lint to error, but we recommend that you first use
+    //   `declare_unsuppressable_lint!` during at least one release cycle.
+    //
+    // - Eventually, remove the lint.
     store.register_future_incompatible(sess, vec![
         FutureIncompatibleInfo {
             id: LintId::of(PRIVATE_IN_PUBLIC),

--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -3,6 +3,7 @@ use rustc::hir::def_id::DefId;
 use rustc::lint;
 use rustc::ty;
 use rustc::ty::adjustment;
+use lint::builtin::UNUSED_ATTRIBUTES;
 use lint::{LateContext, EarlyContext, LintContext, LintArray};
 use lint::{LintPass, EarlyLintPass, LateLintPass};
 
@@ -202,12 +203,6 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for PathStatements {
             }
         }
     }
-}
-
-declare_lint! {
-    pub UNUSED_ATTRIBUTES,
-    Warn,
-    "detects attributes that were not used by the compiler"
 }
 
 declare_lint_pass!(UnusedAttributes => [UNUSED_ATTRIBUTES]);

--- a/src/test/run-pass/array-slice-vec/vec-matching-autoslice.stderr
+++ b/src/test/run-pass/array-slice-vec/vec-matching-autoslice.stderr
@@ -1,0 +1,54 @@
+warning: #[allow(illegal_floating_point_literal_pattern)] has no effect
+  --> $DIR/vec-matching-autoslice.rs:2:10
+   |
+LL | #![allow(illegal_floating_point_literal_pattern)] // FIXME #41620
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: #[warn(unused_attributes)] on by default
+   = note: the minimum lint level for `illegal_floating_point_literal_pattern` is `warn`
+   = note: the lint level cannot be reduced to `allow`
+   = help: remove the #[allow(illegal_floating_point_literal_pattern)] directive
+   = warning: `illegal_floating_point_literal_pattern` was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: #[allow(illegal_floating_point_literal_pattern)] has no effect
+  --> $DIR/vec-matching-autoslice.rs:2:10
+   |
+LL | #![allow(illegal_floating_point_literal_pattern)] // FIXME #41620
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the minimum lint level for `illegal_floating_point_literal_pattern` is `warn`
+   = note: the lint level cannot be reduced to `allow`
+   = help: remove the #[allow(illegal_floating_point_literal_pattern)] directive
+   = warning: `illegal_floating_point_literal_pattern` was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/vec-matching-autoslice.rs:20:18
+   |
+LL |         ([_, _], 0.5) => panic!(),
+   |                  ^^^
+   |
+note: lint level defined here
+  --> $DIR/vec-matching-autoslice.rs:2:10
+   |
+LL | #![allow(illegal_floating_point_literal_pattern)] // FIXME #41620
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: #[warn(illegal_floating_point_literal_pattern)] is the minimum lint level
+   = note: the lint level cannot be reduced to `allow`
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/vec-matching-autoslice.rs:20:18
+   |
+LL |         ([_, _], 0.5) => panic!(),
+   |                  ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+

--- a/src/test/run-pass/binding/match-range.stderr
+++ b/src/test/run-pass/binding/match-range.stderr
@@ -1,0 +1,124 @@
+warning: #[allow(illegal_floating_point_literal_pattern)] has no effect
+  --> $DIR/match-range.rs:2:10
+   |
+LL | #![allow(illegal_floating_point_literal_pattern)] // FIXME #41620
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: #[warn(unused_attributes)] on by default
+   = note: the minimum lint level for `illegal_floating_point_literal_pattern` is `warn`
+   = note: the lint level cannot be reduced to `allow`
+   = help: remove the #[allow(illegal_floating_point_literal_pattern)] directive
+   = warning: `illegal_floating_point_literal_pattern` was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: #[allow(illegal_floating_point_literal_pattern)] has no effect
+  --> $DIR/match-range.rs:2:10
+   |
+LL | #![allow(illegal_floating_point_literal_pattern)] // FIXME #41620
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the minimum lint level for `illegal_floating_point_literal_pattern` is `warn`
+   = note: the lint level cannot be reduced to `allow`
+   = help: remove the #[allow(illegal_floating_point_literal_pattern)] directive
+   = warning: `illegal_floating_point_literal_pattern` was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/match-range.rs:36:7
+   |
+LL |       1.0..=5.0 => {}
+   |       ^^^
+   |
+note: lint level defined here
+  --> $DIR/match-range.rs:2:10
+   |
+LL | #![allow(illegal_floating_point_literal_pattern)] // FIXME #41620
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: #[warn(illegal_floating_point_literal_pattern)] is the minimum lint level
+   = note: the lint level cannot be reduced to `allow`
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/match-range.rs:36:13
+   |
+LL |       1.0..=5.0 => {}
+   |             ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/match-range.rs:40:8
+   |
+LL |       -3.6..=3.6 => {}
+   |        ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/match-range.rs:40:14
+   |
+LL |       -3.6..=3.6 => {}
+   |              ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/match-range.rs:44:9
+   |
+LL |         0.0..3.5 => panic!("should not match the range end"),
+   |         ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/match-range.rs:44:14
+   |
+LL |         0.0..3.5 => panic!("should not match the range end"),
+   |              ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/match-range.rs:48:9
+   |
+LL |         0.0..3.5 => {},
+   |         ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/match-range.rs:48:14
+   |
+LL |         0.0..3.5 => {},
+   |              ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/match-range.rs:36:7
+   |
+LL |       1.0..=5.0 => {}
+   |       ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+

--- a/src/test/run-pass/issues/issue-15881-model-lexer-dotdotdot.stderr
+++ b/src/test/run-pass/issues/issue-15881-model-lexer-dotdotdot.stderr
@@ -1,0 +1,84 @@
+warning: #[allow(illegal_floating_point_literal_pattern)] has no effect
+  --> $DIR/issue-15881-model-lexer-dotdotdot.rs:2:10
+   |
+LL | #![allow(illegal_floating_point_literal_pattern)] // FIXME #41620
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: #[warn(unused_attributes)] on by default
+   = note: the minimum lint level for `illegal_floating_point_literal_pattern` is `warn`
+   = note: the lint level cannot be reduced to `allow`
+   = help: remove the #[allow(illegal_floating_point_literal_pattern)] directive
+   = warning: `illegal_floating_point_literal_pattern` was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: #[allow(illegal_floating_point_literal_pattern)] has no effect
+  --> $DIR/issue-15881-model-lexer-dotdotdot.rs:2:10
+   |
+LL | #![allow(illegal_floating_point_literal_pattern)] // FIXME #41620
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the minimum lint level for `illegal_floating_point_literal_pattern` is `warn`
+   = note: the lint level cannot be reduced to `allow`
+   = help: remove the #[allow(illegal_floating_point_literal_pattern)] directive
+   = warning: `illegal_floating_point_literal_pattern` was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/issue-15881-model-lexer-dotdotdot.rs:30:7
+   |
+LL |       1.0...5.0 => {}
+   |       ^^^
+   |
+note: lint level defined here
+  --> $DIR/issue-15881-model-lexer-dotdotdot.rs:2:10
+   |
+LL | #![allow(illegal_floating_point_literal_pattern)] // FIXME #41620
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: #[warn(illegal_floating_point_literal_pattern)] is the minimum lint level
+   = note: the lint level cannot be reduced to `allow`
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/issue-15881-model-lexer-dotdotdot.rs:30:13
+   |
+LL |       1.0...5.0 => {}
+   |             ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/issue-15881-model-lexer-dotdotdot.rs:34:8
+   |
+LL |       -3.6...3.6 => {}
+   |        ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/issue-15881-model-lexer-dotdotdot.rs:34:14
+   |
+LL |       -3.6...3.6 => {}
+   |              ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/issue-15881-model-lexer-dotdotdot.rs:30:7
+   |
+LL |       1.0...5.0 => {}
+   |       ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+

--- a/src/test/run-pass/issues/issue-7222.stderr
+++ b/src/test/run-pass/issues/issue-7222.stderr
@@ -1,0 +1,64 @@
+warning: #[allow(illegal_floating_point_literal_pattern)] has no effect
+  --> $DIR/issue-7222.rs:3:10
+   |
+LL | #![allow(illegal_floating_point_literal_pattern)] // FIXME #41620
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: #[warn(unused_attributes)] on by default
+   = note: the minimum lint level for `illegal_floating_point_literal_pattern` is `warn`
+   = note: the lint level cannot be reduced to `allow`
+   = help: remove the #[allow(illegal_floating_point_literal_pattern)] directive
+   = warning: `illegal_floating_point_literal_pattern` was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: #[allow(illegal_floating_point_literal_pattern)] has no effect
+  --> $DIR/issue-7222.rs:3:10
+   |
+LL | #![allow(illegal_floating_point_literal_pattern)] // FIXME #41620
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the minimum lint level for `illegal_floating_point_literal_pattern` is `warn`
+   = note: the lint level cannot be reduced to `allow`
+   = help: remove the #[allow(illegal_floating_point_literal_pattern)] directive
+   = warning: `illegal_floating_point_literal_pattern` was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/issue-7222.rs:9:9
+   |
+LL |         0.0 ..= FOO => (),
+   |         ^^^
+   |
+note: lint level defined here
+  --> $DIR/issue-7222.rs:3:10
+   |
+LL | #![allow(illegal_floating_point_literal_pattern)] // FIXME #41620
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: #[warn(illegal_floating_point_literal_pattern)] is the minimum lint level
+   = note: the lint level cannot be reduced to `allow`
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/issue-7222.rs:9:17
+   |
+LL |         0.0 ..= FOO => (),
+   |                 ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/issue-7222.rs:9:9
+   |
+LL |         0.0 ..= FOO => (),
+   |         ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+

--- a/src/test/run-pass/union/union-pat-refutability.stderr
+++ b/src/test/run-pass/union/union-pat-refutability.stderr
@@ -1,0 +1,54 @@
+warning: #[allow(illegal_floating_point_literal_pattern)] has no effect
+  --> $DIR/union-pat-refutability.rs:3:10
+   |
+LL | #![allow(illegal_floating_point_literal_pattern)]
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: #[warn(unused_attributes)] on by default
+   = note: the minimum lint level for `illegal_floating_point_literal_pattern` is `warn`
+   = note: the lint level cannot be reduced to `allow`
+   = help: remove the #[allow(illegal_floating_point_literal_pattern)] directive
+   = warning: `illegal_floating_point_literal_pattern` was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: #[allow(illegal_floating_point_literal_pattern)] has no effect
+  --> $DIR/union-pat-refutability.rs:3:10
+   |
+LL | #![allow(illegal_floating_point_literal_pattern)]
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the minimum lint level for `illegal_floating_point_literal_pattern` is `warn`
+   = note: the lint level cannot be reduced to `allow`
+   = help: remove the #[allow(illegal_floating_point_literal_pattern)] directive
+   = warning: `illegal_floating_point_literal_pattern` was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/union-pat-refutability.rs:24:44
+   |
+LL |             Value { tag: Tag::F, u: U { f: 0.0 } } => true,
+   |                                            ^^^
+   |
+note: lint level defined here
+  --> $DIR/union-pat-refutability.rs:3:10
+   |
+LL | #![allow(illegal_floating_point_literal_pattern)]
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: #[warn(illegal_floating_point_literal_pattern)] is the minimum lint level
+   = note: the lint level cannot be reduced to `allow`
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/union-pat-refutability.rs:24:44
+   |
+LL |             Value { tag: Tag::F, u: U { f: 0.0 } } => true,
+   |                                            ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+

--- a/src/test/ui/anon-params-deprecated.stderr
+++ b/src/test/ui/anon-params-deprecated.stderr
@@ -9,7 +9,8 @@ note: lint level defined here
    |
 LL | #![warn(anonymous_parameters)]
    |         ^^^^^^^^^^^^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #41686 <https://github.com/rust-lang/rust/issues/41686>
 
 warning: anonymous parameters are deprecated and will be removed in the next edition.
@@ -18,7 +19,8 @@ warning: anonymous parameters are deprecated and will be removed in the next edi
 LL |     fn bar_with_default_impl(String, String) {}
    |                              ^^^^^^ help: Try naming the parameter or explicitly ignoring it: `_: String`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #41686 <https://github.com/rust-lang/rust/issues/41686>
 
 warning: anonymous parameters are deprecated and will be removed in the next edition.
@@ -27,6 +29,7 @@ warning: anonymous parameters are deprecated and will be removed in the next edi
 LL |     fn bar_with_default_impl(String, String) {}
    |                                      ^^^^^^ help: Try naming the parameter or explicitly ignoring it: `_: String`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #41686 <https://github.com/rust-lang/rust/issues/41686>
 

--- a/src/test/ui/await-keyword/2015-edition-warning.fixed
+++ b/src/test/ui/await-keyword/2015-edition-warning.fixed
@@ -7,21 +7,27 @@ mod outer_mod {
     pub mod r#await {
 //~^ ERROR `await` is a keyword
 //~| WARN was previously accepted
+//~| WARN hard error
         pub struct r#await;
 //~^ ERROR `await` is a keyword
 //~| WARN was previously accepted
+//~| WARN hard error
     }
 }
 use outer_mod::r#await::r#await;
 //~^ ERROR `await` is a keyword
 //~| ERROR `await` is a keyword
 //~| WARN was previously accepted
+//~| WARN hard error
 //~| WARN was previously accepted
+//~| WARN hard error
 
 fn main() {
     match r#await { r#await => {} }
 //~^ ERROR `await` is a keyword
 //~| ERROR `await` is a keyword
 //~| WARN was previously accepted
+//~| WARN hard error
 //~| WARN was previously accepted
+//~| WARN hard error
 }

--- a/src/test/ui/await-keyword/2015-edition-warning.rs
+++ b/src/test/ui/await-keyword/2015-edition-warning.rs
@@ -7,21 +7,27 @@ mod outer_mod {
     pub mod await {
 //~^ ERROR `await` is a keyword
 //~| WARN was previously accepted
+//~| WARN hard error
         pub struct await;
 //~^ ERROR `await` is a keyword
 //~| WARN was previously accepted
+//~| WARN hard error
     }
 }
 use outer_mod::await::await;
 //~^ ERROR `await` is a keyword
 //~| ERROR `await` is a keyword
 //~| WARN was previously accepted
+//~| WARN hard error
 //~| WARN was previously accepted
+//~| WARN hard error
 
 fn main() {
     match await { await => {} }
 //~^ ERROR `await` is a keyword
 //~| ERROR `await` is a keyword
 //~| WARN was previously accepted
+//~| WARN hard error
 //~| WARN was previously accepted
+//~| WARN hard error
 }

--- a/src/test/ui/await-keyword/2015-edition-warning.stderr
+++ b/src/test/ui/await-keyword/2015-edition-warning.stderr
@@ -9,52 +9,58 @@ note: lint level defined here
    |
 LL | #![deny(keyword_idents)]
    |         ^^^^^^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `await` is a keyword in the 2018 edition
-  --> $DIR/2015-edition-warning.rs:10:20
+  --> $DIR/2015-edition-warning.rs:11:20
    |
 LL |         pub struct await;
    |                    ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `await` is a keyword in the 2018 edition
-  --> $DIR/2015-edition-warning.rs:15:16
+  --> $DIR/2015-edition-warning.rs:17:16
    |
 LL | use outer_mod::await::await;
    |                ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `await` is a keyword in the 2018 edition
-  --> $DIR/2015-edition-warning.rs:15:23
+  --> $DIR/2015-edition-warning.rs:17:23
    |
 LL | use outer_mod::await::await;
    |                       ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `await` is a keyword in the 2018 edition
-  --> $DIR/2015-edition-warning.rs:22:11
+  --> $DIR/2015-edition-warning.rs:26:11
    |
 LL |     match await { await => {} }
    |           ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `await` is a keyword in the 2018 edition
-  --> $DIR/2015-edition-warning.rs:22:19
+  --> $DIR/2015-edition-warning.rs:26:19
    |
 LL |     match await { await => {} }
    |                   ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: aborting due to 6 previous errors

--- a/src/test/ui/derives/deriving-with-repr-packed.rs
+++ b/src/test/ui/derives/deriving-with-repr-packed.rs
@@ -7,15 +7,18 @@
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 //~^ ERROR #[derive] can't be used
-//~| hard error
-//~^^^ ERROR #[derive] can't be used
-//~| hard error
+//~| WARN this was previously accepted
+//~| WARN hard error
+//~| ERROR #[derive] can't be used
+//~| WARN this was previously accepted
+//~| WARN hard error
 #[repr(packed)]
 pub struct Foo<T>(T, T, T);
 
 #[derive(PartialEq, Eq)]
 //~^ ERROR #[derive] can't be used
-//~| hard error
+//~| WARN this was previously accepted
+//~| WARN hard error
 #[repr(packed)]
 pub struct Bar(u32, u32, u32);
 
@@ -24,7 +27,8 @@ struct Y(usize);
 
 #[derive(PartialEq)]
 //~^ ERROR #[derive] can't be used
-//~| hard error
+//~| WARN this was previously accepted
+//~| WARN hard error
 #[repr(packed)]
 struct X(Y);
 

--- a/src/test/ui/derives/deriving-with-repr-packed.stderr
+++ b/src/test/ui/derives/deriving-with-repr-packed.stderr
@@ -9,7 +9,8 @@ note: lint level defined here
    |
 LL | #![deny(safe_packed_borrows)]
    |         ^^^^^^^^^^^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #46043 <https://github.com/rust-lang/rust/issues/46043>
 
 error: #[derive] can't be used on a #[repr(packed)] struct with type or const parameters (error E0133)
@@ -18,25 +19,28 @@ error: #[derive] can't be used on a #[repr(packed)] struct with type or const pa
 LL | #[derive(Copy, Clone, PartialEq, Eq)]
    |                       ^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #46043 <https://github.com/rust-lang/rust/issues/46043>
 
 error: #[derive] can't be used on a #[repr(packed)] struct that does not derive Copy (error E0133)
-  --> $DIR/deriving-with-repr-packed.rs:16:10
+  --> $DIR/deriving-with-repr-packed.rs:18:10
    |
 LL | #[derive(PartialEq, Eq)]
    |          ^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #46043 <https://github.com/rust-lang/rust/issues/46043>
 
 error: #[derive] can't be used on a #[repr(packed)] struct that does not derive Copy (error E0133)
-  --> $DIR/deriving-with-repr-packed.rs:25:10
+  --> $DIR/deriving-with-repr-packed.rs:28:10
    |
 LL | #[derive(PartialEq)]
    |          ^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #46043 <https://github.com/rust-lang/rust/issues/46043>
 
 error: aborting due to 4 previous errors

--- a/src/test/ui/dyn-keyword/dyn-2015-edition-keyword-ident-lint.fixed
+++ b/src/test/ui/dyn-keyword/dyn-2015-edition-keyword-ident-lint.fixed
@@ -13,26 +13,33 @@ mod outer_mod {
     pub mod r#dyn {
 //~^ ERROR `dyn` is a keyword
 //~| WARN was previously accepted
+//~| WARN hard error
         pub struct r#dyn;
 //~^ ERROR `dyn` is a keyword
 //~| WARN was previously accepted
+//~| WARN hard error
     }
 }
 use outer_mod::r#dyn::r#dyn;
 //~^ ERROR `dyn` is a keyword
 //~| WARN was previously accepted
+//~| WARN hard error
 //~| ERROR `dyn` is a keyword
 //~| WARN was previously accepted
+//~| WARN hard error
 
 fn main() {
     match r#dyn { r#dyn => {} }
 //~^ ERROR `dyn` is a keyword
 //~| WARN was previously accepted
+//~| WARN hard error
 //~| ERROR `dyn` is a keyword
 //~| WARN was previously accepted
+//~| WARN hard error
     macro_defn::r#dyn();
 //~^ ERROR `dyn` is a keyword
 //~| WARN was previously accepted
+//~| WARN hard error
 
     macro_defn::boxed();
 }
@@ -43,6 +50,7 @@ mod macro_defn {
     macro_rules! r#dyn {
 //~^ ERROR `dyn` is a keyword
 //~| WARN was previously accepted
+//~| WARN hard error
 
         // Note that we do not lint nor fix occurrences under macros
         ($dyn:tt) => { (Box<dyn Trait>, Box<$dyn Trait>) }
@@ -51,15 +59,20 @@ mod macro_defn {
     pub fn r#dyn() -> ::outer_mod::r#dyn::r#dyn {
 //~^ ERROR `dyn` is a keyword
 //~| WARN was previously accepted
+//~| WARN hard error
 //~| ERROR `dyn` is a keyword
 //~| WARN was previously accepted
+//~| WARN hard error
 //~| ERROR `dyn` is a keyword
 //~| WARN was previously accepted
+//~| WARN hard error
         ::outer_mod::r#dyn::r#dyn
 //~^ ERROR `dyn` is a keyword
 //~| WARN was previously accepted
+//~| WARN hard error
 //~| ERROR `dyn` is a keyword
 //~| WARN was previously accepted
+//~| WARN hard error
     }
 
 
@@ -67,6 +80,7 @@ mod macro_defn {
     pub fn boxed() -> r#dyn!(
         //~^ ERROR `dyn` is a keyword
         //~| WARN was previously accepted
+        //~| WARN hard error
 
             // Note that we do not lint nor fix occurrences under macros
             dyn

--- a/src/test/ui/dyn-keyword/dyn-2015-edition-keyword-ident-lint.rs
+++ b/src/test/ui/dyn-keyword/dyn-2015-edition-keyword-ident-lint.rs
@@ -13,26 +13,33 @@ mod outer_mod {
     pub mod dyn {
 //~^ ERROR `dyn` is a keyword
 //~| WARN was previously accepted
+//~| WARN hard error
         pub struct dyn;
 //~^ ERROR `dyn` is a keyword
 //~| WARN was previously accepted
+//~| WARN hard error
     }
 }
 use outer_mod::dyn::dyn;
 //~^ ERROR `dyn` is a keyword
 //~| WARN was previously accepted
+//~| WARN hard error
 //~| ERROR `dyn` is a keyword
 //~| WARN was previously accepted
+//~| WARN hard error
 
 fn main() {
     match dyn { dyn => {} }
 //~^ ERROR `dyn` is a keyword
 //~| WARN was previously accepted
+//~| WARN hard error
 //~| ERROR `dyn` is a keyword
 //~| WARN was previously accepted
+//~| WARN hard error
     macro_defn::dyn();
 //~^ ERROR `dyn` is a keyword
 //~| WARN was previously accepted
+//~| WARN hard error
 
     macro_defn::boxed();
 }
@@ -43,6 +50,7 @@ mod macro_defn {
     macro_rules! dyn {
 //~^ ERROR `dyn` is a keyword
 //~| WARN was previously accepted
+//~| WARN hard error
 
         // Note that we do not lint nor fix occurrences under macros
         ($dyn:tt) => { (Box<dyn Trait>, Box<$dyn Trait>) }
@@ -51,15 +59,20 @@ mod macro_defn {
     pub fn dyn() -> ::outer_mod::dyn::dyn {
 //~^ ERROR `dyn` is a keyword
 //~| WARN was previously accepted
+//~| WARN hard error
 //~| ERROR `dyn` is a keyword
 //~| WARN was previously accepted
+//~| WARN hard error
 //~| ERROR `dyn` is a keyword
 //~| WARN was previously accepted
+//~| WARN hard error
         ::outer_mod::dyn::dyn
 //~^ ERROR `dyn` is a keyword
 //~| WARN was previously accepted
+//~| WARN hard error
 //~| ERROR `dyn` is a keyword
 //~| WARN was previously accepted
+//~| WARN hard error
     }
 
 
@@ -67,6 +80,7 @@ mod macro_defn {
     pub fn boxed() -> dyn!(
         //~^ ERROR `dyn` is a keyword
         //~| WARN was previously accepted
+        //~| WARN hard error
 
             // Note that we do not lint nor fix occurrences under macros
             dyn

--- a/src/test/ui/dyn-keyword/dyn-2015-edition-keyword-ident-lint.stderr
+++ b/src/test/ui/dyn-keyword/dyn-2015-edition-keyword-ident-lint.stderr
@@ -9,124 +9,138 @@ note: lint level defined here
    |
 LL | #![deny(keyword_idents)]
    |         ^^^^^^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `dyn` is a keyword in the 2018 edition
-  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:16:20
+  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:17:20
    |
 LL |         pub struct dyn;
    |                    ^^^ help: you can use a raw identifier to stay compatible: `r#dyn`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `dyn` is a keyword in the 2018 edition
-  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:21:16
+  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:23:16
    |
 LL | use outer_mod::dyn::dyn;
    |                ^^^ help: you can use a raw identifier to stay compatible: `r#dyn`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `dyn` is a keyword in the 2018 edition
-  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:21:21
+  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:23:21
    |
 LL | use outer_mod::dyn::dyn;
    |                     ^^^ help: you can use a raw identifier to stay compatible: `r#dyn`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `dyn` is a keyword in the 2018 edition
-  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:28:11
+  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:32:11
    |
 LL |     match dyn { dyn => {} }
    |           ^^^ help: you can use a raw identifier to stay compatible: `r#dyn`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `dyn` is a keyword in the 2018 edition
-  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:28:17
+  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:32:17
    |
 LL |     match dyn { dyn => {} }
    |                 ^^^ help: you can use a raw identifier to stay compatible: `r#dyn`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `dyn` is a keyword in the 2018 edition
-  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:33:17
+  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:39:17
    |
 LL |     macro_defn::dyn();
    |                 ^^^ help: you can use a raw identifier to stay compatible: `r#dyn`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `dyn` is a keyword in the 2018 edition
-  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:43:18
+  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:50:18
    |
 LL |     macro_rules! dyn {
    |                  ^^^ help: you can use a raw identifier to stay compatible: `r#dyn`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `dyn` is a keyword in the 2018 edition
-  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:51:12
+  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:59:12
    |
 LL |     pub fn dyn() -> ::outer_mod::dyn::dyn {
    |            ^^^ help: you can use a raw identifier to stay compatible: `r#dyn`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `dyn` is a keyword in the 2018 edition
-  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:51:34
+  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:59:34
    |
 LL |     pub fn dyn() -> ::outer_mod::dyn::dyn {
    |                                  ^^^ help: you can use a raw identifier to stay compatible: `r#dyn`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `dyn` is a keyword in the 2018 edition
-  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:51:39
+  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:59:39
    |
 LL |     pub fn dyn() -> ::outer_mod::dyn::dyn {
    |                                       ^^^ help: you can use a raw identifier to stay compatible: `r#dyn`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `dyn` is a keyword in the 2018 edition
-  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:58:22
+  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:69:22
    |
 LL |         ::outer_mod::dyn::dyn
    |                      ^^^ help: you can use a raw identifier to stay compatible: `r#dyn`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `dyn` is a keyword in the 2018 edition
-  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:58:27
+  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:69:27
    |
 LL |         ::outer_mod::dyn::dyn
    |                           ^^^ help: you can use a raw identifier to stay compatible: `r#dyn`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `dyn` is a keyword in the 2018 edition
-  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:67:23
+  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:80:23
    |
 LL |     pub fn boxed() -> dyn!(
    |                       ^^^ help: you can use a raw identifier to stay compatible: `r#dyn`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: aborting due to 14 previous errors

--- a/src/test/ui/editions/edition-raw-pointer-method-2015.rs
+++ b/src/test/ui/editions/edition-raw-pointer-method-2015.rs
@@ -10,4 +10,5 @@ fn main() {
     let _ = y.is_null();
     //~^ error: type annotations needed [tyvar_behind_raw_pointer]
     //~^^ warning: this was previously accepted
+    //~| warning: hard error
 }

--- a/src/test/ui/editions/edition-raw-pointer-method-2015.stderr
+++ b/src/test/ui/editions/edition-raw-pointer-method-2015.stderr
@@ -10,7 +10,8 @@ note: lint level defined here
 LL | #[deny(warnings)]
    |        ^^^^^^^^
    = note: #[deny(tyvar_behind_raw_pointer)] implied by #[deny(warnings)]
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #46906 <https://github.com/rust-lang/rust/issues/46906>
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gate/issue-43106-gating-of-inline.rs
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-inline.rs
@@ -17,6 +17,7 @@ mod inline {
     #[inline = "2100"] fn f() { }
     //~^ WARN attribute must be of the form
     //~| WARN this was previously accepted
+    //~| WARN hard error
 
     #[inline] struct S;
     //~^ ERROR attribute should be applied to function or closure

--- a/src/test/ui/feature-gate/issue-43106-gating-of-inline.stderr
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-inline.stderr
@@ -5,7 +5,8 @@ LL |     #[inline = "2100"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^
    |
    = note: #[warn(ill_formed_attribute_input)] on by default
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
 error[E0518]: attribute should be applied to function or closure
@@ -30,19 +31,19 @@ LL |     mod inner { #![inline] }
    |     ------------^^^^^^^^^^-- not a function or closure
 
 error[E0518]: attribute should be applied to function or closure
-  --> $DIR/issue-43106-gating-of-inline.rs:21:5
+  --> $DIR/issue-43106-gating-of-inline.rs:22:5
    |
 LL |     #[inline] struct S;
    |     ^^^^^^^^^ --------- not a function or closure
 
 error[E0518]: attribute should be applied to function or closure
-  --> $DIR/issue-43106-gating-of-inline.rs:24:5
+  --> $DIR/issue-43106-gating-of-inline.rs:25:5
    |
 LL |     #[inline] type T = S;
    |     ^^^^^^^^^ ----------- not a function or closure
 
 error[E0518]: attribute should be applied to function or closure
-  --> $DIR/issue-43106-gating-of-inline.rs:27:5
+  --> $DIR/issue-43106-gating-of-inline.rs:28:5
    |
 LL |     #[inline] impl S { }
    |     ^^^^^^^^^ ---------- not a function or closure

--- a/src/test/ui/feature-gates/feature-gate-default_type_parameter_fallback.rs
+++ b/src/test/ui/feature-gates/feature-gate-default_type_parameter_fallback.rs
@@ -3,10 +3,12 @@
 fn avg<T=i32>(_: T) {}
 //~^ ERROR defaults for type parameters are only allowed
 //~| WARN this was previously accepted
+//~| WARN hard error
 
 struct S<T>(T);
 impl<T=i32> S<T> {}
 //~^ ERROR defaults for type parameters are only allowed
 //~| WARN this was previously accepted
+//~| WARN hard error
 
 fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-default_type_parameter_fallback.stderr
+++ b/src/test/ui/feature-gates/feature-gate-default_type_parameter_fallback.stderr
@@ -5,16 +5,18 @@ LL | fn avg<T=i32>(_: T) {}
    |        ^
    |
    = note: #[deny(invalid_type_param_default)] on by default
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #36887 <https://github.com/rust-lang/rust/issues/36887>
 
 error: defaults for type parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions.
-  --> $DIR/feature-gate-default_type_parameter_fallback.rs:8:6
+  --> $DIR/feature-gate-default_type_parameter_fallback.rs:9:6
    |
 LL | impl<T=i32> S<T> {}
    |      ^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #36887 <https://github.com/rust-lang/rust/issues/36887>
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/future-incompatible-lint-group.rs
+++ b/src/test/ui/future-incompatible-lint-group.rs
@@ -3,6 +3,7 @@
 trait Tr {
     fn f(u8) {} //~ ERROR anonymous parameters are deprecated
                 //~^ WARN this was previously accepted
+                //~| WARN hard error
 }
 
 fn main() {}

--- a/src/test/ui/future-incompatible-lint-group.stderr
+++ b/src/test/ui/future-incompatible-lint-group.stderr
@@ -10,7 +10,8 @@ note: lint level defined here
 LL | #![deny(future_incompatible)]
    |         ^^^^^^^^^^^^^^^^^^^
    = note: #[deny(anonymous_parameters)] implied by #[deny(future_incompatible)]
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #41686 <https://github.com/rust-lang/rust/issues/41686>
 
 error: aborting due to previous error

--- a/src/test/ui/impl-trait/issue-57979-impl-trait-in-path.rs
+++ b/src/test/ui/impl-trait/issue-57979-impl-trait-in-path.rs
@@ -19,7 +19,8 @@ mod warned {
     pub trait Quux<T> { type Assoc; }
     pub fn demo(_: impl Quux<(), Assoc=<() as Quux<impl Bar>>::Assoc>) { }
     //~^ WARN `impl Trait` is not allowed in path parameters
-    //~| WARN will become a hard error in a future release!
+    //~| WARN this was previously accepted
+    //~| WARN hard error
     impl<T> Quux<T> for () { type Assoc = u32; }
 }
 
@@ -30,7 +31,8 @@ mod denied {
     pub trait Quux<T> { type Assoc; }
     pub fn demo(_: impl Quux<(), Assoc=<() as Quux<impl Bar>>::Assoc>) { }
     //~^ ERROR `impl Trait` is not allowed in path parameters
-    //~| WARN will become a hard error in a future release!
+    //~| WARN this was previously accepted
+    //~| WARN hard error
     impl<T> Quux<T> for () { type Assoc = u32; }
 }
 

--- a/src/test/ui/impl-trait/issue-57979-impl-trait-in-path.stderr
+++ b/src/test/ui/impl-trait/issue-57979-impl-trait-in-path.stderr
@@ -9,21 +9,23 @@ note: lint level defined here
    |
 LL |     #![warn(nested_impl_trait)]
    |             ^^^^^^^^^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #59014 <https://github.com/rust-lang/rust/issues/59014>
 
 error: `impl Trait` is not allowed in path parameters
-  --> $DIR/issue-57979-impl-trait-in-path.rs:31:52
+  --> $DIR/issue-57979-impl-trait-in-path.rs:32:52
    |
 LL |     pub fn demo(_: impl Quux<(), Assoc=<() as Quux<impl Bar>>::Assoc>) { }
    |                                                    ^^^^^^^^
    |
 note: lint level defined here
-  --> $DIR/issue-57979-impl-trait-in-path.rs:27:13
+  --> $DIR/issue-57979-impl-trait-in-path.rs:28:13
    |
 LL |     #![deny(nested_impl_trait)]
    |             ^^^^^^^^^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #59014 <https://github.com/rust-lang/rust/issues/59014>
 
 error: aborting due to previous error

--- a/src/test/ui/impl-trait/issue-57979-nested-impl-trait-in-assoc-proj.rs
+++ b/src/test/ui/impl-trait/issue-57979-nested-impl-trait-in-assoc-proj.rs
@@ -20,7 +20,8 @@ mod warned {
     pub trait Quux { type Assoc; }
     pub fn demo(_: impl Quux<Assoc=impl Foo<impl Bar>>) { }
     //~^ WARN nested `impl Trait` is not allowed
-    //~| WARN will become a hard error in a future release!
+    //~| WARN this was previously accepted
+    //~| WARN hard error
 }
 
 mod denied {
@@ -31,7 +32,8 @@ mod denied {
     pub trait Quux { type Assoc; }
     pub fn demo(_: impl Quux<Assoc=impl Foo<impl Bar>>) { }
     //~^ ERROR nested `impl Trait` is not allowed
-    //~| WARN will become a hard error in a future release!
+    //~| WARN this was previously accepted
+    //~| WARN hard error
 }
 
 fn main() { }

--- a/src/test/ui/impl-trait/issue-57979-nested-impl-trait-in-assoc-proj.stderr
+++ b/src/test/ui/impl-trait/issue-57979-nested-impl-trait-in-assoc-proj.stderr
@@ -12,11 +12,12 @@ note: lint level defined here
    |
 LL |     #![warn(nested_impl_trait)]
    |             ^^^^^^^^^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #59014 <https://github.com/rust-lang/rust/issues/59014>
 
 error: nested `impl Trait` is not allowed
-  --> $DIR/issue-57979-nested-impl-trait-in-assoc-proj.rs:32:45
+  --> $DIR/issue-57979-nested-impl-trait-in-assoc-proj.rs:33:45
    |
 LL |     pub fn demo(_: impl Quux<Assoc=impl Foo<impl Bar>>) { }
    |                                    ---------^^^^^^^^-
@@ -25,11 +26,12 @@ LL |     pub fn demo(_: impl Quux<Assoc=impl Foo<impl Bar>>) { }
    |                                    outer `impl Trait`
    |
 note: lint level defined here
-  --> $DIR/issue-57979-nested-impl-trait-in-assoc-proj.rs:27:13
+  --> $DIR/issue-57979-nested-impl-trait-in-assoc-proj.rs:28:13
    |
 LL |     #![deny(nested_impl_trait)]
    |             ^^^^^^^^^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #59014 <https://github.com/rust-lang/rust/issues/59014>
 
 error: aborting due to previous error

--- a/src/test/ui/imports/local-modularized-tricky-fail-3.rs
+++ b/src/test/ui/imports/local-modularized-tricky-fail-3.rs
@@ -13,10 +13,12 @@ mod m {
     use exported;
     //~^ ERROR macro-expanded `macro_export` macros from the current crate cannot
     //~| WARN this was previously accepted
+    //~| WARN hard error
 }
 
 fn main() {
     ::exported!();
     //~^ ERROR macro-expanded `macro_export` macros from the current crate cannot
     //~| WARN this was previously accepted
+    //~| WARN hard error
 }

--- a/src/test/ui/imports/local-modularized-tricky-fail-3.stderr
+++ b/src/test/ui/imports/local-modularized-tricky-fail-3.stderr
@@ -5,7 +5,8 @@ LL |     use exported;
    |         ^^^^^^^^
    |
    = note: #[deny(macro_expanded_macro_exports_accessed_by_absolute_paths)] on by default
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #52234 <https://github.com/rust-lang/rust/issues/52234>
 note: the macro is defined here
   --> $DIR/local-modularized-tricky-fail-3.rs:5:5
@@ -19,12 +20,13 @@ LL |   define_exported!();
    |   ------------------- in this macro invocation
 
 error: macro-expanded `macro_export` macros from the current crate cannot be referred to by absolute paths
-  --> $DIR/local-modularized-tricky-fail-3.rs:19:5
+  --> $DIR/local-modularized-tricky-fail-3.rs:20:5
    |
 LL |     ::exported!();
    |     ^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #52234 <https://github.com/rust-lang/rust/issues/52234>
 note: the macro is defined here
   --> $DIR/local-modularized-tricky-fail-3.rs:5:5

--- a/src/test/ui/inference/inference-variable-behind-raw-pointer.stderr
+++ b/src/test/ui/inference/inference-variable-behind-raw-pointer.stderr
@@ -5,6 +5,7 @@ LL |     if data.is_null() {}
    |             ^^^^^^^
    |
    = note: #[warn(tyvar_behind_raw_pointer)] on by default
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #46906 <https://github.com/rust-lang/rust/issues/46906>
 

--- a/src/test/ui/issues/issue-27060.rs
+++ b/src/test/ui/issues/issue-27060.rs
@@ -24,9 +24,11 @@ fn main() {
     }
 
     let _ = &good.data; //~ ERROR borrow of packed field is unsafe
-                        //~| hard error
+                        //~| WARN previously accepted
+                        //~| WARN hard error
     let _ = &good.data2[0]; //~ ERROR borrow of packed field is unsafe
-                            //~| hard error
+                        //~| WARN previously accepted
+                        //~| WARN hard error
     let _ = &*good.data; // ok, behind a pointer
     let _ = &good.aligned; // ok, has align 1
     let _ = &good.aligned[2]; // ok, has align 1

--- a/src/test/ui/issues/issue-27060.stderr
+++ b/src/test/ui/issues/issue-27060.stderr
@@ -9,17 +9,19 @@ note: lint level defined here
    |
 LL | #[deny(safe_packed_borrows)]
    |        ^^^^^^^^^^^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #46043 <https://github.com/rust-lang/rust/issues/46043>
    = note: fields of packed structs might be misaligned: dereferencing a misaligned pointer or even just creating a misaligned reference is undefined behavior
 
 error: borrow of packed field is unsafe and requires unsafe function or block (error E0133)
-  --> $DIR/issue-27060.rs:28:13
+  --> $DIR/issue-27060.rs:29:13
    |
 LL |     let _ = &good.data2[0];
    |             ^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #46043 <https://github.com/rust-lang/rust/issues/46043>
    = note: fields of packed structs might be misaligned: dereferencing a misaligned pointer or even just creating a misaligned reference is undefined behavior
 

--- a/src/test/ui/issues/issue-30079.rs
+++ b/src/test/ui/issues/issue-30079.rs
@@ -4,7 +4,8 @@ mod m1 {
     struct Priv;
     impl ::SemiPriv {
         pub fn f(_: Priv) {} //~ WARN private type `m1::Priv` in public interface
-        //~^ WARNING hard error
+        //~^ WARN previously accepted
+        //~| WARNING hard error
     }
 
     impl Priv {

--- a/src/test/ui/issues/issue-30079.stderr
+++ b/src/test/ui/issues/issue-30079.stderr
@@ -5,11 +5,12 @@ LL |         pub fn f(_: Priv) {}
    |         ^^^^^^^^^^^^^^^^^^^^
    |
    = note: #[warn(private_in_public)] on by default
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error[E0446]: private type `m2::Priv` in public interface
-  --> $DIR/issue-30079.rs:18:9
+  --> $DIR/issue-30079.rs:19:9
    |
 LL |     struct Priv;
    |     - `m2::Priv` declared as private
@@ -18,7 +19,7 @@ LL |         type Target = Priv;
    |         ^^^^^^^^^^^^^^^^^^^ can't leak private type
 
 error[E0446]: private type `m3::Priv` in public interface
-  --> $DIR/issue-30079.rs:35:9
+  --> $DIR/issue-30079.rs:36:9
    |
 LL |     struct Priv;
    |     - `m3::Priv` declared as private

--- a/src/test/ui/issues/issue-32995-2.rs
+++ b/src/test/ui/issues/issue-32995-2.rs
@@ -4,10 +4,12 @@ fn main() {
     { fn f<X: ::std::marker()::Send>() {} }
     //~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
     //~| WARN previously accepted
+    //~| WARN hard error
 
     { fn f() -> impl ::std::marker()::Send { } }
     //~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
     //~| WARN previously accepted
+    //~| WARN hard error
 }
 
 #[derive(Clone)]
@@ -16,3 +18,4 @@ struct X;
 impl ::std::marker()::Copy for X {}
 //~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
 //~| WARN previously accepted
+//~| WARN hard error

--- a/src/test/ui/issues/issue-32995-2.stderr
+++ b/src/test/ui/issues/issue-32995-2.stderr
@@ -5,25 +5,28 @@ LL |     { fn f<X: ::std::marker()::Send>() {} }
    |                            ^^
    |
    = note: #[deny(parenthesized_params_in_types_and_modules)] on by default
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #42238 <https://github.com/rust-lang/rust/issues/42238>
 
 error: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/issue-32995-2.rs:8:35
+  --> $DIR/issue-32995-2.rs:9:35
    |
 LL |     { fn f() -> impl ::std::marker()::Send { } }
    |                                   ^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #42238 <https://github.com/rust-lang/rust/issues/42238>
 
 error: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/issue-32995-2.rs:16:19
+  --> $DIR/issue-32995-2.rs:18:19
    |
 LL | impl ::std::marker()::Copy for X {}
    |                   ^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #42238 <https://github.com/rust-lang/rust/issues/42238>
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/issues/issue-32995.rs
+++ b/src/test/ui/issues/issue-32995.rs
@@ -4,30 +4,37 @@ fn main() {
     let x: usize() = 1;
     //~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
     //~| WARN previously accepted
+    //~| WARN hard error
 
     let b: ::std::boxed()::Box<_> = Box::new(1);
     //~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
     //~| WARN previously accepted
+    //~| WARN hard error
 
     let p = ::std::str::()::from_utf8(b"foo").unwrap();
     //~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
     //~| WARN previously accepted
+    //~| WARN hard error
 
     let p = ::std::str::from_utf8::()(b"foo").unwrap();
     //~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
     //~| WARN previously accepted
+    //~| WARN hard error
 
     let o : Box<::std::marker()::Send> = Box::new(1);
     //~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
     //~| WARN previously accepted
+    //~| WARN hard error
 
     let o : Box<Send + ::std::marker()::Sync> = Box::new(1);
     //~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
     //~| WARN previously accepted
+    //~| WARN hard error
 }
 
 fn foo<X:Default>() {
     let d : X() = Default::default();
     //~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
     //~| WARN previously accepted
+    //~| WARN hard error
 }

--- a/src/test/ui/issues/issue-32995.stderr
+++ b/src/test/ui/issues/issue-32995.stderr
@@ -5,61 +5,68 @@ LL |     let x: usize() = 1;
    |                 ^^
    |
    = note: #[deny(parenthesized_params_in_types_and_modules)] on by default
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #42238 <https://github.com/rust-lang/rust/issues/42238>
 
 error: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/issue-32995.rs:8:24
+  --> $DIR/issue-32995.rs:9:24
    |
 LL |     let b: ::std::boxed()::Box<_> = Box::new(1);
    |                        ^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #42238 <https://github.com/rust-lang/rust/issues/42238>
 
 error: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/issue-32995.rs:12:25
+  --> $DIR/issue-32995.rs:14:25
    |
 LL |     let p = ::std::str::()::from_utf8(b"foo").unwrap();
    |                         ^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #42238 <https://github.com/rust-lang/rust/issues/42238>
 
 error: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/issue-32995.rs:16:36
+  --> $DIR/issue-32995.rs:19:36
    |
 LL |     let p = ::std::str::from_utf8::()(b"foo").unwrap();
    |                                    ^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #42238 <https://github.com/rust-lang/rust/issues/42238>
 
 error: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/issue-32995.rs:20:30
+  --> $DIR/issue-32995.rs:24:30
    |
 LL |     let o : Box<::std::marker()::Send> = Box::new(1);
    |                              ^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #42238 <https://github.com/rust-lang/rust/issues/42238>
 
 error: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/issue-32995.rs:24:37
+  --> $DIR/issue-32995.rs:29:37
    |
 LL |     let o : Box<Send + ::std::marker()::Sync> = Box::new(1);
    |                                     ^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #42238 <https://github.com/rust-lang/rust/issues/42238>
 
 error: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/issue-32995.rs:30:14
+  --> $DIR/issue-32995.rs:36:14
    |
 LL |     let d : X() = Default::default();
    |              ^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #42238 <https://github.com/rust-lang/rust/issues/42238>
 
 error: aborting due to 7 previous errors

--- a/src/test/ui/issues/issue-33140-traitobject-crate.stderr
+++ b/src/test/ui/issues/issue-33140-traitobject-crate.stderr
@@ -11,7 +11,8 @@ note: lint level defined here
    |
 LL | #![warn(order_dependent_trait_objects)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #56484 <https://github.com/rust-lang/rust/issues/56484>
 
 warning: conflicting implementations of trait `Trait` for type `(dyn std::marker::Send + std::marker::Sync + 'static)`: (E0119)
@@ -22,7 +23,8 @@ LL | unsafe impl Trait for ::std::marker::Send + Send + Sync { }
 LL | unsafe impl Trait for ::std::marker::Sync + Send { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `(dyn std::marker::Send + std::marker::Sync + 'static)`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #56484 <https://github.com/rust-lang/rust/issues/56484>
 
 warning: conflicting implementations of trait `Trait` for type `(dyn std::marker::Send + std::marker::Sync + 'static)`: (E0119)
@@ -34,6 +36,7 @@ LL | unsafe impl Trait for ::std::marker::Sync + Sync { }
 LL | unsafe impl Trait for ::std::marker::Sync + Send + Sync { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `(dyn std::marker::Send + std::marker::Sync + 'static)`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #56484 <https://github.com/rust-lang/rust/issues/56484>
 

--- a/src/test/ui/issues/issue-38715.rs
+++ b/src/test/ui/issues/issue-38715.rs
@@ -4,5 +4,6 @@ macro_rules! foo { ($i:ident) => {} }
 #[macro_export]
 macro_rules! foo { () => {} } //~ ERROR a macro named `foo` has already been exported
                               //~| WARN this was previously accepted
+                              //~| WARN hard error
 
 fn main() {}

--- a/src/test/ui/issues/issue-38715.stderr
+++ b/src/test/ui/issues/issue-38715.stderr
@@ -5,7 +5,8 @@ LL | macro_rules! foo { () => {} }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `foo` already exported
    |
    = note: #[deny(duplicate_macro_exports)] on by default
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #35896 <https://github.com/rust-lang/rust/issues/35896>
 note: previous macro export is now shadowed
   --> $DIR/issue-38715.rs:2:1

--- a/src/test/ui/issues/issue-39404.rs
+++ b/src/test/ui/issues/issue-39404.rs
@@ -3,5 +3,6 @@
 macro_rules! m { ($i) => {} }
 //~^ ERROR missing fragment specifier
 //~| WARN previously accepted
+//~| WARN hard error
 
 fn main() {}

--- a/src/test/ui/issues/issue-39404.stderr
+++ b/src/test/ui/issues/issue-39404.stderr
@@ -5,7 +5,8 @@ LL | macro_rules! m { ($i) => {} }
    |                   ^^
    |
    = note: #[deny(missing_fragment_specifier)] on by default
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #40107 <https://github.com/rust-lang/rust/issues/40107>
 
 error: aborting due to previous error

--- a/src/test/ui/issues/issue-41255.rs
+++ b/src/test/ui/issues/issue-41255.rs
@@ -8,18 +8,25 @@ fn main() {
     let x = 42.0;
     match x {
         5.0 => {}, //~ ERROR floating-point types cannot be used in patterns
+                   //~| WARN this was previously accepted
                    //~| WARNING hard error
         5.0f32 => {}, //~ ERROR floating-point types cannot be used in patterns
+                      //~| WARN this was previously accepted
                       //~| WARNING hard error
         -5.0 => {}, //~ ERROR floating-point types cannot be used in patterns
+                    //~| WARN this was previously accepted
                     //~| WARNING hard error
         1.0 .. 33.0 => {}, //~ ERROR floating-point types cannot be used in patterns
+                           //~| WARN this was previously accepted
                            //~| WARNING hard error
                            //~| ERROR floating-point types cannot be used in patterns
+                           //~| WARN this was previously accepted
                            //~| WARNING hard error
         39.0 ..= 70.0 => {}, //~ ERROR floating-point types cannot be used in patterns
+                             //~| WARN this was previously accepted
                              //~| WARNING hard error
                              //~| ERROR floating-point types cannot be used in patterns
+                             //~| WARN this was previously accepted
                              //~| WARNING hard error
         _ => {},
     };
@@ -27,6 +34,7 @@ fn main() {
     // Same for tuples
     match (x, 5) {
         (3.14, 1) => {}, //~ ERROR floating-point types cannot be used
+                         //~| WARN this was previously accepted
                          //~| WARNING hard error
         _ => {},
     }
@@ -34,6 +42,7 @@ fn main() {
     struct Foo { x: f32 };
     match (Foo { x }) {
         Foo { x: 2.0 } => {}, //~ ERROR floating-point types cannot be used
+                              //~| WARN this was previously accepted
                               //~| WARNING hard error
         _ => {},
     }

--- a/src/test/ui/issues/issue-41255.stderr
+++ b/src/test/ui/issues/issue-41255.stderr
@@ -9,79 +9,88 @@ note: lint level defined here
    |
 LL | #![forbid(illegal_floating_point_literal_pattern)]
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
 error: floating-point types cannot be used in patterns
-  --> $DIR/issue-41255.rs:12:9
+  --> $DIR/issue-41255.rs:13:9
    |
 LL |         5.0f32 => {},
    |         ^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
 error: floating-point types cannot be used in patterns
-  --> $DIR/issue-41255.rs:14:10
+  --> $DIR/issue-41255.rs:16:10
    |
 LL |         -5.0 => {},
    |          ^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
 error: floating-point types cannot be used in patterns
-  --> $DIR/issue-41255.rs:16:9
+  --> $DIR/issue-41255.rs:19:9
    |
 LL |         1.0 .. 33.0 => {},
    |         ^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
 error: floating-point types cannot be used in patterns
-  --> $DIR/issue-41255.rs:16:16
+  --> $DIR/issue-41255.rs:19:16
    |
 LL |         1.0 .. 33.0 => {},
    |                ^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
 error: floating-point types cannot be used in patterns
-  --> $DIR/issue-41255.rs:20:9
+  --> $DIR/issue-41255.rs:25:9
    |
 LL |         39.0 ..= 70.0 => {},
    |         ^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
 error: floating-point types cannot be used in patterns
-  --> $DIR/issue-41255.rs:20:18
+  --> $DIR/issue-41255.rs:25:18
    |
 LL |         39.0 ..= 70.0 => {},
    |                  ^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
 error: floating-point types cannot be used in patterns
-  --> $DIR/issue-41255.rs:29:10
+  --> $DIR/issue-41255.rs:36:10
    |
 LL |         (3.14, 1) => {},
    |          ^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
 error: floating-point types cannot be used in patterns
-  --> $DIR/issue-41255.rs:36:18
+  --> $DIR/issue-41255.rs:44:18
    |
 LL |         Foo { x: 2.0 } => {},
    |                  ^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
 error: aborting due to 9 previous errors

--- a/src/test/ui/issues/issue-43355.rs
+++ b/src/test/ui/issues/issue-43355.rs
@@ -12,7 +12,8 @@ impl<X, T> Trait1<X> for T where T: Trait2<X> {
 
 impl<X> Trait1<Box<X>> for A {
 //~^ ERROR conflicting implementations of trait
-//~| hard error
+//~| WARN this was previously accepted by the compiler but is being phased out
+//~| WARN hard error
 //~| downstream crates may implement trait `Trait2<std::boxed::Box<_>>` for type `A`
     type Output = i32;
 }

--- a/src/test/ui/issues/issue-43355.stderr
+++ b/src/test/ui/issues/issue-43355.stderr
@@ -8,7 +8,8 @@ LL | impl<X> Trait1<Box<X>> for A {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `A`
    |
    = note: #[deny(incoherent_fundamental_impls)] on by default
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #46205 <https://github.com/rust-lang/rust/issues/46205>
    = note: downstream crates may implement trait `Trait2<std::boxed::Box<_>>` for type `A`
 

--- a/src/test/ui/issues/issue-50781.rs
+++ b/src/test/ui/issues/issue-50781.rs
@@ -5,6 +5,7 @@ trait Trait {}
 trait X {
     fn foo(&self) where Self: Trait; //~ ERROR the trait `X` cannot be made into an object
     //~^ WARN this was previously accepted by the compiler but is being phased out
+    //~| WARN hard error
 }
 
 impl X for () {

--- a/src/test/ui/issues/issue-50781.stderr
+++ b/src/test/ui/issues/issue-50781.stderr
@@ -9,7 +9,8 @@ note: lint level defined here
    |
 LL | #![deny(where_clauses_object_safety)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #51443 <https://github.com/rust-lang/rust/issues/51443>
    = note: method `foo` references the `Self` type in where clauses
 

--- a/src/test/ui/issues/issue-6804.rs
+++ b/src/test/ui/issues/issue-6804.rs
@@ -10,12 +10,14 @@ fn main() {
     match x {
         NAN => {}, //~ ERROR floating-point types cannot be used
         //~^ WARN this was previously accepted by the compiler but is being phased out
+        //~| WARN hard error
         _ => {},
     };
 
     match [x, 1.0] {
         [NAN, _] => {}, //~ ERROR floating-point types cannot be used
         //~^ WARN this was previously accepted by the compiler but is being phased out
+        //~| WARN hard error
         _ => {},
     };
 }

--- a/src/test/ui/issues/issue-6804.stderr
+++ b/src/test/ui/issues/issue-6804.stderr
@@ -9,16 +9,18 @@ note: lint level defined here
    |
 LL | #![deny(illegal_floating_point_literal_pattern)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
 error: floating-point types cannot be used in patterns
-  --> $DIR/issue-6804.rs:17:10
+  --> $DIR/issue-6804.rs:18:10
    |
 LL |         [NAN, _] => {},
    |          ^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/lint/lint-incoherent-auto-trait-objects.rs
+++ b/src/test/ui/lint/lint-incoherent-auto-trait-objects.rs
@@ -6,16 +6,19 @@ impl Foo for dyn Send {}
 
 impl Foo for dyn Send + Send {}
 //~^ ERROR conflicting implementations
-//~| hard error
+//~| WARN this was previously accepted
+//~| WARN hard error
 
 impl Foo for dyn Send + Sync {}
 
 impl Foo for dyn Sync + Send {}
 //~^ ERROR conflicting implementations
-//~| hard error
+//~| WARN this was previously accepted
+//~| WARN hard error
 
 impl Foo for dyn Send + Sync + Send {}
 //~^ ERROR conflicting implementations
-//~| hard error
+//~| WARN this was previously accepted
+//~| WARN hard error
 
 fn main() {}

--- a/src/test/ui/lint/lint-incoherent-auto-trait-objects.stderr
+++ b/src/test/ui/lint/lint-incoherent-auto-trait-objects.stderr
@@ -8,11 +8,12 @@ LL | impl Foo for dyn Send + Send {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `(dyn std::marker::Send + 'static)`
    |
    = note: #[deny(order_dependent_trait_objects)] on by default
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #56484 <https://github.com/rust-lang/rust/issues/56484>
 
 error: conflicting implementations of trait `Foo` for type `(dyn std::marker::Send + std::marker::Sync + 'static)`: (E0119)
-  --> $DIR/lint-incoherent-auto-trait-objects.rs:13:1
+  --> $DIR/lint-incoherent-auto-trait-objects.rs:14:1
    |
 LL | impl Foo for dyn Send + Sync {}
    | ---------------------------- first implementation here
@@ -20,11 +21,12 @@ LL |
 LL | impl Foo for dyn Sync + Send {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `(dyn std::marker::Send + std::marker::Sync + 'static)`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #56484 <https://github.com/rust-lang/rust/issues/56484>
 
 error: conflicting implementations of trait `Foo` for type `(dyn std::marker::Send + std::marker::Sync + 'static)`: (E0119)
-  --> $DIR/lint-incoherent-auto-trait-objects.rs:17:1
+  --> $DIR/lint-incoherent-auto-trait-objects.rs:19:1
    |
 LL | impl Foo for dyn Sync + Send {}
    | ---------------------------- first implementation here
@@ -32,7 +34,8 @@ LL | impl Foo for dyn Sync + Send {}
 LL | impl Foo for dyn Send + Sync + Send {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `(dyn std::marker::Send + std::marker::Sync + 'static)`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #56484 <https://github.com/rust-lang/rust/issues/56484>
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/lint/lint-min-allow-no-effect.rs
+++ b/src/test/ui/lint/lint-min-allow-no-effect.rs
@@ -1,0 +1,20 @@
+#![deny(unused_attributes)]
+//~^ NOTE lint level defined here
+
+#![allow(illegal_floating_point_literal_pattern)]
+//~^ ERROR #[allow(illegal_floating_point_literal_pattern)] has no effect [unused_attributes]
+//~| NOTE the minimum lint level for `illegal_floating_point_literal_pattern` is `warn`
+//~| NOTE the lint level cannot be reduced to `allow`
+//~| HELP remove the #[allow(illegal_floating_point_literal_pattern)] directive
+//~| WARN `illegal_floating_point_literal_pattern` was previously accepted
+//~| WARN hard error
+//~| NOTE for more information
+//~| ERROR #[allow(illegal_floating_point_literal_pattern)] has no effect [unused_attributes]
+//~| NOTE the minimum lint level for `illegal_floating_point_literal_pattern` is `warn`
+//~| NOTE the lint level cannot be reduced to `allow`
+//~| HELP remove the #[allow(illegal_floating_point_literal_pattern)] directive
+//~| WARN `illegal_floating_point_literal_pattern` was previously accepted
+//~| WARN hard error
+//~| NOTE for more information
+
+fn main() {}

--- a/src/test/ui/lint/lint-min-allow-no-effect.stderr
+++ b/src/test/ui/lint/lint-min-allow-no-effect.stderr
@@ -1,0 +1,33 @@
+error: #[allow(illegal_floating_point_literal_pattern)] has no effect
+  --> $DIR/lint-min-allow-no-effect.rs:4:10
+   |
+LL | #![allow(illegal_floating_point_literal_pattern)]
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: lint level defined here
+  --> $DIR/lint-min-allow-no-effect.rs:1:9
+   |
+LL | #![deny(unused_attributes)]
+   |         ^^^^^^^^^^^^^^^^^
+   = note: the minimum lint level for `illegal_floating_point_literal_pattern` is `warn`
+   = note: the lint level cannot be reduced to `allow`
+   = help: remove the #[allow(illegal_floating_point_literal_pattern)] directive
+   = warning: `illegal_floating_point_literal_pattern` was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+error: #[allow(illegal_floating_point_literal_pattern)] has no effect
+  --> $DIR/lint-min-allow-no-effect.rs:4:10
+   |
+LL | #![allow(illegal_floating_point_literal_pattern)]
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the minimum lint level for `illegal_floating_point_literal_pattern` is `warn`
+   = note: the lint level cannot be reduced to `allow`
+   = help: remove the #[allow(illegal_floating_point_literal_pattern)] directive
+   = warning: `illegal_floating_point_literal_pattern` was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/lint/lint-min-deny-has-effect.rs
+++ b/src/test/ui/lint/lint-min-deny-has-effect.rs
@@ -1,0 +1,7 @@
+// run-pass
+
+#![deny(unused_attributes)]
+
+#![deny(illegal_floating_point_literal_pattern)]
+
+fn main() {}

--- a/src/test/ui/lint/lint-min-warn-cannot-allow.rs
+++ b/src/test/ui/lint/lint-min-warn-cannot-allow.rs
@@ -1,0 +1,17 @@
+#![deny(warnings)]
+//~^ NOTE lint level defined here
+
+#![allow(illegal_floating_point_literal_pattern)]
+
+fn _0() {
+    if let 0.0 = 0.0 {}
+    //~^ ERROR floating-point types cannot be used in patterns
+    //~| NOTE #[deny(illegal_floating_point_literal_pattern)] implied by #[deny(warnings)]
+    //~| NOTE #[warn(illegal_floating_point_literal_pattern)] is the minimum lint level
+    //~| NOTE the lint level cannot be reduced to `allow`
+    //~| WARN this was previously accepted
+    //~| WARN hard error
+    //~| NOTE for more information, see issue #41620
+}
+
+fn main() {}

--- a/src/test/ui/lint/lint-min-warn-cannot-allow.stderr
+++ b/src/test/ui/lint/lint-min-warn-cannot-allow.stderr
@@ -1,0 +1,20 @@
+error: floating-point types cannot be used in patterns
+  --> $DIR/lint-min-warn-cannot-allow.rs:7:12
+   |
+LL |     if let 0.0 = 0.0 {}
+   |            ^^^
+   |
+note: lint level defined here
+  --> $DIR/lint-min-warn-cannot-allow.rs:1:9
+   |
+LL | #![deny(warnings)]
+   |         ^^^^^^^^
+   = note: #[deny(illegal_floating_point_literal_pattern)] implied by #[deny(warnings)]
+   = note: #[warn(illegal_floating_point_literal_pattern)] is the minimum lint level
+   = note: the lint level cannot be reduced to `allow`
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+error: aborting due to previous error
+

--- a/src/test/ui/lint/lint-min-warn-cannot-allow2.rs
+++ b/src/test/ui/lint/lint-min-warn-cannot-allow2.rs
@@ -1,0 +1,11 @@
+// run-pass
+
+// FIXME(centril): enforce the warnings and such somehow.
+
+#![warn(warnings)]
+
+#![allow(illegal_floating_point_literal_pattern)]
+
+fn main() {
+    if let 0.0 = 0.0 {}
+}

--- a/src/test/ui/lint/lint-min-warn-cannot-allow2.stderr
+++ b/src/test/ui/lint/lint-min-warn-cannot-allow2.stderr
@@ -1,0 +1,27 @@
+warning: floating-point types cannot be used in patterns
+  --> $DIR/lint-min-warn-cannot-allow2.rs:10:12
+   |
+LL |     if let 0.0 = 0.0 {}
+   |            ^^^
+   |
+note: lint level defined here
+  --> $DIR/lint-min-warn-cannot-allow2.rs:7:10
+   |
+LL | #![allow(illegal_floating_point_literal_pattern)]
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: #[warn(illegal_floating_point_literal_pattern)] is the minimum lint level
+   = note: the lint level cannot be reduced to `allow`
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/lint-min-warn-cannot-allow2.rs:10:12
+   |
+LL |     if let 0.0 = 0.0 {}
+   |            ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+

--- a/src/test/ui/lint/lint-min-warn-has-effect.rs
+++ b/src/test/ui/lint/lint-min-warn-has-effect.rs
@@ -1,0 +1,7 @@
+// run-pass
+
+#![deny(unused_attributes)]
+
+#![warn(illegal_floating_point_literal_pattern)]
+
+fn main() {}

--- a/src/test/ui/macros/macro-at-most-once-rep-2015-ques-sep.stderr
+++ b/src/test/ui/macros/macro-at-most-once-rep-2015-ques-sep.stderr
@@ -10,7 +10,8 @@ note: lint level defined here
 LL | #![warn(rust_2018_compatibility)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^
    = note: #[warn(question_mark_macro_sep)] implied by #[warn(rust_2018_compatibility)]
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #48075 <https://github.com/rust-lang/rust/issues/48075>
 
 warning: using `?` as a separator is deprecated and will be a hard error in an upcoming edition
@@ -19,6 +20,7 @@ warning: using `?` as a separator is deprecated and will be a hard error in an u
 LL |     ($(a)?+) => {}
    |          ^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #48075 <https://github.com/rust-lang/rust/issues/48075>
 

--- a/src/test/ui/macros/macro-multiple-matcher-bindings.stderr
+++ b/src/test/ui/macros/macro-multiple-matcher-bindings.stderr
@@ -9,7 +9,8 @@ note: lint level defined here
    |
 LL | #![warn(duplicate_matcher_binding_name)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #57593 <https://github.com/rust-lang/rust/issues/57593>
 
 warning: duplicate matcher binding
@@ -18,7 +19,8 @@ warning: duplicate matcher binding
 LL |     ($a:ident, $a:path) => {};
    |      ^^^^^^^^  ^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #57593 <https://github.com/rust-lang/rust/issues/57593>
 
 warning: duplicate matcher binding
@@ -27,7 +29,8 @@ warning: duplicate matcher binding
 LL |     ($a:ident, $($a:ident),*) => {};
    |      ^^^^^^^^    ^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #57593 <https://github.com/rust-lang/rust/issues/57593>
 
 warning: duplicate matcher binding
@@ -36,6 +39,7 @@ warning: duplicate matcher binding
 LL |     ($($a:ident)+ # $($($a:path),+);*) => {};
    |        ^^^^^^^^         ^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #57593 <https://github.com/rust-lang/rust/issues/57593>
 

--- a/src/test/ui/malformed/malformed-regressions.stderr
+++ b/src/test/ui/malformed/malformed-regressions.stderr
@@ -5,7 +5,8 @@ LL | #[doc]
    | ^^^^^^
    |
    = note: #[warn(ill_formed_attribute_input)] on by default
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
 warning: attribute must be of the form `#[ignore]` or `#[ignore = "reason"]`
@@ -14,7 +15,8 @@ warning: attribute must be of the form `#[ignore]` or `#[ignore = "reason"]`
 LL | #[ignore()]
    | ^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
 warning: attribute must be of the form `#[inline]` or `#[inline(always|never)]`
@@ -23,7 +25,8 @@ warning: attribute must be of the form `#[inline]` or `#[inline(always|never)]`
 LL | #[inline = ""]
    | ^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
 warning: attribute must be of the form `#[link(name = "...", /*opt*/ kind = "dylib|static|...",
@@ -33,7 +36,8 @@ warning: attribute must be of the form `#[link(name = "...", /*opt*/ kind = "dyl
 LL | #[link]
    | ^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
 warning: attribute must be of the form `#[link(name = "...", /*opt*/ kind = "dylib|static|...",
@@ -43,6 +47,7 @@ warning: attribute must be of the form `#[link(name = "...", /*opt*/ kind = "dyl
 LL | #[link = ""]
    | ^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 

--- a/src/test/ui/match/match-range-fail-dominate.stderr
+++ b/src/test/ui/match/match-range-fail-dominate.stderr
@@ -35,7 +35,8 @@ LL |       0.01f64 ... 6.5f64 => {}
    |       ^^^^^^^
    |
    = note: #[warn(illegal_floating_point_literal_pattern)] on by default
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
 warning: floating-point types cannot be used in patterns
@@ -44,7 +45,8 @@ warning: floating-point types cannot be used in patterns
 LL |       0.01f64 ... 6.5f64 => {}
    |                   ^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
 warning: floating-point types cannot be used in patterns
@@ -53,7 +55,8 @@ warning: floating-point types cannot be used in patterns
 LL |       0.02f64 => {}
    |       ^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
 error: unreachable pattern

--- a/src/test/ui/methods/method-call-lifetime-args-lint-fail.rs
+++ b/src/test/ui/methods/method-call-lifetime-args-lint-fail.rs
@@ -23,43 +23,55 @@ fn method_call() {
     S.late::<'static>(&0, &0);
     //~^ ERROR cannot specify lifetime arguments explicitly
     //~| WARN this was previously accepted
+    //~| WARN hard error
     S.late::<'static, 'static>(&0, &0);
     //~^ ERROR cannot specify lifetime arguments explicitly
     //~| WARN this was previously accepted
+    //~| WARN hard error
     S.late::<'static, 'static, 'static>(&0, &0);
     //~^ ERROR cannot specify lifetime arguments explicitly
     //~| WARN this was previously accepted
+    //~| WARN hard error
     S.late_early(&0); // OK
     S.late_early::<'static>(&0);
     //~^ ERROR cannot specify lifetime arguments explicitly
     //~| WARN this was previously accepted
+    //~| WARN hard error
     S.late_early::<'static, 'static>(&0);
     //~^ ERROR cannot specify lifetime arguments explicitly
     //~| WARN this was previously accepted
+    //~| WARN hard error
     S.late_early::<'static, 'static, 'static>(&0);
     //~^ ERROR cannot specify lifetime arguments explicitly
     //~| WARN this was previously accepted
+    //~| WARN hard error
 
     S.late_implicit(&0, &0); // OK
     S.late_implicit::<'static>(&0, &0);
     //~^ ERROR cannot specify lifetime arguments explicitly
     //~| WARN this was previously accepted
+    //~| WARN hard error
     S.late_implicit::<'static, 'static>(&0, &0);
     //~^ ERROR cannot specify lifetime arguments explicitly
     //~| WARN this was previously accepted
+    //~| WARN hard error
     S.late_implicit::<'static, 'static, 'static>(&0, &0);
     //~^ ERROR cannot specify lifetime arguments explicitly
     //~| WARN this was previously accepted
+    //~| WARN hard error
     S.late_implicit_early(&0); // OK
     S.late_implicit_early::<'static>(&0);
     //~^ ERROR cannot specify lifetime arguments explicitly
     //~| WARN this was previously accepted
+    //~| WARN hard error
     S.late_implicit_early::<'static, 'static>(&0);
     //~^ ERROR cannot specify lifetime arguments explicitly
     //~| WARN this was previously accepted
+    //~| WARN hard error
     S.late_implicit_early::<'static, 'static, 'static>(&0);
     //~^ ERROR cannot specify lifetime arguments explicitly
     //~| WARN this was previously accepted
+    //~| WARN hard error
 
     S::early_tricky_explicit::<'static>(loop {}, loop {}); // OK
     S::early_tricky_implicit::<'static>(loop {}, loop {}); // OK
@@ -69,10 +81,12 @@ fn ufcs() {
     S::late_early::<'static>(S, &0);
     //~^ ERROR cannot specify lifetime arguments explicitly
     //~| WARN this was previously accepted
+    //~| WARN hard error
 
     S::late_implicit_early::<'static>(S, &0);
     //~^ ERROR cannot specify lifetime arguments explicitly
     //~| WARN this was previously accepted
+    //~| WARN hard error
 }
 
 fn lint_not_inference_error() {
@@ -82,6 +96,7 @@ fn lint_not_inference_error() {
     f::<'static, u8>;
     //~^ ERROR cannot specify lifetime arguments explicitly
     //~| WARN this was previously accepted
+    //~| WARN hard error
 }
 
 fn main() {}

--- a/src/test/ui/methods/method-call-lifetime-args-lint-fail.stderr
+++ b/src/test/ui/methods/method-call-lifetime-args-lint-fail.stderr
@@ -12,11 +12,12 @@ note: lint level defined here
    |
 LL | #![deny(late_bound_lifetime_arguments)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/method-call-lifetime-args-lint-fail.rs:26:14
+  --> $DIR/method-call-lifetime-args-lint-fail.rs:27:14
    |
 LL |     fn late<'a, 'b>(self, _: &'a u8, _: &'b u8) {}
    |             -- the late bound lifetime parameter is introduced here
@@ -24,11 +25,12 @@ LL |     fn late<'a, 'b>(self, _: &'a u8, _: &'b u8) {}
 LL |     S.late::<'static, 'static>(&0, &0);
    |              ^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/method-call-lifetime-args-lint-fail.rs:29:14
+  --> $DIR/method-call-lifetime-args-lint-fail.rs:31:14
    |
 LL |     fn late<'a, 'b>(self, _: &'a u8, _: &'b u8) {}
    |             -- the late bound lifetime parameter is introduced here
@@ -36,19 +38,8 @@ LL |     fn late<'a, 'b>(self, _: &'a u8, _: &'b u8) {}
 LL |     S.late::<'static, 'static, 'static>(&0, &0);
    |              ^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
-
-error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/method-call-lifetime-args-lint-fail.rs:33:20
-   |
-LL |     fn late_early<'a, 'b>(self, _: &'a u8) -> &'b u8 { loop {} }
-   |                   -- the late bound lifetime parameter is introduced here
-...
-LL |     S.late_early::<'static>(&0);
-   |                    ^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
@@ -57,14 +48,28 @@ error: cannot specify lifetime arguments explicitly if late bound lifetime param
 LL |     fn late_early<'a, 'b>(self, _: &'a u8) -> &'b u8 { loop {} }
    |                   -- the late bound lifetime parameter is introduced here
 ...
-LL |     S.late_early::<'static, 'static>(&0);
+LL |     S.late_early::<'static>(&0);
    |                    ^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/method-call-lifetime-args-lint-fail.rs:39:20
+  --> $DIR/method-call-lifetime-args-lint-fail.rs:40:20
+   |
+LL |     fn late_early<'a, 'b>(self, _: &'a u8) -> &'b u8 { loop {} }
+   |                   -- the late bound lifetime parameter is introduced here
+...
+LL |     S.late_early::<'static, 'static>(&0);
+   |                    ^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
+
+error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/method-call-lifetime-args-lint-fail.rs:44:20
    |
 LL |     fn late_early<'a, 'b>(self, _: &'a u8) -> &'b u8 { loop {} }
    |                   -- the late bound lifetime parameter is introduced here
@@ -72,31 +77,8 @@ LL |     fn late_early<'a, 'b>(self, _: &'a u8) -> &'b u8 { loop {} }
 LL |     S.late_early::<'static, 'static, 'static>(&0);
    |                    ^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
-
-error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/method-call-lifetime-args-lint-fail.rs:44:23
-   |
-LL |     fn late_implicit(self, _: &u8, _: &u8) {}
-   |                               - the late bound lifetime parameter is introduced here
-...
-LL |     S.late_implicit::<'static>(&0, &0);
-   |                       ^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
-
-error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/method-call-lifetime-args-lint-fail.rs:47:23
-   |
-LL |     fn late_implicit(self, _: &u8, _: &u8) {}
-   |                               - the late bound lifetime parameter is introduced here
-...
-LL |     S.late_implicit::<'static, 'static>(&0, &0);
-   |                       ^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
@@ -105,14 +87,41 @@ error: cannot specify lifetime arguments explicitly if late bound lifetime param
 LL |     fn late_implicit(self, _: &u8, _: &u8) {}
    |                               - the late bound lifetime parameter is introduced here
 ...
-LL |     S.late_implicit::<'static, 'static, 'static>(&0, &0);
+LL |     S.late_implicit::<'static>(&0, &0);
    |                       ^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/method-call-lifetime-args-lint-fail.rs:54:29
+  --> $DIR/method-call-lifetime-args-lint-fail.rs:54:23
+   |
+LL |     fn late_implicit(self, _: &u8, _: &u8) {}
+   |                               - the late bound lifetime parameter is introduced here
+...
+LL |     S.late_implicit::<'static, 'static>(&0, &0);
+   |                       ^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
+
+error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/method-call-lifetime-args-lint-fail.rs:58:23
+   |
+LL |     fn late_implicit(self, _: &u8, _: &u8) {}
+   |                               - the late bound lifetime parameter is introduced here
+...
+LL |     S.late_implicit::<'static, 'static, 'static>(&0, &0);
+   |                       ^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
+
+error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/method-call-lifetime-args-lint-fail.rs:63:29
    |
 LL |     fn late_implicit_early<'b>(self, _: &u8) -> &'b u8 { loop {} }
    |                                         - the late bound lifetime parameter is introduced here
@@ -120,11 +129,12 @@ LL |     fn late_implicit_early<'b>(self, _: &u8) -> &'b u8 { loop {} }
 LL |     S.late_implicit_early::<'static>(&0);
    |                             ^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/method-call-lifetime-args-lint-fail.rs:57:29
+  --> $DIR/method-call-lifetime-args-lint-fail.rs:67:29
    |
 LL |     fn late_implicit_early<'b>(self, _: &u8) -> &'b u8 { loop {} }
    |                                         - the late bound lifetime parameter is introduced here
@@ -132,11 +142,12 @@ LL |     fn late_implicit_early<'b>(self, _: &u8) -> &'b u8 { loop {} }
 LL |     S.late_implicit_early::<'static, 'static>(&0);
    |                             ^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/method-call-lifetime-args-lint-fail.rs:60:29
+  --> $DIR/method-call-lifetime-args-lint-fail.rs:71:29
    |
 LL |     fn late_implicit_early<'b>(self, _: &u8) -> &'b u8 { loop {} }
    |                                         - the late bound lifetime parameter is introduced here
@@ -144,11 +155,12 @@ LL |     fn late_implicit_early<'b>(self, _: &u8) -> &'b u8 { loop {} }
 LL |     S.late_implicit_early::<'static, 'static, 'static>(&0);
    |                             ^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/method-call-lifetime-args-lint-fail.rs:69:21
+  --> $DIR/method-call-lifetime-args-lint-fail.rs:81:21
    |
 LL |     fn late_early<'a, 'b>(self, _: &'a u8) -> &'b u8 { loop {} }
    |                   -- the late bound lifetime parameter is introduced here
@@ -156,11 +168,12 @@ LL |     fn late_early<'a, 'b>(self, _: &'a u8) -> &'b u8 { loop {} }
 LL |     S::late_early::<'static>(S, &0);
    |                     ^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/method-call-lifetime-args-lint-fail.rs:73:30
+  --> $DIR/method-call-lifetime-args-lint-fail.rs:86:30
    |
 LL |     fn late_implicit_early<'b>(self, _: &u8) -> &'b u8 { loop {} }
    |                                         - the late bound lifetime parameter is introduced here
@@ -168,11 +181,12 @@ LL |     fn late_implicit_early<'b>(self, _: &u8) -> &'b u8 { loop {} }
 LL |     S::late_implicit_early::<'static>(S, &0);
    |                              ^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/method-call-lifetime-args-lint-fail.rs:82:9
+  --> $DIR/method-call-lifetime-args-lint-fail.rs:96:9
    |
 LL |     fn f<'early, 'late, T: 'early>() {}
    |                  ----- the late bound lifetime parameter is introduced here
@@ -180,7 +194,8 @@ LL |     fn f<'early, 'late, T: 'early>() {}
 LL |     f::<'static, u8>;
    |         ^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
 
 error: aborting due to 15 previous errors

--- a/src/test/ui/methods/method-call-lifetime-args-lint.rs
+++ b/src/test/ui/methods/method-call-lifetime-args-lint.rs
@@ -12,10 +12,12 @@ fn method_call() {
     S.late::<'static>(&0, &0);
     //~^ ERROR cannot specify lifetime arguments explicitly
     //~| WARN this was previously accepted
+    //~| WARN hard error
 
     S.late_implicit::<'static>(&0, &0);
     //~^ ERROR cannot specify lifetime arguments explicitly
     //~| WARN this was previously accepted
+    //~| WARN hard error
 }
 
 fn main() {}

--- a/src/test/ui/methods/method-call-lifetime-args-lint.stderr
+++ b/src/test/ui/methods/method-call-lifetime-args-lint.stderr
@@ -12,11 +12,12 @@ note: lint level defined here
    |
 LL | #![deny(late_bound_lifetime_arguments)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/method-call-lifetime-args-lint.rs:16:23
+  --> $DIR/method-call-lifetime-args-lint.rs:17:23
    |
 LL |     fn late_implicit(self, _: &u8, _: &u8) {}
    |                               - the late bound lifetime parameter is introduced here
@@ -24,7 +25,8 @@ LL |     fn late_implicit(self, _: &u8, _: &u8) {}
 LL |     S.late_implicit::<'static>(&0, &0);
    |                       ^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/no-patterns-in-args-2.rs
+++ b/src/test/ui/no-patterns-in-args-2.rs
@@ -3,6 +3,7 @@
 trait Tr {
     fn f1(mut arg: u8); //~ ERROR patterns aren't allowed in methods without bodies
                         //~^ WARN was previously accepted
+                        //~| WARN hard error
     fn f2(&arg: u8); //~ ERROR patterns aren't allowed in methods without bodies
     fn g1(arg: u8); // OK
     fn g2(_: u8); // OK

--- a/src/test/ui/no-patterns-in-args-2.stderr
+++ b/src/test/ui/no-patterns-in-args-2.stderr
@@ -1,5 +1,5 @@
 error[E0642]: patterns aren't allowed in methods without bodies
-  --> $DIR/no-patterns-in-args-2.rs:6:11
+  --> $DIR/no-patterns-in-args-2.rs:7:11
    |
 LL |     fn f2(&arg: u8);
    |           ^^^^
@@ -15,7 +15,8 @@ note: lint level defined here
    |
 LL | #![deny(patterns_in_fns_without_body)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #35203 <https://github.com/rust-lang/rust/issues/35203>
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/non-exhaustive/non-exhaustive-float-range-match.rs
+++ b/src/test/ui/non-exhaustive/non-exhaustive-float-range-match.rs
@@ -4,10 +4,22 @@
 fn main() {
     match 0.0 {
       0.0..=1.0 => {}
+      //~^ WARN floating-point types cannot be used in patterns
+      //~| WARN this was previously accepted
+      //~| WARN hard error
+      //~| WARN floating-point types cannot be used in patterns
+      //~| WARN this was previously accepted
+      //~| WARN hard error
       _ => {} // ok
     }
 
     match 0.0 { //~ ERROR non-exhaustive patterns
       0.0..=1.0 => {}
+      //~^ WARN floating-point types cannot be used in patterns
+      //~| WARN this was previously accepted
+      //~| WARN hard error
+      //~| WARN floating-point types cannot be used in patterns
+      //~| WARN this was previously accepted
+      //~| WARN hard error
     }
 }

--- a/src/test/ui/non-exhaustive/non-exhaustive-float-range-match.stderr
+++ b/src/test/ui/non-exhaustive/non-exhaustive-float-range-match.stderr
@@ -1,5 +1,52 @@
+warning: floating-point types cannot be used in patterns
+  --> $DIR/non-exhaustive-float-range-match.rs:6:7
+   |
+LL |       0.0..=1.0 => {}
+   |       ^^^
+   |
+note: lint level defined here
+  --> $DIR/non-exhaustive-float-range-match.rs:1:10
+   |
+LL | #![allow(illegal_floating_point_literal_pattern)]
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: #[warn(illegal_floating_point_literal_pattern)] is the minimum lint level
+   = note: the lint level cannot be reduced to `allow`
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/non-exhaustive-float-range-match.rs:6:13
+   |
+LL |       0.0..=1.0 => {}
+   |             ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/non-exhaustive-float-range-match.rs:17:7
+   |
+LL |       0.0..=1.0 => {}
+   |       ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/non-exhaustive-float-range-match.rs:17:13
+   |
+LL |       0.0..=1.0 => {}
+   |             ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
 error[E0004]: non-exhaustive patterns: `_` not covered
-  --> $DIR/non-exhaustive-float-range-match.rs:10:11
+  --> $DIR/non-exhaustive-float-range-match.rs:16:11
    |
 LL |     match 0.0 {
    |           ^^^ pattern `_` not covered

--- a/src/test/ui/non-exhaustive/non-exhaustive-match.rs
+++ b/src/test/ui/non-exhaustive/non-exhaustive-match.rs
@@ -46,8 +46,26 @@ fn main() {
     let vec: &[f32] = &vec;
     match *vec { //~ ERROR non-exhaustive patterns: `[_, _, _, _]` not covered
         [0.1, 0.2, 0.3] => (),
+        //~^ WARN floating-point types cannot be used in patterns
+        //~| WARN this was previously accepted
+        //~| WARN hard error
+        //~| WARN floating-point types cannot be used in patterns
+        //~| WARN this was previously accepted
+        //~| WARN hard error
+        //~| WARN floating-point types cannot be used in patterns
+        //~| WARN this was previously accepted
+        //~| WARN hard error
         [0.1, 0.2] => (),
+        //~^ WARN floating-point types cannot be used in patterns
+        //~| WARN this was previously accepted
+        //~| WARN hard error
+        //~| WARN floating-point types cannot be used in patterns
+        //~| WARN this was previously accepted
+        //~| WARN hard error
         [0.1] => (),
+        //~^ WARN floating-point types cannot be used in patterns
+        //~| WARN this was previously accepted
+        //~| WARN hard error
         [] => ()
     }
     let vec = vec![Some(42), None, Some(21)];

--- a/src/test/ui/non-exhaustive/non-exhaustive-match.stderr
+++ b/src/test/ui/non-exhaustive/non-exhaustive-match.stderr
@@ -66,6 +66,73 @@ LL |     match *vec {
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
+warning: floating-point types cannot be used in patterns
+  --> $DIR/non-exhaustive-match.rs:48:10
+   |
+LL |         [0.1, 0.2, 0.3] => (),
+   |          ^^^
+   |
+note: lint level defined here
+  --> $DIR/non-exhaustive-match.rs:2:10
+   |
+LL | #![allow(illegal_floating_point_literal_pattern)]
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: #[warn(illegal_floating_point_literal_pattern)] is the minimum lint level
+   = note: the lint level cannot be reduced to `allow`
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/non-exhaustive-match.rs:48:15
+   |
+LL |         [0.1, 0.2, 0.3] => (),
+   |               ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/non-exhaustive-match.rs:48:20
+   |
+LL |         [0.1, 0.2, 0.3] => (),
+   |                    ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/non-exhaustive-match.rs:58:10
+   |
+LL |         [0.1, 0.2] => (),
+   |          ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/non-exhaustive-match.rs:58:15
+   |
+LL |         [0.1, 0.2] => (),
+   |               ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/non-exhaustive-match.rs:65:10
+   |
+LL |         [0.1] => (),
+   |          ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
 error[E0004]: non-exhaustive patterns: `[_, _, _, _]` not covered
   --> $DIR/non-exhaustive-match.rs:47:11
    |

--- a/src/test/ui/privacy/legacy-ctor-visibility.rs
+++ b/src/test/ui/privacy/legacy-ctor-visibility.rs
@@ -13,6 +13,7 @@ mod m {
             S(10);
             //~^ ERROR private struct constructors are not usable through re-exports in outer modules
             //~| WARN this was previously accepted
+            //~| WARN hard error
         }
     }
 }

--- a/src/test/ui/privacy/legacy-ctor-visibility.stderr
+++ b/src/test/ui/privacy/legacy-ctor-visibility.stderr
@@ -5,7 +5,8 @@ LL |             S(10);
    |             ^
    |
    = note: #[deny(legacy_constructor_visibility)] on by default
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #39207 <https://github.com/rust-lang/rust/issues/39207>
 
 error: aborting due to previous error

--- a/src/test/ui/privacy/private-in-public-assoc-ty.rs
+++ b/src/test/ui/privacy/private-in-public-assoc-ty.rs
@@ -15,8 +15,10 @@ mod m {
     pub trait PubTr {
         //~^ WARN private trait `m::PrivTr` in public interface
         //~| WARN this was previously accepted
+        //~| WARN hard error
         //~| WARN private type `m::Priv` in public interface
         //~| WARN this was previously accepted
+        //~| WARN hard error
         type Alias1: PrivTr;
         type Alias2: PubTrAux1<Priv> = u8;
         type Alias3: PubTrAux2<A = Priv> = u8;

--- a/src/test/ui/privacy/private-in-public-assoc-ty.stderr
+++ b/src/test/ui/privacy/private-in-public-assoc-ty.stderr
@@ -11,7 +11,8 @@ LL | |     }
    | |_____^
    |
    = note: #[warn(private_in_public)] on by default
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 warning: private type `m::Priv` in public interface (error E0446)
@@ -26,11 +27,12 @@ LL | |         fn infer_exist() -> Self::Exist;
 LL | |     }
    | |_____^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error[E0446]: private type `m::Priv` in public interface
-  --> $DIR/private-in-public-assoc-ty.rs:24:9
+  --> $DIR/private-in-public-assoc-ty.rs:26:9
    |
 LL |     struct Priv;
    |     - `m::Priv` declared as private
@@ -39,7 +41,7 @@ LL |         type Alias4 = Priv;
    |         ^^^^^^^^^^^^^^^^^^^ can't leak private type
 
 error[E0446]: private type `m::Priv` in public interface
-  --> $DIR/private-in-public-assoc-ty.rs:31:9
+  --> $DIR/private-in-public-assoc-ty.rs:33:9
    |
 LL |     struct Priv;
    |     - `m::Priv` declared as private
@@ -48,7 +50,7 @@ LL |         type Alias1 = Priv;
    |         ^^^^^^^^^^^^^^^^^^^ can't leak private type
 
 error[E0445]: private trait `m::PrivTr` in public interface
-  --> $DIR/private-in-public-assoc-ty.rs:34:9
+  --> $DIR/private-in-public-assoc-ty.rs:36:9
    |
 LL |     trait PrivTr {}
    |     - `m::PrivTr` declared as private

--- a/src/test/ui/privacy/private-in-public-non-principal.rs
+++ b/src/test/ui/privacy/private-in-public-non-principal.rs
@@ -6,6 +6,7 @@ auto trait PrivNonPrincipal {}
 pub fn leak_dyn_nonprincipal() -> Box<PubPrincipal + PrivNonPrincipal> { loop {} }
 //~^ WARN private trait `PrivNonPrincipal` in public interface
 //~| WARN this was previously accepted
+//~| WARN hard error
 
 #[deny(missing_docs)]
 fn container() {

--- a/src/test/ui/privacy/private-in-public-non-principal.stderr
+++ b/src/test/ui/privacy/private-in-public-non-principal.stderr
@@ -5,17 +5,18 @@ LL | pub fn leak_dyn_nonprincipal() -> Box<PubPrincipal + PrivNonPrincipal> { lo
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: #[warn(private_in_public)] on by default
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: missing documentation for a method
-  --> $DIR/private-in-public-non-principal.rs:13:9
+  --> $DIR/private-in-public-non-principal.rs:14:9
    |
 LL |         pub fn check_doc_lint() {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: lint level defined here
-  --> $DIR/private-in-public-non-principal.rs:10:8
+  --> $DIR/private-in-public-non-principal.rs:11:8
    |
 LL | #[deny(missing_docs)]
    |        ^^^^^^^^^^^^

--- a/src/test/ui/privacy/private-in-public-warn.rs
+++ b/src/test/ui/privacy/private-in-public-warn.rs
@@ -13,29 +13,38 @@ mod types {
     }
 
     pub type Alias = Priv; //~ ERROR private type `types::Priv` in public interface
-    //~^ WARNING hard error
+        //~^ WARNING this was previously accepted
+        //~| WARNING hard error
     pub enum E {
         V1(Priv), //~ ERROR private type `types::Priv` in public interface
-        //~^ WARNING hard error
+        //~^ WARNING this was previously accepted
+        //~| WARNING hard error
         V2 { field: Priv }, //~ ERROR private type `types::Priv` in public interface
-        //~^ WARNING hard error
+        //~^ WARNING this was previously accepted
+        //~| WARNING hard error
     }
     pub trait Tr {
         const C: Priv = Priv; //~ ERROR private type `types::Priv` in public interface
-        //~^ WARNING hard error
+        //~^ WARNING this was previously accepted
+        //~| WARNING hard error
         type Alias = Priv; //~ ERROR private type `types::Priv` in public interface
         fn f1(arg: Priv) {} //~ ERROR private type `types::Priv` in public interface
-        //~^ WARNING hard error
+        //~^ WARNING this was previously accepted
+        //~| WARNING hard error
         fn f2() -> Priv { panic!() } //~ ERROR private type `types::Priv` in public interface
-        //~^ WARNING hard error
+        //~^ WARNING this was previously accepted
+        //~| WARNING hard error
     }
     extern {
         pub static ES: Priv; //~ ERROR private type `types::Priv` in public interface
-        //~^ WARNING hard error
+        //~^ WARNING this was previously accepted
+        //~| WARNING hard error
         pub fn ef1(arg: Priv); //~ ERROR private type `types::Priv` in public interface
-        //~^ WARNING hard error
+        //~^ WARNING this was previously accepted
+        //~| WARNING hard error
         pub fn ef2() -> Priv; //~ ERROR private type `types::Priv` in public interface
-        //~^ WARNING hard error
+        //~^ WARNING this was previously accepted
+        //~| WARNING hard error
     }
     impl PubTr for Pub {
         type Alias = Priv; //~ ERROR private type `types::Priv` in public interface
@@ -48,23 +57,30 @@ mod traits {
     pub trait PubTr {}
 
     pub type Alias<T: PrivTr> = T; //~ ERROR private trait `traits::PrivTr` in public interface
-    //~| WARNING hard error
-    //~| WARNING bounds on generic parameters are not enforced in type aliases
+        //~^ WARNING this was previously accepted
+        //~| WARNING hard error
+        //~| WARNING bounds on generic parameters are not enforced in type aliases
     pub trait Tr1: PrivTr {} //~ ERROR private trait `traits::PrivTr` in public interface
-    //~^ WARNING hard error
+        //~^ WARNING this was previously accepted
+        //~| WARNING hard error
     pub trait Tr2<T: PrivTr> {} //~ ERROR private trait `traits::PrivTr` in public interface
-        //~^ WARNING hard error
+        //~^ WARNING this was previously accepted
+        //~| WARNING hard error
     pub trait Tr3 {
         //~^ ERROR private trait `traits::PrivTr` in public interface
+        //~| WARNING this was previously accepted
         //~| WARNING hard error
         type Alias: PrivTr;
         fn f<T: PrivTr>(arg: T) {} //~ ERROR private trait `traits::PrivTr` in public interface
-        //~^ WARNING hard error
+        //~^ WARNING this was previously accepted
+        //~| WARNING hard error
     }
     impl<T: PrivTr> Pub<T> {} //~ ERROR private trait `traits::PrivTr` in public interface
-        //~^ WARNING hard error
+        //~^ WARNING this was previously accepted
+        //~| WARNING hard error
     impl<T: PrivTr> PubTr for Pub<T> {} //~ ERROR private trait `traits::PrivTr` in public interface
-        //~^ WARNING hard error
+        //~^ WARNING this was previously accepted
+        //~| WARNING hard error
 }
 
 mod traits_where {
@@ -74,21 +90,26 @@ mod traits_where {
 
     pub type Alias<T> where T: PrivTr = T;
         //~^ ERROR private trait `traits_where::PrivTr` in public interface
+        //~| WARNING this was previously accepted
         //~| WARNING hard error
         //~| WARNING where clauses are not enforced in type aliases
     pub trait Tr2<T> where T: PrivTr {}
         //~^ ERROR private trait `traits_where::PrivTr` in public interface
+        //~| WARNING this was previously accepted
         //~| WARNING hard error
     pub trait Tr3 {
         fn f<T>(arg: T) where T: PrivTr {}
         //~^ ERROR private trait `traits_where::PrivTr` in public interface
+        //~| WARNING this was previously accepted
         //~| WARNING hard error
     }
     impl<T> Pub<T> where T: PrivTr {}
         //~^ ERROR private trait `traits_where::PrivTr` in public interface
+        //~| WARNING this was previously accepted
         //~| WARNING hard error
     impl<T> PubTr for Pub<T> where T: PrivTr {}
         //~^ ERROR private trait `traits_where::PrivTr` in public interface
+        //~| WARNING this was previously accepted
         //~| WARNING hard error
 }
 
@@ -100,13 +121,17 @@ mod generics {
 
     pub trait Tr1: PrivTr<Pub> {}
         //~^ ERROR private trait `generics::PrivTr<generics::Pub>` in public interface
+        //~| WARNING this was previously accepted
         //~| WARNING hard error
     pub trait Tr2: PubTr<Priv> {} //~ ERROR private type `generics::Priv` in public interface
-        //~^ WARNING hard error
+        //~^ WARNING this was previously accepted
+        //~| WARNING hard error
     pub trait Tr3: PubTr<[Priv; 1]> {} //~ ERROR private type `generics::Priv` in public interface
-        //~^ WARNING hard error
+        //~^ WARNING this was previously accepted
+        //~| WARNING hard error
     pub trait Tr4: PubTr<Pub<Priv>> {} //~ ERROR private type `generics::Priv` in public interface
-        //~^ WARNING hard error
+        //~^ WARNING this was previously accepted
+        //~| WARNING hard error
 }
 
 mod impls {
@@ -204,7 +229,8 @@ mod aliases_pub {
 
     impl PrivAlias {
         pub fn f(arg: Priv) {} //~ ERROR private type `aliases_pub::Priv` in public interface
-        //~^ WARNING hard error
+        //~^ WARNING this was previously accepted
+        //~| WARNING hard error
     }
     impl PrivUseAliasTr for PrivUseAlias {
         type Check = Priv; //~ ERROR private type `aliases_pub::Priv` in public interface
@@ -248,11 +274,14 @@ mod aliases_priv {
 
     pub trait Tr1: PrivUseAliasTr {}
         //~^ ERROR private trait `aliases_priv::PrivTr1` in public interface
+        //~| WARNING this was previously accepted
         //~| WARNING hard error
     pub trait Tr2: PrivUseAliasTr<PrivAlias> {}
         //~^ ERROR private trait `aliases_priv::PrivTr1<aliases_priv::Priv2>` in public interface
+        //~| WARNING this was previously accepted
         //~| WARNING hard error
         //~| ERROR private type `aliases_priv::Priv2` in public interface
+        //~| WARNING this was previously accepted
         //~| WARNING hard error
 
     impl PrivUseAlias {

--- a/src/test/ui/privacy/private-in-public-warn.stderr
+++ b/src/test/ui/privacy/private-in-public-warn.stderr
@@ -9,92 +9,101 @@ note: lint level defined here
    |
 LL | #![deny(private_in_public)]
    |         ^^^^^^^^^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: private type `types::Priv` in public interface (error E0446)
-  --> $DIR/private-in-public-warn.rs:18:12
+  --> $DIR/private-in-public-warn.rs:19:12
    |
 LL |         V1(Priv),
    |            ^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: private type `types::Priv` in public interface (error E0446)
-  --> $DIR/private-in-public-warn.rs:20:14
+  --> $DIR/private-in-public-warn.rs:22:14
    |
 LL |         V2 { field: Priv },
    |              ^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
-
-error: private type `types::Priv` in public interface (error E0446)
-  --> $DIR/private-in-public-warn.rs:24:9
-   |
-LL |         const C: Priv = Priv;
-   |         ^^^^^^^^^^^^^^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
-
-error[E0446]: private type `types::Priv` in public interface
-  --> $DIR/private-in-public-warn.rs:26:9
-   |
-LL |     struct Priv;
-   |     - `types::Priv` declared as private
-...
-LL |         type Alias = Priv;
-   |         ^^^^^^^^^^^^^^^^^^ can't leak private type
 
 error: private type `types::Priv` in public interface (error E0446)
   --> $DIR/private-in-public-warn.rs:27:9
    |
+LL |         const C: Priv = Priv;
+   |         ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
+
+error[E0446]: private type `types::Priv` in public interface
+  --> $DIR/private-in-public-warn.rs:30:9
+   |
+LL |     struct Priv;
+   |     - `types::Priv` declared as private
+...
+LL |         type Alias = Priv;
+   |         ^^^^^^^^^^^^^^^^^^ can't leak private type
+
+error: private type `types::Priv` in public interface (error E0446)
+  --> $DIR/private-in-public-warn.rs:31:9
+   |
 LL |         fn f1(arg: Priv) {}
    |         ^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: private type `types::Priv` in public interface (error E0446)
-  --> $DIR/private-in-public-warn.rs:29:9
+  --> $DIR/private-in-public-warn.rs:34:9
    |
 LL |         fn f2() -> Priv { panic!() }
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: private type `types::Priv` in public interface (error E0446)
-  --> $DIR/private-in-public-warn.rs:33:9
+  --> $DIR/private-in-public-warn.rs:39:9
    |
 LL |         pub static ES: Priv;
    |         ^^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: private type `types::Priv` in public interface (error E0446)
-  --> $DIR/private-in-public-warn.rs:35:9
+  --> $DIR/private-in-public-warn.rs:42:9
    |
 LL |         pub fn ef1(arg: Priv);
    |         ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: private type `types::Priv` in public interface (error E0446)
-  --> $DIR/private-in-public-warn.rs:37:9
+  --> $DIR/private-in-public-warn.rs:45:9
    |
 LL |         pub fn ef2() -> Priv;
    |         ^^^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error[E0446]: private type `types::Priv` in public interface
-  --> $DIR/private-in-public-warn.rs:41:9
+  --> $DIR/private-in-public-warn.rs:50:9
    |
 LL |     struct Priv;
    |     - `types::Priv` declared as private
@@ -103,157 +112,173 @@ LL |         type Alias = Priv;
    |         ^^^^^^^^^^^^^^^^^^ can't leak private type
 
 error: private trait `traits::PrivTr` in public interface (error E0445)
-  --> $DIR/private-in-public-warn.rs:50:5
+  --> $DIR/private-in-public-warn.rs:59:5
    |
 LL |     pub type Alias<T: PrivTr> = T;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: private trait `traits::PrivTr` in public interface (error E0445)
-  --> $DIR/private-in-public-warn.rs:53:5
+  --> $DIR/private-in-public-warn.rs:63:5
    |
 LL |     pub trait Tr1: PrivTr {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
-
-error: private trait `traits::PrivTr` in public interface (error E0445)
-  --> $DIR/private-in-public-warn.rs:55:5
-   |
-LL |     pub trait Tr2<T: PrivTr> {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
-
-error: private trait `traits::PrivTr` in public interface (error E0445)
-  --> $DIR/private-in-public-warn.rs:57:5
-   |
-LL | /     pub trait Tr3 {
-LL | |
-LL | |
-LL | |         type Alias: PrivTr;
-LL | |         fn f<T: PrivTr>(arg: T) {}
-LL | |
-LL | |     }
-   | |_____^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
-
-error: private trait `traits::PrivTr` in public interface (error E0445)
-  --> $DIR/private-in-public-warn.rs:61:9
-   |
-LL |         fn f<T: PrivTr>(arg: T) {}
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
-
-error: private trait `traits::PrivTr` in public interface (error E0445)
-  --> $DIR/private-in-public-warn.rs:64:5
-   |
-LL |     impl<T: PrivTr> Pub<T> {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: private trait `traits::PrivTr` in public interface (error E0445)
   --> $DIR/private-in-public-warn.rs:66:5
    |
+LL |     pub trait Tr2<T: PrivTr> {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
+
+error: private trait `traits::PrivTr` in public interface (error E0445)
+  --> $DIR/private-in-public-warn.rs:69:5
+   |
+LL | /     pub trait Tr3 {
+LL | |
+LL | |
+LL | |
+...  |
+LL | |
+LL | |     }
+   | |_____^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
+
+error: private trait `traits::PrivTr` in public interface (error E0445)
+  --> $DIR/private-in-public-warn.rs:74:9
+   |
+LL |         fn f<T: PrivTr>(arg: T) {}
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
+
+error: private trait `traits::PrivTr` in public interface (error E0445)
+  --> $DIR/private-in-public-warn.rs:78:5
+   |
+LL |     impl<T: PrivTr> Pub<T> {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
+   = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
+
+error: private trait `traits::PrivTr` in public interface (error E0445)
+  --> $DIR/private-in-public-warn.rs:81:5
+   |
 LL |     impl<T: PrivTr> PubTr for Pub<T> {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: private trait `traits_where::PrivTr` in public interface (error E0445)
-  --> $DIR/private-in-public-warn.rs:75:5
+  --> $DIR/private-in-public-warn.rs:91:5
    |
 LL |     pub type Alias<T> where T: PrivTr = T;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: private trait `traits_where::PrivTr` in public interface (error E0445)
-  --> $DIR/private-in-public-warn.rs:79:5
+  --> $DIR/private-in-public-warn.rs:96:5
    |
 LL |     pub trait Tr2<T> where T: PrivTr {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: private trait `traits_where::PrivTr` in public interface (error E0445)
-  --> $DIR/private-in-public-warn.rs:83:9
+  --> $DIR/private-in-public-warn.rs:101:9
    |
 LL |         fn f<T>(arg: T) where T: PrivTr {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: private trait `traits_where::PrivTr` in public interface (error E0445)
-  --> $DIR/private-in-public-warn.rs:87:5
+  --> $DIR/private-in-public-warn.rs:106:5
    |
 LL |     impl<T> Pub<T> where T: PrivTr {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: private trait `traits_where::PrivTr` in public interface (error E0445)
-  --> $DIR/private-in-public-warn.rs:90:5
+  --> $DIR/private-in-public-warn.rs:110:5
    |
 LL |     impl<T> PubTr for Pub<T> where T: PrivTr {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: private trait `generics::PrivTr<generics::Pub>` in public interface (error E0445)
-  --> $DIR/private-in-public-warn.rs:101:5
+  --> $DIR/private-in-public-warn.rs:122:5
    |
 LL |     pub trait Tr1: PrivTr<Pub> {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: private type `generics::Priv` in public interface (error E0446)
-  --> $DIR/private-in-public-warn.rs:104:5
+  --> $DIR/private-in-public-warn.rs:126:5
    |
 LL |     pub trait Tr2: PubTr<Priv> {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: private type `generics::Priv` in public interface (error E0446)
-  --> $DIR/private-in-public-warn.rs:106:5
+  --> $DIR/private-in-public-warn.rs:129:5
    |
 LL |     pub trait Tr3: PubTr<[Priv; 1]> {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: private type `generics::Priv` in public interface (error E0446)
-  --> $DIR/private-in-public-warn.rs:108:5
+  --> $DIR/private-in-public-warn.rs:132:5
    |
 LL |     pub trait Tr4: PubTr<Pub<Priv>> {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error[E0446]: private type `impls::Priv` in public interface
-  --> $DIR/private-in-public-warn.rs:135:9
+  --> $DIR/private-in-public-warn.rs:160:9
    |
 LL |     struct Priv;
    |     - `impls::Priv` declared as private
@@ -262,16 +287,17 @@ LL |         type Alias = Priv;
    |         ^^^^^^^^^^^^^^^^^^ can't leak private type
 
 error: private type `aliases_pub::Priv` in public interface (error E0446)
-  --> $DIR/private-in-public-warn.rs:206:9
+  --> $DIR/private-in-public-warn.rs:231:9
    |
 LL |         pub fn f(arg: Priv) {}
    |         ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error[E0446]: private type `aliases_pub::Priv` in public interface
-  --> $DIR/private-in-public-warn.rs:210:9
+  --> $DIR/private-in-public-warn.rs:236:9
    |
 LL |     struct Priv;
    |     - `aliases_pub::Priv` declared as private
@@ -280,7 +306,7 @@ LL |         type Check = Priv;
    |         ^^^^^^^^^^^^^^^^^^ can't leak private type
 
 error[E0446]: private type `aliases_pub::Priv` in public interface
-  --> $DIR/private-in-public-warn.rs:213:9
+  --> $DIR/private-in-public-warn.rs:239:9
    |
 LL |     struct Priv;
    |     - `aliases_pub::Priv` declared as private
@@ -289,7 +315,7 @@ LL |         type Check = Priv;
    |         ^^^^^^^^^^^^^^^^^^ can't leak private type
 
 error[E0446]: private type `aliases_pub::Priv` in public interface
-  --> $DIR/private-in-public-warn.rs:216:9
+  --> $DIR/private-in-public-warn.rs:242:9
    |
 LL |     struct Priv;
    |     - `aliases_pub::Priv` declared as private
@@ -298,7 +324,7 @@ LL |         type Check = Priv;
    |         ^^^^^^^^^^^^^^^^^^ can't leak private type
 
 error[E0446]: private type `aliases_pub::Priv` in public interface
-  --> $DIR/private-in-public-warn.rs:219:9
+  --> $DIR/private-in-public-warn.rs:245:9
    |
 LL |     struct Priv;
    |     - `aliases_pub::Priv` declared as private
@@ -307,34 +333,37 @@ LL |         type Check = Priv;
    |         ^^^^^^^^^^^^^^^^^^ can't leak private type
 
 error: private trait `aliases_priv::PrivTr1` in public interface (error E0445)
-  --> $DIR/private-in-public-warn.rs:249:5
+  --> $DIR/private-in-public-warn.rs:275:5
    |
 LL |     pub trait Tr1: PrivUseAliasTr {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: private trait `aliases_priv::PrivTr1<aliases_priv::Priv2>` in public interface (error E0445)
-  --> $DIR/private-in-public-warn.rs:252:5
+  --> $DIR/private-in-public-warn.rs:279:5
    |
 LL |     pub trait Tr2: PrivUseAliasTr<PrivAlias> {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: private type `aliases_priv::Priv2` in public interface (error E0446)
-  --> $DIR/private-in-public-warn.rs:252:5
+  --> $DIR/private-in-public-warn.rs:279:5
    |
 LL |     pub trait Tr2: PrivUseAliasTr<PrivAlias> {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 warning: bounds on generic parameters are not enforced in type aliases
-  --> $DIR/private-in-public-warn.rs:50:23
+  --> $DIR/private-in-public-warn.rs:59:23
    |
 LL |     pub type Alias<T: PrivTr> = T;
    |                       ^^^^^^
@@ -343,7 +372,7 @@ LL |     pub type Alias<T: PrivTr> = T;
    = help: the bound will not be checked when the type alias is used, and should be removed
 
 warning: where clauses are not enforced in type aliases
-  --> $DIR/private-in-public-warn.rs:75:29
+  --> $DIR/private-in-public-warn.rs:91:29
    |
 LL |     pub type Alias<T> where T: PrivTr = T;
    |                             ^^^^^^^^^

--- a/src/test/ui/proc-macro/generate-mod.rs
+++ b/src/test/ui/proc-macro/generate-mod.rs
@@ -16,14 +16,18 @@ struct S;
 #[derive(generate_mod::CheckDerive)] //~ WARN cannot find type `FromOutside` in this scope
                                      //~| WARN cannot find type `OuterDerive` in this scope
                                      //~| WARN this was previously accepted
+                                     //~| WARN it will become a hard error
                                      //~| WARN this was previously accepted
+                                     //~| WARN it will become a hard error
 struct Z;
 
 fn inner_block() {
     #[derive(generate_mod::CheckDerive)] //~ WARN cannot find type `FromOutside` in this scope
                                         //~| WARN cannot find type `OuterDerive` in this scope
                                         //~| WARN this was previously accepted
+                                        //~| WARN it will become a hard error
                                         //~| WARN this was previously accepted
+                                        //~| WARN it will become a hard error
     struct InnerZ;
 }
 

--- a/src/test/ui/proc-macro/generate-mod.stderr
+++ b/src/test/ui/proc-macro/generate-mod.stderr
@@ -29,7 +29,8 @@ LL | #[derive(generate_mod::CheckDerive)]
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^ names from parent modules are not accessible without an explicit import
    |
    = note: #[warn(proc_macro_derive_resolution_fallback)] on by default
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #50504 <https://github.com/rust-lang/rust/issues/50504>
 
 warning: cannot find type `OuterDerive` in this scope
@@ -38,25 +39,28 @@ warning: cannot find type `OuterDerive` in this scope
 LL | #[derive(generate_mod::CheckDerive)]
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^ names from parent modules are not accessible without an explicit import
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #50504 <https://github.com/rust-lang/rust/issues/50504>
 
 warning: cannot find type `FromOutside` in this scope
-  --> $DIR/generate-mod.rs:23:14
+  --> $DIR/generate-mod.rs:25:14
    |
 LL |     #[derive(generate_mod::CheckDerive)]
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^ names from parent modules are not accessible without an explicit import
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #50504 <https://github.com/rust-lang/rust/issues/50504>
 
 warning: cannot find type `OuterDerive` in this scope
-  --> $DIR/generate-mod.rs:23:14
+  --> $DIR/generate-mod.rs:25:14
    |
 LL |     #[derive(generate_mod::CheckDerive)]
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^ names from parent modules are not accessible without an explicit import
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #50504 <https://github.com/rust-lang/rust/issues/50504>
 
 error: aborting due to 4 previous errors

--- a/src/test/ui/pub/pub-reexport-priv-extern-crate.rs
+++ b/src/test/ui/pub/pub-reexport-priv-extern-crate.rs
@@ -3,6 +3,7 @@
 extern crate core;
 pub use core as reexported_core; //~ ERROR `core` is private, and cannot be re-exported
                                  //~^ WARN this was previously accepted
+                                 //~| WARN hard error
 
 mod foo1 {
     extern crate core;
@@ -11,6 +12,7 @@ mod foo1 {
 mod foo2 {
     use foo1::core; //~ ERROR `core` is private, and cannot be re-exported
                     //~^ WARN this was previously accepted
+                    //~| WARN hard error
     pub mod bar {
         extern crate core;
     }
@@ -19,6 +21,7 @@ mod foo2 {
 mod baz {
     pub use foo2::bar::core; //~ ERROR `core` is private, and cannot be re-exported
                              //~^ WARN this was previously accepted
+                             //~| WARN hard error
 }
 
 fn main() {}

--- a/src/test/ui/pub/pub-reexport-priv-extern-crate.stderr
+++ b/src/test/ui/pub/pub-reexport-priv-extern-crate.stderr
@@ -5,25 +5,28 @@ LL | pub use core as reexported_core;
    |         ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: #[deny(pub_use_of_private_extern_crate)] on by default
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: extern crate `core` is private, and cannot be re-exported (error E0365), consider declaring with `pub`
-  --> $DIR/pub-reexport-priv-extern-crate.rs:12:9
+  --> $DIR/pub-reexport-priv-extern-crate.rs:13:9
    |
 LL |     use foo1::core;
    |         ^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: extern crate `core` is private, and cannot be re-exported (error E0365), consider declaring with `pub`
-  --> $DIR/pub-reexport-priv-extern-crate.rs:20:13
+  --> $DIR/pub-reexport-priv-extern-crate.rs:22:13
    |
 LL |     pub use foo2::bar::core;
    |             ^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/rfc1445/match-forbidden-without-eq.rs
+++ b/src/test/ui/rfc1445/match-forbidden-without-eq.rs
@@ -18,8 +18,9 @@ fn main() {
     let x = 0.0;
     match x {
         f32::INFINITY => { }
-        //~^ WARNING floating-point types cannot be used in patterns
-        //~| WARNING will become a hard error in a future release
+        //~^ WARN floating-point types cannot be used in patterns
+        //~| WARN this was previously accepted
+        //~| WARN will become a hard error in a future release
         _ => { }
     }
 }

--- a/src/test/ui/rfc1445/match-forbidden-without-eq.stderr
+++ b/src/test/ui/rfc1445/match-forbidden-without-eq.stderr
@@ -11,7 +11,8 @@ LL |         f32::INFINITY => { }
    |         ^^^^^^^^^^^^^
    |
    = note: #[warn(illegal_floating_point_literal_pattern)] on by default
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
 error: aborting due to previous error

--- a/src/test/ui/rust-2018/async-ident-allowed.rs
+++ b/src/test/ui/rust-2018/async-ident-allowed.rs
@@ -7,5 +7,6 @@
 
 fn main() {
     let async = 3; //~ ERROR: is a keyword
-    //~^ WARN previously accepted
+    //~^ WARN this was previously accepted
+    //~| WARN hard error in the 2018 edition
 }

--- a/src/test/ui/rust-2018/async-ident-allowed.stderr
+++ b/src/test/ui/rust-2018/async-ident-allowed.stderr
@@ -10,7 +10,8 @@ note: lint level defined here
 LL | #![deny(rust_2018_compatibility)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^
    = note: #[deny(keyword_idents)] implied by #[deny(rust_2018_compatibility)]
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: aborting due to previous error

--- a/src/test/ui/rust-2018/async-ident.fixed
+++ b/src/test/ui/rust-2018/async-ident.fixed
@@ -5,19 +5,23 @@
 // run-rustfix
 
 fn r#async() {} //~ ERROR async
-//~^ WARN hard error in the 2018 edition
+//~^ WARN this was previously accepted
+//~| WARN hard error in the 2018 edition
 
 macro_rules! foo {
     ($foo:ident) => {};
     ($r#async:expr, r#async) => {};
     //~^ ERROR async
     //~| ERROR async
+    //~| WARN this was previously accepted
     //~| WARN hard error in the 2018 edition
+    //~| WARN this was previously accepted
     //~| WARN hard error in the 2018 edition
 }
 
 foo!(r#async);
     //~^ ERROR async
+    //~| WARN this was previously accepted
     //~| WARN hard error in the 2018 edition
 
 mod dont_lint_raw {
@@ -27,40 +31,49 @@ mod dont_lint_raw {
 mod async_trait {
     trait r#async {}
     //~^ ERROR async
+    //~| WARN this was previously accepted
     //~| WARN hard error in the 2018 edition
     struct MyStruct;
     impl r#async for MyStruct {}
     //~^ ERROR async
+    //~| WARN this was previously accepted
     //~| WARN hard error in the 2018 edition
 }
 
 mod async_static {
     static r#async: u32 = 0;
     //~^ ERROR async
+    //~| WARN this was previously accepted
     //~| WARN hard error in the 2018 edition
 }
 
 mod async_const {
     const r#async: u32 = 0;
     //~^ ERROR async
+    //~| WARN this was previously accepted
     //~| WARN hard error in the 2018 edition
 }
 
 struct Foo;
 impl Foo { fn r#async() {} }
     //~^ ERROR async
+    //~| WARN this was previously accepted
     //~| WARN hard error in the 2018 edition
 
 fn main() {
     struct r#async {}
     //~^ ERROR async
+    //~| WARN this was previously accepted
     //~| WARN hard error in the 2018 edition
     let r#async: r#async = r#async {};
     //~^ ERROR async
+    //~| WARN this was previously accepted
     //~| WARN hard error in the 2018 edition
     //~| ERROR async
+    //~| WARN this was previously accepted
     //~| WARN hard error in the 2018 edition
     //~| ERROR async
+    //~| WARN this was previously accepted
     //~| WARN hard error in the 2018 edition
 }
 
@@ -68,6 +81,7 @@ fn main() {
 macro_rules! produces_async {
     () => (pub fn r#async() {})
     //~^ ERROR async
+    //~| WARN this was previously accepted
     //~| WARN hard error in the 2018 edition
 }
 
@@ -75,5 +89,6 @@ macro_rules! produces_async {
 macro_rules! consumes_async {
     (r#async) => (1)
     //~^ ERROR async
+    //~| WARN this was previously accepted
     //~| WARN hard error in the 2018 edition
 }

--- a/src/test/ui/rust-2018/async-ident.rs
+++ b/src/test/ui/rust-2018/async-ident.rs
@@ -5,19 +5,23 @@
 // run-rustfix
 
 fn async() {} //~ ERROR async
-//~^ WARN hard error in the 2018 edition
+//~^ WARN this was previously accepted
+//~| WARN hard error in the 2018 edition
 
 macro_rules! foo {
     ($foo:ident) => {};
     ($async:expr, async) => {};
     //~^ ERROR async
     //~| ERROR async
+    //~| WARN this was previously accepted
     //~| WARN hard error in the 2018 edition
+    //~| WARN this was previously accepted
     //~| WARN hard error in the 2018 edition
 }
 
 foo!(async);
     //~^ ERROR async
+    //~| WARN this was previously accepted
     //~| WARN hard error in the 2018 edition
 
 mod dont_lint_raw {
@@ -27,40 +31,49 @@ mod dont_lint_raw {
 mod async_trait {
     trait async {}
     //~^ ERROR async
+    //~| WARN this was previously accepted
     //~| WARN hard error in the 2018 edition
     struct MyStruct;
     impl async for MyStruct {}
     //~^ ERROR async
+    //~| WARN this was previously accepted
     //~| WARN hard error in the 2018 edition
 }
 
 mod async_static {
     static async: u32 = 0;
     //~^ ERROR async
+    //~| WARN this was previously accepted
     //~| WARN hard error in the 2018 edition
 }
 
 mod async_const {
     const async: u32 = 0;
     //~^ ERROR async
+    //~| WARN this was previously accepted
     //~| WARN hard error in the 2018 edition
 }
 
 struct Foo;
 impl Foo { fn async() {} }
     //~^ ERROR async
+    //~| WARN this was previously accepted
     //~| WARN hard error in the 2018 edition
 
 fn main() {
     struct async {}
     //~^ ERROR async
+    //~| WARN this was previously accepted
     //~| WARN hard error in the 2018 edition
     let async: async = async {};
     //~^ ERROR async
+    //~| WARN this was previously accepted
     //~| WARN hard error in the 2018 edition
     //~| ERROR async
+    //~| WARN this was previously accepted
     //~| WARN hard error in the 2018 edition
     //~| ERROR async
+    //~| WARN this was previously accepted
     //~| WARN hard error in the 2018 edition
 }
 
@@ -68,6 +81,7 @@ fn main() {
 macro_rules! produces_async {
     () => (pub fn async() {})
     //~^ ERROR async
+    //~| WARN this was previously accepted
     //~| WARN hard error in the 2018 edition
 }
 
@@ -75,5 +89,6 @@ macro_rules! produces_async {
 macro_rules! consumes_async {
     (async) => (1)
     //~^ ERROR async
+    //~| WARN this was previously accepted
     //~| WARN hard error in the 2018 edition
 }

--- a/src/test/ui/rust-2018/async-ident.stderr
+++ b/src/test/ui/rust-2018/async-ident.stderr
@@ -9,133 +9,148 @@ note: lint level defined here
    |
 LL | #![deny(keyword_idents)]
    |         ^^^^^^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `async` is a keyword in the 2018 edition
-  --> $DIR/async-ident.rs:12:7
+  --> $DIR/async-ident.rs:13:7
    |
 LL |     ($async:expr, async) => {};
    |       ^^^^^ help: you can use a raw identifier to stay compatible: `r#async`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `async` is a keyword in the 2018 edition
-  --> $DIR/async-ident.rs:12:19
+  --> $DIR/async-ident.rs:13:19
    |
 LL |     ($async:expr, async) => {};
    |                   ^^^^^ help: you can use a raw identifier to stay compatible: `r#async`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `async` is a keyword in the 2018 edition
-  --> $DIR/async-ident.rs:19:6
+  --> $DIR/async-ident.rs:22:6
    |
 LL | foo!(async);
    |      ^^^^^ help: you can use a raw identifier to stay compatible: `r#async`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `async` is a keyword in the 2018 edition
-  --> $DIR/async-ident.rs:28:11
+  --> $DIR/async-ident.rs:32:11
    |
 LL |     trait async {}
    |           ^^^^^ help: you can use a raw identifier to stay compatible: `r#async`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `async` is a keyword in the 2018 edition
-  --> $DIR/async-ident.rs:32:10
+  --> $DIR/async-ident.rs:37:10
    |
 LL |     impl async for MyStruct {}
    |          ^^^^^ help: you can use a raw identifier to stay compatible: `r#async`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `async` is a keyword in the 2018 edition
-  --> $DIR/async-ident.rs:38:12
+  --> $DIR/async-ident.rs:44:12
    |
 LL |     static async: u32 = 0;
    |            ^^^^^ help: you can use a raw identifier to stay compatible: `r#async`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `async` is a keyword in the 2018 edition
-  --> $DIR/async-ident.rs:44:11
+  --> $DIR/async-ident.rs:51:11
    |
 LL |     const async: u32 = 0;
    |           ^^^^^ help: you can use a raw identifier to stay compatible: `r#async`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `async` is a keyword in the 2018 edition
-  --> $DIR/async-ident.rs:50:15
+  --> $DIR/async-ident.rs:58:15
    |
 LL | impl Foo { fn async() {} }
    |               ^^^^^ help: you can use a raw identifier to stay compatible: `r#async`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `async` is a keyword in the 2018 edition
-  --> $DIR/async-ident.rs:55:12
+  --> $DIR/async-ident.rs:64:12
    |
 LL |     struct async {}
    |            ^^^^^ help: you can use a raw identifier to stay compatible: `r#async`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `async` is a keyword in the 2018 edition
-  --> $DIR/async-ident.rs:58:9
+  --> $DIR/async-ident.rs:68:9
    |
 LL |     let async: async = async {};
    |         ^^^^^ help: you can use a raw identifier to stay compatible: `r#async`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `async` is a keyword in the 2018 edition
-  --> $DIR/async-ident.rs:58:16
+  --> $DIR/async-ident.rs:68:16
    |
 LL |     let async: async = async {};
    |                ^^^^^ help: you can use a raw identifier to stay compatible: `r#async`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `async` is a keyword in the 2018 edition
-  --> $DIR/async-ident.rs:58:24
+  --> $DIR/async-ident.rs:68:24
    |
 LL |     let async: async = async {};
    |                        ^^^^^ help: you can use a raw identifier to stay compatible: `r#async`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `async` is a keyword in the 2018 edition
-  --> $DIR/async-ident.rs:69:19
+  --> $DIR/async-ident.rs:82:19
    |
 LL |     () => (pub fn async() {})
    |                   ^^^^^ help: you can use a raw identifier to stay compatible: `r#async`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `async` is a keyword in the 2018 edition
-  --> $DIR/async-ident.rs:76:6
+  --> $DIR/async-ident.rs:90:6
    |
 LL |     (async) => (1)
    |      ^^^^^ help: you can use a raw identifier to stay compatible: `r#async`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: aborting due to 15 previous errors

--- a/src/test/ui/rust-2018/dyn-keyword.fixed
+++ b/src/test/ui/rust-2018/dyn-keyword.fixed
@@ -6,5 +6,6 @@
 
 fn main() {
     let r#dyn = (); //~ ERROR dyn
-    //~^ WARN hard error in the 2018 edition
+    //~^ WARN this was previously accepted
+    //~| WARN hard error in the 2018 edition
 }

--- a/src/test/ui/rust-2018/dyn-keyword.rs
+++ b/src/test/ui/rust-2018/dyn-keyword.rs
@@ -6,5 +6,6 @@
 
 fn main() {
     let dyn = (); //~ ERROR dyn
-    //~^ WARN hard error in the 2018 edition
+    //~^ WARN this was previously accepted
+    //~| WARN hard error in the 2018 edition
 }

--- a/src/test/ui/rust-2018/dyn-keyword.stderr
+++ b/src/test/ui/rust-2018/dyn-keyword.stderr
@@ -9,7 +9,8 @@ note: lint level defined here
    |
 LL | #![deny(keyword_idents)]
    |         ^^^^^^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: aborting due to previous error

--- a/src/test/ui/rust-2018/edition-lint-fully-qualified-paths.fixed
+++ b/src/test/ui/rust-2018/edition-lint-fully-qualified-paths.fixed
@@ -19,9 +19,11 @@ mod foo {
 fn main() {
     let _: <foo::Baz as crate::foo::Foo>::Bar = ();
     //~^ ERROR absolute paths must start with
-    //~| this was previously accepted
+    //~| WARN this was previously accepted
+    //~| WARN it will become a hard error
 
     let _: <crate::foo::Baz as foo::Foo>::Bar = ();
     //~^ ERROR absolute paths must start with
-    //~| this was previously accepted
+    //~| WARN this was previously accepted
+    //~| WARN it will become a hard error
 }

--- a/src/test/ui/rust-2018/edition-lint-fully-qualified-paths.rs
+++ b/src/test/ui/rust-2018/edition-lint-fully-qualified-paths.rs
@@ -19,9 +19,11 @@ mod foo {
 fn main() {
     let _: <foo::Baz as ::foo::Foo>::Bar = ();
     //~^ ERROR absolute paths must start with
-    //~| this was previously accepted
+    //~| WARN this was previously accepted
+    //~| WARN it will become a hard error
 
     let _: <::foo::Baz as foo::Foo>::Bar = ();
     //~^ ERROR absolute paths must start with
-    //~| this was previously accepted
+    //~| WARN this was previously accepted
+    //~| WARN it will become a hard error
 }

--- a/src/test/ui/rust-2018/edition-lint-fully-qualified-paths.stderr
+++ b/src/test/ui/rust-2018/edition-lint-fully-qualified-paths.stderr
@@ -9,16 +9,18 @@ note: lint level defined here
    |
 LL | #![deny(absolute_paths_not_starting_with_crate)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
 error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
-  --> $DIR/edition-lint-fully-qualified-paths.rs:24:13
+  --> $DIR/edition-lint-fully-qualified-paths.rs:25:13
    |
 LL |     let _: <::foo::Baz as foo::Foo>::Bar = ();
    |             ^^^^^^^^^^ help: use `crate`: `crate::foo::Baz`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/rust-2018/edition-lint-nested-empty-paths.fixed
+++ b/src/test/ui/rust-2018/edition-lint-nested-empty-paths.fixed
@@ -17,14 +17,17 @@ crate mod foo {
 use crate::foo::{bar::{baz::{}}};
 //~^ ERROR absolute paths must start with
 //~| WARN this was previously accepted
+//~| WARN it will become a hard error
 
 use crate::foo::{bar::{XX, baz::{}}};
 //~^ ERROR absolute paths must start with
 //~| WARN this was previously accepted
+//~| WARN it will become a hard error
 
 use crate::foo::{bar::{baz::{}, baz1::{}}};
 //~^ ERROR absolute paths must start with
 //~| WARN this was previously accepted
+//~| WARN it will become a hard error
 
 fn main() {
 }

--- a/src/test/ui/rust-2018/edition-lint-nested-empty-paths.rs
+++ b/src/test/ui/rust-2018/edition-lint-nested-empty-paths.rs
@@ -17,14 +17,17 @@ crate mod foo {
 use foo::{bar::{baz::{}}};
 //~^ ERROR absolute paths must start with
 //~| WARN this was previously accepted
+//~| WARN it will become a hard error
 
 use foo::{bar::{XX, baz::{}}};
 //~^ ERROR absolute paths must start with
 //~| WARN this was previously accepted
+//~| WARN it will become a hard error
 
 use foo::{bar::{baz::{}, baz1::{}}};
 //~^ ERROR absolute paths must start with
 //~| WARN this was previously accepted
+//~| WARN it will become a hard error
 
 fn main() {
 }

--- a/src/test/ui/rust-2018/edition-lint-nested-empty-paths.stderr
+++ b/src/test/ui/rust-2018/edition-lint-nested-empty-paths.stderr
@@ -9,25 +9,28 @@ note: lint level defined here
    |
 LL | #![deny(absolute_paths_not_starting_with_crate)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
 error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
-  --> $DIR/edition-lint-nested-empty-paths.rs:21:5
+  --> $DIR/edition-lint-nested-empty-paths.rs:22:5
    |
 LL | use foo::{bar::{XX, baz::{}}};
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `crate`: `crate::foo::{bar::{XX, baz::{}}}`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
 error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
-  --> $DIR/edition-lint-nested-empty-paths.rs:25:5
+  --> $DIR/edition-lint-nested-empty-paths.rs:27:5
    |
 LL | use foo::{bar::{baz::{}, baz1::{}}};
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `crate`: `crate::foo::{bar::{baz::{}, baz1::{}}}`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/rust-2018/edition-lint-nested-paths.fixed
+++ b/src/test/ui/rust-2018/edition-lint-nested-paths.fixed
@@ -5,7 +5,8 @@
 
 use crate::foo::{a, b};
 //~^ ERROR absolute paths must start with
-//~| this was previously accepted
+//~| WARN this was previously accepted
+//~| WARN it will become a hard error
 
 mod foo {
     crate fn a() {}
@@ -20,7 +21,8 @@ fn main() {
     {
         use crate::foo::{self as x, c};
         //~^ ERROR absolute paths must start with
-        //~| this was previously accepted
+        //~| WARN this was previously accepted
+        //~| WARN it will become a hard error
         x::a();
         c();
     }

--- a/src/test/ui/rust-2018/edition-lint-nested-paths.rs
+++ b/src/test/ui/rust-2018/edition-lint-nested-paths.rs
@@ -5,7 +5,8 @@
 
 use foo::{a, b};
 //~^ ERROR absolute paths must start with
-//~| this was previously accepted
+//~| WARN this was previously accepted
+//~| WARN it will become a hard error
 
 mod foo {
     crate fn a() {}
@@ -20,7 +21,8 @@ fn main() {
     {
         use foo::{self as x, c};
         //~^ ERROR absolute paths must start with
-        //~| this was previously accepted
+        //~| WARN this was previously accepted
+        //~| WARN it will become a hard error
         x::a();
         c();
     }

--- a/src/test/ui/rust-2018/edition-lint-nested-paths.stderr
+++ b/src/test/ui/rust-2018/edition-lint-nested-paths.stderr
@@ -9,16 +9,18 @@ note: lint level defined here
    |
 LL | #![deny(absolute_paths_not_starting_with_crate)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
 error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
-  --> $DIR/edition-lint-nested-paths.rs:21:13
+  --> $DIR/edition-lint-nested-paths.rs:22:13
    |
 LL |         use foo::{self as x, c};
    |             ^^^^^^^^^^^^^^^^^^^ help: use `crate`: `crate::foo::{self as x, c}`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/rust-2018/edition-lint-paths.fixed
+++ b/src/test/ui/rust-2018/edition-lint-paths.fixed
@@ -12,17 +12,20 @@ pub mod foo {
     use crate::bar::Bar;
     //~^ ERROR absolute
     //~| WARN this was previously accepted
+    //~| WARN it will become a hard error
     use super::bar::Bar2;
     use crate::bar::Bar3;
 
     use crate::bar;
     //~^ ERROR absolute
     //~| WARN this was previously accepted
+    //~| WARN it will become a hard error
     use crate::{bar as something_else};
 
     use crate::{Bar as SomethingElse, main};
     //~^ ERROR absolute
     //~| WARN this was previously accepted
+    //~| WARN it will become a hard error
 
     use crate::{Bar as SomethingElse2, main as another_main};
 
@@ -35,6 +38,7 @@ pub mod foo {
 use crate::bar::Bar;
 //~^ ERROR absolute
 //~| WARN this was previously accepted
+//~| WARN it will become a hard error
 
 pub mod bar {
     use edition_lint_paths as foo;
@@ -47,16 +51,19 @@ mod baz {
     use crate::*;
     //~^ ERROR absolute
     //~| WARN this was previously accepted
+    //~| WARN it will become a hard error
 }
 
 impl crate::foo::SomeTrait for u32 { }
 //~^ ERROR absolute
 //~| WARN this was previously accepted
+//~| WARN it will become a hard error
 
 fn main() {
     let x = crate::bar::Bar;
     //~^ ERROR absolute
     //~| WARN this was previously accepted
+    //~| WARN it will become a hard error
     let x = bar::Bar;
     let x = crate::bar::Bar;
     let x = self::bar::Bar;

--- a/src/test/ui/rust-2018/edition-lint-paths.rs
+++ b/src/test/ui/rust-2018/edition-lint-paths.rs
@@ -12,17 +12,20 @@ pub mod foo {
     use ::bar::Bar;
     //~^ ERROR absolute
     //~| WARN this was previously accepted
+    //~| WARN it will become a hard error
     use super::bar::Bar2;
     use crate::bar::Bar3;
 
     use bar;
     //~^ ERROR absolute
     //~| WARN this was previously accepted
+    //~| WARN it will become a hard error
     use crate::{bar as something_else};
 
     use {Bar as SomethingElse, main};
     //~^ ERROR absolute
     //~| WARN this was previously accepted
+    //~| WARN it will become a hard error
 
     use crate::{Bar as SomethingElse2, main as another_main};
 
@@ -35,6 +38,7 @@ pub mod foo {
 use bar::Bar;
 //~^ ERROR absolute
 //~| WARN this was previously accepted
+//~| WARN it will become a hard error
 
 pub mod bar {
     use edition_lint_paths as foo;
@@ -47,16 +51,19 @@ mod baz {
     use *;
     //~^ ERROR absolute
     //~| WARN this was previously accepted
+    //~| WARN it will become a hard error
 }
 
 impl ::foo::SomeTrait for u32 { }
 //~^ ERROR absolute
 //~| WARN this was previously accepted
+//~| WARN it will become a hard error
 
 fn main() {
     let x = ::bar::Bar;
     //~^ ERROR absolute
     //~| WARN this was previously accepted
+    //~| WARN it will become a hard error
     let x = bar::Bar;
     let x = crate::bar::Bar;
     let x = self::bar::Bar;

--- a/src/test/ui/rust-2018/edition-lint-paths.stderr
+++ b/src/test/ui/rust-2018/edition-lint-paths.stderr
@@ -9,61 +9,68 @@ note: lint level defined here
    |
 LL | #![deny(absolute_paths_not_starting_with_crate)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
 error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
-  --> $DIR/edition-lint-paths.rs:18:9
+  --> $DIR/edition-lint-paths.rs:19:9
    |
 LL |     use bar;
    |         ^^^ help: use `crate`: `crate::bar`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
 error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
-  --> $DIR/edition-lint-paths.rs:23:9
+  --> $DIR/edition-lint-paths.rs:25:9
    |
 LL |     use {Bar as SomethingElse, main};
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `crate`: `crate::{Bar as SomethingElse, main}`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
 error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
-  --> $DIR/edition-lint-paths.rs:35:5
+  --> $DIR/edition-lint-paths.rs:38:5
    |
 LL | use bar::Bar;
    |     ^^^^^^^^ help: use `crate`: `crate::bar::Bar`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
 error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
-  --> $DIR/edition-lint-paths.rs:47:9
+  --> $DIR/edition-lint-paths.rs:51:9
    |
 LL |     use *;
    |         ^ help: use `crate`: `crate::*`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
 error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
-  --> $DIR/edition-lint-paths.rs:52:6
+  --> $DIR/edition-lint-paths.rs:57:6
    |
 LL | impl ::foo::SomeTrait for u32 { }
    |      ^^^^^^^^^^^^^^^^ help: use `crate`: `crate::foo::SomeTrait`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
 error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
-  --> $DIR/edition-lint-paths.rs:57:13
+  --> $DIR/edition-lint-paths.rs:63:13
    |
 LL |     let x = ::bar::Bar;
    |             ^^^^^^^^^^ help: use `crate`: `crate::bar::Bar`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
 error: aborting due to 7 previous errors

--- a/src/test/ui/rust-2018/extern-crate-rename.fixed
+++ b/src/test/ui/rust-2018/extern-crate-rename.fixed
@@ -12,8 +12,8 @@ extern crate edition_lint_paths as my_crate;
 use crate::my_crate::foo;
 //~^ ERROR absolute paths must start
 //~| WARNING this was previously accepted
+//~| WARN it will become a hard error
 
 fn main() {
     foo();
 }
-

--- a/src/test/ui/rust-2018/extern-crate-rename.rs
+++ b/src/test/ui/rust-2018/extern-crate-rename.rs
@@ -12,8 +12,8 @@ extern crate edition_lint_paths as my_crate;
 use my_crate::foo;
 //~^ ERROR absolute paths must start
 //~| WARNING this was previously accepted
+//~| WARN it will become a hard error
 
 fn main() {
     foo();
 }
-

--- a/src/test/ui/rust-2018/extern-crate-rename.stderr
+++ b/src/test/ui/rust-2018/extern-crate-rename.stderr
@@ -9,7 +9,8 @@ note: lint level defined here
    |
 LL | #![deny(absolute_paths_not_starting_with_crate)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
 error: aborting due to previous error

--- a/src/test/ui/rust-2018/extern-crate-submod.fixed
+++ b/src/test/ui/rust-2018/extern-crate-submod.fixed
@@ -19,8 +19,8 @@ mod m {
 use crate::m::edition_lint_paths::foo;
 //~^ ERROR absolute paths must start
 //~| WARNING this was previously accepted
+//~| WARN it will become a hard error
 
 fn main() {
     foo();
 }
-

--- a/src/test/ui/rust-2018/extern-crate-submod.rs
+++ b/src/test/ui/rust-2018/extern-crate-submod.rs
@@ -19,8 +19,8 @@ mod m {
 use m::edition_lint_paths::foo;
 //~^ ERROR absolute paths must start
 //~| WARNING this was previously accepted
+//~| WARN it will become a hard error
 
 fn main() {
     foo();
 }
-

--- a/src/test/ui/rust-2018/extern-crate-submod.stderr
+++ b/src/test/ui/rust-2018/extern-crate-submod.stderr
@@ -9,7 +9,8 @@ note: lint level defined here
    |
 LL | #![deny(absolute_paths_not_starting_with_crate)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
 error: aborting due to previous error

--- a/src/test/ui/rust-2018/suggestions-not-always-applicable.stderr
+++ b/src/test/ui/rust-2018/suggestions-not-always-applicable.stderr
@@ -10,7 +10,8 @@ note: lint level defined here
 LL | #![warn(rust_2018_compatibility)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^
    = note: #[warn(absolute_paths_not_starting_with_crate)] implied by #[warn(rust_2018_compatibility)]
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
 warning: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
@@ -19,6 +20,7 @@ warning: absolute paths must start with `self`, `super`, `crate`, or an external
 LL |     #[foo]
    |     ^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 

--- a/src/test/ui/rust-2018/try-ident.stderr
+++ b/src/test/ui/rust-2018/try-ident.stderr
@@ -10,7 +10,8 @@ note: lint level defined here
 LL | #![warn(rust_2018_compatibility)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^
    = note: #[warn(keyword_idents)] implied by #[warn(rust_2018_compatibility)]
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 warning: `try` is a keyword in the 2018 edition
@@ -19,6 +20,7 @@ warning: `try` is a keyword in the 2018 edition
 LL | fn try() {
    |    ^^^ help: you can use a raw identifier to stay compatible: `r#try`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 

--- a/src/test/ui/rust-2018/try-macro.stderr
+++ b/src/test/ui/rust-2018/try-macro.stderr
@@ -10,6 +10,7 @@ note: lint level defined here
 LL | #![warn(rust_2018_compatibility)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^
    = note: #[warn(keyword_idents)] implied by #[warn(rust_2018_compatibility)]
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in the 2018 edition!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 

--- a/src/test/ui/safe-extern-statics.rs
+++ b/src/test/ui/safe-extern-statics.rs
@@ -12,10 +12,14 @@ extern {
 fn main() {
     let a = A; //~ ERROR use of extern static is unsafe
                //~^ WARN this was previously accepted by the compiler
+               //~| WARN it will become a hard error
     let ra = &A; //~ ERROR use of extern static is unsafe
                  //~^ WARN this was previously accepted by the compiler
+                 //~| WARN it will become a hard error
     let xa = XA; //~ ERROR use of extern static is unsafe
                  //~^ WARN this was previously accepted by the compiler
+                 //~| WARN it will become a hard error
     let xra = &XA; //~ ERROR use of extern static is unsafe
                    //~^ WARN this was previously accepted by the compiler
+                   //~| WARN it will become a hard error
 }

--- a/src/test/ui/safe-extern-statics.stderr
+++ b/src/test/ui/safe-extern-statics.stderr
@@ -5,37 +5,41 @@ LL |     let a = A;
    |             ^
    |
    = note: #[deny(safe_extern_statics)] on by default
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #36247 <https://github.com/rust-lang/rust/issues/36247>
    = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
 
 error: use of extern static is unsafe and requires unsafe function or block (error E0133)
-  --> $DIR/safe-extern-statics.rs:15:14
+  --> $DIR/safe-extern-statics.rs:16:14
    |
 LL |     let ra = &A;
    |              ^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #36247 <https://github.com/rust-lang/rust/issues/36247>
    = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
 
 error: use of extern static is unsafe and requires unsafe function or block (error E0133)
-  --> $DIR/safe-extern-statics.rs:17:14
+  --> $DIR/safe-extern-statics.rs:19:14
    |
 LL |     let xa = XA;
    |              ^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #36247 <https://github.com/rust-lang/rust/issues/36247>
    = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
 
 error: use of extern static is unsafe and requires unsafe function or block (error E0133)
-  --> $DIR/safe-extern-statics.rs:19:15
+  --> $DIR/safe-extern-statics.rs:22:15
    |
 LL |     let xra = &XA;
    |               ^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #36247 <https://github.com/rust-lang/rust/issues/36247>
    = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
 

--- a/src/test/ui/type-alias-enum-variants-priority.rs
+++ b/src/test/ui/type-alias-enum-variants-priority.rs
@@ -14,6 +14,7 @@ impl Tr for E {
     type V = u8;
     fn f() -> Self::V { 0 }
     //~^ ERROR ambiguous associated item
+    //~| WARN it will become a hard error
     //~| WARN this was previously accepted
 }
 

--- a/src/test/ui/type-alias-enum-variants-priority.stderr
+++ b/src/test/ui/type-alias-enum-variants-priority.stderr
@@ -9,7 +9,8 @@ note: lint level defined here
    |
 LL | #![deny(ambiguous_associated_items)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out
+   = warning: it will become a hard error in a future release!
    = note: for more information, see issue #57644 <https://github.com/rust-lang/rust/issues/57644>
 note: `V` could refer to variant defined here
   --> $DIR/type-alias-enum-variants-priority.rs:5:5


### PR DESCRIPTION
Introduce a notion of `min_level: Level` for `Lint`s. The minimum level cannot be loosened further.

+ For example, if you have `min_level: Warn` for `nested_impl_trait` and then you `#[allow(nested_impl_trait)` then a warning will still be emitted regardless of `--cap-lints`.
+ Moreover, when `#[allow(nested_impl_trait)]` has no effect, this will trigger `unused_attributes`.
+ When `#[deny(warnings)]` is used, this is also taken into account. In particular, the minimum level will result in a warning being triggered which will cause `#[deny(warnings)]` to produce a compilation failure. However, `--cap-lints` *will* be honored here such that a warning is still emitted for `nested_impl_trait` but `deny(warnings)` becomes `$the_cap(warnings)`. We do this so that if crate A depends on crate B and B violates `nested_impl_trait`, then this does not produce a compilation failure in A.

Also, we introduce a macro `declare_unsuppressable_lint!` which sets `min_level: Warn`.
We then use `declare_unsuppressable_lint!` for  `ILLEGAL_FLOATING_POINT_LITERAL_PATTERN`.

fixes https://github.com/rust-lang/rust/issues/34596
cc @nikomatsakis 
r? @pnkfelix 