### PR TITLE
rust-doc: Always collapse all implementors in trait docs

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -2460,6 +2460,16 @@ if (!DOMTokenList.prototype.remove) {
         onEachLazy(main.getElementsByClassName("loading-content"), function(e) {
             e.remove();
         });
+
+        // Collapse all trait implementors before we show the main container.
+        // Otherwise, on big pages like std::iter::Iterator, showing the whole tree at once
+        // creates *MAMMOTH* reflow/repaint events that can block the main thread for 2+ seconds.
+        const implementors = document.getElementById('implementors-list');
+        if (implementors) {
+            onEachLazy(implementors.getElementsByClassName('collapse-toggle'), function(e) {
+               collapseDocs(e, 'hide');
+            });
+        }
         onEachLazy(main.childNodes, function(e) {
             // Unhide the actual content once loading is complete. Headers get
             // flex treatment for their horizontal layout, divs get block treatment


### PR DESCRIPTION
Some traits, like std::iter::Iterator, have many dozens of implementors. Given
that Iterator also has many methods, this results in positively monstrous DOM
trees that cause evne modern computers to choke for several seconds (and hang
the UI thread) while reflowing and repainting these massive trees.

Before showing the Implementors section, ensure all implementors are collapsed
so that only the name of the implementor shows up, and not the full list of all
implemented methods.

---

On my machine, this causes DOMContentLoaded event to fire in about 2.5s, rather than 4.5s. And it eliminates the mammoth Recalculate Style + Layout that stalls my browser for 2+ seconds on the std::iter::Iterator page.

r? @GuillaumeGomez 