### PR TITLE
Stabilize futures_api

### DIFF
--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -911,7 +911,7 @@ impl<G: ?Sized + Generator> Generator for Pin<Box<G>> {
     }
 }
 
-#[unstable(feature = "futures_api", issue = "50547")]
+#[stable(feature = "futures_api", since = "1.36.0")]
 impl<F: ?Sized + Future + Unpin> Future for Box<F> {
     type Output = F::Output;
 

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -85,7 +85,6 @@
 #![feature(fmt_internals)]
 #![feature(fn_traits)]
 #![feature(fundamental)]
-#![feature(futures_api)]
 #![feature(lang_items)]
 #![feature(libc)]
 #![feature(needs_allocator)]

--- a/src/libcore/future/future.rs
+++ b/src/libcore/future/future.rs
@@ -1,6 +1,4 @@
-#![unstable(feature = "futures_api",
-            reason = "futures in libcore are unstable",
-            issue = "50547")]
+#![stable(feature = "futures_api", since = "1.36.0")]
 
 use crate::marker::Unpin;
 use crate::ops;
@@ -26,8 +24,10 @@ use crate::task::{Context, Poll};
 /// `await!` the value.
 #[doc(spotlight)]
 #[must_use = "futures do nothing unless polled"]
+#[stable(feature = "futures_api", since = "1.36.0")]
 pub trait Future {
     /// The type of value produced on completion.
+    #[stable(feature = "futures_api", since = "1.36.0")]
     type Output;
 
     /// Attempt to resolve the future to a final value, registering
@@ -92,9 +92,11 @@ pub trait Future {
     /// [`Context`]: ../task/struct.Context.html
     /// [`Waker`]: ../task/struct.Waker.html
     /// [`Waker::wake`]: ../task/struct.Waker.html#method.wake
+    #[stable(feature = "futures_api", since = "1.36.0")]
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output>;
 }
 
+#[stable(feature = "futures_api", since = "1.36.0")]
 impl<F: ?Sized + Future + Unpin> Future for &mut F {
     type Output = F::Output;
 
@@ -103,6 +105,7 @@ impl<F: ?Sized + Future + Unpin> Future for &mut F {
     }
 }
 
+#[stable(feature = "futures_api", since = "1.36.0")]
 impl<P> Future for Pin<P>
 where
     P: Unpin + ops::DerefMut,

--- a/src/libcore/future/mod.rs
+++ b/src/libcore/future/mod.rs
@@ -1,8 +1,7 @@
-#![unstable(feature = "futures_api",
-            reason = "futures in libcore are unstable",
-            issue = "50547")]
+#![stable(feature = "futures_api", since = "1.36.0")]
 
 //! Asynchronous values.
 
 mod future;
+#[stable(feature = "futures_api", since = "1.36.0")]
 pub use self::future::Future;

--- a/src/libcore/task/mod.rs
+++ b/src/libcore/task/mod.rs
@@ -1,11 +1,11 @@
-#![unstable(feature = "futures_api",
-            reason = "futures in libcore are unstable",
-            issue = "50547")]
+#![stable(feature = "futures_api", since = "1.36.0")]
 
 //! Types and Traits for working with asynchronous tasks.
 
 mod poll;
+#[stable(feature = "futures_api", since = "1.36.0")]
 pub use self::poll::Poll;
 
 mod wake;
+#[stable(feature = "futures_api", since = "1.36.0")]
 pub use self::wake::{Context, Waker, RawWaker, RawWakerVTable};

--- a/src/libcore/task/poll.rs
+++ b/src/libcore/task/poll.rs
@@ -1,6 +1,4 @@
-#![unstable(feature = "futures_api",
-            reason = "futures in libcore are unstable",
-            issue = "50547")]
+#![stable(feature = "futures_api", since = "1.36.0")]
 
 use crate::ops::Try;
 use crate::result::Result;
