### PR TITLE
SGX target: change re-entry abort logic

### DIFF
--- a/src/libstd/sys/sgx/abi/entry.S
+++ b/src/libstd/sys/sgx/abi/entry.S
@@ -65,10 +65,6 @@ IMAGE_BASE:
     /*  The size in bytes of enclacve EH_FRM_HDR section */
     globvar EH_FRM_HDR_SIZE 8
 
-.Lreentry_panic_msg:
-    .asciz "Re-entered aborted enclave!"
-.Lreentry_panic_msg_end:
-
 .org .Lxsave_clear+512
 .Lxsave_header:
     .int 0, 0 /*  XSTATE_BV */
@@ -210,10 +206,8 @@ sgx_entry:
 /*  end sgx_entry */
 
 .Lreentry_panic:
-    lea .Lreentry_panic_msg(%rip),%rdi
-    mov $.Lreentry_panic_msg_end-.Lreentry_panic_msg,%esi
     orq $8,%rsp
-    jmp panic_msg
+    jmp abort_reentry
 
 /*  This *MUST* be called with 6 parameters, otherwise register information */
 /*  might leak! */
@@ -279,10 +273,8 @@ usercall:
 /*
 The following functions need to be defined externally:
 ```
-// Called by entry code when it needs to panic
-extern "C" fn panic_msg(msg: &'static str) -> ! {
-    panic!(msg)
-}
+// Called by entry code on re-entry after exit
+extern "C" fn abort_reentry() -> !;
 
 // Called once when a TCS is first entered
 extern "C" fn tcs_init(secondary: bool);

--- a/src/libstd/sys/sgx/abi/mod.rs
+++ b/src/libstd/sys/sgx/abi/mod.rs
@@ -29,7 +29,7 @@ unsafe extern "C" fn tcs_init(secondary: bool) {
     static RELOC_STATE: AtomicUsize = AtomicUsize::new(UNINIT);
 
     if secondary && RELOC_STATE.load(Ordering::Relaxed) != DONE {
-        panic::panic_msg("Entered secondary TCS before main TCS!")
+        rtabort!("Entered secondary TCS before main TCS!")
     }
 
     // Try to atomically swap UNINIT with BUSY. The returned state can be:
@@ -91,4 +91,10 @@ pub(super) fn exit_with_code(code: isize) -> ! {
         }
     }
     usercalls::exit(code != 0);
+}
+
+#[cfg(not(test))]
+#[no_mangle]
+extern "C" fn abort_reentry() -> ! {
+    usercalls::exit(false)
 }

--- a/src/libstd/sys/sgx/abi/panic.rs
+++ b/src/libstd/sys/sgx/abi/panic.rs
@@ -1,4 +1,4 @@
-use super::usercalls::{alloc::UserRef, self};
+use super::usercalls::alloc::UserRef;
 use crate::cmp;
 use crate::io::{self, Write};
 use crate::mem;
@@ -47,10 +47,4 @@ impl Write for SgxPanicOutput {
     fn flush(&mut self) -> io::Result<()> {
         Ok(())
     }
-}
-
-#[cfg_attr(not(test), no_mangle)]
-pub extern "C" fn panic_msg(msg: &str) -> ! {
-    let _ = SgxPanicOutput::new().map(|mut out| out.write(msg.as_bytes()));
-    usercalls::exit(true)
 }


### PR DESCRIPTION
Even though re-entry after exit is generally not acceptable, there is a race condition where the enclave thinks it's exited but userspace doesn't know that yet. An entry during that time will currently result in an enclave panic (see https://github.com/rust-lang/rust/pull/59997#issuecomment-483846291, https://github.com/rust-lang/rust/pull/60003#issuecomment-483888170). Instead of panicking, just do a regular exit on re-entry.

cc @jseyfried 