### PR TITLE
Add a comment explaining why SecRandomCopyBytes is not used on MacOS

### DIFF
--- a/src/libstd/sys/unix/rand.rs
+++ b/src/libstd/sys/unix/rand.rs
@@ -99,6 +99,13 @@ mod imp {
     }
 }
 
+// On iOS and MacOS `SecRandomCopyBytes` calls `CCRandomCopyBytes` with
+// `kCCRandomDefault`. `CCRandomCopyBytes` manages a CSPRNG which is seeded
+// from `/dev/random` and which runs on its own thread accessed via GCD.
+// This seems needlessly heavyweight for the purposes of generating two u64s
+// once per thread in `hashmap_random_keys`. Therefore `SecRandomCopyBytes` is
+// only used on iOS where direct access to `/dev/urandom` is blocked by the
+// sandbox.
 #[cfg(target_os = "ios")]
 mod imp {
     use crate::io;


### PR DESCRIPTION
SecRandomCopyBytes is [available since MacOS 10.7](https://developer.apple.com/documentation/security/1399291-secrandomcopybytes?language=objc) which is the minimum supported version and which was suggested in https://github.com/rust-lang/rust/pull/58901#issuecomment-470188115 is the earliest version currently in use.

This matches the behaviour of other platforms which have a random number generator syscall available.