### PR TITLE
Rollup of 10 pull requests

### DIFF
--- a/src/doc/rustc/src/command-line-arguments.md
+++ b/src/doc/rustc/src/command-line-arguments.md
@@ -86,6 +86,12 @@ This flag will set which lints should be set to the [deny level](lints/levels.ht
 
 This flag will set which lints should be set to the [forbid level](lints/levels.html#forbid).
 
+## `-Z`: set options for debugging rustc
+
+This flag lets you set options for debugging rustc. In order to set multiple options, the -Z flag
+can be used multiple times. For example: `rustc -Z verbose -Z time`. Specifying options with -Z is
+only available on nightly. To view all available options run: `rustc -Z help`.
+
 ## `--cap-lints`: set the most restrictive lint level
 
 This flag lets you 'cap' lints, for more, [see here](lints/levels.html#capping-lints).

--- a/src/doc/rustc/src/command-line-arguments.md
+++ b/src/doc/rustc/src/command-line-arguments.md
@@ -86,11 +86,12 @@ This flag will set which lints should be set to the [deny level](lints/levels.ht
 
 This flag will set which lints should be set to the [forbid level](lints/levels.html#forbid).
 
-## `-Z`: set options for debugging rustc
+## `-Z`: set unstable options
 
-This flag lets you set options for debugging rustc. In order to set multiple options, the -Z flag
-can be used multiple times. For example: `rustc -Z verbose -Z time`. Specifying options with -Z is
-only available on nightly. To view all available options run: `rustc -Z help`.
+This flag will allow you to set unstable options of rustc. In order to set multiple options,
+the -Z flag can be used multiple times. For example: `rustc -Z verbose -Z time`.
+Specifying options with -Z is only available on nightly. To view all available options
+run: `rustc -Z help`.
 
 ## `--cap-lints`: set the most restrictive lint level
 

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -63,6 +63,8 @@
 //!
 //! [dereferencing]: ../../std/ops/trait.Deref.html
 //! [`Box`]: struct.Box.html
+//! [`Global`]: ../alloc/struct.Global.html
+//! [`Layout`]: ../alloc/struct.Layout.html
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -65,7 +65,7 @@
 #![allow(explicit_outlives_requirements)]
 
 #![warn(deprecated_in_future)]
-#![warn(intra_doc_link_resolution_failure)]
+#![deny(intra_doc_link_resolution_failure)]
 #![warn(missing_debug_implementations)]
 
 #![cfg_attr(not(test), feature(generator_trait))]

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -286,13 +286,13 @@ pub struct AssertParamIsEq<T: Eq + ?Sized> { _field: ::marker::PhantomData<T> }
 #[derive(Clone, Copy, PartialEq, Debug, Hash)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub enum Ordering {
-    /// An ordering where a compared value is less [than another].
+    /// An ordering where a compared value is less than another.
     #[stable(feature = "rust1", since = "1.0.0")]
     Less = -1,
-    /// An ordering where a compared value is equal [to another].
+    /// An ordering where a compared value is equal to another.
     #[stable(feature = "rust1", since = "1.0.0")]
     Equal = 0,
-    /// An ordering where a compared value is greater [than another].
+    /// An ordering where a compared value is greater than another.
     #[stable(feature = "rust1", since = "1.0.0")]
     Greater = 1,
 }

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -60,7 +60,7 @@
 
 #![warn(deprecated_in_future)]
 #![warn(missing_docs)]
-#![warn(intra_doc_link_resolution_failure)]
+#![deny(intra_doc_link_resolution_failure)]
 #![warn(missing_debug_implementations)]
 
 #![feature(allow_internal_unstable)]

--- a/src/libcore/ops/arith.rs
+++ b/src/libcore/ops/arith.rs
@@ -220,21 +220,21 @@ sub_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 /// // derive `Eq` and `PartialEq`.
 /// #[derive(Debug, Eq, PartialEq)]
 /// struct Rational {
-///     nominator: usize,
+///     numerator: usize,
 ///     denominator: usize,
 /// }
 ///
 /// impl Rational {
-///     fn new(nominator: usize, denominator: usize) -> Self {
+///     fn new(numerator: usize, denominator: usize) -> Self {
 ///         if denominator == 0 {
 ///             panic!("Zero is an invalid denominator!");
 ///         }
 ///
 ///         // Reduce to lowest terms by dividing by the greatest common
 ///         // divisor.
-///         let gcd = gcd(nominator, denominator);
+///         let gcd = gcd(numerator, denominator);
 ///         Rational {
-///             nominator: nominator / gcd,
+///             numerator: numerator / gcd,
 ///             denominator: denominator / gcd,
 ///         }
 ///     }
@@ -245,9 +245,9 @@ sub_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 ///     type Output = Self;
 ///
 ///     fn mul(self, rhs: Self) -> Self {
-///         let nominator = self.nominator * rhs.nominator;
+///         let numerator = self.numerator * rhs.numerator;
 ///         let denominator = self.denominator * rhs.denominator;
-///         Rational::new(nominator, denominator)
+///         Rational::new(numerator, denominator)
 ///     }
 /// }
 ///
@@ -340,21 +340,21 @@ mul_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 /// // derive `Eq` and `PartialEq`.
 /// #[derive(Debug, Eq, PartialEq)]
 /// struct Rational {
-///     nominator: usize,
+///     numerator: usize,
 ///     denominator: usize,
 /// }
 ///
 /// impl Rational {
-///     fn new(nominator: usize, denominator: usize) -> Self {
+///     fn new(numerator: usize, denominator: usize) -> Self {
 ///         if denominator == 0 {
 ///             panic!("Zero is an invalid denominator!");
 ///         }
 ///
 ///         // Reduce to lowest terms by dividing by the greatest common
 ///         // divisor.
-///         let gcd = gcd(nominator, denominator);
+///         let gcd = gcd(numerator, denominator);
 ///         Rational {
-///             nominator: nominator / gcd,
+///             numerator: numerator / gcd,
 ///             denominator: denominator / gcd,
 ///         }
 ///     }
@@ -365,13 +365,13 @@ mul_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 ///     type Output = Self;
 ///
 ///     fn div(self, rhs: Self) -> Self::Output {
-///         if rhs.nominator == 0 {
+///         if rhs.numerator == 0 {
 ///             panic!("Cannot divide by zero-valued `Rational`!");
 ///         }
 ///
-///         let nominator = self.nominator * rhs.denominator;
-///         let denominator = self.denominator * rhs.nominator;
-///         Rational::new(nominator, denominator)
+///         let numerator = self.numerator * rhs.denominator;
+///         let denominator = self.denominator * rhs.numerator;
+///         Rational::new(numerator, denominator)
 ///     }
 /// }
 ///

--- a/src/librustc/infer/error_reporting/mod.rs
+++ b/src/librustc/infer/error_reporting/mod.rs
@@ -278,7 +278,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
     }
 
     fn explain_span(self, heading: &str, span: Span) -> (String, Option<Span>) {
-        let lo = self.sess.source_map().lookup_char_pos_adj(span.lo());
+        let lo = self.sess.source_map().lookup_char_pos(span.lo());
         (
             format!("the {} at {}:{}", heading, lo.line, lo.col.to_usize() + 1),
             Some(span),

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -755,8 +755,31 @@ impl<'a, 'tcx> LateContext<'a, 'tcx> {
     }
 
     /// Check if a `DefId`'s path matches the given absolute type path usage.
+    ///
+    /// # Examples
+    /// ```rust,ignore (no cx or def_id available)
+    /// if cx.match_def_path(def_id, &["core", "option", "Option"]) {
+    ///     // The given `def_id` is that of an `Option` type
+    /// }
+    /// ```
     // Uplifted from rust-lang/rust-clippy
-    pub fn match_path(&self, def_id: DefId, path: &[&str]) -> bool {
+    pub fn match_def_path(&self, def_id: DefId, path: &[&str]) -> bool {
+        let names = self.get_def_path(def_id);
+
+        names.len() == path.len() && names.into_iter().zip(path.iter()).all(|(a, &b)| *a == *b)
+    }
+
+    /// Gets the absolute path of `def_id` as a vector of `&str`.
+    ///
+    /// # Examples
+    /// ```rust,ignore (no cx or def_id available)
+    /// let def_path = cx.get_def_path(def_id);
+    /// if let &["core", "option", "Option"] = &def_path[..] {
+    ///     // The given `def_id` is that of an `Option` type
+    /// }
+    /// ```
+    // Uplifted from rust-lang/rust-clippy
+    pub fn get_def_path(&self, def_id: DefId) -> Vec<&'static str> {
         pub struct AbsolutePathPrinter<'a, 'tcx> {
             pub tcx: TyCtxt<'a, 'tcx, 'tcx>,
         }
@@ -856,10 +879,12 @@ impl<'a, 'tcx> LateContext<'a, 'tcx> {
             }
         }
 
-        let names = AbsolutePathPrinter { tcx: self.tcx }.print_def_path(def_id, &[]).unwrap();
-
-        names.len() == path.len()
-            && names.into_iter().zip(path.iter()).all(|(a, &b)| *a == *b)
+        AbsolutePathPrinter { tcx: self.tcx }
+            .print_def_path(def_id, &[])
+            .unwrap()
+            .iter()
+            .map(LocalInternedString::get)
+            .collect()
     }
 }
 

--- a/src/librustc/lint/internal.rs
+++ b/src/librustc/lint/internal.rs
@@ -100,7 +100,7 @@ fn lint_ty_kind_usage(cx: &LateContext<'_, '_>, segment: &PathSegment) -> bool {
     if segment.ident.as_str() == "TyKind" {
         if let Some(def) = segment.def {
             if let Some(did) = def.opt_def_id() {
-                return cx.match_path(did, &["rustc", "ty", "sty", "TyKind"]);
+                return cx.match_def_path(did, &["rustc", "ty", "sty", "TyKind"]);
             }
         }
     }

--- a/src/librustc/mir/interpret/error.rs
+++ b/src/librustc/mir/interpret/error.rs
@@ -65,8 +65,8 @@ impl<'tcx> fmt::Display for FrameInfo<'tcx> {
                 write!(f, "inside call to `{}`", self.instance)?;
             }
             if !self.call_site.is_dummy() {
-                let lo = tcx.sess.source_map().lookup_char_pos_adj(self.call_site.lo());
-                write!(f, " at {}:{}:{}", lo.filename, lo.line, lo.col.to_usize() + 1)?;
+                let lo = tcx.sess.source_map().lookup_char_pos(self.call_site.lo());
+                write!(f, " at {}:{}:{}", lo.file.name, lo.line, lo.col.to_usize() + 1)?;
             }
             Ok(())
         })

--- a/src/librustc_data_structures/graph/dominators/mod.rs
+++ b/src/librustc_data_structures/graph/dominators/mod.rs
@@ -8,8 +8,6 @@ use super::super::indexed_vec::{Idx, IndexVec};
 use super::iterate::reverse_post_order;
 use super::ControlFlowGraph;
 
-use std::fmt;
-
 #[cfg(test)]
 mod test;
 
@@ -156,50 +154,5 @@ impl<'dom, Node: Idx> Iterator for Iter<'dom, Node> {
         } else {
             return None;
         }
-    }
-}
-
-pub struct DominatorTree<N: Idx> {
-    root: N,
-    children: IndexVec<N, Vec<N>>,
-}
-
-impl<Node: Idx> DominatorTree<Node> {
-    pub fn children(&self, node: Node) -> &[Node] {
-        &self.children[node]
-    }
-}
-
-impl<Node: Idx> fmt::Debug for DominatorTree<Node> {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(
-            &DominatorTreeNode {
-                tree: self,
-                node: self.root,
-            },
-            fmt,
-        )
-    }
-}
-
-struct DominatorTreeNode<'tree, Node: Idx> {
-    tree: &'tree DominatorTree<Node>,
-    node: Node,
-}
-
-impl<'tree, Node: Idx> fmt::Debug for DominatorTreeNode<'tree, Node> {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let subtrees: Vec<_> = self.tree
-            .children(self.node)
-            .iter()
-            .map(|&child| DominatorTreeNode {
-                tree: self.tree,
-                node: child,
-            })
-            .collect();
-        fmt.debug_tuple("")
-            .field(&self.node)
-            .field(&subtrees)
-            .finish()
     }
 }

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -743,7 +743,7 @@ fn usage(verbose: bool, include_unstable_options: bool) {
     }
     let message = "Usage: rustc [OPTIONS] INPUT";
     let nightly_help = if nightly_options::is_nightly_build() {
-        "\n    -Z help             Print internal options for debugging rustc"
+        "\n    -Z help             Print unstable compiler options"
     } else {
         ""
     };
