### PR TITLE
Document the -Z flag to the rustc book

### DIFF
--- a/src/doc/rustc/src/command-line-arguments.md
+++ b/src/doc/rustc/src/command-line-arguments.md
@@ -86,6 +86,12 @@ This flag will set which lints should be set to the [deny level](lints/levels.ht
 
 This flag will set which lints should be set to the [forbid level](lints/levels.html#forbid).
 
+## `-Z`: set options for debugging rustc
+
+This flag lets you set options for debugging rustc. In order to set multiple options, the -Z flag
+can be used multiple times. For example: `rustc -Z verbose -Z time`. Specifying options with -Z is
+only available on nightly. To view all available options run: `rustc -Z help`.
+
 ## `--cap-lints`: set the most restrictive lint level
 
 This flag lets you 'cap' lints, for more, [see here](lints/levels.html#capping-lints).

--- a/src/doc/rustc/src/command-line-arguments.md
+++ b/src/doc/rustc/src/command-line-arguments.md
@@ -86,11 +86,12 @@ This flag will set which lints should be set to the [deny level](lints/levels.ht
 
 This flag will set which lints should be set to the [forbid level](lints/levels.html#forbid).
 
-## `-Z`: set options for debugging rustc
+## `-Z`: set unstable options
 
-This flag lets you set options for debugging rustc. In order to set multiple options, the -Z flag
-can be used multiple times. For example: `rustc -Z verbose -Z time`. Specifying options with -Z is
-only available on nightly. To view all available options run: `rustc -Z help`.
+This flag will allow you to set unstable options of rustc. In order to set multiple options,
+the -Z flag can be used multiple times. For example: `rustc -Z verbose -Z time`.
+Specifying options with -Z is only available on nightly. To view all available options
+run: `rustc -Z help`.
 
 ## `--cap-lints`: set the most restrictive lint level
 

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -743,7 +743,7 @@ fn usage(verbose: bool, include_unstable_options: bool) {
     }
     let message = "Usage: rustc [OPTIONS] INPUT";
     let nightly_help = if nightly_options::is_nightly_build() {
-        "\n    -Z help             Print internal options for debugging rustc"
+        "\n    -Z help             Print unstable compiler options"
     } else {
         ""
     };
@@ -891,7 +891,7 @@ Available lint options:
 }
 
 fn describe_debug_flags() {
-    println!("\nAvailable debug options:\n");
+    println!("\nAvailable options:\n");
     print_flag_list("-Z", config::DB_OPTIONS);
 }
 


### PR DESCRIPTION
# Description

Changes:
- Added new documentation on the `-Z` flag of rustc in the command-line arguments section of the rustc book.

If I need to rephrase anything or if you have any improvements, please let me know! I deliberately did not create an exhaustive list of all options since they are likely to change over time and per toolchain version.

closes #41142