### PR TITLE
Use resume_unwind instead of panic!() for nicer compiletest errors

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -3422,7 +3422,9 @@ impl ProcRes {
              \n",
             self.status, self.cmdline, self.stdout, self.stderr
         );
-        panic!();
+        // Use resume_unwind instead of panic!() to prevent a panic message + backtrace from
+        // compiletest, which is unnecessary noise.
+        std::panic::resume_unwind(Box::new(()));
     }
 }
 


### PR DESCRIPTION
cc https://github.com/rust-lang/rust/pull/58783#issuecomment-477287606