### PR TITLE
-Z call-metadata: add call metadata to LLVM IR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2597,6 +2597,7 @@ dependencies = [
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_llvm 0.0.0",
+ "smallvec 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/src/librustc/cg.rs
+++ b/src/librustc/cg.rs
@@ -1,0 +1,160 @@
+//! Call graph metadata
+
+use crate::hir::def_id::{DefId, LOCAL_CRATE};
+use crate::ty::subst::SubstsRef;
+use crate::ty::{
+    ExistentialTraitRef, Instance, InstanceDef, ParamEnv, PolyTraitRef, TraitRef, Ty, TyCtxt,
+};
+use crate::mir::interpret::{AllocKind, Allocation};
+
+use rustc_data_structures::fx::{FxHashMap, FxHashSet};
+use rustc_macros::HashStable;
+
+use std::sync::Arc;
+
+/// Call graph metadata loaded from an external crate
+#[derive(HashStable)]
+pub struct ExternCallGraphMetadata<'tcx> {
+    /// list of functions casted / coerced into function pointers
+    pub function_pointers: Vec<(DefId, SubstsRef<'tcx>)>,
+
+    /// list of types casted / coerced into trait objects
+    pub trait_objects: Vec<TraitRef<'tcx>>,
+
+    /// list of types whose drop glue may be invoked by trait object drop glue
+    pub dynamic_drop_glue: Vec<(Ty<'tcx>, Vec<ExistentialTraitRef<'tcx>>)>,
+}
+
+impl<'tcx> ExternCallGraphMetadata<'tcx> {
+    pub fn empty() -> Self {
+        ExternCallGraphMetadata {
+            function_pointers: vec![],
+            trait_objects: vec![],
+            dynamic_drop_glue: vec![],
+        }
+    }
+}
+
+/// Local call graph metadata
+#[derive(Clone, Default, HashStable)]
+pub struct LocalCallGraphMetadata<'tcx> {
+    /// list of functions casted / coerced into function pointers
+    pub function_pointers: FxHashSet<(DefId, SubstsRef<'tcx>)>,
+
+    /// list of types casted / coerced into trait objects
+    pub trait_objects: FxHashSet<TraitRef<'tcx>>,
+
+    /// list of types whose drop glue may be invoked by trait object drop glue
+    pub dynamic_drop_glue: FxHashMap<Ty<'tcx>, FxHashSet<ExistentialTraitRef<'tcx>>>,
+}
+
+impl<'tcx> LocalCallGraphMetadata<'tcx> {
+    /// Registers `alloc` as a const-evaluated trait object
+    ///
+    /// Returns `false` if `alloc` was *not* a trait object
+    pub fn register_const_trait_object(&mut self,
+                                       tcx: TyCtxt<'a, 'tcx, 'tcx>,
+                                       alloc: &'tcx Allocation) -> bool {
+        let has_drop_glue = alloc.relocations.values().any(|(_, inner)| {
+            let kind = tcx.alloc_map.lock().get(*inner);
+
+            if let Some(AllocKind::Function(instance)) = kind {
+                if let InstanceDef::DropGlue(..) = instance.def {
+                    return true;
+                }
+            }
+
+            false
+        });
+
+        if has_drop_glue {
+            for (_, inner) in alloc.relocations.values() {
+                let kind = tcx.alloc_map.lock().get(*inner);
+
+                if let Some(AllocKind::Function(method)) = kind {
+                    self.register_dynamic_dispatch(tcx, method);
+                } else {
+                    bug!("unexpected `AllocKind`: {:?}", kind);
+                }
+            }
+        }
+
+        has_drop_glue
+    }
+
+    /// Registers that `method` is dynamically dispatched
+    pub fn register_dynamic_dispatch(&mut self,
+                                     tcx: TyCtxt<'a, 'tcx, 'tcx>,
+                                     method: Instance<'tcx>) {
+        if let Some((trait_ref, _)) = method.trait_ref_and_method(tcx) {
+            self.trait_objects.insert(trait_ref);
+        }
+    }
+
+    /// Registers that `function` is casted / coerced into a function pointer
+    pub fn register_function_pointer(&mut self, function: Instance<'tcx>) {
+        self.function_pointers.insert((function.def_id(), function.substs));
+    }
+
+    /// Registers that `poly_trait_ref` is used as a trait object
+    pub fn register_trait_object(&mut self,
+                                 tcx: TyCtxt<'a, 'tcx, 'tcx>,
+                                 poly_trait_ref: PolyTraitRef<'tcx>) {
+        let trait_ref = tcx.normalize_erasing_late_bound_regions(
+            ParamEnv::reveal_all(),
+            &poly_trait_ref,
+        );
+
+        self.trait_objects.insert(trait_ref);
+
+        let self_ty = trait_ref.self_ty();
+        let existential_trait_ref = ExistentialTraitRef::erase_self_ty(tcx, trait_ref);
+
+        self.dynamic_drop_glue.entry(self_ty).or_default().insert(existential_trait_ref);
+    }
+
+    pub fn extend(&mut self, other: Self) {
+        self.function_pointers.extend(other.function_pointers);
+        self.trait_objects.extend(other.trait_objects);
+
+        for (ty, traits) in other.dynamic_drop_glue {
+            self.dynamic_drop_glue.entry(ty).or_default().extend(traits);
+        }
+    }
+}
+
+/// Local and external call graph metadata
+#[derive(HashStable)]
+pub struct AllCallGraphMetadata<'tcx> {
+    /// list of functions casted / coerced into function pointers
+    pub function_pointers: FxHashSet<(DefId, SubstsRef<'tcx>)>,
+
+    /// list of types casted / coerced into trait objects
+    pub trait_objects: FxHashSet<TraitRef<'tcx>>,
+
+    /// list of types whose drop glue may be invoked by trait object drop glue
+    pub dynamic_drop_glue: FxHashMap<Ty<'tcx>, Arc<FxHashSet<ExistentialTraitRef<'tcx>>>>,
+}
+
+pub fn collect<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) -> AllCallGraphMetadata<'tcx> {
+    let mut cg = (*tcx.local_call_graph_metadata(LOCAL_CRATE)).clone();
+
+    for &cnum in tcx.crates().iter() {
+        let ext = tcx.extern_call_graph_metadata(cnum);
+
+        cg.function_pointers.extend(ext.function_pointers.iter().cloned());
+        cg.trait_objects.extend(ext.trait_objects.iter().cloned());
+
+        for (ty, traits) in &ext.dynamic_drop_glue {
+            cg.dynamic_drop_glue.entry(*ty).or_default().extend(traits.iter().cloned());
+        }
+    }
+
+    AllCallGraphMetadata {
+        function_pointers: cg.function_pointers,
+        trait_objects: cg.trait_objects,
+        dynamic_drop_glue: cg.dynamic_drop_glue.into_iter().map(|(ty, traits)| {
+            (ty, Arc::new(traits))
+        }).collect(),
+    }
+}

