### PR TITLE
make liballoc internal test suite mostly pass in Miri

### DIFF
--- a/src/liballoc/alloc.rs
+++ b/src/liballoc/alloc.rs
@@ -252,6 +252,7 @@ mod tests {
     }
 
     #[bench]
+    #[cfg(not(miri))] // Miri does not support benchmarks
     fn alloc_owned_small(b: &mut Bencher) {
         b.iter(|| {
             let _: Box<_> = box 10;

--- a/src/liballoc/collections/linked_list.rs
+++ b/src/liballoc/collections/linked_list.rs
@@ -1354,6 +1354,7 @@ mod tests {
 
     #[test]
     #[cfg_attr(target_os = "emscripten", ignore)]
+    #[cfg(not(miri))] // Miri does not support threads
     fn test_send() {
         let n = list_from(&[1, 2, 3]);
         thread::spawn(move || {
@@ -1371,6 +1372,7 @@ mod tests {
         for _ in 0..25 {
             fuzz_test(3);
             fuzz_test(16);
+            #[cfg(not(miri))] // Miri is too slow
             fuzz_test(189);
         }
     }

--- a/src/liballoc/collections/vec_deque.rs
+++ b/src/liballoc/collections/vec_deque.rs
@@ -2799,6 +2799,7 @@ mod tests {
     use super::VecDeque;
 
     #[bench]
+    #[cfg(not(miri))] // Miri does not support benchmarks
     fn bench_push_back_100(b: &mut test::Bencher) {
         let mut deq = VecDeque::with_capacity(101);
         b.iter(|| {
@@ -2811,6 +2812,7 @@ mod tests {
     }
 
     #[bench]
+    #[cfg(not(miri))] // Miri does not support benchmarks
     fn bench_push_front_100(b: &mut test::Bencher) {
         let mut deq = VecDeque::with_capacity(101);
         b.iter(|| {
@@ -2823,6 +2825,7 @@ mod tests {
     }
 
     #[bench]
+    #[cfg(not(miri))] // Miri does not support benchmarks
     fn bench_pop_back_100(b: &mut test::Bencher) {
         let mut deq = VecDeque::<i32>::with_capacity(101);
 
@@ -2836,6 +2839,7 @@ mod tests {
     }
 
     #[bench]
+    #[cfg(not(miri))] // Miri does not support benchmarks
     fn bench_pop_front_100(b: &mut test::Bencher) {
         let mut deq = VecDeque::<i32>::with_capacity(101);
 
@@ -3090,6 +3094,11 @@ mod tests {
     fn test_vec_from_vecdeque() {
         use crate::vec::Vec;
 
+        #[cfg(not(miri))] // Miri is too slow
+        let max_pwr = 7;
+        #[cfg(miri)]
+        let max_pwr = 5;
+
         fn create_vec_and_test_convert(cap: usize, offset: usize, len: usize) {
             let mut vd = VecDeque::with_capacity(cap);
             for _ in 0..offset {
@@ -3103,7 +3112,7 @@ mod tests {
             assert!(vec.into_iter().eq(vd));
         }
 
-        for cap_pwr in 0..7 {
+        for cap_pwr in 0..max_pwr {
             // Make capacity as a (2^x)-1, so that the ring size is 2^x
             let cap = (2i32.pow(cap_pwr) - 1) as usize;
 

--- a/src/liballoc/collections/vec_deque.rs
+++ b/src/liballoc/collections/vec_deque.rs
@@ -3094,11 +3094,6 @@ mod tests {
     fn test_vec_from_vecdeque() {
         use crate::vec::Vec;
 
-        #[cfg(not(miri))] // Miri is too slow
-        let max_pwr = 7;
-        #[cfg(miri)]
-        let max_pwr = 5;
-
         fn create_vec_and_test_convert(cap: usize, offset: usize, len: usize) {
             let mut vd = VecDeque::with_capacity(cap);
             for _ in 0..offset {
@@ -3111,6 +3106,11 @@ mod tests {
             assert_eq!(vec.len(), vd.len());
             assert!(vec.into_iter().eq(vd));
         }
+
+        #[cfg(not(miri))] // Miri is too slow
+        let max_pwr = 7;
+        #[cfg(miri)]
+        let max_pwr = 5;
 
         for cap_pwr in 0..max_pwr {
             // Make capacity as a (2^x)-1, so that the ring size is 2^x

--- a/src/liballoc/sync.rs
+++ b/src/liballoc/sync.rs
@@ -1678,6 +1678,7 @@ mod tests {
 
     #[test]
     #[cfg_attr(target_os = "emscripten", ignore)]
+    #[cfg(not(miri))] // Miri does not support threads
     fn manually_share_arc() {
         let v = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
         let arc_v = Arc::new(v);
@@ -1982,6 +1983,7 @@ mod tests {
 
     #[test]
     #[cfg_attr(target_os = "emscripten", ignore)]
+    #[cfg(not(miri))] // Miri does not support threads
     fn test_weak_count_locked() {
         let mut a = Arc::new(atomic::AtomicBool::new(false));
         let a2 = a.clone();


### PR DESCRIPTION
I discovered, to my surprise, that liballoc has two test suites: `liballoc/tests`, and a bunch of stuff embedded directly within liballoc.  The latter was not covered by [miri-test-libstd](https://github.com/RalfJung/miri-test-libstd) yet.  This disables in Miri the tests that Miri cannot support or runs too slowly.