### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/src/liballoc/str.rs
+++ b/src/liballoc/str.rs
@@ -68,6 +68,8 @@ pub use core::str::pattern;
 pub use core::str::EncodeUtf16;
 #[stable(feature = "split_ascii_whitespace", since = "1.34.0")]
 pub use core::str::SplitAsciiWhitespace;
+#[stable(feature = "str_escape", since = "1.34.0")]
+pub use core::str::{EscapeDebug, EscapeDefault, EscapeUnicode};
 
 #[unstable(feature = "slice_concat_ext",
            reason = "trait should not have to exist",

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -234,12 +234,12 @@ fn resolve_struct_error<'sess, 'a>(resolver: &'sess Resolver<'_>,
                 },
                 Def::TyParam(def_id) => {
                     if let Some(span) = resolver.definitions.opt_span(def_id) {
-                        err.span_label(span, "type variable from outer function");
+                        err.span_label(span, "type parameter from outer function");
                     }
                 }
                 Def::ConstParam(def_id) => {
                     if let Some(span) = resolver.definitions.opt_span(def_id) {
-                        err.span_label(span, "const variable from outer function");
+                        err.span_label(span, "const parameter from outer function");
                     }
                 }
                 _ => {

--- a/src/libstd/collections/mod.rs
+++ b/src/libstd/collections/mod.rs
@@ -150,10 +150,9 @@
 //! Any `with_capacity` constructor will instruct the collection to allocate
 //! enough space for the specified number of elements. Ideally this will be for
 //! exactly that many elements, but some implementation details may prevent
-//! this. [`Vec`] and [`VecDeque`] can be relied on to allocate exactly the
-//! requested amount, though. Use `with_capacity` when you know exactly how many
-//! elements will be inserted, or at least have a reasonable upper-bound on that
-//! number.
+//! this. See collection-specific documentation for details. In general, use
+//! `with_capacity` when you know exactly how many elements will be inserted, or
+//! at least have a reasonable upper-bound on that number.
 //!
 //! When anticipating a large influx of elements, the `reserve` family of
 //! methods can be used to hint to the collection how much room it should make

--- a/src/test/ui/bad/bad-type-env-capture.stderr
+++ b/src/test/ui/bad/bad-type-env-capture.stderr
@@ -2,7 +2,7 @@ error[E0401]: can't use generic parameters from outer function
   --> $DIR/bad-type-env-capture.rs:2:15
    |
 LL | fn foo<T>() {
-   |        - type variable from outer function
+   |        - type parameter from outer function
 LL |     fn bar(b: T) { }
    |        ---    ^ use of generic parameter from outer function
    |        |

--- a/src/test/ui/const-generics/const-param-from-outer-fn.stderr
+++ b/src/test/ui/const-generics/const-param-from-outer-fn.stderr
@@ -8,7 +8,7 @@ error[E0401]: can't use generic parameters from outer function
   --> $DIR/const-param-from-outer-fn.rs:6:9
    |
 LL | fn foo<const X: u32>() {
-   |              - const variable from outer function
+   |              - const parameter from outer function
 LL |     fn bar() -> u32 {
    |        --- try adding a local generic parameter in this method instead
 LL |         X

--- a/src/test/ui/error-codes/E0401.stderr
+++ b/src/test/ui/error-codes/E0401.stderr
@@ -2,7 +2,7 @@ error[E0401]: can't use generic parameters from outer function
   --> $DIR/E0401.rs:4:39
    |
 LL | fn foo<T>(x: T) {
-   |        - type variable from outer function
+   |        - type parameter from outer function
 LL |     fn bfnr<U, V: Baz<U>, W: Fn()>(y: T) {
    |        ---------------------------    ^ use of generic parameter from outer function
    |        |
@@ -12,7 +12,7 @@ error[E0401]: can't use generic parameters from outer function
   --> $DIR/E0401.rs:9:16
    |
 LL | fn foo<T>(x: T) {
-   |        - type variable from outer function
+   |        - type parameter from outer function
 ...
 LL |     fn baz<U,
    |        --- try adding a local generic parameter in this method instead

--- a/src/test/ui/inner-static-type-parameter.stderr
+++ b/src/test/ui/inner-static-type-parameter.stderr
@@ -2,7 +2,7 @@ error[E0401]: can't use generic parameters from outer function
   --> $DIR/inner-static-type-parameter.rs:6:19
    |
 LL | fn foo<T>() {
-   |    --- - type variable from outer function
+   |    --- - type parameter from outer function
    |    |
    |    try adding a local generic parameter in this method instead
 LL |     static a: Bar<T> = Bar::What;

--- a/src/test/ui/issues/issue-3021-c.stderr
+++ b/src/test/ui/issues/issue-3021-c.stderr
@@ -2,7 +2,7 @@ error[E0401]: can't use generic parameters from outer function
   --> $DIR/issue-3021-c.rs:4:24
    |
 LL | fn siphash<T>() {
-   |            - type variable from outer function
+   |            - type parameter from outer function
 ...
 LL |         fn g(&self, x: T) -> T;
    |            -           ^ use of generic parameter from outer function
@@ -13,7 +13,7 @@ error[E0401]: can't use generic parameters from outer function
   --> $DIR/issue-3021-c.rs:4:30
    |
 LL | fn siphash<T>() {
-   |            - type variable from outer function
+   |            - type parameter from outer function
 ...
 LL |         fn g(&self, x: T) -> T;
    |            -                 ^ use of generic parameter from outer function

--- a/src/test/ui/issues/issue-3214.stderr
+++ b/src/test/ui/issues/issue-3214.stderr
@@ -2,7 +2,7 @@ error[E0401]: can't use generic parameters from outer function
   --> $DIR/issue-3214.rs:3:12
    |
 LL | fn foo<T>() {
-   |    --- - type variable from outer function
+   |    --- - type parameter from outer function
    |    |
    |    try adding a local generic parameter in this method instead
 LL |     struct Foo {

--- a/src/test/ui/issues/issue-5997-enum.stderr
+++ b/src/test/ui/issues/issue-5997-enum.stderr
@@ -2,7 +2,7 @@ error[E0401]: can't use generic parameters from outer function
   --> $DIR/issue-5997-enum.rs:2:16
    |
 LL | fn f<Z>() -> bool {
-   |    - - type variable from outer function
+   |    - - type parameter from outer function
    |    |
    |    try adding a local generic parameter in this method instead
 LL |     enum E { V(Z) }

--- a/src/test/ui/issues/issue-5997-struct.stderr
+++ b/src/test/ui/issues/issue-5997-struct.stderr
@@ -2,7 +2,7 @@ error[E0401]: can't use generic parameters from outer function
   --> $DIR/issue-5997-struct.rs:2:14
    |
 LL | fn f<T>() -> bool {
-   |    - - type variable from outer function
+   |    - - type parameter from outer function
    |    |
    |    try adding a local generic parameter in this method instead
 LL |     struct S(T);

--- a/src/test/ui/nested-ty-params.stderr
+++ b/src/test/ui/nested-ty-params.stderr
@@ -2,7 +2,7 @@ error[E0401]: can't use generic parameters from outer function
   --> $DIR/nested-ty-params.rs:3:16
    |
 LL | fn hd<U>(v: Vec<U> ) -> U {
-   |       - type variable from outer function
+   |       - type parameter from outer function
 LL |     fn hd1(w: [U]) -> U { return w[0]; }
    |        ---     ^ use of generic parameter from outer function
    |        |
@@ -12,7 +12,7 @@ error[E0401]: can't use generic parameters from outer function
   --> $DIR/nested-ty-params.rs:3:23
    |
 LL | fn hd<U>(v: Vec<U> ) -> U {
-   |       - type variable from outer function
+   |       - type parameter from outer function
 LL |     fn hd1(w: [U]) -> U { return w[0]; }
    |        ---            ^ use of generic parameter from outer function
    |        |

--- a/src/test/ui/resolve/resolve-type-param-in-item-in-trait.stderr
+++ b/src/test/ui/resolve/resolve-type-param-in-item-in-trait.stderr
@@ -2,7 +2,7 @@ error[E0401]: can't use generic parameters from outer function
   --> $DIR/resolve-type-param-in-item-in-trait.rs:8:22
    |
 LL | trait TraitA<A> {
-   |              - type variable from outer function
+   |              - type parameter from outer function
 LL |     fn outer(&self) {
    |        ----- try adding a local generic parameter in this method instead
 LL |         enum Foo<B> {
@@ -13,7 +13,7 @@ error[E0401]: can't use generic parameters from outer function
   --> $DIR/resolve-type-param-in-item-in-trait.rs:16:23
    |
 LL | trait TraitB<A> {
-   |              - type variable from outer function
+   |              - type parameter from outer function
 LL |     fn outer(&self) {
    |        ----- try adding a local generic parameter in this method instead
 LL |         struct Foo<B>(A);
@@ -23,7 +23,7 @@ error[E0401]: can't use generic parameters from outer function
   --> $DIR/resolve-type-param-in-item-in-trait.rs:23:28
    |
 LL | trait TraitC<A> {
-   |              - type variable from outer function
+   |              - type parameter from outer function
 LL |     fn outer(&self) {
    |        ----- try adding a local generic parameter in this method instead
 LL |         struct Foo<B> { a: A }
@@ -33,7 +33,7 @@ error[E0401]: can't use generic parameters from outer function
   --> $DIR/resolve-type-param-in-item-in-trait.rs:30:22
    |
 LL | trait TraitD<A> {
-   |              - type variable from outer function
+   |              - type parameter from outer function
 LL |     fn outer(&self) {
 LL |         fn foo<B>(a: A) { }
    |            ------    ^ use of generic parameter from outer function

--- a/src/test/ui/type/type-arg-out-of-scope.stderr
+++ b/src/test/ui/type/type-arg-out-of-scope.stderr
@@ -2,7 +2,7 @@ error[E0401]: can't use generic parameters from outer function
   --> $DIR/type-arg-out-of-scope.rs:3:25
    |
 LL | fn foo<T>(x: T) {
-   |        - type variable from outer function
+   |        - type parameter from outer function
 LL |     fn bar(f: Box<FnMut(T) -> T>) { }
    |        ---              ^ use of generic parameter from outer function
    |        |
@@ -12,7 +12,7 @@ error[E0401]: can't use generic parameters from outer function
   --> $DIR/type-arg-out-of-scope.rs:3:31
    |
 LL | fn foo<T>(x: T) {
-   |        - type variable from outer function
+   |        - type parameter from outer function
 LL |     fn bar(f: Box<FnMut(T) -> T>) { }
    |        ---                    ^ use of generic parameter from outer function
    |        |

--- a/src/tools/publish_toolstate.py
+++ b/src/tools/publish_toolstate.py
@@ -16,8 +16,8 @@ except ImportError:
 MAINTAINERS = {
     'miri': '@oli-obk @RalfJung @eddyb',
     'clippy-driver': '@Manishearth @llogiq @mcarton @oli-obk @phansch',
-    'rls': '@nrc @Xanewok',
-    'rustfmt': '@nrc @topecongiro',
+    'rls': '@Xanewok',
+    'rustfmt': '@topecongiro',
     'book': '@carols10cents @steveklabnik',
     'nomicon': '@frewsxcv @Gankro',
     'reference': '@steveklabnik @Havvy @matthewjasper @ehuss',


### PR DESCRIPTION
Successful merges:

 - #59908 (Re-export core::str::{EscapeDebug, EscapeDefault, EscapeUnicode} in std)
 - #59984 (Remove collection-specific `with_capacity` documentation from `std::collections`)
 - #60036 (Remove nrc from toolstate pings)
 - #60037 (Resolve inconsistency in error messages between "parameter" and "variable".)

Failed merges:


r? @ghost