### PR TITLE
Remove invalid assertion back::link::from add_upstream_rust_crates().

### DIFF
--- a/src/librustc_codegen_llvm/back/link.rs
+++ b/src/librustc_codegen_llvm/back/link.rs
@@ -1396,10 +1396,6 @@ fn add_upstream_rust_crates(cmd: &mut dyn Linker,
 
     // Same thing as above, but for dynamic crates instead of static crates.
     fn add_dynamic_crate(cmd: &mut dyn Linker, sess: &Session, cratepath: &Path) {
-        // If we're performing LTO, then it should have been previously required
-        // that all upstream rust dependencies were available in an rlib format.
-        assert!(!are_upstream_rust_objects_already_included(sess));
-
         // Just need to tell the linker about where the library lives and
         // what its name is
         let parent = cratepath.parent();

--- a/src/test/run-make-fulldeps/lto-dylib-dep/Makefile
+++ b/src/test/run-make-fulldeps/lto-dylib-dep/Makefile
@@ -1,0 +1,10 @@
+-include ../tools.mk
+
+# Test that we don't run into an assertion when using a Rust dylib dependency
+# while compiling with full LTO.
+# See https://github.com/rust-lang/rust/issues/59137
+
+all:
+	$(RUSTC) a_dylib.rs --crate-type=dylib -C prefer-dynamic
+	$(RUSTC) main.rs -C lto
+	$(call RUN,main)

--- a/src/test/run-make-fulldeps/lto-dylib-dep/a_dylib.rs
+++ b/src/test/run-make-fulldeps/lto-dylib-dep/a_dylib.rs
@@ -1,0 +1,4 @@
+
+pub fn foo() {
+    println!("bar");
+}

--- a/src/test/run-make-fulldeps/lto-dylib-dep/main.rs
+++ b/src/test/run-make-fulldeps/lto-dylib-dep/main.rs
@@ -1,0 +1,6 @@
+
+extern crate a_dylib;
+
+fn main() {
+    a_dylib::foo();
+}


### PR DESCRIPTION
This removes a misplaced assertion. The function containing the assertion is actually only ever called for upstream crates that are not considered for LTO, so we don't care whether upstream code has been merged in by LTO or not.

Fixes #59137 

r? @alexcrichton 