### PR TITLE
[WIP] rust case insensitive fs support

### DIFF
--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -198,6 +198,9 @@ pub struct RenderOptions {
     pub generate_search_filter: bool,
     /// Option (disabled by default) to generate files used by RLS and some other tools.
     pub generate_redirect_pages: bool,
+    /// Option (disabled by default) to generate file with names that won't crate conflicts
+    /// on case insensitive file systems.
+    pub case_insensitive: bool,
 }
 
 impl Options {
@@ -431,6 +434,7 @@ impl Options {
 
         let show_coverage = matches.opt_present("show-coverage");
         let document_private = matches.opt_present("document-private-items");
+        let case_insensitive = matches.opt_present("case-insensitive");
 
         let default_passes = if matches.opt_present("no-defaults") {
             passes::DefaultPassOption::None
@@ -508,6 +512,7 @@ impl Options {
                 markdown_playground_url,
                 generate_search_filter,
                 generate_redirect_pages,
+                case_insensitive,
             }
         })
     }

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -486,7 +486,7 @@ if (!DOMTokenList.prototype.remove) {
                             var res = buildHrefAndPath(obj);
                             obj.displayPath = pathSplitter(res[0]);
                             obj.fullPath = obj.displayPath + obj.name;
-                            // To be sure than it some items aren't considered as duplicate.
+                            // To be sure that some items aren't considered as duplicate.
                             obj.fullPath += "|" + obj.ty;
                             obj.href = res[1];
                             out.push(obj);
@@ -1269,14 +1269,15 @@ if (!DOMTokenList.prototype.remove) {
             var href;
             var type = itemTypes[item.ty];
             var name = item.name;
+            var path = item.alternative_path || item.path;
 
             if (type === "mod") {
-                displayPath = item.path + "::";
-                href = rootPath + item.path.replace(/::/g, "/") + "/" +
+                displayPath = path + "::";
+                href = rootPath + path.replace(/::/g, "/") + "/" +
                        name + "/index.html";
             } else if (type === "primitive" || type === "keyword") {
                 displayPath = "";
-                href = rootPath + item.path.replace(/::/g, "/") +
+                href = rootPath + path.replace(/::/g, "/") +
                        "/" + type + "." + name + ".html";
             } else if (type === "externcrate") {
                 displayPath = "";
@@ -1288,15 +1289,15 @@ if (!DOMTokenList.prototype.remove) {
                 if (parentType === "primitive") {
                     displayPath = myparent.name + "::";
                 } else {
-                    displayPath = item.path + "::" + myparent.name + "::";
+                    displayPath = path + "::" + myparent.name + "::";
                 }
-                href = rootPath + item.path.replace(/::/g, "/") +
+                href = rootPath + path.replace(/::/g, "/") +
                        "/" + parentType +
                        "." + myparent.name +
                        ".html" + anchor;
             } else {
-                displayPath = item.path + "::";
-                href = rootPath + item.path.replace(/::/g, "/") +
+                displayPath = path + "::";
+                href = rootPath + path.replace(/::/g, "/") +
                        "/" + type + "." + name + ".html";
             }
             return [displayPath, href];
@@ -1593,7 +1594,8 @@ if (!DOMTokenList.prototype.remove) {
                     var rawRow = items[i];
                     var row = {crate: crate, ty: rawRow[0], name: rawRow[1],
                                path: rawRow[2] || lastPath, desc: rawRow[3],
-                               parent: paths[rawRow[4]], type: rawRow[5]};
+                               parent: paths[rawRow[4]], type: rawRow[5],
+                               alternative_path: rawRow[6]};
                     searchIndex.push(row);
                     if (typeof row.name === "string") {
                         var word = row.name.toLowerCase();

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -355,6 +355,11 @@ fn opts() -> Vec<RustcOptGroup> {
                       "show-coverage",
                       "calculate percentage of public items with documentation")
         }),
+        unstable("case-insensitive", |o| {
+            o.optflag("",
+                      "case-insensitive",
+                      "Generate files with taking into account case insensitive file system")
+        }),
     ]
 }
 


### PR DESCRIPTION
This PR aims the support for case insensitive file systems in such cases:

```rust
pub struct FoO;
pub struct Foo;
```

I now need people to take a look and look for bugs that I'd have missed (windows' users would be very cool!).

I plan on adding the code sample above as a test but that seems a bit limited compared to the amount of code there is...

r? @QuietMisdreavus 