### PR TITLE
Updated the environment description in rustc.

### DIFF
--- a/src/doc/man/rustc.1
+++ b/src/doc/man/rustc.1
@@ -265,8 +265,8 @@ Optimize with possible levels 0\[en]3
 
 .SH ENVIRONMENT
 
-Some of these affect the output of the compiler, while others affect programs
-which link to the standard library.
+Some of these affect only test harness programs (generated via rustc --test);
+others affect all programs which link to the Rust standard library.
 
 .TP
 \fBRUST_TEST_THREADS\fR


### PR DESCRIPTION
# Description

- Updated the "environment" description in the `rustc` man pages

The old wording suggested that all the mentioned flags influenced the output of the compiler,
where this was not the case.

closes #59504