### PR TITLE
bump stdsimd; make intra_doc_link_resolution_failure an error again; make lints more consistent

### DIFF
--- a/src/liballoc/borrow.rs
+++ b/src/liballoc/borrow.rs
@@ -32,6 +32,7 @@ impl<'a, B: ?Sized> Borrow<B> for Cow<'a, B>
 /// from any borrow of a given type.
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait ToOwned {
+    /// The resulting type after obtaining ownership.
     #[stable(feature = "rust1", since = "1.0.0")]
     type Owned: Borrow<Self>;
 

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -760,6 +760,7 @@ impl<A, F: Fn<A> + ?Sized> Fn<A> for Box<F> {
 #[unstable(feature = "fnbox",
            reason = "will be deprecated if and when `Box<FnOnce>` becomes usable", issue = "28796")]
 pub trait FnBox<A>: FnOnce<A> {
+    /// Performs the call operation.
     fn call_box(self: Box<Self>, args: A) -> Self::Output;
 }
 

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -58,12 +58,12 @@
 #![no_std]
 #![needs_allocator]
 
-#![deny(rust_2018_idioms)]
-#![allow(explicit_outlives_requirements)]
-
 #![warn(deprecated_in_future)]
 #![warn(missing_debug_implementations)]
 #![deny(intra_doc_link_resolution_failure)] // rustdoc is run without -D warnings
+
+#![deny(rust_2018_idioms)]
+#![allow(explicit_outlives_requirements)]
 
 #![cfg_attr(not(test), feature(generator_trait))]
 #![cfg_attr(test, feature(test))]

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -59,6 +59,7 @@
 #![needs_allocator]
 
 #![warn(deprecated_in_future)]
+#![warn(missing_docs)]
 #![warn(missing_debug_implementations)]
 #![deny(intra_doc_link_resolution_failure)] // rustdoc is run without -D warnings
 

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -62,8 +62,8 @@
 #![allow(explicit_outlives_requirements)]
 
 #![warn(deprecated_in_future)]
-#![warn(intra_doc_link_resolution_failure)]
 #![warn(missing_debug_implementations)]
+#![deny(intra_doc_link_resolution_failure)] // rustdoc is run without -D warnings
 
 #![cfg_attr(not(test), feature(generator_trait))]
 #![cfg_attr(test, feature(test))]

--- a/src/liballoc/slice.rs
+++ b/src/liballoc/slice.rs
@@ -570,6 +570,16 @@ pub trait SliceConcatExt<T: ?Sized> {
     #[stable(feature = "rename_connect_to_join", since = "1.3.0")]
     fn join(&self, sep: &T) -> Self::Output;
 
+    /// Flattens a slice of `T` into a single value `Self::Output`, placing a
+    /// given separator between each.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #![allow(deprecated)]
+    /// assert_eq!(["hello", "world"].connect(" "), "hello world");
+    /// assert_eq!([[1, 2], [3, 4]].connect(&0), [1, 2, 0, 3, 4]);
+    /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_deprecated(since = "1.3.0", reason = "renamed to join")]
     fn connect(&self, sep: &T) -> Self::Output;

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -60,8 +60,8 @@
 
 #![warn(deprecated_in_future)]
 #![warn(missing_docs)]
-#![warn(intra_doc_link_resolution_failure)]
 #![warn(missing_debug_implementations)]
+#![deny(intra_doc_link_resolution_failure)] // rustdoc is run without -D warnings
 
 #![feature(allow_internal_unstable)]
 #![feature(arbitrary_self_types)]

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -205,9 +205,10 @@
 // Don't link to std. We are std.
 #![no_std]
 
-#![deny(missing_docs)]
-#![deny(intra_doc_link_resolution_failure)]
-#![deny(missing_debug_implementations)]
+//#![warn(deprecated_in_future)] // FIXME: std still has quite a few uses of `mem::uninitialized`
+#![warn(missing_docs)]
+#![warn(missing_debug_implementations)]
+#![deny(intra_doc_link_resolution_failure)] // rustdoc is run without -D warnings
 
 #![deny(rust_2018_idioms)]
 #![allow(explicit_outlives_requirements)]


### PR DESCRIPTION
I made `intra_doc_link_resolution_failure` warn so that it would properly respect `deny-warnings = false` in `config.toml`.  `#[warn]` still become errors with `-D warnings` so I thought this was fine.

Turns out however that we don't pass `-D warnings` when running rustdoc, so for additional rustdoc-lints we need to set them to `deny`.

Also sue the opportunity to make the lint flags more consistent between libcore, liballoc, libstd.

Cc @gnzlbg for the *big* stdsimd update.