### PR TITLE
rustfix coverage: Skip UI tests with non-json error-format

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2820,12 +2820,15 @@ impl<'test> TestCx<'test> {
             // don't test rustfix with nll right now
         } else if self.config.rustfix_coverage {
             // Find out which tests have `MachineApplicable` suggestions but are missing
-            // `run-rustfix` or `run-rustfix-only-machine-applicable` headers
+            // `run-rustfix` or `run-rustfix-only-machine-applicable` headers.
+            //
+            // This will return an empty `Vec` in case the executed test file has a
+            // `compile-flags: --error-format=xxxx` header with a value other than `json`.
             let suggestions = get_suggestions_from_json(
                 &proc_res.stderr,
                 &HashSet::new(),
                 Filter::MachineApplicableOnly
-            ).unwrap();
+            ).unwrap_or_default();
             if suggestions.len() > 0
                 && !self.props.run_rustfix
                 && !self.props.rustfix_only_machine_applicable {


### PR DESCRIPTION
When using the `rustfix-coverage` flag, some tests currently fail
because they define a different error-format than `json`.

The current implementation crashes when encountering those tests. Since
we don't care about non-json test output when collecting the coverage
data, we handle those tests by returning an empty `Vec` instead.

r? @oli-obk