### PR TITLE
Remove note about transmute for float bitpatterns.

### DIFF
--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -737,16 +737,6 @@ extern "rust-intrinsic" {
     ///
     /// There are a few things that `transmute` is really useful for.
     ///
-    /// Getting the bitpattern of a floating point type (or, more generally,
-    /// type punning, when `T` and `U` aren't pointers):
-    ///
-    /// ```
-    /// let bitpattern = unsafe {
-    ///     std::mem::transmute::<f32, u32>(1.0)
-    /// };
-    /// assert_eq!(bitpattern, 0x3F800000);
-    /// ```
-    ///
     /// Turning a pointer into a function pointer. This is *not* portable to
     /// machines where function pointers and data pointers have different sizes.
     ///


### PR DESCRIPTION
This particular usecase has been safely abstracted in these `std` functions: [f32::to_bits](https://doc.rust-lang.org/std/primitive.f32.html#method.to_bits), [f32::from_bits](https://doc.rust-lang.org/std/primitive.f32.html#method.from_bits), [f64::to_bits](https://doc.rust-lang.org/std/primitive.f64.html#method.to_bits), [f64::from_bits](https://doc.rust-lang.org/std/primitive.f64.html#method.from_bits). So, I think we shouldn't recommend an unnecessary use of `unsafe` here anymore.