### PR TITLE
Fix doc links in str::escape_{debug, default, unicode}

### DIFF
--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -3986,7 +3986,7 @@ impl str {
     /// Note: only extended grapheme codepoints that begin the string will be
     /// escaped.
     ///
-    /// [`char::escape_debug`]: ../std/primitive.char.html#method.escape_debug
+    /// [`char::escape_debug`]: ../../std/primitive.char.html#method.escape_debug
     ///
     /// # Examples
     ///
@@ -4031,7 +4031,7 @@ impl str {
 
     /// Return an iterator that escapes each char in `self` with [`char::escape_default`].
     ///
-    /// [`char::escape_default`]: ../std/primitive.char.html#method.escape_default
+    /// [`char::escape_default`]: ../../std/primitive.char.html#method.escape_default
     ///
     /// # Examples
     ///
@@ -4069,7 +4069,7 @@ impl str {
 
     /// Return an iterator that escapes each char in `self` with [`char::escape_unicode`].
     ///
-    /// [`char::escape_unicode`]: ../std/primitive.char.html#method.escape_unicode
+    /// [`char::escape_unicode`]: ../../std/primitive.char.html#method.escape_unicode
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Links to `char::escape_{debug, default, unicode}` in `str::escape_{debug, default, unicode}` documentation start with `../std/` but should start with `../../std/` to not 404.