--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -54,6 +54,30 @@ impl<'a, 'gcx, T> ToStableHashKey<StableHashingContext<'a>> for &'gcx ty::List<T
     }
 }
 
+impl<'a, 'tcx> ToStableHashKey<StableHashingContext<'a>> for ty::Instance<'tcx> {
+    type KeyType = Fingerprint;
+
+    #[inline]
+    fn to_stable_hash_key(&self, hcx: &StableHashingContext<'a>) -> Fingerprint {
+        let mut hasher = StableHasher::new();
+        let mut hcx: StableHashingContext<'a> = hcx.clone();
+        self.hash_stable(&mut hcx, &mut hasher);
+        hasher.finish()
+    }
+}
+
+impl<'a, 'tcx> ToStableHashKey<StableHashingContext<'a>> for ty::ExistentialTraitRef<'tcx> {
+    type KeyType = Fingerprint;
+
+    #[inline]
+    fn to_stable_hash_key(&self, hcx: &StableHashingContext<'a>) -> Fingerprint {
+        let mut hasher = StableHasher::new();
+        let mut hcx: StableHashingContext<'a> = hcx.clone();
+        self.hash_stable(&mut hcx, &mut hasher);
+        hasher.finish()
+    }
+}
+
 impl<'a, 'gcx> HashStable<StableHashingContext<'a>> for ty::subst::Kind<'gcx> {
     fn hash_stable<W: StableHasherResult>(&self,
                                           hcx: &mut StableHashingContext<'a>,

--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -2,6 +2,9 @@
 //! from rustc::ty in no particular order.
 
 use crate::ich::{Fingerprint, StableHashingContext, NodeIdHashingMode};
+use crate::hir::def_id::DefId;
+use crate::ty::Ty;
+use crate::ty::subst::SubstsRef;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::stable_hasher::{HashStable, ToStableHashKey,
                                            StableHasher, StableHasherResult};
@@ -54,7 +57,7 @@ impl<'a, 'gcx, T> ToStableHashKey<StableHashingContext<'a>> for &'gcx ty::List<T
     }
 }
 
-impl<'a, 'tcx> ToStableHashKey<StableHashingContext<'a>> for ty::Instance<'tcx> {
+impl<'a, 'tcx> ToStableHashKey<StableHashingContext<'a>> for ty::ExistentialTraitRef<'tcx> {
     type KeyType = Fingerprint;
 
     #[inline]
@@ -66,7 +69,31 @@ impl<'a, 'tcx> ToStableHashKey<StableHashingContext<'a>> for ty::Instance<'tcx> 
     }
 }
 
