### PR TITLE
libstd: win: Remove calls to SetHandleInformation

### DIFF
--- a/src/libstd/sys/windows/c.rs
+++ b/src/libstd/sys/windows/c.rs
@@ -132,6 +132,7 @@ impl Clone for WIN32_FIND_DATAW {
 }
 
 pub const WSA_FLAG_OVERLAPPED: DWORD = 0x01;
+pub const WSA_FLAG_NO_HANDLE_INHERIT: DWORD = 0x80;
 
 pub const WSADESCRIPTION_LEN: usize = 256;
 pub const WSASYS_STATUS_LEN: usize = 128;
@@ -167,8 +168,6 @@ pub const SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE: DWORD = 0x2;
 pub const STD_INPUT_HANDLE: DWORD = -10i32 as DWORD;
 pub const STD_OUTPUT_HANDLE: DWORD = -11i32 as DWORD;
 pub const STD_ERROR_HANDLE: DWORD = -12i32 as DWORD;
-
-pub const HANDLE_FLAG_INHERIT: DWORD = 0x00000001;
 
 pub const PROGRESS_CONTINUE: DWORD = 0;
 
@@ -1083,9 +1082,6 @@ extern "system" {
     pub fn GetUserProfileDirectoryW(hToken: HANDLE,
                                     lpProfileDir: LPWSTR,
                                     lpcchSize: *mut DWORD) -> BOOL;
-    pub fn SetHandleInformation(hObject: HANDLE,
-                                dwMask: DWORD,
-                                dwFlags: DWORD) -> BOOL;
     pub fn CopyFileExW(lpExistingFileName: LPCWSTR,
                        lpNewFileName: LPCWSTR,
                        lpProgressRoutine: LPPROGRESS_ROUTINE,

--- a/src/libstd/sys/windows/net.rs
+++ b/src/libstd/sys/windows/net.rs
@@ -97,12 +97,12 @@ impl Socket {
         };
         let socket = unsafe {
             match c::WSASocketW(fam, ty, 0, ptr::null_mut(), 0,
-                                c::WSA_FLAG_OVERLAPPED) {
+                                c::WSA_FLAG_OVERLAPPED |
+                                c::WSA_FLAG_NO_HANDLE_INHERIT) {
                 c::INVALID_SOCKET => Err(last_error()),
                 n => Ok(Socket(n)),
             }
         }?;
-        socket.set_no_inherit()?;
         Ok(socket)
     }
 
@@ -168,7 +168,6 @@ impl Socket {
                 n => Ok(Socket(n)),
             }
         }?;
-        socket.set_no_inherit()?;
         Ok(socket)
     }
 
@@ -182,12 +181,12 @@ impl Socket {
                                 info.iSocketType,
                                 info.iProtocol,
                                 &mut info, 0,
-                                c::WSA_FLAG_OVERLAPPED) {
+                                c::WSA_FLAG_OVERLAPPED |
+                                c::WSA_FLAG_NO_HANDLE_INHERIT) {
                 c::INVALID_SOCKET => Err(last_error()),
                 n => Ok(Socket(n)),
             }
         }?;
-        socket.set_no_inherit()?;
         Ok(socket)
     }
 
@@ -310,13 +309,6 @@ impl Socket {
             let nsec = (raw % 1000) * 1000000;
             Ok(Some(Duration::new(secs as u64, nsec as u32)))
         }
-    }
-
-    fn set_no_inherit(&self) -> io::Result<()> {
-        sys::cvt(unsafe {
-            c::SetHandleInformation(self.0 as c::HANDLE,
-                                    c::HANDLE_FLAG_INHERIT, 0)
-        }).map(|_| ())
     }
 
     pub fn shutdown(&self, how: Shutdown) -> io::Result<()> {

--- a/src/libstd/sys/windows/process.rs
+++ b/src/libstd/sys/windows/process.rs
@@ -267,13 +267,8 @@ impl Stdio {
 
             Stdio::MakePipe => {
                 let ours_readable = stdio_id != c::STD_INPUT_HANDLE;
-                let pipes = pipe::anon_pipe(ours_readable)?;
+                let pipes = pipe::anon_pipe(ours_readable, true)?;
                 *pipe = Some(pipes.ours);
-                cvt(unsafe {
-                    c::SetHandleInformation(pipes.theirs.handle().raw(),
-                                            c::HANDLE_FLAG_INHERIT,
-                                            c::HANDLE_FLAG_INHERIT)
-                })?;
                 Ok(pipes.theirs.into_handle())
             }
 


### PR DESCRIPTION
This function isn't available when targeting UWP.
Instead:
- Create all sockets with the WSA_FLAG_NO_HANDLE_INHERIT flag
  The socket created by accept() need not to explicitely disable handle
  inheritance, since the documentation states «The newly created socket
  is the socket that will handle the actual connection; it has the same
  properties as socket s, including the asynchronous events registered
  with the WSAAsyncSelect or WSAEventSelect functions.»
  The WSA_FLAG_NO_HANDLE_INHERIT is available starting from Windows 7
  (sp1) which matches Rust's target platform for Windows
- Pass a boolean flag to allow the 'their' end of pipes to be
  inheritable directly upon creating it, instead of a later call to
  SetHandleInformation

As you'd have guessed, this is the first MR of a serie that intend to allow rust to (cross) compile UWP apps. More will come, but I still have to remove quite a few forbidden functions usage.

As a side note, I'm *extremely* new to rust, so I might have missed something rather obvious, please bare with me :)