### PR TITLE
whitelist RTM x86 target cpu feature

### DIFF
--- a/src/librustc_codegen_llvm/llvm_util.rs
+++ b/src/librustc_codegen_llvm/llvm_util.rs
@@ -154,6 +154,7 @@ const X86_WHITELIST: &[(&str, Option<&str>)] = &[
     ("popcnt", None),
     ("rdrand", None),
     ("rdseed", None),
+    ("rtm", Some("rtm_target_feature")),
     ("sha", None),
     ("sse", None),
     ("sse2", None),

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -2432,6 +2432,7 @@ fn from_target_feature(
                 Some("cmpxchg16b_target_feature") => rust_features.cmpxchg16b_target_feature,
                 Some("adx_target_feature") => rust_features.adx_target_feature,
                 Some("movbe_target_feature") => rust_features.movbe_target_feature,
+                Some("rtm_target_feature") => rust_features.rtm_target_feature,
                 Some(name) => bug!("unknown target feature gate {}", name),
                 None => true,
             };

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -402,6 +402,7 @@ declare_features! (
     (active, adx_target_feature, "1.32.0", Some(44839), None),
     (active, cmpxchg16b_target_feature, "1.32.0", Some(44839), None),
     (active, movbe_target_feature, "1.34.0", Some(44839), None),
+    (active, rtm_target_feature, "1.35.0", Some(44839), None),
 
     // Allows macro invocations on modules expressions and statements and
     // procedural macros to expand to non-items.

--- a/src/test/ui/target-feature-gate.rs
+++ b/src/test/ui/target-feature-gate.rs
@@ -23,6 +23,7 @@
 // gate-test-adx_target_feature
 // gate-test-cmpxchg16b_target_feature
 // gate-test-movbe_target_feature
+// gate-test-rtm_target_feature
 // min-llvm-version 6.0
 
 #[target_feature(enable = "avx512bw")]

--- a/src/test/ui/target-feature-gate.stderr
+++ b/src/test/ui/target-feature-gate.stderr
@@ -1,5 +1,5 @@
 error[E0658]: the target feature `avx512bw` is currently unstable
-  --> $DIR/target-feature-gate.rs:28:18
+  --> $DIR/target-feature-gate.rs:29:18
    |
 LL | #[target_feature(enable = "avx512bw")]
    |                  ^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This PR adds support for intels restricted transactional memory cpu feature. I mostly copied what was done for the [movbe](https://github.com/rust-lang/rust/pull/57999) feature.

https://github.com/rust-lang-nursery/stdsimd/issues/718