### PR TITLE
Remove check_match from const_eval

### DIFF
--- a/src/test/ui/issues/issue-23302-1.stderr
+++ b/src/test/ui/issues/issue-23302-1.stderr
@@ -5,7 +5,7 @@ LL |     A = X::A as isize,
    |         ^^^^^^^^^^^^^
    |
    = note: ...which again requires processing `X::A::{{constant}}#0`, completing the cycle
-note: cycle used when const-evaluating `X::A::{{constant}}#0`
+note: cycle used when processing `X::A::{{constant}}#0`
   --> $DIR/issue-23302-1.rs:4:9
    |
 LL |     A = X::A as isize,

--- a/src/test/ui/issues/issue-23302-2.stderr
+++ b/src/test/ui/issues/issue-23302-2.stderr
@@ -5,7 +5,7 @@ LL |     A = Y::B as isize,
    |         ^^^^^^^^^^^^^
    |
    = note: ...which again requires processing `Y::A::{{constant}}#0`, completing the cycle
-note: cycle used when const-evaluating `Y::A::{{constant}}#0`
+note: cycle used when processing `Y::A::{{constant}}#0`
   --> $DIR/issue-23302-2.rs:4:9
    |
 LL |     A = Y::B as isize,

--- a/src/test/ui/issues/issue-36163.stderr
+++ b/src/test/ui/issues/issue-36163.stderr
@@ -10,7 +10,7 @@ note: ...which requires processing `A`...
 LL | const A: isize = Foo::B as isize;
    |                  ^^^^^^^^^^^^^^^
    = note: ...which again requires processing `Foo::B::{{constant}}#0`, completing the cycle
-note: cycle used when const-evaluating `Foo::B::{{constant}}#0`
+note: cycle used when processing `Foo::B::{{constant}}#0`
   --> $DIR/issue-36163.rs:4:9
    |
 LL |     B = A,

--- a/src/test/ui/issues/issue-51714.rs
+++ b/src/test/ui/issues/issue-51714.rs
@@ -10,5 +10,4 @@ fn main() {
 
     [(); return while let Some(n) = Some(0) {}];
     //~^ ERROR return statement outside of function body
-    //~^^ WARN irrefutable while-let pattern
 }

--- a/src/test/ui/issues/issue-51714.stderr
+++ b/src/test/ui/issues/issue-51714.stderr
@@ -22,14 +22,6 @@ error[E0572]: return statement outside of function body
 LL |     [(); return while let Some(n) = Some(0) {}];
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: irrefutable while-let pattern
-  --> $DIR/issue-51714.rs:11:17
-   |
-LL |     [(); return while let Some(n) = Some(0) {}];
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: #[warn(irrefutable_let_patterns)] on by default
-
 error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0572`.


### PR DESCRIPTION
This fixes #59378. 

It seems that the `check_match` may be unnecessary, so this removes it per instructions provided in the issue. I re-ran the tests for `librustc_mir` and everything seemed fine! 