### PR TITLE
compiletest normalization: preserve non-JSON lines such as ICEs

### DIFF
--- a/src/librustc_mir/interpret/validity.rs
+++ b/src/librustc_mir/interpret/validity.rs
@@ -353,7 +353,7 @@ impl<'rt, 'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>>
                 match self.ecx.memory.check_align(ptr, align) {
                     Ok(_) => {},
                     Err(err) => {
-                        error!("{:?} is not aligned to {:?}", ptr, align);
+                        info!("{:?} is not aligned to {:?}", ptr, align);
                         match err.kind {
                             InterpError::InvalidNullPointerUsage =>
                                 return validation_failure!("NULL reference", self.path),

--- a/src/test/run-pass/backtrace-debuginfo.rs
+++ b/src/test/run-pass/backtrace-debuginfo.rs
@@ -10,9 +10,11 @@
 // ignore-pretty issue #37195
 // ignore-cloudabi spawning processes is not supported
 // ignore-emscripten spawning processes is not supported
+// normalize-stderr-test ".*\n" -> ""
 
-// note that above `-opt-bisect-limit=0` is used to basically disable
-// optimizations
+// Note that above `-opt-bisect-limit=0` is used to basically disable
+// optimizations. It creates tons of output on stderr, hence we normalize
+// that away entirely.
 
 use std::env;
 

--- a/src/test/ui/conditional-compilation/cfg-arg-invalid-1.stderr
+++ b/src/test/ui/conditional-compilation/cfg-arg-invalid-1.stderr
@@ -1,0 +1,2 @@
+error: invalid `--cfg` argument: `a(b=c)` (expected `key` or `key="value"`)
+

--- a/src/test/ui/conditional-compilation/cfg-arg-invalid-2.stderr
+++ b/src/test/ui/conditional-compilation/cfg-arg-invalid-2.stderr
@@ -1,0 +1,2 @@
+error: invalid `--cfg` argument: `a{b}` (expected `key` or `key="value"`)
+

--- a/src/test/ui/conditional-compilation/cfg-arg-invalid-3.stderr
+++ b/src/test/ui/conditional-compilation/cfg-arg-invalid-3.stderr
@@ -1,0 +1,2 @@
+error: invalid `--cfg` argument: `a::b` (argument key must be an identifier)
+

--- a/src/test/ui/conditional-compilation/cfg-arg-invalid-4.stderr
+++ b/src/test/ui/conditional-compilation/cfg-arg-invalid-4.stderr
@@ -1,0 +1,2 @@
+error: invalid `--cfg` argument: `a(b)` (expected `key` or `key="value"`)
+

--- a/src/test/ui/conditional-compilation/cfg-arg-invalid-5.stderr
+++ b/src/test/ui/conditional-compilation/cfg-arg-invalid-5.stderr
@@ -1,0 +1,2 @@
+error: invalid `--cfg` argument: `a=10` (argument value must be a string)
+

--- a/src/test/ui/conditional-compilation/cfg-empty-codemap.stderr
+++ b/src/test/ui/conditional-compilation/cfg-empty-codemap.stderr
@@ -1,0 +1,2 @@
+error: invalid `--cfg` argument: `""` (expected `key` or `key="value"`)
+

--- a/src/test/ui/duplicate/dupe-symbols-7.rs
+++ b/src/test/ui/duplicate/dupe-symbols-7.rs
@@ -1,5 +1,9 @@
 //
 // error-pattern: entry symbol `main` defined multiple times
+
+// FIXME https://github.com/rust-lang/rust/issues/59774
+// normalize-stderr-test "thread.*panicked.*Metadata module not compiled.*\n" -> ""
+// normalize-stderr-test "note:.*RUST_BACKTRACE=1.*\n" -> ""
 #![allow(warnings)]
 
 #[no_mangle]

--- a/src/test/ui/duplicate/dupe-symbols-7.stderr
+++ b/src/test/ui/duplicate/dupe-symbols-7.stderr
@@ -1,5 +1,5 @@
 error: entry symbol `main` defined multiple times
-  --> $DIR/dupe-symbols-7.rs:6:1
+  --> $DIR/dupe-symbols-7.rs:10:1
    |
 LL | fn main(){}
    | ^^^^^^^^^^^

--- a/src/test/ui/huge-array-simple.rs
+++ b/src/test/ui/huge-array-simple.rs
@@ -1,6 +1,10 @@
 // error-pattern: too big for the current architecture
 
 // normalize-stderr-test "; \d+]" -> "; N]"
+
+// FIXME https://github.com/rust-lang/rust/issues/59774
+// normalize-stderr-test "thread.*panicked.*Metadata module not compiled.*\n" -> ""
+// normalize-stderr-test "note:.*RUST_BACKTRACE=1.*\n" -> ""
 #![allow(exceeding_bitshifts)]
 
 #[cfg(target_pointer_width = "64")]

--- a/src/test/ui/huge-array.rs
+++ b/src/test/ui/huge-array.rs
@@ -1,5 +1,9 @@
 // error-pattern:; 1518600000
 
+// FIXME https://github.com/rust-lang/rust/issues/59774
+// normalize-stderr-test "thread.*panicked.*Metadata module not compiled.*\n" -> ""
+// normalize-stderr-test "note:.*RUST_BACKTRACE=1.*\n" -> ""
+
 fn generic<T: Copy>(t: T) {
     let s: [T; 1518600000] = [t; 1518600000];
 }

--- a/src/test/ui/huge-enum.rs
+++ b/src/test/ui/huge-enum.rs
@@ -1,6 +1,10 @@
 // normalize-stderr-test "std::option::Option<\[u32; \d+\]>" -> "TYPE"
 // normalize-stderr-test "\[u32; \d+\]" -> "TYPE"
 
+// FIXME https://github.com/rust-lang/rust/issues/59774
+// normalize-stderr-test "thread.*panicked.*Metadata module not compiled.*\n" -> ""
+// normalize-stderr-test "note:.*RUST_BACKTRACE=1.*\n" -> ""
+
 #[cfg(target_pointer_width = "32")]
 fn main() {
     let big: Option<[u32; (1<<29)-1]> = None;

--- a/src/test/ui/huge-struct.rs
+++ b/src/test/ui/huge-struct.rs
@@ -2,6 +2,10 @@
 // normalize-stderr-test "S1M" -> "SXX"
 // error-pattern: too big for the current
 
+// FIXME https://github.com/rust-lang/rust/issues/59774
+// normalize-stderr-test "thread.*panicked.*Metadata module not compiled.*\n" -> ""
+// normalize-stderr-test "note:.*RUST_BACKTRACE=1.*\n" -> ""
+
 struct S32<T> {
     v0: T,
     v1: T,

--- a/src/test/ui/issues/issue-15919.rs
+++ b/src/test/ui/issues/issue-15919.rs
@@ -1,6 +1,10 @@
 // error-pattern: too big for the current architecture
 // normalize-stderr-test "\[usize; \d+\]" -> "[usize; N]"
 
+// FIXME https://github.com/rust-lang/rust/issues/59774
+// normalize-stderr-test "thread.*panicked.*Metadata module not compiled.*\n" -> ""
+// normalize-stderr-test "note:.*RUST_BACKTRACE=1.*\n" -> ""
+
 #[cfg(target_pointer_width = "32")]
 fn main() {
     let x = [0usize; 0xffff_ffff];

--- a/src/test/ui/issues/issue-17913.rs
+++ b/src/test/ui/issues/issue-17913.rs
@@ -1,6 +1,10 @@
 // normalize-stderr-test "\[&usize; \d+\]" -> "[&usize; N]"
 // error-pattern: too big for the current architecture
 
+// FIXME https://github.com/rust-lang/rust/issues/59774
+// normalize-stderr-test "thread.*panicked.*Metadata module not compiled.*\n" -> ""
+// normalize-stderr-test "note:.*RUST_BACKTRACE=1.*\n" -> ""
+
 #![feature(box_syntax)]
 
 #[cfg(target_pointer_width = "64")]

--- a/src/test/ui/issues/issue-56762.rs
+++ b/src/test/ui/issues/issue-56762.rs
@@ -1,4 +1,8 @@
 // only-x86_64
+
+// FIXME https://github.com/rust-lang/rust/issues/59774
+// normalize-stderr-test "thread.*panicked.*Metadata module not compiled.*\n" -> ""
+// normalize-stderr-test "note:.*RUST_BACKTRACE=1.*\n" -> ""
 const HUGE_SIZE: usize = !0usize / 8;
 
 

--- a/src/test/ui/linkage2.rs
+++ b/src/test/ui/linkage2.rs
@@ -1,3 +1,7 @@
+// FIXME https://github.com/rust-lang/rust/issues/59774
+// normalize-stderr-test "thread.*panicked.*Metadata module not compiled.*\n" -> ""
+// normalize-stderr-test "note:.*RUST_BACKTRACE=1.*\n" -> ""
+
 #![feature(linkage)]
 
 extern {

--- a/src/test/ui/linkage2.stderr
+++ b/src/test/ui/linkage2.stderr
@@ -1,5 +1,5 @@
 error: must have type `*const T` or `*mut T`
-  --> $DIR/linkage2.rs:4:32
+  --> $DIR/linkage2.rs:8:32
    |
 LL |     #[linkage = "extern_weak"] static foo: i32;
    |                                ^^^^^^^^^^^^^^^^

--- a/src/test/ui/linkage3.rs
+++ b/src/test/ui/linkage3.rs
@@ -1,3 +1,7 @@
+// FIXME https://github.com/rust-lang/rust/issues/59774
+// normalize-stderr-test "thread.*panicked.*Metadata module not compiled.*\n" -> ""
+// normalize-stderr-test "note:.*RUST_BACKTRACE=1.*\n" -> ""
+
 #![feature(linkage)]
 
 extern {

--- a/src/test/ui/linkage3.stderr
+++ b/src/test/ui/linkage3.stderr
@@ -1,5 +1,5 @@
 error: invalid linkage specified
-  --> $DIR/linkage3.rs:4:24
+  --> $DIR/linkage3.rs:8:24
    |
 LL |     #[linkage = "foo"] static foo: *const i32;
    |                        ^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/pattern/const-pat-ice.rs
+++ b/src/test/ui/pattern/const-pat-ice.rs
@@ -1,5 +1,7 @@
 // failure-status: 101
 // rustc-env:RUST_BACKTRACE=0
+// normalize-stderr-test "note: rustc 1.* running on .*" -> "note: rustc VERSION running on TARGET"
+// normalize-stderr-test "note: compiler flags: .*" -> "note: compiler flags: FLAGS"
 
 // This is a repro test for an ICE in our pattern handling of constants.
 

--- a/src/test/ui/pattern/const-pat-ice.stderr
+++ b/src/test/ui/pattern/const-pat-ice.stderr
@@ -1,0 +1,13 @@
+thread 'rustc' panicked at 'assertion failed: rows.iter().all(|r| r.len() == v.len())', src/librustc_mir/hair/pattern/_match.rs:1069:5
+note: Run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
+
+error: internal compiler error: unexpected panic
+
+note: the compiler unexpectedly panicked. this is a bug.
+
+note: we would appreciate a bug report: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md#bug-reports
+
+note: rustc 1.35.0-dev running on x86_64-unknown-linux-gnu
+
+note: compiler flags: -Z threads=1 -Z ui-testing -Z unstable-options -C prefer-dynamic -C rpath
+

--- a/src/test/ui/pattern/const-pat-ice.stderr
+++ b/src/test/ui/pattern/const-pat-ice.stderr
@@ -7,7 +7,7 @@ note: the compiler unexpectedly panicked. this is a bug.
 
 note: we would appreciate a bug report: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md#bug-reports
 
-note: rustc 1.35.0-dev running on x86_64-unknown-linux-gnu
+note: rustc VERSION running on TARGET
 
-note: compiler flags: -Z threads=1 -Z ui-testing -Z unstable-options -C prefer-dynamic -C rpath
+note: compiler flags: FLAGS
 

--- a/src/test/ui/proc-macro/invalid-punct-ident-1.rs
+++ b/src/test/ui/proc-macro/invalid-punct-ident-1.rs
@@ -1,5 +1,9 @@
 // aux-build:invalid-punct-ident.rs
 
+// FIXME https://github.com/rust-lang/rust/issues/59998
+// normalize-stderr-windows "thread.*panicked.*proc_macro_server.rs.*\n" -> ""
+// normalize-stderr-windows "note:.*RUST_BACKTRACE=1.*\n" -> ""
+
 #[macro_use]
 extern crate invalid_punct_ident;
 

--- a/src/test/ui/proc-macro/invalid-punct-ident-1.rs
+++ b/src/test/ui/proc-macro/invalid-punct-ident-1.rs
@@ -1,8 +1,8 @@
 // aux-build:invalid-punct-ident.rs
 
 // FIXME https://github.com/rust-lang/rust/issues/59998
-// normalize-stderr-windows "thread.*panicked.*proc_macro_server.rs.*\n" -> ""
-// normalize-stderr-windows "note:.*RUST_BACKTRACE=1.*\n" -> ""
+// normalize-stderr-test "thread.*panicked.*proc_macro_server.rs.*\n" -> ""
+// normalize-stderr-test "note:.*RUST_BACKTRACE=1.*\n" -> ""
 
 #[macro_use]
 extern crate invalid_punct_ident;

--- a/src/test/ui/proc-macro/invalid-punct-ident-1.stderr
+++ b/src/test/ui/proc-macro/invalid-punct-ident-1.stderr
@@ -1,5 +1,5 @@
 error: proc macro panicked
-  --> $DIR/invalid-punct-ident-1.rs:6:1
+  --> $DIR/invalid-punct-ident-1.rs:10:1
    |
 LL | invalid_punct!();
    | ^^^^^^^^^^^^^^^^^

--- a/src/test/ui/proc-macro/invalid-punct-ident-2.rs
+++ b/src/test/ui/proc-macro/invalid-punct-ident-2.rs
@@ -1,5 +1,9 @@
 // aux-build:invalid-punct-ident.rs
 
+// FIXME https://github.com/rust-lang/rust/issues/59998
+// normalize-stderr-windows "thread.*panicked.*proc_macro_server.rs.*\n" -> ""
+// normalize-stderr-windows "note:.*RUST_BACKTRACE=1.*\n" -> ""
+
 #[macro_use]
 extern crate invalid_punct_ident;
 

--- a/src/test/ui/proc-macro/invalid-punct-ident-2.rs
+++ b/src/test/ui/proc-macro/invalid-punct-ident-2.rs
@@ -1,8 +1,8 @@
 // aux-build:invalid-punct-ident.rs
 
 // FIXME https://github.com/rust-lang/rust/issues/59998
-// normalize-stderr-windows "thread.*panicked.*proc_macro_server.rs.*\n" -> ""
-// normalize-stderr-windows "note:.*RUST_BACKTRACE=1.*\n" -> ""
+// normalize-stderr-test "thread.*panicked.*proc_macro_server.rs.*\n" -> ""
+// normalize-stderr-test "note:.*RUST_BACKTRACE=1.*\n" -> ""
 
 #[macro_use]
 extern crate invalid_punct_ident;

--- a/src/test/ui/proc-macro/invalid-punct-ident-2.stderr
+++ b/src/test/ui/proc-macro/invalid-punct-ident-2.stderr
@@ -1,5 +1,5 @@
 error: proc macro panicked
-  --> $DIR/invalid-punct-ident-2.rs:6:1
+  --> $DIR/invalid-punct-ident-2.rs:10:1
    |
 LL | invalid_ident!();
    | ^^^^^^^^^^^^^^^^^

--- a/src/test/ui/proc-macro/invalid-punct-ident-3.rs
+++ b/src/test/ui/proc-macro/invalid-punct-ident-3.rs
@@ -1,5 +1,9 @@
 // aux-build:invalid-punct-ident.rs
 
+// FIXME https://github.com/rust-lang/rust/issues/59998
+// normalize-stderr-windows "thread.*panicked.*proc_macro_server.rs.*\n" -> ""
+// normalize-stderr-windows "note:.*RUST_BACKTRACE=1.*\n" -> ""
+
 #[macro_use]
 extern crate invalid_punct_ident;
 

--- a/src/test/ui/proc-macro/invalid-punct-ident-3.rs
+++ b/src/test/ui/proc-macro/invalid-punct-ident-3.rs
@@ -1,8 +1,8 @@
 // aux-build:invalid-punct-ident.rs
 
 // FIXME https://github.com/rust-lang/rust/issues/59998
-// normalize-stderr-windows "thread.*panicked.*proc_macro_server.rs.*\n" -> ""
-// normalize-stderr-windows "note:.*RUST_BACKTRACE=1.*\n" -> ""
+// normalize-stderr-test "thread.*panicked.*proc_macro_server.rs.*\n" -> ""
+// normalize-stderr-test "note:.*RUST_BACKTRACE=1.*\n" -> ""
 
 #[macro_use]
 extern crate invalid_punct_ident;

--- a/src/test/ui/proc-macro/invalid-punct-ident-3.stderr
+++ b/src/test/ui/proc-macro/invalid-punct-ident-3.stderr
@@ -1,5 +1,5 @@
 error: proc macro panicked
-  --> $DIR/invalid-punct-ident-3.rs:6:1
+  --> $DIR/invalid-punct-ident-3.rs:10:1
    |
 LL | invalid_raw_ident!();
    | ^^^^^^^^^^^^^^^^^^^^^

--- a/src/tools/compiletest/src/json.rs
+++ b/src/tools/compiletest/src/json.rs
@@ -78,7 +78,8 @@ pub fn extract_rendered(output: &str, proc_res: &ProcRes) -> String {
                     }
                 }
             } else {
-                None
+                // preserve non-JSON lines, such as ICEs
+                Some(format!("{}\n", line))
             }
         })
         .collect()


### PR DESCRIPTION
Currently, every non-JSON line from stderr gets normalized away when compiletest normalizes the output. In particular, ICEs get normalized to the empty output. That does not seem desirable, so this changes normalization to preserve non-JSON lines instead.

Also see https://github.com/laumann/compiletest-rs/issues/169: because of that bug, Miri currently *looks* green in the toolstate, but some tests ICE. That same bug is likely no longer present in latest compiletest because the error code gets checked separately, but it still seems like a good idea to also make sure that ICEs are considered stderr output:
This change found an accidental user-visible `error!` in CTFE validation (fixed), and a non-deterministic panic when there are two `main` symbols (not fixed, no idea where this comes from). Both got missed before because non-JSON output got ignored.