@@ -891,7 +891,7 @@ Available lint options:
 }
 
 fn describe_debug_flags() {
-    println!("\nAvailable debug options:\n");
+    println!("\nAvailable options:\n");
     print_flag_list("-Z", config::DB_OPTIONS);
 }
 

--- a/src/libstd/keyword_docs.rs
+++ b/src/libstd/keyword_docs.rs
@@ -25,8 +25,7 @@
 ///
 /// For more information on what `as` is capable of, see the [Reference]
 ///
-/// [Reference]:
-/// https://doc.rust-lang.org/reference/expressions/operator-expr.html#type-cast-expressions
+/// [Reference]: ../reference/expressions/operator-expr.html#type-cast-expressions
 /// [`crate`]: keyword.crate.html
 mod as_keyword { }
 
@@ -80,8 +79,8 @@ mod as_keyword { }
 ///
 /// [pointer]: primitive.pointer.html
 /// [Rust Book]:
-/// https://doc.rust-lang.org/stable/book/2018-edition/ch03-01-variables-and-mutability.html#differences-between-variables-and-constants
-/// [Reference]: https://doc.rust-lang.org/reference/items/constant-items.html
+/// ../book/ch03-01-variables-and-mutability.html#differences-between-variables-and-constants
+/// [Reference]: ../reference/items/constant-items.html
 mod const_keyword { }
 
 #[doc(keyword = "crate")]
