### PR TITLE
proc_macro: stop using LEB128 for RPC.

### DIFF
--- a/src/libproc_macro/bridge/rpc.rs
+++ b/src/libproc_macro/bridge/rpc.rs
@@ -24,32 +24,22 @@ pub(super) trait DecodeMut<'a, 's, S>: Sized {
 }
 
 macro_rules! rpc_encode_decode {
-    (uleb128 $ty:ty) => {
+    (le $ty:ty) => {
         impl<S> Encode<S> for $ty {
-            fn encode(mut self, w: &mut Writer, s: &mut S) {
-                let mut byte = 0x80;
-                while byte & 0x80 != 0 {
-                    byte = (self & 0x7f) as u8;
-                    self >>= 7;
-                    if self != 0 {
-                        byte |= 0x80;
-                    }
-                    byte.encode(w, s);
-                }
+            fn encode(self, w: &mut Writer, _: &mut S) {
+                w.write_all(&self.to_le_bytes()).unwrap();
             }
         }
 
         impl<S> DecodeMut<'_, '_, S> for $ty {
-            fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
-                let mut byte = 0x80;
-                let mut v = 0;
-                let mut shift = 0;
-                while byte & 0x80 != 0 {
-                    byte = u8::decode(r, s);
-                    v |= ((byte & 0x7f) as Self) << shift;
-                    shift += 7;
-                }
-                v
+            fn decode(r: &mut Reader<'_>, _: &mut S) -> Self {
+                const N: usize = ::std::mem::size_of::<$ty>();
+
+                let mut bytes = [0; N];
+                bytes.copy_from_slice(&r[..N]);
+                *r = &r[N..];
+
+                Self::from_le_bytes(bytes)
             }
         }
     };
@@ -136,8 +126,8 @@ impl<S> DecodeMut<'_, '_, S> for u8 {
     }
 }
 
-rpc_encode_decode!(uleb128 u32);
-rpc_encode_decode!(uleb128 usize);
+rpc_encode_decode!(le u32);
+rpc_encode_decode!(le usize);
 
 impl<S> Encode<S> for bool {
     fn encode(self, w: &mut Writer, s: &mut S) {


### PR DESCRIPTION
I'm not sure how much of an improvement this creates, it's pretty tricky to measure.