### PR TITLE
Simplify doc comment lexing

### DIFF
--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -631,26 +631,14 @@ impl<'a> StringReader<'a> {
                         self.bump();
                     }
 
-                    if doc_comment {
+                    let tok = if doc_comment {
                         self.with_str_from(start_bpos, |string| {
-                            // comments with only more "/"s are not doc comments
-                            let tok = if is_doc_comment(string) {
-                                token::DocComment(Symbol::intern(string))
-                            } else {
-                                token::Comment
-                            };
-
-                            Some(TokenAndSpan {
-                                tok,
-                                sp: self.mk_sp(start_bpos, self.pos),
-                            })
+                            token::DocComment(Symbol::intern(string))
                         })
                     } else {
-                        Some(TokenAndSpan {
-                            tok: token::Comment,
-                            sp: self.mk_sp(start_bpos, self.pos),
-                        })
-                    }
+                        token::Comment
+                    };
+                    Some(TokenAndSpan { tok, sp: self.mk_sp(start_bpos, self.pos) })
                 }
                 Some('*') => {
                     self.bump();


### PR DESCRIPTION
is_doc_comment function checks the first four chars, but this is
redundant, `doc_comment` local var has the same info.