-impl<'a, 'tcx> ToStableHashKey<StableHashingContext<'a>> for ty::ExistentialTraitRef<'tcx> {
+impl<'a, 'tcx> ToStableHashKey<StableHashingContext<'a>> for ty::TraitRef<'tcx> {
+    type KeyType = Fingerprint;
+
+    #[inline]
+    fn to_stable_hash_key(&self, hcx: &StableHashingContext<'a>) -> Fingerprint {
+        let mut hasher = StableHasher::new();
+        let mut hcx: StableHashingContext<'a> = hcx.clone();
+        self.hash_stable(&mut hcx, &mut hasher);
+        hasher.finish()
+    }
+}
+
+impl<'a, 'tcx> ToStableHashKey<StableHashingContext<'a>> for (DefId, SubstsRef<'tcx>) {
+    type KeyType = Fingerprint;
+
+    #[inline]
+    fn to_stable_hash_key(&self, hcx: &StableHashingContext<'a>) -> Fingerprint {
+        let mut hasher = StableHasher::new();
+        let mut hcx: StableHashingContext<'a> = hcx.clone();
+        self.hash_stable(&mut hcx, &mut hasher);
+        hasher.finish()
+    }
+}
+
+impl<'a, 'tcx> ToStableHashKey<StableHashingContext<'a>> for Ty<'tcx> {
     type KeyType = Fingerprint;
 
     #[inline]

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -103,6 +103,7 @@ pub mod diagnostics;
 #[macro_use]
 pub mod query;
 
+pub mod cg;
 pub mod cfg;
 pub mod dep_graph;
 pub mod hir;

--- a/src/librustc/query/mod.rs
+++ b/src/librustc/query/mod.rs
@@ -893,7 +893,9 @@ rustc_queries! {
             desc { "checking if `{}` may be called via dynamic dispatch", instance }
         }
 
-        query drop_glue(instance: ty::Instance<'tcx>) -> Option<Arc<FxHashSet<ty::ExistentialTraitRef<'tcx>>>> {
+        query drop_glue(instance: ty::Instance<'tcx>) ->
+            Option<Arc<FxHashSet<ty::ExistentialTraitRef<'tcx>>>>
+        {
             no_force
             desc { "checking if `{}` may be called by a trait object destructor", instance }
         }

--- a/src/librustc/query/mod.rs
+++ b/src/librustc/query/mod.rs
@@ -861,8 +861,13 @@ rustc_queries! {
     }
 
     Codegen {
-        query collect_and_partition_mono_items(_: CrateNum)
-            -> (Arc<DefIdSet>, Arc<Vec<Arc<CodegenUnit<'tcx>>>>) {
+        query collect_and_partition_mono_items(_: CrateNum) -> (
+            Arc<DefIdSet>,
+            Arc<Vec<Arc<CodegenUnit<'tcx>>>>,
+            Arc<FxHashSet<ty::Instance<'tcx>>>,
+            Arc<FxHashSet<ty::Instance<'tcx>>>,
+            Arc<FxHashMap<ty::Instance<'tcx>, Arc<FxHashSet<ty::ExistentialTraitRef<'tcx>>>>>
+        ) {
             eval_always
             desc { "collect_and_partition_mono_items" }
         }
@@ -873,6 +878,24 @@ rustc_queries! {
         }
         query backend_optimization_level(_: CrateNum) -> OptLevel {
             desc { "optimization level used by backend" }
+        }
+
+        // -Z call-metadata
+        // functions that may be called via a function pointer
+        query function_pointer(instance: ty::Instance<'tcx>) -> bool {
+            no_force
+            desc { "checking if `{}` may be called via a function pointer", instance }
+        }
+
+        // trait methods that may be called via dynamic dispatch
+        query dynamic_dispatch(instance: ty::Instance<'tcx>) -> bool {
+            no_force
+            desc { "checking if `{}` may be called via dynamic dispatch", instance }
+        }
+
+        query drop_glue(instance: ty::Instance<'tcx>) -> Option<Arc<FxHashSet<ty::ExistentialTraitRef<'tcx>>>> {
+            no_force
+            desc { "checking if `{}` may be called by a trait object destructor", instance }
         }
     }
 

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -1444,6 +1444,8 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
          the same values as the target option of the same name"),
     allow_features: Option<Vec<String>> = (None, parse_opt_comma_list, [TRACKED],
         "only allow the listed language features to be enabled in code (space separated)"),
+    call_metadata: bool = (false, parse_bool, [UNTRACKED],
+                           "adds call metadata to LLVM IR"),
 }
 
 pub fn default_lib_output() -> CrateType {

--- a/src/librustc/ty/query/keys.rs
+++ b/src/librustc/ty/query/keys.rs
@@ -45,6 +45,16 @@ impl<'tcx> Key for ty::Instance<'tcx> {
     }
 }
 
+impl<'tcx> Key for ty::TraitRef<'tcx> {
+    fn query_crate(&self) -> CrateNum {
+        LOCAL_CRATE
+    }
+
+    fn default_span(&self, tcx: TyCtxt<'_, '_, '_>) -> Span {
+        tcx.def_span(self.def_id)
+    }
+}
+
 impl<'tcx> Key for mir::interpret::GlobalId<'tcx> {
     fn query_crate(&self) -> CrateNum {
         self.instance.query_crate()

--- a/src/librustc/ty/query/mod.rs
+++ b/src/librustc/ty/query/mod.rs
@@ -1,3 +1,4 @@
+use crate::cg;
 use crate::dep_graph::{self, DepNode};
 use crate::hir::def_id::{CrateNum, DefId, DefIndex};
 use crate::hir::def::{Def, Export};

--- a/src/librustc_codegen_llvm/Cargo.toml
+++ b/src/librustc_codegen_llvm/Cargo.toml
@@ -16,6 +16,7 @@ num_cpus = "1.0"
 rustc-demangle = "0.1.4"
 rustc_llvm = { path = "../librustc_llvm" }
 memmap = "0.6"
+smallvec = { version = "0.6.7", features = ["union", "may_dangle"] }
 
 [features]
 # This is used to convince Cargo to separately cache builds of `rustc_codegen_llvm`

--- a/src/librustc_codegen_llvm/callee.rs
+++ b/src/librustc_codegen_llvm/callee.rs
@@ -5,6 +5,7 @@
 //! closure.
 
 use crate::attributes;
+use crate::common;
 use crate::llvm;
 use crate::monomorphize::Instance;
 use crate::context::CodegenCx;
@@ -16,7 +17,7 @@ use rustc::ty::layout::{LayoutOf, HasTyCtxt};
 
 /// Codegens a reference to a fn/method item, monomorphizing and
 /// inlining as it goes.
-///
+//
 /// # Parameters
 ///
 /// - `cx`: the crate context
@@ -187,6 +188,12 @@ pub fn get_fn(
     };
 
     cx.instances.borrow_mut().insert(instance, llfn);
+
+    common::add_define_metadata(
+        cx,
+        instance,
+        llfn,
+    );
 
     llfn
 }

--- a/src/librustc_codegen_llvm/llvm/ffi.rs
+++ b/src/librustc_codegen_llvm/llvm/ffi.rs
@@ -1820,4 +1820,10 @@ extern "C" {
                              bytecode: *const c_char,
                              bytecode_len: usize) -> bool;
     pub fn LLVMRustLinkerFree(linker: &'a mut Linker<'a>);
+    pub fn LLVMRustCreateMDString(C: &'a Context, S: *const c_char) -> &'a Metadata;
+    pub fn LLVMRustCreateMDTuple(C: &'a Context,
+                                 Ptr: *const &'a Metadata,
+                                 Count: c_uint) -> &'a Metadata;
+    pub fn LLVMRustAddFunctionMetadata(Fn: &Value, Metadata: &Metadata);
+    pub fn LLVMRustAddInstructionMetadata(Instr: &Value, Metadata: &Metadata);
 }

--- a/src/librustc_codegen_llvm/llvm/mod.rs
+++ b/src/librustc_codegen_llvm/llvm/mod.rs
@@ -134,6 +134,30 @@ pub fn SetUnnamedAddr(global: &'a Value, unnamed: bool) {
     }
 }
 
+pub fn CreateMDString(llcx: &'a Context, s: &CStr) -> &'a Metadata {
+    unsafe {
+        LLVMRustCreateMDString(llcx, s.as_ptr())
+    }
+}
+
+pub fn CreateMDTuple(llcx: &'a Context, elems: &[&'a Metadata]) -> &'a Metadata {
+    unsafe {
+        LLVMRustCreateMDTuple(llcx, elems.as_ptr(), elems.len() as c_uint)
+    }
+}
+
+pub fn AddFunctionMetadata(llfn: &'a Value, meta: &'a Metadata) {
+    unsafe {
+        LLVMRustAddFunctionMetadata(llfn, meta)
+    }
+}
+
+pub fn AddInstructionMetadata(llfn: &'a Value, meta: &'a Metadata) {
+    unsafe {
+        LLVMRustAddInstructionMetadata(llfn, meta)
+    }
+}
+
 pub fn set_thread_local(global: &'a Value, is_thread_local: bool) {
     unsafe {
         LLVMSetThreadLocal(global, is_thread_local as Bool);

--- a/src/librustc_codegen_llvm/mono_item.rs
+++ b/src/librustc_codegen_llvm/mono_item.rs
@@ -1,5 +1,6 @@
 use crate::attributes;
 use crate::base;
+use crate::common;
 use crate::context::CodegenCx;
 use crate::llvm;
 use crate::monomorphize::Instance;
@@ -44,8 +45,11 @@ impl PreDefineMethods<'tcx> for CodegenCx<'ll, 'tcx> {
                 !instance.substs.has_param_types());
 
         let mono_sig = instance.fn_sig(self.tcx());
+
         let attrs = self.tcx.codegen_fn_attrs(instance.def_id());
         let lldecl = self.declare_fn(symbol_name, mono_sig);
+        common::add_define_metadata(self, instance, lldecl);
+
         unsafe { llvm::LLVMRustSetLinkage(lldecl, base::linkage_to_llvm(linkage)) };
         base::set_link_section(lldecl, &attrs);
         if linkage == Linkage::LinkOnceODR ||

--- a/src/librustc_codegen_ssa/back/symbol_export.rs
+++ b/src/librustc_codegen_ssa/back/symbol_export.rs
@@ -243,7 +243,7 @@ fn exported_symbols_provider_local<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         let need_visibility = tcx.sess.target.target.options.dynamic_linking &&
                               !tcx.sess.target.target.options.only_cdylib;
 
-        let (_, cgus) = tcx.collect_and_partition_mono_items(LOCAL_CRATE);
+        let (_, cgus, _, _, _) = tcx.collect_and_partition_mono_items(LOCAL_CRATE);
 
         for (mono_item, &(linkage, visibility)) in cgus.iter()
                                                        .flat_map(|cgu| cgu.items().iter()) {

--- a/src/librustc_codegen_ssa/back/symbol_export.rs
+++ b/src/librustc_codegen_ssa/back/symbol_export.rs
@@ -243,7 +243,7 @@ fn exported_symbols_provider_local<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         let need_visibility = tcx.sess.target.target.options.dynamic_linking &&
                               !tcx.sess.target.target.options.only_cdylib;
 
-        let (_, cgus, _, _, _) = tcx.collect_and_partition_mono_items(LOCAL_CRATE);
+        let (_, cgus, _) = tcx.collect_and_partition_mono_items(LOCAL_CRATE);
 
         for (mono_item, &(linkage, visibility)) in cgus.iter()
                                                        .flat_map(|cgu| cgu.items().iter()) {

--- a/src/librustc_codegen_ssa/base.rs
+++ b/src/librustc_codegen_ssa/base.rs
@@ -854,7 +854,7 @@ impl CrateInfo {
 }
 
 fn is_codegened_item(tcx: TyCtxt<'_, '_, '_>, id: DefId) -> bool {
-    let (all_mono_items, _, _, _, _) =
+    let (all_mono_items, _, _) =
         tcx.collect_and_partition_mono_items(LOCAL_CRATE);
     all_mono_items.contains(&id)
 }
@@ -879,7 +879,7 @@ pub fn provide_both(providers: &mut Providers<'_>) {
             config::OptLevel::SizeMin => config::OptLevel::Default,
         };
 
-        let (defids, _, _, _, _) = tcx.collect_and_partition_mono_items(cratenum);
+        let (defids, _, _) = tcx.collect_and_partition_mono_items(cratenum);
         for id in &*defids {
             let hir::CodegenFnAttrs { optimize, .. } = tcx.codegen_fn_attrs(*id);
             match optimize {

--- a/src/librustc_codegen_ssa/base.rs
+++ b/src/librustc_codegen_ssa/base.rs
@@ -854,7 +854,7 @@ impl CrateInfo {
 }
 
 fn is_codegened_item(tcx: TyCtxt<'_, '_, '_>, id: DefId) -> bool {
-    let (all_mono_items, _) =
+    let (all_mono_items, _, _, _, _) =
         tcx.collect_and_partition_mono_items(LOCAL_CRATE);
     all_mono_items.contains(&id)
 }
@@ -879,7 +879,7 @@ pub fn provide_both(providers: &mut Providers<'_>) {
             config::OptLevel::SizeMin => config::OptLevel::Default,
         };
 
-        let (defids, _) = tcx.collect_and_partition_mono_items(cratenum);
+        let (defids, _, _, _, _) = tcx.collect_and_partition_mono_items(cratenum);
         for id in &*defids {
             let hir::CodegenFnAttrs { optimize, .. } = tcx.codegen_fn_attrs(*id);
             match optimize {

--- a/src/librustc_codegen_ssa/lib.rs
+++ b/src/librustc_codegen_ssa/lib.rs
@@ -123,6 +123,7 @@ pub enum ModuleKind {
     Allocator,
 }
 
+/// Used by `-Z call-metadata` to add informational LLVM metadata that doesn't affect optimizations
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum CallKind<'tcx> {
     Direct,

--- a/src/librustc_codegen_ssa/lib.rs
+++ b/src/librustc_codegen_ssa/lib.rs
@@ -31,6 +31,7 @@
 use std::path::PathBuf;
 use rustc::dep_graph::WorkProduct;
 use rustc::session::config::{OutputFilenames, OutputType};
+use rustc::ty::ExistentialTraitRef;
 use rustc::middle::lang_items::LangItem;
 use rustc::hir::def_id::CrateNum;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
@@ -120,6 +121,14 @@ pub enum ModuleKind {
     Regular,
     Metadata,
     Allocator,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum CallKind<'tcx> {
+    Direct,
+    DropGlue(ExistentialTraitRef<'tcx>),
+    DynamicDispatch(ExistentialTraitRef<'tcx>, Symbol),
+    FnPtr,
 }
 
 bitflags::bitflags! {

--- a/src/librustc_codegen_ssa/mir/block.rs
+++ b/src/librustc_codegen_ssa/mir/block.rs
@@ -332,7 +332,9 @@ impl<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             ty::Dynamic(ref trait_data, _) => {
                 let principal = self.cx.tcx().normalize_erasing_late_bound_regions(
                     ty::ParamEnv::reveal_all(),
-                    &trait_data.principal().unwrap_or_else(|| bug!("trait object has no principal")),
+                    &trait_data.principal().unwrap_or_else(|| {
+                        bug!("trait object has no principal")
+                    }),
                 );
                 let sig = drop_fn.fn_sig(self.cx.tcx());
                 let sig = self.cx.tcx().normalize_erasing_late_bound_regions(

--- a/src/librustc_codegen_ssa/mir/block.rs
+++ b/src/librustc_codegen_ssa/mir/block.rs
@@ -1,5 +1,5 @@
 use rustc::middle::lang_items;
-use rustc::ty::{self, Ty, TypeFoldable, InstanceDef};
+use rustc::ty::{self, ExistentialTraitRef, Ty, TypeFoldable, InstanceDef};
 use rustc::ty::layout::{self, LayoutOf, HasTyCtxt};
 use rustc::mir::{self, Place, PlaceBase, Static, StaticKind};
 use rustc::mir::interpret::InterpError;
@@ -478,7 +478,9 @@ impl<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                                                      substs).unwrap();
                 let call_kind = if let InstanceDef::Virtual(..) = instance.def {
                     if let Some((trait_ref, method)) = instance.trait_ref_and_method(bx.tcx()) {
-                        CallKind::DynamicDispatch(trait_ref, method)
+                        let existential_trait_ref =
+                            ExistentialTraitRef::erase_self_ty(bx.tcx(), trait_ref);
+                        CallKind::DynamicDispatch(existential_trait_ref, method)
                     } else {
                         bug!("virtual instance is not a trait method {:?}", instance);
                     }

--- a/src/librustc_codegen_ssa/traits/abi.rs
+++ b/src/librustc_codegen_ssa/traits/abi.rs
@@ -1,3 +1,4 @@
+use crate::CallKind;
 use super::BackendTypes;
 use rustc::ty::{FnSig, Instance, Ty};
 use rustc_target::abi::call::FnType;
@@ -9,6 +10,9 @@ pub trait AbiMethods<'tcx> {
 }
 
 pub trait AbiBuilderMethods<'tcx>: BackendTypes {
-    fn apply_attrs_callsite(&mut self, ty: &FnType<'tcx, Ty<'tcx>>, callsite: Self::Value);
+    fn apply_attrs_callsite(&mut self,
+                            ty: &FnType<'tcx, Ty<'tcx>>,
+                            callsite: Self::Value,
+                            kind: CallKind<'tcx>);
     fn get_param(&self, index: usize) -> Self::Value;
 }

--- a/src/librustc_data_structures/stable_hasher.rs
+++ b/src/librustc_data_structures/stable_hasher.rs
@@ -298,6 +298,25 @@ impl<T1, T2, T3, T4, CTX> HashStable<CTX> for (T1, T2, T3, T4)
     }
 }
 
+impl<T1, T2, T3, T4, T5, CTX> HashStable<CTX> for (T1, T2, T3, T4, T5)
+    where T1: HashStable<CTX>,
+          T2: HashStable<CTX>,
+          T3: HashStable<CTX>,
+          T4: HashStable<CTX>,
+          T5: HashStable<CTX>,
+{
+    fn hash_stable<W: StableHasherResult>(&self,
+                                          ctx: &mut CTX,
+                                          hasher: &mut StableHasher<W>) {
+        let (ref _0, ref _1, ref _2, ref _3, ref _4) = *self;
+        _0.hash_stable(ctx, hasher);
+        _1.hash_stable(ctx, hasher);
+        _2.hash_stable(ctx, hasher);
+        _3.hash_stable(ctx, hasher);
+        _4.hash_stable(ctx, hasher);
+    }
+}
+
 impl<T: HashStable<CTX>, CTX> HashStable<CTX> for [T] {
     default fn hash_stable<W: StableHasherResult>(&self,
                                                   ctx: &mut CTX,

--- a/src/librustc_metadata/cstore_impl.rs
+++ b/src/librustc_metadata/cstore_impl.rs
@@ -250,6 +250,13 @@ provide! { <'tcx> tcx, def_id, other, cdata,
 
         Arc::new(cdata.exported_symbols(tcx))
     }
+
+    extern_call_graph_metadata => {
+        let cnum = cdata.cnum;
+        assert!(cnum != LOCAL_CRATE);
+
+        Lrc::new(cdata.get_call_graph_metadata(tcx))
+    }
 }
 
 pub fn provide<'tcx>(providers: &mut Providers<'tcx>) {

--- a/src/librustc_metadata/schema.rs
+++ b/src/librustc_metadata/schema.rs
@@ -201,6 +201,7 @@ pub struct CrateRoot {
     pub impls: LazySeq<TraitImpls>,
     pub exported_symbols: EncodedExportedSymbols,
     pub interpret_alloc_index: LazySeq<u32>,
+    pub call_graph_metadata: EncodedCallGraphMetadata,
 
     pub index: LazySeq<index::Index>,
 
@@ -582,4 +583,12 @@ pub const TAG_INVALID_SPAN: u8 = 1;
 pub struct EncodedExportedSymbols {
     pub position: usize,
     pub len: usize,
+}
+
+#[derive(RustcEncodable, RustcDecodable)]
+pub struct EncodedCallGraphMetadata {
+    // (`position`, `len`) for all fields
+    pub function_pointers: (usize, usize),
+    pub trait_objects: (usize, usize),
+    // FIXME(japaric) add dynamic_drop_glue
 }

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -1550,3 +1550,29 @@ extern "C" LLVMValueRef
 LLVMRustBuildMaxNum(LLVMBuilderRef B, LLVMValueRef LHS, LLVMValueRef RHS) {
     return wrap(unwrap(B)->CreateMaxNum(unwrap(LHS),unwrap(RHS)));
 }
+
+extern "C" LLVMMetadataRef
+LLVMRustCreateMDString(LLVMContextRef ContextRef, const char* S) {
+  LLVMContext &Context = *unwrap(ContextRef);
+  return wrap(MDString::get(Context, S));
+}
+
+extern "C" LLVMMetadataRef
+LLVMRustCreateMDTuple(LLVMContextRef ContextRef,
+                      LLVMMetadataRef *Ptr,
+                      unsigned Count) {
+  LLVMContext &Context = *unwrap(ContextRef);
+  return wrap(MDTuple::get(Context, makeArrayRef(unwrap(Ptr), Count)));
+}
+
+extern "C" void
+LLVMRustAddFunctionMetadata(LLVMValueRef Fn, LLVMMetadataRef Metadata) {
+  Function* F = unwrap<Function>(Fn);
+  F->setMetadata("rust", unwrap<MDNode>(Metadata));
+}
+
+extern "C" void
+LLVMRustAddInstructionMetadata(LLVMValueRef Instr, LLVMMetadataRef Metadata) {
+  Instruction* I = unwrap<Instruction>(Instr);
+  I->setMetadata("rust", unwrap<MDNode>(Metadata));
+}


### PR DESCRIPTION
This PR implements eRFC rust-lang/rust#59412 in spirit but there are some
differences between the implementation and the original proposal.

## What

Here's a summary of *what* the `-Z call-metadata` feature does:

1. Each function that:

- may be used as a function pointer,
- it's a method of a trait that may be dispatched dynamically,
- or may be called by trait object drop glue

receives a *single* `!rust` metadata node when translated into LLVM IR (turns
out you can't attach several `!rust` metadata nodes as I originally thought).
The node describes in which of those categories the function falls into (it may
belong to more than one category).

As an example consider this piece of code:

``` rust
fn foo() -> i32 {
    0
}

trait Bar<T> {
    fn bar(&self) -> T;
}

struct Baz;

impl Bar<bool> for Baz {
    fn bar(&self) -> bool {
        true
    }
}

impl Bar<i32> for Baz {
    fn bar(&self) -> i32 {
        0
    }
}

struct Quux;

impl Bar<i32> for Quux {
    fn bar(&self) -> i32 {
        1
    }
}

fn main() {
    let x: fn() -> i32 = foo;
    x();
    let y: fn(&Baz) -> bool = Baz::bar;

    let z: Box<dyn Bar<bool>> = Box::new(Baz);
    let a = z.bar();
    drop(z);
    let mut w: &dyn Bar<i32> = &Quux;
    w = &Baz;
    let b = w.bar();
}
```

Using the `-Z call-metadata` flag produces the following (unoptimized) IR:

> NOTE mangled names and debug metadata have been omitted to keep the IR short

``` llvm
; core::ptr::real_drop_in_place
define internal void @_(%Baz* nonnull align 1) unnamed_addr #4 !rust !180 {
  ; ..
}

; core::ptr::real_drop_in_place
define internal void @_(%Quux* nonnull align 1) unnamed_addr #4 !rust !190 {
  ; ..
}

; hello::foo
define internal i32 @_() unnamed_addr #4 !rust !363 {
  ; ..
}

; <hello::Baz as hello::Bar<bool>>::bar
define internal zeroext i1 @_(%Baz* noalias nonnull readonly align 1) unnamed_addr #4 !rust !370 {
  ; ..
}

; <hello::Baz as hello::Bar<i32>>::bar
define internal i32 @_(%Baz* noalias nonnull readonly align 1) unnamed_addr #4 !rust !377 {
  ; ..
}

; <hello::Quux as hello::Bar<i32>>::bar
define internal i32 @_(%Quux* noalias nonnull readonly align 1) unnamed_addr #4 !rust !377 {
  ; ..
}

!180 = !{!"drop", !"Bar<i32>", !"Bar<bool>"}
!190 = !{!"drop", !"Bar<i32>"}
!363 = !{!"fn", !"fn() -> i32"}
!370 = !{!"dyn", !"Bar<bool>", !"bar", !"fn", !"fn(&Baz) -> bool"}
!377 = !{!"dyn", !"Bar<i32>", !"bar"}
```

Functions that may be called via a function pointer receive metadata of the
form: `!"fn" !"fn() -> i32"`, where the second node is the signature of the
function. Example: `!363`

Trait methods that may be called via dynamic dispatch receive metadata of the
form: `!"dyn" !"Bar<bool>" !"bar"`, where the second node is a concrete trait
and the third node is the name of the method. Example: `!377`

Note that a single function can receive both `"fn"` and `"dyn"` metadata as
it's the case of `<Baz as Bar<i32>::bar` in the example above (`!370`).

Destructors that may be invoked by trait object drop glue receive metadata of
the form: `!"drop" !"Bar<i32>"`, where the second node is a concrete trait.
Example: `!180`

A single destructor may be invoked by different trait objects (because a type
can implement several traits); in that case the "drop" metadata will contain
one node for each trait, as it's the case of `Baz`'s destructor in the above
example (`!190`).

2. Indirect function calls will receive metadata at call site if they belong to
   any of these groups:

- Function pointer calls,
- Dynamic dispatch, or
- Trait object drop glue

Using our previous example, this is the part of the IR that shows the call site
metadata added by the `-Z call-metadata` flag:

``` llvm
; hello::main
define internal void @() unnamed_addr #0 {
  ; ..

  ; `x()`
  %1 = call i32 %0(), !rust !363

  ; ..

  ; `let a = z.bar();`
  %14 = invoke zeroext i1 %13({}* align 1 %8)
          to label %bb4 unwind label %cleanup, !db!rust !430

  ; ..

  ; `let b = w.bar();`
  %37 = invoke i32 %36({}* align 1 %31)
          to label %bb6 unwind label %cleanup, !rust !377

  ; ..

  ; `drop(z)`
  call void @_ZN4core3ptr18real_drop_in_place17h9dde6f5cdf273fbdE(..) #26

  ; ..
}

; this is `Box<dyn Bar<bool>>`'s destructor
; core::ptr::real_drop_in_place
define internal void @_ZN4core3ptr18real_drop_in_place17h9dde6f5cdf273fbdE(..) {
  ; ..

  ; `drop_in_place::<dyn Bar<bool>>(_)`
  invoke void %8({}* align 1 %3)
          to label %bb3 unwind label %cleanup, !rust !211

  ; ..
}

!211 = !{!"drop", !"Bar<bool>"}
!363 = !{!"fn", !"fn() -> i32"}
!377 = !{!"dyn", !"Bar<i32>", !"bar"}
!430 = !{!"dyn", !"Bar<bool>", !"bar"}
```

A function invocation may only belong to a single category. The syntax used for
call site metadata is as follows:

- `!"fn" "fn() -> i32"` for function pointer calls. The second node is the
  signature of the function being invoked. Example: `!363`

- `!"dyn" !"Bar<bool>" !"bar"` for dynamic dispatch. The second node is a
  concrete trait and the third node is the name of the method being dispatched.
  Examples: `!377` and `!430`

- `!"drop"` !"Bar<bool>" for drop glue. The second node is a concrete trait. In
  the case of call site "drop" metadata only a single trait will listed. Example: `!211`

## How

And here's a high level description of *how* the flag is implemented.

In the MIR monomorphize collector pass we take note of:

- Functions converted into function pointers. These occur in two places: in
  non-const context (e.g. `let x: fn() = foo`), and in const-context (`static X:
  fn() = foo`). These hit two different code paths in the compiler (while
  walking the MIR of functions and when looking into MIR values of static variables) but in
  both cases we keep track of which `Instance`s (`rustc` type used to track
  concrete functions) get converted into a function pointer in a `FxHashSet`.

- Traits that can get converted into trait objects. Again these occur in two
  places: non-const context (e.g. `let x: &dyn Foo = &Bar`) and in const-context
  (`static X: &'static dyn Foo = &Bar`). As in the previous bullet these hit two
  different code paths in the compiler but in both cases we keep track of *all
  methods (`Instance`s) that belong to these traits* in a `FxHashSet`.

- Drop glue of trait objects. While performing bullet 2 we also note down the
  types that implement traits that get converted into trait objects. In this
  case we store in the information in a `FxHashMap` that goes from the
  *implementer* destructor (the `Instance` e.g. `real_drop_inplace(&mut Bar)`)
  to the set of concrete traits (`ExistentialTraitRef`s) implemented by the
  implementer type (only the ones that get converted into trait objects).

(Now I realize that for the second bullet it would use less memory to keep
a set of `ExistentialTraitRef`s (traits) instead of a set of `Instance`s (trait
methods)).

Then in the LLVM codegen pass:

- When declaring functions (lowering them to `define` items in LLVM IR) we
  attach "define"-level metadata if the function (`Instance`) is in one of the
  sets / maps we previously collected. The functions get either "drop"
  metadata, a mixture of "dyn" and "fn" metadata or no `!rust` metadata.

- When lowering function invocations to `call` / `invoke` instructions we look up
  the callee (`Instance`) in the sets / maps we previously collected and if
  there's a match we add either "fn", "dyn" or "drop" metadata.

## TODO / questions

This doesn't fully work cross crate. Call site metadata is always complete, even
if the function being invoked comes from a different crate; and in the case of
LTO, invocations in functions defined in dependencies will also get call site
metadata. The "define"-level metadata, however, is incomplete; only functions
defined (or monomorphize) in the top crate get this kind of metadata.

To get complete "define"-level metadata I think we would have to store the call
metadata ("is this function converted into function pointer?", "is this trait
converted into a trait object?", etc.) in the rlib metadata (like we do for
types and traits). However, that would mean either (a) *always* building and
storing the call metadata, which would impact everyone's compile times and
increase rlib size, or (b) only storing the metadata when the `-Z call-metadata`
flag is used, which would worsen end-users' experience as they would need to
recompile `core` / `std` to get full information. If we do (b) we could compile
the `std` facade with `-Z call-metadata` so end users don't need to recompile it
themselves (which requires a tool like Xargo).

My gut feeling (and hope) is that always building and storing the extra maps /
sets won't have much impact on compile time given that it's the existing MIR
pass plus a few extra trait lookups and map/set insertions per indirect function
call. So perhaps we can always build and store the call metadata?

r? @eddyb or @oli-obk 