### PR TITLE
Rollup of 15 pull requests

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -133,7 +133,7 @@ Compatibility Notes
 [`num::NonZeroI64`]: https://doc.rust-lang.org/std/num/struct.NonZeroI64.html
 [`num::NonZeroI8`]: https://doc.rust-lang.org/std/num/struct.NonZeroI8.html
 [`num::NonZeroIsize`]: https://doc.rust-lang.org/std/num/struct.NonZeroIsize.html
-[`slice::sort_by_cached_key`]: https://doc.rust-lang.org/std/slice/fn.sort_by_cached_key
+[`slice::sort_by_cached_key`]: https://doc.rust-lang.org/std/primitive.slice.html#method.sort_by_cached_key
 [`str::escape_debug`]: https://doc.rust-lang.org/std/primitive.str.html#method.escape_debug
 [`str::escape_default`]: https://doc.rust-lang.org/std/primitive.str.html#method.escape_default
 [`str::escape_unicode`]: https://doc.rust-lang.org/std/primitive.str.html#method.escape_unicode

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -277,7 +277,7 @@ impl Step for TheBook {
         builder.ensure(Rustbook {
             target,
             name: INTERNER.intern_string(name.to_string()),
-            version: RustbookVersion::MdBook1,
+            version: RustbookVersion::MdBook2,
         });
 
         // building older edition redirects
@@ -286,21 +286,21 @@ impl Step for TheBook {
         builder.ensure(Rustbook {
             target,
             name: INTERNER.intern_string(source_name),
-            version: RustbookVersion::MdBook1,
+            version: RustbookVersion::MdBook2,
         });
 
         let source_name = format!("{}/second-edition", name);
         builder.ensure(Rustbook {
             target,
             name: INTERNER.intern_string(source_name),
-            version: RustbookVersion::MdBook1,
+            version: RustbookVersion::MdBook2,
         });
 
         let source_name = format!("{}/2018-edition", name);
         builder.ensure(Rustbook {
             target,
             name: INTERNER.intern_string(source_name),
-            version: RustbookVersion::MdBook1,
+            version: RustbookVersion::MdBook2,
         });
 
         // build the version info page and CSS

--- a/src/doc/rustc/src/command-line-arguments.md
+++ b/src/doc/rustc/src/command-line-arguments.md
@@ -86,6 +86,12 @@ This flag will set which lints should be set to the [deny level](lints/levels.ht
 
 This flag will set which lints should be set to the [forbid level](lints/levels.html#forbid).
 
+## `-Z`: set options for debugging rustc
+
+This flag lets you set options for debugging rustc. In order to set multiple options, the -Z flag
+can be used multiple times. For example: `rustc -Z verbose -Z time`. Specifying options with -Z is
+only available on nightly. To view all available options run: `rustc -Z help`.
+
 ## `--cap-lints`: set the most restrictive lint level
 
 This flag lets you 'cap' lints, for more, [see here](lints/levels.html#capping-lints).

--- a/src/doc/rustc/src/command-line-arguments.md
+++ b/src/doc/rustc/src/command-line-arguments.md
@@ -86,11 +86,12 @@ This flag will set which lints should be set to the [deny level](lints/levels.ht
 
 This flag will set which lints should be set to the [forbid level](lints/levels.html#forbid).
 
-## `-Z`: set options for debugging rustc
+## `-Z`: set unstable options
 
-This flag lets you set options for debugging rustc. In order to set multiple options, the -Z flag
-can be used multiple times. For example: `rustc -Z verbose -Z time`. Specifying options with -Z is
-only available on nightly. To view all available options run: `rustc -Z help`.
+This flag will allow you to set unstable options of rustc. In order to set multiple options,
+the -Z flag can be used multiple times. For example: `rustc -Z verbose -Z time`.
+Specifying options with -Z is only available on nightly. To view all available options
+run: `rustc -Z help`.
 
 ## `--cap-lints`: set the most restrictive lint level
 

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -63,6 +63,8 @@
 //!
 //! [dereferencing]: ../../std/ops/trait.Deref.html
 //! [`Box`]: struct.Box.html
+//! [`Global`]: ../alloc/struct.Global.html
+//! [`Layout`]: ../alloc/struct.Layout.html
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -286,13 +286,13 @@ pub struct AssertParamIsEq<T: Eq + ?Sized> { _field: ::marker::PhantomData<T> }
 #[derive(Clone, Copy, PartialEq, Debug, Hash)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub enum Ordering {
-    /// An ordering where a compared value is less [than another].
+    /// An ordering where a compared value is less than another.
     #[stable(feature = "rust1", since = "1.0.0")]
     Less = -1,
-    /// An ordering where a compared value is equal [to another].
+    /// An ordering where a compared value is equal to another.
     #[stable(feature = "rust1", since = "1.0.0")]
     Equal = 0,
-    /// An ordering where a compared value is greater [than another].
+    /// An ordering where a compared value is greater than another.
     #[stable(feature = "rust1", since = "1.0.0")]
     Greater = 1,
 }

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -737,16 +737,6 @@ extern "rust-intrinsic" {
     ///
     /// There are a few things that `transmute` is really useful for.
     ///
-    /// Getting the bitpattern of a floating point type (or, more generally,
-    /// type punning, when `T` and `U` aren't pointers):
-    ///
-    /// ```
-    /// let bitpattern = unsafe {
-    ///     std::mem::transmute::<f32, u32>(1.0)
-    /// };
-    /// assert_eq!(bitpattern, 0x3F800000);
-    /// ```
-    ///
     /// Turning a pointer into a function pointer. This is *not* portable to
     /// machines where function pointers and data pointers have different sizes.
     ///

--- a/src/libcore/ops/arith.rs
+++ b/src/libcore/ops/arith.rs
@@ -220,21 +220,21 @@ sub_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 /// // derive `Eq` and `PartialEq`.
 /// #[derive(Debug, Eq, PartialEq)]
 /// struct Rational {
-///     nominator: usize,
+///     numerator: usize,
 ///     denominator: usize,
 /// }
 ///
 /// impl Rational {
-///     fn new(nominator: usize, denominator: usize) -> Self {
+///     fn new(numerator: usize, denominator: usize) -> Self {
 ///         if denominator == 0 {
 ///             panic!("Zero is an invalid denominator!");
 ///         }
 ///
 ///         // Reduce to lowest terms by dividing by the greatest common
 ///         // divisor.
-///         let gcd = gcd(nominator, denominator);
+///         let gcd = gcd(numerator, denominator);
 ///         Rational {
-///             nominator: nominator / gcd,
+///             numerator: numerator / gcd,
 ///             denominator: denominator / gcd,
 ///         }
 ///     }
@@ -245,9 +245,9 @@ sub_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 ///     type Output = Self;
 ///
 ///     fn mul(self, rhs: Self) -> Self {
-///         let nominator = self.nominator * rhs.nominator;
+///         let numerator = self.numerator * rhs.numerator;
 ///         let denominator = self.denominator * rhs.denominator;
-///         Rational::new(nominator, denominator)
+///         Rational::new(numerator, denominator)
 ///     }
 /// }
 ///
@@ -340,21 +340,21 @@ mul_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 /// // derive `Eq` and `PartialEq`.
 /// #[derive(Debug, Eq, PartialEq)]
 /// struct Rational {
-///     nominator: usize,
+///     numerator: usize,
 ///     denominator: usize,
 /// }
 ///
 /// impl Rational {
-///     fn new(nominator: usize, denominator: usize) -> Self {
+///     fn new(numerator: usize, denominator: usize) -> Self {
 ///         if denominator == 0 {
 ///             panic!("Zero is an invalid denominator!");
 ///         }
 ///
 ///         // Reduce to lowest terms by dividing by the greatest common
 ///         // divisor.
-///         let gcd = gcd(nominator, denominator);
+///         let gcd = gcd(numerator, denominator);
 ///         Rational {
-///             nominator: nominator / gcd,
+///             numerator: numerator / gcd,
 ///             denominator: denominator / gcd,
 ///         }
 ///     }
@@ -365,13 +365,13 @@ mul_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 ///     type Output = Self;
 ///
 ///     fn div(self, rhs: Self) -> Self::Output {
-///         if rhs.nominator == 0 {
+///         if rhs.numerator == 0 {
 ///             panic!("Cannot divide by zero-valued `Rational`!");
 ///         }
 ///
-///         let nominator = self.nominator * rhs.denominator;
-///         let denominator = self.denominator * rhs.nominator;
-///         Rational::new(nominator, denominator)
+///         let numerator = self.numerator * rhs.denominator;
+///         let denominator = self.denominator * rhs.numerator;
+///         Rational::new(numerator, denominator)
 ///     }
 /// }
 ///

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -166,7 +166,7 @@ pub struct Session {
     pub driver_lint_caps: FxHashMap<lint::LintId, lint::Level>,
 
     /// `Span`s of trait methods that weren't found to avoid emitting object safety errors
-    pub trait_methods_not_found: OneThread<RefCell<FxHashSet<Span>>>,
+    pub trait_methods_not_found: Lock<FxHashSet<Span>>,
 }
 
 pub struct PerfStats {
@@ -1236,7 +1236,7 @@ fn build_session_(
         has_global_allocator: Once::new(),
         has_panic_handler: Once::new(),
         driver_lint_caps,
-        trait_methods_not_found: OneThread::new(RefCell::new(Default::default())),
+        trait_methods_not_found: Lock::new(Default::default()),
     };
 
     validate_commandline_args_with_session_available(&sess);

--- a/src/librustc_data_structures/graph/dominators/mod.rs
+++ b/src/librustc_data_structures/graph/dominators/mod.rs
@@ -8,8 +8,6 @@ use super::super::indexed_vec::{Idx, IndexVec};
 use super::iterate::reverse_post_order;
 use super::ControlFlowGraph;
 
-use std::fmt;
-
 #[cfg(test)]
 mod test;
 
@@ -156,50 +154,5 @@ impl<'dom, Node: Idx> Iterator for Iter<'dom, Node> {
         } else {
             return None;
         }
-    }
-}
-
-pub struct DominatorTree<N: Idx> {
-    root: N,
-    children: IndexVec<N, Vec<N>>,
-}
-
-impl<Node: Idx> DominatorTree<Node> {
-    pub fn children(&self, node: Node) -> &[Node] {
-        &self.children[node]
-    }
-}
-
-impl<Node: Idx> fmt::Debug for DominatorTree<Node> {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(
-            &DominatorTreeNode {
-                tree: self,
-                node: self.root,
-            },
-            fmt,
-        )
-    }
-}
-
-struct DominatorTreeNode<'tree, Node: Idx> {
-    tree: &'tree DominatorTree<Node>,
-    node: Node,
-}
-
-impl<'tree, Node: Idx> fmt::Debug for DominatorTreeNode<'tree, Node> {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let subtrees: Vec<_> = self.tree
-            .children(self.node)
-            .iter()
-            .map(|&child| DominatorTreeNode {
-                tree: self.tree,
-                node: child,
-            })
-            .collect();
-        fmt.debug_tuple("")
-            .field(&self.node)
-            .field(&subtrees)
-            .finish()
     }
 }

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -743,7 +743,7 @@ fn usage(verbose: bool, include_unstable_options: bool) {
     }
     let message = "Usage: rustc [OPTIONS] INPUT";
     let nightly_help = if nightly_options::is_nightly_build() {
-        "\n    -Z help             Print internal options for debugging rustc"
+        "\n    -Z help             Print unstable compiler options"
     } else {
         ""
     };
@@ -891,7 +891,7 @@ Available lint options:
 }
 
 fn describe_debug_flags() {
-    println!("\nAvailable debug options:\n");
+    println!("\nAvailable options:\n");
     print_flag_list("-Z", config::DB_OPTIONS);
 }
 

--- a/src/librustc_mir/diagnostics.rs
+++ b/src/librustc_mir/diagnostics.rs
@@ -2307,10 +2307,10 @@ let q = *p;
 ```
 
 Here, the expression `&foo()` is borrowing the expression
-`foo()`. As `foo()` is call to a function, and not the name of
+`foo()`. As `foo()` is a call to a function, and not the name of
 a variable, this creates a **temporary** -- that temporary stores
 the return value from `foo()` so that it can be borrowed.
-So you might imagine that `let p = bar(&foo())` is equivalent
+You could imagine that `let p = bar(&foo());` is equivalent
 to this:
 
 ```compile_fail,E0597

--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -23,7 +23,6 @@ use rustc::middle::cstore::ExternCrate;
 use rustc::session::config::{CrateType, Input, OutputType};
 use rustc::ty::{self, DefIdTree, TyCtxt};
 use rustc::{bug, span_bug};
-use rustc_typeck::hir_ty_to_ty;
 use rustc_codegen_utils::link::{filename_for_metadata, out_filename};
 use rustc_data_structures::sync::Lrc;
 
@@ -658,23 +657,9 @@ impl<'l, 'tcx: 'l> SaveContext<'l, 'tcx> {
                 ..
             }) => HirDef::Local(self.tcx.hir().hir_to_node_id(canonical_id)),
 
