### PR TITLE
Miri: refactor new allocation tagging

### DIFF
--- a/src/librustc/mir/interpret/pointer.rs
+++ b/src/librustc/mir/interpret/pointer.rs
@@ -95,10 +95,16 @@ impl<'tcx> Pointer<()> {
     }
 
     #[inline(always)]
+    pub fn with_tag<Tag>(self, tag: Tag) -> Pointer<Tag>
+    {
+        Pointer::new_with_tag(self.alloc_id, self.offset, tag)
+    }
+
+    #[inline(always)]
     pub fn with_default_tag<Tag>(self) -> Pointer<Tag>
         where Tag: Default
     {
-        Pointer::new_with_tag(self.alloc_id, self.offset, Default::default())
+        self.with_tag(Tag::default())
     }
 }
 

--- a/src/librustc/mir/interpret/value.rs
+++ b/src/librustc/mir/interpret/value.rs
@@ -119,13 +119,18 @@ impl<Tag> fmt::Display for Scalar<Tag> {
 
 impl<'tcx> Scalar<()> {
     #[inline]
+    pub fn with_tag<Tag>(self, new_tag: Tag) -> Scalar<Tag> {
+        match self {
+            Scalar::Ptr(ptr) => Scalar::Ptr(ptr.with_tag(new_tag)),
+            Scalar::Bits { bits, size } => Scalar::Bits { bits, size },
+        }
+    }
+
+    #[inline(always)]
     pub fn with_default_tag<Tag>(self) -> Scalar<Tag>
         where Tag: Default
     {
-        match self {
-            Scalar::Ptr(ptr) => Scalar::Ptr(ptr.with_default_tag()),
-            Scalar::Bits { bits, size } => Scalar::Bits { bits, size },
-        }
+        self.with_tag(Tag::default())
     }
 }
 
@@ -134,14 +139,6 @@ impl<'tcx, Tag> Scalar<Tag> {
     pub fn erase_tag(self) -> Scalar {
         match self {
             Scalar::Ptr(ptr) => Scalar::Ptr(ptr.erase_tag()),
-            Scalar::Bits { bits, size } => Scalar::Bits { bits, size },
-        }
-    }
-
-    #[inline]
-    pub fn with_tag(self, new_tag: Tag) -> Self {
-        match self {
-            Scalar::Ptr(ptr) => Scalar::Ptr(Pointer { tag: new_tag, ..ptr }),
             Scalar::Bits { bits, size } => Scalar::Bits { bits, size },
         }
     }
@@ -434,13 +431,18 @@ impl<Tag> fmt::Display for ScalarMaybeUndef<Tag> {
 
 impl<'tcx> ScalarMaybeUndef<()> {
     #[inline]
+    pub fn with_tag<Tag>(self, new_tag: Tag) -> ScalarMaybeUndef<Tag> {
+        match self {
+            ScalarMaybeUndef::Scalar(s) => ScalarMaybeUndef::Scalar(s.with_tag(new_tag)),
+            ScalarMaybeUndef::Undef => ScalarMaybeUndef::Undef,
+        }
+    }
+
+    #[inline(always)]
     pub fn with_default_tag<Tag>(self) -> ScalarMaybeUndef<Tag>
         where Tag: Default
     {
-        match self {
-            ScalarMaybeUndef::Scalar(s) => ScalarMaybeUndef::Scalar(s.with_default_tag()),
-            ScalarMaybeUndef::Undef => ScalarMaybeUndef::Undef,
-        }
+        self.with_tag(Tag::default())
     }
 }
 

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -11,7 +11,7 @@ use rustc::hir::def::Def;
 use rustc::mir::interpret::{ConstEvalErr, ErrorHandled};
 use rustc::mir;
 use rustc::ty::{self, TyCtxt, query::TyCtxtAt};
-use rustc::ty::layout::{self, LayoutOf, VariantIdx};
+use rustc::ty::layout::{self, LayoutOf, VariantIdx, Size};
 use rustc::ty::subst::Subst;
 use rustc::traits::Reveal;
 use rustc::util::common::ErrorReported;
@@ -21,7 +21,7 @@ use syntax::ast::Mutability;
 use syntax::source_map::{Span, DUMMY_SP};
 
 use crate::interpret::{self,
-    PlaceTy, MPlaceTy, MemPlace, OpTy, ImmTy, Immediate, Scalar, Pointer,
+    PlaceTy, MPlaceTy, MemPlace, OpTy, ImmTy, Immediate, Scalar,
     RawConst, ConstValue,
     EvalResult, EvalError, InterpError, GlobalId, InterpretCx, StackPopCleanup,
     Allocation, AllocId, MemoryKind,
@@ -406,6 +406,15 @@ impl<'a, 'mir, 'tcx> interpret::Machine<'a, 'mir, 'tcx>
         Cow::Borrowed(alloc)
     }
 
+    #[inline(always)]
+    fn new_allocation(
+        _size: Size,
+        _extra: &Self::MemoryExtra,
+        _kind: MemoryKind<!>,
+    ) -> (Self::AllocExtra, Self::PointerTag) {
+        ((), ())
+    }
+
     fn box_alloc(
         _ecx: &mut InterpretCx<'a, 'mir, 'tcx, Self>,
         _dest: PlaceTy<'tcx>,
@@ -437,15 +446,6 @@ impl<'a, 'mir, 'tcx> interpret::Machine<'a, 'mir, 'tcx>
             &ecx.memory,
             &ecx.stack[..],
         )
-    }
-
-    #[inline(always)]
-    fn tag_new_allocation(
-        _ecx: &mut InterpretCx<'a, 'mir, 'tcx, Self>,
-        ptr: Pointer,
-        _kind: MemoryKind<Self::MemoryKinds>,
-    ) -> Pointer {
-        ptr
     }
 
     #[inline(always)]

--- a/src/librustc_mir/interpret/traits.rs
+++ b/src/librustc_mir/interpret/traits.rs
@@ -52,7 +52,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> InterpretCx<'a, 'mir, 'tcx, M> 
             ptr_size * (3 + methods.len() as u64),
             ptr_align,
             MemoryKind::Vtable,
-        ).with_default_tag();
+        );
         let tcx = &*self.tcx;
 
         let drop = crate::monomorphize::resolve_drop_in_place(*tcx, ty);


### PR DESCRIPTION
Tagging and initializing `AllocExtra` now go hand-in-hand so one cannot forget to do one when doing the other. In particular, `memory.allocate` is now much easier to use correctly (because it will already return a tagged pointer).

r? @oli-obk