### PR TITLE
improve worst-case performance of HashSet.is_subset

### DIFF
--- a/src/libstd/collections/hash/set.rs
+++ b/src/libstd/collections/hash/set.rs
@@ -627,7 +627,11 @@ impl<T, S> HashSet<T, S>
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn is_subset(&self, other: &HashSet<T, S>) -> bool {
-        self.iter().all(|v| other.contains(v))
+        if self.len() <= other.len() {
+            self.iter().all(|v| other.contains(v))
+        } else {
+            false
+        }
     }
 
     /// Returns `true` if the set is a superset of another,


### PR DESCRIPTION
One more simple optimization opportunity for HashSet that was applied in BTreeSet in #59186 (and wasn't in #57043). Already covered by the existing unit test.

r? @KodrAus