### PR TITLE
Fix rustdoc sidebar z-index

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -346,7 +346,7 @@ nav.sub {
 	margin: 0;
 }
 .docblock-short code {
-	white-space: nowrap;
+	white-space: pre-wrap;
 }
 
 .docblock h1, .docblock h2, .docblock h3, .docblock h4, .docblock h5 {

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -166,6 +166,7 @@ nav.sub {
 	top: 0;
 	height: 100vh;
 	overflow: auto;
+	z-index: 1;
 }
 
 .sidebar .block > ul > li {


### PR DESCRIPTION
I think the screenshot will say everything:
![image](https://user-images.githubusercontent.com/2884517/56098429-37fa3680-5f09-11e9-8c54-4e2548aa0818.png)

live example: https://docs.rs/nom/4.2.3/nom/

I chose the smallest z-index to avoid problems with other blocks.