### PR TITLE
string: implement From<&String> for String

### DIFF
--- a/src/liballoc/string.rs
+++ b/src/liballoc/string.rs
@@ -2179,6 +2179,14 @@ impl From<&str> for String {
     }
 }
 
+#[stable(feature = "from_ref_string", since = "1.35.0")]
+impl From<&String> for String {
+    #[inline]
+    fn from(s: &String) -> String {
+        s.clone()
+    }
+}
+
 // note: test pulls in libstd, which causes errors here
 #[cfg(not(test))]
 #[stable(feature = "string_from_box", since = "1.18.0")]


### PR DESCRIPTION
Allow Strings to be created from borrowed Strings. This is mostly
to make things like passing `&String` to an `impl Into<String>`
parameter frictionless.

Fixes #59827.