### PR TITLE
clarify what the item is in "not a module" error

### DIFF
--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -3731,9 +3731,16 @@ impl<'a> Resolver<'a> {
                             def, path.len() - i - 1
                         ));
                     } else {
+                        let label = format!(
+                            "`{}` is {} {}, not a module",
+                            ident,
+                            def.article(),
+                            def.kind_name(),
+                        );
+
                         return PathResult::Failed {
                             span: ident.span,
-                            label: format!("not a module `{}`", ident),
+                            label,
                             suggestion: None,
                             is_error_from_last_segment: is_last,
                         };

--- a/src/test/ui/issues/issue-30560.rs
+++ b/src/test/ui/issues/issue-30560.rs
@@ -1,10 +1,7 @@
 type Alias = ();
-use Alias::*;
-//~^ ERROR unresolved import `Alias` [E0432]
-//~| not a module `Alias`
-use std::io::Result::*;
-//~^ ERROR unresolved import `std::io::Result` [E0432]
-//~| not a module `Result`
+use Alias::*; //~ ERROR unresolved import `Alias` [E0432]
+
+use std::io::Result::*; //~ ERROR unresolved import `std::io::Result` [E0432]
 
 trait T {}
 use T::*; //~ ERROR items in traits are not importable

--- a/src/test/ui/issues/issue-30560.stderr
+++ b/src/test/ui/issues/issue-30560.stderr
@@ -1,5 +1,5 @@
 error: items in traits are not importable.
-  --> $DIR/issue-30560.rs:10:5
+  --> $DIR/issue-30560.rs:7:5
    |
 LL | use T::*;
    |     ^^^^
@@ -8,13 +8,13 @@ error[E0432]: unresolved import `Alias`
   --> $DIR/issue-30560.rs:2:5
    |
 LL | use Alias::*;
-   |     ^^^^^ not a module `Alias`
+   |     ^^^^^ `Alias` is a type alias, not a module
 
 error[E0432]: unresolved import `std::io::Result`
-  --> $DIR/issue-30560.rs:5:14
+  --> $DIR/issue-30560.rs:4:14
    |
 LL | use std::io::Result::*;
-   |              ^^^^^^ not a module `Result`
+   |              ^^^^^^ `Result` is a type alias, not a module
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/macros/macro-path-prelude-fail-1.rs
+++ b/src/test/ui/macros/macro-path-prelude-fail-1.rs
@@ -2,8 +2,8 @@
 
 mod m {
     fn check() {
-        Vec::clone!(); //~ ERROR failed to resolve: not a module `Vec`
-        u8::clone!(); //~ ERROR failed to resolve: not a module `u8`
+        Vec::clone!(); //~ ERROR failed to resolve: `Vec` is a struct, not a module
+        u8::clone!(); //~ ERROR failed to resolve: `u8` is a builtin type, not a module
     }
 }
 

--- a/src/test/ui/macros/macro-path-prelude-fail-1.stderr
+++ b/src/test/ui/macros/macro-path-prelude-fail-1.stderr
@@ -1,14 +1,14 @@
-error[E0433]: failed to resolve: not a module `Vec`
+error[E0433]: failed to resolve: `Vec` is a struct, not a module
   --> $DIR/macro-path-prelude-fail-1.rs:5:9
    |
 LL |         Vec::clone!();
-   |         ^^^ not a module `Vec`
+   |         ^^^ `Vec` is a struct, not a module
 
-error[E0433]: failed to resolve: not a module `u8`
+error[E0433]: failed to resolve: `u8` is a builtin type, not a module
   --> $DIR/macro-path-prelude-fail-1.rs:6:9
    |
 LL |         u8::clone!();
-   |         ^^ not a module `u8`
+   |         ^^ `u8` is a builtin type, not a module
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/resolve/resolve-variant-assoc-item.rs
+++ b/src/test/ui/resolve/resolve-variant-assoc-item.rs
@@ -2,6 +2,6 @@ enum E { V }
 use E::V;
 
 fn main() {
-    E::V::associated_item; //~ ERROR failed to resolve: not a module `V`
-    V::associated_item; //~ ERROR failed to resolve: not a module `V`
+    E::V::associated_item; //~ ERROR failed to resolve: `V` is a variant, not a module
+    V::associated_item; //~ ERROR failed to resolve: `V` is a variant, not a module
 }

--- a/src/test/ui/resolve/resolve-variant-assoc-item.stderr
+++ b/src/test/ui/resolve/resolve-variant-assoc-item.stderr
@@ -1,14 +1,14 @@
-error[E0433]: failed to resolve: not a module `V`
+error[E0433]: failed to resolve: `V` is a variant, not a module
   --> $DIR/resolve-variant-assoc-item.rs:5:8
    |
 LL |     E::V::associated_item;
-   |        ^ not a module `V`
+   |        ^ `V` is a variant, not a module
 
-error[E0433]: failed to resolve: not a module `V`
+error[E0433]: failed to resolve: `V` is a variant, not a module
   --> $DIR/resolve-variant-assoc-item.rs:6:5
    |
 LL |     V::associated_item;
-   |     ^ not a module `V`
+   |     ^ `V` is a variant, not a module
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/rust-2018/uniform-paths/prelude-fail.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/prelude-fail.stderr
@@ -8,7 +8,7 @@ error[E0432]: unresolved import `rustfmt`
   --> $DIR/prelude-fail.rs:7:5
    |
 LL | use rustfmt::skip as imported_rustfmt_skip;
-   |     ^^^^^^^ not a module `rustfmt`
+   |     ^^^^^^^ `rustfmt` is a tool module, not a module
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/ufcs/ufcs-partially-resolved.rs
+++ b/src/test/ui/ufcs/ufcs-partially-resolved.rs
@@ -45,9 +45,9 @@ fn main() {
     <u8 as E::N>::NN; //~ ERROR cannot find method or associated constant `NN` in `E::N`
     <u8 as A::N>::NN; //~ ERROR cannot find method or associated constant `NN` in `A::N`
     let _: <u8 as Tr::Y>::NN; //~ ERROR cannot find associated type `NN` in `Tr::Y`
-    let _: <u8 as E::Y>::NN; //~ ERROR failed to resolve: not a module `Y`
+    let _: <u8 as E::Y>::NN; //~ ERROR failed to resolve: `Y` is a variant, not a module
     <u8 as Tr::Y>::NN; //~ ERROR cannot find method or associated constant `NN` in `Tr::Y`
-    <u8 as E::Y>::NN; //~ ERROR failed to resolve: not a module `Y`
+    <u8 as E::Y>::NN; //~ ERROR failed to resolve: `Y` is a variant, not a module
 
     let _: <u8 as Dr>::Z; //~ ERROR expected associated type, found method `Dr::Z`
     <u8 as Dr>::X; //~ ERROR expected method or associated constant, found associated type `Dr::X`

--- a/src/test/ui/ufcs/ufcs-partially-resolved.stderr
+++ b/src/test/ui/ufcs/ufcs-partially-resolved.stderr
@@ -1,14 +1,14 @@
-error[E0433]: failed to resolve: not a module `Y`
+error[E0433]: failed to resolve: `Y` is a variant, not a module
   --> $DIR/ufcs-partially-resolved.rs:48:22
    |
 LL |     let _: <u8 as E::Y>::NN;
-   |                      ^ not a module `Y`
+   |                      ^ `Y` is a variant, not a module
 
-error[E0433]: failed to resolve: not a module `Y`
+error[E0433]: failed to resolve: `Y` is a variant, not a module
   --> $DIR/ufcs-partially-resolved.rs:50:15
    |
 LL |     <u8 as E::Y>::NN;
-   |               ^ not a module `Y`
+   |               ^ `Y` is a variant, not a module
 
 error[E0576]: cannot find associated type `N` in trait `Tr`
   --> $DIR/ufcs-partially-resolved.rs:19:24

--- a/src/test/ui/use/use-associated-const.rs
+++ b/src/test/ui/use/use-associated-const.rs
@@ -1,0 +1,13 @@
+#![allow(unused_imports)]
+
+pub mod foo {
+    pub struct Foo;
+
+    impl Foo {
+        pub const BAR: i32 = 0;
+    }
+}
+
+use foo::Foo::BAR; //~ ERROR unresolved import `foo::Foo`
+
+fn main() {}

--- a/src/test/ui/use/use-associated-const.stderr
+++ b/src/test/ui/use/use-associated-const.stderr
@@ -1,0 +1,9 @@
+error[E0432]: unresolved import `foo::Foo`
+  --> $DIR/use-associated-const.rs:11:10
+   |
+LL | use foo::Foo::BAR;
+   |          ^^^ `Foo` is a struct, not a module
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0432`.

--- a/src/test/ui/use/use-from-trait-xc.stderr
+++ b/src/test/ui/use/use-from-trait-xc.stderr
@@ -20,19 +20,19 @@ error[E0432]: unresolved import `use_from_trait_xc::Foo`
   --> $DIR/use-from-trait-xc.rs:14:24
    |
 LL | use use_from_trait_xc::Foo::new;
-   |                        ^^^ not a module `Foo`
+   |                        ^^^ `Foo` is a struct, not a module
 
 error[E0432]: unresolved import `use_from_trait_xc::Foo`
   --> $DIR/use-from-trait-xc.rs:17:24
    |
 LL | use use_from_trait_xc::Foo::C;
-   |                        ^^^ not a module `Foo`
+   |                        ^^^ `Foo` is a struct, not a module
 
 error[E0432]: unresolved import `use_from_trait_xc::Bar`
   --> $DIR/use-from-trait-xc.rs:20:24
    |
 LL | use use_from_trait_xc::Bar::new as bnew;
-   |                        ^^^ not a module `Bar`
+   |                        ^^^ `Bar` is a struct, not a module
 
 error[E0432]: unresolved import `use_from_trait_xc::Baz::new`
   --> $DIR/use-from-trait-xc.rs:23:5

--- a/src/test/ui/use/use-from-trait.rs
+++ b/src/test/ui/use/use-from-trait.rs
@@ -1,17 +1,10 @@
-use Trait::foo;
-//~^ ERROR `foo` is not directly importable
-use Trait::Assoc;
-//~^ ERROR `Assoc` is not directly importable
-use Trait::C;
-//~^ ERROR `C` is not directly importable
+use Trait::foo; //~ ERROR `foo` is not directly importable
+use Trait::Assoc; //~ ERROR `Assoc` is not directly importable
+use Trait::C; //~ ERROR `C` is not directly importable
 
-use Foo::new;
-//~^ ERROR unresolved import `Foo` [E0432]
-//~| not a module `Foo`
+use Foo::new; //~ ERROR unresolved import `Foo` [E0432]
 
-use Foo::C2;
-//~^ ERROR unresolved import `Foo` [E0432]
-//~| not a module `Foo`
+use Foo::C2; //~ ERROR unresolved import `Foo` [E0432]
 
 pub trait Trait {
     fn foo();

--- a/src/test/ui/use/use-from-trait.stderr
+++ b/src/test/ui/use/use-from-trait.stderr
@@ -5,28 +5,28 @@ LL | use Trait::foo;
    |     ^^^^^^^^^^ cannot be imported directly
 
 error[E0253]: `Assoc` is not directly importable
-  --> $DIR/use-from-trait.rs:3:5
+  --> $DIR/use-from-trait.rs:2:5
    |
 LL | use Trait::Assoc;
    |     ^^^^^^^^^^^^ cannot be imported directly
 
 error[E0253]: `C` is not directly importable
-  --> $DIR/use-from-trait.rs:5:5
+  --> $DIR/use-from-trait.rs:3:5
    |
 LL | use Trait::C;
    |     ^^^^^^^^ cannot be imported directly
 
 error[E0432]: unresolved import `Foo`
-  --> $DIR/use-from-trait.rs:8:5
+  --> $DIR/use-from-trait.rs:5:5
    |
 LL | use Foo::new;
-   |     ^^^ not a module `Foo`
+   |     ^^^ `Foo` is a struct, not a module
 
 error[E0432]: unresolved import `Foo`
-  --> $DIR/use-from-trait.rs:12:5
+  --> $DIR/use-from-trait.rs:7:5
    |
 LL | use Foo::C2;
-   |     ^^^ not a module `Foo`
+   |     ^^^ `Foo` is a struct, not a module
 
 error: aborting due to 5 previous errors
 


### PR DESCRIPTION
The motivation here was that I was trying to import an associated constant when I thought it was an enum variant, and got confused by this error.

Ideally I would like to add a note saying that associated constants, types, and methods cannot be imported, but I'm not sure that the associated items for a `Def` can be checked at resolve time.