-            Node::Ty(ty) => if let hir::Ty {
-                node: hir::TyKind::Path(ref qpath),
-                ..
-            } = *ty
-            {
-                match *qpath {
-                    hir::QPath::Resolved(_, ref path) => path.def,
-                    hir::QPath::TypeRelative(..) => {
-                        let ty = hir_ty_to_ty(self.tcx, ty);
-                        if let ty::Projection(proj) = ty.sty {
-                            return HirDef::AssociatedTy(proj.item_def_id);
-                        }
-                        HirDef::Err
-                    }
-                }
-            } else {
-                HirDef::Err
+            Node::Ty(&hir::Ty { node: hir::TyKind::Path(ref qpath), .. } ) => {
+                let hir_id = self.tcx.hir().node_to_hir_id(id);
+                self.tables.qpath_def(qpath, hir_id)
             },
 
             _ => HirDef::Err,

--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -647,6 +647,10 @@ impl<'l, 'tcx: 'l> SaveContext<'l, 'tcx> {
             Node::Pat(&hir::Pat {
                 node: hir::PatKind::TupleStruct(ref qpath, ..),
                 ..
+            }) |
+            Node::Ty(&hir::Ty {
+                node: hir::TyKind::Path(ref qpath),
+                ..
             }) => {
                 let hir_id = self.tcx.hir().node_to_hir_id(id);
                 self.tables.qpath_def(qpath, hir_id)
@@ -656,11 +660,6 @@ impl<'l, 'tcx: 'l> SaveContext<'l, 'tcx> {
                 node: hir::PatKind::Binding(_, canonical_id, ..),
                 ..
             }) => HirDef::Local(self.tcx.hir().hir_to_node_id(canonical_id)),
