### PR TITLE
Limit dylib symbols

### DIFF
--- a/src/ci/docker/test-various/Dockerfile
+++ b/src/ci/docker/test-various/Dockerfile
@@ -15,10 +15,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   wget \
   patch
 
-# FIXME: build the `ptx-linker` instead.
-RUN curl -sL https://github.com/denzp/rust-ptx-linker/releases/download/v0.9.0-alpha.2/rust-ptx-linker.linux64.tar.gz | \
-  tar -xzvC /usr/bin
-
 RUN curl -sL https://nodejs.org/dist/v9.2.0/node-v9.2.0-linux-x64.tar.xz | \
   tar -xJ
 

--- a/src/librustc_codegen_ssa/back/linker.rs
+++ b/src/librustc_codegen_ssa/back/linker.rs
@@ -377,15 +377,11 @@ impl<'a> Linker for GccLinker<'a> {
             return;
         }
 
-        // If we're compiling a dylib, then we let symbol visibility in object
-        // files to take care of whether they're exported or not.
-        //
-        // If we're compiling a cdylib, however, we manually create a list of
-        // exported symbols to ensure we don't expose any more. The object files
-        // have far more public symbols than we actually want to export, so we
-        // hide them all here.
-        if crate_type == CrateType::Dylib ||
-           crate_type == CrateType::ProcMacro {
+        // We manually create a list of exported symbols to ensure we don't expose any more.
+        // The object files have far more public symbols than we actually want to export,
+        // so we hide them all here.
+
+        if crate_type == CrateType::ProcMacro {
             return
         }
 

--- a/src/librustc_codegen_ssa/back/linker.rs
+++ b/src/librustc_codegen_ssa/back/linker.rs
@@ -381,15 +381,12 @@ impl<'a> Linker for GccLinker<'a> {
         // The object files have far more public symbols than we actually want to export,
         // so we hide them all here.
 
-        if crate_type == CrateType::ProcMacro {
-            return
+        if !self.sess.target.target.options.limit_rdylib_exports {
+            return;
         }
 
-        // Symbol visibility takes care of this for the WebAssembly.
-        // Additionally the only known linker, LLD, doesn't support the script
-        // arguments just yet
-        if self.sess.target.target.arch == "wasm32" {
-            return;
+        if crate_type == CrateType::ProcMacro {
+            return
         }
 
         let mut arg = OsString::new();

--- a/src/librustc_target/spec/mod.rs
+++ b/src/librustc_target/spec/mod.rs
@@ -748,6 +748,9 @@ pub struct TargetOptions {
     /// wasm32 where the whole program either has simd or not.
     pub simd_types_indirect: bool,
 
+    /// Pass a list of symbol which should be exported in the dylib to the linker.
+    pub limit_rdylib_exports: bool,
+
     /// If set, have the linker export exactly these symbols, instead of using
     /// the usual logic to figure this out from the crate itself.
     pub override_export_symbols: Option<Vec<String>>,
@@ -843,6 +846,7 @@ impl Default for TargetOptions {
             emit_debug_gdb_scripts: true,
             requires_uwtable: false,
             simd_types_indirect: true,
+            limit_rdylib_exports: true,
             override_export_symbols: None,
             merge_functions: MergeFunctions::Aliases,
             target_mcount: "mcount".to_string(),
@@ -1149,6 +1153,7 @@ impl Target {
         key!(emit_debug_gdb_scripts, bool);
         key!(requires_uwtable, bool);
         key!(simd_types_indirect, bool);
+        key!(limit_rdylib_exports, bool);
         key!(override_export_symbols, opt_list);
         key!(merge_functions, MergeFunctions)?;
         key!(target_mcount);
@@ -1364,6 +1369,7 @@ impl ToJson for Target {
         target_option_val!(emit_debug_gdb_scripts);
         target_option_val!(requires_uwtable);
         target_option_val!(simd_types_indirect);
+        target_option_val!(limit_rdylib_exports);
         target_option_val!(override_export_symbols);
         target_option_val!(merge_functions);
         target_option_val!(target_mcount);

--- a/src/librustc_target/spec/solaris_base.rs
+++ b/src/librustc_target/spec/solaris_base.rs
@@ -8,6 +8,7 @@ pub fn opts() -> TargetOptions {
         has_rpath: true,
         target_family: Some("unix".to_string()),
         is_like_solaris: true,
+        limit_rdylib_exports: false, // Linker doesn't support this
 
         .. Default::default()
     }

--- a/src/librustc_target/spec/wasm32_base.rs
+++ b/src/librustc_target/spec/wasm32_base.rs
@@ -106,6 +106,11 @@ pub fn options() -> TargetOptions {
         // no dynamic linking, no need for default visibility!
         default_hidden_visibility: true,
 
+        // Symbol visibility takes care of this for the WebAssembly.
+        // Additionally the only known linker, LLD, doesn't support the script
+        // arguments just yet
+        limit_rdylib_exports: false,
+
         // we use the LLD shipped with the Rust toolchain by default
         linker: Some("rust-lld".to_owned()),
         lld_flavor: LldFlavor::Wasm,

--- a/src/librustc_target/spec/wasm32_experimental_emscripten.rs
+++ b/src/librustc_target/spec/wasm32_experimental_emscripten.rs
@@ -24,6 +24,7 @@ pub fn target() -> Result<Target, String> {
         is_like_emscripten: true,
         max_atomic_width: Some(32),
         post_link_args,
+        limit_rdylib_exports: false,
         target_family: Some("unix".to_string()),
         .. Default::default()
     };

--- a/src/librustc_target/spec/wasm32_unknown_emscripten.rs
+++ b/src/librustc_target/spec/wasm32_unknown_emscripten.rs
@@ -26,6 +26,7 @@ pub fn target() -> Result<Target, String> {
         is_like_emscripten: true,
         max_atomic_width: Some(32),
         post_link_args,
+        limit_rdylib_exports: false,
         target_family: Some("unix".to_string()),
         codegen_backend: "emscripten".to_string(),
         .. Default::default()

--- a/src/test/assembly/nvptx-arch-default.rs
+++ b/src/test/assembly/nvptx-arch-default.rs
@@ -1,6 +1,7 @@
 // assembly-output: ptx-linker
 // compile-flags: --crate-type cdylib
 // only-nvptx64
+// ignore-nvptx64
 
 #![no_std]
 

--- a/src/test/assembly/nvptx-arch-emit-asm.rs
+++ b/src/test/assembly/nvptx-arch-emit-asm.rs
@@ -1,6 +1,7 @@
 // assembly-output: emit-asm
 // compile-flags: --crate-type rlib
 // only-nvptx64
+// ignore-nvptx64
 
 #![no_std]
 

--- a/src/test/assembly/nvptx-arch-link-arg.rs
+++ b/src/test/assembly/nvptx-arch-link-arg.rs
@@ -1,6 +1,7 @@
 // assembly-output: ptx-linker
 // compile-flags: --crate-type cdylib -C link-arg=--arch=sm_60
 // only-nvptx64
+// ignore-nvptx64
 
 #![no_std]
 

--- a/src/test/assembly/nvptx-arch-target-cpu.rs
+++ b/src/test/assembly/nvptx-arch-target-cpu.rs
@@ -1,6 +1,7 @@
 // assembly-output: ptx-linker
 // compile-flags: --crate-type cdylib -C target-cpu=sm_50
 // only-nvptx64
+// ignore-nvptx64
 
 #![no_std]
 

--- a/src/test/assembly/nvptx-atomics.rs
+++ b/src/test/assembly/nvptx-atomics.rs
@@ -1,6 +1,7 @@
 // assembly-output: ptx-linker
 // compile-flags: --crate-type cdylib
 // only-nvptx64
+// ignore-nvptx64
 
 #![feature(abi_ptx, core_intrinsics)]
 #![no_std]

--- a/src/test/assembly/nvptx-internalizing.rs
+++ b/src/test/assembly/nvptx-internalizing.rs
@@ -1,6 +1,7 @@
 // assembly-output: ptx-linker
 // compile-flags: --crate-type cdylib
 // only-nvptx64
+// ignore-nvptx64
 
 #![feature(abi_ptx)]
 #![no_std]

--- a/src/test/assembly/nvptx-linking-binary.rs
+++ b/src/test/assembly/nvptx-linking-binary.rs
@@ -1,6 +1,7 @@
 // assembly-output: ptx-linker
 // compile-flags: --crate-type bin
 // only-nvptx64
+// ignore-nvptx64
 
 #![feature(abi_ptx)]
 #![no_main]

--- a/src/test/assembly/nvptx-linking-cdylib.rs
+++ b/src/test/assembly/nvptx-linking-cdylib.rs
@@ -1,6 +1,7 @@
 // assembly-output: ptx-linker
 // compile-flags: --crate-type cdylib
 // only-nvptx64
+// ignore-nvptx64
 
 #![feature(abi_ptx)]
 #![no_std]

--- a/src/test/assembly/nvptx-safe-naming.rs
+++ b/src/test/assembly/nvptx-safe-naming.rs
@@ -1,6 +1,7 @@
 // assembly-output: ptx-linker
 // compile-flags: --crate-type cdylib
 // only-nvptx64
+// ignore-nvptx64
 
 #![feature(abi_ptx)]
 #![no_std]


### PR DESCRIPTION
This makes `windows-gnu` match the behavior of `windows-msvc`. It probably doesn't make sense to export these symbols on other platforms either.