### PR TITLE
Don't build rustdoc in more than one stage

### DIFF
--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1678,16 +1678,6 @@ impl Step for Crate {
         builder.ensure(compile::Test { compiler, target });
         builder.ensure(RemoteCopyLibs { compiler, target });
 
-        // If we're not doing a full bootstrap but we're testing a stage2 version of
-        // libstd, then what we're actually testing is the libstd produced in
-        // stage1. Reflect that here by updating the compiler that we're working
-        // with automatically.
-        let compiler = if builder.force_use_stage1(compiler, target) {
-            builder.compiler(1, compiler.host)
-        } else {
-            compiler.clone()
-        };
-
         let mut cargo = builder.cargo(compiler, mode, target, test_kind.subcommand());
         match mode {
             Mode::Std => {


### PR DESCRIPTION
This also introduces a check that if we're attempting to build rustdoc in more than one stage we bail out and abort the build. It shouldn't ever be necessary to do so within one build (it may be necessary locally, primarily, where you don't want a full stage 2 compiler), so just bail out if it happens.

r? @alexcrichton 