### PR TITLE
rustc: Start implementing compat with LLVM 9

### DIFF
--- a/src/librustc_codegen_llvm/debuginfo/mod.rs
+++ b/src/librustc_codegen_llvm/debuginfo/mod.rs
@@ -296,12 +296,6 @@ impl DebugInfoMethods<'tcx> for CodegenCx<'ll, 'tcx> {
 
         let mut flags = DIFlags::FlagPrototyped;
 
-        if let Some((id, _)) = self.tcx.entry_fn(LOCAL_CRATE) {
-            if id == def_id {
-                flags |= DIFlags::FlagMainSubprogram;
-            }
-        }
-
         if self.layout_of(sig.output()).abi.is_uninhabited() {
             flags |= DIFlags::FlagNoReturn;
         }
@@ -312,6 +306,11 @@ impl DebugInfoMethods<'tcx> for CodegenCx<'ll, 'tcx> {
         }
         if self.sess().opts.optimize != config::OptLevel::No {
             spflags |= DISPFlags::SPFlagOptimized;
+        }
+        if let Some((id, _)) = self.tcx.entry_fn(LOCAL_CRATE) {
+            if id == def_id {
+                spflags |= DISPFlags::SPFlagMainSubprogram;
+            }
         }
 
         let fn_metadata = unsafe {

--- a/src/librustc_codegen_llvm/llvm/ffi.rs
+++ b/src/librustc_codegen_llvm/llvm/ffi.rs
@@ -588,7 +588,6 @@ pub mod debuginfo {
             const FlagIntroducedVirtual   = (1 << 18);
             const FlagBitField            = (1 << 19);
             const FlagNoReturn            = (1 << 20);
-            const FlagMainSubprogram      = (1 << 21);
         }
     }
 
@@ -603,6 +602,7 @@ pub mod debuginfo {
             const SPFlagLocalToUnit       = (1 << 2);
             const SPFlagDefinition        = (1 << 3);
             const SPFlagOptimized         = (1 << 4);
+            const SPFlagMainSubprogram    = (1 << 5);
         }
     }
 


### PR DESCRIPTION
This commit doesn't actually migrate to LLVM 9, but it brings our own
C++ bindings in line with LLVM 9 and able to compile against tip of
tree. The changes made were:

* The `MainSubprogram` flag for debuginfo moved between flag types.
* Iteration of archive members was tweaked slightly and we have to
  construct the two iterators before constructing the returned
  `RustArchiveIterator` value.
* The `getOrInsertFunction` binding now returns a wrapper which we use
  `getCallee()` on to get the value we're interested in.