### PR TITLE
wasm32: Default to a "static" relocation model

### DIFF
--- a/src/librustc_target/spec/wasm32_base.rs
+++ b/src/librustc_target/spec/wasm32_base.rs
@@ -118,6 +118,15 @@ pub fn options() -> TargetOptions {
 
         pre_link_args,
 
+        // This has no effect in LLVM 8 or prior, but in LLVM 9 and later when
+        // PIC code is implemented this has quite a drastric effect if it stays
+        // at the default, `pic`. In an effort to keep wasm binaries as minimal
+        // as possible we're defaulting to `static` for now, but the hope is
+        // that eventually we can ship a `pic`-compatible standard library which
+        // works with `static` as well (or works with some method of generating
+        // non-relative calls and such later on).
+        relocation_model: "static".to_string(),
+
         .. Default::default()
     }
 }


### PR DESCRIPTION
LLVM 9 is adding support for a "pic" relocation model for wasm code,
which is quite different than the current model. In order to preserve
the mode of compilation that we have today default to "static" to ensure
that we don't accidentally start creating experimental relocatable
binaries.