### PR TITLE
Revert "compile crates under test w/ -Zemit-stack-sizes"

### DIFF
--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -187,33 +187,6 @@ fn main() {
             cmd.arg("-C").arg(format!("debug-assertions={}", debug_assertions));
         }
 
-        // Build all crates in the `std` facade with `-Z emit-stack-sizes` to add stack usage
-        // information.
-        //
-        // When you use this `-Z` flag with Cargo you get stack usage information on all crates
-        // compiled from source, and when you are using LTO you also get information on pre-compiled
-        // crates like `core` and `std`, even if they were not compiled with `-Z emit-stack-sizes`.
-        // However, there's an exception: `compiler_builtins`. This crate is special and doesn't
-        // participate in LTO because it's always linked as a separate object file. For this reason
-        // it's impossible to get stack usage information about `compiler-builtins` using
-        // `RUSTFLAGS` + Cargo, or `cargo rustc`.
-        //
-        // To make the stack usage information of all crates under the `std` facade available to
-        // Cargo based stack usage analysis tools, in both LTO and non-LTO mode, we compile them
-        // with the `-Z emit-stack-sizes` flag. The `RUSTC_EMIT_STACK_SIZES` var helps us apply this
-        // flag only to the crates in the `std` facade. The `-Z` flag is known to currently work
-        // with targets that produce ELF files so we limit its use flag to those targets.
-        //
-        // NOTE(japaric) if this ever causes problem with an LLVM upgrade or any PR feel free to
-        // remove it or comment it out
-        if env::var_os("RUSTC_EMIT_STACK_SIZES").is_some()
-            && (target.contains("-linux-")
-                || target.contains("-none-eabi")
-                || target.ends_with("-none-elf"))
-        {
-            cmd.arg("-Zemit-stack-sizes");
-        }
-
         if let Ok(s) = env::var("RUSTC_CODEGEN_UNITS") {
             cmd.arg("-C").arg(format!("codegen-units={}", s));
         }

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -97,8 +97,6 @@ impl Step for Std {
         let _folder = builder.fold_output(|| format!("stage{}-std", compiler.stage));
         builder.info(&format!("Building stage{} std artifacts ({} -> {})", compiler.stage,
                 &compiler.host, target));
-        // compile with `-Z emit-stack-sizes`; see bootstrap/src/rustc.rs for more details
-        cargo.env("RUSTC_EMIT_STACK_SIZES", "1");
         run_cargo(builder,
                   &mut cargo,
                   &libstd_stamp(builder, compiler, target),
@@ -397,8 +395,6 @@ impl Step for Test {
         let _folder = builder.fold_output(|| format!("stage{}-test", compiler.stage));
         builder.info(&format!("Building stage{} test artifacts ({} -> {})", compiler.stage,
                 &compiler.host, target));
-        // compile with `-Z emit-stack-sizes`; see bootstrap/src/rustc.rs for more details
-        cargo.env("RUSTC_EMIT_STACK_SIZES", "1");
         run_cargo(builder,
                   &mut cargo,
                   &libtest_stamp(builder, compiler, target),


### PR DESCRIPTION
Revert PR #59401 to fix issue #59652 (a stable-to-beta regression).

This is result of squashing two revert commits:

Revert "compile all crates under test w/ -Zemit-stack-sizes"

This reverts commit 7d365cf27f4249fc9b61ba8abfc813abe43f1cb7.

Revert "bootstrap: build compiler-builtins with -Z emit-stack-sizes"

This reverts commit 8b8488ce8fc047282e7159343f30609417f9fa39.

----

(My intention is that someone can re-add this code again later, either after the `ld.gold` issue itself is fixed, or with safe-guards to check whether `ld.gold` is in use and then issuing warnings about the problems here when they arise.)