### PR TITLE
Fix equivalent string in escape_default docs

### DIFF
--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -4054,7 +4054,7 @@ impl str {
     /// Both are equivalent to:
     ///
     /// ```
-    /// println!("\\u{{2764}}\n!");
+    /// println!("\\u{{2764}}\\n!");
     /// ```
     ///
     /// Using `to_string`:


### PR DESCRIPTION
This newline should be escaped.