### PR TITLE
Miri now supports entropy, but is still slow

### DIFF
--- a/src/liballoc/tests/binary_heap.rs
+++ b/src/liballoc/tests/binary_heap.rs
@@ -282,7 +282,7 @@ fn assert_covariance() {
 //
 // Destructors must be called exactly once per element.
 #[test]
-#[cfg(not(miri))] // Miri does not support panics nor entropy
+#[cfg(not(miri))] // Miri does not support catching panics
 fn panic_safe() {
     static DROP_COUNTER: AtomicUsize = AtomicUsize::new(0);
 

--- a/src/liballoc/tests/slice.rs
+++ b/src/liballoc/tests/slice.rs
@@ -389,7 +389,7 @@ fn test_reverse() {
 }
 
 #[test]
-#[cfg(not(miri))] // Miri does not support entropy
+#[cfg(not(miri))] // Miri is too slow
 fn test_sort() {
     let mut rng = thread_rng();
 
@@ -466,10 +466,19 @@ fn test_sort() {
 }
 
 #[test]
-#[cfg(not(miri))] // Miri does not support entropy
 fn test_sort_stability() {
-    for len in (2..25).chain(500..510) {
-        for _ in 0..10 {
+    #[cfg(not(miri))] // Miri is too slow
+    let large_limit = 510;
+    #[cfg(not(miri))] // Miri is too slow
+    let rounds = 10;
+
+    #[cfg(miri)]
+    let large_limit = 500; // effectively skips the large tests
+    #[cfg(miri)]
+    let rounds = 1;
+
+    for len in (2..25).chain(500..large_limit) {
+        for _ in 0..rounds {
             let mut counts = [0; 10];
 
             // create a vector like [(6, 1), (5, 1), (6, 2), ...],
@@ -1397,7 +1406,7 @@ fn test_box_slice_clone() {
 #[test]
 #[allow(unused_must_use)] // here, we care about the side effects of `.clone()`
 #[cfg_attr(target_os = "emscripten", ignore)]
-#[cfg(not(miri))] // Miri does not support threads nor entropy
+#[cfg(not(miri))] // Miri does not support threads
 fn test_box_slice_clone_panics() {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -1589,7 +1598,7 @@ thread_local!(static SILENCE_PANIC: Cell<bool> = Cell::new(false));
 
 #[test]
 #[cfg_attr(target_os = "emscripten", ignore)] // no threads
-#[cfg(not(miri))] // Miri does not support threads nor entropy
+#[cfg(not(miri))] // Miri does not support threads
 fn panic_safe() {
     let prev = panic::take_hook();
     panic::set_hook(Box::new(move |info| {

--- a/src/liballoc/tests/slice.rs
+++ b/src/liballoc/tests/slice.rs
@@ -468,16 +468,16 @@ fn test_sort() {
 #[test]
 fn test_sort_stability() {
     #[cfg(not(miri))] // Miri is too slow
-    let large_limit = 510;
+    let large_range = 500..510;
     #[cfg(not(miri))] // Miri is too slow
     let rounds = 10;
 
     #[cfg(miri)]
-    let large_limit = 500; // effectively skips the large tests
+    let large_range = 0..0; // empty range
     #[cfg(miri)]
     let rounds = 1;
 
-    for len in (2..25).chain(500..large_limit) {
+    for len in (2..25).chain(large_range) {
         for _ in 0..rounds {
             let mut counts = [0; 10];
 

--- a/src/libcore/tests/slice.rs
+++ b/src/libcore/tests/slice.rs
@@ -1024,7 +1024,7 @@ fn test_rotate_right() {
 
 #[test]
 #[cfg(not(target_arch = "wasm32"))]
-#[cfg(not(miri))] // Miri does not support entropy
+#[cfg(not(miri))] // Miri is too slow
 fn sort_unstable() {
     use core::cmp::Ordering::{Equal, Greater, Less};
     use core::slice::heapsort;
@@ -1095,7 +1095,7 @@ fn sort_unstable() {
 
 #[test]
 #[cfg(not(target_arch = "wasm32"))]
-#[cfg(not(miri))] // Miri does not support entropy
+#[cfg(not(miri))] // Miri is too slow
 fn partition_at_index() {
     use core::cmp::Ordering::{Equal, Greater, Less};
     use rand::rngs::SmallRng;

--- a/src/libcore/tests/slice.rs
+++ b/src/libcore/tests/slice.rs
@@ -1024,22 +1024,31 @@ fn test_rotate_right() {
 
 #[test]
 #[cfg(not(target_arch = "wasm32"))]
-#[cfg(not(miri))] // Miri is too slow
 fn sort_unstable() {
     use core::cmp::Ordering::{Equal, Greater, Less};
     use core::slice::heapsort;
     use rand::{FromEntropy, Rng, rngs::SmallRng, seq::SliceRandom};
 
+    #[cfg(not(miri))] // Miri is too slow
+    let large_range = 500..510;
+    #[cfg(not(miri))] // Miri is too slow
+    let rounds = 100;
+
+    #[cfg(miri)]
+    let large_range = 0..0; // empty range
+    #[cfg(miri)]
+    let rounds = 1;
+
     let mut v = [0; 600];
     let mut tmp = [0; 600];
     let mut rng = SmallRng::from_entropy();
 
-    for len in (2..25).chain(500..510) {
+    for len in (2..25).chain(large_range) {
         let v = &mut v[0..len];
         let tmp = &mut tmp[0..len];
 
         for &modulus in &[5, 10, 100, 1000] {
-            for _ in 0..100 {
+            for _ in 0..rounds {
                 for i in 0..len {
                     v[i] = rng.gen::<i32>() % modulus;
                 }


### PR DESCRIPTION
Adjust the `cfg` and their comments in the test suites accordingly.