### PR TITLE
Correct unused parameter diagnostic

### DIFF
--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -938,10 +938,12 @@ fn check_variances_for_type_defn<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                         .map(|(index, _)| Parameter(index as u32))
                         .collect();
 
-    identify_constrained_generic_params(tcx,
-                                     &ty_predicates,
-                                     None,
-                                     &mut constrained_parameters);
+    identify_constrained_generic_params(
+        tcx,
+        &ty_predicates,
+        None,
+        &mut constrained_parameters,
+    );
 
     for (index, _) in variances.iter().enumerate() {
         if constrained_parameters.contains(&Parameter(index as u32)) {
@@ -949,6 +951,7 @@ fn check_variances_for_type_defn<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         }
 
         let param = &hir_generics.params[index];
+
         match param.name {
             hir::ParamName::Error => { }
             _ => report_bivariance(tcx, param.span, param.name.ident().name),
@@ -1123,7 +1126,7 @@ fn error_392<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, span: Span, param_name: ast:
                        -> DiagnosticBuilder<'tcx> {
     let mut err = struct_span_err!(tcx.sess, span, E0392,
                   "parameter `{}` is never used", param_name);
-    err.span_label(span, "unused type parameter");
+    err.span_label(span, "unused parameter");
     err
 }
 

--- a/src/test/ui/error-codes/E0392.stderr
+++ b/src/test/ui/error-codes/E0392.stderr
@@ -2,7 +2,7 @@ error[E0392]: parameter `T` is never used
   --> $DIR/E0392.rs:1:10
    |
 LL | enum Foo<T> { Bar }
-   |          ^ unused type parameter
+   |          ^ unused parameter
    |
    = help: consider removing `T` or using a marker such as `std::marker::PhantomData`
 

--- a/src/test/ui/inner-static-type-parameter.stderr
+++ b/src/test/ui/inner-static-type-parameter.stderr
@@ -12,7 +12,7 @@ error[E0392]: parameter `T` is never used
   --> $DIR/inner-static-type-parameter.rs:3:10
    |
 LL | enum Bar<T> { What }
-   |          ^ unused type parameter
+   |          ^ unused parameter
    |
    = help: consider removing `T` or using a marker such as `std::marker::PhantomData`
 

--- a/src/test/ui/issues/issue-17904-2.stderr
+++ b/src/test/ui/issues/issue-17904-2.stderr
@@ -2,7 +2,7 @@ error[E0392]: parameter `T` is never used
   --> $DIR/issue-17904-2.rs:4:12
    |
 LL | struct Foo<T> where T: Copy;
-   |            ^ unused type parameter
+   |            ^ unused parameter
    |
    = help: consider removing `T` or using a marker such as `std::marker::PhantomData`
 

--- a/src/test/ui/issues/issue-20413.stderr
+++ b/src/test/ui/issues/issue-20413.stderr
@@ -2,7 +2,7 @@ error[E0392]: parameter `T` is never used
   --> $DIR/issue-20413.rs:5:15
    |
 LL | struct NoData<T>;
-   |               ^ unused type parameter
+   |               ^ unused parameter
    |
    = help: consider removing `T` or using a marker such as `std::marker::PhantomData`
 

--- a/src/test/ui/issues/issue-36299.stderr
+++ b/src/test/ui/issues/issue-36299.stderr
@@ -2,7 +2,7 @@ error[E0392]: parameter `'a` is never used
   --> $DIR/issue-36299.rs:1:12
    |
 LL | struct Foo<'a, A> {}
-   |            ^^ unused type parameter
+   |            ^^ unused parameter
    |
    = help: consider removing `'a` or using a marker such as `std::marker::PhantomData`
 
@@ -10,7 +10,7 @@ error[E0392]: parameter `A` is never used
   --> $DIR/issue-36299.rs:1:16
    |
 LL | struct Foo<'a, A> {}
-   |                ^ unused type parameter
+   |                ^ unused parameter
    |
    = help: consider removing `A` or using a marker such as `std::marker::PhantomData`
 

--- a/src/test/ui/issues/issue-36638.stderr
+++ b/src/test/ui/issues/issue-36638.stderr
@@ -14,7 +14,7 @@ error[E0392]: parameter `Self` is never used
   --> $DIR/issue-36638.rs:3:12
    |
 LL | struct Foo<Self>(Self);
-   |            ^^^^ unused type parameter
+   |            ^^^^ unused parameter
    |
    = help: consider removing `Self` or using a marker such as `std::marker::PhantomData`
 

--- a/src/test/ui/issues/issue-37534.stderr
+++ b/src/test/ui/issues/issue-37534.stderr
@@ -18,7 +18,7 @@ error[E0392]: parameter `T` is never used
   --> $DIR/issue-37534.rs:1:12
    |
 LL | struct Foo<T: ?Hash> { }
-   |            ^ unused type parameter
+   |            ^ unused parameter
    |
    = help: consider removing `T` or using a marker such as `std::marker::PhantomData`
 

--- a/src/test/ui/regions/region-bounds-on-objects-and-type-parameters.stderr
+++ b/src/test/ui/regions/region-bounds-on-objects-and-type-parameters.stderr
@@ -25,7 +25,7 @@ error[E0392]: parameter `'c` is never used
   --> $DIR/region-bounds-on-objects-and-type-parameters.rs:11:18
    |
 LL | struct Foo<'a,'b,'c> {
-   |                  ^^ unused type parameter
+   |                  ^^ unused parameter
    |
    = help: consider removing `'c` or using a marker such as `std::marker::PhantomData`
 

--- a/src/test/ui/self/self_type_keyword.stderr
+++ b/src/test/ui/self/self_type_keyword.stderr
@@ -62,7 +62,7 @@ error[E0392]: parameter `'Self` is never used
   --> $DIR/self_type_keyword.rs:8:12
    |
 LL | struct Bar<'Self>;
-   |            ^^^^^ unused type parameter
+   |            ^^^^^ unused parameter
    |
    = help: consider removing `'Self` or using a marker such as `std::marker::PhantomData`
 

--- a/src/test/ui/variance/variance-regions-unused-direct.stderr
+++ b/src/test/ui/variance/variance-regions-unused-direct.stderr
@@ -2,7 +2,7 @@ error[E0392]: parameter `'a` is never used
   --> $DIR/variance-regions-unused-direct.rs:5:18
    |
 LL | struct Bivariant<'a>;
-   |                  ^^ unused type parameter
+   |                  ^^ unused parameter
    |
    = help: consider removing `'a` or using a marker such as `std::marker::PhantomData`
 
@@ -10,7 +10,7 @@ error[E0392]: parameter `'d` is never used
   --> $DIR/variance-regions-unused-direct.rs:7:19
    |
 LL | struct Struct<'a, 'd> {
-   |                   ^^ unused type parameter
+   |                   ^^ unused parameter
    |
    = help: consider removing `'d` or using a marker such as `std::marker::PhantomData`
 

--- a/src/test/ui/variance/variance-regions-unused-indirect.stderr
+++ b/src/test/ui/variance/variance-regions-unused-indirect.stderr
@@ -2,7 +2,7 @@ error[E0392]: parameter `'a` is never used
   --> $DIR/variance-regions-unused-indirect.rs:3:10
    |
 LL | enum Foo<'a> {
-   |          ^^ unused type parameter
+   |          ^^ unused parameter
    |
    = help: consider removing `'a` or using a marker such as `std::marker::PhantomData`
 
@@ -10,7 +10,7 @@ error[E0392]: parameter `'a` is never used
   --> $DIR/variance-regions-unused-indirect.rs:7:10
    |
 LL | enum Bar<'a> {
-   |          ^^ unused type parameter
+   |          ^^ unused parameter
    |
    = help: consider removing `'a` or using a marker such as `std::marker::PhantomData`
 

--- a/src/test/ui/variance/variance-unused-region-param.stderr
+++ b/src/test/ui/variance/variance-unused-region-param.stderr
@@ -2,7 +2,7 @@ error[E0392]: parameter `'a` is never used
   --> $DIR/variance-unused-region-param.rs:3:19
    |
 LL | struct SomeStruct<'a> { x: u32 }
-   |                   ^^ unused type parameter
+   |                   ^^ unused parameter
    |
    = help: consider removing `'a` or using a marker such as `std::marker::PhantomData`
 
@@ -10,7 +10,7 @@ error[E0392]: parameter `'a` is never used
   --> $DIR/variance-unused-region-param.rs:4:15
    |
 LL | enum SomeEnum<'a> { Nothing }
-   |               ^^ unused type parameter
+   |               ^^ unused parameter
    |
    = help: consider removing `'a` or using a marker such as `std::marker::PhantomData`
 

--- a/src/test/ui/variance/variance-unused-type-param.stderr
+++ b/src/test/ui/variance/variance-unused-type-param.stderr
@@ -2,7 +2,7 @@ error[E0392]: parameter `A` is never used
   --> $DIR/variance-unused-type-param.rs:6:19
    |
 LL | struct SomeStruct<A> { x: u32 }
-   |                   ^ unused type parameter
+   |                   ^ unused parameter
    |
    = help: consider removing `A` or using a marker such as `std::marker::PhantomData`
 
@@ -10,7 +10,7 @@ error[E0392]: parameter `A` is never used
   --> $DIR/variance-unused-type-param.rs:9:15
    |
 LL | enum SomeEnum<A> { Nothing }
-   |               ^ unused type parameter
+   |               ^ unused parameter
    |
    = help: consider removing `A` or using a marker such as `std::marker::PhantomData`
 
@@ -18,7 +18,7 @@ error[E0392]: parameter `T` is never used
   --> $DIR/variance-unused-type-param.rs:13:15
    |
 LL | enum ListCell<T> {
-   |               ^ unused type parameter
+   |               ^ unused parameter
    |
    = help: consider removing `T` or using a marker such as `std::marker::PhantomData`
 


### PR DESCRIPTION
The message was incorrect for unused lifetime parameters. There's no need to be specific.