### PR TITLE
Fix paste error in split_ascii_whitespace docs.

### DIFF
--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -2712,7 +2712,7 @@ impl str {
     /// All kinds of ASCII whitespace are considered:
     ///
     /// ```
-    /// let mut iter = " Mary   had\ta little  \n\t lamb".split_whitespace();
+    /// let mut iter = " Mary   had\ta little  \n\t lamb".split_ascii_whitespace();
     /// assert_eq!(Some("Mary"), iter.next());
     /// assert_eq!(Some("had"), iter.next());
     /// assert_eq!(Some("a"), iter.next());


### PR DESCRIPTION
It was accidentally still testing the unicode version, `split_whitespace`.