### PR TITLE
Add hooks for Miri panic unwinding

### DIFF
--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -1352,12 +1352,7 @@ extern "rust-intrinsic" {
     /// Internal hook used by Miri to implement unwinding.
     /// Perma-unstable: do not use
     #[cfg(not(bootstrap))]
-    // Note that the type is data is pretty arbitrary:
-    // we just need something that's guarnateed to be a fat
-    // pointer. Using `*mut [()]` instead of the actual type
-    // `*mut (Any + Send)` allows us to avoid making `Any` and `Send`
-    // lang items
-    pub fn miri_start_panic(data: *mut [()]) -> !;
+    pub fn miri_start_panic(data: *mut (dyn crate::any::Any + crate::marker::Send)) -> !;
 }
 
 // Some functions are defined here because they accidentally got made

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -1352,7 +1352,12 @@ extern "rust-intrinsic" {
     /// Internal hook used by Miri to implement unwinding.
     /// Perma-unstable: do not use
     #[cfg(not(bootstrap))]
-    pub fn miri_start_panic(data: u128) -> !;
+    // Note that the type is data is pretty arbitrary:
+    // we just need something that's guarnateed to be a fat
+    // pointer. Using `*mut [()]` instead of the actual type
+    // `*mut (Any + Send)` allows us to avoid making `Any` and `Send`
+    // lang items
+    pub fn miri_start_panic(data: *mut [()]) -> !;
 }
 
 // Some functions are defined here because they accidentally got made

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -1352,7 +1352,7 @@ extern "rust-intrinsic" {
     /// Internal hook used by Miri to implement unwinding.
     /// Perma-unstable: do not use
     #[cfg(not(bootstrap))]
-    pub fn miri_start_panic(data: *mut (dyn crate::any::Any + Send)) -> !;
+    pub fn miri_start_panic(data: u128) -> !;
 }
 
 // Some functions are defined here because they accidentally got made

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -1348,6 +1348,11 @@ extern "rust-intrinsic" {
     /// See documentation of `<*const T>::offset_from` for details.
     #[cfg(not(bootstrap))]
     pub fn ptr_offset_from<T>(ptr: *const T, base: *const T) -> isize;
+
+    /// Internal hook used by Miri to implement unwinding.
+    /// Perma-unstable: do not use
+    #[cfg(not(bootstrap))]
+    pub fn miri_start_panic(data: *mut (dyn crate::any::Any + Send)) -> !;
 }
 
 // Some functions are defined here because they accidentally got made

--- a/src/libpanic_unwind/lib.rs
+++ b/src/libpanic_unwind/lib.rs
@@ -36,7 +36,10 @@ use core::raw;
 use core::panic::BoxMeUp;
 
 cfg_if::cfg_if! {
-    if #[cfg(target_os = "emscripten")] {
+    if #[cfg(miri)] {
+        #[path = "miri.rs"]
+        mod imp;
+    } else if #[cfg(target_os = "emscripten")] {
         #[path = "emcc.rs"]
         mod imp;
     } else if #[cfg(target_arch = "wasm32")] {

--- a/src/libpanic_unwind/lib.rs
+++ b/src/libpanic_unwind/lib.rs
@@ -100,5 +100,3 @@ pub unsafe extern "C" fn __rust_start_panic(payload: usize) -> u32 {
     let payload = payload as *mut &mut dyn BoxMeUp;
     imp::panic(Box::from_raw((*payload).box_me_up()))
 }
-
-

--- a/src/libpanic_unwind/lib.rs
+++ b/src/libpanic_unwind/lib.rs
@@ -98,5 +98,7 @@ pub unsafe extern "C" fn __rust_start_panic(payload: usize) -> u32 {
     imp::panic(Box::from_raw((*payload).box_me_up()))
 }
 
+// A dummy helper function for Miri.
+// Used to push an empty stack frame when we start unwinding
 #[cfg(miri)]
 pub fn miri_panic_trampoline() {}

--- a/src/libpanic_unwind/lib.rs
+++ b/src/libpanic_unwind/lib.rs
@@ -39,9 +39,6 @@ cfg_if::cfg_if! {
     if #[cfg(miri)] {
         #[path = "miri.rs"]
         mod imp;
-        // Export this at the root of the crate so that Miri
-        // has a stable palce to look it up
-        pub use imp::miri_panic_trampoline;
     } else if #[cfg(target_os = "emscripten")] {
         #[path = "emcc.rs"]
         mod imp;

--- a/src/libpanic_unwind/lib.rs
+++ b/src/libpanic_unwind/lib.rs
@@ -97,3 +97,6 @@ pub unsafe extern "C" fn __rust_start_panic(payload: usize) -> u32 {
     let payload = payload as *mut &mut dyn BoxMeUp;
     imp::panic(Box::from_raw((*payload).box_me_up()))
 }
+
+#[cfg(miri)]
+pub fn miri_panic_trampoline() {}

--- a/src/libpanic_unwind/lib.rs
+++ b/src/libpanic_unwind/lib.rs
@@ -39,6 +39,9 @@ cfg_if::cfg_if! {
     if #[cfg(miri)] {
         #[path = "miri.rs"]
         mod imp;
+        // Export this at the root of the crate so that Miri
+        // has a stable palce to look it up
+        pub use imp::miri_panic_trampoline;
     } else if #[cfg(target_os = "emscripten")] {
         #[path = "emcc.rs"]
         mod imp;
