### PR TITLE
Remove collection-specific `with_capacity` documentation from `std::collections`

### DIFF
--- a/src/libstd/collections/mod.rs
+++ b/src/libstd/collections/mod.rs
@@ -150,10 +150,9 @@
 //! Any `with_capacity` constructor will instruct the collection to allocate
 //! enough space for the specified number of elements. Ideally this will be for
 //! exactly that many elements, but some implementation details may prevent
-//! this. [`Vec`] and [`VecDeque`] can be relied on to allocate exactly the
-//! requested amount, though. Use `with_capacity` when you know exactly how many
-//! elements will be inserted, or at least have a reasonable upper-bound on that
-//! number.
+//! this. See collection-specific documentation for details. In general, use
+//! `with_capacity` when you know exactly how many elements will be inserted, or
+//! at least have a reasonable upper-bound on that number.
 //!
 //! When anticipating a large influx of elements, the `reserve` family of
 //! methods can be used to hint to the collection how much room it should make


### PR DESCRIPTION
Fixes #59931

The style of `std::collections` module doc is very much a beginner friendly guide, and documenting niche, collection-specific behaviour feels out of place, if not brittle. 

The note about `VecDeque` is outdated (see issue), and while `Vec` probably won't change its guarantees any time soon, the users who are interested in its allocation properties will find that in its own documentation.