### PR TITLE
Suggest appropriate path when calling associated item on bare types

### DIFF
--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -165,6 +165,10 @@ pub struct Session {
 
     /// `Span`s of trait methods that weren't found to avoid emitting object safety errors
     pub trait_methods_not_found: Lock<FxHashSet<Span>>,
+
+    /// Mapping from ident span to path span for paths that don't exist as written, but that
+    /// exist under `std`. For example, wrote `str::from_utf8` instead of `std::str::from_utf8`.
+    pub confused_type_with_std_module: Lock<FxHashMap<Span, Span>>,
 }
 
 pub struct PerfStats {
@@ -1248,6 +1252,7 @@ fn build_session_(
         has_panic_handler: Once::new(),
         driver_lint_caps,
         trait_methods_not_found: Lock::new(Default::default()),
+        confused_type_with_std_module: Lock::new(Default::default()),
     };
 
     validate_commandline_args_with_session_available(&sess);

--- a/src/test/ui/issues/issue-22933-3.stderr
+++ b/src/test/ui/issues/issue-22933-3.stderr
@@ -3,6 +3,10 @@ error[E0599]: no associated item named `MIN` found for type `u8` in the current 
    |
 LL | const FOO: [u32; u8::MIN as usize] = [];
    |                      ^^^ associated item not found in `u8`
+help: you are looking for the module in `std`, not the primitive type
+   |
+LL | const FOO: [u32; std::u8::MIN as usize] = [];
+   |                  ^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/suggest-std-when-using-type.rs
+++ b/src/test/ui/suggestions/suggest-std-when-using-type.rs
@@ -1,0 +1,7 @@
+fn main() {
+    let pi = f32::consts::PI; //~ ERROR ambiguous associated type
+    let bytes = "hello world".as_bytes();
+    let string = unsafe {
+        str::from_utf8(bytes) //~ ERROR no function or associated item named `from_utf8` found
+    };
+}

--- a/src/test/ui/suggestions/suggest-std-when-using-type.stderr
+++ b/src/test/ui/suggestions/suggest-std-when-using-type.stderr
@@ -1,0 +1,24 @@
+error[E0223]: ambiguous associated type
+  --> $DIR/suggest-std-when-using-type.rs:2:14
+   |
+LL |     let pi = f32::consts::PI;
+   |              ^^^^^^^^^^^^^^^
+help: you are looking for the module in `std`, not the primitive type
+   |
+LL |     let pi = std::f32::consts::PI;
+   |              ^^^^^^^^^^^^^^^^^^^^
+
+error[E0599]: no function or associated item named `from_utf8` found for type `str` in the current scope
+  --> $DIR/suggest-std-when-using-type.rs:5:14
+   |
+LL |         str::from_utf8(bytes)
+   |              ^^^^^^^^^ function or associated item not found in `str`
+help: you are looking for the module in `std`, not the primitive type
+   |
+LL |         std::str::from_utf8(bytes)
+   |         ^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0223, E0599.
+For more information about an error, try `rustc --explain E0223`.


### PR DESCRIPTION
When looking at the documentation for `std::f32` or `std::str`, for
example, it is easy to get confused and assume `std::f32` and `f32`
are the same thing. Because of this, it is not uncommon to attempt
writing `f32::consts::PI` instead of the correct
`std::f32::consts::PI`. When encountering the former, which results
in an access error due to it being an inexistent path, try to access
the same path under `std`. If this succeeds, this information is
stored for later tweaking of the final E0599 to provide an
appropriate suggestion.

Fix #26760, fix #46660.