### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/src/librustc/lint/internal.rs
+++ b/src/librustc/lint/internal.rs
@@ -28,15 +28,7 @@ impl DefaultHashTypes {
     }
 }
 
-impl LintPass for DefaultHashTypes {
-    fn get_lints(&self) -> LintArray {
-        lint_array!(DEFAULT_HASH_TYPES)
-    }
-
-    fn name(&self) -> &'static str {
-        "DefaultHashTypes"
-    }
-}
+impl_lint_pass!(DefaultHashTypes => [DEFAULT_HASH_TYPES]);
 
 impl EarlyLintPass for DefaultHashTypes {
     fn check_ident(&mut self, cx: &EarlyContext<'_>, ident: Ident) {
@@ -68,17 +60,7 @@ declare_lint! {
     "Usage of `ty::TyKind` outside of the `ty::sty` module"
 }
 
-pub struct TyKindUsage;
-
-impl LintPass for TyKindUsage {
-    fn get_lints(&self) -> LintArray {
-        lint_array!(USAGE_OF_TY_TYKIND)
-    }
-
-    fn name(&self) -> &'static str {
-        "TyKindUsage"
-    }
-}
+declare_lint_pass!(TyKindUsage => [USAGE_OF_TY_TYKIND]);
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TyKindUsage {
     fn check_path(&mut self, cx: &LateContext<'_, '_>, path: &'tcx Path, _: HirId) {

--- a/src/librustc_target/spec/wasm32_base.rs
+++ b/src/librustc_target/spec/wasm32_base.rs
@@ -118,6 +118,15 @@ pub fn options() -> TargetOptions {
 
         pre_link_args,
 
+        // This has no effect in LLVM 8 or prior, but in LLVM 9 and later when
+        // PIC code is implemented this has quite a drastric effect if it stays
+        // at the default, `pic`. In an effort to keep wasm binaries as minimal
+        // as possible we're defaulting to `static` for now, but the hope is
+        // that eventually we can ship a `pic`-compatible standard library which
+        // works with `static` as well (or works with some method of generating
+        // non-relative calls and such later on).
+        relocation_model: "static".to_string(),
+
         .. Default::default()
     }
 }

--- a/src/libstd/collections/hash/set.rs
+++ b/src/libstd/collections/hash/set.rs
@@ -627,7 +627,11 @@ impl<T, S> HashSet<T, S>
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn is_subset(&self, other: &HashSet<T, S>) -> bool {
-        self.iter().all(|v| other.contains(v))
+        if self.len() <= other.len() {
+            self.iter().all(|v| other.contains(v))
+        } else {
+            false
+        }
     }
 
     /// Returns `true` if the set is a superset of another,

--- a/src/libstd/ffi/os_str.rs
+++ b/src/libstd/ffi/os_str.rs
@@ -960,6 +960,7 @@ impl IntoInner<Buf> for OsString {
 }
 
 impl AsInner<Slice> for OsStr {
+    #[inline]
     fn as_inner(&self) -> &Slice {
         &self.inner
     }

--- a/src/libstd/sys_common/os_str_bytes.rs
+++ b/src/libstd/sys_common/os_str_bytes.rs
@@ -236,9 +236,11 @@ pub trait OsStrExt {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl OsStrExt for OsStr {
+    #[inline]
     fn from_bytes(slice: &[u8]) -> &OsStr {
         unsafe { mem::transmute(slice) }
     }
+    #[inline]
     fn as_bytes(&self) -> &[u8] {
         &self.as_inner().inner
     }

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -1,10 +1,9 @@
 use crate::ast::{self, Ident};
-use crate::source_map::{SourceMap, FilePathMapping};
 use crate::parse::{token, ParseSess};
 use crate::symbol::Symbol;
 
 use errors::{Applicability, FatalError, Diagnostic, DiagnosticBuilder};
-use syntax_pos::{BytePos, CharPos, Pos, Span, NO_EXPANSION};
+use syntax_pos::{BytePos, Pos, Span, NO_EXPANSION};
 use core::unicode::property::Pattern_White_Space;
 
 use std::borrow::Cow;
@@ -667,14 +666,9 @@ impl<'a> StringReader<'a> {
                     return None;
                 }
 
-                // I guess this is the only way to figure out if
-                // we're at the beginning of the file...
-                let smap = SourceMap::new(FilePathMapping::empty());
-                smap.files.borrow_mut().source_files.push(self.source_file.clone());
-                let loc = smap.lookup_char_pos_adj(self.pos);
-                debug!("Skipping a shebang");
-                if loc.line == 1 && loc.col == CharPos(0) {
-                    // FIXME: Add shebang "token", return it
+                let is_beginning_of_file = self.pos == self.source_file.start_pos;
+                if is_beginning_of_file {
+                    debug!("Skipping a shebang");
                     let start = self.pos;
                     while !self.ch_is('\n') && !self.is_eof() {
                         self.bump();
@@ -1911,7 +1905,7 @@ mod tests {
 
     use crate::ast::{Ident, CrateConfig};
     use crate::symbol::Symbol;
-    use crate::source_map::SourceMap;
+    use crate::source_map::{SourceMap, FilePathMapping};
     use crate::feature_gate::UnstableFeatures;
     use crate::parse::token;
     use crate::diagnostics::plugin::ErrorMap;


### PR DESCRIPTION
Successful merges:

 - #59665 (improve worst-case performance of HashSet.is_subset)
 - #59687 (cleanup shebang handling in the lexer)
 - #59690 (Mark unix::ffi::OsStrExt methods as inline)
 - #59702 (Use declare_lint_pass! and impl_lint_pass! in more places)
 - #59712 (wasm32: Default to a "static" relocation model)

Failed merges:


r? @ghost