### PR TITLE
Change `copytest` parameter name from `y` to `sign`

### DIFF
--- a/src/libstd/f32.rs
+++ b/src/libstd/f32.rs
@@ -193,11 +193,11 @@ impl f32 {
     }
 
     /// Returns a number composed of the magnitude of `self` and the sign of
-    /// `y`.
+    /// `sign`.
     ///
-    /// Equal to `self` if the sign of `self` and `y` are the same, otherwise
+    /// Equal to `self` if the sign of `self` and `sign` are the same, otherwise
     /// equal to `-self`. If `self` is a `NAN`, then a `NAN` with the sign of
-    /// `y` is returned.
+    /// `sign` is returned.
     ///
     /// # Examples
     ///
@@ -216,8 +216,8 @@ impl f32 {
     #[inline]
     #[must_use]
     #[stable(feature = "copysign", since = "1.35.0")]
-    pub fn copysign(self, y: f32) -> f32 {
-        unsafe { intrinsics::copysignf32(self, y) }
+    pub fn copysign(self, sign: f32) -> f32 {
+        unsafe { intrinsics::copysignf32(self, sign) }
     }
 
     /// Fused multiply-add. Computes `(self * a) + b` with only one rounding

--- a/src/libstd/f64.rs
+++ b/src/libstd/f64.rs
@@ -171,11 +171,11 @@ impl f64 {
     }
 
     /// Returns a number composed of the magnitude of `self` and the sign of
-    /// `y`.
+    /// `sign`.
     ///
-    /// Equal to `self` if the sign of `self` and `y` are the same, otherwise
+    /// Equal to `self` if the sign of `self` and `sign` are the same, otherwise
     /// equal to `-self`. If `self` is a `NAN`, then a `NAN` with the sign of
-    /// `y` is returned.
+    /// `sign` is returned.
     ///
     /// # Examples
     ///
@@ -194,8 +194,8 @@ impl f64 {
     #[inline]
     #[must_use]
     #[stable(feature = "copysign", since = "1.35.0")]
-    pub fn copysign(self, y: f64) -> f64 {
-        unsafe { intrinsics::copysignf64(self, y) }
+    pub fn copysign(self, sign: f64) -> f64 {
+        unsafe { intrinsics::copysignf64(self, sign) }
     }
 
     /// Fused multiply-add. Computes `(self * a) + b` with only one rounding


### PR DESCRIPTION
This should help clarify ambiguity with whether `a.copysign(b)` applies the sign of `a` to `b` or `b` to `a`.

r? @Centril