@@ -114,7 +113,7 @@ mod const_keyword { }
 /// }
 /// ```
 ///
-/// [Reference]: https://doc.rust-lang.org/reference/items/extern-crates.html
+/// [Reference]: ../reference/items/extern-crates.html
 mod crate_keyword { }
 
 #[doc(keyword = "enum")]
@@ -169,8 +168,8 @@ mod crate_keyword { }
 ///
 /// [Algebraic Data Types]: https://en.wikipedia.org/wiki/Algebraic_data_type
 /// [`Option`]: option/enum.Option.html
-/// [Rust Book]: https://doc.rust-lang.org/book/ch06-01-defining-an-enum.html
-/// [Reference]: https://doc.rust-lang.org/reference/items/enumerations.html
+/// [Rust Book]: ../book/ch06-01-defining-an-enum.html
+/// [Reference]: ../reference/items/enumerations.html
 mod enum_keyword { }
 
 #[doc(keyword = "extern")]
@@ -211,8 +210,8 @@ mod enum_keyword { }
 /// For more information on FFI, check the [Rust book] or the [Reference].
 ///
 /// [Rust book]:
-/// https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#using-extern-functions-to-call-external-code
-/// [Reference]: https://doc.rust-lang.org/reference/items/external-blocks.html
+/// ../book/ch19-01-unsafe-rust.html#using-extern-functions-to-call-external-code
+/// [Reference]: ../reference/items/external-blocks.html
 mod extern_keyword { }
 
 #[doc(keyword = "fn")]
