### PR TITLE
Make deprecation lint `ambiguous_associated_items` deny-by-default

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -382,7 +382,7 @@ declare_lint! {
 
 declare_lint! {
     pub AMBIGUOUS_ASSOCIATED_ITEMS,
-    Warn,
+    Deny,
     "ambiguous associated items"
 }
 

--- a/src/test/ui/type-alias-enum-variants-priority.rs
+++ b/src/test/ui/type-alias-enum-variants-priority.rs
@@ -1,5 +1,4 @@
 #![feature(type_alias_enum_variants)]
-#![deny(ambiguous_associated_items)]
 
 enum E {
     V

--- a/src/test/ui/type-alias-enum-variants-priority.stderr
+++ b/src/test/ui/type-alias-enum-variants-priority.stderr
@@ -1,23 +1,19 @@
 error: ambiguous associated item
-  --> $DIR/type-alias-enum-variants-priority.rs:15:15
+  --> $DIR/type-alias-enum-variants-priority.rs:14:15
    |
 LL |     fn f() -> Self::V { 0 }
    |               ^^^^^^^ help: use fully-qualified syntax: `<E as Trait>::V`
    |
-note: lint level defined here
-  --> $DIR/type-alias-enum-variants-priority.rs:2:9
-   |
-LL | #![deny(ambiguous_associated_items)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: #[deny(ambiguous_associated_items)] on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57644 <https://github.com/rust-lang/rust/issues/57644>
 note: `V` could refer to variant defined here
-  --> $DIR/type-alias-enum-variants-priority.rs:5:5
+  --> $DIR/type-alias-enum-variants-priority.rs:4:5
    |
 LL |     V
    |     ^
 note: `V` could also refer to associated type defined here
-  --> $DIR/type-alias-enum-variants-priority.rs:9:5
+  --> $DIR/type-alias-enum-variants-priority.rs:8:5
    |
 LL |     type V;
    |     ^^^^^^^


### PR DESCRIPTION
As requested by r? @Centril 

cc https://github.com/rust-lang/rust/issues/57644