-
-            Node::Ty(&hir::Ty { node: hir::TyKind::Path(ref qpath), .. } ) => {
-                let hir_id = self.tcx.hir().node_to_hir_id(id);
-                self.tables.qpath_def(qpath, hir_id)
-            },
 
             _ => HirDef::Err,
         }

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -379,7 +379,7 @@ pub fn check_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>)
     }
 }
 
-/// A quasi-deprecated helper used in rustdoc and save-analysis to get
+/// A quasi-deprecated helper used in rustdoc and clippy to get
 /// the type from a HIR node.
 pub fn hir_ty_to_ty<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, hir_ty: &hir::Ty) -> Ty<'tcx> {
     // In case there are any projections etc, find the "environment"

--- a/src/libstd/sys/sgx/alloc.rs
+++ b/src/libstd/sys/sgx/alloc.rs
@@ -1,4 +1,4 @@
-use crate::alloc::{self, GlobalAlloc, Layout, System};
+use crate::alloc::{GlobalAlloc, Layout, System};
 
 use super::waitqueue::SpinMutex;
 
@@ -36,11 +36,11 @@ unsafe impl GlobalAlloc for System {
 #[cfg(not(test))]
 #[no_mangle]
 pub unsafe extern "C" fn __rust_c_alloc(size: usize, align: usize) -> *mut u8 {
-    alloc::alloc(Layout::from_size_align_unchecked(size, align))
+    crate::alloc::alloc(Layout::from_size_align_unchecked(size, align))
 }
 
 #[cfg(not(test))]
 #[no_mangle]
 pub unsafe extern "C" fn __rust_c_dealloc(ptr: *mut u8, size: usize, align: usize) {
-    alloc::dealloc(ptr, Layout::from_size_align_unchecked(size, align))
+    crate::alloc::dealloc(ptr, Layout::from_size_align_unchecked(size, align))
 }

--- a/src/test/rustdoc-js/substring.js
+++ b/src/test/rustdoc-js/substring.js
@@ -1,0 +1,8 @@
+const QUERY = 'waker_from';
+
+const EXPECTED = {
+    'others': [
+        { 'path': 'substring::SuperWaker', 'name': 'local_waker_from_nonlocal' },
+        { 'path': 'substring::SuperWakerTask', 'name': 'local_waker_from_nonlocal' },
+    ],
+};

--- a/src/test/rustdoc-js/substring.rs
+++ b/src/test/rustdoc-js/substring.rs
@@ -1,0 +1,21 @@
+pub struct SuperWaker;
+
+impl SuperWaker {
+    pub fn local_waker_from_nonlocal() {}
+    pub fn local_waker_frm_nonlocal() {}
+    pub fn some_method() {}
+    pub fn some_other_method() {}
+    pub fn waker_non_local() {}
+    pub fn from_non_local() {}
+}
+
+pub struct SuperWakerTask;
+
+impl SuperWakerTask {
+    pub fn local_waker_from_nonlocal() {}
+    pub fn local_waker_frm_nonlocal() {}
+    pub fn some_method() {}
+    pub fn some_other_method() {}
+    pub fn waker_non_local() {}
+    pub fn from_non_local() {}
+}

--- a/src/test/ui/associated-item/associated-item-enum.rs
+++ b/src/test/ui/associated-item/associated-item-enum.rs
@@ -1,0 +1,20 @@
+enum Enum { Variant }
+
+impl Enum {
+    const MISSPELLABLE: i32 = 0;
+    fn misspellable() {}
+}
+
+trait Trait {
+    fn misspellable_trait() {}
+}
+
+impl Trait for Enum {
+    fn misspellable_trait() {}
+}
+
+fn main() {
+    Enum::mispellable(); //~ ERROR no variant or associated item
+    Enum::mispellable_trait(); //~ ERROR no variant or associated item
+    Enum::MISPELLABLE; //~ ERROR no variant or associated item
+}

--- a/src/test/ui/associated-item/associated-item-enum.stderr
+++ b/src/test/ui/associated-item/associated-item-enum.stderr
@@ -1,0 +1,36 @@
+error[E0599]: no variant or associated item named `mispellable` found for type `Enum` in the current scope
+  --> $DIR/associated-item-enum.rs:17:11
+   |
+LL | enum Enum { Variant }
+   | --------- variant or associated item `mispellable` not found here
+...
+LL |     Enum::mispellable();
+   |           ^^^^^^^^^^^
+   |           |
+   |           variant or associated item not found in `Enum`
+   |           help: there is a method with a similar name: `misspellable`
+
+error[E0599]: no variant or associated item named `mispellable_trait` found for type `Enum` in the current scope
+  --> $DIR/associated-item-enum.rs:18:11
+   |
+LL | enum Enum { Variant }
+   | --------- variant or associated item `mispellable_trait` not found here
+...
+LL |     Enum::mispellable_trait();
+   |           ^^^^^^^^^^^^^^^^^ variant or associated item not found in `Enum`
+
+error[E0599]: no variant or associated item named `MISPELLABLE` found for type `Enum` in the current scope
+  --> $DIR/associated-item-enum.rs:19:11
+   |
+LL | enum Enum { Variant }
+   | --------- variant or associated item `MISPELLABLE` not found here
+...
+LL |     Enum::MISPELLABLE;
+   |           ^^^^^^^^^^^
+   |           |
+   |           variant or associated item not found in `Enum`
+   |           help: there is an associated constant with a similar name: `MISSPELLABLE`
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0599`.

--- a/src/test/ui/auto-ref-slice-plus-ref.stderr
+++ b/src/test/ui/auto-ref-slice-plus-ref.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `test_mut` found for type `std::vec::Vec<{integer}
   --> $DIR/auto-ref-slice-plus-ref.rs:7:7
    |
 LL |     a.test_mut();
-   |       ^^^^^^^^ help: did you mean: `get_mut`
+   |       ^^^^^^^^ help: there is a method with a similar name: `get_mut`
    |
    = help: items from traits can only be used if the trait is implemented and in scope
    = note: the following trait defines an item `test_mut`, perhaps you need to implement it:

--- a/src/test/ui/block-result/issue-3563.stderr
+++ b/src/test/ui/block-result/issue-3563.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `b` found for type `&Self` in the current scope
   --> $DIR/issue-3563.rs:3:17
    |
 LL |         || self.b()
-   |                 ^ help: did you mean: `a`
+   |                 ^ help: there is a method with a similar name: `a`
 
 error: aborting due to previous error
 

--- a/src/test/ui/bogus-tag.stderr
+++ b/src/test/ui/bogus-tag.stderr
@@ -1,11 +1,11 @@
-error[E0599]: no variant named `Hsl` found for type `Color` in the current scope
+error[E0599]: no variant or associated item named `Hsl` found for type `Color` in the current scope
   --> $DIR/bogus-tag.rs:7:16
    |
 LL | enum Color { Rgb(isize, isize, isize), Rgba(isize, isize, isize, isize), }
-   | ---------- variant `Hsl` not found here
+   | ---------- variant or associated item `Hsl` not found here
 ...
 LL |         Color::Hsl(h, s, l) => { println!("hsl"); }
-   |                ^^^ variant not found in `Color`
+   |                ^^^ variant or associated item not found in `Color`
 
 error: aborting due to previous error
 

--- a/src/test/ui/empty/empty-struct-braces-expr.rs
+++ b/src/test/ui/empty/empty-struct-braces-expr.rs
@@ -19,6 +19,8 @@ fn main() {
 
     let xe1 = XEmpty1; //~ ERROR expected value, found struct `XEmpty1`
     let xe1 = XEmpty1(); //~ ERROR expected function, found struct `XEmpty1`
-    let xe3 = XE::Empty3; //~ ERROR no variant named `Empty3` found for type
-    let xe3 = XE::Empty3(); //~ ERROR no variant named `Empty3` found for type
+    let xe3 = XE::Empty3; //~ ERROR no variant or associated item named `Empty3` found for type
+    let xe3 = XE::Empty3(); //~ ERROR no variant or associated item named `Empty3` found for type
+
+    XE::Empty1 {}; //~ ERROR no variant `Empty1` in enum `empty_struct::XE`
 }

--- a/src/test/ui/empty/empty-struct-braces-expr.stderr
+++ b/src/test/ui/empty/empty-struct-braces-expr.stderr
@@ -46,25 +46,31 @@ LL |     let xe1 = XEmpty1();
    |               did you mean `XEmpty1 { /* fields */ }`?
    |               help: a unit struct with a similar name exists: `XEmpty2`
 
-error[E0599]: no variant named `Empty3` found for type `empty_struct::XE` in the current scope
+error[E0599]: no variant or associated item named `Empty3` found for type `empty_struct::XE` in the current scope
   --> $DIR/empty-struct-braces-expr.rs:22:19
    |
 LL |     let xe3 = XE::Empty3;
    |                   ^^^^^^
    |                   |
-   |                   variant not found in `empty_struct::XE`
-   |                   help: did you mean: `XEmpty3`
+   |                   variant or associated item not found in `empty_struct::XE`
+   |                   help: there is a variant with a similar name: `XEmpty3`
 
-error[E0599]: no variant named `Empty3` found for type `empty_struct::XE` in the current scope
+error[E0599]: no variant or associated item named `Empty3` found for type `empty_struct::XE` in the current scope
   --> $DIR/empty-struct-braces-expr.rs:23:19
    |
 LL |     let xe3 = XE::Empty3();
    |                   ^^^^^^
    |                   |
-   |                   variant not found in `empty_struct::XE`
-   |                   help: did you mean: `XEmpty3`
+   |                   variant or associated item not found in `empty_struct::XE`
+   |                   help: there is a variant with a similar name: `XEmpty3`
 
-error: aborting due to 8 previous errors
+error: no variant `Empty1` in enum `empty_struct::XE`
+  --> $DIR/empty-struct-braces-expr.rs:25:9
+   |
+LL |     XE::Empty1 {};
+   |         ^^^^^^ help: there is a variant with a similar name: `XEmpty3`
+
+error: aborting due to 9 previous errors
 
 Some errors occurred: E0423, E0599.
 For more information about an error, try `rustc --explain E0423`.

--- a/src/test/ui/issues/issue-22933-2.rs
+++ b/src/test/ui/issues/issue-22933-2.rs
@@ -2,7 +2,7 @@ enum Delicious {
     Pie      = 0x1,
     Apple    = 0x2,
     ApplePie = Delicious::Apple as isize | Delicious::PIE as isize,
-    //~^ ERROR no variant named `PIE` found for type `Delicious`
+    //~^ ERROR no variant or associated item named `PIE` found for type `Delicious`
 }
 
 fn main() {}

--- a/src/test/ui/issues/issue-22933-2.stderr
+++ b/src/test/ui/issues/issue-22933-2.stderr
@@ -1,11 +1,11 @@
-error[E0599]: no variant named `PIE` found for type `Delicious` in the current scope
+error[E0599]: no variant or associated item named `PIE` found for type `Delicious` in the current scope
   --> $DIR/issue-22933-2.rs:4:55
    |
 LL | enum Delicious {
-   | -------------- variant `PIE` not found here
+   | -------------- variant or associated item `PIE` not found here
 ...
 LL |     ApplePie = Delicious::Apple as isize | Delicious::PIE as isize,
-   |                                                       ^^^ variant not found in `Delicious`
+   |                                                       ^^^ variant or associated item not found in `Delicious`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-23173.rs
+++ b/src/test/ui/issues/issue-23173.rs
@@ -6,12 +6,8 @@ struct Struct {
 fn use_token(token: &Token) { unimplemented!() }
 
 fn main() {
-    use_token(&Token::Homura);
-    //~^ ERROR no variant named `Homura`
-    Struct::method();
-    //~^ ERROR no function or associated item named `method` found for type
-    Struct::method;
-    //~^ ERROR no function or associated item named `method` found for type
-    Struct::Assoc;
-    //~^ ERROR no associated item named `Assoc` found for type `Struct` in
+    use_token(&Token::Homura); //~ ERROR no variant or associated item named `Homura`
+    Struct::method(); //~ ERROR no function or associated item named `method` found for type
+    Struct::method; //~ ERROR no function or associated item named `method` found for type
+    Struct::Assoc; //~ ERROR no associated item named `Assoc` found for type `Struct` in
 }

--- a/src/test/ui/issues/issue-23173.stderr
+++ b/src/test/ui/issues/issue-23173.stderr
@@ -1,14 +1,14 @@
-error[E0599]: no variant named `Homura` found for type `Token` in the current scope
+error[E0599]: no variant or associated item named `Homura` found for type `Token` in the current scope
   --> $DIR/issue-23173.rs:9:23
    |
 LL | enum Token { LeftParen, RightParen, Plus, Minus, /* etc */ }
-   | ---------- variant `Homura` not found here
+   | ---------- variant or associated item `Homura` not found here
 ...
 LL |     use_token(&Token::Homura);
-   |                       ^^^^^^ variant not found in `Token`
+   |                       ^^^^^^ variant or associated item not found in `Token`
 
 error[E0599]: no function or associated item named `method` found for type `Struct` in the current scope
-  --> $DIR/issue-23173.rs:11:13
+  --> $DIR/issue-23173.rs:10:13
    |
 LL | struct Struct {
    | ------------- function or associated item `method` not found for this
@@ -17,7 +17,7 @@ LL |     Struct::method();
    |             ^^^^^^ function or associated item not found in `Struct`
 
 error[E0599]: no function or associated item named `method` found for type `Struct` in the current scope
-  --> $DIR/issue-23173.rs:13:13
+  --> $DIR/issue-23173.rs:11:13
    |
 LL | struct Struct {
    | ------------- function or associated item `method` not found for this
@@ -26,7 +26,7 @@ LL |     Struct::method;
    |             ^^^^^^ function or associated item not found in `Struct`
 
 error[E0599]: no associated item named `Assoc` found for type `Struct` in the current scope
-  --> $DIR/issue-23173.rs:15:13
+  --> $DIR/issue-23173.rs:12:13
    |
 LL | struct Struct {
    | ------------- associated item `Assoc` not found for this

--- a/src/test/ui/issues/issue-23217.rs
+++ b/src/test/ui/issues/issue-23217.rs
@@ -1,6 +1,5 @@
 pub enum SomeEnum {
-    B = SomeEnum::A,
-    //~^ ERROR no variant named `A` found for type `SomeEnum`
+    B = SomeEnum::A, //~ ERROR no variant or associated item named `A` found for type `SomeEnum`
 }
 
 fn main() {}

--- a/src/test/ui/issues/issue-23217.stderr
+++ b/src/test/ui/issues/issue-23217.stderr
@@ -1,13 +1,13 @@
-error[E0599]: no variant named `A` found for type `SomeEnum` in the current scope
+error[E0599]: no variant or associated item named `A` found for type `SomeEnum` in the current scope
   --> $DIR/issue-23217.rs:2:19
    |
 LL | pub enum SomeEnum {
-   | ----------------- variant `A` not found here
+   | ----------------- variant or associated item `A` not found here
 LL |     B = SomeEnum::A,
    |                   ^
    |                   |
-   |                   variant not found in `SomeEnum`
-   |                   help: did you mean: `B`
+   |                   variant or associated item not found in `SomeEnum`
+   |                   help: there is a variant with a similar name: `B`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-28344.stderr
+++ b/src/test/ui/issues/issue-28344.stderr
@@ -11,7 +11,7 @@ LL |     let x: u8 = BitXor::bitor(0 as u8, 0 as u8);
    |                         ^^^^^
    |                         |
    |                         function or associated item not found in `dyn std::ops::BitXor<_>`
-   |                         help: did you mean: `bitxor`
+   |                         help: there is a method with a similar name: `bitxor`
 
 error[E0191]: the value of the associated type `Output` (from the trait `std::ops::BitXor`) must be specified
   --> $DIR/issue-28344.rs:8:13
@@ -26,7 +26,7 @@ LL |     let g = BitXor::bitor;
    |                     ^^^^^
    |                     |
    |                     function or associated item not found in `dyn std::ops::BitXor<_>`
-   |                     help: did you mean: `bitxor`
+   |                     help: there is a method with a similar name: `bitxor`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/issues/issue-28971.rs
+++ b/src/test/ui/issues/issue-28971.rs
@@ -1,5 +1,3 @@
-// This should not cause an ICE
-
 enum Foo {
     Bar(u8)
 }
@@ -7,7 +5,7 @@ fn main(){
     foo(|| {
         match Foo::Bar(1) {
             Foo::Baz(..) => (),
-            //~^ ERROR no variant named `Baz` found for type `Foo`
+            //~^ ERROR no variant or associated item named `Baz` found for type `Foo`
             _ => (),
         }
     });

--- a/src/test/ui/issues/issue-28971.stderr
+++ b/src/test/ui/issues/issue-28971.stderr
@@ -1,14 +1,14 @@
-error[E0599]: no variant named `Baz` found for type `Foo` in the current scope
-  --> $DIR/issue-28971.rs:9:18
+error[E0599]: no variant or associated item named `Baz` found for type `Foo` in the current scope
+  --> $DIR/issue-28971.rs:7:18
    |
 LL | enum Foo {
-   | -------- variant `Baz` not found here
+   | -------- variant or associated item `Baz` not found here
 ...
 LL |             Foo::Baz(..) => (),
    |                  ^^^
    |                  |
-   |                  variant not found in `Foo`
-   |                  help: did you mean: `Bar`
+   |                  variant or associated item not found in `Foo`
+   |                  help: there is a variant with a similar name: `Bar`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-34209.rs
+++ b/src/test/ui/issues/issue-34209.rs
@@ -4,8 +4,7 @@ enum S {
 
 fn bug(l: S) {
     match l {
-        S::B { } => { },
-        //~^ ERROR no variant `B` on enum `S`
+        S::B {} => {}, //~ ERROR no variant `B` in enum `S`
     }
 }
 

--- a/src/test/ui/issues/issue-34209.stderr
+++ b/src/test/ui/issues/issue-34209.stderr
@@ -1,8 +1,11 @@
-error: no variant `B` on enum `S`
-  --> $DIR/issue-34209.rs:7:9
+error: no variant `B` in enum `S`
+  --> $DIR/issue-34209.rs:7:12
    |
-LL |         S::B { } => { },
-   |         ^^^^ help: did you mean: `S::A`
+LL | enum S {
+   | ------ variant `B` not found here
+...
+LL |         S::B {} => {},
+   |            ^ help: there is a variant with a similar name: `A`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-50264-inner-deref-trait/result-deref-err.stderr
+++ b/src/test/ui/issues/issue-50264-inner-deref-trait/result-deref-err.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `deref_err` found for type `std::result::Result<_,
   --> $DIR/result-deref-err.rs:4:28
    |
 LL |     let _result = &Err(41).deref_err();
-   |                            ^^^^^^^^^ help: did you mean: `deref_ok`
+   |                            ^^^^^^^^^ help: there is a method with a similar name: `deref_ok`
    |
    = note: the method `deref_err` exists but the following trait bounds were not satisfied:
            `{integer} : std::ops::Deref`

--- a/src/test/ui/suggestions/suggest-methods.stderr
+++ b/src/test/ui/suggestions/suggest-methods.stderr
@@ -5,19 +5,19 @@ LL | struct Foo;
    | ----------- method `bat` not found for this
 ...
 LL |     f.bat(1.0);
-   |       ^^^ help: did you mean: `bar`
+   |       ^^^ help: there is a method with a similar name: `bar`
 
 error[E0599]: no method named `is_emtpy` found for type `std::string::String` in the current scope
   --> $DIR/suggest-methods.rs:21:15
    |
 LL |     let _ = s.is_emtpy();
-   |               ^^^^^^^^ help: did you mean: `is_empty`
+   |               ^^^^^^^^ help: there is a method with a similar name: `is_empty`
 
 error[E0599]: no method named `count_eos` found for type `u32` in the current scope
   --> $DIR/suggest-methods.rs:25:19
    |
 LL |     let _ = 63u32.count_eos();
-   |                   ^^^^^^^^^ help: did you mean: `count_zeros`
+   |                   ^^^^^^^^^ help: there is a method with a similar name: `count_zeros`
 
 error[E0599]: no method named `count_o` found for type `u32` in the current scope
   --> $DIR/suggest-methods.rs:28:19

--- a/src/test/ui/suggestions/suggest-variants.rs
+++ b/src/test/ui/suggestions/suggest-variants.rs
@@ -12,4 +12,7 @@ fn main() {
     println!("My shape is {:?}", Shape::Squareee { size: 5});  //~ ERROR no variant `Squareee`
     println!("My shape is {:?}", Shape::Circl { size: 5}); //~ ERROR no variant `Circl`
     println!("My shape is {:?}", Shape::Rombus{ size: 5}); //~ ERROR no variant `Rombus`
+    Shape::Squareee; //~ ERROR no variant
+    Shape::Circl; //~ ERROR no variant
+    Shape::Rombus; //~ ERROR no variant
 }

--- a/src/test/ui/suggestions/suggest-variants.stderr
+++ b/src/test/ui/suggestions/suggest-variants.stderr
@@ -1,20 +1,65 @@
-error: no variant `Squareee` on enum `Shape`
-  --> $DIR/suggest-variants.rs:12:34
+error: no variant `Squareee` in enum `Shape`
+  --> $DIR/suggest-variants.rs:12:41
    |
+LL | enum Shape {
+   | ---------- variant `Squareee` not found here
+...
 LL |     println!("My shape is {:?}", Shape::Squareee { size: 5});
-   |                                  ^^^^^^^^^^^^^^^ help: did you mean: `Shape::Square`
+   |                                         ^^^^^^^^ help: there is a variant with a similar name: `Square`
 
-error: no variant `Circl` on enum `Shape`
-  --> $DIR/suggest-variants.rs:13:34
+error: no variant `Circl` in enum `Shape`
+  --> $DIR/suggest-variants.rs:13:41
    |
+LL | enum Shape {
+   | ---------- variant `Circl` not found here
+...
 LL |     println!("My shape is {:?}", Shape::Circl { size: 5});
-   |                                  ^^^^^^^^^^^^ help: did you mean: `Shape::Circle`
+   |                                         ^^^^^ help: there is a variant with a similar name: `Circle`
 
-error: no variant `Rombus` on enum `Shape`
-  --> $DIR/suggest-variants.rs:14:34
+error: no variant `Rombus` in enum `Shape`
+  --> $DIR/suggest-variants.rs:14:41
    |
+LL | enum Shape {
+   | ---------- variant `Rombus` not found here
+...
 LL |     println!("My shape is {:?}", Shape::Rombus{ size: 5});
-   |                                  ^^^^^^^^^^^^^ unknown variant
+   |                                  -------^^^^^^
+   |                                  |
+   |                                  variant not found in `Shape`
 
-error: aborting due to 3 previous errors
+error[E0599]: no variant or associated item named `Squareee` found for type `Shape` in the current scope
+  --> $DIR/suggest-variants.rs:15:12
+   |
+LL | enum Shape {
+   | ---------- variant or associated item `Squareee` not found here
+...
+LL |     Shape::Squareee;
+   |            ^^^^^^^^
+   |            |
+   |            variant or associated item not found in `Shape`
+   |            help: there is a variant with a similar name: `Square`
 
+error[E0599]: no variant or associated item named `Circl` found for type `Shape` in the current scope
+  --> $DIR/suggest-variants.rs:16:12
+   |
+LL | enum Shape {
+   | ---------- variant or associated item `Circl` not found here
+...
+LL |     Shape::Circl;
+   |            ^^^^^
+   |            |
+   |            variant or associated item not found in `Shape`
+   |            help: there is a variant with a similar name: `Circle`
+
+error[E0599]: no variant or associated item named `Rombus` found for type `Shape` in the current scope
+  --> $DIR/suggest-variants.rs:17:12
+   |
+LL | enum Shape {
+   | ---------- variant or associated item `Rombus` not found here
+...
+LL |     Shape::Rombus;
+   |            ^^^^^^ variant or associated item not found in `Shape`
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0599`.

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -303,6 +303,10 @@ pub struct TestProps {
     // For UI tests, allows compiler to generate arbitrary output to stderr
     pub dont_check_compiler_stderr: bool,
     // Don't force a --crate-type=dylib flag on the command line
+    //
+    // Set this for example if you have an auxiliary test file that contains
+    // a proc-macro and needs `#![crate_type = "proc-macro"]`. This ensures
+    // that the aux file is compiled as a `proc-macro` and not as a `dylib`.
     pub no_prefer_dynamic: bool,
     // Run --pretty expanded when running pretty printing tests
     pub pretty_expanded: bool,
@@ -490,7 +494,7 @@ impl TestProps {
             }
 
             if !self.compile_pass {
-                // run-pass implies must_compile_successfully
+                // run-pass implies compile_pass
                 self.compile_pass = config.parse_compile_pass(ln) || self.run_pass;
             }
 


### PR DESCRIPTION
Successful merges:

 - #59680 (Document the -Z flag to the rustc book)
 - #59711 (Add back the substring test)
 - #59806 (compiletest: Improve no_prefer_dynamic docs)
 - #59809 (Make trait_methods_not_found use a lock)
 - #59811 (Kill dead code dominator code.)
 - #59814 (Fix broken links on std::boxed doc page)
 - #59821 (improve unknown enum variant errors)
 - #59831 (Remove strange formatting in `Ordering` docs.)
 - #59836 (std::ops::Div examples: correct nominator to numerator)
 - #59857 (SGX target: fix cfg(test) build)
 - #59876 (Update TRPL to use mdbook 0.2)
 - #59880 (Remove note about transmute for float bitpatterns.)
 - #59889 (Update diagnostics.rs)
 - #59891 (Fix the link to sort_by_cached_key)
 - #59894 (save-analysis: Pull associated type definition using `qpath_def`)

Failed merges:


r? @ghost