@@ -278,8 +277,8 @@ mod extern_keyword { }
 ///
 /// [`impl`]: keyword.impl.html
 /// [`extern`]: keyword.extern.html
-/// [Rust book]: https://doc.rust-lang.org/book/ch03-03-how-functions-work.html
-/// [Reference]: https://doc.rust-lang.org/reference/items/functions.html
+/// [Rust book]: ../book/ch03-03-how-functions-work.html
+/// [Reference]: ../reference/items/functions.html
 mod fn_keyword { }
 
 #[doc(keyword = "for")]
@@ -352,12 +351,11 @@ mod fn_keyword { }
 /// For more information on for-loops, see the [Rust book] or the [Reference].
 ///
 /// [`impl`]: keyword.impl.html
-/// [higher-ranked trait bounds]:
-/// https://doc.rust-lang.org/nightly/reference/trait-bounds.html#higher-ranked-trait-bounds
+/// [higher-ranked trait bounds]: ../reference/trait-bounds.html#higher-ranked-trait-bounds
 /// [`IntoIterator`]: iter/trait.IntoIterator.html
 /// [Rust book]:
-/// https://doc.rust-lang.org/book/2018-edition/ch03-05-control-flow.html#looping-through-a-collection-with-for
-/// [Reference]: https://doc.rust-lang.org/reference/expressions/loop-expr.html#iterator-loops
+/// ../book/ch03-05-control-flow.html#looping-through-a-collection-with-for
+/// [Reference]: ../reference/expressions/loop-expr.html#iterator-loops
 mod for_keyword { }
 
 #[doc(keyword = "if")]
@@ -430,9 +428,8 @@ mod for_keyword { }
 ///
 /// For more information on `if` expressions, see the [Rust book] or the [Reference].
 ///
