### PR TITLE
Fix cross-crate visibility of fictive variant constructors

### DIFF
--- a/src/test/ui/rfc-2008-non-exhaustive/variants_fictive_visibility.rs
+++ b/src/test/ui/rfc-2008-non-exhaustive/variants_fictive_visibility.rs
@@ -4,6 +4,9 @@
 extern crate variants;
 
 const S: u8 = 0;
+
+// OK, `Struct` in value namespace is crate-private, so it's filtered away
+// and there's no conflict with the previously defined `const S`.
 use variants::NonExhaustiveVariants::Struct as S;
 
 fn main() {}

--- a/src/test/ui/rfc-2008-non-exhaustive/variants_fictive_visibility.rs
+++ b/src/test/ui/rfc-2008-non-exhaustive/variants_fictive_visibility.rs
@@ -1,0 +1,9 @@
+// compile-pass
+// aux-build:variants.rs
+
+extern crate variants;
+
+const S: u8 = 0;
+use variants::NonExhaustiveVariants::Struct as S;
+
+fn main() {}


### PR DESCRIPTION
After merging https://github.com/rust-lang/rust/pull/59376 I realized that the code in the decoder wasn't entirely correct - we "decoded" fictive variant constructors with their variant's visibility, which could be public, rather than demoted to `pub(crate)`.

Fictive constructors are not directly usable in expression/patterns, but the effect still can be observed with imports.

r? @davidtwco 