### PR TITLE
Show better errors for LLVM IR output

### DIFF
--- a/src/librustc_codegen_llvm/llvm/ffi.rs
+++ b/src/librustc_codegen_llvm/llvm/ffi.rs
@@ -1687,7 +1687,8 @@ extern "C" {
                                Demangle: extern fn(*const c_char,
                                                    size_t,
                                                    *mut c_char,
-                                                   size_t) -> size_t);
+                                                   size_t) -> size_t,
+                               ) -> LLVMRustResult;
     pub fn LLVMRustSetLLVMOptions(Argc: c_int, Argv: *const *const c_char);
     pub fn LLVMRustPrintPasses();
     pub fn LLVMRustSetNormalizedTarget(M: &Module, triple: *const c_char);


### PR DESCRIPTION
I was trying to output LLVM IR directly to the console:

    $ rustc hello.rs --emit=llvm-ir -o /dev/stdout
    LLVM ERROR: IO failure on output stream: Bad file descriptor

Now `LLVMRustPrintModule` returns an error, and we print:

    error: failed to write LLVM IR to /dev/stdout.hello.7rcbfp3g-cgu.0.rcgu.ll: Permission denied

... which is more informative.