-/// [Rust book]:
-/// https://doc.rust-lang.org/stable/book/2018-edition/ch03-05-control-flow.html#if-expressions
-/// [Reference]: https://doc.rust-lang.org/reference/expressions/if-expr.html
+/// [Rust book]: ../book/ch03-05-control-flow.html#if-expressions
+/// [Reference]: ../reference/expressions/if-expr.html
 mod if_keyword { }
 
 #[doc(keyword = "impl")]
@@ -493,10 +490,9 @@ mod if_keyword { }
 ///
 /// For more information on `impl Trait` syntax, see the [Rust book][book2].
 ///
-/// [book1]: https://doc.rust-lang.org/stable/book/2018-edition/ch05-03-method-syntax.html
-/// [Reference]: https://doc.rust-lang.org/reference/items/implementations.html
-/// [book2]:
-/// https://doc.rust-lang.org/stable/book/2018-edition/ch10-02-traits.html#returning-traits
+/// [book1]: ../book/ch05-03-method-syntax.html
+/// [Reference]: ../reference/items/implementations.html
+/// [book2]: ../book/ch10-02-traits.html#returning-types-that-implement-traits
 mod impl_keyword { }
 
 #[doc(keyword = "let")]
@@ -554,13 +550,12 @@ mod impl_keyword { }
 /// enumerations. `while let` also exists, which runs a loop with a pattern matched value until
 /// that pattern can't be matched.
 ///
-/// For more information on the `let` keyword, see the [Rust book] or the [Reference]
+/// For more information on the `let` keyword, see the [Rust book][book2] or the [Reference]
 ///
-/// [book1]: https://doc.rust-lang.org/stable/book/2018-edition/ch06-02-match.html
+/// [book1]: ../book/ch06-02-match.html
 /// [`if`]: keyword.if.html
-/// [book2]:
-/// https://doc.rust-lang.org/stable/book/2018-edition/ch18-01-all-the-places-for-patterns.html#let-statements
-/// [Reference]: https://doc.rust-lang.org/reference/statements.html#let-statements
+/// [book2]: ../book/ch18-01-all-the-places-for-patterns.html#let-statements
+/// [Reference]: ../reference/statements.html#let-statements
 mod let_keyword { }
 
 #[doc(keyword = "loop")]
@@ -605,7 +600,7 @@ mod let_keyword { }
 ///
 /// For more information on `loop` and loops in general, see the [Reference].
 ///
-/// [Reference]: https://doc.rust-lang.org/reference/expressions/loop-expr.html
+/// [Reference]: ../reference/expressions/loop-expr.html
 mod loop_keyword { }
 
 #[doc(keyword = "struct")]
@@ -712,6 +707,6 @@ mod loop_keyword { }
 /// [Reference][reference].
 ///
 /// [`PhantomData`]: marker/struct.PhantomData.html
-/// [book]: https://doc.rust-lang.org/book/ch05-01-defining-structs.html
-/// [reference]: https://doc.rust-lang.org/reference/items/structs.html
+/// [book]: ../book/ch05-01-defining-structs.html
+/// [reference]: ../reference/items/structs.html
 mod struct_keyword { }

--- a/src/libstd/num.rs
+++ b/src/libstd/num.rs
@@ -13,6 +13,8 @@ pub use core::num::Wrapping;
 
 #[stable(feature = "nonzero", since = "1.28.0")]
 pub use core::num::{NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU128, NonZeroUsize};
+#[stable(feature = "signed_nonzero", since = "1.34.0")]
+pub use core::num::{NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI128, NonZeroIsize};
 
 #[cfg(test)] use crate::fmt;
 #[cfg(test)] use crate::ops::{Add, Sub, Mul, Div, Rem};

