### PR TITLE
Kill dead code dominator code.

### DIFF
--- a/src/librustc_data_structures/graph/dominators/mod.rs
+++ b/src/librustc_data_structures/graph/dominators/mod.rs
@@ -8,8 +8,6 @@ use super::super::indexed_vec::{Idx, IndexVec};
 use super::iterate::reverse_post_order;
 use super::ControlFlowGraph;
 
-use std::fmt;
-
 #[cfg(test)]
 mod test;
 
@@ -156,50 +154,5 @@ impl<'dom, Node: Idx> Iterator for Iter<'dom, Node> {
         } else {
             return None;
         }
-    }
-}
-
-pub struct DominatorTree<N: Idx> {
-    root: N,
-    children: IndexVec<N, Vec<N>>,
-}
-
-impl<Node: Idx> DominatorTree<Node> {
-    pub fn children(&self, node: Node) -> &[Node] {
-        &self.children[node]
-    }
-}
-
-impl<Node: Idx> fmt::Debug for DominatorTree<Node> {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(
-            &DominatorTreeNode {
-                tree: self,
-                node: self.root,
-            },
-            fmt,
-        )
-    }
-}
-
-struct DominatorTreeNode<'tree, Node: Idx> {
-    tree: &'tree DominatorTree<Node>,
-    node: Node,
-}
-
-impl<'tree, Node: Idx> fmt::Debug for DominatorTreeNode<'tree, Node> {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let subtrees: Vec<_> = self.tree
-            .children(self.node)
-            .iter()
-            .map(|&child| DominatorTreeNode {
-                tree: self.tree,
-                node: child,
-            })
-            .collect();
-        fmt.debug_tuple("")
-            .field(&self.node)
-            .field(&subtrees)
-            .finish()
     }
 }


### PR DESCRIPTION
Hi,

Whilst fiddling around in the dominator code, I found some (I think) unused code. This code *was* used at the time it was imported, but over time it seems to have become redundant.

I've tested a build up to stage 1 with no problems. Maybe the tests will turn up something though.

P.S.

There is a FIXME comment in `dominators/mod.rs`:
```
    pub fn is_dominated_by(&self, node: Node, dom: Node) -> bool {                  
        // FIXME -- could be optimized by using post-order-rank                     
        self.dominators(node).any(|n| n == dom)                                     
    }
```

I'm not sure of the intention of this comment. The `Dominators` struct already operates over post-order rank nodes. Any ideas?