@@ -9,20 +7,27 @@ use crate::result::Result;
 /// scheduled to receive a wakeup instead.
 #[must_use = "this `Poll` may be a `Pending` variant, which should be handled"]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[stable(feature = "futures_api", since = "1.36.0")]
 pub enum Poll<T> {
     /// Represents that a value is immediately ready.
-    Ready(T),
+    #[stable(feature = "futures_api", since = "1.36.0")]
+    Ready(
+        #[stable(feature = "futures_api", since = "1.36.0")]
+        T
+    ),
 
     /// Represents that a value is not ready yet.
     ///
     /// When a function returns `Pending`, the function *must* also
     /// ensure that the current task is scheduled to be awoken when
     /// progress can be made.
+    #[stable(feature = "futures_api", since = "1.36.0")]
     Pending,
 }
 
 impl<T> Poll<T> {
     /// Changes the ready value of this `Poll` with the closure provided.
+    #[stable(feature = "futures_api", since = "1.36.0")]
     pub fn map<U, F>(self, f: F) -> Poll<U>
         where F: FnOnce(T) -> U
     {
@@ -34,6 +39,7 @@ impl<T> Poll<T> {
 
     /// Returns `true` if this is `Poll::Ready`
     #[inline]
+    #[stable(feature = "futures_api", since = "1.36.0")]
     pub fn is_ready(&self) -> bool {
         match *self {
             Poll::Ready(_) => true,
@@ -43,6 +49,7 @@ impl<T> Poll<T> {
 
     /// Returns `true` if this is `Poll::Pending`
     #[inline]
+    #[stable(feature = "futures_api", since = "1.36.0")]
     pub fn is_pending(&self) -> bool {
         !self.is_ready()
     }
@@ -50,6 +57,7 @@ impl<T> Poll<T> {
 
 impl<T, E> Poll<Result<T, E>> {
     /// Changes the success value of this `Poll` with the closure provided.
+    #[stable(feature = "futures_api", since = "1.36.0")]
     pub fn map_ok<U, F>(self, f: F) -> Poll<Result<U, E>>
         where F: FnOnce(T) -> U
     {
@@ -61,6 +69,7 @@ impl<T, E> Poll<Result<T, E>> {
     }
 
     /// Changes the error value of this `Poll` with the closure provided.
+    #[stable(feature = "futures_api", since = "1.36.0")]
     pub fn map_err<U, F>(self, f: F) -> Poll<Result<T, U>>
         where F: FnOnce(E) -> U
     {
@@ -72,12 +81,14 @@ impl<T, E> Poll<Result<T, E>> {
     }
 }
 
+#[stable(feature = "futures_api", since = "1.36.0")]
 impl<T> From<T> for Poll<T> {
     fn from(t: T) -> Poll<T> {
         Poll::Ready(t)
     }
 }
 
+#[stable(feature = "futures_api", since = "1.36.0")]
 impl<T, E> Try for Poll<Result<T, E>> {
     type Ok = Poll<T>;
     type Error = E;
@@ -102,6 +113,7 @@ impl<T, E> Try for Poll<Result<T, E>> {
     }
 }
 
+#[stable(feature = "futures_api", since = "1.36.0")]
 impl<T, E> Try for Poll<Option<Result<T, E>>> {
     type Ok = Poll<Option<T>>;
     type Error = E;

--- a/src/librustc/ich/impls_syntax.rs
+++ b/src/librustc/ich/impls_syntax.rs
@@ -121,6 +121,7 @@ impl_stable_hash_for!(struct ::syntax::attr::Stability {
     feature,
     rustc_depr,
     promotable,
+    allow_const_fn_ptr,
     const_stability
 });
 

--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -441,6 +441,7 @@ impl<'a, 'tcx> Index<'tcx> {
                     rustc_depr: None,
                     const_stability: None,
                     promotable: false,
+                    allow_const_fn_ptr: false,
                 });
                 annotator.parent_stab = Some(stability);
             }

--- a/src/librustc/query/mod.rs
+++ b/src/librustc/query/mod.rs
@@ -235,6 +235,8 @@ rustc_queries! {
         /// constructor function).
         query is_promotable_const_fn(_: DefId) -> bool {}
 
+        query const_fn_is_allowed_fn_ptr(_: DefId) -> bool {}
+
         /// True if this is a foreign item (i.e., linked via `extern { ... }`).
         query is_foreign_item(_: DefId) -> bool {}
 

--- a/src/librustc/ty/constness.rs
+++ b/src/librustc/ty/constness.rs
@@ -95,9 +95,16 @@ pub fn provide<'tcx>(providers: &mut Providers<'tcx>) {
         }
     }
 
+    fn const_fn_is_allowed_fn_ptr<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) -> bool {
+        tcx.is_const_fn(def_id) &&
+            tcx.lookup_stability(def_id)
+                .map(|stab| stab.allow_const_fn_ptr).unwrap_or(false)
+    }
+
     *providers = Providers {
         is_const_fn_raw,
         is_promotable_const_fn,
+        const_fn_is_allowed_fn_ptr,
         ..*providers
     };
 }

--- a/src/libstd/future.rs
+++ b/src/libstd/future.rs
@@ -9,6 +9,7 @@ use core::task::{Context, Poll};
 use core::ops::{Drop, Generator, GeneratorState};
 
 #[doc(inline)]
+#[stable(feature = "futures_api", since = "1.36.0")]
 pub use core::future::*;
 
 /// Wrap a generator in a future.

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -263,7 +263,6 @@
 #![feature(fixed_size_array)]
 #![feature(fn_traits)]
 #![feature(fnbox)]
-#![feature(futures_api)]
 #![feature(generator_trait)]
 #![feature(hash_raw_entry)]
 #![feature(hashmap_internals)]
@@ -458,18 +457,15 @@ pub mod process;
 pub mod sync;
 pub mod time;
 
-#[unstable(feature = "futures_api",
-           reason = "futures in libcore are unstable",
-           issue = "50547")]
+#[stable(feature = "futures_api", since = "1.36.0")]
 pub mod task {
     //! Types and Traits for working with asynchronous tasks.
     #[doc(inline)]
+    #[stable(feature = "futures_api", since = "1.36.0")]
     pub use core::task::*;
 }
 
-#[unstable(feature = "futures_api",
-           reason = "futures in libcore are unstable",
-           issue = "50547")]
+#[stable(feature = "futures_api", since = "1.36.0")]
 pub mod future;
 
 // Platform-abstraction modules

