### PR TITLE
[stable] Cherry-pick stdlib fix

### DIFF
--- a/src/libstd/num.rs
+++ b/src/libstd/num.rs
@@ -13,6 +13,8 @@ pub use core::num::Wrapping;
 
 #[stable(feature = "nonzero", since = "1.28.0")]
 pub use core::num::{NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU128, NonZeroUsize};
+#[stable(feature = "signed_nonzero", since = "1.34.0")]
+pub use core::num::{NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI128, NonZeroIsize};
 
 #[cfg(test)] use fmt;
 #[cfg(test)] use ops::{Add, Sub, Mul, Div, Rem};

--- a/src/test/ui/try-block/try-block-bad-type.stderr
+++ b/src/test/ui/try-block/try-block-bad-type.stderr
@@ -6,9 +6,9 @@ LL |         Err("")?; //~ ERROR the trait bound `i32: std::convert::From<&str>`
    |
    = help: the following implementations were found:
              <i32 as std::convert::From<bool>>
-             <i32 as std::convert::From<core::num::NonZeroI32>>
              <i32 as std::convert::From<i16>>
              <i32 as std::convert::From<i8>>
+             <i32 as std::convert::From<std::num::NonZeroI32>>
            and 2 others
    = note: required by `std::convert::From::from`
 


### PR DESCRIPTION
Cherry-picked:

* #59835: Re-export NonZero signed variant in std

r? @Mark-Simulacrum 
cc https://github.com/rust-lang/rust/issues/59834 @rust-lang/release 