### PR TITLE
wasi: Use shared API for preopened fds

### DIFF
--- a/src/ci/docker/dist-various-2/build-wasi-toolchain.sh
+++ b/src/ci/docker/dist-various-2/build-wasi-toolchain.sh
@@ -12,7 +12,7 @@ export PATH=`pwd`/clang+llvm-8.0.0-x86_64-linux-gnu-ubuntu-14.04/bin:$PATH
 git clone https://github.com/CraneStation/wasi-sysroot
 
 cd wasi-sysroot
-git reset --hard 320054e84f8f2440def3b1c8700cedb8fd697bf8
+git reset --hard e5f14be38362f1ab83302895a6e74b2ffd0e2302
 make -j$(nproc) INSTALL_DIR=/wasm32-unknown-wasi install
 
 cd ..


### PR DESCRIPTION
This commit updates the wasi target with supported added in
CraneStation/wasi-sysroot#10. That function allows both C and Rust to
cooperate in how preopened files are managed, enabling us to learn about
propened files through the same interface. The `open_parent` function in
the wasi `fs` module was updated to avoid its own initialization of a
global preopened map and instead delegate to libc to perform this
functionality.

This should both be more robust into the future in terms of handling
path logic as well as ensuring the propened map is correctly set up at
process boot time. This does currently require some unfortunate
allocations on our side, but if that becomes an issue we can always
paper over those in time!