### PR TITLE
rustdoc: use --static-root-path for settings.js

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -2113,7 +2113,8 @@ impl Context {
                  &final_file);
 
         // Generating settings page.
-        let settings = Settings::new("./", &self.shared.resource_suffix);
+        let settings = Settings::new(self.shared.static_root_path.deref().unwrap_or("./"),
+                                     &self.shared.resource_suffix);
         page.title = "Rustdoc settings";
         page.description = "Settings of Rustdoc";
         page.root_path = "./";

--- a/src/test/rustdoc/static-root-path.rs
+++ b/src/test/rustdoc/static-root-path.rs
@@ -12,3 +12,7 @@ pub struct SomeStruct;
 // @!matches - '"\.\./\.\./source-script\.js"'
 // @matches - '"\.\./\.\./source-files.js"'
 // @!matches - '"/cache/source-files\.js"'
+
+// @has settings.html
+// @matches - '/cache/settings\.js'
+// @!matches - '\./settings\.js'


### PR DESCRIPTION
At the time i was writing https://github.com/rust-lang/docs.rs/pull/332, i noticed that the `settings.js` file that was being loaded was not being loaded from the `--static-root-path`. This PR fixes that so that users on docs.rs can effectively cache this file.