### PR TITLE
In `-Zprint-type-size` output, sort enum variants by size.

### DIFF
--- a/src/librustc/session/code_stats.rs
+++ b/src/librustc/session/code_stats.rs
@@ -57,7 +57,13 @@ impl CodeStats {
                                          overall_size: Size,
                                          packed: bool,
                                          opt_discr_size: Option<Size>,
-                                         variants: Vec<VariantInfo>) {
+                                         mut variants: Vec<VariantInfo>) {
+        // Sort variants so the largest ones are shown first. A stable sort is
+        // used here so that source code order is preserved for all variants
+        // that have the same size.
+        variants.sort_by(|info1, info2| {
+            info2.size.cmp(&info1.size)
+        });
         let info = TypeSizeInfo {
             kind,
             type_description: type_desc.to_string(),

--- a/src/test/ui/print_type_sizes/multiple_types.stdout
+++ b/src/test/ui/print_type_sizes/multiple_types.stdout
@@ -1,9 +1,9 @@
 print-type-size type: `Enum`: 51 bytes, alignment: 1 bytes
 print-type-size     discriminant: 1 bytes
-print-type-size     variant `Small`: 7 bytes
-print-type-size         field `.0`: 7 bytes
 print-type-size     variant `Large`: 50 bytes
 print-type-size         field `.0`: 50 bytes
+print-type-size     variant `Small`: 7 bytes
+print-type-size         field `.0`: 7 bytes
 print-type-size type: `FiftyBytes`: 50 bytes, alignment: 1 bytes
 print-type-size     field `.0`: 50 bytes
 print-type-size type: `SevenBytes`: 7 bytes, alignment: 1 bytes

--- a/src/test/ui/print_type_sizes/niche-filling.stdout
+++ b/src/test/ui/print_type_sizes/niche-filling.stdout
@@ -4,15 +4,15 @@ print-type-size     field `.post`: 2 bytes
 print-type-size     field `.pre`: 1 bytes
 print-type-size     end padding: 1 bytes
 print-type-size type: `MyOption<IndirectNonZero>`: 12 bytes, alignment: 4 bytes
-print-type-size     variant `None`: 0 bytes
 print-type-size     variant `Some`: 12 bytes
 print-type-size         field `.0`: 12 bytes
-print-type-size type: `EmbeddedDiscr`: 8 bytes, alignment: 4 bytes
 print-type-size     variant `None`: 0 bytes
+print-type-size type: `EmbeddedDiscr`: 8 bytes, alignment: 4 bytes
 print-type-size     variant `Record`: 7 bytes
 print-type-size         field `.val`: 4 bytes
 print-type-size         field `.post`: 2 bytes
 print-type-size         field `.pre`: 1 bytes
+print-type-size     variant `None`: 0 bytes
 print-type-size     end padding: 1 bytes
 print-type-size type: `NestedNonZero`: 8 bytes, alignment: 4 bytes
 print-type-size     field `.val`: 4 bytes
@@ -20,59 +20,59 @@ print-type-size     field `.post`: 2 bytes
 print-type-size     field `.pre`: 1 bytes
 print-type-size     end padding: 1 bytes
 print-type-size type: `Enum4<(), char, (), ()>`: 4 bytes, alignment: 4 bytes
-print-type-size     variant `One`: 0 bytes
-print-type-size         field `.0`: 0 bytes
 print-type-size     variant `Two`: 4 bytes
 print-type-size         field `.0`: 4 bytes
+print-type-size     variant `One`: 0 bytes
+print-type-size         field `.0`: 0 bytes
 print-type-size     variant `Three`: 0 bytes
 print-type-size         field `.0`: 0 bytes
 print-type-size     variant `Four`: 0 bytes
 print-type-size         field `.0`: 0 bytes
 print-type-size type: `MyOption<char>`: 4 bytes, alignment: 4 bytes
-print-type-size     variant `None`: 0 bytes
 print-type-size     variant `Some`: 4 bytes
 print-type-size         field `.0`: 4 bytes
+print-type-size     variant `None`: 0 bytes
 print-type-size type: `MyOption<std::num::NonZeroU32>`: 4 bytes, alignment: 4 bytes
-print-type-size     variant `None`: 0 bytes
 print-type-size     variant `Some`: 4 bytes
 print-type-size         field `.0`: 4 bytes
+print-type-size     variant `None`: 0 bytes
 print-type-size type: `std::num::NonZeroU32`: 4 bytes, alignment: 4 bytes
 print-type-size     field `.0`: 4 bytes
 print-type-size type: `Enum4<(), (), (), MyOption<u8>>`: 2 bytes, alignment: 1 bytes
+print-type-size     variant `Four`: 2 bytes
+print-type-size         field `.0`: 2 bytes
 print-type-size     variant `One`: 0 bytes
 print-type-size         field `.0`: 0 bytes
 print-type-size     variant `Two`: 0 bytes
 print-type-size         field `.0`: 0 bytes
 print-type-size     variant `Three`: 0 bytes
 print-type-size         field `.0`: 0 bytes
-print-type-size     variant `Four`: 2 bytes
-print-type-size         field `.0`: 2 bytes
 print-type-size type: `MyOption<MyOption<u8>>`: 2 bytes, alignment: 1 bytes
-print-type-size     variant `None`: 0 bytes
 print-type-size     variant `Some`: 2 bytes
 print-type-size         field `.0`: 2 bytes
+print-type-size     variant `None`: 0 bytes
 print-type-size type: `MyOption<u8>`: 2 bytes, alignment: 1 bytes
 print-type-size     discriminant: 1 bytes
-print-type-size     variant `None`: 0 bytes
 print-type-size     variant `Some`: 1 bytes
 print-type-size         field `.0`: 1 bytes
+print-type-size     variant `None`: 0 bytes
 print-type-size type: `Enum4<(), (), bool, ()>`: 1 bytes, alignment: 1 bytes
+print-type-size     variant `Three`: 1 bytes
+print-type-size         field `.0`: 1 bytes
 print-type-size     variant `One`: 0 bytes
 print-type-size         field `.0`: 0 bytes
 print-type-size     variant `Two`: 0 bytes
 print-type-size         field `.0`: 0 bytes
-print-type-size     variant `Three`: 1 bytes
-print-type-size         field `.0`: 1 bytes
 print-type-size     variant `Four`: 0 bytes
 print-type-size         field `.0`: 0 bytes
 print-type-size type: `MyOption<bool>`: 1 bytes, alignment: 1 bytes
-print-type-size     variant `None`: 0 bytes
 print-type-size     variant `Some`: 1 bytes
 print-type-size         field `.0`: 1 bytes
+print-type-size     variant `None`: 0 bytes
 print-type-size type: `MyOption<std::cmp::Ordering>`: 1 bytes, alignment: 1 bytes
-print-type-size     variant `None`: 0 bytes
 print-type-size     variant `Some`: 1 bytes
 print-type-size         field `.0`: 1 bytes
+print-type-size     variant `None`: 0 bytes
 print-type-size type: `std::cmp::Ordering`: 1 bytes, alignment: 1 bytes
 print-type-size     discriminant: 1 bytes
 print-type-size     variant `Less`: 0 bytes

--- a/src/test/ui/print_type_sizes/padding.stdout
+++ b/src/test/ui/print_type_sizes/padding.stdout
@@ -1,21 +1,21 @@
 print-type-size type: `E1`: 12 bytes, alignment: 4 bytes
 print-type-size     discriminant: 1 bytes
+print-type-size     variant `B`: 11 bytes
+print-type-size         padding: 3 bytes
+print-type-size         field `.0`: 8 bytes, alignment: 4 bytes
 print-type-size     variant `A`: 7 bytes
 print-type-size         field `.1`: 1 bytes
 print-type-size         padding: 2 bytes
 print-type-size         field `.0`: 4 bytes, alignment: 4 bytes
+print-type-size type: `E2`: 12 bytes, alignment: 4 bytes
+print-type-size     discriminant: 1 bytes
 print-type-size     variant `B`: 11 bytes
 print-type-size         padding: 3 bytes
 print-type-size         field `.0`: 8 bytes, alignment: 4 bytes
-print-type-size type: `E2`: 12 bytes, alignment: 4 bytes
-print-type-size     discriminant: 1 bytes
 print-type-size     variant `A`: 7 bytes
 print-type-size         field `.0`: 1 bytes
 print-type-size         padding: 2 bytes
 print-type-size         field `.1`: 4 bytes, alignment: 4 bytes
-print-type-size     variant `B`: 11 bytes
-print-type-size         padding: 3 bytes
-print-type-size         field `.0`: 8 bytes, alignment: 4 bytes
 print-type-size type: `S`: 8 bytes, alignment: 4 bytes
 print-type-size     field `.g`: 4 bytes
 print-type-size     field `.a`: 1 bytes

--- a/src/test/ui/print_type_sizes/repr-align.stdout
+++ b/src/test/ui/print_type_sizes/repr-align.stdout
@@ -1,10 +1,10 @@
 print-type-size type: `E`: 32 bytes, alignment: 16 bytes
 print-type-size     discriminant: 4 bytes
-print-type-size     variant `A`: 4 bytes
-print-type-size         field `.0`: 4 bytes
 print-type-size     variant `B`: 28 bytes
 print-type-size         padding: 12 bytes
 print-type-size         field `.0`: 16 bytes, alignment: 16 bytes
+print-type-size     variant `A`: 4 bytes
+print-type-size         field `.0`: 4 bytes
 print-type-size type: `S`: 32 bytes, alignment: 16 bytes
 print-type-size     field `.c`: 16 bytes
 print-type-size     field `.a`: 4 bytes

--- a/src/test/ui/print_type_sizes/variants.stdout
+++ b/src/test/ui/print_type_sizes/variants.stdout
@@ -1,9 +1,9 @@
 print-type-size type: `Enum`: 51 bytes, alignment: 1 bytes
 print-type-size     discriminant: 1 bytes
-print-type-size     variant `Small`: 7 bytes
-print-type-size         field `.0`: 7 bytes
 print-type-size     variant `Large`: 50 bytes
 print-type-size         field `.0`: 50 bytes
+print-type-size     variant `Small`: 7 bytes
+print-type-size         field `.0`: 7 bytes
 print-type-size type: `FiftyBytes`: 50 bytes, alignment: 1 bytes
 print-type-size     field `.0`: 50 bytes
 print-type-size type: `SevenBytes`: 7 bytes, alignment: 1 bytes


### PR DESCRIPTION
It's useful to see the biggest variants first.

r? @pnkfelix 