### PR TITLE
ci: pin android emulator to 28.0.23

### DIFF
--- a/src/ci/docker/arm-android/Dockerfile
+++ b/src/ci/docker/arm-android/Dockerfile
@@ -23,7 +23,7 @@ RUN dpkg --add-architecture i386 && \
 
 COPY scripts/android-sdk.sh /scripts/
 RUN . /scripts/android-sdk.sh && \
-    download_and_create_avd 4333796 armeabi-v7a 18
+    download_and_create_avd 4333796 armeabi-v7a 18 5264690
 
 ENV PATH=$PATH:/android/sdk/emulator
 ENV PATH=$PATH:/android/sdk/tools

--- a/src/ci/docker/scripts/android-sdk.sh
+++ b/src/ci/docker/scripts/android-sdk.sh
@@ -20,9 +20,17 @@ download_sysimage() {
     # The output from sdkmanager is so noisy that it will occupy all of the 4 MB
     # log extremely quickly. Thus we must silence all output.
     yes | sdkmanager --licenses > /dev/null
-    yes | sdkmanager platform-tools emulator \
+    yes | sdkmanager platform-tools \
         "platforms;android-$api" \
         "system-images;android-$api;default;$abi" > /dev/null
+}
+
+download_emulator() {
+    # Download a pinned version of the emulator since upgrades can cause issues
+    curl -fo emulator.zip "https://dl.google.com/android/repository/emulator-linux-$1.zip"
+    rm -rf "${ANDROID_HOME}/emulator"
+    unzip -q emulator.zip -d "${ANDROID_HOME}"
+    rm -f emulator.zip
 }
 
 create_avd() {
@@ -40,11 +48,12 @@ download_and_create_avd() {
     download_sdk $1
     download_sysimage $2 $3
     create_avd $2 $3
+    download_emulator $4
 }
 
 # Usage:
 #
-#       setup_android_sdk 4333796 armeabi-v7a 18
+#       download_and_create_avd 4333796 armeabi-v7a 18 5264690
 #
 # 4333796 =>
 #   SDK tool version.
@@ -53,3 +62,6 @@ download_and_create_avd() {
 #   System image ABI
 # 18 =>
 #   Android API Level (18 = Android 4.3 = Jelly Bean MR2)
+# 5264690 =>
+#   Android Emulator version.
+#   Copy from the "build_id" in the `/android/sdk/emulator/emulator -version` output


### PR DESCRIPTION
Apparently Android Emulator 28.0.25 (the latest one) is broken for us, and `sdkmanager` doesn't have a way to pin a package to a specific version. This PR stops downloading the emulator from `sdkmanager`, downloading it manually instead.

Tested this locally and confirmed it works. I'll open an issue on Google's issue tracker later today.

Fixes https://github.com/rust-lang/rust/issues/59757  