@@ -98,7 +101,4 @@ pub unsafe extern "C" fn __rust_start_panic(payload: usize) -> u32 {
     imp::panic(Box::from_raw((*payload).box_me_up()))
 }
 
-// A dummy helper function for Miri.
-// Used to push an empty stack frame when we start unwinding
-#[cfg(miri)]
-pub fn miri_panic_trampoline() {}
+

--- a/src/libpanic_unwind/miri.rs
+++ b/src/libpanic_unwind/miri.rs
@@ -1,9 +1,13 @@
+use core::any::Any;
+use alloc::boxed::Box;
+
 pub fn payload() -> *mut u8 {
     core::ptr::null_mut()
 }
 
-pub unsafe fn panic(data: Box<dyn Any + Send>) -> u32 {
-    core::intrinsics::miri_start_panic(Box::into_raw(data))
+pub unsafe fn panic(data: Box<dyn Any + Send>) -> ! {
+    let raw_val = core::mem::transmute::<_, u128>(Box::into_raw(data));
+    core::intrinsics::miri_start_panic(raw_val)
 }
 
 pub unsafe fn cleanup(ptr: *mut u8) -> Box<dyn Any + Send> {

--- a/src/libpanic_unwind/miri.rs
+++ b/src/libpanic_unwind/miri.rs
@@ -6,8 +6,7 @@ pub fn payload() -> *mut u8 {
 }
 
 pub unsafe fn panic(data: Box<dyn Any + Send>) -> ! {
-    let raw_val: *mut [()] = core::mem::transmute::<*mut (dyn Any + Send), _>(Box::into_raw(data));
-    core::intrinsics::miri_start_panic(raw_val)
+    core::intrinsics::miri_start_panic(Box::into_raw(data))
 }
 
 pub unsafe fn cleanup(ptr: *mut u8) -> Box<dyn Any + Send> {

--- a/src/libpanic_unwind/miri.rs
+++ b/src/libpanic_unwind/miri.rs
@@ -1,0 +1,12 @@
+pub fn payload() -> *mut u8 {
+    core::ptr::null_mut()
+}
+
+pub unsafe fn panic(data: Box<dyn Any + Send>) -> u32 {
+    core::intrinsics::miri_start_panic(Box::into_raw(data))
+}
+
+pub unsafe fn cleanup(ptr: *mut u8) -> Box<dyn Any + Send> {
+    Box::from_raw(ptr)
+}
+

--- a/src/libpanic_unwind/miri.rs
+++ b/src/libpanic_unwind/miri.rs
@@ -6,7 +6,7 @@ pub fn payload() -> *mut u8 {
 }
 
 pub unsafe fn panic(data: Box<dyn Any + Send>) -> ! {
-    let raw_val = core::mem::transmute::<_, u128>(Box::into_raw(data));
+    let raw_val: *mut [()] = core::mem::transmute::<*mut (dyn Any + Send), _>(Box::into_raw(data));
     core::intrinsics::miri_start_panic(raw_val)
 }
 
@@ -14,3 +14,11 @@ pub unsafe fn cleanup(ptr: *mut u8) -> Box<dyn Any + Send> {
     Box::from_raw(ptr)
 }
 
+
+// This is required by the compiler to exist (e.g., it's a lang item),
+// but is never used by Miri. Therefore, we just use a stub here
+#[lang = "eh_personality"]
+#[cfg(not(test))]
+fn rust_eh_personality() {
+    unsafe { core::intrinsics::abort() }
+}

--- a/src/libpanic_unwind/miri.rs
+++ b/src/libpanic_unwind/miri.rs
@@ -21,8 +21,3 @@ pub unsafe fn cleanup(ptr: *mut u8) -> Box<dyn Any + Send> {
 fn rust_eh_personality() {
     unsafe { core::intrinsics::abort() }
 }
-
-// A dummy helper function for Miri.
-// Used to push an empty stack frame when we start unwinding
-#[cfg(miri)]
-pub fn miri_panic_trampoline() {}

--- a/src/libpanic_unwind/miri.rs
+++ b/src/libpanic_unwind/miri.rs
@@ -21,3 +21,8 @@ pub unsafe fn cleanup(ptr: *mut u8) -> Box<dyn Any + Send> {
 fn rust_eh_personality() {
     unsafe { core::intrinsics::abort() }
 }
+
+// A dummy helper function for Miri.
+// Used to push an empty stack frame when we start unwinding
+#[cfg(miri)]
+pub fn miri_panic_trampoline() {}

--- a/src/librustc_codegen_ssa/mir/block.rs
+++ b/src/librustc_codegen_ssa/mir/block.rs
@@ -532,6 +532,11 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         // We should only emit a call to this intrinsic in #[cfg(miri)] mode,
         // which means that we will never actually use the generate object files
         // (we will just be interpreting the MIR)
+        //
+        // Note that we still need to be able to codegen *something* for this intrisnic:
+        // Miri currently uses Xargo to build a special libstd. As a side effect,
+        // we generate normal object files for libstd - while these are never used,
+        // we still need to be able to build them.
         if intrinsic == Some("miri_start_panic") {
             bx.abort();
             bx.unreachable();

--- a/src/librustc_codegen_ssa/mir/block.rs
+++ b/src/librustc_codegen_ssa/mir/block.rs
@@ -528,6 +528,16 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             _ => FnAbi::new(&bx, sig, &extra_args)
         };
 
+        // This should never be reachable at runtime:
+        // We should only emit a call to this intrinsic in #[cfg(miri)] mode,
+        // which means that we will never actually use the generate object files
+        // (we will just be interpreting the MIR)
+        if intrinsic == Some("miri_start_panic") {
+            bx.abort();
+            bx.unreachable();
+            return;
+        }
+
         // Emit a panic or a no-op for `panic_if_uninhabited`.
         if intrinsic == Some("panic_if_uninhabited") {
             let ty = instance.unwrap().substs.type_at(0);

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -376,6 +376,8 @@ impl<'mir, 'tcx> interpret::Machine<'mir, 'tcx> for CompileTimeInterpreter<'mir,
         instance: ty::Instance<'tcx>,
         args: &[OpTy<'tcx>],
         dest: Option<PlaceTy<'tcx>>,
+        _ret: Option<mir::BasicBlock>,
+        _unwind: Option<mir::BasicBlock>
     ) -> InterpResult<'tcx> {
         if ecx.emulate_intrinsic(span, instance, args, dest)? {
             return Ok(());

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -474,7 +474,8 @@ impl<'mir, 'tcx> interpret::Machine<'mir, 'tcx> for CompileTimeInterpreter<'mir,
     /// Called immediately before a stack frame gets popped.
     #[inline(always)]
     fn stack_pop(
-        _ecx: &mut InterpCx<'mir, 'tcx, Self>, _extra: ()) -> InterpResult<'tcx, StackPopInfo> {
+        _ecx: &mut InterpCx<'mir, 'tcx, Self>, _extra: (),
+    ) -> InterpResult<'tcx, StackPopInfo> {
         // Const-eval mode does not support unwinding from panics
         Ok(StackPopInfo::Normal)
     }

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -24,7 +24,7 @@ use crate::interpret::{self,
     PlaceTy, MPlaceTy, OpTy, ImmTy, Immediate, Scalar, Pointer,
     RawConst, ConstValue, Machine,
     InterpResult, InterpErrorInfo, GlobalId, InterpCx, StackPopCleanup,
-    Allocation, AllocId, MemoryKind, Memory, StackPopInfo,
+    Allocation, AllocId, MemoryKind, Memory,
     snapshot, RefTracking, intern_const_alloc_recursive,
 };
 
@@ -469,16 +469,6 @@ impl<'mir, 'tcx> interpret::Machine<'mir, 'tcx> for CompileTimeInterpreter<'mir,
     #[inline(always)]
     fn stack_push(_ecx: &mut InterpCx<'mir, 'tcx, Self>) -> InterpResult<'tcx> {
         Ok(())
-    }
-
-    /// Called immediately before a stack frame gets popped.
-    #[inline(always)]
-    fn stack_pop(
-        _ecx: &mut InterpCx<'mir, 'tcx, Self>,
-        _extra: (),
-    ) -> InterpResult<'tcx, StackPopInfo> {
-        // Const-eval mode does not support unwinding from panics
-        Ok(StackPopInfo::Normal)
     }
 }
 

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -474,7 +474,8 @@ impl<'mir, 'tcx> interpret::Machine<'mir, 'tcx> for CompileTimeInterpreter<'mir,
     /// Called immediately before a stack frame gets popped.
     #[inline(always)]
     fn stack_pop(
-        _ecx: &mut InterpCx<'mir, 'tcx, Self>, _extra: (),
+        _ecx: &mut InterpCx<'mir, 'tcx, Self>,
+        _extra: (),
     ) -> InterpResult<'tcx, StackPopInfo> {
         // Const-eval mode does not support unwinding from panics
         Ok(StackPopInfo::Normal)

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -337,7 +337,7 @@ impl<'mir, 'tcx> interpret::Machine<'mir, 'tcx> for CompileTimeInterpreter<'mir,
                 // Some functions we support even if they are non-const -- but avoid testing
                 // that for const fn!  We certainly do *not* want to actually call the fn
                 // though, so be sure we return here.
-                return if ecx.hook_fn(instance, args, dest)? {
+                return if ecx.hook_panic_fn(instance, args, dest)? {
                     ecx.goto_block(ret)?; // fully evaluated and done
                     Ok(None)
                 } else {

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -583,7 +583,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
 
         // If we're popping frames due to unwinding, and we didn't just exit
         // unwinding, we skip a bunch of validation and cleanup logic (including
-        // jumping to the regular return block specified in the StackPopCleanu)
+        // jumping to the regular return block specified in the StackPopCleanup)
         let cur_unwinding = unwinding && stack_pop_info != StackPopInfo::StopUnwinding;
 
         info!("StackPopCleanup: {:?} StackPopInfo: {:?} cur_unwinding = {:?}",

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -98,7 +98,7 @@ pub enum StackPopCleanup {
     /// Jump to the next block in the caller, or cause UB if None (that's a function
     /// that may never return). Also store layout of return place so
     /// we can validate it at that layout.
-    /// 'ret' stores the block we jump to on a normal return, while 'unwind'
+    /// `ret` stores the block we jump to on a normal return, while 'unwind'
     /// stores the block used for cleanup during unwinding
     Goto { ret: Option<mir::BasicBlock>, unwind: Option<mir::BasicBlock> },
     /// Just do nohing: Used by Main and for the box_alloc hook in miri.

--- a/src/librustc_mir/interpret/intrinsics.rs
+++ b/src/librustc_mir/interpret/intrinsics.rs
@@ -354,9 +354,10 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         Ok(true)
     }
 
-    /// "Intercept" a function call because we have something special to do for it.
+    /// "Intercept" a function call to a panic-related function
+    /// because we have something special to do for it.
     /// Returns `true` if an intercept happened.
-    pub fn hook_fn(
+    pub fn hook_panic_fn(
         &mut self,
         instance: ty::Instance<'tcx>,
         args: &[OpTy<'tcx, M::PointerTag>],

--- a/src/librustc_mir/interpret/intrinsics.rs
+++ b/src/librustc_mir/interpret/intrinsics.rs
@@ -95,11 +95,10 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
     ) -> InterpResult<'tcx, bool> {
         let substs = instance.substs;
 
-        // The intrinsic itself cannot diverge, so if we got here without a return
-        // place... (can happen e.g., for transmute returning `!`)
+        // We currently do not handle any diverging intrinsics.
         let dest = match dest {
             Some(dest) => dest,
-            None => throw_ub!(Unreachable)
+            None => return Ok(false)
         };
         let intrinsic_name = &*self.tcx.item_name(instance.def_id()).as_str();
 

--- a/src/librustc_mir/interpret/intrinsics.rs
+++ b/src/librustc_mir/interpret/intrinsics.rs
@@ -101,7 +101,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             Some(dest) => dest,
             None => throw_ub!(Unreachable)
         };
-        let intrinsic_name = &self.tcx.item_name(instance.def_id()).as_str();
+        let intrinsic_name = &*self.tcx.item_name(instance.def_id()).as_str();
 
         match intrinsic_name {
             "caller_location" => {

--- a/src/librustc_mir/interpret/machine.rs
+++ b/src/librustc_mir/interpret/machine.rs
@@ -268,9 +268,12 @@ pub trait Machine<'mir, 'tcx>: Sized {
 
     /// Called immediately after a stack frame gets popped
     fn stack_pop(
-        ecx: &mut InterpCx<'mir, 'tcx, Self>,
-        extra: Self::FrameExtra,
-    ) -> InterpResult<'tcx, StackPopInfo>;
+        _ecx: &mut InterpCx<'mir, 'tcx, Self>,
+        _extra: Self::FrameExtra,
+    ) -> InterpResult<'tcx, StackPopInfo> {
+        // By default, we do not support unwinding from panics
+        Ok(StackPopInfo::Normal)
+    }
 
     fn int_to_ptr(
         _mem: &Memory<'mir, 'tcx, Self>,

--- a/src/librustc_mir/interpret/machine.rs
+++ b/src/librustc_mir/interpret/machine.rs
@@ -18,7 +18,7 @@ use super::{
 
 /// Data returned by Machine::stack_pop,
 /// to provide further control over the popping of the stack frame
-#[derive(Eq, PartialEq, Debug)]
+#[derive(Eq, PartialEq, Debug, Copy, Clone)]
 pub enum StackPopInfo {
     /// Indicates that we have just started unwinding
     /// as the result of panic

--- a/src/librustc_mir/interpret/machine.rs
+++ b/src/librustc_mir/interpret/machine.rs
@@ -24,7 +24,10 @@ pub enum StackPopInfo {
     /// as the result of panic
     StartUnwinding,
 
-    /// Indicates that we performed a normal return
+    /// Indicates that no special handling should be
+    /// done - we'll either return normally or unwind
+    /// based on the terminator for the function
+    /// we're leaving.
     Normal,
 
     /// Indicates that we should stop unwinding,

--- a/src/librustc_mir/interpret/machine.rs
+++ b/src/librustc_mir/interpret/machine.rs
@@ -270,6 +270,7 @@ pub trait Machine<'mir, 'tcx>: Sized {
     fn stack_pop(
         _ecx: &mut InterpCx<'mir, 'tcx, Self>,
         _extra: Self::FrameExtra,
+        _unwinding: bool
     ) -> InterpResult<'tcx, StackPopInfo> {
         // By default, we do not support unwinding from panics
         Ok(StackPopInfo::Normal)

--- a/src/librustc_mir/interpret/machine.rs
+++ b/src/librustc_mir/interpret/machine.rs
@@ -20,10 +20,6 @@ use super::{
 /// to provide further control over the popping of the stack frame
 #[derive(Eq, PartialEq, Debug, Copy, Clone)]
 pub enum StackPopInfo {
-    /// Indicates that we have just started unwinding
-    /// as the result of panic
-    StartUnwinding,
-
     /// Indicates that no special handling should be
     /// done - we'll either return normally or unwind
     /// based on the terminator for the function
@@ -177,6 +173,8 @@ pub trait Machine<'mir, 'tcx>: Sized {
         instance: ty::Instance<'tcx>,
         args: &[OpTy<'tcx, Self::PointerTag>],
         dest: Option<PlaceTy<'tcx, Self::PointerTag>>,
+        ret: Option<mir::BasicBlock>,
+        unwind: Option<mir::BasicBlock>,
     ) -> InterpResult<'tcx>;
 
     /// Called for read access to a foreign static item.

--- a/src/librustc_mir/interpret/mod.rs
+++ b/src/librustc_mir/interpret/mod.rs
@@ -26,7 +26,7 @@ pub use self::place::{Place, PlaceTy, MemPlace, MPlaceTy};
 
 pub use self::memory::{Memory, MemoryKind, AllocCheck, FnVal};
 
-pub use self::machine::{Machine, AllocMap, MayLeak};
+pub use self::machine::{Machine, AllocMap, MayLeak, StackPopInfo};
 
 pub use self::operand::{ScalarMaybeUndef, Immediate, ImmTy, Operand, OpTy};
 

--- a/src/librustc_mir/interpret/snapshot.rs
+++ b/src/librustc_mir/interpret/snapshot.rs
@@ -326,7 +326,7 @@ struct FrameSnapshot<'a, 'tcx> {
     return_to_block: &'a StackPopCleanup,
     return_place: Option<Place<(), AllocIdSnapshot<'a>>>,
     locals: IndexVec<mir::Local, LocalValue<(), AllocIdSnapshot<'a>>>,
-    block: &'a mir::BasicBlock,
+    block: Option<mir::BasicBlock>,
     stmt: usize,
 }
 
@@ -364,7 +364,7 @@ impl<'a, 'mir, 'tcx, Ctx> Snapshot<'a, Ctx> for &'a Frame<'mir, 'tcx>
             instance: *instance,
             span: *span,
             return_to_block,
-            block,
+            block: *block,
             stmt: *stmt,
             return_place: return_place.map(|r| r.snapshot(ctx)),
             locals: locals.iter().map(|local| local.snapshot(ctx)).collect(),

--- a/src/librustc_mir/interpret/snapshot.rs
+++ b/src/librustc_mir/interpret/snapshot.rs
@@ -315,7 +315,7 @@ impl<'a, Ctx> Snapshot<'a, Ctx> for &'a Allocation
 }
 
 impl_stable_hash_for!(enum crate::interpret::eval_context::StackPopCleanup {
-    Goto(block),
+    Goto { ret, unwind },
     None { cleanup },
 });
 

--- a/src/librustc_mir/interpret/step.rs
+++ b/src/librustc_mir/interpret/step.rs
@@ -290,6 +290,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
 
         let old_stack = self.cur_frame();
         let old_bb = self.frame().block;
+
         self.eval_terminator(terminator)?;
         if !self.stack.is_empty() {
             // This should change *something*

--- a/src/librustc_mir/interpret/step.rs
+++ b/src/librustc_mir/interpret/step.rs
@@ -49,7 +49,16 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             return Ok(false);
         }
 
-        let block = self.frame().block;
+        let block = match self.frame().block {
+            Some(block) => block,
+            None => {
+                // We are unwinding and this fn has no cleanup code.
+                // Just go on unwinding.
+                trace!("unwinding: skipping frame");
+                self.pop_stack_frame(/* unwinding */ true)?;
+                return Ok(true)
+            }
+        };
         let stmt_id = self.frame().stmt;
         let body = self.body();
         let basic_block = &body.basic_blocks()[block];

--- a/src/librustc_mir/interpret/terminator.rs
+++ b/src/librustc_mir/interpret/terminator.rs
@@ -265,7 +265,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         match instance.def {
             ty::InstanceDef::Intrinsic(..) => {
                 let old_stack = self.cur_frame();
-                M::call_intrinsic(self, span, instance, args, dest)?;
+                M::call_intrinsic(self, span, instance, args, dest, ret, unwind)?;
                 // No stack frame gets pushed, the main loop will just act as if the
                 // call completed.
                 if ret.is_some() {

--- a/src/librustc_mir/interpret/terminator.rs
+++ b/src/librustc_mir/interpret/terminator.rs
@@ -15,7 +15,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
     #[inline]
     pub fn goto_block(&mut self, target: Option<mir::BasicBlock>) -> InterpResult<'tcx> {
         if let Some(target) = target {
-            self.frame_mut().block = target;
+            self.frame_mut().block = Some(target);
             self.frame_mut().stmt = 0;
             Ok(())
         } else {

--- a/src/librustc_mir/interpret/terminator.rs
+++ b/src/librustc_mir/interpret/terminator.rs
@@ -264,11 +264,6 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
 
         match instance.def {
             ty::InstanceDef::Intrinsic(..) => {
-
-                if caller_abi != Abi::RustIntrinsic {
-                    throw_unsup!(FunctionAbiMismatch(caller_abi, Abi::RustIntrinsic))
-                }
-
                 M::call_intrinsic(self, span, instance, args, dest)?;
                 // No stack frame gets pushed, the main loop will just act as if the
                 // call completed.

--- a/src/librustc_mir/interpret/terminator.rs
+++ b/src/librustc_mir/interpret/terminator.rs
@@ -269,12 +269,6 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                     throw_unsup!(FunctionAbiMismatch(caller_abi, Abi::RustIntrinsic))
                 }
 
-                // The intrinsic itself cannot diverge, so if we got here without a return
-                // place... (can happen e.g., for transmute returning `!`)
-                let dest = match dest {
-                    Some(dest) => dest,
-                    None => throw_ub!(Unreachable)
-                };
                 M::call_intrinsic(self, span, instance, args, dest)?;
                 // No stack frame gets pushed, the main loop will just act as if the
                 // call completed.

--- a/src/librustc_mir/interpret/terminator.rs
+++ b/src/librustc_mir/interpret/terminator.rs
@@ -31,7 +31,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         match terminator.kind {
             Return => {
                 self.frame().return_place.map(|r| self.dump_place(*r));
-                self.pop_stack_frame()?
+                self.pop_stack_frame(/* unwinding */ false)?
             }
 
             Goto { target } => self.goto_block(Some(target))?,
@@ -67,6 +67,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 ref func,
                 ref args,
                 ref destination,
+                ref cleanup,
                 ..
             } => {
                 let (dest, ret) = match *destination {
@@ -98,13 +99,14 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                     &args[..],
                     dest,
                     ret,
+                    *cleanup
                 )?;
             }
 
             Drop {
                 ref location,
                 target,
-                ..
+                unwind,
             } => {
                 // FIXME(CTFE): forbid drop in const eval
                 let place = self.eval_place(location)?;
@@ -117,6 +119,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                     instance,
                     terminator.source_info.span,
                     target,
+                    unwind
                 )?;
             }
 
@@ -160,10 +163,21 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 }
             }
 
+
+            // When we encounter Resume, we've finished unwinding
+            // cleanup for the current stack frame. We pop it in order
+            // to continue unwinding the next frame
+            Resume => {
+                trace!("unwinding: resuming from cleanup");
+                // By definition, a Resume terminaor means
+                // that we're unwinding
+                self.pop_stack_frame(/* unwinding */ true)?;
+                return Ok(())
+            },
+
             Yield { .. } |
             GeneratorDrop |
             DropAndReplace { .. } |
-            Resume |
             Abort => unimplemented!("{:#?}", terminator.kind),
             FalseEdges { .. } => bug!("should have been eliminated by\
                                       `simplify_branches` mir pass"),
@@ -237,6 +251,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         args: &[OpTy<'tcx, M::PointerTag>],
         dest: Option<PlaceTy<'tcx, M::PointerTag>>,
         ret: Option<mir::BasicBlock>,
+        unwind: Option<mir::BasicBlock>
     ) -> InterpResult<'tcx> {
         trace!("eval_fn_call: {:#?}", fn_val);
 
@@ -249,6 +264,11 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
 
         match instance.def {
             ty::InstanceDef::Intrinsic(..) => {
+
+                if caller_abi != Abi::RustIntrinsic {
+                    throw_unsup!(FunctionAbiMismatch(caller_abi, Abi::RustIntrinsic))
+                }
+
                 // The intrinsic itself cannot diverge, so if we got here without a return
                 // place... (can happen e.g., for transmute returning `!`)
                 let dest = match dest {
@@ -259,7 +279,9 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 // No stack frame gets pushed, the main loop will just act as if the
                 // call completed.
                 self.goto_block(ret)?;
-                self.dump_place(*dest);
+                if let Some(dest) = dest {
+                    self.dump_place(*dest)
+                }
                 Ok(())
             }
             ty::InstanceDef::VtableShim(..) |
@@ -294,7 +316,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 }
 
                 // We need MIR for this fn
-                let body = match M::find_fn(self, instance, args, dest, ret)? {
+                let body = match M::find_fn(self, instance, args, dest, ret, unwind)? {
                     Some(body) => body,
                     None => return Ok(()),
                 };
@@ -304,7 +326,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                     span,
                     body,
                     dest,
-                    StackPopCleanup::Goto(ret),
+                    StackPopCleanup::Goto { ret, unwind }
                 )?;
 
                 // We want to pop this frame again in case there was an error, to put
@@ -422,7 +444,6 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             // cannot use the shim here, because that will only result in infinite recursion
             ty::InstanceDef::Virtual(_, idx) => {
                 let mut args = args.to_vec();
-                let ptr_size = self.pointer_size();
                 // We have to implement all "object safe receivers".  Currently we
                 // support built-in pointers (&, &mut, Box) as well as unsized-self.  We do
                 // not yet support custom self types.
@@ -439,15 +460,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 };
                 // Find and consult vtable
                 let vtable = receiver_place.vtable();
-                let vtable_slot = vtable.ptr_offset(ptr_size * (idx as u64 + 3), self)?;
-                let vtable_slot = self.memory.check_ptr_access(
-                    vtable_slot,
-                    ptr_size,
-                    self.tcx.data_layout.pointer_align.abi,
-                )?.expect("cannot be a ZST");
-                let fn_ptr = self.memory.get_raw(vtable_slot.alloc_id)?
-                    .read_ptr_sized(self, vtable_slot)?.not_undef()?;
-                let drop_fn = self.memory.get_fn(fn_ptr)?;
+                let drop_fn = self.get_vtable_slot(vtable, idx)?;
 
                 // `*mut receiver_place.layout.ty` is almost the layout that we
                 // want for args[0]: We have to project to field 0 because we want
@@ -462,7 +475,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 });
                 trace!("Patched self operand to {:#?}", args[0]);
                 // recurse with concrete function
-                self.eval_fn_call(drop_fn, span, caller_abi, &args, dest, ret)
+                self.eval_fn_call(drop_fn, span, caller_abi, &args, dest, ret, unwind)
             }
         }
     }
@@ -473,6 +486,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         instance: ty::Instance<'tcx>,
         span: Span,
         target: mir::BasicBlock,
+        unwind: Option<mir::BasicBlock>
     ) -> InterpResult<'tcx> {
         trace!("drop_in_place: {:?},\n  {:?}, {:?}", *place, place.layout.ty, instance);
         // We take the address of the object.  This may well be unaligned, which is fine
@@ -503,6 +517,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             &[arg.into()],
             Some(dest.into()),
             Some(target),
+            unwind
         )
     }
 }

--- a/src/librustc_mir/interpret/terminator.rs
+++ b/src/librustc_mir/interpret/terminator.rs
@@ -265,6 +265,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         match instance.def {
             ty::InstanceDef::Intrinsic(..) => {
                 let old_stack = self.cur_frame();
+                let old_bb = self.frame().block;
                 M::call_intrinsic(self, span, instance, args, dest, ret, unwind)?;
                 // No stack frame gets pushed, the main loop will just act as if the
                 // call completed.
@@ -275,7 +276,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                     // then the intrinsic implementation should have
                     // changed the stack frame (otherwise, we'll end
                     // up trying to execute this intrinsic call again)
-                    assert!(self.cur_frame() != old_stack);
+                    debug_assert!(self.cur_frame() != old_stack || self.frame().block != old_bb);
                 }
                 if let Some(dest) = dest {
                     self.dump_place(*dest)

--- a/src/librustc_mir/interpret/terminator.rs
+++ b/src/librustc_mir/interpret/terminator.rs
@@ -169,7 +169,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             // to continue unwinding the next frame
             Resume => {
                 trace!("unwinding: resuming from cleanup");
-                // By definition, a Resume terminaor means
+                // By definition, a Resume terminator means
                 // that we're unwinding
                 self.pop_stack_frame(/* unwinding */ true)?;
                 return Ok(())

--- a/src/librustc_mir/interpret/traits.rs
+++ b/src/librustc_mir/interpret/traits.rs
@@ -97,6 +97,27 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         Ok(vtable)
     }
 
+    /// Resolve the function at the specified slot in the provided
+    /// vtable. An index of '0' corresponds to the first method
+    /// declared in the trait of the provided vtable
+    pub fn get_vtable_slot(
+        &self,
+        vtable: Scalar<M::PointerTag>,
+        idx: usize
+    ) -> InterpResult<'tcx, FnVal<'tcx, M::ExtraFnVal>> {
+        let ptr_size = self.pointer_size();
+        // Skip over the 'drop_ptr', 'size', and 'align' fields
+        let vtable_slot = vtable.ptr_offset(ptr_size * (idx as u64 + 3), self)?;
+        let vtable_slot = self.memory.check_ptr_access(
+            vtable_slot,
+            ptr_size,
+            self.tcx.data_layout.pointer_align.abi,
+        )?.expect("cannot be a ZST");
+        let fn_ptr = self.memory.get(vtable_slot.alloc_id)?
+            .read_ptr_sized(self, vtable_slot)?.not_undef()?;
+        Ok(self.memory.get_fn(fn_ptr)?)
+    }
+
     /// Returns the drop fn instance as well as the actual dynamic type
     pub fn read_drop_type_from_vtable(
         &self,

--- a/src/librustc_mir/interpret/traits.rs
+++ b/src/librustc_mir/interpret/traits.rs
@@ -113,7 +113,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             ptr_size,
             self.tcx.data_layout.pointer_align.abi,
         )?.expect("cannot be a ZST");
-        let fn_ptr = self.memory.get(vtable_slot.alloc_id)?
+        let fn_ptr = self.memory.get_raw(vtable_slot.alloc_id)?
             .read_ptr_sized(self, vtable_slot)?.not_undef()?;
         Ok(self.memory.get_fn(fn_ptr)?)
     }

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -164,6 +164,8 @@ impl<'mir, 'tcx> interpret::Machine<'mir, 'tcx> for ConstPropMachine {
         _instance: ty::Instance<'tcx>,
         _args: &[OpTy<'tcx>],
         _dest: Option<PlaceTy<'tcx>>,
+        _ret: Option<BasicBlock>,
+        _unwind: Option<BasicBlock>
     ) -> InterpResult<'tcx> {
         throw_unsup_format!("calling intrinsics isn't supported in ConstProp");
     }

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -30,7 +30,7 @@ use crate::interpret::{
     self, InterpCx, ScalarMaybeUndef, Immediate, OpTy,
     StackPopCleanup, LocalValue, LocalState, AllocId, Frame,
     Allocation, MemoryKind, ImmTy, Pointer, Memory, PlaceTy,
-    Operand as InterpOperand,
+    StackPopInfo, Operand as InterpOperand,
 };
 use crate::const_eval::error_to_const_error;
 use crate::transform::{MirPass, MirSource};
@@ -143,6 +143,7 @@ impl<'mir, 'tcx> interpret::Machine<'mir, 'tcx> for ConstPropMachine {
         _args: &[OpTy<'tcx>],
         _dest: Option<PlaceTy<'tcx>>,
         _ret: Option<BasicBlock>,
+        _unwind: Option<BasicBlock>,
     ) -> InterpResult<'tcx, Option<&'mir Body<'tcx>>> {
         Ok(None)
     }
@@ -162,7 +163,7 @@ impl<'mir, 'tcx> interpret::Machine<'mir, 'tcx> for ConstPropMachine {
         _span: Span,
         _instance: ty::Instance<'tcx>,
         _args: &[OpTy<'tcx>],
-        _dest: PlaceTy<'tcx>,
+        _dest: Option<PlaceTy<'tcx>>,
     ) -> InterpResult<'tcx> {
         throw_unsup_format!("calling intrinsics isn't supported in ConstProp");
     }
@@ -254,8 +255,11 @@ impl<'mir, 'tcx> interpret::Machine<'mir, 'tcx> for ConstPropMachine {
 
     /// Called immediately before a stack frame gets popped.
     #[inline(always)]
-    fn stack_pop(_ecx: &mut InterpCx<'mir, 'tcx, Self>, _extra: ()) -> InterpResult<'tcx> {
-        Ok(())
+    fn stack_pop(
+        _ecx: &mut InterpCx<'mir, 'tcx, Self>,
+        _extra: ()
+    ) -> InterpResult<'tcx, StackPopInfo> {
+        Ok(StackPopInfo::Normal)
     }
 }
 

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -30,7 +30,7 @@ use crate::interpret::{
     self, InterpCx, ScalarMaybeUndef, Immediate, OpTy,
     StackPopCleanup, LocalValue, LocalState, AllocId, Frame,
     Allocation, MemoryKind, ImmTy, Pointer, Memory, PlaceTy,
-    StackPopInfo, Operand as InterpOperand,
+    Operand as InterpOperand,
 };
 use crate::const_eval::error_to_const_error;
 use crate::transform::{MirPass, MirSource};
@@ -251,15 +251,6 @@ impl<'mir, 'tcx> interpret::Machine<'mir, 'tcx> for ConstPropMachine {
     #[inline(always)]
     fn stack_push(_ecx: &mut InterpCx<'mir, 'tcx, Self>) -> InterpResult<'tcx> {
         Ok(())
-    }
-
-    /// Called immediately before a stack frame gets popped.
-    #[inline(always)]
-    fn stack_pop(
-        _ecx: &mut InterpCx<'mir, 'tcx, Self>,
-        _extra: ()
-    ) -> InterpResult<'tcx, StackPopInfo> {
-        Ok(StackPopInfo::Normal)
     }
 }
 

--- a/src/librustc_typeck/check/intrinsic.rs
+++ b/src/librustc_typeck/check/intrinsic.rs
@@ -385,7 +385,9 @@ pub fn check_intrinsic_type(tcx: TyCtxt<'_>, it: &hir::ForeignItem) {
             }
 
             "miri_start_panic" => {
-                (0, vec![tcx.mk_mut_ptr(tcx.mk_slice(tcx.mk_unit()))], tcx.types.never)
+                // TODO - the relevant types aren't lang items,
+                // so it's not trivial to check this
+                return;
             }
 
             ref other => {

--- a/src/librustc_typeck/check/intrinsic.rs
+++ b/src/librustc_typeck/check/intrinsic.rs
@@ -384,6 +384,10 @@ pub fn check_intrinsic_type(tcx: TyCtxt<'_>, it: &hir::ForeignItem) {
                 (1, vec![ tcx.mk_mut_ptr(param(0)), param(0) ], tcx.mk_unit())
             }
 
+            "miri_start_panic" => {
+                (0, vec![tcx.types.u128], tcx.types.never)
+            }
+
             ref other => {
                 struct_span_err!(tcx.sess, it.span, E0093,
                                  "unrecognized intrinsic function: `{}`",

--- a/src/librustc_typeck/check/intrinsic.rs
+++ b/src/librustc_typeck/check/intrinsic.rs
@@ -385,7 +385,7 @@ pub fn check_intrinsic_type(tcx: TyCtxt<'_>, it: &hir::ForeignItem) {
             }
 
             "miri_start_panic" => {
-                // TODO - the relevant types aren't lang items,
+                // FIXME - the relevant types aren't lang items,
                 // so it's not trivial to check this
                 return;
             }

--- a/src/librustc_typeck/check/intrinsic.rs
+++ b/src/librustc_typeck/check/intrinsic.rs
@@ -385,7 +385,7 @@ pub fn check_intrinsic_type(tcx: TyCtxt<'_>, it: &hir::ForeignItem) {
             }
 
             "miri_start_panic" => {
-                (0, vec![tcx.types.u128], tcx.types.never)
+                (0, vec![tcx.mk_mut_ptr(tcx.mk_slice(tcx.mk_unit()))], tcx.types.never)
             }
 
             ref other => {

--- a/src/libstd/sys_common/backtrace.rs
+++ b/src/libstd/sys_common/backtrace.rs
@@ -66,7 +66,14 @@ unsafe fn _print(w: &mut dyn Write, format: PrintFmt) -> io::Result<()> {
 }
 
 unsafe fn _print_fmt(fmt: &mut fmt::Formatter<'_>, print_fmt: PrintFmt) -> fmt::Result {
-    let cwd = env::current_dir().ok();
+    // Always 'fail' to get the cwd when running under Miri -
+    // this allows Miri to display backtraces in isolation mode
+    let cwd = if !cfg!(miri) {
+        env::current_dir().ok()
+    } else {
+        None
+    };
+
     let mut print_path = move |fmt: &mut fmt::Formatter<'_>, bows: BytesOrWideString<'_>| {
         output_filename(fmt, bows, print_fmt, cwd.as_ref())
     };


### PR DESCRIPTION
This commits adds in some additional hooks to allow Miri to properly
handle panic unwinding. None of this should have any impact on CTFE mode

This supports https://github.com/rust-lang/miri/pull/693