--- a/src/libsyntax/diagnostics/metadata.rs
+++ b/src/libsyntax/diagnostics/metadata.rs
@@ -36,9 +36,9 @@ pub struct ErrorLocation {
 impl ErrorLocation {
     /// Creates an error location from a span.
     pub fn from_span(ecx: &ExtCtxt<'_>, sp: Span) -> ErrorLocation {
-        let loc = ecx.source_map().lookup_char_pos_adj(sp.lo());
+        let loc = ecx.source_map().lookup_char_pos(sp.lo());
         ErrorLocation {
-            filename: loc.filename,
+            filename: loc.file.name.clone(),
             line: loc.line
         }
     }

--- a/src/libsyntax/source_map.rs
+++ b/src/libsyntax/source_map.rs
@@ -388,16 +388,6 @@ impl SourceMap {
         }
     }
 
-    pub fn lookup_char_pos_adj(&self, pos: BytePos) -> LocWithOpt {
-        let loc = self.lookup_char_pos(pos);
-        LocWithOpt {
-            filename: loc.file.name.clone(),
-            line: loc.line,
-            col: loc.col,
-            file: Some(loc.file)
-        }
-    }
-
     /// Returns `Some(span)`, a union of the lhs and rhs span. The lhs must precede the rhs. If
     /// there are gaps between lhs and rhs, the resulting union will cross these gaps.
     /// For this to work, the spans have to be:
@@ -438,10 +428,10 @@ impl SourceMap {
             return "no-location".to_string();
         }
 
-        let lo = self.lookup_char_pos_adj(sp.lo());
-        let hi = self.lookup_char_pos_adj(sp.hi());
+        let lo = self.lookup_char_pos(sp.lo());
+        let hi = self.lookup_char_pos(sp.hi());
         format!("{}:{}:{}: {}:{}",
-                        lo.filename,
+                        lo.file.name,
                         lo.line,
                         lo.col.to_usize() + 1,
                         hi.line,

--- a/src/libsyntax_pos/lib.rs
+++ b/src/libsyntax_pos/lib.rs
@@ -1295,7 +1295,7 @@ impl Sub for CharPos {
 }
 
 // _____________________________________________________________________________
-// Loc, LocWithOpt, SourceFileAndLine, SourceFileAndBytePos
+// Loc, SourceFileAndLine, SourceFileAndBytePos
 //
 
 /// A source code location used for error reporting.
@@ -1309,17 +1309,6 @@ pub struct Loc {
     pub col: CharPos,
     /// The (0-based) column offset when displayed.
     pub col_display: usize,
-}
-
-/// A source code location used as the result of `lookup_char_pos_adj`.
-// Actually, *none* of the clients use the filename *or* file field;
-// perhaps they should just be removed.
-#[derive(Debug)]
-pub struct LocWithOpt {
-    pub filename: FileName,
-    pub line: usize,
-    pub col: CharPos,
-    pub file: Option<Lrc<SourceFile>>,
 }
 
 // Used to be structural records.

--- a/src/test/ui/try-block/try-block-bad-type.stderr
+++ b/src/test/ui/try-block/try-block-bad-type.stderr
@@ -6,9 +6,9 @@ LL |         Err("")?;
    |
    = help: the following implementations were found:
              <i32 as std::convert::From<bool>>
-             <i32 as std::convert::From<core::num::NonZeroI32>>
              <i32 as std::convert::From<i16>>
              <i32 as std::convert::From<i8>>
+             <i32 as std::convert::From<std::num::NonZeroI32>>
            and 2 others
    = note: required by `std::convert::From::from`
 

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -303,6 +303,10 @@ pub struct TestProps {
     // For UI tests, allows compiler to generate arbitrary output to stderr
     pub dont_check_compiler_stderr: bool,
     // Don't force a --crate-type=dylib flag on the command line
+    //
+    // Set this for example if you have an auxiliary test file that contains
+    // a proc-macro and needs `#![crate_type = "proc-macro"]`. This ensures
+    // that the aux file is compiled as a `proc-macro` and not as a `dylib`.
     pub no_prefer_dynamic: bool,
     // Run --pretty expanded when running pretty printing tests
     pub pretty_expanded: bool,
@@ -490,7 +494,7 @@ impl TestProps {
             }
 
             if !self.compile_pass {
-                // run-pass implies must_compile_successfully
+                // run-pass implies compile_pass
                 self.compile_pass = config.parse_compile_pass(ln) || self.run_pass;
             }
 


### PR DESCRIPTION
Successful merges:

 - #59680 (Document the -Z flag to the rustc book)
 - #59735 (remove lookup_char_pos_adj)
 - #59779 (Uplift `get_def_path` from Clippy)
 - #59806 (compiletest: Improve no_prefer_dynamic docs)
 - #59811 (Kill dead code dominator code.)
 - #59814 (Fix broken links on std::boxed doc page)
 - #59830 (Fix links on keyword docs.)
 - #59831 (Remove strange formatting in `Ordering` docs.)
 - #59835 (Re-export NonZero signed variant in std)
 - #59836 (std::ops::Div examples: correct nominator to numerator)

Failed merges:


r? @ghost