--- a/src/libstd/panic.rs
+++ b/src/libstd/panic.rs
@@ -319,7 +319,7 @@ impl<T: fmt::Debug> fmt::Debug for AssertUnwindSafe<T> {
     }
 }
 
-#[unstable(feature = "futures_api", issue = "50547")]
+#[stable(feature = "futures_api", since = "1.36.0")]
 impl<F: Future> Future for AssertUnwindSafe<F> {
     type Output = F::Output;
 

--- a/src/test/compile-fail/must_use-in-stdlib-traits.rs
+++ b/src/test/compile-fail/must_use-in-stdlib-traits.rs
@@ -1,5 +1,5 @@
 #![deny(unused_must_use)]
-#![feature(arbitrary_self_types, futures_api)]
+#![feature(arbitrary_self_types)]
 
 use std::iter::Iterator;
 use std::future::Future;

--- a/src/test/run-pass/async-await.rs
+++ b/src/test/run-pass/async-await.rs
@@ -1,7 +1,7 @@
 // edition:2018
 // aux-build:arc_wake.rs
 
-#![feature(async_await, await_macro, futures_api)]
+#![feature(async_await, await_macro)]
 
 extern crate arc_wake;
 

--- a/src/test/run-pass/auxiliary/arc_wake.rs
+++ b/src/test/run-pass/auxiliary/arc_wake.rs
@@ -1,7 +1,5 @@
 // edition:2018
 
-#![feature(futures_api)]
-
 use std::sync::Arc;
 use std::task::{
     Waker, RawWaker, RawWakerVTable,

--- a/src/test/run-pass/futures-api.rs
+++ b/src/test/run-pass/futures-api.rs
@@ -1,7 +1,5 @@
 // aux-build:arc_wake.rs
 
-#![feature(futures_api)]
-
 extern crate arc_wake;
 
 use std::future::Future;

--- a/src/test/run-pass/issue-54716.rs
+++ b/src/test/run-pass/issue-54716.rs
@@ -3,7 +3,7 @@
 // run-pass
 
 #![allow(unused_variables)]
-#![feature(async_await, await_macro, futures_api)]
+#![feature(async_await, await_macro)]
 
 extern crate arc_wake;
 

--- a/src/test/run-pass/issue-55809.rs
+++ b/src/test/run-pass/issue-55809.rs
@@ -1,7 +1,7 @@
 // edition:2018
 // run-pass
 
-#![feature(async_await, await_macro, futures_api)]
+#![feature(async_await, await_macro)]
 
 trait Foo { }
 

--- a/src/test/rustdoc/async-fn.rs
+++ b/src/test/rustdoc/async-fn.rs
@@ -1,6 +1,6 @@
 // edition:2018
 
-#![feature(async_await, futures_api)]
+#![feature(async_await)]
 
 // @has async_fn/fn.foo.html '//pre[@class="rust fn"]' 'pub async fn foo() -> Option<Foo>'
 pub async fn foo() -> Option<Foo> {

--- a/src/test/ui/async-fn-multiple-lifetimes.rs
+++ b/src/test/ui/async-fn-multiple-lifetimes.rs
@@ -1,6 +1,6 @@
 // edition:2018
 
-#![feature(arbitrary_self_types, async_await, await_macro, futures_api, pin)]
+#![feature(arbitrary_self_types, async_await, await_macro, pin)]
 
 use std::ops::Add;
 

--- a/src/test/ui/consts/min_const_fn/allow_const_fn_ptr.rs
+++ b/src/test/ui/consts/min_const_fn/allow_const_fn_ptr.rs
@@ -1,0 +1,10 @@
+#![feature(rustc_attrs, staged_api)]
+
+#[stable(feature = "rust1", since = "1.0.0")]
+const fn error(_: fn()) {} //~ ERROR function pointers in const fn are unstable
+
+#[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_allow_const_fn_ptr]
+const fn compiles(_: fn()) {}
+
+fn main() {}

--- a/src/test/ui/consts/min_const_fn/allow_const_fn_ptr.stderr
+++ b/src/test/ui/consts/min_const_fn/allow_const_fn_ptr.stderr
@@ -1,0 +1,11 @@
+error[E0723]: function pointers in const fn are unstable (see issue #57563)
+  --> $DIR/allow_const_fn_ptr.rs:4:16
+   |
+LL | const fn error(_: fn()) {}
+   |                ^
+   |
+   = help: add #![feature(const_fn)] to the crate attributes to enable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0723`.

--- a/src/test/ui/consts/min_const_fn/allow_const_fn_ptr.stderr
+++ b/src/test/ui/consts/min_const_fn/allow_const_fn_ptr.stderr
@@ -1,9 +1,10 @@
-error[E0723]: function pointers in const fn are unstable (see issue #57563)
+error[E0723]: function pointers in const fn are unstable
   --> $DIR/allow_const_fn_ptr.rs:4:16
    |
 LL | const fn error(_: fn()) {}
    |                ^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/consts/min_const_fn/allow_const_fn_ptr_feature_gate.rs
+++ b/src/test/ui/consts/min_const_fn/allow_const_fn_ptr_feature_gate.rs
@@ -1,0 +1,11 @@
+#![feature(staged_api)]
+
+#[stable(feature = "rust1", since = "1.0.0")]
+const fn error(_: fn()) {}
+
+#[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_allow_const_fn_ptr]
+//~^ ERROR unless otherwise specified, attributes with the prefix `rustc_` are reserved
+const fn compiles(_: fn()) {}
+
+fn main() {}

--- a/src/test/ui/consts/min_const_fn/allow_const_fn_ptr_feature_gate.stderr
+++ b/src/test/ui/consts/min_const_fn/allow_const_fn_ptr_feature_gate.stderr
@@ -1,0 +1,12 @@
+error[E0658]: unless otherwise specified, attributes with the prefix `rustc_` are reserved for internal compiler diagnostics
+  --> $DIR/allow_const_fn_ptr_feature_gate.rs:7:3
+   |
+LL | #[rustc_allow_const_fn_ptr]
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
+   = help: add #![feature(rustc_attrs)] to the crate attributes to enable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/consts/min_const_fn/allow_const_fn_ptr_run_pass.rs
+++ b/src/test/ui/consts/min_const_fn/allow_const_fn_ptr_run_pass.rs
@@ -1,0 +1,18 @@
+// run-pass
+
+#![feature(rustc_attrs, staged_api)]
+#![stable(feature = "rust1", since = "1.0.0")]
+
+#[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_allow_const_fn_ptr]
+const fn takes_fn_ptr(_: fn()) {}
+
+const FN: fn() = || ();
+
+const fn gives_fn_ptr() {
+    takes_fn_ptr(FN)
+}
+
+fn main() {
+    gives_fn_ptr();
+}

--- a/src/test/ui/editions/edition-deny-async-fns-2015.rs
+++ b/src/test/ui/editions/edition-deny-async-fns-2015.rs
@@ -1,6 +1,6 @@
 // edition:2015
 
-#![feature(futures_api, async_await)]
+#![feature(async_await)]
 
 async fn foo() {} //~ ERROR `async fn` is not permitted in the 2015 edition
 

--- a/src/test/ui/feature-gates/feature-gate-async-await-2015-edition.rs
+++ b/src/test/ui/feature-gates/feature-gate-async-await-2015-edition.rs
@@ -1,7 +1,5 @@
 // edition:2015
 
-#![feature(futures_api)]
-
 async fn foo() {} //~ ERROR `async fn` is not permitted in the 2015 edition
                   //~^ ERROR async fn is unstable
 

--- a/src/test/ui/feature-gates/feature-gate-async-await-2015-edition.stderr
+++ b/src/test/ui/feature-gates/feature-gate-async-await-2015-edition.stderr
@@ -1,23 +1,23 @@
 error[E0670]: `async fn` is not permitted in the 2015 edition
-  --> $DIR/feature-gate-async-await-2015-edition.rs:5:1
+  --> $DIR/feature-gate-async-await-2015-edition.rs:3:1
    |
 LL | async fn foo() {}
    | ^^^^^
 
 error[E0422]: cannot find struct, variant or union type `async` in this scope
-  --> $DIR/feature-gate-async-await-2015-edition.rs:9:13
+  --> $DIR/feature-gate-async-await-2015-edition.rs:7:13
    |
 LL |     let _ = async {};
    |             ^^^^^ not found in this scope
 
 error[E0425]: cannot find value `async` in this scope
-  --> $DIR/feature-gate-async-await-2015-edition.rs:10:13
+  --> $DIR/feature-gate-async-await-2015-edition.rs:8:13
    |
 LL |     let _ = async || { true };
    |             ^^^^^ not found in this scope
 
 error[E0658]: async fn is unstable
-  --> $DIR/feature-gate-async-await-2015-edition.rs:5:1
+  --> $DIR/feature-gate-async-await-2015-edition.rs:3:1
    |
 LL | async fn foo() {}
    | ^^^^^^^^^^^^^^^^^

--- a/src/test/ui/feature-gates/feature-gate-async-await.rs
+++ b/src/test/ui/feature-gates/feature-gate-async-await.rs
@@ -1,7 +1,5 @@
 // edition:2018
 
-#![feature(futures_api)]
-
 struct S;
 
 impl S {

--- a/src/test/ui/feature-gates/feature-gate-async-await.stderr
+++ b/src/test/ui/feature-gates/feature-gate-async-await.stderr
@@ -1,11 +1,11 @@
 error[E0706]: trait fns cannot be declared `async`
-  --> $DIR/feature-gate-async-await.rs:12:5
+  --> $DIR/feature-gate-async-await.rs:10:5
    |
 LL |     async fn foo();
    |     ^^^^^^^^^^^^^^^
 
 error[E0658]: async fn is unstable
-  --> $DIR/feature-gate-async-await.rs:8:5
+  --> $DIR/feature-gate-async-await.rs:6:5
    |
 LL |     async fn foo() {}
    |     ^^^^^^^^^^^^^^^^^
@@ -14,7 +14,7 @@ LL |     async fn foo() {}
    = help: add #![feature(async_await)] to the crate attributes to enable
 
 error[E0658]: async fn is unstable
-  --> $DIR/feature-gate-async-await.rs:12:5
+  --> $DIR/feature-gate-async-await.rs:10:5
    |
 LL |     async fn foo();
    |     ^^^^^^^^^^^^^^^
@@ -23,7 +23,7 @@ LL |     async fn foo();
    = help: add #![feature(async_await)] to the crate attributes to enable
 
 error[E0658]: async fn is unstable
-  --> $DIR/feature-gate-async-await.rs:16:1
+  --> $DIR/feature-gate-async-await.rs:14:1
    |
 LL | async fn foo() {}
    | ^^^^^^^^^^^^^^^^^
@@ -32,7 +32,7 @@ LL | async fn foo() {}
    = help: add #![feature(async_await)] to the crate attributes to enable
 
 error[E0658]: async blocks are unstable
-  --> $DIR/feature-gate-async-await.rs:19:13
+  --> $DIR/feature-gate-async-await.rs:17:13
    |
 LL |     let _ = async {};
    |             ^^^^^^^^
@@ -41,7 +41,7 @@ LL |     let _ = async {};
    = help: add #![feature(async_await)] to the crate attributes to enable
 
 error[E0658]: async closures are unstable
-  --> $DIR/feature-gate-async-await.rs:20:13
+  --> $DIR/feature-gate-async-await.rs:18:13
    |
 LL |     let _ = async || {};
    |             ^^^^^^^^^^^

--- a/src/test/ui/impl-trait/recursive-async-impl-trait-type.rs
+++ b/src/test/ui/impl-trait/recursive-async-impl-trait-type.rs
@@ -2,7 +2,7 @@
 // Test that impl trait does not allow creating recursive types that are
 // otherwise forbidden when using `async` and `await`.
 
-#![feature(await_macro, async_await, futures_api, generators)]
+#![feature(await_macro, async_await, generators)]
 
 async fn recursive_async_function() -> () { //~ ERROR
     await!(recursive_async_function());

--- a/src/test/ui/impl-trait/recursive-impl-trait-type.rs
+++ b/src/test/ui/impl-trait/recursive-impl-trait-type.rs
@@ -1,7 +1,7 @@
 // Test that impl trait does not allow creating recursive types that are
 // otherwise forbidden.
 
-#![feature(futures_api, generators)]
+#![feature(generators)]
 
 fn option(i: i32) -> impl Sized { //~ ERROR
     if i < 0 {

--- a/src/test/ui/issues/issue-54974.rs
+++ b/src/test/ui/issues/issue-54974.rs
@@ -1,7 +1,7 @@
 // compile-pass
 // edition:2018
 
-#![feature(async_await, await_macro, futures_api)]
+#![feature(async_await, await_macro)]
 
 use std::sync::Arc;
 

--- a/src/test/ui/issues/issue-55324.rs
+++ b/src/test/ui/issues/issue-55324.rs
@@ -1,7 +1,7 @@
 // compile-pass
 // edition:2018
 
-#![feature(async_await, await_macro, futures_api)]
+#![feature(async_await, await_macro)]
 
 use std::future::Future;
 

--- a/src/test/ui/issues/issue-58885.rs
+++ b/src/test/ui/issues/issue-58885.rs
@@ -1,7 +1,7 @@
 // compile-pass
 // edition:2018
 
-#![feature(async_await, await_macro, futures_api)]
+#![feature(async_await, await_macro)]
 
 struct Xyz {
     a: u64,

--- a/src/test/ui/issues/issue-59001.rs
+++ b/src/test/ui/issues/issue-59001.rs
@@ -1,7 +1,7 @@
 // compile-pass
 // edition:2018
 
-#![feature(async_await, await_macro, futures_api)]
+#![feature(async_await, await_macro)]
 
 use std::future::Future;
 

--- a/src/test/ui/no-args-non-move-async-closure.rs
+++ b/src/test/ui/no-args-non-move-async-closure.rs
@@ -1,6 +1,6 @@
 // edition:2018
 
-#![feature(arbitrary_self_types, async_await, await_macro, futures_api, pin)]
+#![feature(async_await, await_macro)]
 
 fn main() {
     let _ = async |x: u8| {};

--- a/src/test/ui/try-poll.rs
+++ b/src/test/ui/try-poll.rs
@@ -1,7 +1,6 @@
 // compile-pass
 
 #![allow(dead_code, unused)]
-#![feature(futures_api)]
 
 use std::task::Poll;
 


### PR DESCRIPTION
cc https://github.com/rust-lang/rust/issues/59725.
Based on https://github.com/rust-lang/rust/pull/59733 and https://github.com/rust-lang/rust/pull/59119 -- only the last two commits here are relevant.

r? @withoutboats , @oli-obk for the introduction of `rustc_allow_const_fn_ptr`.

--------------------------

@XAMPPRocky Prefer T-libs for relnotes.

// Centril