### PR TITLE
Uplift `get_def_path` from Clippy

### DIFF
--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -755,8 +755,31 @@ impl<'a, 'tcx> LateContext<'a, 'tcx> {
     }
 
     /// Check if a `DefId`'s path matches the given absolute type path usage.
+    ///
+    /// # Examples
+    /// ```rust,ignore (no `cx` or `def_id` available)
+    /// if cx.match_def_path(def_id, &["core", "option", "Option"]) {
+    ///     // The given `def_id` is that of an `Option` type
+    /// }
+    /// ```
     // Uplifted from rust-lang/rust-clippy
-    pub fn match_path(&self, def_id: DefId, path: &[&str]) -> bool {
+    pub fn match_def_path(&self, def_id: DefId, path: &[&str]) -> bool {
+        let names = self.get_def_path(def_id);
+
+        names.len() == path.len() && names.into_iter().zip(path.iter()).all(|(a, &b)| *a == *b)
+    }
+
+    /// Gets the absolute path of `def_id` as a vector of `&str`.
+    ///
+    /// # Examples
+    /// ```rust,ignore (no `cx` or `def_id` available)
+    /// let def_path = cx.get_def_path(def_id);
+    /// if let &["core", "option", "Option"] = &def_path[..] {
+    ///     // The given `def_id` is that of an `Option` type
+    /// }
+    /// ```
+    // Uplifted from rust-lang/rust-clippy
+    pub fn get_def_path(&self, def_id: DefId) -> Vec<LocalInternedString> {
         pub struct AbsolutePathPrinter<'a, 'tcx> {
             pub tcx: TyCtxt<'a, 'tcx, 'tcx>,
         }
@@ -856,10 +879,9 @@ impl<'a, 'tcx> LateContext<'a, 'tcx> {
             }
         }
 
-        let names = AbsolutePathPrinter { tcx: self.tcx }.print_def_path(def_id, &[]).unwrap();
-
-        names.len() == path.len()
-            && names.into_iter().zip(path.iter()).all(|(a, &b)| *a == *b)
+        AbsolutePathPrinter { tcx: self.tcx }
+            .print_def_path(def_id, &[])
+            .unwrap()
     }
 }
 

--- a/src/librustc/lint/internal.rs
+++ b/src/librustc/lint/internal.rs
@@ -100,7 +100,7 @@ fn lint_ty_kind_usage(cx: &LateContext<'_, '_>, segment: &PathSegment) -> bool {
     if segment.ident.as_str() == "TyKind" {
         if let Some(def) = segment.def {
             if let Some(did) = def.opt_def_id() {
-                return cx.match_path(did, &["rustc", "ty", "sty", "TyKind"]);
+                return cx.match_def_path(did, &["rustc", "ty", "sty", "TyKind"]);
             }
         }
     }


### PR DESCRIPTION
cc rust-lang/rust-clippy#3926
cc #59738 

This uplifts `get_def_path` from Clippy. This is a follow up on the
implementation of internal lints: #59316

The internal lint implementation also copied the implementation of the
`AbsolutePathPrinter`. To get rid of this code duplication this also
uplifts the `get_def_path` function from Clippy.

This also renames `match_path` to `match_def_path`, as it was originally
named in Clippy.

r? @Manishearth 