### PR TITLE
Documented BinaryHeap performance.

### DIFF
--- a/src/liballoc/collections/binary_heap.rs
+++ b/src/liballoc/collections/binary_heap.rs
@@ -167,7 +167,7 @@ use super::SpecExtend;
 ///
 /// The costs of `push` and `pop` and `peek` can be performed in `O(1)` time.
 /// Note that these are non-amortized costs. The amortized cost for `push`
-/// and `pop` are `O(log(N)` due to re-allocations and maintaining the heap property.
+/// and `pop` are `O(log(N))` due to re-allocations and maintaining the heap property.
 ///
 /// # Examples
 ///

--- a/src/liballoc/collections/binary_heap.rs
+++ b/src/liballoc/collections/binary_heap.rs
@@ -165,6 +165,9 @@ use super::SpecExtend;
 /// trait, changes while it is in the heap. This is normally only possible
 /// through `Cell`, `RefCell`, global state, I/O, or unsafe code.
 ///
+/// Both `push` and `pop` operations can be performed in `O(log(n))` time, whereas `peek` can be
+/// performed in `O(1)` time.
+///
 /// # Examples
 ///
 /// ```

--- a/src/liballoc/collections/binary_heap.rs
+++ b/src/liballoc/collections/binary_heap.rs
@@ -165,8 +165,10 @@ use super::SpecExtend;
 /// trait, changes while it is in the heap. This is normally only possible
 /// through `Cell`, `RefCell`, global state, I/O, or unsafe code.
 ///
-/// Both `push` and `pop` operations can be performed in `O(log(n))` time,
-/// whereas `peek` can be performed in `O(1)` time.
+/// The costs of `push` and `pop` operations are `O(log(n))` whereas `peek`
+/// can be performed in `O(1)` time. Note that the cost of a `push`
+/// operation is an amortized cost which does not take into account potential
+/// re-allocations when the current buffer cannot hold more elements.
 ///
 /// # Examples
 ///

--- a/src/liballoc/collections/binary_heap.rs
+++ b/src/liballoc/collections/binary_heap.rs
@@ -165,8 +165,8 @@ use super::SpecExtend;
 /// trait, changes while it is in the heap. This is normally only possible
 /// through `Cell`, `RefCell`, global state, I/O, or unsafe code.
 ///
-/// Both `push` and `pop` operations can be performed in `O(log(n))` time, whereas `peek` can be
-/// performed in `O(1)` time.
+/// Both `push` and `pop` operations can be performed in `O(log(n))` time,
+/// whereas `peek` can be performed in `O(1)` time.
 ///
 /// # Examples
 ///

--- a/src/liballoc/collections/binary_heap.rs
+++ b/src/liballoc/collections/binary_heap.rs
@@ -165,10 +165,9 @@ use super::SpecExtend;
 /// trait, changes while it is in the heap. This is normally only possible
 /// through `Cell`, `RefCell`, global state, I/O, or unsafe code.
 ///
-/// The costs of `push` and `pop` operations are `O(log(n))` whereas `peek`
-/// can be performed in `O(1)` time. Note that the cost of a `push`
-/// operation is an amortized cost which does not take into account potential
-/// re-allocations when the current buffer cannot hold more elements.
+/// The costs of `push` and `pop` and `peek` can be performed in `O(1)` time.
+/// Note that these are non-amortized costs. The amortized cost for `push`
+/// and `pop` are `O(log(N)` due to re-allocations and maintaining the heap property.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
# Description

As has been described in #47976 the performance of `BinaryHeap` was not yet documented. This PR adds a line specifying the performance of the `push`, `pop` and `peek` operations of `BinaryHeap`.

I deliberately did not add it to the [std::collections](https://doc.rust-lang.org/std/collections/index.html#performance) page, because it does not have operations such as `insert` and `remove`. I was unsure whether I should have created a new section called queues since the only two queues present in `std::collections` are `VecDeque` and `BinaryHeap` and `VecDeque` can append at both sides of the queue making it harder to create a consistent table. That's why I took this approach in the end.

@steveklabnik What do you think about this? Or do you think I can better ping someone else for this?

closes #47976