### PR TITLE
Add summary and reference to Rust trademark guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,3 +261,15 @@ BSD-like licenses.
 
 See [LICENSE-APACHE](LICENSE-APACHE), [LICENSE-MIT](LICENSE-MIT), and
 [COPYRIGHT](COPYRIGHT) for details.
+
+## Trademark
+[trademark]: #trademark
+
+The Rust programming language is an open source, community project governed
+by a core team. It is also sponsored by the Mozilla Foundation (“Mozilla”),
+which owns and protects the Rust and Cargo trademarks and logos
+(the “Rust Trademarks”).
+
+If you want to use these names or brands, please read the [media guide][media-guide].
+
+[media-guide]: https://www.rust-lang.org/policies/media-guide

--- a/README.md
+++ b/README.md
@@ -272,4 +272,8 @@ which owns and protects the Rust and Cargo trademarks and logos
 
 If you want to use these names or brands, please read the [media guide][media-guide].
 
+Third-party logos may be subject to third-party copyrights and trademarks. See
+[Licenses][policies-licenses] for details.
+
 [media-guide]: https://www.rust-lang.org/policies/media-guide
+[policies-licenses]: https://www.rust-lang.org/policies/licenses


### PR DESCRIPTION
Fix #53287 
cc @steveklabnik 