### PR TITLE
Clean up handling of `-Z pgo-gen` commandline option.

### DIFF
--- a/src/librustc_codegen_llvm/attributes.rs
+++ b/src/librustc_codegen_llvm/attributes.rs
@@ -104,7 +104,7 @@ pub fn set_probestack(cx: &CodegenCx<'ll, '_>, llfn: &'ll Value) {
     }
 
     // probestack doesn't play nice either with pgo-gen.
-    if cx.sess().opts.debugging_opts.pgo_gen.is_some() {
+    if cx.sess().opts.debugging_opts.pgo_gen.enabled() {
         return;
     }
 

--- a/src/librustc_codegen_llvm/back/link.rs
+++ b/src/librustc_codegen_llvm/back/link.rs
@@ -1014,7 +1014,7 @@ fn link_args(cmd: &mut dyn Linker,
         cmd.build_static_executable();
     }
 
-    if sess.opts.debugging_opts.pgo_gen.is_some() {
+    if sess.opts.debugging_opts.pgo_gen.enabled() {
         cmd.pgo_gen();
     }
 

--- a/src/librustc_codegen_ssa/back/symbol_export.rs
+++ b/src/librustc_codegen_ssa/back/symbol_export.rs
@@ -209,7 +209,7 @@ fn exported_symbols_provider_local<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         }
     }
 
-    if tcx.sess.opts.debugging_opts.pgo_gen.is_some() {
+    if tcx.sess.opts.debugging_opts.pgo_gen.enabled() {
         // These are weak symbols that point to the profile version and the
         // profile name, which need to be treated as exported so LTO doesn't nix
         // them.

--- a/src/librustc_codegen_ssa/back/write.rs
+++ b/src/librustc_codegen_ssa/back/write.rs
@@ -12,7 +12,8 @@ use rustc_incremental::{copy_cgu_workproducts_to_incr_comp_cache_dir,
 use rustc::dep_graph::{WorkProduct, WorkProductId, WorkProductFileKind};
 use rustc::dep_graph::cgu_reuse_tracker::CguReuseTracker;
 use rustc::middle::cstore::EncodedMetadata;
-use rustc::session::config::{self, OutputFilenames, OutputType, Passes, Sanitizer, Lto};
+use rustc::session::config::{self, OutputFilenames, OutputType, Passes, Lto,
+                             Sanitizer, PgoGenerate};
 use rustc::session::Session;
 use rustc::util::nodemap::FxHashMap;
 use rustc::hir::def_id::{CrateNum, LOCAL_CRATE};
@@ -56,7 +57,7 @@ pub struct ModuleConfig {
     /// Some(level) to optimize binary size, or None to not affect program size.
     pub opt_size: Option<config::OptLevel>,
 
-    pub pgo_gen: Option<String>,
+    pub pgo_gen: PgoGenerate,
     pub pgo_use: String,
 
     // Flags indicating which outputs to produce.
@@ -94,7 +95,7 @@ impl ModuleConfig {
             opt_level: None,
             opt_size: None,
 
-            pgo_gen: None,
+            pgo_gen: PgoGenerate::Disabled,
             pgo_use: String::new(),
 
             emit_no_opt_bc: false,

--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -862,7 +862,7 @@ impl<'a> CrateLoader<'a> {
 
     fn inject_profiler_runtime(&mut self) {
         if self.sess.opts.debugging_opts.profile ||
-            self.sess.opts.debugging_opts.pgo_gen.is_some()
+            self.sess.opts.debugging_opts.pgo_gen.enabled()
         {
             info!("loading profiler");
 

--- a/src/test/run-make-fulldeps/pgo-gen-lto/Makefile
+++ b/src/test/run-make-fulldeps/pgo-gen-lto/Makefile
@@ -1,10 +1,8 @@
 -include ../tools.mk
 
-# ignore-windows
-
 all:
 ifeq ($(PROFILER_SUPPORT),1)
-	$(RUSTC) -Copt-level=3 -Clto=fat -Z pgo-gen="$(TMPDIR)/test.profraw" test.rs
+	$(RUSTC) -Copt-level=3 -Clto=fat -Z pgo-gen="$(TMPDIR)" test.rs
 	$(call RUN,test) || exit 1
-	[ -e "$(TMPDIR)/test.profraw" ] || (echo "No .profraw file"; exit 1)
+	[ -e "$(TMPDIR)"/default_*.profraw ] || (echo "No .profraw file"; exit 1)
 endif

--- a/src/test/run-make-fulldeps/pgo-gen/Makefile
+++ b/src/test/run-make-fulldeps/pgo-gen/Makefile
@@ -1,10 +1,8 @@
 -include ../tools.mk
 
-# ignore-windows
-
 all:
 ifeq ($(PROFILER_SUPPORT),1)
-	$(RUSTC) -g -Z pgo-gen="$(TMPDIR)/test.profraw" test.rs
+	$(RUSTC) -g -Z pgo-gen="$(TMPDIR)" test.rs
 	$(call RUN,test) || exit 1
-	[ -e "$(TMPDIR)/test.profraw" ] || (echo "No .profraw file"; exit 1)
+	[ -e "$(TMPDIR)"/default_*.profraw ] || (echo "No .profraw file"; exit 1)
 endif


### PR DESCRIPTION
This PR adapts the `-Z pgo-gen` flag to how Clang and GCC handle the corresponding `-fprofile-generate` flag. In particular, the flag now optionally takes a directory to place the profiling data in and allows to omit the argument (instead of having to pass an empty string).